### PR TITLE
Relation support to N=15

### DIFF
--- a/main/src/library/Boxable.flix
+++ b/main/src/library/Boxable.flix
@@ -264,3 +264,133 @@ instance Boxable[(a, b, c, d, e)] with Boxable[a], Boxable[b], Boxable[c], Boxab
         case _                    => ?bug
     }
 }
+
+instance Boxable[(a, b, c, d, e, f)] with Boxable[a], Boxable[b], Boxable[c], Boxable[d], Boxable[e], Boxable[f] {
+    pub def box(x: (a, b, c, d, e, f)): Boxed = {
+        let value = x as ##java.lang.Object;
+        let compare = (o1, o2) -> Order.compare(o1 as (a, b, c, d, e, f), o2 as (a, b, c, d, e, f));
+        let toString = o -> ToString.toString(o as (a, b, c, d, e, f));
+        BoxedObject(value, compare, toString)
+    }
+    pub def unbox(x: Boxed): (a, b, c, d, e, f) = match x {
+        case BoxedObject(v, _, _) => v as (a, b, c, d, e, f)
+        case _                    => ?bug
+    }
+}
+
+instance Boxable[(a, b, c, d, e, f, g)] with Boxable[a], Boxable[b], Boxable[c], Boxable[d], Boxable[e], Boxable[f], Boxable[g] {
+    pub def box(x: (a, b, c, d, e, f, g)): Boxed = {
+        let value = x as ##java.lang.Object;
+        let compare = (o1, o2) -> Order.compare(o1 as (a, b, c, d, e, f, g), o2 as (a, b, c, d, e, f, g));
+        let toString = o -> ToString.toString(o as (a, b, c, d, e, f, g));
+        BoxedObject(value, compare, toString)
+    }
+    pub def unbox(x: Boxed): (a, b, c, d, e, f, g) = match x {
+        case BoxedObject(v, _, _) => v as (a, b, c, d, e, f, g)
+        case _                    => ?bug
+    }
+}
+
+instance Boxable[(a, b, c, d, e, f, g, h)] with Boxable[a], Boxable[b], Boxable[c], Boxable[d], Boxable[e], Boxable[f], Boxable[g], Boxable[h] {
+    pub def box(x: (a, b, c, d, e, f, g, h)): Boxed = {
+        let value = x as ##java.lang.Object;
+        let compare = (o1, o2) -> Order.compare(o1 as (a, b, c, d, e, f, g, h), o2 as (a, b, c, d, e, f, g, h));
+        let toString = o -> ToString.toString(o as (a, b, c, d, e, f, g, h));
+        BoxedObject(value, compare, toString)
+    }
+    pub def unbox(x: Boxed): (a, b, c, d, e, f, g, h) = match x {
+        case BoxedObject(v, _, _) => v as (a, b, c, d, e, f, g, h)
+        case _                    => ?bug
+    }
+}
+
+instance Boxable[(a, b, c, d, e, f, g, h, i)] with Boxable[a], Boxable[b], Boxable[c], Boxable[d], Boxable[e], Boxable[f], Boxable[g], Boxable[h], Boxable[i] {
+    pub def box(x: (a, b, c, d, e, f, g, h, i)): Boxed = {
+        let value = x as ##java.lang.Object;
+        let compare = (o1, o2) -> Order.compare(o1 as (a, b, c, d, e, f, g, h, i), o2 as (a, b, c, d, e, f, g, h, i));
+        let toString = o -> ToString.toString(o as (a, b, c, d, e, f, g, h, i));
+        BoxedObject(value, compare, toString)
+    }
+    pub def unbox(x: Boxed): (a, b, c, d, e, f, g, h, i) = match x {
+        case BoxedObject(v, _, _) => v as (a, b, c, d, e, f, g, h, i)
+        case _                    => ?bug
+    }
+}
+
+instance Boxable[(a, b, c, d, e, f, g, h, i, j)] with Boxable[a], Boxable[b], Boxable[c], Boxable[d], Boxable[e], Boxable[f], Boxable[g], Boxable[h], Boxable[i], Boxable[j] {
+    pub def box(x: (a, b, c, d, e, f, g, h, i, j)): Boxed = {
+        let value = x as ##java.lang.Object;
+        let compare = (o1, o2) -> Order.compare(o1 as (a, b, c, d, e, f, g, h, i, j), o2 as (a, b, c, d, e, f, g, h, i, j));
+        let toString = o -> ToString.toString(o as (a, b, c, d, e, f, g, h, i, j));
+        BoxedObject(value, compare, toString)
+    }
+    pub def unbox(x: Boxed): (a, b, c, d, e, f, g, h, i, j) = match x {
+        case BoxedObject(v, _, _) => v as (a, b, c, d, e, f, g, h, i, j)
+        case _                    => ?bug
+    }
+}
+
+instance Boxable[(a, b, c, d, e, f, g, h, i, j, k)] with Boxable[a], Boxable[b], Boxable[c], Boxable[d], Boxable[e], Boxable[f], Boxable[g], Boxable[h], Boxable[i], Boxable[j], Boxable[k] {
+    pub def box(x: (a, b, c, d, e, f, g, h, i, j, k)): Boxed = {
+        let value = x as ##java.lang.Object;
+        let compare = (o1, o2) -> Order.compare(o1 as (a, b, c, d, e, f, g, h, i, j, k), o2 as (a, b, c, d, e, f, g, h, i, j, k));
+        let toString = o -> ToString.toString(o as (a, b, c, d, e, f, g, h, i, j, k));
+        BoxedObject(value, compare, toString)
+    }
+    pub def unbox(x: Boxed): (a, b, c, d, e, f, g, h, i, j, k) = match x {
+        case BoxedObject(v, _, _) => v as (a, b, c, d, e, f, g, h, i, j, k)
+        case _                    => ?bug
+    }
+}
+
+instance Boxable[(a, b, c, d, e, f, g, h, i, j, k, l)] with Boxable[a], Boxable[b], Boxable[c], Boxable[d], Boxable[e], Boxable[f], Boxable[g], Boxable[h], Boxable[i], Boxable[j], Boxable[k], Boxable[l] {
+    pub def box(x: (a, b, c, d, e, f, g, h, i, j, k, l)): Boxed = {
+        let value = x as ##java.lang.Object;
+        let compare = (o1, o2) -> Order.compare(o1 as (a, b, c, d, e, f, g, h, i, j, k, l), o2 as (a, b, c, d, e, f, g, h, i, j, k, l));
+        let toString = o -> ToString.toString(o as (a, b, c, d, e, f, g, h, i, j, k, l));
+        BoxedObject(value, compare, toString)
+    }
+    pub def unbox(x: Boxed): (a, b, c, d, e, f, g, h, i, j, k, l) = match x {
+        case BoxedObject(v, _, _) => v as (a, b, c, d, e, f, g, h, i, j, k, l)
+        case _                    => ?bug
+    }
+}
+
+instance Boxable[(a, b, c, d, e, f, g, h, i, j, k, l, m)] with Boxable[a], Boxable[b], Boxable[c], Boxable[d], Boxable[e], Boxable[f], Boxable[g], Boxable[h], Boxable[i], Boxable[j], Boxable[k], Boxable[l], Boxable[m] {
+    pub def box(x: (a, b, c, d, e, f, g, h, i, j, k, l, m)): Boxed = {
+        let value = x as ##java.lang.Object;
+        let compare = (o1, o2) -> Order.compare(o1 as (a, b, c, d, e, f, g, h, i, j, k, l, m), o2 as (a, b, c, d, e, f, g, h, i, j, k, l, m));
+        let toString = o -> ToString.toString(o as (a, b, c, d, e, f, g, h, i, j, k, l, m));
+        BoxedObject(value, compare, toString)
+    }
+    pub def unbox(x: Boxed): (a, b, c, d, e, f, g, h, i, j, k, l, m) = match x {
+        case BoxedObject(v, _, _) => v as (a, b, c, d, e, f, g, h, i, j, k, l, m)
+        case _                    => ?bug
+    }
+}
+
+instance Boxable[(a, b, c, d, e, f, g, h, i, j, k, l, m, n)] with Boxable[a], Boxable[b], Boxable[c], Boxable[d], Boxable[e], Boxable[f], Boxable[g], Boxable[h], Boxable[i], Boxable[j], Boxable[k], Boxable[l], Boxable[m], Boxable[n] {
+    pub def box(x: (a, b, c, d, e, f, g, h, i, j, k, l, m, n)): Boxed = {
+        let value = x as ##java.lang.Object;
+        let compare = (o1, o2) -> Order.compare(o1 as (a, b, c, d, e, f, g, h, i, j, k, l, m, n), o2 as (a, b, c, d, e, f, g, h, i, j, k, l, m, n));
+        let toString = o -> ToString.toString(o as (a, b, c, d, e, f, g, h, i, j, k, l, m, n));
+        BoxedObject(value, compare, toString)
+    }
+    pub def unbox(x: Boxed): (a, b, c, d, e, f, g, h, i, j, k, l, m, n) = match x {
+        case BoxedObject(v, _, _) => v as (a, b, c, d, e, f, g, h, i, j, k, l, m, n)
+        case _                    => ?bug
+    }
+}
+
+instance Boxable[(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)] with Boxable[a], Boxable[b], Boxable[c], Boxable[d], Boxable[e], Boxable[f], Boxable[g], Boxable[h], Boxable[i], Boxable[j], Boxable[k], Boxable[l], Boxable[m], Boxable[n], Boxable[o] {
+    pub def box(x: (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)): Boxed = {
+        let value = x as ##java.lang.Object;
+        let compare = (o1, o2) -> Order.compare(o1 as (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o), o2 as (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o));
+        let toString = o -> ToString.toString(o as (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o));
+        BoxedObject(value, compare, toString)
+    }
+    pub def unbox(x: Boxed): (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) = match x {
+        case BoxedObject(v, _, _) => v as (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)
+        case _                    => ?bug
+    }
+}

--- a/main/src/library/Eq.flix
+++ b/main/src/library/Eq.flix
@@ -183,3 +183,48 @@ instance Eq[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with Eq[a1], Eq[a2], Eq[a
             x1 == y1 and x2 == y2 and x3 == y3 and x4 == y4 and x5 == y5 and x6 == y6 and x7 == y7 and x8 == y8 and x9 == y9 and x10 == y10
 
 }
+
+instance Eq[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)] with Eq[a1], Eq[a2], Eq[a3], Eq[a4], Eq[a5], Eq[a6], Eq[a7], Eq[a8], Eq[a9], Eq[a10], Eq[a11] {
+
+    pub def eq(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)): Bool =
+        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) = t1;
+        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11) = t2;
+            x1 == y1 and x2 == y2 and x3 == y3 and x4 == y4 and x5 == y5 and x6 == y6 and x7 == y7 and x8 == y8 and x9 == y9 and x10 == y10 and x11 == y11
+
+}
+
+instance Eq[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)] with Eq[a1], Eq[a2], Eq[a3], Eq[a4], Eq[a5], Eq[a6], Eq[a7], Eq[a8], Eq[a9], Eq[a10], Eq[a11], Eq[a12] {
+
+    pub def eq(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)): Bool =
+        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) = t1;
+        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12) = t2;
+            x1 == y1 and x2 == y2 and x3 == y3 and x4 == y4 and x5 == y5 and x6 == y6 and x7 == y7 and x8 == y8 and x9 == y9 and x10 == y10 and x11 == y11 and x12 == y12
+
+}
+
+instance Eq[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)] with Eq[a1], Eq[a2], Eq[a3], Eq[a4], Eq[a5], Eq[a6], Eq[a7], Eq[a8], Eq[a9], Eq[a10], Eq[a11], Eq[a12], Eq[a13] {
+
+    pub def eq(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)): Bool =
+        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13) = t1;
+        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13) = t2;
+            x1 == y1 and x2 == y2 and x3 == y3 and x4 == y4 and x5 == y5 and x6 == y6 and x7 == y7 and x8 == y8 and x9 == y9 and x10 == y10 and x11 == y11 and x12 == y12 and x13 == y13
+
+}
+
+instance Eq[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)] with Eq[a1], Eq[a2], Eq[a3], Eq[a4], Eq[a5], Eq[a6], Eq[a7], Eq[a8], Eq[a9], Eq[a10], Eq[a11], Eq[a12], Eq[a13], Eq[a14] {
+
+    pub def eq(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)): Bool =
+        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14) = t1;
+        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14) = t2;
+            x1 == y1 and x2 == y2 and x3 == y3 and x4 == y4 and x5 == y5 and x6 == y6 and x7 == y7 and x8 == y8 and x9 == y9 and x10 == y10 and x11 == y11 and x12 == y12 and x13 == y13 and x14 == y14
+
+}
+
+instance Eq[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)] with Eq[a1], Eq[a2], Eq[a3], Eq[a4], Eq[a5], Eq[a6], Eq[a7], Eq[a8], Eq[a9], Eq[a10], Eq[a11], Eq[a12], Eq[a13], Eq[a14], Eq[a15] {
+
+    pub def eq(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)): Bool =
+        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) = t1;
+        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15) = t2;
+            x1 == y1 and x2 == y2 and x3 == y3 and x4 == y4 and x5 == y5 and x6 == y6 and x7 == y7 and x8 == y8 and x9 == y9 and x10 == y10 and x11 == y11 and x12 == y12 and x13 == y13 and x14 == y14 and x15 == y15
+
+}

--- a/main/src/library/Fixpoint/Ast/BodyPredicate.flix
+++ b/main/src/library/Fixpoint/Ast/BodyPredicate.flix
@@ -23,7 +23,16 @@ namespace Fixpoint/Ast {
         case Guard3(v -> v -> v -> Bool, VarSym, VarSym, VarSym, SourceLocation)
         case Guard4(v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, SourceLocation)
         case Guard5(v -> v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
-        /// TODO (spt)
+        case Guard6(v -> v -> v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case Guard7(v -> v -> v -> v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case Guard8(v -> v -> v -> v -> v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case Guard9(v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case Guard10(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case Guard11(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case Guard12(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case Guard13(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case Guard14(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case Guard15(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
     }
 
     instance ToString[BodyPredicate[v]] with ToString[v] {
@@ -46,6 +55,16 @@ namespace Fixpoint/Ast {
                 case Guard3(_, v1, v2, v3, _) => "<clo>(${v1}, ${v2}, ${v3})"
                 case Guard4(_, v1, v2, v3, v4, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4})"
                 case Guard5(_, v1, v2, v3, v4, v5, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5})"
+                case Guard6(_, v1, v2, v3, v4, v5, v6, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6})"
+                case Guard7(_, v1, v2, v3, v4, v5, v6, v7, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7})"
+                case Guard8(_, v1, v2, v3, v4, v5, v6, v7, v8, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8})"
+                case Guard9(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9})"
+                case Guard10(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10})"
+                case Guard11(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11})"
+                case Guard12(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12})"
+                case Guard13(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12}, ${v13})"
+                case Guard14(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12}, ${v13}, ${v14})"
+                case Guard15(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12}, ${v13}, ${v14}, ${v15})"
             }
     }
 }

--- a/main/src/library/Fixpoint/Ast/BodyPredicate.flix
+++ b/main/src/library/Fixpoint/Ast/BodyPredicate.flix
@@ -23,6 +23,7 @@ namespace Fixpoint/Ast {
         case Guard3(v -> v -> v -> Bool, VarSym, VarSym, VarSym, SourceLocation)
         case Guard4(v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, SourceLocation)
         case Guard5(v -> v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        /// TODO (spt)
     }
 
     instance ToString[BodyPredicate[v]] with ToString[v] {

--- a/main/src/library/Fixpoint/Ast/HeadTerm.flix
+++ b/main/src/library/Fixpoint/Ast/HeadTerm.flix
@@ -23,7 +23,16 @@ namespace Fixpoint/Ast {
         case App3(v -> v -> v -> v, VarSym, VarSym, VarSym, SourceLocation)
         case App4(v -> v -> v -> v -> v, VarSym, VarSym, VarSym, VarSym, SourceLocation)
         case App5(v -> v -> v -> v -> v -> v, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
-        /// TODO (spt)
+        case App6(v -> v -> v -> v -> v -> v -> v, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case App7(v -> v -> v -> v -> v -> v -> v -> v, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case App8(v -> v -> v -> v -> v -> v -> v -> v -> v, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)        
+        case App9(v -> v -> v -> v -> v -> v -> v -> v -> v -> v, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case App10(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case App11(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case App12(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case App13(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case App14(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        case App15(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
     }
 
     instance ToString[HeadTerm[v]] with ToString[v] {
@@ -36,6 +45,16 @@ namespace Fixpoint/Ast {
             case HeadTerm.App3(_, v1, v2, v3, _) => "<clo>(${v1}, ${v2}, ${v3})"
             case HeadTerm.App4(_, v1, v2, v3, v4, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4})"
             case HeadTerm.App5(_, v1, v2, v3, v4, v5, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5})"
+            case HeadTerm.App6(_, v1, v2, v3, v4, v5, v6, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6})"
+            case HeadTerm.App7(_, v1, v2, v3, v4, v5, v6, v7, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7})"
+            case HeadTerm.App8(_, v1, v2, v3, v4, v5, v6, v7, v8, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8})"
+            case HeadTerm.App9(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9})"
+            case HeadTerm.App10(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10})"
+            case HeadTerm.App11(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11})"
+            case HeadTerm.App12(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12})"
+            case HeadTerm.App13(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12}, ${v13})"
+            case HeadTerm.App14(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12}, ${v13}, ${v14})"
+            case HeadTerm.App15(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, _) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12}, ${v13}, ${v14}, ${v15})"
         }
     }
 }

--- a/main/src/library/Fixpoint/Ast/HeadTerm.flix
+++ b/main/src/library/Fixpoint/Ast/HeadTerm.flix
@@ -23,6 +23,7 @@ namespace Fixpoint/Ast {
         case App3(v -> v -> v -> v, VarSym, VarSym, VarSym, SourceLocation)
         case App4(v -> v -> v -> v -> v, VarSym, VarSym, VarSym, VarSym, SourceLocation)
         case App5(v -> v -> v -> v -> v -> v, VarSym, VarSym, VarSym, VarSym, VarSym, SourceLocation)
+        /// TODO (spt)
     }
 
     instance ToString[HeadTerm[v]] with ToString[v] {

--- a/main/src/library/Fixpoint/Compiler.flix
+++ b/main/src/library/Fixpoint/Compiler.flix
@@ -19,7 +19,7 @@ use Fixpoint/Ast.{Datalog, Constraint, BodyPredicate, BodyTerm, HeadTerm, Denota
 use Fixpoint/Ast.Datalog.Datalog;
 use Fixpoint/Ast.Constraint.Constraint;
 use Fixpoint/Ast.HeadPredicate.HeadAtom;
-use Fixpoint/Ast.BodyPredicate.{BodyAtom, Guard0, Guard1, Guard2, Guard3, Guard4, Guard5};
+use Fixpoint/Ast.BodyPredicate.{BodyAtom, Guard0, Guard1, Guard2, Guard3, Guard4, Guard5, Guard6, Guard7, Guard8, Guard9, Guard10, Guard11, Guard12, Guard13, Guard14, Guard15};
 use Fixpoint/Ast.PredSym.PredSym;
 
 namespace Fixpoint {
@@ -155,6 +155,131 @@ namespace Fixpoint {
             let t4 = unwrap(Map.get(v4, env));
             let t5 = unwrap(Map.get(v5, env));
             RamTerm.App5(f, t1, t2, t3, t4, t5)
+        case HeadTerm.App6(f, v1, v2, v3, v4, v5, v6, _) =>
+            let t1 = unwrap(Map.get(v1, env));
+            let t2 = unwrap(Map.get(v2, env));
+            let t3 = unwrap(Map.get(v3, env));
+            let t4 = unwrap(Map.get(v4, env));
+            let t5 = unwrap(Map.get(v5, env));
+            let t6 = unwrap(Map.get(v6, env));
+            RamTerm.App6(f, t1, t2, t3, t4, t5, t6)
+        case HeadTerm.App7(f, v1, v2, v3, v4, v5, v6, v7, _) =>
+            let t1 = unwrap(Map.get(v1, env));
+            let t2 = unwrap(Map.get(v2, env));
+            let t3 = unwrap(Map.get(v3, env));
+            let t4 = unwrap(Map.get(v4, env));
+            let t5 = unwrap(Map.get(v5, env));
+            let t6 = unwrap(Map.get(v6, env));
+            let t7 = unwrap(Map.get(v7, env));
+            RamTerm.App7(f, t1, t2, t3, t4, t5, t6, t7)
+        case HeadTerm.App8(f, v1, v2, v3, v4, v5, v6, v7, v8, _) =>
+            let t1 = unwrap(Map.get(v1, env));
+            let t2 = unwrap(Map.get(v2, env));
+            let t3 = unwrap(Map.get(v3, env));
+            let t4 = unwrap(Map.get(v4, env));
+            let t5 = unwrap(Map.get(v5, env));
+            let t6 = unwrap(Map.get(v6, env));
+            let t7 = unwrap(Map.get(v7, env));
+            let t8 = unwrap(Map.get(v8, env));
+            RamTerm.App8(f, t1, t2, t3, t4, t5, t6, t7, t8)
+        case HeadTerm.App9(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, _) =>
+            let t1 = unwrap(Map.get(v1, env));
+            let t2 = unwrap(Map.get(v2, env));
+            let t3 = unwrap(Map.get(v3, env));
+            let t4 = unwrap(Map.get(v4, env));
+            let t5 = unwrap(Map.get(v5, env));
+            let t6 = unwrap(Map.get(v6, env));
+            let t7 = unwrap(Map.get(v7, env));
+            let t8 = unwrap(Map.get(v8, env));
+            let t9 = unwrap(Map.get(v9, env));
+            RamTerm.App9(f, t1, t2, t3, t4, t5, t6, t7, t8, t9)
+        case HeadTerm.App10(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, _) =>
+            let t1 = unwrap(Map.get(v1, env));
+            let t2 = unwrap(Map.get(v2, env));
+            let t3 = unwrap(Map.get(v3, env));
+            let t4 = unwrap(Map.get(v4, env));
+            let t5 = unwrap(Map.get(v5, env));
+            let t6 = unwrap(Map.get(v6, env));
+            let t7 = unwrap(Map.get(v7, env));
+            let t8 = unwrap(Map.get(v8, env));
+            let t9 = unwrap(Map.get(v9, env));
+            let t10 = unwrap(Map.get(v10, env));
+            RamTerm.App10(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)
+        case HeadTerm.App11(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, _) =>
+            let t1 = unwrap(Map.get(v1, env));
+            let t2 = unwrap(Map.get(v2, env));
+            let t3 = unwrap(Map.get(v3, env));
+            let t4 = unwrap(Map.get(v4, env));
+            let t5 = unwrap(Map.get(v5, env));
+            let t6 = unwrap(Map.get(v6, env));
+            let t7 = unwrap(Map.get(v7, env));
+            let t8 = unwrap(Map.get(v8, env));
+            let t9 = unwrap(Map.get(v9, env));
+            let t10 = unwrap(Map.get(v10, env));
+            let t11 = unwrap(Map.get(v11, env));
+            RamTerm.App11(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)
+        case HeadTerm.App12(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, _) =>
+            let t1 = unwrap(Map.get(v1, env));
+            let t2 = unwrap(Map.get(v2, env));
+            let t3 = unwrap(Map.get(v3, env));
+            let t4 = unwrap(Map.get(v4, env));
+            let t5 = unwrap(Map.get(v5, env));
+            let t6 = unwrap(Map.get(v6, env));
+            let t7 = unwrap(Map.get(v7, env));
+            let t8 = unwrap(Map.get(v8, env));
+            let t9 = unwrap(Map.get(v9, env));
+            let t10 = unwrap(Map.get(v10, env));
+            let t11 = unwrap(Map.get(v11, env));
+            let t12 = unwrap(Map.get(v12, env));
+            RamTerm.App12(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)
+        case HeadTerm.App13(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, _) =>
+            let t1 = unwrap(Map.get(v1, env));
+            let t2 = unwrap(Map.get(v2, env));
+            let t3 = unwrap(Map.get(v3, env));
+            let t4 = unwrap(Map.get(v4, env));
+            let t5 = unwrap(Map.get(v5, env));
+            let t6 = unwrap(Map.get(v6, env));
+            let t7 = unwrap(Map.get(v7, env));
+            let t8 = unwrap(Map.get(v8, env));
+            let t9 = unwrap(Map.get(v9, env));
+            let t10 = unwrap(Map.get(v10, env));
+            let t11 = unwrap(Map.get(v11, env));
+            let t12 = unwrap(Map.get(v12, env));
+            let t13 = unwrap(Map.get(v13, env));
+            RamTerm.App13(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)
+        case HeadTerm.App14(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, _) =>
+            let t1 = unwrap(Map.get(v1, env));
+            let t2 = unwrap(Map.get(v2, env));
+            let t3 = unwrap(Map.get(v3, env));
+            let t4 = unwrap(Map.get(v4, env));
+            let t5 = unwrap(Map.get(v5, env));
+            let t6 = unwrap(Map.get(v6, env));
+            let t7 = unwrap(Map.get(v7, env));
+            let t8 = unwrap(Map.get(v8, env));
+            let t9 = unwrap(Map.get(v9, env));
+            let t10 = unwrap(Map.get(v10, env));
+            let t11 = unwrap(Map.get(v11, env));
+            let t12 = unwrap(Map.get(v12, env));
+            let t13 = unwrap(Map.get(v13, env));
+            let t14 = unwrap(Map.get(v14, env));
+            RamTerm.App14(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)
+        case HeadTerm.App15(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, _) =>
+            let t1 = unwrap(Map.get(v1, env));
+            let t2 = unwrap(Map.get(v2, env));
+            let t3 = unwrap(Map.get(v3, env));
+            let t4 = unwrap(Map.get(v4, env));
+            let t5 = unwrap(Map.get(v5, env));
+            let t6 = unwrap(Map.get(v6, env));
+            let t7 = unwrap(Map.get(v7, env));
+            let t8 = unwrap(Map.get(v8, env));
+            let t9 = unwrap(Map.get(v9, env));
+            let t10 = unwrap(Map.get(v10, env));
+            let t11 = unwrap(Map.get(v11, env));
+            let t12 = unwrap(Map.get(v12, env));
+            let t13 = unwrap(Map.get(v13, env));
+            let t14 = unwrap(Map.get(v14, env));
+            let t15 = unwrap(Map.get(v15, env));
+            RamTerm.App15(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)
     }
 
     /// Augment body atoms with row variables.
@@ -239,6 +364,131 @@ namespace Fixpoint {
                     let t4 = unwrap(Map.get(v4, env));
                     let t5 = unwrap(Map.get(v5, env));
                     BoolExp.Guard5(f, t1, t2, t3, t4, t5) :: acc
+                case Guard6(f, v1, v2, v3, v4, v5, v6, _) =>
+                    let t1 = unwrap(Map.get(v1, env));
+                    let t2 = unwrap(Map.get(v2, env));
+                    let t3 = unwrap(Map.get(v3, env));
+                    let t4 = unwrap(Map.get(v4, env));
+                    let t5 = unwrap(Map.get(v5, env));
+                    let t6 = unwrap(Map.get(v6, env));
+                    BoolExp.Guard6(f, t1, t2, t3, t4, t5, t6) :: acc
+                case Guard7(f, v1, v2, v3, v4, v5, v6, v7, _) =>
+                    let t1 = unwrap(Map.get(v1, env));
+                    let t2 = unwrap(Map.get(v2, env));
+                    let t3 = unwrap(Map.get(v3, env));
+                    let t4 = unwrap(Map.get(v4, env));
+                    let t5 = unwrap(Map.get(v5, env));
+                    let t6 = unwrap(Map.get(v6, env));
+                    let t7 = unwrap(Map.get(v7, env));
+                    BoolExp.Guard7(f, t1, t2, t3, t4, t5, t6, t7) :: acc
+                case Guard8(f, v1, v2, v3, v4, v5, v6, v7, v8, _) =>
+                    let t1 = unwrap(Map.get(v1, env));
+                    let t2 = unwrap(Map.get(v2, env));
+                    let t3 = unwrap(Map.get(v3, env));
+                    let t4 = unwrap(Map.get(v4, env));
+                    let t5 = unwrap(Map.get(v5, env));
+                    let t6 = unwrap(Map.get(v6, env));
+                    let t7 = unwrap(Map.get(v7, env));
+                    let t8 = unwrap(Map.get(v8, env));
+                    BoolExp.Guard8(f, t1, t2, t3, t4, t5, t6, t7, t8) :: acc
+                case Guard9(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, _) =>
+                    let t1 = unwrap(Map.get(v1, env));
+                    let t2 = unwrap(Map.get(v2, env));
+                    let t3 = unwrap(Map.get(v3, env));
+                    let t4 = unwrap(Map.get(v4, env));
+                    let t5 = unwrap(Map.get(v5, env));
+                    let t6 = unwrap(Map.get(v6, env));
+                    let t7 = unwrap(Map.get(v7, env));
+                    let t8 = unwrap(Map.get(v8, env));
+                    let t9 = unwrap(Map.get(v9, env));
+                    BoolExp.Guard9(f, t1, t2, t3, t4, t5, t6, t7, t8, t9) :: acc
+                case Guard10(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, _) =>
+                    let t1 = unwrap(Map.get(v1, env));
+                    let t2 = unwrap(Map.get(v2, env));
+                    let t3 = unwrap(Map.get(v3, env));
+                    let t4 = unwrap(Map.get(v4, env));
+                    let t5 = unwrap(Map.get(v5, env));
+                    let t6 = unwrap(Map.get(v6, env));
+                    let t7 = unwrap(Map.get(v7, env));
+                    let t8 = unwrap(Map.get(v8, env));
+                    let t9 = unwrap(Map.get(v9, env));
+                    let t10 = unwrap(Map.get(v10, env));
+                    BoolExp.Guard10(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) :: acc
+                case Guard11(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, _) =>
+                    let t1 = unwrap(Map.get(v1, env));
+                    let t2 = unwrap(Map.get(v2, env));
+                    let t3 = unwrap(Map.get(v3, env));
+                    let t4 = unwrap(Map.get(v4, env));
+                    let t5 = unwrap(Map.get(v5, env));
+                    let t6 = unwrap(Map.get(v6, env));
+                    let t7 = unwrap(Map.get(v7, env));
+                    let t8 = unwrap(Map.get(v8, env));
+                    let t9 = unwrap(Map.get(v9, env));
+                    let t10 = unwrap(Map.get(v10, env));
+                    let t11 = unwrap(Map.get(v11, env));
+                    BoolExp.Guard11(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11) :: acc
+                case Guard12(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, _) =>
+                    let t1 = unwrap(Map.get(v1, env));
+                    let t2 = unwrap(Map.get(v2, env));
+                    let t3 = unwrap(Map.get(v3, env));
+                    let t4 = unwrap(Map.get(v4, env));
+                    let t5 = unwrap(Map.get(v5, env));
+                    let t6 = unwrap(Map.get(v6, env));
+                    let t7 = unwrap(Map.get(v7, env));
+                    let t8 = unwrap(Map.get(v8, env));
+                    let t9 = unwrap(Map.get(v9, env));
+                    let t10 = unwrap(Map.get(v10, env));
+                    let t11 = unwrap(Map.get(v11, env));
+                    let t12 = unwrap(Map.get(v12, env));
+                    BoolExp.Guard12(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12) :: acc
+                case Guard13(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, _) =>
+                    let t1 = unwrap(Map.get(v1, env));
+                    let t2 = unwrap(Map.get(v2, env));
+                    let t3 = unwrap(Map.get(v3, env));
+                    let t4 = unwrap(Map.get(v4, env));
+                    let t5 = unwrap(Map.get(v5, env));
+                    let t6 = unwrap(Map.get(v6, env));
+                    let t7 = unwrap(Map.get(v7, env));
+                    let t8 = unwrap(Map.get(v8, env));
+                    let t9 = unwrap(Map.get(v9, env));
+                    let t10 = unwrap(Map.get(v10, env));
+                    let t11 = unwrap(Map.get(v11, env));
+                    let t12 = unwrap(Map.get(v12, env));
+                    let t13 = unwrap(Map.get(v13, env));
+                    BoolExp.Guard13(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13) :: acc
+                case Guard14(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, _) =>
+                    let t1 = unwrap(Map.get(v1, env));
+                    let t2 = unwrap(Map.get(v2, env));
+                    let t3 = unwrap(Map.get(v3, env));
+                    let t4 = unwrap(Map.get(v4, env));
+                    let t5 = unwrap(Map.get(v5, env));
+                    let t6 = unwrap(Map.get(v6, env));
+                    let t7 = unwrap(Map.get(v7, env));
+                    let t8 = unwrap(Map.get(v8, env));
+                    let t9 = unwrap(Map.get(v9, env));
+                    let t10 = unwrap(Map.get(v10, env));
+                    let t11 = unwrap(Map.get(v11, env));
+                    let t12 = unwrap(Map.get(v12, env));
+                    let t13 = unwrap(Map.get(v13, env));
+                    let t14 = unwrap(Map.get(v14, env));
+                    BoolExp.Guard14(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14) :: acc
+                case Guard15(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, _) =>
+                    let t1 = unwrap(Map.get(v1, env));
+                    let t2 = unwrap(Map.get(v2, env));
+                    let t3 = unwrap(Map.get(v3, env));
+                    let t4 = unwrap(Map.get(v4, env));
+                    let t5 = unwrap(Map.get(v5, env));
+                    let t6 = unwrap(Map.get(v6, env));
+                    let t7 = unwrap(Map.get(v7, env));
+                    let t8 = unwrap(Map.get(v8, env));
+                    let t9 = unwrap(Map.get(v9, env));
+                    let t10 = unwrap(Map.get(v10, env));
+                    let t11 = unwrap(Map.get(v11, env));
+                    let t12 = unwrap(Map.get(v12, env));
+                    let t13 = unwrap(Map.get(v13, env));
+                    let t14 = unwrap(Map.get(v14, env));
+                    let t15 = unwrap(Map.get(v15, env));
+                    BoolExp.Guard15(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15) :: acc
             }, Nil, body) as & Pure
 
     /// Restrict a constraint system to those constraints whose head predicate belongs to the given domain.

--- a/main/src/library/Fixpoint/IndexSelection.flix
+++ b/main/src/library/Fixpoint/IndexSelection.flix
@@ -137,6 +137,51 @@ namespace Fixpoint {
             isTermGround(freeVars, t3) and
             isTermGround(freeVars, t4) and
             isTermGround(freeVars, t5)
+        case BoolExp.Guard6(_, t1, t2, t3, t4, t5, t6) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6)
+        case BoolExp.Guard7(_, t1, t2, t3, t4, t5, t6, t7) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7)
+        case BoolExp.Guard8(_, t1, t2, t3, t4, t5, t6, t7, t8) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8)
+        case BoolExp.Guard9(_, t1, t2, t3, t4, t5, t6, t7, t8, t9) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8) and
+            isTermGround(freeVars, t9)
+        case BoolExp.Guard10(_, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8) and
+            isTermGround(freeVars, t9) and
+            isTermGround(freeVars, t10)
     }
 
     /// A term is ground if it is a literal or a free variable.
@@ -167,5 +212,50 @@ namespace Fixpoint {
             isTermGround(freeVars, t3) and
             isTermGround(freeVars, t4) and
             isTermGround(freeVars, t5)
+        case RamTerm.App6(_, t1, t2, t3, t4, t5, t6) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6)
+        case RamTerm.App7(_, t1, t2, t3, t4, t5, t6, t7) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7)
+        case RamTerm.App8(_, t1, t2, t3, t4, t5, t6, t7, t8) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8)
+        case RamTerm.App9(_, t1, t2, t3, t4, t5, t6, t7, t8, t9) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8) and
+            isTermGround(freeVars, t9)
+        case RamTerm.App10(_, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8) and
+            isTermGround(freeVars, t9) and
+            isTermGround(freeVars, t10)
     }
 }

--- a/main/src/library/Fixpoint/IndexSelection.flix
+++ b/main/src/library/Fixpoint/IndexSelection.flix
@@ -182,6 +182,76 @@ namespace Fixpoint {
             isTermGround(freeVars, t8) and
             isTermGround(freeVars, t9) and
             isTermGround(freeVars, t10)
+        case BoolExp.Guard11(_, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8) and
+            isTermGround(freeVars, t9) and
+            isTermGround(freeVars, t10) and
+            isTermGround(freeVars, t11)
+        case BoolExp.Guard12(_, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8) and
+            isTermGround(freeVars, t9) and
+            isTermGround(freeVars, t10) and
+            isTermGround(freeVars, t11) and
+            isTermGround(freeVars, t12)
+        case BoolExp.Guard13(_, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8) and
+            isTermGround(freeVars, t9) and
+            isTermGround(freeVars, t10) and
+            isTermGround(freeVars, t11) and
+            isTermGround(freeVars, t12) and
+            isTermGround(freeVars, t13)
+        case BoolExp.Guard14(_, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8) and
+            isTermGround(freeVars, t9) and
+            isTermGround(freeVars, t10) and
+            isTermGround(freeVars, t11) and
+            isTermGround(freeVars, t12) and
+            isTermGround(freeVars, t13) and
+            isTermGround(freeVars, t14)
+        case BoolExp.Guard15(_, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8) and
+            isTermGround(freeVars, t9) and
+            isTermGround(freeVars, t10) and
+            isTermGround(freeVars, t11) and
+            isTermGround(freeVars, t12) and
+            isTermGround(freeVars, t13) and
+            isTermGround(freeVars, t14) and
+            isTermGround(freeVars, t15)
     }
 
     /// A term is ground if it is a literal or a free variable.
@@ -257,5 +327,75 @@ namespace Fixpoint {
             isTermGround(freeVars, t8) and
             isTermGround(freeVars, t9) and
             isTermGround(freeVars, t10)
+        case RamTerm.App11(_, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8) and
+            isTermGround(freeVars, t9) and
+            isTermGround(freeVars, t10) and
+            isTermGround(freeVars, t11)
+        case RamTerm.App12(_, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8) and
+            isTermGround(freeVars, t9) and
+            isTermGround(freeVars, t10) and
+            isTermGround(freeVars, t11) and
+            isTermGround(freeVars, t12)
+        case RamTerm.App13(_, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8) and
+            isTermGround(freeVars, t9) and
+            isTermGround(freeVars, t10) and
+            isTermGround(freeVars, t11) and
+            isTermGround(freeVars, t12) and
+            isTermGround(freeVars, t13)
+        case RamTerm.App14(_, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8) and
+            isTermGround(freeVars, t9) and
+            isTermGround(freeVars, t10) and
+            isTermGround(freeVars, t11) and
+            isTermGround(freeVars, t12) and
+            isTermGround(freeVars, t13) and
+            isTermGround(freeVars, t14)
+        case RamTerm.App15(_, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15) =>
+            isTermGround(freeVars, t1) and
+            isTermGround(freeVars, t2) and
+            isTermGround(freeVars, t3) and
+            isTermGround(freeVars, t4) and
+            isTermGround(freeVars, t5) and
+            isTermGround(freeVars, t6) and
+            isTermGround(freeVars, t7) and
+            isTermGround(freeVars, t8) and
+            isTermGround(freeVars, t9) and
+            isTermGround(freeVars, t10) and
+            isTermGround(freeVars, t11) and
+            isTermGround(freeVars, t12) and
+            isTermGround(freeVars, t13) and
+            isTermGround(freeVars, t14) and
+            isTermGround(freeVars, t15)
     }
 }

--- a/main/src/library/Fixpoint/Interpreter.flix
+++ b/main/src/library/Fixpoint/Interpreter.flix
@@ -204,6 +204,81 @@ namespace Fixpoint {
                 let v9 = evalTerm(env, t9);
                 let v10 = evalTerm(env, t10);
                 f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)(v9)(v10)
+            case BoolExp.Guard11(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11) =>
+                let v1 = evalTerm(env, t1);
+                let v2 = evalTerm(env, t2);
+                let v3 = evalTerm(env, t3);
+                let v4 = evalTerm(env, t4);
+                let v5 = evalTerm(env, t5);
+                let v6 = evalTerm(env, t6);
+                let v7 = evalTerm(env, t7);
+                let v8 = evalTerm(env, t8);
+                let v9 = evalTerm(env, t9);
+                let v10 = evalTerm(env, t10);
+                let v11 = evalTerm(env, t11);
+                f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)(v9)(v10)(v11)
+            case BoolExp.Guard12(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12) =>
+                let v1 = evalTerm(env, t1);
+                let v2 = evalTerm(env, t2);
+                let v3 = evalTerm(env, t3);
+                let v4 = evalTerm(env, t4);
+                let v5 = evalTerm(env, t5);
+                let v6 = evalTerm(env, t6);
+                let v7 = evalTerm(env, t7);
+                let v8 = evalTerm(env, t8);
+                let v9 = evalTerm(env, t9);
+                let v10 = evalTerm(env, t10);
+                let v11 = evalTerm(env, t11);
+                let v12 = evalTerm(env, t12);
+                f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)(v9)(v10)(v11)(v12)
+            case BoolExp.Guard13(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13) =>
+                let v1 = evalTerm(env, t1);
+                let v2 = evalTerm(env, t2);
+                let v3 = evalTerm(env, t3);
+                let v4 = evalTerm(env, t4);
+                let v5 = evalTerm(env, t5);
+                let v6 = evalTerm(env, t6);
+                let v7 = evalTerm(env, t7);
+                let v8 = evalTerm(env, t8);
+                let v9 = evalTerm(env, t9);
+                let v10 = evalTerm(env, t10);
+                let v11 = evalTerm(env, t11);
+                let v12 = evalTerm(env, t12);
+                let v13 = evalTerm(env, t13);
+                f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)(v9)(v10)(v11)(v12)(v13)
+            case BoolExp.Guard14(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14) =>
+                let v1 = evalTerm(env, t1);
+                let v2 = evalTerm(env, t2);
+                let v3 = evalTerm(env, t3);
+                let v4 = evalTerm(env, t4);
+                let v5 = evalTerm(env, t5);
+                let v6 = evalTerm(env, t6);
+                let v7 = evalTerm(env, t7);
+                let v8 = evalTerm(env, t8);
+                let v9 = evalTerm(env, t9);
+                let v10 = evalTerm(env, t10);
+                let v11 = evalTerm(env, t11);
+                let v12 = evalTerm(env, t12);
+                let v13 = evalTerm(env, t13);
+                let v14 = evalTerm(env, t14);
+                f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)(v9)(v10)(v11)(v12)(v13)(v14)
+            case BoolExp.Guard15(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15) =>
+                let v1 = evalTerm(env, t1);
+                let v2 = evalTerm(env, t2);
+                let v3 = evalTerm(env, t3);
+                let v4 = evalTerm(env, t4);
+                let v5 = evalTerm(env, t5);
+                let v6 = evalTerm(env, t6);
+                let v7 = evalTerm(env, t7);
+                let v8 = evalTerm(env, t8);
+                let v9 = evalTerm(env, t9);
+                let v10 = evalTerm(env, t10);
+                let v11 = evalTerm(env, t11);
+                let v12 = evalTerm(env, t12);
+                let v13 = evalTerm(env, t13);
+                let v14 = evalTerm(env, t14);
+                let v15 = evalTerm(env, t15);
+                f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)(v9)(v10)(v11)(v12)(v13)(v14)(v15)
         } as & Pure, es)
 
     def evalTerm(env: SearchEnv[v], term: RamTerm[v]): v with ToString[v] = match term {
@@ -243,6 +318,131 @@ namespace Fixpoint {
             let v4 = evalTerm(env, t4);
             let v5 = evalTerm(env, t5);
             f(v1)(v2)(v3)(v4)(v5)
+        case RamTerm.App6(f, t1, t2, t3, t4, t5, t6) =>
+            let v1 = evalTerm(env, t1);
+            let v2 = evalTerm(env, t2);
+            let v3 = evalTerm(env, t3);
+            let v4 = evalTerm(env, t4);
+            let v5 = evalTerm(env, t5);
+            let v6 = evalTerm(env, t6);
+            f(v1)(v2)(v3)(v4)(v5)(v6)
+        case RamTerm.App7(f, t1, t2, t3, t4, t5, t6, t7) =>
+            let v1 = evalTerm(env, t1);
+            let v2 = evalTerm(env, t2);
+            let v3 = evalTerm(env, t3);
+            let v4 = evalTerm(env, t4);
+            let v5 = evalTerm(env, t5);
+            let v6 = evalTerm(env, t6);
+            let v7 = evalTerm(env, t7);
+            f(v1)(v2)(v3)(v4)(v5)(v6)(v7)
+        case RamTerm.App8(f, t1, t2, t3, t4, t5, t6, t7, t8) =>
+            let v1 = evalTerm(env, t1);
+            let v2 = evalTerm(env, t2);
+            let v3 = evalTerm(env, t3);
+            let v4 = evalTerm(env, t4);
+            let v5 = evalTerm(env, t5);
+            let v6 = evalTerm(env, t6);
+            let v7 = evalTerm(env, t7);
+            let v8 = evalTerm(env, t8);
+            f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)
+        case RamTerm.App9(f, t1, t2, t3, t4, t5, t6, t7, t8, t9) =>
+            let v1 = evalTerm(env, t1);
+            let v2 = evalTerm(env, t2);
+            let v3 = evalTerm(env, t3);
+            let v4 = evalTerm(env, t4);
+            let v5 = evalTerm(env, t5);
+            let v6 = evalTerm(env, t6);
+            let v7 = evalTerm(env, t7);
+            let v8 = evalTerm(env, t8);
+            let v9 = evalTerm(env, t9);
+            f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)(v9)
+        case RamTerm.App10(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) =>
+            let v1 = evalTerm(env, t1);
+            let v2 = evalTerm(env, t2);
+            let v3 = evalTerm(env, t3);
+            let v4 = evalTerm(env, t4);
+            let v5 = evalTerm(env, t5);
+            let v6 = evalTerm(env, t6);
+            let v7 = evalTerm(env, t7);
+            let v8 = evalTerm(env, t8);
+            let v9 = evalTerm(env, t9);
+            let v10 = evalTerm(env, t10);
+            f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)(v9)(v10)
+        case RamTerm.App11(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11) =>
+            let v1 = evalTerm(env, t1);
+            let v2 = evalTerm(env, t2);
+            let v3 = evalTerm(env, t3);
+            let v4 = evalTerm(env, t4);
+            let v5 = evalTerm(env, t5);
+            let v6 = evalTerm(env, t6);
+            let v7 = evalTerm(env, t7);
+            let v8 = evalTerm(env, t8);
+            let v9 = evalTerm(env, t9);
+            let v10 = evalTerm(env, t10);
+            let v11 = evalTerm(env, t11);
+            f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)(v9)(v10)(v11)
+        case RamTerm.App12(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12) =>
+            let v1 = evalTerm(env, t1);
+            let v2 = evalTerm(env, t2);
+            let v3 = evalTerm(env, t3);
+            let v4 = evalTerm(env, t4);
+            let v5 = evalTerm(env, t5);
+            let v6 = evalTerm(env, t6);
+            let v7 = evalTerm(env, t7);
+            let v8 = evalTerm(env, t8);
+            let v9 = evalTerm(env, t9);
+            let v10 = evalTerm(env, t10);
+            let v11 = evalTerm(env, t11);
+            let v12 = evalTerm(env, t12);
+            f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)(v9)(v10)(v11)(v12)
+        case RamTerm.App13(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13) =>
+            let v1 = evalTerm(env, t1);
+            let v2 = evalTerm(env, t2);
+            let v3 = evalTerm(env, t3);
+            let v4 = evalTerm(env, t4);
+            let v5 = evalTerm(env, t5);
+            let v6 = evalTerm(env, t6);
+            let v7 = evalTerm(env, t7);
+            let v8 = evalTerm(env, t8);
+            let v9 = evalTerm(env, t9);
+            let v10 = evalTerm(env, t10);
+            let v11 = evalTerm(env, t11);
+            let v12 = evalTerm(env, t12);
+            let v13 = evalTerm(env, t13);
+            f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)(v9)(v10)(v11)(v12)(v13)
+        case RamTerm.App14(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14) =>
+            let v1 = evalTerm(env, t1);
+            let v2 = evalTerm(env, t2);
+            let v3 = evalTerm(env, t3);
+            let v4 = evalTerm(env, t4);
+            let v5 = evalTerm(env, t5);
+            let v6 = evalTerm(env, t6);
+            let v7 = evalTerm(env, t7);
+            let v8 = evalTerm(env, t8);
+            let v9 = evalTerm(env, t9);
+            let v10 = evalTerm(env, t10);
+            let v11 = evalTerm(env, t11);
+            let v12 = evalTerm(env, t12);
+            let v13 = evalTerm(env, t13);
+            let v14 = evalTerm(env, t14);
+            f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)(v9)(v10)(v11)(v12)(v13)(v14)
+        case RamTerm.App15(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15) =>
+            let v1 = evalTerm(env, t1);
+            let v2 = evalTerm(env, t2);
+            let v3 = evalTerm(env, t3);
+            let v4 = evalTerm(env, t4);
+            let v5 = evalTerm(env, t5);
+            let v6 = evalTerm(env, t6);
+            let v7 = evalTerm(env, t7);
+            let v8 = evalTerm(env, t8);
+            let v9 = evalTerm(env, t9);
+            let v10 = evalTerm(env, t10);
+            let v11 = evalTerm(env, t11);
+            let v12 = evalTerm(env, t12);
+            let v13 = evalTerm(env, t13);
+            let v14 = evalTerm(env, t14);
+            let v15 = evalTerm(env, t15);
+            f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)(v9)(v10)(v11)(v12)(v13)(v14)(v15)
         case _ => bug!("Illegal term ${term}")
     }
 }

--- a/main/src/library/Fixpoint/Interpreter.flix
+++ b/main/src/library/Fixpoint/Interpreter.flix
@@ -154,6 +154,56 @@ namespace Fixpoint {
                 let v4 = evalTerm(env, t4);
                 let v5 = evalTerm(env, t5);
                 f(v1)(v2)(v3)(v4)(v5)
+            case BoolExp.Guard6(f, t1, t2, t3, t4, t5, t6) =>
+                let v1 = evalTerm(env, t1);
+                let v2 = evalTerm(env, t2);
+                let v3 = evalTerm(env, t3);
+                let v4 = evalTerm(env, t4);
+                let v5 = evalTerm(env, t5);
+                let v6 = evalTerm(env, t6);
+                f(v1)(v2)(v3)(v4)(v5)(v6)                
+            case BoolExp.Guard7(f, t1, t2, t3, t4, t5, t6, t7) =>
+                let v1 = evalTerm(env, t1);
+                let v2 = evalTerm(env, t2);
+                let v3 = evalTerm(env, t3);
+                let v4 = evalTerm(env, t4);
+                let v5 = evalTerm(env, t5);
+                let v6 = evalTerm(env, t6);
+                let v7 = evalTerm(env, t7);
+                f(v1)(v2)(v3)(v4)(v5)(v6)(v7)
+            case BoolExp.Guard8(f, t1, t2, t3, t4, t5, t6, t7, t8) =>
+                let v1 = evalTerm(env, t1);
+                let v2 = evalTerm(env, t2);
+                let v3 = evalTerm(env, t3);
+                let v4 = evalTerm(env, t4);
+                let v5 = evalTerm(env, t5);
+                let v6 = evalTerm(env, t6);
+                let v7 = evalTerm(env, t7);
+                let v8 = evalTerm(env, t8);
+                f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)
+            case BoolExp.Guard9(f, t1, t2, t3, t4, t5, t6, t7, t8, t9) =>
+                let v1 = evalTerm(env, t1);
+                let v2 = evalTerm(env, t2);
+                let v3 = evalTerm(env, t3);
+                let v4 = evalTerm(env, t4);
+                let v5 = evalTerm(env, t5);
+                let v6 = evalTerm(env, t6);
+                let v7 = evalTerm(env, t7);
+                let v8 = evalTerm(env, t8);
+                let v9 = evalTerm(env, t9);
+                f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)(v9)
+            case BoolExp.Guard10(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) =>
+                let v1 = evalTerm(env, t1);
+                let v2 = evalTerm(env, t2);
+                let v3 = evalTerm(env, t3);
+                let v4 = evalTerm(env, t4);
+                let v5 = evalTerm(env, t5);
+                let v6 = evalTerm(env, t6);
+                let v7 = evalTerm(env, t7);
+                let v8 = evalTerm(env, t8);
+                let v9 = evalTerm(env, t9);
+                let v10 = evalTerm(env, t10);
+                f(v1)(v2)(v3)(v4)(v5)(v6)(v7)(v8)(v9)(v10)
         } as & Pure, es)
 
     def evalTerm(env: SearchEnv[v], term: RamTerm[v]): v with ToString[v] = match term {

--- a/main/src/library/Fixpoint/Ram/BoolExp.flix
+++ b/main/src/library/Fixpoint/Ram/BoolExp.flix
@@ -26,6 +26,11 @@ namespace Fixpoint/Ram {
         case Guard3(v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v])
         case Guard4(v -> v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
         case Guard5(v -> v -> v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case Guard6(v -> v -> v -> v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case Guard7(v -> v -> v -> v -> v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case Guard8(v -> v -> v -> v -> v -> v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case Guard9(v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case Guard10(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
     }
 
     instance ToString[BoolExp[v]] with ToString[v] {
@@ -42,6 +47,11 @@ namespace Fixpoint/Ram {
                 case Guard3(_, v1, v2, v3) => "<clo>(${v1}, ${v2}, ${v3})"
                 case Guard4(_, v1, v2, v3, v4) => "<clo>(${v1}, ${v2}, ${v3}, ${v4})"
                 case Guard5(_, v1, v2, v3, v4, v5) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5})"
+                case Guard6(_, v1, v2, v3, v4, v5, v6) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6})"
+                case Guard7(_, v1, v2, v3, v4, v5, v6, v7) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7})"
+                case Guard8(_, v1, v2, v3, v4, v5, v6, v7, v8) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8})"
+                case Guard9(_, v1, v2, v3, v4, v5, v6, v7, v8, v9) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9})"
+                case Guard10(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10})"
             }
     }
 }

--- a/main/src/library/Fixpoint/Ram/BoolExp.flix
+++ b/main/src/library/Fixpoint/Ram/BoolExp.flix
@@ -31,6 +31,11 @@ namespace Fixpoint/Ram {
         case Guard8(v -> v -> v -> v -> v -> v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
         case Guard9(v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
         case Guard10(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case Guard11(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case Guard12(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case Guard13(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case Guard14(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case Guard15(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> Bool, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
     }
 
     instance ToString[BoolExp[v]] with ToString[v] {
@@ -52,6 +57,11 @@ namespace Fixpoint/Ram {
                 case Guard8(_, v1, v2, v3, v4, v5, v6, v7, v8) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8})"
                 case Guard9(_, v1, v2, v3, v4, v5, v6, v7, v8, v9) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9})"
                 case Guard10(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10})"
+                case Guard11(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11})"
+                case Guard12(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12})"
+                case Guard13(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12}, ${v13})"
+                case Guard14(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12}, ${v13}, ${v14})"
+                case Guard15(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12}, ${v13}, ${v14}, ${v15})"
             }
     }
 }

--- a/main/src/library/Fixpoint/Ram/RamTerm.flix
+++ b/main/src/library/Fixpoint/Ram/RamTerm.flix
@@ -41,6 +41,11 @@ namespace Fixpoint/Ram {
         case App8(v -> v -> v -> v -> v -> v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
         case App9(v -> v -> v -> v -> v -> v -> v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
         case App10(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case App11(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case App12(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case App13(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case App14(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case App15(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
     }
 
     instance ToString[RamTerm[v]] with ToString[v] {
@@ -60,6 +65,11 @@ namespace Fixpoint/Ram {
             case App8(_, v1, v2, v3, v4, v5, v6, v7, v8) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8})"
             case App9(_, v1, v2, v3, v4, v5, v6, v7, v8, v9) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9})"
             case App10(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10})"
+            case App11(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11})"
+            case App12(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12})"
+            case App13(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12}, ${v13})"
+            case App14(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12}, ${v13}, ${v14})"
+            case App15(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10}, ${v11}, ${v12}, ${v13}, ${v14}, ${v15})"
         }
     }
 }

--- a/main/src/library/Fixpoint/Ram/RamTerm.flix
+++ b/main/src/library/Fixpoint/Ram/RamTerm.flix
@@ -36,6 +36,11 @@ namespace Fixpoint/Ram {
         case App3(v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v])
         case App4(v -> v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
         case App5(v -> v -> v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case App6(v -> v -> v -> v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case App7(v -> v -> v -> v -> v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case App8(v -> v -> v -> v -> v -> v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case App9(v -> v -> v -> v -> v -> v -> v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
+        case App10(v -> v -> v -> v -> v -> v -> v -> v -> v -> v -> v, RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v], RamTerm[v])
     }
 
     instance ToString[RamTerm[v]] with ToString[v] {
@@ -50,6 +55,11 @@ namespace Fixpoint/Ram {
             case App3(_, v1, v2, v3) => "<clo>(${v1}, ${v2}, ${v3})"
             case App4(_, v1, v2, v3, v4) => "<clo>(${v1}, ${v2}, ${v3}, ${v4})"
             case App5(_, v1, v2, v3, v4, v5) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5})"
+            case App6(_, v1, v2, v3, v4, v5, v6) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6})"
+            case App7(_, v1, v2, v3, v4, v5, v6, v7) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7})"
+            case App8(_, v1, v2, v3, v4, v5, v6, v7, v8) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8})"
+            case App9(_, v1, v2, v3, v4, v5, v6, v7, v8, v9) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9})"
+            case App10(_, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) => "<clo>(${v1}, ${v2}, ${v3}, ${v4}, ${v5}, ${v6}, ${v7}, ${v8}, ${v9}, ${v10})"
         }
     }
 }

--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -104,6 +104,41 @@ namespace Fixpoint {
         (factsOf(p, d) |> Array.map(f)) as & Pure
 
     ///
+    /// Returns all facts in `d` associated with the predicate symbol `p`.
+    ///
+    pub def facts6(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6] =
+        let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]));
+        (factsOf(p, d) |> Array.map(f)) as & Pure
+
+    ///
+    /// Returns all facts in `d` associated with the predicate symbol `p`.
+    ///
+    pub def facts7(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7] =
+        let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]));
+        (factsOf(p, d) |> Array.map(f)) as & Pure
+
+    ///
+    /// Returns all facts in `d` associated with the predicate symbol `p`.
+    ///
+    pub def facts8(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8] =
+        let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]));
+        (factsOf(p, d) |> Array.map(f)) as & Pure
+
+    ///
+    /// Returns all facts in `d` associated with the predicate symbol `p`.
+    ///
+    pub def facts9(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8, t9)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9] =
+        let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]));
+        (factsOf(p, d) |> Array.map(f)) as & Pure
+
+    ///
+    /// Returns all facts in `d` associated with the predicate symbol `p`.
+    ///
+    pub def facts10(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10] =
+        let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]));
+        (factsOf(p, d) |> Array.map(f)) as & Pure
+
+    ///
     /// Returns an array of facts associated with the given predicate symbol `p` in the given Datalog program `d`.
     ///
     def factsOf(p: PredSym, d: Datalog[v]): Array[Array[v]] & Impure =

--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -145,8 +145,34 @@ namespace Fixpoint {
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]));
         (factsOf(p, d) |> Array.map(f)) as & Pure
     
-    /// TODO (spt)
+    ///
+    /// Returns all facts in `d` associated with the predicate symbol `p`.
+    ///
+    pub def facts12(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12] =
+        let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]), unbox(terms[11]));
+        (factsOf(p, d) |> Array.map(f)) as & Pure
 
+    ///
+    /// Returns all facts in `d` associated with the predicate symbol `p`.
+    ///
+    pub def facts13(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13] =
+        let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]), unbox(terms[11]), unbox(terms[12]));
+        (factsOf(p, d) |> Array.map(f)) as & Pure
+
+    ///
+    /// Returns all facts in `d` associated with the predicate symbol `p`.
+    ///
+    pub def facts14(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13], Boxable[t14] =
+        let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]), unbox(terms[11]), unbox(terms[12]), unbox(terms[13]));
+        (factsOf(p, d) |> Array.map(f)) as & Pure
+    
+    ///
+    /// Returns all facts in `d` associated with the predicate symbol `p`.
+    ///
+    pub def facts15(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13], Boxable[t14], Boxable[t15] =
+        let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]), unbox(terms[11]), unbox(terms[12]), unbox(terms[13]), unbox(terms[14]));
+        (factsOf(p, d) |> Array.map(f)) as & Pure
+    
 
     ///
     /// Returns an array of facts associated with the given predicate symbol `p` in the given Datalog program `d`.

--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -63,7 +63,32 @@ namespace Fixpoint {
         case Datalog(facts, rules) => Datalog(restrict(facts, Set#{p}), rules)
     }
 
-    // TODO: Add doc and add for N=1 to N=10
+    // TODO: is N=1 correct?
+    
+    pub def projectInto1[f: Type -> Type, t1: Type](p: PredSym, ts: f[t1]):
+        Datalog[Boxed] with Boxable[t1], Foldable[f] =
+        use Fixpoint/Ast.SourceLocation.{Unknown};
+        let facts = Foldable.foldRight(v1 -> acc -> {
+            Constraint(HeadAtom(p, Denotation.Relational,
+                                [HeadTerm.Lit(box(v1), Unknown)],
+                                Unknown),
+                        [], Unknown) :: acc
+        }, Nil, ts) as & Pure;
+        Datalog(List.toArray(facts), []) as & Pure
+
+    pub def projectInto2[f: Type -> Type, t1: Type, t2: Type](p: PredSym, ts: f[(t1, t2)]):
+        Datalog[Boxed] with Boxable[t1], Boxable[t2], Foldable[f] =
+        use Fixpoint/Ast.SourceLocation.{Unknown};
+        let facts = Foldable.foldRight(vs -> acc -> {
+            let (v1, v2) = vs;
+            Constraint(HeadAtom(p, Denotation.Relational,
+                                [HeadTerm.Lit(box(v1), Unknown),
+                                 HeadTerm.Lit(box(v2), Unknown)],
+                                Unknown),
+                        [], Unknown) :: acc
+        }, Nil, ts) as & Pure;
+        Datalog(List.toArray(facts), []) as & Pure
+
     pub def projectInto3[f: Type -> Type, t1: Type, t2: Type, t3: Type](p: PredSym, ts: f[(t1, t2, t3)]):
         Datalog[Boxed] with Boxable[t1], Boxable[t2], Boxable[t3], Foldable[f] =
         use Fixpoint/Ast.SourceLocation.{Unknown};
@@ -77,6 +102,252 @@ namespace Fixpoint {
                         [], Unknown) :: acc
         }, Nil, ts) as & Pure;
         Datalog(List.toArray(facts), []) as & Pure
+
+    pub def projectInto4[f: Type -> Type, t1: Type, t2: Type, t3: Type, t4: Type](p: PredSym, ts: f[(t1, t2, t3, t4)]):
+        Datalog[Boxed] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Foldable[f] =
+        use Fixpoint/Ast.SourceLocation.{Unknown};
+        let facts = Foldable.foldRight(vs -> acc -> {
+            let (v1, v2, v3, v4) = vs;
+            Constraint(HeadAtom(p, Denotation.Relational,
+                                [HeadTerm.Lit(box(v1), Unknown),
+                                 HeadTerm.Lit(box(v2), Unknown),
+                                 HeadTerm.Lit(box(v3), Unknown),
+                                 HeadTerm.Lit(box(v4), Unknown)],
+                                Unknown),
+                        [], Unknown) :: acc
+        }, Nil, ts) as & Pure;
+        Datalog(List.toArray(facts), []) as & Pure
+
+    pub def projectInto5[f: Type -> Type, t1: Type, t2: Type, t3: Type, t4: Type, t5: Type](p: PredSym, ts: f[(t1, t2, t3, t4, t5)]):
+        Datalog[Boxed] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Foldable[f] =
+        use Fixpoint/Ast.SourceLocation.{Unknown};
+        let facts = Foldable.foldRight(vs -> acc -> {
+            let (v1, v2, v3, v4, v5) = vs;
+            Constraint(HeadAtom(p, Denotation.Relational,
+                                [HeadTerm.Lit(box(v1), Unknown),
+                                 HeadTerm.Lit(box(v2), Unknown),
+                                 HeadTerm.Lit(box(v3), Unknown),
+                                 HeadTerm.Lit(box(v4), Unknown),
+                                 HeadTerm.Lit(box(v5), Unknown)],
+                                Unknown),
+                        [], Unknown) :: acc
+        }, Nil, ts) as & Pure;
+        Datalog(List.toArray(facts), []) as & Pure      
+    
+    pub def projectInto6[f: Type -> Type, t1: Type, t2: Type, t3: Type, t4: Type, t5: Type, t6: Type](p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6)]):
+        Datalog[Boxed] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Foldable[f] =
+        use Fixpoint/Ast.SourceLocation.{Unknown};
+        let facts = Foldable.foldRight(vs -> acc -> {
+            let (v1, v2, v3, v4, v5, v6) = vs;
+            Constraint(HeadAtom(p, Denotation.Relational,
+                                [HeadTerm.Lit(box(v1), Unknown),
+                                 HeadTerm.Lit(box(v2), Unknown),
+                                 HeadTerm.Lit(box(v3), Unknown),
+                                 HeadTerm.Lit(box(v4), Unknown),
+                                 HeadTerm.Lit(box(v5), Unknown),
+                                 HeadTerm.Lit(box(v6), Unknown)],
+                                Unknown),
+                        [], Unknown) :: acc
+        }, Nil, ts) as & Pure;
+        Datalog(List.toArray(facts), []) as & Pure
+
+    pub def projectInto7[f: Type -> Type, t1: Type, t2: Type, t3: Type, t4: Type, t5: Type, t6: Type, t7: Type](p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7)]):
+        Datalog[Boxed] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Foldable[f] =
+        use Fixpoint/Ast.SourceLocation.{Unknown};
+        let facts = Foldable.foldRight(vs -> acc -> {
+            let (v1, v2, v3, v4, v5, v6, v7) = vs;
+            Constraint(HeadAtom(p, Denotation.Relational,
+                                [HeadTerm.Lit(box(v1), Unknown),
+                                 HeadTerm.Lit(box(v2), Unknown),
+                                 HeadTerm.Lit(box(v3), Unknown),
+                                 HeadTerm.Lit(box(v4), Unknown),
+                                 HeadTerm.Lit(box(v5), Unknown),
+                                 HeadTerm.Lit(box(v6), Unknown),
+                                 HeadTerm.Lit(box(v7), Unknown)],
+                                Unknown),
+                        [], Unknown) :: acc
+        }, Nil, ts) as & Pure;
+        Datalog(List.toArray(facts), []) as & Pure
+
+    pub def projectInto8[f: Type -> Type, t1: Type, t2: Type, t3: Type, t4: Type, t5: Type, t6: Type, t7: Type, t8: Type](p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8)]):
+        Datalog[Boxed] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Foldable[f] =
+        use Fixpoint/Ast.SourceLocation.{Unknown};
+        let facts = Foldable.foldRight(vs -> acc -> {
+            let (v1, v2, v3, v4, v5, v6, v7, v8) = vs;
+            Constraint(HeadAtom(p, Denotation.Relational,
+                                [HeadTerm.Lit(box(v1), Unknown),
+                                 HeadTerm.Lit(box(v2), Unknown),
+                                 HeadTerm.Lit(box(v3), Unknown),
+                                 HeadTerm.Lit(box(v4), Unknown),
+                                 HeadTerm.Lit(box(v5), Unknown),
+                                 HeadTerm.Lit(box(v6), Unknown),
+                                 HeadTerm.Lit(box(v7), Unknown),
+                                 HeadTerm.Lit(box(v8), Unknown)],
+                                Unknown),
+                        [], Unknown) :: acc
+        }, Nil, ts) as & Pure;
+        Datalog(List.toArray(facts), []) as & Pure
+
+    pub def projectInto9[f: Type -> Type, t1: Type, t2: Type, t3: Type, t4: Type, t5: Type, t6: Type, t7: Type, t8: Type, t9: Type](p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8, t9)]):
+        Datalog[Boxed] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Foldable[f] =
+        use Fixpoint/Ast.SourceLocation.{Unknown};
+        let facts = Foldable.foldRight(vs -> acc -> {
+            let (v1, v2, v3, v4, v5, v6, v7, v8, v9) = vs;
+            Constraint(HeadAtom(p, Denotation.Relational,
+                                [HeadTerm.Lit(box(v1), Unknown),
+                                 HeadTerm.Lit(box(v2), Unknown),
+                                 HeadTerm.Lit(box(v3), Unknown),
+                                 HeadTerm.Lit(box(v4), Unknown),
+                                 HeadTerm.Lit(box(v5), Unknown),
+                                 HeadTerm.Lit(box(v6), Unknown),
+                                 HeadTerm.Lit(box(v7), Unknown),
+                                 HeadTerm.Lit(box(v8), Unknown),
+                                 HeadTerm.Lit(box(v9), Unknown)],
+                                Unknown),
+                        [], Unknown) :: acc
+        }, Nil, ts) as & Pure;
+        Datalog(List.toArray(facts), []) as & Pure
+
+    pub def projectInto10[f: Type -> Type, t1: Type, t2: Type, t3: Type, t4: Type, t5: Type, t6: Type, t7: Type, t8: Type, t9: Type, t10: Type](p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)]):
+        Datalog[Boxed] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Foldable[f] =
+        use Fixpoint/Ast.SourceLocation.{Unknown};
+        let facts = Foldable.foldRight(vs -> acc -> {
+            let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) = vs;
+            Constraint(HeadAtom(p, Denotation.Relational,
+                                [HeadTerm.Lit(box(v1), Unknown),
+                                 HeadTerm.Lit(box(v2), Unknown),
+                                 HeadTerm.Lit(box(v3), Unknown),
+                                 HeadTerm.Lit(box(v4), Unknown),
+                                 HeadTerm.Lit(box(v5), Unknown),
+                                 HeadTerm.Lit(box(v6), Unknown),
+                                 HeadTerm.Lit(box(v7), Unknown),
+                                 HeadTerm.Lit(box(v8), Unknown),
+                                 HeadTerm.Lit(box(v9), Unknown),
+                                 HeadTerm.Lit(box(v10), Unknown)],
+                                Unknown),
+                        [], Unknown) :: acc
+        }, Nil, ts) as & Pure;
+        Datalog(List.toArray(facts), []) as & Pure 
+
+    pub def projectInto11[f: Type -> Type, t1: Type, t2: Type, t3: Type, t4: Type, t5: Type, t6: Type, t7: Type, t8: Type, t9: Type, t10: Type, t11: Type](p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)]):
+        Datalog[Boxed] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Foldable[f] =
+        use Fixpoint/Ast.SourceLocation.{Unknown};
+        let facts = Foldable.foldRight(vs -> acc -> {
+            let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) = vs;
+            Constraint(HeadAtom(p, Denotation.Relational,
+                                [HeadTerm.Lit(box(v1), Unknown),
+                                 HeadTerm.Lit(box(v2), Unknown),
+                                 HeadTerm.Lit(box(v3), Unknown),
+                                 HeadTerm.Lit(box(v4), Unknown),
+                                 HeadTerm.Lit(box(v5), Unknown),
+                                 HeadTerm.Lit(box(v6), Unknown),
+                                 HeadTerm.Lit(box(v7), Unknown),
+                                 HeadTerm.Lit(box(v8), Unknown),
+                                 HeadTerm.Lit(box(v9), Unknown),
+                                 HeadTerm.Lit(box(v10), Unknown),
+                                 HeadTerm.Lit(box(v11), Unknown)],
+                                Unknown),
+                        [], Unknown) :: acc
+        }, Nil, ts) as & Pure;
+        Datalog(List.toArray(facts), []) as & Pure 
+
+    pub def projectInto12[f: Type -> Type, t1: Type, t2: Type, t3: Type, t4: Type, t5: Type, t6: Type, t7: Type, t8: Type, t9: Type, t10: Type, t11: Type, t12: Type](p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)]):
+        Datalog[Boxed] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Foldable[f] =
+        use Fixpoint/Ast.SourceLocation.{Unknown};
+        let facts = Foldable.foldRight(vs -> acc -> {
+            let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) = vs;
+            Constraint(HeadAtom(p, Denotation.Relational,
+                                [HeadTerm.Lit(box(v1), Unknown),
+                                 HeadTerm.Lit(box(v2), Unknown),
+                                 HeadTerm.Lit(box(v3), Unknown),
+                                 HeadTerm.Lit(box(v4), Unknown),
+                                 HeadTerm.Lit(box(v5), Unknown),
+                                 HeadTerm.Lit(box(v6), Unknown),
+                                 HeadTerm.Lit(box(v7), Unknown),
+                                 HeadTerm.Lit(box(v8), Unknown),
+                                 HeadTerm.Lit(box(v9), Unknown),
+                                 HeadTerm.Lit(box(v10), Unknown),
+                                 HeadTerm.Lit(box(v11), Unknown),
+                                 HeadTerm.Lit(box(v12), Unknown)],
+                                Unknown),
+                        [], Unknown) :: acc
+        }, Nil, ts) as & Pure;
+        Datalog(List.toArray(facts), []) as & Pure 
+
+    pub def projectInto13[f: Type -> Type, t1: Type, t2: Type, t3: Type, t4: Type, t5: Type, t6: Type, t7: Type, t8: Type, t9: Type, t10: Type, t11: Type, t12: Type, t13: Type](p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)]):
+        Datalog[Boxed] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13], Foldable[f] =
+        use Fixpoint/Ast.SourceLocation.{Unknown};
+        let facts = Foldable.foldRight(vs -> acc -> {
+            let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) = vs;
+            Constraint(HeadAtom(p, Denotation.Relational,
+                                [HeadTerm.Lit(box(v1), Unknown),
+                                 HeadTerm.Lit(box(v2), Unknown),
+                                 HeadTerm.Lit(box(v3), Unknown),
+                                 HeadTerm.Lit(box(v4), Unknown),
+                                 HeadTerm.Lit(box(v5), Unknown),
+                                 HeadTerm.Lit(box(v6), Unknown),
+                                 HeadTerm.Lit(box(v7), Unknown),
+                                 HeadTerm.Lit(box(v8), Unknown),
+                                 HeadTerm.Lit(box(v9), Unknown),
+                                 HeadTerm.Lit(box(v10), Unknown),
+                                 HeadTerm.Lit(box(v11), Unknown),
+                                 HeadTerm.Lit(box(v12), Unknown),
+                                 HeadTerm.Lit(box(v13), Unknown)],
+                                Unknown),
+                        [], Unknown) :: acc
+        }, Nil, ts) as & Pure;
+        Datalog(List.toArray(facts), []) as & Pure 
+
+    pub def projectInto14[f: Type -> Type, t1: Type, t2: Type, t3: Type, t4: Type, t5: Type, t6: Type, t7: Type, t8: Type, t9: Type, t10: Type, t11: Type, t12: Type, t13: Type, t14: Type](p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)]):
+        Datalog[Boxed] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13], Boxable[t14], Foldable[f] =
+        use Fixpoint/Ast.SourceLocation.{Unknown};
+        let facts = Foldable.foldRight(vs -> acc -> {
+            let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) = vs;
+            Constraint(HeadAtom(p, Denotation.Relational,
+                                [HeadTerm.Lit(box(v1), Unknown),
+                                 HeadTerm.Lit(box(v2), Unknown),
+                                 HeadTerm.Lit(box(v3), Unknown),
+                                 HeadTerm.Lit(box(v4), Unknown),
+                                 HeadTerm.Lit(box(v5), Unknown),
+                                 HeadTerm.Lit(box(v6), Unknown),
+                                 HeadTerm.Lit(box(v7), Unknown),
+                                 HeadTerm.Lit(box(v8), Unknown),
+                                 HeadTerm.Lit(box(v9), Unknown),
+                                 HeadTerm.Lit(box(v10), Unknown),
+                                 HeadTerm.Lit(box(v11), Unknown),
+                                 HeadTerm.Lit(box(v12), Unknown),
+                                 HeadTerm.Lit(box(v13), Unknown),
+                                 HeadTerm.Lit(box(v14), Unknown)],
+                                Unknown),
+                        [], Unknown) :: acc
+        }, Nil, ts) as & Pure;
+        Datalog(List.toArray(facts), []) as & Pure   
+
+    pub def projectInto15[f: Type -> Type, t1: Type, t2: Type, t3: Type, t4: Type, t5: Type, t6: Type, t7: Type, t8: Type, t9: Type, t10: Type, t11: Type, t12: Type, t13: Type, t14: Type, t15: Type](p: PredSym, ts: f[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)]):
+        Datalog[Boxed] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13], Boxable[t14], Boxable[t15], Foldable[f] =
+        use Fixpoint/Ast.SourceLocation.{Unknown};
+        let facts = Foldable.foldRight(vs -> acc -> {
+            let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) = vs;
+            Constraint(HeadAtom(p, Denotation.Relational,
+                                [HeadTerm.Lit(box(v1), Unknown),
+                                 HeadTerm.Lit(box(v2), Unknown),
+                                 HeadTerm.Lit(box(v3), Unknown),
+                                 HeadTerm.Lit(box(v4), Unknown),
+                                 HeadTerm.Lit(box(v5), Unknown),
+                                 HeadTerm.Lit(box(v6), Unknown),
+                                 HeadTerm.Lit(box(v7), Unknown),
+                                 HeadTerm.Lit(box(v8), Unknown),
+                                 HeadTerm.Lit(box(v9), Unknown),
+                                 HeadTerm.Lit(box(v10), Unknown),
+                                 HeadTerm.Lit(box(v11), Unknown),
+                                 HeadTerm.Lit(box(v12), Unknown),
+                                 HeadTerm.Lit(box(v13), Unknown),
+                                 HeadTerm.Lit(box(v14), Unknown),
+                                 HeadTerm.Lit(box(v15), Unknown)],
+                                Unknown),
+                        [], Unknown) :: acc
+        }, Nil, ts) as & Pure;
+        Datalog(List.toArray(facts), []) as & Pure   
 
     ///
     /// Returns all facts in `d` associated with the predicate symbol `p`.

--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -139,6 +139,16 @@ namespace Fixpoint {
         (factsOf(p, d) |> Array.map(f)) as & Pure
 
     ///
+    /// Returns all facts in `d` associated with the predicate symbol `p`.
+    ///
+    pub def facts11(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11] =
+        let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]));
+        (factsOf(p, d) |> Array.map(f)) as & Pure
+    
+    /// TODO (spt)
+
+
+    ///
     /// Returns an array of facts associated with the given predicate symbol `p` in the given Datalog program `d`.
     ///
     def factsOf(p: PredSym, d: Datalog[v]): Array[Array[v]] & Impure =

--- a/main/src/library/Fixpoint/VarsToIndices.flix
+++ b/main/src/library/Fixpoint/VarsToIndices.flix
@@ -82,6 +82,56 @@ namespace Fixpoint {
                 let t4 = lowerTerm(rowVars, v4);
                 let t5 = lowerTerm(rowVars, v5);
                 BoolExp.Guard5(f, t1, t2, t3, t4, t5)
+            case BoolExp.Guard6(f, v1, v2, v3, v4, v5, v6) =>
+                let t1 = lowerTerm(rowVars, v1);
+                let t2 = lowerTerm(rowVars, v2);
+                let t3 = lowerTerm(rowVars, v3);
+                let t4 = lowerTerm(rowVars, v4);
+                let t5 = lowerTerm(rowVars, v5);
+                let t6 = lowerTerm(rowVars, v6);
+                BoolExp.Guard6(f, t1, t2, t3, t4, t5, t6)                
+            case BoolExp.Guard7(f, v1, v2, v3, v4, v5, v6, v7) =>
+                let t1 = lowerTerm(rowVars, v1);
+                let t2 = lowerTerm(rowVars, v2);
+                let t3 = lowerTerm(rowVars, v3);
+                let t4 = lowerTerm(rowVars, v4);
+                let t5 = lowerTerm(rowVars, v5);
+                let t6 = lowerTerm(rowVars, v6);
+                let t7 = lowerTerm(rowVars, v7);
+                BoolExp.Guard7(f, t1, t2, t3, t4, t5, t6, t7)
+            case BoolExp.Guard8(f, v1, v2, v3, v4, v5, v6, v7, v8) =>
+                let t1 = lowerTerm(rowVars, v1);
+                let t2 = lowerTerm(rowVars, v2);
+                let t3 = lowerTerm(rowVars, v3);
+                let t4 = lowerTerm(rowVars, v4);
+                let t5 = lowerTerm(rowVars, v5);
+                let t6 = lowerTerm(rowVars, v6);
+                let t7 = lowerTerm(rowVars, v7);
+                let t8 = lowerTerm(rowVars, v8);
+                BoolExp.Guard8(f, t1, t2, t3, t4, t5, t6, t7, t8)
+            case BoolExp.Guard9(f, v1, v2, v3, v4, v5, v6, v7, v8, v9) =>
+                let t1 = lowerTerm(rowVars, v1);
+                let t2 = lowerTerm(rowVars, v2);
+                let t3 = lowerTerm(rowVars, v3);
+                let t4 = lowerTerm(rowVars, v4);
+                let t5 = lowerTerm(rowVars, v5);
+                let t6 = lowerTerm(rowVars, v6);
+                let t7 = lowerTerm(rowVars, v7);
+                let t8 = lowerTerm(rowVars, v8);
+                let t9 = lowerTerm(rowVars, v9);
+                BoolExp.Guard9(f, t1, t2, t3, t4, t5, t6, t7, t8, t9)
+            case BoolExp.Guard10(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) =>
+                let t1 = lowerTerm(rowVars, v1);
+                let t2 = lowerTerm(rowVars, v2);
+                let t3 = lowerTerm(rowVars, v3);
+                let t4 = lowerTerm(rowVars, v4);
+                let t5 = lowerTerm(rowVars, v5);
+                let t6 = lowerTerm(rowVars, v6);
+                let t7 = lowerTerm(rowVars, v7);
+                let t8 = lowerTerm(rowVars, v8);
+                let t9 = lowerTerm(rowVars, v9);
+                let t10 = lowerTerm(rowVars, v10);
+                BoolExp.Guard10(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)
         }
 
     def lowerTerm(rowVars: Map[RowVar, RowVar], term: RamTerm[v]): RamTerm[v] = match term {
@@ -120,5 +170,55 @@ namespace Fixpoint {
             let t4 = lowerTerm(rowVars, v4);
             let t5 = lowerTerm(rowVars, v5);
             RamTerm.App5(f, t1, t2, t3, t4, t5)
+        case RamTerm.App6(f, v1, v2, v3, v4, v5, v6) =>
+            let t1 = lowerTerm(rowVars, v1);
+            let t2 = lowerTerm(rowVars, v2);
+            let t3 = lowerTerm(rowVars, v3);
+            let t4 = lowerTerm(rowVars, v4);
+            let t5 = lowerTerm(rowVars, v5);
+            let t6 = lowerTerm(rowVars, v6);
+            RamTerm.App6(f, t1, t2, t3, t4, t5, t6)
+        case RamTerm.App7(f, v1, v2, v3, v4, v5, v6, v7) =>
+            let t1 = lowerTerm(rowVars, v1);
+            let t2 = lowerTerm(rowVars, v2);
+            let t3 = lowerTerm(rowVars, v3);
+            let t4 = lowerTerm(rowVars, v4);
+            let t5 = lowerTerm(rowVars, v5);
+            let t6 = lowerTerm(rowVars, v6);
+            let t7 = lowerTerm(rowVars, v7);
+            RamTerm.App7(f, t1, t2, t3, t4, t5, t6, t7)
+        case RamTerm.App8(f, v1, v2, v3, v4, v5, v6, v7, v8) =>
+            let t1 = lowerTerm(rowVars, v1);
+            let t2 = lowerTerm(rowVars, v2);
+            let t3 = lowerTerm(rowVars, v3);
+            let t4 = lowerTerm(rowVars, v4);
+            let t5 = lowerTerm(rowVars, v5);
+            let t6 = lowerTerm(rowVars, v6);
+            let t7 = lowerTerm(rowVars, v7);
+            let t8 = lowerTerm(rowVars, v8);
+            RamTerm.App8(f, t1, t2, t3, t4, t5, t6, t7, t8)
+        case RamTerm.App9(f, v1, v2, v3, v4, v5, v6, v7, v8, v9) =>
+            let t1 = lowerTerm(rowVars, v1);
+            let t2 = lowerTerm(rowVars, v2);
+            let t3 = lowerTerm(rowVars, v3);
+            let t4 = lowerTerm(rowVars, v4);
+            let t5 = lowerTerm(rowVars, v5);
+            let t6 = lowerTerm(rowVars, v6);
+            let t7 = lowerTerm(rowVars, v7);
+            let t8 = lowerTerm(rowVars, v8);
+            let t9 = lowerTerm(rowVars, v9);
+            RamTerm.App9(f, t1, t2, t3, t4, t5, t6, t7, t8, t9)
+        case RamTerm.App10(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) =>
+            let t1 = lowerTerm(rowVars, v1);
+            let t2 = lowerTerm(rowVars, v2);
+            let t3 = lowerTerm(rowVars, v3);
+            let t4 = lowerTerm(rowVars, v4);
+            let t5 = lowerTerm(rowVars, v5);
+            let t6 = lowerTerm(rowVars, v6);
+            let t7 = lowerTerm(rowVars, v7);
+            let t8 = lowerTerm(rowVars, v8);
+            let t9 = lowerTerm(rowVars, v9);
+            let t10 = lowerTerm(rowVars, v10);
+            RamTerm.App10(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)
     }
 }

--- a/main/src/library/Fixpoint/VarsToIndices.flix
+++ b/main/src/library/Fixpoint/VarsToIndices.flix
@@ -132,6 +132,81 @@ namespace Fixpoint {
                 let t9 = lowerTerm(rowVars, v9);
                 let t10 = lowerTerm(rowVars, v10);
                 BoolExp.Guard10(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)
+            case BoolExp.Guard11(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) =>
+                let t1 = lowerTerm(rowVars, v1);
+                let t2 = lowerTerm(rowVars, v2);
+                let t3 = lowerTerm(rowVars, v3);
+                let t4 = lowerTerm(rowVars, v4);
+                let t5 = lowerTerm(rowVars, v5);
+                let t6 = lowerTerm(rowVars, v6);
+                let t7 = lowerTerm(rowVars, v7);
+                let t8 = lowerTerm(rowVars, v8);
+                let t9 = lowerTerm(rowVars, v9);
+                let t10 = lowerTerm(rowVars, v10);
+                let t11 = lowerTerm(rowVars, v11);
+                BoolExp.Guard11(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)
+            case BoolExp.Guard12(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) =>
+                let t1 = lowerTerm(rowVars, v1);
+                let t2 = lowerTerm(rowVars, v2);
+                let t3 = lowerTerm(rowVars, v3);
+                let t4 = lowerTerm(rowVars, v4);
+                let t5 = lowerTerm(rowVars, v5);
+                let t6 = lowerTerm(rowVars, v6);
+                let t7 = lowerTerm(rowVars, v7);
+                let t8 = lowerTerm(rowVars, v8);
+                let t9 = lowerTerm(rowVars, v9);
+                let t10 = lowerTerm(rowVars, v10);
+                let t11 = lowerTerm(rowVars, v11);
+                let t12 = lowerTerm(rowVars, v12);
+                BoolExp.Guard12(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)
+            case BoolExp.Guard13(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) =>
+                let t1 = lowerTerm(rowVars, v1);
+                let t2 = lowerTerm(rowVars, v2);
+                let t3 = lowerTerm(rowVars, v3);
+                let t4 = lowerTerm(rowVars, v4);
+                let t5 = lowerTerm(rowVars, v5);
+                let t6 = lowerTerm(rowVars, v6);
+                let t7 = lowerTerm(rowVars, v7);
+                let t8 = lowerTerm(rowVars, v8);
+                let t9 = lowerTerm(rowVars, v9);
+                let t10 = lowerTerm(rowVars, v10);
+                let t11 = lowerTerm(rowVars, v11);
+                let t12 = lowerTerm(rowVars, v12);
+                let t13 = lowerTerm(rowVars, v13);
+                BoolExp.Guard13(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)
+            case BoolExp.Guard14(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) =>
+                let t1 = lowerTerm(rowVars, v1);
+                let t2 = lowerTerm(rowVars, v2);
+                let t3 = lowerTerm(rowVars, v3);
+                let t4 = lowerTerm(rowVars, v4);
+                let t5 = lowerTerm(rowVars, v5);
+                let t6 = lowerTerm(rowVars, v6);
+                let t7 = lowerTerm(rowVars, v7);
+                let t8 = lowerTerm(rowVars, v8);
+                let t9 = lowerTerm(rowVars, v9);
+                let t10 = lowerTerm(rowVars, v10);
+                let t11 = lowerTerm(rowVars, v11);
+                let t12 = lowerTerm(rowVars, v12);
+                let t13 = lowerTerm(rowVars, v13);
+                let t14 = lowerTerm(rowVars, v14);
+                BoolExp.Guard14(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)
+            case BoolExp.Guard15(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) =>
+                let t1 = lowerTerm(rowVars, v1);
+                let t2 = lowerTerm(rowVars, v2);
+                let t3 = lowerTerm(rowVars, v3);
+                let t4 = lowerTerm(rowVars, v4);
+                let t5 = lowerTerm(rowVars, v5);
+                let t6 = lowerTerm(rowVars, v6);
+                let t7 = lowerTerm(rowVars, v7);
+                let t8 = lowerTerm(rowVars, v8);
+                let t9 = lowerTerm(rowVars, v9);
+                let t10 = lowerTerm(rowVars, v10);
+                let t11 = lowerTerm(rowVars, v11);
+                let t12 = lowerTerm(rowVars, v12);
+                let t13 = lowerTerm(rowVars, v13);
+                let t14 = lowerTerm(rowVars, v14);
+                let t15 = lowerTerm(rowVars, v15);
+                BoolExp.Guard15(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)
         }
 
     def lowerTerm(rowVars: Map[RowVar, RowVar], term: RamTerm[v]): RamTerm[v] = match term {
@@ -220,5 +295,80 @@ namespace Fixpoint {
             let t9 = lowerTerm(rowVars, v9);
             let t10 = lowerTerm(rowVars, v10);
             RamTerm.App10(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)
+        case RamTerm.App11(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) =>
+            let t1 = lowerTerm(rowVars, v1);
+            let t2 = lowerTerm(rowVars, v2);
+            let t3 = lowerTerm(rowVars, v3);
+            let t4 = lowerTerm(rowVars, v4);
+            let t5 = lowerTerm(rowVars, v5);
+            let t6 = lowerTerm(rowVars, v6);
+            let t7 = lowerTerm(rowVars, v7);
+            let t8 = lowerTerm(rowVars, v8);
+            let t9 = lowerTerm(rowVars, v9);
+            let t10 = lowerTerm(rowVars, v10);
+            let t11 = lowerTerm(rowVars, v11);
+            RamTerm.App11(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)
+        case RamTerm.App12(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) =>
+            let t1 = lowerTerm(rowVars, v1);
+            let t2 = lowerTerm(rowVars, v2);
+            let t3 = lowerTerm(rowVars, v3);
+            let t4 = lowerTerm(rowVars, v4);
+            let t5 = lowerTerm(rowVars, v5);
+            let t6 = lowerTerm(rowVars, v6);
+            let t7 = lowerTerm(rowVars, v7);
+            let t8 = lowerTerm(rowVars, v8);
+            let t9 = lowerTerm(rowVars, v9);
+            let t10 = lowerTerm(rowVars, v10);
+            let t11 = lowerTerm(rowVars, v11);
+            let t12 = lowerTerm(rowVars, v12);
+            RamTerm.App12(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)
+        case RamTerm.App13(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) =>
+            let t1 = lowerTerm(rowVars, v1);
+            let t2 = lowerTerm(rowVars, v2);
+            let t3 = lowerTerm(rowVars, v3);
+            let t4 = lowerTerm(rowVars, v4);
+            let t5 = lowerTerm(rowVars, v5);
+            let t6 = lowerTerm(rowVars, v6);
+            let t7 = lowerTerm(rowVars, v7);
+            let t8 = lowerTerm(rowVars, v8);
+            let t9 = lowerTerm(rowVars, v9);
+            let t10 = lowerTerm(rowVars, v10);
+            let t11 = lowerTerm(rowVars, v11);
+            let t12 = lowerTerm(rowVars, v12);
+            let t13 = lowerTerm(rowVars, v13);
+            RamTerm.App13(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)
+        case RamTerm.App14(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) =>
+            let t1 = lowerTerm(rowVars, v1);
+            let t2 = lowerTerm(rowVars, v2);
+            let t3 = lowerTerm(rowVars, v3);
+            let t4 = lowerTerm(rowVars, v4);
+            let t5 = lowerTerm(rowVars, v5);
+            let t6 = lowerTerm(rowVars, v6);
+            let t7 = lowerTerm(rowVars, v7);
+            let t8 = lowerTerm(rowVars, v8);
+            let t9 = lowerTerm(rowVars, v9);
+            let t10 = lowerTerm(rowVars, v10);
+            let t11 = lowerTerm(rowVars, v11);
+            let t12 = lowerTerm(rowVars, v12);
+            let t13 = lowerTerm(rowVars, v13);
+            let t14 = lowerTerm(rowVars, v14);
+            RamTerm.App14(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)
+        case RamTerm.App15(f, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) =>
+            let t1 = lowerTerm(rowVars, v1);
+            let t2 = lowerTerm(rowVars, v2);
+            let t3 = lowerTerm(rowVars, v3);
+            let t4 = lowerTerm(rowVars, v4);
+            let t5 = lowerTerm(rowVars, v5);
+            let t6 = lowerTerm(rowVars, v6);
+            let t7 = lowerTerm(rowVars, v7);
+            let t8 = lowerTerm(rowVars, v8);
+            let t9 = lowerTerm(rowVars, v9);
+            let t10 = lowerTerm(rowVars, v10);
+            let t11 = lowerTerm(rowVars, v11);
+            let t12 = lowerTerm(rowVars, v12);
+            let t13 = lowerTerm(rowVars, v13);
+            let t14 = lowerTerm(rowVars, v14);
+            let t15 = lowerTerm(rowVars, v15);
+            RamTerm.App15(f, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)
     }
 }

--- a/main/src/library/Order.flix
+++ b/main/src/library/Order.flix
@@ -477,3 +477,125 @@ instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with Order[a1], Order[
         lazy (x10 <=> y10)
 
 }
+
+instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11] {
+
+    ///
+    /// Compares `t1` and `t2` lexicographically.
+    ///
+    pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)): Comparison =
+        use Order.thenCompare;
+        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) = t1;
+        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11) = t2;
+             (x1 <=> y1) `thenCompare`
+        lazy (x2 <=> y2) `thenCompare`
+        lazy (x3 <=> y3) `thenCompare`
+        lazy (x4 <=> y4) `thenCompare`
+        lazy (x5 <=> y5) `thenCompare`
+        lazy (x6 <=> y6) `thenCompare`
+        lazy (x7 <=> y7) `thenCompare`
+        lazy (x8 <=> y8) `thenCompare`
+        lazy (x9 <=> y9) `thenCompare`
+        lazy (x10 <=> y10) `thenCompare`
+        lazy (x11 <=> y11)
+}
+
+instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11], Order[a12] {
+
+    ///
+    /// Compares `t1` and `t2` lexicographically.
+    ///
+    pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)): Comparison =
+        use Order.thenCompare;
+        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) = t1;
+        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12) = t2;
+             (x1 <=> y1) `thenCompare`
+        lazy (x2 <=> y2) `thenCompare`
+        lazy (x3 <=> y3) `thenCompare`
+        lazy (x4 <=> y4) `thenCompare`
+        lazy (x5 <=> y5) `thenCompare`
+        lazy (x6 <=> y6) `thenCompare`
+        lazy (x7 <=> y7) `thenCompare`
+        lazy (x8 <=> y8) `thenCompare`
+        lazy (x9 <=> y9) `thenCompare`
+        lazy (x10 <=> y10) `thenCompare`
+        lazy (x11 <=> y11) `thenCompare`
+        lazy (x12 <=> y12)
+}
+
+instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11], Order[a12], Order[a13] {
+
+    ///
+    /// Compares `t1` and `t2` lexicographically.
+    ///
+    pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)): Comparison =
+        use Order.thenCompare;
+        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13) = t1;
+        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13) = t2;
+             (x1 <=> y1) `thenCompare`
+        lazy (x2 <=> y2) `thenCompare`
+        lazy (x3 <=> y3) `thenCompare`
+        lazy (x4 <=> y4) `thenCompare`
+        lazy (x5 <=> y5) `thenCompare`
+        lazy (x6 <=> y6) `thenCompare`
+        lazy (x7 <=> y7) `thenCompare`
+        lazy (x8 <=> y8) `thenCompare`
+        lazy (x9 <=> y9) `thenCompare`
+        lazy (x10 <=> y10) `thenCompare`
+        lazy (x11 <=> y11) `thenCompare`
+        lazy (x12 <=> y12) `thenCompare`
+        lazy (x13 <=> y13) 
+}
+
+instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11], Order[a12], Order[a13], Order[a14] {
+
+    ///
+    /// Compares `t1` and `t2` lexicographically.
+    ///
+    pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)): Comparison =
+        use Order.thenCompare;
+        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14) = t1;
+        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14) = t2;
+             (x1 <=> y1) `thenCompare`
+        lazy (x2 <=> y2) `thenCompare`
+        lazy (x3 <=> y3) `thenCompare`
+        lazy (x4 <=> y4) `thenCompare`
+        lazy (x5 <=> y5) `thenCompare`
+        lazy (x6 <=> y6) `thenCompare`
+        lazy (x7 <=> y7) `thenCompare`
+        lazy (x8 <=> y8) `thenCompare`
+        lazy (x9 <=> y9) `thenCompare`
+        lazy (x10 <=> y10) `thenCompare`
+        lazy (x11 <=> y11) `thenCompare`
+        lazy (x12 <=> y12) `thenCompare`
+        lazy (x13 <=> y13) `thenCompare`
+        lazy (x14 <=> y14)
+
+}
+
+instance Order[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)] with Order[a1], Order[a2], Order[a3], Order[a4], Order[a5], Order[a6], Order[a7], Order[a8], Order[a9], Order[a10], Order[a11], Order[a12], Order[a13], Order[a14], Order[a15] {
+
+    ///
+    /// Compares `t1` and `t2` lexicographically.
+    ///
+    pub def compare(t1: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15), t2: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)): Comparison =
+        use Order.thenCompare;
+        let (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) = t1;
+        let (y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13, y14, y15) = t2;
+             (x1 <=> y1) `thenCompare`
+        lazy (x2 <=> y2) `thenCompare`
+        lazy (x3 <=> y3) `thenCompare`
+        lazy (x4 <=> y4) `thenCompare`
+        lazy (x5 <=> y5) `thenCompare`
+        lazy (x6 <=> y6) `thenCompare`
+        lazy (x7 <=> y7) `thenCompare`
+        lazy (x8 <=> y8) `thenCompare`
+        lazy (x9 <=> y9) `thenCompare`
+        lazy (x10 <=> y10) `thenCompare`
+        lazy (x11 <=> y11) `thenCompare`
+        lazy (x12 <=> y12) `thenCompare`
+        lazy (x13 <=> y13) `thenCompare`
+        lazy (x14 <=> y14) `thenCompare`
+        lazy (x15 <=> y15)
+
+}

--- a/main/src/library/ToString.flix
+++ b/main/src/library/ToString.flix
@@ -150,6 +150,41 @@ instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with ToString[a1], 
     }
 }
 
+instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10], ToString[a11] {
+    pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)): String = match t {
+        case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) =>
+            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10}, ${x11})"
+    }
+}
+
+instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10], ToString[a11], ToString[a12] {
+    pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)): String = match t {
+        case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) =>
+            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10}, ${x11}, ${x12})"
+    }
+}
+
+instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10], ToString[a11], ToString[a12], ToString[a13] {
+    pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)): String = match t {
+        case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13) =>
+            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10}, ${x11}, ${x12}, ${x13})"
+    }
+}
+
+instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10], ToString[a11], ToString[a12], ToString[a13], ToString[a14] {
+    pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)): String = match t {
+        case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14) =>
+            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10}, ${x11}, ${x12}, ${x13}, ${x14})"
+    }
+}
+
+instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)] with ToString[a1], ToString[a2], ToString[a3], ToString[a4], ToString[a5], ToString[a6], ToString[a7], ToString[a8], ToString[a9], ToString[a10], ToString[a11], ToString[a12], ToString[a13], ToString[a14], ToString[a15] {
+    pub def toString(t: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)): String = match t {
+        case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) =>
+            "(${x1}, ${x2}, ${x3}, ${x4}, ${x5}, ${x6}, ${x7}, ${x8}, ${x9}, ${x10}, ${x11}, ${x12}, ${x13}, ${x14}, ${x15})"
+    }
+}
+
 instance ToString[Array[a]] with ToString[a] {
     pub def toString(a: Array[a]): String = ToStringOps.arrayToStringHelper(a, 0, "")
 }


### PR DESCRIPTION
This PR is work supporting tuples and relations to arity N=15.

Tuple instances for the classes `ToString`, `Eq`, `Order` and `Boxable` have been implemented up to 15.

The `Guard` and `App` datatypes in the new solver in the new solver have been extended up to 15. The families of `projectIntoX` and `factsX` functions have been implemented up to 15.