### PR TITLE
ci: add testing timeout to ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,9 @@ concurrency:
 
 jobs:
   build:
+    # Limit the build time
+    timeout-minutes: 9
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,16 +9,17 @@ concurrency:
 
 jobs:
   build:
-    # Limit the build time
-    timeout-minutes: 9
-
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out the master branch
+        uses: actions/checkout@v2
       - name: Set up JDK 1.11
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
-      - name: Build with Gradle
-        run: ./gradlew clean build
+      - name: Build with gradle
+        run: ./gradlew clean compileTestScala
+      - name: Run tests with timeout
+        timeout-minutes: 1
+        run: ./gradlew test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,5 +21,5 @@ jobs:
       - name: Build with gradle
         run: ./gradlew clean compileTestScala
       - name: Run tests with timeout
-        timeout-minutes: 1
+        timeout-minutes: 9
         run: ./gradlew test


### PR DESCRIPTION
Fixes #3500. Splits up the build and test gradle steps so that the timeout can be applied just to the tests.