### PR TITLE
Use TableSwitch when generating code for SelectChannel

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -31,3 +31,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Erik Funder Carstensen](https://github.com/halvko)
 - [Rasmus Larsen](https://github.com/herbstein)
 - [Thomas Søe Plougsgaard](https://github.com/plougsgaard)
+- [Oskar Haarklou Veileborg](https://github.com/BarrensZeppelin)

--- a/main/test/flix/Test.Exp.Concurrency.Select.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Select.flix
@@ -107,6 +107,20 @@ namespace Test/Exp/Concurrency/Select {
         }
 
     @test
+    def testSelectDefault01(): Bool & Impure =
+        select {
+            case x <- chan Bool 1 => x
+            case _                => true
+        }
+
+    @test
+    def testSelectDefault02(): Bool & Impure =
+        (1 + select {
+            case x <- chan Int64 1 => 2
+            case _                 => 1
+        }) == 2
+
+    @test
     def testSelectRandom01(): Unit & Impure = {
         let c9 = chan Unit 0;
         let c10 = chan Unit 0;


### PR DESCRIPTION
This change reduces the size of generated code.
The use of the `TABLESWITCH` instruction also seems natural here. :slightly_smiling_face: 

It most likely doesn't improve performance.
I think the JIT optimiser can automatically transform the series of if-then-else constructs to a switch (you can manually investigate this, if you have the time :upside_down_face:).
Even if it cannot, any performance improvement will be overshadowed by the expensive locking operations involved in the select statement.

For further reduction of code size, you can hoist the `GETFIELD "element"` instruction out of each branch at the cost of a `SWAP`, such that
```
DUP
GETFIELD "branchNumber"
TABLESWITCH ...
case 0:
     GETFIELD "element"
     ...
```
becomes
```
DUP
GETFIELD "element"
SWAP
GETFIELD "branchNumber"
TABLESWITCH ...
case 0:
     ...
```