### PR TITLE
Add short-circuiting list folds to Option and Result

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -497,9 +497,14 @@ namespace List {
     ///
     /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, s))...)`.
     ///
-    pub def foldRight(f: (a, b) -> b & e, s: b, xs: List[a]): b & e = match xs {
-        case Nil => s
-        case x :: rs => f(x, foldRight(f, s, rs))
+    pub def foldRight(f: (a, b) -> b & e, s: b, xs: List[a]): b & e = foldRightHelper(f, s, xs, s1 -> s1 as & e)
+
+    ///
+    /// Helper function for `foldRight`.
+    ///
+    def foldRightHelper(f: (a, b) -> b & e, s: b, xs: List[a], k: b -> b & e): b & e = match xs {
+        case Nil => k(s)
+        case x :: rs => foldRightHelper(f, s, rs, s1 -> k(f(x, s1)))
     }
 
     ///

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -217,6 +217,49 @@ namespace Option {
     }
 
     ///
+    /// Returns the result of applying `f` to a start value `s` and the elements in `xs`
+    /// going from left to right.
+    ///
+    /// If at any step applying `f` fails (i.e. it produces a `None` value) the traversal
+    /// of `xs` is short-circuited and `None` is returned.
+    ///
+    /// If `f` is successfully applied to all the elements in `xs` the result is of the form:
+    /// `Some(f(...f(f(s, x1), x2)..., xn))`.
+    ///
+    pub def foldLeftM(f: (b, a) -> Option[b] & f, s: b, xs: List[a]): Option[b] & f = match xs {
+        case Nil => Some(s)
+        case x :: rs => match f(s, x) {
+            case Some(s1) => foldLeftM(f, s1, rs)
+            case None => None
+        }
+    }
+
+    ///
+    /// Returns the result of applying `f` to a start value `s` and the elements in `xs`
+    /// going from right to left.
+    ///
+    /// If at any step applying `f` fails (i.e. it produces a `None` value) the traversal
+    /// of `xs` is short-circuited and `None` is returned.
+    ///
+    /// If `f` is successfully applied to al elements in `xs` the result is of the form:
+    /// `Some(f(x1, ...f(xn-1, f(xn, s))...))`.
+    ///
+    pub def foldRightM(f: (a, b) -> Option[b] & f, s: b, xs: List[a]): Option[b] & f =
+        foldRightMHelper(f, s, xs, _ -> None as & f, s1 -> Some(s1) as & f)
+
+    ///
+    /// Helper function for `foldRightM`.
+    ///
+    def foldRightMHelper(f: (a, b) -> Option[b] & f, s: b, xs: List[a], fk: Unit -> Option[b] & f, sk: b -> Option[b] & f): Option[b] & f = match xs {
+        case Nil => sk(s)
+        case x :: rs =>
+            foldRightMHelper(f, s, rs, fk, s1 -> match f(x, s1) {
+                    case Some(s2) => sk(s2)
+                    case None => fk()
+                })
+    }
+
+    ///
     /// Returns a one-element list of the value `v` if `o` is `Some(v)`. Otherwise returns the empty list.
     ///
     pub def toList(o: Option[a]): List[a] = match o {

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -199,6 +199,49 @@ namespace Result {
     }
 
     ///
+    /// Returns the result of applying `f` to a start value `s` and the elements in `xs`
+    /// going from left to right.
+    ///
+    /// If at any step applying `f` fails (i.e. it produces a `Err(e)` value) the traversal
+    /// of `xs` is short-circuited and `Err(e)` is returned.
+    ///
+    /// If `f` is successfully applied to all elements in `xs` the result is of the form:
+    /// `Ok(f(...f(f(s, x1), x2)..., xn))`.
+    ///
+    pub def foldLeftM(f: (b, a) -> Result[b, e] & f, s: b, xs: List[a]): Result[b, e] & f = match xs {
+        case Nil => Ok(s)
+        case x :: rs => match f(s, x) {
+            case Ok(s1) => foldLeftM(f, s1, rs)
+            case Err(e) => Err(e)
+        }
+    }
+
+    ///
+    /// Returns the result of applying `f` to a start value `s` and the elements in `xs`
+    /// going from right to left.
+    ///
+    /// If at any step applying `f` fails (i.e. it produces a `Err(e)` value) the traversal
+    /// of `xs` is short-circuited and `Err(e)` is returned.
+    ///
+    /// If `f` is successfully applied to all elements in `xs` the result is of the form:
+    /// `Ok(f(x1, ...f(xn-1, f(xn, s))...))`.
+    ///
+    pub def foldRightM(f: (a, b) -> Result[b, e] & f, s: b, xs: List[a]): Result[b, e] & f =
+        foldRightMHelper(f, s, xs, e1 -> Err(e1) as & f, s1 -> Ok(s1) as & f)
+
+    ///
+    /// Helper function for `foldRightM`.
+    ///
+    def foldRightMHelper(f: (a, b) -> Result[b, e] & f, s: b, xs: List[a], fk: e -> Result[b, e] & f, sk: b -> Result[b, e] & f): Result[b, e] & f = match xs {
+        case Nil => sk(s)
+        case x :: rs =>
+            foldRightMHelper(f, s, rs, fk, s1 -> match f(x, s1) {
+                    case Ok(s2) => sk(s2)
+                    case Err(e) => fk(e)
+                })
+    }
+
+    ///
     /// Returns a one-element list of the value `v` if `r` is `Ok(v)`. Otherwise returns the empty list.
     ///
     pub def toList(r: Result[t, e]): List[t] = match r {

--- a/main/test/ca/uwaterloo/flix/library/TestOption.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestOption.flix
@@ -384,6 +384,54 @@ def traverseX07(): Bool = Option.traverseX(x -> if (x == 2) None else Some(x), 1
 def traverseX08(): Bool = Option.traverseX(_ -> Some(42), 1 :: 2 :: 3 :: Nil) == Some()
 
 /////////////////////////////////////////////////////////////////////////////
+// foldLeftM                                                               //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def foldLeftM01(): Bool = Option.foldLeftM((ac, i) -> if (i < 0) None else Some(Int32.max(i, ac)), 0, Nil) == Some(0)
+
+@test
+def foldLeftM02(): Bool = Option.foldLeftM((ac, i) -> if (i < 0) None else Some(Int32.max(i, ac)), 0, 1 :: Nil) == Some(1)
+
+@test
+def foldLeftM03(): Bool = Option.foldLeftM((ac, i) -> if (i < 0) None else Some(Int32.max(i, ac)), 0, 1 :: 2 :: Nil) == Some(2)
+
+@test
+def foldLeftM04(): Bool = Option.foldLeftM((ac, i) -> if (i < 0) None else Some(Int32.max(i, ac)), 0, 1 :: 2 :: 3 :: Nil) == Some(3)
+
+@test
+def foldLeftM05(): Bool = Option.foldLeftM((ac, i) -> if (i < 0) None else Some(Int32.max(i, ac)), 0, -1 :: 2 :: 3 :: Nil) == None
+
+@test
+def foldLeftM06(): Bool = Option.foldLeftM((ac, i) -> if (i < 0) None else Some(Int32.max(i, ac)), 0, 1 :: -2 :: 3 :: Nil) == None
+
+@test
+def foldLeftM07(): Bool = Option.foldLeftM((ac, i) -> if (i < 0) None else Some(Int32.max(i, ac)), 0, 1 :: 2 :: -3 :: Nil) == None
+
+/////////////////////////////////////////////////////////////////////////////
+// foldRightM                                                              //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def foldRightM01(): Bool = Option.foldRightM((i, ac) -> if (i < 0) None else Some(Int32.max(i, ac)), 0, Nil) == Some(0)
+
+@test
+def foldRightM02(): Bool = Option.foldRightM((i, ac) -> if (i < 0) None else Some(Int32.max(i, ac)), 0, 1 :: Nil) == Some(1)
+
+@test
+def foldRightM03(): Bool = Option.foldRightM((i, ac) -> if (i < 0) None else Some(Int32.max(i, ac)), 0, 1 :: 2 :: Nil) == Some(2)
+
+@test
+def foldRightM04(): Bool = Option.foldRightM((i, ac) -> if (i < 0) None else Some(Int32.max(i, ac)), 0, 1 :: 2 :: 3 :: Nil) == Some(3)
+
+@test
+def foldRightM05(): Bool = Option.foldRightM((i, ac) -> if (i < 0) None else Some(Int32.max(i, ac)), 0, -1 :: 2 :: 3 :: Nil) == None
+
+@test
+def foldRightM06(): Bool = Option.foldRightM((i, ac) -> if (i < 0) None else Some(Int32.max(i, ac)), 0, 1 :: -2 :: 3 :: Nil) == None
+
+@test
+def foldRightM07(): Bool = Option.foldRightM((i, ac) -> if (i < 0) None else Some(Int32.max(i, ac)), 0, 1 :: 2 :: -3 :: Nil) == None
+
+/////////////////////////////////////////////////////////////////////////////
 // zip                                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -271,6 +271,53 @@ def traverseX07(): Bool = Result.traverseX(x -> if (x == 2) Err("two") else Ok(x
 @test
 def traverseX08(): Bool = Result.traverseX(_ -> Ok(42), 1 :: 2 :: 3 :: Nil) == Ok()
 
+/////////////////////////////////////////////////////////////////////////////
+// foldLeftM                                                               //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def foldLeftM01(): Bool = Result.foldLeftM((ac, i) -> if (i < 0) Err(-1) else Ok(Int32.max(i, ac)), 0, Nil) == Ok(0)
+
+@test
+def foldLeftM02(): Bool = Result.foldLeftM((ac, i) -> if (i < 0) Err(-1) else Ok(Int32.max(i, ac)), 0, 1 :: Nil) == Ok(1)
+
+@test
+def foldLeftM03(): Bool = Result.foldLeftM((ac, i) -> if (i < 0) Err(-1) else Ok(Int32.max(i, ac)), 0, 1 :: 2 :: Nil) == Ok(2)
+
+@test
+def foldLeftM04(): Bool = Result.foldLeftM((ac, i) -> if (i < 0) Err(-1) else Ok(Int32.max(i, ac)), 0, 1 :: 2 :: 3 :: Nil) == Ok(3)
+
+@test
+def foldLeftM05(): Bool = Result.foldLeftM((ac, i) -> if (i < 0) Err(-1) else Ok(Int32.max(i, ac)), 0, -1 :: 2 :: 3 :: Nil) == Err(-1)
+
+@test
+def foldLeftM06(): Bool = Result.foldLeftM((ac, i) -> if (i < 0) Err(-1) else Ok(Int32.max(i, ac)), 0, 1 :: -2 :: 3 :: Nil) == Err(-1)
+
+@test
+def foldLeftM07(): Bool = Result.foldLeftM((ac, i) -> if (i < 0) Err(-1) else Ok(Int32.max(i, ac)), 0, 1 :: 2 :: -3 :: Nil) == Err(-1)
+
+/////////////////////////////////////////////////////////////////////////////
+// foldRightM                                                              //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def foldRightM01(): Bool = Result.foldRightM((i, ac) -> if (i < 0) Err(-1) else Ok(Int32.max(i, ac)), 0, Nil) == Ok(0)
+
+@test
+def foldRightM02(): Bool = Result.foldRightM((i, ac) -> if (i < 0) Err(-1) else Ok(Int32.max(i, ac)), 0, 1 :: Nil) == Ok(1)
+
+@test
+def foldRightM03(): Bool = Result.foldRightM((i, ac) -> if (i < 0) Err(-1) else Ok(Int32.max(i, ac)), 0, 1 :: 2 :: Nil) == Ok(2)
+
+@test
+def foldRightM04(): Bool = Result.foldRightM((i, ac) -> if (i < 0) Err(-1) else Ok(Int32.max(i, ac)), 0, 1 :: 2 :: 3 :: Nil) == Ok(3)
+
+@test
+def foldRightM05(): Bool = Result.foldRightM((i, ac) -> if (i < 0) Err(-1) else Ok(Int32.max(i, ac)), 0, -1 :: 2 :: 3 :: Nil) == Err(-1)
+
+@test
+def foldRightM06(): Bool = Result.foldRightM((i, ac) -> if (i < 0) Err(-1) else Ok(Int32.max(i, ac)), 0, 1 :: -2 :: 3 :: Nil) == Err(-1)
+
+@test
+def foldRightM07(): Bool = Result.foldRightM((i, ac) -> if (i < 0) Err(-1) else Ok(Int32.max(i, ac)), 0, 1 :: 2 :: -3 :: Nil) == Err(-1)
 
 /////////////////////////////////////////////////////////////////////////////
 // toList                                                                  //


### PR DESCRIPTION
Hi Magnus - this PR adds "short-circuiting" list folds to Option and Result.

It also re-implements `List.foldRight` in CPS so it shouldn't blow the stack. 

See Issue #1263 - Names for short-circuiting Result and Option folds? 
