### PR TITLE
Show purity for pure functions and expressions in LSP

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompleteProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompleteProvider.scala
@@ -249,12 +249,12 @@ object CompleteProvider {
 
       val tpe = FormatType.formatType(tpe0)
       val eff = eff0 match {
-        case Type.Cst(TypeConstructor.True, _) => ""
-        case Type.Cst(TypeConstructor.False, _) => " & Impure"
-        case e => " & " + FormatType.formatType(e)
+        case Type.Cst(TypeConstructor.True, _) => "Pure"
+        case Type.Cst(TypeConstructor.False, _) => "Impure"
+        case e => FormatType.formatType(e)
       }
 
-      s"$name(${args.mkString(", ")}): $tpe$eff"
+      s"$name(${args.mkString(", ")}): $tpe & $eff"
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompleteProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompleteProvider.scala
@@ -242,19 +242,19 @@ object CompleteProvider {
     * Returns the label for the given `name`, and `spec`.
     */
   private def getLabel(name: String, spec: TypedAst.Spec): String = spec match {
-    case TypedAst.Spec(_, _, _, _, fparams, _, tpe0, eff0, _) =>
+    case TypedAst.Spec(_, _, _, _, fparams, _, retTpe0, eff0, _) =>
       val args = fparams.map {
         fparam => s"${fparam.sym.text}: ${FormatType.formatType(fparam.tpe)}"
       }
 
-      val tpe = FormatType.formatType(tpe0)
+      val retTpe = FormatType.formatType(retTpe0)
       val eff = eff0 match {
         case Type.Cst(TypeConstructor.True, _) => "Pure"
         case Type.Cst(TypeConstructor.False, _) => "Impure"
         case e => FormatType.formatType(e)
       }
 
-      s"$name(${args.mkString(", ")}): $tpe & $eff"
+      s"$name(${args.mkString(", ")}): $retTpe & $eff"
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HoverProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HoverProvider.scala
@@ -110,11 +110,12 @@ object HoverProvider {
 
   private def formatTypAndEff(tpe0: Type, eff0: Type): String = {
     val t = FormatType.formatType(tpe0)
-    eff0 match {
-      case Type.Cst(TypeConstructor.True, _) => t
-      case Type.Cst(TypeConstructor.False, _) => s"$t & Impure"
-      case eff => s"$t & ${FormatType.formatType(eff)}"
+    val e = eff0 match {
+      case Type.Cst(TypeConstructor.True, _) => "Pure"
+      case Type.Cst(TypeConstructor.False, _) => "Impure"
+      case eff => FormatType.formatType(eff)
     }
+    s"$t & $e"
   }
 
   private def hoverTypeConstructor(tc: TypeConstructor, loc: SourceLocation)(implicit index: Index, root: Root): JObject = {

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -44,7 +44,7 @@ object NamedAst {
 
   case class Def(sym: Symbol.DefnSym, spec: NamedAst.Spec, exp: NamedAst.Expression) extends NamedAst.DefOrSig
 
-  case class Spec(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, tparams: List[NamedAst.TypeParam], fparams: List[NamedAst.FormalParam], sc: NamedAst.Scheme, tpe: Type, eff: Type, loc: SourceLocation)
+  case class Spec(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, tparams: List[NamedAst.TypeParam], fparams: List[NamedAst.FormalParam], sc: NamedAst.Scheme, retTpe: Type, eff: Type, loc: SourceLocation)
 
   case class Enum(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.EnumSym, tparams: List[NamedAst.TypeParam], cases: Map[Name.Tag, NamedAst.Case], tpe: NamedAst.Type, kind: Kind, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -42,7 +42,7 @@ object TypedAst {
 
   case class Def(sym: Symbol.DefnSym, spec: TypedAst.Spec, impl: TypedAst.Impl)
 
-  case class Spec(doc: Ast.Doc, ann: List[TypedAst.Annotation], mod: Ast.Modifiers, tparams: List[TypedAst.TypeParam], fparams: List[TypedAst.FormalParam], declaredScheme: Scheme, tpe: Type, eff: Type, loc: SourceLocation)
+  case class Spec(doc: Ast.Doc, ann: List[TypedAst.Annotation], mod: Ast.Modifiers, tparams: List[TypedAst.TypeParam], fparams: List[TypedAst.FormalParam], declaredScheme: Scheme, retTpe: Type, eff: Type, loc: SourceLocation)
 
   case class Impl(exp: TypedAst.Expression, inferredScheme: Scheme)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -39,11 +39,11 @@ object WeededAst {
 
     case class Instance(doc: Ast.Doc, mod: Ast.Modifiers, clazz: Name.QName, tpe: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], defs: List[WeededAst.Declaration.Def], loc: SourceLocation) extends WeededAst.Declaration
 
-    case class Sig(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: Option[WeededAst.Expression], tpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation) extends WeededAst.Declaration
+    case class Sig(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: Option[WeededAst.Expression], tpe: WeededAst.Type, retTpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation) extends WeededAst.Declaration
 
-    case class Def(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: WeededAst.Expression, tpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation) extends WeededAst.Declaration
+    case class Def(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: WeededAst.Expression, tpe: WeededAst.Type, retTpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation) extends WeededAst.Declaration
 
-    case class Law(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: WeededAst.Expression, tpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation) extends WeededAst.Declaration
+    case class Law(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: WeededAst.Expression, tpe: WeededAst.Type, retTpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation) extends WeededAst.Declaration
 
     case class Enum(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.TypeParams, cases: Map[Name.Tag, WeededAst.Case], loc: SourceLocation) extends WeededAst.Declaration
 

--- a/main/src/ca/uwaterloo/flix/language/debug/FormatSignature.scala
+++ b/main/src/ca/uwaterloo/flix/language/debug/FormatSignature.scala
@@ -37,7 +37,7 @@ object FormatSignature {
     * Returns a markdown string for the given `name` and `spec`.
     */
   private def formatSpec(name: String, spec: TypedAst.Spec)(implicit audience: Audience): String = {
-    s"""def **${name}**(${formatFormalParams(spec.fparams)}): ${formatResultTypeAndEff(spec.tpe, spec.eff)}
+    s"""def **${name}**(${formatFormalParams(spec.fparams)}): ${formatResultTypeAndEff(spec.retTpe, spec.eff)}
        |""".stripMargin
 
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
@@ -105,7 +105,7 @@ object Documentor extends Phase[TypedAst.Root, TypedAst.Root] {
     }
 
     // Compute return type and effect.
-    val result = defn0.spec.tpe
+    val result = defn0.spec.retTpe
     val effect = defn0.spec.eff
 
     // Construct the JSON object.

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -199,10 +199,10 @@ object Lowering extends Phase[Root, Root] {
     * Lowers the given `spec0`.
     */
   private def visitSpec(spec0: Spec)(implicit root: Root, flix: Flix): Spec = spec0 match {
-    case Spec(doc, ann, mod, tparams, fparams, declaredScheme, tpe, eff, loc) =>
+    case Spec(doc, ann, mod, tparams, fparams, declaredScheme, retTpe, eff, loc) =>
       val fs = fparams.map(visitFormalParam)
       val ds = visitScheme(declaredScheme)
-      Spec(doc, ann, mod, tparams, fs, ds, tpe, eff, loc)
+      Spec(doc, ann, mod, tparams, fs, ds, retTpe, eff, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -135,7 +135,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
       /*
      * Definition.
      */
-      case decl@WeededAst.Declaration.Def(doc, ann, mod, ident, tparams0, fparams0, exp, tpe, eff0, tconstrs, loc) =>
+      case decl@WeededAst.Declaration.Def(doc, ann, mod, ident, tparams0, fparams0, exp, tpe, retTpe, eff0, tconstrs, loc) =>
         // Check if the definition already exists.
         val defsAndSigs = prog0.defsAndSigs.getOrElse(ns0, Map.empty)
         defsAndSigs.get(ident.name) match {
@@ -159,7 +159,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
       /*
      * Law.
      */
-      case WeededAst.Declaration.Law(doc, ann, mod, ident, tparams0, fparams0, exp, tpe, eff0, tconstrs, loc) => ??? // TODO
+      case WeededAst.Declaration.Law(doc, ann, mod, ident, tparams0, fparams0, exp, tpe, retTpe, eff0, tconstrs, loc) => ??? // TODO
 
       /*
      * Enum.
@@ -376,7 +376,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
     * Performs naming on the given signature declaration `sig` under the given environments `env0`, `uenv0`, and `tenv0`.
     */
   private def visitSig(sig: WeededAst.Declaration.Sig, uenv0: UseEnv, tenv0: Map[String, Type.Var], ns0: Name.NName, classIdent: Name.Ident, classSym: Symbol.ClassSym, classTparam: NamedAst.TypeParam)(implicit flix: Flix): Validation[NamedAst.Sig, NameError] = sig match {
-    case WeededAst.Declaration.Sig(doc, ann, mod, ident, tparams0, fparams0, exp0, tpe0, eff0, tconstrs0, loc) =>
+    case WeededAst.Declaration.Sig(doc, ann, mod, ident, tparams0, fparams0, exp0, tpe0, retTpe0, eff0, tconstrs0, loc) =>
       flatMapN(getTypeParamsFromFormalParams(tparams0, fparams0, tpe0, loc, allowElision = true, uenv0, tenv0), checkSigType(ident, classTparam, tpe0, loc)) {
         case (tparams, _) =>
           val tenv = tenv0 ++ getTypeEnv(tparams)
@@ -387,12 +387,12 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
               val classTconstr = NamedAst.TypeConstraint(Name.mkQName(classIdent), NamedAst.Type.Var(classTparam.tpe, classTparam.loc), classSym.loc)
               val schemeVal = getDefOrSigScheme(tparams, tpe0, uenv0, tenv, classTconstr :: tconstrs, List(classTparam.tpe))
               val expVal = traverse(exp0)(visitExp(_, env0, uenv0, tenv))
-              val tpeVal = visitType(tpe0, uenv0, tenv)
+              val retTpeVal = visitType(retTpe0, uenv0, tenv)
               val effVal = visitType(eff0, uenv0, tenv)
-              mapN(annVal, schemeVal, tpeVal, effVal, expVal) {
-                case (as, sc, tpe, eff, exp) =>
+              mapN(annVal, schemeVal, retTpeVal, effVal, expVal) {
+                case (as, sc, retTpe, eff, exp) =>
                   val sym = Symbol.mkSigSym(classSym, ident)
-                  val spec = NamedAst.Spec(doc, as, mod, tparams, fparams, sc, tpe, eff, loc)
+                  val spec = NamedAst.Spec(doc, as, mod, tparams, fparams, sc, retTpe, eff, loc)
                   NamedAst.Sig(sym, spec, exp.headOption)
               }
           }
@@ -414,7 +414,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
     * Performs naming on the given definition declaration `decl0` under the given environments `env0`, `uenv0`, and `tenv0`, with type constraints `tconstrs`.
     */
   private def visitDef(decl0: WeededAst.Declaration.Def, uenv0: UseEnv, tenv0: Map[String, Type.Var], ns0: Name.NName, addedTconstrs: List[NamedAst.TypeConstraint], addedQuantifiers: List[Type.Var])(implicit flix: Flix): Validation[NamedAst.Def, NameError] = decl0 match {
-    case WeededAst.Declaration.Def(doc, ann, mod, ident, tparams0, fparams0, exp, tpe0, eff0, tconstrs, loc) =>
+    case WeededAst.Declaration.Def(doc, ann, mod, ident, tparams0, fparams0, exp, tpe0, retTpe0, eff0, tconstrs, loc) =>
       // TODO: we use tenv when getting the types from formal params first, before the explicit tparams have a chance to modify it
       // This means that if an explicit type variable is shadowing, the outer scope variable will be used for some parts, and inner for others
       // Resulting in a type error rather than a redundancy error (as redundancy checking happens later)
@@ -429,12 +429,12 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
               val annVal = traverse(ann)(visitAnnotation(_, env0, uenv0, tenv))
               val expVal = visitExp(exp, env0, uenv0, tenv)
               val schemeVal = getDefOrSigScheme(tparams, tpe0, uenv0, tenv, tconstrs ++ addedTconstrs, addedQuantifiers)
-              val tpeVal = visitType(tpe0, uenv0, tenv)
+              val retTpeVal = visitType(retTpe0, uenv0, tenv)
               val effVal = visitType(eff0, uenv0, tenv)
-              mapN(annVal, expVal, schemeVal, tpeVal, effVal) {
-                case (as, e, sc, tpe, eff) =>
+              mapN(annVal, expVal, schemeVal, retTpeVal, effVal) {
+                case (as, e, sc, retTpe, eff) =>
                   val sym = Symbol.mkDefnSym(ns0, ident)
-                  val spec = NamedAst.Spec(doc, as, mod, tparams, fparams, sc, tpe, eff, loc)
+                  val spec = NamedAst.Spec(doc, as, mod, tparams, fparams, sc, retTpe, eff, loc)
                   NamedAst.Def(sym, spec, e)
               }
           }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -229,18 +229,18 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
     * Performs name resolution on the given spec `s0` in the given namespace `ns0`.
     */
   def resolve(s0: NamedAst.Spec, ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Spec, ResolutionError] = s0 match {
-    case NamedAst.Spec(doc, ann0, mod, tparams0, fparams0, sc0, tpe0, eff0, loc) =>
+    case NamedAst.Spec(doc, ann0, mod, tparams0, fparams0, sc0, retTpe0, eff0, loc) =>
 
       val fparamsVal = resolveFormalParams(fparams0, ns0, root)
       val tparamsVal = resolveTypeParams(tparams0, ns0, root)
       val annVal = traverse(ann0)(visitAnnotation(_, ns0, root))
       val schemeVal = resolveScheme(sc0, ns0, root)
-      val tpeVal = lookupType(tpe0, ns0, root)
+      val retTpeVal = lookupType(retTpe0, ns0, root)
       val effVal = lookupType(eff0, ns0, root)
 
-      mapN(fparamsVal, tparamsVal, annVal, schemeVal, tpeVal, effVal) {
-        case (fparams, tparams, ann, scheme, tpe, eff) =>
-          ResolvedAst.Spec(doc, ann, mod, tparams, fparams, scheme, tpe, eff, loc)
+      mapN(fparamsVal, tparamsVal, annVal, schemeVal, retTpeVal, effVal) {
+        case (fparams, tparams, ann, scheme, retTpe, eff) =>
+          ResolvedAst.Spec(doc, ann, mod, tparams, fparams, scheme, retTpe, eff, loc)
       }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -129,9 +129,10 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
         (as, mod, tparams, fparams, eff, exp) = res
         _ <- requirePublic(mod, ident)
         ts = fparams.map(_.tpe.get)
-        tpe = WeededAst.Type.Arrow(ts, eff, visitType(tpe0), loc)
+        retTpe = visitType(tpe0)
+        tpe = WeededAst.Type.Arrow(ts, eff, retTpe, loc)
         tconstrs <- traverse(tconstrs0)(visitTypeConstraint)
-      } yield List(WeededAst.Declaration.Sig(doc, as, mod, ident, tparams, fparams, exp.headOption, tpe, eff, tconstrs, loc))
+      } yield List(WeededAst.Declaration.Sig(doc, as, mod, ident, tparams, fparams, exp.headOption, tpe, retTpe, eff, tconstrs, loc))
   }
 
   /**
@@ -183,9 +184,10 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
         (as, mod, tparams, fparams, exp, eff) = res
         _ <- if (requiresPublic) requirePublic(mod, ident) else ().toSuccess // conditionally require a public modifier
         ts = fparams.map(_.tpe.get)
-        tpe = WeededAst.Type.Arrow(ts, eff, visitType(tpe0), loc)
+        retTpe = visitType(tpe0)
+        tpe = WeededAst.Type.Arrow(ts, eff, retTpe, loc)
         tconstrs <- traverse(tconstrs0)(visitTypeConstraint)
-      } yield List(WeededAst.Declaration.Def(doc, as, mod, ident, tparams, fparams, exp, tpe, eff, tconstrs, loc))
+      } yield List(WeededAst.Declaration.Def(doc, as, mod, ident, tparams, fparams, exp, tpe, retTpe, eff, tconstrs, loc))
   }
 
   /**
@@ -204,8 +206,9 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
       mapN(annVal, modVal, tparamsVal, formalsVal, expVal) {
         case (ann, mod, tparams, fs, exp) =>
           val ts = fs.map(_.tpe.get)
-          val tpe = WeededAst.Type.Arrow(ts, WeededAst.Type.True(loc), WeededAst.Type.Ambiguous(Name.mkQName("Bool"), loc), loc)
-          List(WeededAst.Declaration.Def(doc, ann, mod, ident, tparams, fs, exp, tpe, WeededAst.Type.True(loc), Nil, loc))
+          val retTpe = WeededAst.Type.Ambiguous(Name.mkQName("Bool"), loc)
+          val tpe = WeededAst.Type.Arrow(ts, WeededAst.Type.True(loc), retTpe, loc)
+          List(WeededAst.Declaration.Def(doc, ann, mod, ident, tparams, fs, exp, tpe, retTpe, WeededAst.Type.True(loc), Nil, loc))
       }
   }
 


### PR DESCRIPTION
Fixes https://github.com/flix/flix/issues/2065
Also fixes a bug where LSP showed the whole function type in the place of the return type.