### PR TITLE
Update link to fixpoint documentation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -34,3 +34,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Oskar Haarklou Veileborg](https://github.com/BarrensZeppelin)
 - [Justin Fargnoli](https://github.com/justinfargnoli)
 - [Benjamin Dahse](https://github.com/bdahse)
+- [J. Ryan Stinnett](https://github.com/jryans)

--- a/doc/PROJECTS.md
+++ b/doc/PROJECTS.md
@@ -51,7 +51,7 @@ The aim of this project is to: (1) understand how the semi-naive evaluation algo
 (2) re-design and re-implemented the fixpoint engine in the Flix language to make it faster and easier to maintain.
 
 - Stefano Ceri: What you always wanted to know about Datalog (and never dared to ask)
-- https://flix.dev/programming-flix/#/fixpoints/ 
+- https://doc.flix.dev/fixpoints/
 
 
 


### PR DESCRIPTION
The fixpoint documentation has moved, so this updates a link to match.