### PR TITLE
Add abs, ceil, floor and round to Float32 and Float64

### DIFF
--- a/main/src/library/Float32.flix
+++ b/main/src/library/Float32.flix
@@ -319,4 +319,54 @@ namespace Float32 {
             nanValue
         else
             valueOf(clamp(x, minf32, maxf32)).longValue() as & Pure
+
+    ///
+    /// Returns the absolute value of `x`.
+    ///
+    @Time(1) @Space(1)
+    pub def abs(x: Float32): Float32 =
+        import java.lang.Math:abs(Float32);
+        abs(x) as & Pure
+
+    ///
+    /// Returns `x` rounded up to a Float32 representing the nearest larger integer value.
+    ///
+    @Time(1) @Space(1)
+    pub def ceil(x: Float32): Float32 =
+        import java.lang.Float:valueOf(Float32) as valueOfF32;
+        import java.lang.Double:valueOf(Float64) as valueOfF64;
+        import java.lang.Math:ceil(Float64);
+        import java.lang.Double.floatValue();
+        import java.lang.Float.doubleValue();
+        let x1 = ceil(doubleValue(valueOfF32(x))) as & Pure;
+        floatValue(valueOfF64(x1)) as & Pure
+
+    ///
+    /// Returns `x` rounded down to a Float32 representing the nearest smaller integer value.
+    ///
+    @Time(1) @Space(1)
+    pub def floor(x: Float32): Float32 =
+        import java.lang.Float:valueOf(Float32) as valueOfF32;
+        import java.lang.Double:valueOf(Float64) as valueOfF64;
+        import java.lang.Math:floor(Float64);
+        import java.lang.Double.floatValue();
+        import java.lang.Float.doubleValue();
+        let x1 = floor(doubleValue(valueOfF32(x))) as & Pure;
+        floatValue(valueOfF64(x1)) as & Pure
+
+    ///
+    /// Returns `x` rounded to a Float32 representing the nearest integer value.
+    ///
+    /// The rounding may be upwards or downwards.
+    ///
+    @Time(1) @Space(1)
+    pub def round(x: Float32): Float32 =
+        import java.lang.Float:valueOf(Float32) as valueOfF32;
+        import java.lang.Double:valueOf(Float64) as valueOfF64;
+        import java.lang.Math:rint(Float64);
+        import java.lang.Double.floatValue();
+        import java.lang.Float.doubleValue();
+        let x1 = rint(doubleValue(valueOfF32(x))) as & Pure;
+        floatValue(valueOfF64(x1)) as & Pure
+
 }

--- a/main/src/library/Float32.flix
+++ b/main/src/library/Float32.flix
@@ -357,7 +357,8 @@ namespace Float32 {
     ///
     /// Returns `x` rounded to a Float32 representing the nearest integer value.
     ///
-    /// The rounding may be upwards or downwards.
+    /// The rounding may be upwards or downwards. If the rounding up and rounding down are equally
+    /// close, `x` will be rounded to an even value (i.e. `round(0.5f32) == 0.0f32`).
     ///
     @Time(1) @Space(1)
     pub def round(x: Float32): Float32 =

--- a/main/src/library/Float64.flix
+++ b/main/src/library/Float64.flix
@@ -364,4 +364,38 @@ namespace Float64 {
         else
             valueOf(clamp(x, minf64, maxf64)).floatValue() as & Pure
 
+    ///
+    /// Returns the absolute value of `x`.
+    ///
+    @Time(1) @Space(1)
+    pub def abs(x: Float64): Float64 =
+        import java.lang.Math:abs(Float64);
+        abs(x) as & Pure
+
+    ///
+    /// Returns `x` rounded up to a Float64 representing the nearest larger integer value.
+    ///
+    @Time(1) @Space(1)
+    pub def ceil(x: Float64): Float64 =
+        import java.lang.Math:ceil(Float64);
+        ceil(x) as & Pure
+
+    ///
+    /// Returns `x` rounded down to a Float64 representing the nearest smaller integer value.
+    ///
+    @Time(1) @Space(1)
+    pub def floor(x: Float64): Float64 =
+        import java.lang.Math:floor(Float64);
+        floor(x) as & Pure
+
+    ///
+    /// Returns `x` rounded to a Float64 representing the nearest integer value.
+    ///
+    /// The rounding may be upwards or downwards.
+    ///
+    @Time(1) @Space(1)
+    pub def round(x: Float64): Float64 =
+        import java.lang.Math:rint(Float64);
+        rint(x) as & Pure
+
 }

--- a/main/src/library/Float64.flix
+++ b/main/src/library/Float64.flix
@@ -391,7 +391,8 @@ namespace Float64 {
     ///
     /// Returns `x` rounded to a Float64 representing the nearest integer value.
     ///
-    /// The rounding may be upwards or downwards.
+    /// The rounding may be upwards or downwards. If the rounding up and rounding down are equally
+    /// close, `x` will be rounded to an even value (i.e. `round(0.5f64) == 0.0f64`).
     ///
     @Time(1) @Space(1)
     pub def round(x: Float64): Float64 =

--- a/main/test/ca/uwaterloo/flix/library/TestFloat32.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFloat32.flix
@@ -523,4 +523,13 @@ namespace TestFloat32 {
     @test
     def clampToInt6408(): Bool = Float32.clampToInt64(Float32.nan(), -100i64, 100i64, -127i64) == -127i64
 
+    /////////////////////////////////////////////////////////////////////////////
+    // ceil                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+    @test
+    def ceil01(): Bool =
+        let d1 = Float32.ceil(0.5f32);
+        Float32.tryToInt32(d1) == Some(2)
+
+
 }

--- a/main/test/ca/uwaterloo/flix/library/TestFloat32.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFloat32.flix
@@ -524,12 +524,163 @@ namespace TestFloat32 {
     def clampToInt6408(): Bool = Float32.clampToInt64(Float32.nan(), -100i64, 100i64, -127i64) == -127i64
 
     /////////////////////////////////////////////////////////////////////////////
+    // abs                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    def equalsEps(x: Float32, y: Float32, eps: Float32): Bool =
+        let diff = Float32.abs(x - y);
+        let x1 = Float32.abs(x);
+        let y1 = Float32.abs(y);
+        let largest = if (y1 > x1) y1 else x1;
+        if (diff <= largest * eps) true else false
+
+    @test
+    def abs01(): Bool =
+        equalsEps(Float32.abs(0.0f32), 0.0f32, 0.001f32)
+
+    @test
+    def abs02(): Bool =
+        equalsEps(Float32.abs(10.1f32), 10.1f32, 0.001f32)
+
+    @test
+    def abs03(): Bool =
+        equalsEps(Float32.abs(-10.1f32), 10.1f32, 0.001f32)
+
+    @test
+    def abs04(): Bool =
+        Float32.abs(Float32.nan()) |> Float32.isNan
+
+    @test
+    def abs05(): Bool =
+        Float32.abs(Float32.positiveInfinity()) == Float32.positiveInfinity()
+
+    @test
+    def abs06(): Bool =
+        Float32.abs(Float32.negativeInfinity()) == Float32.positiveInfinity()
+
+    /////////////////////////////////////////////////////////////////////////////
     // ceil                                                                    //
     /////////////////////////////////////////////////////////////////////////////
     @test
     def ceil01(): Bool =
-        let d1 = Float32.ceil(0.5f32);
-        Float32.tryToInt32(d1) == Some(2)
+        equalsEps(Float32.ceil(0.5f32), 1.0f32, 0.001f32)
 
+    @test
+    def ceil02(): Bool =
+        equalsEps(Float32.ceil(0.1f32), 1.0f32, 0.001f32)
+
+    @test
+    def ceil03(): Bool =
+        equalsEps(Float32.ceil(1.0f32), 1.0f32, 0.001f32)
+
+    @test
+    def ceil04(): Bool =
+        equalsEps(Float32.ceil(0.0f32), 0.0f32, 0.001f32)
+
+    @test
+    def ceil05(): Bool =
+        equalsEps(Float32.ceil(-0.1f32), 0.0f32, 0.001f32)
+
+    @test
+    def ceil06(): Bool =
+        equalsEps(Float32.ceil(-0.9f32), 0.0f32, 0.001f32)
+
+    @test
+    def ceil07(): Bool =
+        Float32.ceil(Float32.nan()) |> Float32.isNan
+
+    @test
+    def ceil08(): Bool =
+        Float32.ceil(Float32.positiveInfinity()) == Float32.positiveInfinity()
+
+    @test
+    def ceil09(): Bool =
+        Float32.ceil(Float32.negativeInfinity()) == Float32.negativeInfinity()
+
+    /////////////////////////////////////////////////////////////////////////////
+    // floor                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+    @test
+    def floor01(): Bool =
+        equalsEps(Float32.floor(0.5f32), 0.0f32, 0.001f32)
+
+    @test
+    def floor02(): Bool =
+        equalsEps(Float32.floor(0.1f32), 0.0f32, 0.001f32)
+
+    @test
+    def floor03(): Bool =
+        equalsEps(Float32.floor(1.0f32), 1.0f32, 0.001f32)
+
+    @test
+    def floor04(): Bool =
+        equalsEps(Float32.floor(0.0f32), 0.0f32, 0.001f32)
+
+    @test
+    def floor05(): Bool =
+        equalsEps(Float32.floor(-0.1f32), -1.0f32, 0.001f32)
+
+    @test
+    def floor06(): Bool =
+        equalsEps(Float32.floor(-0.9f32), -1.0f32, 0.001f32)
+
+    @test
+    def floor07(): Bool =
+        Float32.floor(Float32.nan()) |> Float32.isNan
+
+    @test
+    def floor08(): Bool =
+        Float32.floor(Float32.positiveInfinity()) == Float32.positiveInfinity()
+
+    @test
+    def floor09(): Bool =
+        Float32.floor(Float32.negativeInfinity()) == Float32.negativeInfinity()
+
+    /////////////////////////////////////////////////////////////////////////////
+    // round                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+    @test
+    def round01(): Bool =
+        equalsEps(Float32.round(0.5f32), 0.0f32, 0.001f32)
+
+    @test
+    def round02(): Bool =
+        equalsEps(Float32.round(0.1f32), 0.0f32, 0.001f32)
+
+    @test
+    def round03(): Bool =
+        equalsEps(Float32.round(1.0f32), 1.0f32, 0.001f32)
+
+    @test
+    def round04(): Bool =
+        equalsEps(Float32.round(0.0f32), 0.0f32, 0.001f32)
+
+    @test
+    def round05(): Bool =
+        equalsEps(Float32.round(-0.1f32), 0.0f32, 0.001f32)
+
+    @test
+    def round06(): Bool =
+        equalsEps(Float32.round(-0.9f32), -1.0f32, 0.001f32)
+
+    @test
+    def round07(): Bool =
+        Float32.round(Float32.nan()) |> Float32.isNan
+
+    @test
+    def round08(): Bool =
+        Float32.round(Float32.positiveInfinity()) == Float32.positiveInfinity()
+
+    @test
+    def round09(): Bool =
+        Float32.round(Float32.negativeInfinity()) == Float32.negativeInfinity()
+
+    @test
+    def round10(): Bool =
+        equalsEps(Float32.round(1.5f32), 2.0f32, 0.001f32)
+
+    @test
+    def round11(): Bool =
+        equalsEps(Float32.round(2.5f32), 2.0f32, 0.001f32)
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestFloat64.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFloat64.flix
@@ -555,4 +555,164 @@ namespace TestFloat64 {
         let ans = Float64.clampToFloat32(Float64.nan(), -100.0f32, 100.0f32);
         Float32.isNan(ans) == true
 
+    /////////////////////////////////////////////////////////////////////////////
+    // abs                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    def equalsEps(x: Float64, y: Float64, eps: Float64): Bool =
+        let diff = Float64.abs(x - y);
+        let x1 = Float64.abs(x);
+        let y1 = Float64.abs(y);
+        let largest = if (y1 > x1) y1 else x1;
+        if (diff <= largest * eps) true else false
+
+    @test
+    def abs01(): Bool =
+        equalsEps(Float64.abs(0.0f64), 0.0f64, 0.001f64)
+
+    @test
+    def abs02(): Bool =
+        equalsEps(Float64.abs(10.1f64), 10.1f64, 0.001f64)
+
+    @test
+    def abs03(): Bool =
+        equalsEps(Float64.abs(-10.1f64), 10.1f64, 0.001f64)
+
+    @test
+    def abs04(): Bool =
+        Float64.abs(Float64.nan()) |> Float64.isNan
+
+    @test
+    def abs05(): Bool =
+        Float64.abs(Float64.positiveInfinity()) == Float64.positiveInfinity()
+
+    @test
+    def abs06(): Bool =
+        Float64.abs(Float64.negativeInfinity()) == Float64.positiveInfinity()
+
+    /////////////////////////////////////////////////////////////////////////////
+    // ceil                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+    @test
+    def ceil01(): Bool =
+        equalsEps(Float64.ceil(0.5f64), 1.0f64, 0.001f64)
+
+    @test
+    def ceil02(): Bool =
+        equalsEps(Float64.ceil(0.1f64), 1.0f64, 0.001f64)
+
+    @test
+    def ceil03(): Bool =
+        equalsEps(Float64.ceil(1.0f64), 1.0f64, 0.001f64)
+
+    @test
+    def ceil04(): Bool =
+        equalsEps(Float64.ceil(0.0f64), 0.0f64, 0.001f64)
+
+    @test
+    def ceil05(): Bool =
+        equalsEps(Float64.ceil(-0.1f64), 0.0f64, 0.001f64)
+
+    @test
+    def ceil06(): Bool =
+        equalsEps(Float64.ceil(-0.9f64), 0.0f64, 0.001f64)
+
+    @test
+    def ceil07(): Bool =
+        Float64.ceil(Float64.nan()) |> Float64.isNan
+
+    @test
+    def ceil08(): Bool =
+        Float64.ceil(Float64.positiveInfinity()) == Float64.positiveInfinity()
+
+    @test
+    def ceil09(): Bool =
+        Float64.ceil(Float64.negativeInfinity()) == Float64.negativeInfinity()
+
+    /////////////////////////////////////////////////////////////////////////////
+    // floor                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+    @test
+    def floor01(): Bool =
+        equalsEps(Float64.floor(0.5f64), 0.0f64, 0.001f64)
+
+    @test
+    def floor02(): Bool =
+        equalsEps(Float64.floor(0.1f64), 0.0f64, 0.001f64)
+
+    @test
+    def floor03(): Bool =
+        equalsEps(Float64.floor(1.0f64), 1.0f64, 0.001f64)
+
+    @test
+    def floor04(): Bool =
+        equalsEps(Float64.floor(0.0f64), 0.0f64, 0.001f64)
+
+    @test
+    def floor05(): Bool =
+        equalsEps(Float64.floor(-0.1f64), -1.0f64, 0.001f64)
+
+    @test
+    def floor06(): Bool =
+        equalsEps(Float64.floor(-0.9f64), -1.0f64, 0.001f64)
+
+    @test
+    def floor07(): Bool =
+        Float64.floor(Float64.nan()) |> Float64.isNan
+
+    @test
+    def floor08(): Bool =
+        Float64.floor(Float64.positiveInfinity()) == Float64.positiveInfinity()
+
+    @test
+    def floor09(): Bool =
+        Float64.floor(Float64.negativeInfinity()) == Float64.negativeInfinity()
+
+    /////////////////////////////////////////////////////////////////////////////
+    // round                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+    @test
+    def round01(): Bool =
+        equalsEps(Float64.round(0.5f64), 0.0f64, 0.001f64)
+
+    @test
+    def round02(): Bool =
+        equalsEps(Float64.round(0.1f64), 0.0f64, 0.001f64)
+
+    @test
+    def round03(): Bool =
+        equalsEps(Float64.round(1.0f64), 1.0f64, 0.001f64)
+
+    @test
+    def round04(): Bool =
+        equalsEps(Float64.round(0.0f64), 0.0f64, 0.001f64)
+
+    @test
+    def round05(): Bool =
+        equalsEps(Float64.round(-0.1f64), 0.0f64, 0.001f64)
+
+    @test
+    def round06(): Bool =
+        equalsEps(Float64.round(-0.9f64), -1.0f64, 0.001f64)
+
+    @test
+    def round07(): Bool =
+        Float64.round(Float64.nan()) |> Float64.isNan
+
+    @test
+    def round08(): Bool =
+        Float64.round(Float64.positiveInfinity()) == Float64.positiveInfinity()
+
+    @test
+    def round09(): Bool =
+        Float64.round(Float64.negativeInfinity()) == Float64.negativeInfinity()
+
+    @test
+    def round10(): Bool =
+        equalsEps(Float64.round(1.5f64), 2.0f64, 0.001f64)
+
+    @test
+    def round11(): Bool =
+        equalsEps(Float64.round(2.5f64), 2.0f64, 0.001f64)
+
 }


### PR DESCRIPTION
Currently Float32 and Float64 are missing explicit rounding functions. The conversion functions like `tryToInt32` obviously perform rounding but the round is always equivalent to `floor` because it uses Java's `Double.longValue`.

This PR adds the rounding functions `ceil`, `floor` and `round`. It also add `abs` which was present for Int32 etc. but missing for Float32 and Float64. 


`ceil`, `floor` and `round` are `Float64 -> Float64`. `round` in Java is actually `double -> long` (ceil and floor are `double -> double`). As we already have quite a number of conversions functions in the Float32 and Float64 modules, I think it makes sense to have `round` behave like `ceil` and `floor` - a user can then choose an appropriate conversion function after rounding. In the .net world `round` is also `double -> double` so this isn't a particularly unusual idiom.

The implementations of the round functions for Float32 are not so elegant because Java doesn't have native functions on floats for them. In Java it's expected to cast to a double: 

~~~

float d1 = 1.01f;
float d2 = (float) Math.floor(d1);
System.out.println("floor: " + d1 + " => " + d2);

~~~

I tried implementing this code with Flix's cast but calling the functions resulted in runtime crashes so I use the more verbose code that calls the native Java conversion functions instead. I didn't convert to Flix's Float64 because I didn't want to increase the use of code from the Float64 module in the Float32 module (though there already is some in the existing conversion code).