### PR TITLE
Remove support for passing Flix values from native code.

### DIFF
--- a/examples/misc/NativeTest.flix
+++ b/examples/misc/NativeTest.flix
@@ -383,12 +383,4 @@ namespace NativeTest {
     rel TupleOfSets(t: (Set[Int], Set[Str], Set[Str]));
     TupleOfSets(tupleOfSets(0)).
     print TupleOfSets.
-
-    // TODO(mhyee): clean up
-    def scalaHi(i: Int, j: Int): Int = #ca.uwaterloo.flix.util.misc.ScalaNative.hi(i, j)
-    def javaHi(i: Int, j: Int): Int = #ca.uwaterloo.flix.util.misc.JavaNative.hi(i, j)
-    rel Ints(i: Int);
-    Ints(scalaHi(3, 3)).
-    Ints(javaHi(4, 5)).
-    print Ints.
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -829,10 +829,9 @@ object Typer {
     * Returns a Flix type corresponding to the given canonical name.
     */
   private def java2flix(canonicalName: String): TypedAst.Type = canonicalName match {
-    case "ca.uwaterloo.flix.runtime.Value.Unit$" => TypedAst.Type.Unit
-    case "boolean" | "java.lang.Boolean" | "ca.uwaterloo.flix.runtime.Value.Bool" => TypedAst.Type.Bool
-    case "int" | "java.lang.Integer" | "ca.uwaterloo.flix.runtime.Value.Int" => TypedAst.Type.Int
-    case "java.lang.String" | "ca.uwaterloo.flix.runtime.Value.Str" => TypedAst.Type.Str
+    case "boolean" | "java.lang.Boolean" => TypedAst.Type.Bool
+    case "int" | "java.lang.Integer" => TypedAst.Type.Int
+    case "java.lang.String" => TypedAst.Type.Str
     case t if t.matches("scala.Tuple[2-5]") =>
       // Create a list of N TypedAst.Type.Native("java.lang.Object")
       val types = List().padTo(t.last - '0', TypedAst.Type.Native("java.lang.Object"))

--- a/main/src/ca/uwaterloo/flix/runtime/Interpreter.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/Interpreter.scala
@@ -305,9 +305,7 @@ object Interpreter {
         val newEnv = closureEnv ++ formals.map(_.ident.name).zip(args).toMap
         eval(body, root, newEnv)
       case Value.NativeMethod(method) =>
-        val nativeArgs = args.zip(method.getParameterTypes.map(_.getCanonicalName)).map { case (arg, typ) =>
-            if (typ.startsWith("ca.uwaterloo.flix.runtime.Value")) arg else arg.toJava
-        }
+        val nativeArgs = args.map(_.toJava)
         val tpe = function.tpe.asInstanceOf[Type.Lambda].retTpe
         Value.java2flix(method.invoke(null, nativeArgs: _*), tpe)
     }

--- a/main/src/ca/uwaterloo/flix/runtime/Value.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/Value.scala
@@ -188,37 +188,31 @@ object Value {
     * Convert from native values to Flix values                               *
     * **************************************************************************/
 
-  def java2flix(obj: AnyRef, tpe: Type): Value = obj match {
-    case v: Value.Unit.type => v
-    case v: Value.Bool => v
-    case v: Value.Int => v
-    case v: Value.Str => v
-    case _ => tpe match {
-      case Type.Bool => if (obj.asInstanceOf[java.lang.Boolean].booleanValue) Value.True else Value.False
-      case Type.Int => Value.mkInt(obj.asInstanceOf[java.lang.Integer].intValue)
-      case Type.Str => Value.mkStr(obj.asInstanceOf[java.lang.String])
-      case Type.Tuple(typs) if (2 to 5).contains(typs.size) =>
-        def makeTuple(elms: java.lang.Object*): Value.Tuple =
-          Value.Tuple(elms.toList.zip(typs).map { case (e, t) => java2flix(e, t) })
-        typs.size match {
-          case 2 =>
-            val t = obj.asInstanceOf[(java.lang.Object, java.lang.Object)]
-            makeTuple(t._1, t._2)
-          case 3 =>
-            val t = obj.asInstanceOf[(java.lang.Object, java.lang.Object, java.lang.Object)]
-            makeTuple(t._1, t._2, t._3)
-          case 4 =>
-            val t = obj.asInstanceOf[(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)]
-            makeTuple(t._1, t._2, t._3, t._4)
-          case 5 =>
-            val t = obj.asInstanceOf[(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)]
-            makeTuple(t._1, t._2, t._3, t._4, t._5)
-        }
-      case Type.Set(typ) =>
-        Value.Set(obj.asInstanceOf[scala.collection.immutable.Set[java.lang.Object]].map(e => java2flix(e, typ)))
-      case Type.Var(_) | Type.Unit | Type.Tag(_, _, _) | Type.Enum(_) | Type.Tuple(_) | Type.Set(_) | Type.Lambda(_, _) |
-           Type.Predicate(_) | Type.Native(_) =>
-        Value.Native(obj)
-    }
+  def java2flix(obj: AnyRef, tpe: Type): Value = tpe match {
+    case Type.Bool => if (obj.asInstanceOf[java.lang.Boolean].booleanValue) Value.True else Value.False
+    case Type.Int => Value.mkInt(obj.asInstanceOf[java.lang.Integer].intValue)
+    case Type.Str => Value.mkStr(obj.asInstanceOf[java.lang.String])
+    case Type.Tuple(typs) if (2 to 5).contains(typs.size) =>
+      def makeTuple(elms: java.lang.Object*): Value.Tuple =
+        Value.Tuple(elms.toList.zip(typs).map { case (e, t) => java2flix(e, t) })
+      typs.size match {
+        case 2 =>
+          val t = obj.asInstanceOf[(java.lang.Object, java.lang.Object)]
+          makeTuple(t._1, t._2)
+        case 3 =>
+          val t = obj.asInstanceOf[(java.lang.Object, java.lang.Object, java.lang.Object)]
+          makeTuple(t._1, t._2, t._3)
+        case 4 =>
+          val t = obj.asInstanceOf[(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)]
+          makeTuple(t._1, t._2, t._3, t._4)
+        case 5 =>
+          val t = obj.asInstanceOf[(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)]
+          makeTuple(t._1, t._2, t._3, t._4, t._5)
+      }
+    case Type.Set(typ) =>
+      Value.Set(obj.asInstanceOf[scala.collection.immutable.Set[java.lang.Object]].map(e => java2flix(e, typ)))
+    case Type.Var(_) | Type.Unit | Type.Tag(_, _, _) | Type.Enum(_) | Type.Tuple(_) | Type.Set(_) | Type.Lambda(_, _) |
+         Type.Predicate(_) | Type.Native(_) =>
+      Value.Native(obj)
   }
 }

--- a/main/src/ca/uwaterloo/flix/util/misc/JavaNative.java
+++ b/main/src/ca/uwaterloo/flix/util/misc/JavaNative.java
@@ -1,8 +1,5 @@
 package ca.uwaterloo.flix.util.misc;
 
-import ca.uwaterloo.flix.runtime.Value;
-import ca.uwaterloo.flix.runtime.Value$;
-
 // See examples/misc/NativeTest.flix for the program that uses this native class.
 public class JavaNative {
 
@@ -31,9 +28,5 @@ public class JavaNative {
 
     public static String strcat(String s1, String s2) {
         return s1 + s2;
-    }
-
-    public static Value.Int hi(Value.Int v, int i) {
-        return Value$.MODULE$.mkInt(v.i() + i);
     }
 }

--- a/main/src/ca/uwaterloo/flix/util/misc/ScalaNative.scala
+++ b/main/src/ca/uwaterloo/flix/util/misc/ScalaNative.scala
@@ -1,7 +1,5 @@
 package ca.uwaterloo.flix.util.misc
 
-import ca.uwaterloo.flix.runtime.Value
-
 object ScalaNative {
   // Note that these values are compiled as a static method
   val strTuple2 = ("foo", "bar")
@@ -23,6 +21,4 @@ object ScalaNative {
 
   def mkSet(i: Int) = (0 until i).toSet
   def incrSetBy(s: Set[Int], i: Int) = s.map(_ + i)
-
-  def hi(v: Value.Int, i: Int): Value.Int = Value.mkInt(v.i + i)
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1118,6 +1118,4 @@ class TestTyper extends FunSuite {
   // TODO(mhyee): Tuples of Flix types
 
   // TODO(mhyee): Sets of #java.lang.Object, Sets of Flix types
-
-  // TODO(mhyee): Flix values from native code
 }


### PR DESCRIPTION
Fixes #40. And by "fixes," I mean "reverts." (I didn't do a `git revert` because of conflicts.)

The original motivation for this feature was to defeat type erasure, but
that didn't actually work. We also found a different way to defeat type
erasure (by using type ascriptions in Flix code).

Therefore, this feature no longer has any benefit, especially since the
implementation is clunky and has its own problems.
