### PR TITLE
feat: add `CommutativeMonoid`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -165,6 +165,7 @@ class Flix {
     "SemiGroup.flix" -> LocalResource.get("/src/library/SemiGroup.flix"),
     "CommutativeSemiGroup.flix" -> LocalResource.get("/src/library/CommutativeSemiGroup.flix"),
     "Monoid.flix" -> LocalResource.get("/src/library/Monoid.flix"),
+    "CommutativeMonoid.flix" -> LocalResource.get("/src/library/CommutativeMonoid.flix"),
     "Foldable.flix" -> LocalResource.get("/src/library/Foldable.flix"),
     "Traversable.flix" -> LocalResource.get("/src/library/Traversable.flix"),
     "Identity.flix" -> LocalResource.get("/src/library/Identity.flix"),

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -158,17 +158,17 @@ class Flix {
 
     "Environment.flix" -> LocalResource.get("/src/library/Environment.flix"),
 
+    "Applicative.flix" -> LocalResource.get("/src/library/Applicative.flix"),
+    "CommutativeMonoid.flix" -> LocalResource.get("/src/library/CommutativeMonoid.flix"),
+    "CommutativeSemiGroup.flix" -> LocalResource.get("/src/library/CommutativeSemiGroup.flix"),
+    "Foldable.flix" -> LocalResource.get("/src/library/Foldable.flix"),
     "FromString.flix" -> LocalResource.get("/src/library/FromString.flix"),
     "Functor.flix" -> LocalResource.get("/src/library/Functor.flix"),
-    "Applicative.flix" -> LocalResource.get("/src/library/Applicative.flix"),
-    "Monad.flix" -> LocalResource.get("/src/library/Monad.flix"),
-    "SemiGroup.flix" -> LocalResource.get("/src/library/SemiGroup.flix"),
-    "CommutativeSemiGroup.flix" -> LocalResource.get("/src/library/CommutativeSemiGroup.flix"),
-    "Monoid.flix" -> LocalResource.get("/src/library/Monoid.flix"),
-    "CommutativeMonoid.flix" -> LocalResource.get("/src/library/CommutativeMonoid.flix"),
-    "Foldable.flix" -> LocalResource.get("/src/library/Foldable.flix"),
-    "Traversable.flix" -> LocalResource.get("/src/library/Traversable.flix"),
     "Identity.flix" -> LocalResource.get("/src/library/Identity.flix"),
+    "Monad.flix" -> LocalResource.get("/src/library/Monad.flix"),
+    "Monoid.flix" -> LocalResource.get("/src/library/Monoid.flix"),
+    "SemiGroup.flix" -> LocalResource.get("/src/library/SemiGroup.flix"),
+    "Traversable.flix" -> LocalResource.get("/src/library/Traversable.flix"),
 
     "Validation.flix" -> LocalResource.get("/src/library/Validation.flix"),
 

--- a/main/src/library/CommutativeMonoid.flix
+++ b/main/src/library/CommutativeMonoid.flix
@@ -39,3 +39,29 @@ pub class CommutativeMonoid[a] with Monoid[a] {
     law commutative: forall(x: a, y: a) with Eq[a] . CommutativeMonoid.combine(x, y) == CommutativeMonoid.combine(y, x)
 
 }
+
+instance CommutativeMonoid[Unit]
+
+instance CommutativeMonoid[Set[a]] with Order[a]
+
+instance CommutativeMonoid[Map[k, v]] with Order[k], CommutativeMonoid[v]
+
+instance CommutativeMonoid[Option[a]] with CommutativeMonoid[a]
+
+instance CommutativeMonoid[(a1, a2)] with CommutativeMonoid[a1], CommutativeMonoid[a2]
+
+instance CommutativeMonoid[(a1, a2, a3)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3]
+
+instance CommutativeMonoid[(a1, a2, a3, a4)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4]
+
+instance CommutativeMonoid[(a1, a2, a3, a4, a5)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5]
+
+instance CommutativeMonoid[(a1, a2, a3, a4, a5, a6)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5], CommutativeMonoid[a6]
+
+instance CommutativeMonoid[(a1, a2, a3, a4, a5, a6, a7)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5], CommutativeMonoid[a6], CommutativeMonoid[a7]
+
+instance CommutativeMonoid[(a1, a2, a3, a4, a5, a6, a7, a8)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5], CommutativeMonoid[a6], CommutativeMonoid[a7], CommutativeMonoid[a8]
+
+instance CommutativeMonoid[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5], CommutativeMonoid[a6], CommutativeMonoid[a7], CommutativeMonoid[a8], CommutativeMonoid[a9]
+
+instance CommutativeMonoid[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3], CommutativeMonoid[a4], CommutativeMonoid[a5], CommutativeMonoid[a6], CommutativeMonoid[a7], CommutativeMonoid[a8], CommutativeMonoid[a9], CommutativeMonoid[a10]

--- a/main/src/library/CommutativeMonoid.flix
+++ b/main/src/library/CommutativeMonoid.flix
@@ -39,8 +39,21 @@ pub class CommutativeMonoid[a] with Monoid[a] {
     law commutative: forall(x: a, y: a) with Eq[a] . CommutativeMonoid.combine(x, y) == CommutativeMonoid.combine(y, x)
 
 }
-
 instance CommutativeMonoid[Unit]
+
+instance CommutativeMonoid[Int8]
+
+instance CommutativeMonoid[Int16]
+
+instance CommutativeMonoid[Int32]
+
+instance CommutativeMonoid[Int64]
+
+instance CommutativeMonoid[BigInt]
+
+instance CommutativeMonoid[Float32]
+
+instance CommutativeMonoid[Float64]
 
 instance CommutativeMonoid[(a1, a2)] with CommutativeMonoid[a1], CommutativeMonoid[a2]
 

--- a/main/src/library/CommutativeMonoid.flix
+++ b/main/src/library/CommutativeMonoid.flix
@@ -42,12 +42,6 @@ pub class CommutativeMonoid[a] with Monoid[a] {
 
 instance CommutativeMonoid[Unit]
 
-instance CommutativeMonoid[Set[a]] with Order[a]
-
-instance CommutativeMonoid[Map[k, v]] with Order[k], CommutativeMonoid[v]
-
-instance CommutativeMonoid[Option[a]] with CommutativeMonoid[a]
-
 instance CommutativeMonoid[(a1, a2)] with CommutativeMonoid[a1], CommutativeMonoid[a2]
 
 instance CommutativeMonoid[(a1, a2, a3)] with CommutativeMonoid[a1], CommutativeMonoid[a2], CommutativeMonoid[a3]

--- a/main/src/library/CommutativeMonoid.flix
+++ b/main/src/library/CommutativeMonoid.flix
@@ -30,6 +30,10 @@ pub class CommutativeMonoid[a] with Monoid[a] {
     pub def combine(x: a, y: a): a =
         Monoid.combine(x, y)
 
+    law leftIdentity: forall(x: a) with Eq[a] . CommutativeMonoid.combine(CommutativeMonoid.empty(), x) == x
+
+    law rightIdentity: forall(x: a) with Eq[a] . CommutativeMonoid.combine(x, CommutativeMonoid.empty()) == x
+
     law associative: forall(x: a, y: a, z: a) with Eq[a] . CommutativeMonoid.combine(CommutativeMonoid.combine(x, y), z) == CommutativeMonoid.combine(x, CommutativeMonoid.combine(y, z))
 
     law commutative: forall(x: a, y: a) with Eq[a] . CommutativeMonoid.combine(x, y) == CommutativeMonoid.combine(y, x)

--- a/main/src/library/CommutativeMonoid.flix
+++ b/main/src/library/CommutativeMonoid.flix
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2022 Jakob Schneider Villumsen
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+///
+/// A type class for types that form a commutative monoid.
+///
+pub class CommutativeMonoid[a] with Monoid[a] {
+
+    ///
+    /// Returns a neutral element.
+    ///
+    pub def empty(): a = Monoid.empty()
+
+    ///
+    /// An associative & commutative binary operation on `a`.
+    ///
+    pub def combine(x: a, y: a): a =
+        Monoid.combine(x, y)
+
+    law associative: forall(x: a, y: a, z: a) with Eq[a] . CommutativeMonoid.combine(CommutativeMonoid.combine(x, y), z) == CommutativeMonoid.combine(x, CommutativeMonoid.combine(y, z))
+
+    law commutative: forall(x: a, y: a) with Eq[a] . CommutativeMonoid.combine(x, y) == CommutativeMonoid.combine(y, x)
+
+}

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -44,14 +44,6 @@ instance Eq[List[a]] with Eq[a] {
     }
 }
 
-instance SemiGroup[List[a]] {
-    pub def combine(x: List[a], y: List[a]): List[a] = x ::: y
-}
-
-instance Monoid[List[a]] {
-    pub def empty(): List[a] = Nil
-}
-
 instance Order[List[a]] with Order[a] {
 
     ///
@@ -89,6 +81,14 @@ instance Foldable[List] {
 instance Traversable[List] {
     pub def traverse(f: a -> m[b] & ef, t: List[a]): m[List[b]] & ef with Applicative[m] = List.traverse(f, t)
     pub override def sequence(t: List[m[a]]): m[List[a]] with Applicative[m] = List.sequence(t)
+}
+
+instance SemiGroup[List[a]] {
+    pub def combine(x: List[a], y: List[a]): List[a] = x ::: y
+}
+
+instance Monoid[List[a]] {
+    pub def empty(): List[a] = Nil
 }
 
 namespace List {

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -48,6 +48,10 @@ instance SemiGroup[List[a]] {
     pub def combine(x: List[a], y: List[a]): List[a] = x ::: y
 }
 
+instance Monoid[List[a]] {
+    pub def empty(): List[a] = Nil
+}
+
 instance Order[List[a]] with Order[a] {
 
     ///

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -71,6 +71,12 @@ instance SemiGroup[Map[k,v]] with Order[k], SemiGroup[v] {
 
 instance CommutativeSemiGroup[Map[k,v]] with Order[k], CommutativeSemiGroup[v]
 
+instance Monoid[Map[k, v]] with Order[k], Monoid[v] {
+    pub def empty(): Map[k, v] = Map.empty()
+}
+
+instance CommutativeMonoid[Map[k, v]] with Order[k], CommutativeMonoid[v]
+
 namespace Map {
 
     ///

--- a/main/src/library/Monoid.flix
+++ b/main/src/library/Monoid.flix
@@ -18,7 +18,7 @@
 /// A type class for Monoids, objects that support an associative binary
 /// operation `combine` and neutral element `empty`.
 ///
-pub lawless class Monoid[a] with SemiGroup[a] {
+pub class Monoid[a] with SemiGroup[a] {
     ///
     /// Returns a neutral element.
     ///

--- a/main/src/library/Monoid.flix
+++ b/main/src/library/Monoid.flix
@@ -51,6 +51,34 @@ instance Monoid[Unit] {
     pub def empty(): Unit = ()
 }
 
+instance Monoid[Int8] {
+    pub def empty(): Int8 = 0i8
+}
+
+instance Monoid[Int16] {
+    pub def empty(): Int16 = 0i16
+}
+
+instance Monoid[Int32] {
+    pub def empty(): Int32 = 0
+}
+
+instance Monoid[Int64] {
+    pub def empty(): Int64 = 0i64
+}
+
+instance Monoid[BigInt] {
+    pub def empty(): BigInt = 0ii
+}
+
+instance Monoid[Float32] {
+    pub def empty(): Float32 = 0.0f32
+}
+
+instance Monoid[Float64] {
+    pub def empty(): Float64 = 0.0f64
+}
+
 instance Monoid[String] {
     pub def empty(): String = ""
 }

--- a/main/src/library/Monoid.flix
+++ b/main/src/library/Monoid.flix
@@ -30,6 +30,8 @@ pub lawless class Monoid[a] with SemiGroup[a] {
     pub def combine(x: a, y: a): a =
         SemiGroup.combine(x, y)
 
+    law identity: forall(x: a, y: a) with Eq[a] . if (x == Monoid.empty()) Monoid.combine(x, y) == y else true
+
     law associative: forall(x: a, y: a, z: a) with Eq[a] . Monoid.combine(Monoid.combine(x, y), z) == Monoid.combine(x, Monoid.combine(y, z))
 
 }

--- a/main/src/library/Monoid.flix
+++ b/main/src/library/Monoid.flix
@@ -30,7 +30,9 @@ pub class Monoid[a] with SemiGroup[a] {
     pub def combine(x: a, y: a): a =
         SemiGroup.combine(x, y)
 
-    law identity: forall(x: a, y: a) with Eq[a] . if (x == Monoid.empty()) Monoid.combine(x, y) == y else true
+    law leftIdentity: forall(x: a) with Eq[a] . Monoid.combine(Monoid.empty(), x) == x
+
+    law rightIdentity: forall(x: a) with Eq[a] . Monoid.combine(x, Monoid.empty()) == x
 
     law associative: forall(x: a, y: a, z: a) with Eq[a] . Monoid.combine(Monoid.combine(x, y), z) == Monoid.combine(x, Monoid.combine(y, z))
 

--- a/main/src/library/Monoid.flix
+++ b/main/src/library/Monoid.flix
@@ -55,10 +55,6 @@ instance Monoid[String] {
     pub def empty(): String = ""
 }
 
-instance Monoid[Option[a]] with Monoid[a] {
-    pub def empty(): Option[a] = None
-}
-
 instance Monoid[(a1, a2)] with Monoid[a1], Monoid[a2] {
     pub def empty(): (a1, a2) = (Monoid.empty(), Monoid.empty())
 }
@@ -93,23 +89,4 @@ instance Monoid[(a1, a2, a3, a4, a5, a6, a7, a8, a9)] with Monoid[a1], Monoid[a2
 
 instance Monoid[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)] with Monoid[a1], Monoid[a2], Monoid[a3], Monoid[a4], Monoid[a5], Monoid[a6], Monoid[a7], Monoid[a8], Monoid[a9], Monoid[a10] {
     pub def empty(): (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = (Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty(), Monoid.empty())
-}
-
-instance Monoid[Validation[t, e]] with Monoid[t] {
-    pub def empty(): Validation[t, e] = Success(Monoid.empty())
-}
-
-instance Monoid[List[a]] {
-    pub def empty(): List[a] = Nil
-}
-
-///
-/// `combine` is set union.
-///
-instance Monoid[Set[a]] with Order[a] {
-    pub def empty(): Set[a] = Set.empty()
-}
-
-instance Monoid[Map[k, v]] with Order[k], Monoid[v] {
-    pub def empty(): Map[k, v] = Map.empty()
 }

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -87,6 +87,13 @@ instance SemiGroup[Option[a]] with SemiGroup[a] {
 
 instance CommutativeSemiGroup[Option[a]] with CommutativeSemiGroup[a]
 
+
+instance Monoid[Option[a]] with Monoid[a] {
+    pub def empty(): Option[a] = None
+}
+
+instance CommutativeMonoid[Option[a]] with CommutativeMonoid[a]
+
 namespace Option {
 
     ///

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -60,6 +60,12 @@ instance SemiGroup[Set[a]] with Order[a] {
 
 instance CommutativeSemiGroup[Set[a]] with Order[a]
 
+instance Monoid[Set[a]] with Order[a] {
+    pub def empty(): Set[a] = Set.empty()
+}
+
+instance CommutativeMonoid[Set[a]] with Order[a]
+
 namespace Set {
 
     ///

--- a/main/src/library/Validation.flix
+++ b/main/src/library/Validation.flix
@@ -38,6 +38,10 @@ instance SemiGroup[Validation[t, e]] with SemiGroup[t] {
     }
 }
 
+instance Monoid[Validation[t, e]] with Monoid[t] {
+    pub def empty(): Validation[t, e] = Success(Monoid.empty())
+}
+
 namespace Validation {
 
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestMonoid.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMonoid.flix
@@ -29,6 +29,118 @@ namespace TestMonoid {
     def unitCombine01(): Bool = combine((), ()) == ()
 
     /////////////////////////////////////////////////////////////////////////////
+    // Int8                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def combineInt801(): Bool = combine(0i8, 0i8) == 0i8
+
+    @test
+    def combineInt802(): Bool = combine(1i8, 0i8) == 1i8
+
+    @test
+    def combineInt803(): Bool = combine(0i8, 2i8) == 2i8
+
+    @test
+    def combineInt804(): Bool = combine(1i8, 2i8) == 3i8
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int16                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def combineInt1601(): Bool = combine(0i16, 0i16) == 0i16
+
+    @test
+    def combineInt1602(): Bool = combine(1i16, 0i16) == 1i16
+
+    @test
+    def combineInt1603(): Bool = combine(0i16, 2i16) == 2i16
+
+    @test
+    def combineInt1604(): Bool = combine(1i16, 2i16) == 3i16
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int32                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def combineInt3201(): Bool = combine(0i32, 0i32) == 0i32
+
+    @test
+    def combineInt3202(): Bool = combine(1i32, 0i32) == 1i32
+
+    @test
+    def combineInt3203(): Bool = combine(0i32, 2i32) == 2i32
+
+    @test
+    def combineInt3204(): Bool = combine(1i32, 2i32) == 3i32
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int64                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def combineInt6401(): Bool = combine(0i64, 0i64) == 0i64
+
+    @test
+    def combineInt6402(): Bool = combine(1i64, 0i64) == 1i64
+
+    @test
+    def combineInt6403(): Bool = combine(0i64, 2i64) == 2i64
+
+    @test
+    def combineInt6404(): Bool = combine(1i64, 2i64) == 3i64
+
+    /////////////////////////////////////////////////////////////////////////////
+    // BigInt                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def combineBigInt01(): Bool = combine(0ii, 0ii) == 0ii
+
+    @test
+    def combineBigInt02(): Bool = combine(1ii, 0ii) == 1ii
+
+    @test
+    def combineBigInt03(): Bool = combine(0ii, 2ii) == 2ii
+
+    @test
+    def combineBigInt04(): Bool = combine(1ii, 2ii) == 3ii
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Float32                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def combineFloat3201(): Bool = combine(0.0f32, 0.0f32) == 0.0f32
+
+    @test
+    def combineFloat3202(): Bool = combine(1.0f32, 0.0f32) == 1.0f32
+
+    @test
+    def combineFloat3203(): Bool = combine(0.0f32, 2.0f32) == 2.0f32
+
+    @test
+    def combineFloat3204(): Bool = combine(1.0f32, 2.0f32) == 3.0f32
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Float64                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def combineFloat6401(): Bool = combine(0.0f64, 0.0f64) == 0.0f64
+
+    @test
+    def combineFloat6402(): Bool = combine(1.0f64, 0.0f64) == 1.0f64
+
+    @test
+    def combineFloat6403(): Bool = combine(0.0f64, 2.0f64) == 2.0f64
+
+    @test
+    def combineFloat6404(): Bool = combine(1.0f64, 2.0f64) == 3.0f64
+
+    /////////////////////////////////////////////////////////////////////////////
     // String                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Closes #1681

I've added the `identity` law to the `Monoid` TC as that is a requirement for the algebraic structure. Should it perhaps be phrased differently like
```flix
law identity: forall(x: a) with Eq[a] . Monoid.combine(x, Monoid.empty()) == x and Monoid.combine(Monoid.empty(), x) == x
```