### PR TITLE
Adding Support for native calls in flix.

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Codegen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Codegen.scala
@@ -603,6 +603,11 @@ object Codegen {
       // If the method is static, use INVOKESTATIC otherwise use INVOKEVIRTUAL
       val invokeInsn = if (Modifier.isStatic(method.getModifiers)) INVOKESTATIC else INVOKEVIRTUAL
       visitor.visitMethodInsn(invokeInsn, declaration, name, descriptor, false)
+      // If the method is void, put a unit on top of the stack
+      if(asm.Type.getType(method.getReturnType) == asm.Type.VOID_TYPE) {
+        val clazz = Constants.unitClass
+        visitor.visitFieldInsn(GETSTATIC, asm.Type.getInternalName(clazz), "MODULE$", asm.Type.getDescriptor(clazz))
+      }
 
     case Expression.UserError(_, loc) =>
       val name = asm.Type.getInternalName(classOf[UserException])

--- a/main/src/ca/uwaterloo/flix/language/phase/Codegen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Codegen.scala
@@ -16,6 +16,8 @@
 
 package ca.uwaterloo.flix.language.phase
 
+import java.lang.reflect.Modifier
+
 import ca.uwaterloo.flix.api._
 import ca.uwaterloo.flix.language.ast.Ast.Hook
 import ca.uwaterloo.flix.language.ast.ExecutableAst.{Definition, Expression, LoadExpression, StoreExpression}
@@ -32,7 +34,6 @@ import scala.language.existentials
 // TODO: Debugging information
 
 object Codegen {
-
   /*
    * Constants passed to the asm library to generate bytecode.
    *
@@ -573,11 +574,35 @@ object Codegen {
     case Expression.Universal(params, exp, loc) =>
       throw InternalCompilerException(s"Unexpected expression: '$expr' at ${loc.source.format}.")
 
-    case Expression.NativeConstructor(constructor, args, tpe, loc) => ??? // TODO
+    case Expression.NativeConstructor(constructor, args, tpe, loc) =>
+      val descriptor = asm.Type.getConstructorDescriptor(constructor)
+      val declaration = asm.Type.getInternalName(constructor.getDeclaringClass)
+      // Create a new object of the declaration type
+      visitor.visitTypeInsn(NEW, declaration)
+      // Duplicate the reference since the first argument for a constructor call is the reference to the object
+      visitor.visitInsn(DUP)
+      // Evaluate arguments left-to-right and push them onto the stack.
+      args.foreach(compileExpression(ctx, visitor, entryPoint))
+      // Call the constructor
+      visitor.visitMethodInsn(INVOKESPECIAL, declaration, "<init>", descriptor, false)
 
-    case Expression.NativeField(field, tpe, loc) => ??? // TODO
+    case Expression.NativeField(field, tpe, loc) =>
+      // Fetch a field from an object
+      val declaration = asm.Type.getInternalName(field.getDeclaringClass)
+      val name = field.getName
+      // Use GETSTATIC if the field is static and GETFIELD if the field is on an object
+      val getCode = if(Modifier.isStatic(field.getModifiers)) GETSTATIC else GETFIELD
+      visitor.visitFieldInsn(getCode, declaration, name, ctx.descriptor(tpe))
 
-    case Expression.NativeMethod(method, args, tpe, loc) => ??? // TODO
+    case Expression.NativeMethod(method, args, tpe, loc) =>
+      // Evaluate arguments left-to-right and push them onto the stack.
+      args.foreach(compileExpression(ctx, visitor, entryPoint))
+      val declaration = asm.Type.getInternalName(method.getDeclaringClass)
+      val name = method.getName
+      val descriptor = asm.Type.getMethodDescriptor(method)
+      // If the method is static, use INVOKESTATIC otherwise use INVOKEVIRTUAL
+      val invokeCode = if (Modifier.isStatic(method.getModifiers)) INVOKESTATIC else INVOKEVIRTUAL
+      visitor.visitMethodInsn(invokeCode, declaration, name, descriptor, false)
 
     case Expression.UserError(_, loc) =>
       val name = asm.Type.getInternalName(classOf[UserException])

--- a/main/src/ca/uwaterloo/flix/language/phase/Codegen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Codegen.scala
@@ -591,8 +591,8 @@ object Codegen {
       val declaration = asm.Type.getInternalName(field.getDeclaringClass)
       val name = field.getName
       // Use GETSTATIC if the field is static and GETFIELD if the field is on an object
-      val getCode = if(Modifier.isStatic(field.getModifiers)) GETSTATIC else GETFIELD
-      visitor.visitFieldInsn(getCode, declaration, name, ctx.descriptor(tpe))
+      val getInsn = if(Modifier.isStatic(field.getModifiers)) GETSTATIC else GETFIELD
+      visitor.visitFieldInsn(getInsn, declaration, name, ctx.descriptor(tpe))
 
     case Expression.NativeMethod(method, args, tpe, loc) =>
       // Evaluate arguments left-to-right and push them onto the stack.
@@ -601,8 +601,8 @@ object Codegen {
       val name = method.getName
       val descriptor = asm.Type.getMethodDescriptor(method)
       // If the method is static, use INVOKESTATIC otherwise use INVOKEVIRTUAL
-      val invokeCode = if (Modifier.isStatic(method.getModifiers)) INVOKESTATIC else INVOKEVIRTUAL
-      visitor.visitMethodInsn(invokeCode, declaration, name, descriptor, false)
+      val invokeInsn = if (Modifier.isStatic(method.getModifiers)) INVOKESTATIC else INVOKEVIRTUAL
+      visitor.visitMethodInsn(invokeInsn, declaration, name, descriptor, false)
 
     case Expression.UserError(_, loc) =>
       val name = asm.Type.getInternalName(classOf[UserException])

--- a/main/test/ca/uwaterloo/flix/language/feature/FeatureSuite.scala
+++ b/main/test/ca/uwaterloo/flix/language/feature/FeatureSuite.scala
@@ -22,7 +22,8 @@ import org.scalatest.{ParallelTestExecution, Suites}
 class FeatureSuite extends Suites(
   new FlixTest("TestConstraint", "main/test/ca/uwaterloo/flix/language/feature/TestConstraint.flix"),
   new FlixTest("TestEquality", "main/test/ca/uwaterloo/flix/language/feature/TestEquality.flix"),
-  new FlixTest("TestPatternMatch", "main/test/ca/uwaterloo/flix/language/feature/TestPatternMatch.flix")
+  new FlixTest("TestPatternMatch", "main/test/ca/uwaterloo/flix/language/feature/TestPatternMatch.flix"),
+  new  FlixTest("TestNativeCall", "main/test/ca/uwaterloo/flix/language/feature/TestNativeCall.flix")
 ) with ParallelTestExecution {
   /* left empty */
 }

--- a/main/test/ca/uwaterloo/flix/language/feature/TestNativeCall.flix
+++ b/main/test/ca/uwaterloo/flix/language/feature/TestNativeCall.flix
@@ -1,0 +1,96 @@
+/////////////////////////////////////////////////////////////////////////////
+// Native Constructor                                                      //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def nativeCall01: Bool = assertEq!(unsafe native new java.lang.String(), "")
+
+@test
+def nativeCall02: Bool =
+    let x = unsafe native new java.lang.Character('c');
+    let y = unsafe native new java.lang.Character('c');
+    unsafe native method java.lang.Character.equals(x, y)
+
+@test
+def nativeCall03: Bool =
+    let x = unsafe native new java.util.BitSet();
+    assertEq!(unsafe native method java.util.BitSet.toString(x), "{}")
+
+@test
+def nativeCall04: Bool =
+    let x = unsafe native new java.util.Date(96, 6, 12);
+    assertEq!(unsafe native method java.util.Date.toString(x), "Fri Jul 12 00:00:00 EDT 1996")
+
+/////////////////////////////////////////////////////////////////////////////
+// Native Static Field                                                     //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def nativeCall05: Bool = assertEq!(unsafe native field java.lang.Character.BYTES, 2)
+
+@test
+def nativeCall06: Bool = assertEq!(unsafe native field java.lang.Character.SIZE, 16)
+
+@test
+def nativeCall07: Bool = assertEq!(unsafe native field java.lang.Long.SIZE, 64)
+
+@test
+def nativeCall08: Bool = assertEq!(unsafe native field java.lang.Float.SIZE, 32)
+
+/////////////////////////////////////////////////////////////////////////////
+// Native Static Methods                                                   //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def nativeCall09: Bool = assertEq!(unsafe native method java.lang.Integer.bitCount(2), 1)
+
+@test
+def nativeCall10: Bool = assertEq!(unsafe native method java.lang.Integer.bitCount(7), 3)
+
+@test
+def nativeCall11: Bool = !(unsafe native method java.lang.Boolean.logicalAnd(true, false))
+
+@test
+def nativeCall12: Bool = unsafe native method java.lang.Boolean.logicalOr(true, false)
+
+@test
+def nativeCall13: Bool = !(unsafe native method java.lang.Boolean.logicalOr(false, false))
+
+@test
+def nativeCall14: Bool =
+    let x = unsafe native method java.lang.Byte.decode("8");
+    assertEq!(unsafe native method java.lang.Byte.intValue(x), 8)
+
+/////////////////////////////////////////////////////////////////////////////
+// Native Static Methods                                                   //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def nativeCall15: Bool =
+    let x = unsafe native new java.lang.String();
+    unsafe native method java.lang.String.isEmpty(x)
+
+@test
+def nativeCall16: Bool =
+    let x = unsafe native new java.lang.String();
+    assertEq!(unsafe native method java.lang.String.length(x), 0)
+
+@test
+def nativeCall17: Bool =
+    let x = unsafe native new java.util.Date(96, 6, 12);
+    let y = unsafe native new java.util.Date(100, 0, 0);
+    unsafe native method java.util.Date.before(x, y)
+
+@test
+def nativeCall18: Bool =
+    let x = unsafe native new java.util.Date(100, 0, 0);
+    let y = unsafe native new java.util.Date(96, 6, 12);
+    !(unsafe native method java.util.Date.before(x, y))
+
+@test
+def nativeCall19: Bool =
+    let x = unsafe native new java.util.Date(96, 6, 12);
+    let y = unsafe native new java.util.Date(96, 6, 12);
+    unsafe native method java.util.Date.equals(x, y)
+
+@test
+def nativeCall20: Bool =
+    let x = unsafe native new java.util.Date(96, 6, 12);
+    let y = unsafe native new java.util.Date(100, 0, 0);
+    !(unsafe native method java.util.Date.equals(x, y))

--- a/main/test/ca/uwaterloo/flix/language/feature/TestNativeCall.flix
+++ b/main/test/ca/uwaterloo/flix/language/feature/TestNativeCall.flix
@@ -89,3 +89,10 @@ def nativeMethod12: Bool =
     let x = unsafe native new java.util.Date(96, 6, 12);
     let y = unsafe native new java.util.Date(100, 0, 0);
     !(unsafe native method java.util.Date.equals(x, y))
+
+@test
+def nativeMethod13: Bool =
+    let x = unsafe native new java.util.BitSet();
+    let y = unsafe native method java.util.BitSet.set(x, 10);
+    let z = unsafe native method java.util.BitSet.set(x, 3);
+    assertEq!(unsafe native method java.util.BitSet.toString(x), "{3, 10}")

--- a/main/test/ca/uwaterloo/flix/language/feature/TestNativeCall.flix
+++ b/main/test/ca/uwaterloo/flix/language/feature/TestNativeCall.flix
@@ -18,7 +18,7 @@ def nativeCall03: Bool =
 @test
 def nativeCall04: Bool =
     let x = unsafe native new java.util.Date(96, 6, 12);
-    assertEq!(unsafe native method java.util.Date.toString(x), "Fri Jul 12 00:00:00 EDT 1996")
+     assertEq!(unsafe native method java.util.Date.getTime(x), 837144000000i64)
 
 /////////////////////////////////////////////////////////////////////////////
 // Native Static Field                                                     //

--- a/main/test/ca/uwaterloo/flix/language/feature/TestNativeCall.flix
+++ b/main/test/ca/uwaterloo/flix/language/feature/TestNativeCall.flix
@@ -2,16 +2,16 @@
 // Native Constructor                                                      //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def nativeCall01: Bool = assertEq!(unsafe native new java.lang.String(), "")
+def nativeNew01: Bool = assertEq!(unsafe native new java.lang.String(), "")
 
 @test
-def nativeCall02: Bool =
+def nativeNew02: Bool =
     let x = unsafe native new java.lang.Character('c');
     let y = unsafe native new java.lang.Character('c');
     unsafe native method java.lang.Character.equals(x, y)
 
 @test
-def nativeCall03: Bool =
+def nativeNew03: Bool =
     let x = unsafe native new java.util.BitSet();
     assertEq!(unsafe native method java.util.BitSet.toString(x), "{}")
 
@@ -19,37 +19,37 @@ def nativeCall03: Bool =
 // Native Static Field                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def nativeCall04: Bool = assertEq!(unsafe native field java.lang.Character.BYTES, 2)
+def nativeField01: Bool = assertEq!(unsafe native field java.lang.Character.BYTES, 2)
 
 @test
-def nativeCall05: Bool = assertEq!(unsafe native field java.lang.Character.SIZE, 16)
+def nativeField02: Bool = assertEq!(unsafe native field java.lang.Character.SIZE, 16)
 
 @test
-def nativeCall06: Bool = assertEq!(unsafe native field java.lang.Long.SIZE, 64)
+def nativeField03: Bool = assertEq!(unsafe native field java.lang.Long.SIZE, 64)
 
 @test
-def nativeCall07: Bool = assertEq!(unsafe native field java.lang.Float.SIZE, 32)
+def nativeField04: Bool = assertEq!(unsafe native field java.lang.Float.SIZE, 32)
 
 /////////////////////////////////////////////////////////////////////////////
 // Native Static Methods                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def nativeCall08: Bool = assertEq!(unsafe native method java.lang.Integer.bitCount(2), 1)
+def nativeMethod01: Bool = assertEq!(unsafe native method java.lang.Integer.bitCount(2), 1)
 
 @test
-def nativeCall09: Bool = assertEq!(unsafe native method java.lang.Integer.bitCount(7), 3)
+def nativeMethod02: Bool = assertEq!(unsafe native method java.lang.Integer.bitCount(7), 3)
 
 @test
-def nativeCall10: Bool = !(unsafe native method java.lang.Boolean.logicalAnd(true, false))
+def nativeMethod03: Bool = !(unsafe native method java.lang.Boolean.logicalAnd(true, false))
 
 @test
-def nativeCall11: Bool = unsafe native method java.lang.Boolean.logicalOr(true, false)
+def nativeMethod04: Bool = unsafe native method java.lang.Boolean.logicalOr(true, false)
 
 @test
-def nativeCall12: Bool = !(unsafe native method java.lang.Boolean.logicalOr(false, false))
+def nativeMethod05: Bool = !(unsafe native method java.lang.Boolean.logicalOr(false, false))
 
 @test
-def nativeCall13: Bool =
+def nativeMethod06: Bool =
     let x = unsafe native method java.lang.Byte.decode("8");
     assertEq!(unsafe native method java.lang.Byte.intValue(x), 8)
 
@@ -57,35 +57,35 @@ def nativeCall13: Bool =
 // Native Static Methods                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def nativeCall14: Bool =
+def nativeMethod07: Bool =
     let x = unsafe native new java.lang.String();
     unsafe native method java.lang.String.isEmpty(x)
 
 @test
-def nativeCall15: Bool =
+def nativeMethod08: Bool =
     let x = unsafe native new java.lang.String();
     assertEq!(unsafe native method java.lang.String.length(x), 0)
 
 @test
-def nativeCall16: Bool =
+def nativeMethod09: Bool =
     let x = unsafe native new java.util.Date(96, 6, 12);
     let y = unsafe native new java.util.Date(100, 0, 0);
     unsafe native method java.util.Date.before(x, y)
 
 @test
-def nativeCall17: Bool =
+def nativeMethod10: Bool =
     let x = unsafe native new java.util.Date(100, 0, 0);
     let y = unsafe native new java.util.Date(96, 6, 12);
     !(unsafe native method java.util.Date.before(x, y))
 
 @test
-def nativeCall18: Bool =
+def nativeMethod11: Bool =
     let x = unsafe native new java.util.Date(96, 6, 12);
     let y = unsafe native new java.util.Date(96, 6, 12);
     unsafe native method java.util.Date.equals(x, y)
 
 @test
-def nativeCall19: Bool =
+def nativeMethod12: Bool =
     let x = unsafe native new java.util.Date(96, 6, 12);
     let y = unsafe native new java.util.Date(100, 0, 0);
     !(unsafe native method java.util.Date.equals(x, y))

--- a/main/test/ca/uwaterloo/flix/language/feature/TestNativeCall.flix
+++ b/main/test/ca/uwaterloo/flix/language/feature/TestNativeCall.flix
@@ -15,46 +15,41 @@ def nativeCall03: Bool =
     let x = unsafe native new java.util.BitSet();
     assertEq!(unsafe native method java.util.BitSet.toString(x), "{}")
 
-@test
-def nativeCall04: Bool =
-    let x = unsafe native new java.util.Date(96, 6, 12);
-     assertEq!(unsafe native method java.util.Date.getTime(x), 837144000000i64)
-
 /////////////////////////////////////////////////////////////////////////////
 // Native Static Field                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def nativeCall05: Bool = assertEq!(unsafe native field java.lang.Character.BYTES, 2)
+def nativeCall04: Bool = assertEq!(unsafe native field java.lang.Character.BYTES, 2)
 
 @test
-def nativeCall06: Bool = assertEq!(unsafe native field java.lang.Character.SIZE, 16)
+def nativeCall05: Bool = assertEq!(unsafe native field java.lang.Character.SIZE, 16)
 
 @test
-def nativeCall07: Bool = assertEq!(unsafe native field java.lang.Long.SIZE, 64)
+def nativeCall06: Bool = assertEq!(unsafe native field java.lang.Long.SIZE, 64)
 
 @test
-def nativeCall08: Bool = assertEq!(unsafe native field java.lang.Float.SIZE, 32)
+def nativeCall07: Bool = assertEq!(unsafe native field java.lang.Float.SIZE, 32)
 
 /////////////////////////////////////////////////////////////////////////////
 // Native Static Methods                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def nativeCall09: Bool = assertEq!(unsafe native method java.lang.Integer.bitCount(2), 1)
+def nativeCall08: Bool = assertEq!(unsafe native method java.lang.Integer.bitCount(2), 1)
 
 @test
-def nativeCall10: Bool = assertEq!(unsafe native method java.lang.Integer.bitCount(7), 3)
+def nativeCall09: Bool = assertEq!(unsafe native method java.lang.Integer.bitCount(7), 3)
 
 @test
-def nativeCall11: Bool = !(unsafe native method java.lang.Boolean.logicalAnd(true, false))
+def nativeCall10: Bool = !(unsafe native method java.lang.Boolean.logicalAnd(true, false))
 
 @test
-def nativeCall12: Bool = unsafe native method java.lang.Boolean.logicalOr(true, false)
+def nativeCall11: Bool = unsafe native method java.lang.Boolean.logicalOr(true, false)
 
 @test
-def nativeCall13: Bool = !(unsafe native method java.lang.Boolean.logicalOr(false, false))
+def nativeCall12: Bool = !(unsafe native method java.lang.Boolean.logicalOr(false, false))
 
 @test
-def nativeCall14: Bool =
+def nativeCall13: Bool =
     let x = unsafe native method java.lang.Byte.decode("8");
     assertEq!(unsafe native method java.lang.Byte.intValue(x), 8)
 
@@ -62,35 +57,35 @@ def nativeCall14: Bool =
 // Native Static Methods                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def nativeCall15: Bool =
+def nativeCall14: Bool =
     let x = unsafe native new java.lang.String();
     unsafe native method java.lang.String.isEmpty(x)
 
 @test
-def nativeCall16: Bool =
+def nativeCall15: Bool =
     let x = unsafe native new java.lang.String();
     assertEq!(unsafe native method java.lang.String.length(x), 0)
 
 @test
-def nativeCall17: Bool =
+def nativeCall16: Bool =
     let x = unsafe native new java.util.Date(96, 6, 12);
     let y = unsafe native new java.util.Date(100, 0, 0);
     unsafe native method java.util.Date.before(x, y)
 
 @test
-def nativeCall18: Bool =
+def nativeCall17: Bool =
     let x = unsafe native new java.util.Date(100, 0, 0);
     let y = unsafe native new java.util.Date(96, 6, 12);
     !(unsafe native method java.util.Date.before(x, y))
 
 @test
-def nativeCall19: Bool =
+def nativeCall18: Bool =
     let x = unsafe native new java.util.Date(96, 6, 12);
     let y = unsafe native new java.util.Date(96, 6, 12);
     unsafe native method java.util.Date.equals(x, y)
 
 @test
-def nativeCall20: Bool =
+def nativeCall19: Bool =
     let x = unsafe native new java.util.Date(96, 6, 12);
     let y = unsafe native new java.util.Date(100, 0, 0);
     !(unsafe native method java.util.Date.equals(x, y))


### PR DESCRIPTION
Apart from discussions in https://github.com/flix/flix/issues/410 there are couple of other issues:

1. I'm not quite sure why `def f: Bool = unsafe native field java.lang.Boolean.TRUE` fails at invoking in `Linker.scala`
2. Is there a way to call void functions like the following:
`def f: Bool =
    let x = unsafe native new java.util.BitSet();
    unsafe native method java.util.BitSet.set(x, 1);
    true`
I also tried `let y = unsafe native method java.util.BitSet.set(x, 1);` but this tries to pop an object off the stack so this fails.
3. Every field with `_` in it fails at parsing stage
4. There is no way currently to fetch fields of an object. Looking at NativeField, no object is provided so only static field codes can be emitted. 