### PR TITLE
Add `with` syntax to enum declarations

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -46,7 +46,7 @@ object NamedAst {
 
   case class Spec(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, tparams: NamedAst.TypeParams, fparams: List[NamedAst.FormalParam], sc: NamedAst.Scheme, retTpe: NamedAst.Type, eff: NamedAst.Type, loc: SourceLocation)
 
-  case class Enum(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.EnumSym, tparams: NamedAst.TypeParams, cases: Map[Name.Tag, NamedAst.Case], tpe: NamedAst.Type, loc: SourceLocation)
+  case class Enum(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.EnumSym, tparams: NamedAst.TypeParams, derives: List[Name.QName], cases: Map[Name.Tag, NamedAst.Case], tpe: NamedAst.Type, loc: SourceLocation)
 
   case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.TypeAliasSym, tparams: NamedAst.TypeParams, tpe: NamedAst.Type, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -119,10 +119,11 @@ object ParsedAst {
       * @param sp1     the position of the first character in the declaration.
       * @param ident   the name of the enum.
       * @param tparams the type parameters.
+      * @param derives the derivations of the enum.
       * @param cases   the cases of the enum.
       * @param sp2     the position of the last character in the declaration.
       */
-    case class Enum(doc: ParsedAst.Doc, mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, cases: Seq[ParsedAst.Case], sp2: SourcePosition) extends ParsedAst.Declaration
+    case class Enum(doc: ParsedAst.Doc, mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, derives: Seq[Name.QName], cases: Seq[ParsedAst.Case], sp2: SourcePosition) extends ParsedAst.Declaration
 
     /**
       * Opaque Type Declaration.

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -42,7 +42,7 @@ object ResolvedAst {
 
   case class Spec(doc: Ast.Doc, ann: List[ResolvedAst.Annotation], mod: Ast.Modifiers, tparams: ResolvedAst.TypeParams, fparams: List[ResolvedAst.FormalParam], sc: ResolvedAst.Scheme, tpe: UnkindedType, eff: UnkindedType, loc: SourceLocation)
 
-  case class Enum(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.EnumSym, tparams: ResolvedAst.TypeParams, cases: Map[Name.Tag, ResolvedAst.Case], tpeDeprecated: UnkindedType, sc: ResolvedAst.Scheme, loc: SourceLocation)
+  case class Enum(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.EnumSym, tparams: ResolvedAst.TypeParams, derives: List[Symbol.ClassSym], cases: Map[Name.Tag, ResolvedAst.Case], tpeDeprecated: UnkindedType, sc: ResolvedAst.Scheme, loc: SourceLocation)
 
   case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.TypeAliasSym, tparams: ResolvedAst.TypeParams, tpe: UnkindedType, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -45,7 +45,7 @@ object WeededAst {
 
     case class Law(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: WeededAst.Expression, tpe: WeededAst.Type, retTpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation) extends WeededAst.Declaration
 
-    case class Enum(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.TypeParams, cases: Map[Name.Tag, WeededAst.Case], loc: SourceLocation) extends WeededAst.Declaration
+    case class Enum(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.TypeParams, derives: List[Name.QName], cases: Map[Name.Tag, WeededAst.Case], loc: SourceLocation) extends WeededAst.Declaration
 
     case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.TypeParams, tpe: WeededAst.Type, loc: SourceLocation) extends WeededAst.Declaration
 

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -495,6 +495,19 @@ object ResolutionError {
     }
   }
 
+  // MATT docs
+  case class DuplicateDerivation(sym: Symbol.ClassSym, loc1: SourceLocation, loc2: SourceLocation) extends ResolutionError {
+    override def summary: String = "" // MATT
+    override def message: VirtualTerminal = new VirtualTerminal() // MATT
+    override def loc: SourceLocation = SourceLocation.Unknown // MATT
+  }
+
+  // MATT docs
+  case class IllegalDerivation(sym: Symbol.ClassSym, loc: SourceLocation) extends ResolutionError {
+    override def summary: String = "" // MATT
+    override def message: VirtualTerminal = new VirtualTerminal() // MATT
+  }
+
   /**
     * Removes all access modifiers from the given string `s`.
     */

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -495,17 +495,50 @@ object ResolutionError {
     }
   }
 
-  // MATT docs
+  /**
+    * An error raised to indicate a duplicate derivation.
+    *
+    * @param sym  the class symbol of the duplicate derivation.
+    * @param loc1 the location of the first occurrence.
+    * @param loc2 the location of the second occurrence.
+    */
   case class DuplicateDerivation(sym: Symbol.ClassSym, loc1: SourceLocation, loc2: SourceLocation) extends ResolutionError {
-    override def summary: String = "" // MATT
-    override def message: VirtualTerminal = new VirtualTerminal() // MATT
-    override def loc: SourceLocation = SourceLocation.Unknown // MATT
+    override def summary: String = s"Duplicate derivation: ${sym.name}"
+
+    override def message: VirtualTerminal = {
+      val vt = new VirtualTerminal
+      vt << Line(kind, source.format) << NewLine
+      vt << ">> Duplicate derivation '" << Red(sym.name) << "'." << NewLine
+      vt << NewLine
+      vt << Code(loc1, "the first occurrence was here.") << NewLine
+      vt << NewLine
+      vt << Code(loc2, "the second occurrence was here.") << NewLine
+      vt << NewLine
+      vt << Underline("Tip:") << " Remove one of the occurrences." << NewLine
+    }
+
+    override def loc: SourceLocation = loc1
   }
 
-  // MATT docs
-  case class IllegalDerivation(sym: Symbol.ClassSym, loc: SourceLocation) extends ResolutionError {
-    override def summary: String = "" // MATT
-    override def message: VirtualTerminal = new VirtualTerminal() // MATT
+  /**
+    * An error raised to indicate an illegal derivation.
+    *
+    * @param sym       the class symbol of the illegal derivation.
+    * @param legalSyms the list of class symbols of legal derivations.
+    * @param loc       the location where the error occurred.
+    */
+  case class IllegalDerivation(sym: Symbol.ClassSym, legalSyms: List[Symbol.ClassSym], loc: SourceLocation) extends ResolutionError {
+    override def summary: String = s"Illegal derivation: ${sym.name}"
+
+    override def message: VirtualTerminal = {
+      val vt = new VirtualTerminal
+      vt << Line(kind, source.format) << NewLine
+      vt << ">> Illegal derivation '" << Red(sym.name) << "'." << NewLine
+      vt << NewLine
+      vt << Code(loc, "Illegal derivation.")
+      vt << NewLine
+      vt << Underline("Tip:") << s" Only the following classes may be derived: ${legalSyms.map(_.name).mkString(", ")}."
+    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -93,7 +93,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     * Performs kinding on the given enum.
     */
   private def visitEnum(enum: ResolvedAst.Enum, root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Enum, CompilationError] = enum match {
-    case ResolvedAst.Enum(doc, mod, sym, tparams0, cases0, tpeDeprecated0, sc0, loc) =>
+    case ResolvedAst.Enum(doc, mod, sym, tparams0, derives, cases0, tpeDeprecated0, sc0, loc) =>
       val kenv = getKindEnvFromTypeParamsDefaultStar(tparams0)
 
       val tparamsVal = Validation.traverse(tparams0.tparams)(visitTypeParam(_, kenv))
@@ -1038,7 +1038,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     * Gets the kind of the enum.
     */
   private def getEnumKind(enum: ResolvedAst.Enum)(implicit flix: Flix): Kind = enum match {
-    case ResolvedAst.Enum(_, _, _, tparams, _, _, _, _) =>
+    case ResolvedAst.Enum(_, _, _, tparams, _, _, _, _, _) =>
       val kenv = getKindEnvFromTypeParamsDefaultStar(tparams)
       tparams.tparams.foldRight(Kind.Star: Kind) {
         case (tparam, acc) => kenv.map(tparam.tpe) ->: acc

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -164,7 +164,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
       /*
      * Enum.
      */
-      case WeededAst.Declaration.Enum(doc, mod, ident, tparams0, cases, loc) =>
+      case WeededAst.Declaration.Enum(doc, mod, ident, tparams0, derives, cases, loc) =>
         val enums0 = prog0.enums.getOrElse(ns0, Map.empty)
         lookupTypeOrClass(ident, ns0, prog0) match {
           case LookupResult.NotDefined =>
@@ -187,7 +187,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
 
             mapN(casesOf(cases, uenv0, tenv)) {
               case cases =>
-                val enum = NamedAst.Enum(doc, mod, sym, tparams, cases, enumType, loc)
+                val enum = NamedAst.Enum(doc, mod, sym, tparams, derives, cases, enumType, loc)
                 val enums = enums0 + (ident.name -> enum)
                 prog0.copy(enums = prog0.enums + (ns0 -> enums))
             }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -189,11 +189,11 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       }
 
       def Derivations = rule {
-        keyword("with") ~ oneOrMore(Names.Class).separatedBy( optWS ~ "," ~ optWS)
+        optWS ~ optional(keyword("with") ~ oneOrMore(Names.Class).separatedBy(optWS ~ "," ~ optWS)) ~> ((o: Option[Seq[Name.Ident]]) => o.getOrElse(Seq.empty))
       }
 
       rule {
-        Documentation ~ Modifiers ~ SP ~ keyword("enum") ~ WS ~ Names.Type ~ TypeParams ~ optWS ~ Body ~ SP ~> ParsedAst.Declaration.Enum
+        Documentation ~ Modifiers ~ SP ~ keyword("enum") ~ WS ~ Names.Type ~ TypeParams ~ Derivations ~ optWS ~ Body ~ SP ~> ParsedAst.Declaration.Enum
       }
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -189,7 +189,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       }
 
       def Derivations = rule {
-        optWS ~ optional(keyword("with") ~ oneOrMore(Names.Class).separatedBy(optWS ~ "," ~ optWS)) ~> ((o: Option[Seq[Name.Ident]]) => o.getOrElse(Seq.empty))
+        optWS ~ optional(keyword("with") ~ oneOrMore(Names.QualifiedClass).separatedBy(optWS ~ "," ~ optWS)) ~> ((o: Option[Seq[Name.QName]]) => o.getOrElse(Seq.empty))
       }
 
       rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -189,7 +189,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       }
 
       def Derivations = rule {
-        optWS ~ optional(keyword("with") ~ oneOrMore(Names.QualifiedClass).separatedBy(optWS ~ "," ~ optWS)) ~> ((o: Option[Seq[Name.QName]]) => o.getOrElse(Seq.empty))
+        optWS ~ optional(keyword("with") ~ WS ~ oneOrMore(Names.QualifiedClass).separatedBy(optWS ~ "," ~ optWS)) ~> ((o: Option[Seq[Name.QName]]) => o.getOrElse(Seq.empty))
       }
 
       rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -188,6 +188,10 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
         NonEmptyBody | EmptyBody
       }
 
+      def Derivations = rule {
+        keyword("with") ~ oneOrMore(Names.Class).separatedBy( optWS ~ "," ~ optWS)
+      }
+
       rule {
         Documentation ~ Modifiers ~ SP ~ keyword("enum") ~ WS ~ Names.Type ~ TypeParams ~ optWS ~ Body ~ SP ~> ParsedAst.Declaration.Enum
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1116,7 +1116,9 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
       }
   }
 
-  // MATT docs
+  /**
+    * Performs name resolution on the given list of derivations `derives0`.
+    */
   def resolveDerivations(derives0: List[Name.QName], ns0: Name.NName, root: NamedAst.Root): Validation[List[Symbol.ClassSym], ResolutionError] = {
     val derivesVal = Validation.traverse(derives0)(resolveDerivation(_, ns0, root))
     flatMapN(derivesVal) {
@@ -1133,15 +1135,19 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
     }
   }
 
-  // MATT docs
-  def resolveDerivation(derive: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[Symbol.ClassSym, ResolutionError] = {
+  /**
+    * Performs name resolution on the given of derivation `derive0`.
+    */
+  def resolveDerivation(derive0: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[Symbol.ClassSym, ResolutionError] = {
     for {
-      clazz <- lookupClass(derive, ns0, root)
-      _ <- checkDerivable(clazz.sym, derive.loc)
+      clazz <- lookupClass(derive0, ns0, root)
+      _ <- checkDerivable(clazz.sym, derive0.loc)
     } yield clazz.sym
   }
 
-  // MATT docs
+  /**
+    * Checks that the given class `sym` is derivable.
+    */
   def checkDerivable(sym: Symbol.ClassSym, loc: SourceLocation): Validation[Unit, ResolutionError] = {
     val eqSym = new Symbol.ClassSym(Nil, "Eq", SourceLocation.Unknown)
     val orderSym = new Symbol.ClassSym(Nil, "Order", SourceLocation.Unknown)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1152,10 +1152,11 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
     val eqSym = new Symbol.ClassSym(Nil, "Eq", SourceLocation.Unknown)
     val orderSym = new Symbol.ClassSym(Nil, "Order", SourceLocation.Unknown)
     val toStringSym = new Symbol.ClassSym(Nil, "ToString", SourceLocation.Unknown)
-    if (Set(eqSym, orderSym, toStringSym).contains(sym)) {
+    val legalSyms = List(eqSym, orderSym, toStringSym)
+    if (legalSyms.contains(sym)) {
       ().toSuccess
     } else {
-      ResolutionError.IllegalDerivation(sym, loc).toFailure
+      ResolutionError.IllegalDerivation(sym, legalSyms, loc).toFailure
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1131,7 +1131,6 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
           case Some((sym, loc1, loc2)) => ResolutionError.DuplicateDerivation(sym, loc1, loc2).toFailure
           case None => derives.toSuccess
         }
-
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -217,7 +217,7 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
     * Performs weeding on the given enum declaration `d0`.
     */
   private def visitEnum(d0: ParsedAst.Declaration.Enum)(implicit flix: Flix): Validation[List[WeededAst.Declaration.Enum], WeederError] = d0 match {
-    case ParsedAst.Declaration.Enum(doc0, mods, sp1, ident, tparams0, cases, sp2) =>
+    case ParsedAst.Declaration.Enum(doc0, mods, sp1, ident, tparams0, derives, cases, sp2) =>
       val doc = visitDoc(doc0)
       val modVal = visitModifiers(mods, legalModifiers = Set(Ast.Modifier.Public))
       val tparamsVal = visitTypeParams(tparams0)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -243,7 +243,7 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
                   ))
               }
           } map {
-            case m => List(WeededAst.Declaration.Enum(doc, mod, ident, tparams, m, mkSL(sp1, sp2)))
+            case m => List(WeededAst.Declaration.Enum(doc, mod, ident, tparams, derives.toList, m, mkSL(sp1, sp2)))
           }
       }
   }
@@ -263,7 +263,7 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
       mapN(modVal, tparamsVal) {
         case (mod, tparams) =>
           val cases = Map(Name.mkTag(ident) -> WeededAst.Case(ident, Name.mkTag(ident), visitType(tpe0)))
-          List(WeededAst.Declaration.Enum(doc, mod, ident, tparams, cases, mkSL(sp1, sp2)))
+          List(WeededAst.Declaration.Enum(doc, mod, ident, tparams, Nil, cases, mkSL(sp1, sp2)))
       }
   }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -793,4 +793,33 @@ class TestResolver extends FunSuite with TestUtils {
     val result = compile(input, DefaultOptions)
     expectError[ResolutionError.CyclicClassHierarchy](result)
   }
+
+  test("DuplicateDerivation.01") {
+    val input =
+      """
+        |enum E with Eq, Eq
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[ResolutionError.DuplicateDerivation](result)
+  }
+
+  test("DuplicateDerivation.02") {
+    val input =
+      """
+        |enum E with ToString, Order, ToString
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[ResolutionError.DuplicateDerivation](result)
+  }
+
+  test("IllegalDerivation.01") {
+    val input =
+      """
+        |class C[a]
+        |
+        |enum E with C
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[ResolutionError.IllegalDerivation](result)
+  }
 }

--- a/main/test/flix/LangSuite.scala
+++ b/main/test/flix/LangSuite.scala
@@ -25,6 +25,11 @@ class LangSuite extends Suites(
   new FlixTest("Test.Def.Scoped", "main/test/flix/Test.Def.Scoped.flix"),
 
   //
+  // Derivations.
+  //
+  new FlixTest("Test.Derivation", "main/test/flix/Test.Derivation.flix"),
+
+  //
   // Effects.
   //
   new FlixTest("Test.Eff.Advanced", "main/test/flix/Test.Eff.Advanced.flix"),

--- a/main/test/flix/Test.Derivation.flix
+++ b/main/test/flix/Test.Derivation.flix
@@ -1,0 +1,9 @@
+namespace Test/Derivation {
+    pub enum E[a] with Eq {
+        case C1
+        case C2(a)
+    }
+
+    @test
+    def empty(): Bool = true
+}

--- a/main/test/flix/Test.Derivation.flix
+++ b/main/test/flix/Test.Derivation.flix
@@ -1,8 +1,12 @@
 namespace Test/Derivation {
-    pub enum E[a] with Eq {
+    pub enum E1[a] with Eq {
         case C1
         case C2(a)
     }
+
+    pub enum E2 with Eq, ToString
+
+    pub enum E3 with Eq, Order, ToString
 
     @test
     def empty(): Bool = true


### PR DESCRIPTION
Fixes https://github.com/flix/flix/issues/2155

### Features
* Can add `with ...` to enums.
  * [x] impl
  * [x] test
* A type class name is never repeated.
  * [x] impl
  * [x] test
* Every type class name is one of `Eq`, `Order`, and `ToString`.
  * [x] impl
  * [x] test

### General requirements
* [x] Don't make a complete mess
* [x] Don't break anything else
* [x] Provide documentation
* [x] Add license to new files
* [x] Manually check new error formatting
* [x] Manually check diff
