### PR TITLE
fix: mark `{Functor, Boxable}` as pub

### DIFF
--- a/main/src/library/Boxable.flix
+++ b/main/src/library/Boxable.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for types that can be boxed.
 ///
-lawless class Boxable[a] with Order[a], ToString[a] {
+pub lawless class Boxable[a] with Order[a], ToString[a] {
 
     ///
     /// Boxes the given `x`.

--- a/main/src/library/Functor.flix
+++ b/main/src/library/Functor.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for types that can be mapped over.
 ///
-class Functor[m : Type -> Type] {
+pub class Functor[m : Type -> Type] {
     ///
     /// Applies the function `f` to `x` preserving its structure.
     ///


### PR DESCRIPTION
Closes #3091