### PR TITLE
feat: add `SemiGroup` and `CommutativeSemiGroup` symbolic operators

### DIFF
--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -14,7 +14,6 @@
  *  limitations under the License.
  */
 
-
 ///
 /// A type class for types that form a commutative semigroup.
 ///
@@ -30,6 +29,11 @@ pub class CommutativeSemiGroup[a] with SemiGroup[a] {
     law commutative: forall(x: a, y: a) with Eq[a] . CommutativeSemiGroup.combine(x, y) == CommutativeSemiGroup.combine(y, x)
 
 }
+
+///
+/// Alias for `CommutativeSemiGroup.combine`.
+///
+pub def |+|(x: a, y: a): a with CommutativeSemiGroup[a] = CommutativeSemiGroup.combine(x, y)
 
 instance CommutativeSemiGroup[Unit]
 

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -107,6 +107,26 @@ pub def |>(x: a, f: a -> b & ef): b & ef = f(x)
 pub def ||>(x: (a, b), f: ((a, b)) -> c & ef): c & ef = f(x)
 
 ///
+/// Alias for `SemiGroup.combine`.
+///
+pub def ++(x: a, y: a): a with SemiGroup[a] = SemiGroup.combine(x, y)
+
+///
+/// Alias for `CommutativeSemiGroup.combine`.
+///
+pub def |+|(x: a, y: a): a with CommutativeSemiGroup[a] = CommutativeSemiGroup.combine(x, y)
+
+///
+/// Returns `true` if `x` implies `y` logically holds.
+///
+pub def ==>(x: Bool, y: Bool): Bool = not x or y
+
+///
+/// Returns true if `x` implies `y` and vise versa.
+///
+pub def <==>(x: Bool, y: Bool): Bool = x == y
+
+///
 /// Converts `x` to a string and prints it to standard out.
 ///
 pub def print(x: a): Unit & Impure with ToString[a] =
@@ -121,16 +141,6 @@ pub def println(x: a): Unit & Impure with ToString[a] =
     import static get java.lang.System.out as getOut;
     import java.io.PrintStream.println(String);
     x |> ToString.toString |> println(getOut())
-
-///
-/// Returns `true` if `x` implies `y` logically holds.
-///
-pub def ==>(x: Bool, y: Bool): Bool = not x or y
-
-///
-/// Returns true if `x` implies `y` and vise versa.
-///
-pub def <==>(x: Bool, y: Bool): Bool = x == y
 
 ///
 /// Crashes the current process with the given message `m`.

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -107,16 +107,6 @@ pub def |>(x: a, f: a -> b & ef): b & ef = f(x)
 pub def ||>(x: (a, b), f: ((a, b)) -> c & ef): c & ef = f(x)
 
 ///
-/// Alias for `SemiGroup.combine`.
-///
-pub def ++(x: a, y: a): a with SemiGroup[a] = SemiGroup.combine(x, y)
-
-///
-/// Alias for `CommutativeSemiGroup.combine`.
-///
-pub def |+|(x: a, y: a): a with CommutativeSemiGroup[a] = CommutativeSemiGroup.combine(x, y)
-
-///
 /// Returns `true` if `x` implies `y` logically holds.
 ///
 pub def ==>(x: Bool, y: Bool): Bool = not x or y

--- a/main/src/library/SemiGroup.flix
+++ b/main/src/library/SemiGroup.flix
@@ -34,6 +34,11 @@ pub lawless class SemiGroup[a] {
 
 }
 
+///
+/// Alias for `SemiGroup.combine`.
+///
+pub def ++(x: a, y: a): a with SemiGroup[a] = SemiGroup.combine(x, y)
+
 instance SemiGroup[Unit] {
     pub def combine(_: Unit, _: Unit): Unit = ()
 }

--- a/main/test/ca/uwaterloo/flix/library/LibrarySuite.scala
+++ b/main/test/ca/uwaterloo/flix/library/LibrarySuite.scala
@@ -27,6 +27,7 @@ class LibrarySuite extends Suites(
   new FlixTest("TestChain", "main/test/ca/uwaterloo/flix/library/TestChain.flix")(Options.TestWithLibAll),
   new FlixTest("TestChar", "main/test/ca/uwaterloo/flix/library/TestChar.flix")(Options.TestWithLibAll),
   new FlixTest("TestChoice", "main/test/ca/uwaterloo/flix/library/TestChoice.flix")(Options.TestWithLibAll),
+  new FlixTest("TestCommutativeSemiGroup", "main/test/ca/uwaterloo/flix/library/TestCommutativeSemiGroup.flix")(Options.TestWithLibAll),
   new FlixTest("TestChannel", "main/test/ca/uwaterloo/flix/library/TestChannel.flix")(Options.TestWithLibAll),
   new FlixTest("TestDemandList", "main/test/ca/uwaterloo/flix/library/TestDemandList.flix")(Options.TestWithLibAll),
   new FlixTest("TestEnvironment", "main/test/ca/uwaterloo/flix/library/TestEnvironment.flix")(Options.TestWithLibAll),

--- a/main/test/ca/uwaterloo/flix/library/TestCommutativeSemiGroup.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestCommutativeSemiGroup.flix
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2022 Magnus Madsen
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace TestCommutativeSemiGroup {
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Syntax                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def operator01(): Bool = (1 |+| 1) == 2
+
+    @test
+    def operator02(): Bool = (Set#{1, 2} |+| Set#{2, 3}) == Set#{1, 2, 3}
+
+}

--- a/main/test/ca/uwaterloo/flix/library/TestSemiGroup.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSemiGroup.flix
@@ -429,4 +429,17 @@ namespace TestSemiGroup {
     @test
     def associativeTest01(): Bool = combine(combine("a", "b"), "c") == combine("a", combine("b", "c"))
 
+    /////////////////////////////////////////////////////////////////////////////
+    // Syntax                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def operator01(): Bool = (1 ++ 1) == 2
+
+    @test
+    def operator02(): Bool = ("abc" ++ "def") == "abcdef"
+
+    @test
+    def operator03(): Bool = (1 :: 2 :: Nil ++ 3 :: 4 :: Nil) == 1 :: 2 :: 3 :: 4 :: Nil
+
 }


### PR DESCRIPTION
Fixes #3063

I cannot add these directly to Prelude because it breaks our tests. Maybe we need two Preludes? Not sure what to do.