### PR TITLE
Add Support for Lawful and Unlawful Modifiers

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -230,6 +230,11 @@ object Ast {
     def isInline: Boolean = mod contains Modifier.Inline
 
     /**
+      * Returns `true` if these modifiers contain the lawless modifier.
+      */
+    def isLawless: Boolean = mod contains Modifier.Lawless
+
+    /**
       * Returns `true` if these modifiers contain the public modifier.
       */
     def isPublic: Boolean = mod contains Modifier.Public
@@ -243,6 +248,12 @@ object Ast {
       * Returns `true` if these modifiers contain the synthetic modifier.
       */
     def isSynthetic: Boolean = mod contains Modifier.Synthetic
+
+    /**
+      * Returns `true` if these modifiers contain the unlawful modifier.
+      */
+    def isUnlawful: Boolean = mod contains Modifier.Unlawful
+
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -258,6 +258,11 @@ object Ast {
     case object Inline extends Modifier
 
     /**
+      * The lawless modifier.
+      */
+    case object Lawless extends Modifier
+
+    /**
       * The public modifier.
       */
     case object Public extends Modifier
@@ -271,6 +276,11 @@ object Ast {
       * The synthetic modifier.
       */
     case object Synthetic extends Modifier
+
+    /**
+      * The unlawful modifier.
+      */
+    case object Unlawful extends Modifier
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.errors
 import ca.uwaterloo.flix.language.CompilationError
 import ca.uwaterloo.flix.language.ast.{Scheme, SourceLocation, Symbol, Type}
 import ca.uwaterloo.flix.language.debug.{Audience, FormatScheme, FormatType}
-import ca.uwaterloo.flix.util.vt.VirtualString.{Code, Line, NewLine, Red, Underline}
+import ca.uwaterloo.flix.util.vt.VirtualString._
 import ca.uwaterloo.flix.util.vt.VirtualTerminal
 
 /**
@@ -203,4 +203,29 @@ object InstanceError {
       vt << Underline("Tip:") << s" Add an instance of '${superClass.name}' for '${FormatType.formatType(tpe)}'."
     }
   }
+
+  /**
+    * Error indicating an unlawful super class of a lawful subclass.
+    *
+    * @param subClass   the lawful sub class.
+    * @param superClass the unlawful super class.
+    * @param loc        the location where the error occurred.
+    */
+  case class UnlawfulSuperClass(subClass: Symbol.ClassSym, superClass: Symbol.ClassSym, loc: SourceLocation) extends InstanceError {
+    override def summary: String = s"Unlawful super class '$superClass'."
+
+    override def message: VirtualTerminal = {
+      val vt = new VirtualTerminal()
+      vt << Line(kind, source.format) << NewLine
+      vt << ">> Unlawful super class '" << Red(superClass.name) << "'." << NewLine
+      vt << NewLine
+      vt << ">> The class '" << Red(subClass.name) << "' extends the unlawful class '" << Red(superClass.name) << "'." << NewLine
+      vt << ">> A lawful class cannot extend an unlawful class."
+      vt << NewLine
+      vt << Code(loc, s"unlawful super class")
+      vt << NewLine
+      vt << Underline("Tip:") << s" Mark '${subClass.name}' as unlawful."
+    }
+  }
+
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
@@ -246,7 +246,7 @@ object InstanceError {
       vt << NewLine
       vt << Code(loc, s"unlawful signature")
       vt << NewLine
-      vt << Underline("Tip:") << s" Create a law for ${sym} or mark the class as unlawful."
+      vt << Underline("Tip:") << s" Create a law for '${sym}' or mark the class as unlawful."
     }
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
@@ -228,4 +228,25 @@ object InstanceError {
     }
   }
 
+  /**
+    * Error indicating an unlawful signature in a lawful class.
+    *
+    * @param sym the symbol of the unlawful signature.
+    * @param loc the location where the error occurred.
+    */
+  case class UnlawfulSignature(sym: Symbol.SigSym, loc: SourceLocation) extends InstanceError {
+    override def summary: String = s"Unlawful signature '$sym'."
+
+    override def message: VirtualTerminal = {
+      val vt = new VirtualTerminal()
+      vt << Line(kind, source.format) << NewLine
+      vt << ">> Unlawful signature '" << Red(sym.name) << "'." << NewLine
+      vt << NewLine
+      vt << ">> Each signature of a lawful class must appear in at least one law."
+      vt << NewLine
+      vt << Code(loc, s"unlawful signature")
+      vt << NewLine
+      vt << Underline("Tip:") << s" Create a law for ${sym} or mark the class as unlawful."
+    }
+  }
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
@@ -205,26 +205,26 @@ object InstanceError {
   }
 
   /**
-    * Error indicating an unlawful super class of a lawful subclass.
+    * Error indicating an lawless super class of a lawful subclass.
     *
     * @param subClass   the lawful sub class.
-    * @param superClass the unlawful super class.
+    * @param superClass the lawless super class.
     * @param loc        the location where the error occurred.
     */
-  case class UnlawfulSuperClass(subClass: Symbol.ClassSym, superClass: Symbol.ClassSym, loc: SourceLocation) extends InstanceError {
-    override def summary: String = s"Unlawful super class '$superClass'."
+  case class LawlessSuperClass(subClass: Symbol.ClassSym, superClass: Symbol.ClassSym, loc: SourceLocation) extends InstanceError {
+    override def summary: String = s"Lawless super class '$superClass'."
 
     override def message: VirtualTerminal = {
       val vt = new VirtualTerminal()
       vt << Line(kind, source.format) << NewLine
-      vt << ">> Unlawful super class '" << Red(superClass.name) << "'." << NewLine
+      vt << ">> Lawless super class '" << Red(superClass.name) << "'." << NewLine
       vt << NewLine
-      vt << ">> The class '" << Red(subClass.name) << "' extends the unlawful class '" << Red(superClass.name) << "'." << NewLine
+      vt << ">> The class '" << Red(subClass.name) << "' extends the lawless class '" << Red(superClass.name) << "'." << NewLine
       vt << ">> A lawful class cannot extend an unlawful class."
       vt << NewLine
-      vt << Code(loc, s"unlawful super class")
+      vt << Code(loc, s"lawless super class")
       vt << NewLine
-      vt << Underline("Tip:") << s" Mark '${subClass.name}' as unlawful."
+      vt << Underline("Tip:") << s" Mark '${subClass.name}' as lawless."
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -156,6 +156,19 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
         }
     }
 
+    // MATT docs
+    // MATT test
+    // MATT actually use this def
+    def checkLawfulness(clazz: TypedAst.Class): Validation[Unit, InstanceError] = clazz match {
+      case TypedAst.Class(doc, mod, sym, tparam, superClasses, signatures, laws, loc) => (mod.isLawless, laws) match {
+        // Case 1: lawless class with laws: error
+        case (true, _ :: _) => ??? // MATT make error
+        // Case 2: lawful class without laws: error
+        case (false, Nil) => ??? // MATT make error
+        // Case 3: appropriate modifier
+        case _ => ().toSuccess
+      }
+    }
 
     /**
       * Reassembles a set of instances of the same class.

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -33,10 +33,11 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
   override def run(root: TypedAst.Root)(implicit flix: Flix): Validation[TypedAst.Root, CompilationError] = flix.phase("Instances") {
     for {
       _ <- visitInstances(root)
+      _ <- visitClasses(root)
     } yield root
   }
 
-  // MATT use this
+  // MATT docs
   private def visitClasses(root: TypedAst.Root)(implicit flix: Flix): Validation[Unit, InstanceError] = {
 
     // MATT docs
@@ -152,10 +153,13 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
     }
 
     def visitClass(class0: TypedAst.Class): Validation[Unit, InstanceError] = {
-      ??? // MATT
+      for {
+        _ <- checkLawfulSuperClasses(class0)
+        _ <- checkLawApplication(class0)
+      } yield ()
     }
 
-    ??? // MATT
+    Validation.traverseX(root.classes.values)(visitClass)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -50,7 +50,7 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
             superSym =>
               val superClass = root.classes(superSym)
               if (superClass.mod.isLawless) {
-                InstanceError.UnlawfulSuperClass(sym, superSym, loc).toFailure
+                InstanceError.LawlessSuperClass(sym, superSym, loc).toFailure
               } else {
                 ().toSuccess
               }

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -28,7 +28,7 @@ import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps, Validation}
 object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
 
   /**
-    * Validates instances in the given AST root.
+    * Validates instances and classes in the given AST root.
     */
   override def run(root: TypedAst.Root)(implicit flix: Flix): Validation[TypedAst.Root, CompilationError] = flix.phase("Instances") {
     for {
@@ -37,10 +37,14 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
     } yield root
   }
 
-  // MATT docs
+  /**
+    * Validates all instances in the given AST root.
+    */
   private def visitClasses(root: TypedAst.Root)(implicit flix: Flix): Validation[Unit, InstanceError] = {
 
-    // MATT docs
+    /**
+      * Checks that every super class of `class0` is lawful, unless `class0` is marked `lawless`.
+      */
     def checkLawfulSuperClasses(class0: TypedAst.Class): Validation[Unit, InstanceError] = class0 match {
       case TypedAst.Class(_, mod, sym, _, superClasses, _, _, loc) =>
         if (mod.isLawless) {
@@ -58,7 +62,9 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
         }
     }
 
-    // MATT docs
+    /**
+      * Creates a list of all the sigs used in the given `defn0`.
+      */
     def findUsedSigs(defn0: TypedAst.Def): List[Symbol.SigSym] = {
       def visit(exp0: TypedAst.Expression): List[Symbol.SigSym] = exp0 match {
         case Expression.Unit(_) => Nil
@@ -134,7 +140,9 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
       visit(defn0.exp)
     }
 
-    // MATT docs
+    /**
+      * Checks that all signatures in `class0` are used in laws, unless `class0` is marked `lawless`.
+      */
     def checkLawApplication(class0: TypedAst.Class): Validation[Unit, InstanceError] = class0 match {
       case TypedAst.Class(_, mod, _, _, _, signatures, laws, _) =>
         if (mod.isLawless) {
@@ -152,6 +160,9 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
         }
     }
 
+    /**
+      * Performs validations on a single class.
+      */
     def visitClass(class0: TypedAst.Class): Validation[Unit, InstanceError] = {
       for {
         _ <- checkLawfulSuperClasses(class0)
@@ -165,8 +176,6 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
 
   /**
     * Validates all instances in the given AST root.
-    *
-    * Returns [[Err]] if a definition fails to type check.
     */
   private def visitInstances(root: TypedAst.Root)(implicit flix: Flix): Validation[Unit, InstanceError] = {
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -159,7 +159,8 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
       } yield ()
     }
 
-    Validation.traverseX(root.classes.values)(visitClass)
+    val results = ParOps.parMap(root.classes.values, visitClass)
+    Validation.traverseX(results)(identity)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -145,7 +145,7 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
               if (usedSigs.contains(sig.sym)) {
                 ().toSuccess
               } else {
-                ??? // MATT error
+                InstanceError.UnlawfulSignature(sig.sym, sig.loc).toFailure
               }
           }
         }

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -39,8 +39,9 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
   // MATT use this
   private def visitClasses(root: TypedAst.Root)(implicit flix: Flix): Validation[Unit, InstanceError] = {
 
+    // MATT docs
     def checkLawfulSuperClasses(class0: TypedAst.Class): Validation[Unit, InstanceError] = class0 match {
-      case TypedAst.Class(_, mod, _, _, superClasses, _, _, _) =>
+      case TypedAst.Class(_, mod, sym, _, superClasses, _, _, loc) =>
         if (mod.isLawless) {
           ().toSuccess
         } else {
@@ -48,7 +49,7 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
             superSym =>
               val superClass = root.classes(superSym)
               if (superClass.mod.isLawless) {
-                ??? // MATT error
+                InstanceError.UnlawfulSuperClass(sym, superSym, loc).toFailure
               } else {
                 ().toSuccess
               }

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -82,7 +82,7 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
     }
 
     val results = ParOps.parMap(root.classes.values, visitClass)
-    Validation.traverseX(results)(identity)
+    Validation.sequenceX(results)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -75,25 +75,25 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
         case Expression.Str(_, _) => Nil
         case Expression.Default(_, _) => Nil
         case Expression.Wild(_, _) => Nil
-        case Expression.Var(sym, _, _) => Nil
-        case Expression.Def(sym, _, _) => Nil
+        case Expression.Var(_, _, _) => Nil
+        case Expression.Def(_, _, _) => Nil
         case Expression.Sig(sym, _, _) => List(sym)
-        case Expression.Hole(sym, _, _, _) => Nil
-        case Expression.Lambda(fparam, exp, _, _) => visit(exp)
+        case Expression.Hole(_, _, _, _) => Nil
+        case Expression.Lambda(_, exp, _, _) => visit(exp)
         case Expression.Apply(exp, exps, _, _, _) => visit(exp) ++ exps.flatMap(visit)
-        case Expression.Unary(sop, exp, _, _, _) => visit(exp)
-        case Expression.Binary(sop, exp1, exp2, _, _, _) => visit(exp1) ++ visit(exp2)
-        case Expression.Let(sym, exp1, exp2, _, _, _) => visit(exp1) ++ visit(exp2)
+        case Expression.Unary(_, exp, _, _, _) => visit(exp)
+        case Expression.Binary(_, exp1, exp2, _, _, _) => visit(exp1) ++ visit(exp2)
+        case Expression.Let(_, exp1, exp2, _, _, _) => visit(exp1) ++ visit(exp2)
         case Expression.IfThenElse(exp1, exp2, exp3, _, _, _) => visit(exp1) ++ visit(exp2) ++ visit(exp3)
         case Expression.Stm(exp1, exp2, _, _, _) => visit(exp1) ++ visit(exp2)
         case Expression.Match(exp, rules, _, _, _) => visit(exp) ++ rules.flatMap(rule => visit(rule.exp) ++ visit(rule.guard))
         case Expression.Choose(exps, rules, _, _, _) => exps.flatMap(visit) ++ rules.flatMap(rule => visit(rule.exp))
-        case Expression.Tag(sym, tag, exp, _, _, _) => visit(exp)
+        case Expression.Tag(_, _, exp, _, _, _) => visit(exp)
         case Expression.Tuple(elms, _, _, _) => elms.flatMap(visit)
         case Expression.RecordEmpty(_, _) => Nil
-        case Expression.RecordSelect(exp, field, _, _, _) => visit(exp)
-        case Expression.RecordExtend(field, value, rest, _, _, _) => visit(value) ++ visit(rest)
-        case Expression.RecordRestrict(field, rest, _, _, _) => visit(rest)
+        case Expression.RecordSelect(exp, _, _, _, _) => visit(exp)
+        case Expression.RecordExtend(_, value, rest, _, _, _) => visit(value) ++ visit(rest)
+        case Expression.RecordRestrict(_, rest, _, _, _) => visit(rest)
         case Expression.ArrayLit(elms, _, _, _) => elms.flatMap(visit)
         case Expression.ArrayNew(elm, len, _, _, _) => visit(elm) ++ visit(len)
         case Expression.ArrayLoad(base, index, _, _, _) => visit(base) ++ visit(index)
@@ -135,7 +135,7 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
 
     // MATT docs
     def checkLawApplication(class0: TypedAst.Class): Validation[Unit, InstanceError] = class0 match {
-      case TypedAst.Class(_, mod, _, _, _, signatures, laws, _) => // MATT make _
+      case TypedAst.Class(_, mod, _, _, _, signatures, laws, _) =>
         if (mod.isLawless) {
           ().toSuccess
         } else {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1347,6 +1347,10 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       SP ~ capture(keyword("inline")) ~ SP ~> ParsedAst.Modifier
     }
 
+    def Lawless: Rule1[ParsedAst.Modifier] = rule {
+      SP ~ capture(keyword("lawless")) ~ SP ~> ParsedAst.Modifier
+    }
+
     def Public: Rule1[ParsedAst.Modifier] = rule {
       SP ~ capture(keyword("pub")) ~ SP ~> ParsedAst.Modifier
     }
@@ -1355,8 +1359,12 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       SP ~ capture(keyword("sealed")) ~ SP ~> ParsedAst.Modifier
     }
 
+    def Unlawful: Rule1[ParsedAst.Modifier] = rule {
+      SP ~ capture(keyword("unlawful")) ~ SP ~> ParsedAst.Modifier
+    }
+
     def Modifier: Rule1[ParsedAst.Modifier] = rule {
-      Inline | Public | Sealed
+      Inline | Lawless | Public | Sealed | Unlawful
     }
 
     rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -116,7 +116,7 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
       val laws0 = lawsAndSigs.collect { case law: ParsedAst.Declaration.Law => law }
       val sigs0 = lawsAndSigs.collect { case sig: ParsedAst.Declaration.Sig => sig }
       for {
-        mods <- visitModifiers(mods0, legalModifiers = Set(Ast.Modifier.Public, Ast.Modifier.Sealed))
+        mods <- visitModifiers(mods0, legalModifiers = Set(Ast.Modifier.Public, Ast.Modifier.Sealed, Ast.Modifier.Lawless))
         sigs <- traverse(sigs0)(visitSig)
         laws <- traverse(laws0)(visitLaw)
         superClasses <- visitSuperClasses(tparam0, superClasses0)
@@ -166,7 +166,7 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
       val doc = visitDoc(doc0)
       val tpe = visitType(tpe0)
       for {
-        mods <- visitModifiers(mods0, legalModifiers = Set(Ast.Modifier.Public))
+        mods <- visitModifiers(mods0, legalModifiers = Set(Ast.Modifier.Public, Ast.Modifier.Unlawful))
         defs <- traverse(defs0)(visitDef)
         constrs = visitTypeConstraints(constrs0.getOrElse(Seq.empty))
       } yield List(WeededAst.Declaration.Instance(doc, mods, clazz, tpe, constrs, defs.flatten, loc))
@@ -1741,8 +1741,10 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
   private def visitModifier(m: ParsedAst.Modifier, legalModifiers: Set[Ast.Modifier]): Validation[Ast.Modifier, WeederError] = {
     val modifier = m.name match {
       case "inline" => Ast.Modifier.Inline
+      case "lawless" => Ast.Modifier.Lawless
       case "pub" => Ast.Modifier.Public
       case "sealed" => Ast.Modifier.Sealed
+      case "unlawful" => Ast.Modifier.Unlawful
       case s => throw InternalCompilerException(s"Unknown modifier '$s' near ${mkSL(m.sp1, m.sp2).format}.")
     }
 

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -103,6 +103,13 @@ object Validation {
   def traverse[T, S, E](xs: Iterable[T])(f: T => Validation[S, E]): Validation[List[S], E] = fastTraverse(xs)(f)
 
   /**
+    * Traverses `xs` applying the function `f` to each element, ignoring non-error results.
+    */
+  def traverseX[T, E](xs: Iterable[T])(f: T => Validation[_, E]): Validation[Unit, E] = {
+    traverse(xs)(f).map(_ => ())
+  }
+
+  /**
     * A fast implementation of traverse.
     */
   private def fastTraverse[T, S, E](xs: Iterable[T])(f: T => Validation[S, E]): Validation[List[S], E] = {

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -98,6 +98,13 @@ object Validation {
   }
 
   /**
+    * Sequences the given list of validations `xs`, ignoring non-error results.
+    */
+  def sequenceX[T, E](xs: Iterable[Validation[T, E]]): Validation[Unit, E] = {
+    sequence(xs).map(_ => ())
+  }
+
+  /**
     * Traverses `xs` applying the function `f` to each element.
     */
   def traverse[T, S, E](xs: Iterable[T])(f: T => Validation[S, E]): Validation[List[S], E] = fastTraverse(xs)(f)

--- a/main/src/library/Add.flix
+++ b/main/src/library/Add.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for addition.
 ///
-pub class Add[a] {
+pub lawless class Add[a] {
     ///
     /// Returns the sum of `x` and `y`.
     ///

--- a/main/src/library/BitwiseAnd.flix
+++ b/main/src/library/BitwiseAnd.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for bitwise and.
 ///
-pub class BitwiseAnd[a] {
+pub lawless class BitwiseAnd[a] {
     ///
     /// Returns the bitwise AND of `x` and `y`.
     ///

--- a/main/src/library/BitwiseNot.flix
+++ b/main/src/library/BitwiseNot.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for bitwise not.
 ///
-pub class BitwiseNot[a] {
+pub lawless class BitwiseNot[a] {
     ///
     /// Returns the bitwise NOT of `x`.
     ///

--- a/main/src/library/BitwiseOr.flix
+++ b/main/src/library/BitwiseOr.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for bitwise or.
 ///
-pub class BitwiseOr[a] {
+pub lawless class BitwiseOr[a] {
     ///
     /// Returns the bitwise OR of `x` and `y`.
     ///

--- a/main/src/library/BitwiseShl.flix
+++ b/main/src/library/BitwiseShl.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for bitwise left shift.
 ///
-pub class BitwiseShl[a] {
+pub lawless class BitwiseShl[a] {
     ///
     /// Returns `x` shifted left by `n` bits.
     ///

--- a/main/src/library/BitwiseShr.flix
+++ b/main/src/library/BitwiseShr.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for bitwise right shift.
 ///
-pub class BitwiseShr[a] {
+pub lawless class BitwiseShr[a] {
     ///
     /// Returns `x` shifted right by `n` bits.
     ///

--- a/main/src/library/BitwiseXor.flix
+++ b/main/src/library/BitwiseXor.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for bitwise xor.
 ///
-pub class BitwiseXor[a] {
+pub lawless class BitwiseXor[a] {
     ///
     /// Returns the bitwise XOR of `x` and `y`.
     ///

--- a/main/src/library/Copy.flix
+++ b/main/src/library/Copy.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for duplicable elements.
 ///
-pub class Copy[a] {
+pub lawless class Copy[a] {
     ///
     /// Returns a shallow copy of `x`.
     ///

--- a/main/src/library/Div.flix
+++ b/main/src/library/Div.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for division.
 ///
-pub class Div[a] {
+pub lawless class Div[a] {
     ///
     /// Returns `x` divided by `y`.
     ///

--- a/main/src/library/Drop.flix
+++ b/main/src/library/Drop.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for closable types.
 ///
-pub class Drop[a] {
+pub lawless class Drop[a] {
     ///
     /// Drops `x`.
     ///

--- a/main/src/library/Eq.flix
+++ b/main/src/library/Eq.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for equality and inequality.
 ///
-pub class Eq[a] {
+pub lawless class Eq[a] {
 
     ///
     /// Returns `true` if and only if `x` is equal to `y`.

--- a/main/src/library/Exp.flix
+++ b/main/src/library/Exp.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for exponentiation.
 ///
-pub class Exp[a] {
+pub lawless class Exp[a] {
     ///
     /// Returns `b` raised to the power of `n`.
     ///

--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for data structures that can be folded.
 ///
-pub class Foldable[t :# Type -> Type] {
+pub lawless class Foldable[t :# Type -> Type] {
 
     ///
     /// Left-associative fold of a structure.

--- a/main/src/library/FromString.flix
+++ b/main/src/library/FromString.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for types that can be constructed from strings.
 ///
-pub class FromString[a] {
+pub lawless class FromString[a] {
     ///
     /// Optionally returns the value associated with the given string `s`.
     ///

--- a/main/src/library/Functor.flix
+++ b/main/src/library/Functor.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for types that can be mapped over.
 ///
-class Functor[m :# Type -> Type] {
+lawless class Functor[m :# Type -> Type] {
     ///
     /// Applies the function `f` to `s` preserving its structure.
     ///

--- a/main/src/library/Hash.flix
+++ b/main/src/library/Hash.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for types that can be hashed.
 ///
-pub class Hash[a] {
+pub lawless class Hash[a] {
     ///
     /// Returns a hash value for the given x.
     ///

--- a/main/src/library/JoinLattice.flix
+++ b/main/src/library/JoinLattice.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for join semi lattices.
 ///
-class JoinLattice[a] {
+lawless class JoinLattice[a] {
 
     ///
     /// Returns the least upper bound of `x` and `y`.

--- a/main/src/library/LowerBound.flix
+++ b/main/src/library/LowerBound.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for partially ordered types that have a lower bound.
 ///
-pub class LowerBound[a] {
+pub lawless class LowerBound[a] {
     ///
     /// Returns the smallest value of `a`.
     ///

--- a/main/src/library/MeetLattice.flix
+++ b/main/src/library/MeetLattice.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for meet semi lattices.
 ///
-class MeetLattice[a] {
+lawless class MeetLattice[a] {
 
     ///
     /// Returns the greatest lower bound of `x` and `y`.

--- a/main/src/library/Monoid.flix
+++ b/main/src/library/Monoid.flix
@@ -18,7 +18,7 @@
 /// A type class for monoids, objects that support an associative binary
 /// operation `combine` and neutral element `empty`.
 ///
-pub class Monoid[a] {
+pub lawless class Monoid[a] {
     ///
     /// Returns a neutral element.
     ///

--- a/main/src/library/Mul.flix
+++ b/main/src/library/Mul.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for multiplication.
 ///
-pub class Mul[a] {
+pub lawless class Mul[a] {
     ///
     /// Returns `x` multiplied by `y`.
     ///

--- a/main/src/library/Neg.flix
+++ b/main/src/library/Neg.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for negation.
 ///
-pub class Neg[a] {
+pub lawless class Neg[a] {
     ///
     /// Returns -`x`.
     ///

--- a/main/src/library/Order.flix
+++ b/main/src/library/Order.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for types with a total order.
 ///
-pub class Order[a] {
+pub lawless class Order[a] {
 
     /// Returns `true` if and only if `x < y`.
     pub def less(x: a, y: a): Bool

--- a/main/src/library/PartialOrder.flix
+++ b/main/src/library/PartialOrder.flix
@@ -13,7 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-class PartialOrder[a] {
+lawless class PartialOrder[a] {
 
     ///
     /// Returns `true` if `x` is smaller equal to `y`.

--- a/main/src/library/Rem.flix
+++ b/main/src/library/Rem.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for modulo (i.e. remainder).
 ///
-pub class Rem[a] {
+pub lawless class Rem[a] {
     ///
     /// Returns `x` modulo `n`.
     ///

--- a/main/src/library/Semigroup.flix
+++ b/main/src/library/Semigroup.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for types that form a semigroup.
 ///
-pub class Semigroup[a] {
+pub lawless class Semigroup[a] {
     ///
     /// An associative binary operation on `a`.
     ///

--- a/main/src/library/Sub.flix
+++ b/main/src/library/Sub.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for subtraction.
 ///
-pub class Sub[a] {
+pub lawless class Sub[a] {
     ///
     /// Returns the difference of `x` and `y`.
     ///

--- a/main/src/library/ToString.flix
+++ b/main/src/library/ToString.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for types that can be converted to strings.
 ///
-pub class ToString[a] {
+pub lawless class ToString[a] {
     ///
     /// Returns a string representation of the given x.
     ///

--- a/main/src/library/UpperBound.flix
+++ b/main/src/library/UpperBound.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for partially ordered types that have an upper bound.
 ///
-pub class UpperBound[a] {
+pub lawless class UpperBound[a] {
     ///
     /// Returns the largest value of `a`.
     ///

--- a/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
@@ -445,4 +445,55 @@ class TestInstances extends FunSuite with TestUtils {
     val result = compile(input, DefaultOptions)
     expectError[InstanceError.MissingSuperClassInstance](result)
   }
+
+  test("Test.LawlessSuperClass.01") {
+    val input =
+      """
+        |lawless class A[a]
+        |class B[a] extends A[a]
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[InstanceError.LawlessSuperClass](result)
+  }
+
+  test("Test.LawlessSuperClass.02") {
+    val input =
+      """
+        |lawless class A[a]
+        |class B[a]
+        |class C[a] extends A[a], B[a]
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[InstanceError.LawlessSuperClass](result)
+  }
+
+  test("Test.UnlawfulSignature.01") {
+    val input =
+      """
+        |class C[a] {
+        |  def f(): a
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[InstanceError.UnlawfulSignature](result)
+  }
+
+  test("Test.UnlawfulSignature.02") {
+    val input =
+      """
+        |instance C[Int] {
+        |  pub def f(x: Int): Bool = true
+        |  pub def g(x: Int): Bool = true
+        |}
+        |
+        |class C[a] {
+        |  pub def f(x: a): Bool
+        |  pub def g(x: a): Bool
+        |
+        |  law l(): Bool = forall (x: a) . C.f(x)
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[InstanceError.UnlawfulSignature](result)
+  }
 }

--- a/main/test/flix/Test.Dec.Class.flix
+++ b/main/test/flix/Test.Dec.Class.flix
@@ -6,14 +6,14 @@ namespace Test/Dec/Class {
 
     namespace Test02 {
 
-        class X[a] {
+        lawless class X[a] {
             pub def f(x: a): Bool
         }
 
     }
 
     namespace Test03 {
-        class X[a] {
+        lawless class X[a] {
             pub def f(x: a): Bool
         }
 
@@ -25,11 +25,11 @@ namespace Test/Dec/Class {
     }
 
     namespace Test04 {
-        class C[a] {
+        lawless class C[a] {
             pub def f(x: a): Bool
         }
 
-        class D[a] {
+        lawless class D[a] {
             pub def g(x: a): Bool
         }
 
@@ -49,7 +49,7 @@ namespace Test/Dec/Class {
         use Test/Dec/Class.List.Nil;
         use Test/Dec/Class.Option;
 
-        pub class C[a] {
+        pub lawless class C[a] {
             pub def f(x: a): Bool
         }
 
@@ -80,7 +80,7 @@ namespace Test/Dec/Class {
         use Test/Dec/Class.Option.None;
         use Test/Dec/Class.Option.Some;
 
-        class F[m :# Type -> Type] {
+        lawless class F[m :# Type -> Type] {
             pub def map(f: a -> b, x: m[a]): m[b]
         }
 
@@ -93,7 +93,7 @@ namespace Test/Dec/Class {
     }
 
     namespace Test09 {
-        class Eff[e :# Bool] {
+        lawless class Eff[e :# Bool] {
             pub def isPure(f: a -> b & e): Bool
         }
 
@@ -107,13 +107,13 @@ namespace Test/Dec/Class {
     }
 
     namespace Test10 {
-        class C[a] {
+        lawless class C[a] {
             pub def f(x: a): Bool
         }
 
-        class D[a] extends C[a]
+        lawless class D[a] extends C[a]
 
-        class E[a] extends D[a]
+        lawless class E[a] extends D[a]
 
         instance C[Int] {
             def f(_x: Int): Bool = true
@@ -142,7 +142,7 @@ namespace Test/Dec/Class {
     }
 
     namespace Test12 {
-        class C[a] {
+        lawless class C[a] {
             pub def f(): a
 
             law l(): Bool = true

--- a/main/test/flix/Test.Exp.Infix.flix
+++ b/main/test/flix/Test.Exp.Infix.flix
@@ -25,7 +25,7 @@ namespace Test/Exp/Infix {
         pub def mul(x: Int, y: Int): Int = x * y
     }
 
-    class Divisible[a] {
+    lawless class Divisible[a] {
         pub def div(x: a, y: a): a
     }
 

--- a/main/test/flix/Test.Use.Sig.flix
+++ b/main/test/flix/Test.Use.Sig.flix
@@ -1,5 +1,5 @@
 namespace A {
-    pub class FClass[a] {
+    pub lawless class FClass[a] {
         pub def f(): a
     }
 
@@ -24,7 +24,7 @@ namespace A {
 }
 
 namespace B {
-    pub class FClass[a] {
+    pub lawless class FClass[a] {
         pub def f(): a
     }
 
@@ -50,7 +50,7 @@ namespace B {
 }
 
 namespace C {
-    pub class FClass[a] {
+    pub lawless class FClass[a] {
         pub def f(): a
     }
 
@@ -85,7 +85,7 @@ namespace D {
     def testNamespace11(): Bool = gz() == 7
 }
 
-pub class GClass[a] {
+pub lawless class GClass[a] {
     pub def g(): a
 }
 
@@ -94,7 +94,7 @@ instance GClass[Int] {
 }
 
 namespace X {
-    pub class GClass[a] {
+    pub lawless class GClass[a] {
         pub def g(): a
     }
 
@@ -103,7 +103,7 @@ namespace X {
     }
 
     namespace Y {
-        pub class GClass[a] {
+        pub lawless class GClass[a] {
             pub def g(): a
         }
 
@@ -112,7 +112,7 @@ namespace X {
         }
 
         namespace Z {
-            pub class GClass[a] {
+            pub lawless class GClass[a] {
                 pub def g(): a
             }
 


### PR DESCRIPTION
Checks to include:
* If a class is **lawful** (i.e. no `lawless` modifier):
  * all super classes are lawful
    * [x] impl
    * [x] test
  * every definition is used in at least one class law
    * [x] impl
    * [x] test
* [x] Modify existing classes to follow new rules.