### PR TITLE
refactor: reorganize `Namer.visitSig` and `Namer.visitDef`

### DIFF
--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -271,6 +271,16 @@ object Validation {
     }
 
   /**
+    * FlatMaps over t1, t2, t3, t4, t5, and t6.
+    */
+  def flatMapN[T1, T2, T3, T4, T5, T6, U, E](t1: Validation[T1, E], t2: Validation[T2, E], t3: Validation[T3, E],
+                                             t4: Validation[T4, E], t5: Validation[T5, E], t6: Validation[T6, E])
+                                             (f: (T1, T2, T3, T4, T5, T6) => Validation[U, E]): Validation[U, E] =
+    (t1, t2, t3, t4, t5, t6) match {
+      case (Success(v1), Success(v2), Success(v3), Success(v4), Success(v5), Success(v6)) => f(v1, v2, v3, v4, v5, v6)
+      case _ => Failure(t1.errors #::: t2.errors #::: t3.errors #::: t4.errors #::: t5.errors #::: t6.errors)
+    }
+  /**
     * Sequences over t1, t2, and t3.
     */
   def sequenceT[T1, T2, T3, U, E](t1: Validation[T1, E], t2: Validation[T2, E], t3: Validation[T3, E]): Validation[(T1, T2, T3), E] =


### PR DESCRIPTION
This change more clearly separates the steps in the `visit*` functions, gets rid of some redundancy, and better distinguishes between parts that can fail and those that can't, all making way for a cleaner implementation of #1230 in the Namer.