### PR TITLE
feat: allow single effect without braces

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -280,12 +280,16 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       keyword("Write") ~ optWS ~ "(" ~ optWS ~ oneOrMore(Names.Variable).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~> ParsedAst.Effect.Write
     }
 
+    def Single: Rule1[ParsedAst.Type] = rule {
+      SP ~ (Var | Read | Write) ~ SP ~> ((sp1: SourcePosition, eff: ParsedAst.Effect, sp2: SourcePosition) => ParsedAst.Type.Union(sp1, Seq(eff), sp2))
+    }
+
     def Union: Rule1[ParsedAst.Type] = rule {
       SP ~ "{" ~ optWS ~ zeroOrMore(Var | Read | Write).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ "}" ~ SP ~> ParsedAst.Type.Union
     }
 
     rule {
-      WS ~ "\\" ~ WS ~ Union
+      WS ~ "\\" ~ WS ~ (Single | Union)
     }
   }
 


### PR DESCRIPTION
Allow: 

```
pub def count(f: a -> Bool, a: ScopedArray[a, r]): Int32 \ { Read(r) } =
    foldLeft((b,x) -> if (f(x)) b + 1 else b, 0, a)

```

to be written as:

```
pub def count(f: a -> Bool, a: ScopedArray[a, r]): Int32 \ Read(r) = // Note: No braces
    foldLeft((b,x) -> if (f(x)) b + 1 else b, 0, a)
```

when there is a single effect.