### PR TITLE
Added traverseX to Option, Result and Validation. Plus tailrec / CPS changes 

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -220,10 +220,20 @@ namespace List {
     /// That is, the result is of the form: `f(x1) :: f(x2) :: ...`.
     ///
     @Time(time(f) * length(xs)) @Space(space(f) * length(xs))
-    pub def map(f: a -> b & e, xs: List[a]): List[b] & e = match xs {
-        case Nil => Nil
-        case x :: rs => f(x) :: map(f, rs)
+    pub def map(f: a -> b & e, xs: List[a]): List[b] & e =
+        mapHelper(f, xs, ys -> ys)
+
+    ///
+    /// Helper function for `map`.
+    ///
+    def mapHelper(f: a -> b & e, xs: List[a], k: List[b] -> List[b]): List[b] & e = match xs {
+        case Nil => k(Nil)
+        case x :: rs => {
+            let a = f(x);
+            mapHelper(f, rs, ys -> k(a :: ys))
+        }
     }
+
 
     ///
     /// Returns the result of applying `f` to every element in `xs` along with that element's index.

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -203,6 +203,20 @@ namespace Option {
     }
 
     ///
+    /// Returns `Some()` if each of `f(xs_i)` is `Some(_)`. Otherwise returns `None`.
+    ///
+    /// This function is the "forgetful" version of `traverse`, use it when the you want the effect
+    /// of applying `f` to each element but do not care about collecting the results.
+    ///
+    pub def traverseX(f: a -> Option[b] & e, xs: List[a]): Option[Unit] & e = match xs {
+        case Nil            => Some()
+        case x :: rs        => match f(x) {
+            case None    => None
+            case Some(_) => traverseX(f, rs)
+        }
+    }
+
+    ///
     /// Returns a one-element list of the value `v` if `o` is `Some(v)`. Otherwise returns the empty list.
     ///
     pub def toList(o: Option[a]): List[a] = match o {

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -185,6 +185,20 @@ namespace Result {
     }
 
     ///
+    /// Returns `Ok()` if each of `f(xs_i)` is `Ok(_)`. Otherwise returns `None`.
+    ///
+    /// This function is the "forgetful" version of `traverse`, use it when the you want the effect
+    /// of applying `f` to each element but do not care about collecting the results.
+    ///
+    pub def traverseX(f: a -> Result[b, e] & f, xs: List[a]): Result[Unit, e] & f = match xs {
+        case Nil            => Ok()
+        case x :: rs        => match f(x) {
+            case Err(e) => Err(e)
+            case Ok(_)  => traverseX(f, rs)
+        }
+    }
+
+    ///
     /// Returns a one-element list of the value `v` if `r` is `Ok(v)`. Otherwise returns the empty list.
     ///
     pub def toList(r: Result[t, e]): List[t] = match r {

--- a/main/src/library/Validation.flix
+++ b/main/src/library/Validation.flix
@@ -81,32 +81,100 @@ namespace Validation {
     ///
     /// Otherwise returns `Failure(e1 :: ... :: en)` with all of the failures concatenated.
     ///
-    pub def sequence(xs: List[Validation[t, e]]): Validation[List[t], e] = match xs {
-        case Nil     => Success(Nil)
-        case v :: vs => match (v, sequence(vs)) {
-            case (Success(x), Success(rs)) => Success(x :: rs)
-            case (Success(_), Failure(e))  => Failure(e)
-            case (Failure(e), Success(_))  => Failure(e)
-            case (Failure(x), Failure(y))  => Failure(Nel.append(x, y))
-        }
+    pub def sequence(xs: List[Validation[t, e]]): Validation[List[t], e] =
+        sequenceHelperSuccess(xs, ys -> Success(ys))
+
+    ///
+    /// Helper function for `sequence`.
+    ///
+    /// Precondition: no Failure has been encountered.
+    ///
+    def sequenceHelperSuccess(xs: List[Validation[a, e]], sk: List[a] -> Validation[List[a], e]): Validation[List[a], e] = match xs {
+        case Nil              => sk(Nil)
+        case Success(x) :: vs => sequenceHelperSuccess(vs, xs -> sk(x :: xs))
+        case Failure(e) :: vs => sequenceHelperFailure(vs, e)
     }
+
+    ///
+    /// Helper function for `sequence`.
+    ///
+    /// Precondition: at least one Failure has been encountered.
+    ///
+    def sequenceHelperFailure(xs: List[Validation[a, e]], ac: Nel[e]): Validation[List[a], e] = match xs {
+        case Nil              => Failure(ac)
+        case Success(_) :: vs => sequenceHelperFailure(vs, ac)
+        case Failure(e) :: vs => sequenceHelperFailure(vs, Nel.append(ac, e))
+    }
+
 
     ///
     /// Returns `Success(v1 :: v2 :: ... v :: vn)` if each of `f(xs_i)` is `Success(v_i)`.
     ///
     /// Otherwise returns `Failure(e1 :: ... :: en)` with all of the failures concatenated.
     ///
-    pub def traverse(f: a -> Validation[b, e] & f, xs: List[a]): Validation[List[b], e] & f = match xs {
-        case Nil        => Success(Nil)
+    pub def traverse(f: a -> Validation[b, e] & f, xs: List[a]): Validation[List[b], e] & f =
+        traverseHelperSuccess(f, xs, ys -> Success(ys))
+
+    ///
+    /// Helper function for `traverse`.
+    ///
+    /// Precondition: no Failure has been encountered.
+    ///
+    def traverseHelperSuccess(f: a -> Validation[b, e] & f, xs: List[a], sk: List[b] -> Validation[List[b], e]): Validation[List[b], e] & f = match xs {
+        case Nil        => sk(Nil)
         case v :: vs    => match f(v) {
-            case Success(x) => match traverse(f, vs) {
-                case Success(rs) => Success(x :: rs)
-                case Failure(e)  => Failure(e)
-            }
-            case Failure(x) => match traverse(f, vs) {
-               case Success(_) => Failure(x)
-               case Failure(y) => Failure(Nel.append(x, y))
-           }
+            case Success(x) => traverseHelperSuccess(f, vs, xs -> sk(x :: xs))
+            case Failure(x) => traverseHelperFailure(f, vs, x)
+        }
+    }
+
+    ///
+    /// Helper function for `traverse`.
+    ///
+    /// Precondition: at least one Failure has been encountered.
+    ///
+    def traverseHelperFailure(f: a -> Validation[b, e] & f, xs: List[a], ac: Nel[e]): Validation[List[b], e] & f = match xs {
+        case Nil        => Failure(ac)
+        case v :: vs    => match f(v) {
+            case Success(_) => traverseHelperFailure(f, vs, ac)
+            case Failure(x) => traverseHelperFailure(f, vs, Nel.append(ac, x))
+        }
+    }
+
+    ///
+    /// Returns `Success()` if each of `f(xs_i)` is `Success(_)`.
+    ///
+    /// Otherwise returns `Failure(e1 :: ... :: en)` with all of the failures concatenated.
+    ///
+    /// This function is the "forgetful" version of `traverse`, use it when the you want the effect
+    /// of applying `f` to each element but do not care about collecting the results.
+    ///
+    pub def traverseX(f: a -> Validation[b, e] & f, xs: List[a]): Validation[Unit, e] & f =
+        traverseXHelperSuccess(f, xs)
+
+    ///
+    /// Helper function for `traverseX`.
+    ///
+    /// Precondition: no Failure has been encountered.
+    ///
+    def traverseXHelperSuccess(f: a -> Validation[b, e] & f, xs: List[a]): Validation[Unit, e] & f = match xs {
+        case Nil        => Success()
+        case v :: vs    => match f(v) {
+            case Success(_) => traverseXHelperSuccess(f, vs)
+            case Failure(e) => traverseXHelperFailure(f, vs, e)
+        }
+    }
+
+    ///
+    /// Helper function for `traverseX`.
+    ///
+    /// Precondition: at least one Failure has been encountered.
+    ///
+    def traverseXHelperFailure(f: a -> Validation[b, e] & f, xs: List[a], ac: Nel[e]): Validation[Unit, e] & f = match xs {
+        case Nil        => Failure(ac)
+        case v :: vs    => match f(v) {
+            case Success(_) => traverseXHelperFailure(f, vs, ac)
+            case Failure(e) => traverseXHelperFailure(f, vs, Nel.append(ac, e))
         }
     }
 

--- a/main/test/ca/uwaterloo/flix/library/TestOption.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestOption.flix
@@ -357,6 +357,33 @@ def traverse07(): Bool = Option.traverse(x -> if (x == 2) None else Some(x), 1 :
 def traverse08(): Bool = Option.traverse(_ -> Some(42), 1 :: 2 :: 3 :: Nil) == Some(42 :: 42 :: 42 :: Nil)
 
 /////////////////////////////////////////////////////////////////////////////
+// traverseX                                                               //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def traverseX01(): Bool = Option.traverseX(x -> Some(x + 1), Nil) == Some()
+
+@test
+def traverseX02(): Bool = Option.traverseX(x -> Some(x + 1), 1 :: Nil) == Some()
+
+@test
+def traverseX03(): Bool = Option.traverseX(x -> Some(x + 1), 1 :: 2 :: Nil) == Some()
+
+@test
+def traverseX04(): Bool = Option.traverseX(x -> Some(x + 1), 1 :: 2 :: 3 :: Nil) == Some()
+
+@test
+def traverseX05(): Bool = Option.traverseX(x -> if (x == 1) None else Some(x), 1 :: 2 :: 3 :: Nil) == None
+
+@test
+def traverseX06(): Bool = Option.traverseX(x -> if (x == 3) None else Some(x), 1 :: 2 :: 3 :: Nil) == None
+
+@test
+def traverseX07(): Bool = Option.traverseX(x -> if (x == 2) None else Some(x), 1 :: 2 :: 3 :: Nil) == None
+
+@test
+def traverseX08(): Bool = Option.traverseX(_ -> Some(42), 1 :: 2 :: 3 :: Nil) == Some()
+
+/////////////////////////////////////////////////////////////////////////////
 // zip                                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -245,6 +245,34 @@ def traverse07(): Bool = Result.traverse(x -> if (x == 2) Err("two") else Ok(x),
 def traverse08(): Bool = Result.traverse(_ -> Ok(42), 1 :: 2 :: 3 :: Nil) == Ok(42 :: 42 :: 42 :: Nil)
 
 /////////////////////////////////////////////////////////////////////////////
+// traverseX                                                               //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def traverseX01(): Bool = Result.traverseX(x -> Ok(x + 1), Nil) == Ok()
+
+@test
+def traverseX02(): Bool = Result.traverseX(x -> Ok(x + 1), 1 :: Nil) == Ok()
+
+@test
+def traverseX03(): Bool = Result.traverseX(x -> Ok(x + 1), 1 :: 2 :: Nil) == Ok()
+
+@test
+def traverseX04(): Bool = Result.traverseX(x -> Ok(x + 1), 1 :: 2 :: 3 :: Nil) == Ok()
+
+@test
+def traverseX05(): Bool = Result.traverseX(x -> if (x == 1) Err("one") else Ok(x), 1 :: 2 :: 3 :: Nil) == Err("one")
+
+@test
+def traverseX06(): Bool = Result.traverseX(x -> if (x == 3) Err("three") else Ok(x), 1 :: 2 :: 3 :: Nil) == Err("three")
+
+@test
+def traverseX07(): Bool = Result.traverseX(x -> if (x == 2) Err("two") else Ok(x), 1 :: 2 :: 3 :: Nil) == Err("two")
+
+@test
+def traverseX08(): Bool = Result.traverseX(_ -> Ok(42), 1 :: 2 :: 3 :: Nil) == Ok()
+
+
+/////////////////////////////////////////////////////////////////////////////
 // toList                                                                  //
 /////////////////////////////////////////////////////////////////////////////
 @test

--- a/main/test/ca/uwaterloo/flix/library/TestValidation.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestValidation.flix
@@ -154,6 +154,31 @@ namespace Validation {
     def traverse07(): Bool = traverse(x -> if (x == 2) Success(x + 1) else Failure(Nel(x, Nil)), 1 :: 2 :: 3 :: Nil) == Failure(Nel(1, 3 :: Nil))
 
     /////////////////////////////////////////////////////////////////////////////
+    // traverseX                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def traverseX01(): Bool = traverseX(x -> Success(x + 1), 1 :: Nil) == Success()
+
+    @test
+    def traverseX02(): Bool = traverseX(x -> Success(x + 1), 1 :: 2 :: Nil) == Success()
+
+    @test
+    def traverseX03(): Bool = traverseX(x -> Success(x + 1), 1 :: 2 :: 3 :: Nil) == Success()
+
+    @test
+    def traverseX04(): Bool = traverseX(x -> Failure(Nel(x, Nil)), 1 :: 2 :: 3 :: Nil) == Failure(Nel(1, 2 :: 3 :: Nil))
+
+    @test
+    def traverseX05(): Bool = traverseX(x -> Failure(Nel(x, x :: Nil)), 1 :: 2 :: 3 :: Nil) == Failure(Nel(1, 1 :: 2 :: 2 :: 3 :: 3 :: Nil))
+
+    @test
+    def traverseX06(): Bool = traverseX(x -> if (x != 2) Success(x + 1) else Failure(Nel(42, Nil)), 1 :: 2 :: 3 :: Nil) == Failure(Nel(42, Nil))
+
+    @test
+    def traverseX07(): Bool = traverseX(x -> if (x == 2) Success(x + 1) else Failure(Nel(x, Nil)), 1 :: 2 :: 3 :: Nil) == Failure(Nel(1, 3 :: Nil))
+
+    /////////////////////////////////////////////////////////////////////////////
     // toOption                                                                //
     /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Hi Magnus 

This adds `traverseX` to Option, Result and Validation.

It also changes `Validation.sequence` , `Validation.traverse` and `List.map` so they are in CPS / tail recursive and shouldn't burst the stack.