### PR TITLE
refactor: use let rec in `MutList`

### DIFF
--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -232,34 +232,32 @@ namespace MutList {
     /// searching from left to right.
     ///
     pub def indexOfLeft(x: a, v: MutList[a]): Option[Int32] & Impure with Eq[a] =
-        let MutList(a, l) = v;
-        indexOfLeftHelper(x, deref a, deref l, 0)
-
-    ///
-    /// Helper function for `indexOfLeft`.
-    ///
-    def indexOfLeftHelper(x: a, a: Array[a], len: Int32, i: Int32): Option[Int32] & Impure with Eq[a] =
-        if (i >= len)
-            None
-        else
-            if (x == a[i]) Some(i) else indexOfLeftHelper(x, a, len, i + 1)
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        def loop(i) = {
+            if (i >= l)
+                None
+            else
+                if (x == a[i]) Some(i) else loop(i + 1)
+        };
+        loop(0)
 
     ///
     /// Optionally returns the position of the first occurrence of `x` in `v`
     /// searching from right to left.
     ///
     pub def indexOfRight(x: a, v: MutList[a]): Option[Int32] & Impure with Eq[a] =
-        let MutList(a, l) = v;
-        indexOfRightHelper(x, deref a, (deref l) - 1)
-
-    ///
-    /// Helper function for `indexOfRight`.
-    ///
-    def indexOfRightHelper(x: a, a: Array[a], i: Int32): Option[Int32] & Impure with Eq[a] =
-        if (i < 0)
-            None
-        else
-            if (x == a[i]) Some(i) else indexOfRightHelper(x, a, i - 1)
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        def loop(i) = {
+            if (i < 0)
+                None
+            else
+                if (x == a[i]) Some(i) else loop(i - 1)
+        };
+        loop(l - 1)
 
     ///
     /// Alias for `findLeft`.
@@ -273,17 +271,17 @@ namespace MutList {
     /// Returns `None` if the given mutable list `v` is empty.
     ///
     pub def findLeft(f: a -> Bool, v: MutList[a]): Option[a] & Impure =
-        let MutList(a, l) = v;
-        findLeftHelper(f, deref a, deref l, 0)
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        def loop(i) = {
+            if (i >= l)
+                None
+            else
+                if (f(a[i])) Some(a[i]) else loop(i + 1)
 
-    ///
-    /// Helper function for `findLeft`.
-    ///
-    def findLeftHelper(f: a -> Bool, a: Array[a], len: Int32, i: Int32): Option[a] & Impure =
-        if (i >= len)
-            None
-        else
-            if (f(a[i])) Some(a[i]) else findLeftHelper(f, a, len, i + 1)
+        };
+        loop(0)
 
     ///
     /// Optionally returns the right-most element in the given mutable list `v` that satisfies the given predicate `f`.
@@ -292,17 +290,17 @@ namespace MutList {
     /// Returns `None` if the given mutable list `v` is empty.
     ///
     pub def findRight(f: a -> Bool, v: MutList[a]): Option[a] & Impure =
-        let MutList(a, l) = v;
-        findRightHelper(f, deref a, (deref l) - 1)
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        def loop(i) = {
+            if (i < 0)
+                None
+            else
+                if (f(a[i])) Some(a[i]) else loop(i - 1)
 
-    ///
-    /// Helper function for `findRight`.
-    ///
-    def findRightHelper(f: a -> Bool, a: Array[a], i: Int32): Option[a] & Impure =
-        if (i < 0)
-            None
-        else
-            if (f(a[i])) Some(a[i]) else findRightHelper(f, a, i - 1)
+        };
+        loop(l - 1)
 
     ///
     /// Alias for `scanLeft`.

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -636,23 +636,22 @@ namespace MutList {
     /// Reverses the order of the elements in the given mutable list `v`.
     ///
     pub def reverse!(v: mut MutList[a]): Unit & Impure =
-        let MutList(a, l) = v;
-        let len = deref l;
-        reverseHelper!(deref a, len / 2, 0, len - 1)
-
-    ///
-    /// Helper function for `reverse!`.
-    ///
-    def reverseHelper!(a: mut Array[a], halflen: Int32, i: Int32, j: Int32): Unit & Impure =
-        if (i >= halflen)
-            ()
-        else {
-            let x = a[i];
-            let y = a[j];
-            Array.put(y, i, a);
-            Array.put(x, j, a);
-            reverseHelper!(a, halflen, i + 1, j - 1)
-        }
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        let halflen = l / 2;
+        def loop(i, j) = {
+            if (i >= halflen)
+                ()
+            else {
+                let x = a[i];
+                let y = a[j];
+                Array.put(y, i, a);
+                Array.put(x, j, a);
+                loop(i + 1, j - 1)
+            }
+        };
+        loop(0, l - 1)
 
     ///
     /// Shrinks the given mutable list `v` down to a capacity of `n` elements but no less than 8.
@@ -666,7 +665,7 @@ namespace MutList {
         if (n < capv and capv != minCap) {
             let len = deref l;
             let newCap = Order.max(n, minCap);
-            a := Array.slice(0, newCap, deref a);
+            a := Array.copyOfRange(0, newCap, deref a);
             l := Order.min(len, newCap)
         }
         else ()
@@ -730,20 +729,21 @@ namespace MutList {
     /// Returns `true` if the mutable lists `v1` and `v2` have the same elements, i.e. are structurally equal.
     ///
     pub def sameElements(v1: MutList[a], v2: MutList[a]): Bool & Impure with Eq[a] =
-        let MutList(a1, l1) = v1;
-        let MutList(a2, l2) = v2;
-        let len1 = deref l1;
-        let len2 = deref l2;
-        len1 == len2 and sameElementsHelper(deref a1, deref a2, 0, len1)
-
-    ///
-    /// Helper function for `sameElements`.
-    ///
-    def sameElementsHelper(a1: Array[a], a2: Array[a], i: Int32, n: Int32): Bool & Impure with Eq[a] =
-        if (i >= n)
-            true
-        else
-            a1[i] == a2[i] and sameElementsHelper(a1, a2, i + 1, n)
+        let MutList(ra1, rl1) = v1;
+        let MutList(ra2, rl2) = v2;
+        let a1 = deref ra1;
+        let a2 = deref ra2;
+        let l1 = deref rl1;
+        let l2 = deref rl2;
+        def loop(i) = {
+            if (i >= l1)
+                true
+            else if (a1[i] == a2[i])
+                loop(i + 1)
+            else
+                false
+        };
+        if (l1 == l2) loop(0) else false
 
     ///
     /// Render `v` as a String. Elements are rendered with the
@@ -783,45 +783,35 @@ namespace MutList {
     /// Applies `f` to all the elements in `v`.
     ///
     pub def foreach(f: a -> Unit & ef, v: MutList[a]): Unit & Impure =
-        let MutList(a, l) = v;
-        let len = deref l;
-        if (len < 1)
-            ()
-        else
-            foreachHelper(f, deref a, 0, len)
-
-    ///
-    /// Helper function for `foreach`.
-    ///
-    def foreachHelper(f: a -> Unit & ef, a: Array[a], i: Int32, n: Int32): Unit & Impure =
-        if (i >= n)
-            ()
-        else {
-            f(a[i]);
-            foreachHelper(f, a, i + 1, n)
-        }
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        def loop(i) = {
+            if (i >= l)
+                ()
+            else {
+                f(a[i]);
+                loop(i + 1)
+            }
+        };
+        loop(0)
 
     ///
     /// Applies `f` to all the elements in `v`.
     ///
     pub def foreachWithIndex(f: (a, Int32) -> Unit & ef, v: MutList[a]): Unit & Impure =
-        let MutList(a, l) = v;
-        let len = deref l;
-        if (len < 1)
-            ()
-        else
-            foreachWithIndexHelper(f, deref a, 0, len)
-
-    ///
-    /// Helper function for `foreachWithIndex`.
-    ///
-    def foreachWithIndexHelper(f: (a, Int32) -> Unit & ef, a: Array[a], i: Int32, n: Int32): Unit & Impure =
-        if (i >= n)
-            ()
-        else {
-            f(a[i], i);
-            foreachWithIndexHelper(f, a, i + 1, n)
-        }
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        def loop(i) = {
+            if (i >= l)
+                ()
+            else {
+                f(a[i], i);
+                loop(i + 1)
+            }
+        };
+        loop(0)
 
     ///
     /// Compresses the given mutable list `v` if needed.

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -77,7 +77,7 @@ namespace MutList {
         if (i >= deref l)
             bug!("Invalid argument ${i}")
         else
-            Array.get(i, deref a)
+            (deref a)[i]
 
     ///
     /// Returns the number of elements in the given mutable list `v`.
@@ -172,17 +172,16 @@ namespace MutList {
     /// Returns `false` if the given mutable list `v` is empty.
     ///
     pub def exists(f: a -> Bool, v: MutList[a]): Bool & Impure =
-        let MutList(a, l) = v;
-        existsHelper(f, deref a, deref l, 0)
-
-    ///
-    /// Helper function for `exists`.
-    ///
-    def existsHelper(f: a -> Bool, a: Array[a], len: Int32, i: Int32): Bool & Impure =
-        if (i >= len)
-            false
-        else
-            f(a[i]) or existsHelper(f, a, len, i + 1)
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        def loop(i) = {
+            if (i >= l)
+                false
+            else
+                if (f(a[i])) true else loop(i + 1)
+        };
+        loop(0)
 
     ///
     /// Returns `true` if the given predicate `f` holds for all elements of the given mutable list `v`.
@@ -190,17 +189,16 @@ namespace MutList {
     /// Returns `true` if the given mutable list `v` is empty.
     ///
     pub def forall(f: a -> Bool, v: MutList[a]): Bool & Impure =
-        let MutList(a, l) = v;
-        forallHelper(f, deref a, deref l, 0)
-
-    ///
-    /// Helper function for `forall`.
-    ///
-    def forallHelper(f: a -> Bool, a: Array[a], len: Int32, i: Int32): Bool & Impure =
-        if (i >= len)
-            true
-        else
-            f(a[i]) and existsHelper(f, a, len, i + 1)
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        def loop(i) = {
+            if (i >= l)
+                true
+            else
+                if (f(a[i])) loop(i + 1) else false
+        };
+        loop(0)
 
     ///
     /// Optionally returns the first element of the given mutable list `v`.

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -298,7 +298,6 @@ namespace MutList {
                 None
             else
                 if (f(a[i])) Some(a[i]) else loop(i - 1)
-
         };
         loop(l - 1)
 
@@ -311,45 +310,43 @@ namespace MutList {
     /// Accumulates the result of applying `f` to `v` going left to right.
     ///
     pub def scanLeft(f: (b, a) -> b & ef, s: b, v: MutList[a]): MutList[b] & Impure =
-        let MutList(a, l) = v;
-        let len = deref l;
-        let b = [s; len + 1];
-        scanLeftHelper(f, s, deref a, b, 1, len + 1);
-        MutList(ref b, ref (len + 1))
-
-    ///
-    /// Helper function for `scanLeft`.
-    ///
-    def scanLeftHelper(f: (b, a) -> b & ef, s: b, a: Array[a], b: Array[b], i: Int32, n: Int32): Unit & Impure =
-        if (i >= n)
-            ()
-        else {
-            let s1 = f(s, a[i - 1]);
-            b[i] = s1;
-            scanLeftHelper(f, s1, a, b, i + 1, n)
-        }
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        let n = l + 1;
+        let b = [s; n];
+        def loop(i, ss) = {
+            if (i >= n)
+                ()
+            else {
+                let s1 = f(ss, a[i - 1]);
+                b[i] = s1;
+                loop(i + 1, s1)
+            }
+        };
+        loop(1, s);
+        MutList(ref b, ref n)
 
     ///
     /// Accumulates the result of applying `f` to `v` going right to left.
     ///
     pub def scanRight(f: (a, b) -> b & ef, s: b, v: MutList[a]): MutList[b] & Impure =
-        let MutList(a, l) = v;
-        let len = deref l;
-        let b = [s; len + 1];
-        scanRightHelper(f, s, deref a, b, len - 1);
-        MutList(ref b, ref (len + 1))
-
-    ///
-    /// Helper function for `scanRight`.
-    ///
-    def scanRightHelper(f: (a, b) -> b & ef, s: b, a: Array[a], b: Array[b], i: Int32): Unit & Impure =
-        if (i < 0)
-            ()
-        else {
-            let s1 = f(a[i], s);
-            b[i] = s1;
-            scanRightHelper(f, s1, a, b, i - 1)
-        }
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        let n = l + 1;
+        let b = [s; n];
+        def loop(i, ss) = {
+            if (i < 0)
+                ()
+            else {
+                let s1 = f(a[i], ss);
+                b[i] = s1;
+                loop(i - 1, s1)
+            }
+        };
+        loop(l - 1, s);
+        MutList(ref b, ref n)
 
     ///
     /// Apply `f` to every element in `v`.

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -315,11 +315,11 @@ namespace MutList {
         let l = deref rl;
         let n = l + 1;
         let b = [s; n];
-        def loop(i, ss) = {
+        def loop(i, acc) = {
             if (i >= n)
                 ()
             else {
-                let s1 = f(ss, a[i - 1]);
+                let s1 = f(acc, a[i - 1]);
                 b[i] = s1;
                 loop(i + 1, s1)
             }
@@ -336,11 +336,11 @@ namespace MutList {
         let l = deref rl;
         let n = l + 1;
         let b = [s; n];
-        def loop(i, ss) = {
+        def loop(i, acc) = {
             if (i < 0)
                 ()
             else {
-                let s1 = f(a[i], ss);
+                let s1 = f(a[i], acc);
                 b[i] = s1;
                 loop(i - 1, s1)
             }
@@ -354,53 +354,83 @@ namespace MutList {
     /// The result is a new mutable list.
     ///
     pub def map(f: a -> b & ef, v: MutList[a]): MutList[b] & Impure =
-        let MutList(a, l) = v;
-        let len = deref l;
-        MutList(ref Array.init(i -> f((deref a)[i]), len), ref len)
+        if (isEmpty(v))
+            new()
+        else {
+            let MutList(ra, rl) = v;
+            let a = deref ra;
+            let l = deref rl;
+            let x = f(a[0]);
+            let b = [x; Array.length(a)];
+            def loop(i) = {
+                if (i >= l)
+                    ()
+                else {
+                    b[i] = f(a[i]);
+                    loop(i + 1)
+                }
+            };
+            loop(1);
+            MutList(ref b, ref l)
+        }
 
     ///
     /// Apply `f` to every element in `v`.
     ///
     pub def transform!(f: a -> a, v: mut MutList[a]): Unit & Impure =
-        let MutList(a, l) = v;
-        transformHelper!(f, deref a, 0, deref l)
-
-    ///
-    /// Helper function for `transform!`
-    ///
-    def transformHelper!(f: a -> a, a: Array[a], i: Int32, n: Int32): Unit & Impure =
-        if (i >= n)
-            ()
-        else {
-            a[i] = f(a[i]);
-            transformHelper!(f, a, i + 1, n)
-        }
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        def loop(i) = {
+            if (i >= l)
+                ()
+            else {
+                a[i] = f(a[i]);
+                loop(i + 1)
+            }
+        };
+        loop(0)
 
     ///
     /// Returns the result of applying `f` to every element in `v` along with that element's index.
     ///
     pub def mapWithIndex(f: (a, Int32) -> b & ef, v: MutList[a]): MutList[b] & Impure =
-        let MutList(a, l) = v;
-        let len = deref l;
-        MutList(ref Array.init(i -> f((deref a)[i], i), len), ref len)
+        if (isEmpty(v))
+            new()
+        else {
+            let MutList(ra, rl) = v;
+            let a = deref ra;
+            let l = deref rl;
+            let x = f(a[0], 0);
+            let b = [x; Array.length(a)];
+            def loop(i) = {
+                if (i >= l)
+                    ()
+                else {
+                    b[i] = f(a[i], i);
+                    loop(i + 1)
+                }
+            };
+            loop(1);
+            MutList(ref b, ref l)
+        }
 
     ///
     /// Apply `f` to every element in `v` along with that element's index.
     ///
     pub def transformWithIndex!(f: (a, Int32) -> a, v: mut MutList[a]): Unit & Impure =
-        let MutList(a, l) = v;
-        transformWithIndexHelper!(f, deref a, 0, deref l)
-
-    ///
-    /// Helper function for `transformWithIndex!`
-    ///
-    def transformWithIndexHelper!(f: (a, Int32) -> a, a: Array[a], i: Int32, n: Int32): Unit & Impure =
-        if (i >= n)
-            ()
-        else {
-            a[i] = f(a[i], i);
-            transformWithIndexHelper!(f, a, i + 1, n)
-        }
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        def loop(i) = {
+            if (i >= l)
+                ()
+            else {
+                a[i] = f(a[i], i);
+                loop(i + 1)
+            }
+        };
+        loop(0)
 
     ///
     /// Applies `f` to a start value `s` and all elements in `a` going from left to right.
@@ -408,18 +438,18 @@ namespace MutList {
     /// That is, the result is of the form: `f(...f(f(s, a[0]), a[1])..., xn)`.
     ///
     pub def foldLeft(f: (b, a) -> b & ef, s: b, v: MutList[a]): b & Impure =
-        let len = length(v);
-        foldLeftHelper(f, s, v, len, 0)
-
-    ///
-    /// Helper function for `foldLeft`.
-    ///
-    def foldLeftHelper(f: (b, a) -> b & ef, s: b, v: MutList[a], len: Int32, i: Int32): b & Impure =
-        if (i < len)
-            let s1 = f(s, get(i, v)) as & Impure;
-            foldLeftHelper(f, s1, v, len, i + 1)
-        else
-            s
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        def loop(i, acc) = {
+            if (i >= l)
+                acc
+            else {
+                let s1 = f(acc, a[i]);
+                loop(i + 1, s1)
+            }
+        };
+        loop(0, s)
 
     ///
     /// Applies `f` to a start value `s` and all elements in `a` going from left to right.
@@ -429,18 +459,18 @@ namespace MutList {
     /// The implementation is tail recursive.
     ///
     pub def foldRight(f: (a, b) -> b & ef, s: b, v: MutList[a]): b & Impure =
-        let len = length(v);
-        foldRightHelper(f, s, v, len - 1)
-
-    ///
-    /// Helper function for `foldRight`.
-    ///
-    def foldRightHelper(f: (a, b) -> b & ef, s: b, v: MutList[a], i: Int32): b & Impure =
-        if (i < 0)
-            s
-        else
-            let s1 = f(get(i, v), s) as & Impure;
-            foldRightHelper(f, s1, v, i - 1)
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        def loop(i, acc) = {
+            if (i < 0)
+                acc
+            else {
+                let s1 = f(a[i], acc);
+                loop(i - 1, s1)
+            }
+        };
+        loop(l - 1, s)
 
     ///
     /// Applies `f` to a start value `s` and all elements in `v` going from left to right.
@@ -449,18 +479,18 @@ namespace MutList {
     /// The foldRightLazy function exists to allow early termination of a fold.
     ///
     pub def foldRightLazy(f: (a, Lazy[b]) -> b & ef, s: b, v: MutList[a]): b & Impure =
-        let len = length(v);
-        foldRightLazyHelper(f, s, v, len - 1)
-
-    ///
-    /// Helper function for `foldRightLazy`.
-    ///
-    def foldRightLazyHelper(f: (a, Lazy[b]) -> b & ef, s: b, v: MutList[a], i: Int32): b & Impure =
-        if (i < 0)
-            s
-        else
-            let s1 = f(get(i, v), lazy s) as & Impure;
-            foldRightLazyHelper(f, s1, v, i - 1)
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        def loop(i, acc) = {
+            if (i < 0)
+                acc
+            else {
+                let s1 = f(a[i], lazy acc);
+                loop(i - 1, s1)
+            }
+        };
+        loop(l - 1, s)
 
     ///
     /// Applies `f` to all elements in `v` going from left to right until a single value `v` is obtained. Returns `Some(v)`.
@@ -498,9 +528,9 @@ namespace MutList {
         let MutList(a, l) = v;
         let len = deref l;
         if (len > minCapacity())
-            MutList(ref Array.slice(0, len, deref a), ref len)
+            MutList(ref Array.copyOfRange(0, len, deref a), ref len)
         else
-            MutList(ref Array.slice(0, capacity(v), deref a), ref len)
+            MutList(ref Array.copyOfRange(0, capacity(v), deref a), ref len)
 
     ///
     /// Optionally removes and returns the last element in the given mutable list `v`.
@@ -542,7 +572,7 @@ namespace MutList {
         if (capacity(v) - len == 0)
             reserve!(len, v)
         else ();
-        let sub = Array.slice(i, len, deref a);
+        let sub = Array.copyOfRange(i, len, deref a);
         Array.updateSequence!(i + 1, sub, deref a);
         (deref a)[i] = x;
         l := len + 1
@@ -555,26 +585,26 @@ namespace MutList {
     /// If the given index `i` exceeds the length of the mutable list, no element is removed.
     ///
     pub def remove!(i: Int32, v: mut MutList[a]): Unit & Impure =
-        let MutList(a, l) = v;
-        let len = deref l;
-        if (i < len) {
-            removeHelper!(i, len, deref a);
-            l := len - 1;
+        let MutList(ra, rl) = v;
+        let a = deref ra;
+        let l = deref rl;
+        let n = l - 1;
+        def loop(i) = {
+            if (i < n) {
+                a[i] = a[i + 1];
+                loop(i + 1)
+            }
+            else if (i == n) {
+                a[i] = $DEFAULT$
+            }
+            else
+                ()
+        };
+        if (i < l) {
+            loop(i);
+            rl := n;
             compress!(v)
         }
-        else
-            ()
-
-    ///
-    /// Helper function for `remove!`.
-    ///
-    def removeHelper!(i: Int32, n: Int32, a: Array[a]): Unit & Impure =
-        if (i < n - 1) {
-            a[i] = a[i + 1];
-            removeHelper!(i + 1, n, a)
-        }
-        else if (i == n - 1)
-            a[i] = $DEFAULT$
         else
             ()
 


### PR DESCRIPTION
Closes #3156

Also fixes a bug where `forall` called `exists`... that doesn't seem like the correct behavior.
```flix
def forallHelper(f: a -> Bool, a: Array[a], len: Int32, i: Int32): Bool & Impure =
        if (i >= len)
            true
        else
            f(a[i]) and existsHelper(f, a, len, i + 1)
```