### PR TITLE
Update SimplifiedAst and ExecutableAst.

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
@@ -87,8 +87,6 @@ object SimplifiedAst {
 
     case class AssertRule(rule: SimplifiedAst.Constraint.Rule, loc: SourceLocation) extends SimplifiedAst.Directive
 
-    case class Print(name: Name.Resolved, loc: SourceLocation) extends SimplifiedAst.Directive
-
   }
 
   sealed trait Expression extends SimplifiedAst {
@@ -284,6 +282,7 @@ object SimplifiedAst {
       override def toString: String = "λ(" + args.map(_.tpe).mkString(", ") + ") " + body
     }
 
+    case class Hook(hook: Ast.Hook, tpe: Type, loc: SourceLocation) extends SimplifiedAst.Expression
 
     // TODO: Eliminate once we have lambda lifting
     case class Closure(args: List[SimplifiedAst.FormalArg],
@@ -521,10 +520,15 @@ object SimplifiedAst {
                             tpe: Type.Predicate,
                             loc: SourceLocation) extends SimplifiedAst.Predicate.Body
 
-      case class Function(name: Name.Resolved,
-                          terms: List[SimplifiedAst.Term.Body],
-                          tpe: Type.Lambda,
-                          loc: SourceLocation) extends SimplifiedAst.Predicate.Body
+      case class ApplyFilter(name: Name.Resolved,
+                            terms: List[SimplifiedAst.Term.Body],
+                            tpe: Type.Lambda,
+                            loc: SourceLocation) extends SimplifiedAst.Predicate.Body
+
+      case class ApplyHookFilter(hook: Ast.Hook,
+                                 terms: List[SimplifiedAst.Term.Body],
+                                 tpe: Type.Lambda,
+                                 loc: SourceLocation) extends SimplifiedAst.Predicate.Body
 
       case class NotEqual(ident1: Name.Ident,
                           ident2: Name.Ident,
@@ -562,6 +566,11 @@ object SimplifiedAst {
                        loc: SourceLocation) extends SimplifiedAst.Term.Head {
 
       }
+
+      case class ApplyHook(hook: Ast.Hook,
+                           args: List[SimplifiedAst.Term.Head],
+                           tpe: Type,
+                           loc: SourceLocation) extends SimplifiedAst.Term.Head
 
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -77,6 +77,7 @@ object Simplifier {
         // TODO: Variable numbering
         SimplifiedAst.Expression.Var(ident, -1, tpe, loc)
       case TypedAst.Expression.Ref(name, tpe, loc) => SimplifiedAst.Expression.Ref(name, tpe, loc)
+      case TypedAst.Expression.Hook(hook, tpe, loc) => SimplifiedAst.Expression.Hook(hook, tpe, loc)
       case TypedAst.Expression.Lambda(annotations, args, body, tpe, loc) =>
         SimplifiedAst.Expression.Lambda(annotations, args map Simplifier.simplify, simplify(body), tpe, loc)
       case TypedAst.Expression.Apply(e, args, tpe, loc) =>
@@ -88,6 +89,7 @@ object Simplifier {
         SimplifiedAst.Expression.Binary(op, simplify(e1), simplify(e2), tpe, loc)
       case TypedAst.Expression.IfThenElse(e1, e2, e3, tpe, loc) =>
         SimplifiedAst.Expression.IfThenElse(simplify(e1), simplify(e2), simplify(e3), tpe, loc)
+      case TypedAst.Expression.Switch(rules, tpe, loc) => ???
       case TypedAst.Expression.Let(ident, e1, e2, tpe, loc) =>
         // TODO: Variable numbering
         SimplifiedAst.Expression.Let(ident, -1, simplify(e1), simplify(e2), tpe, loc)
@@ -279,7 +281,9 @@ object Simplifier {
         case TypedAst.Predicate.Body.Collection(name, terms, tpe, loc) =>
           SimplifiedAst.Predicate.Body.Collection(name, terms map Term.simplify, tpe, loc)
         case TypedAst.Predicate.Body.ApplyFilter(name, terms, tpe, loc) =>
-          SimplifiedAst.Predicate.Body.Function(name, terms map Term.simplify, tpe, loc)
+          SimplifiedAst.Predicate.Body.ApplyFilter(name, terms map Term.simplify, tpe, loc)
+        case TypedAst.Predicate.Body.ApplyHookFilter(hook, terms, tpe, loc) =>
+          SimplifiedAst.Predicate.Body.ApplyHookFilter(hook, terms map Term.simplify, tpe, loc)
         case TypedAst.Predicate.Body.NotEqual(ident1, ident2, tpe, loc) =>
           SimplifiedAst.Predicate.Body.NotEqual(ident1, ident2, tpe, loc)
         case TypedAst.Predicate.Body.Loop(ident, term, tpe, loc) =>
@@ -294,6 +298,7 @@ object Simplifier {
       case TypedAst.Term.Head.Var(ident, tpe, loc) => SimplifiedAst.Term.Head.Var(ident, tpe, loc)
       case TypedAst.Term.Head.Lit(lit, tpe, loc) => SimplifiedAst.Term.Head.Exp(Literal.simplify(lit), tpe, loc)
       case TypedAst.Term.Head.Apply(name, args, tpe, loc) => SimplifiedAst.Term.Head.Apply(name, args map simplify, tpe, loc)
+      case TypedAst.Term.Head.ApplyHook(hook, args, tpe, loc) => SimplifiedAst.Term.Head.ApplyHook(hook, args map simplify, tpe, loc)
     }
 
     def simplify(tast: TypedAst.Term.Body)(implicit genSym: GenSym): SimplifiedAst.Term.Body = tast match {


### PR DESCRIPTION
And the phases Simplifier and CreateExecutableAst.

A few changes from the front-end never got propagated to the back-end.
This commit finishes that work. Specifically:
- Predicate.Body.Function has been renamed to
  Predicate.Body.ApplyFilter
- Predicate.Body.ApplyHookFilter was added
- Directive.Print was removed
- Expression.Hook was added
- Term.Head.ApplyHook was added

@magnus-madsen: Please take a closer look to confirm I did this properly. The diff should be pretty straightforward.

Once this is merged in, I can continue the back-end refactor (to use ExecutableAst instead of TypedAst.)
