### PR TITLE
Simplify compiler

### DIFF
--- a/main/src/library/Fixpoint/Compiler.flix
+++ b/main/src/library/Fixpoint/Compiler.flix
@@ -297,18 +297,25 @@ namespace Fixpoint {
                     Array.mapWithIndex(compileBodyTerm, terms) |>
                     Array.mapWithIndex(t -> i -> (t, i)) |>
                     Array.foldRight(match (t, i) -> ts ->
-                        if (isCurrentRowload(t, rowVar, i))
-                            ts
-                        else
-                            match denotation {
-                                case Denotation.Relational =>
-                                    BoolExp.Eq(RamTerm.RowLoad(rowVar, i), t)
-                                case Denotation.Latticenal(_, leq, _, _) =>
-                                    if (i < Array.length(terms) - 1)
-                                        BoolExp.Eq(RamTerm.RowLoad(rowVar, i), t)
-                                    else
-                                        BoolExp.Leq(leq, t, RamTerm.LoadLatVar(rowVar))
-                    } :: ts, acc)
+                        let checkRamTerm = term -> match term {
+                            case RamTerm.RowLoad(rVar, index) => 
+                            if (rVar == rowVar and index == i) 
+                                ts 
+                            else BoolExp.Eq(RamTerm.RowLoad(rowVar, i), t) :: ts
+                            case _ => BoolExp.Eq(RamTerm.RowLoad(rowVar, i), t) :: ts
+                        };
+                        match denotation {
+                            case Denotation.Relational =>
+                                checkRamTerm(t)
+                            case Denotation.Latticenal(_, leq, _, _) =>
+                                if (i < Array.length(terms) - 1)
+                                    checkRamTerm(t)
+                                else
+                                    match t {
+                                        case RamTerm.LoadLatVar(rVar) => if (rVar == rowVar) ts else BoolExp.Leq(leq, t, RamTerm.LoadLatVar(rowVar)) :: ts
+                                        case _ => BoolExp.Leq(leq, t, RamTerm.LoadLatVar(rowVar)) :: ts
+                                    }
+                    }, acc)
                 case BodyAtom(PredSym(pred), denotation, Polarity.Negative, terms) =>
                     let ramTerms = Array.mapWithIndex(compileBodyTerm, terms);
                     BoolExp.NotMemberOf(ramTerms, RamSym.Full(pred, denotation)) :: acc
@@ -340,18 +347,6 @@ namespace Fixpoint {
                     let t5 = unwrap(Map.get(v5, env));
                     BoolExp.Guard5(f, t1, t2, t3, t4, t5) :: acc
             }, Nil, body) as & Pure
-
-    ///
-    /// Determines whether the RamTerm termToCheck is a RowLoad RamTerm with RowVar rowVar and Index index.
-    ///
-    def isCurrentRowload(termToCheck: RamTerm[v], rowVar: RowVar, index: Int): Bool =
-        match termToCheck {
-            case RamTerm.RowLoad(row, i) =>
-                if (row == rowVar and i == index)
-                    true
-                else false
-            case _ => false
-        }
 
     ///
     /// Restrict a constraint system to those constraints whose head predicate belongs to the given domain.

--- a/main/src/library/Fixpoint/Compiler.flix
+++ b/main/src/library/Fixpoint/Compiler.flix
@@ -296,8 +296,7 @@ namespace Fixpoint {
                 case BodyAtom(_, denotation, Polarity.Positive, terms) =>
                     Array.mapWithIndex(compileBodyTerm, terms) |>
                     Array.mapWithIndex(t -> i -> (t, i)) |>
-                    Array.foldRight(tup -> ts ->
-                        let (t, i) = tup;
+                    Array.foldRight(match (t, i) -> ts ->
                         if (isCurrentRowload(t, rowVar, i))
                             ts
                         else

--- a/main/src/library/Fixpoint/Compiler.flix
+++ b/main/src/library/Fixpoint/Compiler.flix
@@ -296,7 +296,8 @@ namespace Fixpoint {
                 case BodyAtom(_, denotation, Polarity.Positive, terms) =>
                     Array.mapWithIndex(compileBodyTerm, terms) |>
                     Array.mapWithIndex(t -> i -> (t, i)) |>
-                    Array.foldRight((t, i) -> ts ->
+                    Array.foldRight(tup -> ts ->
+                        let (t, i) = tup;
                         if (isCurrentRowload(t, rowVar, i))
                             ts
                         else
@@ -341,6 +342,9 @@ namespace Fixpoint {
                     BoolExp.Guard5(f, t1, t2, t3, t4, t5) :: acc
             }, Nil, body) as & Pure
 
+    ///
+    /// Determines whether the RamTerm termToCheck is a RowLoad RamTerm with RowVar rowVar and Index index.
+    ///
     def isCurrentRowload(termToCheck: RamTerm[v], rowVar: RowVar, index: Int): Bool =
         match termToCheck {
             case RamTerm.RowLoad(row, i) =>

--- a/main/src/library/Fixpoint/Compiler.flix
+++ b/main/src/library/Fixpoint/Compiler.flix
@@ -295,15 +295,20 @@ namespace Fixpoint {
             match atom {
                 case BodyAtom(_, denotation, Polarity.Positive, terms) =>
                     Array.mapWithIndex(compileBodyTerm, terms) |>
-                    Array.mapWithIndex(t -> i -> match denotation {
-                        case Denotation.Relational => BoolExp.Eq(RamTerm.RowLoad(rowVar, i), t)
-                        case Denotation.Latticenal(_, leq, _, _) =>
-                            if (i < Array.length(terms) - 1)
-                                BoolExp.Eq(RamTerm.RowLoad(rowVar, i), t)
-                            else
-                                BoolExp.Leq(leq, t, RamTerm.LoadLatVar(rowVar))
-                    }) |>
-                    Array.foldRight(x -> xs -> x :: xs, acc)
+                    Array.mapWithIndex(t -> i -> (t, i)) |>
+                    Array.foldRight((t, i) -> ts ->
+                        if (isCurrentRowload(t, rowVar, i))
+                            ts
+                        else
+                            match denotation {
+                                case Denotation.Relational =>
+                                    BoolExp.Eq(RamTerm.RowLoad(rowVar, i), t)
+                                case Denotation.Latticenal(_, leq, _, _) =>
+                                    if (i < Array.length(terms) - 1)
+                                        BoolExp.Eq(RamTerm.RowLoad(rowVar, i), t)
+                                    else
+                                        BoolExp.Leq(leq, t, RamTerm.LoadLatVar(rowVar))
+                    } :: ts, acc)
                 case BodyAtom(PredSym(pred), denotation, Polarity.Negative, terms) =>
                     let ramTerms = Array.mapWithIndex(compileBodyTerm, terms);
                     BoolExp.NotMemberOf(ramTerms, RamSym.Full(pred, denotation)) :: acc
@@ -335,6 +340,15 @@ namespace Fixpoint {
                     let t5 = unwrap(Map.get(v5, env));
                     BoolExp.Guard5(f, t1, t2, t3, t4, t5) :: acc
             }, Nil, body) as & Pure
+
+    def isCurrentRowload(termToCheck: RamTerm[v], rowVar: RowVar, index: Int): Bool =
+        match termToCheck {
+            case RamTerm.RowLoad(row, i) =>
+                if (row == rowVar and i == index)
+                    true
+                else false
+            case _ => false
+        }
 
     ///
     /// Restrict a constraint system to those constraints whose head predicate belongs to the given domain.


### PR DESCRIPTION
Made a small change to compileRule in the Datalog Compiler.
BoolExp like `t[i] == t[i]` are now no longer created.
A better name for `isCurrentRowLoad` might be a good idea.