### PR TITLE
Minor cleanup of Pattern Match Exhaustiveness (Fixes #468)

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -160,6 +160,7 @@ namespace List {
         case Nil => s :: Nil
         case x :: rs => match scanRight(f, s, rs) with {
             case y :: ys => f(x, y) :: y :: ys
+            case _ => ??? // Shouldn't happen
         }
     }
 

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -426,10 +426,12 @@ namespace Map {
     def differenceWithKey[k, v](f: (k, v, v) -> Option[v], m1: Map[k, v], m2: Map[k, v]): Map[k, v] =
         let diff = filterWithKey((k, v) -> !memberOf(k, m2), m1);
         let g = (k, v, m) -> if (memberOf(k, m1))
-                                let Some(v1) = get(k, m1);
-                                match f(k, v1, v) with {
-                                    case None => m
-                                    case Some(w) => insert(k, w, m)
+                                match get(k, m1) with {
+                                    case Some(v1) => match f(k, v1, v) with {
+                                        case None => m
+                                        case Some(w) => insert(k, w, m)
+                                    }
+                                    case None => ??? // Shouldn't happen
                                 }
                              else m;
         foldRightWithKey(g, diff, m2)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.api.{Flix, RuleException}
-import ca.uwaterloo.flix.language.errors.ResolutionError
+import ca.uwaterloo.flix.language.errors.{NonExhaustiveMatchError, ResolutionError}
 import ca.uwaterloo.flix.runtime.Model
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.FunSuite
@@ -1456,27 +1456,27 @@ class TestParser extends FunSuite with TestUtils {
 
   test("Expression.MatchLambda.05") {
     val input = "def f: Option[Int] -> Int = match None -> 42"
-    run(input, core = false)
+    expectError[NonExhaustiveMatchError](new Flix().addStr(input).compile())
   }
 
   test("Expression.MatchLambda.06") {
     val input = "def f: Option[Int] -> Int = match Some(x) -> x"
-    run(input, core = false)
+    expectError[NonExhaustiveMatchError](new Flix().addStr(input).compile())
   }
 
   test("Expression.MatchLambda.07") {
     val input = "def f: List[Int] -> Int = match Nil -> 42"
-    run(input, core = false)
+    expectError[NonExhaustiveMatchError](new Flix().addStr(input).compile())
   }
 
   test("Expression.MatchLambda.08") {
     val input = "def f: List[Int] -> Int = match x :: Nil -> x"
-    run(input, core = false)
+    expectError[NonExhaustiveMatchError](new Flix().addStr(input).compile())
   }
 
   test("Expression.MatchLambda.09") {
     val input = "def f: List[Int] -> Int = match x :: y :: Nil -> x + y"
-    run(input, core = false)
+    expectError[NonExhaustiveMatchError](new Flix().addStr(input).compile())
   }
 
   test("Expression.Existential.01") {


### PR DESCRIPTION
- Made the check recursive on expressions (oops)
- Use Int instead of Integer
- Don't use getClass
- Reorder type constructor
- Added a few more tests for nested cases