### PR TITLE
kind-check everywhere

### DIFF
--- a/examples/polymorphic-record-extension-and-restriction.flix
+++ b/examples/polymorphic-record-extension-and-restriction.flix
@@ -1,11 +1,11 @@
 /// Polymorphically extends the record `r` with an `age` label.
 /// Preserves (retains) all other labels polymorphically.
-def withAge[a](r: a, v: Int): {age: Int | a} =
+def withAge[a](r: {| a}, v: Int): {age: Int | a} =
     { +age = v | r }
 
 /// Polymorphically restricts (removes) the `age` label from `r`.
 /// Preserves (retains) all other labels polymorphically.
-def withoutAge[a](r: {age: Int | a}): a = {-age | r}
+def withoutAge[a](r: {age: Int | a}): {| a} = {-age | r}
 
 /// Construct several records and extend them with an age.
 def main(): Int =

--- a/examples/the-ast-typing-problem-with-polymorphic-records.flix
+++ b/examples/the-ast-typing-problem-with-polymorphic-records.flix
@@ -7,8 +7,8 @@ enum Exp[r] {
     case True,
     case False,
     case Cst({value: Int | r}),
-    case Add({exp1: Exp[r], exp2: Exp[r] | r}),
-    case Ite({exp1: Exp[r], exp2: Exp[r], exp3: Exp[r] | r})
+    case Add({exp1: Exp[{| r}], exp2: Exp[{| r}] | r}),
+    case Ite({exp1: Exp[{| r}], exp2: Exp[{| r}], exp3: Exp[{| r}] | r})
 }
 
 /// Next, we define a grammar of types:

--- a/examples/the-ast-typing-problem-with-polymorphic-records.flix
+++ b/examples/the-ast-typing-problem-with-polymorphic-records.flix
@@ -54,7 +54,7 @@ def main(): Type =
 
 /// We can extend the function above to be one that is polymorphic
 /// in whatever other fields an expression may be decorated with:
-def typeCheck2[r](e: Exp[r]): Exp[{tpe: Type | r}] = match e {
+def typeCheck2[r](e: Exp[{| r}]): Exp[{tpe: Type | r}] = match e {
     case True   => True
     case False  => False
     case Cst(i) => Cst({ +tpe = TInt | { value = i.value | i}})

--- a/examples/type-safe-builders-with-ufcs-and-records.flix
+++ b/examples/type-safe-builders-with-ufcs-and-records.flix
@@ -20,13 +20,13 @@ def main(): Unit =
 def connection(): {pass: Option[Str]} = {pass = None}
 
 /// The host function extends the options record with a hostname.
-def host[r](o: r, h: Str): {host: Str | r} = {+host = h | o}
+def host[r](o: {| r}, h: Str): {host: Str | r} = {+host = h | o}
 
 /// The port function extends the options record with a port number.
-def port[r](o: r, p: Int): {port: Int | r} = {+port = p | o}
+def port[r](o: {| r}, p: Int): {port: Int | r} = {+port = p | o}
 
 /// The user function extends the options record with a username.
-def user[r](o: r, u: Str): {user: Str | r} = {+user = u | o}
+def user[r](o: {| r}, u: Str): {user: Str | r} = {+user = u | o}
 
 /// The pass function *updates* the options record with a new value
 /// of its pass field. Notice that the options record must already

--- a/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
@@ -51,6 +51,8 @@ sealed trait Kind {
     case (Kind.Record, Kind.Record) => true
     case (Kind.Schema, Kind.Schema) => true
 
+    case (_, Kind.Unbound) => true
+
     // subkinds
     case (Kind.Record, Kind.Star) => true
     case (Kind.Schema, Kind.Star) => true
@@ -64,9 +66,9 @@ sealed trait Kind {
 object Kind {
 
   /**
-    * Represents a kind variable.
+    * Placeholder for types that cannot be kinded.
     */
-  case class Var(id: Int) extends Kind
+  case object Unbound extends Kind
 
   /**
     * Represents the kind of types.
@@ -94,11 +96,6 @@ object Kind {
   case class Arrow(k1: Kind, k2: Kind) extends Kind
 
   /**
-    * Returns a fresh kind variable.
-    */
-  def freshVar()(implicit flix: Flix): Kind = Var(flix.genSym.freshId())
-
-  /**
     * Returns the kind: * -> (* ... -> *)
     */
   def mkArrow(length: Int): Kind = {
@@ -120,7 +117,7 @@ object Kind {
     */
   implicit object ShowInstance extends Show[Kind] {
     def show(a: Kind): String = a match {
-      case Var(id) => "'" + id
+      case Unbound => "?"
       case Star => "*"
       case Bool => "Bool"
       case Record => "Record"

--- a/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
@@ -51,7 +51,7 @@ sealed trait Kind {
     case (Kind.Record, Kind.Record) => true
     case (Kind.Schema, Kind.Schema) => true
 
-    case (_, Kind.Unbound) => true
+    case (_, Kind.Var(_)) => true
 
     // subkinds
     case (Kind.Record, Kind.Star) => true
@@ -66,9 +66,9 @@ sealed trait Kind {
 object Kind {
 
   /**
-    * Placeholder for types that cannot be kinded.
+    * Represents a kind variable.
     */
-  case object Unbound extends Kind
+  case class Var(id: Int) extends Kind
 
   /**
     * Represents the kind of types.
@@ -108,6 +108,11 @@ object Kind {
     }
   }
 
+  /**
+    * Returns a fresh kind variable.
+    */
+  def freshVar()(implicit flix: Flix): Kind = Var(flix.genSym.freshId())
+
   /////////////////////////////////////////////////////////////////////////////
   // Type Class Instances                                                    //
   /////////////////////////////////////////////////////////////////////////////
@@ -117,7 +122,7 @@ object Kind {
     */
   implicit object ShowInstance extends Show[Kind] {
     def show(a: Kind): String = a match {
-      case Unbound => "?"
+      case Var(id) => "'" + id
       case Star => "*"
       case Bool => "Bool"
       case Record => "Record"

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -124,7 +124,7 @@ object TypeConstructor {
     /**
       * The shape of an extended schema is { name: type | rest }
       */
-    def kind: Kind = Kind.Star ->: Kind.Schema ->: Kind.Record
+    def kind: Kind = Kind.Star ->: Kind.Schema ->: Kind.Schema
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -127,11 +127,11 @@ object TypeError {
       val vt = new VirtualTerminal()
       vt << Line(kind, source.format) << NewLine
       vt << ">> Unable to unify the types: '" << Red(FormatType.formatType(type1)) << "' and '" << Red(FormatType.formatType(type2)) << "'." << NewLine
-      vt << s"     due to mismatch in kinds '$kind1' and '$kind2'"
-      vt <<
       vt << NewLine
       vt << Code(loc, "mismatched kinds.") << NewLine
       vt << NewLine
+      vt << "Kind One: " << Cyan(kind1.toString) << NewLine
+      vt << "Kind Two: " << Magenta(kind2.toString) << NewLine
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.errors
 
 import ca.uwaterloo.flix.language.CompilationError
-import ca.uwaterloo.flix.language.ast.{Scheme, SourceLocation, Type}
+import ca.uwaterloo.flix.language.ast.{Kind, Scheme, SourceLocation, Type}
 import ca.uwaterloo.flix.language.debug.{Audience, FormatScheme, FormatType, TypeDiff}
 import ca.uwaterloo.flix.util.vt.VirtualString._
 import ca.uwaterloo.flix.util.vt._
@@ -117,6 +117,21 @@ object TypeError {
       vt << "  (1) Are you trying to pass null where a non-null value is required?" << NewLine
       vt << NewLine
       vt
+    }
+  }
+
+  case class MismatchedKinds(type1: Type, type2: Type, kind1: Kind, kind2: Kind, loc: SourceLocation) extends TypeError {
+    def summary: String = s"Unable to unify the kinds '$kind1' and '$kind2'.'"
+
+    def message: VirtualTerminal = {
+      val vt = new VirtualTerminal()
+      vt << Line(kind, source.format) << NewLine
+      vt << ">> Unable to unify the types: '" << Red(FormatType.formatType(type1)) << "' and '" << Red(FormatType.formatType(type2)) << "'." << NewLine
+      vt << s"     due to mismatch in kinds '$kind1' and '$kind2'"
+      vt <<
+      vt << NewLine
+      vt << Code(loc, "mismatched kinds.") << NewLine
+      vt << NewLine
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -120,13 +120,22 @@ object TypeError {
     }
   }
 
-  case class MismatchedKinds(type1: Type, type2: Type, kind1: Kind, kind2: Kind, loc: SourceLocation) extends TypeError {
+  /**
+    * Mismatched kinds.
+    *
+    * @param tpe1 the first type.
+    * @param tpe2 the second type.
+    * @param kind1 the first kind.
+    * @param kind2 the second kind.
+    * @param loc the location where the error occurred.
+    */
+  case class MismatchedKinds(tpe1: Type, tpe2: Type, kind1: Kind, kind2: Kind, loc: SourceLocation) extends TypeError {
     def summary: String = s"Unable to unify the kinds '$kind1' and '$kind2'.'"
 
     def message: VirtualTerminal = {
       val vt = new VirtualTerminal()
       vt << Line(kind, source.format) << NewLine
-      vt << ">> Unable to unify the types: '" << Red(FormatType.formatType(type1)) << "' and '" << Red(FormatType.formatType(type2)) << "'." << NewLine
+      vt << ">> Unable to unify the types: '" << Red(FormatType.formatType(tpe1)) << "' and '" << Red(FormatType.formatType(tpe2)) << "'." << NewLine
       vt << NewLine
       vt << Code(loc, "mismatched kinds.") << NewLine
       vt << NewLine

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -285,7 +285,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
       case (macc, ident) => macc.get(ident.name) match {
         case None =>
           // We use a kind variable since we do not know the kind of the type variable.
-          val tvar = Type.freshVar(Kind.Unbound)
+          val tvar = Type.freshVar(Kind.freshVar())
           macc + (ident.name -> tvar)
         case Some(tvar) => macc
       }
@@ -1349,8 +1349,8 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
     tparams0.map {
       ident =>
         // Get the kind for each type variable from the implicit type params.
-        // Use an unbound kind if not found; this will be caught later by redundancy checks.
-        val kind = kindPerName.getOrElse(ident.name, Kind.Unbound)
+        // Use a kind variable if not found; this will be caught later by redundancy checks.
+        val kind = kindPerName.getOrElse(ident.name, Kind.freshVar())
         val tvar = Type.freshVar(kind)
         // Remember the original textual name.
         tvar.setText(ident.name)
@@ -1438,8 +1438,8 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
     typeVars.toList.sorted.map {
       case name =>
         val ident = Name.Ident(SourcePosition.Unknown, name, SourcePosition.Unknown)
-        // We use an unbound kind since we do not know the kind of the type variable.
-        val tvar = Type.freshVar(Kind.Unbound)
+        // We use a kind variable since we do not know the kind of the type variable.
+        val tvar = Type.freshVar(Kind.freshVar())
         tvar.setText(name)
         NamedAst.TypeParam(ident, tvar, loc)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -1366,7 +1366,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
     val typeVarsWithKind = cases.flatMap {
       c => freeVarsWithKind(c.tpe)
     }
-    createTypeParams(typeVarsWithKind, loc)
+    freshTypeParamsWithKind(typeVarsWithKind, loc)
   }
 
   /**
@@ -1390,14 +1390,14 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
     val typeVarsWithKind = typeVarsWithKindOverallType ::: typeVarsWithKindArgs
 
     // Create a type param for each type variable
-    createTypeParams(typeVarsWithKind, loc)
+    freshTypeParamsWithKind(typeVarsWithKind, loc)
   }
 
   /**
     * Ensure each occurrence of the same name maps to the same kind.
     * Then create a type param for each name.
     */
-  private def createTypeParams(typeVarsWithKind: List[(Name.Ident, Kind)], loc: SourceLocation)(implicit flix: Flix): Validation[List[NamedAst.TypeParam], NameError] = {
+  private def freshTypeParamsWithKind(typeVarsWithKind: List[(Name.Ident, Kind)], loc: SourceLocation)(implicit flix: Flix): Validation[List[NamedAst.TypeParam], NameError] = {
     // create a map of name -> (ident, kind), ensuring all kinds for a given name match
     val kindPerName = foldRight(typeVarsWithKind)(Map.empty[String, (Name.Ident, Kind)].toSuccess) {
       case ((ident0, kind0), acc) => acc.get(ident0.name) match {

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -43,9 +43,9 @@ object Unification {
 
     // Check if the kind of `x` matches the kind of `tpe`.
 
-    //if (x.kind != tpe.kind) {
-    //  return Result.Err(TypeError.KindError())
-    //}
+    if (!(tpe.kind <:: x.kind)) {
+      return Result.Err(UnificationError.MismatchedKinds(x.kind, tpe.kind))
+    }
 
     // We can substitute `x` for `tpe`. Update the textual name of `tpe`.
     if (x.getText.nonEmpty && tpe.isInstanceOf[Type.Var]) {
@@ -62,17 +62,33 @@ object Unification {
   def unifyTypes(tpe1: Type, tpe2: Type)(implicit flix: Flix): Result[Substitution, UnificationError] = {
     (tpe1, tpe2) match {
       case (x: Type.Var, y: Type.Var) =>
-        // Case 1: Check if the type variables are syntactically the same.
-        if (x.id == y.id && x.kind == y.kind)
-          return Result.Ok(Substitution.empty)
-        // Case 2: The left type variable is flexible.
-        if (x.rigidity == Rigidity.Flexible)
-          return Result.Ok(Substitution.singleton(x, y))
-        // Case 3: The right type variable is flexible.
-        if (y.rigidity == Rigidity.Flexible)
-          return Result.Ok(Substitution.singleton(y, x))
-        // Case 4: Both type variables are rigid.
-        Result.Err(UnificationError.RigidVar(x, y))
+        (x.id, y.id, x.rigidity, y.rigidity) match {
+          // Case 1: Check if the type variables are syntactically the same.
+          case (xId, yId, _, _) if xId == yId => Result.Ok(Substitution.empty)
+          // Case 2: Both type variables are flexible
+          case (_, _, Rigidity.Flexible, Rigidity.Flexible) =>
+            if (y.kind <:: x.kind)
+              Result.Ok(Substitution.singleton(x, y))
+            else if (x.kind <:: y.kind)
+              Result.Ok(Substitution.singleton(y, x))
+            else
+              Result.Err(UnificationError.MismatchedKinds(x.kind, y.kind))
+          // Case 3: The left type variable is flexible.
+          case (_, _, Rigidity.Flexible, Rigidity.Rigid) =>
+            if (y.kind <:: x.kind)
+              Result.Ok(Substitution.singleton(x, y))
+            else
+              Result.Err(UnificationError.MismatchedKinds(x.kind, y.kind))
+          // Case 4: The right type variable is flexible.
+          case (_, _, Rigidity.Rigid, Rigidity.Flexible) =>
+            if (x.kind <:: y.kind)
+              Result.Ok(Substitution.singleton(y, x))
+            else
+              Result.Err(UnificationError.MismatchedKinds(x.kind, y.kind))
+          // Case 5: Both type variables are rigid.
+          case (_, _, Rigidity.Rigid, Rigidity.Rigid) =>
+            Result.Err(UnificationError.RigidVar(x, y))
+        }
 
       case (x: Type.Var, _) =>
         if (x.kind == Kind.Bool || tpe2.kind == Kind.Bool)
@@ -263,6 +279,9 @@ object Unification {
 
         case Result.Err(UnificationError.NonSchemaType(tpe)) =>
           Err(TypeError.NonSchemaType(tpe, loc))
+
+        case Result.Err(UnificationError.MismatchedKinds(kind1, kind2)) =>
+          Err(TypeError.MismatchedKinds(type1, type2, kind1, kind2, loc))
       }
     }
     )

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/UnificationError.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/UnificationError.scala
@@ -15,7 +15,7 @@
  */
 package ca.uwaterloo.flix.language.phase.unification
 
-import ca.uwaterloo.flix.language.ast.Type
+import ca.uwaterloo.flix.language.ast.{Kind, Type}
 
 /**
   * A common super-type for unification errors.
@@ -95,5 +95,12 @@ object UnificationError {
     * @param nonSchemaType the unexpected non-schema type.
     */
   case class NonSchemaType(nonSchemaType: Type) extends UnificationError
+
+  /**
+    * A unification error due to an mismatch in type variable kinds.
+    * @param kind1 the first kind.
+    * @param kind2 the second kind.
+    */
+  case class MismatchedKinds(kind1: Kind, kind2: Kind) extends UnificationError
 
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -453,79 +453,157 @@ class TestNamer extends FunSuite with TestUtils {
     expectError[NameError.UndefinedTypeVar](result)
   }
 
-  test("MismatchedTypeParamKind.01") {
+  test("MismatchedTypeParamKind.Explicit.01") {
+    val input = "def f[o](g: Int -> o & o): Int = 123"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Explicit.02") {
+    val input = "def f[e](g: Int -> Int & e): e = g(123)"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Explicit.03") {
+    val input = "def f[a](s: #{| a}, r: {| a}): Int = 123"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Explicit.04") {
+    val input = "def f[a](s: #{X(Int) | a}, r: {x: Int | a}): Int = 123"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Explicit.05") {
+    val input = "def f[a](r: {| a}, t: a): Int = 123"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Explicit.06") {
+    val input = "def f[a](s: #{| a}, t: a): Int = 123"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Explicit.07") {
+    val input = "def f[a](s: Option[{|a}]): a = 123"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Explicit.08") {
+    val input = "def f[r](a: {x: {| r}}): r = 123"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Explicit.09") {
+    val input = "def f[e](a: e): Int & not e = 123"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Explicit.10") {
+    val input = "def f[e, f](a: Map[e, f]): Int & e and f = 123"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Explicit.11") {
+    val input = "def f[a](r: {x: a | a}): Int = 123"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Explicit.12") {
+    val input = "def f[n](a: String ? n, b: n): Int = 123"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Explicit.13") {
+    val input = "def f[a, b, e](g: Option[a -> b & e]): Int & not (a or b) = 123"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Implicit.01") {
     val input = "def f(g: Int -> o & o): Int = 123"
     val result = compile(input, DefaultOptions)
     expectError[NameError.MismatchedTypeParamKinds](result)
   }
 
-  test("MismatchedTypeParamKind.02") {
+  test("MismatchedTypeParamKind.Implicit.02") {
     val input = "def f(g: Int -> Int & e): e = g(123)"
     val result = compile(input, DefaultOptions)
     expectError[NameError.MismatchedTypeParamKinds](result)
   }
 
-  test("MismatchedTypeParamKind.03") {
+  test("MismatchedTypeParamKind.Implicit.03") {
     val input = "def f(s: #{| a}, r: {| a}): Int = 123"
     val result = compile(input, DefaultOptions)
     expectError[NameError.MismatchedTypeParamKinds](result)
   }
 
-  test("MismatchedTypeParamKind.04") {
+  test("MismatchedTypeParamKind.Implicit.04") {
     val input = "def f(s: #{X(Int) | a}, r: {x: Int | a}): Int = 123"
     val result = compile(input, DefaultOptions)
     expectError[NameError.MismatchedTypeParamKinds](result)
   }
 
-  test("MismatchedTypeParamKind.05") {
+  test("MismatchedTypeParamKind.Implicit.05") {
     val input = "def f(r: {| a}, t: a): Int = 123"
     val result = compile(input, DefaultOptions)
     expectError[NameError.MismatchedTypeParamKinds](result)
   }
 
-  test("MismatchedTypeParamKind.06") {
+  test("MismatchedTypeParamKind.Implicit.06") {
     val input = "def f(s: #{| a}, t: a): Int = 123"
     val result = compile(input, DefaultOptions)
     expectError[NameError.MismatchedTypeParamKinds](result)
   }
 
-  test("MismatchedTypeParamKind.07") {
+  test("MismatchedTypeParamKind.Implicit.07") {
     val input = "def f(s: Option[{|a}]): a = 123"
     val result = compile(input, DefaultOptions)
     expectError[NameError.MismatchedTypeParamKinds](result)
   }
 
-  test("MismatchedTypeParamKind.08") {
+  test("MismatchedTypeParamKind.Implicit.08") {
     val input = "def f(a: {x: {| r}}): r = 123"
     val result = compile(input, DefaultOptions)
     expectError[NameError.MismatchedTypeParamKinds](result)
   }
 
-  test("MismatchedTypeParamKind.09") {
+  test("MismatchedTypeParamKind.Implicit.09") {
     val input = "def f(a: e): Int & not e = 123"
     val result = compile(input, DefaultOptions)
     expectError[NameError.MismatchedTypeParamKinds](result)
   }
 
-  test("MismatchedTypeParamKind.10") {
+  test("MismatchedTypeParamKind.Implicit.10") {
     val input = "def f(a: Map[e, f]): Int & e and f = 123"
     val result = compile(input, DefaultOptions)
     expectError[NameError.MismatchedTypeParamKinds](result)
   }
 
-  test("MismatchedTypeParamKind.11") {
+  test("MismatchedTypeParamKind.Implicit.11") {
     val input = "def f(r: {x: a | a}): Int = 123"
     val result = compile(input, DefaultOptions)
     expectError[NameError.MismatchedTypeParamKinds](result)
   }
 
-  test("MismatchedTypeParamKind.12") {
+  test("MismatchedTypeParamKind.Implicit.12") {
     val input = "def f(a: String ? n, b: n): Int = 123"
     val result = compile(input, DefaultOptions)
     expectError[NameError.MismatchedTypeParamKinds](result)
   }
 
-  test("MismatchedTypeParamKind.13") {
+  test("MismatchedTypeParamKind.Implicit.13") {
     val input = "def f(g: Option[a -> b & e]): Int & not (a or b) = 123"
     val result = compile(input, DefaultOptions)
     expectError[NameError.MismatchedTypeParamKinds](result)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -608,4 +608,226 @@ class TestNamer extends FunSuite with TestUtils {
     val result = compile(input, DefaultOptions)
     expectError[NameError.MismatchedTypeParamKinds](result)
   }
+
+
+  test("MismatchedTypeParamKind.Enum.01") {
+    val input =
+      """
+        |enum E[o] {
+        |    case A(Int -> o & o)
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Enum.02") {
+    val input =
+      """
+        |enum E[e] {
+        |    case A((Int -> Int & e) -> e)
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Enum.03") {
+    val input =
+      """
+        |enum E[a] {
+        |    case A(#{| a}, {| a})
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Enum.04") {
+    val input =
+      """
+        |enum E[a] {
+        |    case A(#{X(Int) | a}, {x: Int | a})
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Enum.05") {
+    val input =
+      """
+        |enum E[a] {
+        |    case A({| a}, a)
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Enum.06") {
+    val input =
+      """
+        |enum E[a] {
+        |    case A(#{| a}, a)
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Enum.07") {
+    val input =
+      """enum E[a] {
+        |    case A(Option[{| a}] -> a)
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Enum.08") {
+    val input =
+      """
+        |enum E[a] {
+        |    case A({x: {| r}} -> r)
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Enum.09") {
+    val input =
+      """
+        |enum E[e] {
+        |    case A(e -> Int & not e)
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Enum.10") {
+    val input =
+      """
+        |enum E[e, f] {
+        |    case A(Map[e, f] -> Int & e and f)
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Enum.11") {
+    val input =
+      """
+        |enum E[a] {
+        |    case A({x: a | a})
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Enum.12") {
+    val input =
+      """
+        |enum E[a, n] {
+        |    case A(String ? n, n)
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.Enum.13") {
+    val input =
+      """
+        |enum E[a, b, e] {
+        |    case A(Option[a -> b & e] -> Int & not (a or b))
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+
+  test("MismatchedTypeParamKind.TypeAlias.01") {
+    val input = "type alias T[o] = Int -> o & o"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.TypeAlias.02") {
+    val input = "type alias T[e] = (Int -> Int & e) -> e"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.TypeAlias.03") {
+    val input = "type alias T[a] = (#{| a}, {| a})"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.TypeAlias.04") {
+    val input = "type alias T[a] = (#{X(Int) | a}, {x: Int | a})"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.TypeAlias.05") {
+    val input = "type alias T[a] = ({| a}, a)"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.TypeAlias.06") {
+    val input = "type alias T[a] = (#{| a}, a)"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.TypeAlias.07") {
+    val input = "type alias T[a] = Option[{| a}] -> a"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.TypeAlias.08") {
+    val input = "type alias T[r] = {x: {| r}} -> r"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.TypeAlias.09") {
+    val input = "type alias T[e] = e -> Int & not e"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.TypeAlias.10") {
+    val input = "type alias T[e, f] = Map[e, f] -> Int & e and f"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.TypeAlias.11") {
+    val input = "type alias T[a] = {x: a | a}"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.TypeAlias.12") {
+    val input = "type alias T[a, n] = (String ? n, n)"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
+
+  test("MismatchedTypeParamKind.TypeAlias.13") {
+    val input = "type alias T[a, b, e] = Option[a -> b & e] -> Int & not (a or b)"
+    val result = compile(input, DefaultOptions)
+    expectError[NameError.MismatchedTypeParamKinds](result)
+  }
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/unification/TestUnification.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/unification/TestUnification.scala
@@ -18,15 +18,10 @@ package ca.uwaterloo.flix.language.phase.unification
 
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type, TypeConstructor}
-import ca.uwaterloo.flix.language.errors.TypeError.OccursCheckError
+import ca.uwaterloo.flix.language.ast.{Kind, Rigidity, SourceLocation, Type}
 import ca.uwaterloo.flix.language.phase.unification.InferMonad.seqM
-import ca.uwaterloo.flix.language.phase.unification.UnificationError.OccursCheck
 import ca.uwaterloo.flix.util.Result
-import ca.uwaterloo.flix.util.Result.Err
 import org.scalatest.FunSuite
-
-import scala.reflect.ClassTag
 
 class TestUnification extends FunSuite with TestUtils {
 
@@ -329,6 +324,34 @@ class TestUnification extends FunSuite with TestUtils {
     val field = Type.mkRelation(List(Type.Bool))
     val label = "x"
     val tpe2 = Type.mkSchemaExtend(label, field, tpe1)
+    val result = Unification.unifyTypes(tpe1, tpe2)
+    assert(!isOk(result))
+  }
+
+  test("Unify.14") {
+    val tpe1 = Type.Var(1, Kind.Schema)
+    val tpe2 = Type.Var(2, Kind.Record)
+    val result = Unification.unifyTypes(tpe1, tpe2)
+    assert(!isOk(result))
+  }
+
+  test("Unify.15") {
+    val tpe1 = Type.Var(1, Kind.Star, Rigidity.Rigid)
+    val tpe2 = Type.Var(2, Kind.Record, Rigidity.Flexible)
+    val result = Unification.unifyTypes(tpe1, tpe2)
+    assert(!isOk(result))
+  }
+
+  test("Unify.16") {
+    val tpe1 = Type.Var(1, Kind.Star, Rigidity.Flexible)
+    val tpe2 = Type.Var(2, Kind.Record, Rigidity.Rigid)
+    val result = Unification.unifyTypes(tpe1, tpe2)
+    assert(isOk(result))
+  }
+
+  test("Unify.17") {
+    val tpe1 = Type.Var(1, Kind.Star, Rigidity.Rigid)
+    val tpe2 = Type.Var(2, Kind.Star, Rigidity.Rigid)
     val result = Unification.unifyTypes(tpe1, tpe2)
     assert(!isOk(result))
   }

--- a/main/test/flix/Test.Exp.Record.Polymorphism.flix
+++ b/main/test/flix/Test.Exp.Record.Polymorphism.flix
@@ -38,7 +38,7 @@ namespace Test/Exp/Record/Polymorphism {
         let _p8 = withColor(p4, "Black");
         ()
 
-    def withColor[r](rec: r, col: Str): { color: Str | r } =
+    def withColor[r](rec: {| r}, col: Str): { color: Str | r } =
         { +color = col | rec }
 
     @test
@@ -53,7 +53,7 @@ namespace Test/Exp/Record/Polymorphism {
         let _p8 = withAgeAndSex(42, "f", p4);
         ()
 
-    def withAgeAndSex[r](age: Int, sex: Str, rec: r): { age: Int, sex: Str | r } =
+    def withAgeAndSex[r](age: Int, sex: Str, rec: {| r}): { age: Int, sex: Str | r } =
         { +age = age, +sex = sex | rec }
 
     @test


### PR DESCRIPTION
Adds kind checking to
* functions with explicit parameters
* enums
* type aliases

Turns out that kind vars are not needed (I think). I reverted to the "Unbound" kind.

Before pushing, I'd like to:
- [x] improve error messaging
- [ ] ~introduce predicate kinds for going inside schemas instead of using `*`~ (not really necessary as parsing protects us)

But the logic is all there, so this should be review-worthy.