### PR TITLE
Replace `in` operator by semicolon.

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -426,14 +426,8 @@ class Parser(val source: SourceInput) extends org.parboiled2.Parser {
       SP ~ atomic("if") ~ optWS ~ "(" ~ optWS ~ Expression ~ optWS ~ ")" ~ optWS ~ Expression ~ WS ~ atomic("else") ~ WS ~ Expression ~ SP ~> ParsedAst.Expression.IfThenElse
     }
 
-    def LetMatch: Rule1[ParsedAst.Expression.LetMatch] = {
-      def InOrSC: Rule0 = rule {
-        (WS ~ atomic("in") ~ WS) | (optWS ~ ";" ~ optWS)
-      }
-
-      rule {
-        SP ~ atomic("let") ~ WS ~ Pattern ~ optWS ~ "=" ~ optWS ~ Expression ~ InOrSC ~ Expression ~ SP ~> ParsedAst.Expression.LetMatch
-      }
+    def LetMatch: Rule1[ParsedAst.Expression.LetMatch] = rule {
+      SP ~ atomic("let") ~ WS ~ Pattern ~ optWS ~ "=" ~ optWS ~ Expression ~ optWS ~ ";" ~ optWS ~ Expression ~ SP ~> ParsedAst.Expression.LetMatch
     }
 
     def Match: Rule1[ParsedAst.Expression.Match] = {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -852,7 +852,8 @@ class TestParser extends FunSuite with TestUtils {
     val input =
       """
         |def f: Int =
-        |  let x = 42 in x
+        |  let x = 42;
+        |    x
         | """.stripMargin
     run(input)
   }
@@ -861,7 +862,7 @@ class TestParser extends FunSuite with TestUtils {
     val input =
       """
         |def f: Int =
-        |  let (x, y) = (42, 21) in
+        |  let (x, y) = (42, 21);
         |    x + y
         | """.stripMargin
     run(input)
@@ -871,9 +872,9 @@ class TestParser extends FunSuite with TestUtils {
     val input =
       """
         |def f: Int =
-        |  let x = 1 in
-        |  let y = 2 in
-        |  let z = 3 in
+        |  let x = 1;
+        |  let y = 2;
+        |  let z = 3;
         |    x + y + z
       """.stripMargin
     run(input)
@@ -884,33 +885,33 @@ class TestParser extends FunSuite with TestUtils {
     val input =
     """
       |def f: Int =
-      |    let x1 = 1 in
-      |    let x2 = 1 in
-      |    let x3 = 1 in
-      |    let x4 = 1 in
-      |    let x5 = 1 in
-      |    let x6 = 1 in
-      |    let x7 = 1 in
-      |    let x8 = 1 in
-      |    let x9 = 1 in
-      |    let y1 = 1 in
-      |    let y2 = 1 in
-      |    let y3 = 1 in
-      |    let y4 = 1 in
-      |    let y5 = 1 in
-      |    let y6 = 1 in
-      |    let y7 = 1 in
-      |    let y8 = 1 in
-      |    let y9 = 1 in
-      |    let z1 = 1 in
-      |    let z2 = 1 in
-      |    let z3 = 1 in
-      |    let z4 = 1 in
-      |    let z5 = 1 in
-      |    let z6 = 1 in
-      |    let z7 = 1 in
-      |    let z8 = 1 in
-      |    let z9 = 1 in
+      |    let x1 = 1;
+      |    let x2 = 1;
+      |    let x3 = 1;
+      |    let x4 = 1;
+      |    let x5 = 1;
+      |    let x6 = 1;
+      |    let x7 = 1;
+      |    let x8 = 1;
+      |    let x9 = 1;
+      |    let y1 = 1;
+      |    let y2 = 1;
+      |    let y3 = 1;
+      |    let y4 = 1;
+      |    let y5 = 1;
+      |    let y6 = 1;
+      |    let y7 = 1;
+      |    let y8 = 1;
+      |    let y9 = 1;
+      |    let z1 = 1;
+      |    let z2 = 1;
+      |    let z3 = 1;
+      |    let z4 = 1;
+      |    let z5 = 1;
+      |    let z6 = 1;
+      |    let z7 = 1;
+      |    let z8 = 1;
+      |    let z9 = 1;
       |        1
     """.stripMargin
     run(input)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -492,19 +492,19 @@ class TestTyper extends FunSuite with TestUtils {
   // Let (Positive)                                                          //
   /////////////////////////////////////////////////////////////////////////////
   test("Expression.Let01") {
-    val input = "def f: Int = let x = 42 in x"
+    val input = "def f: Int = let x = 42; x"
     val result = new Flix().addStr(input).compile()
     result.get
   }
 
   test("Expression.Let02") {
-    val input = "def f(x: Int): Int = let y = 42 in x + y"
+    val input = "def f(x: Int): Int = let y = 42; x + y"
     val result = new Flix().addStr(input).compile()
     result.get
   }
 
   test("Expression.Let03") {
-    val input = "def f(x: Bool): Int = let x = 42 in x"
+    val input = "def f(x: Bool): Int = let x = 42; x"
     val result = new Flix().addStr(input).compile()
     result.get
   }
@@ -513,13 +513,13 @@ class TestTyper extends FunSuite with TestUtils {
   // LetMatch (Positive)                                                     //
   /////////////////////////////////////////////////////////////////////////////
   test("Expression.LetMatch01") {
-    val input = "def f: Int = let (x, y) = (1, 2) in x + y"
+    val input = "def f: Int = let (x, y) = (1, 2); x + y"
     val result = new Flix().addStr(input).compile()
     result.get
   }
 
   test("Expression.LetMatch02") {
-    val input = "def f: Int8 = let (x, (y, z, w)) = (true, ('a', 1i8, 2i8)) in z + w"
+    val input = "def f: Int8 = let (x, (y, z, w)) = (true, ('a', 1i8, 2i8)); z + w"
     val result = new Flix().addStr(input).compile()
     result.get
   }
@@ -532,8 +532,8 @@ class TestTyper extends FunSuite with TestUtils {
         |  case C(Int)
         |}
         |
-        |def f(e: E): Bool = let E.A(b) = e in b
-        |def g(e: E): Char = let E.B(c) = e in c
+        |def f(e: E): Bool = let E.A(b) = e; b
+        |def g(e: E): Char = let E.B(c) = e; c
       """.stripMargin
     val result = new Flix().addStr(input).compile()
     result.get
@@ -546,7 +546,7 @@ class TestTyper extends FunSuite with TestUtils {
         |  case B
         |}
         |
-        |def f(e: E): Int8 = let E.A(true, 'a', i) = e in i
+        |def f(e: E): Int8 = let E.A(true, 'a', i) = e; i
       """.stripMargin
     val result = new Flix().addStr(input).compile()
     result.get

--- a/main/test/ca/uwaterloo/flix/runtime/TestBackend.scala
+++ b/main/test/ca/uwaterloo/flix/runtime/TestBackend.scala
@@ -827,7 +827,7 @@ class TestBackend extends FunSuite {
 
   test("Expression.Lambda.05") {
     val input =
-      """namespace A { def f(x: Int32): Int32 = let y = B/g(x + 1i32) in y * y }
+      """namespace A { def f(x: Int32): Int32 = let y = B/g(x + 1i32); y * y }
         |namespace B { def g(x: Int32): Int32 = x - 4i32 }
         |namespace C { def h: Int32 = A/f(5i32) + B/g(0i32) }
       """.stripMargin
@@ -851,7 +851,7 @@ class TestBackend extends FunSuite {
       """def f(x: Int8, y: Int8): Int8 = (x: Int8) - y
         |def g(x: Int8): Int8 = x * 3i8
         |def h(x: Int8): Int8 = g(x - 1i8)
-        |def x: Int8 = let x = 7i8 in f(g(3i8), h(h(x)))
+        |def x: Int8 = let x = 7i8; f(g(3i8), h(h(x)))
       """.stripMargin
     val t = new Tester(input)
     t.runTest(Value.mkInt32(-42), "x")
@@ -1074,7 +1074,7 @@ class TestBackend extends FunSuite {
 
   test("Expression.Hook - Hook.Safe.07") {
     import HookSafeHelpers._
-    val input = "def x: Int8 = let x = 7i8 in f(g(3i8), h(h(x)))"
+    val input = "def x: Int8 = let x = 7i8; f(g(3i8), h(h(x)))"
     val t = new Tester(input, solve = false)
     val flix = t.flix
 
@@ -1385,7 +1385,7 @@ class TestBackend extends FunSuite {
 
   test("Expression.Hook - Hook.Unsafe.07") {
     import HookUnsafeHelpers._
-    val input = "def x: Int8 = let x = 7i8 in f(g(3i8), h(h(x)))"
+    val input = "def x: Int8 = let x = 7i8; f(g(3i8), h(h(x)))"
     val t = new Tester(input, solve = false)
     val flix = t.flix
 
@@ -4820,31 +4820,31 @@ class TestBackend extends FunSuite {
   /////////////////////////////////////////////////////////////////////////////
 
   test("Expression.Let.01") {
-    val input = "def f: Int = let x = true in 42"
+    val input = "def f: Int = let x = true; 42"
     val t = new Tester(input)
     t.runTest(Value.mkInt32(42), "f")
   }
 
   test("Expression.Let.02") {
-    val input = "def f: Int8 = let x = 42i8 in x"
+    val input = "def f: Int8 = let x = 42i8; x"
     val t = new Tester(input)
     t.runTest(Value.mkInt32(42), "f")
   }
 
   test("Expression.Let.03") {
-    val input = "def f: Int16 = let x = 1i16 in x + 2i16"
+    val input = "def f: Int16 = let x = 1i16; x + 2i16"
     val t = new Tester(input)
     t.runTest(Value.mkInt32(3), "f")
   }
 
   test("Expression.Let.04") {
-    val input = """def f: Str = let x = false in if (x) "abz" else "xyz""""
+    val input = """def f: Str = let x = false; if (x) "abz" else "xyz""""
     val t = new Tester(input)
     t.runTest(Value.mkStr("xyz"), "f")
   }
 
   test("Expression.Let.05") {
-    val input = "def f: Int = let x = 14 - 3 in x + 2"
+    val input = "def f: Int = let x = 14 - 3; x + 2"
     val t = new Tester(input)
     t.runTest(Value.mkInt32(13), "f")
   }
@@ -4852,9 +4852,9 @@ class TestBackend extends FunSuite {
   test("Expression.Let.06") {
     val input =
       """def f: Int =
-        |  let x = 14 - 3 in
-        |    let y = 2 * 4 in
-        |      x + y
+        |  let x = 14 - 3;
+        |  let y = 2 * 4;
+        |    x + y
       """.stripMargin
     val t = new Tester(input)
     t.runTest(Value.mkInt32(19), "f")
@@ -4863,10 +4863,10 @@ class TestBackend extends FunSuite {
   test("Expression.Let.07") {
     val input =
       """def f: Int =
-        |  let x = 1 in
-        |    let y = x + 2 in
-        |      let z = y + 3 in
-        |        z
+        |  let x = 1;
+        |  let y = x + 2;
+        |  let z = y + 3;
+        |    z
       """.stripMargin
     val t = new Tester(input)
     t.runTest(Value.mkInt32(6), "f")
@@ -4875,10 +4875,10 @@ class TestBackend extends FunSuite {
   test("Expression.Let.08") {
     val input =
       """def f(a: Int, b: Int, c: Int): Int =
-        |  let x = 1337 in
-        |    let y = -101010 in
-        |      let z = 42 in
-        |        y
+        |  let x = 1337;
+        |  let y = -101010;
+        |  let z = 42;
+        |    y
         |def g: Int = f(-1337, 101010, -42)
       """.stripMargin
     val t = new Tester(input)
@@ -4888,10 +4888,10 @@ class TestBackend extends FunSuite {
   test("Expression.Let.09") {
     val input =
       """def f(a: Int, b: Int, c: Int): Int =
-        |  let x = 1337 in
-        |    let y = -101010 in
-        |      let z = 42 in
-        |        b
+        |  let x = 1337;
+        |  let y = -101010;
+        |  let z = 42;
+        |    b
         |def g: Int = f(-1337, 101010, -42)
       """.stripMargin
     val t = new Tester(input)
@@ -4899,7 +4899,7 @@ class TestBackend extends FunSuite {
   }
 
   test("Expression.Let.10") {
-    val input = "def f: Int64 = let x = 0i64 in x"
+    val input = "def f: Int64 = let x = 0i64; x"
     val t = new Tester(input)
     t.runTest(Value.mkInt64(0), "f")
   }
@@ -4907,10 +4907,10 @@ class TestBackend extends FunSuite {
   test("Expression.Let.11") {
     val input =
       """def f: Int64 =
-        |  let x = 1337i64 in
-        |    let y = -101010i64 in
-        |      let z = 42i64 in
-        |        y
+        |  let x = 1337i64;
+        |  let y = -101010i64;
+        |  let z = 42i64;
+        |    y
       """.stripMargin
     val t = new Tester(input)
     t.runTest(Value.mkInt64(-101010), "f")
@@ -4919,10 +4919,10 @@ class TestBackend extends FunSuite {
   test("Expression.Let.12") {
     val input =
       """def f: Int64 =
-        |  let x = 1337i64 in
-        |    let y = -101010i64 in
-        |      let z = 42i64 in
-        |        y
+        |  let x = 1337i64;
+        |  let y = -101010i64;
+        |  let z = 42i64;
+        |    y
       """.stripMargin
     val t = new Tester(input)
     t.runTest(Value.mkInt64(-101010), "f")
@@ -4931,10 +4931,10 @@ class TestBackend extends FunSuite {
   test("Expression.Let.13") {
     val input =
       """def f(a: Int64, b: Int64, c: Int64): Int64 =
-        |  let x = 1337i64 in
-        |    let y = -101010i64 in
-        |      let z = 42i64 in
-        |        y
+        |  let x = 1337i64;
+        |  let y = -101010i64;
+        |  let z = 42i64;
+        |    y
         |def g: Int64 = f(-1337i64, 101010i64, -42i64)
       """.stripMargin
     val t = new Tester(input)
@@ -4944,10 +4944,10 @@ class TestBackend extends FunSuite {
   test("Expression.Let.14") {
     val input =
       """def f(a: Int32, b: Int64, c: Int64): Int64 =
-        |  let x = 1337i32 in
-        |    let y = -101010i64 in
-        |      let z = 42i64 in
-        |        y
+        |  let x = 1337i32;
+        |  let y = -101010i64;
+        |  let z = 42i64;
+        |    y
         |def g: Int64 = f(-1337i32, 101010i64, -42i64)
       """.stripMargin
     val t = new Tester(input)
@@ -4957,10 +4957,10 @@ class TestBackend extends FunSuite {
   test("Expression.Let.15") {
     val input =
       """def f(a: Int64, b: Int64, c: Int64): Int64 =
-        |  let x = 1337i64 in
-        |    let y = -101010i64 in
-        |      let z = 42i64 in
-        |        b
+        |  let x = 1337i64;
+        |  let y = -101010i64;
+        |  let z = 42i64;
+        |    b
         |def g: Int64 = f(-1337i64, 101010i64, -42i64)
       """.stripMargin
     val t = new Tester(input)
@@ -4970,10 +4970,10 @@ class TestBackend extends FunSuite {
   test("Expression.Let.16") {
     val input =
       """def f(a: Int32, b: Int64, c: Int64): Int64 =
-        |  let x = 1337i32 in
-        |    let y = -101010i64 in
-        |      let z = 42i64 in
-        |        b
+        |  let x = 1337i32;
+        |  let y = -101010i64;
+        |  let z = 42i64;
+        |    b
         |def g: Int64 = f(-1337i32, 101010i64, -42i64)
       """.stripMargin
     val t = new Tester(input)
@@ -4983,32 +4983,32 @@ class TestBackend extends FunSuite {
   test("Expression.Let.17") {
     val input =
       """enum ConstProp { case Top, case Val(Int), case Bot }
-        |def f: ConstProp = let x = ConstProp.Val(42) in x
+        |def f: ConstProp = let x = ConstProp.Val(42); x
       """.stripMargin
     val t = new Tester(input)
     t.runTest(Value.mkTag("Val", Value.mkInt32(42)), "f")
   }
 
   test("Expression.Let.18") {
-    val input = "def f: () = let x = () in x"
+    val input = "def f: () = let x = (); x"
     val t = new Tester(input)
     t.runTest(Value.Unit, "f")
   }
 
   test("Expression.Let.19") {
-    val input = """def f: Str = let x = "helloworld" in x"""
+    val input = """def f: Str = let x = "helloworld"; x"""
     val t = new Tester(input)
     t.runTest(Value.mkStr("helloworld"), "f")
   }
 
   test("Expression.Let.20") {
-    val input = "def f: (Int, Int) = let x = (123, 456) in x"
+    val input = "def f: (Int, Int) = let x = (123, 456); x"
     val t = new Tester(input)
     t.runTest(Value.Tuple(Array(123, 456).map(Value.mkInt32)), "f")
   }
 
   test("Expression.Let.21") {
-    val input = "def f: Set[Int] = let x = #{9, 99, 999} in x"
+    val input = "def f: Set[Int] = let x = #{9, 99, 999}; x"
     val t = new Tester(input)
     t.runTest(Value.mkSet(Set(9, 99, 999).map(Value.mkInt32)), "f")
   }
@@ -5016,9 +5016,9 @@ class TestBackend extends FunSuite {
   test("Expression.Let.22") {
     val input =
       """def f: Char =
-        |  let x = 'a' in
-        |    let y = 'b' in
-        |      y
+        |  let x = 'a';
+        |  let y = 'b';
+        |    y
       """.stripMargin
     val t = new Tester(input)
     t.runTest(Value.mkChar('b'), "f")
@@ -5027,9 +5027,9 @@ class TestBackend extends FunSuite {
   test("Expression.Let.23") {
     val input =
       """def f: Float32 =
-        |  let x = 1.2f32 in
-        |    let y = 3.4f32 in
-        |      y
+        |  let x = 1.2f32;
+        |  let y = 3.4f32;
+        |    y
       """.stripMargin
     val t = new Tester(input)
     t.runTest(Value.mkFloat32(3.4f), "f")
@@ -5038,9 +5038,9 @@ class TestBackend extends FunSuite {
   test("Expression.Let.24") {
     val input =
       """def f: Float64 =
-        |  let x = 1.2f64 in
-        |    let y = 3.4f64 in
-        |      y
+        |  let x = 1.2f64;
+        |  let y = 3.4f64;
+        |    y
       """.stripMargin
     val t = new Tester(input)
     t.runTest(Value.mkFloat64(3.4d), "f")
@@ -5049,9 +5049,9 @@ class TestBackend extends FunSuite {
   test("Expression.Let.25") {
     val input =
       """def f(x: Int): Int32 =
-        |  let x = x + 1 in
-        |    let x = x + 2 in
-        |      x + 3
+        |  let x = x + 1;
+        |  let x = x + 2;
+        |    x + 3
         |def g: Int = f(0)
       """.stripMargin
     val t = new Tester(input)
@@ -5061,10 +5061,10 @@ class TestBackend extends FunSuite {
   test("Expression.Let.26") {
     val input =
       """def f(x: Int): Int64 =
-        |  let x = x + 1 in
-        |    let x = 40i64 in
-        |      let x = x + 2i64 in
-        |        x
+        |  let x = x + 1;
+        |  let x = 40i64;
+        |  let x = x + 2i64;
+        |    x
         |def g: Int64 = f(0)
       """.stripMargin
     val t = new Tester(input)
@@ -5074,9 +5074,9 @@ class TestBackend extends FunSuite {
   test("Expression.Let.27") {
     val input =
       """def f: BigInt =
-        |  let x = 12345678901234567890ii in
-        |    let y = 98765432109876543210ii in
-        |      y
+        |  let x = 12345678901234567890ii;
+        |  let y = 98765432109876543210ii;
+        |    y
       """.stripMargin
     val t = new Tester(input)
     t.runTest(Value.mkBigInt("98765432109876543210"), "f")
@@ -5942,7 +5942,7 @@ class TestBackend extends FunSuite {
     val input =
       """enum NameAndAge { case T(Str,Int) }
         |def f(x: NameAndAge): Int =
-        |  let NameAndAge.T(_, age) = x in
+        |  let NameAndAge.T(_, age) = x;
         |    age
         |def g01: Int = f(NameAndAge.T("James", 42))
         |def g02: Int = f(NameAndAge.T("John", 21))
@@ -6203,7 +6203,8 @@ class TestBackend extends FunSuite {
   test("Match.Tuple.01") {
     val input =
       """def f(x: Int, y: Int): Int =
-        |  let (a, b) = (x, y) in a + b
+        |  let (a, b) = (x, y);
+        |    a + b
         |def g01: Int = f(5, 6)
         |def g02: Int = f(6, 5)
         |def g03: Int = f(100, 23)
@@ -6338,7 +6339,7 @@ class TestBackend extends FunSuite {
     import HookUnsafeHelpers._
     val input =
       """def fst(t: (Native, Native)): Native =
-        |  let (x, _) = t in x
+        |  let (x, _) = t; x
         |def g: (Native, Native) = f(12)
         |def h: Native = fst(g())
       """.stripMargin
@@ -6356,7 +6357,7 @@ class TestBackend extends FunSuite {
     import HookUnsafeHelpers._
     val input =
       """def fst(t: (Native, Native)): Native =
-        |  let (x, _) = t in x
+        |  let (x, _) = t; x
         |def g: (Native, Native) = f(12)
         |def h: Native = fst(g())
       """.stripMargin
@@ -6374,7 +6375,7 @@ class TestBackend extends FunSuite {
     import HookUnsafeHelpers._
     val input =
       """def fst(t: (Int, Str)): Int =
-        |  let (x, _) = t in x
+        |  let (x, _) = t; x
         |def g: (Int, Str) = f(12)
         |def h: Int = fst(g())
       """.stripMargin


### PR DESCRIPTION
See the associated issue #226 