### PR TITLE
ci: add community build script

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -8,7 +8,7 @@ jobs:
     env:
       # === ADD PROJECTS HERE === #
       #   (space-separated list)  #
-      PROJECTS: ""
+      PROJECTS: magnus-madsen/helloworld
 
       PROJ_DIR: project-build
 

--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -1,0 +1,37 @@
+on: [pull_request]
+
+jobs:
+  community-build:
+
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      # === ADD PROJECTS HERE === #
+      #   (space-separated list)  #
+      PROJECTS: ""
+
+      PROJ_DIR: project-build
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Build jar
+        run: ./gradlew jar
+      - name: Build community projects
+        run: |
+          # Sanity check: Make sure the project build directory does not exist.
+          test ! -e ${{ env.PROJ_DIR }}
+          
+          # Build each project in a fresh directory.
+          for project in ${{ env.PROJECTS }}; do
+            mkdir ${{ env.PROJ_DIR }}
+            cd ${{ env.PROJ_DIR }}
+            java -jar ../build/libs/flix.jar init
+            java -jar ../build/libs/flix.jar install $project
+            java -jar ../build/libs/flix.jar build
+            cd ..
+            rm -rf ${{ env.PROJ_DIR }}
+          done


### PR DESCRIPTION
A basic initial version. Takes a list of projects and installs and builds each individually.

Future work includes:
* actually adding projects to the list
* collecting a list of failures instead of failing fast
* dependency management

Depends on https://github.com/flix/flix/pull/3044
Related to #2943 