### PR TITLE
Use Markdown for LSP hover

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -40,3 +40,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Manoj Kumar](https://github.com/manoj2601)
 - [Jakob Schneider Villumsen](https://github.com/jaschdoc)
 - [Ramiro Calle](https://github.com/rrramiro)
+- [Jacob Harris Cryer Kragh](https://github.com/jhckragh)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HoverProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HoverProvider.scala
@@ -63,7 +63,11 @@ object HoverProvider {
   }
 
   private def hoverTypAndEff(tpe: Type, eff: Type, loc: SourceLocation)(implicit index: Index, root: Root): JObject = {
-    val markup = formatTypAndEff(tpe, eff)
+    val markup =
+      s"""```flix
+         |${formatTypAndEff(tpe, eff)}
+         |```
+         |""".stripMargin
     val contents = MarkupContent(MarkupKind.Markdown, markup)
     val range = Range.from(loc)
     val result = ("contents" -> contents.toJSON) ~ ("range" -> range.toJSON)
@@ -73,7 +77,9 @@ object HoverProvider {
   private def hoverDef(sym: Symbol.DefnSym, loc: SourceLocation)(implicit index: Index, root: Root): JObject = {
     val defDecl = root.defs(sym)
     val markup =
-      s"""${FormatSignature.asMarkDown(defDecl)}
+      s"""```flix
+         |${FormatSignature.asMarkDown(defDecl)}
+         |```
          |
          |${FormatDoc.asMarkDown(defDecl.spec.doc)}
          |""".stripMargin
@@ -86,7 +92,9 @@ object HoverProvider {
   private def hoverSig(sym: Symbol.SigSym, loc: SourceLocation)(implicit index: Index, root: Root): JObject = {
     val sigDecl = root.sigs(sym)
     val markup =
-      s"""${FormatSignature.asMarkDown(sigDecl)}
+      s"""```flix
+         |${FormatSignature.asMarkDown(sigDecl)}
+         |```
          |
          |${FormatDoc.asMarkDown(sigDecl.spec.doc)}
          |""".stripMargin
@@ -98,7 +106,9 @@ object HoverProvider {
 
   private def hoverFixpoint(tpe: Type, eff: Type, stf: Ast.Stratification, loc: SourceLocation)(implicit index: Index, root: Root): JObject = {
     val markup =
-      s"""${formatTypAndEff(tpe, eff)}
+      s"""```flix
+         |${formatTypAndEff(tpe, eff)}
+         |```
          |
          |${formatStratification(stf)}
          |""".stripMargin
@@ -119,7 +129,11 @@ object HoverProvider {
   }
 
   private def hoverTypeConstructor(tc: TypeConstructor, loc: SourceLocation)(implicit index: Index, root: Root): JObject = {
-    val markup = formatKind(tc)
+    val markup =
+      s"""```flix
+         |${formatKind(tc)}
+         |```
+         |""".stripMargin
     val contents = MarkupContent(MarkupKind.Markdown, markup)
     val range = Range.from(loc)
     val result = ("contents" -> contents.toJSON) ~ ("range" -> range.toJSON)

--- a/main/src/ca/uwaterloo/flix/language/debug/FormatSignature.scala
+++ b/main/src/ca/uwaterloo/flix/language/debug/FormatSignature.scala
@@ -37,7 +37,7 @@ object FormatSignature {
     * Returns a markdown string for the given `name` and `spec`.
     */
   private def formatSpec(name: String, spec: TypedAst.Spec)(implicit audience: Audience): String = {
-    s"""def **${name}**(${formatFormalParams(spec.fparams)}): ${formatResultTypeAndEff(spec.retTpe, spec.eff)}
+    s"""def ${name}(${formatFormalParams(spec.fparams)}): ${formatResultTypeAndEff(spec.retTpe, spec.eff)}
        |""".stripMargin
 
   }


### PR DESCRIPTION
This is an attempt to address #2210. The attached image shows what it looks like in VS Code.

![flix-hover-0](https://user-images.githubusercontent.com/129259/132091386-03c9da13-9fdd-4269-9302-12d3d6514f44.png)
