### PR TITLE
Add MutDeque

### DIFF
--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2021 Jakob Schneider Villumsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use Array.{length, get, put};
+
+/// Represents a mutable deque.
+pub enum MutDeque[a] {
+    case MutDeque(Ref[Array[a]], Ref[Int32], Ref[Int32])
+}
+
+
+namespace MutDeque {
+
+    ///
+    /// Creates a new MutDeque with default values.
+    //
+    pub def new(): MutDeque[a] & Impure = MutDeque(ref [], ref 0, ref 0)
+
+
+    ///
+    /// Removes and returns the front element as an optional of d in O(1) time. Returns None if d is empty.
+    ///
+    pub def popFront(d: MutDeque[a]): Option[a] & Impure = match d {
+        case _ if isEmpty(d) => None
+
+        case MutDeque(arr, f, _) if isWithinBounds(deref f, deref arr) =>
+            let front = deref f;
+            f := increment(front)(withRespectTo(deref arr));
+            Some(get(deref arr, front))
+
+        case MutDeque(arr, _, _) => Some((deref arr)[-1]) // Internal Error - should be unreachable
+    }
+
+
+    ///
+    /// Removes and returns the back element as an optional of d in O(1) time. Returns None if d is empty.
+    ///
+    pub def popBack(d: MutDeque[a]): Option[a] & Impure = match d {
+        case _ if isEmpty(d) => None
+
+        case MutDeque(arr, _, b) if isWithinBounds(deref b, deref arr) =>
+            b := decrement(deref b)(withRespectTo(deref arr));
+            Some(get(deref arr, deref b))
+
+        case MutDeque(arr, _, _) => Some((deref arr)[-1]) // Internal Error - should be unreachable
+    }
+
+
+    ///
+    /// Pushes x to the front of d in amortized O(1) time.
+    ///
+    pub def pushFront(x: a, d: MutDeque[a]): Unit & Impure = match d {
+        case MutDeque(arr, front, back) if requiresExpansion(d) =>
+            let oldIndex = computeEndIndexOf(deref arr);
+            arr := expandWithDefault(d, x);
+            front := length(deref arr) - 1;
+            back := oldIndex - 1
+
+        case MutDeque(arr, front, _) =>
+            front := decrement(deref front)(withRespectTo(deref arr));
+            arr := put(deref arr, deref front, x)
+    }
+
+
+    ///
+    /// Pushes x to the back of d in amortized O(1) time.
+    ///
+    pub def pushBack(x: a, d: MutDeque[a]): Unit & Impure = match d {
+        case MutDeque(arr, front, back) if requiresExpansion(d) =>
+            let oldEndIndex = computeEndIndexOf(deref arr);
+            arr := expandWithDefault(d, x);
+            front := 0;
+            back := oldEndIndex
+
+        case MutDeque(arr, _, back) =>
+            arr := put(deref arr, deref back, x);
+            back := increment(deref back)(withRespectTo(deref arr))
+    }
+
+
+    ///
+    /// Returns the number of elements in d that satisfy the predicate f in O(n) time.
+    ///
+    pub def count(f: a -> Bool, d: MutDeque[a]): Int32 & Impure = {
+        foldLeft((acc, x) -> if (f(x)) acc + 1 else acc, 0, d)
+    }
+
+
+    ///
+    /// Applies f to a start value s and all elements in d, going from left to right.
+    ///
+    pub def foldLeft(f: (b, a) -> b & e, s: b, d: MutDeque[a]): b & Impure = match d {
+        case _ if isEmpty(d)        => s
+        case MutDeque(arr, _, back) =>
+            let (currentVal, nextEl) = getFoldElementsFrom(d);
+            foldLeft(f, f(s, currentVal), MutDeque(arr, nextEl, back))
+    }
+
+
+    ///
+    /// Applies f to a start value s and all elements in d, going from right to left.
+    ///
+    pub def foldRight(f: (a, b) -> b & e, s: b, d: MutDeque[a]): b & Impure = match d {
+        case _ if isEmpty(d)        => s
+        case MutDeque(arr, _, back) =>
+            let (currentVal, nextEl) = getFoldElementsFrom(d);
+            f(currentVal, foldRight(f, s, MutDeque(arr, nextEl, back)))
+    }
+
+
+    ///
+    /// Returns true if d is empty, else false.
+    ///
+    pub def isEmpty(d: MutDeque[a]): Bool & Impure = {
+        let MutDeque(_, front, back) = d;
+        deref front == deref back
+    }
+
+
+    ///
+    /// Helper function for foldLeft and foldRight.
+    ///
+    def getFoldElementsFrom(d: MutDeque[a]): (a, Ref[Int32]) & Impure = {
+        let MutDeque(arr, front, _) = d;
+        let currentVal = get(deref arr, deref front);
+        let nextEl = ref increment(deref front)(withRespectTo(deref arr));
+        (currentVal, nextEl)
+    }
+
+
+    ///
+    /// Helper function for push operations.
+    ///
+    def requiresExpansion(d: MutDeque[a]): Bool & Impure =
+        let MutDeque(arr, front, back) = d;
+        length(deref arr) == 0 || (deref back + 1) % length(deref arr) == deref front
+
+
+    ///
+    /// Helper function to increment indices.
+    ///
+    def increment(i: Int32, limit: Int32): Int32 = (i + 1) % limit
+
+
+    ///
+    /// Helper function to decrement indices.
+    ///
+    def decrement(i: Int32, limit: Int32): Int32 = if (i - 1 < 0) limit - 1 else i - 1
+
+
+    ///
+    /// Helper function used in increment calls to improve readability.
+    ///
+    def withRespectTo(arr: Array[a]): Int32 = length(arr)
+
+
+    ///
+    /// Helper function for push operations which copies the elements of d to an array of double length and writes x to remaining "empty" entries.
+    ///
+    def expandWithDefault(d: MutDeque[a], x: a): Array[a] & Impure = {
+        let MutDeque(arr, _, _) = d;
+        if (length(deref arr) == 0) Array.init(_ -> x, 2)
+        else {
+            let doubleLength = 2 * length(deref arr);
+            Array.init(_ -> {
+                match popFront(d) {
+                    case None    => x
+                    case Some(v) => v
+                }
+            }, doubleLength)
+        }
+    }
+
+
+    ///
+    /// Helper function for pop operations to determine if index i is within bounds of arr.
+    ///
+    def isWithinBounds(i: Int32, arr: Array[a]): Bool = {
+        i >= 0 && i < length(arr)
+    }
+
+
+    ///
+    /// Helper function for push operations that determines wrap-around index
+    ///
+    def computeEndIndexOf(arr: Array[a]): Int32 =
+        let len = length(arr);
+        if (len == 0) 1 else len
+}

--- a/main/test/ca/uwaterloo/flix/library/TestMutDeque.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutDeque.flix
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Jakob Schneider Villumsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use List.{filter, head, foreach};
 use Array.{length => lengthOfArray};
 use Console.{printLine => println};

--- a/main/test/ca/uwaterloo/flix/library/TestMutDeque.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutDeque.flix
@@ -1,0 +1,429 @@
+use List.{filter, head, foreach};
+use Array.{length => lengthOfArray};
+use Console.{printLine => println};
+use TestUtil.{impureAssert, printErrors};
+use MutDeque.{popFront, popBack, pushFront, pushBack, count, isEmpty};
+
+
+namespace TestMutDeque {
+    pub def testAll(): Int32 & Impure = {
+
+        let testResults: List[Int32] =
+            testInitialParameters_expectSuccess() ::
+            testPopFront_withEmptyDeque_expectFailure() ::
+            testPopFront_withNonEmptyDeque_expectSuccess() ::
+            testPopFront_withNonEmptyDequeUntilEmpty_expectFailure() ::
+            testPushBack_withEmptyDeque_expectSuccess() ::
+            testPushBack_withFullDeque_expectSuccess() ::
+            testPushBack_withExpansion_expectSuccess() ::
+            testPopBack_withEmptyDeque_expectFailure() ::
+            testPopBack_withNoneEmptyDeque_expectSuccess() ::
+            testPushFront_withEmptyDeque_expectSuccess() ::
+            testPushFront_withFullDeque_expectSuccess() ::
+            testCount_withAlwaysTrueCondition_expectSuccess() ::
+            testCount_withNumberOfALetters_expectSuccess() ::
+            testCount_withEmptyDeque_expectSuccess() ::
+            testCount_withAlwaysFalseCondition_expectSuccess() ::
+            testCount_withNumberOfAsAndPushAndPop_expectSuccess() ::
+            testAllOperations_expectSuccess() ::
+            Nil;
+
+        printErrors("TestMutDeque")(testResults);
+
+        match testResults |> filter(x -> x == 1) |> head {
+            case Some(_) =>
+                println("Tests exited with errors.");
+                1
+            case _       =>
+                println("All tests passed.");
+                0
+        }
+    }
+
+
+    def testInitialParameters_expectSuccess(): Int32 & Impure = {
+        let MutDeque(a, s, e) = MutDeque.new();
+
+        impureAssert(() ->
+            lengthOfArray(deref a) == 0
+            && deref s == 0
+            && deref e == 0
+        )
+    }
+
+
+    def testPopFront_withEmptyDeque_expectFailure(): Int32 & Impure = {
+        let mdq = MutDeque.new();
+
+        impureAssert(() ->
+            popFront(mdq) == None
+            && popFront(mdq) == None
+            && popFront(mdq) == None
+            && popFront(mdq) == None
+        )
+    }
+
+
+    def testPopFront_withNonEmptyDeque_expectSuccess(): Int32 & Impure = {
+        let mdq = MutDeque(ref [1, 2, 3, -1], ref 0, ref 3);
+
+        impureAssert(() ->
+            let MutDeque(_, front, back) = mdq;
+            deref front == 0
+            && deref back == 3
+            && popFront(mdq) == Some(1)
+            && deref front == 1
+            && deref back == 3
+        )
+    }
+
+    def testPopFront_withNonEmptyDequeUntilEmpty_expectFailure(): Int32 & Impure = {
+        let mq = MutDeque(ref [1, 2, 3, -1], ref 0, ref 3);
+        let MutDeque(_, front, back) = mq;
+
+        impureAssert(() ->
+            deref front == 0
+            && popFront(mq) == Some(1)
+            && deref front == 1
+            && popFront(mq) == Some(2)
+            && deref front == 2
+            && popFront(mq) == Some(3)
+            && deref front == 3
+            && deref back == 3
+            && popFront(mq) == None
+        )
+    }
+
+
+    def testPushBack_withEmptyDeque_expectSuccess(): Int32 & Impure = {
+        impureAssert(() ->
+            let mdq = MutDeque.new();
+            let MutDeque(arr, front, back) = mdq;
+
+            match
+            deref front == 0
+            && deref back == 0
+            && Array.length(deref arr) == 0 {
+
+                case true =>
+                    pushBack("a", mdq);
+
+                    deref front == 0
+                    && deref back == 1
+                    && Array.length(deref arr) == 2
+                    && popFront(mdq) == Some("a")
+                    && popFront(mdq) == None
+
+                case _ => false
+            }
+        )
+    }
+
+
+    def testPushBack_withFullDeque_expectSuccess(): Int32 & Impure = {
+        impureAssert(() ->
+            let mdq = MutDeque.new();
+            let MutDeque(arr, front, back) = mdq;
+            pushBack("a", mdq);
+            pushBack("b", mdq);
+
+            match
+            Array.length(deref arr) == 4
+            && deref front == 0
+            && deref back == 2 {
+
+                case true =>
+                    pushBack("c", mdq);
+                    pushBack("d", mdq);
+
+                    match
+                    Array.length(deref arr) == 8
+                    && deref front == 0
+                    && deref back == 4 {
+
+                        case true =>
+                        popFront(mdq) == Some("a")
+                        && popFront(mdq) == Some("b")
+                        && popFront(mdq) == Some("c")
+                        && popFront(mdq) == Some("d")
+
+                        case _ => false
+                    }
+
+                case _ => false
+            }
+        )
+    }
+
+
+    def testPushBack_withExpansion_expectSuccess(): Int32 & Impure = {
+        impureAssert(() ->
+            let mdq = MutDeque.new();
+            let MutDeque(arr, front, back) = mdq;
+
+            match
+            lengthOfArray(deref arr) == 0 {
+                case true =>
+                    pushBack("a", mdq);
+
+                    match
+                    lengthOfArray(deref arr) == 2 {
+                        case true =>
+                            pushBack("a", mdq);
+
+                            match
+                            lengthOfArray(deref arr) == 4 {
+                                case true =>
+                                    pushBack("a", mdq);
+                                    pushBack("a", mdq);
+                                    pushBack("a", mdq);
+                                    pushBack("a", mdq);
+
+                                    match
+                                    lengthOfArray(deref arr) == 8
+                                    && deref front == 0
+                                    && deref back == 6 {
+                                        case true =>
+                                            popFront(mdq);
+                                            popFront(mdq);
+                                            popFront(mdq);
+                                            popFront(mdq);
+                                            popFront(mdq);
+                                            popFront(mdq);
+
+                                            match
+                                            popFront(mdq) == None
+                                            && lengthOfArray(deref arr) == 8
+                                            && deref front == 6 {
+                                                case true =>
+                                                    pushBack("a", mdq);
+
+                                                    lengthOfArray(deref arr) == 8
+                                                    && count(x -> x == "a", mdq) == 1
+
+                                                case _ => false
+                                            }
+
+                                        case _ => false
+                                    }
+
+
+                                case _ => false
+                            }
+
+                        case _ => false
+                    }
+
+                case _ => false
+            }
+        )
+    }
+
+
+    def testPopBack_withEmptyDeque_expectFailure(): Int32 & Impure = {
+        impureAssert(() ->
+            popBack(MutDeque.new()) == None
+            && popBack(MutDeque.new()) == None
+            && popBack(MutDeque.new()) == None
+            && popBack(MutDeque.new()) == None
+        )
+    }
+
+
+    def testPopBack_withNoneEmptyDeque_expectSuccess(): Int32 & Impure = {
+        impureAssert(() ->
+            let mdq = MutDeque.new();
+            let MutDeque(_, front, back) = mdq;
+            pushBack("a", mdq);
+            pushBack("b", mdq);
+            pushBack("c", mdq);
+
+            deref front == 0
+            && deref back == 3
+            && popBack(mdq) == Some("c")
+            && deref back == 2
+            && popBack(mdq) == Some("b")
+            && deref back == 1
+            && popBack(mdq) == Some("a")
+            && deref back == 0
+            && isEmpty(mdq)
+        )
+    }
+
+
+    def testPushFront_withEmptyDeque_expectSuccess(): Int32 & Impure = {
+        impureAssert(() ->
+            let mdq = MutDeque.new();
+            let MutDeque(arr, front, back) = mdq;
+
+            match
+            deref front == 0
+            && deref back == 0
+            && Array.length(deref arr) == 0 {
+
+                case true =>
+                    pushFront("a", mdq);
+
+                    match
+                    deref front == 1
+                    && deref back == 0
+                    && Array.length(deref arr) == 2
+                    && popFront(mdq) == Some("a")
+                    && deref front == 0
+                    && popFront(mdq) == None {
+
+                        case true =>
+                            pushFront("b", mdq);
+
+                            deref front == 1
+                            && deref back == 0
+                            && Array.length(deref arr) == 2
+                            && popBack(mdq) == Some("b")
+                            && deref front == 1
+                            && deref back == 1
+                            && popBack(mdq) == None
+                            && deref back == 1
+
+                        case _ => false
+                    }
+
+                case _ => false
+            }
+        )
+    }
+
+
+    def testPushFront_withFullDeque_expectSuccess(): Int32 & Impure = {
+        impureAssert(() ->
+            let mdq = MutDeque.new();
+            let MutDeque(arr, front, back) = mdq;
+            pushFront("a", mdq);
+            pushFront("b", mdq);
+
+            match
+            Array.length(deref arr) == 4
+            && deref front == 3
+            && deref back == 1 {
+
+                case true =>
+                    pushFront("c", mdq);
+                    pushFront("d", mdq);
+
+                    match
+                    Array.length(deref arr) == 8
+                    && deref front == 7
+                    && deref back == 3 {
+
+                        case true =>
+                        popFront(mdq) == Some("d")
+                        && popFront(mdq) == Some("c")
+                        && popFront(mdq) == Some("b")
+                        && popFront(mdq) == Some("a")
+                        && isEmpty(mdq)
+                        && popFront(mdq) == None
+
+                        case _ => false
+                    }
+
+                case _ => false
+            }
+        )
+    }
+
+    def testCount_withEmptyDeque_expectSuccess(): Int32 & Impure = {
+        impureAssert(() ->
+            let mdq = MutDeque.new();
+            count(i -> i == 1, mdq) == 0
+        )
+    }
+
+    def testCount_withAlwaysTrueCondition_expectSuccess(): Int32 & Impure = {
+        impureAssert(() ->
+            let mdq = MutDeque.new();
+            pushBack("b", mdq);
+            pushBack("b", mdq);
+            pushBack("b", mdq);
+            count(_ -> true, mdq) == 3
+        )
+    }
+
+    def testCount_withAlwaysFalseCondition_expectSuccess(): Int32 & Impure = {
+        impureAssert(() ->
+            let mdq = MutDeque.new();
+            pushBack("b", mdq);
+            pushBack("b", mdq);
+            pushBack("b", mdq);
+            count(_ -> false, mdq) == 0
+        )
+    }
+
+    def testCount_withNumberOfALetters_expectSuccess(): Int32 & Impure = {
+        impureAssert(() ->
+            let mdq = MutDeque.new();
+            pushBack("a", mdq);
+            pushBack("b", mdq);
+            pushBack("a", mdq);
+            count(x -> x == "a", mdq) == 2
+            && count(x -> x == "b", mdq) == 1
+        )
+    }
+
+    def testCount_withNumberOfAsAndPushAndPop_expectSuccess(): Int32 & Impure = {
+        impureAssert(() ->
+            let mdq = MutDeque.new();
+            pushBack("a", mdq);
+            pushBack("b", mdq);
+            pushBack("a", mdq);
+
+            match
+            count(x -> x == "a", mdq) == 2
+            && count(x -> x == "b", mdq) == 1 {
+
+                case true =>
+                    popFront(mdq);
+                    count(x -> x == "a", mdq) == 1
+                    && count(x -> x == "b", mdq) == 1
+
+                case _ => false
+            }
+        )
+    }
+
+    def testAllOperations_expectSuccess(): Int32 & Impure = {
+        impureAssert(() ->
+            let mdq = MutDeque.new();
+            let MutDeque(_arr, _front, _back) = mdq;
+            pushFront("a", mdq);
+            pushBack("b", mdq);
+            pushFront("c", mdq);
+
+            count(x -> x == "b", mdq) == 1
+            && popBack(mdq) == Some("b")
+            && count(x -> x == "b", mdq) == 0
+            && popBack(mdq) == Some("a")
+            && popFront(mdq) == Some("c")
+            && isEmpty(mdq)
+        )
+    }
+}
+
+namespace TestUtil {
+    pub def impureAssert(x: Unit -> Bool & Impure): Int32 & Impure = {
+        if (x()) 0 else 1
+    }
+
+    pub def pureAssert(x: Unit -> Bool): Int32 = {
+        if (x()) 0 else 1
+    }
+
+    pub def collectFailures(results: List[Int32]): List[(Int32, Int32)] = {
+        results
+        |> mapWithIndex((res, idx) -> (idx + 1, res))
+        |> filter(x -> snd(x) == 1)
+    }
+
+    pub def printErrors(name: String, results: List[Int32]): Unit & Impure = {
+        collectFailures(results)
+        |> foreach(x -> println("TEST FAILED: ${name}, test ${Int32.toString(fst(x))}"))
+    }
+}


### PR DESCRIPTION
Fixes #1952

This is not final and must be reviewed.
I think the tests are very inelegant and should be refactored to make more sense. Maybe they should be split into white-box tests for the specific implementation and some black-box tests which should *always* work regardless of implementation.
Additionally, I simply copy-pasted the original code but I  assume the tests would have to be annotated with the @test tag for the testsuite to pick it up when executing tests.
Also, I think there might be some awkward expressions in some of the helper functions in the MutDeque.flix file.