### PR TITLE
fix: make type alias erasure work for both unkinded and kinded types

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -945,11 +945,11 @@ object Type {
     * to clear all aliases for easier processing.
     */
   def eraseAliases(t: Type): Type = t match {
-    case tvar: Type.Var => tvar.asKinded
+    case tvar: Type.Var => tvar
     case Type.Cst(_, _) => t
     case Type.Apply(tpe1, tpe2, loc) => Type.Apply(eraseAliases(tpe1), eraseAliases(tpe2), loc)
     case Type.Alias(_, _, tpe, _) => eraseAliases(tpe)
-    case Type.Ascribe(_, _, _) => throw InternalCompilerException("Unexpected type ascription.")
+    case Type.Ascribe(tpe, kind, loc) => Type.Ascribe(tpe, kind, loc)
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -893,4 +893,15 @@ class TestResolver extends FunSuite with TestUtils {
     val result = compile(input, Options.TestWithLibNix)
     expectError[ResolutionError.IllegalDerivation](result)
   }
+
+  test("IllegalType.01") {
+    val input =
+      """
+        |def isThisThingNull(x: a): Bool =
+        |    import static java.util.Objects.isNull(a): Bool & Pure;
+        |    isNull(x)
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ResolutionError.IllegalType](result)
+  }
 }


### PR DESCRIPTION
fixes #3692. This IllegalType error also needs a refactor separately, as it uses `formatWellKindedType` on unkinded types.