### PR TITLE
feat: remove `System.exit` call in `Main.class` and support all return types of the flix main

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -214,10 +214,10 @@ object Main {
               case Some(a) => a.split(" ")
             }
             // Invoke main with the supplied arguments.
-            val exitCode = m(args)
+            m(args)
 
-            // Exit with the returned exit code.
-            System.exit(exitCode)
+            // Exit.
+            System.exit(0)
         }
 
         if (cmdOpts.benchmark) {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -239,12 +239,12 @@ object JvmBackend {
   /**
     * Optionally returns a reference to main.
     */
-  private def getCompiledMain(root: Root)(implicit flix: Flix): Option[Array[String] => Int] =
+  private def getCompiledMain(root: Root)(implicit flix: Flix): Option[Array[String] => Unit] =
     root.defs.get(Symbol.Main) map { defn =>
       (actualArgs: Array[String]) => {
         val args: Array[AnyRef] = Array(actualArgs)
-        val result = link(defn.sym, root).apply(args)
-        result.asInstanceOf[Integer].intValue()
+        link(defn.sym, root).apply(args)
+        ()
       }
     }
 

--- a/main/src/ca/uwaterloo/flix/runtime/CompilationResult.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/CompilationResult.scala
@@ -27,7 +27,7 @@ import ca.uwaterloo.flix.language.ast._
   * @param codeSize the number of bytes the compiler generated.
   */
 class CompilationResult(root: Root,
-                        main: Option[Array[String] => Int],
+                        main: Option[Array[String] => Unit],
                         defs: Map[Symbol.DefnSym, () => AnyRef],
                         val totalTime: Long,
                         val codeSize: Int) {
@@ -40,7 +40,7 @@ class CompilationResult(root: Root,
   /**
     * Optionally returns the main function.
     */
-  def getMain: Option[Array[String] => Int] = main
+  def getMain: Option[Array[String] => Unit] = main
 
   /**
     * Returns all the benchmark functions in the program.

--- a/main/src/ca/uwaterloo/flix/tools/Packager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Packager.scala
@@ -29,7 +29,7 @@ import java.nio.file._
 import java.nio.file.attribute.BasicFileAttributes
 import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
 import scala.collection.mutable
-import scala.util.{Using, Success, Failure}
+import scala.util.{Failure, Success, Using}
 
 /**
   * An interface to manage flix packages.
@@ -324,9 +324,8 @@ object Packager {
       compilationResult <- build(p, o).toOption
       main <- compilationResult.getMain
     } yield {
-      val exitCode = main(Array.empty)
-      println(s"Main exited with status code $exitCode.")
-      resultFor(exitCode)
+      main(Array.empty)
+      ().toOk[Unit, Int]
     }
     res.getOrElse(1.toErr)
   }
@@ -547,17 +546,6 @@ object Packager {
     override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
       result += file
       FileVisitResult.CONTINUE
-    }
-  }
-
-  /**
-    * Converts the given exit code into a result.
-    */
-  private def resultFor(code: Int): Result[Unit, Int] = {
-    if (code == 0) {
-      ().toOk
-    } else {
-      code.toErr
     }
   }
 }


### PR DESCRIPTION
The backend can cope with main methods of the form `def main(_: Array[String]): A`. flix `-run` still uses `System.exit`. Fixes some of #3338.