### PR TITLE
Add Enum and EnumCase DocumentSymbolProvider (#2290)

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
@@ -245,7 +245,7 @@ class LanguageServer(port: Int) extends WebSocketServer(new InetSocketAddress("l
       ("id" -> id) ~ RenameProvider.processRename(newName, uri, pos)(index, root)
 
     case Request.DocumentSymbols(id, uri) =>
-      ("id" -> id) ~ ("status" -> "success") ~ ("result" -> SymbolProvider.processDocumentSymbols(uri)(index, root).map(_.toJSON))
+      ("id" -> id) ~ ("status" -> "success") ~ ("result" -> SymbolProvider.processDocumentSymbols(uri)(root).map(_.toJSON))
 
     case Request.Uses(id, uri, pos) =>
       ("id" -> id) ~ FindReferencesProvider.findRefs(uri, pos)(index, root)


### PR DESCRIPTION
Partially fix: https://github.com/flix/flix/issues/2290

Trying to add `Enum` and `EnumCase` SymbolKind Provider. I have tested the changes and the outline and breadcumbs in vscode are looking fine.
![Screenshot from 2021-09-26 14-32-03](https://user-images.githubusercontent.com/55001950/134808412-fe7d268d-7c15-4601-a1c0-c7528b4b307f.png)


I have still some doubts about the documentation, I don't know when the docs is included in the AST and how to use it to return the correct `range` field of `DocumentSymbol`. I also noticed that `EnumCase` doesn't have any documentation attached, is it true?

