### PR TITLE
Rewrite GenRecordExtendClasses to use bytecode DSL

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -16,6 +16,8 @@
 
 package ca.uwaterloo.flix.language.phase.jvm
 
+import ca.uwaterloo.flix.language.ast.MonoType
+
 /**
   * Represents all Flix types that are not object on the JVM including Void.
   */
@@ -113,4 +115,23 @@ object BackendType {
     */
   def erasedTypes: List[BackendType] =
     Bool :: Char :: Float32 :: Float64 :: Int8 :: Int16 :: Int32 :: Int64 :: JvmName.Object.toObjTpe.toTpe :: Nil
+
+  /**
+    * Computes the erased `BackendType` based on the given `MonoType`.
+    */
+  def toErasedBackendType(tpe: MonoType): BackendType = tpe match {
+    case MonoType.Bool => Bool
+    case MonoType.Char => Char
+    case MonoType.Float32 => Float32
+    case MonoType.Float64 => Float64
+    case MonoType.Int8 => Int8
+    case MonoType.Int16 => Int16
+    case MonoType.Int32 => Int32
+    case MonoType.Int64 => Int64
+    case MonoType.Unit | MonoType.BigInt | MonoType.Str | MonoType.Array(_) | MonoType.Channel(_) |
+         MonoType.Lazy(_) | MonoType.Ref(_) | MonoType.Tuple(_) | MonoType.Enum(_, _) |
+         MonoType.Arrow(_, _) | MonoType.RecordEmpty() | MonoType.RecordExtend(_, _, _) |
+         MonoType.SchemaEmpty() | MonoType.SchemaExtend(_, _, _) | MonoType.Relation(_) |
+         MonoType.Lattice(_) | MonoType.Native(_) | MonoType.Var(_) => JvmName.Object.toObjTpe.toTpe
+  }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -159,6 +159,9 @@ object BytecodeInstructions {
   def IFEQ(cases: Boolean => InstructionSet): InstructionSet =
     branch(Opcodes.IFEQ)(cases)
 
+  def IFNE(cases: Boolean => InstructionSet): InstructionSet =
+    branch(Opcodes.IFNE)(cases)
+
   def IFNULL(cases: Boolean => InstructionSet): InstructionSet =
     branch(Opcodes.IFNULL)(cases)
 
@@ -242,7 +245,7 @@ object BytecodeInstructions {
   }
 
   def matchBool(cases: Boolean => InstructionSet): InstructionSet =
-    IFEQ(b => cases(!b))
+    IFNE(cases)
 
   def invokeConstructor(className: JvmName, descriptor: MethodDescriptor = MethodDescriptor.NothingToVoid): InstructionSet =
     INVOKESPECIAL(className, JvmName.ConstructorMethod, descriptor)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
@@ -44,7 +44,7 @@ class ClassMaker(visitor: ClassWriter) {
     * Creates a instruction set calling `<init>` on `java.lang.Object` and returns.
     */
   def mkObjectConstructor(v: Visibility): Unit = {
-    val constructor = ALOAD(0) ~ invokeConstructor(JvmName.Object, MethodDescriptor.NothingToVoid) ~ RETURN()
+    val constructor = loadThis() ~ invokeConstructor(JvmName.Object, MethodDescriptor.NothingToVoid) ~ RETURN()
     mkConstructor(constructor, MethodDescriptor.NothingToVoid, v)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -558,8 +558,6 @@ object GenExpression {
       // Invoking the constructor
       visitor.visitMethodInsn(INVOKESPECIAL, classType.name.toInternalName, "<init>", MethodDescriptor.NothingToVoid.toDescriptor, false)
 
-      //Push the required argument to call the RecordExtend constructor.
-
       //Put the label of field (which is going to be the extension).
       visitor.visitInsn(DUP)
       visitor.visitLdcInsn(field.name)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -517,7 +517,7 @@ object GenExpression {
       addSourceLine(visitor, loc)
 
       // Get the correct record extend class, given the expression type 'tpe'
-      // We get the JvmType of the extended record class to call the proper getField
+      // We get the JvmType of the extended record class to retrieve the proper field
       val classType = JvmOps.getRecordType(tpe)
 
       // We get the JvmType of the record interface
@@ -566,7 +566,7 @@ object GenExpression {
       //Put the value of the field onto the stack, since it is an expression we first need to compile it.
       visitor.visitInsn(DUP)
       compileExpression(value, visitor, currentClass, lenv0, entryPoint)
-      visitor.visitFieldInsn(PUTFIELD, classType.name.toInternalName, GenRecordExtendClasses.ValueFieldName, JvmOps.getJvmType(value.tpe).toDescriptor)
+      visitor.visitFieldInsn(PUTFIELD, classType.name.toInternalName, GenRecordExtendClasses.ValueFieldName, JvmOps.getErasedJvmType(value.tpe).toDescriptor)
 
       //Put the value of the rest of the record onto the stack, since it's an expression we need to compile it first.
       visitor.visitInsn(DUP)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenMatchErrorClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenMatchErrorClass.scala
@@ -17,6 +17,7 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions.Branch.{FalseBranch, TrueBranch}
 import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions._
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Finality._
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Instancing._
@@ -72,18 +73,18 @@ object GenMatchErrorClass {
     loadThis() ~
       ALOAD(1) ~
       IF_ACMPNE {
-        case true =>
+        case TrueBranch =>
           ALOAD(1) ~
             IFNULL {
-              case true =>
+              case TrueBranch =>
                 pushBool(false) ~ IRETURN()
-              case false =>
+              case FalseBranch =>
                 loadThis() ~
                   INVOKEVIRTUAL(JvmName.Object, "getClass", mkDescriptor()(JvmName.Class.toObjTpe.toTpe)) ~
                   ALOAD(1) ~
                   INVOKEVIRTUAL(JvmName.Object, "getClass", mkDescriptor()(JvmName.Class.toObjTpe.toTpe)) ~
                   IF_ACMPNE {
-                    case true =>
+                    case TrueBranch =>
                       ALOAD(1) ~
                         CHECKCAST(JvmName.MatchError) ~
                         ASTORE(2) ~
@@ -93,11 +94,11 @@ object GenMatchErrorClass {
                         GETFIELD(JvmName.MatchError, LocationFieldName, JvmName.ReifiedSourceLocation.toObjTpe.toTpe) ~
                         INVOKESTATIC(JvmName.Objects, "equals", mkDescriptor(JvmName.Object.toObjTpe.toTpe, JvmName.Object.toObjTpe.toTpe)(BackendType.Bool)) ~
                         IRETURN()
-                    case false =>
+                    case FalseBranch =>
                       pushBool(false) ~ IRETURN()
                   }
             }
-        case false =>
+        case FalseBranch =>
           pushBool(true) ~ IRETURN()
       }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenMatchErrorClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenMatchErrorClass.scala
@@ -51,7 +51,7 @@ object GenMatchErrorClass {
 
   private def genConstructor(): InstructionSet = {
     val stringBuilderDescriptor = mkDescriptor(BackendObjType.String.toTpe)(JvmName.StringBuilder.toObjTpe.toTpe)
-    ALOAD(0) ~
+    loadThis() ~
       NEW(JvmName.StringBuilder) ~
       DUP() ~
       invokeConstructor(JvmName.StringBuilder) ~
@@ -62,40 +62,43 @@ object GenMatchErrorClass {
       INVOKEVIRTUAL(JvmName.StringBuilder, "append", stringBuilderDescriptor) ~
       INVOKEVIRTUAL(JvmName.StringBuilder, "toString", mkDescriptor()(BackendObjType.String.toTpe)) ~
       invokeConstructor(JvmName.FlixError, mkDescriptor(BackendObjType.String.toTpe)(VoidableType.Void)) ~
-      ALOAD(0) ~
+      loadThis() ~
       ALOAD(1) ~
       PUTFIELD(JvmName.MatchError, LocationFieldName, JvmName.ReifiedSourceLocation.toObjTpe.toTpe) ~
       RETURN()
   }
 
   private def genEquals(): InstructionSet =
-    ALOAD(0) ~
+    loadThis() ~
       ALOAD(1) ~
       IF_ACMPNE {
-        ALOAD(1) ~
-          IFNULL {
-            pushBool(false) ~ IRETURN()
-          } {
-            ALOAD(0) ~
-              INVOKEVIRTUAL(JvmName.Object, "getClass", mkDescriptor()(JvmName.Class.toObjTpe.toTpe)) ~
-              ALOAD(1) ~
-              INVOKEVIRTUAL(JvmName.Object, "getClass", mkDescriptor()(JvmName.Class.toObjTpe.toTpe)) ~
-              IF_ACMPNE {
-                ALOAD(1) ~
-                  CHECKCAST(JvmName.MatchError) ~
-                  ASTORE(2) ~
-                  ALOAD(0) ~
-                  GETFIELD(JvmName.MatchError, LocationFieldName, JvmName.ReifiedSourceLocation.toObjTpe.toTpe) ~
-                  ALOAD(2) ~
-                  GETFIELD(JvmName.MatchError, LocationFieldName, JvmName.ReifiedSourceLocation.toObjTpe.toTpe) ~
-                  INVOKESTATIC(JvmName.Objects, "equals", mkDescriptor(JvmName.Object.toObjTpe.toTpe, JvmName.Object.toObjTpe.toTpe)(BackendType.Bool)) ~
-                  IRETURN()
-              } {
+        case true =>
+          ALOAD(1) ~
+            IFNULL {
+              case true =>
                 pushBool(false) ~ IRETURN()
-              }
-          }
-      } {
-        pushBool(true) ~ IRETURN()
+              case false =>
+                loadThis() ~
+                  INVOKEVIRTUAL(JvmName.Object, "getClass", mkDescriptor()(JvmName.Class.toObjTpe.toTpe)) ~
+                  ALOAD(1) ~
+                  INVOKEVIRTUAL(JvmName.Object, "getClass", mkDescriptor()(JvmName.Class.toObjTpe.toTpe)) ~
+                  IF_ACMPNE {
+                    case true =>
+                      ALOAD(1) ~
+                        CHECKCAST(JvmName.MatchError) ~
+                        ASTORE(2) ~
+                        loadThis() ~
+                        GETFIELD(JvmName.MatchError, LocationFieldName, JvmName.ReifiedSourceLocation.toObjTpe.toTpe) ~
+                        ALOAD(2) ~
+                        GETFIELD(JvmName.MatchError, LocationFieldName, JvmName.ReifiedSourceLocation.toObjTpe.toTpe) ~
+                        INVOKESTATIC(JvmName.Objects, "equals", mkDescriptor(JvmName.Object.toObjTpe.toTpe, JvmName.Object.toObjTpe.toTpe)(BackendType.Bool)) ~
+                        IRETURN()
+                    case false =>
+                      pushBool(false) ~ IRETURN()
+                  }
+            }
+        case false =>
+          pushBool(true) ~ IRETURN()
       }
 
   private def genHashCode(): InstructionSet =
@@ -103,7 +106,7 @@ object GenMatchErrorClass {
       ANEWARRAY(JvmName.Object) ~
       DUP() ~
       ICONST_0() ~
-      ALOAD(0) ~
+      loadThis() ~
       GETFIELD(JvmName.MatchError, LocationFieldName, JvmName.ReifiedSourceLocation.toObjTpe.toTpe) ~
       AASTORE() ~
       INVOKESTATIC(JvmName.Object, "hash", mkDescriptor(BackendType.Array(JvmName.Object.toObjTpe.toTpe))(BackendType.Int32)) ~

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRecordExtend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRecordExtend.scala
@@ -18,356 +18,105 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.ErasedAst.Root
-import ca.uwaterloo.flix.language.ast.MonoType
-import org.objectweb.asm.Opcodes._
-import org.objectweb.asm.{ClassWriter, Label}
+import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions._
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{Finality, Instancing, Visibility}
+import ca.uwaterloo.flix.language.phase.jvm.GenRecordInterfaces.{LookupFieldFunctionName, RestrictFieldFunctionName}
+import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor.mkDescriptor
 
-/**
-  * Generates bytecode for the extended record class.
-  */
 object GenRecordExtend {
 
+  val LabelFieldName: String = "label"
+  val ValueFieldName: String = "value"
+  val RestFieldName: String = "rest"
+
   /**
-    * Returns a Map with a single entry, for the extended record class
+    * Returns a Map with an extended record class entry for each element in `ts`.
     */
-  def gen(ts: Set[MonoType])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
+  def gen(ts: Iterable[BackendObjType.RecordExtend])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
     ts.foldLeft(Map.empty[JvmName, JvmClass]) {
-      case (macc, tpe@MonoType.RecordExtend(_, value, _)) =>
-        val interfaceType = JvmOps.getRecordInterfaceType()
-        val jvmType = JvmOps.getRecordExtendClassType(tpe)
-        val jvmName = jvmType.name
-        val valueJvmErasedType = JvmOps.getErasedJvmType(value)
-        val targs = List[JvmType](JvmType.String, valueJvmErasedType, interfaceType)
-        val bytecode = genByteCode(jvmType, interfaceType, targs, valueJvmErasedType)
-        macc + (jvmName -> JvmClass(jvmName, bytecode))
-      case (macc, _) =>
-        macc
+      case (macc, extendType) =>
+        macc + (extendType.jvmName -> JvmClass(extendType.jvmName, genByteCode(extendType)))
     }
   }
 
   /**
-    * This method creates the class for the RecordExtend.
-    * Here, we first instantiate the visitor required to emit the code.
-    *
-    * Then we create the name of the class to be generated and store the result in `className`
-    *
-    * We then define the super of this class (Object is the super here) and interfaces which this class implements
-    * (RecordExtend).
-    * Then using super and interfaces we will create the class header.
-    *
-    * Then we generate the code for each of the fields in the RecordExtend class, namely the label, value and the rest of the record
-    * with the value being specialized according to the type of RecordExtend. This is if we are generating RecordExtend$Obj
+    * This method creates a `RecordExtend$V` class with some value type `V`.
+    * This implements the record interface.
     *
     * We generate the following fields in the class:
     *
-    * private String field0;
-    * private Object field1;
-    * private IRecord field2;
+    * private String label;
+    * private V value;
+    * private IRecord rest;
     *
-    * Then we generate the code for the getField method. Simply returns this.field1
+    * The constructor just calls the object constructor so fields have to be set directly from external code.
     *
-    * Then we precede with generating the code for constructor.The constructor receives three arguments, the field label,
-    * value and the rest of the record.
-    * For example for RecordExtend$Obj(String, Object, IRecord) creates the following constructor:
+    * public RecordExtend$V() {}
     *
-    * public RecordExtend(String var1, Object var2, IRecord var3) {
-    * this.field0 = var1;
-    * this.field1 = var2;
-    * this.field2 = var3;
-    * }
-    *
-    *
-    * Then, we generate the lookupField method. The method receives one argument, the field label.
+    * We generate the lookupField method. The method receives one argument, the field label.
     * The method should check if the current record label is equal to the provided label. If it is equal it should return this
     * (The record object which has the given label). In case the provided label is not equal we recursively call lookupField on the rest of the record,
     * and return the value provided by the recursive call.
     *
-    *
-    * Afterwards, we generate the restrictField method. The method receives one argument, the field label.
-    * The method should check if the current record label is equal to the provided label. If it is equal it should return the rest of the record
-    * (field2).In case the provided label is not equal we recursively call restrictField on the rest of the record.
-    * Then we should set our 'rest' field(field2) to what was returned by the recursive call.
-    * Because we might need to update our 'rest' pointer since if the provided label is equal to the next field label,
-    * then this field should no longer be in the record. We then return 'this'.
-    *
-    *
-    * Next, we will generate the `toString()` method which will always throws an exception, since `toString` should not be called.
-    * The `toString` method is always the following:
-    *
-    * public string toString(Object var1) throws Exception {
-    * throw new Exception("toString method shouldn't be called");
-    * }
-    *
-    * Then, we will generate the `hashCode()` method which will always throws an exception, since `hashCode` should not be called.
-    * The `hashCode` method is always the following:
-    *
-    * public int hashCode(Object var1) throws Exception {
-    * throw new Exception("hashCode method shouldn't be called");
-    * }
-    *
-    * Finally, we generate the `equals(Obj)` method which will always throws an exception, since `equals` should not be called.
-    * The `equals` method is always the following:
-    *
-    * public boolean equals(Object var1) throws Exception {
-    * throw new Exception("equals method shouldn't be called");
-    * }
-    *
-    */
-  private def genByteCode(classType: JvmType.Reference, interfaceType: JvmType.Reference, targs: List[JvmType],
-                          valueJvmErasedType: JvmType)(implicit root: Root, flix: Flix): Array[Byte] = {
-    // class writer
-    val visitor = AsmOps.mkClassWriter()
-
-    // internal name of super
-    val superClass = JvmName.Object.toInternalName
-
-    // internal name of interfaces to be implemented
-    val implementedInterfaces = Array(interfaceType.name.toInternalName)
-
-    // Initialize the visitor to create a class.
-    visitor.visit(AsmOps.JavaVersion, ACC_PUBLIC + ACC_FINAL, classType.name.toInternalName, null, superClass, implementedInterfaces)
-
-    // Source of the class
-    visitor.visitSource(classType.name.toInternalName, null)
-
-    for ((field, ind) <- targs.zipWithIndex) {
-      // Name of the field
-      val fieldName = s"field$ind"
-
-      // Defining fields of the tuple
-      AsmOps.compileField(visitor, fieldName, field, isStatic = false, isPrivate = true)
-    }
-
-    //Emit the code to getField (the value of the record field)
-    AsmOps.compileGetFieldMethod(visitor, classType.name, "field1", "getField", valueJvmErasedType)
-
-    // Emit the code for the constructor
-    compileRecordExtendConstructor(visitor, classType, targs)
-
-    // Emit code for the 'lookupField' method
-    compileRecordExtendLookupField(visitor, classType)
-
-    // Emit code for the 'restrictField' method
-    compileRecordExtendRestrictField(visitor, classType)
-
-    // Generate `toString` method
-    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "toString",
-      AsmOps.getMethodDescriptor(Nil, JvmType.String),
-      "toString method shouldn't be called")
-
-    // Generate `hashCode` method
-    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "hashCode",
-      AsmOps.getMethodDescriptor(Nil, JvmType.PrimInt),
-      "hashCode method shouldn't be called")
-
-    // Generate `equals` method
-    AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "equals",
-      AsmOps.getMethodDescriptor(List(JvmType.Object), JvmType.Void),
-      "equals method shouldn't be called")
-
-    visitor.visitEnd()
-    visitor.toByteArray
-  }
-
-
-  /**
-    * This method generates the constructor for the RecordExtend class. This constructor receives three arguments, the field label,
-    * value and the rest of the record.
-    * For example for RecordExtend$Obj(String, Object, IRecord) creates the following constructor:
-    *
-    * public RecordExtend$Obj(String var1, Object var2, IRecord var3) {
-    * this.field0 = var1;
-    * this.field1 = var2;
-    * this.field2 = var3;
-    * }
-    *
-    */
-  def compileRecordExtendConstructor(visitor: ClassWriter, classType: JvmType.Reference, fields: List[JvmType])(implicit root: Root, flix: Flix): Unit = {
-
-    val constructor = visitor.visitMethod(ACC_PUBLIC, "<init>", AsmOps.getMethodDescriptor(fields, JvmType.Void), null, null)
-
-    constructor.visitCode()
-    constructor.visitVarInsn(ALOAD, 0)
-
-    // Call the super (java.lang.Object) constructor
-    constructor.visitMethodInsn(INVOKESPECIAL, JvmName.Object.toInternalName, "<init>", AsmOps.getMethodDescriptor(Nil, JvmType.Void), false)
-
-
-    var offset: Int = 1
-    //Emit code to set each of the fields to the corresponding value provided in the arguments
-    //e.g. for the first field it should emit this.field0 = var1
-    for ((field, ind) <- fields.zipWithIndex) {
-      val iLoad = AsmOps.getLoadInstruction(field)
-
-      constructor.visitVarInsn(ALOAD, 0)
-      constructor.visitVarInsn(iLoad, offset)
-      constructor.visitFieldInsn(PUTFIELD, classType.name.toInternalName, s"field$ind", field.toDescriptor)
-
-      field match {
-        case JvmType.PrimLong | JvmType.PrimDouble => offset += 2
-        case _ => offset += 1
-      }
-    }
-
-    // Return
-    constructor.visitInsn(RETURN)
-
-    // Parameters of visit max are thrown away because visitor will calculate the frame and variable stack size
-    constructor.visitMaxs(65535, 65535)
-    constructor.visitEnd()
-  }
-
-
-  /**
-    * This method generates code for the lookupField method in the RecordExtend class. The method receives one argument, the field label.
-    * The method should check if the current record label is equal to the provided label. If it is equal it should return this
-    * (The record object which has the given label). In case the provided label is not equal we recursively call lookupField on the rest of the record,
-    * and return the value provided by the recursive call.
-    *
-    */
-  def compileRecordExtendLookupField(visitor: ClassWriter, classType: JvmType.Reference)(implicit root: Root, flix: Flix): Unit = {
-
-    val interfaceType = JvmOps.getRecordInterfaceType()
-    val getRecordWithField = visitor.visitMethod(ACC_PUBLIC, "lookupField",
-      AsmOps.getMethodDescriptor(List(JvmType.String), interfaceType), null, null)
-
-    getRecordWithField.visitCode()
-
-    //Push "this" onto stack
-    getRecordWithField.visitVarInsn(ALOAD, 0)
-
-    //Push this.field0 onto the stack
-    getRecordWithField.visitFieldInsn(GETFIELD, classType.name.toInternalName, "field0", JvmType.String.toDescriptor)
-
-    //Push the function argument onto the stack
-    getRecordWithField.visitVarInsn(ALOAD, 1)
-
-    //Compare both strings on the stack using equals.
-    getRecordWithField.visitMethodInsn(INVOKEVIRTUAL, BackendObjType.String.jvmName.toInternalName,
-      "equals", AsmOps.getMethodDescriptor(List(JvmType.Object), JvmType.PrimBool), false)
-
-    //create new labels
-    val falseCase = new Label
-
-    //if the strings are equal ...
-    getRecordWithField.visitJumpInsn(IFEQ, falseCase)
-
-    //true case
-    //return this.field1
-
-    //Load 'this' onto the stack
-    getRecordWithField.visitVarInsn(ALOAD, 0)
-
-    getRecordWithField.visitInsn(ARETURN)
-
-
-    //Emit false case label
-    getRecordWithField.visitLabel(falseCase)
-
-    //false case
-    //recursively call this.field2.lookupField(var1)
-
-    //Load 'this' onto the stack
-    getRecordWithField.visitVarInsn(ALOAD, 0)
-
-    //Push this.field2 onto the stack
-    getRecordWithField.visitFieldInsn(GETFIELD, classType.name.toInternalName, "field2",
-      JvmOps.getRecordInterfaceType().toDescriptor)
-
-    //Push var1 onto the stack
-    getRecordWithField.visitVarInsn(ALOAD, 1)
-
-    //call this.field2.getField(var1)
-    getRecordWithField.visitMethodInsn(INVOKEINTERFACE, JvmOps.getRecordInterfaceType().name.toInternalName,
-      "lookupField", AsmOps.getMethodDescriptor(List(JvmType.String), interfaceType), true)
-
-
-    getRecordWithField.visitInsn(ARETURN)
-
-    getRecordWithField.visitMaxs(1, 1)
-    getRecordWithField.visitEnd()
-  }
-
-  /**
-    * This method generates code for the restrictField method in the RecordExtend class. The method receives one argument, the field label.
+    * We generate the restrictField method. The method receives one argument, the field label.
     * The method should check if the current record label is equal to the provided label. If it is equal it should return the rest of the record
     * (field2).In case the provided label is not equal we recursively call restrictField on the rest of the record.
     * Then we should set our 'rest' field(field2) to what was returned by the recursive call.
     * Because we might need to update our 'rest' pointer since if the provided label is equal to the next field label,
     * then this field should no longer be in the record. We then return 'this'.
     */
-  def compileRecordExtendRestrictField(visitor: ClassWriter, classType: JvmType.Reference)(implicit root: Root, flix: Flix): Unit = {
+  private def genByteCode(extendType: BackendObjType.RecordExtend)(implicit root: Root, flix: Flix): Array[Byte] = {
+    val cm = ClassMaker.mkClass(extendType.jvmName, Visibility.Public, Finality.Final, interfaces = List(extendType.interface))
 
-    val restrictField = visitor.visitMethod(ACC_PUBLIC, "restrictField",
-      AsmOps.getMethodDescriptor(List(JvmType.String), JvmOps.getRecordInterfaceType()), null, null)
+    cm.mkField(LabelFieldName, BackendObjType.String.toTpe, Visibility.Public, Finality.NonFinal, Instancing.NonStatic)
+    cm.mkField(ValueFieldName, extendType.value, Visibility.Public, Finality.NonFinal, Instancing.NonStatic)
+    cm.mkField(RestFieldName, extendType.interface.toObjTpe.toTpe, Visibility.Public, Finality.NonFinal, Instancing.NonStatic)
 
-    restrictField.visitCode()
+    cm.mkObjectConstructor(Visibility.Public)
 
-    //Push "this" onto stack
-    restrictField.visitVarInsn(ALOAD, 0)
+    val stringToRecordInterface = mkDescriptor(BackendObjType.String.toTpe)(extendType.interface.toObjTpe.toTpe)
+    cm.mkMethod(genLookupFieldMethod(extendType), LookupFieldFunctionName, stringToRecordInterface, Visibility.Public, Finality.Final, Instancing.NonStatic)
+    cm.mkMethod(genRestrictFieldMethod(extendType), RestrictFieldFunctionName, stringToRecordInterface, Visibility.Public, Finality.Final, Instancing.NonStatic)
 
-    //Push this.field0 onto the stack
-    restrictField.visitFieldInsn(GETFIELD, classType.name.toInternalName, "field0", JvmType.String.toDescriptor)
-
-    //Push the function argument onto the stack
-    restrictField.visitVarInsn(ALOAD, 1)
-
-    //Compare both strings on the stack using equals.
-    restrictField.visitMethodInsn(INVOKEVIRTUAL, BackendObjType.String.jvmName.toInternalName,
-      "equals", AsmOps.getMethodDescriptor(List(JvmType.Object), JvmType.PrimBool), false)
-
-    //create new labels
-    val falseCase = new Label
-
-    //if the strings are equal ...
-    restrictField.visitJumpInsn(IFEQ, falseCase)
-
-    //true case
-    //return this.field2
-
-    //Load 'this' onto the stack
-    restrictField.visitVarInsn(ALOAD, 0)
-
-    //Push this.field2 onto the stack
-    restrictField.visitFieldInsn(GETFIELD, classType.name.toInternalName, "field2", JvmOps.getRecordInterfaceType().toDescriptor)
-
-    restrictField.visitInsn(ARETURN)
-
-
-    //Emit false case label
-    restrictField.visitLabel(falseCase)
-
-    //false case
-    //this.field2 = this.field2.restrictField(var1);
-    //return this;
-
-    //Load 'this' onto the stack
-    restrictField.visitVarInsn(ALOAD, 0)
-
-    //Duplicate this as we need to set this.field2
-    restrictField.visitInsn(DUP)
-
-    //Push this.field2 onto the stack
-    restrictField.visitFieldInsn(GETFIELD, classType.name.toInternalName, "field2", JvmOps.getRecordInterfaceType().toDescriptor)
-
-    //Push var1 onto the stack
-    restrictField.visitVarInsn(ALOAD, 1)
-
-    //call this.field2.restrictField(var1)
-    restrictField.visitMethodInsn(INVOKEINTERFACE, JvmOps.getRecordInterfaceType().name.toInternalName,
-      "restrictField", AsmOps.getMethodDescriptor(List(JvmType.String), JvmOps.getRecordInterfaceType()), true)
-
-    //this.field2 = this.field2.restrictField(var1);
-    restrictField.visitFieldInsn(PUTFIELD, classType.name.toInternalName, "field2", JvmOps.getRecordInterfaceType().toDescriptor)
-
-    //push this onto the stack in order to return it.
-    restrictField.visitVarInsn(ALOAD, 0)
-
-
-    restrictField.visitInsn(ARETURN)
-
-    restrictField.visitMaxs(1, 1)
-    restrictField.visitEnd()
+    cm.closeClassMaker
   }
 
+  /**
+    * Compares the label of `this`and `ALOAD(1)` and executes the designated branch.
+    */
+  private def caseOnLabelEquality(extendType: BackendObjType.RecordExtend)(cases: Boolean => InstructionSet): InstructionSet =
+    loadThis() ~
+      GETFIELD(extendType.jvmName, LabelFieldName, BackendObjType.String.toTpe) ~
+      ALOAD(1) ~
+      INVOKEVIRTUAL(BackendObjType.String.jvmName, "equals", mkDescriptor(JvmName.Object.toObjTpe.toTpe)(BackendType.Bool)) ~
+      matchBool(cases)
+
+  private def genLookupFieldMethod(extendType: BackendObjType.RecordExtend)(implicit root: Root, flix: Flix): InstructionSet =
+    caseOnLabelEquality(extendType) {
+      case true =>
+        loadThis() ~ ARETURN()
+      case false =>
+        loadThis() ~
+          GETFIELD(extendType.jvmName, RestFieldName, extendType.interface.toObjTpe.toTpe) ~
+          ALOAD(1) ~
+          INVOKEINTERFACE(extendType.interface, LookupFieldFunctionName, mkDescriptor(BackendObjType.String.toTpe)(extendType.interface.toObjTpe.toTpe)) ~
+          ARETURN()
+    }
+
+  private def genRestrictFieldMethod(extendType: BackendObjType.RecordExtend)(implicit root: Root, flix: Flix): InstructionSet =
+    caseOnLabelEquality(extendType) {
+      case true =>
+        loadThis() ~
+          GETFIELD(extendType.jvmName, RestFieldName, extendType.interface.toObjTpe.toTpe) ~
+          ARETURN()
+      case false =>
+        loadThis() ~
+          DUP() ~
+          GETFIELD(extendType.jvmName, RestFieldName, extendType.interface.toObjTpe.toTpe) ~
+          ALOAD(1) ~
+          INVOKEINTERFACE(extendType.interface, RestrictFieldFunctionName, mkDescriptor(BackendObjType.String.toTpe)(extendType.interface.toObjTpe.toTpe)) ~
+          PUTFIELD(extendType.jvmName, RestFieldName, extendType.interface.toObjTpe.toTpe) ~
+          loadThis() ~
+          ARETURN()
+    }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRefClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRefClasses.scala
@@ -8,7 +8,7 @@ object GenRefClasses {
 
   val ValueFieldName: String = "value"
 
-  def gen(types: List[BackendObjType.Ref])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
+  def gen(types: Iterable[BackendObjType.Ref])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
     types.map { refType =>
       refType.jvmName -> JvmClass(refType.jvmName, genRefClass(refType))
     }.toMap

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -39,8 +39,9 @@ object JvmBackend extends Phase[Root, CompilationResult] {
     //
     implicit val r: Root = root
 
-    // TODO: This should be limited to those actually used
+    // TODO: These should be limited to those actually used
     val erasedRefTypes: List[BackendObjType.Ref] = BackendType.erasedTypes.map(BackendObjType.Ref)
+    val erasedExtendTypes: List[BackendObjType.RecordExtend] = BackendType.erasedTypes.map(BackendObjType.RecordExtend("TEMP", _, BackendObjType.RecordEmpty.toTpe))
 
     // Generate all classes.
     val allClasses = flix.subphase("CodeGen") {
@@ -128,7 +129,7 @@ object JvmBackend extends Phase[Root, CompilationResult] {
       //
       // Generate extended record classes for each (different) RecordExtend type in the program
       //
-      val recordExtendClasses = GenRecordExtend.gen(types)
+      val recordExtendClasses = GenRecordExtend.gen(erasedExtendTypes)
 
       //
       // Generate references classes.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -39,10 +39,6 @@ object JvmBackend extends Phase[Root, CompilationResult] {
     //
     implicit val r: Root = root
 
-    // TODO: These should be limited to those actually used
-    val erasedRefTypes: List[BackendObjType.Ref] = BackendType.erasedTypes.map(BackendObjType.Ref)
-    val erasedExtendTypes: List[BackendObjType.RecordExtend] = BackendType.erasedTypes.map(BackendObjType.RecordExtend("TEMP", _, BackendObjType.RecordEmpty.toTpe))
-
     // Generate all classes.
     val allClasses = flix.subphase("CodeGen") {
 
@@ -65,6 +61,9 @@ object JvmBackend extends Phase[Root, CompilationResult] {
       // Compute the set of types in the program.
       //
       val types = JvmOps.typesOf(root)
+
+      val erasedRefTypes: Iterable[BackendObjType.Ref] = JvmOps.getRefsOf(types)
+      val erasedExtendTypes: Iterable[BackendObjType.RecordExtend] = JvmOps.getRecordExtendsOf(types)
 
       //
       // Generate the main class.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -817,6 +817,40 @@ object JvmOps {
   }
 
   /**
+    * Returns the set of ref types in `types` without searching recursively.
+    */
+  def getRefsOf(types: Iterable[MonoType])(implicit flix: Flix, root: Root): Set[BackendObjType.Ref] =
+    types.foldLeft(Set.empty[BackendObjType.Ref]){
+      case (acc, tpe) => acc ++ getRefsOf(tpe)
+    }
+
+  /**
+    * Returns a singleton set of the appropriate ref type if `tpe` is of ref type.
+    */
+  def getRefsOf(tpe: MonoType)(implicit flix: Flix, root: Root): Set[BackendObjType.Ref] = tpe match {
+    case MonoType.Ref(tpe) => Set(BackendObjType.Ref(BackendType.toErasedBackendType(tpe)))
+    case _ => Set.empty
+  }
+
+  /**
+    * Returns the set of record extend types in `types` without searching recursively.
+    */
+  def getRecordExtendsOf(types: Iterable[MonoType])(implicit flix: Flix, root: Root): Set[BackendObjType.RecordExtend] =
+    types.foldLeft(Set.empty[BackendObjType.RecordExtend]){
+      case (acc, tpe) => acc ++ getRecordExtendsOf(tpe)
+    }
+
+  /**
+    * Returns a singleton set of the appropriate record extend type if `tpe` is of record extend type.
+    */
+  def getRecordExtendsOf(tpe: MonoType)(implicit flix: Flix, root: Root): Set[BackendObjType.RecordExtend] = tpe match {
+    case MonoType.RecordExtend(field, value, _) =>
+      // TODO: should use mono -> backend transformation on `rest`
+      Set(BackendObjType.RecordExtend(field, BackendType.toErasedBackendType(value), BackendObjType.RecordEmpty.toTpe))
+    case _ => Set.empty
+  }
+
+  /**
     * Returns the set of all instantiated types in the given AST `root`.
     *
     * This include type components. For example, if the program contains


### PR DESCRIPTION
Part of #2591
```
public final class RecordExtend$Int32 implements IRecord$ {
    public String label;
    public int value;
    public IRecord$ rest;

    public RecordExtend$Int32() {
    }

    public final IRecord$ lookupField(String var1) {
        return (IRecord$)(!this.label.equals(var1) ? this.rest.lookupField(var1) : this);
    }

    public final IRecord$ restrictField(String var1) {
        if (!this.label.equals(var1)) {
            this.rest = this.rest.restrictField(var1);
            return this;
        } else {
            return this.rest;
        }
    }
}
```