### PR TITLE
refactor: Change Validation to use Nec rather than Nel (related to #3232)

### DIFF
--- a/main/src/library/GetOpt.flix
+++ b/main/src/library/GetOpt.flix
@@ -155,7 +155,10 @@ namespace GetOpt {
         let answers = getOpt1(ordering, optDescriptors, sourceArgs);
         match answers.errors ::: List.map(errUnrec, answers.unknowns) {
             case Nil => Success({options = answers.options, nonOptions = answers.nonOptions})
-            case e :: es => Failure(Nel(e, es))
+            case e :: es => match List.toNec(es) {
+                case None    => Failure(Nec.singleton(e))
+                case Some(c) => Failure(Nec.cons(e, c))
+            }
         }
 
     ///

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -1254,6 +1254,26 @@ namespace List {
         }
 
     ///
+    /// Returns the list `l` as `Option[Nel[a]]`.
+    ///
+    /// If `l` is empty return `None`, otherwise return the Nel wrapped in `Some`.
+    ///
+    pub def toNel(l: List[a]): Option[Nel[a]] = match l {
+        case Nil     => None
+        case x :: xs => Some(Nel(x, xs))
+    }
+
+    ///
+    /// Returns the list `l` as `Option[Nec[a]]`.
+    ///
+    /// If `l` is empty return `None`, otherwise return the Nec wrapped in `Some`.
+    ///
+    pub def toNec(l: List[a]): Option[Nec[a]] = match l {
+        case Nil     => None
+        case x :: xs => Some(foldLeft(Nec.snoc, Nec.singleton(x), xs))
+    }
+
+    ///
     /// Sort list `l` so that elements are ordered from low to high according to their `Order` instance.
     ///
     /// The sort is not stable, i.e., equal elements may appear in a different order than in the input `l`.

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -32,6 +32,28 @@ instance Eq[Nec[a]] with Eq[a] {
     pub def eq(c1: Nec[a], c2: Nec[a]): Bool = Nec.equals(c1, c2)
 }
 
+instance Order[Nec[a]] with Order[a] {
+    ///
+    /// Compares `c1` and `c2` lexicographically.
+    ///
+    pub def compare(c1: Nec[a], c2: Nec[a]): Comparison =
+        use Nec.ViewLeft.{OneLeft, SomeLeft};
+        match (Nec.viewLeft(c1), Nec.viewLeft(c2)) {
+            case (OneLeft(x), OneLeft(y))           => x <=> y
+            case (OneLeft(x), SomeLeft(y, _))       => match (x <=> y) {
+                case EqualTo => LessThan
+                case cmp     => cmp
+            }
+            case (SomeLeft(x, _), OneLeft(y))       => match (x <=> y) {
+                case EqualTo => GreaterThan
+                case cmp     => cmp
+            }
+            case (SomeLeft(x, xs), SomeLeft(y, ys)) =>
+                let cmp = x <=> y;
+                if (cmp == EqualTo) xs <=> ys else cmp
+        }
+}
+
 instance Hash[Nec[a]] with Hash[a] {
     pub def hash(c: Nec[a]): Int32 = 39119 + Hash.hash(Nec.toList(c))
 }

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -439,7 +439,7 @@ namespace Option {
     ///
     @Time(1) @Space(1)
     pub def toSuccess(o: Option[t], e: e): Validation[t, e] = match o {
-        case None       => Failure(Nel(e, Nil))
+        case None       => Failure(Nec.singleton(e))
         case Some(a)    => Success(a)
     }
 
@@ -449,7 +449,7 @@ namespace Option {
     @Time(1) @Space(1)
     pub def toFailure(o: Option[e], d: t): Validation[t, e] = match o {
         case None       => Success(d)
-        case Some(e)    => Failure(Nel(e, Nil))
+        case Some(e)    => Failure(Nec.singleton(e))
     }
 
     ///

--- a/main/src/library/Validation.flix
+++ b/main/src/library/Validation.flix
@@ -19,7 +19,7 @@
 ///
 pub enum Validation[t, e] with Eq, Order, ToString {
     case Success(t),
-    case Failure(Nel[e])
+    case Failure(Nec[e])
 }
 
 instance Hash[Validation[t, e]] with Hash[t], Hash[e] {
@@ -32,7 +32,7 @@ instance Hash[Validation[t, e]] with Hash[t], Hash[e] {
 instance SemiGroup[Validation[t, e]] with SemiGroup[t] {
     pub def combine(x: Validation[t, e], y: Validation[t, e]): Validation[t, e] = match (x, y) {
         case (Success(x1), Success(y1))     => Success(SemiGroup.combine(x1, y1))
-        case (Failure(es1), Failure(es2))   => Failure(Nel.append(es1, es2))
+        case (Failure(es1), Failure(es2))   => Failure(Nec.append(es1, es2))
         case (Failure(_), _)                => x
         case (_, Failure(_))                => y
     }
@@ -48,11 +48,11 @@ namespace Validation {
     /// Applies the function in `v1` to the value in `v2`.
     ///
     @Time(1) @Space(1)
-    pub def ap(v1: Validation[t -> u & f, e], v2: Validation[t, e]): Validation[u, e] & f = match (v1, v2) {
+    pub def ap(v1: Validation[t -> u & ef, e], v2: Validation[t, e]): Validation[u, e] & ef = match (v1, v2) {
         case (Success(f), Success(v)) => Success(f(v))
         case (Success(_), Failure(e)) => Failure(e)
         case (Failure(e), Success(_)) => Failure(e)
-        case (Failure(x), Failure(y)) => Failure(Nel.append(x, y))
+        case (Failure(x), Failure(y)) => Failure(Nec.append(x, y))
     }
 
     ///
@@ -97,7 +97,7 @@ namespace Validation {
     /// Returns `Success(f(v))` if `o` is `Success(v)`. Otherwise returns `v`.
     ///
     @Time(time(f)) @Space(space(f))
-    pub def map(f: t -> u & f, v: Validation[t, e]): Validation[u, e] & f = match v {
+    pub def map(f: t -> u & ef, v: Validation[t, e]): Validation[u, e] & ef = match v {
         case Success(t) => Success(f(t))
         case Failure(e) => Failure(e)
     }
@@ -126,10 +126,10 @@ namespace Validation {
     ///
     /// Precondition: at least one Failure has been encountered.
     ///
-    def sequenceHelperFailure(xs: List[Validation[a, e]], ac: Nel[e]): Validation[List[a], e] = match xs {
+    def sequenceHelperFailure(xs: List[Validation[a, e]], ac: Nec[e]): Validation[List[a], e] = match xs {
         case Nil              => Failure(ac)
         case Success(_) :: vs => sequenceHelperFailure(vs, ac)
-        case Failure(e) :: vs => sequenceHelperFailure(vs, Nel.append(ac, e))
+        case Failure(e) :: vs => sequenceHelperFailure(vs, Nec.append(ac, e))
     }
 
 
@@ -138,7 +138,7 @@ namespace Validation {
     ///
     /// Otherwise returns `Failure(e1 :: ... :: en)` with all of the failures concatenated.
     ///
-    pub def traverse(f: a -> Validation[b, e] & f, xs: List[a]): Validation[List[b], e] & f =
+    pub def traverse(f: a -> Validation[b, e] & ef, xs: List[a]): Validation[List[b], e] & ef =
         traverseHelperSuccess(f, xs, ys -> Success(ys))
 
     ///
@@ -146,7 +146,7 @@ namespace Validation {
     ///
     /// Precondition: no Failure has been encountered.
     ///
-    def traverseHelperSuccess(f: a -> Validation[b, e] & f, xs: List[a], sk: List[b] -> Validation[List[b], e]): Validation[List[b], e] & f = match xs {
+    def traverseHelperSuccess(f: a -> Validation[b, e] & ef, xs: List[a], sk: List[b] -> Validation[List[b], e]): Validation[List[b], e] & ef = match xs {
         case Nil        => sk(Nil)
         case v :: vs    => match f(v) {
             case Success(x) => traverseHelperSuccess(f, vs, xs -> sk(x :: xs))
@@ -159,11 +159,11 @@ namespace Validation {
     ///
     /// Precondition: at least one Failure has been encountered.
     ///
-    def traverseHelperFailure(f: a -> Validation[b, e] & f, xs: List[a], ac: Nel[e]): Validation[List[b], e] & f = match xs {
+    def traverseHelperFailure(f: a -> Validation[b, e] & ef, xs: List[a], ac: Nec[e]): Validation[List[b], e] & ef = match xs {
         case Nil        => Failure(ac)
         case v :: vs    => match f(v) {
             case Success(_) => traverseHelperFailure(f, vs, ac)
-            case Failure(x) => traverseHelperFailure(f, vs, Nel.append(ac, x))
+            case Failure(x) => traverseHelperFailure(f, vs, Nec.append(ac, x))
         }
     }
 
@@ -175,7 +175,7 @@ namespace Validation {
     /// This function is the "forgetful" version of `traverse`, use it when the you want the effect
     /// of applying `f` to each element but do not care about collecting the results.
     ///
-    pub def traverseX(f: a -> Validation[b, e] & f, xs: List[a]): Validation[Unit, e] & f =
+    pub def traverseX(f: a -> Validation[b, e] & ef, xs: List[a]): Validation[Unit, e] & ef =
         traverseXHelperSuccess(f, xs)
 
     ///
@@ -183,7 +183,7 @@ namespace Validation {
     ///
     /// Precondition: no Failure has been encountered.
     ///
-    def traverseXHelperSuccess(f: a -> Validation[b, e] & f, xs: List[a]): Validation[Unit, e] & f = match xs {
+    def traverseXHelperSuccess(f: a -> Validation[b, e] & ef, xs: List[a]): Validation[Unit, e] & ef = match xs {
         case Nil        => Success()
         case v :: vs    => match f(v) {
             case Success(_) => traverseXHelperSuccess(f, vs)
@@ -196,11 +196,11 @@ namespace Validation {
     ///
     /// Precondition: at least one Failure has been encountered.
     ///
-    def traverseXHelperFailure(f: a -> Validation[b, e] & f, xs: List[a], ac: Nel[e]): Validation[Unit, e] & f = match xs {
+    def traverseXHelperFailure(f: a -> Validation[b, e] & ef, xs: List[a], ac: Nec[e]): Validation[Unit, e] & ef = match xs {
         case Nil        => Failure(ac)
         case v :: vs    => match f(v) {
             case Success(_) => traverseXHelperFailure(f, vs, ac)
-            case Failure(e) => traverseXHelperFailure(f, vs, Nel.append(ac, e))
+            case Failure(e) => traverseXHelperFailure(f, vs, Nec.append(ac, e))
         }
     }
 
@@ -223,7 +223,7 @@ namespace Validation {
     /// Returns `Err(e)` if `v` is `Failure(e)`.
     ///
     @Time(1) @Space(1)
-    pub def toResult(v: Validation[t, e]): Result[t, Nel[e]] = match v {
+    pub def toResult(v: Validation[t, e]): Result[t, Nec[e]] = match v {
         case Success(t) => Ok(t)
         case Failure(e) => Err(e)
     }
@@ -246,7 +246,7 @@ namespace Validation {
     /// Returns the concatenation of all the failures as `Failure(xs)` if either or both of `v1` or `v2` are `Failure(xs1)`.
     ///
     @Time(time(f)) @Space(space(f))
-    pub def lift2(f: (t1, t2) -> u & f, v1: Validation[t1, e], v2: Validation[t2, e]): Validation[u, e] & f =
+    pub def lift2(f: (t1, t2) -> u & ef, v1: Validation[t1, e], v2: Validation[t2, e]): Validation[u, e] & ef =
         ap(map(f, v1), v2)
 
     ///
@@ -255,7 +255,7 @@ namespace Validation {
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2` and `v3` are `Failure(xs1)`.
     ///
     @Time(time(f)) @Space(space(f))
-    pub def lift3(f: (t1, t2, t3) -> u & f, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e]): Validation[u, e] & f =
+    pub def lift3(f: (t1, t2, t3) -> u & ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e]): Validation[u, e] & ef =
         ap(lift2(f, v1, v2), v3)
 
     ///
@@ -264,7 +264,7 @@ namespace Validation {
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, `v3` and `v4` are `Failure(xs1)`.
     ///
     @Time(time(f)) @Space(space(f))
-    pub def lift4(f: (t1, t2, t3, t4) -> u & f, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e]): Validation[u, e] & f=
+    pub def lift4(f: (t1, t2, t3, t4) -> u & ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e]): Validation[u, e] & ef=
         ap(lift3(f, v1, v2, v3), v4)
 
     ///
@@ -273,7 +273,7 @@ namespace Validation {
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v5` are `Failure(xs1)`.
     ///
     @Time(time(f)) @Space(space(f))
-    pub def lift5(f: (t1, t2, t3, t4, t5) -> u & f, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e]): Validation[u, e] & f =
+    pub def lift5(f: (t1, t2, t3, t4, t5) -> u & ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e]): Validation[u, e] & ef =
         ap(lift4(f, v1, v2, v3, v4), v5)
 
     ///
@@ -282,7 +282,7 @@ namespace Validation {
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v6` are `Failure(xs1)`.
     ///
     @Time(time(f)) @Space(space(f))
-    pub def lift6(f: (t1, t2, t3, t4, t5, t6) -> u & f, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e]): Validation[u, e] & f =
+    pub def lift6(f: (t1, t2, t3, t4, t5, t6) -> u & ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e]): Validation[u, e] & ef =
         ap(lift5(f, v1, v2, v3, v4, v5), v6)
 
     ///
@@ -291,7 +291,7 @@ namespace Validation {
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v7` are `Failure(xs1)`.
     ///
     @Time(time(f)) @Space(space(f))
-    pub def lift7(f: (t1, t2, t3, t4, t5, t6, t7) -> u & f, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e]): Validation[u, e] & f=
+    pub def lift7(f: (t1, t2, t3, t4, t5, t6, t7) -> u & ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e]): Validation[u, e] & ef=
         ap(lift6(f, v1, v2, v3, v4, v5, v6), v7)
 
     ///
@@ -300,7 +300,7 @@ namespace Validation {
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v8` are `Failure(xs1)`.
     ///
     @Time(time(f)) @Space(space(f))
-    pub def lift8(f: (t1, t2, t3, t4, t5, t6, t7, t8) -> u & f, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e], v8: Validation[t8, e]): Validation[u, e] & f =
+    pub def lift8(f: (t1, t2, t3, t4, t5, t6, t7, t8) -> u & ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e], v8: Validation[t8, e]): Validation[u, e] & ef =
         ap(lift7(f, v1, v2, v3, v4, v5, v6, v7), v8)
 
     ///
@@ -309,7 +309,7 @@ namespace Validation {
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v9` are `Failure(xs1)`.
     ///
     @Time(time(f)) @Space(space(f))
-    pub def lift9(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9) -> u & f, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e], v8: Validation[t8, e], v9: Validation[t9, e]): Validation[u, e] & f =
+    pub def lift9(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9) -> u & ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e], v8: Validation[t8, e], v9: Validation[t9, e]): Validation[u, e] & ef =
         ap(lift8(f, v1, v2, v3, v4, v5, v6, v7, v8), v9)
 
     ///
@@ -318,7 +318,7 @@ namespace Validation {
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v10` are `Failure(xs1)`.
     ///
     @Time(time(f)) @Space(space(f))
-    pub def lift10(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) -> u & f, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e], v8: Validation[t8, e], v9: Validation[t9, e], v10: Validation[t10, e]): Validation[u, e] & f =
+    pub def lift10(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) -> u & ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e], v8: Validation[t8, e], v9: Validation[t9, e], v10: Validation[t10, e]): Validation[u, e] & ef =
         ap(lift9(f, v1, v2, v3, v4, v5, v6, v7, v8, v9), v10)
 
 

--- a/main/test/ca/uwaterloo/flix/library/TestGetOpt.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestGetOpt.flix
@@ -68,7 +68,7 @@ namespace TestGetOpt {
         case Failure(_) => false
     }
 
-    def assertFailureWith(x: Validation[a, e], test: Nel[e] -> Bool): Bool  = match x {
+    def assertFailureWith(x: Validation[a, e], test: Nec[e] -> Bool): Bool  = match x {
         case Success(_) => false
         case Failure(es) => test(es)
     }
@@ -158,21 +158,21 @@ namespace TestGetOpt {
         /// "-m" not defined
         let args = ["-m"];
         getOpt(Permute, options(), args) `assertFailureWith` x ->
-            Nel.length(x) == 1
+            Nec.length(x) == 1
 
     @test
     def testCharArgs10(): Bool & Impure =
         /// "-m" not defined
         let args = ["-Xm"];
         getOpt(Permute, options(), args) `assertFailureWith` x ->
-            Nel.length(x) == 1
+            Nec.length(x) == 1
 
     @test
     def testCharArgs11(): Bool & Impure =
         /// "-m" not defined
         let args = ["-X", "-m"];
         getOpt(Permute, options(), args) `assertFailureWith` x ->
-            Nel.length(x) == 1
+            Nec.length(x) == 1
 
     /////////////////////////////////////////////////////////////////////////////
     // String / name options                                                   //
@@ -235,21 +235,21 @@ namespace TestGetOpt {
         /// "--multiple" not defined
         let args = ["--multiple"];
         getOpt(Permute, options(), args) `assertFailureWith` x ->
-            Nel.length(x) == 1
+            Nec.length(x) == 1
 
     @test
     def testStringArgs10(): Bool & Impure =
         /// "--multiple" not defined
         let args = ["--hires", "--multiple"];
         getOpt(Permute, options(), args) `assertFailureWith` x ->
-            Nel.length(x) == 1
+            Nec.length(x) == 1
 
     @test
     def testStringArgs11(): Bool & Impure =
         /// "--multiple" not defined
         let args = ["--hires", "--multiple", "test_option1"];
         getOpt(Permute, options(), args) `assertFailureWith` x ->
-            Nel.length(x) == 1
+            Nec.length(x) == 1
 
     /////////////////////////////////////////////////////////////////////////////
     // Mixed short and name options                                            //
@@ -312,21 +312,21 @@ namespace TestGetOpt {
         /// "-m" not defined
         let args = ["--hires", "-m"];
         getOpt(Permute, options(), args) `assertFailureWith` x ->
-            Nel.length(x) == 1
+            Nec.length(x) == 1
 
     @test
     def testMixedArgs10(): Bool & Impure =
         /// "--multiple" not defined
         let args = ["-X", "--multiple"];
         getOpt(Permute, options(), args) `assertFailureWith` x ->
-            Nel.length(x) == 1
+            Nec.length(x) == 1
 
     @test
     def testMixedArgs11(): Bool & Impure =
         /// "--multiple" not defined
         let args = ["-X", "--multiple", "test_option1"];
         getOpt(Permute, options(), args) `assertFailureWith` x ->
-            Nel.length(x) == 1
+            Nec.length(x) == 1
 
     /////////////////////////////////////////////////////////////////////////////
     // Prefix of long option                                                   //
@@ -337,7 +337,7 @@ namespace TestGetOpt {
         /// Fail: Could be "hires" or "height"
         let args = ["--h=1000"];
         getOpt(Permute, options(), args) `assertFailureWith` x ->
-            Nel.length(x) == 1
+            Nec.length(x) == 1
 
     @test
     def testPrefixArgs02(): Bool & Impure =
@@ -374,7 +374,7 @@ namespace TestGetOpt {
     def testDecodeArgs02(): Bool & Impure =
         let args = ["--width=fourteen_thousand"];
         getOpt(Permute, options(), args) `assertFailureWith` x ->
-            Nel.length(x) == 1
+            Nec.length(x) == 1
 
     @test
     def testDecodeArgs03(): Bool & Impure =
@@ -386,19 +386,19 @@ namespace TestGetOpt {
     def testDecodeArgs04(): Bool & Impure =
         let args = ["--width=fourteen_hundred", "--height=1000"];
         getOpt(Permute, options(), args) `assertFailureWith` x ->
-            Nel.length(x) == 1
+            Nec.length(x) == 1
 
     @test
     def testDecodeArgs05(): Bool & Impure =
         let args = ["--width=1400", "--height=one_thousand"];
         getOpt(Permute, options(), args) `assertFailureWith` x ->
-            Nel.length(x) == 1
+            Nec.length(x) == 1
 
     @test
     def testDecodeArgs06(): Bool & Impure =
         let args = ["--width=fourteen_hundred", "--height=one_thousand"];
         getOpt(Permute, options(), args) `assertFailureWith` x ->
-            Nel.length(x) == 2
+            Nec.length(x) == 2
 
     /////////////////////////////////////////////////////////////////////////////
     // Preprocess                                                              //

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -1906,6 +1906,44 @@ def toArray04(): Bool & Impure =
     Array.sameElements(a, [1,2,3])
 
 /////////////////////////////////////////////////////////////////////////////
+// toNel                                                                   //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def toNel01(): Bool = List.toNel(Nil: List[Unit]) == None
+
+@test
+def toNel02(): Bool = List.toNel(1 :: Nil) == Some(Nel(1, Nil))
+
+@test
+def toNel03(): Bool = List.toNel(1 :: 2 :: Nil) == Some(Nel(1, 2 :: Nil))
+
+@test
+def toNel04(): Bool = List.toNel(1 :: 1 :: Nil) == Some(Nel(1, 1 :: Nil))
+
+@test
+def toNel05(): Bool = List.toNel(2 :: 1 :: Nil) == Some(Nel(2, 1 :: Nil))
+
+/////////////////////////////////////////////////////////////////////////////
+// toNec                                                                   //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def toNec01(): Bool = List.toNec(Nil: List[Unit]) == None
+
+@test
+def toNec02(): Bool = List.toNec(1 :: Nil) == Some(Nec.singleton(1))
+
+@test
+def toNec03(): Bool = List.toNec(1 :: 2 :: Nil) == Some(Nec.cons(1, Nec.singleton(2)))
+
+@test
+def toNec04(): Bool = List.toNec(1 :: 1 :: Nil) == Some(Nec.cons(1, Nec.singleton(1)))
+
+@test
+def toNec05(): Bool = List.toNec(2 :: 1 :: Nil) == Some(Nec.cons(2, Nec.singleton(1)))
+
+/////////////////////////////////////////////////////////////////////////////
 // sortWith                                                                //
 /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestMonoid.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMonoid.flix
@@ -411,13 +411,13 @@ namespace TestMonoid {
     def validationEmpty01(): Bool = empty(): Validation[String, String] == Success("")
 
     @test
-    def validationCombine01(): Bool = combine(Failure(Nel.singleton("e1")), Failure(Nel.singleton("e2"))): Validation[String, String] == Failure(Nel.append(Nel.singleton("e1"), Nel.singleton("e2")))
+    def validationCombine01(): Bool = combine(Failure(Nec.singleton("e1")), Failure(Nec.singleton("e2"))): Validation[String, String] == Failure(Nec.append(Nec.singleton("e1"), Nec.singleton("e2")))
 
     @test
-    def validationCombine02(): Bool = combine(Success("a"), Failure(Nel.singleton("e1"))): Validation[String, String] == Failure(Nel.singleton("e1"))
+    def validationCombine02(): Bool = combine(Success("a"), Failure(Nec.singleton("e1"))): Validation[String, String] == Failure(Nec.singleton("e1"))
 
     @test
-    def validationCombine03(): Bool = combine(Failure(Nel.singleton("e1")), Success("1")): Validation[String, String] == Failure(Nel.singleton("e1"))
+    def validationCombine03(): Bool = combine(Failure(Nec.singleton("e1")), Success("1")): Validation[String, String] == Failure(Nec.singleton("e1"))
 
     @test
     def validationCombine04(): Bool = combine(Success("a"), Success("1")): Validation[String, String] == Success("a1")

--- a/main/test/ca/uwaterloo/flix/library/TestNec.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestNec.flix
@@ -76,6 +76,40 @@ namespace TestNec {
     def notEquals04(): Bool = necOf3(1, 2, 3) != necOf3(1, 2, 2)
 
     /////////////////////////////////////////////////////////////////////////////
+    // compare                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def testCompare01(): Bool = Order.compare(singleton(1), singleton(1)) == EqualTo
+
+    @test
+    def testCompare02(): Bool = Order.compare(singleton(1), singleton(2)) == LessThan
+
+    @test
+    def testCompare03(): Bool = Order.compare(singleton(2), singleton(1)) == GreaterThan
+
+    @test
+    def testCompare04(): Bool = Order.compare(singleton(1), necOf2(1, 2)) == LessThan
+
+    @test
+    def testCompare05(): Bool = Order.compare(necOf2(1, 2), singleton(1)) == GreaterThan
+
+    @test
+    def testCompare06(): Bool = Order.compare(singleton(1), necOf2(0,0)) == GreaterThan
+
+    @test
+    def testCompare07(): Bool = Order.compare(necOf2(0, 0), singleton(1)) == LessThan
+
+    @test
+    def testCompare08(): Bool = Order.compare(necOf2(1, 2), necOf2(1, 1)) == GreaterThan
+
+    @test
+    def testCompare09(): Bool = Order.compare(necOf2(1, 2), necOf2(1, 3)) == LessThan
+
+    @test
+    def testCompare10(): Bool = Order.compare(necOf4(1, 2, 3, 4), necOf4(1, 2, 3, 4)) == EqualTo
+
+    /////////////////////////////////////////////////////////////////////////////
     // singleton                                                               //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestOption.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestOption.flix
@@ -172,7 +172,7 @@ def toErr02(): Bool = Option.toErr(Some("err"), "default") == Err("err")
 // toSuccess                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toSuccess01(): Bool = Option.toSuccess(None: Option[Unit], "err") == Failure(Nel("err", Nil))
+def toSuccess01(): Bool = Option.toSuccess(None: Option[Unit], "err") == Failure(Nec.singleton("err"))
 
 @test
 def toSuccess02(): Bool = Option.toSuccess(Some(1), "err") == Success(1)
@@ -184,7 +184,7 @@ def toSuccess02(): Bool = Option.toSuccess(Some(1), "err") == Success(1)
 def toFailure01(): Bool = Option.toFailure(None: Option[Unit], "default") == Success("default")
 
 @test
-def toFailure02(): Bool = Option.toFailure(Some("err"), "default") == Failure(Nel("err", Nil))
+def toFailure02(): Bool = Option.toFailure(Some("err"), "default") == Failure(Nec.singleton("err"))
 
 /////////////////////////////////////////////////////////////////////////////
 // withDefault                                                             //

--- a/main/test/ca/uwaterloo/flix/library/TestSemiGroup.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSemiGroup.flix
@@ -212,13 +212,13 @@ namespace TestSemiGroup {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def combineValidation01(): Bool = combine(Failure(Nel.singleton("e1")), Failure(Nel.singleton("e2"))): Validation[String, String] == Failure(Nel.append(Nel.singleton("e1"), Nel.singleton("e2")))
+    def combineValidation01(): Bool = combine(Failure(Nec.singleton("e1")), Failure(Nec.singleton("e2"))): Validation[String, String] == Failure(Nec.append(Nec.singleton("e1"), Nec.singleton("e2")))
 
     @test
-    def combineValidation02(): Bool = combine(Success("a"), Failure(Nel.singleton("e1"))): Validation[String, String] == Failure(Nel.singleton("e1"))
+    def combineValidation02(): Bool = combine(Success("a"), Failure(Nec.singleton("e1"))): Validation[String, String] == Failure(Nec.singleton("e1"))
 
     @test
-    def combineValidation03(): Bool = combine(Failure(Nel.singleton("e1")), Success("1")): Validation[String, String] == Failure(Nel.singleton("e1"))
+    def combineValidation03(): Bool = combine(Failure(Nec.singleton("e1")), Success("1")): Validation[String, String] == Failure(Nec.singleton("e1"))
 
     @test
     def combineValidation04(): Bool = combine(Success("a"), Success("1")): Validation[String, String] == Success("a1")

--- a/main/test/ca/uwaterloo/flix/library/TestValidation.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestValidation.flix
@@ -13,460 +13,479 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-namespace Validation {
+
+namespace TestValidation {
 
     use Hash.hash;
+    use Nec.{cons, singleton};
+
+    def necOf2(x: a, y: a): Nec[a] = cons(x, singleton(y))
+
+    def necOf3(w: a, x: a, y: a): Nec[a] = cons(w, cons(x, singleton(y)))
+
+    def necOf4(v: a, w: a, x: a, y: a): Nec[a] = cons(v, cons(w, cons(x, singleton(y))))
+
+    def necOf5(u: a, v: a, w: a, x: a, y: a): Nec[a] = cons(u, cons(v, cons(w, cons(x, singleton(y)))))
+
+    def necOf6(t: a, u: a, v: a, w: a, x: a, y: a): Nec[a] = cons(t, cons(u, cons(v, cons(w, cons(x, singleton(y))))))
+
+    def necOf7(s: a, t: a, u: a, v: a, w: a, x: a, y: a): Nec[a] = cons(s, cons(t, cons(u, cons(v, cons(w, cons(x, singleton(y)))))))
+
+    def necOf8(r: a, s: a, t: a, u: a, v: a, w: a, x: a, y: a): Nec[a] = cons(r, cons(s, cons(t, cons(u, cons(v, cons(w, cons(x, singleton(y))))))))
+
+    def necOf9(q: a, r: a, s: a, t: a, u: a, v: a, w: a, x: a, y: a): Nec[a] = cons(q, cons(r, cons(s, cons(t, cons(u, cons(v, cons(w, cons(x, singleton(y)))))))))
+
+    def necOf10(p: a, q: a, r: a, s: a, t: a, u: a, v: a, w: a, x: a, y: a): Nec[a] = cons(p, cons(q, cons(r, cons(s, cons(t, cons(u, cons(v, cons(w, cons(x, singleton(y))))))))))
 
     /////////////////////////////////////////////////////////////////////////////
     // ap                                                                      //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def ap01(): Bool = ap(Success(x -> x + 1), Success(123)): Validation[_, Unit] == Success(124)
+    def ap01(): Bool = Validation.ap(Success(x -> x + 1), Success(123)): Validation[_, Unit] == Success(124)
 
     @test
-    def ap02(): Bool = ap(Success(x -> x + 1), Failure(Nel(42, Nil))) == Failure(Nel(42, Nil))
+    def ap02(): Bool = Validation.ap(Success(x -> x + 1), Failure(singleton(42))) == Failure(singleton(42))
 
     @test
-    def ap03(): Bool = ap(Failure(Nel(42, Nil)), Success(123)): Validation[Unit, _] == Failure(Nel(42, Nil))
+    def ap03(): Bool = Validation.ap(Failure(singleton(42)), Success(123)): Validation[Unit, _] == Failure(singleton(42))
 
     @test
-    def ap04(): Bool = ap(Failure(Nel(123, Nil)), (Failure(Nel(456, Nil)))): Validation[Unit, _] == Failure(Nel(123, 456 :: Nil))
+    def ap04(): Bool = Validation.ap(Failure(singleton(123)), (Failure(singleton(456)))): Validation[Unit, _] == Failure(necOf2(123, 456))
 
     @test
-    def ap05(): Bool = ap(Failure(Nel(1, 2 :: Nil)), (Failure(Nel(3, Nil)))): Validation[Unit, _] == Failure(Nel(1, 2 :: 3 :: Nil))
+    def ap05(): Bool = Validation.ap(Failure(necOf2(1, 2)), (Failure(singleton(3)))): Validation[Unit, _] == Failure(necOf3(1, 2, 3))
 
     @test
-    def ap06(): Bool = ap(Failure(Nel(1, Nil)), (Failure(Nel(2, 3 :: Nil)))): Validation[Unit, _] == Failure(Nel(1, 2 :: 3 :: Nil))
+    def ap06(): Bool = Validation.ap(Failure(singleton(1)), (Failure(necOf2(2, 3)))): Validation[Unit, _] == Failure(necOf3(1, 2, 3))
 
     @test
-    def ap07(): Bool = ap(Failure(Nel(1, 2 :: Nil)), (Failure(Nel(3, 4 :: Nil)))): Validation[Unit, _] == Failure(Nel(1, 2 :: 3 :: 4 :: Nil))
+    def ap07(): Bool = Validation.ap(Failure(necOf2(1, 2)), (Failure(necOf2(3, 4)))): Validation[Unit, _] == Failure(necOf4(1, 2, 3, 4))
 
     /////////////////////////////////////////////////////////////////////////////
     // getWithDefault                                                          //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def getWithDefault01(): Bool = getWithDefault(456, Success(123)) == 123
+    def getWithDefault01(): Bool = Validation.getWithDefault(456, Success(123)) == 123
 
     @test
-    def getWithDefault02(): Bool = getWithDefault(456, Failure(Nel(42, Nil))) == 456
+    def getWithDefault02(): Bool = Validation.getWithDefault(456, Failure(singleton(42))) == 456
 
     /////////////////////////////////////////////////////////////////////////////
     // withDefault                                                             //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def withDefault01(): Bool = withDefault(default = Success(2), Success(1)): Validation[_, Unit] == Success(1)
+    def withDefault01(): Bool = Validation.withDefault(default = Success(2), Success(1)): Validation[_, Unit] == Success(1)
 
     @test
-    def withDefault02(): Bool = withDefault(default = Failure(Nel(1, Nil)), Success(1)) == Success(1)
+    def withDefault02(): Bool = Validation.withDefault(default = Failure(singleton(1)), Success(1)) == Success(1)
 
     @test
-    def withDefault03(): Bool = withDefault(default = Success(2), Failure(Nel(1, Nil))) == Success(2)
+    def withDefault03(): Bool = Validation.withDefault(default = Success(2), Failure(singleton(1))) == Success(2)
 
     @test
-    def withDefault04(): Bool = withDefault(default = Failure(Nel(2, Nil)), Failure(Nel(1, Nil))): Validation[Unit, _] == Failure(Nel(2, Nil))
+    def withDefault04(): Bool = Validation.withDefault(default = Failure(singleton(2)), Failure(singleton(1))): Validation[Unit, _] == Failure(singleton(2))
 
     /////////////////////////////////////////////////////////////////////////////
     // exists                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def exists01(): Bool = exists(x -> x == 123, (Success(123))) == true
+    def exists01(): Bool = Validation.exists(x -> x == 123, (Success(123))) == true
 
     @test
-    def exists02(): Bool = exists(x -> x != 123, (Success(123))) == false
+    def exists02(): Bool = Validation.exists(x -> x != 123, (Success(123))) == false
 
     /////////////////////////////////////////////////////////////////////////////
     // forall                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def forall01(): Bool = exists(x -> x == 123, (Success(123))) == true
+    def forall01(): Bool = Validation.exists(x -> x == 123, (Success(123))) == true
 
     @test
-    def forall02(): Bool = exists(x -> x != 123, (Success(123))) == false
+    def forall02(): Bool = Validation.exists(x -> x != 123, (Success(123))) == false
 
     /////////////////////////////////////////////////////////////////////////////
     // map                                                                     //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def map01(): Bool = map(x -> x, Success(123)): Validation[_, Unit] == Success(123)
+    def map01(): Bool = Validation.map(x -> x, Success(123)): Validation[_, Unit] == Success(123)
 
     @test
-    def map02(): Bool = map(x -> x + 1, Success(123)): Validation[_, Unit] == Success(124)
+    def map02(): Bool = Validation.map(x -> x + 1, Success(123)): Validation[_, Unit] == Success(124)
 
     @test
-    def map03(): Bool = map(x -> x, Failure(Nel(123, Nil))): Validation[Unit, _] == Failure(Nel(123, Nil))
+    def map03(): Bool = Validation.map(x -> x, Failure(singleton(123))): Validation[Unit, _] == Failure(singleton(123))
 
     @test
-    def map04(): Bool = (Success(123): Validation[_, Unit]) |> map(x -> x + 1) |> map(x -> x * 2)  == Success(248)
+    def map04(): Bool = (Success(123): Validation[_, Unit]) |> Validation.map(x -> x + 1) |> Validation.map(x -> x * 2)  == Success(248)
 
     /////////////////////////////////////////////////////////////////////////////
     // sequence                                                                //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def sequence01(): Bool = sequence(Success(1) :: Nil): Validation[_, Unit] == Success(1 :: Nil)
+    def sequence01(): Bool = Validation.sequence(Success(1) :: Nil): Validation[_, Unit] == Success(1 :: Nil)
 
     @test
-    def sequence02(): Bool = sequence(Success(1) :: Success(2) :: Nil): Validation[_, Unit] == Success(1 :: 2 :: Nil)
+    def sequence02(): Bool = Validation.sequence(Success(1) :: Success(2) :: Nil): Validation[_, Unit] == Success(1 :: 2 :: Nil)
 
     @test
-    def sequence03(): Bool = sequence(Success(1) :: Success(2) :: Success(3) :: Nil): Validation[_, Unit] == Success(1 :: 2 :: 3 :: Nil)
+    def sequence03(): Bool = Validation.sequence(Success(1) :: Success(2) :: Success(3) :: Nil): Validation[_, Unit] == Success(1 :: 2 :: 3 :: Nil)
 
     @test
-    def sequence04(): Bool = sequence(Failure(Nel(1, Nil)) :: Nil): Validation[List[Unit], _] == Failure(Nel(1, Nil))
+    def sequence04(): Bool = Validation.sequence(Failure(singleton(1)) :: Nil): Validation[List[Unit], _] == Failure(singleton(1))
 
     @test
-    def sequence05(): Bool = sequence(Failure(Nel(1, Nil)) :: Failure(Nel(2, Nil)) :: Nil): Validation[List[Unit], _] == Failure(Nel(1, 2 :: Nil))
+    def sequence05(): Bool = Validation.sequence(Failure(singleton(1)) :: Failure(singleton(2)) :: Nil): Validation[List[Unit], _] == Failure(necOf2(1, 2))
 
     @test
-    def sequence06(): Bool = sequence(Success(1) :: Failure(Nel(42, Nil)) :: Nil) == Failure(Nel(42, Nil))
+    def sequence06(): Bool = Validation.sequence(Success(1) :: Failure(singleton(42)) :: Nil) == Failure(singleton(42))
 
     @test
-    def sequence07(): Bool = sequence(Failure(Nel(42, Nil)) :: Success(1) :: Nil) == Failure(Nel(42, Nil))
+    def sequence07(): Bool = Validation.sequence(Failure(singleton(42)) :: Success(1) :: Nil) == Failure(singleton(42))
 
     /////////////////////////////////////////////////////////////////////////////
     // traverse                                                                //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def traverse01(): Bool = traverse(x -> Success(x + 1), 1 :: Nil): Validation[_, Unit] == Success(2 :: Nil)
+    def traverse01(): Bool = Validation.traverse(x -> Success(x + 1), 1 :: Nil): Validation[_, Unit] == Success(2 :: Nil)
 
     @test
-    def traverse02(): Bool = traverse(x -> Success(x + 1), 1 :: 2 :: Nil): Validation[_, Unit] == Success(2 :: 3 :: Nil)
+    def traverse02(): Bool = Validation.traverse(x -> Success(x + 1), 1 :: 2 :: Nil): Validation[_, Unit] == Success(2 :: 3 :: Nil)
 
     @test
-    def traverse03(): Bool = traverse(x -> Success(x + 1), 1 :: 2 :: 3 :: Nil): Validation[_, Unit] == Success(2 :: 3 :: 4 :: Nil)
+    def traverse03(): Bool = Validation.traverse(x -> Success(x + 1), 1 :: 2 :: 3 :: Nil): Validation[_, Unit] == Success(2 :: 3 :: 4 :: Nil)
 
     @test
-    def traverse04(): Bool = traverse(x -> Failure(Nel(x, Nil)), 1 :: 2 :: 3 :: Nil): Validation[List[Unit], _] == Failure(Nel(1, 2 :: 3 :: Nil))
+    def traverse04(): Bool = Validation.traverse(x -> Failure(singleton(x)), 1 :: 2 :: 3 :: Nil): Validation[List[Unit], _] == Failure(necOf3(1, 2, 3))
 
     @test
-    def traverse05(): Bool = traverse(x -> Failure(Nel(x, x :: Nil)), 1 :: 2 :: 3 :: Nil): Validation[List[Unit], _] == Failure(Nel(1, 1 :: 2 :: 2 :: 3 :: 3 :: Nil))
+    def traverse05(): Bool = Validation.traverse(x -> Failure(necOf2(x, x)), 1 :: 2 :: 3 :: Nil): Validation[List[Unit], _] == Failure(necOf6(1, 1, 2, 2, 3, 3))
 
     @test
-    def traverse06(): Bool = traverse(x -> if (x != 2) Success(x + 1) else Failure(Nel(42, Nil)), 1 :: 2 :: 3 :: Nil) == Failure(Nel(42, Nil))
+    def traverse06(): Bool = Validation.traverse(x -> if (x != 2) Success(x + 1) else Failure(singleton(42)), 1 :: 2 :: 3 :: Nil) == Failure(singleton(42))
 
     @test
-    def traverse07(): Bool = traverse(x -> if (x == 2) Success(x + 1) else Failure(Nel(x, Nil)), 1 :: 2 :: 3 :: Nil) == Failure(Nel(1, 3 :: Nil))
+    def traverse07(): Bool = Validation.traverse(x -> if (x == 2) Success(x + 1) else Failure(singleton(x)), 1 :: 2 :: 3 :: Nil) == Failure(necOf2(1, 3))
 
     /////////////////////////////////////////////////////////////////////////////
     // traverseX                                                               //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def traverseX01(): Bool = traverseX(x -> Success(x + 1), 1 :: Nil): Validation[_, Unit] == Success()
+    def traverseX01(): Bool = Validation.traverseX(x -> Success(x + 1), 1 :: Nil): Validation[_, Unit] == Success()
 
     @test
-    def traverseX02(): Bool = traverseX(x -> Success(x + 1), 1 :: 2 :: Nil): Validation[_, Unit] == Success()
+    def traverseX02(): Bool = Validation.traverseX(x -> Success(x + 1), 1 :: 2 :: Nil): Validation[_, Unit] == Success()
 
     @test
-    def traverseX03(): Bool = traverseX(x -> Success(x + 1), 1 :: 2 :: 3 :: Nil): Validation[_, Unit] == Success()
+    def traverseX03(): Bool = Validation.traverseX(x -> Success(x + 1), 1 :: 2 :: 3 :: Nil): Validation[_, Unit] == Success()
 
     @test
-    def traverseX04(): Bool = traverseX(x -> Failure(Nel(x, Nil)), 1 :: 2 :: 3 :: Nil) == Failure(Nel(1, 2 :: 3 :: Nil))
+    def traverseX04(): Bool = Validation.traverseX(x -> Failure(singleton(x)), 1 :: 2 :: 3 :: Nil) == Failure(necOf3(1, 2, 3))
 
     @test
-    def traverseX05(): Bool = traverseX(x -> Failure(Nel(x, x :: Nil)), 1 :: 2 :: 3 :: Nil) == Failure(Nel(1, 1 :: 2 :: 2 :: 3 :: 3 :: Nil))
+    def traverseX05(): Bool = Validation.traverseX(x -> Failure(necOf2(x, x)), 1 :: 2 :: 3 :: Nil) == Failure(necOf6(1, 1, 2, 2, 3, 3))
 
     @test
-    def traverseX06(): Bool = traverseX(x -> if (x != 2) Success(x + 1) else Failure(Nel(42, Nil)), 1 :: 2 :: 3 :: Nil) == Failure(Nel(42, Nil))
+    def traverseX06(): Bool = Validation.traverseX(x -> if (x != 2) Success(x + 1) else Failure(singleton(42)), 1 :: 2 :: 3 :: Nil) == Failure(singleton(42))
 
     @test
-    def traverseX07(): Bool = traverseX(x -> if (x == 2) Success(x + 1) else Failure(Nel(x, Nil)), 1 :: 2 :: 3 :: Nil) == Failure(Nel(1, 3 :: Nil))
+    def traverseX07(): Bool = Validation.traverseX(x -> if (x == 2) Success(x + 1) else Failure(singleton(x)), 1 :: 2 :: 3 :: Nil) == Failure(necOf2(1, 3))
 
     /////////////////////////////////////////////////////////////////////////////
     // toOption                                                                //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def toOption01(): Bool = (Success(123) |> toOption) == Some(123)
+    def toOption01(): Bool = (Success(123) |> Validation.toOption) == Some(123)
 
     @test
-    def toOption02(): Bool = (Failure(Nel(42, Nil)) |> toOption): Option[Int32] == None
+    def toOption02(): Bool = (Failure(singleton(42)) |> Validation.toOption): Option[Int32] == None
 
     /////////////////////////////////////////////////////////////////////////////
     // toResult                                                                //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def toResult01(): Bool = (Success(123) |> toResult): Result[_, Nel[Unit]] == Ok(123)
+    def toResult01(): Bool = (Success(123) |> Validation.toResult): Result[_, Nec[Unit]] == Ok(123)
 
     @test
-    def toResult02(): Bool = (Failure(Nel(42, Nil)) |> toResult): Result[Unit, _] == Err(Nel(42, Nil))
+    def toResult02(): Bool = (Failure(singleton(42)) |> Validation.toResult): Result[Unit, _] == Err(singleton(42))
 
     /////////////////////////////////////////////////////////////////////////////
     // toList                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def toList01(): Bool = (Success(123) |> toList) == 123 :: Nil
+    def toList01(): Bool = (Success(123) |> Validation.toList) == 123 :: Nil
 
     @test
-    def toList02(): Bool = ((Failure(Nel(42, Nil)): Validation[Unit, _]) |> toList) == Nil
+    def toList02(): Bool = ((Failure(singleton(42)): Validation[Unit, _]) |> Validation.toList) == Nil
 
-/////////////////////////////////////////////////////////////////////////////
-// lift2                                                                   //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // lift2                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def lift201(): Bool = Validation.lift2((x1,x2) -> x1 + x2, Success(123), Success(1)): Validation[_, Unit] == Success(124)
+    @test
+    def lift201(): Bool = Validation.lift2((x1,x2) -> x1 + x2, Success(123), Success(1)): Validation[_, Unit] == Success(124)
 
-@test
-def lift202(): Bool = Validation.lift2((x1,x2) -> x1 + x2, Success(123), Failure(Nel("e1", Nil))) == Failure(Nel("e1", Nil))
+    @test
+    def lift202(): Bool = Validation.lift2((x1,x2) -> x1 + x2, Success(123), Failure(singleton("e1"))) == Failure(singleton("e1"))
 
-@test
-def lift203(): Bool = Validation.lift2((x1,x2) -> x1 + x2, Failure(Nel("e1", Nil)), Success(1)) == Failure(Nel("e1", Nil))
+    @test
+    def lift203(): Bool = Validation.lift2((x1,x2) -> x1 + x2, Failure(singleton("e1")), Success(1)) == Failure(singleton("e1"))
 
-@test
-def lift204(): Bool = Validation.lift2((x1,x2) -> x1 + x2, Failure(Nel("e1", Nil)), Failure(Nel("e2", Nil)): Validation[Int32, String]) == Failure(Nel("e1", "e2" :: Nil))
+    @test
+    def lift204(): Bool = Validation.lift2((x1,x2) -> x1 + x2, Failure(singleton("e1")), Failure(singleton("e2")): Validation[Int32, String]) == Failure(necOf2("e1", "e2"))
 
-/////////////////////////////////////////////////////////////////////////////
-// lift3                                                                   //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // lift3                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def lift301(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Success(123), Success(1), Success(2)): Validation[_, Unit] == Success(126)
+    @test
+    def lift301(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Success(123), Success(1), Success(2)): Validation[_, Unit] == Success(126)
 
-@test
-def lift302(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Success(123), Success(1), Failure(Nel("e1", Nil))) == Failure(Nel("e1", Nil))
+    @test
+    def lift302(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Success(123), Success(1), Failure(singleton("e1"))) == Failure(singleton("e1"))
 
-@test
-def lift303(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Success(123), Failure(Nel("e1", Nil)), Success(2)) == Failure(Nel("e1", Nil))
+    @test
+    def lift303(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Success(123), Failure(singleton("e1")), Success(2)) == Failure(singleton("e1"))
 
-@test
-def lift304(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Failure(Nel("e1", Nil)), Success(1), Success(2)) == Failure(Nel("e1", Nil))
+    @test
+    def lift304(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Failure(singleton("e1")), Success(1), Success(2)) == Failure(singleton("e1"))
 
-@test
-def lift305(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Success(123), Failure(Nel("e1", Nil)), Failure(Nel("e2", Nil))) == Failure(Nel("e1", "e2" :: Nil))
+    @test
+    def lift305(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Success(123), Failure(singleton("e1")), Failure(singleton("e2"))) == Failure(necOf2("e1", "e2"))
 
-@test
-def lift306(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Failure(Nel("e1", Nil)), Success(1), Failure(Nel("e2", Nil))) == Failure(Nel("e1", "e2" :: Nil))
+    @test
+    def lift306(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Failure(singleton("e1")), Success(1), Failure(singleton("e2"))) == Failure(necOf2("e1", "e2"))
 
-@test
-def lift307(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Failure(Nel("e1", Nil)), Failure(Nel("e2", Nil)), Failure(Nel("e3", Nil)): Validation[Int32, String]) == Failure(Nel("e1", "e2" :: "e3" :: Nil))
+    @test
+    def lift307(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")): Validation[Int32, String]) == Failure(necOf3("e1", "e2", "e3"))
 
-/////////////////////////////////////////////////////////////////////////////
-// lift4                                                                   //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // lift4                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def lift401(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Success(123), Success(1), Success(2), Success(3)): Validation[_, Unit] == Success(129)
+    @test
+    def lift401(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Success(123), Success(1), Success(2), Success(3)): Validation[_, Unit] == Success(129)
 
-@test
-def lift402(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Success(123), Success(1), Success(2), Failure(Nel("e1", Nil))) == Failure(Nel("e1", Nil))
+    @test
+    def lift402(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Success(123), Success(1), Success(2), Failure(singleton("e1"))) == Failure(singleton("e1"))
 
-@test
-def lift403(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Success(123), Success(1), Failure(Nel("e1", Nil)), Success(3)) == Failure(Nel("e1", Nil))
+    @test
+    def lift403(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Success(123), Success(1), Failure(singleton("e1")), Success(3)) == Failure(singleton("e1"))
 
-@test
-def lift404(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Success(123), Failure(Nel("e1", Nil)), Success(2), Success(3)) == Failure(Nel("e1", Nil))
+    @test
+    def lift404(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Success(123), Failure(singleton("e1")), Success(2), Success(3)) == Failure(singleton("e1"))
 
-@test
-def lift405(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Failure(Nel("e1", Nil)), Success(1), Success(2), Success(3)) == Failure(Nel("e1", Nil))
+    @test
+    def lift405(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Failure(singleton("e1")), Success(1), Success(2), Success(3)) == Failure(singleton("e1"))
 
-@test
-def lift406(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Failure(Nel("e1", Nil)), Failure(Nel("e2", Nil)), Failure(Nel("e3", Nil)), Failure(Nel("e4", Nil)): Validation[Int32, String]) == Failure(Nel("e1", "e2" :: "e3" :: "e4" :: Nil))
+    @test
+    def lift406(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")): Validation[Int32, String]) == Failure(necOf4("e1", "e2", "e3", "e4"))
 
-/////////////////////////////////////////////////////////////////////////////
-// lift5                                                                   //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // lift5                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def lift501(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Success(123), Success(1), Success(2), Success(3), Success(4)): Validation[_, Unit] == Success(133)
+    @test
+    def lift501(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Success(123), Success(1), Success(2), Success(3), Success(4)): Validation[_, Unit] == Success(133)
 
-@test
-def lift502(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Success(123), Success(1), Success(2), Success(3), Failure(Nel("e1", Nil))) == Failure(Nel("e1", Nil))
+    @test
+    def lift502(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Success(123), Success(1), Success(2), Success(3), Failure(singleton("e1"))) == Failure(singleton("e1"))
 
-@test
-def lift503(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Success(123), Success(1), Success(2), Failure(Nel("e1", Nil)), Success(4)) == Failure(Nel("e1", Nil))
+    @test
+    def lift503(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Success(123), Success(1), Success(2), Failure(singleton("e1")), Success(4)) == Failure(singleton("e1"))
 
-@test
-def lift504(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Success(123), Success(1), Failure(Nel("e1", Nil)), Success(3), Success(4)) == Failure(Nel("e1", Nil))
+    @test
+    def lift504(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Success(123), Success(1), Failure(singleton("e1")), Success(3), Success(4)) == Failure(singleton("e1"))
 
-@test
-def lift505(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Success(123), Failure(Nel("e1", Nil)), Success(2), Success(3), Success(4)) == Failure(Nel("e1", Nil))
+    @test
+    def lift505(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Success(123), Failure(singleton("e1")), Success(2), Success(3), Success(4)) == Failure(singleton("e1"))
 
-@test
-def lift506(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Failure(Nel("e1", Nil)), Success(1), Success(2), Success(3), Success(4)) == Failure(Nel("e1", Nil))
+    @test
+    def lift506(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Failure(singleton("e1")), Success(1), Success(2), Success(3), Success(4)) == Failure(singleton("e1"))
 
-@test
-def lift507(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Failure(Nel("e1", Nil)), Failure(Nel("e2", Nil)), Failure(Nel("e3", Nil)), Failure(Nel("e4", Nil)), Failure(Nel("e5", Nil)): Validation[Int32, String]) == Failure(Nel("e1", "e2" :: "e3" :: "e4" :: "e5" :: Nil))
+    @test
+    def lift507(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")): Validation[Int32, String]) == Failure(necOf5("e1", "e2", "e3", "e4", "e5"))
 
-/////////////////////////////////////////////////////////////////////////////
-// lift6                                                                   //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // lift6                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def lift601(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5)): Validation[_, Unit] == Success(138)
+    @test
+    def lift601(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5)): Validation[_, Unit] == Success(138)
 
-@test
-def lift602(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Success(123), Success(1), Success(2), Success(3), Success(4), Failure(Nel("e1", Nil))) == Failure(Nel("e1", Nil))
+    @test
+    def lift602(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Success(123), Success(1), Success(2), Success(3), Success(4), Failure(singleton("e1"))) == Failure(singleton("e1"))
 
-@test
-def lift603(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Success(123), Success(1), Success(2), Success(3), Failure(Nel("e1", Nil)), Success(5)) == Failure(Nel("e1", Nil))
+    @test
+    def lift603(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Success(123), Success(1), Success(2), Success(3), Failure(singleton("e1")), Success(5)) == Failure(singleton("e1"))
 
-@test
-def lift604(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Success(123), Success(1), Success(2), Failure(Nel("e1", Nil)), Success(4), Success(5)) == Failure(Nel("e1", Nil))
+    @test
+    def lift604(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Success(123), Success(1), Success(2), Failure(singleton("e1")), Success(4), Success(5)) == Failure(singleton("e1"))
 
-@test
-def lift605(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Success(123), Success(1), Failure(Nel("e1", Nil)), Success(3), Success(4), Success(5)) == Failure(Nel("e1", Nil))
+    @test
+    def lift605(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Success(123), Success(1), Failure(singleton("e1")), Success(3), Success(4), Success(5)) == Failure(singleton("e1"))
 
-@test
-def lift606(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Success(123), Failure(Nel("e1", Nil)), Success(2), Success(3), Success(4), Success(5)) == Failure(Nel("e1", Nil))
+    @test
+    def lift606(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Success(123), Failure(singleton("e1")), Success(2), Success(3), Success(4), Success(5)) == Failure(singleton("e1"))
 
-@test
-def lift607(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Failure(Nel("e1", Nil)), Success(1), Success(2), Success(3), Success(4), Success(5)) == Failure(Nel("e1", Nil))
+    @test
+    def lift607(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Failure(singleton("e1")), Success(1), Success(2), Success(3), Success(4), Success(5)) == Failure(singleton("e1"))
 
-@test
-def lift608(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Failure(Nel("e1", Nil)), Failure(Nel("e2", Nil)), Failure(Nel("e3", Nil)), Failure(Nel("e4", Nil)), Failure(Nel("e5", Nil)), Failure(Nel("e6", Nil)): Validation[Int32, String]) == Failure(Nel("e1", "e2" :: "e3" :: "e4" :: "e5" :: "e6" :: Nil))
+    @test
+    def lift608(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")), Failure(singleton("e6")): Validation[Int32, String]) == Failure(necOf6("e1", "e2", "e3", "e4", "e5", "e6"))
 
-/////////////////////////////////////////////////////////////////////////////
-// lift7                                                                   //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // lift7                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def lift701(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6)): Validation[_, Unit] == Success(144)
+    @test
+    def lift701(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6)): Validation[_, Unit] == Success(144)
 
-@test
-def lift702(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Failure(Nel("e1", Nil))) == Failure(Nel("e1", Nil))
+    @test
+    def lift702(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Failure(singleton("e1"))) == Failure(singleton("e1"))
 
-@test
-def lift703(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Success(1), Success(2), Success(3), Success(4), Failure(Nel("e1", Nil)), Success(6)) == Failure(Nel("e1", Nil))
+    @test
+    def lift703(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Success(1), Success(2), Success(3), Success(4), Failure(singleton("e1")), Success(6)) == Failure(singleton("e1"))
 
-@test
-def lift704(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Success(1), Success(2), Success(3), Failure(Nel("e1", Nil)), Success(5), Success(6)) == Failure(Nel("e1", Nil))
+    @test
+    def lift704(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Success(1), Success(2), Success(3), Failure(singleton("e1")), Success(5), Success(6)) == Failure(singleton("e1"))
 
-@test
-def lift705(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Success(1), Success(2), Failure(Nel("e1", Nil)), Success(4), Success(5), Success(6)) == Failure(Nel("e1", Nil))
+    @test
+    def lift705(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Success(1), Success(2), Failure(singleton("e1")), Success(4), Success(5), Success(6)) == Failure(singleton("e1"))
 
-@test
-def lift706(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Success(1), Failure(Nel("e1", Nil)), Success(3), Success(4), Success(5), Success(6)) == Failure(Nel("e1", Nil))
+    @test
+    def lift706(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Success(1), Failure(singleton("e1")), Success(3), Success(4), Success(5), Success(6)) == Failure(singleton("e1"))
 
-@test
-def lift707(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Failure(Nel("e1", Nil)), Success(2), Success(3), Success(4), Success(5), Success(6)) == Failure(Nel("e1", Nil))
+    @test
+    def lift707(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Failure(singleton("e1")), Success(2), Success(3), Success(4), Success(5), Success(6)) == Failure(singleton("e1"))
 
-@test
-def lift708(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Failure(Nel("e1", Nil)), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6)) == Failure(Nel("e1", Nil))
+    @test
+    def lift708(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Failure(singleton("e1")), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6)) == Failure(singleton("e1"))
 
-@test
-def lift709(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Failure(Nel("e1", Nil)), Failure(Nel("e2", Nil)), Failure(Nel("e3", Nil)), Failure(Nel("e4", Nil)), Failure(Nel("e5", Nil)), Failure(Nel("e6", Nil)), Failure(Nel("e7", Nil)): Validation[Int32, String]) == Failure(Nel("e1", "e2" :: "e3" :: "e4" :: "e5" :: "e6" :: "e7" :: Nil))
+    @test
+    def lift709(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")), Failure(singleton("e6")), Failure(singleton("e7")): Validation[Int32, String]) == Failure(necOf7("e1", "e2", "e3", "e4", "e5", "e6", "e7"))
 
-/////////////////////////////////////////////////////////////////////////////
-// lift8                                                                   //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // lift8                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def lift801(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7)): Validation[_, Unit] == Success(151)
+    @test
+    def lift801(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7)): Validation[_, Unit] == Success(151)
 
-@test
-def lift802(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Failure(Nel("e1", Nil))) == Failure(Nel("e1", Nil))
+    @test
+    def lift802(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Failure(singleton("e1"))) == Failure(singleton("e1"))
 
-@test
-def lift803(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Failure(Nel("e1", Nil)), Success(7)) == Failure(Nel("e1", Nil))
+    @test
+    def lift803(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Failure(singleton("e1")), Success(7)) == Failure(singleton("e1"))
 
-@test
-def lift804(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Success(2), Success(3), Success(4), Failure(Nel("e1", Nil)), Success(6), Success(7)) == Failure(Nel("e1", Nil))
+    @test
+    def lift804(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Success(2), Success(3), Success(4), Failure(singleton("e1")), Success(6), Success(7)) == Failure(singleton("e1"))
 
-@test
-def lift805(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Success(2), Success(3), Failure(Nel("e1", Nil)), Success(5), Success(6), Success(7)) == Failure(Nel("e1", Nil))
+    @test
+    def lift805(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Success(2), Success(3), Failure(singleton("e1")), Success(5), Success(6), Success(7)) == Failure(singleton("e1"))
 
-@test
-def lift806(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Success(2), Failure(Nel("e1", Nil)), Success(4), Success(5), Success(6), Success(7)) == Failure(Nel("e1", Nil))
+    @test
+    def lift806(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Success(2), Failure(singleton("e1")), Success(4), Success(5), Success(6), Success(7)) == Failure(singleton("e1"))
 
-@test
-def lift807(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Failure(Nel("e1", Nil)), Success(3), Success(4), Success(5), Success(6), Success(7)) == Failure(Nel("e1", Nil))
+    @test
+    def lift807(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Failure(singleton("e1")), Success(3), Success(4), Success(5), Success(6), Success(7)) == Failure(singleton("e1"))
 
-@test
-def lift808(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Failure(Nel("e1", Nil)), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7)) == Failure(Nel("e1", Nil))
+    @test
+    def lift808(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Failure(singleton("e1")), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7)) == Failure(singleton("e1"))
 
-@test
-def lift809(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Failure(Nel("e1", Nil)), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7)) == Failure(Nel("e1", Nil))
+    @test
+    def lift809(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Failure(singleton("e1")), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7)) == Failure(singleton("e1"))
 
-@test
-def lift810(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Failure(Nel("e1", Nil)), Failure(Nel("e2", Nil)), Failure(Nel("e3", Nil)), Failure(Nel("e4", Nil)), Failure(Nel("e5", Nil)), Failure(Nel("e6", Nil)), Failure(Nel("e7", Nil)), Failure(Nel("e8", Nil)): Validation[Int32, String]) == Failure(Nel("e1", "e2" :: "e3" :: "e4" :: "e5" :: "e6" :: "e7" :: "e8" :: Nil))
+    @test
+    def lift810(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")), Failure(singleton("e6")), Failure(singleton("e7")), Failure(singleton("e8")): Validation[Int32, String]) == Failure(necOf8("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8"))
 
-/////////////////////////////////////////////////////////////////////////////
-// lift9                                                                   //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // lift9                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def lift901(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8)): Validation[_, Unit] == Success(159)
+    @test
+    def lift901(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8)): Validation[_, Unit] == Success(159)
 
-@test
-def lift902(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Failure(Nel("e1", Nil))) == Failure(Nel("e1", Nil))
+    @test
+    def lift902(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Failure(singleton("e1"))) == Failure(singleton("e1"))
 
-@test
-def lift903(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Failure(Nel("e1", Nil)), Success(8)) == Failure(Nel("e1", Nil))
+    @test
+    def lift903(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Failure(singleton("e1")), Success(8)) == Failure(singleton("e1"))
 
-@test
-def lift904(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Failure(Nel("e1", Nil)), Success(7), Success(8)) == Failure(Nel("e1", Nil))
+    @test
+    def lift904(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Failure(singleton("e1")), Success(7), Success(8)) == Failure(singleton("e1"))
 
-@test
-def lift905(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Success(3), Success(4), Failure(Nel("e1", Nil)), Success(6), Success(7), Success(8)) == Failure(Nel("e1", Nil))
+    @test
+    def lift905(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Success(3), Success(4), Failure(singleton("e1")), Success(6), Success(7), Success(8)) == Failure(singleton("e1"))
 
-@test
-def lift906(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Success(3), Failure(Nel("e1", Nil)), Success(5), Success(6), Success(7), Success(8)) == Failure(Nel("e1", Nil))
+    @test
+    def lift906(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Success(3), Failure(singleton("e1")), Success(5), Success(6), Success(7), Success(8)) == Failure(singleton("e1"))
 
-@test
-def lift907(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Failure(Nel("e1", Nil)), Success(4), Success(5), Success(6), Success(7), Success(8)) == Failure(Nel("e1", Nil))
+    @test
+    def lift907(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Failure(singleton("e1")), Success(4), Success(5), Success(6), Success(7), Success(8)) == Failure(singleton("e1"))
 
-@test
-def lift908(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Failure(Nel("e1", Nil)), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8)) == Failure(Nel("e1", Nil))
+    @test
+    def lift908(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Failure(singleton("e1")), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8)) == Failure(singleton("e1"))
 
-@test
-def lift909(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Failure(Nel("e1", Nil)), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8)) == Failure(Nel("e1", Nil))
+    @test
+    def lift909(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Failure(singleton("e1")), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8)) == Failure(singleton("e1"))
 
-@test
-def lift910(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Failure(Nel("e1", Nil)), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8)) == Failure(Nel("e1", Nil))
+    @test
+    def lift910(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Failure(singleton("e1")), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8)) == Failure(singleton("e1"))
 
-@test
-def lift911(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Failure(Nel("e1", Nil)), Failure(Nel("e2", Nil)), Failure(Nel("e3", Nil)), Failure(Nel("e4", Nil)), Failure(Nel("e5", Nil)), Failure(Nel("e6", Nil)), Failure(Nel("e7", Nil)), Failure(Nel("e8", Nil)), Failure(Nel("e9", Nil)): Validation[Int32, String]) == Failure(Nel("e1", "e2" :: "e3" :: "e4" :: "e5" :: "e6" :: "e7" :: "e8" :: "e9" :: Nil))
+    @test
+    def lift911(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")), Failure(singleton("e6")), Failure(singleton("e7")), Failure(singleton("e8")), Failure(singleton("e9")): Validation[Int32, String]) == Failure(necOf9("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9"))
 
-/////////////////////////////////////////////////////////////////////////////
-// lift10                                                                  //
-/////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // lift10                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
 
-@test
-def lift1001(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8), Success(9)): Validation[_, Unit] == Success(168)
+    @test
+    def lift1001(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8), Success(9)): Validation[_, Unit] == Success(168)
 
-@test
-def lift1002(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8), Failure(Nel("e1", Nil))) == Failure(Nel("e1", Nil))
+    @test
+    def lift1002(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8), Failure(singleton("e1"))) == Failure(singleton("e1"))
 
-@test
-def lift1003(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Failure(Nel("e1", Nil)), Success(9)) == Failure(Nel("e1", Nil))
+    @test
+    def lift1003(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Failure(singleton("e1")), Success(9)) == Failure(singleton("e1"))
 
-@test
-def lift1004(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Failure(Nel("e1", Nil)), Success(8), Success(9)) == Failure(Nel("e1", Nil))
+    @test
+    def lift1004(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Failure(singleton("e1")), Success(8), Success(9)) == Failure(singleton("e1"))
 
-@test
-def lift1005(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Failure(Nel("e1", Nil)), Success(7), Success(8), Success(9)) == Failure(Nel("e1", Nil))
+    @test
+    def lift1005(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Failure(singleton("e1")), Success(7), Success(8), Success(9)) == Failure(singleton("e1"))
 
-@test
-def lift1006(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Success(4), Failure(Nel("e1", Nil)), Success(6), Success(7), Success(8), Success(9)) == Failure(Nel("e1", Nil))
+    @test
+    def lift1006(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Success(4), Failure(singleton("e1")), Success(6), Success(7), Success(8), Success(9)) == Failure(singleton("e1"))
 
-@test
-def lift1007(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Failure(Nel("e1", Nil)), Success(5), Success(6), Success(7), Success(8), Success(9)) == Failure(Nel("e1", Nil))
+    @test
+    def lift1007(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Failure(singleton("e1")), Success(5), Success(6), Success(7), Success(8), Success(9)) == Failure(singleton("e1"))
 
-@test
-def lift1008(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Failure(Nel("e1", Nil)), Success(4), Success(5), Success(6), Success(7), Success(8), Success(9)) == Failure(Nel("e1", Nil))
+    @test
+    def lift1008(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Failure(singleton("e1")), Success(4), Success(5), Success(6), Success(7), Success(8), Success(9)) == Failure(singleton("e1"))
 
-@test
-def lift1009(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Failure(Nel("e1", Nil)), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8), Success(9)) == Failure(Nel("e1", Nil))
+    @test
+    def lift1009(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Failure(singleton("e1")), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8), Success(9)) == Failure(singleton("e1"))
 
-@test
-def lift1010(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Failure(Nel("e1", Nil)), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8), Success(9)) == Failure(Nel("e1", Nil))
+    @test
+    def lift1010(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Failure(singleton("e1")), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8), Success(9)) == Failure(singleton("e1"))
 
-@test
-def lift1011(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Failure(Nel("e1", Nil)), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8), Success(9)) == Failure(Nel("e1", Nil))
+    @test
+    def lift1011(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Failure(singleton("e1")), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8), Success(9)) == Failure(singleton("e1"))
 
-@test
-def lift1012(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Failure(Nel("e1", Nil)), Failure(Nel("e2", Nil)), Failure(Nel("e3", Nil)), Failure(Nel("e4", Nil)), Failure(Nel("e5", Nil)), Failure(Nel("e6", Nil)), Failure(Nel("e7", Nil)), Failure(Nel("e8", Nil)), Failure(Nel("e9", Nil)), Failure(Nel("e10", Nil)): Validation[Int32, String]) == Failure(Nel("e1", "e2" :: "e3" :: "e4" :: "e5" :: "e6" :: "e7" :: "e8" :: "e9" :: "e10" :: Nil))
+    @test
+    def lift1012(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")), Failure(singleton("e6")), Failure(singleton("e7")), Failure(singleton("e8")), Failure(singleton("e9")), Failure(singleton("e10")): Validation[Int32, String]) == Failure(necOf10("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9", "e10"))
 
     /////////////////////////////////////////////////////////////////////////////
     // hash                                                                    //
@@ -476,7 +495,7 @@ def lift1012(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 
     def hash01(): Bool = hash(Success(()): Validation[_, Unit]) == hash(Success(()): Validation[_, Unit])
 
     @test
-    def hash02(): Bool = hash(Success(()): Validation[_, Unit]) != hash(Failure(Nel((), () :: Nil)): Validation[Unit, _])
+    def hash02(): Bool = hash(Success(()): Validation[_, Unit]) != hash(Failure(necOf2((), ())): Validation[Unit, _])
 
     @test
     def hash03(): Bool = hash(Success(1, 2): Validation[_, Unit]) == hash(Success(1, 2): Validation[_, Unit])
@@ -485,6 +504,6 @@ def lift1012(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 
     def hash04(): Bool = hash(Success(1, 2, 3): Validation[_, Unit]) != hash(Success(1, 3, 2): Validation[_, Unit])
 
     @test
-    def hash05(): Bool = hash(Success(Nel(1, Nil)): Validation[_, Int32]) != hash(Failure(Nel(1, Nil)): Validation[Nel[Int32], _])
+    def hash05(): Bool = hash(Success(singleton(1)): Validation[_, Int32]) != hash(Failure(singleton(1)): Validation[Nec[Int32], _])
 
 }


### PR DESCRIPTION
This PR changes `Validation` to use `Nec` rather than `Nel` to track failures. It adds some new functionality so `Nec` can replace `Nel`: 

* `Order` instance to `Nec`
* `toNel` and `toNec` to `List`

All tests that use `Validation` have been updated. These were minor changes except to the `Validation` test module. I've changed the Validation test module so its namespace is `TestValidation` which is the usual style (before it was just `Validation`). Functions under test are now called with qualified names e.g. `Validation.ap` etc. Because constructing `Nec` s can't reuse `List` syntax (whereas `Nel` can) I've added the family of `necOf2` etc. functions as internal helpers to `TestValidation`.
