### PR TITLE
feat: add effect to `CodeHint.NonTrivialEffect` summary

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/CodeHint.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/CodeHint.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.language.errors
 
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol, Type}
 import ca.uwaterloo.flix.language.debug.Audience
-import ca.uwaterloo.flix.language.debug.FormatEff.formatEff
+import ca.uwaterloo.flix.language.debug.FormatEff
 
 /**
   * A common super-type for code hints.
@@ -131,7 +131,7 @@ object CodeHint {
     * @param loc the location of the expression.
     */
   case class NonTrivialEffect(tpe: Type, loc: SourceLocation) extends CodeHint {
-    def summary: String = s"Expression has a non-trivial effect. ${formatEff(tpe)(Audience.External)}"
+    def summary: String = s"Expression has a non-trivial effect: ${FormatEff.formatEff(tpe)(Audience.External)}"
 
     def severity: Severity = Severity.Info
   }

--- a/main/src/ca/uwaterloo/flix/language/errors/CodeHint.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/CodeHint.scala
@@ -15,7 +15,9 @@
  */
 package ca.uwaterloo.flix.language.errors
 
-import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
+import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol, Type}
+import ca.uwaterloo.flix.language.debug.Audience
+import ca.uwaterloo.flix.language.debug.FormatEff.formatEff
 
 /**
   * A common super-type for code hints.
@@ -125,10 +127,11 @@ object CodeHint {
   /**
     * A code hint that indicates that an expression has a non-trivial effect.
     *
+    * @param tpe the type of the expression.
     * @param loc the location of the expression.
     */
-  case class NonTrivialEffect(loc: SourceLocation) extends CodeHint {
-    def summary: String = s"Expression has a non-trivial effect."
+  case class NonTrivialEffect(tpe: Type, loc: SourceLocation) extends CodeHint {
+    def summary: String = s"Expression has a non-trivial effect. ${formatEff(tpe)(Audience.External)}"
 
     def severity: Severity = Severity.Info
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -333,7 +333,7 @@ object CodeHinter {
     */
   private def checkEffect(tpe: Type, loc: SourceLocation): List[CodeHint] = {
     if (nonTrivialEffect(tpe)) {
-      CodeHint.NonTrivialEffect(loc) :: Nil
+      CodeHint.NonTrivialEffect(tpe, loc) :: Nil
     } else {
       Nil
     }


### PR DESCRIPTION
Adds the effect to the summary of `CodeHint.NonTrivialEffect` as seen in the image below.
![Screenshot from 2021-12-21 19-47-24](https://user-images.githubusercontent.com/60233376/146982398-5384a9d7-fa90-4d8e-a71e-ab399b775ceb.png)

