### PR TITLE
Fix bug in simplifying pattern matches

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/package.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/package.scala
@@ -12,9 +12,11 @@ package object phase {
     private var number: Int = new Random().nextInt() // TODO
 
     // TODO: Consider allowing a "seed" variable.
-    def fresh2(): Name.Ident = {
+    def fresh2(): Name.Ident = fresh2("tmp")
+
+    def fresh2(prefix: String): Name.Ident = {
       number = number + 1
-      Name.Ident(SourcePosition.Unknown, "tmp" + number, SourcePosition.Unknown)
+      Name.Ident(SourcePosition.Unknown, prefix + number, SourcePosition.Unknown)
     }
 
   }

--- a/main/test/ca/uwaterloo/flix/runtime/TestInterpreter.scala
+++ b/main/test/ca/uwaterloo/flix/runtime/TestInterpreter.scala
@@ -4884,8 +4884,7 @@ class TestInterpreter extends FunSuite {
     assert(executed)
   }
 
-  // TODO: Bug in the simplifier causes a NoSuchElementException.
-  // However, the test catches this exception and so the test passes.
+  // TODO: Catch the proper exception.
   // See https://github.com/magnus-madsen/flix/issues/118
   test("Match.Error.01") {
     val input =


### PR DESCRIPTION
Fixes #122.

This bugfix is one of the "delete the code and rewrite from scratch" fixes.

The problem was when we combined all the rules of a pattern match (which were already compiled into if-then-else expressions) into a series of nested let-bindings. We generated the fallthrough case as a synthetic rule, but it was never processed.

Consider the example in the comment. Given the code:

```
match x with {
  case PATTERN_1 => BODY_1
  case PATTERN_2 => BODY_2
  ...
  case PATTERN_N => BODY_N
}
```

We would generate the code:

```
let v' = x in
  let fallthrough = fn () ERROR in
    let v_n = fn () if (PATTERN_N succeeds) BODY_N else fallthrough() in
      ...
      let v_2 = fn () if (PATTERN_2 succeeds) BODY_2 else v_3() in
        let v_1 = fn () if (PATTERN_1 succeeds) BODY_1 else v_2() in
          v_1()
```

Note how each case has a variable name (`v_i`), a pattern and body (`PATTERN_i` and `BODY_i`), and a call to the next pattern (`v_(i+1)`). But this is not the case for fallthrough.

The bug in the old code was treating the fallthrough as a rule, but this is incorrect because there is no "next" rule to call.

My solution handles the fallthrough separately. I generate the let-bindings for the rules, and then separately generate the let-bindings for the fallthrough and match expression. I ended up rewriting the fold as a recursive function -- this is clearer because the "next" name is handled explicitly.

I confirm that all tests pass, and the match error test actually throws a match error (even though we can't yet test for it).
