### PR TITLE
Add check command to the build system

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -86,6 +86,10 @@ object Main {
           Packager.init(cwd, options)
           System.exit(0)
 
+        case Command.Check =>
+          Packager.check(cwd, options)
+          System.exit(0)
+
         case Command.Build =>
           Packager.build(cwd, options)
           System.exit(0)
@@ -201,6 +205,8 @@ object Main {
 
     case object Init extends Command
 
+    case object Check extends Command
+
     case object Build extends Command
 
     case object BuildJar extends Command
@@ -228,6 +234,8 @@ object Main {
 
       // Command
       cmd("init").action((_, c) => c.copy(command = Command.Init)).text("  create a new project in the current directory.")
+
+      cmd("check").action((_, c) => c.copy(command = Command.Check)).text("  type checks the current project.")
 
       cmd("build").action((_, c) => c.copy(command = Command.Build)).text("  build the current project.")
 

--- a/main/src/ca/uwaterloo/flix/tools/Packager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Packager.scala
@@ -141,7 +141,6 @@ object Packager {
       case Validation.Failure(errors) =>
         implicit val _ = TerminalContext.AnsiTerminal
         errors.foreach(e => println(e.message.fmt))
-        None
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/tools/Packager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Packager.scala
@@ -109,6 +109,43 @@ object Packager {
   }
 
   /**
+    * Type checks the source files for the given project path `p`.
+    */
+  def check(p: Path, o: Options)(implicit tc: TerminalContext): Unit = {
+    // Check that the path is a project path.
+    if (!isProjectPath(p))
+      throw new RuntimeException(s"The path '$p' does not appear to be a flix project.")
+
+    // Configure a new Flix object.
+    val flix = new Flix()
+    flix.setOptions(o)
+
+    // Add all source files.
+    for (sourceFile <- getAllFiles(getSourceDirectory(p))) {
+      if (sourceFile.getFileName.toString.endsWith(".flix")) {
+        flix.addPath(sourceFile)
+      }
+    }
+
+    // Add all test files.
+    for (testFile <- getAllFiles(getTestDirectory(p))) {
+      if (testFile.getFileName.toString.endsWith(".flix")) {
+        flix.addPath(testFile)
+      }
+    }
+
+    flix.check() match {
+      case Validation.Success(_) =>
+        implicit val _ = TerminalContext.AnsiTerminal
+        println("Check Completed!")
+      case Validation.Failure(errors) =>
+        implicit val _ = TerminalContext.AnsiTerminal
+        errors.foreach(e => println(e.message.fmt))
+        None
+    }
+  }
+
+  /**
     * Builds (compiles) the source files for the given project path `p`.
     */
   def build(p: Path, o: Options)(implicit tc: TerminalContext): Option[CompilationResult] = {

--- a/main/src/ca/uwaterloo/flix/tools/Packager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Packager.scala
@@ -135,9 +135,7 @@ object Packager {
     }
 
     flix.check() match {
-      case Validation.Success(_) =>
-        implicit val _ = TerminalContext.AnsiTerminal
-        println("Check Completed!")
+      case Validation.Success(_) => ()
       case Validation.Failure(errors) =>
         implicit val _ = TerminalContext.AnsiTerminal
         errors.foreach(e => println(e.message.fmt))

--- a/main/test/ca/uwaterloo/flix/tools/TestPackager.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestPackager.scala
@@ -19,6 +19,12 @@ class TestPackager extends FunSuite {
     Packager.init(p, DefaultOptions)
   }
 
+  test("check") {
+    val p = Files.createTempDirectory(ProjectPrefix)
+    Packager.init(p, DefaultOptions)
+    Packager.check(p, DefaultOptions)
+  }
+
   test("build") {
     val p = Files.createTempDirectory(ProjectPrefix)
     Packager.init(p, DefaultOptions)


### PR DESCRIPTION
This adds another command to the build system "check" which only type checks the program. Similar to the other build system commands, you simply run `flix check` to type check the program.

It's inspired by the "cargo check" command from the [cargo](https://doc.rust-lang.org/cargo/commands/cargo-check.html) (Rust) build system.