### PR TITLE
refactor: clean up `Main.class`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenMainClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenMainClass.scala
@@ -19,6 +19,7 @@ package ca.uwaterloo.flix.language.phase.jvm
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.ErasedAst.{Def, Root}
 import ca.uwaterloo.flix.language.ast.{MonoType, Symbol}
+import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes._
 
@@ -28,22 +29,27 @@ import org.objectweb.asm.Opcodes._
 object GenMainClass {
 
   /**
-    * Returns the main class.
+    * Returns the main class if `root` has an entrypoint and `root.defs` has a
+    * corresponding method.
     */
   def gen()(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = getMain(root) match {
     case None => Map.empty
     case Some(defn) =>
+      checkMainType(defn)
+
       val jvmType = JvmOps.getMainClassType()
       val jvmName = jvmType.name
-      val arrowType = defn.tpe.asInstanceOf[MonoType.Arrow]
-      // returnType, giveArgs, and their use can be inlined if m_main return type is known
-      val giveArgs = arrowType.args.headOption match {
-        case None => false
-        case Some(_) => true // assume its array of string
-      }
-      val returnType = JvmOps.getErasedJvmType(arrowType.result)
-      val bytecode = genByteCode(defn.sym, jvmType, giveArgs, returnType)
+      val bytecode = genByteCode(defn.sym, jvmType)
+
       Map(jvmName -> JvmClass(jvmName, bytecode))
+  }
+
+  /**
+    * Throws `InternalCompilerException` if the type  of `defn` is not `Unit -> Unit`.
+    */
+  private def checkMainType(defn: Def): Unit = defn.tpe match {
+    case MonoType.Arrow(List(MonoType.Unit), MonoType.Unit) => ()
+    case other => throw InternalCompilerException(s"Entrypoint function should have type Unit -> Unit not '$other'")
   }
 
   /**
@@ -56,7 +62,7 @@ object GenMainClass {
     }
   }
 
-  private def genByteCode(sym: Symbol.DefnSym, jvmType: JvmType.Reference, giveArgs: Boolean, returnType: JvmType)(implicit root: Root, flix: Flix): Array[Byte] = {
+  private def genByteCode(sym: Symbol.DefnSym, jvmType: JvmType.Reference)(implicit root: Root, flix: Flix): Array[Byte] = {
     // class writer
     val visitor = AsmOps.mkClassWriter()
 
@@ -64,67 +70,65 @@ object GenMainClass {
     val superClass = JvmName.Object.toInternalName
 
     // Initialize the visitor to create a class.
-    visitor.visit(AsmOps.JavaVersion, ACC_PUBLIC + ACC_FINAL, jvmType.name.toInternalName, null, superClass, null)
+    visitor.visit(AsmOps.JavaVersion, ACC_PUBLIC + ACC_FINAL,
+      jvmType.name.toInternalName, null, superClass, null)
 
     // Source of the class
     visitor.visitSource(jvmType.name.toInternalName, null)
 
     // Emit the code for the main method
-    compileMainMethod(sym, visitor, giveArgs, returnType)
+    compileMainMethod(sym, visitor)
 
     visitor.visitEnd()
     visitor.toByteArray
   }
 
   /**
-    * Emits code for the main method in the main class. The emitted (byte)code should satisfy the following signature for the method:
-    * public static void main(String[])
+    * Emits code for the main method in the main class. The emitted (byte)code
+    * should satisfy the following signature for the method:
+    * `public static void main(String[])`
     *
-    * The method itself needs simply invoke the m_entry method which is in the root namespace.
+    * The method itself needs simply invoke the m_entrypoint method which is in
+    * the root namespace.
     *
     * The emitted code for the method should correspond to:
     *
-    * Ns.m_entry((Object)null);
+    * `public static void main(String[] args) = {`
+    *
+    * `dev.flix.runtime.Global.setArgs(args);`
+    *
+    * `Ns.m_entrypoint(Unit.INSTANCE);`
+    *
+    * `}`
     */
-  private def compileMainMethod(sym: Symbol.DefnSym, visitor: ClassWriter, giveArgs: Boolean, returnType: JvmType)(implicit root: Root, flix: Flix): Unit = {
-
-    //Get the (argument) descriptor, since the main argument is of type String[], we need to get it's corresponding descriptor
-    val argumentDescriptor = AsmOps.getArrayType(JvmType.String)
-
-    //Get the (result) descriptor, since main method returns void, we need to get the void type descriptor
-    val resultDescriptor = JvmType.Void.toDescriptor
-
-    //Emit the main method signature
-    val main = visitor.visitMethod(ACC_PUBLIC + ACC_STATIC, "main", s"($argumentDescriptor)$resultDescriptor", null, null)
+  private def compileMainMethod(sym: Symbol.DefnSym, visitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = {
+    // The required java main signature `Array[String] -> Void`.
+    val javaMainDescriptor = s"(${AsmOps.getArrayType(JvmType.String)})${JvmType.Void.toDescriptor}"
+    // `public static void main(String[] args)`.
+    val main = visitor.visitMethod(ACC_PUBLIC + ACC_STATIC, "main",
+      javaMainDescriptor, null, null)
 
     main.visitCode()
-
-    //Get the root namespace in order to get the class type when invoking m_<entry>
-    val ns = JvmOps.getNamespace(sym)
-
-    // Call Ns.m_<entry>(args)
 
     // Push the args array on the stack.
     main.visitVarInsn(ALOAD, 0)
 
-    // Save the args in `dev.flix.runtime.Global.setArgs(..)
-    main.visitMethodInsn(INVOKESTATIC, JvmName.Global.toInternalName, GenGlobalClass.SetArgsMethodName,
-      s"([${BackendObjType.String.toDescriptor})V", false)
+    // Save the args in `dev.flix.runtime.Global.setArgs(..)`.
+    val setArgsDescriptor = s"(${AsmOps.getArrayType(JvmType.String)})${JvmType.Void.toDescriptor}"
+    main.visitMethodInsn(INVOKESTATIC, JvmName.Global.toInternalName,
+      GenGlobalClass.SetArgsMethodName, setArgsDescriptor, false)
 
-    val nsClassName = JvmOps.getNamespaceClassType(ns).name.toInternalName
+    // Push `Unit` on the stack.
+    main.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName,
+      BackendObjType.Unit.InstanceField.name, BackendObjType.Unit.jvmName.toDescriptor)
+
+    // Call the `Ns.m_entrypoint` method.
+    val nsClassName = JvmOps.getNamespaceClassType(JvmOps.getNamespace(sym)).name.toInternalName
     val mainMethodName = JvmOps.getDefMethodNameInNamespaceClass(sym)
-    if (giveArgs) {
-      // give the args
-      main.visitVarInsn(ALOAD, 0)
-      main.visitMethodInsn(INVOKESTATIC, nsClassName, mainMethodName,
-        AsmOps.getMethodDescriptor(List(JvmType.Object), returnType), false)
-    } else {
-      // no args
-      main.visitMethodInsn(INVOKESTATIC, nsClassName, mainMethodName,
-        AsmOps.getMethodDescriptor(Nil, returnType), false)
-    }
-
-    // The return value is ignored
+    val erasedUnit = JvmOps.getErasedJvmType(MonoType.Unit)
+    val mainDescriptor = AsmOps.getMethodDescriptor(List(erasedUnit), erasedUnit)
+    main.visitMethodInsn(INVOKESTATIC, nsClassName, mainMethodName, mainDescriptor, false)
+    // The return value is ignored.
 
     main.visitInsn(RETURN)
     main.visitMaxs(1, 1)


### PR DESCRIPTION
`Main.class` is always
```java
public final class Main {
    public static void main(String[] var0) {
        dev.flix.runtime.Global.setArgs(var0);
        Ns.m_entrypoint(dev.flix.runtime.Unit.INSTANCE);
    }
}
```
except that `m_entrypoint` will be whatever `root.entrypoint` dictates