### PR TITLE
Reintroduce `reifyEff`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -334,6 +334,9 @@ object Indexer {
 
     case Expression.ReifyType(t, _, _, _, _) =>
       visitType(t) ++ Index.occurrenceOf(exp0)
+
+    case Expression.ReifyEff(sym, exp1, exp2, exp3, _, _, _) =>
+      visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3) ++ Index.occurrenceOf(sym, exp1.tpe) ++ Index.occurrenceOf(exp0)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -18,9 +18,8 @@ package ca.uwaterloo.flix.api.lsp.provider
 import ca.uwaterloo.flix.api.lsp._
 import ca.uwaterloo.flix.language.ast.Ast.{BoundBy, TypeConstraint}
 import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.{Body, Head}
-import ca.uwaterloo.flix.language.ast.{SourceLocation, Type, TypeConstructor, TypedAst}
-import ca.uwaterloo.flix.language.ast.Symbol
-import ca.uwaterloo.flix.language.ast.TypedAst.{CatchRule, Constraint, Expression, FormalParam, MatchRule, Pattern, Root, SelectChannelRule, TypeParam}
+import ca.uwaterloo.flix.language.ast.TypedAst._
+import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.util.InternalCompilerException
 import org.json4s.JsonAST.JObject
 import org.json4s.JsonDSL._
@@ -442,6 +441,10 @@ object SemanticTokensProvider {
 
     case Expression.ReifyType(t, _, _, _, _) => visitType(t)
 
+    case Expression.ReifyEff(sym, exp1, exp2, exp3, tpe, eff, loc) =>
+      val o = getSemanticTokenType(sym, exp1.tpe)
+      val t = SemanticToken(o, Nil, sym.loc)
+      Iterator(t) ++ visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -196,6 +196,8 @@ object KindedAst {
 
     case class ReifyType(t: Type, k: Kind, loc: SourceLocation) extends KindedAst.Expression
 
+    case class ReifyEff(sym: Symbol.VarSym, exp1: KindedAst.Expression, exp2: KindedAst.Expression, exp3: KindedAst.Expression, loc: SourceLocation) extends KindedAst.Expression
+
   }
 
   sealed trait Pattern {

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -212,6 +212,8 @@ object NamedAst {
 
     case class ReifyType(t: NamedAst.Type, k: Kind, loc: SourceLocation) extends NamedAst.Expression
 
+    case class ReifyEff(sym: Symbol.VarSym, exp1: NamedAst.Expression,exp2: NamedAst.Expression, exp3: NamedAst.Expression, loc: SourceLocation) extends NamedAst.Expression
+
   }
 
   sealed trait Pattern {

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -212,7 +212,7 @@ object NamedAst {
 
     case class ReifyType(t: NamedAst.Type, k: Kind, loc: SourceLocation) extends NamedAst.Expression
 
-    case class ReifyEff(sym: Symbol.VarSym, exp1: NamedAst.Expression,exp2: NamedAst.Expression, exp3: NamedAst.Expression, loc: SourceLocation) extends NamedAst.Expression
+    case class ReifyEff(sym: Symbol.VarSym, exp1: NamedAst.Expression, exp2: NamedAst.Expression, exp3: NamedAst.Expression, loc: SourceLocation) extends NamedAst.Expression
 
   }
 
@@ -398,7 +398,9 @@ object NamedAst {
 
   sealed trait TypeParam {
     def name: Name.Ident
+
     def tpe: ast.Type.UnkindedVar
+
     def loc: SourceLocation
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1036,6 +1036,18 @@ object ParsedAst {
       */
     case class ReifyType(sp1: SourcePosition, t: ParsedAst.Type, sp2: SourcePosition) extends ParsedAst.Expression
 
+    /**
+      * ReifyEff Expression (Will eventually be replaced by other reify expressions).
+      *
+      * @param sp1   the position of the first character in the expression.
+      * @param exp1  the function expression on whose purity to match.
+      * @param ident the name to bind the pure function to.
+      * @param exp2  the then expression.
+      * @param exp3  the else expression.
+      * @param sp2   the position of the last character in the expression.
+      */
+    case class ReifyEff(sp1: SourcePosition, exp1: ParsedAst.Expression, ident: Name.Ident, exp2: ParsedAst.Expression, exp3: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Expression
+
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -197,6 +197,8 @@ object ResolvedAst {
 
     case class ReifyType(t: Type, k: Kind, loc: SourceLocation) extends ResolvedAst.Expression
 
+    case class ReifyEff(sym: Symbol.VarSym, exp1: ResolvedAst.Expression,exp2: ResolvedAst.Expression, exp3: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
+
   }
 
   sealed trait Pattern {

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -197,7 +197,7 @@ object ResolvedAst {
 
     case class ReifyType(t: Type, k: Kind, loc: SourceLocation) extends ResolvedAst.Expression
 
-    case class ReifyEff(sym: Symbol.VarSym, exp1: ResolvedAst.Expression,exp2: ResolvedAst.Expression, exp3: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
+    case class ReifyEff(sym: Symbol.VarSym, exp1: ResolvedAst.Expression, exp2: ResolvedAst.Expression, exp3: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -291,6 +291,8 @@ object TypedAst {
 
     case class ReifyType(t: Type, k: Kind, tpe: Type, eff: Type, loc: SourceLocation) extends TypedAst.Expression
 
+    case class ReifyEff(sym: Symbol.VarSym, exp1: TypedAst.Expression, exp2: TypedAst.Expression, exp3: TypedAst.Expression, tpe: Type, eff: Type, loc: SourceLocation) extends TypedAst.Expression
+
   }
 
   sealed trait Pattern {

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -213,6 +213,8 @@ object WeededAst {
 
     case class ReifyType(t: WeededAst.Type, k: Kind, loc: SourceLocation) extends WeededAst.Expression
 
+    case class ReifyEff(ident: Name.Ident, exp1: WeededAst.Expression,exp2: WeededAst.Expression, exp3: WeededAst.Expression, loc: SourceLocation) extends WeededAst.Expression
+
   }
 
   sealed trait Pattern {

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -213,7 +213,7 @@ object WeededAst {
 
     case class ReifyType(t: WeededAst.Type, k: Kind, loc: SourceLocation) extends WeededAst.Expression
 
-    case class ReifyEff(ident: Name.Ident, exp1: WeededAst.Expression,exp2: WeededAst.Expression, exp3: WeededAst.Expression, loc: SourceLocation) extends WeededAst.Expression
+    case class ReifyEff(ident: Name.Ident, exp1: WeededAst.Expression, exp2: WeededAst.Expression, exp3: WeededAst.Expression, loc: SourceLocation) extends WeededAst.Expression
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
@@ -243,6 +243,9 @@ object TypedAstOps {
       case Expression.ReifyType(_, _, _, _, _) =>
         Map.empty
 
+      case Expression.ReifyEff(_, exp1, exp2, exp3, _, _, _) =>
+        visitExp(exp1, env0) ++ visitExp(exp2, env0) ++ visitExp(exp3, env0)
+
     }
 
     /**
@@ -399,6 +402,7 @@ object TypedAstOps {
     case Expression.FixpointProjectOut(_, exp, _, _, _) => sigSymsOf(exp)
     case Expression.Reify(_, _, _, _) => Set.empty
     case Expression.ReifyType(_, _, _, _, _) => Set.empty
+    case Expression.ReifyEff(_, exp1, exp2, exp3, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2) ++sigSymsOf(exp3)
   }
 
   /**
@@ -663,6 +667,9 @@ object TypedAstOps {
 
     case Expression.ReifyType(_, _, _, _, _) =>
       Map.empty
+
+    case Expression.ReifyEff(sym, exp1, exp2, exp3, _, _, _) =>
+      (freeVars(exp1) ++ freeVars(exp2) ++ freeVars(exp3)) - sym
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/debug/FormatExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/debug/FormatExpression.scala
@@ -82,6 +82,7 @@ object FormatExpression {
     case TypedAst.Expression.FixpointProjectOut(pred, exp, tpe, eff, loc) => s"FixpointProjectOut($pred, $exp)"
     case TypedAst.Expression.Reify(t, _, _, _) => s"Reify($t)"
     case TypedAst.Expression.ReifyType(t, k, _, _, _) => s"ReifyType($t, $k)"
+    case TypedAst.Expression.ReifyEff(sym, exp1, exp2, exp3, _, _, _) => s"ReifyEff($sym, $exp1, $exp2, $exp3)"
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -571,6 +571,14 @@ object Kinder extends Phase[ResolvedAst.Root, KindedAst.Root] {
       for {
         t <- visitType(t0, k0, kenv, taenv, root)
       } yield KindedAst.Expression.ReifyType(t, k0, loc)
+
+    case ResolvedAst.Expression.ReifyEff(sym, exp1, exp2, exp3, loc) =>
+      for {
+        e1 <- visitExp(exp1, kenv, taenv, root)
+        e2 <- visitExp(exp2, kenv, taenv, root)
+        e3 <- visitExp(exp3, kenv, taenv, root)
+      } yield KindedAst.Expression.ReifyEff(sym, e1, e2, e3, loc)
+
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Linter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Linter.scala
@@ -244,6 +244,8 @@ object Linter extends Phase[TypedAst.Root, TypedAst.Root] {
 
       case Expression.ReifyType(_, _, _, _, _) => Nil
 
+      case Expression.ReifyEff(_, exp1, exp2, exp3, _, _, _) => visitExp(exp1, lint0) ++ visitExp(exp2, lint0) ++ visitExp(exp3, lint0)
+
     }
 
     tryLint(exp0, lint0) ::: recursiveErrors
@@ -389,7 +391,7 @@ object Linter extends Phase[TypedAst.Root, TypedAst.Root] {
         s2 <- unifyExps(exps1, exps2, metaVars)
       } yield s2 @@ s1
 
-      // TODO: Not sure if we need to take the type of the semantic operator into account, e.g. Int32.Neg is the same as Int16.Neg?
+    // TODO: Not sure if we need to take the type of the semantic operator into account, e.g. Int32.Neg is the same as Int16.Neg?
     case (Expression.Unary(op1, exp1, _, _, _), Expression.Unary(op2, exp2, _, _, _)) if op1 == op2 =>
       unifyExp(exp1, exp2, metaVars)
 
@@ -962,6 +964,12 @@ object Linter extends Phase[TypedAst.Root, TypedAst.Root] {
 
       case Expression.ReifyType(t, k, tpe, eff, loc) =>
         Expression.ReifyType(t, k, tpe, eff, loc)
+
+      case Expression.ReifyEff(sym, exp1, exp2, exp3, tpe, eff, loc) =>
+        val e1 = apply(exp1)
+        val e2 = apply(exp2)
+        val e3 = apply(exp3)
+        Expression.ReifyEff(sym, e1, e2, e3, tpe, eff, loc)
 
       case Expression.Existential(_, _, _) => throw InternalCompilerException(s"Unexpected expression: $exp0.")
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -602,6 +602,13 @@ object Lowering extends Phase[Root, Root] {
       val tpe = visitType(tpe0)
       Expression.ReifyType(t, k, tpe, eff, loc)
 
+    case Expression.ReifyEff(sym, exp1, exp2, exp3, tpe, eff, loc) =>
+      val t = visitType(tpe)
+      val e1 = visitExp(exp1)
+      val e2 = visitExp(exp2)
+      val e3 = visitExp(exp3)
+      Expression.ReifyEff(sym, e1, e2, e3, tpe, eff, loc)
+
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -1504,6 +1504,12 @@ object Lowering extends Phase[Root, Root] {
     case Expression.ReifyType(t, k, tpe, eff, loc) =>
       Expression.ReifyType(t, k, tpe, eff, loc)
 
+    case Expression.ReifyEff(sym, exp1, exp2, exp3, tpe, eff, loc) =>
+      val e1 = substExp(exp1, subst)
+      val e2 = substExp(exp2, subst)
+      val e3 = substExp(exp3, subst)
+      Expression.ReifyEff(sym, e1, e2, e3, tpe, eff, loc)
+
     case Expression.FixpointConstraintSet(cs, stf, tpe, loc) => throw InternalCompilerException(s"Unexpected expression near ${loc.format}.")
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -607,7 +607,7 @@ object Lowering extends Phase[Root, Root] {
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
       val e3 = visitExp(exp3)
-      Expression.ReifyEff(sym, e1, e2, e3, tpe, eff, loc)
+      Expression.ReifyEff(sym, e1, e2, e3, t, eff, loc)
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -894,6 +894,12 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
         case t => NamedAst.Expression.ReifyType(t, k, loc)
       }
 
+    case WeededAst.Expression.ReifyEff(ident, exp1, exp2, exp3, loc) =>
+      val sym = Symbol.freshVarSym(ident, Scopedness.Unscoped, BoundBy.Let)
+      mapN(visitExp(exp1, env0, uenv0, tenv0), visitExp(exp2, env0 + (ident.name -> sym), uenv0, tenv0), visitExp(exp3, env0, uenv0, tenv0)) {
+        case (e1, e2, e3) => NamedAst.Expression.ReifyEff(sym, e1, e2, e3, loc)
+      }
+
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -1304,6 +1304,7 @@ object Namer extends Phase[WeededAst.Program, NamedAst.Root] {
     case WeededAst.Expression.FixpointProjectOut(pred, exp1, exp2, loc) => freeVars(exp1) ++ freeVars(exp2)
     case WeededAst.Expression.Reify(t, loc) => Nil
     case WeededAst.Expression.ReifyType(t, k, loc) => Nil
+    case WeededAst.Expression.ReifyEff(ident, exp1, exp2, exp3, loc) => filterBoundVars(freeVars(exp1) ++ freeVars(exp2) ++ freeVars(exp3), List(ident))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -638,7 +638,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     def Primary: Rule1[ParsedAst.Expression] = rule {
       LetRegion | LetMatch | LetMatchStar | LetUse | LetImport | IfThenElse | Reify | ReifyBool |
-        ReifyType | Choose | Match | LambdaMatch | TryCatch | Lambda | Tuple |
+        ReifyType | ReifyEff | Choose | Match | LambdaMatch | TryCatch | Lambda | Tuple |
         RecordOperation | RecordLiteral | Block | RecordSelectLambda | NewChannel |
         GetChannel | SelectChannel | Spawn | Lazy | Force | Intrinsic | ArrayLit | ArrayNew |
         FNil | FSet | FMap | ConstraintSet | FixpointProject | FixpointSolveWithProject |
@@ -682,6 +682,20 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     def ReifyType: Rule1[ParsedAst.Expression.ReifyType] = rule {
       SP ~ keyword("reifyType") ~ WS ~ Type ~ SP ~> ParsedAst.Expression.ReifyType
+    }
+
+    def ReifyEff: Rule1[ParsedAst.Expression.ReifyEff] = {
+      def ThenBranch: Rule2[Name.Ident, ParsedAst.Expression] = rule {
+        keyword("case") ~ WS ~ keyword("Pure") ~ "(" ~ Names.Variable ~ ")" ~ WS ~ keyword("=>") ~ WS ~ Expression
+      }
+
+      def ElseBranch: Rule1[ParsedAst.Expression] = rule {
+        keyword("case") ~ WS ~ "_" ~ WS ~ keyword("=>") ~ WS ~ Expression
+      }
+
+      rule {
+        SP ~ keyword("reifyEff") ~ WS ~ Expression ~ optWS ~ "{" ~ optWS ~ ThenBranch ~ optWS ~ ElseBranch ~ optWS ~ "}" ~ SP ~> ParsedAst.Expression.ReifyEff
+      }
     }
 
     def LetMatch: Rule1[ParsedAst.Expression.LetMatch] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -694,7 +694,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       }
 
       rule {
-        SP ~ keyword("reifyEff") ~ WS ~ Expression ~ optWS ~ "{" ~ optWS ~ ThenBranch ~ optWS ~ ElseBranch ~ optWS ~ "}" ~ SP ~> ParsedAst.Expression.ReifyEff
+        SP ~ keyword("reifyEff") ~ optWS ~ "(" ~ optWS ~ Expression ~ optWS ~ ")" ~ optWS ~ "{" ~ optWS ~ ThenBranch ~ WS ~ ElseBranch ~ optWS ~ "}" ~ SP ~> ParsedAst.Expression.ReifyEff
       }
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
@@ -364,6 +364,13 @@ object PatternExhaustiveness extends Phase[TypedAst.Root, TypedAst.Root] {
         case Expression.ReifyType(_, _, _, _, _) =>
           tast.toSuccess
 
+        case Expression.ReifyEff(_, exp1, exp2, exp3, _, _, _) =>
+          for {
+            _ <- checkPats(exp1, root)
+            _ <- checkPats(exp2, root)
+            _ <- checkPats(exp3, root)
+          } yield tast
+
       }
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -599,6 +599,9 @@ object Redundancy extends Phase[TypedAst.Root, TypedAst.Root] {
 
     case Expression.ReifyType(_, _, _, _, _) =>
       Used.empty
+
+    case Expression.ReifyEff(sym, exp1, exp2, exp3, tpe, _, _) =>
+      Used.of(sym) ++ visitExp(exp1, env0) ++ visitExp(exp2, env0)++ visitExp(exp3, env0)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -991,6 +991,12 @@ object Resolver extends Phase[NamedAst.Root, ResolvedAst.Root] {
             t <- resolveType(t0, taenv, ns0, root)
           } yield ResolvedAst.Expression.ReifyType(t, k, loc)
 
+        case NamedAst.Expression.ReifyEff(sym, exp1, exp2, exp3, loc) =>
+          for {
+            e1 <- visit(exp1, tenv0)
+            e2 <- visit(exp2, tenv0)
+            e3 <- visit(exp3, tenv0)
+          } yield ResolvedAst.Expression.ReifyEff(sym, e1, e2, e3, loc)
 
       }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -244,6 +244,9 @@ object Safety extends Phase[Root, Root] {
 
     case Expression.ReifyType(_, _, _, _, _) => Nil
 
+    case Expression.ReifyEff(_, exp1, exp2, exp3, _, _, _) =>
+      visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
+
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -314,6 +314,9 @@ object Simplifier extends Phase[TypedAst.Root, SimplifiedAst.Root] {
 
       case TypedAst.Expression.ReifyType(_, _, _, _, _) =>
         throw InternalCompilerException(s"Unexpected expression: $exp0.")
+
+      case TypedAst.Expression.ReifyEff(_, _, _, _, _, _, _) =>
+        throw InternalCompilerException(s"Unexpected expression: $exp0.")
     }
 
     /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Statistics.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Statistics.scala
@@ -151,6 +151,7 @@ object Statistics extends Phase[Root, Root] {
       case Expression.FixpointProjectOut(pred, exp, tpe, eff, loc) => visitExp(exp)
       case Expression.Reify(t, tpe, eff, loc) => Counter.empty
       case Expression.ReifyType(t, k, tpe, eff, loc) => Counter.empty
+      case Expression.ReifyEff(sym, exp1, exp2, exp3, tpe, eff, loc) => visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
     }
 
     base ++ subExprs

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -414,6 +414,11 @@ object Stratifier extends Phase[Root, Root] {
     case Expression.ReifyType(t, k, tpe, eff, loc) =>
       Expression.ReifyType(t, k, tpe, eff, loc).toSuccess
 
+    case Expression.ReifyEff(sym, exp1, exp2, exp3, tpe, eff, loc) =>
+      mapN(visitExp(exp1), visitExp(exp2), visitExp(exp3)) {
+        case (e1, e2, e3) => Expression.ReifyEff(sym, e1, e2, e3, tpe, eff, loc)
+      }
+
   }
 
   /**
@@ -652,6 +657,8 @@ object Stratifier extends Phase[Root, Root] {
     case Expression.ReifyType(_, _, _, _, _) =>
       DependencyGraph.empty
 
+    case Expression.ReifyEff(_, exp1, exp2, exp3, _, _, _) =>
+     dependencyGraphOfExp(exp1) + dependencyGraphOfExp(exp2) + dependencyGraphOfExp(exp3)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Terminator.scala
@@ -129,6 +129,7 @@ object Terminator extends Phase[Root, Root] {
       case Expression.FixpointProjectOut(_, exp, _, _, _) => visit(exp)
       case Expression.Reify(_, _, _, _) => false // reify expressions always terminate.
       case Expression.ReifyType(_, _, _, _, _) => false // reify expressions always terminate.
+      case Expression.ReifyEff(_, _, _, _, _, _, _) => false // reify expressions always terminate.
     }
 
     visit(exp0)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -327,6 +327,7 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
         val tparams = getTypeParams(tparams0)
         sym -> TypedAst.TypeAlias(doc, mod, sym, tparams, tpe, loc)
     }
+
     root.typeAliases.values.map(visitTypeAlias).toMap
   }
 
@@ -1456,6 +1457,23 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
           case _ =>
             throw InternalCompilerException(s"Unexpected kind: '$k'.")
         }
+
+      case KindedAst.Expression.ReifyEff(sym, exp1, exp2, exp3, loc) =>
+        val a = Type.freshVar(Kind.Star, loc)
+        val b = Type.freshVar(Kind.Star, loc)
+        val ef = Type.freshVar(Kind.Bool, loc)
+        val polyLambdaType = Type.mkArrowWithEffect(a, ef, b, loc)
+        val pureLambdaType = Type.mkPureArrow(a, b, loc)
+        for {
+          (constrs1, tpe1, eff1) <- visitExp(exp1)
+          (constrs2, tpe2, eff2) <- visitExp(exp2)
+          (constrs3, tpe3, eff3) <- visitExp(exp3)
+          actualLambdaType <- unifyTypeM(polyLambdaType, tpe1, loc)
+          boundVar <- unifyTypeM(sym.tvar.ascribedWith(Kind.Star), pureLambdaType, loc)
+          resultTyp <- unifyTypeM(tpe2, tpe3, loc)
+          resultEff = Type.mkAnd(eff1, eff2, eff3, loc)
+        } yield (constrs1 ++ constrs2 ++ constrs3, resultTyp, resultEff)
+
     }
 
     /**
@@ -1872,6 +1890,14 @@ object Typer extends Phase[KindedAst.Root, TypedAst.Root] {
         val eff = Type.Pure
         TypedAst.Expression.ReifyType(t, k0, tpe, eff, loc)
 
+      case KindedAst.Expression.ReifyEff(sym, exp1, exp2, exp3, loc) =>
+        val e1 = visitExp(exp1, subst0)
+        val e2 = visitExp(exp2, subst0)
+        val e3 = visitExp(exp3, subst0)
+
+        val tpe = e2.tpe
+        val eff = Type.mkAnd(e1.eff, e2.eff, e3.eff, loc)
+        TypedAst.Expression.ReifyEff(sym, e1, e2, e3, tpe, eff, loc)
     }
 
     /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1461,6 +1461,11 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
       val t = visitType(t0)
       WeededAst.Expression.ReifyType(t, Kind.Star, mkSL(sp1, sp2)).toSuccess
 
+    case ParsedAst.Expression.ReifyEff(sp1, exp1, ident, exp2, exp3, sp2) =>
+      mapN(visitExp(exp1), visitExp(exp2), visitExp(exp3)) {
+        case (e1, e2, e3) =>
+          WeededAst.Expression.ReifyEff(ident, e1, e2, e3, mkSL(sp1, sp2))
+      }
   }
 
   /**
@@ -2526,6 +2531,7 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
     case ParsedAst.Expression.Reify(sp1, _, _) => sp1
     case ParsedAst.Expression.ReifyBool(sp1, _, _) => sp1
     case ParsedAst.Expression.ReifyType(sp1, _, _) => sp1
+    case ParsedAst.Expression.ReifyEff(sp1, _, _, _, _, _) => sp1
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -283,6 +283,9 @@ object CodeHinter {
 
     case Expression.ReifyType(_, _, _, _, _) =>
       Nil
+
+    case Expression.ReifyEff(_, exp1, exp2, exp3, _, _, _) =>
+      visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
   }
 
   /**

--- a/main/src/library/LazyList.flix
+++ b/main/src/library/LazyList.flix
@@ -216,10 +216,14 @@ namespace LazyList {
     /// - If `f` is impure then it is applied eagerly (i.e. the entire list `l` is forced).
     ///
     pub def map(f: a -> b & ef, l: LazyList[a]): LazyList[b] & ef =
-        if (reify ef)
-            mapL(f as a -> b & Pure,   l)
-        else
-            mapE(f as a -> b & Impure, l) as & ef
+        reifyEff f {
+            case Pure(g) => mapL(g, l)
+            case _       => mapE(f, l)
+        }
+        //if (reify ef)
+        //    mapL(f as a -> b & Pure,   l)
+        //else
+        //    mapE(f as a -> b & Impure, l) as & ef
 
     ///
     /// Returns the result of applying `f` to every element in `l`.
@@ -250,13 +254,13 @@ namespace LazyList {
     ///
     /// Applies `f` eagerly (i.e. the entire list `l` is forced).
     ///
-    def mapE(f: a -> b & Impure, l: LazyList[a]): LazyList[b] & Impure =
+    def mapE(f: a -> b & ef, l: LazyList[a]): LazyList[b] & ef =
         mapEAcc(f, l, ks -> ks)
 
     ///
     /// Helper function for `mapE`.
     ///
-    def mapEAcc(f: a -> b & Impure, l: LazyList[a], k: LazyList[b] -> LazyList[b]): LazyList[b] & Impure = match l {
+    def mapEAcc(f: a -> b & ef, l: LazyList[a], k: LazyList[b] -> LazyList[b]): LazyList[b] & ef = match l {
         case ENil         => k(ENil)
         case ECons(x, xs) =>
             let x1 = f(x);

--- a/main/src/library/LazyList.flix
+++ b/main/src/library/LazyList.flix
@@ -216,14 +216,10 @@ namespace LazyList {
     /// - If `f` is impure then it is applied eagerly (i.e. the entire list `l` is forced).
     ///
     pub def map(f: a -> b & ef, l: LazyList[a]): LazyList[b] & ef =
-        reifyEff f {
+        reifyEff(f) {
             case Pure(g) => mapL(g, l)
             case _       => mapE(f, l)
         }
-        //if (reify ef)
-        //    mapL(f as a -> b & Pure,   l)
-        //else
-        //    mapE(f as a -> b & Impure, l) as & ef
 
     ///
     /// Returns the result of applying `f` to every element in `l`.
@@ -281,10 +277,10 @@ namespace LazyList {
     /// - If `f` is impure then it is applied eagerly (i.e. the entire list `l` is forced).
     ///
     pub def filter(f: a -> Bool & ef, l: LazyList[a]): LazyList[a] & ef =
-        if (reify ef)
-            filterL(f as a -> Bool & Pure,   l)
-        else
-            filterE(f as a -> Bool & Impure, l) as & ef
+        reifyEff(f) {
+            case Pure(g) => filterL(g, l)
+            case _       => filterE(f, l)
+        }
 
     ///
     /// Returns a lazy list of every element in `l` that satisfies the predicate `f`.
@@ -303,13 +299,13 @@ namespace LazyList {
     ///
     /// Applies `f` eagerly (i.e. the entire list `l` is forced).
     ///
-    def filterE(f: a -> Bool & Impure, l: LazyList[a]): LazyList[a] & Impure =
+    def filterE(f: a -> Bool & ef, l: LazyList[a]): LazyList[a] & ef =
         filterEAcc(f, l, ks -> ks)
 
     ///
     /// Helper function for `filterE`
     ///
-    def filterEAcc(f: a -> Bool & Impure, l: LazyList[a], k: LazyList[a] -> LazyList[a]): LazyList[a] & Impure = match l {
+    def filterEAcc(f: a -> Bool & ef, l: LazyList[a], k: LazyList[a] -> LazyList[a]): LazyList[a] & ef = match l {
         case ENil         => k(ENil)
         case ECons(x, xs) => if (f(x)) filterEAcc(f,       xs, ks -> k(ECons(x, ks))) else filterEAcc(f,       xs, k)
         case LCons(x, xs) => if (f(x)) filterEAcc(f, force xs, ks -> k(ECons(x, ks))) else filterEAcc(f, force xs, k)


### PR DESCRIPTION
This PR reintroduces `reifyEff`. The long-term goal is to replace `reifyEff` by a more general `reify` construct. In meanwhile, the `reifyEff` construct is sound whereas soundness for the other reify constructs (w.r.t. Booleans) is still an open question.