### PR TITLE
Interim toString / fromString for the numeric types

### DIFF
--- a/main/src/flix/runtime/library/InterimReadShow.java
+++ b/main/src/flix/runtime/library/InterimReadShow.java
@@ -21,10 +21,13 @@ import java.math.BigInteger;
 /**
  * A wrapper class for reading and showing primitive types that provides concrete, non-overloaded methods.
  *
- * Flix can resolve overloading for Java's `parseInt` family of functions, so these do not
- * need wrappers, but we need to supply a non-overloaded "reader" for BigInteger.
+ * Java's standard library has a odd quirk where the float parsing functions `Float.parseFloat` and
+ * `Double.parseDouble` trims whitespace in the input but the corresponding integer parsing functions
+ * don't trim and instead throw an exception if they encounter whitespace.
  *
- * Note - This is considered an interim solution for reading and showing primitive types.
+ * So Flix can provide a consistent API (always trim) we trim whitespace for the integer parsers here.
+ *
+ * Note - This module is considered an interim solution for reading and showing primitive types.
  */
 public class InterimReadShow {
 
@@ -32,20 +35,40 @@ public class InterimReadShow {
         return Byte.toString(i);
     }
 
+    public static byte byteFromString(String s) throws Exception {
+        return Byte.parseByte(s.strip());
+    }
+
     public static String shortToString(short i) {
         return Short.toString(i);
+    }
+
+    public static short shortFromString(String s) throws Exception {
+        return Short.parseShort(s.strip());
     }
 
     public static String intToString(int i) {
         return Integer.toString(i);
     }
 
+    public static int intFromString(String s) throws Exception {
+        return Integer.parseInt(s.strip());
+    }
+
     public static String longToString(long i) {
         return Long.toString(i);
     }
 
+    public static long longFromString(String s) throws Exception {
+        return Long.parseLong(s.strip());
+    }
+
     public static String bigIntegerToString(BigInteger i) {
         return i.toString();
+    }
+
+    public static BigInteger bigIntegerFromString(String s) throws Exception {
+        return new BigInteger(s.strip());
     }
 
     public static String floatToString(float d) {
@@ -56,8 +79,5 @@ public class InterimReadShow {
         return Double.toString(d);
     }
 
-    public static BigInteger bigIntegerFromString(String s) throws Exception {
-        return new BigInteger(s.trim());
-    }
 
 }

--- a/main/src/flix/runtime/library/InterimReadShow.java
+++ b/main/src/flix/runtime/library/InterimReadShow.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Stephen Tetley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flix.runtime.library;
+
+import java.math.BigInteger;
+
+/**
+ * A wrapper class for reading and showing primitive types that provides concrete, non-overloaded methods.
+ *
+ * Flix can resolve overloading for Java's `parseInt` family of functions, so these do not
+ * need wrappers, but we need to supply a non-overloaded "reader" for BigInteger.
+ *
+ * Note - This is considered an interim solution for reading and showing primitive types.
+ */
+public class InterimReadShow {
+
+    public static String byteToString(byte i) {
+        return Byte.toString(i);
+    }
+
+    public static String shortToString(short i) {
+        return Short.toString(i);
+    }
+
+    public static String intToString(int i) {
+        return Integer.toString(i);
+    }
+
+    public static String longToString(long i) {
+        return Long.toString(i);
+    }
+
+    public static String bigIntegerToString(BigInteger i) {
+        return i.toString();
+    }
+
+    public static String floatToString(float d) {
+        return Float.toString(d);
+    }
+
+    public static String doubleToString(double d) {
+        return Double.toString(d);
+    }
+
+    public static BigInteger bigIntegerFromString(String s) throws Exception {
+        return new BigInteger(s.trim());
+    }
+
+}

--- a/main/src/library/BigInt.flix
+++ b/main/src/library/BigInt.flix
@@ -78,4 +78,20 @@ namespace BigInt {
     ///
     pub def flipBit(x: BigInt, position: Int32): BigInt = x ^^^ (1ii <<< position)
 
+    ///
+    /// Return a string representation of `x`.
+    ///
+    pub def toString(x: BigInt): Str =
+        native method flix.runtime.library.InterimReadShow.bigIntegerToString(x) as Str
+
+    ///
+    /// Parse the string `s` as an BigInt.
+    /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
+    ///
+    pub def fromString(s: Str): Result[BigInt, Str] = try {
+         let i = native method flix.runtime.library.InterimReadShow.bigIntegerFromString(s) as BigInt;
+         Ok(i)
+     } catch {
+         case _: ##java.lang.NumberFormatException => Err("BigInt.fromString")
+     }
 }

--- a/main/src/library/BigInt.flix
+++ b/main/src/library/BigInt.flix
@@ -85,7 +85,7 @@ namespace BigInt {
         native method flix.runtime.library.InterimReadShow.bigIntegerToString(x) as Str
 
     ///
-    /// Parse the string `s` as an BigInt.
+    /// Parse the string `s` as an BigInt, leading or trailing whitespace is trimmed.
     /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
     ///
     pub def fromString(s: Str): Result[BigInt, Str] = try {

--- a/main/src/library/Float32.flix
+++ b/main/src/library/Float32.flix
@@ -93,7 +93,7 @@ namespace Float32 {
         native method flix.runtime.library.InterimReadShow.floatToString(x) as Str
 
     ///
-    /// Parse the string `s` as a Float32.
+    /// Parse the string `s` as a Float32, leading or trailing whitespace is trimmed.
     /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
     ///
     pub def fromString(s: Str): Result[Float32, Str] = try {

--- a/main/src/library/Float32.flix
+++ b/main/src/library/Float32.flix
@@ -85,4 +85,21 @@ namespace Float32 {
     /// Returns the larger of `x` and `y`.
     ///
     pub def max(x: Float32, y: Float32): Float32 = if (x >= y) x else y
+
+    ///
+    /// Return a string representation of `x`.
+    ///
+    pub def toString(x: Float32): Str =
+        native method flix.runtime.library.InterimReadShow.floatToString(x) as Str
+
+    ///
+    /// Parse the string `s` as a Float32.
+    /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
+    ///
+    pub def fromString(s: Str): Result[Float32, Str] = try {
+         let i = native method java.lang.Float.parseFloat(s) as Float32;
+         Ok(i)
+     } catch {
+         case _: ##java.lang.NumberFormatException => Err("Float32.fromString")
+     }
 }

--- a/main/src/library/Float64.flix
+++ b/main/src/library/Float64.flix
@@ -85,4 +85,21 @@ namespace Float64 {
     /// Returns the larger of `x` and `y`.
     ///
     pub def max(x: Float64, y: Float64): Float64 = if (x >= y) x else y
+
+    ///
+    /// Return a string representation of `x`.
+    ///
+    pub def toString(x: Float64): Str =
+        native method flix.runtime.library.InterimReadShow.doubleToString(x) as Str
+
+    ///
+    /// Parse the string `s` as a Float64.
+    /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
+    ///
+    pub def fromString(s: Str): Result[Float64, Str] = try {
+         let i = native method java.lang.Double.parseDouble(s) as Float64;
+         Ok(i)
+     } catch {
+         case _: ##java.lang.NumberFormatException => Err("Float64.fromString")
+     }
 }

--- a/main/src/library/Float64.flix
+++ b/main/src/library/Float64.flix
@@ -93,7 +93,7 @@ namespace Float64 {
         native method flix.runtime.library.InterimReadShow.doubleToString(x) as Str
 
     ///
-    /// Parse the string `s` as a Float64.
+    /// Parse the string `s` as a Float64, leading or trailing whitespace is trimmed.
     /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
     ///
     pub def fromString(s: Str): Result[Float64, Str] = try {

--- a/main/src/library/Int16.flix
+++ b/main/src/library/Int16.flix
@@ -246,11 +246,11 @@ namespace Int16 {
         native method flix.runtime.library.InterimReadShow.shortToString(x) as Str
 
     ///
-    /// Parse the string `s` as an Int16.
+    /// Parse the string `s` as an Int16, leading or trailing whitespace is trimmed.
     /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
     ///
     pub def fromString(s: Str): Result[Int16, Str] = try {
-         let i = native method java.lang.Short.parseShort(s) as Int16;
+         let i = native method flix.runtime.library.InterimReadShow.shortFromString(s) as Int16;
          Ok(i)
      } catch {
          case _: ##java.lang.NumberFormatException => Err("Int16.fromString")

--- a/main/src/library/Int16.flix
+++ b/main/src/library/Int16.flix
@@ -250,7 +250,7 @@ namespace Int16 {
     /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
     ///
     pub def fromString(s: Str): Result[Int16, Str] = try {
-         let i = native method java.lang.Byte.parseByte(s) as Int16;
+         let i = native method java.lang.Short.parseShort(s) as Int16;
          Ok(i)
      } catch {
          case _: ##java.lang.NumberFormatException => Err("Int16.fromString")

--- a/main/src/library/Int16.flix
+++ b/main/src/library/Int16.flix
@@ -238,4 +238,21 @@ namespace Int16 {
     /// The bits of x have positions: 0 (rightmost bit) - 15 (leftmost bit)
     ///
     pub def flipBit(x: Int16, position: Int32): Int16 = x ^^^ (1i16 <<< position)
+
+    ///
+    /// Return a string representation of `x`.
+    ///
+    pub def toString(x: Int16): Str =
+        native method flix.runtime.library.InterimReadShow.shortToString(x) as Str
+
+    ///
+    /// Parse the string `s` as an Int16.
+    /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
+    ///
+    pub def fromString(s: Str): Result[Int16, Str] = try {
+         let i = native method java.lang.Byte.parseByte(s) as Int16;
+         Ok(i)
+     } catch {
+         case _: ##java.lang.NumberFormatException => Err("Int16.fromString")
+     }
 }

--- a/main/src/library/Int32.flix
+++ b/main/src/library/Int32.flix
@@ -242,11 +242,11 @@ namespace Int32 {
         native method flix.runtime.library.InterimReadShow.intToString(x) as Str
 
     ///
-    /// Parse the string `s` as an Int32.
+    /// Parse the string `s` as an Int32, leading or trailing whitespace is trimmed.
     /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
     ///
     pub def fromString(s: Str): Result[Int32, Str] = try {
-         let i = native method java.lang.Integer.parseInt(s) as Int32;
+         let i = native method flix.runtime.library.InterimReadShow.intFromString(s) as Int32;
          Ok(i)
      } catch {
          case _: ##java.lang.NumberFormatException => Err("Int32.fromString")

--- a/main/src/library/Int32.flix
+++ b/main/src/library/Int32.flix
@@ -234,4 +234,21 @@ namespace Int32 {
     /// The bits of x have positions: 0 (rightmost bit) - 31 (leftmost bit)
     ///
     pub def flipBit(x: Int32, position: Int32): Int32 = x ^^^ (1 <<< position)
+
+    ///
+    /// Return a string representation of `x`.
+    ///
+    pub def toString(x: Int32): Str =
+        native method flix.runtime.library.InterimReadShow.intToString(x) as Str
+
+    ///
+    /// Parse the string `s` as an Int32.
+    /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
+    ///
+    pub def fromString(s: Str): Result[Int32, Str] = try {
+         let i = native method java.lang.Integer.parseInt(s) as Int32;
+         Ok(i)
+     } catch {
+         case _: ##java.lang.NumberFormatException => Err("Int32.fromString")
+     }
 }

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -242,11 +242,11 @@ namespace Int64 {
         native method flix.runtime.library.InterimReadShow.longToString(x) as Str
 
     ///
-    /// Parse the string `s` as an Int64.
+    /// Parse the string `s` as an Int64, leading or trailing whitespace is trimmed.
     /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
     ///
     pub def fromString(s: Str): Result[Int64, Str] = try {
-         let i = native method java.lang.Long.parseLong(s) as Int64;
+         let i = native method flix.runtime.library.InterimReadShow.longFromString(s) as Int64;
          Ok(i)
      } catch {
          case _: ##java.lang.NumberFormatException => Err("Int64.fromString")

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -246,7 +246,7 @@ namespace Int64 {
     /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
     ///
     pub def fromString(s: Str): Result[Int64, Str] = try {
-         let i = native method java.lang.Integer.parseInt(s) as Int64;
+         let i = native method java.lang.Long.parseLong(s) as Int64;
          Ok(i)
      } catch {
          case _: ##java.lang.NumberFormatException => Err("Int64.fromString")

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -234,4 +234,21 @@ namespace Int64 {
     /// The bits of x have positions: 0 (rightmost bit) - 63 (leftmost bit)
     ///
     pub def flipBit(x: Int64, position: Int32): Int64 = x ^^^ (1i64 <<< position)
+
+    ///
+    /// Return a string representation of `x`.
+    ///
+    pub def toString(x: Int64): Str =
+        native method flix.runtime.library.InterimReadShow.longToString(x) as Str
+
+    ///
+    /// Parse the string `s` as an Int64.
+    /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
+    ///
+    pub def fromString(s: Str): Result[Int64, Str] = try {
+         let i = native method java.lang.Integer.parseInt(s) as Int64;
+         Ok(i)
+     } catch {
+         case _: ##java.lang.NumberFormatException => Err("Int64.fromString")
+     }
 }

--- a/main/src/library/Int8.flix
+++ b/main/src/library/Int8.flix
@@ -238,4 +238,21 @@ namespace Int8 {
     /// The bits of x have positions: 0 (rightmost bit) - 7 (leftmost bit)
     ///
     pub def flipBit(x: Int8, position: Int32): Int8 = x ^^^ (1i8 <<< position)
+
+    ///
+    /// Return a string representation of `x`.
+    ///
+    pub def toString(x: Int8): Str =
+        native method flix.runtime.library.InterimReadShow.byteToString(x) as Str
+
+    ///
+    /// Parse the string `s` as an Int8.
+    /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
+    ///
+    pub def fromString(s: Str): Result[Int8, Str] = try {
+         let i = native method java.lang.Byte.parseByte(s) as Int8;
+         Ok(i)
+     } catch {
+         case _: ##java.lang.NumberFormatException => Err("Int8.fromString")
+     }
 }

--- a/main/src/library/Int8.flix
+++ b/main/src/library/Int8.flix
@@ -246,11 +246,11 @@ namespace Int8 {
         native method flix.runtime.library.InterimReadShow.byteToString(x) as Str
 
     ///
-    /// Parse the string `s` as an Int8.
+    /// Parse the string `s` as an Int8, leading or trailing whitespace is trimmed.
     /// A successful parse is wrapped with `OK(x)`, a parse failure is indicated by `Err(_)`.
     ///
     pub def fromString(s: Str): Result[Int8, Str] = try {
-         let i = native method java.lang.Byte.parseByte(s) as Int8;
+         let i = native method flix.runtime.library.InterimReadShow.byteFromString(s) as Int8;
          Ok(i)
      } catch {
          case _: ##java.lang.NumberFormatException => Err("Int8.fromString")

--- a/main/test/ca/uwaterloo/flix/library/TestBigInt.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestBigInt.flix
@@ -361,3 +361,48 @@ def flipBit12(): Bool = BigInt.flipBit(-1ii, 31) `assertEq!` -2147483649ii
 
 @test
 def flipBit13(): Bool = BigInt.flipBit(-1ii, 32) `assertEq!` -4294967297ii
+
+/////////////////////////////////////////////////////////////////////////////
+// toString                                                                //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def toString01(): Bool = BigInt.toString(0ii) == "0"
+
+@test
+def toString02(): Bool = BigInt.toString(1ii) == "1"
+
+@test
+def toString03(): Bool = BigInt.toString(-1ii) == "-1"
+
+@test
+def toString04(): Bool = BigInt.toString(3498457932459234592873452983453245ii) == "3498457932459234592873452983453245"
+
+@test
+def toString05(): Bool = BigInt.toString(-3498457932459234592873452983453245ii) == "-3498457932459234592873452983453245"
+
+/////////////////////////////////////////////////////////////////////////////
+// fromString                                                              //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def fromString01(): Bool = BigInt.fromString("Bad") |> Result.isErr
+
+@test
+def fromString02(): Bool = BigInt.fromString(" 1") == Ok(1ii)
+
+@test
+def fromString03(): Bool = BigInt.fromString("1 ") == Ok(1ii)
+
+@test
+def fromString04(): Bool = BigInt.fromString("0") == Ok(0ii)
+
+@test
+def fromString05(): Bool = BigInt.fromString("1") == Ok(1ii)
+
+@test
+def fromString06(): Bool = BigInt.fromString("-1") == Ok(-1ii)
+
+@test
+def fromString07(): Bool = BigInt.fromString("3498457932459234592873452983453245") == Ok(3498457932459234592873452983453245ii)
+
+@test
+def fromString08(): Bool = BigInt.fromString("-3498457932459234592873452983453245") == Ok(-3498457932459234592873452983453245ii)

--- a/main/test/ca/uwaterloo/flix/library/TestFloat32.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFloat32.flix
@@ -166,3 +166,69 @@ def max02(): Bool = Float32.max(4.0f32, -16.0f32) `assertEq!` 4.0f32
 
 @test
 def max03(): Bool = Float32.max(-34.0f32, -16.0f32) `assertEq!` -16.0f32
+
+/////////////////////////////////////////////////////////////////////////////
+// toString                                                                //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def toString01(): Bool = Float32.toString(0.0f32) == "0.0"
+
+@test
+def toString02(): Bool = Float32.toString(1.0f32) == "1.0"
+
+@test
+def toString03(): Bool = Float32.toString(-1.0f32) == "-1.0"
+
+@test
+def toString04(): Bool = Float32.toString(3.14f32) == "3.14"
+
+@test
+def toString05(): Bool = Float32.toString(-3.14f32) == "-3.14"
+
+@test
+def toString06(): Bool = Float32.toString(Float32.nan()) == "NaN"
+
+@test
+def toString07(): Bool = Float32.toString(Float32.positiveInfinity()) == "Infinity"
+
+@test
+def toString08(): Bool = Float32.toString(Float32.negativeInfinity()) == "-Infinity"
+
+/////////////////////////////////////////////////////////////////////////////
+// fromString                                                              //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def fromString01(): Bool = Float32.fromString("Bad") |> Result.isErr
+
+@test
+def fromString02(): Bool = Float32.fromString(" 1.0") == Ok(1.0f32)
+
+@test
+def fromString03(): Bool = Float32.fromString("1.0 ") == Ok(1.0f32)
+
+@test
+def fromString04(): Bool = Float32.fromString("0.0") == Ok(0.0f32)
+
+@test
+def fromString05(): Bool = Float32.fromString("1.0") == Ok(1.0f32)
+
+@test
+def fromString06(): Bool = Float32.fromString("-1.0") == Ok(-1.0f32)
+
+@test
+def fromString07(): Bool = Float32.fromString("3.14") == Ok(3.14f32)
+
+@test
+def fromString08(): Bool = Float32.fromString("-3.14") == Ok(-3.14f32)
+
+@test
+def fromString09(): Bool = match Float32.fromString("NaN") {
+    case Ok(x)  => Float32.isNan(x)
+    case _ => false
+}
+
+@test
+def fromString10(): Bool = Float32.fromString("Infinity") == Ok(Float32.positiveInfinity())
+
+@test
+def fromString11(): Bool = Float32.fromString("-Infinity") == Ok(Float32.negativeInfinity())

--- a/main/test/ca/uwaterloo/flix/library/TestFloat64.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFloat64.flix
@@ -166,3 +166,69 @@ def max02(): Bool = Float64.max(4.0f64, -16.0f64) `assertEq!` 4.0f64
 
 @test
 def max03(): Bool = Float64.max(-34.0f64, -16.0f64) `assertEq!` -16.0f64
+
+/////////////////////////////////////////////////////////////////////////////
+// toString                                                                //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def toString01(): Bool = Float64.toString(0.0f64) == "0.0"
+
+@test
+def toString02(): Bool = Float64.toString(1.0f64) == "1.0"
+
+@test
+def toString03(): Bool = Float64.toString(-1.0f64) == "-1.0"
+
+@test
+def toString04(): Bool = Float64.toString(3.14f64) == "3.14"
+
+@test
+def toString05(): Bool = Float64.toString(-3.14f64) == "-3.14"
+
+@test
+def toString06(): Bool = Float64.toString(Float64.nan()) == "NaN"
+
+@test
+def toString07(): Bool = Float64.toString(Float64.positiveInfinity()) == "Infinity"
+
+@test
+def toString08(): Bool = Float64.toString(Float64.negativeInfinity()) == "-Infinity"
+
+/////////////////////////////////////////////////////////////////////////////
+// fromString                                                              //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def fromString01(): Bool = Float64.fromString("Bad") |> Result.isErr
+
+@test
+def fromString02(): Bool = Float64.fromString(" 1.0") == Ok(1.0f64)
+
+@test
+def fromString03(): Bool = Float64.fromString("1.0 ") == Ok(1.0f64)
+
+@test
+def fromString04(): Bool = Float64.fromString("0.0") == Ok(0.0f64)
+
+@test
+def fromString05(): Bool = Float64.fromString("1.0") == Ok(1.0f64)
+
+@test
+def fromString06(): Bool = Float64.fromString("-1.0") == Ok(-1.0f64)
+
+@test
+def fromString07(): Bool = Float64.fromString("3.14") == Ok(3.14f64)
+
+@test
+def fromString08(): Bool = Float64.fromString("-3.14") == Ok(-3.14f64)
+
+@test
+def fromString09(): Bool = match Float64.fromString("NaN") {
+    case Ok(x)  => Float64.isNan(x)
+    case _ => false
+}
+
+@test
+def fromString10(): Bool = Float64.fromString("Infinity") == Ok(Float64.positiveInfinity())
+
+@test
+def fromString11(): Bool = Float64.fromString("-Infinity") == Ok(Float64.negativeInfinity())

--- a/main/test/ca/uwaterloo/flix/library/TestInt16.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt16.flix
@@ -684,10 +684,10 @@ def toString05(): Bool = Int16.toString(-32768i16) == "-32768"
 def fromString01(): Bool = Int16.fromString("Bad") |> Result.isErr
 
 @test
-def fromString02(): Bool = Int16.fromString(" 1") |> Result.isErr
+def fromString02(): Bool = Int16.fromString(" 1") == Ok(1i16)
 
 @test
-def fromString03(): Bool = Int16.fromString("1 ") |> Result.isErr
+def fromString03(): Bool = Int16.fromString("1 ") == Ok(1i16)
 
 @test
 def fromString04(): Bool = Int16.fromString("0") == Ok(0i16)

--- a/main/test/ca/uwaterloo/flix/library/TestInt16.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt16.flix
@@ -658,3 +658,48 @@ def flipBit11(): Bool = Int16.flipBit(-1i16, 13) `assertEq!` (-1i16-(1i16 <<< 13
 
 @test
 def flipBit12(): Bool = Int16.flipBit(-1i16, 32) `assertEq!` -2i16
+
+/////////////////////////////////////////////////////////////////////////////
+// toString                                                                //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def toString01(): Bool = Int16.toString(0i16) == "0"
+
+@test
+def toString02(): Bool = Int16.toString(1i16) == "1"
+
+@test
+def toString03(): Bool = Int16.toString(-1i16) == "-1"
+
+@test
+def toString04(): Bool = Int16.toString(32767i16) == "32767"
+
+@test
+def toString05(): Bool = Int16.toString(-32768i16) == "-32768"
+
+/////////////////////////////////////////////////////////////////////////////
+// fromString                                                              //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def fromString01(): Bool = Int16.fromString("Bad") |> Result.isErr
+
+@test
+def fromString02(): Bool = Int16.fromString(" 1") |> Result.isErr
+
+@test
+def fromString03(): Bool = Int16.fromString("1 ") |> Result.isErr
+
+@test
+def fromString04(): Bool = Int16.fromString("0") == Ok(0i16)
+
+@test
+def fromString05(): Bool = Int16.fromString("1") == Ok(1i16)
+
+@test
+def fromString06(): Bool = Int16.fromString("-1") == Ok(-1i16)
+
+@test
+def fromString07(): Bool = Int16.fromString("32767") == Ok(32767i16)
+
+@test
+def fromString08(): Bool = Int16.fromString("-32768") == Ok(-32768i16)

--- a/main/test/ca/uwaterloo/flix/library/TestInt32.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt32.flix
@@ -618,10 +618,10 @@ def toString05(): Bool = Int32.toString(-2147483648) == "-2147483648"
 def fromString01(): Bool = Int32.fromString("Bad") |> Result.isErr
 
 @test
-def fromString02(): Bool = Int32.fromString(" 1") |> Result.isErr
+def fromString02(): Bool = Int32.fromString(" 1") == Ok(1)
 
 @test
-def fromString03(): Bool = Int32.fromString("1 ") |> Result.isErr
+def fromString03(): Bool = Int32.fromString("1 ") == Ok(1)
 
 @test
 def fromString04(): Bool = Int32.fromString("0") == Ok(0)

--- a/main/test/ca/uwaterloo/flix/library/TestInt32.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt32.flix
@@ -592,3 +592,48 @@ def flipBit11(): Bool = Int32.flipBit(-1, 31) `assertEq!` 2147483647
 
 @test
 def flipBit12(): Bool = Int32.flipBit(-1, 32) `assertEq!` -2
+
+/////////////////////////////////////////////////////////////////////////////
+// toString                                                                //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def toString01(): Bool = Int32.toString(0) == "0"
+
+@test
+def toString02(): Bool = Int32.toString(1) == "1"
+
+@test
+def toString03(): Bool = Int32.toString(-1) == "-1"
+
+@test
+def toString04(): Bool = Int32.toString(2147483647) == "2147483647"
+
+@test
+def toString05(): Bool = Int32.toString(-2147483648) == "-2147483648"
+
+/////////////////////////////////////////////////////////////////////////////
+// fromString                                                              //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def fromString01(): Bool = Int32.fromString("Bad") |> Result.isErr
+
+@test
+def fromString02(): Bool = Int32.fromString(" 1") |> Result.isErr
+
+@test
+def fromString03(): Bool = Int32.fromString("1 ") |> Result.isErr
+
+@test
+def fromString04(): Bool = Int32.fromString("0") == Ok(0)
+
+@test
+def fromString05(): Bool = Int32.fromString("1") == Ok(1)
+
+@test
+def fromString06(): Bool = Int32.fromString("-1") == Ok(-1)
+
+@test
+def fromString07(): Bool = Int32.fromString("2147483647") == Ok(2147483647)
+
+@test
+def fromString08(): Bool = Int32.fromString("-2147483648") == Ok(-2147483648)

--- a/main/test/ca/uwaterloo/flix/library/TestInt64.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt64.flix
@@ -631,3 +631,48 @@ def flipBit11(): Bool = Int64.flipBit(-1i64, 31) `assertEq!` (-1i64-(1i64 <<< 31
 
 @test
 def flipBit12(): Bool = Int64.flipBit(-1i64, 64) `assertEq!` -2i64
+
+/////////////////////////////////////////////////////////////////////////////
+// toString                                                                //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def toString01(): Bool = Int64.toString(0i64) == "0"
+
+@test
+def toString02(): Bool = Int64.toString(1i64) == "1"
+
+@test
+def toString03(): Bool = Int64.toString(-1i64) == "-1"
+
+@test
+def toString04(): Bool = Int64.toString(9223372036854775807i64) == "9223372036854775807"
+
+@test
+def toString05(): Bool = Int64.toString(-9223372036854775808i64) == "-9223372036854775808"
+
+/////////////////////////////////////////////////////////////////////////////
+// fromString                                                              //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def fromString01(): Bool = Int64.fromString("Bad") |> Result.isErr
+
+@test
+def fromString02(): Bool = Int64.fromString(" 1") |> Result.isErr
+
+@test
+def fromString03(): Bool = Int64.fromString("1 ") |> Result.isErr
+
+@test
+def fromString04(): Bool = Int64.fromString("0") == Ok(0i64)
+
+@test
+def fromString05(): Bool = Int64.fromString("1") == Ok(1i64)
+
+@test
+def fromString06(): Bool = Int64.fromString("-1") == Ok(-1i64)
+
+@test
+def fromString07(): Bool = Int64.fromString("9223372036854775807") == Ok(9223372036854775807i64)
+
+@test
+def fromString08(): Bool = Int64.fromString("-9223372036854775808") == Ok(-9223372036854775808i64)

--- a/main/test/ca/uwaterloo/flix/library/TestInt64.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt64.flix
@@ -657,10 +657,10 @@ def toString05(): Bool = Int64.toString(-9223372036854775808i64) == "-9223372036
 def fromString01(): Bool = Int64.fromString("Bad") |> Result.isErr
 
 @test
-def fromString02(): Bool = Int64.fromString(" 1") |> Result.isErr
+def fromString02(): Bool = Int64.fromString(" 1") == Ok(1i64)
 
 @test
-def fromString03(): Bool = Int64.fromString("1 ") |> Result.isErr
+def fromString03(): Bool = Int64.fromString("1 ") == Ok(1i64)
 
 @test
 def fromString04(): Bool = Int64.fromString("0") == Ok(0i64)

--- a/main/test/ca/uwaterloo/flix/library/TestInt8.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt8.flix
@@ -681,10 +681,10 @@ def toString05(): Bool = Int8.toString(-128i8) == "-128"
 def fromString01(): Bool = Int8.fromString("Bad") |> Result.isErr
 
 @test
-def fromString02(): Bool = Int8.fromString(" 1") |> Result.isErr
+def fromString02(): Bool = Int8.fromString(" 1") == Ok(1i8)
 
 @test
-def fromString03(): Bool = Int8.fromString("1 ") |> Result.isErr
+def fromString03(): Bool = Int8.fromString("1 ") == Ok(1i8)
 
 @test
 def fromString04(): Bool = Int8.fromString("0") == Ok(0i8)

--- a/main/test/ca/uwaterloo/flix/library/TestInt8.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt8.flix
@@ -660,19 +660,19 @@ def flipBit12(): Bool = Int8.flipBit(-1i8, 32) `assertEq!` -2i8
 // toString                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toString01(): Bool = Int8.toString(0i8)  == "0"
+def toString01(): Bool = Int8.toString(0i8) == "0"
 
 @test
-def toString02(): Bool = Int8.toString(1i8)  == "1"
+def toString02(): Bool = Int8.toString(1i8) == "1"
 
 @test
-def toString03(): Bool = Int8.toString(-1i8)  == "-1"
+def toString03(): Bool = Int8.toString(-1i8) == "-1"
 
 @test
-def toString04(): Bool = Int8.toString(127i8)  == "127"
+def toString04(): Bool = Int8.toString(127i8) == "127"
 
 @test
-def toString05(): Bool = Int8.toString(-127i8)  == "-127"
+def toString05(): Bool = Int8.toString(-128i8) == "-128"
 
 /////////////////////////////////////////////////////////////////////////////
 // fromString                                                              //
@@ -687,16 +687,16 @@ def fromString02(): Bool = Int8.fromString(" 1") |> Result.isErr
 def fromString03(): Bool = Int8.fromString("1 ") |> Result.isErr
 
 @test
-def fromString04(): Bool = Int8.fromString("0")  == Ok(0i8)
+def fromString04(): Bool = Int8.fromString("0") == Ok(0i8)
 
 @test
-def fromString05(): Bool = Int8.fromString("1")  == Ok(1i8)
+def fromString05(): Bool = Int8.fromString("1") == Ok(1i8)
 
 @test
-def fromString06(): Bool = Int8.fromString("-1")  == Ok(-1i8)
+def fromString06(): Bool = Int8.fromString("-1") == Ok(-1i8)
 
 @test
-def fromString07(): Bool = Int8.fromString("127")  == Ok(127i8)
+def fromString07(): Bool = Int8.fromString("127") == Ok(127i8)
 
 @test
-def fromString08(): Bool = Int8.fromString("-127")  == Ok(-127i8)
+def fromString08(): Bool = Int8.fromString("-128") == Ok(-128i8)

--- a/main/test/ca/uwaterloo/flix/library/TestInt8.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt8.flix
@@ -655,3 +655,48 @@ def flipBit11(): Bool = Int8.flipBit(-1i8, 5) `assertEq!` (-1i8-(1i8 <<< 5))
 
 @test
 def flipBit12(): Bool = Int8.flipBit(-1i8, 32) `assertEq!` -2i8
+
+/////////////////////////////////////////////////////////////////////////////
+// toString                                                                //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def toString01(): Bool = Int8.toString(0i8)  == "0"
+
+@test
+def toString02(): Bool = Int8.toString(1i8)  == "1"
+
+@test
+def toString03(): Bool = Int8.toString(-1i8)  == "-1"
+
+@test
+def toString04(): Bool = Int8.toString(127i8)  == "127"
+
+@test
+def toString05(): Bool = Int8.toString(-127i8)  == "-127"
+
+/////////////////////////////////////////////////////////////////////////////
+// fromString                                                              //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def fromString01(): Bool = Int8.fromString("Bad") |> Result.isErr
+
+@test
+def fromString02(): Bool = Int8.fromString(" 1") |> Result.isErr
+
+@test
+def fromString03(): Bool = Int8.fromString("1 ") |> Result.isErr
+
+@test
+def fromString04(): Bool = Int8.fromString("0")  == Ok(0i8)
+
+@test
+def fromString05(): Bool = Int8.fromString("1")  == Ok(1i8)
+
+@test
+def fromString06(): Bool = Int8.fromString("-1")  == Ok(-1i8)
+
+@test
+def fromString07(): Bool = Int8.fromString("127")  == Ok(127i8)
+
+@test
+def fromString08(): Bool = Int8.fromString("-127")  == Ok(-127i8)


### PR DESCRIPTION
Hi Magnus - here's a pull request for `toString` / `fromString` on the numeric types.

I've decided to follow an "allow leading or trailing whitespace" principle for the `fromString` functions. In Java the float and double "parse" functions allow leading and trailing whitespace but the integer parse functions don't. This inconsistency doesn't feel like the best choice. 

Choosing "allow leading or trailing whitespace" has meant I have to manually trim the input first for the integer parsers which makes them slower than they could be if you know their input doesn't have whitespace, but it seems a bit of a shame to make the float and double parses less flexible by testing if their input has whitespace and returning Err(_) if it does.

I'm certainly happy to change to "disallow all whitespace" if you prefer that. I do have a definite preference for consistency though in this case, and would prefer not to follow Java.


The tests on Float32 and Float64 aren't particularly taxing (though they do cover infinities and NaN). For tests, I'm a bit concerned precision and  floating point equality so I didn't test on numbers with significant decimal places.