### PR TITLE
feat: Add the Identity Functor/Monad - #3092

### DIFF
--- a/examples/analysis/IFDS.flix
+++ b/examples/analysis/IFDS.flix
@@ -17,7 +17,7 @@ rel SummaryEdge(node: String, factin: String, factout: String)
 rel Results(node: String, fact: String)
 
 rel Facts(fact: String)
-rel Identity(node: String)
+rel Id(node: String)
 
 // Rules
 def main(_: Array[String]): Int32 & Impure =
@@ -85,14 +85,14 @@ def main(_: Array[String]): Int32 & Impure =
         EshIntra("n1","g","g").
         EshIntra("n2","x","x").
 
-        Identity("n3").
-        Identity("sp").
-        Identity("n4").
-        Identity("n6").
-        Identity("n8").
-        Identity("n9").
+        Id("n3").
+        Id("sp").
+        Id("n4").
+        Id("n6").
+        Id("n8").
+        Id("n9").
 
-        EshIntra(idnode,f,f) :- Facts(f), Identity(idnode).
+        EshIntra(idnode,f,f) :- Facts(f), Id(idnode).
         EshIntra("n5","a","a").
         EshIntra("n6","g","a").
         EshIntra("n7","a","a").

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -166,6 +166,7 @@ class Flix {
     "Monoid.flix" -> LocalResource.get("/src/library/Monoid.flix"),
     "Foldable.flix" -> LocalResource.get("/src/library/Foldable.flix"),
     "Traversable.flix" -> LocalResource.get("/src/library/Traversable.flix"),
+    "Identity.flix" -> LocalResource.get("/src/library/Identity.flix"),
 
     "Validation.flix" -> LocalResource.get("/src/library/Validation.flix"),
 

--- a/main/src/library/Identity.flix
+++ b/main/src/library/Identity.flix
@@ -1,0 +1,106 @@
+/*
+ *  Copyright 2022 Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+///
+/// The Identity Functor / Monad.
+///
+
+pub enum Identity[a] with Eq, Order, ToString, Hash, Boxable { case Identity(a) }
+
+instance SemiGroup[Identity[a]] with SemiGroup[a] {
+    pub def combine(x: Identity[a], y: Identity[a]): Identity[a] =
+        let Identity(x1) = x;
+        let Identity(y1) = y;
+        Identity(SemiGroup.combine(x1, y1))
+}
+
+instance Monoid[Identity[a]] with Monoid[a] {
+    pub def empty(): Identity[a] = Identity(Monoid.empty())
+}
+
+instance Functor[Identity] {
+    pub def map(f: a -> b & ef, x: Identity[a]): Identity[b] & ef =
+        let Identity(x1) = x;
+        Identity(f(x1))
+}
+
+instance Applicative[Identity] {
+    pub def point(x: a): Identity[a] =
+        Identity(x)
+
+    pub def ap(f: Identity[a -> b & ef], x: Identity[a]): Identity[b] & ef =
+        let Identity(f1) = f;
+        let Identity(x1) = x;
+        Identity(f1(x1))
+}
+
+instance Monad[Identity] {
+    pub def flatMap(f: a -> Identity[b] & ef, x: Identity[a]): Identity[b] & ef =
+        let Identity(x1) = x;
+        f(x1)
+}
+
+instance Foldable[Identity] {
+    pub def foldLeft(f: (b, a) -> b & ef, s: b, x: Identity[a]): b & ef =
+        let Identity(x1) = x;
+        f(s, x1)
+
+    pub def foldRight(f: (a, b) -> b & ef, s: b, x: Identity[a]): b & ef =
+        let Identity(x1) = x;
+        f(x1, s)
+}
+
+instance Traversable[Identity] {
+    pub def traverse(f: a -> m[b] & ef, x: Identity[a]): m[Identity[b]] & ef with Applicative[m] =
+        let Identity(x1) = x;
+        Functor.map(Identity, f(x1))
+
+    pub override def sequence(x: Identity[m[a]]): m[Identity[a]] with Applicative[m] =
+        let Identity(x1) = x;
+        Functor.map(Identity, x1)
+}
+
+instance Add[Identity[a]] with Add[a] {
+    pub def add(x: Identity[a], y: Identity[a]): Identity[a] =
+        let Identity(x1) = x;
+        let Identity(y1) = y;
+        Identity(Add.add(x1, y1))
+}
+
+instance Sub[Identity[a]] with Sub[a]  {
+    pub def sub(x: Identity[a], y: Identity[a]): Identity[a] =
+        let Identity(x1) = x;
+        let Identity(y1) = y;
+        Identity(Sub.sub(x1, y1))
+}
+
+instance Mul[Identity[a]] with Mul[a]  {
+    pub def mul(x: Identity[a], y: Identity[a]): Identity[a] =
+        let Identity(x1) = x;
+        let Identity(y1) = y;
+        Identity(Mul.mul(x1, y1))
+}
+
+instance Div[Identity[a]] with Div[a]  {
+    pub def div(x: Identity[a], y: Identity[a]): Identity[a] =
+        let Identity(x1) = x;
+        let Identity(y1) = y;
+        Identity(Div.div(x1, y1))
+}
+
+instance Neg[Identity[a]] with Neg[a] {
+    pub def neg(x: Identity[a]): Identity[a] = Functor.map(Neg.neg, x)
+}

--- a/main/test/ca/uwaterloo/flix/library/LibrarySuite.scala
+++ b/main/test/ca/uwaterloo/flix/library/LibrarySuite.scala
@@ -71,4 +71,5 @@ class LibrarySuite extends Suites(
   new FlixTest("TestApplicative", "main/test/ca/uwaterloo/flix/library/TestApplicative.flix")(Options.TestWithLibAll),
   new FlixTest("TestMonad", "main/test/ca/uwaterloo/flix/library/TestMonad.flix")(Options.TestWithLibAll),
   new FlixTest("TestFoldable", "main/test/ca/uwaterloo/flix/library/TestFoldable.flix")(Options.TestWithLibAll),
+  new FlixTest("TestIdentity", "main/test/ca/uwaterloo/flix/library/TestIdentity.flix")(Options.TestWithLibAll),
 )

--- a/main/test/ca/uwaterloo/flix/library/TestIdentity.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIdentity.flix
@@ -1,0 +1,132 @@
+/*
+ *  Copyright 2022 Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace TestIdentity {
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // SemiGroup                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def combine01(): Bool =
+        SemiGroup.combine(Identity(1 :: Nil), Identity(2 :: Nil)) == Identity(1 :: 2 :: Nil)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Monoid                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def empty01(): Bool =
+        Identity(Monoid.empty() : List[Int32]) == Identity(Nil): Identity[List[Int32]]
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Functor                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def map01(): Bool =
+        Functor.map(x -> x + 1, Identity(0)) == Identity(1)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Applicative                                                             //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def point01(): Bool =
+        Applicative.point(1) : Identity[Int32] == Identity(1)
+
+    @test
+    def ap01(): Bool =
+        Applicative.ap(Identity(x -> x+ 1), Identity(1)) == Identity(2)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Monad                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def flatMap01(): Bool =
+        Monad.flatMap(x -> Identity(x+1), Identity(1)) == Identity(2)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Foldable                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def foldLeft01(): Bool =
+        Foldable.foldLeft((s, x) -> s+x, 100, Identity(1)) == 101
+
+    @test
+    def foldRight01(): Bool =
+        Foldable.foldRight((x, s) -> s+x, 100, Identity(1)) == 101
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Traversable                                                             //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def traverse01(): Bool =
+        Traversable.traverse(x -> x :: Nil, Identity(1)) == Identity(1) :: Nil
+
+    @test
+    def sequence01(): Bool =
+        Traversable.sequence(Identity(1 :: 2 :: Nil)) == Identity(1) :: Identity(2) :: Nil
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Add                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def add01(): Bool =
+        Identity(1) + Identity(2) == Identity(3)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Sub                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def sub01(): Bool =
+        Identity(3) - Identity(2) == Identity(1)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Mul                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def mul01(): Bool =
+        Identity(3) * Identity(2) == Identity(6)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Div                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def div01(): Bool =
+        Identity(6) / Identity(2) == Identity(3)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Neg                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def neg01(): Bool =
+        Neg.neg(Identity(1)) == Identity(-1)
+
+    @test
+    def neg02(): Bool =
+        Neg.neg(Identity(-1)) == Identity(1)
+
+}


### PR DESCRIPTION
This PR adds the Identity type and instances - see issue Add Identity type and instances #3092

The PR adds the derivable instances and:

SemiGroup
Monoid
Functor
Applicative
Monad
Foladble
Traversable

It also adds the "number" instances: 

Add
Sub
Mul
Div
Neg

Haskell's Identity functor has the equivalent number instances so I have added them too.


The test suite is very simple as there isn't really anything "mechanical" about the Identity functor - if one test works for a class method any other should work.

