### PR TITLE
Added primitive instances and tests for LowerBound and UpperBound 

### DIFF
--- a/main/src/library/Bool.flix
+++ b/main/src/library/Bool.flix
@@ -13,6 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+instance LowerBound[Bool] {
+    def minValue(): Bool = false
+}
+
+instance UpperBound[Bool] {
+    def maxValue(): Bool = true
+}
+
 namespace Bool {
 
     ///

--- a/main/src/library/Char.flix
+++ b/main/src/library/Char.flix
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+instance LowerBound[Char] {
+    def minValue(): Char = '\u0000'
+}
+
+instance UpperBound[Char] {
+    def maxValue(): Char = '\uffff'
+}
+
 namespace Char {
 
     ///

--- a/main/src/library/Float32.flix
+++ b/main/src/library/Float32.flix
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+instance LowerBound[Float32] {
+    def minValue(): Float32 = Float32.minValue()
+}
+
+instance UpperBound[Float32] {
+    def maxValue(): Float32 = Float32.maxValue()
+}
+
 namespace Float32 {
 
     ///

--- a/main/src/library/Float64.flix
+++ b/main/src/library/Float64.flix
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+instance LowerBound[Float64] {
+    def minValue(): Float64 = Float64.minValue()
+}
+
+instance UpperBound[Float64] {
+    def maxValue(): Float64 = Float64.maxValue()
+}
+
 namespace Float64 {
 
     ///

--- a/main/src/library/Int16.flix
+++ b/main/src/library/Int16.flix
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+instance LowerBound[Int16] {
+    def minValue(): Int16 = Int16.minValue()
+}
+
+instance UpperBound[Int16] {
+    def maxValue(): Int16 = Int16.maxValue()
+}
+
 namespace Int16 {
 
     ///

--- a/main/src/library/Int32.flix
+++ b/main/src/library/Int32.flix
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+instance LowerBound[Int32] {
+    def minValue(): Int32 = Int32.minValue()
+}
+
+instance UpperBound[Int32] {
+    def maxValue(): Int32 = Int32.maxValue()
+}
+
 namespace Int32 {
 
     ///

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+instance LowerBound[Int64] {
+    def minValue(): Int64 = Int64.minValue()
+}
+
+instance UpperBound[Int64] {
+    def maxValue(): Int64 = Int64.maxValue()
+}
+
 namespace Int64 {
 
     ///

--- a/main/src/library/Int8.flix
+++ b/main/src/library/Int8.flix
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+instance LowerBound[Int8] {
+    def minValue(): Int8 = Int8.minValue()
+}
+
+instance UpperBound[Int8] {
+    def maxValue(): Int8 = Int8.maxValue()
+}
+
 namespace Int8 {
 
     ///

--- a/main/src/library/LowerBound.flix
+++ b/main/src/library/LowerBound.flix
@@ -64,34 +64,8 @@ instance LowerBound[Unit] {
     def minValue(): Unit = ()
 }
 
-instance LowerBound[Bool] {
-    def minValue(): Bool = false
-}
 
-instance LowerBound[Int8] {
-    def minValue(): Int8 = Int8.minValue()
-}
 
-instance LowerBound[Int16] {
-    def minValue(): Int16 = Int16.minValue()
-}
 
-instance LowerBound[Int32] {
-    def minValue(): Int32 = Int32.minValue()
-}
 
-instance LowerBound[Int64] {
-    def minValue(): Int64 = Int64.minValue()
-}
 
-instance LowerBound[Float32] {
-    def minValue(): Float32 = Float32.minValue()
-}
-
-instance LowerBound[Float64] {
-    def minValue(): Float64 = Float64.minValue()
-}
-
-instance LowerBound[Char] {
-    def minValue(): Char = '\u0000'
-}

--- a/main/src/library/LowerBound.flix
+++ b/main/src/library/LowerBound.flix
@@ -59,3 +59,39 @@ instance LowerBound[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with [a1 : LowerBound,
 instance LowerBound[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with [a1 : LowerBound, a2 : LowerBound, a3 : LowerBound, a4 : LowerBound, a5 : LowerBound, a6 : LowerBound, a7 : LowerBound, a8 : LowerBound, a9 : LowerBound, a10 : LowerBound] {
     def minValue(): (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = (LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue(), LowerBound.minValue())
 }
+
+instance LowerBound[Unit] {
+    def minValue(): Unit = ()
+}
+
+instance LowerBound[Bool] {
+    def minValue(): Bool = false
+}
+
+instance LowerBound[Int8] {
+    def minValue(): Int8 = Int8.minValue()
+}
+
+instance LowerBound[Int16] {
+    def minValue(): Int16 = Int16.minValue()
+}
+
+instance LowerBound[Int32] {
+    def minValue(): Int32 = Int32.minValue()
+}
+
+instance LowerBound[Int64] {
+    def minValue(): Int64 = Int64.minValue()
+}
+
+instance LowerBound[Float32] {
+    def minValue(): Float32 = Float32.minValue()
+}
+
+instance LowerBound[Float64] {
+    def minValue(): Float64 = Float64.minValue()
+}
+
+instance LowerBound[Char] {
+    def minValue(): Char = '\u0000'
+}

--- a/main/src/library/UpperBound.flix
+++ b/main/src/library/UpperBound.flix
@@ -59,3 +59,39 @@ instance UpperBound[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with [a1 : UpperBound,
 instance UpperBound[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with [a1 : UpperBound, a2 : UpperBound, a3 : UpperBound, a4 : UpperBound, a5 : UpperBound, a6 : UpperBound, a7 : UpperBound, a8 : UpperBound, a9 : UpperBound, a10 : UpperBound] {
     def maxValue(): (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = (UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue(), UpperBound.maxValue())
 }
+
+instance UpperBound[Unit] {
+    def maxValue(): Unit = ()
+}
+
+instance UpperBound[Bool] {
+    def maxValue(): Bool = true
+}
+
+instance UpperBound[Int8] {
+    def maxValue(): Int8 = Int8.maxValue()
+}
+
+instance UpperBound[Int16] {
+    def maxValue(): Int16 = Int16.maxValue()
+}
+
+instance UpperBound[Int32] {
+    def maxValue(): Int32 = Int32.maxValue()
+}
+
+instance UpperBound[Int64] {
+    def maxValue(): Int64 = Int64.maxValue()
+}
+
+instance UpperBound[Float32] {
+    def maxValue(): Float32 = Float32.maxValue()
+}
+
+instance UpperBound[Float64] {
+    def maxValue(): Float64 = Float64.maxValue()
+}
+
+instance UpperBound[Char] {
+    def maxValue(): Char = '\uffff'
+}

--- a/main/src/library/UpperBound.flix
+++ b/main/src/library/UpperBound.flix
@@ -63,35 +63,3 @@ instance UpperBound[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with [a1 : UpperB
 instance UpperBound[Unit] {
     def maxValue(): Unit = ()
 }
-
-instance UpperBound[Bool] {
-    def maxValue(): Bool = true
-}
-
-instance UpperBound[Int8] {
-    def maxValue(): Int8 = Int8.maxValue()
-}
-
-instance UpperBound[Int16] {
-    def maxValue(): Int16 = Int16.maxValue()
-}
-
-instance UpperBound[Int32] {
-    def maxValue(): Int32 = Int32.maxValue()
-}
-
-instance UpperBound[Int64] {
-    def maxValue(): Int64 = Int64.maxValue()
-}
-
-instance UpperBound[Float32] {
-    def maxValue(): Float32 = Float32.maxValue()
-}
-
-instance UpperBound[Float64] {
-    def maxValue(): Float64 = Float64.maxValue()
-}
-
-instance UpperBound[Char] {
-    def maxValue(): Char = '\uffff'
-}

--- a/main/test/ca/uwaterloo/flix/library/LibrarySuite.scala
+++ b/main/test/ca/uwaterloo/flix/library/LibrarySuite.scala
@@ -53,6 +53,8 @@ class LibrarySuite extends Suites(
   new FlixTest("TestHash", "main/test/ca/uwaterloo/flix/library/TestHash.flix")(Options.TestWithLibrary),
   new FlixTest("TestLazyList", "main/test/ca/uwaterloo/flix/library/TestLazyList.flix")(Options.TestWithLibrary),
   new FlixTest("TestMonoid", "main/test/ca/uwaterloo/flix/library/TestMonoid.flix")(Options.TestWithLibrary),
+  new FlixTest("TestLowerBound", "main/test/ca/uwaterloo/flix/library/TestLowerBound.flix")(Options.TestWithLibrary),
+  new FlixTest("TestUpperBound", "main/test/ca/uwaterloo/flix/library/TestUpperBound.flix")(Options.TestWithLibrary),
 
   new FlixTest("Core/Io/TestFile", "main/test/ca/uwaterloo/flix/library/Core/Io/TestFile.flix")(Options.TestWithLibrary),
   new FlixTest("Core/Io/TestInputStream", "main/test/ca/uwaterloo/flix/library/Core/Io/TestInputStream.flix")(Options.TestWithLibrary),

--- a/main/test/ca/uwaterloo/flix/library/TestLowerBound.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestLowerBound.flix
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2020 Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace TestLowerBound {
+    use LowerBound.minValue;
+
+    @test
+    def testUnit(): Bool = minValue() == ()
+
+    @test
+    def testBool(): Bool = minValue() == false
+
+    @test
+    def testInt8(): Bool = minValue() == -128i8
+
+    @test
+    def testInt16(): Bool = minValue() == -32_768i16
+
+    @test
+    def testInt32(): Bool = minValue() == -2_147_483_648
+
+    @test
+    def testInt64(): Bool = minValue() == -9_223_372_036_854_775_808i64
+
+    @test
+    def testFloat32(): Bool = minValue() == Float32.minValue()
+
+    @test
+    def testFloat64(): Bool = minValue() == Float64.minValue()
+
+    @test
+    def testChar(): Bool = minValue() == Char.fromInt32(0)
+
+    @test
+    def testTuple2(): Bool = minValue() == ('\u0000', '\u0000')
+
+    @test
+    def testTuple3(): Bool = minValue() == ('\u0000', '\u0000', '\u0000')
+
+    @test
+    def testTuple4(): Bool = minValue() == ('\u0000', '\u0000', '\u0000', '\u0000')
+
+    @test
+    def testTuple5(): Bool = minValue() == ('\u0000', '\u0000', '\u0000', '\u0000', '\u0000')
+
+    @test
+    def testTuple6(): Bool = minValue() == ('\u0000', '\u0000', '\u0000', '\u0000', '\u0000', '\u0000')
+
+    @test
+    def testTuple7(): Bool = minValue() == ('\u0000', '\u0000', '\u0000', '\u0000', '\u0000', '\u0000', '\u0000')
+
+    @test
+    def testTuple8(): Bool = minValue() == ('\u0000', '\u0000', '\u0000', '\u0000', '\u0000', '\u0000', '\u0000', '\u0000')
+
+    @test
+    def testTuple9(): Bool = minValue() == ('\u0000', '\u0000', '\u0000', '\u0000', '\u0000', '\u0000', '\u0000', '\u0000', '\u0000')
+
+    @test
+    def testTuple10(): Bool = minValue() == ('\u0000', '\u0000', '\u0000', '\u0000', '\u0000', '\u0000', '\u0000', '\u0000', '\u0000', '\u0000')
+
+}

--- a/main/test/ca/uwaterloo/flix/library/TestUpperBound.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestUpperBound.flix
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2020 Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace TestUpperBound {
+    use UpperBound.maxValue;
+
+    @test
+    def testUnit(): Bool = maxValue() == ()
+
+    @test
+    def testBool(): Bool = maxValue() == true
+
+    @test
+    def testInt8(): Bool = maxValue() == 127i8
+
+    @test
+    def testInt16(): Bool = maxValue() == 32_767i16
+
+    @test
+    def testInt32(): Bool = maxValue() == 2_147_483_647
+
+    @test
+    def testInt64(): Bool = maxValue() == 9_223_372_036_854_775_807i64
+
+    @test
+    def testFloat32(): Bool = maxValue() == Float32.maxValue()
+
+    @test
+    def testFloat64(): Bool = maxValue() == Float64.maxValue()
+
+    @test
+    def testChar(): Bool = maxValue() == '\uffff'
+
+    @test
+    def testTuple2(): Bool = maxValue() == ('\uffff', '\uffff')
+
+    @test
+    def testTuple3(): Bool = maxValue() == ('\uffff', '\uffff', '\uffff')
+
+    @test
+    def testTuple4(): Bool = maxValue() == ('\uffff', '\uffff', '\uffff', '\uffff')
+
+    @test
+    def testTuple5(): Bool = maxValue() == ('\uffff', '\uffff', '\uffff', '\uffff', '\uffff')
+
+    @test
+    def testTuple6(): Bool = maxValue() == ('\uffff', '\uffff', '\uffff', '\uffff', '\uffff', '\uffff')
+
+    @test
+    def testTuple7(): Bool = maxValue() == ('\uffff', '\uffff', '\uffff', '\uffff', '\uffff', '\uffff', '\uffff')
+
+    @test
+    def testTuple8(): Bool = maxValue() == ('\uffff', '\uffff', '\uffff', '\uffff', '\uffff', '\uffff', '\uffff', '\uffff')
+
+    @test
+    def testTuple9(): Bool = maxValue() == ('\uffff', '\uffff', '\uffff', '\uffff', '\uffff', '\uffff', '\uffff', '\uffff', '\uffff')
+
+    @test
+    def testTuple10(): Bool = maxValue() == ('\uffff', '\uffff', '\uffff', '\uffff', '\uffff', '\uffff', '\uffff', '\uffff', '\uffff', '\uffff')
+
+}


### PR DESCRIPTION
Hi Magnus

I noticed the LowerBound and UpperBound classes only had Tuple instances so I've added instances for Unit, Bool, Char and the number types (except BigInt). 

I've also added tests.

Happy Christmas, please don't rush to review the changes.