### PR TITLE
Add sortWith to List / Add unfolds to List, Map and Set

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -848,7 +848,7 @@ namespace List {
     /// Sort list `xs` with the comparing function `cmp`.
     ///
     /// The sort implementation is a mergesort.
-    /// Acknowlegdement: derived from Thomas Nordin's `sortBy` in the Haskell base libraries.
+    /// Acknowledgement: derived from Thomas Nordin's `sortBy` in the Haskell base libraries.
     ///
     pub def sortWith(cmp: (a,a) -> Int32, xs: List[a]): List[a] =
         sortGenerateSequences(cmp, xs) |> sortMergeAll(cmp)
@@ -930,9 +930,9 @@ namespace List {
     ///
     /// Helper function for `unfold`.
     ///
-    def unfoldHelper(f: s -> Option[(a, s)] & e, st: s, cont: List[a] -> List[a]): List[a] & e = match f(st) {
-        case None => cont(Nil)
-        case Some(a, st1) => unfoldHelper(f, st1, xs -> cont(a :: xs))
+    def unfoldHelper(f: s -> Option[(a, s)] & e, st: s, k: List[a] -> List[a]): List[a] & e = match f(st) {
+        case None => k(Nil)
+        case Some(a, st1) => unfoldHelper(f, st1, xs -> k(a :: xs))
     }
 
     ///
@@ -943,14 +943,14 @@ namespace List {
     ///
     /// `next` should return `None` to signal the end of building the list.
     ///
-    pub def unfoldWithIter(next: () -> Option[a] & e): List[a] & e = unfoldWithIterHelper(next, xs -> xs)
+    pub def unfoldWithIter(next: () ~> Option[a]): List[a] & Impure = unfoldWithIterHelper(next, xs -> xs)
 
     ///
     /// Helper function for `unfoldWithIter`.
     ///
-    def unfoldWithIterHelper(next: () -> Option[a] & e, cont: List[a] -> List[a]): List[a] & e = match next() {
-        case None => cont(Nil)
-        case Some(a) => unfoldWithIterHelper(next, xs -> cont(a :: xs))
+    def unfoldWithIterHelper(next: () ~> Option[a], k: List[a] -> List[a]): List[a] & Impure = match next() {
+        case None => k(Nil)
+        case Some(a) => unfoldWithIterHelper(next, xs -> k(a :: xs))
     }
 
     ///

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -918,8 +918,15 @@ namespace List {
         case (rs, Nil) => rs
     }
 
+    ///
+    /// TODO.
+    ///
     pub def unfold(f: s -> Option[(a, s)] & e, st: s): List[a] & e = unfoldHelper(f, st, xs -> xs)
 
+
+    ///
+    /// Helper function for `unfold`.
+    ///
     def unfoldHelper(f: s -> Option[(a, s)] & e, st: s, cont: List[a] -> List[a]): List[a] & e = match f(st) {
         case None => cont(Nil)
         case Some(a, st1) => unfoldHelper(f, st1, xs -> cont(a :: xs))

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -943,14 +943,14 @@ namespace List {
     ///
     /// `next` should return `None` to signal the end of building the list.
     ///
-    pub def unfoldWithIterator(next: () -> Option[a] & e): List[a] & e = unfoldWithIteratorHelper(next, xs -> xs)
+    pub def unfoldWithIter(next: () -> Option[a] & e): List[a] & e = unfoldWithIterHelper(next, xs -> xs)
 
     ///
-    /// Helper function for `unfoldWithIterator`.
+    /// Helper function for `unfoldWithIter`.
     ///
-    def unfoldWithIteratorHelper(next: () -> Option[a] & e, cont: List[a] -> List[a]): List[a] & e = match next() {
+    def unfoldWithIterHelper(next: () -> Option[a] & e, cont: List[a] -> List[a]): List[a] & e = match next() {
         case None => cont(Nil)
-        case Some(a) => unfoldWithIteratorHelper(next, xs -> cont(a :: xs))
+        case Some(a) => unfoldWithIterHelper(next, xs -> cont(a :: xs))
     }
 
     ///

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -909,13 +909,20 @@ namespace List {
     /// Helper function for `sortWith`.
     ///
     def sortMerge(cmp: (a,a) -> Int32, xs: List[a], ys: List[a]) : List[a] = match (xs, ys) {
-            case (r :: rs, s :: ss) =>
-                if (cmp(r,s) > 0)
-                    s :: sortMerge(cmp, xs, ss)
-                else
-                    r :: sortMerge(cmp, rs, ys)
-            case (Nil, ss) => ss
-            case (rs, Nil) => rs
+        case (r :: rs, s :: ss) =>
+            if (cmp(r,s) > 0)
+                s :: sortMerge(cmp, xs, ss)
+            else
+                r :: sortMerge(cmp, rs, ys)
+        case (Nil, ss) => ss
+        case (rs, Nil) => rs
+    }
+
+    pub def unfold(f: s -> Option[(a, s)] & e, st: s): List[a] & e = unfoldHelper(f, st, xs -> xs)
+
+    def unfoldHelper(f: s -> Option[(a, s)] & e, st: s, cont: List[a] -> List[a]): List[a] & e = match f(st) {
+        case None => cont(Nil)
+        case Some(a, st1) => unfoldHelper(f, st1, xs -> cont(a :: xs))
     }
 
     ///

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -936,6 +936,24 @@ namespace List {
     }
 
     ///
+    /// Build a list by applying the function `next` to `()`. `next` is expected to encapsulate
+    /// a stateful resource such as a file handle that can be iterated.
+    ///
+    /// `next` should return `Some(a)` to signal a new list element `a`.
+    ///
+    /// `next` should return `None` to signal the end of building the list.
+    ///
+    pub def unfoldWithIterator(next: () -> Option[a] & e): List[a] & e = unfoldWithIteratorHelper(next, xs -> xs)
+
+    ///
+    /// Helper function for `unfoldWithIterator`.
+    ///
+    def unfoldWithIteratorHelper(next: () -> Option[a] & e, cont: List[a] -> List[a]): List[a] & e = match next() {
+        case None => cont(Nil)
+        case Some(a) => unfoldWithIteratorHelper(next, xs -> cont(a :: xs))
+    }
+
+    ///
     /// Compares `xs` and `ys` lexicographically.
     ///
     def __cmp(xs: List[a], ys: List[a]): Int32 = match (xs, ys) {

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -919,10 +919,13 @@ namespace List {
     }
 
     ///
-    /// TODO.
+    /// Build a list by applying `f` to the seed value `st`.
+    ///
+    /// `f` should return `Some(a,st1)` to signal a new list element `a` and a new seed value `st1`.
+    ///
+    /// `f` should return `None` to signal the end of building the list.
     ///
     pub def unfold(f: s -> Option[(a, s)] & e, st: s): List[a] & e = unfoldHelper(f, st, xs -> xs)
-
 
     ///
     /// Helper function for `unfold`.

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -845,6 +845,80 @@ namespace List {
         }
 
     ///
+    /// Sort list `xs` with the comparing function `cmp`.
+    ///
+    /// The sort implementation is a mergesort.
+    /// Acknowlegdement: derived from Thomas Nordin's `sortBy` in the Haskell base libraries.
+    ///
+    pub def sortWith(cmp: (a,a) -> Int32, xs: List[a]): List[a] =
+        sortGenerateSequences(cmp, xs) |> sortMergeAll(cmp)
+
+    ///
+    /// Helper function for `sortWith`.
+    ///
+    def sortGenerateSequences(cmp: (a,a) -> Int32, xs: List[a]): List[List[a]] = match xs {
+        case a :: b :: rs =>
+            if (cmp(a, b) > 0)
+                sortDescendingStep(cmp, b, a :: Nil, rs)
+            else
+                sortAscendingStep(cmp, b, vs -> a :: vs, rs)
+        case rs => rs :: Nil
+    }
+
+    ///
+    /// Helper function for `sortWith`.
+    ///
+    def sortDescendingStep(cmp: (a,a) -> Int32, x: a, xs: List[a], ys: List[a]): List[List[a]] = match ys {
+        case r1 :: rs if (cmp(x, r1) > 0) =>
+            sortDescendingStep(cmp, r1, x :: xs, rs)
+        case rs =>
+            (x :: xs) :: sortGenerateSequences(cmp, rs)
+    }
+
+    ///
+    /// Helper function for `sortWith`.
+    ///
+    def sortAscendingStep(cmp: (a,a) -> Int32, x: a, xsf: List[a] -> List[a], ys: List[a]): List[List[a]] = match ys {
+        case r1 :: rs if (cmp(x, r1) <= 0)  =>
+            sortAscendingStep(cmp, r1, vs -> xsf(x :: vs), rs)
+        case rs =>
+            let x1 = xsf( x :: Nil);
+            x1 :: sortGenerateSequences(cmp, rs)
+        }
+
+    ///
+    /// Helper function for `sortWith`.
+    ///
+    def sortMergeAll(cmp: (a,a) -> Int32, xss: List[List[a]]) : List[a] = match xss {
+        case x :: Nil => x
+        case rs => sortMergeAll(cmp, sortMergePairs(cmp, rs))
+    }
+
+    ///
+    /// Helper function for `sortWith`.
+    ///
+    def sortMergePairs(cmp: (a,a) -> Int32, xss: List[List[a]]) : List[List[a]] = match xss {
+        case a :: b :: rs => {
+            let x = sortMerge(cmp, a, b);
+            x :: sortMergePairs(cmp, rs)
+        }
+        case rs => rs
+    }
+
+    ///
+    /// Helper function for `sortWith`.
+    ///
+    def sortMerge(cmp: (a,a) -> Int32, xs: List[a], ys: List[a]) : List[a] = match (xs, ys) {
+            case (r :: rs, s :: ss) =>
+                if (cmp(r,s) > 0)
+                    s :: sortMerge(cmp, xs, ss)
+                else
+                    r :: sortMerge(cmp, rs, ys)
+            case (Nil, ss) => ss
+            case (rs, Nil) => rs
+    }
+
+    ///
     /// Compares `xs` and `ys` lexicographically.
     ///
     def __cmp(xs: List[a], ys: List[a]): Int32 = match (xs, ys) {

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -493,6 +493,16 @@ namespace Map {
         let Map(xs) = m;
         RedBlackTree.foreach(f, xs)
 
+    pub def unfold(f: s -> Option[(k, v, s)] & e, st: s): Map[k,v] & e = unfoldHelper(f, st, empty())
+
+    ///
+    /// Helper function for `unfold`.
+    ///
+    pub def unfoldHelper(f: s -> Option[(k, v, s)] & e, st: s, ac: Map[k,v]): Map[k,v] & e = match f(st) {
+        case None => ac
+        case Some((k, v, st1)) => unfoldHelper(f, st1, insert(k, v, ac))
+    }
+
     ///
     /// Helper function for `cmp`.
     ///

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -511,6 +511,24 @@ namespace Map {
     }
 
     ///
+    /// Build a map by applying the function `next` to `()`. `next` is expected to encapsulate
+    /// a stateful resource such as a file handle that can be iterated.
+    ///
+    /// `next` should return `Some(k,v)` to signal a new key-value pair `k` and `v`.
+    ///
+    /// `next` should return `None` to signal the end of building the map.
+    ///
+    pub def unfoldWithIterator(next: () -> Option[(k, v)] & e): Map[k, v] & e = unfoldWithIteratorHelper(next, empty())
+
+    ///
+    /// Helper function for `unfoldWithIterator`.
+    ///
+    def unfoldWithIteratorHelper(next: () -> Option[(k, v)] & e, ac: Map[k, v]): Map[k, v] & e = match next() {
+        case None => ac
+        case Some(k, v) => unfoldWithIteratorHelper(next, insert(k, v, ac))
+    }
+
+    ///
     /// Helper function for `cmp`.
     ///
     def __cmpHelper(m1: List[(k, v)], m2: List[(k, v)]): Int32 = match (m1, m2) {

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -493,6 +493,13 @@ namespace Map {
         let Map(xs) = m;
         RedBlackTree.foreach(f, xs)
 
+    ///
+    /// Build a map by applying `f` to the seed value `st`.
+    ///
+    /// `f` should return `Some(k,v,st1)` to signal a new key-value pair `k` and `v` and a new seed value `st1`.
+    ///
+    /// `f` should return `None` to signal the end of building the map.
+    ///
     pub def unfold(f: s -> Option[(k, v, s)] & e, st: s): Map[k,v] & e = unfoldHelper(f, st, empty())
 
     ///

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -518,14 +518,14 @@ namespace Map {
     ///
     /// `next` should return `None` to signal the end of building the map.
     ///
-    pub def unfoldWithIterator(next: () -> Option[(k, v)] & e): Map[k, v] & e = unfoldWithIteratorHelper(next, empty())
+    pub def unfoldWithIter(next: () -> Option[(k, v)] & e): Map[k, v] & e = unfoldWithIterHelper(next, empty())
 
     ///
-    /// Helper function for `unfoldWithIterator`.
+    /// Helper function for `unfoldWithIter`.
     ///
-    def unfoldWithIteratorHelper(next: () -> Option[(k, v)] & e, ac: Map[k, v]): Map[k, v] & e = match next() {
+    def unfoldWithIterHelper(next: () -> Option[(k, v)] & e, ac: Map[k, v]): Map[k, v] & e = match next() {
         case None => ac
-        case Some(k, v) => unfoldWithIteratorHelper(next, insert(k, v, ac))
+        case Some(k, v) => unfoldWithIterHelper(next, insert(k, v, ac))
     }
 
     ///

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -505,7 +505,7 @@ namespace Map {
     ///
     /// Helper function for `unfold`.
     ///
-    pub def unfoldHelper(f: s -> Option[(k, v, s)] & e, st: s, ac: Map[k,v]): Map[k,v] & e = match f(st) {
+    def unfoldHelper(f: s -> Option[(k, v, s)] & e, st: s, ac: Map[k,v]): Map[k,v] & e = match f(st) {
         case None => ac
         case Some((k, v, st1)) => unfoldHelper(f, st1, insert(k, v, ac))
     }
@@ -518,12 +518,12 @@ namespace Map {
     ///
     /// `next` should return `None` to signal the end of building the map.
     ///
-    pub def unfoldWithIter(next: () -> Option[(k, v)] & e): Map[k, v] & e = unfoldWithIterHelper(next, empty())
+    pub def unfoldWithIter(next: () ~> Option[(k, v)]): Map[k, v] & Impure = unfoldWithIterHelper(next, empty())
 
     ///
     /// Helper function for `unfoldWithIter`.
     ///
-    def unfoldWithIterHelper(next: () -> Option[(k, v)] & e, ac: Map[k, v]): Map[k, v] & e = match next() {
+    def unfoldWithIterHelper(next: () ~> Option[(k, v)], ac: Map[k, v]): Map[k, v] & Impure = match next() {
         case None => ac
         case Some(k, v) => unfoldWithIterHelper(next, insert(k, v, ac))
     }

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -335,7 +335,11 @@ namespace Set {
         RedBlackTree.foreach((x, _) -> f(x), es)
 
     ///
-    /// TODO
+    /// Build a set by applying `f` to the seed value `st`.
+    ///
+    /// `f` should return `Some(a,st1)` to signal a new set element `a` and a new seed value `st1`.
+    ///
+    /// `f` should return `None` to signal the end of building the set.
     ///
     pub def unfold(f: s -> Option[(a, s)] & e, st: s): Set[a] & e = unfoldHelper(f, st, empty())
 

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -359,14 +359,14 @@ namespace Set {
     ///
     /// `next` should return `None` to signal the end of building the set.
     ///
-    pub def unfoldWithIterator(next: () -> Option[a] & e): Set[a] & e = unfoldWithIteratorHelper(next, empty())
+    pub def unfoldWithIter(next: () -> Option[a] & e): Set[a] & e = unfoldWithIterHelper(next, empty())
 
     ///
-    /// Helper function for `unfoldWithIterator`.
+    /// Helper function for `unfoldWithIter`.
     ///
-    def unfoldWithIteratorHelper(next: () -> Option[a] & e, ac: Set[a]): Set[a] & e = match next() {
+    def unfoldWithIterHelper(next: () -> Option[a] & e, ac: Set[a]): Set[a] & e = match next() {
         case None => ac
-        case Some(a) => unfoldWithIteratorHelper(next, insert(a, ac))
+        case Some(a) => unfoldWithIterHelper(next, insert(a, ac))
     }
 
     ///

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -346,7 +346,7 @@ namespace Set {
     ///
     /// Helper function for `unfold`.
     ///
-    pub def unfoldHelper(f: s -> Option[(a, s)] & e, st: s, ac: Set[a]): Set[a] & e = match f(st) {
+    def unfoldHelper(f: s -> Option[(a, s)] & e, st: s, ac: Set[a]): Set[a] & e = match f(st) {
         case None => ac
         case Some((a, st1)) => unfoldHelper(f, st1, insert(a, ac))
     }
@@ -359,12 +359,12 @@ namespace Set {
     ///
     /// `next` should return `None` to signal the end of building the set.
     ///
-    pub def unfoldWithIter(next: () -> Option[a] & e): Set[a] & e = unfoldWithIterHelper(next, empty())
+    pub def unfoldWithIter(next: () ~> Option[a]): Set[a] & Impure = unfoldWithIterHelper(next, empty())
 
     ///
     /// Helper function for `unfoldWithIter`.
     ///
-    def unfoldWithIterHelper(next: () -> Option[a] & e, ac: Set[a]): Set[a] & e = match next() {
+    def unfoldWithIterHelper(next: () ~> Option[a], ac: Set[a]): Set[a] & Impure = match next() {
         case None => ac
         case Some(a) => unfoldWithIterHelper(next, insert(a, ac))
     }

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -352,6 +352,24 @@ namespace Set {
     }
 
     ///
+    /// Build a set by applying the function `next` to `()`. `next` is expected to encapsulate
+    /// a stateful resource such as a file handle that can be iterated.
+    ///
+    /// `next` should return `Some(a)` to signal a value pair `a`.
+    ///
+    /// `next` should return `None` to signal the end of building the set.
+    ///
+    pub def unfoldWithIterator(next: () -> Option[a] & e): Set[a] & e = unfoldWithIteratorHelper(next, empty())
+
+    ///
+    /// Helper function for `unfoldWithIterator`.
+    ///
+    def unfoldWithIteratorHelper(next: () -> Option[a] & e, ac: Set[a]): Set[a] & e = match next() {
+        case None => ac
+        case Some(a) => unfoldWithIteratorHelper(next, insert(a, ac))
+    }
+
+    ///
     /// Helper function for `cmp`.
     ///
     def __cmpHelper(xs: List[a], ys: List[a]): Int32 = match (xs, ys) {

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -335,6 +335,19 @@ namespace Set {
         RedBlackTree.foreach((x, _) -> f(x), es)
 
     ///
+    /// TODO
+    ///
+    pub def unfold(f: s -> Option[(a, s)] & e, st: s): Set[a] & e = unfoldHelper(f, st, empty())
+
+    ///
+    /// Helper function for `unfold`.
+    ///
+    pub def unfoldHelper(f: s -> Option[(a, s)] & e, st: s, ac: Set[a]): Set[a] & e = match f(st) {
+        case None => ac
+        case Some((a, st1)) => unfoldHelper(f, st1, insert(a, ac))
+    }
+
+    ///
     /// Helper function for `cmp`.
     ///
     def __cmpHelper(xs: List[a], ys: List[a]): Int32 = match (xs, ys) {

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -1836,4 +1836,86 @@ def unfold05(): Bool =
 def unfold06(): Bool =
     List.unfold(s -> if (s >= 10) None else Some(Char.fromInt32(s + 48), s + 2), 0) == '0' :: '2' :: '4' :: '6' :: '8' :: Nil
 
+/////////////////////////////////////////////////////////////////////////////
+// unfoldWithIterator                                                      //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def unfoldWithIterator01(): Bool & Impure =
+    let x = ref 0;
+    let step = () ->
+        if (true)
+            None
+        else {
+            let c = Char.fromInt32(deref x + 48);
+            x := deref x + 1;
+            Some(c)
+        };
+    List.unfoldWithIterator(step) == Nil
+
+@test
+def unfoldWithIterator02(): Bool & Impure =
+    let x = ref 0;
+    let step = () ->
+        if (deref x > 0)
+            None
+        else {
+            let c = Char.fromInt32(deref x + 48);
+            x := deref x + 1;
+            Some(c)
+        };
+    List.unfoldWithIterator(step) == '0' :: Nil
+
+@test
+def unfoldWithIterator03(): Bool & Impure =
+    let x = ref 0;
+    let step = () ->
+        if (deref x > 1)
+            None
+        else {
+            let c = Char.fromInt32(deref x + 48);
+            x := deref x + 1;
+            Some(c)
+        };
+    List.unfoldWithIterator(step) == '0' :: '1' :: Nil
+
+@test
+def unfoldWithIterator04(): Bool & Impure =
+    let x = ref 0;
+    let step = () ->
+        if (deref x >= 10)
+            None
+        else {
+            let c = Char.fromInt32(deref x + 48);
+            x := deref x + 1;
+            Some(c)
+        };
+    List.unfoldWithIterator(step) == '0' :: '1' :: '2' :: '3' :: '4' :: '5' :: '6' :: '7' :: '8' :: '9' :: Nil
+
+@test
+def unfoldWithIterator05(): Bool & Impure =
+    let x = ref 5;
+    let step = () ->
+        if (deref x >= 10)
+            None
+        else {
+            let c = Char.fromInt32(deref x + 48);
+            x := deref x + 1;
+            Some(c)
+        };
+    List.unfoldWithIterator(step) == '5' :: '6' :: '7' :: '8' :: '9' :: Nil
+
+@test
+def unfoldWithIterator06(): Bool & Impure =
+    let x = ref 0;
+    let step = () ->
+        if (deref x >= 10)
+            None
+        else {
+            let c = Char.fromInt32(deref x + 48);
+            x := deref x + 2;
+            Some(c)
+        };
+    List.unfoldWithIterator(step) == '0' :: '2' :: '4' :: '6' :: '8' :: Nil
+
 }

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -1824,4 +1824,16 @@ def unfold02(): Bool =
 def unfold03(): Bool =
     List.unfold(s -> if (s > 1) None else Some(Char.fromInt32(s + 48), s + 1), 0) == '0' :: '1' :: Nil
 
+@test
+def unfold04(): Bool =
+    List.unfold(s -> if (s >= 10) None else Some(Char.fromInt32(s + 48), s + 1), 0) == '0' :: '1' :: '2' :: '3' :: '4' :: '5' :: '6' :: '7' :: '8' :: '9' :: Nil
+
+@test
+def unfold05(): Bool =
+    List.unfold(s -> if (s >= 10) None else Some(Char.fromInt32(s + 48), s + 1), 5) == '5' :: '6' :: '7' :: '8' :: '9' :: Nil
+
+@test
+def unfold06(): Bool =
+    List.unfold(s -> if (s >= 10) None else Some(Char.fromInt32(s + 48), s + 2), 0) == '0' :: '2' :: '4' :: '6' :: '8' :: Nil
+
 }

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -1752,5 +1752,61 @@ def toArray04(): Bool & Impure =
     let a = List.toArray(1 :: 2 :: 3 :: Nil);
     Array.sameElements(a, [1,2,3])
 
+/////////////////////////////////////////////////////////////////////////////
+// sortWith                                                                //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def sortWith01(): Bool =
+    List.sortWith((x,y) -> if (x < y) -1 else 1, Nil: List[Int32]) == Nil
+
+@test
+def sortWith02(): Bool =
+    List.sortWith((x,y) -> if (x < y) -1 else 1, 0 :: Nil) == 0 :: Nil
+
+@test
+def sortWith03(): Bool =
+    List.sortWith((x,y) -> if (x < y) -1 else 1, 0 :: 1 :: Nil) == 0 :: 1 :: Nil
+
+@test
+def sortWith04(): Bool =
+    List.sortWith((x,y) -> if (x < y) -1 else 1, 1 :: 0 :: Nil) == 0 :: 1 :: Nil
+
+@test
+def sortWith05(): Bool =
+    List.sortWith((x,y) -> if (x < y) -1 else 1, 1 :: 1 :: Nil) == 1 :: 1 :: Nil
+
+@test
+def sortWith06(): Bool =
+    List.sortWith((x,y) -> if (x < y) -1 else 1, 0 :: 1 :: 2 :: 3 :: 4 :: 5 :: Nil) == 0 :: 1 :: 2 :: 3 :: 4 :: 5 :: Nil
+
+@test
+def sortWith07(): Bool =
+    List.sortWith((x,y) -> if (x < y) -1 else 1, 5 :: 4 :: 3 :: 2 :: 1 :: 0 :: Nil) == 0 :: 1 :: 2 :: 3 :: 4 :: 5 :: Nil
+
+@test
+def sortWith08(): Bool =
+    List.sortWith((x,y) -> if (x < y) -1 else 1, 5 :: 3 :: 0 :: 4 :: 1 :: 2 :: Nil) == 0 :: 1 :: 2 :: 3 :: 4 :: 5 :: Nil
+
+@test
+def sortWith09(): Bool =
+    List.sortWith((x,y) -> if (x < y) -1 else 1, 2 :: 3 :: 0 :: 4 :: 1 :: 2 :: Nil) == 0 :: 1 :: 2 :: 2 :: 3 :: 4 :: Nil
+
+@test
+def sortWith10(): Bool =
+    List.sortWith((x,y) -> if (x > y) -1 else 1, 0 :: 1 :: 2 :: 3 :: 4 :: 5 :: Nil) == 5 :: 4 :: 3 :: 2 :: 1 :: 0 :: Nil
+
+@test
+def sortWith11(): Bool =
+    List.sortWith((x,y) -> if (x > y) -1 else 1, 5 :: 4 :: 3 :: 2 :: 1 :: 0 :: Nil) == 5 :: 4 :: 3 :: 2 :: 1 :: 0 :: Nil
+
+@test
+def sortWith12(): Bool =
+    List.sortWith((x,y) -> if (x > y) -1 else 1, 5 :: 3 :: 0 :: 4 :: 1 :: 2 :: Nil) == 5 :: 4 :: 3 :: 2 :: 1 :: 0 :: Nil
+
+@test
+def sortWith13(): Bool =
+    List.sortWith((x,y) -> if (x > y) -1 else 1, 2 :: 3 :: 0 :: 4 :: 1 :: 2 :: Nil) == 4 :: 3 :: 2 :: 2 :: 1 :: 0 :: Nil
+
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -1808,5 +1808,20 @@ def sortWith12(): Bool =
 def sortWith13(): Bool =
     List.sortWith((x,y) -> if (x > y) -1 else 1, 2 :: 3 :: 0 :: 4 :: 1 :: 2 :: Nil) == 4 :: 3 :: 2 :: 2 :: 1 :: 0 :: Nil
 
+/////////////////////////////////////////////////////////////////////////////
+// unfold                                                                  //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def unfold01(): Bool =
+    List.unfold(s -> if (true) None else Some(Char.fromInt32(s + 48), s + 1), 0) == Nil
+
+@test
+def unfold02(): Bool =
+    List.unfold(s -> if (s > 0) None else Some(Char.fromInt32(s + 48), s + 1), 0) == '0' :: Nil
+
+@test
+def unfold03(): Bool =
+    List.unfold(s -> if (s > 1) None else Some(Char.fromInt32(s + 48), s + 1), 0) == '0' :: '1' :: Nil
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -1837,11 +1837,11 @@ def unfold06(): Bool =
     List.unfold(s -> if (s >= 10) None else Some(Char.fromInt32(s + 48), s + 2), 0) == '0' :: '2' :: '4' :: '6' :: '8' :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
-// unfoldWithIterator                                                      //
+// unfoldWithIter                                                          //
 /////////////////////////////////////////////////////////////////////////////
 
 @test
-def unfoldWithIterator01(): Bool & Impure =
+def unfoldWithIter01(): Bool & Impure =
     let x = ref 0;
     let step = () ->
         if (true)
@@ -1851,10 +1851,10 @@ def unfoldWithIterator01(): Bool & Impure =
             x := deref x + 1;
             Some(c)
         };
-    List.unfoldWithIterator(step) == Nil
+    List.unfoldWithIter(step) == Nil
 
 @test
-def unfoldWithIterator02(): Bool & Impure =
+def unfoldWithIter02(): Bool & Impure =
     let x = ref 0;
     let step = () ->
         if (deref x > 0)
@@ -1864,10 +1864,10 @@ def unfoldWithIterator02(): Bool & Impure =
             x := deref x + 1;
             Some(c)
         };
-    List.unfoldWithIterator(step) == '0' :: Nil
+    List.unfoldWithIter(step) == '0' :: Nil
 
 @test
-def unfoldWithIterator03(): Bool & Impure =
+def unfoldWithIter03(): Bool & Impure =
     let x = ref 0;
     let step = () ->
         if (deref x > 1)
@@ -1877,10 +1877,10 @@ def unfoldWithIterator03(): Bool & Impure =
             x := deref x + 1;
             Some(c)
         };
-    List.unfoldWithIterator(step) == '0' :: '1' :: Nil
+    List.unfoldWithIter(step) == '0' :: '1' :: Nil
 
 @test
-def unfoldWithIterator04(): Bool & Impure =
+def unfoldWithIter04(): Bool & Impure =
     let x = ref 0;
     let step = () ->
         if (deref x >= 10)
@@ -1890,10 +1890,10 @@ def unfoldWithIterator04(): Bool & Impure =
             x := deref x + 1;
             Some(c)
         };
-    List.unfoldWithIterator(step) == '0' :: '1' :: '2' :: '3' :: '4' :: '5' :: '6' :: '7' :: '8' :: '9' :: Nil
+    List.unfoldWithIter(step) == '0' :: '1' :: '2' :: '3' :: '4' :: '5' :: '6' :: '7' :: '8' :: '9' :: Nil
 
 @test
-def unfoldWithIterator05(): Bool & Impure =
+def unfoldWithIter05(): Bool & Impure =
     let x = ref 5;
     let step = () ->
         if (deref x >= 10)
@@ -1903,10 +1903,10 @@ def unfoldWithIterator05(): Bool & Impure =
             x := deref x + 1;
             Some(c)
         };
-    List.unfoldWithIterator(step) == '5' :: '6' :: '7' :: '8' :: '9' :: Nil
+    List.unfoldWithIter(step) == '5' :: '6' :: '7' :: '8' :: '9' :: Nil
 
 @test
-def unfoldWithIterator06(): Bool & Impure =
+def unfoldWithIter06(): Bool & Impure =
     let x = ref 0;
     let step = () ->
         if (deref x >= 10)
@@ -1916,6 +1916,6 @@ def unfoldWithIterator06(): Bool & Impure =
             x := deref x + 2;
             Some(c)
         };
-    List.unfoldWithIterator(step) == '0' :: '2' :: '4' :: '6' :: '8' :: Nil
+    List.unfoldWithIter(step) == '0' :: '2' :: '4' :: '6' :: '8' :: Nil
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMap.flix
@@ -1589,11 +1589,11 @@ def unfold06(): Bool =
     Map.unfold(s -> if (s >= 10) None else Some(s, Char.fromInt32(s + 48), s + 2), 0) == Map#{0 -> '0', 2 -> '2', 4 -> '4', 6 -> '6', 8 -> '8'}
 
 /////////////////////////////////////////////////////////////////////////////
-// unfoldWithIterator                                                      //
+// unfoldWithIter                                                          //
 /////////////////////////////////////////////////////////////////////////////
 
 @test
-def unfoldWithIterator01(): Bool & Impure =
+def unfoldWithIter01(): Bool & Impure =
     let x = ref 0;
     let step = () ->
         if (true)
@@ -1604,10 +1604,10 @@ def unfoldWithIterator01(): Bool & Impure =
             x := deref x + 1;
             Some(k, v)
         };
-    Map.unfoldWithIterator(step) == Map#{}
+    Map.unfoldWithIter(step) == Map#{}
 
 @test
-def unfoldWithIterator02(): Bool & Impure =
+def unfoldWithIter02(): Bool & Impure =
     let x = ref 0;
     let step = () ->
         if (deref x > 0)
@@ -1618,10 +1618,10 @@ def unfoldWithIterator02(): Bool & Impure =
             x := deref x + 1;
             Some(k, v)
         };
-    Map.unfoldWithIterator(step) == Map#{0 -> '0'}
+    Map.unfoldWithIter(step) == Map#{0 -> '0'}
 
 @test
-def unfoldWithIterator03(): Bool & Impure =
+def unfoldWithIter03(): Bool & Impure =
     let x = ref 0;
     let step = () ->
         if (deref x > 1)
@@ -1632,10 +1632,10 @@ def unfoldWithIterator03(): Bool & Impure =
             x := deref x + 1;
             Some(k, v)
         };
-    Map.unfoldWithIterator(step) == Map#{0 -> '0', 1 -> '1'}
+    Map.unfoldWithIter(step) == Map#{0 -> '0', 1 -> '1'}
 
 @test
-def unfoldWithIterator04(): Bool & Impure =
+def unfoldWithIter04(): Bool & Impure =
     let x = ref 0;
     let step = () ->
         if (deref x >= 10)
@@ -1646,10 +1646,10 @@ def unfoldWithIterator04(): Bool & Impure =
             x := deref x + 1;
             Some(k, v)
         };
-    Map.unfoldWithIterator(step) == Map#{0 -> '0', 1 -> '1', 2 -> '2', 3 -> '3', 4 -> '4', 5 -> '5', 6 -> '6', 7 -> '7', 8 -> '8', 9 -> '9'}
+    Map.unfoldWithIter(step) == Map#{0 -> '0', 1 -> '1', 2 -> '2', 3 -> '3', 4 -> '4', 5 -> '5', 6 -> '6', 7 -> '7', 8 -> '8', 9 -> '9'}
 
 @test
-def unfoldWithIterator05(): Bool & Impure =
+def unfoldWithIter05(): Bool & Impure =
     let x = ref 5;
     let step = () ->
         if (deref x >= 10)
@@ -1660,10 +1660,10 @@ def unfoldWithIterator05(): Bool & Impure =
             x := deref x + 1;
             Some(k, v)
         };
-    Map.unfoldWithIterator(step) == Map#{5 -> '5', 6 -> '6', 7 -> '7', 8 -> '8', 9 -> '9'}
+    Map.unfoldWithIter(step) == Map#{5 -> '5', 6 -> '6', 7 -> '7', 8 -> '8', 9 -> '9'}
 
 @test
-def unfoldWithIterator06(): Bool & Impure =
+def unfoldWithIter06(): Bool & Impure =
     let x = ref 0;
     let step = () ->
         if (deref x >= 10)
@@ -1674,6 +1674,6 @@ def unfoldWithIterator06(): Bool & Impure =
             x := deref x + 2;
             Some(k, v)
         };
-    Map.unfoldWithIterator(step) == Map#{0 -> '0', 2 -> '2', 4 -> '4', 6 -> '6', 8 -> '8'}
+    Map.unfoldWithIter(step) == Map#{0 -> '0', 2 -> '2', 4 -> '4', 6 -> '6', 8 -> '8'}
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMap.flix
@@ -1588,4 +1588,92 @@ def unfold05(): Bool =
 def unfold06(): Bool =
     Map.unfold(s -> if (s >= 10) None else Some(s, Char.fromInt32(s + 48), s + 2), 0) == Map#{0 -> '0', 2 -> '2', 4 -> '4', 6 -> '6', 8 -> '8'}
 
+/////////////////////////////////////////////////////////////////////////////
+// unfoldWithIterator                                                      //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def unfoldWithIterator01(): Bool & Impure =
+    let x = ref 0;
+    let step = () ->
+        if (true)
+            None
+        else {
+            let k = deref x;
+            let v = Char.fromInt32(k + 48);
+            x := deref x + 1;
+            Some(k, v)
+        };
+    Map.unfoldWithIterator(step) == Map#{}
+
+@test
+def unfoldWithIterator02(): Bool & Impure =
+    let x = ref 0;
+    let step = () ->
+        if (deref x > 0)
+            None
+        else {
+            let k = deref x;
+            let v = Char.fromInt32(k + 48);
+            x := deref x + 1;
+            Some(k, v)
+        };
+    Map.unfoldWithIterator(step) == Map#{0 -> '0'}
+
+@test
+def unfoldWithIterator03(): Bool & Impure =
+    let x = ref 0;
+    let step = () ->
+        if (deref x > 1)
+            None
+        else {
+            let k = deref x;
+            let v = Char.fromInt32(k + 48);
+            x := deref x + 1;
+            Some(k, v)
+        };
+    Map.unfoldWithIterator(step) == Map#{0 -> '0', 1 -> '1'}
+
+@test
+def unfoldWithIterator04(): Bool & Impure =
+    let x = ref 0;
+    let step = () ->
+        if (deref x >= 10)
+            None
+        else {
+            let k = deref x;
+            let v = Char.fromInt32(k + 48);
+            x := deref x + 1;
+            Some(k, v)
+        };
+    Map.unfoldWithIterator(step) == Map#{0 -> '0', 1 -> '1', 2 -> '2', 3 -> '3', 4 -> '4', 5 -> '5', 6 -> '6', 7 -> '7', 8 -> '8', 9 -> '9'}
+
+@test
+def unfoldWithIterator05(): Bool & Impure =
+    let x = ref 5;
+    let step = () ->
+        if (deref x >= 10)
+            None
+        else {
+            let k = deref x;
+            let v = Char.fromInt32(k + 48);
+            x := deref x + 1;
+            Some(k, v)
+        };
+    Map.unfoldWithIterator(step) == Map#{5 -> '5', 6 -> '6', 7 -> '7', 8 -> '8', 9 -> '9'}
+
+@test
+def unfoldWithIterator06(): Bool & Impure =
+    let x = ref 0;
+    let step = () ->
+        if (deref x >= 10)
+            None
+        else {
+            let k = deref x;
+            let v = Char.fromInt32(k + 48);
+            x := deref x + 2;
+            Some(k, v)
+        };
+    Map.unfoldWithIterator(step) == Map#{0 -> '0', 2 -> '2', 4 -> '4', 6 -> '6', 8 -> '8'}
+
 }

--- a/main/test/ca/uwaterloo/flix/library/TestMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMap.flix
@@ -1560,4 +1560,32 @@ def foreach02(): Bool & Impure =
     Map.foreach((k, _) -> r := k, Map#{1 -> "Hello World!"});
     1 == deref r
 
+/////////////////////////////////////////////////////////////////////////////
+// unfold                                                                  //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def unfold01(): Bool =
+    Map.unfold(s -> if (true) None else Some(s, Char.fromInt32(s + 48), s + 1), 0) == Map#{}
+
+@test
+def unfold02(): Bool =
+    Map.unfold(s -> if (s > 0) None else Some(s, Char.fromInt32(s + 48), s + 1), 0) == Map#{0 -> '0'}
+
+@test
+def unfold03(): Bool =
+    Map.unfold(s -> if (s > 1) None else Some(s, Char.fromInt32(s + 48), s + 1), 0) == Map#{0 -> '0', 1 -> '1'}
+
+@test
+def unfold04(): Bool =
+    Map.unfold(s -> if (s >= 10) None else Some(s, Char.fromInt32(s + 48), s + 1), 0) == Map#{0 -> '0', 1 -> '1', 2 -> '2', 3 -> '3', 4 -> '4', 5 -> '5', 6 -> '6', 7 -> '7', 8 -> '8', 9 -> '9'}
+
+@test
+def unfold05(): Bool =
+    Map.unfold(s -> if (s >= 10) None else Some(s, Char.fromInt32(s + 48), s + 1), 5) == Map#{5 -> '5', 6 -> '6', 7 -> '7', 8 -> '8', 9 -> '9'}
+
+@test
+def unfold06(): Bool =
+    Map.unfold(s -> if (s >= 10) None else Some(s, Char.fromInt32(s + 48), s + 2), 0) == Map#{0 -> '0', 2 -> '2', 4 -> '4', 6 -> '6', 8 -> '8'}
+
 }

--- a/main/test/ca/uwaterloo/flix/library/TestSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSet.flix
@@ -1054,11 +1054,11 @@ def unfold06(): Bool =
     Set.unfold(s -> if (s >= 10) None else Some(Char.fromInt32(s + 48), s + 2), 0) == Set#{'0', '2', '4', '6', '8'}
 
 /////////////////////////////////////////////////////////////////////////////
-// unfoldWithIterator                                                      //
+// unfoldWithIter                                                          //
 /////////////////////////////////////////////////////////////////////////////
 
 @test
-def unfoldWithIterator01(): Bool & Impure =
+def unfoldWithIter01(): Bool & Impure =
     let x = ref 0;
     let step = () ->
         if (true)
@@ -1068,10 +1068,10 @@ def unfoldWithIterator01(): Bool & Impure =
             x := deref x + 1;
             Some(c)
         };
-    Set.unfoldWithIterator(step) == Set#{}
+    Set.unfoldWithIter(step) == Set#{}
 
 @test
-def unfoldWithIterator02(): Bool & Impure =
+def unfoldWithIter02(): Bool & Impure =
     let x = ref 0;
     let step = () ->
         if (deref x > 0)
@@ -1081,10 +1081,10 @@ def unfoldWithIterator02(): Bool & Impure =
             x := deref x + 1;
             Some(c)
         };
-    Set.unfoldWithIterator(step) == Set#{'0'}
+    Set.unfoldWithIter(step) == Set#{'0'}
 
 @test
-def unfoldWithIterator03(): Bool & Impure =
+def unfoldWithIter03(): Bool & Impure =
     let x = ref 0;
     let step = () ->
         if (deref x > 1)
@@ -1094,10 +1094,10 @@ def unfoldWithIterator03(): Bool & Impure =
             x := deref x + 1;
             Some(c)
         };
-    Set.unfoldWithIterator(step) == Set#{'0', '1'}
+    Set.unfoldWithIter(step) == Set#{'0', '1'}
 
 @test
-def unfoldWithIterator04(): Bool & Impure =
+def unfoldWithIter04(): Bool & Impure =
     let x = ref 0;
     let step = () ->
         if (deref x >= 10)
@@ -1107,10 +1107,10 @@ def unfoldWithIterator04(): Bool & Impure =
             x := deref x + 1;
             Some(c)
         };
-    Set.unfoldWithIterator(step) == Set#{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
+    Set.unfoldWithIter(step) == Set#{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
 
 @test
-def unfoldWithIterator05(): Bool & Impure =
+def unfoldWithIter05(): Bool & Impure =
     let x = ref 5;
     let step = () ->
         if (deref x >= 10)
@@ -1120,10 +1120,10 @@ def unfoldWithIterator05(): Bool & Impure =
             x := deref x + 1;
             Some(c)
         };
-    Set.unfoldWithIterator(step) == Set#{'5', '6', '7', '8', '9'}
+    Set.unfoldWithIter(step) == Set#{'5', '6', '7', '8', '9'}
 
 @test
-def unfoldWithIterator06(): Bool & Impure =
+def unfoldWithIter06(): Bool & Impure =
     let x = ref 0;
     let step = () ->
         if (deref x >= 10)
@@ -1133,5 +1133,5 @@ def unfoldWithIterator06(): Bool & Impure =
             x := deref x + 2;
             Some(c)
         };
-    Set.unfoldWithIterator(step) == Set#{'0', '2', '4', '6', '8'}
+    Set.unfoldWithIter(step) == Set#{'0', '2', '4', '6', '8'}
 }

--- a/main/test/ca/uwaterloo/flix/library/TestSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSet.flix
@@ -1053,5 +1053,85 @@ def unfold05(): Bool =
 def unfold06(): Bool =
     Set.unfold(s -> if (s >= 10) None else Some(Char.fromInt32(s + 48), s + 2), 0) == Set#{'0', '2', '4', '6', '8'}
 
+/////////////////////////////////////////////////////////////////////////////
+// unfoldWithIterator                                                      //
+/////////////////////////////////////////////////////////////////////////////
 
+@test
+def unfoldWithIterator01(): Bool & Impure =
+    let x = ref 0;
+    let step = () ->
+        if (true)
+            None
+        else {
+            let c = Char.fromInt32(deref x + 48);
+            x := deref x + 1;
+            Some(c)
+        };
+    Set.unfoldWithIterator(step) == Set#{}
+
+@test
+def unfoldWithIterator02(): Bool & Impure =
+    let x = ref 0;
+    let step = () ->
+        if (deref x > 0)
+            None
+        else {
+            let c = Char.fromInt32(deref x + 48);
+            x := deref x + 1;
+            Some(c)
+        };
+    Set.unfoldWithIterator(step) == Set#{'0'}
+
+@test
+def unfoldWithIterator03(): Bool & Impure =
+    let x = ref 0;
+    let step = () ->
+        if (deref x > 1)
+            None
+        else {
+            let c = Char.fromInt32(deref x + 48);
+            x := deref x + 1;
+            Some(c)
+        };
+    Set.unfoldWithIterator(step) == Set#{'0', '1'}
+
+@test
+def unfoldWithIterator04(): Bool & Impure =
+    let x = ref 0;
+    let step = () ->
+        if (deref x >= 10)
+            None
+        else {
+            let c = Char.fromInt32(deref x + 48);
+            x := deref x + 1;
+            Some(c)
+        };
+    Set.unfoldWithIterator(step) == Set#{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
+
+@test
+def unfoldWithIterator05(): Bool & Impure =
+    let x = ref 5;
+    let step = () ->
+        if (deref x >= 10)
+            None
+        else {
+            let c = Char.fromInt32(deref x + 48);
+            x := deref x + 1;
+            Some(c)
+        };
+    Set.unfoldWithIterator(step) == Set#{'5', '6', '7', '8', '9'}
+
+@test
+def unfoldWithIterator06(): Bool & Impure =
+    let x = ref 0;
+    let step = () ->
+        if (deref x >= 10)
+            None
+        else {
+            let c = Char.fromInt32(deref x + 48);
+            x := deref x + 2;
+            Some(c)
+        };
+    Set.unfoldWithIterator(step) == Set#{'0', '2', '4', '6', '8'}
 }

--- a/main/test/ca/uwaterloo/flix/library/TestSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSet.flix
@@ -1025,5 +1025,33 @@ def foreach02(): Bool & Impure =
     Set.foreach(x -> r := x, Set#{42});
     42 == deref r
 
+/////////////////////////////////////////////////////////////////////////////
+// unfold                                                                  //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def unfold01(): Bool =
+    Set.unfold(s -> if (true) None else Some(Char.fromInt32(s + 48), s + 1), 0) == Set#{}
+
+@test
+def unfold02(): Bool =
+    Set.unfold(s -> if (s > 0) None else Some(Char.fromInt32(s + 48), s + 1), 0) == Set#{'0'}
+
+@test
+def unfold03(): Bool =
+    Set.unfold(s -> if (s > 1) None else Some(Char.fromInt32(s + 48), s + 1), 0) == Set#{'0', '1'}
+
+@test
+def unfold04(): Bool =
+    Set.unfold(s -> if (s >= 10) None else Some(Char.fromInt32(s + 48), s + 1), 0) == Set#{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
+
+@test
+def unfold05(): Bool =
+    Set.unfold(s -> if (s >= 10) None else Some(Char.fromInt32(s + 48), s + 1), 5) == Set#{'5', '6', '7', '8', '9'}
+
+@test
+def unfold06(): Bool =
+    Set.unfold(s -> if (s >= 10) None else Some(Char.fromInt32(s + 48), s + 2), 0) == Set#{'0', '2', '4', '6', '8'}
+
 
 }


### PR DESCRIPTION
Pull request for issue #1052 - Add `sortWith` to List / Add unfolds to List, Map and Set

Adds the following functions:

~~~

List.flix - sortWith
List.flix - unfold
List.flix - unfoldWithIter

Map.flix - unfold
Map.flix - unfoldWithIter

Set.flix - unfold
Set.flix - unfoldWithIter

~~~

The `sortWith` is a Flix implementation of `sortBy` from Haskell's Data.List - the Haskell code has been refined at least three times for performance.