### PR TITLE
feat: add product3, product4 and product5 to Applicative #2935

### DIFF
--- a/main/src/library/Applicative.flix
+++ b/main/src/library/Applicative.flix
@@ -143,6 +143,24 @@ namespace Applicative {
         Applicative.liftA2((_, b) -> b, fa, fb)
 
     ///
+    /// Chain three applicative actions, return the 3-tuple of their results.
+    ///
+    pub def product3(x1: m[t1], x2: m[t2], x3: m[t3]): m[(t1, t2, t3)] with Applicative[m] =
+        Applicative.liftA3((a, b, c) -> (a, b, c), x1, x2, x3)
+
+    ///
+    /// Chain four applicative actions, return the 4-tuple of their results.
+    ///
+    pub def product4(x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4]): m[(t1, t2, t3, t4)] with Applicative[m] =
+        Applicative.liftA4((a, b, c, d) -> (a, b, c, d), x1, x2, x3, x4)
+
+    ///
+    /// Chain five applicative actions, return the 5-tuple of their results.
+    ///
+    pub def product5(x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4], x5: m[t5]): m[(t1, t2, t3, t4, t5)] with Applicative[m] =
+        Applicative.liftA5((a, b, c, d, e) -> (a, b, c, d, e), x1, x2, x3, x4, x5)
+
+    ///
     /// `<*>` is an operator alias for `ap`.
     ///
     pub def <*>(mf: m[a -> b & ef], ma: m[a]): m[b] & ef with Applicative[m] = Applicative.ap(mf, ma)

--- a/main/test/ca/uwaterloo/flix/library/TestApplicative.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestApplicative.flix
@@ -16,7 +16,7 @@
 
 namespace TestApplicative {
 
-    use Applicative.{product, productLeft, productRight};
+    use Applicative.{product, productLeft, productRight, product3, product4, product5};
     use Applicative.{<*>, <**>, *>, <*};
 
     /////////////////////////////////////////////////////////////////////////////
@@ -102,6 +102,66 @@ namespace TestApplicative {
     @test
     def productRight06(): Bool =
         productRight(1 :: Nil, 2 :: Nil) == 2 :: Nil
+
+    /////////////////////////////////////////////////////////////////////////////
+    // product3                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def product301(): Bool =
+        product3(None, None, None) == None
+
+    @test
+    def product302(): Bool =
+        product3(None, Some(2), Some(3)) == None
+
+    @test
+    def product303(): Bool =
+        product3(Some(1), Some(2), None) == None
+
+    @test
+    def product304(): Bool =
+        product3(Some(1), Some(2), Some(3)) == Some((1, 2, 3))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // product4                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def product401(): Bool =
+        product4(None, None, None, None) == None
+
+    @test
+    def product402(): Bool =
+        product4(None, Some(2), Some(3), Some(4)) == None
+
+    @test
+    def product403(): Bool =
+        product4(Some(1), Some(2), Some(3), None) == None
+
+    @test
+    def product404(): Bool =
+        product4(Some(1), Some(2), Some(3), Some(4)) == Some((1, 2, 3, 4))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // product5                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def product501(): Bool =
+        product5(None, None, None, None, None) == None
+
+    @test
+    def product502(): Bool =
+        product5(None, Some(2), Some(3), Some(4), Some(5)) == None
+
+    @test
+    def product503(): Bool =
+        product5(Some(1), Some(2), Some(3), Some(4), None) == None
+
+    @test
+    def product504(): Bool =
+        product5(Some(1), Some(2), Some(3), Some(4), Some(5)) == Some((1, 2, 3, 4, 5))
 
     /////////////////////////////////////////////////////////////////////////////
     // symAp (<*>)                                                             //


### PR DESCRIPTION
This PR adds `product3`, `product4` and `product5` to `Applicative` - these are a family of functions like `liftN` but they produce tuples rather than take a "consolidation function".

Naming follows `liftA`.

See issue  #2935 "Applicative - product3, product4 and product5 ?"