### PR TITLE
LSP: Add preliminary support for classes and instances

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Entity.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Entity.scala
@@ -25,12 +25,12 @@ sealed trait Entity {
 
 object Entity {
 
-  case class Class(e: TypedAst.Class) extends Entity {
+  case class Case(e: TypedAst.Case) extends Entity {
     def loc: SourceLocation = e.loc
   }
 
-  case class Case(e: TypedAst.Case) extends Entity {
-    def loc: SourceLocation = e.loc
+  case class Class(e: TypedAst.Class) extends Entity {
+    def loc: SourceLocation = e.sym.loc
   }
 
   case class Def(e: TypedAst.Def) extends Entity {

--- a/main/src/ca/uwaterloo/flix/api/lsp/Entity.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Entity.scala
@@ -25,6 +25,10 @@ sealed trait Entity {
 
 object Entity {
 
+  case class Class(e: TypedAst.Class) extends Entity {
+    def loc: SourceLocation = e.loc
+  }
+
   case class Case(e: TypedAst.Case) extends Entity {
     def loc: SourceLocation = e.loc
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/Entity.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Entity.scala
@@ -37,6 +37,10 @@ object Entity {
     def loc: SourceLocation = e.loc
   }
 
+  case class Sig(e: TypedAst.Sig) extends Entity {
+    def loc: SourceLocation = e.loc
+  }
+
   case class Enum(e: TypedAst.Enum) extends Entity {
     def loc: SourceLocation = e.sym.loc
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
@@ -42,6 +42,11 @@ object Index {
   def occurrenceOf(defn0: Def): Index = empty + Entity.Def(defn0)
 
   /**
+    * Returns an index for the given `sig0`.
+    */
+  def occurrenceOf(sig0: Sig): Index = empty + Entity.Sig(sig0)
+
+  /**
     * Returns an index for the given `enum0`.
     */
   def occurrenceOf(enum0: Enum): Index = empty + Entity.Enum(enum0)

--- a/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.api.lsp
 
 import ca.uwaterloo.flix.language.ast.TypedAst._
-import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.util.collection.MultiMap
 
 object Index {
@@ -25,6 +25,11 @@ object Index {
     */
   val empty: Index = Index(Map.empty, MultiMap.empty, MultiMap.empty, MultiMap.empty, MultiMap.empty, MultiMap.empty,
     MultiMap.empty, MultiMap.empty, MultiMap.empty, MultiMap.empty, MultiMap.empty)
+
+  /**
+    * Returns an index for the given `class0`.
+    */
+  def occurrenceOf(class0: TypedAst.Class): Index = empty + Entity.Class(class0)
 
   /**
     * Returns an index for the given `case0`.

--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -74,8 +74,7 @@ object Indexer {
     */
   private def visitClass(class0: TypedAst.Class): Index = class0 match {
     case TypedAst.Class(doc, mod, sym, tparam, signatures, loc) =>
-
-      Index.empty
+      Index.occurrenceOf(class0)
   }
 
   /**
@@ -150,7 +149,7 @@ object Indexer {
       Index.occurrenceOf(exp0) ++ Index.useOf(sym, loc)
 
     case Expression.Sig(sym, _, loc) =>
-      Index.occurrenceOf(exp0) ++ Index.useOf(sym, loc)
+      Index.occurrenceOf(exp0) ++ Index.useOf(sym, loc) ++ Index.useOf(sym.clazz, loc)
 
     case Expression.Hole(_, _, _, _) =>
       Index.occurrenceOf(exp0)

--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -36,7 +36,7 @@ object Indexer {
     }
     val idx4 = root.instances.foldLeft(Index.empty) {
       case (acc, (_, instances)) => acc ++ instances.foldLeft(Index.empty) {
-        case (acc1, instance) => acc ++ visitInstance(instance)
+        case (acc1, instance) => acc1 ++ visitInstance(instance)
       }
     }
     val idx5 = root.sigs.foldLeft(Index.empty) {

--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.api.lsp
 
 import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.{Body, Head}
 import ca.uwaterloo.flix.language.ast.TypedAst.{CatchRule, ChoiceRule, Constraint, Def, Enum, Expression, FormalParam, MatchRule, Pattern, Predicate, Root, SelectChannelRule}
-import ca.uwaterloo.flix.language.ast.{Scheme, SourceLocation, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.{Ast, Scheme, SourceLocation, Type, TypeConstructor, TypedAst}
 
 object Indexer {
 
@@ -31,7 +31,13 @@ object Indexer {
     val idx2 = root.enums.foldLeft(Index.empty) {
       case (acc, (_, enum0)) => acc ++ visitEnum(enum0)
     }
-    idx1 ++ idx2
+    val idx3 = root.classes.foldLeft(Index.empty) {
+      case (acc, (_, class0)) => acc ++ visitClass(class0)
+    }
+    val idx4 = root.classEnv.foldLeft(Index.empty) {
+      case (acc, (_, instances)) => acc ++ visitInstances(instances)
+    }
+    idx1 ++ idx2 ++ idx3 ++ idx4
   }
 
   /**
@@ -57,6 +63,20 @@ object Indexer {
     }
     idx0 ++ idx1
   }
+
+  /**
+    * Returns a reverse index for the given class `class0`.
+    */
+  private def visitClass(class0: TypedAst.Class): Index = class0 match {
+    case TypedAst.Class(doc, mod, sym, tparam, signatures, loc) =>
+
+      Index.empty
+  }
+
+  /**
+    * Returns a reverse index for the given instance `instance0`.
+    */
+  private def visitInstances(value: List[Ast.Instance]): Index = Index.empty // TODO
 
   /**
     * Returns a reverse index for the given expression `exp0`.

--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -62,6 +62,21 @@ object Indexer {
   }
 
   /**
+    * Returns a reverse index for the given signature `sig0`.
+    */
+  private def visitSig(sig0: Sig): Index = sig0 match {
+    case Sig(_, _, _, _, tparams, fparams, _, _, _) =>
+      val idx1 = Index.occurrenceOf(sig0)
+      val idx2 = fparams.foldLeft(Index.empty) {
+        case (acc, fparam) => acc ++ visitFormalParam(fparam)
+      }
+      val idx3 = tparams.foldLeft(Index.empty) {
+        case (acc, tparam) => acc ++ visitTypeParam(tparam)
+      }
+      idx1 ++ idx2 ++ idx3
+  }
+
+  /**
     * Returns a reverse index for the given enum `enum0`.
     */
   private def visitEnum(enum0: Enum): Index = {
@@ -91,13 +106,6 @@ object Indexer {
         case (acc, defn) => visitDef(defn)
       }
       idx1 ++ idx2 ++ idx3
-  }
-
-  /**
-    * Returns a reverse index for the given signature `sig0`.
-    */
-  private def visitSig(sig0: Sig): Index = {
-    Index.empty // TODO
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.api.lsp
 
 import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.{Body, Head}
-import ca.uwaterloo.flix.language.ast.TypedAst.{CatchRule, ChoiceRule, Constraint, Def, Enum, Expression, FormalParam, MatchRule, Pattern, Predicate, Root, SelectChannelRule}
+import ca.uwaterloo.flix.language.ast.TypedAst.{CatchRule, ChoiceRule, Constraint, Def, Enum, Expression, FormalParam, Instance, MatchRule, Pattern, Predicate, Root, SelectChannelRule, Sig}
 import ca.uwaterloo.flix.language.ast.{Ast, Scheme, SourceLocation, Type, TypeConstructor, TypedAst}
 
 object Indexer {
@@ -34,10 +34,15 @@ object Indexer {
     val idx3 = root.classes.foldLeft(Index.empty) {
       case (acc, (_, class0)) => acc ++ visitClass(class0)
     }
-    val idx4 = root.classEnv.foldLeft(Index.empty) {
-      case (acc, (_, instances)) => acc ++ visitInstances(instances)
+    val idx4 = root.instances.foldLeft(Index.empty) {
+      case (acc, (_, instances)) => acc ++ instances.foldLeft(Index.empty) {
+        case (acc1, instance) => acc ++ visitInstance(instance)
+      }
     }
-    idx1 ++ idx2 ++ idx3 ++ idx4
+    val idx5 = root.sigs.foldLeft(Index.empty) {
+      case (acc, (_, sig)) => acc ++ visitSig(sig)
+    }
+    idx1 ++ idx2 ++ idx3 ++ idx4 ++ idx5
   }
 
   /**
@@ -76,7 +81,14 @@ object Indexer {
   /**
     * Returns a reverse index for the given instance `instance0`.
     */
-  private def visitInstances(value: List[Ast.Instance]): Index = Index.empty // TODO
+  private def visitInstance(instance0: Instance): Index = Index.empty // TODO
+
+  /**
+    * Returns a reverse index for the given signature `sig0`.
+    */
+  private def visitSig(sig0: Sig): Index = {
+    Index.empty // TODO
+  }
 
   /**
     * Returns a reverse index for the given expression `exp0`.

--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -81,9 +81,13 @@ object Indexer {
     * Returns a reverse index for the given instance `instance0`.
     */
   private def visitInstance(instance0: Instance): Index = instance0 match {
-    case Instance(doc, mod, sym, tpe, tconstrs, defs, loc) =>
-
-      Index.empty
+    case Instance(_, _, sym, tpe, _, defs, loc) =>
+      val idx1 = Index.useOf(sym, loc)
+      val idx2 = visitType(tpe)
+      val idx3 = defs.foldLeft(Index.empty) {
+        case (acc, defn) => visitDef(defn)
+      }
+      idx1 ++ idx2 ++ idx3
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -81,7 +81,11 @@ object Indexer {
   /**
     * Returns a reverse index for the given instance `instance0`.
     */
-  private def visitInstance(instance0: Instance): Index = Index.empty // TODO
+  private def visitInstance(instance0: Instance): Index = instance0 match {
+    case Instance(doc, mod, sym, tpe, tconstrs, defs, loc) =>
+
+      Index.empty
+  }
 
   /**
     * Returns a reverse index for the given signature `sig0`.

--- a/main/src/ca/uwaterloo/flix/api/lsp/LocationLink.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LocationLink.scala
@@ -28,7 +28,7 @@ object LocationLink {
   /**
     * Returns a location link to the given symbol `sym`.
     */
-  def fromDefSym(sym: Symbol.DefnSym, root: Root, loc: SourceLocation): LocationLink = {
+  def fromDefSym(sym: Symbol.DefnSym, loc: SourceLocation)(implicit root: Root): LocationLink = {
     val defDecl = root.defs(sym)
     val originSelectionRange = Range.from(loc)
     val targetUri = sym.loc.source.name
@@ -40,7 +40,19 @@ object LocationLink {
   /**
     * Returns a location link to the given symbol `sym`.
     */
-  def fromEnumSym(sym: Symbol.EnumSym, root: Root, loc: SourceLocation): LocationLink = {
+  def fromSigSym(sym: Symbol.SigSym, loc: SourceLocation)(implicit root: Root): LocationLink = {
+    val sigDecl = root.sigs(sym)
+    val originSelectionRange = Range.from(loc)
+    val targetUri = sym.loc.source.name
+    val targetRange = Range.from(sym.loc)
+    val targetSelectionRange = Range.from(sigDecl.loc)
+    LocationLink(originSelectionRange, targetUri, targetRange, targetSelectionRange)
+  }
+
+  /**
+    * Returns a location link to the given symbol `sym`.
+    */
+  def fromEnumSym(sym: Symbol.EnumSym, loc: SourceLocation)(implicit root: Root): LocationLink = {
     val enumDecl = root.enums(sym)
     val originSelectionRange = Range.from(loc)
     val targetUri = sym.loc.source.name
@@ -52,7 +64,7 @@ object LocationLink {
   /**
     * Returns a location link to the given symbol `sym`.
     */
-  def fromEnumAndTag(sym: Symbol.EnumSym, tag: Name.Tag, root: Root, loc: SourceLocation): LocationLink = {
+  def fromEnumAndTag(sym: Symbol.EnumSym, tag: Name.Tag, loc: SourceLocation)(implicit root: Root): LocationLink = {
     val enumDecl = root.enums(sym)
     val caseDecl = enumDecl.cases(tag)
     val originSelectionRange = Range.from(loc)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
@@ -31,6 +31,8 @@ object FindReferencesProvider {
 
         case Entity.Case(caze) => findTagUses(caze.sym, caze.tag)
 
+        case Entity.Class(class0) => findClassUses(class0.sym)
+
         case Entity.Def(defn) => findDefUses(defn.sym)
 
         case Entity.Enum(enum0) => findEnumUses(enum0.sym)
@@ -68,6 +70,12 @@ object FindReferencesProvider {
 
       }
     }
+  }
+
+  private def findClassUses(sym: Symbol.ClassSym)(implicit index: Index, root: Root): JObject = {
+    val uses = index.usesOf(sym)
+    val locs = uses.toList.map(Location.from)
+    ("status" -> "success") ~ ("result" -> locs.map(_.toJSON))
   }
 
   private def findDefUses(sym: Symbol.DefnSym)(implicit index: Index, root: Root): JObject = {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
@@ -37,6 +37,7 @@ object FindReferencesProvider {
 
         case Entity.Exp(exp) => exp match {
           case Expression.Def(sym, _, _) => findDefUses(sym)
+          case Expression.Sig(sym, _, _) => findSigUses(sym)
           case Expression.Var(sym, _, _) => findVarUses(sym)
           case Expression.Tag(sym, tag, _, _, _, _) => findTagUses(sym, tag)
           case _ => mkNotFound(uri, pos)
@@ -70,6 +71,12 @@ object FindReferencesProvider {
   }
 
   private def findDefUses(sym: Symbol.DefnSym)(implicit index: Index, root: Root): JObject = {
+    val uses = index.usesOf(sym)
+    val locs = uses.toList.map(Location.from)
+    ("status" -> "success") ~ ("result" -> locs.map(_.toJSON))
+  }
+
+  private def findSigUses(sym: Symbol.SigSym)(implicit index: Index, root: Root): JObject = {
     val uses = index.usesOf(sym)
     val locs = uses.toList.map(Location.from)
     ("status" -> "success") ~ ("result" -> locs.map(_.toJSON))

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
@@ -35,6 +35,8 @@ object FindReferencesProvider {
 
         case Entity.Def(defn) => findDefUses(defn.sym)
 
+        case Entity.Sig(sig0) => findSigUses(sig0.sym)
+
         case Entity.Enum(enum0) => findEnumUses(enum0.sym)
 
         case Entity.Exp(exp) => exp match {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
@@ -34,27 +34,30 @@ object GotoProvider {
 
         case Entity.Exp(exp) => exp match {
           case Expression.Def(sym, _, loc) =>
-            ("status" -> "success") ~ ("result" -> LocationLink.fromDefSym(sym, root, loc).toJSON)
+            ("status" -> "success") ~ ("result" -> LocationLink.fromDefSym(sym, loc)(root).toJSON)
+
+          case Expression.Sig(sym, _, loc) =>
+            ("status" -> "success") ~ ("result" -> LocationLink.fromSigSym(sym, loc)(root).toJSON)
 
           case Expression.Var(sym, _, loc) =>
             ("status" -> "success") ~ ("result" -> LocationLink.fromVarSym(sym, loc).toJSON)
 
           case Expression.Tag(sym, tag, _, _, _, _) =>
-            ("status" -> "success") ~ ("result" -> LocationLink.fromEnumAndTag(sym, tag, root, tag.loc).toJSON)
+            ("status" -> "success") ~ ("result" -> LocationLink.fromEnumAndTag(sym, tag, tag.loc)(root).toJSON)
 
           case _ => mkNotFound(uri, pos)
         }
 
         case Entity.Pattern(pat) => pat match {
           case Pattern.Tag(sym, tag, _, _, _) =>
-            ("status" -> "success") ~ ("result" -> LocationLink.fromEnumAndTag(sym, tag, root, tag.loc).toJSON)
+            ("status" -> "success") ~ ("result" -> LocationLink.fromEnumAndTag(sym, tag, tag.loc)(root).toJSON)
 
           case _ => mkNotFound(uri, pos)
         }
 
         case Entity.TypeCon(tc, loc) => tc match {
           case TypeConstructor.Enum(sym, _) =>
-            ("status" -> "success") ~ ("result" -> LocationLink.fromEnumSym(sym, root, loc).toJSON)
+            ("status" -> "success") ~ ("result" -> LocationLink.fromEnumSym(sym, loc)(root).toJSON)
 
           case _ => mkNotFound(uri, pos)
         }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
@@ -37,6 +37,7 @@ object HighlightProvider {
         case Entity.Exp(exp) => exp match {
           case Expression.Var(sym, _, _) => highlightVar(sym)
           case Expression.Def(sym, _, _) => highlightDef(sym)
+          case Expression.Sig(sym, _, _) => highlightSig(sym)
           case Expression.Tag(sym, tag, _, _, _, _) => highlightTag(sym, tag)
           case _ => mkNotFound(uri, pos)
         }
@@ -78,6 +79,12 @@ object HighlightProvider {
   }
 
   private def highlightDef(sym: Symbol.DefnSym)(implicit index: Index, root: Root): JObject = {
+    val write = (sym.loc, DocumentHighlightKind.Write)
+    val reads = index.usesOf(sym).toList.map(loc => (loc, DocumentHighlightKind.Read))
+    highlight(write :: reads)
+  }
+
+  private def highlightSig(sym: Symbol.SigSym)(implicit index: Index, root: Root): JObject = {
     val write = (sym.loc, DocumentHighlightKind.Write)
     val reads = index.usesOf(sym).toList.map(loc => (loc, DocumentHighlightKind.Read))
     highlight(write :: reads)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
@@ -32,6 +32,8 @@ object HighlightProvider {
 
         case Entity.Def(defn) => highlightDef(defn.sym)
 
+        case Entity.Sig(sig0) => highlightSig(sig0.sym)
+
         case Entity.Enum(enum) => highlightEnum(enum.sym)
 
         case Entity.Exp(exp) => exp match {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HoverProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HoverProvider.scala
@@ -40,6 +40,8 @@ object HoverProvider {
           exp match {
             case Expression.Def(sym, _, loc) => hoverDef(sym, loc)
 
+            case Expression.Sig(sym, _, loc) => hoverSig(sym, loc)
+
             case Expression.FixpointConstraintSet(_, stf, tpe, loc) => hoverFixpoint(tpe, Type.Pure, stf, loc)
 
             case Expression.FixpointCompose(_, _, stf, tpe, eff, loc) => hoverFixpoint(tpe, eff, stf, loc)
@@ -69,11 +71,24 @@ object HoverProvider {
   }
 
   private def hoverDef(sym: Symbol.DefnSym, loc: SourceLocation)(implicit index: Index, root: Root): JObject = {
-    val decl = root.defs(sym)
+    val defDecl = root.defs(sym)
     val markup =
-      s"""${FormatSignature.asMarkDown(decl)}
+      s"""${FormatSignature.asMarkDown(defDecl)}
          |
-         |${FormatDoc.asMarkDown(decl.doc)}
+         |${FormatDoc.asMarkDown(defDecl.doc)}
+         |""".stripMargin
+    val contents = MarkupContent(MarkupKind.Markdown, markup)
+    val range = Range.from(loc)
+    val result = ("contents" -> contents.toJSON) ~ ("range" -> range.toJSON)
+    ("status" -> "success") ~ ("result" -> result)
+  }
+
+  private def hoverSig(sym: Symbol.SigSym, loc: SourceLocation)(implicit index: Index, root: Root): JObject = {
+    val sigDecl = root.sigs(sym)
+    val markup =
+      s"""${FormatSignature.asMarkDown(sigDecl)}
+         |
+         |${FormatDoc.asMarkDown(sigDecl.doc)}
          |""".stripMargin
     val contents = MarkupContent(MarkupKind.Markdown, markup)
     val range = Range.from(loc)

--- a/main/src/ca/uwaterloo/flix/language/debug/FormatSignature.scala
+++ b/main/src/ca/uwaterloo/flix/language/debug/FormatSignature.scala
@@ -15,7 +15,7 @@
  */
 package ca.uwaterloo.flix.language.debug
 
-import ca.uwaterloo.flix.language.ast.{Type, TypeConstructor, TypedAst}
+import ca.uwaterloo.flix.language.ast.{Scheme, Type, TypeConstructor, TypedAst}
 
 object FormatSignature {
 
@@ -23,15 +23,23 @@ object FormatSignature {
     * Returns a markdown string for the signature of the given definition.
     */
   def asMarkDown(defn: TypedAst.Def)(implicit audience: Audience): String = {
-    s"""def **${defn.sym.name}**(${formatFormalParams(defn)}): ${formatResultTypeAndEff(defn)}
+    s"""def **${defn.sym.name}**(${formatFormalParams(defn.fparams)}): ${formatResultTypeAndEff(defn.declaredScheme)}
+       |""".stripMargin
+  }
+
+  /**
+    * Returns a markdown string for the signature of the given definition.
+    */
+  def asMarkDown(sig: TypedAst.Sig)(implicit audience: Audience): String = {
+    s"""def **${sig.sym.name}**(${formatFormalParams(sig.fparams)}): ${formatResultTypeAndEff(sig.sc)}
        |""".stripMargin
   }
 
   /**
     * Returns a formatted string of the formal parameters.
     */
-  private def formatFormalParams(defn: TypedAst.Def)(implicit audience: Audience): String = {
-    val formattedArgs = defn.fparams.map {
+  private def formatFormalParams(fparams: List[TypedAst.FormalParam])(implicit audience: Audience): String = {
+    val formattedArgs = fparams.map {
       case TypedAst.FormalParam(sym, _, tpe, _) => s"${sym.text}: ${FormatType.formatType(tpe)}"
     }
 
@@ -41,8 +49,8 @@ object FormatSignature {
   /**
     * Returns a formatted string of the result type and effect.
     */
-  private def formatResultTypeAndEff(defn: TypedAst.Def)(implicit audience: Audience): String = {
-    val baseType = defn.declaredScheme.base
+  private def formatResultTypeAndEff(sc: Scheme)(implicit audience: Audience): String = {
+    val baseType = sc.base
     val resultTyp = getResultType(baseType)
     val resultEff = getEffectType(baseType)
 


### PR DESCRIPTION
Goto:
- [x] Exp.Sig

Hover:
- [x] Exp.Sig
- [x] Sig

FindRefs:
- [x] Exp.Sig - only works for other expressions.
- [x] ClassSym - class
- [x] Decl.Sig

Highlight:
- [x] Exp.Sig - only works for other expressions.

Other:
- [x] Process expressions inside instances.