### PR TITLE
Add `LazyList.{append, count, drop, flatten}`

### DIFF
--- a/main/src/library/LazyList.flix
+++ b/main/src/library/LazyList.flix
@@ -229,26 +229,15 @@ namespace LazyList {
         case LCons(x, xs) => if (f(x)) filterEAcc(f, force xs, ECons(x, acc)) else filterEAcc(f, force xs, acc)
         case LList(xs)    => filterEAcc(f, force xs, acc)
     }
-    
-    /// Applies `f` to a start value `s` and all elements in `l` going from left to right.
-    ///
-    /// That is, the result is of the form: `f(...f(f(s, x1), x2)..., xn)`.
-    ///
-    pub def foldLeft(f: (b, a) -> b & ef, s: b, l: LazyList[a]): b & ef = match l {
-        case ENil         => s
-        case ECons(x, xs) => foldLeft(f, f(s, x),       xs)
-        case LCons(x, xs) => foldLeft(f, f(s, x), force xs)
-        case LList(xs)    => foldLeft(f, s,       force xs)
-    }
 
     ///
     /// Returns `k` appended to `l`.
     ///
-    pub def append(l: LazyList[a], k: LazyList[a]): LazyList[a] = match l {
-        case ENil         => k
-        case ECons(x, xs) => LCons(x, lazy append(      xs, k))
-        case LCons(x, xs) => LCons(x, lazy append(force xs, k))
-        case LList(xs)    => LList(   lazy append(force xs, k))
+    pub def append(l1: LazyList[a], l2: LazyList[a]): LazyList[a] = match l1 {
+        case ENil         => l2
+        case ECons(x, xs) => LCons(x, lazy append(      xs, l2))
+        case LCons(x, xs) => LCons(x, lazy append(force xs, l2))
+        case LList(xs)    => LList(   lazy append(force xs, l2))
     }
 
     /// Applies `f` to a start value `s` and all elements in `l` going from left to right.

--- a/main/src/library/LazyList.flix
+++ b/main/src/library/LazyList.flix
@@ -365,4 +365,14 @@ namespace LazyList {
                 case LCons(_, xs) => LList(lazy drop(n - 1, force xs))
                 case LList(xs)    => LList(lazy drop(n,     force xs))
             }
+
+    ///
+    /// Returns the concatenation of the elements in `l`.
+    ///
+    pub def flatten(l: LazyList[LazyList[a]]): LazyList[a] = match l {
+        case ENil          => ENil
+        case ECons(xs, ys) => append(xs, flatten(      ys))
+        case LCons(xs, ys) => append(xs, flatten(force ys))
+        case LList(xs)     => flatten(force xs)
+    }
 }

--- a/main/src/library/LazyList.flix
+++ b/main/src/library/LazyList.flix
@@ -228,6 +228,18 @@ namespace LazyList {
         case ECons(x, xs) => if (f(x)) filterEAcc(f, xs, ECons(x, acc))       else filterEAcc(f, xs, acc)
         case LCons(x, xs) => if (f(x)) filterEAcc(f, force xs, ECons(x, acc)) else filterEAcc(f, force xs, acc)
         case LList(xs)    => filterEAcc(f, force xs, acc)
+    /// Applies `f` to a start value `s` and all elements in `l` going from left to right.
+    ///
+    /// That is, the result is of the form: `f(...f(f(s, x1), x2)..., xn)`.
+    ///
+    pub def foldLeft(f: (b, a) -> b & ef, s: b, l: LazyList[a]): b & ef = match l {
+        case ENil         => s
+        case ECons(x, xs) => foldLeft(f, f(s, x),       xs)
+        case LCons(x, xs) => foldLeft(f, f(s, x), force xs)
+        case LList(xs)    => foldLeft(f, s,       force xs)
+    }
+
+    ///
     /// Returns `k` appended to `l`.
     ///
     pub def append(l: LazyList[a], k: LazyList[a]): LazyList[a] = match l {
@@ -329,4 +341,11 @@ namespace LazyList {
         case LCons(x, xs) => toSetAcc(force xs, Set.insert(x, acc))
         case LList(xs)    => toSetAcc(force xs, acc)
     }
+    ///
+    /// Returns the number of elements in `l` that satisfy the predicate `f`.
+    ///
+    /// The function `f` must be pure.
+    ///
+    pub def count(f: a -> Bool, l: LazyList[a]): Int32 =
+        foldLeft((i, x) -> if (f(x)) i + 1 else i, 0, l)
 }

--- a/main/src/library/LazyList.flix
+++ b/main/src/library/LazyList.flix
@@ -228,6 +228,8 @@ namespace LazyList {
         case ECons(x, xs) => if (f(x)) filterEAcc(f, xs, ECons(x, acc))       else filterEAcc(f, xs, acc)
         case LCons(x, xs) => if (f(x)) filterEAcc(f, force xs, ECons(x, acc)) else filterEAcc(f, force xs, acc)
         case LList(xs)    => filterEAcc(f, force xs, acc)
+    }
+    
     /// Applies `f` to a start value `s` and all elements in `l` going from left to right.
     ///
     /// That is, the result is of the form: `f(...f(f(s, x1), x2)..., xn)`.

--- a/main/src/library/LazyList.flix
+++ b/main/src/library/LazyList.flix
@@ -228,6 +228,13 @@ namespace LazyList {
         case ECons(x, xs) => if (f(x)) filterEAcc(f, xs, ECons(x, acc))       else filterEAcc(f, xs, acc)
         case LCons(x, xs) => if (f(x)) filterEAcc(f, force xs, ECons(x, acc)) else filterEAcc(f, force xs, acc)
         case LList(xs)    => filterEAcc(f, force xs, acc)
+    /// Returns `k` appended to `l`.
+    ///
+    pub def append(l: LazyList[a], k: LazyList[a]): LazyList[a] = match l {
+        case ENil         => k
+        case ECons(x, xs) => LCons(x, lazy append(      xs, k))
+        case LCons(x, xs) => LCons(x, lazy append(force xs, k))
+        case LList(xs)    => LList(   lazy append(force xs, k))
     }
 
     /// Applies `f` to a start value `s` and all elements in `l` going from left to right.

--- a/main/src/library/LazyList.flix
+++ b/main/src/library/LazyList.flix
@@ -348,4 +348,21 @@ namespace LazyList {
     ///
     pub def count(f: a -> Bool, l: LazyList[a]): Int32 =
         foldLeft((i, x) -> if (f(x)) i + 1 else i, 0, l)
+
+    ///
+    /// Returns `l` without the first `n` elements.
+    ///
+    /// Returns `ENil` if `n > length(l)`.
+    /// Returns `l` if `n < 1`.
+    ///
+    pub def drop(n: Int32, l: LazyList[a]): LazyList[a] =
+        if (n < 1)
+            l
+        else
+            match l {
+                case ENil         => l
+                case ECons(_, xs) => LList(lazy drop(n - 1,       xs))
+                case LCons(_, xs) => LList(lazy drop(n - 1, force xs))
+                case LList(xs)    => LList(lazy drop(n,     force xs))
+            }
 }

--- a/main/src/library/LazyList.flix
+++ b/main/src/library/LazyList.flix
@@ -136,9 +136,9 @@ namespace LazyList {
     ///
     def reverseAcc(l: LazyList[a], acc: LazyList[a]): LazyList[a] = match l {
         case ENil         => acc
-        case ECons(x, xs) => reverseAcc(xs, ECons(x, acc))
-        case LCons(x, xs) => reverseAcc(force xs, ECons(x, acc))
-        case LList(xs)    => reverseAcc(force xs, acc)
+        case ECons(x, xs) => LList(lazy reverseAcc(xs, ECons(x, acc)))
+        case LCons(x, xs) => LList(lazy reverseAcc(force xs, ECons(x, acc)))
+        case LList(xs)    => LList(lazy reverseAcc(force xs, acc))
     }
 
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestLazyList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestLazyList.flix
@@ -1021,4 +1021,97 @@ namespace TestLazyList {
     @test
     def drop15(): Bool =
     	LazyList.range(0, 1000) |> LazyList.drop(500) == LazyList.range(500, 1000)
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // flatten                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def flatten01(): Bool =
+        LazyList.flatten(ENil: LazyList[LazyList[Unit]]) == ENil
+
+    @test
+    def flatten02(): Bool =
+        LazyList.flatten(LList(lazy ENil): LazyList[LazyList[Unit]]) == ENil
+
+    @test
+    def flatten03(): Bool =
+        LazyList.flatten(ECons(ENil, ENil)): LazyList[Unit] == ENil
+
+    @test
+    def flatten04(): Bool =
+        LazyList.flatten(ECons(LList(lazy ENil), ENil)): LazyList[Unit] == ENil
+
+    @test
+    def flatten05(): Bool =
+        LazyList.flatten(LList(lazy ECons(ENil, ENil))): LazyList[Unit] == ENil
+
+    @test
+    def flatten06(): Bool =
+        LazyList.flatten(ECons(ENil, LList(lazy ENil))): LazyList[Unit] == ENil
+
+    @test
+    def flatten07(): Bool =
+        LazyList.flatten(ECons(ENil, ECons(ENil, ENil))): LazyList[Unit] == ENil
+
+    @test
+    def flatten08(): Bool =
+    	LazyList.flatten(ECons(LCons(1, lazy ENil), ENil)) == ECons(1, ENil)
+
+    @test
+    def flatten09(): Bool =
+    	LazyList.flatten(ECons(LList(lazy ECons(1, LList(lazy ENil))), ENil)) == ECons(1, ENil)
+
+    @test
+    def flatten10(): Bool =
+    	LazyList.flatten(ECons(ECons(1, LList(lazy ENil)), ENil)) == ECons(1, ENil)
+
+    @test
+    def flatten11(): Bool =
+    	LazyList.flatten(ECons(LCons(1, lazy LList(lazy ENil)), ENil)) == ECons(1, ENil)
+
+    @test
+    def flatten12(): Bool =
+        LazyList.flatten(ECons((ECons(1, ECons(2, ENil))), ENil)) == ECons(1, ECons(2, ENil))
+
+    @test
+    def flatten13(): Bool =
+    	LazyList.flatten(ECons(LList(lazy LCons(1, lazy LList(lazy LCons(2, lazy ENil)))), ENil)) == ECons(1, ECons(2, ENil))
+
+    @test
+    def flatten14(): Bool =
+    	LazyList.flatten(ECons(ENil, ECons(ECons(1, ECons(2, ENil)), ENil))) == ECons(1, ECons(2, ENil))
+
+    @test
+    def flatten15(): Bool =
+    	LazyList.flatten(ECons(ENil, ECons(LList(lazy LCons(1, lazy LList(lazy LCons(2, lazy ENil)))), ENil))) == ECons(1, ECons(2, ENil))
+
+    @test
+    def flatten16(): Bool =
+    	LazyList.flatten(ECons(ENil, ECons(LList(lazy LCons(1, lazy ECons(2, LList(lazy ENil)))), ENil))) == ECons(1, ECons(2, ENil))
+
+    @test
+    def flatten17(): Bool =
+    	LazyList.flatten(ECons(LList(lazy LCons(1, lazy LList(lazy LCons(2, lazy ENil)))), ECons((ECons(1, ECons(2, ENil))), ENil))) == ECons(1, ECons(2, ECons(1, ECons(2, ENil))))
+
+    @test
+    def flatten18(): Bool =
+    	LazyList.flatten(ECons(LList(lazy LCons(1, lazy ECons(2, LList(lazy ENil)))), ECons((ECons(1, ECons(2, ENil))), ENil))) == ECons(1, ECons(2, ECons(1, ECons(2, ENil))))
+
+    @test
+    def flatten19(): Bool =
+    	LazyList.flatten(ECons((ECons(1, ECons(2, ENil))), ECons(LList(lazy LCons(1, lazy LCons(2, lazy ENil))), ENil))) == ECons(1, ECons(2, ECons(1, ECons(2, ENil))))
+
+    @test
+    def flatten20(): Bool =
+    	LazyList.flatten(ECons(ECons(1, LCons(2, lazy ENil)), ECons((ECons(1, ECons(2, ENil))), ENil))) == ECons(1, ECons(2, ECons(1, ECons(2, ENil))))
+
+    @test
+    def flatten21(): Bool =
+    	LazyList.flatten(ECons((ECons(1, ECons(2, ENil))), ECons(ENil, ECons(ENil, ECons(LList(lazy LCons(3, lazy LCons(4, lazy ENil))), ENil))))) == ECons(1, ECons(2, ECons(3, ECons(4, ENil))))
+
+    @test
+    def flatten22(): Bool =
+    	LazyList.flatten(ECons(ECons(1, LCons(2, lazy ENil)), ECons(ENil, ECons(ENil, ECons((ECons(3, ECons(4, ENil))), ENil))))) == ECons(1, ECons(2, ECons(3, ECons(4, ENil))))
 }

--- a/main/test/ca/uwaterloo/flix/library/TestLazyList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestLazyList.flix
@@ -907,4 +907,53 @@ namespace TestLazyList {
     @test
     def append16(): Bool =
     	LazyList.append(ECons(4, ENil), LCons(1, lazy ECons(2, LCons(3, lazy LList(lazy ENil))))) == ECons(4, ECons(1, ECons(2, ECons(3, ENil))))
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // count                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def count01(): Bool =
+        LazyList.count(x -> x > 3, ENil) == 0
+
+    @test
+    def count02(): Bool =
+        LazyList.count(x -> x > 3, LList(lazy ENil)) == 0
+
+    @test
+    def count03(): Bool =
+    	LazyList.count(x -> x > 3, LList(lazy LCons(1, lazy LList(lazy LCons(1, lazy LList(lazy LCons(1, lazy ENil))))))) == 0
+
+    @test
+    def count04(): Bool =
+    	LazyList.count(x -> x > 3, LCons(1, lazy LCons(1, lazy LCons(1, lazy ENil)))) == 0
+
+    @test
+    def count05(): Bool =
+    	LazyList.count(x -> x > 3, ECons(4, ENil)) == 1
+
+    @test
+    def count06(): Bool =
+    	LazyList.count(x -> x > 3, LList(lazy LCons(4, lazy ENil))) == 1
+
+    @test
+    def count07(): Bool =
+        LazyList.count(_ -> true, LazyList.range(1000, 2000)) == 1000
+
+    @test
+    def count08(): Bool =
+        LazyList.count(_ -> false, LazyList.range(1000, 2000)) == 0
+
+    @test
+    def count09(): Bool =
+        LazyList.count(x -> x > 3, ECons(1, ECons(2, ENil))) == 0
+
+    @test
+    def count10(): Bool =
+        LazyList.count(x -> x > 3, ECons(1, ECons(8, ENil))) == 1
+
+    @test
+    def count11(): Bool =
+        LazyList.count(x -> x > 3, ECons(8, ECons(1, ENil))) == 1
 }

--- a/main/test/ca/uwaterloo/flix/library/TestLazyList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestLazyList.flix
@@ -841,4 +841,70 @@ namespace TestLazyList {
     @test
     def toSet10(): Bool =
     	LazyList.toSet(ECons(1, LCons(2, lazy ECons(3, ENil)))) == Set#{1, 2, 3}
+    // append                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def append01(): Bool =
+    	LazyList.append(ENil: LazyList[Unit], ENil: LazyList[Unit]) == ENil
+
+    @test
+    def append02(): Bool =
+    	LazyList.append(LList(lazy ENil): LazyList[Unit], ENil: LazyList[Unit]) == ENil
+
+    @test
+    def append03(): Bool =
+    	LazyList.append(ENil, LList(lazy ENil): LazyList[Unit]) == ENil
+
+    @test
+    def append04(): Bool =
+    	LazyList.append(LList(lazy ENil), LList(lazy ENil): LazyList[Unit]) == ENil
+
+    @test
+    def append05(): Bool =
+    	LazyList.append(LCons(1, lazy ENil), LList(lazy ENil)) == ECons(1, ENil)
+
+    @test
+    def append06(): Bool =
+    	LazyList.append(LList(lazy ECons(1, LList(lazy ENil))), LList(lazy ENil)) == ECons(1, ENil)
+
+    @test
+    def append07(): Bool =
+    	LazyList.append(ECons(1, LList(lazy ENil)), LList(lazy ENil)) == ECons(1, ENil)
+
+    @test
+    def append08(): Bool =
+    	LazyList.append(LCons(1, lazy ENil), ENil) == ECons(1, ENil)
+
+    @test
+    def append09(): Bool =
+    	LazyList.append(ENil, LCons(1, lazy ENil)) == ECons(1, ENil)
+
+    @test
+    def append10(): Bool =
+    	LazyList.append(ENil, LList(lazy ECons(1, LList(lazy ENil)))) == ECons(1, ENil)
+
+    @test
+    def append11(): Bool =
+    	LazyList.append(LList(lazy ENil), ECons(1, LList(lazy ENil))) == ECons(1, ENil)
+
+    @test
+    def append12(): Bool =
+    	LazyList.append(LList(lazy ENil), LCons(1, lazy LList(lazy ENil))) == ECons(1, ENil)
+
+    @test
+    def append13(): Bool =
+    	LazyList.append(ECons(1, ECons(2, ECons(3, ENil))), ECons(4, LList(lazy ENil))) == ECons(1, ECons(2, ECons(3, ECons(4, ENil))))
+
+    @test
+    def append14(): Bool =
+    	LazyList.append(ECons(1, ECons(2, ECons(3, ENil))), LCons(4, lazy LList(lazy ENil))) == ECons(1, ECons(2, ECons(3, ECons(4, ENil))))
+
+    @test
+    def append15(): Bool =
+    	LazyList.append(ECons(4, ENil), ECons(1, LCons(2, lazy LList(lazy LCons(3, lazy ENil))))) == ECons(4, ECons(1, ECons(2, ECons(3, ENil))))
+
+    @test
+    def append16(): Bool =
+    	LazyList.append(ECons(4, ENil), LCons(1, lazy ECons(2, LCons(3, lazy LList(lazy ENil))))) == ECons(4, ECons(1, ECons(2, ECons(3, ENil))))
 }

--- a/main/test/ca/uwaterloo/flix/library/TestLazyList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestLazyList.flix
@@ -956,4 +956,69 @@ namespace TestLazyList {
     @test
     def count11(): Bool =
         LazyList.count(x -> x > 3, ECons(8, ECons(1, ENil))) == 1
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // drop                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def drop01(): Bool =
+        LazyList.drop(-1, ENil: LazyList[Unit]) == ENil
+
+    @test
+    def drop02(): Bool =
+        LazyList.drop(0, ENil: LazyList[Unit]) == ENil
+
+    @test
+    def drop03(): Bool =
+        LazyList.drop(-1, LList(lazy ENil): LazyList[Unit]) == ENil
+
+    @test
+    def drop04(): Bool =
+        LazyList.drop(0, LList(lazy ENil): LazyList[Unit]) == ENil
+
+    @test
+    def drop05(): Bool =
+        LazyList.drop(1, ENil: LazyList[Unit]) == ENil
+
+    @test
+    def drop06(): Bool =
+        LazyList.drop(1, LList(lazy ENil): LazyList[Unit]) == ENil
+
+    @test
+    def drop07(): Bool =
+        LazyList.drop(-1, ECons(1, ENil)) == ECons(1, ENil)
+
+    @test
+    def drop08(): Bool =
+        LazyList.drop(0, ECons(1, ENil)) == ECons(1, ENil)
+
+    @test
+    def drop09(): Bool =
+        LazyList.drop(1, ECons(1, ENil)) == ENil
+
+    @test
+    def drop10(): Bool =
+    	LazyList.drop(1, LCons(1, lazy ENil)) == ENil
+
+    @test
+    def drop11(): Bool =
+    	LazyList.drop(1, LList(lazy ECons(1, LList(lazy ENil)))) == ENil
+
+    @test
+    def drop12(): Bool =
+        LazyList.drop(2, ECons(1, ENil)) == ENil
+
+    @test
+    def drop13(): Bool =
+    	LazyList.drop(2, LCons(1, lazy ENil)) == ENil
+
+    @test
+    def drop14(): Bool =
+    	LazyList.drop(2, LList(lazy ECons(1, LList(lazy ENil)))) == ENil
+
+    @test
+    def drop15(): Bool =
+    	LazyList.range(0, 1000) |> LazyList.drop(500) == LazyList.range(500, 1000)
 }


### PR DESCRIPTION
Resolves #2033 

- [x] Refactor `LazyList.reverse` to be even lazier
- [x] Add `LazyList.append`
- [x] Add `LazyList.count`
- [x] Add `LazyList.drop`
- [x] Add `LazyList.flatten`

Note that `foldLeft` and `Eq` have been implemented here, but are also implemented in #2141 and #2109 respectively.