### PR TITLE
feat: allow type/eff casts/ascriptions on imports

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1674,7 +1674,7 @@ object ParsedAst {
       * @param sig   the types of the formal parameters.
       * @param ident the name given to the imported constructor.
       */
-    case class Constructor(fqn: Seq[String], sig: Seq[ParsedAst.Type], ident: Name.Ident) extends JvmOp
+    case class Constructor(fqn: Seq[String], sig: Seq[ParsedAst.Type], tpe: Option[Type], eff: Option[Type], ident: Name.Ident) extends JvmOp
 
     /**
       * Method Invocation.
@@ -1683,7 +1683,7 @@ object ParsedAst {
       * @param sig   the types of the formal parameters.
       * @param ident the optional name given to the imported method.
       */
-    case class Method(fqn: Seq[String], sig: Seq[ParsedAst.Type], ident: Option[Name.Ident]) extends JvmOp
+    case class Method(fqn: Seq[String], sig: Seq[ParsedAst.Type], tpe: Option[Type], eff: Option[Type], ident: Option[Name.Ident]) extends JvmOp
 
     /**
       * Static Method Invocation.
@@ -1692,7 +1692,7 @@ object ParsedAst {
       * @param sig   the declared types of the formal parameters.
       * @param ident the optional name given to the imported method.
       */
-    case class StaticMethod(fqn: Seq[String], sig: Seq[ParsedAst.Type], ident: Option[Name.Ident]) extends JvmOp
+    case class StaticMethod(fqn: Seq[String], sig: Seq[ParsedAst.Type], tpe: Option[Type], eff: Option[Type], ident: Option[Name.Ident]) extends JvmOp
 
     /**
       * Get Object Field.
@@ -1700,7 +1700,7 @@ object ParsedAst {
       * @param fqn   the fully-qualified name of the field.
       * @param ident the name given to the imported field.
       */
-    case class GetField(fqn: Seq[String], ident: Name.Ident) extends JvmOp
+    case class GetField(fqn: Seq[String], tpe: Option[Type], eff: Option[Type], ident: Name.Ident) extends JvmOp
 
     /**
       * Put ObjectField.
@@ -1708,7 +1708,7 @@ object ParsedAst {
       * @param fqn   the fully-qualified name of the field.
       * @param ident the name given to the imported field.
       */
-    case class PutField(fqn: Seq[String], ident: Name.Ident) extends JvmOp
+    case class PutField(fqn: Seq[String], tpe: Option[Type], eff: Option[Type], ident: Name.Ident) extends JvmOp
 
     /**
       * Get Static Field.
@@ -1716,7 +1716,7 @@ object ParsedAst {
       * @param fqn   the fully-qualified name of the field.
       * @param ident the name given to the imported field.
       */
-    case class GetStaticField(fqn: Seq[String], ident: Name.Ident) extends JvmOp
+    case class GetStaticField(fqn: Seq[String], tpe: Option[Type], eff: Option[Type], ident: Name.Ident) extends JvmOp
 
     /**
       * Put Static Field.
@@ -1724,7 +1724,7 @@ object ParsedAst {
       * @param fqn   the fully-qualified name of the field.
       * @param ident the name given to the imported field.
       */
-    case class PutStaticField(fqn: Seq[String], ident: Name.Ident) extends JvmOp
+    case class PutStaticField(fqn: Seq[String], tpe: Option[Type], eff: Option[Type], ident: Name.Ident) extends JvmOp
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -693,35 +693,39 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     def LetImport: Rule1[ParsedAst.Expression] = {
 
       def Constructor: Rule1[ParsedAst.JvmOp] = rule {
-        keyword("new") ~ WS ~ Names.JavaName ~ optWS ~ Signature ~ WS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.Constructor
+        keyword("new") ~ WS ~ Names.JavaName ~ optWS ~ Signature ~ optWS ~ OptAscription ~ optWS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.Constructor
       }
 
       def Method: Rule1[ParsedAst.JvmOp] = rule {
-        Names.JavaName ~ optWS ~ Signature ~ optional(WS ~ keyword("as") ~ WS ~ Names.Variable) ~> ParsedAst.JvmOp.Method
+        Names.JavaName ~ optWS ~ Signature ~ optWS ~ OptAscription ~ optional(WS ~ keyword("as") ~ WS ~ Names.Variable) ~> ParsedAst.JvmOp.Method
       }
 
       def StaticMethod: Rule1[ParsedAst.JvmOp] = rule {
-        keyword("static") ~ WS ~ Names.JavaName ~ optWS ~ Signature ~ optional(WS ~ keyword("as") ~ WS ~ Names.Variable) ~> ParsedAst.JvmOp.StaticMethod
+        keyword("static") ~ WS ~ Names.JavaName ~ optWS ~ Signature ~ optWS ~ OptAscription ~ optional(WS ~ keyword("as") ~ WS ~ Names.Variable) ~> ParsedAst.JvmOp.StaticMethod
       }
 
       def GetField: Rule1[ParsedAst.JvmOp] = rule {
-        keyword("get") ~ WS ~ Names.JavaName ~ WS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.GetField
+        keyword("get") ~ WS ~ Names.JavaName ~ optWS ~ OptAscription ~ optWS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.GetField
       }
 
       def PutField: Rule1[ParsedAst.JvmOp] = rule {
-        keyword("set") ~ WS ~ Names.JavaName ~ WS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.PutField
+        keyword("set") ~ WS ~ Names.JavaName ~ optWS ~ OptAscription ~ optWS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.PutField
       }
 
       def GetStaticField: Rule1[ParsedAst.JvmOp] = rule {
-        keyword("static") ~ WS ~ keyword("get") ~ WS ~ Names.JavaName ~ WS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.GetStaticField
+        keyword("static") ~ WS ~ keyword("get") ~ WS ~ Names.JavaName ~ optWS ~ OptAscription ~ optWS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.GetStaticField
       }
 
       def PutStaticField: Rule1[ParsedAst.JvmOp] = rule {
-        keyword("static") ~ WS ~ keyword("set") ~ WS ~ Names.JavaName ~ WS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.PutStaticField
+        keyword("static") ~ WS ~ keyword("set") ~ WS ~ Names.JavaName ~ optWS ~ OptAscription ~ optWS ~ keyword("as") ~ WS ~ Names.Variable ~> ParsedAst.JvmOp.PutStaticField
       }
 
       def Signature: Rule1[Seq[ParsedAst.Type]] = rule {
         "(" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")"
+      }
+
+      def OptAscription: Rule2[Option[ParsedAst.Type], Option[ParsedAst.Type]] = rule {
+        (":" ~ optWS ~ TypAndEffFragment) | (push(None: Option[ParsedAst.Type]) ~ push(None: Option[ParsedAst.Type]))
       }
 
       def Import: Rule1[ParsedAst.JvmOp] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -697,11 +697,11 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       }
 
       def Method: Rule1[ParsedAst.JvmOp] = rule {
-        Names.JavaName ~ optWS ~ Signature ~ optWS ~ OptAscription ~ optional(WS ~ keyword("as") ~ WS ~ Names.Variable) ~> ParsedAst.JvmOp.Method
+        Names.JavaName ~ optWS ~ Signature ~ optWS ~ OptAscription ~ optional(optWS ~ keyword("as") ~ WS ~ Names.Variable) ~> ParsedAst.JvmOp.Method
       }
 
       def StaticMethod: Rule1[ParsedAst.JvmOp] = rule {
-        keyword("static") ~ WS ~ Names.JavaName ~ optWS ~ Signature ~ optWS ~ OptAscription ~ optional(WS ~ keyword("as") ~ WS ~ Names.Variable) ~> ParsedAst.JvmOp.StaticMethod
+        keyword("static") ~ WS ~ Names.JavaName ~ optWS ~ Signature ~ optWS ~ OptAscription ~ optional(optWS ~ keyword("as") ~ WS ~ Names.Variable) ~> ParsedAst.JvmOp.StaticMethod
       }
 
       def GetField: Rule1[ParsedAst.JvmOp] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -726,7 +726,8 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
               }
 
               // Assemble the lambda expression.
-              val lambdaBody = WeededAst.Expression.InvokeConstructor(className, as, ts, loc)
+              val call = WeededAst.Expression.InvokeConstructor(className, as, ts, loc)
+              val lambdaBody = WeededAst.Expression.Cast(call, tpe, eff, loc)
               val e1 = mkCurried(fs, lambdaBody, loc)
               WeededAst.Expression.Let(ident, Ast.Modifiers.Empty, e1, e2, loc)
           }
@@ -816,7 +817,8 @@ object Weeder extends Phase[ParsedAst.Program, WeededAst.Program] {
               }
 
               // Assemble the lambda expression.
-              val lambdaBody = WeededAst.Expression.InvokeStaticMethod(className, methodName, as, ts, loc)
+              val call = WeededAst.Expression.InvokeStaticMethod(className, methodName, as, ts, loc)
+              val lambdaBody = WeededAst.Expression.Cast(call, tpe, eff, loc)
               val e1 = mkCurried(fs, lambdaBody, loc)
               WeededAst.Expression.Let(ident, Ast.Modifiers.Empty, e1, e2, loc)
           }

--- a/main/test/flix/Test.Exp.Jvm.GetField.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetField.flix
@@ -70,4 +70,11 @@ namespace Test/Exp/Jvm/GetField {
         let o = newObject();
         getField(o) == "Hello World"
 
+    @test
+    def testGetObjectField01(): ##java.lang.Object & Impure =
+        import new flix.test.TestClass() as newObject;
+        import get flix.test.TestClass.stringField: ##java.lang.Object as getField;
+        let o = newObject();
+        getField(o)
+
 }

--- a/main/test/flix/Test.Exp.Jvm.GetField.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetField.flix
@@ -63,4 +63,11 @@ namespace Test/Exp/Jvm/GetField {
         let o = newObject();
         getField(o) == "Hello World"
 
+    @test
+    def testGetPureField01(): Bool =
+        import new flix.test.TestClass(): _ & Pure as newObject;
+        import get flix.test.TestClass.stringField: _ & Pure as getField;
+        let o = newObject();
+        getField(o) == "Hello World"
+
 }

--- a/main/test/flix/Test.Exp.Jvm.GetFieldDoubleNestedClass.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetFieldDoubleNestedClass.flix
@@ -69,4 +69,11 @@ namespace Test/Exp/Jvm/GetFieldDoubleNestedClass {
         import get flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.stringField: & Pure as getField;
         let o: ##flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
         getField(o) == "Hello World"
+
+    @test
+    def testGetObjectField01(): ##java.lang.Object & Impure =
+        import new flix.test.TestClass$_StaticNestedClass$DoubleNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.stringField: ##java.lang.Object as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        getField(o)
 }

--- a/main/test/flix/Test.Exp.Jvm.GetFieldDoubleNestedClass.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetFieldDoubleNestedClass.flix
@@ -63,4 +63,10 @@ namespace Test/Exp/Jvm/GetFieldDoubleNestedClass {
         let o: ##flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
         getField(o) == "Hello World"
 
+    @test
+    def testGetPureField01(): Bool =
+        import new flix.test.TestClass$_StaticNestedClass$DoubleNestedClass(): _ & Pure as newObject;
+        import get flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.stringField: & Pure as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        getField(o) == "Hello World"
 }

--- a/main/test/flix/Test.Exp.Jvm.GetFieldStaticInnerClass.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetFieldStaticInnerClass.flix
@@ -69,4 +69,11 @@ namespace Test/Exp/Jvm/GetFieldStaticInnerClass {
         import get flix.test.TestClass$_StaticNestedClass.stringField: _ & Pure as getField;
         let o: ##flix.test.TestClass$_StaticNestedClass = newObject();
         getField(o) == "Hello World"
+
+    @test
+    def testGetObjectField01(): ##java.lang.Object & Impure =
+        import new flix.test.TestClass$_StaticNestedClass() as newObject;
+        import get flix.test.TestClass$_StaticNestedClass.stringField: ##java.lang.Object as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass = newObject();
+        getField(o)
 }

--- a/main/test/flix/Test.Exp.Jvm.GetFieldStaticInnerClass.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetFieldStaticInnerClass.flix
@@ -63,4 +63,10 @@ namespace Test/Exp/Jvm/GetFieldStaticInnerClass {
         let o: ##flix.test.TestClass$_StaticNestedClass = newObject();
         getField(o) == "Hello World"
 
+    @test
+    def testGetPureField01(): Bool =
+        import new flix.test.TestClass$_StaticNestedClass(): _ & Pure as newObject;
+        import get flix.test.TestClass$_StaticNestedClass.stringField: _ & Pure as getField;
+        let o: ##flix.test.TestClass$_StaticNestedClass = newObject();
+        getField(o) == "Hello World"
 }

--- a/main/test/flix/Test.Exp.Jvm.GetStaticField.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetStaticField.flix
@@ -88,4 +88,8 @@ namespace Test/Exp/Jvm/GetStaticField {
         import static get flix.test.TestClass.STRING_FIELD as getField;
         getField() == "Hello World"
 
+    @test
+    def testGetStaticPureField01(): Bool =
+        import static get flix.test.TestClass.STRING_FIELD: _ & Pure as getField;
+        getField() == "Hello World"
 }

--- a/main/test/flix/Test.Exp.Jvm.GetStaticField.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetStaticField.flix
@@ -92,4 +92,10 @@ namespace Test/Exp/Jvm/GetStaticField {
     def testGetStaticPureField01(): Bool =
         import static get flix.test.TestClass.STRING_FIELD: _ & Pure as getField;
         getField() == "Hello World"
+
+    @test
+    def testGetStaticObjectField01(): ##java.lang.Object & Impure =
+        import static get flix.test.TestClass.STRING_FIELD: ##java.lang.Object as getField;
+        getField()
+
 }

--- a/main/test/flix/Test.Exp.Jvm.GetStaticFieldStaticInnerClass.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetStaticFieldStaticInnerClass.flix
@@ -45,4 +45,8 @@ namespace Test/Exp/Jvm/GetStaticFieldStaticInnerClass {
         import static get flix.test.TestClass$_StaticNestedClass.STRING_FIELD as getField;
         getField() == "Hello World"
 
+    @test
+    def testGetStaticPureField01(): Bool =
+        import static get flix.test.TestClass$_StaticNestedClass.STRING_FIELD: _ & Pure as getField;
+        getField() == "Hello World"
 }

--- a/main/test/flix/Test.Exp.Jvm.GetStaticFieldStaticInnerClass.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetStaticFieldStaticInnerClass.flix
@@ -49,4 +49,9 @@ namespace Test/Exp/Jvm/GetStaticFieldStaticInnerClass {
     def testGetStaticPureField01(): Bool =
         import static get flix.test.TestClass$_StaticNestedClass.STRING_FIELD: _ & Pure as getField;
         getField() == "Hello World"
+
+    @test
+    def testGetStaticObjectField01(): ##java.lang.Object & Impure =
+        import static get flix.test.TestClass$_StaticNestedClass.STRING_FIELD: ##java.lang.Object as getField;
+        getField()
 }

--- a/main/test/flix/Test.Exp.Jvm.InvokeConstructor.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeConstructor.flix
@@ -46,7 +46,12 @@ namespace Test/Exp/Jvm/InvokeConstructor {
         newString("Hello World")
 
     @test
-    def testInvokePureConstructor09(): ##java.lang.String =
+    def testInvokePureConstructor01(): ##java.lang.String =
         import new java.lang.String(String): _ & Pure as newString;
+        newString("Hello World")
+
+    @test
+    def testInvokeObjectConstructor01(): ##java.lang.Object & Impure =
+        import new java.lang.String(String): ##java.lang.Object as newString;
         newString("Hello World")
 }

--- a/main/test/flix/Test.Exp.Jvm.InvokeConstructor.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeConstructor.flix
@@ -45,4 +45,8 @@ namespace Test/Exp/Jvm/InvokeConstructor {
         import new java.lang.String(String) as newString;
         newString("Hello World")
 
+    @test
+    def testInvokePureConstructor09(): ##java.lang.String =
+        import new java.lang.String(String): _ & Pure as newString;
+        newString("Hello World")
 }

--- a/main/test/flix/Test.Exp.Jvm.InvokeMethod.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeMethod.flix
@@ -29,4 +29,9 @@ namespace Test/Exp/Jvm/InvokeMethod {
     def testInvokePureMethod01(): Bool =
         import java.lang.String.toLowerCase(): _ & Pure;
         toLowerCase("HELLO WORLD") == "hello world"
+
+    @test
+    def testInvokeObjectMethod01(): ##java.lang.Object & Impure =
+        import java.lang.String.toLowerCase(): ##java.lang.Object;
+        toLowerCase("HELLO WORLD")
 }

--- a/main/test/flix/Test.Exp.Jvm.InvokeMethod.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeMethod.flix
@@ -25,4 +25,8 @@ namespace Test/Exp/Jvm/InvokeMethod {
         import java.lang.String.replaceAll(String, String);
         replaceAll("hello world", "hello", "goodbye") == "goodbye world"
 
+    @test
+    def testInvokePureMethod01(): Bool =
+        import java.lang.String.toLowerCase(): _ & Pure;
+        toLowerCase("HELLO WORLD") == "hello world"
 }

--- a/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.flix
@@ -34,4 +34,9 @@ namespace Test/Exp/Jvm/InvokeStaticMethod {
     def testInvokePureStaticMethod01(): Bool =
         import static java.lang.String.valueOf(Bool): _ & Pure;
         valueOf(true) == "true"
+
+    @test
+    def testInvokeObjectStaticMethod01(): ##java.lang.Object & Impure =
+        import static java.lang.String.valueOf(Bool): ##java.lang.Object;
+        valueOf(true)
 }

--- a/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.flix
@@ -30,4 +30,8 @@ namespace Test/Exp/Jvm/InvokeStaticMethod {
         import static java.lang.String.valueOf(Int64);
         valueOf(42i64) == "42"
 
+    @test
+    def testInvokePureStaticMethod01(): Bool =
+        import static java.lang.String.valueOf(Bool): _ & Pure;
+        valueOf(true) == "true"
 }

--- a/main/test/flix/Test.Exp.Jvm.PutField.flix
+++ b/main/test/flix/Test.Exp.Jvm.PutField.flix
@@ -80,13 +80,4 @@ namespace Test/Exp/Jvm/PutField {
         let o = newObject();
         setField(o, "Goodbye World");
         getField(o) == "Goodbye World"
-
-    @test
-    def testPutPureField01(): Bool =
-        import new flix.test.TestClass(): _ & Pure as newObject;
-        import get flix.test.TestClass.stringField: _ & Pure as getField;
-        import set flix.test.TestClass.stringField: _ & Pure as setField;
-        let o = newObject();
-        setField(o, "Goodbye World");
-        getField(o) == "Goodbye World"
 }

--- a/main/test/flix/Test.Exp.Jvm.PutField.flix
+++ b/main/test/flix/Test.Exp.Jvm.PutField.flix
@@ -81,4 +81,12 @@ namespace Test/Exp/Jvm/PutField {
         setField(o, "Goodbye World");
         getField(o) == "Goodbye World"
 
+    @test
+    def testPutPureField01(): Bool =
+        import new flix.test.TestClass(): _ & Pure as newObject;
+        import get flix.test.TestClass.stringField: _ & Pure as getField;
+        import set flix.test.TestClass.stringField: _ & Pure as setField;
+        let o = newObject();
+        setField(o, "Goodbye World");
+        getField(o) == "Goodbye World"
 }

--- a/main/test/flix/Test.Exp.Jvm.PutStaticField.flix
+++ b/main/test/flix/Test.Exp.Jvm.PutStaticField.flix
@@ -126,4 +126,11 @@ namespace Test/Exp/Jvm/PutStaticField {
         setField("Goodbye World!");
         getField() == "Goodbye World!"
 
+    @test
+    def testPutStaticPureField02(): Bool & Impure =
+        import static get flix.test.TestClass.STRING_FIELD: _ & Pure as getField;
+        import static set flix.test.TestClass.STRING_FIELD: _ & Pure as setField;
+        setField("Goodbye World!");
+        getField() == "Goodbye World!"
+
 }

--- a/main/test/flix/Test.Exp.Jvm.PutStaticField.flix
+++ b/main/test/flix/Test.Exp.Jvm.PutStaticField.flix
@@ -126,11 +126,4 @@ namespace Test/Exp/Jvm/PutStaticField {
         setField("Goodbye World!");
         getField() == "Goodbye World!"
 
-    @test
-    def testPutStaticPureField02(): Bool & Impure =
-        import static get flix.test.TestClass.STRING_FIELD: _ & Pure as getField;
-        import static set flix.test.TestClass.STRING_FIELD: _ & Pure as setField;
-        setField("Goodbye World!");
-        getField() == "Goodbye World!"
-
 }


### PR DESCRIPTION
In this draft, the ascriptions are desugared to casts. In the future I'd like to explore more strict options, such as requiring the type ascriptions to be valid subtyping-wise.