### PR TITLE
Name Fixes

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -39,7 +39,7 @@ namespace List {
     /// Returns `Some(x)` if `x` is the first element of `xs`.
     /// Returns `None` if `xs` is empty.
     ///
-    def headOpt[a](xs: List[a]): Option[a] = match xs with {
+    def head[a](xs: List[a]): Option[a] = match xs with {
         case Nil => None
         case x :: _ => Some(x)
     }
@@ -48,10 +48,10 @@ namespace List {
     /// Returns `Some(x)` if `x` is the last element of `xs`.
     /// Returns `None` if `xs` is empty.
     ///
-    def lastOpt[a](xs: List[a]): Option[a] = match xs with {
+    def last[a](xs: List[a]): Option[a] = match xs with {
         case Nil => None
         case x :: Nil => Some(x)
-        case x :: rs => lastOpt(rs)
+        case x :: rs => last(rs)
     }
 
     ///
@@ -429,14 +429,14 @@ namespace List {
     ///
     /// Alias for `reduceLeftOpt`.
     ///
-    def reduceOpt[a](f: (a, a) -> a, xs: List[a]): Option[a] = reduceLeftOpt(f, xs)
+    def reduce[a](f: (a, a) -> a, xs: List[a]): Option[a] = reduceLeft(f, xs)
 
     ///
     /// Applies `f` to all elements in `xs` going from left to right until a single value `v` is obtained.  Returns `Some(v)`.
     /// That is, the result is of the form: `Some(f(...f(f(x1, x2), x3)..., xn))`
     /// Returns `None` if `xs` is empty.
     ///
-    def reduceLeftOpt[a](f: (a, a) -> a, xs: List[a]): Option[a] = match xs with {
+    def reduceLeft[a](f: (a, a) -> a, xs: List[a]): Option[a] = match xs with {
         case Nil => None
         case x :: rs => Some(foldLeft(f, x, rs))
     }
@@ -446,9 +446,9 @@ namespace List {
     /// That is, the result is of the form: `Some(f(x1, ...f(xn-2, f(xn-1, xn))...))`
     /// Returns `None` if `xs` is empty.
     ///
-    def reduceRightOpt[a](f: (a, a) -> a, xs: List[a]): Option[a] = match xs with {
+    def reduceRight[a](f: (a, a) -> a, xs: List[a]): Option[a] = match xs with {
         case Nil => None
-        case x :: rs => match reduceRightOpt(f, rs) with {
+        case x :: rs => match reduceRight(f, rs) with {
             case None => Some(x)
             case Some(v) => Some(f(x, v))
         }

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -141,27 +141,27 @@ namespace Set {
     ///
     /// Alias for `reduceLeftOpt`.
     ///
-    def reduceOpt[a](f: (a, a) -> a, xs: Set[a]): Option[a] =
+    def reduce[a](f: (a, a) -> a, xs: Set[a]): Option[a] =
         let Set(s) = xs;
-            List.reduceOpt(f, s)
+            List.reduce(f, s)
 
     ///
     /// Applies `f` to all elements in `xs` going from left to right until a single value `v` is obtained.  Returns `Some(v)`.
     /// That is, the result is of the form: `Some(f(...f(f(x1, x2), x3)..., xn))`
     /// Returns `None` if `xs` is the empty set.
     ///
-    def reduceLeftOpt[a](f: (a, a) -> a, xs: Set[a]): Option[a] =
+    def reduceLeft[a](f: (a, a) -> a, xs: Set[a]): Option[a] =
         let Set(s) = xs;
-            List.reduceLeftOpt(f, s)
+            List.reduceLeft(f, s)
 
     ///
     /// Applies `f` to all elements in `xs` going from right to left until a single value `v` is obtained.  Returns `Some(v)`.
     /// That is, the result is of the form: `Some(f(x1, ...f(xn-2, f(xn-1, xn))...))`
     /// Returns `None` if `xs` is the empty set.
     ///
-    def reduceRightOpt[a](f: (a, a) -> a, xs: Set[a]): Option[a] =
+    def reduceRight[a](f: (a, a) -> a, xs: Set[a]): Option[a] =
         let Set(s) = xs;
-            List.reduceRightOpt(f, s)
+            List.reduceRight(f, s)
 
     //
     // ## Special Folds

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -27,34 +27,34 @@ def isEmpty02: Bool = assertNot!(List.isEmpty(1 :: Nil))
 def isEmpty03: Bool = assertNot!(List.isEmpty(1 :: 2 :: Nil))
 
 /////////////////////////////////////////////////////////////////////////////
-// headOpt                                                                 //
+// head                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def headOpt01: Bool = List.headOpt(Nil) `assertEq!` None
+def head01: Bool = List.head(Nil) `assertEq!` None
 
 @test
-def headOpt02: Bool = List.headOpt(1 :: Nil) `assertEq!` Some(1)
+def head02: Bool = List.head(1 :: Nil) `assertEq!` Some(1)
 
 @test
-def headOpt03: Bool = List.headOpt(2 :: 1 :: Nil) `assertEq!` Some(2)
+def head03: Bool = List.head(2 :: 1 :: Nil) `assertEq!` Some(2)
 
 @test
-def headOpt04: Bool = List.headOpt(3 :: 2 :: 1 :: Nil) `assertEq!` Some(3)
+def head04: Bool = List.head(3 :: 2 :: 1 :: Nil) `assertEq!` Some(3)
 
 /////////////////////////////////////////////////////////////////////////////
-// lastOpt                                                                 //
+// last                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def lastOpt01: Bool = List.lastOpt(Nil) `assertEq!` None
+def last01: Bool = List.last(Nil) `assertEq!` None
 
 @test
-def lastOpt02: Bool = List.lastOpt(1 :: Nil) `assertEq!` Some(1)
+def last02: Bool = List.last(1 :: Nil) `assertEq!` Some(1)
 
 @test
-def lastOpt03: Bool = List.lastOpt(1 :: 2 :: Nil) `assertEq!` Some(2)
+def last03: Bool = List.last(1 :: 2 :: Nil) `assertEq!` Some(2)
 
 @test
-def lastOpt04: Bool = List.lastOpt(1 :: 2 :: 3 :: Nil) `assertEq!` Some(3)
+def last04: Bool = List.last(1 :: 2 :: 3 :: Nil) `assertEq!` Some(3)
 
 /////////////////////////////////////////////////////////////////////////////
 // length                                                                  //
@@ -911,58 +911,58 @@ def foldRight03: Bool = List.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, 1 :: 
 def foldRight04: Bool = List.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, 1 :: 2 :: 3 :: Nil) `assertEq!` 382
 
 /////////////////////////////////////////////////////////////////////////////
-// reduceOpt                                                               //
+// reduce                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduceOpt01: Bool = List.reduceOpt((a, b) -> a-b, Nil: List[Int]) `assertEq!` None
+def reduce01: Bool = List.reduce((a, b) -> a-b, Nil: List[Int]) `assertEq!` None
 
 @test
-def reduceOpt02: Bool = List.reduceOpt((a, b) -> a-b, 1 :: Nil) `assertEq!` Some(1)
+def reduce02: Bool = List.reduce((a, b) -> a-b, 1 :: Nil) `assertEq!` Some(1)
 
 @test
-def reduceOpt03: Bool = List.reduceOpt((a, b) -> a-b, 1 :: 2 :: Nil) `assertEq!` Some(-1)
+def reduce03: Bool = List.reduce((a, b) -> a-b, 1 :: 2 :: Nil) `assertEq!` Some(-1)
 
 @test
-def reduceOpt04: Bool = List.reduceOpt((a, b) -> a-b, 1 :: 2 :: 3 :: Nil) `assertEq!` Some(-4)
+def reduce04: Bool = List.reduce((a, b) -> a-b, 1 :: 2 :: 3 :: Nil) `assertEq!` Some(-4)
 
 @test
-def reduceOpt05: Bool = List.reduceOpt((a, b) -> a-b, 1 :: 2 :: 3 :: 4 :: Nil) `assertEq!` Some(-8)
-
-/////////////////////////////////////////////////////////////////////////////
-// reduceLeftOpt                                                           //
-/////////////////////////////////////////////////////////////////////////////
-@test
-def reduceLeftOpt01: Bool = List.reduceLeftOpt((a, b) -> a-b, Nil: List[Int]) `assertEq!` None
-
-@test
-def reduceLeftOpt02: Bool = List.reduceLeftOpt((a, b) -> a-b, 1 :: Nil) `assertEq!` Some(1)
-
-@test
-def reduceLeftOpt03: Bool = List.reduceLeftOpt((a, b) -> a-b, 1 :: 2 :: Nil) `assertEq!` Some(-1)
-
-@test
-def reduceLeftOpt04: Bool = List.reduceLeftOpt((a, b) -> a-b, 1 :: 2 :: 3 :: Nil) `assertEq!` Some(-4)
-
-@test
-def reduceLeftOpt05: Bool = List.reduceLeftOpt((a, b) -> a-b, 1 :: 2 :: 3 :: 4 :: Nil) `assertEq!` Some(-8)
+def reduce05: Bool = List.reduce((a, b) -> a-b, 1 :: 2 :: 3 :: 4 :: Nil) `assertEq!` Some(-8)
 
 /////////////////////////////////////////////////////////////////////////////
-// reduceRightOpt                                                          //
+// reduceLeft                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduceRightOpt01: Bool = List.reduceRightOpt((a, b) -> a-b, Nil: List[Int]) `assertEq!` None
+def reduceLeft01: Bool = List.reduceLeft((a, b) -> a-b, Nil: List[Int]) `assertEq!` None
 
 @test
-def reduceRightOpt02: Bool = List.reduceRightOpt((a, b) -> a-b, 1 :: Nil) `assertEq!` Some(1)
+def reduceLeft02: Bool = List.reduceLeft((a, b) -> a-b, 1 :: Nil) `assertEq!` Some(1)
 
 @test
-def reduceRightOpt03: Bool = List.reduceRightOpt((a, b) -> a-b, 1 :: 2 :: Nil) `assertEq!` Some(-1)
+def reduceLeft03: Bool = List.reduceLeft((a, b) -> a-b, 1 :: 2 :: Nil) `assertEq!` Some(-1)
 
 @test
-def reduceRightOpt04: Bool = List.reduceRightOpt((a, b) -> a-b, 1 :: 2 :: 3 :: Nil) `assertEq!` Some(2)
+def reduceLeft04: Bool = List.reduceLeft((a, b) -> a-b, 1 :: 2 :: 3 :: Nil) `assertEq!` Some(-4)
 
 @test
-def reduceRightOpt05: Bool = List.reduceRightOpt((a, b) -> a-b, 1 :: 2 :: 3 :: 4 :: Nil) `assertEq!` Some(-2)
+def reduceLeft05: Bool = List.reduceLeft((a, b) -> a-b, 1 :: 2 :: 3 :: 4 :: Nil) `assertEq!` Some(-8)
+
+/////////////////////////////////////////////////////////////////////////////
+// reduceRight                                                             //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def reduceRight01: Bool = List.reduceRight((a, b) -> a-b, Nil: List[Int]) `assertEq!` None
+
+@test
+def reduceRight02: Bool = List.reduceRight((a, b) -> a-b, 1 :: Nil) `assertEq!` Some(1)
+
+@test
+def reduceRight03: Bool = List.reduceRight((a, b) -> a-b, 1 :: 2 :: Nil) `assertEq!` Some(-1)
+
+@test
+def reduceRight04: Bool = List.reduceRight((a, b) -> a-b, 1 :: 2 :: 3 :: Nil) `assertEq!` Some(2)
+
+@test
+def reduceRight05: Bool = List.reduceRight((a, b) -> a-b, 1 :: 2 :: 3 :: 4 :: Nil) `assertEq!` Some(-2)
 
 /////////////////////////////////////////////////////////////////////////////
 // count                                                                   //

--- a/main/test/ca/uwaterloo/flix/library/TestSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSet.flix
@@ -399,58 +399,58 @@ def foldRight03: Bool = Set.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, #{2, 1
 def foldRight04: Bool = Set.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, #{3, 2, 1}) `assertEq!` 382
 
 /////////////////////////////////////////////////////////////////////////////
-// reduceOpt                                                               //
+// reduce                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduceOpt01: Bool = Set.reduceOpt((a, b) -> a-b, #{}: Set[Int]) `assertEq!` None
+def reduce01: Bool = Set.reduce((a, b) -> a-b, #{}: Set[Int]) `assertEq!` None
 
 @test
-def reduceOpt02: Bool = Set.reduceOpt((a, b) -> a-b, #{1}) `assertEq!` Some(1)
+def reduce02: Bool = Set.reduce((a, b) -> a-b, #{1}) `assertEq!` Some(1)
 
 @test
-def reduceOpt03: Bool = Set.reduceOpt((a, b) -> a-b, #{2, 1}) `assertEq!` Some(-1)
+def reduce03: Bool = Set.reduce((a, b) -> a-b, #{2, 1}) `assertEq!` Some(-1)
 
 @test
-def reduceOpt04: Bool = Set.reduceOpt((a, b) -> a-b, #{3, 2, 1}) `assertEq!` Some(-4)
+def reduce04: Bool = Set.reduce((a, b) -> a-b, #{3, 2, 1}) `assertEq!` Some(-4)
 
 @test
-def reduceOpt05: Bool = Set.reduceOpt((a, b) -> a-b, #{4, 3, 2, 1}) `assertEq!` Some(-8)
-
-/////////////////////////////////////////////////////////////////////////////
-// reduceLeftOpt                                                           //
-/////////////////////////////////////////////////////////////////////////////
-@test
-def reduceLeftOpt01: Bool = Set.reduceLeftOpt((a, b) -> a-b, #{}: Set[Int]) `assertEq!` None
-
-@test
-def reduceLeftOpt02: Bool = Set.reduceLeftOpt((a, b) -> a-b, #{1}) `assertEq!` Some(1)
-
-@test
-def reduceLeftOpt03: Bool = Set.reduceLeftOpt((a, b) -> a-b, #{2, 1}) `assertEq!` Some(-1)
-
-@test
-def reduceLeftOpt04: Bool = Set.reduceLeftOpt((a, b) -> a-b, #{3, 2, 1}) `assertEq!` Some(-4)
-
-@test
-def reduceLeftOpt05: Bool = Set.reduceLeftOpt((a, b) -> a-b, #{4, 3, 2, 1}) `assertEq!` Some(-8)
+def reduce05: Bool = Set.reduce((a, b) -> a-b, #{4, 3, 2, 1}) `assertEq!` Some(-8)
 
 /////////////////////////////////////////////////////////////////////////////
-// reduceRightOpt                                                          //
+// reduceLeft                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduceRightOpt01: Bool = Set.reduceRightOpt((a, b) -> a-b, #{}: Set[Int]) `assertEq!` None
+def reduceLeft01: Bool = Set.reduceLeft((a, b) -> a-b, #{}: Set[Int]) `assertEq!` None
 
 @test
-def reduceRightOpt02: Bool = Set.reduceRightOpt((a, b) -> a-b, #{1}) `assertEq!` Some(1)
+def reduceLeft02: Bool = Set.reduceLeft((a, b) -> a-b, #{1}) `assertEq!` Some(1)
 
 @test
-def reduceRightOpt03: Bool = Set.reduceRightOpt((a, b) -> a-b, #{2, 1}) `assertEq!` Some(-1)
+def reduceLeft03: Bool = Set.reduceLeft((a, b) -> a-b, #{2, 1}) `assertEq!` Some(-1)
 
 @test
-def reduceRightOpt04: Bool = Set.reduceRightOpt((a, b) -> a-b, #{3, 2, 1}) `assertEq!` Some(2)
+def reduceLeft04: Bool = Set.reduceLeft((a, b) -> a-b, #{3, 2, 1}) `assertEq!` Some(-4)
 
 @test
-def reduceRightOpt05: Bool = Set.reduceRightOpt((a, b) -> a-b, #{4, 3, 2, 1}) `assertEq!` Some(-2)
+def reduceLeft05: Bool = Set.reduceLeft((a, b) -> a-b, #{4, 3, 2, 1}) `assertEq!` Some(-8)
+
+/////////////////////////////////////////////////////////////////////////////
+// reduceRight                                                             //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def reduceRight01: Bool = Set.reduceRight((a, b) -> a-b, #{}: Set[Int]) `assertEq!` None
+
+@test
+def reduceRight02: Bool = Set.reduceRight((a, b) -> a-b, #{1}) `assertEq!` Some(1)
+
+@test
+def reduceRight03: Bool = Set.reduceRight((a, b) -> a-b, #{2, 1}) `assertEq!` Some(-1)
+
+@test
+def reduceRight04: Bool = Set.reduceRight((a, b) -> a-b, #{3, 2, 1}) `assertEq!` Some(2)
+
+@test
+def reduceRight05: Bool = Set.reduceRight((a, b) -> a-b, #{4, 3, 2, 1}) `assertEq!` Some(-2)
 
 /////////////////////////////////////////////////////////////////////////////
 // count                                                                   //


### PR DESCRIPTION
- Addressed https://github.com/flix/flix/issues/379

Note:  The addition of `reduce` functions to `Map` in another PR uses `List.reduceOpt` which has been renamed here.  So I will update this PR once the Map PR is merged.