### PR TITLE
feat: eliminate single case enum

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Inliner.scala
@@ -287,7 +287,11 @@ object Inliner {
 
     case OccurrenceAst.Expression.Is(sym, tag, exp, purity, loc) =>
       val e = visitExp(exp, subst0)
-      LiftedAst.Expression.Is(sym, tag, e, purity, loc)
+      val enum0 = root.enums(sym)
+      if (enum0.cases.size == 1 && e.purity == Pure)
+          LiftedAst.Expression.True(loc)
+      else
+        LiftedAst.Expression.Is(sym, tag, e, purity, loc)
 
     case OccurrenceAst.Expression.Tag(sym, tag, exp, tpe, purity, loc) =>
       val e = visitExp(exp, subst0)


### PR DESCRIPTION
Task 3 from #3638 

Do we need to somehow check that the value of `e` points to the single case in the enum?