### PR TITLE
Finish BigInts implementation. Also includes tests, other fixes.

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -246,6 +246,11 @@ class Flix {
   def mkInt64Type: IType = new WrappedType(Type.Int64)
 
   /**
+    * Returns the BigInt type.
+    */
+  def mkBigIntType: IType = new WrappedType(Type.BigInt)
+
+  /**
     * Returns the Str type.
     */
   def mkStrType: IType = new WrappedType(Type.Str)
@@ -436,6 +441,26 @@ class Flix {
     * Returns the int64 value corresponding to the given long.
     */
   def mkInt64(l: Long): IValue = new WrappedValue(Value.mkInt64(l))
+
+  /**
+    * Returns the BigInt value corresponding to the given int.
+    */
+  def mkBigInt(i: Int): IValue = new WrappedValue(Value.mkBigInt(i))
+
+  /**
+    * Returns the BigInt value corresponding to the given long.
+    */
+  def mkBigInt(l: Long): IValue = new WrappedValue(Value.mkBigInt(l))
+
+  /**
+    * Returns the BigInt value corresponding to the given string.
+    */
+  def mkBigInt(s: String): IValue = new WrappedValue(Value.mkBigInt(s))
+
+  /**
+    * Returns the BigInt value corresponding to the given java.math.BigInteger.
+    */
+  def mkBigInt(o: java.math.BigInteger): IValue = new WrappedValue(Value.mkBigInt(o))
 
   /**
     * Returns the str value corresponding to the given string.

--- a/main/src/ca/uwaterloo/flix/api/IType.scala
+++ b/main/src/ca/uwaterloo/flix/api/IType.scala
@@ -55,6 +55,11 @@ trait IType {
   def isInt64: Boolean
 
   /**
+    * Returns `true` if `this` type is the BigInt type.
+    */
+  def isBigInt: Boolean
+
+  /**
     * Returns `true` if `this` type is the str type.
     */
   def isStr: Boolean

--- a/main/src/ca/uwaterloo/flix/api/IValue.scala
+++ b/main/src/ca/uwaterloo/flix/api/IValue.scala
@@ -101,6 +101,13 @@ trait IValue {
     */
   def getInt64: Long
 
+  /**
+    * Returns the BigInt represented by `this` value.
+    *
+    * @throws UnsupportedOperationException if `this` value is not of int64 type.
+    */
+  def getBigInt: java.math.BigInteger
+
   /////////////////////////////////////////////////////////////////////////////
   // Strings                                                                 //
   /////////////////////////////////////////////////////////////////////////////

--- a/main/src/ca/uwaterloo/flix/api/WrappedType.scala
+++ b/main/src/ca/uwaterloo/flix/api/WrappedType.scala
@@ -31,6 +31,9 @@ final class WrappedType(val tpe: Type) extends IType {
   def isInt64: Boolean =
     tpe == Type.Int64
 
+  def isBigInt: Boolean =
+    tpe == Type.BigInt
+
   def isStr: Boolean =
     tpe == Type.Str
 

--- a/main/src/ca/uwaterloo/flix/api/WrappedValue.scala
+++ b/main/src/ca/uwaterloo/flix/api/WrappedValue.scala
@@ -35,6 +35,8 @@ final class WrappedValue(val ref: AnyRef) extends IValue {
 
   def getInt64: Long = Value.cast2int64(ref)
 
+  def getBigInt: java.math.BigInteger = Value.cast2bigInt(ref)
+
   def getStr: String = Value.cast2str(ref)
 
   def getTuple: Array[IValue] = Value.cast2tuple(ref).map(e => new WrappedValue(e))

--- a/main/src/ca/uwaterloo/flix/language/phase/LoadBytecode.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/LoadBytecode.scala
@@ -126,13 +126,13 @@ object LoadBytecode {
     case Type.Int16 => classOf[Short]
     case Type.Int32 => classOf[Int]
     case Type.Int64 => classOf[Long]
+    case Type.BigInt => classOf[java.math.BigInteger]
     case Type.Str => classOf[java.lang.String]
     case Type.Enum(_, _) => classOf[Value.Tag]
     case Type.Tuple(elms) => classOf[Value.Tuple]
     case Type.FSet(_) => classOf[scala.collection.immutable.Set[AnyRef]]
     case Type.Lambda(_, _) => interfaces(tpe)
     case Type.Tag(_, _, _) => throw InternalCompilerException(s"No corresponding JVM type for $tpe.")
-    case _ => ???
   }
 
   /**
@@ -150,6 +150,7 @@ object LoadBytecode {
       case Expression.Int16(lit) => Set.empty
       case Expression.Int32(lit) => Set.empty
       case Expression.Int64(lit) => Set.empty
+      case Expression.BigInt(lit) => Set.empty
       case Expression.Str(lit) => Set.empty
       case Expression.LoadBool(n, o) => Set.empty
       case Expression.LoadInt8(b, o) => Set.empty

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -439,6 +439,7 @@ object Typer {
                   case (Type.Int16, Type.Int32) => TypedAst.Expression.Binary(op, e1, e2, Type.Int16, loc).toSuccess
                   case (Type.Int32, Type.Int32) => TypedAst.Expression.Binary(op, e1, e2, Type.Int32, loc).toSuccess
                   case (Type.Int64, Type.Int32) => TypedAst.Expression.Binary(op, e1, e2, Type.Int64, loc).toSuccess
+                  case (Type.BigInt, Type.Int32) => TypedAst.Expression.Binary(op, e1, e2, Type.BigInt, loc).toSuccess
                   case (t1, t2) => TypeError.ExpectedEqualTypes(t1, t2, e1.loc, e2.loc).toFailure // TODO: Wrong error message.
                 }
               }

--- a/main/src/ca/uwaterloo/flix/runtime/Interpreter.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/Interpreter.scala
@@ -26,6 +26,7 @@ object Interpreter {
     case Expression.Int16(lit) => Value.mkInt16(lit)
     case Expression.Int32(lit) => Value.mkInt32(lit)
     case Expression.Int64(lit) => Value.mkInt64(lit)
+    case Expression.BigInt(lit) => Value.mkBigInt(lit)
     case Expression.Str(lit) => Value.mkStr(lit)
     case load: LoadExpression =>
       val e = Value.cast2int64(eval(load.e, root, env))
@@ -119,6 +120,7 @@ object Interpreter {
         case Type.Int16 => Value.mkInt16(-Value.cast2int16(v))
         case Type.Int32 => Value.mkInt32(-Value.cast2int32(v))
         case Type.Int64 => Value.mkInt64(-Value.cast2int64(v))
+        case Type.BigInt => Value.mkBigInt(Value.cast2bigInt(v).negate)
         case _ => throw new InternalRuntimeException(s"Can't apply UnaryOperator.$op to type ${e.tpe}.")
       }
       case UnaryOperator.BitwiseNegate => e.tpe match {
@@ -126,6 +128,7 @@ object Interpreter {
         case Type.Int16 => Value.mkInt16(~Value.cast2int16(v))
         case Type.Int32 => Value.mkInt32(~Value.cast2int32(v))
         case Type.Int64 => Value.mkInt64(~Value.cast2int64(v))
+        case Type.BigInt => Value.mkBigInt(Value.cast2bigInt(v).not)
         case _ => throw new InternalRuntimeException(s"Can't apply UnaryOperator.$op to type ${e.tpe}.")
       }
     }
@@ -142,6 +145,7 @@ object Interpreter {
         case Type.Int16 => Value.mkInt16(Value.cast2int16(v1) + Value.cast2int16(v2))
         case Type.Int32 => Value.mkInt32(Value.cast2int32(v1) + Value.cast2int32(v2))
         case Type.Int64 => Value.mkInt64(Value.cast2int64(v1) + Value.cast2int64(v2))
+        case Type.BigInt => Value.mkBigInt(Value.cast2bigInt(v1) add Value.cast2bigInt(v2))
         case _ => throw new InternalRuntimeException(s"Can't apply BinaryOperator.$o to type ${e1.tpe}.")
       }
       case BinaryOperator.Minus => e1.tpe match {
@@ -151,6 +155,7 @@ object Interpreter {
         case Type.Int16 => Value.mkInt16(Value.cast2int16(v1) - Value.cast2int16(v2))
         case Type.Int32 => Value.mkInt32(Value.cast2int32(v1) - Value.cast2int32(v2))
         case Type.Int64 => Value.mkInt64(Value.cast2int64(v1) - Value.cast2int64(v2))
+        case Type.BigInt => Value.mkBigInt(Value.cast2bigInt(v1) subtract Value.cast2bigInt(v2))
         case _ => throw new InternalRuntimeException(s"Can't apply BinaryOperator.$o to type ${e1.tpe}.")
       }
       case BinaryOperator.Times => e1.tpe match {
@@ -160,6 +165,7 @@ object Interpreter {
         case Type.Int16 => Value.mkInt16(Value.cast2int16(v1) * Value.cast2int16(v2))
         case Type.Int32 => Value.mkInt32(Value.cast2int32(v1) * Value.cast2int32(v2))
         case Type.Int64 => Value.mkInt64(Value.cast2int64(v1) * Value.cast2int64(v2))
+        case Type.BigInt => Value.mkBigInt(Value.cast2bigInt(v1) multiply Value.cast2bigInt(v2))
         case _ => throw new InternalRuntimeException(s"Can't apply BinaryOperator.$o to type ${e1.tpe}.")
       }
       case BinaryOperator.Divide => e1.tpe match {
@@ -169,6 +175,7 @@ object Interpreter {
         case Type.Int16 => Value.mkInt16(Value.cast2int16(v1) / Value.cast2int16(v2))
         case Type.Int32 => Value.mkInt32(Value.cast2int32(v1) / Value.cast2int32(v2))
         case Type.Int64 => Value.mkInt64(Value.cast2int64(v1) / Value.cast2int64(v2))
+        case Type.BigInt => Value.mkBigInt(Value.cast2bigInt(v1) divide Value.cast2bigInt(v2))
         case _ => throw new InternalRuntimeException(s"Can't apply BinaryOperator.$o to type ${e1.tpe}.")
       }
       case BinaryOperator.Modulo => e1.tpe match {
@@ -178,6 +185,7 @@ object Interpreter {
         case Type.Int16 => Value.mkInt16(Value.cast2int16(v1) % Value.cast2int16(v2))
         case Type.Int32 => Value.mkInt32(Value.cast2int32(v1) % Value.cast2int32(v2))
         case Type.Int64 => Value.mkInt64(Value.cast2int64(v1) % Value.cast2int64(v2))
+        case Type.BigInt => Value.mkBigInt(Value.cast2bigInt(v1) remainder Value.cast2bigInt(v2))
         case _ => throw new InternalRuntimeException(s"Can't apply BinaryOperator.$o to type ${e1.tpe}.")
       }
       case BinaryOperator.Exponentiate => e1.tpe match {
@@ -204,6 +212,7 @@ object Interpreter {
         case Type.Int16 => Value.mkBool(Value.cast2int16(v1) < Value.cast2int16(v2))
         case Type.Int32 => Value.mkBool(Value.cast2int32(v1) < Value.cast2int32(v2))
         case Type.Int64 => Value.mkBool(Value.cast2int64(v1) < Value.cast2int64(v2))
+        case Type.BigInt => Value.mkBool((Value.cast2bigInt(v1) compareTo Value.cast2bigInt(v2)) < 0)
         case _ => throw new InternalRuntimeException(s"Can't apply BinaryOperator.$o to type ${e1.tpe}.")
       }
       case BinaryOperator.LessEqual => e1.tpe match {
@@ -214,6 +223,7 @@ object Interpreter {
         case Type.Int16 => Value.mkBool(Value.cast2int16(v1) <= Value.cast2int16(v2))
         case Type.Int32 => Value.mkBool(Value.cast2int32(v1) <= Value.cast2int32(v2))
         case Type.Int64 => Value.mkBool(Value.cast2int64(v1) <= Value.cast2int64(v2))
+        case Type.BigInt => Value.mkBool((Value.cast2bigInt(v1) compareTo Value.cast2bigInt(v2)) <= 0)
         case _ => throw new InternalRuntimeException(s"Can't apply BinaryOperator.$o to type ${e1.tpe}.")
       }
       case BinaryOperator.Greater => e1.tpe match {
@@ -224,6 +234,7 @@ object Interpreter {
         case Type.Int16 => Value.mkBool(Value.cast2int16(v1) > Value.cast2int16(v2))
         case Type.Int32 => Value.mkBool(Value.cast2int32(v1) > Value.cast2int32(v2))
         case Type.Int64 => Value.mkBool(Value.cast2int64(v1) > Value.cast2int64(v2))
+        case Type.BigInt => Value.mkBool((Value.cast2bigInt(v1) compareTo Value.cast2bigInt(v2)) > 0)
         case _ => throw new InternalRuntimeException(s"Can't apply BinaryOperator.$o to type ${e1.tpe}.")
       }
       case BinaryOperator.GreaterEqual => e1.tpe match {
@@ -234,6 +245,7 @@ object Interpreter {
         case Type.Int16 => Value.mkBool(Value.cast2int16(v1) >= Value.cast2int16(v2))
         case Type.Int32 => Value.mkBool(Value.cast2int32(v1) >= Value.cast2int32(v2))
         case Type.Int64 => Value.mkBool(Value.cast2int64(v1) >= Value.cast2int64(v2))
+        case Type.BigInt => Value.mkBool((Value.cast2bigInt(v1) compareTo Value.cast2bigInt(v2)) >= 0)
         case _ => throw new InternalRuntimeException(s"Can't apply BinaryOperator.$o to type ${e1.tpe}.")
       }
       case BinaryOperator.Equal => Value.mkBool(v1 == v2)
@@ -264,6 +276,7 @@ object Interpreter {
         case Type.Int16 => Value.mkInt16(Value.cast2int16(v1) & Value.cast2int16(v2))
         case Type.Int32 => Value.mkInt32(Value.cast2int32(v1) & Value.cast2int32(v2))
         case Type.Int64 => Value.mkInt64(Value.cast2int64(v1) & Value.cast2int64(v2))
+        case Type.BigInt => Value.mkBigInt(Value.cast2bigInt(v1) and Value.cast2bigInt(v2))
         case _ => throw new InternalRuntimeException(s"Can't apply BinaryOperator.$o to type ${e1.tpe}.")
       }
       case BinaryOperator.BitwiseOr => e1.tpe match {
@@ -271,6 +284,7 @@ object Interpreter {
         case Type.Int16 => Value.mkInt16(Value.cast2int16(v1) | Value.cast2int16(v2))
         case Type.Int32 => Value.mkInt32(Value.cast2int32(v1) | Value.cast2int32(v2))
         case Type.Int64 => Value.mkInt64(Value.cast2int64(v1) | Value.cast2int64(v2))
+        case Type.BigInt => Value.mkBigInt(Value.cast2bigInt(v1) or Value.cast2bigInt(v2))
         case _ => throw new InternalRuntimeException(s"Can't apply BinaryOperator.$o to type ${e1.tpe}.")
       }
       case BinaryOperator.BitwiseXor => e1.tpe match {
@@ -278,6 +292,7 @@ object Interpreter {
         case Type.Int16 => Value.mkInt16(Value.cast2int16(v1) ^ Value.cast2int16(v2))
         case Type.Int32 => Value.mkInt32(Value.cast2int32(v1) ^ Value.cast2int32(v2))
         case Type.Int64 => Value.mkInt64(Value.cast2int64(v1) ^ Value.cast2int64(v2))
+        case Type.BigInt => Value.mkBigInt(Value.cast2bigInt(v1) xor Value.cast2bigInt(v2))
         case _ => throw new InternalRuntimeException(s"Can't apply BinaryOperator.$o to type ${e1.tpe}.")
       }
       case BinaryOperator.BitwiseLeftShift => e1.tpe match {
@@ -285,6 +300,7 @@ object Interpreter {
         case Type.Int16 => Value.mkInt16(Value.cast2int16(v1) << Value.cast2int32(v2))
         case Type.Int32 => Value.mkInt32(Value.cast2int32(v1) << Value.cast2int32(v2))
         case Type.Int64 => Value.mkInt64(Value.cast2int64(v1) << Value.cast2int32(v2))
+        case Type.BigInt => Value.mkBigInt(Value.cast2bigInt(v1) shiftLeft Value.cast2int32(v2))
         case _ => throw new InternalRuntimeException(s"Can't apply BinaryOperator.$o to type ${e1.tpe}.")
       }
       case BinaryOperator.BitwiseRightShift => e1.tpe match {
@@ -292,6 +308,7 @@ object Interpreter {
         case Type.Int16 => Value.mkInt16(Value.cast2int16(v1) >> Value.cast2int32(v2))
         case Type.Int32 => Value.mkInt32(Value.cast2int32(v1) >> Value.cast2int32(v2))
         case Type.Int64 => Value.mkInt64(Value.cast2int64(v1) >> Value.cast2int32(v2))
+        case Type.BigInt => Value.mkBigInt(Value.cast2bigInt(v1) shiftRight Value.cast2int32(v2))
         case _ => throw new InternalRuntimeException(s"Can't apply BinaryOperator.$o to type ${e1.tpe}.")
       }
     }

--- a/main/src/ca/uwaterloo/flix/runtime/Value.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/Value.scala
@@ -155,6 +155,33 @@ object Value {
   def mkInt64(l: Long): AnyRef = new java.lang.Long(l)
 
   /**
+    * Constructs a java.math.BigInteger from the given int `i`.
+    */
+  @inline
+  def mkBigInt(i: Int): AnyRef = java.math.BigInteger.valueOf(i)
+
+  /**
+    * Constructs a java.math.BigInteger from the given long `l`.
+    */
+  @inline
+  def mkBigInt(l: Long): AnyRef = java.math.BigInteger.valueOf(l)
+
+  /**
+    * Constructs a java.math.BigInteger from the given string `s`.
+    */
+  @inline
+  def mkBigInt(s: String): AnyRef = new java.math.BigInteger(s)
+
+  /**
+    * Constructs the Flix representation of a java.math.BigInteger for the given `ref`.
+    */
+  @inline
+  def mkBigInt(ref: AnyRef): AnyRef = ref match {
+    case o: java.math.BigInteger => o
+    case _ => throw new InternalRuntimeException(s"Unexpected non-bigint value: '$ref'.")
+  }
+
+  /**
     * Casts the given reference `ref` to an int8.
     */
   @inline
@@ -188,6 +215,15 @@ object Value {
   def cast2int64(ref: AnyRef): Long = ref match {
     case o: java.lang.Long => o.longValue()
     case _ => throw new InternalRuntimeException(s"Unexpected non-int64 value: '$ref'.")
+  }
+
+  /**
+    * Casts the given reference `ref` to a java.math.BigInteger.
+    */
+  @inline
+  def cast2bigInt(ref: AnyRef): java.math.BigInteger = ref match {
+    case o: java.math.BigInteger => o
+    case _ => throw new InternalRuntimeException(s"Unexpected non-bigint value: '$ref'.")
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/main/src/ca/uwaterloo/flix/runtime/verifier/SymbolicEvaluator.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/verifier/SymbolicEvaluator.scala
@@ -205,7 +205,7 @@ object SymbolicEvaluator {
               case SymVal.Int16(i) => lift(pc, SymVal.Int16((-i).toShort))
               case SymVal.Int32(i) => lift(pc, SymVal.Int32(-i))
               case SymVal.Int64(i) => lift(pc, SymVal.Int64(-i))
-              case SymVal.BigInt(i) => lift(pc, SymVal.BigInt(i.negate()))
+              case SymVal.BigInt(i) => lift(pc, SymVal.BigInt(i.negate))
 
               // Symbolic semantics.
               case SymVal.AtomicVar(id) =>
@@ -225,7 +225,7 @@ object SymbolicEvaluator {
               case SymVal.Int16(i) => lift(pc, SymVal.Int16((~i).toShort))
               case SymVal.Int32(i) => lift(pc, SymVal.Int32(~i))
               case SymVal.Int64(i) => lift(pc, SymVal.Int64(~i))
-              case SymVal.BigInt(i) => throw InternalCompilerException(s"Type Error: BigInt does not support BitwiseNegate.")
+              case SymVal.BigInt(i) => lift(pc, SymVal.BigInt(i.not))
 
               // Symbolic semantics
               case SymVal.AtomicVar(id) =>
@@ -327,7 +327,7 @@ object SymbolicEvaluator {
               case (SymVal.Int16(i1), SymVal.Int16(i2)) => lift(pc, SymVal.Int16((i1 % i2).toShort))
               case (SymVal.Int32(i1), SymVal.Int32(i2)) => lift(pc, SymVal.Int32(i1 % i2))
               case (SymVal.Int64(i1), SymVal.Int64(i2)) => lift(pc, SymVal.Int64(i1 % i2))
-              case (SymVal.BigInt(i1), SymVal.BigInt(i2)) => lift(pc, SymVal.BigInt(i1 mod i2))
+              case (SymVal.BigInt(i1), SymVal.BigInt(i2)) => lift(pc, SymVal.BigInt(i1 remainder i2))
 
               // Symbolic semantics.
               case _ =>
@@ -629,11 +629,11 @@ object SymbolicEvaluator {
               */
             case BinaryOperator.BitwiseLeftShift => (v1, v2) match {
               // Concrete semantics.
-              case (SymVal.Int8(i1), SymVal.Int8(i2)) => lift(pc, SymVal.Int8((i1 << i2).toByte))
-              case (SymVal.Int16(i1), SymVal.Int16(i2)) => lift(pc, SymVal.Int16((i1 << i2).toShort))
+              case (SymVal.Int8(i1), SymVal.Int32(i2)) => lift(pc, SymVal.Int8((i1 << i2).toByte))
+              case (SymVal.Int16(i1), SymVal.Int32(i2)) => lift(pc, SymVal.Int16((i1 << i2).toShort))
               case (SymVal.Int32(i1), SymVal.Int32(i2)) => lift(pc, SymVal.Int32(i1 << i2))
-              case (SymVal.Int64(i1), SymVal.Int64(i2)) => lift(pc, SymVal.Int64(i1 << i2))
-              case (SymVal.BigInt(i1), SymVal.BigInt(i2)) => throw InternalCompilerException(s"Type Error: BigInt does not support BitwiseLeftShift.")
+              case (SymVal.Int64(i1), SymVal.Int32(i2)) => lift(pc, SymVal.Int64(i1 << i2))
+              case (SymVal.BigInt(i1), SymVal.Int32(i2)) => lift(pc, SymVal.BigInt(i1 shiftLeft i2))
 
               // Symbolic semantics.
               case _ =>
@@ -647,11 +647,11 @@ object SymbolicEvaluator {
               */
             case BinaryOperator.BitwiseRightShift => (v1, v2) match {
               // Concrete semantics.
-              case (SymVal.Int8(i1), SymVal.Int8(i2)) => lift(pc, SymVal.Int8((i1 >> i2).toByte))
-              case (SymVal.Int16(i1), SymVal.Int16(i2)) => lift(pc, SymVal.Int16((i1 >> i2).toShort))
+              case (SymVal.Int8(i1), SymVal.Int32(i2)) => lift(pc, SymVal.Int8((i1 >> i2).toByte))
+              case (SymVal.Int16(i1), SymVal.Int32(i2)) => lift(pc, SymVal.Int16((i1 >> i2).toShort))
               case (SymVal.Int32(i1), SymVal.Int32(i2)) => lift(pc, SymVal.Int32(i1 >> i2))
-              case (SymVal.Int64(i1), SymVal.Int64(i2)) => lift(pc, SymVal.Int64(i1 >> i2))
-              case (SymVal.BigInt(i1), SymVal.BigInt(i2)) => throw InternalCompilerException(s"Type Error: BigInt does not support BitwiseRightShift.")
+              case (SymVal.Int64(i1), SymVal.Int32(i2)) => lift(pc, SymVal.Int64(i1 >> i2))
+              case (SymVal.BigInt(i1), SymVal.Int32(i2)) => lift(pc, SymVal.BigInt(i1 shiftRight i2))
 
               // Symbolic semantics.
               case _ =>

--- a/main/test/ca/uwaterloo/flix/TestExamples.scala
+++ b/main/test/ca/uwaterloo/flix/TestExamples.scala
@@ -166,8 +166,7 @@ class TestExamples extends FunSuite {
     t.checkValue(List(Two), "Constant/A", List(Value.mkInt32(6)))
   }
 
-  // TODO: Implement BigInt in interpreter and codegen
-  ignore("ConstantSign.flix") {
+  test("ConstantSign.flix") {
     val input =
       """namespace ConstantSign {
         |    let ConstSign<> = (ConstSign.Bot, ConstSign.Top, leq, lub, glb);
@@ -201,8 +200,8 @@ class TestExamples extends FunSuite {
 
     val ConstantSign = Symbol.Resolved.mk(List("ConstantSign", "ConstSign"))
 
-    val Zer = Value.mkTag(ConstantSign, "Cst", Value.mkInt32(0))
-    val One = Value.mkTag(ConstantSign, "Cst", Value.mkInt32(1))
+    val Zer = Value.mkTag(ConstantSign, "Cst", Value.mkBigInt(0))
+    val One = Value.mkTag(ConstantSign, "Cst", Value.mkBigInt(1))
     val Pos = Value.mkTag(ConstantSign, "Pos", Value.Unit)
     val Top = Value.mkTag(ConstantSign, "Top", Value.Unit)
 


### PR DESCRIPTION
Both the interpreter and code generator now support BigInts. Tests
have been updated accordingly.

There are also other minor fixes:
- The Value object now supports constructing/casting BigInts
- The Flix API for interop now supports the BigInt type and its values
- Typer is updated to allow bitwise operations with BigInts
- The SymbolicEvaluator has been updated to support bitwise operations
  for BigInts
- Fixed an issue in the SymbolicEvaluator: the second argument (i.e.
  shift amount) for a bitwise shift is always a 32-bit int
- Fixed a test in TestExamples

Fixes #150.
