### PR TITLE
docs: Fix examples with the static method invokation

### DIFF
--- a/examples/select-with-defaults-and-timers.flix
+++ b/examples/select-with-defaults-and-timers.flix
@@ -1,6 +1,6 @@
 /// Sends the value `x` on the channel `c` after a delay.
 def slow(x: Int32, c: Channel[Int32]): Unit & Impure =
-    import static java.lang.Thread.sleep(Int64);
+    import java.lang.Thread:sleep(Int64);
     sleep(Duration.oneMinute() / 1_000_000i64);
     c <- x;
     ()

--- a/examples/using-laziness-for-logging.flix
+++ b/examples/using-laziness-for-logging.flix
@@ -1,6 +1,6 @@
 /// Emulates some slow computation.
 def slowFunction(): String = {
-    import static java.lang.Thread.sleep(Int64);
+    import java.lang.Thread:sleep(Int64);
     let _ = sleep(5000i64) as & Pure;
     Int32.toString(42)
 }


### PR DESCRIPTION
When I built examples with Flix v0.25.0, I found two compilation errors:

```
-- Parse Error -------------------------------------------------- 
C:\Users\kengo\github\flix-playground\src\main\flix\using-laziness-for-logging.flix

     >> Parse Error:

     Invalid input "static j", expected '=', Constructor, Method, StaticMethod, GetField, PutField, GetStaticField, PutStaticField, ':', "->", '[', '.', "::" or ":::" (line 3, column 12):
         import static java.lang.Thread.sleep(Int64);
                ^
```
```
-- Parse Error -------------------------------------------------- 
C:\Users\kengo\github\flix-playground\src\main\f
     >> Parse Error:

     Invalid input "static j", expected Constructor, Method, StaticMethod, GetField, PutField, GetStaticField, PutStaticField, ':', "->", '[', '.', "::", ":::", "as" or Op (line 3, column 12):
         import static java.lang.Thread.sleep(Int64);
                ^
```

According to https://doc.flix.dev/interoperability/ the latest way to invoke static methods is `fqcn:methodName(arguments)`.
I applied these changes in local, then these compilation messages disappeared. 