### PR TITLE
add tailrec annotation and check

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -248,6 +248,7 @@ class Flix {
         Stratifier |>
         PatternExhaustiveness |>
         Redundancy |>
+        TailrecCheck |>
         Linter |>
         Safety
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -113,6 +113,15 @@ object Ast {
     }
 
     /**
+      * An AST node that represents a `@tailrec` annotatino.
+      *
+      * @param loc the source location of the annotation.
+      */
+    case class Tailrec(loc: SourceLocation) extends Annotation {
+      override def toString: String = "@tailrec"
+    }
+
+    /**
       * An AST node that represents a `@test` annotation.
       *
       * A function marked with `test` is evaluated as part of the test framework.
@@ -198,6 +207,11 @@ object Ast {
       * Returns `true` if `this` sequence contains the `@unchecked` annotation.
       */
     def isUnchecked: Boolean = annotations exists (_.isInstanceOf[Annotation.Unchecked])
+
+    /**
+      * Returns `true` if `this` sequence contains the `@tailrec` annotation.
+      */
+    def isTailrec: Boolean = annotations exists (_.isInstanceOf[Annotation.Tailrec])
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/errors/NonTailRecursiveCallError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/NonTailRecursiveCallError.scala
@@ -1,0 +1,31 @@
+package ca.uwaterloo.flix.language.errors
+
+import ca.uwaterloo.flix.language.CompilationError
+import ca.uwaterloo.flix.language.ast.SourceLocation
+import ca.uwaterloo.flix.util.vt.VirtualString.{Code, Line, NewLine, Red, Underline}
+import ca.uwaterloo.flix.util.vt.VirtualTerminal
+
+case class NonTailRecursiveCallError(loc: SourceLocation) extends CompilationError {
+  /**
+    * Returns the kind of error message, e.g. "Syntax Error" or "Type Error".
+    */
+  override def kind: String = "Non-tail-recursive call Error."
+
+  /**
+    * Returns a short description of the error message.
+    */
+  override def summary: String = "Non-tail-recursive call."
+
+  /**
+    * Returns the formatted error message.
+    */
+  override def message: VirtualTerminal = {
+    val vt = new VirtualTerminal
+    vt << Line(kind, source.format) << NewLine
+    vt << ">> Non-tail-recursive call."
+    vt << NewLine
+    vt << Code(loc, "call not in tail position.")
+    vt << NewLine
+    vt << Underline("Tip:") << " Refactor the function to use tail recursion, or remove the @tailrec annotation." << NewLine
+  }
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/TailrecCheck.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TailrecCheck.scala
@@ -1,0 +1,170 @@
+package ca.uwaterloo.flix.language.phase
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.CompilationError
+import ca.uwaterloo.flix.language.ast.Ast.Annotation
+import ca.uwaterloo.flix.language.ast.TypedAst
+import ca.uwaterloo.flix.language.ast.TypedAst.Expression
+import ca.uwaterloo.flix.language.errors.NonTailRecursiveCallError
+import ca.uwaterloo.flix.util.{InternalCompilerException, Validation}
+import ca.uwaterloo.flix.util.Validation.{ToFailure, ToSuccess}
+
+object TailrecCheck extends Phase[TypedAst.Root, TypedAst.Root] {
+
+  override def run(input: TypedAst.Root)(implicit flix: Flix): Validation[TypedAst.Root, CompilationError] = {
+    val annotatedDefs = input.defs.values.filter(_.ann.exists(_.name.isInstanceOf[Annotation.Tailrec])) // MATT don't we have a better annotation checking mechanism?
+    Validation.mapN(Validation.sequence(annotatedDefs.map(tailRecCheck))) {
+      _ => input
+    }
+  }
+
+
+  private def tailRecCheck(defn0: TypedAst.Def): Validation[Unit, CompilationError] = {
+    def visit(exp0: TypedAst.Expression, isTail: Boolean): Validation[Unit, CompilationError] = exp0 match {
+      case Expression.Unit(loc) => ().toSuccess
+      case Expression.Null(tpe, loc) => ().toSuccess
+      case Expression.True(loc) => ().toSuccess
+      case Expression.False(loc) => ().toSuccess
+      case Expression.Char(lit, loc) => ().toSuccess
+      case Expression.Float32(lit, loc) => ().toSuccess
+      case Expression.Float64(lit, loc) => ().toSuccess
+      case Expression.Int8(lit, loc) => ().toSuccess
+      case Expression.Int16(lit, loc) => ().toSuccess
+      case Expression.Int32(lit, loc) => ().toSuccess
+      case Expression.Int64(lit, loc) => ().toSuccess
+      case Expression.BigInt(lit, loc) => ().toSuccess
+      case Expression.Str(lit, loc) => ().toSuccess
+      case Expression.Default(tpe, loc) => ().toSuccess
+      case Expression.Wild(tpe, loc) => ().toSuccess
+      case Expression.Var(sym, tpe, loc) => ().toSuccess
+      case Expression.Def(sym, tpe, loc) => ().toSuccess
+      case Expression.Sig(sym, tpe, loc) => ().toSuccess
+      case Expression.Hole(sym, tpe, eff, loc) => ().toSuccess
+      case Expression.Lambda(fparam, exp, tpe, loc) => ().toSuccess
+      case Expression.Apply(Expression.Def(defn, _, _), exps, tpe, eff, loc) if !isTail && defn == defn0.sym && defn0.fparams.length == exps.length =>
+        NonTailRecursiveCallError(loc).toFailure
+      case Expression.Apply(exp, exps, tpe, eff, loc) =>
+        for {
+          _ <- visit(exp, false)
+          _ <- Validation.sequence(exps.map(visit(_, false)))
+        } yield ()
+      case Expression.Unary(op, exp, tpe, eff, loc) => visit(exp, false)
+      case Expression.Binary(op, exp1, exp2, tpe, eff, loc) =>
+        Validation.mapN(visit(exp1, false), visit(exp2, false)) {
+          case _ => ()
+        }
+      case Expression.Let(sym, exp1, exp2, tpe, eff, loc) =>
+        Validation.mapN(visit(exp1, false), visit(exp2, isTail)) {
+          case _ => ()
+        }
+      case Expression.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
+        Validation.mapN(visit(exp1, false), visit(exp2, isTail), visit(exp3, isTail)) {
+          case _ => ()
+        }
+      case Expression.Stm(exp1, exp2, tpe, eff, loc) =>
+        Validation.mapN(visit(exp1, false), visit(exp2, isTail)) {
+          case _ => ()
+        }
+      case Expression.Match(exp, rules, tpe, eff, loc) =>
+        for {
+          _ <- visit(exp, false)
+          _ <- Validation.sequence(rules.map { rule => visit(rule.guard, false) })
+          _ <- Validation.sequence(rules.map { rule => visit(rule.exp, isTail) })
+        } yield ()
+      case Expression.NullMatch(exps, rules, tpe, eff, loc) =>
+        for {
+          _ <- Validation.sequence(exps.map { exp => visit(exp, false) })
+          _ <- Validation.sequence(rules.map { rule => visit(rule.exp, isTail) })
+        } yield ()
+      case Expression.Tag(sym, tag, exp, tpe, eff, loc) => visit(exp, isTail) // MATT ?
+      case Expression.Tuple(elms, tpe, eff, loc) =>
+        Validation.mapN(Validation.sequence(elms.map(visit(_, false)))) {
+          _: List[Unit] => ()
+        }
+      case Expression.RecordEmpty(tpe, loc) => ().toSuccess
+      case Expression.RecordSelect(exp, label, tpe, eff, loc) => visit(exp, false)
+      case Expression.RecordExtend(label, value, rest, tpe, eff, loc) =>
+        Validation.mapN(visit(value, false), visit(rest, false)) {
+          case _ => ()
+        }
+      case Expression.RecordRestrict(label, rest, tpe, eff, loc) => visit(rest, false)
+      case Expression.ArrayLit(elms, tpe, eff, loc) =>
+        Validation.mapN(Validation.sequence(elms.map(visit(_, false)))) {
+          _: List[Unit] => ()
+        }
+      case Expression.ArrayNew(elm, len, tpe, eff, loc) =>
+        Validation.mapN(visit(elm, false), visit(len, false)) {
+          case _ => ()
+        }
+      case Expression.ArrayLoad(base, index, tpe, eff, loc) =>
+        Validation.mapN(visit(base, false), visit(index, false)) {
+          case _ => ()
+        }
+      case Expression.ArrayLength(base, eff, loc) => visit(base, false)
+      case Expression.ArrayStore(base, index, elm, loc) =>
+        Validation.mapN(visit(base, false), visit(index, false)) {
+          case _ => ()
+        }
+      case Expression.ArraySlice(base, beginIndex, endIndex, tpe, loc) =>
+        Validation.mapN(visit(base, false), visit(beginIndex, false), visit(base, false)) {
+          case _ => ()
+        }
+      case Expression.Ref(exp, tpe, eff, loc) => visit(exp, false)
+      case Expression.Deref(exp, tpe, eff, loc) => visit(exp, false)
+      case Expression.Assign(exp1, exp2, tpe, eff, loc) =>
+        Validation.mapN(visit(exp1, false), visit(exp2, false)) {
+          case _ => ()
+        }
+      case Expression.Existential(fparam, exp, loc) => visit(exp, false)
+      case Expression.Universal(fparam, exp, loc) => visit(exp, false)
+      case Expression.Ascribe(exp, tpe, eff, loc) => visit(exp, isTail) // MATT ?
+      case Expression.Cast(exp, tpe, eff, loc) => visit(exp, isTail) // MATT ?
+      case Expression.TryCatch(exp, rules, tpe, eff, loc) =>
+        for {
+          _ <- visit(exp, false)
+          _ <- Validation.sequence(rules.map { rule => visit(rule.exp, isTail) })
+        } yield () // MATT idk how to deal with this but it's going away soon anyway I think?
+      case Expression.InvokeConstructor(constructor, args, tpe, eff, loc) =>
+        Validation.mapN(Validation.sequence(args.map(visit(_, false)))) {
+          _: List[Unit] => ()
+        }
+      case Expression.InvokeMethod(method, exp, args, tpe, eff, loc) =>
+        Validation.mapN(Validation.sequence(args.map(visit(_, false)))) {
+          _: List[Unit] => ()
+        }
+      case Expression.InvokeStaticMethod(method, args, tpe, eff, loc) =>
+        Validation.mapN(Validation.sequence(args.map(visit(_, false)))) {
+          _: List[Unit] => ()
+        }
+      case Expression.GetField(field, exp, tpe, eff, loc) => visit(exp, false) // MATT
+      case Expression.PutField(field, exp1, exp2, tpe, eff, loc) =>
+        Validation.mapN(visit(exp1, false), visit(exp2, false)) {
+          case _ => ()
+        }
+      case Expression.GetStaticField(field, tpe, eff, loc) => ().toSuccess
+      case Expression.PutStaticField(field, exp, tpe, eff, loc) => visit(exp, false)
+      case Expression.NewChannel(exp, tpe, eff, loc) => visit(exp, false)
+      case Expression.GetChannel(exp, tpe, eff, loc) => visit(exp, false)
+      case Expression.PutChannel(exp1, exp2, tpe, eff, loc) =>
+        Validation.mapN(visit(exp1, false), visit(exp2, false)) {
+          case _ => ()
+        }
+      case Expression.SelectChannel(rules, default, tpe, eff, loc) =>
+        for {
+          _ <- Validation.sequence(rules.map { rule => visit(rule.exp, isTail) }) // MATT ?
+          _ <- default.map(visit(_, isTail)).getOrElse(().toSuccess) // MATT ?
+        } yield ()
+      case Expression.Spawn(exp, tpe, eff, loc) => visit(exp, false)
+      case Expression.Lazy(exp, tpe, loc) => visit(exp, false)
+      case Expression.Force(exp, tpe, eff, loc) => visit(exp, false)
+      case Expression.FixpointConstraintSet(cs, tpe, loc) => throw InternalCompilerException("Unexpected expression.") // MATT
+      case Expression.FixpointCompose(exp1, exp2, tpe, eff, loc) => throw InternalCompilerException("Unexpected expression.") // MATT
+      case Expression.FixpointSolve(exp, stf, tpe, eff, loc) => throw InternalCompilerException("Unexpected expression.") // MATT
+      case Expression.FixpointProject(name, exp, tpe, eff, loc) => throw InternalCompilerException("Unexpected expression.") // MATT
+      case Expression.FixpointEntails(exp1, exp2, tpe, eff, loc) => throw InternalCompilerException("Unexpected expression.") // MATT
+      case Expression.FixpointFold(name, exp1, exp2, exp3, tpe, eff, loc) => throw InternalCompilerException("Unexpected expression.") // MATT
+    }
+
+    visit(defn0.exp, true)
+  }
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1522,6 +1522,7 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
           case "deprecated" => WeededAst.Annotation(Ast.Annotation.Deprecated(loc), args, loc).toSuccess
           case "law" => WeededAst.Annotation(Ast.Annotation.Law(loc), args, loc).toSuccess
           case "lint" => WeededAst.Annotation(Ast.Annotation.Lint(loc), args, loc).toSuccess
+          case "tailrec" => WeededAst.Annotation(Ast.Annotation.Tailrec(loc), args, loc).toSuccess
           case "test" => WeededAst.Annotation(Ast.Annotation.Test(loc), args, loc).toSuccess
           case "unchecked" => WeededAst.Annotation(Ast.Annotation.Unchecked(loc), args, loc).toSuccess
           case "Time" => WeededAst.Annotation(Ast.Annotation.Time(loc), args, loc).toSuccess

--- a/main/test/ca/uwaterloo/flix/language/phase/PhaseSuite.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/PhaseSuite.scala
@@ -24,6 +24,7 @@ class PhaseSuite extends Suites(
   new TestNamer,
   new TestPatExhaustiveness,
   new TestRedundancy,
+  new TestTailRecCheck,
   new TestResolver,
   new TestSafety,
   new TestTyper,

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTailRecCheck.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTailRecCheck.scala
@@ -1,0 +1,41 @@
+package ca.uwaterloo.flix.language.phase
+
+import ca.uwaterloo.flix.TestUtils
+import ca.uwaterloo.flix.language.errors.NonTailRecursiveCallError
+import ca.uwaterloo.flix.util.Options
+import org.scalatest.FunSuite
+
+class TestTailRecCheck extends FunSuite with TestUtils {
+
+  val DefaultOptions: Options = Options.DefaultTest.copy(core = true)
+
+  test("NonTailRecursiveCallError.01") {
+    val input =
+      s"""
+         |@tailrec
+         |def fact(i: Int): Int =
+         |  if (i == 1)
+         |    1
+         |  else
+         |    i * fact(i - 1)
+         |
+       """.stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[NonTailRecursiveCallError](result)
+  }
+
+  test("NonTailRecursiveCallError.02") {
+    val input =
+      s"""
+         |@tailrec
+         |def fact(i: Int, acc: Int): Int =
+         |  if (i == 1)
+         |    acc
+         |  else
+         |    fact(i - 1, acc * i)
+         |
+       """.stripMargin
+    val result = compile(input, DefaultOptions)
+    result.get
+  }
+}


### PR DESCRIPTION
Fixes #905 

Might be better to include in a different phase but as there's no AST transformation, I imagine the impact is pretty low.

The idea is all there, before pulling, I still need to:

- [ ] cleanup all the repetitive monad business
- [ ] expand test coverage
- [ ] handle fixpoint-related expressions
- [ ] remove any other `// MATT` tags
- [ ] add license comments to new files