### PR TITLE
Rewrite GenRefClasses to use bytecode DSL

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -37,9 +37,10 @@
   - Names such as `beginExp` etc. quickly get outdated.
 - Leave the code in better state than you found it in.
 
-## Jvm-specific
+## JVM Bytecode Generation Policy
 
 - Prefer public fields over private fields with getter/setter.
 - Prefer direct field initialization over construction arguments.
+- Ensure classes are final.
 
 If a PR discovers a new style principle, feel free to add it to this file as part of the same PR.

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -37,4 +37,9 @@
   - Names such as `beginExp` etc. quickly get outdated.
 - Leave the code in better state than you found it in.
 
+## Jvm-specific
+
+- Prefer public fields over private fields with getter/setter.
+- Prefer direct field initialization over construction arguments.
+
 If a PR discovers a new style principle, feel free to add it to this file as part of the same PR.

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -35,6 +35,7 @@
 - Write single-variable `mapN` cases open to additional variables with `mapN ... { case ... => ... }`
 - Prefer to name expressions just `exp1`, `exp2`, `exp3`.
   - Names such as `beginExp` etc. quickly get outdated.
+- Never use toString for anything other than debugging.
 - Leave the code in better state than you found it in.
 
 ## JVM Bytecode Generation Policy

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/AsmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/AsmOps.scala
@@ -368,7 +368,7 @@ object AsmOps {
     mv.visitInsn(SWAP)
     mv.visitLdcInsn(hole)
     mv.visitInsn(SWAP)
-    mv.visitMethodInsn(INVOKESPECIAL, className.toInternalName, "<init>", s"(${JvmName.String.toDescriptor}${JvmName.ReifiedSourceLocation.toDescriptor})${JvmType.Void.toDescriptor}", false)
+    mv.visitMethodInsn(INVOKESPECIAL, className.toInternalName, "<init>", s"(${BackendObjType.String.toDescriptor}${JvmName.ReifiedSourceLocation.toDescriptor})${JvmType.Void.toDescriptor}", false)
     mv.visitInsn(ATHROW)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -25,7 +25,7 @@ import ca.uwaterloo.flix.util.InternalCompilerException
   */
 sealed trait BackendObjType {
   /**
-    * The `JvmName` that represents the type `Ref(Int)` refers to `Ref$Int`.
+    * The `JvmName` that represents the type `Ref(Int)` refers to `"Ref$Int"`.
     */
   val jvmName: JvmName = this match {
     case BackendObjType.Unit => JvmName(DevFlixRuntime, "Unit")
@@ -47,7 +47,7 @@ sealed trait BackendObjType {
   }
 
   /**
-    * The JVM type descriptor of the form `L<jvmName.toInternalName>;`.
+    * The JVM type descriptor of the form `"L<jvmName.toInternalName>;"`.
     */
   def toDescriptor: String = jvmName.toDescriptor
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm
+
+import ca.uwaterloo.flix.language.ast.Symbol
+import ca.uwaterloo.flix.language.phase.jvm.JvmName.Delimiter
+
+sealed trait BackendObjType {
+  def jvmName: JvmName
+
+  def toDescriptor: String = jvmName.toDescriptor
+
+  def toTpe: BackendType.Reference = BackendType.Reference(this)
+}
+
+object BackendObjType {
+
+  private val rootPackage: List[String] = Nil
+
+  private val devFlixRuntime = List("dev", "flix", "runtime")
+
+  private val javaLang = List("java", "lang")
+
+  private def erasedListOfTypes(ts: List[BackendType]): String =
+    ts.map(e => e.toErased.toString).mkString(Delimiter)
+
+  case object Unit extends BackendObjType {
+    override val jvmName: JvmName = JvmName(devFlixRuntime, "Unit")
+  }
+
+  case object BigInt extends BackendObjType {
+    override val jvmName: JvmName = JvmName(List("java", "math"), "BigInteger")
+  }
+
+  case object String extends BackendObjType {
+    override val jvmName: JvmName = JvmName(javaLang, "String")
+  }
+
+  case class Channel(tpe: BackendType) extends BackendObjType {
+    override val jvmName: JvmName = JvmName(List("ca", "uwaterloo", "flix", "runtime", "interpreter"), "Channel")
+  }
+
+  case class Lazy(tpe: BackendType) extends BackendObjType {
+    override val jvmName: JvmName = JvmName(rootPackage, s"Lazy$Delimiter${tpe.toErased}")
+  }
+
+  case class Ref(tpe: BackendType) extends BackendObjType {
+    override val jvmName: JvmName = JvmName(rootPackage, s"Ref$Delimiter${tpe.toErased}")
+  }
+
+  case class Tuple(elms: List[BackendType]) extends BackendObjType {
+    override val jvmName: JvmName = JvmName(rootPackage, s"Tuple${elms.length}$Delimiter${erasedListOfTypes(elms)}")
+  }
+
+  case class Enum(sym: Symbol.EnumSym, args: List[BackendType]) extends BackendObjType {
+    override val jvmName: JvmName = ???
+  }
+
+  case class Arrow(args: List[BackendType], result: BackendType) extends BackendObjType {
+    override val jvmName: JvmName = JvmName(rootPackage, s"Fn${args.length}$Delimiter${erasedListOfTypes(args)}$Delimiter${result.toErased}")
+  }
+
+  case object RecordEmpty extends BackendObjType {
+    // TODO: These should include delimiter
+    override val jvmName: JvmName = JvmName(rootPackage, s"RecordEmpty")
+    val interface: JvmName = JvmName(rootPackage, "IRecord")
+  }
+
+  case class RecordExtend(field: String, value: BackendType, rest: BackendType) extends BackendObjType {
+    override val jvmName: JvmName = JvmName(rootPackage, s"RecordExtend$Delimiter${value.toErased}")
+  }
+
+  case object SchemaEmpty extends BackendObjType {
+    override val jvmName: JvmName = ???
+  }
+
+  case class SchemaExtend(name: String, tpe: BackendType, rest: BackendType) extends BackendObjType {
+    override val jvmName: JvmName = ???
+  }
+
+  case class Relation(tpes: List[BackendType]) extends BackendObjType {
+    override val jvmName: JvmName = ???
+  }
+
+  case class Lattice(tpes: List[BackendType]) extends BackendObjType {
+    override val jvmName: JvmName = ???
+  }
+
+  case class Native(jvmName: JvmName) extends BackendObjType
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -37,14 +37,14 @@ sealed trait BackendObjType {
     case BackendObjType.Lazy(tpe) => JvmName(RootPackage, s"Lazy$Delimiter${tpe.toErased}")
     case BackendObjType.Ref(tpe) => JvmName(RootPackage, s"Ref$Delimiter${tpe.toErased}")
     case BackendObjType.Tuple(elms) => JvmName(RootPackage, s"Tuple${elms.length}$Delimiter${erasedListOfTypes(elms)}")
-    case BackendObjType.Enum(_, _) => ???
+    case BackendObjType.Enum(_, _) => JvmName(RootPackage, "MissingInBackendObjType") // TODO
     case BackendObjType.Arrow(args, result) => JvmName(RootPackage, s"Fn${args.length}$Delimiter${erasedListOfTypes(args)}$Delimiter${result.toErased}")
     case BackendObjType.RecordEmpty => JvmName(RootPackage, s"RecordEmpty$Delimiter")
     case BackendObjType.RecordExtend(_, value, _) => JvmName(RootPackage, s"RecordExtend$Delimiter${value.toErased}")
-    case BackendObjType.SchemaEmpty => ???
-    case BackendObjType.SchemaExtend(_, _, _) => ???
-    case BackendObjType.Relation(_) => ???
-    case BackendObjType.Lattice(_) => ???
+    case BackendObjType.SchemaEmpty => JvmName(RootPackage, "MissingInBackendObjType") // TODO
+    case BackendObjType.SchemaExtend(_, _, _) => JvmName(RootPackage, "MissingInBackendObjType") // TODO
+    case BackendObjType.Relation(_) => JvmName(RootPackage, "MissingInBackendObjType") // TODO
+    case BackendObjType.Lattice(_) => JvmName(RootPackage, "MissingInBackendObjType") // TODO
     case BackendObjType.Native(className) => className
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -24,11 +24,8 @@ import ca.uwaterloo.flix.language.phase.jvm.JvmName.{Delimiter, DevFlixRuntime, 
   */
 sealed trait BackendObjType {
   /**
-    * Constructs a concatenated list of erased strings delimited with `JvmName.Delimiter`.
+    * The `JvmName` that represents the type `Ref(Int)` refers to `Ref$Int`.
     */
-  private def erasedListOfTypes(ts: List[BackendType]): String =
-    ts.map(e => e.toErased.toString).mkString(Delimiter)
-
   val jvmName: JvmName = this match {
     case BackendObjType.Unit => JvmName(DevFlixRuntime, "Unit")
     case BackendObjType.BigInt => JvmName(List("java", "math"), "BigInteger")
@@ -48,9 +45,21 @@ sealed trait BackendObjType {
     case BackendObjType.Native(className) => className
   }
 
+  /**
+    * The JVM type descriptor of the form `L<jvmName.toInternalName>;`.
+    */
   def toDescriptor: String = jvmName.toDescriptor
 
+  /**
+    * Returns `this` wrapped in `BackendType.Reference`.
+    */
   def toTpe: BackendType.Reference = BackendType.Reference(this)
+
+  /**
+    * Constructs a concatenated list of erased strings delimited with `JvmName.Delimiter`.
+    */
+  private def erasedListOfTypes(ts: List[BackendType]): String =
+    ts.map(e => e.toErased.toString).mkString(Delimiter)
 }
 
 object BackendObjType {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.language.ast.Symbol
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.{Delimiter, DevFlixRuntime, JavaLang, RootPackage}
+import ca.uwaterloo.flix.util.InternalCompilerException
 
 /**
   * Represents all Flix types that are objects on the JVM (array is an exception).
@@ -34,14 +35,14 @@ sealed trait BackendObjType {
     case BackendObjType.Lazy(tpe) => JvmName(RootPackage, s"Lazy$Delimiter${tpe.toErased}")
     case BackendObjType.Ref(tpe) => JvmName(RootPackage, s"Ref$Delimiter${tpe.toErased}")
     case BackendObjType.Tuple(elms) => JvmName(RootPackage, s"Tuple${elms.length}$Delimiter${erasedListOfTypes(elms)}")
-    case BackendObjType.Enum(_, _) => JvmName(RootPackage, "MissingInBackendObjType") // TODO
+    case BackendObjType.Enum(_, _) => throw InternalCompilerException("Enum JVM NAME") // TODO
     case BackendObjType.Arrow(args, result) => JvmName(RootPackage, s"Fn${args.length}$Delimiter${erasedListOfTypes(args)}$Delimiter${result.toErased}")
     case BackendObjType.RecordEmpty => JvmName(RootPackage, s"RecordEmpty$Delimiter")
     case BackendObjType.RecordExtend(_, value, _) => JvmName(RootPackage, s"RecordExtend$Delimiter${value.toErased}")
-    case BackendObjType.SchemaEmpty => JvmName(RootPackage, "MissingInBackendObjType") // TODO
-    case BackendObjType.SchemaExtend(_, _, _) => JvmName(RootPackage, "MissingInBackendObjType") // TODO
-    case BackendObjType.Relation(_) => JvmName(RootPackage, "MissingInBackendObjType") // TODO
-    case BackendObjType.Lattice(_) => JvmName(RootPackage, "MissingInBackendObjType") // TODO
+    case BackendObjType.SchemaEmpty() => throw InternalCompilerException("SchemaEmpty JVM NAME") // TODO
+    case BackendObjType.SchemaExtend(_, _, _) => throw InternalCompilerException("SchemaExtend JVM NAME") // TODO
+    case BackendObjType.Relation(_) => throw InternalCompilerException("Relation JVM NAME") // TODO
+    case BackendObjType.Lattice(_) => throw InternalCompilerException("Lattice JVM NAME") // TODO
     case BackendObjType.Native(className) => className
   }
 
@@ -89,7 +90,8 @@ object BackendObjType {
     val interface: JvmName = JvmName(RootPackage, s"IRecord$Delimiter")
   }
 
-  case object SchemaEmpty extends BackendObjType
+  // TODO: Should be an object
+  case class SchemaEmpty() extends BackendObjType
 
   case class SchemaExtend(name: String, tpe: BackendType, rest: BackendType) extends BackendObjType
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -19,6 +19,9 @@ package ca.uwaterloo.flix.language.phase.jvm
 import ca.uwaterloo.flix.language.ast.Symbol
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.Delimiter
 
+/**
+  * Represents all Flix types that are objects on the JVM (array is an exception).
+  */
 sealed trait BackendObjType {
   def jvmName: JvmName
 
@@ -35,6 +38,9 @@ object BackendObjType {
 
   private val javaLang = List("java", "lang")
 
+  /**
+    * Constructs a concatenated list of erased strings delimited with `JvmName.Delimiter`.
+    */
   private def erasedListOfTypes(ts: List[BackendType]): String =
     ts.map(e => e.toErased.toString).mkString(Delimiter)
 
@@ -100,5 +106,10 @@ object BackendObjType {
     override val jvmName: JvmName = ???
   }
 
+  /**
+    * Represents a JVM type not represented in Flix like `java.lang.Object` or `dev.flix.runtime.ReifiedSourceLocation`.
+    * This should not be used for `java.lang.String` for example since `BackendObjType.String`
+    * represents this type.
+    */
   case class Native(jvmName: JvmName) extends BackendObjType
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -20,6 +20,9 @@ package ca.uwaterloo.flix.language.phase.jvm
   * Represents all Flix types that are not object on the JVM including Void.
   */
 sealed trait VoidableType {
+  /**
+    * Returns a descriptor for the type. `Void` has descriptor `"V"`.
+    */
   def toDescriptor: String
 }
 
@@ -27,6 +30,9 @@ object VoidableType {
   case object Void extends VoidableType {
     override val toDescriptor: String = "V"
 
+    /**
+      * The erased string representation used in JVM names.
+      */
     override def toString: String = "Void"
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -33,7 +33,7 @@ object VoidableType {
     /**
       * The erased string representation used in JVM names.
       */
-    override def toString: String = "Void"
+    val toErasedString: String = "Void"
   }
 }
 
@@ -68,7 +68,7 @@ sealed trait BackendType extends VoidableType {
   /**
     * A string representing the erased type. This is used for parametrized class names.
     */
-  override val toString: String = this match {
+  val toErasedString: String = this match {
     case BackendType.Bool => "Bool"
     case BackendType.Char => "Char"
     case BackendType.Int8 => "Int8"

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -35,100 +35,71 @@ object VoidableType {
   * Represents all Flix types that are not objects on the JVM (array is an exception).
   */
 sealed trait BackendType extends VoidableType {
-  def toDescriptor: String
+  val toDescriptor: String = this match {
+    case BackendType.Bool => "Z"
+    case BackendType.Char => "C"
+    case BackendType.Int8 => "B"
+    case BackendType.Int16 => "S"
+    case BackendType.Int32 => "I"
+    case BackendType.Int64 => "J"
+    case BackendType.Float32 => "F"
+    case BackendType.Float64 => "D"
+    case BackendType.Array(tpe) => s"[${tpe.toDescriptor}"
+    case BackendType.Reference(ref) => ref.toDescriptor
+  }
 
-  def toErased: BackendType
+  /**
+    * Returns the erased type, either itself if `this` is primitive or `java.lang.Object`
+    * if `this` is an array or a reference.
+    * @return
+    */
+  def toErased: BackendType = this match {
+    case BackendType.Bool | BackendType.Char | BackendType.Int8 | BackendType.Int16 |
+         BackendType.Int32 | BackendType.Int64 | BackendType.Float32 | BackendType.Float64 => this
+    case BackendType.Array(_) | BackendType.Reference(_) => JvmName.Object.toObjTpe.toTpe
+  }
 
   /**
     * A string representing the erased type. This is used for parametrized class names.
     */
-  override def toString: String = "BackendType:MissingImpl"
+  override val toString: String = this match {
+    case BackendType.Bool => "Bool"
+    case BackendType.Char => "Char"
+    case BackendType.Int8 => "Int8"
+    case BackendType.Int16 => "Int16"
+    case BackendType.Int32 => "Int32"
+    case BackendType.Int64 => "Int64"
+    case BackendType.Float32 => "Float32"
+    case BackendType.Float64 => "Float64"
+    case BackendType.Array(_) | BackendType.Reference(_) => "Obj"
+  }
 }
 
 object BackendType {
-  case object Bool extends BackendType {
-    override val toDescriptor: String = "Z"
+  case object Bool extends BackendType
 
-    override def toErased: BackendType = this
+  case object Char extends BackendType
 
-    override def toString: String = "Bool"
-  }
+  case object Int8 extends BackendType
 
-  case object Char extends BackendType {
-    override val toDescriptor: String = "C"
+  case object Int16 extends BackendType
 
-    override def toErased: BackendType = this
+  case object Int32 extends BackendType
 
-    override def toString: String = "Char"
-  }
+  case object Int64 extends BackendType
 
-  case object Int8 extends BackendType {
-    override val toDescriptor: String = "B"
+  case object Float32 extends BackendType
 
-    override def toErased: BackendType = this
-
-    override def toString: String = "Int8"
-  }
-
-  case object Int16 extends BackendType {
-    override val toDescriptor: String = "S"
-
-    override def toErased: BackendType = this
-
-    override def toString: String = "Int16"
-  }
-
-  case object Int32 extends BackendType {
-    override val toDescriptor: String = "I"
-
-    override def toErased: BackendType = this
-
-    override def toString: String = "Int32"
-  }
-
-  case object Int64 extends BackendType {
-    override val toDescriptor: String = "J"
-
-    override def toErased: BackendType = this
-
-    override def toString: String = "Int64"
-  }
-
-  case object Float32 extends BackendType {
-    override val toDescriptor: String = "F"
-
-    override def toErased: BackendType = this
-
-    override def toString: String = "Float32"
-  }
-
-  case object Float64 extends BackendType {
-    override val toDescriptor: String = "D"
-
-    override def toErased: BackendType = this
-
-    override def toString: String = "Float64"
-  }
+  case object Float64 extends BackendType
 
   case class Array(tpe: BackendType) extends BackendType {
-    override def toDescriptor: String = s"[${tpe.toDescriptor}"
-
-    override def toErased: BackendType = JvmName.Object.toObjTpe.toTpe
-
-    override def toString: String = "Obj"
   }
 
   /**
     * Holds a reference to some object type.
     */
   case class Reference(ref: BackendObjType) extends BackendType {
-    override val toDescriptor: String = ref.toDescriptor
-
     def name: JvmName = ref.jvmName
-
-    override def toErased: BackendType = JvmName.Object.toObjTpe.toTpe
-
-    override def toString: String = "Obj"
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm
+
+
+sealed trait VoidableType {
+  def toDescriptor: String
+}
+
+object VoidableType {
+  case object Void extends VoidableType {
+    override val toDescriptor: String = "V"
+
+    override def toString: String = "Void"
+  }
+}
+
+
+sealed trait BackendType extends VoidableType {
+  def toDescriptor: String
+
+  def toErased: BackendType
+}
+
+object BackendType {
+  case object Bool extends BackendType {
+    override val toDescriptor: String = "Z"
+
+    override def toErased: BackendType = this
+
+    override def toString: String = "Bool"
+  }
+
+  case object Char extends BackendType {
+    override val toDescriptor: String = "C"
+
+    override def toErased: BackendType = this
+
+    override def toString: String = "Char"
+  }
+
+  case object Int8 extends BackendType {
+    override val toDescriptor: String = "B"
+
+    override def toErased: BackendType = this
+
+    override def toString: String = "Int8"
+  }
+
+  case object Int16 extends BackendType {
+    override val toDescriptor: String = "S"
+
+    override def toErased: BackendType = this
+
+    override def toString: String = "Int16"
+  }
+
+  case object Int32 extends BackendType {
+    override val toDescriptor: String = "I"
+
+    override def toErased: BackendType = this
+
+    override def toString: String = "Int32"
+  }
+
+  case object Int64 extends BackendType {
+    override val toDescriptor: String = "J"
+
+    override def toErased: BackendType = this
+
+    override def toString: String = "Int64"
+  }
+
+  case object Float32 extends BackendType {
+    override val toDescriptor: String = "F"
+
+    override def toErased: BackendType = this
+
+    override def toString: String = "Float32"
+  }
+
+  case object Float64 extends BackendType {
+    override val toDescriptor: String = "D"
+
+    override def toErased: BackendType = this
+
+    override def toString: String = "Float64"
+  }
+
+  case class Array(tpe: BackendType) extends BackendType {
+    override def toDescriptor: String = s"[${tpe.toDescriptor}"
+
+    override def toErased: BackendType = JvmName.Object.toObjTpe.toTpe
+
+    override def toString: String = "Obj"
+  }
+
+  case class Reference(ref: BackendObjType) extends BackendType {
+    override val toDescriptor: String = ref.toDescriptor
+
+    def name: JvmName = ref.jvmName
+
+    override def toErased: BackendType = JvmName.Object.toObjTpe.toTpe
+
+    override def toString: String = "Obj"
+  }
+
+
+  def erasedTypes: List[BackendType] =
+    Bool :: Char :: Float32 :: Float64 :: Int8 :: Int16 :: Int32 :: Int64 :: JvmName.Object.toObjTpe.toTpe :: Nil
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -16,7 +16,9 @@
 
 package ca.uwaterloo.flix.language.phase.jvm
 
-
+/**
+  * Represents all Flix types that are not object on the JVM including Void.
+  */
 sealed trait VoidableType {
   def toDescriptor: String
 }
@@ -29,11 +31,18 @@ object VoidableType {
   }
 }
 
-
+/**
+  * Represents all Flix types that are not objects on the JVM (array is an exception).
+  */
 sealed trait BackendType extends VoidableType {
   def toDescriptor: String
 
   def toErased: BackendType
+
+  /**
+    * A string representing the erased type. This is used for parametrized class names.
+    */
+  override def toString: String = "BackendType:MissingImpl"
 }
 
 object BackendType {
@@ -109,6 +118,9 @@ object BackendType {
     override def toString: String = "Obj"
   }
 
+  /**
+    * Holds a reference to some object type.
+    */
   case class Reference(ref: BackendObjType) extends BackendType {
     override val toDescriptor: String = ref.toDescriptor
 
@@ -119,7 +131,9 @@ object BackendType {
     override def toString: String = "Obj"
   }
 
-
+  /**
+    * Contains all the primitive types and `Reference(Native(JvmName.Object))`.
+    */
   def erasedTypes: List[BackendType] =
     Bool :: Char :: Float32 :: Float64 :: Int8 :: Int16 :: Int32 :: Int64 :: JvmName.Object.toObjTpe.toTpe :: Nil
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -31,7 +31,7 @@ object BytecodeInstructions {
     def visitInstruction(opcode: Int): Unit = visitor.visitInsn(opcode)
 
     def visitMethodInstruction(opcode: Int, owner: JvmName, methodName: String, descriptor: MethodDescriptor): Unit =
-      visitor.visitMethodInsn(opcode, owner.toInternalName, methodName, descriptor.toString, false)
+      visitor.visitMethodInsn(opcode, owner.toInternalName, methodName, descriptor.toDescriptor, false)
 
     def visitFieldInstruction(opcode: Int, owner: JvmName, fieldName: String, fieldType: BackendType): Unit =
       visitor.visitFieldInsn(opcode, owner.toInternalName, fieldName, fieldType.toDescriptor)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
@@ -25,22 +25,22 @@ import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
 import org.objectweb.asm.{ClassWriter, Opcodes}
 
 class ClassMaker(visitor: ClassWriter) {
-  private def makeField(fieldName: String, fieldType: JvmType, v: Visibility, f: Finality, i: Instancing): Unit = {
+  private def makeField(fieldName: String, fieldType: BackendType, v: Visibility, f: Finality, i: Instancing): Unit = {
     val modifier = v.toInt + f.toInt + i.toInt
     val field = visitor.visitField(modifier, fieldName, fieldType.toDescriptor, null, null)
     field.visitEnd()
   }
 
-  def mkField(fieldName: String, fieldType: JvmType, v: Visibility, f: Finality, i: Instancing): Unit = {
+  def mkField(fieldName: String, fieldType: BackendType, v: Visibility, f: Finality, i: Instancing): Unit = {
     makeField(fieldName, fieldType, v, f, i)
   }
 
   def mkConstructor(f: BytecodeInstructions.InstructionSet, descriptor: MethodDescriptor, v: Visibility): Unit = {
-    mkMethod(f, JvmName.ConstructorMethod, descriptor, v, Implementable, Instanced)
+    mkMethod(f, JvmName.ConstructorMethod, descriptor, v, NonFinal, NonStatic)
   }
 
   def mkStaticConstructor(f: BytecodeInstructions.InstructionSet): Unit =
-    mkMethod(f, JvmName.StaticConstructorMethod, MethodDescriptor.NothingToVoid, Default, Implementable, Static)
+    mkMethod(f, JvmName.StaticConstructorMethod, MethodDescriptor.NothingToVoid, Default, NonFinal, Static)
 
   def mkMethod(ins: BytecodeInstructions.InstructionSet, methodName: String, descriptor: MethodDescriptor, v: Visibility, f: Finality, i: Instancing): Unit = {
     val m = v.toInt + f.toInt + i.toInt
@@ -99,7 +99,7 @@ object ClassMaker {
       override val toInt: Int = Opcodes.ACC_FINAL
     }
 
-    case object Implementable extends Finality {
+    case object NonFinal extends Finality {
       override val toInt: Int = 0
     }
   }
@@ -113,7 +113,7 @@ object ClassMaker {
       override val toInt: Int = Opcodes.ACC_STATIC
     }
 
-    case object Instanced extends Instancing {
+    case object NonStatic extends Instancing {
       override val toInt: Int = 0
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
@@ -40,6 +40,9 @@ class ClassMaker(visitor: ClassWriter) {
     mkMethod(f, JvmName.ConstructorMethod, descriptor, v, NonFinal, NonStatic)
   }
 
+  /**
+    * Creates a instruction set calling `<init>` on `java.lang.Object` and returns.
+    */
   def mkObjectConstructor(v: Visibility): Unit = {
     val constructor = ALOAD(0) ~ invokeConstructor(JvmName.Object, MethodDescriptor.NothingToVoid) ~ RETURN()
     mkConstructor(constructor, MethodDescriptor.NothingToVoid, v)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
@@ -17,6 +17,7 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions._
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Finality._
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Instancing._
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility._
@@ -37,6 +38,11 @@ class ClassMaker(visitor: ClassWriter) {
 
   def mkConstructor(f: BytecodeInstructions.InstructionSet, descriptor: MethodDescriptor, v: Visibility): Unit = {
     mkMethod(f, JvmName.ConstructorMethod, descriptor, v, NonFinal, NonStatic)
+  }
+
+  def mkObjectConstructor(v: Visibility): Unit = {
+    val constructor = ALOAD(0) ~ invokeConstructor(JvmName.Object, MethodDescriptor.NothingToVoid) ~ RETURN()
+    mkConstructor(constructor, MethodDescriptor.NothingToVoid, v)
   }
 
   def mkStaticConstructor(f: BytecodeInstructions.InstructionSet): Unit =

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
@@ -36,8 +36,8 @@ class ClassMaker(visitor: ClassWriter) {
     makeField(fieldName, fieldType, v, f, i)
   }
 
-  def mkConstructor(f: BytecodeInstructions.InstructionSet, descriptor: MethodDescriptor, v: Visibility): Unit = {
-    mkMethod(f, JvmName.ConstructorMethod, descriptor, v, NonFinal, NonStatic)
+  def mkConstructor(ins: InstructionSet, d: MethodDescriptor, v: Visibility): Unit = {
+    mkMethod(ins, JvmName.ConstructorMethod, d, v, NonFinal, NonStatic)
   }
 
   /**
@@ -48,12 +48,12 @@ class ClassMaker(visitor: ClassWriter) {
     mkConstructor(constructor, MethodDescriptor.NothingToVoid, v)
   }
 
-  def mkStaticConstructor(f: BytecodeInstructions.InstructionSet): Unit =
-    mkMethod(f, JvmName.StaticConstructorMethod, MethodDescriptor.NothingToVoid, Default, NonFinal, Static)
+  def mkStaticConstructor(ins: InstructionSet): Unit =
+    mkMethod(ins, JvmName.StaticConstructorMethod, MethodDescriptor.NothingToVoid, Default, NonFinal, Static)
 
-  def mkMethod(ins: BytecodeInstructions.InstructionSet, methodName: String, descriptor: MethodDescriptor, v: Visibility, f: Finality, i: Instancing): Unit = {
+  def mkMethod(ins: InstructionSet, methodName: String, d: MethodDescriptor, v: Visibility, f: Finality, i: Instancing): Unit = {
     val m = v.toInt + f.toInt + i.toInt
-    val mv = visitor.visitMethod(m, methodName, descriptor.toString, null, null)
+    val mv = visitor.visitMethod(m, methodName, d.toDescriptor, null, null)
     mv.visitCode()
     ins(new BytecodeInstructions.F(mv))
     mv.visitMaxs(999, 999)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -752,14 +752,16 @@ object GenExpression {
       visitor.visitTypeInsn(NEW, classType.name.toInternalName)
       // Duplicate it since one instance will get consumed by constructor
       visitor.visitInsn(DUP)
+      // Call the constructor
+      visitor.visitMethodInsn(INVOKESPECIAL, classType.name.toInternalName, "<init>", AsmOps.getMethodDescriptor(Nil, JvmType.Void), false)
+      // Duplicate it since one instance will get consumed by putfield
+      visitor.visitInsn(DUP)
       // Evaluate the underlying expression
       compileExpression(exp, visitor, currentClass, lenv0, entryPoint)
       // Erased type of the value of the reference
       val valueErasedType = JvmOps.getErasedJvmType(tpe.asInstanceOf[MonoType.Ref].tpe)
-      // Constructor descriptor
-      val constructorDescriptor = AsmOps.getMethodDescriptor(List(valueErasedType), JvmType.Void)
-      // Call the constructor
-      visitor.visitMethodInsn(INVOKESPECIAL, classType.name.toInternalName, "<init>", constructorDescriptor, false)
+      // set the field with the ref value
+      visitor.visitFieldInsn(PUTFIELD, classType.name.toInternalName, GenRefClasses.ValueFieldName, valueErasedType.toDescriptor)
 
     case Expression.Deref(exp, tpe, loc) =>
       // Adding source line number for debugging

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -978,26 +978,26 @@ object GenExpression {
 
     case Expression.NewChannel(exp, _, loc) =>
       addSourceLine(visitor, loc)
-      visitor.visitTypeInsn(NEW, BackendObjType.Channel(null).jvmName.toInternalName)
+      visitor.visitTypeInsn(NEW, JvmName.Channel.toInternalName)
       visitor.visitInsn(DUP)
       compileExpression(exp, visitor, currentClass, lenv0, entryPoint)
-      visitor.visitMethodInsn(INVOKESPECIAL, BackendObjType.Channel(null).jvmName.toInternalName, "<init>", AsmOps.getMethodDescriptor(List(JvmType.PrimInt), JvmType.Void), false)
+      visitor.visitMethodInsn(INVOKESPECIAL, JvmName.Channel.toInternalName, "<init>", AsmOps.getMethodDescriptor(List(JvmType.PrimInt), JvmType.Void), false)
 
     case Expression.GetChannel(exp, tpe, loc) =>
       addSourceLine(visitor, loc)
       compileExpression(exp, visitor, currentClass, lenv0, entryPoint)
-      visitor.visitTypeInsn(CHECKCAST, BackendObjType.Channel(null).jvmName.toInternalName)
-      visitor.visitMethodInsn(INVOKEVIRTUAL, BackendObjType.Channel(null).jvmName.toInternalName, "get", AsmOps.getMethodDescriptor(Nil, JvmType.Object), false)
+      visitor.visitTypeInsn(CHECKCAST, JvmName.Channel.toInternalName)
+      visitor.visitMethodInsn(INVOKEVIRTUAL, JvmName.Channel.toInternalName, "get", AsmOps.getMethodDescriptor(Nil, JvmType.Object), false)
       AsmOps.castIfNotPrimAndUnbox(visitor, JvmOps.getJvmType(tpe))
 
     case Expression.PutChannel(exp1, exp2, _, loc) =>
       addSourceLine(visitor, loc)
       compileExpression(exp1, visitor, currentClass, lenv0, entryPoint)
-      visitor.visitTypeInsn(CHECKCAST, BackendObjType.Channel(null).jvmName.toInternalName)
+      visitor.visitTypeInsn(CHECKCAST, JvmName.Channel.toInternalName)
       visitor.visitInsn(DUP)
       compileExpression(exp2, visitor, currentClass, lenv0, entryPoint)
       AsmOps.boxIfPrim(visitor, JvmOps.getJvmType(exp2.tpe))
-      visitor.visitMethodInsn(INVOKEVIRTUAL, BackendObjType.Channel(null).jvmName.toInternalName, "put", AsmOps.getMethodDescriptor(List(JvmType.Object), JvmType.Void), false)
+      visitor.visitMethodInsn(INVOKEVIRTUAL, JvmName.Channel.toInternalName, "put", AsmOps.getMethodDescriptor(List(JvmType.Object), JvmType.Void), false)
 
     case Expression.SelectChannel(rules, default, _, loc) =>
       addSourceLine(visitor, loc)
@@ -1005,7 +1005,7 @@ object GenExpression {
 
       // Calculate the size of the array and initiate it
       compileInt(visitor, rules.size)
-      visitor.visitTypeInsn(ANEWARRAY, BackendObjType.Channel(null).jvmName.toInternalName)
+      visitor.visitTypeInsn(ANEWARRAY, JvmName.Channel.toInternalName)
       for ((rule, index) <- rules.zipWithIndex) {
         // Dup so we end up with an array on top of the stack
         visitor.visitInsn(DUP)
@@ -1014,7 +1014,7 @@ object GenExpression {
         // Compile the chan expression 100
         compileExpression(rule.chan, visitor, currentClass, lenv0, entryPoint)
         // Cast the type from Object to Channel
-        visitor.visitTypeInsn(CHECKCAST, BackendObjType.Channel(null).jvmName.toInternalName)
+        visitor.visitTypeInsn(CHECKCAST, JvmName.Channel.toInternalName)
         // Store the expression in the array
         visitor.visitInsn(AASTORE)
       }
@@ -1029,7 +1029,7 @@ object GenExpression {
 
       // TODO SJ: Should we create a JvmName for the return type here? yes
       // Invoke select in Channel. This puts a SelectChoice on the stack
-      visitor.visitMethodInsn(INVOKESTATIC, BackendObjType.Channel(null).jvmName.toInternalName, "select", "([Lca/uwaterloo/flix/runtime/interpreter/Channel;Z)Lca/uwaterloo/flix/runtime/interpreter/SelectChoice;", false)
+      visitor.visitMethodInsn(INVOKESTATIC, JvmName.Channel.toInternalName, "select", "([Lca/uwaterloo/flix/runtime/interpreter/Channel;Z)Lca/uwaterloo/flix/runtime/interpreter/SelectChoice;", false)
 
       // Check if the default case was selected
       val defaultLabel = new Label()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenGlobalCounterClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenGlobalCounterClass.scala
@@ -39,18 +39,13 @@ object GenGlobalCounterClass {
   private def genByteCode()(implicit flix: Flix): Array[Byte] = {
     val cm = ClassMaker.mkClass(JvmName.GlobalCounter, Public, Final)
 
-    cm.mkConstructor(genConstructor(), JvmName.MethodDescriptor.NothingToVoid, Private)
+    cm.mkObjectConstructor(Private)
     cm.mkStaticConstructor(genStaticConstructor())
     cm.mkField(counterFieldName, JvmName.AtomicLong.toObjTpe.toTpe, Private, Final, Static)
     cm.mkMethod(genNewIdMethod(), NewIdMethodName, MethodDescriptor(Nil, BackendType.Int64), Public, Final, Static)
 
     cm.closeClassMaker
   }
-
-  private def genConstructor(): InstructionSet =
-    ALOAD(0) ~
-      invokeConstructor(JvmName.Object) ~
-      RETURN()
 
   private def genStaticConstructor(): InstructionSet =
     NEW(JvmName.AtomicLong) ~

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenGlobalCounterClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenGlobalCounterClass.scala
@@ -41,30 +41,27 @@ object GenGlobalCounterClass {
 
     cm.mkConstructor(genConstructor(), JvmName.MethodDescriptor.NothingToVoid, Private)
     cm.mkStaticConstructor(genStaticConstructor())
-    cm.mkField(counterFieldName, JvmType.AtomicLong, Private, Final, Static)
-    cm.mkMethod(genNewIdMethod(), NewIdMethodName, MethodDescriptor(Nil, JvmType.PrimLong), Public, Final, Static)
+    cm.mkField(counterFieldName, JvmName.AtomicLong.toObjTpe.toTpe, Private, Final, Static)
+    cm.mkMethod(genNewIdMethod(), NewIdMethodName, MethodDescriptor(Nil, BackendType.Int64), Public, Final, Static)
 
     cm.closeClassMaker
   }
 
-  private def genConstructor(): InstructionSet = {
+  private def genConstructor(): InstructionSet =
     ALOAD(0) ~
       invokeConstructor(JvmName.Object) ~
       RETURN()
-  }
 
-  private def genStaticConstructor(): InstructionSet = {
+  private def genStaticConstructor(): InstructionSet =
     NEW(JvmName.AtomicLong) ~
       DUP() ~
       invokeConstructor(JvmName.AtomicLong) ~
-      PUTSTATIC(JvmName.AtomicLong, counterFieldName, JvmType.AtomicLong) ~
+      PUTSTATIC(JvmName.AtomicLong, counterFieldName, JvmName.AtomicLong.toObjTpe.toTpe) ~
       RETURN()
-  }
 
-  private def genNewIdMethod()(implicit flix: Flix): InstructionSet = {
-    GETSTATIC(JvmName.GlobalCounter, counterFieldName, JvmType.AtomicLong) ~
-      INVOKEVIRTUAL(JvmName.AtomicLong, "getAndIncrement", MethodDescriptor(Nil, JvmType.PrimLong)) ~
+  private def genNewIdMethod()(implicit flix: Flix): InstructionSet =
+    GETSTATIC(JvmName.GlobalCounter, counterFieldName, JvmName.AtomicLong.toObjTpe.toTpe) ~
+      INVOKEVIRTUAL(JvmName.AtomicLong, "getAndIncrement", MethodDescriptor(Nil, BackendType.Int64)) ~
       LRETURN()
-  }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenHoleErrorClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenHoleErrorClass.scala
@@ -47,7 +47,7 @@ object GenHoleErrorClass {
     genConstructor(name, superClass, visitor)
     genEquals(name, visitor)
     genHashCode(name, visitor)
-    visitor.visitField(ACC_PUBLIC + ACC_FINAL, HoleFieldName, JvmName.String.toDescriptor, null, null).visitEnd()
+    visitor.visitField(ACC_PUBLIC + ACC_FINAL, HoleFieldName, BackendObjType.String.jvmName.toDescriptor, null, null).visitEnd()
     visitor.visitField(ACC_PUBLIC + ACC_FINAL, LocationFieldName, JvmName.ReifiedSourceLocation.toDescriptor, null, null).visitEnd()
 
     visitor.visitEnd()
@@ -55,10 +55,10 @@ object GenHoleErrorClass {
   }
 
   private def genConstructor(name: JvmName, superClass: JvmName, visitor: ClassWriter): Unit = {
-    val stringToBuilderDescriptor = s"(${JvmName.String.toDescriptor})${JvmName.StringBuilder.toDescriptor}"
+    val stringToBuilderDescriptor = s"(${BackendObjType.String.jvmName.toDescriptor})${JvmName.StringBuilder.toDescriptor}"
     val builderName = JvmName.StringBuilder.toInternalName
 
-    val method = visitor.visitMethod(ACC_PUBLIC, "<init>", s"(${JvmName.String.toDescriptor}${JvmName.ReifiedSourceLocation.toDescriptor})${JvmType.Void.toDescriptor}", null, null)
+    val method = visitor.visitMethod(ACC_PUBLIC, "<init>", s"(${BackendObjType.String.jvmName.toDescriptor}${JvmName.ReifiedSourceLocation.toDescriptor})${JvmType.Void.toDescriptor}", null, null)
     method.visitCode()
 
     method.visitVarInsn(ALOAD, 0)
@@ -78,7 +78,7 @@ object GenHoleErrorClass {
     method.visitMethodInsn(INVOKESPECIAL, superClass.toInternalName, "<init>", AsmOps.getMethodDescriptor(List(JvmType.String), JvmType.Void), false)
     method.visitVarInsn(ALOAD, 0)
     method.visitVarInsn(ALOAD, 1)
-    method.visitFieldInsn(PUTFIELD, name.toInternalName, HoleFieldName, JvmName.String.toDescriptor)
+    method.visitFieldInsn(PUTFIELD, name.toInternalName, HoleFieldName, BackendObjType.String.jvmName.toDescriptor)
     method.visitVarInsn(ALOAD, 0)
     method.visitVarInsn(ALOAD, 2)
     method.visitFieldInsn(PUTFIELD, name.toInternalName, LocationFieldName, JvmName.ReifiedSourceLocation.toDescriptor)
@@ -119,9 +119,9 @@ object GenHoleErrorClass {
     method.visitTypeInsn(CHECKCAST, name.toInternalName)
     method.visitVarInsn(ASTORE, 2)
     method.visitVarInsn(ALOAD, 0)
-    method.visitFieldInsn(GETFIELD, name.toInternalName, HoleFieldName, JvmName.String.toDescriptor)
+    method.visitFieldInsn(GETFIELD, name.toInternalName, HoleFieldName, BackendObjType.String.jvmName.toDescriptor)
     method.visitVarInsn(ALOAD, 2)
-    method.visitFieldInsn(GETFIELD, name.toInternalName, HoleFieldName, JvmName.String.toDescriptor)
+    method.visitFieldInsn(GETFIELD, name.toInternalName, HoleFieldName, BackendObjType.String.jvmName.toDescriptor)
     method.visitMethodInsn(INVOKESTATIC, JvmName.Objects.toInternalName, "equals", AsmOps.getMethodDescriptor(List(JvmType.Object, JvmType.Object), JvmType.PrimBool), false)
     val returnFalse2 = new Label()
     method.visitJumpInsn(IFEQ, returnFalse2)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRecordExtend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRecordExtend.scala
@@ -243,7 +243,7 @@ object GenRecordExtend {
     getRecordWithField.visitVarInsn(ALOAD, 1)
 
     //Compare both strings on the stack using equals.
-    getRecordWithField.visitMethodInsn(INVOKEVIRTUAL, JvmName.String.toInternalName,
+    getRecordWithField.visitMethodInsn(INVOKEVIRTUAL, BackendObjType.String.jvmName.toInternalName,
       "equals", AsmOps.getMethodDescriptor(List(JvmType.Object), JvmType.PrimBool), false)
 
     //create new labels
@@ -313,7 +313,7 @@ object GenRecordExtend {
     restrictField.visitVarInsn(ALOAD, 1)
 
     //Compare both strings on the stack using equals.
-    restrictField.visitMethodInsn(INVOKEVIRTUAL, JvmName.String.toInternalName,
+    restrictField.visitMethodInsn(INVOKEVIRTUAL, BackendObjType.String.jvmName.toInternalName,
       "equals", AsmOps.getMethodDescriptor(List(JvmType.Object), JvmType.PrimBool), false)
 
     //create new labels

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRefClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRefClasses.scala
@@ -2,9 +2,7 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.ErasedAst.Root
-import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions._
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{Finality, Instancing, Visibility}
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor.mkDescriptor
 
 object GenRefClasses {
 
@@ -20,17 +18,8 @@ object GenRefClasses {
     val cm = ClassMaker.mkClass(refType.jvmName, Visibility.Public, Finality.Final)
 
     cm.mkField(ValueFieldName, refType.tpe, Visibility.Public, Finality.NonFinal, Instancing.NonStatic)
-    cm.mkConstructor(genConstructor(refType), mkDescriptor(refType.tpe)(VoidableType.Void), Visibility.Public)
+    cm.mkObjectConstructor(Visibility.Public)
 
     cm.closeClassMaker
-  }
-
-  private def genConstructor(refType: BackendObjType.Ref)(implicit root: Root, flix: Flix): InstructionSet = {
-    ALOAD(0) ~
-      invokeConstructor(JvmName.Object, mkDescriptor()(VoidableType.Void)) ~
-      ALOAD(0) ~
-      xLoad(refType.tpe, 1) ~
-      PUTFIELD(refType.jvmName, ValueFieldName, refType.tpe) ~
-      RETURN()
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRefClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRefClasses.scala
@@ -2,117 +2,35 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.ErasedAst.Root
-import ca.uwaterloo.flix.language.ast.MonoType
-import ca.uwaterloo.flix.language.phase.jvm.JvmOps.{getErasedJvmType, getJvmType}
-import org.objectweb.asm.ClassWriter
-import org.objectweb.asm.Opcodes._
+import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions._
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{Finality, Instancing, Visibility}
+import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor.mkDescriptor
 
-/**
-  * Generates bytecode for the cell classes.
-  */
 object GenRefClasses {
 
-  /**
-    * Returns the bytecode for the cell classes built-in to the Flix language.
-    */
-  def gen()(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
+  val ValueFieldName: String = "value"
 
-    // Type that we need a cell class for
-    val types = List(MonoType.Bool, MonoType.Char, MonoType.Float32, MonoType.Float64,
-      MonoType.Int8, MonoType.Int16, MonoType.Int32, MonoType.Int64, MonoType.Unit)
-
-    // Generating each cell class
-    types.map { tpe =>
-      val classType = JvmOps.getRefClassType(MonoType.Ref(tpe))
-      classType.name -> JvmClass(classType.name, genRefClass(classType, getErasedJvmType(tpe)))
+  def gen(types: List[BackendObjType.Ref])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
+    types.map { refType =>
+      refType.jvmName -> JvmClass(refType.jvmName, genRefClass(refType))
     }.toMap
   }
 
-  /**
-    * Generating class `classType` with value of type `tpe`
-    */
-  private def genRefClass(classType: JvmType.Reference, tpe: JvmType)(implicit root: Root, flix: Flix): Array[Byte] = {
-    // Class visitor
-    val visitor = AsmOps.mkClassWriter()
+  private def genRefClass(refType: BackendObjType.Ref)(implicit root: Root, flix: Flix): Array[Byte] = {
+    val cm = ClassMaker.mkClass(refType.jvmName, Visibility.Public, Finality.Final)
 
-    // Class visitor
-    visitor.visit(AsmOps.JavaVersion, ACC_PUBLIC + ACC_FINAL, classType.name.toInternalName, null,
-      JvmName.Object.toInternalName, null)
+    cm.mkField(ValueFieldName, refType.tpe, Visibility.Public, Finality.NonFinal, Instancing.NonStatic)
+    cm.mkConstructor(genConstructor(refType), mkDescriptor(refType.tpe)(VoidableType.Void), Visibility.Public)
 
-
-    // Generate the instance field
-    AsmOps.compileField(visitor, "value", tpe, isStatic = false, isPrivate = true)
-
-    // Generate the constructor
-    genConstructor(classType, tpe, visitor)
-
-    // Generate `getValue` method
-    genGetValue(classType, tpe, visitor)
-
-    // Generate `setValue` method
-    genSetValue(classType, tpe, visitor)
-
-    // Generate the `toString` method.
-    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "toString", AsmOps.getMethodDescriptor(Nil, JvmType.String),
-      "toString method shouldn't be called")
-
-    // Generate the `hashCode` method.
-    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "hashCode", AsmOps.getMethodDescriptor(Nil, JvmType.PrimInt),
-      "hashCode method shouldn't be called")
-
-    // Generate the `equals` method.
-    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "equals", AsmOps.getMethodDescriptor(List(JvmType.Object), JvmType.PrimBool),
-      "equals method shouldn't be called")
-
-    // Complete the visitor and get the bytecode.
-    visitor.visitEnd()
-    visitor.toByteArray
+    cm.closeClassMaker
   }
 
-  /**
-    * Generating constructor for the class `classType` with value of type `cellType`
-    */
-  private def genConstructor(classType: JvmType.Reference, cellType: JvmType, visitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = {
-    val iLoad = AsmOps.getLoadInstruction(cellType)
-    val initMethod = visitor.visitMethod(ACC_PUBLIC, "<init>", AsmOps.getMethodDescriptor(List(cellType), JvmType.Void), null, null)
-    initMethod.visitCode()
-    initMethod.visitVarInsn(ALOAD, 0)
-    initMethod.visitMethodInsn(INVOKESPECIAL, JvmName.Object.toInternalName, "<init>", AsmOps.getMethodDescriptor(Nil, JvmType.Void), false)
-    initMethod.visitVarInsn(ALOAD, 0)
-    initMethod.visitVarInsn(iLoad, 1)
-    initMethod.visitFieldInsn(PUTFIELD, classType.name.toInternalName, "value", cellType.toDescriptor)
-    initMethod.visitInsn(RETURN)
-    initMethod.visitMaxs(2, 2)
-    initMethod.visitEnd()
+  private def genConstructor(refType: BackendObjType.Ref)(implicit root: Root, flix: Flix): InstructionSet = {
+    ALOAD(0) ~
+      invokeConstructor(JvmName.Object, mkDescriptor()(VoidableType.Void)) ~
+      ALOAD(0) ~
+      xLoad(refType.tpe, 1) ~
+      PUTFIELD(refType.jvmName, ValueFieldName, refType.tpe) ~
+      RETURN()
   }
-
-  /**
-    * Generating `getValue` method for the class `classType` with value of type `cellType`
-    */
-  private def genGetValue(classType: JvmType.Reference, cellType: JvmType, visitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = {
-    val iRet = AsmOps.getReturnInstruction(cellType)
-    val getValue = visitor.visitMethod(ACC_PUBLIC, "getValue", AsmOps.getMethodDescriptor(Nil, cellType), null, null)
-    getValue.visitCode()
-    getValue.visitVarInsn(ALOAD, 0)
-    getValue.visitFieldInsn(GETFIELD, classType.name.toInternalName, "value", cellType.toDescriptor)
-    getValue.visitInsn(iRet)
-    getValue.visitMaxs(1, 1)
-    getValue.visitEnd()
-  }
-
-  /**
-    * Generating `setValue` method for the class `classType` with value of type `cellType`
-    */
-  private def genSetValue(classType: JvmType.Reference, cellType: JvmType, visitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = {
-    val iLoad = AsmOps.getLoadInstruction(cellType)
-    val setValue = visitor.visitMethod(ACC_PUBLIC, "setValue", AsmOps.getMethodDescriptor(List(cellType), JvmType.Void), null, null)
-    setValue.visitCode()
-    setValue.visitVarInsn(ALOAD, 0)
-    setValue.visitVarInsn(iLoad, 1)
-    setValue.visitFieldInsn(PUTFIELD, classType.name.toInternalName, "value", cellType.toDescriptor)
-    setValue.visitInsn(RETURN)
-    setValue.visitMaxs(2, 2)
-    setValue.visitEnd()
-  }
-
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenReifiedSourceLocationClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenReifiedSourceLocationClass.scala
@@ -66,7 +66,7 @@ object GenReifiedSourceLocationClass {
   }
 
   private def genToString(name: JvmName, visitor: ClassWriter): Unit = {
-    val stringToBuilderDescriptor = s"(${JvmName.String.toDescriptor})${JvmName.StringBuilder.toDescriptor}"
+    val stringToBuilderDescriptor = s"(${BackendObjType.String.jvmName.toDescriptor})${JvmName.StringBuilder.toDescriptor}"
     val intToBuilderDescriptor = s"(${JvmType.PrimInt.toDescriptor})${JvmName.StringBuilder.toDescriptor}"
     val builderName = JvmName.StringBuilder.toInternalName
 
@@ -77,7 +77,7 @@ object GenReifiedSourceLocationClass {
     method.visitInsn(DUP)
     method.visitMethodInsn(INVOKESPECIAL, builderName, "<init>", AsmOps.getMethodDescriptor(Nil, JvmType.Void), false)
     method.visitVarInsn(ALOAD, 0)
-    method.visitFieldInsn(GETFIELD, name.toInternalName, SourceFieldName, JvmName.String.toDescriptor)
+    method.visitFieldInsn(GETFIELD, name.toInternalName, SourceFieldName, BackendObjType.String.jvmName.toDescriptor)
     method.visitMethodInsn(INVOKEVIRTUAL, builderName, "append", stringToBuilderDescriptor, false)
     method.visitLdcInsn(":")
     method.visitMethodInsn(INVOKEVIRTUAL, builderName, "append", stringToBuilderDescriptor, false)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenTagClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenTagClasses.scala
@@ -238,7 +238,7 @@ object GenTagClasses {
     method.visitInsn(DUP)
 
     // Getting instance of `UnitClass`
-    method.visitFieldInsn(GETSTATIC, JvmName.Unit.toInternalName, GenUnitClass.InstanceFieldName, JvmName.Unit.toDescriptor)
+    method.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, GenUnitClass.InstanceFieldName, BackendObjType.Unit.jvmName.toDescriptor)
     // Calling constructor on the object
     method.visitMethodInsn(INVOKESPECIAL, classType.name.toInternalName, "<init>",
       AsmOps.getMethodDescriptor(List(JvmType.Object), JvmType.Void), false)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenUnitClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenUnitClass.scala
@@ -30,14 +30,14 @@ object GenUnitClass {
   val InstanceFieldName = "INSTANCE"
 
   def gen()(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
-    Map(JvmName.Unit -> JvmClass(JvmName.Unit, genByteCode()))
+    Map(BackendObjType.Unit.jvmName -> JvmClass(BackendObjType.Unit.jvmName, genByteCode()))
   }
 
   private def genByteCode()(implicit flix: Flix): Array[Byte] = {
-    val cm = mkClass(JvmName.Unit, Public, Final)
+    val cm = mkClass(BackendObjType.Unit.jvmName, Public, Final)
 
     // Singleton instance
-    cm.mkField(InstanceFieldName, JvmType.Unit, Public, Final, Static)
+    cm.mkField(InstanceFieldName, BackendObjType.Unit.toTpe, Public, Final, Static)
 
     cm.mkStaticConstructor(genStaticConstructor())
     cm.mkConstructor(genConstructor(), MethodDescriptor.NothingToVoid, Private)
@@ -45,18 +45,16 @@ object GenUnitClass {
     cm.closeClassMaker
   }
 
-  private def genStaticConstructor(): InstructionSet = {
-    NEW(JvmName.Unit) ~
+  private def genStaticConstructor(): InstructionSet =
+    NEW(BackendObjType.Unit.jvmName) ~
       DUP() ~
-      invokeConstructor(JvmName.Unit) ~
-      PUTSTATIC(JvmName.Unit, InstanceFieldName, JvmType.Unit) ~
+      invokeConstructor(BackendObjType.Unit.jvmName) ~
+      PUTSTATIC(BackendObjType.Unit.jvmName, InstanceFieldName, BackendObjType.Unit.toTpe) ~
       RETURN()
-  }
 
-  private def genConstructor(): InstructionSet = {
+  private def genConstructor(): InstructionSet =
     ALOAD(0) ~
       invokeConstructor(JvmName.Object) ~
       RETURN()
-  }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenUnitClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenUnitClass.scala
@@ -23,7 +23,6 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Finality._
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Instancing._
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility._
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker._
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
 
 object GenUnitClass {
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenUnitClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenUnitClass.scala
@@ -40,7 +40,7 @@ object GenUnitClass {
     cm.mkField(InstanceFieldName, BackendObjType.Unit.toTpe, Public, Final, Static)
 
     cm.mkStaticConstructor(genStaticConstructor())
-    cm.mkConstructor(genConstructor(), MethodDescriptor.NothingToVoid, Private)
+    cm.mkObjectConstructor(Private)
 
     cm.closeClassMaker
   }
@@ -51,10 +51,4 @@ object GenUnitClass {
       invokeConstructor(BackendObjType.Unit.jvmName) ~
       PUTSTATIC(BackendObjType.Unit.jvmName, InstanceFieldName, BackendObjType.Unit.toTpe) ~
       RETURN()
-
-  private def genConstructor(): InstructionSet =
-    ALOAD(0) ~
-      invokeConstructor(JvmName.Object) ~
-      RETURN()
-
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -39,6 +39,10 @@ object JvmBackend extends Phase[Root, CompilationResult] {
     //
     implicit val r: Root = root
 
+    // TODO: This should be limited to those actually used
+    val erasedRefTypes = List(JvmType.PrimBool, JvmType.PrimChar, JvmType.PrimFloat, JvmType.PrimDouble,
+      JvmType.PrimByte, JvmType.PrimShort, JvmType.PrimInt, JvmType.PrimLong, JvmType.Reference(JvmName.Object)).map(JvmType.???(_))
+
     // Generate all classes.
     val allClasses = flix.subphase("CodeGen") {
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -40,8 +40,7 @@ object JvmBackend extends Phase[Root, CompilationResult] {
     implicit val r: Root = root
 
     // TODO: This should be limited to those actually used
-    val erasedRefTypes = List(JvmType.PrimBool, JvmType.PrimChar, JvmType.PrimFloat, JvmType.PrimDouble,
-      JvmType.PrimByte, JvmType.PrimShort, JvmType.PrimInt, JvmType.PrimLong, JvmType.Reference(JvmName.Object)).map(JvmType.???(_))
+    val erasedRefTypes: List[BackendObjType.Ref] = BackendType.erasedTypes.map(BackendObjType.Ref)
 
     // Generate all classes.
     val allClasses = flix.subphase("CodeGen") {
@@ -134,7 +133,7 @@ object JvmBackend extends Phase[Root, CompilationResult] {
       //
       // Generate references classes.
       //
-      val refClasses = GenRefClasses.gen()
+      val refClasses = GenRefClasses.gen(erasedRefTypes)
 
       //
       // Generate lazy classes.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -70,44 +70,46 @@ object JvmName {
     JvmName(l.init.toList, l.last)
   }
 
+  val RootPackage: List[String] = Nil
+
   //
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Java Names ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   //
 
-  private val javaLang = List("java", "lang")
+  val JavaLang: List[String] = List("java", "lang")
 
   val AtomicLong: JvmName = JvmName(List("java", "util", "concurrent", "atomic"), "AtomicLong")
-  val Boolean: JvmName = JvmName(javaLang, "Boolean")
-  val Byte: JvmName = JvmName(javaLang, "Byte")
-  val Character: JvmName = JvmName(javaLang, "Character")
-  val Class: JvmName = JvmName(javaLang, "Class")
-  val Double: JvmName = JvmName(javaLang, "Double")
-  val Exception: JvmName = JvmName(javaLang, "Exception")
-  val Float: JvmName = JvmName(javaLang, "Float")
+  val Boolean: JvmName = JvmName(JavaLang, "Boolean")
+  val Byte: JvmName = JvmName(JavaLang, "Byte")
+  val Character: JvmName = JvmName(JavaLang, "Character")
+  val Class: JvmName = JvmName(JavaLang, "Class")
+  val Double: JvmName = JvmName(JavaLang, "Double")
+  val Exception: JvmName = JvmName(JavaLang, "Exception")
+  val Float: JvmName = JvmName(JavaLang, "Float")
   val Function: JvmName = JvmName(List("java", "util", "function"), "Function")
-  val Integer: JvmName = JvmName(javaLang, "Integer")
-  val Long: JvmName = JvmName(javaLang, "Long")
-  val Object: JvmName = JvmName(javaLang, "Object")
-  val Objects: JvmName = JvmName(javaLang, "Objects")
-  val Runnable: JvmName = JvmName(javaLang, "Runnable")
-  val RuntimeException: JvmName = JvmName(javaLang, "RuntimeException")
-  val Short: JvmName = JvmName(javaLang, "Short")
-  val StringBuilder: JvmName = JvmName(javaLang, "StringBuilder")
-  val UnsupportedOperationException: JvmName = JvmName(javaLang, "UnsupportedOperationException")
+  val Integer: JvmName = JvmName(JavaLang, "Integer")
+  val Long: JvmName = JvmName(JavaLang, "Long")
+  val Object: JvmName = JvmName(JavaLang, "Object")
+  val Objects: JvmName = JvmName(JavaLang, "Objects")
+  val Runnable: JvmName = JvmName(JavaLang, "Runnable")
+  val RuntimeException: JvmName = JvmName(JavaLang, "RuntimeException")
+  val Short: JvmName = JvmName(JavaLang, "Short")
+  val StringBuilder: JvmName = JvmName(JavaLang, "StringBuilder")
+  val UnsupportedOperationException: JvmName = JvmName(JavaLang, "UnsupportedOperationException")
 
   //
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Flix Names ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   //
 
-  private val devFlixRuntime = List("dev", "flix", "runtime")
+  val DevFlixRuntime: List[String] = List("dev", "flix", "runtime")
 
   val Context: JvmName = JvmName(Nil, "Context")
-  val FlixError: JvmName = JvmName(devFlixRuntime, "FlixError")
-  val GlobalCounter: JvmName = JvmName(devFlixRuntime, "GlobalCounter")
-  val HoleError: JvmName = JvmName(devFlixRuntime, "HoleError")
-  val MatchError: JvmName = JvmName(devFlixRuntime, "MatchError")
-  val ProxyObject: JvmName = JvmName(devFlixRuntime, "ProxyObject")
-  val ReifiedSourceLocation: JvmName = JvmName(devFlixRuntime, "ReifiedSourceLocation")
+  val FlixError: JvmName = JvmName(DevFlixRuntime, "FlixError")
+  val GlobalCounter: JvmName = JvmName(DevFlixRuntime, "GlobalCounter")
+  val HoleError: JvmName = JvmName(DevFlixRuntime, "HoleError")
+  val MatchError: JvmName = JvmName(DevFlixRuntime, "MatchError")
+  val ProxyObject: JvmName = JvmName(DevFlixRuntime, "ProxyObject")
+  val ReifiedSourceLocation: JvmName = JvmName(DevFlixRuntime, "ReifiedSourceLocation")
   val SelectChoice: JvmName = JvmName(List("ca", "uwaterloo", "flix", "runtime", "interpreter"), "SelectChoice")
 
   //

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -29,7 +29,7 @@ object JvmName {
     /**
       * Returns the type descriptor of this method.
       */
-    override lazy val toString: String = {
+    val toDescriptor: String = {
       // Descriptor of result
       val resultDescriptor = result.toDescriptor
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -112,6 +112,9 @@ object JvmName {
   val ReifiedSourceLocation: JvmName = JvmName(DevFlixRuntime, "ReifiedSourceLocation")
   val SelectChoice: JvmName = JvmName(List("ca", "uwaterloo", "flix", "runtime", "interpreter"), "SelectChoice")
 
+  // Deprecated: Should not be used in new code.
+  val Channel: JvmName = JvmName(List("ca", "uwaterloo", "flix", "runtime", "interpreter"), "Channel")
+
   //
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Scala Names ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   //

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -317,7 +317,7 @@ object JvmOps {
       val valueType = stringify(getErasedJvmType(value))
 
       // The JVM name is of the form RecordExtend
-      val name = "RecordExtend$" + valueType
+      val name = "RecordExtend" + JvmName.Delimiter + valueType
 
       // The type resides in the root package.
       JvmType.Reference(JvmName(RootPackage, name))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmType.scala
@@ -96,12 +96,11 @@ object JvmType {
   //
 
   val AtomicLong: JvmType.Reference = Reference(JvmName.AtomicLong)
-  val BigInteger: JvmType.Reference = Reference(JvmName.BigInteger)
+  val BigInteger: JvmType.Reference = Reference(BackendObjType.BigInt.jvmName)
   val Class: JvmType.Reference = Reference(JvmName.Class)
   val Function: JvmType.Reference = Reference(JvmName.Function)
   val Object: JvmType.Reference = Reference(JvmName.Object)
-  val String: JvmType.Reference = Reference(JvmName.String)
-  val StringBuilder: JvmType.Reference = Reference(JvmName.StringBuilder)
+  val String: JvmType.Reference = Reference(BackendObjType.String.jvmName)
 
   //
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Flix Types ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -109,7 +108,7 @@ object JvmType {
 
   val Context: JvmType.Reference = Reference(JvmName.Context)
   val ReifiedSourceLocation: JvmType.Reference = Reference(JvmName.ReifiedSourceLocation)
-  val Unit: JvmType.Reference = Reference(JvmName.Unit)
+  val Unit: JvmType.Reference = Reference(BackendObjType.Unit.jvmName)
 
   //
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Scala Types ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
part of #2591 

This PR:
```
public final class Ref$Char {
    public char value;

    public Ref$Char(char var1) {
        this.value = var1;
    }
}
```
```
public final class Ref$Obj {
    public Object value;

    public Ref$Obj(Object var1) {
        this.value = var1;
    }
}

```
Master:
```
public final class Ref$Char {
    private char value;

    public Ref$Char(char var1) {
        this.value = var1;
    }

    public char getValue() {
        return this.value;
    }

    public void setValue(char var1) {
        this.value = var1;
    }

    public final String toString() {
        throw new UnsupportedOperationException("toString method shouldn't be called");
    }

    public final int hashCode() {
        throw new UnsupportedOperationException("hashCode method shouldn't be called");
    }

    public final boolean equals(Object var1) {
        throw new UnsupportedOperationException("equals method shouldn't be called");
    }
}
```
```
public final class Ref$Obj {
    private Object value;

    public Ref$Obj(Object var1) {
        this.value = var1;
    }

    public Object getValue() {
        return this.value;
    }

    public void setValue(Object var1) {
        this.value = var1;
    }

    public final String toString() {
        throw new UnsupportedOperationException("toString method shouldn't be called");
    }

    public final int hashCode() {
        throw new UnsupportedOperationException("hashCode method shouldn't be called");
    }

    public final boolean equals(Object var1) {
        throw new UnsupportedOperationException("equals method shouldn't be called");
    }
}
```