### PR TITLE
Add Result.traverse and Result.sequence plus List and Option tailrec / CPS changes

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -63,9 +63,14 @@ namespace List {
     /// Returns the length of `xs`.
     ///
     @Time(length(xs)) @Space(1)
-    pub def length(xs: List[a]): Int32 = match xs {
-        case Nil => 0
-        case _ :: rs => 1 + length(rs)
+    pub def length(xs: List[a]): Int32 = lengthHelper(xs, 0)
+
+    ///
+    /// Helper function for `length`.
+    ///
+    def lengthHelper(xs: List[a], ac: Int32): Int32 = match xs {
+        case _ :: rs => lengthHelper(rs, ac + 1)
+        case Nil => ac
     }
 
     ///
@@ -145,7 +150,13 @@ namespace List {
     /// Returns `Nil` if `b >= e`.
     ///
     @Time(e - b) @Space(e - b)
-    pub def range(b: Int32, e: Int32): List[Int32] = if (b >= e) Nil else b :: range(b + 1, e)
+    pub def range(b: Int32, e: Int32): List[Int32] = rangeHelper(b, e, xs -> xs)
+
+    ///
+    /// Helper function for `range`.
+    ///
+    def rangeHelper(b: Int32, e: Int32, k: List[Int32] -> List[Int32]): List[Int32] =
+        if (b >= e) k(Nil) else rangeHelper(b + 1, e, xs -> k(b :: xs))
 
     ///
     /// Returns a list with the element `a` repeated `n` times.
@@ -153,7 +164,14 @@ namespace List {
     /// Returns `Nil` if `n < 0`.
     ///
     @Time(n) @Space(n)
-    pub def repeat(a: a, n: Int32): List[a] = if (n <= 0) Nil else a :: repeat(a, n - 1)
+    pub def repeat(a: a, n: Int32): List[a] = repeatHelper(a, n, xs -> xs)
+
+    ///
+    /// Helper function for `repeat`.
+    ///
+    def repeatHelper(a: a, n: Int32, k: List[a] -> List[a]): List[a] =
+        if (n <= 0) k(Nil) else repeatHelper(a, n - 1, xs -> k(a :: xs))
+
 
     ///
     /// Alias for `scanLeft`.

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -173,21 +173,33 @@ namespace Option {
     ///
     /// Returns `Some(v1 :: v2 :: ... :: vn)` if each of `xs_i` is `Some(v_i)`. Otherwise returns `None`.
     ///
-    pub def sequence(xs: List[Option[a]]): Option[List[a]] = match xs {
-        case Nil            => Some(Nil)
-        case None :: _      => None
-        case Some(y) :: ys  => map(zs -> y :: zs, sequence(ys))
+    pub def sequence(xs: List[Option[a]]): Option[List[a]] =
+        sequenceHelper(xs, _ -> None, ys -> Some(ys))
+
+    ///
+    /// Helper function for `sequence`.
+    ///
+    def sequenceHelper(xs: List[Option[a]], fk: Unit -> Option[List[a]], sk: List[a] -> Option[List[a]]): Option[List[a]] = match xs {
+        case Nil            => sk(Nil)
+        case None :: _      => fk()
+        case Some(y) :: rs  => sequenceHelper(rs, fk, ys -> sk(y :: ys))
     }
 
     ///
     /// Returns `Some(v1 :: v2 :: ... v :: vn)` if each of `f(xs_i)` is `Some(v_i)`. Otherwise returns `None`.
     ///
-    pub def traverse(f: a -> Option[b] & e, xs: List[a]): Option[List[b]] & e = match xs {
-        case Nil        => Some(Nil)
-        case y :: ys    =>
-            let* z = f(y);
-            let* zs = traverse(f, ys);
-            Some(z :: zs)
+    pub def traverse(f: a -> Option[b] & e, xs: List[a]): Option[List[b]] & e =
+        traverseHelper(f, xs, _ -> None, ys -> Some(ys))
+
+    ///
+    /// Helper function for `traverse`.
+    ///
+    def traverseHelper(f: a -> Option[b] & f, xs: List[a], fk: Unit -> Option[List[b]], sk: List[b] -> Option[List[b]]): Option[List[b]] & f = match xs {
+        case Nil            => sk(Nil)
+        case x :: rs        => match f(x) {
+            case None    => fk()
+            case Some(y) => traverseHelper(f, rs, fk, ys -> sk(y :: ys))
+        }
     }
 
     ///

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -151,6 +151,40 @@ namespace Result {
     }
 
     ///
+    /// Returns `Ok(v1 :: v2 :: ... :: vn)` if each of `xs_i` is `Ok(v_i)`.
+    /// Otherwise returns the first `Err` encountered.
+    ///
+    pub def sequence(xs: List[Result[a, e]]): Result[List[a], e] =
+        sequenceHelper(xs, e -> Err(e), ys -> Ok(ys))
+
+    ///
+    /// Helper function for `sequence`.
+    ///
+    def sequenceHelper(xs: List[Result[a, e]], fk: e -> Result[List[a], e], sk: List[a] -> Result[List[a], e]): Result[List[a], e] = match xs {
+        case Nil            => sk(Nil)
+        case Err(e) :: _    => fk(e)
+        case Ok(y) :: rs    => sequenceHelper(rs, fk, ys -> sk(y :: ys))
+    }
+
+    ///
+    /// Returns `Some(v1 :: v2 :: ... v :: vn)` if each of `f(xs_i)` is `Ok(v_i)`.
+    /// Otherwise returns the first `Err` encountered.
+    ///
+    pub def traverse(f: a -> Result[b, e] & f, xs: List[a]): Result[List[b], e] & f =
+        traverseHelper(f, xs, e -> Err(e), ys -> Ok(ys))
+
+    ///
+    /// Helper function for `traverse`.
+    ///
+    def traverseHelper(f: a -> Result[b, e] & f, xs: List[a], fk: e -> Result[List[b], e], sk: List[b] -> Result[List[b], e]): Result[List[b], e] & f = match xs {
+        case Nil            => sk(Nil)
+        case x :: rs        => match f(x) {
+            case Err(e) => fk(e)
+            case Ok(y)  => traverseHelper(f, rs, fk, ys -> sk(y :: ys))
+        }
+    }
+
+    ///
     /// Returns a one-element list of the value `v` if `r` is `Ok(v)`. Otherwise returns the empty list.
     ///
     pub def toList(r: Result[t, e]): List[t] = match r {

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -194,6 +194,57 @@ def foldRight04(): Bool = Result.foldRight((i, b) -> if (i == 2 && b) true else 
 def foldRight05(): Bool = Result.foldRight((i, b) -> if (i == 2 && b) true else false, Ok(2), true) == true
 
 /////////////////////////////////////////////////////////////////////////////
+// sequence                                                                //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def sequence01(): Bool = Result.sequence(Nil) == Ok(Nil)
+
+@test
+def sequence02(): Bool = Result.sequence(Ok(1) :: Nil) == Ok(1 :: Nil)
+
+@test
+def sequence03(): Bool = Result.sequence(Ok(1) :: Ok(2) :: Nil) == Ok(1 :: 2 :: Nil)
+
+@test
+def sequence04(): Bool = Result.sequence(Ok(1) :: Ok(2) :: Ok(3) :: Nil) == Ok(1 :: 2 :: 3 :: Nil)
+
+@test
+def sequence05(): Bool = Result.sequence(Err("one") :: Ok(2) :: Ok(3) :: Nil) == Err("one")
+
+@test
+def sequence06(): Bool = Result.sequence(Ok(1) :: Ok(2) :: Err("three") :: Nil) == Err("three")
+
+@test
+def sequence07(): Bool = Result.sequence(Ok(1) :: Err("two") :: Ok(3) :: Nil) == Err("two")
+
+/////////////////////////////////////////////////////////////////////////////
+// traverse                                                                //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def traverse01(): Bool = Result.traverse(x -> Ok(x + 1), Nil) == Ok(Nil)
+
+@test
+def traverse02(): Bool = Result.traverse(x -> Ok(x + 1), 1 :: Nil) == Ok(2 :: Nil)
+
+@test
+def traverse03(): Bool = Result.traverse(x -> Ok(x + 1), 1 :: 2 :: Nil) == Ok(2 :: 3 :: Nil)
+
+@test
+def traverse04(): Bool = Result.traverse(x -> Ok(x + 1), 1 :: 2 :: 3 :: Nil) == Ok(2 :: 3 :: 4 :: Nil)
+
+@test
+def traverse05(): Bool = Result.traverse(x -> if (x == 1) Err("one") else Ok(x), 1 :: 2 :: 3 :: Nil) == Err("one")
+
+@test
+def traverse06(): Bool = Result.traverse(x -> if (x == 3) Err("three") else Ok(x), 1 :: 2 :: 3 :: Nil) == Err("three")
+
+@test
+def traverse07(): Bool = Result.traverse(x -> if (x == 2) Err("two") else Ok(x), 1 :: 2 :: 3 :: Nil) == Err("two")
+
+@test
+def traverse08(): Bool = Result.traverse(_ -> Ok(42), 1 :: 2 :: 3 :: Nil) == Ok(42 :: 42 :: 42 :: Nil)
+
+/////////////////////////////////////////////////////////////////////////////
 // toList                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test


### PR DESCRIPTION
Hi Magnus - here's the PR to fix `List.length` and add `Result.traverse` & `Result.sequence` .

Changes:

* List.length - made tail recursive with an accumulator

* List.repeat & List.range - re-implemented in continuation passing style

* Option.traverse & Option.sequence - re-implemented in continuation passing style

* Result.traverse & Result.sequence - new additions, implemented in CPS. Added tests to TestResult.


Adding `traverse` and `sequence` to Result matches Option.

Reimplementing the Option and List functions means they should work with long lists. `List.length` was noted as not being tail recursive in issue #1226. I also noticed `List.range` and `List.repeat` weren't tail recursive / in CPS when trying to use them to generate long lists for test cases.

