### PR TITLE
Add spawn with channel

### DIFF
--- a/main/src/library/Channel.flix
+++ b/main/src/library/Channel.flix
@@ -102,6 +102,14 @@ namespace Channel {
     }
 
     ///
+    /// Spawn the function `f` and send its value on the channel returned by this function.
+    ///
+    def spawnWithChannel(f: Unit -> a & ef): Channel[a] & ef =
+        let c = chan 1;
+        spawn(c <- f());
+        c
+
+    ///
     /// Creates a new channel. A runtime error occurs if `bufferSize` is
     /// negative. A channel with `bufferSize` zero means that sending and
     /// receiving is syncronized.

--- a/main/src/library/Channel.flix
+++ b/main/src/library/Channel.flix
@@ -104,9 +104,9 @@ namespace Channel {
     ///
     /// Spawn the function `f` and send its value on the channel returned by this function.
     ///
-    def spawnWithChannel(f: Unit -> a & ef): Channel[a] & Impure =
-        let c = chan 1;
-        spawn(c <- f());
+    pub def spawnWithChannel(f: Unit -> a & ef): Channel[a] & Impure =
+        let c = chan a 1;
+        spawn c <- f();
         c
 
     ///

--- a/main/src/library/Channel.flix
+++ b/main/src/library/Channel.flix
@@ -104,7 +104,7 @@ namespace Channel {
     ///
     /// Spawn the function `f` and send its value on the channel returned by this function.
     ///
-    def spawnWithChannel(f: Unit -> a & ef): Channel[a] & ef =
+    def spawnWithChannel(f: Unit -> a & ef): Channel[a] & Impure =
         let c = chan 1;
         spawn(c <- f());
         c


### PR DESCRIPTION
Fixed #2703

Maybe we shouldn't mix "backend" functionality and "frontend" things like spawnWithChannel. Maybe we should rename `Channel.flix` to `Mpmc.flix` or something obscure and have `Channel.Flix` be nice usable things like this function? Maybe `Channels.flix` is more a la Javas `Collections`.