### PR TITLE
Add `{Functor, Order}` instances to `LazyList`

### DIFF
--- a/main/src/library/LazyList.flix
+++ b/main/src/library/LazyList.flix
@@ -44,6 +44,34 @@ instance ToString[LazyList[a]] with ToString[a] {
     pub def toString(l: LazyList[a]): String = LazyList.toString(l)
 }
 
+instance Order[LazyList[a]] with Order[a] {
+
+    ///
+    /// Compares `l1` and `l2` lexicographically.
+    ///
+    pub def compare(l1: LazyList[a], l2: LazyList[a]): Comparison = match (l1, l2) {
+        case (ENil        ,         ENil) => EqualTo
+        case (_           ,         ENil) => GreaterThan
+        case (ENil        ,            _) => LessThan
+        case (LList(xs)   ,    LList(ys)) => (force xs) <=> (force ys)
+        case (_           ,    LList(ys)) =>         l1 <=> (force ys)
+        case (LList(xs)   ,            _) => (force xs) <=>        l2
+        case (ECons(x, xs), ECons(y, ys)) =>
+            let cmp = x <=> y;
+            if (cmp == EqualTo)         xs <=> ys         else cmp
+        case (ECons(x, xs), LCons(y, ys)) =>
+            let cmp = x <=> y;
+            if (cmp == EqualTo)         xs <=> (force ys) else cmp
+        case (LCons(x, xs), ECons(y, ys)) =>
+            let cmp = x <=> y;
+            if (cmp == EqualTo) (force xs) <=>        ys  else cmp
+        case (LCons(x, xs), LCons(y, ys)) =>
+            let cmp = x <=> y;
+            if (cmp == EqualTo) (force xs) <=> (force ys) else cmp
+    }
+}
+
+
 namespace LazyList {
 
     ///

--- a/main/src/library/LazyList.flix
+++ b/main/src/library/LazyList.flix
@@ -40,6 +40,10 @@ instance Foldable[LazyList] {
     pub def foldRight(f: (a, b) -> b & ef, s: b, l: LazyList[a]): b & ef = LazyList.foldRight(f, s, l)
 }
 
+instance Functor[LazyList] {
+    pub def map(f: a -> b & ef, l: LazyList[a]): LazyList[b] & ef = LazyList.map(f, l)
+}
+
 instance ToString[LazyList[a]] with ToString[a] {
     pub def toString(l: LazyList[a]): String = LazyList.toString(l)
 }

--- a/main/test/ca/uwaterloo/flix/library/TestLazyList2.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestLazyList2.flix
@@ -569,4 +569,37 @@ namespace TestLazyList2 {
     def sum07(): Bool =
         List.range(1, 101) |> List.toLazy |> LazyList.sum == 5050
 
+
+    /////////////////////////////////////////////////////////////////////////////
+    // order                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def order01(): Bool =
+        ENil: LazyList[Unit] <=> ENil: LazyList[Unit] == EqualTo
+
+    @test
+    def order02(): Bool =
+        ((1 :: Nil) |> List.toLazy) <=> ENil: LazyList[Int32] == GreaterThan
+
+    @test
+    def order03(): Bool =
+        ENil: LazyList[Int32] <=> ((1 :: Nil) |> List.toLazy) == LessThan
+
+    @test
+    def order04(): Bool =
+        ((1 :: Nil) |> List.toLazy) <=> ((1 :: Nil) |> List.toLazy) == EqualTo
+
+    @test
+    def order05(): Bool =
+        ((2 :: 1 :: Nil) |> List.toLazy) <=> ((1 :: 1 :: Nil) |> List.toLazy) == GreaterThan
+
+    @test
+    def order06(): Bool =
+        ((1 :: 1 :: Nil) |> List.toLazy) <=> ((2 :: 1 :: Nil) |> List.toLazy) == LessThan
+
+    @test
+    def order07(): Bool =
+        ((1 :: Nil) |> List.toLazy) <=> ((1 :: 1 :: Nil) |> List.toLazy) == LessThan
+
 }


### PR DESCRIPTION
Related to #2307 

Should the `compare` function be defined within the `LazyList` namespace?