### PR TITLE
Introduce Choice Data Type, Part VI

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/BenchmarkCompiler.scala
+++ b/main/src/ca/uwaterloo/flix/tools/BenchmarkCompiler.scala
@@ -112,6 +112,7 @@ object BenchmarkCompiler {
     flix.addInput("Test.Exp.Ascribe.flix", LocalResource.get("/test/flix/Test.Exp.Ascribe.flix"))
     flix.addInput("Test.Exp.Binary.Spaceship.flix", LocalResource.get("/test/flix/Test.Exp.Binary.Spaceship.flix"))
     flix.addInput("Test.Exp.Cast.flix", LocalResource.get("/test/flix/Test.Exp.Cast.flix"))
+    flix.addInput("Test.Exp.Choose.flix", LocalResource.get("/test/flix/Test.Exp.Choose.flix"))
     flix.addInput("Test.Exp.Concurrency.Buffered.flix", LocalResource.get("/test/flix/Test.Exp.Concurrency.Buffered.flix"))
     flix.addInput("Test.Exp.Concurrency.NewChannel.flix", LocalResource.get("/test/flix/Test.Exp.Concurrency.NewChannel.flix"))
     flix.addInput("Test.Exp.Concurrency.Unbuffered.flix", LocalResource.get("/test/flix/Test.Exp.Concurrency.Unbuffered.flix"))

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -690,4 +690,52 @@ class TestTyper extends FunSuite with TestUtils {
     expectError[TypeError.GeneralizationError](result)
   }
 
+  test("Test.Choice.Empty.01") {
+    val input =
+      """
+        |def main(): Unit =
+        |    let f = x -> {
+        |        choose x {
+        |            case Absent     => 1 as & Impure
+        |        };
+        |        choose x {
+        |            case Present(_) => 2 as & Impure
+        |        }
+        |    };
+        |    f(Absent)
+        |
+        |pub enum Choice[a, _isAbsent :# Bool, _isPresent :# Bool] {
+        |    case Absent
+        |    case Present(a)
+        |}
+        |
+      """.stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[TypeError.MismatchedBools](result)
+  }
+
+  test("Test.Choice.Empty.02") {
+    val input =
+      """
+        |def main(): Unit =
+        |    let f = x -> {
+        |        choose x {
+        |            case Absent     => 1 as & Impure
+        |        };
+        |        choose x {
+        |            case Present(_) => 2 as & Impure
+        |        }
+        |    };
+        |    f(Present(123))
+        |
+        |pub enum Choice[a, _isAbsent :# Bool, _isPresent :# Bool] {
+        |    case Absent
+        |    case Present(a)
+        |}
+        |
+      """.stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[TypeError.MismatchedBools](result)
+  }
+
 }

--- a/main/test/flix/LangSuite.scala
+++ b/main/test/flix/LangSuite.scala
@@ -53,7 +53,7 @@ class LangSuite extends Suites(
   //
   // Choose.
   //
-  new FlixTest("Test.Exp.Choose", "main/test/flix/Test.Exp.Choose.flix"),
+  new FlixTest("Test.Exp.Choose", "main/test/flix/Test.Exp.Choose.flix")(Options.TestWithLibrary),
 
   //
   // Concurrency.

--- a/main/test/flix/Test.Exp.Choose.flix
+++ b/main/test/flix/Test.Exp.Choose.flix
@@ -516,7 +516,55 @@ namespace Test/Exp/Choose {
         };
         f(Present(123), if (true) Absent else Present(456)) == 1
 
-    // TODO: Add more tests
+    @test
+    def testChooseIf13(): Bool =
+        let f = (x, y) -> {
+            choose (x, y) {
+                case (_, Absent)        => 1
+                case (_, Present(_))    => 2
+            }
+        };
+        f(Absent, if (true) Absent else Present(123)) == 1
+
+    @test
+    def testChooseIf14(): Bool =
+        let f = (x, y) -> {
+            choose (x, y) {
+                case (_, Absent)        => 1
+                case (_, Present(_))    => 2
+            }
+        };
+        f(Present(123), if (true) Absent else Present(456)) == 1
+
+    @test
+    def testChooseIf15(): Bool =
+        let f = (x, y) -> {
+            choose (x, y) {
+                case (_, Absent)        => 1
+                case (_, Present(_))    => 2
+            }
+        };
+        f(if (true) Absent else Present(123), Absent) == 1
+
+    @test
+    def testChooseIf16(): Bool =
+        let f = (x, y) -> {
+            choose (x, y) {
+                case (_, Absent)        => 1
+                case (_, Present(_))    => 2
+            }
+        };
+        f(if (true) Absent else Present(123), Present(123)) == 2
+
+    @test
+    def testChooseIf17(): Bool =
+        let f = (x, y) -> {
+            choose (x, y) {
+                case (_, Absent)        => 1
+                case (_, Present(_))    => 2
+            }
+        };
+        f(if (true) Absent else Present(123),  if (true) Absent else Present(456)) == 1
 
 }
 

--- a/main/test/flix/Test.Exp.Choose.flix
+++ b/main/test/flix/Test.Exp.Choose.flix
@@ -387,6 +387,26 @@ namespace Test/Exp/Choose {
         f(Present("a"), Absent) == "a"
 
     @test
+    def testChooseThreeWithTwoCases01(): Bool =
+        let f = (x, y, z) -> {
+            choose (x, y, z) {
+                case (Absent, Absent, Absent)         => 1
+                case (Present(_), Absent, Present(_)) => 2
+            }
+        };
+        f(Absent, Absent, Absent) == 1
+
+    @test
+    def testChooseThreeWithTwoCases02(): Bool =
+        let f = (x, y, z) -> {
+            choose (x, y, z) {
+                case (Absent, Absent, Absent)         => 1
+                case (Present(_), Absent, Present(_)) => 2
+            }
+        };
+        f(Present(123), Absent, Present(456)) == 2
+
+    @test
     def testChooseIf01(): Bool =
         let f = x -> {
             choose x {

--- a/main/test/flix/Test.Exp.Choose.flix
+++ b/main/test/flix/Test.Exp.Choose.flix
@@ -587,8 +587,3 @@ namespace Test/Exp/Choose {
         f(if (true) Absent else Present(123),  if (true) Absent else Present(456)) == 1
 
 }
-
-pub enum Choice[a, _isAbsent :# Bool, _isPresent :# Bool] {
-    case Absent
-    case Present(a)
-}

--- a/main/test/flix/Test.Exp.Choose.flix
+++ b/main/test/flix/Test.Exp.Choose.flix
@@ -516,6 +516,8 @@ namespace Test/Exp/Choose {
         };
         f(Present(123), if (true) Absent else Present(456)) == 1
 
+    // TODO: Add more tests
+
 }
 
 pub enum Choice[a, _isAbsent :# Bool, _isPresent :# Bool] {


### PR DESCRIPTION
Tasks:
- [x] Add test cases to benchmarks.
- [x] Use BoolUnification constructs to simplify Boolean formulas.
- [x] Fix typing with wildcards.
- [ ] Add combinators to `Choice` namespace.
- [ ] Investigate if the types can be simplified.
- [ ] Review all code related to `Choice`.

Decisions:
- [ ] Do we want some syntactic sugar for the `Choice` type?
