### PR TITLE
Add Textual Field to Type.Var

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -76,7 +76,7 @@ sealed trait Type {
     * Returns a human readable string representation of `this` type.
     */
   override def toString: String = this match {
-    case Type.Var(x, k) => "'" + x
+    case tvar@Type.Var(x, k) => tvar.getText.getOrElse("'" + x)
     case Type.Unit => "Unit"
     case Type.Bool => "Bool"
     case Type.Char => "Char"
@@ -110,7 +110,24 @@ object Type {
   /**
     * A type variable expression.
     */
-  case class Var(id: Int, kind: Kind) extends Type
+  case class Var(id: Int, kind: Kind) extends Type {
+    /**
+      * The optional textual name of `this` type variable.
+      */
+    private var text: Option[String] = None
+
+    /**
+      * Optionally returns the textual name of `this` type variable.
+      */
+    def getText: Option[String] = text
+
+    /**
+      * Sets the textual name of `this` type variable.
+      */
+    def setText(s: String): Unit = {
+      text = Some(s)
+    }
+  }
 
   /**
     * A type constructor that represents the unit value.

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -17,6 +17,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.language.GenSym
+import ca.uwaterloo.flix.language.ast.Type.Var
 import ca.uwaterloo.flix.language.ast._
 import ca.uwaterloo.flix.language.errors.NameError
 import ca.uwaterloo.flix.util.Validation
@@ -86,7 +87,12 @@ object Namer {
 
             // Compute the type environment from the formal type parameters.
             val tparams = tparams0.map {
-              case p => NamedAst.TypeParam(p, Type.freshTypeVar(), p.loc)
+              case p =>
+                // Generate a fresh type variable for the type parameter.
+                val tvar = Type.freshTypeVar()
+                // Remember the original textual name.
+                tvar.setText(p.name)
+                NamedAst.TypeParam(p, tvar, p.loc)
             }
             val tenv0 = tparams.map(p => p.name.name -> p.tpe).toMap
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
@@ -136,17 +136,25 @@ object Unification {
       * Performs the so-called occurs-check to ensure that the substitution is kind-preserving.
       */
     def unifyVar(x: Type.Var, tpe: Type): Result[Substitution, UnificationError] = {
+      // The type variable and type are in fact the same.
       if (x == tpe) {
         return Result.Ok(Substitution.empty)
       }
+
+      // The type variable occurs inside the type.
       if (tpe.typeVars contains x) {
         return Result.Err(UnificationError.OccursCheck(x, tpe))
       }
-      // TODO: Kinds disabled for now. Requires changed to the
-      // previous phase to associated type variables with their kinds.
+
+      // TODO: Kinds disabled for now. Requires changed to the previous phase to associated type variables with their kinds.
       //if (x.kind != tpe.kind) {
       //  return Result.Err(TypeError.KindError())
       //}
+
+      // We can substitute `x` for `tpe`. Update the textual name of `tpe`.
+      if (x.getText.nonEmpty && tpe.isInstanceOf[Type.Var]) {
+        tpe.asInstanceOf[Type.Var].setText(x.getText.get)
+      }
       Result.Ok(Substitution.singleton(x, tpe))
     }
 


### PR DESCRIPTION
Adds a text field to `Type.Var` to track the type parameter name assigned by the user.