### PR TITLE
Fix the #458

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/EnumGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EnumGen.scala
@@ -512,8 +512,8 @@ object EnumGen extends Phase[ExecutableAst.Root, ExecutableAst.Root] {
       method.visitTypeInsn(CHECKCAST, asm.Type.getInternalName(Constants.tupleClass))
 
       // Call `getBoxedValue()` on the object
-      method.visitMethodInsn(INVOKEVIRTUAL, asm.Type.getInternalName(tupleClazz), getBoxedValueMethod.getName,
-        asm.Type.getMethodDescriptor(getBoxedValueMethod), false)
+      method.visitMethodInsn(INVOKEINTERFACE, asm.Type.getInternalName(tupleClazz), getBoxedValueMethod.getName,
+        asm.Type.getMethodDescriptor(getBoxedValueMethod), true)
 
       // Duplicate the reference to array
       method.visitInsn(DUP)


### PR DESCRIPTION
In order to invoke an interface method, in addition to passing in `INVOKEINTERFACE` as an argument `true` has to be passed inside `visitMethodInsn` as the last argument. 