### PR TITLE
Remove {SimplifiedAst,ExecutableAst}.Expression.Int

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ExecutableAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ExecutableAst.scala
@@ -132,12 +132,6 @@ object ExecutableAst {
       override def toString: String = "#f"
     }
 
-    // TODO: Eventually we'll want to use the specialized ints below, and this will alias to Int32
-    case class Int(lit: scala.Int) extends ExecutableAst.Expression {
-      final val tpe = Type.Int32
-      final val loc = SourceLocation.Unknown
-    }
-
     case class Int8(lit: scala.Byte) extends ExecutableAst.Expression {
       final val tpe = Type.Int8
       final val loc = SourceLocation.Unknown

--- a/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
@@ -134,12 +134,6 @@ object SimplifiedAst {
       override def toString: String = "#f"
     }
 
-    // TODO: Eventually we'll want to use the specialized ints below, and this will alias to Int32
-    case class Int(lit: scala.Int) extends SimplifiedAst.Expression {
-      final val tpe = Type.Int32
-      final val loc = SourceLocation.Unknown
-    }
-
     case class Int8(lit: scala.Byte) extends SimplifiedAst.Expression {
       final val tpe = Type.Int8
       final val loc = SourceLocation.Unknown

--- a/main/src/ca/uwaterloo/flix/language/phase/Codegen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Codegen.scala
@@ -112,7 +112,6 @@ object Codegen {
 
     case Expression.True => visitor.visitInsn(ICONST_1)
     case Expression.False => visitor.visitInsn(ICONST_0)
-    case Expression.Int(i) => compileInt(visitor)(i)
     case Expression.Int8(b) => compileInt(visitor)(b)
     case Expression.Int16(s) => compileInt(visitor)(s)
     case Expression.Int32(i) => compileInt(visitor)(i)

--- a/main/src/ca/uwaterloo/flix/language/phase/CreateExecutableAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/CreateExecutableAst.scala
@@ -116,7 +116,6 @@ object CreateExecutableAst {
       case SimplifiedAst.Expression.Unit => ExecutableAst.Expression.Unit
       case SimplifiedAst.Expression.True => ExecutableAst.Expression.True
       case SimplifiedAst.Expression.False => ExecutableAst.Expression.False
-      case SimplifiedAst.Expression.Int(lit) => ExecutableAst.Expression.Int(lit)
       case SimplifiedAst.Expression.Int8(lit) => ExecutableAst.Expression.Int8(lit)
       case SimplifiedAst.Expression.Int16(lit) => ExecutableAst.Expression.Int16(lit)
       case SimplifiedAst.Expression.Int32(lit) => ExecutableAst.Expression.Int32(lit)
@@ -183,7 +182,7 @@ object CreateExecutableAst {
     object Head {
       def toExecutable(sast: SimplifiedAst.Predicate.Head): ExecutableAst.Predicate.Head = sast match {
         case SimplifiedAst.Predicate.Head.Relation(name, terms, tpe, loc) =>
-          ExecutableAst.Predicate.Head.Relation (name, terms.map(Term.toExecutable).toArray, tpe, loc)
+          ExecutableAst.Predicate.Head.Relation(name, terms.map(Term.toExecutable).toArray, tpe, loc)
       }
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -258,7 +258,7 @@ object Simplifier {
       case TypedAst.Literal.Unit(loc) => SimplifiedAst.Expression.Unit
       case TypedAst.Literal.Bool(b, loc) =>
         if (b) SimplifiedAst.Expression.True else SimplifiedAst.Expression.False
-      case TypedAst.Literal.Int(i, loc) => SimplifiedAst.Expression.Int(i)
+      case TypedAst.Literal.Int(i, loc) => SimplifiedAst.Expression.Int32(i)
       case TypedAst.Literal.Str(s, loc) => SimplifiedAst.Expression.Str(s)
       case TypedAst.Literal.Tag(enum, tag, lit, tpe, loc) => SimplifiedAst.Expression.Tag(enum, tag, simplify(lit), tpe, loc)
       case TypedAst.Literal.Tuple(elms, tpe, loc) => SimplifiedAst.Expression.Tuple(elms map simplify, tpe, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -404,7 +404,7 @@ object Verifier {
         val formula = {
           val x = mkVar("x")
 
-          ∀(x)(Expression.Binary(BinaryOperator.GreaterEqual, ???, Expression.Int(0), Type.Bool, SourceLocation.Unknown))
+          ∀(x)(Expression.Binary(BinaryOperator.GreaterEqual, ???, Expression.Int32(0), Type.Bool, SourceLocation.Unknown))
         }
 
         val name = "HeightNonNegative(" + lattice.tpe + ")"
@@ -1012,7 +1012,7 @@ object Verifier {
     * (In addition to all tags, tuples, sets, maps, etc.)
     */
   def visitArithExpr(e0: Expression, ctx: Context): ArithExpr = e0 match {
-    case Int(i) => ctx.mkInt(i)
+    case Int32(i) => ctx.mkInt(i)
     case Var(name, offset, tpe, loc) => ctx.mkIntConst(name.name)
     case Unary(op, e1, tpe, loc) => op match {
       case UnaryOperator.Plus => visitArithExpr(e1, ctx)
@@ -1087,7 +1087,7 @@ object Verifier {
     * (In addition to all tags, tuples, sets, maps, etc.)
     */
   def visitBitVecExpr(e0: Expression, ctx: Context): BitVecExpr = e0 match {
-    case Int(i) => ctx.mkBV(i, 32)
+    case Int32(i) => ctx.mkBV(i, 32)
     case Unary(op, e1, tpe, loc) => op match {
       case UnaryOperator.BitwiseNegate => ctx.mkBVNot(visitBitVecExpr(e1, ctx))
       case _ => throw new InternalCompilerError(s"Illegal unary operator: $op.")
@@ -1206,7 +1206,7 @@ object Verifier {
   def model2env(model: Model): Map[String, Expression] = {
     def visit(exp: Expr): Expression = exp match {
       case e: BoolExpr => if (e.isTrue) True else False
-      case e: IntNum => Int(e.getInt)
+      case e: IntNum => Int32(e.getInt)
       case _ => throw new InternalCompilerError(s"Unexpected Z3 expression: $exp.")
     }
 

--- a/main/src/ca/uwaterloo/flix/runtime/PartialEvaluator.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/PartialEvaluator.scala
@@ -48,7 +48,6 @@ object PartialEvaluator {
       case Int16(lit) => k(Int16(lit))
       case Int32(lit) => k(Int32(lit))
       case Int64(lit) => k(Int64(lit))
-      case Int(lit) => k(Int(lit)) // TODO: Int is deprecated.
 
       // TODO
       case v: Closure => k(v)
@@ -96,7 +95,7 @@ object PartialEvaluator {
           * Unary Minus.
           */
         case UnaryOperator.Minus => eval(exp, env0, {
-          case Int(i) => k(Int(-i))
+          case Int32(i) => k(Int32(-i))
           case residual => k(residual)
         })
 
@@ -104,7 +103,7 @@ object PartialEvaluator {
           * Unary Bitwise Negation.
           */
         case UnaryOperator.BitwiseNegate => eval(exp, env0, {
-          case Int(i) => Int(~i)
+          case Int32(i) => Int32(~i)
           case residual => k(residual)
         })
       }
@@ -124,9 +123,9 @@ object PartialEvaluator {
               // Partially evaluate exp2.
               eval(exp2, env0, {
                 case e2 => (e1, e2) match {
-                  case (Int(x), Int(y)) => k(Int(x + y))
-                  case (Int(0), _) => k(e2)
-                  case (_, Int(0)) => k(e1)
+                  case (Int32(x), Int32(y)) => k(Int32(x + y))
+                  case (Int32(0), _) => k(e2)
+                  case (_, Int32(0)) => k(e1)
                   case (r1, r2) => k(Binary(op, r1, r2, tpe, loc))
                 }
               })
@@ -404,7 +403,6 @@ object PartialEvaluator {
     case v: Int16 => true
     case v: Int32 => true
     case v: Int64 => true
-    case v: Int => true
     case v: Str => true
     case v: Tag => isValue(v.exp)
     case v: Tuple => v.elms.forall(isValue)


### PR DESCRIPTION
The backend should be using Int32 instead.

Fixes #104.
