### PR TITLE
Add MutSet.queryWith

### DIFF
--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -643,7 +643,7 @@ namespace Map {
     ///
     pub def query(p: k -> Comparison & e, m: Map[k, v]): List[(k, v)] & e =
         let Map(xs) = m;
-        RedBlackTree.queryWith(p, (k, v) -> (k, v), xs)
+        RedBlackTree.query(p, (k, v) -> (k, v), xs)
 
     /////////////////////////////////////////////////////////////////////////////
     // Lints: Use Cases                                                        //

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -645,6 +645,15 @@ namespace Map {
         let Map(xs) = m;
         RedBlackTree.query(p, (k, v) -> (k, v), xs)
 
+    ///
+    /// Applies `f` to all key-value pairs `(k, v)` from the map `m` where `p(k)` returns `EqualTo`.
+    ///
+    /// The function `f` must be impure.
+    ///
+    pub def queryWith(p: k -> Comparison & e, f: (k, v) ~> Unit, m: Map[k, v]): Unit & Impure =
+        let Map(xs) = m;
+        RedBlackTree.queryWith(p, f, xs)
+
     /////////////////////////////////////////////////////////////////////////////
     // Lints: Use Cases                                                        //
     /////////////////////////////////////////////////////////////////////////////

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -443,4 +443,13 @@ namespace MutMap {
         let MutMap(mm) = m;
         Map.query(p, deref mm)
 
+    ///
+    /// Applies `f` to all key-value pairs `(k, v)` in the mutable map `m` where `p(k)` returns `EqualTo`.
+    ///
+    /// The function `f` must be impure.
+    ///
+    pub def queryWith(p: k -> Comparison & e, f: (k, v) ~> Unit, m: MutMap[k, v]): Unit & Impure =
+        let MutMap(mm) = m;
+        Map.queryWith(p, f, deref mm)
+
 }

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -352,8 +352,17 @@ namespace MutSet {
     ///
     /// That is, the result is a list of all elements `x` where `p(x)` returns `Equal`.
     ///
-    pub def query(p: a -> Comparison, s: MutSet[a]): List[a] & Impure =
+    pub def query(p: a -> Comparison & e, s: MutSet[a]): List[a] & Impure =
         let MutSet(ms) = s;
         Set.query(p, deref ms)
+
+    ///
+    /// Applies `f` to all elements from the set `s` where `p(x)` returns `EqualTo`.
+    ///
+    /// The function `f` must be impure.
+    ///
+    pub def queryWith(p: a -> Comparison & e, f: a ~> Unit, s: MutSet[a]): Unit & Impure =
+        let MutSet(ms) = s;
+        Set.queryWith(p, f, deref ms)
 
 }

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -419,30 +419,34 @@ namespace RedBlackTree {
     }
 
     ///
+    /// Applies `f` to all key-value pairs from `tree` where `p(k)` returns `EqualTo`.
+    ///
+    /// The function `f` must be impure.
+    ///
+    pub def queryWith(p: k -> Comparison & e, f: (k, v) ~> Unit, tree: RedBlackTree[k, v]): Unit & Impure = match tree {
+        case Node(_, a, k, v, b) =>
+            match p(k) {
+                case LessThan => queryWith(p, f, b)
+                case EqualTo => {
+                    queryWith(p, f, a);
+                    f(k, v);
+                    queryWith(p, f, b)
+                }
+                case GreaterThan => queryWith(p, f, a)
+            }
+        case _ => ()
+    }
+
+    ///
     /// Extracts a range of key-value pairs from `tree`.
     ///
     /// That is, the result is a list of all pairs `f(k, v)` where `p(k)` returns `Equal`.
     ///
-    pub def queryWith(p: k -> Comparison & e, f: (k, v) -> a, tree: RedBlackTree[k, v]): List[a] & e =
+    pub def query(p: k -> Comparison & e, f: (k, v) -> a, tree: RedBlackTree[k, v]): List[a] & e =
         let buffer = MutList.new() as & e;
-        queryWithHelper(p, f, buffer, tree) as & e;
+        let g = k -> v -> MutList.push!(f(k, v), buffer);
+        queryWith(p, g, tree) as & e;
         MutList.toImmutable(buffer) as & e
-
-    pub def queryWithHelper(p: k -> Comparison & e, f: (k, v) -> a, buffer: MutList[a], tree: RedBlackTree[k, v]): Unit & Impure = {
-        match tree {
-            case Node(_, a, k, v, b) =>
-                match p(k) {
-                    case LessThan => queryWithHelper(p, f, buffer, b)
-                    case EqualTo => {
-                        queryWithHelper(p, f, buffer, a);
-                        MutList.push!(f(k, v), buffer);
-                        queryWithHelper(p, f, buffer, b)
-                    }
-                    case GreaterThan => queryWithHelper(p, f, buffer, a)
-                }
-            case _ => ()
-        }
-    }
 
     ///
     /// Extracts `k -> v` where `k` is the leftmost (i.e. smallest) key in the tree.

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -492,7 +492,16 @@ namespace Set {
     ///
     pub def query(p: a -> Comparison & e, xs: Set[a]): List[a] & e =
         let Set(es) = xs;
-        RedBlackTree.queryWith(p, (k, _) -> k, es)
+        RedBlackTree.query(p, (k, _) -> k, es)
+
+    ///
+    /// Applies `f` to all elements from the set `xs` where `p(x)` returns `EqualTo`.
+    ///
+    /// The function `f` must be impure.
+    ///
+    pub def queryWith(p: a -> Comparison & e, f: a ~> Unit, xs: Set[a]): Unit & Impure =
+        let Set(es) = xs;
+        RedBlackTree.queryWith(p, (k, _) -> f(k), es)
 
     ///
     /// Helper function for `range`.


### PR DESCRIPTION
The intended usecase is to rewrite MutSet.query followed by List.foreach into MutSet.queryWith. This is to avoid allocating a temporary buffer to store the query result.
For example:
````
let s = MutSet.empty();
MutSet.query(x -> ..., s) |>
List.foreach(...)
````
Can now be written as:
````
let s = MutSet.empty();
MutSet.queryWith(x -> ..., ...., s)
````