### PR TITLE
Introduce reproducible builds to build-jar and build-pkg commands

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/Packager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Packager.scala
@@ -488,7 +488,7 @@ object Packager {
     * Here we use 1980 February to avoid the complexity introduced by this hack.
     *
     * @see <a href="https://bugs.openjdk.java.net/browse/JDK-4759491">JDK-4759491 that introduced the hack around 1980 January from Java 8+</a>
-    * @see <a href="https://bugs.openjdk.java.net/browse/JDK-6303183">JDK-6303183 that explains why the second should be even to create ZIP files in non platform specific way</a>
+    * @see <a href="https://bugs.openjdk.java.net/browse/JDK-6303183">JDK-6303183 that explains why the second should be even to create ZIP files in platform-independent way</a>
     * @see <a href="https://github.com/gradle/gradle/blob/445deb9aa988e506120b7918bf91acb421e429ba/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java#L42-L57">A similar case from Gradle</a>
     */
   private val ENOUGH_OLD_CONSTANT_TIME: Long = new GregorianCalendar(1980, Calendar.FEBRUARY, 1, 0, 0, 0).getTimeInMillis
@@ -562,7 +562,7 @@ object Packager {
   }
 
   /**
-    * The comparator which compares Path objects by a non platform specific way.
+    * The comparator which compares Path objects by a non platform-specific way.
     * @see <a href="https://reproducible-builds.org/">Reproducible Builds</a>
     */
   class PathComparator extends Ordering[Path] {
@@ -575,8 +575,8 @@ object Packager {
       */
     private def iterate(p: Path): Iterator[String] =
       p.iterator.asScala.map(
-        // Convert Path to String, to compare the name of path elements by a non platform specific way.
-        // According to Javadoc, the implementation of `Path.compareTo(Path)` is platform specific.
+        // Convert Path to String, to compare the name of path elements by a platform-independent way.
+        // According to Javadoc, the implementation of `Path.compareTo(Path)` is platform-specific.
         Objects.toString
       )
 

--- a/main/test/ca/uwaterloo/flix/tools/TestPackager.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestPackager.scala
@@ -4,6 +4,10 @@ import ca.uwaterloo.flix.util.Options
 import org.scalatest.FunSuite
 
 import java.nio.file.Files
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.zip.ZipFile
+import scala.jdk.CollectionConverters.EnumerationHasAsScala
 
 class TestPackager extends FunSuite {
 
@@ -40,6 +44,21 @@ class TestPackager extends FunSuite {
     assert(jarPath.getFileName.toString.startsWith(ProjectPrefix))
   }
 
+  test("build-jar generates ZIP entries with fixed time") {
+    val p = Files.createTempDirectory(ProjectPrefix)
+    Packager.init(p, DefaultOptions)
+    Packager.buildJar(p, DefaultOptions)
+
+    val packageName = p.getFileName.toString
+    val packagePath = p.resolve(packageName + ".jar")
+    val format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+    for (e <- new ZipFile(packagePath.toFile).entries().asScala) {
+      val time = new Date(e.getTime)
+      val formatted = format.format(time)
+      assert(formatted.equals("1980-02-01 00:00:00"))
+    }
+  }
+
   test("build-pkg") {
     val p = Files.createTempDirectory(ProjectPrefix)
     Packager.init(p, DefaultOptions)
@@ -49,6 +68,21 @@ class TestPackager extends FunSuite {
     val packagePath = p.resolve(packageName + ".fpkg")
     assert(Files.exists(packagePath))
     assert(packagePath.getFileName.toString.startsWith(ProjectPrefix))
+  }
+
+  test("build-pkg generates ZIP entries with fixed time") {
+    val p = Files.createTempDirectory(ProjectPrefix)
+    Packager.init(p, DefaultOptions)
+    Packager.buildPkg(p, DefaultOptions)
+
+    val packageName = p.getFileName.toString
+    val packagePath = p.resolve(packageName + ".fpkg")
+    val format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+    for (e <- new ZipFile(packagePath.toFile).entries().asScala) {
+      val time = new Date(e.getTime)
+      val formatted = format.format(time)
+      assert(formatted.equals("1980-02-01 00:00:00"))
+    }
   }
 
   test("benchmark") {

--- a/main/test/ca/uwaterloo/flix/tools/TestPathComparator.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestPathComparator.scala
@@ -1,0 +1,61 @@
+package ca.uwaterloo.flix.tools
+
+import ca.uwaterloo.flix.tools.Packager.PathComparator
+import org.scalatest.FunSuite
+
+import java.nio.file.Paths
+
+class TestPathComparator extends FunSuite {
+  test("order by file name") {
+    val comparator = new PathComparator()
+    val list = Array(
+      Paths.get("b.txt"),
+      Paths.get("a.txt"),
+    )
+    assert(list.sorted(comparator).sameElements(Array(
+      Paths.get("a.txt"),
+      Paths.get("b.txt")
+    )))
+  }
+  test("order by folder name") {
+    val comparator = new PathComparator()
+    val list = Array(
+      Paths.get("b", "child.txt"),
+      Paths.get("a", "child.txt")
+    )
+    assert(list.sorted(comparator).sameElements(Array(
+      Paths.get("a", "child.txt"),
+      Paths.get("b", "child.txt")
+    )))
+  }
+  test("order by child file name") {
+    val comparator = new PathComparator()
+    val list = Array(
+      Paths.get("parent", "b.txt"),
+      Paths.get("parent", "a.txt"),
+      Paths.get("parent", "c.txt")
+    )
+    assert(list.sorted(comparator).sameElements(Array(
+      Paths.get("parent", "a.txt"),
+      Paths.get("parent", "b.txt"),
+      Paths.get("parent", "c.txt")
+    )))
+  }
+  test("complex case") {
+    val comparator = new PathComparator()
+    val list = Array(
+      Paths.get("2", "d.txt"),
+      Paths.get("1", "c.txt"),
+      Paths.get("1", "b.txt"),
+      Paths.get("2", "a.txt"),
+      Paths.get("2", "3", "c.txt")
+    )
+    assert(list.sorted(comparator).sameElements(Array(
+      Paths.get("1", "b.txt"),
+      Paths.get("1", "c.txt"),
+      Paths.get("2", "3", "c.txt"),
+      Paths.get("2", "a.txt"),
+      Paths.get("2", "d.txt")
+    )))
+  }
+}

--- a/main/test/ca/uwaterloo/flix/tools/ToolsSuite.scala
+++ b/main/test/ca/uwaterloo/flix/tools/ToolsSuite.scala
@@ -3,7 +3,8 @@ package ca.uwaterloo.flix.tools
 import org.scalatest.Suites
 
 class ToolsSuite extends Suites(
-  new TestPackager
+  new TestPackager,
+  new TestPathComparator
 ) {
   /* left empty */
 }


### PR DESCRIPTION
[Reproducible Builds](https://reproducible-builds.org/) is a good manner contributing to development process reliability. This PR introduces some to make the build result reproducible, by using fixed timestamps and sorting `ZipEntry`.

The build result is still not enough reproducible, because it has an implicit dependency on the JDK we use. Flix users still need to use the same JDK to get the same binary.  
This problem can be solved when the build system has a feature to fix the JDK, just like [the JVM toolchain from Gradle](https://docs.gradle.org/current/userguide/toolchains.html). And I left this task because I think it's too huge to handle at this time.

There is one more idea to sort `ZipEntry` in the file: change the `Packager.getAllFiles()` method and make sure it sorts the `List[Path]` in a platform-independent way. In my understanding, Java's `FileVisitor` provides no intuitive way to implement it, so I chose this way to keep the change simple and small.