### PR TITLE
Add reflection library to dependencies.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -28,6 +28,7 @@
     <!-- ======================================================== -->
     <path id="classpath">
         <pathelement location="${scala.home}/lib/scala-library.jar"/>
+        <pathelement location="${scala.home}/lib/scala-reflect.jar"/>
         <fileset dir="${lib.dir}">
             <include name="**/*.jar"/>
         </fileset>


### PR DESCRIPTION
Adding this line allowed me to build with `ant build-all`, and failed without it. (tried with scala 2.12.8)