### PR TITLE
feat: add functor-applicative-monad combinators and test suites

### DIFF
--- a/main/src/library/Applicative.flix
+++ b/main/src/library/Applicative.flix
@@ -121,3 +121,31 @@ pub class Applicative[m : Type -> Type] with Functor[m] {
     ///
     law mapCorrespondence: forall(f: a -> b, x: m[a]) with Eq[m[b]] . Functor.map(f, x) == Applicative.ap(Applicative.point(f), x)
 }
+
+namespace Applicative {
+
+    ///
+    /// Chain two applicative actions, return only the result of the first.
+    ///
+    pub def seqLeft(fa: m[a], fb: m[b]): m[a] with Applicative[m] =
+        Applicative.liftA2((a, _) -> a, fa, fb)
+
+    ///
+    /// Chain two applicative actions, return only the result of the second.
+    ///
+    pub def seqRight(fa: m[a], fb : m[b]): m[b] with Applicative[m] =
+        Applicative.liftA2((_, b) -> b, fa, fb)
+
+    ///
+    /// Perform the applicative action `f` only when `x` is true.
+    ///
+    pub def whenTrue(x: Bool, f: m[Unit]): m[Unit] with Applicative[m] =
+        if (x) f else point(())
+
+    ///
+    /// Perform the applicative action `f` only when `x` is false.
+    ///
+    pub def whenFalse(x: Bool, f: m[Unit]): m[Unit] with Applicative[m] =
+        if (not x) f else point(())
+
+}

--- a/main/src/library/Applicative.flix
+++ b/main/src/library/Applicative.flix
@@ -125,27 +125,21 @@ pub class Applicative[m : Type -> Type] with Functor[m] {
 namespace Applicative {
 
     ///
+    /// Chain two applicative actions, returns the product of their results.
+    ///
+    pub def product(fa: m[a], fb: m[b]): m[(a, b)] with Applicative[m] =
+        Applicative.liftA2((a, b) -> (a, b), fa, fb)
+
+    ///
     /// Chain two applicative actions, return only the result of the first.
     ///
-    pub def seqLeft(fa: m[a], fb: m[b]): m[a] with Applicative[m] =
+    pub def productLeft(fa: m[a], fb: m[b]): m[a] with Applicative[m] =
         Applicative.liftA2((a, _) -> a, fa, fb)
 
     ///
     /// Chain two applicative actions, return only the result of the second.
     ///
-    pub def seqRight(fa: m[a], fb : m[b]): m[b] with Applicative[m] =
+    pub def productRight(fa: m[a], fb : m[b]): m[b] with Applicative[m] =
         Applicative.liftA2((_, b) -> b, fa, fb)
-
-    ///
-    /// Perform the applicative action `f` only when `x` is true.
-    ///
-    pub def whenTrue(x: Bool, f: m[Unit]): m[Unit] with Applicative[m] =
-        if (x) f else point(())
-
-    ///
-    /// Perform the applicative action `f` only when `x` is false.
-    ///
-    pub def whenFalse(x: Bool, f: m[Unit]): m[Unit] with Applicative[m] =
-        if (not x) f else point(())
 
 }

--- a/main/src/library/Functor.flix
+++ b/main/src/library/Functor.flix
@@ -36,13 +36,21 @@ class Functor[m : Type -> Type] {
 }
 
 namespace Functor {
-  ///
-  /// Lifts the function `f` into the functor.
-  ///
-  pub def lift[a: Type, b: Type, ef: Bool, m: Type -> Type](f: a -> b & ef): m[a] -> m[b] & ef with Functor[m] = Functor.map(f)
+    ///
+    /// Lifts the function `f` into the functor.
+    ///
+    pub def lift[a: Type, b: Type, ef: Bool, m: Type -> Type](f: a -> b & ef): m[a] -> m[b] & ef with Functor[m] = Functor.map(f)
 
-  ///
-  /// Replaces the value `a` in `s` by the given value `x` preserving the structure of `s`.
-  ///
-  pub def as[a: Type, b: Type, m: Type -> Type](s: m[a], x: b): m[b] with Functor[m] = Functor.map(_ -> x, s)
+    ///
+    /// Replaces the value `a` in `s` by the given value `x` preserving the structure of `s`.
+    ///
+    pub def as[a: Type, b: Type, m: Type -> Type](s: m[a], x: b): m[b] with Functor[m] = Functor.map(_ -> x, s)
+
+    ///
+    /// Replaces the value `a` in `s` with `Unit` preserving the structure of `s`.
+    ///
+    /// This function is typically used to discard the return value of computing `s`.
+    ///
+    pub def ignore(s: m[a]): m[Unit] with Functor[m] = s `Functor.as` ()
+
 }

--- a/main/src/library/Monad.flix
+++ b/main/src/library/Monad.flix
@@ -50,3 +50,53 @@ pub class Monad[m : Type -> Type] with Applicative[m] {
     ///
     law apCorrespondence: forall(f: m[a -> b], x: m[a]) with Eq[m[b]] . Applicative.ap(f, x) == Monad.flatMap(g -> Monad.flatMap(y -> Applicative.point(g(y)), x), f)
 }
+
+
+namespace Monad {
+
+    use Applicative.{point};
+
+    ///
+    /// The monadic `join` operator.
+    /// Collapse `x` - a monadic action nested in an outer monadic layer - to a single layer.
+    ///
+    /// E.g. for the Option monad: `join(Some(Some(1)))` becomes `Some(1)`.
+    ///
+    pub def join(x: m[m[a]]): m[a] with Monad[m] = flatMap(identity, x)
+
+    ///
+    /// Chain the evaluation of the monadic actions `x` and `k`.
+    /// The result of `x` is mapped by the monadic function `k`.
+    ///
+    pub def bind(x: m[a], k: a -> m[b] & ef): m[b] & ef with Monad[m] = flatMap(k, x)
+
+    ///
+    /// The left-to-right Kleisli composition operator for monads.
+    ///
+    /// Map `x` with the monadic function `f1` and then map its result with the function `f2`.
+    ///
+    pub def kleisliLeft(f1: a -> m[b] & ef1, f2: b -> m[c] & ef2, x: a): m[c] & (ef1 and ef2) with Monad[m] =
+        bind(f1(x), x1 -> f2(x1))
+
+    ///
+    /// The right-to-left Kleisli composition operator for monads.
+    ///
+    /// Map `x` with the monadic function `f2` and then map its result with the function `f1`.
+    ///
+    pub def kleisliRight(f1: b -> m[c] & ef1, f2: a -> m[b] & ef2, x: a): m[c] & (ef1 and ef2) with Monad[m] =
+        bind(f2(x), x1 -> f1(x1))
+
+
+    ///
+    /// Perform the monadic action `f` only when `x` evaluates to true.
+    ///
+    pub def whenTrueM(x: m[Bool], f: m[Unit]): m[Unit] with Monad[m] =
+        bind(x, x1 -> if (x1) f else point(()))
+
+    ///
+    /// Perform the monadic action `f` only when `x` evaluates to false.
+    ///
+    pub def whenFalseM(x: m[Bool], f: m[Unit]): m[Unit] with Monad[m] =
+        bind(x, x1 -> if (not x1) f else point(()))
+
+}

--- a/main/src/library/Monad.flix
+++ b/main/src/library/Monad.flix
@@ -54,21 +54,13 @@ pub class Monad[m : Type -> Type] with Applicative[m] {
 
 namespace Monad {
 
-    use Applicative.{point};
-
     ///
     /// The monadic `join` operator.
-    /// Collapse `x` - a monadic action nested in an outer monadic layer - to a single layer.
+    /// Flatten `x` - a monadic action nested in an outer monadic layer - to a single layer.
     ///
-    /// E.g. for the Option monad: `join(Some(Some(1)))` becomes `Some(1)`.
+    /// E.g. for the Option monad: `flatten(Some(Some(1)))` becomes `Some(1)`.
     ///
-    pub def join(x: m[m[a]]): m[a] with Monad[m] = flatMap(identity, x)
-
-    ///
-    /// Chain the evaluation of the monadic actions `x` and `k`.
-    /// The result of `x` is mapped by the monadic function `k`.
-    ///
-    pub def bind(x: m[a], k: a -> m[b] & ef): m[b] & ef with Monad[m] = flatMap(k, x)
+    pub def flatten(x: m[m[a]]): m[a] with Monad[m] = flatMap(identity, x)
 
     ///
     /// The left-to-right Kleisli composition operator for monads.
@@ -76,7 +68,7 @@ namespace Monad {
     /// Map `x` with the monadic function `f1` and then map its result with the function `f2`.
     ///
     pub def kleisliLeft(f1: a -> m[b] & ef1, f2: b -> m[c] & ef2, x: a): m[c] & (ef1 and ef2) with Monad[m] =
-        bind(f1(x), x1 -> f2(x1))
+        flatMap(x1 -> f2(x1), f1(x))
 
     ///
     /// The right-to-left Kleisli composition operator for monads.
@@ -84,19 +76,7 @@ namespace Monad {
     /// Map `x` with the monadic function `f2` and then map its result with the function `f1`.
     ///
     pub def kleisliRight(f1: b -> m[c] & ef1, f2: a -> m[b] & ef2, x: a): m[c] & (ef1 and ef2) with Monad[m] =
-        bind(f2(x), x1 -> f1(x1))
+        flatMap(x1 -> f1(x1), f2(x))
 
-
-    ///
-    /// Perform the monadic action `f` only when `x` evaluates to true.
-    ///
-    pub def whenTrueM(x: m[Bool], f: m[Unit]): m[Unit] with Monad[m] =
-        bind(x, x1 -> if (x1) f else point(()))
-
-    ///
-    /// Perform the monadic action `f` only when `x` evaluates to false.
-    ///
-    pub def whenFalseM(x: m[Bool], f: m[Unit]): m[Unit] with Monad[m] =
-        bind(x, x1 -> if (not x1) f else point(()))
 
 }

--- a/main/test/ca/uwaterloo/flix/library/LibrarySuite.scala
+++ b/main/test/ca/uwaterloo/flix/library/LibrarySuite.scala
@@ -66,4 +66,7 @@ class LibrarySuite extends Suites(
   new FlixTest("TestUpperBound", "main/test/ca/uwaterloo/flix/library/TestUpperBound.flix")(Options.TestWithLibAll),
   new FlixTest("TestGetOpt", "main/test/ca/uwaterloo/flix/library/TestGetOpt.flix")(Options.TestWithLibAll),
   new FlixTest("TestSemiGroup", "main/test/ca/uwaterloo/flix/library/TestSemiGroup.flix")(Options.TestWithLibAll),
+  new FlixTest("TestFunctor", "main/test/ca/uwaterloo/flix/library/TestFunctor.flix")(Options.TestWithLibAll),
+  new FlixTest("TestApplicative", "main/test/ca/uwaterloo/flix/library/TestApplicative.flix")(Options.TestWithLibAll),
+  new FlixTest("TestMonad", "main/test/ca/uwaterloo/flix/library/TestMonad.flix")(Options.TestWithLibAll),
 )

--- a/main/test/ca/uwaterloo/flix/library/TestApplicative.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestApplicative.flix
@@ -1,0 +1,140 @@
+/*
+ *  Copyright 2021 Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace TestApplicative {
+
+    use Applicative.{seqRight, seqLeft, whenTrue, whenFalse};
+
+    // Local definition of a State applicative so we can have observable side-effects
+    // to test `whenTrue` and `whenFalse`.
+
+    opaque type State[s, a] = s -> (s, a) & Impure
+
+    instance Functor[State[s]] {
+        pub def map(f: a -> b & ef, m: State[s, a]): State[s, b] & ef =
+            State(s ->
+                let State(m1) = m;
+                let (s1, a) = m1(s);
+                (s1, f(a)) as & Impure
+            ) as & ef
+    }
+
+    instance Applicative[State[s]] {
+        pub def point(x: a): State[s, a] = State(s -> (s, x) as & Impure)
+        pub def ap(mf: State[s, a -> b & ef], ma: State[s, a]): State[s, b] & ef =
+            State(s ->
+                let State(mf1) = mf;
+                let (s1, f) = mf1(s) as & Impure;
+                let State(ma1) = ma;
+                let (s2, b) = ma1(s1);
+                (s2, f(b)) as & Impure
+            ) as & ef
+    }
+
+    def runState(m: State[s, a], s: s): (s, a) & Impure =
+        let State(m1) = m;
+        m1(s)
+
+    def update(f: s -> s & ef): State[s, Unit] & ef =
+        State(s ->
+            (f(s) as & Impure, ())
+        ) as & ef
+
+    /////////////////////////////////////////////////////////////////////////////
+    // seqLeft                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def seqLeft01(): Bool =
+        seqLeft(None, Some(2)) == None
+
+    @test
+    def seqLeft02(): Bool =
+        seqLeft(Some(1), None) == None
+
+    @test
+    def seqLeft03(): Bool =
+        seqLeft(Some(1), Some(2)) == Some(1)
+
+    @test
+    def seqLeft04(): Bool =
+        seqLeft(Nil, 2 :: Nil) == Nil
+
+    @test
+    def seqLeft05(): Bool =
+        seqLeft(1 :: Nil, Nil) == Nil
+
+    @test
+    def seqLeft06(): Bool =
+        seqLeft(1 :: Nil, 2 :: Nil) == 1 :: Nil
+
+    /////////////////////////////////////////////////////////////////////////////
+    // seqRight                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def seqRight01(): Bool =
+        seqRight(None, Some(2)) == None
+
+    @test
+    def seqRight02(): Bool =
+        seqRight(Some(1), None) == None
+
+    @test
+    def seqRight03(): Bool =
+        seqRight(Some(1), Some(2)) == Some(2)
+
+    @test
+    def seqRight04(): Bool =
+        seqRight(Nil, 2 :: Nil) == Nil
+
+    @test
+    def seqRight05(): Bool =
+        seqRight(1 :: Nil, Nil) == Nil
+
+    @test
+    def seqRight06(): Bool =
+        seqRight(1 :: Nil, 2 :: Nil) == 2 :: Nil
+
+    /////////////////////////////////////////////////////////////////////////////
+    // whenTrue                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def whenTrue01(): Bool =
+        let ma = whenTrue(true, update(s -> s+100));
+        runState(ma, 0) as & Pure == (100, ())
+
+    @test
+    def whenTrue02(): Bool =
+        let ma = whenTrue(false, update(s -> s+100));
+        runState(ma, 0) as & Pure == (0, ())
+
+    /////////////////////////////////////////////////////////////////////////////
+    // whenFalse                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def whenFalse01(): Bool =
+        let ma = whenFalse(false, update(s -> s+100));
+        runState(ma, 0) as & Pure == (100, ())
+
+    @test
+    def whenFalse02(): Bool =
+        let ma = whenFalse(true, update(s -> s+100));
+        runState(ma, 0) as & Pure == (0, ())
+
+}

--- a/main/test/ca/uwaterloo/flix/library/TestApplicative.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestApplicative.flix
@@ -16,125 +16,90 @@
 
 namespace TestApplicative {
 
-    use Applicative.{seqRight, seqLeft, whenTrue, whenFalse};
-
-    // Local definition of a State applicative so we can have observable side-effects
-    // to test `whenTrue` and `whenFalse`.
-
-    opaque type State[s, a] = s -> (s, a) & Impure
-
-    instance Functor[State[s]] {
-        pub def map(f: a -> b & ef, m: State[s, a]): State[s, b] & ef =
-            State(s ->
-                let State(m1) = m;
-                let (s1, a) = m1(s);
-                (s1, f(a)) as & Impure
-            ) as & ef
-    }
-
-    instance Applicative[State[s]] {
-        pub def point(x: a): State[s, a] = State(s -> (s, x) as & Impure)
-        pub def ap(mf: State[s, a -> b & ef], ma: State[s, a]): State[s, b] & ef =
-            State(s ->
-                let State(mf1) = mf;
-                let (s1, f) = mf1(s) as & Impure;
-                let State(ma1) = ma;
-                let (s2, b) = ma1(s1);
-                (s2, f(b)) as & Impure
-            ) as & ef
-    }
-
-    def runState(m: State[s, a], s: s): (s, a) & Impure =
-        let State(m1) = m;
-        m1(s)
-
-    def update(f: s -> s & ef): State[s, Unit] & ef =
-        State(s ->
-            (f(s) as & Impure, ())
-        ) as & ef
+    use Applicative.{product, productLeft, productRight};
 
     /////////////////////////////////////////////////////////////////////////////
-    // seqLeft                                                                 //
+    // product                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def seqLeft01(): Bool =
-        seqLeft(None, Some(2)) == None
+    def product01(): Bool =
+        product(None, Some(2)) == None
 
     @test
-    def seqLeft02(): Bool =
-        seqLeft(Some(1), None) == None
+    def product02(): Bool =
+        product(Some(1), None) == None
 
     @test
-    def seqLeft03(): Bool =
-        seqLeft(Some(1), Some(2)) == Some(1)
+    def product03(): Bool =
+        product(Some(1), Some(2)) == Some(1, 2)
 
     @test
-    def seqLeft04(): Bool =
-        seqLeft(Nil, 2 :: Nil) == Nil
+    def product04(): Bool =
+        product(Nil, 2 :: Nil) == Nil
 
     @test
-    def seqLeft05(): Bool =
-        seqLeft(1 :: Nil, Nil) == Nil
+    def product05(): Bool =
+        product(1 :: Nil, Nil) == Nil
 
     @test
-    def seqLeft06(): Bool =
-        seqLeft(1 :: Nil, 2 :: Nil) == 1 :: Nil
+    def product06(): Bool =
+        product(1 :: Nil, 2 :: Nil) == (1, 2) :: Nil
 
     /////////////////////////////////////////////////////////////////////////////
-    // seqRight                                                                //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @test
-    def seqRight01(): Bool =
-        seqRight(None, Some(2)) == None
-
-    @test
-    def seqRight02(): Bool =
-        seqRight(Some(1), None) == None
-
-    @test
-    def seqRight03(): Bool =
-        seqRight(Some(1), Some(2)) == Some(2)
-
-    @test
-    def seqRight04(): Bool =
-        seqRight(Nil, 2 :: Nil) == Nil
-
-    @test
-    def seqRight05(): Bool =
-        seqRight(1 :: Nil, Nil) == Nil
-
-    @test
-    def seqRight06(): Bool =
-        seqRight(1 :: Nil, 2 :: Nil) == 2 :: Nil
-
-    /////////////////////////////////////////////////////////////////////////////
-    // whenTrue                                                                //
+    // productLeft                                                             //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def whenTrue01(): Bool =
-        let ma = whenTrue(true, update(s -> s+100));
-        runState(ma, 0) as & Pure == (100, ())
+    def productLeft01(): Bool =
+        productLeft(None, Some(2)) == None
 
     @test
-    def whenTrue02(): Bool =
-        let ma = whenTrue(false, update(s -> s+100));
-        runState(ma, 0) as & Pure == (0, ())
+    def productLeft02(): Bool =
+        productLeft(Some(1), None) == None
+
+    @test
+    def productLeft03(): Bool =
+        productLeft(Some(1), Some(2)) == Some(1)
+
+    @test
+    def productLeft04(): Bool =
+        productLeft(Nil, 2 :: Nil) == Nil
+
+    @test
+    def productLeft05(): Bool =
+        productLeft(1 :: Nil, Nil) == Nil
+
+    @test
+    def productLeft06(): Bool =
+        productLeft(1 :: Nil, 2 :: Nil) == 1 :: Nil
 
     /////////////////////////////////////////////////////////////////////////////
-    // whenFalse                                                               //
+    // productRight                                                            //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def whenFalse01(): Bool =
-        let ma = whenFalse(false, update(s -> s+100));
-        runState(ma, 0) as & Pure == (100, ())
+    def productRight01(): Bool =
+        productRight(None, Some(2)) == None
 
     @test
-    def whenFalse02(): Bool =
-        let ma = whenFalse(true, update(s -> s+100));
-        runState(ma, 0) as & Pure == (0, ())
+    def productRight02(): Bool =
+        productRight(Some(1), None) == None
+
+    @test
+    def productRight03(): Bool =
+        productRight(Some(1), Some(2)) == Some(2)
+
+    @test
+    def productRight04(): Bool =
+        productRight(Nil, 2 :: Nil) == Nil
+
+    @test
+    def productRight05(): Bool =
+        productRight(1 :: Nil, Nil) == Nil
+
+    @test
+    def productRight06(): Bool =
+        productRight(1 :: Nil, 2 :: Nil) == 2 :: Nil
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestFunctor.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFunctor.flix
@@ -16,7 +16,7 @@
 
 namespace TestFunctor {
 
-    use Functor.{lift};
+    use Functor.{lift, ignore};
 
 
     /////////////////////////////////////////////////////////////////////////////
@@ -73,22 +73,22 @@ namespace TestFunctor {
 
     @test
     def ignore01(): Bool =
-        Functor.ignore(None) == None
+        ignore(None) == None
 
     @test
     def ignore02(): Bool =
-        Functor.ignore(Some(1)) == Some(())
+        ignore(Some(1)) == Some(())
 
     @test
     def ignore03(): Bool =
-        Functor.ignore(Nil) == Nil
+        ignore(Nil) == Nil
 
     @test
     def ignore04(): Bool =
-        Functor.ignore(1 :: Nil) == () :: Nil
+        ignore(1 :: Nil) == () :: Nil
 
     @test
     def ignore05(): Bool =
-        Functor.ignore(1 :: 2 :: Nil) == () :: () :: Nil
+        ignore(1 :: 2 :: Nil) == () :: () :: Nil
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestFunctor.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFunctor.flix
@@ -1,0 +1,94 @@
+/*
+ *  Copyright 2021 Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace TestFunctor {
+
+    use Functor.{lift};
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // lift                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def lift01(): Bool =
+        lift(x -> x + 1, None) == None
+
+    @test
+    def lift02(): Bool =
+        lift(x -> x + 1, Some(1)) == Some(2)
+
+    @test
+    def lift03(): Bool =
+        lift(x -> x + 1, Nil) == Nil
+
+    @test
+    def lift04(): Bool =
+        lift(x -> x + 1, 1 :: Nil) == 2 :: Nil
+
+    @test
+    def lift05(): Bool =
+        lift(x -> x + 1, 1 :: 2 :: Nil) == 2 :: 3 :: Nil
+
+    /////////////////////////////////////////////////////////////////////////////
+    // as                                                                      //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def as01(): Bool =
+        Functor.as(None, 'A') == None
+
+    @test
+    def as02(): Bool =
+        Functor.as(Some(1), 'A') == Some('A')
+
+    @test
+    def as03(): Bool =
+        Functor.as(Nil, 'A') == Nil
+
+    @test
+    def as04(): Bool =
+        Functor.as(1 :: Nil, 'A') == 'A' :: Nil
+
+    @test
+    def as05(): Bool =
+        Functor.as(1 :: 2 :: Nil, 'A') == 'A' :: 'A' :: Nil
+
+    /////////////////////////////////////////////////////////////////////////////
+    // ignore                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def ignore01(): Bool =
+        Functor.ignore(None) == None
+
+    @test
+    def ignore02(): Bool =
+        Functor.ignore(Some(1)) == Some(())
+
+    @test
+    def ignore03(): Bool =
+        Functor.ignore(Nil) == Nil
+
+    @test
+    def ignore04(): Bool =
+        Functor.ignore(1 :: Nil) == () :: Nil
+
+    @test
+    def ignore05(): Bool =
+        Functor.ignore(1 :: 2 :: Nil) == () :: () :: Nil
+
+}

--- a/main/test/ca/uwaterloo/flix/library/TestMonad.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMonad.flix
@@ -1,0 +1,151 @@
+/*
+ *  Copyright 2021 Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace TestMonad {
+
+    use Applicative.{point};
+    use Monad.{join, bind, kleisliLeft, kleisliRight, whenTrueM, whenFalseM};
+
+    // Local definition of a State monad so we can have observable side-effects
+    // to test `whenTrueM` and `whenFalseM`.
+
+    opaque type State[s, a] = s -> (s, a) & Impure
+
+    instance Functor[State[s]] {
+        pub def map(f: a -> b & ef, m: State[s, a]): State[s, b] & ef =
+            State(s ->
+                let State(m1) = m;
+                let (s1, a) = m1(s);
+                (s1, f(a)) as & Impure
+            ) as & ef
+    }
+
+    instance Applicative[State[s]] {
+        pub def point(x: a): State[s, a] = State(s -> (s, x) as & Impure)
+        pub def ap(mf: State[s, a -> b & ef], ma: State[s, a]): State[s, b] & ef =
+            State(s ->
+                let State(mf1) = mf;
+                let (s1, f) = mf1(s) as & Impure;
+                let State(ma1) = ma;
+                let (s2, b) = ma1(s1);
+                (s2, f(b)) as & Impure
+            ) as & ef
+    }
+
+    instance Monad[State[s]] {
+        pub def flatMap(f: a -> State[s, b] & ef, m: State[s, a]): State[s, b] & ef =
+            State(s ->
+                let State(m1) = m;
+                let (s1, a) = m1(s);
+                let State(m2) = f(a) as & Impure;
+                m2(s1)
+            ) as & ef
+    }
+
+    def runState(m: State[s, a], s: s): (s, a) & Impure =
+        let State(m1) = m;
+        m1(s)
+
+    def update(f: s -> s & ef): State[s, Unit] & ef =
+        State(s ->
+            (f(s) as & Impure, ())
+        ) as & ef
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // join                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def join01(): Bool =
+        let x: Option[Option[Int32]] = None;
+        join(x) == None
+
+    @test
+    def join02(): Bool =
+        let x: Option[Option[Int32]] = Some(None);
+        join(x) == None
+
+    @test
+    def join03(): Bool =
+        let x: Option[Option[Int32]] = Some(Some(1));
+        join(x) == Some(1)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // bind                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def bind01(): Bool =
+        bind(None, x -> Some((x, x))) == None
+
+    @test
+    def bind02(): Bool =
+        bind(Some(1), x -> Some((x, x))) == Some((1, 1))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // kleisliLeft                                                             //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def kleisliLeft01(): Bool =
+        kleisliLeft(_ -> None, x2 -> Some(ToString.toString(x2)), 1) == None
+
+    @test
+    def kleisliLeft02(): Bool =
+        kleisliLeft(x1 -> Some(x1 + 1), x2 -> Some(ToString.toString(x2)), 1) == Some("2")
+
+    /////////////////////////////////////////////////////////////////////////////
+    // kleisliRight                                                            //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def kleisliRight01(): Bool =
+        kleisliRight(x1 -> Some(ToString.toString(x1)), _ -> None, 1) == None
+
+    @test
+    def kleisliRight02(): Bool =
+        kleisliRight(x1 -> Some(ToString.toString(x1)), x2 -> Some(x2 + 1), 1) == Some("2")
+
+    /////////////////////////////////////////////////////////////////////////////
+    // whenTrueM                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def whenTrueM01(): Bool =
+        let ma = whenTrueM(point(true), update(s -> s+100));
+        runState(ma, 0) as & Pure == (100, ())
+
+    @test
+    def whenTrueM02(): Bool =
+        let ma = whenTrueM(point(false), update(s -> s+100));
+        runState(ma, 0) as & Pure == (0, ())
+
+    /////////////////////////////////////////////////////////////////////////////
+    // whenFalseM                                                              //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def whenFalseM01(): Bool =
+        let ma = whenFalseM(point(false), update(s -> s+100));
+        runState(ma, 0) as & Pure == (100, ())
+
+    @test
+    def whenFalseM02(): Bool =
+        let ma = whenFalseM(point(true), update(s -> s+100));
+        runState(ma, 0) as & Pure == (0, ())
+
+}

--- a/main/test/ca/uwaterloo/flix/library/TestMonad.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMonad.flix
@@ -16,85 +16,26 @@
 
 namespace TestMonad {
 
-    use Applicative.{point};
-    use Monad.{join, bind, kleisliLeft, kleisliRight, whenTrueM, whenFalseM};
-
-    // Local definition of a State monad so we can have observable side-effects
-    // to test `whenTrueM` and `whenFalseM`.
-
-    opaque type State[s, a] = s -> (s, a) & Impure
-
-    instance Functor[State[s]] {
-        pub def map(f: a -> b & ef, m: State[s, a]): State[s, b] & ef =
-            State(s ->
-                let State(m1) = m;
-                let (s1, a) = m1(s);
-                (s1, f(a)) as & Impure
-            ) as & ef
-    }
-
-    instance Applicative[State[s]] {
-        pub def point(x: a): State[s, a] = State(s -> (s, x) as & Impure)
-        pub def ap(mf: State[s, a -> b & ef], ma: State[s, a]): State[s, b] & ef =
-            State(s ->
-                let State(mf1) = mf;
-                let (s1, f) = mf1(s) as & Impure;
-                let State(ma1) = ma;
-                let (s2, b) = ma1(s1);
-                (s2, f(b)) as & Impure
-            ) as & ef
-    }
-
-    instance Monad[State[s]] {
-        pub def flatMap(f: a -> State[s, b] & ef, m: State[s, a]): State[s, b] & ef =
-            State(s ->
-                let State(m1) = m;
-                let (s1, a) = m1(s);
-                let State(m2) = f(a) as & Impure;
-                m2(s1)
-            ) as & ef
-    }
-
-    def runState(m: State[s, a], s: s): (s, a) & Impure =
-        let State(m1) = m;
-        m1(s)
-
-    def update(f: s -> s & ef): State[s, Unit] & ef =
-        State(s ->
-            (f(s) as & Impure, ())
-        ) as & ef
-
+    use Monad.{flatten, kleisliLeft, kleisliRight};
 
     /////////////////////////////////////////////////////////////////////////////
-    // join                                                                    //
+    // flatten                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def join01(): Bool =
+    def flatten01(): Bool =
         let x: Option[Option[Int32]] = None;
-        join(x) == None
+        flatten(x) == None
 
     @test
-    def join02(): Bool =
+    def flatten02(): Bool =
         let x: Option[Option[Int32]] = Some(None);
-        join(x) == None
+        flatten(x) == None
 
     @test
-    def join03(): Bool =
+    def flatten03(): Bool =
         let x: Option[Option[Int32]] = Some(Some(1));
-        join(x) == Some(1)
-
-    /////////////////////////////////////////////////////////////////////////////
-    // bind                                                                    //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @test
-    def bind01(): Bool =
-        bind(None, x -> Some((x, x))) == None
-
-    @test
-    def bind02(): Bool =
-        bind(Some(1), x -> Some((x, x))) == Some((1, 1))
+        flatten(x) == Some(1)
 
     /////////////////////////////////////////////////////////////////////////////
     // kleisliLeft                                                             //
@@ -119,33 +60,5 @@ namespace TestMonad {
     @test
     def kleisliRight02(): Bool =
         kleisliRight(x1 -> Some(ToString.toString(x1)), x2 -> Some(x2 + 1), 1) == Some("2")
-
-    /////////////////////////////////////////////////////////////////////////////
-    // whenTrueM                                                               //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @test
-    def whenTrueM01(): Bool =
-        let ma = whenTrueM(point(true), update(s -> s+100));
-        runState(ma, 0) as & Pure == (100, ())
-
-    @test
-    def whenTrueM02(): Bool =
-        let ma = whenTrueM(point(false), update(s -> s+100));
-        runState(ma, 0) as & Pure == (0, ())
-
-    /////////////////////////////////////////////////////////////////////////////
-    // whenFalseM                                                              //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @test
-    def whenFalseM01(): Bool =
-        let ma = whenFalseM(point(false), update(s -> s+100));
-        runState(ma, 0) as & Pure == (100, ())
-
-    @test
-    def whenFalseM02(): Bool =
-        let ma = whenFalseM(point(true), update(s -> s+100));
-        runState(ma, 0) as & Pure == (0, ())
 
 }


### PR DESCRIPTION
This PR adds a small set of combinators to Functor, Applicative and Monad and adds test suites for those modules.

I've limited the combintors in this PR to named ones (no operators) and avoided traversals (examples would be `mapM` etc). I'd like Flix to have operators and effectful traversals soon, but there is probably more bikeshedding about naming and typing for these functions so I've left them out.

The PR adds:

`ignore` to Functor - this is called `void` in Haskell but I wanted to avoid the name.

`seqLeft` to Applicative - this is `(<*)` in Haskell 

`seqRight` to Applicative - this is `(*>)` in Haskell 

`whenTrue` to Applicative - this is `when` in Haskell / PureScript

`whenFalse` to Applicative - this is `unless` in Haskell / PureScript

`join` to Monad

`bind` to Monad - this is `flatMap` with the arguments flipped

`kleisliLeft` to Monad - this is `(<=<)` in Haskell 

`kleisliRight` to Monad - this is `(>=>)` in Haskell 

`whenTrueM` to Applicative - this is `whenM` in PureScript

`whenFalseM` to Applicative - this is `unlessM` in PureScript 


I've always disliked the `when` and `unless` pair in Haskell. To me the names don't sufficiently imply which should be for the true case and which for the false case so I've gone for longer but more explicit names.

I re-indented Functor to use 4 spaces so the module looks like it has more changes than it actually has.