### PR TITLE
Unit Direct Comparison

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Codegen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Codegen.scala
@@ -603,6 +603,11 @@ object Codegen {
       // If the method is static, use INVOKESTATIC otherwise use INVOKEVIRTUAL
       val invokeInsn = if (Modifier.isStatic(method.getModifiers)) INVOKESTATIC else INVOKEVIRTUAL
       visitor.visitMethodInsn(invokeInsn, declaration, name, descriptor, false)
+      // If the method is void, put a unit on top of the stack
+      if(asm.Type.getType(method.getReturnType) == asm.Type.VOID_TYPE) {
+        val clazz = Constants.unitClass
+        visitor.visitFieldInsn(GETSTATIC, asm.Type.getInternalName(clazz), "MODULE$", asm.Type.getDescriptor(clazz))
+      }
 
     case Expression.UserError(_, loc) =>
       val name = asm.Type.getInternalName(classOf[UserException])

--- a/main/src/ca/uwaterloo/flix/language/phase/Codegen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Codegen.scala
@@ -1094,14 +1094,16 @@ object Codegen {
         }
         e1.tpe match {
           case Type.Unit if o == BinaryOperator.Equal || o == BinaryOperator.NotEqual =>
-            // Unit can only be equal to unit, so the objects are poped from the top of the stack
+            // Unit can only be equal to unit, so objects are poped from the top of the stack
             visitor.visitInsn(POP)
             visitor.visitInsn(POP)
-            (e2.tpe, o) match {
-              case (Type.Unit, BinaryOperator.NotEqual) => visitor.visitJumpInsn(GOTO, condElse)
-              case (Type.Unit, BinaryOperator.Equal) =>
-              case (_, BinaryOperator.Equal) => visitor.visitJumpInsn(GOTO, condElse)
-              case (_, BinaryOperator.NotEqual) =>
+            // A unit value is always equal itself, so no need to branch.
+            // A unit value is never unequal to itself, so always branch to else label.
+            e2.tpe match {
+              case Type.Unit if o == BinaryOperator.NotEqual => visitor.visitJumpInsn(GOTO, condElse)
+              case Type.Unit if o == BinaryOperator.Equal =>
+              case _ if o == BinaryOperator.Equal => visitor.visitJumpInsn(GOTO, condElse)
+              case _ =>
             }
           case Type.Str if o == BinaryOperator.Equal || o == BinaryOperator.NotEqual =>
             // String can be compared using Object's `equal` method

--- a/main/test/ca/uwaterloo/flix/language/feature/TestNativeCall.flix
+++ b/main/test/ca/uwaterloo/flix/language/feature/TestNativeCall.flix
@@ -89,3 +89,10 @@ def nativeMethod12: Bool =
     let x = unsafe native new java.util.Date(96, 6, 12);
     let y = unsafe native new java.util.Date(100, 0, 0);
     !(unsafe native method java.util.Date.equals(x, y))
+
+@test
+def nativeMethod13: Bool =
+    let x = unsafe native new java.util.BitSet();
+    let y = unsafe native method java.util.BitSet.set(x, 10);
+    let z = unsafe native method java.util.BitSet.set(x, 3);
+    assertEq!(unsafe native method java.util.BitSet.toString(x), "{3, 10}")


### PR DESCRIPTION
If LHS of a comparison is a unit, this directly checks the equality to the second object based on the type of the second object instead of callibg `equals` method on LHS. 
This is for issue https://github.com/flix/flix/issues/427