### PR TITLE
Remove Caching of Predicate Symbols

### DIFF
--- a/main/src/flix/runtime/fixpoint/Solver.java
+++ b/main/src/flix/runtime/fixpoint/Solver.java
@@ -48,7 +48,7 @@ public final class Solver {
         for (Constraint fact : cs.getFacts()) {
             Predicate head = fact.getHeadPredicate();
             if (head instanceof AtomPredicate) {
-                if (((AtomPredicate) head).getSym() == sym) {
+                if (((AtomPredicate) head).getSym().equals(sym)) {
                     result.add(fact);
                 }
             }

--- a/main/src/flix/runtime/fixpoint/symbol/LatSym.java
+++ b/main/src/flix/runtime/fixpoint/symbol/LatSym.java
@@ -18,8 +18,7 @@ package flix.runtime.fixpoint.symbol;
 
 import flix.runtime.fixpoint.LatticeOps;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents a lattice symbol.
@@ -27,14 +26,9 @@ import java.util.Map;
 public final class LatSym implements PredSym {
 
     /**
-     * An internal cache of lattice symbols.
-     */
-    private static final Map<String, LatSym> INTERNAL_CACHE = new HashMap<>();
-
-    /**
      * Returns the lattice symbol for the given `name`.
      */
-    public synchronized static LatSym of(String name, int arity, /* nullable */ String[] attributes, LatticeOps ops) {
+    public static LatSym of(String name, int arity, /* nullable */ String[] attributes, LatticeOps ops) {
         if (name == null)
             throw new IllegalArgumentException("'name' must be non-null.");
         if (attributes != null && attributes.length != arity)
@@ -42,13 +36,7 @@ public final class LatSym implements PredSym {
         if (ops == null)
             throw new IllegalArgumentException("'ops' must be non-null.");
 
-        var lookup = INTERNAL_CACHE.get(name);
-        if (lookup != null) {
-            return lookup;
-        }
-        var sym = new LatSym(name, arity, attributes, ops);
-        INTERNAL_CACHE.put(name, sym);
-        return sym;
+        return new LatSym(name, arity, attributes, ops);
     }
 
     /**
@@ -75,7 +63,7 @@ public final class LatSym implements PredSym {
      * Constructs a fresh lattice symbol with the given `name`, `arity`, `attributes`, and `ops`.
      */
     private LatSym(String name, int arity, String[] attributes, LatticeOps ops) {
-        this.name = name;
+        this.name = name.intern();
         this.arity = arity;
         this.attributes = attributes;
         this.ops = ops;
@@ -117,6 +105,22 @@ public final class LatSym implements PredSym {
         return name;
     }
 
-    /* equality by identity */
+    /**
+     * Equality defined by on the symbol name.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LatSym latSym = (LatSym) o;
+        return Objects.equals(name, latSym.name);
+    }
 
+    /**
+     * Equality defined by on the symbol name.
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
 }

--- a/main/src/flix/runtime/fixpoint/symbol/RelSym.java
+++ b/main/src/flix/runtime/fixpoint/symbol/RelSym.java
@@ -16,8 +16,7 @@
 
 package flix.runtime.fixpoint.symbol;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents a relation symbol.
@@ -25,26 +24,15 @@ import java.util.Map;
 public final class RelSym implements PredSym {
 
     /**
-     * An internal cache of relation symbols.
-     */
-    private static final Map<String, RelSym> INTERNAL_CACHE = new HashMap<>();
-
-    /**
      * Returns the relation symbol for the given `name`.
      */
-    public synchronized static RelSym of(String name, int arity, /* nullable */ String[] attributes) {
+    public static RelSym of(String name, int arity, /* nullable */ String[] attributes) {
         if (name == null)
             throw new IllegalArgumentException("'name' must be non-null.");
         if (attributes != null && attributes.length != arity)
             throw new IllegalArgumentException("'attributes' must have the same length as 'arity'.");
 
-        var lookup = INTERNAL_CACHE.get(name);
-        if (lookup != null) {
-            return lookup;
-        }
-        var sym = new RelSym(name, arity, attributes);
-        INTERNAL_CACHE.put(name, sym);
-        return sym;
+        return new RelSym(name, arity, attributes);
     }
 
     /**
@@ -66,7 +54,7 @@ public final class RelSym implements PredSym {
      * Constructs a fresh relation symbol with the given `name`, `arity`, and `attributes`.
      */
     private RelSym(String name, int arity, String[] attributes) {
-        this.name = name;
+        this.name = name.intern();
         this.arity = arity;
         this.attributes = attributes;
     }
@@ -100,6 +88,23 @@ public final class RelSym implements PredSym {
         return name;
     }
 
-    /* equality by identity */
 
+    /**
+     * Equality defined on the symbol name.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RelSym relSym = (RelSym) o;
+        return Objects.equals(name, relSym.name);
+    }
+
+    /**
+     * Equality defined on the symbol name.
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
 }


### PR DESCRIPTION
In the presence of first-class constraints where a predicate symbol may have multiple meanings it is unsound to do so.