### PR TITLE
feat: do not emit JVM bytecode unless `--output` is specified

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -82,9 +82,9 @@ object Main {
       explain = cmdOpts.explain,
       incremental = cmdOpts.xincremental,
       json = cmdOpts.json,
+      output = cmdOpts.output.map(s => Paths.get(s)),
       progress = true,
       threads = cmdOpts.threads.getOrElse(Runtime.getRuntime.availableProcessors()),
-      writeClassFiles = !cmdOpts.interactive,
       xnostratifier = cmdOpts.xnostratifier,
       xperf = cmdOpts.xperf,
       xstatistics = cmdOpts.xstatistics,
@@ -254,6 +254,7 @@ object Main {
                      json: Boolean = false,
                      listen: Option[Int] = None,
                      lsp: Option[Int] = None,
+                     output: Option[String] = None,
                      test: Boolean = false,
                      threads: Option[Int] = None,
                      xbenchmarkCodeSize: Boolean = false,
@@ -376,6 +377,11 @@ object Main {
       opt[Int]("lsp").action((s, c) => c.copy(lsp = Some(s))).
         valueName("<port>").
         text("starts the LSP server and listens on the given port.")
+
+      // Output.
+      opt[String]("output").action((s, c) => c.copy(output = Some(s))).
+        text("specifies the output directory for JVM bytecode.")
+
       // Test.
       opt[Unit]("test").action((_, c) => c.copy(test = true)).
         text("runs unit tests.")

--- a/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
@@ -44,7 +44,7 @@ object Documentor {
   /**
     * The directory where to write the ouput.
     */
-  val OutputDirectory: Path = Paths.get("./target/api")
+  val OutputDirectory: Path = Paths.get("./build/api")
 
   /**
     * The audience to use for formatting types and effects.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -205,11 +205,11 @@ object JvmBackend {
     // Write each class (and interface) to disk.
     //
     // NB: In interactive and test mode we skip writing the files to disk.
-    if (flix.options.writeClassFiles && !flix.options.test) {
+    if (flix.options.output.nonEmpty) {
       flix.subphase("WriteClasses") {
         for ((_, jvmClass) <- allClasses) {
           flix.subtask(jvmClass.name.toBinaryName, sample = true)
-          JvmOps.writeClass(flix.options.targetDirectory, jvmClass)
+          JvmOps.writeClass(flix.options.output.get, jvmClass)
         }
       }
     }

--- a/main/src/ca/uwaterloo/flix/tools/BenchmarkCompiler.scala
+++ b/main/src/ca/uwaterloo/flix/tools/BenchmarkCompiler.scala
@@ -186,7 +186,7 @@ object BenchmarkCompiler {
   private def newFlix(o: Options): Flix = {
     val flix = new Flix()
 
-    flix.setOptions(opts = o.copy(loadClassFiles = false, writeClassFiles = false))
+    flix.setOptions(opts = o.copy(loadClassFiles = false))
 
     // NB: We only use unit tests from the standard library because we want to test real code.
 

--- a/main/src/ca/uwaterloo/flix/tools/Packager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Packager.scala
@@ -187,9 +187,9 @@ object Packager {
 
     // Configure a new Flix object.
     val newOptions = o.copy(
-      targetDirectory = getBuildDirectory(p),
-      loadClassFiles = loadClasses,
-      writeClassFiles = true)
+      output = Some(getBuildDirectory(p)),
+      loadClassFiles = loadClasses
+    )
     flix.setOptions(newOptions)
 
     // Add sources and packages.

--- a/main/src/ca/uwaterloo/flix/tools/SocketServer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/SocketServer.scala
@@ -117,18 +117,10 @@ class SocketServer(port: Int) extends WebSocketServer(new InetSocketAddress(port
       case _ => false
     }
 
-    // --Xno-stratifier
-    val xnostratifier = json \\ "xnostratifier" match {
-      case JBool(b) => b
-      case _ => false
-    }
-
     // Construct the options object.
     val opts = Options.Default.copy(
       lib = if (xcore) LibLevel.Min else LibLevel.All,
-      writeClassFiles = false,
-      xallowredundancies = xallowredundancies,
-      xnostratifier = xnostratifier,
+      xallowredundancies = xallowredundancies
     )
 
     // Return the source and options.

--- a/main/src/ca/uwaterloo/flix/util/Options.scala
+++ b/main/src/ca/uwaterloo/flix/util/Options.scala
@@ -16,7 +16,7 @@
 
 package ca.uwaterloo.flix.util
 
-import java.nio.file.{Path, Paths}
+import java.nio.file.Path
 
 object Options {
   /**
@@ -29,13 +29,12 @@ object Options {
     explain = false,
     incremental = false,
     json = false,
+    output = None,
     progress = false,
     test = false,
     target = JvmTarget.Version18,
-    targetDirectory = Paths.get("./target/flix/"),
     threads = Runtime.getRuntime.availableProcessors(),
     loadClassFiles = true,
-    writeClassFiles = true,
     xallowredundancies = false,
     xnostratifier = false,
     xperf = false,
@@ -72,13 +71,12 @@ object Options {
   * @param documentor         enables generation of flixdoc.
   * @param incremental        enables incremental compilation.
   * @param json               enable json output.
+  * @param output             the optional output directory where to place JVM bytecode.
   * @param progress           print progress during compilation.
   * @param test               enables test mode.
   * @param target             the target JVM.
-  * @param targetDirectory    the target directory for compiled code.
   * @param threads            selects the number of threads to use.
   * @param loadClassFiles     loads the generated class files into the JVM.
-  * @param writeClassFiles    enables output of class files.
   * @param xallowredundancies disables the redundancy checker.
   * @param xnostratifier      disables computation of stratification.
   * @param xstatistics        enables statistics collection.
@@ -91,12 +89,11 @@ case class Options(lib: LibLevel,
                    incremental: Boolean,
                    json: Boolean,
                    progress: Boolean,
+                   output: Option[Path],
                    target: JvmTarget,
-                   targetDirectory: Path,
                    test: Boolean,
                    threads: Int,
                    loadClassFiles: Boolean,
-                   writeClassFiles: Boolean,
                    xallowredundancies: Boolean,
                    xnostratifier: Boolean,
                    xperf: Boolean,

--- a/main/test/ca/uwaterloo/flix/TestMain.scala
+++ b/main/test/ca/uwaterloo/flix/TestMain.scala
@@ -99,6 +99,12 @@ class TestMain extends FunSuite {
     assert(opts.lsp.nonEmpty)
   }
 
+  test("--output build") {
+    val args = Array("--output", "build", "p.flix")
+    val opts = Main.parseCmdOpts(args).get
+    assert(opts.output.contains("build"))
+  }
+
   test("--test") {
     val args = Array("--test", "p.flix")
     val opts = Main.parseCmdOpts(args).get


### PR DESCRIPTION
Fixes #3059