### PR TITLE
feat: add log and factorial function to Int8, Int16, and Int64

### DIFF
--- a/main/src/library/Int16.flix
+++ b/main/src/library/Int16.flix
@@ -272,6 +272,18 @@ namespace Int16 {
     pub def flipBit(x: Int16, position: Int32): Int16 = x ^^^ (1i16 <<< position)
 
     ///
+    /// Returns the integer binary logarithm of `x`.
+    ///
+    @Time(1) @Space(1)
+    pub def log2(x: Int16): Int32 = highestOneBitPosition(x)
+
+    ///
+    /// Returns the factorial of `x`.
+    ///
+    @Time(factorial(x)) @Space(1)
+    pub def factorial(x: Int16): Int32 = toInt32(x) |> Int32.factorial
+
+    ///
     /// Return a string representation of `x`.
     ///
     @Time(1) @Space(1)

--- a/main/src/library/Int16.flix
+++ b/main/src/library/Int16.flix
@@ -275,7 +275,9 @@ namespace Int16 {
     /// Returns the integer binary logarithm of `x`.
     ///
     @Time(1) @Space(1)
-    pub def log2(x: Int16): Int32 = highestOneBitPosition(x)
+    pub def log2(x: Int16): Int16 =
+        let position = highestOneBitPosition(x);
+        Int32.clampToInt16(position, 0i16, Int16.maxValue())
 
     ///
     /// Returns the factorial of `x`.

--- a/main/src/library/Int32.flix
+++ b/main/src/library/Int32.flix
@@ -279,13 +279,12 @@ namespace Int32 {
     /// Returns the factorial of `x`.
     ///
     @Time(factorial(x)) @Space(1)
-    pub def factorial(x: Int32): Int32 = factorialHelper(x, 1)
-
-    ///
-    /// Helper function for `factorial`.
-    ///
-    def factorialHelper(x: Int32, acc: Int32): Int32 =
-        if (x == 0) acc else factorialHelper(x - 1, x * acc)
+    pub def factorial(x: Int32): Int32 =
+        def factorialHelper(y, acc) = match y {
+            case 0 => acc
+            case _ => factorialHelper(y - 1, y * acc)
+        };
+        factorialHelper(x, 1)
 
     ///
     /// Return a string representation of `x`.

--- a/main/src/library/Int32.flix
+++ b/main/src/library/Int32.flix
@@ -280,11 +280,11 @@ namespace Int32 {
     ///
     @Time(factorial(x)) @Space(1)
     pub def factorial(x: Int32): Int32 =
-        def factorialHelper(y, acc) = match y {
+        def loop(y, acc) = match y {
             case 0 => acc
-            case _ => factorialHelper(y - 1, y * acc)
+            case _ => loop(y - 1, y * acc)
         };
-        factorialHelper(x, 1)
+        loop(x, 1)
 
     ///
     /// Return a string representation of `x`.

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -270,7 +270,7 @@ namespace Int64 {
     /// Returns the integer binary logarithm of `x`.
     ///
     @Time(1) @Space(1)
-    pub def log2(x: Int64): Int32 = highestOneBitPosition(x)
+    pub def log2(x: Int64): Int64 = highestOneBitPosition(x) |> Int32.toInt64
 
     ///
     /// Returns the factorial of `x`.

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -271,17 +271,17 @@ namespace Int64 {
     ///
     @Time(1) @Space(1)
     pub def log2(x: Int64): Int32 = highestOneBitPosition(x)
+
     ///
     /// Returns the factorial of `x`.
     ///
     @Time(factorial(x)) @Space(1)
-    pub def factorial(x: Int64): Int64 = factorialHelper(x, 1i64)
-
-    ///
-    /// Helper function for `factorial`.
-    ///
-    def factorialHelper(x: Int64, acc: Int64): Int64 =
-        if (x == 0i64) acc else factorialHelper(x - 1i64, x * acc)
+    pub def factorial(x: Int64): Int64 =
+        def factorialHelper(y, acc) = match y {
+            case 0i64 => acc
+            case _    => factorialHelper(y - 1i64, y * acc)
+        };
+        factorialHelper(x, 1i64)
 
     ///
     /// Return a string representation of `x`.

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -277,11 +277,11 @@ namespace Int64 {
     ///
     @Time(factorial(x)) @Space(1)
     pub def factorial(x: Int64): Int64 =
-        def factorialHelper(y, acc) = match y {
+        def loop(y, acc) = match y {
             case 0i64 => acc
-            case _    => factorialHelper(y - 1i64, y * acc)
+            case _    => loop(y - 1i64, y * acc)
         };
-        factorialHelper(x, 1i64)
+        loop(x, 1i64)
 
     ///
     /// Return a string representation of `x`.

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -267,6 +267,23 @@ namespace Int64 {
     pub def flipBit(x: Int64, position: Int32): Int64 = x ^^^ (1i64 <<< position)
 
     ///
+    /// Returns the integer binary logarithm of `x`.
+    ///
+    @Time(1) @Space(1)
+    pub def log2(x: Int64): Int32 = highestOneBitPosition(x)
+    ///
+    /// Returns the factorial of `x`.
+    ///
+    @Time(factorial(x)) @Space(1)
+    pub def factorial(x: Int64): Int64 = factorialHelper(x, 1i64)
+
+    ///
+    /// Helper function for `factorial`.
+    ///
+    def factorialHelper(x: Int64, acc: Int64): Int64 =
+        if (x == 0i64) acc else factorialHelper(x - 1i64, x * acc)
+
+    ///
     /// Return a string representation of `x`.
     ///
     @Time(1) @Space(1)

--- a/main/src/library/Int8.flix
+++ b/main/src/library/Int8.flix
@@ -275,7 +275,9 @@ namespace Int8 {
     /// Returns the integer binary logarithm of `x`.
     ///
     @Time(1) @Space(1)
-    pub def log2(x: Int8): Int32 = highestOneBitPosition(x)
+    pub def log2(x: Int8): Int8 =
+        let position = highestOneBitPosition(x);
+        Int32.clampToInt8(position, 0i8, Int8.maxValue())
 
     ///
     /// Returns the factorial of `x`.

--- a/main/src/library/Int8.flix
+++ b/main/src/library/Int8.flix
@@ -272,6 +272,18 @@ namespace Int8 {
     pub def flipBit(x: Int8, position: Int32): Int8 = x ^^^ (1i8 <<< position)
 
     ///
+    /// Returns the integer binary logarithm of `x`.
+    ///
+    @Time(1) @Space(1)
+    pub def log2(x: Int8): Int32 = highestOneBitPosition(x)
+
+    ///
+    /// Returns the factorial of `x`.
+    ///
+    @Time(factorial(x)) @Space(1)
+    pub def factorial(x: Int8): Int32 = toInt32(x) |> Int32.factorial
+
+    ///
     /// Return a string representation of `x`.
     ///
     @Time(1) @Space(1)

--- a/main/test/ca/uwaterloo/flix/library/TestInt16.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt16.flix
@@ -690,25 +690,25 @@ namespace TestInt16 {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def log201(): Bool = Int16.log2(10i16) == 3
+    def log201(): Bool = Int16.log2(10i16) == 3i16
 
     @test
-    def log202(): Bool = Int16.log2(10000i16) == 13
+    def log202(): Bool = Int16.log2(10000i16) == 13i16
 
     @test
-    def log203(): Bool = Int16.log2(8i16) == 3
+    def log203(): Bool = Int16.log2(8i16) == 3i16
 
     @test
-    def log204(): Bool = Int16.log2(256i16) == 8
+    def log204(): Bool = Int16.log2(256i16) == 8i16
 
     @test
-    def log205(): Bool = Int16.log2(1i16) == 0
+    def log205(): Bool = Int16.log2(1i16) == 0i16
 
     @test
-    def log206(): Bool = Int16.log2(32767i16) == 14
+    def log206(): Bool = Int16.log2(32767i16) == 14i16
 
     @test
-    def log207(): Bool = Int16.log2(20i16) == 4
+    def log207(): Bool = Int16.log2(20i16) == 4i16
 
     /////////////////////////////////////////////////////////////////////////////
     // factorial                                                               //

--- a/main/test/ca/uwaterloo/flix/library/TestInt16.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt16.flix
@@ -686,6 +686,56 @@ namespace TestInt16 {
     def flipBit12(): Bool = Int16.flipBit(-1i16, 32) == -2i16
 
     /////////////////////////////////////////////////////////////////////////////
+    // log2                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def log201(): Bool = Int16.log2(10i16) == 3
+
+    @test
+    def log202(): Bool = Int16.log2(10000i16) == 13
+
+    @test
+    def log203(): Bool = Int16.log2(8i16) == 3
+
+    @test
+    def log204(): Bool = Int16.log2(256i16) == 8
+
+    @test
+    def log205(): Bool = Int16.log2(1i16) == 0
+
+    @test
+    def log206(): Bool = Int16.log2(32767i16) == 14
+
+    @test
+    def log207(): Bool = Int16.log2(20i16) == 4
+
+    /////////////////////////////////////////////////////////////////////////////
+    // factorial                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def factorial01(): Bool = Int16.factorial(0i16) == 1
+
+    @test
+    def factorial02(): Bool = Int16.factorial(1i16) == 1
+
+    @test
+    def factorial03(): Bool = Int16.factorial(2i16) == 2
+
+    @test
+    def factorial04(): Bool = Int16.factorial(3i16) == 6
+
+    @test
+    def factorial05(): Bool = Int16.factorial(4i16) == 24
+
+    @test
+    def factorial06(): Bool = Int16.factorial(5i16) == 120
+
+    @test
+    def factorial07(): Bool = Int16.factorial(10i16) == 3628800
+
+    /////////////////////////////////////////////////////////////////////////////
     // toString                                                                //
     /////////////////////////////////////////////////////////////////////////////
     @test

--- a/main/test/ca/uwaterloo/flix/library/TestInt64.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt64.flix
@@ -663,28 +663,28 @@ namespace TestInt64 {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def log201(): Bool = Int64.log2(10i64) == 3
+    def log201(): Bool = Int64.log2(10i64) == 3i64
 
     @test
-    def log202(): Bool = Int64.log2(10000i64) == 13
+    def log202(): Bool = Int64.log2(10000i64) == 13i64
 
     @test
-    def log203(): Bool = Int64.log2(8i64) == 3
+    def log203(): Bool = Int64.log2(8i64) == 3i64
 
     @test
-    def log204(): Bool = Int64.log2(256i64) == 8
+    def log204(): Bool = Int64.log2(256i64) == 8i64
 
     @test
-    def log205(): Bool = Int64.log2(1i64) == 0
+    def log205(): Bool = Int64.log2(1i64) == 0i64
 
     @test
-    def log206(): Bool = Int64.log2(12345678i64) == 23
+    def log206(): Bool = Int64.log2(12345678i64) == 23i64
 
     @test
-    def log207(): Bool = Int64.log2(20i64) == 4
+    def log207(): Bool = Int64.log2(20i64) == 4i64
 
     @test
-    def log208(): Bool = Int64.log2(9_223_372_036_854_775_807i64) == 62
+    def log208(): Bool = Int64.log2(9_223_372_036_854_775_807i64) == 62i64
 
     /////////////////////////////////////////////////////////////////////////////
     // factorial                                                               //

--- a/main/test/ca/uwaterloo/flix/library/TestInt64.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt64.flix
@@ -659,6 +659,59 @@ namespace TestInt64 {
     def flipBit12(): Bool = Int64.flipBit(-1i64, 64) == -2i64
 
     /////////////////////////////////////////////////////////////////////////////
+    // log2                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def log201(): Bool = Int64.log2(10i64) == 3
+
+    @test
+    def log202(): Bool = Int64.log2(10000i64) == 13
+
+    @test
+    def log203(): Bool = Int64.log2(8i64) == 3
+
+    @test
+    def log204(): Bool = Int64.log2(256i64) == 8
+
+    @test
+    def log205(): Bool = Int64.log2(1i64) == 0
+
+    @test
+    def log206(): Bool = Int64.log2(12345678i64) == 23
+
+    @test
+    def log207(): Bool = Int64.log2(20i64) == 4
+
+    @test
+    def log208(): Bool = Int64.log2(9_223_372_036_854_775_807i64) == 62
+
+    /////////////////////////////////////////////////////////////////////////////
+    // factorial                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def factorial01(): Bool = Int64.factorial(0i64) == 1i64
+
+    @test
+    def factorial02(): Bool = Int64.factorial(1i64) == 1i64
+
+    @test
+    def factorial03(): Bool = Int64.factorial(2i64) == 2i64
+
+    @test
+    def factorial04(): Bool = Int64.factorial(3i64) == 6i64
+
+    @test
+    def factorial05(): Bool = Int64.factorial(4i64) == 24i64
+
+    @test
+    def factorial06(): Bool = Int64.factorial(5i64) == 120i64
+
+    @test
+    def factorial07(): Bool = Int64.factorial(10i64) == 3628800i64
+
+    /////////////////////////////////////////////////////////////////////////////
     // toString                                                                //
     /////////////////////////////////////////////////////////////////////////////
     @test

--- a/main/test/ca/uwaterloo/flix/library/TestInt8.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt8.flix
@@ -683,6 +683,50 @@ namespace TestInt8 {
     def flipBit12(): Bool = Int8.flipBit(-1i8, 32) == -2i8
     
     /////////////////////////////////////////////////////////////////////////////
+    // log2                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def log201(): Bool = Int8.log2(10i8) == 3
+
+    @test
+    def log202(): Bool = Int8.log2(8i8) == 3
+
+    @test
+    def log203(): Bool = Int8.log2(127i8) == 6
+
+    @test
+    def log204(): Bool = Int8.log2(1i8) == 0
+
+    @test
+    def log205(): Bool = Int8.log2(20i8) == 4
+
+    /////////////////////////////////////////////////////////////////////////////
+    // factorial                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def factorial01(): Bool = Int8.factorial(0i8) == 1
+
+    @test
+    def factorial02(): Bool = Int8.factorial(1i8) == 1
+
+    @test
+    def factorial03(): Bool = Int8.factorial(2i8) == 2
+
+    @test
+    def factorial04(): Bool = Int8.factorial(3i8) == 6
+
+    @test
+    def factorial05(): Bool = Int8.factorial(4i8) == 24
+
+    @test
+    def factorial06(): Bool = Int8.factorial(5i8) == 120
+
+    @test
+    def factorial07(): Bool = Int8.factorial(10i8) == 3628800
+
+    /////////////////////////////////////////////////////////////////////////////
     // toString                                                                //
     /////////////////////////////////////////////////////////////////////////////
     @test

--- a/main/test/ca/uwaterloo/flix/library/TestInt8.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt8.flix
@@ -687,19 +687,19 @@ namespace TestInt8 {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def log201(): Bool = Int8.log2(10i8) == 3
+    def log201(): Bool = Int8.log2(10i8) == 3i8
 
     @test
-    def log202(): Bool = Int8.log2(8i8) == 3
+    def log202(): Bool = Int8.log2(8i8) == 3i8
 
     @test
-    def log203(): Bool = Int8.log2(127i8) == 6
+    def log203(): Bool = Int8.log2(127i8) == 6i8
 
     @test
-    def log204(): Bool = Int8.log2(1i8) == 0
+    def log204(): Bool = Int8.log2(1i8) == 0i8
 
     @test
-    def log205(): Bool = Int8.log2(20i8) == 4
+    def log205(): Bool = Int8.log2(20i8) == 4i8
 
     /////////////////////////////////////////////////////////////////////////////
     // factorial                                                               //


### PR DESCRIPTION
Add `log2` and `factorial` functions to `Int8`, `Int16`, and `Int64` just like #1247.

I think this PR is not enough to close #1246, due to a lack of consideration for negative values. If we have a clear plan (e.g. returning 0) I will implement it in this branch later. :)