### PR TITLE
Rewrite GenRecordEmpty to use bytecode DSL

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -88,6 +88,11 @@ object BytecodeInstructions {
     f
   }
 
+  def ATHROW(): InstructionSet = f => {
+    f.visitInstruction(Opcodes.ATHROW)
+    f
+  }
+
   def CHECKCAST(className: JvmName): InstructionSet = f => {
     f.visitTypeInstruction(Opcodes.CHECKCAST, className)
     f

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -509,14 +509,7 @@ object GenExpression {
       // We get the JvmType of the class for the RecordEmpty
       val classType = JvmOps.getRecordEmptyClassType()
       // Instantiating a new object of tuple
-      visitor.visitTypeInsn(NEW, classType.name.toInternalName)
-      // Duplicating the class
-      visitor.visitInsn(DUP)
-
-      // Descriptor of constructor
-      val constructorDescriptor = AsmOps.getMethodDescriptor(List(), JvmType.Void)
-      // Invoking the constructor
-      visitor.visitMethodInsn(INVOKESPECIAL, classType.name.toInternalName, "<init>", constructorDescriptor, false)
+      visitor.visitFieldInsn(GETSTATIC, classType.name.toInternalName, GenRecordEmpty.InstanceFieldName, classType.toDescriptor)
 
     case Expression.RecordSelect(exp, field, tpe, loc) =>
       // Adding source line number for debugging

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -509,7 +509,7 @@ object GenExpression {
       // We get the JvmType of the class for the RecordEmpty
       val classType = JvmOps.getRecordEmptyClassType()
       // Instantiating a new object of tuple
-      visitor.visitFieldInsn(GETSTATIC, classType.name.toInternalName, GenRecordEmpty.InstanceFieldName, classType.toDescriptor)
+      visitor.visitFieldInsn(GETSTATIC, classType.name.toInternalName, GenRecordEmptyClass.InstanceFieldName, classType.toDescriptor)
 
     case Expression.RecordSelect(exp, field, tpe, loc) =>
       // Adding source line number for debugging

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRecordEmpty.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRecordEmpty.scala
@@ -1,5 +1,6 @@
 /*
  * Copyright 2019 Miguel Fialho
+ * Copyright 2021 Jonathan Lindegaard Starup
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +19,9 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.ErasedAst.Root
-import org.objectweb.asm.ClassWriter
-import org.objectweb.asm.Opcodes._
+import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions.InstructionSet
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{Finality, Instancing, Visibility}
+import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor.mkDescriptor
 
 /**
   * Generates bytecode for the empty record class.
@@ -30,136 +32,49 @@ object GenRecordEmpty {
     * Returns a Map with a single entry, for the empty record class
     */
   def gen()(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
-    val interfaceType = JvmOps.getRecordInterfaceType()
-    val jvmType = JvmOps.getRecordEmptyClassType()
-    val jvmName = jvmType.name
-    val bytecode = genByteCode(jvmType, interfaceType)
-    Map(jvmName -> JvmClass(jvmName, bytecode))
+    Map(BackendObjType.RecordEmpty.jvmName -> JvmClass(BackendObjType.RecordEmpty.jvmName, genByteCode()))
   }
 
   /**
     * This method creates the class for RecordEmpty.
-    * Here, we first instantiate the visitor required to emit the code.
     *
-    * Then we create the name of the class to be generated and store the result in `className`
-    *
-    * We then define the super of this class (Object is the super here) and interfaces which this class implements
-    * (RecordEmpty).
-    * Then using super and interfaces we will create the class header.
-    *
-    * Then we precede with generating the code for constructor.The constructor doesn't receive any arguments.
-    * For example for RecordEmpty() creates the following constructor:
-    *
-    * public RecordEmpty() {}
+    * We then define the interfaces which this class implements (RecordEmpty).
     *
     * First, we will generate the `lookupField(String)` method which will always throws an exception,
     * since `lookupField` should not be called.
-    * The `lookupField` method is always the following:
     *
-    * public IRecord lookupField(String var1) throws Exception {
-    * throw new Exception("lookupField method shouldn't be called");
+    * public final IRecord lookupField(String var1) {
+    * throw new UnsupportedOperationException("lookupField method shouldn't be called");
     * }
     *
     * Afterwards, we will generate the `restrictField(String)` method which will always throws an exception, since `restrictField` should not be called.
-    * The `restrictField` method is always the following:
     *
-    * public string restrictField(String var1) throws Exception {
-    * throw new Exception("restrictField method shouldn't be called");
+    * public final IRecord restrictField(String var1) {
+    * throw new UnsupportedOperationException("restrictField method shouldn't be called");
     * }
-    *
-    * Next, we will generate the `toString()` method which will always throws an exception, since `toString` should not be called.
-    * The `toString` method is always the following:
-    *
-    * public string toString() throws Exception {
-    * throw new Exception("toString method shouldn't be called");
-    * }
-    *
-    * Then, we will generate the `hashCode()` method which will always throws an exception, since `hashCode` should not be called.
-    * The `hashCode` method is always the following:
-    *
-    * public int hashCode() throws Exception {
-    * throw new Exception("hashCode method shouldn't be called");
-    * }
-    *
-    * Finally, we generate the `equals(Obj)` method which will always throws an exception, since `equals` should not be called.
-    * The `equals` method is always the following:
-    *
-    * public boolean equals(Object var1) throws Exception {
-    * throw new Exception("equals method shouldn't be called");
-    * }
-    *
     */
-  private def genByteCode(classType: JvmType.Reference, interfaceType: JvmType.Reference)(implicit root: Root, flix: Flix): Array[Byte] = {
-    // class writer
-    val visitor = AsmOps.mkClassWriter()
+  private def genByteCode()(implicit root: Root, flix: Flix): Array[Byte] = {
+    val recordInterface = BackendObjType.RecordEmpty.interface
+    val cm = ClassMaker.mkClass(BackendObjType.RecordEmpty.jvmName, Visibility.Public, Finality.Final, interfaces = List(recordInterface))
 
-    // internal name of super
-    val superClass = JvmName.Object.toInternalName
+    cm.mkObjectConstructor(Visibility.Public)
+    cm.mkMethod(genLookupFieldMethod(), GenRecordInterfaces.LookupFieldFunctionName, mkDescriptor(BackendObjType.String.toTpe)(recordInterface.toObjTpe.toTpe), Visibility.Public, Finality.Final, Instancing.NonStatic)
+    cm.mkMethod(genRestrictFieldMethod(), GenRecordInterfaces.RestrictFieldFunctionName, mkDescriptor(BackendObjType.String.toTpe)(recordInterface.toObjTpe.toTpe), Visibility.Public, Finality.Final, Instancing.NonStatic)
 
-    // internal name of interfaces to be implemented
-    val implementedInterfaces = Array(interfaceType.name.toInternalName)
+    //    // Generate 'lookupField' method
+    //    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "lookupField",
+    //      AsmOps.getMethodDescriptor(List(JvmType.String), interfaceType),
+    //      "lookupField method shouldn't be called")
+    //
+    //    // Generate 'restrictField' method
+    //    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "restrictField",
+    //      AsmOps.getMethodDescriptor(List(JvmType.String), JvmOps.getRecordInterfaceType()),
+    //      "restrictField method shouldn't be called")
 
-    // Initialize the visitor to create a class.
-    visitor.visit(AsmOps.JavaVersion, ACC_PUBLIC + ACC_FINAL, classType.name.toInternalName, null, superClass, implementedInterfaces)
-
-    // Source of the class
-    visitor.visitSource(classType.name.toInternalName, null)
-
-    // Emit the code for the constructor
-    compileRecordEmptyConstructor(visitor)
-
-    // Generate 'lookupField' method
-    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "lookupField",
-      AsmOps.getMethodDescriptor(List(JvmType.String), interfaceType),
-      "lookupField method shouldn't be called")
-
-    // Generate 'restrictField' method
-    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "restrictField",
-      AsmOps.getMethodDescriptor(List(JvmType.String), JvmOps.getRecordInterfaceType()),
-      "restrictField method shouldn't be called")
-
-    // Generate `toString` method
-    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "toString",
-      AsmOps.getMethodDescriptor(Nil, JvmType.String),
-      "toString method shouldn't be called")
-
-    // Generate `hashCode` method
-    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "hashCode",
-      AsmOps.getMethodDescriptor(Nil, JvmType.PrimInt),
-      "hashCode method shouldn't be called")
-
-    // Generate `equals` method
-    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "equals",
-      AsmOps.getMethodDescriptor(List(JvmType.Object), JvmType.Void),
-      "equals method shouldn't be called")
-
-    visitor.visitEnd()
-    visitor.toByteArray
+    cm.closeClassMaker
   }
 
+  private def genLookupFieldMethod(): InstructionSet = ???
 
-  /**
-    * This method generates the constructor for the RecordEmpty class. This constructor doesn't receive any arguments.
-    * For example for RecordEmpty() creates the following constructor:
-    *
-    * public RecordEmpty() {}
-    */
-  def compileRecordEmptyConstructor(visitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = {
-
-    val constructor = visitor.visitMethod(ACC_PUBLIC, "<init>", AsmOps.getMethodDescriptor(Nil, JvmType.Void), null, null)
-
-    constructor.visitCode()
-    constructor.visitVarInsn(ALOAD, 0)
-
-    // Call the super (java.lang.Object) constructor
-    constructor.visitMethodInsn(INVOKESPECIAL, JvmName.Object.toInternalName, "<init>", AsmOps.getMethodDescriptor(Nil, JvmType.Void), false)
-
-    // Return
-    constructor.visitInsn(RETURN)
-
-    // Parameters of visit max are thrown away because visitor will calculate the frame and variable stack size
-    constructor.visitMaxs(65535, 65535)
-    constructor.visitEnd()
-  }
-
+  private def genRestrictFieldMethod(): InstructionSet = ???
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRecordEmptyClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRecordEmptyClass.scala
@@ -27,7 +27,7 @@ import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor.mkDescripto
 /**
   * Generates bytecode for the empty record class.
   */
-object GenRecordEmpty {
+object GenRecordEmptyClass {
 
   val InstanceFieldName: String = "INSTANCE"
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRecordInterfaces.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRecordInterfaces.scala
@@ -25,6 +25,10 @@ import org.objectweb.asm.Opcodes._
   */
 object GenRecordInterfaces {
 
+  val LookupFieldFunctionName: String = "lookupField"
+
+  val RestrictFieldFunctionName: String = "restrictField"
+
   /**
     * Returns a Map with a single entry, for the record interface
     */
@@ -57,12 +61,12 @@ object GenRecordInterfaces {
     visitor.visitSource(interfaceType.name.toInternalName, null)
 
     //Emitting a getRecordWithField method
-    val getRecordWithField = visitor.visitMethod(ACC_PUBLIC + ACC_ABSTRACT, "lookupField",
+    val getRecordWithField = visitor.visitMethod(ACC_PUBLIC + ACC_ABSTRACT, LookupFieldFunctionName,
       AsmOps.getMethodDescriptor(List(JvmType.String), interfaceType), null, null)
     getRecordWithField.visitEnd()
 
     //Emitting a restrictField method
-    val restrictField = visitor.visitMethod(ACC_PUBLIC + ACC_ABSTRACT, "restrictField",
+    val restrictField = visitor.visitMethod(ACC_PUBLIC + ACC_ABSTRACT, RestrictFieldFunctionName,
       AsmOps.getMethodDescriptor(List(JvmType.String), interfaceType), null, null)
     restrictField.visitEnd()
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -123,7 +123,7 @@ object JvmBackend extends Phase[Root, CompilationResult] {
       //
       // Generate empty record class.
       //
-      val recordEmptyClasses = GenRecordEmpty.gen()
+      val recordEmptyClasses = GenRecordEmptyClass.gen()
 
       //
       // Generate extended record classes for each (different) RecordExtend type in the program

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -275,7 +275,7 @@ object JvmOps {
   def getRecordInterfaceType()(implicit root: Root, flix: Flix): JvmType.Reference = {
 
     // The JVM name is of the form IRecord
-    val name = "IRecord"
+    val name = s"IRecord${JvmName.Delimiter}"
 
     // The type resides in the root package.
     JvmType.Reference(JvmName(RootPackage, name))


### PR DESCRIPTION
Part of #2591 
* ~~Is there any reason this is not a singleton pattern?~~ No, I've changed it
* ~~This should be called GenRecordEmptyClass according to the other files~~ Changed it

Genrated class
```
public final class RecordEmpty implements  {
    public static final RecordEmpty INSTANCE = new RecordEmpty();

    private RecordEmpty() {
    }

    public final  lookupField(String var1) {
        throw new UnsupportedOperationException("lookupField method shouldn't be called");
    }

    public final  restrictField(String var1) {
        throw new UnsupportedOperationException("restrictField method shouldn't be called");
    }
}
```