### PR TITLE
feat: add monadic folds to Foldable

### DIFF
--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -217,6 +217,42 @@ pub lawless class Foldable[t : Type -> Type] {
     pub def foreach(f: a -> Unit & ef, t: t[a]): Unit & ef =
         Foldable.foldLeft((_, x) -> f(x), (), t)
 
+
+    // Acknowledgement: `foldLeftM` and `foldRightM` are derived from Haskell's Data.Foldable.
+    // Because they use CPS, the implementations work for both strict and lazy languages.
+    // Counterintuitively `foldLeftM` uses a right-fold and `foldRighM` uses a left-fold
+    // but the "direction of travel" is observably correct.
+
+    ///
+    /// A monadic version of `foldLeft`.
+    ///
+    /// Applies the monadic `f` to a start value `s` and all elements in `t` going
+    /// from left to right.
+    ///
+    pub def foldLeftM(f: (b, a) -> m[b] & ef, s: b, t: t[a]): m[b] & ef with Monad[m] =
+        let f1 = (x, k) -> z -> Monad.flatMap(k, f(z, x));
+        s |> Foldable.foldRight(f1, x1 -> Applicative.point(x1) as & ef, t)
+
+    ///
+    /// A monadic version of `foldRight`.
+    ///
+    /// Applies the monadic `f` to a start value `s` and all elements in `t` going
+    /// from right to left.
+    ///
+    pub def foldRightM(f: (a, b) -> m[b] & ef, s: b, t: t[a]): m[b] & ef with Monad[m] =
+        let f1 = (k, x) -> z -> Monad.flatMap(k, f(x, z));
+        s |> Foldable.foldLeft(f1, x1 -> Applicative.point(x1) as & ef, t)
+
+    ///
+    /// A monadic version of `foreach`.
+    ///
+    /// Apply `f` to every value in `t`. `f` is applied for its monadic effect,
+    /// the answer it produces is discarded.
+    ///
+    pub def foreachM(f: a -> m[b] & ef, t: t[a]): m[Unit] & ef with Monad[m] =
+        use Applicative.{point, *>};
+        Foldable.foldLeftM((acc, a) -> f(a) *> point(acc), (), t)
+
 }
 
 namespace Foldable {
@@ -228,34 +264,4 @@ namespace Foldable {
     ///
     pub def fold[t: Type -> Type, a: Type](t: t[a]): a with Foldable[t], Monoid[a] =
         Foldable.foldLeft((acc, x) -> Monoid.combine(acc, x), Monoid.empty(), t)
-
-    ///
-    /// A monadic version of `foldLeft`.
-    ///
-    /// Applies the monadic `f` to a start value `s` and all elements in `t` going
-    /// from left to right.
-    ///
-    pub def foldLeftM(f: (b, a) -> m[b] & ef, s: b, t: t[a]): m[b] & ef with Foldable[t], Monad[m] =
-        let f1 = (x, k) -> z -> Monad.flatMap(k, f(z, x));
-        s |> Foldable.foldRight(f1, x1 -> Applicative.point(x1) as & ef, t)
-
-    ///
-    /// A monadic version of `foldRight`.
-    ///
-    /// Applies the monadic `f` to a start value `s` and all elements in `t` going
-    /// from right to left.
-    ///
-    pub def foldRightM(f: (a, b) -> m[b] & ef, s: b, t: t[a]): m[b] & ef with Foldable[t], Monad[m] =
-        let f1 = (k, x) -> z -> Monad.flatMap(k, f(x, z));
-        s |> Foldable.foldLeft(f1, x1 -> Applicative.point(x1) as & ef, t)
-
-    ///
-    /// A monadic version of `foreach`.
-    ///
-    /// Apply `f` to every value in `t`. `f` is applied for its monadic effect,
-    /// the answer it produces is discarded.
-    ///
-    pub def foreachM(f: a -> m[b] & ef, t: t[a]): m[Unit] & ef with Foldable[t], Monad[m] =
-        foldLeftM((acc, a) -> f(a) *> Applicative.point(acc), (), t)
-
 }

--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -221,9 +221,41 @@ pub lawless class Foldable[t : Type -> Type] {
 
 namespace Foldable {
 
+    use Applicative.{*>};
+
     ///
     /// Returns the result of applying `combine` to all the elements in `t`, using `empty` as the initial value.
     ///
     pub def fold[t: Type -> Type, a: Type](t: t[a]): a with Foldable[t], Monoid[a] =
         Foldable.foldLeft((acc, x) -> Monoid.combine(acc, x), Monoid.empty(), t)
+
+    ///
+    /// A monadic version of `foldLeft`.
+    ///
+    /// Applies the monadic `f` to a start value `s` and all elements in `t` going
+    /// from left to right.
+    ///
+    pub def foldLeftM(f: (b, a) -> m[b], s: b, t: t[a]): m[b] with Foldable[t], Monad[m] =
+        let f1 = (x, k) -> z -> Monad.flatMap(k, f(z, x));
+        s |> Foldable.foldRight(f1, Applicative.point, t)
+
+    ///
+    /// A monadic version of `foldRight`.
+    ///
+    /// Applies the monadic `f` to a start value `s` and all elements in `t` going
+    /// from right to left.
+    ///
+    pub def foldRightM(f: (a, b) -> m[b], s: b, t: t[a]): m[b] with Foldable[t], Monad[m] =
+        let f1 = (k, x) -> z -> Monad.flatMap(k, f(x, z));
+        s |> Foldable.foldLeft(f1, Applicative.point, t)
+
+    ///
+    /// A monadic version of `foreach`.
+    ///
+    /// Apply `f` to every value in `t`. `f` is applied for its monadic effect,
+    /// the answer it produces is discarded.
+    ///
+    pub def foreachM(f: a -> m[b], t: t[a]): m[Unit] with Foldable[t], Monad[m] =
+        foldLeftM((acc, a) -> f(a) *> Applicative.point(acc), (), t)
+
 }

--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -235,9 +235,9 @@ namespace Foldable {
     /// Applies the monadic `f` to a start value `s` and all elements in `t` going
     /// from left to right.
     ///
-    pub def foldLeftM(f: (b, a) -> m[b], s: b, t: t[a]): m[b] with Foldable[t], Monad[m] =
+    pub def foldLeftM(f: (b, a) -> m[b] & ef, s: b, t: t[a]): m[b] & ef with Foldable[t], Monad[m] =
         let f1 = (x, k) -> z -> Monad.flatMap(k, f(z, x));
-        s |> Foldable.foldRight(f1, Applicative.point, t)
+        s |> Foldable.foldRight(f1, x1 -> Applicative.point(x1) as & ef, t)
 
     ///
     /// A monadic version of `foldRight`.
@@ -245,9 +245,9 @@ namespace Foldable {
     /// Applies the monadic `f` to a start value `s` and all elements in `t` going
     /// from right to left.
     ///
-    pub def foldRightM(f: (a, b) -> m[b], s: b, t: t[a]): m[b] with Foldable[t], Monad[m] =
+    pub def foldRightM(f: (a, b) -> m[b] & ef, s: b, t: t[a]): m[b] & ef with Foldable[t], Monad[m] =
         let f1 = (k, x) -> z -> Monad.flatMap(k, f(x, z));
-        s |> Foldable.foldLeft(f1, Applicative.point, t)
+        s |> Foldable.foldLeft(f1, x1 -> Applicative.point(x1) as & ef, t)
 
     ///
     /// A monadic version of `foreach`.
@@ -255,7 +255,7 @@ namespace Foldable {
     /// Apply `f` to every value in `t`. `f` is applied for its monadic effect,
     /// the answer it produces is discarded.
     ///
-    pub def foreachM(f: a -> m[b], t: t[a]): m[Unit] with Foldable[t], Monad[m] =
+    pub def foreachM(f: a -> m[b] & ef, t: t[a]): m[Unit] & ef with Foldable[t], Monad[m] =
         foldLeftM((acc, a) -> f(a) *> Applicative.point(acc), (), t)
 
 }

--- a/main/test/ca/uwaterloo/flix/library/LibrarySuite.scala
+++ b/main/test/ca/uwaterloo/flix/library/LibrarySuite.scala
@@ -69,4 +69,5 @@ class LibrarySuite extends Suites(
   new FlixTest("TestFunctor", "main/test/ca/uwaterloo/flix/library/TestFunctor.flix")(Options.TestWithLibAll),
   new FlixTest("TestApplicative", "main/test/ca/uwaterloo/flix/library/TestApplicative.flix")(Options.TestWithLibAll),
   new FlixTest("TestMonad", "main/test/ca/uwaterloo/flix/library/TestMonad.flix")(Options.TestWithLibAll),
+  new FlixTest("TestFoldable", "main/test/ca/uwaterloo/flix/library/TestFoldable.flix")(Options.TestWithLibAll),
 )

--- a/main/test/ca/uwaterloo/flix/library/TestFoldable.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFoldable.flix
@@ -18,7 +18,7 @@ namespace TestFoldable {
 
     use Applicative.{point, *>};
 
-    /// To check foldLeftM, foldRightM, foreachM we want a monad with
+    /// To test foldLeftM, foldRightM, foreachM we want a monad with
     /// "side-effects" so we can log direction of travel.
 
     opaque type Logger[i, a] = (Chain[i], a)

--- a/main/test/ca/uwaterloo/flix/library/TestFoldable.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFoldable.flix
@@ -1,0 +1,136 @@
+/*
+ *  Copyright 2021 Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace TestFoldable {
+
+    use Applicative.{point, *>};
+
+    /// To check foldLeftM, foldRightM, foreachM we want a monad with
+    /// "side-effects" so we can log direction of travel.
+
+    opaque type Logger[i, a] = (Chain[i], a)
+
+    def tell(x: i): Logger[i, Unit] = Logger((Chain.singleton(x), ()))
+
+    def runLogger(ma: Logger[i, a]): (List[i], a) =
+        let Logger((w, a)) = ma;
+        (Chain.toList(w), a)
+
+
+    instance Functor[Logger[i]] {
+        pub def map(f: a -> b & ef, ma: Logger[i, a]): Logger[i, b] & ef =
+            let Logger((w, a)) = ma;
+            Logger((w, f(a)))
+    }
+
+    instance Applicative[Logger[i]] {
+        pub def point(x: a): Logger[i, a] = Logger(Chain.empty(), x)
+
+        pub def ap(mf: Logger[i, a -> b & ef], ma: Logger[i, a]): Logger[i, b] & ef =
+            let Logger((w1, f)) = mf;
+            let Logger((w2, a)) = ma;
+            Logger((Chain.append(w1, w2), f(a)))
+        }
+
+
+    instance Monad[Logger[i]] {
+        pub def flatMap(f: a -> Logger[i, b] & ef, ma: Logger[i, a]): Logger[i, b] & ef =
+            let Logger((w1, a)) = ma;
+            let Logger((w2, b)) = f(a);
+            Logger((Chain.append(w1, w2), b))
+    }
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // fold                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def fold01(): Bool =
+        Foldable.fold(Nil: List[String]) == ""
+
+    @test
+    def fold02(): Bool =
+        Foldable.fold("a" :: Nil) == "a"
+
+    @test
+    def fold03(): Bool =
+        Foldable.fold("a" :: "b" :: Nil) == "ab"
+
+    /////////////////////////////////////////////////////////////////////////////
+    // foldLeftM                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    def foldLeftStep(acc: Int32, a: Int32): Logger[Int32, Int32] =
+        tell(a) *> point(acc+a)
+
+    @test
+    def foldLeftM01(): Bool =
+        let xs: List[Int32] = Nil;
+        runLogger(Foldable.foldLeftM(foldLeftStep, 0, xs)) == (Nil, 0)
+
+    @test
+    def foldLeftM02(): Bool =
+        let xs = 1 :: 2 :: Nil;
+        runLogger(Foldable.foldLeftM(foldLeftStep, 0, xs)) == (1 :: 2 :: Nil, 3)
+
+    @test
+    def foldLeftM03(): Bool =
+        let xs = 1 :: 2 :: 3 :: 4 :: 5 :: Nil;
+        runLogger(Foldable.foldLeftM(foldLeftStep, 0, xs)) == (1 :: 2 :: 3 :: 4 :: 5 :: Nil, 15)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // foldRightM                                                              //
+    /////////////////////////////////////////////////////////////////////////////
+
+    def foldRightStep(a: Int32, acc: Int32): Logger[Int32, Int32] =
+        tell(a) *> point(acc+a)
+
+    @test
+    def foldRightM01(): Bool =
+        let xs: List[Int32] = Nil;
+        runLogger(Foldable.foldRightM(foldRightStep, 0, xs)) == (Nil, 0)
+
+    @test
+    def foldRightM02(): Bool =
+        let xs = 1 :: 2 :: Nil;
+        runLogger(Foldable.foldRightM(foldRightStep, 0, xs)) == (2 :: 1 :: Nil, 3)
+
+    @test
+    def foldRightM03(): Bool =
+        let xs = 1 :: 2 :: 3 :: 4 :: 5 :: Nil;
+        runLogger(Foldable.foldRightM(foldRightStep, 0, xs)) == (5 :: 4 :: 3 :: 2 :: 1 :: Nil, 15)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // foreachM                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def foreachM01(): Bool =
+        let xs: List[Int32] = Nil;
+        runLogger(Foldable.foreachM(tell, xs)) == (Nil, ())
+
+    @test
+    def foreachM02(): Bool =
+        let xs = 1 :: 2 :: Nil;
+        runLogger(Foldable.foreachM(tell, xs)) == (1 :: 2 :: Nil, ())
+
+    @test
+    def foreachM03(): Bool =
+        let xs = 1 :: 2 :: 3 :: 4 :: 5 :: Nil;
+        runLogger(Foldable.foreachM(tell, xs)) == (1 :: 2 :: 3 :: 4 :: 5 :: Nil, ())
+
+}


### PR DESCRIPTION
This PR adds `foldLeftM`, `foldRightM` and `foreachM` to `Foldable` as functions in the namespace plus a test suite.

Discussion points: 

I added `foldLeftM` etc. as functions rather than class methods because the implementations are a bit "tricky" - `foldLeftM` and `foldRightM` are ported from Haskell's stdlib, they build functions that are applied to the state.

`foreachM` could have been called `mapX` following a naming convention we've used a bit with "X" meaning _forgetful_. I'm now not so happy with this convention (even though I think I introduced it) so I have avoided it.  
