### PR TITLE
Use better precision for Timer.sleepAndSend

### DIFF
--- a/main/src/library/Concurrent/Channel/Timer.flix
+++ b/main/src/library/Concurrent/Channel/Timer.flix
@@ -76,6 +76,8 @@ namespace Concurrent/Channel/Timer {
     /// Sleeps for `s` nanoseconds and then sends the Unit value to the given channel `c`.
     ///
     def sleepAndSend(ns: Int64, c: Channel[Unit]): Unit & Impure =
-        import static java.lang.Thread.sleep(Int64): Unit & Impure;
-        sleep(ns / 1000000i64); c <- (); ()
+        import static java.lang.Thread.sleep(Int64, Int32): Unit & Impure;
+        let millis = ns  /  1000000i64;
+        let nanos  = ns mod 1000000i64;
+        sleep(millis, Int64.clampToInt32(nanos, 0i32, 1000000i32)); c <- (); ()
 }

--- a/main/src/library/Concurrent/Channel/Timer.flix
+++ b/main/src/library/Concurrent/Channel/Timer.flix
@@ -77,7 +77,7 @@ namespace Concurrent/Channel/Timer {
     ///
     def sleepAndSend(ns: Int64, c: Channel[Unit]): Unit & Impure =
         import static java.lang.Thread.sleep(Int64, Int32): Unit & Impure;
-        let millis = ns  /  1000000i64;
-        let nanos  = ns mod 1000000i64;
-        sleep(millis, Int64.clampToInt32(nanos, 0i32, 1000000i32)); c <- (); ()
+        let millis = ns  /  1_000_000i64;
+        let nanos  = ns mod 1_000_000i64;
+        sleep(millis, Int64.clampToInt32(nanos, 0i32, 1_000_000i32)); c <- (); ()
 }

--- a/main/test/ca/uwaterloo/flix/library/TestTimer.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestTimer.flix
@@ -32,3 +32,8 @@ def testMicrosecondsTimer01(): Bool & Impure = select {
 def testNanosecondsTimer01(): Bool & Impure = select {
     case _ <- Concurrent/Channel/Timer.nanoseconds(0i64) => true
 }
+
+@test
+def testNanosecondsTimer02(): Bool & Impure = select {
+    case _ <- Concurrent/Channel/Timer.nanoseconds(999999i64) => true
+}


### PR DESCRIPTION
This PR replaces `java.lang.Thread.sleep(Int64)` with `java.lang.Thread.sleep(Int64, Int32)`.
To convert Int64 to Int32, this PR uses [Int64.clampToInt32](https://api.flix.dev/#Int64) API.

close #3031