### PR TITLE
Fix index out of bounds in ToStringOps.arrayToStringHelper

### DIFF
--- a/main/src/library/ToString.flix
+++ b/main/src/library/ToString.flix
@@ -156,7 +156,10 @@ instance ToString[Array[a]] with ToString[a] {
 
 namespace ToStringOps {
     pub def arrayToStringHelper[a : ToString](a: Array[a], i: Int32, acc: String): String =
-        if (i == 0) arrayToStringHelper(a, i + 1, "${a[i]}") as & Pure
-        else if (i < a.length) arrayToStringHelper(a, i + 1, "${acc}, ${a[i]}") as & Pure
-        else "[${acc}]"
+        if (i < a.length) {
+            if (i == 0) arrayToStringHelper(a, i + 1, "${a[i]}") as & Pure
+            else arrayToStringHelper(a, i + 1, "${acc}, ${a[i]}") as & Pure
+        } else {
+            "[${acc}]"
+        }
 }


### PR DESCRIPTION
When printing an empty array, there is an access to index 0 in ToStringOps.arrayToStringHelper.