### PR TITLE
refactor: clean up `Namer`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -85,7 +85,7 @@ object SemanticTokensProvider {
     //
     // Construct an iterator of the semantic tokens from type aliases.
     //
-    val typeAliasTokens = root.typealiases.flatMap {
+    val typeAliasTokens = root.typeAliases.flatMap {
       case (_, decl) if include(uri, decl.loc) => visitTypeAlias(decl)
       case _ => Nil
     }

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -27,7 +27,7 @@ object NamedAst {
                   instances: Map[Name.NName, Map[String, List[NamedAst.Instance]]],
                   defsAndSigs: Map[Name.NName, Map[String, NamedAst.DefOrSig]],
                   enums: Map[Name.NName, Map[String, NamedAst.Enum]],
-                  typealiases: Map[Name.NName, Map[String, NamedAst.TypeAlias]],
+                  typeAliases: Map[Name.NName, Map[String, NamedAst.TypeAlias]],
                   entryPoint: Option[Symbol.DefnSym],
                   reachable: Set[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -27,7 +27,7 @@ object ResolvedAst {
                   instances: Map[Symbol.ClassSym, List[ResolvedAst.Instance]],
                   defs: Map[Symbol.DefnSym, ResolvedAst.Def],
                   enums: Map[Symbol.EnumSym, ResolvedAst.Enum],
-                  typealiases: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias],
+                  typeAliases: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias],
                   taOrder: List[Symbol.TypeAliasSym],
                   entryPoint: Option[Symbol.DefnSym],
                   reachable: Set[Symbol.DefnSym],

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -29,7 +29,7 @@ object TypedAst {
                   sigs: Map[Symbol.SigSym, TypedAst.Sig],
                   defs: Map[Symbol.DefnSym, TypedAst.Def],
                   enums: Map[Symbol.EnumSym, TypedAst.Enum],
-                  typealiases: Map[Symbol.TypeAliasSym, TypedAst.TypeAlias],
+                  typeAliases: Map[Symbol.TypeAliasSym, TypedAst.TypeAlias],
                   entryPoint: Option[Symbol.DefnSym],
                   reachable: Set[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],

--- a/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
@@ -105,7 +105,7 @@ object Documentor {
     //
     // Type Aliases.
     //
-    val typeAliasesByNS = root.typealiases.values.groupBy(getNameSpace).flatMap {
+    val typeAliasesByNS = root.typeAliases.values.groupBy(getNameSpace).flatMap {
       case (ns, decls) =>
         val filtered = decls.filter(_.mod.isPublic).toList
         val sorted = filtered.sortBy(_.sym.name)

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -125,7 +125,7 @@ object Kinder {
   private def visitTypeAliases(aliases: List[Symbol.TypeAliasSym], root: ResolvedAst.Root)(implicit flix: Flix): Validation[Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], KindError] = {
     Validation.fold(aliases, Map.empty[Symbol.TypeAliasSym, KindedAst.TypeAlias]) {
       case (taenv, sym) =>
-        val alias = root.typealiases(sym)
+        val alias = root.typeAliases(sym)
         visitTypeAlias(alias, taenv, root) map {
           kind => taenv + (sym -> kind)
         }

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -137,7 +137,7 @@ object Namer {
       /*
      * Definition.
      */
-      case decl@WeededAst.Declaration.Def(doc, ann, mod, ident, tparams0, fparams0, exp, tpe, retTpe, eff0, tconstrs, loc) =>
+      case decl@WeededAst.Declaration.Def(_, _, _, ident, _, _, _, _, _, _, _, _) =>
         // Check if the definition already exists.
         val defsAndSigs = prog0.defsAndSigs.getOrElse(ns0, Map.empty)
         defsAndSigs.get(ident.name) match {
@@ -166,7 +166,7 @@ object Namer {
       /*
      * Enum.
      */
-      case enum0@WeededAst.Declaration.Enum(doc, ann, mod, ident, tparams0, derives, cases, loc) =>
+      case enum0@WeededAst.Declaration.Enum(_, _, _, ident, _, _, _, _) =>
         val enums0 = prog0.enums.getOrElse(ns0, Map.empty)
         lookupTypeOrClass(ident, ns0, prog0) match {
           case LookupResult.NotDefined =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -55,7 +55,7 @@ object Resolver {
   def run(root: NamedAst.Root, oldRoot: ResolvedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Validation[ResolvedAst.Root, ResolutionError] = flix.phase("Resolver") {
 
     // Type aliases must be processed first in order to provide a `taenv` for looking up type alias symbols.
-    flatMapN(resolveTypeAliases(root.typealiases, root)) {
+    flatMapN(resolveTypeAliases(root.typeAliases, root)) {
       case (taenv, taOrder) =>
 
         val classesVal = resolveClasses(root, taenv, oldRoot, changeSet)
@@ -1607,10 +1607,10 @@ object Resolver {
         case None =>
           // Case 1: The type alias was not found. Report an error.
           ResolutionError.UndefinedName(qname, ns0, loc).toFailure
-        case Some(typealias) =>
+        case Some(typeAlias) =>
           // Case 2: The type alias was found. Use it.
           for {
-            t <- getTypeAliasTypeIfAccessible(typealias, ns0, root, loc)
+            t <- getTypeAliasTypeIfAccessible(typeAlias, ns0, root, loc)
             ts <- traverse(targs)(semiResolveType(_, ns0, root))
             r <- semiResolveType(rest, ns0, root)
             app = Type.mkApply(t, ts, loc)
@@ -1793,7 +1793,7 @@ object Resolver {
       */
     def lookupIn(ns: Name.NName): EnumOrTypeAliasLookupResult = {
       val enumsInNamespace = root.enums.getOrElse(ns, Map.empty)
-      val aliasesInNamespace = root.typealiases.getOrElse(ns, Map.empty)
+      val aliasesInNamespace = root.typeAliases.getOrElse(ns, Map.empty)
       (enumsInNamespace.get(qname.ident.name), aliasesInNamespace.get(qname.ident.name)) match {
         case (None, None) =>
           // Case 1: name not found
@@ -1846,15 +1846,15 @@ object Resolver {
   private def lookupTypeAlias(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Option[NamedAst.TypeAlias] = {
     if (qname.isUnqualified) {
       // Case 1: The name is unqualified. Lookup in the current namespace.
-      val typeAliasesInNamespace = root.typealiases.getOrElse(ns0, Map.empty)
+      val typeAliasesInNamespace = root.typeAliases.getOrElse(ns0, Map.empty)
       typeAliasesInNamespace.get(qname.ident.name) orElse {
         // Case 1.1: The name was not found in the current namespace. Try the root namespace.
-        val typeAliasesInRootNS = root.typealiases.getOrElse(Name.RootNS, Map.empty)
+        val typeAliasesInRootNS = root.typeAliases.getOrElse(Name.RootNS, Map.empty)
         typeAliasesInRootNS.get(qname.ident.name)
       }
     } else {
       // Case 2: The name is qualified. Look it up in its namespace.
-      root.typealiases.getOrElse(qname.namespace, Map.empty).get(qname.ident.name)
+      root.typeAliases.getOrElse(qname.namespace, Map.empty).get(qname.ident.name)
     }
   }
 


### PR DESCRIPTION
Introduces a couple of helpers to make the top-level visitor a little cleaner and more regular.