### PR TITLE
refactor: remove ParsedAst.Type.Unit

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1322,14 +1322,6 @@ object ParsedAst {
   object Type {
 
     /**
-      * Unit type.
-      *
-      * @param sp1 the position of the first character in the type.
-      * @param sp2 the position of the last character in the type.
-      */
-    case class Unit(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Type
-
-    /**
       * Type Variable.
       *
       * @param sp1   the position of the first character in the type.
@@ -1735,7 +1727,7 @@ object ParsedAst {
     * @param tpe   the type of the declared tag
     * @param sp2   the position of the last character in the case declaration.
     */
-  case class Case(sp1: SourcePosition, ident: Name.Ident, tpe: ParsedAst.Type, sp2: SourcePosition)
+  case class Case(sp1: SourcePosition, ident: Name.Ident, tpe: Option[ParsedAst.Type], sp2: SourcePosition)
 
   /**
     * A common super-type for a sequence of type parameters.

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -143,19 +143,8 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def Enum: Rule1[ParsedAst.Declaration.Enum] = {
-      def Case: Rule1[ParsedAst.Case] = {
-        def CaseWithUnit: Rule1[ParsedAst.Case] = namedRule("Case") {
-          SP ~ Names.Tag ~ SP ~> ((sp1: SourcePosition, ident: Name.Ident, sp2: SourcePosition) =>
-            ParsedAst.Case(sp1, ident, ParsedAst.Type.Unit(sp1, sp2), sp2))
-        }
-
-        def CaseWithType: Rule1[ParsedAst.Case] = namedRule("Case") {
-          SP ~ Names.Tag ~ Types.Tuple ~ SP ~> ParsedAst.Case
-        }
-
-        rule {
-          CaseWithType | CaseWithUnit
-        }
+      def Case: Rule1[ParsedAst.Case] = rule {
+        SP ~ Names.Tag ~ optional(Types.Tuple) ~ SP ~> ParsedAst.Case
       }
 
       def NonEmptyCaseList: Rule1[Seq[ParsedAst.Case]] = rule {


### PR DESCRIPTION
It fooled me into thinking it actually meant something, but really it is only used for this one enum case case, which IMO is more the responsibility of the Weeder.