### PR TITLE
fix: remove assumption that types have same kind in `Unification`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -72,13 +72,13 @@ object Unification {
       case (x: Type.Var, y: Type.Var) => unifyVars(x.asKinded, y.asKinded)
 
       case (x: Type.Var, _) =>
-        if (x.kind == Kind.Bool || tpe2.kind == Kind.Bool)
+        if (x.kind == Kind.Bool && tpe2.kind == Kind.Bool)
           BoolUnification.unify(x, tpe2)
         else
           unifyVar(x.asKinded, tpe2)
 
       case (_, x: Type.Var) =>
-        if (x.kind == Kind.Bool || tpe1.kind == Kind.Bool)
+        if (x.kind == Kind.Bool && tpe1.kind == Kind.Bool)
           BoolUnification.unify(x, tpe1)
         else
           unifyVar(x.asKinded, tpe1)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -146,6 +146,21 @@ class TestTyper extends FunSuite with TestUtils {
     expectError[TypeError.MismatchedTypes](result)
   }
 
+  test("TestMismatchedTypes.Arrow.01") {
+    // Regression test.
+    // See https://github.com/flix/flix/issues/3634
+    val input =
+      """
+        |opaque type E[a: Type, ef: Bool] = Unit
+        |def f(g: E[Int32, true]): Bool = ???
+        |def mkE(): E[Int32, true] & ef = ???
+        |
+        |def g(): Bool = f(mkE)
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.MismatchedTypes](result)
+  }
+
   test("TestOverApplied.01") {
     val input =
       """


### PR DESCRIPTION
fixes #3634