### PR TITLE
Add Monoid typeclass and first set of instances to the standard library

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -136,6 +136,7 @@ class Flix {
     "FromString.flix" -> LocalResource.get("/src/library/FromString.flix"),
     "Functor.flix" -> LocalResource.get("/src/library/Functor.flix"),
     "Hash.flix" -> LocalResource.get("/src/library/Hash.flix"),
+    "Monoid.flix" -> LocalResource.get("/src/library/Monoid.flix"),
 
     "Bounded.flix" -> LocalResource.get("/src/library/Bounded.flix"),
     "TotalOrder.flix" -> LocalResource.get("/src/library/TotalOrder.flix"),

--- a/main/src/library/Monoid.flix
+++ b/main/src/library/Monoid.flix
@@ -1,0 +1,139 @@
+/*
+ *  Copyright 2020 Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+///
+/// A type class for monoids, objects that support an associative binary
+/// operation `combine` and neutral element `empty`.
+///
+pub class Monoid[a] {
+    ///
+    /// Returns a neutral element.
+    ///
+    pub def empty(): a
+
+    ///
+    /// Returns the result of __combining__ `x` and `y`.
+    ///
+    /// [When Flix has Superclasses this function should be moved into the
+    /// class Semigroup.]
+    ///
+    pub def combine(x: a, y: a): a
+}
+
+instance Monoid[Unit] {
+    def empty(): Unit = ()
+    def combine(_: Unit, _: Unit): Unit = ()
+}
+
+instance Monoid[String] {
+    def empty(): String = ""
+    def combine(x: String, y: String): String = x + y
+}
+
+instance Monoid[Option[a]] with [a : Monoid] {
+    def empty(): Option[a] = None
+    def combine(x: Option[a], y: Option[a]): Option[a] = match (x, y) {
+        case (Some(x1), Some(y1)) => Some(Monoid.combine(x1, y1))
+        case (a, None) => a
+        case (None, b) => b
+    }
+}
+
+instance Monoid[(a1, a2)] with [a1 : Monoid, a2 : Monoid] {
+    def empty(): (a1, a2) = (Monoid.empty(), Monoid.empty())
+    def combine(x: (a1, a2), y: (a1, a2)): (a1, a2) = match (x, y) {
+        case ((x1, x2), (y1, y2)) => (Monoid.combine(x1, y1), Monoid.combine(x2, y2))
+    }
+}
+
+instance Monoid[(a1, a2, a3)] with [a1 : Monoid, a2 : Monoid, a3: Monoid] {
+    def empty(): (a1, a2, a3) = (Monoid.empty(), Monoid.empty(), Monoid.empty())
+    def combine(x: (a1, a2, a3), y: (a1, a2, a3)): (a1, a2, a3) = match (x, y) {
+        case ((x1, x2, x3), (y1, y2, y3)) => (Monoid.combine(x1, y1), Monoid.combine(x2, y2), Monoid.combine(x3, y3))
+    }
+}
+
+instance Monoid[(a1, a2, a3, a4)] with [a1 : Monoid, a2 : Monoid, a3: Monoid, a4: Monoid] {
+    def empty(): (a1, a2, a3, a4) = (Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty())
+    def combine(x: (a1, a2, a3, a4), y: (a1, a2, a3, a4)): (a1, a2, a3, a4) = match (x, y) {
+        case ((x1, x2, x3, x4), (y1, y2, y3, y4)) => (Monoid.combine(x1, y1), Monoid.combine(x2, y2), Monoid.combine(x3, y3), Monoid.combine(x4, y4))
+    }
+}
+
+instance Monoid[(a1, a2, a3, a4, a5)] with [a1 : Monoid, a2 : Monoid, a3: Monoid, a4: Monoid, a5: Monoid] {
+    def empty(): (a1, a2, a3, a4, a5) = (Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty())
+    def combine(x: (a1, a2, a3, a4, a5), y: (a1, a2, a3, a4, a5)): (a1, a2, a3, a4, a5) = match (x, y) {
+        case ((x1, x2, x3, x4, x5), (y1, y2, y3, y4, y5)) => (Monoid.combine(x1, y1), Monoid.combine(x2, y2), Monoid.combine(x3, y3), Monoid.combine(x4, y4), Monoid.combine(x5, y5))
+    }
+}
+
+instance Monoid[(a1, a2, a3, a4, a5, a6)] with [a1 : Monoid, a2 : Monoid, a3: Monoid, a4: Monoid, a5: Monoid, a6: Monoid] {
+    def empty(): (a1, a2, a3, a4, a5, a6) = (Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty())
+    def combine(x: (a1, a2, a3, a4, a5, a6), y: (a1, a2, a3, a4, a5, a6)): (a1, a2, a3, a4, a5, a6) = match (x, y) {
+        case ((x1, x2, x3, x4, x5, x6), (y1, y2, y3, y4, y5, y6)) => (Monoid.combine(x1, y1), Monoid.combine(x2, y2), Monoid.combine(x3, y3), Monoid.combine(x4, y4), Monoid.combine(x5, y5), Monoid.combine(x6, y6))
+    }
+}
+
+instance Monoid[(a1, a2, a3, a4, a5, a6, a7)] with [a1 : Monoid, a2 : Monoid, a3: Monoid, a4: Monoid, a5: Monoid, a6: Monoid, a7: Monoid] {
+    def empty(): (a1, a2, a3, a4, a5, a6, a7) = (Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty())
+    def combine(x: (a1, a2, a3, a4, a5, a6, a7), y: (a1, a2, a3, a4, a5, a6, a7)): (a1, a2, a3, a4, a5, a6, a7) = match (x, y) {
+        case ((x1, x2, x3, x4, x5, x6, x7), (y1, y2, y3, y4, y5, y6, y7)) => (Monoid.combine(x1, y1), Monoid.combine(x2, y2), Monoid.combine(x3, y3), Monoid.combine(x4, y4), Monoid.combine(x5, y5), Monoid.combine(x6, y6), Monoid.combine(x7, y7))
+    }
+}
+
+instance Monoid[(a1, a2, a3, a4, a5, a6, a7, a8)] with [a1 : Monoid, a2 : Monoid, a3: Monoid, a4: Monoid, a5: Monoid, a6: Monoid, a7: Monoid, a8: Monoid] {
+    def empty(): (a1, a2, a3, a4, a5, a6, a7, a8) = (Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty())
+    def combine(x: (a1, a2, a3, a4, a5, a6, a7, a8), y: (a1, a2, a3, a4, a5, a6, a7, a8)): (a1, a2, a3, a4, a5, a6, a7, a8) = match (x, y) {
+        case ((x1, x2, x3, x4, x5, x6, x7, x8), (y1, y2, y3, y4, y5, y6, y7, y8)) => (Monoid.combine(x1, y1), Monoid.combine(x2, y2), Monoid.combine(x3, y3), Monoid.combine(x4, y4), Monoid.combine(x5, y5), Monoid.combine(x6, y6), Monoid.combine(x7, y7), Monoid.combine(x8, y8))
+    }
+}
+
+instance Monoid[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with [a1 : Monoid, a2 : Monoid, a3: Monoid, a4: Monoid, a5: Monoid, a6: Monoid, a7: Monoid, a8: Monoid, a9: Monoid] {
+    def empty(): (a1, a2, a3, a4, a5, a6, a7, a8, a9) = (Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty())
+    def combine(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9), y: (a1, a2, a3, a4, a5, a6, a7, a8, a9)): (a1, a2, a3, a4, a5, a6, a7, a8, a9) = match (x, y) {
+        case ((x1, x2, x3, x4, x5, x6, x7, x8, x9), (y1, y2, y3, y4, y5, y6, y7, y8, y9)) => (Monoid.combine(x1, y1), Monoid.combine(x2, y2), Monoid.combine(x3, y3), Monoid.combine(x4, y4), Monoid.combine(x5, y5), Monoid.combine(x6, y6), Monoid.combine(x7, y7), Monoid.combine(x8, y8), Monoid.combine(x9, y9))
+    }
+}
+
+instance Monoid[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with [a1 : Monoid, a2 : Monoid, a3: Monoid, a4: Monoid, a5: Monoid, a6: Monoid, a7: Monoid, a8: Monoid, a9: Monoid, a10: Monoid] {
+    def empty(): (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = (Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty())
+    def combine(x: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10), y: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)): (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = match (x, y) {
+        case ((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10), (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10)) => (Monoid.combine(x1, y1), Monoid.combine(x2, y2), Monoid.combine(x3, y3), Monoid.combine(x4, y4), Monoid.combine(x5, y5), Monoid.combine(x6, y6), Monoid.combine(x7, y7), Monoid.combine(x8, y8), Monoid.combine(x9, y9), Monoid.combine(x10, y10))
+    }
+}
+
+instance Monoid[Validation[t, e]] with [t : Monoid] {
+    def empty(): Validation[t, e] = Success(Monoid.empty())
+    def combine(x: Validation[t, e], y: Validation[t, e]): Validation[t, e] = match (x, y) {
+        case (Success(x1), Success(y1)) => Success(Monoid.combine(x1, y1))
+        case (Failure(es1), Failure(es2)) => Failure(Nel.append(es1, es2))
+        case (Failure(_), _) => x
+        case (_, Failure(_)) => y
+    }
+}
+
+instance Monoid[List[a]] {
+    def empty(): List[a] = Nil
+    def combine(x: List[a], y: List[a]): List[a] = List.append(x, y)
+}
+
+///
+/// `combine` is set union.
+///
+instance Monoid[Set[a]] {
+    def empty(): Set[a] = Set.empty()
+    def combine(x: Set[a], y: Set[a]): Set[a] = Set.union(x, y)
+}

--- a/main/src/library/Monoid.flix
+++ b/main/src/library/Monoid.flix
@@ -33,6 +33,17 @@ pub class Monoid[a] {
     pub def combine(x: a, y: a): a
 }
 
+namespace Monoid {
+
+    ///
+    /// Returns the result of applying `combine` to all the elements of list `xs`,
+    /// using `empty` as the initial value.
+    ///
+    pub def combineAll[a: Monoid](xs: List[a]): a =
+        List.foldLeft((ac, x) -> combine(ac, x), Monoid.empty(), xs)
+
+}
+
 instance Monoid[Unit] {
     def empty(): Unit = ()
     def combine(_: Unit, _: Unit): Unit = ()
@@ -136,4 +147,12 @@ instance Monoid[List[a]] {
 instance Monoid[Set[a]] {
     def empty(): Set[a] = Set.empty()
     def combine(x: Set[a], y: Set[a]): Set[a] = Set.union(x, y)
+}
+
+instance Monoid[Map[k, v]] with [v: Monoid] {
+    def empty(): Map[k, v] = Map.empty()
+    def combine(x: Map[k, v], y: Map[k, v]): Map[k, v] =
+        let ins = (ac, k, v) -> Map.insertWith(Monoid.combine, k, v, ac);
+        Map.foldWithKey(ins, y, x)
+
 }

--- a/main/test/ca/uwaterloo/flix/library/LibrarySuite.scala
+++ b/main/test/ca/uwaterloo/flix/library/LibrarySuite.scala
@@ -52,6 +52,7 @@ class LibrarySuite extends Suites(
   new FlixTest("TestFunctor", "main/test/ca/uwaterloo/flix/library/TestFunctor.flix")(Options.TestWithLibrary),
   new FlixTest("TestHash", "main/test/ca/uwaterloo/flix/library/TestHash.flix")(Options.TestWithLibrary),
   new FlixTest("TestLazyList", "main/test/ca/uwaterloo/flix/library/TestLazyList.flix")(Options.TestWithLibrary),
+  new FlixTest("TestMonoid", "main/test/ca/uwaterloo/flix/library/TestMonoid.flix")(Options.TestWithLibrary),
 
   new FlixTest("Core/Io/TestFile", "main/test/ca/uwaterloo/flix/library/Core/Io/TestFile.flix")(Options.TestWithLibrary),
   new FlixTest("Core/Io/TestInputStream", "main/test/ca/uwaterloo/flix/library/Core/Io/TestInputStream.flix")(Options.TestWithLibrary),

--- a/main/test/ca/uwaterloo/flix/library/TestMonoid.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMonoid.flix
@@ -1,0 +1,357 @@
+/*
+ *  Copyright 2020 Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace TestMonoid {
+
+use Monoid.{empty, combine};
+
+/////////////////////////////////////////////////////////////////////////////
+// Unit                                                                    //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def unitEmpty01(): Bool = empty() == ()
+
+@test
+def unitCombine01(): Bool = combine((), ()) == ()
+
+/////////////////////////////////////////////////////////////////////////////
+// String                                                                  //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def stringEmpty01(): Bool = empty() == ""
+
+@test
+def stringCombine01(): Bool = combine("", "") == ""
+
+@test
+def stringCombine02(): Bool = combine("a", "") == "a"
+
+@test
+def stringCombine03(): Bool = combine("", "b") == "b"
+
+@test
+def stringCombine04(): Bool = combine("a", "b") == "ab"
+
+/////////////////////////////////////////////////////////////////////////////
+// Option                                                                  //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def optionEmpty01(): Bool = empty(): Option[Unit] == None
+
+@test
+def optionCombine01(): Bool = combine(None, None): Option[Unit] == None
+
+@test
+def optionCombine02(): Bool = combine(Some("a"), None) == Some("a")
+
+@test
+def optionCombine03(): Bool = combine(None, Some("1")) == Some("1")
+
+@test
+def optionCombine04(): Bool = combine(Some("a"), Some("1")) == Some("a1")
+
+/////////////////////////////////////////////////////////////////////////////
+// Tuple 2                                                                 //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def tuple2Empty01(): Bool = empty() == ("", "")
+
+@test
+def tuple2Empty02(): Bool = empty() == ("", ())
+
+@test
+def tuple2Combine01(): Bool = combine(("", ""), ("", "")) == ("", "")
+
+@test
+def tuple2Combine02(): Bool = combine(("a", "b"), ("", "")) == ("a", "b")
+
+@test
+def tuple2Combine03(): Bool = combine(("", ""), ("1", "2")) == ("1", "2")
+
+@test
+def tuple2Combine04(): Bool = combine(("a", "b"), ("1", "2")) == ("a1", "b2")
+
+@test
+def tuple2Combine05(): Bool = combine(("a", ()), ("1", ())) == ("a1", ())
+
+/////////////////////////////////////////////////////////////////////////////
+// Tuple 3                                                                 //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def tuple3Empty01(): Bool = empty() == ("", "", "")
+
+@test
+def tuple3Empty02(): Bool = empty() == ("", (), "")
+
+@test
+def tuple3Combine01(): Bool = combine(("", "", ""), ("", "", "")) == ("", "", "")
+
+@test
+def tuple3Combine02(): Bool = combine(("a", "b", "c"), ("", "", "")) == ("a", "b", "c")
+
+@test
+def tuple3Combine03(): Bool = combine(("", "", ""), ("1", "2", "3")) == ("1", "2", "3")
+
+@test
+def tuple3Combine04(): Bool = combine(("a", "b", "c"), ("1", "2", "3")) == ("a1", "b2", "c3")
+
+@test
+def tuple3Combine05(): Bool = combine(("a", (), "b"), ("1", (), "2")) == ("a1", (), "b2")
+
+/////////////////////////////////////////////////////////////////////////////
+// Tuple 4                                                                 //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def tuple4Empty01(): Bool = empty() == ("", "", "", "")
+
+@test
+def tuple4Empty02(): Bool = empty() == ("", (), "", ())
+
+@test
+def tuple4Combine01(): Bool = combine(("", "", "", ""), ("", "", "", "")) == ("", "", "", "")
+
+@test
+def tuple4Combine02(): Bool = combine(("a", "b", "c", "d"), ("", "", "", "")) == ("a", "b", "c", "d")
+
+@test
+def tuple4Combine03(): Bool = combine(("", "", "", ""), ("1", "2", "3", "4")) == ("1", "2", "3", "4")
+
+@test
+def tuple4Combine04(): Bool = combine(("a", "b", "c", "d"), ("1", "2", "3", "4")) == ("a1", "b2", "c3", "d4")
+
+@test
+def tuple4Combine05(): Bool = combine(("a", (), "b", ()), ("1", (), "2", ())) == ("a1", (), "b2", ())
+
+/////////////////////////////////////////////////////////////////////////////
+// Tuple 5                                                                 //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def tuple5Empty01(): Bool = empty() == ("", "", "", "", "")
+
+@test
+def tuple5Empty02(): Bool = empty() == ("", (), "", (), "")
+
+@test
+def tuple5Combine01(): Bool = combine(("", "", "", "", ""), ("", "", "", "", "")) == ("", "", "", "", "")
+
+@test
+def tuple5Combine02(): Bool = combine(("a", "b", "c", "d", "e"), ("", "", "", "", "")) == ("a", "b", "c", "d", "e")
+
+@test
+def tuple5Combine03(): Bool = combine(("", "", "", "", ""), ("1", "2", "3", "4", "5")) == ("1", "2", "3", "4", "5")
+
+@test
+def tuple5Combine04(): Bool = combine(("a", "b", "c", "d", "e"), ("1", "2", "3", "4", "5")) == ("a1", "b2", "c3", "d4", "e5")
+
+@test
+def tuple5Combine05(): Bool = combine(("a", (), "b", (), "c"), ("1", (), "2", (), "3")) == ("a1", (), "b2", (), "c3")
+
+/////////////////////////////////////////////////////////////////////////////
+// Tuple 6                                                                 //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def tuple6Empty01(): Bool = empty() == ("", "", "", "", "", "")
+
+@test
+def tuple6Empty02(): Bool = empty() == ("", (), "", (), "", ())
+
+@test
+def tuple6Combine01(): Bool = combine(("", "", "", "", "", ""), ("", "", "", "", "", "")) == ("", "", "", "", "", "")
+
+@test
+def tuple6Combine02(): Bool = combine(("a", "b", "c", "d", "e", "f"), ("", "", "", "", "", "")) == ("a", "b", "c", "d", "e", "f")
+
+@test
+def tuple6Combine03(): Bool = combine(("", "", "", "", "", ""), ("1", "2", "3", "4", "5", "6")) == ("1", "2", "3", "4", "5", "6")
+
+@test
+def tuple6Combine04(): Bool = combine(("a", "b", "c", "d", "e", "f"), ("1", "2", "3", "4", "5", "6")) == ("a1", "b2", "c3", "d4", "e5", "f6")
+
+@test
+def tuple6Combine05(): Bool = combine(("a", (), "b", (), "c", ()), ("1", (), "2", (), "3", ())) == ("a1", (), "b2", (), "c3", ())
+
+/////////////////////////////////////////////////////////////////////////////
+// Tuple 7                                                                 //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def tuple7Empty01(): Bool = empty() == ("", "", "", "", "", "", "")
+
+@test
+def tuple7Empty02(): Bool = empty() == ("", (), "", (), "", (), "")
+
+@test
+def tuple7Combine01(): Bool = combine(("", "", "", "", "", "", ""), ("", "", "", "", "", "", "")) == ("", "", "", "", "", "", "")
+
+@test
+def tuple7Combine02(): Bool = combine(("a", "b", "c", "d", "e", "f", "g"), ("", "", "", "", "", "", "")) == ("a", "b", "c", "d", "e", "f", "g")
+
+@test
+def tuple7Combine03(): Bool = combine(("", "", "", "", "", "", ""), ("1", "2", "3", "4", "5", "6", "7")) == ("1", "2", "3", "4", "5", "6", "7")
+
+@test
+def tuple7Combine04(): Bool = combine(("a", "b", "c", "d", "e", "f", "g"), ("1", "2", "3", "4", "5", "6", "7")) == ("a1", "b2", "c3", "d4", "e5", "f6", "g7")
+
+@test
+def tuple7Combine05(): Bool = combine(("a", (), "b", (), "c", (), "d"), ("1", (), "2", (), "3", (), "4")) == ("a1", (), "b2", (), "c3", (), "d4")
+
+/////////////////////////////////////////////////////////////////////////////
+// Tuple 8                                                                 //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def tuple8Empty01(): Bool = empty() == ("", "", "", "", "", "", "", "")
+
+@test
+def tuple8Empty02(): Bool = empty() == ("", (), "", (), "", (), "", ())
+
+@test
+def tuple8Combine01(): Bool = combine(("", "", "", "", "", "", "", ""), ("", "", "", "", "", "", "", "")) == ("", "", "", "", "", "", "", "")
+
+@test
+def tuple8Combine02(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h"), ("", "", "", "", "", "", "", "")) == ("a", "b", "c", "d", "e", "f", "g", "h")
+
+@test
+def tuple8Combine03(): Bool = combine(("", "", "", "", "", "", "", ""), ("1", "2", "3", "4", "5", "6", "7", "8")) == ("1", "2", "3", "4", "5", "6", "7", "8")
+
+@test
+def tuple8Combine04(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h"), ("1", "2", "3", "4", "5", "6", "7", "8")) == ("a1", "b2", "c3", "d4", "e5", "f6", "g7", "h8")
+
+@test
+def tuple8Combine05(): Bool = combine(("a", (), "b", (), "c", (), "d", ()), ("1", (), "2", (), "3", (), "4", ())) == ("a1", (), "b2", (), "c3", (), "d4", ())
+
+/////////////////////////////////////////////////////////////////////////////
+// Tuple 9                                                                 //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def tuple9Empty01(): Bool = empty() == ("", "", "", "", "", "", "", "", "")
+
+@test
+def tuple9Empty02(): Bool = empty() == ("", (), "", (), "", (), "", (), "")
+
+@test
+def tuple9Combine01(): Bool = combine(("", "", "", "", "", "", "", "", ""), ("", "", "", "", "", "", "", "", "")) == ("", "", "", "", "", "", "", "", "")
+
+@test
+def tuple9Combine02(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h", "i"), ("", "", "", "", "", "", "", "", "")) == ("a", "b", "c", "d", "e", "f", "g", "h", "i")
+
+@test
+def tuple9Combine03(): Bool = combine(("", "", "", "", "", "", "", "", ""), ("1", "2", "3", "4", "5", "6", "7", "8", "9")) == ("1", "2", "3", "4", "5", "6", "7", "8", "9")
+
+@test
+def tuple9Combine04(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h", "i"), ("1", "2", "3", "4", "5", "6", "7", "8", "9")) == ("a1", "b2", "c3", "d4", "e5", "f6", "g7", "h8", "i9")
+
+@test
+def tuple9Combine05(): Bool = combine(("a", (), "b", (), "c", (), "d", (), "e"), ("1", (), "2", (), "3", (), "4", (), "5")) == ("a1", (), "b2", (), "c3", (), "d4", (), "e5")
+
+/////////////////////////////////////////////////////////////////////////////
+// Tuple 10                                                                //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def tuple10Empty01(): Bool = empty() == ("", "", "", "", "", "", "", "", "", "")
+
+@test
+def tuple10Empty02(): Bool = empty() == ("", (), "", (), "", (), "", (), "", ())
+
+@test
+def tuple10Combine01(): Bool = combine(("", "", "", "", "", "", "", "", "", ""), ("", "", "", "", "", "", "", "", "", "")) == ("", "", "", "", "", "", "", "", "", "")
+
+@test
+def tuple10Combine02(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h", "i", "j"), ("", "", "", "", "", "", "", "", "", "")) == ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+
+@test
+def tuple10Combine03(): Bool = combine(("", "", "", "", "", "", "", "", "", ""), ("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")) == ("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
+
+@test
+def tuple10Combine04(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h", "i", "j"), ("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")) == ("a1", "b2", "c3", "d4", "e5", "f6", "g7", "h8", "i9", "j0")
+
+@test
+def tuple10Combine05(): Bool = combine(("a", (), "b", (), "c", (), "d", (), "e", ()), ("1", (), "2", (), "3", (), "4", (), "5", ())) == ("a1", (), "b2", (), "c3", (), "d4", (), "e5", ())
+
+/////////////////////////////////////////////////////////////////////////////
+// Validation                                                              //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def validationEmpty01(): Bool = empty(): Validation[String, String] == Success("")
+
+@test
+def validationCombine01(): Bool = combine(Failure(Nel.singleton("e1")), Failure(Nel.singleton("e2"))): Validation[String, String] == Failure(Nel.append(Nel.singleton("e1"), Nel.singleton("e2")))
+
+@test
+def validationCombine02(): Bool = combine(Success("a"), Failure(Nel.singleton("e1"))): Validation[String, String] == Failure(Nel.singleton("e1"))
+
+@test
+def validationCombine03(): Bool = combine(Failure(Nel.singleton("e1")), Success("1")): Validation[String, String] == Failure(Nel.singleton("e1"))
+
+@test
+def validationCombine04(): Bool = combine(Success("a"), Success("1")): Validation[String, String] == Success("a1")
+
+/////////////////////////////////////////////////////////////////////////////
+// List                                                                    //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def listEmpty01(): Bool = empty(): List[Int32] == Nil
+
+@test
+def listCombine01(): Bool = combine(Nil, Nil): List[Int32] == Nil
+
+@test
+def listCombine02(): Bool = combine(1 :: Nil, Nil) == 1 :: Nil
+
+@test
+def listCombine03(): Bool = combine(Nil, 2 :: Nil) == 2 :: Nil
+
+@test
+def listCombine04(): Bool = combine(1 :: Nil, 2 :: Nil) == 1 :: 2 :: Nil
+
+@test
+def listCombine05(): Bool = combine(1 :: 2 :: Nil, 1 :: 2 :: Nil) == 1 :: 2 :: 1 :: 2 :: Nil
+
+/////////////////////////////////////////////////////////////////////////////
+// Set                                                                     //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def setEmpty01(): Bool = empty(): Set[Int32] == Set#{}
+
+@test
+def setCombine01(): Bool = combine(Set#{}, Set#{}): Set[Int32] == Set#{}
+
+@test
+def setCombine02(): Bool = combine(Set#{1}, Set#{}) == Set#{1}
+
+@test
+def setCombine03(): Bool = combine(Set#{}, Set#{2}) == Set#{2}
+
+@test
+def setCombine04(): Bool = combine(Set#{1}, Set#{2}) == Set#{1, 2}
+
+@test
+def setCombine05(): Bool = combine(Set#{1, 2}, Set#{1, 2}) == Set#{1, 2}
+
+}

--- a/main/test/ca/uwaterloo/flix/library/TestMonoid.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMonoid.flix
@@ -16,342 +16,387 @@
 
 namespace TestMonoid {
 
-use Monoid.{empty, combine};
+    use Monoid.{empty, combine};
+    use Monoid.{combineAll};
 
-/////////////////////////////////////////////////////////////////////////////
-// Unit                                                                    //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // combineAll                                                              //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def unitEmpty01(): Bool = empty() == ()
+    @test
+    def combineAll01(): Bool = combineAll(Nil: List[Unit]) == ()
 
-@test
-def unitCombine01(): Bool = combine((), ()) == ()
+    @test
+    def combineAll02(): Bool = combineAll(() :: Nil) == ()
 
-/////////////////////////////////////////////////////////////////////////////
-// String                                                                  //
-/////////////////////////////////////////////////////////////////////////////
+    @test
+    def combineAll03(): Bool = combineAll(Nil: List[String]) == ""
 
-@test
-def stringEmpty01(): Bool = empty() == ""
+    @test
+    def combineAll04(): Bool = combineAll("a" :: Nil) == "a"
 
-@test
-def stringCombine01(): Bool = combine("", "") == ""
+    @test
+    def combineAll05(): Bool = combineAll("a" :: "b" :: Nil) == "ab"
 
-@test
-def stringCombine02(): Bool = combine("a", "") == "a"
+    @test
+    def combineAll06(): Bool = combineAll("a" :: "b" :: "cdefg" :: Nil) == "abcdefg"
 
-@test
-def stringCombine03(): Bool = combine("", "b") == "b"
+    /////////////////////////////////////////////////////////////////////////////
+    // Unit                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def stringCombine04(): Bool = combine("a", "b") == "ab"
+    @test
+    def unitEmpty01(): Bool = empty() == ()
 
-/////////////////////////////////////////////////////////////////////////////
-// Option                                                                  //
-/////////////////////////////////////////////////////////////////////////////
+    @test
+    def unitCombine01(): Bool = combine((), ()) == ()
 
-@test
-def optionEmpty01(): Bool = empty(): Option[Unit] == None
+    /////////////////////////////////////////////////////////////////////////////
+    // String                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def optionCombine01(): Bool = combine(None, None): Option[Unit] == None
+    @test
+    def stringEmpty01(): Bool = empty() == ""
 
-@test
-def optionCombine02(): Bool = combine(Some("a"), None) == Some("a")
+    @test
+    def stringCombine01(): Bool = combine("", "") == ""
 
-@test
-def optionCombine03(): Bool = combine(None, Some("1")) == Some("1")
+    @test
+    def stringCombine02(): Bool = combine("a", "") == "a"
 
-@test
-def optionCombine04(): Bool = combine(Some("a"), Some("1")) == Some("a1")
+    @test
+    def stringCombine03(): Bool = combine("", "b") == "b"
 
-/////////////////////////////////////////////////////////////////////////////
-// Tuple 2                                                                 //
-/////////////////////////////////////////////////////////////////////////////
+    @test
+    def stringCombine04(): Bool = combine("a", "b") == "ab"
 
-@test
-def tuple2Empty01(): Bool = empty() == ("", "")
+    /////////////////////////////////////////////////////////////////////////////
+    // Option                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def tuple2Empty02(): Bool = empty() == ("", ())
+    @test
+    def optionEmpty01(): Bool = empty(): Option[Unit] == None
 
-@test
-def tuple2Combine01(): Bool = combine(("", ""), ("", "")) == ("", "")
+    @test
+    def optionCombine01(): Bool = combine(None, None): Option[Unit] == None
 
-@test
-def tuple2Combine02(): Bool = combine(("a", "b"), ("", "")) == ("a", "b")
+    @test
+    def optionCombine02(): Bool = combine(Some("a"), None) == Some("a")
 
-@test
-def tuple2Combine03(): Bool = combine(("", ""), ("1", "2")) == ("1", "2")
+    @test
+    def optionCombine03(): Bool = combine(None, Some("1")) == Some("1")
 
-@test
-def tuple2Combine04(): Bool = combine(("a", "b"), ("1", "2")) == ("a1", "b2")
+    @test
+    def optionCombine04(): Bool = combine(Some("a"), Some("1")) == Some("a1")
 
-@test
-def tuple2Combine05(): Bool = combine(("a", ()), ("1", ())) == ("a1", ())
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple 2                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
 
-/////////////////////////////////////////////////////////////////////////////
-// Tuple 3                                                                 //
-/////////////////////////////////////////////////////////////////////////////
+    @test
+    def tuple2Empty01(): Bool = empty() == ("", "")
 
-@test
-def tuple3Empty01(): Bool = empty() == ("", "", "")
+    @test
+    def tuple2Empty02(): Bool = empty() == ("", ())
 
-@test
-def tuple3Empty02(): Bool = empty() == ("", (), "")
+    @test
+    def tuple2Combine01(): Bool = combine(("", ""), ("", "")) == ("", "")
 
-@test
-def tuple3Combine01(): Bool = combine(("", "", ""), ("", "", "")) == ("", "", "")
+    @test
+    def tuple2Combine02(): Bool = combine(("a", "b"), ("", "")) == ("a", "b")
 
-@test
-def tuple3Combine02(): Bool = combine(("a", "b", "c"), ("", "", "")) == ("a", "b", "c")
+    @test
+    def tuple2Combine03(): Bool = combine(("", ""), ("1", "2")) == ("1", "2")
 
-@test
-def tuple3Combine03(): Bool = combine(("", "", ""), ("1", "2", "3")) == ("1", "2", "3")
+    @test
+    def tuple2Combine04(): Bool = combine(("a", "b"), ("1", "2")) == ("a1", "b2")
 
-@test
-def tuple3Combine04(): Bool = combine(("a", "b", "c"), ("1", "2", "3")) == ("a1", "b2", "c3")
+    @test
+    def tuple2Combine05(): Bool = combine(("a", ()), ("1", ())) == ("a1", ())
 
-@test
-def tuple3Combine05(): Bool = combine(("a", (), "b"), ("1", (), "2")) == ("a1", (), "b2")
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple 3                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
 
-/////////////////////////////////////////////////////////////////////////////
-// Tuple 4                                                                 //
-/////////////////////////////////////////////////////////////////////////////
+    @test
+    def tuple3Empty01(): Bool = empty() == ("", "", "")
 
-@test
-def tuple4Empty01(): Bool = empty() == ("", "", "", "")
+    @test
+    def tuple3Empty02(): Bool = empty() == ("", (), "")
 
-@test
-def tuple4Empty02(): Bool = empty() == ("", (), "", ())
+    @test
+    def tuple3Combine01(): Bool = combine(("", "", ""), ("", "", "")) == ("", "", "")
 
-@test
-def tuple4Combine01(): Bool = combine(("", "", "", ""), ("", "", "", "")) == ("", "", "", "")
+    @test
+    def tuple3Combine02(): Bool = combine(("a", "b", "c"), ("", "", "")) == ("a", "b", "c")
 
-@test
-def tuple4Combine02(): Bool = combine(("a", "b", "c", "d"), ("", "", "", "")) == ("a", "b", "c", "d")
+    @test
+    def tuple3Combine03(): Bool = combine(("", "", ""), ("1", "2", "3")) == ("1", "2", "3")
 
-@test
-def tuple4Combine03(): Bool = combine(("", "", "", ""), ("1", "2", "3", "4")) == ("1", "2", "3", "4")
+    @test
+    def tuple3Combine04(): Bool = combine(("a", "b", "c"), ("1", "2", "3")) == ("a1", "b2", "c3")
 
-@test
-def tuple4Combine04(): Bool = combine(("a", "b", "c", "d"), ("1", "2", "3", "4")) == ("a1", "b2", "c3", "d4")
+    @test
+    def tuple3Combine05(): Bool = combine(("a", (), "b"), ("1", (), "2")) == ("a1", (), "b2")
 
-@test
-def tuple4Combine05(): Bool = combine(("a", (), "b", ()), ("1", (), "2", ())) == ("a1", (), "b2", ())
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple 4                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
 
-/////////////////////////////////////////////////////////////////////////////
-// Tuple 5                                                                 //
-/////////////////////////////////////////////////////////////////////////////
+    @test
+    def tuple4Empty01(): Bool = empty() == ("", "", "", "")
 
-@test
-def tuple5Empty01(): Bool = empty() == ("", "", "", "", "")
+    @test
+    def tuple4Empty02(): Bool = empty() == ("", (), "", ())
 
-@test
-def tuple5Empty02(): Bool = empty() == ("", (), "", (), "")
+    @test
+    def tuple4Combine01(): Bool = combine(("", "", "", ""), ("", "", "", "")) == ("", "", "", "")
 
-@test
-def tuple5Combine01(): Bool = combine(("", "", "", "", ""), ("", "", "", "", "")) == ("", "", "", "", "")
+    @test
+    def tuple4Combine02(): Bool = combine(("a", "b", "c", "d"), ("", "", "", "")) == ("a", "b", "c", "d")
 
-@test
-def tuple5Combine02(): Bool = combine(("a", "b", "c", "d", "e"), ("", "", "", "", "")) == ("a", "b", "c", "d", "e")
+    @test
+    def tuple4Combine03(): Bool = combine(("", "", "", ""), ("1", "2", "3", "4")) == ("1", "2", "3", "4")
 
-@test
-def tuple5Combine03(): Bool = combine(("", "", "", "", ""), ("1", "2", "3", "4", "5")) == ("1", "2", "3", "4", "5")
+    @test
+    def tuple4Combine04(): Bool = combine(("a", "b", "c", "d"), ("1", "2", "3", "4")) == ("a1", "b2", "c3", "d4")
 
-@test
-def tuple5Combine04(): Bool = combine(("a", "b", "c", "d", "e"), ("1", "2", "3", "4", "5")) == ("a1", "b2", "c3", "d4", "e5")
+    @test
+    def tuple4Combine05(): Bool = combine(("a", (), "b", ()), ("1", (), "2", ())) == ("a1", (), "b2", ())
 
-@test
-def tuple5Combine05(): Bool = combine(("a", (), "b", (), "c"), ("1", (), "2", (), "3")) == ("a1", (), "b2", (), "c3")
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple 5                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
 
-/////////////////////////////////////////////////////////////////////////////
-// Tuple 6                                                                 //
-/////////////////////////////////////////////////////////////////////////////
+    @test
+    def tuple5Empty01(): Bool = empty() == ("", "", "", "", "")
 
-@test
-def tuple6Empty01(): Bool = empty() == ("", "", "", "", "", "")
+    @test
+    def tuple5Empty02(): Bool = empty() == ("", (), "", (), "")
 
-@test
-def tuple6Empty02(): Bool = empty() == ("", (), "", (), "", ())
+    @test
+    def tuple5Combine01(): Bool = combine(("", "", "", "", ""), ("", "", "", "", "")) == ("", "", "", "", "")
 
-@test
-def tuple6Combine01(): Bool = combine(("", "", "", "", "", ""), ("", "", "", "", "", "")) == ("", "", "", "", "", "")
+    @test
+    def tuple5Combine02(): Bool = combine(("a", "b", "c", "d", "e"), ("", "", "", "", "")) == ("a", "b", "c", "d", "e")
 
-@test
-def tuple6Combine02(): Bool = combine(("a", "b", "c", "d", "e", "f"), ("", "", "", "", "", "")) == ("a", "b", "c", "d", "e", "f")
+    @test
+    def tuple5Combine03(): Bool = combine(("", "", "", "", ""), ("1", "2", "3", "4", "5")) == ("1", "2", "3", "4", "5")
 
-@test
-def tuple6Combine03(): Bool = combine(("", "", "", "", "", ""), ("1", "2", "3", "4", "5", "6")) == ("1", "2", "3", "4", "5", "6")
+    @test
+    def tuple5Combine04(): Bool = combine(("a", "b", "c", "d", "e"), ("1", "2", "3", "4", "5")) == ("a1", "b2", "c3", "d4", "e5")
 
-@test
-def tuple6Combine04(): Bool = combine(("a", "b", "c", "d", "e", "f"), ("1", "2", "3", "4", "5", "6")) == ("a1", "b2", "c3", "d4", "e5", "f6")
+    @test
+    def tuple5Combine05(): Bool = combine(("a", (), "b", (), "c"), ("1", (), "2", (), "3")) == ("a1", (), "b2", (), "c3")
 
-@test
-def tuple6Combine05(): Bool = combine(("a", (), "b", (), "c", ()), ("1", (), "2", (), "3", ())) == ("a1", (), "b2", (), "c3", ())
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple 6                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
 
-/////////////////////////////////////////////////////////////////////////////
-// Tuple 7                                                                 //
-/////////////////////////////////////////////////////////////////////////////
+    @test
+    def tuple6Empty01(): Bool = empty() == ("", "", "", "", "", "")
 
-@test
-def tuple7Empty01(): Bool = empty() == ("", "", "", "", "", "", "")
+    @test
+    def tuple6Empty02(): Bool = empty() == ("", (), "", (), "", ())
 
-@test
-def tuple7Empty02(): Bool = empty() == ("", (), "", (), "", (), "")
+    @test
+    def tuple6Combine01(): Bool = combine(("", "", "", "", "", ""), ("", "", "", "", "", "")) == ("", "", "", "", "", "")
 
-@test
-def tuple7Combine01(): Bool = combine(("", "", "", "", "", "", ""), ("", "", "", "", "", "", "")) == ("", "", "", "", "", "", "")
+    @test
+    def tuple6Combine02(): Bool = combine(("a", "b", "c", "d", "e", "f"), ("", "", "", "", "", "")) == ("a", "b", "c", "d", "e", "f")
 
-@test
-def tuple7Combine02(): Bool = combine(("a", "b", "c", "d", "e", "f", "g"), ("", "", "", "", "", "", "")) == ("a", "b", "c", "d", "e", "f", "g")
+    @test
+    def tuple6Combine03(): Bool = combine(("", "", "", "", "", ""), ("1", "2", "3", "4", "5", "6")) == ("1", "2", "3", "4", "5", "6")
 
-@test
-def tuple7Combine03(): Bool = combine(("", "", "", "", "", "", ""), ("1", "2", "3", "4", "5", "6", "7")) == ("1", "2", "3", "4", "5", "6", "7")
+    @test
+    def tuple6Combine04(): Bool = combine(("a", "b", "c", "d", "e", "f"), ("1", "2", "3", "4", "5", "6")) == ("a1", "b2", "c3", "d4", "e5", "f6")
 
-@test
-def tuple7Combine04(): Bool = combine(("a", "b", "c", "d", "e", "f", "g"), ("1", "2", "3", "4", "5", "6", "7")) == ("a1", "b2", "c3", "d4", "e5", "f6", "g7")
+    @test
+    def tuple6Combine05(): Bool = combine(("a", (), "b", (), "c", ()), ("1", (), "2", (), "3", ())) == ("a1", (), "b2", (), "c3", ())
 
-@test
-def tuple7Combine05(): Bool = combine(("a", (), "b", (), "c", (), "d"), ("1", (), "2", (), "3", (), "4")) == ("a1", (), "b2", (), "c3", (), "d4")
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple 7                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
 
-/////////////////////////////////////////////////////////////////////////////
-// Tuple 8                                                                 //
-/////////////////////////////////////////////////////////////////////////////
+    @test
+    def tuple7Empty01(): Bool = empty() == ("", "", "", "", "", "", "")
 
-@test
-def tuple8Empty01(): Bool = empty() == ("", "", "", "", "", "", "", "")
+    @test
+    def tuple7Empty02(): Bool = empty() == ("", (), "", (), "", (), "")
 
-@test
-def tuple8Empty02(): Bool = empty() == ("", (), "", (), "", (), "", ())
+    @test
+    def tuple7Combine01(): Bool = combine(("", "", "", "", "", "", ""), ("", "", "", "", "", "", "")) == ("", "", "", "", "", "", "")
 
-@test
-def tuple8Combine01(): Bool = combine(("", "", "", "", "", "", "", ""), ("", "", "", "", "", "", "", "")) == ("", "", "", "", "", "", "", "")
+    @test
+    def tuple7Combine02(): Bool = combine(("a", "b", "c", "d", "e", "f", "g"), ("", "", "", "", "", "", "")) == ("a", "b", "c", "d", "e", "f", "g")
 
-@test
-def tuple8Combine02(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h"), ("", "", "", "", "", "", "", "")) == ("a", "b", "c", "d", "e", "f", "g", "h")
+    @test
+    def tuple7Combine03(): Bool = combine(("", "", "", "", "", "", ""), ("1", "2", "3", "4", "5", "6", "7")) == ("1", "2", "3", "4", "5", "6", "7")
 
-@test
-def tuple8Combine03(): Bool = combine(("", "", "", "", "", "", "", ""), ("1", "2", "3", "4", "5", "6", "7", "8")) == ("1", "2", "3", "4", "5", "6", "7", "8")
+    @test
+    def tuple7Combine04(): Bool = combine(("a", "b", "c", "d", "e", "f", "g"), ("1", "2", "3", "4", "5", "6", "7")) == ("a1", "b2", "c3", "d4", "e5", "f6", "g7")
 
-@test
-def tuple8Combine04(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h"), ("1", "2", "3", "4", "5", "6", "7", "8")) == ("a1", "b2", "c3", "d4", "e5", "f6", "g7", "h8")
+    @test
+    def tuple7Combine05(): Bool = combine(("a", (), "b", (), "c", (), "d"), ("1", (), "2", (), "3", (), "4")) == ("a1", (), "b2", (), "c3", (), "d4")
 
-@test
-def tuple8Combine05(): Bool = combine(("a", (), "b", (), "c", (), "d", ()), ("1", (), "2", (), "3", (), "4", ())) == ("a1", (), "b2", (), "c3", (), "d4", ())
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple 8                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
 
-/////////////////////////////////////////////////////////////////////////////
-// Tuple 9                                                                 //
-/////////////////////////////////////////////////////////////////////////////
+    @test
+    def tuple8Empty01(): Bool = empty() == ("", "", "", "", "", "", "", "")
 
-@test
-def tuple9Empty01(): Bool = empty() == ("", "", "", "", "", "", "", "", "")
+    @test
+    def tuple8Empty02(): Bool = empty() == ("", (), "", (), "", (), "", ())
 
-@test
-def tuple9Empty02(): Bool = empty() == ("", (), "", (), "", (), "", (), "")
+    @test
+    def tuple8Combine01(): Bool = combine(("", "", "", "", "", "", "", ""), ("", "", "", "", "", "", "", "")) == ("", "", "", "", "", "", "", "")
 
-@test
-def tuple9Combine01(): Bool = combine(("", "", "", "", "", "", "", "", ""), ("", "", "", "", "", "", "", "", "")) == ("", "", "", "", "", "", "", "", "")
+    @test
+    def tuple8Combine02(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h"), ("", "", "", "", "", "", "", "")) == ("a", "b", "c", "d", "e", "f", "g", "h")
 
-@test
-def tuple9Combine02(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h", "i"), ("", "", "", "", "", "", "", "", "")) == ("a", "b", "c", "d", "e", "f", "g", "h", "i")
+    @test
+    def tuple8Combine03(): Bool = combine(("", "", "", "", "", "", "", ""), ("1", "2", "3", "4", "5", "6", "7", "8")) == ("1", "2", "3", "4", "5", "6", "7", "8")
 
-@test
-def tuple9Combine03(): Bool = combine(("", "", "", "", "", "", "", "", ""), ("1", "2", "3", "4", "5", "6", "7", "8", "9")) == ("1", "2", "3", "4", "5", "6", "7", "8", "9")
+    @test
+    def tuple8Combine04(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h"), ("1", "2", "3", "4", "5", "6", "7", "8")) == ("a1", "b2", "c3", "d4", "e5", "f6", "g7", "h8")
 
-@test
-def tuple9Combine04(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h", "i"), ("1", "2", "3", "4", "5", "6", "7", "8", "9")) == ("a1", "b2", "c3", "d4", "e5", "f6", "g7", "h8", "i9")
+    @test
+    def tuple8Combine05(): Bool = combine(("a", (), "b", (), "c", (), "d", ()), ("1", (), "2", (), "3", (), "4", ())) == ("a1", (), "b2", (), "c3", (), "d4", ())
 
-@test
-def tuple9Combine05(): Bool = combine(("a", (), "b", (), "c", (), "d", (), "e"), ("1", (), "2", (), "3", (), "4", (), "5")) == ("a1", (), "b2", (), "c3", (), "d4", (), "e5")
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple 9                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
 
-/////////////////////////////////////////////////////////////////////////////
-// Tuple 10                                                                //
-/////////////////////////////////////////////////////////////////////////////
+    @test
+    def tuple9Empty01(): Bool = empty() == ("", "", "", "", "", "", "", "", "")
 
-@test
-def tuple10Empty01(): Bool = empty() == ("", "", "", "", "", "", "", "", "", "")
+    @test
+    def tuple9Empty02(): Bool = empty() == ("", (), "", (), "", (), "", (), "")
 
-@test
-def tuple10Empty02(): Bool = empty() == ("", (), "", (), "", (), "", (), "", ())
+    @test
+    def tuple9Combine01(): Bool = combine(("", "", "", "", "", "", "", "", ""), ("", "", "", "", "", "", "", "", "")) == ("", "", "", "", "", "", "", "", "")
 
-@test
-def tuple10Combine01(): Bool = combine(("", "", "", "", "", "", "", "", "", ""), ("", "", "", "", "", "", "", "", "", "")) == ("", "", "", "", "", "", "", "", "", "")
+    @test
+    def tuple9Combine02(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h", "i"), ("", "", "", "", "", "", "", "", "")) == ("a", "b", "c", "d", "e", "f", "g", "h", "i")
 
-@test
-def tuple10Combine02(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h", "i", "j"), ("", "", "", "", "", "", "", "", "", "")) == ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+    @test
+    def tuple9Combine03(): Bool = combine(("", "", "", "", "", "", "", "", ""), ("1", "2", "3", "4", "5", "6", "7", "8", "9")) == ("1", "2", "3", "4", "5", "6", "7", "8", "9")
 
-@test
-def tuple10Combine03(): Bool = combine(("", "", "", "", "", "", "", "", "", ""), ("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")) == ("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
+    @test
+    def tuple9Combine04(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h", "i"), ("1", "2", "3", "4", "5", "6", "7", "8", "9")) == ("a1", "b2", "c3", "d4", "e5", "f6", "g7", "h8", "i9")
 
-@test
-def tuple10Combine04(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h", "i", "j"), ("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")) == ("a1", "b2", "c3", "d4", "e5", "f6", "g7", "h8", "i9", "j0")
+    @test
+    def tuple9Combine05(): Bool = combine(("a", (), "b", (), "c", (), "d", (), "e"), ("1", (), "2", (), "3", (), "4", (), "5")) == ("a1", (), "b2", (), "c3", (), "d4", (), "e5")
 
-@test
-def tuple10Combine05(): Bool = combine(("a", (), "b", (), "c", (), "d", (), "e", ()), ("1", (), "2", (), "3", (), "4", (), "5", ())) == ("a1", (), "b2", (), "c3", (), "d4", (), "e5", ())
+    /////////////////////////////////////////////////////////////////////////////
+    // Tuple 10                                                                //
+    /////////////////////////////////////////////////////////////////////////////
 
-/////////////////////////////////////////////////////////////////////////////
-// Validation                                                              //
-/////////////////////////////////////////////////////////////////////////////
+    @test
+    def tuple10Empty01(): Bool = empty() == ("", "", "", "", "", "", "", "", "", "")
 
-@test
-def validationEmpty01(): Bool = empty(): Validation[String, String] == Success("")
+    @test
+    def tuple10Empty02(): Bool = empty() == ("", (), "", (), "", (), "", (), "", ())
 
-@test
-def validationCombine01(): Bool = combine(Failure(Nel.singleton("e1")), Failure(Nel.singleton("e2"))): Validation[String, String] == Failure(Nel.append(Nel.singleton("e1"), Nel.singleton("e2")))
+    @test
+    def tuple10Combine01(): Bool = combine(("", "", "", "", "", "", "", "", "", ""), ("", "", "", "", "", "", "", "", "", "")) == ("", "", "", "", "", "", "", "", "", "")
 
-@test
-def validationCombine02(): Bool = combine(Success("a"), Failure(Nel.singleton("e1"))): Validation[String, String] == Failure(Nel.singleton("e1"))
+    @test
+    def tuple10Combine02(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h", "i", "j"), ("", "", "", "", "", "", "", "", "", "")) == ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
 
-@test
-def validationCombine03(): Bool = combine(Failure(Nel.singleton("e1")), Success("1")): Validation[String, String] == Failure(Nel.singleton("e1"))
+    @test
+    def tuple10Combine03(): Bool = combine(("", "", "", "", "", "", "", "", "", ""), ("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")) == ("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
 
-@test
-def validationCombine04(): Bool = combine(Success("a"), Success("1")): Validation[String, String] == Success("a1")
+    @test
+    def tuple10Combine04(): Bool = combine(("a", "b", "c", "d", "e", "f", "g", "h", "i", "j"), ("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")) == ("a1", "b2", "c3", "d4", "e5", "f6", "g7", "h8", "i9", "j0")
 
-/////////////////////////////////////////////////////////////////////////////
-// List                                                                    //
-/////////////////////////////////////////////////////////////////////////////
+    @test
+    def tuple10Combine05(): Bool = combine(("a", (), "b", (), "c", (), "d", (), "e", ()), ("1", (), "2", (), "3", (), "4", (), "5", ())) == ("a1", (), "b2", (), "c3", (), "d4", (), "e5", ())
 
-@test
-def listEmpty01(): Bool = empty(): List[Int32] == Nil
+    /////////////////////////////////////////////////////////////////////////////
+    // Validation                                                              //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def listCombine01(): Bool = combine(Nil, Nil): List[Int32] == Nil
+    @test
+    def validationEmpty01(): Bool = empty(): Validation[String, String] == Success("")
 
-@test
-def listCombine02(): Bool = combine(1 :: Nil, Nil) == 1 :: Nil
+    @test
+    def validationCombine01(): Bool = combine(Failure(Nel.singleton("e1")), Failure(Nel.singleton("e2"))): Validation[String, String] == Failure(Nel.append(Nel.singleton("e1"), Nel.singleton("e2")))
 
-@test
-def listCombine03(): Bool = combine(Nil, 2 :: Nil) == 2 :: Nil
+    @test
+    def validationCombine02(): Bool = combine(Success("a"), Failure(Nel.singleton("e1"))): Validation[String, String] == Failure(Nel.singleton("e1"))
 
-@test
-def listCombine04(): Bool = combine(1 :: Nil, 2 :: Nil) == 1 :: 2 :: Nil
+    @test
+    def validationCombine03(): Bool = combine(Failure(Nel.singleton("e1")), Success("1")): Validation[String, String] == Failure(Nel.singleton("e1"))
 
-@test
-def listCombine05(): Bool = combine(1 :: 2 :: Nil, 1 :: 2 :: Nil) == 1 :: 2 :: 1 :: 2 :: Nil
+    @test
+    def validationCombine04(): Bool = combine(Success("a"), Success("1")): Validation[String, String] == Success("a1")
 
-/////////////////////////////////////////////////////////////////////////////
-// Set                                                                     //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // List                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def setEmpty01(): Bool = empty(): Set[Int32] == Set#{}
+    @test
+    def listEmpty01(): Bool = empty(): List[Int32] == Nil
 
-@test
-def setCombine01(): Bool = combine(Set#{}, Set#{}): Set[Int32] == Set#{}
+    @test
+    def listCombine01(): Bool = combine(Nil, Nil): List[Int32] == Nil
 
-@test
-def setCombine02(): Bool = combine(Set#{1}, Set#{}) == Set#{1}
+    @test
+    def listCombine02(): Bool = combine(1 :: Nil, Nil) == 1 :: Nil
 
-@test
-def setCombine03(): Bool = combine(Set#{}, Set#{2}) == Set#{2}
+    @test
+    def listCombine03(): Bool = combine(Nil, 2 :: Nil) == 2 :: Nil
 
-@test
-def setCombine04(): Bool = combine(Set#{1}, Set#{2}) == Set#{1, 2}
+    @test
+    def listCombine04(): Bool = combine(1 :: Nil, 2 :: Nil) == 1 :: 2 :: Nil
 
-@test
-def setCombine05(): Bool = combine(Set#{1, 2}, Set#{1, 2}) == Set#{1, 2}
+    @test
+    def listCombine05(): Bool = combine(1 :: 2 :: Nil, 1 :: 2 :: Nil) == 1 :: 2 :: 1 :: 2 :: Nil
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Set                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def setEmpty01(): Bool = empty(): Set[Int32] == Set#{}
+
+    @test
+    def setCombine01(): Bool = combine(Set#{}, Set#{}): Set[Int32] == Set#{}
+
+    @test
+    def setCombine02(): Bool = combine(Set#{1}, Set#{}) == Set#{1}
+
+    @test
+    def setCombine03(): Bool = combine(Set#{}, Set#{2}) == Set#{2}
+
+    @test
+    def setCombine04(): Bool = combine(Set#{1}, Set#{2}) == Set#{1, 2}
+
+    @test
+    def setCombine05(): Bool = combine(Set#{1, 2}, Set#{1, 2}) == Set#{1, 2}
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Map                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def mapEmpty01(): Bool = empty(): Map[Int32, String] == Map#{}
+
+    @test
+    def mapCombine01(): Bool = combine(Map#{}, Map#{}): Map[Int32, String] == Map#{}
+
+    @test
+    def mapCombine02(): Bool = combine(Map#{1 -> "A"}, Map#{}) == Map#{1 -> "A"}
+
+    @test
+    def mapCombine03(): Bool = combine(Map#{}, Map#{1 -> "a"}) == Map#{1 -> "a"}
+
+    @test
+    def mapCombine04(): Bool = combine(Map#{1 -> "A"}, Map#{1 -> "a"}) == Map#{1 -> "Aa"}
+
+    @test
+    def mapCombine05(): Bool = combine(Map#{1 -> "A", 2 -> "B", 3 -> "C"}, Map#{2 -> "b", 3 -> "c", 4 -> "d"}) == Map#{1 -> "A", 2 -> "Bb", 3 -> "Cc", 4 -> "d"}
 
 }


### PR DESCRIPTION
This PR adds a Monoid typeclass, see:

Add Monoid Type Class #1545

At them moment this class is quite simple - it just has `empty` and `combine`. It doesn't have a `mconcat`-like method that Haskell's Monoid has. Ideally we would be able to supply a default implementation for `mconcat` (or however it gets named). As I don't think we can do this yet I have left it out.

Also when Flix gets superclasses we should follow Haskell and move the `combine` method into a `Semigroup` class.

The instances implemented so far are essentially "uncontroversial" except Option. By uncontroversial I mean the type has a single sensible instance - e.g Strings are obviously `""` for `empty` and `+` (String.append) for `concat`. 

The Set instance uses `union` which seems the most obvious choice.

The Validation instance has a "positive" empty so you can fold a list of validations.

Option has a recursive implementation. There are different "favourites" in the Haskell world, but I think e.g. left- or right-biased Option would be better as wrappers (c.f. newtypes in Haskell and opaque types in Flix). 

I haven't made any of the wrapped types that Haskell's Monoid class comes with. As Flix's typeclasses are being actively developed it seems sensible to leave them out whilst things are expected to change.

