### PR TITLE
Add syntax for list/append

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -543,10 +543,21 @@ object ParsedAst {
       * Cons expression (of list).
       *
       * @param hd  the head of the list.
+      * @param sp1 the position of the first character in the :: operator.
+      * @param sp2 the position of the last character in the :: operator.
       * @param tl  the tail of the list.
-      * @param sp2 the position of the last character in the expression.
       */
-    case class FCons(hd: ParsedAst.Expression, tl: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Expression
+    case class FCons(hd: ParsedAst.Expression, sp1: SourcePosition, sp2: SourcePosition, tl: ParsedAst.Expression) extends ParsedAst.Expression
+
+    /**
+      * Append expression (of list).
+      *
+      * @param fst the first list.
+      * @param sp1 the position of the first character in the operator @@.
+      * @param sp2 the position of the last character in the operator @@.
+      * @param snd the second list.
+      */
+    case class FAppend(fst: ParsedAst.Expression, sp1: SourcePosition, sp2: SourcePosition, snd: ParsedAst.Expression) extends ParsedAst.Expression
 
     /**
       * Vector Expression.
@@ -665,8 +676,8 @@ object ParsedAst {
       case Pattern.Lit(sp1, _, _) => sp1
       case Pattern.Tag(sp1, _, _, _, _) => sp1
       case Pattern.Tuple(sp1, _, _) => sp1
-      case Pattern.FNil(sp1, sp2) => sp1
-      case Pattern.FCons(hd, _, _) => hd.leftMostSourcePosition
+      case Pattern.FNil(sp1, _) => sp1
+      case Pattern.FCons(hd, _, _, _) => hd.leftMostSourcePosition
       case Pattern.FVec(sp1, _, _, _) => sp1
       case Pattern.FSet(sp1, _, _, _) => sp1
       case Pattern.FMap(sp1, _, _, _) => sp1
@@ -736,10 +747,11 @@ object ParsedAst {
       * Cons Pattern (of list).
       *
       * @param hd  the head pattern.
+      * @param sp1 the position of the first character in the :: operator.
+      * @param sp2 the position of the last character in the :: operator.
       * @param tl  the tail pattern.
-      * @param sp2 the position of the last character in the pattern.
       */
-    case class FCons(hd: ParsedAst.Pattern, tl: ParsedAst.Pattern, sp2: SourcePosition) extends ParsedAst.Pattern
+    case class FCons(hd: ParsedAst.Pattern, sp1: SourcePosition, sp2: SourcePosition, tl: ParsedAst.Pattern) extends ParsedAst.Pattern
 
     /**
       * Vector Pattern.

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -468,7 +468,7 @@ class Parser(val source: SourceInput) extends org.parboiled2.Parser {
     }
 
     def FAppend: Rule1[ParsedAst.Expression] = rule {
-      FList ~ optional(optWS ~ SP ~ atomic("@@") ~ SP ~ optWS ~ Expression ~> ParsedAst.Expression.FAppend)
+      FList ~ optional(optWS ~ SP ~ atomic(":::") ~ SP ~ optWS ~ Expression ~> ParsedAst.Expression.FAppend)
     }
 
     def FList: Rule1[ParsedAst.Expression] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -411,7 +411,7 @@ class Parser(val source: SourceInput) extends org.parboiled2.Parser {
     }
 
     def Ascribe: Rule1[ParsedAst.Expression] = rule {
-      FList ~ optional(optWS ~ ":" ~ optWS ~ Type ~ SP ~> ParsedAst.Expression.Ascribe)
+      FAppend ~ optional(optWS ~ ":" ~ optWS ~ Type ~ SP ~> ParsedAst.Expression.Ascribe)
     }
 
     def Primary: Rule1[ParsedAst.Expression] = rule {
@@ -467,8 +467,12 @@ class Parser(val source: SourceInput) extends org.parboiled2.Parser {
       SP ~ atomic("Nil") ~ SP ~> ParsedAst.Expression.FNil
     }
 
+    def FAppend: Rule1[ParsedAst.Expression] = rule {
+      FList ~ optional(optWS ~ SP ~ atomic("@@") ~ SP ~ optWS ~ Expression ~> ParsedAst.Expression.FAppend)
+    }
+
     def FList: Rule1[ParsedAst.Expression] = rule {
-      Apply ~ optional(optWS ~ atomic("::") ~ optWS ~ Expression ~ SP ~> ParsedAst.Expression.FCons)
+      Apply ~ optional(optWS ~ SP ~ atomic("::") ~ SP ~ optWS ~ Expression ~> ParsedAst.Expression.FCons)
     }
 
     def FVec: Rule1[ParsedAst.Expression.FVec] = rule {
@@ -566,7 +570,7 @@ class Parser(val source: SourceInput) extends org.parboiled2.Parser {
     }
 
     def FList: Rule1[ParsedAst.Pattern] = rule {
-      Simple ~ optional(optWS ~ atomic("::") ~ optWS ~ Pattern ~ SP ~> ParsedAst.Pattern.FCons)
+      Simple ~ optional(optWS ~ SP ~ atomic("::") ~ SP ~ optWS ~ Pattern ~> ParsedAst.Pattern.FCons)
     }
 
     def FVec: Rule1[ParsedAst.Pattern.FVec] = {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -511,7 +511,7 @@ object Weeder {
               // NB: We painstakingly construct the qualified name
               // to ensure that source locations are available.
               val loc = mkSL(sp1, sp2)
-              val namespace = List(Name.Ident(sp1, "list", sp2))
+              val namespace = List(Name.Ident(sp1, "List", sp2))
               val ident = Name.Ident(sp1, "append", sp2)
               val qname = Name.QName(sp1, Name.NName(sp1, namespace, sp2), ident, sp2)
               val lambda = WeededAst.Expression.VarOrRef(qname, loc)

--- a/main/src/ca/uwaterloo/flix/runtime/Value.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/Value.scala
@@ -21,7 +21,7 @@ import java.util
 import ca.uwaterloo.flix.language.ast.Symbol
 import ca.uwaterloo.flix.util.InternalRuntimeException
 
-import scala.collection.{immutable, mutable}
+import scala.collection.immutable
 
 object Value {
 
@@ -312,7 +312,7 @@ object Value {
   /**
     * Returns the list `vs` with the element `v` prepended.
     */
-  def mkCons(v: AnyRef, vs: AnyRef): Value.Tag = mkTag("Cons", Tuple(Array(v,vs)))
+  def mkCons(v: AnyRef, vs: AnyRef): Value.Tag = mkTag("Cons", Tuple(Array(v, vs)))
 
   /**
     * Returns the given Scala list `as` as a Flix list.
@@ -447,7 +447,14 @@ object Value {
     case o: java.lang.Integer => o.intValue().toString
     case o: java.lang.Long => o.longValue().toString
     case o: java.lang.String => o
-    case o: Value.Tag => s"${o.tag}(${pretty(o.value)})"
+    case o: Value.Tag =>
+      if (o.tag == "Cons") {
+        val e1 = o.value.asInstanceOf[Value.Tuple].elms(0)
+        val e2 = o.value.asInstanceOf[Value.Tuple].elms(1)
+        s"${pretty(e1)} :: ${pretty(e2)}"
+      }
+      else
+        s"${o.tag}(${pretty(o.value)})"
     case Value.Tuple(elms) => "(" + elms.map(pretty).mkString(",") + ")"
     case _ => ref.toString
   }

--- a/main/src/tutorials/interpreter.flix
+++ b/main/src/tutorials/interpreter.flix
@@ -150,24 +150,24 @@ def compileAExp(e: AExp): List[Inst] = match e with {
     case Plus(e1, e2)   =>
         let is1 = compileAExp(e1);
         let is2 = compileAExp(e2);
-            append(append(is2, is1), (Add :: Nil))
+            is2 ::: is1 ::: Add :: Nil
     case Minus(e1, e2)  =>
         let is1 = compileAExp(e1);
         let is2 = compileAExp(e2);
-            append(append(is2, is1), (Sub :: Nil))
+            is2 ::: is1 ::: Sub :: Nil
     case Times(e1, e2)  =>
         let is1 = compileAExp(e1);
         let is2 = compileAExp(e2);
-            append(append(is2, is1), (Mul :: Nil))
+            is2 ::: is1 ::: Mul :: Nil
     case Divide(e1, e2)  =>
         let is1 = compileAExp(e1);
         let is2 = compileAExp(e2);
-            append(append(is2, is1), (Div :: Nil))
+            is2 ::: is1 ::: Div :: Nil
     case IfThenElse(e1, e2, e3)  =>
         let is1 = compileBExp(e1);
         let is2 = compileAExp(e2);
         let is3 = compileAExp(e3);
-            append(is1, Branch(is2, is3) :: Nil)
+            is1 ::: Branch(is2, is3) :: Nil
 }
 
 //
@@ -178,23 +178,23 @@ def compileBExp(e: BExp): List[Inst] = match e with {
     case False          => Push(0) :: Nil
     case Not(e)         =>
         let is = compileBExp(e);
-            append(is, Neg :: Nil)
+            is ::: Neg :: Nil
     case Conj(e1, e2)   =>
         let is1 = compileBExp(e1);
         let is2 = compileBExp(e2);
-            append(append(is2, is1), And :: Nil)
+            is2 ::: is1 ::: And :: Nil
     case Disj(e1, e2)   =>
         let is1 = compileBExp(e1);
         let is2 = compileBExp(e2);
-            append(append(is2, is1), Or :: Nil)
+            is2 ::: is1 ::: Or :: Nil
     case Eq(e1, e2)     =>
         let is1 = compileAExp(e1);
         let is2 = compileAExp(e2);
-            append(append(is2, is1), Cmp :: Nil)
+            is2 ::: is1 ::: Cmp :: Nil
     case Neq(e1, e2)    =>
         let is1 = compileAExp(e1);
         let is2 = compileAExp(e2);
-            append(append(is2, is1), Neg :: Cmp :: Nil)
+            is2 ::: is1 ::: Neg :: Cmp :: Nil
 }
 
 //
@@ -259,9 +259,13 @@ def testCompileAndEval4: Int = evalInst(compileAExp(IfThenElse(True, Cst(1), Cst
 def testCompileAndEval5: Int = evalInst(compileAExp(IfThenElse(Neq(Cst(1), Cst(2)), Cst(42), Cst(21))), Nil)
 
 //
-// Here is the append function used earlier:
+// In case the standard library is not included, we need to define list/append:
 //
-def append(xs: List[Inst], ys: List[Inst]): List[Inst] = match xs with {
-    case Nil => ys
-    case z :: zs => z :: append(zs, ys)
+namespace list {
+
+    def append(xs: List[Inst], ys: List[Inst]): List[Inst] = match xs with {
+        case Nil => ys
+        case z :: zs => z :: append(zs, ys)
+    }
+
 }

--- a/main/src/tutorials/interpreter.flix
+++ b/main/src/tutorials/interpreter.flix
@@ -261,7 +261,7 @@ def testCompileAndEval5: Int = evalInst(compileAExp(IfThenElse(Neq(Cst(1), Cst(2
 //
 // In case the standard library is not included, we need to define list/append:
 //
-namespace list {
+namespace List {
 
     def append(xs: List[Inst], ys: List[Inst]): List[Inst] = match xs with {
         case Nil => ys

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -18,8 +18,8 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.api.{Flix, RuleException}
-import ca.uwaterloo.flix.language.errors.{ResolutionError, TypeError}
-import ca.uwaterloo.flix.util.{InternalCompilerException, Options}
+import ca.uwaterloo.flix.language.errors.ResolutionError
+import ca.uwaterloo.flix.util.Options
 import org.scalatest.FunSuite
 
 class TestParser extends FunSuite with TestUtils {
@@ -1195,45 +1195,87 @@ class TestParser extends FunSuite with TestUtils {
   }
 
   test("Expression.Append.01") {
-    intercept[RuntimeException] {
-      val input = "def f: List[Int] = Nil @@ Nil"
-      run(input)
-    }
+    // TODO: Once list is included by default this can be improved.
+    val append =
+      """
+        |namespace list {
+        |    def append[a](xs: List[a], ys: List[a]): List[a] = ???
+        |}
+        |
+      """.stripMargin
+
+    val input = "def f: List[Int] = Nil ::: Nil"
+    run(input + append)
   }
 
   test("Expression.Append.02") {
-    intercept[RuntimeException] {
-      val input = "def f: List[Int] = 1 :: Nil @@ 1 :: Nil"
-      run(input)
-    }
+    // TODO: Once list is included by default this can be improved.
+    val append =
+      """
+        |namespace list {
+        |    def append[a](xs: List[a], ys: List[a]): List[a] = ???
+        |}
+        |
+      """.stripMargin
+
+    val input = "def f: List[Int] = 1 :: Nil ::: 1 :: Nil"
+    run(input + append)
   }
 
   test("Expression.Append.03") {
-    intercept[RuntimeException] {
-      val input = "def f: List[Int] = 1 :: Nil @@ 1 :: 2 :: Nil"
-      run(input)
-    }
+    // TODO: Once list is included by default this can be improved.
+    val append =
+      """
+        |namespace list {
+        |    def append[a](xs: List[a], ys: List[a]): List[a] = ???
+        |}
+        |
+      """.stripMargin
+
+    val input = "def f: List[Int] = 1 :: Nil ::: 1 :: 2 :: Nil"
+    run(input + append)
   }
 
   test("Expression.Append.04") {
-    intercept[RuntimeException] {
-      val input = "def f: List[Int] = 1 :: 2 :: Nil @@ 1 :: 2 :: Nil"
-      run(input)
-    }
+    // TODO: Once list is included by default this can be improved.
+    val append =
+      """
+        |namespace list {
+        |    def append[a](xs: List[a], ys: List[a]): List[a] = ???
+        |}
+        |
+      """.stripMargin
+
+    val input = "def f: List[Int] = 1 :: 2 :: Nil ::: 1 :: 2 :: Nil"
+    run(input + append)
   }
 
   test("Expression.Append.05") {
-    intercept[RuntimeException] {
-      val input = "def f: List[Int] = Nil @@ Nil @@ Nil"
-      run(input)
-    }
+    // TODO: Once list is included by default this can be improved.
+    val append =
+      """
+        |namespace list {
+        |    def append[a](xs: List[a], ys: List[a]): List[a] = ???
+        |}
+        |
+      """.stripMargin
+
+    val input = "def f: List[Int] = Nil ::: Nil ::: Nil"
+    run(input + append)
   }
 
   test("Expression.Append.06") {
-    intercept[RuntimeException] {
-      val input = "def f: List[Int] = 1 :: Nil @@ 2 :: Nil @@ 3 :: Nil"
-      run(input)
-    }
+    // TODO: Once list is included by default this can be improved.
+    val append =
+      """
+        |namespace list {
+        |    def append[a](xs: List[a], ys: List[a]): List[a] = ???
+        |}
+        |
+      """.stripMargin
+
+    val input = "def f: List[Int] = 1 :: Nil ::: 2 :: Nil ::: 3 :: Nil"
+    run(input + append)
   }
 
   test("Expression.Vec.01") {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -1198,7 +1198,7 @@ class TestParser extends FunSuite with TestUtils {
     // TODO: Once list is included by default this can be improved.
     val append =
       """
-        |namespace list {
+        |namespace List {
         |    def append[a](xs: List[a], ys: List[a]): List[a] = ???
         |}
         |
@@ -1212,7 +1212,7 @@ class TestParser extends FunSuite with TestUtils {
     // TODO: Once list is included by default this can be improved.
     val append =
       """
-        |namespace list {
+        |namespace List {
         |    def append[a](xs: List[a], ys: List[a]): List[a] = ???
         |}
         |
@@ -1226,7 +1226,7 @@ class TestParser extends FunSuite with TestUtils {
     // TODO: Once list is included by default this can be improved.
     val append =
       """
-        |namespace list {
+        |namespace List {
         |    def append[a](xs: List[a], ys: List[a]): List[a] = ???
         |}
         |
@@ -1240,7 +1240,7 @@ class TestParser extends FunSuite with TestUtils {
     // TODO: Once list is included by default this can be improved.
     val append =
       """
-        |namespace list {
+        |namespace List {
         |    def append[a](xs: List[a], ys: List[a]): List[a] = ???
         |}
         |
@@ -1254,7 +1254,7 @@ class TestParser extends FunSuite with TestUtils {
     // TODO: Once list is included by default this can be improved.
     val append =
       """
-        |namespace list {
+        |namespace List {
         |    def append[a](xs: List[a], ys: List[a]): List[a] = ???
         |}
         |
@@ -1268,7 +1268,7 @@ class TestParser extends FunSuite with TestUtils {
     // TODO: Once list is included by default this can be improved.
     val append =
       """
-        |namespace list {
+        |namespace List {
         |    def append[a](xs: List[a], ys: List[a]): List[a] = ???
         |}
         |

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -883,37 +883,37 @@ class TestParser extends FunSuite with TestUtils {
   test("Expression.LetMatch.04") {
     // Note: This is to test the performance of deeply nested lets.
     val input =
-    """
-      |def f: Int =
-      |    let x1 = 1;
-      |    let x2 = 1;
-      |    let x3 = 1;
-      |    let x4 = 1;
-      |    let x5 = 1;
-      |    let x6 = 1;
-      |    let x7 = 1;
-      |    let x8 = 1;
-      |    let x9 = 1;
-      |    let y1 = 1;
-      |    let y2 = 1;
-      |    let y3 = 1;
-      |    let y4 = 1;
-      |    let y5 = 1;
-      |    let y6 = 1;
-      |    let y7 = 1;
-      |    let y8 = 1;
-      |    let y9 = 1;
-      |    let z1 = 1;
-      |    let z2 = 1;
-      |    let z3 = 1;
-      |    let z4 = 1;
-      |    let z5 = 1;
-      |    let z6 = 1;
-      |    let z7 = 1;
-      |    let z8 = 1;
-      |    let z9 = 1;
-      |        1
-    """.stripMargin
+      """
+        |def f: Int =
+        |    let x1 = 1;
+        |    let x2 = 1;
+        |    let x3 = 1;
+        |    let x4 = 1;
+        |    let x5 = 1;
+        |    let x6 = 1;
+        |    let x7 = 1;
+        |    let x8 = 1;
+        |    let x9 = 1;
+        |    let y1 = 1;
+        |    let y2 = 1;
+        |    let y3 = 1;
+        |    let y4 = 1;
+        |    let y5 = 1;
+        |    let y6 = 1;
+        |    let y7 = 1;
+        |    let y8 = 1;
+        |    let y9 = 1;
+        |    let z1 = 1;
+        |    let z2 = 1;
+        |    let z3 = 1;
+        |    let z4 = 1;
+        |    let z5 = 1;
+        |    let z6 = 1;
+        |    let z7 = 1;
+        |    let z8 = 1;
+        |    let z9 = 1;
+        |        1
+      """.stripMargin
     run(input)
   }
 
@@ -1192,6 +1192,48 @@ class TestParser extends FunSuite with TestUtils {
   test("Expression.ListList.03") {
     val input = "def f: List[List[Int]] = (Nil) :: (1 :: Nil) :: (2 :: 3 :: 4 :: Nil) :: Nil"
     run(input)
+  }
+
+  test("Expression.Append.01") {
+    intercept[RuntimeException] {
+      val input = "def f: List[Int] = Nil @@ Nil"
+      run(input)
+    }
+  }
+
+  test("Expression.Append.02") {
+    intercept[RuntimeException] {
+      val input = "def f: List[Int] = 1 :: Nil @@ 1 :: Nil"
+      run(input)
+    }
+  }
+
+  test("Expression.Append.03") {
+    intercept[RuntimeException] {
+      val input = "def f: List[Int] = 1 :: Nil @@ 1 :: 2 :: Nil"
+      run(input)
+    }
+  }
+
+  test("Expression.Append.04") {
+    intercept[RuntimeException] {
+      val input = "def f: List[Int] = 1 :: 2 :: Nil @@ 1 :: 2 :: Nil"
+      run(input)
+    }
+  }
+
+  test("Expression.Append.05") {
+    intercept[RuntimeException] {
+      val input = "def f: List[Int] = Nil @@ Nil @@ Nil"
+      run(input)
+    }
+  }
+
+  test("Expression.Append.06") {
+    intercept[RuntimeException] {
+      val input = "def f: List[Int] = 1 :: Nil @@ 2 :: Nil @@ 3 :: Nil"
+      run(input)
+    }
   }
 
   test("Expression.Vec.01") {


### PR DESCRIPTION
This PR adds syntactic sugar for `list/append`. Namely:

```
def f: List[Int] = 1 :: Nil @@ 1 :: 2 :: Nil
```
