### PR TITLE
Tests and cleanup for evalHeadTerm, evalBodyTerm, eval2, evalCall

### DIFF
--- a/main/src/ca/uwaterloo/flix/runtime/Interpreter.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/Interpreter.scala
@@ -1,6 +1,6 @@
 package ca.uwaterloo.flix.runtime
 
-import ca.uwaterloo.flix.language.ast.TypedAst.{Expression, Literal, Pattern, Type, Term, Root}
+import ca.uwaterloo.flix.language.ast.TypedAst.{Definition, Expression, Literal, Pattern, Type, Term, Root}
 import ca.uwaterloo.flix.language.ast.{TypedAst, BinaryOperator, UnaryOperator}
 
 // TODO: Consider an EvaluationContext
@@ -275,11 +275,10 @@ object Interpreter {
     eval(body, root, newEnv)
   }
 
-  def evalCall(d: TypedAst.Definition.Constant, terms: List[TypedAst.Term.Body], root: TypedAst.Root, env: Map[String, Value]): Value = {
-    val Value.Closure(formals, body, closureEnv) = evalGeneral(d.exp, root, env)
+  def evalCall(definition: Definition.Constant, terms: List[Term.Body], root: Root, env: Env): Value = {
+    val Value.Closure(formals, body, closureEnv) = evalGeneral(definition.exp, root, env)
     val evalArgs = terms.map(t => evalBodyTerm(t, env))
     val newEnv = closureEnv ++ formals.map(_.ident.name).zip(evalArgs).toMap
     eval(body, root, newEnv)
   }
-
 }

--- a/main/test/ca/uwaterloo/flix/runtime/TestInterpreter.scala
+++ b/main/test/ca/uwaterloo/flix/runtime/TestInterpreter.scala
@@ -2719,4 +2719,174 @@ class TestInterpreter extends FunSuite {
     val value = Interpreter.eval2(lambda, v1, v2, root)
     assertResult(Value.mkInt(6))(value)
   }
+
+  test("evalCall01") {
+    // () => false
+    val lambda = Expression.Lambda(
+      List(), Expression.Lit(Literal.Bool(false, loc), Type.Bool, loc), Type.Lambda(List(), Type.Bool), loc)
+    val definition = Definition.Constant(name01, lambda, Type.Lambda(List(), Type.Bool), loc)
+
+    // (() => false)()
+    val value = Interpreter.evalCall(definition, List(), root, Map())
+    assertResult(Value.False)(value)
+  }
+
+  test("evalCall02") {
+    // x => 3
+    val lambda = Expression.Lambda(
+      List(FormalArg(ident01, Type.Int)), Expression.Lit(Literal.Int(3, loc), Type.Int, loc),
+      Type.Lambda(List(Type.Int), Type.Int), loc)
+    val definition = Definition.Constant(name01, lambda, Type.Lambda(List(Type.Int), Type.Int), loc)
+
+    // (x => 3)(4)
+    val value = Interpreter.evalCall(definition, List(Term.Body.Lit(Literal.Int(4, loc), Type.Int, loc)), root, Map())
+    assertResult(Value.mkInt(3))(value)
+  }
+
+  test("evalCall03") {
+    // x => x
+    val lambda = Expression.Lambda(
+      List(FormalArg(ident01, Type.Int)), Expression.Var(ident01, Type.Int, loc),
+      Type.Lambda(List(Type.Int), Type.Int), loc)
+    val definition = Definition.Constant(name01, lambda, Type.Lambda(List(Type.Int), Type.Int), loc)
+
+    // (x => x)(5)
+    val value = Interpreter.evalCall(definition, List(Term.Body.Lit(Literal.Int(5, loc), Type.Int, loc)), root, Map())
+    assertResult(Value.mkInt(5))(value)
+  }
+
+  test("evalCall04") {
+    // x => 1 + 2
+    val lambda = Expression.Lambda(
+      List(FormalArg(ident01, Type.Int)),
+      Expression.Binary(
+        BinaryOperator.Plus,
+        Expression.Lit(Literal.Int(1, loc), Type.Int, loc),
+        Expression.Lit(Literal.Int(2, loc), Type.Int, loc),
+        Type.Int, loc),
+      Type.Lambda(List(Type.Int), Type.Int), loc)
+    val definition = Definition.Constant(name01, lambda, Type.Lambda(List(Type.Int), Type.Int), loc)
+
+    // (x => 1 + 2)(42)
+    val value = Interpreter.evalCall(definition, List(Term.Body.Lit(Literal.Int(42, loc), Type.Int, loc)), root, Map())
+    assertResult(Value.mkInt(3))(value)
+  }
+
+  test("evalCall05") {
+    // x => x + 2
+    val lambda = Expression.Lambda(
+      List(FormalArg(ident01, Type.Int)),
+      Expression.Binary(
+        BinaryOperator.Plus,
+        Expression.Var(ident01, Type.Int, loc),
+        Expression.Lit(Literal.Int(2, loc), Type.Int, loc),
+        Type.Int, loc),
+      Type.Lambda(List(Type.Int), Type.Int), loc)
+    val definition = Definition.Constant(name01, lambda, Type.Lambda(List(Type.Int), Type.Int), loc)
+
+    // (x => x + 2)(100)
+    val value = Interpreter.evalCall(definition, List(Term.Body.Lit(Literal.Int(100, loc), Type.Int, loc)), root, Map())
+    assertResult(Value.mkInt(102))(value)
+  }
+
+  test("evalCall06") {
+    // (x, y) => x + y
+    val lambda = Expression.Lambda(
+      List(FormalArg(ident01, Type.Int), FormalArg(ident02, Type.Int)),
+      Expression.Binary(
+        BinaryOperator.Plus,
+        Expression.Var(ident01, Type.Int, loc),
+        Expression.Var(ident02, Type.Int, loc),
+        Type.Int, loc),
+      Type.Lambda(List(Type.Int, Type.Int), Type.Int), loc)
+    val definition = Definition.Constant(name01, lambda, Type.Lambda(List(Type.Int, Type.Int), Type.Int), loc)
+
+    // (x, y => x + y)(3, 4)
+    val apply = Expression.Apply(lambda, List(
+      Expression.Lit(Literal.Int(3, loc), Type.Int, loc),
+      Expression.Lit(Literal.Int(4, loc), Type.Int, loc)),
+      Type.Int, loc)
+    val value = Interpreter.evalCall(definition, List(
+      Term.Body.Lit(Literal.Int(3, loc), Type.Int, loc),
+      Term.Body.Lit(Literal.Int(4, loc), Type.Int, loc)), root, Map())
+    assertResult(Value.mkInt(7))(value)
+  }
+
+  test("evalCall07") {
+    // (x, y) => if (x) then true else y
+    val lambda = Expression.Lambda(
+      List(FormalArg(ident01, Type.Bool), FormalArg(ident02, Type.Bool)),
+      Expression.IfThenElse(
+        Expression.Var(ident01, Type.Bool, loc),
+        Expression.Lit(Literal.Bool(true, loc), Type.Bool, loc),
+        Expression.Var(ident02, Type.Bool, loc),
+        Type.Bool, loc),
+      Type.Lambda(List(Type.Bool, Type.Bool), Type.Bool), loc)
+    val definition = Definition.Constant(name01, lambda, Type.Lambda(List(Type.Bool, Type.Bool), Type.Bool), loc)
+
+    // ((x, y) => if (x) then true else y)(false, true)
+    val value = Interpreter.evalCall(definition, List(
+      Term.Body.Lit(Literal.Bool(false, loc), Type.Bool, loc),
+      Term.Body.Lit(Literal.Bool(true, loc), Type.Bool, loc)), root, Map())
+    assertResult(Value.True)(value)
+  }
+
+  test("evalCall08") {
+    // (x, y, z) => x + (y + z)
+    val lambda = Expression.Lambda(
+      List(FormalArg(ident01, Type.Int), FormalArg(ident02, Type.Int), FormalArg(ident03, Type.Int)),
+      Expression.Binary(
+        BinaryOperator.Plus,
+        Expression.Var(ident01, Type.Int, loc),
+        Expression.Binary(
+          BinaryOperator.Plus,
+          Expression.Var(ident02, Type.Int, loc),
+          Expression.Var(ident03, Type.Int, loc),
+          Type.Int, loc),
+        Type.Int, loc),
+      Type.Lambda(List(Type.Int, Type.Int, Type.Int), Type.Int), loc)
+    val definition = Definition.Constant(name01, lambda, Type.Lambda(List(Type.Int, Type.Int, Type.Int), Type.Int), loc)
+
+    // (x, y, z => x + (y + z))(2, 42, 5)
+    val apply = Expression.Apply(lambda, List(
+      Expression.Lit(Literal.Int(2, loc), Type.Int, loc),
+      Expression.Lit(Literal.Int(42, loc), Type.Int, loc),
+      Expression.Lit(Literal.Int(5, loc), Type.Int, loc)),
+      Type.Int, loc)
+    val value = Interpreter.evalCall(definition, List(
+      Term.Body.Lit(Literal.Int(2, loc), Type.Int, loc),
+      Term.Body.Lit(Literal.Int(42, loc), Type.Int, loc),
+      Term.Body.Lit(Literal.Int(5, loc), Type.Int, loc)), root, Map())
+    assertResult(Value.mkInt(49))(value)
+  }
+
+  test("evalCall00") {
+    // (x, y, z) => x + (y + z)
+    val lambda = Expression.Lambda(
+      List(FormalArg(ident01, Type.Int), FormalArg(ident02, Type.Int), FormalArg(ident03, Type.Int)),
+      Expression.Binary(
+        BinaryOperator.Plus,
+        Expression.Var(ident01, Type.Int, loc),
+        Expression.Binary(
+          BinaryOperator.Plus,
+          Expression.Var(ident02, Type.Int, loc),
+          Expression.Var(ident03, Type.Int, loc),
+          Type.Int, loc),
+        Type.Int, loc),
+      Type.Lambda(List(Type.Int, Type.Int, Type.Int), Type.Int), loc)
+    val definition = Definition.Constant(name01, lambda, Type.Lambda(List(Type.Int, Type.Int, Type.Int), Type.Int), loc)
+    val env = Map("foo" -> Value.mkInt(5))
+
+    // (x, y, z => x + (y + z))(2, 42, foo)
+    val apply = Expression.Apply(lambda, List(
+      Expression.Lit(Literal.Int(2, loc), Type.Int, loc),
+      Expression.Lit(Literal.Int(42, loc), Type.Int, loc),
+      Expression.Lit(Literal.Int(5, loc), Type.Int, loc)),
+      Type.Int, loc)
+    val value = Interpreter.evalCall(definition, List(
+      Term.Body.Lit(Literal.Int(2, loc), Type.Int, loc),
+      Term.Body.Lit(Literal.Int(42, loc), Type.Int, loc),
+      Term.Body.Var(toIdent("foo"), Type.Int, loc)), root, env)
+    assertResult(Value.mkInt(49))(value)
+  }
 }


### PR DESCRIPTION
Fixes #16.

Changes to the actual `eval*` implementations are straightforward, though `evalBodyTerm` doesn't yet handle the `Wildcard` case.

Tests are basically adapted from existing tests for `eval`, with `Expression`s changed to `Term`s as needed.
