### PR TITLE
Check param kinds

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.util.tc.Show
+import ca.uwaterloo.flix.language.debug.FormatKind
 
 /**
   * A kind represents the "type" of a type expression.
@@ -37,7 +37,7 @@ sealed trait Kind {
   /**
     * Returns a human readable representation of `this` kind.
     */
-  override def toString: String = Kind.ShowInstance.show(this)
+  override def toString: String = FormatKind.formatKind(this)
 
   /**
     * Returns true if `left` is a subkind of `this`.
@@ -112,24 +112,5 @@ object Kind {
     * Returns a fresh kind variable.
     */
   def freshVar()(implicit flix: Flix): Kind = Var(flix.genSym.freshId())
-
-  /////////////////////////////////////////////////////////////////////////////
-  // Type Class Instances                                                    //
-  /////////////////////////////////////////////////////////////////////////////
-
-  /**
-    * Show instance for Type.
-    */
-  implicit object ShowInstance extends Show[Kind] {
-    def show(a: Kind): String = a match {
-      case Var(id) => "'" + id
-      case Star => "*"
-      case Bool => "Bool"
-      case Record => "Record"
-      case Schema => "Schema"
-      case Arrow(Arrow(k11, k12), k2) => s"($k11 -> $k12) -> $k2"
-      case Arrow(k1, k2) => s"$k1 -> $k2"
-    }
-  }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/debug/FormatKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/debug/FormatKind.scala
@@ -1,0 +1,21 @@
+package ca.uwaterloo.flix.language.debug
+
+import ca.uwaterloo.flix.language.ast.Kind
+
+object FormatKind {
+
+  /**
+    * Create a string representation of the kind.
+    */
+  def formatKind(kind: Kind): String = kind match {
+    case Kind.Var(id) => s"`$id"
+    case Kind.Star => "*"
+    case Kind.Bool => "Bool"
+    case Kind.Record => "Record"
+    case Kind.Schema => "Schema"
+    // parenthesize the left because `->` is right-associative
+    case Kind.Arrow(k1: Kind.Arrow, k2) => s"(${formatKind(k1)}) -> ${formatKind(k2)}"
+    case Kind.Arrow(k1, k2) => s"${formatKind(k1)} -> ${formatKind(k2)}"
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -20,6 +20,7 @@ import java.lang.reflect.{Constructor, Field, Method}
 
 import ca.uwaterloo.flix.language.CompilationError
 import ca.uwaterloo.flix.language.ast.{Kind, Name, SourceLocation, Symbol, Type}
+import ca.uwaterloo.flix.language.debug.{Audience, FormatKind, FormatType}
 import ca.uwaterloo.flix.util.vt.VirtualString._
 import ca.uwaterloo.flix.util.vt.VirtualTerminal
 
@@ -31,6 +32,8 @@ sealed trait ResolutionError extends CompilationError {
 }
 
 object ResolutionError {
+
+  private implicit val audience = Audience.External
 
   /**
     * Ambiguous Name Error.
@@ -119,7 +122,7 @@ object ResolutionError {
     def message: VirtualTerminal = {
       val vt = new VirtualTerminal
       vt << Line(kind, source.format) << NewLine
-      vt << ">> Illegal type: '" << Red(tpe.toString) << "'." << NewLine
+      vt << ">> Illegal type: '" << Red(FormatType.formatType(tpe)) << "'." << NewLine
       vt << NewLine
       vt << Code(loc, "illegal type.") << NewLine
     }
@@ -135,7 +138,7 @@ object ResolutionError {
     override def message: VirtualTerminal = {
       val vt = new VirtualTerminal
       vt << Line(kind, source.format) << NewLine
-      vt << ">> Illegal uninhabited type: '" << Red(tpe.toString) << "' with kind '" << Red(tpe.kind.toString) << "'." << NewLine
+      vt << ">> Illegal uninhabited type: '" << Red(FormatType.formatType(tpe)) << "' with kind '" << Red(FormatKind.formatKind(tpe.kind)) << "'." << NewLine
       vt << NewLine
       vt << Code(loc, "uninhabited type.")
       vt << NewLine
@@ -155,7 +158,7 @@ object ResolutionError {
     override def message: VirtualTerminal = {
       val vt = new VirtualTerminal
       vt << Line(kind, source.format) << NewLine
-      vt << ">> Illegal type application: '" << Red(tpe1.toString) << "' applied to '" << Red(tpe2.toString) << "'." << NewLine
+      vt << ">> Illegal type application: '" << Red(FormatType.formatType(tpe1)) << "' applied to '" << Red(FormatType.formatType(tpe2)) << "'." << NewLine
       vt << NewLine
       vt << Code(loc, "illegal type application.")
       vt << NewLine

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.errors
 import java.lang.reflect.{Constructor, Field, Method}
 
 import ca.uwaterloo.flix.language.CompilationError
-import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, Type}
+import ca.uwaterloo.flix.language.ast.{Kind, Name, SourceLocation, Symbol, Type}
 import ca.uwaterloo.flix.util.vt.VirtualString._
 import ca.uwaterloo.flix.util.vt.VirtualTerminal
 
@@ -122,6 +122,44 @@ object ResolutionError {
       vt << ">> Illegal type: '" << Red(tpe.toString) << "'." << NewLine
       vt << NewLine
       vt << Code(loc, "illegal type.") << NewLine
+    }
+  }
+
+  /**
+    * Illegal Uninhabited Type Error.
+    * @param tpe the uninhabited type.
+    * @param loc the location where the error occurred.
+    */
+  case class IllegalUninhabitedType(tpe: Type, loc: SourceLocation) extends ResolutionError {
+    override def summary: String = "Illegal uninhabited type."
+    override def message: VirtualTerminal = {
+      val vt = new VirtualTerminal
+      vt << Line(kind, source.format) << NewLine
+      vt << ">> Illegal uninhabited type: '" << Red(tpe.toString) << "' with kind '" << Red(tpe.kind.toString) << "'." << NewLine
+      vt << NewLine
+      vt << Code(loc, "uninhabited type.")
+      vt << NewLine
+      vt << Underline("Tip:") << " Types in this location must be inhabited."
+      vt << "     Ensure the type has the correct number of parameters."
+    }
+  }
+
+  /**
+    * Illegal Type Application Error.
+    * @param tpe1 the type used as a type constructor.
+    * @param tpe2 the type used as an argument.
+    * @param loc the location where the error occurred.
+    */
+  case class IllegalTypeApplication(tpe1: Type, tpe2: Type, loc: SourceLocation) extends ResolutionError {
+    override def summary: String = "Illegal type application."
+    override def message: VirtualTerminal = {
+      val vt = new VirtualTerminal
+      vt << Line(kind, source.format) << NewLine
+      vt << ">> Illegal type application: '" << Red(tpe1.toString) << "' applied to '" << Red(tpe2.toString) << "'." << NewLine
+      vt << NewLine
+      vt << Code(loc, "illegal type application.")
+      vt << NewLine
+      vt << Underline("Tip:") << " Ensure the type has the correct number of parameters."
     }
   }
 
@@ -361,12 +399,6 @@ object ResolutionError {
       }
       vt
     }
-  }
-
-  case class IllegalKind() extends ResolutionError { // MATT to be filled in
-    override def loc: SourceLocation = SourceLocation.Unknown
-    override def summary: String = ""
-    override def message: VirtualTerminal = new VirtualTerminal
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -363,6 +363,12 @@ object ResolutionError {
     }
   }
 
+  case class IllegalKind() extends ResolutionError { // MATT to be filled in
+    override def loc: SourceLocation = SourceLocation.Unknown
+    override def summary: String = ""
+    override def message: VirtualTerminal = new VirtualTerminal
+  }
+
   /**
     * Removes all access modifiers from the given string `s`.
     */

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1162,7 +1162,7 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
       for {
         tpe1 <- lookupType(base0, ns0, root)
         tpe2 <- lookupType(targ0, ns0, root)
-        app <- tryMkApply(tpe1, tpe2, loc)
+        app <- mkApply(tpe1, tpe2, loc)
       } yield Type.simplify(app)
 
     case NamedAst.Type.True(loc) =>
@@ -1498,7 +1498,7 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
   /**
     * Tries to apply `tpe1` to `tpe2`. Creates a resolution error if `tpe1` is not a type constructor.
     */
-  private def tryMkApply(tpe1: Type, tpe2: Type, loc: SourceLocation): Validation[Type, ResolutionError] = {
+  private def mkApply(tpe1: Type, tpe2: Type, loc: SourceLocation): Validation[Type, ResolutionError] = {
     tpe1.kind match {
       case _: Kind.Arrow => Type.Apply(tpe1, tpe2).toSuccess
       case _ => ResolutionError.IllegalTypeApplication(tpe1, tpe2, loc).toFailure

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.errors.ResolutionError
-import ca.uwaterloo.flix.util.Options
+import ca.uwaterloo.flix.util.{Options, Validation}
 import org.scalatest.FunSuite
 
 class TestResolver extends FunSuite with TestUtils {
@@ -580,4 +580,23 @@ class TestResolver extends FunSuite with TestUtils {
     expectError[ResolutionError.UndefinedType](result)
   }
 
+  test("NonStarParam.01") {
+    val input =
+      """
+        |def f(a: Result[Int]): Int = 123
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibrary)
+    expectError[ResolutionError.IllegalKind](result)
+  }
+
+  test("NonStarParam.02") {
+    val input =
+      """
+        |enum E {
+        |  case A(Result[Int])
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibrary)
+    expectError[ResolutionError.IllegalKind](result)
+  }
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -580,7 +580,7 @@ class TestResolver extends FunSuite with TestUtils {
     expectError[ResolutionError.UndefinedType](result)
   }
 
-  test("ImproperType.01") {
+  test("IllegalUninhabitedType.01") {
     val input =
       """
         |enum P[a, b] {
@@ -593,7 +593,7 @@ class TestResolver extends FunSuite with TestUtils {
     expectError[ResolutionError.IllegalUninhabitedType](result)
   }
 
-  test("ImproperType.02") {
+  test("IllegalUninhabitedType.02") {
     val input =
       """
         |enum P[a, b] {
@@ -608,7 +608,64 @@ class TestResolver extends FunSuite with TestUtils {
     expectError[ResolutionError.IllegalUninhabitedType](result)
   }
 
-  test("IllegalTypeApplication.03") {
+
+  test("IllegalUninhabitedType.03") {
+    val input =
+      """
+        |enum P[a, b] {
+        |  case C(a, b)
+        |}
+        |
+        |def f(p: P): Int = 123
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[ResolutionError.IllegalUninhabitedType](result)
+  }
+
+  test("IllegalUninhabitedType.04") {
+    val input =
+      """
+        |enum P[a, b] {
+        |  case C(a, b)
+        |}
+        |
+        |enum E {
+        |  case A(P)
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[ResolutionError.IllegalUninhabitedType](result)
+  }
+
+  test("IllegalUninhabitedType.05") {
+    val input =
+      """
+        |enum P[a, b, c] {
+        |  case C(a, b, c)
+        |}
+        |
+        |def f(p: P[Int, Int]): Int = 123
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[ResolutionError.IllegalUninhabitedType](result)
+  }
+
+  test("IllegalUninhabitedType.06") {
+    val input =
+      """
+        |enum P[a, b, c] {
+        |  case C(a, b, c)
+        |}
+        |
+        |enum E {
+        |  case A(P[Int, Int])
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[ResolutionError.IllegalUninhabitedType](result)
+  }
+
+  test("IllegalTypeApplication.01") {
     val input =
       """
         |enum P[a, b] {
@@ -617,6 +674,36 @@ class TestResolver extends FunSuite with TestUtils {
         |
         |def f(p: P[Int, String, String]): Int = 123
         |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[ResolutionError.IllegalTypeApplication](result)
+  }
+
+  test("IllegalTypeApplication.02") {
+    val input =
+      """
+        |type alias R = {x: Int}
+        |
+        |def f(p: R[Int]): Int = 123
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[ResolutionError.IllegalTypeApplication](result)
+  }
+
+  test("IllegalTypeApplication.03") {
+    val input =
+      """
+        |rel A(a: Int)
+        |
+        |type alias S = #{ A }
+        |
+        |def f(p: S[Int]): Int = 123
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[ResolutionError.IllegalTypeApplication](result)
+  }
+
+  test("IllegalTypeApplication.04") {
+    val input = "def f(p: Str[Int]): Int = 123"
     val result = compile(input, DefaultOptions)
     expectError[ResolutionError.IllegalTypeApplication](result)
   }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -580,23 +580,44 @@ class TestResolver extends FunSuite with TestUtils {
     expectError[ResolutionError.UndefinedType](result)
   }
 
-  test("NonStarParam.01") {
+  test("ImproperType.01") {
     val input =
       """
-        |def f(a: Result[Int]): Int = 123
+        |enum P[a, b] {
+        |  case C(a, b)
+        |}
+        |
+        |def f(p: P[Int]): Int = 123
         |""".stripMargin
-    val result = compile(input, Options.TestWithLibrary)
-    expectError[ResolutionError.IllegalKind](result)
+    val result = compile(input, DefaultOptions)
+    expectError[ResolutionError.IllegalUninhabitedType](result)
   }
 
-  test("NonStarParam.02") {
+  test("ImproperType.02") {
     val input =
       """
+        |enum P[a, b] {
+        |  case C(a, b)
+        |}
+        |
         |enum E {
-        |  case A(Result[Int])
+        |  case A(P[Int])
         |}
         |""".stripMargin
-    val result = compile(input, Options.TestWithLibrary)
-    expectError[ResolutionError.IllegalKind](result)
+    val result = compile(input, DefaultOptions)
+    expectError[ResolutionError.IllegalUninhabitedType](result)
+  }
+
+  test("IllegalTypeApplication.03") {
+    val input =
+      """
+        |enum P[a, b] {
+        |  case C(a, b)
+        |}
+        |
+        |def f(p: P[Int, String, String]): Int = 123
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[ResolutionError.IllegalTypeApplication](result)
   }
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -17,7 +17,6 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
-import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.errors.ResolutionError
 import ca.uwaterloo.flix.util.{Options, Validation}
 import org.scalatest.FunSuite
@@ -661,6 +660,12 @@ class TestResolver extends FunSuite with TestUtils {
         |  case A(P[Int, Int])
         |}
         |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[ResolutionError.IllegalUninhabitedType](result)
+  }
+
+  test("IllegalUninhabitedType.07") {
+    val input = """def f(x: true): Int = 123"""
     val result = compile(input, DefaultOptions)
     expectError[ResolutionError.IllegalUninhabitedType](result)
   }


### PR DESCRIPTION
Fixes #348 

Ensures that parameters of enum cases, existential and universal types, and functions all have proper types (`*` kind).

I didn't include relation parameters since it seemed that we ignore these anyway (?).

E.g. this program runs without error.
```
rel A(a: Int)

A("abc").
```