### PR TITLE
refactor: remove `:browse`, `:benchmark`, `:doc`, `:hole`, and `:search`

### DIFF
--- a/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
@@ -41,11 +41,6 @@ object Command {
   case object Reload extends Command
 
   /**
-    * Runs all unit tests in the program.
-    */
-  case object Test extends Command
-
-  /**
     * Warms up the compiler.
     */
   case object Warmup extends Command
@@ -107,12 +102,6 @@ object Command {
     //
     if (input == ":r" || input == ":reload")
       return Command.Reload
-
-    //
-    // Test
-    //
-    if (input == ":test")
-      return Command.Test
 
     //
     // Warmup

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
@@ -36,11 +36,6 @@ object Command {
   case object Run extends Command
 
   /**
-    * Shows the context for the given hole `fqn`.
-    */
-  case class Hole(fqnOpt: Option[String]) extends Command
-
-  /**
     * Reloads all source paths.
     */
   case object Reload extends Command
@@ -106,17 +101,6 @@ object Command {
     //
     if (input.startsWith(":run"))
       return Command.Run
-
-    //
-    // Hole
-    //
-    if (input.startsWith(":hole")) {
-      val fqn = input.substring(":hole".length).trim
-      if (fqn.isEmpty)
-        return Command.Hole(None)
-      else
-        return Command.Hole(Some(fqn))
-    }
 
     //
     // Reload

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
@@ -46,11 +46,6 @@ object Command {
   case object Reload extends Command
 
   /**
-    * Runs all benchmarks in the program.
-    */
-  case object Benchmark extends Command
-
-  /**
     * Runs all unit tests in the program.
     */
   case object Test extends Command
@@ -128,12 +123,6 @@ object Command {
     //
     if (input == ":r" || input == ":reload")
       return Command.Reload
-
-    //
-    // Benchmark
-    //
-    if (input == ":benchmark")
-      return Command.Benchmark
 
     //
     // Test

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
@@ -41,21 +41,6 @@ object Command {
   case class Hole(fqnOpt: Option[String]) extends Command
 
   /**
-    * Shows the definitions, relations, and lattices in the given namespace.
-    */
-  case class Browse(ns: Option[String]) extends Command
-
-  /**
-    * Show the documentation for the given fully-qualified name.
-    */
-  case class Doc(fqn: String) extends Command
-
-  /**
-    * Searches for a definition symbol which contains `needle` as part of its name.
-    */
-  case class Search(needle: String) extends Command
-
-  /**
     * Reloads all source paths.
     */
   case object Reload extends Command
@@ -136,41 +121,6 @@ object Command {
         return Command.Hole(None)
       else
         return Command.Hole(Some(fqn))
-    }
-
-    //
-    // Browse
-    //
-    if (input.startsWith(":browse")) {
-      if (input.trim == ":browse") {
-        return Command.Browse(None)
-      }
-      val ns = input.substring(":browse".length).trim
-      return Command.Browse(Some(ns))
-    }
-
-    //
-    // Doc
-    //
-    if (input.startsWith(":doc ")) {
-      val fqn = input.substring(":doc ".length).trim
-      if (fqn.isEmpty) {
-        terminal.writer().println("Missing argument for command :doc.")
-        return Command.Nop
-      }
-      return Command.Doc(fqn)
-    }
-
-    //
-    // Search
-    //
-    if (input.startsWith(":search ")) {
-      val needle = input.substring(":search ".length).trim
-      if (needle.isEmpty) {
-        terminal.writer().println("Missing argument for command :search.")
-        return Command.Nop
-      }
-      return Command.Search(needle)
     }
 
     //

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -161,7 +161,6 @@ class Shell(initialPaths: List[Path], options: Options) {
     case Command.Run => execRun()
     case Command.Hole(fqnOpt) => execHole(fqnOpt)
     case Command.Reload => execReload()
-    case Command.Benchmark => execBenchmark()
     case Command.Test => execTest()
     case Command.Warmup => execWarmup()
     case Command.Watch => execWatch()
@@ -289,14 +288,6 @@ class Shell(initialPaths: List[Path], options: Options) {
   }
 
   /**
-    * Run all benchmarks in the program.
-    */
-  private def execBenchmark()(implicit terminal: Terminal): Unit = {
-    // Run all benchmarks.
-    Benchmarker.benchmark(this.compilationResult, terminal.writer())(options)
-  }
-
-  /**
     * Run all unit tests in the program.
     */
   private def execTest()(implicit terminal: Terminal): Unit = {
@@ -374,7 +365,6 @@ class Shell(initialPaths: List[Path], options: Options) {
     w.println("  :run                            Runs the main function.")
     w.println("  :hole         <fqn>             Shows the hole context of <fqn>.")
     w.println("  :reload :r                      Recompiles every source file.")
-    w.println("  :benchmark                      Run all benchmarks in the program and show the results.")
     w.println("  :test                           Run all unit tests in the program and show the results.")
     w.println("  :warmup                         Warms up the compiler by running it multiple times.")
     w.println("  :watch :w                       Watches all source files for changes.")


### PR DESCRIPTION
Fixes #2946