### PR TITLE
fix: Environment getArgs tests and pre-entrypoint args default

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenGlobalClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenGlobalClass.scala
@@ -67,7 +67,8 @@ object GenGlobalClass {
     NEW(JvmName.AtomicLong) ~
       DUP() ~ invokeConstructor(JvmName.AtomicLong) ~
       counterField.putStaticField() ~
-      ACONST_NULL() ~
+      ICONST_0() ~
+      ANEWARRAY(BackendObjType.String.jvmName) ~
       argsField.putStaticField() ~
       RETURN()
 

--- a/main/test/ca/uwaterloo/flix/language/TestProgramArgs.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestProgramArgs.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Jonathan Lindegaard Starup
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language
+
+import ca.uwaterloo.flix.TestUtils
+import ca.uwaterloo.flix.language.errors.SafetyError.IllegalNonPositivelyBoundVariable
+import ca.uwaterloo.flix.util.{Options, Validation}
+import org.scalatest.FunSuite
+
+class TestProgramArgs extends FunSuite with TestUtils {
+
+  test("ProgramArgs.01") {
+    val arg = "Correct"
+    val input =
+      s"""
+        |def main(): Unit = match Environment.getArgs() {
+        |    case "$arg" :: Nil => ()
+        |    case _ :: Nil => ?wrongArgumentValue
+        |    case _ => ?incorrectNumberOfArgs
+        |}
+      """.stripMargin
+    val result = compile(input, Options.TestWithLibAll)
+    result match {
+      case Validation.Success(result) => result.getMain match {
+        case Some(main) => try {
+          main.apply(Array(arg))
+        } catch {
+          case e: java.lang.Throwable => fail(e)
+        }
+        case None => fail("No entrypoint")
+      }
+      case Validation.Failure(errors) =>
+        val actuals = errors.map(_.getClass)
+        fail(s"Expected success, but found errors ${actuals.mkString(", ")}.")
+    }
+  }
+
+}

--- a/main/test/ca/uwaterloo/flix/library/TestEnvironment.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestEnvironment.flix
@@ -76,8 +76,7 @@ namespace TestEnvironment {
         Environment.getVirtualProcessors() > 0
 
     @test
-    def testGetArgs(): Bool =
-        let _ = Environment.getArgs();
-        true
+    def testGetArgs(): List[String] =
+        Environment.getArgs();
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestEnvironment.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestEnvironment.flix
@@ -76,7 +76,6 @@ namespace TestEnvironment {
         Environment.getVirtualProcessors() > 0
 
     @test
-    def testGetArgs(): List[String] =
-        Environment.getArgs();
+    def testGetArgs(): List[String] = Environment.getArgs()
 
 }


### PR DESCRIPTION
Fix environment test, add test of environment getargs functionality and change pre-entrypoint args value from null to []