### PR TITLE
refactor: List.groupBy rewritten to be in CPS

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -940,19 +940,24 @@ namespace List {
     /// The function `f` must be pure.
     ///
     @Time(time(f) * length(l)) @Space(space(f) * length(l))
-    pub def groupBy(f: (a, a) -> Bool, l: List[a]): List[List[a]] = match l {
-        case Nil => Nil
-        case x :: xs =>
-            let (r1, r2) = extractHelper(f, xs, x :: Nil, Nil);
-            r1 :: groupBy(f, r2)
-    }
+    pub def groupBy(f: (a, a) -> Bool, l: List[a]): List[List[a]] =
+        def loop(l1, k) = match l1 {
+            case Nil => k(Nil)
+            case x :: xs =>
+                let (r1, r2) = extractHelper(f, xs, x :: Nil, ks -> ks);
+                loop(r2, ks -> k(r1 :: ks))
+        };
+        loop(l, ks -> ks)
 
     ///
     /// Helper function for `groupBy`.
     ///
-    def extractHelper(f: (a, a) -> Bool, l1: List[a], l2: List[a], l3: List[a]): (List[a], List[a]) = match l1 {
-        case Nil     => (reverse(l2), reverse(l3))
-        case x :: xs => if (agreeHelper(f, x, l2)) extractHelper(f, xs, x :: l2, l3) else extractHelper(f, xs, l2, x :: l3)
+    /// The list `l2` is needed by `agreeHelper` so it must be materialized (rather than a continuation).
+    /// We have no choice but to reverse it.
+    ///
+    def extractHelper(f: (a, a) -> Bool, l1: List[a], l2: List[a], k: List[a] -> List[a]): (List[a], List[a]) = match l1 {
+        case Nil     => (reverse(l2), k(Nil))
+        case x :: xs => if (agreeHelper(f, x, l2)) extractHelper(f, xs, x :: l2, k) else extractHelper(f, xs, l2, ks -> k(x :: ks))
     }
 
     ///


### PR DESCRIPTION
`List.groupBy` is not tail recursive this PR rewrites it in the CPS style.

This program is a pathological case for `groupBy` - the input list is long and there are no groups:

~~~

def main(_args: Array[String]): Int32 & Impure =
    println("Small `groupBy` ...");
    testGroupBy(10) |> println;
    println("Big `groupBy` ...");
    testGroupBy(100000) |> println;
    0


def testGroupBy(e: Int32): Int32 = 
    List.range(0, e) |> List.groupBy((x,y) -> x == y) |> List.length

~~~

With the current head, it runs out of memory rather than directly burst the stack on my PC...

~~~ 

Small `groupBy` ...
10
Big `groupBy` ...
Exception in thread "main" java.lang.OutOfMemoryError: Java heap space
	at List.Clo%reverse%1028348.getUniqueThreadClosure(Unknown Source)
	at List.Clo%reverse%1028348.invoke(Unknown Source)
	at Cont%Obj.unwind(Cont%Obj)
	at List.Def%reverse%1011449.invoke(Unknown Source)
	at Cont%Obj.unwind(Cont%Obj)
	at List.Def%extractHelper%1010801.invoke(Unknown Source)
	at Cont%Obj.unwind(Cont%Obj)
	at List.Def%groupBy%1000328.invoke(Unknown Source)
	at Cont%Obj.unwind(Cont%Obj)
	at List.Def%groupBy%1000328.invoke(Unknown Source)
	at Cont%Obj.unwind(Cont%Obj)
	at List.Def%groupBy%1000328.invoke(Unknown Source)
	at Cont%Obj.unwind(Cont%Obj)
	at List.Def%groupBy%1000328.invoke(Unknown Source)
	at Cont%Obj.unwind(Cont%Obj)
	at List.Def%groupBy%1000328.invoke(Unknown Source)
	at Cont%Obj.unwind(Cont%Obj)
	at List.Def%groupBy%1000328.invoke(Unknown Source)
	at Cont%Obj.unwind(Cont%Obj)
	at List.Def%groupBy%1000328.invoke(Unknown Source)
	at Cont%Obj.unwind(Cont%Obj)
	at List.Def%groupBy%1000328.invoke(Unknown Source)
	at Cont%Obj.unwind(Cont%Obj)
	at List.Def%groupBy%1000328.invoke(Unknown Source)
	at Cont%Obj.unwind(Cont%Obj)
	at List.Def%groupBy%1000328.invoke(Unknown Source)
	at Cont%Obj.unwind(Cont%Obj)
	at List.Def%groupBy%1000328.invoke(Unknown Source)
	at Cont%Obj.unwind(Cont%Obj)
	at List.Def%groupBy%1000328.invoke(Unknown Source)
	at Cont%Obj.unwind(Cont%Obj)
	at List.Def%groupBy%1000328.invoke(Unknown Source)

Process finished with exit code 1

~~~

The same program runs to completion with the CPS version of `groupBy` in this PR:

~~~

Small `groupBy` ...
10
Big `groupBy` ...
100000

Process finished with exit code 0

~~~
