### PR TITLE
Add Record pattern matching support

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -243,6 +243,7 @@ object KindedAst {
 
     case class ArrayHeadSpread(sym: Symbol.VarSym, elms: scala.List[KindedAst.Pattern], tvar: ast.Type.KindedVar, loc: SourceLocation) extends KindedAst.Pattern
 
+    case class Record(elms: List[KindedAst.Pattern], loc: SourceLocation) extends KindedAst.Pattern
   }
 
   sealed trait ChoicePattern {

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -265,6 +265,7 @@ object NamedAst {
 
     case class ArrayHeadSpread(sym: Symbol.VarSym, elms: scala.List[NamedAst.Pattern], loc: SourceLocation) extends NamedAst.Pattern
 
+    case class Record(elms: List[NamedAst.Pattern], loc: SourceLocation) extends NamedAst.Pattern
   }
 
   sealed trait ChoicePattern

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1128,6 +1128,7 @@ object ParsedAst {
       case Pattern.ArrayTailSpread(sp1, _, _, _) => sp1
       case Pattern.FNil(sp1, _) => sp1
       case Pattern.FCons(hd, _, _, _) => hd.leftMostSourcePosition
+      case Pattern.RecordField(sp1, _, _, _) => sp1
       case Pattern.Record(sp1, _, _) => sp1
     }
 
@@ -1199,13 +1200,23 @@ object ParsedAst {
     case class FCons(hd: ParsedAst.Pattern, sp1: SourcePosition, sp2: SourcePosition, tl: ParsedAst.Pattern) extends ParsedAst.Pattern
 
     /**
+      * Record Field Pattern.
+      *
+      * @param sp1      the position of the first character in the pattern.
+      * @param name     the name of the field.
+      * @param pattern  optional pattern associated to this field.
+      * @param sp2      the position of the last character in the pattern.
+      */
+    case class RecordField(sp1: SourcePosition, name: Name.Ident, pattern: Option[ParsedAst.Pattern], sp2: SourcePosition) extends ParsedAst.Pattern
+
+    /**
       * Record Pattern.
       *
-      * @param sp1  the position of the first character in the pattern.
-      * @param elms the elements of the record, at least one.
-      * @param sp2  the position of the last character in the pattern.
+      * @param sp1    the position of the first character in the pattern.
+      * @param fields the fields of the record.
+      * @param sp2    the position of the last character in the pattern.
       */
-    case class Record(sp1: SourcePosition, elms: Seq[ParsedAst.Pattern], sp2: SourcePosition) extends ParsedAst.Pattern
+    case class Record(sp1: SourcePosition, fields: Seq[ParsedAst.Pattern.RecordField], sp2: SourcePosition) extends ParsedAst.Pattern
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1128,6 +1128,7 @@ object ParsedAst {
       case Pattern.ArrayTailSpread(sp1, _, _, _) => sp1
       case Pattern.FNil(sp1, _) => sp1
       case Pattern.FCons(hd, _, _, _) => hd.leftMostSourcePosition
+      case Pattern.Record(sp1, _, _) => sp1
     }
 
   }
@@ -1196,6 +1197,15 @@ object ParsedAst {
       * @param tl  the tail pattern.
       */
     case class FCons(hd: ParsedAst.Pattern, sp1: SourcePosition, sp2: SourcePosition, tl: ParsedAst.Pattern) extends ParsedAst.Pattern
+
+    /**
+      * Record Pattern.
+      *
+      * @param sp1  the position of the first character in the pattern.
+      * @param elms the elements of the record, at least one.
+      * @param sp2  the position of the last character in the pattern.
+      */
+    case class Record(sp1: SourcePosition, elms: Seq[ParsedAst.Pattern], sp2: SourcePosition) extends ParsedAst.Pattern
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -244,6 +244,7 @@ object ResolvedAst {
 
     case class ArrayHeadSpread(sym: Symbol.VarSym, elms: scala.List[ResolvedAst.Pattern], loc: SourceLocation) extends ResolvedAst.Pattern
 
+    case class Record(elms: List[ResolvedAst.Pattern], loc: SourceLocation) extends ResolvedAst.Pattern
   }
 
   sealed trait ChoicePattern {

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -259,6 +259,7 @@ object WeededAst {
 
     case class ArrayHeadSpread(ident: Option[Name.Ident], elms: scala.List[WeededAst.Pattern], loc: SourceLocation) extends WeededAst.Pattern
 
+    case class Record(elms: scala.List[WeededAst.Pattern], loc: SourceLocation) extends WeededAst.Pattern
   }
 
   sealed trait ChoicePattern

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -259,6 +259,8 @@ object WeededAst {
 
     case class ArrayHeadSpread(ident: Option[Name.Ident], elms: scala.List[WeededAst.Pattern], loc: SourceLocation) extends WeededAst.Pattern
 
+    case class RecordField(ident: Name.Ident, pattern: Option[WeededAst.Pattern], loc: SourceLocation) extends WeededAst.Pattern
+
     case class Record(elms: scala.List[WeededAst.Pattern], loc: SourceLocation) extends WeededAst.Pattern
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -760,6 +760,12 @@ object Kinder {
       mapN(elmsVal) {
         elms => KindedAst.Pattern.ArrayHeadSpread(sym, elms, Type.freshVar(Kind.Star, loc.asSynthetic), loc)
       }
+
+    case ResolvedAst.Pattern.Record(elms0, loc) =>
+      val elmsVal = traverse(elms0)(visitPattern(_, kenv, root))
+      mapN(elmsVal) {
+        elms => KindedAst.Pattern.Record(elms, loc)
+      }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -1002,6 +1002,8 @@ object Namer {
           m += (id.name -> sym)
           NamedAst.Pattern.ArrayHeadSpread(sym, elms map visit, loc)
       }
+
+      case WeededAst.Pattern.Record(elms, loc) => NamedAst.Pattern.Record(elms map visit, loc)
     }
 
     (visit(pat0), m.toMap)

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1189,7 +1189,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def Record: Rule1[ParsedAst.Pattern] = rule {
-      SP ~ "{" ~ optWS ~ oneOrMore(Pattern).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ "}" ~ SP ~> ParsedAst.Pattern.Record
+      SP ~ "{" ~ optWS ~ zeroOrMore(Pattern).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ "}" ~ SP ~> ParsedAst.Pattern.Record
     }
 
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1149,7 +1149,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
   object Patterns {
 
     def Simple: Rule1[ParsedAst.Pattern] = rule {
-      FNil | Tag | Lit | Tuple | Array | ArrayTailSpread | ArrayHeadSpread | Var
+      FNil | Tag | Lit | Tuple | Array | ArrayTailSpread | ArrayHeadSpread | Var | Record
     }
 
     def Var: Rule1[ParsedAst.Pattern.Var] = rule {
@@ -1188,8 +1188,12 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       Simple ~ optional(optWS ~ SP ~ operatorX("::") ~ SP ~ optWS ~ Pattern ~> ParsedAst.Pattern.FCons)
     }
 
-    def Record: Rule1[ParsedAst.Pattern] = rule {
-      SP ~ "{" ~ optWS ~ zeroOrMore(Pattern).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ "}" ~ SP ~> ParsedAst.Pattern.Record
+    def RecordField: Rule1[ParsedAst.Pattern] = rule {
+      SP ~ (Names.Field ~ optional(optWS ~ "=" ~ optWS ~ Pattern)) ~ SP ~> ParsedAst.Pattern.RecordField
+    }
+
+    def Record: Rule1[ParsedAst.Pattern.Record] = rule {
+      SP ~ "{" ~ optWS ~ zeroOrMore(RecordField).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ "}" ~ SP ~> ParsedAst.Pattern.Record
     }
 
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1188,6 +1188,10 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       Simple ~ optional(optWS ~ SP ~ operatorX("::") ~ SP ~ optWS ~ Pattern ~> ParsedAst.Pattern.FCons)
     }
 
+    def Record: Rule1[ParsedAst.Pattern] = rule {
+      SP ~ "{" ~ optWS ~ oneOrMore(Pattern).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ "}" ~ SP ~> ParsedAst.Pattern.Record
+    }
+
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1176,6 +1176,12 @@ object Resolver {
           mapN(esVal) {
             es => ResolvedAst.Pattern.ArrayHeadSpread(sym, es, loc)
           }
+
+        case NamedAst.Pattern.Record(elms, loc) =>
+          val esVal = traverse(elms)(visit)
+          mapN(esVal) {
+            es => ResolvedAst.Pattern.Record(es, loc)
+          }
       }
 
       visit(pat0)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1922,6 +1922,12 @@ object Weeder {
             WeededAst.Pattern.Tag(None, tag, pat, loc)
         }
 
+      case ParsedAst.Pattern.RecordField(sp1, ident, pattern, sp2) => pattern match {
+        case Some(pat0) => visitPattern(pat0) map (pat =>
+            WeededAst.Pattern.RecordField(ident, Some(pat), mkSL(sp1, sp2)))
+        case None => WeededAst.Pattern.RecordField(ident, None, mkSL(sp1, sp2)).toSuccess
+      }
+
       case ParsedAst.Pattern.Record(sp1, fields, sp2) =>
         traverse(fields)(visit) map (elems =>
           WeededAst.Pattern.Record(elems, mkSL(sp1, sp2)))

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1922,6 +1922,9 @@ object Weeder {
             WeededAst.Pattern.Tag(None, tag, pat, loc)
         }
 
+      case ParsedAst.Pattern.Record(sp1, fields, sp2) =>
+        traverse(fields)(visit) map (elems =>
+          WeededAst.Pattern.Record(elems, mkSL(sp1, sp2)))
     }
 
     visit(pattern)

--- a/main/test/flix/Test.Exp.Match.Record.flix
+++ b/main/test/flix/Test.Exp.Match.Record.flix
@@ -43,18 +43,18 @@ namespace Test/Exp/Match/Record {
     }
 
     @test
-    def testMatchRecord08(): Bool = match {x = 10, y = 12, { z = 11 } } {
-        case { x, y, { z } } => x == 10 && y == 12 && z == 11
+    def testMatchRecord08(): Bool = match {x = 10, y = 12, v = { z = 11 } } {
+        case { x, y, v = { z } } => x == 10 && y == 12 && z == 11
     }
 
     @test
-    def testMatchRecord09(): Bool = match {x = 10, y = 12, { z = 11 } } {
-        case { x, { z } } => x == 10 && z == 11
+    def testMatchRecord09(): Bool = match {x = 10, y = 12, v = { z = 11 } } {
+        case { x, v = { z } } => x == 10 && z == 11
     }
 
     @test
-    def testMatchRecord10(): Bool = match {x = 10, y = 12, { z = 11 } } {
-        case { x, { z } } => x == 10 && z == 11
+    def testMatchRecord10(): Bool = match {x = 10, y = 12, v = { z = 11 } } {
+        case { x, v = { z } } => x == 10 && z == 11
         case _ => false
     }
 }

--- a/main/test/flix/Test.Exp.Match.Record.flix
+++ b/main/test/flix/Test.Exp.Match.Record.flix
@@ -1,0 +1,60 @@
+namespace Test/Exp/Match/Record {
+
+    @test
+    def testMatchRecord01(): Bool = match {x = 12, y = 10} {
+        case { x, y } => x == 12 && y == 10
+        case _ => false
+    }
+
+    @test
+    def testMatchRecord02(): Bool = match {x = "a", y = "b"} {
+        case { x, y } => x == "a" && y == "b"
+        case _ => false
+    }
+
+    @test
+    def testMatchRecord03(): Bool = match {x = 12, y = 10} {
+        case { x } => x == 12
+        case _ => false
+    }
+
+    @test
+    def testMatchRecord04(): Bool = match {x = 12, y = 10} {
+        case { y } => y == 10
+        case _ => false
+    }
+
+    @test
+    def testMatchRecord05(): Bool = match {x = 12, y = 10} {
+        case { y } => y == 10
+        case { x } => false
+        case _ => false
+    }
+
+    @test
+    def testMatchRecord06(): Bool = match {y = 10, x = 12} {
+        case { x, y } => x == 12 && y == 10
+        case _ => false
+    }
+
+    @test
+    def testMatchRecord07(): Bool = match {y = 10, x = 12} {
+        case { x } => x == 12
+    }
+
+    @test
+    def testMatchRecord08(): Bool = match {x = 10, y = 12, { z = 11 } } {
+        case { x, y, { z } } => x == 10 && y == 12 && z == 11
+    }
+
+    @test
+    def testMatchRecord09(): Bool = match {x = 10, y = 12, { z = 11 } } {
+        case { x, { z } } => x == 10 && z == 11
+    }
+
+    @test
+    def testMatchRecord10(): Bool = match {x = 10, y = 12, { z = 11 } } {
+        case { x, { z } } => x == 10 && z == 11
+        case _ => false
+    }
+}


### PR DESCRIPTION
Address: #777 

Add some tests, also to discuss the design of the feature:
Do we want to allow partial matching (aka deconstruction)?

As I understand records are kind of structural types, that also can have unspecified properties (when so specified in the definition). In this regard they seem to be similar to javascript objects, and I would really like to have deconstruction for them.

By allowing partial matching we can have multiple cases (last test case) but I would expect the first that match to be taken.

Also, this syntax could be allowed for function parameters and let expressions I guess.