### PR TITLE
Configure Flix instance with `AnsiTerminalFormatter`

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -179,7 +179,7 @@ object Main {
     }
 
     // configure Flix and add the paths.
-    implicit val flix: Flix = new Flix()
+    val flix = new Flix()
     flix.setOptions(options)
     for (file <- cmdOpts.files) {
       val ext = file.getName.split('.').last

--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -91,24 +91,6 @@ object Main {
       xstrictmono = cmdOpts.xstrictmono
     )
 
-    // configure Flix and add the paths.
-    implicit val flix: Flix = new Flix()
-    flix.setOptions(options)
-    for (file <- cmdOpts.files) {
-      val ext = file.getName.split('.').last
-      ext match {
-        case "flix" => flix.addPath(file.toPath)
-        case "fpkg" => flix.addPath(file.toPath)
-        case "jar" => flix.addJar(file.toPath)
-        case _ =>
-          Console.println(s"Unrecognized file extension: '$ext'.")
-          System.exit(1)
-      }
-    }
-    if (Formatter.hasColorSupport)
-      flix.setFormatter(AnsiTerminalFormatter)
-
-
     // Don't use progress bar if benchmarking.
     if (cmdOpts.benchmark || cmdOpts.xbenchmarkCodeSize || cmdOpts.xbenchmarkPhases || cmdOpts.xbenchmarkThroughput) {
       options = options.copy(progress = false)
@@ -195,6 +177,23 @@ object Main {
       shell.loop()
       System.exit(0)
     }
+
+    // configure Flix and add the paths.
+    implicit val flix: Flix = new Flix()
+    flix.setOptions(options)
+    for (file <- cmdOpts.files) {
+      val ext = file.getName.split('.').last
+      ext match {
+        case "flix" => flix.addPath(file.toPath)
+        case "fpkg" => flix.addPath(file.toPath)
+        case "jar" => flix.addJar(file.toPath)
+        case _ =>
+          Console.println(s"Unrecognized file extension: '$ext'.")
+          System.exit(1)
+      }
+    }
+    if (Formatter.hasColorSupport)
+      flix.setFormatter(AnsiTerminalFormatter)
 
     // evaluate main.
     val timer = new Timer(flix.compile())

--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -179,7 +179,7 @@ object Main {
     }
 
     // configure Flix and add the paths.
-    val flix = new Flix()
+    implicit val flix: Flix = new Flix()
     flix.setOptions(options)
     for (file <- cmdOpts.files) {
       val ext = file.getName.split('.').last

--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -91,6 +91,24 @@ object Main {
       xstrictmono = cmdOpts.xstrictmono
     )
 
+    // configure Flix and add the paths.
+    implicit val flix: Flix = new Flix()
+    flix.setOptions(options)
+    for (file <- cmdOpts.files) {
+      val ext = file.getName.split('.').last
+      ext match {
+        case "flix" => flix.addPath(file.toPath)
+        case "fpkg" => flix.addPath(file.toPath)
+        case "jar" => flix.addJar(file.toPath)
+        case _ =>
+          Console.println(s"Unrecognized file extension: '$ext'.")
+          System.exit(1)
+      }
+    }
+    if (Formatter.hasColorSupport)
+      flix.setFormatter(AnsiTerminalFormatter)
+
+
     // Don't use progress bar if benchmarking.
     if (cmdOpts.benchmark || cmdOpts.xbenchmarkCodeSize || cmdOpts.xbenchmarkPhases || cmdOpts.xbenchmarkThroughput) {
       options = options.copy(progress = false)
@@ -177,23 +195,6 @@ object Main {
       shell.loop()
       System.exit(0)
     }
-
-    // configure Flix and add the paths.
-    implicit val flix: Flix = new Flix()
-    flix.setOptions(options)
-    for (file <- cmdOpts.files) {
-      val ext = file.getName.split('.').last
-      ext match {
-        case "flix" => flix.addPath(file.toPath)
-        case "fpkg" => flix.addPath(file.toPath)
-        case "jar" => flix.addJar(file.toPath)
-        case _ =>
-          Console.println(s"Unrecognized file extension: '$ext'.")
-          System.exit(1)
-      }
-    }
-    if (Formatter.hasColorSupport)
-      flix.setFormatter(AnsiTerminalFormatter)
 
     // evaluate main.
     val timer = new Timer(flix.compile())

--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -20,6 +20,7 @@ import ca.uwaterloo.flix.api.lsp.LanguageServer
 import ca.uwaterloo.flix.api.{Flix, Version}
 import ca.uwaterloo.flix.runtime.shell.Shell
 import ca.uwaterloo.flix.tools._
+import ca.uwaterloo.flix.util.Formatter.AnsiTerminalFormatter
 import ca.uwaterloo.flix.util._
 
 import java.io.{File, PrintWriter}
@@ -191,6 +192,8 @@ object Main {
           System.exit(1)
       }
     }
+    if (Formatter.hasColorSupport)
+      flix.setFormatter(AnsiTerminalFormatter)
 
     // evaluate main.
     val timer = new Timer(flix.compile())

--- a/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst.Root
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
 import ca.uwaterloo.flix.language.debug._
 import ca.uwaterloo.flix.language.phase.extra.CodeHinter
+import ca.uwaterloo.flix.util.Formatter.AnsiTerminalFormatter
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
 import ca.uwaterloo.flix.util.Validation.{Failure, Success}
 import ca.uwaterloo.flix.util._
@@ -37,7 +38,6 @@ import org.json4s.native.JsonMethods.parse
 import java.io.ByteArrayInputStream
 import java.net.InetSocketAddress
 import java.nio.charset.Charset
-import java.nio.file.Path
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.zip.ZipInputStream
@@ -289,6 +289,8 @@ class LanguageServer(port: Int) extends WebSocketServer(new InetSocketAddress("l
   private def processCheck(requestId: String)(implicit ws: WebSocket): JValue = {
     // Configure the Flix compiler.
     val flix = new Flix()
+    if (Formatter.hasColorSupport)
+      flix.setFormatter(AnsiTerminalFormatter)
 
     // Add sources.
     for ((uri, source) <- sources) {

--- a/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
@@ -21,7 +21,6 @@ import ca.uwaterloo.flix.language.ast.TypedAst.Root
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
 import ca.uwaterloo.flix.language.debug._
 import ca.uwaterloo.flix.language.phase.extra.CodeHinter
-import ca.uwaterloo.flix.util.Formatter.AnsiTerminalFormatter
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
 import ca.uwaterloo.flix.util.Validation.{Failure, Success}
 import ca.uwaterloo.flix.util._
@@ -289,8 +288,6 @@ class LanguageServer(port: Int) extends WebSocketServer(new InetSocketAddress("l
   private def processCheck(requestId: String)(implicit ws: WebSocket): JValue = {
     // Configure the Flix compiler.
     val flix = new Flix()
-    if (Formatter.hasColorSupport)
-      flix.setFormatter(AnsiTerminalFormatter)
 
     // Add sources.
     for ((uri, source) <- sources) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Reader.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reader.scala
@@ -16,15 +16,14 @@
 
 package ca.uwaterloo.flix.language.phase
 
-import java.nio.file.Files
-
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.Ast.{Input, Source}
-import ca.uwaterloo.flix.language.ast.Symbol
 import ca.uwaterloo.flix.tools.Packager
-import ca.uwaterloo.flix.util.Validation._
 import ca.uwaterloo.flix.util.Validation
+import ca.uwaterloo.flix.util.Validation._
+
+import java.nio.file.Files
 
 /**
   * A phase to read inputs into memory.

--- a/main/src/ca/uwaterloo/flix/tools/Packager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Packager.scala
@@ -175,6 +175,7 @@ object Packager {
     * Builds (compiles) the source files for the given project path `p`.
     */
   def build(p: Path, o: Options, loadClasses: Boolean = true)(implicit flix: Flix = new Flix()): Option[CompilationResult] = {
+    flix.setFormatter(AnsiTerminalFormatter)
     // Check that the path is a project path.
     if (!isProjectPath(p))
       throw new RuntimeException(s"The path '$p' does not appear to be a flix project.")


### PR DESCRIPTION
Closes #2680

I'm not sure the LSP Flix instance should configure a Formatter. It's guarded by an if-check but it should probably still not be there.