### PR TITLE
improve MissingImplementation error

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
@@ -91,7 +91,9 @@ object InstanceError {
       val vt = new VirtualTerminal()
       vt << Line(kind, source.format) << NewLine
       vt << NewLine
-      vt << Code(loc, s"The signature ${sig.name} is missing from the instance.")
+      vt << Code(loc, s"missing implementation") << NewLine
+      vt << NewLine
+      vt << s"Missing implementation of '" << Red(sig.name) << "' defined in class '" << Red(sig.clazz.name) << "'." << NewLine
       vt << NewLine
       vt << Underline("Tip:") << " Add an implementation of the signature to the instance."
     }

--- a/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
@@ -91,9 +91,9 @@ object InstanceError {
       val vt = new VirtualTerminal()
       vt << Line(kind, source.format) << NewLine
       vt << NewLine
-      vt << Code(loc, s"missing implementation") << NewLine
+      vt << s"Missing implementation of '" << Red(sig.name) << "' required by class '" << Red(sig.clazz.name) << "'." << NewLine
       vt << NewLine
-      vt << s"Missing implementation of '" << Red(sig.name) << "' defined in class '" << Red(sig.clazz.name) << "'." << NewLine
+      vt << Code(loc, s"missing implementation") << NewLine
       vt << NewLine
       vt << Underline("Tip:") << " Add an implementation of the signature to the instance."
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -169,7 +169,7 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
         mods <- visitModifiers(mods0, legalModifiers = Set(Ast.Modifier.Public, Ast.Modifier.Unlawful))
         defs <- traverse(defs0)(visitDef)
         constrs = visitTypeConstraints(constrs0.getOrElse(Seq.empty))
-      } yield List(WeededAst.Declaration.Instance(doc, mods, clazz, tpe, constrs, defs.flatten, loc))
+      } yield List(WeededAst.Declaration.Instance(doc, mods, clazz, tpe, constrs, defs.flatten, clazz.loc))
 
   }
 


### PR DESCRIPTION
Fixes #1747 

### Features
* The error message should start with a message, e.g. "Missing implementation of X defined in class Y" (with proper colors)
  * [x] impl
  * [ ] test
* The error message should not report the entire instance as wrong (too much red). Better to just report "Foo" as the location.
  * [x] impl
  * [ ] test

### General requirements
* [x] Don't make a complete mess
* [x] Don't break anything else
* [x] Provide documentation
* [x] Add license to new files

![Screenshot from 2021-03-07 11-29-05](https://user-images.githubusercontent.com/19153692/110236958-7eac0c00-7f39-11eb-8f83-e6e66b2bb7ba.png)

