### PR TITLE
fix: make `Flix.scala` call `Main.class`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Bootstrap.scala
@@ -64,11 +64,13 @@ object Bootstrap {
         // And finally assign the method object to the definition.
         defn.method = method
       }
-      root.entryPoint.map { _ =>
+      // These two lookups match the condition that genMainClass has for generation.
+      root.entryPoint.flatMap(root.defs.get).map { _ =>
         val mainName = JvmOps.getMainClassType().name
         val mainClass = loadedClasses.getOrElse(mainName, throw InternalCompilerException(s"Class not found: '${mainName.toInternalName}'."))
         val mainMethods = allMethods.getOrElse(mainClass, throw InternalCompilerException(s"methods for '${mainName.toInternalName}' not found."))
         val mainMethod = mainMethods.getOrElse("main", throw InternalCompilerException(s"Cannot find 'main' method of '${mainName.toInternalName}'"))
+        // This is a specialized version of the link function in JvmBackend
         (args: Array[String]) => {
           try {
             // Call the method passing the argument array.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -226,6 +226,7 @@ object JvmBackend {
     } else {
       //
       // Loads all the generated classes into the JVM and decorates the AST.
+      // Returns the main of `Main.class` if it exists.
       //
       val main = Bootstrap.bootstrap(allClasses)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -227,29 +227,14 @@ object JvmBackend {
       //
       // Loads all the generated classes into the JVM and decorates the AST.
       //
-      Bootstrap.bootstrap(allClasses)
+      val main = Bootstrap.bootstrap(allClasses)
 
       //
       // Return the compilation result.
       //
-      new CompilationResult(root, getCompiledMain(root), getCompiledDefs(root), flix.getTotalTime, outputBytes).toSuccess
+      new CompilationResult(root, main, getCompiledDefs(root), flix.getTotalTime, outputBytes).toSuccess
     }
   }
-
-  /**
-    * Optionally returns a reference to main.
-    */
-  private def getCompiledMain(root: Root)(implicit flix: Flix): Option[Array[String] => Unit] =
-    root.entryPoint match {
-      case None => None
-      case Some(sym) => root.defs.get(sym) map { defn =>
-        (actualArgs: Array[String]) => {
-          val args: Array[AnyRef] = Array(actualArgs)
-          link(defn.sym, root).apply(args)
-          ()
-        }
-      }
-    }
 
   /**
     * Returns a map from definition symbols to executable functions (backed by JVM backend).


### PR DESCRIPTION
This PR makes `Flix.scala` call `main` on `Main.class` that calls the program main. On master both `Flix.scala` and `Main.class` calls the program main which means that mistakes in `Main.class` are hard to find since `java -jar Flix.jar ...` would not use `Main.class`.

This was discussed in #3487.