### PR TITLE
feat: add `CodeHint.UnsafePurityCast` and `CodeHint.Deprecated`.

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
@@ -327,8 +327,9 @@ class LanguageServer(port: Int) extends WebSocketServer(new InetSocketAddress("l
             case Success(_) =>
               // Case 1: No code hints.
               ("id" -> requestId) ~ ("status" -> "success") ~ ("time" -> e)
-            case Failure(errors) =>
+            case Failure(l) =>
               // Case 2: Code hints are available.
+              val errors = l.filter(hint => sources.contains(hint.loc.source.name))
               val results = PublishDiagnosticsParams.from(errors)
               ("id" -> requestId) ~ ("status" -> "failure") ~ ("result" -> results.map(_.toJSON))
           }

--- a/main/src/ca/uwaterloo/flix/language/errors/CodeHint.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/CodeHint.scala
@@ -29,6 +29,21 @@ trait CodeHint extends CompilationMessage {
 object CodeHint {
 
   /**
+    * A code hint that indicates a symbol is deprecated.
+    *
+    * @param loc the location of the expression.
+    */
+  case class Deprecated(loc: SourceLocation) extends CodeHint {
+    def summary: String = s"Deprecated."
+
+    override def severity: Severity = Severity.Info
+
+    def message(formatter: Formatter): String = summary
+
+    def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
     * A code hint that indicates that a purity polymorphic operation is lazy.
     *
     * @param sym the symbol of the operation that is lazy.
@@ -99,6 +114,21 @@ object CodeHint {
     */
   case class NonTrivialEffect(loc: SourceLocation) extends CodeHint {
     def summary: String = s"Expression has a non-trivial effect."
+
+    override def severity: Severity = Severity.Info
+
+    def message(formatter: Formatter): String = summary
+
+    def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+    * A code hint that indicates an unsafe cast to pure.
+    *
+    * @param loc the location of the expression.
+    */
+  case class UnsafePurityCast(loc: SourceLocation) extends CodeHint {
+    def summary: String = s"Unsafe cast to pure."
 
     override def severity: Severity = Severity.Info
 

--- a/main/src/ca/uwaterloo/flix/language/errors/CodeHint.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/CodeHint.scala
@@ -29,7 +29,7 @@ trait CodeHint extends CompilationMessage {
 object CodeHint {
 
   /**
-    * A code hint that indicates a symbol is deprecated.
+    * A code hint that indicates a deprecation.
     *
     * @param loc the location of the expression.
     */

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1934,10 +1934,10 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
       case args =>
         past.ident.name match {
           case "benchmark" => WeededAst.Annotation(Ast.Annotation.Benchmark(loc), args, loc).toSuccess
-          case "deprecated" => WeededAst.Annotation(Ast.Annotation.Deprecated(loc), args, loc).toSuccess
           case "law" => WeededAst.Annotation(Ast.Annotation.Law(loc), args, loc).toSuccess
           case "lint" => WeededAst.Annotation(Ast.Annotation.Lint(loc), args, loc).toSuccess
           case "test" => WeededAst.Annotation(Ast.Annotation.Test(loc), args, loc).toSuccess
+          case "Deprecated" => WeededAst.Annotation(Ast.Annotation.Deprecated(loc), args, loc).toSuccess
           case "LazyWhenPure" => WeededAst.Annotation(Ast.Annotation.LazyWhenPure(loc), args, loc).toSuccess
           case "ParallelWhenPure" => WeededAst.Annotation(Ast.Annotation.ParallelWhenPure(loc), args, loc).toSuccess
           case "Time" => WeededAst.Annotation(Ast.Annotation.Time(loc), args, loc).toSuccess

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase.extra
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.{Body, Head}
 import ca.uwaterloo.flix.language.ast.TypedAst._
-import ca.uwaterloo.flix.language.ast.{Ast, SourceLocation, Symbol, Type, TypedAst}
+import ca.uwaterloo.flix.language.ast.{Ast, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.errors.CodeHint
 import ca.uwaterloo.flix.util.Validation
 import ca.uwaterloo.flix.util.Validation._
@@ -51,9 +51,10 @@ object CodeHinter {
 
     case Expression.Var(_, _, _) => Nil
 
-    case Expression.Def(_, _, _) => Nil
+    case Expression.Def(sym, _, loc) =>
+      checkDeprecated(sym, loc)
 
-    case Expression.Sig(_, _, _) => Nil
+    case Expression.Sig(sym, _, loc) => Nil
 
     case Expression.Hole(_, _, _) => Nil
 
@@ -85,7 +86,7 @@ object CodeHinter {
 
     case Expression.Default(_, _) => Nil
 
-    case Expression.Lambda(_, exp, _, _) =>
+    case Expression.Lambda(fparam, exp, _, _) =>
       checkEffect(exp.eff, exp.loc) ++ visitExp(exp)
 
     case Expression.Apply(exp, exps, _, eff, loc) =>
@@ -172,8 +173,8 @@ object CodeHinter {
     case Expression.Ascribe(exp, _, _, _) =>
       visitExp(exp)
 
-    case Expression.Cast(exp, _, _, _) =>
-      visitExp(exp)
+    case Expression.Cast(exp, tpe, eff, loc) =>
+      checkCast(tpe, eff, loc) ++ visitExp(exp)
 
     case Expression.TryCatch(exp, rules, _, _, _) =>
       visitExp(exp) ++ rules.flatMap {
@@ -253,6 +254,12 @@ object CodeHinter {
   }
 
   /**
+    * Computes code quality hints for the given list of expressions `exps`.
+    */
+  private def visitExps(exps: List[Expression])(implicit root: Root): List[CodeHint] =
+    exps.flatMap(visitExp)
+
+  /**
     * Computes code quality hints for the given constraint `c`.
     */
   private def visitConstraint(c: Constraint)(implicit root: Root): List[CodeHint] =
@@ -272,12 +279,6 @@ object CodeHinter {
     case Body.Atom(_, _, _, _, _, _) => Nil
     case Body.Guard(exp, _) => visitExp(exp)
   }
-
-  /**
-    * Computes code quality hints for the given list of expressions `exps`.
-    */
-  private def visitExps(exps: List[Expression])(implicit root: Root): List[CodeHint] =
-    exps.flatMap(visitExp)
 
   /**
     * Checks whether `sym` would benefit from `tpe` being pure.
@@ -326,6 +327,29 @@ object CodeHinter {
       CodeHint.NonTrivialEffect(loc) :: Nil
     } else {
       Nil
+    }
+  }
+
+  /**
+    * Checks whether the given definition symbol `sym` is deprecated.
+    */
+  private def checkDeprecated(sym: Symbol.DefnSym, loc: SourceLocation)(implicit root: Root): List[CodeHint] = {
+    val defn = root.defs(sym)
+    val isDeprecated = defn.spec.ann.exists(ann => ann.name.isInstanceOf[Ast.Annotation.Deprecated])
+    if (isDeprecated) {
+      CodeHint.Deprecated(loc) :: Nil
+    } else {
+      Nil
+    }
+  }
+
+  /**
+    * Checks whether a cast to the given `tpe` and `eff` is an unsafe purity cast.
+    */
+  private def checkCast(tpe: Type, eff: Type, loc: SourceLocation): List[CodeHint] = {
+    eff.typeConstructor match {
+      case Some(TypeConstructor.True) => CodeHint.UnsafePurityCast(eff.loc) :: Nil
+      case _ => Nil
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -54,7 +54,7 @@ object CodeHinter {
     case Expression.Def(sym, _, loc) =>
       checkDeprecated(sym, loc)
 
-    case Expression.Sig(sym, _, loc) => Nil
+    case Expression.Sig(_, _, _) => Nil
 
     case Expression.Hole(_, _, _) => Nil
 
@@ -86,7 +86,7 @@ object CodeHinter {
 
     case Expression.Default(_, _) => Nil
 
-    case Expression.Lambda(fparam, exp, _, _) =>
+    case Expression.Lambda(_, exp, _, _) =>
       checkEffect(exp.eff, exp.loc) ++ visitExp(exp)
 
     case Expression.Apply(exp, exps, _, eff, loc) =>


### PR DESCRIPTION
Fixes #2719