### PR TITLE
Refactor IndexedLattice

### DIFF
--- a/examples/analysis/SUopt.flix
+++ b/examples/analysis/SUopt.flix
@@ -116,3 +116,12 @@ SU(l,a,f(b)) :- Clear(l), PtH(a,b).
 def top(e: Int): SULattice = SULattice.Top;
 Kill(l,f(b)) :- Store(l,p,q), Pt(p,b).
 Kill(l, top(42)) :- Phi(l,_,_).
+
+// uncomment to introduce an error delta debugging
+//def isTop(e: SULattice): Bool = match e with {
+//   case SULattice.Bottom => false
+//   case SULattice.Single(s) => false
+//   case SULattice.Top => true // (1 / 0) == 0
+//}
+
+//false :- isTop(x), SU("431", "212 hbMakeCodeLengths:freq_addr<mem>", x).

--- a/main/src/ca/uwaterloo/flix/api/WrappedModel.scala
+++ b/main/src/ca/uwaterloo/flix/api/WrappedModel.scala
@@ -37,7 +37,7 @@ final class WrappedModel(val model: Model) extends IModel {
     model.getLatticeOpt(name) match {
       case None => throw new IllegalArgumentException(s"Unknown relation: '$name'.")
       case Some(iterable) => iterable.map {
-        case (keys, values) => (keys ::: values).map(e => new WrappedValue(e): IValue).toArray
+        case (keys, elm) => (keys :: elm :: Nil).map(e => new WrappedValue(e): IValue).toArray
       }.asJava
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/ast/ExecutableAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ExecutableAst.scala
@@ -70,7 +70,7 @@ object ExecutableAst {
 
     case class Lattice(sym: Symbol.TableSym,
                        keys: Array[ExecutableAst.Attribute],
-                       values: Array[ExecutableAst.Attribute],
+                       value: ExecutableAst.Attribute,
                        loc: SourceLocation) extends ExecutableAst.Table
 
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/CreateExecutableAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/CreateExecutableAst.scala
@@ -131,8 +131,7 @@ object CreateExecutableAst {
         ExecutableAst.Table.Relation(symbol, attributesArray, loc)
       case SimplifiedAst.Table.Lattice(symbol, keys, value, loc) =>
         val keysArray = keys.map(CreateExecutableAst.toExecutable).toArray
-        val valuesArray = Array(CreateExecutableAst.toExecutable(value))
-        ExecutableAst.Table.Lattice(symbol, keysArray, valuesArray, loc)
+        ExecutableAst.Table.Lattice(symbol, keysArray, CreateExecutableAst.toExecutable(value), loc)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/runtime/Model.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/Model.scala
@@ -30,7 +30,7 @@ class Model(root: ExecutableAst.Root,
             time: Time,
             definitions: Map[Symbol.Resolved, () => AnyRef],
             relations: Map[Symbol.TableSym, Iterable[List[AnyRef]]],
-            lattices: Map[Symbol.TableSym, Iterable[(List[AnyRef], List[AnyRef])]]) {
+            lattices: Map[Symbol.TableSym, Iterable[(List[AnyRef], AnyRef)]]) {
 
   def getRoot: ExecutableAst.Root = root
 
@@ -46,10 +46,10 @@ class Model(root: ExecutableAst.Root,
   def getRelationOpt(name: String): Option[Iterable[List[AnyRef]]] =
     relations.get(Symbol.mkTableSym(name))
 
-  def getLattice(name: String): Iterable[(List[AnyRef], List[AnyRef])] =
+  def getLattice(name: String): Iterable[(List[AnyRef], AnyRef)] =
     getLatticeOpt(name).get
 
-  def getLatticeOpt(name: String): Option[Iterable[(List[AnyRef], List[AnyRef])]] =
+  def getLatticeOpt(name: String): Option[Iterable[(List[AnyRef], AnyRef)]] =
     lattices.get(Symbol.mkTableSym(name))
 
 }

--- a/main/src/ca/uwaterloo/flix/runtime/Solver.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/Solver.scala
@@ -649,10 +649,10 @@ class Solver(val root: ExecutableAst.Root, options: Options) {
         val table = relation.scan.toIterable.map(_.toList)
         macc + ((sym, table))
     }
-    val lattices = dataStore.lattices.foldLeft(Map.empty[Symbol.TableSym, Iterable[(List[AnyRef], List[AnyRef])]]) {
+    val lattices = dataStore.lattices.foldLeft(Map.empty[Symbol.TableSym, Iterable[(List[AnyRef], AnyRef)]]) {
       case (macc, (sym, lattice)) =>
         val table = lattice.scan.toIterable.map {
-          case (keys, values) => (keys.toArray.toList, values.toList)
+          case (keys, values) => (keys.toArray.toList, values)
         }
         macc + ((sym, table))
     }

--- a/main/src/ca/uwaterloo/flix/runtime/datastore/IndexedLattice.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/datastore/IndexedLattice.scala
@@ -238,7 +238,7 @@ class IndexedLattice[ValueType <: AnyRef](val lattice: ExecutableAst.Table.Latti
 
         if (rv != pv) {
           val bot = Bot(i)
-          val glb = Interpreter.evalCall(Glb(i), Array(pv, rv).asInstanceOf[Array[AnyRef]], root).asInstanceOf[ValueType]
+          val glb = glb2(pv, rv)
 
           if (bot == glb)
             return false
@@ -252,7 +252,7 @@ class IndexedLattice[ValueType <: AnyRef](val lattice: ExecutableAst.Table.Latti
   }
 
   /**
-    * Returns `true` iff `x` is less than or equal to `y` according to the partial order.
+    * Returns `true` iff `x` is less than or equal to `y`.
     */
   private def leq(x: ValueType, y: ValueType): Boolean = {
     if (x eq y) {
@@ -265,7 +265,7 @@ class IndexedLattice[ValueType <: AnyRef](val lattice: ExecutableAst.Table.Latti
   }
 
   /**
-    * Returns the least upper bound of `x` and `y` according to the partial order.
+    * Returns the least upper bound of `x` and `y`.
     */
   private def lub(x: ValueType, y: ValueType): Array[ValueType] = {
     // TODO
@@ -279,6 +279,19 @@ class IndexedLattice[ValueType <: AnyRef](val lattice: ExecutableAst.Table.Latti
     val res = new Array[ValueType](1)
     res(0) = r
     res
+  }
+
+  /**
+    * Returns the greatest lower bound of `x` and `y`..
+    */
+  private def glb2(x: ValueType, y: ValueType): ValueType = {
+    // TODO
+    //if (x eq y) {
+    //  return x
+    // }
+
+    val args = Array(x, y).asInstanceOf[Array[AnyRef]]
+    Interpreter.evalCall(Glb(0), args, root).asInstanceOf[ValueType]
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/runtime/datastore/IndexedLattice.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/datastore/IndexedLattice.scala
@@ -72,13 +72,7 @@ class IndexedLattice[ValueType <: AnyRef](val lattice: ExecutableAst.Table.Latti
   /**
     * The Glb operator(s). Must be defined as Flix functions.
     */
-  private val Glb: Array[ExecutableAst.Definition.Constant] = {
-    val a = new Array[ExecutableAst.Definition.Constant](latticeOps.length)
-    for ((l, i) <- latticeOps.zipWithIndex) {
-      a(i) = root.constants(l.glb)
-    }
-    a
-  }
+  private val Glb: ExecutableAst.Definition.Constant = root.constants(latticeOps(0).glb)
 
   /**
     * Initialize the store for all indexes.
@@ -285,13 +279,12 @@ class IndexedLattice[ValueType <: AnyRef](val lattice: ExecutableAst.Table.Latti
     * Returns the greatest lower bound of `x` and `y`..
     */
   private def glb2(x: ValueType, y: ValueType): ValueType = {
-    // TODO
-    //if (x eq y) {
-    //  return x
-    // }
+    if (x eq y) {
+      return x
+    }
 
     val args = Array(x, y).asInstanceOf[Array[AnyRef]]
-    Interpreter.evalCall(Glb(0), args, root).asInstanceOf[ValueType]
+    Interpreter.evalCall(Glb, args, root).asInstanceOf[ValueType]
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/runtime/datastore/IndexedLattice.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/datastore/IndexedLattice.scala
@@ -40,14 +40,12 @@ class IndexedLattice[ValueType <: AnyRef](val lattice: ExecutableAst.Table.Latti
   /**
     * The number of element columns in the lattice.
     */
-  private val numberOfElms = lattice.values.length
+  private val numberOfElms = 1
 
   /**
     * The lattice operations associated with each lattice.
     */
-  private val latticeOps: Array[ExecutableAst.Definition.Lattice] = lattice.values.map {
-    case ExecutableAst.Attribute(_, tpe) => root.lattices(tpe)
-  }
+  private val latticeOps: Array[ExecutableAst.Definition.Lattice] = Array(root.lattices(lattice.value.tpe))
 
   /**
     * The bottom element(s).

--- a/main/src/ca/uwaterloo/flix/runtime/debugger/RestServer.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/debugger/RestServer.scala
@@ -249,7 +249,7 @@ class RestServer(solver: Solver) {
     */
   class ListLattice(lattice: IndexedLattice[AnyRef]) extends JsonHandler {
     def json: JValue = JObject(
-      JField("cols", JArray(lattice.lattice.keys.toList.map(a => JString(a.ident.name)) ::: lattice.lattice.values.toList.map(a => JString(a.ident.name)))),
+      JField("cols", JArray(lattice.lattice.keys.toList.map(a => JString(a.ident.name)) ::: JString(lattice.lattice.value.ident.name) :: Nil)),
       JField("rows", JArray(lattice.scan.toList.map {
         case (key, elms) => JArray(key.toArray.map(k => JString(Value.pretty(k))).toList ::: elms.map(e => JString(Value.pretty(e))).toList)
       })))

--- a/main/src/ca/uwaterloo/flix/runtime/debugger/RestServer.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/debugger/RestServer.scala
@@ -251,7 +251,7 @@ class RestServer(solver: Solver) {
     def json: JValue = JObject(
       JField("cols", JArray(lattice.lattice.keys.toList.map(a => JString(a.ident.name)) ::: JString(lattice.lattice.value.ident.name) :: Nil)),
       JField("rows", JArray(lattice.scan.toList.map {
-        case (key, elms) => JArray(key.toArray.map(k => JString(Value.pretty(k))).toList ::: elms.map(e => JString(Value.pretty(e))).toList)
+        case (key, elm) => JArray(key.toArray.map(k => JString(Value.pretty(k))).toList ::: JString(Value.pretty(elm)) :: Nil)
       })))
   }
 

--- a/main/src/ca/uwaterloo/flix/util/PrettyPrint.scala
+++ b/main/src/ca/uwaterloo/flix/util/PrettyPrint.scala
@@ -56,7 +56,7 @@ object PrettyPrint {
       case None => // nop
       case Some(xs) =>
         val l = model.getRoot.tables(sym).asInstanceOf[ExecutableAst.Table.Lattice]
-        val cols = l.keys.map(_.ident.name).toList ::: l.values.map(_.ident.name).toList
+        val cols = l.keys.map(_.ident.name).toList ::: l.value.ident.name :: Nil
         val ascii = new AsciiTable().withCols(cols: _*)
         for ((keys, elms) <- xs.toSeq.sortBy(_._1.head.toString)) {
           ascii.mkRow((keys map Value.pretty) ++ (elms map Value.pretty))

--- a/main/src/ca/uwaterloo/flix/util/PrettyPrint.scala
+++ b/main/src/ca/uwaterloo/flix/util/PrettyPrint.scala
@@ -58,8 +58,8 @@ object PrettyPrint {
         val l = model.getRoot.tables(sym).asInstanceOf[ExecutableAst.Table.Lattice]
         val cols = l.keys.map(_.ident.name).toList ::: l.value.ident.name :: Nil
         val ascii = new AsciiTable().withCols(cols: _*)
-        for ((keys, elms) <- xs.toSeq.sortBy(_._1.head.toString)) {
-          ascii.mkRow((keys map Value.pretty) ++ (elms map Value.pretty))
+        for ((keys, elm) <- xs.toSeq.sortBy(_._1.head.toString)) {
+          ascii.mkRow((keys map Value.pretty) ++ List(Value.pretty(elm)))
         }
 
         Console.println(l.sym)

--- a/main/test/ca/uwaterloo/flix/runtime/TestSolver.scala
+++ b/main/test/ca/uwaterloo/flix/runtime/TestSolver.scala
@@ -375,9 +375,9 @@ class TestSolver extends FunSuite {
 
     val model = new Flix().setOptions(opts).addStr(Parity.Definition).addStr(s).solve().get
     val A = model.getLattice("A").toMap
-    assert(A(List(Value.mkInt32(1))).head == Parity.Odd)
-    assert(A(List(Value.mkInt32(2))).head == Parity.Even)
-    assert(A(List(Value.mkInt32(3))).head == Parity.Top)
+    assert(A(List(Value.mkInt32(1))) == Parity.Odd)
+    assert(A(List(Value.mkInt32(2))) == Parity.Even)
+    assert(A(List(Value.mkInt32(3))) == Parity.Top)
   }
 
   test("Lattice02") {
@@ -391,7 +391,7 @@ class TestSolver extends FunSuite {
 
     val model = new Flix().setOptions(opts).addStr(Parity.Definition).addStr(s).solve().get
     val A = model.getLattice("A").toMap
-    assert(A(List(Value.mkInt32(1))).head == Parity.Top)
+    assert(A(List(Value.mkInt32(1))) == Parity.Top)
   }
 
   test("Lattice03") {
@@ -407,7 +407,7 @@ class TestSolver extends FunSuite {
 
     val model = new Flix().setOptions(opts).addStr(Parity.Definition).addStr(s).solve().get
     val A = model.getLattice("A").toMap
-    assert(A(List(Value.mkInt32(3))).head == Parity.Top)
+    assert(A(List(Value.mkInt32(3))) == Parity.Top)
   }
 
   test("NotEqual01") {


### PR DESCRIPTION
In the previous versions of Flix, a predicate was of the form P(k1, ..., kn, l1, ..., ln) where k1...kn are keys and l1...ln are lattice elements. In current versions, we only allow P(k1, ..., kn, l). This PR implements that change for IndexedLattice. The benefit is slightly cleaner code, and fewer array allocations.