### PR TITLE
Properly encode DocumentSymbol into JSON

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/DocumentSymbol.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/DocumentSymbol.scala
@@ -42,7 +42,7 @@ case class DocumentSymbol(name: String,
                           children: List[DocumentSymbol]) {
   def toJSON: JValue =
     ("name" -> name) ~
-      ("kind" -> detail) ~
+      ("detail" -> detail) ~
       ("kind" -> JInt(kind.toInt)) ~
       ("range" -> range.toJSON) ~
       ("selectionRange" -> selectionRange.toJSON) ~


### PR DESCRIPTION
I have found a little bug in DocumentSymbol, where the detail field where incorrecly encoded.