### PR TITLE
Fix #1091

### DIFF
--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -340,6 +340,7 @@ namespace RedBlackTree {
     def redden(tree: RedBlackTree[k, v]): RedBlackTree[k, v] = match tree {
         case Node(Black, Node(Black, a, k1, v1, b), k2, v2, Node(Black, c, k3, v3, d)) =>
             Node(Red, Node(Black, a, k1, v1, b), k2, v2, Node(Black, c, k3, v3, d))
+        case DoubleBlackLeaf => Leaf
         case _ => tree
     }
 

--- a/main/test/ca/uwaterloo/flix/library/TestRedBlackTree.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestRedBlackTree.flix
@@ -37,6 +37,20 @@ namespace TestRedBlackTree {
         !RedBlackTree.memberOf(99, RedBlackTree.delete(99, toTree(List.range(0, 100))))
 
     @test
+    def testEmptyAfterDelete01(): Bool =
+        RedBlackTree.empty() == RedBlackTree.delete(42, RedBlackTree.insert(42, (), RedBlackTree.empty()))
+
+    @test
+    def testEmptyAfterDelete02(): Bool =
+        RedBlackTree.empty() == RedBlackTree.delete(2, RedBlackTree.delete(1, RedBlackTree.delete(0, toTree(List.range(0, 3)))))
+
+    @test
+    def testEmptyAfterDelete03(): Bool =
+        let tree =
+        List.fold((acc, x) -> RedBlackTree.delete(x, acc), toTree(List.range(0, 20)), List.range(0, 20));
+        tree == RedBlackTree.empty()
+
+    @test
     def testBinarySearchTreeInvariant01(): Bool =
         checkBinarySearchTreeInvariant(toTree(List.range(0, 10)))
 


### PR DESCRIPTION
Fix issue #1091 by adding an extra case to the `redden` method which converts `DoubleBlackLeaf` to `Leaf`.