### PR TITLE
refactor: migrate to new Effect AST

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -77,7 +77,7 @@ object ParsedAst {
       * @param tconstrs   the type constraints.
       * @param sp2        the position of the last character in the declaration.
       */
-    case class Def(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.Type], tconstrs: Seq[ParsedAst.TypeConstraint], exp: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Declaration
+    case class Def(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.EffectSetOrBool], tconstrs: Seq[ParsedAst.TypeConstraint], exp: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Declaration
 
     /**
       * Signature Declaration.
@@ -95,7 +95,7 @@ object ParsedAst {
       * @param exp        the optional expression.
       * @param sp2        the position of the last character in the declaration.
       */
-    case class Sig(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.Type], tconstrs: Seq[ParsedAst.TypeConstraint], exp: Option[ParsedAst.Expression], sp2: SourcePosition) extends ParsedAst.Declaration with ParsedAst.Declaration.LawOrSig
+    case class Sig(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.EffectSetOrBool], tconstrs: Seq[ParsedAst.TypeConstraint], exp: Option[ParsedAst.Expression], sp2: SourcePosition) extends ParsedAst.Declaration with ParsedAst.Declaration.LawOrSig
 
     /**
       * Law Declaration.
@@ -126,7 +126,7 @@ object ParsedAst {
       * @param tconstrs   the type constraints.
       * @param sp2        the position of the last character in the declaration.
       */
-    case class Op(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.Type], tconstrs: Seq[ParsedAst.TypeConstraint], sp2: SourcePosition) extends ParsedAst.Declaration
+    case class Op(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.EffectSetOrBool], tconstrs: Seq[ParsedAst.TypeConstraint], sp2: SourcePosition) extends ParsedAst.Declaration
 
     /**
       * Enum Declaration.
@@ -2081,6 +2081,13 @@ object ParsedAst {
       */
     case class LatPredicateWithTypes(sp1: SourcePosition, name: Name.Ident, tpes: Seq[ParsedAst.Type], tpe: ParsedAst.Type, sp2: SourcePosition) extends PredicateType
 
+  }
+
+  // MATT docs
+  sealed trait EffectSetOrBool
+  object EffectSetOrBool {
+    case class Set(s: EffectSet) extends EffectSetOrBool
+    case class Bool(b: Type) extends EffectSetOrBool
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -77,7 +77,7 @@ object ParsedAst {
       * @param tconstrs   the type constraints.
       * @param sp2        the position of the last character in the declaration.
       */
-    case class Def(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.EffectSetOrBool], tconstrs: Seq[ParsedAst.TypeConstraint], exp: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Declaration
+    case class Def(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.EffectOrPurity], tconstrs: Seq[ParsedAst.TypeConstraint], exp: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Declaration
 
     /**
       * Signature Declaration.
@@ -95,7 +95,7 @@ object ParsedAst {
       * @param exp        the optional expression.
       * @param sp2        the position of the last character in the declaration.
       */
-    case class Sig(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.EffectSetOrBool], tconstrs: Seq[ParsedAst.TypeConstraint], exp: Option[ParsedAst.Expression], sp2: SourcePosition) extends ParsedAst.Declaration with ParsedAst.Declaration.LawOrSig
+    case class Sig(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.EffectOrPurity], tconstrs: Seq[ParsedAst.TypeConstraint], exp: Option[ParsedAst.Expression], sp2: SourcePosition) extends ParsedAst.Declaration with ParsedAst.Declaration.LawOrSig
 
     /**
       * Law Declaration.
@@ -126,7 +126,7 @@ object ParsedAst {
       * @param tconstrs   the type constraints.
       * @param sp2        the position of the last character in the declaration.
       */
-    case class Op(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.EffectSetOrBool], tconstrs: Seq[ParsedAst.TypeConstraint], sp2: SourcePosition) extends ParsedAst.Declaration
+    case class Op(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.EffectOrPurity], tconstrs: Seq[ParsedAst.TypeConstraint], sp2: SourcePosition) extends ParsedAst.Declaration
 
     /**
       * Enum Declaration.
@@ -2077,18 +2077,18 @@ object ParsedAst {
   /**
     * Represents an effect represented either as a set or a boolean formula.
     */
-  sealed trait EffectSetOrBool
+  sealed trait EffectOrPurity
 
-  object EffectSetOrBool {
+  object EffectOrPurity {
     /**
       * Represents an effect implemented as a set.
       */
-    case class Set(s: EffectSet) extends EffectSetOrBool
+    case class Effect(s: EffectSet) extends EffectOrPurity
 
     /**
       * Represents an effect implemented as a boolean formula.
       */
-    case class Bool(b: Type) extends EffectSetOrBool
+    case class Purity(b: Type) extends EffectOrPurity
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -2074,10 +2074,20 @@ object ParsedAst {
 
   }
 
-  // MATT docs
+  /**
+    * Represents an effect represented either as a set or a boolean formula.
+    */
   sealed trait EffectSetOrBool
+
   object EffectSetOrBool {
+    /**
+      * Represents an effect implemented as a set.
+      */
     case class Set(s: EffectSet) extends EffectSetOrBool
+
+    /**
+      * Represents an effect implemented as a boolean formula.
+      */
     case class Bool(b: Type) extends EffectSetOrBool
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1469,15 +1469,6 @@ object ParsedAst {
     case class Or(tpe1: ParsedAst.Type, tpe2: ParsedAst.Type, sp2: SourcePosition) extends ParsedAst.Type
 
     /**
-      * Represents a union of purities.
-      *
-      * @param sp1  the position of the first character in the type.
-      * @param purs the purities.
-      * @param sp2  the position of the last character in the type.
-      */
-    case class Union(sp1: SourcePosition, purs: Seq[ParsedAst.Purity], sp2: SourcePosition) extends Type
-
-    /**
       * Kind Ascription.
       *
       * @param tpe  the ascribed type.

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -283,17 +283,17 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     SP ~ Names.Attribute ~ optWS ~ ":" ~ optWS ~ Type ~ SP ~> ParsedAst.Attribute
   }
 
-  def TypeAndEffect: Rule2[ParsedAst.Type, Option[ParsedAst.EffectSetOrBool]] = rule {
+  def TypeAndEffect: Rule2[ParsedAst.Type, Option[ParsedAst.EffectOrPurity]] = rule {
     Type ~ optional(optWS ~ EffectSetOrBool)
   }
 
-  def EffectSetOrBool: Rule1[ParsedAst.EffectSetOrBool] = {
-    def Set: Rule1[ParsedAst.EffectSetOrBool] = rule {
-      "\\" ~ optWS ~ Effects.EffectSet ~> ParsedAst.EffectSetOrBool.Set
+  def EffectSetOrBool: Rule1[ParsedAst.EffectOrPurity] = {
+    def Set: Rule1[ParsedAst.EffectOrPurity] = rule {
+      "\\" ~ optWS ~ Effects.EffectSet ~> ParsedAst.EffectOrPurity.Effect
     }
 
-    def Bool: Rule1[ParsedAst.EffectSetOrBool] = rule {
-      "&" ~ optWS ~ Type ~> ParsedAst.EffectSetOrBool.Bool
+    def Bool: Rule1[ParsedAst.EffectOrPurity] = rule {
+      "&" ~ optWS ~ Type ~> ParsedAst.EffectOrPurity.Purity
     }
 
     rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -2201,50 +2201,11 @@ object Weeder {
       val t2 = visitType(tpe2)
       WeededAst.Type.Or(t1, t2, mkSL(sp1, sp2))
 
-    case ParsedAst.Type.Union(sp1, efs, sp2) =>
-      val loc = mkSL(sp1, sp2)
-      if (efs.isEmpty)
-        WeededAst.Type.True(loc)
-      else {
-        val zero = visitReadOrWrite(efs.head, loc)
-        efs.tail.foldLeft(zero) {
-          case (acc, rw) => WeededAst.Type.And(acc, visitReadOrWrite(rw, loc), loc)
-        }
-      }
-
     case ParsedAst.Type.Ascribe(tpe, kind, sp2) =>
       val sp1 = leftMostSourcePosition(tpe)
       val t = visitType(tpe)
       val k = visitKind(kind)
       WeededAst.Type.Ascribe(t, k, mkSL(sp1, sp2))
-  }
-
-  /**
-    * Returns the given read or write effect as a WeededAst type.
-    */
-  private def visitReadOrWrite(rw: ParsedAst.Purity, loc: SourceLocation): WeededAst.Type = rw match {
-    case Purity.Var(sp1, ident, sp2) =>
-      WeededAst.Type.Var(ident, mkSL(sp1, sp2))
-
-    case Purity.Read(idents) =>
-      if (idents.isEmpty)
-        WeededAst.Type.True(loc)
-      else {
-        val zero: WeededAst.Type = WeededAst.Type.Var(idents.head, idents.head.loc)
-        idents.tail.foldLeft(zero) {
-          case (acc, ident) => WeededAst.Type.And(acc, WeededAst.Type.Var(ident, ident.loc), loc)
-        }
-      }
-
-    case Purity.Write(idents) =>
-      if (idents.isEmpty)
-        WeededAst.Type.True(loc)
-      else {
-        val zero: WeededAst.Type = WeededAst.Type.Var(idents.head, idents.head.loc)
-        idents.tail.foldLeft(zero) {
-          case (acc, ident) => WeededAst.Type.And(acc, WeededAst.Type.Var(ident, ident.loc), loc)
-        }
-      }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -2272,10 +2272,10 @@ object Weeder {
   /**
     * Weeds the given parsed optional effect `effOpt`.
     */
-  private def visitEff(effOpt: Option[ParsedAst.EffectSetOrBool], loc: SourceLocation)(implicit flix: Flix): Validation[WeededAst.Type, WeederError] = effOpt match {
+  private def visitEff(effOpt: Option[ParsedAst.EffectOrPurity], loc: SourceLocation)(implicit flix: Flix): Validation[WeededAst.Type, WeederError] = effOpt match {
     case None => WeededAst.Type.True(loc.asSynthetic).toSuccess
-    case Some(ParsedAst.EffectSetOrBool.Bool(tpe)) => visitType(tpe).toSuccess
-    case Some(ParsedAst.EffectSetOrBool.Set(s)) =>
+    case Some(ParsedAst.EffectOrPurity.Purity(tpe)) => visitType(tpe).toSuccess
+    case Some(ParsedAst.EffectOrPurity.Effect(s)) =>
       // for now just pull out the reads and vars and convert them to types
       s match {
         case EffectSet.Singleton(sp1, eff, sp2) => visitSingleEffect(eff).toSuccess

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -2329,12 +2329,6 @@ object Weeder {
               }
               tpe.toSuccess
           }
-        case EffectSet.Set(sp1, eff0 +: effs0, sp2) =>
-          val loc = mkSL(sp1, sp2)
-          val tpe = effs0.foldLeft(visitSingleEffect(eff0)) {
-            case (acc, eff) => WeededAst.Type.And(acc, visitSingleEffect(eff), loc)
-          }
-          tpe.toSuccess
       }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -2282,7 +2282,7 @@ object Weeder {
         case EffectSet.Pure(sp1, sp2) => WeededAst.Type.True(mkSL(sp1, sp2)).toSuccess
         case EffectSet.Set(sp1, effs, sp2) =>
           val loc = mkSL(sp1, sp2)
-          effs match {
+          effs.toList match {
             case Nil => WeededAst.Type.True(loc).toSuccess
             case hd :: tl =>
               val tpe = tl.foldLeft(visitSingleEffect(hd)) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -2718,7 +2718,6 @@ object Weeder {
     case ParsedAst.Type.Not(sp1, _, _) => sp1
     case ParsedAst.Type.And(tpe1, _, _) => leftMostSourcePosition(tpe1)
     case ParsedAst.Type.Or(tpe1, _, _) => leftMostSourcePosition(tpe1)
-    case ParsedAst.Type.Union(sp1, _, _) => sp1
     case ParsedAst.Type.Ascribe(tpe, _, _) => leftMostSourcePosition(tpe)
   }
 


### PR DESCRIPTION
related to #3542, depends on #3559

This is just the refactoring step. Next I'll add tests using the full power of the new syntax.