### PR TITLE
feat: add `CommutativeSemiGroup`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -163,6 +163,7 @@ class Flix {
     "Applicative.flix" -> LocalResource.get("/src/library/Applicative.flix"),
     "Monad.flix" -> LocalResource.get("/src/library/Monad.flix"),
     "SemiGroup.flix" -> LocalResource.get("/src/library/SemiGroup.flix"),
+    "CommutativeSemiGroup.flix" -> LocalResource.get("/src/library/CommutativeSemiGroup.flix"),
     "Monoid.flix" -> LocalResource.get("/src/library/Monoid.flix"),
     "Foldable.flix" -> LocalResource.get("/src/library/Foldable.flix"),
     "Traversable.flix" -> LocalResource.get("/src/library/Traversable.flix"),

--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -41,9 +41,9 @@ instance CommutativeSemiGroup[Int64]
 
 instance CommutativeSemiGroup[BigInt]
 
-instance SemiGroup[Float32]
+instance CommutativeSemiGroup[Float32]
 
-instance SemiGroup[Float64]
+instance CommutativeSemiGroup[Float64]
 
 instance CommutativeSemiGroup[(a1, a2)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2]
 

--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -25,6 +25,8 @@ pub class CommutativeSemiGroup[a] with SemiGroup[a] {
     ///
     pub def combine(x: a, y: a): a = SemiGroup.combine(x, y)
 
+    law associative: forall(x: a, y: a, z: a) with Eq[a] . CommutativeSemiGroup.combine(CommutativeSemiGroup.combine(x, y), z) == CommutativeSemiGroup.combine(x, CommutativeSemiGroup.combine(y, z))
+
     law commutative: forall(x: a, y: a) with Eq[a] . CommutativeSemiGroup.combine(x, y) == CommutativeSemiGroup.combine(y, x)
 
 }

--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -18,8 +18,68 @@
 ///
 /// A type class for types that form a commutative semigroup.
 ///
-pub lawless class CommutativeSemiGroup[a] with SemiGroup[a] {
+pub class CommutativeSemiGroup[a] with SemiGroup[a] {
 
-    law commutative: forall(x: a, y: a) with Eq[a] . SemiGroup.combine(x, y) == SemiGroup.combine(y, x)
+    ///
+    /// An associative binary operation on `a`.
+    ///
+    pub def combine(x: a, y: a): a = SemiGroup.combine(x, y)
+
+    ///
+    /// Returns `x` combined with itself `n` times.
+    ///
+    pub def combineN(x: a, n: Int32): a = SemiGroup.combineN(x, n)
+
+    law commutative: forall(x: a, y: a) with Eq[a] . CommutativeSemiGroup.combine(x, y) == CommutativeCommutativeSemiGroup.combine(y, x)
 
 }
+
+instance CommutativeSemiGroup[Unit] {
+}
+
+instance CommutativeSemiGroup[Option[a]] with CommutativeSemiGroup[a] {
+}
+
+instance CommutativeSemiGroup[Set[a]] with Order[a] {
+}
+
+instance CommutativeSemiGroup[Map[k,v]] with Order[k], CommutativeSemiGroup[v] {
+    pub def combine(x: Map[k,v], y: Map[k,v]): Map[k,v] = Map.unionWith(CommutativeSemiGroup.combine, x, y)
+}
+/*
+instance CommutativeSemiGroup[Validation[t, e]] with CommutativeSemiGroup[t] {
+    pub def combine(x: Validation[t, e], y: Validation[t, e]): Validation[t, e] = match (x, y) {
+        case (Success(x1), Success(y1))     => Success(CommutativeSemiGroup.combine(x1, y1))
+        case (Failure(es1), Failure(es2))   => Failure(Nel.append(es1, es2))
+        case (Failure(_), _)                => x
+        case (_, Failure(_))                => y
+    }
+}
+*/
+instance CommutativeSemiGroup[(a1, a2)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2] {
+}
+
+instance CommutativeSemiGroup[(a1, a2, a3)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3] {
+}
+
+instance CommutativeSemiGroup[(a1, a2, a3, a4)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4] {
+}
+
+instance CommutativeSemiGroup[(a1, a2, a3, a4, a5)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5] {
+}
+
+instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6] {
+}
+
+instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7] {
+}
+
+instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7], CommutativeSemiGroup[a8] {
+}
+
+instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7], CommutativeSemiGroup[a8], CommutativeSemiGroup[a9] {
+}
+
+instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7], CommutativeSemiGroup[a8], CommutativeSemiGroup[a9], CommutativeSemiGroup[a10] {
+}
+

--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -1,0 +1,25 @@
+/*
+ *  Copyright 2022 Jakob Schneider Villumsen
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+///
+/// A type class for types that form a commutative semigroup.
+///
+pub lawless class CommutativeSemiGroup[a] with SemiGroup[a] {
+
+    law commutative: forall(x: a, y: a) with Eq[a] . SemiGroup.combine(x, y) == SemiGroup.combine(y, x)
+
+}

--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -34,52 +34,23 @@ pub class CommutativeSemiGroup[a] with SemiGroup[a] {
 
 }
 
-instance CommutativeSemiGroup[Unit] {
-}
+instance CommutativeSemiGroup[Unit]
 
-instance CommutativeSemiGroup[Option[a]] with CommutativeSemiGroup[a] {
-}
+instance CommutativeSemiGroup[(a1, a2)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2]
 
-instance CommutativeSemiGroup[Set[a]] with Order[a] {
-}
+instance CommutativeSemiGroup[(a1, a2, a3)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3]
 
-instance CommutativeSemiGroup[Map[k,v]] with Order[k], CommutativeSemiGroup[v] {
-    pub def combine(x: Map[k,v], y: Map[k,v]): Map[k,v] = Map.unionWith(CommutativeSemiGroup.combine, x, y)
-}
-/*
-instance CommutativeSemiGroup[Validation[t, e]] with CommutativeSemiGroup[t] {
-    pub def combine(x: Validation[t, e], y: Validation[t, e]): Validation[t, e] = match (x, y) {
-        case (Success(x1), Success(y1))     => Success(CommutativeSemiGroup.combine(x1, y1))
-        case (Failure(es1), Failure(es2))   => Failure(Nel.append(es1, es2))
-        case (Failure(_), _)                => x
-        case (_, Failure(_))                => y
-    }
-}
-*/
-instance CommutativeSemiGroup[(a1, a2)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2] {
-}
+instance CommutativeSemiGroup[(a1, a2, a3, a4)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4]
 
-instance CommutativeSemiGroup[(a1, a2, a3)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3] {
-}
+instance CommutativeSemiGroup[(a1, a2, a3, a4, a5)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5]
 
-instance CommutativeSemiGroup[(a1, a2, a3, a4)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4] {
-}
+instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6]
 
-instance CommutativeSemiGroup[(a1, a2, a3, a4, a5)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5] {
-}
+instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7]
 
-instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6] {
-}
+instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7], CommutativeSemiGroup[a8]
 
-instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7] {
-}
+instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7], CommutativeSemiGroup[a8], CommutativeSemiGroup[a9]
 
-instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7], CommutativeSemiGroup[a8] {
-}
-
-instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7], CommutativeSemiGroup[a8], CommutativeSemiGroup[a9] {
-}
-
-instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7], CommutativeSemiGroup[a8], CommutativeSemiGroup[a9], CommutativeSemiGroup[a10] {
-}
+instance CommutativeSemiGroup[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3], CommutativeSemiGroup[a4], CommutativeSemiGroup[a5], CommutativeSemiGroup[a6], CommutativeSemiGroup[a7], CommutativeSemiGroup[a8], CommutativeSemiGroup[a9], CommutativeSemiGroup[a10]
 

--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -31,6 +31,16 @@ pub class CommutativeSemiGroup[a] with SemiGroup[a] {
 
 instance CommutativeSemiGroup[Unit]
 
+instance CommutativeSemiGroup[Int8]
+
+instance CommutativeSemiGroup[Int16]
+
+instance CommutativeSemiGroup[Int32]
+
+instance CommutativeSemiGroup[Int64]
+
+instance CommutativeSemiGroup[BigInt]
+
 instance CommutativeSemiGroup[(a1, a2)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2]
 
 instance CommutativeSemiGroup[(a1, a2, a3)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3]

--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -41,6 +41,10 @@ instance CommutativeSemiGroup[Int64]
 
 instance CommutativeSemiGroup[BigInt]
 
+instance SemiGroup[Float32]
+
+instance SemiGroup[Float64]
+
 instance CommutativeSemiGroup[(a1, a2)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2]
 
 instance CommutativeSemiGroup[(a1, a2, a3)] with CommutativeSemiGroup[a1], CommutativeSemiGroup[a2], CommutativeSemiGroup[a3]

--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -21,7 +21,7 @@
 pub class CommutativeSemiGroup[a] with SemiGroup[a] {
 
     ///
-    /// An associative binary operation on `a`.
+    /// An associative & commutative binary operation on `a`.
     ///
     pub def combine(x: a, y: a): a = SemiGroup.combine(x, y)
 

--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -25,11 +25,6 @@ pub class CommutativeSemiGroup[a] with SemiGroup[a] {
     ///
     pub def combine(x: a, y: a): a = SemiGroup.combine(x, y)
 
-    ///
-    /// Returns `x` combined with itself `n` times.
-    ///
-    pub def combineN(x: a, n: Int32): a = SemiGroup.combineN(x, n)
-
     law commutative: forall(x: a, y: a) with Eq[a] . CommutativeSemiGroup.combine(x, y) == CommutativeSemiGroup.combine(y, x)
 
 }

--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -30,7 +30,7 @@ pub class CommutativeSemiGroup[a] with SemiGroup[a] {
     ///
     pub def combineN(x: a, n: Int32): a = SemiGroup.combineN(x, n)
 
-    law commutative: forall(x: a, y: a) with Eq[a] . CommutativeSemiGroup.combine(x, y) == CommutativeCommutativeSemiGroup.combine(y, x)
+    law commutative: forall(x: a, y: a) with Eq[a] . CommutativeSemiGroup.combine(x, y) == CommutativeSemiGroup.combine(y, x)
 
 }
 

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -44,6 +44,10 @@ instance Eq[List[a]] with Eq[a] {
     }
 }
 
+instance SemiGroup[List[a]] {
+    pub def combine(x: List[a], y: List[a]): List[a] = x ::: y
+}
+
 instance Order[List[a]] with Order[a] {
 
     ///

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -65,6 +65,10 @@ instance Traversable[Map[k]] {
     pub override def sequence(t: Map[k, m[a]]): m[Map[k, a]] with Applicative[m] = Map.sequence(t)
 }
 
+instance SemiGroup[Map[k,v]] with Order[k], SemiGroup[v] {
+    pub def combine(x: Map[k,v], y: Map[k,v]): Map[k,v] = Map.unionWith(SemiGroup.combine, x, y)
+}
+
 instance CommutativeSemiGroup[Map[k,v]] with Order[k], CommutativeSemiGroup[v]
 
 namespace Map {

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -65,6 +65,8 @@ instance Traversable[Map[k]] {
     pub override def sequence(t: Map[k, m[a]]): m[Map[k, a]] with Applicative[m] = Map.sequence(t)
 }
 
+instance CommutativeSemiGroup[Map[k,v]] with Order[k], CommutativeSemiGroup[v]
+
 namespace Map {
 
     ///

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -77,6 +77,8 @@ instance Traversable[Option] {
 
 }
 
+instance CommutativeSemiGroup[Option[a]] with CommutativeSemiGroup[a]
+
 namespace Option {
 
     ///

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -77,6 +77,14 @@ instance Traversable[Option] {
 
 }
 
+instance SemiGroup[Option[a]] with SemiGroup[a] {
+    pub def combine(x: Option[a], y: Option[a]): Option[a] = match (x, y) {
+        case (a, None)              => a
+        case (None, b)              => b
+        case (Some(x1), Some(y1))   => Some(SemiGroup.combine(x1, y1))
+    }
+}
+
 instance CommutativeSemiGroup[Option[a]] with CommutativeSemiGroup[a]
 
 namespace Option {

--- a/main/src/library/SemiGroup.flix
+++ b/main/src/library/SemiGroup.flix
@@ -42,35 +42,6 @@ instance SemiGroup[String] {
     pub def combine(x: String, y: String): String = x + y
 }
 
-instance SemiGroup[Option[a]] with SemiGroup[a] {
-    pub def combine(x: Option[a], y: Option[a]): Option[a] = match (x, y) {
-        case (a, None)              => a
-        case (None, b)              => b
-        case (Some(x1), Some(y1))   => Some(SemiGroup.combine(x1, y1))
-    }
-}
-
-instance SemiGroup[List[a]] {
-    pub def combine(x: List[a], y: List[a]): List[a] = x ::: y
-}
-
-instance SemiGroup[Set[a]] with Order[a] {
-    pub def combine(x: Set[a], y: Set[a]): Set[a] = Set.union(x,y)
-}
-
-instance SemiGroup[Map[k,v]] with Order[k], SemiGroup[v] {
-    pub def combine(x: Map[k,v], y: Map[k,v]): Map[k,v] = Map.unionWith(SemiGroup.combine, x, y)
-}
-
-instance SemiGroup[Validation[t, e]] with SemiGroup[t] {
-    pub def combine(x: Validation[t, e], y: Validation[t, e]): Validation[t, e] = match (x, y) {
-        case (Success(x1), Success(y1))     => Success(SemiGroup.combine(x1, y1))
-        case (Failure(es1), Failure(es2))   => Failure(Nel.append(es1, es2))
-        case (Failure(_), _)                => x
-        case (_, Failure(_))                => y
-    }
-}
-
 instance SemiGroup[(a1, a2)] with SemiGroup[a1], SemiGroup[a2] {
     pub def combine(x: (a1, a2), y: (a1, a2)): (a1, a2) = match (x, y) {
         case ((x1, x2), (y1, y2)) => (SemiGroup.combine(x1, y1), SemiGroup.combine(x2, y2))

--- a/main/src/library/SemiGroup.flix
+++ b/main/src/library/SemiGroup.flix
@@ -38,6 +38,26 @@ instance SemiGroup[Unit] {
     pub def combine(_: Unit, _: Unit): Unit = ()
 }
 
+instance SemiGroup[Int8] {
+    pub def combine(x: Int8, y: Int8): Int8 = x + y
+}
+
+instance SemiGroup[Int16] {
+    pub def combine(x: Int16, y: Int16): Int16 = x + y
+}
+
+instance SemiGroup[Int32] {
+    pub def combine(x: Int32, y: Int32): Int32 = x + y
+}
+
+instance SemiGroup[Int64] {
+    pub def combine(x: Int64, y: Int64): Int64 = x + y
+}
+
+instance SemiGroup[BigInt] {
+    pub def combine(x: BigInt, y: BigInt): BigInt = x + y
+}
+
 instance SemiGroup[String] {
     pub def combine(x: String, y: String): String = x + y
 }

--- a/main/src/library/SemiGroup.flix
+++ b/main/src/library/SemiGroup.flix
@@ -58,6 +58,14 @@ instance SemiGroup[BigInt] {
     pub def combine(x: BigInt, y: BigInt): BigInt = x + y
 }
 
+instance SemiGroup[Float32] {
+    pub def combine(x: Float32, y: Float32): Float32 = x + y
+}
+
+instance SemiGroup[Float64] {
+    pub def combine(x: Float64, y: Float64): Float64 = x + y
+}
+
 instance SemiGroup[String] {
     pub def combine(x: String, y: String): String = x + y
 }

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -54,6 +54,10 @@ instance Foldable[Set] {
     pub def foldRight(f: (a, b) -> b & ef, s: b, s1: Set[a]): b & ef = Set.foldRight(f, s, s1)
 }
 
+instance SemiGroup[Set[a]] with Order[a] {
+    pub def combine(x: Set[a], y: Set[a]): Set[a] = Set.union(x,y)
+}
+
 instance CommutativeSemiGroup[Set[a]] with Order[a]
 
 namespace Set {

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -54,6 +54,8 @@ instance Foldable[Set] {
     pub def foldRight(f: (a, b) -> b & ef, s: b, s1: Set[a]): b & ef = Set.foldRight(f, s, s1)
 }
 
+instance CommutativeSemiGroup[Set[a]] with Order[a]
+
 namespace Set {
 
     ///

--- a/main/src/library/Validation.flix
+++ b/main/src/library/Validation.flix
@@ -29,6 +29,15 @@ instance Hash[Validation[t, e]] with Hash[t], Hash[e] {
     }
 }
 
+instance SemiGroup[Validation[t, e]] with SemiGroup[t] {
+    pub def combine(x: Validation[t, e], y: Validation[t, e]): Validation[t, e] = match (x, y) {
+        case (Success(x1), Success(y1))     => Success(SemiGroup.combine(x1, y1))
+        case (Failure(es1), Failure(es2))   => Failure(Nel.append(es1, es2))
+        case (Failure(_), _)                => x
+        case (_, Failure(_))                => y
+    }
+}
+
 namespace Validation {
 
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestSemiGroup.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSemiGroup.flix
@@ -26,6 +26,86 @@ namespace TestSemiGroup {
     def combineUnit01(): Bool = combine((), ()) == ()
 
     /////////////////////////////////////////////////////////////////////////////
+    // Int8                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def combineInt801(): Bool = combine(0i8, 0i8) == 0i8
+
+    @test
+    def combineInt802(): Bool = combine(1i8, 0i8) == 1i8
+
+    @test
+    def combineInt803(): Bool = combine(0i8, 2i8) == 2i8
+
+    @test
+    def combineInt804(): Bool = combine(1i8, 2i8) == 3i8
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int16                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def combineInt1601(): Bool = combine(0i16, 0i16) == 0i16
+
+    @test
+    def combineInt1602(): Bool = combine(1i16, 0i16) == 1i16
+
+    @test
+    def combineInt1603(): Bool = combine(0i16, 2i16) == 2i16
+
+    @test
+    def combineInt1604(): Bool = combine(1i16, 2i16) == 3i16
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int32                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def combineInt3201(): Bool = combine(0i32, 0i32) == 0i32
+
+    @test
+    def combineInt3202(): Bool = combine(1i32, 0i32) == 1i32
+
+    @test
+    def combineInt3203(): Bool = combine(0i32, 2i32) == 2i32
+
+    @test
+    def combineInt3204(): Bool = combine(1i32, 2i32) == 3i32
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int64                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def combineInt6401(): Bool = combine(0i64, 0i64) == 0i64
+
+    @test
+    def combineInt6402(): Bool = combine(1i64, 0i64) == 1i64
+
+    @test
+    def combineInt6403(): Bool = combine(0i64, 2i64) == 2i64
+
+    @test
+    def combineInt6404(): Bool = combine(1i64, 2i64) == 3i64
+
+    /////////////////////////////////////////////////////////////////////////////
+    // BigInt                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def combineBigInt01(): Bool = combine(0ii, 0ii) == 0ii
+
+    @test
+    def combineBigInt02(): Bool = combine(1ii, 0ii) == 1ii
+
+    @test
+    def combineBigInt03(): Bool = combine(0ii, 2ii) == 2ii
+
+    @test
+    def combineBigInt04(): Bool = combine(1ii, 2ii) == 3ii
+
+    /////////////////////////////////////////////////////////////////////////////
     // String                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestSemiGroup.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSemiGroup.flix
@@ -110,32 +110,32 @@ namespace TestSemiGroup {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def combineFloat3201(): Bool = combine(0f32, 0f32) == 0f32
+    def combineFloat3201(): Bool = combine(0.0f32, 0.0f32) == 0.0f32
 
     @test
-    def combineFloat3202(): Bool = combine(1f32, 0f32) == 1f32
+    def combineFloat3202(): Bool = combine(1.0f32, 0.0f32) == 1.0f32
 
     @test
-    def combineFloat3203(): Bool = combine(0f32, 2f32) == 2f32
+    def combineFloat3203(): Bool = combine(0.0f32, 2.0f32) == 2.0f32
 
     @test
-    def combineFloat3204(): Bool = combine(1f32, 2f32) == 3f32
+    def combineFloat3204(): Bool = combine(1.0f32, 2.0f32) == 3.0f32
 
     /////////////////////////////////////////////////////////////////////////////
     // Float64                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def combineFloat6401(): Bool = combine(0f64, 0f64) == 0f64
+    def combineFloat6401(): Bool = combine(0.0f64, 0.0f64) == 0.0f64
 
     @test
-    def combineFloat6402(): Bool = combine(1f64, 0f64) == 1f64
+    def combineFloat6402(): Bool = combine(1.0f64, 0.0f64) == 1.0f64
 
     @test
-    def combineFloat6403(): Bool = combine(0f64, 2f64) == 2f64
+    def combineFloat6403(): Bool = combine(0.0f64, 2.0f64) == 2.0f64
 
     @test
-    def combineFloat6404(): Bool = combine(1f64, 2f64) == 3f64
+    def combineFloat6404(): Bool = combine(1.0f64, 2.0f64) == 3.0f64
 
     /////////////////////////////////////////////////////////////////////////////
     // String                                                                  //

--- a/main/test/ca/uwaterloo/flix/library/TestSemiGroup.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSemiGroup.flix
@@ -106,6 +106,38 @@ namespace TestSemiGroup {
     def combineBigInt04(): Bool = combine(1ii, 2ii) == 3ii
 
     /////////////////////////////////////////////////////////////////////////////
+    // Float32                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def combineFloat3201(): Bool = combine(0f32, 0f32) == 0f32
+
+    @test
+    def combineFloat3202(): Bool = combine(1f32, 0f32) == 1f32
+
+    @test
+    def combineFloat3203(): Bool = combine(0f32, 2f32) == 2f32
+
+    @test
+    def combineFloat3204(): Bool = combine(1f32, 2f32) == 3f32
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Float64                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def combineFloat6401(): Bool = combine(0f64, 0f64) == 0f64
+
+    @test
+    def combineFloat6402(): Bool = combine(1f64, 0f64) == 1f64
+
+    @test
+    def combineFloat6403(): Bool = combine(0f64, 2f64) == 2f64
+
+    @test
+    def combineFloat6404(): Bool = combine(1f64, 2f64) == 3f64
+
+    /////////////////////////////////////////////////////////////////////////////
     // String                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Closes #1922

I'm not sure how to enforce the commutative law when extending `SemiGroup` which has instances of combine defined for `String` as concatenation which is clearly not commutative. Does the compiler enforce the laws yet? Any ideas? I'll take a look at typelevel / cats meanwhile.