### PR TITLE
Add Random Probing to Select

### DIFF
--- a/main/src/ca/uwaterloo/flix/runtime/interpreter/Channel.java
+++ b/main/src/ca/uwaterloo/flix/runtime/interpreter/Channel.java
@@ -321,6 +321,11 @@ public final class Channel {
     }
   }
 
+  /**
+   * Retrieves the head of the elementQueue without removing it.
+   *
+   * @return the head of the elementQueue
+   */
   private Object peek() {
     channelLock.lock();
     try {

--- a/main/src/ca/uwaterloo/flix/runtime/interpreter/Channel.java
+++ b/main/src/ca/uwaterloo/flix/runtime/interpreter/Channel.java
@@ -104,18 +104,6 @@ public final class Channel {
         selectLock.lock();
 
         try {
-//          // Check if any channel has an element
-//          for (int index = 0; index < channels.length; index++) {
-//            Channel channel = channels[index];
-//            Object element = channel.tryGet();
-//            if (element != null) {
-//              // Element found.
-//              // Return the element and the branchNumber (index of the array) of the containing channel
-//              return new SelectChoice(index, element);
-//            }
-//          }
-
-          // Return SelectChoice if there is are waiting element(s) in one of the channels
           {
             // List of channels with waiting elements.
             // 7 is a guess of the maximum number of channels with waiting elements.
@@ -139,7 +127,6 @@ public final class Channel {
               return new SelectChoice(randomChannelIndex, element);
             }
           }
-
 
           // No element was found.
 

--- a/main/src/ca/uwaterloo/flix/runtime/interpreter/ChannelIndexPair.java
+++ b/main/src/ca/uwaterloo/flix/runtime/interpreter/ChannelIndexPair.java
@@ -1,0 +1,42 @@
+package ca.uwaterloo.flix.runtime.interpreter;
+
+import java.util.Objects;
+
+class ChannelIndexPair {
+    private final Channel channel;
+    private final int index;
+
+    ChannelIndexPair(Channel channel, int index) {
+        this.channel = channel;
+        this.index = index;
+    }
+
+    public Channel getChannel() {
+        return channel;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ChannelIndexPair that = (ChannelIndexPair) o;
+        return index == that.index && Objects.equals(channel, that.channel);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(channel, index);
+    }
+
+    @Override
+    public String toString() {
+        return "ChannelIndexPair{" +
+                "channel=" + channel +
+                ", index=" + index +
+                '}';
+    }
+}

--- a/main/test/flix/Test.Exp.Concurrency.Select.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Select.flix
@@ -154,7 +154,7 @@ namespace Test/Exp/Concurrency/Select {
         ()
     }
 
-    @test
+    /*@test
     def testSelectRandom02(): Unit & Impure = {
         let c10 = chan Unit 0;
         let c11 = chan Unit 0;
@@ -166,7 +166,7 @@ namespace Test/Exp/Concurrency/Select {
         case _ <- c11 => <- c13 ; <- c12 ; <- c10 ; ()
         };
         ()
-    }
+    }*/
 
     @test
     def testSelectRandom03(): Unit & Impure = {
@@ -361,6 +361,24 @@ namespace Test/Exp/Concurrency/Select {
         case _ <- c6 => ()
         case _ <- c6 => ()
         } ; c7 <- () ; () ; () } ; () ; c6 <- () ; () ; <- c9;
+        ()
+    }
+
+    @test
+    def testSelectRandom10(): Unit & Impure = {
+        let c10 = chan Unit 0;
+        let c11 = chan Unit 0;
+        let c12 = chan Unit 0;
+        let c13 = chan Unit 0;
+        spawn { c13 <- () ; () } ;
+        spawn { c12 <- () ; () } ;
+        spawn { c11 <- () ; () } ;
+        spawn { c10 <- () ; () } ;
+        select {
+            case _ <- c10 => <- c13 ; <- c12 ; <- c11
+            case _ <- c13 => <- c12 ; <- c10 ; <- c11
+            case _ <- c11 => <- c13 ; <- c12 ; <- c10
+        };
         ()
     }
 

--- a/main/test/flix/Test.Exp.Concurrency.Select.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Select.flix
@@ -154,7 +154,7 @@ namespace Test/Exp/Concurrency/Select {
         ()
     }
 
-    /*@test
+    @test
     def testSelectRandom02(): Unit & Impure = {
         let c10 = chan Unit 0;
         let c11 = chan Unit 0;
@@ -166,7 +166,7 @@ namespace Test/Exp/Concurrency/Select {
         case _ <- c11 => <- c13 ; <- c12 ; <- c10 ; ()
         };
         ()
-    }*/
+    }
 
     @test
     def testSelectRandom03(): Unit & Impure = {


### PR DESCRIPTION
Fix #1718.

Note: my early attempts at implementing this fix caused `Test.Exp.Concurrency.Select.testSelectRandom10` and `Test.Exp.Concurrency.Select.testSelectRandom02` to sometimes deadlock. If these tests deadlock in the future, it may be because of a bug in my implementation. 