### PR TITLE
Improved CodeGen for `Lazy`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/AsmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/AsmOps.scala
@@ -302,7 +302,7 @@ object AsmOps {
     * For example, the class of `Tuple[Int32, Int32]` has the following `setField0` method:
     *
     * public final void setField0(int var) {
-    *   this.field0 = var;
+    * this.field0 = var;
     * }
     */
   def compileSetFieldMethod(visitor: ClassWriter, classType: JvmName, fieldName: String, methodName: String, fieldType: JvmType): Unit = {
@@ -640,7 +640,7 @@ object AsmOps {
   /**
     * Emits code to call a closure (not in tail position). fType is the type of the called closure. argsType is the type of its arguments, and resultType is the type of its result.
     */
-  def compileClosureApplication(visitor: MethodVisitor, fType: MonoType, argsTypes: List[MonoType], resultType: MonoType)(implicit root: Root, flix: Flix) = {
+  def compileClosureApplication(visitor: MethodVisitor, fType: MonoType, argsTypes: List[MonoType], resultType: MonoType, castFinalValue: Boolean = true)(implicit root: Root, flix: Flix): Unit = {
     // Type of the continuation interface
     val cont = JvmOps.getContinuationInterfaceType(fType)
     // Type of the function interface
@@ -679,6 +679,6 @@ object AsmOps {
     // Load IFO from local variable and invoke `getResult` on it
     visitor.visitVarInsn(ALOAD, 2)
     visitor.visitMethodInsn(INVOKEINTERFACE, cont.name.toInternalName, "getResult", AsmOps.getMethodDescriptor(Nil, JvmOps.getErasedJvmType(resultType)), true)
-    AsmOps.castIfNotPrim(visitor, JvmOps.getJvmType(resultType))
+    if (castFinalValue) AsmOps.castIfNotPrim(visitor, JvmOps.getJvmType(resultType))
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenLazyClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenLazyClasses.scala
@@ -81,18 +81,6 @@ object GenLazyClasses {
     // Emit the code for the constructor
     compileLazyConstructor(visitor, classType)
 
-    // Generate `toString` method
-    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "toString", AsmOps.getMethodDescriptor(Nil, JvmType.String),
-      "toString method shouldn't be called")
-
-    // Generate `hashCode` method
-    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "hashCode", AsmOps.getMethodDescriptor(Nil, JvmType.PrimInt),
-      "hashCode method shouldn't be called")
-
-    // Generate `equals` method
-    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "equals", AsmOps.getMethodDescriptor(List(JvmType.Object), JvmType.Void),
-      "equals method shouldn't be called")
-
     visitor.visitEnd()
     visitor.toByteArray
   }
@@ -103,7 +91,7 @@ object GenLazyClasses {
    * Emits code to call a closure (not in tail position). fType is the type of the called
    * closure. argsType is the type of its arguments, and resultType is the type of its result.
    */
-  private def compileClosureApplication(visitor: MethodVisitor, valueType: MonoType)(implicit root: Root, flix: Flix) = {
+  private def compileClosureApplication(visitor: MethodVisitor, valueType: MonoType)(implicit root: Root, flix: Flix): Unit = {
     val fType = MonoType.Arrow(List(MonoType.Unit), valueType)
     // Type of the continuation interface
     val cont = JvmOps.getContinuationInterfaceType(fType)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenLazyClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenLazyClasses.scala
@@ -19,17 +19,17 @@ package ca.uwaterloo.flix.language.phase.jvm
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.FinalAst.Root
 import ca.uwaterloo.flix.language.ast.MonoType
-import org.objectweb.asm.{ClassWriter, Label, MethodVisitor}
 import org.objectweb.asm.Opcodes._
+import org.objectweb.asm.{ClassWriter, Label}
 
 /**
- * Generates bytecode for the lazy classes.
- */
+  * Generates bytecode for the lazy classes.
+  */
 object GenLazyClasses {
 
   /**
-   * Returns the set of lazy classes for the given set of types `ts`.
-   */
+    * Returns the set of lazy classes for the given set of types `ts`.
+    */
   def gen(ts: Set[MonoType])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
     ts.foldLeft(Map.empty[JvmName, JvmClass]) {
       case (macc, tpe@MonoType.Lazy(valueType)) =>
@@ -38,12 +38,12 @@ object GenLazyClasses {
         val fullType = JvmOps.getLazyClassType(tpe)
         val jvmName = fullType.name
         if (!macc.contains(jvmName)) {
-          val bytecode = genByteCode(fullType, valueType)
+          val bytecode = genByteCode(fullType, JvmOps.getErasedJvmType(valueType), valueType)
           macc + (jvmName -> JvmClass(jvmName, bytecode))
         } else {
           macc
         }
-      case (macc, tpe) =>
+      case (macc, _) =>
         // Case 2: The type constructor is a non-tuple.
         // Nothing to be done. Return the map.
         macc
@@ -51,19 +51,21 @@ object GenLazyClasses {
   }
 
   /**
-   * This method creates the class for each lazy value.
-   * The specific lazy class has an associated value type (tpe) which
-   * is either a jvm primitive or object.
-   *
-   * The lazy class has three fields - initialized: bool, expression: () -> tpe,
-   * and value: tpe. These are all private. force(context) is the only public
-   * method, which retuns a value of type tpe given a context to call the
-   * expression closure in.
-   *
-   * force will only evaluate the expression the first time, based on the flag initialized.
-   * After that point it will store the result in value and just return that.
-   */
-  private def genByteCode(classType: JvmType.Reference, valueType: MonoType)(implicit root: Root, flix: Flix): Array[Byte] = {
+    * This method creates the class for each lazy value.
+    * The specific lazy class has an associated value type (tpe) which
+    * is either a jvm primitive or object.
+    *
+    * The lazy class has two fields - expression: () -> tpe,
+    * and value: tpe. These are all public. force(context) is a public
+    * method, which returns a value of type tpe given a context to call the
+    * expression closure in. It will set expression = null, which can be checked in
+    * order to check the validity of value.
+    *
+    * force will only evaluate the expression the first time, based on expression == null.
+    * After that point it will store the result in value and just return that. Since force is
+    * synchronized, this check should be done inline and not through force, unless expression != null.
+    */
+  private def genByteCode(classType: JvmType.Reference, erasedType: JvmType, valueType: MonoType)(implicit root: Root, flix: Flix): Array[Byte] = {
     // class writer
     val visitor = AsmOps.mkClassWriter()
 
@@ -73,10 +75,9 @@ object GenLazyClasses {
     // Initialize the visitor to create a class.
     visitor.visit(AsmOps.JavaVersion, ACC_PUBLIC + ACC_FINAL, classType.name.toInternalName, null, superClass, null)
 
-    AsmOps.compileField(visitor, "initialized", JvmType.PrimBool, isStatic = false, isPrivate = true)
-    AsmOps.compileField(visitor, "expression", JvmType.Object, isStatic = false, isPrivate = true)
-    AsmOps.compileField(visitor, "value", JvmOps.getErasedJvmType(valueType), isStatic = false, isPrivate = true)
-    compileForceMethod(visitor, classType, valueType)
+    AsmOps.compileField(visitor, "expression", JvmType.Object, isStatic = false, isPrivate = false)
+    AsmOps.compileField(visitor, "value", erasedType, isStatic = false, isPrivate = false)
+    compileForceMethod(visitor, classType, erasedType, valueType)
 
     // Emit the code for the constructor
     compileLazyConstructor(visitor, classType)
@@ -86,132 +87,66 @@ object GenLazyClasses {
   }
 
   /**
-   * !OBS!: This code was copied from AsmOps to omit the last cast in the function.
-   *
-   * Emits code to call a closure (not in tail position). fType is the type of the called
-   * closure. argsType is the type of its arguments, and resultType is the type of its result.
-   */
-  private def compileClosureApplication(visitor: MethodVisitor, valueType: MonoType)(implicit root: Root, flix: Flix): Unit = {
-    val fType = MonoType.Arrow(List(MonoType.Unit), valueType)
-    // Type of the continuation interface
-    val cont = JvmOps.getContinuationInterfaceType(fType)
-    // Label for the loop
-    val loop = new Label
-    visitor.visitFieldInsn(PUTFIELD, JvmName.Context.toInternalName, "continuation", JvmType.Object.toDescriptor)
-    // Begin of the loop
-    visitor.visitLabel(loop)
-    // Getting `continuation` field on `Context`
-    visitor.visitVarInsn(ALOAD, 1)
-    visitor.visitFieldInsn(GETFIELD, JvmName.Context.toInternalName, "continuation", JvmType.Object.toDescriptor)
-    // Setting `continuation` field of global to `null`
-    visitor.visitVarInsn(ALOAD, 1)
-    visitor.visitInsn(ACONST_NULL)
-    visitor.visitFieldInsn(PUTFIELD, JvmName.Context.toInternalName, "continuation", JvmType.Object.toDescriptor)
-    // Cast to the continuation
-    visitor.visitTypeInsn(CHECKCAST, cont.name.toInternalName)
-    // Duplicate
-    visitor.visitInsn(DUP)
-    // Save it on the IFO local variable
-    visitor.visitVarInsn(ASTORE, 2)
-    // Call invoke
-    visitor.visitVarInsn(ALOAD, 1)
-    visitor.visitMethodInsn(INVOKEINTERFACE, cont.name.toInternalName, "invoke", AsmOps.getMethodDescriptor(List(JvmType.Context), JvmType.Void), true)
-    // Getting `continuation` field on `Context`
-    visitor.visitVarInsn(ALOAD, 1)
-    visitor.visitFieldInsn(GETFIELD, JvmName.Context.toInternalName, "continuation", JvmType.Object.toDescriptor)
-    visitor.visitJumpInsn(IFNONNULL, loop)
-    // Load IFO from local variable and invoke `getResult` on it
-    visitor.visitVarInsn(ALOAD, 2)
-    visitor.visitMethodInsn(INVOKEINTERFACE, cont.name.toInternalName, "getResult", AsmOps.getMethodDescriptor(Nil, JvmOps.getErasedJvmType(valueType)), true)
-  }
-
-  /**
-   * The force method takes a context as argument to call the expression closure in.
-   * The result of the expression given in the constructor is then returned.
-   * This is only actually evaluated the first time, and saved to return directly
-   * afterwards.
-   *
-   * If lazy has associated type of Obj, the returned object needs to be casted
-   * to whatever expected type.
-   */
-  private def compileForceMethod(visitor: ClassWriter, classType: JvmType.Reference, valueType: MonoType)(implicit root: Root, flix: Flix): Unit = {
-    /*
-    force(context) :=
-
-    lock(this)
-    if (!this.initialized) {
-      this.value = this.expression()
-      this.initialized = true
-    }
-    tpe result = this.value
-    unlock(this)
-    return result
-     */
-
-    val erasedValueType = JvmOps.getErasedJvmType(valueType)
-    val erasedValueTypeDescriptor = erasedValueType.toDescriptor
+    * The force method takes a context as argument to call the expression closure in.
+    * The result of the expression given in the constructor is then returned.
+    * This is only actually evaluated the first time, and saved to return directly
+    * afterwards. force is synchronized to make sure that expression is never evaluated twice.
+    *
+    * If lazy has associated type of Obj, the returned object needs to be casted
+    * to whatever expected type.
+    */
+  private def compileForceMethod(visitor: ClassWriter, classType: JvmType.Reference, erasedType: JvmType, valueType: MonoType)(implicit root: Root, flix: Flix): Unit = {
+    val erasedValueTypeDescriptor = erasedType.toDescriptor
     val internalClassType = classType.name.toInternalName
+    val returnIns = AsmOps.getReturnInstruction(erasedType)
 
     // Header of the method.
-    val returnDescription = AsmOps.getMethodDescriptor(List(JvmType.Context), erasedValueType)
-    val method = visitor.visitMethod(ACC_PUBLIC + ACC_FINAL, "force", returnDescription, null, null)
+    val returnDescription = AsmOps.getMethodDescriptor(List(JvmType.Context), erasedType)
+    val method = visitor.visitMethod(ACC_PUBLIC + ACC_FINAL + ACC_SYNCHRONIZED, "force", returnDescription, null, null)
     method.visitCode()
-
-    // [this] This is pushed to lock the object.
-    method.visitVarInsn(ALOAD, 0)
-    // [] The object is now locked.
-    method.visitInsn(MONITORENTER)
 
     // [this] this is pushed to retrieve initialized to check if the Lazy object has already been evaluated.
     method.visitVarInsn(ALOAD, 0)
     // [this.initialized] the condition can now be checked.
-    method.visitFieldInsn(GETFIELD, internalClassType, "initialized", JvmType.PrimBool.toDescriptor)
-
-    // [] If expression has been evaluated, skip to returning this.value.
-    val skip = new Label
-    method.visitJumpInsn(IFNE, skip)
-
-    // [context] Load the context to give as an argument to the expression closure.
-    method.visitVarInsn(ALOAD, 1)
-    // [context, this] push this to get the expression.
-    method.visitVarInsn(ALOAD, 0)
-    // [context, expression] now ready to call the expression closure.
     method.visitFieldInsn(GETFIELD, internalClassType, "expression", JvmType.Object.toDescriptor)
-    // [value] The result of expression remains on the stack.
-    compileClosureApplication(method, valueType)
-    // [value, this] this is pushed to assign this.value = value.
+
+    // [] if expression is null (multiple threads tried to initialize) return value field, else continue
+    val continue = new Label
+    method.visitJumpInsn(IFNONNULL, continue)
+
+    // return lazy.value if lazy is already initialized
     method.visitVarInsn(ALOAD, 0)
-    // [this, value] the two stack elements are swapped, technique depending on values type category.
-    if (AsmOps.getStackSize(erasedValueType) == 1) {
-      method.visitInsn(SWAP)
-    } else {
-      method.visitInsn(DUP_X2)
-      method.visitInsn(POP)
-    }
+    method.visitFieldInsn(GETFIELD, internalClassType, "value", erasedValueTypeDescriptor)
+    method.visitInsn(returnIns)
+
+    method.visitLabel(continue)
+    // [this] to assign the expression value
+    method.visitVarInsn(ALOAD, 0)
+    // [this, context] load the context to give as an argument to the expression closure.
+    method.visitVarInsn(ALOAD, 1)
+    // [this, context, this] push this to get the expression.
+    method.visitVarInsn(ALOAD, 0)
+    // [this, context, expression] now ready to call the expression closure.
+    method.visitFieldInsn(GETFIELD, internalClassType, "expression", JvmType.Object.toDescriptor)
+    // [this, value] the result of expression remains on the stack.
+    AsmOps.compileClosureApplication(method, MonoType.Arrow(List(MonoType.Unit), valueType), Nil, valueType, castFinalValue = false)
     // [] this.value now stores the result from expression.
     method.visitFieldInsn(PUTFIELD, internalClassType, "value", erasedValueTypeDescriptor)
 
-    // [this] this is pushed to update initialized such that evaluation is skipped the next call.
+    // [this] this is pushed to update expression such that evaluation is skipped the next call.
     method.visitVarInsn(ALOAD, 0)
-    // [this, 1] true is pushed to assign this.initialized = true.
-    method.visitInsn(ICONST_1)
-    // [] initialized is now true.
-    method.visitFieldInsn(PUTFIELD, internalClassType, "initialized", JvmType.PrimBool.toDescriptor)
+    // [this, null] null is pushed to assign this.expression = null.
+    method.visitInsn(ACONST_NULL)
+    // [] expression is now null.
+    method.visitFieldInsn(PUTFIELD, internalClassType, "expression", JvmType.Object.toDescriptor)
 
-    // This is the return point if initialized was true at the start of force.
-    method.visitLabel(skip)
     // [this] this is pushed to retrieve this.value.
     method.visitVarInsn(ALOAD, 0)
-    // [this.value] The return value is now on the stack.
+    // [this.value] the return value is now on the stack.
     method.visitFieldInsn(GETFIELD, internalClassType, "value", erasedValueTypeDescriptor)
 
-    // [this.value, this] this is pushed to unlock the object.
-    method.visitVarInsn(ALOAD, 0)
-    // [this.value] we are now ready to return.
-    method.visitInsn(MONITOREXIT)
-
     // [] Return the value of appropriate type.
-    method.visitInsn(AsmOps.getReturnInstruction(erasedValueType))
+    method.visitInsn(returnIns)
 
     // Parameters of visit max are thrown away because visitor will calculate the frame and variable stack size
     method.visitMaxs(1, 1)
@@ -219,16 +154,10 @@ object GenLazyClasses {
   }
 
   /**
-   * The constructor takes a expression object, which should be a function that takes
-   * no argument and returns something of type tpe, related to the type of the lazy class.
-   */
+    * The constructor takes a expression object, which should be a function that takes
+    * no argument and returns something of type tpe, related to the type of the lazy class.
+    */
   def compileLazyConstructor(visitor: ClassWriter, classType: JvmType.Reference)(implicit root: Root, flix: Flix): Unit = {
-    /*
-    Lazy$tpe(expression) :=
-
-    this.initialized = false
-    this.expression = expression.
-     */
     val constructor = visitor.visitMethod(ACC_PUBLIC, "<init>", AsmOps.getMethodDescriptor(List(JvmType.Object), JvmType.Void), null, null)
 
     constructor.visitCode()
@@ -237,13 +166,6 @@ object GenLazyClasses {
 
     // [] Call the super (java.lang.Object) constructor
     constructor.visitMethodInsn(INVOKESPECIAL, JvmName.Object.toInternalName, "<init>", AsmOps.getMethodDescriptor(Nil, JvmType.Void), false)
-
-    // [this] this is pushed to assign initialized to false.
-    constructor.visitVarInsn(ALOAD, 0)
-    // [this, false] now ready to put field.
-    constructor.visitInsn(ICONST_0)
-    // [] initialized = false.
-    constructor.visitFieldInsn(PUTFIELD, classType.name.toInternalName, "initialized", JvmType.PrimBool.toDescriptor)
 
     // [this] save the argument to expression.
     constructor.visitVarInsn(ALOAD, 0)


### PR DESCRIPTION
Fixes #2328

Current benchmark:
```flix
use Benchmark.Benchmark;
use Benchmark.defBenchmark;

pub def bench1(): Benchmark = 
     defBenchmark("List", () -> { 
         List.range(1, 10_000) |>
         List.map(x -> x + 1) |>
         List.map(x -> x + 1) |>
         List.map(x -> x + 1)
    })

pub def bench2(): Benchmark = 
     defBenchmark("LazyList", () -> { 
         LazyList.range(1, 10_000) |>
         mapE(x -> x + 1) |>
         mapE(x -> x + 1) |>
         mapE(x -> x + 1 as & Impure)
    } as & Pure)

pub def mapE(f: a -> b & ef, l: LazyList[a]): LazyList[b] & Impure =
    let r = MutList.new();
    mapERec(f, l, r);
    MutList.foldRight((x, xs) -> ECons(x, xs), ENil, r)

def mapERec(f: a -> b & ef, l: LazyList[a], r: MutList[b]): Unit & Impure =
    match l {
        case ENil         => ()
        case ECons(x, xs) => 
            MutList.push!(f(x), r);
            mapERec(f, xs, r)
        case LCons(x, xs) => 
            MutList.push!(f(x), r);
            mapERec(f, force xs, r)
        case LList(xs)    => mapERec(f, force xs, r)
    }
    
def main(_args: Array[String]) : Int32 & Impure = 
    let bs = [bench1(), bench2()];
    Benchmark.runWithBudget(bs, 300_000_000_000i64);
    0
    

```
Results:
```
Benchmark                                         Iterations          Time (avg)
List                                                   27704          4368 us/op
LazyList                                                5740         14153 us/op (x3.24)

Total time elapsed: 202 seconds. Time budget was: 600 seconds.
```
```
Benchmark                                         Iterations          Time (avg)
List                                                   13568          4530 us/op
LazyList                                                2827         19872 us/op (x4.39)

Total time elapsed: 117 seconds. Time budget was: 300 seconds.
```
```
Benchmark                                         Iterations          Time (avg)
List                                                    6506          5089 us/op
LazyList                                                1240         19368 us/op (x3.81)

Total time elapsed: 57 seconds. Time budget was: 150 seconds.
```