### PR TITLE
refactor: move `Test.Exp.{Apply, Ascribe, BigInt, Binary, Match, Record}`

### DIFF
--- a/main/test/flix/CompilerSuite.scala
+++ b/main/test/flix/CompilerSuite.scala
@@ -31,6 +31,20 @@ class CompilerSuite extends FlixSuite(incremental = true) {
   mkTest("main/test/flix/Test.Exp.Ascribe.flix")
 
   //
+  // BigInt.
+  //
+  mkTest("main/test/flix/Test.Exp.BigInt.flix")
+
+  //
+  // Binary.
+  //
+  mkTest("main/test/flix/Test.Exp.Binary.Arithmetic.flix")
+  mkTest("main/test/flix/Test.Exp.Binary.Bitwise.flix")
+  mkTest("main/test/flix/Test.Exp.Binary.Comparison.flix")
+  mkTest("main/test/flix/Test.Exp.Binary.Logic.flix")
+  mkTest("main/test/flix/Test.Exp.Binary.Spaceship.flix")
+
+  //
   // Fixpoint
   //
   mkTest("main/test/flix/Test.Exp.Fixpoint.Compose.flix")
@@ -40,7 +54,6 @@ class CompilerSuite extends FlixSuite(incremental = true) {
   mkTest("main/test/flix/Test.Exp.Fixpoint.Query.flix")
   mkTest("main/test/flix/Test.Exp.Fixpoint.Solve.flix")
   mkTest("main/test/flix/Test.Exp.Fixpoint.Solve.Lattice.flix")
-
 
   //
   // Match.
@@ -60,7 +73,6 @@ class CompilerSuite extends FlixSuite(incremental = true) {
   mkTest("main/test/flix/Test.Exp.Match.Tag.flix")
   mkTest("main/test/flix/Test.Exp.Match.Unit.flix")
   mkTest("main/test/flix/Test.Exp.Match.Wild.flix")
-
 
   //
   // Record.

--- a/main/test/flix/CompilerSuite.scala
+++ b/main/test/flix/CompilerSuite.scala
@@ -5,6 +5,13 @@ import ca.uwaterloo.flix.util.{FlixSuite, Options}
 class CompilerSuite extends FlixSuite(incremental = true) {
   implicit val options: Options = Options.TestWithLibAll
 
+
+  //
+  // Apply.
+  //
+  mkTest("main/test/flix/Test.Exp.Apply.Tail.flix")
+  mkTest("main/test/flix/Test.Exp.Apply.Named.flix")
+
   //
   // Arrays
   //
@@ -19,10 +26,9 @@ class CompilerSuite extends FlixSuite(incremental = true) {
   mkTest("main/test/flix/Test.Exp.ArrayStore.flix")
 
   //
-  // Apply.
+  // Ascribe.
   //
-  mkTest("main/test/flix/Test.Exp.Apply.Tail.flix")
-  mkTest("main/test/flix/Test.Exp.Apply.Named.flix")
+  mkTest("main/test/flix/Test.Exp.Ascribe.flix")
 
   //
   // Fixpoint

--- a/main/test/flix/CompilerSuite.scala
+++ b/main/test/flix/CompilerSuite.scala
@@ -19,6 +19,12 @@ class CompilerSuite extends FlixSuite(incremental = true) {
   mkTest("main/test/flix/Test.Exp.ArrayStore.flix")
 
   //
+  // Apply.
+  //
+  mkTest("main/test/flix/Test.Exp.Apply.Tail.flix")
+  mkTest("main/test/flix/Test.Exp.Apply.Named.flix")
+
+  //
   // Fixpoint
   //
   mkTest("main/test/flix/Test.Exp.Fixpoint.Compose.flix")

--- a/main/test/flix/CompilerSuite.scala
+++ b/main/test/flix/CompilerSuite.scala
@@ -41,4 +41,24 @@ class CompilerSuite extends FlixSuite(incremental = true) {
   mkTest("main/test/flix/Test.Exp.Fixpoint.Solve.flix")
   mkTest("main/test/flix/Test.Exp.Fixpoint.Solve.Lattice.flix")
 
+
+  //
+  // Match.
+  //
+  mkTest("main/test/flix/Test.Exp.Match.Array.flix")
+  mkTest("main/test/flix/Test.Exp.Match.Bool.flix")
+  mkTest("main/test/flix/Test.Exp.Match.Char.flix")
+  mkTest("main/test/flix/Test.Exp.Match.Guard.flix")
+  mkTest("main/test/flix/Test.Exp.Match.Float32.flix")
+  mkTest("main/test/flix/Test.Exp.Match.Float64.flix")
+  mkTest("main/test/flix/Test.Exp.Match.Int8.flix")
+  mkTest("main/test/flix/Test.Exp.Match.Int16.flix")
+  mkTest("main/test/flix/Test.Exp.Match.Int32.flix")
+  mkTest("main/test/flix/Test.Exp.Match.Int64.flix")
+  mkTest("main/test/flix/Test.Exp.Match.List.flix")
+  mkTest("main/test/flix/Test.Exp.Match.String.flix")
+  mkTest("main/test/flix/Test.Exp.Match.Tag.flix")
+  mkTest("main/test/flix/Test.Exp.Match.Unit.flix")
+  mkTest("main/test/flix/Test.Exp.Match.Wild.flix")
+
 }

--- a/main/test/flix/CompilerSuite.scala
+++ b/main/test/flix/CompilerSuite.scala
@@ -61,4 +61,16 @@ class CompilerSuite extends FlixSuite(incremental = true) {
   mkTest("main/test/flix/Test.Exp.Match.Unit.flix")
   mkTest("main/test/flix/Test.Exp.Match.Wild.flix")
 
+
+  //
+  // Record.
+  //
+  mkTest("main/test/flix/Test.Exp.Record.Extend.flix")
+  mkTest("main/test/flix/Test.Exp.Record.Literal.flix")
+  mkTest("main/test/flix/Test.Exp.Record.Multiple.flix")
+  mkTest("main/test/flix/Test.Exp.Record.Polymorphism.flix")
+  mkTest("main/test/flix/Test.Exp.Record.Restrict.flix")
+  mkTest("main/test/flix/Test.Exp.Record.Select.flix")
+  mkTest("main/test/flix/Test.Exp.Record.Update.flix")
+
 }

--- a/main/test/flix/LangSuite.scala
+++ b/main/test/flix/LangSuite.scala
@@ -61,11 +61,6 @@ class LangSuite extends Suites(
   new FlixTest("Test.Equality.Set", "main/test/flix/Test.Equality.Set.flix")(Options.TestWithLibAll),
 
   //
-  // Ascribe.
-  //
-  new FlixTest("Test.Exp.Ascribe", "main/test/flix/Test.Exp.Ascribe.flix")(Options.TestWithLibAll),
-
-  //
   // BigInt.
   //
   new FlixTest("Test.Exp.BigInt", "main/test/flix/Test.Exp.BigInt.flix"),

--- a/main/test/flix/LangSuite.scala
+++ b/main/test/flix/LangSuite.scala
@@ -211,17 +211,6 @@ class LangSuite extends Suites(
   new FlixTest("Test.Exp.Null", "main/test/flix/Test.Exp.Null.flix"),
 
   //
-  // Record.
-  //
-  new FlixTest("Test.Exp.Record.Extend", "main/test/flix/Test.Exp.Record.Extend.flix"),
-  new FlixTest("Test.Exp.Record.Literal", "main/test/flix/Test.Exp.Record.Literal.flix"),
-  new FlixTest("Test.Exp.Record.Multiple", "main/test/flix/Test.Exp.Record.Multiple.flix"),
-  new FlixTest("Test.Exp.Record.Polymorphism", "main/test/flix/Test.Exp.Record.Polymorphism.flix"),
-  new FlixTest("Test.Exp.Record.Restrict", "main/test/flix/Test.Exp.Record.Restrict.flix"),
-  new FlixTest("Test.Exp.Record.Select", "main/test/flix/Test.Exp.Record.Select.flix"),
-  new FlixTest("Test.Exp.Record.Update", "main/test/flix/Test.Exp.Record.Update.flix"),
-
-  //
   // Reference.
   //
   new FlixTest("Test.Exp.Ref", List(

--- a/main/test/flix/LangSuite.scala
+++ b/main/test/flix/LangSuite.scala
@@ -206,25 +206,6 @@ class LangSuite extends Suites(
   new FlixTest("Test.Exp.List", "main/test/flix/Test.Exp.List.flix"),
 
   //
-  // Match.
-  //
-  new FlixTest("Test.Exp.Match.Array", "main/test/flix/Test.Exp.Match.Array.flix"),
-  new FlixTest("Test.Exp.Match.Bool", "main/test/flix/Test.Exp.Match.Bool.flix"),
-  new FlixTest("Test.Exp.Match.Char", "main/test/flix/Test.Exp.Match.Char.flix"),
-  new FlixTest("Test.Exp.Match.Guard", "main/test/flix/Test.Exp.Match.Guard.flix"),
-  new FlixTest("Test.Exp.Match.Float32", "main/test/flix/Test.Exp.Match.Float32.flix"),
-  new FlixTest("Test.Exp.Match.Float64", "main/test/flix/Test.Exp.Match.Float64.flix"),
-  new FlixTest("Test.Exp.Match.Int8", "main/test/flix/Test.Exp.Match.Int8.flix"),
-  new FlixTest("Test.Exp.Match.Int16", "main/test/flix/Test.Exp.Match.Int16.flix"),
-  new FlixTest("Test.Exp.Match.Int32", "main/test/flix/Test.Exp.Match.Int32.flix"),
-  new FlixTest("Test.Exp.Match.Int64", "main/test/flix/Test.Exp.Match.Int64.flix"),
-  new FlixTest("Test.Exp.Match.List", "main/test/flix/Test.Exp.Match.List.flix"),
-  new FlixTest("Test.Exp.Match.String", "main/test/flix/Test.Exp.Match.String.flix"),
-  new FlixTest("Test.Exp.Match.Tag", "main/test/flix/Test.Exp.Match.Tag.flix"),
-  new FlixTest("Test.Exp.Match.Unit", "main/test/flix/Test.Exp.Match.Unit.flix"),
-  new FlixTest("Test.Exp.Match.Wild", "main/test/flix/Test.Exp.Match.Wild.flix"),
-
-  //
   // Null.
   //
   new FlixTest("Test.Exp.Null", "main/test/flix/Test.Exp.Null.flix"),

--- a/main/test/flix/LangSuite.scala
+++ b/main/test/flix/LangSuite.scala
@@ -61,20 +61,6 @@ class LangSuite extends Suites(
   new FlixTest("Test.Equality.Set", "main/test/flix/Test.Equality.Set.flix")(Options.TestWithLibAll),
 
   //
-  // BigInt.
-  //
-  new FlixTest("Test.Exp.BigInt", "main/test/flix/Test.Exp.BigInt.flix"),
-
-  //
-  // Binary.
-  //
-  new FlixTest("Test.Exp.Binary.Arithmetic", "main/test/flix/Test.Exp.Binary.Arithmetic.flix"),
-  new FlixTest("Test.Exp.Binary.Bitwise", "main/test/flix/Test.Exp.Binary.Bitwise.flix"),
-  new FlixTest("Test.Exp.Binary.Comparison", "main/test/flix/Test.Exp.Binary.Comparison.flix"),
-  new FlixTest("Test.Exp.Binary.Logic", "main/test/flix/Test.Exp.Binary.Logic.flix"),
-  new FlixTest("Test.Exp.Binary.Spaceship", "main/test/flix/Test.Exp.Binary.Spaceship.flix")(Options.TestWithLibAll),
-
-  //
   // Block.
   //
   new FlixTest("Test.Exp.Block", "main/test/flix/Test.Exp.Block.flix"),

--- a/main/test/flix/LangSuite.scala
+++ b/main/test/flix/LangSuite.scala
@@ -61,12 +61,6 @@ class LangSuite extends Suites(
   new FlixTest("Test.Equality.Set", "main/test/flix/Test.Equality.Set.flix")(Options.TestWithLibAll),
 
   //
-  // Apply.
-  //
-  new FlixTest("Test.Exp.Apply.Tail", "main/test/flix/Test.Exp.Apply.Tail.flix"),
-  new FlixTest("Test.Exp.Apply.Named", "main/test/flix/Test.Exp.Apply.Named.flix"),
-
-  //
   // Ascribe.
   //
   new FlixTest("Test.Exp.Ascribe", "main/test/flix/Test.Exp.Ascribe.flix")(Options.TestWithLibAll),


### PR DESCRIPTION
Related to #3144