### PR TITLE
Bootstrap DocumentSymbol support in LSP (#2051)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -41,3 +41,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Jakob Schneider Villumsen](https://github.com/jaschdoc)
 - [Ramiro Calle](https://github.com/rrramiro)
 - [Jacob Harris Cryer Kragh](https://github.com/jhckragh)
+- [Nicola Dardanis](https://github.com/nicdard)

--- a/main/src/ca/uwaterloo/flix/api/lsp/DocumentSymbol.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/DocumentSymbol.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Nicola Dardanis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.api.lsp
+
+import org.json4s.JsonDSL._
+import org.json4s._
+
+/**
+  * Represents a `DocumentSymbol` in LSP.
+  *
+  * @param name           The name of this symbol. Will be displayed in the user interface.
+  * @param detail         More detail for this symbol, e.g the signature of a function.
+  * @param kind           The kind of this symbol.
+  * @param range          The range enclosing this symbol not including leading/trailing whitespace
+  *                       but everything else like comments. This information is typically used to
+  *                       determine if the clients cursor is inside the symbol to reveal in the
+  *                       symbol in the UI.
+  * @param selectionRange The range that should be selected and revealed when this symbol is being
+  *                       picked, e.g. the name of a function. Must be contained by the `range`.
+  * @param tags           Tags for this symbol.
+  * @param children       Children of this symbol, e.g. properties of a class.
+  */
+case class DocumentSymbol(name: String,
+                          detail: Option[String],
+                          kind: SymbolKind,
+                          range: Range,
+                          selectionRange: Range,
+                          tags: List[SymbolTag] = List(),
+                          children: List[DocumentSymbol]) {
+  def toJSON: JValue =
+    ("name" -> name) ~
+      ("kind" -> detail) ~
+      ("kind" -> JInt(kind.toInt)) ~
+      ("range" -> range.toJSON) ~
+      ("selectionRange" -> selectionRange.toJSON) ~
+      ("tags" -> tags.map(_.toJSON)) ~
+      ("children" -> children.map(_.toJSON))
+}
+

--- a/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
@@ -177,6 +177,7 @@ class LanguageServer(port: Int) extends WebSocketServer(new InetSocketAddress("l
       case JString("lsp/hover") => Request.parseHover(json)
       case JString("lsp/goto") => Request.parseGoto(json)
       case JString("lsp/rename") => Request.parseRename(json)
+      case JString("lsp/documentSymbols") => Request.parseDocumentSymbols(json)
       case JString("lsp/uses") => Request.parseUses(json)
 
       case s => Err(s"Unsupported request: '$s'.")
@@ -241,6 +242,9 @@ class LanguageServer(port: Int) extends WebSocketServer(new InetSocketAddress("l
 
     case Request.Rename(id, newName, uri, pos) =>
       ("id" -> id) ~ RenameProvider.processRename(newName, uri, pos)(index, root)
+
+    case Request.DocumentSymbols(id, uri) =>
+      ("id" -> id) ~ ("status" -> "success") ~ ("result" -> SymbolProvider.processDocumentSymbols(uri)(index, root).map(_.toJSON))
 
     case Request.Uses(id, uri, pos) =>
       ("id" -> id) ~ FindReferencesProvider.findRefs(uri, pos)(index, root)

--- a/main/src/ca/uwaterloo/flix/api/lsp/Request.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Request.scala
@@ -105,6 +105,11 @@ object Request {
   case class Uses(requestId: String, uri: String, pos: Position) extends Request
 
   /**
+    * A request to get document symbols information.
+    */
+  case class DocumentSymbols(requestId: String, uri: String) extends Request
+
+  /**
     * Tries to parse the given `json` value as a [[AddUri]] request.
     */
   def parseAddUri(json: json4s.JValue): Result[Request, String] = {
@@ -265,6 +270,16 @@ object Request {
       uri <- parseUri(json)
       pos <- Position.parse(json \\ "position")
     } yield Request.Uses(id, uri, pos)
+  }
+
+  /**
+    * Tries to parse the given `json` value as a [[DocumentSymbols]] request.
+    */
+  def parseDocumentSymbols(v: JValue): Result[Request, String] = {
+    for {
+      id <- parseId(v)
+      uri <- parseUri(v)
+    } yield Request.DocumentSymbols(id, uri)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/SymbolTag.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/SymbolTag.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Nicola Dardanis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.api.lsp
+
+import org.json4s.JsonAST.{JInt, JValue}
+
+/**
+  * Represents a `SymbolTag` in LSP.
+  */
+trait SymbolTag {
+  def toJSON: JValue = this match {
+    case SymbolTag.Deprecated => JInt(1)
+  }
+}
+
+object SymbolTag {
+  case object Deprecated extends SymbolTag
+}

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Nicola Dardanis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.api.lsp.provider
+
+import ca.uwaterloo.flix.api.lsp.{DocumentSymbol, Index, Position, Range, SymbolKind, SymbolTag}
+import ca.uwaterloo.flix.language.ast.TypedAst.Root
+import ca.uwaterloo.flix.language.debug.Audience
+
+object SymbolProvider {
+
+  private implicit val audience: Audience = Audience.External
+
+  def processDocumentSymbols(uri: String)(implicit index: Index, root: Root): List[DocumentSymbol] =
+    List(DocumentSymbol("name",
+      Some("description"),
+      SymbolKind.Interface,
+      Range(Position(1, 1), Position(2, 5)),
+      Range(Position(1, 1), Position(2, 5)),
+      List(SymbolTag.Deprecated),
+      List(DocumentSymbol(
+        "parent",
+        Some("parentDescription"),
+        SymbolKind.Interface,
+        Range(Position(0, 4), Position(0, 10)),
+        Range(Position(0, 4), Position(0, 10)),
+        List(),
+        List()
+      ))
+    ))
+}


### PR DESCRIPTION
Partially fixies: #2051

* Add Data structures for `DocumentSymbol` and `lsp/symbols` request.
* Add dummy implementation of `SymbolProvider` which returns always an hardcoded list, in a second PR (or adding a commit to this one) I will also add the logic to gather the information from the AST.