### PR TITLE
Import native static inner classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ target
 /*.flix
 /build
 /.gradle
+.metals
+.vscode
+.bloop

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -39,3 +39,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Felix Wiemuth](https://github.com/felixwiemuth)
 - [Manoj Kumar](https://github.com/manoj2601)
 - [Jakob Schneider Villumsen](https://github.com/jaschdoc)
+- [Ramiro Calle](https://github.com/rrramiro)

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -675,24 +675,16 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     def LetImport: Rule1[ParsedAst.Expression] = {
 
-      def JvmIdent: Rule1[String] = rule {
-        capture(CharPredicate.Alpha ~ zeroOrMore(CharPredicate.AlphaNum + '_'))
-      }
-
-      def JvmName: Rule1[Seq[String]] = rule {
-        oneOrMore(JvmIdent).separatedBy(".")
-      }
-
       def JvmStaticName: Rule1[Seq[String]] = rule {
-        oneOrMore(JvmIdent).separatedBy(".") ~ ":" ~ JvmIdent ~> ((xs: Seq[String], x: String) => xs :+ x)
+        oneOrMore(Names.JavaIdentifier).separatedBy(".") ~ ":" ~ Names.JavaIdentifier ~> ((xs: Seq[String], x: String) => xs :+ x)
       }
 
       def Constructor: Rule1[ParsedAst.JvmOp] = rule {
-        keyword("new") ~ WS ~ JvmName ~ optWS ~ Signature ~ WS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.Constructor
+        keyword("new") ~ WS ~ Names.JavaName ~ optWS ~ Signature ~ WS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.Constructor
       }
 
       def Method: Rule1[ParsedAst.JvmOp] = rule {
-        JvmName ~ optWS ~ Signature ~ optional(WS ~ keyword("as") ~ WS ~ Names.Variable) ~> ParsedAst.JvmOp.Method
+        Names.JavaName ~ optWS ~ Signature ~ optional(WS ~ keyword("as") ~ WS ~ Names.Variable) ~> ParsedAst.JvmOp.Method
       }
 
       def StaticMethod: Rule1[ParsedAst.JvmOp] = rule {
@@ -700,11 +692,11 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       }
 
       def GetField: Rule1[ParsedAst.JvmOp] = rule {
-        keyword("get") ~ WS ~ JvmName ~ WS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.GetField
+        keyword("get") ~ WS ~ Names.JavaName ~ WS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.GetField
       }
 
       def PutField: Rule1[ParsedAst.JvmOp] = rule {
-        keyword("set") ~ WS ~ JvmName ~ WS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.PutField
+        keyword("set") ~ WS ~ Names.JavaName ~ WS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.PutField
       }
 
       def GetStaticField: Rule1[ParsedAst.JvmOp] = rule {
@@ -1580,14 +1572,12 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       LowerCaseName | Wildcard | GreekName | MathName
     }
 
-    def JavaName: Rule1[Seq[String]] = {
-      def JavaIdentifier: Rule1[String] = rule {
-        capture(CharPredicate.Alpha ~ zeroOrMore(CharPredicate.AlphaNum))
-      }
+    def JavaIdentifier: Rule1[String] = rule {
+      capture((CharPredicate.Alpha | anyOf("_$")) ~ zeroOrMore(CharPredicate.AlphaNum | anyOf("_$")))
+    }
 
-      rule {
+    def JavaName: Rule1[Seq[String]] = rule {
         oneOrMore(JavaIdentifier).separatedBy(".")
-      }
     }
 
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -74,7 +74,7 @@ object JvmOps {
     case MonoType.Relation(attr) => JvmType.Reference(JvmName.PredSym)
     case MonoType.Native(clazz) =>
       // TODO: Ugly hack.
-      val fqn = clazz.getCanonicalName.replace('.', '/')
+      val fqn = clazz.getName.replace('.', '/')
       JvmType.Reference(JvmName.mk(fqn))
     case MonoType.SchemaEmpty() => JvmType.Reference(JvmName.Runtime.Fixpoint.ConstraintSystem)
     case MonoType.SchemaExtend(_, _, _) => JvmType.Reference(JvmName.Runtime.Fixpoint.ConstraintSystem)

--- a/main/src/flix/test/TestClass.java
+++ b/main/src/flix/test/TestClass.java
@@ -30,4 +30,47 @@ public class TestClass {
     public long             int64Field      = 127;
     public String           stringField     = "Hello World";
 
+    public static class _StaticNestedClass {
+        //
+        // Static Fields in inner class.
+        //
+        public static boolean   BOOL_FIELD = true;
+        public static char      CHAR_FIELD = 'A';
+        public static float     FLOAT32_FIELD = 123.456f;
+        public static double    FLOAT64_FIELD = 123.456;
+        public static byte      INT8_FIELD = 127;
+        public static short     INT16_FIELD = 127;
+        public static int       INT32_FIELD = 127;
+        public static long      INT64_FIELD = 127;
+        public static String    STRING_FIELD = "Hello World";
+
+        //
+        // Instance Fields in inner class.
+        //
+        public boolean          boolField       = true;
+        public char             charField       = 'A';
+        public float            float32Field    = 123.456f;
+        public double           float64Field    = 123.456;
+        public byte             int8Field       = 127;
+        public short            int16Field      = 127;
+        public int              int32Field      = 127;
+        public long             int64Field      = 127;
+        public String           stringField     = "Hello World";
+
+        public static class DoubleNestedClass {
+            //
+            // Instance Fields in inner class.
+            //
+            public boolean          boolField       = true;
+            public char             charField       = 'A';
+            public float            float32Field    = 123.456f;
+            public double           float64Field    = 123.456;
+            public byte             int8Field       = 127;
+            public short            int16Field      = 127;
+            public int              int32Field      = 127;
+            public long             int64Field      = 127;
+            public String           stringField     = "Hello World";
+
+        }
+    }
 }

--- a/main/test/flix/LangSuite.scala
+++ b/main/test/flix/LangSuite.scala
@@ -182,6 +182,9 @@ class LangSuite extends Suites(
   //
   new FlixTest("Test.Exp.Jvm.GetField", "main/test/flix/Test.Exp.Jvm.GetField.flix"),
   new FlixTest("Test.Exp.Jvm.GetStaticField", "main/test/flix/Test.Exp.Jvm.GetStaticField.flix")(Options.TestWithLibAll),
+  new FlixTest("Test.Exp.Jvm.GetFieldStaticInnerClass", "main/test/flix/Test.Exp.Jvm.GetFieldStaticInnerClass.flix"),
+  new FlixTest("Test.Exp.Jvm.GetStaticFieldStaticInnerClass", "main/test/flix/Test.Exp.Jvm.GetStaticFieldStaticInnerClass.flix"),
+  new FlixTest("Test.Exp.Jvm.GetFieldDoubleNestedClass", "main/test/flix/Test.Exp.Jvm.GetFieldDoubleNestedClass.flix"),
   new FlixTest("Test.Exp.Jvm.InvokeConstructor", "main/test/flix/Test.Exp.Jvm.InvokeConstructor.flix"),
   new FlixTest("Test.Exp.Jvm.InvokeMethod", "main/test/flix/Test.Exp.Jvm.InvokeMethod.flix"),
   new FlixTest("Test.Exp.Jvm.InvokeStaticMethod", "main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.flix"),

--- a/main/test/flix/Test.Exp.Jvm.GetFieldDoubleNestedClass.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetFieldDoubleNestedClass.flix
@@ -1,0 +1,66 @@
+namespace Test/Exp/Jvm/GetFieldDoubleNestedClass {
+
+    @test
+    def testGetBoolField01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass$DoubleNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.boolField as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        getField(o) == true
+
+    @test
+    def testGetCharField01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass$DoubleNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.charField as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        getField(o) == 'A'
+
+    @test
+    def testGetFloat32Field01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass$DoubleNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.float32Field as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        getField(o) == 123.456f32
+
+    @test
+    def testGetFloat64Field01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass$DoubleNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.float64Field as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        getField(o) == 123.456f64
+
+    @test
+    def testGetInt8Field01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass$DoubleNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.int8Field as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        getField(o) == 127i8
+
+    @test
+    def testGetInt16Field01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass$DoubleNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.int16Field as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        getField(o) == 127i16
+
+    @test
+    def testGetInt32Field01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass$DoubleNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.int32Field as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        getField(o) == 127i32
+
+    @test
+    def testGetInt64Field01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass$DoubleNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.int64Field as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        getField(o) == 127i64
+
+    @test
+    def testGetStringField01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass$DoubleNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.stringField as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        getField(o) == "Hello World"
+
+}

--- a/main/test/flix/Test.Exp.Jvm.GetFieldStaticInnerClass.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetFieldStaticInnerClass.flix
@@ -1,0 +1,66 @@
+namespace Test/Exp/Jvm/GetFieldStaticInnerClass {
+
+    @test
+    def testGetBoolField01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass.boolField as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass = newObject();
+        getField(o) == true
+
+    @test
+    def testGetCharField01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass.charField as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass = newObject();
+        getField(o) == 'A'
+
+    @test
+    def testGetFloat32Field01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass.float32Field as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass = newObject();
+        getField(o) == 123.456f32
+
+    @test
+    def testGetFloat64Field01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass.float64Field as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass = newObject();
+        getField(o) == 123.456f64
+
+    @test
+    def testGetInt8Field01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass.int8Field as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass = newObject();
+        getField(o) == 127i8
+
+    @test
+    def testGetInt16Field01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass.int16Field as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass = newObject();
+        getField(o) == 127i16
+
+    @test
+    def testGetInt32Field01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass.int32Field as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass = newObject();
+        getField(o) == 127i32
+
+    @test
+    def testGetInt64Field01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass.int64Field as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass = newObject();
+        getField(o) == 127i64
+
+    @test
+    def testGetStringField01(): Bool & Impure =
+        import new flix.test.TestClass$_StaticNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass.stringField as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass = newObject();
+        getField(o) == "Hello World"
+
+}

--- a/main/test/flix/Test.Exp.Jvm.GetStaticFieldStaticInnerClass.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetStaticFieldStaticInnerClass.flix
@@ -1,0 +1,48 @@
+namespace Test/Exp/Jvm/GetStaticFieldStaticInnerClass {
+
+    @test
+    def testGetStaticBoolField01(): Bool & Impure =
+        import get flix.test.TestClass$_StaticNestedClass:BOOL_FIELD as getField;
+        getField() == true
+
+    @test
+    def testGetStaticCharField01(): Bool & Impure =
+        import get flix.test.TestClass$_StaticNestedClass:CHAR_FIELD as getField;
+        getField() == 'A'
+
+    @test
+    def testGetStaticFloat32Field01(): Bool & Impure =
+        import get flix.test.TestClass$_StaticNestedClass:FLOAT32_FIELD as getField;
+        getField() == 123.456f32
+
+    @test
+    def testGetStaticFloat64Field01(): Bool & Impure =
+        import get flix.test.TestClass$_StaticNestedClass:FLOAT64_FIELD as getField;
+        getField() == 123.456f64
+
+    @test
+    def testGetStaticInt8Field01(): Bool & Impure =
+        import get flix.test.TestClass$_StaticNestedClass:INT8_FIELD as getField;
+        getField() == 127i8
+
+    @test
+    def testGetStaticInt16Field01(): Bool & Impure =
+        import get flix.test.TestClass$_StaticNestedClass:INT16_FIELD as getField;
+        getField() == 127i16
+
+    @test
+    def testGetStaticInt32Field01(): Bool & Impure =
+        import get flix.test.TestClass$_StaticNestedClass:INT32_FIELD as getField;
+        getField() == 127i32
+
+    @test
+    def testGetStaticInt64Field01(): Bool & Impure =
+        import get flix.test.TestClass$_StaticNestedClass:INT64_FIELD as getField;
+        getField() == 127i64
+
+    @test
+    def testGetStaticStringField01(): Bool & Impure =
+        import get flix.test.TestClass$_StaticNestedClass:STRING_FIELD as getField;
+        getField() == "Hello World"
+
+}


### PR DESCRIPTION
This is a proposal for handling native static inner classes.
It would allow importing for example the `Map.Entry` class, this way:
```
import java.util.Map$Entry.getKey();
```