### PR TITLE
Remove Order constraint on Eq[Map[k, v]] and Eq[Set[a]]

### DIFF
--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -38,9 +38,9 @@ instance Hash[Map[k, v]] with Hash[k], Hash[v] {
         Map.foldLeftWithKey((acc, k, v) -> acc * 17 + Hash.hash(k) + 19 * Hash.hash(v), 7937, m)
 }
 
-instance Eq[Map[k, v]] with Order[k], Eq[v] {
+instance Eq[Map[k, v]] with Eq[k], Eq[v] {
     pub def eq(m1: Map[k, v], m2: Map[k, v]): Bool =
-        Map.isSubmapOf(m1, m2) and Map.isSubmapOf(m2, m1)
+        Map.toList(m1) == Map.toList(m2)
 
 }
 

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -38,9 +38,9 @@ instance Hash[Set[a]] with Hash[a] {
         Set.foldLeft((acc, x) -> acc * 37 + Hash.hash(x), 7793, xs)
 }
 
-instance Eq[Set[a]] with Order[a] {
+instance Eq[Set[a]] with Eq[a] {
     pub def eq(xs: Set[a], ys: Set[a]): Bool =
-        Set.isSubsetOf(xs, ys) and Set.isSubsetOf(ys, xs)
+        Set.toList(xs) == Set.toList(ys)
 }
 
 instance Order[Set[a]] with Order[a] {


### PR DESCRIPTION
It's also slightly faster if we trust the annotations (`n` vs `n log n`).

Allows sets and maps to be present in derived instances:
```
opaque type Thing[a] with Eq = Set[a]
```

Related: https://github.com/flix/flix/issues/2394 (this fix only works for sets and maps; the general case is still unsolved)