### PR TITLE
Display enums code hints at use site

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
@@ -316,7 +316,7 @@ class LanguageServer(port: Int) extends WebSocketServer(new InetSocketAddress("l
           // println(s"lsp/check: ${e / 1_000_000}ms")
 
           // Compute Code Quality hints.
-          val codeHints = CodeHinter.run(root, sources.keySet.toSet)(flix)
+          val codeHints = CodeHinter.run(root, sources.keySet.toSet)(flix).toList
           if (codeHints.isEmpty) {
             // Case 1: No code hints.
             ("id" -> requestId) ~ ("status" -> "success") ~ ("time" -> e)


### PR DESCRIPTION
Correctly mark as `Deprecated` or `Experimental` enums (and respective tags) at use sites.

Follows from the discussion in:
https://github.com/flix/flix/pull/3294

Related to this issue: https://github.com/flix/flix/issues/2831

![Screenshot from 2022-03-20 21-07-21](https://user-images.githubusercontent.com/55001950/159183947-8620a5f5-a739-420d-ac92-c59851020383.png)
