### PR TITLE
refactor: remove unused return and use ZipWithIndex

### DIFF
--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -1360,7 +1360,7 @@ namespace Array {
         let l = new MutList(static);
         def loop(i) = {
             if (i >= len)
-                Nil
+                ()
             else {
                 if (f(a[i])) MutList.push!(i, l) else ();
                 loop(i + 1)
@@ -1478,11 +1478,11 @@ namespace Array {
     /// The function returns the final value of the accumulator `s`.
     ///
     @Time(time(f) * length(a)) @Space(space(f))
-    def foreachAccum(f: (a, b) -> b & ef, s: b, a: Array[a]): b & Impure =
+    def foreachAccum(f: (a, b) -> b & ef, s: b, a: Array[a]): Unit & Impure =
         let len = length(a);
         def loop(i, acc) = {
             if (i >= len)
-                acc
+                ()
             else
                 loop(i + 1, f(a[i], acc))
         };

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -1201,7 +1201,7 @@ namespace List {
         case Some(x) =>
             let a = Array.new(x, length(l));
             let f = (i, b) -> { a[i] = b; i + 1 };
-            foldLeft(f, 0, l);
+            foreach((b, i) -> a[i] = b, zipWithIndex(l))
             a
         }
 


### PR DESCRIPTION
This is in preparation for disallowing discarding non-unit values