### PR TITLE
feat: set up for migration to effect sets

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1501,6 +1501,7 @@ object ParsedAst {
     case class Read(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
     case class Write(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
     case class Eff(sp1: SourcePosition, name: Name.QName, sp2: SourcePosition) extends ParsedAst.Effect
+    case class Impure(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Effect
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1561,30 +1561,6 @@ object ParsedAst {
     case class Eff(sp1: SourcePosition, name: Name.QName, sp2: SourcePosition) extends ParsedAst.Effect
 
     /**
-      * Effect set subtraction.
-      *
-      * @param eff1 the first effect.
-      * @param effs the other effects.
-      */
-    case class Minus(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
-
-    /**
-      * Effect set addition.
-      *
-      * @param eff1 the first effect.
-      * @param effs the other effects.
-      */
-    case class Plus(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
-
-    /**
-      * Effect set intersection.
-      *
-      * @param eff1 the first effect.
-      * @param effs the other effects.
-      */
-    case class Intersect(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
-
-    /**
       * Effect set complement.
       *
       * @param sp1 the position of the first character in the effect.
@@ -1592,6 +1568,30 @@ object ParsedAst {
       * @param sp2 the position of the last character in the effect.
       */
     case class Complement(sp1: SourcePosition, eff: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
+
+    /**
+      * Effect set addition.
+      *
+      * @param eff1 the first effect.
+      * @param effs the other effects.
+      */
+    case class Union(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
+
+    /**
+      * Effect set intersection.
+      *
+      * @param eff1 the first effect.
+      * @param effs the other effects.
+      */
+    case class Intersection(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
+
+    /**
+      * Effect set subtraction.
+      *
+      * @param eff1 the first effect.
+      * @param effs the other effects.
+      */
+    case class Difference(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1480,13 +1480,24 @@ object ParsedAst {
 
   }
 
+  // MATT docs
+  sealed trait EffectSet
+
+  object EffectSet {
+    case class Singleton(sp1: SourcePosition, eff: Effect, sp2: SourcePosition) extends EffectSet
+    case class Pure(sp1: SourcePosition, sp2: SourcePosition) extends EffectSet
+    case class Set(sp1: SourcePosition, effs: Seq[Effect], sp2: SourcePosition) extends EffectSet
+  }
+
+  // MATT docs
   sealed trait Effect
 
   object Effect {
     case class Var(sp1: SourcePosition, ident: Name.Ident, sp2: SourcePosition) extends ParsedAst.Effect
     case class Minus(sp1: SourcePosition, eff1: ParsedAst.Effect, eff2: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
-    case class Read(sp1: SourcePosition, reg: Name.Ident, sp2: SourcePosition) extends ParsedAst.Effect
-    case class Write(sp1: SourcePosition, reg: Name.Ident, sp2: SourcePosition) extends ParsedAst.Effect
+    case class Plus(sp1: SourcePosition, eff1: ParsedAst.Effect, eff2: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
+    case class Read(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
+    case class Write(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
     case class Eff(sp1: SourcePosition, name: Name.QName, sp2: SourcePosition) extends ParsedAst.Effect
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1529,6 +1529,38 @@ object ParsedAst {
     case class Var(sp1: SourcePosition, ident: Name.Ident, sp2: SourcePosition) extends ParsedAst.Effect
 
     /**
+      * Represents a read of the region variables `regs`.
+      *
+      * @param regs the region variables that are read.
+      */
+    case class Read(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
+
+    /**
+      * Represents a write of the region variables `regs`.
+      *
+      * @param regs the region variables that are written.
+      */
+    case class Write(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
+
+    /**
+      * Represents the Impure effect.
+      * This is the "top" effect, i.e., the set of all effects.
+      *
+      * @param sp1 the position of the first character in the effect.
+      * @param sp2 the position of the last character in the effect.
+      */
+    case class Impure(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Effect
+
+    /**
+      * A reference to an declared effect.
+      *
+      * @param sp1  the position of the first character in the effect.
+      * @param name the fully qualified name of the effect.
+      * @param sp2  the position of the last character in the effect.
+      */
+    case class Eff(sp1: SourcePosition, name: Name.QName, sp2: SourcePosition) extends ParsedAst.Effect
+
+    /**
       * Effect set subtraction.
       *
       * @param eff1 the first effect.
@@ -1560,38 +1592,6 @@ object ParsedAst {
       * @param sp2 the position of the last character in the effect.
       */
     case class Complement(sp1: SourcePosition, eff: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
-
-    /**
-      * Represents a read of the region variables `regs`.
-      *
-      * @param regs the region variables that are read.
-      */
-    case class Read(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
-
-    /**
-      * Represents a write of the region variables `regs`.
-      *
-      * @param regs the region variables that are written.
-      */
-    case class Write(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
-
-    /**
-      * A reference to an declared effect.
-      *
-      * @param sp1  the position of the first character in the effect.
-      * @param name the fully qualified name of the effect.
-      * @param sp2  the position of the last character in the effect.
-      */
-    case class Eff(sp1: SourcePosition, name: Name.QName, sp2: SourcePosition) extends ParsedAst.Effect
-
-    /**
-      * Represents the Impure effect.
-      * This is the "top" effect, i.e., the set of all effects.
-      *
-      * @param sp1 the position of the first character in the effect.
-      * @param sp2 the position of the last character in the effect.
-      */
-    case class Impure(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Effect
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1494,9 +1494,9 @@ object ParsedAst {
 
   object Effect {
     case class Var(sp1: SourcePosition, ident: Name.Ident, sp2: SourcePosition) extends ParsedAst.Effect
-    case class Minus(sp1: SourcePosition, eff1: ParsedAst.Effect, eff2: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
-    case class Plus(sp1: SourcePosition, eff1: ParsedAst.Effect, eff2: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
-    case class Intersect(sp1: SourcePosition, eff1: ParsedAst.Effect, eff2: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
+    case class Minus(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
+    case class Plus(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
+    case class Intersect(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
     case class Complement(sp1: SourcePosition, eff: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
     case class Read(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
     case class Write(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1487,7 +1487,7 @@ object ParsedAst {
 
   object EffectSet {
     /**
-      * Singleton effect set.
+      * Represents and effect set with a single effect.
       *
       * @param sp1 the position of the first character in the set.
       * @param eff the effect.
@@ -1496,7 +1496,7 @@ object ParsedAst {
     case class Singleton(sp1: SourcePosition, eff: Effect, sp2: SourcePosition) extends EffectSet
 
     /**
-      * Pure effect set.
+      * Represents the empty effect set. Written as `{ }` or `{ Pure ` depending on the syntactic context.
       *
       * @param sp1 the position of the first character in the set.
       * @param sp2 the position of the last character in the set.
@@ -1504,7 +1504,7 @@ object ParsedAst {
     case class Pure(sp1: SourcePosition, sp2: SourcePosition) extends EffectSet
 
     /**
-      * A set of effects.
+      * Represents a set of effects.
       *
       * @param sp1  the position of the first character in the set.
       * @param effs the effects.
@@ -1573,22 +1573,23 @@ object ParsedAst {
       *
       * @param regs the region variables that are written.
       */
-
     case class Write(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
 
     /**
       * A reference to an declared effect.
       *
       * @param sp1  the position of the first character in the effect.
-      * @param name the declared effect.
+      * @param name the fully qualified name of the effect.
       * @param sp2  the position of the last character in the effect.
       */
     case class Eff(sp1: SourcePosition, name: Name.QName, sp2: SourcePosition) extends ParsedAst.Effect
 
     /**
-      * The Impure effect.
-      * @param sp1  the position of the first character in the effect.
-      * @param sp2  the position of the last character in the effect.
+      * Represents the Impure effect.
+      * This is the "top" effect, i.e., the set of all effects.
+      *
+      * @param sp1 the position of the first character in the effect.
+      * @param sp2 the position of the last character in the effect.
       */
     case class Impure(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Effect
   }

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1480,6 +1480,16 @@ object ParsedAst {
 
   }
 
+  sealed trait Effect
+
+  object Effect {
+    case class Var(sp1: SourcePosition, ident: Name.Ident, sp2: SourcePosition) extends ParsedAst.Effect
+    case class Minus(sp1: SourcePosition, eff1: ParsedAst.Effect, eff2: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
+    case class Read(sp1: SourcePosition, reg: Name.Ident, sp2: SourcePosition) extends ParsedAst.Effect
+    case class Write(sp1: SourcePosition, reg: Name.Ident, sp2: SourcePosition) extends ParsedAst.Effect
+    case class Eff(sp1: SourcePosition, name: Name.QName, sp2: SourcePosition) extends ParsedAst.Effect
+  }
+
   /**
     * Represents a purity.
     */

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1552,7 +1552,7 @@ object ParsedAst {
     case class Impure(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Effect
 
     /**
-      * A reference to an declared effect.
+      * Represents a reference to an declared effect.
       *
       * @param sp1  the position of the first character in the effect.
       * @param name the fully qualified name of the effect.
@@ -1561,7 +1561,7 @@ object ParsedAst {
     case class Eff(sp1: SourcePosition, name: Name.QName, sp2: SourcePosition) extends ParsedAst.Effect
 
     /**
-      * Effect set complement.
+      * Represents the complement of an effect set.
       *
       * @param sp1 the position of the first character in the effect.
       * @param eff the complemented effect.
@@ -1570,7 +1570,7 @@ object ParsedAst {
     case class Complement(sp1: SourcePosition, eff: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
 
     /**
-      * Effect set addition.
+      * Represents the union of effect sets.
       *
       * @param eff1 the first effect.
       * @param effs the other effects.
@@ -1578,7 +1578,7 @@ object ParsedAst {
     case class Union(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
 
     /**
-      * Effect set intersection.
+      * Represents the intersection of effect sets.
       *
       * @param eff1 the first effect.
       * @param effs the other effects.
@@ -1586,7 +1586,7 @@ object ParsedAst {
     case class Intersection(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
 
     /**
-      * Effect set subtraction.
+      * Represents the difference of effect sets.
       *
       * @param eff1 the first effect.
       * @param effs the other effects.

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1496,6 +1496,8 @@ object ParsedAst {
     case class Var(sp1: SourcePosition, ident: Name.Ident, sp2: SourcePosition) extends ParsedAst.Effect
     case class Minus(sp1: SourcePosition, eff1: ParsedAst.Effect, eff2: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
     case class Plus(sp1: SourcePosition, eff1: ParsedAst.Effect, eff2: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
+    case class Intersect(sp1: SourcePosition, eff1: ParsedAst.Effect, eff2: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
+    case class Complement(sp1: SourcePosition, eff: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
     case class Read(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
     case class Write(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
     case class Eff(sp1: SourcePosition, name: Name.QName, sp2: SourcePosition) extends ParsedAst.Effect

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1480,27 +1480,116 @@ object ParsedAst {
 
   }
 
-  // MATT docs
+  /**
+    * Effect Set
+    */
   sealed trait EffectSet
 
   object EffectSet {
+    /**
+      * Singleton effect set.
+      *
+      * @param sp1 the position of the first character in the set.
+      * @param eff the effect.
+      * @param sp2 the position of the last character in the set.
+      */
     case class Singleton(sp1: SourcePosition, eff: Effect, sp2: SourcePosition) extends EffectSet
+
+    /**
+      * Pure effect set.
+      *
+      * @param sp1 the position of the first character in the set.
+      * @param sp2 the position of the last character in the set.
+      */
     case class Pure(sp1: SourcePosition, sp2: SourcePosition) extends EffectSet
+
+    /**
+      * A set of effects.
+      *
+      * @param sp1  the position of the first character in the set.
+      * @param effs the effects.
+      * @param sp2  the position of the last character in the set.
+      */
     case class Set(sp1: SourcePosition, effs: Seq[Effect], sp2: SourcePosition) extends EffectSet
   }
 
-  // MATT docs
+  /**
+    * A single effect.
+    */
   sealed trait Effect
 
   object Effect {
+    /**
+      * Effect variable.
+      *
+      * @param sp1   the position of the first character in the effect.
+      * @param ident the name of the variable.
+      * @param sp2   the position of the last character in the effect.
+      */
     case class Var(sp1: SourcePosition, ident: Name.Ident, sp2: SourcePosition) extends ParsedAst.Effect
+
+    /**
+      * Effect set subtraction.
+      *
+      * @param eff1 the first effect.
+      * @param effs the other effects.
+      */
     case class Minus(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
+
+    /**
+      * Effect set addition.
+      *
+      * @param eff1 the first effect.
+      * @param effs the other effects.
+      */
     case class Plus(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
+
+    /**
+      * Effect set intersection.
+      *
+      * @param eff1 the first effect.
+      * @param effs the other effects.
+      */
     case class Intersect(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
+
+    /**
+      * Effect set complement.
+      *
+      * @param sp1 the position of the first character in the effect.
+      * @param eff the complemented effect.
+      * @param sp2 the position of the last character in the effect.
+      */
     case class Complement(sp1: SourcePosition, eff: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
+
+    /**
+      * Represents a read of the region variables `regs`.
+      *
+      * @param regs the region variables that are read.
+      */
     case class Read(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
+
+    /**
+      * Represents a write of the region variables `regs`.
+      *
+      * @param regs the region variables that are written.
+      */
+
     case class Write(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
+
+    /**
+      * A reference to an declared effect.
+      *
+      * @param sp1  the position of the first character in the effect.
+      * @param name the declared effect.
+      * @param sp2  the position of the last character in the effect.
+      */
     case class Eff(sp1: SourcePosition, name: Name.QName, sp2: SourcePosition) extends ParsedAst.Effect
+
+    /**
+      * The Impure effect.
+      * @param sp1  the position of the first character in the effect.
+      * @param sp2  the position of the last character in the effect.
+      */
     case class Impure(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Effect
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -308,13 +308,13 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       SP ~ "{" ~ optWS ~ zeroOrMore(Var | Read | Write).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ "}" ~ SP ~> ParsedAst.Type.Union
     }
 
-    rule {
-      WS ~ "\\" ~ WS ~ (Single | Union)
+    // unused for now
+    def EffectAlt: Rule1[ParsedAst.EffectSet] = rule {
+      optWS ~ "\\" ~ optWS ~ Effects.EffectSet
     }
 
-    def EffectAlt: Rule1[ParsedAst.EffectSet] = rule {
-      // MATT change back to \\ when ready
-      optWS ~ "|" ~ optWS ~ Effects.EffectSet
+    rule {
+      WS ~ "\\" ~ WS ~ (Single | Union)
     }
 
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1463,15 +1463,15 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def PlusTail = rule {
-      operatorX("+") ~ oneOrMore(SimpleEffect).separatedBy(optWS ~ "+" ~ optWS) ~> ParsedAst.Effect.Plus
+      operatorX("+") ~ oneOrMore(SimpleEffect).separatedBy(optWS ~ "+" ~ optWS) ~> ParsedAst.Effect.Union
     }
 
     def MinusTail = rule {
-      operatorX("-") ~ oneOrMore(SimpleEffect).separatedBy(optWS ~ "-" ~ optWS) ~> ParsedAst.Effect.Minus
+      operatorX("-") ~ oneOrMore(SimpleEffect).separatedBy(optWS ~ "-" ~ optWS) ~> ParsedAst.Effect.Difference
     }
 
     def IntersectTail = rule {
-        operatorX("&") ~ oneOrMore(SimpleEffect).separatedBy(optWS ~ "&" ~ optWS) ~> ParsedAst.Effect.Intersect
+        operatorX("&") ~ oneOrMore(SimpleEffect).separatedBy(optWS ~ "&" ~ optWS) ~> ParsedAst.Effect.Intersection
     }
 
     def BinaryTail = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -311,6 +311,12 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     rule {
       WS ~ "\\" ~ WS ~ (Single | Union)
     }
+
+    def EffectAlt: Rule1[ParsedAst.EffectSet] = rule {
+      // MATT change back to \\ when ready
+      optWS ~ "|" ~ optWS ~ Effects.EffectSet
+    }
+
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1393,6 +1393,10 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
   }
 
+  object Effects {
+    def Var: Rule1[ParsedAst.Effect]
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   // Kinds                                                                   //
   /////////////////////////////////////////////////////////////////////////////

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1394,7 +1394,19 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
   }
 
   object Effects {
-    def Var: Rule1[ParsedAst.Effect]
+    def Var: Rule1[ParsedAst.Effect] = rule {
+      SP ~ Names.Variable ~ SP ~> ParsedAst.Effect.Var
+    }
+
+    def Read: Rule1[ParsedAst.Effect] = rule {
+      SP ~ keyword("Read") ~ optWS ~ "(" ~ optWS ~ oneOrMore(Names.Variable).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~> ParsedAst.Purity.Read
+    }
+
+    def Write: Rule1[ParsedAst.Effect] = rule {
+      SP ~ keyword("Write") ~ optWS ~ "(" ~ optWS ~ oneOrMore(Names.Variable).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~> ParsedAst.Purity.Write
+    }
+
+    def Plus: Rule1[ParsedAst.Effect]
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1395,6 +1395,23 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
   object Effects {
 
+    def EffectSet: Rule1[ParsedAst.EffectSet] = rule {
+      // NB: Pure must come before Set since they overlap
+      Pure | Set | Singleton
+    }
+
+    def Pure: Rule1[ParsedAst.EffectSet] = rule {
+      SP ~ "{" ~ optWS ~ keyword("Pure") ~ optWS ~ "}" ~ SP ~> ParsedAst.EffectSet.Pure
+    }
+
+    def Set: Rule1[ParsedAst.EffectSet] = rule {
+      SP ~ "{" ~ optWS ~ oneOrMore(Effect).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ "}" ~ SP ~> ParsedAst.EffectSet.Set
+    }
+
+    def Singleton: Rule1[ParsedAst.EffectSet] = rule {
+      SP ~ Effect ~ SP ~> ParsedAst.EffectSet.Singleton
+    }
+
     def Effect: Rule1[ParsedAst.Effect] = rule {
       Binary | SimpleEffect
     }
@@ -1428,7 +1445,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def SimpleEffect: Rule1[ParsedAst.Effect] = rule {
-      Var | Read | Write | Eff | Complement | Parens
+      Var | Impure | Read | Write | Eff | Complement | Parens
     }
 
     // We only allow chains of like operators.

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1394,19 +1394,39 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
   }
 
   object Effects {
+
+    // MATT match Arrow pattern
+    def Effect: Rule1[ParsedAst.Effect] = rule {
+      Plus | Minus | SimpleEffect
+    }
+
     def Var: Rule1[ParsedAst.Effect] = rule {
       SP ~ Names.Variable ~ SP ~> ParsedAst.Effect.Var
     }
 
     def Read: Rule1[ParsedAst.Effect] = rule {
-      SP ~ keyword("Read") ~ optWS ~ "(" ~ optWS ~ oneOrMore(Names.Variable).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~> ParsedAst.Purity.Read
+      SP ~ keyword("Read") ~ optWS ~ "(" ~ optWS ~ oneOrMore(Names.Variable).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~> ParsedAst.Effect.Read
     }
 
     def Write: Rule1[ParsedAst.Effect] = rule {
-      SP ~ keyword("Write") ~ optWS ~ "(" ~ optWS ~ oneOrMore(Names.Variable).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~> ParsedAst.Purity.Write
+      SP ~ keyword("Write") ~ optWS ~ "(" ~ optWS ~ oneOrMore(Names.Variable).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~> ParsedAst.Effect.Write
     }
 
-    def Plus: Rule1[ParsedAst.Effect]
+    def Eff: Rule1[ParsedAst.Effect] = rule {
+      SP ~ Names.QualifiedEffect ~ SP ~> ParsedAst.Effect.Eff
+    }
+
+    def SimpleEffect: Rule1[ParsedAst.Effect] = rule {
+      Var | Read | Write | Eff
+    }
+
+    def Plus: Rule1[ParsedAst.Effect] = rule {
+      SP ~ SimpleEffect ~ optWS ~ operatorX("+") ~ optWS ~ Effect ~> ParsedAst.Effect.Plus
+    }
+
+    def Minus: Rule1[ParsedAst.Effect] = rule {
+      SP ~ SimpleEffect ~ optWS ~ operatorX("-") ~ optWS ~ Effect ~> ParsedAst.Effect.Minus
+    }
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1403,6 +1403,10 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       SP ~ Names.Variable ~ SP ~> ParsedAst.Effect.Var
     }
 
+    def Impure: Rule1[ParsedAst.Effect] = rule {
+      SP ~ keyword("Impure") ~ SP ~> ParsedAst.Effect.Impure
+    }
+
     def Read: Rule1[ParsedAst.Effect] = rule {
       SP ~ keyword("Read") ~ optWS ~ "(" ~ optWS ~ oneOrMore(Names.Variable).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~ SP ~> ParsedAst.Effect.Read
     }


### PR DESCRIPTION
related to #3542. This only contains some unused Parser structures. I am separating this from the next step since there may be complications to handle in the Weeder in order to support the new grammar without breaking the old.