### PR TITLE
Well-Kinded Types Part I: Refactor record and schema kinds

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
@@ -26,7 +26,7 @@ sealed trait Kind {
   /**
     * Constructs an arrow kind.
     */
-  def ->(that: Kind): Kind = Kind.Arrow(List(this), that)
+  def ->:(left: Kind): Kind = Kind.Arrow(List(left), this)
 
   /**
     * Returns a human readable representation of `this` kind.

--- a/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
@@ -25,6 +25,10 @@ sealed trait Kind {
 
   /**
     * Constructs an arrow kind.
+    *
+    * This is a right-associative operator, i.e., the following two kinds are equivalent:
+    *   - `Kind.Star ->: Kind.Star ->: Kind.Star`
+    *   - `Kind.Star ->: (Kind.Star ->: Kind.Star)`
     */
   def ->:(left: Kind): Kind = Kind.Arrow(List(left), this)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
@@ -87,10 +87,6 @@ object Scheme {
       }
       case Type.Cst(_) => tpe0
       case Type.Arrow(l, eff) => Type.Arrow(l, visitType(eff))
-      case Type.RecordEmpty => Type.RecordEmpty
-      case Type.RecordExtend(label, value, rest) => Type.RecordExtend(label, visitType(value), visitType(rest))
-      case Type.SchemaEmpty => Type.SchemaEmpty
-      case Type.SchemaExtend(sym, t, rest) => Type.SchemaExtend(sym, visitType(t), visitType(rest))
       case Type.Zero => Type.Zero
       case Type.Succ(n, t) => Type.Succ(n, t)
       case Type.Apply(tpe1, tpe2) => Type.Apply(visitType(tpe1), visitType(tpe2))

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -41,10 +41,6 @@ sealed trait Type {
     case Type.Zero => SortedSet.empty
     case Type.Succ(n, t) => t.typeVars
     case Type.Arrow(_, eff) => eff.typeVars
-    case Type.RecordEmpty => SortedSet.empty
-    case Type.RecordExtend(label, value, rest) => value.typeVars ++ rest.typeVars
-    case Type.SchemaEmpty => SortedSet.empty
-    case Type.SchemaExtend(sym, tpe, rest) => tpe.typeVars ++ rest.typeVars
     case Type.Lambda(tvar, tpe) => tpe.typeVars - tvar
     case Type.Apply(tpe1, tpe2) => tpe1.typeVars ++ tpe2.typeVars
   }
@@ -96,10 +92,6 @@ sealed trait Type {
     case Type.Var(_, _, _) => 1
     case Type.Cst(tc) => 1
     case Type.Arrow(_, eff) => eff.size + 1
-    case Type.RecordEmpty => 1
-    case Type.RecordExtend(_, value, rest) => value.size + rest.size
-    case Type.SchemaEmpty => 1
-    case Type.SchemaExtend(_, tpe, rest) => tpe.size + rest.size
     case Type.Zero => 1
     case Type.Succ(_, t) => t.size + 1
     case Type.Lambda(_, tpe) => tpe.size + 1
@@ -175,6 +167,17 @@ object Type {
   val Str: Type = Type.Cst(TypeConstructor.Str)
 
   /**
+    * Represents the RecordEmpty type.
+    */
+  val RecordEmpty: Type = Type.Cst(TypeConstructor.RecordEmpty)
+
+
+  /**
+    * Represents the SchemaEmpty type.
+    */
+  val SchemaEmpty: Type = Type.Cst(TypeConstructor.SchemaEmpty)
+
+  /**
     * Represents the Pure effect. (TRUE in the Boolean algebra.)
     */
   val Pure: Type = Type.Cst(TypeConstructor.Pure)
@@ -242,34 +245,6 @@ object Type {
   }
 
   /**
-    * A type constructor that represents the empty record type.
-    */
-  case object RecordEmpty extends Type {
-    def kind: Kind = Kind.Record
-  }
-
-  /**
-    * A type constructor that represents a record extension type.
-    */
-  case class RecordExtend(label: String, value: Type, rest: Type) extends Type {
-    def kind: Kind = Kind.Star -> Kind.Record
-  }
-
-  /**
-    * A type constructor that represents the empty schema type.
-    */
-  case object SchemaEmpty extends Type {
-    def kind: Kind = Kind.Schema
-  }
-
-  /**
-    * A type constructor that represents a schema extension type.
-    */
-  case class SchemaExtend(name: String, tpe: Type, rest: Type) extends Type {
-    def kind: Kind = Kind.Star -> Kind.Schema
-  }
-
-  /**
     * A type constructor that represents zero.
     */
   case object Zero extends Type {
@@ -287,7 +262,7 @@ object Type {
     * A type expression that represents a type abstraction [x] => tpe.
     */
   case class Lambda(tvar: Type.Var, tpe: Type) extends Type {
-    def kind: Kind = Kind.Star -> Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Star
   }
 
   /**
@@ -300,9 +275,15 @@ object Type {
       * The kind of a type application can unique be determined
       * from the kind of the first type argument `t1`.
       */
-    def kind: Kind = tpe1.kind match {
-      case Kind.Arrow(_, k) => k
-      case _ => throw InternalCompilerException("Illegal kind.")
+    def kind: Kind = {
+      tpe1.kind match {
+        case Kind.Arrow(kparams, k) => kparams match {
+          case _ :: Nil => k
+          case _ :: tail => Kind.Arrow(tail, k)
+          case _ => throw InternalCompilerException(s"Illegal kind: '${tpe1.kind}' of type '$tpe1''")
+        }
+        case _ => throw InternalCompilerException(s"Illegal kind: '${tpe1.kind}' of type '$tpe1''")
+      }
     }
   }
 
@@ -372,6 +353,20 @@ object Type {
     ts.foldLeft(init: Type) {
       case (acc, x) => Apply(acc, x)
     }
+  }
+
+  /**
+    * Constructs a RecordExtend type.
+    */
+  def mkRecordExtend(label: String, tpe: Type, rest: Type): Type = {
+    mkApply(Type.Cst(TypeConstructor.RecordExtend(label)), List(tpe, rest))
+  }
+
+  /**
+    * Constructs a SchemaExtend type.
+    */
+  def mkSchemaExtend(sym: String, tpe: Type, rest: Type): Type = {
+    mkApply(Type.Cst(TypeConstructor.SchemaExtend(sym)), List(tpe, rest))
   }
 
   /**
@@ -469,14 +464,6 @@ object Type {
 
           // Put everything together.
           argPart + arrowPart + resultPart + effPart
-
-        case Type.RecordEmpty => "{ }"
-
-        case Type.RecordExtend(label, value, rest) => "{" + label + " = " + visit(value, m) + " | " + visit(rest, m) + "}"
-
-        case Type.SchemaEmpty => "#{ }"
-
-        case Type.SchemaExtend(sym, t, rest) => "#{" + sym + " = " + visit(t, m) + " | " + visit(rest, m) + "}"
 
         case Type.Lambda(tvar, tpe) => m.getOrElse(tvar.id, tvar.id.toString) + " => " + visit(tpe, m)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -167,13 +167,12 @@ object Type {
   val Str: Type = Type.Cst(TypeConstructor.Str)
 
   /**
-    * Represents the RecordEmpty type.
+    * Represents the type of an empty record.
     */
   val RecordEmpty: Type = Type.Cst(TypeConstructor.RecordEmpty)
 
-
   /**
-    * Represents the SchemaEmpty type.
+    * Represents the type of an empty schema.
     */
   val SchemaEmpty: Type = Type.Cst(TypeConstructor.SchemaEmpty)
 
@@ -365,8 +364,8 @@ object Type {
   /**
     * Constructs a SchemaExtend type.
     */
-  def mkSchemaExtend(sym: String, tpe: Type, rest: Type): Type = {
-    mkApply(Type.Cst(TypeConstructor.SchemaExtend(sym)), List(tpe, rest))
+  def mkSchemaExtend(name: String, tpe: Type, rest: Type): Type = {
+    mkApply(Type.Cst(TypeConstructor.SchemaExtend(name)), List(tpe, rest))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -87,13 +87,47 @@ object TypeConstructor {
   }
 
   /**
+    * A type constructor that represents the type of empty records.
+    */
+  case object RecordEmpty extends TypeConstructor {
+    def kind: Kind = Kind.Record
+  }
+
+  /**
+    * A type constructor that represents the type of extended records.
+    */
+  case class RecordExtend(label: String) extends TypeConstructor {
+    /**
+      * The shape of an extended record is Record[t;r]
+      */
+    def kind: Kind = Kind.Star ->: Kind.Record ->: Kind.Record
+  }
+
+  /**
+    * A type constructor that represents the type of empty schemas.
+    */
+  case object SchemaEmpty extends TypeConstructor {
+    def kind: Kind = Kind.Schema
+  }
+
+  /**
+    * A type constructor that represents the type of extended schemas.
+    */
+  case class SchemaExtend(label: String) extends TypeConstructor {
+    /**
+      * The shape of an extended schema is Schema[t;r]
+      */
+    def kind: Kind = Kind.Star ->: Kind.Schema ->: Kind.Record
+  }
+
+  /**
     * A type constructor that represent the type of arrays.
     */
   case object Array extends TypeConstructor {
     /**
       * The shape of an array is Array[t].
       */
-    def kind: Kind = Kind.Star -> Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Star
   }
 
   /**
@@ -103,7 +137,7 @@ object TypeConstructor {
     /**
       * The shape of a channel is Channel[t].
       */
-    def kind: Kind = Kind.Star -> Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Star
   }
 
   /**
@@ -125,7 +159,7 @@ object TypeConstructor {
     /**
       * The shape of a reference is Ref[t].
       */
-    def kind: Kind = Kind.Star -> Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Star
   }
 
   /**
@@ -145,21 +179,21 @@ object TypeConstructor {
     /**
       * The shape of a vector is Array[t;n].
       */
-    def kind: Kind = (Kind.Star -> Kind.Nat) -> Kind.Star
+    def kind: Kind = (Kind.Star ->: Kind.Nat) ->: Kind.Star
   }
 
   /**
     * A type constructor for relations.
     */
   case object Relation extends TypeConstructor {
-    def kind: Kind = Kind.Star -> Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Star
   }
 
   /**
     * A type constructor for lattices.
     */
   case object Lattice extends TypeConstructor {
-    def kind: Kind = Kind.Star -> Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Star
   }
 
   /**
@@ -184,21 +218,21 @@ object TypeConstructor {
     * A type constructor that represents the negation of an effect.
     */
   case object Not extends TypeConstructor {
-    def kind: Kind = Kind.Effect -> Kind.Effect
+    def kind: Kind = Kind.Effect ->: Kind.Effect
   }
 
   /**
     * A type constructor that represents the conjunction of two effects.
     */
   case object And extends TypeConstructor {
-    def kind: Kind = Kind.Effect -> Kind.Effect -> Kind.Effect
+    def kind: Kind = Kind.Effect ->: Kind.Effect ->: Kind.Effect
   }
 
   /**
     * A type constructor that represents the disjunction of two effects.
     */
   case object Or extends TypeConstructor {
-    def kind: Kind = Kind.Effect -> Kind.Effect -> Kind.Effect
+    def kind: Kind = Kind.Effect ->: Kind.Effect ->: Kind.Effect
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -98,7 +98,7 @@ object TypeConstructor {
     */
   case class RecordExtend(label: String) extends TypeConstructor {
     /**
-      * The shape of an extended record is Record[t;r]
+      * The shape of an extended record is { label: type | rest }
       */
     def kind: Kind = Kind.Star ->: Kind.Record ->: Kind.Record
   }
@@ -113,9 +113,9 @@ object TypeConstructor {
   /**
     * A type constructor that represents the type of extended schemas.
     */
-  case class SchemaExtend(label: String) extends TypeConstructor {
+  case class SchemaExtend(name: String) extends TypeConstructor {
     /**
-      * The shape of an extended schema is Schema[t;r]
+      * The shape of an extended schema is { name: type | rest }
       */
     def kind: Kind = Kind.Star ->: Kind.Schema ->: Kind.Record
   }

--- a/main/src/ca/uwaterloo/flix/language/debug/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/debug/FormatType.scala
@@ -1,6 +1,6 @@
 package ca.uwaterloo.flix.language.debug
 
-import ca.uwaterloo.flix.language.ast.Type
+import ca.uwaterloo.flix.language.ast.{Type, TypeConstructor}
 import ca.uwaterloo.flix.language.ast.Type.ShowInstance
 import ca.uwaterloo.flix.util.InternalCompilerException
 import ca.uwaterloo.flix.util.tc.Show._
@@ -11,8 +11,8 @@ object FormatType {
     * Returns a human readable representation of the given type `tpe`.
     */
   def format(tpe: Type): String = tpe match {
-    case Type.SchemaEmpty => "#{}"
-    case _: Type.SchemaExtend =>
+    case Type.Cst(TypeConstructor.SchemaEmpty) => "#{}"
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaExtend(_)), _), _) =>
       val middlePart = getSchemaTypes(tpe).map(format).mkString(", ")
       "#{ " + middlePart + " }"
 
@@ -24,8 +24,8 @@ object FormatType {
     */
   private def getSchemaTypes(tpe: Type): List[Type] = tpe match {
     case Type.Var(_, _, _) => Nil
-    case Type.SchemaEmpty => Nil
-    case Type.SchemaExtend(sym, tpe, rest) => tpe :: getSchemaTypes(rest)
+    case Type.Cst(TypeConstructor.SchemaEmpty) => Nil
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaExtend(_)), tpe), rest) => tpe :: getSchemaTypes(rest)
     case _ => throw InternalCompilerException(s"Unexpected type: '$tpe'.")
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
@@ -160,6 +160,8 @@ object Documentor extends Phase[TypedAst.Root, TypedAst.Root] {
         case TypeConstructor.Int64 => "Int64"
         case TypeConstructor.BigInt => "BigInt"
         case TypeConstructor.Str => "Str"
+        case TypeConstructor.RecordEmpty => "{ }"
+        case TypeConstructor.SchemaEmpty => "Schema { }"
 
         case TypeConstructor.Relation => "Relation"
 
@@ -174,6 +176,12 @@ object Documentor extends Phase[TypedAst.Root, TypedAst.Root] {
             sym.toString
           else
             sym.toString + "[" + args.map(format).mkString(", ") + "]"
+
+        case TypeConstructor.RecordExtend(label) =>
+          "{" + label + " = " + format(args(0)) + " | " + format(args(1)) + "}"
+
+        case TypeConstructor.SchemaExtend(sym) =>
+          "{" + sym + " = " + format(args(0)) + " | " + format(args(1)) + "}"
 
         case TypeConstructor.Native(clazz) => clazz.getName + (if (args.isEmpty) "" else "[" + args.map(format).mkString(", ") + "]")
 
@@ -207,16 +215,6 @@ object Documentor extends Phase[TypedAst.Root, TypedAst.Root] {
         } else {
           "(" + argumentTypes.map(format).mkString(", ") + ") -> " + format(resultType)
         }
-
-      case Type.RecordEmpty => "{ }"
-
-      case Type.RecordExtend(label, value, rest) =>
-        "{" + label + " = " + format(value) + " | " + format(rest) + "}"
-
-      case Type.SchemaEmpty => "Schema { }"
-
-      case Type.SchemaExtend(sym, t, rest) =>
-        "{" + sym + " = " + format(t) + " | " + format(rest) + "}"
 
       case Type.Lambda(tvar, tpe) => tvar.toString + " => " + format(tpe)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
@@ -557,6 +557,8 @@ object Finalize extends Phase[SimplifiedAst.Root, FinalAst.Root] {
       case Type.Cst(TypeConstructor.Str) => MonoType.Str
       case Type.Cst(TypeConstructor.Relation) => MonoType.Relation(args)
       case Type.Cst(TypeConstructor.Lattice) => MonoType.Lattice(args)
+      case Type.Cst(TypeConstructor.RecordEmpty) => MonoType.RecordEmpty()
+      case Type.Cst(TypeConstructor.SchemaEmpty) => MonoType.SchemaEmpty()
 
       // Compound Types.
       case Type.Cst(TypeConstructor.Array) => MonoType.Array(args.head)
@@ -575,13 +577,9 @@ object Finalize extends Phase[SimplifiedAst.Root, FinalAst.Root] {
 
       case Type.Arrow(l, _) => MonoType.Arrow(args.init, args.last)
 
-      case Type.RecordEmpty => MonoType.RecordEmpty()
+      case Type.Cst(TypeConstructor.RecordExtend(label)) => MonoType.RecordExtend(label, args(0), args(1))
 
-      case Type.RecordExtend(label, value, rest) => MonoType.RecordExtend(label, visitType(value), visitType(rest))
-
-      case Type.SchemaEmpty => MonoType.SchemaEmpty()
-
-      case Type.SchemaExtend(sym, tpe, rest) => MonoType.SchemaExtend(sym, visitType(tpe), visitType(rest))
+      case Type.Cst(TypeConstructor.SchemaExtend(label)) => MonoType.SchemaExtend(label, args(0), args(1))
 
       case Type.Zero => MonoType.Unit
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
@@ -80,15 +80,13 @@ object Monomorph extends Phase[TypedAst.Root, TypedAst.Root] {
         case Type.Var(_, _, _) => Type.Unit
         case Type.Cst(_) => t
         case Type.Arrow(l, eff) => Type.Arrow(l, visit(eff))
-        case Type.RecordEmpty => Type.RecordEmpty
-        case Type.RecordExtend(label, value, rest) => rest match {
-          case Type.Var(_, _, _) => Type.RecordExtend(label, visit(value), Type.RecordEmpty)
-          case _ => Type.RecordExtend(label, visit(value), visit(rest))
+        case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordExtend(label)), tpe), rest) => rest match {
+          case Type.Var(_, _, _) => Type.mkRecordExtend(label, visit(tpe), Type.RecordEmpty)
+          case _ => Type.mkRecordExtend(label, visit(tpe), visit(rest))
         }
-        case Type.SchemaEmpty => Type.SchemaEmpty
-        case Type.SchemaExtend(sym, tt, rest) => rest match {
-          case Type.Var(_, _, _) => Type.SchemaExtend(sym, visit(tt), Type.SchemaEmpty)
-          case _ => Type.SchemaExtend(sym, visit(tt), visit(rest))
+        case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaExtend(sym)), tpe), rest) => rest match {
+          case Type.Var(_, _, _) => Type.mkSchemaExtend(sym, visit(tpe), Type.SchemaEmpty)
+          case _ => Type.mkSchemaExtend(sym, visit(tpe), visit(rest))
         }
         case Type.Zero => Type.Zero
         case Type.Succ(n, i) => Type.Succ(n, i)

--- a/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
@@ -732,6 +732,8 @@ object PatternExhaustiveness extends Phase[TypedAst.Root, TypedAst.Root] {
       case Type.Cst(TypeConstructor.Ref) => 0
       case Type.Cst(TypeConstructor.Relation) => 0
       case Type.Cst(TypeConstructor.Lattice) => 0
+      case Type.Cst(TypeConstructor.RecordEmpty) => 0
+      case Type.Cst(TypeConstructor.SchemaEmpty) => 0
       case Type.Arrow(length, _) => length
       case Type.Cst(TypeConstructor.Array) => 1
       case Type.Cst(TypeConstructor.Channel) => 1
@@ -739,12 +741,10 @@ object PatternExhaustiveness extends Phase[TypedAst.Root, TypedAst.Root] {
       case Type.Cst(TypeConstructor.Native(clazz)) => 0
       case Type.Cst(TypeConstructor.Vector) => 2
       case Type.Cst(TypeConstructor.Tuple(l)) => l
+      case Type.Cst(TypeConstructor.RecordExtend(_)) => 2
+      case Type.Cst(TypeConstructor.SchemaExtend(_)) => 2
       case Type.Zero => 0
       case Type.Succ(n, t) => 2
-      case Type.RecordEmpty => 0 // TODO: Correct?
-      case Type.RecordExtend(base, label, value) => 0 // TODO: Correct?
-      case Type.SchemaEmpty => 0 // TODO: Correct?
-      case Type.SchemaExtend(base, label, value) => 0 // TODO: Correct?
       case Type.Apply(tpe1, tpe2) => countTypeArgs(tpe1)
       case Type.Cst(TypeConstructor.Pure) => throw InternalCompilerException(s"Unexpected type: '$tpe'.")
       case Type.Cst(TypeConstructor.Impure) => throw InternalCompilerException(s"Unexpected type: '$tpe'.")

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -20,7 +20,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.CompilationError
 import ca.uwaterloo.flix.language.ast.Ast.{DependencyEdge, DependencyGraph, Polarity}
 import ca.uwaterloo.flix.language.ast.TypedAst._
-import ca.uwaterloo.flix.language.ast.{Ast, SourceLocation, Symbol, Type}
+import ca.uwaterloo.flix.language.ast.{Ast, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.errors.StratificationError
 import ca.uwaterloo.flix.util.Validation._
 import ca.uwaterloo.flix.util.{InternalCompilerException, Validation}
@@ -877,8 +877,8 @@ object Stratifier extends Phase[Root, Root] {
     */
   private def predicateSymbolsOf(tpe: Type): Set[String] = tpe match {
     case Type.Var(_, _, _) => Set.empty
-    case Type.SchemaEmpty => Set.empty
-    case Type.SchemaExtend(sym, _, rest) => predicateSymbolsOf(rest) + sym
+    case Type.Cst(TypeConstructor.SchemaEmpty) => Set.empty
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaExtend(sym)), tpe), rest) => predicateSymbolsOf(rest) + sym
     case _ => throw InternalCompilerException(s"Unexpected non-schema type: '$tpe'.")
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Synthesize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Synthesize.scala
@@ -1356,8 +1356,8 @@ object Synthesize extends Phase[Root, Root] {
       * Returns `true` if `tpe` is a record type.
       */
     def isRecord(tpe: Type): Boolean = tpe.typeConstructor match {
-      case Type.RecordEmpty => true
-      case Type.RecordExtend(base, label, value) => true
+      case Type.Cst(TypeConstructor.RecordEmpty) => true
+      case Type.Cst(TypeConstructor.RecordExtend(_)) => true
       case _ => false
     }
 
@@ -1365,8 +1365,8 @@ object Synthesize extends Phase[Root, Root] {
       * Returns `true` if `tpe` is a schema type.
       */
     def isSchema(tpe: Type): Boolean = tpe.typeConstructor match {
-      case Type.SchemaEmpty => true
-      case Type.SchemaExtend(_, _, _) => true
+      case Type.Cst(TypeConstructor.SchemaEmpty) => true
+      case Type.Cst(TypeConstructor.SchemaExtend(_)) => true
       case _ => false
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -586,7 +586,7 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
         // r.label : tpe
         //
         val freshRowVar = Type.freshTypeVar()
-        val expectedType = Type.RecordExtend(label, tvar, freshRowVar)
+        val expectedType = Type.mkRecordExtend(label, tvar, freshRowVar)
         for {
           (tpe, eff) <- visitExp(exp)
           recordType <- unifyTypM(tpe, expectedType, loc)
@@ -602,7 +602,7 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
         for {
           (tpe1, eff1) <- visitExp(exp1)
           (tpe2, eff2) <- visitExp(exp2)
-          resultTyp <- unifyTypM(tvar, Type.RecordExtend(label, tpe1, tpe2), loc)
+          resultTyp <- unifyTypM(tvar, Type.mkRecordExtend(label, tpe1, tpe2), loc)
           resultEff = mkAnd(eff1, eff2)
         } yield (resultTyp, resultEff)
 
@@ -615,7 +615,7 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
         val freshRowVar = Type.freshTypeVar()
         for {
           (tpe, eff) <- visitExp(exp)
-          recordType <- unifyTypM(tpe, Type.RecordExtend(label, freshFieldType, freshRowVar), loc)
+          recordType <- unifyTypM(tpe, Type.mkRecordExtend(label, freshFieldType, freshRowVar), loc)
           resultTyp <- unifyTypM(tvar, freshRowVar, loc)
           resultEff = eff
         } yield (resultTyp, resultEff)
@@ -1126,8 +1126,8 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
 
         for {
           (tpe, eff) <- visitExp(exp)
-          expectedType <- unifyTypM(tpe, Type.SchemaExtend(name, freshPredicateTypeVar, freshRestSchemaTypeVar), loc)
-          resultTyp <- unifyTypM(tvar, Type.SchemaExtend(name, freshPredicateTypeVar, freshResultSchemaTypeVar), loc)
+          expectedType <- unifyTypM(tpe, Type.mkSchemaExtend(name, freshPredicateTypeVar, freshRestSchemaTypeVar), loc)
+          resultTyp <- unifyTypM(tvar, Type.mkSchemaExtend(name, freshPredicateTypeVar, freshResultSchemaTypeVar), loc)
           resultEff = eff
         } yield (resultTyp, resultEff)
 
@@ -1160,7 +1160,7 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
           (fType, eff2) <- visitExp(exp2)
           (constraintsType, eff3) <- visitExp(exp3)
           // constraints should have the form {pred.sym : R(tupleType) | freshRestTypeVar}
-          constraintsType2 <- unifyTypM(constraintsType, Type.SchemaExtend(name, Type.Apply(freshPredicateNameTypeVar, tupleType), freshRestTypeVar), loc)
+          constraintsType2 <- unifyTypM(constraintsType, Type.mkSchemaExtend(name, Type.Apply(freshPredicateNameTypeVar, tupleType), freshRestTypeVar), loc)
           // f is of type tupleType -> initType -> initType. It cannot have any effect.
           fType2 <- unifyTypM(fType, Type.mkPureArrow(tupleType, Type.mkPureArrow(initType, initType)), loc)
           resultTyp <- unifyTypM(tvar, initType, loc) // the result of the fold is the same type as init
@@ -1720,7 +1720,7 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
         (termTypes, termEffects) <- seqM(terms.map(inferExp(_, root))).map(_.unzip)
         pureTermEffects <- unifyEffM(Type.Pure, mkAnd(termEffects), loc)
         predicateType <- unifyTypM(tvar, mkRelationOrLatticeType(name, den, termTypes, root), loc)
-      } yield Type.SchemaExtend(name, predicateType, Type.freshTypeVar())
+      } yield Type.mkSchemaExtend(name, predicateType, Type.freshTypeVar())
 
     case ResolvedAst.Predicate.Head.Union(exp, tvar, loc) =>
       //
@@ -1761,7 +1761,7 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
       for {
         termTypes <- seqM(terms.map(inferPattern(_, root)))
         predicateType <- unifyTypM(tvar, mkRelationOrLatticeType(name, den, termTypes, root), loc)
-      } yield Type.SchemaExtend(name, predicateType, Type.freshTypeVar())
+      } yield Type.mkSchemaExtend(name, predicateType, Type.freshTypeVar())
 
     //
     //  exp : Bool

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -835,9 +835,9 @@ object JvmOps {
 
     case MonoType.Tuple(length) => Type.Cst(TypeConstructor.Tuple(0)) // hack
     case MonoType.RecordEmpty() => Type.RecordEmpty
-    case MonoType.RecordExtend(label, value, rest) => Type.RecordExtend(label, hackMonoType2Type(value), hackMonoType2Type(rest))
+    case MonoType.RecordExtend(label, value, rest) => Type.mkRecordExtend(label, hackMonoType2Type(value), hackMonoType2Type(rest))
     case MonoType.SchemaEmpty() => Type.SchemaEmpty
-    case MonoType.SchemaExtend(sym, t, rest) => Type.SchemaExtend(sym, hackMonoType2Type(t), hackMonoType2Type(rest))
+    case MonoType.SchemaExtend(sym, t, rest) => Type.mkSchemaExtend(sym, hackMonoType2Type(t), hackMonoType2Type(rest))
   }
 
   // TODO: Remove

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Substitution.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Substitution.scala
@@ -64,6 +64,10 @@ case class Substitution(m: Map[Type.Var, Type]) {
             case Some(y) if x.kind != t.kind => throw InternalCompilerException(s"Expected kind `${x.kind}' but got `${t.kind}'.")
           }
         case Type.Cst(tc) => t
+        case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordExtend(label)), tpe), rest) =>
+          Type.mkRecordExtend(label, visit(tpe), visit(rest))
+        case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaExtend(sym)), tpe), rest) =>
+          Type.mkSchemaExtend(sym, visit(tpe), visit(rest))
         case Type.Apply(t1, t2) =>
           (visit(t1), visit(t2)) match {
             // Simplify boolean equations.
@@ -73,10 +77,6 @@ case class Substitution(m: Map[Type.Var, Type]) {
             case (x, y) => Type.Apply(x, y)
           }
         case Type.Arrow(l, eff) => Type.Arrow(l, visit(eff))
-        case Type.RecordEmpty => Type.RecordEmpty
-        case Type.RecordExtend(label, field, rest) => Type.RecordExtend(label, visit(field), visit(rest))
-        case Type.SchemaEmpty => Type.SchemaEmpty
-        case Type.SchemaExtend(sym, tpe, rest) => Type.SchemaExtend(sym, visit(tpe), visit(rest))
         case Type.Zero => Type.Zero
         case Type.Succ(n, t) => Type.Succ(n, visit(t))
         case Type.Lambda(tvar, tpe) => throw InternalCompilerException(s"Unexpected type '$tpe0'.")

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Substitution.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Substitution.scala
@@ -64,10 +64,6 @@ case class Substitution(m: Map[Type.Var, Type]) {
             case Some(y) if x.kind != t.kind => throw InternalCompilerException(s"Expected kind `${x.kind}' but got `${t.kind}'.")
           }
         case Type.Cst(tc) => t
-        case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordExtend(label)), tpe), rest) =>
-          Type.mkRecordExtend(label, visit(tpe), visit(rest))
-        case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaExtend(sym)), tpe), rest) =>
-          Type.mkSchemaExtend(sym, visit(tpe), visit(rest))
         case Type.Apply(t1, t2) =>
           (visit(t1), visit(t2)) match {
             // Simplify boolean equations.

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.language.phase.unification
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.{Rigidity, SourceLocation, Type}
+import ca.uwaterloo.flix.language.ast.{Rigidity, SourceLocation, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.errors.TypeError
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
 import ca.uwaterloo.flix.util.{InternalCompilerException, Result}
@@ -79,6 +79,26 @@ object Unification {
 
     case (Type.Cst(c1), Type.Cst(c2)) if c1 == c2 => Result.Ok(Substitution.empty)
 
+    case (Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordExtend(label1)), fieldType1), restRow1), row2) =>
+      // Attempt to write the row to match.
+      rewriteRow(row2, label1, fieldType1, row2) flatMap {
+        case (subst1, restRow2) =>
+          // TODO: Missing the safety/occurs check.
+          unifyTypes(subst1(restRow1), subst1(restRow2)) flatMap {
+            case subst2 => Result.Ok(subst2 @@ subst1)
+          }
+      }
+
+    case (Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaExtend(sym)), tpe), restRow1), row2) =>
+      // Attempt to write the row to match.
+      rewriteSchemaRow(row2, sym, tpe, row2) flatMap {
+        case (subst1, restRow2) =>
+          // TODO: Missing the safety/occurs check.
+          unifyTypes(subst1(restRow1), subst1(restRow2)) flatMap {
+            case subst2 => Result.Ok(subst2 @@ subst1)
+          }
+      }
+
     case (Type.Apply(t11, t12), Type.Apply(t21, t22)) =>
       unifyTypes(t11, t21) match {
         case Result.Ok(subst1) => unifyTypes(subst1(t12), subst1(t22)) match {
@@ -89,30 +109,6 @@ object Unification {
       }
 
     case (Type.Arrow(l1, eff1), Type.Arrow(l2, eff2)) if l1 == l2 => BoolUnification.unifyEffects(eff1, eff2)
-
-    case (Type.RecordEmpty, Type.RecordEmpty) => Result.Ok(Substitution.empty)
-
-    case (Type.SchemaEmpty, Type.SchemaEmpty) => Result.Ok(Substitution.empty)
-
-    case (Type.RecordExtend(label1, fieldType1, restRow1), row2) =>
-      // Attempt to write the row to match.
-      rewriteRow(row2, label1, fieldType1, row2) flatMap {
-        case (subst1, restRow2) =>
-          // TODO: Missing the safety/occurs check.
-          unifyTypes(subst1(restRow1), subst1(restRow2)) flatMap {
-            case subst2 => Result.Ok(subst2 @@ subst1)
-          }
-      }
-
-    case (Type.SchemaExtend(sym, tpe, restRow1), row2) =>
-      // Attempt to write the row to match.
-      rewriteSchemaRow(row2, sym, tpe, row2) flatMap {
-        case (subst1, restRow2) =>
-          // TODO: Missing the safety/occurs check.
-          unifyTypes(subst1(restRow1), subst1(restRow2)) flatMap {
-            case subst2 => Result.Ok(subst2 @@ subst1)
-          }
-      }
 
     case (Type.Zero, Type.Zero) => Result.Ok(Substitution.empty) // 0 == 0
 
@@ -133,7 +129,7 @@ object Unification {
     * Attempts to rewrite the given row type `row2` into a row that has the given label `label1` in front.
     */
   private def rewriteRow(row2: Type, label1: String, fieldType1: Type, originalType: Type)(implicit flix: Flix): Result[(Substitution, Type), UnificationError] = row2 match {
-    case Type.RecordExtend(label2, fieldType2, restRow2) =>
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordExtend(label2)), fieldType2), restRow2) =>
       // Case 1: The row is of the form %{ label2: fieldType2 | restRow2 }
       if (label1 == label2) {
         // Case 1.1: The labels match, their types must match.
@@ -143,18 +139,18 @@ object Unification {
       } else {
         // Case 1.2: The labels do not match, attempt to match with a label further down.
         rewriteRow(restRow2, label1, fieldType1, originalType) map {
-          case (subst, rewrittenRow) => (subst, Type.RecordExtend(label2, fieldType2, rewrittenRow))
+          case (subst, rewrittenRow) => (subst, Type.mkRecordExtend(label2, fieldType2, rewrittenRow))
         }
       }
     case tvar: Type.Var =>
       // Case 2: The row is a type variable.
       // Introduce a fresh type variable to represent one more level of the row.
       val restRow2 = Type.freshTypeVar()
-      val type2 = Type.RecordExtend(label1, fieldType1, restRow2)
+      val type2 = Type.mkRecordExtend(label1, fieldType1, restRow2)
       val subst = Substitution.singleton(tvar, type2)
       Ok((subst, restRow2))
 
-    case Type.RecordEmpty =>
+    case Type.Cst(TypeConstructor.RecordEmpty) =>
       // Case 3: The `label` does not exist in the record.
       Err(UnificationError.UndefinedLabel(label1, fieldType1, originalType))
 
@@ -168,7 +164,7 @@ object Unification {
     */
   // TODO: This is a copy of the above function. It would be nice if it could be the same function, but the shape of labels is different.
   private def rewriteSchemaRow(row2: Type, label1: String, fieldType1: Type, originalType: Type)(implicit flix: Flix): Result[(Substitution, Type), UnificationError] = row2 match {
-    case Type.SchemaExtend(label2, fieldType2, restRow2) =>
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaExtend(label2)), fieldType2), restRow2) =>
       // Case 1: The row is of the form %{ label2: fieldType2 | restRow2 }
       if (label1 == label2) {
         // Case 1.1: The labels match, their types must match.
@@ -178,18 +174,18 @@ object Unification {
       } else {
         // Case 1.2: The labels do not match, attempt to match with a label further down.
         rewriteSchemaRow(restRow2, label1, fieldType1, originalType) map {
-          case (subst, rewrittenRow) => (subst, Type.SchemaExtend(label2, fieldType2, rewrittenRow))
+          case (subst, rewrittenRow) => (subst, Type.mkSchemaExtend(label2, fieldType2, rewrittenRow))
         }
       }
     case tvar: Type.Var =>
       // Case 2: The row is a type variable.
       // Introduce a fresh type variable to represent one more level of the row.
       val restRow2 = Type.freshTypeVar()
-      val type2 = Type.SchemaExtend(label1, fieldType1, restRow2)
+      val type2 = Type.mkSchemaExtend(label1, fieldType1, restRow2)
       val subst = Substitution.singleton(tvar, type2)
       Ok((subst, restRow2))
 
-    case Type.SchemaEmpty =>
+    case Type.Cst(TypeConstructor.SchemaEmpty) =>
       // Case 3: The `label` does not exist in the record.
       Err(UnificationError.UndefinedPredicate(label1, fieldType1, originalType))
 


### PR DESCRIPTION
The first of several incremental changes to introduce well-kinded types.

`Type.Record` and `Type.Schema` are replaced by applications of new `TypeConstructor.Record` and `TypeConstructor.Schema`.

Unit tests pass and no to-dos remain. This should be fine to merge if approved.