### PR TITLE
Abbreviate pattern match syntax

### DIFF
--- a/examples/algebraic-data-types-and-pattern-matching.flix
+++ b/examples/algebraic-data-types-and-pattern-matching.flix
@@ -7,7 +7,7 @@ enum Shape {
 
 /// Computes the area of the given shape using
 /// pattern matching and basic arithmetic.
-def area(s: Shape): Int = match s with {
+def area(s: Shape): Int = match s {
     case Circle(r)       => 3 * (r * r)
     case Square(w)       => w * w
     case Rectangle(h, w) => h * w

--- a/examples/an-interpreter-for-a-trivial-expression-language.flix
+++ b/examples/an-interpreter-for-a-trivial-expression-language.flix
@@ -50,7 +50,7 @@ enum BExp {
 //
 // We now define a small interpreter for arithmetic expressions.
 //
-def evalAExp(e: AExp): Int = match e with {
+def evalAExp(e: AExp): Int = match e {
     case Cst(i)                 => i
     case Plus(e1, e2)           => evalAExp(e1) + evalAExp(e2)
     case Minus(e1, e2)          => evalAExp(e1) - evalAExp(e2)
@@ -64,7 +64,7 @@ def evalAExp(e: AExp): Int = match e with {
 //
 // and here is the small interpreter for boolean expressions.
 //
-def evalBExp(e: BExp): Bool = match e with {
+def evalBExp(e: BExp): Bool = match e {
     case True           => true
     case False          => false
     case Not(e1)        => !evalBExp(e1)

--- a/examples/analysis/IDE.flix
+++ b/examples/analysis/IDE.flix
@@ -8,33 +8,33 @@ namespace IDE {
 
     def equ(e1: Value, e2: Value): Bool = e1 == e2
 
-    def lub(e1: Value, e2: Value): Value = match (e1, e2) with {
+    def lub(e1: Value, e2: Value): Value = match (e1, e2) {
         case (Value.Bot, x) => x
         case (x, Value.Bot) => x
         case (Value.Cst(n1), Value.Cst(n2)) => if(n1 == n2) Value.Cst(n1) else Value.Top
         case _ => Value.Top
     }
 
-    def leq(e1: Value, e2: Value): Bool = match (e1, e2) with {
+    def leq(e1: Value, e2: Value): Bool = match (e1, e2) {
         case (Value.Bot, _) => true
         case (Value.Cst(n1), Value.Cst(n2)) => n1 == n2
         case (_, Value.Top) => true
         case _ => false
     }
 
-    def sum(e1: Value, e2: Int): Value = match e1 with {
+    def sum(e1: Value, e2: Int): Value = match e1 {
         case Value.Cst(n) => Value.Cst(n+e2)
         case _ => e1
     }
 
-    def prod(e1: Value, e2: Int): Value = match (e1, e2) with {
+    def prod(e1: Value, e2: Int): Value = match (e1, e2) {
         case (Value.Cst(n), _) => Value.Cst(n*e2)
         case (Value.Bot, _) => Value.Bot
         case (_, zero) => if(zero == 0) Value.Cst(0) else e1
         case _ => e1
     }
 
-    def glb(e1: Value, e2: Value): Value = match (e1, e2) with {
+    def glb(e1: Value, e2: Value): Value = match (e1, e2) {
         case (Value.Top, x) => x
         case (x, Value.Top) => x
         case (Value.Cst(n1), Value.Cst(n2)) => if(n1 == n2) Value.Cst(n1) else Value.Bot
@@ -48,9 +48,9 @@ namespace IDE {
         case NonBotTrans(Int,Int,Value)
     }
 
-  def compose(t1: Transformer, t2: Transformer): Transformer = match (t1, t2) with {
+  def compose(t1: Transformer, t2: Transformer): Transformer = match (t1, t2) {
     case (_,Transformer.BotTrans) => Transformer.BotTrans
-    case (Transformer.BotTrans, Transformer.NonBotTrans(_, _, c)) => match c with {
+    case (Transformer.BotTrans, Transformer.NonBotTrans(_, _, c)) => match c {
       case Value.Bot => Transformer.BotTrans
       case Value.Top => Transformer.NonBotTrans(0,0,Value.Top)
       case Value.Cst(cc) => Transformer.NonBotTrans(0,cc,c)
@@ -61,12 +61,12 @@ namespace IDE {
 
     // from paper: f = \l. a*l+b meet c; f(Top) = Top
     // paper is upside-down, so: f = \l. a*l+b join c; f(Bot) = Bot
-    def apply(t: Transformer, l: Value): Value = match t with {
+    def apply(t: Transformer, l: Value): Value = match t {
         case Transformer.BotTrans => Value.Bot
         case Transformer.NonBotTrans(a, b, c) => if(l==Value.Bot) Value.Bot else lub(sum(prod(l,a),b),c)
     }
 
-    def translub(t1: Transformer, t2: Transformer): Transformer = match (t1, t2) with {
+    def translub(t1: Transformer, t2: Transformer): Transformer = match (t1, t2) {
         case (Transformer.BotTrans, _) => t2
         case (_, Transformer.BotTrans) => t1
         case (Transformer.NonBotTrans(a1, b1, c1), Transformer.NonBotTrans(a2, b2, c2)) =>

--- a/examples/analysis/SUopt.flix
+++ b/examples/analysis/SUopt.flix
@@ -26,19 +26,19 @@
 
   def equ(e1: SULattice, e2: SULattice): Bool = e1 == e2
 
-  def leq(e1: SULattice, e2: SULattice): Bool = match (e1, e2) with {
+  def leq(e1: SULattice, e2: SULattice): Bool = match (e1, e2) {
     case (SULattice.Bottom, _) => true
     case (_, SULattice.Top) => true
     case (SULattice.Single(s1), SULattice.Single(s2)) => s1 == s2
     case _ => false
   }
-  def lub(e1: SULattice, e2: SULattice): SULattice = match (e1, e2) with {
+  def lub(e1: SULattice, e2: SULattice): SULattice = match (e1, e2) {
     case (SULattice.Bottom, _) => e2
     case (_, SULattice.Bottom) => e1
     case (SULattice.Single(s1), SULattice.Single(s2)) => if (s1 == s2) SULattice.Single(s1) else SULattice.Top
     case _ => SULattice.Top
   }
-  def glb(e1: SULattice, e2: SULattice): SULattice = match (e1, e2) with {
+  def glb(e1: SULattice, e2: SULattice): SULattice = match (e1, e2) {
     case (SULattice.Top, _) => e2
     case (_, SULattice.Top) => e1
     case (SULattice.Single(s1), SULattice.Single(s2)) => if (s1 == s2) SULattice.Single(s1) else SULattice.Bottom
@@ -82,7 +82,7 @@ Pt(p,b) :- FILoad(p,q,_), Pt(q,a), PtH(a,b).
 // Preserve
 // ---------
 //su-after(l,a,t) :- su-before(l,a,t), NOT kill(l,a).
-def killNot(a: Str, e: SULattice): Bool = match e with {
+def killNot(a: Str, e: SULattice): Bool = match e {
   case SULattice.Bottom => false
   case SULattice.Single(s) => a != s
   case SULattice.Top => true
@@ -93,7 +93,7 @@ SU(l2,a;t) :- CFG(l1, l2), SU(l1,a;t), killNot(a, k), Kill(l2;k).
 //
 // PtSu
 // ---------
-def filter(e: SULattice, p: Str): Bool = match e with {
+def filter(e: SULattice, p: Str): Bool = match e {
   case SULattice.Bottom => false
   case SULattice.Single(s) => p == s
   case SULattice.Top => true

--- a/examples/domains/Belnap.flix
+++ b/examples/domains/Belnap.flix
@@ -25,7 +25,7 @@ namespace Belnap {
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
     #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
-    pub def leq(e1: Belnap, e2: Belnap): Bool = match (e1, e2) with {
+    pub def leq(e1: Belnap, e2: Belnap): Bool = match (e1, e2) {
         case (Bot, _)       => true
         case (True, True)   => true
         case (False, False) => true
@@ -37,7 +37,7 @@ namespace Belnap {
     /// Returns the least upper bound of `e1` and `e2`.
     ///
     #upperBound #leastUpperBound #commutative #associative
-    pub def lub(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) with {
+    pub def lub(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) {
         case (Bot, x)       => x
         case (x, Bot)       => x
         case (True, True)   => True
@@ -49,7 +49,7 @@ namespace Belnap {
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
     #lowerBound #greatestLowerBound #commutative #associative
-    pub def glb(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) with {
+    pub def glb(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) {
         case (Top, x)       => x
         case (x, Top)       => x
         case (True, True)   => True
@@ -61,7 +61,7 @@ namespace Belnap {
     /// The lattice height function.
     ///
     #nonNegative #decreasing(equ, leq)
-    pub def height(e: Belnap): BigInt = match e with {
+    pub def height(e: Belnap): BigInt = match e {
         case Top    => 0ii
         case True   => 1ii
         case False  => 1ii
@@ -78,7 +78,7 @@ namespace Belnap {
     ///
     #safe1(x -> !x)
     #strict1 #monotone1
-    pub def not(e: Belnap): Belnap = match e with {
+    pub def not(e: Belnap): Belnap = match e {
         case Bot    => Bot
         case True   => False
         case False  => True
@@ -90,7 +90,7 @@ namespace Belnap {
     ///
     #safe2((x, y) -> x && y)
     #strict2 #monotone2 #commutative #associative
-    pub def and(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) with {
+    pub def and(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) {
         case (Bot, _)       => Bot
         case (_, Bot)       => Bot
         case (True, True)   => True
@@ -105,7 +105,7 @@ namespace Belnap {
     ///
     #safe2((x, y) -> x || y)
     #strict2 #monotone2 #commutative #associative
-    pub def or(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) with {
+    pub def or(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) {
         case (Bot, _)       => Bot
         case (_, Bot)       => Bot
         case (True, True)   => True
@@ -120,7 +120,7 @@ namespace Belnap {
     ///
     #safe2((x, y) -> x ⊕ y)
     #strict2 #monotone2 #commutative #associative
-    pub def xor(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) with {
+    pub def xor(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) {
         case (Bot, _)       => Bot
         case (_, Bot)       => Bot
         case (True, True)   => False
@@ -135,7 +135,7 @@ namespace Belnap {
     ///
     #safe2((x, y) -> x → y)
     #strict2 #monotone2
-    pub def implies(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) with {
+    pub def implies(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) {
         case (Bot, _)         => Bot
         case (_, Bot)         => Bot
         case (True, True)     => True
@@ -150,7 +150,7 @@ namespace Belnap {
     ///
     #safe2((x, y) -> x ↔ y)
     #strict2 #monotone2 #commutative #associative
-    pub def bicondition(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) with {
+    pub def bicondition(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) {
         case (Bot, _)       => Bot
         case (_, Bot)       => Bot
         case (True, True)   => True

--- a/examples/domains/Constant.flix
+++ b/examples/domains/Constant.flix
@@ -23,7 +23,7 @@ namespace Domain/Constant {
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
     #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
-    def leq(e1: Constant, e2: Constant): Bool = match (e1, e2) with {
+    def leq(e1: Constant, e2: Constant): Bool = match (e1, e2) {
         case (Bot, _)           => true
         case (Cst(n1), Cst(n2)) => n1 == n2
         case (_, Top)           => true
@@ -34,7 +34,7 @@ namespace Domain/Constant {
     /// Returns the least upper bound of `e1` and `e2`.
     ///
     #upperBound #leastUpperBound #commutative #associative
-    def lub(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+    def lub(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, x)           => x
         case (x, Bot)           => x
         case (Cst(n1), Cst(n2)) => if (n1 == n2) e1 else Top
@@ -45,7 +45,7 @@ namespace Domain/Constant {
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
     #lowerBound #greatestLowerBound #commutative #associative
-    def glb(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+    def glb(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Top, x)           => x
         case (x, Top)           => x
         case (Cst(n1), Cst(n2)) => if (n1 == n2) e1 else Bot
@@ -56,7 +56,7 @@ namespace Domain/Constant {
     /// The lattice height function.
     ///
     #nonNegative #decreasing(equ, leq)
-    pub def height(e: Constant): BigInt = match e with {
+    pub def height(e: Constant): BigInt = match e {
         case Top    => 0ii
         case Cst(_) => 1ii
         case Bot    => 2ii
@@ -72,7 +72,7 @@ namespace Domain/Constant {
      */
     #safe1(x -> x + 1)
     #strict1 #monotone1
-    pub def inc(e: Constant): Constant = match e with {
+    pub def inc(e: Constant): Constant = match e {
         case Bot    => Bot
         case Cst(n) => Cst(n + 1)
         case Top    => Top
@@ -83,7 +83,7 @@ namespace Domain/Constant {
     ///
     #safe1(x -> x - 1)
     #strict1 #monotone1
-    pub def dec(e: Constant): Constant = match e with {
+    pub def dec(e: Constant): Constant = match e {
         case Bot    => Bot
         case Cst(n) => Cst(n - 1)
         case Top    => Top
@@ -94,7 +94,7 @@ namespace Domain/Constant {
     ///
     #safe2((x, y) -> x + y)
     #strict2 #monotone2 #commutative #associative
-    pub def plus(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+    pub def plus(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 + n2)
@@ -106,7 +106,7 @@ namespace Domain/Constant {
     ///
     #safe2((x, y) -> x - y)
     #strict2 #monotone2
-    pub def minus(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+    pub def minus(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 - n2)
@@ -118,7 +118,7 @@ namespace Domain/Constant {
     ///
     #safe2((x, y) -> x * y)
     #strict2 #monotone2 #commutative #associative
-    pub def times(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+    pub def times(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 * n2)
@@ -130,7 +130,7 @@ namespace Domain/Constant {
     ///
     #safe2((x, y) -> x / y)
     #strict2 #monotone2
-    pub def divide(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+    pub def divide(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 / n2)
@@ -142,7 +142,7 @@ namespace Domain/Constant {
     ///
     #safe2((x, y) -> x % y)
     #strict2 #monotone2
-    pub def modulo(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+    pub def modulo(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 % n2)
@@ -154,7 +154,7 @@ namespace Domain/Constant {
     ///
     #safe1(x -> ~~~x)
     #strict1 #monotone1
-    pub def negate(e: Constant): Constant = match e with {
+    pub def negate(e: Constant): Constant = match e {
         case Bot       => Bot
         case Cst(n)    => Cst(~~~ n)
         case Top       => Top
@@ -165,7 +165,7 @@ namespace Domain/Constant {
     ///
     #safe2((x, y) -> x &&& y)
     #strict2 #monotone2 #commutative #associative
-    pub def and(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+    pub def and(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 &&& n2)
@@ -177,7 +177,7 @@ namespace Domain/Constant {
     ///
     #safe2((x, y) -> x ||| y)
     #strict2 #monotone2 #commutative #associative
-    pub def or(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+    pub def or(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 ||| n2)
@@ -189,7 +189,7 @@ namespace Domain/Constant {
     ///
     #safe2((x, y) -> x ^^^ y)
     #strict2 #monotone2 #commutative #associative
-    pub def xor(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+    pub def xor(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 ^^^ n2)
@@ -201,7 +201,7 @@ namespace Domain/Constant {
     ///
     #safe2((x, y) -> x <<< y)
     #strict2 #monotone2
-    pub def leftShift(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+    pub def leftShift(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 <<< n2)
@@ -214,7 +214,7 @@ namespace Domain/Constant {
     ///
     #safe2((x, y) -> x >>> y)
     #strict2 #monotone2
-    pub def rightShift(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+    pub def rightShift(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 >>> n2)
@@ -228,7 +228,7 @@ namespace Domain/Constant {
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
     #PartialOrder.monotone2(leq, leq, Belnap.leq)
     #commutative
-    pub def eq(e1: Constant, e2: Constant): Belnap.Belnap = match (e1, e2) with {
+    pub def eq(e1: Constant, e2: Constant): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)           => Belnap/Belnap.Bot
         case (_, Bot)           => Belnap/Belnap.Bot
         case (Cst(n1), Cst(n2)) => Belnap.alpha(n1 == n2)
@@ -250,7 +250,7 @@ namespace Domain/Constant {
     #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
     #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    pub def less(e1: Constant, e2: Constant): Belnap.Belnap = match (e1, e2) with {
+    pub def less(e1: Constant, e2: Constant): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)           => Belnap/Belnap.Bot
         case (_, Bot)           => Belnap/Belnap.Bot
         case (Cst(n1), Cst(n2)) => Belnap.alpha(n1 < n2)

--- a/examples/domains/ConstantParity.flix
+++ b/examples/domains/ConstantParity.flix
@@ -25,7 +25,7 @@ namespace Domain/ConstantParity {
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
     #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
-    def leq(e1: ConstantParity, e2: ConstantParity): Bool = match (e1, e2) with {
+    def leq(e1: ConstantParity, e2: ConstantParity): Bool = match (e1, e2) {
         case (Bot, _)           => true
         case (Cst(n1), Cst(n2)) => n1 == n2
         case (Cst(n), Odd)      => isOdd(n)
@@ -40,7 +40,7 @@ namespace Domain/ConstantParity {
     /// Returns the least upper bound of `e1` and `e2`.
     ///
     #upperBound #leastUpperBound #commutative #associative
-    def lub(e1: ConstantParity, e2: ConstantParity): ConstantParity = match (e1, e2) with {
+    def lub(e1: ConstantParity, e2: ConstantParity): ConstantParity = match (e1, e2) {
         case (Bot, x)           => x
         case (x, Bot)           => x
         case (Cst(n1), Cst(n2)) => {
@@ -62,7 +62,7 @@ namespace Domain/ConstantParity {
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
     #lowerBound #greatestLowerBound #commutative #associative
-    def glb(e1: ConstantParity, e2: ConstantParity): ConstantParity = match (e1, e2) with {
+    def glb(e1: ConstantParity, e2: ConstantParity): ConstantParity = match (e1, e2) {
         case (Top, x)           => x
         case (x, Top)           => x
         case (Cst(n1), Cst(n2)) => if (n1 == n2)  Cst(n1) else Bot
@@ -79,7 +79,7 @@ namespace Domain/ConstantParity {
     /// The lattice height function.
     ///
     #nonNegative #decreasing(equ, leq)
-    pub def height(e: ConstantParity): BigInt = match e with {
+    pub def height(e: ConstantParity): BigInt = match e {
         case Top    => 0ii
         case Odd    => 1ii
         case Even   => 1ii
@@ -97,7 +97,7 @@ namespace Domain/ConstantParity {
     ///
     #safe1(x -> x + 1ii)
     #strict1 #monotone1
-    pub def inc(e: ConstantParity): ConstantParity = match e with {
+    pub def inc(e: ConstantParity): ConstantParity = match e {
         case Bot    => Bot
         case Cst(n) => Cst(n + 1ii)
         case Even   => Odd
@@ -110,7 +110,7 @@ namespace Domain/ConstantParity {
     ///
     #safe1(x -> x - 1ii)
     #strict1 #monotone1
-    pub def dec(e: ConstantParity): ConstantParity = match e with {
+    pub def dec(e: ConstantParity): ConstantParity = match e {
         case Bot    => Bot
         case Cst(n) => Cst(n - 1ii)
         case Even   => Odd
@@ -123,7 +123,7 @@ namespace Domain/ConstantParity {
     ///
     #safe2((x, y) -> x + y)
     #strict2 #monotone2 #commutative
-    pub def plus(e1: ConstantParity, e2: ConstantParity): ConstantParity = match (e1, e2) with {
+    pub def plus(e1: ConstantParity, e2: ConstantParity): ConstantParity = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 + n2)
@@ -143,7 +143,7 @@ namespace Domain/ConstantParity {
     ///
     #safe2((x, y) -> x - y)
     #strict2 #monotone2
-    pub def minus(e1: ConstantParity, e2: ConstantParity): ConstantParity = match (e1, e2) with {
+    pub def minus(e1: ConstantParity, e2: ConstantParity): ConstantParity = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 - n2)
@@ -163,7 +163,7 @@ namespace Domain/ConstantParity {
     ///
     #safe2((x, y) -> x * y)
     #strict2  // NB: @monotone annotation removed since Z3 reports unknown.
-    pub def times(e1: ConstantParity, e2: ConstantParity): ConstantParity = match (e1, e2) with {
+    pub def times(e1: ConstantParity, e2: ConstantParity): ConstantParity = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 * n2)
@@ -185,7 +185,7 @@ namespace Domain/ConstantParity {
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
     #PartialOrder.monotone2(leq, leq, Belnap.leq)
     #commutative
-    pub def eq(e1: ConstantParity, e2: ConstantParity): Belnap.Belnap = match (e1, e2) with {
+    pub def eq(e1: ConstantParity, e2: ConstantParity): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)           => Belnap/Belnap.Bot
         case (_, Bot)           => Belnap/Belnap.Bot
         case (Cst(n1), Cst(n2)) => Belnap.alpha(n1 == n2)
@@ -211,7 +211,7 @@ namespace Domain/ConstantParity {
     #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
     #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    pub def less(e1: ConstantParity, e2: ConstantParity): Belnap.Belnap = match (e1, e2) with {
+    pub def less(e1: ConstantParity, e2: ConstantParity): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)           => Belnap/Belnap.Bot
         case (_, Bot)           => Belnap/Belnap.Bot
         case (Cst(n1), Cst(n2)) => Belnap.alpha(n1 < n2)

--- a/examples/domains/ConstantSign.flix
+++ b/examples/domains/ConstantSign.flix
@@ -25,7 +25,7 @@ namespace Domain/ConstantSign {
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
     #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
-    def leq(e1: ConstantSign, e2: ConstantSign): Bool = match (e1, e2) with {
+    def leq(e1: ConstantSign, e2: ConstantSign): Bool = match (e1, e2) {
         case (Bot, _)           => true
         case (Cst(n1), Cst(n2)) => n1 == n2
         case (Cst(n), Neg)      => n <= 0ii
@@ -40,7 +40,7 @@ namespace Domain/ConstantSign {
     /// Returns the least upper bound of `e1` and `e2`.
     ///
     #upperBound #leastUpperBound #commutative #associative
-    def lub(e1: ConstantSign, e2: ConstantSign): ConstantSign = match (e1, e2) with {
+    def lub(e1: ConstantSign, e2: ConstantSign): ConstantSign = match (e1, e2) {
         case (Bot, x)           => x
         case (x, Bot)           => x
         case (Cst(n1), Cst(n2)) => {
@@ -62,7 +62,7 @@ namespace Domain/ConstantSign {
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
     #lowerBound #greatestLowerBound #commutative #associative
-    def glb(e1: ConstantSign, e2: ConstantSign): ConstantSign = match (e1, e2) with {
+    def glb(e1: ConstantSign, e2: ConstantSign): ConstantSign = match (e1, e2) {
         case (Top, x)           => x
         case (x, Top)           => x
         case (Cst(n1), Cst(n2)) => if (n1 == n2) Cst(n1) else Bot
@@ -81,7 +81,7 @@ namespace Domain/ConstantSign {
     /// The lattice height function.
     ///
     #nonNegative #decreasing(equ, leq)
-    pub def height(e: ConstantSign): BigInt = match e with {
+    pub def height(e: ConstantSign): BigInt = match e {
         case Top    => 0ii
         case Neg    => 1ii
         case Pos    => 1ii
@@ -99,7 +99,7 @@ namespace Domain/ConstantSign {
     ///
     #safe1(x -> x + 1ii)
     #strict1 #monotone1
-    pub def inc(e: ConstantSign): ConstantSign = match e with {
+    pub def inc(e: ConstantSign): ConstantSign = match e {
         case Bot    => Bot
         case Cst(n) => Cst(n + 1ii)
         case Neg    => Top
@@ -112,7 +112,7 @@ namespace Domain/ConstantSign {
     ///
     #safe1(x -> x - 1ii)
     #strict1 #monotone1
-    pub def dec(e: ConstantSign): ConstantSign = match e with {
+    pub def dec(e: ConstantSign): ConstantSign = match e {
         case Bot    => Bot
         case Cst(n) => Cst(n - 1ii)
         case Neg    => Neg
@@ -125,7 +125,7 @@ namespace Domain/ConstantSign {
     ///
     #safe2((x, y) -> x + y)
     #strict2 #monotone2 #commutative
-    pub def plus(e1: ConstantSign, e2: ConstantSign): ConstantSign = match (e1, e2) with {
+    pub def plus(e1: ConstantSign, e2: ConstantSign): ConstantSign = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 + n2)
@@ -143,7 +143,7 @@ namespace Domain/ConstantSign {
     ///
     #safe2((x, y) -> x - y)
     #strict2 #monotone2
-    pub def minus(e1: ConstantSign, e2: ConstantSign): ConstantSign = match (e1, e2) with {
+    pub def minus(e1: ConstantSign, e2: ConstantSign): ConstantSign = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 - n2)
@@ -161,7 +161,7 @@ namespace Domain/ConstantSign {
     ///
     #safe2((x, y) -> x * y)
     #strict2 #monotone2 #commutative #associative
-    pub def times(e1: ConstantSign, e2: ConstantSign): ConstantSign = match (e1, e2) with {
+    pub def times(e1: ConstantSign, e2: ConstantSign): ConstantSign = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
         case (Cst(n1), Cst(n2)) => Cst(n1 * n2)
@@ -185,7 +185,7 @@ namespace Domain/ConstantSign {
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
     #PartialOrder.monotone2(leq, leq, Belnap.leq)
     #commutative
-    pub def eq(e1: ConstantSign, e2: ConstantSign): Belnap.Belnap = match (e1, e2) with {
+    pub def eq(e1: ConstantSign, e2: ConstantSign): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)           => Belnap/Belnap.Bot
         case (_, Bot)           => Belnap/Belnap.Bot
         case (Cst(n1), Cst(n2)) => Belnap.alpha(n1 == n2)
@@ -211,7 +211,7 @@ namespace Domain/ConstantSign {
     #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
     #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    pub def less(e1: ConstantSign, e2: ConstantSign): Belnap.Belnap = match (e1, e2) with {
+    pub def less(e1: ConstantSign, e2: ConstantSign): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)           => Belnap/Belnap.Bot
         case (_, Bot)           => Belnap/Belnap.Bot
         case (Cst(n1), Cst(n2)) => Belnap.alpha(n1 < n2)

--- a/examples/domains/Interval.flix
+++ b/examples/domains/Interval.flix
@@ -28,7 +28,7 @@ namespace Domain/Interval {
     ///
     /// Returns the canonical representation of the given interval `e`.
     ///
-    def norm(x: Interval): Interval = match x with {
+    def norm(x: Interval): Interval = match x {
         case Bot            => Bot
         case Range(b, e)    => if (b <= e) Range(b, e) else Bot
         case Top            => Top
@@ -38,7 +38,7 @@ namespace Domain/Interval {
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
     #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
-    def leq(x: Interval, y: Interval): Bool = match (x, y) with {
+    def leq(x: Interval, y: Interval): Bool = match (x, y) {
         case (Bot, _)                       => true
         case (Range(b1, e1), Range(b2, e2)) => b2 <= b1 && e1 <= e2
         case (_, Top)                       => true
@@ -49,7 +49,7 @@ namespace Domain/Interval {
     /// Returns the least upper bound of `e1` and `e2`.
     ///
     #upperBound #leastUpperBound
-    def lub(x: Interval, y: Interval): Interval = match (x, y) with {
+    def lub(x: Interval, y: Interval): Interval = match (x, y) {
         case (Bot, _)                       => y
         case (_, Bot)                       => x
         case (Range(b1, e1), Range(b2, e2)) => norm(Range(BigInt.min(b1, b2), BigInt.max(e1, e2)))
@@ -60,7 +60,7 @@ namespace Domain/Interval {
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
     #lowerBound #greatestLowerBound
-    def glb(x: Interval, y: Interval): Interval = match (x, y) with {
+    def glb(x: Interval, y: Interval): Interval = match (x, y) {
         case (Top, _)                       => y
         case (_, Top)                       => x
         case (Range(b1, e1), Range(b2, e2)) => norm(Range(BigInt.max(b1, b2), BigInt.min(e1, e2)))
@@ -77,7 +77,7 @@ namespace Domain/Interval {
     ///
     #safe1(x -> x + 1ii)
     #strict1 #monotone1
-    pub def inc(x: Interval): Interval = match x with {
+    pub def inc(x: Interval): Interval = match x {
         case Bot            => Bot
         case Range(b, e)    => norm(Range(b + 1ii, e + 1ii))
         case Top            => Top
@@ -88,7 +88,7 @@ namespace Domain/Interval {
     ///
     #safe1(x -> x - 1ii)
     #strict1 #monotone1
-    pub def dec(x: Interval): Interval = match x with {
+    pub def dec(x: Interval): Interval = match x {
         case Bot            => Bot
         case Range(b, e)    => norm(Range(b - 1ii, e - 1ii))
         case Top            => Top
@@ -99,7 +99,7 @@ namespace Domain/Interval {
     ///
     #safe2((x, y) -> x + y)
     #strict2 #monotone2
-    pub def plus(x: Interval, y: Interval): Interval = match (x, y) with {
+    pub def plus(x: Interval, y: Interval): Interval = match (x, y) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
         case (Range(b1, e1), Range(b2, e2)) => norm(Range(b1 + b2, e1 + e2))
@@ -111,7 +111,7 @@ namespace Domain/Interval {
     ///
     #safe2((x, y) -> x - y)
     #strict2 #monotone2
-    pub def minus(x: Interval, y: Interval): Interval = match (x, y) with {
+    pub def minus(x: Interval, y: Interval): Interval = match (x, y) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
         case (Range(b1, e1), Range(b2, e2)) => norm(Range(b1 - e2, e1 - b2))
@@ -123,7 +123,7 @@ namespace Domain/Interval {
     ///
     #safe2((x, y) -> x * y)
     #strict2 /* undecidable #monotone2 */
-    pub def times(x: Interval, y: Interval): Interval = match (x, y) with {
+    pub def times(x: Interval, y: Interval): Interval = match (x, y) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
         case (Range(b1, e1), Range(b2, e2)) =>
@@ -138,7 +138,7 @@ namespace Domain/Interval {
       */
     #safeBelnap2((x, y) -> x == y)
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2 #commutativeBelnap
-    pub def eq(x: Interval, y: Interval): Belnap.Belnap = match (x, y) with {
+    pub def eq(x: Interval, y: Interval): Belnap.Belnap = match (x, y) {
         case (Bot, _)                                           => Belnap/Belnap.Bot
         case (_, Bot)                                           => Belnap/Belnap.Bot
         case (Range(b1, e1), Range(b2, e2)) => {
@@ -161,7 +161,7 @@ namespace Domain/Interval {
       */
    #safeBelnap2((x, y) -> x < y)
    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2
-   pub def less(x: Interval, y: Interval): Belnap.Belnap = match (x, y) with {
+   pub def less(x: Interval, y: Interval): Belnap.Belnap = match (x, y) {
         case (Bot, _)                                  => Belnap/Belnap.Bot
         case (_, Bot)                                  => Belnap/Belnap.Bot
         case (Range(b1, e1), Range(b2, e2))   =>

--- a/examples/domains/IntervalAlt.flix
+++ b/examples/domains/IntervalAlt.flix
@@ -28,7 +28,7 @@ namespace Domain/IntervalAlt {
     ///
     /// Returns the canonical representation of the given IntervalAlt `e`.
     ///
-    def norm(x: IntervalAlt): IntervalAlt = match x with {
+    def norm(x: IntervalAlt): IntervalAlt = match x {
         case Bot            => Bot
         case Range(b, e)    => if (b <= e) (if (e - b <= maxWidth()) Range(b, e) else Top) else Bot
         case Top            => Top
@@ -43,7 +43,7 @@ namespace Domain/IntervalAlt {
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
     #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
-    def leq(x: IntervalAlt, y: IntervalAlt): Bool = match (x, y) with {
+    def leq(x: IntervalAlt, y: IntervalAlt): Bool = match (x, y) {
         case (Bot, _)                       => true
         case (Range(b1, e1), Range(b2, e2)) => b2 <= b1 && e1 <= e2
         case (_, Top)                       => true
@@ -54,7 +54,7 @@ namespace Domain/IntervalAlt {
     /// Returns the least upper bound of `e1` and `e2`.
     ///
     #upperBound #leastUpperBound
-    def lub(x: IntervalAlt, y: IntervalAlt): IntervalAlt = match (x, y) with {
+    def lub(x: IntervalAlt, y: IntervalAlt): IntervalAlt = match (x, y) {
         case (Bot, _)                       => y
         case (_, Bot)                       => x
         case (Range(b1, e1), Range(b2, e2)) => norm(Range(BigInt.min(b1, b2), BigInt.max(e1, e2)))
@@ -65,7 +65,7 @@ namespace Domain/IntervalAlt {
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
     #lowerBound #greatestLowerBound
-    def glb(x: IntervalAlt, y: IntervalAlt): IntervalAlt = match (x, y) with {
+    def glb(x: IntervalAlt, y: IntervalAlt): IntervalAlt = match (x, y) {
         case (Top, _)                       => y
         case (_, Top)                       => x
         case (Range(b1, e1), Range(b2, e2)) => norm(Range(BigInt.max(b1, b2), BigInt.min(e1, e2)))
@@ -76,7 +76,7 @@ namespace Domain/IntervalAlt {
     /// The lattice height function.
     ///
     #nonNegative #decreasing(equ, leq)
-    pub def height(x: IntervalAlt): BigInt = match x with {
+    pub def height(x: IntervalAlt): BigInt = match x {
         case Top            => 0ii
         case Range(b, e)    => 99ii - (e - b)
         case Bot            => 100ii
@@ -92,7 +92,7 @@ namespace Domain/IntervalAlt {
     ///
     #safe1(x -> x + 1ii)
     #strict1 #monotone1
-    pub def inc(x: IntervalAlt): IntervalAlt = match x with {
+    pub def inc(x: IntervalAlt): IntervalAlt = match x {
         case Bot            => Bot
         case Range(b, e)    => norm(Range(b + 1ii, e + 1ii))
         case Top            => Top
@@ -103,7 +103,7 @@ namespace Domain/IntervalAlt {
     ///
     #safe1(x -> x - 1ii)
     #strict1 #monotone1
-    pub def dec(x: IntervalAlt): IntervalAlt = match x with {
+    pub def dec(x: IntervalAlt): IntervalAlt = match x {
         case Bot            => Bot
         case Range(b, e)    => norm(Range(b - 1ii, e - 1ii))
         case Top            => Top
@@ -114,7 +114,7 @@ namespace Domain/IntervalAlt {
     ///
     #safe2((x, y) -> x + y)
     #strict2 #monotone2
-    pub def plus(x: IntervalAlt, y: IntervalAlt): IntervalAlt = match (x, y) with {
+    pub def plus(x: IntervalAlt, y: IntervalAlt): IntervalAlt = match (x, y) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
         case (Range(b1, e1), Range(b2, e2)) => norm(Range(b1 + b2, e1 + e2))
@@ -126,7 +126,7 @@ namespace Domain/IntervalAlt {
     ///
     #safe2((x, y) -> x - y)
     #strict2 #monotone2
-    pub def minus(x: IntervalAlt, y: IntervalAlt): IntervalAlt = match (x, y) with {
+    pub def minus(x: IntervalAlt, y: IntervalAlt): IntervalAlt = match (x, y) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
         case (Range(b1, e1), Range(b2, e2)) => norm(Range(b1 - e2, e1 - b2))
@@ -138,7 +138,7 @@ namespace Domain/IntervalAlt {
     ///
     #safe2((x, y) -> x * y)
     #strict2 /* #monotone2 loops/timeout */
-    pub def times(x: IntervalAlt, y: IntervalAlt): IntervalAlt = match (x, y) with {
+    pub def times(x: IntervalAlt, y: IntervalAlt): IntervalAlt = match (x, y) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
         case (Range(b1, e1), Range(b2, e2)) =>
@@ -153,7 +153,7 @@ namespace Domain/IntervalAlt {
       */
     #safeBelnap2((x, y) -> x == y)
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2 #commutativeBelnap
-    pub def eq(x: IntervalAlt, y: IntervalAlt): Belnap.Belnap = match (x, y) with {
+    pub def eq(x: IntervalAlt, y: IntervalAlt): Belnap.Belnap = match (x, y) {
         case (Bot, _)                                           => Belnap/Belnap.Bot
         case (_, Bot)                                           => Belnap/Belnap.Bot
         case (Range(b1, e1), Range(b2, e2)) => {
@@ -176,7 +176,7 @@ namespace Domain/IntervalAlt {
       */
     #safeBelnap2((x, y) -> x < y)
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2
-    pub def less(x: IntervalAlt, y: IntervalAlt): Belnap.Belnap = match (x, y) with {
+    pub def less(x: IntervalAlt, y: IntervalAlt): Belnap.Belnap = match (x, y) {
         case (Bot, _)                                  => Belnap/Belnap.Bot
         case (_, Bot)                                  => Belnap/Belnap.Bot
         case (Range(b1, e1), Range(b2, e2))   =>

--- a/examples/domains/IntervalInf.flix
+++ b/examples/domains/IntervalInf.flix
@@ -25,7 +25,7 @@ namespace Domain/IntervalInf {
     ///
     /// Returns the canonical representation of the given IntervalInf `e`.
     ///
-    def norm(e: IntervalInf): IntervalInf = match e with {
+    def norm(e: IntervalInf): IntervalInf = match e {
         case Bot            => Bot
         case Range(b, e)    => if (b <= e) Range(b, e) else Bot
         case Upper(e)       => Upper(e)
@@ -37,7 +37,7 @@ namespace Domain/IntervalInf {
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
-    def leq(e1: IntervalInf, e2: IntervalInf): Bool = match (e1, e2) with {
+    def leq(e1: IntervalInf, e2: IntervalInf): Bool = match (e1, e2) {
         case (Bot, _)                       => true
         case (Range(b1, e1), Range(b2, e2)) => b2 <= b1 && e1 <= e2
         case (Range(b1, e1), Upper(e2))     => e1 <= e2
@@ -52,7 +52,7 @@ namespace Domain/IntervalInf {
     /// Returns the least upper bound of `e1` and `e2`.
     ///
     #upperBound #leastUpperBound #commutative /* slow #associative */
-    def lub(e1: IntervalInf, e2: IntervalInf): IntervalInf = match (e1, e2) with {
+    def lub(e1: IntervalInf, e2: IntervalInf): IntervalInf = match (e1, e2) {
         case (Bot, x)                       => x
         case (x, Bot)                       => x
         case (Range(b1, e1), Range(b2, e2)) => norm(Range(BigInt.min(b1, b2), BigInt.max(e1, e2)))
@@ -69,7 +69,7 @@ namespace Domain/IntervalInf {
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
     #lowerBound #greatestLowerBound #commutative /* slow #associative */
-    def glb(e1: IntervalInf, e2: IntervalInf): IntervalInf = match (e1, e2) with {
+    def glb(e1: IntervalInf, e2: IntervalInf): IntervalInf = match (e1, e2) {
         case (Top, x)                       => x
         case (x, Top)                       => x
         case (Range(b1, e1), Range(b2, e2)) => norm(Range(BigInt.max(b1, b2), BigInt.min(e1, e2)))
@@ -94,7 +94,7 @@ namespace Domain/IntervalInf {
     ///
     #safe1(x -> x + 1ii)
     #strict1 #monotone1
-    def inc(e: IntervalInf): IntervalInf = match e with {
+    def inc(e: IntervalInf): IntervalInf = match e {
         case Bot            => Bot
         case Range(b, e)    => norm(Range(b + 1ii, e + 1ii))
         case Upper(e)       => norm(Upper(e + 1ii))
@@ -107,7 +107,7 @@ namespace Domain/IntervalInf {
     ///
     #safe1(x -> x - 1ii)
     #strict1 #monotone1
-    def dec(e: IntervalInf): IntervalInf = match e with {
+    def dec(e: IntervalInf): IntervalInf = match e {
         case Bot            => Bot
         case Range(b, e)    => norm(Range(b - 1ii, e - 1ii))
         case Upper(e)       => norm(Upper(e - 1ii))
@@ -120,7 +120,7 @@ namespace Domain/IntervalInf {
     ///
     #safe2((x, y) -> x + y)
     #strict2 #monotone2 #commutative
-    def plus(e1: IntervalInf, e2: IntervalInf): IntervalInf = match (e1, e2) with {
+    def plus(e1: IntervalInf, e2: IntervalInf): IntervalInf = match (e1, e2) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
         case (Range(b1, e1), Range(b2, e2)) => norm(Range(b1 + b2, e1 + e2))
@@ -138,7 +138,7 @@ namespace Domain/IntervalInf {
 //    ///
 //    #safe2((x, y) -> x - y)
 //    #strict2 #monotone2
-//    def minus(e1: IntervalInf, e2: IntervalInf): IntervalInf = match (e1, e2) with {
+//    def minus(e1: IntervalInf, e2: IntervalInf): IntervalInf = match (e1, e2) {
 //        case (Bot, _)                       => Bot
 //        case (_, Bot)                       => Bot
 //        case (Range(b1, e1), Range(b2, e2)) => norm(Range(b1 - e2, e1 - b2))
@@ -150,7 +150,7 @@ namespace Domain/IntervalInf {
     ///
     #safe2((x, y) -> x * y)
     #strict2  #monotone2 /**/ /* slow? #commutative */
-    def times(e1: IntervalInf, e2: IntervalInf): IntervalInf = match (e1, e2) with {
+    def times(e1: IntervalInf, e2: IntervalInf): IntervalInf = match (e1, e2) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
         case (Range(b1, e1), Range(b2, e2)) =>
@@ -169,7 +169,7 @@ namespace Domain/IntervalInf {
       */
     #safeBelnap2((x, y) -> x == y)
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2 #commutativeBelnap
-    def eq(e1: IntervalInf, e2: IntervalInf): Belnap.Belnap = match (e1, e2) with {
+    def eq(e1: IntervalInf, e2: IntervalInf): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)                                           => Belnap/Belnap.Bot
         case (_, Bot)                                           => Belnap/Belnap.Bot
         case (Range(b1, e1), Range(b2, e2)) => {
@@ -198,7 +198,7 @@ namespace Domain/IntervalInf {
       */
    #safeBelnap2((x, y) -> x < y)
    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2
-    def less(e1: IntervalInf, e2: IntervalInf): Belnap.Belnap = match (e1, e2) with {
+    def less(e1: IntervalInf, e2: IntervalInf): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)                                  => Belnap/Belnap.Bot
         case (_, Bot)                                  => Belnap/Belnap.Bot
         case (Range(b1, e1), Range(b2, e2))   =>

--- a/examples/domains/Mod3.flix
+++ b/examples/domains/Mod3.flix
@@ -25,7 +25,7 @@ namespace Domain/Mod3 {
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
     #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
-    pub def leq(e1: Mod3, e2: Mod3): Bool = match (e1, e2) with {
+    pub def leq(e1: Mod3, e2: Mod3): Bool = match (e1, e2) {
         case (Bot, _)   => true
         case (Zer, Zer) => true
         case (One, One) => true
@@ -38,7 +38,7 @@ namespace Domain/Mod3 {
     /// Returns the least upper bound of `e1` and `e2`.
     ///
     #upperBound #leastUpperBound #commutative #associative
-    pub def lub(e1: Mod3, e2: Mod3): Mod3 = match (e1, e2) with {
+    pub def lub(e1: Mod3, e2: Mod3): Mod3 = match (e1, e2) {
         case (Bot, x)   => x
         case (x, Bot)   => x
         case (Zer, Zer) => Zer
@@ -51,7 +51,7 @@ namespace Domain/Mod3 {
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
     #lowerBound #greatestLowerBound #commutative #associative
-    pub def glb(e1: Mod3, e2: Mod3): Mod3 = match (e1, e2) with {
+    pub def glb(e1: Mod3, e2: Mod3): Mod3 = match (e1, e2) {
         case (Top, x)   => x
         case (x, Top)   => x
         case (Zer, Zer) => Zer
@@ -64,7 +64,7 @@ namespace Domain/Mod3 {
     /// The lattice height function.
     ///
     #nonNegative #decreasing(equ, leq)
-    pub def height(e: Mod3): BigInt = match e with {
+    pub def height(e: Mod3): BigInt = match e {
         case Top    => 0ii
         case Zer    => 1ii
         case One    => 1ii
@@ -87,7 +87,7 @@ namespace Domain/Mod3 {
     ///
     #safe1(x -> x + 1ii)
     #strict1 #monotone1
-    pub def inc(e: Mod3): Mod3 = match e with {
+    pub def inc(e: Mod3): Mod3 = match e {
        case Bot => Bot
        case Zer => One
        case One => Two
@@ -100,7 +100,7 @@ namespace Domain/Mod3 {
     ///
     #safe1(x -> x - 1ii)
     #strict1 #monotone1
-    pub def dec(e: Mod3): Mod3 = match e with {
+    pub def dec(e: Mod3): Mod3 = match e {
        case Bot => Bot
        case Zer => Two
        case One => Zer
@@ -113,7 +113,7 @@ namespace Domain/Mod3 {
     ///
     #safe2((x, y) -> x + y)
     #strict2 #monotone2 #commutative #associative
-    pub def plus(e1: Mod3, e2: Mod3): Mod3 = match (e1, e2) with {
+    pub def plus(e1: Mod3, e2: Mod3): Mod3 = match (e1, e2) {
        case (_, Bot)   => Bot
        case (Bot, _)   => Bot
        case (Zer, x)   => x
@@ -130,7 +130,7 @@ namespace Domain/Mod3 {
     ///
     #safe2((x, y) -> x - y)
     #strict2 #monotone2
-    pub def minus(e1: Mod3, e2: Mod3): Mod3 = match (e1, e2) with {
+    pub def minus(e1: Mod3, e2: Mod3): Mod3 = match (e1, e2) {
        case (_, Bot)   => Bot
        case (Bot, _)   => Bot
        case (Zer, Zer) => Zer
@@ -150,7 +150,7 @@ namespace Domain/Mod3 {
     ///
     /* unknown #safe2((x, y) -> x * y) */
     #strict2 #monotone2 #commutative #associative
-    pub def times(e1: Mod3, e2: Mod3): Mod3 = match (e1, e2) with {
+    pub def times(e1: Mod3, e2: Mod3): Mod3 = match (e1, e2) {
         case (_, Bot)   => Bot
         case (Bot, _)   => Bot
         case (Zer, _)   => Zer
@@ -165,7 +165,7 @@ namespace Domain/Mod3 {
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
     #PartialOrder.monotone2(leq, leq, Belnap.leq)
     #commutative
-    pub def eq(e1: Mod3, e2: Mod3): Belnap.Belnap = match (e1, e2) with {
+    pub def eq(e1: Mod3, e2: Mod3): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)   => Belnap/Belnap.Bot
         case (_, Bot)   => Belnap/Belnap.Bot
         case (Zer, One) => Belnap/Belnap.False
@@ -191,7 +191,7 @@ namespace Domain/Mod3 {
     #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
     #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    pub def less(e1: Mod3, e2: Mod3): Belnap.Belnap = match (e1, e2) with {
+    pub def less(e1: Mod3, e2: Mod3): Belnap.Belnap = match (e1, e2) {
         case (Bot, _) => Belnap/Belnap.Bot
         case (_, Bot) => Belnap/Belnap.Bot
         case _        => Belnap/Belnap.Top

--- a/examples/domains/Parity.flix
+++ b/examples/domains/Parity.flix
@@ -23,7 +23,7 @@ namespace Domain/Parity {
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
     #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
-    def leq(e1: Parity, e2: Parity): Bool = match (e1, e2) with {
+    def leq(e1: Parity, e2: Parity): Bool = match (e1, e2) {
         case (Bot, _)       => true
         case (Odd, Odd)     => true
         case (Even, Even)   => true
@@ -35,7 +35,7 @@ namespace Domain/Parity {
     /// Returns the least upper bound of `e1` and `e2`.
     ///
     #commutative #associative #upperBound #leastUpperBound
-    def lub(e1: Parity, e2: Parity): Parity = match (e1, e2) with {
+    def lub(e1: Parity, e2: Parity): Parity = match (e1, e2) {
         case (Bot, x)       => x
         case (x, Bot)       => x
         case (Odd, Odd)     => Odd
@@ -47,7 +47,7 @@ namespace Domain/Parity {
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
     #commutative #associative #lowerBound #greatestLowerBound
-    def glb(e1: Parity, e2: Parity): Parity = match (e1, e2) with {
+    def glb(e1: Parity, e2: Parity): Parity = match (e1, e2) {
         case (Top, x)       => x
         case (x, Top)       => x
         case (Odd, Odd)     => Odd
@@ -59,7 +59,7 @@ namespace Domain/Parity {
     /// The lattice height function.
     ///
     #nonNegative #decreasing(equ, leq)
-    pub def height(e: Parity): BigInt = match e with {
+    pub def height(e: Parity): BigInt = match e {
         case Top    => 0ii
         case Odd    => 1ii
         case Even   => 1ii
@@ -76,7 +76,7 @@ namespace Domain/Parity {
     ///
     #safe1(x -> x + 1)
     #strict1 #monotone1
-    pub def inc(e: Parity): Parity = match e with {
+    pub def inc(e: Parity): Parity = match e {
         case Bot  => Bot
         case Odd  => Even
         case Even => Odd
@@ -88,7 +88,7 @@ namespace Domain/Parity {
     ///
     #safe1(x -> x - 1)
     #strict1 #monotone1
-    pub def dec(e: Parity): Parity = match e with {
+    pub def dec(e: Parity): Parity = match e {
         case Bot  => Bot
         case Odd  => Even
         case Even => Odd
@@ -100,7 +100,7 @@ namespace Domain/Parity {
     ///
     #safe2((x, y) -> x + y)
     #strict2 #monotone2 #commutative #associative
-    pub def plus(e1: Parity, e2: Parity): Parity = match (e1, e2) with {
+    pub def plus(e1: Parity, e2: Parity): Parity = match (e1, e2) {
         case (_, Bot)       => Bot
         case (Bot, _)       => Bot
         case (Odd, Odd)     => Even
@@ -115,7 +115,7 @@ namespace Domain/Parity {
     ///
     #safe2((x, y) -> x - y)
     #strict2 #monotone2
-    pub def minus(e1: Parity, e2: Parity): Parity = match (e1, e2) with {
+    pub def minus(e1: Parity, e2: Parity): Parity = match (e1, e2) {
         case (_, Bot)       => Bot
         case (Bot, _)       => Bot
         case (Odd, Odd)     => Even
@@ -130,7 +130,7 @@ namespace Domain/Parity {
     ///
     #safe2((x, y) -> x * y)
     #strict2 #monotone2 #commutative #associative
-    pub def times(e1: Parity, e2: Parity): Parity = match (e1, e2) with {
+    pub def times(e1: Parity, e2: Parity): Parity = match (e1, e2) {
         case (_, Bot)       => Bot
         case (Bot, _)       => Bot
         case (Odd, Odd)     => Odd
@@ -145,7 +145,7 @@ namespace Domain/Parity {
     ///
     #safe2((x, y) -> x / y)
     #strict2 #monotone2
-    pub def divide(e1: Parity, e2: Parity): Parity = match (e1, e2) with {
+    pub def divide(e1: Parity, e2: Parity): Parity = match (e1, e2) {
        case (_, Bot)    => Bot
        case (Bot, _)    => Bot
        case _           => Top
@@ -156,7 +156,7 @@ namespace Domain/Parity {
     ///
     #safe2((x, y) -> x % y)
     #strict2 #monotone2
-    pub def modulo(e1: Parity, e2: Parity): Parity = match (e1, e2) with {
+    pub def modulo(e1: Parity, e2: Parity): Parity = match (e1, e2) {
        case (_, Bot)        => Bot
        case (Bot, _)        => Bot
        case (Odd, Odd)      => Top
@@ -171,7 +171,7 @@ namespace Domain/Parity {
     ///
     #safe1(x -> ~~~x)
     #strict1 #monotone1
-    pub def negate(e: Parity): Parity = match e with {
+    pub def negate(e: Parity): Parity = match e {
         case Bot    => Bot
         case Odd    => Even
         case Even   => Odd
@@ -183,7 +183,7 @@ namespace Domain/Parity {
     ///
     #safe2((x, y) -> x &&& y)
     #strict2 #monotone2 #commutative #associative
-    pub def and(e1: Parity, e2: Parity): Parity = match (e1, e2) with {
+    pub def and(e1: Parity, e2: Parity): Parity = match (e1, e2) {
        case (_, Bot)        => Bot
        case (Bot, _)        => Bot
        case (Odd, Odd)      => Odd
@@ -198,7 +198,7 @@ namespace Domain/Parity {
     ///
     #safe2((x, y) -> x ||| y)
     #strict2 #monotone2 #commutative #associative
-    pub def or(e1: Parity, e2: Parity): Parity = match (e1, e2) with {
+    pub def or(e1: Parity, e2: Parity): Parity = match (e1, e2) {
       case (_, Bot)         => Bot
       case (Bot, _)         => Bot
       case (Odd, Odd)       => Odd
@@ -213,7 +213,7 @@ namespace Domain/Parity {
     ///
     #safe2((x, y) -> x ^^^ y)
     #strict2 #monotone2 #commutative #associative
-    pub def xor(e1: Parity, e2: Parity): Parity = match (e1, e2) with {
+    pub def xor(e1: Parity, e2: Parity): Parity = match (e1, e2) {
       case (_, Bot)         => Bot
       case (Bot, _)         => Bot
       case (Odd, Odd)       => Even
@@ -228,7 +228,7 @@ namespace Domain/Parity {
     ///
     #safe2((x, y) -> x <<< y)
     #strict2 #monotone2
-    pub def leftShift(e1: Parity, e2: Parity): Parity = match (e1, e2) with {
+    pub def leftShift(e1: Parity, e2: Parity): Parity = match (e1, e2) {
       case (_, Bot)         => Bot
       case (Bot, _)         => Bot
       case (Odd, Odd)       => Even
@@ -243,7 +243,7 @@ namespace Domain/Parity {
     ///
     #safe2((x, y) -> x >>> y)
     #strict2 #monotone2
-    pub def rightShift(e1: Parity, e2: Parity): Parity = match (e1, e2) with {
+    pub def rightShift(e1: Parity, e2: Parity): Parity = match (e1, e2) {
       case (_, Bot)     => Bot
       case (Bot, _)     => Bot
       case _            => Top
@@ -256,7 +256,7 @@ namespace Domain/Parity {
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
     #PartialOrder.monotone2(leq, leq, Belnap.leq)
     #commutative
-    pub def eq(e1: Parity, e2: Parity): Belnap.Belnap = match (e1, e2) with {
+    pub def eq(e1: Parity, e2: Parity): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)       => Belnap/Belnap.Bot
         case (_, Bot)       => Belnap/Belnap.Bot
         case (Odd, Even)    => Belnap/Belnap.False
@@ -279,7 +279,7 @@ namespace Domain/Parity {
     #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
     #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    pub def less(e1: Parity, e2: Parity): Belnap.Belnap = match (e1, e2) with {
+    pub def less(e1: Parity, e2: Parity): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)   => Belnap/Belnap.Bot
         case (_, Bot)   => Belnap/Belnap.Bot
         case _          => Belnap/Belnap.Top

--- a/examples/domains/ParitySign.flix
+++ b/examples/domains/ParitySign.flix
@@ -27,7 +27,7 @@ namespace Domain/ParitySign {
     ///
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
-    def leq(x: ParitySign, y: ParitySign): Bool = match (x, y) with {
+    def leq(x: ParitySign, y: ParitySign): Bool = match (x, y) {
         case (Bot, _)       => true
         case (ONeg, ONeg)   => true
         case (Zer, Zer)     => true
@@ -43,7 +43,7 @@ namespace Domain/ParitySign {
     ///
     /// Returns the least upper bound of `e1` and `e2`.
     ///
-    def lub(e1: ParitySign, e2: ParitySign): ParitySign = match (e1, e2) with {
+    def lub(e1: ParitySign, e2: ParitySign): ParitySign = match (e1, e2) {
         case (Bot, x)       => x
         case (x, Bot)       => x
         case (ONeg, ONeg)   => ONeg
@@ -61,7 +61,7 @@ namespace Domain/ParitySign {
     ///
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
-    def glb(e1: ParitySign, e2: ParitySign): ParitySign = match (e1, e2) with {
+    def glb(e1: ParitySign, e2: ParitySign): ParitySign = match (e1, e2) {
         case (Top, x)       => x
         case (x, Top)       => x
         case (ONeg, ONeg)   => ONeg
@@ -90,7 +90,7 @@ namespace Domain/ParitySign {
     ///
     /// Over-approximates integer `increment`.
     ///
-    pub def inc(e: ParitySign): ParitySign = match e with {
+    pub def inc(e: ParitySign): ParitySign = match e {
         case Bot    => Bot
         case ONeg   => ENeg
         case Zer    => OPos
@@ -103,7 +103,7 @@ namespace Domain/ParitySign {
     ///
     /// Over-approximates integer `decrement`.
     ///
-    pub def dec(e: ParitySign): ParitySign = match e with {
+    pub def dec(e: ParitySign): ParitySign = match e {
         case Bot    => Bot
         case ONeg   => ENeg
         case Zer    => ONeg
@@ -116,7 +116,7 @@ namespace Domain/ParitySign {
     ///
     /// Over-approximates integer `addition`.
     ///
-    pub def plus(e1: ParitySign, e2: ParitySign): ParitySign = match (e1, e2) with {
+    pub def plus(e1: ParitySign, e2: ParitySign): ParitySign = match (e1, e2) {
         case (Bot, _)   => Bot
         case (_, Bot)   => Bot
         // case (ONeg, ONeg) => Even // TODO: Need Even and Odd

--- a/examples/domains/PrefixSuffix.flix
+++ b/examples/domains/PrefixSuffix.flix
@@ -25,7 +25,7 @@ namespace Domain/PrefixSuffix {
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
     #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
-    def leq(e1: PrefixSuffix, e2: PrefixSuffix): Bool = match (e1, e2) with {
+    def leq(e1: PrefixSuffix, e2: PrefixSuffix): Bool = match (e1, e2) {
         case (Bot, _)                           => true
         case (PreSuf(p1, s1), PreSuf(p2, s2))   => p1 == p2 && s1 == s2
         case (PreSuf(p1, _), Pre(p2))           => p1 == p2
@@ -40,7 +40,7 @@ namespace Domain/PrefixSuffix {
     /// Returns the least upper bound of `e1` and `e2`.
     ///
     #upperBound #leastUpperBound #commutative #associative
-    def lub(e1: PrefixSuffix, e2: PrefixSuffix): PrefixSuffix = match (e1, e2) with {
+    def lub(e1: PrefixSuffix, e2: PrefixSuffix): PrefixSuffix = match (e1, e2) {
         case (Bot, x)                           => x
         case (x, Bot)                           => x
         case (PreSuf(p1, s1), PreSuf(p2, s2))   => {
@@ -62,7 +62,7 @@ namespace Domain/PrefixSuffix {
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
     #lowerBound #greatestLowerBound #commutative #associative
-    def glb(e1: PrefixSuffix, e2: PrefixSuffix): PrefixSuffix = match (e1, e2) with {
+    def glb(e1: PrefixSuffix, e2: PrefixSuffix): PrefixSuffix = match (e1, e2) {
         case (Top, x)                           => x
         case (x, Top)                           => x
         case (PreSuf(p1, s1), PreSuf(p2, s2))   => if (p1 == p2 && s1 == s2) PreSuf(p1, s1) else Bot
@@ -81,7 +81,7 @@ namespace Domain/PrefixSuffix {
     /// The lattice height function.
     ///
     #nonNegative #decreasing(equ, leq)
-    pub def height(e: PrefixSuffix): BigInt = match e with {
+    pub def height(e: PrefixSuffix): BigInt = match e {
         case Top            => 0ii
         case Pre(_)         => 1ii
         case Suf(_)         => 1ii
@@ -93,7 +93,7 @@ namespace Domain/PrefixSuffix {
     /// Over-approximates `concatenate`.
     ///
     #strict2 #monotone2 #associative
-    pub def concatenate(e1: PrefixSuffix, e2: PrefixSuffix): PrefixSuffix = match (e1, e2) with {
+    pub def concatenate(e1: PrefixSuffix, e2: PrefixSuffix): PrefixSuffix = match (e1, e2) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
         case (PreSuf(p1, _), PreSuf(_, s2)) => PreSuf(p1, s2)
@@ -118,7 +118,7 @@ namespace Domain/PrefixSuffix {
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
     #PartialOrder.monotone2(leq, leq, Belnap.leq)
     #commutative
-    pub def eq(e1: PrefixSuffix, e2: PrefixSuffix): Belnap.Belnap = match (e1, e2) with {
+    pub def eq(e1: PrefixSuffix, e2: PrefixSuffix): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)            => Belnap/Belnap.Bot
         case (_, Bot)            => Belnap/Belnap.Bot
         case (PreSuf(p1, s1), PreSuf(p2, s2)) => {

--- a/examples/domains/Sign.flix
+++ b/examples/domains/Sign.flix
@@ -29,7 +29,7 @@ namespace Domain/Sign {
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
     #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
-    def leq(e1: Sign, e2: Sign): Bool = match (e1, e2) with {
+    def leq(e1: Sign, e2: Sign): Bool = match (e1, e2) {
         case (Bot, _)   => true
         case (Zer, Zer) => true
         case (Zer, Neg) => true
@@ -44,7 +44,7 @@ namespace Domain/Sign {
     /// Returns the least upper bound of `e1` and `e2`.
     ///
     #upperBound #leastUpperBound #commutative #associative
-    def lub(e1: Sign, e2: Sign): Sign = match (e1, e2) with {
+    def lub(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, x)   => x
         case (x, Bot)   => x
         case (Zer, Zer) => Zer
@@ -61,7 +61,7 @@ namespace Domain/Sign {
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
     #lowerBound #greatestLowerBound #commutative #associative
-    def glb(e1: Sign, e2: Sign): Sign = match (e1, e2) with {
+    def glb(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Top, x)   => x
         case (x, Top)   => x
         case (Zer, Zer) => Zer
@@ -82,7 +82,7 @@ namespace Domain/Sign {
     /// The lattice height function.
     ///
     #nonNegative #decreasing(equ, leq)
-    pub def height(e: Sign): BigInt = match e with {
+    pub def height(e: Sign): BigInt = match e {
         case Top    => 0ii
         case Pos    => 1ii
         case Neg    => 1ii
@@ -104,7 +104,7 @@ namespace Domain/Sign {
     ///
     #safe1(x -> x + 1ii)
     #strict1 #monotone1
-    pub def inc(e: Sign): Sign = match e with {
+    pub def inc(e: Sign): Sign = match e {
         case Bot => Bot
         case Neg => Top
         case Zer => Pos
@@ -117,7 +117,7 @@ namespace Domain/Sign {
     ///
     #safe1(x -> x - 1ii)
     #strict1 #monotone1
-    pub def dec(e: Sign): Sign = match e with {
+    pub def dec(e: Sign): Sign = match e {
         case Bot => Bot
         case Neg => Neg
         case Zer => Neg
@@ -130,7 +130,7 @@ namespace Domain/Sign {
     ///
     #safe2((x, y) -> x + y)
     #strict2 #monotone2 #commutative #associative
-    pub def plus(e1: Sign, e2: Sign): Sign = match (e1, e2) with {
+    pub def plus(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, _) => Bot
         case (_, Bot) => Bot
         case (Neg, Neg) => Neg
@@ -150,7 +150,7 @@ namespace Domain/Sign {
     ///
     #safe2((x, y) -> x - y)
     #strict2 #monotone2
-    pub def minus(e1: Sign, e2: Sign): Sign = match (e1, e2) with {
+    pub def minus(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, _)   => Bot
         case (_, Bot)   => Bot
         case (Neg, Neg) => Top
@@ -170,7 +170,7 @@ namespace Domain/Sign {
     ///
     #safe2((x, y) -> x * y)
     #strict2 #monotone2
-    pub def times(e1: Sign, e2: Sign): Sign = match (e1, e2) with {
+    pub def times(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, _)   => Bot
         case (_, Bot)   => Bot
         case (Neg, Neg) => Pos
@@ -193,7 +193,7 @@ namespace Domain/Sign {
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
     #PartialOrder.monotone2(leq, leq, Belnap.leq)
     #commutative
-    pub def eq(e1: Sign, e2: Sign): Belnap.Belnap = match (e1, e2) with {
+    pub def eq(e1: Sign, e2: Sign): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)   => Belnap/Belnap.Bot
         case (_, Bot)   => Belnap/Belnap.Bot
         case (Zer, Zer) => Belnap/Belnap.True
@@ -215,7 +215,7 @@ namespace Domain/Sign {
     #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
     #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    pub def less(e1: Sign, e2: Sign): Belnap.Belnap = match (e1, e2) with {
+    pub def less(e1: Sign, e2: Sign): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)   => Belnap/Belnap.Bot
         case (_, Bot)   => Belnap/Belnap.Bot
         case (Zer, Zer) => Belnap/Belnap.False

--- a/examples/domains/StrictSign.flix
+++ b/examples/domains/StrictSign.flix
@@ -23,7 +23,7 @@ namespace Domain/StrictSign {
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
     #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
-    def leq(e1: Sign, e2: Sign): Bool = match (e1, e2) with {
+    def leq(e1: Sign, e2: Sign): Bool = match (e1, e2) {
         case (Bot, _)   => true
         case (Neg, Neg) => true
         case (Zer, Zer) => true
@@ -36,7 +36,7 @@ namespace Domain/StrictSign {
     /// Returns the least upper bound of `e1` and `e2`.
     ///
     #upperBound #leastUpperBound #commutative #associative
-    def lub(e1: Sign, e2: Sign): Sign = match (e1, e2) with {
+    def lub(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, x)   => x
         case (x, Bot)   => x
         case (Neg, Neg) => Neg
@@ -49,7 +49,7 @@ namespace Domain/StrictSign {
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
     #lowerBound #greatestLowerBound #commutative #associative
-    def glb(e1: Sign, e2: Sign): Sign = match (e1, e2) with {
+    def glb(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Top, x)   => x
         case (x, Top)   => x
         case (Neg, Neg) => Neg
@@ -62,7 +62,7 @@ namespace Domain/StrictSign {
     /// The lattice height function.
     ///
     #nonNegative #decreasing(equ, leq)
-    pub def height(e: Sign): BigInt = match e with {
+    pub def height(e: Sign): BigInt = match e {
         case Top    => 0ii
         case Neg    => 1ii
         case Zer    => 1ii
@@ -84,7 +84,7 @@ namespace Domain/StrictSign {
     ///
     #safe1(x -> x + 1ii)
     #strict1 #monotone1
-    pub def inc(e: Sign): Sign = match e with {
+    pub def inc(e: Sign): Sign = match e {
         case Bot => Bot
         case Neg => Top
         case Zer => Pos
@@ -97,7 +97,7 @@ namespace Domain/StrictSign {
     ///
     #safe1(x -> x - 1ii)
     #strict1 #monotone1
-    pub def dec(e: Sign): Sign = match e with {
+    pub def dec(e: Sign): Sign = match e {
         case Bot => Bot
         case Neg => Neg
         case Zer => Neg
@@ -110,7 +110,7 @@ namespace Domain/StrictSign {
     ///
     #safe2((x, y) -> x + y)
     #strict2 #monotone2 #commutative #associative
-    pub def plus(e1: Sign, e2: Sign): Sign = match (e1, e2) with {
+    pub def plus(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, _)   => Bot
         case (_, Bot)   => Bot
         case (Neg, Neg) => Neg
@@ -130,7 +130,7 @@ namespace Domain/StrictSign {
     ///
     #safe2((x, y) -> x - y)
     #strict2 #monotone2
-    pub def minus(e1: Sign, e2: Sign): Sign = match (e1, e2) with {
+    pub def minus(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, _)   => Bot
         case (_, Bot)   => Bot
         case (Neg, Neg) => Top
@@ -150,7 +150,7 @@ namespace Domain/StrictSign {
     ///
     #safe2((x, y) -> x * y)
     #strict2 #monotone2 #commutative #associative
-    pub def times(e1: Sign, e2: Sign): Sign = match (e1, e2) with {
+    pub def times(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, _)   => Bot
         case (_, Bot)   => Bot
         case (Neg, Neg) => Pos
@@ -172,7 +172,7 @@ namespace Domain/StrictSign {
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
     #PartialOrder.monotone2(leq, leq, Belnap.leq)
     #commutative
-    pub def eq(e1: Sign, e2: Sign): Belnap.Belnap = match (e1, e2) with {
+    pub def eq(e1: Sign, e2: Sign): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)   => Belnap/Belnap.Bot
         case (_, Bot)   => Belnap/Belnap.Bot
         case (Neg, Neg) => Belnap/Belnap.Top
@@ -202,7 +202,7 @@ namespace Domain/StrictSign {
     #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
     #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
     #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    pub def less(e1: Sign, e2: Sign): Belnap.Belnap = match (e1, e2) with {
+    pub def less(e1: Sign, e2: Sign): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)   => Belnap/Belnap.Bot
         case (_, Bot)   => Belnap/Belnap.Bot
         case (Neg, Zer) => Belnap/Belnap.True

--- a/examples/enums-and-parametric-polymorphism.flix
+++ b/examples/enums-and-parametric-polymorphism.flix
@@ -8,7 +8,7 @@ enum Tree[a] {
 /// A higher-order function that transforms a tree with
 /// elements of type a to a tree with elements of type b.
 def map[a, b](f: a -> b, t: Tree[a]): Tree[b] =
-  match t with {
+  match t {
     case Leaf(x)    => Leaf(f(x))
     case Node(l, r) => Node(map(f, l), map(f, r))
   }

--- a/examples/fixpoint-computations-on-lattices.flix
+++ b/examples/fixpoint-computations-on-lattices.flix
@@ -14,7 +14,7 @@ enum Sign {
 def equ(e1: Sign, e2: Sign): Bool = e1 == e2
 
 /// The partial order relation on the lattice elements.
-def leq(e1: Sign, e2: Sign): Bool = match (e1, e2) with {
+def leq(e1: Sign, e2: Sign): Bool = match (e1, e2) {
     case (Bot, _)   => true
     case (Neg, Neg) => true
     case (Zer, Zer) => true
@@ -24,7 +24,7 @@ def leq(e1: Sign, e2: Sign): Bool = match (e1, e2) with {
 }
 
 /// The least upper bound relation on the lattice elements.
-def lub(e1: Sign, e2: Sign): Sign = match (e1, e2) with {
+def lub(e1: Sign, e2: Sign): Sign = match (e1, e2) {
     case (Bot, x)   => x
     case (x, Bot)   => x
     case (Neg, Neg) => Neg
@@ -34,7 +34,7 @@ def lub(e1: Sign, e2: Sign): Sign = match (e1, e2) with {
 }
 
 /// The greatest lower bound relation on the lattice elements.
-def glb(e1: Sign, e2: Sign): Sign = match (e1, e2) with {
+def glb(e1: Sign, e2: Sign): Sign = match (e1, e2) {
     case (Top, x)   => x
     case (x, Top)   => x
     case (Neg, Neg) => Neg

--- a/examples/lists-and-list-processing.flix
+++ b/examples/lists-and-list-processing.flix
@@ -8,7 +8,7 @@ def aList(): List[Int] = 1 :: 2 :: 3 :: Nil
 def bList(): List[Int] = aList() ::: aList()
 
 /// We can use pattern matching to take a list apart:
-def length[a](l: List[a]): Int = match l with {
+def length[a](l: List[a]): Int = match l {
   case Nil     => 0
   case x :: xs => 1 + length(xs)
 }

--- a/examples/misc/FloydWarshall.flix
+++ b/examples/misc/FloydWarshall.flix
@@ -24,7 +24,7 @@ def equ(e1: Dist, e2: Dist): Bool = e1 == e2
 ///
 /// Returns `true` if the distance `e1` is greater than or equal to the distance `e2`.
 ///
-def leq(e1: Dist, e2: Dist): Bool = match (e1, e2) with {
+def leq(e1: Dist, e2: Dist): Bool = match (e1, e2) {
   case (_, Top) => true
   case (Bot, _) => true
   case (Dst(n1), Dst(n2)) => n1 >= n2
@@ -34,7 +34,7 @@ def leq(e1: Dist, e2: Dist): Bool = match (e1, e2) with {
 ///
 /// Returns the shorter distance of `e1` and `e2`.
 ///
-def lub(e1: Dist, e2: Dist): Dist = match (e1, e2) with {
+def lub(e1: Dist, e2: Dist): Dist = match (e1, e2) {
   case (Bot, x) => x
   case (x, Bot) => x
   case (Dst(n1), Dst(n2)) => Dst(Int32.min(n1, n2))
@@ -44,7 +44,7 @@ def lub(e1: Dist, e2: Dist): Dist = match (e1, e2) with {
 ///
 /// Returns the greater distance of `e1` and `e2`.
 ///
-def glb(e1: Dist, e2: Dist): Dist = match (e1, e2) with {
+def glb(e1: Dist, e2: Dist): Dist = match (e1, e2) {
   case (Top, x) => x
   case (x, Top) => x
   case (Dst(n1), Dst(n2)) => Dst(Int32.max(n1, n2))
@@ -66,7 +66,7 @@ ShortestDist(a, a; Top) :- ShortestDist(a, a; d), negativeDist(d).
 /// Transfer function.
 /// Returns the sum of two given distances.
 ///
-def sum(e1: Dist, e2: Dist): Dist = match (e1, e2) with {
+def sum(e1: Dist, e2: Dist): Dist = match (e1, e2) {
   case (Top, _) => Top
   case (_, Top) => Top
   case (Dst(n1), Dst(n2)) => Dst(n1 + n2)
@@ -77,7 +77,7 @@ def sum(e1: Dist, e2: Dist): Dist = match (e1, e2) with {
 /// Filter function.
 /// Returns `true` if the given distance `d` is negative.
 ///
-def negativeDist(d: Dist): Bool = match d with {
+def negativeDist(d: Dist): Bool = match d {
   case Top => true
   case Dst(x) => x < 0
   case _ => false

--- a/examples/sending-and-receiving-on-channels.flix
+++ b/examples/sending-and-receiving-on-channels.flix
@@ -1,6 +1,6 @@
 /// A function that sends every element of a list
 def send(o: Channel[Int], l: List[Int]): Unit & Impure =
-    match l with {
+    match l {
         case Nil     => ()
         case x :: xs => o <- x; send(o, xs)
     }
@@ -8,7 +8,7 @@ def send(o: Channel[Int], l: List[Int]): Unit & Impure =
 /// A function that receives n elements
 /// and collects them into a list.
 def recv(i: Channel[Int], n: Int): List[Int] & Impure =
-    match n with {
+    match n {
         case 0 => Nil
         case _ => (<- i) :: recv(i, n - 1)
     }

--- a/examples/the-ast-typing-problem-with-polymorphic-records.flix
+++ b/examples/the-ast-typing-problem-with-polymorphic-records.flix
@@ -19,7 +19,7 @@ enum Type {
 
 /// We can now write a function that given an expression extended
 /// with a tpe: Type field returns its type!
-def typeOf[r](e: Exp[{tpe: Type | r}]): Type = match e with {
+def typeOf[r](e: Exp[{tpe: Type | r}]): Type = match e {
     case True   => TBool
     case False  => TBool
     case Cst(_) => TInt
@@ -30,7 +30,7 @@ def typeOf[r](e: Exp[{tpe: Type | r}]): Type = match e with {
 /// We can write a function that takes an untyped expression
 /// and returns a typed expression decorated with the type.
 /// For simplicity, the actual checks have been omitted.
-def typeCheck(e: Exp[{}]): Exp[{tpe: Type}] = match e with {
+def typeCheck(e: Exp[{}]): Exp[{tpe: Type}] = match e {
     case True   => True
     case False  => False
     case Cst(i) => Cst({value = i.value, tpe = TInt})
@@ -54,7 +54,7 @@ def main(): Type =
 
 /// We can extend the function above to be one that is polymorphic
 /// in whatever other fields an expression may be decorated with:
-def typeCheck2[r](e: Exp[r]): Exp[{tpe: Type | r}] = match e with {
+def typeCheck2[r](e: Exp[r]): Exp[{tpe: Type | r}] = match e {
     case True   => True
     case False  => False
     case Cst(i) => Cst({ +tpe = TInt | { value = i.value | i}})

--- a/examples/using-channels-and-select.flix
+++ b/examples/using-channels-and-select.flix
@@ -1,20 +1,20 @@
  /// Mooo's `n` times on channel `c`.
 def mooo(c: Channel[Str], n: Int): Unit & Impure =
-    match n with {
+    match n {
         case 0 => ()
         case x => c <- "Mooo!"; mooo(c, x - 1)
     }
 
 /// Meow's `n` times on channel `c`.
 def meow(c: Channel[Str], n: Int): Unit & Impure =
-    match n with {
+    match n {
         case 0 => ()
         case x => c <- "Meow!"; meow(c, x - 1)
     }
 
 /// Hiss'es `n` times on channel `c`.
 def hiss(c: Channel[Str], n: Int): Unit & Impure =
-    match n with {
+    match n {
         case 0 => ()
         case x => c <- "Hiss!"; hiss(c, x - 1)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -776,7 +776,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       }
 
       rule {
-        SP ~ atomic("match") ~ WS ~ Expression ~ optional(WS ~ atomic("with") ~ WS) ~ optWS ~ "{" ~ optWS ~ oneOrMore(Rule).separatedBy(CaseSeparator) ~ optWS ~ "}" ~ SP ~> ParsedAst.Expression.Match
+        SP ~ atomic("match") ~ WS ~ Expression ~ optWS ~ "{" ~ optWS ~ oneOrMore(Rule).separatedBy(CaseSeparator) ~ optWS ~ "}" ~ SP ~> ParsedAst.Expression.Match
       }
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -855,7 +855,7 @@ object Simplifier extends Phase[TypedAst.Root, SimplifiedAst.Root] {
       //
       // Given the code:
       //
-      // match x with {
+      // match x {
       //   case PATTERN_1 => BODY_1
       //   case PATTERN_2 => BODY_2
       //   ...

--- a/main/src/ca/uwaterloo/flix/language/phase/Synthesize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Synthesize.scala
@@ -578,7 +578,7 @@ object Synthesize extends Phase[Root, Root] {
             //
             // then we generate the expression:
             //
-            //   match (e1, e2) with {
+            //   match (e1, e2) {
             //     case (None(freshX), None(freshY)) => recurse(tpe, freshX, freshY)
             //     case (Some(freshX), Some(freshY)) => recurse(tpe, freshX, freshY)
             //     case _                            => false
@@ -641,7 +641,7 @@ object Synthesize extends Phase[Root, Root] {
             //
             // then we generate the expression:
             //
-            //   match (e1, e2) with {
+            //   match (e1, e2) {
             //     case ((x1, x2, x3), (y1, y2, y3)) => recurse(x1, y1) && recurse(x2, y2) && recurse(x2, y2)
             //   }
             //
@@ -820,7 +820,7 @@ object Synthesize extends Phase[Root, Root] {
             //
             // then we generate the expression:
             //
-            //   match e with {
+            //   match e {
             //     case (None(freshX)) => 1 + recurse(freshX)
             //     case (Some(freshX)) => 2 + recurse(freshX)
             //   }
@@ -875,7 +875,7 @@ object Synthesize extends Phase[Root, Root] {
             //
             // then we generate the expression:
             //
-            //   match exp0 with {
+            //   match exp0 {
             //     case (x1, x2, x3) => recurse(x1) + recurse(x2) + recurse(x3)
             //   }
             //
@@ -1081,7 +1081,7 @@ object Synthesize extends Phase[Root, Root] {
             //
             // then we generate the expression:
             //
-            //   match exp0 with {
+            //   match exp0 {
             //     case (x1, x2, x3) => "(" + recurse(x1) + ", " + recurse(x2) + ", " + recurse(x3) + ")"
             //   }
             //
@@ -1134,7 +1134,7 @@ object Synthesize extends Phase[Root, Root] {
             //
             // then we generate the expression:
             //
-            //   match e with {
+            //   match e {
             //     case (None(freshX)) => "None(" + recurse(freshX) + ")"
             //     case (Some(freshX)) => "Some(" + recurse(freshX) + ")"
             //   }

--- a/main/src/tutorials/interpreter.flix
+++ b/main/src/tutorials/interpreter.flix
@@ -53,7 +53,7 @@ enum BExp {
 //
 // We now define a small interpreter for arithmetic expressions.
 //
-def evalAExp(e: AExp): Int = match e with {
+def evalAExp(e: AExp): Int = match e {
     case Cst(i)                 => i
     case Plus(e1, e2)           => evalAExp(e1) + evalAExp(e2)
     case Minus(e1, e2)          => evalAExp(e1) - evalAExp(e2)
@@ -66,7 +66,7 @@ def evalAExp(e: AExp): Int = match e with {
 //
 // and here is the small interpreter for boolean expressions.
 //
-def evalBExp(e: BExp): Bool = match e with {
+def evalBExp(e: BExp): Bool = match e {
     case True           => true
     case False          => false
     case Not(e1)        => !evalBExp(e1)
@@ -156,7 +156,7 @@ enum Inst {
 //
 // The append function appends two lists and is defined in the bottom of this file.
 //
-def compileAExp(e: AExp): List[Inst] = match e with {
+def compileAExp(e: AExp): List[Inst] = match e {
     case Cst(i)         => Push(i) :: Nil
     case Plus(e1, e2)   =>
         let is1 = compileAExp(e1);
@@ -180,7 +180,7 @@ def compileAExp(e: AExp): List[Inst] = match e with {
 //
 // and a compiler for boolean expressions:
 //
-def compileBExp(e: BExp): List[Inst] = match e with {
+def compileBExp(e: BExp): List[Inst] = match e {
     case True           => Push(1) :: Nil
     case False          => Push(0) :: Nil
     case Not(e1)         =>
@@ -240,7 +240,7 @@ def testCompileBExp5(): List[Inst] = compileBExp(Neq(Cst(1), Cst(2)))
 //
 // Finally, we write an interpreter for the stack-based language:
 //
-def evalInst(instructions: List[Inst], stack: List[Int]): Int = match (instructions, stack) with {
+def evalInst(instructions: List[Inst], stack: List[Int]): Int = match (instructions, stack) {
     case (Nil, x :: _) => x
     case ((Push(i)) :: rs, st) => evalInst(rs, i :: st)
     case (Add :: rs, i1 :: i2 :: st) => evalInst(rs, (i1 + i2) :: st)

--- a/main/src/tutorials/introduction.flix
+++ b/main/src/tutorials/introduction.flix
@@ -49,7 +49,7 @@ def equ(e1: Constant, e2: Constant): Bool = e1 == e2
 // The next task is to define the partial order on Constant.
 // This is straightforward with pattern matching on the arguments:
 //
-def leq(e1: Constant, e2: Constant): Bool = match (e1, e2) with {
+def leq(e1: Constant, e2: Constant): Bool = match (e1, e2) {
     case (Bot, _)           => true
     case (Cst(n1), Cst(n2)) => n1 == n2
     case (_, Top)           => true
@@ -59,7 +59,7 @@ def leq(e1: Constant, e2: Constant): Bool = match (e1, e2) with {
 //
 // Then it's on to the least upper bound:
 //
-def lub(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+def lub(e1: Constant, e2: Constant): Constant = match (e1, e2) {
     case (Bot, x)           => x
     case (x, Bot)           => x
     case (Cst(n1), Cst(n2)) => if (n1 == n2) e1 else Top
@@ -69,7 +69,7 @@ def lub(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
 //
 // ... and the greatest lower bound:
 //
-def glb(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+def glb(e1: Constant, e2: Constant): Constant = match (e1, e2) {
     case (Top, x)           => x
     case (x, Top)           => x
     case (Cst(n1), Cst(n2)) => if (n1 == n2) e1 else Bot
@@ -123,7 +123,7 @@ LocalVar(r; div(v1, v2)) :- DivStm(r, x, y),
 //
 // We must define the sum transfer function:
 //
-def sum(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+def sum(e1: Constant, e2: Constant): Constant = match (e1, e2) {
     case (Bot, _)           => Bot
     case (_, Bot)           => Bot
     case (Cst(n1), Cst(n2)) => Cst(n1 + n2)
@@ -133,7 +133,7 @@ def sum(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
 //
 // And the div transfer function:
 //
-def div(e1: Constant, e2: Constant): Constant = match (e1, e2) with {
+def div(e1: Constant, e2: Constant): Constant = match (e1, e2) {
     case (_, Bot)           => Bot
     case (Bot, _)           => Bot
     case (Cst(n1), Cst(n2)) => if (n2 == 0) Bot else Cst(n1 / n2)
@@ -167,7 +167,7 @@ ArithmeticError(r) :- isMaybeZero(y),
 //
 // Defining the filter function is straightforward:
 //
-def isMaybeZero(e: Constant): Bool = match e with {
+def isMaybeZero(e: Constant): Bool = match e {
     case Bot    => false
     case Cst(n) => n == 0
     case Top    => true

--- a/main/src/tutorials/lambda-calculus.flix
+++ b/main/src/tutorials/lambda-calculus.flix
@@ -36,7 +36,7 @@ enum EvaluationContext {
 ///
 /// Returns `true` if the given expression `e0` is a value.
 ///
-def isValue(e0: Expression): Bool = match e0 with {
+def isValue(e0: Expression): Bool = match e0 {
     case Abs(x, e) => true
     case _         => false
 }
@@ -54,7 +54,7 @@ def nonValue(e0: Expression): Bool = !isValue(e0)
 ///
 /// Returns the expression itself (and the empty evaluation context) if the expression is irreducible.
 ///
-def redex(e0: Expression): (Expression, EvaluationContext) = match e0 with {
+def redex(e0: Expression): (Expression, EvaluationContext) = match e0 {
     case Var(x) =>
         // A variable cannot be reduced.
         (Var(x), Hole)
@@ -83,7 +83,7 @@ def redex(e0: Expression): (Expression, EvaluationContext) = match e0 with {
 /// Returns an expression reconstructed from the given evaluation context `ec0`
 /// with the given expression `e0` replacing the hole in the context.
 ///
-def recompose(e0: Expression, ec0: EvaluationContext): Expression = match ec0 with {
+def recompose(e0: Expression, ec0: EvaluationContext): Expression = match ec0 {
     case Hole         => e0
     case EApp1(ec, e) => App(recompose(e0, ec), e)
     case EApp2(v, ec) => App(v, recompose(e0, ec))
@@ -94,7 +94,7 @@ def recompose(e0: Expression, ec0: EvaluationContext): Expression = match ec0 wi
 ///
 def step(e0: Expression): Expression =
     let (rdx, ec) = redex(e0);
-    match rdx with {
+    match rdx {
         case App(Abs(x, e1), e2) =>
             // Perform beta-reduction: Use alpha-renaming to avoid capture.
             recompose(substitute(e1, x, alpha(e2, Map.empty())), ec)
@@ -105,7 +105,7 @@ def step(e0: Expression): Expression =
 ///
 /// Replaces every occurrence of the variable `x` in the expression `e0` with the expression `r0`.
 ///
-def substitute(e0: Expression, x: Int, r0: Expression): Expression = match e0 with {
+def substitute(e0: Expression, x: Int, r0: Expression): Expression = match e0 {
     case Var(y)      => if (x == y) r0 else Var(y)
     case Abs(y, e)   => if (x == y) Abs(y, e) else Abs(y, substitute(e, x, r0))
     case App(e1, e2) => App(substitute(e1, x, r0), substitute(e2, x, r0))
@@ -114,10 +114,10 @@ def substitute(e0: Expression, x: Int, r0: Expression): Expression = match e0 wi
 ///
 /// Performs alpha conversion by introducing fresh variables for all variables in the given expression `e0`.
 ///
-def alpha(e0: Expression, m: Map[Int, Int]): Expression = match e0 with {
+def alpha(e0: Expression, m: Map[Int, Int]): Expression = match e0 {
     case Var(x) =>
         // Check if we need to rename the variable.
-        match Map.get(x, m) with {
+        match Map.get(x, m) {
             case None    => Var(x)
             case Some(y) => Var(y)
         }

--- a/main/test/ca/uwaterloo/flix/language/feature/Test.Expression.Match.Wild.flix
+++ b/main/test/ca/uwaterloo/flix/language/feature/Test.Expression.Match.Wild.flix
@@ -1,25 +1,25 @@
 namespace Test/Expression/Match/Wild {
 
     @test
-    def wild01(): Bool = match () with {
+    def wild01(): Bool = match () {
         case _ => true
     }
 
     @test
-    def wild02(): Bool = match 123 with {
+    def wild02(): Bool = match 123 {
         case 0 => false
         case 1 => false
         case _ => true
     }
 
     @test
-    def wild03(): Bool = match None with {
+    def wild03(): Bool = match None {
         case Some(_) => false
         case _       => true
     }
 
     @test
-    def wild04(): Bool = match Some(Ok(123)) with {
+    def wild04(): Bool = match Some(Ok(123)) {
         case Some(Err(_)) => false
         case Some(Ok(_))  => true
         case _            => false

--- a/main/test/ca/uwaterloo/flix/language/feature/Test.Expression.Match.flix
+++ b/main/test/ca/uwaterloo/flix/language/feature/Test.Expression.Match.flix
@@ -6,35 +6,35 @@
 // (MkClosureRef, ApplyClosure, free variables).                           //
 /////////////////////////////////////////////////////////////////////////////
 
-def f04(x: Int): Int = match x with {
+def f04(x: Int): Int = match x {
   case _ => 1
 }
 
 @test
 def testMatchVar01(): Bool = f04(3) == 1
 
-def f05(x: Int): Int = match x with {
+def f05(x: Int): Int = match x {
   case a => a
 }
 
 @test
 def testMatchVar02(): Bool = f05(3) == 3
 
-def f06(x: Int): Int = match x with {
+def f06(x: Int): Int = match x {
   case a => a + 11
 }
 
 @test
 def testMatchVar03(): Bool = f06(3) == 14
 
-def f07(x: Unit): Bool = match x with {
+def f07(x: Unit): Bool = match x {
   case () => true
 }
 
 @test
 def testMatchLiteral01(): Bool = f07(()) == true
 
-def f08(x: Bool): Int = match x with {
+def f08(x: Bool): Int = match x {
   case true => 30
   case false => 81
 }
@@ -45,7 +45,7 @@ def testMatchLiteral02(): Bool = f08(true) == 30
 @test
 def testMatchLiteral03(): Bool = f08(false) == 81
 
-def f09(x: Bool): Int = match x with {
+def f09(x: Bool): Int = match x {
   case true => 30
   case _ => 81
 }
@@ -56,7 +56,7 @@ def testMatchLiteral04(): Bool = f09(true) == 30
 @test
 def testMatchLiteral05(): Bool = f09(false) == 81
 
-def f10(x: Int): Str = match x with {
+def f10(x: Int): Str = match x {
   case -1 => "minus one"
   case 0 => "zero"
   case 1 => "one"
@@ -78,7 +78,7 @@ def testMatchLiteral09(): Bool = f10(2) == "unknown"
 @test
 def testMatchLiteral10(): Bool = f10(3) == "unknown"
 
-def f11(x: Int8): Str = match x with {
+def f11(x: Int8): Str = match x {
   case -128i8 => "min"
   case -2i8 => "a"
   case 6i8 => "b"
@@ -101,7 +101,7 @@ def testMatchLiteral14(): Bool = f11(127i8) == "max"
 @test
 def testMatchLiteral15(): Bool = f11(0i8) == "unknown"
 
-def f12(x: Int16): Str = match x with {
+def f12(x: Int16): Str = match x {
   case -32768i16 => "min"
   case -211i16 => "a"
   case 623i16 => "b"
@@ -124,7 +124,7 @@ def testMatchLiteral19(): Bool = f12(32767i16) == "max"
 @test
 def testMatchLiteral20(): Bool = f12(0i16) == "unknown"
 
-def f13(x: Int32): Str = match x with {
+def f13(x: Int32): Str = match x {
   case -2147483648i32 => "min"
   case -2136541i32 => "a"
   case 6254523i32 => "b"
@@ -147,7 +147,7 @@ def testMatchLiteral24(): Bool = f13(2147483647i32) == "max"
 @test
 def testMatchLiteral25(): Bool = f13(0i32) == "unknown"
 
-def f14(x: Int64): Str = match x with {
+def f14(x: Int64): Str = match x {
   case -9223372036854775808i64 => "min"
   case -213645454545541i64 => "a"
   case 6287816254523i64 => "b"
@@ -170,7 +170,7 @@ def testMatchLiteral29(): Bool = f14(9223372036854775807i64) == "max"
 @test
 def testMatchLiteral30(): Bool = f14(0i64) == "unknown"
 
-def f15(x: Str): Str = match x with {
+def f15(x: Str): Str = match x {
   case "one" => "un"
   case "two" => "deux"
   case "three" => "trois"
@@ -191,7 +191,7 @@ def testMatchLiteral34(): Bool = f15("four") == "???"
 
 enum Foo16 { case Bar16, case Baz16, case Abc16(Int,Str), case Xyz16 }
 
-def f16(x: Foo16): Int = match x with {
+def f16(x: Foo16): Int = match x {
   case Foo16.Bar16 => 1
   case Foo16.Baz16 => 2
   case Foo16.Abc16(42, "hi") => 3
@@ -219,7 +219,7 @@ def testMatchLiteral40(): Bool = f16(Foo16.Abc16(40, "a")) == 0
 @test
 def testMatchLiteral41(): Bool = f16(Foo16.Xyz16) == 0
 
-def f17(x: Str, y: Bool): Int = match (x, y) with {
+def f17(x: Str, y: Bool): Int = match (x, y) {
   case ("hi", false) => 1
   case _ => 2
 }
@@ -236,7 +236,7 @@ def testMatchLiteral44(): Bool = f17("abc", true) == 2
 @test
 def testMatchLiteral45(): Bool = f17("abc", false) == 2
 
-def f18(x: (Int, (Int, Int))): Int = match x with {
+def f18(x: (Int, (Int, Int))): Int = match x {
   case (4, (12, 8)) => 1
   case (4, (12, 0)) => 2
   case (1, (12, 8)) => 3
@@ -255,9 +255,9 @@ def testMatchLiteral48(): Bool = f18((1, (12, 8))) == 3
 @test
 def testMatchLiteral49(): Bool = f18((1, (12, 0))) == 4
 
-def f19(x: Int, y: Int): Int = match x with {
+def f19(x: Int, y: Int): Int = match x {
   case 0 => y
-  case _ =>  match y with {
+  case _ =>  match y {
     case 0 => x
     case _ => 0
   }
@@ -275,7 +275,7 @@ def testMatchLiteral52(): Bool = f19(0, 2) == 2
 @test
 def testMatchLiteral53(): Bool = f19(3, 4) == 0
 
-def f20(x: BigInt): Str = match x with {
+def f20(x: BigInt): Str = match x {
   case -9223372036854775809ii => "-"
   case 9223372036854775809ii => "+"
   case _ => "unknown"
@@ -310,7 +310,7 @@ def testMatchTag04(): Bool = f21(NameAndAge21.T21("Mary", 33)) == 33
 
 enum NameAndAge22 { case T22(Str,Int) }
 
-def f22(x: NameAndAge22): Int = match x with {
+def f22(x: NameAndAge22): Int = match x {
   case NameAndAge22.T22("James", age) => age
   case _ => -1
 }
@@ -329,7 +329,7 @@ def testMatchTag08(): Bool = f22(NameAndAge22.T22("Mary", 33)) == -1
 
 enum ConstProp23 { case Top23, case Val23(Int), case Bot23 }
 
-def f23(x: ConstProp23): Int = match x with {
+def f23(x: ConstProp23): Int = match x {
   case ConstProp23.Top23 => -1
   case ConstProp23.Val23(v) => v
   case ConstProp23.Bot23 => -2
@@ -349,7 +349,7 @@ def testMatchTag12(): Bool = f23(ConstProp23.Bot23) == -2
 
 enum BoolTag24 { case Top24, case B24(Bool), case Bot24 }
 
-def f24(x: BoolTag24): Int = match x with {
+def f24(x: BoolTag24): Int = match x {
   case BoolTag24.Top24 => 0
   case BoolTag24.B24(b) => if (b) 1 else -1
   case BoolTag24.Bot24 => 0
@@ -369,9 +369,9 @@ def testMatchTag16(): Bool = f24(BoolTag24.Bot24) == 0
 
 enum Val25 { case Nip25, case Val25((Str, Int)) }
 
-def f25(x: Val25): Int = match x with {
+def f25(x: Val25): Int = match x {
   case Val25.Nip25 => 0
-  case Val25.Val25(v) => match v with {
+  case Val25.Val25(v) => match v {
     case ("x", _) => -1
     case (_, y) => y
   }
@@ -391,12 +391,12 @@ def testMatchTag20(): Bool = f25(Val25.Val25(("x", 3))) == -1
 
 enum Val26 { case Nip26, case Val26((Str, Int)) }
 
-def f26(x: Val26): Int = match x with {
+def f26(x: Val26): Int = match x {
   case Val26.Nip26 => 0
-  case Val26.Val26(v) => match v with {
-    case (w, y) => match w with {
+  case Val26.Val26(v) => match v {
+    case (w, y) => match w {
       case "x" => -1
-      case _ => match y with {
+      case _ => match y {
         case z => z
       }
     }
@@ -419,14 +419,14 @@ enum A27 { case AA27(Int), case AB27(Int) }
 
 enum B27 { case Top27, case BB27(A27), case Bot27 }
 
-def f27(x: B27): Str = match x with {
+def f27(x: B27): Str = match x {
   case B27.Top27 => "top"
-  case B27.BB27(y) => match y with {
-    case A27.AA27(a) => match a with {
+  case B27.BB27(y) => match y {
+    case A27.AA27(a) => match a {
       case 0 => "a0"
       case _ => "aaa"
     }
-    case A27.AB27(b) => match b with {
+    case A27.AB27(b) => match b {
       case 0 => "b0"
       case _ => "bbb"
     }
@@ -454,7 +454,7 @@ def testMatchTag30(): Bool = f27(B27.BB27(A27.AB27(-1))) == "bbb"
 
 enum Val28 { case Nip28, case Val28(Set[Int]) }
 
-def f28(x: Val28): Set[Int] = match x with {
+def f28(x: Val28): Set[Int] = match x {
   case Val28.Nip28 => Set#{0}
   case Val28.Val28(s) => s
 }
@@ -467,7 +467,7 @@ def testMatchTag32(): Bool = f28(Val28.Val28(Set#{1, 2, 3})) == Set#{1, 2, 3}
 
 enum Val29 { case Val29(Int8) }
 
-def f29(): Int8 = match Val29.Val29(32i8) with {
+def f29(): Int8 = match Val29.Val29(32i8) {
   case Val29.Val29(x) => x
 }
 
@@ -476,7 +476,7 @@ def testMatchTag33(): Bool = f29() == 32i8
 
 enum Val30 { case Val30(Int16) }
 
-def f30(): Int16 = match Val30.Val30(3200i16) with {
+def f30(): Int16 = match Val30.Val30(3200i16) {
   case Val30.Val30(x) => x
 }
 
@@ -485,7 +485,7 @@ def testMatchTag34(): Bool = f30() == 3200i16
 
 enum Val31 { case Val31(Int32) }
 
-def f31(): Int32 = match Val31.Val31(32000000i32) with {
+def f31(): Int32 = match Val31.Val31(32000000i32) {
   case Val31.Val31(x) => x
 }
 
@@ -493,7 +493,7 @@ def f31(): Int32 = match Val31.Val31(32000000i32) with {
 def testMatchTag35(): Bool = f31() == 32000000i32
 
 enum Val32 { case Val32(Int64) }
-def f32(): Int64 = match Val32.Val32(320000000000i64) with {
+def f32(): Int64 = match Val32.Val32(320000000000i64) {
   case Val32.Val32(x) => x
 }
 
@@ -502,7 +502,7 @@ def testMatchTag36(): Bool = f32() == 320000000000i64
 
 enum Val33 { case Val33(Char) }
 
-def f33(): Char = match Val33.Val33('a') with {
+def f33(): Char = match Val33.Val33('a') {
   case Val33.Val33(x) => x
 }
 
@@ -511,7 +511,7 @@ def testMatchTag37(): Bool = f33() == 'a'
 
 enum Val34 { case Val34(Float32) }
 
-def f34(): Float32 = match Val34.Val34(4.2f32) with {
+def f34(): Float32 = match Val34.Val34(4.2f32) {
   case Val34.Val34(x) => x
 }
 
@@ -520,7 +520,7 @@ def testMatchTag38(): Bool = f34() == 4.2f32
 
 enum Val35 { case Val35(Float64) }
 
-def f35(): Float64 = match Val35.Val35(4.2f64) with {
+def f35(): Float64 = match Val35.Val35(4.2f64) {
   case Val35.Val35(x) => x
 }
 
@@ -529,7 +529,7 @@ def testMatchTag39(): Bool = f35() == 4.2f64
 
 enum Val36 { case Val36(BigInt) }
 
-def f36(): BigInt = match Val36.Val36(100000000000000000000ii) with {
+def f36(): BigInt = match Val36.Val36(100000000000000000000ii) {
   case Val36.Val36(x) => x
 }
 
@@ -549,7 +549,7 @@ def testMatchTuple02(): Bool = f41(6, 5) == 11
 @test
 def testMatchTuple03(): Bool = f41(100, 23) == 123
 
-def f42(x: Int, y: Bool): Str = match (x, y) with {
+def f42(x: Int, y: Bool): Str = match (x, y) {
   case (5, true) => "abc"
   case (5, _) => "def"
   case (_, true) => "ghi"
@@ -568,7 +568,7 @@ def testMatchTuple06(): Bool = f42(6, true) == "ghi"
 @test
 def testMatchTuple07(): Bool = f42(0, false) == "jkl"
 
-def f43(x: BigInt, y: Int, z: Int): Int = match (x, (y, z)) with {
+def f43(x: BigInt, y: Int, z: Int): Int = match (x, (y, z)) {
   case (1ii, (2, 3)) => -1
   case (1ii, (2, _)) => -2
   case (1ii, (_, 3)) => -3
@@ -596,7 +596,7 @@ def testMatchTuple13(): Bool = f43(2ii, 10, 20) == 30
 
 enum ConstProp44 { case Top44, case Val44(Int), case Bot44 }
 
-def f44(x: ConstProp44, y: ConstProp44): Int = match (x, y) with {
+def f44(x: ConstProp44, y: ConstProp44): Int = match (x, y) {
   case (ConstProp44.Top44, ConstProp44.Top44) => 1
   case (ConstProp44.Bot44, ConstProp44.Bot44) => 2
   case (ConstProp44.Val44(v1), ConstProp44.Val44(v2)) => if (v1 == v2) 3 else 4
@@ -623,7 +623,7 @@ def testMatchTuple19(): Bool = f44(ConstProp44.Top44, ConstProp44.Bot44) == 5
 
 enum NameAndAge45 { case T45(Str,Int) }
 
-def f45(x: Int, y: NameAndAge45): Int = match (x, y) with {
+def f45(x: Int, y: NameAndAge45): Int = match (x, y) {
   case (1, NameAndAge45.T45("James", _)) => 1
   case (a, NameAndAge45.T45("James", b)) => a + b
   case (_, NameAndAge45.T45(_, 24)) => 2
@@ -651,10 +651,10 @@ def testMatchTuple25(): Bool = f45(3, NameAndAge45.T45("Anne", 18)) == -1
 @test
 def testMatchTuple26(): Bool = f45(4, NameAndAge45.T45("Charles", 64)) == -1
 
-def f46(x: Int, y: Int): Int = match (x, y) with {
-  case (u, v) => match u with {
+def f46(x: Int, y: Int): Int = match (x, y) {
+  case (u, v) => match u {
     case 0 => v
-    case _ => match v with {
+    case _ => match v {
       case 0 => u
       case _ => 0
     }
@@ -674,7 +674,7 @@ def testMatchTuple29(): Bool = f46(0, 2) == 2
 def testMatchTuple30(): Bool = f46(3, 4) == 0
 
 @test
-def testMatchTupleWithSep01(): Bool = match 0 with {
+def testMatchTupleWithSep01(): Bool = match 0 {
     case 0 => true,
     case 1 => true,
     case 2 => true,
@@ -682,6 +682,6 @@ def testMatchTupleWithSep01(): Bool = match 0 with {
 }
 
 @test
-def testMatchTupleWithSep02(): Bool = match 0 with {
+def testMatchTupleWithSep02(): Bool = match 0 {
     case 0 => true, case 1 => true, case 2 => true, case _ => true
 }

--- a/main/test/ca/uwaterloo/flix/language/feature/Test.Pattern.List.flix
+++ b/main/test/ca/uwaterloo/flix/language/feature/Test.Pattern.List.flix
@@ -1,18 +1,18 @@
 @test
-def testPatternList01(): Bool = match Nil with {
+def testPatternList01(): Bool = match Nil {
     case Nil => true
     case _   => false
 }
 
 @test
-def testPatternList02(): Bool = match Nil with {
+def testPatternList02(): Bool = match Nil {
     case Nil      => true
     case 1 :: Nil => false
     case _        => false
 }
 
 @test
-def testPatternList03(): Bool = match Nil with {
+def testPatternList03(): Bool = match Nil {
     case Nil           => true
     case 1 :: Nil      => false
     case 1 :: 2 :: Nil => false
@@ -20,20 +20,20 @@ def testPatternList03(): Bool = match Nil with {
 }
 
 @test
-def testPatternList04(): Bool = match 1 :: Nil with {
+def testPatternList04(): Bool = match 1 :: Nil {
     case Nil      => false
     case 1 :: Nil => true
     case _        => false
 }
 
 @test
-def testPatternList05(): Bool = match 1 :: 2 :: Nil with {
+def testPatternList05(): Bool = match 1 :: 2 :: Nil {
     case Nil      => false
     case _ :: _   => true
 }
 
 @test
-def testPatternList06(): Bool = match 1 :: 2 :: Nil with {
+def testPatternList06(): Bool = match 1 :: 2 :: Nil {
     case Nil            => false
     case 1 :: Nil       => false
     case 1 :: 2 :: Nil  => true
@@ -41,33 +41,33 @@ def testPatternList06(): Bool = match 1 :: 2 :: Nil with {
 }
 
 @test
-def testPatternList07(): Bool = match 1 :: 2 :: Nil with {
+def testPatternList07(): Bool = match 1 :: 2 :: Nil {
     case x :: y :: Nil  => x + 1 == y
     case _              => false
 }
 
 @test
-def testPatternList08(): Bool = match 1 :: 2 :: 3 :: Nil with {
+def testPatternList08(): Bool = match 1 :: 2 :: 3 :: Nil {
     case x :: 2 :: z :: Nil => x + 2 == z
     case _                  => false
 }
 
 
 @test
-def testPatternOption01(): Bool = match Nil with {
+def testPatternOption01(): Bool = match Nil {
     case Nil => true
     case _   => false
 }
 
 @test
-def testPatternOption02(): Bool = match None :: Nil with {
+def testPatternOption02(): Bool = match None :: Nil {
     case Nil         => false
     case None :: Nil => true
     case _           => false
 }
 
 @test
-def testPatternOption03(): Bool = match Some(123) :: Nil with {
+def testPatternOption03(): Bool = match Some(123) :: Nil {
     case Nil              => false
     case Some(x) :: Nil   => x == 123
     case _                => false
@@ -75,20 +75,20 @@ def testPatternOption03(): Bool = match Some(123) :: Nil with {
 
 
 @test
-def testListList01(): Bool = match Nil : List[List[Int]] with {
+def testListList01(): Bool = match Nil : List[List[Int]] {
     case Nil              => true
     case _                => false
 }
 
 @test
-def testListList02(): Bool = match (1 :: Nil) :: Nil with {
+def testListList02(): Bool = match (1 :: Nil) :: Nil {
     case Nil                => false
     case (1 :: Nil) :: Nil  => true
     case _                  => false
 }
 
 @test
-def testListList03(): Bool = match (1 :: Nil) :: (2 :: Nil) :: Nil with {
+def testListList03(): Bool = match (1 :: Nil) :: (2 :: Nil) :: Nil {
     case Nil                             => false
     case (x :: Nil) :: (y :: Nil) :: Nil => x + 1 == y
     case _                               => false

--- a/main/test/ca/uwaterloo/flix/language/feature/Test.UnusedVarSym.flix
+++ b/main/test/ca/uwaterloo/flix/language/feature/Test.UnusedVarSym.flix
@@ -16,38 +16,38 @@ def unusedVarSym03(): Int =
 
 @test
 def unusedVarSym04(): Int =
-    match 123 with {
+    match 123 {
         case _foo => 456
     }
 
 @test
 def unusedVarSym05(): Int =
-    match (1, 2) with {
+    match (1, 2) {
         case (x, _y) => x
     }
 
 @test
 def unusedVarSym06(): Int =
-    match (1, 2) with {
+    match (1, 2) {
         case (_x, y) => y
     }
 
 @test
 def unusedVarSym07(): Int =
-    match (1, 2) with {
+    match (1, 2) {
         case (_x, _y) => 123
     }
 
 @test
 def unusedVarSym08(): Int =
-    match Some(123) with {
+    match Some(123) {
         case None => 456
         case Some(_foo) => 789
     }
 
 @test
 def unusedVarSym09(): Int =
-    match Ok(123) with {
+    match Ok(123) {
         case Ok(_foo) => 456
         case Err(_bar) => 789
     }

--- a/main/test/ca/uwaterloo/flix/language/feature/TestTailCallElimination.flix
+++ b/main/test/ca/uwaterloo/flix/language/feature/TestTailCallElimination.flix
@@ -19,13 +19,13 @@ def testTCE06(): Bool = even(123456)
 @test
 def testTCE07(): Bool = odd(1234567)
 
-def odd(n: Int): Bool = match n with {
+def odd(n: Int): Bool = match n {
     case 0 => false
     case 1 => true
     case x => even(x - 1)
 }
 
-def even(n: Int): Bool = match n with {
+def even(n: Int): Bool = match n {
     case 0 => true
     case 1 => false
     case x => odd(x - 1)
@@ -58,13 +58,13 @@ def testTCE11(): Int =  ping(12345, x -> x)
 @test
 def testTCE12(): Int =  ping(1234567, x -> x)
 
-def ping(n: Int, c: Int -> Int): Int = match n with {
+def ping(n: Int, c: Int -> Int): Int = match n {
     case 0 => c(0)
     case 1 => c(1)
     case x => pong(x - 1, z -> c(z + 1))
 }
 
-def pong(n: Int, c: Int -> Int): Int = match n with {
+def pong(n: Int, c: Int -> Int): Int = match n {
     case 0 => c(0)
     case 1 => c(1)
     case x => ping(x - 1, z -> c(z + 1))

--- a/main/test/ca/uwaterloo/flix/language/feature/TestUniformFunctionCallSyntax.flix
+++ b/main/test/ca/uwaterloo/flix/language/feature/TestUniformFunctionCallSyntax.flix
@@ -63,7 +63,7 @@ def inc(x: Int): Int = x + 1
 def add(x: Int, y: Int): Int = x + y
 def sum(x: Int, y: Int, z: Int): Int = x + y + z
 
-def isEmpty[a](xs: List[a]): Bool = match xs with {
+def isEmpty[a](xs: List[a]): Bool = match xs {
     case Nil => true
     case _ => false
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestPatExhaustiveness.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestPatExhaustiveness.scala
@@ -29,7 +29,7 @@ class TestPatExhaustiveness extends FunSuite with TestUtils {
 
   test("Pattern.Literal.Char.01") {
     val input =
-      """def f(x: Char): Int = match x with {
+      """def f(x: Char): Int = match x {
         |  case 'a' => 1
         |  case 'b' => 2
         |  case 'c' => 3
@@ -41,7 +41,7 @@ class TestPatExhaustiveness extends FunSuite with TestUtils {
 
   test("Pattern.Literal.Int32.01") {
     val input =
-      """def f(x: Int): Int = match x with {
+      """def f(x: Int): Int = match x {
         |  case 1 => 1
         |  case 2 => 2
         |  case 3 => 3
@@ -53,7 +53,7 @@ class TestPatExhaustiveness extends FunSuite with TestUtils {
 
   test("Pattern.Literal.Int64.01") {
     val input =
-      """def f(x: Int64): Int = match x with {
+      """def f(x: Int64): Int = match x {
         |  case 1i64 => 1
         |  case 2i64 => 2
         |  case 3i64 => 3
@@ -65,7 +65,7 @@ class TestPatExhaustiveness extends FunSuite with TestUtils {
 
   test("Pattern.Literal.Str.01") {
     val input =
-      """def f(x: Str): Int = match x with {
+      """def f(x: Str): Int = match x {
         |  case "foo" => 1
         |  case "bar" => 2
         |  case "baz" => 3
@@ -82,7 +82,7 @@ class TestPatExhaustiveness extends FunSuite with TestUtils {
         |  case Blu
         |}
         |
-        |def f(x: (Color, Color)): Int = match x with {
+        |def f(x: (Color, Color)): Int = match x {
         |  case (Color.Red() ,_ ) => 1
         |  case (_, Color.Blu) => 2
         |}
@@ -93,7 +93,7 @@ class TestPatExhaustiveness extends FunSuite with TestUtils {
 
   test("Pattern.Literal.Tuples.02") {
     val input =
-      """def f(x: (Int8, (Str, Str))): Int = match x with {
+      """def f(x: (Int8, (Str, Str))): Int = match x {
         |  case (5i8, ("five", _)) => 5
         |  case (6i8, (_, "six")) => 6
         |  case (7i8, (_,_)) => 7
@@ -105,7 +105,7 @@ class TestPatExhaustiveness extends FunSuite with TestUtils {
 
   test("Pattern.Literal.Tuples.03") {
     val input =
-      """def f(x: (Int, Int, Int, Int, Int)): Int = match x with {
+      """def f(x: (Int, Int, Int, Int, Int)): Int = match x {
         |  case (1,2,3,4,5) => 1
         |  case (_,2,3,4,5) => 1
         |  case (1,_,3,4,5) => 1
@@ -124,7 +124,7 @@ class TestPatExhaustiveness extends FunSuite with TestUtils {
         |   case Lst(Int32, IntList),
         |   case Empty
         |}
-        |def f(i: Int32, xs: IntList): Int32 = match (i, xs) with {
+        |def f(i: Int32, xs: IntList): Int32 = match (i, xs) {
         |  case (0, Lst(x, _)) => x
         |  case (p, Lst(x, rs)) => x
         |}
@@ -139,7 +139,7 @@ class TestPatExhaustiveness extends FunSuite with TestUtils {
         |   case Lst(Int32, IntList),
         |   case Empty
         |}
-        |def f(l1: IntList, l2: IntList): Int32 = match (l1, l2) with {
+        |def f(l1: IntList, l2: IntList): Int32 = match (l1, l2) {
         |  case (Empty, Empty) => 0
         |  case (Lst(x,xs), Lst(y,ys)) => 1
         |}
@@ -154,7 +154,7 @@ class TestPatExhaustiveness extends FunSuite with TestUtils {
         |   case Lst(Int32, IntList),
         |   case Empty
         |}
-        |def f(xs: IntList): Int32 = match xs with {
+        |def f(xs: IntList): Int32 = match xs {
         |  case Empty => 42
         |}
       """.stripMargin
@@ -189,7 +189,7 @@ class TestPatExhaustiveness extends FunSuite with TestUtils {
         |  case Good
         |}
         |
-        |def f(x: Evil): Evil = match x with {
+        |def f(x: Evil): Evil = match x {
         |  case Evil(_, Evil(_, Evil(_, Evil(_, Evil(_, Evil(_, Evil(_, _))))))) => Evil(Good, Good)
         |}
       """.stripMargin
@@ -234,11 +234,11 @@ class TestPatExhaustiveness extends FunSuite with TestUtils {
         |   case Lst(Int32, IntList),
         |   case Empty
         |}
-        |def f(xs: IntList): Int32 = match xs with {
+        |def f(xs: IntList): Int32 = match xs {
         |  case Empty => 0
-        |  case Lst(y,ys) => match ys with {
+        |  case Lst(y,ys) => match ys {
         |      case Empty => 0
-        |      case Lst(z,zs) => match zs with {
+        |      case Lst(z,zs) => match zs {
         |           case Empty => 0
         |      }
         |  }
@@ -257,7 +257,7 @@ class TestPatExhaustiveness extends FunSuite with TestUtils {
         |}
         |
         |def f(l: List[Int]): Int = let foo = 42 ;
-        |     match l with {
+        |     match l {
         |         case Nil => 42
         |     }
       """.stripMargin

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -37,7 +37,7 @@ class TestRedundancy extends FunSuite with TestUtils {
     val input =
       s"""
          |def main(): Int =
-         |    match (123, 456) with {
+         |    match (123, 456) {
          |        case (_x, _y) => _x + _y
          |    }
          |
@@ -180,7 +180,7 @@ class TestRedundancy extends FunSuite with TestUtils {
       """
         |def main(): Int =
         |    let x = 123;
-        |    match (456, 789) with {
+        |    match (456, 789) {
         |        case (x, _) => x
         |    }
         |
@@ -194,7 +194,7 @@ class TestRedundancy extends FunSuite with TestUtils {
       """
         |def main(): Int =
         |    let x = 123;
-        |    match (456, 789) with {
+        |    match (456, 789) {
         |        case (_, x) => x
         |    }
         |
@@ -208,7 +208,7 @@ class TestRedundancy extends FunSuite with TestUtils {
       """
         |def main(): Int =
         |    let x = 123;
-        |    match (456, 789) with {
+        |    match (456, 789) {
         |        case (u, v) => u + v
         |        case (x, y) => x + y
         |    }
@@ -223,7 +223,7 @@ class TestRedundancy extends FunSuite with TestUtils {
       """
         |def main(): Int =
         |    let x = 123;
-        |    match (456, 789) with {
+        |    match (456, 789) {
         |        case (u, v) => u + v
         |        case (y, x) => x + y
         |    }
@@ -262,7 +262,7 @@ class TestRedundancy extends FunSuite with TestUtils {
       """
         |def main(): Int =
         |    let x = 123;
-        |    match (456, 789) with {
+        |    match (456, 789) {
         |        case (u, v) => u + v
         |        case (y, x) => x + y
         |    }
@@ -661,7 +661,7 @@ class TestRedundancy extends FunSuite with TestUtils {
          |}
          |
          |pub def f(x: Option[Int]): Int =
-         |    match x with {
+         |    match x {
          |        case y => 123
          |    }
          |
@@ -679,7 +679,7 @@ class TestRedundancy extends FunSuite with TestUtils {
          |}
          |
          |pub def f(x: Option[Int]): Int =
-         |    match x with {
+         |    match x {
          |        case None    => 123
          |        case Some(y) => 456
          |    }
@@ -698,7 +698,7 @@ class TestRedundancy extends FunSuite with TestUtils {
          |}
          |
          |pub def f(x: Option[(Int, Int)]): Int =
-         |    match x with {
+         |    match x {
          |        case None         => 123
          |        case Some((y, z)) => z
          |    }
@@ -782,7 +782,7 @@ class TestRedundancy extends FunSuite with TestUtils {
   test("UnconditionalRecursion.03") {
     val input =
       s"""
-         |def foo(x: Int): Int = match x with {
+         |def foo(x: Int): Int = match x {
          |    case 0 => foo(999)
          |    case _ => foo(123)
          |}

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -533,7 +533,7 @@ class TestResolver extends FunSuite with TestUtils {
          |    case Bar
          |  }
          |
-         |  def f(b: B): Int = match b with {
+         |  def f(b: B): Int = match b {
          |    case B.Qux => 42
          |  }
          |}

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -242,7 +242,7 @@ class TestWeeder extends FunSuite with TestUtils {
 
   test("NonLinearPattern.01") {
     val input =
-      """def f(): Bool = match (21, 42) with {
+      """def f(): Bool = match (21, 42) {
         |  case (x, x) => true
         |}
       """.stripMargin
@@ -252,7 +252,7 @@ class TestWeeder extends FunSuite with TestUtils {
 
   test("NonLinearPattern.02") {
     val input =
-      """def f(): Bool = match (21, 42, 84) with {
+      """def f(): Bool = match (21, 42, 84) {
         |  case (x, x, x) => true
         |}
       """.stripMargin
@@ -262,7 +262,7 @@ class TestWeeder extends FunSuite with TestUtils {
 
   test("NonLinearPattern.03") {
     val input =
-      """def f(): Bool = match (1, (2, (3, 4))) with {
+      """def f(): Bool = match (1, (2, (3, 4))) {
         |  case (x, (y, (z, x))) => true
         |}
       """.stripMargin

--- a/main/test/flix/Test.Exp.Hole.flix
+++ b/main/test/flix/Test.Exp.Hole.flix
@@ -4,49 +4,49 @@ namespace Test/Exp/Hole {
     def testHole01(): Int = if (true) 42 else ?hole
 
     @test
-    def testHole02(): Int = match Some(42) with {
+    def testHole02(): Int = match Some(42) {
         case None    => ?hole
         case Some(n) => n
     }
 
     @test
-    def testHole03(): Int = match (None : Option[Int]) with {
+    def testHole03(): Int = match (None : Option[Int]) {
         case None    => 1
         case Some(n) => n + ?hole
     }
 
     @test
-    def testHole04(): Int = match (None : Option[Int]) with {
+    def testHole04(): Int = match (None : Option[Int]) {
         case None    => 1
         case Some(n) => ?hole(n)
     }
 
     @test
-    def testHole05(): Int = match (None : Option[Int]) with {
+    def testHole05(): Int = match (None : Option[Int]) {
         case None    => 1
         case Some(n) => ?hole(n, n, n)
     }
 
     @test
-    def testHole06(): Int = match (None : Option[Int]) with {
+    def testHole06(): Int = match (None : Option[Int]) {
         case None    => 42
         case Some(n) => List.length(?hole)
     }
 
     @test
-    def testHole07(): Int = match (None : Option[Int]) with {
+    def testHole07(): Int = match (None : Option[Int]) {
         case None    => 42
         case Some(n) => ?hole1(List.unzip(?hole2))
     }
 
     @test
-    def testHole08(): Int = match (None : Option[Int]) with {
+    def testHole08(): Int = match (None : Option[Int]) {
         case None    => 42
         case Some(n) => ?hole1(List.map(?hole2, ?hole3))
     }
 
     @test
-    def testHole09(): Int = match (None : Option[Int]) with {
+    def testHole09(): Int = match (None : Option[Int]) {
         case None    => 42
         case Some(n) => ?hole1(List.map(?hole2, List.range(?hole3, ?hole4)))
     }


### PR DESCRIPTION
Remove `with` from all uses of pattern match as per #861.