### PR TITLE
Rename foldRightL to foldRightLazy

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -668,9 +668,9 @@ namespace List {
     /// The function f must be pure.
     ///
     /// That is, the result is of the form: `f(x1, ...lazy f(xn-1, lazy f(xn, s))...)`.
-    /// The foldRightL function exists to allow early termination of a fold.
+    /// The foldRightLazy function exists to allow early termination of a fold.
     ///
-    pub def foldRightL(f: (a, Lazy[b]) -> b, s: b, l: List[a]): b =
+    pub def foldRightLazy(f: (a, Lazy[b]) -> b, s: b, l: List[a]): b =
         def loop(l2) = match l2 {
             case Nil     => s
             case y :: ys => f(y, lazy loop(ys))

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -338,10 +338,10 @@ namespace Nel {
     /// The function f must be pure.
     ///
     /// That is, the result is of the form: `f(x1, ...lazy f(xn-1, lazy f(xn, s))...)`.
-    /// The foldRightL function exists to allow early termination of a fold.
+    /// The foldRightLazy function exists to allow early termination of a fold.
     ///
-    pub def foldRightL(f: (a, Lazy[b]) -> b, s: b, l: Nel[a]): b = match l {
-        case Nel(x, xs) => f(x, lazy List.foldRightL(f, s, xs))
+    pub def foldRightLazy(f: (a, Lazy[b]) -> b, s: b, l: Nel[a]): b = match l {
+        case Nel(x, xs) => f(x, lazy List.foldRightLazy(f, s, xs))
     }
 
     ///

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -254,7 +254,7 @@ namespace Option {
     ///
     /// The function f must be pure.
     ///
-    pub def foldRightL(f: (a, Lazy[b]) -> b, o: Option[a], z: b): b = match o {
+    pub def foldRightLazy(f: (a, Lazy[b]) -> b, o: Option[a], z: b): b = match o {
         case None => z
         case Some(v) => f(v, lazy z)
     }

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -189,7 +189,7 @@ namespace Result {
     /// The function f must be pure.
     ///
     @Time(time(f)) @Space(space(f))
-    pub def foldRightL(f: (t, Lazy[a]) -> a, r: Result[t, e], z: a): a = match r {
+    pub def foldRightLazy(f: (t, Lazy[a]) -> a, r: Result[t, e], z: a): a = match r {
         case Ok(v) => f(v, lazy z)
         case Err(_) => z
     }

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -1024,19 +1024,19 @@ def foldRight03(): Bool = List.foldRight((e, i) -> (i - e)*(e rem 2 + 1), 100, 1
 def foldRight04(): Bool = List.foldRight((e, i) -> (i - e)*(e rem 2 + 1), 100, 1 :: 2 :: 3 :: Nil) == 382
 
 /////////////////////////////////////////////////////////////////////////////
-// foldRightL                                                              //
+// foldRightLazy                                                           //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldRightL01(): Bool = List.foldRightL((e, i) -> (force i - e) * (e rem 2 + 1), 100, Nil) == 100
+def foldRightLazy01(): Bool = List.foldRightLazy((e, i) -> (force i - e) * (e rem 2 + 1), 100, Nil) == 100
 
 @test
-def foldRightL02(): Bool = List.foldRightL((e, i) -> (force i - e) * (e rem 2 + 1), 100, 1 :: Nil) == 198
+def foldRightLazy02(): Bool = List.foldRightLazy((e, i) -> (force i - e) * (e rem 2 + 1), 100, 1 :: Nil) == 198
 
 @test
-def foldRightL03(): Bool = List.foldRightL((e, i) -> (force i - e) * (e rem 2 + 1), 100, 1 :: 2 :: Nil) == 194
+def foldRightLazy03(): Bool = List.foldRightLazy((e, i) -> (force i - e) * (e rem 2 + 1), 100, 1 :: 2 :: Nil) == 194
 
 @test
-def foldRightL04(): Bool = List.foldRightL((e, i) -> (force i - e) * (e rem 2 + 1), 100, 1 :: 2 :: 3 :: Nil) == 382
+def foldRightLazy04(): Bool = List.foldRightLazy((e, i) -> (force i - e) * (e rem 2 + 1), 100, 1 :: 2 :: 3 :: Nil) == 382
 
 /////////////////////////////////////////////////////////////////////////////
 // reduceLeft                                                              //

--- a/main/test/ca/uwaterloo/flix/library/TestNel.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestNel.flix
@@ -369,17 +369,17 @@ namespace Nel {
     def foldRight03(): Bool = foldRight((x, acc) -> acc - x, 0, Nel(1, 2 :: 3 :: Nil)) == -6
 
     /////////////////////////////////////////////////////////////////////////////
-    // foldRightL                                                              //
+    // foldRightLazy                                                           //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def foldRightL01(): Bool = foldRightL((x, acc) -> force acc - x, 0, Nel(1, Nil)) == -1
+    def foldRightLazy01(): Bool = foldRightLazy((x, acc) -> force acc - x, 0, Nel(1, Nil)) == -1
 
     @test
-    def foldRightL02(): Bool = foldRightL((x, acc) -> force acc - x, 0, Nel(1, 2 :: Nil)) == -3
+    def foldRightLazy02(): Bool = foldRightLazy((x, acc) -> force acc - x, 0, Nel(1, 2 :: Nil)) == -3
 
     @test
-    def foldRightL03(): Bool = foldRightL((x, acc) -> force acc - x, 0, Nel(1, 2 :: 3 :: Nil)) == -6
+    def foldRightLazy03(): Bool = foldRightLazy((x, acc) -> force acc - x, 0, Nel(1, 2 :: 3 :: Nil)) == -6
 
     /////////////////////////////////////////////////////////////////////////////
     // reduce                                                                  //

--- a/main/test/ca/uwaterloo/flix/library/TestOption.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestOption.flix
@@ -328,22 +328,22 @@ def foldRight04(): Bool = Option.foldRight((i, b) -> if (i == 2 and b) true else
 def foldRight05(): Bool = Option.foldRight((i, b) -> if (i == 2 and b) true else false, Some(2), true) == true
 
 /////////////////////////////////////////////////////////////////////////////
-// foldRightL                                                              //
+// foldRightLazy                                                           //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldRightL01(): Bool = Option.foldRightL((i, b) -> if (i == 2 and force b) true else false, None, false) == false
+def foldRightLazy01(): Bool = Option.foldRightLazy((i, b) -> if (i == 2 and force b) true else false, None, false) == false
 
 @test
-def foldRightL02(): Bool = Option.foldRightL((i, b) -> if (i == 2 and force b) true else false, Some(1), false) == false
+def foldRightLazy02(): Bool = Option.foldRightLazy((i, b) -> if (i == 2 and force b) true else false, Some(1), false) == false
 
 @test
-def foldRightL03(): Bool = Option.foldRightL((i, b) -> if (i == 2 and force b) true else false, Some(2), false) == false
+def foldRightLazy03(): Bool = Option.foldRightLazy((i, b) -> if (i == 2 and force b) true else false, Some(2), false) == false
 
 @test
-def foldRightL04(): Bool = Option.foldRightL((i, b) -> if (i == 2 and force b) true else false, Some(1), true) == false
+def foldRightLazy04(): Bool = Option.foldRightLazy((i, b) -> if (i == 2 and force b) true else false, Some(1), true) == false
 
 @test
-def foldRightL05(): Bool = Option.foldRightL((i, b) -> if (i == 2 and force b) true else false, Some(2), true) == true
+def foldRightLazy05(): Bool = Option.foldRightLazy((i, b) -> if (i == 2 and force b) true else false, Some(2), true) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // sequence                                                                //

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -226,22 +226,22 @@ def foldRight05(): Bool = Result.foldRight((i, b) -> if (i == 2 and b) true else
 
 
 /////////////////////////////////////////////////////////////////////////////
-// foldRightL                                                              //
+// foldRightLazy                                                           //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def foldRightL01(): Bool = Result.foldRightL((i, b) -> if (i == 2 and force b) true else false, Err(-1ii), false) == false
+def foldRightLazy01(): Bool = Result.foldRightLazy((i, b) -> if (i == 2 and force b) true else false, Err(-1ii), false) == false
 
 @test
-def foldRightL02(): Bool = Result.foldRightL((i, b) -> if (i == 2 and force b) true else false, Ok(1), false) == false
+def foldRightLazy02(): Bool = Result.foldRightLazy((i, b) -> if (i == 2 and force b) true else false, Ok(1), false) == false
 
 @test
-def foldRightL03(): Bool = Result.foldRightL((i, b) -> if (i == 2 and force b) true else false, Ok(1), true) == false
+def foldRightLazy03(): Bool = Result.foldRightLazy((i, b) -> if (i == 2 and force b) true else false, Ok(1), true) == false
 
 @test
-def foldRightL04(): Bool = Result.foldRightL((i, b) -> if (i == 2 and force b) true else false, Ok(2), false) == false
+def foldRightLazy04(): Bool = Result.foldRightLazy((i, b) -> if (i == 2 and force b) true else false, Ok(2), false) == false
 
 @test
-def foldRightL05(): Bool = Result.foldRightL((i, b) -> if (i == 2 and force b) true else false, Ok(2), true) == true
+def foldRightLazy05(): Bool = Result.foldRightLazy((i, b) -> if (i == 2 and force b) true else false, Ok(2), true) == true
 
 /////////////////////////////////////////////////////////////////////////////
 // sequence                                                                //


### PR DESCRIPTION
Rename `foldRightL` to `foldRightLazy` for List, Nel, Result, Option

#2977 