### PR TITLE
refactor: remove uses of `Validation.flatMap` from `Weeder`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -541,7 +541,7 @@ class Flix {
     * Compiles the given typed ast to an executable ast.
     */
   def compile(): Validation[CompilationResult, CompilationMessage] =
-    check() andThen codeGen
+    Validation.flatMapN(check())(codeGen)
 
   /**
     * Enters the phase with the given name.

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -541,7 +541,7 @@ class Flix {
     * Compiles the given typed ast to an executable ast.
     */
   def compile(): Validation[CompilationResult, CompilationMessage] =
-    check() flatMap codeGen
+    check() andThen codeGen
 
   /**
     * Enters the phase with the given name.

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -243,7 +243,7 @@ object Instances {
       Validation.traverseX(checks) {
         case inst :: unchecked =>
           // check that the instance is on a valid type, suppressing other errors if not
-          checkSimple(inst) flatMap {
+          checkSimple(inst) andThen {
             _ =>
               Validation.sequenceX(List(
                 Validation.traverse(unchecked)(checkOverlap(_, inst)),

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.{Ast, Kind, Scheme, Symbol, Type, TypeCons
 import ca.uwaterloo.flix.language.errors.InstanceError
 import ca.uwaterloo.flix.language.phase.unification.{ClassEnvironment, Substitution, Unification, UnificationError}
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
-import ca.uwaterloo.flix.util.Validation.{ToFailure, ToSuccess}
+import ca.uwaterloo.flix.util.Validation.{ToFailure, ToSuccess, flatMapN}
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps, Validation}
 
 object Instances {
@@ -243,7 +243,7 @@ object Instances {
       Validation.traverseX(checks) {
         case inst :: unchecked =>
           // check that the instance is on a valid type, suppressing other errors if not
-          checkSimple(inst) andThen {
+          flatMapN(checkSimple(inst)) {
             _ =>
               Validation.sequenceX(List(
                 Validation.traverse(unchecked)(checkOverlap(_, inst)),

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -53,7 +53,7 @@ object Kinder {
   def run(root: ResolvedAst.Root, oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Validation[KindedAst.Root, CompilationMessage] = flix.phase("Kinder") {
 
     // Type aliases must be processed first in order to provide a `taenv` for looking up type alias symbols.
-    visitTypeAliases(root.taOrder, root) flatMap {
+    visitTypeAliases(root.taOrder, root) andThen {
       taenv =>
 
         // Extra type annotations are required due to limitations in Scala's type inference.
@@ -780,7 +780,7 @@ object Kinder {
   private def visitType(tpe0: Type, expectedKind: Kind, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[Type, KindError] = tpe0 match {
     case tvar: Type.UnkindedVar => visitTypeVar(tvar, expectedKind, kenv)
     case Type.Cst(cst, loc) =>
-      visitTypeConstructor(cst, kenv, taenv, root) flatMap {
+      visitTypeConstructor(cst, kenv, taenv, root) andThen {
         tycon =>
           val kind = tycon.kind
           unify(expectedKind, kind) match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -17,7 +17,6 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast._
 import ca.uwaterloo.flix.language.errors.KindError
 import ca.uwaterloo.flix.util.Validation.{ToFailure, ToSuccess, flatMapN, mapN, traverse}
@@ -50,10 +49,10 @@ import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps, Validation}
   */
 object Kinder {
 
-  def run(root: ResolvedAst.Root, oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Validation[KindedAst.Root, CompilationMessage] = flix.phase("Kinder") {
+  def run(root: ResolvedAst.Root, oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Validation[KindedAst.Root, KindError] = flix.phase("Kinder") {
 
     // Type aliases must be processed first in order to provide a `taenv` for looking up type alias symbols.
-    visitTypeAliases(root.taOrder, root) andThen {
+    flatMapN(visitTypeAliases(root.taOrder, root)) {
       taenv =>
 
         // Extra type annotations are required due to limitations in Scala's type inference.
@@ -84,7 +83,7 @@ object Kinder {
   /**
     * Performs kinding on the given enum.
     */
-  private def visitEnum(enum: ResolvedAst.Enum, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Enum, CompilationMessage] = enum match {
+  private def visitEnum(enum: ResolvedAst.Enum, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Enum, KindError] = enum match {
     case ResolvedAst.Enum(doc, ann, mod, sym, tparams0, derives, cases0, tpeDeprecated0, sc0, loc) =>
       val kenv = getKindEnvFromTypeParamsDefaultStar(tparams0)
 
@@ -780,7 +779,7 @@ object Kinder {
   private def visitType(tpe0: Type, expectedKind: Kind, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[Type, KindError] = tpe0 match {
     case tvar: Type.UnkindedVar => visitTypeVar(tvar, expectedKind, kenv)
     case Type.Cst(cst, loc) =>
-      visitTypeConstructor(cst, kenv, taenv, root) andThen {
+      flatMapN(visitTypeConstructor(cst, kenv, taenv, root)) {
         tycon =>
           val kind = tycon.kind
           unify(expectedKind, kind) match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -78,7 +78,7 @@ object Namer {
        * Namespace.
        */
       case WeededAst.Declaration.Namespace(ns, uses, decls, loc) =>
-        mergeUseEnvs(uses, uenv0) andThen {
+        flatMapN(mergeUseEnvs(uses, uenv0)) {
           newEnv =>
             Validation.fold(decls, prog0) {
               case (pacc, decl) =>
@@ -95,7 +95,7 @@ object Namer {
         lookupTypeOrClass(ident, ns0, prog0) match {
           case LookupResult.NotDefined =>
             // Case 1: The class does not already exist. Update it.
-            visitClass(decl, uenv0, Map.empty, ns0) andThen {
+            flatMapN(visitClass(decl, uenv0, Map.empty, ns0)) {
               case clazz@NamedAst.Class(_, _, _, _, _, _, sigs, _, _) =>
                 // add each signature to the namespace
                 // TODO add laws

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -78,7 +78,7 @@ object Namer {
        * Namespace.
        */
       case WeededAst.Declaration.Namespace(ns, uses, decls, loc) =>
-        mergeUseEnvs(uses, uenv0) flatMap {
+        mergeUseEnvs(uses, uenv0) andThen {
           newEnv =>
             Validation.fold(decls, prog0) {
               case (pacc, decl) =>
@@ -95,7 +95,7 @@ object Namer {
         lookupTypeOrClass(ident, ns0, prog0) match {
           case LookupResult.NotDefined =>
             // Case 1: The class does not already exist. Update it.
-            visitClass(decl, uenv0, Map.empty, ns0) flatMap {
+            visitClass(decl, uenv0, Map.empty, ns0) andThen {
               case clazz@NamedAst.Class(_, _, _, _, _, _, sigs, _, _) =>
                 // add each signature to the namespace
                 // TODO add laws

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -55,7 +55,7 @@ object Resolver {
   def run(root: NamedAst.Root, oldRoot: ResolvedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Validation[ResolvedAst.Root, ResolutionError] = flix.phase("Resolver") {
 
     // Type aliases must be processed first in order to provide a `taenv` for looking up type alias symbols.
-    resolveTypeAliases(root.typealiases, root) andThen {
+    flatMapN(resolveTypeAliases(root.typealiases, root)) {
       case (taenv, taOrder) =>
 
         val classesVal = resolveClasses(root, taenv, oldRoot, changeSet)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -55,7 +55,7 @@ object Resolver {
   def run(root: NamedAst.Root, oldRoot: ResolvedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Validation[ResolvedAst.Root, ResolutionError] = flix.phase("Resolver") {
 
     // Type aliases must be processed first in order to provide a `taenv` for looking up type alias symbols.
-    resolveTypeAliases(root.typealiases, root) flatMap {
+    resolveTypeAliases(root.typealiases, root) andThen {
       case (taenv, taOrder) =>
 
         val classesVal = resolveClasses(root, taenv, oldRoot, changeSet)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1691,7 +1691,7 @@ object Weeder {
       WeededAst.Expression.False(mkSL(sp1, sp2)).toSuccess
 
     case ParsedAst.Literal.Char(sp1, chars, sp2) =>
-      weedCharSequence(chars) flatMap {
+      weedCharSequence(chars) andThen {
         case string if string.lengthIs == 1 => WeededAst.Expression.Char(string.head, mkSL(sp1, sp2)).toSuccess
         case string => WeederError.NonSingleCharacter(string, mkSL(sp1, sp2)).toFailure
       }
@@ -1749,7 +1749,7 @@ object Weeder {
     case ParsedAst.Literal.True(sp1, sp2) => WeededAst.Pattern.True(mkSL(sp1, sp2)).toSuccess
     case ParsedAst.Literal.False(sp1, sp2) => WeededAst.Pattern.False(mkSL(sp1, sp2)).toSuccess
     case ParsedAst.Literal.Char(sp1, chars, sp2) =>
-      weedCharSequence(chars) flatMap {
+      weedCharSequence(chars) andThen {
         case string if string.lengthIs == 1 => WeededAst.Pattern.Char(string.head, mkSL(sp1, sp2)).toSuccess
         case string => WeederError.NonSingleCharacter(string, mkSL(sp1, sp2)).toFailure
       }
@@ -2310,7 +2310,7 @@ object Weeder {
             seen += (ident.name -> param)
           }
 
-          visitModifiers(mods, legalModifiers = Set.empty) flatMap {
+          visitModifiers(mods, legalModifiers = Set.empty) andThen {
             case mod =>
               if (typeRequired && typeOpt.isEmpty)
                 IllegalFormalParameter(ident.name, mkSL(sp1, sp2)).toFailure

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -40,15 +40,13 @@ sealed trait Validation[+T, +E] {
     case Validation.Failure(errors) => Validation.Failure(errors)
   }
 
-  // Deprecated. Use `andThen` instead.
-  final def flatMap[U, A >: E](f: T => Validation[U, A]): Validation[U, A] = this.andThen(f)
-
   /**
     * Similar to `map` but does not wrap the result in a [[Validation.Success]].
     *
     * Preserves the errors.
     */
-  final def andThen[U, A >: E](f: T => Validation[U, A]): Validation[U, A] = this match {
+    // Deprecated. Use flatMapN instead.
+  final def flatMap[U, A >: E](f: T => Validation[U, A]): Validation[U, A] = this match {
     case Validation.Success(input) => f(input) match {
       case Validation.Success(value) => Validation.Success(value)
       case Validation.Failure(thatErrors) => Validation.Failure(errors #::: thatErrors)
@@ -249,7 +247,6 @@ object Validation {
   /**
     * FlatMaps over t1.
     */
-  // Deprecated. Use `sequenceT` and `andThen` instead.
   def flatMapN[T1, U, E](t1: Validation[T1, E])(f: T1 => Validation[U, E]): Validation[U, E] =
     t1 match {
       case Success(v1) => f(v1)
@@ -259,7 +256,6 @@ object Validation {
   /**
     * FlatMaps over t1 and t2.
     */
-  // Deprecated. Use `sequenceT` and `andThen` instead.
   def flatMapN[T1, T2, U, E](t1: Validation[T1, E], t2: Validation[T2, E])
                             (f: (T1, T2) => Validation[U, E]): Validation[U, E] =
     (t1, t2) match {
@@ -270,7 +266,6 @@ object Validation {
   /**
     * FlatMaps over t1, t2, and t3.
     */
-  // Deprecated. Use `sequenceT` and `andThen` instead.
   def flatMapN[T1, T2, T3, U, E](t1: Validation[T1, E], t2: Validation[T2, E], t3: Validation[T3, E])
                                 (f: (T1, T2, T3) => Validation[U, E]): Validation[U, E] =
     (t1, t2, t3) match {
@@ -281,7 +276,6 @@ object Validation {
   /**
     * FlatMaps over t1, t2, t3, and t4.
     */
-  // Deprecated. Use `sequenceT` and `andThen` instead.
   def flatMapN[T1, T2, T3, T4, U, E](t1: Validation[T1, E], t2: Validation[T2, E], t3: Validation[T3, E],
                                      t4: Validation[T4, E])
                                     (f: (T1, T2, T3, T4) => Validation[U, E]): Validation[U, E] =
@@ -293,7 +287,6 @@ object Validation {
   /**
     * FlatMaps over t1, t2, t3, t4, and t5.
     */
-  // Deprecated. Use `sequenceT` and `andThen` instead.
   def flatMapN[T1, T2, T3, T4, T5, U, E](t1: Validation[T1, E], t2: Validation[T2, E], t3: Validation[T3, E],
                                          t4: Validation[T4, E], t5: Validation[T5, E])
                                         (f: (T1, T2, T3, T4, T5) => Validation[U, E]): Validation[U, E] =
@@ -305,7 +298,6 @@ object Validation {
   /**
     * FlatMaps over t1, t2, t3, t4, t5, and t6.
     */
-  // Deprecated. Use `sequenceT` and `andThen` instead.
   def flatMapN[T1, T2, T3, T4, T5, T6, U, E](t1: Validation[T1, E], t2: Validation[T2, E], t3: Validation[T3, E],
                                              t4: Validation[T4, E], t5: Validation[T5, E], t6: Validation[T6, E])
                                              (f: (T1, T2, T3, T4, T5, T6) => Validation[U, E]): Validation[U, E] =
@@ -358,7 +350,7 @@ object Validation {
     */
   def foldRight[T, U, E](xs: Seq[T])(zero: Validation[U, E])(f: (T, U) => Validation[U, E]): Validation[U, E] = {
     xs.foldRight(zero) {
-      case (a, acc) => acc andThen {
+      case (a, acc) => flatMapN(acc) {
         case v => f(a, v)
       }
     }
@@ -387,7 +379,7 @@ object Validation {
     */
   def fold[In, Out, Error](xs: Iterable[In], zero: Out)(f: (Out, In) => Validation[Out, Error]): Validation[Out, Error] = {
     xs.foldLeft(Success(zero): Validation[Out, Error]) {
-      case (acc, a) => acc andThen {
+      case (acc, a) => flatMapN(acc) {
         case value => f(value, a)
       }
     }

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -249,6 +249,7 @@ object Validation {
   /**
     * FlatMaps over t1.
     */
+  // Deprecated. Use `sequenceT` and `andThen` instead.
   def flatMapN[T1, U, E](t1: Validation[T1, E])(f: T1 => Validation[U, E]): Validation[U, E] =
     t1 match {
       case Success(v1) => f(v1)
@@ -258,6 +259,7 @@ object Validation {
   /**
     * FlatMaps over t1 and t2.
     */
+  // Deprecated. Use `sequenceT` and `andThen` instead.
   def flatMapN[T1, T2, U, E](t1: Validation[T1, E], t2: Validation[T2, E])
                             (f: (T1, T2) => Validation[U, E]): Validation[U, E] =
     (t1, t2) match {
@@ -268,6 +270,7 @@ object Validation {
   /**
     * FlatMaps over t1, t2, and t3.
     */
+  // Deprecated. Use `sequenceT` and `andThen` instead.
   def flatMapN[T1, T2, T3, U, E](t1: Validation[T1, E], t2: Validation[T2, E], t3: Validation[T3, E])
                                 (f: (T1, T2, T3) => Validation[U, E]): Validation[U, E] =
     (t1, t2, t3) match {
@@ -278,6 +281,7 @@ object Validation {
   /**
     * FlatMaps over t1, t2, t3, and t4.
     */
+  // Deprecated. Use `sequenceT` and `andThen` instead.
   def flatMapN[T1, T2, T3, T4, U, E](t1: Validation[T1, E], t2: Validation[T2, E], t3: Validation[T3, E],
                                      t4: Validation[T4, E])
                                     (f: (T1, T2, T3, T4) => Validation[U, E]): Validation[U, E] =
@@ -289,6 +293,7 @@ object Validation {
   /**
     * FlatMaps over t1, t2, t3, t4, and t5.
     */
+  // Deprecated. Use `sequenceT` and `andThen` instead.
   def flatMapN[T1, T2, T3, T4, T5, U, E](t1: Validation[T1, E], t2: Validation[T2, E], t3: Validation[T3, E],
                                          t4: Validation[T4, E], t5: Validation[T5, E])
                                         (f: (T1, T2, T3, T4, T5) => Validation[U, E]): Validation[U, E] =
@@ -300,6 +305,7 @@ object Validation {
   /**
     * FlatMaps over t1, t2, t3, t4, t5, and t6.
     */
+  // Deprecated. Use `sequenceT` and `andThen` instead.
   def flatMapN[T1, T2, T3, T4, T5, T6, U, E](t1: Validation[T1, E], t2: Validation[T2, E], t3: Validation[T3, E],
                                              t4: Validation[T4, E], t5: Validation[T5, E], t6: Validation[T6, E])
                                              (f: (T1, T2, T3, T4, T5, T6) => Validation[U, E]): Validation[U, E] =
@@ -307,6 +313,7 @@ object Validation {
       case (Success(v1), Success(v2), Success(v3), Success(v4), Success(v5), Success(v6)) => f(v1, v2, v3, v4, v5, v6)
       case _ => Failure(t1.errors #::: t2.errors #::: t3.errors #::: t4.errors #::: t5.errors #::: t6.errors)
     }
+
   /**
     * Sequences over t1, t2, and t3.
     */

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -220,6 +220,30 @@ object Validation {
     }
 
   /**
+    * Maps over t1, t2, t3, t4, t5, t6, t7, and t8.
+    */
+  def mapN[T1, T2, T3, T4, T5, T6, T7, T8, U, E](t1: Validation[T1, E], t2: Validation[T2, E], t3: Validation[T3, E],
+                                                 t4: Validation[T4, E], t5: Validation[T5, E], t6: Validation[T6, E],
+                                                 t7: Validation[T7, E], t8: Validation[T8, E])
+                                                 (f: (T1, T2, T3, T4, T5, T6, T7, T8) => U): Validation[U, E] =
+    (t1, t2, t3, t4, t5, t6, t7, t8) match {
+      case (Success(v1), Success(v2), Success(v3), Success(v4), Success(v5), Success(v6), Success(v7), Success(v8)) => Success(f(v1, v2, v3, v4, v5, v6, v7, v8))
+      case _ => Failure(t1.errors #::: t2.errors #::: t3.errors #::: t4.errors #::: t5.errors #::: t6.errors #::: t7.errors #::: t8.errors)
+    }
+
+  /**
+    * Maps over t1, t2, t3, t4, t5, t6, t7, t8, and t9.
+    */
+  def mapN[T1, T2, T3, T4, T5, T6, T7, T8, T9, U, E](t1: Validation[T1, E], t2: Validation[T2, E], t3: Validation[T3, E],
+                                                 t4: Validation[T4, E], t5: Validation[T5, E], t6: Validation[T6, E],
+                                                 t7: Validation[T7, E], t8: Validation[T8, E], t9: Validation[T9, E])
+                                                 (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => U): Validation[U, E] =
+    (t1, t2, t3, t4, t5, t6, t7, t8, t9) match {
+      case (Success(v1), Success(v2), Success(v3), Success(v4), Success(v5), Success(v6), Success(v7), Success(v8), Success(v9)) => Success(f(v1, v2, v3, v4, v5, v6, v7, v8, v9))
+      case _ => Failure(t1.errors #::: t2.errors #::: t3.errors #::: t4.errors #::: t5.errors #::: t6.errors #::: t7.errors #::: t8.errors #::: t9.errors)
+    }
+
+  /**
     * FlatMaps over t1.
     */
   def flatMapN[T1, U, E](t1: Validation[T1, E])(f: T1 => Validation[U, E]): Validation[U, E] =

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -45,7 +45,7 @@ sealed trait Validation[+T, +E] {
     *
     * Preserves the errors.
     */
-  final def flatMap[U, A >: E](f: T => Validation[U, A]): Validation[U, A] = this match {
+  final def andThen[U, A >: E](f: T => Validation[U, A]): Validation[U, A] = this match {
     case Validation.Success(input) => f(input) match {
       case Validation.Success(value) => Validation.Success(value)
       case Validation.Failure(thatErrors) => Validation.Failure(errors #::: thatErrors)
@@ -324,7 +324,7 @@ object Validation {
     */
   def foldRight[T, U, E](xs: Seq[T])(zero: Validation[U, E])(f: (T, U) => Validation[U, E]): Validation[U, E] = {
     xs.foldRight(zero) {
-      case (a, acc) => acc flatMap {
+      case (a, acc) => acc andThen {
         case v => f(a, v)
       }
     }
@@ -353,7 +353,7 @@ object Validation {
     */
   def fold[In, Out, Error](xs: Iterable[In], zero: Out)(f: (Out, In) => Validation[Out, Error]): Validation[Out, Error] = {
     xs.foldLeft(Success(zero): Validation[Out, Error]) {
-      case (acc, a) => acc flatMap {
+      case (acc, a) => acc andThen {
         case value => f(value, a)
       }
     }

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -40,6 +40,9 @@ sealed trait Validation[+T, +E] {
     case Validation.Failure(errors) => Validation.Failure(errors)
   }
 
+  // Deprecated. Use `andThen` instead.
+  final def flatMap[U, A >: E](f: T => Validation[U, A]): Validation[U, A] = this.andThen(f)
+
   /**
     * Similar to `map` but does not wrap the result in a [[Validation.Success]].
     *

--- a/main/test/ca/uwaterloo/flix/util/TestValidation.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestValidation.scala
@@ -78,14 +78,14 @@ class TestValidation extends FunSuite {
     assertResult(Failure(LazyList(ex)))(result)
   }
 
-  test("flatMap01") {
+  test("andThen01") {
     val result = "foo".toSuccess[String, Exception].andThen {
       case x => x.toUpperCase.toSuccess
     }
     assertResult(Success("FOO"))(result)
   }
 
-  test("flatMap02") {
+  test("andThen02") {
     val result = "foo".toSuccess[String, Exception].andThen {
       case x => x.toUpperCase.toSuccess
     }.andThen {
@@ -96,7 +96,7 @@ class TestValidation extends FunSuite {
     assertResult(Success("OOFOOF"))(result)
   }
 
-  test("flatMap03") {
+  test("andThen03") {
     val ex = new RuntimeException()
     val result = "foo".toSuccess[String, Exception].andThen {
       case x => ex.toFailure
@@ -104,7 +104,7 @@ class TestValidation extends FunSuite {
     assertResult(Failure(LazyList(ex)))(result)
   }
 
-  test("flatMap04") {
+  test("andThen04") {
     val result = "foo".toSuccess[String, Int].andThen {
       case x => Success(x.toUpperCase)
     }.andThen {
@@ -115,7 +115,7 @@ class TestValidation extends FunSuite {
     assertResult(Success("OOFOOF"))(result)
   }
 
-  test("flatMap05") {
+  test("andThen05") {
     val result = "foo".toSuccess[String, Int].andThen {
       case x => Success(x.toUpperCase)
     }.andThen {

--- a/main/test/ca/uwaterloo/flix/util/TestValidation.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestValidation.scala
@@ -17,7 +17,6 @@
 package ca.uwaterloo.flix.util
 
 import ca.uwaterloo.flix.util.Validation._
-
 import org.scalatest.FunSuite
 
 
@@ -78,84 +77,84 @@ class TestValidation extends FunSuite {
     assertResult(Failure(LazyList(ex)))(result)
   }
 
-  test("andThen01") {
-    val result = "foo".toSuccess[String, Exception].andThen {
+  test("flatMapN01") {
+    val result = flatMapN("foo".toSuccess[String, Exception]) {
       case x => x.toUpperCase.toSuccess
     }
     assertResult(Success("FOO"))(result)
   }
 
-  test("andThen02") {
-    val result = "foo".toSuccess[String, Exception].andThen {
-      case x => x.toUpperCase.toSuccess
-    }.andThen {
-      case y => y.reverse.toSuccess
-    }.andThen {
-      case z => (z + z).toSuccess
+  test("flatMapN02") {
+    val result = flatMapN("foo".toSuccess[String, Exception]) {
+      case x => flatMapN(x.toUpperCase.toSuccess) {
+        case y => flatMapN(y.reverse.toSuccess) {
+          case z => (z + z).toSuccess
+        }
+      }
     }
     assertResult(Success("OOFOOF"))(result)
   }
 
   test("andThen03") {
     val ex = new RuntimeException()
-    val result = "foo".toSuccess[String, Exception].andThen {
+    val result = flatMapN("foo".toSuccess[String, Exception]) {
       case x => ex.toFailure
     }
     assertResult(Failure(LazyList(ex)))(result)
   }
 
   test("andThen04") {
-    val result = "foo".toSuccess[String, Int].andThen {
-      case x => Success(x.toUpperCase)
-    }.andThen {
-      case y => Success(y.reverse)
-    }.andThen {
-      case z => Success(z + z)
+    val result = flatMapN("foo".toSuccess[String, Int]) {
+      case x => flatMapN(Success(x.toUpperCase)) {
+        case y => flatMapN(Success(y.reverse)) {
+          case z => Success(z + z)
+        }
+      }
     }
     assertResult(Success("OOFOOF"))(result)
   }
 
   test("andThen05") {
-    val result = "foo".toSuccess[String, Int].andThen {
-      case x => Success(x.toUpperCase)
-    }.andThen {
-      case y => Failure(LazyList(4, 5, 6))
-    }.andThen {
-      case z => Failure(LazyList(7, 8, 9))
+    val result = flatMapN("foo".toSuccess[String, Int]) {
+      case x => flatMapN(Success(x.toUpperCase)) {
+        case y => flatMapN(Failure(LazyList(4, 5, 6))) {
+          case z => Failure(LazyList(7, 8, 9))
+        }
+      }
     }
     assertResult(Failure(LazyList(4, 5, 6)))(result)
   }
 
-  test("traverse01") {
-    val result = traverse(List(1, 2, 3)) {
-      case x => Success(x + 1)
+    test("traverse01") {
+      val result = traverse(List(1, 2, 3)) {
+        case x => Success(x + 1)
+      }
+
+      assertResult(Success(List(2, 3, 4)))(result)
     }
 
-    assertResult(Success(List(2, 3, 4)))(result)
-  }
+    test("traverse02") {
+      val result = traverse(List(1, 2, 3)) {
+        case x => Failure(LazyList(42))
+      }
 
-  test("traverse02") {
-    val result = traverse(List(1, 2, 3)) {
-      case x => Failure(LazyList(42))
+      assertResult(Failure(LazyList(42, 42, 42)))(result)
     }
 
-    assertResult(Failure(LazyList(42, 42, 42)))(result)
-  }
+    test("traverse03") {
+      val result = traverse(List(1, 2, 3)) {
+        case x => if (x % 2 == 1) Success(x) else Failure(LazyList(x))
+      }
 
-  test("traverse03") {
-    val result = traverse(List(1, 2, 3)) {
-      case x => if (x % 2 == 1) Success(x) else Failure(LazyList(x))
+      assertResult(Failure(LazyList(2)))(result)
     }
 
-    assertResult(Failure(LazyList(2)))(result)
-  }
+    test("foldRight01") {
+      val result = foldRight(List(1, 1, 1))(Success(10)) {
+        case (x, acc) => (acc - x).toSuccess
+      }
 
-  test("foldRight01") {
-    val result = foldRight(List(1, 1, 1))(Success(10)) {
-      case (x, acc) => (acc - x).toSuccess
+      assertResult(Success(7))(result)
     }
-
-    assertResult(Success(7))(result)
-  }
 
 }

--- a/main/test/ca/uwaterloo/flix/util/TestValidation.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestValidation.scala
@@ -79,18 +79,18 @@ class TestValidation extends FunSuite {
   }
 
   test("flatMap01") {
-    val result = "foo".toSuccess[String, Exception].flatMap {
+    val result = "foo".toSuccess[String, Exception].andThen {
       case x => x.toUpperCase.toSuccess
     }
     assertResult(Success("FOO"))(result)
   }
 
   test("flatMap02") {
-    val result = "foo".toSuccess[String, Exception].flatMap {
+    val result = "foo".toSuccess[String, Exception].andThen {
       case x => x.toUpperCase.toSuccess
-    }.flatMap {
+    }.andThen {
       case y => y.reverse.toSuccess
-    }.flatMap {
+    }.andThen {
       case z => (z + z).toSuccess
     }
     assertResult(Success("OOFOOF"))(result)
@@ -98,29 +98,29 @@ class TestValidation extends FunSuite {
 
   test("flatMap03") {
     val ex = new RuntimeException()
-    val result = "foo".toSuccess[String, Exception].flatMap {
+    val result = "foo".toSuccess[String, Exception].andThen {
       case x => ex.toFailure
     }
     assertResult(Failure(LazyList(ex)))(result)
   }
 
   test("flatMap04") {
-    val result = "foo".toSuccess[String, Int].flatMap {
+    val result = "foo".toSuccess[String, Int].andThen {
       case x => Success(x.toUpperCase)
-    }.flatMap {
+    }.andThen {
       case y => Success(y.reverse)
-    }.flatMap {
+    }.andThen {
       case z => Success(z + z)
     }
     assertResult(Success("OOFOOF"))(result)
   }
 
   test("flatMap05") {
-    val result = "foo".toSuccess[String, Int].flatMap {
+    val result = "foo".toSuccess[String, Int].andThen {
       case x => Success(x.toUpperCase)
-    }.flatMap {
+    }.andThen {
       case y => Failure(LazyList(4, 5, 6))
-    }.flatMap {
+    }.andThen {
       case z => Failure(LazyList(7, 8, 9))
     }
     assertResult(Failure(LazyList(4, 5, 6)))(result)


### PR DESCRIPTION
related to #3426 