### PR TITLE
Tail Recursion Modulo Cons

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/FinalAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/FinalAst.scala
@@ -151,6 +151,8 @@ object FinalAst {
 
     case class Index(base: FinalAst.Expression, offset: scala.Int, tpe: MonoType, loc: SourceLocation) extends FinalAst.Expression
 
+    case class IndexMut(base: FinalAst.Expression, offset: scala.Int, toInsert: FinalAst.Expression, tpe: MonoType, loc: SourceLocation) extends FinalAst.Expression
+
     case class Tuple(elms: List[FinalAst.Expression], tpe: MonoType, loc: SourceLocation) extends FinalAst.Expression
 
     case class RecordEmpty(tpe: MonoType, loc: SourceLocation) extends FinalAst.Expression

--- a/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
@@ -177,6 +177,8 @@ object SimplifiedAst {
 
     case class Index(base: SimplifiedAst.Expression, offset: scala.Int, tpe: Type, loc: SourceLocation) extends SimplifiedAst.Expression
 
+    case class IndexMut(base: SimplifiedAst.Expression, offset: scala.Int, toInsert: SimplifiedAst.Expression, tpe: Type, loc: SourceLocation) extends SimplifiedAst.Expression
+
     case class Tuple(elms: List[SimplifiedAst.Expression], tpe: Type, loc: SourceLocation) extends SimplifiedAst.Expression
 
     case class RecordEmpty(tpe: Type, loc: SourceLocation) extends SimplifiedAst.Expression

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/SimplifiedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/SimplifiedAstOps.scala
@@ -183,6 +183,11 @@ object SimplifiedAstOps {
         checkExp(base, env0, ienv0)
         checkType(tpe)
 
+      case Expression.IndexMut(base, _, toInsert, tpe, _) =>
+        checkExp(base, env0, ienv0)
+        checkExp(toInsert, env0, ienv0)
+        checkType(tpe)
+
       case Expression.Tuple(elms, tpe, loc) =>
         for (elm <- elms) {
           checkExp(elm, env0, ienv0)

--- a/main/src/ca/uwaterloo/flix/language/debug/PrettyPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/debug/PrettyPrinter.scala
@@ -240,6 +240,13 @@ object PrettyPrinter {
           vt.text(offset.toString)
           vt.text("]")
 
+        case Expression.IndexMut(base, offset, toInsert, _, _) =>
+          visitExp(base)
+          vt.text("[")
+          vt.text(offset.toString)
+          vt.text("] := ")
+          visitExp(toInsert)
+
         case Expression.Tuple(elms, tpe, loc) =>
           vt.text("(")
           for (elm <- elms) {

--- a/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
@@ -188,6 +188,11 @@ object ClosureConv extends Phase[Root, Root] {
     case Expression.Index(e, offset, tpe, loc) =>
       Expression.Index(visitExp(e), offset, tpe, loc)
 
+    case Expression.IndexMut(base, offset, toInsert, tpe, loc) =>
+      val b = visitExp(base)
+      val ti = visitExp(toInsert)
+      Expression.IndexMut(b, offset, ti, tpe, loc)
+
     case Expression.Tuple(elms, tpe, loc) =>
       Expression.Tuple(elms.map(visitExp), tpe, loc)
 
@@ -482,6 +487,7 @@ object ClosureConv extends Phase[Root, Root] {
     case Expression.Untag(sym, tag, exp, tpe, loc) => freeVars(exp)
     case Expression.Tag(enum, tag, exp, tpe, loc) => freeVars(exp)
     case Expression.Index(base, offset, tpe, loc) => freeVars(base)
+    case Expression.IndexMut(base, _, toInsert, _, _) => freeVars(base) ++ freeVars(toInsert)
     case Expression.Tuple(elms, tpe, loc) => mutable.LinkedHashSet.empty ++ elms.flatMap(freeVars)
     case Expression.RecordEmpty(tpe, loc) => mutable.LinkedHashSet.empty
     case Expression.RecordSelect(exp, label, tpe, loc) => freeVars(exp)
@@ -733,6 +739,11 @@ object ClosureConv extends Phase[Root, Root] {
       case Expression.Index(exp, offset, tpe, loc) =>
         val e = visitExp(exp)
         Expression.Index(e, offset, tpe, loc)
+
+      case Expression.IndexMut(base, offset, toInsert, tpe, loc) =>
+        val b = visitExp(base)
+        val ti = visitExp(toInsert)
+        Expression.IndexMut(b, offset, ti, tpe, loc)
 
       case Expression.Tuple(elms, tpe, loc) =>
         val es = elms map visitExp

--- a/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
@@ -229,6 +229,12 @@ object Finalize extends Phase[SimplifiedAst.Root, FinalAst.Root] {
         val t = visitType(tpe)
         FinalAst.Expression.Index(b, offset, t, loc)
 
+      case SimplifiedAst.Expression.IndexMut(base, offset, toInsert, tpe, loc) =>
+        val b = visit(base)
+        val ti = visit(toInsert)
+        val t = visitType(tpe)
+        FinalAst.Expression.IndexMut(b, offset, ti, t, loc)
+
       case SimplifiedAst.Expression.Tuple(elms, tpe, loc) =>
         val es = elms map visit
         val t = visitType(tpe)

--- a/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
@@ -195,6 +195,11 @@ object LambdaLift extends Phase[SimplifiedAst.Root, SimplifiedAst.Root] {
         val e = visitExp(exp)
         Expression.Index(e, offset, tpe, loc)
 
+      case Expression.IndexMut(base, offset, toInsert, tpe, loc) =>
+        val b = visitExp(base)
+        val ti = visitExp(toInsert)
+        Expression.IndexMut(b, offset, ti, tpe, loc)
+
       case Expression.Tuple(elms, tpe, loc) =>
         val es = elms map visitExp
         Expression.Tuple(es, tpe, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Optimizer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Optimizer.scala
@@ -168,6 +168,11 @@ object Optimizer extends Phase[SimplifiedAst.Root, SimplifiedAst.Root] {
         val b = visitExp(base, env0)
         Expression.Index(b, offset, tpe, loc)
 
+      case Expression.IndexMut(base, offset, toInsert, tpe, loc) =>
+        val b = visitExp(base, env0)
+        val ti = visitExp(toInsert, env0)
+        Expression.IndexMut(b, offset, ti, tpe, loc)
+
       case Expression.Tuple(elms, tpe, loc) =>
         val es = elms map (visitExp(_, env0))
         Expression.Tuple(es, tpe, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -1325,6 +1325,11 @@ object Simplifier extends Phase[TypedAst.Root, SimplifiedAst.Root] {
       case SimplifiedAst.Expression.Index(exp, offset, tpe, loc) =>
         SimplifiedAst.Expression.Index(visitExp(exp), offset, tpe, loc)
 
+      case SimplifiedAst.Expression.IndexMut(base, offset, toInsert, tpe, loc) =>
+        val b = visitExp(base)
+        val ti = visitExp(toInsert)
+        SimplifiedAst.Expression.IndexMut(b, offset, ti, tpe, loc)
+
       case SimplifiedAst.Expression.Tuple(elms, tpe, loc) =>
         SimplifiedAst.Expression.Tuple(elms.map(visitExp), tpe, loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Tailrec.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Tailrec.scala
@@ -19,8 +19,10 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.CompilationError
 import ca.uwaterloo.flix.language.ast.SimplifiedAst._
+import ca.uwaterloo.flix.language.debug.PrettyPrinter
 import ca.uwaterloo.flix.util.{Optimization, Validation}
 import ca.uwaterloo.flix.util.Validation._
+import ca.uwaterloo.flix.util.vt.TerminalContext
 
 /**
   * The Tailrec phase identifies function calls that are in tail recursive position.
@@ -34,6 +36,7 @@ object Tailrec extends Phase[Root, Root] {
     * Identifies tail recursive calls in the given AST `root`.
     */
   def run(root: Root)(implicit flix: Flix): Validation[Root, CompilationError] = flix.phase("Tailrec") {
+    println(PrettyPrinter.Simplified.fmtRoot(root).fmt(TerminalContext.AnsiTerminal))
     //
     // Check if tail call elimination is enabled.
     //
@@ -46,7 +49,11 @@ object Tailrec extends Phase[Root, Root] {
     val defns = root.defs.map {
       case (sym, defn) => sym -> tailrec(defn)
     }
-    root.copy(defs = defns).toSuccess
+    //root.copy(defs = defns).toSuccess
+    val newRoot = root.copy(defs = defns)
+    println("__________________-----____________________________________")
+    println(PrettyPrinter.Simplified.fmtRoot(newRoot).fmt(TerminalContext.AnsiTerminal))
+    newRoot.toSuccess
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Tailrec.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Tailrec.scala
@@ -36,6 +36,7 @@ object Tailrec extends Phase[Root, Root] {
     * Identifies tail recursive calls in the given AST `root`.
     */
   def run(root: Root)(implicit flix: Flix): Validation[Root, CompilationError] = flix.phase("Tailrec") {
+    println("__________________Before TailRec____________________________________")
     println(PrettyPrinter.Simplified.fmtRoot(root).fmt(TerminalContext.AnsiTerminal))
     //
     // Check if tail call elimination is enabled.
@@ -50,8 +51,9 @@ object Tailrec extends Phase[Root, Root] {
       case (sym, defn) => sym -> tailrec(defn)
     }
     //root.copy(defs = defns).toSuccess
+
     val newRoot = root.copy(defs = defns)
-    println("__________________-----____________________________________")
+    println("__________________After TailRec____________________________________")
     println(PrettyPrinter.Simplified.fmtRoot(newRoot).fmt(TerminalContext.AnsiTerminal))
     newRoot.toSuccess
   }
@@ -120,6 +122,20 @@ object Tailrec extends Phase[Root, Root] {
 
         Expression.SelectChannel(rs, d, tpe, loc)
 
+      case Expression.Tag(sym, tag, exp, tpe, loc) =>
+        // First check that `exp` is a Tuple
+        if (tag == "Cons") {
+          println(exp.getClass)
+        }
+        if (exp.getClass.getName == Expression.Tuple.getClass.getName) {
+          // Then we need to make sure that the `tag` is Cons
+          if (tag == "Cons") {
+            println(sym)
+            println(tag)
+          }
+        }
+
+        exp0
       /*
        * Other expression: No calls in tail position.
        */

--- a/main/src/ca/uwaterloo/flix/language/phase/TreeShaker.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TreeShaker.scala
@@ -159,6 +159,9 @@ object TreeShaker extends Phase[SimplifiedAst.Root, SimplifiedAst.Root] {
       case Expression.Index(exp, _, _, _) =>
         visitExp(exp)
 
+      case Expression.IndexMut(base, _, toInsert, _, _) =>
+        visitExp(base) ++ visitExp(toInsert)
+
       case Expression.Tuple(elms, _, _) =>
         visitExps(elms)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/VarNumbering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/VarNumbering.scala
@@ -145,6 +145,10 @@ object VarNumbering extends Phase[SimplifiedAst.Root, SimplifiedAst.Root] {
 
       case Expression.Index(exp, index, tpe, loc) => visitExp(exp, i0)
 
+      case Expression.IndexMut(base, _, toInsert, _, _) =>
+        val i1 = visitExp(base, i0)
+        visitExp(toInsert, i1)
+
       case Expression.Tuple(elms, tpe, loc) => visitExps(elms, i0)
 
       case Expression.RecordEmpty(tpe, loc) => i0

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -439,6 +439,14 @@ object GenExpression {
       // Cast the object to it's type if it's not a primitive
       AsmOps.castIfNotPrim(visitor, JvmOps.getJvmType(tpe))
 
+    case Expression.IndexMut(base, offset, toInsert, tpe, _) =>
+      // We get the JvmType of the class of the tuple
+      val classType = JvmOps.getTupleInterfaceType(base.tpe.asInstanceOf[MonoType.Tuple])
+      // evaluate the `toInsert`
+      ???
+
+
+
     case Expression.Tuple(elms, tpe, loc) =>
       // Adding source line number for debugging
       addSourceLine(visitor, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -604,6 +604,8 @@ object JvmOps {
 
       case Expression.Index(base, offset, tpe, loc) => visitExp(base)
 
+      case Expression.IndexMut(base, _, toInsert, _, _) => visitExp(base) ++ visitExp(toInsert)
+
       case Expression.Tuple(elms, tpe, loc) => elms.foldLeft(Set.empty[ClosureInfo]) {
         case (sacc, e) => sacc ++ visitExp(e)
       }
@@ -953,6 +955,8 @@ object JvmOps {
       case Expression.Untag(sym, tag, exp, tpe, loc) => visitExp(exp) + tpe
 
       case Expression.Index(base, offset, tpe, loc) => visitExp(base) + tpe
+
+      case Expression.IndexMut(base, _, toInsert, tpe, _) => visitExp(base) ++ visitExp(toInsert) + tpe
 
       case Expression.Tuple(elms, tpe, loc) => elms.foldLeft(Set(tpe)) {
         case (sacc, e) => sacc ++ visitExp(e)

--- a/main/src/ca/uwaterloo/flix/runtime/evaluator/SymbolicEvaluator.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/evaluator/SymbolicEvaluator.scala
@@ -746,6 +746,15 @@ object SymbolicEvaluator {
         }
 
       /**
+        * IndexMut (into tuple), mutate tuple.
+        */
+      case Expression.IndexMut(base, offset, toInsert, _, _) =>
+        eval(pc0, base, env0, lenv0, qua0) flatMap {
+          case (pc, qua, SymVal.Tuple(elms)) => ???
+          case v => throw InternalCompilerException(s"MonoType Error: Unexpected value: '$v'.")
+        }
+
+      /**
         * ArrayLit.
         */
       case Expression.ArrayLit(elms, tpe, loc) => ???

--- a/main/src/ca/uwaterloo/flix/runtime/evaluator/SymbolicEvaluator.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/evaluator/SymbolicEvaluator.scala
@@ -749,10 +749,7 @@ object SymbolicEvaluator {
         * IndexMut (into tuple), mutate tuple.
         */
       case Expression.IndexMut(base, offset, toInsert, _, _) =>
-        eval(pc0, base, env0, lenv0, qua0) flatMap {
-          case (pc, qua, SymVal.Tuple(elms)) => ???
-          case v => throw InternalCompilerException(s"MonoType Error: Unexpected value: '$v'.")
-        }
+        ???
 
       /**
         * ArrayLit.


### PR DESCRIPTION
The goal of this project is to to generalize tail-call elimination in Flix to also include tail recursion modulo cons.
The first goal of this project is to extend the backend with mutable tuples:

- [x] Extend `FinalAst.scala` with `IndexMut` as the expression to mutate tuples
- [x] Implement case for `IndexMut` for `closuresOf` and `typesOf` in `JvmOps.scala`
- [x] Add unimplemented case for `IndexMut` SymbolicEvaluator.scala
- [x] Extend `SimplifiedAst` with `IndexMut`
- [x] Add simple case for `IndexMut` in `checkExp` in `SimplifiedAstOps.scala`
- [x] Add a case for `IndexMut`for `fmtExp` in `PrettyPrinter.scala`
- [x] Add a case for `IndexMut`for `visitExp`, `freeVars` and `replace` in `ClosureConv.scala`
- [x] Add a case for `IndexMut`for `visitExp` in `Finalize.scala`
- [x] Add a case for `IndexMut`for `liftExp` in `LambdaLift.scala`
- [x] Add a case for `IndexMut`for `run` in `Optimizer.scala`
- [x] Add a case for `IndexMut`for `substitute` in `Simplifier.scala`
- [x] Add a case for `IndexMut`for `visitExp` in `TreeShaker.scala`
- [x] Add a case for `IndexMut`for `number` in `VarNumbering.scala`
- [ ] Implement case for `IndexMut` for `compileExpression` in `GenExpression.scala`
- [ ] Extend Tailrec to also identify TRMC and rewrite with a helper function.
- [ ] Find a way of allowing for the return of multiple definitions in Tailrec