### PR TITLE
LSP: Add skeleton support for Semantic Tokens

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
@@ -179,6 +179,12 @@ case class Index(m: Map[(String, Int), List[Entity]],
   }
 
   /**
+   * Returns all entities in the document at the given `uri`.
+   */
+  def query(uri: String): List[Entity] =
+    m.view.filterKeys { case (s, _) => s == uri }.values.flatten.toList
+
+  /**
     * Returns all uses of the given symbol `sym`.
     */
   def usesOf(sym: Symbol.ClassSym): Set[SourceLocation] = classUses(sym)

--- a/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
@@ -19,6 +19,8 @@ import ca.uwaterloo.flix.language.ast.TypedAst._
 import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.util.collection.MultiMap
 
+import scala.collection.mutable.ArrayBuffer
+
 object Index {
   /**
     * Represents the empty reverse index.
@@ -181,8 +183,15 @@ case class Index(m: Map[(String, Int), List[Entity]],
   /**
    * Returns all entities in the document at the given `uri`.
    */
-  def query(uri: String): List[Entity] =
-    m.view.filterKeys { case (s, _) => s == uri }.values.flatten.toList
+  def query(uri: String): Iterable[Entity] = {
+    val res = new ArrayBuffer[Entity]()
+    for (((entitiesUri, _), entities) <- m) {
+      if (entitiesUri == uri) {
+        res.addAll(entities)
+      }
+    }
+    res
+  }
 
   /**
     * Returns all uses of the given symbol `sym`.

--- a/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
@@ -179,6 +179,7 @@ class LanguageServer(port: Int) extends WebSocketServer(new InetSocketAddress("l
       case JString("lsp/rename") => Request.parseRename(json)
       case JString("lsp/documentSymbols") => Request.parseDocumentSymbols(json)
       case JString("lsp/uses") => Request.parseUses(json)
+      case JString("lsp/semanticTokens") => Request.parseSemanticTokens(json)
 
       case s => Err(s"Unsupported request: '$s'.")
     }
@@ -248,6 +249,9 @@ class LanguageServer(port: Int) extends WebSocketServer(new InetSocketAddress("l
 
     case Request.Uses(id, uri, pos) =>
       ("id" -> id) ~ FindReferencesProvider.findRefs(uri, pos)(index, root)
+
+    case Request.SemanticTokens(id, uri) =>
+      ("id" -> id) ~ SemanticTokensProvider.provideSemanticTokens(uri)(index, root)
 
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/Request.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Request.scala
@@ -110,6 +110,11 @@ object Request {
   case class DocumentSymbols(requestId: String, uri: String) extends Request
 
   /**
+   * A request to get semantic tokens for a file.
+   */
+  case class SemanticTokens(requestId: String, uri: String) extends Request
+
+  /**
     * Tries to parse the given `json` value as a [[AddUri]] request.
     */
   def parseAddUri(json: json4s.JValue): Result[Request, String] = {
@@ -280,6 +285,16 @@ object Request {
       id <- parseId(v)
       uri <- parseUri(v)
     } yield Request.DocumentSymbols(id, uri)
+  }
+
+  /**
+   * Tries to parse the given `json` value as a [[SemanticTokens]] request.
+   */
+  def parseSemanticTokens(json: JValue): Result[Request, String] = {
+    for {
+      id <- parseId(json)
+      uri <- parseUri(json)
+    } yield Request.SemanticTokens(id, uri)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/SemanticToken.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/SemanticToken.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Jacob Harris Cryer Kragh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.api.lsp
+
+import ca.uwaterloo.flix.api.lsp.SemanticTokenModifier.SemanticTokenModifier
+import ca.uwaterloo.flix.api.lsp.SemanticTokenType.SemanticTokenType
+import ca.uwaterloo.flix.language.ast.SourceLocation
+
+/**
+ * Represents a semantic token in LSP.
+ *
+ * @param loc The location of the token.
+ * @param tokenType What kind of token this is ("number" or "string" or "function" or ...).
+ * @param tokenModifiers A list of modifiers that apply to this token (e.g. "declaration" or "static").
+ */
+case class SemanticToken(loc: SourceLocation, tokenType: SemanticTokenType, tokenModifiers: List[SemanticTokenModifier])

--- a/main/src/ca/uwaterloo/flix/api/lsp/SemanticToken.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/SemanticToken.scala
@@ -15,8 +15,6 @@
  */
 package ca.uwaterloo.flix.api.lsp
 
-import ca.uwaterloo.flix.api.lsp.SemanticTokenModifier.SemanticTokenModifier
-import ca.uwaterloo.flix.api.lsp.SemanticTokenType.SemanticTokenType
 import ca.uwaterloo.flix.language.ast.SourceLocation
 
 /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/SemanticTokenModifier.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/SemanticTokenModifier.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Jacob Harris Cryer Kragh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.api.lsp
+
+/**
+ * The semantic token modifiers that are currently supported.
+ *
+ * Note: The intermediate TypeScript server is responsible for communicating the legend
+ * to the client. The TS server must list the token modifiers in the same order as is used
+ * here in the Scala code. The reason for this is that the response is encoded as a
+ * sequence of integers, and a modifier is represented by its index in the legend.
+ */
+object SemanticTokenModifier extends Enumeration {
+  type SemanticTokenModifier = Value
+
+  val Declaration, Definition = Value
+}

--- a/main/src/ca/uwaterloo/flix/api/lsp/SemanticTokenModifier.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/SemanticTokenModifier.scala
@@ -16,15 +16,23 @@
 package ca.uwaterloo.flix.api.lsp
 
 /**
- * The semantic token modifiers that are currently supported.
+ * Represents a semantic token modifier in LSP.
  *
  * Note: The intermediate TypeScript server is responsible for communicating the legend
  * to the client. The TS server must list the token modifiers in the same order as is used
  * here in the Scala code. The reason for this is that the response is encoded as a
  * sequence of integers, and a modifier is represented by its index in the legend.
  */
-object SemanticTokenModifier extends Enumeration {
-  type SemanticTokenModifier = Value
-
-  val Declaration, Definition = Value
+sealed trait SemanticTokenModifier {
+  def toInt: Int = this match {
+    case SemanticTokenModifier.Declaration => 0
+    case SemanticTokenModifier.Definition => 1
+  }
 }
+
+object SemanticTokenModifier {
+  case object Declaration extends SemanticTokenModifier
+
+  case object Definition extends SemanticTokenModifier
+}
+

--- a/main/src/ca/uwaterloo/flix/api/lsp/SemanticTokenType.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/SemanticTokenType.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.api.lsp
 
 /**
- * The semantic token types that are currently supported.
+ * Represents a semantic token type in LSP.
  *
  * Note: The intermediate TypeScript server is responsible for communicating the legend
  * to the client. The TS server must list the token types in the same order as is used
@@ -24,8 +24,15 @@ package ca.uwaterloo.flix.api.lsp
  * sequence of integers, and the integer representing a token type is the type's
  * index in the legend.
  */
-object SemanticTokenType extends Enumeration {
-  type SemanticTokenType = Value
+sealed trait SemanticTokenType {
+  def toInt: Int = this match {
+    case SemanticTokenType.Number => 0
+    case SemanticTokenType.Str => 1
+  }
+}
 
-  val Number, Str = Value
+object SemanticTokenType {
+  case object Number extends SemanticTokenType
+
+  case object Str extends SemanticTokenType
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/SemanticTokenType.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/SemanticTokenType.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Jacob Harris Cryer Kragh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.api.lsp
+
+/**
+ * The semantic token types that are currently supported.
+ *
+ * Note: The intermediate TypeScript server is responsible for communicating the legend
+ * to the client. The TS server must list the token types in the same order as is used
+ * here in the Scala code. The reason for this is that the response is encoded as a
+ * sequence of integers, and the integer representing a token type is the type's
+ * index in the legend.
+ */
+object SemanticTokenType extends Enumeration {
+  type SemanticTokenType = Value
+
+  val Number, Str = Value
+}

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -15,8 +15,7 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider
 
-import ca.uwaterloo.flix.api.lsp.SemanticTokenModifier.SemanticTokenModifier
-import ca.uwaterloo.flix.api.lsp.{Entity, Index, SemanticToken, SemanticTokenType}
+import ca.uwaterloo.flix.api.lsp._
 import ca.uwaterloo.flix.language.ast.TypedAst.{Expression, Root}
 import org.json4s.JsonAST.JObject
 import org.json4s.JsonDSL._
@@ -76,7 +75,7 @@ object SemanticTokensProvider {
       encoding += relLine
       encoding += relCol
       encoding += token.loc.endCol - token.loc.beginCol
-      encoding += token.tokenType.id
+      encoding += token.tokenType.toInt
       encoding += encodeModifiers(token.tokenModifiers)
 
       prevLine = token.loc.beginLine - 1
@@ -90,5 +89,5 @@ object SemanticTokensProvider {
    * Encodes a list of modifiers as a bitset (as per the LSP spec).
    */
   def encodeModifiers(modifiers: List[SemanticTokenModifier]): Int =
-    modifiers.foldLeft(0)((bitset, modifier) => bitset | (1 << modifier.id))
+    modifiers.foldLeft(0)((bitset, modifier) => bitset | (1 << modifier.toInt))
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -1,0 +1,99 @@
+package ca.uwaterloo.flix.api.lsp.provider
+
+import ca.uwaterloo.flix.api.lsp.{Entity, Index}
+import ca.uwaterloo.flix.language.ast.SourceLocation
+import ca.uwaterloo.flix.language.ast.TypedAst.{Expression, Root}
+import org.json4s.JsonAST.JObject
+import org.json4s.JsonDSL._
+
+import scala.collection.mutable.ArrayBuffer
+
+object SemanticTokensProvider {
+  /**
+   * The token types currently supported by the provider.
+   *
+   * Note: The intermediate TypeScript server is responsible for communicating the legend
+   * to the client. The TS server must list the token types in the same order as is used
+   * here in the Scala code. The reason for this is that the response is encoded as a
+   * sequence of integers, and the integer representing a token type is the type's
+   * index in the legend.
+   */
+  private object TokenType extends Enumeration {
+    type TokenType = Value
+
+    val Number, Str = Value
+  }
+
+  /**
+   * The token modifiers currently supported by the provider.
+   *
+   * Note: See the remark in the documentation for SemanticTokenType; the same
+   * constraint applies to modifiers: The TS server must list the modifiers
+   * in the same order as is used here in the Scala code.
+   */
+  private object TokenModifier extends Enumeration {
+    type TokenModifier = Value
+
+    val Declaration, Definition = Value
+  }
+
+  private case class SemanticToken(loc: SourceLocation,
+                                   tokenType: SemanticTokensProvider.TokenType.TokenType,
+                                   tokenModifiers: List[SemanticTokensProvider.TokenModifier.TokenModifier])
+
+  def provideSemanticTokens(uri: String)(implicit index: Index, root: Root): JObject = {
+    val entities = index.query(uri)
+    val semanticTokens = entities.flatMap(getSemanticTokens)
+    val encoding = encodeSemanticTokens(semanticTokens)
+    val result = ("data" -> encoding)
+    ("status" -> "success") ~ ("result" -> result)
+  }
+
+  private def getSemanticTokens(entity: Entity): List[SemanticToken] = entity match {
+    case Entity.Exp(e) => e match {
+      case Expression.Int8(_, _)
+           | Expression.Int16(_, _)
+           | Expression.Int32(_, _)
+           | Expression.Float32(_, _)
+           | Expression.Float64(_, _)
+           | Expression.BigInt(_, _) => List(SemanticToken(e.loc, TokenType.Number, List()))
+      case Expression.Str(_, loc) => List(SemanticToken(loc, TokenType.Str, List()))
+      case _ => List() // TODO: Handle other kinds of expressions
+    }
+    case _ => List() // TODO: Handle other kinds of entities
+  }
+
+  // Inspired by https://github.com/microsoft/vscode-languageserver-node/blob/f425af9de46a0187adb78ec8a46b9b2ce80c5412/server/src/sematicTokens.proposed.ts#L45
+  private def encodeSemanticTokens(tokens: List[SemanticToken]): List[Int] = {
+    val encoding = new ArrayBuffer[Int](initialSize = 5 * tokens.size)
+
+    var prevLine = 0
+    var prevCol = 0
+
+    for (token <- tokens.sortBy(_.loc)) {
+      var relLine = token.loc.beginLine - 1
+      var relCol = token.loc.beginCol - 1
+
+      if (encoding.nonEmpty) {
+        relLine -= prevLine
+        if (relLine == 0) {
+          relCol -= prevCol
+        }
+      }
+
+      encoding += relLine
+      encoding += relCol
+      encoding += token.loc.endCol - token.loc.beginCol
+      encoding += token.tokenType.id
+      encoding += encodeModifiers(token.tokenModifiers)
+
+      prevLine = token.loc.beginLine - 1
+      prevCol = token.loc.beginCol - 1
+    }
+
+    encoding.toList
+  }
+
+  def encodeModifiers(modifiers: List[SemanticTokensProvider.TokenModifier.TokenModifier]): Int =
+    modifiers.foldLeft(0)((bitset, modifier) => bitset | (1 << modifier.id))
+}


### PR DESCRIPTION
This is a first step towards making the language server capable of providing useful semantic tokens.

There is probably room for improvement in the code as I'm not very familiar with Scala nor with the Flix compiler API.

The image below shows that the code is able to provide semantic tokens to the VS Code extension (once it has been extended as described [here](https://github.com/flix/vscode-flix/issues/122)).

![flix-st-example-1](https://user-images.githubusercontent.com/129259/133000581-8237a143-6ac4-44a5-927c-70ce36ea4726.png)
