### PR TITLE
fix: make interpolation parsing strict

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -618,7 +618,7 @@ object WeederError {
 
     def explain(formatter: Formatter): Option[String] = Some({
       import formatter._
-      s"${underline("Tip:")}" + " The valid escape sequences are '\\t', '\\\\', '\\\'', '\\\"', '\\n', and '\\r'."
+      s"${underline("Tip:")}" + " The valid escape sequences are '\\t', '\\\\', '\\\'', '\\\"', '\\${', '\\n', and '\\r'."
     })
 
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -361,7 +361,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     // Note that outside of patterns, Strings are parsed as [[Interpolation]]s
     def Str: Rule1[ParsedAst.Literal.Str] = rule {
-      SP ~ "\"" ~ zeroOrMore(!"\"" ~ Chars.CharCode) ~ "\"" ~ SP ~> ParsedAst.Literal.Str
+      SP ~ "\"" ~ zeroOrMore(!("\"" | atomic("${")) ~ Chars.CharCode) ~ "\"" ~ SP ~> ParsedAst.Literal.Str
     }
 
     def Float: Rule1[ParsedAst.Literal] = rule {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -341,4 +341,22 @@ class TestParser extends FunSuite with TestUtils {
     expectError[ParseError](result)
   }
 
+  test("ParseError.Interpolation.01") {
+    val input = s"""pub def foo(): String = "$${""""
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ParseError](result)
+  }
+
+  test("ParseError.Interpolation.02") {
+    val input = s"""pub def foo(): String = "$${1 + }""""
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ParseError](result)
+  }
+
+  test("ParseError.Interpolation.03") {
+    val input = s"""pub def foo(): String = "$${1 + {2}""""
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ParseError](result)
+  }
+
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -521,4 +521,16 @@ class TestWeeder extends FunSuite with TestUtils {
     val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.EmptyInterpolatedExpression](result)
   }
+
+  test("HalfInterpolationEscape.01") {
+    val input = "def f(): String = \"${}\""
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.EmptyInterpolatedExpression](result)
+  }
+
+  test("HalfInterpolationEscape.02") {
+    val input = s"""pub def foo(): String = "\\$$ {""""
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.InvalidEscapeSequence](result)
+  }
 }

--- a/main/test/ca/uwaterloo/flix/library/TestString.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestString.flix
@@ -3334,5 +3334,22 @@ def stripSuffix06(): Bool = String.stripSuffix({substr = "def"}, "abcdef") == So
 @test
 def stripSuffix07(): Bool = String.stripPrefix({substr = "abc"}, "ABCDEF") == None
 
+/////////////////////////////////////////////////////////////////////////////
+// escapeInterpolation                                                     //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def escapeInterpolation01(): Bool = "\${" == ("$" + "{")
+
+@test
+def escapeInterpolation02(): Bool = "\${1 + {2}" == ("$" + "{1 + {2}")
+
+@test
+def escapeInterpolation03(): Bool = "\${}" == ("$" + "{}")
+
+@test
+def escapeInterpolation04(): String = "$"
+
+
 }
 


### PR DESCRIPTION
Causes any string containing `${` to be considered an interpolation (which means that it doesn't fall back to reading it as a string). You can avoid this with `\${` (`\$` is an illegal escape) (fixes #2798).

Examples:
code | behaviour 
--- | ---
`"\$"` | illegal escape sequence
`"${"` | parsing error: expected <expression things> not "
`"$"` | just the string `$`
`"${f(Map#{}}"` | parsing error: did not expect `}`
`"\${"` | the string `${`