### PR TITLE
A faster version of Array.filter

### DIFF
--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -917,7 +917,32 @@ namespace Array {
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def filter(f: a -> Bool, a: Array[a]): Array[a] & Impure =
-        foldRight((x,xs) -> if (f(x)) x :: xs else xs, Nil, a) |> List.toArray
+        let len = length(a);
+        if (len < 1) {
+            []
+        } else {
+            let out = new(a[0], len);
+            let endPos = filterHelper(f, 0, a, 0, out);
+            slice(out, 0, endPos)
+        }
+
+    ///
+    /// Helper function for `filter`.
+    /// The array `out` is mutated if successes are found as the initial array `a` is iterated.
+    /// The returned Int32 is the current "write position" and it tells the calling function where to slice `out`.
+    ///
+    def filterHelper(f: a -> Bool, aix: Int32, a: Array[a], oix: Int32, out: Array[a]): Int32 & Impure =
+        if (aix >= length(a))
+            oix
+        else {
+            let x = a[aix];
+            if (f(x)) {
+                out[oix] = x;
+                filterHelper(f, aix + 1, a, oix + 1, out)
+            } else {
+                filterHelper(f, aix + 1, a, oix, out)
+            }
+        }
 
     ///
     /// Returns a pair of lists `(a1, a2)`.


### PR DESCRIPTION
c.f Datalog: Optimize Array.filter #1897

`Array.filter` has been re-implemented to use an interim array rather than an interim list. Because we don't know ahead of time the length of the output array, it is initialized to the same size as the input array; at the end of filtering the input array the output array is truncated to contain just the positives.

@magnus-madsen I've committed the version that calls Array.length on the input array within the helper. Results were a bit mixed on my PC - maybe some background task was running. Both versions with an interim array look faster. The odd and even tests are essentially the same so the results should be just about the same in a run - the version using Array.length in the helper had a very fast run for odd array size 1048576 and the code is a little bit simpler by having one less argument.

# Interim list

~~~

------------------------------ Running Benchmarks ------------------------------

Warmup: ...............

Benchmark                                         Iterations          Time (avg)
Array.filter(x -> x % 2 == 1, Array.range(1, 16))               53757            10 us/op
Array.filter(x -> x % 2 == 1, Array.range(1, 256))               12622            90 us/op
Array.filter(x -> x % 2 == 1, Array.range(1, 4096))                2433          1416 us/op
Array.filter(x -> x % 2 == 1, Array.range(1, 65536))                 191         23327 us/op
Array.filter(x -> x % 2 == 1, Array.range(1, 1048576))                  25        480943 us/op
Array.filter(x -> x % 2 == 0, Array.range(1, 16))               78369             6 us/op
Array.filter(x -> x % 2 == 0, Array.range(1, 256))               15893            92 us/op
Array.filter(x -> x % 2 == 0, Array.range(1, 4096))                2695          1474 us/op
Array.filter(x -> x % 2 == 0, Array.range(1, 65536))                 328         24335 us/op
Array.filter(x -> x % 2 == 0, Array.range(1, 1048576))                  26        530787 us/op
Array.filter(x -> x % 10 == 0, Array.range(1, 16))               99535             6 us/op
Array.filter(x -> x % 10 == 0, Array.range(1, 256))               27886            84 us/op
Array.filter(x -> x % 10 == 0, Array.range(1, 4096))                4754          1288 us/op
Array.filter(x -> x % 10 == 0, Array.range(1, 65536))                 460         20506 us/op
Array.filter(x -> x % 10 == 0, Array.range(1, 1048576))                  28        362389 us/op

Total time elapsed: 83 seconds. Time budget was: 300 seconds.

Process finished with exit code 0

~~~

# Interim Array

~~~

------------------------------ Running Benchmarks ------------------------------

Warmup: ...............

Benchmark                                         Iterations          Time (avg)
Array.filter(x -> x % 2 == 1, Array.range(1, 16))               74380             4 us/op
Array.filter(x -> x % 2 == 1, Array.range(1, 256))               20588            30 us/op
Array.filter(x -> x % 2 == 1, Array.range(1, 4096))                3091          1020 us/op
Array.filter(x -> x % 2 == 1, Array.range(1, 65536))                 335         16294 us/op
Array.filter(x -> x % 2 == 1, Array.range(1, 1048576))                  35        262283 us/op
Array.filter(x -> x % 2 == 0, Array.range(1, 16))              171887             4 us/op
Array.filter(x -> x % 2 == 0, Array.range(1, 256))               62408            66 us/op
Array.filter(x -> x % 2 == 0, Array.range(1, 4096))                6981          1058 us/op
Array.filter(x -> x % 2 == 0, Array.range(1, 65536))                 488         16867 us/op
Array.filter(x -> x % 2 == 0, Array.range(1, 1048576))                  32        274025 us/op
Array.filter(x -> x % 10 == 0, Array.range(1, 16))              148760             4 us/op
Array.filter(x -> x % 10 == 0, Array.range(1, 256))               41574            64 us/op
Array.filter(x -> x % 10 == 0, Array.range(1, 4096))                3500          1043 us/op
Array.filter(x -> x % 10 == 0, Array.range(1, 65536))                 518         16793 us/op
Array.filter(x -> x % 10 == 0, Array.range(1, 1048576))                  34        289434 us/op

Total time elapsed: 77 seconds. Time budget was: 300 seconds.

~~~

# Interim Array and "len" not a static argument

~~~

------------------------------ Running Benchmarks ------------------------------

Warmup: ...............

Benchmark                                         Iterations          Time (avg)
Array.filter(x -> x % 2 == 1, Array.range(1, 16))               41468             6 us/op
Array.filter(x -> x % 2 == 1, Array.range(1, 256))               14376            27 us/op
Array.filter(x -> x % 2 == 1, Array.range(1, 4096))                2950           419 us/op
Array.filter(x -> x % 2 == 1, Array.range(1, 65536))                 295          6967 us/op
Array.filter(x -> x % 2 == 1, Array.range(1, 1048576))                  34        116794 us/op
Array.filter(x -> x % 2 == 0, Array.range(1, 16))              186374             3 us/op
Array.filter(x -> x % 2 == 0, Array.range(1, 256))               67618            72 us/op
Array.filter(x -> x % 2 == 0, Array.range(1, 4096))                5936          1176 us/op
Array.filter(x -> x % 2 == 0, Array.range(1, 65536))                 398         19281 us/op
Array.filter(x -> x % 2 == 0, Array.range(1, 1048576))                  34        310328 us/op
Array.filter(x -> x % 10 == 0, Array.range(1, 16))              149031             5 us/op
Array.filter(x -> x % 10 == 0, Array.range(1, 256))               38037            72 us/op
Array.filter(x -> x % 10 == 0, Array.range(1, 4096))                5266          1153 us/op
Array.filter(x -> x % 10 == 0, Array.range(1, 65536))                 529         18821 us/op
Array.filter(x -> x % 10 == 0, Array.range(1, 1048576))                  34        327597 us/op

Total time elapsed: 73 seconds. Time budget was: 300 seconds.

Process finished with exit code 0

~~~

This is the code of the benchmark...

~~~

namespace Bench/Library/Array/Filter {

    use Benchmark.Benchmark;
    use Benchmark.defBenchmark;

    pub def benchmarks(): Array[Benchmark] & Impure = [
        benchmarkFilterOdds(),
        benchmarkFilterEvens(),
        benchmarkFilterMod10()
    ] |> Array.flatten

    pub def benchmarkFilterOdds(): Array[Benchmark] & Impure =
        let filterOdds = n -> Array.range(1, n) |> Array.filter(x -> x % 2 == 1);
        let odds04 = () -> filterOdds(2 ** 4);
        let odds08 = () -> filterOdds(2 ** 8);
        let odds12 = () -> filterOdds(2 ** 12);
        let odds16 = () -> filterOdds(2 ** 16);
        let odds20 = () -> filterOdds(2 ** 20);
        [
            defBenchmark("Array.filter(x -> x % 2 == 1, Array.range(1, ${2 ** 04}))", () -> odds04() as & Pure),
            defBenchmark("Array.filter(x -> x % 2 == 1, Array.range(1, ${2 ** 08}))", () -> odds08() as & Pure),
            defBenchmark("Array.filter(x -> x % 2 == 1, Array.range(1, ${2 ** 12}))", () -> odds12() as & Pure),
            defBenchmark("Array.filter(x -> x % 2 == 1, Array.range(1, ${2 ** 16}))", () -> odds16() as & Pure),
            defBenchmark("Array.filter(x -> x % 2 == 1, Array.range(1, ${2 ** 20}))", () -> odds20() as & Pure)
        ]

    pub def benchmarkFilterEvens(): Array[Benchmark] & Impure =
        let filterEvens = n -> Array.range(1, n) |> Array.filter(x -> x % 2 == 0);
        let evens04 = () -> filterEvens(2 ** 4);
        let evens08 = () -> filterEvens(2 ** 8);
        let evens12 = () -> filterEvens(2 ** 12);
        let evens16 = () -> filterEvens(2 ** 16);
        let evens20 = () -> filterEvens(2 ** 20);
        [
            defBenchmark("Array.filter(x -> x % 2 == 0, Array.range(1, ${2 ** 04}))", () -> evens04() as & Pure),
            defBenchmark("Array.filter(x -> x % 2 == 0, Array.range(1, ${2 ** 08}))", () -> evens08() as & Pure),
            defBenchmark("Array.filter(x -> x % 2 == 0, Array.range(1, ${2 ** 12}))", () -> evens12() as & Pure),
            defBenchmark("Array.filter(x -> x % 2 == 0, Array.range(1, ${2 ** 16}))", () -> evens16() as & Pure),
            defBenchmark("Array.filter(x -> x % 2 == 0, Array.range(1, ${2 ** 20}))", () -> evens20() as & Pure)
        ]

    pub def benchmarkFilterMod10(): Array[Benchmark] & Impure =
        let filterMod10 = n -> Array.range(1, n) |> Array.filter(x -> x % 10 == 0);
        let modTen04 = () -> filterMod10(2 ** 4);
        let modTen08 = () -> filterMod10(2 ** 8);
        let modTen12 = () -> filterMod10(2 ** 12);
        let modTen16 = () -> filterMod10(2 ** 16);
        let modTen20 = () -> filterMod10(2 ** 20);
        [
            defBenchmark("Array.filter(x -> x % 10 == 0, Array.range(1, ${2 ** 04}))", () -> modTen04() as & Pure),
            defBenchmark("Array.filter(x -> x % 10 == 0, Array.range(1, ${2 ** 08}))", () -> modTen08() as & Pure),
            defBenchmark("Array.filter(x -> x % 10 == 0, Array.range(1, ${2 ** 12}))", () -> modTen12() as & Pure),
            defBenchmark("Array.filter(x -> x % 10 == 0, Array.range(1, ${2 ** 16}))", () -> modTen16() as & Pure),
            defBenchmark("Array.filter(x -> x % 10 == 0, Array.range(1, ${2 ** 20}))", () -> modTen20() as & Pure)
        ]
}

~~~