### PR TITLE
Include flix std library in jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,10 @@ jar {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
         configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
+    
+    from('main/src') {
+        include 'library/**/*.flix'
+    }
 }
 
 task testAll(dependsOn: ['testClasses'], type: JavaExec) {


### PR DESCRIPTION
The way i tested for if the standard library was present in the last PR, turned out to be wrong. In this jar target, the Flix standard library is added as expected.