### PR TITLE
Add support for CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # The Flix Programming Language
 
 [![Build Status](https://travis-ci.org/flix/flix.svg?branch=master)](https://travis-ci.org/flix/flix)
+[![CircleCI](https://circleci.com/gh/flix/flix.svg?style=svg)](https://circleci.com/gh/flix/flix)
 
 Main repository for the source code of the Flix compiler and run-time.
 

--- a/build.xml
+++ b/build.xml
@@ -42,7 +42,7 @@
         <mkdir dir="${out.dir}/classes"/>
 
         <!-- Compile scala sources. -->
-        <scalac srcdir="${src.dir}" destdir="${out.dir}/classes" classpathref="classpath">
+        <scalac srcdir="${src.dir}" destdir="${out.dir}/classes" classpathref="classpath" fork="true">
             <include name="**/*.scala"/>
         </scalac>
 

--- a/circle.yml
+++ b/circle.yml
@@ -5,5 +5,4 @@ dependencies:
 
   override:
     environment:
-      SCALA_HOME: `pwd`/scala-2.11.7
-      PATH: $SCALA_HOME/bin:$PATH
+      SCALA_HOME: /home/ubuntu/scala-2.11.7

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,12 @@
-pre:
-  - env
-  - pushd .
-  - cd
-  - wget http://downloads.typesafe.com/scala/2.11.7/scala-2.11.7.tgz
-  - tar xzf scala-2.11.7.tgz
-  - export SCALA_HOME=`pwd`/scala-2.11.7
-  - export PATH=$SCALA_HOME/bin:$PATH
-  - popd
-  - scalac -version
-  - which scalac
+dependencies:
+  pre:
+    - env
+    - pushd .
+    - cd
+    - wget http://downloads.typesafe.com/scala/2.11.7/scala-2.11.7.tgz
+    - tar xzf scala-2.11.7.tgz
+    - export SCALA_HOME=`pwd`/scala-2.11.7
+    - export PATH=$SCALA_HOME/bin:$PATH
+    - popd
+    - scalac -version
+    - which scalac

--- a/circle.yml
+++ b/circle.yml
@@ -9,3 +9,7 @@ machine:
   java:
     version:
       oraclejdk8
+
+test:
+  override:
+    - ant test

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,6 @@ dependencies:
     - wget http://downloads.typesafe.com/scala/2.11.7/scala-2.11.7.tgz
     - tar xzf scala-2.11.7.tgz
 
-  override:
-    environment:
-      SCALA_HOME: /home/ubuntu/scala-2.11.7
+machine:
+  environment:
+    SCALA_HOME: /home/ubuntu/scala-2.11.7

--- a/circle.yml
+++ b/circle.yml
@@ -5,4 +5,4 @@ dependencies:
 
 machine:
   environment:
-    SCALA_HOME: /home/ubuntu/scala-2.11.7
+    SCALA_HOME: /home/ubuntu/flix/scala-2.11.7

--- a/circle.yml
+++ b/circle.yml
@@ -6,3 +6,6 @@ dependencies:
 machine:
   environment:
     SCALA_HOME: /home/ubuntu/flix/scala-2.11.7
+  java:
+    version:
+      oraclejdk8

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,8 @@ dependencies:
   pre:
     - wget http://downloads.typesafe.com/scala/2.11.7/scala-2.11.7.tgz
     - tar xzf scala-2.11.7.tgz
-    - export SCALA_HOME=`pwd`/scala-2.11.7
-    - export PATH=$SCALA_HOME/bin:$PATH
-    - scalac -version
-    - which scalac
+
+  override:
+    environment:
+      SCALA_HOME: `pwd`/scala-2.11.7
+      PATH: $SCALA_HOME/bin:$PATH

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+before:
+  - env
+  - pushd .
+  - cd
+  - wget http://downloads.typesafe.com/scala/2.11.7/scala-2.11.7.tgz
+  - tar xzf scala-2.11.7.tgz
+  - export SCALA_HOME=`pwd`/scala-2.11.7
+  - export PATH=$SCALA_HOME/bin:$PATH
+  - popd
+  - scalac -version
+  - which scalac

--- a/circle.yml
+++ b/circle.yml
@@ -1,12 +1,8 @@
 dependencies:
   pre:
-    - env
-    - pushd .
-    - cd
     - wget http://downloads.typesafe.com/scala/2.11.7/scala-2.11.7.tgz
     - tar xzf scala-2.11.7.tgz
     - export SCALA_HOME=`pwd`/scala-2.11.7
     - export PATH=$SCALA_HOME/bin:$PATH
-    - popd
     - scalac -version
     - which scalac

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,4 @@
-before:
+pre:
   - env
   - pushd .
   - cd

--- a/main/test/ca/uwaterloo/flix/TestAll.scala
+++ b/main/test/ca/uwaterloo/flix/TestAll.scala
@@ -36,9 +36,9 @@ class TestAll extends Suites(
   new TestValue,
   new TestValidation,
   new TestMain,
-  new TestDeltaSolver,
+  new TestDeltaSolver
   //new TestLibrary, // TODO
-   new TestExamples
+  // new TestExamples // TODO: Pending fixes to Codegen performance.
 ) with ParallelTestExecution {
 
 }

--- a/main/test/ca/uwaterloo/flix/TestAll.scala
+++ b/main/test/ca/uwaterloo/flix/TestAll.scala
@@ -36,9 +36,9 @@ class TestAll extends Suites(
   new TestValue,
   new TestValidation,
   new TestMain,
-  new TestDeltaSolver
+  new TestDeltaSolver,
   //new TestLibrary, // TODO
-  // new TestExamples // TODO: temporarily removed while we figure out what to do with travis.
+   new TestExamples
 ) with ParallelTestExecution {
 
 }


### PR DESCRIPTION
This small PR adds support for continuous integration with circle ci.

The plan is to run travis ci and circle ci simultaneously to

 (1) Help us uncover bugs in Flix, esp. related to testing. 
(2) Find out which one we prefer to use.