### PR TITLE
Create ExecutableAst phase

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ExecutableAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ExecutableAst.scala
@@ -158,8 +158,9 @@ object ExecutableAst {
       final val loc = SourceLocation.Unknown
     }
 
-    case class Str(lit: java.lang.String, loc: SourceLocation) extends ExecutableAst.Expression {
+    case class Str(lit: java.lang.String) extends ExecutableAst.Expression {
       final val tpe = Type.Str
+      final val loc = SourceLocation.Unknown
     }
 
     /**

--- a/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
@@ -160,8 +160,9 @@ object SimplifiedAst {
       final val loc = SourceLocation.Unknown
     }
 
-    case class Str(lit: java.lang.String, loc: SourceLocation) extends SimplifiedAst.Expression {
+    case class Str(lit: java.lang.String) extends SimplifiedAst.Expression {
       final val tpe = Type.Str
+      final val loc = SourceLocation.Unknown
     }
 
     /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Codegen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Codegen.scala
@@ -117,7 +117,7 @@ object Codegen {
     case Expression.Int16(s) => compileInt(visitor)(s)
     case Expression.Int32(i) => compileInt(visitor)(i)
     case Expression.Int64(l) => compileInt(visitor)(l, isLong = true)
-    case Expression.Str(s, _) => visitor.visitLdcInsn(s)
+    case Expression.Str(s) => visitor.visitLdcInsn(s)
 
     case load: LoadExpression => compileLoadExpr(context, visitor)(load)
     case store: StoreExpression => compileStoreExpr(context, visitor)(store)

--- a/main/src/ca/uwaterloo/flix/language/phase/CreateExecutableAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/CreateExecutableAst.scala
@@ -121,7 +121,7 @@ object CreateExecutableAst {
       case SimplifiedAst.Expression.Int16(lit) => ExecutableAst.Expression.Int16(lit)
       case SimplifiedAst.Expression.Int32(lit) => ExecutableAst.Expression.Int32(lit)
       case SimplifiedAst.Expression.Int64(lit) => ExecutableAst.Expression.Int64(lit)
-      case SimplifiedAst.Expression.Str(lit, loc) => ExecutableAst.Expression.Str(lit, loc)
+      case SimplifiedAst.Expression.Str(lit) => ExecutableAst.Expression.Str(lit)
       case SimplifiedAst.Expression.LoadBool(e, offset) => ExecutableAst.Expression.LoadBool(toExecutable(e), offset)
       case SimplifiedAst.Expression.LoadInt8(e, offset) => ExecutableAst.Expression.LoadInt8(toExecutable(e), offset)
       case SimplifiedAst.Expression.LoadInt16(e, offset) => ExecutableAst.Expression.LoadInt16(toExecutable(e), offset)

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -259,7 +259,7 @@ object Simplifier {
       case TypedAst.Literal.Bool(b, loc) =>
         if (b) SimplifiedAst.Expression.True else SimplifiedAst.Expression.False
       case TypedAst.Literal.Int(i, loc) => SimplifiedAst.Expression.Int(i)
-      case TypedAst.Literal.Str(s, loc) => SimplifiedAst.Expression.Str(s, loc)
+      case TypedAst.Literal.Str(s, loc) => SimplifiedAst.Expression.Str(s)
       case TypedAst.Literal.Tag(enum, tag, lit, tpe, loc) => SimplifiedAst.Expression.Tag(enum, tag, simplify(lit), tpe, loc)
       case TypedAst.Literal.Tuple(elms, tpe, loc) => SimplifiedAst.Expression.Tuple(elms map simplify, tpe, loc)
       case TypedAst.Literal.Set(elms, tpe, loc) => SimplifiedAst.Expression.Set(elms map simplify, tpe, loc)

--- a/main/src/ca/uwaterloo/flix/runtime/PartialEvaluator.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/PartialEvaluator.scala
@@ -56,7 +56,7 @@ object PartialEvaluator {
       /**
         * Str Expression.
         */
-      case Str(lit, loc) => k(Str(lit, loc))
+      case Str(lit) => k(Str(lit))
 
       /**
         * Var Expressions/

--- a/main/test/ca/uwaterloo/flix/language/backend/phase/TestCodegen.scala
+++ b/main/test/ca/uwaterloo/flix/language/backend/phase/TestCodegen.scala
@@ -719,7 +719,7 @@ class TestCodegen extends FunSuite {
 
   test("Codegen - Str01") {
     val definition = Function(name, args = List(),
-      body = Str("foobar", loc),
+      body = Str("foobar"),
       Type.Lambda(List(), Type.Str), loc)
 
     val code = new CompiledCode(List(definition))
@@ -730,7 +730,7 @@ class TestCodegen extends FunSuite {
 
   test("Codegen - Str02") {
     val definition = Function(name, args = List(),
-      body = Str("", loc),
+      body = Str(""),
       Type.Lambda(List(), Type.Str), loc)
 
     val code = new CompiledCode(List(definition))
@@ -1098,7 +1098,7 @@ class TestCodegen extends FunSuite {
   test("Codegen - Let15") {
     val definition = Function(name, args = List(),
       body = Let(toIdent("x"), 0,
-        exp1 = Str("helloworld", loc),
+        exp1 = Str("helloworld"),
         exp2 = Var(toIdent("x"), 0, Type.Str, loc),
         Type.Str, loc),
       Type.Lambda(List(), Type.Str), loc)
@@ -6045,7 +6045,7 @@ class TestCodegen extends FunSuite {
     val ident = toIdent("def")
     val enum = Type.Enum(Name.Resolved.mk("ConstProp"), Map("abc.bar" -> Type.Tag(tagName, ident, Type.Str)))
     val definition = Function(name, args = List(),
-      body = Tag(tagName, ident, Str("hello", loc), enum, loc),
+      body = Tag(tagName, ident, Str("hello"), enum, loc),
       Type.Lambda(List(), enum), loc)
 
     val code = new CompiledCode(List(definition))
@@ -6059,7 +6059,7 @@ class TestCodegen extends FunSuite {
     val ident = toIdent("def")
     val enum = Type.Enum(Name.Resolved.mk("abc"), Map("abc.bar" -> Type.Tag(tagName, ident, Type.Tuple(List(Type.Int32, Type.Str)))))
     val definition = Function(name, args = List(),
-      body = Tag(tagName, ident, Tuple(List(Int32(1), Str("one", loc)),
+      body = Tag(tagName, ident, Tuple(List(Int32(1), Str("one")),
         Type.Tuple(List(Type.Int32, Type.Str)), loc), enum, loc),
       Type.Lambda(List(), enum), loc)
 
@@ -6140,7 +6140,7 @@ class TestCodegen extends FunSuite {
 
     val definition = Function(name, args = List(),
       body = Let(toIdent("x"), 0,
-        exp1 = Tag(tagName, ident, Tuple(List(Int32(1), Str("one", loc)),
+        exp1 = Tag(tagName, ident, Tuple(List(Int32(1), Str("one")),
           Type.Tuple(List(Type.Int32, Type.Str)), loc), enum, loc),
         exp2 = GetTagValue(Var(toIdent("x"), 0, enum, loc), Type.Tuple(List(Type.Int32, Type.Str)), loc),
         Type.Unit, loc),
@@ -6180,7 +6180,7 @@ class TestCodegen extends FunSuite {
 
   test("Codegen - Tuple03") {
     val definition = Function(name, args = List(),
-      body = Tuple(List(Str("un", loc), Str("deux", loc), Str("trois", loc), Str("quatre", loc)),
+      body = Tuple(List(Str("un"), Str("deux"), Str("trois"), Str("quatre")),
         Type.Tuple(List(Type.Str, Type.Str, Type.Str, Type.Str)), loc),
       Type.Lambda(List(), Type.Tuple(List(Type.Str, Type.Str, Type.Str, Type.Str))), loc)
 
@@ -6192,7 +6192,7 @@ class TestCodegen extends FunSuite {
 
   test("Codegen - Tuple04") {
     val definition = Function(name, args = List(),
-      body = Tuple(List(Str("un", loc), False, Int64(12345), Unit, Int8(-2)),
+      body = Tuple(List(Str("un"), False, Int64(12345), Unit, Int8(-2)),
         Type.Tuple(List(Type.Str, Type.Bool, Type.Int64, Type.Unit, Type.Int8)), loc),
       Type.Lambda(List(), Type.Tuple(List(Type.Str, Type.Bool, Type.Int64, Type.Unit, Type.Int8))), loc)
 
@@ -6220,7 +6220,7 @@ class TestCodegen extends FunSuite {
     val definition = Function(name, args = List(),
       body = Tuple(List(
         Tuple(List(Int32(123), Int32(456)), Type.Tuple(List(Type.Int32, Type.Int32)), loc),
-        Tuple(List(Str("654", loc), Str("321", loc)), Type.Tuple(List(Type.Str, Type.Str)), loc)),
+        Tuple(List(Str("654"), Str("321")), Type.Tuple(List(Type.Str, Type.Str)), loc)),
         Type.Tuple(List(Type.Tuple(List(Type.Int32, Type.Int32)), Type.Tuple(List(Type.Str, Type.Str)))), loc),
       Type.Lambda(List(), Type.Tuple(List(Type.Tuple(List(Type.Int32, Type.Int32)), Type.Tuple(List(Type.Str, Type.Str))))), loc)
 
@@ -6237,7 +6237,7 @@ class TestCodegen extends FunSuite {
   test("Codegen - TupleAt01") {
     val definition = Function(name, args = List(),
       body = Let(toIdent("x"), 0,
-        exp1 = Tuple(List(Str("un", loc), False, Int64(12345), Unit, Int8(-2)),
+        exp1 = Tuple(List(Str("un"), False, Int64(12345), Unit, Int8(-2)),
           Type.Tuple(List(Type.Str, Type.Bool, Type.Int64, Type.Unit, Type.Int8)), loc),
         exp2 = GetTupleIndex(Var(toIdent("x"), 0, Type.Tuple(List(Type.Str, Type.Bool, Type.Int64, Type.Unit, Type.Int8)), loc), 0, Type.Str, loc),
         Type.Str, loc),
@@ -6252,7 +6252,7 @@ class TestCodegen extends FunSuite {
   test("Codegen - TupleAt02") {
     val definition = Function(name, args = List(),
       body = Let(toIdent("x"), 0,
-        exp1 = Tuple(List(Str("un", loc), False, Int64(12345), Unit, Int8(-2)),
+        exp1 = Tuple(List(Str("un"), False, Int64(12345), Unit, Int8(-2)),
           Type.Tuple(List(Type.Str, Type.Bool, Type.Int64, Type.Unit, Type.Int8)), loc),
         exp2 = GetTupleIndex(Var(toIdent("x"), 0, Type.Tuple(List(Type.Str, Type.Bool, Type.Int64, Type.Unit, Type.Int8)), loc), 1, Type.Bool, loc),
         Type.Bool, loc),
@@ -6267,7 +6267,7 @@ class TestCodegen extends FunSuite {
   test("Codegen - TupleAt03") {
     val definition = Function(name, args = List(),
       body = Let(toIdent("x"), 0,
-        exp1 = Tuple(List(Str("un", loc), False, Int64(12345), Unit, Int8(-2)),
+        exp1 = Tuple(List(Str("un"), False, Int64(12345), Unit, Int8(-2)),
           Type.Tuple(List(Type.Str, Type.Bool, Type.Int64, Type.Unit, Type.Int8)), loc),
         exp2 = GetTupleIndex(Var(toIdent("x"), 0, Type.Tuple(List(Type.Str, Type.Bool, Type.Int64, Type.Unit, Type.Int8)), loc), 2, Type.Int64, loc),
         Type.Int64, loc),
@@ -6282,7 +6282,7 @@ class TestCodegen extends FunSuite {
   test("Codegen - TupleAt04") {
     val definition = Function(name, args = List(),
       body = Let(toIdent("x"), 0,
-        exp1 = Tuple(List(Str("un", loc), False, Int64(12345), Unit, Int8(-2)),
+        exp1 = Tuple(List(Str("un"), False, Int64(12345), Unit, Int8(-2)),
           Type.Tuple(List(Type.Str, Type.Bool, Type.Int64, Type.Unit, Type.Int8)), loc),
         exp2 = GetTupleIndex(Var(toIdent("x"), 0, Type.Tuple(List(Type.Str, Type.Bool, Type.Int64, Type.Unit, Type.Int8)), loc), 3, Type.Unit, loc),
         Type.Unit, loc),
@@ -6297,7 +6297,7 @@ class TestCodegen extends FunSuite {
   test("Codegen - TupleAt05") {
     val definition = Function(name, args = List(),
       body = Let(toIdent("x"), 0,
-        exp1 = Tuple(List(Str("un", loc), False, Int64(12345), Unit, Int8(-2)),
+        exp1 = Tuple(List(Str("un"), False, Int64(12345), Unit, Int8(-2)),
           Type.Tuple(List(Type.Str, Type.Bool, Type.Int64, Type.Unit, Type.Int8)), loc),
         exp2 = GetTupleIndex(Var(toIdent("x"), 0, Type.Tuple(List(Type.Str, Type.Bool, Type.Int64, Type.Unit, Type.Int8)), loc), 4, Type.Int8, loc),
         Type.Int8, loc),
@@ -6328,7 +6328,7 @@ class TestCodegen extends FunSuite {
     val innerLet = Let(toIdent("y"), 1,
       exp1 = Tuple(List(
         Tuple(List(Int16(123), Int32(456)), Type.Tuple(List(Type.Int16, Type.Int32)), loc),
-        Tuple(List(Str("654", loc), Str("321", loc)), Type.Tuple(List(Type.Str, Type.Str)), loc)),
+        Tuple(List(Str("654"), Str("321")), Type.Tuple(List(Type.Str, Type.Str)), loc)),
         Type.Tuple(List(Type.Tuple(List(Type.Int16, Type.Int32)), Type.Tuple(List(Type.Str, Type.Str)))), loc),
       exp2 = GetTupleIndex(Var(toIdent("y"), 1, Type.Tuple(List(Type.Tuple(List(Type.Int16, Type.Int32)), Type.Tuple(List(Type.Str, Type.Str)))), loc), 0, Type.Tuple(List(Type.Int32, Type.Int32)), loc),
       Type.Tuple(List(Type.Int16, Type.Int32)), loc)


### PR DESCRIPTION
Fixes #101:

> For now I'm calling it `CreateExecutableAst`, with the method `toExecutable`. We should come up with better names.
> 
> We might move this code into the `Codegen` object, or combine them in some other way.
> 
> Right now, the transformation basically an identity transform, but lists are copied to arrays.
> 
> Throughout this process, I'm going to make sure `ExecutableAst` is consistent with our other ASTs (since it hasn't been updated for a while), and I'm also moving all the code (e.g. `dependenciesOf`) into the phase.

We need to figure out better names, and also how the `Codegen` fits in with this phase.

I made two changes to `SimplifiedAst`:
1. I preserve `Name.Ident` as well as the variable offset (instead of discarding the identifier), since `index2var` needs it. It looks like the `Solver` still uses names instead of offsets -- maybe this will change?
2. I removed `SourceLocation` from `Str`. The `Int`s don't have it either.
