### PR TITLE
fix: make flix-pkg zip the src directory not the build directory

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/Packager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Packager.scala
@@ -314,7 +314,7 @@ object Packager {
 
       // Add all source files.
       // Here we sort entries by relative file name to apply https://reproducible-builds.org/
-      for ((sourceFile, fileNameWithSlashes) <- getAllFiles(getBuildDirectory(p))
+      for ((sourceFile, fileNameWithSlashes) <- getAllFiles(getSourceDirectory(p))
           .map{path=>(path, convertPathToRelativeFileName(p, path))}
           .sortBy(_._2)) {
         addToZip(zip, fileNameWithSlashes, sourceFile)


### PR DESCRIPTION
I think there was a copy/paste error with a recent change to `packager.scala` and the directory that `buildPkg` packages into a zip was changed from `src` to `build` so subsequently the `.fpkg` file wrongly contains `.class` files not Flix source files.

This change puts it back to `src`.