### PR TITLE
feat: add `Iterator.isEmpty`

### DIFF
--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -73,6 +73,15 @@ namespace Iterator {
             Some(next())
 
     ///
+    /// Returns true if the iterator is empty.
+    ///
+    /// Does **not** consume any elements of the iterator.
+    ///
+    pub def isEmpty(iter: Iterator[a]): Bool & Impure =
+        let Iterator(done, _) = iter;
+        d()
+
+    ///
     /// Returns an iterator of all integers between `b` (inclusive) and `e` (exclusive).
     ///
     /// Returns an empty iterator if `b >= e`.

--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -79,7 +79,7 @@ namespace Iterator {
     ///
     pub def isEmpty(iter: Iterator[a]): Bool & Impure =
         let Iterator(done, _) = iter;
-        d()
+        done()
 
     ///
     /// Returns an iterator of all integers between `b` (inclusive) and `e` (exclusive).

--- a/main/test/ca/uwaterloo/flix/library/TestIterator.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterator.flix
@@ -56,6 +56,24 @@ namespace TestIterator {
         let _ = invokeIsEmpty(100, iter);
         Iterator.toList(iter) == 1 :: Nil
 
+    @test
+    def isEmpty03(): Bool & Impure =
+        let iter = Iterator.range(0, 100);
+        let _ = invokeIsEmpty(100, iter);
+        Iterator.toList(iter) == List.range(0, 100)
+
+    @test
+    def isEmpty04(): Bool & Impure =
+        let iter = Iterator.repeat(2, 10);
+        let _ = invokeIsEmpty(100, iter);
+        Iterator.toList(iter) == 10 :: 10 :: Nil
+
+    @test
+    def isEmpty05(): Bool & Impure =
+        let iter = (1 :: 2 :: 3 :: Nil) |> List.toIterator |> Iterator.lazyFilter(i -> i < 3);
+        let _ = invokeIsEmpty(100, iter);
+        Iterator.toList(iter) == 1 :: 2 :: Nil
+
     ///
     /// Helper function that invokes `Iterator.isEmpty` `n` times.
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestIterator.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterator.flix
@@ -104,6 +104,30 @@ namespace TestIterator {
         let _ = invokeIsEmpty(100, iter);
         Iterator.toList(iter) == 5 :: 7 :: 9 :: Nil
 
+    @test
+    def isEmpty10(): Bool & Impure = // flatMap
+        let i = (1 :: 2 :: 3 :: Nil) |> List.toIterator;
+        let iter = Iterator.flatMap(x -> Iterator.singleton(x + 1), i);
+        let _ = invokeIsEmpty(100, iter);
+        Iterator.toList(iter) == 2 :: 3 :: 4 :: Nil
+
+    @test
+    def isEmpty11(): Bool & Impure = // intersperse
+        let i = (1 :: 2 :: 3 :: Nil) |> List.toIterator;
+        let iter = Iterator.intersperse(5, i);
+        let _ = invokeIsEmpty(100, iter);
+        Iterator.toList(iter) == 1 :: 5 :: 2 :: 5 :: 3 :: Nil
+
+    @test
+    def isEmpty12(): Bool & Impure = // intercalate
+        let iterA  = (11 :: 12 :: 13 :: Nil) |> List.toIterator;
+        let iterB0 = (1 :: Nil) |> List.toIterator;
+        let iterB1 = (2 :: 3 :: Nil) |> List.toIterator;
+        let iterB  = (iterB0 :: iterB1 :: Nil) |> List.toIterator;
+        let iter = Iterator.intercalate(iterA, iterB);
+        let _ = invokeIsEmpty(100, iter);
+        Iterator.toList(iter) == 1 :: 11 :: 12 :: 13 :: 2 :: 3 :: Nil
+
     ///
     /// Helper function that invokes `Iterator.isEmpty` `n` times.
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestIterator.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterator.flix
@@ -47,32 +47,46 @@ namespace TestIterator {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def isEmpty01(): Bool & Impure =
+    def isEmpty01(): Bool & Impure = // empty
         Iterator.empty() |> Iterator.isEmpty
 
     @test
-    def isEmpty02(): Bool & Impure =
+    def isEmpty02(): Bool & Impure = // singleton
         let iter = Iterator.singleton(1);
         let _ = invokeIsEmpty(100, iter);
         Iterator.toList(iter) == 1 :: Nil
 
     @test
-    def isEmpty03(): Bool & Impure =
+    def isEmpty03(): Bool & Impure = // range
         let iter = Iterator.range(0, 100);
         let _ = invokeIsEmpty(100, iter);
         Iterator.toList(iter) == List.range(0, 100)
 
     @test
-    def isEmpty04(): Bool & Impure =
+    def isEmpty04(): Bool & Impure = // repeat
         let iter = Iterator.repeat(2, 10);
         let _ = invokeIsEmpty(100, iter);
         Iterator.toList(iter) == 10 :: 10 :: Nil
 
     @test
-    def isEmpty05(): Bool & Impure =
+    def isEmpty05(): Bool & Impure = // lazyFilter
         let iter = (1 :: 2 :: 3 :: Nil) |> List.toIterator |> Iterator.lazyFilter(i -> i < 3);
         let _ = invokeIsEmpty(100, iter);
         Iterator.toList(iter) == 1 :: 2 :: Nil
+
+    @test
+    def isEmpty06(): Bool & Impure = // lazyMap
+        let iter = (1 :: 2 :: 3 :: Nil) |> List.toIterator |> Iterator.lazyMap(i -> i + 1);
+        let _ = invokeIsEmpty(100, iter);
+        Iterator.toList(iter) == 2 :: 3 :: 4 :: Nil
+
+    @test
+    def isEmpty07(): Bool & Impure = // append
+        let i1 = (1 :: 2 :: 3 :: Nil) |> List.toIterator;
+        let i2 = (4 :: 5 :: 6 :: Nil) |> List.toIterator;
+        let iter = Iterator.append(i1, i2);
+        let _ = invokeIsEmpty(100, iter);
+        Iterator.toList(iter) == 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: Nil
 
     ///
     /// Helper function that invokes `Iterator.isEmpty` `n` times.

--- a/main/test/ca/uwaterloo/flix/library/TestIterator.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterator.flix
@@ -41,6 +41,34 @@ namespace TestIterator {
         Iterator.next(iter);
         Iterator.next(iter) == Some(2)
 
+
+    /////////////////////////////////////////////////////////////////////////////
+    // isEmpty (idempotency)                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def isEmpty01(): Bool & Impure =
+        Iterator.empty() |> Iterator.isEmpty
+
+    @test
+    def isEmpty02(): Bool & Impure =
+        let iter = Iterator.singleton(1);
+        let _ = invokeIsEmpty(100, iter);
+        Iterator.toList(iter) == 1 :: Nil
+
+    ///
+    /// Helper function that invokes `Iterator.isEmpty` `n` times.
+    ///
+    def invokeIsEmpty(n: Int32, iter: Iterator[a]): Bool & Impure =
+        def loop(m) =
+            if (m <= 0)
+                true
+            else {
+                Iterator.isEmpty(iter);
+                loop(m - 1)
+            };
+        loop(n)
+
     /////////////////////////////////////////////////////////////////////////////
     // range                                                                   //
     /////////////////////////////////////////////////////////////////////////////

--- a/main/test/ca/uwaterloo/flix/library/TestIterator.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterator.flix
@@ -94,7 +94,7 @@ namespace TestIterator {
         let i2 = (4 :: 5 :: 6 :: Nil) |> List.toIterator;
         let iter = Iterator.zip(i1, i2);
         let _ = invokeIsEmpty(100, iter);
-        Iterator.toList(iter) == 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: Nil
+        Iterator.toList(iter) == (1, 4) :: (2, 5) :: (3, 6) :: Nil
 
     @test
     def isEmpty09(): Bool & Impure = // lazyZipWith

--- a/main/test/ca/uwaterloo/flix/library/TestIterator.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterator.flix
@@ -88,6 +88,22 @@ namespace TestIterator {
         let _ = invokeIsEmpty(100, iter);
         Iterator.toList(iter) == 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: Nil
 
+    @test
+    def isEmpty08(): Bool & Impure = // zip
+        let i1 = (1 :: 2 :: 3 :: Nil) |> List.toIterator;
+        let i2 = (4 :: 5 :: 6 :: Nil) |> List.toIterator;
+        let iter = Iterator.zip(i1, i2);
+        let _ = invokeIsEmpty(100, iter);
+        Iterator.toList(iter) == 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: Nil
+
+    @test
+    def isEmpty09(): Bool & Impure = // lazyZipWith
+        let i1 = (1 :: 2 :: 3 :: Nil) |> List.toIterator;
+        let i2 = (4 :: 5 :: 6 :: Nil) |> List.toIterator;
+        let iter = Iterator.lazyZipWith((x, y) -> x + y, i1, i2);
+        let _ = invokeIsEmpty(100, iter);
+        Iterator.toList(iter) == 5 :: 7 :: 9 :: Nil
+
     ///
     /// Helper function that invokes `Iterator.isEmpty` `n` times.
     ///


### PR DESCRIPTION
Closes #2892

The goal is to have tests for every function that modifies or creates the `done` function.

- [x] `empty`
- [x] `singleton`
- [x] `range`
- [x] `repeat`
- [x] `lazyFilter`
- [x] `lazyMap`
- [x] `append`
- [x] `zip`
- [x] `lazyZipWith`
- [x] `flatMap`
- [x] `intercalate`
- [ ] Refactor test from #2712 when merged s.t. it is placed at the `isEmpty` tests.