### PR TITLE
fix: use smart Boolean constructors in Kinder

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -876,7 +876,7 @@ object Kinder {
           val k1 = Kind.Arrow(t2.kind, expectedKind)
           val t1Val = visitType(t10, k1, kenv, taenv, root)
           mapN(t1Val) {
-            t1 => Type.Apply(t1, t2, loc)
+            t1 => mkApply(t1, t2, loc)
           }
       }
     case Type.Ascribe(t, k, loc) =>
@@ -1158,11 +1158,13 @@ object Kinder {
   }
 
   /**
-    * Asserts that the type variable is unkinded.
+    * Creates the type application `t1[t2]`, while simplifying trivial boolean formulas.
     */
-  private def assertUnkindedVar(tvar: Type.Var): Type.UnkindedVar = tvar match {
-    case unkinded: Type.UnkindedVar => unkinded
-    case kinded: Type.KindedVar => throw InternalCompilerException("Unexpected kinded type variable.")
+  private def mkApply(t1: Type, t2: Type, loc: SourceLocation): Type = t1 match {
+    case Type.Apply(Type.Cst(TypeConstructor.And, _), arg, _) => Type.mkAnd(arg, t2, loc)
+    case Type.Apply(Type.Cst(TypeConstructor.Or, _), arg, _) => Type.mkOr(arg, t2, loc)
+    case Type.Cst(TypeConstructor.Not, _) => Type.mkNot(t2, loc)
+    case t => Type.Apply(t, t2, loc)
   }
 
   /**

--- a/main/test/flix/LangSuite.scala
+++ b/main/test/flix/LangSuite.scala
@@ -38,6 +38,7 @@ class LangSuite extends Suites(
   //
   new FlixTest("Test.Eff.Advanced", "main/test/flix/Test.Eff.Advanced.flix"),
   new FlixTest("Test.Eff.Polymorphism", "main/test/flix/Test.Eff.Polymorphism.flix")(Options.TestWithLibAll),
+  new FlixTest("Test.Eff.Simplification", "main/test/flix/Test.Eff.Simplification.flix"),
 
   //
   // Equality.

--- a/main/test/flix/Test.Eff.Advanced.flix
+++ b/main/test/flix/Test.Eff.Advanced.flix
@@ -48,9 +48,6 @@ namespace Test/Eff/Advanced {
     /// A pure function from Unit -> Unit.
     def pure(): Unit = ()
 
-    /// A (redundantly) pure function from Unit -> Unit.
-    def doublePure(): Unit & Pure and Pure = ()
-
     /// An impure function from Unit -> Unit.
     def impure(): Unit & Impure = [1, 2, 3]; ()
 

--- a/main/test/flix/Test.Eff.Advanced.flix
+++ b/main/test/flix/Test.Eff.Advanced.flix
@@ -48,6 +48,9 @@ namespace Test/Eff/Advanced {
     /// A pure function from Unit -> Unit.
     def pure(): Unit = ()
 
+    /// A (redundantly) pure function from Unit -> Unit.
+    def doublePure(): Unit & Pure and Pure = ()
+
     /// An impure function from Unit -> Unit.
     def impure(): Unit & Impure = [1, 2, 3]; ()
 

--- a/main/test/flix/Test.Eff.Simplification.flix
+++ b/main/test/flix/Test.Eff.Simplification.flix
@@ -1,0 +1,25 @@
+namespace Test/Eff/Simplification {
+    @test
+    def testPureAndPure(): Unit & Pure and Pure = pure()
+
+    @test
+    def testPureAndImpure(): Unit = Pure and Impure = impure()
+
+    @test
+    def testImpureAndImpure(): Unit = Impure and Impure = impure()
+
+    @test
+    def testPureOrPure(): Unit & Pure or Pure = pure()
+
+    @test
+    def testPureOrImpure(): Unit = Pure and Impure = pure()
+
+    @test
+    def testImpureOrImpure(): Unit = Impure and Impure = impure()
+
+    /// a pure function
+    def pure(): Unit & Pure = ()
+
+    /// an impure function
+    def impure(): Unit & Impure = () as & Impure
+}

--- a/main/test/flix/Test.Eff.Simplification.flix
+++ b/main/test/flix/Test.Eff.Simplification.flix
@@ -12,10 +12,10 @@ namespace Test/Eff/Simplification {
     def testPureOrPure(): Unit & Pure or Pure = pure()
 
     @test
-    def testPureOrImpure(): Unit & Pure and Impure = pure()
+    def testPureOrImpure(): Unit & Pure or Impure = pure()
 
     @test
-    def testImpureOrImpure(): Unit & Impure and Impure = impure()
+    def testImpureOrImpure(): Unit & Impure or Impure = impure()
 
     /// a pure function
     def pure(): Unit & Pure = ()

--- a/main/test/flix/Test.Eff.Simplification.flix
+++ b/main/test/flix/Test.Eff.Simplification.flix
@@ -3,19 +3,19 @@ namespace Test/Eff/Simplification {
     def testPureAndPure(): Unit & Pure and Pure = pure()
 
     @test
-    def testPureAndImpure(): Unit = Pure and Impure = impure()
+    def testPureAndImpure(): Unit & Pure and Impure = impure()
 
     @test
-    def testImpureAndImpure(): Unit = Impure and Impure = impure()
+    def testImpureAndImpure(): Unit & Impure and Impure = impure()
 
     @test
     def testPureOrPure(): Unit & Pure or Pure = pure()
 
     @test
-    def testPureOrImpure(): Unit = Pure and Impure = pure()
+    def testPureOrImpure(): Unit & Pure and Impure = pure()
 
     @test
-    def testImpureOrImpure(): Unit = Impure and Impure = impure()
+    def testImpureOrImpure(): Unit & Impure and Impure = impure()
 
     /// a pure function
     def pure(): Unit & Pure = ()


### PR DESCRIPTION
fixes #3570, related to #3604

This isn't a totally reliable solution, as type aliases and probably other features make everything more complicated. But I'm hoping the new boolean unification stuff will address this issue more robustly.

So this is a quick fix in order to unblock #3604