### PR TITLE
Refactor the Arrow Type Constructor to take an Effect (Bool) as its First Argument

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -89,8 +89,8 @@ object TypeConstructor {
   /**
     * A type constructor that represents the type of functions.
     */
-  case class Arrow(arity: Int, eff: Type) extends TypeConstructor { // TODO: Move effect.
-    def kind: Kind = Kind.mkArrow(arity)
+  case class Arrow(arity: Int) extends TypeConstructor {
+    def kind: Kind = Kind.Bool ->: Kind.mkArrow(arity)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/debug/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/debug/FormatType.scala
@@ -222,14 +222,16 @@ object FormatType {
             case _ => formatApply("∨", args)
           }
 
-          case TypeConstructor.Arrow(arity, eff) =>
+          case TypeConstructor.Arrow(arity) =>
             if (arity < 2) {
               formatApply(s"Arrow$arity", args)
             } else {
 
               // Retrieve and result type.
-              val types = args.take(arity).map(visit)
-              val applyParams = args.drop(arity) // excess args
+              val eff = args.head
+              val typeArgs = args.slice(1, arity + 1)
+              val types = typeArgs.map(visit)
+              val applyParams = typeArgs.drop(arity + 1) // excess args
               val typeStrings = types.padTo(arity, "???")
 
               // Format the arguments.

--- a/main/src/ca/uwaterloo/flix/language/debug/TypeDiff.scala
+++ b/main/src/ca/uwaterloo/flix/language/debug/TypeDiff.scala
@@ -98,8 +98,8 @@ object TypeDiff {
         case (TypeConstructor.Enum(sym1, kind1), TypeConstructor.Enum(sym2, kind2)) if ((sym1 == sym2) && (kind1 == kind2)) =>
           val diffs = (tpe1.typeArguments zip tpe2.typeArguments).map { case (t1, t2) => diff(t1, t2) }
           mkApply(TypeDiff.Enum, diffs)
-        case (TypeConstructor.Arrow(len1, _), TypeConstructor.Arrow(len2, _)) if (len1 == len2) =>
-          val diffs = (tpe1.typeArguments zip tpe2.typeArguments).map { case (t1, t2) => diff(t1, t2) }
+        case (TypeConstructor.Arrow(len1), TypeConstructor.Arrow(len2)) if (len1 == len2) =>
+          val diffs = (tpe1.typeArguments.tail zip tpe2.typeArguments.tail).map { case (t1, t2) => diff(t1, t2) }
           mkApply(TypeDiff.Arrow, diffs)
         case _ => if (tc1 == tc2) TypeDiff.Other else TypeDiff.Mismatch(tpe1, tpe2)
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
@@ -128,7 +128,7 @@ object Documentor extends Phase[TypedAst.Root, TypedAst.Root] {
     * Returns the effect of the given function type `tpe0`.
     */
   private def getEffectType(tpe0: Type): Type = tpe0.typeConstructor match {
-    case Some(TypeConstructor.Arrow(_, eff)) => eff
+    case Some(TypeConstructor.Arrow(_)) => tpe0.typeArguments.head
     case _ => tpe0
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
@@ -587,7 +587,7 @@ object Finalize extends Phase[SimplifiedAst.Root, FinalAst.Root] {
 
           case TypeConstructor.Tuple(l) => MonoType.Tuple(args)
 
-          case TypeConstructor.Arrow(l, _) => MonoType.Arrow(args.init, args.last)
+          case TypeConstructor.Arrow(l) => MonoType.Arrow(args.drop(1).init, args.last)
 
           case TypeConstructor.RecordExtend(label) => MonoType.RecordExtend(label, args.head, args(1))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
@@ -708,7 +708,7 @@ object PatternExhaustiveness extends Phase[TypedAst.Root, TypedAst.Root] {
       case Some(TypeConstructor.Lattice) => 0
       case Some(TypeConstructor.RecordEmpty) => 0
       case Some(TypeConstructor.SchemaEmpty) => 0
-      case Some(TypeConstructor.Arrow(length, _)) => length
+      case Some(TypeConstructor.Arrow(length)) => length
       case Some(TypeConstructor.Array) => 1
       case Some(TypeConstructor.Channel) => 1
       case Some(TypeConstructor.Enum(sym, kind)) => 0 // TODO: Correct?

--- a/main/src/ca/uwaterloo/flix/language/phase/Synthesize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Synthesize.scala
@@ -555,7 +555,7 @@ object Synthesize extends Phase[Root, Root] {
 
           case TypeConstructor.Str => default
 
-          case TypeConstructor.Arrow(_, _) =>
+          case TypeConstructor.Arrow(_) =>
             val method = classOf[java.lang.Object].getMethod("equals", classOf[java.lang.Object])
             Expression.InvokeMethod(method, exp1, List(exp2), Type.Bool, Type.Pure, sl)
 
@@ -797,7 +797,7 @@ object Synthesize extends Phase[Root, Root] {
             val method = classOf[java.lang.String].getMethod("hashCode")
             Expression.InvokeMethod(method, exp0, Nil, Type.Str, Type.Pure, sl)
 
-          case TypeConstructor.Arrow(l, _) =>
+          case TypeConstructor.Arrow(l) =>
             val method = classOf[java.lang.Object].getMethod("hashCode")
             Expression.InvokeMethod(method, exp0, Nil, Type.Int32, Type.Pure, sl)
 
@@ -1046,7 +1046,7 @@ object Synthesize extends Phase[Root, Root] {
 
           case TypeConstructor.Str => exp0
 
-          case TypeConstructor.Arrow(l, _) =>
+          case TypeConstructor.Arrow(l) =>
             Expression.Str("<<closure>>", sl)
 
           case TypeConstructor.Array =>
@@ -1232,7 +1232,7 @@ object Synthesize extends Phase[Root, Root] {
       */
     // TODO: Deprecated
     def isArrow(tpe: Type): Boolean = tpe.typeConstructor match {
-      case Some(TypeConstructor.Arrow(_, _)) => true
+      case Some(TypeConstructor.Arrow(_)) => true
       case _ => false
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Substitution.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Substitution.scala
@@ -58,7 +58,6 @@ case class Substitution(m: Map[Type.Var, Type]) {
     def visit(t: Type): Type =
       t match {
         case x: Type.Var => m.getOrElse(x, x)
-        case Type.Cst(TypeConstructor.Arrow(l, eff)) => Type.Cst(TypeConstructor.Arrow(l, visit(eff)))
         case Type.Cst(tc) => t
         case Type.Apply(t1, t2) =>
           val y = visit(t2)

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -97,9 +97,6 @@ object Unification {
         else
           unifyVar(x, tpe1)
 
-      case (Type.Cst(TypeConstructor.Arrow(l1, eff1)), Type.Cst(TypeConstructor.Arrow(l2, eff2))) if l1 == l2 =>
-        BoolUnification.unify(eff1, eff2)
-
       case (Type.Cst(c1), Type.Cst(c2)) if c1 == c2 => Result.Ok(Substitution.empty)
 
       case _ if tpe1.kind == Kind.Bool || tpe2.kind == Kind.Bool =>

--- a/main/test/ca/uwaterloo/flix/language/debug/TestFormatType.scala
+++ b/main/test/ca/uwaterloo/flix/language/debug/TestFormatType.scala
@@ -360,7 +360,7 @@ class TestFormatType extends FunSuite with TestUtils {
   }
 
   test("FormatIllFormedType.Arrow.External.01") {
-    val tpe = Type.Cst(TypeConstructor.Arrow(2, Type.Pure))
+    val tpe = Type.Apply(Type.Cst(TypeConstructor.Arrow(2)), Type.Pure)
 
     val expected = "??? -> ???"
     val actual = FormatType.formatType(tpe)(Audience.External)
@@ -369,7 +369,7 @@ class TestFormatType extends FunSuite with TestUtils {
   }
 
   test("FormatIllFormedType.Arrow.External.02") {
-    val tpe = Type.mkApply(Type.Cst(TypeConstructor.Arrow(3, Type.Impure)), List(Type.Str))
+    val tpe = Type.mkApply(Type.Cst(TypeConstructor.Arrow(3)), List(Type.Impure, Type.Str))
 
     val expected = "String -> ??? ~> ???"
     val actual = FormatType.formatType(tpe)(Audience.External)
@@ -380,7 +380,7 @@ class TestFormatType extends FunSuite with TestUtils {
   ignore("FormatIllFormedType.Arrow.External.03") {
     val eff = Type.Var(0, Kind.Bool, Rigidity.Flexible)
     eff.setText("e")
-    val tpe = Type.mkApply(Type.Cst(TypeConstructor.Arrow(2, eff)), List(Type.Str, Type.Float32, Type.Int8))
+    val tpe = Type.mkApply(Type.Cst(TypeConstructor.Arrow(2)), List(eff, Type.Str, Type.Float32, Type.Int8))
 
     val expected = "(String -> Float32 & e)[Int8]"
     val actual = FormatType.formatType(tpe)(Audience.External)


### PR DESCRIPTION
Fixes https://github.com/flix/flix/issues/1224

Note that I chose to put the effect as the first parameter to the type constructor. This allowed for a slightly easier head/tail split for separating the proper types from the effect.