### PR TITLE
add mismatched kind tests

### DIFF
--- a/main/test/ca/uwaterloo/flix/TestUtils.scala
+++ b/main/test/ca/uwaterloo/flix/TestUtils.scala
@@ -42,7 +42,7 @@ trait TestUtils {
       val expected = classTag.runtimeClass
       val actuals = errors.map(_.getClass)
 
-      if (!actuals.contains(expected))
+      if (!actuals.exists(expected.isAssignableFrom(_)))
         fail(s"Expected an error of type ${expected.getSimpleName}, but found ${actuals.mkString(", ")}.")
   }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.TypeError
-import ca.uwaterloo.flix.util.Options
+import ca.uwaterloo.flix.util.{Options, Validation}
 import org.scalatest.FunSuite
 
 class TestTyper extends FunSuite with TestUtils {
@@ -162,4 +162,33 @@ class TestTyper extends FunSuite with TestUtils {
     expectError[TypeError.GeneralizationError](result)
   }
 
+  test("TestMismatchedKinds.01") {
+    val input = "def f(): {| x} = {a = 2} <+> {a = 2}"
+    val result = compile(input, DefaultOptions)
+    expectError[TypeError.MismatchedKinds](result)
+  }
+
+  test("TestMismatchedKinds.02") {
+    val input = "def f(): #{| x} = {a = 2} <+> {a = 2}"
+    val result = compile(input, DefaultOptions)
+    expectError[TypeError.MismatchedKinds](result)
+  }
+
+  test("TestMismatchedKinds.03") {
+    val input = "def f(): {a: Int} = {a = 2} <+> {a = 2}"
+    val result = compile(input, DefaultOptions)
+    expectError[TypeError.MismatchedKinds](result)
+  }
+
+  test("TestMismatchedKinds.04") {
+    val input = "def f(): Str = 1 |= 2"
+    val result = compile(input, DefaultOptions)
+    expectError[TypeError.MismatchedKinds](result)
+  }
+
+  test("TestMismatchedKinds.05") {
+    val input = "def f(): Str = solve \"hello\""
+    val result = compile(input, DefaultOptions)
+    expectError[TypeError.MismatchedKinds](result)
+  }
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -191,4 +191,34 @@ class TestTyper extends FunSuite with TestUtils {
     val result = compile(input, DefaultOptions)
     expectError[TypeError.MismatchedKinds](result)
   }
+
+  test("TestMismatchedKinds.06") {
+    val input =
+      """
+        |rel A(a: Int)
+        |
+        |def f(): Int = {
+        |  let b = "b";
+        |  let c = "c";
+        |  let d = "d";
+        |  fold A b c d
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[TypeError](result) // TODO use more specific error once TypeError logic is more defined
+  }
+
+  test("TestMismatchedKinds.07") {
+    val input =
+      """
+        |rel A(a: Int)
+        |
+        |def f(): Int = {
+        |  let b = "b";
+        |  project A b
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[TypeError](result) // TODO use more specific error once TypeError logic is more defined
+  }
 }


### PR DESCRIPTION
Adds more tests relating to https://github.com/flix/flix/issues/808

However, I didn't cover all the cases:

`TypeError.NonSchemaType` and `TypeError.NonRecordType` overlap somewhat with the purpose of `TypeError.MismatchedKinds` and `TypeError.MismatchedTypes`, so some cases where I expected to get one, I got the other. (`project`, `fold`). I think part of this is `unifyTypes`'s dependency on parameter order. E.g.

```scala
    val rec = Type.mkRecordExtend("a", Type.Str, Type.RecordEmpty)
    val str = Type.Str
    val res1 = Unification.unifyTypes(rec, str) // NonRecordType
    val res2 = Unification.unifyTypes(str, rec) // MismatchedTypes
```

It would be nice to have a contract where `unifyTypes(a, b) ~== unifyTypes(b, a)`

And I would propose some principles on when a user could expect each error:
* Mismatched kinds only if not explainable with types:
  * two vars with different kinds
  * one var and a bound type with different kinds
* Mismatched types for all other cases?
* Get rid of Non(Schema|Record)Type?

The alternatives include:
* keep NonSchemaType and NonRecordType and check both vars for schema-ness and record-ness
* keep parameter order dependency and document it and try to enforce it (?)