### PR TITLE
Adding distinct and distinctWith to List.

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -1077,12 +1077,69 @@ namespace List {
     pub def unfoldWithOkIter(next: Unit ~> Result[Option[a], e]): Result[List[a], e] & Impure = unfoldWithOkIterHelper(next, xs -> xs)
 
     ///
-    /// Helper function for `unfoldWithOkIter`
+    /// Helper function for `unfoldWithOkIter`.
     ///
     def unfoldWithOkIterHelper(next: Unit ~> Result[Option[a], e], k: Result[List[a], e] -> Result[List[a], e]): Result[List[a], e] & Impure = match next() {
         case Ok(None) => k(Ok(Nil))
         case Err(e) => k(Err(e))
         case Ok(Some(a)) => unfoldWithOkIterHelper(next, Result.flatMap(xs -> k(Ok(a :: xs))))
+    }
+
+    ///
+    /// Returns the list `xs` with duplicates removed. The first occurence of
+    /// an element is kept and except for the removal of subsequent duplicates
+    /// the order of `xs` is preserved.
+    ///
+    /// `distinct` uses the Flix's builtin equality test. Use `distinctWith` if you
+    /// need a custom equality test.
+    ///
+    pub def distinct(xs: List[a]): List[a] =
+        distinctHelper(xs, Nil, ks -> ks)
+
+    ///
+    /// Helper function for `distinct`.
+    ///
+    def distinctHelper(xs: List[a], ys: List[a], k: List[a] -> List[a]): List[a] = match xs {
+        case Nil => k(Nil)
+        case x :: rs =>
+            if (memberOf(x, ys))
+                distinctHelper(rs, ys, k)
+            else
+                distinctHelper(rs, (x :: ys), ks -> k(x :: ks))
+    }
+
+    ///
+    /// Returns the list `xs` with duplicates removed using the supplied function
+    /// `f` for comparison. The first occurence of an element is kept and except
+    /// for the removal of subsequent duplicates the order of `xs` is preserved.
+    ///
+    pub def distinctWith(f: (a, a) -> Bool, xs: List[a]): List[a] =
+        distinctWithHelper(f, xs, Nil, ks -> ks)
+
+    ///
+    /// Helper function for `distinctWith`.
+    ///
+    def distinctWithHelper(f: (a, a) -> Bool, xs: List[a], ys: List[a], k: List[a] -> List[a]): List[a] = match xs {
+        case Nil => k(Nil)
+        case x :: rs =>
+            if (memberOfWith(f, x, ys))
+                distinctWithHelper(f, rs, ys, k)
+            else
+                distinctWithHelper(f, rs, (x :: ys), ks -> k(x :: ks))
+    }
+
+    ///
+    /// Helper function for `distinctWith`.
+    ///
+    /// This is a generalization of `memberOf` that uses the function `f` for comparison.
+    ///
+    def memberOfWith(f: (a, a) -> Bool, x: a, xs: List[a]): Bool = match xs {
+        case Nil => false
+        case y :: rs =>
+            if (f(x, y))
+                true
+            else
+                memberOfWith(f, x, rs)
     }
 
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -1941,7 +1941,6 @@ def unfoldWithIter06(): Bool & Impure =
         };
     List.unfoldWithIter(step) == '0' :: '2' :: '4' :: '6' :: '8' :: Nil
 
-}
 
 /////////////////////////////////////////////////////////////////////////////
 // unfoldWithOkIter                                                        //
@@ -1981,3 +1980,85 @@ def unfoldWithOkIter03(): Bool & Impure =
             Ok(None)
         };
     List.unfoldWithOkIter(step) == Ok(1 :: 2 :: 3 :: 4 :: Nil)
+
+/////////////////////////////////////////////////////////////////////////////
+// distinct                                                                //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def distinct01(): Bool =
+    List.distinct(Nil) == Nil
+
+@test
+def distinct02(): Bool =
+    List.distinct(1 :: Nil) == 1 :: Nil
+
+@test
+def distinct03(): Bool =
+    List.distinct(1 :: 2 :: Nil) == 1 :: 2 :: Nil
+
+@test
+def distinct04(): Bool =
+    List.distinct(1 :: 1 :: 2 :: Nil) == 1 :: 2 :: Nil
+
+@test
+def distinct05(): Bool =
+    List.distinct(1 :: 2 :: 1 :: Nil) == 1 :: 2 :: Nil
+
+@test
+def distinct06(): Bool =
+    List.distinct(1 :: 2 :: 2 :: Nil) == 1 :: 2 :: Nil
+
+@test
+def distinct07(): Bool =
+    List.distinct(1 :: 2 :: 2 :: 3 :: Nil) == 1 :: 2 :: 3 :: Nil
+
+@test
+def distinct08(): Bool =
+    List.distinct(1 :: 2 :: 2 :: 3 :: 1 :: 4 :: Nil) == 1 :: 2 :: 3 :: 4 :: Nil
+
+@test
+def distinct09(): Bool =
+    List.distinct(4 :: 4 :: 3  :: 4 :: 2 :: 1 :: 1 :: Nil) == 4 :: 3 :: 2 :: 1 :: Nil
+
+/////////////////////////////////////////////////////////////////////////////
+// distinctWith                                                            //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def distinctWith01(): Bool =
+    List.distinctWith((x,y) -> x == y, Nil) == Nil
+
+@test
+def distinctWith02(): Bool =
+    List.distinctWith((x,y) -> x == y, 1 :: Nil) == 1 :: Nil
+
+@test
+def distinctWith03(): Bool =
+    List.distinctWith((x,y) -> x == y, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
+
+@test
+def distinctWith04(): Bool =
+    List.distinctWith((x,y) -> x == y, 1 :: 1 :: 2 :: Nil) == 1 :: 2 :: Nil
+
+@test
+def distinctWith05(): Bool =
+    List.distinctWith((x,y) -> x == y, 1 :: 2 :: 1 :: Nil) == 1 :: 2 :: Nil
+
+@test
+def distinctWith06(): Bool =
+    List.distinctWith((x,y) -> x == y, 1 :: 2 :: 2 :: Nil) == 1 :: 2 :: Nil
+
+@test
+def distinctWith07(): Bool =
+    List.distinctWith((x,y) -> x == y, 1 :: 2 :: 2 :: 3 :: Nil) == 1 :: 2 :: 3 :: Nil
+
+@test
+def distinctWith08(): Bool =
+    List.distinctWith((x,y) -> x == y, 1 :: 2 :: 2 :: 3 :: 1 :: 4 :: Nil) == 1 :: 2 :: 3 :: 4 :: Nil
+
+@test
+def distinctWith09(): Bool =
+    List.distinctWith((x,y) -> x == y, 4 :: 4 :: 3  :: 4 :: 2 :: 1 :: 1 :: Nil) == 4 :: 3 :: 2 :: 1 :: Nil
+
+}


### PR DESCRIPTION
This PR adds `distinct` and `distinctWith` to List which remove duplicates from the input list. 

`distinctWith` is the generalization with a user supplied equality test. `distinct` uses Flix's builtin in `(==)` via calling `memberOf`.

See issue #1293 Add nubBy (remove duplicates) to List
