### PR TITLE
chore: handle `LetRegion` in LSP `Indexer`.

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -183,7 +183,7 @@ object Indexer {
       Index.occurrenceOf(sym, exp1.tpe) ++ visitExp(exp1) ++ visitExp(exp2) ++ Index.occurrenceOf(exp0)
 
     case Expression.LetRegion(sym, exp, _, _, _) =>
-      visitExp(exp) ++ Index.occurrenceOf(exp0)
+      Index.occurrenceOf(sym, sym.tvar) ++ visitExp(exp) ++ Index.occurrenceOf(exp0)
 
     case Expression.IfThenElse(exp1, exp2, exp3, _, _, _) =>
       visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3) ++ Index.occurrenceOf(exp0)


### PR DESCRIPTION
Fixes #3266