### PR TITLE
feat: add check to disallow lattice variables used in relational contexts without fix

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -108,6 +108,11 @@ object SafetyError {
     /**
       * Returns a formatted string with helpful suggestions.
       */
-    def explain(formatter: Formatter): Option[String] = None
+    def explain(formatter: Formatter): Option[String] = Some({
+      import formatter._
+      s"""
+         |${underline("Tip:")} Lattice variables can be used as non-lattice values with the `fix` keyword.
+         |""".stripMargin
+    })
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -86,4 +86,28 @@ object SafetyError {
       */
     def explain(formatter: Formatter): Option[String] = None
   }
+
+  /**
+    * An error raised to indicate an illegal use of a lattice variable `sym` as a non-lattice value.
+    *
+    * @param sym the lattice symbol used in a relational context.
+    * @param loc the position of the head atom containing the illegal variable.
+    */
+  case class IllegalUseOfLatticeVariable(sym: Symbol.VarSym, loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Illegal relational use of lattice variable '$sym'"
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Illegal relational use of lattice variable '${red(sym.text)}'.
+         |
+         |${code(loc, "the lattice variable occurs here.")}
+         |""".stripMargin
+    }
+
+    /**
+      * Returns a formatted string with helpful suggestions.
+      */
+    def explain(formatter: Formatter): Option[String] = None
+  }
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
-import ca.uwaterloo.flix.language.errors.SafetyError.{IllegalNegativelyBoundWildVariable, IllegalNegativelyBoundWildcard, IllegalNonPositivelyBoundVariable}
+import ca.uwaterloo.flix.language.errors.SafetyError.{IllegalNegativelyBoundWildVariable, IllegalNegativelyBoundWildcard, IllegalNonPositivelyBoundVariable, IllegalUseOfLatticeVariable}
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.FunSuite
 
@@ -123,6 +123,17 @@ class TestSafety extends FunSuite with TestUtils {
       """.stripMargin
     val result = compile(input, DefaultOptions)
     expectError[IllegalNegativelyBoundWildcard](result)
+  }
+
+  test("UseOfLatticeVariable.01") {
+    val input =
+      """
+        |pub def f(): #{ A(Int32), B(Int32; Int32) } = #{
+        |    A(x: Int32) :- B(12; x).
+        |}
+      """.stripMargin
+    val result = compile(input, Options.TestWithLibAll)
+    expectError[IllegalUseOfLatticeVariable](result)
   }
 
 }

--- a/main/test/flix/Test.Exp.Fixpoint.Solve.Lattice.flix
+++ b/main/test/flix/Test.Exp.Fixpoint.Solve.Lattice.flix
@@ -79,93 +79,102 @@ namespace Test/Exp/Fixpoint/Solve/Lattice {
         case _                  => Top
     }
 
-    // TODO: How to extract lattice facts?
-
     @test
-    def testFixpointLattice01(): Bool =
-        let _m = solve #{
+    def testFixpointLattice01(): Bool & Impure =
+        let m = solve #{
             LocalVar((); Top). LocalVar((); Top). LocalVar((); Top). LocalVar((); Top).
         };
-        true // TODO
+        let ans = query m select t from LocalVar(_; t);
+        ans.length == 1 and ans[0] == Top
 
     @test
-    def testFixpointLattice02(): Bool =
-        let _m = solve #{
-            LocalVar((); Top). LocalVar((); Top). LocalVar((); Top). LocalVar((); Top).
+    def testFixpointLattice02(): Bool & Impure =
+        let m = solve #{
+            LocalVar((); Bot). LocalVar((); Top). LocalVar((); Bot). LocalVar((); Top).
         };
-        true // TODO
+        let ans = query m select t from LocalVar(_; t);
+        ans.length == 1 and ans[0] == Top
 
     @test
-    def testFixpointLattice03(): Bool =
-        let _m = solve #{
+    def testFixpointLattice03(): Bool & Impure =
+        let m = solve #{
             LocalVar((); Cst(39)).
         };
-        true // TODO
+        let ans = query m select t from LocalVar(_; t);
+        ans.length == 1 and ans[0] == Cst(39)
 
     @test
-    def testFixpointLattice04(): Bool =
-        let _m = solve #{
-            LocalVar((); Cst(39)).
+    def testFixpointLattice04(): Bool & Impure =
+        let m = solve #{
+            LocalVar((); Cst(39)). LocalVar((); Bot).
         };
-        true // TODO
+        let ans = query m select t from LocalVar(_; t);
+        ans.length == 1 and ans[0] == Cst(39)
 
     @test
-    def testFixpointLattice05(): Bool =
-        let _m = solve #{
+    def testFixpointLattice05(): Bool & Impure =
+        let m = solve #{
             LocalVar((); Cst(39)). LocalVar((); Cst(39)).
         };
-        true // TODO
+        let ans = query m select t from LocalVar(_; t);
+        ans.length == 1 and ans[0] == Cst(39)
 
     @test
-    def testFixpointLattice06(): Bool =
-        let _m = solve #{
+    def testFixpointLattice06(): Bool & Impure =
+        let m = solve #{
             LocalVar((); Cst(39)). LocalVar((); Cst(12)).
         };
-        true // TODO
+        let ans = query m select t from LocalVar(_; t);
+        ans.length == 1 and ans[0] == Top
 
     @test
-    def testFixpointLattice07(): Bool =
-        let _m = solve #{
-            LocalVar((); Cst(39)). LocalVar((); Cst(12)).
+    def testFixpointLattice07(): Bool & Impure =
+        let m = solve #{
+            LocalVar((); Cst(39)). LocalVar((); Cst(12)). LocalVar((); Bot).
         };
-        true // TODO
+        let ans = query m select t from LocalVar(_; t);
+        ans.length == 1 and ans[0] == Top
 
     @test
-    def testFixpointLattice08(): Bool =
-        let _m = solve #{
+    def testFixpointLattice08(): Bool & Impure =
+        let m = solve #{
             LitStm("a", 39).
             LocalVar(x; Cst(c)) :- LitStm(x, c).
         };
-        true // TODO
+        let ans = query m select t from LocalVar(_; t);
+        ans.length == 1 and ans[0] == Cst(39)
 
     @test
-    def testFixpointLattice09(): Bool =
-        let _m = solve #{
-            LitStm("a", 39).
+    def testFixpointLattice09(): Bool & Impure =
+        let m = solve #{
+            LitStm("a", 39). LitStm("a", 345).
             LocalVar(x; Cst(c)) :- LitStm(x, c).
         };
-        true // TODO
+        let ans = query m select t from LocalVar(_; t);
+        ans.length == 1 and ans[0] == Top
 
     @test
-    def testFixpointLattice10(): Bool =
-        let _m = solve #{
+    def testFixpointLattice10(): Bool & Impure =
+        let m = solve #{
             LitStm("a", 39).
             AddStm("r", "a", "a").
             LocalVar(x; Cst(c)) :- LitStm(x, c).
             LocalVar(r; sum(v1, v2)) :- AddStm(r, x, y), LocalVar(x; v1), LocalVar(y; v2).
 
         };
-        true // TODO
+        let ans = query m select t from LocalVar("r"; t);
+        ans.length == 1 and ans[0] == Cst(39+39)
 
     @test
-    def testFixpointLattice11(): Bool =
-        let _m = solve #{
+    def testFixpointLattice11(): Bool & Impure =
+        let m = solve #{
             LitStm("a", 39).
+            LitStm("b", 12).
             AddStm("r", "a", "b").
             LocalVar(x; Cst(c)) :- LitStm(x, c).
             LocalVar(r; sum(v1, v2)) :- AddStm(r, x, y), LocalVar(x; v1), LocalVar(y; v2).
-
         };
-        true // TODO
+        let ans = query m select t from LocalVar("r"; t);
+        ans.length == 1 and ans[0] == Cst(39+12)
 
 }


### PR DESCRIPTION
This includes adding `fix` in the rewrite of query expressions like
```
query p select (x, y) from A(x; y)
```
this is understood as
```
query p select (x, y) from fix A(x; y)
```
which you can also write yourself, but it is added automatically.