### PR TITLE
feat: disallow `()` after enum case

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -142,13 +142,14 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     def Enum: Rule1[ParsedAst.Declaration.Enum] = {
       def Case: Rule1[ParsedAst.Case] = {
+        // the optional `()` prevents () from being seen as an empty record row
         def CaseWithUnit: Rule1[ParsedAst.Case] = namedRule("Case") {
-          SP ~ Names.Tag ~ SP ~> ((sp1: SourcePosition, ident: Name.Ident, sp2: SourcePosition) =>
+          SP ~ Names.Tag ~ SP ~ optional("()") ~> ((sp1: SourcePosition, ident: Name.Ident, sp2: SourcePosition) =>
             ParsedAst.Case(sp1, ident, ParsedAst.Type.Unit(sp1, sp2), sp2))
         }
 
         def CaseWithType: Rule1[ParsedAst.Case] = namedRule("Case") {
-          SP ~ Names.Tag ~ Type ~ SP ~> ParsedAst.Case
+          SP ~ Names.Tag ~ Types.Tuple ~ SP ~> ParsedAst.Case
         }
 
         rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -142,9 +142,8 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     def Enum: Rule1[ParsedAst.Declaration.Enum] = {
       def Case: Rule1[ParsedAst.Case] = {
-        // the optional `()` prevents () from being seen as an empty record row
         def CaseWithUnit: Rule1[ParsedAst.Case] = namedRule("Case") {
-          SP ~ Names.Tag ~ SP ~ optional("()") ~> ((sp1: SourcePosition, ident: Name.Ident, sp2: SourcePosition) =>
+          SP ~ Names.Tag ~ SP ~> ((sp1: SourcePosition, ident: Name.Ident, sp2: SourcePosition) =>
             ParsedAst.Case(sp1, ident, ParsedAst.Type.Unit(sp1, sp2), sp2))
         }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -359,4 +359,15 @@ class TestParser extends FunSuite with TestUtils {
     expectError[ParseError](result)
   }
 
+  test("ParseError.EnumCase.01") {
+    val input =
+      """
+        |enum E {
+        |    case C()
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ParseError](result)
+  }
+
 }

--- a/main/test/flix/Test.Dec.Enum.flix
+++ b/main/test/flix/Test.Dec.Enum.flix
@@ -2,9 +2,4 @@ namespace Test/Dec/Enum {
     pub enum Empty
 
     pub enum EmptyWithBraces {}
-
-    pub enum E {
-        case CaseWithoutParens
-        case CaseWithParens()
-    }
 }

--- a/main/test/flix/Test.Dec.Enum.flix
+++ b/main/test/flix/Test.Dec.Enum.flix
@@ -2,4 +2,9 @@ namespace Test/Dec/Enum {
     pub enum Empty
 
     pub enum EmptyWithBraces {}
+
+    pub enum E {
+        case CaseWithoutParens
+        case CaseWithParens()
+    }
 }


### PR DESCRIPTION
~This implementation allows the `()` and parses as if it were not there. The other option is to disallow it.~

This implementation disallows `()` at the end of an enum case. (E.g. `case C()`)

fixes https://github.com/flix/flix/issues/3002