### PR TITLE
Refactoring + Sanity check

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenClosureClasses.scala
@@ -167,7 +167,6 @@ object GenClosureClasses {
     applyMethod.visitVarInsn(ALOAD, 0)
 
     // Swapping `this` and result of the expression
-    // TODO: Ramin could be extract this into a helper in AsmOps? It is used in several places, right?
     if (AsmOps.getStackSize(resultType) == 1) {
       applyMethod.visitInsn(SWAP)
     } else {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenClosureClasses.scala
@@ -74,6 +74,9 @@ object GenClosureClasses {
     visitor.visit(AsmOps.JavaVersion, ACC_PUBLIC + ACC_FINAL, classType.name.toInternalName, null,
       JvmName.Object.toInternalName, superInterface)
 
+    // Context at creation
+    AsmOps.compileField(visitor, "creationContext", JvmType.Object, isStatic = false, isPrivate = true)
+
     // Generate a field for each closured captured variable.
     for ((freeVar, index) <- closure.freeVars.zipWithIndex) {
       // `JvmType` of `freeVar`
@@ -127,6 +130,35 @@ object GenClosureClasses {
 
     // Function parameters
     val params = defn.formals.takeRight(defn.formals.length - freeVars.length)
+
+    // Sanity check
+    val skipLabel = new Label
+    applyMethod.visitVarInsn(ALOAD, 0)
+    applyMethod.visitFieldInsn(GETFIELD, classType.name.toInternalName, "creationContext", JvmType.Object.toDescriptor)
+    applyMethod.visitVarInsn(ALOAD, 1)
+    applyMethod.visitMethodInsn(INVOKEVIRTUAL, JvmName.Object.toInternalName, "equals",
+    AsmOps.getMethodDescriptor(List(JvmType.Object), JvmType.PrimBool), false)
+
+    // If contexts are equal, precede to evaluate
+    applyMethod.visitJumpInsn(IFNE, skipLabel)
+
+    val message = "Closure is called with a different Context"
+    // Create a new `Exception` object
+    applyMethod.visitTypeInsn(NEW, JvmName.Exception.toInternalName)
+    applyMethod.visitInsn(DUP)
+
+    // add the message to the stack
+    applyMethod.visitLdcInsn(message)
+
+    // invoke the constructor of the `Exception` object
+    applyMethod.visitMethodInsn(INVOKESPECIAL, JvmName.Exception.toInternalName, "<init>",
+    AsmOps.getMethodDescriptor(List(JvmType.String), JvmType.Void), false)
+
+    // throw the exception
+    applyMethod.visitInsn(ATHROW)
+
+    // Visit skip label
+    applyMethod.visitLabel(skipLabel)
 
     // Enter label
     val enterLabel = new Label()
@@ -190,15 +222,20 @@ object GenClosureClasses {
     val varTypes = freeVars.map(_.tpe).map(JvmOps.getErasedJvmType)
 
     // Constructor header
-    val constructor = visitor.visitMethod(ACC_PUBLIC, "<init>", AsmOps.getMethodDescriptor(varTypes, JvmType.Void), null, null)
+    val constructor = visitor.visitMethod(ACC_PUBLIC, "<init>", AsmOps.getMethodDescriptor(JvmType.Object +: varTypes, JvmType.Void), null, null)
 
     // Calling constructor of super
     constructor.visitVarInsn(ALOAD, 0)
     constructor.visitMethodInsn(INVOKESPECIAL, JvmName.Object.toInternalName, "<init>",
       AsmOps.getMethodDescriptor(Nil, JvmType.Void), false)
 
+    // Saving the context
+    constructor.visitVarInsn(ALOAD, 0)
+    constructor.visitVarInsn(ALOAD, 1)
+    constructor.visitFieldInsn(PUTFIELD, classType.name.toInternalName, "creationContext", JvmType.Object.toDescriptor)
+
     // Setting up closure args
-    var offset: Int = 1
+    var offset: Int = 2
     for ((tpe, index) <- varTypes.zipWithIndex) {
       constructor.visitVarInsn(ALOAD, 0)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenClosureClasses.scala
@@ -136,11 +136,9 @@ object GenClosureClasses {
     applyMethod.visitVarInsn(ALOAD, 0)
     applyMethod.visitFieldInsn(GETFIELD, classType.name.toInternalName, "creationContext", JvmType.Object.toDescriptor)
     applyMethod.visitVarInsn(ALOAD, 1)
-    applyMethod.visitMethodInsn(INVOKEVIRTUAL, JvmName.Object.toInternalName, "equals",
-    AsmOps.getMethodDescriptor(List(JvmType.Object), JvmType.PrimBool), false)
 
     // If contexts are equal, precede to evaluate
-    applyMethod.visitJumpInsn(IFNE, skipLabel)
+    applyMethod.visitJumpInsn(IF_ACMPEQ, skipLabel)
 
     val message = "Closure is called with a different Context"
     // Create a new `Exception` object

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -80,6 +80,8 @@ object GenExpression {
       visitor.visitTypeInsn(NEW, jvmType.name.toInternalName)
       // Duplicate
       visitor.visitInsn(DUP)
+      // Load the context object
+      visitor.visitVarInsn(ALOAD, 1)
       // Capturing free args
       for (f <- freeVars) {
         val v = Expression.Var(f.sym, f.tpe, loc)
@@ -87,7 +89,7 @@ object GenExpression {
       }
       // Calling the constructor
       val varTypes = freeVars.map(_.tpe).map(JvmOps.getErasedJvmType)
-      visitor.visitMethodInsn(INVOKESPECIAL, jvmType.name.toInternalName, "<init>", AsmOps.getMethodDescriptor(varTypes, JvmType.Void), false)
+      visitor.visitMethodInsn(INVOKESPECIAL, jvmType.name.toInternalName, "<init>", AsmOps.getMethodDescriptor(JvmType.Object +: varTypes, JvmType.Void), false)
 
     case Expression.ApplyClo(exp, args, tpe, loc) =>
       // Label for the loop

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunctionClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunctionClasses.scala
@@ -138,7 +138,6 @@ object GenFunctionClasses {
     applyMethod.visitVarInsn(ALOAD, 0)
 
     // Swapping `this` and result of the expression
-    // TODO: Ramin could be extract this into a helper in AsmOps? It is used in several places, right?
     if (AsmOps.getStackSize(resultType) == 1) {
       applyMethod.visitInsn(SWAP)
     } else {


### PR DESCRIPTION
Refactoring AsmOps + adding sanity check for closures.
@magnus-madsen: Can we add a flag so we can turn this sanity check off at times? I'm concerned about it's performance when we have a lot of closure calls (because it will do the sanity check each time a closure is called). 