### PR TITLE
refactor: replace Entity.TypeCon with Entity.Type in LSP

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Entity.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Entity.scala
@@ -15,7 +15,8 @@
  */
 package ca.uwaterloo.flix.api.lsp
 
-import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
+import ca.uwaterloo.flix.language.ast
+import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, TypedAst}
 
 sealed trait Entity {
   def loc: SourceLocation
@@ -66,10 +67,12 @@ object Entity {
   }
 
   // TODO: Split this into LetBound and SelectBound?
-  case class LocalVar(sym: Symbol.VarSym, tpe: Type) extends Entity {
+  case class LocalVar(sym: Symbol.VarSym, tpe: ast.Type) extends Entity {
     def loc: SourceLocation = sym.loc
   }
 
-  case class TypeCon(tc: TypeConstructor, loc: SourceLocation) extends Entity
+  case class Type(t: ast.Type) extends Entity {
+    def loc: SourceLocation = t.loc
+  }
 
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.api.lsp
 
 import ca.uwaterloo.flix.language.ast.TypedAst._
-import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
+import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, Type, TypedAst}
 import ca.uwaterloo.flix.util.collection.MultiMap
 
 import scala.collection.mutable.ArrayBuffer
@@ -79,9 +79,9 @@ object Index {
   def occurrenceOf(pred: Name.Pred): Index = empty + Entity.Pred(pred)
 
   /**
-    * Returns an index for the given `tpe0`.
+    * Returns an index for the given type `t`.
     */
-  def occurrenceOf(tc: TypeConstructor, loc: SourceLocation): Index = empty + Entity.TypeCon(tc, loc)
+  def occurrenceOf(t: Type): Index = empty + Entity.Type(t)
 
   /**
     * Returns an index for the given local variable `sym0`.

--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -427,9 +427,9 @@ object Indexer {
       case TypeConstructor.Arrow(_) =>
         // We do not index arrow constructors.
         Index.empty
-      case TypeConstructor.RecordRowExtend(field) => Index.occurrenceOf(tc, loc) ++ Index.useOf(field)
-      case TypeConstructor.SchemaRowExtend(pred) => Index.occurrenceOf(tc, loc) ++ Index.useOf(pred)
-      case _ => Index.occurrenceOf(tc, loc)
+      case TypeConstructor.RecordRowExtend(field) => Index.occurrenceOf(tpe0) ++ Index.useOf(field)
+      case TypeConstructor.SchemaRowExtend(pred) => Index.occurrenceOf(tpe0) ++ Index.useOf(pred)
+      case _ => Index.occurrenceOf(tpe0)
     }
     case Type.Apply(tpe1, tpe2, _) => visitType(tpe1) ++ visitType(tpe2)
     case Type.Alias(_, _, tpe, _) => visitType(tpe) // TODO index TypeAlias

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.api.lsp.provider
 
 import ca.uwaterloo.flix.api.lsp.{Entity, Index, Location, Position}
 import ca.uwaterloo.flix.language.ast.TypedAst.{Expression, Pattern, Root}
-import ca.uwaterloo.flix.language.ast.{Name, Symbol, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.{Name, Symbol, Type, TypeConstructor}
 import org.json4s.JsonAST.JObject
 import org.json4s.JsonDSL._
 
@@ -61,10 +61,13 @@ object FindReferencesProvider {
 
         case Entity.LocalVar(sym, _) => findVarReferences(sym)
 
-        case Entity.TypeCon(tc, loc) => tc match {
-          case TypeConstructor.RecordRowExtend(field) => findFieldReferences(field)
-          case TypeConstructor.SchemaRowExtend(pred) => findPredReferences(pred)
-          case TypeConstructor.KindedEnum(sym, _) => findEnumReferences(sym)
+        case Entity.Type(t) => t match {
+          case Type.Cst(tc, _) => tc match {
+            case TypeConstructor.RecordRowExtend(field) => findFieldReferences(field)
+            case TypeConstructor.SchemaRowExtend(pred) => findPredReferences(pred)
+            case TypeConstructor.KindedEnum(sym, _) => findEnumReferences(sym)
+            case _ => mkNotFound(uri, pos)
+          }
           case _ => mkNotFound(uri, pos)
         }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.api.lsp.provider
 
 import ca.uwaterloo.flix.api.lsp.{Entity, Index, LocationLink, Position}
-import ca.uwaterloo.flix.language.ast.TypeConstructor
+import ca.uwaterloo.flix.language.ast.{Type, TypeConstructor}
 import ca.uwaterloo.flix.language.ast.TypedAst.{Expression, Pattern, Root}
 import org.json4s.JsonAST.JObject
 import org.json4s.JsonDSL._
@@ -55,8 +55,8 @@ object GotoProvider {
           case _ => mkNotFound(uri, pos)
         }
 
-        case Entity.TypeCon(tc, loc) => tc match {
-          case TypeConstructor.KindedEnum(sym, _) =>
+        case Entity.Type(t) => t match {
+          case Type.Cst(TypeConstructor.KindedEnum(sym, _), loc) =>
             ("status" -> "success") ~ ("result" -> LocationLink.fromEnumSym(sym, loc)(root).toJSON)
 
           case _ => mkNotFound(uri, pos)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.api.lsp.provider
 
 import ca.uwaterloo.flix.api.lsp.{DocumentHighlight, DocumentHighlightKind, Entity, Index, Position, Range}
 import ca.uwaterloo.flix.language.ast.TypedAst.{Expression, Pattern, Root}
-import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, Type, TypeConstructor}
 import org.json4s.JsonAST.{JArray, JObject}
 import org.json4s.JsonDSL._
 
@@ -58,10 +58,13 @@ object HighlightProvider {
 
         case Entity.LocalVar(sym, _) => highlightVar(sym)
 
-        case Entity.TypeCon(tc, loc) => tc match {
-          case TypeConstructor.RecordRowExtend(field) => highlightField(field)
-          case TypeConstructor.SchemaRowExtend(pred) => highlightPred(pred)
-          case TypeConstructor.KindedEnum(sym, _) => highlightEnum(sym)
+        case Entity.Type(t) => t match {
+          case Type.Cst(tc, _) => tc match {
+            case TypeConstructor.RecordRowExtend(field) => highlightField(field)
+            case TypeConstructor.SchemaRowExtend(pred) => highlightPred(pred)
+            case TypeConstructor.KindedEnum(sym, _) => highlightEnum(sym)
+            case _ => mkNotFound(uri, pos)
+          }
           case _ => mkNotFound(uri, pos)
         }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HoverProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HoverProvider.scala
@@ -49,7 +49,7 @@ object HoverProvider {
 
         case Entity.LocalVar(sym, tpe) => hoverType(tpe, sym.loc)
 
-        case Entity.TypeCon(tc, loc) => hoverTypeConstructor(tc, loc)
+        case Entity.Type(t) => hoverKind(t)
 
         case _ => mkNotFound(uri, pos)
       }
@@ -120,20 +120,16 @@ object HoverProvider {
     s"$t & $e"
   }
 
-  private def hoverTypeConstructor(tc: TypeConstructor, loc: SourceLocation)(implicit index: Index, root: Root): JObject = {
+  private def hoverKind(t: Type)(implicit index: Index, root: Root): JObject = {
     val markup =
       s"""```flix
-         |${formatKind(tc)}
+         |${FormatKind.formatKind(t.kind)}
          |```
          |""".stripMargin
     val contents = MarkupContent(MarkupKind.Markdown, markup)
-    val range = Range.from(loc)
+    val range = Range.from(t.loc)
     val result = ("contents" -> contents.toJSON) ~ ("range" -> range.toJSON)
     ("status" -> "success") ~ ("result" -> result)
-  }
-
-  private def formatKind(tc: TypeConstructor): String = {
-    FormatKind.formatKind(tc.kind)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/RenameProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/RenameProvider.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.api.lsp.provider
 
 import ca.uwaterloo.flix.api.lsp.{Entity, Index, Position, Range, TextEdit, WorkspaceEdit}
 import ca.uwaterloo.flix.language.ast.TypedAst.{Expression, Pattern, Root}
-import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, Type, TypeConstructor}
 import org.json4s.JsonAST.JObject
 import org.json4s.JsonDSL._
 
@@ -57,9 +57,12 @@ object RenameProvider {
 
         case Entity.LocalVar(sym, _) => renameVar(sym, newName)
 
-        case Entity.TypeCon(tc, _) => tc match {
-          case TypeConstructor.RecordRowExtend(field) => renameField(field, newName)
-          case TypeConstructor.SchemaRowExtend(pred) => renamePred(pred, newName)
+        case Entity.Type(t) => t match {
+          case Type.Cst(tc, _) => tc match {
+            case TypeConstructor.RecordRowExtend(field) => renameField(field, newName)
+            case TypeConstructor.SchemaRowExtend(pred) => renamePred(pred, newName)
+            case _ => mkNotFound(uri, pos)
+          }
           case _ => mkNotFound(uri, pos)
         }
 


### PR DESCRIPTION
Leads the way to a cleaner implementation of handling type vars in the LSP for various providers

related to #3463 