### PR TITLE
fix: `Foldable.toArray`

### DIFF
--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -176,7 +176,7 @@ pub lawless class Foldable[t : Type -> Type] {
     ///
     pub def toArray(t: t[a]): Array[a] & Impure =
         let v = MutList.new();
-        Foldable.foldRight((x, _) -> MutList.push!(x, v), (), t);
+        Foldable.foldLeft((_, a) -> MutList.push!(a, v), (), t);
         MutList.toArray(v)
 
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestFoldable.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFoldable.flix
@@ -199,4 +199,21 @@ namespace TestFoldable {
     def joinWith04(): Bool =
         Foldable.joinWith(x -> x + x, ",", "1" :: "2" :: "3" :: Nil) == "11,22,33"
 
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toArray                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toArray01(): Bool & Impure =
+        Array.sameElements(Foldable.toArray(Nel(1, Nil)), [1])
+
+    @test
+    def toArray02(): Bool & Impure =
+        Array.sameElements(Foldable.toArray(Nel(1, 2 :: 3 :: Nil)), [1, 2, 3])
+
+    @test
+    def toArray03(): Bool & Impure =
+        Array.sameElements(Foldable.toArray(Nel(1, 1 :: 2 :: 3 :: Nil)), [1, 1, 2, 3])
+
 }


### PR DESCRIPTION
Fixes `Foldable.toArray`. It reversed the elements before this fix (with `foldRight`) and there were no tests to ensure correct behavior.