### PR TITLE
Refactor record types

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
@@ -50,12 +50,7 @@ object Kind {
   /**
     * The kind of predicate sets.
     */
-  case object PredicateSet extends Kind
-
-  /**
-    * The kind of predicates.
-    */
-  case object Predicate extends Kind
+  case object SchemaRow extends Kind
 
   /**
     * The kind of natural number expressions.
@@ -85,7 +80,7 @@ object Kind {
     def show(a: Kind): String = a match {
       case Kind.Star => "*"
       case Kind.RecordRow => "RecordRow"
-      case Kind.Schema => "Schema"
+      case Kind.SchemaRow => "SchemaRow"
       case Kind.Nat => "Nat"
       case Kind.Effect => "Effect"
       case Kind.Arrow(List(Kind.Star), Kind.Star) => "* -> *"

--- a/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
@@ -43,14 +43,19 @@ object Kind {
   case object Star extends Kind
 
   /**
-    * The kind of records.
+    * The kind of records row sets.
     */
-  case object Record extends Kind
+  case object RecordRowSet extends Kind
 
   /**
-    * The kind of schemas.
+    * The kind of predicate sets.
     */
-  case object Schema extends Kind
+  case object PredicateSet extends Kind
+
+  /**
+    * The kind of predicates.
+    */
+  case object Predicate extends Kind
 
   /**
     * The kind of natural number expressions.

--- a/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
@@ -45,7 +45,7 @@ object Kind {
   /**
     * The kind of records row sets.
     */
-  case object RecordRowSet extends Kind
+  case object RecordRow extends Kind
 
   /**
     * The kind of predicate sets.
@@ -84,7 +84,7 @@ object Kind {
   implicit object ShowInstance extends Show[Kind] {
     def show(a: Kind): String = a match {
       case Kind.Star => "*"
-      case Kind.Record => "Record"
+      case Kind.RecordRow => "RecordRow"
       case Kind.Schema => "Schema"
       case Kind.Nat => "Nat"
       case Kind.Effect => "Effect"

--- a/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
@@ -66,9 +66,11 @@ object MonoType {
 
   case class Arrow(args: List[MonoType], result: MonoType) extends MonoType
 
-  case class RecordEmpty() extends MonoType
+  case class EmptyRecordRow() extends MonoType
 
-  case class RecordExtend(label: String, value: MonoType, rest: MonoType) extends MonoType
+  case class ExtendedRecordRow(label: String, value: MonoType, rest: MonoType) extends MonoType
+
+  case class Record(row: MonoType) extends MonoType
 
   case class SchemaEmpty() extends MonoType
 

--- a/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
@@ -66,11 +66,9 @@ object MonoType {
 
   case class Arrow(args: List[MonoType], result: MonoType) extends MonoType
 
-  case class EmptyRecordRow() extends MonoType
+  case class RecordEmpty() extends MonoType
 
-  case class ExtendedRecordRow(label: String, value: MonoType, rest: MonoType) extends MonoType
-
-  case class Record(row: MonoType) extends MonoType
+  case class RecordExtend(label: String, value: MonoType, rest: MonoType) extends MonoType
 
   case class SchemaEmpty() extends MonoType
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -287,6 +287,8 @@ object NamedAst {
 
     case class RecordEmpty(loc: SourceLocation) extends NamedAst.Type
 
+    case class RecordVar(tpe: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
+
     case class RecordExtend(label: Name.Ident, field: NamedAst.Type, rest: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
 
     case class SchemaEmpty(loc: SourceLocation) extends NamedAst.Type

--- a/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
@@ -43,8 +43,6 @@ object Scheme {
       case Type.Var(x, k) => freshVars.getOrElse(x, t0)
       case Type.Cst(tc) => Type.Cst(tc)
       case Type.Arrow(l, eff) => Type.Arrow(l, visitType(eff))
-      case Type.RecordEmpty => Type.RecordEmpty
-      case Type.RecordExtend(label, value, rest) => Type.RecordExtend(label, visitType(value), visitType(rest))
       case Type.SchemaEmpty => Type.SchemaEmpty
       case Type.SchemaExtend(sym, t, rest) => Type.SchemaExtend(sym, visitType(t), visitType(rest))
       case Type.Zero => Type.Zero

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -386,7 +386,7 @@ object Type {
   /**
     * Extends the record row `rest` with the given type and label.
     */
-  def mkExtendRecordRow(label: String, tpe: Type, rest: Type): Type = {
+  def mkExtendedRecordRow(label: String, tpe: Type, rest: Type): Type = {
     val extendedRow = mkApply(Type.Cst(TypeConstructor.ExtendedRecordRow(label)), List(tpe, rest))
     Type.Apply(Type.Cst(TypeConstructor.Record), extendedRow)
   }

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -386,9 +386,19 @@ object Type {
   /**
     * Extends the record row `rest` with the given type and label.
     */
-  def mkExtendRecordRow(label: String, tpe: Type, rest: Type): Type = {
+  def mkExtendedRecordRow(label: String, tpe: Type, rest: Type): Type = {
     val extendedRow = mkApply(Type.Cst(TypeConstructor.ExtendedRecordRow(label)), List(tpe, rest))
     Type.Apply(Type.Cst(TypeConstructor.Record), extendedRow)
+  }
+
+  // MATT this and the above method form a sort of wrapper case class thing. Is there a better way to do this?
+  object matchExtendedRecordRow {
+    def unapply(arg: Type): Option[(String, Type, Type)] = {
+      arg match {
+        case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.ExtendedRecordRow(label)), tpe), rest) => Some((label, tpe, rest))
+        case _ => None
+      }
+    }
   }
 
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -196,6 +196,11 @@ object Type {
     */
   val Impure: Type = Type.Cst(TypeConstructor.Impure)
 
+  /**
+    * Represents the empty record row.
+    */
+  val EmptyRecordRow: Type = Type.Cst(TypeConstructor.EmptyRecordRow)
+
   /////////////////////////////////////////////////////////////////////////////
   // Types                                                                   //
   /////////////////////////////////////////////////////////////////////////////
@@ -368,6 +373,15 @@ object Type {
       case (acc, x) => Apply(acc, x)
     }
   }
+
+  /**
+    * Extends the record row `rest` with the given type and label.
+    */
+  def mkExtendRecordRow(label: String, tpe: Type, rest: Type): Type = {
+    val extendedRow = mkApply(Type.Cst(TypeConstructor.ExtendedRecordRow(label)), List(tpe, rest))
+    Type.Apply(Type.Cst(TypeConstructor.Record), extendedRow)
+  }
+
 
   /////////////////////////////////////////////////////////////////////////////
   // Type Class Instances                                                    //

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -386,19 +386,9 @@ object Type {
   /**
     * Extends the record row `rest` with the given type and label.
     */
-  def mkExtendedRecordRow(label: String, tpe: Type, rest: Type): Type = {
+  def mkExtendRecordRow(label: String, tpe: Type, rest: Type): Type = {
     val extendedRow = mkApply(Type.Cst(TypeConstructor.ExtendedRecordRow(label)), List(tpe, rest))
     Type.Apply(Type.Cst(TypeConstructor.Record), extendedRow)
-  }
-
-  // MATT this and the above method form a sort of wrapper case class thing. Is there a better way to do this?
-  object matchExtendedRecordRow {
-    def unapply(arg: Type): Option[(String, Type, Type)] = {
-      arg match {
-        case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.ExtendedRecordRow(label)), tpe), rest) => Some((label, tpe, rest))
-        case _ => None
-      }
-    }
   }
 
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -383,7 +383,6 @@ object Type {
     }
   }
 
-  // MATT maybe we don't need to have all of these
   /**
     * Extends the record row `rest` with the given type and label.
     */
@@ -392,13 +391,8 @@ object Type {
   }
 
   /**
-    * Fully constructs the record row.
+    * Construct a record from a record row.
     */
-  def mkExtendedRecord(label: String, tpe: Type, rest: Type): Type = {
-    mkRecord(mkExtendedRecordRow(label, tpe, rest))
-  }
-
-  // MATT docs
   def mkRecord(row: Type): Type = {
     mkApply(Type.Cst(TypeConstructor.Record), List(row))
   }

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -255,34 +255,6 @@ object Type {
   }
 
   /**
-    * A type constructor that represents the empty record type.
-    */
-  case object RecordEmpty extends Type {
-    def kind: Kind = Kind.Record
-  }
-
-  /**
-    * A type constructor that represents a record extension type.
-    */
-  case class RecordExtend(label: String, value: Type, rest: Type) extends Type {
-    def kind: Kind = Kind.Star -> Kind.Record
-  }
-
-  /**
-    * A type constructor that represents the empty schema type.
-    */
-  case object SchemaEmpty extends Type {
-    def kind: Kind = Kind.Schema
-  }
-
-  /**
-    * A type constructor that represents a schema extension type.
-    */
-  case class SchemaExtend(sym: Symbol.PredSym, tpe: Type, rest: Type) extends Type {
-    def kind: Kind = Kind.Star -> Kind.Schema
-  }
-
-  /**
     * A type constructor that represents zero.
     */
   case object Zero extends Type {

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -383,12 +383,24 @@ object Type {
     }
   }
 
+  // MATT maybe we don't need to have all of these
   /**
     * Extends the record row `rest` with the given type and label.
     */
   def mkExtendedRecordRow(label: String, tpe: Type, rest: Type): Type = {
-    val extendedRow = mkApply(Type.Cst(TypeConstructor.ExtendedRecordRow(label)), List(tpe, rest))
-    Type.Apply(Type.Cst(TypeConstructor.Record), extendedRow)
+    mkApply(Type.Cst(TypeConstructor.ExtendedRecordRow(label)), List(tpe, rest))
+  }
+
+  /**
+    * Fully constructs the record row.
+    */
+  def mkExtendedRecord(label: String, tpe: Type, rest: Type): Type = {
+    mkRecord(mkExtendedRecordRow(label, tpe, rest))
+  }
+
+  // MATT docs
+  def mkRecord(row: Type): Type = {
+    mkApply(Type.Cst(TypeConstructor.Record), List(row))
   }
 
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -87,6 +87,58 @@ object TypeConstructor {
   }
 
   /**
+    * A type constructor that represents the type of records.
+    */
+  case object Record extends TypeConstructor {
+    /**
+      * The shape of a record is Record[r] where r is of kind RecordRow.
+      */
+    def kind: Kind = Kind.RecordRowSet -> Kind.Star
+  }
+
+  /**
+    * A type constructor that represents the type of empty record row sets.
+    */
+  case object EmptyRecordRowSet extends TypeConstructor {
+    def kind: Kind = Kind.RecordRowSet
+  }
+
+  /**
+    * A type constructor that represents the type of extended record row sets.
+    */
+  case object ExpandedRecordRowSet extends TypeConstructor {
+    def kind: Kind = Kind.Star -> Kind.RecordRowSet -> Kind.RecordRowSet
+  }
+
+  /**
+    * A type constructor that represents the type of schemas.
+    */
+  case object Schema extends TypeConstructor {
+    def kind: Kind = Kind.PredicateSet -> Kind.Star
+  }
+
+  /**
+    * A type constructor that represents the type of predicate sets.
+    */
+  case object EmptyPredicateSet extends TypeConstructor {
+    def kind: Kind = Kind.PredicateSet
+  }
+
+  /**
+    * A type constructor that represents the type of expanded predicate sets.
+    */
+  case object ExpandedPredicateSet extends TypeConstructor {
+    def kind: Kind = Kind.Predicate -> Kind.PredicateSet -> Kind.PredicateSet
+  }
+
+  /**
+    * A type constructor that represents the type of predicates.
+    */
+  case object Predicate extends TypeConstructor {
+    def kind: Kind = Kind.Predicate
+  }
+
+  /**
     * A type constructor that represent the type of arrays.
     */
   case object Array extends TypeConstructor {

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -114,27 +114,6 @@ object TypeConstructor {
   }
 
   /**
-    * A type constructor that represents the type of schemas.
-    */
-  case object Schema extends TypeConstructor {
-    def kind: Kind = Kind.SchemaRow -> Kind.Star
-  }
-
-  /**
-    * A type constructor that represents the type of schema rows.
-    */
-  case object EmptySchemaRow extends TypeConstructor {
-    def kind: Kind = Kind.SchemaRow
-  }
-
-  /**
-    * A type constructor that represents the type of extended schema rows.
-    */
-  case class ExtendedSchemaRow(sym: Symbol.PredSym) extends TypeConstructor {
-    def kind: Kind = Kind.SchemaRow -> Kind.SchemaRow
-  }
-
-  /**
     * A type constructor that represent the type of arrays.
     */
   case object Array extends TypeConstructor {

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -93,21 +93,24 @@ object TypeConstructor {
     /**
       * The shape of a record is Record[r] where r is of kind RecordRow.
       */
-    def kind: Kind = Kind.RecordRowSet -> Kind.Star
+    def kind: Kind = Kind.RecordRow -> Kind.Star
   }
 
   /**
-    * A type constructor that represents the type of empty record row sets.
+    * A type constructor that represents the type of empty record rows.
     */
-  case object EmptyRecordRowSet extends TypeConstructor {
-    def kind: Kind = Kind.RecordRowSet
+  case object EmptyRecordRow extends TypeConstructor {
+    def kind: Kind = Kind.RecordRow
   }
 
   /**
-    * A type constructor that represents the type of extended record row sets.
+    * A type constructor that represents the type of extended record rows.
     */
-  case object ExpandedRecordRowSet extends TypeConstructor {
-    def kind: Kind = Kind.Star -> Kind.RecordRowSet -> Kind.RecordRowSet
+  case class ExtendedRecordRow(label: String) extends TypeConstructor {
+    /**
+      * The shape of an extended record row is ExtendedRecordRow[t,r] where r is of kind RecordRow.
+      */
+    def kind: Kind = Kind.Star -> Kind.RecordRow -> Kind.RecordRow
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -117,28 +117,21 @@ object TypeConstructor {
     * A type constructor that represents the type of schemas.
     */
   case object Schema extends TypeConstructor {
-    def kind: Kind = Kind.PredicateSet -> Kind.Star
+    def kind: Kind = Kind.SchemaRow -> Kind.Star
   }
 
   /**
-    * A type constructor that represents the type of predicate sets.
+    * A type constructor that represents the type of schema rows.
     */
-  case object EmptyPredicateSet extends TypeConstructor {
-    def kind: Kind = Kind.PredicateSet
+  case object EmptySchemaRow extends TypeConstructor {
+    def kind: Kind = Kind.SchemaRow
   }
 
   /**
-    * A type constructor that represents the type of expanded predicate sets.
+    * A type constructor that represents the type of extended schema rows.
     */
-  case object ExpandedPredicateSet extends TypeConstructor {
-    def kind: Kind = Kind.Predicate -> Kind.PredicateSet -> Kind.PredicateSet
-  }
-
-  /**
-    * A type constructor that represents the type of predicates.
-    */
-  case object Predicate extends TypeConstructor {
-    def kind: Kind = Kind.Predicate
+  case class ExtendedSchemaRow(sym: Symbol.PredSym) extends TypeConstructor {
+    def kind: Kind = Kind.SchemaRow -> Kind.SchemaRow
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -284,6 +284,8 @@ object WeededAst {
 
     case class RecordEmpty(loc: SourceLocation) extends WeededAst.Type
 
+    case class RecordVar(tpe: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
+
     case class RecordExtend(label: Name.Ident, tpe: WeededAst.Type, rest: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
 
     case class SchemaEmpty(loc: SourceLocation) extends WeededAst.Type

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -21,7 +21,7 @@ import java.lang.reflect.{Constructor, Field, Method}
 import ca.uwaterloo.flix.language.CompilationError
 import ca.uwaterloo.flix.language.ast.Ast.Source
 import ca.uwaterloo.flix.language.ast.Type._
-import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, Type}
+import ca.uwaterloo.flix.language.ast.{Name, NamedAst, SourceLocation, Symbol, Type}
 import ca.uwaterloo.flix.util.tc.Show.ShowableSyntax
 import ca.uwaterloo.flix.util.vt.VirtualString._
 import ca.uwaterloo.flix.util.vt.VirtualTerminal

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -174,17 +174,17 @@ object TypeError {
   /**
     * Unexpected non-record type error.
     *
-    * @param tpe the unexpected non-record type.
+    * @param tpe the unexpected non-record row type.
     * @param loc the location where the error occurred.
     */
-  case class NonRecordType(tpe: Type, loc: SourceLocation) extends TypeError {
+  case class NonRecordRowType(tpe: Type, loc: SourceLocation) extends TypeError {
     val source: Source = loc.source
     val message: VirtualTerminal = {
       val vt = new VirtualTerminal()
       vt << Line(kind, source.format) << NewLine
-      vt << ">> Unexpected non-record type: '" << Red(tpe.show) << "'." << NewLine
+      vt << ">> Unexpected non-record row type: '" << Red(tpe.show) << "'." << NewLine
       vt << NewLine
-      vt << Code(loc, "unexpected non-record type.") << NewLine
+      vt << Code(loc, "unexpected non-record row type.") << NewLine
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
@@ -161,6 +161,10 @@ object Documentor extends Phase[TypedAst.Root, TypedAst.Root] {
         case TypeConstructor.BigInt => "BigInt"
         case TypeConstructor.Str => "Str"
 
+        case TypeConstructor.Record => "Record" // MATT fix these to match standard { } pattern
+        case TypeConstructor.EmptyRecordRow => "EmptyRecordRow"
+        case TypeConstructor.ExtendedRecordRow(label) => s"ExtendedRecordRow($label)"
+
         case TypeConstructor.Relation(sym) => sym.toString
 
         case TypeConstructor.Lattice(sym) => sym.toString

--- a/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
@@ -208,11 +208,6 @@ object Documentor extends Phase[TypedAst.Root, TypedAst.Root] {
           "(" + argumentTypes.map(format).mkString(", ") + ") -> " + format(resultType)
         }
 
-      case Type.RecordEmpty => "{ }"
-
-      case Type.RecordExtend(label, value, rest) =>
-        "{" + label + " = " + format(value) + " | " + format(rest) + "}"
-
       case Type.SchemaEmpty => "Schema { }"
 
       case Type.SchemaExtend(sym, t, rest) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
@@ -161,9 +161,9 @@ object Documentor extends Phase[TypedAst.Root, TypedAst.Root] {
         case TypeConstructor.BigInt => "BigInt"
         case TypeConstructor.Str => "Str"
 
-        case TypeConstructor.Record => "Record" // MATT fix these to match standard { } pattern
-        case TypeConstructor.EmptyRecordRow => "EmptyRecordRow"
-        case TypeConstructor.ExtendedRecordRow(label) => s"ExtendedRecordRow($label)"
+        case TypeConstructor.Record => "Record"
+        case TypeConstructor.EmptyRecordRow => "{ }"
+        case TypeConstructor.ExtendedRecordRow(label) => "{" + label + " = " + format(args(0)) + " | " + format(args(1)) + "}"
 
         case TypeConstructor.Relation(sym) => sym.toString
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
@@ -593,6 +593,12 @@ object Finalize extends Phase[SimplifiedAst.Root, FinalAst.Root] {
 
       case Type.Arrow(l, _) => MonoType.Arrow(args.init, args.last)
 
+      case Type.Cst(TypeConstructor.Record) => args.head
+
+      case Type.Cst(TypeConstructor.ExtendedRecordRow(label)) => MonoType.RecordExtend(label, args(0), args(1))
+
+      case Type.Cst(TypeConstructor.EmptyRecordRow) => MonoType.RecordEmpty()
+
       case Type.SchemaEmpty => MonoType.SchemaEmpty()
 
       case Type.SchemaExtend(sym, tpe, rest) => MonoType.SchemaExtend(sym, visitType(tpe), visitType(rest))

--- a/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
@@ -593,10 +593,6 @@ object Finalize extends Phase[SimplifiedAst.Root, FinalAst.Root] {
 
       case Type.Arrow(l, _) => MonoType.Arrow(args.init, args.last)
 
-      case Type.RecordEmpty => MonoType.RecordEmpty()
-
-      case Type.RecordExtend(label, value, rest) => MonoType.RecordExtend(label, visitType(value), visitType(rest))
-
       case Type.SchemaEmpty => MonoType.SchemaEmpty()
 
       case Type.SchemaExtend(sym, tpe, rest) => MonoType.SchemaExtend(sym, visitType(tpe), visitType(rest))

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
@@ -78,11 +78,6 @@ object Monomorph extends Phase[TypedAst.Root, TypedAst.Root] {
         case Type.Var(_, _) => Type.Unit
         case Type.Cst(tc) => Type.Cst(tc)
         case Type.Arrow(l, eff) => Type.Arrow(l, visit(eff))
-        case Type.RecordEmpty => Type.RecordEmpty
-        case Type.RecordExtend(label, value, rest) => rest match {
-          case Type.Var(_, _) => Type.RecordExtend(label, visit(value), Type.RecordEmpty)
-          case _ => Type.RecordExtend(label, visit(value), visit(rest))
-        }
         case Type.SchemaEmpty => Type.SchemaEmpty
         case Type.SchemaExtend(sym, tt, rest) => rest match {
           case Type.Var(_, _) => Type.SchemaExtend(sym, visit(tt), Type.SchemaEmpty)

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -1135,6 +1135,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
     case WeededAst.Type.Unit(loc) => Nil
     case WeededAst.Type.Tuple(elms, loc) => elms.flatMap(freeVars)
     case WeededAst.Type.RecordEmpty(loc) => Nil
+    case WeededAst.Type.RecordVar(tpe, loc) => freeVars(tpe)
     case WeededAst.Type.RecordExtend(l, t, r, loc) => freeVars(t) ::: freeVars(r)
     case WeededAst.Type.SchemaEmpty(loc) => Nil
     case WeededAst.Type.Schema(ts, r, loc) => ts.flatMap(freeVars) ::: freeVars(r)

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -948,6 +948,11 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
     case WeededAst.Type.RecordEmpty(loc) =>
       NamedAst.Type.RecordEmpty(loc).toSuccess
 
+    case WeededAst.Type.RecordVar(tpe, loc) =>
+      mapN(visitType(tpe, tenv0)) {
+        case t => NamedAst.Type.RecordVar(t, loc)
+      }
+
     case WeededAst.Type.RecordExtend(label, value, rest, loc) =>
       mapN(visitType(value, tenv0), visitType(rest, tenv0)) {
         case (t, r) => NamedAst.Type.RecordExtend(label, t, r, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
@@ -741,6 +741,9 @@ object PatternExhaustiveness extends Phase[TypedAst.Root, TypedAst.Root] {
       case Type.Cst(TypeConstructor.Tuple(l)) => l
       case Type.Zero => 0
       case Type.Succ(n, t) => 2
+      case Type.Cst(TypeConstructor.Record) => 1
+      case Type.Cst(TypeConstructor.EmptyRecordRow) => 0
+      case Type.Cst(TypeConstructor.ExtendedRecordRow(_)) => 2
       case Type.SchemaEmpty => 0 // TODO: Correct?
       case Type.SchemaExtend(base, label, value) => 0 // TODO: Correct?
       case Type.Apply(tpe1, tpe2) => countTypeArgs(tpe1)

--- a/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
@@ -741,8 +741,6 @@ object PatternExhaustiveness extends Phase[TypedAst.Root, TypedAst.Root] {
       case Type.Cst(TypeConstructor.Tuple(l)) => l
       case Type.Zero => 0
       case Type.Succ(n, t) => 2
-      case Type.RecordEmpty => 0 // TODO: Correct?
-      case Type.RecordExtend(base, label, value) => 0 // TODO: Correct?
       case Type.SchemaEmpty => 0 // TODO: Correct?
       case Type.SchemaExtend(base, label, value) => 0 // TODO: Correct?
       case Type.Apply(tpe1, tpe2) => countTypeArgs(tpe1)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1149,7 +1149,8 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
       for {
         v <- lookupType(value, ns0, root)
         r <- lookupType(rest, ns0, root)
-      } yield Type.mkExtendRecordRow(label, v, r)
+      } yield Type.mkExtendedRecordRow(label.name, v, r)  // MATT need to translate between records and rows here,
+                                                          // MATT or add Record/ExtendedRow/EmptyRow to NamedAst types?
 
     case NamedAst.Type.SchemaEmpty(loc) =>
       Type.SchemaEmpty.toSuccess

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1149,7 +1149,7 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
       for {
         v <- lookupType(value, ns0, root)
         r <- lookupType(rest, ns0, root)
-      } yield Type.mkExtendedRecordRow(label.name, v, r)
+      } yield Type.mkExtendRecordRow(label, v, r)
 
     case NamedAst.Type.SchemaEmpty(loc) =>
       Type.SchemaEmpty.toSuccess

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1149,7 +1149,7 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
       for {
         v <- lookupType(value, ns0, root)
         r <- lookupType(rest, ns0, root)
-      } yield Type.mkExtendRecordRow(label, v, r)
+      } yield Type.mkExtendedRecordRow(label.name, v, r)
 
     case NamedAst.Type.SchemaEmpty(loc) =>
       Type.SchemaEmpty.toSuccess

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1143,13 +1143,13 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
       ) yield Type.mkTuple(elms)
 
     case NamedAst.Type.RecordEmpty(loc) =>
-      Type.RecordEmpty.toSuccess
+      Type.Apply(Type.Cst(TypeConstructor.Record), Type.Cst(TypeConstructor.EmptyRecordRow)).toSuccess
 
     case NamedAst.Type.RecordExtend(label, value, rest, loc) =>
       for {
         v <- lookupType(value, ns0, root)
         r <- lookupType(rest, ns0, root)
-      } yield Type.RecordExtend(label.name, v, r)
+      } yield Type.mkExtendRecordRow(label, v, r)
 
     case NamedAst.Type.SchemaEmpty(loc) =>
       Type.SchemaEmpty.toSuccess
@@ -1506,13 +1506,6 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
 
       case Type.Arrow(l, eff) => Type.Arrow(l, eval(eff, subst))
 
-      case Type.RecordEmpty => t
-
-      case Type.RecordExtend(label, value, rest) =>
-        val t1 = eval(value, subst)
-        val t2 = eval(rest, subst)
-        Type.RecordExtend(label, t1, t2)
-
       case Type.SchemaEmpty => t
 
       case Type.SchemaExtend(sym, tpe, rest) =>
@@ -1674,10 +1667,6 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
       }
 
     case Type.Cst(TypeConstructor.Native(clazz)) => clazz.toSuccess
-
-    case Type.RecordEmpty => Class.forName("java.lang.Object").toSuccess
-
-    case Type.RecordExtend(_, _, _) => Class.forName("java.lang.Object").toSuccess
 
     case Type.SchemaEmpty => Class.forName("java.lang.Object").toSuccess
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Synthesize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Synthesize.scala
@@ -1293,8 +1293,7 @@ object Synthesize extends Phase[Root, Root] {
       * Returns `true` if `tpe` is a record type.
       */
     def isRecord(tpe: Type): Boolean = tpe.typeConstructor match {
-      case Type.RecordEmpty => true
-      case Type.RecordExtend(base, label, value) => true
+      case Type.Apply(Type.Cst(TypeConstructor.Record), _) => true
       case _ => false
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Synthesize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Synthesize.scala
@@ -1293,7 +1293,7 @@ object Synthesize extends Phase[Root, Root] {
       * Returns `true` if `tpe` is a record type.
       */
     def isRecord(tpe: Type): Boolean = tpe.typeConstructor match {
-      case Type.Apply(Type.Cst(TypeConstructor.Record), _) => true
+      case Type.Cst(TypeConstructor.Record) => true
       case _ => false
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -598,7 +598,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         //  { } : { }
         //
         for {
-          resultType <- unifyTypM(tvar, Type.Apply(Type.Cst(TypeConstructor.Record), Type.EmptyRecordRow), loc)
+          resultType <- unifyTypM(tvar, Type.mkRecord(Type.EmptyRecordRow), loc)
         } yield (resultType, Type.Pure)
 
       case ResolvedAst.Expression.RecordSelect(exp, label, tvar, evar, loc) =>
@@ -608,7 +608,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         // r.label : tpe
         //
         val freshRowVar = Type.freshTypeVarWithKind(Kind.RecordRow)
-        val expectedType = Type.mkExtendedRecord(label, tvar, freshRowVar)
+        val expectedType = Type.mkRecord(Type.mkExtendedRecordRow(label, tvar, freshRowVar))
         for {
           (tpe, eff) <- visitExp(exp)
           recordType <- unifyTypM(tpe, expectedType, loc)
@@ -626,7 +626,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
           (tpe1, eff1) <- visitExp(exp1)
           (tpe2, eff2) <- visitExp(exp2)
           restRecordType <- unifyTypM(Type.mkRecord(restRowType), tpe2, loc)
-          resultTyp <- unifyTypM(tvar, Type.mkExtendedRecord(label, tpe1, restRowType), loc)
+          resultTyp <- unifyTypM(tvar, Type.mkRecord(Type.mkExtendedRecordRow(label, tpe1, restRowType)), loc)
           resultEff <- unifyEffM(evar, mkAnd(eff1, eff2), loc)
         } yield (resultTyp, resultEff)
 
@@ -639,8 +639,8 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         val freshRowVar = Type.freshTypeVarWithKind(Kind.RecordRow)
         for {
           (tpe, eff) <- visitExp(exp)
-          recordTyp <- unifyTypM(tpe, Type.mkExtendedRecord(label, freshFieldType, freshRowVar), loc)
-          resultTyp <- unifyTypM(tvar, Type.Apply(Type.Cst(TypeConstructor.Record), freshRowVar), loc)
+          recordTyp <- unifyTypM(tpe, Type.mkRecord(Type.mkExtendedRecordRow(label, freshFieldType, freshRowVar)), loc)
+          resultTyp <- unifyTypM(tvar, Type.mkRecord(freshRowVar), loc)
           resultEff <- unifyEffM(evar, eff, loc)
         } yield (resultTyp, resultEff)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -598,7 +598,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         //  { } : { }
         //
         for {
-          resultType <- unifyTypM(tvar, Type.RecordEmpty, loc)
+          resultType <- unifyTypM(tvar, Type.Apply(Type.Cst(TypeConstructor.Record), Type.EmptyRecordRow), loc)
         } yield (resultType, Type.Pure)
 
       case ResolvedAst.Expression.RecordSelect(exp, label, tvar, evar, loc) =>
@@ -607,8 +607,8 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         // -------------------------
         // r.label : tpe
         //
-        val freshRowVar = Type.freshTypeVarXXXDeprecated()
-        val expectedType = Type.RecordExtend(label, tvar, freshRowVar)
+        val freshRowVar = Type.freshTypeVarWithKind(Kind.RecordRow)
+        val expectedType = Type.mkExtendRecordRow(label, tvar, freshRowVar)
         for {
           (tpe, eff) <- visitExp(exp)
           recordType <- unifyTypM(tpe, expectedType, loc)
@@ -624,7 +624,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         for {
           (tpe1, eff1) <- visitExp(exp1)
           (tpe2, eff2) <- visitExp(exp2)
-          resultTyp <- unifyTypM(tvar, Type.RecordExtend(label, tpe1, tpe2), loc)
+          resultTyp <- unifyTypM(tvar, Type.mkExtendRecordRow(label, tpe1, tpe2), loc)
           resultEff <- unifyEffM(evar, mkAnd(eff1, eff2), loc)
         } yield (resultTyp, resultEff)
 
@@ -637,7 +637,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         val freshRowVar = Type.freshTypeVarXXXDeprecated()
         for {
           (tpe, eff) <- visitExp(exp)
-          recordType <- unifyTypM(tpe, Type.RecordExtend(label, freshFieldType, freshRowVar), loc)
+          recordType <- unifyTypM(tpe, Type.mkExtendRecordRow(label, freshFieldType, freshRowVar), loc)
           resultTyp <- unifyTypM(tvar, freshRowVar, loc)
           resultEff <- unifyEffM(evar, eff, loc)
         } yield (resultTyp, resultEff)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -608,7 +608,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         // r.label : tpe
         //
         val freshRowVar = Type.freshTypeVarWithKind(Kind.RecordRow)
-        val expectedType = Type.mkExtendedRecordRow(label, tvar, freshRowVar)
+        val expectedType = Type.mkExtendRecordRow(label, tvar, freshRowVar)
         for {
           (tpe, eff) <- visitExp(exp)
           recordType <- unifyTypM(tpe, expectedType, loc)
@@ -624,7 +624,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         for {
           (tpe1, eff1) <- visitExp(exp1)
           (tpe2, eff2) <- visitExp(exp2)
-          resultTyp <- unifyTypM(tvar, Type.mkExtendedRecordRow(label, tpe1, tpe2), loc)
+          resultTyp <- unifyTypM(tvar, Type.mkExtendRecordRow(label, tpe1, tpe2), loc)
           resultEff <- unifyEffM(evar, mkAnd(eff1, eff2), loc)
         } yield (resultTyp, resultEff)
 
@@ -637,7 +637,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         val freshRowVar = Type.freshTypeVarXXXDeprecated()
         for {
           (tpe, eff) <- visitExp(exp)
-          recordType <- unifyTypM(tpe, Type.mkExtendedRecordRow(label, freshFieldType, freshRowVar), loc)
+          recordType <- unifyTypM(tpe, Type.mkExtendRecordRow(label, freshFieldType, freshRowVar), loc)
           resultTyp <- unifyTypM(tvar, freshRowVar, loc)
           resultEff <- unifyEffM(evar, eff, loc)
         } yield (resultTyp, resultEff)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -608,7 +608,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         // r.label : tpe
         //
         val freshRowVar = Type.freshTypeVarWithKind(Kind.RecordRow)
-        val expectedType = Type.mkExtendRecordRow(label, tvar, freshRowVar)
+        val expectedType = Type.mkExtendedRecordRow(label, tvar, freshRowVar)
         for {
           (tpe, eff) <- visitExp(exp)
           recordType <- unifyTypM(tpe, expectedType, loc)
@@ -624,7 +624,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         for {
           (tpe1, eff1) <- visitExp(exp1)
           (tpe2, eff2) <- visitExp(exp2)
-          resultTyp <- unifyTypM(tvar, Type.mkExtendRecordRow(label, tpe1, tpe2), loc)
+          resultTyp <- unifyTypM(tvar, Type.mkExtendedRecordRow(label, tpe1, tpe2), loc)
           resultEff <- unifyEffM(evar, mkAnd(eff1, eff2), loc)
         } yield (resultTyp, resultEff)
 
@@ -637,7 +637,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         val freshRowVar = Type.freshTypeVarXXXDeprecated()
         for {
           (tpe, eff) <- visitExp(exp)
-          recordType <- unifyTypM(tpe, Type.mkExtendRecordRow(label, freshFieldType, freshRowVar), loc)
+          recordType <- unifyTypM(tpe, Type.mkExtendedRecordRow(label, freshFieldType, freshRowVar), loc)
           resultTyp <- unifyTypM(tvar, freshRowVar, loc)
           resultEff <- unifyEffM(evar, eff, loc)
         } yield (resultTyp, resultEff)

--- a/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
@@ -312,7 +312,7 @@ object Unification {
 
       case (Type.SchemaEmpty, Type.SchemaEmpty) => Result.Ok(Substitution.empty)
 
-      case (Type.matchExtendedRecordRow(label1, fieldType1, restRow1), row2) =>
+      case (Type.RecordExtend(label1, fieldType1, restRow1), row2) =>
         // Attempt to write the row to match.
         rewriteRow(row2, label1, fieldType1, row2) flatMap {
           case (subst1, restRow2) =>
@@ -373,7 +373,7 @@ object Unification {
       * Attempts to rewrite the given row type `row2` into a row that has the given label `label1` in front.
       */
     def rewriteRow(row2: Type, label1: String, fieldType1: Type, originalType: Type): Result[(Substitution, Type), UnificationError] = row2 match {
-      case Type.matchExtendedRecordRow(label2, fieldType2, restRow2) =>
+      case Type.RecordExtend(label2, fieldType2, restRow2) =>
         // Case 1: The row is of the form %{ label2: fieldType2 | restRow2 }
         if (label1 == label2) {
           // Case 1.1: The labels match, their types must match.
@@ -383,18 +383,18 @@ object Unification {
         } else {
           // Case 1.2: The labels do not match, attempt to match with a label further down.
           rewriteRow(restRow2, label1, fieldType1, originalType) map {
-            case (subst, rewrittenRow) => (subst, Type.mkExtendedRecordRow(label2, fieldType2, rewrittenRow))
+            case (subst, rewrittenRow) => (subst, Type.RecordExtend(label2, fieldType2, rewrittenRow))
           }
         }
       case tvar: Type.Var =>
         // Case 2: The row is a type variable.
         // Introduce a fresh type variable to represent one more level of the row.
         val restRow2 = Type.freshTypeVarXXXDeprecated()
-        val type2 = Type.mkExtendedRecordRow(label1, fieldType1, restRow2)
+        val type2 = Type.RecordExtend(label1, fieldType1, restRow2)
         val subst = Unification.Substitution.singleton(tvar, type2)
         Ok((subst, restRow2))
 
-      case Type.EmptyRecordRow =>
+      case Type.RecordEmpty =>
         // Case 3: The `label` does not exist in the record.
         Err(UnificationError.UndefinedLabel(label1, fieldType1, originalType))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
@@ -79,8 +79,6 @@ object Unification {
             }
           case Type.Cst(tc) => Type.Cst(tc)
           case Type.Arrow(l, eff) => Type.Arrow(l, visit(eff))
-          case Type.RecordEmpty => Type.RecordEmpty
-          case Type.RecordExtend(label, field, rest) => Type.RecordExtend(label, visit(field), visit(rest))
           case Type.SchemaEmpty => Type.SchemaEmpty
           case Type.SchemaExtend(sym, tpe, rest) => Type.SchemaExtend(sym, visit(tpe), visit(rest))
           case Type.Zero => Type.Zero
@@ -311,8 +309,6 @@ object Unification {
           Result.Err(UnificationError.MismatchedTypes(tpe1, tpe2))
 
       case (Type.Arrow(l1, eff1), Type.Arrow(l2, eff2)) if l1 == l2 => unifyEffects(eff1, eff2)
-
-      case (Type.RecordEmpty, Type.RecordEmpty) => Result.Ok(Substitution.empty)
 
       case (Type.SchemaEmpty, Type.SchemaEmpty) => Result.Ok(Substitution.empty)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
@@ -312,8 +312,7 @@ object Unification {
 
       case (Type.SchemaEmpty, Type.SchemaEmpty) => Result.Ok(Substitution.empty)
 
-      case (Type.RecordExtend(label1, fieldType1, restRow1), row2) =>
-        // Attempt to write the row to match.
+      case (Type.Apply(Type.Apply(Type.Cst(TypeConstructor.ExtendedRecordRow(label1)), fieldType1), restRow1), row2) =>
         rewriteRow(row2, label1, fieldType1, row2) flatMap {
           case (subst1, restRow2) =>
             // TODO: Missing the safety/occurs check.
@@ -373,7 +372,7 @@ object Unification {
       * Attempts to rewrite the given row type `row2` into a row that has the given label `label1` in front.
       */
     def rewriteRow(row2: Type, label1: String, fieldType1: Type, originalType: Type): Result[(Substitution, Type), UnificationError] = row2 match {
-      case Type.RecordExtend(label2, fieldType2, restRow2) =>
+      case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.ExtendedRecordRow(label2)), fieldType2), restRow2) =>
         // Case 1: The row is of the form %{ label2: fieldType2 | restRow2 }
         if (label1 == label2) {
           // Case 1.1: The labels match, their types must match.
@@ -383,18 +382,18 @@ object Unification {
         } else {
           // Case 1.2: The labels do not match, attempt to match with a label further down.
           rewriteRow(restRow2, label1, fieldType1, originalType) map {
-            case (subst, rewrittenRow) => (subst, Type.RecordExtend(label2, fieldType2, rewrittenRow))
+            case (subst, rewrittenRow) => (subst, Type.mkExtendedRecordRow(label2, fieldType2, rewrittenRow))
           }
         }
       case tvar: Type.Var =>
         // Case 2: The row is a type variable.
         // Introduce a fresh type variable to represent one more level of the row.
         val restRow2 = Type.freshTypeVarXXXDeprecated()
-        val type2 = Type.RecordExtend(label1, fieldType1, restRow2)
+        val type2 = Type.mkExtendedRecordRow(label1, fieldType1, restRow2)
         val subst = Unification.Substitution.singleton(tvar, type2)
         Ok((subst, restRow2))
 
-      case Type.RecordEmpty =>
+      case Type.EmptyRecordRow =>
         // Case 3: The `label` does not exist in the record.
         Err(UnificationError.UndefinedLabel(label1, fieldType1, originalType))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
@@ -238,9 +238,9 @@ object Unification {
     /**
       * An unification error due to an unexpected non-record type.
       *
-      * @param nonRecordType the unexpected non-record type.
+      * @param nonRecordRowType the unexpected non-record type.
       */
-    case class NonRecordType(nonRecordType: Type) extends UnificationError
+    case class NonRecordRowType(nonRecordRowType: Type) extends UnificationError
 
     /**
       * An unification error due to an unexpected non-schema type.
@@ -397,7 +397,7 @@ object Unification {
 
       case _ =>
         // Case 4: The type is not a row.
-        Err(UnificationError.NonRecordType(row2)) // MATT NonRecordRowType
+        Err(UnificationError.NonRecordRowType(row2))
     }
 
     /**
@@ -535,8 +535,8 @@ object Unification {
         case Result.Err(UnificationError.UndefinedLabel(fieldName, fieldType, recordType)) =>
           Err(TypeError.UndefinedField(fieldName, fieldType, recordType, loc))
 
-        case Result.Err(UnificationError.NonRecordType(tpe)) =>
-          Err(TypeError.NonRecordType(tpe, loc))
+        case Result.Err(UnificationError.NonRecordRowType(tpe)) =>
+          Err(TypeError.NonRecordRowType(tpe, loc))
 
         case Result.Err(UnificationError.UndefinedPredicate(predSym, predType, schemaType)) =>
           Err(TypeError.UndefinedPredicate(predSym, predType, schemaType, loc))

--- a/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
@@ -25,8 +25,6 @@ import ca.uwaterloo.flix.util.{InternalCompilerException, Result}
 import scala.annotation.tailrec
 
 object Unification {
-
-
   /**
     * Aliases to make the success variable elimination easier to understand.
     */
@@ -399,7 +397,7 @@ object Unification {
 
       case _ =>
         // Case 4: The type is not a row.
-        Err(UnificationError.NonRecordType(row2))
+        Err(UnificationError.NonRecordType(row2)) // MATT NonRecordRowType
     }
 
     /**
@@ -455,7 +453,7 @@ object Unification {
       */
     def successiveVariableElimination(eff: Type, fvs: List[Type.Var]): (Substitution, Type) = fvs match {
       case Nil => (Substitution.empty, eff)
-        // TODO: Check that eff is false is here. Then return Some(subst) otherwise None.
+      // TODO: Check that eff is false is here. Then return Some(subst) otherwise None.
       case x :: xs =>
         val t0 = Substitution.singleton(x, False)(eff)
         val t1 = Substitution.singleton(x, True)(eff)

--- a/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
@@ -312,7 +312,7 @@ object Unification {
 
       case (Type.SchemaEmpty, Type.SchemaEmpty) => Result.Ok(Substitution.empty)
 
-      case (Type.RecordExtend(label1, fieldType1, restRow1), row2) =>
+      case (Type.matchExtendedRecordRow(label1, fieldType1, restRow1), row2) =>
         // Attempt to write the row to match.
         rewriteRow(row2, label1, fieldType1, row2) flatMap {
           case (subst1, restRow2) =>
@@ -373,7 +373,7 @@ object Unification {
       * Attempts to rewrite the given row type `row2` into a row that has the given label `label1` in front.
       */
     def rewriteRow(row2: Type, label1: String, fieldType1: Type, originalType: Type): Result[(Substitution, Type), UnificationError] = row2 match {
-      case Type.RecordExtend(label2, fieldType2, restRow2) =>
+      case Type.matchExtendedRecordRow(label2, fieldType2, restRow2) =>
         // Case 1: The row is of the form %{ label2: fieldType2 | restRow2 }
         if (label1 == label2) {
           // Case 1.1: The labels match, their types must match.
@@ -383,18 +383,18 @@ object Unification {
         } else {
           // Case 1.2: The labels do not match, attempt to match with a label further down.
           rewriteRow(restRow2, label1, fieldType1, originalType) map {
-            case (subst, rewrittenRow) => (subst, Type.RecordExtend(label2, fieldType2, rewrittenRow))
+            case (subst, rewrittenRow) => (subst, Type.mkExtendedRecordRow(label2, fieldType2, rewrittenRow))
           }
         }
       case tvar: Type.Var =>
         // Case 2: The row is a type variable.
         // Introduce a fresh type variable to represent one more level of the row.
         val restRow2 = Type.freshTypeVarXXXDeprecated()
-        val type2 = Type.RecordExtend(label1, fieldType1, restRow2)
+        val type2 = Type.mkExtendedRecordRow(label1, fieldType1, restRow2)
         val subst = Unification.Substitution.singleton(tvar, type2)
         Ok((subst, restRow2))
 
-      case Type.RecordEmpty =>
+      case Type.EmptyRecordRow =>
         // Case 3: The `label` does not exist in the record.
         Err(UnificationError.UndefinedLabel(label1, fieldType1, originalType))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1581,7 +1581,7 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
 
     case ParsedAst.Type.Record(sp1, fields, restOpt, sp2) =>
       if (fields.isEmpty && restOpt.isDefined) {
-        val tpe = WeededAst.Type.Var(restOpt.get, mkSL(sp1, sp2)) // MATT more precise SL?
+        val tpe = WeededAst.Type.Var(restOpt.get, restOpt.get.loc)
         WeededAst.Type.RecordVar(tpe, mkSL(sp1, sp2))
       } else {
         val init = restOpt match {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -830,16 +830,15 @@ object JvmOps {
       Type.Apply(base, args)
 
     case MonoType.Tuple(length) => Type.Cst(TypeConstructor.Tuple(0)) // hack
-    case MonoType.RecordEmpty() => Type.Apply(Type.Cst(TypeConstructor.Record), Type.EmptyRecordRow)
-    case record @ MonoType.RecordExtend(_, _, _) => Type.Apply(Type.Cst(TypeConstructor.Record), hackMonotype2Row(record))
+    case MonoType.RecordEmpty() => Type.mkRecord(Type.EmptyRecordRow)
+    case record @ MonoType.RecordExtend(_, _, _) => Type.mkRecord(hackMonotype2RecordRow(record))
     case MonoType.SchemaEmpty() => Type.SchemaEmpty
     case MonoType.SchemaExtend(sym, t, rest) => Type.SchemaExtend(sym, hackMonoType2Type(t), hackMonoType2Type(rest))
   }
 
-  // MATT docs
-  private def hackMonotype2Row(tpe: MonoType): Type = tpe match {
+  private def hackMonotype2RecordRow(tpe: MonoType): Type = tpe match {
     case MonoType.RecordEmpty() => Type.EmptyRecordRow
-    case MonoType.RecordExtend(label, value, rest) => Type.mkExtendedRecordRow(label, hackMonoType2Type(value), hackMonotype2Row(rest))
+    case MonoType.RecordExtend(label, value, rest) => Type.mkExtendedRecordRow(label, hackMonoType2Type(value), hackMonotype2RecordRow(rest))
     case _ => throw InternalCompilerException(s"Unexpected type: $tpe")
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -830,10 +830,17 @@ object JvmOps {
       Type.Apply(base, args)
 
     case MonoType.Tuple(length) => Type.Cst(TypeConstructor.Tuple(0)) // hack
-    case MonoType.RecordEmpty() => Type.RecordEmpty
-    case MonoType.RecordExtend(label, value, rest) => Type.RecordExtend(label, hackMonoType2Type(value), hackMonoType2Type(rest))
+    case MonoType.RecordEmpty() => Type.Apply(Type.Cst(TypeConstructor.Record), Type.EmptyRecordRow)
+    case record @ MonoType.RecordExtend(_, _, _) => Type.Apply(Type.Cst(TypeConstructor.Record), hackMonotype2Row(record))
     case MonoType.SchemaEmpty() => Type.SchemaEmpty
     case MonoType.SchemaExtend(sym, t, rest) => Type.SchemaExtend(sym, hackMonoType2Type(t), hackMonoType2Type(rest))
+  }
+
+  // MATT docs
+  private def hackMonotype2Row(tpe: MonoType): Type = tpe match {
+    case MonoType.RecordEmpty() => Type.EmptyRecordRow
+    case MonoType.RecordExtend(label, value, rest) => Type.mkExtendedRecordRow(label, hackMonoType2Type(value), hackMonotype2Row(rest))
+    case _ => throw InternalCompilerException(s"Unexpected type: $tpe")
   }
 
   // TODO: Remove

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -830,9 +830,8 @@ object JvmOps {
       Type.Apply(base, args)
 
     case MonoType.Tuple(length) => Type.Cst(TypeConstructor.Tuple(0)) // hack
-    case MonoType.EmptyRecordRow() => Type.EmptyRecordRow
-    case MonoType.ExtendedRecordRow(label, value, rest) => Type.mkExtendedRecordRow(label, hackMonoType2Type(value), hackMonoType2Type(rest))
-    case MonoType.Record(row) => Type.Apply(Type.Cst(TypeConstructor.Record), hackMonoType2Type(row))
+    case MonoType.RecordEmpty() => Type.RecordEmpty
+    case MonoType.RecordExtend(label, value, rest) => Type.RecordExtend(label, hackMonoType2Type(value), hackMonoType2Type(rest))
     case MonoType.SchemaEmpty() => Type.SchemaEmpty
     case MonoType.SchemaExtend(sym, t, rest) => Type.SchemaExtend(sym, hackMonoType2Type(t), hackMonoType2Type(rest))
   }
@@ -1152,9 +1151,8 @@ object JvmOps {
         }
       case MonoType.Arrow(targs, tresult) => targs.flatMap(nestedTypesOf).toSet ++ nestedTypesOf(tresult) + tpe
 
-      case MonoType.EmptyRecordRow() => Set(tpe)
-      case MonoType.ExtendedRecordRow(_, value, rest) => Set(tpe) ++ nestedTypesOf(value) ++ nestedTypesOf(rest)
-      case MonoType.Record(row) => Set(tpe) ++ nestedTypesOf(row)
+      case MonoType.RecordEmpty() => Set(tpe)
+      case MonoType.RecordExtend(label, value, rest) => Set(tpe) ++ nestedTypesOf(value) ++ nestedTypesOf(rest)
 
       case MonoType.SchemaEmpty() => Set(tpe)
       case MonoType.SchemaExtend(sym, t, rest) => nestedTypesOf(t) ++ nestedTypesOf(rest) + t + rest

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -830,8 +830,9 @@ object JvmOps {
       Type.Apply(base, args)
 
     case MonoType.Tuple(length) => Type.Cst(TypeConstructor.Tuple(0)) // hack
-    case MonoType.RecordEmpty() => Type.RecordEmpty
-    case MonoType.RecordExtend(label, value, rest) => Type.RecordExtend(label, hackMonoType2Type(value), hackMonoType2Type(rest))
+    case MonoType.EmptyRecordRow() => Type.EmptyRecordRow
+    case MonoType.ExtendedRecordRow(label, value, rest) => Type.mkExtendedRecordRow(label, hackMonoType2Type(value), hackMonoType2Type(rest))
+    case MonoType.Record(row) => Type.Apply(Type.Cst(TypeConstructor.Record), hackMonoType2Type(row))
     case MonoType.SchemaEmpty() => Type.SchemaEmpty
     case MonoType.SchemaExtend(sym, t, rest) => Type.SchemaExtend(sym, hackMonoType2Type(t), hackMonoType2Type(rest))
   }
@@ -1151,8 +1152,9 @@ object JvmOps {
         }
       case MonoType.Arrow(targs, tresult) => targs.flatMap(nestedTypesOf).toSet ++ nestedTypesOf(tresult) + tpe
 
-      case MonoType.RecordEmpty() => Set(tpe)
-      case MonoType.RecordExtend(label, value, rest) => Set(tpe) ++ nestedTypesOf(value) ++ nestedTypesOf(rest)
+      case MonoType.EmptyRecordRow() => Set(tpe)
+      case MonoType.ExtendedRecordRow(_, value, rest) => Set(tpe) ++ nestedTypesOf(value) ++ nestedTypesOf(rest)
+      case MonoType.Record(row) => Set(tpe) ++ nestedTypesOf(row)
 
       case MonoType.SchemaEmpty() => Set(tpe)
       case MonoType.SchemaExtend(sym, t, rest) => nestedTypesOf(t) ++ nestedTypesOf(rest) + t + rest

--- a/main/src/ca/uwaterloo/flix/util/vt/TerminalContext.scala
+++ b/main/src/ca/uwaterloo/flix/util/vt/TerminalContext.scala
@@ -95,7 +95,6 @@ object TerminalContext {
     def emitBold(s: String): String = Console.BOLD + s + Console.RESET
 
     def emitUnderline(s: String): String = Console.UNDERLINED + s + Console.RESET
-
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/language/feature/Test.Expression.Record.Polymorphism.flix
+++ b/main/test/ca/uwaterloo/flix/language/feature/Test.Expression.Record.Polymorphism.flix
@@ -72,7 +72,7 @@ def testRecordPolyExtend01(): Unit =
     let _p8 = withColor(p4, "Black");
     ()
 
-def withColor[r](rec: r, col: Str): { color: Str | r } =
+def withColor[r](rec: { | r }, col: Str): { color: Str | r } =
     { +color = col | rec }
 
 @test
@@ -87,7 +87,7 @@ def testRecordPolyExtend02(): Unit =
     let _p8 = withAgeAndSex(42, "f", p4);
     ()
 
-def withAgeAndSex[r](age: Int, sex: Str, rec: r): { age: Int, sex: Str | r } =
+def withAgeAndSex[r](age: Int, sex: Str, rec: { | r }): { age: Int, sex: Str | r } =
     { +age = age, +sex = sex | rec }
 
 @test


### PR DESCRIPTION
Initial changes to record and schema types to ensure well-kindedness.

This separates the rows of records from the records themselves, allowing records to be proper types (*) while kind-checking their contents.

Similarly, for schemas we separate the predicates from the schema, allowing schemas to be proper types (*). The difference for predicates is that the the component types of predicates are not proper types themselves (e.g., we cannot, as far as I know, say `let a = IsConnected(1, 2)`).

The current implementation does not maintain label information, so one of the next steps is to look into that.