### PR TITLE
improve MismatchedSignature error

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
@@ -58,11 +58,12 @@ object InstanceError {
   /**
     * Error indicating that the type scheme of a definition does not match the type scheme of the signature it implements.
     *
+    * @param sigSym   the mismatched signature
     * @param loc      the location of the definition
     * @param expected the scheme of the signature
     * @param actual   the scheme of the definition
     */
-  case class MismatchedSignatures(loc: SourceLocation, expected: Scheme, actual: Scheme) extends InstanceError {
+  case class MismatchedSignatures(sigSym: Symbol.SigSym, loc: SourceLocation, expected: Scheme, actual: Scheme) extends InstanceError {
     def summary: String = "Mismatched signature."
 
     def message: VirtualTerminal = {
@@ -71,8 +72,10 @@ object InstanceError {
       vt << NewLine
       vt << Code(loc, "mismatched signature.") << NewLine
       vt << NewLine
+      vt << "Mismatched signature '" << Red(sigSym.name) << "' declared in class '" << Red(sigSym.clazz.name) << "'." << NewLine
+      vt << NewLine
       vt << s"Expected scheme: ${FormatScheme.formatScheme(expected)}" << NewLine
-      vt << s"Actual scheme: ${FormatScheme.formatScheme(actual)}" << NewLine
+      vt << s"Actual scheme:   ${FormatScheme.formatScheme(actual)}" << NewLine
       vt << NewLine
       vt << Underline("Tip:") << " Modify the definition to match the signature."
     }

--- a/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
@@ -70,9 +70,9 @@ object InstanceError {
       val vt = new VirtualTerminal()
       vt << Line(kind, source.format) << NewLine
       vt << NewLine
-      vt << Code(loc, "mismatched signature.") << NewLine
+      vt << "Mismatched signature '" << Red(sigSym.name) << "' required by class '" << Red(sigSym.clazz.name) << "'." << NewLine
       vt << NewLine
-      vt << "Mismatched signature '" << Red(sigSym.name) << "' declared in class '" << Red(sigSym.clazz.name) << "'." << NewLine
+      vt << Code(loc, "mismatched signature.") << NewLine
       vt << NewLine
       vt << s"Expected scheme: ${FormatScheme.formatScheme(expected)}" << NewLine
       vt << s"Actual scheme:   ${FormatScheme.formatScheme(actual)}" << NewLine

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -166,7 +166,7 @@ object Instances extends Phase[TypedAst.Root, TypedAst.Root] {
                 ().toSuccess
               } else {
                 // Case 2.2: the schemes do not match
-                InstanceError.MismatchedSignatures(defn.loc, expectedScheme, defn.declaredScheme).toFailure
+                InstanceError.MismatchedSignatures(sig.sym, defn.loc, expectedScheme, defn.declaredScheme).toFailure
               }
           }
       }


### PR DESCRIPTION
Fixes #1749 

### Features
* The error message should start with a message, e.g. "Mismatched signature bar declared in class foo" (with colors).
  * [x] impl
  * [ ] test
* It would be nice if the expected and actual types were aligned.
  * [x] impl
  * [ ] test

### General requirements
* [x] Don't make a complete mess
* [x] Don't break anything else
* [x] Provide documentation
* [x] Add license to new files

![Screenshot from 2021-03-07 13-06-42](https://user-images.githubusercontent.com/19153692/110239287-71494e80-7f46-11eb-9315-2efc1ecd11e4.png)
