### PR TITLE
refactor: test for `Iterator.unfoldWithOk`

### DIFF
--- a/main/test/ca/uwaterloo/flix/library/TestIterator.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterator.flix
@@ -128,6 +128,13 @@ namespace TestIterator {
         let _ = invokeIsEmpty(100, iter);
         Iterator.toList(iter) == 1 :: 11 :: 12 :: 13 :: 2 :: 3 :: Nil
 
+    @test
+    def isEmpty13(): Bool & Impure = // unfoldWithOk
+        let Iterator(d, n) = List.toIterator(1 :: 2 :: 3 :: 4 :: 5 :: Nil);
+        let iter = Iterator.unfoldWithOk(() -> if (d()) Err("Done") else Ok(n()));
+        let _ = invokeIsEmpty(100, iter);
+        Iterator.toList(iter) == 1 :: 2 :: 3 :: 4 :: 5 :: Nil
+
     ///
     /// Helper function that invokes `Iterator.isEmpty` `n` times.
     ///
@@ -1043,19 +1050,5 @@ namespace TestIterator {
             List.toIterator;
         Iterator.unfoldWithOk(() -> { d(); n() }) |>
             Iterator.toList == 1 :: 2 :: 3 :: Nil
-
-    @test
-    def unfoldWithOk04(): Bool & Impure =
-        let Iterator(d, n) = List.toIterator(1 :: 2 :: 3 :: 4 :: 5 :: Nil);
-        let Iterator(d1, n1) = Iterator.unfoldWithOk(() -> if (d()) Err("Done") else Ok(n()));
-        def loop(n) =
-            if (n <= 0)
-                true
-            else {
-                d1();
-                loop(n - 1)
-            };
-        let _ = loop(10); // Call done 10 times
-        Iterator.toList(Iterator(d1, n1)) == 1 :: 2 :: 3 :: 4 :: 5 :: Nil
 
 }


### PR DESCRIPTION
Move `isEmpty` for `unfoldWithOk` to `isEmpty` section. Mentioned in #2907