### PR TITLE
feat: add `foldRightL` to List

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -681,6 +681,20 @@ namespace List {
     }
 
     ///
+    /// Lazily applies `f` to a start value `s` and all elements in `xs` going from right to left.
+    /// The function f must be pure.
+    ///
+    /// That is, the result is of the form: `f(x1, ...lazy f(xn-1, lazy f(xn, s))...)`.
+    /// The foldRightL function exists to allow early termination of a fold.
+    ///
+    pub def foldRightL(f: (a, Lazy[b]) -> b, s: b, l: List[a]): b =
+        def loop(xs) = match xs {
+            case Nil     => s
+            case y :: ys => f(y, lazy loop(ys))
+        };
+        loop(l)
+
+    ///
     /// Applies `f` to all elements in `xs` going from left to right until a single value `v` is obtained.  Returns `Some(v)`.
     ///
     /// That is, the result is of the form: `Some(f(...f(f(x1, x2), x3)..., xn))`

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -1024,6 +1024,21 @@ def foldRight03(): Bool = List.foldRight((e, i) -> (i - e)*(e rem 2 + 1), 100, 1
 def foldRight04(): Bool = List.foldRight((e, i) -> (i - e)*(e rem 2 + 1), 100, 1 :: 2 :: 3 :: Nil) == 382
 
 /////////////////////////////////////////////////////////////////////////////
+// foldRightL                                                              //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def foldRightL01(): Bool = List.foldRightL((e, i) -> (force i - e) * (e rem 2 + 1), 100, Nil) == 100
+
+@test
+def foldRightL02(): Bool = List.foldRightL((e, i) -> (force i - e) * (e rem 2 + 1), 100, 1 :: Nil) == 198
+
+@test
+def foldRightL03(): Bool = List.foldRightL((e, i) -> (force i - e) * (e rem 2 + 1), 100, 1 :: 2 :: Nil) == 194
+
+@test
+def foldRightL04(): Bool = List.foldRightL((e, i) -> (force i - e) * (e rem 2 + 1), 100, 1 :: 2 :: 3 :: Nil) == 382
+
+/////////////////////////////////////////////////////////////////////////////
 // reduceLeft                                                              //
 /////////////////////////////////////////////////////////////////////////////
 @test


### PR DESCRIPTION
Add implementation of foldRightL to List namespace together with the testcases. This first PR is used to check if the style and content is ok then I will implement the method in all the namespaces requested in the issue with another PR.

As discussed in #2877 I removed the polymorphic effect. 