### PR TITLE
Removed assert, assertEq and asssertNot from library tests.

### DIFF
--- a/main/test/ca/uwaterloo/flix/library/TestFloat32.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFloat32.flix
@@ -56,7 +56,7 @@ namespace TestFloat32 {
     // nan                                                                     //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def nan01(): Bool = assert!(Float32.isNan(Float32.nan()))
+    def nan01(): Bool = Float32.isNan(Float32.nan()) == true
     
     /////////////////////////////////////////////////////////////////////////////
     // positiveInfinity                                                        //
@@ -74,76 +74,76 @@ namespace TestFloat32 {
     // isFinite                                                                //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def isFinite01(): Bool = assert!(Float32.isFinite(1.0f32))
+    def isFinite01(): Bool = Float32.isFinite(1.0f32) == true
     
     @test
-    def isFinite02(): Bool = assert!(Float32.isFinite(-1.0f32))
+    def isFinite02(): Bool = Float32.isFinite(-1.0f32) == true
     
     @test
-    def isFinite03(): Bool = assert!(Float32.isFinite(Float32.minValue()))
+    def isFinite03(): Bool = Float32.isFinite(Float32.minValue()) == true
     
     @test
-    def isFinite04(): Bool = assert!(Float32.isFinite(Float32.maxValue()))
+    def isFinite04(): Bool = Float32.isFinite(Float32.maxValue()) == true
     
     @test
-    def isFinite05(): Bool = assertNot!(Float32.isFinite(Float32.negativeInfinity()))
+    def isFinite05(): Bool = Float32.isFinite(Float32.negativeInfinity()) == false
     
     @test
-    def isFinite06(): Bool = assertNot!(Float32.isFinite(Float32.positiveInfinity()))
+    def isFinite06(): Bool = Float32.isFinite(Float32.positiveInfinity()) == false
     
     @test
-    def isFinite07(): Bool = assertNot!(Float32.isFinite(Float32.nan()))
+    def isFinite07(): Bool = Float32.isFinite(Float32.nan()) == false
     
     /////////////////////////////////////////////////////////////////////////////
     // isInfinite                                                              //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def isInfinite01(): Bool = assertNot!(Float32.isInfinite(1.0f32))
+    def isInfinite01(): Bool = Float32.isInfinite(1.0f32) == false
     
     @test
-    def isInfinite02(): Bool = assertNot!(Float32.isInfinite(-1.0f32))
+    def isInfinite02(): Bool = Float32.isInfinite(-1.0f32) == false
     
     @test
-    def isInfinite03(): Bool = assertNot!(Float32.isInfinite(Float32.minValue()))
+    def isInfinite03(): Bool = Float32.isInfinite(Float32.minValue()) == false
     
     @test
-    def isInfinite04(): Bool = assertNot!(Float32.isInfinite(Float32.maxValue()))
+    def isInfinite04(): Bool = Float32.isInfinite(Float32.maxValue()) == false
     
     @test
-    def isInfinite05(): Bool = assert!(Float32.isInfinite(Float32.negativeInfinity()))
+    def isInfinite05(): Bool = Float32.isInfinite(Float32.negativeInfinity()) == true
     
     @test
-    def isInfinite06(): Bool = assert!(Float32.isInfinite(Float32.positiveInfinity()))
+    def isInfinite06(): Bool = Float32.isInfinite(Float32.positiveInfinity()) == true
     
     @test
-    def isInfinite07(): Bool = assertNot!(Float32.isInfinite(Float32.nan()))
+    def isInfinite07(): Bool = Float32.isInfinite(Float32.nan()) == false
     
     /////////////////////////////////////////////////////////////////////////////
     // isNan                                                                   //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def isNan01(): Bool = assert!(Float32.isNan(Float32.nan()))
+    def isNan01(): Bool = Float32.isNan(Float32.nan()) == true
     
     @test
-    def isNan02(): Bool = assert!(Float32.isNan(0.0f32 / 0.0f32))
+    def isNan02(): Bool = Float32.isNan(0.0f32 / 0.0f32) == true
     
     @test
-    def isNan03(): Bool = assertNot!(Float32.isNan(Float32.positiveInfinity()))
+    def isNan03(): Bool = Float32.isNan(Float32.positiveInfinity()) == false
     
     @test
-    def isNan04(): Bool = assertNot!(Float32.isNan(Float32.negativeInfinity()))
+    def isNan04(): Bool = Float32.isNan(Float32.negativeInfinity()) == false
     
     @test
-    def isNan05(): Bool = assertNot!(Float32.isNan(1.0f32))
+    def isNan05(): Bool = Float32.isNan(1.0f32) == false
     
     @test
-    def isNan06(): Bool = assertNot!(Float32.isNan(-1.0f32))
+    def isNan06(): Bool = Float32.isNan(-1.0f32) == false
     
     @test
-    def isNan07(): Bool = assertNot!(Float32.isNan(Float32.minValue()))
+    def isNan07(): Bool = Float32.isNan(Float32.minValue()) == false
     
     @test
-    def isNan08(): Bool = assertNot!(Float32.isNan(Float32.maxValue()))
+    def isNan08(): Bool = Float32.isNan(Float32.maxValue()) == false
     
     /////////////////////////////////////////////////////////////////////////////
     // min                                                                     //

--- a/main/test/ca/uwaterloo/flix/library/TestFloat64.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFloat64.flix
@@ -56,7 +56,7 @@ namespace TestFloat64 {
     // nan                                                                     //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def nan01(): Bool = assert!(Float64.isNan(Float64.nan()))
+    def nan01(): Bool = Float64.isNan(Float64.nan()) == true
     
     /////////////////////////////////////////////////////////////////////////////
     // positiveInfinity                                                        //
@@ -74,76 +74,76 @@ namespace TestFloat64 {
     // isFinite                                                                //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def isFinite01(): Bool = assert!(Float64.isFinite(1.0f64))
+    def isFinite01(): Bool = Float64.isFinite(1.0f64) == true
     
     @test
-    def isFinite02(): Bool = assert!(Float64.isFinite(-1.0f64))
+    def isFinite02(): Bool = Float64.isFinite(-1.0f64) == true
     
     @test
-    def isFinite03(): Bool = assert!(Float64.isFinite(Float64.minValue()))
+    def isFinite03(): Bool = Float64.isFinite(Float64.minValue()) == true
     
     @test
-    def isFinite04(): Bool = assert!(Float64.isFinite(Float64.maxValue()))
+    def isFinite04(): Bool = Float64.isFinite(Float64.maxValue()) == true
     
     @test
-    def isFinite05(): Bool = assertNot!(Float64.isFinite(Float64.negativeInfinity()))
+    def isFinite05(): Bool = Float64.isFinite(Float64.negativeInfinity()) == false
     
     @test
-    def isFinite06(): Bool = assertNot!(Float64.isFinite(Float64.positiveInfinity()))
+    def isFinite06(): Bool = Float64.isFinite(Float64.positiveInfinity()) == false
     
     @test
-    def isFinite07(): Bool = assertNot!(Float64.isFinite(Float64.nan()))
+    def isFinite07(): Bool = Float64.isFinite(Float64.nan()) == false
     
     /////////////////////////////////////////////////////////////////////////////
     // isInfinite                                                              //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def isInfinite01(): Bool = assertNot!(Float64.isInfinite(1.0f64))
+    def isInfinite01(): Bool = Float64.isInfinite(1.0f64) == false
     
     @test
-    def isInfinite02(): Bool = assertNot!(Float64.isInfinite(-1.0f64))
+    def isInfinite02(): Bool = Float64.isInfinite(-1.0f64) == false
     
     @test
-    def isInfinite03(): Bool = assertNot!(Float64.isInfinite(Float64.minValue()))
+    def isInfinite03(): Bool = Float64.isInfinite(Float64.minValue()) == false
     
     @test
-    def isInfinite04(): Bool = assertNot!(Float64.isInfinite(Float64.maxValue()))
+    def isInfinite04(): Bool = Float64.isInfinite(Float64.maxValue()) == false
     
     @test
-    def isInfinite05(): Bool = assert!(Float64.isInfinite(Float64.negativeInfinity()))
+    def isInfinite05(): Bool = Float64.isInfinite(Float64.negativeInfinity()) == true
     
     @test
-    def isInfinite06(): Bool = assert!(Float64.isInfinite(Float64.positiveInfinity()))
+    def isInfinite06(): Bool = Float64.isInfinite(Float64.positiveInfinity()) == true
     
     @test
-    def isInfinite07(): Bool = assertNot!(Float64.isInfinite(Float64.nan()))
+    def isInfinite07(): Bool = Float64.isInfinite(Float64.nan()) == false
     
     /////////////////////////////////////////////////////////////////////////////
     // isNan                                                                   //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def isNan01(): Bool = assert!(Float64.isNan(Float64.nan()))
+    def isNan01(): Bool = Float64.isNan(Float64.nan()) == true
     
     @test
-    def isNan02(): Bool = assert!(Float64.isNan(0.0f64 / 0.0f64))
+    def isNan02(): Bool = Float64.isNan(0.0f64 / 0.0f64) == true
     
     @test
-    def isNan03(): Bool = assertNot!(Float64.isNan(Float64.positiveInfinity()))
+    def isNan03(): Bool = Float64.isNan(Float64.positiveInfinity()) == false
     
     @test
-    def isNan04(): Bool = assertNot!(Float64.isNan(Float64.negativeInfinity()))
+    def isNan04(): Bool = Float64.isNan(Float64.negativeInfinity()) == false
     
     @test
-    def isNan05(): Bool = assertNot!(Float64.isNan(1.0f64))
+    def isNan05(): Bool = Float64.isNan(1.0f64) == false
     
     @test
-    def isNan06(): Bool = assertNot!(Float64.isNan(-1.0f64))
+    def isNan06(): Bool = Float64.isNan(-1.0f64) == false
     
     @test
-    def isNan07(): Bool = assertNot!(Float64.isNan(Float64.minValue()))
+    def isNan07(): Bool = Float64.isNan(Float64.minValue()) == false
     
     @test
-    def isNan08(): Bool = assertNot!(Float64.isNan(Float64.maxValue()))
+    def isNan08(): Bool = Float64.isNan(Float64.maxValue()) == false
     
     /////////////////////////////////////////////////////////////////////////////
     // min                                                                     //

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -20,630 +20,630 @@ namespace TestList {
 // isEmpty                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def isEmpty01(): Bool = assert!(List.isEmpty(Nil))
+def isEmpty01(): Bool = List.isEmpty(Nil) == true
 
 @test
-def isEmpty02(): Bool = assertNot!(List.isEmpty(1 :: Nil))
+def isEmpty02(): Bool = List.isEmpty(1 :: Nil) == false
 
 @test
-def isEmpty03(): Bool = assertNot!(List.isEmpty(1 :: 2 :: Nil))
+def isEmpty03(): Bool = List.isEmpty(1 :: 2 :: Nil) == false
 
 /////////////////////////////////////////////////////////////////////////////
 // head                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def head01(): Bool = List.head(Nil) `assertEq!` None
+def head01(): Bool = List.head(Nil) == None
 
 @test
-def head02(): Bool = List.head(1 :: Nil) `assertEq!` Some(1)
+def head02(): Bool = List.head(1 :: Nil) == Some(1)
 
 @test
-def head03(): Bool = List.head(2 :: 1 :: Nil) `assertEq!` Some(2)
+def head03(): Bool = List.head(2 :: 1 :: Nil) == Some(2)
 
 @test
-def head04(): Bool = List.head(3 :: 2 :: 1 :: Nil) `assertEq!` Some(3)
+def head04(): Bool = List.head(3 :: 2 :: 1 :: Nil) == Some(3)
 
 /////////////////////////////////////////////////////////////////////////////
 // last                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def last01(): Bool = List.last(Nil) `assertEq!` None
+def last01(): Bool = List.last(Nil) == None
 
 @test
-def last02(): Bool = List.last(1 :: Nil) `assertEq!` Some(1)
+def last02(): Bool = List.last(1 :: Nil) == Some(1)
 
 @test
-def last03(): Bool = List.last(1 :: 2 :: Nil) `assertEq!` Some(2)
+def last03(): Bool = List.last(1 :: 2 :: Nil) == Some(2)
 
 @test
-def last04(): Bool = List.last(1 :: 2 :: 3 :: Nil) `assertEq!` Some(3)
+def last04(): Bool = List.last(1 :: 2 :: 3 :: Nil) == Some(3)
 
 /////////////////////////////////////////////////////////////////////////////
 // length                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def length01(): Bool = List.length(Nil) `assertEq!` 0
+def length01(): Bool = List.length(Nil) == 0
 
 @test
-def length02(): Bool = List.length(1 :: Nil) `assertEq!` 1
+def length02(): Bool = List.length(1 :: Nil) == 1
 
 @test
-def length03(): Bool = List.length(1 :: 2 :: Nil) `assertEq!` 2
+def length03(): Bool = List.length(1 :: 2 :: Nil) == 2
 
 @test
-def length04(): Bool = List.length(1 :: 2 :: 3 :: Nil) `assertEq!` 3
+def length04(): Bool = List.length(1 :: 2 :: 3 :: Nil) == 3
 
 /////////////////////////////////////////////////////////////////////////////
 // append                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def append01(): Bool = List.append(Nil, Nil) `assertEq!` Nil
+def append01(): Bool = List.append(Nil, Nil) == Nil
 
 @test
-def append02(): Bool = List.append(Nil, 1 :: Nil) `assertEq!` 1 :: Nil
+def append02(): Bool = List.append(Nil, 1 :: Nil) == 1 :: Nil
 
 @test
-def append03(): Bool = List.append(Nil, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def append03(): Bool = List.append(Nil, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def append04(): Bool = List.append(1 :: Nil, Nil) `assertEq!` 1 :: Nil
+def append04(): Bool = List.append(1 :: Nil, Nil) == 1 :: Nil
 
 @test
-def append05(): Bool = List.append(1 :: 2 :: Nil, Nil) `assertEq!` 1 :: 2 :: Nil
+def append05(): Bool = List.append(1 :: 2 :: Nil, Nil) == 1 :: 2 :: Nil
 
 @test
-def append06(): Bool = List.append(1 :: Nil, 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def append06(): Bool = List.append(1 :: Nil, 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def append07(): Bool = List.append(1 :: 2 :: Nil, 3 :: Nil) `assertEq!` 1 :: 2 :: 3 :: Nil
+def append07(): Bool = List.append(1 :: 2 :: Nil, 3 :: Nil) == 1 :: 2 :: 3 :: Nil
 
 @test
-def append08(): Bool = List.append(1 :: Nil, 2 :: 3 :: Nil) `assertEq!` 1 :: 2 :: 3 :: Nil
+def append08(): Bool = List.append(1 :: Nil, 2 :: 3 :: Nil) == 1 :: 2 :: 3 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // memberOf                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def memberOf01(): Bool = assertNot!(List.memberOf(0, Nil))
+def memberOf01(): Bool = List.memberOf(0, Nil) == false
 
 @test
-def memberOf02(): Bool = assertNot!(List.memberOf(0, 1 :: Nil))
+def memberOf02(): Bool = List.memberOf(0, 1 :: Nil) == false
 
 @test
-def memberOf03(): Bool = assert!(List.memberOf(0, 0 :: Nil))
+def memberOf03(): Bool = List.memberOf(0, 0 :: Nil) == true
 
 @test
-def memberOf04(): Bool = assertNot!(List.memberOf(0, 1 :: 2 :: Nil))
+def memberOf04(): Bool = List.memberOf(0, 1 :: 2 :: Nil) == false
 
 @test
-def memberOf05(): Bool = assert!(List.memberOf(1, 1 :: 2 :: Nil))
+def memberOf05(): Bool = List.memberOf(1, 1 :: 2 :: Nil) == true
 
 @test
-def memberOf06(): Bool = assert!(List.memberOf(2, 1 :: 2 :: Nil))
+def memberOf06(): Bool = List.memberOf(2, 1 :: 2 :: Nil) == true
 
 @test
-def memberOf07(): Bool = assertNot!(List.memberOf(3, 1 :: 2 :: Nil))
+def memberOf07(): Bool = List.memberOf(3, 1 :: 2 :: Nil) == false
 
 /////////////////////////////////////////////////////////////////////////////
 // indexOf                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def indexOf01(): Bool = List.indexOf(0, Nil) `assertEq!` -1
+def indexOf01(): Bool = List.indexOf(0, Nil) == -1
 
 @test
-def indexOf02(): Bool = List.indexOf(0, 1 :: Nil) `assertEq!` -1
+def indexOf02(): Bool = List.indexOf(0, 1 :: Nil) == -1
 
 @test
-def indexOf03(): Bool = List.indexOf(1, 1 :: Nil) `assertEq!` 0
+def indexOf03(): Bool = List.indexOf(1, 1 :: Nil) == 0
 
 @test
-def indexOf04(): Bool = List.indexOf(0, 1 :: 2 :: Nil) `assertEq!` -1
+def indexOf04(): Bool = List.indexOf(0, 1 :: 2 :: Nil) == -1
 
 @test
-def indexOf05(): Bool = List.indexOf(1, 1 :: 2 :: Nil) `assertEq!` 0
+def indexOf05(): Bool = List.indexOf(1, 1 :: 2 :: Nil) == 0
 
 @test
-def indexOf06(): Bool = List.indexOf(2, 1 :: 2 :: Nil) `assertEq!` 1
+def indexOf06(): Bool = List.indexOf(2, 1 :: 2 :: Nil) == 1
 
 /////////////////////////////////////////////////////////////////////////////
 // find                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def find01(): Bool = List.find(i -> i > 2, Nil) `assertEq!` None
+def find01(): Bool = List.find(i -> i > 2, Nil) == None
 
 @test
-def find02(): Bool = List.find(i -> i > 2, 1 :: Nil) `assertEq!` None
+def find02(): Bool = List.find(i -> i > 2, 1 :: Nil) == None
 
 @test
-def find03(): Bool = List.find(i -> i > 2, 3 :: Nil) `assertEq!` Some(3)
+def find03(): Bool = List.find(i -> i > 2, 3 :: Nil) == Some(3)
 
 @test
-def find04(): Bool = List.find(i -> i > 2, 1 :: 2 :: Nil) `assertEq!` None
+def find04(): Bool = List.find(i -> i > 2, 1 :: 2 :: Nil) == None
 
 @test
-def find05(): Bool = List.find(i -> i > 2, 6 :: -6 :: Nil) `assertEq!` Some(6)
+def find05(): Bool = List.find(i -> i > 2, 6 :: -6 :: Nil) == Some(6)
 
 @test
-def find06(): Bool = List.find(i -> i > 2, -6 :: 6 :: Nil) `assertEq!` Some(6)
+def find06(): Bool = List.find(i -> i > 2, -6 :: 6 :: Nil) == Some(6)
 
 @test
-def find07(): Bool = List.find(i -> i > 2, 6 :: 7 :: Nil) `assertEq!` Some(6)
+def find07(): Bool = List.find(i -> i > 2, 6 :: 7 :: Nil) == Some(6)
 
 /////////////////////////////////////////////////////////////////////////////
 // findLeft                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def findLeft01(): Bool = List.findLeft(i -> i > 2, Nil) `assertEq!` None
+def findLeft01(): Bool = List.findLeft(i -> i > 2, Nil) == None
 
 @test
-def findLeft02(): Bool = List.findLeft(i -> i > 2, 1 :: Nil) `assertEq!` None
+def findLeft02(): Bool = List.findLeft(i -> i > 2, 1 :: Nil) == None
 
 @test
-def findLeft03(): Bool = List.findLeft(i -> i > 2, 3 :: Nil) `assertEq!` Some(3)
+def findLeft03(): Bool = List.findLeft(i -> i > 2, 3 :: Nil) == Some(3)
 
 @test
-def findLeft04(): Bool = List.findLeft(i -> i > 2, 1 :: 2 :: Nil) `assertEq!` None
+def findLeft04(): Bool = List.findLeft(i -> i > 2, 1 :: 2 :: Nil) == None
 
 @test
-def findLeft05(): Bool = List.findLeft(i -> i > 2, 6 :: -6 :: Nil) `assertEq!` Some(6)
+def findLeft05(): Bool = List.findLeft(i -> i > 2, 6 :: -6 :: Nil) == Some(6)
 
 @test
-def findLeft06(): Bool = List.findLeft(i -> i > 2, -6 :: 6 :: Nil) `assertEq!` Some(6)
+def findLeft06(): Bool = List.findLeft(i -> i > 2, -6 :: 6 :: Nil) == Some(6)
 
 @test
-def findLeft07(): Bool = List.findLeft(i -> i > 2, 6 :: 7 :: Nil) `assertEq!` Some(6)
+def findLeft07(): Bool = List.findLeft(i -> i > 2, 6 :: 7 :: Nil) == Some(6)
 
 /////////////////////////////////////////////////////////////////////////////
 // findRight                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def findRight01(): Bool = List.findRight(i -> i > 2, Nil) `assertEq!` None
+def findRight01(): Bool = List.findRight(i -> i > 2, Nil) == None
 
 @test
-def findRight02(): Bool = List.findRight(i -> i > 2, 1 :: Nil) `assertEq!` None
+def findRight02(): Bool = List.findRight(i -> i > 2, 1 :: Nil) == None
 
 @test
-def findRight03(): Bool = List.findRight(i -> i > 2, 3 :: Nil) `assertEq!` Some(3)
+def findRight03(): Bool = List.findRight(i -> i > 2, 3 :: Nil) == Some(3)
 
 @test
-def findRight04(): Bool = List.findRight(i -> i > 2, 1 :: 2 :: Nil) `assertEq!` None
+def findRight04(): Bool = List.findRight(i -> i > 2, 1 :: 2 :: Nil) == None
 
 @test
-def findRight05(): Bool = List.findRight(i -> i > 2, 6 :: -6 :: Nil) `assertEq!` Some(6)
+def findRight05(): Bool = List.findRight(i -> i > 2, 6 :: -6 :: Nil) == Some(6)
 
 @test
-def findRight06(): Bool = List.findRight(i -> i > 2, -6 :: 6 :: Nil) `assertEq!` Some(6)
+def findRight06(): Bool = List.findRight(i -> i > 2, -6 :: 6 :: Nil) == Some(6)
 
 @test
-def findRight07(): Bool = List.findRight(i -> i > 2, 6 :: 7 :: Nil) `assertEq!` Some(7)
+def findRight07(): Bool = List.findRight(i -> i > 2, 6 :: 7 :: Nil) == Some(7)
 
 /////////////////////////////////////////////////////////////////////////////
 // range                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def range01(): Bool = List.range(1, 0) `assertEq!` Nil
+def range01(): Bool = List.range(1, 0) == Nil
 
 @test
-def range02(): Bool = List.range(1, 1) `assertEq!` Nil
+def range02(): Bool = List.range(1, 1) == Nil
 
 @test
-def range03(): Bool = List.range(1, 2) `assertEq!` 1 :: Nil
+def range03(): Bool = List.range(1, 2) == 1 :: Nil
 
 @test
-def range04(): Bool = List.range(1, 3) `assertEq!` 1 :: 2 :: Nil
+def range04(): Bool = List.range(1, 3) == 1 :: 2 :: Nil
 
 @test
-def range05(): Bool = List.range(1, 4) `assertEq!` 1 :: 2 :: 3 :: Nil
+def range05(): Bool = List.range(1, 4) == 1 :: 2 :: 3 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // repeat                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def repeat01(): Bool = List.repeat(1, -1) `assertEq!` Nil
+def repeat01(): Bool = List.repeat(1, -1) == Nil
 
 @test
-def repeat02(): Bool = List.repeat(1, 0) `assertEq!` Nil
+def repeat02(): Bool = List.repeat(1, 0) == Nil
 
 @test
-def repeat03(): Bool = List.repeat(1, 1) `assertEq!` 1 :: Nil
+def repeat03(): Bool = List.repeat(1, 1) == 1 :: Nil
 
 @test
-def repeat04(): Bool = List.repeat(1, 2) `assertEq!` 1 :: 1 :: Nil
+def repeat04(): Bool = List.repeat(1, 2) == 1 :: 1 :: Nil
 
 @test
-def repeat05(): Bool = List.repeat(1, 3) `assertEq!` 1 :: 1 :: 1 :: Nil
+def repeat05(): Bool = List.repeat(1, 3) == 1 :: 1 :: 1 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // scan                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def scan01(): Bool = List.scan((i, b) -> if (b) i+1 else i+2, 1, Nil) `assertEq!` 1 :: Nil
+def scan01(): Bool = List.scan((i, b) -> if (b) i+1 else i+2, 1, Nil) == 1 :: Nil
 
 @test
-def scan02(): Bool = List.scan((i, b) -> if (b) i+1 else i+2, 1, false :: Nil) `assertEq!` 1 :: 3 :: Nil
+def scan02(): Bool = List.scan((i, b) -> if (b) i+1 else i+2, 1, false :: Nil) == 1 :: 3 :: Nil
 
 @test
-def scan03(): Bool = List.scan((i, b) -> if (b) i+1 else i+2, 1, true :: Nil) `assertEq!` 1 :: 2 :: Nil
+def scan03(): Bool = List.scan((i, b) -> if (b) i+1 else i+2, 1, true :: Nil) == 1 :: 2 :: Nil
 
 @test
-def scan04(): Bool = List.scan((i, b) -> if (b) i+1 else i+2, 1, false :: false :: Nil) `assertEq!` 1 :: 3 :: 5 :: Nil
+def scan04(): Bool = List.scan((i, b) -> if (b) i+1 else i+2, 1, false :: false :: Nil) == 1 :: 3 :: 5 :: Nil
 
 @test
-def scan05(): Bool = List.scan((i, b) -> if (b) i+1 else i+2, 1, false :: true :: Nil) `assertEq!` 1 :: 3 :: 4 :: Nil
+def scan05(): Bool = List.scan((i, b) -> if (b) i+1 else i+2, 1, false :: true :: Nil) == 1 :: 3 :: 4 :: Nil
 
 @test
-def scan06(): Bool = List.scan((i, b) -> if (b) i+1 else i+2, 1, true :: false :: Nil) `assertEq!` 1 :: 2 :: 4 :: Nil
+def scan06(): Bool = List.scan((i, b) -> if (b) i+1 else i+2, 1, true :: false :: Nil) == 1 :: 2 :: 4 :: Nil
 
 @test
-def scan07(): Bool = List.scan((i, b) -> if (b) i+1 else i+2, 1, true :: true :: Nil) `assertEq!` 1 :: 2 :: 3 :: Nil
+def scan07(): Bool = List.scan((i, b) -> if (b) i+1 else i+2, 1, true :: true :: Nil) == 1 :: 2 :: 3 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // scanLeft                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def scanLeft01(): Bool = List.scanLeft((i, b) -> if (b) i+1 else i+2, 1, Nil) `assertEq!` 1 :: Nil
+def scanLeft01(): Bool = List.scanLeft((i, b) -> if (b) i+1 else i+2, 1, Nil) == 1 :: Nil
 
 @test
-def scanLeft02(): Bool = List.scanLeft((i, b) -> if (b) i+1 else i+2, 1, false :: Nil) `assertEq!` 1 :: 3 :: Nil
+def scanLeft02(): Bool = List.scanLeft((i, b) -> if (b) i+1 else i+2, 1, false :: Nil) == 1 :: 3 :: Nil
 
 @test
-def scanLeft03(): Bool = List.scanLeft((i, b) -> if (b) i+1 else i+2, 1, true :: Nil) `assertEq!` 1 :: 2 :: Nil
+def scanLeft03(): Bool = List.scanLeft((i, b) -> if (b) i+1 else i+2, 1, true :: Nil) == 1 :: 2 :: Nil
 
 @test
-def scanLeft04(): Bool = List.scanLeft((i, b) -> if (b) i+1 else i+2, 1, false :: false :: Nil) `assertEq!` 1 :: 3 :: 5 :: Nil
+def scanLeft04(): Bool = List.scanLeft((i, b) -> if (b) i+1 else i+2, 1, false :: false :: Nil) == 1 :: 3 :: 5 :: Nil
 
 @test
-def scanLeft05(): Bool = List.scanLeft((i, b) -> if (b) i+1 else i+2, 1, false :: true :: Nil) `assertEq!` 1 :: 3 :: 4 :: Nil
+def scanLeft05(): Bool = List.scanLeft((i, b) -> if (b) i+1 else i+2, 1, false :: true :: Nil) == 1 :: 3 :: 4 :: Nil
 
 @test
-def scanLeft06(): Bool = List.scanLeft((i, b) -> if (b) i+1 else i+2, 1, true :: false :: Nil) `assertEq!` 1 :: 2 :: 4 :: Nil
+def scanLeft06(): Bool = List.scanLeft((i, b) -> if (b) i+1 else i+2, 1, true :: false :: Nil) == 1 :: 2 :: 4 :: Nil
 
 @test
-def scanLeft07(): Bool = List.scanLeft((i, b) -> if (b) i+1 else i+2, 1, true :: true :: Nil) `assertEq!` 1 :: 2 :: 3 :: Nil
+def scanLeft07(): Bool = List.scanLeft((i, b) -> if (b) i+1 else i+2, 1, true :: true :: Nil) == 1 :: 2 :: 3 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // scanRight                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def scanRight01(): Bool = List.scanRight((b, i) -> if (b) i+1 else i+2, 1, Nil) `assertEq!` 1 :: Nil
+def scanRight01(): Bool = List.scanRight((b, i) -> if (b) i+1 else i+2, 1, Nil) == 1 :: Nil
 
 @test
-def scanRight02(): Bool = List.scanRight((b, i) -> if (b) i+1 else i+2, 1, false :: Nil) `assertEq!` 3 :: 1 :: Nil
+def scanRight02(): Bool = List.scanRight((b, i) -> if (b) i+1 else i+2, 1, false :: Nil) == 3 :: 1 :: Nil
 
 @test
-def scanRight03(): Bool = List.scanRight((b, i) -> if (b) i+1 else i+2, 1, true :: Nil) `assertEq!` 2 :: 1 :: Nil
+def scanRight03(): Bool = List.scanRight((b, i) -> if (b) i+1 else i+2, 1, true :: Nil) == 2 :: 1 :: Nil
 
 @test
-def scanRight04(): Bool = List.scanRight((b, i) -> if (b) i+1 else i+2, 1, false :: false :: Nil) `assertEq!` 5 :: 3 :: 1 :: Nil
+def scanRight04(): Bool = List.scanRight((b, i) -> if (b) i+1 else i+2, 1, false :: false :: Nil) == 5 :: 3 :: 1 :: Nil
 
 @test
-def scanRight05(): Bool = List.scanRight((b, i) -> if (b) i+1 else i+2, 1, false :: true :: Nil) `assertEq!` 4 :: 2 :: 1 :: Nil
+def scanRight05(): Bool = List.scanRight((b, i) -> if (b) i+1 else i+2, 1, false :: true :: Nil) == 4 :: 2 :: 1 :: Nil
 
 @test
-def scanRight06(): Bool = List.scanRight((b, i) -> if (b) i+1 else i+2, 1, true :: false :: Nil) `assertEq!` 4 :: 3 :: 1 :: Nil
+def scanRight06(): Bool = List.scanRight((b, i) -> if (b) i+1 else i+2, 1, true :: false :: Nil) == 4 :: 3 :: 1 :: Nil
 
 @test
-def scanRight07(): Bool = List.scanRight((b, i) -> if (b) i+1 else i+2, 1, true :: true :: Nil) `assertEq!` 3 :: 2 :: 1 :: Nil
+def scanRight07(): Bool = List.scanRight((b, i) -> if (b) i+1 else i+2, 1, true :: true :: Nil) == 3 :: 2 :: 1 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // map                                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def map01(): Bool = List.map(i -> i > 2, Nil) `assertEq!` Nil
+def map01(): Bool = List.map(i -> i > 2, Nil) == Nil
 
 @test
-def map02(): Bool = List.map(i -> i > 2, 1 :: Nil) `assertEq!` false :: Nil
+def map02(): Bool = List.map(i -> i > 2, 1 :: Nil) == false :: Nil
 
 @test
-def map03(): Bool = List.map(i -> i > 2, 3 :: Nil) `assertEq!` true :: Nil
+def map03(): Bool = List.map(i -> i > 2, 3 :: Nil) == true :: Nil
 
 @test
-def map04(): Bool = List.map(i -> i > 2, 1 :: 2 :: Nil) `assertEq!` false :: false :: Nil
+def map04(): Bool = List.map(i -> i > 2, 1 :: 2 :: Nil) == false :: false :: Nil
 
 @test
-def map05(): Bool = List.map(i -> i > 2, 1 :: 8 :: Nil) `assertEq!` false :: true :: Nil
+def map05(): Bool = List.map(i -> i > 2, 1 :: 8 :: Nil) == false :: true :: Nil
 
 @test
-def map06(): Bool = List.map(i -> i > 2, 8 :: 1 :: Nil) `assertEq!` true :: false :: Nil
+def map06(): Bool = List.map(i -> i > 2, 8 :: 1 :: Nil) == true :: false :: Nil
 
 @test
-def map07(): Bool = List.map(i -> i > 2, 7 :: 8 :: Nil) `assertEq!` true :: true :: Nil
+def map07(): Bool = List.map(i -> i > 2, 7 :: 8 :: Nil) == true :: true :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // mapWithIndex                                                            //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def mapWithIndex01(): Bool = List.mapWithIndex((e, i) -> if (i < 1) e > 2 else e <= 2, Nil) `assertEq!` Nil
+def mapWithIndex01(): Bool = List.mapWithIndex((e, i) -> if (i < 1) e > 2 else e <= 2, Nil) == Nil
 
 @test
-def mapWithIndex02(): Bool = List.mapWithIndex((e, i) -> if (i < 1) e > 2 else e <= 2, 1 :: Nil) `assertEq!` false :: Nil
+def mapWithIndex02(): Bool = List.mapWithIndex((e, i) -> if (i < 1) e > 2 else e <= 2, 1 :: Nil) == false :: Nil
 
 @test
-def mapWithIndex03(): Bool = List.mapWithIndex((e, i) -> if (i < 1) e > 2 else e <= 2, 3 :: Nil) `assertEq!` true :: Nil
+def mapWithIndex03(): Bool = List.mapWithIndex((e, i) -> if (i < 1) e > 2 else e <= 2, 3 :: Nil) == true :: Nil
 
 @test
-def mapWithIndex04(): Bool = List.mapWithIndex((e, i) -> if (i < 1) e > 2 else e <= 2, 1 :: 2 :: Nil) `assertEq!` false :: true :: Nil
+def mapWithIndex04(): Bool = List.mapWithIndex((e, i) -> if (i < 1) e > 2 else e <= 2, 1 :: 2 :: Nil) == false :: true :: Nil
 
 @test
-def mapWithIndex05(): Bool = List.mapWithIndex((e, i) -> if (i < 1) e > 2 else e <= 2, 1 :: 8 :: Nil) `assertEq!` false :: false :: Nil
+def mapWithIndex05(): Bool = List.mapWithIndex((e, i) -> if (i < 1) e > 2 else e <= 2, 1 :: 8 :: Nil) == false :: false :: Nil
 
 @test
-def mapWithIndex06(): Bool = List.mapWithIndex((e, i) -> if (i < 1) e > 2 else e <= 2, 8 :: 1 :: Nil) `assertEq!` true :: true :: Nil
+def mapWithIndex06(): Bool = List.mapWithIndex((e, i) -> if (i < 1) e > 2 else e <= 2, 8 :: 1 :: Nil) == true :: true :: Nil
 
 @test
-def mapWithIndex07(): Bool = List.mapWithIndex((e, i) -> if (i < 1) e > 2 else e <= 2, 7 :: 8 :: Nil) `assertEq!` true :: false :: Nil
+def mapWithIndex07(): Bool = List.mapWithIndex((e, i) -> if (i < 1) e > 2 else e <= 2, 7 :: 8 :: Nil) == true :: false :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // flatMap                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def flatMap01(): Bool = List.flatMap(i -> List.repeat(i, i), Nil) `assertEq!` Nil
+def flatMap01(): Bool = List.flatMap(i -> List.repeat(i, i), Nil) == Nil
 
 @test
-def flatMap02(): Bool = List.flatMap(i -> List.repeat(i, i), 0 :: Nil) `assertEq!` Nil
+def flatMap02(): Bool = List.flatMap(i -> List.repeat(i, i), 0 :: Nil) == Nil
 
 @test
-def flatMap03(): Bool = List.flatMap(i -> List.repeat(i, i), 1 :: Nil) `assertEq!` 1 :: Nil
+def flatMap03(): Bool = List.flatMap(i -> List.repeat(i, i), 1 :: Nil) == 1 :: Nil
 
 @test
-def flatMap04(): Bool = List.flatMap(i -> List.repeat(i, i), 2 :: Nil) `assertEq!` 2 :: 2 :: Nil
+def flatMap04(): Bool = List.flatMap(i -> List.repeat(i, i), 2 :: Nil) == 2 :: 2 :: Nil
 
 @test
-def flatMap05(): Bool = List.flatMap(i -> List.repeat(i, i), 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: 2 :: Nil
+def flatMap05(): Bool = List.flatMap(i -> List.repeat(i, i), 1 :: 2 :: Nil) == 1 :: 2 :: 2 :: Nil
 
 @test
-def flatMap06(): Bool = List.flatMap(i -> List.repeat(i, i), 2 :: 3 :: Nil) `assertEq!` 2 :: 2 :: 3 :: 3 :: 3 :: Nil
+def flatMap06(): Bool = List.flatMap(i -> List.repeat(i, i), 2 :: 3 :: Nil) == 2 :: 2 :: 3 :: 3 :: 3 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // reverse                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reverse01(): Bool = List.reverse(Nil) `assertEq!` Nil
+def reverse01(): Bool = List.reverse(Nil) == Nil
 
 @test
-def reverse02(): Bool = List.reverse(1 :: Nil) `assertEq!` 1 :: Nil
+def reverse02(): Bool = List.reverse(1 :: Nil) == 1 :: Nil
 
 @test
-def reverse03(): Bool = List.reverse(1 :: 2 :: Nil) `assertEq!` 2 :: 1 :: Nil
+def reverse03(): Bool = List.reverse(1 :: 2 :: Nil) == 2 :: 1 :: Nil
 
 @test
-def reverse04(): Bool = List.reverse(1 :: 1 :: Nil) `assertEq!` 1 :: 1 :: Nil
+def reverse04(): Bool = List.reverse(1 :: 1 :: Nil) == 1 :: 1 :: Nil
 
 @test
-def reverse05(): Bool = List.reverse(1 :: 2 :: 3 :: Nil) `assertEq!` 3 :: 2 :: 1 :: Nil
+def reverse05(): Bool = List.reverse(1 :: 2 :: 3 :: Nil) == 3 :: 2 :: 1 :: Nil
 
 @test
-def reverse06(): Bool = List.reverse(1 :: 2 :: 3 :: 4 :: Nil) `assertEq!` 4 :: 3 :: 2 :: 1 :: Nil
+def reverse06(): Bool = List.reverse(1 :: 2 :: 3 :: 4 :: Nil) == 4 :: 3 :: 2 :: 1 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // rotateLeft                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def rotateLeft01(): Bool = List.rotateLeft(0, Nil) `assertEq!` Nil
+def rotateLeft01(): Bool = List.rotateLeft(0, Nil) == Nil
 
 @test
-def rotateLeft02(): Bool = List.rotateLeft(1, Nil) `assertEq!` Nil
+def rotateLeft02(): Bool = List.rotateLeft(1, Nil) == Nil
 
 @test
-def rotateLeft03(): Bool = List.rotateLeft(0, 1 :: Nil) `assertEq!` 1 :: Nil
+def rotateLeft03(): Bool = List.rotateLeft(0, 1 :: Nil) == 1 :: Nil
 
 @test
-def rotateLeft04(): Bool = List.rotateLeft(0, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def rotateLeft04(): Bool = List.rotateLeft(0, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def rotateLeft05(): Bool = List.rotateLeft(1, 1 :: 2 :: Nil) `assertEq!` 2 :: 1 :: Nil
+def rotateLeft05(): Bool = List.rotateLeft(1, 1 :: 2 :: Nil) == 2 :: 1 :: Nil
 
 @test
-def rotateLeft06(): Bool = List.rotateLeft(2, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def rotateLeft06(): Bool = List.rotateLeft(2, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def rotateLeft07(): Bool = List.rotateLeft(3, 1 :: 2 :: Nil) `assertEq!` 2 :: 1 :: Nil
+def rotateLeft07(): Bool = List.rotateLeft(3, 1 :: 2 :: Nil) == 2 :: 1 :: Nil
 
 @test
-def rotateLeft08(): Bool = List.rotateLeft(-1, 1 :: 2 :: Nil) `assertEq!` 2 :: 1 :: Nil
+def rotateLeft08(): Bool = List.rotateLeft(-1, 1 :: 2 :: Nil) == 2 :: 1 :: Nil
 
 @test
-def rotateLeft09(): Bool = List.rotateLeft(0, 1 :: 2 :: 3 :: Nil) `assertEq!` 1 :: 2 :: 3 :: Nil
+def rotateLeft09(): Bool = List.rotateLeft(0, 1 :: 2 :: 3 :: Nil) == 1 :: 2 :: 3 :: Nil
 
 @test
-def rotateLeft10(): Bool = List.rotateLeft(1, 1 :: 2 :: 3 :: Nil) `assertEq!` 2 :: 3 :: 1 :: Nil
+def rotateLeft10(): Bool = List.rotateLeft(1, 1 :: 2 :: 3 :: Nil) == 2 :: 3 :: 1 :: Nil
 
 @test
-def rotateLeft11(): Bool = List.rotateLeft(2, 1 :: 2 :: 3 :: Nil) `assertEq!` 3 :: 1 :: 2 :: Nil
+def rotateLeft11(): Bool = List.rotateLeft(2, 1 :: 2 :: 3 :: Nil) == 3 :: 1 :: 2 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // rotateRight                                                             //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def rotateRight01(): Bool = List.rotateRight(0, Nil) `assertEq!` Nil
+def rotateRight01(): Bool = List.rotateRight(0, Nil) == Nil
 
 @test
-def rotateRight02(): Bool = List.rotateRight(1, Nil) `assertEq!` Nil
+def rotateRight02(): Bool = List.rotateRight(1, Nil) == Nil
 
 @test
-def rotateRight03(): Bool = List.rotateRight(0, 1 :: Nil) `assertEq!` 1 :: Nil
+def rotateRight03(): Bool = List.rotateRight(0, 1 :: Nil) == 1 :: Nil
 
 @test
-def rotateRight04(): Bool = List.rotateRight(0, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def rotateRight04(): Bool = List.rotateRight(0, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def rotateRight05(): Bool = List.rotateRight(1, 1 :: 2 :: Nil) `assertEq!` 2 :: 1 :: Nil
+def rotateRight05(): Bool = List.rotateRight(1, 1 :: 2 :: Nil) == 2 :: 1 :: Nil
 
 @test
-def rotateRight06(): Bool = List.rotateRight(2, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def rotateRight06(): Bool = List.rotateRight(2, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def rotateRight07(): Bool = List.rotateRight(3, 1 :: 2 :: Nil) `assertEq!` 2 :: 1 :: Nil
+def rotateRight07(): Bool = List.rotateRight(3, 1 :: 2 :: Nil) == 2 :: 1 :: Nil
 
 @test
-def rotateRight08(): Bool = List.rotateRight(-1, 1 :: 2 :: Nil) `assertEq!` 2 :: 1 :: Nil
+def rotateRight08(): Bool = List.rotateRight(-1, 1 :: 2 :: Nil) == 2 :: 1 :: Nil
 
 @test
-def rotateRight09(): Bool = List.rotateRight(0, 1 :: 2 :: 3 :: Nil) `assertEq!` 1 :: 2 :: 3 :: Nil
+def rotateRight09(): Bool = List.rotateRight(0, 1 :: 2 :: 3 :: Nil) == 1 :: 2 :: 3 :: Nil
 
 @test
-def rotateRight10(): Bool = List.rotateRight(1, 1 :: 2 :: 3 :: Nil) `assertEq!` 3 :: 1 :: 2 :: Nil
+def rotateRight10(): Bool = List.rotateRight(1, 1 :: 2 :: 3 :: Nil) == 3 :: 1 :: 2 :: Nil
 
 @test
-def rotateRight11(): Bool = List.rotateRight(2, 1 :: 2 :: 3 :: Nil) `assertEq!` 2 :: 3 :: 1 :: Nil
+def rotateRight11(): Bool = List.rotateRight(2, 1 :: 2 :: 3 :: Nil) == 2 :: 3 :: 1 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // update                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def update01(): Bool = List.update(0, 2, Nil) `assertEq!` Nil
+def update01(): Bool = List.update(0, 2, Nil) == Nil
 
 @test
-def update02(): Bool = List.update(-1, 2, 1 :: Nil) `assertEq!` 1 :: Nil
+def update02(): Bool = List.update(-1, 2, 1 :: Nil) == 1 :: Nil
 
 @test
-def update03(): Bool = List.update(0, 2, 1 :: Nil) `assertEq!` 2 :: Nil
+def update03(): Bool = List.update(0, 2, 1 :: Nil) == 2 :: Nil
 
 @test
-def update04(): Bool = List.update(1, 2, 1 :: Nil) `assertEq!` 1 :: Nil
+def update04(): Bool = List.update(1, 2, 1 :: Nil) == 1 :: Nil
 
 @test
-def update05(): Bool = List.update(0, 5, 1 :: 2 :: Nil) `assertEq!` 5 :: 2 :: Nil
+def update05(): Bool = List.update(0, 5, 1 :: 2 :: Nil) == 5 :: 2 :: Nil
 
 @test
-def update06(): Bool = List.update(1, 5, 1 :: 2 :: Nil) `assertEq!` 1 :: 5 :: Nil
+def update06(): Bool = List.update(1, 5, 1 :: 2 :: Nil) == 1 :: 5 :: Nil
 
 @test
-def update07(): Bool = List.update(2, 5, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def update07(): Bool = List.update(2, 5, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // replace                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def replace01(): Bool = List.replace(3, 4, Nil) `assertEq!` Nil
+def replace01(): Bool = List.replace(3, 4, Nil) == Nil
 
 @test
-def replace02(): Bool = List.replace(3, 4, 1 :: Nil) `assertEq!` 1 :: Nil
+def replace02(): Bool = List.replace(3, 4, 1 :: Nil) == 1 :: Nil
 
 @test
-def replace03(): Bool = List.replace(3, 4, 3 :: Nil) `assertEq!` 4 :: Nil
+def replace03(): Bool = List.replace(3, 4, 3 :: Nil) == 4 :: Nil
 
 @test
-def replace04(): Bool = List.replace(3, 4, 4 :: Nil) `assertEq!` 4 :: Nil
+def replace04(): Bool = List.replace(3, 4, 4 :: Nil) == 4 :: Nil
 
 @test
-def replace05(): Bool = List.replace(3, 4, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def replace05(): Bool = List.replace(3, 4, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def replace06(): Bool = List.replace(3, 4, 1 :: 3 :: Nil) `assertEq!` 1 :: 4 :: Nil
+def replace06(): Bool = List.replace(3, 4, 1 :: 3 :: Nil) == 1 :: 4 :: Nil
 
 @test
-def replace07(): Bool = List.replace(3, 4, 3 :: 4 :: Nil) `assertEq!` 4 :: 4 :: Nil
+def replace07(): Bool = List.replace(3, 4, 3 :: 4 :: Nil) == 4 :: 4 :: Nil
 
 @test
-def replace08(): Bool = List.replace(3, 4, 3 :: 3 :: Nil) `assertEq!` 4 :: 4 :: Nil
+def replace08(): Bool = List.replace(3, 4, 3 :: 3 :: Nil) == 4 :: 4 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // patch                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def patch01(): Bool = List.patch(0, 0, Nil, Nil) `assertEq!` Nil
+def patch01(): Bool = List.patch(0, 0, Nil, Nil) == Nil
 
 @test
-def patch02(): Bool = List.patch(0, 2, 1 :: 2 :: Nil, Nil) `assertEq!` Nil
+def patch02(): Bool = List.patch(0, 2, 1 :: 2 :: Nil, Nil) == Nil
 
 @test
-def patch03(): Bool = List.patch(0, 2, Nil, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def patch03(): Bool = List.patch(0, 2, Nil, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def patch04(): Bool = List.patch(-3, 3, 1 :: 2 :: 4 :: Nil, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def patch04(): Bool = List.patch(-3, 3, 1 :: 2 :: 4 :: Nil, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def patch05(): Bool = List.patch(2, 3, 1 :: 2 :: 4 :: Nil, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def patch05(): Bool = List.patch(2, 3, 1 :: 2 :: 4 :: Nil, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def patch06(): Bool = List.patch(0, 0, Nil, 1 :: Nil) `assertEq!` 1 :: Nil
+def patch06(): Bool = List.patch(0, 0, Nil, 1 :: Nil) == 1 :: Nil
 
 @test
-def patch07(): Bool = List.patch(1, 0, 2 :: Nil, 1 :: Nil) `assertEq!` 1 :: Nil
+def patch07(): Bool = List.patch(1, 0, 2 :: Nil, 1 :: Nil) == 1 :: Nil
 
 @test
-def patch08(): Bool = List.patch(0, 1, 2 :: Nil, 1 :: Nil) `assertEq!` 2 :: Nil
+def patch08(): Bool = List.patch(0, 1, 2 :: Nil, 1 :: Nil) == 2 :: Nil
 
 @test
-def patch09(): Bool = List.patch(0, 2, 2 :: 4 :: Nil, 1 :: Nil) `assertEq!` 2 :: Nil
+def patch09(): Bool = List.patch(0, 2, 2 :: 4 :: Nil, 1 :: Nil) == 2 :: Nil
 
 @test
-def patch10(): Bool = List.patch(-1, 2, 2 :: 4 :: Nil, 1 :: Nil) `assertEq!` 4 :: Nil
+def patch10(): Bool = List.patch(-1, 2, 2 :: 4 :: Nil, 1 :: Nil) == 4 :: Nil
 
 @test
-def patch11(): Bool = List.patch(-1, 2, 3 :: 4 :: Nil, 1 :: 2 :: Nil) `assertEq!` 4 :: 2 :: Nil
+def patch11(): Bool = List.patch(-1, 2, 3 :: 4 :: Nil, 1 :: 2 :: Nil) == 4 :: 2 :: Nil
 
 @test
-def patch12(): Bool = List.patch(1, 2, 3 :: 4 :: Nil, 1 :: 2 :: Nil) `assertEq!` 1 :: 3 :: Nil
+def patch12(): Bool = List.patch(1, 2, 3 :: 4 :: Nil, 1 :: 2 :: Nil) == 1 :: 3 :: Nil
 
 @test
-def patch13(): Bool = List.patch(-2, 2, 3 :: 4 :: Nil, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def patch13(): Bool = List.patch(-2, 2, 3 :: 4 :: Nil, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def patch14(): Bool = List.patch(2, 2, 3 :: 4 :: Nil, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def patch14(): Bool = List.patch(2, 2, 3 :: 4 :: Nil, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def patch15(): Bool = List.patch(1, 1, 3 :: Nil, 1 :: 2 :: Nil) `assertEq!` 1 :: 3 :: Nil
+def patch15(): Bool = List.patch(1, 1, 3 :: Nil, 1 :: 2 :: Nil) == 1 :: 3 :: Nil
 
 @test
-def patch16(): Bool = List.patch(0, 2, 3 :: 4 :: Nil, 1 :: 2 :: Nil) `assertEq!` 3 :: 4 :: Nil
+def patch16(): Bool = List.patch(0, 2, 3 :: 4 :: Nil, 1 :: 2 :: Nil) == 3 :: 4 :: Nil
 
 @test
-def patch17(): Bool = List.patch(0, 1, 4 :: Nil, 1 :: 2 :: 3 :: Nil) `assertEq!` 4 :: 2 :: 3 :: Nil
+def patch17(): Bool = List.patch(0, 1, 4 :: Nil, 1 :: 2 :: 3 :: Nil) == 4 :: 2 :: 3 :: Nil
 
 @test
-def patch18(): Bool = List.patch(1, 1, 4 :: Nil, 1 :: 2 :: 3 :: Nil) `assertEq!` 1 :: 4 :: 3 :: Nil
+def patch18(): Bool = List.patch(1, 1, 4 :: Nil, 1 :: 2 :: 3 :: Nil) == 1 :: 4 :: 3 :: Nil
 
 @test
-def patch19(): Bool = List.patch(2, 1, 4 :: Nil, 1 :: 2 :: 3 :: Nil) `assertEq!` 1 :: 2 :: 4 :: Nil
+def patch19(): Bool = List.patch(2, 1, 4 :: Nil, 1 :: 2 :: 3 :: Nil) == 1 :: 2 :: 4 :: Nil
 
 @test
-def patch20(): Bool = List.patch(0, 2, 4 :: 5 :: Nil, 1 :: 2 :: 3 :: Nil) `assertEq!` 4 :: 5 :: 3 :: Nil
+def patch20(): Bool = List.patch(0, 2, 4 :: 5 :: Nil, 1 :: 2 :: 3 :: Nil) == 4 :: 5 :: 3 :: Nil
 
 @test
-def patch21(): Bool = List.patch(1, 2, 4 :: 5 :: Nil, 1 :: 2 :: 3 :: Nil) `assertEq!` 1 :: 4 :: 5 :: Nil
+def patch21(): Bool = List.patch(1, 2, 4 :: 5 :: Nil, 1 :: 2 :: 3 :: Nil) == 1 :: 4 :: 5 :: Nil
 
 @test
-def patch22(): Bool = List.patch(0, 2, 4 :: 5 :: 6 :: Nil, 1 :: 2 :: 3 :: Nil) `assertEq!` 4 :: 5 :: 3 :: Nil
+def patch22(): Bool = List.patch(0, 2, 4 :: 5 :: 6 :: Nil, 1 :: 2 :: 3 :: Nil) == 4 :: 5 :: 3 :: Nil
 
 @test
-def patch23(): Bool = List.patch(0, 3, 4 :: 5 :: 6 :: Nil, 1 :: 2 :: 3 :: Nil) `assertEq!` 4 :: 5 :: 6 :: Nil
+def patch23(): Bool = List.patch(0, 3, 4 :: 5 :: 6 :: Nil, 1 :: 2 :: 3 :: Nil) == 4 :: 5 :: 6 :: Nil
 
 @test
-def patch24(): Bool = List.patch(2, 4, 14 :: 15 :: 16 :: 17 :: Nil, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: Nil) `assertEq!`
+def patch24(): Bool = List.patch(2, 4, 14 :: 15 :: 16 :: 17 :: Nil, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: Nil) ==
                     1 :: 2 :: 14 :: 15 :: 16 :: 17 :: 7 :: Nil
 
 @test
-def patch25(): Bool = List.patch(-2, 4, 14 :: 15 :: 16 :: 17 :: Nil, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: Nil) `assertEq!`
+def patch25(): Bool = List.patch(-2, 4, 14 :: 15 :: 16 :: 17 :: Nil, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: Nil) ==
                     16 :: 17 :: 3 :: 4 :: 5 :: 6 :: 7 :: Nil
 
 @test
-def patch26(): Bool = List.patch(4, 5, 14 :: 15 :: 16 :: 17 :: Nil, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: Nil) `assertEq!`
+def patch26(): Bool = List.patch(4, 5, 14 :: 15 :: 16 :: 17 :: Nil, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: Nil) ==
                     1 :: 2 :: 3 :: 4 :: 14 :: 15 :: 16 :: Nil
 
 @test
-def patch27(): Bool = List.patch(4, 2, 14 :: 15 :: 16 :: 17 :: Nil, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: Nil) `assertEq!`
+def patch27(): Bool = List.patch(4, 2, 14 :: 15 :: 16 :: 17 :: Nil, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: Nil) ==
                     1 :: 2 :: 3 :: 4 :: 14 :: 15 :: 7 :: Nil
 
 @test
-def patch28(): Bool = List.patch(-1, 10, -1 :: -2 :: -3 :: -4 :: -5 :: -6 :: -7 :: -8 :: Nil, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: Nil) `assertEq!`
+def patch28(): Bool = List.patch(-1, 10, -1 :: -2 :: -3 :: -4 :: -5 :: -6 :: -7 :: -8 :: Nil, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: Nil) ==
                     -2 :: -3 :: -4 :: -5 :: -6 :: -7 :: -8 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // permutations                                                            //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def permutations01(): Bool = List.permutations(Nil) `assertEq!` Nil :: Nil
+def permutations01(): Bool = List.permutations(Nil) == Nil :: Nil
 
 @test
-def permutations02(): Bool = List.permutations(1 :: Nil) `assertEq!` (1 :: Nil) :: Nil
+def permutations02(): Bool = List.permutations(1 :: Nil) == (1 :: Nil) :: Nil
 
 @test
-def permutations03(): Bool = List.permutations(1 :: 2 :: Nil) `assertEq!` (1 :: 2 :: Nil) :: (2 :: 1 :: Nil) :: Nil
+def permutations03(): Bool = List.permutations(1 :: 2 :: Nil) == (1 :: 2 :: Nil) :: (2 :: 1 :: Nil) :: Nil
 
 @test
-def permutations04(): Bool = List.permutations(1 :: 2 :: 3 :: Nil) `assertEq!` (1 :: 2 :: 3 :: Nil) :: (1 :: 3 :: 2 :: Nil) ::
+def permutations04(): Bool = List.permutations(1 :: 2 :: 3 :: Nil) == (1 :: 2 :: 3 :: Nil) :: (1 :: 3 :: 2 :: Nil) ::
                                                                              (2 :: 1 :: 3 :: Nil) :: (2 :: 3 :: 1 :: Nil) ::
                                                                              (3 :: 1 :: 2 :: Nil) :: (3 :: 2 :: 1 :: Nil) :: Nil
 
@@ -651,17 +651,17 @@ def permutations04(): Bool = List.permutations(1 :: 2 :: 3 :: Nil) `assertEq!` (
 // subsequences                                                            //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def subsequences01(): Bool = List.subsequences(Nil) `assertEq!` Nil :: Nil
+def subsequences01(): Bool = List.subsequences(Nil) == Nil :: Nil
 
 @test
-def subsequences02(): Bool = List.subsequences(1 :: Nil) `assertEq!` (1 :: Nil) :: Nil :: Nil
+def subsequences02(): Bool = List.subsequences(1 :: Nil) == (1 :: Nil) :: Nil :: Nil
 
 @test
-def subsequences03(): Bool = List.subsequences(1 :: 2 :: Nil) `assertEq!` (1 :: 2 :: Nil) :: (1 :: Nil) ::
+def subsequences03(): Bool = List.subsequences(1 :: 2 :: Nil) == (1 :: 2 :: Nil) :: (1 :: Nil) ::
                                                                         (2 :: Nil) :: Nil :: Nil
 
 @test
-def subsequences04(): Bool = List.subsequences(1 :: 2 :: 3 :: Nil) `assertEq!` (1 :: 2 :: 3 :: Nil) :: (1 :: 2 :: Nil) ::
+def subsequences04(): Bool = List.subsequences(1 :: 2 :: 3 :: Nil) == (1 :: 2 :: 3 :: Nil) :: (1 :: 2 :: Nil) ::
                                                                              (1 :: 3 :: Nil) :: (1 :: Nil) ::
                                                                              (2 :: 3 :: Nil) :: (2 :: Nil) ::
                                                                              (3 :: Nil) :: Nil :: Nil
@@ -670,1070 +670,1069 @@ def subsequences04(): Bool = List.subsequences(1 :: 2 :: 3 :: Nil) `assertEq!` (
 // intersperse                                                             //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def intersperse01(): Bool = List.intersperse(11, Nil) `assertEq!` Nil
+def intersperse01(): Bool = List.intersperse(11, Nil) == Nil
 
 @test
-def intersperse02(): Bool = List.intersperse(11, 1 :: Nil) `assertEq!` 1 :: Nil
+def intersperse02(): Bool = List.intersperse(11, 1 :: Nil) == 1 :: Nil
 
 @test
-def intersperse03(): Bool = List.intersperse(11, 1 :: 2 :: Nil) `assertEq!` 1 :: 11 :: 2 :: Nil
+def intersperse03(): Bool = List.intersperse(11, 1 :: 2 :: Nil) == 1 :: 11 :: 2 :: Nil
 
 @test
-def intersperse04(): Bool = List.intersperse(11, 1 :: 2 :: 3 :: Nil) `assertEq!` 1 :: 11 :: 2 :: 11 :: 3 :: Nil
+def intersperse04(): Bool = List.intersperse(11, 1 :: 2 :: 3 :: Nil) == 1 :: 11 :: 2 :: 11 :: 3 :: Nil
 
 @test
-def intersperse05(): Bool = List.intersperse(11, 1 :: 2 :: 3 :: 4 :: Nil) `assertEq!` 1 :: 11 :: 2 :: 11 :: 3 :: 11 :: 4 :: Nil
+def intersperse05(): Bool = List.intersperse(11, 1 :: 2 :: 3 :: 4 :: Nil) == 1 :: 11 :: 2 :: 11 :: 3 :: 11 :: 4 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // transpose                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def transpose01(): Bool = List.transpose(Nil) `assertEq!` Nil
+def transpose01(): Bool = List.transpose(Nil) == Nil
 
 @test
-def transpose02(): Bool = List.transpose(Nil :: Nil) `assertEq!` Nil :: Nil
+def transpose02(): Bool = List.transpose(Nil :: Nil) == Nil :: Nil
 
 @test
-def transpose03(): Bool = List.transpose(Nil :: Nil :: Nil) `assertEq!` Nil :: Nil :: Nil
+def transpose03(): Bool = List.transpose(Nil :: Nil :: Nil) == Nil :: Nil :: Nil
 
 @test
-def transpose04(): Bool = List.transpose(Nil :: Nil :: Nil :: Nil) `assertEq!` Nil :: Nil :: Nil :: Nil
+def transpose04(): Bool = List.transpose(Nil :: Nil :: Nil :: Nil) == Nil :: Nil :: Nil :: Nil
 
 @test
-def transpose05(): Bool = List.transpose((1 :: Nil) :: Nil) `assertEq!` (1 :: Nil) :: Nil
+def transpose05(): Bool = List.transpose((1 :: Nil) :: Nil) == (1 :: Nil) :: Nil
 
 @test
-def transpose06(): Bool = List.transpose((1 :: 2 :: Nil) :: Nil) `assertEq!` (1 :: Nil) :: (2 :: Nil) :: Nil
+def transpose06(): Bool = List.transpose((1 :: 2 :: Nil) :: Nil) == (1 :: Nil) :: (2 :: Nil) :: Nil
 
 @test
-def transpose07(): Bool = List.transpose((1 :: 2 :: 3 :: Nil) :: Nil) `assertEq!`
+def transpose07(): Bool = List.transpose((1 :: 2 :: 3 :: Nil) :: Nil) ==
                         (1 :: Nil) :: (2 :: Nil) :: (3 :: Nil) :: Nil
 
 @test
-def transpose08(): Bool = List.transpose((1 :: 2 :: 3 :: 4 :: Nil) :: Nil) `assertEq!`
+def transpose08(): Bool = List.transpose((1 :: 2 :: 3 :: 4 :: Nil) :: Nil) ==
                         (1 :: Nil) :: (2 :: Nil) :: (3 :: Nil) :: (4 :: Nil) :: Nil
 
 @test
-def transpose09(): Bool = List.transpose((1 :: Nil) :: (2 :: Nil) :: Nil) `assertEq!` (1 :: 2 :: Nil) :: Nil
+def transpose09(): Bool = List.transpose((1 :: Nil) :: (2 :: Nil) :: Nil) == (1 :: 2 :: Nil) :: Nil
 
 @test
-def transpose10(): Bool = List.transpose((1 :: Nil) :: (2 :: Nil) :: (3 :: Nil) :: Nil) `assertEq!`
+def transpose10(): Bool = List.transpose((1 :: Nil) :: (2 :: Nil) :: (3 :: Nil) :: Nil) ==
                         (1 :: 2 :: 3 :: Nil) :: Nil
 
 @test
-def transpose11(): Bool = List.transpose((1 :: Nil) :: (2 :: Nil) :: (3 :: Nil) :: (4 :: Nil) :: Nil) `assertEq!`
+def transpose11(): Bool = List.transpose((1 :: Nil) :: (2 :: Nil) :: (3 :: Nil) :: (4 :: Nil) :: Nil) ==
                         (1 :: 2 :: 3 :: 4 :: Nil) :: Nil
 
 @test
-def transpose12(): Bool = List.transpose((1 :: 2 :: Nil) :: (3 :: 4 :: Nil) :: Nil) `assertEq!`
+def transpose12(): Bool = List.transpose((1 :: 2 :: Nil) :: (3 :: 4 :: Nil) :: Nil) ==
                         (1 :: 3 :: Nil) :: (2 :: 4 :: Nil) :: Nil
 
 @test
-def transpose13(): Bool = List.transpose((1 :: 2 :: 3 :: Nil) :: (4 :: 5 :: 6 :: Nil) :: Nil) `assertEq!`
+def transpose13(): Bool = List.transpose((1 :: 2 :: 3 :: Nil) :: (4 :: 5 :: 6 :: Nil) :: Nil) ==
                         (1 :: 4 :: Nil) :: (2 :: 5 :: Nil) :: (3 :: 6 :: Nil) :: Nil
 
 @test
-def transpose14(): Bool = List.transpose((1 :: 2 :: 3 :: 4 :: Nil) :: (5 :: 6 :: 7 :: 8 :: Nil) :: Nil) `assertEq!`
+def transpose14(): Bool = List.transpose((1 :: 2 :: 3 :: 4 :: Nil) :: (5 :: 6 :: 7 :: 8 :: Nil) :: Nil) ==
                         (1 :: 5 :: Nil) :: (2 :: 6 :: Nil) :: (3 :: 7 :: Nil) :: (4 :: 8 :: Nil) :: Nil
 
 @test
-def transpose15(): Bool = List.transpose((1 :: 2 :: 3 :: 4 :: 5 :: Nil) :: (6 :: 7 :: 8 :: 9 :: 10 :: Nil) :: Nil) `assertEq!`
+def transpose15(): Bool = List.transpose((1 :: 2 :: 3 :: 4 :: 5 :: Nil) :: (6 :: 7 :: 8 :: 9 :: 10 :: Nil) :: Nil) ==
                         (1 :: 6 :: Nil) :: (2 :: 7 :: Nil) :: (3 :: 8 :: Nil) :: (4 :: 9 :: Nil) :: (5 :: 10 :: Nil) :: Nil
 
 @test
-def transpose16(): Bool = List.transpose((1 :: 2 :: Nil) :: (3 :: 4 :: Nil) :: (5 :: 6 :: Nil) :: Nil) `assertEq!`
+def transpose16(): Bool = List.transpose((1 :: 2 :: Nil) :: (3 :: 4 :: Nil) :: (5 :: 6 :: Nil) :: Nil) ==
                         (1 :: 3 :: 5 :: Nil) :: (2 :: 4 :: 6 :: Nil) :: Nil
 
 @test
-def transpose17(): Bool = List.transpose((1 :: 2 :: Nil) :: (3 :: 4 :: Nil) :: (5 :: 6 :: Nil) :: (7 :: 8 :: Nil) :: Nil) `assertEq!`
+def transpose17(): Bool = List.transpose((1 :: 2 :: Nil) :: (3 :: 4 :: Nil) :: (5 :: 6 :: Nil) :: (7 :: 8 :: Nil) :: Nil) ==
                         (1 :: 3 :: 5 :: 7 :: Nil) :: (2 :: 4 :: 6 :: 8 :: Nil) :: Nil
 
 @test
-def transpose18(): Bool = List.transpose((1 :: 2 :: Nil) :: (3 :: 4 :: Nil) :: (5 :: 6 :: Nil) :: (7 :: 8 :: Nil) :: (9 :: 10 :: Nil) :: Nil) `assertEq!`
+def transpose18(): Bool = List.transpose((1 :: 2 :: Nil) :: (3 :: 4 :: Nil) :: (5 :: 6 :: Nil) :: (7 :: 8 :: Nil) :: (9 :: 10 :: Nil) :: Nil) ==
                         (1 :: 3 :: 5 :: 7 :: 9 :: Nil) :: (2 :: 4 :: 6 :: 8 :: 10 :: Nil) :: Nil
 
 @test
-def transpose19(): Bool = List.transpose((1 :: 2 :: 3 :: Nil) :: (4 :: 5 :: 6 :: Nil) :: (7 :: 8 :: 9 :: Nil) :: Nil) `assertEq!`
+def transpose19(): Bool = List.transpose((1 :: 2 :: 3 :: Nil) :: (4 :: 5 :: 6 :: Nil) :: (7 :: 8 :: 9 :: Nil) :: Nil) ==
                         (1 :: 4 :: 7 :: Nil) :: (2 :: 5 :: 8 :: Nil) :: (3 :: 6 :: 9 :: Nil) :: Nil
 
 @test
-def transpose20(): Bool = List.transpose((1 :: 2 :: 3 :: Nil) :: (4 :: 5 :: Nil) :: (7 :: 8 :: 9 :: Nil) :: Nil) `assertEq!`
+def transpose20(): Bool = List.transpose((1 :: 2 :: 3 :: Nil) :: (4 :: 5 :: Nil) :: (7 :: 8 :: 9 :: Nil) :: Nil) ==
                         (1 :: 2 :: 3 :: Nil) :: (4 :: 5 :: Nil) :: (7 :: 8 :: 9 :: Nil) :: Nil
 
 @test
-def transpose21(): Bool = List.transpose((1 :: 2 :: 3 :: Nil) :: Nil :: (7 :: 8 :: 9 :: Nil) :: Nil) `assertEq!`
+def transpose21(): Bool = List.transpose((1 :: 2 :: 3 :: Nil) :: Nil :: (7 :: 8 :: 9 :: Nil) :: Nil) ==
                         (1 :: 2 :: 3 :: Nil) :: Nil :: (7 :: 8 :: 9 :: Nil) :: Nil
 
 @test
-def transpose22(): Bool = List.transpose((1 :: 2 :: 3 :: Nil) :: (4 :: 5 :: 6 :: Nil) :: (7 :: 8 :: 9 :: 10 :: Nil) :: Nil) `assertEq!`
+def transpose22(): Bool = List.transpose((1 :: 2 :: 3 :: Nil) :: (4 :: 5 :: 6 :: Nil) :: (7 :: 8 :: 9 :: 10 :: Nil) :: Nil) ==
                         (1 :: 2 :: 3 :: Nil) :: (4 :: 5 :: 6 :: Nil) :: (7 :: 8 :: 9 :: 10 :: Nil) :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // isPrefixOf                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def isPrefixOf01(): Bool = assert!(List.isPrefixOf(Nil, Nil))
+def isPrefixOf01(): Bool = List.isPrefixOf(Nil, Nil) == true
 
 @test
-def isPrefixOf02(): Bool = assertNot!(List.isPrefixOf(1 :: Nil, Nil))
+def isPrefixOf02(): Bool = List.isPrefixOf(1 :: Nil, Nil) == false
 
 @test
-def isPrefixOf03(): Bool = assert!(List.isPrefixOf(Nil, 1 :: Nil))
+def isPrefixOf03(): Bool = List.isPrefixOf(Nil, 1 :: Nil) == true
 
 @test
-def isPrefixOf04(): Bool = assert!(List.isPrefixOf(1 :: Nil, 1 :: Nil))
+def isPrefixOf04(): Bool = List.isPrefixOf(1 :: Nil, 1 :: Nil) == true
 
 @test
-def isPrefixOf05(): Bool = assertNot!(List.isPrefixOf(2 :: Nil, 1 :: Nil))
+def isPrefixOf05(): Bool = List.isPrefixOf(2 :: Nil, 1 :: Nil) == false
 
 @test
-def isPrefixOf06(): Bool = assertNot!(List.isPrefixOf(1 :: 2 :: Nil, 1 :: Nil))
+def isPrefixOf06(): Bool = List.isPrefixOf(1 :: 2 :: Nil, 1 :: Nil) == false
 
 @test
-def isPrefixOf07(): Bool = assert!(List.isPrefixOf(Nil, 1 :: 2 :: Nil))
+def isPrefixOf07(): Bool = List.isPrefixOf(Nil, 1 :: 2 :: Nil) == true
 
 @test
-def isPrefixOf08(): Bool = assert!(List.isPrefixOf(1 :: Nil, 1 :: 2 :: Nil))
+def isPrefixOf08(): Bool = List.isPrefixOf(1 :: Nil, 1 :: 2 :: Nil) == true
 
 @test
-def isPrefixOf09(): Bool = assertNot!(List.isPrefixOf(2 :: Nil, 1 :: 2 :: Nil))
+def isPrefixOf09(): Bool = List.isPrefixOf(2 :: Nil, 1 :: 2 :: Nil) == false
 
 @test
-def isPrefixOf10(): Bool = assert!(List.isPrefixOf(1 :: 2 :: Nil, 1 :: 2 :: Nil))
+def isPrefixOf10(): Bool = List.isPrefixOf(1 :: 2 :: Nil, 1 :: 2 :: Nil) == true
 
 @test
-def isPrefixOf11(): Bool = assertNot!(List.isPrefixOf(1 :: 3 :: Nil, 1 :: 2 :: Nil))
+def isPrefixOf11(): Bool = List.isPrefixOf(1 :: 3 :: Nil, 1 :: 2 :: Nil) == false
 
 @test
-def isPrefixOf12(): Bool = assertNot!(List.isPrefixOf(1 :: 2 :: 3 :: Nil, 1 :: 2 :: Nil))
+def isPrefixOf12(): Bool = List.isPrefixOf(1 :: 2 :: 3 :: Nil, 1 :: 2 :: Nil) == false
 
 @test
-def isPrefixOf13(): Bool = assertNot!(List.isPrefixOf(1 :: 2 :: 3 :: Nil, 89 :: 11 :: 1 :: 2 :: 3 :: 4 :: Nil))
+def isPrefixOf13(): Bool = List.isPrefixOf(1 :: 2 :: 3 :: Nil, 89 :: 11 :: 1 :: 2 :: 3 :: 4 :: Nil) == false
 
 /////////////////////////////////////////////////////////////////////////////
 // isInfixOf                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def isInfixOf01(): Bool = assert!(List.isInfixOf(Nil, Nil))
+def isInfixOf01(): Bool = List.isInfixOf(Nil, Nil) == true
 
 @test
-def isInfixOf02(): Bool = assertNot!(List.isInfixOf(1 :: Nil, Nil))
+def isInfixOf02(): Bool = List.isInfixOf(1 :: Nil, Nil) == false
 
 @test
-def isInfixOf03(): Bool = assert!(List.isInfixOf(Nil, 1 :: Nil))
+def isInfixOf03(): Bool = List.isInfixOf(Nil, 1 :: Nil) == true
 
 @test
-def isInfixOf04(): Bool = assert!(List.isInfixOf(1 :: Nil, 1 :: Nil))
+def isInfixOf04(): Bool = List.isInfixOf(1 :: Nil, 1 :: Nil) == true
 
 @test
-def isInfixOf05(): Bool = assertNot!(List.isInfixOf(2 :: Nil, 1 :: Nil))
+def isInfixOf05(): Bool = List.isInfixOf(2 :: Nil, 1 :: Nil) == false
 
 @test
-def isInfixOf06(): Bool = assertNot!(List.isInfixOf(1 :: 2 :: Nil, 1 :: Nil))
+def isInfixOf06(): Bool = List.isInfixOf(1 :: 2 :: Nil, 1 :: Nil) == false
 
 @test
-def isInfixOf07(): Bool = assert!(List.isInfixOf(Nil, 1 :: 2 :: Nil))
+def isInfixOf07(): Bool = List.isInfixOf(Nil, 1 :: 2 :: Nil) == true
 
 @test
-def isInfixOf08(): Bool = assert!(List.isInfixOf(1 :: Nil, 1 :: 2 :: Nil))
+def isInfixOf08(): Bool = List.isInfixOf(1 :: Nil, 1 :: 2 :: Nil) == true
 
 @test
-def isInfixOf09(): Bool = assert!(List.isInfixOf(2 :: Nil, 1 :: 2 :: Nil))
+def isInfixOf09(): Bool = List.isInfixOf(2 :: Nil, 1 :: 2 :: Nil) == true
 
 @test
-def isInfixOf10(): Bool = assert!(List.isInfixOf(1 :: 2 :: Nil, 1 :: 2 :: Nil))
+def isInfixOf10(): Bool = List.isInfixOf(1 :: 2 :: Nil, 1 :: 2 :: Nil) == true
 
 @test
-def isInfixOf11(): Bool = assertNot!(List.isInfixOf(1 :: 3 :: Nil, 1 :: 2 :: Nil))
+def isInfixOf11(): Bool = List.isInfixOf(1 :: 3 :: Nil, 1 :: 2 :: Nil) == false
 
 @test
-def isInfixOf12(): Bool = assertNot!(List.isInfixOf(1 :: 2 :: 3 :: Nil, 1 :: 2 :: Nil))
+def isInfixOf12(): Bool = List.isInfixOf(1 :: 2 :: 3 :: Nil, 1 :: 2 :: Nil) == false
 
 @test
-def isInfixOf13(): Bool = assert!(List.isInfixOf(1 :: 2 :: 3 :: Nil, 89 :: 11 :: 1 :: 2 :: 3 :: 4 :: Nil))
+def isInfixOf13(): Bool = List.isInfixOf(1 :: 2 :: 3 :: Nil, 89 :: 11 :: 1 :: 2 :: 3 :: 4 :: Nil) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // isSuffixOf                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def isSuffixOf01(): Bool = assert!(List.isSuffixOf(Nil, Nil))
+def isSuffixOf01(): Bool = List.isSuffixOf(Nil, Nil) == true
 
 @test
-def isSuffixOf02(): Bool = assertNot!(List.isSuffixOf(1 :: Nil, Nil))
+def isSuffixOf02(): Bool = List.isSuffixOf(1 :: Nil, Nil) == false
 
 @test
-def isSuffixOf03(): Bool = assert!(List.isSuffixOf(Nil, 1 :: Nil))
+def isSuffixOf03(): Bool = List.isSuffixOf(Nil, 1 :: Nil)  == true
 
 @test
-def isSuffixOf04(): Bool = assert!(List.isSuffixOf(1 :: Nil, 1 :: Nil))
+def isSuffixOf04(): Bool = List.isSuffixOf(1 :: Nil, 1 :: Nil) == true
 
 @test
-def isSuffixOf05(): Bool = assertNot!(List.isSuffixOf(2 :: Nil, 1 :: Nil))
+def isSuffixOf05(): Bool = List.isSuffixOf(2 :: Nil, 1 :: Nil) == false
 
 @test
-def isSuffixOf06(): Bool = assertNot!(List.isSuffixOf(1 :: 2 :: Nil, 1 :: Nil))
+def isSuffixOf06(): Bool = List.isSuffixOf(1 :: 2 :: Nil, 1 :: Nil) == false
 
 @test
-def isSuffixOf07(): Bool = assert!(List.isSuffixOf(Nil, 1 :: 2 :: Nil))
+def isSuffixOf07(): Bool = List.isSuffixOf(Nil, 1 :: 2 :: Nil) == true
 
 @test
-def isSuffixOf08(): Bool = assertNot!(List.isSuffixOf(1 :: Nil, 1 :: 2 :: Nil))
+def isSuffixOf08(): Bool = List.isSuffixOf(1 :: Nil, 1 :: 2 :: Nil) == false
 
 @test
-def isSuffixOf09(): Bool = assert!(List.isSuffixOf(2 :: Nil, 1 :: 2 :: Nil))
+def isSuffixOf09(): Bool = List.isSuffixOf(2 :: Nil, 1 :: 2 :: Nil) == true
 
 @test
-def isSuffixOf10(): Bool = assert!(List.isSuffixOf(1 :: 2 :: Nil, 1 :: 2 :: Nil))
+def isSuffixOf10(): Bool = List.isSuffixOf(1 :: 2 :: Nil, 1 :: 2 :: Nil) == true
 
 @test
-def isSuffixOf11(): Bool = assertNot!(List.isSuffixOf(1 :: 3 :: Nil, 1 :: 2 :: Nil))
+def isSuffixOf11(): Bool = List.isSuffixOf(1 :: 3 :: Nil, 1 :: 2 :: Nil) == false
 
 @test
-def isSuffixOf12(): Bool = assertNot!(List.isSuffixOf(1 :: 2 :: 3 :: Nil, 1 :: 2 :: Nil))
+def isSuffixOf12(): Bool = List.isSuffixOf(1 :: 2 :: 3 :: Nil, 1 :: 2 :: Nil) == false
 
 @test
-def isSuffixOf13(): Bool = assert!(List.isSuffixOf(1 :: 2 :: 3 :: Nil, 89 :: 11 :: 1 :: 2 :: 3 :: Nil))
+def isSuffixOf13(): Bool = List.isSuffixOf(1 :: 2 :: 3 :: Nil, 89 :: 11 :: 1 :: 2 :: 3 :: Nil) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // fold                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def fold01(): Bool = List.fold((i, e) -> (i - e)*(e % 2 + 1), 100, Nil) `assertEq!` 100
+def fold01(): Bool = List.fold((i, e) -> (i - e)*(e % 2 + 1), 100, Nil) == 100
 
 @test
-def fold02(): Bool = List.fold((i, e) -> (i - e)*(e % 2 + 1), 100, 1 :: Nil) `assertEq!` 198
+def fold02(): Bool = List.fold((i, e) -> (i - e)*(e % 2 + 1), 100, 1 :: Nil) == 198
 
 @test
-def fold03(): Bool = List.fold((i, e) -> (i - e)*(e % 2 + 1), 100, 1 :: 2 :: Nil) `assertEq!` 196
+def fold03(): Bool = List.fold((i, e) -> (i - e)*(e % 2 + 1), 100, 1 :: 2 :: Nil) == 196
 
 @test
-def fold04(): Bool = List.fold((i, e) -> (i - e)*(e % 2 + 1), 100, 1 :: 2 :: 3 :: Nil) `assertEq!` 386
+def fold04(): Bool = List.fold((i, e) -> (i - e)*(e % 2 + 1), 100, 1 :: 2 :: 3 :: Nil) == 386
 
 /////////////////////////////////////////////////////////////////////////////
 // foldLeft                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldLeft01(): Bool = List.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, Nil) `assertEq!` 100
+def foldLeft01(): Bool = List.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, Nil) == 100
 
 @test
-def foldLeft02(): Bool = List.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, 1 :: Nil) `assertEq!` 198
+def foldLeft02(): Bool = List.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, 1 :: Nil) == 198
 
 @test
-def foldLeft03(): Bool = List.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, 1 :: 2 :: Nil) `assertEq!` 196
+def foldLeft03(): Bool = List.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, 1 :: 2 :: Nil) == 196
 
 @test
-def foldLeft04(): Bool = List.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, 1 :: 2 :: 3 :: Nil) `assertEq!` 386
+def foldLeft04(): Bool = List.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, 1 :: 2 :: 3 :: Nil) == 386
 
 /////////////////////////////////////////////////////////////////////////////
 // foldRight                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldRight01(): Bool = List.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, Nil) `assertEq!` 100
+def foldRight01(): Bool = List.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, Nil) == 100
 
 @test
-def foldRight02(): Bool = List.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, 1 :: Nil) `assertEq!` 198
+def foldRight02(): Bool = List.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, 1 :: Nil) == 198
 
 @test
-def foldRight03(): Bool = List.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, 1 :: 2 :: Nil) `assertEq!` 194
+def foldRight03(): Bool = List.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, 1 :: 2 :: Nil) == 194
 
 @test
-def foldRight04(): Bool = List.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, 1 :: 2 :: 3 :: Nil) `assertEq!` 382
+def foldRight04(): Bool = List.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, 1 :: 2 :: 3 :: Nil) == 382
 
 /////////////////////////////////////////////////////////////////////////////
 // reduce                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduce01(): Bool = List.reduce((a, b) -> a-b, Nil: List[Int]) `assertEq!` None
+def reduce01(): Bool = List.reduce((a, b) -> a-b, Nil: List[Int]) == None
 
 @test
-def reduce02(): Bool = List.reduce((a, b) -> a-b, 1 :: Nil) `assertEq!` Some(1)
+def reduce02(): Bool = List.reduce((a, b) -> a-b, 1 :: Nil) == Some(1)
 
 @test
-def reduce03(): Bool = List.reduce((a, b) -> a-b, 1 :: 2 :: Nil) `assertEq!` Some(-1)
+def reduce03(): Bool = List.reduce((a, b) -> a-b, 1 :: 2 :: Nil) == Some(-1)
 
 @test
-def reduce04(): Bool = List.reduce((a, b) -> a-b, 1 :: 2 :: 3 :: Nil) `assertEq!` Some(-4)
+def reduce04(): Bool = List.reduce((a, b) -> a-b, 1 :: 2 :: 3 :: Nil) == Some(-4)
 
 @test
-def reduce05(): Bool = List.reduce((a, b) -> a-b, 1 :: 2 :: 3 :: 4 :: Nil) `assertEq!` Some(-8)
+def reduce05(): Bool = List.reduce((a, b) -> a-b, 1 :: 2 :: 3 :: 4 :: Nil) == Some(-8)
 
 /////////////////////////////////////////////////////////////////////////////
 // reduceLeft                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduceLeft01(): Bool = List.reduceLeft((a, b) -> a-b, Nil: List[Int]) `assertEq!` None
+def reduceLeft01(): Bool = List.reduceLeft((a, b) -> a-b, Nil: List[Int]) == None
 
 @test
-def reduceLeft02(): Bool = List.reduceLeft((a, b) -> a-b, 1 :: Nil) `assertEq!` Some(1)
+def reduceLeft02(): Bool = List.reduceLeft((a, b) -> a-b, 1 :: Nil) == Some(1)
 
 @test
-def reduceLeft03(): Bool = List.reduceLeft((a, b) -> a-b, 1 :: 2 :: Nil) `assertEq!` Some(-1)
+def reduceLeft03(): Bool = List.reduceLeft((a, b) -> a-b, 1 :: 2 :: Nil) == Some(-1)
 
 @test
-def reduceLeft04(): Bool = List.reduceLeft((a, b) -> a-b, 1 :: 2 :: 3 :: Nil) `assertEq!` Some(-4)
+def reduceLeft04(): Bool = List.reduceLeft((a, b) -> a-b, 1 :: 2 :: 3 :: Nil) == Some(-4)
 
 @test
-def reduceLeft05(): Bool = List.reduceLeft((a, b) -> a-b, 1 :: 2 :: 3 :: 4 :: Nil) `assertEq!` Some(-8)
+def reduceLeft05(): Bool = List.reduceLeft((a, b) -> a-b, 1 :: 2 :: 3 :: 4 :: Nil) == Some(-8)
 
 /////////////////////////////////////////////////////////////////////////////
 // reduceRight                                                             //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduceRight01(): Bool = List.reduceRight((a, b) -> a-b, Nil: List[Int]) `assertEq!` None
+def reduceRight01(): Bool = List.reduceRight((a, b) -> a-b, Nil: List[Int]) == None
 
 @test
-def reduceRight02(): Bool = List.reduceRight((a, b) -> a-b, 1 :: Nil) `assertEq!` Some(1)
+def reduceRight02(): Bool = List.reduceRight((a, b) -> a-b, 1 :: Nil) == Some(1)
 
 @test
-def reduceRight03(): Bool = List.reduceRight((a, b) -> a-b, 1 :: 2 :: Nil) `assertEq!` Some(-1)
+def reduceRight03(): Bool = List.reduceRight((a, b) -> a-b, 1 :: 2 :: Nil) == Some(-1)
 
 @test
-def reduceRight04(): Bool = List.reduceRight((a, b) -> a-b, 1 :: 2 :: 3 :: Nil) `assertEq!` Some(2)
+def reduceRight04(): Bool = List.reduceRight((a, b) -> a-b, 1 :: 2 :: 3 :: Nil) == Some(2)
 
 @test
-def reduceRight05(): Bool = List.reduceRight((a, b) -> a-b, 1 :: 2 :: 3 :: 4 :: Nil) `assertEq!` Some(-2)
+def reduceRight05(): Bool = List.reduceRight((a, b) -> a-b, 1 :: 2 :: 3 :: 4 :: Nil) == Some(-2)
 
 /////////////////////////////////////////////////////////////////////////////
 // count                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def count01(): Bool = List.count(i -> i > 3, Nil) `assertEq!` 0
+def count01(): Bool = List.count(i -> i > 3, Nil) == 0
 
 @test
-def count02(): Bool = List.count(i -> i > 3, 1 :: Nil) `assertEq!` 0
+def count02(): Bool = List.count(i -> i > 3, 1 :: Nil) == 0
 
 @test
-def count03(): Bool = List.count(i -> i > 3, 4 :: Nil) `assertEq!` 1
+def count03(): Bool = List.count(i -> i > 3, 4 :: Nil) == 1
 
 @test
-def count04(): Bool = List.count(i -> i > 3, 1 :: 2 :: Nil) `assertEq!` 0
+def count04(): Bool = List.count(i -> i > 3, 1 :: 2 :: Nil) == 0
 
 @test
-def count05(): Bool = List.count(i -> i > 3, 1 :: 8 :: Nil) `assertEq!` 1
+def count05(): Bool = List.count(i -> i > 3, 1 :: 8 :: Nil) == 1
 
 @test
-def count06(): Bool = List.count(i -> i > 3, 8 :: 1 :: Nil) `assertEq!` 1
+def count06(): Bool = List.count(i -> i > 3, 8 :: 1 :: Nil) == 1
 
 @test
-def count07(): Bool = List.count(i -> i > 3, 6 :: 7 :: Nil) `assertEq!` 2
+def count07(): Bool = List.count(i -> i > 3, 6 :: 7 :: Nil) == 2
 
 /////////////////////////////////////////////////////////////////////////////
 // flatten                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def flatten01(): Bool = List.flatten(Nil) `assertEq!` Nil
+def flatten01(): Bool = List.flatten(Nil) == Nil
 
 @test
-def flatten02(): Bool = List.flatten(Nil :: Nil) `assertEq!` Nil
+def flatten02(): Bool = List.flatten(Nil :: Nil) == Nil
 
 @test
-def flatten03(): Bool = List.flatten((1 :: Nil) :: Nil) `assertEq!` 1 :: Nil
+def flatten03(): Bool = List.flatten((1 :: Nil) :: Nil) == 1 :: Nil
 
 @test
-def flatten04(): Bool = List.flatten((1 :: 2 :: Nil) :: Nil) `assertEq!` 1 :: 2 :: Nil
+def flatten04(): Bool = List.flatten((1 :: 2 :: Nil) :: Nil) == 1 :: 2 :: Nil
 
 @test
-def flatten05(): Bool = List.flatten(Nil :: Nil :: Nil) `assertEq!` Nil
+def flatten05(): Bool = List.flatten(Nil :: Nil :: Nil) == Nil
 
 @test
-def flatten06(): Bool = List.flatten((1 :: Nil) :: Nil :: Nil) `assertEq!` 1 :: Nil
+def flatten06(): Bool = List.flatten((1 :: Nil) :: Nil :: Nil) == 1 :: Nil
 
 @test
-def flatten07(): Bool = List.flatten(Nil :: (1 :: Nil) :: Nil) `assertEq!` 1 :: Nil
+def flatten07(): Bool = List.flatten(Nil :: (1 :: Nil) :: Nil) == 1 :: Nil
 
 @test
-def flatten08(): Bool = List.flatten((1 :: Nil) :: (2 :: Nil) :: Nil) `assertEq!` 1 :: 2 :: Nil
+def flatten08(): Bool = List.flatten((1 :: Nil) :: (2 :: Nil) :: Nil) == 1 :: 2 :: Nil
 
 @test
-def flatten09(): Bool = List.flatten((1 :: 2 :: Nil) :: (3 :: 4 :: 5 :: Nil) :: Nil) `assertEq!` 1 :: 2 :: 3 :: 4 :: 5 :: Nil
+def flatten09(): Bool = List.flatten((1 :: 2 :: Nil) :: (3 :: 4 :: 5 :: Nil) :: Nil) == 1 :: 2 :: 3 :: 4 :: 5 :: Nil
 
 @test
-def flatten10(): Bool = List.flatten((1 :: Nil) :: (2 :: 3 :: Nil) :: (4 :: Nil) :: Nil) `assertEq!` 1 :: 2 :: 3 :: 4 :: Nil
+def flatten10(): Bool = List.flatten((1 :: Nil) :: (2 :: 3 :: Nil) :: (4 :: Nil) :: Nil) == 1 :: 2 :: 3 :: 4 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // exists                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def exists01(): Bool = assertNot!(List.exists(i -> i > 3, Nil))
+def exists01(): Bool = List.exists(i -> i > 3, Nil) == false
 
 @test
-def exists02(): Bool = assertNot!(List.exists(i -> i > 3, 1 :: Nil))
+def exists02(): Bool = List.exists(i -> i > 3, 1 :: Nil) == false
 
 @test
-def exists03(): Bool = assert!(List.exists(i -> i > 3, 5 :: Nil))
+def exists03(): Bool = List.exists(i -> i > 3, 5 :: Nil) == true
 
 @test
-def exists04(): Bool = assertNot!(List.exists(i -> i > 3, 1 :: 2 :: Nil))
+def exists04(): Bool = List.exists(i -> i > 3, 1 :: 2 :: Nil) == false
 
 @test
-def exists05(): Bool = assert!(List.exists(i -> i > 3, 1 :: 6 :: Nil))
+def exists05(): Bool = List.exists(i -> i > 3, 1 :: 6 :: Nil) == true
 
 @test
-def exists06(): Bool = assert!(List.exists(i -> i > 3, 6 :: 1 :: Nil))
+def exists06(): Bool = List.exists(i -> i > 3, 6 :: 1 :: Nil) == true
 
 @test
-def exists07(): Bool = assert!(List.exists(i -> i > 3, 16 :: 6 :: Nil))
+def exists07(): Bool = List.exists(i -> i > 3, 16 :: 6 :: Nil) == true
 
 @test
-def exists08(): Bool = assertNot!(List.exists(i -> i > 3, 1 :: -9 :: 3 :: Nil))
+def exists08(): Bool = List.exists(i -> i > 3, 1 :: -9 :: 3 :: Nil) == false
 
 @test
-def exists09(): Bool = assert!(List.exists(i -> i > 3, 1 :: 9 :: 3 :: Nil))
+def exists09(): Bool = List.exists(i -> i > 3, 1 :: 9 :: 3 :: Nil) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // forall                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def forall01(): Bool = assert!(List.forall(i -> i > 3, Nil))
+def forall01(): Bool = List.forall(i -> i > 3, Nil) == true
 
 @test
-def forall02(): Bool = assertNot!(List.forall(i -> i > 3, 1 :: Nil))
+def forall02(): Bool = List.forall(i -> i > 3, 1 :: Nil) == false
 
 @test
-def forall03(): Bool = assert!(List.forall(i -> i > 3, 5 :: Nil))
+def forall03(): Bool = List.forall(i -> i > 3, 5 :: Nil) == true
 
 @test
-def forall04(): Bool = assertNot!(List.forall(i -> i > 3, 1 :: 2 :: Nil))
+def forall04(): Bool = List.forall(i -> i > 3, 1 :: 2 :: Nil) == false
 
 @test
-def forall05(): Bool = assertNot!(List.forall(i -> i > 3, 1 :: 6 :: Nil))
+def forall05(): Bool = List.forall(i -> i > 3, 1 :: 6 :: Nil) == false
 
 @test
-def forall06(): Bool = assertNot!(List.forall(i -> i > 3, 6 :: 1 :: Nil))
+def forall06(): Bool = List.forall(i -> i > 3, 6 :: 1 :: Nil) == false
 
 @test
-def forall07(): Bool = assert!(List.forall(i -> i > 3, 16 :: 6 :: Nil))
+def forall07(): Bool = List.forall(i -> i > 3, 16 :: 6 :: Nil) == true
 
 @test
-def forall08(): Bool = assertNot!(List.forall(i -> i > 3, 1 :: -9 :: 3 :: Nil))
+def forall08(): Bool = List.forall(i -> i > 3, 1 :: -9 :: 3 :: Nil) == false
 
 @test
-def forall09(): Bool = assertNot!(List.forall(i -> i > 3, 1 :: 9 :: 3 :: Nil))
+def forall09(): Bool = List.forall(i -> i > 3, 1 :: 9 :: 3 :: Nil) == false
 
 @test
-def forall10(): Bool = assert!(List.forall(i -> i > 3, 11 :: 9 :: 31 :: Nil))
+def forall10(): Bool = List.forall(i -> i > 3, 11 :: 9 :: 31 :: Nil) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // filter                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def filter01(): Bool = List.filter(i -> i > 3, Nil) `assertEq!` Nil
+def filter01(): Bool = List.filter(i -> i > 3, Nil) == Nil
 
 @test
-def filter02(): Bool = List.filter(i -> i > 3, 2 :: Nil) `assertEq!` Nil
+def filter02(): Bool = List.filter(i -> i > 3, 2 :: Nil) == Nil
 
 @test
-def filter03(): Bool = List.filter(i -> i > 3, 4 :: Nil) `assertEq!` 4 :: Nil
+def filter03(): Bool = List.filter(i -> i > 3, 4 :: Nil) == 4 :: Nil
 
 @test
-def filter04(): Bool = List.filter(i -> i > 3, 1 :: 3 :: Nil) `assertEq!` Nil
+def filter04(): Bool = List.filter(i -> i > 3, 1 :: 3 :: Nil) == Nil
 
 @test
-def filter05(): Bool = List.filter(i -> i > 3, 1 :: 8 :: Nil) `assertEq!` 8 :: Nil
+def filter05(): Bool = List.filter(i -> i > 3, 1 :: 8 :: Nil) == 8 :: Nil
 
 @test
-def filter06(): Bool = List.filter(i -> i > 3, 8 :: 1 :: Nil) `assertEq!` 8 :: Nil
+def filter06(): Bool = List.filter(i -> i > 3, 8 :: 1 :: Nil) == 8 :: Nil
 
 @test
-def filter07(): Bool = List.filter(i -> i > 3, 8 :: 9 :: Nil) `assertEq!` 8 :: 9 :: Nil
+def filter07(): Bool = List.filter(i -> i > 3, 8 :: 9 :: Nil) == 8 :: 9 :: Nil
 
 @test
-def filter08(): Bool = List.filter(i -> i > 3, 1 :: 4 :: 11 :: 2 :: -22 :: 17 :: Nil) `assertEq!` 4 :: 11 :: 17 :: Nil
+def filter08(): Bool = List.filter(i -> i > 3, 1 :: 4 :: 11 :: 2 :: -22 :: 17 :: Nil) == 4 :: 11 :: 17 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // init                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def init01(): Bool = List.init(Nil) `assertEq!` None
+def init01(): Bool = List.init(Nil) == None
 
 @test
-def init02(): Bool = List.init(0 :: Nil) `assertEq!` Some(Nil)
+def init02(): Bool = List.init(0 :: Nil) == Some(Nil)
 
 @test
-def init03(): Bool = List.init(0 :: 1 :: Nil) `assertEq!` Some(0 :: Nil)
+def init03(): Bool = List.init(0 :: 1 :: Nil) == Some(0 :: Nil)
 
 @test
-def init04(): Bool = List.init(2 :: 1 :: 0 :: Nil) `assertEq!` Some(2 :: 1 :: Nil)
+def init04(): Bool = List.init(2 :: 1 :: 0 :: Nil) == Some(2 :: 1 :: Nil)
 
 @test
-def init05(): Bool = List.init('a' :: 'b' :: 'c' :: 'd' :: Nil) `assertEq!` Some('a' :: 'b' :: 'c' :: Nil)
+def init05(): Bool = List.init('a' :: 'b' :: 'c' :: 'd' :: Nil) == Some('a' :: 'b' :: 'c' :: Nil)
 
 @test
-def init06(): Bool = List.init("test1" :: "test2" :: "test3" :: Nil) `assertEq!` Some("test1" :: "test2" :: Nil)
+def init06(): Bool = List.init("test1" :: "test2" :: "test3" :: Nil) == Some("test1" :: "test2" :: Nil)
 
 @test
-def init07(): Bool = List.init(2 :: 1 :: 0 :: -1 :: Nil) `assertEq!` Some(2 :: 1 :: 0 :: Nil)
+def init07(): Bool = List.init(2 :: 1 :: 0 :: -1 :: Nil) == Some(2 :: 1 :: 0 :: Nil)
 
 /////////////////////////////////////////////////////////////////////////////
 // slice                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def slice01(): Bool = List.slice(0, 0, Nil) `assertEq!` Nil
+def slice01(): Bool = List.slice(0, 0, Nil) == Nil
 
 @test
-def slice02(): Bool = List.slice(-1, 1, Nil) `assertEq!` Nil
+def slice02(): Bool = List.slice(-1, 1, Nil) == Nil
 
 @test
-def slice03(): Bool = List.slice(0, 0, 1 :: Nil) `assertEq!` Nil
+def slice03(): Bool = List.slice(0, 0, 1 :: Nil) == Nil
 
 @test
-def slice04(): Bool = List.slice(0, 1, 1 :: Nil) `assertEq!` 1 :: Nil
+def slice04(): Bool = List.slice(0, 1, 1 :: Nil) == 1 :: Nil
 
 @test
-def slice05(): Bool = List.slice(0, 2, 1 :: Nil) `assertEq!` 1 :: Nil
+def slice05(): Bool = List.slice(0, 2, 1 :: Nil) == 1 :: Nil
 
 @test
-def slice06(): Bool = List.slice(2, 5, 1 :: Nil) `assertEq!` Nil
+def slice06(): Bool = List.slice(2, 5, 1 :: Nil) == Nil
 
 @test
-def slice07(): Bool = List.slice(-1, 1, 1 :: Nil) `assertEq!` 1 :: Nil
+def slice07(): Bool = List.slice(-1, 1, 1 :: Nil) == 1 :: Nil
 
 @test
-def slice08(): Bool = List.slice(0, 1, 1 :: 2 :: Nil) `assertEq!` 1 :: Nil
+def slice08(): Bool = List.slice(0, 1, 1 :: 2 :: Nil) == 1 :: Nil
 
 @test
-def slice09(): Bool = List.slice(0, 2, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def slice09(): Bool = List.slice(0, 2, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def slice10(): Bool = List.slice(1, 2, 1 :: 2 :: Nil) `assertEq!` 2 :: Nil
+def slice10(): Bool = List.slice(1, 2, 1 :: 2 :: Nil) == 2 :: Nil
 
 @test
-def slice11(): Bool = List.slice(0, 3, 1 :: 2 :: 3 :: Nil) `assertEq!` 1 :: 2 :: 3 :: Nil
+def slice11(): Bool = List.slice(0, 3, 1 :: 2 :: 3 :: Nil) == 1 :: 2 :: 3 :: Nil
 
 @test
-def slice12(): Bool = List.slice(0, 2, 1 :: 2 :: 3 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def slice12(): Bool = List.slice(0, 2, 1 :: 2 :: 3 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def slice13(): Bool = List.slice(1, 3, 1 :: 2 :: 3 :: Nil) `assertEq!` 2 :: 3 :: Nil
+def slice13(): Bool = List.slice(1, 3, 1 :: 2 :: 3 :: Nil) == 2 :: 3 :: Nil
 
 @test
-def slice14(): Bool = List.slice(1, 2, 1 :: 2 :: 3 :: Nil) `assertEq!` 2 :: Nil
+def slice14(): Bool = List.slice(1, 2, 1 :: 2 :: 3 :: Nil) == 2 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // partition                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def partition01(): Bool = List.partition(i -> i > 3, Nil) `assertEq!` (Nil, Nil)
+def partition01(): Bool = List.partition(i -> i > 3, Nil) == (Nil, Nil)
 
 @test
-def partition02(): Bool = List.partition(i -> i > 3, 1 :: Nil) `assertEq!` (Nil, 1 :: Nil)
+def partition02(): Bool = List.partition(i -> i > 3, 1 :: Nil) == (Nil, 1 :: Nil)
 
 @test
-def partition03(): Bool = List.partition(i -> i > 3, 4 :: Nil) `assertEq!` (4 :: Nil, Nil)
+def partition03(): Bool = List.partition(i -> i > 3, 4 :: Nil) == (4 :: Nil, Nil)
 
 @test
-def partition04(): Bool = List.partition(i -> i > 3, 1 :: 2 :: Nil) `assertEq!` (Nil, 1 :: 2 :: Nil)
+def partition04(): Bool = List.partition(i -> i > 3, 1 :: 2 :: Nil) == (Nil, 1 :: 2 :: Nil)
 
 @test
-def partition05(): Bool = List.partition(i -> i > 3, 1 :: 5 :: Nil) `assertEq!` (5 :: Nil, 1 :: Nil)
+def partition05(): Bool = List.partition(i -> i > 3, 1 :: 5 :: Nil) == (5 :: Nil, 1 :: Nil)
 
 @test
-def partition06(): Bool = List.partition(i -> i > 3, 5 :: 1 :: Nil) `assertEq!` (5 :: Nil, 1 :: Nil)
+def partition06(): Bool = List.partition(i -> i > 3, 5 :: 1 :: Nil) == (5 :: Nil, 1 :: Nil)
 
 @test
-def partition07(): Bool = List.partition(i -> i > 3, 5 :: 8 :: Nil) `assertEq!` (5 :: 8 :: Nil, Nil)
+def partition07(): Bool = List.partition(i -> i > 3, 5 :: 8 :: Nil) == (5 :: 8 :: Nil, Nil)
 
 @test
-def partition08(): Bool = List.partition(i -> i > 3, 4 :: -3 :: -5 :: 1 :: 2 :: 16 :: 7 :: 1 :: 7 :: Nil) `assertEq!`
+def partition08(): Bool = List.partition(i -> i > 3, 4 :: -3 :: -5 :: 1 :: 2 :: 16 :: 7 :: 1 :: 7 :: Nil) ==
                         (4 :: 16 :: 7 :: 7 :: Nil, -3 :: -5 :: 1 :: 2 :: 1 :: Nil)
 
 /////////////////////////////////////////////////////////////////////////////
 // span                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def span01(): Bool = List.span(i -> i > 3, Nil) `assertEq!` (Nil, Nil)
+def span01(): Bool = List.span(i -> i > 3, Nil) == (Nil, Nil)
 
 @test
-def span02(): Bool = List.span(i -> i > 3, 1 :: Nil) `assertEq!` (Nil, 1 :: Nil)
+def span02(): Bool = List.span(i -> i > 3, 1 :: Nil) == (Nil, 1 :: Nil)
 
 @test
-def span03(): Bool = List.span(i -> i > 3, 4 :: Nil) `assertEq!` (4 :: Nil, Nil)
+def span03(): Bool = List.span(i -> i > 3, 4 :: Nil) == (4 :: Nil, Nil)
 
 @test
-def span04(): Bool = List.span(i -> i > 3, 1 :: 2 :: Nil) `assertEq!` (Nil, 1 :: 2 :: Nil)
+def span04(): Bool = List.span(i -> i > 3, 1 :: 2 :: Nil) == (Nil, 1 :: 2 :: Nil)
 
 @test
-def span05(): Bool = List.span(i -> i > 3, 1 :: 5 :: Nil) `assertEq!` (Nil, 1 :: 5 :: Nil)
+def span05(): Bool = List.span(i -> i > 3, 1 :: 5 :: Nil) == (Nil, 1 :: 5 :: Nil)
 
 @test
-def span06(): Bool = List.span(i -> i > 3, 5 :: 1 :: Nil) `assertEq!` (5 :: Nil, 1 :: Nil)
+def span06(): Bool = List.span(i -> i > 3, 5 :: 1 :: Nil) == (5 :: Nil, 1 :: Nil)
 
 @test
-def span07(): Bool = List.span(i -> i > 3, 5 :: 8 :: Nil) `assertEq!` (5 :: 8 :: Nil, Nil)
+def span07(): Bool = List.span(i -> i > 3, 5 :: 8 :: Nil) == (5 :: 8 :: Nil, Nil)
 
 @test
-def span08(): Bool = List.span(i -> i > 3, 4 :: 6 :: -3 :: 11 :: -5 :: 1 :: 2 :: 16 :: 7 :: 1 :: 7 :: Nil) `assertEq!`
+def span08(): Bool = List.span(i -> i > 3, 4 :: 6 :: -3 :: 11 :: -5 :: 1 :: 2 :: 16 :: 7 :: 1 :: 7 :: Nil) ==
                         (4 :: 6 :: Nil, -3 :: 11 :: -5 :: 1 :: 2 :: 16 :: 7 :: 1 :: 7 :: Nil)
 
 /////////////////////////////////////////////////////////////////////////////
 // drop                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def drop01(): Bool = List.drop(-1, Nil) `assertEq!` Nil
+def drop01(): Bool = List.drop(-1, Nil) == Nil
 
 @test
-def drop02(): Bool = List.drop(0, Nil) `assertEq!` Nil
+def drop02(): Bool = List.drop(0, Nil) == Nil
 
 @test
-def drop03(): Bool = List.drop(1, Nil) `assertEq!` Nil
+def drop03(): Bool = List.drop(1, Nil) == Nil
 
 @test
-def drop04(): Bool = List.drop(-1, 1 :: Nil) `assertEq!` 1 :: Nil
+def drop04(): Bool = List.drop(-1, 1 :: Nil) == 1 :: Nil
 
 @test
-def drop05(): Bool = List.drop(0, 1 :: Nil) `assertEq!` 1 :: Nil
+def drop05(): Bool = List.drop(0, 1 :: Nil) == 1 :: Nil
 
 @test
-def drop06(): Bool = List.drop(1, 1 :: Nil) `assertEq!` Nil
+def drop06(): Bool = List.drop(1, 1 :: Nil) == Nil
 
 @test
-def drop07(): Bool = List.drop(2, 1 :: Nil) `assertEq!` Nil
+def drop07(): Bool = List.drop(2, 1 :: Nil) == Nil
 
 @test
-def drop08(): Bool = List.drop(0, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def drop08(): Bool = List.drop(0, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def drop09(): Bool = List.drop(1, 1 :: 2 :: Nil) `assertEq!` 2 :: Nil
+def drop09(): Bool = List.drop(1, 1 :: 2 :: Nil) == 2 :: Nil
 
 @test
-def drop10(): Bool = List.drop(2, 1 :: 2 :: Nil) `assertEq!` Nil
+def drop10(): Bool = List.drop(2, 1 :: 2 :: Nil) == Nil
 
 @test
-def drop11(): Bool = List.drop(2, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: Nil) `assertEq!` 3 :: 4 :: 5 :: 6 :: Nil
+def drop11(): Bool = List.drop(2, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: Nil) == 3 :: 4 :: 5 :: 6 :: Nil
 
 @test
-def drop12(): Bool = List.drop(4, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: Nil) `assertEq!` 5 :: 6 :: Nil
+def drop12(): Bool = List.drop(4, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: Nil) == 5 :: 6 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // dropWhile                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def dropWhile01(): Bool = List.dropWhile(i -> i > 3, Nil) `assertEq!` Nil
+def dropWhile01(): Bool = List.dropWhile(i -> i > 3, Nil) == Nil
 
 @test
-def dropWhile02(): Bool = List.dropWhile(i -> i > 3, 1 :: Nil) `assertEq!` 1 :: Nil
+def dropWhile02(): Bool = List.dropWhile(i -> i > 3, 1 :: Nil) == 1 :: Nil
 
 @test
-def dropWhile03(): Bool = List.dropWhile(i -> i > 3, 4 :: Nil) `assertEq!` Nil
+def dropWhile03(): Bool = List.dropWhile(i -> i > 3, 4 :: Nil) == Nil
 
 @test
-def dropWhile04(): Bool = List.dropWhile(i -> i > 3, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def dropWhile04(): Bool = List.dropWhile(i -> i > 3, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def dropWhile05(): Bool = List.dropWhile(i -> i > 3, 1 :: 5 :: Nil) `assertEq!` 1 :: 5 :: Nil
+def dropWhile05(): Bool = List.dropWhile(i -> i > 3, 1 :: 5 :: Nil) == 1 :: 5 :: Nil
 
 @test
-def dropWhile06(): Bool = List.dropWhile(i -> i > 3, 5 :: 1 :: Nil) `assertEq!` 1 :: Nil
+def dropWhile06(): Bool = List.dropWhile(i -> i > 3, 5 :: 1 :: Nil) == 1 :: Nil
 
 @test
-def dropWhile07(): Bool = List.dropWhile(i -> i > 3, 5 :: 8 :: Nil) `assertEq!` Nil
+def dropWhile07(): Bool = List.dropWhile(i -> i > 3, 5 :: 8 :: Nil) == Nil
 
 @test
-def dropWhile08(): Bool = List.dropWhile(i -> i > 3, 4 :: 6 :: -3 :: 11 :: -5 :: 1 :: 2 :: 16 :: 7 :: 1 :: 7 :: Nil) `assertEq!`
+def dropWhile08(): Bool = List.dropWhile(i -> i > 3, 4 :: 6 :: -3 :: 11 :: -5 :: 1 :: 2 :: 16 :: 7 :: 1 :: 7 :: Nil) ==
                         -3 :: 11 :: -5 :: 1 :: 2 :: 16 :: 7 :: 1 :: 7 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // take                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def take01(): Bool = List.take(-1, Nil) `assertEq!` Nil
+def take01(): Bool = List.take(-1, Nil) == Nil
 
 @test
-def take02(): Bool = List.take(0, Nil) `assertEq!` Nil
+def take02(): Bool = List.take(0, Nil) == Nil
 
 @test
-def take03(): Bool = List.take(1, Nil) `assertEq!` Nil
+def take03(): Bool = List.take(1, Nil) == Nil
 
 @test
-def take04(): Bool = List.take(-1, 1 :: Nil) `assertEq!` Nil
+def take04(): Bool = List.take(-1, 1 :: Nil) == Nil
 
 @test
-def take05(): Bool = List.take(0, 1 :: Nil) `assertEq!` Nil
+def take05(): Bool = List.take(0, 1 :: Nil) == Nil
 
 @test
-def take06(): Bool = List.take(1, 1 :: Nil) `assertEq!` 1 :: Nil
+def take06(): Bool = List.take(1, 1 :: Nil) == 1 :: Nil
 
 @test
-def take07(): Bool = List.take(2, 1 :: Nil) `assertEq!` 1 :: Nil
+def take07(): Bool = List.take(2, 1 :: Nil) == 1 :: Nil
 
 @test
-def take08(): Bool = List.take(0, 1 :: 2 :: Nil) `assertEq!` Nil
+def take08(): Bool = List.take(0, 1 :: 2 :: Nil) == Nil
 
 @test
-def take09(): Bool = List.take(1, 1 :: 2 :: Nil) `assertEq!` 1 :: Nil
+def take09(): Bool = List.take(1, 1 :: 2 :: Nil) == 1 :: Nil
 
 @test
-def take10(): Bool = List.take(2, 1 :: 2 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def take10(): Bool = List.take(2, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def take11(): Bool = List.take(2, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: Nil) `assertEq!` 1 :: 2 :: Nil
+def take11(): Bool = List.take(2, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def take12(): Bool = List.take(4, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: Nil) `assertEq!` 1 :: 2 :: 3 :: 4 :: Nil
+def take12(): Bool = List.take(4, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: Nil) == 1 :: 2 :: 3 :: 4 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // takeWhile                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def takeWhile01(): Bool = List.takeWhile(i -> i > 3, Nil) `assertEq!` Nil
+def takeWhile01(): Bool = List.takeWhile(i -> i > 3, Nil) == Nil
 
 @test
-def takeWhile02(): Bool = List.takeWhile(i -> i > 3, 1 :: Nil) `assertEq!` Nil
+def takeWhile02(): Bool = List.takeWhile(i -> i > 3, 1 :: Nil) == Nil
 
 @test
-def takeWhile03(): Bool = List.takeWhile(i -> i > 3, 4 :: Nil) `assertEq!` 4 :: Nil
+def takeWhile03(): Bool = List.takeWhile(i -> i > 3, 4 :: Nil) == 4 :: Nil
 
 @test
-def takeWhile04(): Bool = List.takeWhile(i -> i > 3, 1 :: 2 :: Nil) `assertEq!` Nil
+def takeWhile04(): Bool = List.takeWhile(i -> i > 3, 1 :: 2 :: Nil) == Nil
 
 @test
-def takeWhile05(): Bool = List.takeWhile(i -> i > 3, 1 :: 5 :: Nil) `assertEq!` Nil
+def takeWhile05(): Bool = List.takeWhile(i -> i > 3, 1 :: 5 :: Nil) == Nil
 
 @test
-def takeWhile06(): Bool = List.takeWhile(i -> i > 3, 5 :: 1 :: Nil) `assertEq!` 5 :: Nil
+def takeWhile06(): Bool = List.takeWhile(i -> i > 3, 5 :: 1 :: Nil) == 5 :: Nil
 
 @test
-def takeWhile07(): Bool = List.takeWhile(i -> i > 3, 5 :: 8 :: Nil) `assertEq!` 5 :: 8 :: Nil
+def takeWhile07(): Bool = List.takeWhile(i -> i > 3, 5 :: 8 :: Nil) == 5 :: 8 :: Nil
 
 @test
-def takeWhile08(): Bool = List.takeWhile(i -> i > 3, 4 :: 6 :: -3 :: 11 :: -5 :: 1 :: 2 :: 16 :: 7 :: 1 :: 7 :: Nil) `assertEq!`
+def takeWhile08(): Bool = List.takeWhile(i -> i > 3, 4 :: 6 :: -3 :: 11 :: -5 :: 1 :: 2 :: 16 :: 7 :: 1 :: 7 :: Nil) ==
                         4 :: 6 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // groupBy                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def groupBy01(): Bool = List.groupBy((a, b) -> a > 3 || b > 8, Nil) `assertEq!` Nil
+def groupBy01(): Bool = List.groupBy((a, b) -> a > 3 || b > 8, Nil) == Nil
 
 @test
-def groupBy02(): Bool = List.groupBy((a, b) -> a > 3 || b > 8, 1 :: Nil) `assertEq!` (1 :: Nil) :: Nil
+def groupBy02(): Bool = List.groupBy((a, b) -> a > 3 || b > 8, 1 :: Nil) == (1 :: Nil) :: Nil
 
 @test
-def groupBy03(): Bool = List.groupBy((a, b) -> a > 3 || b > 8, 1 :: 4 :: Nil) `assertEq!` (1 :: Nil) :: (4 :: Nil) :: Nil
+def groupBy03(): Bool = List.groupBy((a, b) -> a > 3 || b > 8, 1 :: 4 :: Nil) == (1 :: Nil) :: (4 :: Nil) :: Nil
 
 @test
-def groupBy04(): Bool = List.groupBy((a, b) -> a > 3 || b > 8, 1 :: 9 :: Nil) `assertEq!` (1 :: 9 :: Nil) :: Nil
+def groupBy04(): Bool = List.groupBy((a, b) -> a > 3 || b > 8, 1 :: 9 :: Nil) == (1 :: 9 :: Nil) :: Nil
 
 @test
-def groupBy05(): Bool = List.groupBy((a, b) -> a > 3 || b > 8, 1 :: 4 :: 7 :: 6 :: 9 :: 2 :: 4 :: 4 :: 8 :: 16 :: Nil) `assertEq!`
+def groupBy05(): Bool = List.groupBy((a, b) -> a > 3 || b > 8, 1 :: 4 :: 7 :: 6 :: 9 :: 2 :: 4 :: 4 :: 8 :: 16 :: Nil) ==
                       (1 :: 9 :: 16 :: Nil) :: (4 :: 7 :: 6 :: 4 :: 4 :: 8 :: Nil) :: (2 :: Nil) :: Nil
 
 @test
-def groupBy06(): Bool = List.groupBy((a, b) -> a > -6 || a*b >= 0, -1 :: -11 :: 4 :: -11 :: 0 :: 8 :: 2 :: 1 :: -3 :: -24 :: Nil) `assertEq!`
+def groupBy06(): Bool = List.groupBy((a, b) -> a > -6 || a*b >= 0, -1 :: -11 :: 4 :: -11 :: 0 :: 8 :: 2 :: 1 :: -3 :: -24 :: Nil) ==
                       (-1 :: -11 :: -11 :: 0 :: -3 :: -24 :: Nil) :: (4 :: 8 :: 2 :: 1 :: Nil) :: Nil
 
 @test
-def groupBy07(): Bool = List.groupBy((a, b) -> a < 0 || (a > 10 || (b > 10 || a == b)), -5 :: 6 :: 11 :: 8 :: 8 :: -11 :: -1 :: 0 :: 4 :: -1 :: Nil) `assertEq!`
+def groupBy07(): Bool = List.groupBy((a, b) -> a < 0 || (a > 10 || (b > 10 || a == b)), -5 :: 6 :: 11 :: 8 :: 8 :: -11 :: -1 :: 0 :: 4 :: -1 :: Nil) ==
                       (-5 :: 11 :: -11 :: -1 :: -1 :: Nil) :: (6 :: Nil) :: (8 :: 8 :: Nil) :: (0 :: Nil) :: (4 :: Nil) :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // zip                                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def zip01(): Bool = List.zip(Nil, Nil) `assertEq!` Nil
+def zip01(): Bool = List.zip(Nil, Nil) == Nil
 
 @test
-def zip02(): Bool = List.zip(1 :: Nil, Nil) `assertEq!` Nil
+def zip02(): Bool = List.zip(1 :: Nil, Nil) == Nil
 
 @test
-def zip03(): Bool = List.zip(Nil, 2 :: Nil) `assertEq!` Nil
+def zip03(): Bool = List.zip(Nil, 2 :: Nil) == Nil
 
 @test
-def zip04(): Bool = List.zip(1 :: Nil, 2 :: Nil) `assertEq!` (1, 2) :: Nil
+def zip04(): Bool = List.zip(1 :: Nil, 2 :: Nil) == (1, 2) :: Nil
 
 @test
-def zip05(): Bool = List.zip(1 :: 3 :: Nil, 2 :: 4 :: Nil) `assertEq!` (1, 2) :: (3, 4) :: Nil
+def zip05(): Bool = List.zip(1 :: 3 :: Nil, 2 :: 4 :: Nil) == (1, 2) :: (3, 4) :: Nil
 
 @test
-def zip06(): Bool = List.zip(1 :: 3 :: 5 :: Nil, 2 :: 4 :: 6 :: Nil) `assertEq!` (1, 2) :: (3, 4) :: (5, 6) :: Nil
+def zip06(): Bool = List.zip(1 :: 3 :: 5 :: Nil, 2 :: 4 :: 6 :: Nil) == (1, 2) :: (3, 4) :: (5, 6) :: Nil
 
 @test
-def zip07(): Bool = List.zip(1 :: 3 :: 5 :: 7 :: Nil, 2 :: 4 :: 6 :: 8 :: Nil) `assertEq!` (1, 2) :: (3, 4) :: (5, 6) :: (7, 8) :: Nil
+def zip07(): Bool = List.zip(1 :: 3 :: 5 :: 7 :: Nil, 2 :: 4 :: 6 :: 8 :: Nil) == (1, 2) :: (3, 4) :: (5, 6) :: (7, 8) :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // zipWith                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def zipWith01(): Bool = List.zipWith((a, b) -> if (b) a+1 else a, Nil, Nil) `assertEq!` Nil
+def zipWith01(): Bool = List.zipWith((a, b) -> if (b) a+1 else a, Nil, Nil) == Nil
 
 @test
-def zipWith02(): Bool = List.zipWith((a, b) -> if (b) a+1 else a, 1 :: Nil, Nil) `assertEq!` Nil
+def zipWith02(): Bool = List.zipWith((a, b) -> if (b) a+1 else a, 1 :: Nil, Nil) == Nil
 
 @test
-def zipWith03(): Bool = List.zipWith((a, b) -> if (b) a+1 else a, Nil, true :: Nil) `assertEq!` Nil
+def zipWith03(): Bool = List.zipWith((a, b) -> if (b) a+1 else a, Nil, true :: Nil) == Nil
 
 @test
-def zipWith04(): Bool = List.zipWith((a, b) -> if (b) a+1 else a, 1 :: Nil, true :: Nil) `assertEq!` 2 :: Nil
+def zipWith04(): Bool = List.zipWith((a, b) -> if (b) a+1 else a, 1 :: Nil, true :: Nil) == 2 :: Nil
 
 @test
-def zipWith05(): Bool = List.zipWith((a, b) -> if (b) a+1 else a, 1 :: Nil, false :: Nil) `assertEq!` 1 :: Nil
+def zipWith05(): Bool = List.zipWith((a, b) -> if (b) a+1 else a, 1 :: Nil, false :: Nil) == 1 :: Nil
 
 @test
 def zipWith06(): Bool = List.zipWith((a, b) -> if (b) a+1 else a, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: Nil,
-                      false :: true :: true :: false :: false :: true :: true :: true ::Nil) `assertEq!`
+                      false :: true :: true :: false :: false :: true :: true :: true ::Nil) ==
                       1 :: 3 :: 4 :: 4 :: 5 :: 7 :: 8 :: 9 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // unzip                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def unzip01(): Bool = List.unzip(Nil) `assertEq!` (Nil, Nil)
+def unzip01(): Bool = List.unzip(Nil) == (Nil, Nil)
 
 @test
-def unzip02(): Bool = List.unzip((1, true) :: Nil) `assertEq!` (1 :: Nil, true :: Nil)
+def unzip02(): Bool = List.unzip((1, true) :: Nil) == (1 :: Nil, true :: Nil)
 
 @test
-def unzip03(): Bool = List.unzip((1, true) :: (2, true) :: Nil) `assertEq!` (1 :: 2 :: Nil, true :: true :: Nil)
+def unzip03(): Bool = List.unzip((1, true) :: (2, true) :: Nil) == (1 :: 2 :: Nil, true :: true :: Nil)
 
 @test
-def unzip04(): Bool = List.unzip((1, true) :: (2, true) :: (3, false) :: Nil) `assertEq!`
+def unzip04(): Bool = List.unzip((1, true) :: (2, true) :: (3, false) :: Nil) ==
                     (1 :: 2 :: 3 :: Nil, true :: true :: false :: Nil)
 
 /////////////////////////////////////////////////////////////////////////////
 // map2                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def map201(): Bool = List.map2((a, b) -> if (b) a+1 else a, Nil, Nil) `assertEq!` Nil
+def map201(): Bool = List.map2((a, b) -> if (b) a+1 else a, Nil, Nil) == Nil
 
 @test
-def map202(): Bool = List.map2((a, b) -> if (b) a+1 else a, 1 :: Nil, Nil) `assertEq!` Nil
+def map202(): Bool = List.map2((a, b) -> if (b) a+1 else a, 1 :: Nil, Nil) == Nil
 
 @test
-def map203(): Bool = List.map2((a, b) -> if (b) a+1 else a, Nil, true :: Nil) `assertEq!` Nil
+def map203(): Bool = List.map2((a, b) -> if (b) a+1 else a, Nil, true :: Nil) == Nil
 
 @test
-def map204(): Bool = List.map2((a, b) -> if (b) a+1 else a, 1 :: Nil, true :: Nil) `assertEq!` 2 :: Nil
+def map204(): Bool = List.map2((a, b) -> if (b) a+1 else a, 1 :: Nil, true :: Nil) == 2 :: Nil
 
 @test
-def map205(): Bool = List.map2((a, b) -> if (b) a+1 else a, 1 :: Nil, false :: Nil) `assertEq!` 1 :: Nil
+def map205(): Bool = List.map2((a, b) -> if (b) a+1 else a, 1 :: Nil, false :: Nil) == 1 :: Nil
 
 @test
 def map206(): Bool = List.map2((a, b) -> if (b) a+1 else a, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: Nil,
-                   false :: true :: true :: false :: false :: true :: true :: true ::Nil) `assertEq!`
+                   false :: true :: true :: false :: false :: true :: true :: true ::Nil) ==
                    1 :: 3 :: 4 :: 4 :: 5 :: 7 :: 8 :: 9 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // flatMap2                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def flatMap201(): Bool = List.flatMap2((a, b) -> if (b) List.repeat(a, a) else List.repeat(a+1, a+1), Nil, Nil) `assertEq!` Nil
+def flatMap201(): Bool = List.flatMap2((a, b) -> if (b) List.repeat(a, a) else List.repeat(a+1, a+1), Nil, Nil) == Nil
 
 @test
-def flatMap202(): Bool = List.flatMap2((a, b) -> if (b) List.repeat(a, a) else List.repeat(a+1, a+1), 1 :: Nil, Nil) `assertEq!` Nil
+def flatMap202(): Bool = List.flatMap2((a, b) -> if (b) List.repeat(a, a) else List.repeat(a+1, a+1), 1 :: Nil, Nil) == Nil
 
 @test
-def flatMap203(): Bool = List.flatMap2((a, b) -> if (b) List.repeat(a, a) else List.repeat(a+1, a+1), Nil, true :: Nil) `assertEq!` Nil
+def flatMap203(): Bool = List.flatMap2((a, b) -> if (b) List.repeat(a, a) else List.repeat(a+1, a+1), Nil, true :: Nil) == Nil
 
 @test
-def flatMap204(): Bool = List.flatMap2((a, b) -> if (b) List.repeat(a, a) else List.repeat(a+1, a+1), 2 :: Nil, true :: Nil) `assertEq!` 2 :: 2 :: Nil
+def flatMap204(): Bool = List.flatMap2((a, b) -> if (b) List.repeat(a, a) else List.repeat(a+1, a+1), 2 :: Nil, true :: Nil) == 2 :: 2 :: Nil
 
 @test
-def flatMap205(): Bool = List.flatMap2((a, b) -> if (b) List.repeat(a, a) else List.repeat(a+1, a+1), 2 :: Nil, false :: Nil) `assertEq!` 3 :: 3 :: 3 :: Nil
+def flatMap205(): Bool = List.flatMap2((a, b) -> if (b) List.repeat(a, a) else List.repeat(a+1, a+1), 2 :: Nil, false :: Nil) == 3 :: 3 :: 3 :: Nil
 
 @test
 def flatMap206(): Bool = List.flatMap2((a, b) -> if (b) List.repeat(a, a) else List.repeat(a+1, a+1), 1 :: 2 :: 3 :: 4 :: 5 :: Nil,
-                   false :: true :: true :: false :: false :: Nil) `assertEq!`
+                   false :: true :: true :: false :: false :: Nil) ==
                    2 :: 2 :: 2 :: 2 :: 3 :: 3 :: 3 :: 5 :: 5 :: 5 :: 5 :: 5 :: 6 :: 6 :: 6 :: 6 :: 6 :: 6 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // fold2                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def fold201(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, Nil, Nil) `assertEq!` 4
+def fold201(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, Nil, Nil) == 4
 
 @test
-def fold202(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, 1 :: Nil, Nil) `assertEq!` 4
+def fold202(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, 1 :: Nil, Nil) == 4
 
 @test
-def fold203(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, Nil, true :: Nil) `assertEq!` 4
+def fold203(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, Nil, true :: Nil) == 4
 
 @test
-def fold204(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, 2 :: Nil, true :: Nil) `assertEq!` 6
+def fold204(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, 2 :: Nil, true :: Nil) == 6
 
 @test
-def fold205(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, 2 :: Nil, false :: Nil) `assertEq!` 8
+def fold205(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, 2 :: Nil, false :: Nil) == 8
 
 @test
-def fold206(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, true :: true :: Nil) `assertEq!` 9
+def fold206(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, true :: true :: Nil) == 9
 
 @test
-def fold207(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, true :: false :: Nil) `assertEq!` 14
+def fold207(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, true :: false :: Nil) == 14
 
 @test
-def fold208(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, false :: true :: Nil) `assertEq!` 14
+def fold208(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, false :: true :: Nil) == 14
 
 @test
-def fold209(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, false :: false :: Nil) `assertEq!` 24
+def fold209(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, false :: false :: Nil) == 24
 
 @test
 def fold210(): Bool = List.fold2((c, a, b) -> if (b) a+c else a*c, 4, 6 :: -4 :: 3 :: 2 :: Nil,
-                    true :: false :: false :: true :: Nil) `assertEq!` -118
+                    true :: false :: false :: true :: Nil) == -118
 
 /////////////////////////////////////////////////////////////////////////////
 // foldLeft2                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldLeft201(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, Nil, Nil) `assertEq!` 4
+def foldLeft201(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, Nil, Nil) == 4
 
 @test
-def foldLeft202(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, 1 :: Nil, Nil) `assertEq!` 4
+def foldLeft202(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, 1 :: Nil, Nil) == 4
 
 @test
-def foldLeft203(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, Nil, true :: Nil) `assertEq!` 4
+def foldLeft203(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, Nil, true :: Nil) == 4
 
 @test
-def foldLeft204(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, 2 :: Nil, true :: Nil) `assertEq!` 6
+def foldLeft204(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, 2 :: Nil, true :: Nil) == 6
 
 @test
-def foldLeft205(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, 2 :: Nil, false :: Nil) `assertEq!` 8
+def foldLeft205(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, 2 :: Nil, false :: Nil) == 8
 
 @test
-def foldLeft206(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, true :: true :: Nil) `assertEq!` 9
+def foldLeft206(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, true :: true :: Nil) == 9
 
 @test
-def foldLeft207(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, true :: false :: Nil) `assertEq!` 14
+def foldLeft207(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, true :: false :: Nil) == 14
 
 @test
-def foldLeft208(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, false :: true :: Nil) `assertEq!` 14
+def foldLeft208(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, false :: true :: Nil) == 14
 
 @test
-def foldLeft209(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, false :: false :: Nil) `assertEq!` 24
+def foldLeft209(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, false :: false :: Nil) == 24
 
 @test
 def foldLeft210(): Bool = List.foldLeft2((c, a, b) -> if (b) a+c else a*c, 4, 6 :: -4 :: 3 :: 2 :: Nil,
-                        true :: false :: false :: true :: Nil) `assertEq!` -118
+                        true :: false :: false :: true :: Nil) == -118
 
 /////////////////////////////////////////////////////////////////////////////
 // foldRight2                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldRight201(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, Nil, Nil) `assertEq!` 4
+def foldRight201(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, Nil, Nil) == 4
 
 @test
-def foldRight202(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, 1 :: Nil, Nil) `assertEq!` 4
+def foldRight202(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, 1 :: Nil, Nil) == 4
 
 @test
-def foldRight203(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, Nil, true :: Nil) `assertEq!` 4
+def foldRight203(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, Nil, true :: Nil) == 4
 
 @test
-def foldRight204(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, 2 :: Nil, true :: Nil) `assertEq!` 6
+def foldRight204(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, 2 :: Nil, true :: Nil) == 6
 
 @test
-def foldRight205(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, 2 :: Nil, false :: Nil) `assertEq!` 8
+def foldRight205(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, 2 :: Nil, false :: Nil) == 8
 
 @test
-def foldRight206(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, true :: true :: Nil) `assertEq!` 9
+def foldRight206(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, true :: true :: Nil) == 9
 
 @test
-def foldRight207(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, true :: false :: Nil) `assertEq!` 11
+def foldRight207(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, true :: false :: Nil) == 11
 
 @test
-def foldRight208(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, false :: true :: Nil) `assertEq!` 18
+def foldRight208(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, false :: true :: Nil) == 18
 
 @test
-def foldRight209(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, false :: false :: Nil) `assertEq!` 24
+def foldRight209(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, 3 :: 2 :: Nil, false :: false :: Nil) == 24
 
 @test
 def foldRight210(): Bool = List.foldRight2((a, b, c) -> if (b) a+c else a*c, 4, 6 :: -4 :: 3 :: 2 :: Nil,
-                         true :: false :: false :: true :: Nil) `assertEq!` -66
+                         true :: false :: false :: true :: Nil) == -66
 
 /////////////////////////////////////////////////////////////////////////////
 // filterMap                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def filterMap01(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, Nil) `assertEq!` Nil
+def filterMap01(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, Nil) == Nil
 
 @test
-def filterMap02(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, 1 :: Nil) `assertEq!` Nil
+def filterMap02(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, 1 :: Nil) == Nil
 
 @test
-def filterMap03(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, 2 :: Nil) `assertEq!` 1 :: Nil
+def filterMap03(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, 2 :: Nil) == 1 :: Nil
 
 @test
-def filterMap04(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, 1 :: 3 :: Nil) `assertEq!` Nil
+def filterMap04(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, 1 :: 3 :: Nil) == Nil
 
 @test
-def filterMap05(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, 1 :: 4 :: Nil) `assertEq!` 2 :: Nil
+def filterMap05(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, 1 :: 4 :: Nil) == 2 :: Nil
 
 @test
-def filterMap06(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, 6 :: -1 :: Nil) `assertEq!` 3 :: Nil
+def filterMap06(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, 6 :: -1 :: Nil) == 3 :: Nil
 
 @test
-def filterMap07(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, 8 :: 6 :: Nil) `assertEq!` 4 :: 3 :: Nil
+def filterMap07(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, 8 :: 6 :: Nil) == 4 :: 3 :: Nil
 
 @test
-def filterMap08(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, 0 :: 1 :: 2 :: 3 :: 4 :: 5 :: 10 :: Nil) `assertEq!`
+def filterMap08(): Bool = List.filterMap(i -> if (i % 2 == 0) Some(i/2) else None, 0 :: 1 :: 2 :: 3 :: 4 :: 5 :: 10 :: Nil) ==
                         0 :: 1 :: 2 :: 5 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // findMap                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def findMap01(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, Nil) `assertEq!` None
+def findMap01(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, Nil) == None
 
 @test
-def findMap02(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, 1 :: Nil) `assertEq!` None
+def findMap02(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, 1 :: Nil) == None
 
 @test
-def findMap03(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, 2 :: Nil) `assertEq!` Some(1)
+def findMap03(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, 2 :: Nil) == Some(1)
 
 @test
-def findMap04(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, 1 :: 3 :: Nil) `assertEq!` None
+def findMap04(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, 1 :: 3 :: Nil) == None
 
 @test
-def findMap05(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, 1 :: 4 :: Nil) `assertEq!` Some(2)
+def findMap05(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, 1 :: 4 :: Nil) == Some(2)
 
 @test
-def findMap06(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, 6 :: -1 :: Nil) `assertEq!` Some(3)
+def findMap06(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, 6 :: -1 :: Nil) == Some(3)
 
 @test
-def findMap07(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, 8 :: 6 :: Nil) `assertEq!` Some(4)
+def findMap07(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, 8 :: 6 :: Nil) == Some(4)
 
 @test
-def findMap08(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, 0 :: 1 :: 2 :: 3 :: 4 :: 5 :: 10 :: Nil) `assertEq!`
-                      Some(0)
+def findMap08(): Bool = List.findMap(i -> if (i % 2 == 0) Some(i/2) else None, 0 :: 1 :: 2 :: 3 :: 4 :: 5 :: 10 :: Nil) == Some(0)
 
 /////////////////////////////////////////////////////////////////////////////
 // toSet                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toSet01(): Bool = assert!(List.toSet(Nil) == Set#{})
+def toSet01(): Bool = List.toSet(Nil) == Set#{}
 
 @test
-def toSet02(): Bool = assert!(List.toSet(1 :: Nil) == Set#{1})
+def toSet02(): Bool = List.toSet(1 :: Nil) == Set#{1}
 
 @test
-def toSet03(): Bool = assert!(List.toSet(1 :: 2 :: Nil) == Set#{1, 2})
+def toSet03(): Bool = List.toSet(1 :: 2 :: Nil) == Set#{1, 2}
 
 @test
-def toSet04(): Bool = assert!(List.toSet(1 :: 1 :: Nil) == Set#{1})
+def toSet04(): Bool = List.toSet(1 :: 1 :: Nil) == Set#{1}
 
 @test
-def toSet05(): Bool = assert!(List.toSet(1 :: 2 :: 3 :: Nil) == Set#{1, 2, 3})
+def toSet05(): Bool = List.toSet(1 :: 2 :: 3 :: Nil) == Set#{1, 2, 3}
 
 @test
-def toSet06(): Bool = assert!(List.toSet(1 :: 2 :: 1 :: Nil) == Set#{1, 2})
+def toSet06(): Bool = List.toSet(1 :: 2 :: 1 :: Nil) == Set#{1, 2}
 
 @test
-def toSet07(): Bool = assert!(List.toSet(1 :: 1 :: 2 :: Nil) == Set#{1, 2})
+def toSet07(): Bool = List.toSet(1 :: 1 :: 2 :: Nil) == Set#{1, 2}
 
 @test
-def toSet08(): Bool = assert!(List.toSet(2 :: 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 3 :: 3 :: Nil) == Set#{1, 2, 3, 4, 5, 6})
+def toSet08(): Bool = List.toSet(2 :: 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 3 :: 3 :: Nil) == Set#{1, 2, 3, 4, 5, 6}
 
 /////////////////////////////////////////////////////////////////////////////
 // toMap                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toMap01(): Bool = assert!(List.toMap(Nil) == Map#{})
+def toMap01(): Bool = List.toMap(Nil) == Map#{}
 
 @test
-def toMap02(): Bool = assert!(List.toMap((1, true) :: Nil) == Map#{1 -> true})
+def toMap02(): Bool = List.toMap((1, true) :: Nil) == Map#{1 -> true}
 
 @test
-def toMap03(): Bool = assert!(List.toMap((1, true) :: (2, false) :: Nil) == Map#{1 -> true, 2 -> false})
+def toMap03(): Bool = List.toMap((1, true) :: (2, false) :: Nil) == Map#{1 -> true, 2 -> false}
 
 @test
-def toMap04(): Bool = assert!(List.toMap((1, true) :: (1, false) :: Nil) == Map#{1 -> true})
+def toMap04(): Bool = List.toMap((1, true) :: (1, false) :: Nil) == Map#{1 -> true}
 
 /////////////////////////////////////////////////////////////////////////////
 // foreach                                                                 //

--- a/main/test/ca/uwaterloo/flix/library/TestMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMap.flix
@@ -20,1529 +20,1529 @@ namespace TestMap {
 // size                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def size01(): Bool = Map.size(Map#{}) `assertEq!` 0
+def size01(): Bool = Map.size(Map#{}) == 0
 
 @test
-def size02(): Bool = Map.size(Map#{1 -> 2}) `assertEq!` 1
+def size02(): Bool = Map.size(Map#{1 -> 2}) == 1
 
 @test
-def size03(): Bool = Map.size(Map#{1 -> 2, 2 -> 4}) `assertEq!` 2
+def size03(): Bool = Map.size(Map#{1 -> 2, 2 -> 4}) == 2
 
 @test
-def size04(): Bool = Map.size(Map#{1 -> 2, 2 -> 4, 3 -> 6}) `assertEq!` 3
+def size04(): Bool = Map.size(Map#{1 -> 2, 2 -> 4, 3 -> 6}) == 3
 
 @test
-def size05(): Bool = Map.size(Map#{1 -> 2, 2 -> 4, 3 -> 6, 4 -> 8}) `assertEq!` 4
+def size05(): Bool = Map.size(Map#{1 -> 2, 2 -> 4, 3 -> 6, 4 -> 8}) == 4
 
 @test
-def size06(): Bool = Map.size(Map#{1 -> 2, 2 -> 4, 3 -> 6, 4 -> 8, 5 -> 10}) `assertEq!` 5
+def size06(): Bool = Map.size(Map#{1 -> 2, 2 -> 4, 3 -> 6, 4 -> 8, 5 -> 10}) == 5
 
 /////////////////////////////////////////////////////////////////////////////
 // empty                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def empty01(): Bool = assert!(Map.__eq(Map.empty(), Map#{}))
+def empty01(): Bool = Map.__eq(Map.empty(), Map#{}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // singleton                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def singleton01(): Bool = assert!(Map.__eq(Map.singleton(1, 2), Map#{1 -> 2}))
+def singleton01(): Bool = Map.__eq(Map.singleton(1, 2), Map#{1 -> 2}) == true
 
 @test
-def singleton02(): Bool = assert!(Map.__eq(Map.singleton(3, -1), Map#{3 -> -1}))
+def singleton02(): Bool = Map.__eq(Map.singleton(3, -1), Map#{3 -> -1}) == true
 
 @test
-def singleton03(): Bool = assert!(Map.__eq(Map.singleton(-99, -11), Map#{-99 -> -11}))
+def singleton03(): Bool = Map.__eq(Map.singleton(-99, -11), Map#{-99 -> -11}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // isEmpty                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def isEmpty01(): Bool = assert!(Map.isEmpty(Map#{}))
+def isEmpty01(): Bool = Map.isEmpty(Map#{}) == true
 
 @test
-def isEmpty02(): Bool = assertNot!(Map.isEmpty(Map#{1 -> 2}))
+def isEmpty02(): Bool = Map.isEmpty(Map#{1 -> 2}) == false
 
 @test
-def isEmpty03(): Bool = assertNot!(Map.isEmpty(Map#{1 -> 2, 2 -> 4}))
+def isEmpty03(): Bool = Map.isEmpty(Map#{1 -> 2, 2 -> 4}) == false
 
 @test
-def isEmpty04(): Bool = assertNot!(Map.isEmpty(Map#{1 -> 2, 2 -> 4, 3 -> 6}))
+def isEmpty04(): Bool = Map.isEmpty(Map#{1 -> 2, 2 -> 4, 3 -> 6}) == false
 
 @test
-def isEmpty05(): Bool = assertNot!(Map.isEmpty(Map#{1 -> 2, 2 -> 4, 3 -> 6, 4 -> 8}))
+def isEmpty05(): Bool = Map.isEmpty(Map#{1 -> 2, 2 -> 4, 3 -> 6, 4 -> 8}) == false
 
 /////////////////////////////////////////////////////////////////////////////
 // get                                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def get01(): Bool = Map.get(2, Map#{}) `assertEq!` None
+def get01(): Bool = Map.get(2, Map#{}) == None
 
 @test
-def get02(): Bool = Map.get(2, Map#{1 -> 2}) `assertEq!` None
+def get02(): Bool = Map.get(2, Map#{1 -> 2}) == None
 
 @test
-def get03(): Bool = Map.get(2, Map#{2 -> 1}) `assertEq!` Some(1)
+def get03(): Bool = Map.get(2, Map#{2 -> 1}) == Some(1)
 
 @test
-def get04(): Bool = Map.get(5, Map#{2 -> 1, 3 -> 17}) `assertEq!` None
+def get04(): Bool = Map.get(5, Map#{2 -> 1, 3 -> 17}) == None
 
 @test
-def get05(): Bool = Map.get(5, Map#{2 -> 1, 5 -> 17}) `assertEq!` Some(17)
+def get05(): Bool = Map.get(5, Map#{2 -> 1, 5 -> 17}) == Some(17)
 
 @test
-def get06(): Bool = Map.get(5, Map#{5 -> 1, 3 -> 17}) `assertEq!` Some(1)
+def get06(): Bool = Map.get(5, Map#{5 -> 1, 3 -> 17}) == Some(1)
 
 @test
-def get07(): Bool = Map.get(-2, Map#{2 -> 1, 3 -> 17, -1 -> -2}) `assertEq!` None
+def get07(): Bool = Map.get(-2, Map#{2 -> 1, 3 -> 17, -1 -> -2}) == None
 
 @test
-def get08(): Bool = Map.get(-2, Map#{-2 -> 1, 3 -> 17, -1 -> -2}) `assertEq!` Some(1)
+def get08(): Bool = Map.get(-2, Map#{-2 -> 1, 3 -> 17, -1 -> -2}) == Some(1)
 
 @test
-def get09(): Bool = Map.get(-2, Map#{2 -> 1, -2 -> 17, -1 -> -2}) `assertEq!` Some(17)
+def get09(): Bool = Map.get(-2, Map#{2 -> 1, -2 -> 17, -1 -> -2}) == Some(17)
 
 @test
-def get10(): Bool = Map.get(-2, Map#{2 -> 1, 3 -> 17, -2 -> -2}) `assertEq!` Some(-2)
+def get10(): Bool = Map.get(-2, Map#{2 -> 1, 3 -> 17, -2 -> -2}) == Some(-2)
 
 /////////////////////////////////////////////////////////////////////////////
 // getWithDefault                                                          //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def getWithDefault01(): Bool = Map.getWithDefault(2, 34, Map#{}) `assertEq!` 34
+def getWithDefault01(): Bool = Map.getWithDefault(2, 34, Map#{}) == 34
 
 @test
-def getWithDefault02(): Bool = Map.getWithDefault(2, 34, Map#{1 -> 2}) `assertEq!` 34
+def getWithDefault02(): Bool = Map.getWithDefault(2, 34, Map#{1 -> 2}) == 34
 
 @test
-def getWithDefault03(): Bool = Map.getWithDefault(2, 34, Map#{2 -> 1}) `assertEq!` 1
+def getWithDefault03(): Bool = Map.getWithDefault(2, 34, Map#{2 -> 1}) == 1
 
 @test
-def getWithDefault04(): Bool = Map.getWithDefault(5, 34, Map#{2 -> 1, 3 -> 17}) `assertEq!` 34
+def getWithDefault04(): Bool = Map.getWithDefault(5, 34, Map#{2 -> 1, 3 -> 17}) == 34
 
 @test
-def getWithDefault05(): Bool = Map.getWithDefault(5, 34, Map#{2 -> 1, 5 -> 17}) `assertEq!` 17
+def getWithDefault05(): Bool = Map.getWithDefault(5, 34, Map#{2 -> 1, 5 -> 17}) == 17
 
 @test
-def getWithDefault06(): Bool = Map.getWithDefault(5, 34, Map#{5 -> 1, 3 -> 17}) `assertEq!` 1
+def getWithDefault06(): Bool = Map.getWithDefault(5, 34, Map#{5 -> 1, 3 -> 17}) == 1
 
 @test
-def getWithDefault07(): Bool = Map.getWithDefault(-2, 34, Map#{2 -> 1, 3 -> 17, -1 -> -2}) `assertEq!` 34
+def getWithDefault07(): Bool = Map.getWithDefault(-2, 34, Map#{2 -> 1, 3 -> 17, -1 -> -2}) == 34
 
 @test
-def getWithDefault08(): Bool = Map.getWithDefault(-2, 34, Map#{-2 -> 1, 3 -> 17, -1 -> -2}) `assertEq!` 1
+def getWithDefault08(): Bool = Map.getWithDefault(-2, 34, Map#{-2 -> 1, 3 -> 17, -1 -> -2}) == 1
 
 @test
-def getWithDefault09(): Bool = Map.getWithDefault(-2, 34, Map#{2 -> 1, -2 -> 17, -1 -> -2}) `assertEq!` 17
+def getWithDefault09(): Bool = Map.getWithDefault(-2, 34, Map#{2 -> 1, -2 -> 17, -1 -> -2}) == 17
 
 @test
-def getWithDefault10(): Bool = Map.getWithDefault(-2, 34, Map#{2 -> 1, 3 -> 17, -2 -> -2}) `assertEq!` -2
+def getWithDefault10(): Bool = Map.getWithDefault(-2, 34, Map#{2 -> 1, 3 -> 17, -2 -> -2}) == -2
 
 /////////////////////////////////////////////////////////////////////////////
 // memberOf                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def memberOf01(): Bool = assertNot!(Map.memberOf(2, Map#{}))
+def memberOf01(): Bool = Map.memberOf(2, Map#{}) == false
 
 @test
-def memberOf02(): Bool = assertNot!(Map.memberOf(2, Map#{1 -> 2}))
+def memberOf02(): Bool = Map.memberOf(2, Map#{1 -> 2}) == false
 
 @test
-def memberOf03(): Bool = assert!(Map.memberOf(2, Map#{2 -> 1}))
+def memberOf03(): Bool = Map.memberOf(2, Map#{2 -> 1}) == true
 
 @test
-def memberOf04(): Bool = assertNot!(Map.memberOf(5, Map#{2 -> 1, 3 -> 17}))
+def memberOf04(): Bool = Map.memberOf(5, Map#{2 -> 1, 3 -> 17}) == false
 
 @test
-def memberOf05(): Bool = assert!(Map.memberOf(5, Map#{2 -> 1, 5 -> 17}))
+def memberOf05(): Bool = Map.memberOf(5, Map#{2 -> 1, 5 -> 17}) == true
 
 @test
-def memberOf06(): Bool = assert!(Map.memberOf(5, Map#{5 -> 1, 3 -> 17}))
+def memberOf06(): Bool = Map.memberOf(5, Map#{5 -> 1, 3 -> 17}) == true
 
 @test
-def memberOf07(): Bool = assertNot!(Map.memberOf(-2, Map#{2 -> 1, 3 -> 17, -1 -> -2}))
+def memberOf07(): Bool = Map.memberOf(-2, Map#{2 -> 1, 3 -> 17, -1 -> -2}) == false
 
 @test
-def memberOf08(): Bool = assert!(Map.memberOf(-2, Map#{-2 -> 1, 3 -> 17, -1 -> -2}))
+def memberOf08(): Bool = Map.memberOf(-2, Map#{-2 -> 1, 3 -> 17, -1 -> -2}) == true
 
 @test
-def memberOf09(): Bool = assert!(Map.memberOf(-2, Map#{2 -> 1, -2 -> 17, -1 -> -2}))
+def memberOf09(): Bool = Map.memberOf(-2, Map#{2 -> 1, -2 -> 17, -1 -> -2}) == true
 
 @test
-def memberOf10(): Bool = assert!(Map.memberOf(-2, Map#{2 -> 1, 3 -> 17, -2 -> -2}))
+def memberOf10(): Bool = Map.memberOf(-2, Map#{2 -> 1, 3 -> 17, -2 -> -2}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // keysOf                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def keysOf01(): Bool = assert!(Set.__eq(Map.keysOf(Map#{}), Set#{}))
+def keysOf01(): Bool = Set.__eq(Map.keysOf(Map#{}), Set#{}) == true
 
 @test
-def keysOf02(): Bool = assert!(Set.__eq(Map.keysOf(Map#{1 -> 2}), Set#{1}))
+def keysOf02(): Bool = Set.__eq(Map.keysOf(Map#{1 -> 2}), Set#{1}) == true
 
 @test
-def keysOf03(): Bool = assert!(Set.__eq(Map.keysOf(Map#{1 -> 2, 2 -> 4}), Set#{1, 2}))
+def keysOf03(): Bool = Set.__eq(Map.keysOf(Map#{1 -> 2, 2 -> 4}), Set#{1, 2}) == true
 
 @test
-def keysOf04(): Bool = assert!(Set.__eq(Map.keysOf(Map#{1 -> 2, 2 -> 4, 3 -> 6}), Set#{1, 2, 3}))
+def keysOf04(): Bool = Set.__eq(Map.keysOf(Map#{1 -> 2, 2 -> 4, 3 -> 6}), Set#{1, 2, 3}) == true
 
 @test
-def keysOf05(): Bool = assert!(Set.__eq(Map.keysOf(Map#{1 -> 2, 2 -> 4, 3 -> 6, 4 -> 8}), Set#{1, 2, 3, 4}))
+def keysOf05(): Bool = Set.__eq(Map.keysOf(Map#{1 -> 2, 2 -> 4, 3 -> 6, 4 -> 8}), Set#{1, 2, 3, 4}) == true
 
 @test
-def keysOf06(): Bool = assert!(Set.__eq(Map.keysOf(Map#{1 -> 2, 2 -> 4, 3 -> 6, 4 -> 8, 5 -> 10}), Set#{1, 2, 3, 4, 5}))
+def keysOf06(): Bool = Set.__eq(Map.keysOf(Map#{1 -> 2, 2 -> 4, 3 -> 6, 4 -> 8, 5 -> 10}), Set#{1, 2, 3, 4, 5}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // valuesOf                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def valuesOf01(): Bool = Map.valuesOf(Map#{}) `assertEq!` Nil
+def valuesOf01(): Bool = Map.valuesOf(Map#{}) == Nil
 
 @test
-def valuesOf02(): Bool = Map.valuesOf(Map#{1 -> 2}) `assertEq!` 2 :: Nil
+def valuesOf02(): Bool = Map.valuesOf(Map#{1 -> 2}) == 2 :: Nil
 
 @test
-def valuesOf03(): Bool = Map.valuesOf(Map#{1 -> 2, 2 -> 4}) `assertEq!` 2 :: 4 :: Nil
+def valuesOf03(): Bool = Map.valuesOf(Map#{1 -> 2, 2 -> 4}) == 2 :: 4 :: Nil
 
 @test
-def valuesOf04(): Bool = Map.valuesOf(Map#{1 -> 2, 2 -> 4, 3 -> 6}) `assertEq!` 2 :: 4 :: 6 :: Nil
+def valuesOf04(): Bool = Map.valuesOf(Map#{1 -> 2, 2 -> 4, 3 -> 6}) == 2 :: 4 :: 6 :: Nil
 
 @test
-def valuesOf05(): Bool = Map.valuesOf(Map#{1 -> 2, 2 -> 4, 3 -> 6, 4 -> 8}) `assertEq!` 2 :: 4 :: 6 :: 8 :: Nil
+def valuesOf05(): Bool = Map.valuesOf(Map#{1 -> 2, 2 -> 4, 3 -> 6, 4 -> 8}) == 2 :: 4 :: 6 :: 8 :: Nil
 
 @test
-def valuesOf06(): Bool = Map.valuesOf(Map#{1 -> 2, 2 -> 4, 3 -> 6, 4 -> 8, 5 -> 10}) `assertEq!` 2 :: 4 :: 6 :: 8 :: 10 :: Nil
+def valuesOf06(): Bool = Map.valuesOf(Map#{1 -> 2, 2 -> 4, 3 -> 6, 4 -> 8, 5 -> 10}) == 2 :: 4 :: 6 :: 8 :: 10 :: Nil
 
 @test
-def valuesOf07(): Bool = Map.valuesOf(Map#{1 -> -11, 2 -> 4, 3 -> -5, 4 -> 7, 5 -> -5}) `assertEq!` -11 :: 4 :: -5 :: 7 :: -5 :: Nil
+def valuesOf07(): Bool = Map.valuesOf(Map#{1 -> -11, 2 -> 4, 3 -> -5, 4 -> 7, 5 -> -5}) == -11 :: 4 :: -5 :: 7 :: -5 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // insert                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def insert01(): Bool = assert!(Map.__eq(Map.insert(1, 3, Map#{}), Map#{1 -> 3}))
+def insert01(): Bool = Map.__eq(Map.insert(1, 3, Map#{}), Map#{1 -> 3}) == true
 
 @test
-def insert02(): Bool = assert!(Map.__eq(Map.insert(1, 3, Map#{1 -> 4}), Map#{1 -> 3}))
+def insert02(): Bool = Map.__eq(Map.insert(1, 3, Map#{1 -> 4}), Map#{1 -> 3}) == true
 
 @test
-def insert03(): Bool = assert!(Map.__eq(Map.insert(2, 3, Map#{1 -> 4}), Map#{1 -> 4, 2 -> 3}))
+def insert03(): Bool = Map.__eq(Map.insert(2, 3, Map#{1 -> 4}), Map#{1 -> 4, 2 -> 3}) == true
 
 @test
-def insert04(): Bool = assert!(Map.__eq(Map.insert(1, 1, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 1, 5 -> -2}))
+def insert04(): Bool = Map.__eq(Map.insert(1, 1, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 1, 5 -> -2}) == true
 
 @test
-def insert05(): Bool = assert!(Map.__eq(Map.insert(5, 1, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> 1}))
+def insert05(): Bool = Map.__eq(Map.insert(5, 1, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> 1}) == true
 
 @test
-def insert06(): Bool = assert!(Map.__eq(Map.insert(4, -2, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2, 4 -> -2}))
+def insert06(): Bool = Map.__eq(Map.insert(4, -2, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2, 4 -> -2}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // insertWith                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def insertWith01(): Bool = assert!(Map.__eq(Map.insertWith((v1, v2) -> v1 + v2, 1, 3, Map#{}), Map#{1 -> 3}))
+def insertWith01(): Bool = Map.__eq(Map.insertWith((v1, v2) -> v1 + v2, 1, 3, Map#{}), Map#{1 -> 3}) == true
 
 @test
-def insertWith02(): Bool = assert!(Map.__eq(Map.insertWith((v1, v2) -> v1 + v2, 1, 3, Map#{1 -> 4}), Map#{1 -> 7}))
+def insertWith02(): Bool = Map.__eq(Map.insertWith((v1, v2) -> v1 + v2, 1, 3, Map#{1 -> 4}), Map#{1 -> 7}) == true
 
 @test
-def insertWith03(): Bool = assert!(Map.__eq(Map.insertWith((v1, v2) -> v1 + v2, 2, 3, Map#{1 -> 4}), Map#{1 -> 4, 2 -> 3}))
+def insertWith03(): Bool = Map.__eq(Map.insertWith((v1, v2) -> v1 + v2, 2, 3, Map#{1 -> 4}), Map#{1 -> 4, 2 -> 3}) == true
 
 @test
-def insertWith04(): Bool = assert!(Map.__eq(Map.insertWith((v1, v2) -> v1 + v2, 1, 1, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 5, 5 -> -2}))
+def insertWith04(): Bool = Map.__eq(Map.insertWith((v1, v2) -> v1 + v2, 1, 1, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 5, 5 -> -2}) == true
 
 @test
-def insertWith05(): Bool = assert!(Map.__eq(Map.insertWith((v1, v2) -> v1 + v2, 5, 1, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -1}))
+def insertWith05(): Bool = Map.__eq(Map.insertWith((v1, v2) -> v1 + v2, 5, 1, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -1}) == true
 
 @test
-def insertWith06(): Bool = assert!(Map.__eq(Map.insertWith((v1, v2) -> v1 + v2, 4, -2, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2, 4 -> -2}))
+def insertWith06(): Bool = Map.__eq(Map.insertWith((v1, v2) -> v1 + v2, 4, -2, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2, 4 -> -2}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // insertWithKey                                                           //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def insertWithKey01(): Bool = assert!(Map.__eq(Map.insertWithKey((k, v1, v2) -> k + v1 + v2, 1, 3, Map#{}), Map#{1 -> 3}))
+def insertWithKey01(): Bool = Map.__eq(Map.insertWithKey((k, v1, v2) -> k + v1 + v2, 1, 3, Map#{}), Map#{1 -> 3}) == true
 
 @test
-def insertWithKey02(): Bool = assert!(Map.__eq(Map.insertWithKey((k, v1, v2) -> k + v1 + v2, 1, 3, Map#{1 -> 4}), Map#{1 -> 8}))
+def insertWithKey02(): Bool = Map.__eq(Map.insertWithKey((k, v1, v2) -> k + v1 + v2, 1, 3, Map#{1 -> 4}), Map#{1 -> 8}) == true
 
 @test
-def insertWithKey03(): Bool = assert!(Map.__eq(Map.insertWithKey((k, v1, v2) -> k + v1 + v2, 2, 3, Map#{1 -> 4}), Map#{1 -> 4, 2 -> 3}))
+def insertWithKey03(): Bool = Map.__eq(Map.insertWithKey((k, v1, v2) -> k + v1 + v2, 2, 3, Map#{1 -> 4}), Map#{1 -> 4, 2 -> 3}) == true
 
 @test
-def insertWithKey04(): Bool = assert!(Map.__eq(Map.insertWithKey((k, v1, v2) -> k + v1 + v2, 1, 1, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 6, 5 -> -2}))
+def insertWithKey04(): Bool = Map.__eq(Map.insertWithKey((k, v1, v2) -> k + v1 + v2, 1, 1, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 6, 5 -> -2}) == true
 
 @test
-def insertWithKey05(): Bool = assert!(Map.__eq(Map.insertWithKey((k, v1, v2) -> k + v1 + v2, 5, 1, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> 4}))
+def insertWithKey05(): Bool = Map.__eq(Map.insertWithKey((k, v1, v2) -> k + v1 + v2, 5, 1, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> 4}) == true
 
 @test
-def insertWithKey06(): Bool = assert!(Map.__eq(Map.insertWithKey((k, v1, v2) -> k + v1 + v2, 4, -2, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2, 4 -> -2}))
+def insertWithKey06(): Bool = Map.__eq(Map.insertWithKey((k, v1, v2) -> k + v1 + v2, 4, -2, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2, 4 -> -2}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // adjust                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def adjust01(): Bool = assert!(Map.__eq(Map.adjust(v -> 2*v, 1, Map#{}), Map#{}))
+def adjust01(): Bool = Map.__eq(Map.adjust(v -> 2*v, 1, Map#{}), Map#{}) == true
 
 @test
-def adjust02(): Bool = assert!(Map.__eq(Map.adjust(v -> 2*v, 1, Map#{1 -> 4}), Map#{1 -> 8}))
+def adjust02(): Bool = Map.__eq(Map.adjust(v -> 2*v, 1, Map#{1 -> 4}), Map#{1 -> 8}) == true
 
 @test
-def adjust03(): Bool = assert!(Map.__eq(Map.adjust(v -> 2*v, 2, Map#{1 -> 4}), Map#{1 -> 4}))
+def adjust03(): Bool = Map.__eq(Map.adjust(v -> 2*v, 2, Map#{1 -> 4}), Map#{1 -> 4}) == true
 
 @test
-def adjust04(): Bool = assert!(Map.__eq(Map.adjust(v -> 2*v, 1, Map#{1 -> -14, 5 -> -2}), Map#{1 -> -28, 5 -> -2}))
+def adjust04(): Bool = Map.__eq(Map.adjust(v -> 2*v, 1, Map#{1 -> -14, 5 -> -2}), Map#{1 -> -28, 5 -> -2}) == true
 
 @test
-def adjust05(): Bool = assert!(Map.__eq(Map.adjust(v -> 2*v, 5, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -4}))
+def adjust05(): Bool = Map.__eq(Map.adjust(v -> 2*v, 5, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -4}) == true
 
 @test
-def adjust06(): Bool = assert!(Map.__eq(Map.adjust(v -> 2*v, 4, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2}))
+def adjust06(): Bool = Map.__eq(Map.adjust(v -> 2*v, 4, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // adjustWithKey                                                           //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def adjustWithKey01(): Bool = assert!(Map.__eq(Map.adjustWithKey((k, v) -> k+v, 1, Map#{}), Map#{}))
+def adjustWithKey01(): Bool = Map.__eq(Map.adjustWithKey((k, v) -> k+v, 1, Map#{}), Map#{}) == true
 
 @test
-def adjustWithKey02(): Bool = assert!(Map.__eq(Map.adjustWithKey((k, v) -> k+v, 1, Map#{1 -> 4}), Map#{1 -> 5}))
+def adjustWithKey02(): Bool = Map.__eq(Map.adjustWithKey((k, v) -> k+v, 1, Map#{1 -> 4}), Map#{1 -> 5}) == true
 
 @test
-def adjustWithKey03(): Bool = assert!(Map.__eq(Map.adjustWithKey((k, v) -> k+v, 2, Map#{1 -> 4}), Map#{1 -> 4}))
+def adjustWithKey03(): Bool = Map.__eq(Map.adjustWithKey((k, v) -> k+v, 2, Map#{1 -> 4}), Map#{1 -> 4}) == true
 
 @test
-def adjustWithKey04(): Bool = assert!(Map.__eq(Map.adjustWithKey((k, v) -> k+v, 1, Map#{1 -> -14, 5 -> -2}), Map#{1 -> -13, 5 -> -2}))
+def adjustWithKey04(): Bool = Map.__eq(Map.adjustWithKey((k, v) -> k+v, 1, Map#{1 -> -14, 5 -> -2}), Map#{1 -> -13, 5 -> -2}) == true
 
 @test
-def adjustWithKey05(): Bool = assert!(Map.__eq(Map.adjustWithKey((k, v) -> k+v, 5, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> 3}))
+def adjustWithKey05(): Bool = Map.__eq(Map.adjustWithKey((k, v) -> k+v, 5, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> 3}) == true
 
 @test
-def adjustWithKey06(): Bool = assert!(Map.__eq(Map.adjustWithKey((k, v) -> k+v, 4, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2}))
+def adjustWithKey06(): Bool = Map.__eq(Map.adjustWithKey((k, v) -> k+v, 4, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // update                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def update01(): Bool = assert!(Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 1, Map#{}), Map#{}))
+def update01(): Bool = Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 1, Map#{}), Map#{}) == true
 
 @test
-def update02(): Bool = assert!(Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 1, Map#{1 -> 3}), Map#{1 -> 6}))
+def update02(): Bool = Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 1, Map#{1 -> 3}), Map#{1 -> 6}) == true
 
 @test
-def update03(): Bool = assert!(Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 1, Map#{1 -> 4}), Map#{1 -> 4}))
+def update03(): Bool = Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 1, Map#{1 -> 4}), Map#{1 -> 4}) == true
 
 @test
-def update04(): Bool = assert!(Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 2, Map#{1 -> 4}), Map#{1 -> 4}))
+def update04(): Bool = Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 2, Map#{1 -> 4}), Map#{1 -> 4}) == true
 
 @test
-def update05(): Bool = assert!(Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 1, Map#{1 -> -14, 5 -> -2}), Map#{1 -> -14, 5 -> -2}))
+def update05(): Bool = Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 1, Map#{1 -> -14, 5 -> -2}), Map#{1 -> -14, 5 -> -2}) == true
 
 @test
-def update06(): Bool = assert!(Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 1, Map#{1 -> -13, 5 -> -2}), Map#{1 -> -26, 5 -> -2}))
+def update06(): Bool = Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 1, Map#{1 -> -13, 5 -> -2}), Map#{1 -> -26, 5 -> -2}) == true
 
 @test
-def update07(): Bool = assert!(Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 5, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2}))
+def update07(): Bool = Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 5, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2}) == true
 
 @test
-def update08(): Bool = assert!(Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 5, Map#{1 -> 4, 5 -> -1}), Map#{1 -> 4, 5 -> -2}))
+def update08(): Bool = Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 5, Map#{1 -> 4, 5 -> -1}), Map#{1 -> 4, 5 -> -2}) == true
 
 @test
-def update09(): Bool = assert!(Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 4, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2}))
+def update09(): Bool = Map.__eq(Map.update(v -> if (v % 2 != 0) Some(2*v) else None, 4, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // updateWithKey                                                           //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def updateWithKey01(): Bool = assert!(Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 1, Map#{}), Map#{}))
+def updateWithKey01(): Bool = Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 1, Map#{}), Map#{}) == true
 
 @test
-def updateWithKey02(): Bool = assert!(Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 1, Map#{1 -> 3}), Map#{1 -> 7}))
+def updateWithKey02(): Bool = Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 1, Map#{1 -> 3}), Map#{1 -> 7}) == true
 
 @test
-def updateWithKey03(): Bool = assert!(Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 1, Map#{1 -> 4}), Map#{1 -> 4}))
+def updateWithKey03(): Bool = Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 1, Map#{1 -> 4}), Map#{1 -> 4}) == true
 
 @test
-def updateWithKey04(): Bool = assert!(Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 2, Map#{1 -> 4}), Map#{1 -> 4}))
+def updateWithKey04(): Bool = Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 2, Map#{1 -> 4}), Map#{1 -> 4}) == true
 
 @test
-def updateWithKey05(): Bool = assert!(Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 1, Map#{1 -> -14, 5 -> -2}), Map#{1 -> -14, 5 -> -2}))
+def updateWithKey05(): Bool = Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 1, Map#{1 -> -14, 5 -> -2}), Map#{1 -> -14, 5 -> -2}) == true
 
 @test
-def updateWithKey06(): Bool = assert!(Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 1, Map#{1 -> -13, 5 -> -2}), Map#{1 -> -25, 5 -> -2}))
+def updateWithKey06(): Bool = Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 1, Map#{1 -> -13, 5 -> -2}), Map#{1 -> -25, 5 -> -2}) == true
 
 @test
-def updateWithKey07(): Bool = assert!(Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 5, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2}))
+def updateWithKey07(): Bool = Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 5, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2}) == true
 
 @test
-def updateWithKey08(): Bool = assert!(Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 5, Map#{1 -> 4, 5 -> -1}), Map#{1 -> 4, 5 -> 3}))
+def updateWithKey08(): Bool = Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 5, Map#{1 -> 4, 5 -> -1}), Map#{1 -> 4, 5 -> 3}) == true
 
 @test
-def updateWithKey09(): Bool = assert!(Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 4, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2}))
+def updateWithKey09(): Bool = Map.__eq(Map.updateWithKey((k, v) -> if (v % 2 != 0) Some(k+2*v) else None, 4, Map#{1 -> 4, 5 -> -2}), Map#{1 -> 4, 5 -> -2}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // delete                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def delete01(): Bool = assert!(Map.__eq(Map.delete(1, Map#{}), Map#{}))
+def delete01(): Bool = Map.__eq(Map.delete(1, Map#{}), Map#{}) == true
 
 @test
-def delete02(): Bool = assert!(Map.__eq(Map.delete(1, Map#{2 -> 4}), Map#{2 -> 4}))
+def delete02(): Bool = Map.__eq(Map.delete(1, Map#{2 -> 4}), Map#{2 -> 4}) == true
 
 @test
-def delete03(): Bool = assert!(Map.__eq(Map.delete(1, Map#{1 -> 4}), Map#{}))
+def delete03(): Bool = Map.__eq(Map.delete(1, Map#{1 -> 4}), Map#{}) == true
 
 @test
-def delete04(): Bool = assert!(Map.__eq(Map.delete(1, Map#{6 -> 1, 2 -> 4}), Map#{6 -> 1, 2 -> 4}))
+def delete04(): Bool = Map.__eq(Map.delete(1, Map#{6 -> 1, 2 -> 4}), Map#{6 -> 1, 2 -> 4}) == true
 
 @test
-def delete05(): Bool = assert!(Map.__eq(Map.delete(6, Map#{6 -> 1, 2 -> 4}), Map#{2 -> 4}))
+def delete05(): Bool = Map.__eq(Map.delete(6, Map#{6 -> 1, 2 -> 4}), Map#{2 -> 4}) == true
 
 @test
-def delete06(): Bool = assert!(Map.__eq(Map.delete(2, Map#{6 -> 1, 2 -> 4}), Map#{6 -> 1}))
+def delete06(): Bool = Map.__eq(Map.delete(2, Map#{6 -> 1, 2 -> 4}), Map#{6 -> 1}) == true
 
 @test
-def delete07(): Bool = assert!(Map.__eq(Map.delete(1, Map#{6 -> 1, 2 -> 4, 8 -> 89}), Map#{6 -> 1, 2 -> 4, 8 -> 89}))
+def delete07(): Bool = Map.__eq(Map.delete(1, Map#{6 -> 1, 2 -> 4, 8 -> 89}), Map#{6 -> 1, 2 -> 4, 8 -> 89}) == true
 
 @test
-def delete08(): Bool = assert!(Map.__eq(Map.delete(6, Map#{6 -> 1, 2 -> 4, 8 -> 89}), Map#{2 -> 4, 8 -> 89}))
+def delete08(): Bool = Map.__eq(Map.delete(6, Map#{6 -> 1, 2 -> 4, 8 -> 89}), Map#{2 -> 4, 8 -> 89}) == true
 
 @test
-def delete09(): Bool = assert!(Map.__eq(Map.delete(2, Map#{6 -> 1, 2 -> 4, 8 -> 89}), Map#{6 -> 1, 8 -> 89}))
+def delete09(): Bool = Map.__eq(Map.delete(2, Map#{6 -> 1, 2 -> 4, 8 -> 89}), Map#{6 -> 1, 8 -> 89}) == true
 
 @test
-def delete10(): Bool = assert!(Map.__eq(Map.delete(8, Map#{6 -> 1, 2 -> 4, 8 -> 89}), Map#{6 -> 1, 2 -> 4}))
+def delete10(): Bool = Map.__eq(Map.delete(8, Map#{6 -> 1, 2 -> 4, 8 -> 89}), Map#{6 -> 1, 2 -> 4}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // isSubmapOf                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def isSubmapOf01(): Bool = assert!(Map.isSubmapOf(Map#{}, Map#{}))
+def isSubmapOf01(): Bool = Map.isSubmapOf(Map#{}, Map#{}) == true
 
 @test
-def isSubmapOf02(): Bool = assertNot!(Map.isSubmapOf(Map#{1 -> 2}, Map#{}))
+def isSubmapOf02(): Bool = Map.isSubmapOf(Map#{1 -> 2}, Map#{}) == false
 
 @test
-def isSubmapOf03(): Bool = assertNot!(Map.isSubmapOf(Map#{3 -> 4}, Map#{}))
+def isSubmapOf03(): Bool = Map.isSubmapOf(Map#{3 -> 4}, Map#{}) == false
 
 @test
-def isSubmapOf04(): Bool = assert!(Map.isSubmapOf(Map#{1 -> 3}, Map#{1 -> 3}))
+def isSubmapOf04(): Bool = Map.isSubmapOf(Map#{1 -> 3}, Map#{1 -> 3}) == true
 
 @test
-def isSubmapOf05(): Bool = assertNot!(Map.isSubmapOf(Map#{2 -> 3}, Map#{1 -> 3}))
+def isSubmapOf05(): Bool = Map.isSubmapOf(Map#{2 -> 3}, Map#{1 -> 3}) == false
 
 @test
-def isSubmapOf06(): Bool = assertNot!(Map.isSubmapOf(Map#{1 -> 4}, Map#{1 -> 3}))
+def isSubmapOf06(): Bool = Map.isSubmapOf(Map#{1 -> 4}, Map#{1 -> 3}) == false
 
 @test
-def isSubmapOf07(): Bool = assertNot!(Map.isSubmapOf(Map#{1 -> 3, 2 -> 3}, Map#{1 -> 3}))
+def isSubmapOf07(): Bool = Map.isSubmapOf(Map#{1 -> 3, 2 -> 3}, Map#{1 -> 3}) == false
 
 @test
-def isSubmapOf08(): Bool = assertNot!(Map.isSubmapOf(Map#{1 -> 3, 2 -> 3}, Map#{2 -> 3}))
+def isSubmapOf08(): Bool = Map.isSubmapOf(Map#{1 -> 3, 2 -> 3}, Map#{2 -> 3}) == false
 
 @test
-def isSubmapOf09(): Bool = assert!(Map.isSubmapOf(Map#{}, Map#{2 -> 4, 1 -> 3}))
+def isSubmapOf09(): Bool = Map.isSubmapOf(Map#{}, Map#{2 -> 4, 1 -> 3}) == true
 
 @test
-def isSubmapOf10(): Bool = assert!(Map.isSubmapOf(Map#{2 -> 4}, Map#{2 -> 4, 1 -> 3}))
+def isSubmapOf10(): Bool = Map.isSubmapOf(Map#{2 -> 4}, Map#{2 -> 4, 1 -> 3}) == true
 
 @test
-def isSubmapOf11(): Bool = assert!(Map.isSubmapOf(Map#{1 -> 3}, Map#{2 -> 4, 1 -> 3}))
+def isSubmapOf11(): Bool = Map.isSubmapOf(Map#{1 -> 3}, Map#{2 -> 4, 1 -> 3}) == true
 
 @test
-def isSubmapOf12(): Bool = assert!(Map.isSubmapOf(Map#{1 -> 3, 2 -> 4}, Map#{1 -> 3, 2 -> 4}))
+def isSubmapOf12(): Bool = Map.isSubmapOf(Map#{1 -> 3, 2 -> 4}, Map#{1 -> 3, 2 -> 4}) == true
 
 @test
-def isSubmapOf13(): Bool = assert!(Map.isSubmapOf(Map#{2 -> 4, 1 -> 3}, Map#{1 -> 3, 2 -> 4}))
+def isSubmapOf13(): Bool = Map.isSubmapOf(Map#{2 -> 4, 1 -> 3}, Map#{1 -> 3, 2 -> 4}) == true
 
 @test
-def isSubmapOf14(): Bool = assertNot!(Map.isSubmapOf(Map#{2 -> 5, 1 -> 3}, Map#{1 -> 3, 2 -> 4}))
+def isSubmapOf14(): Bool = Map.isSubmapOf(Map#{2 -> 5, 1 -> 3}, Map#{1 -> 3, 2 -> 4}) == false
 
 @test
-def isSubmapOf15(): Bool = assertNot!(Map.isSubmapOf(Map#{2 -> 4, 1 -> -1}, Map#{1 -> 3, 2 -> 4}))
+def isSubmapOf15(): Bool = Map.isSubmapOf(Map#{2 -> 4, 1 -> -1}, Map#{1 -> 3, 2 -> 4}) == false
 
 @test
-def isSubmapOf16(): Bool = assertNot!(Map.isSubmapOf(Map#{3 -> 4, 1 -> 3}, Map#{1 -> 3, 2 -> 4}))
+def isSubmapOf16(): Bool = Map.isSubmapOf(Map#{3 -> 4, 1 -> 3}, Map#{1 -> 3, 2 -> 4}) == false
 
 @test
-def isSubmapOf17(): Bool = assertNot!(Map.isSubmapOf(Map#{2 -> 4, 3 -> 3}, Map#{1 -> 3, 2 -> 4}))
+def isSubmapOf17(): Bool = Map.isSubmapOf(Map#{2 -> 4, 3 -> 3}, Map#{1 -> 3, 2 -> 4}) == false
 
 @test
-def isSubmapOf18(): Bool = assertNot!(Map.isSubmapOf(Map#{2 -> 4, 1 -> 3, 8 -> 9}, Map#{1 -> 3, 2 -> 4}))
+def isSubmapOf18(): Bool = Map.isSubmapOf(Map#{2 -> 4, 1 -> 3, 8 -> 9}, Map#{1 -> 3, 2 -> 4}) == false
 
 /////////////////////////////////////////////////////////////////////////////
 // isProperSubmapOf                                                        //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def isProperSubmapOf01(): Bool = assertNot!(Map.isProperSubmapOf(Map#{}, Map#{}))
+def isProperSubmapOf01(): Bool = Map.isProperSubmapOf(Map#{}, Map#{}) == false
 
 @test
-def isProperSubmapOf02(): Bool = assertNot!(Map.isProperSubmapOf(Map#{1 -> 2}, Map#{}))
+def isProperSubmapOf02(): Bool = Map.isProperSubmapOf(Map#{1 -> 2}, Map#{}) == false
 
 @test
-def isProperSubmapOf03(): Bool = assertNot!(Map.isProperSubmapOf(Map#{3 -> 4}, Map#{}))
+def isProperSubmapOf03(): Bool = Map.isProperSubmapOf(Map#{3 -> 4}, Map#{}) == false
 
 @test
-def isProperSubmapOf04(): Bool = assertNot!(Map.isProperSubmapOf(Map#{1 -> 3}, Map#{1 -> 3}))
+def isProperSubmapOf04(): Bool = Map.isProperSubmapOf(Map#{1 -> 3}, Map#{1 -> 3}) == false
 
 @test
-def isProperSubmapOf05(): Bool = assertNot!(Map.isProperSubmapOf(Map#{2 -> 3}, Map#{1 -> 3}))
+def isProperSubmapOf05(): Bool = Map.isProperSubmapOf(Map#{2 -> 3}, Map#{1 -> 3}) == false
 
 @test
-def isProperSubmapOf06(): Bool = assertNot!(Map.isProperSubmapOf(Map#{1 -> 4}, Map#{1 -> 3}))
+def isProperSubmapOf06(): Bool = Map.isProperSubmapOf(Map#{1 -> 4}, Map#{1 -> 3}) == false
 
 @test
-def isProperSubmapOf07(): Bool = assertNot!(Map.isProperSubmapOf(Map#{1 -> 3, 2 -> 3}, Map#{1 -> 3}))
+def isProperSubmapOf07(): Bool = Map.isProperSubmapOf(Map#{1 -> 3, 2 -> 3}, Map#{1 -> 3}) == false
 
 @test
-def isProperSubmapOf08(): Bool = assertNot!(Map.isProperSubmapOf(Map#{1 -> 3, 2 -> 3}, Map#{2 -> 3}))
+def isProperSubmapOf08(): Bool = Map.isProperSubmapOf(Map#{1 -> 3, 2 -> 3}, Map#{2 -> 3}) == false
 
 @test
-def isProperSubmapOf09(): Bool = assert!(Map.isProperSubmapOf(Map#{}, Map#{2 -> 4, 1 -> 3}))
+def isProperSubmapOf09(): Bool = Map.isProperSubmapOf(Map#{}, Map#{2 -> 4, 1 -> 3}) == true
 
 @test
-def isProperSubmapOf10(): Bool = assert!(Map.isProperSubmapOf(Map#{2 -> 4}, Map#{2 -> 4, 1 -> 3}))
+def isProperSubmapOf10(): Bool = Map.isProperSubmapOf(Map#{2 -> 4}, Map#{2 -> 4, 1 -> 3}) == true
 
 @test
-def isProperSubmapOf11(): Bool = assert!(Map.isProperSubmapOf(Map#{1 -> 3}, Map#{2 -> 4, 1 -> 3}))
+def isProperSubmapOf11(): Bool = Map.isProperSubmapOf(Map#{1 -> 3}, Map#{2 -> 4, 1 -> 3}) == true
 
 @test
-def isProperSubmapOf12(): Bool = assertNot!(Map.isProperSubmapOf(Map#{1 -> 3, 2 -> 4}, Map#{1 -> 3, 2 -> 4}))
+def isProperSubmapOf12(): Bool = Map.isProperSubmapOf(Map#{1 -> 3, 2 -> 4}, Map#{1 -> 3, 2 -> 4}) == false
 
 @test
-def isProperSubmapOf13(): Bool = assertNot!(Map.isProperSubmapOf(Map#{2 -> 4, 1 -> 3}, Map#{1 -> 3, 2 -> 4}))
+def isProperSubmapOf13(): Bool = Map.isProperSubmapOf(Map#{2 -> 4, 1 -> 3}, Map#{1 -> 3, 2 -> 4}) == false
 
 @test
-def isProperSubmapOf14(): Bool = assertNot!(Map.isProperSubmapOf(Map#{2 -> 5, 1 -> 3}, Map#{1 -> 3, 2 -> 4}))
+def isProperSubmapOf14(): Bool = Map.isProperSubmapOf(Map#{2 -> 5, 1 -> 3}, Map#{1 -> 3, 2 -> 4}) == false
 
 @test
-def isProperSubmapOf15(): Bool = assertNot!(Map.isProperSubmapOf(Map#{2 -> 4, 1 -> -1}, Map#{1 -> 3, 2 -> 4}))
+def isProperSubmapOf15(): Bool = Map.isProperSubmapOf(Map#{2 -> 4, 1 -> -1}, Map#{1 -> 3, 2 -> 4}) == false
 
 @test
-def isProperSubmapOf16(): Bool = assertNot!(Map.isProperSubmapOf(Map#{3 -> 4, 1 -> 3}, Map#{1 -> 3, 2 -> 4}))
+def isProperSubmapOf16(): Bool = Map.isProperSubmapOf(Map#{3 -> 4, 1 -> 3}, Map#{1 -> 3, 2 -> 4}) == false
 
 @test
-def isProperSubmapOf17(): Bool = assertNot!(Map.isProperSubmapOf(Map#{2 -> 4, 3 -> 3}, Map#{1 -> 3, 2 -> 4}))
+def isProperSubmapOf17(): Bool = Map.isProperSubmapOf(Map#{2 -> 4, 3 -> 3}, Map#{1 -> 3, 2 -> 4}) == false
 
 @test
-def isProperSubmapOf18(): Bool = assertNot!(Map.isProperSubmapOf(Map#{2 -> 4, 1 -> 3, 8 -> 9}, Map#{1 -> 3, 2 -> 4}))
+def isProperSubmapOf18(): Bool = Map.isProperSubmapOf(Map#{2 -> 4, 1 -> 3, 8 -> 9}, Map#{1 -> 3, 2 -> 4}) == false
 
 /////////////////////////////////////////////////////////////////////////////
 // find                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def find01(): Bool = Map.find((k, v) -> k == v, Map#{}) `assertEq!` None
+def find01(): Bool = Map.find((k, v) -> k == v, Map#{}) == None
 
 @test
-def find02(): Bool = Map.find((k, v) -> k == v, Map#{1 -> 2}) `assertEq!` None
+def find02(): Bool = Map.find((k, v) -> k == v, Map#{1 -> 2}) == None
 
 @test
-def find03(): Bool = Map.find((k, v) -> k == v, Map#{1 -> 1}) `assertEq!` Some((1, 1))
+def find03(): Bool = Map.find((k, v) -> k == v, Map#{1 -> 1}) == Some((1, 1))
 
 @test
-def find04(): Bool = Map.find((k, v) -> k == v, Map#{1 -> 2, 2 -> 3}) `assertEq!` None
+def find04(): Bool = Map.find((k, v) -> k == v, Map#{1 -> 2, 2 -> 3}) == None
 
 @test
-def find05(): Bool = Map.find((k, v) -> k == v, Map#{1 -> 1, 2 -> 3}) `assertEq!` Some((1, 1))
+def find05(): Bool = Map.find((k, v) -> k == v, Map#{1 -> 1, 2 -> 3}) == Some((1, 1))
 
 @test
-def find06(): Bool = Map.find((k, v) -> k == v, Map#{1 -> 2, 2 -> 2}) `assertEq!` Some((2, 2))
+def find06(): Bool = Map.find((k, v) -> k == v, Map#{1 -> 2, 2 -> 2}) == Some((2, 2))
 
 @test
-def find07(): Bool = Map.find((k, v) -> k == v, Map#{1 -> 1, 2 -> 2}) `assertEq!` Some((1, 1))
+def find07(): Bool = Map.find((k, v) -> k == v, Map#{1 -> 1, 2 -> 2}) == Some((1, 1))
 
 /////////////////////////////////////////////////////////////////////////////
 // findLeft                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def findLeft01(): Bool = Map.findLeft((k, v) -> k == v, Map#{}) `assertEq!` None
+def findLeft01(): Bool = Map.findLeft((k, v) -> k == v, Map#{}) == None
 
 @test
-def findLeft02(): Bool = Map.findLeft((k, v) -> k == v, Map#{1 -> 2}) `assertEq!` None
+def findLeft02(): Bool = Map.findLeft((k, v) -> k == v, Map#{1 -> 2}) == None
 
 @test
-def findLeft03(): Bool = Map.findLeft((k, v) -> k == v, Map#{1 -> 1}) `assertEq!` Some((1, 1))
+def findLeft03(): Bool = Map.findLeft((k, v) -> k == v, Map#{1 -> 1}) == Some((1, 1))
 
 @test
-def findLeft04(): Bool = Map.findLeft((k, v) -> k == v, Map#{1 -> 2, 2 -> 3}) `assertEq!` None
+def findLeft04(): Bool = Map.findLeft((k, v) -> k == v, Map#{1 -> 2, 2 -> 3}) == None
 
 @test
-def findLeft05(): Bool = Map.findLeft((k, v) -> k == v, Map#{1 -> 1, 2 -> 3}) `assertEq!` Some((1, 1))
+def findLeft05(): Bool = Map.findLeft((k, v) -> k == v, Map#{1 -> 1, 2 -> 3}) == Some((1, 1))
 
 @test
-def findLeft06(): Bool = Map.findLeft((k, v) -> k == v, Map#{1 -> 2, 2 -> 2}) `assertEq!` Some((2, 2))
+def findLeft06(): Bool = Map.findLeft((k, v) -> k == v, Map#{1 -> 2, 2 -> 2}) == Some((2, 2))
 
 @test
-def findLeft07(): Bool = Map.findLeft((k, v) -> k == v, Map#{1 -> 1, 2 -> 2}) `assertEq!` Some((1, 1))
+def findLeft07(): Bool = Map.findLeft((k, v) -> k == v, Map#{1 -> 1, 2 -> 2}) == Some((1, 1))
 
 /////////////////////////////////////////////////////////////////////////////
 // findRight                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def findRight01(): Bool = Map.findRight((k, v) -> k == v, Map#{}) `assertEq!` None
+def findRight01(): Bool = Map.findRight((k, v) -> k == v, Map#{}) == None
 
 @test
-def findRight02(): Bool = Map.findRight((k, v) -> k == v, Map#{1 -> 2}) `assertEq!` None
+def findRight02(): Bool = Map.findRight((k, v) -> k == v, Map#{1 -> 2}) == None
 
 @test
-def findRight03(): Bool = Map.findRight((k, v) -> k == v, Map#{1 -> 1}) `assertEq!` Some((1, 1))
+def findRight03(): Bool = Map.findRight((k, v) -> k == v, Map#{1 -> 1}) == Some((1, 1))
 
 @test
-def findRight04(): Bool = Map.findRight((k, v) -> k == v, Map#{1 -> 2, 2 -> 3}) `assertEq!` None
+def findRight04(): Bool = Map.findRight((k, v) -> k == v, Map#{1 -> 2, 2 -> 3}) == None
 
 @test
-def findRight05(): Bool = Map.findRight((k, v) -> k == v, Map#{1 -> 1, 2 -> 3}) `assertEq!` Some((1, 1))
+def findRight05(): Bool = Map.findRight((k, v) -> k == v, Map#{1 -> 1, 2 -> 3}) == Some((1, 1))
 
 @test
-def findRight06(): Bool = Map.findRight((k, v) -> k == v, Map#{1 -> 2, 2 -> 2}) `assertEq!` Some((2, 2))
+def findRight06(): Bool = Map.findRight((k, v) -> k == v, Map#{1 -> 2, 2 -> 2}) == Some((2, 2))
 
 @test
-def findRight07(): Bool = Map.findRight((k, v) -> k == v, Map#{1 -> 1, 2 -> 2}) `assertEq!` Some((2, 2))
+def findRight07(): Bool = Map.findRight((k, v) -> k == v, Map#{1 -> 1, 2 -> 2}) == Some((2, 2))
 
 /////////////////////////////////////////////////////////////////////////////
 // filter                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def filter01(): Bool = assert!(Map.__eq(Map.filter(v -> v % 2 == 0, Map#{}), Map#{}))
+def filter01(): Bool = Map.__eq(Map.filter(v -> v % 2 == 0, Map#{}), Map#{}) == true
 
 @test
-def filter02(): Bool = assert!(Map.__eq(Map.filter(v -> v % 2 == 0, Map#{1 -> 2}), Map#{1 -> 2}))
+def filter02(): Bool = Map.__eq(Map.filter(v -> v % 2 == 0, Map#{1 -> 2}), Map#{1 -> 2}) == true
 
 @test
-def filter03(): Bool = assert!(Map.__eq(Map.filter(v -> v % 2 == 0, Map#{1 -> 3}), Map#{}))
+def filter03(): Bool = Map.__eq(Map.filter(v -> v % 2 == 0, Map#{1 -> 3}), Map#{}) == true
 
 @test
-def filter04(): Bool = assert!(Map.__eq(Map.filter(v -> v % 2 == 0, Map#{1 -> 8, 2 -> 4}), Map#{1 -> 8, 2 -> 4}))
+def filter04(): Bool = Map.__eq(Map.filter(v -> v % 2 == 0, Map#{1 -> 8, 2 -> 4}), Map#{1 -> 8, 2 -> 4}) == true
 
 @test
-def filter05(): Bool = assert!(Map.__eq(Map.filter(v -> v % 2 == 0, Map#{1 -> 7, 2 -> 4}), Map#{2 -> 4}))
+def filter05(): Bool = Map.__eq(Map.filter(v -> v % 2 == 0, Map#{1 -> 7, 2 -> 4}), Map#{2 -> 4}) == true
 
 @test
-def filter06(): Bool = assert!(Map.__eq(Map.filter(v -> v % 2 == 0, Map#{1 -> 8, 2 -> 3}), Map#{1 -> 8}))
+def filter06(): Bool = Map.__eq(Map.filter(v -> v % 2 == 0, Map#{1 -> 8, 2 -> 3}), Map#{1 -> 8}) == true
 
 @test
-def filter07(): Bool = assert!(Map.__eq(Map.filter(v -> v % 2 == 0, Map#{1 -> -1, 2 -> -3}), Map#{}))
+def filter07(): Bool = Map.__eq(Map.filter(v -> v % 2 == 0, Map#{1 -> -1, 2 -> -3}), Map#{}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // filterWithKey                                                           //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def filterWithKey01(): Bool = assert!(Map.__eq(Map.filterWithKey((k, v) -> k == v, Map#{}), Map#{}))
+def filterWithKey01(): Bool = Map.__eq(Map.filterWithKey((k, v) -> k == v, Map#{}), Map#{}) == true
 
 @test
-def filterWithKey02(): Bool = assert!(Map.__eq(Map.filterWithKey((k, v) -> k == v, Map#{1 -> 1}), Map#{1 -> 1}))
+def filterWithKey02(): Bool = Map.__eq(Map.filterWithKey((k, v) -> k == v, Map#{1 -> 1}), Map#{1 -> 1}) == true
 
 @test
-def filterWithKey03(): Bool = assert!(Map.__eq(Map.filterWithKey((k, v) -> k == v, Map#{1 -> 3}), Map#{}))
+def filterWithKey03(): Bool = Map.__eq(Map.filterWithKey((k, v) -> k == v, Map#{1 -> 3}), Map#{}) == true
 
 @test
-def filterWithKey04(): Bool = assert!(Map.__eq(Map.filterWithKey((k, v) -> k == v, Map#{1 -> 1, 2 -> 2}), Map#{1 -> 1, 2 -> 2}))
+def filterWithKey04(): Bool = Map.__eq(Map.filterWithKey((k, v) -> k == v, Map#{1 -> 1, 2 -> 2}), Map#{1 -> 1, 2 -> 2}) == true
 
 @test
-def filterWithKey05(): Bool = assert!(Map.__eq(Map.filterWithKey((k, v) -> k == v, Map#{1 -> 7, 2 -> 2}), Map#{2 -> 2}))
+def filterWithKey05(): Bool = Map.__eq(Map.filterWithKey((k, v) -> k == v, Map#{1 -> 7, 2 -> 2}), Map#{2 -> 2}) == true
 
 @test
-def filterWithKey06(): Bool = assert!(Map.__eq(Map.filterWithKey((k, v) -> k == v, Map#{1 -> 1, 2 -> 3}), Map#{1 -> 1}))
+def filterWithKey06(): Bool = Map.__eq(Map.filterWithKey((k, v) -> k == v, Map#{1 -> 1, 2 -> 3}), Map#{1 -> 1}) == true
 
 @test
-def filterWithKey07(): Bool = assert!(Map.__eq(Map.filterWithKey((k, v) -> k == v, Map#{1 -> -1, 2 -> -3}), Map#{}))
+def filterWithKey07(): Bool = Map.__eq(Map.filterWithKey((k, v) -> k == v, Map#{1 -> -1, 2 -> -3}), Map#{}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // map                                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def map01(): Bool = assert!(Map.__eq(Map.map(v -> 3*v, Map#{}), Map#{}))
+def map01(): Bool = Map.__eq(Map.map(v -> 3*v, Map#{}), Map#{}) == true
 
 @test
-def map02(): Bool = assert!(Map.__eq(Map.map(v -> 3*v, Map#{1 -> 4}), Map#{1 -> 12}))
+def map02(): Bool = Map.__eq(Map.map(v -> 3*v, Map#{1 -> 4}), Map#{1 -> 12}) == true
 
 @test
-def map03(): Bool = assert!(Map.__eq(Map.map(v -> 3*v, Map#{2 -> -1, 0 -> 0}), Map#{2 -> -3, 0 -> 0}))
+def map03(): Bool = Map.__eq(Map.map(v -> 3*v, Map#{2 -> -1, 0 -> 0}), Map#{2 -> -3, 0 -> 0}) == true
 
 @test
-def map04(): Bool = assert!(Map.__eq(Map.map(v -> 3*v, Map#{2 -> -1, 5 -> 15, 11 -> -9}), Map#{2 -> -3, 5 -> 45, 11 -> -27}))
+def map04(): Bool = Map.__eq(Map.map(v -> 3*v, Map#{2 -> -1, 5 -> 15, 11 -> -9}), Map#{2 -> -3, 5 -> 45, 11 -> -27}) == true
 
 @test
-def map05(): Bool = assert!(Map.__eq(Map.map(v -> 3*v, Map#{2 -> -1, 5 -> 15, 11 -> -9, 8 -> 8}), Map#{2 -> -3, 5 -> 45, 11 -> -27, 8 -> 24}))
+def map05(): Bool = Map.__eq(Map.map(v -> 3*v, Map#{2 -> -1, 5 -> 15, 11 -> -9, 8 -> 8}), Map#{2 -> -3, 5 -> 45, 11 -> -27, 8 -> 24}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // mapWithKey                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def mapWithKey01(): Bool = assert!(Map.__eq(Map.mapWithKey((_, v) -> v, Map#{}), Map#{}))
+def mapWithKey01(): Bool = Map.__eq(Map.mapWithKey((_, v) -> v, Map#{}), Map#{}) == true
 
 @test
-def mapWithKey02(): Bool = assert!(Map.__eq(Map.mapWithKey((k, v) -> k + v, Map#{1 -> 4}), Map#{1 -> 5}))
+def mapWithKey02(): Bool = Map.__eq(Map.mapWithKey((k, v) -> k + v, Map#{1 -> 4}), Map#{1 -> 5}) == true
 
 @test
-def mapWithKey03(): Bool = assert!(Map.__eq(Map.mapWithKey((k, v) -> k + v, Map#{2 -> -1, 0 -> 0}), Map#{2 -> 1, 0 -> 0}))
+def mapWithKey03(): Bool = Map.__eq(Map.mapWithKey((k, v) -> k + v, Map#{2 -> -1, 0 -> 0}), Map#{2 -> 1, 0 -> 0}) == true
 
 @test
-def mapWithKey04(): Bool = assert!(Map.__eq(Map.mapWithKey((k, v) -> k + v, Map#{2 -> -1, 5 -> 15, 11 -> -9}), Map#{2 -> 1, 5 -> 20, 11 -> 2}))
+def mapWithKey04(): Bool = Map.__eq(Map.mapWithKey((k, v) -> k + v, Map#{2 -> -1, 5 -> 15, 11 -> -9}), Map#{2 -> 1, 5 -> 20, 11 -> 2}) == true
 
 @test
-def mapWithKey05(): Bool = assert!(Map.__eq(Map.mapWithKey((k, v) -> k + v, Map#{2 -> -1, 5 -> 15, 11 -> -9, 8 -> 8}),
-                                        Map#{2 -> 1, 5 -> 20, 11 -> 2, 8 -> 16}))
+def mapWithKey05(): Bool = Map.__eq(Map.mapWithKey((k, v) -> k + v, Map#{2 -> -1, 5 -> 15, 11 -> -9, 8 -> 8}),
+                                        Map#{2 -> 1, 5 -> 20, 11 -> 2, 8 -> 16}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // fold                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def fold01(): Bool = Map.fold((s, v) -> s + v, 0, Map#{}) `assertEq!` 0
+def fold01(): Bool = Map.fold((s, v) -> s + v, 0, Map#{}) == 0
 
 @test
-def fold02(): Bool = Map.fold((s, v) -> s + v, 0, Map#{1 -> 2}) `assertEq!` 2
+def fold02(): Bool = Map.fold((s, v) -> s + v, 0, Map#{1 -> 2}) == 2
 
 @test
-def fold03(): Bool = Map.fold((s, v) -> s + v, 0, Map#{1 -> 2, 3 -> 4}) `assertEq!` 6
+def fold03(): Bool = Map.fold((s, v) -> s + v, 0, Map#{1 -> 2, 3 -> 4}) == 6
 
 @test
-def fold04(): Bool = Map.fold((s, v) -> s + v, 0, Map#{1 -> 2, 3 -> 4, 5 -> 6}) `assertEq!` 12
+def fold04(): Bool = Map.fold((s, v) -> s + v, 0, Map#{1 -> 2, 3 -> 4, 5 -> 6}) == 12
 
 /////////////////////////////////////////////////////////////////////////////
 // foldWithKey                                                             //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldWithKey01(): Bool = Map.foldWithKey((k, s, v) -> k + s + v, 0, Map#{}) `assertEq!` 0
+def foldWithKey01(): Bool = Map.foldWithKey((k, s, v) -> k + s + v, 0, Map#{}) == 0
 
 @test
-def foldWithKey02(): Bool = Map.foldWithKey((k, s, v) -> k + s + v, 0, Map#{1 -> 2}) `assertEq!` 3
+def foldWithKey02(): Bool = Map.foldWithKey((k, s, v) -> k + s + v, 0, Map#{1 -> 2}) == 3
 
 @test
-def foldWithKey03(): Bool = Map.foldWithKey((k, s, v) -> k + s + v, 0, Map#{1 -> 2, 3 -> 4}) `assertEq!` 10
+def foldWithKey03(): Bool = Map.foldWithKey((k, s, v) -> k + s + v, 0, Map#{1 -> 2, 3 -> 4}) == 10
 
 @test
-def foldWithKey04(): Bool = Map.foldWithKey((k, s, v) -> k + s + v, 0, Map#{1 -> 2, 3 -> 4, 5 -> 6}) `assertEq!` 21
+def foldWithKey04(): Bool = Map.foldWithKey((k, s, v) -> k + s + v, 0, Map#{1 -> 2, 3 -> 4, 5 -> 6}) == 21
 
 /////////////////////////////////////////////////////////////////////////////
 // foldLeft                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldLeft01(): Bool = Map.foldLeft((s, v) -> s + v, 0, Map#{}) `assertEq!` 0
+def foldLeft01(): Bool = Map.foldLeft((s, v) -> s + v, 0, Map#{}) == 0
 
 @test
-def foldLeft02(): Bool = Map.foldLeft((s, v) -> s + v, 0, Map#{1 -> 2}) `assertEq!` 2
+def foldLeft02(): Bool = Map.foldLeft((s, v) -> s + v, 0, Map#{1 -> 2}) == 2
 
 @test
-def foldLeft03(): Bool = Map.foldLeft((s, v) -> s + v, 0, Map#{1 -> 2, 3 -> 4}) `assertEq!` 6
+def foldLeft03(): Bool = Map.foldLeft((s, v) -> s + v, 0, Map#{1 -> 2, 3 -> 4}) == 6
 
 @test
-def foldLeft04(): Bool = Map.foldLeft((s, v) -> s + v, 0, Map#{1 -> 2, 3 -> 4, 5 -> 6}) `assertEq!` 12
+def foldLeft04(): Bool = Map.foldLeft((s, v) -> s + v, 0, Map#{1 -> 2, 3 -> 4, 5 -> 6}) == 12
 
 /////////////////////////////////////////////////////////////////////////////
 // foldLeftWithKey                                                         //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldLeftWithKey01(): Bool = Map.foldLeftWithKey((s, k, v) -> k + s + v, 0, Map#{}) `assertEq!` 0
+def foldLeftWithKey01(): Bool = Map.foldLeftWithKey((s, k, v) -> k + s + v, 0, Map#{}) == 0
 
 @test
-def foldLeftWithKey02(): Bool = Map.foldLeftWithKey((s, k, v) -> k + s + v, 0, Map#{1 -> 2}) `assertEq!` 3
+def foldLeftWithKey02(): Bool = Map.foldLeftWithKey((s, k, v) -> k + s + v, 0, Map#{1 -> 2}) == 3
 
 @test
-def foldLeftWithKey03(): Bool = Map.foldLeftWithKey((s, k, v) -> k + s + v, 0, Map#{1 -> 2, 3 -> 4}) `assertEq!` 10
+def foldLeftWithKey03(): Bool = Map.foldLeftWithKey((s, k, v) -> k + s + v, 0, Map#{1 -> 2, 3 -> 4}) == 10
 
 @test
-def foldLeftWithKey04(): Bool = Map.foldLeftWithKey((s, k, v) -> k + s + v, 0, Map#{1 -> 2, 3 -> 4, 5 -> 6}) `assertEq!` 21
+def foldLeftWithKey04(): Bool = Map.foldLeftWithKey((s, k, v) -> k + s + v, 0, Map#{1 -> 2, 3 -> 4, 5 -> 6}) == 21
 
 /////////////////////////////////////////////////////////////////////////////
 // foldRight                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldRight01(): Bool = Map.foldRight((v, s) -> s + v, 0, Map#{}) `assertEq!` 0
+def foldRight01(): Bool = Map.foldRight((v, s) -> s + v, 0, Map#{}) == 0
 
 @test
-def foldRight02(): Bool = Map.foldRight((v, s) -> s + v, 0, Map#{1 -> 2}) `assertEq!` 2
+def foldRight02(): Bool = Map.foldRight((v, s) -> s + v, 0, Map#{1 -> 2}) == 2
 
 @test
-def foldRight03(): Bool = Map.foldRight((v, s) -> s + v, 0, Map#{1 -> 2, 3 -> 4}) `assertEq!` 6
+def foldRight03(): Bool = Map.foldRight((v, s) -> s + v, 0, Map#{1 -> 2, 3 -> 4}) == 6
 
 @test
-def foldRight04(): Bool = Map.foldRight((v, s) -> s + v, 0, Map#{1 -> 2, 3 -> 4, 5 -> 6}) `assertEq!` 12
+def foldRight04(): Bool = Map.foldRight((v, s) -> s + v, 0, Map#{1 -> 2, 3 -> 4, 5 -> 6}) == 12
 
 /////////////////////////////////////////////////////////////////////////////
 // foldRightWithKey                                                        //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldRightWithKey01(): Bool = Map.foldRightWithKey((k, v, s) -> k + s + v, 0, Map#{}) `assertEq!` 0
+def foldRightWithKey01(): Bool = Map.foldRightWithKey((k, v, s) -> k + s + v, 0, Map#{}) == 0
 
 @test
-def foldRightWithKey02(): Bool = Map.foldRightWithKey((k, v, s) -> k + s + v, 0, Map#{1 -> 2}) `assertEq!` 3
+def foldRightWithKey02(): Bool = Map.foldRightWithKey((k, v, s) -> k + s + v, 0, Map#{1 -> 2}) == 3
 
 @test
-def foldRightWithKey03(): Bool = Map.foldRightWithKey((k, v, s) -> k + s + v, 0, Map#{1 -> 2, 3 -> 4}) `assertEq!` 10
+def foldRightWithKey03(): Bool = Map.foldRightWithKey((k, v, s) -> k + s + v, 0, Map#{1 -> 2, 3 -> 4}) == 10
 
 @test
-def foldRightWithKey04(): Bool = Map.foldRightWithKey((k, v, s) -> k + s + v, 0, Map#{1 -> 2, 3 -> 4, 5 -> 6}) `assertEq!` 21
+def foldRightWithKey04(): Bool = Map.foldRightWithKey((k, v, s) -> k + s + v, 0, Map#{1 -> 2, 3 -> 4, 5 -> 6}) == 21
 
 /////////////////////////////////////////////////////////////////////////////
 // reduce                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduce01(): Bool = Map.reduce((v1, v2) -> v1 - v2, Map#{}: Map[Int32, Int32]) `assertEq!` None
+def reduce01(): Bool = Map.reduce((v1, v2) -> v1 - v2, Map#{}: Map[Int32, Int32]) == None
 
 @test
-def reduce02(): Bool = Map.reduce((v1, v2) -> v1 - v2, Map#{1 -> 2}) `assertEq!` Some(2)
+def reduce02(): Bool = Map.reduce((v1, v2) -> v1 - v2, Map#{1 -> 2}) == Some(2)
 
 @test
-def reduce03(): Bool = Map.reduce((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}) `assertEq!` Some(-1)
+def reduce03(): Bool = Map.reduce((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}) == Some(-1)
 
 @test
-def reduce04(): Bool = Map.reduce((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3, 3 -> 4}) `assertEq!` Some(-5)
+def reduce04(): Bool = Map.reduce((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3, 3 -> 4}) == Some(-5)
 
 /////////////////////////////////////////////////////////////////////////////
 // reduceWithKey                                                           //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduceWithKey01(): Bool = Map.reduceWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{}: Map[Int32, Int32]) `assertEq!` None
+def reduceWithKey01(): Bool = Map.reduceWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{}: Map[Int32, Int32]) == None
 
 @test
-def reduceWithKey02(): Bool = Map.reduceWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2}) `assertEq!` Some((1, 2))
+def reduceWithKey02(): Bool = Map.reduceWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2}) == Some((1, 2))
 
 @test
-def reduceWithKey03(): Bool = Map.reduceWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2, 2 -> 3}) `assertEq!` Some((-1, -1))
+def reduceWithKey03(): Bool = Map.reduceWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2, 2 -> 3}) == Some((-1, -1))
 
 @test
-def reduceWithKey04(): Bool = Map.reduceWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2, 2 -> 3, 3 -> 4}) `assertEq!` Some((-4, -5))
+def reduceWithKey04(): Bool = Map.reduceWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == Some((-4, -5))
 
 /////////////////////////////////////////////////////////////////////////////
 // reduceLeft                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduceLeft01(): Bool = Map.reduceLeft((v1, v2) -> v1 - v2, Map#{}: Map[Int32, Int32]) `assertEq!` None
+def reduceLeft01(): Bool = Map.reduceLeft((v1, v2) -> v1 - v2, Map#{}: Map[Int32, Int32]) == None
 
 @test
-def reduceLeft02(): Bool = Map.reduceLeft((v1, v2) -> v1 - v2, Map#{1 -> 2}) `assertEq!` Some(2)
+def reduceLeft02(): Bool = Map.reduceLeft((v1, v2) -> v1 - v2, Map#{1 -> 2}) == Some(2)
 
 @test
-def reduceLeft03(): Bool = Map.reduceLeft((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}) `assertEq!` Some(-1)
+def reduceLeft03(): Bool = Map.reduceLeft((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}) == Some(-1)
 
 @test
-def reduceLeft04(): Bool = Map.reduceLeft((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3, 3 -> 4}) `assertEq!` Some(-5)
+def reduceLeft04(): Bool = Map.reduceLeft((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3, 3 -> 4}) == Some(-5)
 
 /////////////////////////////////////////////////////////////////////////////
 // reduceLeftWithKey                                                       //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduceLeftWithKey01(): Bool = Map.reduceLeftWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{}: Map[Int32, Int32]) `assertEq!` None
+def reduceLeftWithKey01(): Bool = Map.reduceLeftWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{}: Map[Int32, Int32]) == None
 
 @test
-def reduceLeftWithKey02(): Bool = Map.reduceLeftWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2}) `assertEq!` Some((1, 2))
+def reduceLeftWithKey02(): Bool = Map.reduceLeftWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2}) == Some((1, 2))
 
 @test
-def reduceLeftWithKey03(): Bool = Map.reduceLeftWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2, 2 -> 3}) `assertEq!` Some((-1, -1))
+def reduceLeftWithKey03(): Bool = Map.reduceLeftWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2, 2 -> 3}) == Some((-1, -1))
 
 @test
-def reduceLeftWithKey04(): Bool = Map.reduceLeftWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2, 2 -> 3, 3 -> 4}) `assertEq!` Some((-4, -5))
+def reduceLeftWithKey04(): Bool = Map.reduceLeftWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == Some((-4, -5))
 
 /////////////////////////////////////////////////////////////////////////////
 // reduceRight                                                             //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduceRight01(): Bool = Map.reduceRight((v1, v2) -> v1 - v2, Map#{}: Map[Int32, Int32]) `assertEq!` None
+def reduceRight01(): Bool = Map.reduceRight((v1, v2) -> v1 - v2, Map#{}: Map[Int32, Int32]) == None
 
 @test
-def reduceRight02(): Bool = Map.reduceRight((v1, v2) -> v1 - v2, Map#{1 -> 2}) `assertEq!` Some(2)
+def reduceRight02(): Bool = Map.reduceRight((v1, v2) -> v1 - v2, Map#{1 -> 2}) == Some(2)
 
 @test
-def reduceRight03(): Bool = Map.reduceRight((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}) `assertEq!` Some(-1)
+def reduceRight03(): Bool = Map.reduceRight((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}) == Some(-1)
 
 @test
-def reduceRight04(): Bool = Map.reduceRight((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3, 3 -> 4}) `assertEq!` Some(3)
+def reduceRight04(): Bool = Map.reduceRight((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3, 3 -> 4}) == Some(3)
 
 /////////////////////////////////////////////////////////////////////////////
 // reduceRightWithKey                                                      //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduceRightWithKey01(): Bool = Map.reduceRightWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{}: Map[Int32, Int32]) `assertEq!` None
+def reduceRightWithKey01(): Bool = Map.reduceRightWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{}: Map[Int32, Int32]) == None
 
 @test
-def reduceRightWithKey02(): Bool = Map.reduceRightWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2}) `assertEq!` Some((1, 2))
+def reduceRightWithKey02(): Bool = Map.reduceRightWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2}) == Some((1, 2))
 
 @test
-def reduceRightWithKey03(): Bool = Map.reduceRightWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2, 2 -> 3}) `assertEq!` Some((-1, -1))
+def reduceRightWithKey03(): Bool = Map.reduceRightWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2, 2 -> 3}) == Some((-1, -1))
 
 @test
-def reduceRightWithKey04(): Bool = Map.reduceRightWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2, 2 -> 3, 3 -> 4}) `assertEq!` Some((2 , 3))
+def reduceRightWithKey04(): Bool = Map.reduceRightWithKey((k1, v1, k2, v2) -> (k1 - k2, v1 - v2), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == Some((2 , 3))
 
 /////////////////////////////////////////////////////////////////////////////
 // count                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def count01(): Bool = Map.count((k, v) -> k == v, Map#{}) `assertEq!` 0
+def count01(): Bool = Map.count((k, v) -> k == v, Map#{}) == 0
 
 @test
-def count02(): Bool = Map.count((k, v) -> k == v, Map#{1 -> 2}) `assertEq!` 0
+def count02(): Bool = Map.count((k, v) -> k == v, Map#{1 -> 2}) == 0
 
 @test
-def count03(): Bool = Map.count((k, v) -> k == v, Map#{1 -> 1}) `assertEq!` 1
+def count03(): Bool = Map.count((k, v) -> k == v, Map#{1 -> 1}) == 1
 
 @test
-def count04(): Bool = Map.count((k, v) -> k == v, Map#{1 -> 2, 2 -> 3}) `assertEq!` 0
+def count04(): Bool = Map.count((k, v) -> k == v, Map#{1 -> 2, 2 -> 3}) == 0
 
 @test
-def count05(): Bool = Map.count((k, v) -> k == v, Map#{1 -> 1, 2 -> 3}) `assertEq!` 1
+def count05(): Bool = Map.count((k, v) -> k == v, Map#{1 -> 1, 2 -> 3}) == 1
 
 @test
-def count06(): Bool = Map.count((k, v) -> k == v, Map#{1 -> 2, 2 -> 2}) `assertEq!` 1
+def count06(): Bool = Map.count((k, v) -> k == v, Map#{1 -> 2, 2 -> 2}) == 1
 
 @test
-def count07(): Bool = Map.count((k, v) -> k == v, Map#{1 -> 1, 2 -> 2}) `assertEq!` 2
+def count07(): Bool = Map.count((k, v) -> k == v, Map#{1 -> 1, 2 -> 2}) == 2
 
 /////////////////////////////////////////////////////////////////////////////
 // exists                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def exists01(): Bool = assertNot!(Map.exists((k, v) -> k == v, Map#{}))
+def exists01(): Bool = Map.exists((k, v) -> k == v, Map#{}) == false
 
 @test
-def exists02(): Bool = assertNot!(Map.exists((k, v) -> k == v, Map#{1 -> 2}))
+def exists02(): Bool = Map.exists((k, v) -> k == v, Map#{1 -> 2}) == false
 
 @test
-def exists03(): Bool = assert!(Map.exists((k, v) -> k == v, Map#{1 -> 1}))
+def exists03(): Bool = Map.exists((k, v) -> k == v, Map#{1 -> 1}) == true
 
 @test
-def exists04(): Bool = assertNot!(Map.exists((k, v) -> k == v, Map#{1 -> 2, 2 -> 3}))
+def exists04(): Bool = Map.exists((k, v) -> k == v, Map#{1 -> 2, 2 -> 3}) == false
 
 @test
-def exists05(): Bool = assert!(Map.exists((k, v) -> k == v, Map#{1 -> 1, 2 -> 3}))
+def exists05(): Bool = Map.exists((k, v) -> k == v, Map#{1 -> 1, 2 -> 3}) == true
 
 @test
-def exists06(): Bool = assert!(Map.exists((k, v) -> k == v, Map#{1 -> 2, 2 -> 2}))
+def exists06(): Bool = Map.exists((k, v) -> k == v, Map#{1 -> 2, 2 -> 2}) == true
 
 @test
-def exists07(): Bool = assert!(Map.exists((k, v) -> k == v, Map#{1 -> 1, 2 -> 2}))
+def exists07(): Bool = Map.exists((k, v) -> k == v, Map#{1 -> 1, 2 -> 2}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // forall                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def forall01(): Bool = assert!(Map.forall((k, v) -> k == v, Map#{}))
+def forall01(): Bool = Map.forall((k, v) -> k == v, Map#{}) == true
 
 @test
-def forall02(): Bool = assertNot!(Map.forall((k, v) -> k == v, Map#{1 -> 2}))
+def forall02(): Bool = Map.forall((k, v) -> k == v, Map#{1 -> 2}) == false
 
 @test
-def forall03(): Bool = assert!(Map.forall((k, v) -> k == v, Map#{1 -> 1}))
+def forall03(): Bool = Map.forall((k, v) -> k == v, Map#{1 -> 1}) == true
 
 @test
-def forall04(): Bool = assertNot!(Map.forall((k, v) -> k == v, Map#{1 -> 2, 2 -> 3}))
+def forall04(): Bool = Map.forall((k, v) -> k == v, Map#{1 -> 2, 2 -> 3}) == false
 
 @test
-def forall05(): Bool = assertNot!(Map.forall((k, v) -> k == v, Map#{1 -> 1, 2 -> 3}))
+def forall05(): Bool = Map.forall((k, v) -> k == v, Map#{1 -> 1, 2 -> 3}) == false
 
 @test
-def forall06(): Bool = assertNot!(Map.forall((k, v) -> k == v, Map#{1 -> 2, 2 -> 2}))
+def forall06(): Bool = Map.forall((k, v) -> k == v, Map#{1 -> 2, 2 -> 2}) == false
 
 @test
-def forall07(): Bool = assert!(Map.forall((k, v) -> k == v, Map#{1 -> 1, 2 -> 2}))
+def forall07(): Bool = Map.forall((k, v) -> k == v, Map#{1 -> 1, 2 -> 2}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // union                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def union01(): Bool = assert!(Map.__eq(Map.union(Map#{}, Map#{}), Map#{}))
+def union01(): Bool = Map.__eq(Map.union(Map#{}, Map#{}), Map#{}) == true
 
 @test
-def union02(): Bool = assert!(Map.__eq(Map.union(Map#{1 -> 2}, Map#{}), Map#{1 -> 2}))
+def union02(): Bool = Map.__eq(Map.union(Map#{1 -> 2}, Map#{}), Map#{1 -> 2}) == true
 
 @test
-def union03(): Bool = assert!(Map.__eq(Map.union(Map#{}, Map#{1 -> 2}), Map#{1 -> 2}))
+def union03(): Bool = Map.__eq(Map.union(Map#{}, Map#{1 -> 2}), Map#{1 -> 2}) == true
 
 @test
-def union04(): Bool = assert!(Map.__eq(Map.union(Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{1 -> 2, 3 -> 4}))
+def union04(): Bool = Map.__eq(Map.union(Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{1 -> 2, 3 -> 4}) == true
 
 @test
-def union05(): Bool = assert!(Map.__eq(Map.union(Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{1 -> 2, 3 -> 4}))
+def union05(): Bool = Map.__eq(Map.union(Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{1 -> 2, 3 -> 4}) == true
 
 @test
-def union06(): Bool = assert!(Map.__eq(Map.union(Map#{1 -> 2}, Map#{3 -> 4}), Map#{1 -> 2, 3 -> 4}))
+def union06(): Bool = Map.__eq(Map.union(Map#{1 -> 2}, Map#{3 -> 4}), Map#{1 -> 2, 3 -> 4}) == true
 
 @test
-def union07(): Bool = assert!(Map.__eq(Map.union(Map#{1 -> 2}, Map#{1 -> 5}), Map#{1 -> 2}))
+def union07(): Bool = Map.__eq(Map.union(Map#{1 -> 2}, Map#{1 -> 5}), Map#{1 -> 2}) == true
 
 @test
-def union08(): Bool = assert!(Map.__eq(Map.union(Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{1 -> 2, 2 -> 3, 3 -> 4}))
+def union08(): Bool = Map.__eq(Map.union(Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == true
 
 @test
-def union09(): Bool = assert!(Map.__eq(Map.union(Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{1 -> 2, 2 -> 3, 3 -> 4}))
+def union09(): Bool = Map.__eq(Map.union(Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == true
 
 @test
-def union10(): Bool = assert!(Map.__eq(Map.union(Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{1 -> 2, 2 -> 3, 3 -> 4}))
+def union10(): Bool = Map.__eq(Map.union(Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == true
 
 @test
-def union11(): Bool = assert!(Map.__eq(Map.union(Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2, 2 -> 3, 3 -> 4}))
+def union11(): Bool = Map.__eq(Map.union(Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == true
 
 @test
-def union12(): Bool = assert!(Map.__eq(Map.union(Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{1 -> 2, 2 -> 3}))
+def union12(): Bool = Map.__eq(Map.union(Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{1 -> 2, 2 -> 3}) == true
 
 @test
-def union13(): Bool = assert!(Map.__eq(Map.union(Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> 2, 2 -> 3}))
+def union13(): Bool = Map.__eq(Map.union(Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> 2, 2 -> 3}) == true
 
 @test
-def union14(): Bool = assert!(Map.__eq(Map.union(Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 4, 2 -> 3}))
+def union14(): Bool = Map.__eq(Map.union(Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 4, 2 -> 3}) == true
 
 @test
-def union15(): Bool = assert!(Map.__eq(Map.union(Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2, 2 -> 7}))
+def union15(): Bool = Map.__eq(Map.union(Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2, 2 -> 7}) == true
 
 @test
-def union16(): Bool = assert!(Map.__eq(Map.union(Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33}),
-                                   Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22, 1 -> 2, 44 -> 33}))
+def union16(): Bool = Map.__eq(Map.union(Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33}),
+                                   Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22, 1 -> 2, 44 -> 33}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // unionWith                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def unionWith01(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{}, Map#{}), Map#{}: Map[Int, Int]))
+def unionWith01(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{}, Map#{}), Map#{}: Map[Int, Int]) == true
 
 @test
-def unionWith02(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2}, Map#{}), Map#{1 -> 2}))
+def unionWith02(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2}, Map#{}), Map#{1 -> 2}) == true
 
 @test
-def unionWith03(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{}, Map#{1 -> 2}), Map#{1 -> 2}))
+def unionWith03(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{}, Map#{1 -> 2}), Map#{1 -> 2}) == true
 
 @test
-def unionWith04(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{1 -> 2, 3 -> 4}))
+def unionWith04(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{1 -> 2, 3 -> 4}) == true
 
 @test
-def unionWith05(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{1 -> 2, 3 -> 4}))
+def unionWith05(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{1 -> 2, 3 -> 4}) == true
 
 @test
-def unionWith06(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2}, Map#{3 -> 4}), Map#{1 -> 2, 3 -> 4}))
+def unionWith06(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2}, Map#{3 -> 4}), Map#{1 -> 2, 3 -> 4}) == true
 
 @test
-def unionWith07(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2}, Map#{1 -> 5}), Map#{1 -> -3}))
+def unionWith07(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2}, Map#{1 -> 5}), Map#{1 -> -3}) == true
 
 @test
-def unionWith08(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{1 -> 2, 2 -> 3, 3 -> 4}))
+def unionWith08(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == true
 
 @test
-def unionWith09(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{1 -> 2, 2 -> 3, 3 -> 4}))
+def unionWith09(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == true
 
 @test
-def unionWith10(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{1 -> 2, 2 -> 3, 3 -> 4}))
+def unionWith10(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == true
 
 @test
-def unionWith11(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2, 2 -> 3, 3 -> 4}))
+def unionWith11(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == true
 
 @test
-def unionWith12(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{1 -> 2, 2 -> -5}))
+def unionWith12(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{1 -> 2, 2 -> -5}) == true
 
 @test
-def unionWith13(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> -6, 2 -> 3}))
+def unionWith13(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> -6, 2 -> 3}) == true
 
 @test
-def unionWith14(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2, 2 -> 3}))
+def unionWith14(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2, 2 -> 3}) == true
 
 @test
-def unionWith15(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2, 2 -> 4}))
+def unionWith15(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2, 2 -> 4}) == true
 
 @test
-def unionWith16(): Bool = assert!(Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33}),
-                                   Map#{2 -> -1, 11 -> 14, 9 -> 8, 15 -> 1, 1 -> 2, 44 -> 33}))
+def unionWith16(): Bool = Map.__eq(Map.unionWith((v1, v2) -> v1 - v2, Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33}),
+                                   Map#{2 -> -1, 11 -> 14, 9 -> 8, 15 -> 1, 1 -> 2, 44 -> 33}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // unionWithKey                                                            //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def unionWithKey01(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{}), Map#{}: Map[Int, Int]))
+def unionWithKey01(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{}), Map#{}: Map[Int, Int]) == true
 
 @test
-def unionWithKey02(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2}, Map#{}), Map#{1 -> 2}))
+def unionWithKey02(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2}, Map#{}), Map#{1 -> 2}) == true
 
 @test
-def unionWithKey03(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{1 -> 2}), Map#{1 -> 2}))
+def unionWithKey03(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{1 -> 2}), Map#{1 -> 2}) == true
 
 @test
-def unionWithKey04(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{1 -> 2, 3 -> 4}))
+def unionWithKey04(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{1 -> 2, 3 -> 4}) == true
 
 @test
-def unionWithKey05(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{1 -> 2, 3 -> 4}))
+def unionWithKey05(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{1 -> 2, 3 -> 4}) == true
 
 @test
-def unionWithKey06(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2}, Map#{3 -> 4}), Map#{1 -> 2, 3 -> 4}))
+def unionWithKey06(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2}, Map#{3 -> 4}), Map#{1 -> 2, 3 -> 4}) == true
 
 @test
-def unionWithKey07(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2}, Map#{1 -> 5}), Map#{1 -> -2}))
+def unionWithKey07(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2}, Map#{1 -> 5}), Map#{1 -> -2}) == true
 
 @test
-def unionWithKey08(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{1 -> 2, 2 -> 3, 3 -> 4}))
+def unionWithKey08(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == true
 
 @test
-def unionWithKey09(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{1 -> 2, 2 -> 3, 3 -> 4}))
+def unionWithKey09(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == true
 
 @test
-def unionWithKey10(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{1 -> 2, 2 -> 3, 3 -> 4}))
+def unionWithKey10(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == true
 
 @test
-def unionWithKey11(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2, 2 -> 3, 3 -> 4}))
+def unionWithKey11(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == true
 
 @test
-def unionWithKey12(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{1 -> 2, 2 -> -3}))
+def unionWithKey12(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{1 -> 2, 2 -> -3}) == true
 
 @test
-def unionWithKey13(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> -5, 2 -> 3}))
+def unionWithKey13(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> -5, 2 -> 3}) == true
 
 @test
-def unionWithKey14(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 3, 2 -> 3}))
+def unionWithKey14(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 3, 2 -> 3}) == true
 
 @test
-def unionWithKey15(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2, 2 -> 6}))
+def unionWithKey15(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2, 2 -> 6}) == true
 
 @test
-def unionWithKey16(): Bool = assert!(Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33}),
-                                   Map#{2 -> 1, 11 -> 14, 9 -> 8, 15 -> 16, 1 -> 2, 44 -> 33}))
+def unionWithKey16(): Bool = Map.__eq(Map.unionWithKey((k, v1, v2) -> k + v1 - v2, Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33}),
+                                   Map#{2 -> 1, 11 -> 14, 9 -> 8, 15 -> 16, 1 -> 2, 44 -> 33})== true
 
 /////////////////////////////////////////////////////////////////////////////
 // intersection                                                            //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def intersection01(): Bool = assert!(Map.__eq(Map.intersection(Map#{}, Map#{}), Map#{}))
+def intersection01(): Bool = Map.__eq(Map.intersection(Map#{}, Map#{}), Map#{}) == true
 
 @test
-def intersection02(): Bool = assert!(Map.__eq(Map.intersection(Map#{1 -> 2}, Map#{}), Map#{}))
+def intersection02(): Bool = Map.__eq(Map.intersection(Map#{1 -> 2}, Map#{}), Map#{}) == true
 
 @test
-def intersection03(): Bool = assert!(Map.__eq(Map.intersection(Map#{}, Map#{1 -> 2}), Map#{}))
+def intersection03(): Bool = Map.__eq(Map.intersection(Map#{}, Map#{1 -> 2}), Map#{}) == true
 
 @test
-def intersection04(): Bool = assert!(Map.__eq(Map.intersection(Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{}))
+def intersection04(): Bool = Map.__eq(Map.intersection(Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{}) == true
 
 @test
-def intersection05(): Bool = assert!(Map.__eq(Map.intersection(Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{}))
+def intersection05(): Bool = Map.__eq(Map.intersection(Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{}) == true
 
 @test
-def intersection06(): Bool = assert!(Map.__eq(Map.intersection(Map#{1 -> 2}, Map#{3 -> 4}), Map#{}))
+def intersection06(): Bool = Map.__eq(Map.intersection(Map#{1 -> 2}, Map#{3 -> 4}), Map#{}) == true
 
 @test
-def intersection07(): Bool = assert!(Map.__eq(Map.intersection(Map#{1 -> 2}, Map#{1 -> 5}), Map#{1 -> 2}))
+def intersection07(): Bool = Map.__eq(Map.intersection(Map#{1 -> 2}, Map#{1 -> 5}), Map#{1 -> 2}) == true
 
 @test
-def intersection08(): Bool = assert!(Map.__eq(Map.intersection(Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{}))
+def intersection08(): Bool = Map.__eq(Map.intersection(Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{}) == true
 
 @test
-def intersection09(): Bool = assert!(Map.__eq(Map.intersection(Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{}))
+def intersection09(): Bool = Map.__eq(Map.intersection(Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{}) == true
 
 @test
-def intersection10(): Bool = assert!(Map.__eq(Map.intersection(Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{}))
+def intersection10(): Bool = Map.__eq(Map.intersection(Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{}) == true
 
 @test
-def intersection11(): Bool = assert!(Map.__eq(Map.intersection(Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{}))
+def intersection11(): Bool = Map.__eq(Map.intersection(Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{}) == true
 
 @test
-def intersection12(): Bool = assert!(Map.__eq(Map.intersection(Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{2 -> 3}))
+def intersection12(): Bool = Map.__eq(Map.intersection(Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{2 -> 3}) == true
 
 @test
-def intersection13(): Bool = assert!(Map.__eq(Map.intersection(Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> 2}))
+def intersection13(): Bool = Map.__eq(Map.intersection(Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> 2}) == true
 
 @test
-def intersection14(): Bool = assert!(Map.__eq(Map.intersection(Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 4}))
+def intersection14(): Bool = Map.__eq(Map.intersection(Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 4}) == true
 
 @test
-def intersection15(): Bool = assert!(Map.__eq(Map.intersection(Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{2 -> 7}))
+def intersection15(): Bool = Map.__eq(Map.intersection(Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{2 -> 7}) == true
 
 @test
-def intersection16(): Bool = assert!(Map.__eq(Map.intersection(Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33, 11 -> 1}),
-                                   Map#{2 -> 7, 15 -> 22, 11 -> 14}))
+def intersection16(): Bool = Map.__eq(Map.intersection(Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33, 11 -> 1}),
+                                   Map#{2 -> 7, 15 -> 22, 11 -> 14}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // intersectionWith                                                        //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def intersectionWith01(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{}, Map#{}), Map#{}: Map[Int, Int]))
+def intersectionWith01(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{}, Map#{}), Map#{}: Map[Int, Int]) == true
 
 @test
-def intersectionWith02(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2}, Map#{}), Map#{}))
+def intersectionWith02(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2}, Map#{}), Map#{}) == true
 
 @test
-def intersectionWith03(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{}, Map#{1 -> 2}), Map#{}))
+def intersectionWith03(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{}, Map#{1 -> 2}), Map#{}) == true
 
 @test
-def intersectionWith04(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{}))
+def intersectionWith04(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{}) == true
 
 @test
-def intersectionWith05(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{}))
+def intersectionWith05(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{}) == true
 
 @test
-def intersectionWith06(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2}, Map#{3 -> 4}), Map#{}))
+def intersectionWith06(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2}, Map#{3 -> 4}), Map#{}) == true
 
 @test
-def intersectionWith07(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2}, Map#{1 -> 5}), Map#{1 -> -3}))
+def intersectionWith07(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2}, Map#{1 -> 5}), Map#{1 -> -3}) == true
 
 @test
-def intersectionWith08(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{}))
+def intersectionWith08(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{}) == true
 
 @test
-def intersectionWith09(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{}))
+def intersectionWith09(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{}) == true
 
 @test
-def intersectionWith10(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{}))
+def intersectionWith10(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{}) == true
 
 @test
-def intersectionWith11(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{}))
+def intersectionWith11(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{}) == true
 
 @test
-def intersectionWith12(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{2 -> -5}))
+def intersectionWith12(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{2 -> -5}) == true
 
 @test
-def intersectionWith13(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> -6}))
+def intersectionWith13(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> -6}) == true
 
 @test
-def intersectionWith14(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2}))
+def intersectionWith14(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 2}) == true
 
 @test
-def intersectionWith15(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{2 -> 4}))
+def intersectionWith15(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{2 -> 4}) == true
 
 @test
-def intersectionWith16(): Bool = assert!(Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33, 11 -> 11}),
-                                   Map#{2 -> -1, 15 -> 1, 11 -> 3}))
+def intersectionWith16(): Bool = Map.__eq(Map.intersectionWith((v1, v2) -> v1 - v2, Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33, 11 -> 11}),
+                                   Map#{2 -> -1, 15 -> 1, 11 -> 3}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // intersectionWithKey                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def intersectionWithKey01(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{}), Map#{}: Map[Int, Int]))
+def intersectionWithKey01(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{}), Map#{}: Map[Int, Int]) == true
 
 @test
-def intersectionWithKey02(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2}, Map#{}), Map#{}))
+def intersectionWithKey02(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2}, Map#{}), Map#{}) == true
 
 @test
-def intersectionWithKey03(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{1 -> 2}), Map#{}))
+def intersectionWithKey03(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{1 -> 2}), Map#{}) == true
 
 @test
-def intersectionWithKey04(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{}))
+def intersectionWithKey04(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{}) == true
 
 @test
-def intersectionWithKey05(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{}))
+def intersectionWithKey05(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{}) == true
 
 @test
-def intersectionWithKey06(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2}, Map#{3 -> 4}), Map#{}))
+def intersectionWithKey06(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2}, Map#{3 -> 4}), Map#{}) == true
 
 @test
-def intersectionWithKey07(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2}, Map#{1 -> 5}), Map#{1 -> -2}))
+def intersectionWithKey07(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2}, Map#{1 -> 5}), Map#{1 -> -2}) == true
 
 @test
-def intersectionWithKey08(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{}))
+def intersectionWithKey08(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{}) == true
 
 @test
-def intersectionWithKey09(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{}))
+def intersectionWithKey09(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{}) == true
 
 @test
-def intersectionWithKey10(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{}))
+def intersectionWithKey10(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{}) == true
 
 @test
-def intersectionWithKey11(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{}))
+def intersectionWithKey11(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{}) == true
 
 @test
-def intersectionWithKey12(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{2 -> -3}))
+def intersectionWithKey12(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{2 -> -3}) == true
 
 @test
-def intersectionWithKey13(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> -5}))
+def intersectionWithKey13(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> -5}) == true
 
 @test
-def intersectionWithKey14(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 3}))
+def intersectionWithKey14(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 3}) == true
 
 @test
-def intersectionWithKey15(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{2 -> 6}))
+def intersectionWithKey15(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{2 -> 6}) == true
 
 @test
-def intersectionWithKey16(): Bool = assert!(Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33, 11 -> 17}),
-                                   Map#{2 -> 1, 15 -> 16, 11 -> 8}))
+def intersectionWithKey16(): Bool = Map.__eq(Map.intersectionWithKey((k, v1, v2) -> k + v1 - v2, Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33, 11 -> 17}),
+                                   Map#{2 -> 1, 15 -> 16, 11 -> 8}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // difference                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def difference01(): Bool = assert!(Map.__eq(Map.difference(Map#{}, Map#{}), Map#{}))
+def difference01(): Bool = Map.__eq(Map.difference(Map#{}, Map#{}), Map#{}) == true
 
 @test
-def difference02(): Bool = assert!(Map.__eq(Map.difference(Map#{1 -> 2}, Map#{}), Map#{1 -> 2}))
+def difference02(): Bool = Map.__eq(Map.difference(Map#{1 -> 2}, Map#{}), Map#{1 -> 2}) == true
 
 @test
-def difference03(): Bool = assert!(Map.__eq(Map.difference(Map#{}, Map#{1 -> 2}), Map#{}))
+def difference03(): Bool = Map.__eq(Map.difference(Map#{}, Map#{1 -> 2}), Map#{}) == true
 
 @test
-def difference04(): Bool = assert!(Map.__eq(Map.difference(Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{}))
+def difference04(): Bool = Map.__eq(Map.difference(Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{}) == true
 
 @test
-def difference05(): Bool = assert!(Map.__eq(Map.difference(Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{1 -> 2, 3 -> 4}))
+def difference05(): Bool = Map.__eq(Map.difference(Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{1 -> 2, 3 -> 4}) == true
 
 @test
-def difference06(): Bool = assert!(Map.__eq(Map.difference(Map#{1 -> 2}, Map#{3 -> 4}), Map#{1 -> 2}))
+def difference06(): Bool = Map.__eq(Map.difference(Map#{1 -> 2}, Map#{3 -> 4}), Map#{1 -> 2}) == true
 
 @test
-def difference07(): Bool = assert!(Map.__eq(Map.difference(Map#{1 -> 2}, Map#{1 -> 5}), Map#{}))
+def difference07(): Bool = Map.__eq(Map.difference(Map#{1 -> 2}, Map#{1 -> 5}), Map#{}) == true
 
 @test
-def difference08(): Bool = assert!(Map.__eq(Map.difference(Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{}))
+def difference08(): Bool = Map.__eq(Map.difference(Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{}) == true
 
 @test
-def difference09(): Bool = assert!(Map.__eq(Map.difference(Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{1 -> 2, 2 -> 3, 3 -> 4}))
+def difference09(): Bool = Map.__eq(Map.difference(Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == true
 
 @test
-def difference10(): Bool = assert!(Map.__eq(Map.difference(Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{1 -> 2, 2 -> 3}))
+def difference10(): Bool = Map.__eq(Map.difference(Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{1 -> 2, 2 -> 3}) == true
 
 @test
-def difference11(): Bool = assert!(Map.__eq(Map.difference(Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{3 -> 4}))
+def difference11(): Bool = Map.__eq(Map.difference(Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{3 -> 4}) == true
 
 @test
-def difference12(): Bool = assert!(Map.__eq(Map.difference(Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{1 -> 2}))
+def difference12(): Bool = Map.__eq(Map.difference(Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{1 -> 2}) == true
 
 @test
-def difference13(): Bool = assert!(Map.__eq(Map.difference(Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{2 -> 3}))
+def difference13(): Bool = Map.__eq(Map.difference(Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{2 -> 3}) == true
 
 @test
-def difference14(): Bool = assert!(Map.__eq(Map.difference(Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{}))
+def difference14(): Bool = Map.__eq(Map.difference(Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{}) == true
 
 @test
-def difference15(): Bool = assert!(Map.__eq(Map.difference(Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{}))
+def difference15(): Bool = Map.__eq(Map.difference(Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{}) == true
 
 @test
-def difference16(): Bool = assert!(Map.__eq(Map.difference(Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33}),
-                                   Map#{11 -> 14, 9 -> 8}))
+def difference16(): Bool = Map.__eq(Map.difference(Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33}),
+                                   Map#{11 -> 14, 9 -> 8}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // differenceWith                                                          //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def differenceWith01(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{}, Map#{}), Map#{}: Map[Int, Int]))
+def differenceWith01(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{}, Map#{}), Map#{}: Map[Int, Int]) == true
 
 @test
-def differenceWith02(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2}, Map#{}), Map#{1 -> 2}))
+def differenceWith02(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2}, Map#{}), Map#{1 -> 2}) == true
 
 @test
-def differenceWith03(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{}, Map#{1 -> 2}), Map#{}))
+def differenceWith03(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{}, Map#{1 -> 2}), Map#{}) == true
 
 @test
-def differenceWith04(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{}))
+def differenceWith04(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{}) == true
 
 @test
-def differenceWith05(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{1 -> 2, 3 -> 4}))
+def differenceWith05(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{1 -> 2, 3 -> 4}) == true
 
 @test
-def differenceWith06(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2}, Map#{3 -> 4}), Map#{1 -> 2}))
+def differenceWith06(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2}, Map#{3 -> 4}), Map#{1 -> 2}) == true
 
 @test
-def differenceWith07(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2}, Map#{1 -> 5}), Map#{}))
+def differenceWith07(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2}, Map#{1 -> 5}), Map#{}) == true
 
 @test
-def differenceWith08(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 5}, Map#{1 -> 4}), Map#{1 -> 5}))
+def differenceWith08(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 5}, Map#{1 -> 4}), Map#{1 -> 5}) == true
 
 @test
-def differenceWith09(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{}))
+def differenceWith09(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{}) == true
 
 @test
-def differenceWith10(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{1 -> 2, 2 -> 3, 3 -> 4}))
+def differenceWith10(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == true
 
 @test
-def differenceWith11(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{1 -> 2, 2 -> 3}))
+def differenceWith11(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{1 -> 2, 2 -> 3}) == true
 
 @test
-def differenceWith12(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{3 -> 4}))
+def differenceWith12(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{3 -> 4}) == true
 
 @test
-def differenceWith13(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{1 -> 2}))
+def differenceWith13(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{1 -> 2}) == true
 
 @test
-def differenceWith14(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2, 2 -> 9}, Map#{2 -> 8}), Map#{1 -> 2, 2 -> 9}))
+def differenceWith14(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2, 2 -> 9}, Map#{2 -> 8}), Map#{1 -> 2, 2 -> 9}) == true
 
 @test
-def differenceWith15(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{2 -> 3}))
+def differenceWith15(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{2 -> 3}) == true
 
 @test
-def differenceWith16(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 9, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> 9, 2 -> 3}))
+def differenceWith16(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 9, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> 9, 2 -> 3}) == true
 
 @test
-def differenceWith17(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 1}, Map#{1 -> 2, 2 -> 3}), Map#{}))
+def differenceWith17(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 1}, Map#{1 -> 2, 2 -> 3}), Map#{}) == true
 
 @test
-def differenceWith18(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 4}))
+def differenceWith18(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 4}) == true
 
 @test
-def differenceWith19(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{2 -> -4}, Map#{1 -> 2, 2 -> 3}), Map#{}))
+def differenceWith19(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{2 -> -4}, Map#{1 -> 2, 2 -> 3}), Map#{}) == true
 
 @test
-def differenceWith20(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{2 -> 7}))
+def differenceWith20(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{2 -> 7}) == true
 
 @test
-def differenceWith21(): Bool = assert!(Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33}),
-                                   Map#{11 -> 14, 9 -> 8, 15 -> 22}))
+def differenceWith21(): Bool = Map.__eq(Map.differenceWith((v1, v2) -> if (v1 > v2) Some(v1) else None, Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33}),
+                                   Map#{11 -> 14, 9 -> 8, 15 -> 22}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // differenceWithKey                                                       //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def differenceWithKey01(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{}, Map#{}), Map#{}: Map[Int, Int]))
+def differenceWithKey01(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{}, Map#{}), Map#{}: Map[Int, Int]) == true
 
 @test
-def differenceWithKey02(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2}, Map#{}), Map#{1 -> 2}))
+def differenceWithKey02(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2}, Map#{}), Map#{1 -> 2}) == true
 
 @test
-def differenceWithKey03(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{}, Map#{1 -> 2}), Map#{}))
+def differenceWithKey03(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{}, Map#{1 -> 2}), Map#{}) == true
 
 @test
-def differenceWithKey04(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{}))
+def differenceWithKey04(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{}, Map#{1 -> 2, 3 -> 4}), Map#{}) == true
 
 @test
-def differenceWithKey05(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{1 -> 2, 3 -> 4}))
+def differenceWithKey05(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2, 3 -> 4}, Map#{}), Map#{1 -> 2, 3 -> 4}) == true
 
 @test
-def differenceWithKey06(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2}, Map#{3 -> 4}), Map#{1 -> 2}))
+def differenceWithKey06(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2}, Map#{3 -> 4}), Map#{1 -> 2}) == true
 
 @test
-def differenceWithKey07(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2}, Map#{1 -> 5}), Map#{}))
+def differenceWithKey07(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2}, Map#{1 -> 5}), Map#{}) == true
 
 @test
-def differenceWithKey08(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 5}, Map#{1 -> 4}), Map#{1 -> 6}))
+def differenceWithKey08(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 5}, Map#{1 -> 4}), Map#{1 -> 6}) == true
 
 @test
-def differenceWithKey09(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{}))
+def differenceWithKey09(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{}, Map#{1 -> 2, 2 -> 3, 3 -> 4}), Map#{}) == true
 
 @test
-def differenceWithKey10(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{1 -> 2, 2 -> 3, 3 -> 4}))
+def differenceWithKey10(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2, 2 -> 3, 3 -> 4}, Map#{}), Map#{1 -> 2, 2 -> 3, 3 -> 4}) == true
 
 @test
-def differenceWithKey11(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{1 -> 2, 2 -> 3}))
+def differenceWithKey11(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2, 2 -> 3}, Map#{3 -> 4}), Map#{1 -> 2, 2 -> 3}) == true
 
 @test
-def differenceWithKey12(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{3 -> 4}))
+def differenceWithKey12(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{3 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{3 -> 4}) == true
 
 @test
-def differenceWithKey13(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{1 -> 2}))
+def differenceWithKey13(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2, 2 -> 3}, Map#{2 -> 8}), Map#{1 -> 2}) == true
 
 @test
-def differenceWithKey14(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2, 2 -> 9}, Map#{2 -> 8}), Map#{1 -> 2, 2 -> 11}))
+def differenceWithKey14(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2, 2 -> 9}, Map#{2 -> 8}), Map#{1 -> 2, 2 -> 11}) == true
 
 @test
-def differenceWithKey15(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{2 -> 3}))
+def differenceWithKey15(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 2, 2 -> 3}, Map#{1 -> 8}), Map#{2 -> 3}) == true
 
 @test
-def differenceWithKey16(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 9, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> 10, 2 -> 3}))
+def differenceWithKey16(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 9, 2 -> 3}, Map#{1 -> 8}), Map#{1 -> 10, 2 -> 3}) == true
 
 @test
-def differenceWithKey17(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 1}, Map#{1 -> 2, 2 -> 3}), Map#{}))
+def differenceWithKey17(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 1}, Map#{1 -> 2, 2 -> 3}), Map#{}) == true
 
 @test
-def differenceWithKey18(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 5}))
+def differenceWithKey18(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{1 -> 4}, Map#{1 -> 2, 2 -> 3}), Map#{1 -> 5}) == true
 
 @test
-def differenceWithKey19(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{2 -> -4}, Map#{1 -> 2, 2 -> 3}), Map#{}))
+def differenceWithKey19(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{2 -> -4}, Map#{1 -> 2, 2 -> 3}), Map#{}) == true
 
 @test
-def differenceWithKey20(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{2 -> 9}))
+def differenceWithKey20(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{2 -> 7}, Map#{1 -> 2, 2 -> 3}), Map#{2 -> 9}) == true
 
 @test
-def differenceWithKey21(): Bool = assert!(Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33}),
-                                   Map#{11 -> 14, 9 -> 8, 15 -> 37}))
+def differenceWithKey21(): Bool = Map.__eq(Map.differenceWithKey((k, v1, v2) -> if (v1 > v2) Some(v1 + k) else None, Map#{2 -> 7, 11 -> 14, 9 -> 8, 15 -> 22}, Map#{15 -> 21, 1 -> 2, 2 -> 8, 44 -> 33}),
+                                   Map#{11 -> 14, 9 -> 8, 15 -> 37}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // toSet                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toSet01(): Bool = assert!(Set.__eq(Map.toSet(Map#{}), Set#{}))
+def toSet01(): Bool = Set.__eq(Map.toSet(Map#{}), Set#{}) == true
 
 @test
-def toSet02(): Bool = assert!(Set.__eq(Map.toSet(Map#{1 -> 2}), Set#{(1, 2)}))
+def toSet02(): Bool = Set.__eq(Map.toSet(Map#{1 -> 2}), Set#{(1, 2)}) == true
 
 @test
-def toSet03(): Bool = assert!(Set.__eq(Map.toSet(Map#{1 -> 2, 3 -> 4}), Set#{(1, 2), (3, 4)}))
+def toSet03(): Bool = Set.__eq(Map.toSet(Map#{1 -> 2, 3 -> 4}), Set#{(1, 2), (3, 4)}) == true
 
 @test
-def toSet04(): Bool = assert!(Set.__eq(Map.toSet(Map#{1 -> 2, 2 -> 2, 3 -> 4}), Set#{(1, 2), (2, 2), (3, 4)}))
+def toSet04(): Bool = Set.__eq(Map.toSet(Map#{1 -> 2, 2 -> 2, 3 -> 4}), Set#{(1, 2), (2, 2), (3, 4)}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // toList                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toList01(): Bool = Map.toList(Map#{}) `assertEq!` Nil
+def toList01(): Bool = Map.toList(Map#{}) == Nil
 
 @test
-def toList02(): Bool = Map.toList(Map#{1 -> 2}) `assertEq!` (1, 2) :: Nil
+def toList02(): Bool = Map.toList(Map#{1 -> 2}) == (1, 2) :: Nil
 
 @test
-def toList03(): Bool = Map.toList(Map#{1 -> 2, 3 -> 4}) `assertEq!` (1, 2) :: (3, 4) :: Nil
+def toList03(): Bool = Map.toList(Map#{1 -> 2, 3 -> 4}) == (1, 2) :: (3, 4) :: Nil
 
 @test
-def toList04(): Bool = Map.toList(Map#{1 -> 2, 2 -> 2, 3 -> 4}) `assertEq!` (1, 2) :: (2, 2) :: (3, 4) :: Nil
+def toList04(): Bool = Map.toList(Map#{1 -> 2, 2 -> 2, 3 -> 4}) == (1, 2) :: (2, 2) :: (3, 4) :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // eq                                                                      //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def eq01(): Bool = assert!(Map.__eq(Map#{}, Map#{}))
+def eq01(): Bool = Map.__eq(Map#{}, Map#{}) == true
 
 @test
-def eq02(): Bool = assertNot!(Map.__eq(Map#{1 -> 2}, Map#{}))
+def eq02(): Bool = Map.__eq(Map#{1 -> 2}, Map#{}) == false
 
 @test
-def eq03(): Bool = assertNot!(Map.__eq(Map#{}, Map#{1 -> 2}))
+def eq03(): Bool = Map.__eq(Map#{}, Map#{1 -> 2}) == false
 
 @test
-def eq04(): Bool = assertNot!(Map.__eq(Map#{1 -> 2, 3 -> 4}, Map#{}))
+def eq04(): Bool = Map.__eq(Map#{1 -> 2, 3 -> 4}, Map#{}) == false
 
 @test
-def eq05(): Bool = assertNot!(Map.__eq(Map#{}, Map#{1 -> 2, 3 -> 4}))
+def eq05(): Bool = Map.__eq(Map#{}, Map#{1 -> 2, 3 -> 4}) == false
 
 @test
-def eq06(): Bool = assert!(Map.__eq(Map#{1 -> 2}, Map#{1 -> 2}))
+def eq06(): Bool = Map.__eq(Map#{1 -> 2}, Map#{1 -> 2}) == true
 
 @test
-def eq07(): Bool = assertNot!(Map.__eq(Map#{1 -> 3}, Map#{1 -> 2}))
+def eq07(): Bool = Map.__eq(Map#{1 -> 3}, Map#{1 -> 2}) == false
 
 @test
-def eq08(): Bool = assertNot!(Map.__eq(Map#{1 -> 2}, Map#{1 -> 3}))
+def eq08(): Bool = Map.__eq(Map#{1 -> 2}, Map#{1 -> 3}) == false
 
 @test
-def eq09(): Bool = assertNot!(Map.__eq(Map#{2 -> 2}, Map#{1 -> 2}))
+def eq09(): Bool = Map.__eq(Map#{2 -> 2}, Map#{1 -> 2}) == false
 
 @test
-def eq10(): Bool = assertNot!(Map.__eq(Map#{1 -> 2}, Map#{4 -> 2}))
+def eq10(): Bool = Map.__eq(Map#{1 -> 2}, Map#{4 -> 2}) == false
 
 @test
-def eq11(): Bool = assertNot!(Map.__eq(Map#{1 -> 2, 3 -> 4}, Map#{1 -> 2}))
+def eq11(): Bool = Map.__eq(Map#{1 -> 2, 3 -> 4}, Map#{1 -> 2}) == false
 
 @test
-def eq12(): Bool = assertNot!(Map.__eq(Map#{1 -> 2}, Map#{1 -> 2, 3 -> 4}))
+def eq12(): Bool = Map.__eq(Map#{1 -> 2}, Map#{1 -> 2, 3 -> 4}) == false
 
 @test
-def eq13(): Bool = assert!(Map.__eq(Map#{1 -> 2, 3 -> 4}, Map#{1 -> 2, 3 -> 4}))
+def eq13(): Bool = Map.__eq(Map#{1 -> 2, 3 -> 4}, Map#{1 -> 2, 3 -> 4}) == true
 
 @test
-def eq14(): Bool = assert!(Map.__eq(Map#{1 -> 2, 3 -> 4}, Map#{3 -> 4, 1 -> 2}))
+def eq14(): Bool = Map.__eq(Map#{1 -> 2, 3 -> 4}, Map#{3 -> 4, 1 -> 2}) == true
 
 @test
-def eq15(): Bool = assertNot!(Map.__eq(Map#{1 -> 1, 3 -> 4}, Map#{1 -> 2, 3 -> 4}))
+def eq15(): Bool = Map.__eq(Map#{1 -> 1, 3 -> 4}, Map#{1 -> 2, 3 -> 4}) == false
 
 @test
-def eq16(): Bool = assertNot!(Map.__eq(Map#{4 -> 2, 3 -> 4}, Map#{1 -> 2, 3 -> 4}))
+def eq16(): Bool = Map.__eq(Map#{4 -> 2, 3 -> 4}, Map#{1 -> 2, 3 -> 4}) == false
 
 @test
-def eq17(): Bool = assertNot!(Map.__eq(Map#{1 -> 2, 3 -> 4}, Map#{1 -> 2, 2 -> 4}))
+def eq17(): Bool = Map.__eq(Map#{1 -> 2, 3 -> 4}, Map#{1 -> 2, 2 -> 4}) == false
 
 @test
-def eq18(): Bool = assertNot!(Map.__eq(Map#{1 -> 2, 3 -> 4}, Map#{1 -> 2, 3 -> 8}))
+def eq18(): Bool = Map.__eq(Map#{1 -> 2, 3 -> 4}, Map#{1 -> 2, 3 -> 8}) == false
 
 @test
-def eq19(): Bool = assertNot!(Map.__eq(Map#{1 -> 2, 3 -> 4, 5 -> 6}, Map#{1 -> 2, 3 -> 4}))
+def eq19(): Bool = Map.__eq(Map#{1 -> 2, 3 -> 4, 5 -> 6}, Map#{1 -> 2, 3 -> 4}) == false
 
 @test
-def eq20(): Bool = assertNot!(Map.__eq(Map#{1 -> 2, 3 -> 4}, Map#{1 -> 2, 3 -> 4, 5 -> 6}))
+def eq20(): Bool = Map.__eq(Map#{1 -> 2, 3 -> 4}, Map#{1 -> 2, 3 -> 4, 5 -> 6}) == false
 
 @test
-def eq21(): Bool = assert!(Map.__eq(Map#{1 -> 2, 3 -> 4, 5 -> 6}, Map#{1 -> 2, 3 -> 4, 5 -> 6}))
+def eq21(): Bool = Map.__eq(Map#{1 -> 2, 3 -> 4, 5 -> 6}, Map#{1 -> 2, 3 -> 4, 5 -> 6}) == true
 
 @test
-def eq22(): Bool = assert!(Map.__eq(Map#{1 -> 2, 3 -> 4, 5 -> 6}, Map#{1 -> 2, 5 -> 6, 3 -> 4}))
+def eq22(): Bool = Map.__eq(Map#{1 -> 2, 3 -> 4, 5 -> 6}, Map#{1 -> 2, 5 -> 6, 3 -> 4}) == true
 
 @test
-def eq23(): Bool = assert!(Map.__eq(Map#{1 -> 2, 3 -> 4, 5 -> 6}, Map#{3 -> 4, 5 -> 6, 1 -> 2}))
+def eq23(): Bool = Map.__eq(Map#{1 -> 2, 3 -> 4, 5 -> 6}, Map#{3 -> 4, 5 -> 6, 1 -> 2}) == true
 
 @test
-def eq24(): Bool = assert!(Map.__eq(Map#{1 -> 2, 3 -> 4, 5 -> 6}, Map#{5 -> 6, 3 -> 4, 1 -> 2}))
+def eq24(): Bool = Map.__eq(Map#{1 -> 2, 3 -> 4, 5 -> 6}, Map#{5 -> 6, 3 -> 4, 1 -> 2}) == true
 
 @test
-def eq25(): Bool = assert!(Map.__eq(Map#{1 -> 2, 3 -> 4, 5 -> 6, 7 -> 8, 9 -> 10}, Map#{7 -> 8, 1 -> 2, 3 -> 4, 9 -> 10, 5 -> 6}))
+def eq25(): Bool = Map.__eq(Map#{1 -> 2, 3 -> 4, 5 -> 6, 7 -> 8, 9 -> 10}, Map#{7 -> 8, 1 -> 2, 3 -> 4, 9 -> 10, 5 -> 6}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // foreach                                                                 //

--- a/main/test/ca/uwaterloo/flix/library/TestOption.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestOption.flix
@@ -20,151 +20,151 @@ namespace TestOption {
 // isEmpty                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def isEmpty01(): Bool = assert!(Option.isEmpty(None))
+def isEmpty01(): Bool = Option.isEmpty(None) == true
 
 @test
-def isEmpty02(): Bool = assertNot!(Option.isEmpty(Some(0)))
+def isEmpty02(): Bool = Option.isEmpty(Some(0)) == false
 
 @test
-def isEmpty03(): Bool = assertNot!(Option.isEmpty(Some(22ii)))
+def isEmpty03(): Bool = Option.isEmpty(Some(22ii)) == false
 
 /////////////////////////////////////////////////////////////////////////////
 // getWithDefault                                                          //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def getWithDefault01(): Bool = Option.getWithDefault(None, 32) `assertEq!` 32
+def getWithDefault01(): Bool = Option.getWithDefault(None, 32) == 32
 
 @test
-def getWithDefault02(): Bool = Option.getWithDefault(Some(30), 32) `assertEq!` 30
+def getWithDefault02(): Bool = Option.getWithDefault(Some(30), 32) == 30
 
 @test
-def getWithDefault03(): Bool = Option.getWithDefault(None, 32ii) `assertEq!` 32ii
+def getWithDefault03(): Bool = Option.getWithDefault(None, 32ii) == 32ii
 
 @test
-def getWithDefault04(): Bool = Option.getWithDefault(Some(30ii), 32ii) `assertEq!` 30ii
+def getWithDefault04(): Bool = Option.getWithDefault(Some(30ii), 32ii) == 30ii
 
 /////////////////////////////////////////////////////////////////////////////
 // exists                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def exists01(): Bool = assertNot!(Option.exists(i -> i == 2, None))
+def exists01(): Bool = Option.exists(i -> i == 2, None) == false
 
 @test
-def exists02(): Bool = assertNot!(Option.exists(i -> i == 2, Some(1)))
+def exists02(): Bool = Option.exists(i -> i == 2, Some(1)) == false
 
 @test
-def exists03(): Bool = assert!(Option.exists(i -> i == 2, Some(2)))
+def exists03(): Bool = Option.exists(i -> i == 2, Some(2)) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // forall                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def forall01(): Bool = assert!(Option.forall(i -> i == 2, None))
+def forall01(): Bool = Option.forall(i -> i == 2, None) == true
 
 @test
-def forall02(): Bool = assertNot!(Option.forall(i -> i == 2, Some(1)))
+def forall02(): Bool = Option.forall(i -> i == 2, Some(1)) == false
 
 @test
-def forall03(): Bool = assert!(Option.forall(i -> i == 2, Some(2)))
+def forall03(): Bool = Option.forall(i -> i == 2, Some(2)) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // filter                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def filter01(): Bool = Option.filter(i -> i == 2, None) `assertEq!` None
+def filter01(): Bool = Option.filter(i -> i == 2, None) == None
 
 @test
-def filter02(): Bool = Option.filter(i -> i == 2, Some(1)) `assertEq!` None
+def filter02(): Bool = Option.filter(i -> i == 2, Some(1)) == None
 
 @test
-def filter03(): Bool = Option.filter(i -> i == 2, Some(2)) `assertEq!` Some(2)
+def filter03(): Bool = Option.filter(i -> i == 2, Some(2)) == Some(2)
 
 /////////////////////////////////////////////////////////////////////////////
 // map                                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def map01(): Bool = Option.map(i -> 2*i, None) `assertEq!` None
+def map01(): Bool = Option.map(i -> 2*i, None) == None
 
 @test
-def map02(): Bool = Option.map(i -> 2*i, Some(1)) `assertEq!` Some(2)
+def map02(): Bool = Option.map(i -> 2*i, Some(1)) == Some(2)
 
 @test
-def map03(): Bool = Option.map(i -> 2*i, Some(2)) `assertEq!` Some(4)
+def map03(): Bool = Option.map(i -> 2*i, Some(2)) == Some(4)
 
 /////////////////////////////////////////////////////////////////////////////
 // map2                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def map201(): Bool = Option.map2((i, b) -> if (b) 2*i else 3*i, None, None) `assertEq!` None
+def map201(): Bool = Option.map2((i, b) -> if (b) 2*i else 3*i, None, None) == None
 
 @test
-def map202(): Bool = Option.map2((i, b) -> if (b) 2*i else 3*i, Some(1), None) `assertEq!` None
+def map202(): Bool = Option.map2((i, b) -> if (b) 2*i else 3*i, Some(1), None) == None
 
 @test
-def map203(): Bool = Option.map2((i, b) -> if (b) 2*i else 3*i, None, Some(true)) `assertEq!` None
+def map203(): Bool = Option.map2((i, b) -> if (b) 2*i else 3*i, None, Some(true)) == None
 
 @test
-def map204(): Bool = Option.map2((i, b) -> if (b) 2*i else 3*i, Some(1), Some(true)) `assertEq!` Some(2)
+def map204(): Bool = Option.map2((i, b) -> if (b) 2*i else 3*i, Some(1), Some(true)) == Some(2)
 
 @test
-def map205(): Bool = Option.map2((i, b) -> if (b) 2*i else 3*i, Some(1), Some(false)) `assertEq!` Some(3)
+def map205(): Bool = Option.map2((i, b) -> if (b) 2*i else 3*i, Some(1), Some(false)) == Some(3)
 
 /////////////////////////////////////////////////////////////////////////////
 // flatMap                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def flatMap01(): Bool = Option.flatMap(i -> if (i == 1) None else Some(2*i), None) `assertEq!` None
+def flatMap01(): Bool = Option.flatMap(i -> if (i == 1) None else Some(2*i), None) == None
 
 @test
-def flatMap02(): Bool = Option.flatMap(i -> if (i == 1) None else Some(2*i), Some(1)) `assertEq!` None
+def flatMap02(): Bool = Option.flatMap(i -> if (i == 1) None else Some(2*i), Some(1)) == None
 
 @test
-def flatMap03(): Bool = Option.flatMap(i -> if (i == 1) None else Some(2*i), Some(2)) `assertEq!` Some(4)
+def flatMap03(): Bool = Option.flatMap(i -> if (i == 1) None else Some(2*i), Some(2)) == Some(4)
 
 /////////////////////////////////////////////////////////////////////////////
 // flatMap2                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def flatMap201(): Bool = Option.flatMap2((i, b) -> if (b) Some(2*i) else None, None, None) `assertEq!` None
+def flatMap201(): Bool = Option.flatMap2((i, b) -> if (b) Some(2*i) else None, None, None) == None
 
 @test
-def flatMap202(): Bool = Option.flatMap2((i, b) -> if (b) Some(2*i) else None, Some(5), None) `assertEq!` None
+def flatMap202(): Bool = Option.flatMap2((i, b) -> if (b) Some(2*i) else None, Some(5), None) == None
 
 @test
-def flatMap203(): Bool = Option.flatMap2((i, b) -> if (b) Some(2*i) else None, None, Some(true)) `assertEq!` None
+def flatMap203(): Bool = Option.flatMap2((i, b) -> if (b) Some(2*i) else None, None, Some(true)) == None
 
 @test
-def flatMap204(): Bool = Option.flatMap2((i, b) -> if (b) Some(2*i) else None, Some(1), Some(false)) `assertEq!` None
+def flatMap204(): Bool = Option.flatMap2((i, b) -> if (b) Some(2*i) else None, Some(1), Some(false)) == None
 
 @test
-def flatMap205(): Bool = Option.flatMap2((i, b) -> if (b) Some(2*i) else None, Some(1), Some(true)) `assertEq!` Some(2)
+def flatMap205(): Bool = Option.flatMap2((i, b) -> if (b) Some(2*i) else None, Some(1), Some(true)) == Some(2)
 
 /////////////////////////////////////////////////////////////////////////////
 // toList                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toList01(): Bool = Option.toList(None) `assertEq!` Nil
+def toList01(): Bool = Option.toList(None) == Nil
 
 @test
-def toList02(): Bool = Option.toList(Some(1)) `assertEq!` 1 :: Nil
+def toList02(): Bool = Option.toList(Some(1)) == 1 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // toSet                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toSet01(): Bool = Option.toSet(None) `assertEq!` Set#{}
+def toSet01(): Bool = Option.toSet(None) == Set#{}
 
 @test
-def toSet02(): Bool = Option.toSet(Some(1)) `assertEq!` Set#{1}
+def toSet02(): Bool = Option.toSet(Some(1)) == Set#{1}
 
 /////////////////////////////////////////////////////////////////////////////
 // toMap                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toMap01(): Bool = Option.toMap(None) `assertEq!` Map#{}
+def toMap01(): Bool = Option.toMap(None) == Map#{}
 
 @test
-def toMap02(): Bool = Option.toMap(Some((1, true))) `assertEq!` Map#{1 -> true}
+def toMap02(): Bool = Option.toMap(Some((1, true))) == Map#{1 -> true}
 
 /////////////////////////////////////////////////////////////////////////////
 // toOk                                                                   //
@@ -206,104 +206,104 @@ def toFailure02(): Bool = Option.toFailure(Some("err"), "default") == Failure(Ne
 // withDefault                                                             //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def withDefault01(): Bool = Option.withDefault(None, None) `assertEq!` None
+def withDefault01(): Bool = Option.withDefault(None, None) == None
 
 @test
-def withDefault02(): Bool = Option.withDefault(None, Some(1)) `assertEq!` Some(1)
+def withDefault02(): Bool = Option.withDefault(None, Some(1)) == Some(1)
 
 @test
-def withDefault03(): Bool = Option.withDefault(Some(1), None) `assertEq!` Some(1)
+def withDefault03(): Bool = Option.withDefault(Some(1), None) == Some(1)
 
 @test
-def withDefault04(): Bool = Option.withDefault(Some(1), Some(2)) `assertEq!` Some(1)
+def withDefault04(): Bool = Option.withDefault(Some(1), Some(2)) == Some(1)
 
 /////////////////////////////////////////////////////////////////////////////
 // replace                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def replace01(): Bool = Option.replace(3, 4, None) `assertEq!` None
+def replace01(): Bool = Option.replace(3, 4, None) == None
 
 @test
-def replace02(): Bool = Option.replace(3, 4, Some(2)) `assertEq!` Some(2)
+def replace02(): Bool = Option.replace(3, 4, Some(2)) == Some(2)
 
 @test
-def replace03(): Bool = Option.replace(3, 4, Some(3)) `assertEq!` Some(4)
+def replace03(): Bool = Option.replace(3, 4, Some(3)) == Some(4)
 
 @test
-def replace04(): Bool = Option.replace(3, 4, Some(4)) `assertEq!` Some(4)
+def replace04(): Bool = Option.replace(3, 4, Some(4)) == Some(4)
 
 /////////////////////////////////////////////////////////////////////////////
 // count                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def count01(): Bool = Option.count(i -> i == 2, None) `assertEq!` 0
+def count01(): Bool = Option.count(i -> i == 2, None) == 0
 
 @test
-def count02(): Bool = Option.count(i -> i == 2, Some(1)) `assertEq!` 0
+def count02(): Bool = Option.count(i -> i == 2, Some(1)) == 0
 
 @test
-def count03(): Bool = Option.count(i -> i == 2, Some(2)) `assertEq!` 1
+def count03(): Bool = Option.count(i -> i == 2, Some(2)) == 1
 
 /////////////////////////////////////////////////////////////////////////////
 // find                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def find01(): Bool = Option.find(i -> i == 2, None) `assertEq!` None
+def find01(): Bool = Option.find(i -> i == 2, None) == None
 
 @test
-def find02(): Bool = Option.find(i -> i == 2, Some(1)) `assertEq!` None
+def find02(): Bool = Option.find(i -> i == 2, Some(1)) == None
 
 @test
-def find03(): Bool = Option.find(i -> i == 2, Some(2)) `assertEq!` Some(2)
+def find03(): Bool = Option.find(i -> i == 2, Some(2)) == Some(2)
 
 /////////////////////////////////////////////////////////////////////////////
 // flatten                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def flatten01(): Bool = Option.flatten(None) `assertEq!` None
+def flatten01(): Bool = Option.flatten(None) == None
 
 @test
-def flatten02(): Bool = Option.flatten(Some(None)) `assertEq!` None
+def flatten02(): Bool = Option.flatten(Some(None)) == None
 
 @test
-def flatten03(): Bool = Option.flatten(Some(Some(2))) `assertEq!` Some(2)
+def flatten03(): Bool = Option.flatten(Some(Some(2))) == Some(2)
 
 
 /////////////////////////////////////////////////////////////////////////////
 // foldLeft                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldLeft01(): Bool = assertNot!(Option.foldLeft((b, i) -> if (i == 2 && b) true else false, false, None))
+def foldLeft01(): Bool = Option.foldLeft((b, i) -> if (i == 2 && b) true else false, false, None) == false
 
 @test
-def foldLeft02(): Bool = assertNot!(Option.foldLeft((b, i) -> if (i == 2 && b) true else false, false, Some(1)))
+def foldLeft02(): Bool = Option.foldLeft((b, i) -> if (i == 2 && b) true else false, false, Some(1)) == false
 
 @test
-def foldLeft03(): Bool = assertNot!(Option.foldLeft((b, i) -> if (i == 2 && b) true else false, false, Some(2)))
+def foldLeft03(): Bool = Option.foldLeft((b, i) -> if (i == 2 && b) true else false, false, Some(2)) == false
 
 @test
-def foldLeft04(): Bool = assertNot!(Option.foldLeft((b, i) -> if (i == 2 && b) true else false, true, Some(1)))
+def foldLeft04(): Bool = Option.foldLeft((b, i) -> if (i == 2 && b) true else false, true, Some(1)) == false
 
 @test
-def foldLeft05(): Bool = assert!(Option.foldLeft((b, i) -> if (i == 2 && b) true else false, true, Some(2)))
+def foldLeft05(): Bool = Option.foldLeft((b, i) -> if (i == 2 && b) true else false, true, Some(2)) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // foldRight                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldRight01(): Bool = assertNot!(Option.foldRight((i, b) -> if (i == 2 && b) true else false, None, false))
+def foldRight01(): Bool = Option.foldRight((i, b) -> if (i == 2 && b) true else false, None, false) == false
 
 @test
-def foldRight02(): Bool = assertNot!(Option.foldRight((i, b) -> if (i == 2 && b) true else false, Some(1), false))
+def foldRight02(): Bool = Option.foldRight((i, b) -> if (i == 2 && b) true else false, Some(1), false) == false
 
 @test
-def foldRight03(): Bool = assertNot!(Option.foldRight((i, b) -> if (i == 2 && b) true else false, Some(2), false))
+def foldRight03(): Bool = Option.foldRight((i, b) -> if (i == 2 && b) true else false, Some(2), false) == false
 
 @test
-def foldRight04(): Bool = assertNot!(Option.foldRight((i, b) -> if (i == 2 && b) true else false, Some(1), true))
+def foldRight04(): Bool = Option.foldRight((i, b) -> if (i == 2 && b) true else false, Some(1), true) == false
 
 @test
-def foldRight05(): Bool = assert!(Option.foldRight((i, b) -> if (i == 2 && b) true else false, Some(2), true))
+def foldRight05(): Bool = Option.foldRight((i, b) -> if (i == 2 && b) true else false, Some(2), true) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // sequence                                                                //
@@ -360,25 +360,25 @@ def traverse08(): Bool = Option.traverse(_ -> Some(42), 1 :: 2 :: 3 :: Nil) == S
 // zip                                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def zip01(): Bool = Option.zip(None, None) `assertEq!` None
+def zip01(): Bool = Option.zip(None, None) == None
 
 @test
-def zip02(): Bool = Option.zip(Some(1), None) `assertEq!` None
+def zip02(): Bool = Option.zip(Some(1), None) == None
 
 @test
-def zip03(): Bool = Option.zip(None, Some(true)) `assertEq!` None
+def zip03(): Bool = Option.zip(None, Some(true)) == None
 
 @test
-def zip04(): Bool = Option.zip(Some(1), Some(true)) `assertEq!` Some((1, true))
+def zip04(): Bool = Option.zip(Some(1), Some(true)) == Some((1, true))
 
 /////////////////////////////////////////////////////////////////////////////
 // unzip                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def unzip01(): Bool = Option.unzip(None) `assertEq!` (None, None)
+def unzip01(): Bool = Option.unzip(None) == (None, None)
 
 @test
-def unzip02(): Bool = Option.unzip(Some((1, true))) `assertEq!` (Some(1), Some(true))
+def unzip02(): Bool = Option.unzip(Some((1, true))) == (Some(1), Some(true))
 
 /////////////////////////////////////////////////////////////////////////////
 // foreach                                                                 //

--- a/main/test/ca/uwaterloo/flix/library/TestPrelude.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestPrelude.flix
@@ -1,26 +1,42 @@
+/*
+ * Copyright 2020 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /////////////////////////////////////////////////////////////////////////////
 // identity                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def identity01(): Bool = identity(5) `assertEq!` 5
+def identity01(): Bool = identity(5) == 5
 
 @test
-def identity02(): Bool = identity(true) `assertEq!` true
+def identity02(): Bool = identity(true) == true
 
 @test
-def identity03(): Bool = identity(6ii) `assertEq!` 6ii
+def identity03(): Bool = identity(6ii) == 6ii
 
 /////////////////////////////////////////////////////////////////////////////
 // constant                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def constant01(): Bool = (true |> constant(5)) `assertEq!` 5
+def constant01(): Bool = (true |> constant(5)) == 5
 
 @test
-def constant02(): Bool = (5 |> constant(true)) `assertEq!` true
+def constant02(): Bool = (5 |> constant(true)) == true
 
 @test
-def constant03(): Bool = (Nil |> constant(2ii)) `assertEq!` 2ii
+def constant03(): Bool = (Nil |> constant(2ii)) == 2ii
 
 /////////////////////////////////////////////////////////////////////////////
 // flip                                                                    //
@@ -28,22 +44,22 @@ def constant03(): Bool = (Nil |> constant(2ii)) `assertEq!` 2ii
 @test
 def flip01(): Bool =
     let f = flip((x, y) -> x - y);
-    f(5, 4) `assertEq!` -1
+    f(5, 4) == -1
 
 @test
 def flip02(): Bool =
     let f = flip((x, y) -> x - y);
-    f(4, 5) `assertEq!` 1
+    f(4, 5) == 1
 
 @test
 def flip03(): Bool =
     let f = flip((x, y) -> x / y);
-    f(10, 3) `assertEq!` 0
+    f(10, 3) == 0
 
 @test
 def flip04(): Bool =
     let f = flip((x, y) -> x / y);
-    f(3, 10) `assertEq!` 3
+    f(3, 10) == 3
 
 /////////////////////////////////////////////////////////////////////////////
 // curry                                                                   //
@@ -51,22 +67,22 @@ def flip04(): Bool =
 @test
 def curry01(): Bool =
     let f = curry((x, y) -> x - y);
-    (4 |> f(5)) `assertEq!` 1
+    (4 |> f(5)) == 1
 
 @test
 def curry02(): Bool =
     let f = curry((x, y) -> x - y);
-    (5 |> f(4)) `assertEq!` -1
+    (5 |> f(4)) == -1
 
 @test
 def curry03(): Bool =
     let f = curry((x, y) -> x / y);
-    (3 |> f(10)) `assertEq!` 3
+    (3 |> f(10)) == 3
 
 @test
 def curry04(): Bool =
     let f = curry((x, y) -> x / y);
-    (10 |> f(3)) `assertEq!` 0
+    (10 |> f(3)) == 0
 
 /////////////////////////////////////////////////////////////////////////////
 // uncurry                                                                 //
@@ -74,49 +90,49 @@ def curry04(): Bool =
 @test
 def uncurry01(): Bool =
     let f = uncurry(x -> y -> x - y);
-    f(5, 4) `assertEq!` 1
+    f(5, 4) == 1
 
 @test
 def uncurry02(): Bool =
     let f = uncurry(x -> y -> x - y);
-    f(4, 5) `assertEq!` -1
+    f(4, 5) == -1
 
 @test
 def uncurry03(): Bool =
     let f = uncurry(x -> y -> x / y);
-    f(10, 3) `assertEq!` 3
+    f(10, 3) == 3
 
 @test
 def uncurry04(): Bool =
     let f = uncurry(x -> y -> x / y);
-    f(3, 10) `assertEq!` 0
+    f(3, 10) == 0
 
 /////////////////////////////////////////////////////////////////////////////
 // fst                                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def fst01(): Bool = fst((5, 0.0f32)) `assertEq!` 5
+def fst01(): Bool = fst((5, 0.0f32)) == 5
 
 @test
-def fst02(): Bool = fst((0.0f32, 5)) `assertEq!` 0.0f32
+def fst02(): Bool = fst((0.0f32, 5)) == 0.0f32
 
 /////////////////////////////////////////////////////////////////////////////
 // snd                                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def snd01(): Bool = snd((5, 0.0f32)) `assertEq!` 0.0f32
+def snd01(): Bool = snd((5, 0.0f32)) == 0.0f32
 
 @test
-def snd02(): Bool = snd((0.0f32, 5)) `assertEq!` 5
+def snd02(): Bool = snd((0.0f32, 5)) == 5
 
 /////////////////////////////////////////////////////////////////////////////
 // swap                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def swap01(): Bool = swap((5, 0.0f32)) `assertEq!` (0.0f32, 5)
+def swap01(): Bool = swap((5, 0.0f32)) == (0.0f32, 5)
 
 @test
-def swap02(): Bool = swap((0.0f32, 5)) `assertEq!` (5, 0.0f32)
+def swap02(): Bool = swap((0.0f32, 5)) == (5, 0.0f32)
 
 /////////////////////////////////////////////////////////////////////////////
 // Function Composition                                                    //
@@ -126,127 +142,127 @@ def forwardComposition01(): Bool =
     let f = x -> x + 1;
     let g = x -> x * 2;
     let h = f >> g;
-        h(0) `assertEq!` 2 // (0 + 1) * 2
+        h(0) == 2 // (0 + 1) * 2
 
 @test
 def backwardComposition01(): Bool =
     let f = x -> x + 1;
     let g = x -> x * 2;
     let h = f << g;
-        h(0) `assertEq!` 1 // (0 * 2) + 1
+        h(0) == 1 // (0 * 2) + 1
 
 @test
 def forwardPipe01(): Bool =
     let f = x -> x + 1;
     let g = x -> x * 2;
     let r = 0 |> f |> g;
-        r `assertEq!` 2 // (0 + 1) * 2
+        r == 2 // (0 + 1) * 2
 
 @test
 def forwardPipe02(): Bool =
     let f = match (x, y) -> x + y;
     let r = (1, 2) |> f;
-        r `assertEq!` 3
+        r == 3
 
 @test
 def backwardPipe01(): Bool =
     let f = x -> x + 1;
     let g = x -> x * 2;
     let r = f <| (g <| 0);
-        r `assertEq!` 1 // (0 * 2) + 1
+        r == 1 // (0 * 2) + 1
 
 @test
 def backwardPipe02(): Bool =
     let f = match (x, y) -> x + y;
     let r = f <| (1, 2);
-        r `assertEq!` 3
+        r == 3
 
 /////////////////////////////////////////////////////////////////////////////
 // Logical And                                                             //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def mathAnd01(): Bool = (true ∧ true) `assertEq!` true
+def mathAnd01(): Bool = (true ∧ true) == true
 
 @test
-def mathAnd02(): Bool = (true ∧ false) `assertEq!` false
+def mathAnd02(): Bool = (true ∧ false) == false
 
 @test
-def mathAnd03(): Bool = (false ∧ true) `assertEq!` false
+def mathAnd03(): Bool = (false ∧ true) == false
 
 @test
-def mathAnd04(): Bool = (false ∧ false) `assertEq!` false
+def mathAnd04(): Bool = (false ∧ false) == false
 
 /////////////////////////////////////////////////////////////////////////////
 // Logical Or                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def mathOr01(): Bool = (true ∨ true) `assertEq!` true
+def mathOr01(): Bool = (true ∨ true) == true
 
 @test
-def mathOr02(): Bool = (true ∨ false) `assertEq!` true
+def mathOr02(): Bool = (true ∨ false) == true
 
 @test
-def mathOr03(): Bool = (false ∨ true) `assertEq!` true
+def mathOr03(): Bool = (false ∨ true) == true
 
 @test
-def mathOr04(): Bool = (false ∨ false) `assertEq!` false
+def mathOr04(): Bool = (false ∨ false) == false
 
 /////////////////////////////////////////////////////////////////////////////
 // Logical Implication                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def mathImplication01(): Bool = (true → true) `assertEq!` true
+def mathImplication01(): Bool = (true → true) == true
 
 @test
-def mathImplication02(): Bool = (true → false) `assertEq!` false
+def mathImplication02(): Bool = (true → false) == false
 
 @test
-def mathImplication03(): Bool = (false → true) `assertEq!` true
+def mathImplication03(): Bool = (false → true) == true
 
 @test
-def mathImplication04(): Bool = (false → false) `assertEq!` true
+def mathImplication04(): Bool = (false → false) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // Logical Biconditional                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def mathBiconditional01(): Bool = (true ↔ true) `assertEq!` true
+def mathBiconditional01(): Bool = (true ↔ true) == true
 
 @test
-def mathBiconditional02(): Bool = (true ↔ false) `assertEq!` false
+def mathBiconditional02(): Bool = (true ↔ false) == false
 
 @test
-def mathBiconditional03(): Bool = (false ↔ true) `assertEq!` false
+def mathBiconditional03(): Bool = (false ↔ true) == false
 
 @test
-def mathBiconditional04(): Bool = (false ↔ false) `assertEq!` true
+def mathBiconditional04(): Bool = (false ↔ false) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // Logical Xor                                                             //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def mathXor01(): Bool = (true ⊕ true) `assertEq!` false
+def mathXor01(): Bool = (true ⊕ true) == false
 
 @test
-def mathXor02(): Bool = (true ⊕ false) `assertEq!` true
+def mathXor02(): Bool = (true ⊕ false) == true
 
 @test
-def mathXor03(): Bool = (false ⊕ true) `assertEq!` true
+def mathXor03(): Bool = (false ⊕ true) == true
 
 @test
-def mathXor04(): Bool = (false ⊕ false) `assertEq!` false
+def mathXor04(): Bool = (false ⊕ false) == false
 
 /////////////////////////////////////////////////////////////////////////////
 // Sheffer Stroke                                                          //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def mathSheffer01(): Bool = (true ↑ true) `assertEq!` false
+def mathSheffer01(): Bool = (true ↑ true) == false
 
 @test
-def mathSheffer02(): Bool = (true ↑ false) `assertEq!` true
+def mathSheffer02(): Bool = (true ↑ false) == true
 
 @test
-def mathSheffer03(): Bool = (false ↑ true) `assertEq!` true
+def mathSheffer03(): Bool = (false ↑ true) == true
 
 @test
-def mathSheffer04(): Bool = (false ↑ false) `assertEq!` true
+def mathSheffer04(): Bool = (false ↑ false) == true

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -20,214 +20,214 @@ namespace TestResult {
 // isOk                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def isOk01(): Bool = assert!(Result.isOk(Ok(1)))
+def isOk01(): Bool = Result.isOk(Ok(1)) == true
 
 @test
-def isOk02(): Bool = assertNot!(Result.isOk(Err(1)))
+def isOk02(): Bool = Result.isOk(Err(1)) == false
 
 /////////////////////////////////////////////////////////////////////////////
 // isErr                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def isErr01(): Bool = assertNot!(Result.isErr(Ok(1)))
+def isErr01(): Bool = Result.isErr(Ok(1)) == false
 
 @test
-def isErr02(): Bool = assert!(Result.isErr(Err(1)))
+def isErr02(): Bool = Result.isErr(Err(1)) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // getWithDefault                                                          //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def getWithDefault01(): Bool = Result.getWithDefault(Ok(1), 2) `assertEq!` 1
+def getWithDefault01(): Bool = Result.getWithDefault(Ok(1), 2) == 1
 
 @test
-def getWithDefault02(): Bool = Result.getWithDefault(Err(false), 2) `assertEq!` 2
+def getWithDefault02(): Bool = Result.getWithDefault(Err(false), 2) == 2
 
 /////////////////////////////////////////////////////////////////////////////
 // withDefault                                                             //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def withDefault01(): Bool = Result.withDefault(Ok(1), Ok(2)) `assertEq!` Ok(1)
+def withDefault01(): Bool = Result.withDefault(Ok(1), Ok(2)) == Ok(1)
 
 @test
-def withDefault02(): Bool = Result.withDefault(Ok(1), Err(false)) `assertEq!` Ok(1)
+def withDefault02(): Bool = Result.withDefault(Ok(1), Err(false)) == Ok(1)
 
 @test
-def withDefault03(): Bool = Result.withDefault(Err(false), Ok(2)) `assertEq!` Ok(2)
+def withDefault03(): Bool = Result.withDefault(Err(false), Ok(2)) == Ok(2)
 
 @test
-def withDefault04(): Bool = Result.withDefault(Err(false), Err(true)) `assertEq!` Err(true)
+def withDefault04(): Bool = Result.withDefault(Err(false), Err(true)) == Err(true)
 
 /////////////////////////////////////////////////////////////////////////////
 // replace                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def replace01(): Bool = Result.replace(3, 4, Err(false)) `assertEq!` Err(false)
+def replace01(): Bool = Result.replace(3, 4, Err(false)) == Err(false)
 
 @test
-def replace02(): Bool = Result.replace(3, 4, Ok(2)) `assertEq!` Ok(2)
+def replace02(): Bool = Result.replace(3, 4, Ok(2)) == Ok(2)
 
 @test
-def replace03(): Bool = Result.replace(3, 4, Ok(3)) `assertEq!` Ok(4)
+def replace03(): Bool = Result.replace(3, 4, Ok(3)) == Ok(4)
 
 @test
-def replace04(): Bool = Result.replace(3, 4, Ok(4)) `assertEq!` Ok(4)
+def replace04(): Bool = Result.replace(3, 4, Ok(4)) == Ok(4)
 
 /////////////////////////////////////////////////////////////////////////////
 // exists                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def exists01(): Bool = assertNot!(Result.exists(i -> i == 2, Err(false)))
+def exists01(): Bool = Result.exists(i -> i == 2, Err(false)) == false
 
 @test
-def exists02(): Bool = assertNot!(Result.exists(i -> i == 2, Ok(1)))
+def exists02(): Bool = Result.exists(i -> i == 2, Ok(1)) == false
 
 @test
-def exists03(): Bool = assert!(Result.exists(i -> i == 2, Ok(2)))
+def exists03(): Bool = Result.exists(i -> i == 2, Ok(2)) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // forall                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def forall01(): Bool = assert!(Result.forall(i -> i == 2, Err(false)))
+def forall01(): Bool = Result.forall(i -> i == 2, Err(false)) == true
 
 @test
-def forall02(): Bool = assertNot!(Result.forall(i -> i == 2, Ok(1)))
+def forall02(): Bool = Result.forall(i -> i == 2, Ok(1)) == false
 
 @test
-def forall03(): Bool = assert!(Result.forall(i -> i == 2, Ok(2)))
+def forall03(): Bool = Result.forall(i -> i == 2, Ok(2)) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // map                                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def map01(): Bool = Result.map(i -> i == 2, Err(-1ii)) `assertEq!` Err(-1ii)
+def map01(): Bool = Result.map(i -> i == 2, Err(-1ii)) == Err(-1ii)
 
 @test
-def map02(): Bool = Result.map(i -> i == 2, Ok(1)) `assertEq!` Ok(false)
+def map02(): Bool = Result.map(i -> i == 2, Ok(1)) == Ok(false)
 
 @test
-def map03(): Bool = Result.map(i -> i == 2, Ok(2)) `assertEq!` Ok(true)
+def map03(): Bool = Result.map(i -> i == 2, Ok(2)) == Ok(true)
 
 /////////////////////////////////////////////////////////////////////////////
 // mapErr                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def mapErr01(): Bool = Result.mapErr(i -> i == 2, Ok(1)) `assertEq!` Ok(1)
+def mapErr01(): Bool = Result.mapErr(i -> i == 2, Ok(1)) == Ok(1)
 
 @test
-def mapErr02(): Bool = Result.mapErr(i -> i == 2, Err(1)) `assertEq!` Err(false)
+def mapErr02(): Bool = Result.mapErr(i -> i == 2, Err(1)) == Err(false)
 
 @test
-def mapErr03(): Bool = Result.mapErr(i -> i == 2, Err(2)) `assertEq!` Err(true)
+def mapErr03(): Bool = Result.mapErr(i -> i == 2, Err(2)) == Err(true)
 
 /////////////////////////////////////////////////////////////////////////////
 // flatMap                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def flatMap01(): Bool = Result.flatMap(i -> if (i == 2) Ok(i) else Err(false), Err(true)) `assertEq!` Err(true)
+def flatMap01(): Bool = Result.flatMap(i -> if (i == 2) Ok(i) else Err(false), Err(true)) == Err(true)
 
 @test
-def flatMap02(): Bool = Result.flatMap(i -> if (i == 2) Ok(i) else Err(false), Ok(1)) `assertEq!` Err(false)
+def flatMap02(): Bool = Result.flatMap(i -> if (i == 2) Ok(i) else Err(false), Ok(1)) == Err(false)
 
 @test
-def flatMap03(): Bool = Result.flatMap(i -> if (i == 2) Ok(2*i) else Err(false), Ok(2)) `assertEq!` Ok(4)
+def flatMap03(): Bool = Result.flatMap(i -> if (i == 2) Ok(2*i) else Err(false), Ok(2)) == Ok(4)
 
 /////////////////////////////////////////////////////////////////////////////
 // count                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def count01(): Bool = Result.count(i -> i == 2, Err(false)) `assertEq!` 0
+def count01(): Bool = Result.count(i -> i == 2, Err(false)) == 0
 
 @test
-def count02(): Bool = Result.count(i -> i == 2, Ok(1)) `assertEq!` 0
+def count02(): Bool = Result.count(i -> i == 2, Ok(1)) == 0
 
 @test
-def count03(): Bool = Result.count(i -> i == 2, Ok(2)) `assertEq!` 1
+def count03(): Bool = Result.count(i -> i == 2, Ok(2)) == 1
 
 /////////////////////////////////////////////////////////////////////////////
 // find                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def find01(): Bool = Result.find(i -> i == 2, Err(false)) `assertEq!` None
+def find01(): Bool = Result.find(i -> i == 2, Err(false)) == None
 
 @test
-def find02(): Bool = Result.find(i -> i == 2, Ok(1)) `assertEq!` None
+def find02(): Bool = Result.find(i -> i == 2, Ok(1)) == None
 
 @test
-def find03(): Bool = Result.find(i -> i == 2, Ok(2)) `assertEq!` Some(2)
+def find03(): Bool = Result.find(i -> i == 2, Ok(2)) == Some(2)
 
 /////////////////////////////////////////////////////////////////////////////
 // foldLeft                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldLeft01(): Bool = Result.foldLeft((b, i) -> if (i == 2 && b) true else false, false, Err(-1ii)) `assertEq!` false
+def foldLeft01(): Bool = Result.foldLeft((b, i) -> if (i == 2 && b) true else false, false, Err(-1ii)) == false
 
 @test
-def foldLeft02(): Bool = Result.foldLeft((b, i) -> if (i == 2 && b) true else false, false, Ok(1)) `assertEq!` false
+def foldLeft02(): Bool = Result.foldLeft((b, i) -> if (i == 2 && b) true else false, false, Ok(1)) == false
 
 @test
-def foldLeft03(): Bool = Result.foldLeft((b, i) -> if (i == 2 && b) true else false, true, Ok(1)) `assertEq!` false
+def foldLeft03(): Bool = Result.foldLeft((b, i) -> if (i == 2 && b) true else false, true, Ok(1)) == false
 
 @test
-def foldLeft04(): Bool = Result.foldLeft((b, i) -> if (i == 2 && b) true else false, false, Ok(2)) `assertEq!` false
+def foldLeft04(): Bool = Result.foldLeft((b, i) -> if (i == 2 && b) true else false, false, Ok(2)) == false
 
 @test
-def foldLeft05(): Bool = Result.foldLeft((b, i) -> if (i == 2 && b) true else false, true, Ok(2)) `assertEq!` true
+def foldLeft05(): Bool = Result.foldLeft((b, i) -> if (i == 2 && b) true else false, true, Ok(2)) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // foldRight                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldRight01(): Bool = Result.foldRight((i, b) -> if (i == 2 && b) true else false, Err(-1ii), false) `assertEq!` false
+def foldRight01(): Bool = Result.foldRight((i, b) -> if (i == 2 && b) true else false, Err(-1ii), false) == false
 
 @test
-def foldRight02(): Bool = Result.foldRight((i, b) -> if (i == 2 && b) true else false, Ok(1), false) `assertEq!` false
+def foldRight02(): Bool = Result.foldRight((i, b) -> if (i == 2 && b) true else false, Ok(1), false) == false
 
 @test
-def foldRight03(): Bool = Result.foldRight((i, b) -> if (i == 2 && b) true else false, Ok(1), true) `assertEq!` false
+def foldRight03(): Bool = Result.foldRight((i, b) -> if (i == 2 && b) true else false, Ok(1), true) == false
 
 @test
-def foldRight04(): Bool = Result.foldRight((i, b) -> if (i == 2 && b) true else false, Ok(2), false) `assertEq!` false
+def foldRight04(): Bool = Result.foldRight((i, b) -> if (i == 2 && b) true else false, Ok(2), false) == false
 
 @test
-def foldRight05(): Bool = Result.foldRight((i, b) -> if (i == 2 && b) true else false, Ok(2), true) `assertEq!` true
+def foldRight05(): Bool = Result.foldRight((i, b) -> if (i == 2 && b) true else false, Ok(2), true) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // toList                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toList01(): Bool = Result.toList(Err(-1ii)) `assertEq!` Nil
+def toList01(): Bool = Result.toList(Err(-1ii)) == Nil
 
 @test
-def toList02(): Bool = Result.toList(Ok(1)) `assertEq!` 1 :: Nil
+def toList02(): Bool = Result.toList(Ok(1)) == 1 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // toSet                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toSet01(): Bool = Result.toSet(Err(-1ii)) `assertEq!` Set#{}
+def toSet01(): Bool = Result.toSet(Err(-1ii)) == Set#{}
 
 @test
-def toSet02(): Bool = Result.toSet(Ok(1)) `assertEq!` Set#{1}
+def toSet02(): Bool = Result.toSet(Ok(1)) == Set#{1}
 
 /////////////////////////////////////////////////////////////////////////////
 // toMap                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toMap01(): Bool = Result.toMap(Err(-1ii)) `assertEq!` Map#{}
+def toMap01(): Bool = Result.toMap(Err(-1ii)) == Map#{}
 
 @test
-def toMap02(): Bool = Result.toMap(Ok((1, true))) `assertEq!` Map#{1 -> true}
+def toMap02(): Bool = Result.toMap(Ok((1, true))) == Map#{1 -> true}
 
 /////////////////////////////////////////////////////////////////////////////
 // toOption                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toOption01(): Bool = Result.toOption(Err(-1ii)) `assertEq!` None
+def toOption01(): Bool = Result.toOption(Err(-1ii)) == None
 
 @test
-def toOption02(): Bool = Result.toOption(Ok(1)) `assertEq!` Some(1)
+def toOption02(): Bool = Result.toOption(Ok(1)) == Some(1)
 
 /////////////////////////////////////////////////////////////////////////////
 // foreach                                                                 //

--- a/main/test/ca/uwaterloo/flix/library/TestSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSet.flix
@@ -20,994 +20,994 @@ namespace TestSet {
 // size                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def size01(): Bool = Set.size(Set#{}) `assertEq!` 0
+def size01(): Bool = Set.size(Set#{}) == 0
 
 @test
-def size02(): Bool = Set.size(Set#{1}) `assertEq!` 1
+def size02(): Bool = Set.size(Set#{1}) == 1
 
 @test
-def size03(): Bool = Set.size(Set#{1, 2}) `assertEq!` 2
+def size03(): Bool = Set.size(Set#{1, 2}) == 2
 
 @test
-def size04(): Bool = Set.size(Set#{1, 2, 3}) `assertEq!` 3
+def size04(): Bool = Set.size(Set#{1, 2, 3}) == 3
 
 @test
-def size05(): Bool = Set.size(Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14}) `assertEq!` 13
+def size05(): Bool = Set.size(Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14}) == 13
 
 /////////////////////////////////////////////////////////////////////////////
 // empty                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def empty01(): Bool = assert!(Set.__eq(Set.empty(), Set#{}))
+def empty01(): Bool = Set.__eq(Set.empty(), Set#{}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // singleton                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def singleton01(): Bool = assert!(Set.__eq(Set.singleton(1), Set#{1}))
+def singleton01(): Bool = Set.__eq(Set.singleton(1), Set#{1}) == true
 
 @test
-def singleton02(): Bool = assert!(Set.__eq(Set.singleton(2), Set#{2}))
+def singleton02(): Bool = Set.__eq(Set.singleton(2), Set#{2}) == true
 
 @test
-def singleton03(): Bool = assert!(Set.__eq(Set.singleton(true), Set#{true}))
+def singleton03(): Bool = Set.__eq(Set.singleton(true), Set#{true}) == true
 
 @test
-def singleton04(): Bool = assert!(Set.__eq(Set.singleton(false), Set#{false}))
+def singleton04(): Bool = Set.__eq(Set.singleton(false), Set#{false}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // insert                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def insert01(): Bool = assert!(Set.__eq(Set.insert(1, Set#{}), Set#{1}))
+def insert01(): Bool = Set.__eq(Set.insert(1, Set#{}), Set#{1}) == true
 
 @test
-def insert02(): Bool = assert!(Set.__eq(Set.insert(1, Set#{1}), Set#{1}))
+def insert02(): Bool = Set.__eq(Set.insert(1, Set#{1}), Set#{1}) == true
 
 @test
-def insert03(): Bool = assert!(Set.__eq(Set.insert(1, Set#{2}), Set#{1, 2}))
+def insert03(): Bool = Set.__eq(Set.insert(1, Set#{2}), Set#{1, 2}) == true
 
 @test
-def insert04(): Bool = assert!(Set.__eq(Set.insert(1, Set#{2, 3}), Set#{1, 2, 3}))
+def insert04(): Bool = Set.__eq(Set.insert(1, Set#{2, 3}), Set#{1, 2, 3}) == true
 
 @test
-def insert05(): Bool = assert!(Set.__eq(Set.insert(1, Set#{1, 2, 3}), Set#{1, 2, 3}))
+def insert05(): Bool = Set.__eq(Set.insert(1, Set#{1, 2, 3}), Set#{1, 2, 3}) == true
 
 @test
-def insert06(): Bool = assert!(Set.__eq(Set.insert(1, Set#{2, 1, 3}), Set#{2, 1, 3}))
+def insert06(): Bool = Set.__eq(Set.insert(1, Set#{2, 1, 3}), Set#{2, 1, 3}) == true
 
 @test
-def insert07(): Bool = assert!(Set.__eq(Set.insert(1, Set#{2, 1, 3, 7, 8, 9, 10}), Set#{2, 1, 3, 7, 8, 9, 10}))
+def insert07(): Bool = Set.__eq(Set.insert(1, Set#{2, 1, 3, 7, 8, 9, 10}), Set#{2, 1, 3, 7, 8, 9, 10}) == true
 
 @test
-def insert08(): Bool = assert!(Set.__eq(Set.insert(11, Set#{2, 1, 3, 7, 8, 9, 10, 35}), Set#{11, 2, 1, 3, 7, 8, 9, 10, 35}))
+def insert08(): Bool = Set.__eq(Set.insert(11, Set#{2, 1, 3, 7, 8, 9, 10, 35}), Set#{11, 2, 1, 3, 7, 8, 9, 10, 35}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // delete                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def delete01(): Bool = assert!(Set.__eq(Set.delete(1, Set#{}), Set#{}))
+def delete01(): Bool = Set.__eq(Set.delete(1, Set#{}), Set#{}) == true
 
 @test
-def delete02(): Bool = assert!(Set.__eq(Set.delete(1, Set#{1}), Set#{}))
+def delete02(): Bool = Set.__eq(Set.delete(1, Set#{1}), Set#{}) == true
 
 @test
-def delete03(): Bool = assert!(Set.__eq(Set.delete(1, Set#{2}), Set#{2}))
+def delete03(): Bool = Set.__eq(Set.delete(1, Set#{2}), Set#{2}) == true
 
 @test
-def delete04(): Bool = assert!(Set.__eq(Set.delete(2, Set#{2, 3}), Set#{3}))
+def delete04(): Bool = Set.__eq(Set.delete(2, Set#{2, 3}), Set#{3}) == true
 
 @test
-def delete05(): Bool = assert!(Set.__eq(Set.delete(3, Set#{2, 3}), Set#{2}))
+def delete05(): Bool = Set.__eq(Set.delete(3, Set#{2, 3}), Set#{2}) == true
 
 @test
-def delete06(): Bool = assert!(Set.__eq(Set.delete(1, Set#{2, 3}), Set#{2, 3}))
+def delete06(): Bool = Set.__eq(Set.delete(1, Set#{2, 3}), Set#{2, 3}) == true
 
 @test
-def delete07(): Bool = assert!(Set.__eq(Set.delete(0, Set#{1, 2, 3, 4, 5, 6, 7}), Set#{1, 2, 3, 4, 5, 6, 7}))
+def delete07(): Bool = Set.__eq(Set.delete(0, Set#{1, 2, 3, 4, 5, 6, 7}), Set#{1, 2, 3, 4, 5, 6, 7}) == true
 
 @test
-def delete08(): Bool = assert!(Set.__eq(Set.delete(1, Set#{1, 2, 3, 4, 5, 6, 7}), Set#{2, 3, 4, 5, 6, 7}))
+def delete08(): Bool = Set.__eq(Set.delete(1, Set#{1, 2, 3, 4, 5, 6, 7}), Set#{2, 3, 4, 5, 6, 7}) == true
 
 @test
-def delete09(): Bool = assert!(Set.__eq(Set.delete(2, Set#{1, 2, 3, 4, 5, 6, 7}), Set#{1, 3, 4, 5, 6, 7}))
+def delete09(): Bool = Set.__eq(Set.delete(2, Set#{1, 2, 3, 4, 5, 6, 7}), Set#{1, 3, 4, 5, 6, 7}) == true
 
 @test
-def delete10(): Bool = assert!(Set.__eq(Set.delete(6, Set#{1, 2, 3, 4, 5, 6, 7}), Set#{1, 2, 3, 4, 5, 7}))
+def delete10(): Bool = Set.__eq(Set.delete(6, Set#{1, 2, 3, 4, 5, 6, 7}), Set#{1, 2, 3, 4, 5, 7}) == true
 
 @test
-def delete11(): Bool = assert!(Set.__eq(Set.delete(7, Set#{1, 2, 3, 4, 5, 6, 7}), Set#{1, 2, 3, 4, 5, 6}))
+def delete11(): Bool = Set.__eq(Set.delete(7, Set#{1, 2, 3, 4, 5, 6, 7}), Set#{1, 2, 3, 4, 5, 6}) == true
 
 @test
-def delete12(): Bool = assert!(Set.__eq(Set.delete(8, Set#{1, 2, 3, 4, 5, 6, 7}), Set#{1, 2, 3, 4, 5, 6, 7}))
+def delete12(): Bool = Set.__eq(Set.delete(8, Set#{1, 2, 3, 4, 5, 6, 7}), Set#{1, 2, 3, 4, 5, 6, 7}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // isEmpty                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def isEmpty01(): Bool = assert!(Set.isEmpty(Set#{}))
+def isEmpty01(): Bool = Set.isEmpty(Set#{}) == true
 
 @test
-def isEmpty02(): Bool = assertNot!(Set.isEmpty(Set#{1}))
+def isEmpty02(): Bool = Set.isEmpty(Set#{1}) == false
 
 @test
-def isEmpty03(): Bool = assertNot!(Set.isEmpty(Set#{1, 2}))
+def isEmpty03(): Bool = Set.isEmpty(Set#{1, 2}) == false
 
 @test
-def isEmpty04(): Bool = assertNot!(Set.isEmpty(Set#{1, 2, 3}))
+def isEmpty04(): Bool = Set.isEmpty(Set#{1, 2, 3}) == false
 
 @test
-def isEmpty05(): Bool = assertNot!(Set.isEmpty(Set#{1, 2, 3, 4, 5, 6, 7, 8}))
+def isEmpty05(): Bool = Set.isEmpty(Set#{1, 2, 3, 4, 5, 6, 7, 8}) == false
 
 /////////////////////////////////////////////////////////////////////////////
 // memberOf                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def memberOf01(): Bool = assertNot!(Set.memberOf(1, Set#{}))
+def memberOf01(): Bool = Set.memberOf(1, Set#{}) == false
 
 @test
-def memberOf02(): Bool = assertNot!(Set.memberOf(1, Set#{2}))
+def memberOf02(): Bool = Set.memberOf(1, Set#{2}) == false
 
 @test
-def memberOf03(): Bool = assert!(Set.memberOf(1, Set#{1}))
+def memberOf03(): Bool = Set.memberOf(1, Set#{1}) == true
 
 @test
-def memberOf04(): Bool = assert!(Set.memberOf(1, Set#{1, 2}))
+def memberOf04(): Bool = Set.memberOf(1, Set#{1, 2}) == true
 
 @test
-def memberOf05(): Bool = assert!(Set.memberOf(2, Set#{1, 2}))
+def memberOf05(): Bool = Set.memberOf(2, Set#{1, 2}) == true
 
 @test
-def memberOf06(): Bool = assertNot!(Set.memberOf(0, Set#{1, 2}))
+def memberOf06(): Bool = Set.memberOf(0, Set#{1, 2}) == false
 
 @test
-def memberOf07(): Bool = assertNot!(Set.memberOf(3, Set#{1, 2}))
+def memberOf07(): Bool = Set.memberOf(3, Set#{1, 2}) == false
 
 @test
-def memberOf08(): Bool = assertNot!(Set.memberOf(0, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+def memberOf08(): Bool = Set.memberOf(0, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) == false
 
 @test
-def memberOf09(): Bool = assert!(Set.memberOf(1, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+def memberOf09(): Bool = Set.memberOf(1, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) == true
 
 @test
-def memberOf10(): Bool = assert!(Set.memberOf(2, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+def memberOf10(): Bool = Set.memberOf(2, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) == true
 
 @test
-def memberOf11(): Bool = assert!(Set.memberOf(10, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+def memberOf11(): Bool = Set.memberOf(10, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) == true
 
 @test
-def memberOf12(): Bool = assertNot!(Set.memberOf(12, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+def memberOf12(): Bool = Set.memberOf(12, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) == false
 
 /////////////////////////////////////////////////////////////////////////////
 // find                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def find01(): Bool = Set.find(i -> i > 2, Set#{}) `assertEq!` None
+def find01(): Bool = Set.find(i -> i > 2, Set#{}) == None
 
 @test
-def find02(): Bool = Set.find(i -> i > 2, Set#{1}) `assertEq!` None
+def find02(): Bool = Set.find(i -> i > 2, Set#{1}) == None
 
 @test
-def find03(): Bool = Set.find(i -> i > 2, Set#{3}) `assertEq!` Some(3)
+def find03(): Bool = Set.find(i -> i > 2, Set#{3}) == Some(3)
 
 @test
-def find04(): Bool = Set.find(i -> i > 2, Set#{2, 1}) `assertEq!` None
+def find04(): Bool = Set.find(i -> i > 2, Set#{2, 1}) == None
 
 @test
-def find05(): Bool = Set.find(i -> i > 2, Set#{-6, 6}) `assertEq!` Some(6)
+def find05(): Bool = Set.find(i -> i > 2, Set#{-6, 6}) == Some(6)
 
 @test
-def find06(): Bool = Set.find(i -> i > 2, Set#{6, -6}) `assertEq!` Some(6)
+def find06(): Bool = Set.find(i -> i > 2, Set#{6, -6}) == Some(6)
 
 @test
-def find07(): Bool = Set.find(i -> i > 2, Set#{7, 6}) `assertEq!` Some(6)
+def find07(): Bool = Set.find(i -> i > 2, Set#{7, 6}) == Some(6)
 
 /////////////////////////////////////////////////////////////////////////////
 // findLeft                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def findLeft01(): Bool = Set.findLeft(i -> i > 2, Set#{}) `assertEq!` None
+def findLeft01(): Bool = Set.findLeft(i -> i > 2, Set#{}) == None
 
 @test
-def findLeft02(): Bool = Set.findLeft(i -> i > 2, Set#{1}) `assertEq!` None
+def findLeft02(): Bool = Set.findLeft(i -> i > 2, Set#{1}) == None
 
 @test
-def findLeft03(): Bool = Set.findLeft(i -> i > 2, Set#{3}) `assertEq!` Some(3)
+def findLeft03(): Bool = Set.findLeft(i -> i > 2, Set#{3}) == Some(3)
 
 @test
-def findLeft04(): Bool = Set.findLeft(i -> i > 2, Set#{2, 1}) `assertEq!` None
+def findLeft04(): Bool = Set.findLeft(i -> i > 2, Set#{2, 1}) == None
 
 @test
-def findLeft05(): Bool = Set.findLeft(i -> i > 2, Set#{-6, 6}) `assertEq!` Some(6)
+def findLeft05(): Bool = Set.findLeft(i -> i > 2, Set#{-6, 6}) == Some(6)
 
 @test
-def findLeft06(): Bool = Set.findLeft(i -> i > 2, Set#{6, -6}) `assertEq!` Some(6)
+def findLeft06(): Bool = Set.findLeft(i -> i > 2, Set#{6, -6}) == Some(6)
 
 @test
-def findLeft07(): Bool = Set.findLeft(i -> i > 2, Set#{7, 6}) `assertEq!` Some(6)
+def findLeft07(): Bool = Set.findLeft(i -> i > 2, Set#{7, 6}) == Some(6)
 
 /////////////////////////////////////////////////////////////////////////////
 // findRight                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def findRight01(): Bool = Set.findRight(i -> i > 2, Set#{}) `assertEq!` None
+def findRight01(): Bool = Set.findRight(i -> i > 2, Set#{}) == None
 
 @test
-def findRight02(): Bool = Set.findRight(i -> i > 2, Set#{1}) `assertEq!` None
+def findRight02(): Bool = Set.findRight(i -> i > 2, Set#{1}) == None
 
 @test
-def findRight03(): Bool = Set.findRight(i -> i > 2, Set#{3}) `assertEq!` Some(3)
+def findRight03(): Bool = Set.findRight(i -> i > 2, Set#{3}) == Some(3)
 
 @test
-def findRight04(): Bool = Set.findRight(i -> i > 2, Set#{2, 1}) `assertEq!` None
+def findRight04(): Bool = Set.findRight(i -> i > 2, Set#{2, 1}) == None
 
 @test
-def findRight05(): Bool = Set.findRight(i -> i > 2, Set#{-6, 6}) `assertEq!` Some(6)
+def findRight05(): Bool = Set.findRight(i -> i > 2, Set#{-6, 6}) == Some(6)
 
 @test
-def findRight06(): Bool = Set.findRight(i -> i > 2, Set#{6, -6}) `assertEq!` Some(6)
+def findRight06(): Bool = Set.findRight(i -> i > 2, Set#{6, -6}) == Some(6)
 
 @test
-def findRight07(): Bool = Set.findRight(i -> i > 2, Set#{7, 6}) `assertEq!` Some(7)
+def findRight07(): Bool = Set.findRight(i -> i > 2, Set#{7, 6}) == Some(7)
 
 /////////////////////////////////////////////////////////////////////////////
 // isSubsetOf                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def isSubsetOf01(): Bool = assert!(Set.isSubsetOf(Set#{}, Set#{}))
+def isSubsetOf01(): Bool = Set.isSubsetOf(Set#{}, Set#{}) == true
 
 @test
-def isSubsetOf02(): Bool = assert!(Set.isSubsetOf(Set#{}, Set#{1}))
+def isSubsetOf02(): Bool = Set.isSubsetOf(Set#{}, Set#{1}) == true
 
 @test
-def isSubsetOf03(): Bool = assert!(Set.isSubsetOf(Set#{1}, Set#{1}))
+def isSubsetOf03(): Bool = Set.isSubsetOf(Set#{1}, Set#{1}) == true
 
 @test
-def isSubsetOf04(): Bool = assertNot!(Set.isSubsetOf(Set#{1}, Set#{2}))
+def isSubsetOf04(): Bool = Set.isSubsetOf(Set#{1}, Set#{2}) == false
 
 @test
-def isSubsetOf05(): Bool = assert!(Set.isSubsetOf(Set#{}, Set#{1, 2}))
+def isSubsetOf05(): Bool = Set.isSubsetOf(Set#{}, Set#{1, 2}) == true
 
 @test
-def isSubsetOf06(): Bool = assert!(Set.isSubsetOf(Set#{1}, Set#{1, 2}))
+def isSubsetOf06(): Bool = Set.isSubsetOf(Set#{1}, Set#{1, 2}) == true
 
 @test
-def isSubsetOf07(): Bool = assert!(Set.isSubsetOf(Set#{2}, Set#{1, 2}))
+def isSubsetOf07(): Bool = Set.isSubsetOf(Set#{2}, Set#{1, 2}) == true
 
 @test
-def isSubsetOf08(): Bool = assertNot!(Set.isSubsetOf(Set#{3}, Set#{1, 2}))
+def isSubsetOf08(): Bool = Set.isSubsetOf(Set#{3}, Set#{1, 2}) == false
 
 @test
-def isSubsetOf09(): Bool = assert!(Set.isSubsetOf(Set#{1, 2}, Set#{1, 2}))
+def isSubsetOf09(): Bool = Set.isSubsetOf(Set#{1, 2}, Set#{1, 2}) == true
 
 @test
-def isSubsetOf10(): Bool = assert!(Set.isSubsetOf(Set#{2, 1}, Set#{1, 2}))
+def isSubsetOf10(): Bool = Set.isSubsetOf(Set#{2, 1}, Set#{1, 2}) == true
 
 @test
-def isSubsetOf11(): Bool = assertNot!(Set.isSubsetOf(Set#{3, 1}, Set#{1, 2}))
+def isSubsetOf11(): Bool = Set.isSubsetOf(Set#{3, 1}, Set#{1, 2}) == false
 
 @test
-def isSubsetOf12(): Bool = assertNot!(Set.isSubsetOf(Set#{1, 2, 3}, Set#{1, 2}))
+def isSubsetOf12(): Bool = Set.isSubsetOf(Set#{1, 2, 3}, Set#{1, 2}) == false
 
 @test
-def isSubsetOf13(): Bool = assert!(Set.isSubsetOf(Set#{10}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+def isSubsetOf13(): Bool = Set.isSubsetOf(Set#{10}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) == true
 
 @test
-def isSubsetOf14(): Bool = assert!(Set.isSubsetOf(Set#{9, 1}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+def isSubsetOf14(): Bool = Set.isSubsetOf(Set#{9, 1}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) == true
 
 @test
-def isSubsetOf15(): Bool = assert!(Set.isSubsetOf(Set#{6, 5, 8}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+def isSubsetOf15(): Bool = Set.isSubsetOf(Set#{6, 5, 8}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) == true
 
 @test
-def isSubsetOf16(): Bool = assertNot!(Set.isSubsetOf(Set#{10, 2, 3, 6, -1, 4}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+def isSubsetOf16(): Bool = Set.isSubsetOf(Set#{10, 2, 3, 6, -1, 4}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) == false
 
 /////////////////////////////////////////////////////////////////////////////
 // isProperSubsetOf                                                        //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def isProperSubsetOf01(): Bool = assertNot!(Set.isProperSubsetOf(Set#{}, Set#{}))
+def isProperSubsetOf01(): Bool = Set.isProperSubsetOf(Set#{}, Set#{}) == false
 
 @test
-def isProperSubsetOf02(): Bool = assert!(Set.isProperSubsetOf(Set#{}, Set#{1}))
+def isProperSubsetOf02(): Bool = Set.isProperSubsetOf(Set#{}, Set#{1}) == true
 
 @test
-def isProperSubsetOf03(): Bool = assertNot!(Set.isProperSubsetOf(Set#{1}, Set#{1}))
+def isProperSubsetOf03(): Bool = Set.isProperSubsetOf(Set#{1}, Set#{1}) == false
 
 @test
-def isProperSubsetOf04(): Bool = assertNot!(Set.isProperSubsetOf(Set#{1}, Set#{2}))
+def isProperSubsetOf04(): Bool = Set.isProperSubsetOf(Set#{1}, Set#{2}) == false
 
 @test
-def isProperSubsetOf05(): Bool = assert!(Set.isProperSubsetOf(Set#{}, Set#{1, 2}))
+def isProperSubsetOf05(): Bool = Set.isProperSubsetOf(Set#{}, Set#{1, 2}) == true
 
 @test
-def isProperSubsetOf06(): Bool = assert!(Set.isProperSubsetOf(Set#{1}, Set#{1, 2}))
+def isProperSubsetOf06(): Bool = Set.isProperSubsetOf(Set#{1}, Set#{1, 2}) == true
 
 @test
-def isProperSubsetOf07(): Bool = assert!(Set.isProperSubsetOf(Set#{2}, Set#{1, 2}))
+def isProperSubsetOf07(): Bool = Set.isProperSubsetOf(Set#{2}, Set#{1, 2}) == true
 
 @test
-def isProperSubsetOf08(): Bool = assertNot!(Set.isProperSubsetOf(Set#{3}, Set#{1, 2}))
+def isProperSubsetOf08(): Bool = Set.isProperSubsetOf(Set#{3}, Set#{1, 2}) == false
 
 @test
-def isProperSubsetOf09(): Bool = assertNot!(Set.isProperSubsetOf(Set#{1, 2}, Set#{1, 2}))
+def isProperSubsetOf09(): Bool = Set.isProperSubsetOf(Set#{1, 2}, Set#{1, 2}) == false
 
 @test
-def isProperSubsetOf10(): Bool = assertNot!(Set.isProperSubsetOf(Set#{2, 1}, Set#{1, 2}))
+def isProperSubsetOf10(): Bool = Set.isProperSubsetOf(Set#{2, 1}, Set#{1, 2}) == false
 
 @test
-def isProperSubsetOf11(): Bool = assertNot!(Set.isProperSubsetOf(Set#{3, 1}, Set#{1, 2}))
+def isProperSubsetOf11(): Bool = Set.isProperSubsetOf(Set#{3, 1}, Set#{1, 2}) == false
 
 @test
-def isProperSubsetOf12(): Bool = assertNot!(Set.isProperSubsetOf(Set#{1, 2, 3}, Set#{1, 2}))
+def isProperSubsetOf12(): Bool = Set.isProperSubsetOf(Set#{1, 2, 3}, Set#{1, 2}) == false
 
 @test
-def isProperSubsetOf13(): Bool = assert!(Set.isProperSubsetOf(Set#{10}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+def isProperSubsetOf13(): Bool = Set.isProperSubsetOf(Set#{10}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) == true
 
 @test
-def isProperSubsetOf14(): Bool = assert!(Set.isProperSubsetOf(Set#{9, 1}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+def isProperSubsetOf14(): Bool = Set.isProperSubsetOf(Set#{9, 1}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) == true
 
 @test
-def isProperSubsetOf15(): Bool = assert!(Set.isProperSubsetOf(Set#{6, 5, 8}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+def isProperSubsetOf15(): Bool = Set.isProperSubsetOf(Set#{6, 5, 8}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) == true
 
 @test
-def isProperSubsetOf16(): Bool = assertNot!(Set.isProperSubsetOf(Set#{10, 2, 3, 6, -1, 4}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+def isProperSubsetOf16(): Bool = Set.isProperSubsetOf(Set#{10, 2, 3, 6, -1, 4}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) == false
 
 @test
-def isProperSubsetOf17(): Bool = assertNot!(Set.isProperSubsetOf(Set#{10, 2, 3, 6, 1, 4, 5, 9, 8, 7}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+def isProperSubsetOf17(): Bool = Set.isProperSubsetOf(Set#{10, 2, 3, 6, 1, 4, 5, 9, 8, 7}, Set#{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) == false
 
 /////////////////////////////////////////////////////////////////////////////
 // fold                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def fold01(): Bool = Set.fold((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{}) `assertEq!` 100
+def fold01(): Bool = Set.fold((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{}) == 100
 
 @test
-def fold02(): Bool = Set.fold((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{1}) `assertEq!` 198
+def fold02(): Bool = Set.fold((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{1}) == 198
 
 @test
-def fold03(): Bool = Set.fold((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{2, 1}) `assertEq!` 196
+def fold03(): Bool = Set.fold((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{2, 1}) == 196
 
 @test
-def fold04(): Bool = Set.fold((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{3, 2, 1}) `assertEq!` 386
+def fold04(): Bool = Set.fold((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{3, 2, 1}) == 386
 
 /////////////////////////////////////////////////////////////////////////////
 // foldLeft                                                                //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldLeft01(): Bool = Set.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{}) `assertEq!` 100
+def foldLeft01(): Bool = Set.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{}) == 100
 
 @test
-def foldLeft02(): Bool = Set.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{1}) `assertEq!` 198
+def foldLeft02(): Bool = Set.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{1}) == 198
 
 @test
-def foldLeft03(): Bool = Set.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{2, 1}) `assertEq!` 196
+def foldLeft03(): Bool = Set.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{2, 1}) == 196
 
 @test
-def foldLeft04(): Bool = Set.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{3, 2, 1}) `assertEq!` 386
+def foldLeft04(): Bool = Set.foldLeft((i, e) -> (i - e)*(e % 2 + 1), 100, Set#{3, 2, 1}) == 386
 
 /////////////////////////////////////////////////////////////////////////////
 // foldRight                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldRight01(): Bool = Set.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, Set#{}) `assertEq!` 100
+def foldRight01(): Bool = Set.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, Set#{}) == 100
 
 @test
-def foldRight02(): Bool = Set.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, Set#{1}) `assertEq!` 198
+def foldRight02(): Bool = Set.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, Set#{1}) == 198
 
 @test
-def foldRight03(): Bool = Set.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, Set#{2, 1}) `assertEq!` 194
+def foldRight03(): Bool = Set.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, Set#{2, 1}) == 194
 
 @test
-def foldRight04(): Bool = Set.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, Set#{3, 2, 1}) `assertEq!` 382
+def foldRight04(): Bool = Set.foldRight((e, i) -> (i - e)*(e % 2 + 1), 100, Set#{3, 2, 1}) == 382
 
 /////////////////////////////////////////////////////////////////////////////
 // reduce                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduce01(): Bool = Set.reduce((a, b) -> a-b, Set#{}: Set[Int]) `assertEq!` None
+def reduce01(): Bool = Set.reduce((a, b) -> a-b, Set#{}: Set[Int]) == None
 
 @test
-def reduce02(): Bool = Set.reduce((a, b) -> a-b, Set#{1}) `assertEq!` Some(1)
+def reduce02(): Bool = Set.reduce((a, b) -> a-b, Set#{1}) == Some(1)
 
 @test
-def reduce03(): Bool = Set.reduce((a, b) -> a-b, Set#{2, 1}) `assertEq!` Some(-1)
+def reduce03(): Bool = Set.reduce((a, b) -> a-b, Set#{2, 1}) == Some(-1)
 
 @test
-def reduce04(): Bool = Set.reduce((a, b) -> a-b, Set#{3, 2, 1}) `assertEq!` Some(-4)
+def reduce04(): Bool = Set.reduce((a, b) -> a-b, Set#{3, 2, 1}) == Some(-4)
 
 @test
-def reduce05(): Bool = Set.reduce((a, b) -> a-b, Set#{4, 3, 2, 1}) `assertEq!` Some(-8)
+def reduce05(): Bool = Set.reduce((a, b) -> a-b, Set#{4, 3, 2, 1}) == Some(-8)
 
 /////////////////////////////////////////////////////////////////////////////
 // reduceLeft                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduceLeft01(): Bool = Set.reduceLeft((a, b) -> a-b, Set#{}: Set[Int]) `assertEq!` None
+def reduceLeft01(): Bool = Set.reduceLeft((a, b) -> a-b, Set#{}: Set[Int]) == None
 
 @test
-def reduceLeft02(): Bool = Set.reduceLeft((a, b) -> a-b, Set#{1}) `assertEq!` Some(1)
+def reduceLeft02(): Bool = Set.reduceLeft((a, b) -> a-b, Set#{1}) == Some(1)
 
 @test
-def reduceLeft03(): Bool = Set.reduceLeft((a, b) -> a-b, Set#{2, 1}) `assertEq!` Some(-1)
+def reduceLeft03(): Bool = Set.reduceLeft((a, b) -> a-b, Set#{2, 1}) == Some(-1)
 
 @test
-def reduceLeft04(): Bool = Set.reduceLeft((a, b) -> a-b, Set#{3, 2, 1}) `assertEq!` Some(-4)
+def reduceLeft04(): Bool = Set.reduceLeft((a, b) -> a-b, Set#{3, 2, 1}) == Some(-4)
 
 @test
-def reduceLeft05(): Bool = Set.reduceLeft((a, b) -> a-b, Set#{4, 3, 2, 1}) `assertEq!` Some(-8)
+def reduceLeft05(): Bool = Set.reduceLeft((a, b) -> a-b, Set#{4, 3, 2, 1}) == Some(-8)
 
 /////////////////////////////////////////////////////////////////////////////
 // reduceRight                                                             //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def reduceRight01(): Bool = Set.reduceRight((a, b) -> a-b, Set#{}: Set[Int]) `assertEq!` None
+def reduceRight01(): Bool = Set.reduceRight((a, b) -> a-b, Set#{}: Set[Int]) == None
 
 @test
-def reduceRight02(): Bool = Set.reduceRight((a, b) -> a-b, Set#{1}) `assertEq!` Some(1)
+def reduceRight02(): Bool = Set.reduceRight((a, b) -> a-b, Set#{1}) == Some(1)
 
 @test
-def reduceRight03(): Bool = Set.reduceRight((a, b) -> a-b, Set#{2, 1}) `assertEq!` Some(-1)
+def reduceRight03(): Bool = Set.reduceRight((a, b) -> a-b, Set#{2, 1}) == Some(-1)
 
 @test
-def reduceRight04(): Bool = Set.reduceRight((a, b) -> a-b, Set#{3, 2, 1}) `assertEq!` Some(2)
+def reduceRight04(): Bool = Set.reduceRight((a, b) -> a-b, Set#{3, 2, 1}) == Some(2)
 
 @test
-def reduceRight05(): Bool = Set.reduceRight((a, b) -> a-b, Set#{4, 3, 2, 1}) `assertEq!` Some(-2)
+def reduceRight05(): Bool = Set.reduceRight((a, b) -> a-b, Set#{4, 3, 2, 1}) == Some(-2)
 
 /////////////////////////////////////////////////////////////////////////////
 // count                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def count01(): Bool = Set.count(i -> i > 3, Set#{}) `assertEq!` 0
+def count01(): Bool = Set.count(i -> i > 3, Set#{}) == 0
 
 @test
-def count02(): Bool = Set.count(i -> i > 3, Set#{1}) `assertEq!` 0
+def count02(): Bool = Set.count(i -> i > 3, Set#{1}) == 0
 
 @test
-def count03(): Bool = Set.count(i -> i > 3, Set#{4}) `assertEq!` 1
+def count03(): Bool = Set.count(i -> i > 3, Set#{4}) == 1
 
 @test
-def count04(): Bool = Set.count(i -> i > 3, Set#{2, 1}) `assertEq!` 0
+def count04(): Bool = Set.count(i -> i > 3, Set#{2, 1}) == 0
 
 @test
-def count05(): Bool = Set.count(i -> i > 3, Set#{8, 1}) `assertEq!` 1
+def count05(): Bool = Set.count(i -> i > 3, Set#{8, 1}) == 1
 
 @test
-def count06(): Bool = Set.count(i -> i > 3, Set#{1, 8}) `assertEq!` 1
+def count06(): Bool = Set.count(i -> i > 3, Set#{1, 8}) == 1
 
 @test
-def count07(): Bool = Set.count(i -> i > 3, Set#{7, 6}) `assertEq!` 2
+def count07(): Bool = Set.count(i -> i > 3, Set#{7, 6}) == 2
 
 /////////////////////////////////////////////////////////////////////////////
 // flatten                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def flatten01(): Bool = assert!(Set.__eq(Set.flatten(Set#{}), Set#{}))
+def flatten01(): Bool = Set.__eq(Set.flatten(Set#{}), Set#{}) == true
 
 @test
-def flatten02(): Bool = assert!(Set.__eq(Set.flatten(Set#{Set#{}}), Set#{}))
+def flatten02(): Bool = Set.__eq(Set.flatten(Set#{Set#{}}), Set#{}) == true
 
 @test
-def flatten03(): Bool = assert!(Set.__eq(Set.flatten(Set#{Set#{1}}), Set#{1}))
+def flatten03(): Bool = Set.__eq(Set.flatten(Set#{Set#{1}}), Set#{1}) == true
 
 @test
-def flatten04(): Bool = assert!(Set.__eq(Set.flatten(Set#{Set#{1, 2}}), Set#{1, 2}))
+def flatten04(): Bool = Set.__eq(Set.flatten(Set#{Set#{1, 2}}), Set#{1, 2}) == true
 
 @test
-def flatten05(): Bool = assert!(Set.__eq(Set.flatten(Set#{Set#{}, Set#{}}), Set#{}))
+def flatten05(): Bool = Set.__eq(Set.flatten(Set#{Set#{}, Set#{}}), Set#{}) == true
 
 @test
-def flatten06(): Bool = assert!(Set.__eq(Set.flatten(Set#{Set#{1}, Set#{}}), Set#{1}))
+def flatten06(): Bool = Set.__eq(Set.flatten(Set#{Set#{1}, Set#{}}), Set#{1}) == true
 
 @test
-def flatten07(): Bool = assert!(Set.__eq(Set.flatten(Set#{Set#{}, Set#{1}}), Set#{1}))
+def flatten07(): Bool = Set.__eq(Set.flatten(Set#{Set#{}, Set#{1}}), Set#{1}) == true
 
 @test
-def flatten08(): Bool = assert!(Set.__eq(Set.flatten(Set#{Set#{1}, Set#{2}}), Set#{1, 2}))
+def flatten08(): Bool = Set.__eq(Set.flatten(Set#{Set#{1}, Set#{2}}), Set#{1, 2}) == true
 
 @test
-def flatten09(): Bool = assert!(Set.__eq(Set.flatten(Set#{Set#{1}, Set#{1}}), Set#{1}))
+def flatten09(): Bool = Set.__eq(Set.flatten(Set#{Set#{1}, Set#{1}}), Set#{1}) == true
 
 @test
-def flatten10(): Bool = assert!(Set.__eq(Set.flatten(Set#{Set#{1, 2}, Set#{3, 4, 5}}), Set#{1, 2, 3, 4, 5}))
+def flatten10(): Bool = Set.__eq(Set.flatten(Set#{Set#{1, 2}, Set#{3, 4, 5}}), Set#{1, 2, 3, 4, 5}) == true
 
 @test
-def flatten11(): Bool = assert!(Set.__eq(Set.flatten(Set#{Set#{1, 2}, Set#{3, 4, 3}}), Set#{1, 2, 3, 4}))
+def flatten11(): Bool = Set.__eq(Set.flatten(Set#{Set#{1, 2}, Set#{3, 4, 3}}), Set#{1, 2, 3, 4}) == true
 
 @test
-def flatten12(): Bool = assert!(Set.__eq(Set.flatten(Set#{Set#{1, 2}, Set#{3, 4, 1}}), Set#{1, 2, 3, 4}))
+def flatten12(): Bool = Set.__eq(Set.flatten(Set#{Set#{1, 2}, Set#{3, 4, 1}}), Set#{1, 2, 3, 4}) == true
 
 @test
-def flatten13(): Bool = assert!(Set.__eq(Set.flatten(Set#{Set#{1}, Set#{2, 3}, Set#{4}}), Set#{1, 2, 3, 4}))
+def flatten13(): Bool = Set.__eq(Set.flatten(Set#{Set#{1}, Set#{2, 3}, Set#{4}}), Set#{1, 2, 3, 4}) == true
 
 @test
-def flatten14(): Bool = assert!(Set.__eq(Set.flatten(Set#{Set#{1}, Set#{2, 3}, Set#{1}}), Set#{1, 2, 3}))
+def flatten14(): Bool = Set.__eq(Set.flatten(Set#{Set#{1}, Set#{2, 3}, Set#{1}}), Set#{1, 2, 3}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // exists                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def exists01(): Bool = assertNot!(Set.exists(x -> x % 8 == 7, Set#{}))
+def exists01(): Bool = Set.exists(x -> x % 8 == 7, Set#{}) == false
 
 @test
-def exists02(): Bool = assertNot!(Set.exists(x -> x % 8 == 7, Set#{5}))
+def exists02(): Bool = Set.exists(x -> x % 8 == 7, Set#{5}) == false
 
 @test
-def exists03(): Bool = assert!(Set.exists(x -> x % 8 == 7, Set#{7}))
+def exists03(): Bool = Set.exists(x -> x % 8 == 7, Set#{7}) == true
 
 @test
-def exists04(): Bool = assert!(Set.exists(x -> x % 8 == 7, Set#{15}))
+def exists04(): Bool = Set.exists(x -> x % 8 == 7, Set#{15}) == true
 
 @test
-def exists05(): Bool = assertNot!(Set.exists(x -> x % 8 == 7, Set#{1, 44}))
+def exists05(): Bool = Set.exists(x -> x % 8 == 7, Set#{1, 44}) == false
 
 @test
-def exists06(): Bool = assert!(Set.exists(x -> x % 8 == 7, Set#{11, 71}))
+def exists06(): Bool = Set.exists(x -> x % 8 == 7, Set#{11, 71}) == true
 
 @test
-def exists07(): Bool = assert!(Set.exists(x -> x % 8 == 7, Set#{71, 12}))
+def exists07(): Bool = Set.exists(x -> x % 8 == 7, Set#{71, 12}) == true
 
 @test
-def exists08(): Bool = assert!(Set.exists(x -> x % 8 == 7, Set#{71, 79}))
+def exists08(): Bool = Set.exists(x -> x % 8 == 7, Set#{71, 79}) == true
 
 @test
-def exists09(): Bool = assertNot!(Set.exists(x -> x % 8 == 7, Set#{11, -1, -14, -2, 84, 113}))
+def exists09(): Bool = Set.exists(x -> x % 8 == 7, Set#{11, -1, -14, -2, 84, 113}) == false
 
 @test
-def exists10(): Bool = assert!(Set.exists(x -> x % 8 == 7, Set#{11, -1, 31, -14, -2, 84, 111}))
+def exists10(): Bool = Set.exists(x -> x % 8 == 7, Set#{11, -1, 31, -14, -2, 84, 111}) == true
 
 @test
-def exists11(): Bool = assert!(Set.exists(x -> x % 8 == 7, Set#{11, -1, -14, -2, 84, 111, 38}))
+def exists11(): Bool = Set.exists(x -> x % 8 == 7, Set#{11, -1, -14, -2, 84, 111, 38}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // forall                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def forall01(): Bool = assert!(Set.forall(x -> x % 8 == 7, Set#{}))
+def forall01(): Bool = Set.forall(x -> x % 8 == 7, Set#{}) == true
 
 @test
-def forall02(): Bool = assertNot!(Set.forall(x -> x % 8 == 7, Set#{5}))
+def forall02(): Bool = Set.forall(x -> x % 8 == 7, Set#{5}) == false
 
 @test
-def forall03(): Bool = assert!(Set.forall(x -> x % 8 == 7, Set#{7}))
+def forall03(): Bool = Set.forall(x -> x % 8 == 7, Set#{7}) == true
 
 @test
-def forall04(): Bool = assert!(Set.forall(x -> x % 8 == 7, Set#{15}))
+def forall04(): Bool = Set.forall(x -> x % 8 == 7, Set#{15}) == true
 
 @test
-def forall05(): Bool = assertNot!(Set.forall(x -> x % 8 == 7, Set#{1, 44}))
+def forall05(): Bool = Set.forall(x -> x % 8 == 7, Set#{1, 44}) == false
 
 @test
-def forall06(): Bool = assertNot!(Set.forall(x -> x % 8 == 7, Set#{11, 71}))
+def forall06(): Bool = Set.forall(x -> x % 8 == 7, Set#{11, 71}) == false
 
 @test
-def forall07(): Bool = assertNot!(Set.forall(x -> x % 8 == 7, Set#{71, 12}))
+def forall07(): Bool = Set.forall(x -> x % 8 == 7, Set#{71, 12}) == false
 
 @test
-def forall08(): Bool = assert!(Set.forall(x -> x % 8 == 7, Set#{71, 79}))
+def forall08(): Bool = Set.forall(x -> x % 8 == 7, Set#{71, 79}) == true
 
 @test
-def forall09(): Bool = assertNot!(Set.forall(x -> x % 8 == 7, Set#{7, 15, 23, 84, 111}))
+def forall09(): Bool = Set.forall(x -> x % 8 == 7, Set#{7, 15, 23, 84, 111}) == false
 
 @test
-def forall10(): Bool = assertNot!(Set.forall(x -> x % 8 == 7, Set#{7, 15, 23, 111, 3}))
+def forall10(): Bool = Set.forall(x -> x % 8 == 7, Set#{7, 15, 23, 111, 3}) == false
 
 @test
-def forall11(): Bool = assert!(Set.forall(x -> x % 8 == 7, Set#{7, 15, 23, 119, 111}))
+def forall11(): Bool = Set.forall(x -> x % 8 == 7, Set#{7, 15, 23, 119, 111}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // union                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def union01(): Bool = assert!(Set.__eq(Set.union(Set#{}, Set#{}), Set#{}))
+def union01(): Bool = Set.__eq(Set.union(Set#{}, Set#{}), Set#{}) == true
 
 @test
-def union02(): Bool = assert!(Set.__eq(Set.union(Set#{1}, Set#{}), Set#{1}))
+def union02(): Bool = Set.__eq(Set.union(Set#{1}, Set#{}), Set#{1}) == true
 
 @test
-def union03(): Bool = assert!(Set.__eq(Set.union(Set#{}, Set#{2}), Set#{2}))
+def union03(): Bool = Set.__eq(Set.union(Set#{}, Set#{2}), Set#{2}) == true
 
 @test
-def union04(): Bool = assert!(Set.__eq(Set.union(Set#{1}, Set#{1}), Set#{1}))
+def union04(): Bool = Set.__eq(Set.union(Set#{1}, Set#{1}), Set#{1}) == true
 
 @test
-def union05(): Bool = assert!(Set.__eq(Set.union(Set#{1}, Set#{-1}), Set#{1, -1}))
+def union05(): Bool = Set.__eq(Set.union(Set#{1}, Set#{-1}), Set#{1, -1}) == true
 
 @test
-def union06(): Bool = assert!(Set.__eq(Set.union(Set#{}, Set#{-1, 9}), Set#{-1, 9}))
+def union06(): Bool = Set.__eq(Set.union(Set#{}, Set#{-1, 9}), Set#{-1, 9}) == true
 
 @test
-def union07(): Bool = assert!(Set.__eq(Set.union(Set#{9}, Set#{-1, 9}), Set#{-1, 9}))
+def union07(): Bool = Set.__eq(Set.union(Set#{9}, Set#{-1, 9}), Set#{-1, 9}) == true
 
 @test
-def union08(): Bool = assert!(Set.__eq(Set.union(Set#{4}, Set#{-1, 9}), Set#{4, -1, 9}))
+def union08(): Bool = Set.__eq(Set.union(Set#{4}, Set#{-1, 9}), Set#{4, -1, 9}) == true
 
 @test
-def union09(): Bool = assert!(Set.__eq(Set.union(Set#{9, -1}, Set#{-1, 9}), Set#{-1, 9}))
+def union09(): Bool = Set.__eq(Set.union(Set#{9, -1}, Set#{-1, 9}), Set#{-1, 9}) == true
 
 @test
-def union10(): Bool = assert!(Set.__eq(Set.union(Set#{9, 5}, Set#{-1, 9}), Set#{5, -1, 9}))
+def union10(): Bool = Set.__eq(Set.union(Set#{9, 5}, Set#{-1, 9}), Set#{5, -1, 9}) == true
 
 @test
-def union11(): Bool = assert!(Set.__eq(Set.union(Set#{6, 5}, Set#{-1, 9}), Set#{6, 5, -1, 9}))
+def union11(): Bool = Set.__eq(Set.union(Set#{6, 5}, Set#{-1, 9}), Set#{6, 5, -1, 9}) == true
 
 @test
-def union12(): Bool = assert!(Set.__eq(Set.union(Set#{6, -99}, Set#{6, 5, -1, 9, 43, 7, 8, -99}), Set#{6, 5, -1, 9, 43, 7, 8, -99}))
+def union12(): Bool = Set.__eq(Set.union(Set#{6, -99}, Set#{6, 5, -1, 9, 43, 7, 8, -99}), Set#{6, 5, -1, 9, 43, 7, 8, -99}) == true
 
 @test
-def union13(): Bool = assert!(Set.__eq(Set.union(Set#{6, -99, -1, 5, 22}, Set#{6, 5, -1, 9, 43, 7, 8, -99}), Set#{22, 6, 5, -1, 9, 43, 7, 8, -99}))
+def union13(): Bool = Set.__eq(Set.union(Set#{6, -99, -1, 5, 22}, Set#{6, 5, -1, 9, 43, 7, 8, -99}), Set#{22, 6, 5, -1, 9, 43, 7, 8, -99}) == true
 
 @test
-def union14(): Bool = assert!(Set.__eq(Set.union(Set#{-2, -3, -4}, Set#{6, 5, -1, 9, 43, 7, 8, -99}), Set#{-2, -3, -4, 6, 5, -1, 9, 43, 7, 8, -99}))
+def union14(): Bool = Set.__eq(Set.union(Set#{-2, -3, -4}, Set#{6, 5, -1, 9, 43, 7, 8, -99}), Set#{-2, -3, -4, 6, 5, -1, 9, 43, 7, 8, -99}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // intersection                                                            //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def intersection01(): Bool = assert!(Set.__eq(Set.intersection(Set#{}, Set#{}), Set#{}))
+def intersection01(): Bool = Set.__eq(Set.intersection(Set#{}, Set#{}), Set#{}) == true
 
 @test
-def intersection02(): Bool = assert!(Set.__eq(Set.intersection(Set#{1}, Set#{}), Set#{}))
+def intersection02(): Bool = Set.__eq(Set.intersection(Set#{1}, Set#{}), Set#{}) == true
 
 @test
-def intersection03(): Bool = assert!(Set.__eq(Set.intersection(Set#{}, Set#{2}), Set#{}))
+def intersection03(): Bool = Set.__eq(Set.intersection(Set#{}, Set#{2}), Set#{}) == true
 
 @test
-def intersection04(): Bool = assert!(Set.__eq(Set.intersection(Set#{1}, Set#{2}), Set#{}))
+def intersection04(): Bool = Set.__eq(Set.intersection(Set#{1}, Set#{2}), Set#{}) == true
 
 @test
-def intersection05(): Bool = assert!(Set.__eq(Set.intersection(Set#{1}, Set#{1}), Set#{1}))
+def intersection05(): Bool = Set.__eq(Set.intersection(Set#{1}, Set#{1}), Set#{1}) == true
 
 @test
-def intersection06(): Bool = assert!(Set.__eq(Set.intersection(Set#{}, Set#{1, 2}), Set#{}))
+def intersection06(): Bool = Set.__eq(Set.intersection(Set#{}, Set#{1, 2}), Set#{}) == true
 
 @test
-def intersection07(): Bool = assert!(Set.__eq(Set.intersection(Set#{1, 2}, Set#{}), Set#{}))
+def intersection07(): Bool = Set.__eq(Set.intersection(Set#{1, 2}, Set#{}), Set#{}) == true
 
 @test
-def intersection08(): Bool = assert!(Set.__eq(Set.intersection(Set#{2}, Set#{1, 2}), Set#{2}))
+def intersection08(): Bool = Set.__eq(Set.intersection(Set#{2}, Set#{1, 2}), Set#{2}) == true
 
 @test
-def intersection09(): Bool = assert!(Set.__eq(Set.intersection(Set#{1}, Set#{1, 2}), Set#{1}))
+def intersection09(): Bool = Set.__eq(Set.intersection(Set#{1}, Set#{1, 2}), Set#{1}) == true
 
 @test
-def intersection10(): Bool = assert!(Set.__eq(Set.intersection(Set#{2, 1}, Set#{1, 2}), Set#{2, 1}))
+def intersection10(): Bool = Set.__eq(Set.intersection(Set#{2, 1}, Set#{1, 2}), Set#{2, 1}) == true
 
 @test
-def intersection11(): Bool = assert!(Set.__eq(Set.intersection(Set#{1, 2}, Set#{1, 2}), Set#{1, 2}))
+def intersection11(): Bool = Set.__eq(Set.intersection(Set#{1, 2}, Set#{1, 2}), Set#{1, 2}) == true
 
 @test
-def intersection12(): Bool = assert!(Set.__eq(Set.intersection(Set#{3, 2}, Set#{1, 2}), Set#{2}))
+def intersection12(): Bool = Set.__eq(Set.intersection(Set#{3, 2}, Set#{1, 2}), Set#{2}) == true
 
 @test
-def intersection13(): Bool = assert!(Set.__eq(Set.intersection(Set#{3, 55}, Set#{1, 2}), Set#{}))
+def intersection13(): Bool = Set.__eq(Set.intersection(Set#{3, 55}, Set#{1, 2}), Set#{}) == true
 
 @test
-def intersection14(): Bool = assert!(Set.__eq(Set.intersection(Set#{3, 55, 11, 87, 22, 34, -87, 23}, Set#{1, 2, 84, -87, 87, 3, 44}), Set#{3, 87, -87}))
+def intersection14(): Bool = Set.__eq(Set.intersection(Set#{3, 55, 11, 87, 22, 34, -87, 23}, Set#{1, 2, 84, -87, 87, 3, 44}), Set#{3, 87, -87}) == true
 
 @test
-def intersection15(): Bool = assert!(Set.__eq(Set.intersection(Set#{3, 55, 11, 87, 22, 34, -87, 23}, Set#{23, 1, 2, 84, 87, 3}), Set#{3, 87, 23}))
+def intersection15(): Bool = Set.__eq(Set.intersection(Set#{3, 55, 11, 87, 22, 34, -87, 23}, Set#{23, 1, 2, 84, 87, 3}), Set#{3, 87, 23}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // difference                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def difference01(): Bool = assert!(Set.__eq(Set.difference(Set#{}, Set#{}), Set#{}))
+def difference01(): Bool = Set.__eq(Set.difference(Set#{}, Set#{}), Set#{}) == true
 
 @test
-def difference02(): Bool = assert!(Set.__eq(Set.difference(Set#{}, Set#{2}), Set#{}))
+def difference02(): Bool = Set.__eq(Set.difference(Set#{}, Set#{2}), Set#{}) == true
 
 @test
-def difference03(): Bool = assert!(Set.__eq(Set.difference(Set#{1}, Set#{}), Set#{1}))
+def difference03(): Bool = Set.__eq(Set.difference(Set#{1}, Set#{}), Set#{1}) == true
 
 @test
-def difference04(): Bool = assert!(Set.__eq(Set.difference(Set#{1}, Set#{2}), Set#{1}))
+def difference04(): Bool = Set.__eq(Set.difference(Set#{1}, Set#{2}), Set#{1}) == true
 
 @test
-def difference05(): Bool = assert!(Set.__eq(Set.difference(Set#{1}, Set#{1}), Set#{}))
+def difference05(): Bool = Set.__eq(Set.difference(Set#{1}, Set#{1}), Set#{}) == true
 
 @test
-def difference06(): Bool = assert!(Set.__eq(Set.difference(Set#{1, 2}, Set#{}), Set#{1, 2}))
+def difference06(): Bool = Set.__eq(Set.difference(Set#{1, 2}, Set#{}), Set#{1, 2}) == true
 
 @test
-def difference07(): Bool = assert!(Set.__eq(Set.difference(Set#{1, 2}, Set#{1}), Set#{2}))
+def difference07(): Bool = Set.__eq(Set.difference(Set#{1, 2}, Set#{1}), Set#{2}) == true
 
 @test
-def difference08(): Bool = assert!(Set.__eq(Set.difference(Set#{1, 2}, Set#{2}), Set#{1}))
+def difference08(): Bool = Set.__eq(Set.difference(Set#{1, 2}, Set#{2}), Set#{1}) == true
 
 @test
-def difference09(): Bool = assert!(Set.__eq(Set.difference(Set#{1, 2}, Set#{8, 2, 4}), Set#{1}))
+def difference09(): Bool = Set.__eq(Set.difference(Set#{1, 2}, Set#{8, 2, 4}), Set#{1}) == true
 
 @test
-def difference10(): Bool = assert!(Set.__eq(Set.difference(Set#{1, 2}, Set#{3, 1, 2, 4}), Set#{}))
+def difference10(): Bool = Set.__eq(Set.difference(Set#{1, 2}, Set#{3, 1, 2, 4}), Set#{}) == true
 
 @test
-def difference11(): Bool = assert!(Set.__eq(Set.difference(Set#{1, 2}, Set#{3, 11, 21, 4}), Set#{1, 2}))
+def difference11(): Bool = Set.__eq(Set.difference(Set#{1, 2}, Set#{3, 11, 21, 4}), Set#{1, 2}) == true
 
 @test
-def difference12(): Bool = assert!(Set.__eq(Set.difference(Set#{1, 2, 87, 4, 5, 6, 86, 92, 111, -1}, Set#{-1, 92, 4, 5, 1, 2, 86}), Set#{87, 6, 111}))
+def difference12(): Bool = Set.__eq(Set.difference(Set#{1, 2, 87, 4, 5, 6, 86, 92, 111, -1}, Set#{-1, 92, 4, 5, 1, 2, 86}), Set#{87, 6, 111}) == true
 
 @test
-def difference13(): Bool = assert!(Set.__eq(Set.difference(Set#{1, 2, 87, 4, 5, 6, 86, 92, 111, -1}, Set#{-1, 92, 4, 5, 1, 2, 86, 99, 6}), Set#{87, 111}))
+def difference13(): Bool = Set.__eq(Set.difference(Set#{1, 2, 87, 4, 5, 6, 86, 92, 111, -1}, Set#{-1, 92, 4, 5, 1, 2, 86, 99, 6}), Set#{87, 111}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // subsets                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def subsets01(): Bool = assert!(Set.__eq(Set.subsets(Set#{}), Set#{Set#{}}))
+def subsets01(): Bool = Set.__eq(Set.subsets(Set#{}), Set#{Set#{}}) == true
 
 @test
-def subsets02(): Bool = assert!(Set.__eq(Set.subsets(Set#{1}), Set#{Set#{1}, Set#{}}))
+def subsets02(): Bool = Set.__eq(Set.subsets(Set#{1}), Set#{Set#{1}, Set#{}}) == true
 
 @test
-def subsets03(): Bool = assert!(Set.__eq(Set.subsets(Set#{1, 2}), Set#{Set#{1, 2}, Set#{1}, Set#{2}, Set#{}}))
+def subsets03(): Bool = Set.__eq(Set.subsets(Set#{1, 2}), Set#{Set#{1, 2}, Set#{1}, Set#{2}, Set#{}}) == true
 
 @test
-def subsets04(): Bool = assert!(Set.__eq(Set.subsets(Set#{1, 2, 3}), Set#{Set#{1, 2, 3}, Set#{1, 2}, Set#{1, 3}, Set#{1}, Set#{2, 3}, Set#{2}, Set#{3}, Set#{}}))
+def subsets04(): Bool = Set.__eq(Set.subsets(Set#{1, 2, 3}), Set#{Set#{1, 2, 3}, Set#{1, 2}, Set#{1, 3}, Set#{1}, Set#{2, 3}, Set#{2}, Set#{3}, Set#{}}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // filter                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def filter01(): Bool = assert!(Set.__eq(Set.filter(x -> x % 2 == 0, Set#{}), Set#{}))
+def filter01(): Bool = Set.__eq(Set.filter(x -> x % 2 == 0, Set#{}), Set#{}) == true
 
 @test
-def filter02(): Bool = assert!(Set.__eq(Set.filter(x -> x % 2 == 0, Set#{1}), Set#{}))
+def filter02(): Bool = Set.__eq(Set.filter(x -> x % 2 == 0, Set#{1}), Set#{}) == true
 
 @test
-def filter03(): Bool = assert!(Set.__eq(Set.filter(x -> x % 2 == 0, Set#{2}), Set#{2}))
+def filter03(): Bool = Set.__eq(Set.filter(x -> x % 2 == 0, Set#{2}), Set#{2}) == true
 
 @test
-def filter04(): Bool = assert!(Set.__eq(Set.filter(x -> x % 2 == 0, Set#{1, 3}), Set#{}))
+def filter04(): Bool = Set.__eq(Set.filter(x -> x % 2 == 0, Set#{1, 3}), Set#{}) == true
 
 @test
-def filter05(): Bool = assert!(Set.__eq(Set.filter(x -> x % 2 == 0, Set#{8, 3}), Set#{8}))
+def filter05(): Bool = Set.__eq(Set.filter(x -> x % 2 == 0, Set#{8, 3}), Set#{8}) == true
 
 @test
-def filter06(): Bool = assert!(Set.__eq(Set.filter(x -> x % 2 == 0, Set#{-1, 32}), Set#{32}))
+def filter06(): Bool = Set.__eq(Set.filter(x -> x % 2 == 0, Set#{-1, 32}), Set#{32}) == true
 
 @test
-def filter07(): Bool = assert!(Set.__eq(Set.filter(x -> x % 2 == 0, Set#{12, 34}), Set#{12, 34}))
+def filter07(): Bool = Set.__eq(Set.filter(x -> x % 2 == 0, Set#{12, 34}), Set#{12, 34}) == true
 
 @test
-def filter08(): Bool = assert!(Set.__eq(Set.filter(x -> x % 2 == 0, Set#{-33, -1, 12, 1, 34, 88, 7, 77, 31}), Set#{12, 34, 88}))
+def filter08(): Bool = Set.__eq(Set.filter(x -> x % 2 == 0, Set#{-33, -1, 12, 1, 34, 88, 7, 77, 31}), Set#{12, 34, 88}) == true
 
 @test
-def filter09(): Bool = assert!(Set.__eq(Set.filter(x -> x % 2 == 0, Set#{-33, -1, 12, 1, 34, 88, 7, 77, 31, 7, -92, 841}), Set#{12, 34, 88, -92}))
+def filter09(): Bool = Set.__eq(Set.filter(x -> x % 2 == 0, Set#{-33, -1, 12, 1, 34, 88, 7, 77, 31, 7, -92, 841}), Set#{12, 34, 88, -92}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // map                                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def map01(): Bool = assert!(Set.__eq(Set.map(x -> x % 2 == 0, Set#{}), Set#{}))
+def map01(): Bool = Set.__eq(Set.map(x -> x % 2 == 0, Set#{}), Set#{}) == true
 
 @test
-def map02(): Bool = assert!(Set.__eq(Set.map(x -> x % 2 == 0, Set#{1}), Set#{false}))
+def map02(): Bool = Set.__eq(Set.map(x -> x % 2 == 0, Set#{1}), Set#{false}) == true
 
 @test
-def map03(): Bool = assert!(Set.__eq(Set.map(x -> x % 2 == 0, Set#{2}), Set#{true}))
+def map03(): Bool = Set.__eq(Set.map(x -> x % 2 == 0, Set#{2}), Set#{true}) == true
 
 @test
-def map04(): Bool = assert!(Set.__eq(Set.map(x -> x % 2 == 0, Set#{1, -1}), Set#{false}))
+def map04(): Bool = Set.__eq(Set.map(x -> x % 2 == 0, Set#{1, -1}), Set#{false}) == true
 
 @test
-def map05(): Bool = assert!(Set.__eq(Set.map(x -> x % 2 == 0, Set#{1, -12}), Set#{false, true}))
+def map05(): Bool = Set.__eq(Set.map(x -> x % 2 == 0, Set#{1, -12}), Set#{false, true}) == true
 
 @test
-def map06(): Bool = assert!(Set.__eq(Set.map(x -> x % 2 == 0, Set#{16, -1}), Set#{true, false}))
+def map06(): Bool = Set.__eq(Set.map(x -> x % 2 == 0, Set#{16, -1}), Set#{true, false}) == true
 
 @test
-def map07(): Bool = assert!(Set.__eq(Set.map(x -> x % 2 == 0, Set#{12, -12}), Set#{true}))
+def map07(): Bool = Set.__eq(Set.map(x -> x % 2 == 0, Set#{12, -12}), Set#{true}) == true
 
 @test
-def map08(): Bool = assert!(Set.__eq(Set.map(x -> x % 2 == 0, Set#{12, -12}), Set#{true}))
+def map08(): Bool = Set.__eq(Set.map(x -> x % 2 == 0, Set#{12, -12}), Set#{true}) == true
 
 @test
-def map09(): Bool = assert!(Set.__eq(Set.map(x -> x % 2 == 0, Set#{12, -12, 1, 14}), Set#{false, true}))
+def map09(): Bool = Set.__eq(Set.map(x -> x % 2 == 0, Set#{12, -12, 1, 14}), Set#{false, true}) == true
 
 @test
-def map10(): Bool = assert!(Set.__eq(Set.map(x -> x % 2 == 0, Set#{12, -12, 1, 14, 7, 88, -91}), Set#{true, false}))
+def map10(): Bool = Set.__eq(Set.map(x -> x % 2 == 0, Set#{12, -12, 1, 14, 7, 88, -91}), Set#{true, false}) == true
 
 @test
-def map11(): Bool = assert!(Set.__eq(Set.map(x -> x % 2 == 0, Set#{12, -12, 122, 14}), Set#{true}))
+def map11(): Bool = Set.__eq(Set.map(x -> x % 2 == 0, Set#{12, -12, 122, 14}), Set#{true}) == true
 
 @test
-def map12(): Bool = assert!(Set.__eq(Set.map(x -> x % 2 == 0, Set#{123, -123, 1223, 141}), Set#{false}))
+def map12(): Bool = Set.__eq(Set.map(x -> x % 2 == 0, Set#{123, -123, 1223, 141}), Set#{false}) == true
 
 @test
-def map13(): Bool = assert!(Set.__eq(Set.map(x -> x % 9, Set#{11, 5, 16, 4}), Set#{2, 5, 7, 4}))
+def map13(): Bool = Set.__eq(Set.map(x -> x % 9, Set#{11, 5, 16, 4}), Set#{2, 5, 7, 4}) == true
 
 @test
-def map14(): Bool = assert!(Set.__eq(Set.map(x -> x % 9, Set#{0, 5, 1, -9, -8}), Set#{5, 1, 0, -8}))
+def map14(): Bool = Set.__eq(Set.map(x -> x % 9, Set#{0, 5, 1, -9, -8}), Set#{5, 1, 0, -8}) == true
 
 @test
-def map15(): Bool = assert!(Set.__eq(Set.map(x -> x % 9, Set#{0, 5, 1, 10, 7, 19, 28, 2}), Set#{0, 5, 7, 1, 2}))
+def map15(): Bool = Set.__eq(Set.map(x -> x % 9, Set#{0, 5, 1, 10, 7, 19, 28, 2}), Set#{0, 5, 7, 1, 2}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // flatMap                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def flatMap01(): Bool = assert!(Set.__eq(Set.flatMap(x -> if (x % 2 == 0) Set#{} else Set#{x}, Set#{}), Set#{}))
+def flatMap01(): Bool = Set.__eq(Set.flatMap(x -> if (x % 2 == 0) Set#{} else Set#{x}, Set#{}), Set#{}) == true
 
 @test
-def flatMap02(): Bool = assert!(Set.__eq(Set.flatMap(x -> if (x % 2 == 0) Set#{} else Set#{x}, Set#{2}), Set#{}))
+def flatMap02(): Bool = Set.__eq(Set.flatMap(x -> if (x % 2 == 0) Set#{} else Set#{x}, Set#{2}), Set#{}) == true
 
 @test
-def flatMap03(): Bool = assert!(Set.__eq(Set.flatMap(x -> if (x % 2 == 0) Set#{} else Set#{x}, Set#{1}), Set#{1}))
+def flatMap03(): Bool = Set.__eq(Set.flatMap(x -> if (x % 2 == 0) Set#{} else Set#{x}, Set#{1}), Set#{1}) == true
 
 @test
-def flatMap04(): Bool = assert!(Set.__eq(Set.flatMap(x -> if (x % 2 == 0) Set#{} else Set#{x}, Set#{2, 4}), Set#{}))
+def flatMap04(): Bool = Set.__eq(Set.flatMap(x -> if (x % 2 == 0) Set#{} else Set#{x}, Set#{2, 4}), Set#{}) == true
 
 @test
-def flatMap05(): Bool = assert!(Set.__eq(Set.flatMap(x -> if (x % 2 == 0) Set#{} else Set#{x}, Set#{2, 13}), Set#{13}))
+def flatMap05(): Bool = Set.__eq(Set.flatMap(x -> if (x % 2 == 0) Set#{} else Set#{x}, Set#{2, 13}), Set#{13}) == true
 
 @test
-def flatMap06(): Bool = assert!(Set.__eq(Set.flatMap(x -> if (x % 2 == 0) Set#{} else Set#{x}, Set#{15, -8}), Set#{15}))
+def flatMap06(): Bool = Set.__eq(Set.flatMap(x -> if (x % 2 == 0) Set#{} else Set#{x}, Set#{15, -8}), Set#{15}) == true
 
 @test
-def flatMap07(): Bool = assert!(Set.__eq(Set.flatMap(x -> if (x % 2 == 0) Set#{} else Set#{x}, Set#{1, 11}), Set#{1, 11}))
+def flatMap07(): Bool = Set.__eq(Set.flatMap(x -> if (x % 2 == 0) Set#{} else Set#{x}, Set#{1, 11}), Set#{1, 11}) == true
 
 @test
-def flatMap08(): Bool = assert!(Set.__eq(Set.flatMap(x -> Set#{x, 2*x}, Set#{1, 4, 8, 2}), Set#{1, 8, 16, 2, 4}))
+def flatMap08(): Bool = Set.__eq(Set.flatMap(x -> Set#{x, 2*x}, Set#{1, 4, 8, 2}), Set#{1, 8, 16, 2, 4}) == true
 
 @test
-def flatMap09(): Bool = assert!(Set.__eq(Set.flatMap(x -> Set#{x, 3*x}, Set#{1, 8, 3, 2, 9, -5, -1}), Set#{1, 8, 24, 3, 2, 6, 9, 27, -5, -15, -1, -3}))
+def flatMap09(): Bool = Set.__eq(Set.flatMap(x -> Set#{x, 3*x}, Set#{1, 8, 3, 2, 9, -5, -1}), Set#{1, 8, 24, 3, 2, 6, 9, 27, -5, -15, -1, -3}) == true
 
 @test
-def flatMap10(): Bool = assert!(Set.__eq(Set.flatMap(x -> Set#{x, 2*x, 3*x}, Set#{1, 4, 3, 2}), Set#{1, 8, 12, 3, 9, 2, 4, 6}))
+def flatMap10(): Bool = Set.__eq(Set.flatMap(x -> Set#{x, 2*x, 3*x}, Set#{1, 4, 3, 2}), Set#{1, 8, 12, 3, 9, 2, 4, 6}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // replace                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def replace01(): Bool = assert!(Set.__eq(Set.replace(3, 4, Set#{}), Set#{}))
+def replace01(): Bool = Set.__eq(Set.replace(3, 4, Set#{}), Set#{}) == true
 
 @test
-def replace02(): Bool = assert!(Set.__eq(Set.replace(3, 4, Set#{1}), Set#{1}))
+def replace02(): Bool = Set.__eq(Set.replace(3, 4, Set#{1}), Set#{1}) == true
 
 @test
-def replace03(): Bool = assert!(Set.__eq(Set.replace(3, 4, Set#{3}), Set#{4}))
+def replace03(): Bool = Set.__eq(Set.replace(3, 4, Set#{3}), Set#{4}) == true
 
 @test
-def replace04(): Bool = assert!(Set.__eq(Set.replace(3, 4, Set#{4}), Set#{4}))
+def replace04(): Bool = Set.__eq(Set.replace(3, 4, Set#{4}), Set#{4}) == true
 
 @test
-def replace05(): Bool = assert!(Set.__eq(Set.replace(3, 4, Set#{1, 2}), Set#{1, 2}))
+def replace05(): Bool = Set.__eq(Set.replace(3, 4, Set#{1, 2}), Set#{1, 2}) == true
 
 @test
-def replace06(): Bool = assert!(Set.__eq(Set.replace(3, 4, Set#{1, 3}), Set#{1, 4}))
+def replace06(): Bool = Set.__eq(Set.replace(3, 4, Set#{1, 3}), Set#{1, 4}) == true
 
 @test
-def replace07(): Bool = assert!(Set.__eq(Set.replace(3, 4, Set#{3, 2}), Set#{4, 2}))
+def replace07(): Bool = Set.__eq(Set.replace(3, 4, Set#{3, 2}), Set#{4, 2}) == true
 
 @test
-def replace08(): Bool = assert!(Set.__eq(Set.replace(3, 4, Set#{3, 4}), Set#{4}))
+def replace08(): Bool = Set.__eq(Set.replace(3, 4, Set#{3, 4}), Set#{4}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // partition                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def partition01(): Bool = Set.partition(x -> x % 2 == 0, Set#{}) `assertEq!` (Set#{}, Set#{})
+def partition01(): Bool = Set.partition(x -> x % 2 == 0, Set#{}) == (Set#{}, Set#{})
 
 @test
-def partition02(): Bool = Set.partition(x -> x % 2 == 0, Set#{1}) `assertEq!` (Set#{}, Set#{1})
+def partition02(): Bool = Set.partition(x -> x % 2 == 0, Set#{1}) == (Set#{}, Set#{1})
 
 @test
-def partition03(): Bool = Set.partition(x -> x % 2 == 0, Set#{2}) `assertEq!` (Set#{2}, Set#{})
+def partition03(): Bool = Set.partition(x -> x % 2 == 0, Set#{2}) == (Set#{2}, Set#{})
 
 @test
-def partition04(): Bool = Set.partition(x -> x % 2 == 0, Set#{1, 3}) `assertEq!` (Set#{}, Set#{1, 3})
+def partition04(): Bool = Set.partition(x -> x % 2 == 0, Set#{1, 3}) == (Set#{}, Set#{1, 3})
 
 @test
-def partition05(): Bool = Set.partition(x -> x % 2 == 0, Set#{1, 2}) `assertEq!` (Set#{2}, Set#{1})
+def partition05(): Bool = Set.partition(x -> x % 2 == 0, Set#{1, 2}) == (Set#{2}, Set#{1})
 
 @test
-def partition06(): Bool = Set.partition(x -> x % 2 == 0, Set#{2, 1}) `assertEq!` (Set#{2}, Set#{1})
+def partition06(): Bool = Set.partition(x -> x % 2 == 0, Set#{2, 1}) == (Set#{2}, Set#{1})
 
 @test
-def partition07(): Bool = Set.partition(x -> x % 2 == 0, Set#{2, -4}) `assertEq!` (Set#{2, -4}, Set#{})
+def partition07(): Bool = Set.partition(x -> x % 2 == 0, Set#{2, -4}) == (Set#{2, -4}, Set#{})
 
 @test
-def partition08(): Bool = Set.partition(x -> x % 2 == 0, Set#{2, -11, 89, -4, 11, -6, 84}) `assertEq!` (Set#{2, -4, -6, 84}, Set#{-11, 89, 11})
+def partition08(): Bool = Set.partition(x -> x % 2 == 0, Set#{2, -11, 89, -4, 11, -6, 84}) == (Set#{2, -4, -6, 84}, Set#{-11, 89, 11})
 
 @test
-def partition09(): Bool = Set.partition(x -> x % 2 == 0, Set#{84, -6, 11, -4, 89, -11, 2}) `assertEq!` (Set#{84, -6, -4, 2}, Set#{11, 89, -11})
+def partition09(): Bool = Set.partition(x -> x % 2 == 0, Set#{84, -6, 11, -4, 89, -11, 2}) == (Set#{84, -6, -4, 2}, Set#{11, 89, -11})
 
 @test
-def partition10(): Bool = Set.partition(x -> x % 2 == 0, Set#{1, 2, 3, 4, 5, 6, 7, 8}) `assertEq!` (Set#{2, 4, 6, 8}, Set#{1, 3, 5, 7})
+def partition10(): Bool = Set.partition(x -> x % 2 == 0, Set#{1, 2, 3, 4, 5, 6, 7, 8}) == (Set#{2, 4, 6, 8}, Set#{1, 3, 5, 7})
 
 /////////////////////////////////////////////////////////////////////////////
 // toList                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toList01(): Bool = Set.toList(Set#{}) `assertEq!` Nil
+def toList01(): Bool = Set.toList(Set#{}) == Nil
 
 @test
-def toList02(): Bool = Set.toList(Set#{1}) `assertEq!` 1 :: Nil
+def toList02(): Bool = Set.toList(Set#{1}) == 1 :: Nil
 
 @test
-def toList03(): Bool = Set.toList(Set#{1, 2}) `assertEq!` 2 :: 1 :: Nil
+def toList03(): Bool = Set.toList(Set#{1, 2}) == 2 :: 1 :: Nil
 
 @test
-def toList04(): Bool = Set.toList(Set#{1, 2, 3}) `assertEq!` 3 :: 2 :: 1 :: Nil
+def toList04(): Bool = Set.toList(Set#{1, 2, 3}) == 3 :: 2 :: 1 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // toMap                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toMap01(): Bool = assert!(Map.__eq(Set.toMap(Set#{}), Map#{}))
+def toMap01(): Bool = Map.__eq(Set.toMap(Set#{}), Map#{}) == true
 
 @test
-def toMap02(): Bool = assert!(Map.__eq(Set.toMap(Set#{(1, true)}), Map#{1 -> true}))
+def toMap02(): Bool = Map.__eq(Set.toMap(Set#{(1, true)}), Map#{1 -> true}) == true
 
 @test
-def toMap03(): Bool = assert!(Map.__eq(Set.toMap(Set#{(1, true), (2, false)}), Map#{1 -> true, 2 -> false}))
+def toMap03(): Bool = Map.__eq(Set.toMap(Set#{(1, true), (2, false)}), Map#{1 -> true, 2 -> false}) == true
 
 @test
-def toMap04(): Bool = assert!(Map.__eq(Set.toMap(Set#{(1, true), (1, false)}), Map#{1 -> false}))
+def toMap04(): Bool = Map.__eq(Set.toMap(Set#{(1, true), (1, false)}), Map#{1 -> false}) == true
 
 @test
-def toMap05(): Bool = assert!(Map.__eq(Set.toMap(Set#{(1, true), (2, false), (3, true)}), Map#{1 -> true, 2 -> false, 3 -> true}))
+def toMap05(): Bool = Map.__eq(Set.toMap(Set#{(1, true), (2, false), (3, true)}), Map#{1 -> true, 2 -> false, 3 -> true}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // eq                                                                      //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def eq01(): Bool = assert!(Set.__eq(Set#{}, Set#{}))
+def eq01(): Bool = Set.__eq(Set#{}, Set#{}) == true
 
 @test
-def eq02(): Bool = assertNot!(Set.__eq(Set#{1}, Set#{}))
+def eq02(): Bool = Set.__eq(Set#{1}, Set#{}) == false
 
 @test
-def eq03(): Bool = assertNot!(Set.__eq(Set#{}, Set#{1}))
+def eq03(): Bool = Set.__eq(Set#{}, Set#{1}) == false
 
 @test
-def eq04(): Bool = assertNot!(Set.__eq(Set#{1, 2}, Set#{}))
+def eq04(): Bool = Set.__eq(Set#{1, 2}, Set#{}) == false
 
 @test
-def eq05(): Bool = assertNot!(Set.__eq(Set#{}, Set#{1, 2}))
+def eq05(): Bool = Set.__eq(Set#{}, Set#{1, 2}) == false
 
 @test
-def eq06(): Bool = assertNot!(Set.__eq(Set#{1}, Set#{2}))
+def eq06(): Bool = Set.__eq(Set#{1}, Set#{2}) == false
 
 @test
-def eq07(): Bool = assert!(Set.__eq(Set#{1}, Set#{1}))
+def eq07(): Bool = Set.__eq(Set#{1}, Set#{1}) == true
 
 @test
-def eq08(): Bool = assertNot!(Set.__eq(Set#{1, 2, 3}, Set#{}))
+def eq08(): Bool = Set.__eq(Set#{1, 2, 3}, Set#{}) == false
 
 @test
-def eq09(): Bool = assertNot!(Set.__eq(Set#{1, 2}, Set#{1}))
+def eq09(): Bool = Set.__eq(Set#{1, 2}, Set#{1}) == false
 
 @test
-def eq10(): Bool = assertNot!(Set.__eq(Set#{1}, Set#{1, 2}))
+def eq10(): Bool = Set.__eq(Set#{1}, Set#{1, 2}) == false
 
 @test
-def eq11(): Bool = assertNot!(Set.__eq(Set#{}, Set#{1, 2, 3}))
+def eq11(): Bool = Set.__eq(Set#{}, Set#{1, 2, 3}) == false
 
 @test
-def eq12(): Bool = assertNot!(Set.__eq(Set#{1, 2}, Set#{1, 3}))
+def eq12(): Bool = Set.__eq(Set#{1, 2}, Set#{1, 3}) == false
 
 @test
-def eq13(): Bool = assert!(Set.__eq(Set#{1, 2}, Set#{2, 1}))
+def eq13(): Bool = Set.__eq(Set#{1, 2}, Set#{2, 1}) == true
 
 @test
-def eq14(): Bool = assert!(Set.__eq(Set#{1, 2}, Set#{1, 2}))
+def eq14(): Bool = Set.__eq(Set#{1, 2}, Set#{1, 2}) == true
 
 @test
-def eq15(): Bool = assertNot!(Set.__eq(Set#{1, 2, 3}, Set#{1, 2, 4}))
+def eq15(): Bool = Set.__eq(Set#{1, 2, 3}, Set#{1, 2, 4}) == false
 
 @test
-def eq16(): Bool = assert!(Set.__eq(Set#{1, 2, 3}, Set#{1, 2, 3}))
+def eq16(): Bool = Set.__eq(Set#{1, 2, 3}, Set#{1, 2, 3}) == true
 
 @test
-def eq17(): Bool = assert!(Set.__eq(Set#{1, 2, 3}, Set#{2, 3, 1}))
+def eq17(): Bool = Set.__eq(Set#{1, 2, 3}, Set#{2, 3, 1}) == true
 
 @test
-def eq18(): Bool = assert!(Set.__eq(Set#{1, 2, 3}, Set#{3, 1, 2}))
+def eq18(): Bool = Set.__eq(Set#{1, 2, 3}, Set#{3, 1, 2}) == true
 
 @test
-def eq19(): Bool = assert!(Set.__eq(Set#{1, 2, 3}, Set#{2, 1, 3}))
+def eq19(): Bool = Set.__eq(Set#{1, 2, 3}, Set#{2, 1, 3}) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // foreach                                                                 //


### PR DESCRIPTION
See issue...

Remove assert!, assertEq!, and assertNot! From Prelude #1136

This PR removes the assert functions from the standard library tests.