### PR TITLE
ci: add `mlutze/fcwg` to community build

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -4,20 +4,20 @@ jobs:
   community-build:
 
     runs-on: ubuntu-latest
-    continue-on-error: true
+
     env:
       # === ADD PROJECTS HERE === #
       #   (space-separated list)  #
-      PROJECTS: magnus-madsen/helloworld
+      PROJECTS: magnus-madsen/helloworld mlutze/fcwg
 
       PROJ_DIR: project-build
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.11
+      - name: Set up JDK 13
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 13
       - name: Build jar
         run: ./gradlew jar
       - name: Build community projects
@@ -27,11 +27,21 @@ jobs:
           
           # Build each project in a fresh directory.
           for project in ${{ env.PROJECTS }}; do
+            
+            # Initialize the project directory.
             mkdir ${{ env.PROJ_DIR }}
             cd ${{ env.PROJ_DIR }}
             java -jar ../build/libs/flix.jar init
+            
+            # Remove example code to avoid conflicts.
+            rm src/Main.flix
+            rm test/TestMain.flix
+            
+            # Install and build the project.
             java -jar ../build/libs/flix.jar install $project
             java -jar ../build/libs/flix.jar build
+            
+            # Exit and clean the project directory.
             cd ..
             rm -rf ${{ env.PROJ_DIR }}
           done


### PR DESCRIPTION
To support including this package I also had to:
- remove example code after running `flix init`
- update to Java 13