### PR TITLE
Add ToString Instances

### DIFF
--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+instance ToString[Array[a]] with [a : ToString] {
+    def toString(a: Array[a]): String =
+    let s = Array.formatWith(x -> ToString.toString(x), ", ", a) as & Pure;
+    "[${s}]" as & Pure
+}
+
 namespace Array {
 
     ///

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -16,8 +16,8 @@
 
 instance ToString[Array[a]] with [a : ToString] {
     def toString(a: Array[a]): String =
-    let s = Array.formatWith(x -> ToString.toString(x), ", ", a) as & Pure;
-    "[${s}]" as & Pure
+        let s = Array.formatWith(x -> ToString.toString(x), ", ", a) as & Pure;
+        "[${s}]" as & Pure
 }
 
 namespace Array {

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -16,7 +16,7 @@
 
 instance ToString[Array[a]] with [a : ToString] {
     def toString(a: Array[a]): String =
-        let s = Array.formatWith(x -> ToString.toString(x), ", ", a) as & Pure;
+        let s = Array.formatWith(x -> "${x}", ", ", a) as & Pure;
         "[${s}]" as & Pure
 }
 

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -25,6 +25,11 @@ enum List[t] {
     case Cons(t, List[t])
 }
 
+instance ToString[List[a]] with [a : ToString] {
+    def toString(l: List[a]): String =
+        List.foldRight((x, acc) -> "${ToString.toString(x)} :: ${acc}", "Nil", l)
+}
+
 namespace List {
 
     ///

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -26,7 +26,8 @@ enum List[t] {
 }
 
 instance ToString[List[a]] with [a : ToString] {
-    def toString(xs: List[a]): String = List.formatWith(ToString.toString, ", ", xs)
+    def toString(xs: List[a]): String =
+        List.foldRight((x, acc) -> "${ToString.toString(x)} :: ${acc}", "Nil", xs)
 }
 
 namespace List {

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -26,8 +26,7 @@ enum List[t] {
 }
 
 instance ToString[List[a]] with [a : ToString] {
-    def toString(l: List[a]): String =
-        List.foldRight((x, acc) -> "${ToString.toString(x)} :: ${acc}", "Nil", l)
+    def toString(xs: List[a]): String = List.formatWith(ToString.toString, ", ", xs)
 }
 
 namespace List {
@@ -905,14 +904,17 @@ namespace List {
         }
     }
 
-
-
     ///
-    /// Returns the list of characters `xs` as a string.
+    /// Render the list `xs` as a String. Elements are rendered with the
+    /// function `f` and separated with the string `sep`.
     ///
-    @Time(length(xs)) @Space(length(xs))
-    pub def toString(xs: List[Char]): String =
-        List.foldLeft((acc, c) -> String.concat(acc, Char.toString(c)), "", xs)
+    @Time(time(f) * length(xs)) @Space(space(f) * length(xs))
+    pub def formatWith(f: a -> String, sep: String, xs: List[a]): String =
+        List.foldRight((x, acc) -> {
+            let s = "${f(x)}";
+            if (acc == "") s
+            else "${s}${sep}${acc}"
+        }, "", xs)
 
     ///
     /// Returns `xs` as a mutable list.

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -27,7 +27,7 @@ enum List[t] {
 
 instance ToString[List[a]] with [a : ToString] {
     def toString(xs: List[a]): String =
-        List.foldRight((x, acc) -> "${ToString.toString(x)} :: ${acc}", "Nil", xs)
+        List.foldRight((x, acc) -> "${x} :: ${acc}", "Nil", xs)
 }
 
 namespace List {

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -911,11 +911,8 @@ namespace List {
     ///
     @Time(time(f) * length(xs)) @Space(space(f) * length(xs))
     pub def formatWith(f: a -> String, sep: String, xs: List[a]): String =
-        List.foldRight((x, acc) -> {
-            let s = "${f(x)}";
-            if (acc == "") s
-            else "${s}${sep}${acc}"
-        }, "", xs)
+        let s = foldRight((x, acc) -> "${f(x)}${sep}${acc}", "", xs) as & Pure;
+        String.dropRight(String.length(sep), s)
 
     ///
     /// Returns `xs` as a mutable list.

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -26,6 +26,16 @@ enum Map[k, v] {
     case Map(RedBlackTree[k, v])
 }
 
+instance ToString[Map[k, v]] with [k : ToString, v : ToString] {
+    def toString(m: Map[k, v]): String =
+        let s = Map.foldRightWithKey((k, v, acc) -> {
+            let kv = "${ToString.toString(k)} -> ${ToString.toString(v)}";
+            if (acc == "") kv
+            else "${kv}, ${acc}"
+        }, "", m);
+        "Map(${s})"
+}
+
 namespace Map {
 
     ///

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -33,7 +33,7 @@ instance ToString[Map[k, v]] with [k : ToString, v : ToString] {
             if (acc == "") kv
             else "${kv}, ${acc}"
         }, "", m);
-        "Map(${s})"
+        "Map#{${s}}"
 }
 
 namespace Map {

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -28,11 +28,8 @@ enum Map[k, v] {
 
 instance ToString[Map[k, v]] with [k : ToString, v : ToString] {
     def toString(m: Map[k, v]): String =
-        let s = Map.foldRightWithKey((k, v, acc) -> {
-            if (acc == "") kv
-            else "${k} -> ${v}, ${acc}"
-        }, "", m);
-        "Map#{${s}}"
+        let s = Map.foldRightWithKey((k, v, acc) -> "${k} -> ${v}, ${acc}", "", m);
+        "Map#{${String.dropRight(2, s)}}"
 }
 
 namespace Map {

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -29,9 +29,8 @@ enum Map[k, v] {
 instance ToString[Map[k, v]] with [k : ToString, v : ToString] {
     def toString(m: Map[k, v]): String =
         let s = Map.foldRightWithKey((k, v, acc) -> {
-            let kv = "${ToString.toString(k)} -> ${ToString.toString(v)}";
             if (acc == "") kv
-            else "${kv}, ${acc}"
+            else "${k} -> ${v}, ${acc}"
         }, "", m);
         "Map#{${s}}"
 }

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -21,6 +21,16 @@ pub enum MutList[a] {
     case MutList(Ref[Array[a]], Ref[Int32])
 }
 
+instance ToString[MutList[a]] with [a : ToString] {
+    def toString(v: MutList[a]): String =
+        let s = MutList.foldRight((x, acc) -> {
+            let y = "${ToString.toString(x)}";
+            if (acc == "") y
+            else "${y}, ${acc}"
+        }, "", v) as & Pure;
+        "MutList(${s})"
+}
+
 namespace MutList {
 
     ///

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -22,13 +22,10 @@ pub enum MutList[a] {
 }
 
 instance ToString[MutList[a]] with [a : ToString] {
-    def toString(v: MutList[a]): String =
-        let s = MutList.foldRight((x, acc) -> {
-            let y = "${ToString.toString(x)}";
-            if (acc == "") y
-            else "${y}, ${acc}"
-        }, "", v) as & Pure;
-        "MutList(${s})"
+    def toString(v: MutList[a]): String = {
+        let s = MutList.formatWith(x -> "${x}", ", ", v) as & Pure;
+        "MutList#{${s}}"
+    }
 }
 
 namespace MutList {

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -23,11 +23,8 @@ opaque type MutMap[k, v] = Ref[Map[k, v]]
 
 instance ToString[MutMap[k, v]] with [k : ToString, v : ToString] {
     def toString(m: MutMap[k, v]): String =
-        let s = MutMap.foldRightWithKey((k, v, acc) -> {
-            if (acc == "") kv
-            else "${k} -> ${v}, ${acc}"
-        }, "", m) as & Pure;
-        "MutMap#{${s}}"
+        let s = MutMap.foldRightWithKey((k, v, acc) -> "${k} -> ${v}, ${acc}", "", m) as & Pure;
+        "MutMap#{${String.dropRight(2, s)}}"
 }
 
 namespace MutMap {

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -28,7 +28,7 @@ instance ToString[MutMap[k, v]] with [k : ToString, v : ToString] {
             if (acc == "") kv
             else "${kv}, ${acc}"
         }, "", m) as & Pure;
-        "MutMap(${s})"
+        "MutMap#{${s}}"
 }
 
 namespace MutMap {

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -21,6 +21,16 @@ use Core/Cmp.Ordering;
 ///
 opaque type MutMap[k, v] = Ref[Map[k, v]]
 
+instance ToString[MutMap[k, v]] with [k : ToString, v : ToString] {
+    def toString(m: MutMap[k, v]): String =
+        let s = MutMap.foldRightWithKey((k, v, acc) -> {
+            let kv = "${ToString.toString(k)} -> ${ToString.toString(v)}";
+            if (acc == "") kv
+            else "${kv}, ${acc}"
+        }, "", m) as & Pure;
+        "MutMap(${s})"
+}
+
 namespace MutMap {
 
     ///

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -24,9 +24,8 @@ opaque type MutMap[k, v] = Ref[Map[k, v]]
 instance ToString[MutMap[k, v]] with [k : ToString, v : ToString] {
     def toString(m: MutMap[k, v]): String =
         let s = MutMap.foldRightWithKey((k, v, acc) -> {
-            let kv = "${ToString.toString(k)} -> ${ToString.toString(v)}";
             if (acc == "") kv
-            else "${kv}, ${acc}"
+            else "${k} -> ${v}, ${acc}"
         }, "", m) as & Pure;
         "MutMap#{${s}}"
 }

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -28,7 +28,7 @@ instance ToString[MutSet[a]] with [a : ToString] {
             if (acc == "") y
             else "${y}, ${acc}"
         }, "", xs) as & Pure;
-        "MutSet(${s})"
+        "MutSet#{${s}}"
 }
 
 namespace MutSet {

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -23,11 +23,8 @@ opaque type MutSet[t] = Ref[Set[t]]
 
 instance ToString[MutSet[a]] with [a : ToString] {
     def toString(xs: MutSet[a]): String =
-        let s = MutSet.foldRight((x, acc) -> {
-            if (acc == "") y
-            else "${x}, ${acc}"
-        }, "", xs) as & Pure;
-        "MutSet#{${s}}"
+        let s = MutSet.foldRight((x, acc) -> "${x}, ${acc}", "", xs) as & Pure;
+        "MutSet#{${String.dropRight(2, s)}}"
 }
 
 namespace MutSet {

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -21,6 +21,16 @@ use Core/Cmp.Ordering;
 ///
 opaque type MutSet[t] = Ref[Set[t]]
 
+instance ToString[MutSet[a]] with [a : ToString] {
+    def toString(xs: MutSet[a]): String =
+        let s = MutSet.foldRight((x, acc) -> {
+            let y = "${ToString.toString(x)}";
+            if (acc == "") y
+            else "${y}, ${acc}"
+        }, "", xs) as & Pure;
+        "MutSet(${s})"
+}
+
 namespace MutSet {
 
     ///

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -24,9 +24,8 @@ opaque type MutSet[t] = Ref[Set[t]]
 instance ToString[MutSet[a]] with [a : ToString] {
     def toString(xs: MutSet[a]): String =
         let s = MutSet.foldRight((x, acc) -> {
-            let y = "${ToString.toString(x)}";
             if (acc == "") y
-            else "${y}, ${acc}"
+            else "${x}, ${acc}"
         }, "", xs) as & Pure;
         "MutSet#{${s}}"
 }

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -22,6 +22,12 @@ pub enum Nel[a] {
     case Nel(a, List[a])
 }
 
+instance ToString[Nel[a]] with [a : ToString, List[a] : ToString] {
+    def toString(l: Nel[a]): String = match l {
+        case Nel(x, xs) => "Nel(${x}, ${xs})"
+    }
+}
+
 namespace Nel {
 
     ///

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -28,8 +28,8 @@ enum Option[t] {
 
 instance ToString[Option[a]] with [a : ToString] {
     def toString(o: Option[a]): String = match o {
-        case Some(y) => "Some(${y})"
         case None => "None"
+        case Some(y) => "Some(${y})"
     }
 }
 

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -26,6 +26,13 @@ enum Option[t] {
     case Some(t)
 }
 
+instance ToString[Option[a]] with [a : ToString] {
+    def toString(o: Option[a]): String = match o {
+        case Some(y) => "Some(${y})"
+        case None => "None"
+    }
+}
+
 namespace Option {
 
     ///

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -28,8 +28,8 @@ enum Result[t, e] {
 
 instance ToString[Result[t, e]] with [t : ToString, e : ToString] {
     def toString(r: Result[t, e]): String = match r {
-        case Ok(v)  => "Ok(${v})"
-        case Err(v) => "Err(${v})"
+        case Ok(t)  => "Ok(${t})"
+        case Err(e) => "Err(${e})"
     }
 }
 

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -26,6 +26,13 @@ enum Result[t, e] {
     case Err(e)
 }
 
+instance ToString[Result[t, e]] with [t : ToString, e : ToString] {
+    def toString(r: Result[t, e]): String = match r {
+        case Ok(v)  => "Ok(${v})"
+        case Err(v) => "Err(${v})"
+    }
+}
+
 namespace Result {
 
     ///

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -26,6 +26,16 @@ enum Set[t] {
     case Set(RedBlackTree[t, Unit])
 }
 
+instance ToString[Set[a]] with [a : ToString] {
+    def toString(xs: Set[a]): String =
+        let s = Set.foldRight((x, acc) -> {
+            let y = "${ToString.toString(x)}";
+            if (acc == "") y
+            else "${y}, ${acc}"
+            }, "", xs);
+        "Set(${s})"
+}
+
 namespace Set {
 
     ///

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -33,7 +33,7 @@ instance ToString[Set[a]] with [a : ToString] {
             if (acc == "") y
             else "${y}, ${acc}"
             }, "", xs);
-        "Set(${s})"
+        "Set#{${s}}"
 }
 
 namespace Set {

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -28,11 +28,8 @@ enum Set[t] {
 
 instance ToString[Set[a]] with [a : ToString] {
     def toString(xs: Set[a]): String =
-        let s = Set.foldRight((x, acc) -> {
-            if (acc == "") y
-            else "${x}, ${acc}"
-            }, "", xs);
-        "Set#{${s}}"
+        let s = Set.foldRight((x, acc) -> "${x}, ${acc}", "", xs);
+        "Set#{${String.dropRight(2, s)}}"
 }
 
 namespace Set {

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -29,9 +29,8 @@ enum Set[t] {
 instance ToString[Set[a]] with [a : ToString] {
     def toString(xs: Set[a]): String =
         let s = Set.foldRight((x, acc) -> {
-            let y = "${ToString.toString(x)}";
             if (acc == "") y
-            else "${y}, ${acc}"
+            else "${x}, ${acc}"
             }, "", xs);
         "Set#{${s}}"
 }

--- a/main/src/library/ToString.flix
+++ b/main/src/library/ToString.flix
@@ -133,6 +133,3 @@ instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with [a1 : ToString
             "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)}, ${ToString.toString(x4)}, ${ToString.toString(x5)}, ${ToString.toString(x6)}, ${ToString.toString(x7)}, ${ToString.toString(x8)}, ${ToString.toString(x9)}, ${ToString.toString(x10)})"
     }
 }
-
-// TODO: Move tests from TestToString into proper namespaces/files, e.g. TestOption, TestList, etc.
-// TODO: Write more systematic tests that use different types (?).

--- a/main/src/library/ToString.flix
+++ b/main/src/library/ToString.flix
@@ -71,5 +71,68 @@ instance ToString[BigInt] {
     def toString(x: BigInt): String = BigInt.toString(x)
 }
 
+instance ToString[(a1, a2)] with [a1 : ToString, a2 : ToString] {
+    def toString(t: (a1, a2)): String = match t {
+        case (x1, x2) =>
+            "(${ToString.toString(x1)}, ${ToString.toString(x2)})"
+    }
+}
+
+instance ToString[(a1, a2, a3)] with [a1 : ToString, a2 : ToString, a3 : ToString] {
+    def toString(t: (a1, a2, a3)): String = match t {
+        case (x1, x2, x3) =>
+            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)})"
+    }
+}
+
+instance ToString[(a1, a2, a3, a4)] with [a1 : ToString, a2 : ToString, a3 : ToString, a4 : ToString] {
+    def toString(t: (a1, a2, a3, a4)): String = match t {
+        case (x1, x2, x3, x4) =>
+            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)}, ${ToString.toString(x4)})"
+    }
+}
+
+instance ToString[(a1, a2, a3, a4, a5)] with [a1 : ToString, a2 : ToString, a3 : ToString, a4 : ToString, a5 : ToString] {
+    def toString(t: (a1, a2, a3, a4, a5)): String = match t {
+        case (x1, x2, x3, x4, x5) =>
+            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)}, ${ToString.toString(x4)}, ${ToString.toString(x5)})"
+    }
+}
+
+instance ToString[(a1, a2, a3, a4, a5, a6)] with [a1 : ToString, a2 : ToString, a3 : ToString, a4 : ToString, a5 : ToString, a6 : ToString] {
+    def toString(t: (a1, a2, a3, a4, a5, a6)): String = match t {
+        case (x1, x2, x3, x4, x5, x6) =>
+            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)}, ${ToString.toString(x4)}, ${ToString.toString(x5)}, ${ToString.toString(x6)})"
+    }
+}
+
+instance ToString[(a1, a2, a3, a4, a5, a6, a7)] with [a1 : ToString, a2 : ToString, a3 : ToString, a4 : ToString, a5 : ToString, a6 : ToString, a7 : ToString] {
+    def toString(t: (a1, a2, a3, a4, a5, a6, a7)): String = match t {
+        case (x1, x2, x3, x4, x5, x6, x7) =>
+            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)}, ${ToString.toString(x4)}, ${ToString.toString(x5)}, ${ToString.toString(x6)}, ${ToString.toString(x7)})"
+    }
+}
+
+instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8)] with [a1 : ToString, a2 : ToString, a3 : ToString, a4 : ToString, a5 : ToString, a6 : ToString, a7 : ToString, a8 : ToString] {
+    def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8)): String = match t {
+        case (x1, x2, x3, x4, x5, x6, x7, x8) =>
+            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)}, ${ToString.toString(x4)}, ${ToString.toString(x5)}, ${ToString.toString(x6)}, ${ToString.toString(x7)}, ${ToString.toString(x8)})"
+    }
+}
+
+instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with [a1 : ToString, a2 : ToString, a3 : ToString, a4 : ToString, a5 : ToString, a6 : ToString, a7 : ToString, a8 : ToString, a9 : ToString] {
+    def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): String = match t {
+        case (x1, x2, x3, x4, x5, x6, x7, x8, x9) =>
+            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)}, ${ToString.toString(x4)}, ${ToString.toString(x5)}, ${ToString.toString(x6)}, ${ToString.toString(x7)}, ${ToString.toString(x8)}, ${ToString.toString(x9)})"
+    }
+}
+
+instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with [a1 : ToString, a2 : ToString, a3 : ToString, a4 : ToString, a5 : ToString, a6 : ToString, a7 : ToString, a8 : ToString, a9 : ToString, a10 : ToString] {
+    def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): String = match t {
+        case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) =>
+            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)}, ${ToString.toString(x4)}, ${ToString.toString(x5)}, ${ToString.toString(x6)}, ${ToString.toString(x7)}, ${ToString.toString(x8)}, ${ToString.toString(x9)}, ${ToString.toString(x10)})"
+    }
+}
+
 // TODO: Move tests from TestToString into proper namespaces/files, e.g. TestOption, TestList, etc.
 // TODO: Write more systematic tests that use different types (?).

--- a/main/src/library/ToString.flix
+++ b/main/src/library/ToString.flix
@@ -74,62 +74,62 @@ instance ToString[BigInt] {
 instance ToString[(a1, a2)] with [a1 : ToString, a2 : ToString] {
     def toString(t: (a1, a2)): String = match t {
         case (x1, x2) =>
-            "(${ToString.toString(x1)}, ${ToString.toString(x2)})"
+            "(${x1}, ${x2})"
     }
 }
 
 instance ToString[(a1, a2, a3)] with [a1 : ToString, a2 : ToString, a3 : ToString] {
     def toString(t: (a1, a2, a3)): String = match t {
         case (x1, x2, x3) =>
-            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)})"
+            "(${x1}, ${x2}, ${x3})"
     }
 }
 
 instance ToString[(a1, a2, a3, a4)] with [a1 : ToString, a2 : ToString, a3 : ToString, a4 : ToString] {
     def toString(t: (a1, a2, a3, a4)): String = match t {
         case (x1, x2, x3, x4) =>
-            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)}, ${ToString.toString(x4)})"
+            "(${x1}, ${x2}, ${x3}, ${x4})"
     }
 }
 
 instance ToString[(a1, a2, a3, a4, a5)] with [a1 : ToString, a2 : ToString, a3 : ToString, a4 : ToString, a5 : ToString] {
     def toString(t: (a1, a2, a3, a4, a5)): String = match t {
         case (x1, x2, x3, x4, x5) =>
-            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)}, ${ToString.toString(x4)}, ${ToString.toString(x5)})"
+            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5})"
     }
 }
 
 instance ToString[(a1, a2, a3, a4, a5, a6)] with [a1 : ToString, a2 : ToString, a3 : ToString, a4 : ToString, a5 : ToString, a6 : ToString] {
     def toString(t: (a1, a2, a3, a4, a5, a6)): String = match t {
         case (x1, x2, x3, x4, x5, x6) =>
-            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)}, ${ToString.toString(x4)}, ${ToString.toString(x5)}, ${ToString.toString(x6)})"
+            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6})"
     }
 }
 
 instance ToString[(a1, a2, a3, a4, a5, a6, a7)] with [a1 : ToString, a2 : ToString, a3 : ToString, a4 : ToString, a5 : ToString, a6 : ToString, a7 : ToString] {
     def toString(t: (a1, a2, a3, a4, a5, a6, a7)): String = match t {
         case (x1, x2, x3, x4, x5, x6, x7) =>
-            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)}, ${ToString.toString(x4)}, ${ToString.toString(x5)}, ${ToString.toString(x6)}, ${ToString.toString(x7)})"
+            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7})"
     }
 }
 
 instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8)] with [a1 : ToString, a2 : ToString, a3 : ToString, a4 : ToString, a5 : ToString, a6 : ToString, a7 : ToString, a8 : ToString] {
     def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8)): String = match t {
         case (x1, x2, x3, x4, x5, x6, x7, x8) =>
-            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)}, ${ToString.toString(x4)}, ${ToString.toString(x5)}, ${ToString.toString(x6)}, ${ToString.toString(x7)}, ${ToString.toString(x8)})"
+            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8})"
     }
 }
 
 instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with [a1 : ToString, a2 : ToString, a3 : ToString, a4 : ToString, a5 : ToString, a6 : ToString, a7 : ToString, a8 : ToString, a9 : ToString] {
     def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): String = match t {
         case (x1, x2, x3, x4, x5, x6, x7, x8, x9) =>
-            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)}, ${ToString.toString(x4)}, ${ToString.toString(x5)}, ${ToString.toString(x6)}, ${ToString.toString(x7)}, ${ToString.toString(x8)}, ${ToString.toString(x9)})"
+            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9})"
     }
 }
 
 instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with [a1 : ToString, a2 : ToString, a3 : ToString, a4 : ToString, a5 : ToString, a6 : ToString, a7 : ToString, a8 : ToString, a9 : ToString, a10 : ToString] {
     def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): String = match t {
         case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) =>
-            "(${ToString.toString(x1)}, ${ToString.toString(x2)}, ${ToString.toString(x3)}, ${ToString.toString(x4)}, ${ToString.toString(x5)}, ${ToString.toString(x6)}, ${ToString.toString(x7)}, ${ToString.toString(x8)}, ${ToString.toString(x9)}, ${ToString.toString(x10)})"
+            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10})"
     }
 }

--- a/main/src/library/ToString.flix
+++ b/main/src/library/ToString.flix
@@ -71,44 +71,5 @@ instance ToString[BigInt] {
     def toString(x: BigInt): String = BigInt.toString(x)
 }
 
-instance ToString[Option[a]] with [a : ToString] {
-    def toString(o: Option[a]): String = match o {
-        case Some(y) => "Some(${y})"
-        case None => "None"
-    }
-}
-
-instance ToString[List[a]] with [a : ToString] {
-    def toString(l: List[a]): String = match l {
-        // TODO: Replace by foldRight.
-        case Nil => "Nil"
-        case _   =>
-            let s = l |> List.map(ToString.toString) |> List.intersperse(" :: ") |> String.flatten;
-            String.concat(s, " :: Nil")
-    }
-}
-
-instance ToString[Nel[a]] with [a : ToString, List[a] : ToString] {
-    def toString(l: Nel[a]): String = match l {
-        case Nel(x, xs) => "Nel(${x}, ${xs})"
-    }
-}
-
-instance ToString[Result[t, e]] with [t : ToString, e : ToString] {
-    def toString(r: Result[t, e]): String = match r {
-        case Ok(v)  => "Ok(${v})"
-        case Err(v) => "Err(${v})"
-    }
-}
-
-instance ToString[Validation[t, e]] with [t : ToString, Nel[e] : ToString] {
-    def toString(x: Validation[t, e]): String = match x {
-        case Success(v) => "Success(${v})"
-        case Failure(v) => "Failure(${v})"
-    }
-}
-
-// TODO: Move instances to proper namespaces, e.g. to Option, List, etc.
 // TODO: Move tests from TestToString into proper namespaces/files, e.g. TestOption, TestList, etc.
-// TODO: Add instances for Array, Map, MutList, MutMap, MutSet, Set
 // TODO: Write more systematic tests that use different types (?).

--- a/main/src/library/Validation.flix
+++ b/main/src/library/Validation.flix
@@ -22,6 +22,13 @@ pub enum Validation[t, e] {
     case Failure(Nel[e])
 }
 
+instance ToString[Validation[t, e]] with [t : ToString, Nel[e] : ToString] {
+    def toString(x: Validation[t, e]): String = match x {
+        case Success(v) => "Success(${v})"
+        case Failure(v) => "Failure(${v})"
+    }
+}
+
 namespace Validation {
 
     ///

--- a/main/src/library/Validation.flix
+++ b/main/src/library/Validation.flix
@@ -24,8 +24,8 @@ pub enum Validation[t, e] {
 
 instance ToString[Validation[t, e]] with [t : ToString, Nel[e] : ToString] {
     def toString(x: Validation[t, e]): String = match x {
-        case Success(v) => "Success(${v})"
-        case Failure(v) => "Failure(${v})"
+        case Success(t) => "Success(${t})"
+        case Failure(e) => "Failure(${e})"
     }
 }
 

--- a/main/test/ca/uwaterloo/flix/library/LibrarySuite.scala
+++ b/main/test/ca/uwaterloo/flix/library/LibrarySuite.scala
@@ -45,6 +45,8 @@ class LibrarySuite extends Suites(
   new FlixTest("TestTimer", "main/test/ca/uwaterloo/flix/library/TestTimer.flix")(Options.TestWithLibrary),
   new FlixTest("TestValidation", "main/test/ca/uwaterloo/flix/library/TestValidation.flix")(Options.TestWithLibrary),
   new FlixTest("TestMutList", "main/test/ca/uwaterloo/flix/library/TestMutList.flix")(Options.TestWithLibrary),
+  new FlixTest("TestMutSet", "main/test/ca/uwaterloo/flix/library/TestMutSet.flix")(Options.TestWithLibrary),
+  new FlixTest("TestMutMap", "main/test/ca/uwaterloo/flix/library/TestMutMap.flix")(Options.TestWithLibrary),
   new FlixTest("TestToString", "main/test/ca/uwaterloo/flix/library/TestToString.flix")(Options.TestWithLibrary),
   new FlixTest("TestFromString", "main/test/ca/uwaterloo/flix/library/TestFromString.flix")(Options.TestWithLibrary),
   new FlixTest("TestFunctor", "main/test/ca/uwaterloo/flix/library/TestFunctor.flix")(Options.TestWithLibrary),

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -16,6 +16,8 @@
 
 namespace TestArray {
 
+use ToString.toString;
+
 /////////////////////////////////////////////////////////////////////////////
 // new                                                                     //
 /////////////////////////////////////////////////////////////////////////////
@@ -4041,5 +4043,25 @@ def sortWith13!(): Bool & Impure =
     let a = [2,3,0,4,1,2];
     Array.sortWith!((x,y) -> if (x > y) -1 else 1, a);
     Array.sameElements(a, [4,3,2,2,1,0])
+
+/////////////////////////////////////////////////////////////////////////////
+// toString                                                                //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def toString01(): Bool & Impure =
+    toString(Array.range(0, 5)) == "[0, 1, 2, 3, 4]"
+
+@test
+def toString02(): Bool & Impure =
+    toString(Array.range(0, 1)) == "[0]"
+
+@test
+def toString03(): Bool & Impure =
+    toString(Array.new('a', 3)) == "[a, a, a]"
+
+@test
+def toString04(): Bool & Impure =
+    toString(Array.range(1, 3)) == "[1, 2]"
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -16,7 +16,7 @@
 
 namespace TestArray {
 
-use ToString.toString;
+    use ToString.toString;
 
 /////////////////////////////////////////////////////////////////////////////
 // new                                                                     //
@@ -4044,24 +4044,28 @@ def sortWith13!(): Bool & Impure =
     Array.sortWith!((x,y) -> if (x > y) -1 else 1, a);
     Array.sameElements(a, [4,3,2,2,1,0])
 
-/////////////////////////////////////////////////////////////////////////////
-// toString                                                                //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // toString                                                                //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def toString01(): Bool & Impure =
-    toString(Array.range(0, 5)) == "[0, 1, 2, 3, 4]"
+    @test
+    def toString01(): Bool & Impure =
+        toString(Array.range(0, 5)) == "[0, 1, 2, 3, 4]"
 
-@test
-def toString02(): Bool & Impure =
-    toString(Array.range(0, 1)) == "[0]"
+    @test
+    def toString02(): Bool & Impure =
+        toString(Array.range(0, 1)) == "[0]"
 
-@test
-def toString03(): Bool & Impure =
-    toString(Array.new('a', 3)) == "[a, a, a]"
+    @test
+    def toString03(): Bool & Impure =
+        toString(Array.new('a', 3)) == "[a, a, a]"
 
-@test
-def toString04(): Bool & Impure =
-    toString(Array.range(1, 3)) == "[1, 2]"
+    @test
+    def toString04(): Bool & Impure =
+        toString(Array.range(1, 3)) == "[1, 2]"
+
+    @test
+    def toString05(): Bool & Impure =
+        toString(Array.new([1, 2, 3], 3)) == "[[1, 2, 3], [1, 2, 3], [1, 2, 3]]"
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -16,7 +16,7 @@
 
 namespace TestList {
 
-use ToString.toString;
+    use ToString.toString;
 
 /////////////////////////////////////////////////////////////////////////////
 // isEmpty                                                                 //
@@ -2063,28 +2063,32 @@ def distinctWith08(): Bool =
 def distinctWith09(): Bool =
     List.distinctWith((x,y) -> x == y, 4 :: 4 :: 3  :: 4 :: 2 :: 1 :: 1 :: Nil) == 4 :: 3 :: 2 :: 1 :: Nil
 
-/////////////////////////////////////////////////////////////////////////////
-// toString                                                                //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // toString                                                                //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def toString01(): Bool =
-    toString(1 :: Nil) == "1 :: Nil"
+    @test
+    def toString01(): Bool =
+        toString(1 :: Nil) == "1 :: Nil"
 
-@test
-def toString02(): Bool =
-    toString(1 :: 2 :: Nil) == "1 :: 2 :: Nil"
+    @test
+    def toString02(): Bool =
+        toString(1 :: 2 :: Nil) == "1 :: 2 :: Nil"
 
-@test
-def toString03(): Bool =
-    toString(93 :: 3 :: 4 :: Nil) == "93 :: 3 :: 4 :: Nil"
+    @test
+    def toString03(): Bool =
+        toString(93 :: 3 :: 4 :: Nil) == "93 :: 3 :: 4 :: Nil"
 
-@test
-def toString04(): Bool =
-    toString('a' :: 'b' :: 'c' :: Nil) == "a :: b :: c :: Nil"
+    @test
+    def toString04(): Bool =
+        toString('a' :: 'b' :: 'c' :: Nil) == "a :: b :: c :: Nil"
 
-@test
-def toString05(): Bool =
-    toString(true :: false :: true :: true :: Nil) == "true :: false :: true :: true :: Nil"
+    @test
+    def toString05(): Bool =
+        toString(true :: false :: true :: true :: Nil) == "true :: false :: true :: true :: Nil"
+
+    @test
+    def toString06(): Bool =
+        toString((1 :: 2 :: Nil) (2 :: 3 :: Nil) :: (4 :: 7) :: Nil) == "1 :: 2 :: Nil :: 2 :: 3 :: Nil :: 4 :: 7 :: Nil :: Nil"
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -2089,6 +2089,6 @@ def distinctWith09(): Bool =
 
     @test
     def toString06(): Bool =
-        toString((1 :: 2 :: Nil) (2 :: 3 :: Nil) :: (4 :: 7) :: Nil) == "1 :: 2 :: Nil :: 2 :: 3 :: Nil :: 4 :: 7 :: Nil :: Nil"
+        toString((1 :: 2 :: Nil) :: (2 :: 3 :: Nil) :: (4 :: 7 :: Nil) :: Nil) == "1 :: 2 :: Nil :: 2 :: 3 :: Nil :: 4 :: 7 :: Nil :: Nil"
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -16,6 +16,8 @@
 
 namespace TestList {
 
+use ToString.toString;
+
 /////////////////////////////////////////////////////////////////////////////
 // isEmpty                                                                 //
 /////////////////////////////////////////////////////////////////////////////
@@ -2060,5 +2062,29 @@ def distinctWith08(): Bool =
 @test
 def distinctWith09(): Bool =
     List.distinctWith((x,y) -> x == y, 4 :: 4 :: 3  :: 4 :: 2 :: 1 :: 1 :: Nil) == 4 :: 3 :: 2 :: 1 :: Nil
+
+/////////////////////////////////////////////////////////////////////////////
+// toString                                                                //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def toString01(): Bool =
+    toString(1 :: Nil) == "1 :: Nil"
+
+@test
+def toString02(): Bool =
+    toString(1 :: 2 :: Nil) == "1 :: 2 :: Nil"
+
+@test
+def toString03(): Bool =
+    toString(93 :: 3 :: 4 :: Nil) == "93 :: 3 :: 4 :: Nil"
+
+@test
+def toString04(): Bool =
+    toString('a' :: 'b' :: 'c' :: Nil) == "a :: b :: c :: Nil"
+
+@test
+def toString05(): Bool =
+    toString(true :: false :: true :: true :: Nil) == "true :: false :: true :: true :: Nil"
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMap.flix
@@ -18,6 +18,8 @@ use Core/Cmp.Ordering.{LessThan, Equal, GreaterThan};
 
 namespace TestMap {
 
+use ToString.toString;
+
 /////////////////////////////////////////////////////////////////////////////
 // size                                                                    //
 /////////////////////////////////////////////////////////////////////////////
@@ -1763,5 +1765,25 @@ def query17(): Bool =
 def query18(): Bool =
     let m = Map#{(1, 2, 2) -> 0, (1, 2, 3) -> 1, (1, 2, 4) -> 2, (2, 2, 4) -> 3};
     Map.query(x -> if (x <=> (1, 2, 3) > 0) GreaterThan else Equal, m) == ((1, 2, 2), 0) :: ((1, 2, 3), 1) :: Nil
+
+/////////////////////////////////////////////////////////////////////////////
+// toString                                                                //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def toString01(): Bool =
+    toString(Map#{1 -> 2}) == "Map(1 -> 2)"
+
+@test
+def toString02(): Bool =
+    toString(Map#{1 -> 0, 2 -> 1, 3 -> 2}) == "Map(1 -> 0, 2 -> 1, 3 -> 2)"
+
+@test
+def toString03(): Bool =
+    toString(Map#{1 -> "b", 2 -> "a"}) == "Map(1 -> b, 2 -> a)"
+
+@test
+def toString04(): Bool =
+    toString(Map#{97 -> false, 2 -> true, 3 -> false, 4 -> true, 0 -> true}) == "Map(0 -> true, 2 -> true, 3 -> false, 4 -> true, 97 -> false)"
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMap.flix
@@ -18,7 +18,7 @@ use Core/Cmp.Ordering.{LessThan, Equal, GreaterThan};
 
 namespace TestMap {
 
-use ToString.toString;
+    use ToString.toString;
 
 /////////////////////////////////////////////////////////////////////////////
 // size                                                                    //
@@ -1766,24 +1766,28 @@ def query18(): Bool =
     let m = Map#{(1, 2, 2) -> 0, (1, 2, 3) -> 1, (1, 2, 4) -> 2, (2, 2, 4) -> 3};
     Map.query(x -> if (x <=> (1, 2, 3) > 0) GreaterThan else Equal, m) == ((1, 2, 2), 0) :: ((1, 2, 3), 1) :: Nil
 
-/////////////////////////////////////////////////////////////////////////////
-// toString                                                                //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // toString                                                                //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def toString01(): Bool =
-    toString(Map#{1 -> 2}) == "Map(1 -> 2)"
+    @test
+    def toString01(): Bool =
+        toString(Map#{1 -> 2}) == "Map#{1 -> 2}"
 
-@test
-def toString02(): Bool =
-    toString(Map#{1 -> 0, 2 -> 1, 3 -> 2}) == "Map(1 -> 0, 2 -> 1, 3 -> 2)"
+    @test
+    def toString02(): Bool =
+        toString(Map#{1 -> 0, 2 -> 1, 3 -> 2}) == "Map#{1 -> 0, 2 -> 1, 3 -> 2}"
 
-@test
-def toString03(): Bool =
-    toString(Map#{1 -> "b", 2 -> "a"}) == "Map(1 -> b, 2 -> a)"
+    @test
+    def toString03(): Bool =
+        toString(Map#{1 -> "b", 2 -> "a"}) == "Map#{1 -> b, 2 -> a}"
 
-@test
-def toString04(): Bool =
-    toString(Map#{97 -> false, 2 -> true, 3 -> false, 4 -> true, 0 -> true}) == "Map(0 -> true, 2 -> true, 3 -> false, 4 -> true, 97 -> false)"
+    @test
+    def toString04(): Bool =
+        toString(Map#{97 -> false, 2 -> true, 3 -> false, 4 -> true, 0 -> true}) == "Map#{0 -> true, 2 -> true, 3 -> false, 4 -> true, 97 -> false}"
+
+    @test
+    def toString05(): Bool =
+        toString(Map#{2 -> Map#{1 -> 0, 2 -> 1}, 3 -> Map#{3 -> 2, 4 -> 92}}) == "Map#{2 -> Map#{1 -> 0, 2 -> 1}, 3 -> Map#{3 -> 2, 4 -> 92}}"
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestMutList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutList.flix
@@ -1238,14 +1238,14 @@ namespace TestMutList {
     def toString01(): Bool & Impure =
         let v = MutList.new();
         MutList.push!(1, v);
-        toString(v) == "MutList(1)"
+        toString(v) == "MutList#{1}"
 
     @test
     def toString02(): Bool & Impure =
         let v = MutList.new();
         MutList.push!(1, v);
         MutList.push!(97, v);
-        toString(v) == "MutList(1, 97)"
+        toString(v) == "MutList#{1, 97}"
 
     @test
     def toString03(): Bool & Impure =
@@ -1253,7 +1253,7 @@ namespace TestMutList {
         MutList.push!(1, v);
         MutList.push!(97, v);
         MutList.push!(0, v);
-        toString(v) == "MutList(1, 97, 0)"
+        toString(v) == "MutList#{1, 97, 0}"
 
     @test
     def toString04(): Bool & Impure =
@@ -1262,6 +1262,6 @@ namespace TestMutList {
         MutList.push!('b', v);
         MutList.push!('c', v);
         MutList.push!('d', v);
-        toString(v) == "MutList(a, b, c, d)"
+        toString(v) == "MutList#{a, b, c, d}"
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestMutList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutList.flix
@@ -16,6 +16,8 @@
 
 namespace TestMutList {
 
+    use ToString.toString;
+
     /////////////////////////////////////////////////////////////////////////////
     // length                                                                  //
     /////////////////////////////////////////////////////////////////////////////
@@ -1227,5 +1229,39 @@ namespace TestMutList {
         MutList.insert!(2, 0, v);
         MutList.insert!(1, 0, v);
         MutList.capacity(v) == 8
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toString                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toString01(): Bool & Impure =
+        let v = MutList.new();
+        MutList.push!(1, v);
+        toString(v) == "MutList(1)"
+
+    @test
+    def toString02(): Bool & Impure =
+        let v = MutList.new();
+        MutList.push!(1, v);
+        MutList.push!(97, v);
+        toString(v) == "MutList(1, 97)"
+
+    @test
+    def toString03(): Bool & Impure =
+        let v = MutList.new();
+        MutList.push!(1, v);
+        MutList.push!(97, v);
+        MutList.push!(0, v);
+        toString(v) == "MutList(1, 97, 0)"
+
+    @test
+    def toString04(): Bool & Impure =
+        let v = MutList.new();
+        MutList.push!('a', v);
+        MutList.push!('b', v);
+        MutList.push!('c', v);
+        MutList.push!('d', v);
+        toString(v) == "MutList(a, b, c, d)"
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestMutMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutMap.flix
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Esben Bjerre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace TestMutMap {
+
+use ToString.toString;
+
+/////////////////////////////////////////////////////////////////////////////
+// toString                                                                //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def toString01(): Bool & Impure =
+    let s = MutMap.empty();
+    MutMap.put!(1, 45, s);
+    toString(s) == "MutMap(1 -> 45)"
+
+@test
+def toString02(): Bool & Impure =
+    let s = MutMap.empty();
+    MutMap.put!(1, 3, s);
+    MutMap.put!(2, 4, s);
+    toString(s) == "MutMap(1 -> 3, 2 -> 4)"
+
+@test
+def toString03(): Bool & Impure =
+    let s = MutMap.empty();
+    MutMap.put!(1, 'a', s);
+    MutMap.put!(92, 'b', s);
+    MutMap.put!(94, 'c', s);
+    MutMap.put!(97, 'd', s);
+    toString(s) == "MutMap(1 -> a, 92 -> b, 94 -> c, 97 -> d)"
+
+@test
+def toString04(): Bool & Impure =
+    let s = MutMap.empty();
+    MutMap.put!('a', 6, s);
+    MutMap.put!('b', 7, s);
+    MutMap.put!('c', 10, s);
+    MutMap.put!('d', 1337, s);
+    toString(s) == "MutMap(a -> 6, b -> 7, c -> 10, d -> 1337)"
+
+}

--- a/main/test/ca/uwaterloo/flix/library/TestMutMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutMap.flix
@@ -16,41 +16,41 @@
 
 namespace TestMutMap {
 
-use ToString.toString;
+    use ToString.toString;
 
-/////////////////////////////////////////////////////////////////////////////
-// toString                                                                //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // toString                                                                //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def toString01(): Bool & Impure =
-    let s = MutMap.empty();
-    MutMap.put!(1, 45, s);
-    toString(s) == "MutMap(1 -> 45)"
+    @test
+    def toString01(): Bool & Impure =
+        let s = MutMap.empty();
+        MutMap.put!(1, 45, s);
+        toString(s) == "MutMap#{1 -> 45}"
 
-@test
-def toString02(): Bool & Impure =
-    let s = MutMap.empty();
-    MutMap.put!(1, 3, s);
-    MutMap.put!(2, 4, s);
-    toString(s) == "MutMap(1 -> 3, 2 -> 4)"
+    @test
+    def toString02(): Bool & Impure =
+        let s = MutMap.empty();
+        MutMap.put!(1, 3, s);
+        MutMap.put!(2, 4, s);
+        toString(s) == "MutMap#{1 -> 3, 2 -> 4}"
 
-@test
-def toString03(): Bool & Impure =
-    let s = MutMap.empty();
-    MutMap.put!(1, 'a', s);
-    MutMap.put!(92, 'b', s);
-    MutMap.put!(94, 'c', s);
-    MutMap.put!(97, 'd', s);
-    toString(s) == "MutMap(1 -> a, 92 -> b, 94 -> c, 97 -> d)"
+    @test
+    def toString03(): Bool & Impure =
+        let s = MutMap.empty();
+        MutMap.put!(1, 'a', s);
+        MutMap.put!(92, 'b', s);
+        MutMap.put!(94, 'c', s);
+        MutMap.put!(97, 'd', s);
+        toString(s) == "MutMap#{1 -> a, 92 -> b, 94 -> c, 97 -> d}"
 
-@test
-def toString04(): Bool & Impure =
-    let s = MutMap.empty();
-    MutMap.put!('a', 6, s);
-    MutMap.put!('b', 7, s);
-    MutMap.put!('c', 10, s);
-    MutMap.put!('d', 1337, s);
-    toString(s) == "MutMap(a -> 6, b -> 7, c -> 10, d -> 1337)"
+    @test
+    def toString04(): Bool & Impure =
+        let s = MutMap.empty();
+        MutMap.put!('a', 6, s);
+        MutMap.put!('b', 7, s);
+        MutMap.put!('c', 10, s);
+        MutMap.put!('d', 1337, s);
+        toString(s) == "MutMap#{a -> 6, b -> 7, c -> 10, d -> 1337}"
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestMutSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutSet.flix
@@ -26,14 +26,14 @@ namespace TestMutSet {
     def toString01(): Bool & Impure =
         let s = MutSet.empty();
         MutSet.add!(1, s);
-        toString(s) == "MutSet(1)"
+        toString(s) == "MutSet#{1}"
 
     @test
     def toString02(): Bool & Impure =
         let s = MutSet.empty();
         MutSet.add!(1, s);
         MutSet.add!(2, s);
-        toString(s) == "MutSet(1, 2)"
+        toString(s) == "MutSet#{1, 2}"
 
     @test
     def toString03(): Bool & Impure =
@@ -42,7 +42,7 @@ namespace TestMutSet {
         MutSet.add!(92, s);
         MutSet.add!(94, s);
         MutSet.add!(97, s);
-        toString(s) == "MutSet(1, 92, 94, 97)"
+        toString(s) == "MutSet#{1, 92, 94, 97}"
 
     @test
     def toString04(): Bool & Impure =
@@ -51,6 +51,6 @@ namespace TestMutSet {
         MutSet.add!('b', s);
         MutSet.add!('c', s);
         MutSet.add!('d', s);
-        toString(s) == "MutSet(a, b, c, d)"
+        toString(s) == "MutSet#{a, b, c, d}"
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestMutSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutSet.flix
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Esben Bjerre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace TestMutSet {
+
+use ToString.toString;
+
+/////////////////////////////////////////////////////////////////////////////
+// toString                                                                //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def toString01(): Bool & Impure =
+    let s = MutSet.empty();
+    MutSet.add!(1, s);
+    toString(s) == "MutSet(1)"
+
+@test
+def toString02(): Bool & Impure =
+    let s = MutSet.empty();
+    MutSet.add!(1, s);
+    MutSet.add!(2, s);
+    toString(s) == "MutSet(1, 2)"
+
+@test
+def toString03(): Bool & Impure =
+    let s = MutSet.empty();
+    MutSet.add!(1, s);
+    MutSet.add!(92, s);
+    MutSet.add!(94, s);
+    MutSet.add!(97, s);
+    toString(s) == "MutSet(1, 92, 94, 97)"
+
+@test
+def toString04(): Bool & Impure =
+    let s = MutSet.empty();
+    MutSet.add!('a', s);
+    MutSet.add!('b', s);
+    MutSet.add!('c', s);
+    MutSet.add!('d', s);
+    toString(s) == "MutSet(a, b, c, d)"
+
+}

--- a/main/test/ca/uwaterloo/flix/library/TestMutSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutSet.flix
@@ -16,41 +16,41 @@
 
 namespace TestMutSet {
 
-use ToString.toString;
+    use ToString.toString;
 
-/////////////////////////////////////////////////////////////////////////////
-// toString                                                                //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // toString                                                                //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def toString01(): Bool & Impure =
-    let s = MutSet.empty();
-    MutSet.add!(1, s);
-    toString(s) == "MutSet(1)"
+    @test
+    def toString01(): Bool & Impure =
+        let s = MutSet.empty();
+        MutSet.add!(1, s);
+        toString(s) == "MutSet(1)"
 
-@test
-def toString02(): Bool & Impure =
-    let s = MutSet.empty();
-    MutSet.add!(1, s);
-    MutSet.add!(2, s);
-    toString(s) == "MutSet(1, 2)"
+    @test
+    def toString02(): Bool & Impure =
+        let s = MutSet.empty();
+        MutSet.add!(1, s);
+        MutSet.add!(2, s);
+        toString(s) == "MutSet(1, 2)"
 
-@test
-def toString03(): Bool & Impure =
-    let s = MutSet.empty();
-    MutSet.add!(1, s);
-    MutSet.add!(92, s);
-    MutSet.add!(94, s);
-    MutSet.add!(97, s);
-    toString(s) == "MutSet(1, 92, 94, 97)"
+    @test
+    def toString03(): Bool & Impure =
+        let s = MutSet.empty();
+        MutSet.add!(1, s);
+        MutSet.add!(92, s);
+        MutSet.add!(94, s);
+        MutSet.add!(97, s);
+        toString(s) == "MutSet(1, 92, 94, 97)"
 
-@test
-def toString04(): Bool & Impure =
-    let s = MutSet.empty();
-    MutSet.add!('a', s);
-    MutSet.add!('b', s);
-    MutSet.add!('c', s);
-    MutSet.add!('d', s);
-    toString(s) == "MutSet(a, b, c, d)"
+    @test
+    def toString04(): Bool & Impure =
+        let s = MutSet.empty();
+        MutSet.add!('a', s);
+        MutSet.add!('b', s);
+        MutSet.add!('c', s);
+        MutSet.add!('d', s);
+        toString(s) == "MutSet(a, b, c, d)"
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSet.flix
@@ -18,7 +18,7 @@ use Core/Cmp.Ordering.{LessThan, Equal, GreaterThan};
 
 namespace TestSet {
 
-use ToString.toString;
+    use ToString.toString;
 
 /////////////////////////////////////////////////////////////////////////////
 // size                                                                    //
@@ -1171,24 +1171,28 @@ def query06(): Bool =
 def query07(): Bool =
     Set.query(x -> if (x < 42) LessThan else if (x > 42) GreaterThan else Equal, Set#{42}) == 42 :: Nil
 
-/////////////////////////////////////////////////////////////////////////////
-// toString                                                                //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // toString                                                                //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def toString01(): Bool =
-    toString(Set#{1}) == "Set(1)"
+    @test
+    def toString01(): Bool =
+        toString(Set#{1}) == "Set#{1}"
 
-@test
-def toString02(): Bool =
-    toString(Set#{1, 2, 3}) == "Set(1, 2, 3)"
+    @test
+    def toString02(): Bool =
+        toString(Set#{1, 2, 3}) == "Set#{1, 2, 3}"
 
-@test
-def toString03(): Bool =
-    toString(Set#{1, 2}) == "Set(1, 2)"
+    @test
+    def toString03(): Bool =
+        toString(Set#{1, 2}) == "Set#{1, 2}"
 
-@test
-def toString04(): Bool =
-    toString(Set#{97, 2, 3, 4, 0}) == "Set(0, 2, 3, 4, 97)"
+    @test
+    def toString04(): Bool =
+        toString(Set#{97, 2, 3, 4, 0}) == "Set#{0, 2, 3, 4, 97}"
+
+    @test
+    def toString05(): Bool =
+        toString(Set#{Set#{1, 2}, Set#{4, 6}}) == "Set#{Set#{1, 2}, Set#{4, 6}}"
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSet.flix
@@ -18,6 +18,8 @@ use Core/Cmp.Ordering.{LessThan, Equal, GreaterThan};
 
 namespace TestSet {
 
+use ToString.toString;
+
 /////////////////////////////////////////////////////////////////////////////
 // size                                                                    //
 /////////////////////////////////////////////////////////////////////////////
@@ -1168,5 +1170,25 @@ def query06(): Bool =
 @test
 def query07(): Bool =
     Set.query(x -> if (x < 42) LessThan else if (x > 42) GreaterThan else Equal, Set#{42}) == 42 :: Nil
+
+/////////////////////////////////////////////////////////////////////////////
+// toString                                                                //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def toString01(): Bool =
+    toString(Set#{1}) == "Set(1)"
+
+@test
+def toString02(): Bool =
+    toString(Set#{1, 2, 3}) == "Set(1, 2, 3)"
+
+@test
+def toString03(): Bool =
+    toString(Set#{1, 2}) == "Set(1, 2)"
+
+@test
+def toString04(): Bool =
+    toString(Set#{97, 2, 3, 4, 0}) == "Set(0, 2, 3, 4, 97)"
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestString.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestString.flix
@@ -1640,7 +1640,7 @@ def unfoldStringWithIter01(): Bool & Impure =
         else {
             let c1 = Char.fromInt32(deref x + 65);
             let c2 = Char.fromInt32(deref x + 97);
-            let s = List.toString(c1 :: c2 :: '.' :: Nil);
+            let s = List.formatWith(Char.toString, "", c1 :: c2 :: '.' :: Nil);
             x := deref x + 1;
             Some(s)
         };
@@ -1655,7 +1655,7 @@ def unfoldStringWithIter02(): Bool & Impure =
         else {
             let c1 = Char.fromInt32(deref x + 65);
             let c2 = Char.fromInt32(deref x + 97);
-            let s = List.toString(c1 :: c2 :: '.' :: Nil);
+            let s = List.formatWith(Char.toString, "", c1 :: c2 :: '.' :: Nil);
             x := deref x + 1;
             Some(s)
         };
@@ -1670,7 +1670,7 @@ def unfoldStringWithIter03(): Bool & Impure =
         else {
             let c1 = Char.fromInt32(deref x + 65);
             let c2 = Char.fromInt32(deref x + 97);
-            let s = List.toString(c1 :: c2 :: '.' :: Nil);
+            let s = List.formatWith(Char.toString, "", c1 :: c2 :: '.' :: Nil);
             x := deref x + 1;
             Some(s)
         };
@@ -1685,7 +1685,7 @@ def unfoldStringWithIter04(): Bool & Impure =
         else {
             let c1 = Char.fromInt32(deref x + 65);
             let c2 = Char.fromInt32(deref x + 97);
-            let s = List.toString(c1 :: c2 :: '.' :: Nil);
+            let s = List.formatWith(Char.toString, "", c1 :: c2 :: '.' :: Nil);
             x := deref x + 1;
             Some(s)
         };
@@ -1700,7 +1700,7 @@ def unfoldStringWithIter05(): Bool & Impure =
         else {
             let c1 = Char.fromInt32(deref x + 65);
             let c2 = Char.fromInt32(deref x + 97);
-            let s = List.toString(c1 :: c2 :: '.' :: Nil);
+            let s = List.formatWith(Char.toString, "", c1 :: c2 :: '.' :: Nil);
             x := deref x + 1;
             Some(s)
         };
@@ -1715,7 +1715,7 @@ def unfoldStringWithIter06(): Bool & Impure =
         else {
             let c1 = Char.fromInt32(deref x + 65);
             let c2 = Char.fromInt32(deref x + 97);
-            let s = List.toString(c1 :: c2 :: '.' :: Nil);
+            let s = List.formatWith(Char.toString, "", c1 :: c2 :: '.' :: Nil);
             x := deref x + 2;
             Some(s)
         };

--- a/main/test/ca/uwaterloo/flix/library/TestToString.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestToString.flix
@@ -19,55 +19,216 @@ namespace TestToString {
     use ToString.toString;
 
     /////////////////////////////////////////////////////////////////////////////
+    // Unit                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def unitToString01(): Bool = toString(()) == "()"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Bool                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def boolToString01(): Bool = toString(false) == "false"
+
+    @test
+    def boolToString02(): Bool = toString(true) == "true"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Char                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def charToString01(): Bool = toString('a') == "a"
+
+    @test
+    def charToString02(): Bool = toString('A') == "A"
+
+    @test
+    def charToString03(): Bool = toString(' ') == " "
+
+    @test
+    def charToString04(): Bool = toString('+') == "+"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Float32                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def float32ToString01(): Bool = toString(0.0f32) == "0.0"
+
+    @test
+    def float32ToString02(): Bool = toString(1.0f32) == "1.0"
+
+    @test
+    def float32ToString03(): Bool = toString(-1.0f32) == "-1.0"
+
+    @test
+    def float32ToString04(): Bool = toString(3.14f32) == "3.14"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Float64                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def float64ToString01(): Bool = toString(0.0f64) == "0.0"
+
+    @test
+    def float64ToString02(): Bool = toString(1.0f64) == "1.0"
+
+    @test
+    def float64ToString03(): Bool = toString(-1.0f64) == "-1.0"
+
+    @test
+    def float64ToString04(): Bool = toString(3.14f64) == "3.14"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int8                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def int8ToString01(): Bool = toString(0i8) == "0"
+
+    @test
+    def int8ToString02(): Bool = toString(1i8) == "1"
+
+    @test
+    def int8ToString03(): Bool = toString(-128i8) == "-128"
+
+    @test
+    def int8ToString04(): Bool = toString(127i8) == "127"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int16                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def int16ToString01(): Bool = toString(0i16) == "0"
+
+    @test
+    def int16ToString02(): Bool = toString(1i16) == "1"
+
+    @test
+    def int16ToString03(): Bool = toString(-32768i16) == "-32768"
+
+    @test
+    def int16ToString04(): Bool = toString(32767i16) == "32767"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int32                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def int32ToString01(): Bool = toString(0) == "0"
+
+    @test
+    def int32ToString02(): Bool = toString(1) == "1"
+
+    @test
+    def int32ToString03(): Bool = toString(-2147483648) == "-2147483648"
+
+    @test
+    def int32ToString04(): Bool = toString(2147483647) == "2147483647"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int64                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def int64ToString01(): Bool = toString(0i64) == "0"
+
+    @test
+    def int64ToString02(): Bool = toString(1i64) == "1"
+
+    @test
+    def int64ToString03(): Bool = toString(-9223372036854775808i64) == "-9223372036854775808"
+
+    @test
+    def int64ToString04(): Bool = toString(9223372036854775807i64) == "9223372036854775807"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // String                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def stringToString01(): Bool = toString("") == ""
+
+    @test
+    def stringToString02(): Bool = toString("a") == "a"
+
+    @test
+    def stringToString03(): Bool = toString(".") == "."
+
+    @test
+    def stringToString04(): Bool = toString(".#)!933") == ".#)!933"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // BigInt                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def bigIntToString01(): Bool = toString(0ii) == "0"
+
+    @test
+    def bigIntToString02(): Bool = toString(1ii) == "1"
+
+    @test
+    def bigIntToString03(): Bool = toString(-3498457932459234592873452983453245ii) == "-3498457932459234592873452983453245"
+
+    @test
+    def bigIntToString04(): Bool = toString(3498457932459234592873452983453245ii) == "3498457932459234592873452983453245"
+
+    /////////////////////////////////////////////////////////////////////////////
     // Tuple2                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def tuple201(): Bool = toString((1, 1)) == "(1, 1)"
+    def tuple2ToString01(): Bool = toString((1, 1)) == "(1, 1)"
 
     @test
-    def tuple202(): Bool = toString((1, Some(2))) == "(1, Some(2))"
+    def tuple2ToString02(): Bool = toString((1, Some(2))) == "(1, Some(2))"
 
     @test
-    def tuple203(): Bool = toString((true, 1)) == "(true, 1)"
+    def tuple2ToString03(): Bool = toString((true, 1)) == "(true, 1)"
 
     @test
-    def tuple204(): Bool = toString(((1, 2), 91)) == "((1, 2), 91)"
+    def tuple2ToString04(): Bool = toString(((1, 2), 91)) == "((1, 2), 91)"
 
     /////////////////////////////////////////////////////////////////////////////
     // Tuple3                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def tuple301(): Bool = toString((1, 1, 82)) == "(1, 1, 82)"
+    def tuple3ToString01(): Bool = toString((1, 1, 82)) == "(1, 1, 82)"
 
     @test
-    def tuple302(): Bool = toString((1, Some(2), 3)) == "(1, Some(2), 3)"
+    def tuple3ToString02(): Bool = toString((1, Some(2), 3)) == "(1, Some(2), 3)"
 
     @test
-    def tuple303(): Bool = toString((true, 1, false)) == "(true, 1, false)"
+    def tuple3ToString03(): Bool = toString((true, 1, false)) == "(true, 1, false)"
 
     @test
-    def tuple304(): Bool = toString(((1, 2), 91, true)) == "((1, 2), 91, true)"
+    def tuple3ToString04(): Bool = toString(((1, 2), 91, true)) == "((1, 2), 91, true)"
 
     /////////////////////////////////////////////////////////////////////////////
     // Tuple4                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def tuple401(): Bool =
+    def tuple4ToString01(): Bool =
         toString((1, 1, 2, 3)) == "(1, 1, 2, 3)"
 
     @test
-    def tuple402(): Bool =
+    def tuple4ToString02(): Bool =
         toString((1, Some(2), true, false)) == "(1, Some(2), true, false)"
 
     @test
-    def tuple403(): Bool =
+    def tuple4ToString03(): Bool =
         toString((true, 1, 97, 2)) == "(true, 1, 97, 2)"
 
     @test
-    def tuple404(): Bool =
+    def tuple4ToString04(): Bool =
         toString(((1, 2, 4, 7), (1, 2), (1, 2, 4), 4)) == "((1, 2, 4, 7), (1, 2), (1, 2, 4), 4)"
 
     /////////////////////////////////////////////////////////////////////////////
@@ -75,19 +236,19 @@ namespace TestToString {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def tuple501(): Bool =
+    def tuple5ToString01(): Bool =
         toString((1, 1, 2, 3, 9)) == "(1, 1, 2, 3, 9)"
 
     @test
-    def tuple502(): Bool =
+    def tuple5ToString02(): Bool =
         toString((1, Some(2), true, false, true)) == "(1, Some(2), true, false, true)"
 
     @test
-    def tuple503(): Bool =
+    def tuple5ToString03(): Bool =
         toString((true, 1, 97, 2, 9)) == "(true, 1, 97, 2, 9)"
 
     @test
-    def tuple504(): Bool =
+    def tuple5ToString04(): Bool =
         toString(((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5))) == "((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5))"
 
     /////////////////////////////////////////////////////////////////////////////
@@ -95,19 +256,19 @@ namespace TestToString {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def tuple601(): Bool =
+    def tuple6ToString01(): Bool =
         toString((1, 1, 2, 3, 9, 42)) == "(1, 1, 2, 3, 9, 42)"
 
     @test
-    def tuple602(): Bool =
+    def tuple6ToString02(): Bool =
         toString((1, Some(2), true, false, true, 0)) == "(1, Some(2), true, false, true, 0)"
 
     @test
-    def tuple603(): Bool =
+    def tuple6ToString03(): Bool =
         toString((true, 1, 97, 2, 9, false)) == "(true, 1, 97, 2, 9, false)"
 
     @test
-    def tuple604(): Bool =
+    def tuple6ToString04(): Bool =
         toString(((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9))) == "((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9))"
 
     /////////////////////////////////////////////////////////////////////////////
@@ -115,19 +276,19 @@ namespace TestToString {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def tuple701(): Bool =
+    def tuple7ToString01(): Bool =
         toString((1, 1, 2, 3, 9, 42, 2)) == "(1, 1, 2, 3, 9, 42, 2)"
 
     @test
-    def tuple702(): Bool =
+    def tuple7ToString02(): Bool =
         toString((1, Some(2), true, false, true, 0, false)) == "(1, Some(2), true, false, true, 0, false)"
 
     @test
-    def tuple703(): Bool =
+    def tuple7ToString03(): Bool =
         toString((true, 1, 97, 2, 9, false, Some(42))) == "(true, 1, 97, 2, 9, false, Some(42))"
 
     @test
-    def tuple704(): Bool =
+    def tuple7ToString04(): Bool =
         toString(((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1))) == "((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1))"
 
     /////////////////////////////////////////////////////////////////////////////
@@ -135,19 +296,19 @@ namespace TestToString {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def tuple801(): Bool =
+    def tuple8ToString01(): Bool =
         toString((1, 1, 2, 3, 9, 42, 2, 0)) == "(1, 1, 2, 3, 9, 42, 2, 0)"
 
     @test
-    def tuple802(): Bool =
+    def tuple8ToString02(): Bool =
         toString((1, Some(2), true, false, true, 0, false, Some(true))) == "(1, Some(2), true, false, true, 0, false, Some(true))"
 
     @test
-    def tuple803(): Bool =
+    def tuple8ToString03(): Bool =
         toString((true, 1, 97, 2, 9, false, Some(42), 1i64)) == "(true, 1, 97, 2, 9, false, Some(42), 1)"
 
     @test
-    def tuple804(): Bool =
+    def tuple8ToString04(): Bool =
         toString(((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1, 42))) == "((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1, 42))"
 
     /////////////////////////////////////////////////////////////////////////////
@@ -155,19 +316,19 @@ namespace TestToString {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def tuple901(): Bool =
+    def tuple9ToString01(): Bool =
         toString((1, 1, 2, 3, 9, 42, 2, 0, 9)) == "(1, 1, 2, 3, 9, 42, 2, 0, 9)"
 
     @test
-    def tuple902(): Bool =
+    def tuple9ToString02(): Bool =
         toString((1, Some(2), true, false, true, 0, false, Some(true), 1)) == "(1, Some(2), true, false, true, 0, false, Some(true), 1)"
 
     @test
-    def tuple903(): Bool =
+    def tuple9ToString03(): Bool =
         toString((true, 1, 97, 2, 9, false, Some(42), 1i64, 432i32)) == "(true, 1, 97, 2, 9, false, Some(42), 1, 432)"
 
     @test
-    def tuple904(): Bool =
+    def tuple9ToString04(): Bool =
         toString(((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1, 42, false))) == "((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1, 42, false))"
 
     /////////////////////////////////////////////////////////////////////////////
@@ -175,19 +336,19 @@ namespace TestToString {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def tuple1001(): Bool =
+    def tuple10ToString01(): Bool =
         toString((1, 1, 2, 3, 9, 42, 2, 0, 9, 342)) == "(1, 1, 2, 3, 9, 42, 2, 0, 9, 342)"
 
     @test
-    def tuple1002(): Bool =
+    def tuple10ToString02(): Bool =
         toString((1, Some(2), true, false, true, 0, false, Some(true), 1, 1337)) == "(1, Some(2), true, false, true, 0, false, Some(true), 1, 1337)"
 
     @test
-    def tuple1003(): Bool =
+    def tuple10ToString03(): Bool =
         toString((true, 1, 97, 2, 9, false, Some(42), 1i64, 432i32, Some(false))) == "(true, 1, 97, 2, 9, false, Some(42), 1, 432, Some(false))"
 
     @test
-    def tuple1004(): Bool =
+    def tuple10ToString04(): Bool =
         toString(((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1, 42, false, true))) == "((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1, 42, false, true))"
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestToString.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestToString.flix
@@ -15,77 +15,179 @@
  */
 
 namespace TestToString {
+
     use ToString.toString;
 
-    @test
-    def testToStringUnit(): Bool = toString(()) == "()"
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple2                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def testToStringTrue(): Bool = toString(true) == "true"
+    def tuple201(): Bool = toString((1, 1)) == "(1, 1)"
 
     @test
-    def testToStringFalse(): Bool = toString(false) == "false"
+    def tuple202(): Bool = toString((1, Some(2))) == "(1, Some(2))"
 
     @test
-    def testToStringChar(): Bool = toString('Q') == "Q"
+    def tuple203(): Bool = toString((true, 1)) == "(true, 1)"
 
     @test
-    def testToStringFloat32(): Bool = toString(123.0f32) == "123.0"
+    def tuple204(): Bool = toString(((1, 2), 91)) == "((1, 2), 91)"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple3                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def testToStringFloat64(): Bool = toString(123.0f64) == "123.0"
+    def tuple301(): Bool = toString((1, 1, 82)) == "(1, 1, 82)"
 
     @test
-    def testToStringInt8(): Bool = toString(123i8) == "123"
+    def tuple302(): Bool = toString((1, Some(2), 3)) == "(1, Some(2), 3)"
 
     @test
-    def testToStringInt16(): Bool = toString(123i16) == "123"
+    def tuple303(): Bool = toString((true, 1, false)) == "(true, 1, false)"
 
     @test
-    def testToStringInt32(): Bool = toString(123i32) == "123"
+    def tuple304(): Bool = toString(((1, 2), 91, true)) == "((1, 2), 91, true)"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple4                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def testToStringInt64(): Bool = toString(123i64) == "123"
+    def tuple401(): Bool =
+        toString((1, 1, 2, 3)) == "(1, 1, 2, 3)"
 
     @test
-    def testToStringString(): Bool = toString("abcd") == "abcd"
+    def tuple402(): Bool =
+        toString((1, Some(2), true, false)) == "(1, Some(2), true, false)"
 
     @test
-    def testToStringBigInt(): Bool = toString(123ii) == "123"
+    def tuple403(): Bool =
+        toString((true, 1, 97, 2)) == "(true, 1, 97, 2)"
 
     @test
-    def testToStringInt32List(): Bool = toString(1 :: 2 :: 3 :: Nil) == "1 :: 2 :: 3 :: Nil"
+    def tuple404(): Bool =
+        toString(((1, 2, 4, 7), (1, 2), (1, 2, 4), 4)) == "((1, 2, 4, 7), (1, 2), (1, 2, 4), 4)"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple5                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def testToStringNil(): Bool = toString(Nil: List[Int]) == "Nil"
+    def tuple501(): Bool =
+        toString((1, 1, 2, 3, 9)) == "(1, 1, 2, 3, 9)"
 
     @test
-    def testToStringSomeInt32(): Bool = toString(Some(123)) == "Some(123)"
+    def tuple502(): Bool =
+        toString((1, Some(2), true, false, true)) == "(1, Some(2), true, false, true)"
 
     @test
-    def testToStringNone(): Bool = toString(None: Option[String]) == "None"
+    def tuple503(): Bool =
+        toString((true, 1, 97, 2, 9)) == "(true, 1, 97, 2, 9)"
 
     @test
-    def testToStringErr(): Bool = toString(Err("error"): Result[String, String]) == "Err(error)"
+    def tuple504(): Bool =
+        toString(((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5))) == "((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5))"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple6                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def testToStringOk(): Bool = toString(Ok("all good"): Result[String, String]) == "Ok(all good)"
+    def tuple601(): Bool =
+        toString((1, 1, 2, 3, 9, 42)) == "(1, 1, 2, 3, 9, 42)"
 
     @test
-    def testToStringSuccess(): Bool = toString(Success("hooray"): Validation[String, String]) == "Success(hooray)"
+    def tuple602(): Bool =
+        toString((1, Some(2), true, false, true, 0)) == "(1, Some(2), true, false, true, 0)"
 
     @test
-    def testToStringNel(): Bool = toString(Nel("abc", Nil)) == "Nel(abc, Nil)"
+    def tuple603(): Bool =
+        toString((true, 1, 97, 2, 9, false)) == "(true, 1, 97, 2, 9, false)"
 
     @test
-    def testToStringNest01(): Bool =
-        toString(Some(None) :: None :: Some(Some(Ok(123))) :: Some(Some(Err(false))) :: Nil) == "Some(None) :: None :: Some(Some(Ok(123))) :: Some(Some(Err(false))) :: Nil"
+    def tuple604(): Bool =
+        toString(((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9))) == "((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9))"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple7                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def testToStringNest02(): Bool =
-        toString(Some(Nil) :: None :: Some(Success(true) :: Failure(Nel("zut", Nil)) :: Nil) :: Nil) == "Some(Nil) :: None :: Some(Success(true) :: Failure(Nel(zut, Nil)) :: Nil) :: Nil"
+    def tuple701(): Bool =
+        toString((1, 1, 2, 3, 9, 42, 2)) == "(1, 1, 2, 3, 9, 42, 2)"
 
     @test
-    def testToStringNest03(): Bool =
-        toString(Nil :: (1 :: Nil) :: (1 :: 2 :: Nil) :: Nil) == "Nil :: 1 :: Nil :: 1 :: 2 :: Nil :: Nil"
+    def tuple702(): Bool =
+        toString((1, Some(2), true, false, true, 0, false)) == "(1, Some(2), true, false, true, 0, false)"
+
+    @test
+    def tuple703(): Bool =
+        toString((true, 1, 97, 2, 9, false, Some(42))) == "(true, 1, 97, 2, 9, false, Some(42))"
+
+    @test
+    def tuple704(): Bool =
+        toString(((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1))) == "((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1))"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple8                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def tuple801(): Bool =
+        toString((1, 1, 2, 3, 9, 42, 2, 0)) == "(1, 1, 2, 3, 9, 42, 2, 0)"
+
+    @test
+    def tuple802(): Bool =
+        toString((1, Some(2), true, false, true, 0, false, Some(true))) == "(1, Some(2), true, false, true, 0, false, Some(true))"
+
+    @test
+    def tuple803(): Bool =
+        toString((true, 1, 97, 2, 9, false, Some(42), 1i64)) == "(true, 1, 97, 2, 9, false, Some(42), 1)"
+
+    @test
+    def tuple804(): Bool =
+        toString(((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1, 42))) == "((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1, 42))"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple9                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def tuple901(): Bool =
+        toString((1, 1, 2, 3, 9, 42, 2, 0, 9)) == "(1, 1, 2, 3, 9, 42, 2, 0, 9)"
+
+    @test
+    def tuple902(): Bool =
+        toString((1, Some(2), true, false, true, 0, false, Some(true), 1)) == "(1, Some(2), true, false, true, 0, false, Some(true), 1)"
+
+    @test
+    def tuple903(): Bool =
+        toString((true, 1, 97, 2, 9, false, Some(42), 1i64, 432i32)) == "(true, 1, 97, 2, 9, false, Some(42), 1, 432)"
+
+    @test
+    def tuple904(): Bool =
+        toString(((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1, 42, false))) == "((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1, 42, false))"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple10                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def tuple1001(): Bool =
+        toString((1, 1, 2, 3, 9, 42, 2, 0, 9, 342)) == "(1, 1, 2, 3, 9, 42, 2, 0, 9, 342)"
+
+    @test
+    def tuple1002(): Bool =
+        toString((1, Some(2), true, false, true, 0, false, Some(true), 1, 1337)) == "(1, Some(2), true, false, true, 0, false, Some(true), 1, 1337)"
+
+    @test
+    def tuple1003(): Bool =
+        toString((true, 1, 97, 2, 9, false, Some(42), 1i64, 432i32, Some(false))) == "(true, 1, 97, 2, 9, false, Some(42), 1, 432, Some(false))"
+
+    @test
+    def tuple1004(): Bool =
+        toString(((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1, 42, false, true))) == "((1, 2, 4, 7), (1, 2), (1, 2, 4), 4, (1, 2, 3, 4, 5, 9, 1, 42, false, true))"
+
 }


### PR DESCRIPTION
- [x] Add ToString instances for `Map`, `Set`, `MutList`, `MutSet`, and `MutMap`.
- [x] Add ToString instances for arrays.
- [x] Add ToString instances for tuples of size [2..10].
- [x] Add tests for new instances.
- [x] Move instances into file of type (for types that are not built in).
- [x] Move tests from TestToString.flix into test file of type (for types that are not built in).

Fixes #1528.