### PR TITLE
[Backend] [Concurrency] Add `GlobalCounter.java`

### DIFF
--- a/main/src/library/Channel/GlobalCounter.java
+++ b/main/src/library/Channel/GlobalCounter.java
@@ -1,0 +1,10 @@
+package library.Channel;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class GlobalCounter {
+    private static final AtomicLong globalCounter = new AtomicLong();
+
+    public static long newId() {
+        return globalCounter.getAndIncrement();
+    }
+}


### PR DESCRIPTION
This PR is breaking down the "Reimplement `Channel.java` in Flix" (#1904) PR as described in issue #2169. It includes the `GlobalCounter.java` class. 

`GlobalCounter` will be used to give channels unique identifiers. 

This PR should resolve issue #2176.