### PR TITLE
Well-kinded records

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -347,6 +347,7 @@ class Flix {
     val si1 = getStringInputs
     val si2 = getPathInputs
     val si3 = if (options.core) Nil else getStandardLibraryInputs
+//    val si3 = Nil // MATT
     si1 ::: si2 ::: si3
   }
 

--- a/main/src/ca/uwaterloo/flix/language/GenSym.scala
+++ b/main/src/ca/uwaterloo/flix/language/GenSym.scala
@@ -29,7 +29,7 @@ final class GenSym() {
     * Returns a freshly generated unique id.
     */
   def freshId(): Int = {
-    if (counter.get() == 87) {
+    if (List(3, 17, 14319).contains(counter.get())) {
       System.err.println("hello")
     }
     counter.getAndIncrement()

--- a/main/src/ca/uwaterloo/flix/language/GenSym.scala
+++ b/main/src/ca/uwaterloo/flix/language/GenSym.scala
@@ -29,6 +29,9 @@ final class GenSym() {
     * Returns a freshly generated unique id.
     */
   def freshId(): Int = {
+    if (counter.get() == 87) {
+      System.err.println("hello")
+    }
     counter.getAndIncrement()
   }
 

--- a/main/src/ca/uwaterloo/flix/language/GenSym.scala
+++ b/main/src/ca/uwaterloo/flix/language/GenSym.scala
@@ -29,7 +29,7 @@ final class GenSym() {
     * Returns a freshly generated unique id.
     */
   def freshId(): Int = {
-    if (List(3, 17, 14319).contains(counter.get())) {
+    if (List().contains(counter.get())) {
       System.err.println("hello")
     }
     counter.getAndIncrement()

--- a/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
@@ -33,25 +33,6 @@ sealed trait Kind {
     */
   override def toString: String = Kind.ShowInstance.show(this)
 
-  /**
-    * The kind this kind extends.
-    */
-  protected val superKind: Option[Kind] = None
-
-  /**
-    * Returns true iff this kind extends `that` kind directly or indirectly.
-    */
-  def extendsKind(that: Kind): Boolean = {
-    if (this == that) {
-      true
-    } else {
-      superKind match {
-        case None => false
-        case Some(other) => other.extendsKind(that)
-      }
-    }
-  }
-
 }
 
 object Kind {
@@ -64,9 +45,7 @@ object Kind {
   /**
     * The kind of records.
     */
-  case object Record extends Kind {
-    override val superKind: Option[Kind] = Some(Star)
-  }
+  case object Record extends Kind
 
   /**
     * The kind of schemas.
@@ -88,14 +67,6 @@ object Kind {
     */
   case class Arrow(kparams: List[Kind], kr: Kind) extends Kind {
     assert(kparams.nonEmpty)
-
-    override def extendsKind(that: Kind): Boolean = {
-      that match {
-        case Arrow(kparam1, kr1) =>
-          kparams.corresponds(kparam1)(_.extendsKind(_)) && kr.extendsKind(kr1)
-        case _ => false
-      }
-    }
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
@@ -26,7 +26,7 @@ sealed trait Kind {
   /**
     * Constructs an arrow kind.
     */
-  def ->(that: Kind): Kind = Kind.Arrow(List(this), that)
+  def ->:(left: Kind): Kind = Kind.Arrow(List(left), this)
 
   /**
     * Returns a human readable representation of `this` kind.
@@ -83,10 +83,9 @@ object Kind {
       case Kind.Schema => "Schema"
       case Kind.Nat => "Nat"
       case Kind.Effect => "Effect"
-      case Kind.Arrow(List(Kind.Star), Kind.Star) => "* -> *"
-      case Kind.Arrow(List(Kind.Star), kr) => s"* -> ($kr)"
-      case Kind.Arrow(kparams, Kind.Star) => s"(${kparams.mkString(", ")}) -> *"
-      case Kind.Arrow(kparams, kr) => s"(${kparams.mkString(", ")}) -> ($kr)"
+      case Kind.Arrow(List(kparam@ Arrow(_, _)), kr) => s"($kparam) -> $kr"
+      case Kind.Arrow(List(kparam), kr) => s"$kparam -> $kr"
+      case Kind.Arrow(kparams, kr) => s"(${kparams.mkString(", ")}) -> $kr"
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
@@ -52,6 +52,12 @@ object Kind {
     */
   case object Schema extends Kind
 
+  // MATT docs
+  case object Relation extends Kind
+
+  // MATT docs
+  case object Lattice extends Kind
+
   /**
     * The kind of natural number expressions.
     */
@@ -81,6 +87,8 @@ object Kind {
       case Kind.Star => "*"
       case Kind.Record => "Record"
       case Kind.Schema => "Schema"
+      case Kind.Relation => "Relation"
+      case Kind.Lattice => "Lattice"
       case Kind.Nat => "Nat"
       case Kind.Effect => "Effect"
       case Kind.Arrow(List(kparam@ Arrow(_, _)), kr) => s"($kparam) -> $kr"

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -281,7 +281,7 @@ object NamedAst {
 
     case class Unit(loc: SourceLocation) extends NamedAst.Type
 
-    case class Enum(name: Symbol.EnumSym) extends NamedAst.Type
+    case class Enum(name: Symbol.EnumSym, arity: Int) extends NamedAst.Type
 
     case class Tuple(elms: List[NamedAst.Type], loc: SourceLocation) extends NamedAst.Type
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
@@ -33,7 +33,7 @@ object Scheme {
     */
   private def refreshTypeVars(typeVars: List[Type.Var], tpe: Type)(implicit flix: Flix): Type = {
     val freshVars = typeVars.foldLeft(Map.empty[Int, Type.Var]) {
-      case (macc, tvar) => macc + (tvar.id -> Type.freshTypeVar(tvar.kind))
+      case (macc, tvar) => macc + (tvar.id -> Type.freshTypeVarWithKind(tvar.kind))
     }
 
     /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
@@ -43,8 +43,6 @@ object Scheme {
       case Type.Var(x, k) => freshVars.getOrElse(x, t0)
       case Type.Cst(tc) => Type.Cst(tc)
       case Type.Arrow(l, eff) => Type.Arrow(l, visitType(eff))
-      case Type.SchemaEmpty => Type.SchemaEmpty
-      case Type.SchemaExtend(sym, t, rest) => Type.SchemaExtend(sym, visitType(t), visitType(rest))
       case Type.Zero => Type.Zero
       case Type.Succ(n, t) => Type.Succ(n, t)
       case Type.Apply(tpe1, tpe2) => Type.Apply(visitType(tpe1), visitType(tpe2))

--- a/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
@@ -43,8 +43,6 @@ object Scheme {
       case Type.Var(x, k) => freshVars.getOrElse(x, t0)
       case Type.Cst(tc) => Type.Cst(tc)
       case Type.Arrow(l, eff) => Type.Arrow(l, visitType(eff))
-      case Type.RecordEmpty => Type.RecordEmpty
-      case Type.RecordExtend(label, value, rest) => Type.RecordExtend(label, visitType(value), visitType(rest))
       case Type.SchemaEmpty => Type.SchemaEmpty
       case Type.SchemaExtend(sym, t, rest) => Type.SchemaExtend(sym, visitType(t), visitType(rest))
       case Type.Zero => Type.Zero

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -346,7 +346,7 @@ object Symbol {
   /**
     * A common super-type for predicate symbols.
     */
-  trait PredSym
+  sealed trait PredSym
 
   /**
     * Relation Symbol.

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -376,10 +376,19 @@ object Type {
     * Constructs the tuple type (A, B, ...) where the types are drawn from the list `ts`.
     */
   def mkTuple(ts: List[Type]): Type = {
+    require(ts.lengthIs > 1) // MATT change to internalcompilerexcpetion
     val tuple = Type.Cst(TypeConstructor.Tuple(ts.length))
     ts.foldLeft(tuple: Type) {
       case (acc, x) => Apply(acc, x)
     }
+  }
+
+  // MATT rename or replace mkTuple or something
+  // MATT docs
+  def mkTupleSmart(ts: List[Type]): Type = ts match {
+    case Nil => Type.Unit
+    case List(elem) => elem
+    case _ => mkTuple(ts)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -104,11 +104,10 @@ sealed trait Type {
     case Type.Apply(tpe1, tpe2) => tpe1.size + tpe2.size + 1
   }
 
-//  /**
-//    * Returns a human readable string representation of `this` type.
-//    */
-//  override def toString: String = Type.fmtType(this, renameVars = false)
-  // MATT
+  /**
+    * Returns a human readable string representation of `this` type.
+    */
+  override def toString: String = Type.fmtType(this, renameVars = false)
 
 }
 
@@ -257,7 +256,7 @@ object Type {
     * A type constructor that represents a schema extension type.
     */
   case class SchemaExtend(sym: Symbol.PredSym, tpe: Type, rest: Type) extends Type {
-    def kind: Kind = Kind.Star -> Kind.Schema
+    def kind: Kind = Kind.Star ->: Kind.Schema
   }
 
   /**
@@ -278,7 +277,7 @@ object Type {
     * A type expression that represents a type abstraction [x] => tpe.
     */
   case class Lambda(tvar: Type.Var, tpe: Type) extends Type {
-    def kind: Kind = Kind.Star -> Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Star
   }
 
   /**
@@ -293,12 +292,12 @@ object Type {
       */
     def kind: Kind = {
       tpe1.kind match {
-        case Kind.Arrow(kparams, k) => kparams match { // MATT can this kind be simplified?
+        case Kind.Arrow(kparams, k) => kparams match {
           case _ :: Nil => k
           case _ :: tail => Kind.Arrow(tail, k)
-          case _ => throw InternalCompilerException("Illegal kind.") // MATT include kind info
+          case _ => throw InternalCompilerException(s"Illegal kind: '${tpe1.kind}' of type '$tpe1''")
         }
-        case _ => throw InternalCompilerException("Illegal kind.")
+        case _ => throw InternalCompilerException(s"Illegal kind: '${tpe1.kind}' of type '$tpe1''")
       }
     }
   }
@@ -321,10 +320,13 @@ object Type {
     */
   def freshEffectVar()(implicit flix: Flix): Type.Var = Type.Var(flix.genSym.freshId(), Kind.Effect)
 
-  // MATT docs
+  /**
+    * Constructs a RecordExtend type.
+    */
   def mkRecordExtend(label: String, tpe: Type, rest: Type): Type = {
     mkApply(Type.Cst(TypeConstructor.RecordExtend(label)), List(tpe, rest))
   }
+
   /**
     * Constructs an arrow with the given effect type A ->eff B.
     */

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -316,6 +316,18 @@ object Type {
     mkApply(Type.Cst(TypeConstructor.SchemaExtend(sym)), List(tpe, rest))
   }
 
+  // MATT docs
+  def mkRelation(sym: Symbol.RelSym, tuple: Type): Type = {
+    Type.Apply(Type.Cst(TypeConstructor.Relation(sym)), tuple)
+  }
+
+  // MATT docs
+  // MATT could merge with relations since sym knows if it is  rel or lat
+  def mkLattice(sym: Symbol.LatSym, tuple: Type): Type = {
+    Type.Apply(Type.Cst(TypeConstructor.Lattice(sym)), tuple)
+  }
+
+
   /**
     * Constructs an arrow with the given effect type A ->eff B.
     */

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -93,7 +93,7 @@ object TypeConstructor {
     /**
       * The shape of an array is Array[t].
       */
-    def kind: Kind = Kind.Star -> Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Star
   }
 
   /**
@@ -103,7 +103,7 @@ object TypeConstructor {
     /**
       * The shape of a channel is Channel[t].
       */
-    def kind: Kind = Kind.Star -> Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Star
   }
 
   /**
@@ -125,7 +125,7 @@ object TypeConstructor {
     /**
       * The shape of a reference is Ref[t].
       */
-    def kind: Kind = Kind.Star -> Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Star
   }
 
   /**
@@ -135,7 +135,11 @@ object TypeConstructor {
     /**
       * The shape of a tuple is (t1, ..., tn).
       */
-    def kind: Kind = Kind.Arrow(List.fill(l)(Kind.Star), Kind.Star)
+    def kind: Kind =
+      if (l == 0)
+        Kind.Star
+      else
+        Kind.Arrow(List.fill(l)(Kind.Star), Kind.Star)
   }
 
   /**
@@ -145,7 +149,7 @@ object TypeConstructor {
     /**
       * The shape of a vector is Array[t;n].
       */
-    def kind: Kind = (Kind.Star -> Kind.Nat) -> Kind.Star
+    def kind: Kind = (Kind.Star ->: Kind.Nat) ->: Kind.Star
   }
 
   /**
@@ -162,7 +166,7 @@ object TypeConstructor {
     /**
       * The shape of an extended record is Record[t;r]
       */
-    def kind: Kind = Kind.Star -> Kind.Record -> Kind.Record
+    def kind: Kind = Kind.Star ->: Kind.Record ->: Kind.Record
   }
 
   /**
@@ -171,7 +175,7 @@ object TypeConstructor {
     * @param sym the symbol of the relation.
     */
   case class Relation(sym: Symbol.RelSym) extends TypeConstructor {
-    def kind: Kind = Kind.Star -> Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Star
   }
 
   /**
@@ -180,7 +184,7 @@ object TypeConstructor {
     * @param sym the symbol of the lattice.
     */
   case class Lattice(sym: Symbol.LatSym) extends TypeConstructor {
-    def kind: Kind = Kind.Star -> Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Star
   }
 
   /**
@@ -205,21 +209,28 @@ object TypeConstructor {
     * A type constructor that represents the negation of an effect.
     */
   case object Not extends TypeConstructor {
-    def kind: Kind = Kind.Effect -> Kind.Effect
+    def kind: Kind = Kind.Effect ->: Kind.Effect
   }
 
   /**
     * A type constructor that represents the conjunction of two effects.
     */
   case object And extends TypeConstructor {
-    def kind: Kind = Kind.Effect -> Kind.Effect -> Kind.Effect
+    def kind: Kind = Kind.Effect ->: Kind.Effect ->: Kind.Effect
   }
 
   /**
     * A type constructor that represents the disjunction of two effects.
     */
   case object Or extends TypeConstructor {
-    def kind: Kind = Kind.Effect -> Kind.Effect -> Kind.Effect
+    def kind: Kind = Kind.Effect ->: Kind.Effect ->: Kind.Effect
   }
 
+  /**
+    * Create an enum type constructor with the given arity.
+    */
+  def mkEnumCst(sym: Symbol.EnumSym, arity: Int): Enum = {
+    val kind = Seq.fill(arity + 1)(Kind.Star: Kind).reduceRight((k, acc) => k ->: acc)
+    Enum(sym, kind)
+  }
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -149,6 +149,23 @@ object TypeConstructor {
   }
 
   /**
+    * A type constructor that represents the type of empty records.
+    */
+  case object RecordEmpty extends TypeConstructor {
+    def kind: Kind = Kind.Record
+  }
+
+  /**
+    * A type constructor that represents the type of extended records.
+    */
+  case class RecordExtend(label: String) extends TypeConstructor {
+    /**
+      * The shape of an extended record is Record[t;r]
+      */
+    def kind: Kind = Kind.Star -> Kind.Record -> Kind.Record
+  }
+
+  /**
     * A type constructor that represents a relation.
     *
     * @param sym the symbol of the relation.

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -149,7 +149,7 @@ object TypeConstructor {
     /**
       * The shape of a vector is Array[t;n].
       */
-    def kind: Kind = (Kind.Star ->: Kind.Nat) ->: Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Nat ->: Kind.Star
   }
 
   /**
@@ -167,6 +167,17 @@ object TypeConstructor {
       * The shape of an extended record is Record[t;r]
       */
     def kind: Kind = Kind.Star ->: Kind.Record ->: Kind.Record
+  }
+
+  // MATT docs
+  case object SchemaEmpty extends TypeConstructor {
+    def kind: Kind = Kind.Schema
+  }
+
+  // MATT docs
+  case class SchemaExtend(sym: Symbol.PredSym) extends TypeConstructor {
+    // MATT docs
+    def kind: Kind = Kind.Star ->: Kind.Schema ->: Kind.Schema
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -135,7 +135,7 @@ object TypeConstructor {
     /**
       * The shape of a tuple is (t1, ..., tn).
       */
-    def kind: Kind = ??? // TODO
+    def kind: Kind = Kind.Arrow(List.fill(l)(Kind.Star), Kind.Star)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -186,7 +186,7 @@ object TypeConstructor {
     * @param sym the symbol of the relation.
     */
   case class Relation(sym: Symbol.RelSym) extends TypeConstructor {
-    def kind: Kind = Kind.Star ->: Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Relation
   }
 
   /**
@@ -195,7 +195,7 @@ object TypeConstructor {
     * @param sym the symbol of the lattice.
     */
   case class Lattice(sym: Symbol.LatSym) extends TypeConstructor {
-    def kind: Kind = Kind.Star ->: Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Lattice
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/debug/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/debug/FormatType.scala
@@ -11,10 +11,11 @@ object FormatType {
     * Returns a human readable representation of the given type `tpe`.
     */
   def format(tpe: Type): String = tpe match {
-    case Type.SchemaEmpty => "#{}"
-    case _: Type.SchemaExtend =>
-      val middlePart = getSchemaTypes(tpe).map(format).mkString(", ")
-      "#{ " + middlePart + " }"
+//    case Type.SchemaEmpty => "#{}"
+//    case _: Type.SchemaExtend =>
+//      val middlePart = getSchemaTypes(tpe).map(format).mkString(", ")
+//      "#{ " + middlePart + " }"
+      // MATT
 
     case _ => tpe.show
   }
@@ -23,9 +24,9 @@ object FormatType {
     * Returns the types of the predicate symbols in a schema type.
     */
   private def getSchemaTypes(tpe: Type): List[Type] = tpe match {
-    case Type.Var(_, _) => Nil
-    case Type.SchemaEmpty => Nil
-    case Type.SchemaExtend(sym, tpe, rest) => tpe :: getSchemaTypes(rest)
+//    case Type.Var(_, _) => Nil
+//    case Type.SchemaEmpty => Nil
+//    case Type.SchemaExtend(sym, tpe, rest) => tpe :: getSchemaTypes(rest)
     case _ => throw InternalCompilerException(s"Unexpected type: '$tpe'.")
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
@@ -161,6 +161,7 @@ object Documentor extends Phase[TypedAst.Root, TypedAst.Root] {
         case TypeConstructor.BigInt => "BigInt"
         case TypeConstructor.Str => "Str"
         case TypeConstructor.RecordEmpty => "{ }"
+        case TypeConstructor.SchemaEmpty => "#{ }"
 
         case TypeConstructor.Relation(sym) => sym.toString
 
@@ -187,6 +188,9 @@ object Documentor extends Phase[TypedAst.Root, TypedAst.Root] {
         case TypeConstructor.RecordExtend(label) =>
           "{" + label + " = " + format(args(0)) + " | " + format(args(1)) + "}"
 
+        case TypeConstructor.SchemaExtend(sym) =>
+          "#{" + sym + " = " + format(args(0)) + " | " + format(args(1)) + "}"
+
         case TypeConstructor.Pure => "Pure"
 
         case TypeConstructor.Impure => "Impure"
@@ -211,11 +215,6 @@ object Documentor extends Phase[TypedAst.Root, TypedAst.Root] {
         } else {
           "(" + argumentTypes.map(format).mkString(", ") + ") -> " + format(resultType)
         }
-
-      case Type.SchemaEmpty => "Schema { }"
-
-      case Type.SchemaExtend(sym, t, rest) =>
-        "{" + sym + " = " + format(t) + " | " + format(rest) + "}"
 
       case Type.Lambda(tvar, tpe) => tvar.toString + " => " + format(tpe)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
@@ -160,6 +160,7 @@ object Documentor extends Phase[TypedAst.Root, TypedAst.Root] {
         case TypeConstructor.Int64 => "Int64"
         case TypeConstructor.BigInt => "BigInt"
         case TypeConstructor.Str => "Str"
+        case TypeConstructor.RecordEmpty => "{ }"
 
         case TypeConstructor.Relation(sym) => sym.toString
 
@@ -182,6 +183,9 @@ object Documentor extends Phase[TypedAst.Root, TypedAst.Root] {
         case TypeConstructor.Tuple(l) => "(" + args.map(format).mkString(", ") + ")"
 
         case TypeConstructor.Vector => "Vector" + "[" + args.map(format).mkString(", ") + "]"
+
+        case TypeConstructor.RecordExtend(label) =>
+          "{" + label + " = " + format(args(0)) + " | " + format(args(1)) + "}"
 
         case TypeConstructor.Pure => "Pure"
 
@@ -207,11 +211,6 @@ object Documentor extends Phase[TypedAst.Root, TypedAst.Root] {
         } else {
           "(" + argumentTypes.map(format).mkString(", ") + ") -> " + format(resultType)
         }
-
-      case Type.RecordEmpty => "{ }"
-
-      case Type.RecordExtend(label, value, rest) =>
-        "{" + label + " = " + format(value) + " | " + format(rest) + "}"
 
       case Type.SchemaEmpty => "Schema { }"
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
@@ -575,6 +575,7 @@ object Finalize extends Phase[SimplifiedAst.Root, FinalAst.Root] {
       case Type.Cst(TypeConstructor.Str) => MonoType.Str
       case Type.Cst(TypeConstructor.Relation(sym)) => MonoType.Relation(sym, args)
       case Type.Cst(TypeConstructor.Lattice(sym)) => MonoType.Lattice(sym, args)
+      case Type.Cst(TypeConstructor.RecordEmpty) => MonoType.RecordEmpty()
 
       // Compound Types.
       case Type.Cst(TypeConstructor.Array) => MonoType.Array(args.head)
@@ -591,11 +592,11 @@ object Finalize extends Phase[SimplifiedAst.Root, FinalAst.Root] {
 
       case Type.Cst(TypeConstructor.Tuple(l)) => MonoType.Tuple(args)
 
+      case Type.Cst(TypeConstructor.RecordExtend(label)) => MonoType.RecordExtend(label, args(0), args(1))
+
       case Type.Arrow(l, _) => MonoType.Arrow(args.init, args.last)
 
       case Type.RecordEmpty => MonoType.RecordEmpty()
-
-      case Type.RecordExtend(label, value, rest) => MonoType.RecordExtend(label, visitType(value), visitType(rest))
 
       case Type.SchemaEmpty => MonoType.SchemaEmpty()
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
@@ -576,6 +576,7 @@ object Finalize extends Phase[SimplifiedAst.Root, FinalAst.Root] {
       case Type.Cst(TypeConstructor.Relation(sym)) => MonoType.Relation(sym, args)
       case Type.Cst(TypeConstructor.Lattice(sym)) => MonoType.Lattice(sym, args)
       case Type.Cst(TypeConstructor.RecordEmpty) => MonoType.RecordEmpty()
+      case Type.Cst(TypeConstructor.SchemaEmpty) => MonoType.SchemaEmpty()
 
       // Compound Types.
       case Type.Cst(TypeConstructor.Array) => MonoType.Array(args.head)
@@ -594,13 +595,9 @@ object Finalize extends Phase[SimplifiedAst.Root, FinalAst.Root] {
 
       case Type.Cst(TypeConstructor.RecordExtend(label)) => MonoType.RecordExtend(label, args(0), args(1))
 
+      case Type.Cst(TypeConstructor.SchemaExtend(sym)) => MonoType.SchemaExtend(sym, args(0), args(1))
+
       case Type.Arrow(l, _) => MonoType.Arrow(args.init, args.last)
-
-      case Type.RecordEmpty => MonoType.RecordEmpty()
-
-      case Type.SchemaEmpty => MonoType.SchemaEmpty()
-
-      case Type.SchemaExtend(sym, tpe, rest) => MonoType.SchemaExtend(sym, visitType(tpe), visitType(rest))
 
       case Type.Zero => MonoType.Unit
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -128,7 +128,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
           val quantifiers = tparams.map(_.tpe).map(x => NamedAst.Type.Var(x, loc))
           val enumType = if (quantifiers.isEmpty)
             NamedAst.Type.Enum(sym)
-          else {
+          else { // MATT change to Enum(sym, params)?
             val base = NamedAst.Type.Enum(sym)
             quantifiers.foldLeft(base: NamedAst.Type) {
               case (tacc, tvar) => NamedAst.Type.Apply(tacc, tvar, loc)
@@ -157,7 +157,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
           val tparams = tparams0 match {
             case TypeParams.Elided => Nil
             case TypeParams.Explicit(tps) => tps map {
-              case p => NamedAst.TypeParam(p, Type.freshTypeVar(), loc)
+              case p => NamedAst.TypeParam(p, Type.freshTypeVar(), loc);
             }
           }
           val tenv = getTypeEnv(tparams)
@@ -371,7 +371,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
   private def typeEnvFromFreeVars(idents: List[Name.Ident])(implicit flix: Flix): Map[String, Type.Var] =
     idents.foldLeft(Map.empty[String, Type.Var]) {
       case (macc, ident) => macc.get(ident.name) match {
-        case None => macc + (ident.name -> Type.freshTypeVar())
+        case None => macc + (ident.name -> Type.freshTypeVar()) // MATT not used, so I didn't think a lot about this one
         case Some(tvar) => macc
       }
     }
@@ -501,7 +501,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
       }
 
     case WeededAst.Expression.RecordEmpty(loc) =>
-      NamedAst.Expression.RecordEmpty(Type.freshTypeVar(), loc).toSuccess
+      NamedAst.Expression.RecordEmpty(Type.freshTypeVarWithKind(Kind.Record), loc).toSuccess
 
     case WeededAst.Expression.RecordSelect(exp, label, loc) =>
       mapN(visitExp(exp, env0, tenv0)) {
@@ -510,12 +510,12 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
 
     case WeededAst.Expression.RecordExtend(label, value, rest, loc) =>
       mapN(visitExp(value, env0, tenv0), visitExp(rest, env0, tenv0)) {
-        case (v, r) => NamedAst.Expression.RecordExtend(label, v, r, Type.freshTypeVar(), Type.freshEffectVar(), loc)
+        case (v, r) => NamedAst.Expression.RecordExtend(label, v, r, Type.freshTypeVarWithKind(Kind.Record), Type.freshEffectVar(), loc)
       }
 
     case WeededAst.Expression.RecordRestrict(label, rest, loc) =>
       mapN(visitExp(rest, env0, tenv0)) {
-        case r => NamedAst.Expression.RecordRestrict(label, r, Type.freshTypeVar(), Type.freshEffectVar(), loc)
+        case r => NamedAst.Expression.RecordRestrict(label, r, Type.freshTypeVarWithKind(Kind.Record), Type.freshEffectVar(), loc)
       }
 
     case WeededAst.Expression.ArrayLit(elms, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -127,9 +127,9 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
           val tenv = tparams.map(kv => kv.name.name -> kv.tpe).toMap
           val quantifiers = tparams.map(_.tpe).map(x => NamedAst.Type.Var(x, loc))
           val enumType = if (quantifiers.isEmpty)
-            NamedAst.Type.Enum(sym)
-          else { // MATT change to Enum(sym, params)?
-            val base = NamedAst.Type.Enum(sym)
+            NamedAst.Type.Enum(sym, 0)
+          else {
+            val base = NamedAst.Type.Enum(sym, quantifiers.size)
             quantifiers.foldLeft(base: NamedAst.Type) {
               case (tacc, tvar) => NamedAst.Type.Apply(tacc, tvar, loc)
             }
@@ -1278,7 +1278,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
     typeVars.toList.sorted.map {
       case name =>
         val ident = Name.Ident(SourcePosition.Unknown, name, SourcePosition.Unknown)
-        val tvar = Type.freshTypeVar()
+        val tvar = Type.freshTypeVar() // MATT these contain effect types. Need to handle these separately
         tvar.setText(name)
         NamedAst.TypeParam(ident, tvar, loc)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -882,12 +882,12 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
     case WeededAst.Predicate.Head.Atom(qname, den, terms, loc) =>
       for {
         ts <- traverse(terms)(t => visitExp(t, outerEnv ++ headEnv0 ++ ruleEnv0, tenv0))
-      } yield NamedAst.Predicate.Head.Atom(qname, den, ts, Type.freshTypeVarWithKind(Kind.Relation), loc)
+      } yield NamedAst.Predicate.Head.Atom(qname, den, ts, Type.freshTypeVarWithKind(Kind.Schema), loc)
 
     case WeededAst.Predicate.Head.Union(exp, loc) =>
       for {
         e <- visitExp(exp, outerEnv ++ headEnv0 ++ ruleEnv0, tenv0)
-      } yield NamedAst.Predicate.Head.Union(e, Type.freshTypeVarWithKind(Kind.Relation), loc)
+      } yield NamedAst.Predicate.Head.Union(e, Type.freshTypeVarWithKind(Kind.Schema), loc)
   }
 
   /**
@@ -896,7 +896,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
   private def visitBodyPredicate(body: WeededAst.Predicate.Body, outerEnv: Map[String, Symbol.VarSym], headEnv0: Map[String, Symbol.VarSym], ruleEnv0: Map[String, Symbol.VarSym], tenv0: Map[String, Type.Var])(implicit flix: Flix): Validation[NamedAst.Predicate.Body, NameError] = body match {
     case WeededAst.Predicate.Body.Atom(qname, den, polarity, terms, loc) =>
       val ts = terms.map(t => visitPattern(t, outerEnv ++ ruleEnv0))
-      NamedAst.Predicate.Body.Atom(qname, den, polarity, ts, Type.freshTypeVarWithKind(Kind.Relation), loc).toSuccess
+      NamedAst.Predicate.Body.Atom(qname, den, polarity, ts, Type.freshTypeVarWithKind(Kind.Schema), loc).toSuccess
 
     case WeededAst.Predicate.Body.Guard(exp, loc) =>
       for {

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -772,7 +772,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
 
     case WeededAst.Expression.FixpointEntails(exp1, exp2, loc) =>
       mapN(visitExp(exp1, env0, tenv0), visitExp(exp2, env0, tenv0)) {
-        case (e1, e2) => NamedAst.Expression.FixpointEntails(e1, e2, Type.freshTypeVarWithKind(Kind.Schema), Type.freshEffectVar(), loc)
+        case (e1, e2) => NamedAst.Expression.FixpointEntails(e1, e2, Type.freshTypeVar(), Type.freshEffectVar(), loc)
       }
 
     case WeededAst.Expression.FixpointFold(qname, init, f, constraints, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -752,32 +752,32 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
     case WeededAst.Expression.FixpointConstraintSet(cs0, loc) =>
       mapN(traverse(cs0)(visitConstraint(_, env0, tenv0))) {
         case cs =>
-          NamedAst.Expression.FixpointConstraintSet(cs, Type.freshTypeVar(), loc)
+          NamedAst.Expression.FixpointConstraintSet(cs, Type.freshTypeVarWithKind(Kind.Schema), loc)
       }
 
     case WeededAst.Expression.FixpointCompose(exp1, exp2, loc) =>
       mapN(visitExp(exp1, env0, tenv0), visitExp(exp2, env0, tenv0)) {
-        case (e1, e2) => NamedAst.Expression.FixpointCompose(e1, e2, Type.freshTypeVar(), Type.freshEffectVar(), loc)
+        case (e1, e2) => NamedAst.Expression.FixpointCompose(e1, e2, Type.freshTypeVarWithKind(Kind.Schema), Type.freshEffectVar(), loc)
       }
 
     case WeededAst.Expression.FixpointSolve(exp, loc) =>
       visitExp(exp, env0, tenv0) map {
-        case e => NamedAst.Expression.FixpointSolve(e, Type.freshTypeVar(), Type.freshEffectVar(), loc)
+        case e => NamedAst.Expression.FixpointSolve(e, Type.freshTypeVarWithKind(Kind.Schema), Type.freshEffectVar(), loc)
       }
 
     case WeededAst.Expression.FixpointProject(qname, exp, loc) =>
       mapN(visitExp(exp, env0, tenv0)) {
-        case e => NamedAst.Expression.FixpointProject(qname, e, Type.freshTypeVar(), Type.freshEffectVar(), loc)
+        case e => NamedAst.Expression.FixpointProject(qname, e, Type.freshTypeVarWithKind(Kind.Schema), Type.freshEffectVar(), loc)
       }
 
     case WeededAst.Expression.FixpointEntails(exp1, exp2, loc) =>
       mapN(visitExp(exp1, env0, tenv0), visitExp(exp2, env0, tenv0)) {
-        case (e1, e2) => NamedAst.Expression.FixpointEntails(e1, e2, Type.freshTypeVar(), Type.freshEffectVar(), loc)
+        case (e1, e2) => NamedAst.Expression.FixpointEntails(e1, e2, Type.freshTypeVarWithKind(Kind.Schema), Type.freshEffectVar(), loc)
       }
 
     case WeededAst.Expression.FixpointFold(qname, init, f, constraints, loc) =>
       mapN(visitExp(init, env0, tenv0), visitExp(f, env0, tenv0), visitExp(constraints, env0, tenv0)) {
-        case (e1, e2, e3) => NamedAst.Expression.FixpointFold(qname, e1, e2, e3, Type.freshTypeVar(), Type.freshEffectVar(), loc)
+        case (e1, e2, e3) => NamedAst.Expression.FixpointFold(qname, e1, e2, e3, Type.freshTypeVarWithKind(Kind.Schema), Type.freshEffectVar(), loc)
       }
   }
 
@@ -882,12 +882,12 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
     case WeededAst.Predicate.Head.Atom(qname, den, terms, loc) =>
       for {
         ts <- traverse(terms)(t => visitExp(t, outerEnv ++ headEnv0 ++ ruleEnv0, tenv0))
-      } yield NamedAst.Predicate.Head.Atom(qname, den, ts, Type.freshTypeVarWithKind(Kind.Schema), loc)
+      } yield NamedAst.Predicate.Head.Atom(qname, den, ts, Type.freshTypeVarWithKind(Kind.Relation), loc)
 
     case WeededAst.Predicate.Head.Union(exp, loc) =>
       for {
         e <- visitExp(exp, outerEnv ++ headEnv0 ++ ruleEnv0, tenv0)
-      } yield NamedAst.Predicate.Head.Union(e, Type.freshTypeVarWithKind(Kind.Schema), loc)
+      } yield NamedAst.Predicate.Head.Union(e, Type.freshTypeVarWithKind(Kind.Relation), loc)
   }
 
   /**
@@ -896,7 +896,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
   private def visitBodyPredicate(body: WeededAst.Predicate.Body, outerEnv: Map[String, Symbol.VarSym], headEnv0: Map[String, Symbol.VarSym], ruleEnv0: Map[String, Symbol.VarSym], tenv0: Map[String, Type.Var])(implicit flix: Flix): Validation[NamedAst.Predicate.Body, NameError] = body match {
     case WeededAst.Predicate.Body.Atom(qname, den, polarity, terms, loc) =>
       val ts = terms.map(t => visitPattern(t, outerEnv ++ ruleEnv0))
-      NamedAst.Predicate.Body.Atom(qname, den, polarity, ts, Type.freshTypeVarWithKind(Kind.Schema), loc).toSuccess
+      NamedAst.Predicate.Body.Atom(qname, den, polarity, ts, Type.freshTypeVarWithKind(Kind.Relation), loc).toSuccess
 
     case WeededAst.Predicate.Body.Guard(exp, loc) =>
       for {

--- a/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
@@ -739,10 +739,10 @@ object PatternExhaustiveness extends Phase[TypedAst.Root, TypedAst.Root] {
       case Type.Cst(TypeConstructor.Native(clazz)) => 0
       case Type.Cst(TypeConstructor.Vector) => 2
       case Type.Cst(TypeConstructor.Tuple(l)) => l
+      case Type.Cst(TypeConstructor.RecordEmpty) => 0
+      case Type.Cst(TypeConstructor.RecordExtend(label)) => 0 // MATT probably have to do something here
       case Type.Zero => 0
       case Type.Succ(n, t) => 2
-      case Type.RecordEmpty => 0 // TODO: Correct?
-      case Type.RecordExtend(base, label, value) => 0 // TODO: Correct?
       case Type.SchemaEmpty => 0 // TODO: Correct?
       case Type.SchemaExtend(base, label, value) => 0 // TODO: Correct?
       case Type.Apply(tpe1, tpe2) => countTypeArgs(tpe1)

--- a/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
@@ -741,10 +741,10 @@ object PatternExhaustiveness extends Phase[TypedAst.Root, TypedAst.Root] {
       case Type.Cst(TypeConstructor.Tuple(l)) => l
       case Type.Cst(TypeConstructor.RecordEmpty) => 0
       case Type.Cst(TypeConstructor.RecordExtend(label)) => 0 // MATT probably have to do something here
+      case Type.Cst(TypeConstructor.SchemaEmpty) => 0
+      case Type.Cst(TypeConstructor.SchemaExtend(sym)) => 0 // MATT probably have to do something here
       case Type.Zero => 0
       case Type.Succ(n, t) => 2
-      case Type.SchemaEmpty => 0 // TODO: Correct?
-      case Type.SchemaExtend(base, label, value) => 0 // TODO: Correct?
       case Type.Apply(tpe1, tpe2) => countTypeArgs(tpe1)
       case Type.Cst(TypeConstructor.Pure) => throw InternalCompilerException(s"Unexpected type: '$tpe'.")
       case Type.Cst(TypeConstructor.Impure) => throw InternalCompilerException(s"Unexpected type: '$tpe'.")

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1168,9 +1168,9 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
               val s = simplify(t)
 
               // Determine the type of predicate symbol.
-              s.typeConstructor match {
-                case Type.Cst(TypeConstructor.Relation(sym)) => Type.mkSchemaExtend(sym, s, acc).toSuccess
-                case Type.Cst(TypeConstructor.Lattice(sym)) => Type.mkSchemaExtend(sym, s, acc).toSuccess
+              s match {
+                case Type.Apply(Type.Cst(TypeConstructor.Relation(sym)), tuple) => Type.mkSchemaExtend(sym, tuple, acc).toSuccess
+                case Type.Apply(Type.Cst(TypeConstructor.Lattice(sym)), tuple) => Type.mkSchemaExtend(sym, tuple, acc).toSuccess
                 case nonRelationOrLatticeType => ResolutionError.NonRelationOrLattice(nonRelationOrLatticeType, loc).toFailure
               }
           }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1169,8 +1169,8 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
 
               // Determine the type of predicate symbol.
               s.typeConstructor match {
-                case Type.Cst(TypeConstructor.Relation(sym)) => Type.SchemaExtend(sym, s, acc).toSuccess
-                case Type.Cst(TypeConstructor.Lattice(sym)) => Type.SchemaExtend(sym, s, acc).toSuccess
+                case Type.Cst(TypeConstructor.Relation(sym)) => Type.mkSchemaExtend(sym, s, acc).toSuccess
+                case Type.Cst(TypeConstructor.Lattice(sym)) => Type.mkSchemaExtend(sym, s, acc).toSuccess
                 case nonRelationOrLatticeType => ResolutionError.NonRelationOrLattice(nonRelationOrLatticeType, loc).toFailure
               }
           }
@@ -1507,15 +1507,6 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
 
       case Type.Arrow(l, eff) => Type.Arrow(l, eval(eff, subst))
 
-      case Type.RecordEmpty => t
-
-      case Type.SchemaEmpty => t
-
-      case Type.SchemaExtend(sym, tpe, rest) =>
-        val t1 = eval(tpe, subst)
-        val t2 = eval(rest, subst)
-        Type.SchemaExtend(sym, t1, t2)
-
       case Type.Zero => t
 
       case Type.Succ(len, t) => Type.Succ(len, eval(t, subst))
@@ -1649,6 +1640,8 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
 
     case Type.Cst(TypeConstructor.RecordExtend(_)) => Class.forName("java.lang.Object").toSuccess
 
+    case Type.Cst(TypeConstructor.SchemaExtend(_)) => Class.forName("java.lang.Object").toSuccess
+
     case Type.Cst(TypeConstructor.Array) =>
       tpe.typeArguments match {
         case elmTyp :: Nil =>
@@ -1673,11 +1666,9 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
 
     case Type.Cst(TypeConstructor.Native(clazz)) => clazz.toSuccess
 
-    case Type.RecordEmpty => Class.forName("java.lang.Object").toSuccess
+    case Type.Cst(TypeConstructor.RecordEmpty) => Class.forName("java.lang.Object").toSuccess
 
-    case Type.SchemaEmpty => Class.forName("java.lang.Object").toSuccess
-
-    case Type.SchemaExtend(_, _, _) => Class.forName("java.lang.Object").toSuccess
+    case Type.Cst(TypeConstructor.SchemaEmpty) => Class.forName("java.lang.Object").toSuccess
 
     case _ => ResolutionError.IllegalType(tpe, loc).toFailure
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -61,7 +61,7 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
           val fparam = ResolvedAst.FormalParam(Symbol.freshVarSym("_unit"), Ast.Modifiers.Empty, Type.Unit, SourceLocation.Unknown)
           val fparams = List(fparam)
           val sc = Scheme(Nil, Type.freshTypeVar())
-          val eff = Type.freshTypeVar()
+          val eff = Type.freshTypeVar() // MATT should be effect?
           val loc = SourceLocation.Unknown
           val defn = ResolvedAst.Def(doc, ann, mod, sym, tparams, fparams, exp, sc, eff, loc)
           sym -> defn
@@ -1398,7 +1398,9 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
     */
   def getEnumTypeIfAccessible(enum0: NamedAst.Enum, ns0: Name.NName, loc: SourceLocation): Validation[Type, ResolutionError] =
     getEnumIfAccessible(enum0, ns0, loc) map {
-      case enum => Type.Cst(TypeConstructor.Enum(enum.sym, Kind.Star))
+      case enum =>
+        val kind = Seq.fill(enum.tparams.length + 1)(Kind.Star: Kind).reduce(_ -> _) // MATT not necessary if we add tparams to Type.Enum
+        Type.Cst(TypeConstructor.Enum(enum.sym, kind))
     }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1149,7 +1149,7 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
       for {
         v <- lookupType(value, ns0, root)
         r <- lookupType(rest, ns0, root)
-      } yield Type.RecordExtend(label.name, v, r)
+      } yield Type.mkRecordExtend(label.name, v, r)
 
     case NamedAst.Type.SchemaEmpty(loc) =>
       Type.SchemaEmpty.toSuccess
@@ -1508,11 +1508,6 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
 
       case Type.RecordEmpty => t
 
-      case Type.RecordExtend(label, value, rest) =>
-        val t1 = eval(value, subst)
-        val t2 = eval(rest, subst)
-        Type.RecordExtend(label, t1, t2)
-
       case Type.SchemaEmpty => t
 
       case Type.SchemaExtend(sym, tpe, rest) =>
@@ -1651,6 +1646,8 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
 
     case Type.Cst(TypeConstructor.Tuple(_)) => Class.forName("java.lang.Object").toSuccess
 
+    case Type.Cst(TypeConstructor.RecordExtend(_)) => Class.forName("java.lang.Object").toSuccess
+
     case Type.Cst(TypeConstructor.Array) =>
       tpe.typeArguments match {
         case elmTyp :: Nil =>
@@ -1676,8 +1673,6 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Program] {
     case Type.Cst(TypeConstructor.Native(clazz)) => clazz.toSuccess
 
     case Type.RecordEmpty => Class.forName("java.lang.Object").toSuccess
-
-    case Type.RecordExtend(_, _, _) => Class.forName("java.lang.Object").toSuccess
 
     case Type.SchemaEmpty => Class.forName("java.lang.Object").toSuccess
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -20,7 +20,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.CompilationError
 import ca.uwaterloo.flix.language.ast.Ast.{DependencyEdge, DependencyGraph, Polarity}
 import ca.uwaterloo.flix.language.ast.TypedAst._
-import ca.uwaterloo.flix.language.ast.{Ast, SourceLocation, Symbol, Type}
+import ca.uwaterloo.flix.language.ast.{Ast, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.errors.StratificationError
 import ca.uwaterloo.flix.util.Validation._
 import ca.uwaterloo.flix.util.{InternalCompilerException, Validation}
@@ -877,8 +877,8 @@ object Stratifier extends Phase[Root, Root] {
     */
   private def predicateSymbolsOf(tpe: Type): Set[Symbol.PredSym] = tpe match {
     case Type.Var(_, _) => Set.empty
-    case Type.SchemaEmpty => Set.empty
-    case Type.SchemaExtend(sym, _, rest) => predicateSymbolsOf(rest) + sym
+    case Type.Cst(TypeConstructor.SchemaEmpty) => Set.empty
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaExtend(sym)), _), rest) => predicateSymbolsOf(rest) + sym
     case _ => throw InternalCompilerException(s"Unexpected non-schema type: '$tpe'.")
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Synthesize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Synthesize.scala
@@ -1302,8 +1302,8 @@ object Synthesize extends Phase[Root, Root] {
       * Returns `true` if `tpe` is a schema type.
       */
     def isSchema(tpe: Type): Boolean = tpe.typeConstructor match {
-      case Type.SchemaEmpty => true
-      case Type.SchemaExtend(_, _, _) => true
+      case Type.Cst(TypeConstructor.SchemaEmpty) => true
+      case Type.Cst(TypeConstructor.SchemaExtend(_)) => true
       case _ => false
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Synthesize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Synthesize.scala
@@ -1293,8 +1293,8 @@ object Synthesize extends Phase[Root, Root] {
       * Returns `true` if `tpe` is a record type.
       */
     def isRecord(tpe: Type): Boolean = tpe.typeConstructor match {
-      case Type.RecordEmpty => true
-      case Type.RecordExtend(base, label, value) => true
+      case Type.Cst(TypeConstructor.RecordEmpty) => true
+      case Type.Cst(TypeConstructor.RecordExtend(_)) => true
       case _ => false
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -607,7 +607,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         // -------------------------
         // r.label : tpe
         //
-        val freshRowVar = Type.freshTypeVar()
+        val freshRowVar = Type.freshTypeVarWithKind(Kind.Record)
         val expectedType = Type.mkRecordExtend(label, tvar, freshRowVar)
         for {
           (tpe, eff) <- visitExp(exp)
@@ -634,7 +634,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         // { -label | r } : { r }
         //
         val freshFieldType = Type.freshTypeVar()
-        val freshRowVar = Type.freshTypeVar()
+        val freshRowVar = Type.freshTypeVarWithKind(Kind.Record)
         for {
           (tpe, eff) <- visitExp(exp)
           recordType <- unifyTypM(tpe, Type.mkRecordExtend(label, freshFieldType, freshRowVar), loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -608,7 +608,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         // r.label : tpe
         //
         val freshRowVar = Type.freshTypeVar()
-        val expectedType = Type.RecordExtend(label, tvar, freshRowVar)
+        val expectedType = Type.mkRecordExtend(label, tvar, freshRowVar)
         for {
           (tpe, eff) <- visitExp(exp)
           recordType <- unifyTypM(tpe, expectedType, loc)
@@ -624,7 +624,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         for {
           (tpe1, eff1) <- visitExp(exp1)
           (tpe2, eff2) <- visitExp(exp2)
-          resultTyp <- unifyTypM(tvar, Type.RecordExtend(label, tpe1, tpe2), loc)
+          resultTyp <- unifyTypM(tvar, Type.mkRecordExtend(label, tpe1, tpe2), loc)
           resultEff <- unifyEffM(evar, mkAnd(eff1, eff2), loc)
         } yield (resultTyp, resultEff)
 
@@ -637,7 +637,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         val freshRowVar = Type.freshTypeVar()
         for {
           (tpe, eff) <- visitExp(exp)
-          recordType <- unifyTypM(tpe, Type.RecordExtend(label, freshFieldType, freshRowVar), loc)
+          recordType <- unifyTypM(tpe, Type.mkRecordExtend(label, freshFieldType, freshRowVar), loc)
           resultTyp <- unifyTypM(tvar, freshRowVar, loc)
           resultEff <- unifyEffM(evar, eff, loc)
         } yield (resultTyp, resultEff)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -372,7 +372,7 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
 
       case ResolvedAst.Expression.Apply(exp1, exp2, tvar, evar, loc) =>
         val lambdaBodyType = Type.freshTypeVar()
-        val lambdaBodyEff = Type.freshTypeVar()
+        val lambdaBodyEff = Type.freshEffectVar()
         for {
           (tpe1, eff1) <- visitExp(exp1)
           (tpe2, eff2) <- visitExp(exp2)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -1688,11 +1688,11 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
       // Lookup the declared type of the relation/lattice (if it exists).
       val declaredType = sym match {
         case x: Symbol.RelSym => program.relations.get(x) match {
-          case None => Type.freshTypeVarWithKind(Kind.Schema)
+          case None => Type.freshTypeVarWithKind(Kind.Relation)
           case Some(rel) => Scheme.instantiate(rel.sc)
         }
         case x: Symbol.LatSym => program.lattices.get(x) match {
-          case None => Type.freshTypeVarWithKind(Kind.Schema)
+          case None => Type.freshTypeVarWithKind(Kind.Lattice)
           case Some(lat) => Scheme.instantiate(lat.sc)
         }
       }
@@ -1751,11 +1751,11 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
       // Lookup the declared type of the relation/lattice (if it exists).
       val declaredType = sym match {
         case x: Symbol.RelSym => program.relations.get(x) match {
-          case None => Type.freshTypeVarWithKind(Kind.Schema)
+          case None => Type.freshTypeVarWithKind(Kind.Relation)
           case Some(rel) => Scheme.instantiate(rel.sc)
         }
         case x: Symbol.LatSym => program.lattices.get(x) match {
-          case None => Type.freshTypeVarWithKind(Kind.Schema)
+          case None => Type.freshTypeVarWithKind(Kind.Lattice)
           case Some(lat) => Scheme.instantiate(lat.sc)
         }
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -1143,14 +1143,18 @@ object Typer extends Phase[ResolvedAst.Program, TypedAst.Root] {
         //  -------------------------------------------
         //  project P exp2 : #{ P : a | c }
         //
-        val freshPredicateTypeVar = Type.freshTypeVar()
+        val freshTupleTypeVar = Type.freshTypeVar()
+        val predicateType = sym match {
+          case sym: Symbol.LatSym => Type.mkLattice(sym, freshTupleTypeVar)
+          case sym: Symbol.RelSym => Type.mkRelation(sym, freshTupleTypeVar)
+        }
         val freshRestSchemaTypeVar = Type.freshTypeVarWithKind(Kind.Schema)
         val freshResultSchemaTypeVar = Type.freshTypeVarWithKind(Kind.Schema)
 
         for {
           (tpe, eff) <- visitExp(exp)
-          expectedType <- unifyTypM(tpe, Type.mkSchemaExtend(sym, freshPredicateTypeVar, freshRestSchemaTypeVar), loc)
-          resultTyp <- unifyTypM(tvar, Type.mkSchemaExtend(sym, freshPredicateTypeVar, freshResultSchemaTypeVar), loc)
+          expectedType <- unifyTypM(tpe, Type.mkSchemaExtend(sym, predicateType, freshRestSchemaTypeVar), loc)
+          resultTyp <- unifyTypM(tvar, Type.mkSchemaExtend(sym, predicateType, freshResultSchemaTypeVar), loc)
           resultEff <- unifyEffM(evar, eff, loc)
         } yield (resultTyp, resultEff)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Unification.scala
@@ -70,9 +70,11 @@ object Unification {
       */
     def apply(tpe0: Type): Type = {
 
-      // MATT generify, fix param names, docs
-      def canSubstituteKind(varKind: Kind, realKind: Kind): Boolean = (varKind, realKind) match {
-        case (vkind, rkind) if vkind == rkind => true
+      /**
+        * Returns true iff a type of kind `trueKind` can be substituted in place of a type of `varKind`.
+        */
+      def canSubstituteKind(varKind: Kind, trueKind: Kind): Boolean = (varKind, trueKind) match {
+        case (vkind, tkind) if vkind == tkind => true
         case (Kind.Star, Kind.Record) => true
         case _ => false
       }
@@ -82,12 +84,11 @@ object Unification {
           case x: Type.Var =>
             m.get(x) match {
               case None => x
-              case Some(y) if canSubstituteKind(x.kind, t.kind) => y
-              case Some(y) if x.kind != t.kind => throw InternalCompilerException(s"Expected kind `${x.kind}' but got `${t.kind}'.")
+              case Some(y) if canSubstituteKind(x.kind, y.kind) => y
+              case Some(y) => throw InternalCompilerException(s"Expected kind `${x.kind}' but got `${y.kind}'.")
             }
           case Type.Cst(tc) => Type.Cst(tc)
           case Type.Arrow(l, eff) => Type.Arrow(l, visit(eff))
-          case Type.RecordEmpty => Type.RecordEmpty
           case Type.SchemaEmpty => Type.SchemaEmpty
           case Type.SchemaExtend(sym, tpe, rest) => Type.SchemaExtend(sym, visit(tpe), visit(rest))
           case Type.Zero => Type.Zero
@@ -286,9 +287,9 @@ object Unification {
       }
 
       // TODO: Kinds disabled for now. Requires changed to the previous phase to associated type variables with their kinds.
-      if (x.kind != tpe.kind) {
-        throw InternalCompilerException("MATT YOU MESSED UP!") // MATT
-      }
+//      if (x.kind != tpe.kind) {
+//        throw InternalCompilerException(s"Unable to unify kinds: '${x.kind}', '${tpe.kind}''") // MATT
+//      }
 
       // We can substitute `x` for `tpe`. Update the textual name of `tpe`.
       if (x.getText.nonEmpty && tpe.isInstanceOf[Type.Var]) {
@@ -591,7 +592,7 @@ object Unification {
     */
   def unifyTypAllowEmptyM(ts: List[Type], loc: SourceLocation)(implicit flix: Flix): InferMonad[Type] = {
     if (ts.isEmpty)
-      liftM(Type.freshTypeVar()) // MATT right?
+      liftM(Type.freshTypeVar()) // MATT probably need another param
     else
       unifyTypM(ts, loc)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -811,7 +811,7 @@ object JvmOps {
     case MonoType.Native(clazz) => Type.Cst(TypeConstructor.Native(clazz))
     case MonoType.Ref(elm) => Type.Apply(Type.Cst(TypeConstructor.Ref), hackMonoType2Type(elm))
     case MonoType.Arrow(targs, tresult) => Type.mkArrow(targs map hackMonoType2Type, Type.Pure, hackMonoType2Type(tresult))
-    case MonoType.Enum(sym, args) => Type.mkApply(Type.Cst(TypeConstructor.Enum(sym, Kind.Star)), args map hackMonoType2Type)
+    case MonoType.Enum(sym, args) => Type.mkApply(Type.Cst(TypeConstructor.mkEnumCst(sym, args.size)), args map hackMonoType2Type)
 
     case MonoType.Relation(sym, attr) =>
       val base = Type.Cst(TypeConstructor.Relation(sym)): Type

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -833,7 +833,7 @@ object JvmOps {
     case MonoType.RecordEmpty() => Type.RecordEmpty
     case MonoType.RecordExtend(label, value, rest) => Type.mkRecordExtend(label, hackMonoType2Type(value), hackMonoType2Type(rest))
     case MonoType.SchemaEmpty() => Type.SchemaEmpty
-    case MonoType.SchemaExtend(sym, t, rest) => Type.SchemaExtend(sym, hackMonoType2Type(t), hackMonoType2Type(rest))
+    case MonoType.SchemaExtend(sym, t, rest) => Type.mkSchemaExtend(sym, hackMonoType2Type(t), hackMonoType2Type(rest))
   }
 
   // TODO: Remove

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -831,7 +831,7 @@ object JvmOps {
 
     case MonoType.Tuple(length) => Type.Cst(TypeConstructor.Tuple(0)) // hack
     case MonoType.RecordEmpty() => Type.RecordEmpty
-    case MonoType.RecordExtend(label, value, rest) => Type.RecordExtend(label, hackMonoType2Type(value), hackMonoType2Type(rest))
+    case MonoType.RecordExtend(label, value, rest) => Type.mkRecordExtend(label, hackMonoType2Type(value), hackMonoType2Type(rest))
     case MonoType.SchemaEmpty() => Type.SchemaEmpty
     case MonoType.SchemaExtend(sym, t, rest) => Type.SchemaExtend(sym, hackMonoType2Type(t), hackMonoType2Type(rest))
   }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestStratifier.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestStratifier.scala
@@ -135,11 +135,10 @@ class TestStratifier extends FunSuite with TestUtils {
   test("HackTest.01") { // MATT
     val input =
     """
-      |def testRecordDuplicateExtend04(): Bool =
-      |  let r0 = { +x = 123 | {} };
-      |  let r1 = { +x = "abc" | r0 };
-      |  let r2 = { +x = "def" | r0 };
-      |    r1.x != r2.x
+      |rel A(x: Int, y: Int, z: Int)
+      |def testProject01(): Bool =
+      |    let c1 = A(1, 1, 1).;
+      |    (project A c1) |= A(1, 1, 1).
     """.stripMargin
     new Flix().addStr(input).compile()
   }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestStratifier.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestStratifier.scala
@@ -131,4 +131,16 @@ class TestStratifier extends FunSuite with TestUtils {
       """.stripMargin
     expectError[StratificationError](new Flix().addStr(input).compile())
   }
+
+  test("HackTest.01") { // MATT
+    val input =
+    """
+      |def testRecordDuplicateExtend04(): Bool =
+      |  let r0 = { +x = 123 | {} };
+      |  let r1 = { +x = "abc" | r0 };
+      |  let r2 = { +x = "def" | r0 };
+      |    r1.x != r2.x
+    """.stripMargin
+    new Flix().addStr(input).compile()
+  }
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestStratifier.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestStratifier.scala
@@ -133,13 +133,36 @@ class TestStratifier extends FunSuite with TestUtils {
   }
 
   test("HackTest.01") { // MATT
+//    val input =
+//    """
+//      |
+//      |rel Parent(p1: Str, p2: Str)
+//      |rel GrandParent(p1: Str, p2: Str)
+//      |rel Ancestor(p1: Str, p2: Str)
+//      |
+//      |Parent("Magnus", "Inger").
+//      |Parent("Magnus", "Frits").
+//      |Parent("Bjarke", "Inger").
+//      |Parent("Bjarke", "Frits").
+//      |Parent("Frits", "Orla").
+//      |
+//      |GrandParent(x, z) :- Parent(x, y), Parent(y, z).
+//      |Ancestor(x, z) :- Parent(x, y), Parent(y, z).
+//      |
+//      |
+//    """.stripMargin
+
     val input =
-    """
-      |rel A(x: Int, y: Int, z: Int)
-      |def testProject01(): Bool =
-      |    let c1 = A(1, 1, 1).;
-      |    (project A c1) |= A(1, 1, 1).
+      """
+        |
+        |rel Parent(p1: Str, p2: Str)
+        |rel GrandParent(p1: Str, p2: Str)
+        |
+        |Parent("Magnus", "Inger").
+        |GrandParent(x, z) :- Parent(x, y), Parent(y, z).
+        |
     """.stripMargin
-    new Flix().addStr(input).compile()
+    val result = new Flix().addStr(input).compile()
+    result.get
   }
 }


### PR DESCRIPTION
Introduces subkinding to allow well-kindedness while still permitting records to be used as proper types.

I'm not terribly happy with the way I did kinds here as it's more object-oriented than functional, so I'd like to rewrite that if I can find a better way.

Still TODO:

- [ ] do kindchecking in unification (may require implementations of kinds for other types)
- [ ] add negative tests (e.g. `{ a: Int | Str }`
