### PR TITLE
Fix singleton unit tags

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -429,8 +429,8 @@ object GenExpression {
       // TODO: This is a hack until the new and improved backend arrives.
       val whitelistedEnums = List(
         Symbol.mkEnumSym("Comparison"),
-        Symbol.mkEnumSym("RedBlackTree/RedBlackTree"),
-        Symbol.mkEnumSym("RedBlackTree/Color"),
+        Symbol.mkEnumSym("RedBlackTree.RedBlackTree"),
+        Symbol.mkEnumSym("RedBlackTree.Color"),
       )
       if (exp.tpe == MonoType.Unit && whitelistedEnums.contains(enum)) {
         // Read the "unitInstance" field of the appropriate class.


### PR DESCRIPTION
#1781 was supposed to ensure singleton instances of RedBlackTree leafs and colors, but used namespace syntax to refer to a type. This fixes that.