### PR TITLE
LSP: Fix DocumentSymbol range in order to include function body

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Position.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Position.scala
@@ -52,6 +52,12 @@ object Position {
   * @param line      Line position in a document (zero-based).
   * @param character Character offset on a line in a document (zero-based).
   */
-case class Position(line: Int, character: Int) {
+case class Position(line: Int, character: Int) extends Ordered[Position] {
   def toJSON: JValue = ("line" -> line) ~ ("character" -> character)
+
+  override def compare(that: Position): Int =
+    line - that.line match {
+      case 0 => character - that.character
+      case n => n
+    }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/Range.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Range.scala
@@ -33,6 +33,11 @@ object Range {
     Range(Position(loc.beginLine - 1, loc.beginCol - 1), Position(loc.endLine - 1, loc.endCol - 1))
   }
 
+  def merge(r1: Range, r2: Range): Range = {
+    val Range(start, _) = if (r1.start < r2.start) r1 else r2
+    val Range(_, end) = if (r2.end > r1.end) r2 else r1
+    Range(start, end)
+  }
 }
 
 /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
@@ -94,9 +94,21 @@ object SymbolProvider {
     * Returns a Method DocumentSymbol from a Sig node.
     */
   private def mkSigDocumentSymbol(s: TypedAst.Sig): DocumentSymbol = s match {
-    case TypedAst.Sig(sym, spec, _) => DocumentSymbol(
-      sym.name, Some(spec.doc.text), SymbolKind.Method, Range.from(sym.loc), Range.from(sym.loc), Nil, Nil,
-    )
+    case TypedAst.Sig(sym, spec, impl) =>
+      val selectionRange = Range.from(sym.loc)
+      val range = impl match {
+        case None => selectionRange
+        case Some(i) => Range.merge(selectionRange, Range.from(i.exp.loc))
+      }
+      DocumentSymbol(
+        sym.name,
+        Some(spec.doc.text),
+        SymbolKind.Method,
+        range,
+        selectionRange,
+        Nil,
+        Nil,
+      )
   }
 
   /**
@@ -112,8 +124,8 @@ object SymbolProvider {
     * Returns a Function DocumentSymbol from a Def node.
     */
   private def mkDefDocumentSymbol(d: TypedAst.Def): DocumentSymbol = d match {
-    case TypedAst.Def(sym, spec, _) => DocumentSymbol(
-      sym.name, Some(spec.doc.text), SymbolKind.Function, Range.from(sym.loc), Range.from(sym.loc), Nil, Nil,
+    case TypedAst.Def(sym, spec, impl) => DocumentSymbol(
+      sym.name, Some(spec.doc.text), SymbolKind.Function, Range.merge(Range.from(sym.loc), Range.from(impl.exp.loc)), Range.from(sym.loc), Nil, Nil,
     )
   }
 


### PR DESCRIPTION
https://github.com/flix/flix/issues/2390

Include function body in `DocumentSymbol` range so that the breadcrumb and outline for that symbol is correctly displayed even inside the function body.

In the future maybe we can include also the documentation.