### PR TITLE
update law syntax

### DIFF
--- a/examples/domains/Belnap.flix
+++ b/examples/domains/Belnap.flix
@@ -29,7 +29,7 @@ namespace Belnap {
     ///
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
-    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
+//    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
     pub def leq(e1: Belnap, e2: Belnap): Bool = match (e1, e2) {
         case (Bot, _)       => true
         case (True, True)   => true
@@ -41,7 +41,7 @@ namespace Belnap {
     ///
     /// Returns the least upper bound of `e1` and `e2`.
     ///
-    #upperBound #leastUpperBound #commutative #associative
+//    #upperBound #leastUpperBound #commutative #associative
     pub def lub(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) {
         case (Bot, x)       => x
         case (x, Bot)       => x
@@ -53,7 +53,7 @@ namespace Belnap {
     ///
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
-    #lowerBound #greatestLowerBound #commutative #associative
+//    #lowerBound #greatestLowerBound #commutative #associative
     pub def glb(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) {
         case (Top, x)       => x
         case (x, Top)       => x
@@ -65,7 +65,7 @@ namespace Belnap {
     ///
     /// The lattice height function.
     ///
-    #nonNegative
+//    #nonNegative
     pub def height(e: Belnap): BigInt = match e {
         case Top    => 0ii
         case True   => 1ii
@@ -81,8 +81,8 @@ namespace Belnap {
     ///
     /// Over-approximates the logical `not` operator.
     ///
-    #safe1(x -> not x)
-    #strict1 #monotone1
+//    #safe1(x -> not x)
+//    #strict1 #monotone1
     pub def not(e: Belnap): Belnap = match e {
         case Bot    => Bot
         case True   => False
@@ -93,8 +93,8 @@ namespace Belnap {
     ///
     /// Over-approximates the logical `and` operator.
     ///
-    #safe2((x, y) -> x and y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x and y)
+//    #strict2 #monotone2 #commutative #associative
     pub def and(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) {
         case (Bot, _)       => Bot
         case (_, Bot)       => Bot
@@ -108,8 +108,8 @@ namespace Belnap {
     ///
     /// Over-approximates the logical `or` operator.
     ///
-    #safe2((x, y) -> x or y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x or y)
+//    #strict2 #monotone2 #commutative #associative
     pub def or(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) {
         case (Bot, _)       => Bot
         case (_, Bot)       => Bot
@@ -123,8 +123,8 @@ namespace Belnap {
     ///
     /// Over-approximates the logical `xor` operator.
     ///
-    #safe2((x, y) -> x ⊕ y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x ⊕ y)
+//    #strict2 #monotone2 #commutative #associative
     pub def xor(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) {
         case (Bot, _)       => Bot
         case (_, Bot)       => Bot
@@ -138,8 +138,8 @@ namespace Belnap {
     ///
     /// Over-approximates the logical `implies` operator.
     ///
-    #safe2((x, y) -> x → y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x → y)
+//    #strict2 #monotone2
     pub def implies(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) {
         case (Bot, _)         => Bot
         case (_, Bot)         => Bot
@@ -153,8 +153,8 @@ namespace Belnap {
     ///
     /// Over-approximates the logical `bicondition` operator.
     ///
-    #safe2((x, y) -> x ↔ y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x ↔ y)
+//    #strict2 #monotone2 #commutative #associative
     pub def bicondition(e1: Belnap, e2: Belnap): Belnap = match (e1, e2) {
         case (Bot, _)       => Bot
         case (_, Bot)       => Bot
@@ -169,28 +169,28 @@ namespace Belnap {
     // ## Specialized Laws
     //
 
-    law upperBound(lub: (Belnap, Belnap) -> Belnap): Bool = JoinLattice.leastUpperBound1(leq, lub)
+//    law upperBound(lub: (Belnap, Belnap) -> Belnap): Bool = JoinLattice.leastUpperBound1(leq, lub)
 
-    law leastUpperBound(lub: (Belnap, Belnap) -> Belnap): Bool = JoinLattice.leastUpperBound2(leq, lub)
+//    law leastUpperBound(lub: (Belnap, Belnap) -> Belnap): Bool = JoinLattice.leastUpperBound2(leq, lub)
 
-    law lowerBound(glb: (Belnap, Belnap) -> Belnap): Bool = MeetLattice.greatestLowerBound1(leq, glb)
+//    law lowerBound(glb: (Belnap, Belnap) -> Belnap): Bool = MeetLattice.greatestLowerBound1(leq, glb)
 
-    law greatestLowerBound(glb: (Belnap, Belnap) -> Belnap): Bool = MeetLattice.greatestLowerBound2(leq, glb)
+//    law greatestLowerBound(glb: (Belnap, Belnap) -> Belnap): Bool = MeetLattice.greatestLowerBound2(leq, glb)
 
-    law leastElement(leq: (Belnap, Belnap) -> Bool, bot: Belnap): Bool = Bounded.leastElement(bot, leq)
+//    law leastElement(leq: (Belnap, Belnap) -> Bool, bot: Belnap): Bool = Bounded.leastElement(bot, leq)
 
-    law greatestElement(leq: (Belnap, Belnap) -> Bool, top: Belnap): Bool = Bounded.greatestElement(top, leq)
+//    law greatestElement(leq: (Belnap, Belnap) -> Bool, top: Belnap): Bool = Bounded.greatestElement(top, leq)
 
-    law strict1(f: Belnap -> Belnap): Bool = Bounded.strict1(f, Bot, Bot)
+//    law strict1(f: Belnap -> Belnap): Bool = Bounded.strict1(f, Bot, Bot)
 
-    law strict2(f: (Belnap, Belnap) -> Belnap): Bool = Bounded.strict2(f, Bot, Bot, Bot)
+//    law strict2(f: (Belnap, Belnap) -> Belnap): Bool = Bounded.strict2(f, Bot, Bot, Bot)
 
-    law monotone1(f: Belnap -> Belnap): Bool =  PartialOrder.monotone1(f, leq, leq)
+//    law monotone1(f: Belnap -> Belnap): Bool =  PartialOrder.monotone1(f, leq, leq)
 
-    law monotone2(f: (Belnap, Belnap) -> Belnap): Bool =  PartialOrder.monotone2(f, leq, leq, leq)
+//    law monotone2(f: (Belnap, Belnap) -> Belnap): Bool =  PartialOrder.monotone2(f, leq, leq, leq)
 
-    law safe1(fa: Belnap -> Belnap, fc: Bool -> Bool): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
+//    law safe1(fa: Belnap -> Belnap, fc: Bool -> Bool): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
 
-    law safe2(fa: (Belnap, Belnap) -> Belnap, fc: (Bool, Bool) -> Bool): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
+//    law safe2(fa: (Belnap, Belnap) -> Belnap, fc: (Bool, Bool) -> Bool): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
 
 }

--- a/examples/domains/Constant.flix
+++ b/examples/domains/Constant.flix
@@ -34,7 +34,7 @@ namespace Domain/Constant {
     ///
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
-    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
+//    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
     pub def leq(e1: Constant, e2: Constant): Bool = match (e1, e2) {
         case (Bot, _)           => true
         case (Cst(n1), Cst(n2)) => n1 == n2
@@ -45,7 +45,7 @@ namespace Domain/Constant {
     ///
     /// Returns the least upper bound of `e1` and `e2`.
     ///
-    #upperBound #leastUpperBound #commutative #associative
+//    #upperBound #leastUpperBound #commutative #associative
     pub def lub(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, x)           => x
         case (x, Bot)           => x
@@ -56,7 +56,7 @@ namespace Domain/Constant {
     ///
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
-    #lowerBound #greatestLowerBound #commutative #associative
+//    #lowerBound #greatestLowerBound #commutative #associative
     pub def glb(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Top, x)           => x
         case (x, Top)           => x
@@ -67,7 +67,7 @@ namespace Domain/Constant {
     ///
     /// The lattice height function.
     ///
-    #nonNegative
+//    #nonNegative
     pub def height(e: Constant): BigInt = match e {
         case Top    => 0ii
         case Cst(_) => 1ii
@@ -82,8 +82,8 @@ namespace Domain/Constant {
     /**
      * Over-approximates integer `increment`.
      */
-    #safe1(x -> x + 1)
-    #strict1 #monotone1
+//    #safe1(x -> x + 1)
+//    #strict1 #monotone1
     pub def inc(e: Constant): Constant = match e {
         case Bot    => Bot
         case Cst(n) => Cst(n + 1)
@@ -93,8 +93,8 @@ namespace Domain/Constant {
     ///
     /// Over-approximates integer `decrement`.
     ///
-    #safe1(x -> x - 1)
-    #strict1 #monotone1
+//    #safe1(x -> x - 1)
+//    #strict1 #monotone1
     pub def dec(e: Constant): Constant = match e {
         case Bot    => Bot
         case Cst(n) => Cst(n - 1)
@@ -104,8 +104,8 @@ namespace Domain/Constant {
     ///
     /// Over-approximates integer `addition`.
     ///
-    #safe2((x, y) -> x + y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x + y)
+//    #strict2 #monotone2 #commutative #associative
     pub def plus(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -116,8 +116,8 @@ namespace Domain/Constant {
     ///
     /// Over-approximates integer `subtraction`.
     ///
-    #safe2((x, y) -> x - y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x - y)
+//    #strict2 #monotone2
     pub def minus(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -128,8 +128,8 @@ namespace Domain/Constant {
     ///
     /// Over-approximates integer `multiplication`.
     ///
-    #safe2((x, y) -> x * y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x * y)
+//    #strict2 #monotone2 #commutative #associative
     pub def times(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -140,8 +140,8 @@ namespace Domain/Constant {
     ///
     /// Over-approximates integer `division`.
     ///
-    #safe2((x, y) -> x / y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x / y)
+//    #strict2 #monotone2
     pub def divide(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -152,8 +152,8 @@ namespace Domain/Constant {
     ///
     /// Over-approximates integer `modulus`.
     ///
-    #safe2((x, y) -> x % y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x % y)
+//    #strict2 #monotone2
     pub def modulo(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -164,8 +164,8 @@ namespace Domain/Constant {
     ///
     /// Over-approximates `bitwise negation`.
     ///
-    #safe1(x -> ~~~x)
-    #strict1 #monotone1
+//    #safe1(x -> ~~~x)
+//    #strict1 #monotone1
     pub def negate(e: Constant): Constant = match e {
         case Bot       => Bot
         case Cst(n)    => Cst(~~~ n)
@@ -175,8 +175,8 @@ namespace Domain/Constant {
     ///
     /// Over-approximates `bitwise and`.
     ///
-    #safe2((x, y) -> x &&& y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x &&& y)
+//    #strict2 #monotone2 #commutative #associative
     pub def and(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -187,8 +187,8 @@ namespace Domain/Constant {
     ///
     /// Over-approximates `bitwise or`.
     ///
-    #safe2((x, y) -> x ||| y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x ||| y)
+//    #strict2 #monotone2 #commutative #associative
     pub def or(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -199,8 +199,8 @@ namespace Domain/Constant {
     ///
     /// Over-approximates `bitwise xor`.
     ///
-    #safe2((x, y) -> x ^^^ y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x ^^^ y)
+//    #strict2 #monotone2 #commutative #associative
     pub def xor(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -211,8 +211,8 @@ namespace Domain/Constant {
     ///
     /// Over-approximates `bitwise left shift`.
     ///
-    #safe2((x, y) -> x <<< y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x <<< y)
+//    #strict2 #monotone2
     pub def leftShift(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -224,8 +224,8 @@ namespace Domain/Constant {
     /// Over-approximates `bitwise right shift`.
     ///
     ///
-    #safe2((x, y) -> x >>> y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x >>> y)
+//    #strict2 #monotone2
     pub def rightShift(e1: Constant, e2: Constant): Constant = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -236,10 +236,10 @@ namespace Domain/Constant {
     ///
     /// Over-approximates `equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x == y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #PartialOrder.safe2((x, y) -> x == y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def eq(e1: Constant, e2: Constant): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)           => Belnap/Belnap.Bot
         case (_, Bot)           => Belnap/Belnap.Bot
@@ -250,18 +250,18 @@ namespace Domain/Constant {
     ///
     /// Over-approximates `not equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x != y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #PartialOrder.safe2((x, y) -> x != y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def neq(e1: Constant, e2: Constant): Belnap.Belnap = Belnap.not(eq(e1, e2))
 
     ///
     /// Over-approximates `less than`.
     ///
-    #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
     pub def less(e1: Constant, e2: Constant): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)           => Belnap/Belnap.Bot
         case (_, Bot)           => Belnap/Belnap.Bot
@@ -272,9 +272,9 @@ namespace Domain/Constant {
     ///
     /// Over-approximates `less than or equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x <= y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #PartialOrder.safe2((x, y) -> x <= y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
     pub def lessEqual(e1: Constant, e2: Constant): Belnap.Belnap = Belnap.or(e1 `less` e2, e1 `eq` e2)
 
     instance LowerBound[Constant] {
@@ -305,29 +305,29 @@ namespace Domain/Constant {
     // ## Specialized Laws
     //
 
-    law upperBound(lub: (Constant, Constant) -> Constant): Bool = JoinLattice.leastUpperBound1(leq, lub)
+//    law upperBound(lub: (Constant, Constant) -> Constant): Bool = JoinLattice.leastUpperBound1(leq, lub)
 
-    law leastUpperBound(lub: (Constant, Constant) -> Constant): Bool = JoinLattice.leastUpperBound2(leq, lub)
+//    law leastUpperBound(lub: (Constant, Constant) -> Constant): Bool = JoinLattice.leastUpperBound2(leq, lub)
 
-    law lowerBound(glb: (Constant, Constant) -> Constant): Bool = MeetLattice.greatestLowerBound1(leq, glb)
+//    law lowerBound(glb: (Constant, Constant) -> Constant): Bool = MeetLattice.greatestLowerBound1(leq, glb)
 
-    law greatestLowerBound(glb: (Constant, Constant) -> Constant): Bool = MeetLattice.greatestLowerBound2(leq, glb)
+//    law greatestLowerBound(glb: (Constant, Constant) -> Constant): Bool = MeetLattice.greatestLowerBound2(leq, glb)
 
-    law leastElement(leq: (Constant, Constant) -> Bool, bot: Constant): Bool = Bounded.leastElement(bot, leq)
+//    law leastElement(leq: (Constant, Constant) -> Bool, bot: Constant): Bool = Bounded.leastElement(bot, leq)
 
-    law greatestElement(leq: (Constant, Constant) -> Bool, top: Constant): Bool = Bounded.greatestElement(top, leq)
+//    law greatestElement(leq: (Constant, Constant) -> Bool, top: Constant): Bool = Bounded.greatestElement(top, leq)
 
-    law strict1(f: Constant -> Constant): Bool = Bounded.strict1(f, Bot, Bot)
+//    law strict1(f: Constant -> Constant): Bool = Bounded.strict1(f, Bot, Bot)
 
-    law strict2(f: (Constant, Constant) -> Constant): Bool = Bounded.strict2(f, Bot, Bot, Bot)
+//    law strict2(f: (Constant, Constant) -> Constant): Bool = Bounded.strict2(f, Bot, Bot, Bot)
 
-    law monotone1(f: Constant -> Constant): Bool = PartialOrder.monotone1(f, leq, leq)
+//    law monotone1(f: Constant -> Constant): Bool = PartialOrder.monotone1(f, leq, leq)
 
-    law monotone2(f: (Constant, Constant) -> Constant): Bool = PartialOrder.monotone2(f, leq, leq, leq)
+//    law monotone2(f: (Constant, Constant) -> Constant): Bool = PartialOrder.monotone2(f, leq, leq, leq)
 
-    law safe1(fa: Constant -> Constant, fc: Int -> Int): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
+//    law safe1(fa: Constant -> Constant, fc: Int -> Int): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
 
-    law safe2(fa: (Constant, Constant) -> Constant, fc: (Int, Int) -> Int): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
+//    law safe2(fa: (Constant, Constant) -> Constant, fc: (Int, Int) -> Int): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
 
     ///
     /// Tests

--- a/examples/domains/ConstantParity.flix
+++ b/examples/domains/ConstantParity.flix
@@ -30,7 +30,7 @@ namespace Domain/ConstantParity {
     ///
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
-    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
+//    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
     pub def leq(e1: ConstantParity, e2: ConstantParity): Bool = match (e1, e2) {
         case (Bot, _)           => true
         case (Cst(n1), Cst(n2)) => n1 == n2
@@ -45,7 +45,7 @@ namespace Domain/ConstantParity {
     ///
     /// Returns the least upper bound of `e1` and `e2`.
     ///
-    #upperBound #leastUpperBound #commutative #associative
+//    #upperBound #leastUpperBound #commutative #associative
     pub def lub(e1: ConstantParity, e2: ConstantParity): ConstantParity = match (e1, e2) {
         case (Bot, x)           => x
         case (x, Bot)           => x
@@ -67,7 +67,7 @@ namespace Domain/ConstantParity {
     ///
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
-    #lowerBound #greatestLowerBound #commutative #associative
+//    #lowerBound #greatestLowerBound #commutative #associative
     pub def glb(e1: ConstantParity, e2: ConstantParity): ConstantParity = match (e1, e2) {
         case (Top, x)           => x
         case (x, Top)           => x
@@ -84,7 +84,7 @@ namespace Domain/ConstantParity {
     ///
     /// The lattice height function.
     ///
-    #nonNegative
+//    #nonNegative
     pub def height(e: ConstantParity): BigInt = match e {
         case Top    => 0ii
         case Odd    => 1ii
@@ -101,8 +101,8 @@ namespace Domain/ConstantParity {
     ///
     /// Over-approximates integer `increment`.
     ///
-    #safe1(x -> x + 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x + 1ii)
+//    #strict1 #monotone1
     pub def inc(e: ConstantParity): ConstantParity = match e {
         case Bot    => Bot
         case Cst(n) => Cst(n + 1ii)
@@ -114,8 +114,8 @@ namespace Domain/ConstantParity {
     ///
     /// Over-approximates integer `decrement`.
     ///
-    #safe1(x -> x - 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x - 1ii)
+//    #strict1 #monotone1
     pub def dec(e: ConstantParity): ConstantParity = match e {
         case Bot    => Bot
         case Cst(n) => Cst(n - 1ii)
@@ -127,8 +127,8 @@ namespace Domain/ConstantParity {
     ///
     /// Over-approximates integer `addition`.
     ///
-    #safe2((x, y) -> x + y)
-    #strict2 #monotone2 #commutative
+//    #safe2((x, y) -> x + y)
+//    #strict2 #monotone2 #commutative
     pub def plus(e1: ConstantParity, e2: ConstantParity): ConstantParity = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -147,8 +147,8 @@ namespace Domain/ConstantParity {
     ///
     /// Over-approximates integer `subtraction`.
     ///
-    #safe2((x, y) -> x - y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x - y)
+//    #strict2 #monotone2
     pub def minus(e1: ConstantParity, e2: ConstantParity): ConstantParity = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -167,8 +167,8 @@ namespace Domain/ConstantParity {
     ///
     /// Over-approximates integer `multiplication`.
     ///
-    #safe2((x, y) -> x * y)
-    #strict2  // NB: @monotone annotation removed since Z3 reports unknown.
+//    #safe2((x, y) -> x * y)
+//    #strict2  // NB: @monotone annotation removed since Z3 reports unknown.
     pub def times(e1: ConstantParity, e2: ConstantParity): ConstantParity = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -187,10 +187,10 @@ namespace Domain/ConstantParity {
     ///
     /// Over-approximates `equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x == y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #PartialOrder.safe2((x, y) -> x == y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def eq(e1: ConstantParity, e2: ConstantParity): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)           => Belnap/Belnap.Bot
         case (_, Bot)           => Belnap/Belnap.Bot
@@ -205,18 +205,18 @@ namespace Domain/ConstantParity {
     ///
     /// Over-approximates `not equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x != y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #PartialOrder.safe2((x, y) -> x != y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def neq(e1: ConstantParity, e2: ConstantParity): Belnap.Belnap = Belnap.not(eq(e1, e2))
 
     ///
     /// Over-approximates `less than`.
     ///
-    #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
     pub def less(e1: ConstantParity, e2: ConstantParity): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)           => Belnap/Belnap.Bot
         case (_, Bot)           => Belnap/Belnap.Bot
@@ -227,9 +227,9 @@ namespace Domain/ConstantParity {
     ///
     /// Over-approximates `less than or equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x <= y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #PartialOrder.safe2((x, y) -> x <= y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
     pub def lessEqual(e1: ConstantParity, e2: ConstantParity): Belnap.Belnap = Belnap.or(e1 `less` e2, e1 `eq` e2)
 
     ///
@@ -246,28 +246,28 @@ namespace Domain/ConstantParity {
     // ## Specialized Laws
     //
 
-    law upperBound(lub: (ConstantParity, ConstantParity) -> ConstantParity): Bool = JoinLattice.leastUpperBound1(leq, lub)
+//    law upperBound(lub: (ConstantParity, ConstantParity) -> ConstantParity): Bool = JoinLattice.leastUpperBound1(leq, lub)
 
-    law leastUpperBound(lub: (ConstantParity, ConstantParity) -> ConstantParity): Bool = JoinLattice.leastUpperBound2(leq, lub)
+//    law leastUpperBound(lub: (ConstantParity, ConstantParity) -> ConstantParity): Bool = JoinLattice.leastUpperBound2(leq, lub)
 
-    law lowerBound(glb: (ConstantParity, ConstantParity) -> ConstantParity): Bool = MeetLattice.greatestLowerBound1(leq, glb)
+//    law lowerBound(glb: (ConstantParity, ConstantParity) -> ConstantParity): Bool = MeetLattice.greatestLowerBound1(leq, glb)
 
-    law greatestLowerBound(glb: (ConstantParity, ConstantParity) -> ConstantParity): Bool = MeetLattice.greatestLowerBound2(leq, glb)
+//    law greatestLowerBound(glb: (ConstantParity, ConstantParity) -> ConstantParity): Bool = MeetLattice.greatestLowerBound2(leq, glb)
 
-    law leastElement(leq: (ConstantParity, ConstantParity) -> Bool, bot: ConstantParity): Bool = Bounded.leastElement(bot, leq)
+//    law leastElement(leq: (ConstantParity, ConstantParity) -> Bool, bot: ConstantParity): Bool = Bounded.leastElement(bot, leq)
 
-    law greatestElement(leq: (ConstantParity, ConstantParity) -> Bool, top: ConstantParity): Bool = Bounded.greatestElement(top, leq)
+//    law greatestElement(leq: (ConstantParity, ConstantParity) -> Bool, top: ConstantParity): Bool = Bounded.greatestElement(top, leq)
 
-    law strict1(f: ConstantParity -> ConstantParity): Bool = Bounded.strict1(f, Bot, Bot)
+//    law strict1(f: ConstantParity -> ConstantParity): Bool = Bounded.strict1(f, Bot, Bot)
 
-    law strict2(f: (ConstantParity, ConstantParity) -> ConstantParity): Bool = Bounded.strict2(f, Bot, Bot, Bot)
+//    law strict2(f: (ConstantParity, ConstantParity) -> ConstantParity): Bool = Bounded.strict2(f, Bot, Bot, Bot)
 
-    law monotone1(f: ConstantParity -> ConstantParity): Bool = PartialOrder.monotone1(f, leq, leq)
+//    law monotone1(f: ConstantParity -> ConstantParity): Bool = PartialOrder.monotone1(f, leq, leq)
 
-    law monotone2(f: (ConstantParity, ConstantParity) -> ConstantParity): Bool = PartialOrder.monotone2(f, leq, leq, leq)
+//    law monotone2(f: (ConstantParity, ConstantParity) -> ConstantParity): Bool = PartialOrder.monotone2(f, leq, leq, leq)
 
-    law safe1(fa: ConstantParity -> ConstantParity, fc: BigInt -> BigInt): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
+//    law safe1(fa: ConstantParity -> ConstantParity, fc: BigInt -> BigInt): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
 
-    law safe2(fa: (ConstantParity, ConstantParity) -> ConstantParity, fc: (BigInt, BigInt) -> BigInt): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
+//    law safe2(fa: (ConstantParity, ConstantParity) -> ConstantParity, fc: (BigInt, BigInt) -> BigInt): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
 
 }

--- a/examples/domains/ConstantSign.flix
+++ b/examples/domains/ConstantSign.flix
@@ -30,7 +30,7 @@ namespace Domain/ConstantSign {
     ///
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
-    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
+//    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
     pub def leq(e1: ConstantSign, e2: ConstantSign): Bool = match (e1, e2) {
         case (Bot, _)           => true
         case (Cst(n1), Cst(n2)) => n1 == n2
@@ -45,7 +45,7 @@ namespace Domain/ConstantSign {
     ///
     /// Returns the least upper bound of `e1` and `e2`.
     ///
-    #upperBound #leastUpperBound #commutative #associative
+//    #upperBound #leastUpperBound #commutative #associative
     pub def lub(e1: ConstantSign, e2: ConstantSign): ConstantSign = match (e1, e2) {
         case (Bot, x)           => x
         case (x, Bot)           => x
@@ -67,7 +67,7 @@ namespace Domain/ConstantSign {
     ///
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
-    #lowerBound #greatestLowerBound #commutative #associative
+//    #lowerBound #greatestLowerBound #commutative #associative
     pub def glb(e1: ConstantSign, e2: ConstantSign): ConstantSign = match (e1, e2) {
         case (Top, x)           => x
         case (x, Top)           => x
@@ -86,7 +86,7 @@ namespace Domain/ConstantSign {
     ///
     /// The lattice height function.
     ///
-    #nonNegative
+//    #nonNegative
     pub def height(e: ConstantSign): BigInt = match e {
         case Top    => 0ii
         case Neg    => 1ii
@@ -103,8 +103,8 @@ namespace Domain/ConstantSign {
     ///
     /// Over-approximates integer `increment`.
     ///
-    #safe1(x -> x + 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x + 1ii)
+//    #strict1 #monotone1
     pub def inc(e: ConstantSign): ConstantSign = match e {
         case Bot    => Bot
         case Cst(n) => Cst(n + 1ii)
@@ -116,8 +116,8 @@ namespace Domain/ConstantSign {
     ///
     /// Over-approximates integer `decrement`.
     ///
-    #safe1(x -> x - 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x - 1ii)
+//    #strict1 #monotone1
     pub def dec(e: ConstantSign): ConstantSign = match e {
         case Bot    => Bot
         case Cst(n) => Cst(n - 1ii)
@@ -129,8 +129,8 @@ namespace Domain/ConstantSign {
     ///
     /// Over-approximates integer `addition`.
     ///
-    #safe2((x, y) -> x + y)
-    #strict2 #monotone2 #commutative
+//    #safe2((x, y) -> x + y)
+//    #strict2 #monotone2 #commutative
     pub def plus(e1: ConstantSign, e2: ConstantSign): ConstantSign = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -147,8 +147,8 @@ namespace Domain/ConstantSign {
     ///
     /// Over-approximates integer `subtraction`.
     ///
-    #safe2((x, y) -> x - y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x - y)
+//    #strict2 #monotone2
     pub def minus(e1: ConstantSign, e2: ConstantSign): ConstantSign = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -165,8 +165,8 @@ namespace Domain/ConstantSign {
     ///
     /// Over-approximates integer `multiplication`.
     ///
-    #safe2((x, y) -> x * y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x * y)
+//    #strict2 #monotone2 #commutative #associative
     pub def times(e1: ConstantSign, e2: ConstantSign): ConstantSign = match (e1, e2) {
         case (Bot, _)           => Bot
         case (_, Bot)           => Bot
@@ -187,10 +187,10 @@ namespace Domain/ConstantSign {
     ///
     /// Over-approximates `equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x == y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #PartialOrder.safe2((x, y) -> x == y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def eq(e1: ConstantSign, e2: ConstantSign): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)           => Belnap/Belnap.Bot
         case (_, Bot)           => Belnap/Belnap.Bot
@@ -205,18 +205,18 @@ namespace Domain/ConstantSign {
     ///
     /// Over-approximates `not equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x != y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #PartialOrder.safe2((x, y) -> x != y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def neq(e1: ConstantSign, e2: ConstantSign): Belnap.Belnap = Belnap.not(eq(e1, e2))
 
     ///
     /// Over-approximates `less than`.
     ///
-    #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
     pub def less(e1: ConstantSign, e2: ConstantSign): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)           => Belnap/Belnap.Bot
         case (_, Bot)           => Belnap/Belnap.Bot
@@ -231,37 +231,37 @@ namespace Domain/ConstantSign {
     ///
     /// Over-approximates `less than or equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x <= y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #PartialOrder.safe2((x, y) -> x <= y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
     pub def lessEqual(e1: ConstantSign, e2: ConstantSign): Belnap.Belnap = Belnap.or(e1 `less` e2, e1 `eq` e2)
 
     //
     // ## Specialized Laws
     //
 
-    law upperBound(lub: (ConstantSign, ConstantSign) -> ConstantSign): Bool = JoinLattice.leastUpperBound1(leq, lub)
+//    law upperBound(lub: (ConstantSign, ConstantSign) -> ConstantSign): Bool = JoinLattice.leastUpperBound1(leq, lub)
 
-    law leastUpperBound(lub: (ConstantSign, ConstantSign) -> ConstantSign): Bool = JoinLattice.leastUpperBound2(leq, lub)
+//    law leastUpperBound(lub: (ConstantSign, ConstantSign) -> ConstantSign): Bool = JoinLattice.leastUpperBound2(leq, lub)
 
-    law lowerBound(glb: (ConstantSign, ConstantSign) -> ConstantSign): Bool = MeetLattice.greatestLowerBound1(leq, glb)
+//    law lowerBound(glb: (ConstantSign, ConstantSign) -> ConstantSign): Bool = MeetLattice.greatestLowerBound1(leq, glb)
 
-    law greatestLowerBound(glb: (ConstantSign, ConstantSign) -> ConstantSign): Bool = MeetLattice.greatestLowerBound2(leq, glb)
+//    law greatestLowerBound(glb: (ConstantSign, ConstantSign) -> ConstantSign): Bool = MeetLattice.greatestLowerBound2(leq, glb)
 
-    law leastElement(leq: (ConstantSign, ConstantSign) -> Bool, bot: ConstantSign): Bool = Bounded.leastElement(bot, leq)
+//    law leastElement(leq: (ConstantSign, ConstantSign) -> Bool, bot: ConstantSign): Bool = Bounded.leastElement(bot, leq)
 
-    law greatestElement(leq: (ConstantSign, ConstantSign) -> Bool, top: ConstantSign): Bool = Bounded.greatestElement(top, leq)
+//    law greatestElement(leq: (ConstantSign, ConstantSign) -> Bool, top: ConstantSign): Bool = Bounded.greatestElement(top, leq)
 
-    law strict1(f: ConstantSign -> ConstantSign): Bool = Bounded.strict1(f, Bot, Bot)
+//    law strict1(f: ConstantSign -> ConstantSign): Bool = Bounded.strict1(f, Bot, Bot)
 
-    law strict2(f: (ConstantSign, ConstantSign) -> ConstantSign): Bool = Bounded.strict2(f, Bot, Bot, Bot)
+//    law strict2(f: (ConstantSign, ConstantSign) -> ConstantSign): Bool = Bounded.strict2(f, Bot, Bot, Bot)
 
-    law monotone1(f: ConstantSign -> ConstantSign): Bool = PartialOrder.monotone1(f, leq, leq)
+//    law monotone1(f: ConstantSign -> ConstantSign): Bool = PartialOrder.monotone1(f, leq, leq)
 
-    law monotone2(f: (ConstantSign, ConstantSign) -> ConstantSign): Bool = PartialOrder.monotone2(f, leq, leq, leq)
+//    law monotone2(f: (ConstantSign, ConstantSign) -> ConstantSign): Bool = PartialOrder.monotone2(f, leq, leq, leq)
 
-    law safe1(fa: ConstantSign -> ConstantSign, fc: BigInt -> BigInt): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
+//    law safe1(fa: ConstantSign -> ConstantSign, fc: BigInt -> BigInt): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
 
-    law safe2(fa: (ConstantSign, ConstantSign) -> ConstantSign, fc: (BigInt, BigInt) -> BigInt): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
+//    law safe2(fa: (ConstantSign, ConstantSign) -> ConstantSign, fc: (BigInt, BigInt) -> BigInt): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
 
 }

--- a/examples/domains/Interval.flix
+++ b/examples/domains/Interval.flix
@@ -41,7 +41,7 @@ namespace Domain/Interval {
     ///
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
-    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
+//    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
     pub def leq(x: Interval, y: Interval): Bool = match (x, y) {
         case (Bot, _)                       => true
         case (Range(b1, e1), Range(b2, e2)) => b2 <= b1 and e1 <= e2
@@ -52,7 +52,7 @@ namespace Domain/Interval {
     ///
     /// Returns the least upper bound of `e1` and `e2`.
     ///
-    #upperBound #leastUpperBound
+//    #upperBound #leastUpperBound
     pub def lub(x: Interval, y: Interval): Interval = match (x, y) {
         case (Bot, _)                       => y
         case (_, Bot)                       => x
@@ -63,7 +63,7 @@ namespace Domain/Interval {
     ///
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
-    #lowerBound #greatestLowerBound
+//    #lowerBound #greatestLowerBound
     pub def glb(x: Interval, y: Interval): Interval = match (x, y) {
         case (Top, _)                       => y
         case (_, Top)                       => x
@@ -79,8 +79,8 @@ namespace Domain/Interval {
     ///
     /// Over-approximates integer `increment`.
     ///
-    #safe1(x -> x + 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x + 1ii)
+//    #strict1 #monotone1
     pub def inc(x: Interval): Interval = match x {
         case Bot            => Bot
         case Range(b, e)    => norm(Range(b + 1ii, e + 1ii))
@@ -90,8 +90,8 @@ namespace Domain/Interval {
     ///
     /// Over-approximates integer `decrement`.
     ///
-    #safe1(x -> x - 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x - 1ii)
+//    #strict1 #monotone1
     pub def dec(x: Interval): Interval = match x {
         case Bot            => Bot
         case Range(b, e)    => norm(Range(b - 1ii, e - 1ii))
@@ -101,8 +101,8 @@ namespace Domain/Interval {
     ///
     /// Over-approximates integer `addition`.
     ///
-    #safe2((x, y) -> x + y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x + y)
+//    #strict2 #monotone2
     pub def plus(x: Interval, y: Interval): Interval = match (x, y) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
@@ -113,8 +113,8 @@ namespace Domain/Interval {
     ///
     /// Over-approximates integer `subtraction`.
     ///
-    #safe2((x, y) -> x - y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x - y)
+//    #strict2 #monotone2
     pub def minus(x: Interval, y: Interval): Interval = match (x, y) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
@@ -125,8 +125,8 @@ namespace Domain/Interval {
     ///
     /// Over-approximates integer `multiplication`.
     ///
-    #safe2((x, y) -> x * y)
-    #strict2 /* undecidable #monotone2 */
+//    #safe2((x, y) -> x * y)
+//    #strict2 /* undecidable #monotone2 */
     pub def times(x: Interval, y: Interval): Interval = match (x, y) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
@@ -140,8 +140,8 @@ namespace Domain/Interval {
     /**
       * Over-approximates `equal`.
       */
-    #safeBelnap2((x, y) -> x == y)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2 #commutativeBelnap
+//    #safeBelnap2((x, y) -> x == y)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2 #commutativeBelnap
     pub def eq(x: Interval, y: Interval): Belnap.Belnap = match (x, y) {
         case (Bot, _)                                           => Belnap/Belnap.Bot
         case (_, Bot)                                           => Belnap/Belnap.Bot
@@ -156,15 +156,15 @@ namespace Domain/Interval {
     /**
       * Over-approximates `not equal`.
       */
-    #safeBelnap2((x, y) -> x != y)
+//    #safeBelnap2((x, y) -> x != y)
     // NB: Strictness and monotonicity follows from the properties of `not` and `eq`.
     pub def neq(x: Interval, y: Interval): Belnap.Belnap = Belnap.not(eq(x, y))
 
     /**
       * Over-approximates `less than`.
       */
-   #safeBelnap2((x, y) -> x < y)
-   #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2
+//   #safeBelnap2((x, y) -> x < y)
+//   #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2
    pub def less(x: Interval, y: Interval): Belnap.Belnap = match (x, y) {
         case (Bot, _)                                  => Belnap/Belnap.Bot
         case (_, Bot)                                  => Belnap/Belnap.Bot
@@ -183,7 +183,7 @@ namespace Domain/Interval {
     /**
       * Over-approximates `less than or equal`.
       */
-    #safeBelnap2((x, y) -> x <= y)
+//    #safeBelnap2((x, y) -> x <= y)
     // NB: Strictness and monotonicity follows from the properties of `or` and `less`.
     pub def lessEqual(x: Interval, y: Interval): Belnap.Belnap = Belnap.or(x `less` y, x `eq` y)
 
@@ -191,85 +191,85 @@ namespace Domain/Interval {
     // Specialized Laws
     // ------------------------------------------------------------------------
 
-    law reflexive(⊑: (Interval, Interval) -> Bool): Bool =
-        ∀(x: Interval). norm(x) ⊑ norm(x)
+//    law reflexive(⊑: (Interval, Interval) -> Bool): Bool =
+//        ∀(x: Interval). norm(x) ⊑ norm(x)
 
-    law antiSymmetric(⊑: (Interval, Interval) -> Bool): Bool =
-        ∀(x: Interval, y: Interval). ((norm(x) ⊑ norm(y)) ∧ (norm(y) ⊑ norm(x))) → (norm(x) == norm(y))
+//    law antiSymmetric(⊑: (Interval, Interval) -> Bool): Bool =
+//        ∀(x: Interval, y: Interval). ((norm(x) ⊑ norm(y)) ∧ (norm(y) ⊑ norm(x))) → (norm(x) == norm(y))
 
-    law transitive(⊑: (Interval, Interval) -> Bool): Bool =
-        ∀(x: Interval, y: Interval, z: Interval). ((norm(x) ⊑ norm(y)) ∧ (norm(y) ⊑ norm(z))) → (norm(x) ⊑ norm(z))
+//    law transitive(⊑: (Interval, Interval) -> Bool): Bool =
+//        ∀(x: Interval, y: Interval, z: Interval). ((norm(x) ⊑ norm(y)) ∧ (norm(y) ⊑ norm(z))) → (norm(x) ⊑ norm(z))
 
-    law upperBound(⊔: (Interval, Interval) -> Interval): Bool =
-        let ⊑ = leq;
-            ∀(x: Interval, y: Interval).
-                (norm(x) ⊑ (norm(x) ⊔ norm(y))) ∧ (norm(y) ⊑ (norm(x) ⊔ norm(y)))
+//    law upperBound(⊔: (Interval, Interval) -> Interval): Bool =
+//        let ⊑ = leq;
+//            ∀(x: Interval, y: Interval).
+//                (norm(x) ⊑ (norm(x) ⊔ norm(y))) ∧ (norm(y) ⊑ (norm(x) ⊔ norm(y)))
 
-    law leastUpperBound(⊔: (Interval, Interval) -> Interval): Bool =
-        let ⊑ = leq;
-            ∀(x: Interval, y: Interval, z: Interval).
-                ((norm(x) ⊑ norm(z)) ∧ (norm(y) ⊑ norm(z))) → ((norm(x) ⊔ norm(y)) ⊑ norm(z))
+//    law leastUpperBound(⊔: (Interval, Interval) -> Interval): Bool =
+//        let ⊑ = leq;
+//            ∀(x: Interval, y: Interval, z: Interval).
+//                ((norm(x) ⊑ norm(z)) ∧ (norm(y) ⊑ norm(z))) → ((norm(x) ⊔ norm(y)) ⊑ norm(z))
 
-    law lowerBound(⊓: (Interval, Interval) -> Interval): Bool =
-        let ⊑ = leq;
-            ∀(x: Interval, y: Interval).
-                ((norm(x) ⊓ norm(y)) ⊑ norm(x)) ∧ ((norm(x) ⊓ norm(y)) ⊑ norm(y))
+//    law lowerBound(⊓: (Interval, Interval) -> Interval): Bool =
+//        let ⊑ = leq;
+//            ∀(x: Interval, y: Interval).
+//                ((norm(x) ⊓ norm(y)) ⊑ norm(x)) ∧ ((norm(x) ⊓ norm(y)) ⊑ norm(y))
 
-    law greatestLowerBound(⊓: (Interval, Interval) -> Interval): Bool =
-        let ⊑ = leq;
-            ∀(x: Interval, y: Interval, z: Interval).
-                    ((norm(z) ⊑ norm(x)) ∧ (norm(z) ⊑ norm(y))) → (norm(z) ⊑ (norm(x) ⊓ norm(y)))
+//    law greatestLowerBound(⊓: (Interval, Interval) -> Interval): Bool =
+//        let ⊑ = leq;
+//            ∀(x: Interval, y: Interval, z: Interval).
+//                    ((norm(z) ⊑ norm(x)) ∧ (norm(z) ⊑ norm(y))) → (norm(z) ⊑ (norm(x) ⊓ norm(y)))
 
-    law leastElement(⊑: (Interval, Interval) -> Bool, ⊥: Interval): Bool =
-        ∀(x: Interval). ⊥ ⊑ norm(x)
+//    law leastElement(⊑: (Interval, Interval) -> Bool, ⊥: Interval): Bool =
+//        ∀(x: Interval). ⊥ ⊑ norm(x)
 
-    law greatestElement(⊑: (Interval, Interval) -> Bool, ⊤: Interval): Bool =
-        ∀(x: Interval). norm(x) ⊑ ⊤
+//    law greatestElement(⊑: (Interval, Interval) -> Bool, ⊤: Interval): Bool =
+//        ∀(x: Interval). norm(x) ⊑ ⊤
 
-    law associative(f: (Interval, Interval) -> Interval): Bool =
-        ∀(x: Interval, y: Interval, z: Interval).
-                f(norm(x), f(norm(y), norm(z))) == f(f(norm(x), norm(y)), norm(z))
+//    law associative(f: (Interval, Interval) -> Interval): Bool =
+//        ∀(x: Interval, y: Interval, z: Interval).
+//                f(norm(x), f(norm(y), norm(z))) == f(f(norm(x), norm(y)), norm(z))
 
-    law commutative(f: (Interval, Interval) -> Interval): Bool =
-        ∀(x: Interval, y: Interval).
-            f(norm(x), norm(y)) == f(norm(y), norm(x))
+//    law commutative(f: (Interval, Interval) -> Interval): Bool =
+//        ∀(x: Interval, y: Interval).
+//            f(norm(x), norm(y)) == f(norm(y), norm(x))
 
-    law strict1(f: Interval -> Interval): Bool =
-        f(Bot) == Bot
+//    law strict1(f: Interval -> Interval): Bool =
+//        f(Bot) == Bot
 
-    law strict2(f: (Interval, Interval) -> Interval): Bool =
-        f(Bot, Bot) == Bot
+//    law strict2(f: (Interval, Interval) -> Interval): Bool =
+//        f(Bot, Bot) == Bot
 
-    law monotone1(f: Interval -> Interval): Bool =
-        let ⊑ = leq;
-            ∀(x: Interval, y: Interval).
-                (norm(x) ⊑ norm(y)) → (f(norm(x)) ⊑ f(norm(y)))
+//    law monotone1(f: Interval -> Interval): Bool =
+//        let ⊑ = leq;
+//            ∀(x: Interval, y: Interval).
+//                (norm(x) ⊑ norm(y)) → (f(norm(x)) ⊑ f(norm(y)))
 
-    law monotone2(f: (Interval, Interval) -> Interval): Bool =
-        let ⊑ = leq;
-            ∀(x1: Interval, x2: Interval, y1: Interval, y2: Interval).
-                    ((norm(x1) ⊑ norm(y1)) ∧ (norm(x2) ⊑ norm(y2))) → (f(norm(x1), norm(x2)) ⊑ f(norm(y1), norm(y2)))
+//    law monotone2(f: (Interval, Interval) -> Interval): Bool =
+//        let ⊑ = leq;
+//            ∀(x1: Interval, x2: Interval, y1: Interval, y2: Interval).
+//                    ((norm(x1) ⊑ norm(y1)) ∧ (norm(x2) ⊑ norm(y2))) → (f(norm(x1), norm(x2)) ⊑ f(norm(y1), norm(y2)))
 
-    law safe1(fa: Interval -> Interval, fc: BigInt -> BigInt): Bool =
-        ∀(x: BigInt). alpha(fc(x)) `leq` fa(alpha(x))
+//    law safe1(fa: Interval -> Interval, fc: BigInt -> BigInt): Bool =
+//        ∀(x: BigInt). alpha(fc(x)) `leq` fa(alpha(x))
 
-    law safe2(fa: (Interval, Interval) -> Interval, fc: (BigInt, BigInt) -> BigInt): Bool =
-        ∀(x: BigInt, y: BigInt). alpha(fc(x, y)) `leq` fa(alpha(x), alpha(y))
+//    law safe2(fa: (Interval, Interval) -> Interval, fc: (BigInt, BigInt) -> BigInt): Bool =
+//        ∀(x: BigInt, y: BigInt). alpha(fc(x, y)) `leq` fa(alpha(x), alpha(y))
 
     // ------------------------------------------------------------------------
     // Specialized Laws for Interval/Belnap.
     // ------------------------------------------------------------------------
 
-    law commutativeBelnap(f: (Interval, Interval) -> Belnap.Belnap): Bool =
-        ∀(x: Interval, y: Interval).
-            f(norm(x), norm(y)) == f(norm(y), norm(x))
+//    law commutativeBelnap(f: (Interval, Interval) -> Belnap.Belnap): Bool =
+//        ∀(x: Interval, y: Interval).
+//            f(norm(x), norm(y)) == f(norm(y), norm(x))
 
-    law monotoneBelnap2(f: (Interval, Interval) -> Belnap.Belnap): Bool =
-        let ⊑ = leq;
-            ∀(x1: Interval, x2: Interval, y1: Interval, y2: Interval).
-                    ((norm(x1) ⊑ norm(y1)) ∧ (norm(x2) ⊑ norm(y2))) → (f(norm(x1), norm(x2)) `Belnap.leq` f(norm(y1), norm(y2)))
+//    law monotoneBelnap2(f: (Interval, Interval) -> Belnap.Belnap): Bool =
+//        let ⊑ = leq;
+//            ∀(x1: Interval, x2: Interval, y1: Interval, y2: Interval).
+//                    ((norm(x1) ⊑ norm(y1)) ∧ (norm(x2) ⊑ norm(y2))) → (f(norm(x1), norm(x2)) `Belnap.leq` f(norm(y1), norm(y2)))
 
-    law safeBelnap2(fa: (Interval, Interval) -> Belnap.Belnap, fc: (BigInt, BigInt) -> Bool): Bool =
-        ∀(x: BigInt, y: BigInt). Belnap.alpha(fc(x, y)) `Belnap.leq` fa(alpha(x), alpha(y))
+//    law safeBelnap2(fa: (Interval, Interval) -> Belnap.Belnap, fc: (BigInt, BigInt) -> Bool): Bool =
+//        ∀(x: BigInt, y: BigInt). Belnap.alpha(fc(x, y)) `Belnap.leq` fa(alpha(x), alpha(y))
 
 }

--- a/examples/domains/IntervalAlt.flix
+++ b/examples/domains/IntervalAlt.flix
@@ -46,7 +46,7 @@ namespace Domain/IntervalAlt {
     ///
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
-    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
+//    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
     pub def leq(x: IntervalAlt, y: IntervalAlt): Bool = match (x, y) {
         case (Bot, _)                       => true
         case (Range(b1, e1), Range(b2, e2)) => b2 <= b1 and e1 <= e2
@@ -57,7 +57,7 @@ namespace Domain/IntervalAlt {
     ///
     /// Returns the least upper bound of `e1` and `e2`.
     ///
-    #upperBound #leastUpperBound
+//    #upperBound #leastUpperBound
     pub def lub(x: IntervalAlt, y: IntervalAlt): IntervalAlt = match (x, y) {
         case (Bot, _)                       => y
         case (_, Bot)                       => x
@@ -68,7 +68,7 @@ namespace Domain/IntervalAlt {
     ///
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
-    #lowerBound #greatestLowerBound
+//    #lowerBound #greatestLowerBound
     pub def glb(x: IntervalAlt, y: IntervalAlt): IntervalAlt = match (x, y) {
         case (Top, _)                       => y
         case (_, Top)                       => x
@@ -79,7 +79,7 @@ namespace Domain/IntervalAlt {
     ///
     /// The lattice height function.
     ///
-    #nonNegative #decreasing(equ, leq)
+//    #nonNegative #decreasing(equ, leq)
     pub def height(x: IntervalAlt): BigInt = match x {
         case Top            => 0ii
         case Range(b, e)    => 99ii - (e - b)
@@ -94,8 +94,8 @@ namespace Domain/IntervalAlt {
     ///
     /// Over-approximates integer `increment`.
     ///
-    #safe1(x -> x + 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x + 1ii)
+//    #strict1 #monotone1
     pub def inc(x: IntervalAlt): IntervalAlt = match x {
         case Bot            => Bot
         case Range(b, e)    => norm(Range(b + 1ii, e + 1ii))
@@ -105,8 +105,8 @@ namespace Domain/IntervalAlt {
     ///
     /// Over-approximates integer `decrement`.
     ///
-    #safe1(x -> x - 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x - 1ii)
+//    #strict1 #monotone1
     pub def dec(x: IntervalAlt): IntervalAlt = match x {
         case Bot            => Bot
         case Range(b, e)    => norm(Range(b - 1ii, e - 1ii))
@@ -116,8 +116,8 @@ namespace Domain/IntervalAlt {
     ///
     /// Over-approximates integer `addition`.
     ///
-    #safe2((x, y) -> x + y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x + y)
+//    #strict2 #monotone2
     pub def plus(x: IntervalAlt, y: IntervalAlt): IntervalAlt = match (x, y) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
@@ -128,8 +128,8 @@ namespace Domain/IntervalAlt {
     ///
     /// Over-approximates integer `subtraction`.
     ///
-    #safe2((x, y) -> x - y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x - y)
+//    #strict2 #monotone2
     pub def minus(x: IntervalAlt, y: IntervalAlt): IntervalAlt = match (x, y) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
@@ -140,8 +140,8 @@ namespace Domain/IntervalAlt {
     ///
     /// Over-approximates integer `multiplication`.
     ///
-    #safe2((x, y) -> x * y)
-    #strict2 /* #monotone2 loops/timeout */
+//    #safe2((x, y) -> x * y)
+//    #strict2 /* #monotone2 loops/timeout */
     pub def times(x: IntervalAlt, y: IntervalAlt): IntervalAlt = match (x, y) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
@@ -155,8 +155,8 @@ namespace Domain/IntervalAlt {
     /**
       * Over-approximates `equal`.
       */
-    #safeBelnap2((x, y) -> x == y)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2 #commutativeBelnap
+//    #safeBelnap2((x, y) -> x == y)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2 #commutativeBelnap
     pub def eq(x: IntervalAlt, y: IntervalAlt): Belnap.Belnap = match (x, y) {
         case (Bot, _)                                           => Belnap/Belnap.Bot
         case (_, Bot)                                           => Belnap/Belnap.Bot
@@ -171,15 +171,15 @@ namespace Domain/IntervalAlt {
     /**
       * Over-approximates `not equal`.
       */
-    #safeBelnap2((x, y) -> x != y)
+//    #safeBelnap2((x, y) -> x != y)
     // NB: Strictness and monotonicity follows from the properties of `not` and `eq`.
     pub def neq(x: IntervalAlt, y: IntervalAlt): Belnap.Belnap = Belnap.not(eq(x, y))
 
     /**
       * Over-approximates `less than`.
       */
-    #safeBelnap2((x, y) -> x < y)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2
+//    #safeBelnap2((x, y) -> x < y)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2
     pub def less(x: IntervalAlt, y: IntervalAlt): Belnap.Belnap = match (x, y) {
         case (Bot, _)                                  => Belnap/Belnap.Bot
         case (_, Bot)                                  => Belnap/Belnap.Bot
@@ -198,7 +198,7 @@ namespace Domain/IntervalAlt {
     /**
       * Over-approximates `less than or equal`.
       */
-    #safeBelnap2((x, y) -> x <= y)
+//    #safeBelnap2((x, y) -> x <= y)
     // NB: Strictness and monotonicity follows from the properties of `or` and `less`.
     pub def lessEqual(x: IntervalAlt, y: IntervalAlt): Belnap.Belnap = Belnap.or(x `less` y, x `eq` y)
 
@@ -206,94 +206,94 @@ namespace Domain/IntervalAlt {
     // Specialized Laws
     // ------------------------------------------------------------------------
 
-    law reflexive(⊑: (IntervalAlt, IntervalAlt) -> Bool): Bool =
-        ∀(x: IntervalAlt). norm(x) ⊑ norm(x)
+//    law reflexive(⊑: (IntervalAlt, IntervalAlt) -> Bool): Bool =
+//        ∀(x: IntervalAlt). norm(x) ⊑ norm(x)
 
-    law antiSymmetric(⊑: (IntervalAlt, IntervalAlt) -> Bool): Bool =
-        ∀(x: IntervalAlt, y: IntervalAlt). ((norm(x) ⊑ norm(y)) ∧ (norm(y) ⊑ norm(x))) → (norm(x) == norm(y))
+//    law antiSymmetric(⊑: (IntervalAlt, IntervalAlt) -> Bool): Bool =
+//        ∀(x: IntervalAlt, y: IntervalAlt). ((norm(x) ⊑ norm(y)) ∧ (norm(y) ⊑ norm(x))) → (norm(x) == norm(y))
 
-    law transitive(⊑: (IntervalAlt, IntervalAlt) -> Bool): Bool =
-        ∀(x: IntervalAlt, y: IntervalAlt, z: IntervalAlt). ((norm(x) ⊑ norm(y)) ∧ (norm(y) ⊑ norm(z))) → (norm(x) ⊑ norm(z))
+//    law transitive(⊑: (IntervalAlt, IntervalAlt) -> Bool): Bool =
+//        ∀(x: IntervalAlt, y: IntervalAlt, z: IntervalAlt). ((norm(x) ⊑ norm(y)) ∧ (norm(y) ⊑ norm(z))) → (norm(x) ⊑ norm(z))
 
-    law upperBound(⊔: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
-        let ⊑ = leq;
-            ∀(x: IntervalAlt, y: IntervalAlt).
-                (norm(x) ⊑ (norm(x) ⊔ norm(y))) ∧ (norm(y) ⊑ (norm(x) ⊔ norm(y)))
+//    law upperBound(⊔: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
+//        let ⊑ = leq;
+//            ∀(x: IntervalAlt, y: IntervalAlt).
+//                (norm(x) ⊑ (norm(x) ⊔ norm(y))) ∧ (norm(y) ⊑ (norm(x) ⊔ norm(y)))
 
-    law leastUpperBound(⊔: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
-        let ⊑ = leq;
-            ∀(x: IntervalAlt, y: IntervalAlt, z: IntervalAlt).
-                ((norm(x) ⊑ norm(z)) ∧ (norm(y) ⊑ norm(z))) → ((norm(x) ⊔ norm(y)) ⊑ norm(z))
+//    law leastUpperBound(⊔: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
+//        let ⊑ = leq;
+//            ∀(x: IntervalAlt, y: IntervalAlt, z: IntervalAlt).
+//                ((norm(x) ⊑ norm(z)) ∧ (norm(y) ⊑ norm(z))) → ((norm(x) ⊔ norm(y)) ⊑ norm(z))
 
-    law lowerBound(⊓: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
-        let ⊑ = leq;
-            ∀(x: IntervalAlt, y: IntervalAlt).
-                ((norm(x) ⊓ norm(y)) ⊑ norm(x)) ∧ ((norm(x) ⊓ norm(y)) ⊑ norm(y))
+//    law lowerBound(⊓: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
+//        let ⊑ = leq;
+//            ∀(x: IntervalAlt, y: IntervalAlt).
+//                ((norm(x) ⊓ norm(y)) ⊑ norm(x)) ∧ ((norm(x) ⊓ norm(y)) ⊑ norm(y))
 
-    law greatestLowerBound(⊓: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
-        let ⊑ = leq;
-            ∀(x: IntervalAlt, y: IntervalAlt, z: IntervalAlt).
-                    ((norm(z) ⊑ norm(x)) ∧ (norm(z) ⊑ norm(y))) → (norm(z) ⊑ (norm(x) ⊓ norm(y)))
+//    law greatestLowerBound(⊓: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
+//        let ⊑ = leq;
+//            ∀(x: IntervalAlt, y: IntervalAlt, z: IntervalAlt).
+//                    ((norm(z) ⊑ norm(x)) ∧ (norm(z) ⊑ norm(y))) → (norm(z) ⊑ (norm(x) ⊓ norm(y)))
 
-    law leastElement(⊑: (IntervalAlt, IntervalAlt) -> Bool, ⊥: IntervalAlt): Bool =
-        ∀(x: IntervalAlt). ⊥ ⊑ norm(x)
+//    law leastElement(⊑: (IntervalAlt, IntervalAlt) -> Bool, ⊥: IntervalAlt): Bool =
+//        ∀(x: IntervalAlt). ⊥ ⊑ norm(x)
 
-    law greatestElement(⊑: (IntervalAlt, IntervalAlt) -> Bool, ⊤: IntervalAlt): Bool =
-        ∀(x: IntervalAlt). norm(x) ⊑ ⊤
+//    law greatestElement(⊑: (IntervalAlt, IntervalAlt) -> Bool, ⊤: IntervalAlt): Bool =
+//        ∀(x: IntervalAlt). norm(x) ⊑ ⊤
 
-    law nonNegative(h: IntervalAlt -> BigInt): Bool =
-        ∀(x: IntervalAlt). h(norm(x)) >= 0ii
+//    law nonNegative(h: IntervalAlt -> BigInt): Bool =
+//        ∀(x: IntervalAlt). h(norm(x)) >= 0ii
 
-    law decreasing(h: IntervalAlt -> BigInt, equ: (IntervalAlt, IntervalAlt) -> Bool, ⊑: (IntervalAlt, IntervalAlt) -> Bool): Bool =
-        ∀(x1: IntervalAlt, y1: IntervalAlt).
-            let x = norm(x1);
-            let y = norm(y1);
-                (x ⊑ y and not equ(x, y)) → (h(x) > h(y))
+//    law decreasing(h: IntervalAlt -> BigInt, equ: (IntervalAlt, IntervalAlt) -> Bool, ⊑: (IntervalAlt, IntervalAlt) -> Bool): Bool =
+//        ∀(x1: IntervalAlt, y1: IntervalAlt).
+//            let x = norm(x1);
+//            let y = norm(y1);
+//                (x ⊑ y and not equ(x, y)) → (h(x) > h(y))
 
-    law associative(f: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
-        ∀(x: IntervalAlt, y: IntervalAlt, z: IntervalAlt).
-                f(norm(x), f(norm(y), norm(z))) == f(f(norm(x), norm(y)), norm(z))
+//    law associative(f: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
+//        ∀(x: IntervalAlt, y: IntervalAlt, z: IntervalAlt).
+//                f(norm(x), f(norm(y), norm(z))) == f(f(norm(x), norm(y)), norm(z))
 
-    law commutative(f: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
-        ∀(x: IntervalAlt, y: IntervalAlt).
-            f(norm(x), norm(y)) == f(norm(y), norm(x))
+//    law commutative(f: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
+//        ∀(x: IntervalAlt, y: IntervalAlt).
+//            f(norm(x), norm(y)) == f(norm(y), norm(x))
 
-    law strict1(f: IntervalAlt -> IntervalAlt): Bool =
-        f(Bot) == Bot
+//    law strict1(f: IntervalAlt -> IntervalAlt): Bool =
+//        f(Bot) == Bot
 
-    law strict2(f: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
-        f(Bot, Bot) == Bot
+//    law strict2(f: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
+//        f(Bot, Bot) == Bot
 
-    law monotone1(f: IntervalAlt -> IntervalAlt): Bool =
-        let ⊑ = leq;
-            ∀(x: IntervalAlt, y: IntervalAlt).
-                (norm(x) ⊑ norm(y)) → (f(norm(x)) ⊑ f(norm(y)))
+//    law monotone1(f: IntervalAlt -> IntervalAlt): Bool =
+//        let ⊑ = leq;
+//            ∀(x: IntervalAlt, y: IntervalAlt).
+//                (norm(x) ⊑ norm(y)) → (f(norm(x)) ⊑ f(norm(y)))
 
-    law monotone2(f: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
-        let ⊑ = leq;
-            ∀(x1: IntervalAlt, x2: IntervalAlt, y1: IntervalAlt, y2: IntervalAlt).
-                    ((norm(x1) ⊑ norm(y1)) ∧ (norm(x2) ⊑ norm(y2))) → (f(norm(x1), norm(x2)) ⊑ f(norm(y1), norm(y2)))
+//    law monotone2(f: (IntervalAlt, IntervalAlt) -> IntervalAlt): Bool =
+//        let ⊑ = leq;
+//            ∀(x1: IntervalAlt, x2: IntervalAlt, y1: IntervalAlt, y2: IntervalAlt).
+//                    ((norm(x1) ⊑ norm(y1)) ∧ (norm(x2) ⊑ norm(y2))) → (f(norm(x1), norm(x2)) ⊑ f(norm(y1), norm(y2)))
 
-    law safe1(fa: IntervalAlt -> IntervalAlt, fc: BigInt -> BigInt): Bool =
-        ∀(x: BigInt). alpha(fc(x)) `leq` fa(alpha(x))
+//    law safe1(fa: IntervalAlt -> IntervalAlt, fc: BigInt -> BigInt): Bool =
+//        ∀(x: BigInt). alpha(fc(x)) `leq` fa(alpha(x))
 
-    law safe2(fa: (IntervalAlt, IntervalAlt) -> IntervalAlt, fc: (BigInt, BigInt) -> BigInt): Bool =
-        ∀(x: BigInt, y: BigInt). alpha(fc(x, y)) `leq` fa(alpha(x), alpha(y))
+//    law safe2(fa: (IntervalAlt, IntervalAlt) -> IntervalAlt, fc: (BigInt, BigInt) -> BigInt): Bool =
+//        ∀(x: BigInt, y: BigInt). alpha(fc(x, y)) `leq` fa(alpha(x), alpha(y))
 
     // ------------------------------------------------------------------------
     // Specialized Laws for IntervalAlt/Belnap.
     // ------------------------------------------------------------------------
 
-    law commutativeBelnap(f: (IntervalAlt, IntervalAlt) -> Belnap.Belnap): Bool =
-        ∀(x: IntervalAlt, y: IntervalAlt).
-            f(norm(x), norm(y)) == f(norm(y), norm(x))
+//    law commutativeBelnap(f: (IntervalAlt, IntervalAlt) -> Belnap.Belnap): Bool =
+//        ∀(x: IntervalAlt, y: IntervalAlt).
+//            f(norm(x), norm(y)) == f(norm(y), norm(x))
 
-    law monotoneBelnap2(f: (IntervalAlt, IntervalAlt) -> Belnap.Belnap): Bool =
-        let ⊑ = leq;
-            ∀(x1: IntervalAlt, x2: IntervalAlt, y1: IntervalAlt, y2: IntervalAlt).
-                    ((norm(x1) ⊑ norm(y1)) ∧ (norm(x2) ⊑ norm(y2))) → (f(norm(x1), norm(x2)) `Belnap.leq` f(norm(y1), norm(y2)))
+//    law monotoneBelnap2(f: (IntervalAlt, IntervalAlt) -> Belnap.Belnap): Bool =
+//        let ⊑ = leq;
+//            ∀(x1: IntervalAlt, x2: IntervalAlt, y1: IntervalAlt, y2: IntervalAlt).
+//                    ((norm(x1) ⊑ norm(y1)) ∧ (norm(x2) ⊑ norm(y2))) → (f(norm(x1), norm(x2)) `Belnap.leq` f(norm(y1), norm(y2)))
 
-    law safeBelnap2(fa: (IntervalAlt, IntervalAlt) -> Belnap.Belnap, fc: (BigInt, BigInt) -> Bool): Bool =
-        ∀(x: BigInt, y: BigInt). Belnap.alpha(fc(x, y)) `Belnap.leq` fa(alpha(x), alpha(y))
+//    law safeBelnap2(fa: (IntervalAlt, IntervalAlt) -> Belnap.Belnap, fc: (BigInt, BigInt) -> Bool): Bool =
+//        ∀(x: BigInt, y: BigInt). Belnap.alpha(fc(x, y)) `Belnap.leq` fa(alpha(x), alpha(y))
 
 }

--- a/examples/domains/IntervalInf.flix
+++ b/examples/domains/IntervalInf.flix
@@ -36,7 +36,7 @@ namespace Domain/IntervalInf {
     ///
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
-   #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
+//   #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
     def leq(e1: IntervalInf, e2: IntervalInf): Bool = match (e1, e2) {
         case (Bot, _)                       => true
         case (Range(b1, e1), Range(b2, e2)) => b2 <= b1 and e1 <= e2
@@ -51,7 +51,7 @@ namespace Domain/IntervalInf {
     ///
     /// Returns the least upper bound of `e1` and `e2`.
     ///
-    #upperBound #leastUpperBound #commutative /* slow #associative */
+//    #upperBound #leastUpperBound #commutative /* slow #associative */
     def lub(e1: IntervalInf, e2: IntervalInf): IntervalInf = match (e1, e2) {
         case (Bot, x)                       => x
         case (x, Bot)                       => x
@@ -68,7 +68,7 @@ namespace Domain/IntervalInf {
     ///
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
-    #lowerBound #greatestLowerBound #commutative /* slow #associative */
+//    #lowerBound #greatestLowerBound #commutative /* slow #associative */
     def glb(e1: IntervalInf, e2: IntervalInf): IntervalInf = match (e1, e2) {
         case (Top, x)                       => x
         case (x, Top)                       => x
@@ -92,8 +92,8 @@ namespace Domain/IntervalInf {
     ///
     /// Over-approximates integer `increment`.
     ///
-    #safe1(x -> x + 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x + 1ii)
+//    #strict1 #monotone1
     def inc(e: IntervalInf): IntervalInf = match e {
         case Bot            => Bot
         case Range(b, e)    => norm(Range(b + 1ii, e + 1ii))
@@ -105,8 +105,8 @@ namespace Domain/IntervalInf {
     ///
     /// Over-approximates integer `decrement`.
     ///
-    #safe1(x -> x - 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x - 1ii)
+//    #strict1 #monotone1
     def dec(e: IntervalInf): IntervalInf = match e {
         case Bot            => Bot
         case Range(b, e)    => norm(Range(b - 1ii, e - 1ii))
@@ -118,8 +118,8 @@ namespace Domain/IntervalInf {
     ///
     /// Over-approximates integer `addition`.
     ///
-    #safe2((x, y) -> x + y)
-    #strict2 #monotone2 #commutative
+//    #safe2((x, y) -> x + y)
+//    #strict2 #monotone2 #commutative
     def plus(e1: IntervalInf, e2: IntervalInf): IntervalInf = match (e1, e2) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
@@ -148,8 +148,8 @@ namespace Domain/IntervalInf {
     ///
     /// Over-approximates integer `multiplication`.
     ///
-    #safe2((x, y) -> x * y)
-    #strict2  #monotone2 /**/ /* slow? #commutative */
+//    #safe2((x, y) -> x * y)
+//    #strict2  #monotone2 /**/ /* slow? #commutative */
     def times(e1: IntervalInf, e2: IntervalInf): IntervalInf = match (e1, e2) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
@@ -167,8 +167,8 @@ namespace Domain/IntervalInf {
     /**
       * Over-approximates `equal`.
       */
-    #safeBelnap2((x, y) -> x == y)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2 #commutativeBelnap
+//    #safeBelnap2((x, y) -> x == y)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2 #commutativeBelnap
     def eq(e1: IntervalInf, e2: IntervalInf): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)                                           => Belnap/Belnap.Bot
         case (_, Bot)                                           => Belnap/Belnap.Bot
@@ -189,15 +189,15 @@ namespace Domain/IntervalInf {
     /**
       * Over-approximates `not equal`.
       */
-    #safeBelnap2((x, y) -> x != y)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2 #commutativeBelnap
+//    #safeBelnap2((x, y) -> x != y)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2 #commutativeBelnap
     def neq(e1: IntervalInf, e2: IntervalInf): Belnap.Belnap = Belnap.not(eq(e1, e2))
 
     /**
       * Over-approximates `less than`.
       */
-   #safeBelnap2((x, y) -> x < y)
-   #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2
+//   #safeBelnap2((x, y) -> x < y)
+//   #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2
     def less(e1: IntervalInf, e2: IntervalInf): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)                                  => Belnap/Belnap.Bot
         case (_, Bot)                                  => Belnap/Belnap.Bot
@@ -220,7 +220,7 @@ namespace Domain/IntervalInf {
     /**
       * Over-approximates `less than or equal`.
       */
-    #safeBelnap2((x, y) -> x <= y)
+//    #safeBelnap2((x, y) -> x <= y)
     //#Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot) #monotoneBelnap2 // TODO
     def lessEqual(e1: IntervalInf, e2: IntervalInf): Belnap.Belnap = Belnap.or(e1 `less` e2, e1 `eq` e2)
 
@@ -229,85 +229,85 @@ namespace Domain/IntervalInf {
     // Specialized Laws
     // ------------------------------------------------------------------------
 
-    law reflexive(⊑: (IntervalInf, IntervalInf) -> Bool): Bool =
-        ∀(x: IntervalInf). norm(x) ⊑ norm(x)
+//    law reflexive(⊑: (IntervalInf, IntervalInf) -> Bool): Bool =
+//        ∀(x: IntervalInf). norm(x) ⊑ norm(x)
 
-    law antiSymmetric(⊑: (IntervalInf, IntervalInf) -> Bool): Bool =
-        ∀(x: IntervalInf, y: IntervalInf). ((norm(x) ⊑ norm(y)) ∧ (norm(y) ⊑ norm(x))) → (norm(x) == norm(y))
+//    law antiSymmetric(⊑: (IntervalInf, IntervalInf) -> Bool): Bool =
+//        ∀(x: IntervalInf, y: IntervalInf). ((norm(x) ⊑ norm(y)) ∧ (norm(y) ⊑ norm(x))) → (norm(x) == norm(y))
 
-    law transitive(⊑: (IntervalInf, IntervalInf) -> Bool): Bool =
-        ∀(x: IntervalInf, y: IntervalInf, z: IntervalInf). ((norm(x) ⊑ norm(y)) ∧ (norm(y) ⊑ norm(z))) → (norm(x) ⊑ norm(z))
+//    law transitive(⊑: (IntervalInf, IntervalInf) -> Bool): Bool =
+//        ∀(x: IntervalInf, y: IntervalInf, z: IntervalInf). ((norm(x) ⊑ norm(y)) ∧ (norm(y) ⊑ norm(z))) → (norm(x) ⊑ norm(z))
 
-    law upperBound(⊔: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
-        let ⊑ = leq;
-            ∀(x: IntervalInf, y: IntervalInf).
-                (norm(x) ⊑ (norm(x) ⊔ norm(y))) ∧ (norm(y) ⊑ (norm(x) ⊔ norm(y)))
+//    law upperBound(⊔: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
+//        let ⊑ = leq;
+//            ∀(x: IntervalInf, y: IntervalInf).
+//                (norm(x) ⊑ (norm(x) ⊔ norm(y))) ∧ (norm(y) ⊑ (norm(x) ⊔ norm(y)))
 
-    law leastUpperBound(⊔: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
-        let ⊑ = leq;
-            ∀(x: IntervalInf, y: IntervalInf, z: IntervalInf).
-                ((norm(x) ⊑ norm(z)) ∧ (norm(y) ⊑ norm(z))) → ((norm(x) ⊔ norm(y)) ⊑ norm(z))
+//    law leastUpperBound(⊔: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
+//        let ⊑ = leq;
+//            ∀(x: IntervalInf, y: IntervalInf, z: IntervalInf).
+//                ((norm(x) ⊑ norm(z)) ∧ (norm(y) ⊑ norm(z))) → ((norm(x) ⊔ norm(y)) ⊑ norm(z))
 
-    law lowerBound(⊓: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
-        let ⊑ = leq;
-            ∀(x: IntervalInf, y: IntervalInf).
-                ((norm(x) ⊓ norm(y)) ⊑ norm(x)) ∧ ((norm(x) ⊓ norm(y)) ⊑ norm(y))
+//    law lowerBound(⊓: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
+//        let ⊑ = leq;
+//            ∀(x: IntervalInf, y: IntervalInf).
+//                ((norm(x) ⊓ norm(y)) ⊑ norm(x)) ∧ ((norm(x) ⊓ norm(y)) ⊑ norm(y))
 
-    law greatestLowerBound(⊓: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
-        let ⊑ = leq;
-            ∀(x: IntervalInf, y: IntervalInf, z: IntervalInf).
-                    ((norm(z) ⊑ norm(x)) ∧ (norm(z) ⊑ norm(y))) → (norm(z) ⊑ (norm(x) ⊓ norm(y)))
+//    law greatestLowerBound(⊓: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
+//        let ⊑ = leq;
+//            ∀(x: IntervalInf, y: IntervalInf, z: IntervalInf).
+//                    ((norm(z) ⊑ norm(x)) ∧ (norm(z) ⊑ norm(y))) → (norm(z) ⊑ (norm(x) ⊓ norm(y)))
 
-    law leastElement(⊑: (IntervalInf, IntervalInf) -> Bool, ⊥: IntervalInf): Bool =
-        ∀(x: IntervalInf). ⊥ ⊑ norm(x)
+//    law leastElement(⊑: (IntervalInf, IntervalInf) -> Bool, ⊥: IntervalInf): Bool =
+//        ∀(x: IntervalInf). ⊥ ⊑ norm(x)
 
-    law greatestElement(⊑: (IntervalInf, IntervalInf) -> Bool, ⊤: IntervalInf): Bool =
-        ∀(x: IntervalInf). norm(x) ⊑ ⊤
+//    law greatestElement(⊑: (IntervalInf, IntervalInf) -> Bool, ⊤: IntervalInf): Bool =
+//        ∀(x: IntervalInf). norm(x) ⊑ ⊤
 
-    law associative(f: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
-        ∀(x: IntervalInf, y: IntervalInf, z: IntervalInf).
-                f(norm(x), f(norm(y), norm(z))) == f(f(norm(x), norm(y)), norm(z))
+//    law associative(f: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
+//        ∀(x: IntervalInf, y: IntervalInf, z: IntervalInf).
+//                f(norm(x), f(norm(y), norm(z))) == f(f(norm(x), norm(y)), norm(z))
 
-    law commutative(f: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
-        ∀(x: IntervalInf, y: IntervalInf).
-            f(norm(x), norm(y)) == f(norm(y), norm(x))
+//    law commutative(f: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
+//        ∀(x: IntervalInf, y: IntervalInf).
+//            f(norm(x), norm(y)) == f(norm(y), norm(x))
 
-    law strict1(f: IntervalInf -> IntervalInf): Bool =
-        f(Bot) == Bot
+//    law strict1(f: IntervalInf -> IntervalInf): Bool =
+//        f(Bot) == Bot
 
-    law strict2(f: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
-        f(Bot, Bot) == Bot
+//    law strict2(f: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
+//        f(Bot, Bot) == Bot
 
-    law monotone1(f: IntervalInf -> IntervalInf): Bool =
-        let ⊑ = leq;
-            ∀(x: IntervalInf, y: IntervalInf).
-                (norm(x) ⊑ norm(y)) → (f(norm(x)) ⊑ f(norm(y)))
+//    law monotone1(f: IntervalInf -> IntervalInf): Bool =
+//        let ⊑ = leq;
+//            ∀(x: IntervalInf, y: IntervalInf).
+//                (norm(x) ⊑ norm(y)) → (f(norm(x)) ⊑ f(norm(y)))
 
-    law monotone2(f: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
-        let ⊑ = leq;
-            ∀(x1: IntervalInf, x2: IntervalInf, y1: IntervalInf, y2: IntervalInf).
-                    ((norm(x1) ⊑ norm(y1)) ∧ (norm(x2) ⊑ norm(y2))) → (f(norm(x1), norm(x2)) ⊑ f(norm(y1), norm(y2)))
+//    law monotone2(f: (IntervalInf, IntervalInf) -> IntervalInf): Bool =
+//        let ⊑ = leq;
+//            ∀(x1: IntervalInf, x2: IntervalInf, y1: IntervalInf, y2: IntervalInf).
+//                    ((norm(x1) ⊑ norm(y1)) ∧ (norm(x2) ⊑ norm(y2))) → (f(norm(x1), norm(x2)) ⊑ f(norm(y1), norm(y2)))
 
-    law safe1(fa: IntervalInf -> IntervalInf, fc: BigInt -> BigInt): Bool =
-        ∀(x: BigInt). alpha(fc(x)) `leq` fa(alpha(x))
+//    law safe1(fa: IntervalInf -> IntervalInf, fc: BigInt -> BigInt): Bool =
+//        ∀(x: BigInt). alpha(fc(x)) `leq` fa(alpha(x))
 
-    law safe2(fa: (IntervalInf, IntervalInf) -> IntervalInf, fc: (BigInt, BigInt) -> BigInt): Bool =
-        ∀(x: BigInt, y: BigInt). alpha(fc(x, y)) `leq` fa(alpha(x), alpha(y))
+//    law safe2(fa: (IntervalInf, IntervalInf) -> IntervalInf, fc: (BigInt, BigInt) -> BigInt): Bool =
+//        ∀(x: BigInt, y: BigInt). alpha(fc(x, y)) `leq` fa(alpha(x), alpha(y))
 
     // ------------------------------------------------------------------------
     // Specialized Laws for IntervalInf/Belnap.
     // ------------------------------------------------------------------------
 
-    law commutativeBelnap(f: (IntervalInf, IntervalInf) -> Belnap.Belnap): Bool =
-        ∀(x: IntervalInf, y: IntervalInf).
-            f(norm(x), norm(y)) == f(norm(y), norm(x))
+//    law commutativeBelnap(f: (IntervalInf, IntervalInf) -> Belnap.Belnap): Bool =
+//        ∀(x: IntervalInf, y: IntervalInf).
+//            f(norm(x), norm(y)) == f(norm(y), norm(x))
 
-    law monotoneBelnap2(f: (IntervalInf, IntervalInf) -> Belnap.Belnap): Bool =
-        let ⊑ = leq;
-            ∀(x1: IntervalInf, x2: IntervalInf, y1: IntervalInf, y2: IntervalInf).
-                    ((norm(x1) ⊑ norm(y1)) ∧ (norm(x2) ⊑ norm(y2))) → (f(norm(x1), norm(x2)) `Belnap.leq` f(norm(y1), norm(y2)))
+//    law monotoneBelnap2(f: (IntervalInf, IntervalInf) -> Belnap.Belnap): Bool =
+//        let ⊑ = leq;
+//            ∀(x1: IntervalInf, x2: IntervalInf, y1: IntervalInf, y2: IntervalInf).
+//                    ((norm(x1) ⊑ norm(y1)) ∧ (norm(x2) ⊑ norm(y2))) → (f(norm(x1), norm(x2)) `Belnap.leq` f(norm(y1), norm(y2)))
 
-    law safeBelnap2(fa: (IntervalInf, IntervalInf) -> Belnap.Belnap, fc: (BigInt, BigInt) -> Bool): Bool =
-        ∀(x: BigInt, y: BigInt). Belnap.alpha(fc(x, y)) `Belnap.leq` fa(alpha(x), alpha(y))
+//    law safeBelnap2(fa: (IntervalInf, IntervalInf) -> Belnap.Belnap, fc: (BigInt, BigInt) -> Bool): Bool =
+//        ∀(x: BigInt, y: BigInt). Belnap.alpha(fc(x, y)) `Belnap.leq` fa(alpha(x), alpha(y))
 
 }

--- a/examples/domains/Mod3.flix
+++ b/examples/domains/Mod3.flix
@@ -30,7 +30,7 @@ namespace Domain/Mod3 {
     ///
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
-    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
+//    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
     pub def leq(e1: Mod3, e2: Mod3): Bool = match (e1, e2) {
         case (Bot, _)   => true
         case (Zer, Zer) => true
@@ -43,7 +43,7 @@ namespace Domain/Mod3 {
     ///
     /// Returns the least upper bound of `e1` and `e2`.
     ///
-    #upperBound #leastUpperBound #commutative #associative
+//    #upperBound #leastUpperBound #commutative #associative
     pub def lub(e1: Mod3, e2: Mod3): Mod3 = match (e1, e2) {
         case (Bot, x)   => x
         case (x, Bot)   => x
@@ -56,7 +56,7 @@ namespace Domain/Mod3 {
     ///
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
-    #lowerBound #greatestLowerBound #commutative #associative
+//    #lowerBound #greatestLowerBound #commutative #associative
     pub def glb(e1: Mod3, e2: Mod3): Mod3 = match (e1, e2) {
         case (Top, x)   => x
         case (x, Top)   => x
@@ -69,7 +69,7 @@ namespace Domain/Mod3 {
     ///
     /// The lattice height function.
     ///
-    #nonNegative
+//    #nonNegative
     pub def height(e: Mod3): BigInt = match e {
         case Top    => 0ii
         case Zer    => 1ii
@@ -91,8 +91,8 @@ namespace Domain/Mod3 {
     ///
     /// Over-approximates integer `increment`.
     ///
-    #safe1(x -> x + 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x + 1ii)
+//    #strict1 #monotone1
     pub def inc(e: Mod3): Mod3 = match e {
        case Bot => Bot
        case Zer => One
@@ -104,8 +104,8 @@ namespace Domain/Mod3 {
     ///
     /// Over-approximates integer `decrement`.
     ///
-    #safe1(x -> x - 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x - 1ii)
+//    #strict1 #monotone1
     pub def dec(e: Mod3): Mod3 = match e {
        case Bot => Bot
        case Zer => Two
@@ -117,8 +117,8 @@ namespace Domain/Mod3 {
     ///
     /// Over-approximates integer `addition`.
     ///
-    #safe2((x, y) -> x + y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x + y)
+//    #strict2 #monotone2 #commutative #associative
     pub def plus(e1: Mod3, e2: Mod3): Mod3 = match (e1, e2) {
        case (_, Bot)   => Bot
        case (Bot, _)   => Bot
@@ -134,8 +134,8 @@ namespace Domain/Mod3 {
     ///
     /// Over-approximates integer `subtraction`.
     ///
-    #safe2((x, y) -> x - y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x - y)
+//    #strict2 #monotone2
     pub def minus(e1: Mod3, e2: Mod3): Mod3 = match (e1, e2) {
        case (_, Bot)   => Bot
        case (Bot, _)   => Bot
@@ -155,7 +155,7 @@ namespace Domain/Mod3 {
     /// Over-approximates integer `multiplication`.
     ///
     /* unknown #safe2((x, y) -> x * y) */
-    #strict2 #monotone2 #commutative #associative
+//    #strict2 #monotone2 #commutative #associative
     pub def times(e1: Mod3, e2: Mod3): Mod3 = match (e1, e2) {
         case (_, Bot)   => Bot
         case (Bot, _)   => Bot
@@ -167,10 +167,10 @@ namespace Domain/Mod3 {
     ///
     /// Over-approximates `equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x == y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #PartialOrder.safe2((x, y) -> x == y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def eq(e1: Mod3, e2: Mod3): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)   => Belnap/Belnap.Bot
         case (_, Bot)   => Belnap/Belnap.Bot
@@ -185,18 +185,18 @@ namespace Domain/Mod3 {
 
     ///
     /// Over-approximates `not equal`.
-    #PartialOrder.safe2((x, y) -> x != y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #PartialOrder.safe2((x, y) -> x != y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def neq(e1: Mod3, e2: Mod3): Belnap.Belnap = Belnap.not(eq(e1, e2))
 
     ///
     /// Over-approximates `less than`.
     ///
-    #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
     pub def less(e1: Mod3, e2: Mod3): Belnap.Belnap = match (e1, e2) {
         case (Bot, _) => Belnap/Belnap.Bot
         case (_, Bot) => Belnap/Belnap.Bot
@@ -206,37 +206,37 @@ namespace Domain/Mod3 {
     ///
     /// Over-approximates `less than or equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x <= y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #PartialOrder.safe2((x, y) -> x <= y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
     pub def lessEqual(e1: Mod3, e2: Mod3): Belnap.Belnap = Belnap.or(e1 `less` e2, e1 `eq` e2)
 
     //
     // ## Specialized Laws
     //
 
-    law upperBound(lub: (Mod3, Mod3) -> Mod3): Bool = JoinLattice.leastUpperBound1(leq, lub)
+//    law upperBound(lub: (Mod3, Mod3) -> Mod3): Bool = JoinLattice.leastUpperBound1(leq, lub)
 
-    law leastUpperBound(lub: (Mod3, Mod3) -> Mod3): Bool = JoinLattice.leastUpperBound2(leq, lub)
+//    law leastUpperBound(lub: (Mod3, Mod3) -> Mod3): Bool = JoinLattice.leastUpperBound2(leq, lub)
 
-    law lowerBound(glb: (Mod3, Mod3) -> Mod3): Bool = MeetLattice.greatestLowerBound1(leq, glb)
+//    law lowerBound(glb: (Mod3, Mod3) -> Mod3): Bool = MeetLattice.greatestLowerBound1(leq, glb)
 
-    law greatestLowerBound(glb: (Mod3, Mod3) -> Mod3): Bool = MeetLattice.greatestLowerBound2(leq, glb)
+//    law greatestLowerBound(glb: (Mod3, Mod3) -> Mod3): Bool = MeetLattice.greatestLowerBound2(leq, glb)
 
-    law leastElement(leq: (Mod3, Mod3) -> Bool, bot: Mod3): Bool = Bounded.leastElement(bot, leq)
+//    law leastElement(leq: (Mod3, Mod3) -> Bool, bot: Mod3): Bool = Bounded.leastElement(bot, leq)
 
-    law greatestElement(leq: (Mod3, Mod3) -> Bool, top: Mod3): Bool = Bounded.greatestElement(top, leq)
+//    law greatestElement(leq: (Mod3, Mod3) -> Bool, top: Mod3): Bool = Bounded.greatestElement(top, leq)
 
-    law strict1(f: Mod3 -> Mod3): Bool = Bounded.strict1(f, Bot, Bot)
+//    law strict1(f: Mod3 -> Mod3): Bool = Bounded.strict1(f, Bot, Bot)
 
-    law strict2(f: (Mod3, Mod3) -> Mod3): Bool = Bounded.strict2(f, Bot, Bot, Bot)
+//    law strict2(f: (Mod3, Mod3) -> Mod3): Bool = Bounded.strict2(f, Bot, Bot, Bot)
     
-    law monotone1(f: Mod3 -> Mod3): Bool = PartialOrder.monotone1(f, leq, leq)
+//    law monotone1(f: Mod3 -> Mod3): Bool = PartialOrder.monotone1(f, leq, leq)
 
-    law monotone2(f: (Mod3, Mod3) -> Mod3): Bool = PartialOrder.monotone2(f, leq, leq, leq)
+//    law monotone2(f: (Mod3, Mod3) -> Mod3): Bool = PartialOrder.monotone2(f, leq, leq, leq)
 
-    law safe1(fa: Mod3 -> Mod3, fc: BigInt -> BigInt): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
+//    law safe1(fa: Mod3 -> Mod3, fc: BigInt -> BigInt): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
 
-    law safe2(fa: (Mod3, Mod3) -> Mod3, fc: (BigInt, BigInt) -> BigInt): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
+//    law safe2(fa: (Mod3, Mod3) -> Mod3, fc: (BigInt, BigInt) -> BigInt): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
 
 }

--- a/examples/domains/Parity.flix
+++ b/examples/domains/Parity.flix
@@ -27,7 +27,7 @@ namespace Domain/Parity {
     ///
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
-    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
+//    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
     pub def leq(e1: Parity, e2: Parity): Bool = match (e1, e2) {
         case (Bot, _)       => true
         case (Odd, Odd)     => true
@@ -39,7 +39,7 @@ namespace Domain/Parity {
     ///
     /// Returns the least upper bound of `e1` and `e2`.
     ///
-    #commutative #associative #upperBound #leastUpperBound
+//    #commutative #associative #upperBound #leastUpperBound
     pub def lub(e1: Parity, e2: Parity): Parity = match (e1, e2) {
         case (Bot, x)       => x
         case (x, Bot)       => x
@@ -51,7 +51,7 @@ namespace Domain/Parity {
     ///
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
-    #commutative #associative #lowerBound #greatestLowerBound
+//    #commutative #associative #lowerBound #greatestLowerBound
     pub def glb(e1: Parity, e2: Parity): Parity = match (e1, e2) {
         case (Top, x)       => x
         case (x, Top)       => x
@@ -63,7 +63,7 @@ namespace Domain/Parity {
     ///
     /// The lattice height function.
     ///
-    #nonNegative
+//    #nonNegative
     pub def height(e: Parity): BigInt = match e {
         case Top    => 0ii
         case Odd    => 1ii
@@ -79,8 +79,8 @@ namespace Domain/Parity {
     ///
     /// Over-approximates integer `increment`.
     ///
-    #safe1(x -> x + 1)
-    #strict1 #monotone1
+//    #safe1(x -> x + 1)
+//    #strict1 #monotone1
     pub def inc(e: Parity): Parity = match e {
         case Bot  => Bot
         case Odd  => Even
@@ -91,8 +91,8 @@ namespace Domain/Parity {
     ///
     /// Over-approximates integer `decrement`.
     ///
-    #safe1(x -> x - 1)
-    #strict1 #monotone1
+//    #safe1(x -> x - 1)
+//    #strict1 #monotone1
     pub def dec(e: Parity): Parity = match e {
         case Bot  => Bot
         case Odd  => Even
@@ -103,8 +103,8 @@ namespace Domain/Parity {
     ///
     /// Over-approximates integer `addition`.
     ///
-    #safe2((x, y) -> x + y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x + y)
+//    #strict2 #monotone2 #commutative #associative
     pub def plus(e1: Parity, e2: Parity): Parity = match (e1, e2) {
         case (_, Bot)       => Bot
         case (Bot, _)       => Bot
@@ -118,8 +118,8 @@ namespace Domain/Parity {
     ///
     /// Over-approximates integer `subtraction`.
     ///
-    #safe2((x, y) -> x - y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x - y)
+//    #strict2 #monotone2
     pub def minus(e1: Parity, e2: Parity): Parity = match (e1, e2) {
         case (_, Bot)       => Bot
         case (Bot, _)       => Bot
@@ -133,8 +133,8 @@ namespace Domain/Parity {
     ///
     /// Over-approximates integer `multiplication`.
     ///
-    #safe2((x, y) -> x * y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x * y)
+//    #strict2 #monotone2 #commutative #associative
     pub def times(e1: Parity, e2: Parity): Parity = match (e1, e2) {
         case (_, Bot)       => Bot
         case (Bot, _)       => Bot
@@ -148,8 +148,8 @@ namespace Domain/Parity {
     ///
     /// Over-approximates integer `division`.
     ///
-    #safe2((x, y) -> x / y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x / y)
+//    #strict2 #monotone2
     pub def divide(e1: Parity, e2: Parity): Parity = match (e1, e2) {
        case (_, Bot)    => Bot
        case (Bot, _)    => Bot
@@ -159,8 +159,8 @@ namespace Domain/Parity {
     ///
     /// Over-approximates integer `modulus`.
     ///
-    #safe2((x, y) -> x % y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x % y)
+//    #strict2 #monotone2
     pub def modulo(e1: Parity, e2: Parity): Parity = match (e1, e2) {
        case (_, Bot)        => Bot
        case (Bot, _)        => Bot
@@ -174,8 +174,8 @@ namespace Domain/Parity {
     ///
     /// Over-approximates `bitwise negation`.
     ///
-    #safe1(x -> ~~~x)
-    #strict1 #monotone1
+//    #safe1(x -> ~~~x)
+//    #strict1 #monotone1
     pub def negate(e: Parity): Parity = match e {
         case Bot    => Bot
         case Odd    => Even
@@ -186,8 +186,8 @@ namespace Domain/Parity {
     ///
     /// Over-approximates `bitwise and`.
     ///
-    #safe2((x, y) -> x &&& y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x &&& y)
+//    #strict2 #monotone2 #commutative #associative
     pub def and(e1: Parity, e2: Parity): Parity = match (e1, e2) {
        case (_, Bot)        => Bot
        case (Bot, _)        => Bot
@@ -201,8 +201,8 @@ namespace Domain/Parity {
     ///
     /// Over-approximates `bitwise or`.
     ///
-    #safe2((x, y) -> x ||| y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x ||| y)
+//    #strict2 #monotone2 #commutative #associative
     pub def or(e1: Parity, e2: Parity): Parity = match (e1, e2) {
       case (_, Bot)         => Bot
       case (Bot, _)         => Bot
@@ -216,8 +216,8 @@ namespace Domain/Parity {
     ///
     /// Over-approximates `bitwise xor`.
     ///
-    #safe2((x, y) -> x ^^^ y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x ^^^ y)
+//    #strict2 #monotone2 #commutative #associative
     pub def xor(e1: Parity, e2: Parity): Parity = match (e1, e2) {
       case (_, Bot)         => Bot
       case (Bot, _)         => Bot
@@ -231,8 +231,8 @@ namespace Domain/Parity {
     ///
     /// Over-approximates `bitwise left shift`.
     ///
-    #safe2((x, y) -> x <<< y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x <<< y)
+//    #strict2 #monotone2
     pub def leftShift(e1: Parity, e2: Parity): Parity = match (e1, e2) {
       case (_, Bot)         => Bot
       case (Bot, _)         => Bot
@@ -246,8 +246,8 @@ namespace Domain/Parity {
     ///
     /// Over-approximates `bitwise right shift`.
     ///
-    #safe2((x, y) -> x >>> y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x >>> y)
+//    #strict2 #monotone2
     pub def rightShift(e1: Parity, e2: Parity): Parity = match (e1, e2) {
       case (_, Bot)     => Bot
       case (Bot, _)     => Bot
@@ -257,10 +257,10 @@ namespace Domain/Parity {
     ///
     /// Over-approximates `equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x == y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #PartialOrder.safe2((x, y) -> x == y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def eq(e1: Parity, e2: Parity): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)       => Belnap/Belnap.Bot
         case (_, Bot)       => Belnap/Belnap.Bot
@@ -272,18 +272,18 @@ namespace Domain/Parity {
     ///
     /// Over-approximates `not equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x != y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #PartialOrder.safe2((x, y) -> x != y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def neq(e1: Parity, e2: Parity): Belnap.Belnap = Belnap.not(eq(e1, e2))
 
     ///
     /// Over-approximates `less than`.
     ///
-    #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
     pub def less(e1: Parity, e2: Parity): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)   => Belnap/Belnap.Bot
         case (_, Bot)   => Belnap/Belnap.Bot
@@ -293,37 +293,37 @@ namespace Domain/Parity {
     ///
     /// Over-approximates `less than or equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x <= y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #PartialOrder.safe2((x, y) -> x <= y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
     pub def lessEqual(e1: Parity, e2: Parity): Belnap.Belnap = Belnap.or(e1 `less` e2, e1 `eq` e2)
 
     //
     // ## Specialized Laws
     //
 
-    law upperBound(lub: (Parity, Parity) -> Parity): Bool = JoinLattice.leastUpperBound1(leq, lub)
+//    law upperBound(lub: (Parity, Parity) -> Parity): Bool = JoinLattice.leastUpperBound1(leq, lub)
 
-    law leastUpperBound(lub: (Parity, Parity) -> Parity): Bool = JoinLattice.leastUpperBound2(leq, lub)
+//    law leastUpperBound(lub: (Parity, Parity) -> Parity): Bool = JoinLattice.leastUpperBound2(leq, lub)
 
-    law lowerBound(glb: (Parity, Parity) -> Parity): Bool = MeetLattice.greatestLowerBound1(leq, glb)
+//    law lowerBound(glb: (Parity, Parity) -> Parity): Bool = MeetLattice.greatestLowerBound1(leq, glb)
 
-    law greatestLowerBound(glb: (Parity, Parity) -> Parity): Bool = MeetLattice.greatestLowerBound2(leq, glb)
+//    law greatestLowerBound(glb: (Parity, Parity) -> Parity): Bool = MeetLattice.greatestLowerBound2(leq, glb)
 
-    law leastElement(leq: (Parity, Parity) -> Bool, bot: Parity): Bool = Bounded.leastElement(bot, leq)
+//    law leastElement(leq: (Parity, Parity) -> Bool, bot: Parity): Bool = Bounded.leastElement(bot, leq)
 
-    law greatestElement(leq: (Parity, Parity) -> Bool, top: Parity): Bool = Bounded.greatestElement(top, leq)
+//    law greatestElement(leq: (Parity, Parity) -> Bool, top: Parity): Bool = Bounded.greatestElement(top, leq)
 
-    law strict1(f: Parity -> Parity): Bool = Bounded.strict1(f, Bot, Bot)
+//    law strict1(f: Parity -> Parity): Bool = Bounded.strict1(f, Bot, Bot)
 
-    law strict2(f: (Parity, Parity) -> Parity): Bool = Bounded.strict2(f, Bot, Bot, Bot)
+//    law strict2(f: (Parity, Parity) -> Parity): Bool = Bounded.strict2(f, Bot, Bot, Bot)
 
-    law monotone1(f: Parity -> Parity): Bool = PartialOrder.monotone1(f, leq, leq)
+//    law monotone1(f: Parity -> Parity): Bool = PartialOrder.monotone1(f, leq, leq)
 
-    law monotone2(f: (Parity, Parity) -> Parity): Bool = PartialOrder.monotone2(f, leq, leq, leq)
+//    law monotone2(f: (Parity, Parity) -> Parity): Bool = PartialOrder.monotone2(f, leq, leq, leq)
 
-    law safe1(fa: Parity -> Parity, fc: Int -> Int): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
+//    law safe1(fa: Parity -> Parity, fc: Int -> Int): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
 
-    law safe2(fa: (Parity, Parity) -> Parity, fc: (Int, Int) -> Int): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
+//    law safe2(fa: (Parity, Parity) -> Parity, fc: (Int, Int) -> Int): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
 
 }

--- a/examples/domains/PrefixSuffix.flix
+++ b/examples/domains/PrefixSuffix.flix
@@ -28,7 +28,7 @@ namespace Domain/PrefixSuffix {
     ///
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
-    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
+//    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
     pub def leq(e1: PrefixSuffix, e2: PrefixSuffix): Bool = match (e1, e2) {
         case (Bot, _)                           => true
         case (PreSuf(p1, s1), PreSuf(p2, s2))   => p1 == p2 and s1 == s2
@@ -43,7 +43,7 @@ namespace Domain/PrefixSuffix {
     ///
     /// Returns the least upper bound of `e1` and `e2`.
     ///
-    #upperBound #leastUpperBound #commutative #associative
+//    #upperBound #leastUpperBound #commutative #associative
     pub def lub(e1: PrefixSuffix, e2: PrefixSuffix): PrefixSuffix = match (e1, e2) {
         case (Bot, x)                           => x
         case (x, Bot)                           => x
@@ -65,7 +65,7 @@ namespace Domain/PrefixSuffix {
     ///
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
-    #lowerBound #greatestLowerBound #commutative #associative
+//    #lowerBound #greatestLowerBound #commutative #associative
     pub def glb(e1: PrefixSuffix, e2: PrefixSuffix): PrefixSuffix = match (e1, e2) {
         case (Top, x)                           => x
         case (x, Top)                           => x
@@ -84,7 +84,7 @@ namespace Domain/PrefixSuffix {
     ///
     /// The lattice height function.
     ///
-    #nonNegative #decreasing(equ, leq)
+//    #nonNegative #decreasing(equ, leq)
     pub def height(e: PrefixSuffix): BigInt = match e {
         case Top            => 0ii
         case Pre(_)         => 1ii
@@ -96,7 +96,7 @@ namespace Domain/PrefixSuffix {
     ///
     /// Over-approximates `concatenate`.
     ///
-    #strict2 #monotone2 #associative
+//    #strict2 #monotone2 #associative
     pub def concatenate(e1: PrefixSuffix, e2: PrefixSuffix): PrefixSuffix = match (e1, e2) {
         case (Bot, _)                       => Bot
         case (_, Bot)                       => Bot
@@ -119,9 +119,9 @@ namespace Domain/PrefixSuffix {
     ///
     /// Over-approximates `equal`.
     ///
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def eq(e1: PrefixSuffix, e2: PrefixSuffix): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)            => Belnap/Belnap.Bot
         case (_, Bot)            => Belnap/Belnap.Bot
@@ -142,33 +142,33 @@ namespace Domain/PrefixSuffix {
     ///
     /// Over-approximates `not equal`.
     ///
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def neq(e1: PrefixSuffix, e2: PrefixSuffix): Belnap.Belnap = Belnap.not(eq(e1, e2))
 
     //
     // ## Specialized Laws
     //
 
-    law upperBound(lub: (PrefixSuffix, PrefixSuffix) -> PrefixSuffix): Bool = JoinLattice.leastUpperBound1(leq, lub)
+//    law upperBound(lub: (PrefixSuffix, PrefixSuffix) -> PrefixSuffix): Bool = JoinLattice.leastUpperBound1(leq, lub)
 
-    law leastUpperBound(lub: (PrefixSuffix, PrefixSuffix) -> PrefixSuffix): Bool = JoinLattice.leastUpperBound2(leq, lub)
+//    law leastUpperBound(lub: (PrefixSuffix, PrefixSuffix) -> PrefixSuffix): Bool = JoinLattice.leastUpperBound2(leq, lub)
 
-    law lowerBound(glb: (PrefixSuffix, PrefixSuffix) -> PrefixSuffix): Bool = MeetLattice.greatestLowerBound1(leq, glb)
+//    law lowerBound(glb: (PrefixSuffix, PrefixSuffix) -> PrefixSuffix): Bool = MeetLattice.greatestLowerBound1(leq, glb)
 
-    law greatestLowerBound(glb: (PrefixSuffix, PrefixSuffix) -> PrefixSuffix): Bool = MeetLattice.greatestLowerBound2(leq, glb)
+//    law greatestLowerBound(glb: (PrefixSuffix, PrefixSuffix) -> PrefixSuffix): Bool = MeetLattice.greatestLowerBound2(leq, glb)
 
-    law leastElement(leq: (PrefixSuffix, PrefixSuffix) -> Bool, bot: PrefixSuffix): Bool = Bounded.leastElement(bot, leq)
+//    law leastElement(leq: (PrefixSuffix, PrefixSuffix) -> Bool, bot: PrefixSuffix): Bool = Bounded.leastElement(bot, leq)
 
-    law greatestElement(leq: (PrefixSuffix, PrefixSuffix) -> Bool, top: PrefixSuffix): Bool = Bounded.greatestElement(top, leq)
+//    law greatestElement(leq: (PrefixSuffix, PrefixSuffix) -> Bool, top: PrefixSuffix): Bool = Bounded.greatestElement(top, leq)
 
-    law strict1(f: PrefixSuffix -> PrefixSuffix): Bool = Bounded.strict1(f, Bot, Bot)
+//    law strict1(f: PrefixSuffix -> PrefixSuffix): Bool = Bounded.strict1(f, Bot, Bot)
 
-    law strict2(f: (PrefixSuffix, PrefixSuffix) -> PrefixSuffix): Bool = Bounded.strict2(f, Bot, Bot, Bot)
+//    law strict2(f: (PrefixSuffix, PrefixSuffix) -> PrefixSuffix): Bool = Bounded.strict2(f, Bot, Bot, Bot)
 
-    law monotone1(f: PrefixSuffix -> PrefixSuffix): Bool = PartialOrder.monotone1(f, leq, leq)
+//    law monotone1(f: PrefixSuffix -> PrefixSuffix): Bool = PartialOrder.monotone1(f, leq, leq)
 
-    law monotone2(f: (PrefixSuffix, PrefixSuffix) -> PrefixSuffix): Bool = PartialOrder.monotone2(f, leq, leq, leq)
+//    law monotone2(f: (PrefixSuffix, PrefixSuffix) -> PrefixSuffix): Bool = PartialOrder.monotone2(f, leq, leq, leq)
 
 }

--- a/examples/domains/Sign.flix
+++ b/examples/domains/Sign.flix
@@ -34,7 +34,7 @@ namespace Domain/Sign {
     ///
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
-    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
+//    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
     pub def leq(e1: Sign, e2: Sign): Bool = match (e1, e2) {
         case (Bot, _)   => true
         case (Zer, Zer) => true
@@ -49,7 +49,7 @@ namespace Domain/Sign {
     ///
     /// Returns the least upper bound of `e1` and `e2`.
     ///
-    #upperBound #leastUpperBound #commutative #associative
+//    #upperBound #leastUpperBound #commutative #associative
     pub def lub(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, x)   => x
         case (x, Bot)   => x
@@ -66,7 +66,7 @@ namespace Domain/Sign {
     ///
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
-    #lowerBound #greatestLowerBound #commutative #associative
+//    #lowerBound #greatestLowerBound #commutative #associative
     pub def glb(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Top, x)   => x
         case (x, Top)   => x
@@ -87,7 +87,7 @@ namespace Domain/Sign {
     ///
     /// The lattice height function.
     ///
-    #nonNegative
+//    #nonNegative
     pub def height(e: Sign): BigInt = match e {
         case Top    => 0ii
         case Pos    => 1ii
@@ -108,8 +108,8 @@ namespace Domain/Sign {
     ///
     /// Over-approximates integer `increment`.
     ///
-    #safe1(x -> x + 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x + 1ii)
+//    #strict1 #monotone1
     pub def inc(e: Sign): Sign = match e {
         case Bot => Bot
         case Neg => Top
@@ -121,8 +121,8 @@ namespace Domain/Sign {
     ///
     /// Over-approximates integer `decrement`.
     ///
-    #safe1(x -> x - 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x - 1ii)
+//    #strict1 #monotone1
     pub def dec(e: Sign): Sign = match e {
         case Bot => Bot
         case Neg => Neg
@@ -134,8 +134,8 @@ namespace Domain/Sign {
     ///
     /// Over-approximates integer `addition`.
     ///
-    #safe2((x, y) -> x + y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x + y)
+//    #strict2 #monotone2 #commutative #associative
     pub def plus(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, _) => Bot
         case (_, Bot) => Bot
@@ -154,8 +154,8 @@ namespace Domain/Sign {
     ///
     /// Over-approximates integer `subtraction`.
     ///
-    #safe2((x, y) -> x - y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x - y)
+//    #strict2 #monotone2
     pub def minus(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, _)   => Bot
         case (_, Bot)   => Bot
@@ -174,8 +174,8 @@ namespace Domain/Sign {
     ///
     /// Over-approximates integer `multiplication`.
     ///
-    #safe2((x, y) -> x * y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x * y)
+//    #strict2 #monotone2
     pub def times(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, _)   => Bot
         case (_, Bot)   => Bot
@@ -195,10 +195,10 @@ namespace Domain/Sign {
     ///
     /// Over-approximates `equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x == y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #PartialOrder.safe2((x, y) -> x == y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def eq(e1: Sign, e2: Sign): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)   => Belnap/Belnap.Bot
         case (_, Bot)   => Belnap/Belnap.Bot
@@ -209,18 +209,18 @@ namespace Domain/Sign {
     ///
     /// Over-approximates `not equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x != y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #PartialOrder.safe2((x, y) -> x != y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def neq(e1: Sign, e2: Sign): Belnap.Belnap = Belnap.not(eq(e1, e2))
 
     ///
     /// Over-approximates `less than`.
     ///
-    #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
     pub def less(e1: Sign, e2: Sign): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)   => Belnap/Belnap.Bot
         case (_, Bot)   => Belnap/Belnap.Bot
@@ -231,37 +231,37 @@ namespace Domain/Sign {
     ///
     /// Over-approximates `less than or equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x <= y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #PartialOrder.safe2((x, y) -> x <= y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
     pub def lessEqual(e1: Sign, e2: Sign): Belnap.Belnap = Belnap.or(e1 `less` e2, e1 `eq` e2)
 
     //
     // ## Specialized Laws
     //
 
-    law upperBound(lub: (Sign, Sign) -> Sign): Bool = JoinLattice.leastUpperBound1(leq, lub)
+//    law upperBound(lub: (Sign, Sign) -> Sign): Bool = JoinLattice.leastUpperBound1(leq, lub)
 
-    law leastUpperBound(lub: (Sign, Sign) -> Sign): Bool = JoinLattice.leastUpperBound2(leq, lub)
+//    law leastUpperBound(lub: (Sign, Sign) -> Sign): Bool = JoinLattice.leastUpperBound2(leq, lub)
 
-    law lowerBound(glb: (Sign, Sign) -> Sign): Bool = MeetLattice.greatestLowerBound1(leq, glb)
+//    law lowerBound(glb: (Sign, Sign) -> Sign): Bool = MeetLattice.greatestLowerBound1(leq, glb)
 
-    law greatestLowerBound(glb: (Sign, Sign) -> Sign): Bool = MeetLattice.greatestLowerBound2(leq, glb)
+//    law greatestLowerBound(glb: (Sign, Sign) -> Sign): Bool = MeetLattice.greatestLowerBound2(leq, glb)
 
-    law leastElement(leq: (Sign, Sign) -> Bool, bot: Sign): Bool = Bounded.leastElement(bot, leq)
+//    law leastElement(leq: (Sign, Sign) -> Bool, bot: Sign): Bool = Bounded.leastElement(bot, leq)
 
-    law greatestElement(leq: (Sign, Sign) -> Bool, top: Sign): Bool = Bounded.greatestElement(top, leq)
+//    law greatestElement(leq: (Sign, Sign) -> Bool, top: Sign): Bool = Bounded.greatestElement(top, leq)
 
-    law strict1(f: Sign -> Sign): Bool = Bounded.strict1(f, Bot, Bot)
+//    law strict1(f: Sign -> Sign): Bool = Bounded.strict1(f, Bot, Bot)
 
-    law strict2(f: (Sign, Sign) -> Sign): Bool = Bounded.strict2(f, Bot, Bot, Bot)
+//    law strict2(f: (Sign, Sign) -> Sign): Bool = Bounded.strict2(f, Bot, Bot, Bot)
 
-    law monotone1(f: Sign -> Sign): Bool = PartialOrder.monotone1(f, leq, leq)
+//    law monotone1(f: Sign -> Sign): Bool = PartialOrder.monotone1(f, leq, leq)
 
-    law monotone2(f: (Sign, Sign) -> Sign): Bool = PartialOrder.monotone2(f, leq, leq, leq)
+//    law monotone2(f: (Sign, Sign) -> Sign): Bool = PartialOrder.monotone2(f, leq, leq, leq)
 
-    law safe1(fa: Sign -> Sign, fc: BigInt -> BigInt): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
+//    law safe1(fa: Sign -> Sign, fc: BigInt -> BigInt): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
 
-    law safe2(fa: (Sign, Sign) -> Sign, fc: (BigInt, BigInt) -> BigInt): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
+//    law safe2(fa: (Sign, Sign) -> Sign, fc: (BigInt, BigInt) -> BigInt): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
 
 }

--- a/examples/domains/StrictSign.flix
+++ b/examples/domains/StrictSign.flix
@@ -28,8 +28,8 @@ namespace Domain/StrictSign {
     ///
     /// Returns `true` iff `e1` is less than or equal to `e2`.
     ///
-    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
-    def leq(e1: Sign, e2: Sign): Bool = match (e1, e2) {
+//    #reflexive #antiSymmetric #transitive #leastElement(Bot) #greatestElement(Top)
+    pub def leq(e1: Sign, e2: Sign): Bool = match (e1, e2) {
         case (Bot, _)   => true
         case (Neg, Neg) => true
         case (Zer, Zer) => true
@@ -41,7 +41,7 @@ namespace Domain/StrictSign {
     ///
     /// Returns the least upper bound of `e1` and `e2`.
     ///
-    #upperBound #leastUpperBound #commutative #associative
+//    #upperBound #leastUpperBound #commutative #associative
     pub def lub(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, x)   => x
         case (x, Bot)   => x
@@ -54,7 +54,7 @@ namespace Domain/StrictSign {
     ///
     /// Returns the greatest lower bound of `e1` and `e2`.
     ///
-    #lowerBound #greatestLowerBound #commutative #associative
+//    #lowerBound #greatestLowerBound #commutative #associative
     pub def glb(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Top, x)   => x
         case (x, Top)   => x
@@ -67,7 +67,7 @@ namespace Domain/StrictSign {
     ///
     /// The lattice height function.
     ///
-    #nonNegative
+//    #nonNegative
     pub def height(e: Sign): BigInt = match e {
         case Top    => 0ii
         case Neg    => 1ii
@@ -88,8 +88,8 @@ namespace Domain/StrictSign {
     ///
     /// Over-approximates integer `increment`.
     ///
-    #safe1(x -> x + 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x + 1ii)
+//    #strict1 #monotone1
     pub def inc(e: Sign): Sign = match e {
         case Bot => Bot
         case Neg => Top
@@ -101,8 +101,8 @@ namespace Domain/StrictSign {
     ///
     /// Over-approximates integer `decrement`.
     ///
-    #safe1(x -> x - 1ii)
-    #strict1 #monotone1
+//    #safe1(x -> x - 1ii)
+//    #strict1 #monotone1
     pub def dec(e: Sign): Sign = match e {
         case Bot => Bot
         case Neg => Neg
@@ -114,8 +114,8 @@ namespace Domain/StrictSign {
     ///
     /// Over-approximates integer `addition`.
     ///
-    #safe2((x, y) -> x + y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x + y)
+//    #strict2 #monotone2 #commutative #associative
     pub def plus(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, _)   => Bot
         case (_, Bot)   => Bot
@@ -134,8 +134,8 @@ namespace Domain/StrictSign {
     ///
     /// Over-approximates integer `subtraction`.
     ///
-    #safe2((x, y) -> x - y)
-    #strict2 #monotone2
+//    #safe2((x, y) -> x - y)
+//    #strict2 #monotone2
     pub def minus(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, _)   => Bot
         case (_, Bot)   => Bot
@@ -154,8 +154,8 @@ namespace Domain/StrictSign {
     ///
     /// Over-approximates integer `multiplication`.
     ///
-    #safe2((x, y) -> x * y)
-    #strict2 #monotone2 #commutative #associative
+//    #safe2((x, y) -> x * y)
+//    #strict2 #monotone2 #commutative #associative
     pub def times(e1: Sign, e2: Sign): Sign = match (e1, e2) {
         case (Bot, _)   => Bot
         case (_, Bot)   => Bot
@@ -174,10 +174,10 @@ namespace Domain/StrictSign {
     ///
     /// Over-approximates `equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x == y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #PartialOrder.safe2((x, y) -> x == y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def eq(e1: Sign, e2: Sign): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)   => Belnap/Belnap.Bot
         case (_, Bot)   => Belnap/Belnap.Bot
@@ -196,18 +196,18 @@ namespace Domain/StrictSign {
     ///
     /// Over-approximates `not equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x != y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
-    #commutative
+//    #PartialOrder.safe2((x, y) -> x != y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #commutative
     pub def neq(e1: Sign, e2: Sign): Belnap.Belnap = Belnap.not(eq(e1, e2))
 
     ///
     /// Over-approximates `less than`.
     ///
-    #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #PartialOrder.safe2((x, y) -> x < y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
     pub def less(e1: Sign, e2: Sign): Belnap.Belnap = match (e1, e2) {
         case (Bot, _)   => Belnap/Belnap.Bot
         case (_, Bot)   => Belnap/Belnap.Bot
@@ -223,37 +223,37 @@ namespace Domain/StrictSign {
     ///
     /// Over-approximates `less than or equal`.
     ///
-    #PartialOrder.safe2((x, y) -> x <= y, alpha, Belnap.alpha, Belnap.leq)
-    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
-    #PartialOrder.monotone2(leq, leq, Belnap.leq)
+//    #PartialOrder.safe2((x, y) -> x <= y, alpha, Belnap.alpha, Belnap.leq)
+//    #Bounded.strict2(Bot, Bot, Belnap/Belnap.Bot)
+//    #PartialOrder.monotone2(leq, leq, Belnap.leq)
     pub def lessEqual(e1: Sign, e2: Sign): Belnap.Belnap = Belnap.or(e1 `less` e2, e1 `eq` e2)
 
     //
     // ## Specialized Laws
     //
 
-    law upperBound(lub: (Sign, Sign) -> Sign): Bool = JoinLattice.leastUpperBound1(leq, lub)
+//    law upperBound(lub: (Sign, Sign) -> Sign): Bool = JoinLattice.leastUpperBound1(leq, lub)
 
-    law leastUpperBound(lub: (Sign, Sign) -> Sign): Bool = JoinLattice.leastUpperBound2(leq, lub)
+//    law leastUpperBound(lub: (Sign, Sign) -> Sign): Bool = JoinLattice.leastUpperBound2(leq, lub)
 
-    law lowerBound(glb: (Sign, Sign) -> Sign): Bool = MeetLattice.greatestLowerBound1(leq, glb)
+//    law lowerBound(glb: (Sign, Sign) -> Sign): Bool = MeetLattice.greatestLowerBound1(leq, glb)
 
-    law greatestLowerBound(glb: (Sign, Sign) -> Sign): Bool = MeetLattice.greatestLowerBound2(leq, glb)
+//    law greatestLowerBound(glb: (Sign, Sign) -> Sign): Bool = MeetLattice.greatestLowerBound2(leq, glb)
 
-    law leastElement(leq: (Sign, Sign) -> Bool, bot: Sign): Bool = Bounded.leastElement(bot, leq)
+//    law leastElement(leq: (Sign, Sign) -> Bool, bot: Sign): Bool = Bounded.leastElement(bot, leq)
 
-    law greatestElement(leq: (Sign, Sign) -> Bool, top: Sign): Bool = Bounded.greatestElement(top, leq)
+//    law greatestElement(leq: (Sign, Sign) -> Bool, top: Sign): Bool = Bounded.greatestElement(top, leq)
 
-    law strict1(f: Sign -> Sign): Bool = Bounded.strict1(f, Bot, Bot)
+//    law strict1(f: Sign -> Sign): Bool = Bounded.strict1(f, Bot, Bot)
 
-    law strict2(f: (Sign, Sign) -> Sign): Bool = Bounded.strict2(f, Bot, Bot, Bot)
+//    law strict2(f: (Sign, Sign) -> Sign): Bool = Bounded.strict2(f, Bot, Bot, Bot)
 
-    law monotone1(f: Sign -> Sign): Bool = PartialOrder.monotone1(f, leq, leq)
+//    law monotone1(f: Sign -> Sign): Bool = PartialOrder.monotone1(f, leq, leq)
 
-    law monotone2(f: (Sign, Sign) -> Sign): Bool = PartialOrder.monotone2(f, leq, leq, leq)
+//    law monotone2(f: (Sign, Sign) -> Sign): Bool = PartialOrder.monotone2(f, leq, leq, leq)
 
-    law safe1(fa: Sign -> Sign, fc: BigInt -> BigInt): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
+//    law safe1(fa: Sign -> Sign, fc: BigInt -> BigInt): Bool = PartialOrder.safe1(fa, fc, alpha, alpha, leq)
 
-    law safe2(fa: (Sign, Sign) -> Sign, fc: (BigInt, BigInt) -> BigInt): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
+//    law safe2(fa: (Sign, Sign) -> Sign, fc: (BigInt, BigInt) -> BigInt): Bool = PartialOrder.safe2(fa, fc, alpha, alpha, leq)
 
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -97,13 +97,17 @@ object ParsedAst {
     /**
       * Law Declaration.
       *
-      * @param sp1        the position of the first character in the declaration.
-      * @param ident      the name of the law.
-      * @param fparams    the value parameters.
-      * @param exp        the expression.
-      * @param sp2        the position of the last character in the declaration.
+      * @param doc     the optional comment associated with the law
+      * @param ann     the associated annotations.
+      * @param mod     the associated modifiers.
+      * @param sp1     the position of the first character in the declaration.
+      * @param ident   the name of the law.
+      * @param tparams the type parameters.
+      * @param fparams the value parameters.
+      * @param exp     the expression.
+      * @param sp2     the position of the last character in the declaration.
       */
-    case class Law(doc: ParsedAst.Doc, sp1: SourcePosition, ident: Name.Ident, fparams: Seq[ParsedAst.FormalParam], exp: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Declaration with ParsedAst.Declaration.LawOrSig
+    case class Law(doc: ParsedAst.Doc, ann: Seq[ParsedAst.AnnotationOrProperty], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparams: Seq[ParsedAst.FormalParam], exp: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Declaration with ParsedAst.Declaration.LawOrSig
 
     /**
       * Enum Declaration.

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -99,13 +99,11 @@ object ParsedAst {
       *
       * @param sp1        the position of the first character in the declaration.
       * @param ident      the name of the law.
-      * @param tparams    the type parameters.
-      * @param fparamsOpt the value parameters.
-      * @param tpe        the declared type.
+      * @param fparams    the value parameters.
       * @param exp        the expression.
       * @param sp2        the position of the last character in the declaration.
       */
-    case class Law(doc: ParsedAst.Doc, sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, exp: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Declaration with ParsedAst.Declaration.LawOrSig
+    case class Law(doc: ParsedAst.Doc, sp1: SourcePosition, ident: Name.Ident, fparams: Seq[ParsedAst.FormalParam], exp: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Declaration with ParsedAst.Declaration.LawOrSig
 
     /**
       * Enum Declaration.

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -147,7 +147,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def Law: Rule1[ParsedAst.Declaration.Law] = rule {
-      Documentation ~ SP ~ keyword("law") ~ WS ~ Names.Definition ~ optWS ~ ConstrainedTypeParams ~ optWS ~ FormalParamList ~ optWS ~ ":" ~ optWS ~ Type ~ optWS ~ "=" ~ optWS ~ Expression ~ SP ~> ParsedAst.Declaration.Law
+      Documentation ~ SP ~ keyword("law") ~ WS ~ Names.Definition ~ optWS ~ ":" ~ optWS ~ keyword("forall") ~ optWS ~ FormalParamList ~ optWS ~ "." ~ optWS ~ Expression ~ SP ~> ParsedAst.Declaration.Law
     }
 
     def LawOrSig: Rule1[ParsedAst.Declaration.LawOrSig] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -147,7 +147,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def Law: Rule1[ParsedAst.Declaration.Law] = rule {
-      Documentation ~ SP ~ keyword("law") ~ WS ~ Names.Definition ~ optWS ~ ":" ~ optWS ~ keyword("forall") ~ optWS ~ FormalParamList ~ optWS ~ "." ~ optWS ~ Expression ~ SP ~> ParsedAst.Declaration.Law
+      Documentation ~ Annotations ~ Modifiers ~ SP ~ keyword("law") ~ WS ~ Names.Definition ~ optWS ~ ":" ~ optWS ~ keyword("forall") ~ optWS ~ ConstrainedTypeParams ~ optWS ~ FormalParamList ~ optWS ~ "." ~ optWS ~ Expression ~ SP ~> ParsedAst.Declaration.Law
     }
 
     def LawOrSig: Rule1[ParsedAst.Declaration.LawOrSig] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -202,21 +202,20 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
     * Performs weeding on the given law declaration `d0`.
     */
   private def visitLaw(d0: ParsedAst.Declaration.Law)(implicit flix: Flix): Validation[List[WeededAst.Declaration.Def], WeederError] = d0 match {
-    case ParsedAst.Declaration.Law(doc0, sp1, ident, tparams0, fparams0, tpe, exp0, sp2) =>
+    case ParsedAst.Declaration.Law(doc0, sp1, ident, fparams0, exp0, sp2) =>
       val loc = mkSL(ident.sp1, ident.sp2)
       val doc = visitDoc(doc0)
       val expVal = visitExp(exp0)
-      val tparams = visitTypeParams(tparams0)
       val formalsVal = visitFormalParams(fparams0, typeRequired = true)
 
       mapN(formalsVal, expVal) {
         case (fs, exp) =>
           val e = mkCurried(fs.tail, exp, loc)
           val ts = fs.map(_.tpe.get)
-          val t = mkCurriedArrow(ts, WeededAst.Type.True(loc), visitType(tpe), loc)
+          val t = mkCurriedArrow(ts, WeededAst.Type.True(loc), WeededAst.Type.Ambiguous(Name.mkQName("Bool"), loc), loc)
           val ann = Nil
           val mod = Ast.Modifiers(Ast.Modifier.Public :: Nil)
-          List(WeededAst.Declaration.Def(doc, ann, mod, ident, tparams, fs.head :: Nil, e, t, WeededAst.Type.True(loc), loc))
+          List(WeededAst.Declaration.Def(doc, ann, mod, ident, WeededAst.TypeParams.Elided, fs.head :: Nil, e, t, WeededAst.Type.True(loc), loc))
       }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -210,12 +210,11 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
 
       mapN(formalsVal, expVal) {
         case (fs, exp) =>
-          val e = mkCurried(fs.tail, exp, loc)
           val ts = fs.map(_.tpe.get)
-          val t = mkCurriedArrow(ts, WeededAst.Type.True(loc), WeededAst.Type.Ambiguous(Name.mkQName("Bool"), loc), loc)
+          val tpe = WeededAst.Type.Arrow(ts, WeededAst.Type.True(loc), WeededAst.Type.Ambiguous(Name.mkQName("Bool"), loc), loc)
           val ann = Nil
           val mod = Ast.Modifiers(Ast.Modifier.Public :: Nil)
-          List(WeededAst.Declaration.Def(doc, ann, mod, ident, WeededAst.TypeParams.Elided, fs.head :: Nil, e, t, WeededAst.Type.True(loc), loc))
+          List(WeededAst.Declaration.Def(doc, ann, mod, ident, WeededAst.TypeParams.Elided, fs.head :: Nil, exp, tpe, WeededAst.Type.True(loc), loc))
       }
   }
 

--- a/main/src/library/Bounded.flix
+++ b/main/src/library/Bounded.flix
@@ -4,26 +4,30 @@ namespace Bounded {
     ///
     /// The least element law asserts that the bottom element `⊥` is the smallest element of a partial order `⊑`.
     ///
-    law leastElement[e](⊥: e, ⊑: (e, e) -> Bool): Bool = ∀(x: e). ⊥ ⊑ x
+    // TODO change to class law
+//    law leastElement[e](⊥: e, ⊑: (e, e) -> Bool): Bool = ∀(x: e). ⊥ ⊑ x
 
     ///
     /// The greatest element law asserts that the top element `⊤` is the largest element of a partial order `⊑`.
     ///
-    law greatestElement[e](⊤: e, ⊑: (e, e) -> Bool): Bool = ∀(x: e). x ⊑ ⊤
+    // TODO change to class law
+//    law greatestElement[e](⊤: e, ⊑: (e, e) -> Bool): Bool = ∀(x: e). x ⊑ ⊤
 
     ///
     /// The strictness law asserts that a function `f` between two orders must preserve bottoms: `bot` and `cobot`.
     ///
     /// NB: This particular law is for unary functions.
     ///
-    law strict1[a, b : Eq](f: a -> b, bot: a, cobot: b): Bool = f(bot) == cobot
+    // TODO change to class law
+//    law strict1[a, b : Eq](f: a -> b, bot: a, cobot: b): Bool = f(bot) == cobot
 
     ///
     /// The strictness law asserts that a function `f` between two orders must preserve bottoms: `bot` and `cobot`.
     ///
     /// NB: This particular law is for binary functions.
     ///
-    law strict2[a, b, c : Eq](f: (a, b) -> c, bot1: a, bot2: b, cobot: c): Bool = f(bot1, bot2) == cobot
+    // TODO change to class law
+//    law strict2[a, b, c : Eq](f: (a, b) -> c, bot1: a, bot2: b, cobot: c): Bool = f(bot1, bot2) == cobot
 
 }
 

--- a/main/src/library/JoinLattice.flix
+++ b/main/src/library/JoinLattice.flix
@@ -43,15 +43,17 @@ namespace JoinLattice {
     /// The law asserts that the least upper bound operator returns
     //  an element that is greater than or equal to each of its arguments.
     ///
-    law leastUpperBound1[e](⊑: (e, e) -> Bool, ⊔: (e, e) -> e): Bool =
-        ∀(x: e, y: e). (x ⊑ (x ⊔ y)) and (y ⊑ (x ⊔ y))
+    // TODO change to class law
+//    law leastUpperBound1[e](⊑: (e, e) -> Bool, ⊔: (e, e) -> e): Bool =
+//        ∀(x: e, y: e). (x ⊑ (x ⊔ y)) and (y ⊑ (x ⊔ y))
 
     ///
     /// The law asserts that the least upper bound operator returns
     /// the smallest element that is larger than its two arguments.
     ///
-    law leastUpperBound2[e](⊑: (e, e) -> Bool, ⊔: (e, e) -> e): Bool =
-        let implies = (x, y) -> (not x) or y;
-        ∀(x: e, y: e, z: e). ((x ⊑ z) and (y ⊑ z)) `implies` ((x ⊔ y) ⊑ z)
+    // TODO change to class law
+//    law leastUpperBound2[e](⊑: (e, e) -> Bool, ⊔: (e, e) -> e): Bool =
+//        let implies = (x, y) -> (not x) or y;
+//        ∀(x: e, y: e, z: e). ((x ⊑ z) and (y ⊑ z)) `implies` ((x ⊔ y) ⊑ z)
 
 }

--- a/main/src/library/MeetLattice.flix
+++ b/main/src/library/MeetLattice.flix
@@ -47,15 +47,17 @@ namespace MeetLattice {
     /// The lower bound law asserts that the greatest lower bound operator returns an element that
     /// is less than or equal to each of its arguments.
     ///
-    law greatestLowerBound1[e](⊑: (e, e) -> Bool, ⊓: (e, e) -> e): Bool =
-        ∀(x: e, y: e). ((x ⊓ y) ⊑ x) and ((x ⊓ y) ⊑ y)
+    // TODO change to class law
+//    law greatestLowerBound1[e](⊑: (e, e) -> Bool, ⊓: (e, e) -> e): Bool =
+//        ∀(x: e, y: e). ((x ⊓ y) ⊑ x) and ((x ⊓ y) ⊑ y)
 
     ///
     /// The greatest lower bound law asserts that the greatest lower bound operator returns the
     /// largest element that is smaller than its two arguments.
     ///
-    law greatestLowerBound2[e](⊑: (e, e) -> Bool, ⊓: (e, e) -> e): Bool =
-        let implies = (x, y) -> (not x) or y;
-        ∀(x: e, y: e, z: e). ((z ⊑ x) and (z ⊑ y)) `implies` (z ⊑ (x ⊓ y))
+    // TODO change to class law
+//    law greatestLowerBound2[e](⊑: (e, e) -> Bool, ⊓: (e, e) -> e): Bool =
+//        let implies = (x, y) -> (not x) or y;
+//        ∀(x: e, y: e, z: e). ((z ⊑ x) and (z ⊑ y)) `implies` (z ⊑ (x ⊓ y))
 
 }

--- a/main/src/library/PartialOrder.flix
+++ b/main/src/library/PartialOrder.flix
@@ -38,9 +38,9 @@ namespace PartialOrder {
     ///
     /// NB: This particular law is for unary functions.
     ///
-    law monotone1[a, b](f: a -> b, dom: (a, a) -> Bool, codom: (b, b) -> Bool): Bool =
-        let implies = (x, y) -> (not x) or y;
-        ∀(x: a, y: a). (x `dom` y) `implies` (f(x) `codom` f(y))
+//    law monotone1[a, b](f: a -> b, dom: (a, a) -> Bool, codom: (b, b) -> Bool): Bool =
+//        let implies = (x, y) -> (not x) or y;
+//        ∀(x: a, y: a). (x `dom` y) `implies` (f(x) `codom` f(y))
 
     ///
     /// The monotonicity law asserts that a function `f` is order-preserving w.r.t.
@@ -48,9 +48,9 @@ namespace PartialOrder {
     ///
     /// NB: This particular law is for binary functions.
     ///
-    law monotone2[a, b, c](f: (a, b) -> c, dom1: (a, a) -> Bool, dom2: (b, b) -> Bool, codom: (c, c) -> Bool): Bool =
-        let implies = (x, y) -> (not x) or y;
-        ∀(x1: a, x2: a, y1: b, y2: b). ((x1 `dom1` x2) and (y1 `dom2` y2)) `implies` (f(x1, y1) `codom` f(x2, y2))
+//    law monotone2[a, b, c](f: (a, b) -> c, dom1: (a, a) -> Bool, dom2: (b, b) -> Bool, codom: (c, c) -> Bool): Bool =
+//        let implies = (x, y) -> (not x) or y;
+//        ∀(x1: a, x2: a, y1: b, y2: b). ((x1 `dom1` x2) and (y1 `dom2` y2)) `implies` (f(x1, y1) `codom` f(x2, y2))
 
     ///
     /// The safety law asserts that the abstract function `fa` is an over-approximation of the concrete
@@ -58,8 +58,8 @@ namespace PartialOrder {
     ///
     /// NB: This particular law is for unary functions.
     ///
-    law safe1[a1, a2, c1, c2](fa: a1 -> a2, fc: c1 -> c2, alpha1: c1 -> a1, alpha2: c2 -> a2, leq: (a2, a2) -> Bool): Bool =
-        ∀(x: c1). alpha2(fc(x)) `leq` fa(alpha1(x))
+//    law safe1[a1, a2, c1, c2](fa: a1 -> a2, fc: c1 -> c2, alpha1: c1 -> a1, alpha2: c2 -> a2, leq: (a2, a2) -> Bool): Bool =
+//        ∀(x: c1). alpha2(fc(x)) `leq` fa(alpha1(x))
 
     ///
     /// The safety law asserts that the abstract function `fa` is an over-approximation of the concrete
@@ -67,7 +67,7 @@ namespace PartialOrder {
     ///
     /// NB: This particular law is for binary functions.
     ///
-    law safe2[a1, a2, c1, c2](fa: (a1, a1) -> a2, fc: (c1, c1) -> c2, alpha1: c1 -> a1, alpha2: c2 -> a2, leq: (a2, a2) -> Bool): Bool =
-        ∀(x: c1, y: c1). alpha2(fc(x, y)) `leq` fa(alpha1(x), alpha1(y))
+//    law safe2[a1, a2, c1, c2](fa: (a1, a1) -> a2, fc: (c1, c1) -> c2, alpha1: c1 -> a1, alpha2: c2 -> a2, leq: (a2, a2) -> Bool): Bool =
+//        ∀(x: c1, y: c1). alpha2(fc(x, y)) `leq` fa(alpha1(x), alpha1(y))
 
 }

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -107,48 +107,55 @@ pub def space(_f: a -> Int32): Int32 = 1
 ///
 /// The commutative law asserts that for a binary operator `f` the result of `f(x, y)` is equal to `f(y, x)`.
 ///
-law commutative[a, b : Eq](f: (a, a) -> b): Bool =
-    ∀(x: a, y: a). f(x, y) == f(y, x)
+    // TODO change to class law
+//law commutative[a, b : Eq](f: (a, a) -> b): Bool =
+//    ∀(x: a, y: a). f(x, y) == f(y, x)
 
 ///
 /// The associative law asserts that for a binary operator `f` the result of `f(x, f(y, z))` is equal to `f(f(x, y), z)`.
 ///
-law associative[a : Eq](f: (a, a) -> a): Bool =
-    ∀(x: a, y: a, z: a). f(x, f(y, z)) == f(f(x, y), z)
+    // TODO change to class law
+//law associative[a : Eq](f: (a, a) -> a): Bool =
+//    ∀(x: a, y: a, z: a). f(x, f(y, z)) == f(f(x, y), z)
 
 ///
 /// The reflexivity law asserts that any element is less than or equal to itself.
 ///
-law reflexive(⊑: (e, e) -> Bool): Bool = ∀(x: e). x ⊑ x
+    // TODO change to class law
+//law reflexive(⊑: (e, e) -> Bool): Bool = ∀(x: e). x ⊑ x
 
 ///
 /// The anti-symmetry law asserts that if `x` is less than or equal to `y` and vice versa then the
 /// two elements must be equal.
 ///
-law antiSymmetric[e : Eq](⊑: (e, e) -> Bool): Bool =
-    use Bool.{∧, →};
-    ∀(x: e, y: e). ((x ⊑ y) ∧ (y ⊑ x)) → (x == y)
+    // TODO change to class law
+//law antiSymmetric[e : Eq](⊑: (e, e) -> Bool): Bool =
+//    use Bool.{∧, →};
+//    ∀(x: e, y: e). ((x ⊑ y) ∧ (y ⊑ x)) → (x == y)
 
 ///
 /// The transitivity law asserts that if `x` less than or equal to `y` and `y` is less than or equal
 /// to `z` then `x` must be less than or equal to `z`.
 ///
-law transitive(⊑: (e, e) -> Bool): Bool =
-    use Bool.{∧, →};
-    ∀(x: e, y: e, z: e). ((x ⊑ y) ∧ (y ⊑ z)) → (x ⊑ z)
+    // TODO change to class law
+//law transitive(⊑: (e, e) -> Bool): Bool =
+//    use Bool.{∧, →};
+//    ∀(x: e, y: e, z: e). ((x ⊑ y) ∧ (y ⊑ z)) → (x ⊑ z)
 
 ///
 /// The non-negative law asserts that the co-domain of `h` is non-negative.
 ///
-law nonNegative(h: e -> BigInt): Bool = ∀(x: e). h(x) >= 0ii
+    // TODO change to class law
+//law nonNegative(h: e -> BigInt): Bool = ∀(x: e). h(x) >= 0ii
 
 ///
 /// The decreasing law asserts that if an element `x` is strictly less than an element `y` then
 /// the height assigned to `x` is stricty greater than the height assigned to `y`.
 ///
-law decreasing(h: e -> BigInt, equ: (e, e) -> Bool, ⊑: (e, e) -> Bool): Bool =
-    use Bool.{∧, →};
-    ∀(x: e, y: e). (x ⊑ y ∧ not equ(x, y)) → (h(x) > h(y))
+    // TODO change to class law
+//law decreasing(h: e -> BigInt, equ: (e, e) -> Bool, ⊑: (e, e) -> Bool): Bool =
+//    use Bool.{∧, →};
+//    ∀(x: e, y: e). (x ⊑ y ∧ not equ(x, y)) → (h(x) > h(y))
 
 ///
 /// Asserts that the expression `x` is contextually equivalent to the expression `y`.

--- a/main/src/library/TotalOrder.flix
+++ b/main/src/library/TotalOrder.flix
@@ -9,8 +9,9 @@ namespace TotalOrder {
      * or `y` is less than or equal to `x`, i.e. every pair of elements must
      * be mutually comparable.
      */
-    law totality[e](⊑: (e, e) -> Bool): Bool =
-        use Bool.∨;
-        ∀(x: e, y: e). (x ⊑ y) ∨ (y ⊑ x)
+    // TODO change to class law
+//    law totality[e](⊑: (e, e) -> Bool): Bool =
+//        use Bool.∨;
+//        ∀(x: e, y: e). (x ⊑ y) ∨ (y ⊑ x)
 
 }

--- a/main/test/ca/uwaterloo/flix/TestExamples.scala
+++ b/main/test/ca/uwaterloo/flix/TestExamples.scala
@@ -41,21 +41,20 @@ class TestExamples extends Suites(
   //new FlixTest("the-ast-typing-problem-with-polymorphic-records", "examples/the-ast-typing-problem-with-polymorphic-records.flix")(Options.DefaultTest.copy(xallowredundancies = true)),
 
   // Others
-  // TODO re-enable these tests after their laws are update to the new syntax
-//  new FlixTest("TestBelnap", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-//  new FlixTest("TestConstant", "examples/domains/Constant.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-//
-//  new FlixTest("ConstantParity", "examples/domains/ConstantParity.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-//  new FlixTest("ConstantSign", "examples/domains/ConstantSign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-//  new FlixTest("Interval", "examples/domains/Interval.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-//  new FlixTest("IntervalAlt", "examples/domains/IntervalAlt.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-//  // new FlixTest("IntervalInf", "examples/domains/IntervalInf.flix", "examples/domains/Belnap.flix")(compiled = false), // TODO: Broken
-//  new FlixTest("Mod3", "examples/domains/Mod3.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-//  new FlixTest("Parity", "examples/domains/Parity.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-//  new FlixTest("ParitySign", "examples/domains/ParitySign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-//  new FlixTest("PrefixSuffix", "examples/domains/PrefixSuffix.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-//  new FlixTest("Sign", "examples/domains/Sign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-//  new FlixTest("StrictSign", "examples/domains/StrictSign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+  new FlixTest("TestBelnap", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+  new FlixTest("TestConstant", "examples/domains/Constant.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+
+  new FlixTest("ConstantParity", "examples/domains/ConstantParity.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+  new FlixTest("ConstantSign", "examples/domains/ConstantSign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+  new FlixTest("Interval", "examples/domains/Interval.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+  new FlixTest("IntervalAlt", "examples/domains/IntervalAlt.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+  // new FlixTest("IntervalInf", "examples/domains/IntervalInf.flix", "examples/domains/Belnap.flix")(compiled = false), // TODO: Broken
+  new FlixTest("Mod3", "examples/domains/Mod3.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+  new FlixTest("Parity", "examples/domains/Parity.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+  new FlixTest("ParitySign", "examples/domains/ParitySign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+  new FlixTest("PrefixSuffix", "examples/domains/PrefixSuffix.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+  new FlixTest("Sign", "examples/domains/Sign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+  new FlixTest("StrictSign", "examples/domains/StrictSign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
 
   new FlixTest("IFDS", "examples/analysis/IFDS.flix")(Options.TestWithLibrary),
   new FlixTest("IDE", "examples/analysis/IDE.flix")(Options.TestWithLibrary),

--- a/main/test/ca/uwaterloo/flix/TestExamples.scala
+++ b/main/test/ca/uwaterloo/flix/TestExamples.scala
@@ -41,20 +41,21 @@ class TestExamples extends Suites(
   //new FlixTest("the-ast-typing-problem-with-polymorphic-records", "examples/the-ast-typing-problem-with-polymorphic-records.flix")(Options.DefaultTest.copy(xallowredundancies = true)),
 
   // Others
-  new FlixTest("TestBelnap", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-  new FlixTest("TestConstant", "examples/domains/Constant.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-
-  new FlixTest("ConstantParity", "examples/domains/ConstantParity.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-  new FlixTest("ConstantSign", "examples/domains/ConstantSign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-  new FlixTest("Interval", "examples/domains/Interval.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-  new FlixTest("IntervalAlt", "examples/domains/IntervalAlt.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-  // new FlixTest("IntervalInf", "examples/domains/IntervalInf.flix", "examples/domains/Belnap.flix")(compiled = false), // TODO: Broken
-  new FlixTest("Mod3", "examples/domains/Mod3.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-  new FlixTest("Parity", "examples/domains/Parity.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-  new FlixTest("ParitySign", "examples/domains/ParitySign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-  new FlixTest("PrefixSuffix", "examples/domains/PrefixSuffix.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-  new FlixTest("Sign", "examples/domains/Sign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
-  new FlixTest("StrictSign", "examples/domains/StrictSign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+  // TODO re-enable these tests after their laws are update to the new syntax
+//  new FlixTest("TestBelnap", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+//  new FlixTest("TestConstant", "examples/domains/Constant.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+//
+//  new FlixTest("ConstantParity", "examples/domains/ConstantParity.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+//  new FlixTest("ConstantSign", "examples/domains/ConstantSign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+//  new FlixTest("Interval", "examples/domains/Interval.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+//  new FlixTest("IntervalAlt", "examples/domains/IntervalAlt.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+//  // new FlixTest("IntervalInf", "examples/domains/IntervalInf.flix", "examples/domains/Belnap.flix")(compiled = false), // TODO: Broken
+//  new FlixTest("Mod3", "examples/domains/Mod3.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+//  new FlixTest("Parity", "examples/domains/Parity.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+//  new FlixTest("ParitySign", "examples/domains/ParitySign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+//  new FlixTest("PrefixSuffix", "examples/domains/PrefixSuffix.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+//  new FlixTest("Sign", "examples/domains/Sign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
+//  new FlixTest("StrictSign", "examples/domains/StrictSign.flix", "examples/domains/Belnap.flix")(Options.TestWithLibrary),
 
   new FlixTest("IFDS", "examples/analysis/IFDS.flix")(Options.TestWithLibrary),
   new FlixTest("IDE", "examples/analysis/IDE.flix")(Options.TestWithLibrary),

--- a/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
@@ -490,7 +490,7 @@ class TestInstances extends FunSuite with TestUtils {
         |  pub def f(x: a): Bool
         |  pub def g(x: a): Bool
         |
-        |  law l(): Bool = forall (x: a) . C.f(x)
+        |  law l: forall (x: a) . C.f(x)
         |}
         |""".stripMargin
     val result = compile(input, DefaultOptions)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -969,7 +969,7 @@ class TestTyper extends FunSuite with TestUtils {
   test("Test.MismatchedTypes.Law.01") {
     val input =
       """
-        |law f(): Bool = forall (x: Int, y: Bool) . x + y == 3
+        |law f: forall (x: Int, y: Bool) . x + y == 3
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[TypeError.MismatchedTypes](result)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -966,13 +966,13 @@ class TestTyper extends FunSuite with TestUtils {
     expectError[TypeError.MismatchedBools](result)
   }
 
-  test("Test.MismatchedTypes.Law.01") {
+  test("Test.GeneralizationError.Law.01") {
     val input =
       """
         |law f: forall (x: Int, y: Bool) . x + y == 3
         |""".stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[TypeError.MismatchedTypes](result)
+    expectError[TypeError.GeneralizationError](result)
   }
 
   test("Test.ChooseStar.01") {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -966,13 +966,13 @@ class TestTyper extends FunSuite with TestUtils {
     expectError[TypeError.MismatchedBools](result)
   }
 
-  test("Test.GeneralizationError.Law.01") {
+  test("Test.MismatchedTypes.Law.01") {
     val input =
       """
         |law f: forall (x: Int, y: Bool) . x + y == 3
         |""".stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[TypeError.GeneralizationError](result)
+    expectError[TypeError.MismatchedTypes](result)
   }
 
   test("Test.ChooseStar.01") {

--- a/main/test/flix/Test.Dec.Class.flix
+++ b/main/test/flix/Test.Dec.Class.flix
@@ -133,7 +133,7 @@ namespace Test/Dec/Class {
             pub def f(x: a, y: a): Bool
 
             // TODO handle namespaces better
-            law reflexivity(): Bool = forall (x: a, y: a) . Test/Dec/Class/Test11/C.f(x, y) == Test/Dec/Class/Test11/C.f(y, x)
+            law reflexivity: forall (x: a, y: a) . Test/Dec/Class/Test11/C.f(x, y) == Test/Dec/Class/Test11/C.f(y, x)
         }
 
         instance C[Int] {
@@ -145,11 +145,11 @@ namespace Test/Dec/Class {
         lawless class C[a] {
             pub def f(): a
 
-            law l(): Bool = true
+            law l: forall (_x: a) . true
 
             pub def g(): a
 
-            law m(): Bool = true
+            law m: forall (_x: a) . true
         }
     }
 

--- a/main/test/flix/Test.Dec.Class.flix
+++ b/main/test/flix/Test.Dec.Class.flix
@@ -149,7 +149,7 @@ namespace Test/Dec/Class {
 
             pub def g(): a
 
-            law m: forall (_x: a) . true
+            law m: forall[a](_x: a) . true
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/flix/flix/issues/1759

```flix
law myLaw: forall (_x: a) . true

law myLaw2: forall[b](_x: b) . true
```
is equivalent to
```flix
def myLaw(_x: a): Bool = true

def myLaw2[b](_x: b) = true
```

A lot ended up getting commented out, since there's some not-easily-automated refactoring to be done around existing laws.

### Features
* Update law syntax
  * [x] impl
  * [x] test

### General requirements
* [x] Don't make a complete mess
* [x] Don't break anything else
* [x] Provide documentation
* [x] Add license to new files
