### PR TITLE
Fix gradle "jar" build target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 target
 .ensime*
 /*.flix
+/build
+/.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,18 @@ sourceSets {
     }
 }
 
+jar {
+    manifest {
+        attributes 'Main-Class': 'ca.uwaterloo.flix.Main'
+    }
+
+    from {
+        // This line has to come before the next
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+        configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+}
+
 task testAll(dependsOn: ['testClasses'], type: JavaExec) {
     main = 'org.scalatest.tools.Runner'
     args = ['-s', 'ca.uwaterloo.flix.TestAll', '-o']
@@ -59,3 +71,4 @@ task testAll(dependsOn: ['testClasses'], type: JavaExec) {
 }
 
 test.dependsOn testAll
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The behaviour for the jar build target in gradle was not defined. This
has now been done so a jar can be build by running the gradle wrapper,
and giving jar as an argument (on linux "./gradlew jar"). This will
create build/lib/flix.jar.

This makes it possible to create a Flix jar with all neccesary dependencies, without using IntelliJ.

This will only work correctly after running gradle build. My understanding of gradle is not great enough to fix this.