### PR TITLE
Fix printing `explain` message as `Optional`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Diagnostic.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Diagnostic.scala
@@ -29,7 +29,8 @@ object Diagnostic {
     val severity = Some(DiagnosticSeverity.from(compilationMessage.severity))
     val code = compilationMessage.kind
     val message = compilationMessage.summary
-    val fullMessage = compilationMessage.message(formatter) + compilationMessage.explain(formatter)
+    val explanation = compilationMessage.explain(formatter).getOrElse("")
+    val fullMessage = compilationMessage.message(formatter) + explanation
     Diagnostic(range, severity, Some(code), None, message, fullMessage, Nil)
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/Diagnostic.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Diagnostic.scala
@@ -21,8 +21,8 @@ import org.json4s.JsonDSL._
 import org.json4s._
 
 /**
- * Companion object for [[Diagnostic]].
- */
+  * Companion object for [[Diagnostic]].
+  */
 object Diagnostic {
   def from(compilationMessage: CompilationMessage, formatter: Formatter): Diagnostic = {
     val range = Range.from(compilationMessage.loc)
@@ -36,16 +36,16 @@ object Diagnostic {
 }
 
 /**
- * Represents a `Diagnostic` in LSP.
- *
- * @param range       The range at which the message applies.
- * @param severity    The diagnostic's severity. Can be omitted. If omitted it is up to the client to interpret diagnostics as error, warning, info or hint.
- * @param code        The diagnostic's code, which might appear in the user interface.
- * @param source      A human-readable string describing the source of this diagnostic, e.g. 'typescript' or 'super lint'.
- * @param message     The diagnostic's message.
- * @param fullMessage The full error message (non-standard).
- * @param tags        Additional metadata about the diagnostic.
- */
+  * Represents a `Diagnostic` in LSP.
+  *
+  * @param range       The range at which the message applies.
+  * @param severity    The diagnostic's severity. Can be omitted. If omitted it is up to the client to interpret diagnostics as error, warning, info or hint.
+  * @param code        The diagnostic's code, which might appear in the user interface.
+  * @param source      A human-readable string describing the source of this diagnostic, e.g. 'typescript' or 'super lint'.
+  * @param message     The diagnostic's message.
+  * @param fullMessage The full error message (non-standard).
+  * @param tags        Additional metadata about the diagnostic.
+  */
 case class Diagnostic(range: Range, severity: Option[DiagnosticSeverity], code: Option[String], source: Option[String], message: String, fullMessage: String, tags: List[DiagnosticTag]) {
   def toJSON: JValue =
     ("range" -> range.toJSON) ~

--- a/main/src/ca/uwaterloo/flix/api/lsp/Diagnostic.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Diagnostic.scala
@@ -29,7 +29,10 @@ object Diagnostic {
     val severity = Some(DiagnosticSeverity.from(compilationMessage.severity))
     val code = compilationMessage.kind
     val summary = compilationMessage.summary
-    val explanationHeading = formatter.underline("Explanation:") + System.lineSeparator()
+    val explanationHeading =
+      s"""${formatter.underline("Explanation:")}
+         |
+         |""".stripMargin
     val explanation = compilationMessage.explain(formatter).getOrElse("")
     val fullMessage = compilationMessage.message(formatter) + explanationHeading + explanation
     Diagnostic(range, severity, Some(code), None, summary, fullMessage, Nil)

--- a/main/src/ca/uwaterloo/flix/api/lsp/Diagnostic.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Diagnostic.scala
@@ -29,10 +29,9 @@ object Diagnostic {
     val severity = Some(DiagnosticSeverity.from(compilationMessage.severity))
     val code = compilationMessage.kind
     val summary = compilationMessage.summary
-    val explanation = compilationMessage.explain(formatter)
-      .map(s => System.lineSeparator() + s)
-      .getOrElse("")
-    val fullMessage = compilationMessage.message(formatter) + explanation
+    val explanationHeading = formatter.underline("Explanation:") + System.lineSeparator()
+    val explanation = compilationMessage.explain(formatter).getOrElse("")
+    val fullMessage = compilationMessage.message(formatter) + explanationHeading + explanation
     Diagnostic(range, severity, Some(code), None, summary, fullMessage, Nil)
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/Diagnostic.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Diagnostic.scala
@@ -28,10 +28,12 @@ object Diagnostic {
     val range = Range.from(compilationMessage.loc)
     val severity = Some(DiagnosticSeverity.from(compilationMessage.severity))
     val code = compilationMessage.kind
-    val message = compilationMessage.summary
-    val explanation = compilationMessage.explain(formatter).getOrElse("")
+    val summary = compilationMessage.summary
+    val explanation = compilationMessage.explain(formatter)
+      .map(s => System.lineSeparator() + s)
+      .getOrElse("")
     val fullMessage = compilationMessage.message(formatter) + explanation
-    Diagnostic(range, severity, Some(code), None, message, fullMessage, Nil)
+    Diagnostic(range, severity, Some(code), None, summary, fullMessage, Nil)
   }
 }
 

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -393,8 +393,10 @@ class Shell(initialPaths: List[Path], options: Options) {
         for (error <- errors) {
           if (options.explain) {
             val message = error.message(formatter)
-            val explanationHeading = formatter.underline("Explanation:") +
-              System.lineSeparator()
+            val explanationHeading =
+              s"""${formatter.underline("Explanation:")}
+                 |
+                 |""".stripMargin
             val explanation = error.explain(formatter)
             val msg = message + explanationHeading + explanation
             terminal.writer().print(msg)

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -389,12 +389,15 @@ class Shell(initialPaths: List[Path], options: Options) {
         }
       case Validation.Failure(errors) =>
         terminal.writer().println()
+        val formatter = flix.getFormatter
         for (error <- errors) {
           val msg = if (options.explain)
-            error.message(flix.getFormatter) +
-              error.explain(flix.getFormatter).getOrElse("")
+            error.message(formatter) +
+              error.explain(formatter)
+                .map(s => System.lineSeparator() + s)
+                .getOrElse("")
           else
-            error.message(flix.getFormatter)
+            error.message(formatter)
           terminal.writer().print(msg)
         }
         terminal.writer().println()

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -390,7 +390,11 @@ class Shell(initialPaths: List[Path], options: Options) {
       case Validation.Failure(errors) =>
         terminal.writer().println()
         for (error <- errors) {
-          val msg = if (options.explain) error.message(flix.getFormatter) + error.explain(flix.getFormatter) else error.message(flix.getFormatter)
+          val msg = if (options.explain)
+            error.message(flix.getFormatter) +
+              error.explain(flix.getFormatter).getOrElse("")
+          else
+            error.message(flix.getFormatter)
           terminal.writer().print(msg)
         }
         terminal.writer().println()

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -391,14 +391,16 @@ class Shell(initialPaths: List[Path], options: Options) {
         terminal.writer().println()
         val formatter = flix.getFormatter
         for (error <- errors) {
-          val msg = if (options.explain)
-            error.message(formatter) +
-              error.explain(formatter)
-                .map(s => System.lineSeparator() + s)
-                .getOrElse("")
-          else
-            error.message(formatter)
-          terminal.writer().print(msg)
+          if (options.explain) {
+            val message = error.message(formatter)
+            val explanationHeading = formatter.underline("Explanation:") +
+              System.lineSeparator()
+            val explanation = error.explain(formatter)
+            val msg = message + explanationHeading + explanation
+            terminal.writer().print(msg)
+          } else {
+            terminal.writer().print(error.message(formatter))
+          }
         }
         terminal.writer().println()
         terminal.writer().print(prompt)


### PR DESCRIPTION
Fixes errors messages containing a `Some(...)` or `None` at the end of an error message.

Tested as a freshly built jar in a small flix project.