### PR TITLE
Remove subkinding

### DIFF
--- a/examples/the-ast-typing-problem-with-polymorphic-records.flix
+++ b/examples/the-ast-typing-problem-with-polymorphic-records.flix
@@ -19,7 +19,7 @@ enum Type {
 
 /// We can now write a function that given an expression extended
 /// with a tpe: Type field returns its type!
-def typeOf(e: Expr[<tpe: Type | r>]): Type = match e {
+def typeOf(e: Expr[(tpe :: Type | r)]): Type = match e {
     case True   => TBool
     case False  => TBool
     case Cst(_) => TInt
@@ -30,7 +30,7 @@ def typeOf(e: Expr[<tpe: Type | r>]): Type = match e {
 /// We can write a function that takes an untyped expression
 /// and returns a typed expression decorated with the type.
 /// For simplicity, the actual checks have been omitted.
-def typeCheck(e: Expr[<>]): Expr[<tpe: Type>] = match e {
+def typeCheck(e: Expr[()]): Expr[(tpe :: Type)] = match e {
     case True   => True
     case False  => False
     case Cst(i) => Cst({value = i.value, tpe = TInt})
@@ -55,7 +55,7 @@ def main(_args: Array[String]): Int32 & Impure =
 
 /// We can extend the function above to be one that is polymorphic
 /// in whatever other fields an expression may be decorated with:
-def typeCheck2(e: Expr[<| r>]): Expr[<tpe: Type | r>] = match e {
+def typeCheck2(e: Expr[r]): Expr[(tpe :: Type | r)] = match e {
     case True   => True
     case False  => False
     case Cst(i) => Cst({ +tpe = TInt | { value = i.value | i}})

--- a/examples/the-ast-typing-problem-with-polymorphic-records.flix
+++ b/examples/the-ast-typing-problem-with-polymorphic-records.flix
@@ -3,12 +3,12 @@
 /// We begin with a grammar for expressions.
 /// The definition of Exp is polymorphic in a record type that
 /// allows the AST to be decorated with additional fields.
-enum Expr[r: Record] {
+enum Expr[r: RecordRow] {
     case True,
     case False,
     case Cst({value: Int | r}),
-    case Add({exp1: Expr[{| r}], exp2: Expr[{| r}] | r}),
-    case Ite({exp1: Expr[{| r}], exp2: Expr[{| r}], exp3: Expr[{| r}] | r})
+    case Add({exp1: Expr[r], exp2: Expr[r] | r}),
+    case Ite({exp1: Expr[r], exp2: Expr[r], exp3: Expr[r] | r})
 }
 
 /// Next, we define a grammar of types:
@@ -19,7 +19,7 @@ enum Type {
 
 /// We can now write a function that given an expression extended
 /// with a tpe: Type field returns its type!
-def typeOf(e: Expr[{tpe: Type | r}]): Type = match e {
+def typeOf(e: Expr[<tpe: Type | r>]): Type = match e {
     case True   => TBool
     case False  => TBool
     case Cst(_) => TInt
@@ -30,7 +30,7 @@ def typeOf(e: Expr[{tpe: Type | r}]): Type = match e {
 /// We can write a function that takes an untyped expression
 /// and returns a typed expression decorated with the type.
 /// For simplicity, the actual checks have been omitted.
-def typeCheck(e: Expr[{}]): Expr[{tpe: Type}] = match e {
+def typeCheck(e: Expr[<>]): Expr[<tpe: Type>] = match e {
     case True   => True
     case False  => False
     case Cst(i) => Cst({value = i.value, tpe = TInt})
@@ -55,7 +55,7 @@ def main(_args: Array[String]): Int32 & Impure =
 
 /// We can extend the function above to be one that is polymorphic
 /// in whatever other fields an expression may be decorated with:
-def typeCheck2(e: Expr[{| r}]): Expr[{tpe: Type | r}] = match e {
+def typeCheck2(e: Expr[<| r>]): Expr[<tpe: Type | r>] = match e {
     case True   => True
     case False  => False
     case Cst(i) => Cst({ +tpe = TInt | { value = i.value | i}})

--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -417,8 +417,8 @@ object Indexer {
   private def visitType(tpe0: Type): Index = tpe0 match {
     case _: Type.KindedVar => Index.empty
     case Type.Cst(tc, loc) => tc match {
-      case TypeConstructor.RecordExtend(field) => Index.occurrenceOf(tc, loc) ++ Index.useOf(field)
-      case TypeConstructor.SchemaExtend(pred) => Index.occurrenceOf(tc, loc) ++ Index.useOf(pred)
+      case TypeConstructor.RecordRowExtend(field) => Index.occurrenceOf(tc, loc) ++ Index.useOf(field)
+      case TypeConstructor.SchemaRowExtend(pred) => Index.occurrenceOf(tc, loc) ++ Index.useOf(pred)
       case _ => Index.occurrenceOf(tc, loc)
     }
     case Type.Lambda(_, tpe, _) => visitType(tpe)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
@@ -62,8 +62,8 @@ object FindReferencesProvider {
         case Entity.LocalVar(sym, _) => findVarUses(sym)
 
         case Entity.TypeCon(tc, loc) => tc match {
-          case TypeConstructor.RecordExtend(field) => findFieldUses(field)
-          case TypeConstructor.SchemaExtend(pred) => findPredUses(pred)
+          case TypeConstructor.RecordRowExtend(field) => findFieldUses(field)
+          case TypeConstructor.SchemaRowExtend(pred) => findPredUses(pred)
           case TypeConstructor.KindedEnum(sym, _) => findEnumUses(sym)
           case _ => mkNotFound(uri, pos)
         }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
@@ -59,8 +59,8 @@ object HighlightProvider {
         case Entity.LocalVar(sym, _) => highlightVar(sym)
 
         case Entity.TypeCon(tc, loc) => tc match {
-          case TypeConstructor.RecordExtend(field) => highlightField(field)
-          case TypeConstructor.SchemaExtend(pred) => highlightPred(pred)
+          case TypeConstructor.RecordRowExtend(field) => highlightField(field)
+          case TypeConstructor.SchemaRowExtend(pred) => highlightPred(pred)
           case TypeConstructor.KindedEnum(sym, _) => highlightEnum(sym)
           case _ => mkNotFound(uri, pos)
         }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/RenameProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/RenameProvider.scala
@@ -58,8 +58,8 @@ object RenameProvider {
         case Entity.LocalVar(sym, _) => renameVar(sym, newName)
 
         case Entity.TypeCon(tc, _) => tc match {
-          case TypeConstructor.RecordExtend(field) => renameField(field, newName)
-          case TypeConstructor.SchemaExtend(pred) => renamePred(pred, newName)
+          case TypeConstructor.RecordRowExtend(field) => renameField(field, newName)
+          case TypeConstructor.SchemaRowExtend(pred) => renamePred(pred, newName)
           case TypeConstructor.KindedEnum(sym, _) => renameEnum(sym, newName)
           case _ => mkNotFound(uri, pos)
         }

--- a/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
@@ -20,7 +20,6 @@ import ca.uwaterloo.flix.language.debug.FormatKind
 
 import scala.annotation.tailrec
 
-// MATT describe kind system
 /**
   * A kind represents the "type" of a type expression.
   */

--- a/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Kind.scala
@@ -20,6 +20,7 @@ import ca.uwaterloo.flix.language.debug.FormatKind
 
 import scala.annotation.tailrec
 
+// MATT describe kind system
 /**
   * A kind represents the "type" of a type expression.
   */
@@ -40,29 +41,6 @@ sealed trait Kind {
     */
   override def toString: String = FormatKind.formatKind(this)
 
-  /**
-    * Returns true if `left` is a subkind of `this`.
-    * Right-associative.
-    */
-  def <::(left: Kind): Boolean = (left, this) match {
-    // NB: identities first for performance
-    // identities
-    case (Kind.Star, Kind.Star) => true
-    case (Kind.Bool, Kind.Bool) => true
-    case (Kind.Record, Kind.Record) => true
-    case (Kind.Schema, Kind.Schema) => true
-
-    case (_, Kind.Wild) => true
-    case (Kind.Wild, _) => true
-
-    // subkinds
-    case (Kind.Record, Kind.Star) => true
-    case (Kind.Schema, Kind.Star) => true
-
-    // arrow kinds: the left side is contravariant
-    case (Kind.Arrow(k11, k12), Kind.Arrow(k21, k22)) => (k21 <:: k11) && (k12 <:: k22)
-    case _ => false
-  }
 
 }
 
@@ -86,14 +64,19 @@ object Kind {
   case object Bool extends Kind
 
   /**
-    * Represents the kind of records.
+    * Represents the kind of record rows.
     */
-  case object Record extends Kind
+  case object RecordRow extends Kind
 
   /**
-    * Represents the kind of schemas.
+    * Represents the kind of schema rows.
     */
-  case object Schema extends Kind
+  case object SchemaRow extends Kind
+
+  /**
+    * Represents the kind of predicates.
+    */
+  case object Predicate extends Kind
 
   /**
     * Represents the kind of type expressions `k1 -> k2`.
@@ -137,17 +120,4 @@ object Kind {
     case Arrow(k1, k2) => k1 :: kindArgs(k2)
     case _ => Nil
   }
-
-  /**
-    * Returns the minimum kind, or None if the kinds are incomparable.
-    */
-  def min(k1: Kind, k2: Kind): Option[Kind] = {
-    if (k1 <:: k2)
-      Some(k1)
-    else if (k2 <:: k1)
-      Some(k2)
-    else
-      None
-  }
-
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -312,7 +312,7 @@ object NamedAst {
 
     case class RecordRowExtend(field: Name.Field, tpe: NamedAst.Type, rest: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
 
-    case class MakeRecord(row: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
+    case class Record(row: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
 
     case class SchemaRowEmpty(loc: SourceLocation) extends NamedAst.Type
 
@@ -320,7 +320,7 @@ object NamedAst {
 
     case class SchemaRowExtendWithTypes(ident: Name.Ident, den: Ast.Denotation, tpes: List[NamedAst.Type], rest: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
 
-    case class MakeSchema(row: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
+    case class Schema(row: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
 
     case class Native(fqn: String, loc: SourceLocation) extends NamedAst.Type
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -308,15 +308,19 @@ object NamedAst {
 
     case class Tuple(elms: List[NamedAst.Type], loc: SourceLocation) extends NamedAst.Type
 
-    case class RecordEmpty(loc: SourceLocation) extends NamedAst.Type
+    case class RecordRowEmpty(loc: SourceLocation) extends NamedAst.Type
 
-    case class RecordExtend(field: Name.Field, tpe: NamedAst.Type, rest: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
+    case class RecordRowExtend(field: Name.Field, tpe: NamedAst.Type, rest: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
 
-    case class SchemaEmpty(loc: SourceLocation) extends NamedAst.Type
+    case class MakeRecord(row: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
 
-    case class SchemaExtendWithAlias(qname: Name.QName, targs: List[NamedAst.Type], rest: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
+    case class SchemaRowEmpty(loc: SourceLocation) extends NamedAst.Type
 
-    case class SchemaExtendWithTypes(ident: Name.Ident, den: Ast.Denotation, tpes: List[NamedAst.Type], rest: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
+    case class SchemaRowExtendWithAlias(qname: Name.QName, targs: List[NamedAst.Type], rest: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
+
+    case class SchemaRowExtendWithTypes(ident: Name.Ident, den: Ast.Denotation, tpes: List[NamedAst.Type], rest: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
+
+    case class MakeSchema(row: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
 
     case class Native(fqn: String, loc: SourceLocation) extends NamedAst.Type
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1424,14 +1424,19 @@ object ParsedAst {
     case class Bool(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Kind
 
     /**
-      * The Record kind.
+      * The Record Row kind.
       */
-    case class Record(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Kind
+    case class RecordRow(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Kind
 
     /**
-      * The Schema kind.
+      * The Schema Row kind.
       */
-    case class Schema(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Kind
+    case class SchemaRow(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Kind
+
+    /**
+      * The Predicate kind.
+      */
+    case class Predicate(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Kind
 
     /**
       * The Arrow kind.

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1286,13 +1286,34 @@ object ParsedAst {
     case class Record(sp1: SourcePosition, fields: Seq[ParsedAst.RecordFieldType], rest: Option[Name.Ident], sp2: SourcePosition) extends ParsedAst.Type
 
     /**
+      * Record Row type.
+      *
+      * @param sp1    the position of the first character in the type.
+      * @param fields the sequence of field types.
+      * @param rest   the optional row variable.
+      * @param sp2    the position of the last character in the type.
+      */
+    case class RecordRow(sp1: SourcePosition, fields: Seq[ParsedAst.RecordFieldType], rest: Option[Name.Ident], sp2: SourcePosition) extends ParsedAst.Type
+
+    /**
       * Schema Type.
       *
       * @param sp1        the position of the first character in the type.
       * @param predicates the sequence of predicate types.
+      * @param rest       the optional row variable.
       * @param sp2        the position of the last character in the type.
       */
     case class Schema(sp1: SourcePosition, predicates: Seq[ParsedAst.PredicateType], rest: Option[Name.Ident], sp2: SourcePosition) extends ParsedAst.Type
+
+    /**
+      * Schema Row Type.
+      *
+      * @param sp1        the position of the first character in the type.
+      * @param predicates the sequence of predicate types.
+      * @param rest       the optional row variable.
+      * @param sp2        the position of the last character in the type.
+      */
+    case class SchemaRow(sp1: SourcePosition, predicates: Seq[ParsedAst.PredicateType], rest: Option[Name.Ident], sp2: SourcePosition) extends ParsedAst.Type
 
     /**
       * Unary Impure Arrow Type.

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -292,12 +292,22 @@ object Type {
   /**
     * Represents the type of an empty record.
     */
-  val RecordEmpty: Type = Type.Cst(TypeConstructor.RecordEmpty, SourceLocation.Unknown)
+  val RecordRowEmpty: Type = Type.Cst(TypeConstructor.RecordRowEmpty, SourceLocation.Unknown)
+
+  /**
+    * Represents the record type constructor.
+    */
+  val MakeRecord: Type = Type.Cst(TypeConstructor.MakeRecord, SourceLocation.Unknown)
 
   /**
     * Represents the type of an empty schema.
     */
-  val SchemaEmpty: Type = Type.Cst(TypeConstructor.SchemaEmpty, SourceLocation.Unknown)
+  val SchemaRowEmpty: Type = Type.Cst(TypeConstructor.SchemaRowEmpty, SourceLocation.Unknown)
+
+  /**
+    * Represents the schema type constructor.
+    */
+  val MakeSchema: Type = Type.Cst(TypeConstructor.MakeSchema, SourceLocation.Unknown)
 
   /**
     * Represents the Boolean True.
@@ -758,15 +768,15 @@ object Type {
   /**
     * Constructs a RecordExtend type.
     */
-  def mkRecordExtend(field: Name.Field, tpe: Type, rest: Type, loc: SourceLocation): Type = {
-    mkApply(Type.Cst(TypeConstructor.RecordExtend(field), loc), List(tpe, rest), loc)
+  def mkRecordRowExtend(field: Name.Field, tpe: Type, rest: Type, loc: SourceLocation): Type = {
+    mkApply(Type.Cst(TypeConstructor.RecordRowExtend(field), loc), List(tpe, rest), loc)
   }
 
   /**
     * Constructs a SchemaExtend type.
     */
-  def mkSchemaExtend(pred: Name.Pred, tpe: Type, rest: Type, loc: SourceLocation): Type = {
-    mkApply(Type.Cst(TypeConstructor.SchemaExtend(pred), loc), List(tpe, rest), loc)
+  def mkSchemaRowExtend(pred: Name.Pred, tpe: Type, rest: Type, loc: SourceLocation): Type = {
+    mkApply(Type.Cst(TypeConstructor.SchemaRowExtend(pred), loc), List(tpe, rest), loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -297,7 +297,7 @@ object Type {
   /**
     * Represents the record type constructor.
     */
-  val MakeRecord: Type = Type.Cst(TypeConstructor.MakeRecord, SourceLocation.Unknown)
+  val Record: Type = Type.Cst(TypeConstructor.Record, SourceLocation.Unknown)
 
   /**
     * Represents the type of an empty schema.
@@ -307,7 +307,7 @@ object Type {
   /**
     * Represents the schema type constructor.
     */
-  val MakeSchema: Type = Type.Cst(TypeConstructor.MakeSchema, SourceLocation.Unknown)
+  val Schema: Type = Type.Cst(TypeConstructor.Schema, SourceLocation.Unknown)
 
   /**
     * Represents the Boolean True.

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -295,19 +295,9 @@ object Type {
   val RecordRowEmpty: Type = Type.Cst(TypeConstructor.RecordRowEmpty, SourceLocation.Unknown)
 
   /**
-    * Represents the record type constructor.
-    */
-  val Record: Type = Type.Cst(TypeConstructor.Record, SourceLocation.Unknown)
-
-  /**
     * Represents the type of an empty schema.
     */
   val SchemaRowEmpty: Type = Type.Cst(TypeConstructor.SchemaRowEmpty, SourceLocation.Unknown)
-
-  /**
-    * Represents the schema type constructor.
-    */
-  val Schema: Type = Type.Cst(TypeConstructor.Schema, SourceLocation.Unknown)
 
   /**
     * Represents the Boolean True.
@@ -777,6 +767,20 @@ object Type {
     */
   def mkSchemaRowExtend(pred: Name.Pred, tpe: Type, rest: Type, loc: SourceLocation): Type = {
     mkApply(Type.Cst(TypeConstructor.SchemaRowExtend(pred), loc), List(tpe, rest), loc)
+  }
+
+  /**
+    * Constructs a Record type.
+    */
+  def mkRecord(tpe: Type, loc: SourceLocation): Type = {
+    Apply(Type.Cst(TypeConstructor.Record, loc), tpe, loc)
+  }
+
+  /**
+    * Constructs a Schema type.
+    */
+  def mkSchema(tpe: Type, loc: SourceLocation): Type = {
+    Apply(Type.Cst(TypeConstructor.Schema, loc), tpe, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -105,37 +105,57 @@ object TypeConstructor {
   }
 
   /**
-    * A type constructor that represents the type of empty records.
+    * A type constructor that represents the type of empty record rows.
     */
-  case object RecordEmpty extends TypeConstructor {
-    def kind: Kind = Kind.Record
+  case object RecordRowEmpty extends TypeConstructor {
+    def kind: Kind = Kind.RecordRow
   }
 
   /**
-    * A type constructor that represents the type of extended records.
+    * A type constructor that represents the type of extended record rows.
     */
-  case class RecordExtend(field: Name.Field) extends TypeConstructor {
+  case class RecordRowExtend(field: Name.Field) extends TypeConstructor {
     /**
       * The shape of an extended record is { field: type | rest }
       */
-    def kind: Kind = Kind.Star ->: Kind.Record ->: Kind.Record
+    def kind: Kind = Kind.Star ->: Kind.RecordRow ->: Kind.RecordRow
   }
 
   /**
-    * A type constructor that represents the type of empty schemas.
+    * A type constructor that represents the type of records.
     */
-  case object SchemaEmpty extends TypeConstructor {
-    def kind: Kind = Kind.Schema
+  case object MakeRecord extends TypeConstructor {
+    /**
+      * The shape of a record constructor is MakeRecord[row]
+      */
+    def kind: Kind = Kind.RecordRow ->: Kind.Star
   }
 
   /**
-    * A type constructor that represents the type of extended schemas.
+    * A type constructor that represents the type of empty schema rows.
     */
-  case class SchemaExtend(pred: Name.Pred) extends TypeConstructor {
+  case object SchemaRowEmpty extends TypeConstructor {
+    def kind: Kind = Kind.SchemaRow
+  }
+
+  /**
+    * A type constructor that represents the type of extended schema rows.
+    */
+  case class SchemaRowExtend(pred: Name.Pred) extends TypeConstructor {
     /**
       * The shape of an extended schema is { name: type | rest }
       */
-    def kind: Kind = Kind.Star ->: Kind.Schema ->: Kind.Schema
+    def kind: Kind = Kind.Predicate ->: Kind.SchemaRow ->: Kind.SchemaRow
+  }
+
+  /**
+    * A type constructor that represents the type of schemas.
+    */
+  case object MakeSchema extends TypeConstructor {
+    /**
+      * The shape of a schema constructor is MakeSchema[row]
+      */
+    def kind: Kind = Kind.SchemaRow ->: Kind.Star
   }
 
   /**
@@ -223,14 +243,14 @@ object TypeConstructor {
     * A type constructor for relations.
     */
   case object Relation extends TypeConstructor {
-    def kind: Kind = Kind.Star ->: Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Predicate
   }
 
   /**
     * A type constructor for lattices.
     */
   case object Lattice extends TypeConstructor {
-    def kind: Kind = Kind.Star ->: Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Predicate
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -124,9 +124,9 @@ object TypeConstructor {
   /**
     * A type constructor that represents the type of records.
     */
-  case object MakeRecord extends TypeConstructor {
+  case object Record extends TypeConstructor {
     /**
-      * The shape of a record constructor is MakeRecord[row]
+      * The shape of a record constructor is Record[row]
       */
     def kind: Kind = Kind.RecordRow ->: Kind.Star
   }
@@ -151,9 +151,9 @@ object TypeConstructor {
   /**
     * A type constructor that represents the type of schemas.
     */
-  case object MakeSchema extends TypeConstructor {
+  case object Schema extends TypeConstructor {
     /**
-      * The shape of a schema constructor is MakeSchema[row]
+      * The shape of a schema constructor is Schema[row]
       */
     def kind: Kind = Kind.SchemaRow ->: Kind.Star
   }

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -312,7 +312,7 @@ object WeededAst {
 
     case class RecordRowExtend(field: Name.Field, tpe: WeededAst.Type, rest: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
 
-    case class MakeRecord(row: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
+    case class Record(row: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
 
     case class SchemaRowEmpty(loc: SourceLocation) extends WeededAst.Type
 
@@ -320,7 +320,7 @@ object WeededAst {
 
     case class SchemaRowExtendByTypes(name: Name.Ident, den: Ast.Denotation, tpes: List[WeededAst.Type], rest: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
 
-    case class MakeSchema(row: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
+    case class Schema(row: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
 
     case class Relation(tpes: List[WeededAst.Type], loc: SourceLocation) extends WeededAst.Type
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -308,15 +308,19 @@ object WeededAst {
 
     case class Tuple(elms: List[WeededAst.Type], loc: SourceLocation) extends WeededAst.Type
 
-    case class RecordEmpty(loc: SourceLocation) extends WeededAst.Type
+    case class RecordRowEmpty(loc: SourceLocation) extends WeededAst.Type
 
-    case class RecordExtend(field: Name.Field, tpe: WeededAst.Type, rest: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
+    case class RecordRowExtend(field: Name.Field, tpe: WeededAst.Type, rest: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
 
-    case class SchemaEmpty(loc: SourceLocation) extends WeededAst.Type
+    case class MakeRecord(row: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
 
-    case class SchemaExtendByAlias(qname: Name.QName, targs: List[WeededAst.Type], rest: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
+    case class SchemaRowEmpty(loc: SourceLocation) extends WeededAst.Type
 
-    case class SchemaExtendByTypes(name: Name.Ident, den: Ast.Denotation, tpes: List[WeededAst.Type], rest: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
+    case class SchemaRowExtendByAlias(qname: Name.QName, targs: List[WeededAst.Type], rest: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
+
+    case class SchemaRowExtendByTypes(name: Name.Ident, den: Ast.Denotation, tpes: List[WeededAst.Type], rest: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
+
+    case class MakeSchema(row: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
 
     case class Relation(tpes: List[WeededAst.Type], loc: SourceLocation) extends WeededAst.Type
 

--- a/main/src/ca/uwaterloo/flix/language/debug/FormatKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/debug/FormatKind.scala
@@ -11,8 +11,9 @@ object FormatKind {
     case Kind.Wild => "???"
     case Kind.Star => "Type"
     case Kind.Bool => "Bool"
-    case Kind.Record => "Record"
-    case Kind.Schema => "Schema"
+    case Kind.RecordRow => "RecordRow"
+    case Kind.SchemaRow => "SchemaRow"
+    case Kind.Predicate => "Predicate"
     // parenthesize the left because `->` is right-associative
     case Kind.Arrow(k1: Kind.Arrow, k2) => s"(${formatKind(k1)}) -> ${formatKind(k2)}"
     case Kind.Arrow(k1, k2) => s"${formatKind(k1)} -> ${formatKind(k2)}"

--- a/main/src/ca/uwaterloo/flix/language/debug/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/debug/FormatType.scala
@@ -163,14 +163,14 @@ object FormatType {
           case TypeConstructor.RecordRowExtend(field) => args.length match {
             case 0 => s"< $field: ??? >"
             case 1 => s"< $field: ${visit(args.head)} | ??? >"
-            case 2 => formatWellFormedRecordRow(tpe)
+            case 2 => s"< ${formatWellFormedRecordRow(tpe)} >"
             case _ => formatApply(s"RecordExtend($field)", args)
           }
 
           case TypeConstructor.SchemaRowExtend(pred) => args.length match {
             case 0 => s"#< ${pred.name}?(???) >"
             case 1 => s"#< ${formatSchemaField(pred.name, args.head)} | ??? >"
-            case 2 => formatWellFormedSchemaRow(tpe)
+            case 2 => s"#< ${formatWellFormedSchemaRow(tpe)} >"
             case _ => throw InternalCompilerException("unexpected overapplication")
           }
 

--- a/main/src/ca/uwaterloo/flix/language/debug/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/debug/FormatType.scala
@@ -170,9 +170,9 @@ object FormatType {
             case _ => formatApply(s"SchemaExtend($pred)", args)
           }
 
-          case TypeConstructor.MakeRecord => visit(args.head) // MATT better error handling
+          case TypeConstructor.Record => visit(args.head) // MATT better error handling
 
-          case TypeConstructor.MakeSchema => visit(args.head) // MATT better error handling
+          case TypeConstructor.Schema => visit(args.head) // MATT better error handling
 
 
           case TypeConstructor.Tuple(length) =>

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -119,30 +119,6 @@ object TypeError {
   }
 
   /**
-    * Mismatched kinds.
-    *
-    * @param tpe1  the first type.
-    * @param tpe2  the second type.
-    * @param kind1 the first kind.
-    * @param kind2 the second kind.
-    * @param loc   the location where the error occurred.
-    */
-  case class MismatchedKinds(tpe1: Type, tpe2: Type, kind1: Kind, kind2: Kind, loc: SourceLocation) extends TypeError {
-    def summary: String = s"Unable to unify the kinds '$kind1' and '$kind2'.'"
-
-    def message: VirtualTerminal = {
-      val vt = new VirtualTerminal()
-      vt << Line(kind, source.format) << NewLine
-      vt << ">> Unable to unify the types: '" << Red(FormatType.formatType(tpe1)) << "' and '" << Red(FormatType.formatType(tpe2)) << "'." << NewLine
-      vt << NewLine
-      vt << Code(loc, "mismatched kinds.") << NewLine
-      vt << NewLine
-      vt << "Kind One: " << Cyan(kind1.toString) << NewLine
-      vt << "Kind Two: " << Magenta(kind2.toString) << NewLine
-    }
-  }
-
-  /**
     * Mismatched Arity.
     *
     * @param tpe1 the first type.

--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -711,7 +711,7 @@ object Deriver extends Phase[KindedAst.Root, KindedAst.Root] {
     * Filters out non-star type parameters and wild type parameters.
     */
   private def getTypeConstraintsForTypeParams(tparams: List[KindedAst.TypeParam], clazz: Symbol.ClassSym, loc: SourceLocation): List[Ast.TypeConstraint] = tparams.collect {
-    case tparam if tparam.tpe.kind <:: Kind.Star && !tparam.name.isWild => Ast.TypeConstraint(clazz, tparam.tpe, loc)
+    case tparam if tparam.tpe.kind == Kind.Star && !tparam.name.isWild => Ast.TypeConstraint(clazz, tparam.tpe, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
@@ -431,7 +431,7 @@ object Finalize extends Phase[LiftedAst.Root, FinalAst.Root] {
 
           case TypeConstructor.Str => MonoType.Str
 
-          case TypeConstructor.RecordEmpty => MonoType.RecordEmpty()
+          case TypeConstructor.RecordRowEmpty => MonoType.RecordEmpty()
 
           case TypeConstructor.Array => MonoType.Array(args.head)
 
@@ -456,7 +456,9 @@ object Finalize extends Phase[LiftedAst.Root, FinalAst.Root] {
 
           case TypeConstructor.Arrow(l) => MonoType.Arrow(args.drop(1).init, args.last)
 
-          case TypeConstructor.RecordExtend(field) => MonoType.RecordExtend(field.name, args.head, args(1))
+          case TypeConstructor.RecordRowExtend(field) => MonoType.RecordExtend(field.name, args.head, args(1))
+
+          case TypeConstructor.MakeRecord => args.head
 
           case TypeConstructor.True => MonoType.Unit
 
@@ -477,10 +479,14 @@ object Finalize extends Phase[LiftedAst.Root, FinalAst.Root] {
           case TypeConstructor.Lattice =>
             throw InternalCompilerException(s"Unexpected type: '$t0'.")
 
-          case TypeConstructor.SchemaEmpty =>
+          case TypeConstructor.SchemaRowEmpty =>
             throw InternalCompilerException(s"Unexpected type: '$t0'.")
 
-          case TypeConstructor.SchemaExtend(pred) => throw InternalCompilerException(s"Unexpected type: '$t0'.")
+          case TypeConstructor.SchemaRowExtend(pred) =>
+            throw InternalCompilerException(s"Unexpected type: '$t0'.")
+
+          case TypeConstructor.MakeSchema =>
+            throw InternalCompilerException(s"Unexpected type: '$t0'.")
         }
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
@@ -458,7 +458,7 @@ object Finalize extends Phase[LiftedAst.Root, FinalAst.Root] {
 
           case TypeConstructor.RecordRowExtend(field) => MonoType.RecordExtend(field.name, args.head, args(1))
 
-          case TypeConstructor.MakeRecord => args.head
+          case TypeConstructor.Record => args.head
 
           case TypeConstructor.True => MonoType.Unit
 
@@ -485,7 +485,7 @@ object Finalize extends Phase[LiftedAst.Root, FinalAst.Root] {
           case TypeConstructor.SchemaRowExtend(pred) =>
             throw InternalCompilerException(s"Unexpected type: '$t0'.")
 
-          case TypeConstructor.MakeSchema =>
+          case TypeConstructor.Schema =>
             throw InternalCompilerException(s"Unexpected type: '$t0'.")
         }
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -102,7 +102,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
           caze => (tag, caze)
         }
       }
-      val tpeDeprecatedVal = visitType(tpeDeprecated0, KindMatch.subKindOf(Kind.Star), kenv, root)
+      val tpeDeprecatedVal = visitType(tpeDeprecated0, Kind.Star, kenv, root)
       val scVal = visitScheme(sc0, kenv, root)
 
       mapN(tparamsVal, casesVal, tpeDeprecatedVal, scVal) {
@@ -119,7 +119,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
       val kenv = getKindEnvFromTypeParamsDefaultStar(tparams0)
 
       val tparamsVal = Validation.traverse(tparams0.tparams)(visitTypeParam(_, kenv))
-      val tpeVal = visitType(tpe0, KindMatch.Wild, kenv, root)
+      val tpeVal = visitType(tpe0, Kind.Wild, kenv, root)
 
       mapN(tparamsVal, tpeVal) {
         case (_, _) => ()
@@ -132,7 +132,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
   private def visitCase(caze0: ResolvedAst.Case, kenv: KindEnv, root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Case, KindError] = caze0 match {
     case ResolvedAst.Case(enum, tag, tpeDeprecated0, sc0) =>
       for {
-        tpeDeprecated <- visitType(tpeDeprecated0, KindMatch.subKindOf(Kind.Star), kenv, root)
+        tpeDeprecated <- visitType(tpeDeprecated0, Kind.Star, kenv, root)
         sc <- visitScheme(sc0, kenv, root)
       } yield KindedAst.Case(enum, tag, tpeDeprecated, sc)
   }
@@ -163,8 +163,8 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     case ResolvedAst.Instance(doc, mod, sym, tpe0, tconstrs0, defs0, ns, loc) =>
       val kind = getClassKind(root.classes(sym))
       for {
-        kenv <- inferType(tpe0, KindMatch.subKindOf(kind), KindEnv.empty, root)
-        tpeVal = visitType(tpe0, KindMatch.subKindOf(kind), kenv, root)
+        kenv <- inferType(tpe0, kind, KindEnv.empty, root)
+        tpeVal = visitType(tpe0, kind, kenv, root)
         tconstrsVal = Validation.traverse(tconstrs0)(visitTypeConstraint(_, kenv, root))
         defsVal = Validation.traverse(defs0)(visitDef(_, kenv, root))
         result <- Validation.sequenceT(tpeVal, tconstrsVal, defsVal)
@@ -205,8 +205,8 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
       val annVal = Validation.traverse(ann0)(visitAnnotation(_, kenv, root))
       val tparamsVal = Validation.traverse(tparams0.tparams)(visitTypeParam(_, kenv))
       val fparamsVal = Validation.traverse(fparams0)(visitFormalParam(_, kenv, root))
-      val tpeVal = visitType(tpe0, KindMatch.subKindOf(Kind.Star), kenv, root)
-      val effVal = visitType(eff0, KindMatch.subKindOf(Kind.Bool), kenv, root)
+      val tpeVal = visitType(tpe0, Kind.Star, kenv, root)
+      val effVal = visitType(eff0, Kind.Bool, kenv, root)
       val scVal = visitScheme(sc0, kenv, root)
       for {
         result <- Validation.sequenceT(annVal, tparamsVal, fparamsVal, tpeVal, effVal)
@@ -223,7 +223,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     case ResolvedAst.Expression.Wild(loc) => KindedAst.Expression.Wild(Type.freshVar(Kind.Star, loc), loc).toSuccess
 
     case ResolvedAst.Expression.Var(sym, tpe0, loc) =>
-      mapN(visitType(tpe0, KindMatch.subKindOf(Kind.Star), kenv, root)) {
+      mapN(visitType(tpe0, Kind.Star, kenv, root)) {
         tpe => KindedAst.Expression.Var(sym, tpe, loc)
       }
 
@@ -432,15 +432,15 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     case ResolvedAst.Expression.Ascribe(exp0, expectedType0, expectedEff0, loc) =>
       for {
         exp <- visitExp(exp0, kenv, root)
-        expectedType <- Validation.traverse(expectedType0)(visitType(_, KindMatch.subKindOf(Kind.Star), kenv, root))
-        expectedEff <- Validation.traverse(expectedEff0)(visitType(_, KindMatch.subKindOf(Kind.Bool), kenv, root))
+        expectedType <- Validation.traverse(expectedType0)(visitType(_, Kind.Star, kenv, root))
+        expectedEff <- Validation.traverse(expectedEff0)(visitType(_, Kind.Bool, kenv, root))
       } yield KindedAst.Expression.Ascribe(exp, expectedType.headOption, expectedEff.headOption, Type.freshVar(Kind.Star, loc), loc)
 
     case ResolvedAst.Expression.Cast(exp0, declaredType0, declaredEff0, loc) =>
       for {
         exp <- visitExp(exp0, kenv, root)
-        declaredType <- Validation.traverse(declaredType0)(visitType(_, KindMatch.subKindOf(Kind.Star), kenv, root))
-        declaredEff <- Validation.traverse(declaredEff0)(visitType(_, KindMatch.subKindOf(Kind.Bool), kenv, root))
+        declaredType <- Validation.traverse(declaredType0)(visitType(_, Kind.Star, kenv, root))
+        declaredEff <- Validation.traverse(declaredEff0)(visitType(_, Kind.Bool, kenv, root))
       } yield KindedAst.Expression.Cast(exp, declaredType.headOption, declaredEff.headOption, Type.freshVar(Kind.Star, loc), loc)
 
     case ResolvedAst.Expression.TryCatch(exp0, rules0, loc) =>
@@ -486,7 +486,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     case ResolvedAst.Expression.NewChannel(exp0, tpe0, loc) =>
       for {
         exp <- visitExp(exp0, kenv, root)
-        tpe <- visitType(tpe0, KindMatch.subKindOf(Kind.Star), kenv, root)
+        tpe <- visitType(tpe0, Kind.Star, kenv, root)
       } yield KindedAst.Expression.NewChannel(exp, tpe, loc)
 
     case ResolvedAst.Expression.GetChannel(exp0, loc) =>
@@ -698,32 +698,28 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
   }
 
   /**
-    * Performs kinding on the given type variable under the given kind environment, with `kindMatch` expected from context.
+    * Performs kinding on the given type variable under the given kind environment, with `expectedKind` expected from context.
     */
-  private def visitTypeVar(tvar: Type.UnkindedVar, kindMatch: KindMatch, kenv: KindEnv): Validation[Type.KindedVar, KindError] = tvar match {
+  private def visitTypeVar(tvar: Type.UnkindedVar, expectedKind: Kind, kenv: KindEnv): Validation[Type.KindedVar, KindError] = tvar match {
     case tvar@Type.UnkindedVar(id, loc, rigidity, text) =>
       kenv.map.get(tvar) match {
         // Case 1: we don't know about this kind, just ascribe it with what the context expects
-        case None => tvar.ascribedWith(kindMatch.kind).toSuccess
+        case None => tvar.ascribedWith(expectedKind).toSuccess
         // Case 2: we know about this kind, make sure it's behaving as we expect
         case Some(actualKind) =>
-          if (kindMatch.matches(actualKind)) {
-            Type.KindedVar(id, actualKind, loc, rigidity, text).toSuccess
-          } else {
-            val expectedKind = kindMatch.kind
-            KindError.UnexpectedKind(expectedKind = expectedKind, actualKind = actualKind, loc = loc).toFailure
+          unify(expectedKind, actualKind) match {
+            case Some(kind) => Type.KindedVar(id, kind, loc, rigidity, text).toSuccess
+            case None => KindError.UnexpectedKind(expectedKind = expectedKind, actualKind = actualKind, loc = loc).toFailure
           }
       }
-
   }
 
   /**
     * Performs kinding on the given free type variable, with `kindMatch` expected from context.
     */
-  private def visitFreeTypeVar(tvar: Type.UnkindedVar, kindMatch: KindMatch): Type.KindedVar = tvar match {
+  private def visitFreeTypeVar(tvar: Type.UnkindedVar, expectedKind: Kind): Type.KindedVar = tvar match {
     case Type.UnkindedVar(id, rigidity, text, loc) =>
-      val kind = kindMatch.kind
-      Type.KindedVar(id, kind, rigidity, text, loc)
+      Type.KindedVar(id, expectedKind, rigidity, text, loc)
   }
 
   /**
@@ -731,45 +727,43 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     * This is roughly analogous to the reassembly of expressions under a type environment, except that:
     * - Kind errors may be discovered here as they may not have been found during inference (or inference may not have happened at all).
     */
-  private def visitType(tpe0: Type, expectedKind: KindMatch, kenv: KindEnv, root: ResolvedAst.Root)(implicit flix: Flix): Validation[Type, KindError] = tpe0 match {
+  private def visitType(tpe0: Type, expectedKind: Kind, kenv: KindEnv, root: ResolvedAst.Root)(implicit flix: Flix): Validation[Type, KindError] = tpe0 match {
     case tvar: Type.UnkindedVar => visitTypeVar(tvar, expectedKind, kenv)
     case Type.Cst(cst, loc) =>
       val tycon = visitTypeConstructor(cst, root)
       val kind = tycon.kind
-      if (expectedKind.matches(kind)) {
-        Type.Cst(tycon, loc).toSuccess
-      } else {
-        KindError.UnexpectedKind(expectedKind = expectedKind.kind, actualKind = kind, loc).toFailure
+      unify(expectedKind, kind) match {
+        case Some(_) => Type.Cst(tycon, loc).toSuccess
+        case None => KindError.UnexpectedKind(expectedKind = expectedKind, actualKind = kind, loc).toFailure
       }
     case Type.Apply(t10, t20, loc) =>
       for {
-        t2 <- visitType(t20, KindMatch.Wild, kenv, root)
-        k1 = KindMatch.subKindOf(Kind.Arrow(t2.kind, expectedKind.kind))
+        t2 <- visitType(t20, Kind.Wild, kenv, root)
+        k1 = Kind.Arrow(t2.kind, expectedKind)
         t1 <- visitType(t10, k1, kenv, root)
       } yield Type.Apply(t1, t2, loc)
     case Type.Lambda(t10, t20, loc) =>
       val tvar = t10.asUnkinded
       expectedKind match {
-        case KindMatch(_, Kind.Arrow(expK1, expK2)) =>
-          val t1 = visitFreeTypeVar(tvar, KindMatch.subKindOf(expK1))
+        case Kind.Arrow(expK1, expK2) =>
+          val t1 = visitFreeTypeVar(tvar, expK1)
           for {
             newKenv <- kenv + (tvar -> t1.kind)
-            t2 <- visitType(t20, KindMatch.subKindOf(expK2), newKenv, root)
+            t2 <- visitType(t20, expK2, newKenv, root)
           } yield Type.Lambda(t1, t2, loc)
-        case KindMatch(_, Kind.Wild) =>
-          val t1 = visitFreeTypeVar(tvar, KindMatch.Wild)
+        case Kind.Wild =>
+          val t1 = visitFreeTypeVar(tvar, Kind.Wild)
           for {
             newKenv <- kenv + (tvar -> t1.kind)
-            t2 <- visitType(t20, KindMatch.Wild, newKenv, root)
+            t2 <- visitType(t20, Kind.Wild, newKenv, root)
           } yield Type.Lambda(t1, t2, loc)
         case _ =>
-          KindError.UnexpectedKind(expectedKind = expectedKind.kind, actualKind = Kind.Wild ->: Kind.Wild, loc).toFailure
+          KindError.UnexpectedKind(expectedKind = expectedKind, actualKind = Kind.Wild ->: Kind.Wild, loc).toFailure
       }
     case Type.Ascribe(t, k, loc) =>
-      if (expectedKind.matches(k)) {
-        visitType(t, KindMatch.subKindOf(k), kenv, root)
-      } else {
-        KindError.UnexpectedKind(expectedKind = expectedKind.kind, actualKind = k, loc).toFailure
+      unify(k, expectedKind) match {
+        case Some(kind) => visitType(t, kind, kenv, root)
+        case None => KindError.UnexpectedKind(expectedKind = expectedKind, actualKind = k, loc).toFailure
       }
     case _: Type.KindedVar => throw InternalCompilerException("Unexpected kinded type variable.")
   }
@@ -780,9 +774,9 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
   private def visitScheme(sc: ResolvedAst.Scheme, kenv: KindEnv, root: ResolvedAst.Root)(implicit flix: Flix): Validation[Scheme, KindError] = sc match {
     case ResolvedAst.Scheme(quantifiers0, constraints0, base0) =>
       for {
-        quantifiers <- Validation.traverse(quantifiers0)(visitTypeVar(_, KindMatch.Wild, kenv))
+        quantifiers <- Validation.traverse(quantifiers0)(visitTypeVar(_, Kind.Wild, kenv))
         constraints <- Validation.traverse(constraints0)(visitTypeConstraint(_, kenv, root))
-        base <- visitType(base0, KindMatch.subKindOf(Kind.Star), kenv, root)
+        base <- visitType(base0, Kind.Star, kenv, root)
       } yield Scheme(quantifiers, constraints, base)
   }
 
@@ -792,7 +786,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
   private def visitTypeConstraint(tconstr: ResolvedAst.TypeConstraint, kenv: KindEnv, root: ResolvedAst.Root)(implicit flix: Flix): Validation[Ast.TypeConstraint, KindError] = tconstr match {
     case ResolvedAst.TypeConstraint(clazz, tpe0, loc) =>
       val classKind = getClassKind(root.classes(clazz))
-      mapN(visitType(tpe0, KindMatch.subKindOf(classKind), kenv, root)) {
+      mapN(visitType(tpe0, classKind, kenv, root)) {
         tpe => Ast.TypeConstraint(clazz, tpe, loc)
       }
   }
@@ -847,11 +841,11 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     */
   private def visitTypeParam(tparam: ResolvedAst.TypeParam, kenv: KindEnv): Validation[KindedAst.TypeParam, KindError] = tparam match {
     case ResolvedAst.TypeParam.Kinded(name, tpe0, _, loc) =>
-      mapN(visitTypeVar(tpe0, KindMatch.Wild, kenv)) {
+      mapN(visitTypeVar(tpe0, Kind.Wild, kenv)) {
         tpe => KindedAst.TypeParam(name, tpe, loc)
       }
     case ResolvedAst.TypeParam.Unkinded(name, tpe0, loc) =>
-      mapN(visitTypeVar(tpe0, KindMatch.Wild, kenv)) {
+      mapN(visitTypeVar(tpe0, Kind.Wild, kenv)) {
         tpe => KindedAst.TypeParam(name, tpe, loc)
       }
   }
@@ -861,7 +855,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     */
   private def visitFormalParam(fparam0: ResolvedAst.FormalParam, kenv: KindEnv, root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.FormalParam, KindError] = fparam0 match {
     case ResolvedAst.FormalParam(sym, mod, tpe0, loc) =>
-      mapN(visitType(tpe0, KindMatch.subKindOf(Kind.Star), kenv, root)) {
+      mapN(visitType(tpe0, Kind.Star, kenv, root)) {
         tpe => KindedAst.FormalParam(sym, mod, tpe, loc)
       }
   }
@@ -889,7 +883,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
         }
       }
       val schemeKenvVal = inferScheme(sc, kenv, root)
-      val effKenvVal = inferType(eff, KindMatch.subKindOf(Kind.Bool), kenv, root)
+      val effKenvVal = inferType(eff, Kind.Bool, kenv, root)
 
       flatMapN(fparamKenvVal, schemeKenvVal, effKenvVal) {
         case (fparamKenv, schemeKenv, effKenv) => KindEnv.merge(fparamKenv, schemeKenv, effKenv, kenv)
@@ -901,7 +895,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     * Infers a kind environment from the given formal param.
     */
   private def inferFormalParam(fparam0: ResolvedAst.FormalParam, kenv: KindEnv, root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindEnv, KindError] = fparam0 match {
-    case ResolvedAst.FormalParam(_, _, tpe0, _) => inferType(tpe0, KindMatch.subKindOf(Kind.Star), kenv, root)
+    case ResolvedAst.FormalParam(_, _, tpe0, _) => inferType(tpe0, Kind.Star, kenv, root)
   }
 
   /**
@@ -909,7 +903,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     */
   private def inferScheme(sc0: ResolvedAst.Scheme, kenv: KindEnv, root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindEnv, KindError] = sc0 match {
     case ResolvedAst.Scheme(_, constraints, base) =>
-      val baseKenvVal = inferType(base, KindMatch.subKindOf(Kind.Star), kenv, root)
+      val baseKenvVal = inferType(base, Kind.Star, kenv, root)
       val tconstrsKenvsVal = Validation.traverse(constraints)(inferTconstr(_, kenv, root))
 
       Validation.flatMapN(baseKenvVal, tconstrsKenvsVal) {
@@ -923,7 +917,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
   private def inferTconstr(tconstr: ResolvedAst.TypeConstraint, kenv: KindEnv, root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindEnv, KindError] = tconstr match {
     case ResolvedAst.TypeConstraint(clazz, tpe, loc) =>
       val kind = getClassKind(root.classes(clazz))
-      inferType(tpe, KindMatch.subKindOf(kind), kenv: KindEnv, root)
+      inferType(tpe, kind, kenv: KindEnv, root)
   }
 
   /**
@@ -933,13 +927,13 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     * - There are no kind variables; kinds that cannot be determined are instead marked with [[Kind.Wild]].
     * - Subkinding may allow a variable to be ascribed with two different kinds; the most specific is used in the returned environment.
     */
-  private def inferType(tpe: Type, expectedType: KindMatch, kenv0: KindEnv, root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindEnv, KindError] = tpe.baseType match {
+  private def inferType(tpe: Type, expectedKind: Kind, kenv0: KindEnv, root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindEnv, KindError] = tpe.baseType match {
     // Case 1: the type constructor is a variable: all args are * and the constructor is * -> * -> * ... -> expectedType
     case tvar: Type.UnkindedVar =>
       val kind = kenv0.map.get(tvar) match {
         // Case 1.1: the type is not in the kenv: guess that it is Star -> Star -> ... -> ???.
         case None =>
-          tpe.typeArguments.foldLeft(expectedType.kind) {
+          tpe.typeArguments.foldLeft(expectedKind) {
             case (acc, _) => Kind.Star ->: acc
           }
         // Case 1.2: the type is in the kenv: use it.
@@ -947,7 +941,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
       }
 
       Validation.fold(tpe.typeArguments, KindEnv.singleton(tvar -> kind)) {
-        case (acc, targ) => flatMapN(inferType(targ, KindMatch.subKindOf(Kind.Star), kenv0, root)) {
+        case (acc, targ) => flatMapN(inferType(targ, Kind.Star, kenv0, root)) {
           kenv => acc ++ kenv
         }
       }
@@ -957,23 +951,23 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
       val args = Kind.kindArgs(tyconKind)
 
       Validation.fold(tpe.typeArguments.zip(args), KindEnv.empty) {
-        case (acc, (targ, kind)) => flatMapN(inferType(targ, KindMatch.subKindOf(kind), kenv0, root)) {
+        case (acc, (targ, kind)) => flatMapN(inferType(targ, kind, kenv0, root)) {
           kenv => acc ++ kenv
         }
       }
     case Type.Lambda(t1, t2, loc) =>
-      val tyconKind = tpe.typeArguments.foldLeft(expectedType.kind) {
+      val tyconKind = tpe.typeArguments.foldLeft(expectedKind) {
         case (acc, _) => Kind.Star ->: acc
       }
 
       tyconKind match {
         case Kind.Arrow(argKind, retKind) =>
-          val argKenvVal = inferType(t1, KindMatch.superKindOf(argKind), kenv0, root)
-          val retKenvVal = inferType(t2, KindMatch.subKindOf(retKind), kenv0, root)
+          val argKenvVal = inferType(t1, argKind, kenv0, root)
+          val retKenvVal = inferType(t2, retKind, kenv0, root)
 
           val args = Kind.kindArgs(tyconKind)
           val targsKenvVal = Validation.traverse(tpe.typeArguments.zip(args)) {
-            case (targ, kind) => inferType(targ, KindMatch.subKindOf(kind), kenv0, root)
+            case (targ, kind) => inferType(targ, kind, kenv0, root)
           }
           flatMapN(argKenvVal, retKenvVal, targsKenvVal) {
             case (kenv1, kenv2, kenv3) => KindEnv.merge(kenv1 :: kenv2 :: kenv3: _*)
@@ -981,7 +975,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
         case _ => KindError.UnexpectedKind(actualKind = Kind.Wild ->: Kind.Wild, expectedKind = tyconKind, loc = loc).toFailure
       }
 
-    case Type.Ascribe(t, k, loc) => inferType(t, KindMatch.subKindOf(k), kenv0, root)
+    case Type.Ascribe(t, k, loc) => inferType(t, k, kenv0, root)
 
     case _: Type.KindedVar => throw InternalCompilerException("Unexpected kinded var.")
   }
@@ -1111,40 +1105,6 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
   }
 
   /**
-    * Describes a kind bound, a subkind or superkind of some kind.
-    */
-  private case class KindMatch(assoc: KindMatch.Association, kind: Kind) { // MATT kill this class
-    /**
-      * Returns true if the given kind obeys the kind boudn described by this KindMatch.
-      */
-    def matches(other: Kind): Boolean = other == Kind.Wild || kind == Kind.Wild || other == kind
-  }
-
-  private object KindMatch {
-
-    /**
-      * A KindMatch that matches every kind.
-      */
-    // association doesn't matter
-    val Wild: KindMatch = KindMatch(Association.SubKind, Kind.Wild)
-
-    def subKindOf(kind: Kind): KindMatch = KindMatch(Association.SubKind, kind)
-
-    def superKindOf(kind: Kind): KindMatch = KindMatch(Association.SuperKind, kind)
-
-    /**
-      * Describes whether the KindMatch is a lower or upper bound.
-      */
-    sealed trait Association
-
-    object Association {
-      case object SubKind extends Association
-
-      case object SuperKind extends Association
-    }
-  }
-
-  /**
     * A mapping from type variables to kinds.
     */
   private object KindEnv {
@@ -1169,17 +1129,23 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
   }
 
   // MATT docs
-  def unifyKinds(k1: Kind, k2: Kind): Option[Kind] = (k1, k2) match {
+  // MATT name
+  // MATT make everything private probably
+  def unify(k1: Kind, k2: Kind): Option[Kind] = (k1, k2) match {
     case (Kind.Wild, k) => Some(k)
     case (k, Kind.Wild) => Some(k)
     case (Kind.Arrow(k11, k12), Kind.Arrow(k21, k22)) =>
       for {
-        kind1 <- unifyKinds(k11, k21)
-        kind2 <- unifyKinds(k12, k22)
+        kind1 <- unify(k11, k21)
+        kind2 <- unify(k12, k22)
       } yield Kind.Arrow(kind1, kind2)
     case (kind1, kind2) if kind1 == kind2 => Some(kind1)
     case _ => None
   }
+
+  // MATT docs
+  // MATT name
+  def doUnify(k1: Kind, k2: Kind): Boolean = unify(k1, k2).isDefined
 
   private case class KindEnv(map: Map[Type.UnkindedVar, Kind]) {
     /**
@@ -1187,7 +1153,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
       */
     def +(pair: (Type.UnkindedVar, Kind)): Validation[KindEnv, KindError] = pair match {
       case (tvar, kind) => map.get(tvar) match {
-        case Some(kind0) => unifyKinds(kind0, kind) match {
+        case Some(kind0) => unify(kind0, kind) match {
           case Some(minKind) => KindEnv(map + (tvar -> minKind)).toSuccess
           case None => KindError.MismatchedKinds(kind0, kind, tvar.loc).toFailure
         }

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -681,7 +681,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     case ResolvedAst.Predicate.Head.Atom(pred, den, terms0, loc) =>
       for {
         terms <- Validation.traverse(terms0)(visitExp(_, kenv, root))
-      } yield KindedAst.Predicate.Head.Atom(pred, den, terms, Type.freshVar(Kind.Star, loc), loc)
+      } yield KindedAst.Predicate.Head.Atom(pred, den, terms, Type.freshVar(Kind.Predicate, loc), loc)
   }
 
   /**
@@ -691,7 +691,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     case ResolvedAst.Predicate.Body.Atom(pred, den, polarity, terms0, loc) =>
       for {
         terms <- Validation.traverse(terms0)(visitPattern(_, kenv, root))
-      } yield KindedAst.Predicate.Body.Atom(pred, den, polarity, terms, Type.freshVar(Kind.Star, loc), loc)
+      } yield KindedAst.Predicate.Body.Atom(pred, den, polarity, terms, Type.freshVar(Kind.Predicate, loc), loc)
     case ResolvedAst.Predicate.Body.Guard(exp0, loc) =>
       for {
         exp <- visitExp(exp0, kenv, root)

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -338,12 +338,6 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
       } yield KindedAst.Expression.RecordSelect(exp, field, Type.freshVar(Kind.Star, loc), loc)
 
     case ResolvedAst.Expression.RecordExtend(field, value0, rest0, loc) =>
-      // Ideally, if `rest` is not of record kind, we should throw a kind error.
-      // But because we have subkinding, we can't do this in the Kinder.
-      // Consider: { +name = 5 | id({}) }
-      // This is OK, but would be seen as a kind error since id is `(a: *) -> (a: *)`, so `id({}) :: *`
-      // This KindError will be caught later in the Typer
-      // MATT readdress this
       for {
         value <- visitExp(value0, kenv, root)
         rest <- visitExp(rest0, kenv, root)

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -1057,10 +1057,10 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     }
   }
 
-  // MATT docs
-  // MATT name
-  // MATT make everything private probably
-  def unify(k1: Kind, k2: Kind): Option[Kind] = (k1, k2) match {
+  /**
+    * Unifies the kinds, returning the most specific kind if possible.
+    */
+  private def unify(k1: Kind, k2: Kind): Option[Kind] = (k1, k2) match {
     case (Kind.Wild, k) => Some(k)
     case (k, Kind.Wild) => Some(k)
     case (Kind.Arrow(k11, k12), Kind.Arrow(k21, k22)) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -343,6 +343,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
       // Consider: { +name = 5 | id({}) }
       // This is OK, but would be seen as a kind error since id is `(a: *) -> (a: *)`, so `id({}) :: *`
       // This KindError will be caught later in the Typer
+      // MATT readdress this
       for {
         value <- visitExp(value0, kenv, root)
         rest <- visitExp(rest0, kenv, root)

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -550,7 +550,7 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
 
     case ResolvedAst.Expression.Reify(t0, loc) =>
       for {
-        t <- visitType(t0, KindMatch.subKindOf(Kind.Bool), kenv, root)
+        t <- visitType(t0, Kind.Bool, kenv, root)
       } yield KindedAst.Expression.Reify(t, loc)
 
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -795,45 +795,12 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     * Performs kinding on the given type constructor under the given kind environment.
     */
   private def visitTypeConstructor(tycon: TypeConstructor, root: ResolvedAst.Root)(implicit flix: Flix): TypeConstructor = tycon match {
-    case TypeConstructor.Unit => TypeConstructor.Unit
-    case TypeConstructor.Null => TypeConstructor.Null
-    case TypeConstructor.Bool => TypeConstructor.Bool
-    case TypeConstructor.Char => TypeConstructor.Char
-    case TypeConstructor.Float32 => TypeConstructor.Float32
-    case TypeConstructor.Float64 => TypeConstructor.Float64
-    case TypeConstructor.Int8 => TypeConstructor.Int8
-    case TypeConstructor.Int16 => TypeConstructor.Int16
-    case TypeConstructor.Int32 => TypeConstructor.Int32
-    case TypeConstructor.Int64 => TypeConstructor.Int64
-    case TypeConstructor.BigInt => TypeConstructor.BigInt
-    case TypeConstructor.Str => TypeConstructor.Str
-    case TypeConstructor.Arrow(arity) => TypeConstructor.Arrow(arity)
-    case TypeConstructor.RecordRowEmpty => TypeConstructor.RecordRowEmpty // MATT this whole function can be reduced to a few cases
-    case TypeConstructor.RecordRowExtend(field) => TypeConstructor.RecordRowExtend(field)
-    case TypeConstructor.MakeRecord => TypeConstructor.MakeRecord
-    case TypeConstructor.SchemaRowEmpty => TypeConstructor.SchemaRowEmpty
-    case TypeConstructor.SchemaRowExtend(pred) => TypeConstructor.SchemaRowExtend(pred)
-    case TypeConstructor.MakeSchema => TypeConstructor.MakeSchema
-    case TypeConstructor.Array => TypeConstructor.Array
-    case TypeConstructor.Channel => TypeConstructor.Channel
-    case TypeConstructor.Lazy => TypeConstructor.Lazy
-    case TypeConstructor.Tag(sym, tag) => TypeConstructor.Tag(sym, tag)
     case TypeConstructor.UnkindedEnum(sym) =>
       // Lookup the enum kind
       val kind = getEnumKind(root.enums(sym))
       TypeConstructor.KindedEnum(sym, kind)
-    case TypeConstructor.Native(clazz) => TypeConstructor.Native(clazz)
-    case TypeConstructor.ScopedRef => TypeConstructor.ScopedRef
-    case TypeConstructor.Tuple(l) => TypeConstructor.Tuple(l)
-    case TypeConstructor.Relation => TypeConstructor.Relation
-    case TypeConstructor.Lattice => TypeConstructor.Lattice
-    case TypeConstructor.True => TypeConstructor.True
-    case TypeConstructor.False => TypeConstructor.False
-    case TypeConstructor.Not => TypeConstructor.Not
-    case TypeConstructor.And => TypeConstructor.And
-    case TypeConstructor.Or => TypeConstructor.Or
-    case TypeConstructor.Region => TypeConstructor.Region
     case _: TypeConstructor.KindedEnum => throw InternalCompilerException("Unexpected kinded enum.")
+    case t => t
   }
 
   /**
@@ -1058,42 +1025,9 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     * Gets the kind associated with the type constructor.
     */
   private def getTyconKind(tycon: TypeConstructor, root: ResolvedAst.Root)(implicit flix: Flix): Kind = tycon match {
-    case TypeConstructor.Unit => Kind.Star
-    case TypeConstructor.Null => Kind.Star
-    case TypeConstructor.Bool => Kind.Star
-    case TypeConstructor.Char => Kind.Star
-    case TypeConstructor.Float32 => Kind.Star
-    case TypeConstructor.Float64 => Kind.Star
-    case TypeConstructor.Int8 => Kind.Star
-    case TypeConstructor.Int16 => Kind.Star
-    case TypeConstructor.Int32 => Kind.Star
-    case TypeConstructor.Int64 => Kind.Star
-    case TypeConstructor.BigInt => Kind.Star
-    case TypeConstructor.Str => Kind.Star
-    case TypeConstructor.Arrow(arity) => Kind.Bool ->: Kind.mkArrow(arity)
-    case TypeConstructor.RecordRowEmpty => Kind.RecordRow
-    case TypeConstructor.RecordRowExtend(field) => Kind.Star ->: Kind.RecordRow ->: Kind.RecordRow // MATT this whole function can be reduced to a couple cases
-    case TypeConstructor.MakeRecord => Kind.RecordRow ->: Kind.Star
-    case TypeConstructor.SchemaRowEmpty => Kind.SchemaRow
-    case TypeConstructor.SchemaRowExtend(pred) => Kind.Predicate ->: Kind.SchemaRow ->: Kind.SchemaRow
-    case TypeConstructor.MakeSchema => Kind.SchemaRow ->: Kind.Star
-    case TypeConstructor.Array => Kind.Star ->: Kind.Star
-    case TypeConstructor.Channel => Kind.Star ->: Kind.Star
-    case TypeConstructor.Lazy => Kind.Star ->: Kind.Star
-    case TypeConstructor.Tag(sym, tag) => Kind.Star ->: Kind.Star ->: Kind.Star
     case TypeConstructor.UnkindedEnum(sym) => getEnumKind(root.enums(sym))
-    case TypeConstructor.Native(clazz) => Kind.Star
-    case TypeConstructor.ScopedRef => Kind.Star ->: Kind.Bool ->: Kind.Star
-    case TypeConstructor.Tuple(l) => Kind.mkArrow(l)
-    case TypeConstructor.Relation => Kind.Star ->: Kind.Star
-    case TypeConstructor.Lattice => Kind.Star ->: Kind.Star
-    case TypeConstructor.True => Kind.Bool
-    case TypeConstructor.False => Kind.Bool
-    case TypeConstructor.Not => Kind.Bool ->: Kind.Bool
-    case TypeConstructor.And => Kind.Bool ->: Kind.Bool ->: Kind.Bool
-    case TypeConstructor.Or => Kind.Bool ->: Kind.Bool ->: Kind.Bool
-    case TypeConstructor.Region => Kind.Bool ->: Kind.Star
     case _: TypeConstructor.KindedEnum => throw InternalCompilerException("Unexpected kinded enum.")
+    case t => t.kind
   }
 
   /**
@@ -1142,10 +1076,6 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
     case (kind1, kind2) if kind1 == kind2 => Some(kind1)
     case _ => None
   }
-
-  // MATT docs
-  // MATT name
-  def doUnify(k1: Kind, k2: Kind): Boolean = unify(k1, k2).isDefined
 
   private case class KindEnv(map: Map[Type.UnkindedVar, Kind]) {
     /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -698,7 +698,7 @@ object Lowering extends Phase[Root, Root] {
       case _: Type.Ascribe => throw InternalCompilerException(s"Unexpected type: '$tpe0'.")
     }
 
-    if (tpe0.typeConstructor.contains(TypeConstructor.MakeSchema))
+    if (tpe0.typeConstructor.contains(TypeConstructor.Schema))
       Types.Datalog
     else
       visit(tpe0)

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -682,7 +682,7 @@ object Lowering extends Phase[Root, Root] {
   private def visitType(tpe0: Type)(implicit root: Root, flix: Flix): Type = {
     def visit(tpe: Type): Type = tpe match {
       case Type.KindedVar(id, kind, loc, rigidity, text) => kind match {
-        case Kind.Schema => Type.KindedVar(id, Kind.Star, loc, rigidity, text)
+        case Kind.SchemaRow => Type.KindedVar(id, Kind.Star, loc, rigidity, text) // MATT ???
         case _ => tpe0
       }
 
@@ -698,7 +698,7 @@ object Lowering extends Phase[Root, Root] {
       case _: Type.Ascribe => throw InternalCompilerException(s"Unexpected type: '$tpe0'.")
     }
 
-    if (tpe0.kind == Kind.Schema)
+    if (tpe0.typeConstructor.contains(TypeConstructor.MakeSchema))
       Types.Datalog
     else
       visit(tpe0)

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -682,7 +682,7 @@ object Lowering extends Phase[Root, Root] {
   private def visitType(tpe0: Type)(implicit root: Root, flix: Flix): Type = {
     def visit(tpe: Type): Type = tpe match {
       case Type.KindedVar(id, kind, loc, rigidity, text) => kind match {
-        case Kind.SchemaRow => Type.KindedVar(id, Kind.Star, loc, rigidity, text) // MATT ???
+        case Kind.SchemaRow => Type.KindedVar(id, Kind.Star, loc, rigidity, text)
         case _ => tpe0
       }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
@@ -74,8 +74,8 @@ object Monomorph extends Phase[TypedAst.Root, TypedAst.Root] {
       */
     def apply(tpe: Type): Type = s(tpe).map {
       case Type.KindedVar(_, Kind.Bool, _, _, _) => Type.True
-      case Type.KindedVar(_, Kind.Record, _, _, _) => Type.RecordEmpty
-      case Type.KindedVar(_, Kind.Schema, _, _, _) => Type.SchemaEmpty
+      case Type.KindedVar(_, Kind.RecordRow, _, _, _) => Type.RecordRowEmpty
+      case Type.KindedVar(_, Kind.SchemaRow, _, _, _) => Type.SchemaRowEmpty
       case _ => Type.Unit
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -1098,9 +1098,9 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
         case (t, r) => NamedAst.Type.RecordRowExtend(field, t, r, loc)
       }
 
-    case WeededAst.Type.MakeRecord(row, loc) =>
+    case WeededAst.Type.Record(row, loc) =>
       mapN(visitType(row, uenv0, tenv0)) {
-        r => NamedAst.Type.MakeRecord(r, loc)
+        r => NamedAst.Type.Record(r, loc)
       }
 
     case WeededAst.Type.SchemaRowEmpty(loc) =>
@@ -1123,9 +1123,9 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
         case (ts, r) => NamedAst.Type.SchemaRowExtendWithTypes(ident, den, ts, r, loc)
       }
 
-    case WeededAst.Type.MakeSchema(row, loc) =>
+    case WeededAst.Type.Schema(row, loc) =>
       mapN(visitType(row, uenv0, tenv0)) {
-        r => NamedAst.Type.MakeSchema(r, loc)
+        r => NamedAst.Type.Schema(r, loc)
       }
 
     case WeededAst.Type.Relation(tpes, loc) =>
@@ -1346,11 +1346,11 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
     case WeededAst.Type.Tuple(elms, loc) => elms.flatMap(freeVars)
     case WeededAst.Type.RecordRowEmpty(loc) => Nil
     case WeededAst.Type.RecordRowExtend(l, t, r, loc) => freeVars(t) ::: freeVars(r)
-    case WeededAst.Type.MakeRecord(row, loc) => freeVars(row)
+    case WeededAst.Type.Record(row, loc) => freeVars(row)
     case WeededAst.Type.SchemaRowEmpty(loc) => Nil
     case WeededAst.Type.SchemaRowExtendByTypes(_, _, ts, r, loc) => ts.flatMap(freeVars) ::: freeVars(r)
     case WeededAst.Type.SchemaRowExtendByAlias(_, ts, r, _) => ts.flatMap(freeVars) ::: freeVars(r)
-    case WeededAst.Type.MakeSchema(row, loc) => freeVars(row)
+    case WeededAst.Type.Schema(row, loc) => freeVars(row)
     case WeededAst.Type.Relation(ts, loc) => ts.flatMap(freeVars)
     case WeededAst.Type.Lattice(ts, loc) => ts.flatMap(freeVars)
     case WeededAst.Type.Native(fqm, loc) => Nil
@@ -1376,11 +1376,11 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
       case WeededAst.Type.Tuple(elms, loc) => elms.flatMap(visit)
       case WeededAst.Type.RecordRowEmpty(loc) => Nil
       case WeededAst.Type.RecordRowExtend(l, t, r, loc) => visit(t) ::: visit(r)
-      case WeededAst.Type.MakeRecord(row, loc) => visit(row)
+      case WeededAst.Type.Record(row, loc) => visit(row)
       case WeededAst.Type.SchemaRowEmpty(loc) => Nil
       case WeededAst.Type.SchemaRowExtendByTypes(_, _, ts, r, loc) => ts.flatMap(visit) ::: visit(r)
       case WeededAst.Type.SchemaRowExtendByAlias(_, ts, r, _) => ts.flatMap(visit) ::: visit(r)
-      case WeededAst.Type.MakeSchema(row, loc) => visit(row)
+      case WeededAst.Type.Schema(row, loc) => visit(row)
       case WeededAst.Type.Relation(ts, loc) => ts.flatMap(visit)
       case WeededAst.Type.Lattice(ts, loc) => ts.flatMap(visit)
       case WeededAst.Type.Native(fqm, loc) => Nil

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -1090,18 +1090,23 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
         case ts => NamedAst.Type.Tuple(ts, loc)
       }
 
-    case WeededAst.Type.RecordEmpty(loc) =>
-      NamedAst.Type.RecordEmpty(loc).toSuccess
+    case WeededAst.Type.RecordRowEmpty(loc) =>
+      NamedAst.Type.RecordRowEmpty(loc).toSuccess
 
-    case WeededAst.Type.RecordExtend(field, value, rest, loc) =>
+    case WeededAst.Type.RecordRowExtend(field, value, rest, loc) =>
       mapN(visitType(value, uenv0, tenv0), visitType(rest, uenv0, tenv0)) {
-        case (t, r) => NamedAst.Type.RecordExtend(field, t, r, loc)
+        case (t, r) => NamedAst.Type.RecordRowExtend(field, t, r, loc)
       }
 
-    case WeededAst.Type.SchemaEmpty(loc) =>
-      NamedAst.Type.SchemaEmpty(loc).toSuccess
+    case WeededAst.Type.MakeRecord(row, loc) =>
+      mapN(visitType(row, uenv0, tenv0)) {
+        r => NamedAst.Type.MakeRecord(r, loc)
+      }
 
-    case WeededAst.Type.SchemaExtendByAlias(qname, targs, rest, loc) =>
+    case WeededAst.Type.SchemaRowEmpty(loc) =>
+      NamedAst.Type.SchemaRowEmpty(loc).toSuccess
+
+    case WeededAst.Type.SchemaRowExtendByAlias(qname, targs, rest, loc) =>
       // Disambiguate the qname.
       val name = if (qname.isUnqualified) {
         uenv0.typesAndClasses.getOrElse(qname.ident.name, qname)
@@ -1110,12 +1115,17 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
       }
 
       mapN(traverse(targs)(visitType(_, uenv0, tenv0)), visitType(rest, uenv0, tenv0)) {
-        case (ts, r) => NamedAst.Type.SchemaExtendWithAlias(name, ts, r, loc)
+        case (ts, r) => NamedAst.Type.SchemaRowExtendWithAlias(name, ts, r, loc)
       }
 
-    case WeededAst.Type.SchemaExtendByTypes(ident, den, tpes, rest, loc) =>
+    case WeededAst.Type.SchemaRowExtendByTypes(ident, den, tpes, rest, loc) =>
       mapN(traverse(tpes)(visitType(_, uenv0, tenv0)), visitType(rest, uenv0, tenv0)) {
-        case (ts, r) => NamedAst.Type.SchemaExtendWithTypes(ident, den, ts, r, loc)
+        case (ts, r) => NamedAst.Type.SchemaRowExtendWithTypes(ident, den, ts, r, loc)
+      }
+
+    case WeededAst.Type.MakeSchema(row, loc) =>
+      mapN(visitType(row, uenv0, tenv0)) {
+        r => NamedAst.Type.MakeSchema(r, loc)
       }
 
     case WeededAst.Type.Relation(tpes, loc) =>
@@ -1334,11 +1344,13 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
     case WeededAst.Type.Ambiguous(qname, loc) => Nil
     case WeededAst.Type.Unit(loc) => Nil
     case WeededAst.Type.Tuple(elms, loc) => elms.flatMap(freeVars)
-    case WeededAst.Type.RecordEmpty(loc) => Nil
-    case WeededAst.Type.RecordExtend(l, t, r, loc) => freeVars(t) ::: freeVars(r)
-    case WeededAst.Type.SchemaEmpty(loc) => Nil
-    case WeededAst.Type.SchemaExtendByTypes(_, _, ts, r, loc) => ts.flatMap(freeVars) ::: freeVars(r)
-    case WeededAst.Type.SchemaExtendByAlias(_, ts, r, _) => ts.flatMap(freeVars) ::: freeVars(r)
+    case WeededAst.Type.RecordRowEmpty(loc) => Nil
+    case WeededAst.Type.RecordRowExtend(l, t, r, loc) => freeVars(t) ::: freeVars(r)
+    case WeededAst.Type.MakeRecord(row, loc) => freeVars(row)
+    case WeededAst.Type.SchemaRowEmpty(loc) => Nil
+    case WeededAst.Type.SchemaRowExtendByTypes(_, _, ts, r, loc) => ts.flatMap(freeVars) ::: freeVars(r)
+    case WeededAst.Type.SchemaRowExtendByAlias(_, ts, r, _) => ts.flatMap(freeVars) ::: freeVars(r)
+    case WeededAst.Type.MakeSchema(row, loc) => freeVars(row)
     case WeededAst.Type.Relation(ts, loc) => ts.flatMap(freeVars)
     case WeededAst.Type.Lattice(ts, loc) => ts.flatMap(freeVars)
     case WeededAst.Type.Native(fqm, loc) => Nil
@@ -1362,11 +1374,13 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
       case WeededAst.Type.Ambiguous(qname, loc) => Nil
       case WeededAst.Type.Unit(loc) => Nil
       case WeededAst.Type.Tuple(elms, loc) => elms.flatMap(visit)
-      case WeededAst.Type.RecordEmpty(loc) => Nil
-      case WeededAst.Type.RecordExtend(l, t, r, loc) => visit(t) ::: visit(r)
-      case WeededAst.Type.SchemaEmpty(loc) => Nil
-      case WeededAst.Type.SchemaExtendByTypes(_, _, ts, r, loc) => ts.flatMap(visit) ::: visit(r)
-      case WeededAst.Type.SchemaExtendByAlias(_, ts, r, _) => ts.flatMap(visit) ::: visit(r)
+      case WeededAst.Type.RecordRowEmpty(loc) => Nil
+      case WeededAst.Type.RecordRowExtend(l, t, r, loc) => visit(t) ::: visit(r)
+      case WeededAst.Type.MakeRecord(row, loc) => visit(row)
+      case WeededAst.Type.SchemaRowEmpty(loc) => Nil
+      case WeededAst.Type.SchemaRowExtendByTypes(_, _, ts, r, loc) => ts.flatMap(visit) ::: visit(r)
+      case WeededAst.Type.SchemaRowExtendByAlias(_, ts, r, _) => ts.flatMap(visit) ::: visit(r)
+      case WeededAst.Type.MakeSchema(row, loc) => visit(row)
       case WeededAst.Type.Relation(ts, loc) => ts.flatMap(visit)
       case WeededAst.Type.Lattice(ts, loc) => ts.flatMap(visit)
       case WeededAst.Type.Native(fqm, loc) => Nil

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1344,12 +1344,16 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       SP ~ keyword("Bool") ~ SP ~> ParsedAst.Kind.Bool
     }
 
-    def Record: Rule1[ParsedAst.Kind.Record] = rule {
-      SP ~ keyword("Record") ~ SP ~> ParsedAst.Kind.Record
+    def Record: Rule1[ParsedAst.Kind.RecordRow] = rule {
+      SP ~ keyword("RecordRow") ~ SP ~> ParsedAst.Kind.RecordRow
     }
 
-    def Schema: Rule1[ParsedAst.Kind.Schema] = rule {
-      SP ~ keyword("Schema") ~ SP ~> ParsedAst.Kind.Schema
+    def Schema: Rule1[ParsedAst.Kind.SchemaRow] = rule {
+      SP ~ keyword("SchemaRow") ~ SP ~> ParsedAst.Kind.SchemaRow
+    }
+
+    def Predicate: Rule1[ParsedAst.Kind.Predicate] = rule {
+      SP ~ keyword("Predicate") ~ SP ~> ParsedAst.Kind.Predicate
     }
 
     def Parens: Rule1[ParsedAst.Kind] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1263,6 +1263,16 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       }
     }
 
+    def RecordRow: Rule1[ParsedAst.Type] = {
+      def RecordFieldType: Rule1[ParsedAst.RecordFieldType] = rule { // MATT dedupe
+        SP ~ Names.Field ~ optWS ~ ":" ~ optWS ~ Type ~ SP ~> ParsedAst.RecordFieldType
+      }
+
+      rule {
+        SP ~ atomic("<") ~ optWS ~ zeroOrMore(RecordFieldType).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ ">" ~ SP ~> ParsedAst.Type.RecordRow
+      }
+    }
+
     def Schema: Rule1[ParsedAst.Type] = {
       def PredicateWithAlias: Rule1[ParsedAst.PredicateType.PredicateWithAlias] = rule {
         SP ~ Names.QualifiedPredicate ~ optional(TypeArguments) ~ SP ~> ParsedAst.PredicateType.PredicateWithAlias
@@ -1278,6 +1288,24 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
       rule {
         SP ~ atomic("#{") ~ optWS ~ zeroOrMore(RelPredicateWithTypes | LatPredicateWithTypes | PredicateWithAlias).separatedBy(optWS ~ "," ~ optWS) ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ "}" ~ SP ~> ParsedAst.Type.Schema
+      }
+    }
+
+    def Schema: Rule1[ParsedAst.Type] = {
+      def PredicateWithAlias: Rule1[ParsedAst.PredicateType.PredicateWithAlias] = rule {
+        SP ~ Names.QualifiedPredicate ~ optional(TypeArguments) ~ SP ~> ParsedAst.PredicateType.PredicateWithAlias
+      }
+
+      def RelPredicateWithTypes: Rule1[ParsedAst.PredicateType.RelPredicateWithTypes] = rule {
+        SP ~ Names.Predicate ~ optWS ~ "(" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~ SP ~> ParsedAst.PredicateType.RelPredicateWithTypes
+      }
+
+      def LatPredicateWithTypes: Rule1[ParsedAst.PredicateType.LatPredicateWithTypes] = rule {
+        SP ~ Names.Predicate ~ optWS ~ "(" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ";" ~ optWS ~ Type ~ optWS ~ ")" ~ SP ~> ParsedAst.PredicateType.LatPredicateWithTypes
+      }
+
+      rule {
+        SP ~ atomic("#<") ~ optWS ~ zeroOrMore(RelPredicateWithTypes | LatPredicateWithTypes | PredicateWithAlias).separatedBy(optWS ~ "," ~ optWS) ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ ">" ~ SP ~> ParsedAst.Type.SchemaRow
       }
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1254,59 +1254,37 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def Record: Rule1[ParsedAst.Type] = {
-      def RecordFieldType: Rule1[ParsedAst.RecordFieldType] = rule {
-        SP ~ Names.Field ~ optWS ~ ":" ~ optWS ~ Type ~ SP ~> ParsedAst.RecordFieldType
-      }
-
       rule {
         SP ~ atomic("{") ~ optWS ~ zeroOrMore(RecordFieldType).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ "}" ~ SP ~> ParsedAst.Type.Record
       }
     }
 
-    def RecordRow: Rule1[ParsedAst.Type] = {
-      def RecordFieldType: Rule1[ParsedAst.RecordFieldType] = rule { // MATT dedupe
-        SP ~ Names.Field ~ optWS ~ ":" ~ optWS ~ Type ~ SP ~> ParsedAst.RecordFieldType
-      }
-
-      rule {
-        SP ~ atomic("<") ~ optWS ~ zeroOrMore(RecordFieldType).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ ">" ~ SP ~> ParsedAst.Type.RecordRow
-      }
+    def RecordRow: Rule1[ParsedAst.Type] = rule {
+      SP ~ atomic("<") ~ optWS ~ zeroOrMore(RecordFieldType).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ ">" ~ SP ~> ParsedAst.Type.RecordRow
     }
 
-    def Schema: Rule1[ParsedAst.Type] = {
-      def PredicateWithAlias: Rule1[ParsedAst.PredicateType.PredicateWithAlias] = rule {
-        SP ~ Names.QualifiedPredicate ~ optional(TypeArguments) ~ SP ~> ParsedAst.PredicateType.PredicateWithAlias
-      }
-
-      def RelPredicateWithTypes: Rule1[ParsedAst.PredicateType.RelPredicateWithTypes] = rule {
-        SP ~ Names.Predicate ~ optWS ~ "(" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~ SP ~> ParsedAst.PredicateType.RelPredicateWithTypes
-      }
-
-      def LatPredicateWithTypes: Rule1[ParsedAst.PredicateType.LatPredicateWithTypes] = rule {
-        SP ~ Names.Predicate ~ optWS ~ "(" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ";" ~ optWS ~ Type ~ optWS ~ ")" ~ SP ~> ParsedAst.PredicateType.LatPredicateWithTypes
-      }
-
-      rule {
-        SP ~ atomic("#{") ~ optWS ~ zeroOrMore(RelPredicateWithTypes | LatPredicateWithTypes | PredicateWithAlias).separatedBy(optWS ~ "," ~ optWS) ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ "}" ~ SP ~> ParsedAst.Type.Schema
-      }
+    private def RecordFieldType: Rule1[ParsedAst.RecordFieldType] = rule {
+      SP ~ Names.Field ~ optWS ~ ":" ~ optWS ~ Type ~ SP ~> ParsedAst.RecordFieldType
     }
 
-    def SchemaRow: Rule1[ParsedAst.Type] = {
-      def PredicateWithAlias: Rule1[ParsedAst.PredicateType.PredicateWithAlias] = rule {
-        SP ~ Names.QualifiedPredicate ~ optional(TypeArguments) ~ SP ~> ParsedAst.PredicateType.PredicateWithAlias
-      }
+    def Schema: Rule1[ParsedAst.Type] = rule {
+      SP ~ atomic("#{") ~ optWS ~ zeroOrMore(RelPredicateWithTypes | LatPredicateWithTypes | PredicateWithAlias).separatedBy(optWS ~ "," ~ optWS) ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ "}" ~ SP ~> ParsedAst.Type.Schema
+    }
 
-      def RelPredicateWithTypes: Rule1[ParsedAst.PredicateType.RelPredicateWithTypes] = rule {
-        SP ~ Names.Predicate ~ optWS ~ "(" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~ SP ~> ParsedAst.PredicateType.RelPredicateWithTypes
-      }
+    def SchemaRow: Rule1[ParsedAst.Type] = rule {
+      SP ~ atomic("#<") ~ optWS ~ zeroOrMore(RelPredicateWithTypes | LatPredicateWithTypes | PredicateWithAlias).separatedBy(optWS ~ "," ~ optWS) ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ ">" ~ SP ~> ParsedAst.Type.SchemaRow
+    }
 
-      def LatPredicateWithTypes: Rule1[ParsedAst.PredicateType.LatPredicateWithTypes] = rule {
-        SP ~ Names.Predicate ~ optWS ~ "(" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ";" ~ optWS ~ Type ~ optWS ~ ")" ~ SP ~> ParsedAst.PredicateType.LatPredicateWithTypes
-      }
+    private def PredicateWithAlias: Rule1[ParsedAst.PredicateType.PredicateWithAlias] = rule {
+      SP ~ Names.QualifiedPredicate ~ optional(TypeArguments) ~ SP ~> ParsedAst.PredicateType.PredicateWithAlias
+    }
 
-      rule {
-        SP ~ atomic("#<") ~ optWS ~ zeroOrMore(RelPredicateWithTypes | LatPredicateWithTypes | PredicateWithAlias).separatedBy(optWS ~ "," ~ optWS) ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ ">" ~ SP ~> ParsedAst.Type.SchemaRow
-      }
+    private def RelPredicateWithTypes: Rule1[ParsedAst.PredicateType.RelPredicateWithTypes] = rule {
+      SP ~ Names.Predicate ~ optWS ~ "(" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~ SP ~> ParsedAst.PredicateType.RelPredicateWithTypes
+    }
+
+    private def LatPredicateWithTypes: Rule1[ParsedAst.PredicateType.LatPredicateWithTypes] = rule {
+      SP ~ Names.Predicate ~ optWS ~ "(" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ";" ~ optWS ~ Type ~ optWS ~ ")" ~ SP ~> ParsedAst.PredicateType.LatPredicateWithTypes
     }
 
     def Native: Rule1[ParsedAst.Type] = rule {
@@ -1342,9 +1320,10 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       SP ~ Names.QualifiedType ~ SP ~> ParsedAst.Type.Ambiguous
     }
 
-    def TypeArguments: Rule1[Seq[ParsedAst.Type]] = rule {
+    private def TypeArguments: Rule1[Seq[ParsedAst.Type]] = rule {
       "[" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ "]"
     }
+
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1223,7 +1223,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def Primary: Rule1[ParsedAst.Type] = rule {
-      Arrow | Tuple | Record | Schema | Native | True | False | Pure | Impure | Not | Var | Ambiguous
+      Arrow | Tuple | Record | RecordRow | Schema | SchemaRow | Native | True | False | Pure | Impure | Not | Var | Ambiguous
     }
 
     def Arrow: Rule1[ParsedAst.Type] = {
@@ -1291,7 +1291,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       }
     }
 
-    def Schema: Rule1[ParsedAst.Type] = {
+    def SchemaRow: Rule1[ParsedAst.Type] = {
       def PredicateWithAlias: Rule1[ParsedAst.PredicateType.PredicateWithAlias] = rule {
         SP ~ Names.QualifiedPredicate ~ optional(TypeArguments) ~ SP ~> ParsedAst.PredicateType.PredicateWithAlias
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1254,37 +1254,41 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def Record: Rule1[ParsedAst.Type] = {
+      def RecordFieldType: Rule1[ParsedAst.RecordFieldType] = rule {
+        SP ~ Names.Field ~ optWS ~ ":" ~ optWS ~ Type ~ SP ~> ParsedAst.RecordFieldType
+      }
+
       rule {
         SP ~ atomic("{") ~ optWS ~ zeroOrMore(RecordFieldType).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ "}" ~ SP ~> ParsedAst.Type.Record
       }
     }
 
-    def RecordRow: Rule1[ParsedAst.Type] = rule {
-      SP ~ atomic("(") ~ optWS ~ zeroOrMore(RecordRowFieldType).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ ")" ~ SP ~> ParsedAst.Type.RecordRow
+    def RecordRow: Rule1[ParsedAst.Type] = {
+      def RecordRowFieldType: Rule1[ParsedAst.RecordFieldType] = rule {
+        SP ~ Names.Field ~ optWS ~ "::" ~ optWS ~ Type ~ SP ~> ParsedAst.RecordFieldType
+      }
+
+      rule {
+        SP ~ atomic("(") ~ optWS ~ zeroOrMore(RecordRowFieldType).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ ")" ~ SP ~> ParsedAst.Type.RecordRow
+      }
     }
 
-    private def RecordFieldType: Rule1[ParsedAst.RecordFieldType] = rule {
-      SP ~ Names.Field ~ optWS ~ ":" ~ optWS ~ Type ~ SP ~> ParsedAst.RecordFieldType
-    }
+    def Schema: Rule1[ParsedAst.Type] = {
+      def PredicateWithAlias: Rule1[ParsedAst.PredicateType.PredicateWithAlias] = rule {
+        SP ~ Names.QualifiedPredicate ~ optional(TypeArguments) ~ SP ~> ParsedAst.PredicateType.PredicateWithAlias
+      }
 
-    private def RecordRowFieldType: Rule1[ParsedAst.RecordFieldType] = rule {
-      SP ~ Names.Field ~ optWS ~ "::" ~ optWS ~ Type ~ SP ~> ParsedAst.RecordFieldType
-    }
+      def RelPredicateWithTypes: Rule1[ParsedAst.PredicateType.RelPredicateWithTypes] = rule {
+        SP ~ Names.Predicate ~ optWS ~ "(" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~ SP ~> ParsedAst.PredicateType.RelPredicateWithTypes
+      }
 
-    def Schema: Rule1[ParsedAst.Type] = rule {
-      SP ~ atomic("#{") ~ optWS ~ zeroOrMore(RelPredicateWithTypes | LatPredicateWithTypes | PredicateWithAlias).separatedBy(optWS ~ "," ~ optWS) ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ "}" ~ SP ~> ParsedAst.Type.Schema
-    }
+      def LatPredicateWithTypes: Rule1[ParsedAst.PredicateType.LatPredicateWithTypes] = rule {
+        SP ~ Names.Predicate ~ optWS ~ "(" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ";" ~ optWS ~ Type ~ optWS ~ ")" ~ SP ~> ParsedAst.PredicateType.LatPredicateWithTypes
+      }
 
-    private def PredicateWithAlias: Rule1[ParsedAst.PredicateType.PredicateWithAlias] = rule {
-      SP ~ Names.QualifiedPredicate ~ optional(TypeArguments) ~ SP ~> ParsedAst.PredicateType.PredicateWithAlias
-    }
-
-    private def RelPredicateWithTypes: Rule1[ParsedAst.PredicateType.RelPredicateWithTypes] = rule {
-      SP ~ Names.Predicate ~ optWS ~ "(" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~ SP ~> ParsedAst.PredicateType.RelPredicateWithTypes
-    }
-
-    private def LatPredicateWithTypes: Rule1[ParsedAst.PredicateType.LatPredicateWithTypes] = rule {
-      SP ~ Names.Predicate ~ optWS ~ "(" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ";" ~ optWS ~ Type ~ optWS ~ ")" ~ SP ~> ParsedAst.PredicateType.LatPredicateWithTypes
+      rule {
+        SP ~ atomic("#{") ~ optWS ~ zeroOrMore(RelPredicateWithTypes | LatPredicateWithTypes | PredicateWithAlias).separatedBy(optWS ~ "," ~ optWS) ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ "}" ~ SP ~> ParsedAst.Type.Schema
+      }
     }
 
     def Native: Rule1[ParsedAst.Type] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1223,7 +1223,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def Primary: Rule1[ParsedAst.Type] = rule {
-      Arrow | Tuple | Record | RecordRow | Schema | SchemaRow | Native | True | False | Pure | Impure | Not | Var | Ambiguous
+      Arrow | Tuple | Record | RecordRow | Schema | Native | True | False | Pure | Impure | Not | Var | Ambiguous
     }
 
     def Arrow: Rule1[ParsedAst.Type] = {
@@ -1260,19 +1260,19 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def RecordRow: Rule1[ParsedAst.Type] = rule {
-      SP ~ atomic("<") ~ optWS ~ zeroOrMore(RecordFieldType).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ ">" ~ SP ~> ParsedAst.Type.RecordRow
+      SP ~ atomic("(") ~ optWS ~ zeroOrMore(RecordRowFieldType).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ ")" ~ SP ~> ParsedAst.Type.RecordRow
     }
 
     private def RecordFieldType: Rule1[ParsedAst.RecordFieldType] = rule {
       SP ~ Names.Field ~ optWS ~ ":" ~ optWS ~ Type ~ SP ~> ParsedAst.RecordFieldType
     }
 
-    def Schema: Rule1[ParsedAst.Type] = rule {
-      SP ~ atomic("#{") ~ optWS ~ zeroOrMore(RelPredicateWithTypes | LatPredicateWithTypes | PredicateWithAlias).separatedBy(optWS ~ "," ~ optWS) ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ "}" ~ SP ~> ParsedAst.Type.Schema
+    private def RecordRowFieldType: Rule1[ParsedAst.RecordFieldType] = rule {
+      SP ~ Names.Field ~ optWS ~ "::" ~ optWS ~ Type ~ SP ~> ParsedAst.RecordFieldType
     }
 
-    def SchemaRow: Rule1[ParsedAst.Type] = rule {
-      SP ~ atomic("#<") ~ optWS ~ zeroOrMore(RelPredicateWithTypes | LatPredicateWithTypes | PredicateWithAlias).separatedBy(optWS ~ "," ~ optWS) ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ ">" ~ SP ~> ParsedAst.Type.SchemaRow
+    def Schema: Rule1[ParsedAst.Type] = rule {
+      SP ~ atomic("#{") ~ optWS ~ zeroOrMore(RelPredicateWithTypes | LatPredicateWithTypes | PredicateWithAlias).separatedBy(optWS ~ "," ~ optWS) ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ "}" ~ SP ~> ParsedAst.Type.Schema
     }
 
     private def PredicateWithAlias: Rule1[ParsedAst.PredicateType.PredicateWithAlias] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
@@ -702,8 +702,10 @@ object PatternExhaustiveness extends Phase[TypedAst.Root, TypedAst.Root] {
       case Some(TypeConstructor.ScopedRef) => 0
       case Some(TypeConstructor.Relation) => 0
       case Some(TypeConstructor.Lattice) => 0
-      case Some(TypeConstructor.RecordEmpty) => 0
-      case Some(TypeConstructor.SchemaEmpty) => 0
+      case Some(TypeConstructor.RecordRowEmpty) => 0
+      case Some(TypeConstructor.SchemaRowEmpty) => 0
+      case Some(TypeConstructor.MakeRecord) => 0
+      case Some(TypeConstructor.MakeSchema) => 0
       case Some(TypeConstructor.Arrow(length)) => length
       case Some(TypeConstructor.Array) => 1
       case Some(TypeConstructor.Channel) => 1
@@ -712,8 +714,8 @@ object PatternExhaustiveness extends Phase[TypedAst.Root, TypedAst.Root] {
       case Some(TypeConstructor.Tag(sym, tag)) => throw InternalCompilerException(s"Unexpected type: '$tpe'.")
       case Some(TypeConstructor.Native(clazz)) => 0
       case Some(TypeConstructor.Tuple(l)) => l
-      case Some(TypeConstructor.RecordExtend(_)) => 2
-      case Some(TypeConstructor.SchemaExtend(_)) => 2
+      case Some(TypeConstructor.RecordRowExtend(_)) => 2
+      case Some(TypeConstructor.SchemaRowExtend(_)) => 2
       case _ => throw InternalCompilerException(s"Unexpected type: '$tpe'.")
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
@@ -704,8 +704,8 @@ object PatternExhaustiveness extends Phase[TypedAst.Root, TypedAst.Root] {
       case Some(TypeConstructor.Lattice) => 0
       case Some(TypeConstructor.RecordRowEmpty) => 0
       case Some(TypeConstructor.SchemaRowEmpty) => 0
-      case Some(TypeConstructor.MakeRecord) => 0
-      case Some(TypeConstructor.MakeSchema) => 0
+      case Some(TypeConstructor.Record) => 0
+      case Some(TypeConstructor.Schema) => 0
       case Some(TypeConstructor.Arrow(length)) => length
       case Some(TypeConstructor.Array) => 1
       case Some(TypeConstructor.Channel) => 1

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1446,20 +1446,25 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
         tup = Type.mkTuple(elms, loc)
       } yield tup
 
-    case NamedAst.Type.RecordEmpty(loc) =>
-      Type.RecordEmpty.toSuccess
+    case NamedAst.Type.RecordRowEmpty(loc) =>
+      Type.RecordRowEmpty.toSuccess
 
-    case NamedAst.Type.RecordExtend(field, value, rest, loc) =>
+    case NamedAst.Type.RecordRowExtend(field, value, rest, loc) =>
       for {
         v <- lookupType(value, ns0, root)
         r <- lookupType(rest, ns0, root)
-        rec = Type.mkRecordExtend(field, v, r, loc)
+        rec = Type.mkRecordRowExtend(field, v, r, loc)
       } yield rec
 
-    case NamedAst.Type.SchemaEmpty(loc) =>
-      Type.SchemaEmpty.toSuccess
+    case NamedAst.Type.MakeRecord(row, loc) =>
+      for {
+        r <- lookupType(row, ns0, root)
+      } yield Type.Apply(Type.MakeRecord, r, loc)
 
-    case NamedAst.Type.SchemaExtendWithAlias(qname, targs, rest, loc) =>
+    case NamedAst.Type.SchemaRowEmpty(loc) =>
+      Type.SchemaRowEmpty.toSuccess
+
+    case NamedAst.Type.SchemaRowExtendWithAlias(qname, targs, rest, loc) =>
       // Lookup the type alias.
       lookupTypeAlias(qname, ns0, root) match {
         case None =>
@@ -1473,17 +1478,22 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
             r <- lookupType(rest, ns0, root)
             app = Type.mkApply(t, ts, loc)
             tpe = simplify(app)
-            schema = Type.mkSchemaExtend(Name.mkPred(qname.ident), tpe, r, loc)
+            schema = Type.mkSchemaRowExtend(Name.mkPred(qname.ident), tpe, r, loc)
           } yield schema
       }
 
-    case NamedAst.Type.SchemaExtendWithTypes(ident, den, tpes, rest, loc) =>
+    case NamedAst.Type.SchemaRowExtendWithTypes(ident, den, tpes, rest, loc) =>
       for {
         ts <- traverse(tpes)(lookupType(_, ns0, root))
         r <- lookupType(rest, ns0, root)
         pred = mkPredicate(den, ts, loc)
-        schema = Type.mkSchemaExtend(Name.mkPred(ident), pred, r, loc)
+        schema = Type.mkSchemaRowExtend(Name.mkPred(ident), pred, r, loc)
       } yield schema
+
+    case NamedAst.Type.MakeSchema(row, loc) =>
+      for {
+        r <- lookupType(row, ns0, root)
+      } yield Type.Apply(Type.MakeSchema, r, loc)
 
     case NamedAst.Type.Relation(tpes, loc) =>
       for {
@@ -1886,13 +1896,10 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
 
       case TypeConstructor.Native(clazz) => clazz.toSuccess
 
-      case TypeConstructor.RecordEmpty => Class.forName("java.lang.Object").toSuccess
+      case TypeConstructor.MakeRecord => Class.forName("java.lang.Object").toSuccess
 
-      case TypeConstructor.RecordExtend(_) => Class.forName("java.lang.Object").toSuccess
+      case TypeConstructor.MakeSchema => Class.forName("java.lang.Object").toSuccess
 
-      case TypeConstructor.SchemaEmpty => Class.forName("java.lang.Object").toSuccess
-
-      case TypeConstructor.SchemaExtend(_) => Class.forName("java.lang.Object").toSuccess
 
       case _ => ResolutionError.IllegalType(tpe, loc).toFailure
     }
@@ -1946,15 +1953,15 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
 
       case Type.Cst(_, _) => t
 
-      case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordExtend(field), _), tpe, _), rest, loc) =>
+      case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordRowExtend(field), _), tpe, _), rest, loc) => // MATT revisit this
         val t1 = eval(tpe, subst)
         val t2 = eval(rest, subst)
-        Type.mkRecordExtend(field, t1, t2, loc)
+        Type.mkRecordRowExtend(field, t1, t2, loc)
 
-      case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaExtend(pred), _), tpe, _), rest, loc) =>
+      case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(pred), _), tpe, _), rest, loc) => // MATT revisit this
         val t1 = eval(tpe, subst)
         val t2 = eval(rest, subst)
-        Type.mkSchemaExtend(pred, t1, t2, loc)
+        Type.mkSchemaRowExtend(pred, t1, t2, loc)
 
       case Type.Lambda(tvar, tpe, loc) => Type.Lambda(tvar, eval(tpe, subst), loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1456,10 +1456,10 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
         rec = Type.mkRecordRowExtend(field, v, r, loc)
       } yield rec
 
-    case NamedAst.Type.MakeRecord(row, loc) =>
+    case NamedAst.Type.Record(row, loc) =>
       for {
         r <- lookupType(row, ns0, root)
-      } yield Type.Apply(Type.MakeRecord, r, loc)
+      } yield Type.Apply(Type.Record, r, loc)
 
     case NamedAst.Type.SchemaRowEmpty(loc) =>
       Type.SchemaRowEmpty.toSuccess
@@ -1490,10 +1490,10 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
         schema = Type.mkSchemaRowExtend(Name.mkPred(ident), pred, r, loc)
       } yield schema
 
-    case NamedAst.Type.MakeSchema(row, loc) =>
+    case NamedAst.Type.Schema(row, loc) =>
       for {
         r <- lookupType(row, ns0, root)
-      } yield Type.Apply(Type.MakeSchema, r, loc)
+      } yield Type.Apply(Type.Schema, r, loc)
 
     case NamedAst.Type.Relation(tpes, loc) =>
       for {
@@ -1896,9 +1896,9 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
 
       case TypeConstructor.Native(clazz) => clazz.toSuccess
 
-      case TypeConstructor.MakeRecord => Class.forName("java.lang.Object").toSuccess
+      case TypeConstructor.Record => Class.forName("java.lang.Object").toSuccess
 
-      case TypeConstructor.MakeSchema => Class.forName("java.lang.Object").toSuccess
+      case TypeConstructor.Schema => Class.forName("java.lang.Object").toSuccess
 
 
       case _ => ResolutionError.IllegalType(tpe, loc).toFailure

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1459,7 +1459,7 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
     case NamedAst.Type.Record(row, loc) =>
       for {
         r <- lookupType(row, ns0, root)
-      } yield Type.Apply(Type.Record, r, loc)
+      } yield Type.mkRecord(r, loc)
 
     case NamedAst.Type.SchemaRowEmpty(loc) =>
       Type.SchemaRowEmpty.toSuccess
@@ -1493,7 +1493,7 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
     case NamedAst.Type.Schema(row, loc) =>
       for {
         r <- lookupType(row, ns0, root)
-      } yield Type.Apply(Type.Schema, r, loc)
+      } yield Type.mkSchema(r, loc)
 
     case NamedAst.Type.Relation(tpes, loc) =>
       for {

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1953,16 +1953,6 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
 
       case Type.Cst(_, _) => t
 
-      case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordRowExtend(field), _), tpe, _), rest, loc) => // MATT revisit this
-        val t1 = eval(tpe, subst)
-        val t2 = eval(rest, subst)
-        Type.mkRecordRowExtend(field, t1, t2, loc)
-
-      case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(pred), _), tpe, _), rest, loc) => // MATT revisit this
-        val t1 = eval(tpe, subst)
-        val t2 = eval(rest, subst)
-        Type.mkSchemaRowExtend(pred, t1, t2, loc)
-
       case Type.Lambda(tvar, tpe, loc) => Type.Lambda(tvar, eval(tpe, subst), loc)
 
       // TODO: Does not take variable capture into account.

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -872,7 +872,7 @@ object Stratifier extends Phase[Root, Root] {
     * Returns the set of predicates that appears in the given row type `tpe`.
     */
   private def predicateSymbolsOf(tpe: Type): Set[Name.Pred] = tpe.typeConstructors.foldLeft(Set.empty[Name.Pred]) {
-    case (acc, TypeConstructor.SchemaExtend(pred)) => acc + pred
+    case (acc, TypeConstructor.SchemaRowExtend(pred)) => acc + pred
     case (acc, _) => acc
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -1336,8 +1336,8 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
       case KindedAst.Expression.FixpointConstraintSet(cs, tvar, loc) =>
         for {
           (constrs, constraintTypes) <- seqM(cs.map(visitConstraint)).map(_.unzip)
-          aggConstraintType <- unifyTypeAllowEmptyM(constraintTypes, Kind.SchemaRow, loc)
-          resultTyp <- unifyTypeM(tvar, Type.mkSchema(aggConstraintType, loc), loc)
+          schemaRow <- unifyTypeAllowEmptyM(constraintTypes, Kind.SchemaRow, loc)
+          resultTyp <- unifyTypeM(tvar, Type.mkSchema(schemaRow, loc), loc)
         } yield (constrs.flatten, resultTyp, Type.Pure)
 
       case KindedAst.Expression.FixpointMerge(exp1, exp2, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -966,10 +966,13 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
         // ---------------------------------------------
         // { field = exp1 | exp2 } : { field : tpe | r }
         //
+        // MATT update these derivation things
+        val restRow = Type.freshVar(Kind.RecordRow, loc)
         for {
           (constrs1, tpe1, eff1) <- visitExp(exp1)
           (constrs2, tpe2, eff2) <- visitExp(exp2)
-          resultTyp <- unifyTypeM(tvar, Type.Apply(Type.MakeRecord, Type.mkRecordRowExtend(field, tpe1, tpe2, loc), loc), loc)
+          _ <- unifyTypeM(tpe2, Type.Apply(Type.MakeRecord, restRow, loc), loc)
+          resultTyp <- unifyTypeM(tvar, Type.Apply(Type.MakeRecord, Type.mkRecordRowExtend(field, tpe1, restRow, loc), loc), loc)
           resultEff = Type.mkAnd(eff1, eff2, loc)
         } yield (constrs1 ++ constrs2, resultTyp, resultEff)
 
@@ -983,7 +986,7 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
         for {
           (constrs, tpe, eff) <- visitExp(exp)
           recordType <- unifyTypeM(tpe, Type.Apply(Type.MakeRecord, Type.mkRecordRowExtend(field, freshFieldType, freshRowVar, loc), loc), loc)
-          resultTyp <- unifyTypeM(tvar, freshRowVar, loc)
+          resultTyp <- unifyTypeM(tvar, Type.Apply(Type.MakeRecord, freshRowVar, loc), loc)
           resultEff = eff
         } yield (constrs, resultTyp, resultEff)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -1421,7 +1421,7 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
           (constrs1, tpe1, eff1) <- visitExp(exp1)
           (constrs2, tpe2, eff2) <- visitExp(exp2)
           _ <- unifyTypeM(tpe1, expectedSchemaType, loc)
-          _ <- unifyTypeM(tpe2, Type.mkSchema(freshRestSchemaVar, loc), loc) // MATT ?
+          _ <- unifyTypeM(tpe2, Type.mkSchema(freshRestSchemaVar, loc), loc)
           resultTyp <- unifyTypeM(tvar, Type.mkArray(freshTupleVar, loc), loc)
           resultEff = Type.mkAnd(eff1, eff2, loc)
         } yield (constrs1 ++ constrs2, resultTyp, resultEff)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -1415,12 +1415,12 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
         val freshRelOrLat = Type.freshVar(Kind.Star ->: Kind.Predicate, loc)
         val freshTupleVar = Type.freshVar(Kind.Star, loc)
         val freshRestSchemaVar = Type.freshVar(Kind.SchemaRow, loc)
-
+        val expectedSchemaType = Type.Apply(Type.MakeSchema, Type.mkSchemaRowExtend(pred, Type.Apply(freshRelOrLat, freshTupleVar, loc), freshRestSchemaVar, loc), loc)
         for {
           (constrs1, tpe1, eff1) <- visitExp(exp1)
           (constrs2, tpe2, eff2) <- visitExp(exp2)
-          _ <- unifyTypeM(tpe1, Type.mkSchemaRowExtend(pred, Type.Apply(freshRelOrLat, freshTupleVar, loc), freshRestSchemaVar, loc), loc)
-          _ <- unifyTypeM(tpe2, freshRestSchemaVar, loc)
+          _ <- unifyTypeM(tpe1, expectedSchemaType, loc)
+          _ <- unifyTypeM(tpe2, Type.Apply(Type.MakeSchema, freshRestSchemaVar, loc), loc) // MATT ?
           resultTyp <- unifyTypeM(tvar, Type.mkArray(freshTupleVar, loc), loc)
           resultEff = Type.mkAnd(eff1, eff2, loc)
         } yield (constrs1 ++ constrs2, resultTyp, resultEff)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -942,7 +942,7 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
         //  { } : { }
         //
         for {
-          resultType <- unifyTypeM(tvar, Type.Apply(Type.Record, Type.RecordRowEmpty, loc), loc)
+          resultType <- unifyTypeM(tvar, Type.mkRecord(Type.RecordRowEmpty, loc), loc)
         } yield (List.empty, resultType, Type.Pure)
 
       case KindedAst.Expression.RecordSelect(exp, field, tvar, loc) =>
@@ -953,7 +953,7 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
         //
         val freshRowVar = Type.freshVar(Kind.RecordRow, loc)
         val expectedRowType = Type.mkRecordRowExtend(field, tvar, freshRowVar, loc)
-        val expectedRecordType = Type.Apply(Type.Record, expectedRowType, loc)
+        val expectedRecordType = Type.mkRecord(expectedRowType, loc)
         for {
           (constrs, tpe, eff) <- visitExp(exp)
           recordType <- unifyTypeM(tpe, expectedRecordType, loc)
@@ -970,8 +970,8 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
         for {
           (constrs1, tpe1, eff1) <- visitExp(exp1)
           (constrs2, tpe2, eff2) <- visitExp(exp2)
-          _ <- unifyTypeM(tpe2, Type.Apply(Type.Record, restRow, loc), loc)
-          resultTyp <- unifyTypeM(tvar, Type.Apply(Type.Record, Type.mkRecordRowExtend(field, tpe1, restRow, loc), loc), loc)
+          _ <- unifyTypeM(tpe2, Type.mkRecord(restRow, loc), loc)
+          resultTyp <- unifyTypeM(tvar, Type.mkRecord(Type.mkRecordRowExtend(field, tpe1, restRow, loc), loc), loc)
           resultEff = Type.mkAnd(eff1, eff2, loc)
         } yield (constrs1 ++ constrs2, resultTyp, resultEff)
 
@@ -985,8 +985,8 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
         val freshRowVar = Type.freshVar(Kind.RecordRow, loc)
         for {
           (constrs, tpe, eff) <- visitExp(exp)
-          recordType <- unifyTypeM(tpe, Type.Apply(Type.Record, Type.mkRecordRowExtend(field, freshFieldType, freshRowVar, loc), loc), loc)
-          resultTyp <- unifyTypeM(tvar, Type.Apply(Type.Record, freshRowVar, loc), loc)
+          recordType <- unifyTypeM(tpe, Type.mkRecord(Type.mkRecordRowExtend(field, freshFieldType, freshRowVar, loc), loc), loc)
+          resultTyp <- unifyTypeM(tvar, Type.mkRecord(freshRowVar, loc), loc)
           resultEff = eff
         } yield (constrs, resultTyp, resultEff)
 
@@ -1376,8 +1376,8 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
 
         for {
           (constrs, tpe, eff) <- visitExp(exp)
-          expectedType <- unifyTypeM(tpe, Type.Apply(Type.Schema, Type.mkSchemaRowExtend(pred, freshPredicateTypeVar, freshRestSchemaTypeVar, loc), loc), loc)
-          resultTyp <- unifyTypeM(tvar, Type.Apply(Type.Schema, Type.mkSchemaRowExtend(pred, freshPredicateTypeVar, freshResultSchemaTypeVar, loc), loc), loc)
+          expectedType <- unifyTypeM(tpe, Type.mkSchema(Type.mkSchemaRowExtend(pred, freshPredicateTypeVar, freshRestSchemaTypeVar, loc), loc), loc)
+          resultTyp <- unifyTypeM(tvar, Type.mkSchema(Type.mkSchemaRowExtend(pred, freshPredicateTypeVar, freshResultSchemaTypeVar, loc), loc), loc)
           resultEff = eff
         } yield (constrs, resultTyp, resultEff)
 
@@ -1401,7 +1401,7 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
         for {
           (constrs, tpe, eff) <- visitExp(exp)
           expectedType <- unifyTypeM(tpe, Type.mkApply(freshTypeConstructorVar, List(freshElmTypeVar), loc), loc)
-          resultTyp <- unifyTypeM(tvar, Type.Apply(Type.Schema, Type.mkSchemaRowExtend(pred, Type.mkRelation(List(freshElmTypeVar), loc), freshRestSchemaTypeVar, loc), loc), loc)
+          resultTyp <- unifyTypeM(tvar, Type.mkSchema(Type.mkSchemaRowExtend(pred, Type.mkRelation(List(freshElmTypeVar), loc), freshRestSchemaTypeVar, loc), loc), loc)
           resultEff = eff
         } yield (boxable :: foldable :: constrs, resultTyp, resultEff)
 
@@ -1415,12 +1415,12 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
         val freshRelOrLat = Type.freshVar(Kind.Star ->: Kind.Predicate, loc)
         val freshTupleVar = Type.freshVar(Kind.Star, loc)
         val freshRestSchemaVar = Type.freshVar(Kind.SchemaRow, loc)
-        val expectedSchemaType = Type.Apply(Type.Schema, Type.mkSchemaRowExtend(pred, Type.Apply(freshRelOrLat, freshTupleVar, loc), freshRestSchemaVar, loc), loc)
+        val expectedSchemaType = Type.mkSchema(Type.mkSchemaRowExtend(pred, Type.Apply(freshRelOrLat, freshTupleVar, loc), freshRestSchemaVar, loc), loc)
         for {
           (constrs1, tpe1, eff1) <- visitExp(exp1)
           (constrs2, tpe2, eff2) <- visitExp(exp2)
           _ <- unifyTypeM(tpe1, expectedSchemaType, loc)
-          _ <- unifyTypeM(tpe2, Type.Apply(Type.Schema, freshRestSchemaVar, loc), loc) // MATT ?
+          _ <- unifyTypeM(tpe2, Type.mkSchema(freshRestSchemaVar, loc), loc) // MATT ?
           resultTyp <- unifyTypeM(tvar, Type.mkArray(freshTupleVar, loc), loc)
           resultEff = Type.mkAnd(eff1, eff2, loc)
         } yield (constrs1 ++ constrs2, resultTyp, resultEff)
@@ -2017,7 +2017,7 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
         pureTermEffects <- unifyBoolM(Type.Pure, Type.mkAnd(termEffects, loc), loc)
         predicateType <- unifyTypeM(tvar, mkRelationOrLatticeType(pred.name, den, termTypes, root, loc), loc)
         tconstrs = getTermTypeClassConstraints(den, termTypes, root, loc)
-      } yield (termConstrs.flatten ++ tconstrs, Type.Apply(Type.Schema, Type.mkSchemaRowExtend(pred, predicateType, restRow, loc), loc))
+      } yield (termConstrs.flatten ++ tconstrs, Type.mkSchema(Type.mkSchemaRowExtend(pred, predicateType, restRow, loc), loc))
   }
 
   /**
@@ -2039,7 +2039,7 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
         termTypes <- seqM(terms.map(inferPattern(_, root)))
         predicateType <- unifyTypeM(tvar, mkRelationOrLatticeType(pred.name, den, termTypes, root, loc), loc)
         tconstrs = getTermTypeClassConstraints(den, termTypes, root, loc)
-      } yield (tconstrs, Type.Apply(Type.Schema, Type.mkSchemaRowExtend(pred, predicateType, restRow, loc), loc))
+      } yield (tconstrs, Type.mkSchema(Type.mkSchemaRowExtend(pred, predicateType, restRow, loc), loc))
 
     //
     //  exp : Bool
@@ -2152,7 +2152,7 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
   /**
     * Returns an open schema type.
     */
-  private def mkAnySchemaType(loc: SourceLocation)(implicit flix: Flix): Type = Type.Apply(Type.Schema, Type.freshVar(Kind.SchemaRow, loc), loc)
+  private def mkAnySchemaType(loc: SourceLocation)(implicit flix: Flix): Type = Type.mkSchema(Type.freshVar(Kind.SchemaRow, loc), loc)
 
   /**
     * Returns the Flix Type of a Java Class

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -949,7 +949,7 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
         //
         // r : { field = tpe | row }
         // -------------------------
-        // r.field : tpe
+        //       r.field : tpe
         //
         val freshRowVar = Type.freshVar(Kind.RecordRow, loc)
         val expectedRowType = Type.mkRecordRowExtend(field, tvar, freshRowVar, loc)
@@ -962,11 +962,10 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
 
       case KindedAst.Expression.RecordExtend(field, exp1, exp2, tvar, loc) =>
         //
-        // exp1 : tpe
+        //       exp1 : tpe        exp2 : {| r }
         // ---------------------------------------------
         // { field = exp1 | exp2 } : { field : tpe | r }
         //
-        // MATT update these derivation things
         val restRow = Type.freshVar(Kind.RecordRow, loc)
         for {
           (constrs1, tpe1, eff1) <- visitExp(exp1)
@@ -978,8 +977,9 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
 
       case KindedAst.Expression.RecordRestrict(field, exp, tvar, loc) =>
         //
-        // ----------------------
-        // { -field | r } : { r }
+        //  exp : { field : t | r }
+        // -------------------------
+        // { -field | exp } : {| r }
         //
         val freshFieldType = Type.freshVar(Kind.Star, loc)
         val freshRowVar = Type.freshVar(Kind.RecordRow, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1981,6 +1981,20 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
 
       WeededAst.Type.MakeRecord(row, mkSL(sp1, sp2))
 
+    case ParsedAst.Type.Record(sp1, fields, restOpt, sp2) => // MATT dedupe
+      // If rest is absent, then it is the empty record row
+      val rest = restOpt match {
+        case None => WeededAst.Type.RecordRowEmpty(mkSL(sp1, sp2))
+        case Some(name) => WeededAst.Type.Var(name, name.loc)
+      }
+
+      val row = fields.foldRight(rest) {
+        case (ParsedAst.RecordFieldType(ssp1, ident, t, ssp2), acc) =>
+          WeededAst.Type.RecordRowExtend(Name.mkField(ident), visitType(t), acc, mkSL(ssp1, ssp2))
+      }
+
+      row
+
     case ParsedAst.Type.Schema(sp1, predicates, restOpt, sp2) =>
       def buildSchema(base: WeededAst.Type): WeededAst.Type = {
         predicates.foldRight(base) {
@@ -2021,6 +2035,47 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
       }
 
       WeededAst.Type.MakeSchema(row, mkSL(sp1, sp2))
+
+    case ParsedAst.Type.Schema(sp1, predicates, restOpt, sp2) =>
+      def buildSchema(base: WeededAst.Type): WeededAst.Type = { // MATT dedupe also remove this func from original
+        predicates.foldRight(base) {
+          case (ParsedAst.PredicateType.PredicateWithAlias(ssp1, qname, targs, ssp2), acc) =>
+            val ts = targs match {
+              case None => Nil
+              case Some(xs) => xs.map(visitType).toList
+            }
+            WeededAst.Type.SchemaRowExtendByAlias(qname, ts, acc, mkSL(ssp1, ssp2))
+
+          case (ParsedAst.PredicateType.RelPredicateWithTypes(ssp1, name, ts, ssp2), acc) =>
+            WeededAst.Type.SchemaRowExtendByTypes(name, Ast.Denotation.Relational, ts.toList.map(visitType), acc, mkSL(ssp1, ssp2))
+
+          case (ParsedAst.PredicateType.LatPredicateWithTypes(ssp1, name, ts, tpe, ssp2), acc) =>
+            WeededAst.Type.SchemaRowExtendByTypes(name, Ast.Denotation.Latticenal, ts.toList.map(visitType) ::: visitType(tpe) :: Nil, acc, mkSL(ssp1, ssp2))
+        }
+      }
+
+      // If rest is absent, then it is the empty schema row
+      val rest = restOpt match {
+        case None => WeededAst.Type.SchemaRowEmpty(mkSL(sp1, sp2))
+        case Some(name) => WeededAst.Type.Var(name, name.loc)
+      }
+
+      val row = predicates.foldRight(rest) {
+        case (ParsedAst.PredicateType.PredicateWithAlias(ssp1, qname, targs, ssp2), acc) =>
+          val ts = targs match {
+            case None => Nil
+            case Some(xs) => xs.map(visitType).toList
+          }
+          WeededAst.Type.SchemaRowExtendByAlias(qname, ts, acc, mkSL(ssp1, ssp2))
+
+        case (ParsedAst.PredicateType.RelPredicateWithTypes(ssp1, name, ts, ssp2), acc) =>
+          WeededAst.Type.SchemaRowExtendByTypes(name, Ast.Denotation.Relational, ts.toList.map(visitType), acc, mkSL(ssp1, ssp2))
+
+        case (ParsedAst.PredicateType.LatPredicateWithTypes(ssp1, name, ts, tpe, ssp2), acc) =>
+          WeededAst.Type.SchemaRowExtendByTypes(name, Ast.Denotation.Latticenal, ts.toList.map(visitType) ::: visitType(tpe) :: Nil, acc, mkSL(ssp1, ssp2))
+      }
+
+      row
 
     case ParsedAst.Type.UnaryImpureArrow(tpe1, tpe2, sp2) =>
       val loc = mkSL(leftMostSourcePosition(tpe1), sp2)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -2523,7 +2523,9 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
     case ParsedAst.Type.Ambiguous(sp1, _, _) => sp1
     case ParsedAst.Type.Tuple(sp1, _, _) => sp1
     case ParsedAst.Type.Record(sp1, _, _, _) => sp1
+    case ParsedAst.Type.RecordRow(sp1, _, _, _) => sp1
     case ParsedAst.Type.Schema(sp1, _, _, _) => sp1
+    case ParsedAst.Type.SchemaRow(sp1, _, _, _) => sp1
     case ParsedAst.Type.UnaryImpureArrow(tpe1, _, _) => leftMostSourcePosition(tpe1)
     case ParsedAst.Type.UnaryPolymorphicArrow(tpe1, _, _, _) => leftMostSourcePosition(tpe1)
     case ParsedAst.Type.ImpureArrow(sp1, _, _, _) => sp1

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1970,14 +1970,14 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
 
     case ParsedAst.Type.Record(sp1, fields, restOpt, sp2) =>
       val row = buildRecordRow(fields, restOpt, mkSL(sp1, sp2))
-      WeededAst.Type.MakeRecord(row, mkSL(sp1, sp2))
+      WeededAst.Type.Record(row, mkSL(sp1, sp2))
 
     case ParsedAst.Type.RecordRow(sp1, fields, restOpt, sp2) =>
       buildRecordRow(fields, restOpt, mkSL(sp1, sp2))
 
     case ParsedAst.Type.Schema(sp1, predicates, restOpt, sp2) =>
       val row = buildSchemaRow(predicates, restOpt, mkSL(sp1, sp2))
-      WeededAst.Type.MakeSchema(row, mkSL(sp1, sp2))
+      WeededAst.Type.Schema(row, mkSL(sp1, sp2))
 
     case ParsedAst.Type.SchemaRow(sp1, predicates, restOpt, sp2) =>
       buildSchemaRow(predicates, restOpt, mkSL(sp1, sp2))

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1981,7 +1981,7 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
 
       WeededAst.Type.MakeRecord(row, mkSL(sp1, sp2))
 
-    case ParsedAst.Type.Record(sp1, fields, restOpt, sp2) => // MATT dedupe
+    case ParsedAst.Type.RecordRow(sp1, fields, restOpt, sp2) => // MATT dedupe
       // If rest is absent, then it is the empty record row
       val rest = restOpt match {
         case None => WeededAst.Type.RecordRowEmpty(mkSL(sp1, sp2))
@@ -2036,7 +2036,7 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
 
       WeededAst.Type.MakeSchema(row, mkSL(sp1, sp2))
 
-    case ParsedAst.Type.Schema(sp1, predicates, restOpt, sp2) =>
+    case ParsedAst.Type.SchemaRow(sp1, predicates, restOpt, sp2) =>
       def buildSchema(base: WeededAst.Type): WeededAst.Type = { // MATT dedupe also remove this func from original
         predicates.foldRight(base) {
           case (ParsedAst.PredicateType.PredicateWithAlias(ssp1, qname, targs, ssp2), acc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -771,9 +771,25 @@ object JvmOps {
     case MonoType.Lattice(attr) => Type.mkLattice(attr.map(hackMonoType2Type), SourceLocation.Unknown)
     case MonoType.Tuple(length) => Type.mkTuple(Nil, SourceLocation.Unknown) // hack
     case MonoType.RecordEmpty() => Type.Apply(Type.MakeRecord, Type.RecordRowEmpty, SourceLocation.Unknown)
-    case MonoType.RecordExtend(field, value, rest) => Type.Apply(Type.MakeRecord, Type.mkRecordRowExtend(Name.Field(field, SourceLocation.Unknown), hackMonoType2Type(value), hackMonoType2Type(rest).typeArguments.head, SourceLocation.Unknown), SourceLocation.Unknown)
+    case MonoType.RecordExtend(field, value, rest) => Type.Apply(Type.MakeRecord, hackMonoType2RecordRowType(tpe), SourceLocation.Unknown)
     case MonoType.SchemaEmpty() => Type.Apply(Type.MakeSchema, Type.RecordRowEmpty, SourceLocation.Unknown)
-    case MonoType.SchemaExtend(sym, t, rest) => Type.Apply(Type.MakeSchema, Type.mkSchemaRowExtend(Name.Pred(sym, SourceLocation.Unknown), hackMonoType2Type(t), hackMonoType2Type(rest).typeArguments.head, SourceLocation.Unknown), SourceLocation.Unknown)
+    case MonoType.SchemaExtend(sym, t, rest) => Type.Apply(Type.MakeSchema, hackMonoType2SchemaRowType(tpe), SourceLocation.Unknown)
+  }
+
+  // TODO: Remove
+  private def hackMonoType2RecordRowType(tpe: MonoType): Type = tpe match {
+    case MonoType.RecordExtend(field, value, rest) => Type.mkRecordRowExtend(Name.Field(field, SourceLocation.Unknown), hackMonoType2Type(value), hackMonoType2RecordRowType(rest), SourceLocation.Unknown)
+    case MonoType.RecordEmpty() => Type.RecordRowEmpty
+    case MonoType.Var(id) => Type.KindedVar(id, Kind.RecordRow, SourceLocation.Unknown)
+    case _ => throw InternalCompilerException("Unexpected non-row type.")
+  }
+
+  // TODO: Remove
+  private def hackMonoType2SchemaRowType(tpe: MonoType): Type = tpe match {
+    case MonoType.SchemaExtend(sym, t, rest) => Type.mkSchemaRowExtend(Name.Pred(sym, SourceLocation.Unknown), hackMonoType2Type(t), hackMonoType2SchemaRowType(rest), SourceLocation.Unknown)
+    case MonoType.SchemaEmpty() => Type.SchemaRowEmpty
+    case MonoType.Var(id) => Type.KindedVar(id, Kind.RecordRow, SourceLocation.Unknown)
+    case _ => throw InternalCompilerException("Unexpected non-row type.")
   }
 
   // TODO: Remove

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -770,10 +770,10 @@ object JvmOps {
     case MonoType.Relation(attr) => Type.mkRelation(attr.map(hackMonoType2Type), SourceLocation.Unknown)
     case MonoType.Lattice(attr) => Type.mkLattice(attr.map(hackMonoType2Type), SourceLocation.Unknown)
     case MonoType.Tuple(length) => Type.mkTuple(Nil, SourceLocation.Unknown) // hack
-    case MonoType.RecordEmpty() => Type.RecordEmpty
-    case MonoType.RecordExtend(field, value, rest) => Type.mkRecordExtend(Name.Field(field, SourceLocation.Unknown), hackMonoType2Type(value), hackMonoType2Type(rest), SourceLocation.Unknown)
-    case MonoType.SchemaEmpty() => Type.SchemaEmpty
-    case MonoType.SchemaExtend(sym, t, rest) => Type.mkSchemaExtend(Name.Pred(sym, SourceLocation.Unknown), hackMonoType2Type(t), hackMonoType2Type(rest), SourceLocation.Unknown)
+    case MonoType.RecordEmpty() => Type.Apply(Type.MakeRecord, Type.RecordRowEmpty, SourceLocation.Unknown)
+    case MonoType.RecordExtend(field, value, rest) => Type.Apply(Type.MakeRecord, Type.mkRecordRowExtend(Name.Field(field, SourceLocation.Unknown), hackMonoType2Type(value), hackMonoType2Type(rest).typeArguments.head, SourceLocation.Unknown), SourceLocation.Unknown)
+    case MonoType.SchemaEmpty() => Type.Apply(Type.MakeSchema, Type.RecordRowEmpty, SourceLocation.Unknown)
+    case MonoType.SchemaExtend(sym, t, rest) => Type.Apply(Type.MakeSchema, Type.mkSchemaRowExtend(Name.Pred(sym, SourceLocation.Unknown), hackMonoType2Type(t), hackMonoType2Type(rest).typeArguments.head, SourceLocation.Unknown), SourceLocation.Unknown)
   }
 
   // TODO: Remove

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -770,10 +770,10 @@ object JvmOps {
     case MonoType.Relation(attr) => Type.mkRelation(attr.map(hackMonoType2Type), SourceLocation.Unknown)
     case MonoType.Lattice(attr) => Type.mkLattice(attr.map(hackMonoType2Type), SourceLocation.Unknown)
     case MonoType.Tuple(length) => Type.mkTuple(Nil, SourceLocation.Unknown) // hack
-    case MonoType.RecordEmpty() => Type.Apply(Type.MakeRecord, Type.RecordRowEmpty, SourceLocation.Unknown)
-    case MonoType.RecordExtend(field, value, rest) => Type.Apply(Type.MakeRecord, hackMonoType2RecordRowType(tpe), SourceLocation.Unknown)
-    case MonoType.SchemaEmpty() => Type.Apply(Type.MakeSchema, Type.RecordRowEmpty, SourceLocation.Unknown)
-    case MonoType.SchemaExtend(sym, t, rest) => Type.Apply(Type.MakeSchema, hackMonoType2SchemaRowType(tpe), SourceLocation.Unknown)
+    case MonoType.RecordEmpty() => Type.Apply(Type.Record, Type.RecordRowEmpty, SourceLocation.Unknown)
+    case MonoType.RecordExtend(field, value, rest) => Type.Apply(Type.Record, hackMonoType2RecordRowType(tpe), SourceLocation.Unknown)
+    case MonoType.SchemaEmpty() => Type.Apply(Type.Schema, Type.RecordRowEmpty, SourceLocation.Unknown)
+    case MonoType.SchemaExtend(sym, t, rest) => Type.Apply(Type.Schema, hackMonoType2SchemaRowType(tpe), SourceLocation.Unknown)
   }
 
   // TODO: Remove

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -770,10 +770,10 @@ object JvmOps {
     case MonoType.Relation(attr) => Type.mkRelation(attr.map(hackMonoType2Type), SourceLocation.Unknown)
     case MonoType.Lattice(attr) => Type.mkLattice(attr.map(hackMonoType2Type), SourceLocation.Unknown)
     case MonoType.Tuple(length) => Type.mkTuple(Nil, SourceLocation.Unknown) // hack
-    case MonoType.RecordEmpty() => Type.Apply(Type.Record, Type.RecordRowEmpty, SourceLocation.Unknown)
-    case MonoType.RecordExtend(field, value, rest) => Type.Apply(Type.Record, hackMonoType2RecordRowType(tpe), SourceLocation.Unknown)
-    case MonoType.SchemaEmpty() => Type.Apply(Type.Schema, Type.RecordRowEmpty, SourceLocation.Unknown)
-    case MonoType.SchemaExtend(sym, t, rest) => Type.Apply(Type.Schema, hackMonoType2SchemaRowType(tpe), SourceLocation.Unknown)
+    case MonoType.RecordEmpty() => Type.mkRecord(Type.RecordRowEmpty, SourceLocation.Unknown)
+    case MonoType.RecordExtend(field, value, rest) => Type.mkRecord(hackMonoType2RecordRowType(tpe), SourceLocation.Unknown)
+    case MonoType.SchemaEmpty() => Type.mkSchema(Type.RecordRowEmpty, SourceLocation.Unknown)
+    case MonoType.SchemaExtend(sym, t, rest) => Type.mkSchema(hackMonoType2SchemaRowType(tpe), SourceLocation.Unknown)
   }
 
   // TODO: Remove

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -32,7 +32,6 @@ object Unification {
     if (x.id == y.id) {
       Result.Ok(Substitution.empty)
     } else {
-      // MATT removed kind checks
       (x.rigidity, y.rigidity) match {
         // Case 1: x is flexible
         case (Rigidity.Flexible, _) => Result.Ok(Substitution.singleton(x, y))
@@ -60,12 +59,6 @@ object Unification {
     // Check if `x` occurs within `tpe`.
     if (tpe.typeVars contains x) {
       return Result.Err(UnificationError.OccursCheck(x, tpe))
-    }
-
-    // MATT
-    // Check if the kind of `x` matches the kind of `tpe`.
-    if (Kinder.unify(tpe.kind, x.kind).isEmpty) {
-      return Result.Err(UnificationError.MismatchedKinds(x.kind, tpe.kind))
     }
 
     Result.Ok(Substitution.singleton(x, tpe))
@@ -273,9 +266,6 @@ object Unification {
 
         case Result.Err(UnificationError.NonSchemaType(tpe)) =>
           Err(TypeError.NonSchemaType(tpe, loc))
-
-        case Result.Err(UnificationError.MismatchedKinds(kind1, kind2)) =>
-          Err(TypeError.MismatchedKinds(type1, type2, kind1, kind2, loc))
 
         case Result.Err(err: UnificationError.NoMatchingInstance) =>
           throw InternalCompilerException(s"Unexpected unification error: $err")

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.language.phase.unification
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast._
 import ca.uwaterloo.flix.language.errors.TypeError
+import ca.uwaterloo.flix.language.phase.Kinder
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
 import ca.uwaterloo.flix.util.{InternalCompilerException, Result}
 
@@ -62,14 +63,13 @@ object Unification {
     }
 
     // MATT
-//    // Check if the kind of `x` matches the kind of `tpe`.
-//    if (!(tpe.kind == x.kind)) {
-//      return Result.Err(UnificationError.MismatchedKinds(x.kind, tpe.kind))
-//    }
+    // Check if the kind of `x` matches the kind of `tpe`.
+    if (Kinder.unify(tpe.kind, x.kind).isEmpty) {
+      return Result.Err(UnificationError.MismatchedKinds(x.kind, tpe.kind))
+    }
 
     Result.Ok(Substitution.singleton(x, tpe))
   }
-
 
   /**
     * Unifies the two given types `tpe1` and `tpe2`.
@@ -314,9 +314,9 @@ object Unification {
   /**
     * Unifies all the types in the given (possibly empty) list `ts`.
     */
-  def unifyTypeAllowEmptyM(ts: List[Type], loc: SourceLocation)(implicit flix: Flix): InferMonad[Type] = {
+  def unifyTypeAllowEmptyM(ts: List[Type], kind: Kind, loc: SourceLocation)(implicit flix: Flix): InferMonad[Type] = {
     if (ts.isEmpty)
-      liftM(Type.freshVar(Kind.Star, loc))
+      liftM(Type.freshVar(kind, loc))
     else
       unifyTypeM(ts, loc)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -31,15 +31,14 @@ object Unification {
     if (x.id == y.id) {
       Result.Ok(Substitution.empty)
     } else {
+      // MATT removed kind checks
       (x.rigidity, y.rigidity) match {
-        // Case 1: x is flexible and a superkind of y // MATT improve this
-        case (Rigidity.Flexible, _) if y.kind == x.kind => Result.Ok(Substitution.singleton(x, y))
-        // Case 2: y is flexible and a superkind of x
-        case (_, Rigidity.Flexible) if x.kind == y.kind => Result.Ok(Substitution.singleton(y, x))
+        // Case 1: x is flexible
+        case (Rigidity.Flexible, _) => Result.Ok(Substitution.singleton(x, y))
+        // Case 2: y is flexible
+        case (_, Rigidity.Flexible) => Result.Ok(Substitution.singleton(y, x))
         // Case 3: both variables are rigid
         case (Rigidity.Rigid, Rigidity.Rigid) => Result.Err(UnificationError.RigidVar(x, y))
-        // Case 4: at least one variable is flexible but not a superkind of the other
-        case _ => Result.Err(UnificationError.MismatchedKinds(x.kind, y.kind))
       }
     }
   }
@@ -62,10 +61,11 @@ object Unification {
       return Result.Err(UnificationError.OccursCheck(x, tpe))
     }
 
-    // Check if the kind of `x` matches the kind of `tpe`.
-    if (!(tpe.kind == x.kind)) {
-      return Result.Err(UnificationError.MismatchedKinds(x.kind, tpe.kind))
-    }
+    // MATT
+//    // Check if the kind of `x` matches the kind of `tpe`.
+//    if (!(tpe.kind == x.kind)) {
+//      return Result.Err(UnificationError.MismatchedKinds(x.kind, tpe.kind))
+//    }
 
     Result.Ok(Substitution.singleton(x, tpe))
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/UnificationError.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/UnificationError.scala
@@ -97,14 +97,6 @@ object UnificationError {
   case class NonSchemaType(nonSchemaType: Type) extends UnificationError
 
   /**
-    * A unification error due to an mismatch in type variable kinds.
-    *
-    * @param kind1 the first kind.
-    * @param kind2 the second kind.
-    */
-  case class MismatchedKinds(kind1: Kind, kind2: Kind) extends UnificationError
-
-  /**
     * A unification error resulting from a type constraint with no matching instance.
     *
     * @param tconstr the type constraint.

--- a/main/test/ca/uwaterloo/flix/language/debug/TestFormatType.scala
+++ b/main/test/ca/uwaterloo/flix/language/debug/TestFormatType.scala
@@ -47,7 +47,7 @@ class TestFormatType extends FunSuite with TestUtils {
   test("FormatType.WellFormedType.RecordRow.External.01") {
     val tpe = Type.mkRecordRowExtend(Name.Field("x", loc), Type.Int32, Type.mkRecordRowExtend(Name.Field("y", loc), Type.Str, Type.RecordRowEmpty, loc), loc)
 
-    val expected = "< x: Int32, y: String >"
+    val expected = "( x :: Int32, y :: String )"
     val actual = FormatType.formatType(tpe)(Audience.External)
 
     assert(actual == expected)
@@ -57,7 +57,7 @@ class TestFormatType extends FunSuite with TestUtils {
     val rest = Type.KindedVar(0, Kind.RecordRow, loc, Rigidity.Rigid)
     val tpe = Type.mkRecordRowExtend(Name.Field("x", loc), Type.Int32, rest, loc)
 
-    val expected = "< x: Int32 | '0 >"
+    val expected = "( x :: Int32 | '0 )"
     val actual = FormatType.formatType(tpe)(Audience.External)
 
     assert(actual == expected)
@@ -141,7 +141,7 @@ class TestFormatType extends FunSuite with TestUtils {
     val relationType = Type.mkRelation(Type.Int32 :: Type.Str :: Nil, loc)
     val tpe = Type.mkSchemaRowExtend(Name.Pred("S", loc), relationType, Type.SchemaRowEmpty, loc)
 
-    val expected = "#< S(Int32, String) >"
+    val expected = "#( S(Int32, String) )"
     val actual = FormatType.formatType(tpe)(Audience.External)
 
     assert(actual == expected)
@@ -153,7 +153,7 @@ class TestFormatType extends FunSuite with TestUtils {
     val restType = Type.KindedVar(5, Kind.SchemaRow, loc, Rigidity.Flexible)
     val tpe = Type.mkSchemaRowExtend(Name.Pred("A", loc), latticeType1, Type.mkSchemaRowExtend(Name.Pred("B", loc), latticeType2, restType, loc), loc)
 
-    val expected = "#< A<>(String), B<>(Int32, String) | '5 >"
+    val expected = "#( A<>(String), B<>(Int32, String) | '5 )"
     val actual = FormatType.formatType(tpe)(Audience.External)
 
     assert(actual == expected)

--- a/main/test/ca/uwaterloo/flix/language/debug/TestFormatType.scala
+++ b/main/test/ca/uwaterloo/flix/language/debug/TestFormatType.scala
@@ -44,6 +44,25 @@ class TestFormatType extends FunSuite with TestUtils {
     assert(actual == expected)
   }
 
+  test("FormatType.WellFormedType.RecordRow.External.01") {
+    val tpe = Type.mkRecordRowExtend(Name.Field("x", loc), Type.Int32, Type.mkRecordRowExtend(Name.Field("y", loc), Type.Str, Type.RecordRowEmpty, loc), loc)
+
+    val expected = "< x: Int32, y: String >"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.RecordRow.External.02") {
+    val rest = Type.KindedVar(0, Kind.RecordRow, loc, Rigidity.Rigid)
+    val tpe = Type.mkRecordRowExtend(Name.Field("x", loc), Type.Int32, rest, loc)
+
+    val expected = "< x: Int32 | '0 >"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
   test("FormatWellFormedType.Arrow.External.01") {
     val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
     val tpe = Type.mkArrowWithEffect(paramType, Type.Pure, paramType, loc)
@@ -113,6 +132,28 @@ class TestFormatType extends FunSuite with TestUtils {
     val tpe = Type.mkSchema(Type.mkSchemaRowExtend(Name.Pred("A", loc), latticeType1, Type.mkSchemaRowExtend(Name.Pred("B", loc), latticeType2, restType, loc), loc), loc)
 
     val expected = "#{ A<>(String), B<>(Int32, String) | '5 }"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.SchemaRow.External.01") {
+    val relationType = Type.mkRelation(Type.Int32 :: Type.Str :: Nil, loc)
+    val tpe = Type.mkSchemaRowExtend(Name.Pred("S", loc), relationType, Type.SchemaRowEmpty, loc)
+
+    val expected = "#< S(Int32, String) >"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.SchemaRow.External.02") {
+    val latticeType1 = Type.mkLattice(List(Type.Str), loc)
+    val latticeType2 = Type.mkLattice(List(Type.Int32, Type.Str), loc)
+    val restType = Type.KindedVar(5, Kind.SchemaRow, loc, Rigidity.Flexible)
+    val tpe = Type.mkSchemaRowExtend(Name.Pred("A", loc), latticeType1, Type.mkSchemaRowExtend(Name.Pred("B", loc), latticeType2, restType, loc), loc)
+
+    val expected = "#< A<>(String), B<>(Int32, String) | '5 >"
     val actual = FormatType.formatType(tpe)(Audience.External)
 
     assert(actual == expected)

--- a/main/test/ca/uwaterloo/flix/language/debug/TestFormatType.scala
+++ b/main/test/ca/uwaterloo/flix/language/debug/TestFormatType.scala
@@ -22,329 +22,292 @@ import ca.uwaterloo.flix.util.vt.{TerminalContext, VirtualString}
 import org.scalatest.FunSuite
 
 class TestFormatType extends FunSuite with TestUtils {
-  // MATT disabling for now
-//
-//  val loc: SourceLocation = SourceLocation.Unknown
-//
-//  test("FormatType.WellFormedType.Record.External.01") {
-//    val tpe = Type.mkRecordExtend(Name.Field("x", loc), Type.Int32, Type.mkRecordExtend(Name.Field("y", loc), Type.Str, Type.RecordEmpty, loc), loc)
-//
-//    val expected = "{ x: Int32, y: String }"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatWellFormedType.Record.External.02") {
-//    val rest = Type.KindedVar(0, Kind.Record, loc, Rigidity.Rigid)
-//    val tpe = Type.mkRecordExtend(Name.Field("x", loc), Type.Int32, rest, loc)
-//
-//    val expected = "{ x: Int32 | '0 }"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatWellFormedType.Arrow.External.01") {
-//    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
-//    val tpe = Type.mkArrowWithEffect(paramType, Type.Pure, paramType, loc)
-//
-//    val expected = "'0 -> '0"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatWellFormedType.Arrow.External.02") {
-//    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
-//    val returnType = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
-//    val effectType = Type.KindedVar(2, Kind.Bool, loc, Rigidity.Rigid)
-//    val tpe = Type.mkArrowWithEffect(paramType, effectType, returnType, loc)
-//
-//    val expected = "'0 -> '1 & '2"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatWellFormedType.Arrow.External.03") {
-//    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
-//    val returnType = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
-//    val tpe = Type.mkArrowWithEffect(paramType, Type.Impure, returnType, loc)
-//
-//    val expected = "'0 ~> '1"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatWellFormedType.Arrow.External.04") {
-//    val tpe = Type.mkImpureUncurriedArrow(Type.Int8 :: Type.Int16 :: Nil, Type.Int32, loc)
-//
-//    val expected = "Int8 -> Int16 ~> Int32"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatWellFormedType.Arrow.External.05") {
-//    val eff = Type.mkAnd(Type.KindedVar(1, Kind.Bool, loc, Rigidity.Flexible), Type.KindedVar(2, Kind.Bool, loc, Rigidity.Flexible), loc)
-//    val tpe = Type.mkArrowWithEffect(Type.BigInt, eff, Type.Bool, loc)
-//
-//    val expected = "BigInt -> Bool & ('1 ∧ '2)"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatWellFormedType.Schema.External.01") {
-//    val relationType = Type.mkRelation(Type.Int32 :: Type.Str :: Nil, loc)
-//    val tpe = Type.mkSchemaExtend(Name.Pred("S", loc), relationType, Type.SchemaEmpty, loc)
-//
-//    val expected = "#{ S(Int32, String) }"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatWellFormedType.Schema.External.02") {
-//    val latticeType1 = Type.mkLattice(List(Type.Str), loc)
-//    val latticeType2 = Type.mkLattice(List(Type.Int32, Type.Str), loc)
-//    val restType = Type.KindedVar(5, Kind.Schema, loc, Rigidity.Flexible)
-//    val tpe = Type.mkSchemaExtend(Name.Pred("A", loc), latticeType1, Type.mkSchemaExtend(Name.Pred("B", loc), latticeType2, restType, loc), loc)
-//
-//    val expected = "#{ A<>(String), B<>(Int32, String) | '5 }"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatWellFormedType.Enum.External.07") {
-//    val tvar1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Flexible)
-//    val tvar2 = Type.KindedVar(2, Kind.Star, loc, Rigidity.Flexible)
-//    val tvar3 = Type.KindedVar(3, Kind.Star, loc, Rigidity.Flexible)
-//    val tpe = Type.mkEnum(Symbol.mkEnumSym("Triplet"), List(tvar1, tvar2, tvar3), loc)
-//
-//    val expected = "Triplet['1, '2, '3]"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatType.WellFormedType.Record.Internal.01") {
-//    val tpe = Type.mkRecordExtend(Name.Field("x", loc), Type.Int32, Type.mkRecordExtend(Name.Field("y", loc), Type.Str, Type.RecordEmpty, loc), loc)
-//
-//    val expected = "{ x: Int32, y: String }"
-//    val actual = FormatType.formatType(tpe)(Audience.Internal)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatWellFormedType.Record.Internal.02") {
-//    val rest = Type.KindedVar(0, Kind.Record, loc, Rigidity.Rigid)
-//    val tpe = Type.mkRecordExtend(Name.Field("x", loc), Type.Int32, rest, loc)
-//
-//    val expected = "{ x: Int32 | '0 }"
-//    val actual = FormatType.formatType(tpe)(Audience.Internal)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatWellFormedType.Arrow.Internal.01") {
-//    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
-//    val tpe = Type.mkArrowWithEffect(paramType, Type.Pure, paramType, loc)
-//
-//    val expected = "'0 -> '0"
-//    val actual = FormatType.formatType(tpe)(Audience.Internal)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatWellFormedType.Arrow.Internal.02") {
-//    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
-//    val returnType = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
-//    val effectType = Type.KindedVar(2, Kind.Bool, loc, Rigidity.Rigid)
-//    val tpe = Type.mkArrowWithEffect(paramType, effectType, returnType, loc)
-//
-//    val expected = "'0 -> '1 & ''2"
-//    val actual = FormatType.formatType(tpe)(Audience.Internal)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatWellFormedType.Schema.Internal.01") {
-//    val relationType = Type.mkRelation(List(Type.Int32, Type.Str), loc)
-//    val tpe = Type.mkSchemaExtend(Name.Pred("S", loc), relationType, Type.SchemaEmpty, loc)
-//
-//    val expected = "#{ S(Int32, String) }"
-//    val actual = FormatType.formatType(tpe)(Audience.Internal)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatWellFormedType.Schema.Internal.02") {
-//    val latticeType1 = Type.mkLattice(List(Type.Str), loc)
-//    val latticeType2 = Type.mkLattice(List(Type.Int32, Type.Str), loc)
-//    val restType = Type.KindedVar(5, Kind.Schema, loc, Rigidity.Flexible)
-//    val tpe = Type.mkSchemaExtend(Name.Pred("A", loc), latticeType1, Type.mkSchemaExtend(Name.Pred("B", loc), latticeType2, restType, loc), loc)
-//
-//    val expected = "#{ A<>(String), B<>(Int32, String) | '5 }"
-//    val actual = FormatType.formatType(tpe)(Audience.Internal)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatWellFormedType.Enum.Internal.07") {
-//    val tvar1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Flexible)
-//    val tvar2 = Type.KindedVar(2, Kind.Star, loc, Rigidity.Flexible)
-//    val tvar3 = Type.KindedVar(3, Kind.Star, loc, Rigidity.Flexible)
-//    val tpe = Type.mkEnum(Symbol.mkEnumSym("Triplet"), List(tvar1, tvar2, tvar3), loc)
-//
-//    val expected = "Triplet['1, '2, '3]"
-//    val actual = FormatType.formatType(tpe)(Audience.Internal)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatIllFormedType.Record.External.01") {
-//    val tpe = Type.Cst(TypeConstructor.RecordExtend(Name.Field("x", loc)), loc)
-//
-//    val expected = "{ x: ??? }"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatIllFormedType.Record.External.02") {
-//    val tpe = Type.Apply(Type.Cst(TypeConstructor.RecordExtend(Name.Field("x", loc)), loc), Type.Int32, loc)
-//
-//    val expected = "{ x: Int32 | ??? }"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatIllFormedType.Schema.External.01") {
-//    val tpe = Type.Cst(TypeConstructor.SchemaExtend(Name.Pred("X", loc)), loc)
-//
-//    val expected = "#{ X?(???) }"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatIllFormedType.Schema.External.02") {
-//    val tpe = Type.Apply(Type.Cst(TypeConstructor.SchemaExtend(Name.Pred("X", loc)), loc), Type.Int32, loc)
-//
-//    val expected = "#{ X?(Int32) | ??? }"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatIllFormedType.Tuple.External.01") {
-//    val tpe = Type.mkApply(Type.Cst(TypeConstructor.Tuple(2), loc), List(Type.Str), loc)
-//
-//    val expected = "(String, ???)"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatIllFormedType.Effect.External.01") {
-//    val tpe = Type.Not
-//
-//    val expected = "¬???"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatIllFormedType.Effect.External.03") {
-//    val tpe = Type.And
-//
-//    val expected = "??? ∧ ???"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatIllFormedType.Effect.External.04") {
-//    val tpe = Type.Apply(Type.And, Type.Pure, loc)
-//
-//    val expected = "(true) ∧ ???"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatIllFormedType.Effect.External.06") {
-//    val tpe = Type.Or
-//
-//    val expected = "??? ∨ ???"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatIllFormedType.Effect.External.07") {
-//    val tpe = Type.Apply(Type.Or, Type.Pure, loc)
-//
-//    val expected = "(true) ∨ ???"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatIllFormedType.Arrow.External.01") {
-//    val tpe = Type.Apply(Type.Cst(TypeConstructor.Arrow(2), loc), Type.Pure, loc)
-//
-//    val expected = "??? -> ???"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatIllFormedType.Arrow.External.02") {
-//    val tpe = Type.mkApply(Type.Cst(TypeConstructor.Arrow(3), loc), List(Type.Impure, Type.Str), loc)
-//
-//    val expected = "String -> ??? ~> ???"
-//    val actual = FormatType.formatType(tpe)(Audience.External)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatTypeDiff.Tuple.01") {
-//    val tpe1 = Type.mkTuple(List(Type.Int32, Type.Int32, Type.Int32), loc)
-//    val tpe2 = Type.mkTuple(List(Type.Int32, Type.Bool, Type.Int32), loc)
-//
-//    val diff = TypeDiff.diff(tpe1, tpe2)
-//    val expected = "(..., Int32, ...)"
-//    val actual = FormatType.formatTypeDiff(diff, VirtualString.Text)(Audience.External).fmt(TerminalContext.NoTerminal)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatTypeDiff.Arrow.01") {
-//    val tpe1 = Type.mkArrowWithEffect(Type.Int32, Type.Pure, Type.Int32, loc)
-//    val tpe2 = Type.mkArrowWithEffect(Type.Int32, Type.Pure, Type.Bool, loc)
-//
-//    val diff = TypeDiff.diff(tpe1, tpe2)
-//    val expected = "... -> Int32"
-//    val actual = FormatType.formatTypeDiff(diff, VirtualString.Text)(Audience.External).fmt(TerminalContext.NoTerminal)
-//
-//    assert(actual == expected)
-//  }
-//
-//  test("FormatTypeDiff.Enum.01") {
-//    val map = Type.mkEnum(Symbol.mkEnumSym("Map"), Kind.Star ->: Kind.Star ->: Kind.Star, loc)
-//    val tpe1 = Type.mkApply(map, List(Type.Int32, Type.Bool), loc)
-//    val tpe2 = Type.mkApply(map, List(Type.Int32, Type.Str), loc)
-//
-//    val diff = TypeDiff.diff(tpe1, tpe2)
-//    val expected = "...[..., Bool]"
-//    val actual = FormatType.formatTypeDiff(diff, VirtualString.Text)(Audience.External).fmt(TerminalContext.NoTerminal)
-//
-//    assert(actual == expected)
-//  }
+
+  val loc: SourceLocation = SourceLocation.Unknown
+
+  test("FormatType.WellFormedType.Record.External.01") {
+    val tpe = Type.mkRecord(Type.mkRecordRowExtend(Name.Field("x", loc), Type.Int32, Type.mkRecordRowExtend(Name.Field("y", loc), Type.Str, Type.RecordRowEmpty, loc), loc), loc)
+
+    val expected = "{ x: Int32, y: String }"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.Record.External.02") {
+    val rest = Type.KindedVar(0, Kind.RecordRow, loc, Rigidity.Rigid)
+    val tpe = Type.mkRecord(Type.mkRecordRowExtend(Name.Field("x", loc), Type.Int32, rest, loc), loc)
+
+    val expected = "{ x: Int32 | '0 }"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.Arrow.External.01") {
+    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
+    val tpe = Type.mkArrowWithEffect(paramType, Type.Pure, paramType, loc)
+
+    val expected = "'0 -> '0"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.Arrow.External.02") {
+    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
+    val returnType = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
+    val effectType = Type.KindedVar(2, Kind.Bool, loc, Rigidity.Rigid)
+    val tpe = Type.mkArrowWithEffect(paramType, effectType, returnType, loc)
+
+    val expected = "'0 -> '1 & '2"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.Arrow.External.03") {
+    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
+    val returnType = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
+    val tpe = Type.mkArrowWithEffect(paramType, Type.Impure, returnType, loc)
+
+    val expected = "'0 ~> '1"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.Arrow.External.04") {
+    val tpe = Type.mkImpureUncurriedArrow(Type.Int8 :: Type.Int16 :: Nil, Type.Int32, loc)
+
+    val expected = "Int8 -> Int16 ~> Int32"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.Arrow.External.05") {
+    val eff = Type.mkAnd(Type.KindedVar(1, Kind.Bool, loc, Rigidity.Flexible), Type.KindedVar(2, Kind.Bool, loc, Rigidity.Flexible), loc)
+    val tpe = Type.mkArrowWithEffect(Type.BigInt, eff, Type.Bool, loc)
+
+    val expected = "BigInt -> Bool & ('1 ∧ '2)"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.Schema.External.01") {
+    val relationType = Type.mkRelation(Type.Int32 :: Type.Str :: Nil, loc)
+    val tpe = Type.mkSchema(Type.mkSchemaRowExtend(Name.Pred("S", loc), relationType, Type.SchemaRowEmpty, loc), loc)
+
+    val expected = "#{ S(Int32, String) }"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.Schema.External.02") {
+    val latticeType1 = Type.mkLattice(List(Type.Str), loc)
+    val latticeType2 = Type.mkLattice(List(Type.Int32, Type.Str), loc)
+    val restType = Type.KindedVar(5, Kind.SchemaRow, loc, Rigidity.Flexible)
+    val tpe = Type.mkSchema(Type.mkSchemaRowExtend(Name.Pred("A", loc), latticeType1, Type.mkSchemaRowExtend(Name.Pred("B", loc), latticeType2, restType, loc), loc), loc)
+
+    val expected = "#{ A<>(String), B<>(Int32, String) | '5 }"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.Enum.External.07") {
+    val tvar1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Flexible)
+    val tvar2 = Type.KindedVar(2, Kind.Star, loc, Rigidity.Flexible)
+    val tvar3 = Type.KindedVar(3, Kind.Star, loc, Rigidity.Flexible)
+    val tpe = Type.mkEnum(Symbol.mkEnumSym("Triplet"), List(tvar1, tvar2, tvar3), loc)
+
+    val expected = "Triplet['1, '2, '3]"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatType.WellFormedType.Record.Internal.01") {
+    val tpe = Type.mkRecord(Type.mkRecordRowExtend(Name.Field("x", loc), Type.Int32, Type.mkRecordRowExtend(Name.Field("y", loc), Type.Str, Type.RecordRowEmpty, loc), loc), loc)
+
+    val expected = "{ x: Int32, y: String }"
+    val actual = FormatType.formatType(tpe)(Audience.Internal)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.Record.Internal.02") {
+    val rest = Type.KindedVar(0, Kind.RecordRow, loc, Rigidity.Rigid)
+    val tpe = Type.mkRecord(Type.mkRecordRowExtend(Name.Field("x", loc), Type.Int32, rest, loc), loc)
+
+    val expected = "{ x: Int32 | '0 }"
+    val actual = FormatType.formatType(tpe)(Audience.Internal)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.Arrow.Internal.01") {
+    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
+    val tpe = Type.mkArrowWithEffect(paramType, Type.Pure, paramType, loc)
+
+    val expected = "'0 -> '0"
+    val actual = FormatType.formatType(tpe)(Audience.Internal)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.Arrow.Internal.02") {
+    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
+    val returnType = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
+    val effectType = Type.KindedVar(2, Kind.Bool, loc, Rigidity.Rigid)
+    val tpe = Type.mkArrowWithEffect(paramType, effectType, returnType, loc)
+
+    val expected = "'0 -> '1 & ''2"
+    val actual = FormatType.formatType(tpe)(Audience.Internal)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.Schema.Internal.01") {
+    val relationType = Type.mkRelation(List(Type.Int32, Type.Str), loc)
+    val tpe = Type.mkSchema(Type.mkSchemaRowExtend(Name.Pred("S", loc), relationType, Type.SchemaRowEmpty, loc), loc)
+
+    val expected = "#{ S(Int32, String) }"
+    val actual = FormatType.formatType(tpe)(Audience.Internal)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.Schema.Internal.02") {
+    val latticeType1 = Type.mkLattice(List(Type.Str), loc)
+    val latticeType2 = Type.mkLattice(List(Type.Int32, Type.Str), loc)
+    val restType = Type.KindedVar(5, Kind.SchemaRow, loc, Rigidity.Flexible)
+    val tpe = Type.mkSchema(Type.mkSchemaRowExtend(Name.Pred("A", loc), latticeType1, Type.mkSchemaRowExtend(Name.Pred("B", loc), latticeType2, restType, loc), loc), loc)
+
+    val expected = "#{ A<>(String), B<>(Int32, String) | '5 }"
+    val actual = FormatType.formatType(tpe)(Audience.Internal)
+
+    assert(actual == expected)
+  }
+
+  test("FormatWellFormedType.Enum.Internal.07") {
+    val tvar1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Flexible)
+    val tvar2 = Type.KindedVar(2, Kind.Star, loc, Rigidity.Flexible)
+    val tvar3 = Type.KindedVar(3, Kind.Star, loc, Rigidity.Flexible)
+    val tpe = Type.mkEnum(Symbol.mkEnumSym("Triplet"), List(tvar1, tvar2, tvar3), loc)
+
+    val expected = "Triplet['1, '2, '3]"
+    val actual = FormatType.formatType(tpe)(Audience.Internal)
+
+    assert(actual == expected)
+  }
+
+  test("FormatIllFormedType.Tuple.External.01") {
+    val tpe = Type.mkApply(Type.Cst(TypeConstructor.Tuple(2), loc), List(Type.Str), loc)
+
+    val expected = "(String, ???)"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatIllFormedType.Effect.External.01") {
+    val tpe = Type.Not
+
+    val expected = "¬???"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatIllFormedType.Effect.External.03") {
+    val tpe = Type.And
+
+    val expected = "??? ∧ ???"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatIllFormedType.Effect.External.04") {
+    val tpe = Type.Apply(Type.And, Type.Pure, loc)
+
+    val expected = "(true) ∧ ???"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatIllFormedType.Effect.External.06") {
+    val tpe = Type.Or
+
+    val expected = "??? ∨ ???"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatIllFormedType.Effect.External.07") {
+    val tpe = Type.Apply(Type.Or, Type.Pure, loc)
+
+    val expected = "(true) ∨ ???"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatIllFormedType.Arrow.External.01") {
+    val tpe = Type.Apply(Type.Cst(TypeConstructor.Arrow(2), loc), Type.Pure, loc)
+
+    val expected = "??? -> ???"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatIllFormedType.Arrow.External.02") {
+    val tpe = Type.mkApply(Type.Cst(TypeConstructor.Arrow(3), loc), List(Type.Impure, Type.Str), loc)
+
+    val expected = "String -> ??? ~> ???"
+    val actual = FormatType.formatType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
+
+  test("FormatTypeDiff.Tuple.01") {
+    val tpe1 = Type.mkTuple(List(Type.Int32, Type.Int32, Type.Int32), loc)
+    val tpe2 = Type.mkTuple(List(Type.Int32, Type.Bool, Type.Int32), loc)
+
+    val diff = TypeDiff.diff(tpe1, tpe2)
+    val expected = "(..., Int32, ...)"
+    val actual = FormatType.formatTypeDiff(diff, VirtualString.Text)(Audience.External).fmt(TerminalContext.NoTerminal)
+
+    assert(actual == expected)
+  }
+
+  test("FormatTypeDiff.Arrow.01") {
+    val tpe1 = Type.mkArrowWithEffect(Type.Int32, Type.Pure, Type.Int32, loc)
+    val tpe2 = Type.mkArrowWithEffect(Type.Int32, Type.Pure, Type.Bool, loc)
+
+    val diff = TypeDiff.diff(tpe1, tpe2)
+    val expected = "... -> Int32"
+    val actual = FormatType.formatTypeDiff(diff, VirtualString.Text)(Audience.External).fmt(TerminalContext.NoTerminal)
+
+    assert(actual == expected)
+  }
+
+  test("FormatTypeDiff.Enum.01") {
+    val map = Type.mkEnum(Symbol.mkEnumSym("Map"), Kind.Star ->: Kind.Star ->: Kind.Star, loc)
+    val tpe1 = Type.mkApply(map, List(Type.Int32, Type.Bool), loc)
+    val tpe2 = Type.mkApply(map, List(Type.Int32, Type.Str), loc)
+
+    val diff = TypeDiff.diff(tpe1, tpe2)
+    val expected = "...[..., Bool]"
+    val actual = FormatType.formatTypeDiff(diff, VirtualString.Text)(Audience.External).fmt(TerminalContext.NoTerminal)
+
+    assert(actual == expected)
+  }
 }

--- a/main/test/ca/uwaterloo/flix/language/debug/TestFormatType.scala
+++ b/main/test/ca/uwaterloo/flix/language/debug/TestFormatType.scala
@@ -22,328 +22,329 @@ import ca.uwaterloo.flix.util.vt.{TerminalContext, VirtualString}
 import org.scalatest.FunSuite
 
 class TestFormatType extends FunSuite with TestUtils {
-  
-  val loc: SourceLocation = SourceLocation.Unknown
-  
-  test("FormatType.WellFormedType.Record.External.01") {
-    val tpe = Type.mkRecordExtend(Name.Field("x", loc), Type.Int32, Type.mkRecordExtend(Name.Field("y", loc), Type.Str, Type.RecordEmpty, loc), loc)
-
-    val expected = "{ x: Int32, y: String }"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatWellFormedType.Record.External.02") {
-    val rest = Type.KindedVar(0, Kind.Record, loc, Rigidity.Rigid)
-    val tpe = Type.mkRecordExtend(Name.Field("x", loc), Type.Int32, rest, loc)
-
-    val expected = "{ x: Int32 | '0 }"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatWellFormedType.Arrow.External.01") {
-    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
-    val tpe = Type.mkArrowWithEffect(paramType, Type.Pure, paramType, loc)
-
-    val expected = "'0 -> '0"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatWellFormedType.Arrow.External.02") {
-    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
-    val returnType = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
-    val effectType = Type.KindedVar(2, Kind.Bool, loc, Rigidity.Rigid)
-    val tpe = Type.mkArrowWithEffect(paramType, effectType, returnType, loc)
-
-    val expected = "'0 -> '1 & '2"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatWellFormedType.Arrow.External.03") {
-    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
-    val returnType = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
-    val tpe = Type.mkArrowWithEffect(paramType, Type.Impure, returnType, loc)
-
-    val expected = "'0 ~> '1"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatWellFormedType.Arrow.External.04") {
-    val tpe = Type.mkImpureUncurriedArrow(Type.Int8 :: Type.Int16 :: Nil, Type.Int32, loc)
-
-    val expected = "Int8 -> Int16 ~> Int32"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatWellFormedType.Arrow.External.05") {
-    val eff = Type.mkAnd(Type.KindedVar(1, Kind.Bool, loc, Rigidity.Flexible), Type.KindedVar(2, Kind.Bool, loc, Rigidity.Flexible), loc)
-    val tpe = Type.mkArrowWithEffect(Type.BigInt, eff, Type.Bool, loc)
-
-    val expected = "BigInt -> Bool & ('1 ∧ '2)"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatWellFormedType.Schema.External.01") {
-    val relationType = Type.mkRelation(Type.Int32 :: Type.Str :: Nil, loc)
-    val tpe = Type.mkSchemaExtend(Name.Pred("S", loc), relationType, Type.SchemaEmpty, loc)
-
-    val expected = "#{ S(Int32, String) }"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatWellFormedType.Schema.External.02") {
-    val latticeType1 = Type.mkLattice(List(Type.Str), loc)
-    val latticeType2 = Type.mkLattice(List(Type.Int32, Type.Str), loc)
-    val restType = Type.KindedVar(5, Kind.Schema, loc, Rigidity.Flexible)
-    val tpe = Type.mkSchemaExtend(Name.Pred("A", loc), latticeType1, Type.mkSchemaExtend(Name.Pred("B", loc), latticeType2, restType, loc), loc)
-
-    val expected = "#{ A<>(String), B<>(Int32, String) | '5 }"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatWellFormedType.Enum.External.07") {
-    val tvar1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Flexible)
-    val tvar2 = Type.KindedVar(2, Kind.Star, loc, Rigidity.Flexible)
-    val tvar3 = Type.KindedVar(3, Kind.Star, loc, Rigidity.Flexible)
-    val tpe = Type.mkEnum(Symbol.mkEnumSym("Triplet"), List(tvar1, tvar2, tvar3), loc)
-
-    val expected = "Triplet['1, '2, '3]"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatType.WellFormedType.Record.Internal.01") {
-    val tpe = Type.mkRecordExtend(Name.Field("x", loc), Type.Int32, Type.mkRecordExtend(Name.Field("y", loc), Type.Str, Type.RecordEmpty, loc), loc)
-
-    val expected = "{ x: Int32, y: String }"
-    val actual = FormatType.formatType(tpe)(Audience.Internal)
-
-    assert(actual == expected)
-  }
-
-  test("FormatWellFormedType.Record.Internal.02") {
-    val rest = Type.KindedVar(0, Kind.Record, loc, Rigidity.Rigid)
-    val tpe = Type.mkRecordExtend(Name.Field("x", loc), Type.Int32, rest, loc)
-
-    val expected = "{ x: Int32 | '0 }"
-    val actual = FormatType.formatType(tpe)(Audience.Internal)
-
-    assert(actual == expected)
-  }
-
-  test("FormatWellFormedType.Arrow.Internal.01") {
-    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
-    val tpe = Type.mkArrowWithEffect(paramType, Type.Pure, paramType, loc)
-
-    val expected = "'0 -> '0"
-    val actual = FormatType.formatType(tpe)(Audience.Internal)
-
-    assert(actual == expected)
-  }
-
-  test("FormatWellFormedType.Arrow.Internal.02") {
-    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
-    val returnType = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
-    val effectType = Type.KindedVar(2, Kind.Bool, loc, Rigidity.Rigid)
-    val tpe = Type.mkArrowWithEffect(paramType, effectType, returnType, loc)
-
-    val expected = "'0 -> '1 & ''2"
-    val actual = FormatType.formatType(tpe)(Audience.Internal)
-
-    assert(actual == expected)
-  }
-
-  test("FormatWellFormedType.Schema.Internal.01") {
-    val relationType = Type.mkRelation(List(Type.Int32, Type.Str), loc)
-    val tpe = Type.mkSchemaExtend(Name.Pred("S", loc), relationType, Type.SchemaEmpty, loc)
-
-    val expected = "#{ S(Int32, String) }"
-    val actual = FormatType.formatType(tpe)(Audience.Internal)
-
-    assert(actual == expected)
-  }
-
-  test("FormatWellFormedType.Schema.Internal.02") {
-    val latticeType1 = Type.mkLattice(List(Type.Str), loc)
-    val latticeType2 = Type.mkLattice(List(Type.Int32, Type.Str), loc)
-    val restType = Type.KindedVar(5, Kind.Schema, loc, Rigidity.Flexible)
-    val tpe = Type.mkSchemaExtend(Name.Pred("A", loc), latticeType1, Type.mkSchemaExtend(Name.Pred("B", loc), latticeType2, restType, loc), loc)
-
-    val expected = "#{ A<>(String), B<>(Int32, String) | '5 }"
-    val actual = FormatType.formatType(tpe)(Audience.Internal)
-
-    assert(actual == expected)
-  }
-
-  test("FormatWellFormedType.Enum.Internal.07") {
-    val tvar1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Flexible)
-    val tvar2 = Type.KindedVar(2, Kind.Star, loc, Rigidity.Flexible)
-    val tvar3 = Type.KindedVar(3, Kind.Star, loc, Rigidity.Flexible)
-    val tpe = Type.mkEnum(Symbol.mkEnumSym("Triplet"), List(tvar1, tvar2, tvar3), loc)
-
-    val expected = "Triplet['1, '2, '3]"
-    val actual = FormatType.formatType(tpe)(Audience.Internal)
-
-    assert(actual == expected)
-  }
-
-  test("FormatIllFormedType.Record.External.01") {
-    val tpe = Type.Cst(TypeConstructor.RecordExtend(Name.Field("x", loc)), loc)
-
-    val expected = "{ x: ??? }"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatIllFormedType.Record.External.02") {
-    val tpe = Type.Apply(Type.Cst(TypeConstructor.RecordExtend(Name.Field("x", loc)), loc), Type.Int32, loc)
-
-    val expected = "{ x: Int32 | ??? }"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatIllFormedType.Schema.External.01") {
-    val tpe = Type.Cst(TypeConstructor.SchemaExtend(Name.Pred("X", loc)), loc)
-
-    val expected = "#{ X?(???) }"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatIllFormedType.Schema.External.02") {
-    val tpe = Type.Apply(Type.Cst(TypeConstructor.SchemaExtend(Name.Pred("X", loc)), loc), Type.Int32, loc)
-
-    val expected = "#{ X?(Int32) | ??? }"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatIllFormedType.Tuple.External.01") {
-    val tpe = Type.mkApply(Type.Cst(TypeConstructor.Tuple(2), loc), List(Type.Str), loc)
-
-    val expected = "(String, ???)"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatIllFormedType.Effect.External.01") {
-    val tpe = Type.Not
-
-    val expected = "¬???"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatIllFormedType.Effect.External.03") {
-    val tpe = Type.And
-
-    val expected = "??? ∧ ???"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatIllFormedType.Effect.External.04") {
-    val tpe = Type.Apply(Type.And, Type.Pure, loc)
-
-    val expected = "(true) ∧ ???"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatIllFormedType.Effect.External.06") {
-    val tpe = Type.Or
-
-    val expected = "??? ∨ ???"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatIllFormedType.Effect.External.07") {
-    val tpe = Type.Apply(Type.Or, Type.Pure, loc)
-
-    val expected = "(true) ∨ ???"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatIllFormedType.Arrow.External.01") {
-    val tpe = Type.Apply(Type.Cst(TypeConstructor.Arrow(2), loc), Type.Pure, loc)
-
-    val expected = "??? -> ???"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatIllFormedType.Arrow.External.02") {
-    val tpe = Type.mkApply(Type.Cst(TypeConstructor.Arrow(3), loc), List(Type.Impure, Type.Str), loc)
-
-    val expected = "String -> ??? ~> ???"
-    val actual = FormatType.formatType(tpe)(Audience.External)
-
-    assert(actual == expected)
-  }
-
-  test("FormatTypeDiff.Tuple.01") {
-    val tpe1 = Type.mkTuple(List(Type.Int32, Type.Int32, Type.Int32), loc)
-    val tpe2 = Type.mkTuple(List(Type.Int32, Type.Bool, Type.Int32), loc)
-
-    val diff = TypeDiff.diff(tpe1, tpe2)
-    val expected = "(..., Int32, ...)"
-    val actual = FormatType.formatTypeDiff(diff, VirtualString.Text)(Audience.External).fmt(TerminalContext.NoTerminal)
-
-    assert(actual == expected)
-  }
-
-  test("FormatTypeDiff.Arrow.01") {
-    val tpe1 = Type.mkArrowWithEffect(Type.Int32, Type.Pure, Type.Int32, loc)
-    val tpe2 = Type.mkArrowWithEffect(Type.Int32, Type.Pure, Type.Bool, loc)
-
-    val diff = TypeDiff.diff(tpe1, tpe2)
-    val expected = "... -> Int32"
-    val actual = FormatType.formatTypeDiff(diff, VirtualString.Text)(Audience.External).fmt(TerminalContext.NoTerminal)
-
-    assert(actual == expected)
-  }
-
-  test("FormatTypeDiff.Enum.01") {
-    val map = Type.mkEnum(Symbol.mkEnumSym("Map"), Kind.Star ->: Kind.Star ->: Kind.Star, loc)
-    val tpe1 = Type.mkApply(map, List(Type.Int32, Type.Bool), loc)
-    val tpe2 = Type.mkApply(map, List(Type.Int32, Type.Str), loc)
-
-    val diff = TypeDiff.diff(tpe1, tpe2)
-    val expected = "...[..., Bool]"
-    val actual = FormatType.formatTypeDiff(diff, VirtualString.Text)(Audience.External).fmt(TerminalContext.NoTerminal)
-
-    assert(actual == expected)
-  }
+  // MATT disabling for now
+//
+//  val loc: SourceLocation = SourceLocation.Unknown
+//
+//  test("FormatType.WellFormedType.Record.External.01") {
+//    val tpe = Type.mkRecordExtend(Name.Field("x", loc), Type.Int32, Type.mkRecordExtend(Name.Field("y", loc), Type.Str, Type.RecordEmpty, loc), loc)
+//
+//    val expected = "{ x: Int32, y: String }"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatWellFormedType.Record.External.02") {
+//    val rest = Type.KindedVar(0, Kind.Record, loc, Rigidity.Rigid)
+//    val tpe = Type.mkRecordExtend(Name.Field("x", loc), Type.Int32, rest, loc)
+//
+//    val expected = "{ x: Int32 | '0 }"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatWellFormedType.Arrow.External.01") {
+//    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
+//    val tpe = Type.mkArrowWithEffect(paramType, Type.Pure, paramType, loc)
+//
+//    val expected = "'0 -> '0"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatWellFormedType.Arrow.External.02") {
+//    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
+//    val returnType = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
+//    val effectType = Type.KindedVar(2, Kind.Bool, loc, Rigidity.Rigid)
+//    val tpe = Type.mkArrowWithEffect(paramType, effectType, returnType, loc)
+//
+//    val expected = "'0 -> '1 & '2"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatWellFormedType.Arrow.External.03") {
+//    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
+//    val returnType = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
+//    val tpe = Type.mkArrowWithEffect(paramType, Type.Impure, returnType, loc)
+//
+//    val expected = "'0 ~> '1"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatWellFormedType.Arrow.External.04") {
+//    val tpe = Type.mkImpureUncurriedArrow(Type.Int8 :: Type.Int16 :: Nil, Type.Int32, loc)
+//
+//    val expected = "Int8 -> Int16 ~> Int32"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatWellFormedType.Arrow.External.05") {
+//    val eff = Type.mkAnd(Type.KindedVar(1, Kind.Bool, loc, Rigidity.Flexible), Type.KindedVar(2, Kind.Bool, loc, Rigidity.Flexible), loc)
+//    val tpe = Type.mkArrowWithEffect(Type.BigInt, eff, Type.Bool, loc)
+//
+//    val expected = "BigInt -> Bool & ('1 ∧ '2)"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatWellFormedType.Schema.External.01") {
+//    val relationType = Type.mkRelation(Type.Int32 :: Type.Str :: Nil, loc)
+//    val tpe = Type.mkSchemaExtend(Name.Pred("S", loc), relationType, Type.SchemaEmpty, loc)
+//
+//    val expected = "#{ S(Int32, String) }"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatWellFormedType.Schema.External.02") {
+//    val latticeType1 = Type.mkLattice(List(Type.Str), loc)
+//    val latticeType2 = Type.mkLattice(List(Type.Int32, Type.Str), loc)
+//    val restType = Type.KindedVar(5, Kind.Schema, loc, Rigidity.Flexible)
+//    val tpe = Type.mkSchemaExtend(Name.Pred("A", loc), latticeType1, Type.mkSchemaExtend(Name.Pred("B", loc), latticeType2, restType, loc), loc)
+//
+//    val expected = "#{ A<>(String), B<>(Int32, String) | '5 }"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatWellFormedType.Enum.External.07") {
+//    val tvar1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Flexible)
+//    val tvar2 = Type.KindedVar(2, Kind.Star, loc, Rigidity.Flexible)
+//    val tvar3 = Type.KindedVar(3, Kind.Star, loc, Rigidity.Flexible)
+//    val tpe = Type.mkEnum(Symbol.mkEnumSym("Triplet"), List(tvar1, tvar2, tvar3), loc)
+//
+//    val expected = "Triplet['1, '2, '3]"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatType.WellFormedType.Record.Internal.01") {
+//    val tpe = Type.mkRecordExtend(Name.Field("x", loc), Type.Int32, Type.mkRecordExtend(Name.Field("y", loc), Type.Str, Type.RecordEmpty, loc), loc)
+//
+//    val expected = "{ x: Int32, y: String }"
+//    val actual = FormatType.formatType(tpe)(Audience.Internal)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatWellFormedType.Record.Internal.02") {
+//    val rest = Type.KindedVar(0, Kind.Record, loc, Rigidity.Rigid)
+//    val tpe = Type.mkRecordExtend(Name.Field("x", loc), Type.Int32, rest, loc)
+//
+//    val expected = "{ x: Int32 | '0 }"
+//    val actual = FormatType.formatType(tpe)(Audience.Internal)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatWellFormedType.Arrow.Internal.01") {
+//    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
+//    val tpe = Type.mkArrowWithEffect(paramType, Type.Pure, paramType, loc)
+//
+//    val expected = "'0 -> '0"
+//    val actual = FormatType.formatType(tpe)(Audience.Internal)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatWellFormedType.Arrow.Internal.02") {
+//    val paramType = Type.KindedVar(0, Kind.Star, loc, Rigidity.Rigid)
+//    val returnType = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
+//    val effectType = Type.KindedVar(2, Kind.Bool, loc, Rigidity.Rigid)
+//    val tpe = Type.mkArrowWithEffect(paramType, effectType, returnType, loc)
+//
+//    val expected = "'0 -> '1 & ''2"
+//    val actual = FormatType.formatType(tpe)(Audience.Internal)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatWellFormedType.Schema.Internal.01") {
+//    val relationType = Type.mkRelation(List(Type.Int32, Type.Str), loc)
+//    val tpe = Type.mkSchemaExtend(Name.Pred("S", loc), relationType, Type.SchemaEmpty, loc)
+//
+//    val expected = "#{ S(Int32, String) }"
+//    val actual = FormatType.formatType(tpe)(Audience.Internal)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatWellFormedType.Schema.Internal.02") {
+//    val latticeType1 = Type.mkLattice(List(Type.Str), loc)
+//    val latticeType2 = Type.mkLattice(List(Type.Int32, Type.Str), loc)
+//    val restType = Type.KindedVar(5, Kind.Schema, loc, Rigidity.Flexible)
+//    val tpe = Type.mkSchemaExtend(Name.Pred("A", loc), latticeType1, Type.mkSchemaExtend(Name.Pred("B", loc), latticeType2, restType, loc), loc)
+//
+//    val expected = "#{ A<>(String), B<>(Int32, String) | '5 }"
+//    val actual = FormatType.formatType(tpe)(Audience.Internal)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatWellFormedType.Enum.Internal.07") {
+//    val tvar1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Flexible)
+//    val tvar2 = Type.KindedVar(2, Kind.Star, loc, Rigidity.Flexible)
+//    val tvar3 = Type.KindedVar(3, Kind.Star, loc, Rigidity.Flexible)
+//    val tpe = Type.mkEnum(Symbol.mkEnumSym("Triplet"), List(tvar1, tvar2, tvar3), loc)
+//
+//    val expected = "Triplet['1, '2, '3]"
+//    val actual = FormatType.formatType(tpe)(Audience.Internal)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatIllFormedType.Record.External.01") {
+//    val tpe = Type.Cst(TypeConstructor.RecordExtend(Name.Field("x", loc)), loc)
+//
+//    val expected = "{ x: ??? }"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatIllFormedType.Record.External.02") {
+//    val tpe = Type.Apply(Type.Cst(TypeConstructor.RecordExtend(Name.Field("x", loc)), loc), Type.Int32, loc)
+//
+//    val expected = "{ x: Int32 | ??? }"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatIllFormedType.Schema.External.01") {
+//    val tpe = Type.Cst(TypeConstructor.SchemaExtend(Name.Pred("X", loc)), loc)
+//
+//    val expected = "#{ X?(???) }"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatIllFormedType.Schema.External.02") {
+//    val tpe = Type.Apply(Type.Cst(TypeConstructor.SchemaExtend(Name.Pred("X", loc)), loc), Type.Int32, loc)
+//
+//    val expected = "#{ X?(Int32) | ??? }"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatIllFormedType.Tuple.External.01") {
+//    val tpe = Type.mkApply(Type.Cst(TypeConstructor.Tuple(2), loc), List(Type.Str), loc)
+//
+//    val expected = "(String, ???)"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatIllFormedType.Effect.External.01") {
+//    val tpe = Type.Not
+//
+//    val expected = "¬???"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatIllFormedType.Effect.External.03") {
+//    val tpe = Type.And
+//
+//    val expected = "??? ∧ ???"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatIllFormedType.Effect.External.04") {
+//    val tpe = Type.Apply(Type.And, Type.Pure, loc)
+//
+//    val expected = "(true) ∧ ???"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatIllFormedType.Effect.External.06") {
+//    val tpe = Type.Or
+//
+//    val expected = "??? ∨ ???"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatIllFormedType.Effect.External.07") {
+//    val tpe = Type.Apply(Type.Or, Type.Pure, loc)
+//
+//    val expected = "(true) ∨ ???"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatIllFormedType.Arrow.External.01") {
+//    val tpe = Type.Apply(Type.Cst(TypeConstructor.Arrow(2), loc), Type.Pure, loc)
+//
+//    val expected = "??? -> ???"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatIllFormedType.Arrow.External.02") {
+//    val tpe = Type.mkApply(Type.Cst(TypeConstructor.Arrow(3), loc), List(Type.Impure, Type.Str), loc)
+//
+//    val expected = "String -> ??? ~> ???"
+//    val actual = FormatType.formatType(tpe)(Audience.External)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatTypeDiff.Tuple.01") {
+//    val tpe1 = Type.mkTuple(List(Type.Int32, Type.Int32, Type.Int32), loc)
+//    val tpe2 = Type.mkTuple(List(Type.Int32, Type.Bool, Type.Int32), loc)
+//
+//    val diff = TypeDiff.diff(tpe1, tpe2)
+//    val expected = "(..., Int32, ...)"
+//    val actual = FormatType.formatTypeDiff(diff, VirtualString.Text)(Audience.External).fmt(TerminalContext.NoTerminal)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatTypeDiff.Arrow.01") {
+//    val tpe1 = Type.mkArrowWithEffect(Type.Int32, Type.Pure, Type.Int32, loc)
+//    val tpe2 = Type.mkArrowWithEffect(Type.Int32, Type.Pure, Type.Bool, loc)
+//
+//    val diff = TypeDiff.diff(tpe1, tpe2)
+//    val expected = "... -> Int32"
+//    val actual = FormatType.formatTypeDiff(diff, VirtualString.Text)(Audience.External).fmt(TerminalContext.NoTerminal)
+//
+//    assert(actual == expected)
+//  }
+//
+//  test("FormatTypeDiff.Enum.01") {
+//    val map = Type.mkEnum(Symbol.mkEnumSym("Map"), Kind.Star ->: Kind.Star ->: Kind.Star, loc)
+//    val tpe1 = Type.mkApply(map, List(Type.Int32, Type.Bool), loc)
+//    val tpe2 = Type.mkApply(map, List(Type.Int32, Type.Str), loc)
+//
+//    val diff = TypeDiff.diff(tpe1, tpe2)
+//    val expected = "...[..., Bool]"
+//    val actual = FormatType.formatTypeDiff(diff, VirtualString.Text)(Audience.External).fmt(TerminalContext.NoTerminal)
+//
+//    assert(actual == expected)
+//  }
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -125,25 +125,25 @@ class TestTyper extends FunSuite with TestUtils {
   test("TestMismatchedKinds.01") {
     val input = "def foo(): {| x} = {a = 2} <+> {a = 2}"
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedKinds](result)
+    expectError[TypeError.MismatchedTypes](result) // MATT right?
   }
 
   test("TestMismatchedKinds.02") {
     val input = "def foo(): #{| x} = {a = 2} <+> {a = 2}"
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedKinds](result)
+    expectError[TypeError.MismatchedTypes](result) // MATT right?
   }
 
   test("TestMismatchedKinds.03") {
     val input = "def foo(): {a: Int} = {a = 2} <+> {a = 2}"
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedKinds](result)
+    expectError[TypeError.MismatchedTypes](result) // MATT right?
   }
 
   test("TestMismatchedKinds.04") {
     val input = "def foo(): String = solve \"hello\""
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedKinds](result)
+    expectError[TypeError.MismatchedTypes](result) // MATT right?
   }
 
   test("TestLeq.Wildcard.01") {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -122,28 +122,28 @@ class TestTyper extends FunSuite with TestUtils {
     expectError[TypeError.OccursCheckError](result)
   }
 
-  test("TestMismatchedKinds.01") {
+  test("TestMismatchedTypes.01") {
     val input = "def foo(): {| x} = {a = 2} <+> {a = 2}"
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedTypes](result) // MATT right?
+    expectError[TypeError.MismatchedTypes](result)
   }
 
-  test("TestMismatchedKinds.02") {
+  test("TestMismatchedTypes.02") {
     val input = "def foo(): #{| x} = {a = 2} <+> {a = 2}"
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedTypes](result) // MATT right?
+    expectError[TypeError.MismatchedTypes](result)
   }
 
-  test("TestMismatchedKinds.03") {
+  test("TestMismatchedTypes.03") {
     val input = "def foo(): {a: Int} = {a = 2} <+> {a = 2}"
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedTypes](result) // MATT right?
+    expectError[TypeError.MismatchedTypes](result)
   }
 
-  test("TestMismatchedKinds.04") {
+  test("TestMismatchedTypes.04") {
     val input = "def foo(): String = solve \"hello\""
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedTypes](result) // MATT right?
+    expectError[TypeError.MismatchedTypes](result)
   }
 
   test("TestLeq.Wildcard.01") {

--- a/main/test/ca/uwaterloo/flix/language/phase/unification/TestUnification.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/unification/TestUnification.scala
@@ -24,393 +24,378 @@ import ca.uwaterloo.flix.util.Result
 import org.scalatest.FunSuite
 
 class TestUnification extends FunSuite with TestUtils {
-  // MATT disabling for now
-//
-//  implicit val flix: Flix = new Flix()
-//
-//  val loc: SourceLocation = SourceLocation.Unknown
-//
-//  /////////////////////////////////////////////////////////////////////////////
-//  // Substitutions                                                           //
-//  /////////////////////////////////////////////////////////////////////////////
-//
-//  test("Substitution.Empty.01") {
-//    val tpe = Type.Unit
-//    val subst = Substitution.empty
-//    assertResult(Type.Unit)(subst(tpe))
-//  }
-//
-//  test("Substitution.Empty.02") {
-//    val tpe = Type.Bool
-//    val subst = Substitution.empty
-//    assertResult(Type.Bool)(subst(tpe))
-//  }
-//
-//  test("Substitution.Empty.03") {
-//    val tpe = Type.KindedVar(1, Kind.Star, loc)
-//    val subst = Substitution.empty
-//    assertResult(Type.KindedVar(1, Kind.Star, loc))(subst(tpe))
-//  }
-//
-//  test("Substitution.Empty.04") {
-//    val tpe = Type.mkPureArrow(Type.Bool, Type.Unit, loc)
-//    val subst = Substitution.empty
-//    assertResult(Type.mkPureArrow(Type.Bool, Type.Unit, loc))(subst(tpe))
-//  }
-//
-//  test("Substitution.Singleton.01") {
-//    val tpe = Type.KindedVar(1, Kind.Star, loc)
-//    val subst = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Bool)
-//    assertResult(Type.KindedVar(1, Kind.Star, loc))(subst(tpe))
-//  }
-//
-//  test("Substitution.Singleton.02") {
-//    val tpe = Type.KindedVar(1, Kind.Star, loc)
-//    val subst = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
-//    assertResult(Type.Bool)(subst(tpe))
-//  }
-//
-//  test("Substitution.Singleton.05") {
-//    val tpe = Type.KindedVar(1, Kind.Star, loc)
-//    val subst = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
-//    assertResult(Type.KindedVar(2, Kind.Star, loc))(subst(tpe))
-//  }
-//
-//  test("Substitution.++.01") {
-//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
-//    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
-//
-//    val tpe = Type.KindedVar(1, Kind.Star, loc)
-//    assertResult(Type.Bool)((subst1 ++ subst2) (tpe))
-//  }
-//
-//  test("Substitution.++.02") {
-//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
-//    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
-//
-//    val tpe = Type.KindedVar(2, Kind.Star, loc)
-//    assertResult(Type.Char)((subst1 ++ subst2) (tpe))
-//  }
-//
-//  test("Substitution.++.03") {
-//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
-//    val subst2 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Char)
-//
-//    val tpe = Type.KindedVar(1, Kind.Star, loc)
-//    assertResult(Type.Bool)((subst1 ++ subst2) (tpe))
-//  }
-//
-//  test("Substitution.++.04") {
-//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
-//    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
-//
-//    val tpe = Type.mkPureArrow(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc), loc)
-//    assertResult(Type.mkPureArrow(Type.Bool, Type.Char, loc))((subst1 ++ subst2) (tpe))
-//  }
-//
-//  test("Substitution.@@.01") {
-//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
-//    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
-//
-//    val tpe = Type.mkPureArrow(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc), loc)
-//    assertResult(Type.mkPureArrow(Type.Bool, Type.Char, loc))((subst2 @@ subst1) (tpe))
-//  }
-//
-//  test("Substitution.@@.02") {
-//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
-//    val subst2 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Char)
-//
-//    val tpe = Type.KindedVar(1, Kind.Star, loc)
-//    assertResult(Type.Bool)((subst2 @@ subst1) (tpe))
-//  }
-//
-//  test("Substitution.@@.03") {
-//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
-//    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Bool)
-//
-//    val tpe = Type.KindedVar(1, Kind.Star, loc)
-//    assertResult(Type.Bool)((subst2 @@ subst1) (tpe))
-//  }
-//
-//  test("Substitution.@@.04") {
-//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
-//    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.KindedVar(3, Kind.Star, loc))
-//    val subst3 = Substitution.singleton(Type.KindedVar(3, Kind.Star, loc), Type.Bool)
-//
-//    val tpe = Type.KindedVar(1, Kind.Star, loc)
-//    assertResult(Type.Bool)((subst3 @@ (subst2 @@ subst1)) (tpe))
-//  }
-//
-//  test("Unify.Var.01") {
-//    val result = Unification.unifyTypes(Type.KindedVar(1, Kind.Star, loc), Type.Unit)
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.Var.02") {
-//    val result = Unification.unifyTypes(Type.Unit, Type.KindedVar(1, Kind.Star, loc))
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.Var.03") {
-//    val result = Unification.unifyTypes(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(1, Kind.Star, loc))
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.Var.04") {
-//    val result = Unification.unifyTypes(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.Unit") {
-//    val result = Unification.unifyTypes(Type.Unit, Type.Unit)
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.Bool") {
-//    val result = Unification.unifyTypes(Type.Bool, Type.Bool)
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.Char") {
-//    val result = Unification.unifyTypes(Type.Char, Type.Char)
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.Float32") {
-//    val result = Unification.unifyTypes(Type.Float32, Type.Float32)
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.Float64") {
-//    val result = Unification.unifyTypes(Type.Float64, Type.Float64)
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.Int8") {
-//    val result = Unification.unifyTypes(Type.Int8, Type.Int8)
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.Int16") {
-//    val result = Unification.unifyTypes(Type.Int16, Type.Int16)
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.Int32") {
-//    val result = Unification.unifyTypes(Type.Int32, Type.Int32)
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.Int64") {
-//    val result = Unification.unifyTypes(Type.Int64, Type.Int64)
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.BigInt") {
-//    val result = Unification.unifyTypes(Type.BigInt, Type.BigInt)
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.Str") {
-//    val result = Unification.unifyTypes(Type.Str, Type.Str)
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.01") {
-//    val tpe1 = Type.KindedVar(1, Kind.Star, loc)
-//    val tpe2 = Type.Bool
-//    val result = Unification.unifyTypes(tpe1, tpe2).get
-//    assertResult(Type.Bool)(result(tpe1))
-//  }
-//
-//  test("Unify.02") {
-//    val tpe1 = Type.Bool
-//    val tpe2 = Type.KindedVar(1, Kind.Star, loc)
-//    val result = Unification.unifyTypes(tpe1, tpe2).get
-//    assertResult(Type.Bool)(result(tpe2))
-//  }
-//
-//  test("Unify.03") {
-//    val A = Type.KindedVar(1, Kind.Star, loc)
-//    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
-//    val tpe2 = Type.mkPureArrow(Type.Bool, A, loc)
-//    val result = Unification.unifyTypes(tpe1, tpe2).get
-//    assertResult(Type.Char)(result(A))
-//  }
-//
-//  test("Unify.04") {
-//    val A = Type.KindedVar(1, Kind.Star, loc)
-//    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
-//    val tpe2 = Type.mkPureArrow(Type.Bool, A, loc)
-//    val result = Unification.unifyTypes(tpe1, tpe2).get
-//    assertResult(Type.Char)(result(A))
-//  }
-//
-//  test("Unify.05") {
-//    val A = Type.KindedVar(1, Kind.Star, loc)
-//    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
-//    val tpe2 = A
-//    val result = Unification.unifyTypes(tpe1, tpe2).get
-//    assertResult(tpe1)(result(A))
-//  }
-//
-//  test("Unify.06") {
-//    val A = Type.KindedVar(1, Kind.Star, loc)
-//    val tpe1 = A
-//    val tpe2 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
-//    val result = Unification.unifyTypes(tpe1, tpe2).get
-//    assertResult(tpe2)(result(A))
-//  }
-//
-//  test("Unify.07") {
-//    val A = Type.KindedVar(1, Kind.Star, loc)
-//    val tpe1 = Type.mkPureArrow(A, Type.Bool, loc)
-//    val tpe2 = Type.mkPureArrow(Type.Bool, A, loc)
-//    val result = Unification.unifyTypes(tpe1, tpe2).get
-//    assertResult(Type.Bool)(result(A))
-//  }
-//
-//  test("Unify.08") {
-//    val A = Type.KindedVar(1, Kind.Star, loc)
-//    val B = Type.KindedVar(2, Kind.Star, loc)
-//    val tpe1 = Type.mkPureArrow(A, B, loc)
-//    val tpe2 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
-//    val result = Unification.unifyTypes(tpe1, tpe2).get
-//    assertResult(Type.Bool)(result(A))
-//    assertResult(Type.Char)(result(B))
-//  }
-//
-//  test("Unify.09") {
-//    val A = Type.KindedVar(1, Kind.Star, loc)
-//    val B = Type.KindedVar(2, Kind.Star, loc)
-//    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
-//    val tpe2 = Type.mkPureArrow(A, B, loc)
-//    val result = Unification.unifyTypes(tpe1, tpe2).get
-//    assertResult(Type.Bool)(result(A))
-//    assertResult(Type.Char)(result(B))
-//  }
-//
-//  test("Unify.10") {
-//    val A = Type.KindedVar(1, Kind.Star, loc)
-//    val B = Type.KindedVar(2, Kind.Star, loc)
-//    val tpe1 = Type.mkPureArrow(A, Type.Char, loc)
-//    val tpe2 = Type.mkPureArrow(Type.Bool, B, loc)
-//    val result = Unification.unifyTypes(tpe1, tpe2).get
-//    assertResult(Type.Bool)(result(A))
-//    assertResult(Type.Char)(result(B))
-//  }
-//
-//  test("Unify.11") {
-//    val A = Type.KindedVar(1, Kind.Star, loc)
-//    val B = Type.KindedVar(2, Kind.Star, loc)
-//    val C = Type.KindedVar(3, Kind.Star, loc)
-//    val tpe1 = Type.mkPureArrow(A, B, loc)
-//    val tpe2 = Type.mkPureArrow(C, Type.Bool, loc)
-//    val result = Unification.unifyTypes(tpe1, tpe2).get
-//    assertResult(Type.Bool)(result(B))
-//    assertResult(C)(result(A))
-//  }
-//
-//  test("Unify.12") {
-//    val tpe1 = Type.KindedVar(1, Kind.Record, loc)
-//    val field = Type.Bool
-//    val label = Name.Field("x", loc)
-//    val tpe2 = Type.mkRecordExtend(label, field, tpe1, loc)
-//    val result = Unification.unifyTypes(tpe1, tpe2)
-//    assert(!isOk(result))
-//  }
-//
-//  test("Unify.13") {
-//    val tpe1 = Type.KindedVar(1, Kind.Schema, loc)
-//    val field = Type.mkRelation(List(Type.Bool), loc)
-//    val label = Name.Pred("X", loc)
-//    val tpe2 = Type.mkSchemaExtend(label, field, tpe1, loc)
-//    val result = Unification.unifyTypes(tpe1, tpe2)
-//    assert(!isOk(result))
-//  }
-//
-//  test("Unify.14") {
-//    val tpe1 = Type.KindedVar(1, Kind.Schema, loc)
-//    val tpe2 = Type.KindedVar(2, Kind.Record, loc)
-//    val result = Unification.unifyTypes(tpe1, tpe2)
-//    assert(!isOk(result))
-//  }
-//
-//  test("Unify.15") {
-//    val tpe1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
-//    val tpe2 = Type.KindedVar(2, Kind.Record, loc, Rigidity.Flexible)
-//    val result = Unification.unifyTypes(tpe1, tpe2)
-//    assert(!isOk(result))
-//  }
-//
-//  test("Unify.16") {
-//    val tpe1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Flexible)
-//    val tpe2 = Type.KindedVar(2, Kind.Record, loc, Rigidity.Rigid)
-//    val result = Unification.unifyTypes(tpe1, tpe2)
-//    assert(isOk(result))
-//  }
-//
-//  test("Unify.17") {
-//    val tpe1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
-//    val tpe2 = Type.KindedVar(2, Kind.Star, loc, Rigidity.Rigid)
-//    val result = Unification.unifyTypes(tpe1, tpe2)
-//    assert(!isOk(result))
-//  }
-//
-//  test("unifyM.01") {
-//    val subst0 = Substitution.empty
-//    val result = Unification.unifyTypeM(Type.Bool, Type.Bool, loc).run(subst0)
-//    assert(isOk(result))
-//  }
-//
-//  test("unifyM.02") {
-//    val subst0 = Substitution.empty
-//    val result = Unification.unifyTypeM(Type.Bool, Type.Char, loc).run(subst0)
-//    assert(!isOk(result))
-//  }
-//
-//  test("unifyM.03") {
-//    val tpe1 = Type.KindedVar(1, Kind.Star, loc)
-//    val tpe2 = Type.Bool
-//    val subst0 = Substitution.empty
-//    val result = Unification.unifyTypeM(tpe1, tpe2, loc).run(subst0)
-//    val (subst, tpe) = result.get
-//    assertResult(Type.Bool)(subst(tpe1))
-//    assertResult(Type.Bool)(subst(tpe2))
-//    assertResult(Type.Bool)(tpe)
-//  }
-//
-//  test("seqM.01") {
-//    val subst0 = Substitution.empty
-//    val res1 = Unification.unifyTypeM(Type.Bool, Type.Bool, loc)
-//    val res2 = Unification.unifyTypeM(Type.Char, Type.Char, loc)
-//    val result = seqM(List(res1, res2)).run(subst0)
-//    assert(isOk(result))
-//  }
-//
-//  test("seqM.02") {
-//    val subst0 = Substitution.empty
-//    val res1 = Unification.unifyTypeM(Type.Bool, Type.Char, loc)
-//    val res2 = Unification.unifyTypeM(Type.Bool, Type.Char, loc)
-//    val result = seqM(List(res1, res2)).run(subst0)
-//    assert(!isOk(result))
-//  }
-//
-//  test("seqM.03") {
-//    val subst0 = Substitution.empty
-//    val res1 = Unification.unifyTypeM(Type.KindedVar(1, Kind.Star, loc), Type.Bool, loc)
-//    val res2 = Unification.unifyTypeM(Type.KindedVar(2, Kind.Star, loc), Type.Char, loc)
-//    val res3 = Unification.unifyTypeM(Type.KindedVar(3, Kind.Star, loc), Type.mkTuple(List(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc)), loc), loc)
-//    val result = seqM(List(res1, res2, res3)).run(subst0)
-//    val (subst, tpe) = result.get
-//    assertResult(Type.Bool)(subst.m(Type.KindedVar(1, Kind.Star, loc)))
-//    assertResult(Type.Char)(subst.m(Type.KindedVar(2, Kind.Star, loc)))
-//    assertResult(Type.mkTuple(List(Type.Bool, Type.Char), loc))(subst.m(Type.KindedVar(3, Kind.Star, loc)))
-//  }
-//
-//  private def isOk[T, E](r: Result[T, E]) = r match {
-//    case Result.Ok(_) => true
-//    case Result.Err(_) => false
-//  }
+
+  implicit val flix: Flix = new Flix()
+
+  val loc: SourceLocation = SourceLocation.Unknown
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Substitutions                                                           //
+  /////////////////////////////////////////////////////////////////////////////
+
+  test("Substitution.Empty.01") {
+    val tpe = Type.Unit
+    val subst = Substitution.empty
+    assertResult(Type.Unit)(subst(tpe))
+  }
+
+  test("Substitution.Empty.02") {
+    val tpe = Type.Bool
+    val subst = Substitution.empty
+    assertResult(Type.Bool)(subst(tpe))
+  }
+
+  test("Substitution.Empty.03") {
+    val tpe = Type.KindedVar(1, Kind.Star, loc)
+    val subst = Substitution.empty
+    assertResult(Type.KindedVar(1, Kind.Star, loc))(subst(tpe))
+  }
+
+  test("Substitution.Empty.04") {
+    val tpe = Type.mkPureArrow(Type.Bool, Type.Unit, loc)
+    val subst = Substitution.empty
+    assertResult(Type.mkPureArrow(Type.Bool, Type.Unit, loc))(subst(tpe))
+  }
+
+  test("Substitution.Singleton.01") {
+    val tpe = Type.KindedVar(1, Kind.Star, loc)
+    val subst = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Bool)
+    assertResult(Type.KindedVar(1, Kind.Star, loc))(subst(tpe))
+  }
+
+  test("Substitution.Singleton.02") {
+    val tpe = Type.KindedVar(1, Kind.Star, loc)
+    val subst = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
+    assertResult(Type.Bool)(subst(tpe))
+  }
+
+  test("Substitution.Singleton.05") {
+    val tpe = Type.KindedVar(1, Kind.Star, loc)
+    val subst = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
+    assertResult(Type.KindedVar(2, Kind.Star, loc))(subst(tpe))
+  }
+
+  test("Substitution.++.01") {
+    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
+    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
+
+    val tpe = Type.KindedVar(1, Kind.Star, loc)
+    assertResult(Type.Bool)((subst1 ++ subst2) (tpe))
+  }
+
+  test("Substitution.++.02") {
+    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
+    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
+
+    val tpe = Type.KindedVar(2, Kind.Star, loc)
+    assertResult(Type.Char)((subst1 ++ subst2) (tpe))
+  }
+
+  test("Substitution.++.03") {
+    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
+    val subst2 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Char)
+
+    val tpe = Type.KindedVar(1, Kind.Star, loc)
+    assertResult(Type.Bool)((subst1 ++ subst2) (tpe))
+  }
+
+  test("Substitution.++.04") {
+    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
+    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
+
+    val tpe = Type.mkPureArrow(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc), loc)
+    assertResult(Type.mkPureArrow(Type.Bool, Type.Char, loc))((subst1 ++ subst2) (tpe))
+  }
+
+  test("Substitution.@@.01") {
+    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
+    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
+
+    val tpe = Type.mkPureArrow(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc), loc)
+    assertResult(Type.mkPureArrow(Type.Bool, Type.Char, loc))((subst2 @@ subst1) (tpe))
+  }
+
+  test("Substitution.@@.02") {
+    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
+    val subst2 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Char)
+
+    val tpe = Type.KindedVar(1, Kind.Star, loc)
+    assertResult(Type.Bool)((subst2 @@ subst1) (tpe))
+  }
+
+  test("Substitution.@@.03") {
+    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
+    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Bool)
+
+    val tpe = Type.KindedVar(1, Kind.Star, loc)
+    assertResult(Type.Bool)((subst2 @@ subst1) (tpe))
+  }
+
+  test("Substitution.@@.04") {
+    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
+    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.KindedVar(3, Kind.Star, loc))
+    val subst3 = Substitution.singleton(Type.KindedVar(3, Kind.Star, loc), Type.Bool)
+
+    val tpe = Type.KindedVar(1, Kind.Star, loc)
+    assertResult(Type.Bool)((subst3 @@ (subst2 @@ subst1)) (tpe))
+  }
+
+  test("Unify.Var.01") {
+    val result = Unification.unifyTypes(Type.KindedVar(1, Kind.Star, loc), Type.Unit)
+    assert(isOk(result))
+  }
+
+  test("Unify.Var.02") {
+    val result = Unification.unifyTypes(Type.Unit, Type.KindedVar(1, Kind.Star, loc))
+    assert(isOk(result))
+  }
+
+  test("Unify.Var.03") {
+    val result = Unification.unifyTypes(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(1, Kind.Star, loc))
+    assert(isOk(result))
+  }
+
+  test("Unify.Var.04") {
+    val result = Unification.unifyTypes(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
+    assert(isOk(result))
+  }
+
+  test("Unify.Unit") {
+    val result = Unification.unifyTypes(Type.Unit, Type.Unit)
+    assert(isOk(result))
+  }
+
+  test("Unify.Bool") {
+    val result = Unification.unifyTypes(Type.Bool, Type.Bool)
+    assert(isOk(result))
+  }
+
+  test("Unify.Char") {
+    val result = Unification.unifyTypes(Type.Char, Type.Char)
+    assert(isOk(result))
+  }
+
+  test("Unify.Float32") {
+    val result = Unification.unifyTypes(Type.Float32, Type.Float32)
+    assert(isOk(result))
+  }
+
+  test("Unify.Float64") {
+    val result = Unification.unifyTypes(Type.Float64, Type.Float64)
+    assert(isOk(result))
+  }
+
+  test("Unify.Int8") {
+    val result = Unification.unifyTypes(Type.Int8, Type.Int8)
+    assert(isOk(result))
+  }
+
+  test("Unify.Int16") {
+    val result = Unification.unifyTypes(Type.Int16, Type.Int16)
+    assert(isOk(result))
+  }
+
+  test("Unify.Int32") {
+    val result = Unification.unifyTypes(Type.Int32, Type.Int32)
+    assert(isOk(result))
+  }
+
+  test("Unify.Int64") {
+    val result = Unification.unifyTypes(Type.Int64, Type.Int64)
+    assert(isOk(result))
+  }
+
+  test("Unify.BigInt") {
+    val result = Unification.unifyTypes(Type.BigInt, Type.BigInt)
+    assert(isOk(result))
+  }
+
+  test("Unify.Str") {
+    val result = Unification.unifyTypes(Type.Str, Type.Str)
+    assert(isOk(result))
+  }
+
+  test("Unify.01") {
+    val tpe1 = Type.KindedVar(1, Kind.Star, loc)
+    val tpe2 = Type.Bool
+    val result = Unification.unifyTypes(tpe1, tpe2).get
+    assertResult(Type.Bool)(result(tpe1))
+  }
+
+  test("Unify.02") {
+    val tpe1 = Type.Bool
+    val tpe2 = Type.KindedVar(1, Kind.Star, loc)
+    val result = Unification.unifyTypes(tpe1, tpe2).get
+    assertResult(Type.Bool)(result(tpe2))
+  }
+
+  test("Unify.03") {
+    val A = Type.KindedVar(1, Kind.Star, loc)
+    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
+    val tpe2 = Type.mkPureArrow(Type.Bool, A, loc)
+    val result = Unification.unifyTypes(tpe1, tpe2).get
+    assertResult(Type.Char)(result(A))
+  }
+
+  test("Unify.04") {
+    val A = Type.KindedVar(1, Kind.Star, loc)
+    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
+    val tpe2 = Type.mkPureArrow(Type.Bool, A, loc)
+    val result = Unification.unifyTypes(tpe1, tpe2).get
+    assertResult(Type.Char)(result(A))
+  }
+
+  test("Unify.05") {
+    val A = Type.KindedVar(1, Kind.Star, loc)
+    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
+    val tpe2 = A
+    val result = Unification.unifyTypes(tpe1, tpe2).get
+    assertResult(tpe1)(result(A))
+  }
+
+  test("Unify.06") {
+    val A = Type.KindedVar(1, Kind.Star, loc)
+    val tpe1 = A
+    val tpe2 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
+    val result = Unification.unifyTypes(tpe1, tpe2).get
+    assertResult(tpe2)(result(A))
+  }
+
+  test("Unify.07") {
+    val A = Type.KindedVar(1, Kind.Star, loc)
+    val tpe1 = Type.mkPureArrow(A, Type.Bool, loc)
+    val tpe2 = Type.mkPureArrow(Type.Bool, A, loc)
+    val result = Unification.unifyTypes(tpe1, tpe2).get
+    assertResult(Type.Bool)(result(A))
+  }
+
+  test("Unify.08") {
+    val A = Type.KindedVar(1, Kind.Star, loc)
+    val B = Type.KindedVar(2, Kind.Star, loc)
+    val tpe1 = Type.mkPureArrow(A, B, loc)
+    val tpe2 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
+    val result = Unification.unifyTypes(tpe1, tpe2).get
+    assertResult(Type.Bool)(result(A))
+    assertResult(Type.Char)(result(B))
+  }
+
+  test("Unify.09") {
+    val A = Type.KindedVar(1, Kind.Star, loc)
+    val B = Type.KindedVar(2, Kind.Star, loc)
+    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
+    val tpe2 = Type.mkPureArrow(A, B, loc)
+    val result = Unification.unifyTypes(tpe1, tpe2).get
+    assertResult(Type.Bool)(result(A))
+    assertResult(Type.Char)(result(B))
+  }
+
+  test("Unify.10") {
+    val A = Type.KindedVar(1, Kind.Star, loc)
+    val B = Type.KindedVar(2, Kind.Star, loc)
+    val tpe1 = Type.mkPureArrow(A, Type.Char, loc)
+    val tpe2 = Type.mkPureArrow(Type.Bool, B, loc)
+    val result = Unification.unifyTypes(tpe1, tpe2).get
+    assertResult(Type.Bool)(result(A))
+    assertResult(Type.Char)(result(B))
+  }
+
+  test("Unify.11") {
+    val A = Type.KindedVar(1, Kind.Star, loc)
+    val B = Type.KindedVar(2, Kind.Star, loc)
+    val C = Type.KindedVar(3, Kind.Star, loc)
+    val tpe1 = Type.mkPureArrow(A, B, loc)
+    val tpe2 = Type.mkPureArrow(C, Type.Bool, loc)
+    val result = Unification.unifyTypes(tpe1, tpe2).get
+    assertResult(Type.Bool)(result(B))
+    assertResult(C)(result(A))
+  }
+
+  test("Unify.12") {
+    val tpe1 = Type.KindedVar(1, Kind.RecordRow, loc)
+    val field = Type.Bool
+    val label = Name.Field("x", loc)
+    val tpe2 = Type.mkRecord(Type.mkRecordRowExtend(label, field, tpe1, loc), loc)
+    val result = Unification.unifyTypes(tpe1, tpe2)
+    assert(!isOk(result))
+  }
+
+  test("Unify.13") {
+    val tpe1 = Type.KindedVar(1, Kind.SchemaRow, loc)
+    val field = Type.mkRelation(List(Type.Bool), loc)
+    val label = Name.Pred("X", loc)
+    val tpe2 = Type.mkRecord(Type.mkSchemaRowExtend(label, field, tpe1, loc), loc)
+    val result = Unification.unifyTypes(tpe1, tpe2)
+    assert(!isOk(result))
+  }
+
+  test("Unify.15") {
+    val tpe1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Flexible)
+    val tpe2 = Type.KindedVar(2, Kind.RecordRow, loc, Rigidity.Rigid)
+    val result = Unification.unifyTypes(tpe1, tpe2)
+    assert(isOk(result))
+  }
+
+  test("Unify.16") {
+    val tpe1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
+    val tpe2 = Type.KindedVar(2, Kind.Star, loc, Rigidity.Rigid)
+    val result = Unification.unifyTypes(tpe1, tpe2)
+    assert(!isOk(result))
+  }
+
+  test("unifyM.01") {
+    val subst0 = Substitution.empty
+    val result = Unification.unifyTypeM(Type.Bool, Type.Bool, loc).run(subst0)
+    assert(isOk(result))
+  }
+
+  test("unifyM.02") {
+    val subst0 = Substitution.empty
+    val result = Unification.unifyTypeM(Type.Bool, Type.Char, loc).run(subst0)
+    assert(!isOk(result))
+  }
+
+  test("unifyM.03") {
+    val tpe1 = Type.KindedVar(1, Kind.Star, loc)
+    val tpe2 = Type.Bool
+    val subst0 = Substitution.empty
+    val result = Unification.unifyTypeM(tpe1, tpe2, loc).run(subst0)
+    val (subst, tpe) = result.get
+    assertResult(Type.Bool)(subst(tpe1))
+    assertResult(Type.Bool)(subst(tpe2))
+    assertResult(Type.Bool)(tpe)
+  }
+
+  test("seqM.01") {
+    val subst0 = Substitution.empty
+    val res1 = Unification.unifyTypeM(Type.Bool, Type.Bool, loc)
+    val res2 = Unification.unifyTypeM(Type.Char, Type.Char, loc)
+    val result = seqM(List(res1, res2)).run(subst0)
+    assert(isOk(result))
+  }
+
+  test("seqM.02") {
+    val subst0 = Substitution.empty
+    val res1 = Unification.unifyTypeM(Type.Bool, Type.Char, loc)
+    val res2 = Unification.unifyTypeM(Type.Bool, Type.Char, loc)
+    val result = seqM(List(res1, res2)).run(subst0)
+    assert(!isOk(result))
+  }
+
+  test("seqM.03") {
+    val subst0 = Substitution.empty
+    val res1 = Unification.unifyTypeM(Type.KindedVar(1, Kind.Star, loc), Type.Bool, loc)
+    val res2 = Unification.unifyTypeM(Type.KindedVar(2, Kind.Star, loc), Type.Char, loc)
+    val res3 = Unification.unifyTypeM(Type.KindedVar(3, Kind.Star, loc), Type.mkTuple(List(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc)), loc), loc)
+    val result = seqM(List(res1, res2, res3)).run(subst0)
+    val (subst, tpe) = result.get
+    assertResult(Type.Bool)(subst.m(Type.KindedVar(1, Kind.Star, loc)))
+    assertResult(Type.Char)(subst.m(Type.KindedVar(2, Kind.Star, loc)))
+    assertResult(Type.mkTuple(List(Type.Bool, Type.Char), loc))(subst.m(Type.KindedVar(3, Kind.Star, loc)))
+  }
+
+  private def isOk[T, E](r: Result[T, E]) = r match {
+    case Result.Ok(_) => true
+    case Result.Err(_) => false
+  }
 
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/unification/TestUnification.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/unification/TestUnification.scala
@@ -24,392 +24,393 @@ import ca.uwaterloo.flix.util.Result
 import org.scalatest.FunSuite
 
 class TestUnification extends FunSuite with TestUtils {
-
-  implicit val flix: Flix = new Flix()
-
-  val loc: SourceLocation = SourceLocation.Unknown
-
-  /////////////////////////////////////////////////////////////////////////////
-  // Substitutions                                                           //
-  /////////////////////////////////////////////////////////////////////////////
-
-  test("Substitution.Empty.01") {
-    val tpe = Type.Unit
-    val subst = Substitution.empty
-    assertResult(Type.Unit)(subst(tpe))
-  }
-
-  test("Substitution.Empty.02") {
-    val tpe = Type.Bool
-    val subst = Substitution.empty
-    assertResult(Type.Bool)(subst(tpe))
-  }
-
-  test("Substitution.Empty.03") {
-    val tpe = Type.KindedVar(1, Kind.Star, loc)
-    val subst = Substitution.empty
-    assertResult(Type.KindedVar(1, Kind.Star, loc))(subst(tpe))
-  }
-
-  test("Substitution.Empty.04") {
-    val tpe = Type.mkPureArrow(Type.Bool, Type.Unit, loc)
-    val subst = Substitution.empty
-    assertResult(Type.mkPureArrow(Type.Bool, Type.Unit, loc))(subst(tpe))
-  }
-
-  test("Substitution.Singleton.01") {
-    val tpe = Type.KindedVar(1, Kind.Star, loc)
-    val subst = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Bool)
-    assertResult(Type.KindedVar(1, Kind.Star, loc))(subst(tpe))
-  }
-
-  test("Substitution.Singleton.02") {
-    val tpe = Type.KindedVar(1, Kind.Star, loc)
-    val subst = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
-    assertResult(Type.Bool)(subst(tpe))
-  }
-
-  test("Substitution.Singleton.05") {
-    val tpe = Type.KindedVar(1, Kind.Star, loc)
-    val subst = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
-    assertResult(Type.KindedVar(2, Kind.Star, loc))(subst(tpe))
-  }
-
-  test("Substitution.++.01") {
-    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
-    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
-
-    val tpe = Type.KindedVar(1, Kind.Star, loc)
-    assertResult(Type.Bool)((subst1 ++ subst2) (tpe))
-  }
-
-  test("Substitution.++.02") {
-    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
-    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
-
-    val tpe = Type.KindedVar(2, Kind.Star, loc)
-    assertResult(Type.Char)((subst1 ++ subst2) (tpe))
-  }
-
-  test("Substitution.++.03") {
-    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
-    val subst2 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Char)
-
-    val tpe = Type.KindedVar(1, Kind.Star, loc)
-    assertResult(Type.Bool)((subst1 ++ subst2) (tpe))
-  }
-
-  test("Substitution.++.04") {
-    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
-    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
-
-    val tpe = Type.mkPureArrow(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc), loc)
-    assertResult(Type.mkPureArrow(Type.Bool, Type.Char, loc))((subst1 ++ subst2) (tpe))
-  }
-
-  test("Substitution.@@.01") {
-    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
-    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
-
-    val tpe = Type.mkPureArrow(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc), loc)
-    assertResult(Type.mkPureArrow(Type.Bool, Type.Char, loc))((subst2 @@ subst1) (tpe))
-  }
-
-  test("Substitution.@@.02") {
-    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
-    val subst2 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Char)
-
-    val tpe = Type.KindedVar(1, Kind.Star, loc)
-    assertResult(Type.Bool)((subst2 @@ subst1) (tpe))
-  }
-
-  test("Substitution.@@.03") {
-    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
-    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Bool)
-
-    val tpe = Type.KindedVar(1, Kind.Star, loc)
-    assertResult(Type.Bool)((subst2 @@ subst1) (tpe))
-  }
-
-  test("Substitution.@@.04") {
-    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
-    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.KindedVar(3, Kind.Star, loc))
-    val subst3 = Substitution.singleton(Type.KindedVar(3, Kind.Star, loc), Type.Bool)
-
-    val tpe = Type.KindedVar(1, Kind.Star, loc)
-    assertResult(Type.Bool)((subst3 @@ (subst2 @@ subst1)) (tpe))
-  }
-
-  test("Unify.Var.01") {
-    val result = Unification.unifyTypes(Type.KindedVar(1, Kind.Star, loc), Type.Unit)
-    assert(isOk(result))
-  }
-
-  test("Unify.Var.02") {
-    val result = Unification.unifyTypes(Type.Unit, Type.KindedVar(1, Kind.Star, loc))
-    assert(isOk(result))
-  }
-
-  test("Unify.Var.03") {
-    val result = Unification.unifyTypes(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(1, Kind.Star, loc))
-    assert(isOk(result))
-  }
-
-  test("Unify.Var.04") {
-    val result = Unification.unifyTypes(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
-    assert(isOk(result))
-  }
-
-  test("Unify.Unit") {
-    val result = Unification.unifyTypes(Type.Unit, Type.Unit)
-    assert(isOk(result))
-  }
-
-  test("Unify.Bool") {
-    val result = Unification.unifyTypes(Type.Bool, Type.Bool)
-    assert(isOk(result))
-  }
-
-  test("Unify.Char") {
-    val result = Unification.unifyTypes(Type.Char, Type.Char)
-    assert(isOk(result))
-  }
-
-  test("Unify.Float32") {
-    val result = Unification.unifyTypes(Type.Float32, Type.Float32)
-    assert(isOk(result))
-  }
-
-  test("Unify.Float64") {
-    val result = Unification.unifyTypes(Type.Float64, Type.Float64)
-    assert(isOk(result))
-  }
-
-  test("Unify.Int8") {
-    val result = Unification.unifyTypes(Type.Int8, Type.Int8)
-    assert(isOk(result))
-  }
-
-  test("Unify.Int16") {
-    val result = Unification.unifyTypes(Type.Int16, Type.Int16)
-    assert(isOk(result))
-  }
-
-  test("Unify.Int32") {
-    val result = Unification.unifyTypes(Type.Int32, Type.Int32)
-    assert(isOk(result))
-  }
-
-  test("Unify.Int64") {
-    val result = Unification.unifyTypes(Type.Int64, Type.Int64)
-    assert(isOk(result))
-  }
-
-  test("Unify.BigInt") {
-    val result = Unification.unifyTypes(Type.BigInt, Type.BigInt)
-    assert(isOk(result))
-  }
-
-  test("Unify.Str") {
-    val result = Unification.unifyTypes(Type.Str, Type.Str)
-    assert(isOk(result))
-  }
-
-  test("Unify.01") {
-    val tpe1 = Type.KindedVar(1, Kind.Star, loc)
-    val tpe2 = Type.Bool
-    val result = Unification.unifyTypes(tpe1, tpe2).get
-    assertResult(Type.Bool)(result(tpe1))
-  }
-
-  test("Unify.02") {
-    val tpe1 = Type.Bool
-    val tpe2 = Type.KindedVar(1, Kind.Star, loc)
-    val result = Unification.unifyTypes(tpe1, tpe2).get
-    assertResult(Type.Bool)(result(tpe2))
-  }
-
-  test("Unify.03") {
-    val A = Type.KindedVar(1, Kind.Star, loc)
-    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
-    val tpe2 = Type.mkPureArrow(Type.Bool, A, loc)
-    val result = Unification.unifyTypes(tpe1, tpe2).get
-    assertResult(Type.Char)(result(A))
-  }
-
-  test("Unify.04") {
-    val A = Type.KindedVar(1, Kind.Star, loc)
-    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
-    val tpe2 = Type.mkPureArrow(Type.Bool, A, loc)
-    val result = Unification.unifyTypes(tpe1, tpe2).get
-    assertResult(Type.Char)(result(A))
-  }
-
-  test("Unify.05") {
-    val A = Type.KindedVar(1, Kind.Star, loc)
-    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
-    val tpe2 = A
-    val result = Unification.unifyTypes(tpe1, tpe2).get
-    assertResult(tpe1)(result(A))
-  }
-
-  test("Unify.06") {
-    val A = Type.KindedVar(1, Kind.Star, loc)
-    val tpe1 = A
-    val tpe2 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
-    val result = Unification.unifyTypes(tpe1, tpe2).get
-    assertResult(tpe2)(result(A))
-  }
-
-  test("Unify.07") {
-    val A = Type.KindedVar(1, Kind.Star, loc)
-    val tpe1 = Type.mkPureArrow(A, Type.Bool, loc)
-    val tpe2 = Type.mkPureArrow(Type.Bool, A, loc)
-    val result = Unification.unifyTypes(tpe1, tpe2).get
-    assertResult(Type.Bool)(result(A))
-  }
-
-  test("Unify.08") {
-    val A = Type.KindedVar(1, Kind.Star, loc)
-    val B = Type.KindedVar(2, Kind.Star, loc)
-    val tpe1 = Type.mkPureArrow(A, B, loc)
-    val tpe2 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
-    val result = Unification.unifyTypes(tpe1, tpe2).get
-    assertResult(Type.Bool)(result(A))
-    assertResult(Type.Char)(result(B))
-  }
-
-  test("Unify.09") {
-    val A = Type.KindedVar(1, Kind.Star, loc)
-    val B = Type.KindedVar(2, Kind.Star, loc)
-    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
-    val tpe2 = Type.mkPureArrow(A, B, loc)
-    val result = Unification.unifyTypes(tpe1, tpe2).get
-    assertResult(Type.Bool)(result(A))
-    assertResult(Type.Char)(result(B))
-  }
-
-  test("Unify.10") {
-    val A = Type.KindedVar(1, Kind.Star, loc)
-    val B = Type.KindedVar(2, Kind.Star, loc)
-    val tpe1 = Type.mkPureArrow(A, Type.Char, loc)
-    val tpe2 = Type.mkPureArrow(Type.Bool, B, loc)
-    val result = Unification.unifyTypes(tpe1, tpe2).get
-    assertResult(Type.Bool)(result(A))
-    assertResult(Type.Char)(result(B))
-  }
-
-  test("Unify.11") {
-    val A = Type.KindedVar(1, Kind.Star, loc)
-    val B = Type.KindedVar(2, Kind.Star, loc)
-    val C = Type.KindedVar(3, Kind.Star, loc)
-    val tpe1 = Type.mkPureArrow(A, B, loc)
-    val tpe2 = Type.mkPureArrow(C, Type.Bool, loc)
-    val result = Unification.unifyTypes(tpe1, tpe2).get
-    assertResult(Type.Bool)(result(B))
-    assertResult(C)(result(A))
-  }
-
-  test("Unify.12") {
-    val tpe1 = Type.KindedVar(1, Kind.Record, loc)
-    val field = Type.Bool
-    val label = Name.Field("x", loc)
-    val tpe2 = Type.mkRecordExtend(label, field, tpe1, loc)
-    val result = Unification.unifyTypes(tpe1, tpe2)
-    assert(!isOk(result))
-  }
-
-  test("Unify.13") {
-    val tpe1 = Type.KindedVar(1, Kind.Schema, loc)
-    val field = Type.mkRelation(List(Type.Bool), loc)
-    val label = Name.Pred("X", loc)
-    val tpe2 = Type.mkSchemaExtend(label, field, tpe1, loc)
-    val result = Unification.unifyTypes(tpe1, tpe2)
-    assert(!isOk(result))
-  }
-
-  test("Unify.14") {
-    val tpe1 = Type.KindedVar(1, Kind.Schema, loc)
-    val tpe2 = Type.KindedVar(2, Kind.Record, loc)
-    val result = Unification.unifyTypes(tpe1, tpe2)
-    assert(!isOk(result))
-  }
-
-  test("Unify.15") {
-    val tpe1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
-    val tpe2 = Type.KindedVar(2, Kind.Record, loc, Rigidity.Flexible)
-    val result = Unification.unifyTypes(tpe1, tpe2)
-    assert(!isOk(result))
-  }
-
-  test("Unify.16") {
-    val tpe1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Flexible)
-    val tpe2 = Type.KindedVar(2, Kind.Record, loc, Rigidity.Rigid)
-    val result = Unification.unifyTypes(tpe1, tpe2)
-    assert(isOk(result))
-  }
-
-  test("Unify.17") {
-    val tpe1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
-    val tpe2 = Type.KindedVar(2, Kind.Star, loc, Rigidity.Rigid)
-    val result = Unification.unifyTypes(tpe1, tpe2)
-    assert(!isOk(result))
-  }
-
-  test("unifyM.01") {
-    val subst0 = Substitution.empty
-    val result = Unification.unifyTypeM(Type.Bool, Type.Bool, loc).run(subst0)
-    assert(isOk(result))
-  }
-
-  test("unifyM.02") {
-    val subst0 = Substitution.empty
-    val result = Unification.unifyTypeM(Type.Bool, Type.Char, loc).run(subst0)
-    assert(!isOk(result))
-  }
-
-  test("unifyM.03") {
-    val tpe1 = Type.KindedVar(1, Kind.Star, loc)
-    val tpe2 = Type.Bool
-    val subst0 = Substitution.empty
-    val result = Unification.unifyTypeM(tpe1, tpe2, loc).run(subst0)
-    val (subst, tpe) = result.get
-    assertResult(Type.Bool)(subst(tpe1))
-    assertResult(Type.Bool)(subst(tpe2))
-    assertResult(Type.Bool)(tpe)
-  }
-
-  test("seqM.01") {
-    val subst0 = Substitution.empty
-    val res1 = Unification.unifyTypeM(Type.Bool, Type.Bool, loc)
-    val res2 = Unification.unifyTypeM(Type.Char, Type.Char, loc)
-    val result = seqM(List(res1, res2)).run(subst0)
-    assert(isOk(result))
-  }
-
-  test("seqM.02") {
-    val subst0 = Substitution.empty
-    val res1 = Unification.unifyTypeM(Type.Bool, Type.Char, loc)
-    val res2 = Unification.unifyTypeM(Type.Bool, Type.Char, loc)
-    val result = seqM(List(res1, res2)).run(subst0)
-    assert(!isOk(result))
-  }
-
-  test("seqM.03") {
-    val subst0 = Substitution.empty
-    val res1 = Unification.unifyTypeM(Type.KindedVar(1, Kind.Star, loc), Type.Bool, loc)
-    val res2 = Unification.unifyTypeM(Type.KindedVar(2, Kind.Star, loc), Type.Char, loc)
-    val res3 = Unification.unifyTypeM(Type.KindedVar(3, Kind.Star, loc), Type.mkTuple(List(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc)), loc), loc)
-    val result = seqM(List(res1, res2, res3)).run(subst0)
-    val (subst, tpe) = result.get
-    assertResult(Type.Bool)(subst.m(Type.KindedVar(1, Kind.Star, loc)))
-    assertResult(Type.Char)(subst.m(Type.KindedVar(2, Kind.Star, loc)))
-    assertResult(Type.mkTuple(List(Type.Bool, Type.Char), loc))(subst.m(Type.KindedVar(3, Kind.Star, loc)))
-  }
-
-  private def isOk[T, E](r: Result[T, E]) = r match {
-    case Result.Ok(_) => true
-    case Result.Err(_) => false
-  }
+  // MATT disabling for now
+//
+//  implicit val flix: Flix = new Flix()
+//
+//  val loc: SourceLocation = SourceLocation.Unknown
+//
+//  /////////////////////////////////////////////////////////////////////////////
+//  // Substitutions                                                           //
+//  /////////////////////////////////////////////////////////////////////////////
+//
+//  test("Substitution.Empty.01") {
+//    val tpe = Type.Unit
+//    val subst = Substitution.empty
+//    assertResult(Type.Unit)(subst(tpe))
+//  }
+//
+//  test("Substitution.Empty.02") {
+//    val tpe = Type.Bool
+//    val subst = Substitution.empty
+//    assertResult(Type.Bool)(subst(tpe))
+//  }
+//
+//  test("Substitution.Empty.03") {
+//    val tpe = Type.KindedVar(1, Kind.Star, loc)
+//    val subst = Substitution.empty
+//    assertResult(Type.KindedVar(1, Kind.Star, loc))(subst(tpe))
+//  }
+//
+//  test("Substitution.Empty.04") {
+//    val tpe = Type.mkPureArrow(Type.Bool, Type.Unit, loc)
+//    val subst = Substitution.empty
+//    assertResult(Type.mkPureArrow(Type.Bool, Type.Unit, loc))(subst(tpe))
+//  }
+//
+//  test("Substitution.Singleton.01") {
+//    val tpe = Type.KindedVar(1, Kind.Star, loc)
+//    val subst = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Bool)
+//    assertResult(Type.KindedVar(1, Kind.Star, loc))(subst(tpe))
+//  }
+//
+//  test("Substitution.Singleton.02") {
+//    val tpe = Type.KindedVar(1, Kind.Star, loc)
+//    val subst = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
+//    assertResult(Type.Bool)(subst(tpe))
+//  }
+//
+//  test("Substitution.Singleton.05") {
+//    val tpe = Type.KindedVar(1, Kind.Star, loc)
+//    val subst = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
+//    assertResult(Type.KindedVar(2, Kind.Star, loc))(subst(tpe))
+//  }
+//
+//  test("Substitution.++.01") {
+//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
+//    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
+//
+//    val tpe = Type.KindedVar(1, Kind.Star, loc)
+//    assertResult(Type.Bool)((subst1 ++ subst2) (tpe))
+//  }
+//
+//  test("Substitution.++.02") {
+//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
+//    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
+//
+//    val tpe = Type.KindedVar(2, Kind.Star, loc)
+//    assertResult(Type.Char)((subst1 ++ subst2) (tpe))
+//  }
+//
+//  test("Substitution.++.03") {
+//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
+//    val subst2 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Char)
+//
+//    val tpe = Type.KindedVar(1, Kind.Star, loc)
+//    assertResult(Type.Bool)((subst1 ++ subst2) (tpe))
+//  }
+//
+//  test("Substitution.++.04") {
+//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
+//    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
+//
+//    val tpe = Type.mkPureArrow(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc), loc)
+//    assertResult(Type.mkPureArrow(Type.Bool, Type.Char, loc))((subst1 ++ subst2) (tpe))
+//  }
+//
+//  test("Substitution.@@.01") {
+//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
+//    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Char)
+//
+//    val tpe = Type.mkPureArrow(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc), loc)
+//    assertResult(Type.mkPureArrow(Type.Bool, Type.Char, loc))((subst2 @@ subst1) (tpe))
+//  }
+//
+//  test("Substitution.@@.02") {
+//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Bool)
+//    val subst2 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.Char)
+//
+//    val tpe = Type.KindedVar(1, Kind.Star, loc)
+//    assertResult(Type.Bool)((subst2 @@ subst1) (tpe))
+//  }
+//
+//  test("Substitution.@@.03") {
+//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
+//    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.Bool)
+//
+//    val tpe = Type.KindedVar(1, Kind.Star, loc)
+//    assertResult(Type.Bool)((subst2 @@ subst1) (tpe))
+//  }
+//
+//  test("Substitution.@@.04") {
+//    val subst1 = Substitution.singleton(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
+//    val subst2 = Substitution.singleton(Type.KindedVar(2, Kind.Star, loc), Type.KindedVar(3, Kind.Star, loc))
+//    val subst3 = Substitution.singleton(Type.KindedVar(3, Kind.Star, loc), Type.Bool)
+//
+//    val tpe = Type.KindedVar(1, Kind.Star, loc)
+//    assertResult(Type.Bool)((subst3 @@ (subst2 @@ subst1)) (tpe))
+//  }
+//
+//  test("Unify.Var.01") {
+//    val result = Unification.unifyTypes(Type.KindedVar(1, Kind.Star, loc), Type.Unit)
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.Var.02") {
+//    val result = Unification.unifyTypes(Type.Unit, Type.KindedVar(1, Kind.Star, loc))
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.Var.03") {
+//    val result = Unification.unifyTypes(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(1, Kind.Star, loc))
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.Var.04") {
+//    val result = Unification.unifyTypes(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc))
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.Unit") {
+//    val result = Unification.unifyTypes(Type.Unit, Type.Unit)
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.Bool") {
+//    val result = Unification.unifyTypes(Type.Bool, Type.Bool)
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.Char") {
+//    val result = Unification.unifyTypes(Type.Char, Type.Char)
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.Float32") {
+//    val result = Unification.unifyTypes(Type.Float32, Type.Float32)
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.Float64") {
+//    val result = Unification.unifyTypes(Type.Float64, Type.Float64)
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.Int8") {
+//    val result = Unification.unifyTypes(Type.Int8, Type.Int8)
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.Int16") {
+//    val result = Unification.unifyTypes(Type.Int16, Type.Int16)
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.Int32") {
+//    val result = Unification.unifyTypes(Type.Int32, Type.Int32)
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.Int64") {
+//    val result = Unification.unifyTypes(Type.Int64, Type.Int64)
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.BigInt") {
+//    val result = Unification.unifyTypes(Type.BigInt, Type.BigInt)
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.Str") {
+//    val result = Unification.unifyTypes(Type.Str, Type.Str)
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.01") {
+//    val tpe1 = Type.KindedVar(1, Kind.Star, loc)
+//    val tpe2 = Type.Bool
+//    val result = Unification.unifyTypes(tpe1, tpe2).get
+//    assertResult(Type.Bool)(result(tpe1))
+//  }
+//
+//  test("Unify.02") {
+//    val tpe1 = Type.Bool
+//    val tpe2 = Type.KindedVar(1, Kind.Star, loc)
+//    val result = Unification.unifyTypes(tpe1, tpe2).get
+//    assertResult(Type.Bool)(result(tpe2))
+//  }
+//
+//  test("Unify.03") {
+//    val A = Type.KindedVar(1, Kind.Star, loc)
+//    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
+//    val tpe2 = Type.mkPureArrow(Type.Bool, A, loc)
+//    val result = Unification.unifyTypes(tpe1, tpe2).get
+//    assertResult(Type.Char)(result(A))
+//  }
+//
+//  test("Unify.04") {
+//    val A = Type.KindedVar(1, Kind.Star, loc)
+//    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
+//    val tpe2 = Type.mkPureArrow(Type.Bool, A, loc)
+//    val result = Unification.unifyTypes(tpe1, tpe2).get
+//    assertResult(Type.Char)(result(A))
+//  }
+//
+//  test("Unify.05") {
+//    val A = Type.KindedVar(1, Kind.Star, loc)
+//    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
+//    val tpe2 = A
+//    val result = Unification.unifyTypes(tpe1, tpe2).get
+//    assertResult(tpe1)(result(A))
+//  }
+//
+//  test("Unify.06") {
+//    val A = Type.KindedVar(1, Kind.Star, loc)
+//    val tpe1 = A
+//    val tpe2 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
+//    val result = Unification.unifyTypes(tpe1, tpe2).get
+//    assertResult(tpe2)(result(A))
+//  }
+//
+//  test("Unify.07") {
+//    val A = Type.KindedVar(1, Kind.Star, loc)
+//    val tpe1 = Type.mkPureArrow(A, Type.Bool, loc)
+//    val tpe2 = Type.mkPureArrow(Type.Bool, A, loc)
+//    val result = Unification.unifyTypes(tpe1, tpe2).get
+//    assertResult(Type.Bool)(result(A))
+//  }
+//
+//  test("Unify.08") {
+//    val A = Type.KindedVar(1, Kind.Star, loc)
+//    val B = Type.KindedVar(2, Kind.Star, loc)
+//    val tpe1 = Type.mkPureArrow(A, B, loc)
+//    val tpe2 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
+//    val result = Unification.unifyTypes(tpe1, tpe2).get
+//    assertResult(Type.Bool)(result(A))
+//    assertResult(Type.Char)(result(B))
+//  }
+//
+//  test("Unify.09") {
+//    val A = Type.KindedVar(1, Kind.Star, loc)
+//    val B = Type.KindedVar(2, Kind.Star, loc)
+//    val tpe1 = Type.mkPureArrow(Type.Bool, Type.Char, loc)
+//    val tpe2 = Type.mkPureArrow(A, B, loc)
+//    val result = Unification.unifyTypes(tpe1, tpe2).get
+//    assertResult(Type.Bool)(result(A))
+//    assertResult(Type.Char)(result(B))
+//  }
+//
+//  test("Unify.10") {
+//    val A = Type.KindedVar(1, Kind.Star, loc)
+//    val B = Type.KindedVar(2, Kind.Star, loc)
+//    val tpe1 = Type.mkPureArrow(A, Type.Char, loc)
+//    val tpe2 = Type.mkPureArrow(Type.Bool, B, loc)
+//    val result = Unification.unifyTypes(tpe1, tpe2).get
+//    assertResult(Type.Bool)(result(A))
+//    assertResult(Type.Char)(result(B))
+//  }
+//
+//  test("Unify.11") {
+//    val A = Type.KindedVar(1, Kind.Star, loc)
+//    val B = Type.KindedVar(2, Kind.Star, loc)
+//    val C = Type.KindedVar(3, Kind.Star, loc)
+//    val tpe1 = Type.mkPureArrow(A, B, loc)
+//    val tpe2 = Type.mkPureArrow(C, Type.Bool, loc)
+//    val result = Unification.unifyTypes(tpe1, tpe2).get
+//    assertResult(Type.Bool)(result(B))
+//    assertResult(C)(result(A))
+//  }
+//
+//  test("Unify.12") {
+//    val tpe1 = Type.KindedVar(1, Kind.Record, loc)
+//    val field = Type.Bool
+//    val label = Name.Field("x", loc)
+//    val tpe2 = Type.mkRecordExtend(label, field, tpe1, loc)
+//    val result = Unification.unifyTypes(tpe1, tpe2)
+//    assert(!isOk(result))
+//  }
+//
+//  test("Unify.13") {
+//    val tpe1 = Type.KindedVar(1, Kind.Schema, loc)
+//    val field = Type.mkRelation(List(Type.Bool), loc)
+//    val label = Name.Pred("X", loc)
+//    val tpe2 = Type.mkSchemaExtend(label, field, tpe1, loc)
+//    val result = Unification.unifyTypes(tpe1, tpe2)
+//    assert(!isOk(result))
+//  }
+//
+//  test("Unify.14") {
+//    val tpe1 = Type.KindedVar(1, Kind.Schema, loc)
+//    val tpe2 = Type.KindedVar(2, Kind.Record, loc)
+//    val result = Unification.unifyTypes(tpe1, tpe2)
+//    assert(!isOk(result))
+//  }
+//
+//  test("Unify.15") {
+//    val tpe1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
+//    val tpe2 = Type.KindedVar(2, Kind.Record, loc, Rigidity.Flexible)
+//    val result = Unification.unifyTypes(tpe1, tpe2)
+//    assert(!isOk(result))
+//  }
+//
+//  test("Unify.16") {
+//    val tpe1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Flexible)
+//    val tpe2 = Type.KindedVar(2, Kind.Record, loc, Rigidity.Rigid)
+//    val result = Unification.unifyTypes(tpe1, tpe2)
+//    assert(isOk(result))
+//  }
+//
+//  test("Unify.17") {
+//    val tpe1 = Type.KindedVar(1, Kind.Star, loc, Rigidity.Rigid)
+//    val tpe2 = Type.KindedVar(2, Kind.Star, loc, Rigidity.Rigid)
+//    val result = Unification.unifyTypes(tpe1, tpe2)
+//    assert(!isOk(result))
+//  }
+//
+//  test("unifyM.01") {
+//    val subst0 = Substitution.empty
+//    val result = Unification.unifyTypeM(Type.Bool, Type.Bool, loc).run(subst0)
+//    assert(isOk(result))
+//  }
+//
+//  test("unifyM.02") {
+//    val subst0 = Substitution.empty
+//    val result = Unification.unifyTypeM(Type.Bool, Type.Char, loc).run(subst0)
+//    assert(!isOk(result))
+//  }
+//
+//  test("unifyM.03") {
+//    val tpe1 = Type.KindedVar(1, Kind.Star, loc)
+//    val tpe2 = Type.Bool
+//    val subst0 = Substitution.empty
+//    val result = Unification.unifyTypeM(tpe1, tpe2, loc).run(subst0)
+//    val (subst, tpe) = result.get
+//    assertResult(Type.Bool)(subst(tpe1))
+//    assertResult(Type.Bool)(subst(tpe2))
+//    assertResult(Type.Bool)(tpe)
+//  }
+//
+//  test("seqM.01") {
+//    val subst0 = Substitution.empty
+//    val res1 = Unification.unifyTypeM(Type.Bool, Type.Bool, loc)
+//    val res2 = Unification.unifyTypeM(Type.Char, Type.Char, loc)
+//    val result = seqM(List(res1, res2)).run(subst0)
+//    assert(isOk(result))
+//  }
+//
+//  test("seqM.02") {
+//    val subst0 = Substitution.empty
+//    val res1 = Unification.unifyTypeM(Type.Bool, Type.Char, loc)
+//    val res2 = Unification.unifyTypeM(Type.Bool, Type.Char, loc)
+//    val result = seqM(List(res1, res2)).run(subst0)
+//    assert(!isOk(result))
+//  }
+//
+//  test("seqM.03") {
+//    val subst0 = Substitution.empty
+//    val res1 = Unification.unifyTypeM(Type.KindedVar(1, Kind.Star, loc), Type.Bool, loc)
+//    val res2 = Unification.unifyTypeM(Type.KindedVar(2, Kind.Star, loc), Type.Char, loc)
+//    val res3 = Unification.unifyTypeM(Type.KindedVar(3, Kind.Star, loc), Type.mkTuple(List(Type.KindedVar(1, Kind.Star, loc), Type.KindedVar(2, Kind.Star, loc)), loc), loc)
+//    val result = seqM(List(res1, res2, res3)).run(subst0)
+//    val (subst, tpe) = result.get
+//    assertResult(Type.Bool)(subst.m(Type.KindedVar(1, Kind.Star, loc)))
+//    assertResult(Type.Char)(subst.m(Type.KindedVar(2, Kind.Star, loc)))
+//    assertResult(Type.mkTuple(List(Type.Bool, Type.Char), loc))(subst.m(Type.KindedVar(3, Kind.Star, loc)))
+//  }
+//
+//  private def isOk[T, E](r: Result[T, E]) = r match {
+//    case Result.Ok(_) => true
+//    case Result.Err(_) => false
+//  }
 
 }

--- a/main/test/flix/Test.Dec.RelAlias.flix
+++ b/main/test/flix/Test.Dec.RelAlias.flix
@@ -49,6 +49,6 @@ namespace Test/Dec/RelAlias {
 
     type alias Y = #{ A, B, C[Bool] }
 
-    type alias Z[r: Schema] = #{ A | r }
+    type alias Z[r: SchemaRow] = #{ A | r }
 
 }

--- a/main/test/flix/Test.Kind.Def.flix
+++ b/main/test/flix/Test.Kind.Def.flix
@@ -7,27 +7,19 @@ namespace Test/Def/Kinding {
 
             pub def star(x: a): Int = ???
 
-            pub def record(x: { l: Int | a }): Int = ???
+            pub def recordRow(x: { l: Int | a }): Int = ???
 
-            pub def schema(x: #{ R | a }): Int = ???
+            pub def schemaRow(x: #{ R | a }): Int = ???
 
             pub def bool(x: Int -> Int & a): Int = ???
 
             pub def starToStar(x: a[Int]): Int = ???
-
-            pub def starRecord(x: a, y: { l: Int | a }): Int = ???
-
-            pub def starSchema(x: a, y: #{ R | a }): Int = ???
         }
 
         namespace Return {
             rel R(i: Int)
 
             pub def star(): a = ???
-
-            pub def recordStar(x: { l: Int | a }): a = ???
-
-            pub def schemaStar(x: #{ R | a }): a = ???
         }
 
         namespace TypeConstraint {
@@ -42,22 +34,18 @@ namespace Test/Def/Kinding {
         namespace Enum {
             pub enum EStar[_a: Type]
             pub enum EBool[_a: Bool]
-            pub enum ERecord[_a: Record]
-            pub enum ESchema[_a: Schema]
+            pub enum ERecordRow[_a: RecordRow]
+            pub enum ESchemaRow[_a: SchemaRow]
 
             pub def star(x: EStar[a]): Int = ???
 
             pub def bool(x: EBool[a]): Int = ???
 
-            pub def record(x: ERecord[a]): Int = ???
+            pub def record(x: ERecordRow[a]): Int = ???
 
-            pub def schema(x: ESchema[a]): Int = ???
+            pub def schema(x: ESchemaRow[a]): Int = ???
 
             pub def starStar(x: a, y: EStar[a]): Int = ???
-
-            pub def starRecord(x: a, y: ERecord[a]): Int = ???
-
-            pub def starSchema(x: a, y: ESchema[a]): Int = ???
         }
 
         namespace Effect {
@@ -74,10 +62,6 @@ namespace Test/Def/Kinding {
             rel R(i: Int)
 
             pub def star(x: a): Int = ???: a; ???
-
-            pub def record(x: { l: Int | a }): Int = ???: a; ???
-
-            pub def schema(x: #{ R | a }): Int = ???: a; ???
         }
     }
 
@@ -88,27 +72,19 @@ namespace Test/Def/Kinding {
 
             pub def star[a: Type](x: a): Int = ???
 
-            pub def record[a: Record](x: { l: Int | a }): Int = ???
+            pub def recordRow[a: RecordRow](x: { l: Int | a }): Int = ???
 
-            pub def schema[a: Schema](x: #{ R | a }): Int = ???
+            pub def schemaRow[a: SchemaRow](x: #{ R | a }): Int = ???
 
             pub def bool[a: Bool](x: Int -> Int & a): Int = ???
 
             pub def starToStar[a: Type -> Type](x: a[Int]): Int = ???
-
-            pub def starRecord[a: Record](x: a, y: { l: Int | a }): Int = ???
-
-            pub def starSchema[a: Schema](x: a, y: #{ R | a }): Int = ???
         }
 
         namespace Return {
             rel R(i: Int)
 
             pub def star[a: Type](): a = ???
-
-            pub def recordStar[a: Record](x: { l: Int | a }): a = ???
-
-            pub def schemaStar[a: Schema](x: #{ R | a }): a = ???
         }
 
         namespace TypeConstraint {
@@ -127,22 +103,18 @@ namespace Test/Def/Kinding {
         namespace Enum {
             pub enum EStar[_a: Type]
             pub enum EBool[_a: Bool]
-            pub enum ERecord[_a: Record]
-            pub enum ESchema[_a: Schema]
+            pub enum ERecordRow[_a: RecordRow]
+            pub enum ESchemaRow[_a: SchemaRow]
 
             pub def star[a: Type](x: EStar[a]): Int = ???
 
             pub def bool[a: Bool](x: EBool[a]): Int = ???
 
-            pub def record[a: Record](x: ERecord[a]): Int = ???
+            pub def recordRow[a: RecordRow](x: ERecordRow[a]): Int = ???
 
-            pub def schema[a: Schema](x: ESchema[a]): Int = ???
+            pub def schemaRow[a: SchemaRow](x: ESchemaRow[a]): Int = ???
 
             pub def starStar[a: Type](x: a, y: EStar[a]): Int = ???
-
-            pub def starRecord[a: Record](x: a, y: ERecord[a]): Int = ???
-
-            pub def starSchema[a: Schema](x: a, y: ESchema[a]): Int = ???
         }
 
         namespace Effect {
@@ -159,10 +131,6 @@ namespace Test/Def/Kinding {
             rel R(i: Int)
 
             pub def star[a: Type](x: a): Int = ???: a; ???
-
-            pub def record[a: Record](x: { l: Int | a }): Int = ???: a; ???
-
-            pub def schema[a: Schema](x: #{ R | a }): Int = ???: a; ???
         }
     }
 
@@ -181,12 +149,6 @@ namespace Test/Def/Kinding {
             pub class Boxable[a]
             pub enum Datalog[_a]
             pub class Foldable[a: Type -> Type]
-        }
-
-        namespace Test03 {
-            pub enum E[a: Record] {
-                case C(a)
-            }
         }
     }
 

--- a/main/test/flix/Test.Kind.Enum.flix
+++ b/main/test/flix/Test.Kind.Enum.flix
@@ -30,14 +30,12 @@ namespace Test/Enum/Kinding {
             case CBool1(Int -> Int & a)
         }
 
-        pub enum ERecord[a: Record] {
-            case CRecord1(a)
-            case CRecord2({ l: Int | a })
+        pub enum ERecordRow[a: RecordRow] {
+            case CRecordRow1({ l: Int | a })
         }
 
-        pub enum ESchema[a: Schema] {
-            case CSchema1(a)
-            case CSchema2(#{ R | a })
+        pub enum ESchemaRow[a: SchemaRow] {
+            case CSchemaRow1(#{ R | a })
         }
 
         // These pass kinding but cause a crash in the Finalizer.

--- a/main/test/flix/Test.Kind.TypeAlias.flix
+++ b/main/test/flix/Test.Kind.TypeAlias.flix
@@ -14,17 +14,17 @@ namespace Test/Enum/Kinding {
 
         type alias TBool[a: Bool] = Int -> Int & a
 
-        type alias TRecord[a: Record] = { l: Int | a }
+        type alias TRecordRow[a: RecordRow] = { l: Int | a }
 
-        type alias TSchema[a: Schema] = #{ R | a }
+        type alias TSchemaRow[a: SchemaRow] = #{ R | a }
 
         type alias TStarToStar[a: Type -> Type] = a[Int]
 
         type alias TBoolToStar[a: Bool -> Type] = a[Pure]
 
-        type alias TRecordToStar[a: Record -> Type] = a[{}]
+        type alias TRecordRowToStar[a: RecordRow -> Type, r: RecordRow] = a[r]
 
-        type alias TSchemaToStar[a: Schema -> Type] = a[#{}]
+        type alias TSchemaRowToStar[a: SchemaRow -> Type, r: SchemaRow] = a[r]
     }
 
     @test


### PR DESCRIPTION
Fixes https://github.com/flix/flix/issues/2057

The big idea:
We separate `Record`s and `RecordRow`s. 
A `RecordRow` is either an `RecordRowEmpty` or a `RecordRowExtend`
Then to create a proper record (of kind `Type`), we apply the `Record` constructor.

The same thing happens for schemas. The only difference is that we also introduce a `Predicate` kind, which describes relations and lattices.

I've settled for now on the `<x: Int | r>` syntax for describing record rows alone.
Similarly, `#< R | r>` is used for schema rows alone.
The row type syntax is quite rarely used; it's only needed (as far as I have seen) when instantiating a polymorphic enum type:

```scala
enum E[r: RecordRow] {
  // ... cases
}

def processEOfEmptyRecord(e: E[<>]): Int = ???

def extendEWithName(e: E[r]): E[<name: String | r>] = ???
```

| Source Type | Unsugared Type |
| --- | --- |
| `{}` | `MakeRecord[RecordRowEmpty]` |
| `{\| r}` | `MakeRecord[Var(r)]` |
| `{x: Int, y: Bool}` | `MakeRecord[RecordRowExtend(x)[Int, RecordRowExtend(y)[Bool, RecordRowEmpty]]]` |
| `<>` | `RecordRowEmpty` |
| `<x: Int \| r>` | `RecordRowExtend(x)[Int, Var(r)]` |