### PR TITLE
fix: copy closure objects before invocation

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenClosureAbstractClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenClosureAbstractClasses.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.ErasedAst.Root
+import ca.uwaterloo.flix.language.ast.MonoType
+import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes._
+
+object GenClosureAbstractClasses {
+
+  val GetUniqueThreadClosureFunctionName: String = "getUniqueThreadClosure"
+
+
+  /**
+    * Returns the set of function abstract classes for the given set of types `ts`.
+    */
+  def gen(ts: Set[MonoType])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
+    ts.foldLeft(Map.empty[JvmName, JvmClass]) {
+      case (macc, tpe: MonoType.Arrow) =>
+        // Case 1: The type constructor is an arrow type.
+        // Construct the functional interface.
+        val clazz = genClosureAbstractClass(tpe)
+        macc + (clazz.name -> clazz)
+      case (macc, _) =>
+        // Case 2: The type constructor is a non-arrow.
+        // Nothing to be done. Return the map.
+        macc
+    }
+  }
+
+  private def genClosureAbstractClass(tpe: MonoType.Arrow)(implicit root: Root, flix: Flix): JvmClass = {
+    // (Int, String) -> Bool example:
+    // public abstract class Clo2$Int$Obj$Bool extends Fn2$Int$Obj$Bool {
+    //   public Clo2$Int$Obj$Bool() { ... }
+    //   public abstract Clo2$Int$Obj$Bool getUniqueThreadClosure();
+    // }
+
+    val classType = JvmOps.getClosureAbstractClassType(tpe)
+    val superClass = JvmOps.getFunctionInterfaceType(tpe)
+    val cw = AsmOps.mkClassWriter()
+    cw.visit(AsmOps.JavaVersion, ACC_PUBLIC + ACC_ABSTRACT, classType.name.toInternalName, null, superClass.name.toInternalName, null)
+
+    genConstructor(cw, superClass)
+
+    cw.visitMethod(ACC_PUBLIC + ACC_ABSTRACT, GetUniqueThreadClosureFunctionName, AsmOps.getMethodDescriptor(Nil, classType), null, null)
+
+    cw.visitEnd()
+
+    // `JvmClass` of the interface
+    JvmClass(classType.name, cw.toByteArray)
+  }
+
+  private def genConstructor(cw: ClassWriter, superClass: JvmType.Reference): Unit = {
+    val m = cw.visitMethod(ACC_PUBLIC, JvmName.ConstructorMethod, MethodDescriptor.NothingToVoid.toDescriptor, null, null)
+    m.visitCode()
+
+    m.visitIntInsn(ALOAD, 0)
+    m.visitMethodInsn(INVOKESPECIAL, superClass.name.toInternalName, JvmName.ConstructorMethod, MethodDescriptor.NothingToVoid.toDescriptor, false)
+    m.visitInsn(RETURN)
+
+    m.visitMaxs(999, 999)
+    m.visitEnd()
+  }
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -126,9 +126,12 @@ object GenExpression {
     case Expression.ApplyClo(exp, args, tpe, _) =>
       // Type of the function abstract class
       val functionInterface = JvmOps.getFunctionInterfaceType(exp.tpe)
+      val closureAbstractClass = JvmOps.getClosureAbstractClassType(exp.tpe)
       compileExpression(exp, visitor, currentClass, lenv0, entryPoint)
-      // Casting to JvmType of FunctionInterface
-      visitor.visitTypeInsn(CHECKCAST, functionInterface.name.toInternalName)
+      // Casting to JvmType of closure abstract class
+      visitor.visitTypeInsn(CHECKCAST, closureAbstractClass.name.toInternalName)
+      // retrieving the unique thread object
+      visitor.visitMethodInsn(INVOKEVIRTUAL, closureAbstractClass.name.toInternalName, GenClosureAbstractClasses.GetUniqueThreadClosureFunctionName, AsmOps.getMethodDescriptor(Nil, closureAbstractClass), false)
       // Putting args on the Fn class
       for ((arg, i) <- args.zipWithIndex) {
         // Duplicate the FunctionInterface
@@ -167,10 +170,13 @@ object GenExpression {
     case Expression.ApplyCloTail(exp, args, _, _) =>
       // Type of the function abstract class
       val functionInterface = JvmOps.getFunctionInterfaceType(exp.tpe)
+      val closureAbstractClass = JvmOps.getClosureAbstractClassType(exp.tpe)
       // Evaluating the closure
       compileExpression(exp, visitor, currentClass, lenv0, entryPoint)
-      // Casting to JvmType of FunctionInterface
-      visitor.visitTypeInsn(CHECKCAST, functionInterface.name.toInternalName)
+      // Casting to JvmType of closure abstract class
+      visitor.visitTypeInsn(CHECKCAST, closureAbstractClass.name.toInternalName)
+      // retrieving the unique thread object
+      visitor.visitMethodInsn(INVOKEVIRTUAL, closureAbstractClass.name.toInternalName, GenClosureAbstractClasses.GetUniqueThreadClosureFunctionName, AsmOps.getMethodDescriptor(Nil, closureAbstractClass), false)
       // Putting args on the Fn class
       for ((arg, i) <- args.zipWithIndex) {
         // Duplicate the FunctionInterface

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -92,6 +92,11 @@ object JvmBackend extends Phase[Root, CompilationResult] {
       val functionClasses = GenFunctionClasses.gen(root.defs)
 
       //
+      // Generate closure abstract classes for each function in the program.
+      //
+      val closureAbstractClasses = GenClosureAbstractClasses.gen(types)
+
+      //
       // Generate closure classes for each closure in the program.
       //
       val closureClasses = GenClosureClasses.gen(closures)
@@ -175,6 +180,7 @@ object JvmBackend extends Phase[Root, CompilationResult] {
         continuationInterfaces,
         functionInterfaces,
         functionClasses,
+        closureAbstractClasses,
         closureClasses,
         enumInterfaces,
         tagClasses,


### PR DESCRIPTION
every closure call invokes `getUniqueThreadClosure` and operates on that. An abstract class between specific closure classes and the abstract function class is added that declares this method abstractly (fixes #2741).