### PR TITLE
Add `LazyList.dropWhile`

### DIFF
--- a/main/src/library/LazyList.flix
+++ b/main/src/library/LazyList.flix
@@ -795,4 +795,48 @@ namespace LazyList {
         case LList(xs)    => takeWhileEAcc(f, force xs, k)
     }
 
+    ///
+    /// Returns `l` without the longest prefix that satisfies the predicate `f`.
+    ///
+    /// Whether `f` is applied eagerly or lazily depends on its purity:
+    ///
+    /// - If `f` is pure then it is applied lazily (i.e. the tail is not forced).
+    /// - If `f` is impure then it is applied eagerly (i.e. the entire list `l` is forced).
+    ///
+    pub def dropWhile(f: a -> Bool & ef, l: LazyList[a]): LazyList[a] & ef =
+        if (reify ef)
+            dropWhileL(f as a -> Bool & Pure,   l)
+        else
+            dropWhileE(f as a -> Bool & Impure, l) as & ef
+
+    ///
+    /// Returns `l` without the longest prefix that satisfies the predicate `f`.
+    ///
+    /// Applies `f` lazily (i.e. the tail is not forced).
+    ///
+    def dropWhileL(f: a -> Bool, l: LazyList[a]): LazyList[a] =
+        LList(lazy dropWhileLHelper(f, l))
+
+    ///
+    /// Helper function for `dropWhileL`.
+    ///
+    def dropWhileLHelper(f: a -> Bool, l: LazyList[a]): LazyList[a] = match l {
+        case ENil         => ENil
+        case ECons(x, xs) => if (f(x)) LList(lazy dropWhileL(f,       xs)) else l
+        case LCons(x, xs) => if (f(x)) LList(lazy dropWhileL(f, force xs)) else l
+        case LList(xs)    => LList(lazy dropWhileL(f, force xs))
+    }
+
+    ///
+    /// Returns `l` without the longest prefix that satisfies the predicate `f`.
+    ///
+    /// Applies `f` eagerly (i.e. the entire list `l` is forced).
+    ///
+    def dropWhileE(f: a -> Bool & Impure, l: LazyList[a]): LazyList[a] & Impure = match l {
+        case ENil         => ENil
+        case ECons(x, xs) => if (f(x)) dropWhileE(f,       xs) else l
+        case LCons(x, xs) => if (f(x)) dropWhileE(f, force xs) else l
+        case LList(xs)    => dropWhileE(f, force xs)
+    }
+
 }

--- a/main/test/ca/uwaterloo/flix/library/TestLazyList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestLazyList.flix
@@ -1551,11 +1551,11 @@ namespace TestLazyList {
 
     @test
     def zipWithPure07(): Bool =
-    	 ENil: LazyList[Int32] |> LazyList.zipWith((x, y) -> x + y, ECons(1, ECons(2, ENil))) == ENil
+    	ENil: LazyList[Int32] |> LazyList.zipWith((x, y) -> x + y, ECons(1, ECons(2, ENil))) == ENil
 
     @test
     def zipWithPure08(): Bool =
-    	 ENil: LazyList[Int32] |> LazyList.zipWith((x, y) -> x + y, LList(lazy LCons(1, lazy LList(lazy LCons(2, lazy ENil))))) == ENil
+    	ENil: LazyList[Int32] |> LazyList.zipWith((x, y) -> x + y, LList(lazy LCons(1, lazy LList(lazy LCons(2, lazy ENil))))) == ENil
 
     @test
     def zipWithPure09(): Bool =
@@ -3188,5 +3188,300 @@ namespace TestLazyList {
         LazyList.takeWhile(i -> { l := "b" :: deref l; i < 3 } as & Pure) |>
         LazyList.toList as & Impure;
         List.reverse(deref l) == ("a" :: "b" :: "a" :: "b" :: "a" :: Nil)
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // dropWhile (pure)                                                        //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def dropWhilePure01(): Bool =
+        LazyList.dropWhile(i -> i > 3, ENil) == ENil
+
+    @test
+    def dropWhilePure02(): Bool =
+        LazyList.dropWhile(i -> i > 3, LList(lazy ENil)) == ENil
+
+    @test
+    def dropWhilePure03(): Bool =
+        LazyList.dropWhile(i -> i > 3, LCons(1, lazy ENil)) == ECons(1, ENil)
+
+    @test
+    def dropWhilePure04(): Bool =
+        LazyList.dropWhile(i -> i > 3, LList(lazy ECons(1, LList(lazy ENil)))) == ECons(1, ENil)
+
+    @test
+    def dropWhilePure05(): Bool =
+        LazyList.dropWhile(i -> i > 3, ECons(1, LList(lazy ENil))) == ECons(1, ENil)
+
+    @test
+    def dropWhilePure06(): Bool =
+        LazyList.dropWhile(i -> i > 3, ECons(4, LList(lazy ENil))) == ENil
+
+    @test
+    def dropWhilePure07(): Bool =
+        LazyList.dropWhile(i -> i > 3, LCons(4, lazy LList(lazy ENil))) == ENil
+
+    @test
+    def dropWhilePure08(): Bool =
+        LazyList.dropWhile(i -> i > 3, ECons(4, ENil)) == ENil
+
+    @test
+    def dropWhilePure09(): Bool =
+        LazyList.dropWhile(i -> i > 3, LList(lazy LCons(4, lazy ENil))) == ENil
+
+    @test
+    def dropWhilePure10(): Bool =
+        LazyList.dropWhile(i -> i > 3, LList(lazy LCons(1, lazy LList(lazy LCons(2, lazy ENil))))) == ECons(1, ECons(2, ENil))
+
+    @test
+    def dropWhilePure11(): Bool =
+        LazyList.dropWhile(i -> i > 3, LList(lazy LCons(1, lazy ECons(2, LList(lazy ENil))))) == ECons(1, ECons(2, ENil))
+
+    @test
+    def dropWhilePure12(): Bool =
+        LazyList.dropWhile(i -> i > 3, LList(lazy LCons(1, lazy LCons(2, lazy ENil)))) == ECons(1, ECons(2, ENil))
+
+    @test
+    def dropWhilePure13(): Bool =
+        LazyList.dropWhile(i -> i > 3, ECons(1, LCons(2, lazy ENil))) == ECons(1, ECons(2, ENil))
+
+    @test
+    def dropWhilePure14(): Bool =
+        LazyList.dropWhile(i -> i > 3, LCons(1, lazy ECons(5, LList(lazy ENil)))) == ECons(1, ECons(5, ENil))
+
+    @test
+    def dropWhilePure15(): Bool =
+        LazyList.dropWhile(i -> i > 3, LCons(1, lazy LList(lazy ECons(5, ENil)))) == ECons(1, ECons(5, ENil))
+
+    @test
+    def dropWhilePure16(): Bool =
+        LazyList.dropWhile(i -> i > 3, LList(lazy ECons(1, LCons(5, lazy ENil)))) == ECons(1, ECons(5, ENil))
+
+    @test
+    def dropWhilePure17(): Bool =
+        LazyList.dropWhile(i -> i > 3, LList(lazy ECons(1, LList(lazy ECons(5, LList(lazy ENil)))))) == ECons(1, ECons(5, ENil))
+
+    @test
+    def dropWhilePure18(): Bool =
+        LazyList.dropWhile(i -> i > 3, LList(lazy LCons(1, lazy LList(lazy LCons(5, lazy ENil))))) == ECons(1, ECons(5, ENil))
+
+    @test
+    def dropWhilePure19(): Bool =
+        LazyList.dropWhile(i -> i > 3, ECons(5, LList(lazy ECons(1, LList(lazy ENil))))) == ECons(1, ENil)
+
+    @test
+    def dropWhilePure20(): Bool =
+        LazyList.dropWhile(i -> i > 3, LCons(5, lazy LList(lazy ECons(1, LList(lazy ENil))))) == ECons(1, ENil)
+
+    @test
+    def dropWhilePure21(): Bool =
+        LazyList.dropWhile(i -> i > 3, LList(lazy LCons(5, lazy ECons(1, ENil)))) == ECons(1, ENil)
+
+    @test
+    def dropWhilePure22(): Bool =
+        LazyList.dropWhile(i -> i > 3, ECons(5, LList(lazy ECons(1, ENil)))) == ECons(1, ENil)
+
+    @test
+    def dropWhilePure23(): Bool =
+        LazyList.dropWhile(i -> i > 3, LList(lazy ECons(5, ECons(8, ENil)))) == ENil
+
+    @test
+    def dropWhilePure24(): Bool =
+        LazyList.dropWhile(i -> i > 3, LCons(5, lazy LList(lazy ECons(8, LList(lazy ENil))))) == ENil
+
+    @test
+    def dropWhilePure25(): Bool =
+        LazyList.dropWhile(i -> i > 3, ECons(5, ECons(8, LList(lazy ENil)))) == ENil
+
+    @test
+    def dropWhilePure26(): Bool =
+        LazyList.dropWhile(i -> i > 3, LList(lazy ECons(5, LList(lazy LCons(8, lazy ENil))))) == ENil
+
+    @test
+    def dropWhilePure27(): Bool =
+        LazyList.dropWhile(i -> i > 3, ECons(5, LList(lazy ECons(8, ENil)))) == ENil
+
+    @test
+    def dropWhilePure28(): Bool =
+        LazyList.dropWhile(i -> i > 3, ECons(4, ECons(6, ECons(-3, ECons(11, ECons(-5, ECons(1, ECons(2, ECons(16, ECons(7, ECons(1, ECons(7, ENil)))))))))))) == ECons(-3, ECons(11, ECons(-5, ECons(1, ECons(2, ECons(16, ECons(7, ECons(1, ECons(7, ENil)))))))))
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // dropWhile (impure)                                                      //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def dropWhileImpure01(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, ENil) == ENil
+
+    @test
+    def dropWhileImpure02(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LList(lazy ENil)) == ENil
+
+    @test
+    def dropWhileImpure03(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LCons(1, lazy ENil)) == ECons(1, ENil)
+
+    @test
+    def dropWhileImpure04(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LList(lazy ECons(1, LList(lazy ENil)))) == ECons(1, ENil)
+
+    @test
+    def dropWhileImpure05(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, ECons(1, LList(lazy ENil))) == ECons(1, ENil)
+
+    @test
+    def dropWhileImpure06(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, ECons(4, LList(lazy ENil))) == ENil
+
+    @test
+    def dropWhileImpure07(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LCons(4, lazy LList(lazy ENil))) == ENil
+
+    @test
+    def dropWhileImpure08(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, ECons(4, ENil)) == ENil
+
+    @test
+    def dropWhileImpure09(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LList(lazy LCons(4, lazy ENil))) == ENil
+
+    @test
+    def dropWhileImpure10(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LList(lazy LCons(1, lazy LList(lazy LCons(2, lazy ENil))))) == ECons(1, ECons(2, ENil))
+
+    @test
+    def dropWhileImpure11(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LList(lazy LCons(1, lazy ECons(2, LList(lazy ENil))))) == ECons(1, ECons(2, ENil))
+
+    @test
+    def dropWhileImpure12(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LList(lazy LCons(1, lazy LCons(2, lazy ENil)))) == ECons(1, ECons(2, ENil))
+
+    @test
+    def dropWhileImpure13(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, ECons(1, LCons(2, lazy ENil))) == ECons(1, ECons(2, ENil))
+
+    @test
+    def dropWhileImpure14(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LCons(1, lazy ECons(5, LList(lazy ENil)))) == ECons(1, ECons(5, ENil))
+
+    @test
+    def dropWhileImpure15(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LCons(1, lazy LList(lazy ECons(5, ENil)))) == ECons(1, ECons(5, ENil))
+
+    @test
+    def dropWhileImpure16(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LList(lazy ECons(1, LCons(5, lazy ENil)))) == ECons(1, ECons(5, ENil))
+
+    @test
+    def dropWhileImpure17(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LList(lazy ECons(1, LList(lazy ECons(5, LList(lazy ENil)))))) == ECons(1, ECons(5, ENil))
+
+    @test
+    def dropWhileImpure18(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LList(lazy LCons(1, lazy LList(lazy LCons(5, lazy ENil))))) == ECons(1, ECons(5, ENil))
+
+    @test
+    def dropWhileImpure19(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, ECons(5, LList(lazy ECons(1, LList(lazy ENil))))) == ECons(1, ENil)
+
+    @test
+    def dropWhileImpure20(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LCons(5, lazy LList(lazy ECons(1, LList(lazy ENil))))) == ECons(1, ENil)
+
+    @test
+    def dropWhileImpure21(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LList(lazy LCons(5, lazy ECons(1, ENil)))) == ECons(1, ENil)
+
+    @test
+    def dropWhileImpure22(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, ECons(5, LList(lazy ECons(1, ENil)))) == ECons(1, ENil)
+
+    @test
+    def dropWhileImpure23(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LList(lazy ECons(5, ECons(8, ENil)))) == ENil
+
+    @test
+    def dropWhileImpure24(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LCons(5, lazy LList(lazy ECons(8, LList(lazy ENil))))) == ENil
+
+    @test
+    def dropWhileImpure25(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, ECons(5, ECons(8, LList(lazy ENil)))) == ENil
+
+    @test
+    def dropWhileImpure26(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, LList(lazy ECons(5, LList(lazy LCons(8, lazy ENil))))) == ENil
+
+    @test
+    def dropWhileImpure27(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, ECons(5, LList(lazy ECons(8, ENil)))) == ENil
+
+    @test
+    def dropWhileImpure28(): Bool & Impure =
+        LazyList.dropWhile(i -> i > 3 as & Impure, ECons(4, ECons(6, ECons(-3, ECons(11, ECons(-5, ECons(1, ECons(2, ECons(16, ECons(7, ECons(1, ECons(7, ENil)))))))))))) == ECons(-3, ECons(11, ECons(-5, ECons(1, ECons(2, ECons(16, ECons(7, ECons(1, ECons(7, ENil)))))))))
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // dropWhile dropWhile                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def dropWhileDropWhile01(): Bool =
+        ECons(4, ECons(5, ECons(1, ENil))) |> LazyList.dropWhile(i -> i < 5) |> LazyList.dropWhile(i -> i > 1) == ECons(1, ENil)
+
+    @test
+    def dropWhileDropWhile02(): Bool & Impure =
+        ECons(4, ECons(5, ECons(1, ENil))) |> LazyList.dropWhile(i -> i < 5 as & Impure) |> LazyList.dropWhile(i -> i > 1) == ECons(1, ENil)
+
+    @test
+    def dropWhileDropWhile03(): Bool & Impure =
+        ECons(4, ECons(5, ECons(1, ENil))) |> LazyList.dropWhile(i -> i < 5) |> LazyList.dropWhile(i -> i > 1 as & Impure) == ECons(1, ENil)
+
+    @test
+    def dropWhileDropWhile04(): Bool & Impure =
+        ECons(4, ECons(5, ECons(1, ENil))) |> LazyList.dropWhile(i -> i < 5 as & Impure) |> LazyList.dropWhile(i -> i > 1 as & Impure) == ECons(1, ENil)
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // dropWhile dropWhile fusion                                              //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def dropWhileDropWhileFusion01(): Bool & Impure =
+        let l = ref Nil;
+        (1 :: 2 :: 3 :: Nil) |> List.toLazy |>
+        LazyList.dropWhile(i -> { l := "a" :: deref l; i < 3 }) |>
+        LazyList.dropWhile(i -> { l := "b" :: deref l; i < 4 });
+        List.reverse(deref l) == ("a" :: "a" :: "a" :: "b" :: Nil)
+
+    @test
+    def dropWhileDropWhileFusion02(): Bool & Impure =
+        let l = ref Nil;
+        (1 :: 2 :: 3 :: Nil) |> List.toLazy |>
+        LazyList.dropWhile(i -> { l := "a" :: deref l; i < 3 } as & Pure) |>
+        LazyList.dropWhile(i -> { l := "b" :: deref l; i < 4 } as & Pure) |>
+        LazyList.toList as & Impure;
+        List.reverse(deref l) == ("a" :: "a" :: "a" :: "b" :: Nil)
+
+    @test
+    def dropWhileDropWhileFusion03(): Bool & Impure =
+        let l = ref Nil;
+        (1 :: 2 :: 3 :: Nil) |> List.toLazy |>
+        LazyList.dropWhile(i -> { l := "a" :: deref l; i < 1 } as & Pure) |>
+        LazyList.dropWhile(i -> { l := "b" :: deref l; i < 3 } as & Pure) |>
+        LazyList.toList as & Impure;
+        List.reverse(deref l) == ("a" :: "b" :: "b" :: "b" :: Nil)
+
+    @test
+    def dropWhileDropWhileFusion04(): Bool & Impure =
+        let l = ref Nil;
+        (1 :: 2 :: 3 :: Nil) |> List.toLazy |>
+        LazyList.dropWhile(i -> { l := "a" :: deref l; i < 2 } as & Pure) |>
+        LazyList.dropWhile(i -> { l := "b" :: deref l; i < 3 } as & Pure) |>
+        LazyList.toList as & Impure;
+        List.reverse(deref l) == ("a" :: "a" :: "b" :: "b" :: Nil)
 
 }


### PR DESCRIPTION
The tests `dropWhileDropWhileFusion0X` produce the same pattern of letters when evaluated eagerly and lazily. Is there something we can do about that to observe the effects of being evaluated eagerly and lazily?