### PR TITLE
fix: separate TypeVarSym and TypeVar source locations

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompleteProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompleteProvider.scala
@@ -178,8 +178,8 @@ object CompleteProvider {
       * Replaces the text in the given variable symbol `sym` everywhere in the type `tpe`
       * with an equivalent variable symbol with the given `newText`.
       */
-    def replaceText(tvar: Type.Var, tpe: Type, newText: String): Type = tpe match {
-      case Type.KindedVar(sym, loc) if tvar.sym == sym => Type.KindedVar(sym.withText(Some(newText)), loc)
+    def replaceText(tvar: Symbol.TypeVarSym, tpe: Type, newText: String): Type = tpe match {
+      case Type.KindedVar(sym, loc) if tvar == sym => Type.KindedVar(sym.withText(Some(newText)), loc)
       case Type.KindedVar(_, _) => tpe
       case Type.Cst(_, _) => tpe
 
@@ -201,7 +201,7 @@ object CompleteProvider {
       * Formats the given type `tpe`.
       */
     def fmtType(clazz: TypedAst.Class, tpe: Type, hole: String): String =
-      FormatType.formatWellKindedType(replaceText(clazz.tparam.tpe, tpe, hole))
+      FormatType.formatWellKindedType(replaceText(clazz.tparam.sym, tpe, hole))
 
     /**
       * Formats the given formal parameters in `spec`.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -518,8 +518,8 @@ object SemanticTokensProvider {
     */
   private def visitType(tpe0: Type): Iterator[SemanticToken] = tpe0 match {
     case Type.KindedVar(_, loc) =>
-      // TODO: The source location of Type.KindedVar is associated with its declaration, not its use.
-      Iterator.empty
+      val t = SemanticToken(SemanticTokenType.TypeParameter, Nil, loc)
+      Iterator(t)
 
     case Type.Ascribe(tpe, _, _) =>
       visitType(tpe)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -629,9 +629,9 @@ object SemanticTokensProvider {
     * Returns all semantic tokens in the given type parameter `tparam0`.
     */
   private def visitTypeParam(tparam0: TypedAst.TypeParam): Iterator[SemanticToken] = tparam0 match {
-    case TypeParam(ident, _, _) =>
-      // TODO: Disabled until type variables are fixed.
-      Iterator.empty
+    case TypeParam(_, sym, _) =>
+      val t = SemanticToken(SemanticTokenType.TypeParameter, Nil, sym.loc)
+      Iterator(t)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -158,7 +158,7 @@ object SemanticTokensProvider {
     case TypedAst.Enum(_, _, _, sym, tparams, derives, cases, _, _, _) =>
       val t = SemanticToken(SemanticTokenType.Enum, Nil, sym.loc)
       val st1 = Iterator(t)
-      val st2 = tparams.flatMap(visitTypeParam).iterator
+      val st2 = visitTypeParams(tparams)
       val st3 = Iterator(derives: _*).map {
         case Ast.Derivation(_, loc) => SemanticToken(SemanticTokenType.Class, Nil, loc)
       }
@@ -183,11 +183,12 @@ object SemanticTokensProvider {
   private def visitDef(defn0: TypedAst.Def): Iterator[SemanticToken] = {
     val t = SemanticToken(SemanticTokenType.Function, Nil, defn0.sym.loc)
     val st1 = Iterator(t)
-    val st2 = visitFormalParams(defn0.spec.fparams)
-    val st3 = visitType(defn0.spec.retTpe)
-    val st4 = defn0.spec.declaredScheme.constraints.flatMap(visitTypeConstraint)
-    val st5 = visitExp(defn0.impl.exp)
-    st1 ++ st2 ++ st3 ++ st4 ++ st5
+    val st2 = visitTypeParams(defn0.spec.tparams)
+    val st3 = visitFormalParams(defn0.spec.fparams)
+    val st4 = visitType(defn0.spec.retTpe)
+    val st5 = defn0.spec.declaredScheme.constraints.flatMap(visitTypeConstraint)
+    val st6 = visitExp(defn0.impl.exp)
+    st1 ++ st2 ++ st3 ++ st4 ++ st5 ++ st6
   }
 
   /**
@@ -197,10 +198,11 @@ object SemanticTokensProvider {
     case TypedAst.Sig(sym, spec, impl) =>
       val t = SemanticToken(SemanticTokenType.Function, Nil, sig0.sym.loc)
       val st1 = Iterator(t)
-      val st2 = visitFormalParams(spec.fparams)
-      val st3 = visitType(spec.retTpe)
-      val st4 = impl.map(impl => visitExp(impl.exp)).getOrElse(Iterator.empty)
-      st1 ++ st2 ++ st3 ++ st4
+      val st2 = visitTypeParams(spec.tparams)
+      val st3 = visitFormalParams(spec.fparams)
+      val st4 = visitType(spec.retTpe)
+      val st5 = impl.map(impl => visitExp(impl.exp)).getOrElse(Iterator.empty)
+      st1 ++ st2 ++ st3 ++ st4 ++ st5
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -313,5 +313,5 @@ object KindedAst {
 
   case class SelectChannelRule(sym: Symbol.VarSym, chan: KindedAst.Expression, exp: KindedAst.Expression)
 
-  case class TypeParam(name: Name.Ident, tpe: Type.KindedVar, loc: SourceLocation)
+  case class TypeParam(name: Name.Ident, sym: Symbol.KindedTypeVarSym, loc: SourceLocation)
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -357,7 +357,7 @@ object NamedAst {
 
   }
 
-  case class Scheme(quantifiers: List[ast.Type.UnkindedVar], tconstrs: List[NamedAst.TypeConstraint], base: NamedAst.Type)
+  case class Scheme(quantifiers: List[Symbol.UnkindedTypeVarSym], tconstrs: List[NamedAst.TypeConstraint], base: NamedAst.Type)
 
   sealed trait TypeParams {
     val tparams: List[NamedAst.TypeParam]
@@ -404,16 +404,16 @@ object NamedAst {
   sealed trait TypeParam {
     def name: Name.Ident
 
-    def tpe: ast.Type.UnkindedVar
+    def sym: Symbol.UnkindedTypeVarSym
 
     def loc: SourceLocation
   }
 
   object TypeParam {
 
-    case class Kinded(name: Name.Ident, tpe: ast.Type.UnkindedVar, kind: Kind, loc: SourceLocation) extends TypeParam
+    case class Kinded(name: Name.Ident, sym: Symbol.UnkindedTypeVarSym, kind: Kind, loc: SourceLocation) extends TypeParam
 
-    case class Unkinded(name: Name.Ident, tpe: ast.Type.UnkindedVar, loc: SourceLocation) extends TypeParam
+    case class Unkinded(name: Name.Ident, sym: Symbol.UnkindedTypeVarSym, loc: SourceLocation) extends TypeParam
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -286,7 +286,7 @@ object ResolvedAst {
 
   }
 
-  case class Scheme(quantifiers: List[Type.UnkindedVar], constraints: List[ResolvedAst.TypeConstraint], base: Type)
+  case class Scheme(quantifiers: List[Symbol.UnkindedTypeVarSym], constraints: List[ResolvedAst.TypeConstraint], base: Type)
 
   sealed trait TypeParams {
     val tparams: List[ResolvedAst.TypeParam]
@@ -329,14 +329,14 @@ object ResolvedAst {
   case class SelectChannelRule(sym: Symbol.VarSym, chan: ResolvedAst.Expression, exp: ResolvedAst.Expression)
 
   sealed trait TypeParam {
-    val tpe: Type.UnkindedVar
+    val sym: Symbol.UnkindedTypeVarSym
   }
 
   object TypeParam {
 
-    case class Kinded(name: Name.Ident, tpe: Type.UnkindedVar, kind: Kind, loc: SourceLocation) extends TypeParam
+    case class Kinded(name: Name.Ident, sym: Symbol.UnkindedTypeVarSym, kind: Kind, loc: SourceLocation) extends TypeParam
 
-    case class Unkinded(name: Name.Ident, tpe: Type.UnkindedVar, loc: SourceLocation) extends TypeParam
+    case class Unkinded(name: Name.Ident, sym: Symbol.UnkindedTypeVarSym, loc: SourceLocation) extends TypeParam
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
@@ -51,7 +51,7 @@ object Scheme {
   /**
     * Instantiate one of the variables in the scheme, adding new quantifiers as needed.
     */
-  def partiallyInstantiate(sc: Scheme, quantifier: Type.KindedVar, value: Type)(implicit flix: Flix): Scheme = sc match {
+  def partiallyInstantiate(sc: Scheme, quantifier: Symbol.KindedTypeVarSym, value: Type)(implicit flix: Flix): Scheme = sc match {
     case Scheme(quantifiers, constraints, base) =>
       if (!quantifiers.contains(quantifier)) {
         throw InternalCompilerException("Quantifier not in scheme.")
@@ -82,7 +82,7 @@ object Scheme {
           case InstantiateMode.Rigid => Rigidity.Rigid
           case InstantiateMode.Mixed => Rigidity.Flexible
         }
-        macc + (tvar.sym.id -> Type.freshVar(tvar.kind, tvar.loc, rigidity, None))
+        macc + (tvar.id -> Type.freshVar(tvar.kind, tvar.loc, rigidity, None))
     }
 
     /**
@@ -119,7 +119,7 @@ object Scheme {
     */
   def generalize(tconstrs: List[Ast.TypeConstraint], tpe0: Type): Scheme = {
     val quantifiers = tpe0.typeVars ++ tconstrs.flatMap(tconstr => tconstr.arg.typeVars)
-    Scheme(quantifiers.toList, tconstrs, tpe0)
+    Scheme(quantifiers.toList.map(_.sym), tconstrs, tpe0)
   }
 
   /**
@@ -170,7 +170,7 @@ object Scheme {
 /**
   * Representation of polytypes.
   */
-case class Scheme(quantifiers: List[Type.KindedVar], constraints: List[Ast.TypeConstraint], base: Type) {
+case class Scheme(quantifiers: List[Symbol.KindedTypeVarSym], constraints: List[Ast.TypeConstraint], base: Type) {
 
   /**
     * Returns a human readable representation of the polytype.

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -257,7 +257,7 @@ object Symbol {
   /**
     * Kinded type variable symbol.
     */
-  final class KindedTypeVarSym(val id: Int, val text: Option[String], val kind: Kind, val rigidity: Rigidity, val loc: SourceLocation) extends TypeVarSym {
+  final class KindedTypeVarSym(val id: Int, val text: Option[String], val kind: Kind, val rigidity: Rigidity, val loc: SourceLocation) extends TypeVarSym with Ordered[KindedTypeVarSym] {
 
     /**
       * Returns the same symbol with the given kind.
@@ -268,12 +268,13 @@ object Symbol {
 
     override def withRigidity(newRigidity: Rigidity): KindedTypeVarSym = new KindedTypeVarSym(id, text, kind, newRigidity, loc)
 
+    override def compare(that: KindedTypeVarSym): Int = that.id - this.id
   }
 
   /**
     * Unkinded type variable symbol.
     */
-  final class UnkindedTypeVarSym(val id: Int, val text: Option[String], val rigidity: Rigidity, val loc: SourceLocation) extends TypeVarSym {
+  final class UnkindedTypeVarSym(val id: Int, val text: Option[String], val rigidity: Rigidity, val loc: SourceLocation) extends TypeVarSym with Ordered[UnkindedTypeVarSym] {
 
     override def withText(newText: Option[String]): UnkindedTypeVarSym = new UnkindedTypeVarSym(id, newText, rigidity, loc)
 
@@ -283,6 +284,8 @@ object Symbol {
       * Ascribes this UnkindedTypeVarSym with the given kind.
       */
     def ascribedWith(k: Kind): KindedTypeVarSym = new KindedTypeVarSym(id, text, k, rigidity, loc)
+
+    override def compare(that: UnkindedTypeVarSym): Int = that.id - this.id
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -435,6 +435,6 @@ object TypedAst {
 
   case class SelectChannelRule(sym: Symbol.VarSym, chan: TypedAst.Expression, exp: TypedAst.Expression)
 
-  case class TypeParam(name: Name.Ident, tpe: Type.KindedVar, loc: SourceLocation)
+  case class TypeParam(name: Name.Ident, sym: Symbol.KindedTypeVarSym, loc: SourceLocation)
 
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -58,12 +58,12 @@ object TypeError {
     def explain(formatter: Formatter): Option[String] = Some({
       val newLineAndIndent: String = System.lineSeparator() + "  "
 
-      def fmtTypeVar(tvar: Type, declared: Boolean): String = {
+      def fmtTypeVar(tvar: Symbol.KindedTypeVarSym, declared: Boolean): String = {
         val color = if (declared) formatter.cyan _ else formatter.magenta _
-        s"${color(FormatType.formatWellKindedType(tvar))} of kind: '${FormatKind.formatKind(tvar.kind)}'."
+        s"${color(FormatType.formatTypeVarSym(tvar))} of kind: '${FormatKind.formatKind(tvar.kind)}'."
       }
 
-      def fmtQuantifiers(quantifiers: List[Type.Var], declared: Boolean): String = {
+      def fmtQuantifiers(quantifiers: List[Symbol.KindedTypeVarSym], declared: Boolean): String = {
         if (quantifiers.isEmpty)
           "<< no type variables >>"
         else

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatScheme.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatScheme.scala
@@ -44,7 +44,7 @@ object FormatScheme {
       if (sc.quantifiers.isEmpty)
         ""
       else
-        "∀(" + sc.quantifiers.map(FormatType.formatWellKindedType).mkString(", ") + "). "
+        "∀(" + sc.quantifiers.map(FormatType.formatTypeVarSym).mkString(", ") + "). "
 
     val typePart = FormatType.formatWellKindedType(sc.base)
 

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
@@ -30,7 +30,9 @@ object FormatType {
     }
   }
 
-  // MATT docs
+  /**
+    * Transforms the given kinded type variable symbol into a string.
+    */
   def formatTypeVarSym(sym: Symbol.KindedTypeVarSym)(implicit audience: Audience): String = {
     val tpe = Type.KindedVar(sym, SourceLocation.Unknown)
     formatWellKindedType(tpe)

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
@@ -15,7 +15,7 @@
  */
 package ca.uwaterloo.flix.language.fmt
 
-import ca.uwaterloo.flix.language.ast.{Kind, Rigidity, Type}
+import ca.uwaterloo.flix.language.ast.{Kind, Rigidity, SourceLocation, Symbol, Type}
 
 object FormatType {
   /**
@@ -28,6 +28,12 @@ object FormatType {
     } catch {
       case _: Throwable => "ERR_UNABLE_TO_FORMAT_TYPE"
     }
+  }
+
+  // MATT docs
+  def formatTypeVarSym(sym: Symbol.KindedTypeVarSym)(implicit audience: Audience): String = {
+    val tpe = Type.KindedVar(sym, SourceLocation.Unknown)
+    formatWellKindedType(tpe)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -149,7 +149,7 @@ object Deriver {
         tparams = tparams,
         fparams = List(KindedAst.FormalParam(param1, Ast.Modifiers.Empty, sc.base, loc), KindedAst.FormalParam(param2, Ast.Modifiers.Empty, sc.base, loc)),
         sc = Scheme(
-          tparams.map(_.tpe),
+          tparams.map(_.sym),
           List(Ast.TypeConstraint(eqClassSym, sc.base, loc)),
           Type.mkPureUncurriedArrow(List(sc.base, sc.base), Type.mkBool(loc), loc)
         ),
@@ -323,7 +323,7 @@ object Deriver {
         tparams = tparams,
         fparams = List(KindedAst.FormalParam(param1, Ast.Modifiers.Empty, sc.base, loc), KindedAst.FormalParam(param2, Ast.Modifiers.Empty, sc.base, loc)),
         sc = Scheme(
-          tparams.map(_.tpe),
+          tparams.map(_.sym),
           List(Ast.TypeConstraint(orderClassSym, sc.base, loc)),
           Type.mkPureUncurriedArrow(List(sc.base, sc.base), Type.mkEnum(comparisonEnumSym, Kind.Star, loc), loc)
         ),
@@ -488,7 +488,7 @@ object Deriver {
         tparams = tparams,
         fparams = List(KindedAst.FormalParam(param, Ast.Modifiers.Empty, sc.base, loc)),
         sc = Scheme(
-          tparams.map(_.tpe),
+          tparams.map(_.sym),
           List(Ast.TypeConstraint(toStringClassSym, sc.base, loc)),
           Type.mkPureArrow(sc.base, Type.mkString(loc), loc)
         ),
@@ -624,7 +624,7 @@ object Deriver {
         tparams = tparams,
         fparams = List(KindedAst.FormalParam(param, Ast.Modifiers.Empty, sc.base, loc)),
         sc = Scheme(
-          tparams.map(_.tpe),
+          tparams.map(_.sym),
           List(Ast.TypeConstraint(hashClassSym, sc.base, loc)),
           Type.mkPureArrow(sc.base, Type.mkInt32(loc), loc)
         ),
@@ -720,7 +720,7 @@ object Deriver {
     * Filters out non-star type parameters and wild type parameters.
     */
   private def getTypeConstraintsForTypeParams(tparams: List[KindedAst.TypeParam], clazz: Symbol.ClassSym, loc: SourceLocation): List[Ast.TypeConstraint] = tparams.collect {
-    case tparam if tparam.tpe.kind == Kind.Star && !tparam.name.isWild => Ast.TypeConstraint(clazz, tparam.tpe, loc)
+    case tparam if tparam.sym.kind == Kind.Star && !tparam.name.isWild => Ast.TypeConstraint(clazz, Type.KindedVar(tparam.sym, loc), loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -170,7 +170,7 @@ object Instances {
             case (Some(defn), Some(_)) if !defn.spec.mod.isOverride => InstanceError.UnmarkedOverride(defn.sym, defn.sym.loc).toFailure
             // Case 5: there is an implementation with the right modifier
             case (Some(defn), _) =>
-              val expectedScheme = Scheme.partiallyInstantiate(sig.spec.declaredScheme, clazz.tparam.tpe, inst.tpe)
+              val expectedScheme = Scheme.partiallyInstantiate(sig.spec.declaredScheme, clazz.tparam.sym, inst.tpe)
               if (Scheme.equal(expectedScheme, defn.spec.declaredScheme, root.classEnv)) {
                 // Case 5.1: the schemes match. Success!
                 ().toSuccess

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -749,21 +749,31 @@ object Kinder {
     * Performs kinding on the given type variable under the given kind environment, with `expectedKind` expected from context.
     */
   private def visitTypeVar(tvar: Type.UnkindedVar, expectedKind: Kind, kenv: KindEnv): Validation[Type.KindedVar, KindError] = tvar match {
-    case tvar@Type.UnkindedVar(sym, loc) =>
-      kenv.map.get(tvar) match {
-        // Case 1: we don't know about this kind, just ascribe it with what the context expects
-        case None => tvar.ascribedWith(expectedKind).toSuccess
-        // Case 2: we know about this kind, make sure it's behaving as we expect
-        case Some(actualKind) =>
-          unify(expectedKind, actualKind) match {
-            case Some(kind) => Type.KindedVar(sym.ascribedWith(kind), loc).toSuccess
-            case None => KindError.UnexpectedKind(expectedKind = expectedKind, actualKind = actualKind, loc = loc).toFailure
-          }
+    case Type.UnkindedVar(sym0, loc) =>
+      mapN(visitTypeVarSym(sym0, expectedKind, kenv, loc)) {
+        sym => Type.KindedVar(sym, loc)
       }
   }
 
   /**
-    * Performs kinding on the given type under the given kind environment, with `expectedKind` expected from context.
+    * Performs kinding on the given type variable symbol under the given kind environment, with `expectedKind` expected from context.
+    */
+  private def visitTypeVarSym(sym: Symbol.UnkindedTypeVarSym, expectedKind: Kind, kenv: KindEnv, loc: SourceLocation): Validation[Symbol.KindedTypeVarSym, KindError] = {
+    kenv.map.get(sym) match {
+      // Case 1: we don't know about this kind, just ascribe it with what the context expects
+      case None => sym.ascribedWith(expectedKind).toSuccess
+      // Case 2: we know about this kind, make sure it's behaving as we expect
+      case Some(actualKind) =>
+        unify(expectedKind, actualKind) match {
+          case Some(kind) => sym.ascribedWith(kind).toSuccess
+          case None => KindError.UnexpectedKind(expectedKind = expectedKind, actualKind = actualKind, loc = loc).toFailure
+        }
+  }
+}
+
+
+/**
+  * Performs kinding on the given type under the given kind environment, with `expectedKind` expected from context.
     * This is roughly analogous to the reassembly of expressions under a type environment, except that:
     * - Kind errors may be discovered here as they may not have been found during inference (or inference may not have happened at all).
     */
@@ -793,7 +803,7 @@ object Kinder {
       taenv(cst.sym) match {
         case KindedAst.TypeAlias(_, _, _, tparams, tpe, _) =>
           val argsVal = traverse(tparams.zip(args0)) {
-            case (tparam, arg) => visitType(arg, tparam.tpe.kind, kenv, taenv, root)
+            case (tparam, arg) => visitType(arg, tparam.sym.kind, kenv, taenv, root)
           }
           val tpeVal = visitType(t0, tpe.kind, kenv, taenv, root)
           flatMapN(argsVal, tpeVal) {
@@ -812,7 +822,7 @@ object Kinder {
   private def visitScheme(sc: ResolvedAst.Scheme, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[Scheme, KindError] = sc match {
     case ResolvedAst.Scheme(quantifiers0, constraints0, base0) =>
       for {
-        quantifiers <- Validation.traverse(quantifiers0)(visitTypeVar(_, Kind.Wild, kenv))
+        quantifiers <- Validation.traverse(quantifiers0)(sym => visitTypeVarSym(sym, Kind.Wild, kenv, sym.loc))
         constraints <- Validation.traverse(constraints0)(visitTypeConstraint(_, kenv, taenv, root))
         base <- visitType(base0, Kind.Star, kenv, taenv, root)
       } yield Scheme(quantifiers, constraints, base)
@@ -847,11 +857,11 @@ object Kinder {
     */
   private def visitTypeParam(tparam: ResolvedAst.TypeParam, kenv: KindEnv): Validation[KindedAst.TypeParam, KindError] = tparam match {
     case ResolvedAst.TypeParam.Kinded(name, tpe0, _, loc) =>
-      mapN(visitTypeVar(tpe0, Kind.Wild, kenv)) {
+      mapN(visitTypeVarSym(tpe0, Kind.Wild, kenv, loc)) {
         tpe => KindedAst.TypeParam(name, tpe, loc)
       }
     case ResolvedAst.TypeParam.Unkinded(name, tpe0, loc) =>
-      mapN(visitTypeVar(tpe0, Kind.Wild, kenv)) {
+      mapN(visitTypeVarSym(tpe0, Kind.Wild, kenv, loc)) {
         tpe => KindedAst.TypeParam(name, tpe, loc)
       }
   }
@@ -936,7 +946,7 @@ object Kinder {
   private def inferType(tpe: Type, expectedKind: Kind, kenv0: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindEnv, KindError] = tpe.baseType match {
     // Case 1: the type constructor is a variable: all args are * and the constructor is * -> * -> * ... -> expectedType
     case tvar: Type.UnkindedVar =>
-      val kind = kenv0.map.get(tvar) match {
+      val kind = kenv0.map.get(tvar.sym) match {
         // Case 1.1: the type is not in the kenv: guess that it is Star -> Star -> ... -> ???.
         case None =>
           tpe.typeArguments.foldLeft(expectedKind) {
@@ -946,7 +956,7 @@ object Kinder {
         case Some(k) => k
       }
 
-      Validation.fold(tpe.typeArguments, KindEnv.singleton(tvar -> kind)) {
+      Validation.fold(tpe.typeArguments, KindEnv.singleton(tvar.sym -> kind)) {
         case (acc, targ) => flatMapN(inferType(targ, Kind.Star, kenv0, taenv, root)) {
           kenv => acc ++ kenv
         }
@@ -966,7 +976,7 @@ object Kinder {
 
     case Type.Alias(cst, args, tpe, loc) =>
       val alias = taenv(cst.sym)
-      val tparamKinds = alias.tparams.map(_.tpe.kind)
+      val tparamKinds = alias.tparams.map(_.sym.kind)
 
       Validation.fold(args.zip(tparamKinds), KindEnv.empty) {
         case (acc, (targ, kind)) => flatMapN(inferType(targ, kind, kenv0, taenv, root)) {
@@ -1012,7 +1022,7 @@ object Kinder {
   private def getKindEnvFromKindedTypeParams(tparams0: ResolvedAst.TypeParams.Kinded)(implicit flix: Flix): KindEnv = tparams0 match {
     case ResolvedAst.TypeParams.Kinded(tparams) =>
       // no chance of collision
-      val map = tparams.foldLeft(Map.empty[Type.UnkindedVar, Kind]) {
+      val map = tparams.foldLeft(Map.empty[Symbol.UnkindedTypeVarSym, Kind]) {
         case (acc, ResolvedAst.TypeParam.Kinded(_, tpe, kind, _)) =>
           acc + (tpe -> kind)
       }
@@ -1025,7 +1035,7 @@ object Kinder {
   private def getStarKindEnvForTypeParams(tparams0: ResolvedAst.TypeParams.Unkinded)(implicit flix: Flix): KindEnv = tparams0 match {
     case ResolvedAst.TypeParams.Unkinded(tparams) =>
       // no chance of collision
-      val map = tparams.foldLeft(Map.empty[Type.UnkindedVar, Kind]) {
+      val map = tparams.foldLeft(Map.empty[Symbol.UnkindedTypeVarSym, Kind]) {
         case (acc, ResolvedAst.TypeParam.Unkinded(_, tpe, _)) =>
           acc + (tpe -> Kind.Star)
       }
@@ -1039,7 +1049,7 @@ object Kinder {
     case ResolvedAst.Enum(_, _, _, _, tparams, _, _, _, _, _) =>
       val kenv = getKindEnvFromTypeParamsDefaultStar(tparams)
       tparams.tparams.foldRight(Kind.Star: Kind) {
-        case (tparam, acc) => kenv.map(tparam.tpe) ->: acc
+        case (tparam, acc) => kenv.map(tparam.sym) ->: acc
       }
   }
 
@@ -1081,7 +1091,7 @@ object Kinder {
     /**
       * Returns a kind environment consisting of a single mapping.
       */
-    def singleton(pair: (Type.UnkindedVar, Kind)): KindEnv = KindEnv(Map(pair))
+    def singleton(pair: (Symbol.UnkindedTypeVarSym, Kind)): KindEnv = KindEnv(Map(pair))
 
     /**
       * Merges all the given kind environments.
@@ -1108,11 +1118,11 @@ object Kinder {
     case _ => None
   }
 
-  private case class KindEnv(map: Map[Type.UnkindedVar, Kind]) {
+  private case class KindEnv(map: Map[Symbol.UnkindedTypeVarSym, Kind]) {
     /**
       * Adds the given mapping to the kind environment.
       */
-    def +(pair: (Type.UnkindedVar, Kind)): Validation[KindEnv, KindError] = pair match {
+    def +(pair: (Symbol.UnkindedTypeVarSym, Kind)): Validation[KindEnv, KindError] = pair match {
       case (tvar, kind) => map.get(tvar) match {
         case Some(kind0) => unify(kind0, kind) match {
           case Some(minKind) => KindEnv(map + (tvar -> minKind)).toSuccess

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -176,8 +176,8 @@ object Namer {
             // Compute the type parameters.
             val tparams = getTypeParams(tparams0, uenv0)
 
-            val tenv = tparams.tparams.map(kv => kv.name.name -> kv.tpe.sym).toMap
-            val quantifiers = tparams.tparams.map(_.tpe).map(x => NamedAst.Type.Var(x.sym, x.loc))
+            val tenv = tparams.tparams.map(kv => kv.name.name -> kv.sym).toMap
+            val quantifiers = tparams.tparams.map(_.sym).map(sym => NamedAst.Type.Var(sym, sym.loc))
             val enumType = if (quantifiers.isEmpty)
               NamedAst.Type.Enum(sym, ident.loc)
             else {
@@ -332,12 +332,12 @@ object Namer {
       val sym = Symbol.mkClassSym(ns0, ident)
       val tparam = getTypeParam(tparams0)
       val tenv = tenv0 ++ getTypeEnv(List(tparam))
-      val tconstr = NamedAst.TypeConstraint(Name.mkQName(ident), NamedAst.Type.Var(tparam.tpe.sym, tparam.loc), sym.loc)
+      val tconstr = NamedAst.TypeConstraint(Name.mkQName(ident), NamedAst.Type.Var(tparam.sym, tparam.loc), sym.loc)
       for {
         ann <- traverse(ann)(visitAnnotation(_, Map.empty, uenv0, tenv))
         superClasses <- traverse(superClasses0)(visitTypeConstraint(_, uenv0, tenv, ns0))
         sigs <- traverse(signatures)(visitSig(_, uenv0, tenv, ns0, ident, sym, tparam))
-        laws <- traverse(laws0)(visitDef(_, uenv0, tenv, ns0, List(tconstr), List(tparam.tpe)))
+        laws <- traverse(laws0)(visitDef(_, uenv0, tenv, ns0, List(tconstr), List(tparam.sym)))
       } yield NamedAst.Class(doc, ann, mod, sym, tparam, superClasses, sigs, laws, loc)
   }
 
@@ -353,7 +353,7 @@ object Namer {
         tconstrs <- traverse(tconstrs)(visitTypeConstraint(_, uenv0, tenv, ns0))
         qualifiedClass = getClass(clazz, uenv0)
         instTconstr = NamedAst.TypeConstraint(qualifiedClass, tpe, clazz.loc)
-        defs <- traverse(defs0)(visitDef(_, uenv0, tenv, ns0, List(instTconstr), tparams.tparams.map(_.tpe)))
+        defs <- traverse(defs0)(visitDef(_, uenv0, tenv, ns0, List(instTconstr), tparams.tparams.map(_.sym)))
       } yield NamedAst.Instance(doc, mod, qualifiedClass, tpe, tconstrs, defs, loc)
   }
 
@@ -397,8 +397,8 @@ object Namer {
             case (as, exp) =>
 
               // Build the scheme, including the class type constraint.
-              val classTconstr = NamedAst.TypeConstraint(Name.mkQName(classIdent), NamedAst.Type.Var(classTparam.tpe.sym, classTparam.loc), classSym.loc)
-              val quantifiers = classTparam.tpe :: tparams.tparams.map(_.tpe)
+              val classTconstr = NamedAst.TypeConstraint(Name.mkQName(classIdent), NamedAst.Type.Var(classTparam.sym, classTparam.loc), classSym.loc)
+              val quantifiers = classTparam.sym :: tparams.tparams.map(_.sym)
               val sc = NamedAst.Scheme(quantifiers, classTconstr :: tconstrs, tpe)
 
               val sym = Symbol.mkSigSym(classSym, ident)
@@ -422,7 +422,7 @@ object Namer {
   /**
     * Performs naming on the given definition declaration `decl0` under the given environments `env0`, `uenv0`, and `tenv0`, with type constraints `tconstrs`.
     */
-  private def visitDef(decl0: WeededAst.Declaration.Def, uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName, addedTconstrs: List[NamedAst.TypeConstraint], addedQuantifiers: List[Type.UnkindedVar])(implicit flix: Flix): Validation[NamedAst.Def, NameError] = decl0 match {
+  private def visitDef(decl0: WeededAst.Declaration.Def, uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName, addedTconstrs: List[NamedAst.TypeConstraint], addedQuantifiers: List[Symbol.UnkindedTypeVarSym])(implicit flix: Flix): Validation[NamedAst.Def, NameError] = decl0 match {
     case WeededAst.Declaration.Def(doc, ann, mod, ident, tparams0, fparams0, exp, tpe0, retTpe0, eff0, tconstrs0, loc) =>
       flix.subtask(ident.name, sample = true)
 
@@ -453,7 +453,7 @@ object Namer {
             case (as, e) =>
 
               // Build the scheme, including any instance parameters or type constraints
-              val quantifiers = addedQuantifiers ::: tparams.tparams.map(_.tpe)
+              val quantifiers = addedQuantifiers ::: tparams.tparams.map(_.sym)
               val schemeTconstrs = addedTconstrs ::: tconstrs
               val sc = NamedAst.Scheme(quantifiers, schemeTconstrs, tpe)
 
@@ -1531,9 +1531,9 @@ object Namer {
     */
   private def getTypeParam(tparam0: WeededAst.TypeParam)(implicit flix: Flix): NamedAst.TypeParam = tparam0 match {
     case WeededAst.TypeParam.Kinded(ident, kind) =>
-      NamedAst.TypeParam.Kinded(ident, Type.freshUnkindedVar(ident.loc, text = Some(ident.name)), kind, ident.loc)
+      NamedAst.TypeParam.Kinded(ident, mkTypeVarSym(ident), kind, ident.loc)
     case WeededAst.TypeParam.Unkinded(ident) =>
-      NamedAst.TypeParam.Unkinded(ident, Type.freshUnkindedVar(ident.loc, text = Some(ident.name)), ident.loc)
+      NamedAst.TypeParam.Unkinded(ident, mkTypeVarSym(ident), ident.loc)
   }
 
   /**
@@ -1570,8 +1570,7 @@ object Namer {
   private def getExplicitKindedTypeParams(tparams0: List[WeededAst.TypeParam.Kinded])(implicit flix: Flix): NamedAst.TypeParams.Kinded = {
     val tparams = tparams0.map {
       case WeededAst.TypeParam.Kinded(ident, kind) =>
-        val tvar = Type.freshUnkindedVar(loc = ident.loc, text = Some(ident.name))
-        NamedAst.TypeParam.Kinded(ident, tvar, kind, ident.loc)
+        NamedAst.TypeParam.Kinded(ident, mkTypeVarSym(ident), kind, ident.loc)
     }
     NamedAst.TypeParams.Kinded(tparams)
   }
@@ -1582,8 +1581,7 @@ object Namer {
   private def getExplicitTypeParams(tparams0: List[WeededAst.TypeParam.Unkinded], uenv0: UseEnv)(implicit flix: Flix): NamedAst.TypeParams.Unkinded = {
     val tparams = tparams0.map {
       case WeededAst.TypeParam.Unkinded(ident) =>
-        val tvar = Type.freshUnkindedVar(ident.loc, text = Some(ident.name))
-        NamedAst.TypeParam.Unkinded(ident, tvar, ident.loc)
+        NamedAst.TypeParam.Unkinded(ident, mkTypeVarSym(ident), ident.loc)
     }
     NamedAst.TypeParams.Unkinded(tparams)
   }
@@ -1594,7 +1592,7 @@ object Namer {
   private def getImplicitTypeParamsFromTypes(types: List[WeededAst.Type])(implicit flix: Flix): NamedAst.TypeParams.Unkinded = {
     val tvars = types.flatMap(freeVars).distinct
     val tparams = tvars.map {
-      tvar => NamedAst.TypeParam.Unkinded(tvar, Type.freshUnkindedVar(tvar.loc, text = Some(tvar.name)), tvar.loc)
+      ident => NamedAst.TypeParam.Unkinded(ident, mkTypeVarSym(ident), ident.loc)
     }
     NamedAst.TypeParams.Unkinded(tparams)
   }
@@ -1612,7 +1610,7 @@ object Namer {
     val returnTvars = freeVarsInTenv(tpe, tenv)
 
     val tparams = (fparamTvars ++ returnTvars).distinct.map {
-      tvar => NamedAst.TypeParam.Unkinded(tvar, Type.freshUnkindedVar(tvar.loc, text = Some(tvar.name)), tvar.loc)
+      ident => NamedAst.TypeParam.Unkinded(ident, mkTypeVarSym(ident), ident.loc)
     }
 
     NamedAst.TypeParams.Unkinded(tparams)
@@ -1632,7 +1630,7 @@ object Namer {
     * Returns a type environment constructed from the given type parameters `tparams0`.
     */
   private def getTypeEnv(tparams0: List[NamedAst.TypeParam]): Map[String, Symbol.UnkindedTypeVarSym] = {
-    tparams0.map(p => p.name.name -> p.tpe.sym).toMap
+    tparams0.map(p => p.name.name -> p.sym).toMap
   }
 
   /**
@@ -1686,6 +1684,13 @@ object Namer {
   private def getSymLocation(f: NamedAst.DefOrSig): SourceLocation = f match {
     case DefOrSig.Def(d) => d.sym.loc
     case DefOrSig.Sig(s) => s.sym.loc
+  }
+
+  /**
+    * Creates a flexible unkinded type variable symbol from the given ident.
+    */
+  private def mkTypeVarSym(ident: Name.Ident)(implicit flix: Flix): Symbol.UnkindedTypeVarSym = {
+    Symbol.freshUnkindedTypeVarSym(Some(ident.name), Rigidity.Flexible, ident.loc)
   }
 
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -396,7 +396,7 @@ object Resolver {
         for {
           t <- resolveType(tpe, taenv, ns0, root)
         } yield {
-          val freeVars = e0.tparams.tparams.map(_.tpe)
+          val freeVars = e0.tparams.tparams.map(_.sym)
           val caseType = t
           val enumType = mkUnkindedEnum(e0.sym, freeVars, e0.sym.loc)
           val base = Type.mkTag(e0.sym, tag, caseType, enumType, tpe.loc)
@@ -410,7 +410,7 @@ object Resolver {
       tpe <- resolveType(e0.tpe, taenv, ns0, root)
       derives <- derivesVal
     } yield {
-      val sc = ResolvedAst.Scheme(tparams.tparams.map(_.tpe), tconstrs, tpe)
+      val sc = ResolvedAst.Scheme(tparams.tparams.map(_.sym), tconstrs, tpe)
       ResolvedAst.Enum(e0.doc, ann, e0.mod, e0.sym, tparams, derives, cases.toMap, tpe, sc, e0.loc)
     }
   }
@@ -1706,7 +1706,7 @@ object Resolver {
       * The list of arguments must be the same length as the alias's parameters.
       */
     def applyAlias(alias: ResolvedAst.TypeAlias, args: List[Type], cstLoc: SourceLocation): Type = {
-      val map = alias.tparams.tparams.map(_.tpe).zip(args).toMap[Type.Var, Type]
+      val map = alias.tparams.tparams.map(_.sym).zip(args).toMap[Symbol.TypeVarSym, Type]
       val subst = Substitution(map)
       val tpe = subst(alias.tpe)
       val cst = Type.AliasConstructor(alias.sym, cstLoc)
@@ -2198,7 +2198,10 @@ object Resolver {
   /**
     * Construct the enum type `Sym[ts]`.
     */
-  def mkUnkindedEnum(sym: Symbol.EnumSym, ts: List[Type], loc: SourceLocation): Type = Type.mkApply(Type.Cst(TypeConstructor.UnkindedEnum(sym), loc), ts, loc)
+  def mkUnkindedEnum(sym: Symbol.EnumSym, ts: List[Symbol.UnkindedTypeVarSym], loc: SourceLocation): Type = {
+    val args = ts.map(sym => Type.UnkindedVar(sym, sym.loc))
+    Type.mkApply(Type.Cst(TypeConstructor.UnkindedEnum(sym), loc), args, loc)
+  }
 
   /**
     * Construct the type alias type constructor for the given symbol `sym` with the given kind `k`.

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/BoolUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/BoolUnification.scala
@@ -40,9 +40,9 @@ object BoolUnification {
     tpe1 match {
       case x: Type.KindedVar if x.sym.rigidity eq Rigidity.Flexible =>
         if (tpe2 eq Type.True)
-          return Ok(Substitution.singleton(x, Type.True))
+          return Ok(Substitution.singleton(x.sym, Type.True))
         if (tpe2 eq Type.False)
-          return Ok(Substitution.singleton(x, Type.False))
+          return Ok(Substitution.singleton(x.sym, Type.False))
 
       case _: Type.UnkindedVar => throw InternalCompilerException("Unexpected unkinded type variable")
       case _ => // nop
@@ -51,9 +51,9 @@ object BoolUnification {
     tpe2 match {
       case y: Type.KindedVar if y.sym.rigidity eq Rigidity.Flexible =>
         if (tpe1 eq Type.True)
-          return Ok(Substitution.singleton(y, Type.True))
+          return Ok(Substitution.singleton(y.sym, Type.True))
         if (tpe1 eq Type.False)
-          return Ok(Substitution.singleton(y, Type.False))
+          return Ok(Substitution.singleton(y.sym, Type.False))
 
       case _: Type.UnkindedVar => throw InternalCompilerException("Unexpected unkinded type variable")
       case _ => // nop
@@ -100,19 +100,19 @@ object BoolUnification {
   private def successiveVariableElimination(f: Type, fvs: List[Type.KindedVar])(implicit flix: Flix): Substitution = fvs match {
     case Nil =>
       // Determine if f is unsatisfiable when all (rigid) variables are made flexible.
-      val (_, q) = Scheme.instantiate(Scheme(f.typeVars.toList, List.empty, f), InstantiateMode.Flexible)
+      val (_, q) = Scheme.instantiate(Scheme(f.typeVars.toList.map(_.sym), List.empty, f), InstantiateMode.Flexible)
       if (!satisfiable(q))
         Substitution.empty
       else
         throw BooleanUnificationException
 
     case x :: xs =>
-      val t0 = Substitution.singleton(x, Type.False)(f)
-      val t1 = Substitution.singleton(x, Type.True)(f)
+      val t0 = Substitution.singleton(x.sym, Type.False)(f)
+      val t1 = Substitution.singleton(x.sym, Type.True)(f)
       val se = successiveVariableElimination(mkAnd(t0, t1), xs)
 
       // Investigate impact on Monomorph semantics:
-      val st = Substitution.singleton(x, mkOr(se(t0), mkAnd(x, mkNot(se(t1)))))
+      val st = Substitution.singleton(x.sym, mkOr(se(t0), mkAnd(x, mkNot(se(t1)))))
       //val st = Substitution.singleton(x, mkOr(se(t0), mkAnd(Type.freshVar(Kind.Bool, f.loc), mkNot(se(t1)))))
       st ++ se
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -33,9 +33,9 @@ object Unification {
     } else {
       (x.sym.rigidity, y.sym.rigidity) match {
         // Case 1: x is flexible
-        case (Rigidity.Flexible, _) => Result.Ok(Substitution.singleton(x, y))
+        case (Rigidity.Flexible, _) => Result.Ok(Substitution.singleton(x.sym, y))
         // Case 2: y is flexible
-        case (_, Rigidity.Flexible) => Result.Ok(Substitution.singleton(y, x))
+        case (_, Rigidity.Flexible) => Result.Ok(Substitution.singleton(y.sym, x))
         // Case 3: both variables are rigid
         case (Rigidity.Rigid, Rigidity.Rigid) => Result.Err(UnificationError.RigidVar(x, y))
       }
@@ -60,7 +60,7 @@ object Unification {
       return Result.Err(UnificationError.OccursCheck(x, tpe))
     }
 
-    Result.Ok(Substitution.singleton(x, tpe))
+    Result.Ok(Substitution.singleton(x.sym, tpe))
   }
 
   /**
@@ -152,7 +152,7 @@ object Unification {
           // Introduce a fresh type variable to represent one more level of the row.
           val restRow2 = Type.freshVar(Kind.RecordRow, tvar.loc)
           val type2 = Type.mkRecordRowExtend(field1, fieldType1, restRow2, tvar.loc)
-          val subst = Substitution.singleton(tv, type2)
+          val subst = Substitution.singleton(tv.sym, type2)
           Ok((subst, restRow2))
         }
 
@@ -198,7 +198,7 @@ object Unification {
           // Introduce a fresh type variable to represent one more level of the row.
           val restRow2 = Type.freshVar(Kind.SchemaRow, tvar.loc)
           val type2 = Type.mkSchemaRowExtend(label1, fieldType1, restRow2, tvar.loc)
-          val subst = Substitution.singleton(tv, type2)
+          val subst = Substitution.singleton(tv.sym, type2)
           Ok((subst, restRow2))
         }
 
@@ -412,7 +412,7 @@ object Unification {
     */
   def unbindVar(tvar: Type.KindedVar): InferMonad[Unit] =
     InferMonad(s => {
-      Ok((s.unbind(tvar), ()))
+      Ok((s.unbind(tvar.sym), ()))
     })
 
   /**

--- a/main/test/ca/uwaterloo/flix/language/phase/unification/TestUnification.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/unification/TestUnification.scala
@@ -59,82 +59,82 @@ class TestUnification extends FunSuite with TestUtils {
 
   test("Substitution.Singleton.01") {
     val tpe = Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc)
-    val subst = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Bool)
+    val subst = Substitution.singleton(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), Type.Bool)
     assertResult(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc))(subst(tpe))
   }
 
   test("Substitution.Singleton.02") {
     val tpe = Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc)
-    val subst = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Bool)
+    val subst = Substitution.singleton(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), Type.Bool)
     assertResult(Type.Bool)(subst(tpe))
   }
 
   test("Substitution.Singleton.05") {
     val tpe = Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc)
-    val subst = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc))
+    val subst = Substitution.singleton(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc))
     assertResult(Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc))(subst(tpe))
   }
 
   test("Substitution.++.01") {
-    val subst1 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Bool)
-    val subst2 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Char)
+    val subst1 = Substitution.singleton(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), Type.Bool)
+    val subst2 = Substitution.singleton(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), Type.Char)
 
     val tpe = Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc)
     assertResult(Type.Bool)((subst1 ++ subst2) (tpe))
   }
 
   test("Substitution.++.02") {
-    val subst1 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Bool)
-    val subst2 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Char)
+    val subst1 = Substitution.singleton(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), Type.Bool)
+    val subst2 = Substitution.singleton(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), Type.Char)
 
     val tpe = Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc)
     assertResult(Type.Char)((subst1 ++ subst2) (tpe))
   }
 
   test("Substitution.++.03") {
-    val subst1 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Bool)
-    val subst2 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Char)
+    val subst1 = Substitution.singleton(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), Type.Bool)
+    val subst2 = Substitution.singleton(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), Type.Char)
 
     val tpe = Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc)
     assertResult(Type.Bool)((subst1 ++ subst2) (tpe))
   }
 
   test("Substitution.++.04") {
-    val subst1 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Bool)
-    val subst2 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Char)
+    val subst1 = Substitution.singleton(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), Type.Bool)
+    val subst2 = Substitution.singleton(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), Type.Char)
 
     val tpe = Type.mkPureArrow(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc), loc)
     assertResult(Type.mkPureArrow(Type.Bool, Type.Char, loc))((subst1 ++ subst2) (tpe))
   }
 
   test("Substitution.@@.01") {
-    val subst1 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Bool)
-    val subst2 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Char)
+    val subst1 = Substitution.singleton(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), Type.Bool)
+    val subst2 = Substitution.singleton(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), Type.Char)
 
     val tpe = Type.mkPureArrow(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc), loc)
     assertResult(Type.mkPureArrow(Type.Bool, Type.Char, loc))((subst2 @@ subst1) (tpe))
   }
 
   test("Substitution.@@.02") {
-    val subst1 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Bool)
-    val subst2 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Char)
+    val subst1 = Substitution.singleton(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), Type.Bool)
+    val subst2 = Substitution.singleton(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), Type.Char)
 
     val tpe = Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc)
     assertResult(Type.Bool)((subst2 @@ subst1) (tpe))
   }
 
   test("Substitution.@@.03") {
-    val subst1 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc))
-    val subst2 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Bool)
+    val subst1 = Substitution.singleton(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc))
+    val subst2 = Substitution.singleton(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), Type.Bool)
 
     val tpe = Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc)
     assertResult(Type.Bool)((subst2 @@ subst1) (tpe))
   }
 
   test("Substitution.@@.04") {
-    val subst1 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc))
-    val subst2 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.KindedVar(new Symbol.KindedTypeVarSym(3, None, Kind.Star, Rigidity.Flexible, loc), loc))
-    val subst3 = Substitution.singleton(Type.KindedVar(new Symbol.KindedTypeVarSym(3, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.Bool)
+    val subst1 = Substitution.singleton(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc))
+    val subst2 = Substitution.singleton(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), Type.KindedVar(new Symbol.KindedTypeVarSym(3, None, Kind.Star, Rigidity.Flexible, loc), loc))
+    val subst3 = Substitution.singleton(new Symbol.KindedTypeVarSym(3, None, Kind.Star, Rigidity.Flexible, loc), Type.Bool)
 
     val tpe = Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc)
     assertResult(Type.Bool)((subst3 @@ (subst2 @@ subst1)) (tpe))
@@ -388,9 +388,9 @@ class TestUnification extends FunSuite with TestUtils {
     val res3 = Unification.unifyTypeM(Type.KindedVar(new Symbol.KindedTypeVarSym(3, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.mkTuple(List(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc), Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc)), loc), loc)
     val result = seqM(List(res1, res2, res3)).run(subst0)
     val (subst, tpe) = result.get
-    assertResult(Type.Bool)(subst.m(Type.KindedVar(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc), loc)))
-    assertResult(Type.Char)(subst.m(Type.KindedVar(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc), loc)))
-    assertResult(Type.mkTuple(List(Type.Bool, Type.Char), loc))(subst.m(Type.KindedVar(new Symbol.KindedTypeVarSym(3, None, Kind.Star, Rigidity.Flexible, loc), loc)))
+    assertResult(Type.Bool)(subst.m(new Symbol.KindedTypeVarSym(1, None, Kind.Star, Rigidity.Flexible, loc)))
+    assertResult(Type.Char)(subst.m(new Symbol.KindedTypeVarSym(2, None, Kind.Star, Rigidity.Flexible, loc)))
+    assertResult(Type.mkTuple(List(Type.Bool, Type.Char), loc))(subst.m(new Symbol.KindedTypeVarSym(3, None, Kind.Star, Rigidity.Flexible, loc)))
   }
 
   private def isOk[T, E](r: Result[T, E]) = r match {


### PR DESCRIPTION
- changes type parameters to use `TypeVarSym`s instead of `TypeVar`s
- changes scheme quantifiers to use `TypeVarSym`s instead of `TypeVar`s
- changes substitution to use `TypeVarSym`s instead of `TypeVar`s
- adds semantic token for type variable

fixes #2510 