### PR TITLE
Build ClassEnv from classes rather than instances

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -75,19 +75,16 @@ object Typer extends Phase[ResolvedAst.Root, TypedAst.Root] {
   }
 
   /**
-    * Creates a class environment from a ClassSym-Instance multimap.
+    * Creates a class environment from a the classes and instances in the root.
     */
-  private def mkClassEnv(classes: Map[Symbol.ClassSym, ResolvedAst.Class], instances: Map[Symbol.ClassSym, List[ResolvedAst.Instance]]): Map[Symbol.ClassSym, Ast.ClassContext] = {
-    instances.map {
-      case (classSym, instances) =>
+  private def mkClassEnv(classes0: Map[Symbol.ClassSym, ResolvedAst.Class], instances0: Map[Symbol.ClassSym, List[ResolvedAst.Instance]]): Map[Symbol.ClassSym, Ast.ClassContext] = {
+    classes0.map {
+      case (classSym, clazz) =>
+        val instances = instances0.getOrElse(classSym, Nil)
         val envInsts = instances.map {
           case ResolvedAst.Instance(_, _, _, tpe, tconstrs, _, _, _) => Ast.Instance(tpe, tconstrs)
         }
-        val superClasses = classes.get(classSym) match {
-          case Some(ResolvedAst.Class(_, _, _, _, superClasses, _, _, _)) => superClasses
-          case None => throw InternalCompilerException(s"Unexpected unrecognized class $classSym")
-        }
-        (classSym, Ast.ClassContext(superClasses, envInsts))
+        (classSym, Ast.ClassContext(clazz.superClasses, envInsts))
     }
   }
 

--- a/main/test/flix/Test.Dec.Class.flix
+++ b/main/test/flix/Test.Dec.Class.flix
@@ -178,6 +178,18 @@ namespace Test/Dec/Class {
         def testSigOverride03(): Bool = Test/Dec/Class/Test13/C.h() == 1
     }
 
+    namespace Test14 {
+        lawless class C[a] {
+            pub def c(x: a): Int
+        }
+
+        lawless class D[a] with C[a] {
+            pub def d(x: a): Int
+        }
+
+        pub def f[a : D](x: a): Int = Test/Dec/Class/Test14/C.c(x) + Test/Dec/Class/Test14/D.d(x)
+    }
+
     pub enum List[a] {
         case Nil
         case Cons(a, List[a])


### PR DESCRIPTION
Fixes https://github.com/flix/flix/issues/1670

And maybe related to https://github.com/flix/flix/issues/1765 ?

If there were no instances of a class, we didn't add it to the class environment, so we couldn't come to any conclusions about superclasses, etc.

This change builds the ClassEnv from the map of classes rather than map of instances, so we're no longer missing anything if there are no instances.