### PR TITLE
Rewrite GenMatchErrorClass to use bytecode DSL

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
 import ca.uwaterloo.flix.util.InternalCompilerException
-import org.objectweb.asm.{Label, MethodVisitor, Opcodes => Op}
+import org.objectweb.asm.{Label, MethodVisitor, Opcodes}
 
 object BytecodeInstructions {
 
@@ -64,118 +64,118 @@ object BytecodeInstructions {
   //
 
   def AASTORE(): InstructionSet = f => {
-    f.visitInstruction(Op.AASTORE)
+    f.visitInstruction(Opcodes.AASTORE)
     f
   }
 
   def ALOAD(index: Int): InstructionSet = f => {
-    f.visitVarInstruction(Op.ALOAD, index)
+    f.visitVarInstruction(Opcodes.ALOAD, index)
     f
   }
 
   def ANEWARRAY(className: JvmName): InstructionSet = f => {
-    f.visitTypeInstruction(Op.ANEWARRAY, className)
+    f.visitTypeInstruction(Opcodes.ANEWARRAY, className)
     f
   }
 
   def ARETURN(): InstructionSet = f => {
-    f.visitInstruction(Op.ARETURN)
+    f.visitInstruction(Opcodes.ARETURN)
     f
   }
 
   def ASTORE(index: Int): InstructionSet = f => {
-    f.visitVarInstruction(Op.ASTORE, index)
+    f.visitVarInstruction(Opcodes.ASTORE, index)
     f
   }
 
   def CHECKCAST(className: JvmName): InstructionSet = f => {
-    f.visitTypeInstruction(Op.CHECKCAST, className)
+    f.visitTypeInstruction(Opcodes.CHECKCAST, className)
     f
   }
 
   def DRETURN(): InstructionSet = f => {
-    f.visitInstruction(Op.DRETURN)
+    f.visitInstruction(Opcodes.DRETURN)
     f
   }
 
   def DUP(): InstructionSet = f => {
-    f.visitInstruction(Op.DUP)
+    f.visitInstruction(Opcodes.DUP)
     f
   }
 
   def FRETURN(): InstructionSet = f => {
-    f.visitInstruction(Op.FRETURN)
+    f.visitInstruction(Opcodes.FRETURN)
     f
   }
 
   def GETFIELD(className: JvmName, fieldName: String, fieldType: JvmType): InstructionSet = f => {
-    f.visitFieldInstruction(Op.GETFIELD, className, fieldName, fieldType)
+    f.visitFieldInstruction(Opcodes.GETFIELD, className, fieldName, fieldType)
     f
   }
 
   def GETSTATIC(className: JvmName, fieldName: String, fieldType: JvmType): InstructionSet = f => {
-    f.visitFieldInstruction(Op.GETSTATIC, className, fieldName, fieldType)
+    f.visitFieldInstruction(Opcodes.GETSTATIC, className, fieldName, fieldType)
     f
   }
 
   def ICONST_0(): InstructionSet = f => {
-    f.visitInstruction(Op.ICONST_0)
+    f.visitInstruction(Opcodes.ICONST_0)
     f
   }
 
   def ICONST_1(): InstructionSet = f => {
-    f.visitInstruction(Op.ICONST_1)
+    f.visitInstruction(Opcodes.ICONST_1)
     f
   }
 
   def IF_ACMPNE(trueBranch: InstructionSet)(falseBranch: InstructionSet): InstructionSet =
-    branch(Op.IF_ACMPNE)(trueBranch)(falseBranch)
+    branch(Opcodes.IF_ACMPNE)(trueBranch)(falseBranch)
 
   def IFNULL(trueBranch: InstructionSet)(falseBranch: InstructionSet): InstructionSet =
-    branch(Op.IFNULL)(trueBranch)(falseBranch)
+    branch(Opcodes.IFNULL)(trueBranch)(falseBranch)
 
   def INVOKESPECIAL(className: JvmName, methodName: String, descriptor: MethodDescriptor): InstructionSet = f => {
-    f.visitMethodInstruction(Op.INVOKESPECIAL, className, methodName, descriptor)
+    f.visitMethodInstruction(Opcodes.INVOKESPECIAL, className, methodName, descriptor)
     f
   }
 
   def INVOKESTATIC(className: JvmName, methodName: String, descriptor: MethodDescriptor): InstructionSet = f => {
-    f.visitMethodInstruction(Op.INVOKESTATIC, className, methodName, descriptor)
+    f.visitMethodInstruction(Opcodes.INVOKESTATIC, className, methodName, descriptor)
     f
   }
 
   def INVOKEVIRTUAL(className: JvmName, methodName: String, descriptor: MethodDescriptor): InstructionSet = f => {
-    f.visitMethodInstruction(Op.INVOKEVIRTUAL, className, methodName, descriptor)
+    f.visitMethodInstruction(Opcodes.INVOKEVIRTUAL, className, methodName, descriptor)
     f
   }
 
   def IRETURN(): InstructionSet = f => {
-    f.visitInstruction(Op.IRETURN)
+    f.visitInstruction(Opcodes.IRETURN)
     f
   }
 
   def LRETURN(): InstructionSet = f => {
-    f.visitInstruction(Op.LRETURN)
+    f.visitInstruction(Opcodes.LRETURN)
     f
   }
 
   def NEW(className: JvmName): InstructionSet = f => {
-    f.visitTypeInstruction(Op.NEW, className)
+    f.visitTypeInstruction(Opcodes.NEW, className)
     f
   }
 
   def PUTFIELD(className: JvmName, fieldName: String, fieldType: JvmType): InstructionSet = f => {
-    f.visitFieldInstruction(Op.PUTFIELD, className, fieldName, fieldType)
+    f.visitFieldInstruction(Opcodes.PUTFIELD, className, fieldName, fieldType)
     f
   }
 
   def PUTSTATIC(className: JvmName, fieldName: String, fieldType: JvmType): InstructionSet = f => {
-    f.visitFieldInstruction(Op.PUTSTATIC, className, fieldName, fieldType)
+    f.visitFieldInstruction(Opcodes.PUTSTATIC, className, fieldName, fieldType)
     f
   }
 
   def RETURN(): InstructionSet = f => {
-    f.visitInstruction(Op.RETURN)
+    f.visitInstruction(Opcodes.RETURN)
     f
   }
 
@@ -219,7 +219,7 @@ object BytecodeInstructions {
     f.visitJumpInstruction(opcode, jumpLabel)
 
     f = falseBranch(f)
-    f.visitJumpInstruction(Op.GOTO, skipLabel)
+    f.visitJumpInstruction(Opcodes.GOTO, skipLabel)
 
     f.visitLabel(jumpLabel)
     f = trueBranch(f)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
@@ -17,6 +17,9 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Finality._
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Instancing._
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility._
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker._
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
 import org.objectweb.asm.{ClassWriter, Opcodes}
@@ -72,16 +75,18 @@ object ClassMaker {
     def toInt: Int
   }
 
-  case object Private extends Visibility {
-    override val toInt: Int = Opcodes.ACC_PRIVATE
-  }
+  object Visibility {
+    case object Private extends Visibility {
+      override val toInt: Int = Opcodes.ACC_PRIVATE
+    }
 
-  case object Default extends Visibility {
-    override val toInt: Int = 0
-  }
+    case object Default extends Visibility {
+      override val toInt: Int = 0
+    }
 
-  case object Public extends Visibility {
-    override val toInt: Int = Opcodes.ACC_PUBLIC
+    case object Public extends Visibility {
+      override val toInt: Int = Opcodes.ACC_PUBLIC
+    }
   }
 
 
@@ -89,25 +94,28 @@ object ClassMaker {
     def toInt: Int
   }
 
-  case object Final extends Finality {
-    override val toInt: Int = Opcodes.ACC_FINAL
-  }
+  object Finality {
+    case object Final extends Finality {
+      override val toInt: Int = Opcodes.ACC_FINAL
+    }
 
-  case object Implementable extends Finality {
-    override val toInt: Int = 0
+    case object Implementable extends Finality {
+      override val toInt: Int = 0
+    }
   }
-
 
   sealed trait Instancing {
     def toInt: Int
   }
 
-  case object Static extends Instancing {
-    override val toInt: Int = Opcodes.ACC_STATIC
-  }
+  object Instancing {
+    case object Static extends Instancing {
+      override val toInt: Int = Opcodes.ACC_STATIC
+    }
 
-  case object Instanced extends Instancing {
-    override val toInt: Int = 0
+    case object Instanced extends Instancing {
+      override val toInt: Int = 0
+    }
   }
 
 
@@ -115,11 +123,13 @@ object ClassMaker {
     def toInt: Int
   }
 
-  case object Abstract extends Abstraction {
-    override val toInt: Int = Opcodes.ACC_ABSTRACT
-  }
+  object Abstraction {
+    case object Abstract extends Abstraction {
+      override val toInt: Int = Opcodes.ACC_ABSTRACT
+    }
 
-  case object Implemented extends Abstraction {
-    override val toInt: Int = 0
+    case object Implemented extends Abstraction {
+      override val toInt: Int = 0
+    }
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenGlobalCounterClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenGlobalCounterClass.scala
@@ -18,7 +18,9 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions._
-import ca.uwaterloo.flix.language.phase.jvm.ClassMaker._
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Finality._
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Instancing._
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility._
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
 
 /**
@@ -47,14 +49,14 @@ object GenGlobalCounterClass {
 
   private def genConstructor(): InstructionSet = {
     ALOAD(0) ~
-      InvokeSimpleConstructor(JvmName.Object) ~
+      invokeConstructor(JvmName.Object) ~
       RETURN()
   }
 
   private def genStaticConstructor(): InstructionSet = {
     NEW(JvmName.AtomicLong) ~
       DUP() ~
-      InvokeSimpleConstructor(JvmName.AtomicLong) ~
+      invokeConstructor(JvmName.AtomicLong) ~
       PUTSTATIC(JvmName.AtomicLong, counterFieldName, JvmType.AtomicLong) ~
       RETURN()
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenMatchErrorClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenMatchErrorClass.scala
@@ -42,6 +42,8 @@ object GenMatchErrorClass {
     val cm = ClassMaker.mkClass(JvmName.MatchError, Public, Final, superClass = JvmName.FlixError)
 
     cm.mkConstructor(genConstructor(), mkDescriptor(JvmType.ReifiedSourceLocation)(JvmType.Void), Public)
+
+    // TODO: Are these ever used?
     cm.mkMethod(genEquals(), "equals", mkDescriptor(JvmType.Object)(JvmType.PrimBool), Public, Implementable, Instanced)
     cm.mkMethod(genHashCode(), "hashCode", mkDescriptor()(JvmType.PrimInt), Public, Implementable, Instanced)
     cm.mkField(LocationFieldName, JvmType.ReifiedSourceLocation, Public, Final, Instanced)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenMatchErrorClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenMatchErrorClass.scala
@@ -17,132 +17,97 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import org.objectweb.asm.{ClassWriter, Label}
-import org.objectweb.asm.Opcodes._
+import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions._
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Finality._
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Instancing._
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility._
+import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
+import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor.mkDescriptor
+import org.objectweb.asm.Opcodes
 
 object GenMatchErrorClass {
 
   val LocationFieldName: String = "location"
 
   /**
-   * Creates a subclass of `dev.flix.runtime.FlixError` with a `dev.flix.runtime.ReifiedSourceLocation` and a string prefix o the message.
-   * Includes equals and hashCode methods.
-   *
-   * @param className the jvm name of the class
-   * @param prefix something like `Division by zero at ` which will be followed by the location (remember the trailing space)
-   */
+    * Creates a subclass of `dev.flix.runtime.FlixError` with a
+    * `dev.flix.runtime.ReifiedSourceLocation` and a string prefix of the message.
+    * Includes equals and hashCode methods.
+    */
   def gen()(implicit flix: Flix): Map[JvmName, JvmClass] = {
-    val className = JvmName.MatchError
-    val bytecode = genByteCode(className)
-    Map(className -> JvmClass(className, bytecode))
+    Map(JvmName.MatchError -> JvmClass(JvmName.MatchError, genByteCode()))
   }
 
-  private def genByteCode(name: JvmName)(implicit flix: Flix): Array[Byte] = {
-    // class writer
-    val visitor = AsmOps.mkClassWriter()
+  private def genByteCode()(implicit flix: Flix): Array[Byte] = {
+    val cm = ClassMaker.mkClass(JvmName.MatchError, Public, Final, superClass = JvmName.FlixError)
 
-    // internal name of super
-    val superClass = JvmName.FlixError
+    cm.mkConstructor(genConstructor(), mkDescriptor(JvmType.ReifiedSourceLocation)(JvmType.Void), Public)
+    cm.mkMethod(genEquals(), "equals", mkDescriptor(JvmType.Object)(JvmType.PrimBool), Public, Implementable, Instanced)
+    cm.mkMethod(genHashCode(), "hashCode", mkDescriptor()(JvmType.PrimInt), Public, Implementable, Instanced)
+    cm.mkField(LocationFieldName, JvmType.ReifiedSourceLocation, Public, Final, Instanced)
 
-    // Initialize the visitor to create a class.
-    visitor.visit(AsmOps.JavaVersion, ACC_PUBLIC + ACC_FINAL, name.toInternalName, null, superClass.toInternalName, null)
-
-    // Source of the class
-    visitor.visitSource(name.toInternalName, null)
-
-    genConstructor(name, superClass, visitor)
-    genEquals(name, visitor)
-    genHashCode(name, visitor)
-    visitor.visitField(ACC_PUBLIC + ACC_FINAL, LocationFieldName, JvmName.ReifiedSourceLocation.toDescriptor, null, null).visitEnd()
-
-    visitor.visitEnd()
-    visitor.toByteArray
+    cm.closeClassMaker
   }
 
-  private def genConstructor(name: JvmName, superClass: JvmName, visitor: ClassWriter): Unit = {
-    val stringToBuilderDescriptor = s"(${JvmName.String.toDescriptor})${JvmName.StringBuilder.toDescriptor}"
-    val builderName = JvmName.StringBuilder.toInternalName
-
-    val method = visitor.visitMethod(ACC_PUBLIC, "<init>", s"(${JvmName.ReifiedSourceLocation.toDescriptor})${JvmType.Void.toDescriptor}", null, null)
-    method.visitCode()
-
-    method.visitVarInsn(ALOAD, 0)
-    method.visitTypeInsn(NEW, builderName)
-    method.visitInsn(DUP)
-    method.visitMethodInsn(INVOKESPECIAL, builderName, "<init>", AsmOps.getMethodDescriptor(Nil, JvmType.Void), false)
-    method.visitLdcInsn("Non-exhaustive match at ")
-    method.visitMethodInsn(INVOKEVIRTUAL, builderName, "append", stringToBuilderDescriptor, false)
-    method.visitVarInsn(ALOAD, 1)
-    method.visitMethodInsn(INVOKEVIRTUAL, JvmName.ReifiedSourceLocation.toInternalName, "toString", AsmOps.getMethodDescriptor(Nil, JvmType.String), false)
-    method.visitMethodInsn(INVOKEVIRTUAL, builderName, "append", stringToBuilderDescriptor, false)
-    method.visitMethodInsn(INVOKEVIRTUAL, builderName, "toString", AsmOps.getMethodDescriptor(Nil, JvmType.String), false)
-    method.visitMethodInsn(INVOKESPECIAL, superClass.toInternalName, "<init>", AsmOps.getMethodDescriptor(List(JvmType.String), JvmType.Void), false)
-    method.visitVarInsn(ALOAD, 0)
-    method.visitVarInsn(ALOAD, 1)
-    method.visitFieldInsn(PUTFIELD, name.toInternalName, LocationFieldName, JvmName.ReifiedSourceLocation.toDescriptor)
-    method.visitInsn(RETURN)
-
-    method.visitMaxs(999, 999)
-    method.visitEnd()
+  private def genConstructor(): InstructionSet = {
+    val stringBuilderDescriptor = mkDescriptor(JvmType.String)(JvmType.StringBuilder)
+    ALOAD(0) ~
+      NEW(JvmName.StringBuilder) ~
+      DUP() ~
+      invokeConstructor(JvmName.StringBuilder) ~
+      pushString("Non-exhaustive match at ") ~
+      INVOKEVIRTUAL(JvmName.StringBuilder, "append", stringBuilderDescriptor) ~
+      ALOAD(1) ~
+      INVOKEVIRTUAL(JvmName.ReifiedSourceLocation, "toString", mkDescriptor()(JvmType.String)) ~
+      INVOKEVIRTUAL(JvmName.StringBuilder, "append", stringBuilderDescriptor) ~
+      INVOKEVIRTUAL(JvmName.StringBuilder, "toString", mkDescriptor()(JvmType.String)) ~
+      invokeConstructor(JvmName.FlixError, mkDescriptor(JvmType.String)(JvmType.Void)) ~
+      ALOAD(0) ~
+      ALOAD(1) ~
+      PUTFIELD(JvmName.MatchError, LocationFieldName, JvmType.ReifiedSourceLocation) ~
+      RETURN()
   }
 
-  private def genEquals(name: JvmName, visitor: ClassWriter): Unit = {
-    val method = visitor.visitMethod(ACC_PUBLIC, "equals", AsmOps.getMethodDescriptor(List(JvmType.Object), JvmType.PrimBool), null, null)
-    method.visitCode()
-
-    method.visitVarInsn(ALOAD, 0)
-    method.visitVarInsn(ALOAD, 1)
-    val label1 = new Label()
-    method.visitJumpInsn(IF_ACMPNE, label1)
-    method.visitInsn(ICONST_1)
-    method.visitInsn(IRETURN)
-
-    method.visitLabel(label1)
-    method.visitVarInsn(ALOAD, 1)
-    val label2 = new Label()
-    method.visitJumpInsn(IFNULL, label2)
-    method.visitVarInsn(ALOAD, 0)
-    method.visitMethodInsn(INVOKEVIRTUAL, JvmName.Object.toInternalName, "getClass", "()Ljava/lang/Class;", false)
-    method.visitVarInsn(ALOAD, 1)
-    method.visitMethodInsn(INVOKEVIRTUAL, JvmName.Object.toInternalName, "getClass", "()Ljava/lang/Class;", false)
-    val label3 = new Label()
-    method.visitJumpInsn(IF_ACMPEQ, label3)
-
-    method.visitLabel(label2)
-    method.visitInsn(ICONST_0)
-    method.visitInsn(IRETURN)
-
-    method.visitLabel(label3)
-    method.visitVarInsn(ALOAD, 1)
-    method.visitTypeInsn(CHECKCAST, name.toInternalName)
-    method.visitVarInsn(ASTORE, 2)
-    method.visitVarInsn(ALOAD, 0)
-    method.visitFieldInsn(GETFIELD, name.toInternalName, LocationFieldName, JvmName.ReifiedSourceLocation.toDescriptor)
-    method.visitVarInsn(ALOAD, 2)
-    method.visitFieldInsn(GETFIELD, name.toInternalName, LocationFieldName, JvmName.ReifiedSourceLocation.toDescriptor)
-    method.visitMethodInsn(INVOKESTATIC, JvmName.Objects.toInternalName, "equals", AsmOps.getMethodDescriptor(List(JvmType.Object, JvmType.Object), JvmType.PrimBool), false)
-    method.visitInsn(IRETURN)
-
-    method.visitMaxs(999, 999)
-    method.visitEnd()
+  private def genEquals(): InstructionSet = {
+    ALOAD(0) ~
+      ALOAD(1) ~
+      IF_ACMPNE {
+        ALOAD(1) ~
+          IFNULL {
+            pushBool(false) ~ IRETURN()
+          } {
+            ALOAD(0) ~
+              INVOKEVIRTUAL(JvmName.Object, "getClass", MethodDescriptor(Nil, JvmType.Class)) ~
+              ALOAD(1) ~
+              INVOKEVIRTUAL(JvmName.Object, "getClass", MethodDescriptor(Nil, JvmType.Class)) ~
+              IF_ACMPNE {
+                ALOAD(1) ~
+                  CHECKCAST(JvmName.MatchError) ~
+                  ASTORE(2) ~
+                  ALOAD(0) ~
+                  GETFIELD(JvmName.MatchError, LocationFieldName, JvmType.ReifiedSourceLocation) ~
+                  ALOAD(2) ~
+                  GETFIELD(JvmName.MatchError, LocationFieldName, JvmType.ReifiedSourceLocation) ~
+                  INVOKESTATIC(JvmName.Objects, "equals", MethodDescriptor(List(JvmType.Object, JvmType.Object), JvmType.PrimBool)) ~
+                  IRETURN()
+              } {
+                pushBool(false) ~ IRETURN()
+              }
+          }
+      } {
+        pushBool(true) ~ IRETURN()
+      }
   }
 
-  private def genHashCode(name: JvmName, visitor: ClassWriter): Unit = {
-    val method = visitor.visitMethod(ACC_PUBLIC, "hashCode", AsmOps.getMethodDescriptor(Nil, JvmType.PrimInt), null, null)
-    method.visitCode()
-
-    method.visitInsn(ICONST_1)
-    method.visitTypeInsn(ANEWARRAY, JvmName.Object.toInternalName)
-    method.visitInsn(DUP)
-    method.visitInsn(ICONST_0)
-    method.visitVarInsn(ALOAD, 0)
-    method.visitFieldInsn(GETFIELD, name.toInternalName, LocationFieldName, JvmName.ReifiedSourceLocation.toDescriptor)
-    method.visitInsn(AASTORE)
-    method.visitMethodInsn(INVOKESTATIC, JvmName.Objects.toInternalName, "hash", s"([${JvmName.Object.toDescriptor})${JvmType.PrimInt.toDescriptor}", false)
-    method.visitInsn(IRETURN)
-
-    method.visitMaxs(999, 999)
-    method.visitEnd()
+  private def genHashCode(): InstructionSet = {
+    ICONST_1() ~
+      ANEWARRAY(JvmName.Object) ~
+      DUP() ~
+      ICONST_0() ~
+      ALOAD(0) ~
+      GETFIELD(JvmName.MatchError, LocationFieldName, JvmType.ReifiedSourceLocation) ~
+      AASTORE() ~
+      cheat(_.visitMethodInsn(Opcodes.INVOKESTATIC, JvmName.Objects.toInternalName, "hash", s"([${JvmName.Object.toDescriptor})${JvmType.PrimInt.toDescriptor}", false)) ~
+      IRETURN()
   }
-
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenUnitClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenUnitClass.scala
@@ -19,6 +19,9 @@ package ca.uwaterloo.flix.language.phase.jvm
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.ErasedAst.Root
 import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions._
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Finality._
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Instancing._
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility._
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker._
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
 
@@ -45,14 +48,14 @@ object GenUnitClass {
   private def genStaticConstructor(): InstructionSet = {
     NEW(JvmName.Unit) ~
       DUP() ~
-      InvokeSimpleConstructor(JvmName.Unit) ~
+      invokeConstructor(JvmName.Unit) ~
       PUTSTATIC(JvmName.Unit, InstanceFieldName, JvmType.Unit) ~
       RETURN()
   }
 
   private def genConstructor(): InstructionSet = {
     ALOAD(0) ~
-      InvokeSimpleConstructor(JvmName.Object) ~
+      invokeConstructor(JvmName.Object) ~
       RETURN()
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 Magnus Madsen
+ * Copyright 2021 Jonathan Lindegaard Starup
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +33,8 @@ object JvmName {
 
   object MethodDescriptor {
     val NothingToVoid: MethodDescriptor = MethodDescriptor(Nil, JvmType.Void)
+
+    def mkDescriptor(argument: JvmType*)(result: JvmType): MethodDescriptor = MethodDescriptor(argument.toList, result)
   }
 
   /**
@@ -57,152 +60,55 @@ object JvmName {
     JvmName(l.init.toList, l.last)
   }
 
-  /**
-    * The Flix Context class.
-    */
-  val Context: JvmName = JvmName(Nil, "Context")
+  //
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Java Names ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //
 
-  /**
-    * The `java.math.BigInteger` name.
-    */
-  val BigInteger: JvmName = JvmName(List("java", "math"), "BigInteger")
+  private val javaLang = List("java", "lang")
 
-  /**
-    * The `java.lang.Boolean` name.
-    */
-  val Boolean: JvmName = JvmName(List("java", "lang"), "Boolean")
-
-  /**
-    * The `java.lang.Byte` name.
-    */
-  val Byte: JvmName = JvmName(List("java", "lang"), "Byte")
-
-  /**
-    * The `java.lang.Character` name.
-    */
-  val Character: JvmName = JvmName(List("java", "lang"), "Character")
-
-  /**
-    * The `java.lang.Short` name.
-    */
-  val Short: JvmName = JvmName(List("java", "lang"), "Short")
-
-  /**
-    * The `java.lang.Integer` name.
-    */
-  val Integer: JvmName = JvmName(List("java", "lang"), "Integer")
-
-  /**
-    * The `java.lang.Long` name.
-    */
-  val Long: JvmName = JvmName(List("java", "lang"), "Long")
-
-  /**
-    * The `java.lang.Float` name.
-    */
-  val Float: JvmName = JvmName(List("java", "lang"), "Float")
-
-  /**
-    * The `java.lang.Double` name.
-    */
-  val Double: JvmName = JvmName(List("java", "lang"), "Double")
-
-  /**
-    * The `java.lang.Object` name.
-    */
-  val Object: JvmName = JvmName(List("java", "lang"), "Object")
-
-  /**
-    * The `java.lang.Objects` name.
-    */
-  val Objects: JvmName = JvmName(List("java", "lang"), "Objects")
-
-  /**
-    * The `java.lang.Runnable` name.
-    */
-  val Runnable: JvmName = JvmName(List("java", "lang"), "Runnable")
-
-  /**
-    * The `java.lang.StringBuilder` name.
-    */
-  val StringBuilder: JvmName = JvmName(List("java", "lang"), "StringBuilder")
-
-  /**
-    * The `java.lang.String` name.
-    */
-  val String: JvmName = JvmName(List("java", "lang"), "String")
-
-  /**
-    * The `ca.uwaterloo.flix.runtime.interpreter.Channel` name.
-    */
-  val Channel: JvmName = JvmName(List("ca", "uwaterloo", "flix", "runtime", "interpreter"), "Channel")
-
-  /**
-    * The `ca.uwaterloo.flix.runtime.interpreter.SelectChoice` name.
-    */
-  val SelectChoice: JvmName = JvmName(List("ca", "uwaterloo", "flix", "runtime", "interpreter"), "SelectChoice")
-
-  /**
-    * The `scala.math.package$` name.
-    */
-  val ScalaMathPkg: JvmName = JvmName(List("scala", "math"), "package$")
-
-
-  //TODO SJ: place this class a better place
-  /**
-    * The `java.lang.Exception` name.
-    */
-  val Exception: JvmName = JvmName(List("java", "lang"), "Exception")
-
-  /**
-    * The `java.lang.RuntimeException` name.
-    */
-  val RuntimeException: JvmName = JvmName(List("java", "lang"), "RuntimeException")
-
-  /**
-    * The Flix Unit class.
-    */
-  val Unit: JvmName = JvmName(List("dev", "flix", "runtime"), "Unit")
-
-  /**
-    * The `dev.flix.runtime.FlixError` name.
-    */
-  val FlixError: JvmName = JvmName(List("dev", "flix", "runtime"), "FlixError")
-
-  /**
-    * The `dev.flix.runtime.HoleError` name.
-    */
-  val HoleError: JvmName = JvmName(List("dev", "flix", "runtime"), "HoleError")
-
-  /**
-    * The `dev.flix.runtime.MatchError` name.
-    */
-  val MatchError: JvmName = JvmName(List("dev", "flix", "runtime"), "MatchError")
-
-  /**
-    * The `dev.flix.runtime.ReifiedSourceLocation` name.
-    */
-  val ReifiedSourceLocation: JvmName = JvmName(List("dev", "flix", "runtime"), "ReifiedSourceLocation")
-
-  /**
-    * The `dev.flix.runtime.GlobalCounter` name.
-    */
-  val GlobalCounter: JvmName = JvmName(List("dev", "flix", "runtime"), "GlobalCounter")
-
-  /**
-    * The `java.util.concurrent.atomic.AtomicLong` name.
-    */
   val AtomicLong: JvmName = JvmName(List("java", "util", "concurrent", "atomic"), "AtomicLong")
+  val BigInteger: JvmName = JvmName(List("java", "math"), "BigInteger")
+  val Boolean: JvmName = JvmName(javaLang, "Boolean")
+  val Byte: JvmName = JvmName(javaLang, "Byte")
+  val Character: JvmName = JvmName(javaLang, "Character")
+  val Class: JvmName = JvmName(javaLang, "Class")
+  val Double: JvmName = JvmName(javaLang, "Double")
+  val Exception: JvmName = JvmName(javaLang, "Exception")
+  val Float: JvmName = JvmName(javaLang, "Float")
+  val Function: JvmName = JvmName(List("java", "util", "function"), "Function")
+  val Integer: JvmName = JvmName(javaLang, "Integer")
+  val Long: JvmName = JvmName(javaLang, "Long")
+  val Object: JvmName = JvmName(javaLang, "Object")
+  val Objects: JvmName = JvmName(javaLang, "Objects")
+  val Runnable: JvmName = JvmName(javaLang, "Runnable")
+  val RuntimeException: JvmName = JvmName(javaLang, "RuntimeException")
+  val Short: JvmName = JvmName(javaLang, "Short")
+  val String: JvmName = JvmName(javaLang, "String")
+  val StringBuilder: JvmName = JvmName(javaLang, "StringBuilder")
+  val UnsupportedOperationException: JvmName = JvmName(javaLang, "UnsupportedOperationException")
 
-  /**
-    * The `java.lang.Exception` name.
-    */
-  val UnsupportedOperationException: JvmName = JvmName(List("java", "lang"), "UnsupportedOperationException")
+  //
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Flix Names ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //
 
-  val Function: JvmName = mk("java/util/function/Function")
-  
-  val ProxyObject: JvmName = JvmName(List("dev", "flix", "runtime"), "ProxyObject")
+  private val devFlixRuntime = List("dev", "flix", "runtime")
 
+  val Channel: JvmName = JvmName(List("ca", "uwaterloo", "flix", "runtime", "interpreter"), "Channel")
+  val Context: JvmName = JvmName(Nil, "Context")
+  val FlixError: JvmName = JvmName(devFlixRuntime, "FlixError")
+  val GlobalCounter: JvmName = JvmName(devFlixRuntime, "GlobalCounter")
+  val HoleError: JvmName = JvmName(devFlixRuntime, "HoleError")
+  val MatchError: JvmName = JvmName(devFlixRuntime, "MatchError")
+  val ProxyObject: JvmName = JvmName(devFlixRuntime, "ProxyObject")
+  val ReifiedSourceLocation: JvmName = JvmName(devFlixRuntime, "ReifiedSourceLocation")
+  val SelectChoice: JvmName = JvmName(List("ca", "uwaterloo", "flix", "runtime", "interpreter"), "SelectChoice")
+  val Unit: JvmName = JvmName(devFlixRuntime, "Unit")
+
+  //
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Scala Names ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //
+
+  val ScalaMathPkg: JvmName = JvmName(List("scala", "math"), "package$")
 }
 
 /**

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmType.scala
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 Magnus Madsen
+ * Copyright 2021 Jonathan Lindegaard Starup
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,41 +41,6 @@ sealed trait JvmType {
 }
 
 object JvmType {
-
-  /**
-    * The Flix Context class.
-    */
-  val Context: JvmType.Reference = Reference(JvmName.Context)
-
-  /**
-    * The `ca.uwaterloo.flix.api.Unit` type
-    */
-  val Unit: JvmType.Reference = Reference(JvmName.Unit)
-
-  /**
-    * The `java.lang.BigInteger` type.
-    */
-  val BigInteger: JvmType.Reference = Reference(JvmName.BigInteger)
-
-  /**
-    * The `java.lang.Object` type.
-    */
-  val Object: JvmType.Reference = Reference(JvmName.Object)
-
-  /**
-    * The `java.lang.String` type.
-    */
-  val String: JvmType.Reference = Reference(JvmName.String)
-
-  /**
-    * The `scala.math.package$` type
-    */
-  val ScalaMathPkg: JvmType.Reference = Reference(JvmName.ScalaMathPkg)
-
-  val Function: JvmType.Reference = Reference(JvmName.Function)
-
-  val AtomicLong: JvmType.Reference = Reference(JvmName.AtomicLong)
-
   /**
     * Represents the void type.
     */
@@ -125,4 +91,29 @@ object JvmType {
     */
   case class Reference(name: JvmName) extends JvmType
 
+  //
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Java Types ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //
+
+  val AtomicLong: JvmType.Reference = Reference(JvmName.AtomicLong)
+  val BigInteger: JvmType.Reference = Reference(JvmName.BigInteger)
+  val Class: JvmType.Reference = Reference(JvmName.Class)
+  val Function: JvmType.Reference = Reference(JvmName.Function)
+  val Object: JvmType.Reference = Reference(JvmName.Object)
+  val String: JvmType.Reference = Reference(JvmName.String)
+  val StringBuilder: JvmType.Reference = Reference(JvmName.StringBuilder)
+
+  //
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Flix Types ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //
+
+  val Context: JvmType.Reference = Reference(JvmName.Context)
+  val ReifiedSourceLocation: JvmType.Reference = Reference(JvmName.ReifiedSourceLocation)
+  val Unit: JvmType.Reference = Reference(JvmName.Unit)
+
+  //
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Scala Types ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //
+
+  val ScalaMathPkg: JvmType.Reference = Reference(JvmName.ScalaMathPkg)
 }


### PR DESCRIPTION
Part of #2591 

* Array types are missing but I am not sure that can be done incrementally. 
* method string are literals. I am not sure where to store them. I think it could be nice to store them on their JvmName class but this is also a bit weird because of subtyping (youd have to use `JvmName.Object.toStringMethod`)
* The generated class is changed a little bit (a few extra unreachable goto).

Generated class on this PR:
```
package dev.flix.runtime;

public final class MatchError extends FlixError {
    public final ReifiedSourceLocation location;

    public MatchError(ReifiedSourceLocation var1) {
        super("Non-exhaustive match at " + var1.toString());
        this.location = var1;
    }

    public boolean equals(Object var1) {
        if (this == var1) {
            return true;
        } else if (var1 != null) {
            if (this.getClass() == var1.getClass()) {
                return false;
            } else {
                MatchError var2 = (MatchError)var1;
                return Objects.equals(this.location, var2.location);
            }
        } else {
            return false;
        }
    }

    public int hashCode() {
        return Objects.hash(new Object[]{this.location});
    }
}
```
Generated class on Master:
```
package dev.flix.runtime;

public final class MatchError extends FlixError {
    public final ReifiedSourceLocation location;

    public MatchError(ReifiedSourceLocation var1) {
        super("Non-exhaustive match at " + var1.toString());
        this.location = var1;
    }

    public boolean equals(Object var1) {
        if (this == var1) {
            return true;
        } else if (var1 != null && this.getClass() == var1.getClass()) {
            MatchError var2 = (MatchError)var1;
            return Objects.equals(this.location, var2.location);
        } else {
            return false;
        }
    }

    public int hashCode() {
        return Objects.hash(new Object[]{this.location});
    }
}

```