### PR TITLE
Introduce Choice Data Type, Part V

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -716,6 +716,7 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
         //
         // Build the entire Boolean formula.
         //
+        // TODO: Boolean simplification.
         val cond = mkOuterPrecondition(isAbsentVars, isPresentVars)
         val body = mkOuterDisj(rules0, isAbsentVars, isPresentVars)
         val formula = Type.mkImplies(cond, body)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -729,9 +729,9 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
               val maybeBoth = !mustbeAbsent && !mustbePresent
 
               if (mustbeAbsent) {
-                Type.mkAnd(isAllSame(isAbsentVar, isPresentVar, allPats), isExhaustive(restAbsentVars, restPresentVars, absentTails, allPats))
+                Type.mkAnd(isAllSame(isAbsentVar, isPresentVar, allPats), isExhaustive(restAbsentVars, restPresentVars, absentTails, allPats.map(_.tail)))
               } else if (mustbePresent) {
-                Type.mkAnd(isAllSame(isAbsentVar, isPresentVar, allPats), isExhaustive(restAbsentVars, restPresentVars, presentTails, allPats))
+                Type.mkAnd(isAllSame(isAbsentVar, isPresentVar, allPats), isExhaustive(restAbsentVars, restPresentVars, presentTails, allPats.map(_.tail)))
               } else {
                 // TODO: True, so can recurse.
                 val x = isExhaustive(restAbsentVars, restPresentVars, absentTails, allPats.map(_.tail)) // TODO: use pat match

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -743,7 +743,12 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
 
         // TODO: DOC
 
-        def isAllSame(isPresentVar: Type.Var, isAbsentVar: Type.Var, pats: List[List[ResolvedAst.ChoicePattern]]): Type = {
+        /**
+          * Returns a Boolean constraint that is `true` iff the first
+          * pattern is either always `Absent` or `Present` and the corresponding `isAbsentVar` or `isPresentVar`
+          * are set correspondingly.
+          */
+        def isAllSame(isAbsentVar: Type.Var, isPresentVar: Type.Var, pats: List[List[ResolvedAst.ChoicePattern]]): Type = {
           val isAllAbsent = pats.forall {
             case ResolvedAst.ChoicePattern.Absent(_) :: _ => true
             case _ => false
@@ -778,9 +783,9 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
         // Build the entire Boolean formula.
         //
         // TODO: Boolean simplification.
-        val f = mkOuterDisj(rules0, isAbsentVars, isPresentVars)
-        val exhaust = mkExhaustiveCond(isAbsentVars, isPresentVars, rules0)
-        val formula = Type.mkOr(f, exhaust)
+        val outerDisj = mkOuterDisj(rules0, isAbsentVars, isPresentVars)
+        val exhaustiveCond = mkExhaustiveCond(isAbsentVars, isPresentVars, rules0)
+        val formula = Type.mkOr(outerDisj, exhaustiveCond)
         println(FormatType.formatType(formula)(Audience.Internal))
 
         //

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -690,8 +690,9 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
           seqM(rs.map(unifyWithRule))
         }
 
-
-        // TODO: DOC
+        /**
+          * Returns a Boolean formula that is `true` when the given choice rules `rs` are exhaustive.
+          */
         def mkExhaustiveCond(isAbsentVars: List[Type.Var], isPresentVars: List[Type.Var], rs: List[ResolvedAst.ChoiceRule]): Type = {
           val xs = rs.map(_.pat)
           isExhaustive(isAbsentVars, isPresentVars, xs, xs)
@@ -721,11 +722,11 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
               } else if (mustbePresent) {
                 Type.mkAnd(isSamePat(isAbsentVar, isPresentVar, allPats), isExhaustive(restAbsentVars, restPresentVars, presentTails, allPats.map(_.tail)))
               } else {
-                // TODO: True, so can recurse.
                 val x = isExhaustive(restAbsentVars, restPresentVars, absentTails, allPats.map(_.tail)) // TODO: use pat match
                 val y = isExhaustive(restAbsentVars, restPresentVars, presentTails, allPats.map(_.tail))
                 Type.mkAnd(x, y)
               }
+
             case (xs, ys) => throw InternalCompilerException(s"Mismatched isAbsentVars: '$xs' and isPresentVars: '$ys'.")
           }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -784,7 +784,6 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
         val outerDisj = mkOuterDisj(rules0, isAbsentVars, isPresentVars)
         val exhaustiveCond = mkExhaustiveCond(isAbsentVars, isPresentVars, rules0)
         val formula = Type.mkOr(outerDisj, exhaustiveCond)
-        println(FormatType.formatType(formula)(Audience.Internal))
 
         //
         // Put everything together.

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -695,6 +695,7 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
           *
           * That is, a match variable *cannot* have the type `Choice[a, false, false]`.
           */
+          // TODO: Remove?
         def mkOuterPrecondition(isAbsentVars: List[Type.Var], isPresentVars: List[Type.Var]): Type = (isAbsentVars, isPresentVars) match {
           case (Nil, Nil) => Type.True
           case (isAbsentVar :: xs, isPresentVar :: ys) =>
@@ -717,9 +718,7 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
         // Build the entire Boolean formula.
         //
         // TODO: Boolean simplification.
-        val cond = mkOuterPrecondition(isAbsentVars, isPresentVars)
-        val body = mkOuterDisj(rules0, isAbsentVars, isPresentVars)
-        val formula = Type.mkImplies(cond, body)
+        val formula =  mkOuterDisj(rules0, isAbsentVars, isPresentVars)
         println(FormatType.formatType(formula)(Audience.Internal))
 
         //

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -729,9 +729,9 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
               val maybeBoth = !mustbeAbsent && !mustbePresent
 
               if (mustbeAbsent) {
-                Type.mkOr(Type.False, isAllSame(isAbsentVar, isPresentVar, allPats))
+                Type.mkAnd(isAllSame(isAbsentVar, isPresentVar, allPats), isExhaustive(restAbsentVars, restPresentVars, absentTails, allPats))
               } else if (mustbePresent) {
-                Type.mkOr(Type.False, isAllSame(isAbsentVar, isPresentVar, allPats))
+                Type.mkAnd(isAllSame(isAbsentVar, isPresentVar, allPats), isExhaustive(restAbsentVars, restPresentVars, presentTails, allPats))
               } else {
                 // TODO: True, so can recurse.
                 val x = isExhaustive(restAbsentVars, restPresentVars, absentTails, allPats.map(_.tail)) // TODO: use pat match

--- a/main/src/library/Choice.flix
+++ b/main/src/library/Choice.flix
@@ -34,9 +34,9 @@ namespace Choice {
     ///
     /// Returns the given choice `c` as an `Option`.
     ///
-//    pub def toOption[a, isAbsent :# Bool, isPresent :# Bool](c: Choice[a, isAbsent, isPresent]): Option[a] = choose c {
-//        case Absent     => None
-//        case Present(v) => Some(v)
-//    }
+    pub def toOption[a, isAbsent :# Bool, isPresent :# Bool](c: Choice[a, isAbsent, isPresent]): Option[a] = choose c {
+        case Absent     => None
+        case Present(v) => Some(v)
+    }
 
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -659,7 +659,7 @@ class TestTyper extends FunSuite with TestUtils {
       """
         |pub def f(x: Choice[String, true, _]): Int32 =
         |    choose x {
-        |        case Absent     => 1
+        |        case Absent => 1
         |    }
         |
         |pub enum Choice[a, _isAbsent :# Bool, _isPresent :# Bool] {
@@ -669,7 +669,25 @@ class TestTyper extends FunSuite with TestUtils {
         |
       """.stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[TypeError.MismatchedBools](result)
+    expectError[TypeError.GeneralizationError](result)
+  }
+
+  test("TestLeq.Choice.02") {
+    val input =
+      """
+        |pub def f(x: Choice[String, _, true]): Int32 =
+        |    choose x {
+        |        case Present(_) => 1
+        |    }
+        |
+        |pub enum Choice[a, _isAbsent :# Bool, _isPresent :# Bool] {
+        |    case Absent
+        |    case Present(a)
+        |}
+        |
+      """.stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[TypeError.GeneralizationError](result)
   }
 
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -124,65 +124,6 @@ class TestTyper extends FunSuite with TestUtils {
     expectError[TypeError.OccursCheckError](result)
   }
 
-  // TODO
-  ignore("TestLeq.Choice.01") {
-    val input =
-      """
-        |pub def f(x: Choice[String, false, _], y: Choice[String, true, _], z: Choice[String, false, _]): Bool =
-        |    choose (x, y, z) {
-        |        case (Present(a), Present(b), _) => a == "Hello" && b == "World"
-        |        case (_, Present(b), Present(c)) => b == "World" && c == "!"
-        |    }
-        |
-        |pub enum Choice[a, _isAbsent :# Bool, _isPresent :# Bool] {
-        |    case Absent
-        |    case Present(a)
-        |}
-        |
-      """.stripMargin
-    val result = compile(input, DefaultOptions)
-    expectError[TypeError.MismatchedBools](result)
-  }
-
-  // TODO
-  ignore("TestLeq.Choice.02") {
-    val input =
-      """
-        |pub def f(x: Choice[String, true, _], y: Choice[String, false, _], z: Choice[String, true, _]): Bool =
-        |    choose (x, y, z) {
-        |        case (Present(a), Present(b), _) => a == "Hello" && b == "World"
-        |        case (_, Present(b), Present(c)) => b == "World" && c == "!"
-        |    }
-        |
-        |pub enum Choice[a, _isAbsent :# Bool, _isPresent :# Bool] {
-        |    case Absent
-        |    case Present(a)
-        |}
-        |
-      """.stripMargin
-    val result = compile(input, DefaultOptions)
-    expectError[TypeError.MismatchedBools](result)
-  }
-
-  // TODO
-  ignore("TestLeq.Choice.03") {
-    val input =
-      """
-        |def f(x: Choice[String, not not n, _], y: Choice[String, not not n, _]): Bool =
-        |    choose (x, y) {
-        |        case (Present(a), _) => a == "Hello"
-        |    }
-        |
-        |pub enum Choice[a, _isAbsent :# Bool, _isPresent :# Bool] {
-        |    case Absent
-        |    case Present(a)
-        |}
-        |
-      """.stripMargin
-    val result = compile(input, DefaultOptions)
-    expectError[TypeError.GeneralizationError](result)
-  }
-
   test("TestMismatchedKinds.01") {
     val input = "def f(): {| x} = {a = 2} <+> {a = 2}"
     val result = compile(input, DefaultOptions)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -654,4 +654,22 @@ class TestTyper extends FunSuite with TestUtils {
     expectError[TypeError.MismatchedBools](result)
   }
 
+  test("TestLeq.Choice.01") {
+    val input =
+      """
+        |pub def f(x: Choice[String, true, _]): Int32 =
+        |    choose x {
+        |        case Absent     => 1
+        |    }
+        |
+        |pub enum Choice[a, _isAbsent :# Bool, _isPresent :# Bool] {
+        |    case Absent
+        |    case Present(a)
+        |}
+        |
+      """.stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[TypeError.MismatchedBools](result)
+  }
+
 }

--- a/main/test/ca/uwaterloo/flix/library/TestChoice.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestChoice.flix
@@ -18,11 +18,11 @@ namespace TestChoice {
     @test
     def unbox01(): Bool = Choice.unbox(Present("a")) == "a"
 
-//    @test
-//    def toOption01(): Bool = Choice.toOption(Absent) == None
-//
-//    @test
-//    def toOption02(): Bool = Choice.toOption(Present("a")) == Some("a")
+    @test
+    def toOption01(): Bool = Choice.toOption(Absent) == None
+
+    @test
+    def toOption02(): Bool = Choice.toOption(Present("a")) == Some("a")
 
 }
 

--- a/main/test/flix/Test.Def.Generalization.flix
+++ b/main/test/flix/Test.Def.Generalization.flix
@@ -162,4 +162,37 @@ namespace Test/Def/Generalization {
     @test
     def testLeq28(): (Unit -> b & {e1, e2, e3}) -> b & {e3, e2, e1} = f -> f()
 
+    @test
+    def testLeq29(x: Choice[String, true, true]): Int32 =
+        choose x {
+            case Absent     => 1
+            case Present(_) => 2
+        }
+
+    @test
+    def testLeq30(x: Choice[String, _, true]): Int32 =
+        choose x {
+            case Absent     => 1
+            case Present(_) => 2
+        }
+
+    @test
+    def testLeq31(x: Choice[String, true, _]): Int32 =
+        choose x {
+            case Absent     => 1
+            case Present(_) => 2
+        }
+
+    @test
+    def testLeq32(x: Choice[String, _, _]): Int32 =
+        choose x {
+            case Absent     => 1
+            case Present(_) => 2
+        }
+
+    pub enum Choice[a, _isAbsent :# Bool, _isPresent :# Bool] {
+        case Absent
+        case Present(a)
+    }
+
 }

--- a/main/test/flix/Test.Exp.Choose.flix
+++ b/main/test/flix/Test.Exp.Choose.flix
@@ -476,6 +476,26 @@ namespace Test/Exp/Choose {
         };
         f(if (true) Absent else Present(123), if (true) Absent else Present(456)) == 1
 
+    @test
+    def testChooseIf09(): Bool =
+        let f = (x, y) -> {
+            choose (x, y) {
+                case (Absent, Absent)           => 1
+                case (Present(_), Absent)       => 2
+            }
+        };
+        f(if (true) Absent else Present(123), Absent) == 1
+
+    @test
+    def testChooseIf10(): Bool =
+        let f = (x, y) -> {
+            choose (x, y) {
+                case (Absent, Present(_))       => 1
+                case (Present(_), Present(_))   => 2
+            }
+        };
+        f(if (true) Absent else Present(123), Present(456)) == 1
+
 }
 
 pub enum Choice[a, _isAbsent :# Bool, _isPresent :# Bool] {

--- a/main/test/flix/Test.Exp.Choose.flix
+++ b/main/test/flix/Test.Exp.Choose.flix
@@ -496,6 +496,26 @@ namespace Test/Exp/Choose {
         };
         f(if (true) Absent else Present(123), Present(456)) == 1
 
+    @test
+    def testChooseIf11(): Bool =
+        let f = (x, y) -> {
+            choose (x, y) {
+                case (Absent, Absent)     => 1
+                case (Absent, Present(_)) => 2
+            }
+        };
+        f(Absent, if (true) Absent else Present(123)) == 1
+
+    @test
+    def testChooseIf12(): Bool =
+        let f = (x, y) -> {
+            choose (x, y) {
+                case (Present(_), Absent)     => 1
+                case (Present(_), Present(_)) => 2
+            }
+        };
+        f(Present(123), if (true) Absent else Present(456)) == 1
+
 }
 
 pub enum Choice[a, _isAbsent :# Bool, _isPresent :# Bool] {

--- a/main/test/flix/Test.Exp.Choose.flix
+++ b/main/test/flix/Test.Exp.Choose.flix
@@ -416,6 +416,67 @@ namespace Test/Exp/Choose {
         };
         f(if (true) Absent else Present(123)) == 1
 
+    @test
+    def testChooseIf04(): Bool =
+        let f = (x, y) -> {
+            choose (x, y) {
+                case (Absent, Absent)           => 1
+                case (Present(_), Absent)       => 2
+                case (Absent, Present(_))       => 3
+                case (Present(_), Present(_))   => 4
+            }
+        };
+        f(if (true) Absent else Present(123), Absent) == 1
+
+    @test
+    def testChooseIf05(): Bool =
+        let f = (x, y) -> {
+            choose (x, y) {
+                case (Absent, Absent)           => 1
+                case (Present(_), Absent)       => 2
+                case (Absent, Present(_))       => 3
+                case (Present(_), Present(_))   => 4
+            }
+        };
+        f(if (true) Absent else Present(123), Present(456)) == 3
+
+    @test
+    def testChooseIf06(): Bool =
+        let f = (x, y) -> {
+            choose (x, y) {
+                case (Absent, Absent)           => 1
+                case (Present(_), Absent)       => 2
+                case (Absent, Present(_))       => 3
+                case (Present(_), Present(_))   => 4
+            }
+        };
+        f(Absent, if (true) Absent else Present(123)) == 1
+
+    @test
+    def testChooseIf07(): Bool =
+        let f = (x, y) -> {
+            choose (x, y) {
+                case (Absent, Absent)           => 1
+                case (Present(_), Absent)       => 2
+                case (Absent, Present(_))       => 3
+                case (Present(_), Present(_))   => 4
+            }
+        };
+        f(Present(123), if (true) Absent else Present(456)) == 2
+
+
+    @test
+    def testChooseIf08(): Bool =
+        let f = (x, y) -> {
+            choose (x, y) {
+                case (Absent, Absent)           => 1
+                case (Present(_), Absent)       => 2
+                case (Absent, Present(_))       => 3
+                case (Present(_), Present(_))   => 4
+            }
+        };
+        f(if (true) Absent else Present(123), if (true) Absent else Present(456)) == 1
+
 }
 
 pub enum Choice[a, _isAbsent :# Bool, _isPresent :# Bool] {

--- a/main/test/flix/Test.Exp.Choose.flix
+++ b/main/test/flix/Test.Exp.Choose.flix
@@ -386,6 +386,36 @@ namespace Test/Exp/Choose {
         };
         f(Present("a"), Absent) == "a"
 
+    @test
+    def testChooseIf01(): Bool =
+        let f = x -> {
+            choose x {
+                case Absent     => 1
+                case _          => 2
+            }
+        };
+        f(if (true) Absent else Present(123)) == 1
+
+    @test
+    def testChooseIf02(): Bool =
+        let f = x -> {
+            choose x {
+                case Present(_) => 1
+                case _          => 2
+            }
+        };
+        f(if (true) Absent else Present(123)) == 2
+
+    @test
+    def testChooseIf03(): Bool =
+        let f = x -> {
+            choose x {
+                case Absent     => 1
+                case Present(_) => 2
+            }
+        };
+        f(if (true) Absent else Present(123)) == 1
+
 }
 
 pub enum Choice[a, _isAbsent :# Bool, _isPresent :# Bool] {

--- a/main/test/flix/Test.Exp.Choose.flix
+++ b/main/test/flix/Test.Exp.Choose.flix
@@ -342,16 +342,16 @@ namespace Test/Exp/Choose {
         };
         f(Absent, Present("b")) == "b"
 
-//    @test
-//    def testChooseTwoWithThreeCases03(): Bool =
-//        let f = (x, y) -> {
-//            choose (x, y) {
-//                case (Absent, Absent)     => "a"
-//                case (Absent, Present(y)) => y
-//                case (Present(x), Absent) => x
-//            }
-//        };
-//        f(Present("b"), Absent) == "b"
+    @test
+    def testChooseTwoWithThreeCases03(): Bool =
+        let f = (x, y) -> {
+            choose (x, y) {
+                case (Absent, Absent)     => "a"
+                case (Absent, Present(y)) => y
+                case (Present(x), Absent) => x
+            }
+        };
+        f(Present("b"), Absent) == "b"
 
     @test
     def testChooseTwoWithThreeCases04(): Bool =
@@ -463,7 +463,6 @@ namespace Test/Exp/Choose {
             }
         };
         f(Present(123), if (true) Absent else Present(456)) == 2
-
 
     @test
     def testChooseIf08(): Bool =


### PR DESCRIPTION
Tasks:
- [x] Add tests with if expressions.
- [x] Add tests with primitive values.
- [x] Add negative tests.
- [x] Add tests with generalization.
- [ ] Add combinators to `Choice` namespace.
- [ ] Add Boolean simplifier.
- [ ] Add test cases to benchmarks.
- [ ] Fix typing with wildcards.

Decisions:
- [ ] Do we want some syntactic sugar for the `Choice` type?
