### PR TITLE
feat: weed effect declarations

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -47,7 +47,7 @@ object WeededAst {
 
     case class Effect(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, ops: List[WeededAst.Declaration.Op], loc: SourceLocation) extends WeededAst.Declaration
 
-    case class Op(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], tpe: WeededAst.Type, retTpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation) extends WeededAst.Declaration
+    case class Op(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, fparams: List[WeededAst.FormalParam], tpe: WeededAst.Type, retTpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation) extends WeededAst.Declaration
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -45,7 +45,7 @@ object WeededAst {
 
     case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.TypeParams, tpe: WeededAst.Type, loc: SourceLocation) extends WeededAst.Declaration
 
-    case class Effect(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, ops: Seq[WeededAst.Declaration.Op], loc: SourceLocation) extends WeededAst.Declaration
+    case class Effect(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, ops: List[WeededAst.Declaration.Op], loc: SourceLocation) extends WeededAst.Declaration
 
     case class Op(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], tpe: WeededAst.Type, retTpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation) extends WeededAst.Declaration
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -45,6 +45,10 @@ object WeededAst {
 
     case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.TypeParams, tpe: WeededAst.Type, loc: SourceLocation) extends WeededAst.Declaration
 
+    case class Effect(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, ops: Seq[WeededAst.Declaration.Op], loc: SourceLocation) extends WeededAst.Declaration
+
+    case class Op(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], tpe: WeededAst.Type, retTpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation) extends WeededAst.Declaration
+
   }
 
   sealed trait Use

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -35,7 +35,7 @@ object WeededAst {
 
     case class Instance(doc: Ast.Doc, mod: Ast.Modifiers, clazz: Name.QName, tpe: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], defs: List[WeededAst.Declaration.Def], loc: SourceLocation) extends WeededAst.Declaration
 
-    case class Sig(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: Option[WeededAst.Expression], tpe: WeededAst.Type, retTpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation) extends WeededAst.Declaration
+    case class Sig(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: Option[WeededAst.Expression], tpe: WeededAst.Type, retTpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation)
 
     case class Def(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: WeededAst.Expression, tpe: WeededAst.Type, retTpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation) extends WeededAst.Declaration
 
@@ -47,7 +47,7 @@ object WeededAst {
 
     case class Effect(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, ops: List[WeededAst.Declaration.Op], loc: SourceLocation) extends WeededAst.Declaration
 
-    case class Op(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, fparams: List[WeededAst.FormalParam], tpe: WeededAst.Type, retTpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation) extends WeededAst.Declaration
+    case class Op(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, fparams: List[WeededAst.FormalParam], tpe: WeededAst.Type, retTpe: WeededAst.Type, eff: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation)
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -723,4 +723,28 @@ object WeederError {
     })
 
   }
+
+  /**
+    * An error raised to indicate that type parameters are present on an effect or operation.
+    *
+    * @param loc the location where the error occurred.
+    */
+  case class IllegalEffectTypeParams(loc: SourceLocation) extends WeederError {
+    def summary: String = "Unexpected effect type parameters."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Unexpected effect type parameters.
+         |
+         |${code(loc, "unexpected effect type parameters")}
+         |
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = Some({
+      import formatter._
+      s"${underline("Tip:")} Type parameters are not allowed on effects."
+    })
+  }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -197,8 +197,8 @@ object Namer {
           case LookupResult.AlreadyDefined(otherLoc) => mkDuplicateNamePair(ident.name, ident.loc, otherLoc)
         }
 
-      case _: WeededAst.Declaration.Sig =>
-        throw InternalCompilerException("Unexpected signature declaration.") // signatures should not be at the top level
+      // Not handling effects for now
+      case _: WeededAst.Declaration.Effect => prog0.toSuccess
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.{Denotation, Fixity}
+import ca.uwaterloo.flix.language.ast.ParsedAst.TypeParams
 import ca.uwaterloo.flix.language.ast._
 import ca.uwaterloo.flix.language.errors.WeederError
 import ca.uwaterloo.flix.language.errors.WeederError._
@@ -251,13 +252,15 @@ object Weeder {
       }
   }
 
-  // MATT docs
+  /**
+    * Performs weeding on the given effect declaration.
+    */
   private def visitEffect(d0: ParsedAst.Declaration.Effect)(implicit flix: Flix): Validation[List[WeededAst.Declaration.Effect], WeederError] = d0 match {
-    case ParsedAst.Declaration.Effect(doc0, mod0, sp1, ident, tparams, ops0, sp2) =>
+    case ParsedAst.Declaration.Effect(doc0, mod0, sp1, ident, tparams0, ops0, sp2) =>
       val doc = visitDoc(doc0)
       val modVal = visitModifiers(mod0, legalModifiers = Set.empty) // MATT public and stuff?
       val identVal = visitName(ident)
-      val tparamsVal = ??? // assert no tparams
+      val tparamsVal = requireNoTypeParams(tparams0)
       val opsVal = traverse(ops0)(visitOp)
       mapN(modVal, identVal, tparamsVal, opsVal) {
         case (mod, _, _, ops) =>
@@ -265,19 +268,25 @@ object Weeder {
       }
   }
 
-  // MATT docs
+  /**
+    * Performs weeding on the given effect operation.
+    */
   private def visitOp(d0: ParsedAst.Declaration.Op)(implicit flix: Flix): Validation[WeededAst.Declaration.Op, WeederError] = d0 match {
-    case ParsedAst.Declaration.Op(doc, ann0, mod0, sp1, ident, tparams0, fparamsOpt0, tpe0, pur0, tconstrs0, sp2) =>
+    case ParsedAst.Declaration.Op(doc0, ann0, mod0, sp1, ident, tparams0, fparamsOpt0, tpe0, pur0, tconstrs0, sp2) =>
+      val doc = visitDoc(doc0)
+      val annVal = visitAnnotations(ann0)
       val modVal = visitModifiers(mod0, legalModifiers = Set(Ast.Modifier.Public))
       val pubVal = requirePublic(mod0, ident)
-      val tparamsVal = ??? // assert no tparams
+      val tparamsVal = requireNoTypeParams(tparams0)
       val fparamsVal = visitFormalParams(fparamsOpt0, typeRequired = true)
-      val tpe = visitType(tpe0)
       val pur = visitEffectOrPurity(pur0, ident.loc)
       val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint)
-      mapN(modVal, pubVal, tparamsVal, fparamsVal, tconstrsVal) {
-        case (mod, _, _, fparams, tconstrs) =>
-          ??? // MATT
+      mapN(annVal, modVal, pubVal, tparamsVal, fparamsVal, tconstrsVal) {
+        case (ann, mod, _, _, fparams, tconstrs) =>
+          val ts = fparams.map(_.tpe.get)
+          val retTpe = visitType(tpe0)
+          val tpe = WeededAst.Type.Arrow(ts, pur, retTpe, ident.loc)
+          WeededAst.Declaration.Op(doc, ann, mod, ident, fparams, tpe, retTpe, pur, tconstrs, mkSL(sp1, sp2));
       }
   }
 
@@ -2147,6 +2156,18 @@ object Weeder {
     } else {
       WeederError.IllegalPrivateDeclaration(ident, ident.loc).toFailure
     }
+  }
+
+  /**
+    * Returns an error if type parameters are present.
+    */
+  private def requireNoTypeParams(tparams0: ParsedAst.TypeParams): Validation[Unit, WeederError] = tparams0 match {
+    case TypeParams.Elided => ().toSuccess
+    case TypeParams.Explicit(tparams) =>
+      // safe to take head and tail since parsing ensures nonempty type parameters if explicit
+      val sp1 = tparams.head.sp1
+      val sp2 = tparams.last.sp2
+      WeederError.IllegalEffectTypeParams(mkSL(sp1, sp2)).toFailure
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -115,7 +115,7 @@ object Weeder {
 
     case d: ParsedAst.Declaration.Instance => visitInstance(d)
 
-    case _: ParsedAst.Declaration.Effect => Nil.toSuccess // ignoring effect declarations for now
+    case d: ParsedAst.Declaration.Effect => visitEffect(d)
   }
 
   /**
@@ -250,6 +250,8 @@ object Weeder {
           List(WeededAst.Declaration.Def(doc, ann, mod, ident, tparams, fs, exp, tpe, retTpe, WeededAst.Type.True(ident.loc), tconstrs, mkSL(sp1, sp2)))
       }
   }
+
+  private def visitEffect(d0: ParsedAst.Declaration.Effect)(implicit flix: Flix): Validaiton[List[WeededAst.Declaration.Effect], WeederError] =
 
   /**
     * Performs weeding on the given enum declaration `d0`.

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -251,7 +251,35 @@ object Weeder {
       }
   }
 
-  private def visitEffect(d0: ParsedAst.Declaration.Effect)(implicit flix: Flix): Validaiton[List[WeededAst.Declaration.Effect], WeederError] =
+  // MATT docs
+  private def visitEffect(d0: ParsedAst.Declaration.Effect)(implicit flix: Flix): Validation[List[WeededAst.Declaration.Effect], WeederError] = d0 match {
+    case ParsedAst.Declaration.Effect(doc0, mod0, sp1, ident, tparams, ops0, sp2) =>
+      val doc = visitDoc(doc0)
+      val modVal = visitModifiers(mod0, legalModifiers = Set.empty) // MATT public and stuff?
+      val identVal = visitName(ident)
+      val tparamsVal = ??? // assert no tparams
+      val opsVal = traverse(ops0)(visitOp)
+      mapN(modVal, identVal, tparamsVal, opsVal) {
+        case (mod, _, _, ops) =>
+          List(WeededAst.Declaration.Effect(doc, mod, ident, ops, mkSL(sp1, sp2)))
+      }
+  }
+
+  // MATT docs
+  private def visitOp(d0: ParsedAst.Declaration.Op)(implicit flix: Flix): Validation[WeededAst.Declaration.Op, WeederError] = d0 match {
+    case ParsedAst.Declaration.Op(doc, ann0, mod0, sp1, ident, tparams0, fparamsOpt0, tpe0, pur0, tconstrs0, sp2) =>
+      val modVal = visitModifiers(mod0, legalModifiers = Set(Ast.Modifier.Public))
+      val pubVal = requirePublic(mod0, ident)
+      val tparamsVal = ??? // assert no tparams
+      val fparamsVal = visitFormalParams(fparamsOpt0, typeRequired = true)
+      val tpe = visitType(tpe0)
+      val pur = visitEffectOrPurity(pur0, ident.loc)
+      val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint)
+      mapN(modVal, pubVal, tparamsVal, fparamsVal, tconstrsVal) {
+        case (mod, _, _, fparams, tconstrs) =>
+          ??? // MATT
+      }
+  }
 
   /**
     * Performs weeding on the given enum declaration `d0`.

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -613,4 +613,51 @@ class TestWeeder extends FunSuite with TestUtils {
     val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.ReservedName](result)
   }
+
+  test("ReservedName.Effect.01") {
+    val input =
+      """
+        |eff Pure
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.ReservedName](result)
+  }
+
+  test("ReservedName.Effect.02") {
+    val input =
+      """
+        |eff Read
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.ReservedName](result)
+  }
+
+  test("ReservedName.Effect.03") {
+    val input =
+      """
+        |eff Write
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.ReservedName](result)
+  }
+
+  test("IllegalEffectTypeParams.01") {
+    val input =
+      """
+        |eff MyEffect[a]
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalEffectTypeParams](result)
+  }
+
+  test("IllegalEffectTypeParams.02") {
+    val input =
+      """
+        |eff MyEffect {
+        |    def op[a](x: a): Bool
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalEffectTypeParams](result)
+  }
 }

--- a/main/test/flix/Test.Dec.Effect.flix
+++ b/main/test/flix/Test.Dec.Effect.flix
@@ -1,44 +1,39 @@
 namespace Test/Dec/Effect {
     eff Console {
         // Will be removed after Weeder checks are added
-        def readLine(): String
-        def println(s: String): Unit
+        pub def readLine(): String
+        pub def println(s: String): Unit
     }
 
     eff Throw {
         // Will be removed after Weeder checks are added
-        def throw(): a
+        pub def throw(): a
     }
 
     eff Nondeterminism {
-        def fail(): Unit
+        pub def fail(): Unit
         // Will be removed after Weeder checks are added
-        def decide(): Bool
+        pub def decide(): Bool
     }
 
     eff State {
         // Will be removed after Weeder checks are added
-        def get_(): Int
-        def set_(x: Int): Unit
+        pub def get_(): Int
+        pub def set_(x: Int): Unit
     }
 
     eff Threading {
-        def yield(): Unit
-        def spawn_(f: Unit -> Unit): Unit
+        pub def yield(): Unit
+        pub def spawn_(f: Unit -> Unit): Unit
 
         // Will be removed after Weeder checks are added
-        def getNext(): Option[Unit -> Unit]
-        def enqueue(f: Unit -> Unit): Unit
+        pub def getNext(): Option[Unit -> Unit]
+        pub def enqueue(f: Unit -> Unit): Unit
     }
 
     eff Empty
 
     eff EmptyWithParens {
 
-    }
-
-    // Will be removed after Weeder checks are added
-    eff Polymorphic[a] {
-        def op[a](): a
     }
 }

--- a/main/test/flix/Test.Exp.Effect.flix
+++ b/main/test/flix/Test.Exp.Effect.flix
@@ -141,15 +141,15 @@ namespace Test/Exp/Effect {
     eff Empty
 
     eff Fail {
-        def fail(x: String): Unit
+        pub def fail(x: String): Unit
     }
 
     eff Console {
-        def readln(): String
-        def println(x: String): Unit
+        pub def readln(): String
+        pub def println(x: String): Unit
     }
 
     eff Flip {
-        def flip(): Bool
+        pub def flip(): Bool
     }
 }


### PR DESCRIPTION
related to #3543

Handles the following requirements:

Constructs:
- Introduce `Declaration.Eff`.

Checks:
- Reject effects with type parameters (but allow them to be parsed).
- Duplicate Modifier.
- Require public (or?)
- Ban effects called `Pure`, `Read` and `Write`. (Maybe even have an error for each to explain whats up)