### PR TITLE
LSP: Add ImplementationProvider capability and lsp/implementation request

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
@@ -176,6 +176,7 @@ class LanguageServer(port: Int) extends WebSocketServer(new InetSocketAddress("l
       case JString("lsp/highlight") => Request.parseHighlight(json)
       case JString("lsp/hover") => Request.parseHover(json)
       case JString("lsp/goto") => Request.parseGoto(json)
+      case JString("lsp/implementation") => Request.parseImplementation(json)
       case JString("lsp/rename") => Request.parseRename(json)
       case JString("lsp/documentSymbols") => Request.parseDocumentSymbols(json)
       case JString("lsp/workspaceSymbols") => Request.parseWorkspaceSymbols(json)
@@ -241,6 +242,9 @@ class LanguageServer(port: Int) extends WebSocketServer(new InetSocketAddress("l
 
     case Request.Goto(id, uri, pos) =>
       ("id" -> id) ~ GotoProvider.processGoto(uri, pos)(index, root)
+
+    case Request.Implementation(id, uri, pos) =>
+      ("id" -> id) ~ ("status" -> "success") ~ ("result" -> ImplementationProvider.processImplementation(uri, pos)(root).map(_.toJSON))
 
     case Request.Rename(id, newName, uri, pos) =>
       ("id" -> id) ~ RenameProvider.processRename(newName, uri, pos)(index, root)

--- a/main/src/ca/uwaterloo/flix/api/lsp/LocationLink.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LocationLink.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.api.lsp
 
 import ca.uwaterloo.flix.language.ast.TypedAst.Root
-import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol}
+import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, TypedAst}
 import org.json4s.JsonDSL._
 import org.json4s._
 
@@ -82,6 +82,17 @@ object LocationLink {
     val targetUri = sym.loc.source.name
     val targetRange = Range.from(sym.loc)
     val targetSelectionRange = Range.from(sym.loc)
+    LocationLink(originSelectionRange, targetUri, targetRange, targetSelectionRange)
+  }
+
+  /**
+    * Returns a reference to the instance node `instance`.
+    */
+  def fromInstance(instance: TypedAst.Instance, originLoc: SourceLocation): LocationLink = {
+    val originSelectionRange = Range.from(originLoc)
+    val targetUri = instance.loc.source.name
+    val targetRange = Range.from(instance.loc)
+    val targetSelectionRange = Range.from(instance.loc)
     LocationLink(originSelectionRange, targetUri, targetRange, targetSelectionRange)
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/Request.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Request.scala
@@ -85,6 +85,11 @@ object Request {
   case class Goto(requestId: String, uri: String, pos: Position) extends Request
 
   /**
+    * A request to find implementations.
+    */
+  case class Implementation(requestId: String, uri: String, pos: Position) extends Request
+
+  /**
     * A request to get highlight information.
     */
   case class Highlight(requestId: String, uri: String, pos: Position) extends Request
@@ -235,6 +240,17 @@ object Request {
       uri <- parseUri(json)
       pos <- Position.parse(json \\ "position")
     } yield Request.Goto(id, uri, pos)
+  }
+
+  /**
+    * Tries to parse the given `json` value as a [[Implementation]] request.
+    */
+  def parseImplementation(json: JValue): Result[Request, String] = {
+    for {
+      id <- parseId(json)
+      uri <- parseUri(json)
+      pos <- Position.parse(json \\ "position")
+    } yield Request.Implementation(id, uri, pos)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/ImplementationProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/ImplementationProvider.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Nicola Dardanis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.api.lsp.provider
+
+import ca.uwaterloo.flix.api.lsp.{LocationLink, Position}
+import ca.uwaterloo.flix.language.ast.TypedAst.Root
+
+object ImplementationProvider {
+
+  /**
+    * Returns implementations LocationLink for a given class.
+    */
+  def processImplementation(uri: String, position: Position)(implicit root: Root): List[LocationLink] = {
+    if (root == null) {
+      // No AST available.
+      return Nil
+    }
+
+    root.instances.keys.filter(i => i.loc.source.name == uri
+      && (i.loc.beginLine < position.line
+        || (i.loc.beginLine == position.line && i.loc.beginCol <= position.character))
+      && (i.loc.endLine > position.line
+        || (i.loc.endLine == position.line && i.loc.endCol >= position.character))
+    ).flatMap(c => root.instances.getOrElse(c, Nil).map(c => LocationLink.fromInstance(c, c.loc))).toList
+  }
+}


### PR DESCRIPTION
Add [ImplementationProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#textDocument_implementation) to LSP. This will allow to have go to implementation capabilities
![Screenshot from 2021-10-02 01-17-31](https://user-images.githubusercontent.com/55001950/135695224-459e7eff-b1c8-478c-8305-69b93a96a835.png)
.