### PR TITLE
Refactor: import syntax in library part 3

### DIFF
--- a/main/src/library/Int16.flix
+++ b/main/src/library/Int16.flix
@@ -283,9 +283,9 @@ namespace Int16 {
     ///
     @Time(1) @Space(1)
     pub def fromString(s: String): Result[Int16, String] = try {
-        import java.lang.String.strip();
-        import static java.lang.Short.parseShort(String);
-        Ok(s |> strip |> parseShort) as & Pure
+        import java.lang.String.strip(): String & Pure;
+        import static java.lang.Short.parseShort(String): Int16 & Pure;
+        Ok(s |> strip |> parseShort)
     } catch {
         case _: ##java.lang.NumberFormatException => Err("Int16.fromString")
     }
@@ -300,12 +300,12 @@ namespace Int16 {
     ///
     @Time(1) @Space(1)
     pub def tryToInt8(x: Int16): Option[Int8] =
-        import static java.lang.Short.valueOf(Int16);
-        import java.lang.Short.byteValue();
+        import static java.lang.Short.valueOf(Int16): ##java.lang.Short & Pure;
+        import java.lang.Short.byteValue(): Int8 & Pure;
         if (x < Int8.toInt16(Int8.minValue()) or x > Int8.toInt16(Int8.maxValue()))
             None
         else
-            Some(valueOf(x) |> byteValue) as & Pure
+            Some(valueOf(x) |> byteValue)
 
     ///
     /// Convert `x` to a Int32.
@@ -314,9 +314,9 @@ namespace Int16 {
     ///
     @Time(1) @Space(1)
     pub def toInt32(x: Int16): Int32 =
-        import static java.lang.Short.valueOf(Int16);
-        import java.lang.Short.intValue();
-        (valueOf(x) |> intValue) as & Pure
+        import static java.lang.Short.valueOf(Int16): ##java.lang.Short & Pure;
+        import java.lang.Short.intValue(): Int16 & Pure;
+        (valueOf(x) |> intValue)
 
     ///
     /// Convert `x` to a Int64.

--- a/main/src/library/Int16.flix
+++ b/main/src/library/Int16.flix
@@ -315,7 +315,7 @@ namespace Int16 {
     @Time(1) @Space(1)
     pub def toInt32(x: Int16): Int32 =
         import static java.lang.Short.valueOf(Int16): ##java.lang.Short & Pure;
-        import java.lang.Short.intValue(): Int16 & Pure;
+        import java.lang.Short.intValue(): Int32 & Pure;
         (valueOf(x) |> intValue)
 
     ///
@@ -325,9 +325,9 @@ namespace Int16 {
     ///
     @Time(1) @Space(1)
     pub def toInt64(x: Int16): Int64 =
-        import static java.lang.Short.valueOf(Int16);
-        import java.lang.Short.longValue();
-        (valueOf(x) |> longValue) as & Pure
+        import static java.lang.Short.valueOf(Int16): ##java.lang.Short & Pure;
+        import java.lang.Short.longValue(): Int64 & Pure;
+        (valueOf(x) |> longValue)
 
     ///
     /// Convert `x` to a BigInt.
@@ -336,10 +336,10 @@ namespace Int16 {
     ///
     @Time(1) @Space(1)
     pub def toBigInt(x: Int16): BigInt =
-        import static java.lang.Short.valueOf(Int16) as i16ValueOf;
-        import java.lang.Short.longValue();
-        import static java.math.BigInteger.valueOf(Int64) as asBigInt;
-        (i16ValueOf(x) |> longValue |> asBigInt) as & Pure
+        import static java.lang.Short.valueOf(Int16): ##java.lang.Short & Pure as i16ValueOf;
+        import java.lang.Short.longValue(): Int64 & Pure;
+        import static java.math.BigInteger.valueOf(Int64): BigInt & Pure as asBigInt;
+        (i16ValueOf(x) |> longValue |> asBigInt)
 
     ///
     /// Convert `x` to a Float32.
@@ -348,9 +348,9 @@ namespace Int16 {
     ///
     @Time(1) @Space(1)
     pub def toFloat32(x: Int16): Float32 =
-        import static java.lang.Short.valueOf(Int16);
-        import java.lang.Short.floatValue();
-        (valueOf(x) |> floatValue) as & Pure
+        import static java.lang.Short.valueOf(Int16): ##java.lang.Short & Pure;
+        import java.lang.Short.floatValue(): Float32 & Pure;
+        (valueOf(x) |> floatValue)
 
     ///
     /// Convert `x` to a Float64.
@@ -359,9 +359,9 @@ namespace Int16 {
     ///
     @Time(1) @Space(1)
     pub def toFloat64(x: Int16): Float64 =
-        import static java.lang.Short.valueOf(Int16);
-        import java.lang.Short.doubleValue();
-        (valueOf(x) |> doubleValue) as & Pure
+        import static java.lang.Short.valueOf(Int16): ##java.lang.Short & Pure;
+        import java.lang.Short.doubleValue(): Float64 & Pure;
+        (valueOf(x) |> doubleValue)
 
     ///
     /// Helper function for the `clamp` conversion function.
@@ -382,10 +382,10 @@ namespace Int16 {
     ///
     @Time(1) @Space(1)
     pub def clampToInt8(x: Int16, minimum: Int8, maximum: Int8): Int8 =
-        import static java.lang.Short.valueOf(Int16);
-        import java.lang.Short.byteValue();
+        import static java.lang.Short.valueOf(Int16): ##java.lang.Short & Pure;
+        import java.lang.Short.byteValue(): Int8 & Pure;
         let mini16 = Int8.toInt16(minimum);
         let maxi16 = Int8.toInt16(maximum);
-        (valueOf(clamp(x, mini16, maxi16)) |> byteValue) as & Pure
+        (valueOf(clamp(x, mini16, maxi16)) |> byteValue)
 
 }

--- a/main/src/library/Int32.flix
+++ b/main/src/library/Int32.flix
@@ -299,9 +299,9 @@ namespace Int32 {
     ///
     @Time(1) @Space(1)
     pub def fromString(s: String): Result[Int32, String] = try {
-        import java.lang.String.strip();
-        import static java.lang.Integer.parseInt(String);
-        Ok(s |> strip |> parseInt) as & Pure
+        import java.lang.String.strip(): String & Pure;
+        import static java.lang.Integer.parseInt(String): Int32 & Pure;
+        Ok(s |> strip |> parseInt)
     } catch {
         case _: ##java.lang.NumberFormatException => Err("Int32.fromString")
     }
@@ -316,12 +316,12 @@ namespace Int32 {
     ///
     @Time(1) @Space(1)
     pub def tryToInt8(x: Int32): Option[Int8] =
-        import static java.lang.Integer.valueOf(Int32);
-        import java.lang.Integer.byteValue();
+        import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer & Pure;
+        import java.lang.Integer.byteValue(): Int8 & Pure;
         if (x < Int8.toInt32(Int8.minValue()) or x > Int8.toInt32(Int8.maxValue()))
             None
         else
-            Some(valueOf(x) |> byteValue) as & Pure
+            Some(valueOf(x) |> byteValue)
 
     ///
     /// Convert `x` to an `Option[Int16]`.
@@ -333,12 +333,12 @@ namespace Int32 {
     ///
     @Time(1) @Space(1)
     pub def tryToInt16(x: Int32): Option[Int16] =
-        import static java.lang.Integer.valueOf(Int32);
-        import java.lang.Integer.shortValue();
+        import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer & Pure;
+        import java.lang.Integer.shortValue(): Int16 & Pure;
         if (x < Int16.toInt32(Int16.minValue()) or x > Int16.toInt32(Int16.maxValue()))
             None
         else
-            Some(valueOf(x) |> shortValue) as & Pure
+            Some(valueOf(x) |> shortValue)
 
     ///
     /// Convert `x` to a Int64.
@@ -347,9 +347,9 @@ namespace Int32 {
     ///
     @Time(1) @Space(1)
     pub def toInt64(x: Int32): Int64 =
-        import static java.lang.Integer.valueOf(Int32);
-        import java.lang.Integer.longValue();
-        (valueOf(x) |> longValue) as & Pure
+        import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer & Pure;
+        import java.lang.Integer.longValue(): Int64 & Pure;
+        (valueOf(x) |> longValue)
 
     ///
     /// Convert `x` to a BigInt.
@@ -358,10 +358,10 @@ namespace Int32 {
     ///
     @Time(1) @Space(1)
     pub def toBigInt(x: Int32): BigInt =
-        import static java.lang.Integer.valueOf(Int32) as i16ValueOf;
-        import java.lang.Integer.longValue();
-        import static java.math.BigInteger.valueOf(Int64) as asBigInt;
-        (i16ValueOf(x) |> longValue |> asBigInt) as & Pure
+        import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer & Pure as i16ValueOf;
+        import java.lang.Integer.longValue(): Int64 & Pure;
+        import static java.math.BigInteger.valueOf(Int64): BigInt & Pure as asBigInt;
+        (i16ValueOf(x) |> longValue |> asBigInt)
 
     ///
     /// Convert `x` to an Float32.
@@ -370,9 +370,9 @@ namespace Int32 {
     ///
     @Time(1) @Space(1)
     pub def toFloat32(x: Int32): Float32 =
-        import static java.lang.Integer.valueOf(Int32);
-        import java.lang.Integer.floatValue();
-        (valueOf(x) |> floatValue) as & Pure
+        import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer & Pure;
+        import java.lang.Integer.floatValue(): Float32 & Pure;
+        (valueOf(x) |> floatValue)
 
     ///
     /// Convert `x` to a Float64.
@@ -381,9 +381,9 @@ namespace Int32 {
     ///
     @Time(1) @Space(1)
     pub def toFloat64(x: Int32): Float64 =
-        import static java.lang.Integer.valueOf(Int32);
-        import java.lang.Integer.doubleValue();
-        (valueOf(x) |> doubleValue) as & Pure
+        import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer & Pure;
+        import java.lang.Integer.doubleValue(): Float64 & Pure;
+        (valueOf(x) |> doubleValue)
 
     ///
     /// Helper function for the `clamp` conversion functions.
@@ -404,11 +404,11 @@ namespace Int32 {
     ///
     @Time(1) @Space(1)
     pub def clampToInt8(x: Int32, minimum: Int8, maximum: Int8): Int8 =
-        import static java.lang.Integer.valueOf(Int32);
-        import java.lang.Integer.byteValue();
+        import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer & Pure;
+        import java.lang.Integer.byteValue(): Int8 & Pure;
         let mini32 = Int8.toInt32(minimum);
         let maxi32 = Int8.toInt32(maximum);
-        (valueOf(clamp(x, mini32, maxi32)) |> byteValue) as & Pure
+        (valueOf(clamp(x, mini32, maxi32)) |> byteValue)
 
 
     ///
@@ -418,10 +418,10 @@ namespace Int32 {
     ///
     @Time(1) @Space(1)
     pub def clampToInt16(x: Int32, minimum: Int16, maximum: Int16): Int16 =
-        import static java.lang.Integer.valueOf(Int32);
-        import java.lang.Integer.shortValue();
+        import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer & Pure;
+        import java.lang.Integer.shortValue(): Int16 & Pure;
         let mini32 = Int16.toInt32(minimum);
         let maxi32 = Int16.toInt32(maximum);
-        (valueOf(clamp(x, mini32, maxi32)) |> shortValue) as & Pure
+        (valueOf(clamp(x, mini32, maxi32)) |> shortValue)
 
 }

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -278,9 +278,9 @@ namespace Int64 {
     ///
     @Time(1) @Space(1)
     pub def fromString(s: String): Result[Int64, String] = try {
-        import java.lang.String.strip();
-        import static java.lang.Long.parseLong(String);
-        Ok(s |> strip |> parseLong) as & Pure
+        import java.lang.String.strip(): String & Pure;
+        import static java.lang.Long.parseLong(String): Int64 & Pure;
+        Ok(s |> strip |> parseLong)
     } catch {
         case _: ##java.lang.NumberFormatException => Err("Int64.fromString")
     }
@@ -295,12 +295,12 @@ namespace Int64 {
     ///
     @Time(1) @Space(1)
     pub def tryToInt8(x: Int64): Option[Int8] =
-        import static java.lang.Long.valueOf(Int64);
-        import java.lang.Long.byteValue();
+        import static java.lang.Long.valueOf(Int64): ##java.lang.Long & Pure;
+        import java.lang.Long.byteValue(): Int8 & Pure;
         if (x < Int8.toInt64(Int8.minValue()) or x > Int8.toInt64(Int8.maxValue()))
             None
         else
-            Some(valueOf(x) |> byteValue) as & Pure
+            Some(valueOf(x) |> byteValue)
 
     ///
     /// Convert `x` to an `Option[Int16]`.
@@ -312,12 +312,12 @@ namespace Int64 {
     ///
     @Time(1) @Space(1)
     pub def tryToInt16(x: Int64): Option[Int16] =
-        import static java.lang.Long.valueOf(Int64);
-        import java.lang.Long.shortValue();
+        import static java.lang.Long.valueOf(Int64): ##java.lang.Long & Pure;
+        import java.lang.Long.shortValue(): Int16 & Pure;
         if (x < Int16.toInt64(Int16.minValue()) or x > Int16.toInt64(Int16.maxValue()))
             None
         else
-            Some(valueOf(x) |> shortValue) as & Pure
+            Some(valueOf(x) |> shortValue)
 
     ///
     /// Convert `x` to an `Option[Int32]`.
@@ -329,12 +329,12 @@ namespace Int64 {
     ///
     @Time(1) @Space(1)
     pub def tryToInt32(x: Int64): Option[Int32] =
-        import static java.lang.Long.valueOf(Int64);
-        import java.lang.Long.intValue();
+        import static java.lang.Long.valueOf(Int64): ##java.lang.Long & Pure;
+        import java.lang.Long.intValue(): Int32 & Pure;
         if (x < Int32.toInt64(Int32.minValue()) or x > Int32.toInt64(Int32.maxValue()))
             None
         else
-            Some(valueOf(x) |> intValue) as & Pure
+            Some(valueOf(x) |> intValue)
     ///
     /// Convert `x` to a BigInt.
     ///
@@ -342,10 +342,10 @@ namespace Int64 {
     ///
     @Time(1) @Space(1)
     pub def toBigInt(x: Int64): BigInt =
-        import static java.lang.Long.valueOf(Int64) as i64ValueOf;
-        import java.lang.Long.longValue();
-        import static java.math.BigInteger.valueOf(Int64) as asBigInt;
-        (i64ValueOf(x) |> longValue |> asBigInt) as & Pure
+        import static java.lang.Long.valueOf(Int64): ##java.lang.Long & Pure as i64ValueOf;
+        import java.lang.Long.longValue(): Int64 & Pure;
+        import static java.math.BigInteger.valueOf(Int64): BigInt & Pure as asBigInt;
+        (i64ValueOf(x) |> longValue |> asBigInt)
 
     ///
     /// Convert `x` to a Float32.
@@ -354,9 +354,9 @@ namespace Int64 {
     ///
     @Time(1) @Space(1)
     pub def toFloat32(x: Int64): Float32 =
-        import static java.lang.Long.valueOf(Int64);
-        import java.lang.Long.floatValue();
-        (valueOf(x) |> floatValue) as & Pure
+        import static java.lang.Long.valueOf(Int64): ##java.lang.Long & Pure;
+        import java.lang.Long.floatValue(): Float32 & Pure;
+        (valueOf(x) |> floatValue)
 
     ///
     /// Convert `x` to a Float32.
@@ -365,9 +365,9 @@ namespace Int64 {
     ///
     @Time(1) @Space(1)
     pub def toFloat64(x: Int64): Float64 =
-        import static java.lang.Long.valueOf(Int64);
-        import java.lang.Long.doubleValue();
-        (valueOf(x) |> doubleValue) as & Pure
+        import static java.lang.Long.valueOf(Int64): ##java.lang.Long & Pure;
+        import java.lang.Long.doubleValue(): Float64 & Pure;
+        (valueOf(x) |> doubleValue)
 
     ///
     /// Helper function for the `clamp` conversion functions.
@@ -388,11 +388,11 @@ namespace Int64 {
     ///
     @Time(1) @Space(1)
     pub def clampToInt8(x: Int64, minimum: Int8, maximum: Int8): Int8 =
-        import static java.lang.Long.valueOf(Int64);
-        import java.lang.Long.byteValue();
+        import static java.lang.Long.valueOf(Int64): ##java.lang.Long & Pure;
+        import java.lang.Long.byteValue(): Int8 & Pure;
         let mini64 = Int8.toInt64(minimum);
         let maxi64 = Int8.toInt64(maximum);
-        (valueOf(clamp(x, mini64, maxi64)) |> byteValue) as & Pure
+        (valueOf(clamp(x, mini64, maxi64)) |> byteValue)
 
     ///
     /// Convert `x` to an `Int16`.
@@ -401,11 +401,11 @@ namespace Int64 {
     ///
     @Time(1) @Space(1)
     pub def clampToInt16(x: Int64, minimum: Int16, maximum: Int16): Int16 =
-        import static java.lang.Long.valueOf(Int64);
-        import java.lang.Long.shortValue();
+        import static java.lang.Long.valueOf(Int64): ##java.lang.Long & Pure;
+        import java.lang.Long.shortValue(): Int16 & Pure;
         let mini64 = Int16.toInt64(minimum);
         let maxi64 = Int16.toInt64(maximum);
-        (valueOf(clamp(x, mini64, maxi64)) |> shortValue) as & Pure
+        (valueOf(clamp(x, mini64, maxi64)) |> shortValue)
 
 
     ///
@@ -415,10 +415,10 @@ namespace Int64 {
     ///
     @Time(1) @Space(1)
     pub def clampToInt32(x: Int64, minimum: Int32, maximum: Int32): Int32 =
-        import static java.lang.Long.valueOf(Int64);
-        import java.lang.Long.intValue();
+        import static java.lang.Long.valueOf(Int64): ##java.lang.Long & Pure;
+        import java.lang.Long.intValue(): Int32 & Pure;
         let mini64 = Int32.toInt64(minimum);
         let maxi64 = Int32.toInt64(maximum);
-        (valueOf(clamp(x, mini64, maxi64)) |> intValue) as & Pure
+        (valueOf(clamp(x, mini64, maxi64)) |> intValue)
 
 }

--- a/main/src/library/Int8.flix
+++ b/main/src/library/Int8.flix
@@ -332,7 +332,7 @@ namespace Int8 {
     pub def toBigInt(x: Int8): BigInt =
         import static java.lang.Byte.valueOf(Int8): ##java.lang.Byte & Pure as i8ValueOf;
         import java.lang.Byte.longValue(): ##java.math.BigInteger & Pure;
-        import static java.math.BigInteger.valueOf(Int64): BigInt & Pure as asBigInt;
+        import static java.math.BigInteger.valueOf(Int64): Int64 & Pure as asBigInt;
         (i8ValueOf(x) |> longValue |> asBigInt)
 
     ///

--- a/main/src/library/Int8.flix
+++ b/main/src/library/Int8.flix
@@ -331,8 +331,8 @@ namespace Int8 {
     @Time(1) @Space(1)
     pub def toBigInt(x: Int8): BigInt =
         import static java.lang.Byte.valueOf(Int8): ##java.lang.Byte & Pure as i8ValueOf;
-        import java.lang.Byte.longValue(): ##java.math.BigInteger & Pure;
-        import static java.math.BigInteger.valueOf(Int64): Int64 & Pure as asBigInt;
+        import java.lang.Byte.longValue(): Int64 & Pure;
+        import static java.math.BigInteger.valueOf(Int64): BigInt & Pure as asBigInt;
         (i8ValueOf(x) |> longValue |> asBigInt)
 
     ///

--- a/main/src/library/Int8.flix
+++ b/main/src/library/Int8.flix
@@ -297,9 +297,9 @@ namespace Int8 {
     ///
     @Time(1) @Space(1)
     pub def toInt16(x: Int8): Int16 =
-        import static java.lang.Byte.valueOf(Int8);
-        import java.lang.Byte.shortValue();
-        (valueOf(x) |> shortValue) as & Pure
+        import static java.lang.Byte.valueOf(Int8): ##java.lang.Byte & Pure;
+        import java.lang.Byte.shortValue(): Int16 & Pure;
+        (valueOf(x) |> shortValue)
 
     ///
     /// Convert `x` to an Int32.
@@ -308,9 +308,9 @@ namespace Int8 {
     ///
     @Time(1) @Space(1)
     pub def toInt32(x: Int8): Int32 =
-        import static java.lang.Byte.valueOf(Int8);
-        import java.lang.Byte.intValue();
-        (valueOf(x) |> intValue) as & Pure
+        import static java.lang.Byte.valueOf(Int8): ##java.lang.Byte & Pure;
+        import java.lang.Byte.intValue(): Int32 & Pure;
+        (valueOf(x) |> intValue)
 
     ///
     /// Convert `x` to an Int64.
@@ -319,9 +319,9 @@ namespace Int8 {
     ///
     @Time(1) @Space(1)
     pub def toInt64(x: Int8): Int64 =
-        import static java.lang.Byte.valueOf(Int8);
-        import java.lang.Byte.longValue();
-        (valueOf(x) |> longValue) as & Pure
+        import static java.lang.Byte.valueOf(Int8): ##java.lang.Byte & Pure;
+        import java.lang.Byte.longValue(): Int64 & Pure;
+        (valueOf(x) |> longValue)
 
     ///
     /// Convert `x` to a BigInt.
@@ -330,10 +330,10 @@ namespace Int8 {
     ///
     @Time(1) @Space(1)
     pub def toBigInt(x: Int8): BigInt =
-        import static java.lang.Byte.valueOf(Int8) as i8ValueOf;
-        import java.lang.Byte.longValue();
-        import static java.math.BigInteger.valueOf(Int64) as asBigInt;
-        (i8ValueOf(x) |> longValue |> asBigInt) as & Pure
+        import static java.lang.Byte.valueOf(Int8): ##java.lang.Byte & Pure as i8ValueOf;
+        import java.lang.Byte.longValue(): ##java.math.BigInteger & Pure;
+        import static java.math.BigInteger.valueOf(Int64): BigInt & Pure as asBigInt;
+        (i8ValueOf(x) |> longValue |> asBigInt)
 
     ///
     /// Convert `x` to a Float32.
@@ -342,9 +342,9 @@ namespace Int8 {
     ///
     @Time(1) @Space(1)
     pub def toFloat32(x: Int8): Float32 =
-        import static java.lang.Byte.valueOf(Int8);
-        import java.lang.Byte.floatValue();
-        (valueOf(x) |> floatValue) as & Pure
+        import static java.lang.Byte.valueOf(Int8): ##java.lang.Byte & Pure;
+        import java.lang.Byte.floatValue(): Float32 & Pure;
+        (valueOf(x) |> floatValue)
 
     ///
     /// Convert `x` to a Float64.
@@ -353,8 +353,8 @@ namespace Int8 {
     ///
     @Time(1) @Space(1)
     pub def toFloat64(x: Int8): Float64 =
-        import static java.lang.Byte.valueOf(Int8);
-        import java.lang.Byte.doubleValue();
-        (valueOf(x) |> doubleValue) as & Pure
+        import static java.lang.Byte.valueOf(Int8): ##java.lang.Byte & Pure;
+        import java.lang.Byte.doubleValue(): Float64 & Pure;
+        (valueOf(x) |> doubleValue)
 
 }

--- a/main/src/library/Int8.flix
+++ b/main/src/library/Int8.flix
@@ -283,9 +283,9 @@ namespace Int8 {
     ///
     @Time(1) @Space(1)
     pub def fromString(s: String): Result[Int8, String] = try {
-        import java.lang.String.strip();
-        import static java.lang.Byte.parseByte(String);
-        Ok(s |> strip |> parseByte) as & Pure
+        import java.lang.String.strip(): String & Pure;
+        import static java.lang.Byte.parseByte(String): Int8 & Pure;
+        Ok(s |> strip |> parseByte)
     } catch {
         case _: ##java.lang.NumberFormatException => Err("Int8.fromString")
     }

--- a/main/src/library/Object.flix
+++ b/main/src/library/Object.flix
@@ -19,8 +19,8 @@ namespace Object {
     /// Returns `true` if the given value `x` is `null`.
     ///
     pub def isNull(x: a): Bool =
-        import static java.util.Objects.isNull(##java.lang.Object);
-        isNull(x as ##java.lang.Object) as & Pure
+        import static java.util.Objects.isNull(##java.lang.Object): Bool & Pure;
+        isNull(x as ##java.lang.Object)
 
     ///
     /// Returns `None` if the given value `x` is `null`, otherwise returns `Some(x)`.
@@ -33,7 +33,7 @@ namespace Object {
     ///
     @Unsafe
     pub def toString(x: a): String =
-        import static java.util.Objects.toString(##java.lang.Object);
-        toString(x as ##java.lang.Object) as & Pure
+        import static java.util.Objects.toString(##java.lang.Object): String & Pure;
+        toString(x as ##java.lang.Object)
 
 }

--- a/main/src/library/Order.flix
+++ b/main/src/library/Order.flix
@@ -336,8 +336,8 @@ instance Order[BigInt] {
 instance Order[String] {
 
     pub def compare(x: String, y: String): Comparison =
-        import java.lang.String.compareTo(String);
-        Comparison.fromInt32((x `compareTo` y) as & Pure)
+        import java.lang.String.compareTo(String): Int32 & Pure;
+        Comparison.fromInt32((x `compareTo` y))
 
 }
 


### PR DESCRIPTION
Related to #3148

In this PR

- [x] `Int8.flix`
- [x] `Int16.flix`
- [x] `Int32.flix`
- [x] `Int64.flix`
- [x] `Object.flix`
- [x] `Order.flix`