### PR TITLE
fix: propogate empty row type locations in Resolver

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -771,6 +771,20 @@ object Type {
   /**
     * Constructs a RecordExtend type.
     */
+  def mkRecordRowEmpty(loc: SourceLocation): Type = {
+    Type.Cst(TypeConstructor.RecordRowEmpty, loc)
+  }
+
+  /**
+    * Constructs a SchemaExtend type.
+    */
+  def mkSchemaRowEmpty(loc: SourceLocation): Type = {
+    Type.Cst(TypeConstructor.SchemaRowEmpty, loc)
+  }
+
+  /**
+    * Constructs a RecordExtend type.
+    */
   def mkRecordRowExtend(field: Name.Field, tpe: Type, rest: Type, loc: SourceLocation): Type = {
     mkApply(Type.Cst(TypeConstructor.RecordRowExtend(field), loc), List(tpe, rest), loc)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1636,7 +1636,7 @@ object Resolver {
       }
 
     case NamedAst.Type.RecordRowEmpty(loc) =>
-      Type.RecordRowEmpty.toSuccess
+      Type.mkRecordRowEmpty(loc).toSuccess
 
     case NamedAst.Type.RecordRowExtend(field, value, rest, loc) =>
       val vVal = semiResolveType(value, ns0, root)
@@ -1652,7 +1652,7 @@ object Resolver {
       }
 
     case NamedAst.Type.SchemaRowEmpty(loc) =>
-      Type.SchemaRowEmpty.toSuccess
+      Type.mkSchemaRowEmpty(loc).toSuccess
 
     case NamedAst.Type.SchemaRowExtendWithAlias(qname, targs, rest, loc) =>
       // Lookup the type alias.

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -646,6 +646,15 @@ class TestKinder extends FunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
+  test("KindError.Def.Return.04") {
+    val input =
+      """
+        |def f(): () = ???
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError.UnexpectedKind](result)
+  }
+
   test("KindError.Def.TypeConstraint.01") {
     val input =
       """


### PR DESCRIPTION
related to #3412