### PR TITLE
Remove Eq from MutMap.isEmpty

### DIFF
--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -30,7 +30,7 @@ namespace MutMap {
     ///
     /// Returns `true` if and only if `m` is the empty map.
     ///
-    pub def isEmpty[k : Eq, v](m: MutMap[k, v]): Bool & Impure =
+    pub def isEmpty(m: MutMap[k, v]): Bool & Impure =
         let MutMap(mm) = m;
         Map.isEmpty(deref mm)
 


### PR DESCRIPTION
It doesn't make sense and none of the functions it calls requires it.