### PR TITLE
Check Negatively Bound Wildcards

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -8,7 +8,9 @@ import ca.uwaterloo.flix.util.vt.VirtualTerminal
 /**
   * A common super-type for safety errors.
   */
-sealed trait SafetyError extends CompilationError
+sealed trait SafetyError extends CompilationError {
+  def kind: String = "Safety Error"
+}
 
 object SafetyError {
 
@@ -16,7 +18,6 @@ object SafetyError {
     * An error raised to indicate an illegal use of a non-positively bound variable in a negative atom.
     */
   case class IllegalNonPositivelyBoundVariable(sym: Symbol.VarSym, loc: SourceLocation) extends SafetyError {
-    def kind: String = "Safety Error"
     def summary: String = s"Illegal non-positively bound variable '$sym'."
     def message: VirtualTerminal = {
       val vt = new VirtualTerminal
@@ -24,8 +25,22 @@ object SafetyError {
       vt << ">> Illegal non-positively bound variable '" << Red(sym.text) << "'." << NewLine
       vt << NewLine
       vt << Code(loc, "the variable occurs in this negated atom.") << NewLine
+      if (!sym.isWild) {
+        vt << NewLine
+        vt << Underline("Tip:") << " Ensure that the variable occurs in at least one positive atom." << NewLine
+      }
+      vt
+    }
+  }
+
+  case class IllegalNonPositivelyBoundWildcard(loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Illegal non-positively bound wildcard '_'."
+    def message: VirtualTerminal = {
+      val vt = new VirtualTerminal
+      vt << Line(kind, source.format) << NewLine
+      vt << ">> Illegal non-positively bound wildcard '" << Red("_") << "'." << NewLine
       vt << NewLine
-      vt << Underline("Tip:") << " Ensure that the variable occurs in at least one positive atom." << NewLine
+      vt << Code(loc, "the wildcard occurs in this negated atom.") << NewLine
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -15,10 +15,24 @@ sealed trait SafetyError extends CompilationError {
 object SafetyError {
 
   /**
+    * Creates an IllegalNonPositivelyBoundVariable or IllegalNegativelyBoundWildVariable error
+    * depending on `sym.isWild`.
+    *
+    * @param loc the position of the body atom containing the illegal variable.
+    */
+  def makeIllegalNonPositivelyBoundVariableError(sym: Symbol.VarSym, loc: SourceLocation): SafetyError =
+    if (sym.isWild) IllegalNegativelyBoundWildVariable(sym, loc) else IllegalNonPositivelyBoundVariable(sym, loc)
+
+  /**
     * An error raised to indicate an illegal use of a non-positively bound variable in a negative atom.
+    * The symbol must not be wild.
+    * Use makeIllegalNonPositivelyBoundVariableError instead of creating this object directly.
+    *
+    * @param loc the position of the body atom containing the illegal variable.
     */
   case class IllegalNonPositivelyBoundVariable(sym: Symbol.VarSym, loc: SourceLocation) extends SafetyError {
     def summary: String = s"Illegal non-positively bound variable '$sym'."
+
     def message: VirtualTerminal = {
       val vt = new VirtualTerminal
       vt << Line(kind, source.format) << NewLine
@@ -33,12 +47,38 @@ object SafetyError {
     }
   }
 
-  case class IllegalNonPositivelyBoundWildcard(loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Illegal non-positively bound wildcard '_'."
+  /**
+    * An error raised to indicate an illegal use of a wild variable in a negative atom.
+    * The symbol must be wild.
+    * Use makeIllegalNonPositivelyBoundVariableError instead of creating this object directly.
+    *
+    * @param loc the position of the body atom containing the illegal variable.
+    */
+  case class IllegalNegativelyBoundWildVariable(sym: Symbol.VarSym, loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Illegal negatively bound variable '$sym'."
+
     def message: VirtualTerminal = {
       val vt = new VirtualTerminal
       vt << Line(kind, source.format) << NewLine
-      vt << ">> Illegal non-positively bound wildcard '" << Red("_") << "'." << NewLine
+      vt << ">> Illegal negatively bound variable '" << Red(sym.text) << "'." << NewLine
+      vt << NewLine
+      vt << Code(loc, "the variable occurs in this negated atom.") << NewLine
+      vt
+    }
+  }
+
+  /**
+    * An error raised to indicate an illegal use of a wildcard in a negative atom.
+    *
+    * @param loc the position of the body atom containing the illegal wildcard.
+    */
+  case class IllegalNegativelyBoundWildcard(loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Illegal negatively bound wildcard '_'."
+
+    def message: VirtualTerminal = {
+      val vt = new VirtualTerminal
+      vt << Line(kind, source.format) << NewLine
+      vt << ">> Illegal negatively bound wildcard '" << Red("_") << "'." << NewLine
       vt << NewLine
       vt << Code(loc, "the wildcard occurs in this negated atom.") << NewLine
     }

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -15,18 +15,7 @@ sealed trait SafetyError extends CompilationError {
 object SafetyError {
 
   /**
-    * Creates an IllegalNonPositivelyBoundVariable or IllegalNegativelyBoundWildVariable error
-    * depending on `sym.isWild`.
-    *
-    * @param loc the position of the body atom containing the illegal variable.
-    */
-  def makeIllegalNonPositivelyBoundVariableError(sym: Symbol.VarSym, loc: SourceLocation): SafetyError =
-    if (sym.isWild) IllegalNegativelyBoundWildVariable(sym, loc) else IllegalNonPositivelyBoundVariable(sym, loc)
-
-  /**
     * An error raised to indicate an illegal use of a non-positively bound variable in a negative atom.
-    * The symbol must not be wild.
-    * Use makeIllegalNonPositivelyBoundVariableError instead of creating this object directly.
     *
     * @param loc the position of the body atom containing the illegal variable.
     */
@@ -49,8 +38,6 @@ object SafetyError {
 
   /**
     * An error raised to indicate an illegal use of a wild variable in a negative atom.
-    * The symbol must be wild.
-    * Use makeIllegalNonPositivelyBoundVariableError instead of creating this object directly.
     *
     * @param loc the position of the body atom containing the illegal variable.
     */

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -25,7 +25,7 @@ object Safety extends Phase[Root, Root] {
     // Collect all errors.
     //
     val errors = root.defs.flatMap {
-      case (sym, defn) => visitDef(defn)
+      case (_, defn) => visitDef(defn)
     }
 
     //
@@ -46,187 +46,199 @@ object Safety extends Phase[Root, Root] {
     * Performs safety and well-formedness checks on the given expression `exp0`.
     */
   private def visitExp(exp0: Expression): List[CompilationError] = exp0 match {
-    case Expression.Unit(loc) => Nil
+    case Expression.Unit(_) => Nil
 
-    case Expression.Null(tpe, loc) => Nil
+    case Expression.Null(_, _) => Nil
 
-    case Expression.True(loc) => Nil
+    case Expression.True(_) => Nil
 
-    case Expression.False(loc) => Nil
+    case Expression.False(_) => Nil
 
-    case Expression.Char(lit, loc) => Nil
+    case Expression.Char(_, _) => Nil
 
-    case Expression.Float32(lit, loc) => Nil
+    case Expression.Float32(_, _) => Nil
 
-    case Expression.Float64(lit, loc) => Nil
+    case Expression.Float64(_, _) => Nil
 
-    case Expression.Int8(lit, loc) => Nil
+    case Expression.Int8(_, _) => Nil
 
-    case Expression.Int16(lit, loc) => Nil
+    case Expression.Int16(_, _) => Nil
 
-    case Expression.Int32(lit, loc) => Nil
+    case Expression.Int32(_, _) => Nil
 
-    case Expression.Int64(lit, loc) => Nil
+    case Expression.Int64(_, _) => Nil
 
-    case Expression.BigInt(lit, loc) => Nil
+    case Expression.BigInt(_, _) => Nil
 
-    case Expression.Str(lit, loc) => Nil
+    case Expression.Str(_, _) => Nil
 
-    case Expression.Default(tpe, loc) => Nil
+    case Expression.Default(_, _) => Nil
 
-    case Expression.Wild(tpe, loc) => Nil
+    case Expression.Wild(_, _) => Nil
 
-    case Expression.Var(sym, tpe, loc) => Nil
+    case Expression.Var(_, _, _) => Nil
 
-    case Expression.Def(sym, tpe, loc) => Nil
+    case Expression.Def(_, _, _) => Nil
 
-    case Expression.Sig(sym, tpe, loc) => Nil
+    case Expression.Sig(_, _, _) => Nil
 
-    case Expression.Hole(sym, tpe, eff, loc) => Nil
+    case Expression.Hole(_, _, _, _) => Nil
 
-    case Expression.Lambda(fparam, exp, tpe, loc) => visitExp(exp)
-
-    case Expression.Apply(exp, exps, tpe, eff, loc) =>
-      val init = visitExp(exp)
-      exps.foldLeft(init) {
-        case (acc, exp) => acc ::: visitExp(exp)
-      }
-
-    case Expression.Unary(sop, exp, tpe, eff, loc) => visitExp(exp)
-
-    case Expression.Binary(sop, exp1, exp2, tpe, eff, loc) => visitExp(exp1) ::: visitExp(exp2)
-
-    case Expression.Let(sym, mod, exp1, exp2, tpe, eff, loc) => visitExp(exp1) ::: visitExp(exp2)
-
-    case Expression.LetRegion(sym, exp, tpe, eff, loc) => visitExp(exp)
-
-    case Expression.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) => visitExp(exp1) ::: visitExp(exp2) ::: visitExp(exp3)
-
-    case Expression.Stm(exp1, exp2, tpe, eff, loc) => visitExp(exp1) ::: visitExp(exp2)
-
-    case Expression.Match(exp, rules, tpe, eff, loc) =>
-      rules.foldLeft(visitExp(exp)) {
-        case (acc, MatchRule(p, g, e)) => acc ::: visitExp(g) ::: visitExp(e)
-      }
-
-    case Expression.Choose(exps, rules, tpe, eff, loc) =>
-      exps.flatMap(visitExp) ++ rules.flatMap {
-        case ChoiceRule(_, exp) => visitExp(exp)
-      }
-
-    case Expression.Tag(sym, tag, exp, tpe, eff, loc) => visitExp(exp)
-
-    case Expression.Tuple(elms, tpe, eff, loc) =>
-      elms.foldLeft(Nil: List[CompilationError]) {
-        case (acc, e) => acc ::: visitExp(e)
-      }
-
-    case Expression.RecordEmpty(tpe, loc) => Nil
-
-    case Expression.RecordSelect(exp, _, tpe, eff, loc) =>
+    case Expression.Lambda(_, exp, _, _) =>
       visitExp(exp)
 
-    case Expression.RecordExtend(_, value, rest, tpe, eff, loc) =>
-      visitExp(value) ::: visitExp(rest)
+    case Expression.Apply(exp, exps, _, _, _) =>
+      visitExp(exp) ::: exps.flatMap(visitExp)
 
-    case Expression.RecordRestrict(_, rest, tpe, eff, loc) =>
-      visitExp(rest)
-
-    case Expression.ArrayLit(elms, tpe, eff, loc) =>
-      elms.foldLeft(Nil: List[CompilationError]) {
-        case (acc, e) => acc ::: visitExp(e)
-      }
-
-    case Expression.ArrayNew(elm, len, tpe, eff, loc) => visitExp(elm)
-
-    case Expression.ArrayLoad(base, index, tpe, eff, loc) => visitExp(base) ::: visitExp(index)
-
-    case Expression.ArrayLength(base, eff, loc) => visitExp(base)
-
-    case Expression.ArrayStore(base, index, elm, loc) => visitExp(base) ::: visitExp(index) ::: visitExp(elm)
-
-    case Expression.ArraySlice(base, beginIndex, endIndex, tpe, loc) => visitExp(base) ::: visitExp(beginIndex) ::: visitExp(endIndex)
-
-    case Expression.Ref(exp, tpe, eff, loc) => visitExp(exp)
-
-    case Expression.Deref(exp, tpe, eff, loc) => visitExp(exp)
-
-    case Expression.Assign(exp1, exp2, tpe, eff, loc) => visitExp(exp1) ::: visitExp(exp2)
-
-    case Expression.Existential(fparam, exp, loc) => visitExp(exp)
-
-    case Expression.Universal(fparam, exp, loc) => visitExp(exp)
-
-    case Expression.Ascribe(exp, tpe, eff, loc) => visitExp(exp)
-
-    case Expression.Cast(exp, tpe, eff, loc) => visitExp(exp)
-
-    case Expression.TryCatch(exp, rules, tpe, eff, loc) =>
-      rules.foldLeft(visitExp(exp)) {
-        case (acc, CatchRule(_, _, e)) => acc ::: visitExp(e)
-      }
-
-    case Expression.InvokeConstructor(constructor, args, tpe, eff, loc) =>
-      args.foldLeft(Nil: List[CompilationError]) {
-        case (acc, e) => acc ::: visitExp(e)
-      }
-
-    case Expression.InvokeMethod(method, exp, args, tpe, eff, loc) =>
-      args.foldLeft(visitExp(exp)) {
-        case (acc, e) => acc ::: visitExp(e)
-      }
-
-    case Expression.InvokeStaticMethod(method, args, tpe, eff, loc) =>
-      args.foldLeft(Nil: List[CompilationError]) {
-        case (acc, e) => acc ::: visitExp(e)
-      }
-
-    case Expression.GetField(field, exp, tpe, eff, loc) =>
+    case Expression.Unary(_, exp, _, _, _) =>
       visitExp(exp)
 
-    case Expression.PutField(field, exp1, exp2, tpe, eff, loc) =>
+    case Expression.Binary(_, exp1, exp2, _, _, _) =>
       visitExp(exp1) ::: visitExp(exp2)
 
-    case Expression.GetStaticField(field, tpe, eff, loc) =>
-      Nil
+    case Expression.Let(_, _, exp1, exp2, _, _, _) =>
+      visitExp(exp1) ::: visitExp(exp2)
 
-    case Expression.PutStaticField(field, exp, tpe, eff, loc) =>
+    case Expression.LetRegion(_, exp, _, _, _) =>
       visitExp(exp)
 
-    case Expression.NewChannel(exp, tpe, eff, loc) => visitExp(exp)
+    case Expression.IfThenElse(exp1, exp2, exp3, _, _, _) =>
+      visitExp(exp1) ::: visitExp(exp2) ::: visitExp(exp3)
 
-    case Expression.GetChannel(exp, tpe, eff, loc) => visitExp(exp)
+    case Expression.Stm(exp1, exp2, _, _, _) =>
+      visitExp(exp1) ::: visitExp(exp2)
 
-    case Expression.PutChannel(exp1, exp2, tpe, eff, loc) => visitExp(exp1) ::: visitExp(exp2)
+    case Expression.Match(exp, rules, _, _, _) =>
+      visitExp(exp) :::
+        rules.flatMap{case MatchRule(_, g, e) => visitExp(g) ::: visitExp(e)}
 
-    case Expression.SelectChannel(rules, default, tpe, eff, loc) =>
-      val rs = rules.foldLeft(Nil: List[CompilationError]) {
-        case (acc, SelectChannelRule(sym, chan, body)) => acc ::: visitExp(chan) ::: visitExp(body)
-      }
+    case Expression.Choose(exps, rules, _, _, _) =>
+      exps.flatMap(visitExp) :::
+        rules.flatMap{case ChoiceRule(_, exp) => visitExp(exp)}
 
-      val d = default.map(visitExp).getOrElse(Nil)
+    case Expression.Tag(_, _, exp, _, _, _) =>
+      visitExp(exp)
 
-      rs ++ d
+    case Expression.Tuple(elms, _, _, _) =>
+      elms.flatMap(visitExp)
 
-    case Expression.Spawn(exp, tpe, eff, loc) => visitExp(exp)
+    case Expression.RecordEmpty(_, _) => Nil
 
-    case Expression.Lazy(exp, tpe, loc) => visitExp(exp)
+    case Expression.RecordSelect(exp, _, _, _, _) =>
+      visitExp(exp)
 
-    case Expression.Force(exp, tpe, eff, loc) => visitExp(exp)
+    case Expression.RecordExtend(_, value, rest, _, _, _) =>
+      visitExp(value) ::: visitExp(rest)
 
-    case Expression.FixpointConstraintSet(cs, stf, tpe, loc) => cs.flatMap(checkConstraint)
+    case Expression.RecordRestrict(_, rest, _, _, _) =>
+      visitExp(rest)
 
-    case Expression.FixpointMerge(exp1, exp2, stf, tpe, eff, loc) => visitExp(exp1) ::: visitExp(exp2)
+    case Expression.ArrayLit(elms, _, _, _) =>
+      elms.flatMap(visitExp)
 
-    case Expression.FixpointSolve(exp, stf, tpe, eff, loc) => visitExp(exp)
+    case Expression.ArrayNew(elm, _, _, _, _) =>
+      visitExp(elm)
 
-    case Expression.FixpointFilter(pred, exp, tpe, eff, loc) => visitExp(exp)
+    case Expression.ArrayLoad(base, index, _, _, _) =>
+      visitExp(base) ::: visitExp(index)
 
-    case Expression.FixpointProjectIn(exp, pred, tpe, eff, loc) => visitExp(exp)
+    case Expression.ArrayLength(base, _, _) =>
+      visitExp(base)
 
-    case Expression.FixpointProjectOut(pred, exp, tpe, eff, loc) => visitExp(exp)
+    case Expression.ArrayStore(base, index, elm, _) =>
+      visitExp(base) ::: visitExp(index) ::: visitExp(elm)
 
-    case Expression.Reify(t, tpe, eff, loc) => Nil
+    case Expression.ArraySlice(base, beginIndex, endIndex, _, _) =>
+      visitExp(base) ::: visitExp(beginIndex) ::: visitExp(endIndex)
+
+    case Expression.Ref(exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expression.Deref(exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expression.Assign(exp1, exp2, _, _, _) =>
+      visitExp(exp1) ::: visitExp(exp2)
+
+    case Expression.Existential(_, exp, _) =>
+      visitExp(exp)
+
+    case Expression.Universal(_, exp, _) =>
+      visitExp(exp)
+
+    case Expression.Ascribe(exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expression.Cast(exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expression.TryCatch(exp, rules, _, _, _) =>
+      visitExp(exp) :::
+        rules.flatMap{case CatchRule(_, _, e) => visitExp(e)}
+
+    case Expression.InvokeConstructor(_, args, _, _, _) =>
+      args.flatMap(visitExp)
+
+    case Expression.InvokeMethod(_, exp, args, _, _, _) =>
+      visitExp(exp) ::: args.flatMap(visitExp)
+
+    case Expression.InvokeStaticMethod(_, args, _, _, _) =>
+      args.flatMap(visitExp)
+
+    case Expression.GetField(_, exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expression.PutField(_, exp1, exp2, _, _, _) =>
+      visitExp(exp1) ::: visitExp(exp2)
+
+    case Expression.GetStaticField(_, _, _, _) =>
+      Nil
+
+    case Expression.PutStaticField(_, exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expression.NewChannel(exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expression.GetChannel(exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expression.PutChannel(exp1, exp2, _, _, _) =>
+      visitExp(exp1) ::: visitExp(exp2)
+
+    case Expression.SelectChannel(rules, default, _, _, _) =>
+      rules.flatMap{case SelectChannelRule(_, chan, body) => visitExp(chan) :::
+        visitExp(body)} :::
+        default.map(visitExp).getOrElse(Nil)
+
+    case Expression.Spawn(exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expression.Lazy(exp, _, _) =>
+      visitExp(exp)
+
+    case Expression.Force(exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expression.FixpointConstraintSet(cs, _, _, _) =>
+      cs.flatMap(checkConstraint)
+
+    case Expression.FixpointMerge(exp1, exp2, _, _, _, _) =>
+      visitExp(exp1) ::: visitExp(exp2)
+
+    case Expression.FixpointSolve(exp, _, _, _, _) =>
+      visitExp(exp)
+
+    case Expression.FixpointFilter(_, exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expression.FixpointProjectIn(exp, _, _, _, _) =>
+      visitExp(exp)
+
+    case Expression.FixpointProjectOut(_, exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expression.Reify(_, _, _, _) => Nil
 
   }
 
@@ -257,10 +269,10 @@ object Safety extends Phase[Root, Root] {
     * with the given positively defined variable symbols `posVars`.
     */
   private def checkBodyPredicate(p0: Predicate.Body, posVars: Set[Symbol.VarSym], quantVars: Set[Symbol.VarSym]): List[CompilationError] = p0 match {
-    case Predicate.Body.Atom(pred, den, polarity, terms, tpe, loc) =>
+    case Predicate.Body.Atom(_, _, polarity, terms, _, loc) =>
       checkBodyAtomPredicate(polarity, terms, posVars, quantVars, loc)
 
-    case Predicate.Body.Guard(exp, loc) => visitExp(exp)
+    case Predicate.Body.Guard(exp, _) => visitExp(exp)
   }
 
   /**
@@ -272,20 +284,26 @@ object Safety extends Phase[Root, Root] {
       case Polarity.Negative =>
         // Compute the free variables in the terms which are *not* bound by the lexical scope.
         val freeVars = terms.flatMap(freeVarsOf).toSet intersect quantVars
-        val errors = checkNegativeWildcards(terms)
+        val errors = checkNegativeWildcards(terms, loc)
 
         // Check if any free variables are not positively bound.
-        errors ++ ((freeVars -- posVars) map (unboundVar => SafetyError.IllegalNonPositivelyBoundVariable(unboundVar, loc))).toList
+        errors ++ ((freeVars -- posVars) map (unboundVar => SafetyError.makeIllegalNonPositivelyBoundVariableError(unboundVar, loc))).toList
     }
   }
 
-  private def checkNegativeWildcards(terms: List[TypedAst.Pattern]): List[CompilationError] = {
-    terms.flatMap(checkNegativeWildcards)
+  /**
+    * @param loc the location of the atom containing the terms.
+    */
+  private def checkNegativeWildcards(terms: List[TypedAst.Pattern], loc: SourceLocation): List[CompilationError] = {
+    terms.flatMap(checkNegativeWildcards(_, loc))
   }
 
+  /**
+    * @param loc the location of the atom containing the term.
+    */
   @tailrec
-  private def checkNegativeWildcards(term: TypedAst.Pattern): List[CompilationError] = term match {
-    case Pattern.Wild(_, loc) => List(SafetyError.IllegalNonPositivelyBoundWildcard(loc))
+  private def checkNegativeWildcards(term: TypedAst.Pattern, loc: SourceLocation): List[CompilationError] = term match {
+    case Pattern.Wild(_, _) => List(SafetyError.IllegalNegativelyBoundWildcard(loc))
     case Pattern.Var(_, _, _) => Nil
     case Pattern.Unit(_) => Nil
     case Pattern.True(_) => Nil
@@ -299,11 +317,11 @@ object Safety extends Phase[Root, Root] {
     case Pattern.Int64(_, _) => Nil
     case Pattern.BigInt(_, _) => Nil
     case Pattern.Str(_, _) => Nil
-    case Pattern.Tag(_, _, pat, _, _) => checkNegativeWildcards(pat)
-    case Pattern.Tuple(elms, _, _) => checkNegativeWildcards(elms)
-    case Pattern.Array(elms, _, _) => checkNegativeWildcards(elms)
-    case Pattern.ArrayTailSpread(elms, _, _, _) => checkNegativeWildcards(elms)
-    case Pattern.ArrayHeadSpread(_, elms, _, _) => checkNegativeWildcards(elms)
+    case Pattern.Tag(_, _, pat, _, _) => checkNegativeWildcards(pat, loc)
+    case Pattern.Tuple(elms, _, _) => checkNegativeWildcards(elms, loc)
+    case Pattern.Array(elms, _, _) => checkNegativeWildcards(elms, loc)
+    case Pattern.ArrayTailSpread(elms, _, _, _) => checkNegativeWildcards(elms, loc)
+    case Pattern.ArrayHeadSpread(_, elms, _, _) => checkNegativeWildcards(elms, loc)
   }
 
   /**
@@ -315,7 +333,7 @@ object Safety extends Phase[Root, Root] {
     * Returns all positively defined variable symbols in the given body predicate `p0`.
     */
   private def positivelyDefinedVariables(p0: Predicate.Body): Set[Symbol.VarSym] = p0 match {
-    case Predicate.Body.Atom(pred, den, polarity, terms, tpe, loc) => polarity match {
+    case Predicate.Body.Atom(_, _, polarity, terms, _, _) => polarity match {
       case Polarity.Positive =>
         // Case 1: A positive atom positively defines all its free variables.
         terms.flatMap(freeVarsOf).toSet
@@ -324,7 +342,7 @@ object Safety extends Phase[Root, Root] {
         Set.empty
     }
 
-    case Predicate.Body.Guard(exp, loc) => Set.empty
+    case Predicate.Body.Guard(_, _) => Set.empty
   }
 
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -28,7 +28,7 @@ class TestSafety extends FunSuite with TestUtils {
   test("NonPositivelyBoundVariable.01") {
     val input =
       """
-        |pub def f(): #{ A(Int), B(Int) } = solve {
+        |pub def f(): #{ A(Int), B(Int) } = #{
         |    A(x) :- not B(x).
         |}
       """.stripMargin
@@ -47,10 +47,21 @@ class TestSafety extends FunSuite with TestUtils {
     expectError[IllegalNonPositivelyBoundVariable](result)
   }
 
+  test("NonPositivelyBoundVariable.03") {
+    val input =
+      """
+        |pub def f(): #{ A(Int), B(Int), R(Int) } = #{
+        |    R(x) :- not A(x), B(12), if x > 5.
+        |}
+    """.stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[IllegalNonPositivelyBoundVariable](result)
+  }
+
   test("NegativelyBoundWildVariable.01") {
     val input =
       """
-        |pub def f(): #{ A(Int), B(Int), R(Int) } = solve {
+        |pub def f(): #{ A(Int), B(Int), R(Int) } = #{
         |    R(x) :- A(x), not B(_y).
         |}
       """.stripMargin
@@ -70,10 +81,21 @@ class TestSafety extends FunSuite with TestUtils {
     expectError[IllegalNegativelyBoundWildVariable](result)
   }
 
+  test("NegativelyBoundWildVariable.03") {
+    val input =
+      """
+        |pub def f(): #{ A(Int), B(Int), R(Int) } = #{
+        |    R(1) :- A(y), not A(_y), not B(y).
+        |}
+      """.stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[IllegalNegativelyBoundWildVariable](result)
+  }
+
   test("NegativelyBoundWildcard.01") {
     val input =
       """
-        |pub def f(): #{ A(Int), B(Int) } = solve {
+        |pub def f(): #{ A(Int), B(Int) } = #{
         |    A(1) :- not B(_).
         |}
       """.stripMargin
@@ -86,6 +108,17 @@ class TestSafety extends FunSuite with TestUtils {
       """
         |pub def f(): #{ A(Int), B(Int) } = solve {
         |    A(1) :- not B(_), A(_).
+        |}
+      """.stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[IllegalNegativelyBoundWildcard](result)
+  }
+
+  test("NegativelyBoundWildcard.03") {
+    val input =
+      """
+        |pub def f(): #{ A(Int), B(Int) } = #{
+        |    A(1) :- not B(z), A(z), B(_).
         |}
       """.stripMargin
     val result = compile(input, DefaultOptions)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -118,7 +118,7 @@ class TestSafety extends FunSuite with TestUtils {
     val input =
       """
         |pub def f(): #{ A(Int), B(Int) } = #{
-        |    A(1) :- not B(z), A(z), B(_).
+        |    A(1) :- not B(z), A(z), not B(_).
         |}
       """.stripMargin
     val result = compile(input, DefaultOptions)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -17,8 +17,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
-import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.errors.SafetyError.IllegalNonPositivelyBoundVariable
+import ca.uwaterloo.flix.language.errors.SafetyError.{IllegalNegativelyBoundWildVariable, IllegalNegativelyBoundWildcard, IllegalNonPositivelyBoundVariable}
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.FunSuite
 
@@ -41,25 +40,26 @@ class TestSafety extends FunSuite with TestUtils {
     val input =
       """
         |pub def f(): #{ A(Int), B(Int), R(Int) } = solve {
+        |    R(x) :- not A(x), not B(x).
+        |}
+    """.stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[IllegalNonPositivelyBoundVariable](result)
+  }
+
+  test("NegativelyBoundWildVariable.01") {
+    val input =
+      """
+        |pub def f(): #{ A(Int), B(Int), R(Int) } = solve {
         |    R(x) :- A(x), not B(_y).
         |}
       """.stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[IllegalNonPositivelyBoundVariable](result)
+    expectError[IllegalNegativelyBoundWildVariable](result)
   }
 
-  test("NonPositivelyBoundVariable.03") {
-    val input =
-      """
-        |pub def f(): #{ A(Int), B(Int), R(Int) } = solve {
-        |    R(x) :- not A(x), not B(x).
-        |}
-      """.stripMargin
-    val result = compile(input, DefaultOptions)
-    expectError[IllegalNonPositivelyBoundVariable](result)
-  }
 
-  test("NonPositivelyBoundVariable.04") {
+  test("NegativelyBoundWildVariable.02") {
     val input =
       """
         |pub def f(): #{ A(Int), B(Int), R(Int) } = solve {
@@ -67,7 +67,29 @@ class TestSafety extends FunSuite with TestUtils {
         |}
       """.stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[IllegalNonPositivelyBoundVariable](result)
+    expectError[IllegalNegativelyBoundWildVariable](result)
+  }
+
+  test("NegativelyBoundWildcard.01") {
+    val input =
+      """
+        |pub def f(): #{ A(Int), B(Int) } = solve {
+        |    A(1) :- not B(_).
+        |}
+      """.stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[IllegalNegativelyBoundWildcard](result)
+  }
+
+  test("NegativelyBoundWildcard.02") {
+    val input =
+      """
+        |pub def f(): #{ A(Int), B(Int) } = solve {
+        |    A(1) :- not B(_), A(_).
+        |}
+      """.stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[IllegalNegativelyBoundWildcard](result)
   }
 
 }


### PR DESCRIPTION
Fixes #1973

The program
```
def main(_args: Array[String]) : Int32 & Impure =
    let p = #{ A(1, 2). B(1) :- not A(1, _). };
    query p select x from B(x) |> println;
    0
```
results in this error:
```
-- Safety Error -------------------------------------------------- examples\misc\test.flix

>> Illegal negatively bound wildcard '_'.

2 |     let p = #{ A(1, 2). B(1) :- not A(1, _). };
                                    ^^^^^^^^^^^
                                    the wildcard occurs in this negated atom.



Compilation failed with 1 error(s).
```
When `_` is changed to `_x` the error is:
```
-- Safety Error -------------------------------------------------- examples\misc\test.flix

>> Illegal negatively bound variable '_x'.

2 |     let p = #{ A(1, 2). B(1) :- not A(1, _x). };
                                    ^^^^^^^^^^^^
                                    the variable occurs in this negated atom.



Compilation failed with 1 error(s).
``` 
When `B(1) :- not A(1, _).` is changed to `B(x) :- not A(1, x).` in the original program the error is:
```
-- Safety Error -------------------------------------------------- examples\misc\test.flix

>> Illegal non-positively bound variable 'x'.

2 |     let p = #{ A(1, 2). B(x) :- not A(1, x). };
                                    ^^^^^^^^^^^
                                    the variable occurs in this negated atom.


Tip: Ensure that the variable occurs in at least one positive atom.


Compilation failed with 1 error(s).
```