### PR TITLE
Fix variables in documentor

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/unification/BoolUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/BoolUnification.scala
@@ -89,6 +89,11 @@ object BoolUnification {
       //      }
       //    }
 
+      // carry over the old variable names to the new variables
+      subst.m.foreach { // TODO get rid of this insanity
+        case (x, y: Type.Var) => x.getText.foreach(y.setText)
+        case _ => // ignore
+      }
       Ok(subst)
     } catch {
       case BooleanUnificationException => Err(UnificationError.MismatchedBools(tpe1, tpe2))

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -33,9 +33,13 @@ object Unification {
     } else {
       (x.rigidity, y.rigidity) match {
         // Case 1: x is flexible and a superkind of y
-        case (Rigidity.Flexible, _) if y.kind <:: x.kind => Result.Ok(Substitution.singleton(x, y))
+        case (Rigidity.Flexible, _) if y.kind <:: x.kind =>
+          x.getText.foreach(y.setText) // TODO get rid of this insanity
+          Result.Ok(Substitution.singleton(x, y))
         // Case 2: y is flexible and a superkind of x
-        case (_, Rigidity.Flexible) if x.kind <:: y.kind => Result.Ok(Substitution.singleton(y, x))
+        case (_, Rigidity.Flexible) if x.kind <:: y.kind =>
+          y.getText.foreach(x.setText) // TODO get rid of this insanity
+          Result.Ok(Substitution.singleton(y, x))
         // Case 3: both variables are rigid
         case (Rigidity.Rigid, Rigidity.Rigid) => Result.Err(UnificationError.RigidVar(x, y))
         // Case 4: at least one variable is flexible but not a superkind of the other
@@ -68,11 +72,6 @@ object Unification {
       return Result.Err(UnificationError.MismatchedKinds(x.kind, tpe.kind))
     }
 
-    // We can substitute `x` for `tpe`. Update the textual name of `tpe`.
-    if (x.getText.nonEmpty && tpe.isInstanceOf[Type.Var]) {
-      // TODO: Get rid of this insanity.
-      tpe.asInstanceOf[Type.Var].setText(x.getText.get)
-    }
     Result.Ok(Substitution.singleton(x, tpe))
   }
 


### PR DESCRIPTION
Variable names were getting lost in unification. This should fix issues with the names of type variables in the documentor not matching properly.

Output of `--doc` here: https://gist.github.com/mlutze/3a48c1abac9b20b10104bef651e3a8dc

Fixes #1200 

Related: #1146 