### PR TITLE
refactor: move `Test.Exp.*`

### DIFF
--- a/main/test/flix/CompilerSuite.scala
+++ b/main/test/flix/CompilerSuite.scala
@@ -45,6 +45,36 @@ class CompilerSuite extends FlixSuite(incremental = true) {
   mkTest("main/test/flix/Test.Exp.Binary.Spaceship.flix")
 
   //
+  // Block.
+  //
+  mkTest("main/test/flix/Test.Exp.Block.flix")
+
+  //
+  // Cast.
+  //
+  mkTest("main/test/flix/Test.Exp.Cast.flix")
+
+  //
+  // Char.
+  //
+  mkTest("main/test/flix/Test.Exp.Char.flix")
+
+  //
+  // Choose.
+  //
+  mkTest("main/test/flix/Test.Exp.Choose.flix")
+  mkTest("main/test/flix/Test.Exp.ChooseStar.flix")
+
+  //
+  // Concurrency.
+  //
+  mkTest("main/test/flix/Test.Exp.Concurrency.Buffered.flix")
+  mkTest("main/test/flix/Test.Exp.Concurrency.NewChannel.flix")
+  mkTest("main/test/flix/Test.Exp.Concurrency.Unbuffered.flix")
+  mkTest("main/test/flix/Test.Exp.Concurrency.Spawn.flix")
+  mkTest("main/test/flix/Test.Exp.Concurrency.Select.flix")
+
+  //
   // Fixpoint
   //
   mkTest("main/test/flix/Test.Exp.Fixpoint.Compose.flix")

--- a/main/test/flix/CompilerSuite.scala
+++ b/main/test/flix/CompilerSuite.scala
@@ -72,7 +72,7 @@ class CompilerSuite extends FlixSuite(incremental = true) {
   mkTest("main/test/flix/Test.Exp.Concurrency.NewChannel.flix")
   mkTest("main/test/flix/Test.Exp.Concurrency.Unbuffered.flix")
   mkTest("main/test/flix/Test.Exp.Concurrency.Spawn.flix")
-  mkTest("main/test/flix/Test.Exp.Concurrency.Select.flix")
+  mkTest("main/test/flix/Test.Exp.Concurrency.Select.flix")(Options.DefaultTest.copy(xallowredundancies = true))
 
   //
   // Fixpoint
@@ -84,6 +84,60 @@ class CompilerSuite extends FlixSuite(incremental = true) {
   mkTest("main/test/flix/Test.Exp.Fixpoint.Query.flix")
   mkTest("main/test/flix/Test.Exp.Fixpoint.Solve.flix")
   mkTest("main/test/flix/Test.Exp.Fixpoint.Solve.Lattice.flix")
+
+  //
+  // Default.
+  //
+  mkTest("main/test/flix/Test.Exp.Default.flix")
+
+  //
+  // Discard.
+  //
+  mkTest("main/test/flix/Test.Exp.Discard.flix")
+
+  //
+  // Effects.
+  //
+  mkTest("main/test/flix/Test.Exp.Effect.flix")
+
+  //
+  // Floats.
+  //
+  mkTest("main/test/flix/Test.Exp.Float32.flix")
+  mkTest("main/test/flix/Test.Exp.Float64.flix")
+
+  //
+  // Force.
+  //
+  mkTest("main/test/flix/Test.Exp.Force.flix")
+
+  //
+  // Hole.
+  //
+  mkTest("main/test/flix/Test.Exp.Hole.flix")
+
+  //
+  // IfThenElse.
+  //
+  mkTest("main/test/flix/Test.Exp.IfThenElse.flix")
+
+  //
+  // Infix.
+  //
+  mkTest("main/test/flix/Test.Exp.Infix.flix")
+
+  //
+  // Int.
+  //
+  mkTest("main/test/flix/Test.Exp.Int8.flix")
+  mkTest("main/test/flix/Test.Exp.Int16.flix")
+  mkTest("main/test/flix/Test.Exp.Int32.flix")
+  mkTest("main/test/flix/Test.Exp.Int64.flix")
+
+  //
+  // Interpolation.
+  //
+  mkTest("main/test/flix/Test.Exp.Interpolation.flix")
 
   //
   // Match.

--- a/main/test/flix/CompilerSuite.scala
+++ b/main/test/flix/CompilerSuite.scala
@@ -75,17 +75,6 @@ class CompilerSuite extends FlixSuite(incremental = true) {
   mkTest("main/test/flix/Test.Exp.Concurrency.Select.flix")(Options.DefaultTest.copy(xallowredundancies = true))
 
   //
-  // Fixpoint
-  //
-  mkTest("main/test/flix/Test.Exp.Fixpoint.Compose.flix")
-  mkTest("main/test/flix/Test.Exp.Fixpoint.Constraint.flix")
-  mkTest("main/test/flix/Test.Exp.Fixpoint.Lambda.flix")
-  mkTest("main/test/flix/Test.Exp.Fixpoint.Project.flix")
-  mkTest("main/test/flix/Test.Exp.Fixpoint.Query.flix")
-  mkTest("main/test/flix/Test.Exp.Fixpoint.Solve.flix")
-  mkTest("main/test/flix/Test.Exp.Fixpoint.Solve.Lattice.flix")
-
-  //
   // Default.
   //
   mkTest("main/test/flix/Test.Exp.Default.flix")
@@ -99,6 +88,17 @@ class CompilerSuite extends FlixSuite(incremental = true) {
   // Effects.
   //
   mkTest("main/test/flix/Test.Exp.Effect.flix")
+
+  //
+  // Fixpoint
+  //
+  mkTest("main/test/flix/Test.Exp.Fixpoint.Compose.flix")
+  mkTest("main/test/flix/Test.Exp.Fixpoint.Constraint.flix")
+  mkTest("main/test/flix/Test.Exp.Fixpoint.Lambda.flix")
+  mkTest("main/test/flix/Test.Exp.Fixpoint.Project.flix")
+  mkTest("main/test/flix/Test.Exp.Fixpoint.Query.flix")
+  mkTest("main/test/flix/Test.Exp.Fixpoint.Solve.flix")
+  mkTest("main/test/flix/Test.Exp.Fixpoint.Solve.Lattice.flix")
 
   //
   // Floats.

--- a/main/test/flix/LangSuite.scala
+++ b/main/test/flix/LangSuite.scala
@@ -61,36 +61,6 @@ class LangSuite extends Suites(
   new FlixTest("Test.Equality.Set", "main/test/flix/Test.Equality.Set.flix")(Options.TestWithLibAll),
 
   //
-  // Block.
-  //
-  new FlixTest("Test.Exp.Block", "main/test/flix/Test.Exp.Block.flix"),
-
-  //
-  // Cast.
-  //
-  new FlixTest("Test.Exp.Cast", "main/test/flix/Test.Exp.Cast.flix")(Options.TestWithLibAll),
-
-  //
-  // Char.
-  //
-  new FlixTest("Test.Exp.Char", "main/test/flix/Test.Exp.Char.flix"),
-
-  //
-  // Choose.
-  //
-  new FlixTest("Test.Exp.Choose", "main/test/flix/Test.Exp.Choose.flix")(Options.TestWithLibAll),
-  new FlixTest("Test.Exp.ChooseStar", "main/test/flix/Test.Exp.ChooseStar.flix")(Options.TestWithLibAll),
-
-  //
-  // Concurrency.
-  //
-  new FlixTest("Test.Exp.Concurrency.Buffered", "main/test/flix/Test.Exp.Concurrency.Buffered.flix")(Options.TestWithLibAll),
-  new FlixTest("Test.Exp.Concurrency.NewChannel", "main/test/flix/Test.Exp.Concurrency.NewChannel.flix")(Options.TestWithLibAll),
-  new FlixTest("Test.Exp.Concurrency.Unbuffered", "main/test/flix/Test.Exp.Concurrency.Unbuffered.flix")(Options.TestWithLibAll),
-  new FlixTest("Test.Exp.Concurrency.Spawn", "main/test/flix/Test.Exp.Concurrency.Spawn.flix")(Options.TestWithLibAll),
-  new FlixTest("Test.Exp.Concurrency.Select", "main/test/flix/Test.Exp.Concurrency.Select.flix")(Options.DefaultTest.copy(xallowredundancies = true)),
-
-  //
   // Default.
   //
   new FlixTest("Test.Exp.Default", "main/test/flix/Test.Exp.Default.flix"),

--- a/main/test/flix/LangSuite.scala
+++ b/main/test/flix/LangSuite.scala
@@ -61,60 +61,6 @@ class LangSuite extends Suites(
   new FlixTest("Test.Equality.Set", "main/test/flix/Test.Equality.Set.flix")(Options.TestWithLibAll),
 
   //
-  // Default.
-  //
-  new FlixTest("Test.Exp.Default", "main/test/flix/Test.Exp.Default.flix"),
-
-  //
-  // Discard.
-  //
-  new FlixTest("Test.Exp.Discard", "main/test/flix/Test.Exp.Discard.flix"),
-
-  //
-  // Effects.
-  //
-  new FlixTest("Test.Exp.Effect", "main/test/flix/Test.Exp.Effect.flix"),
-
-  //
-  // Floats.
-  //
-  new FlixTest("Test.Exp.Float32", "main/test/flix/Test.Exp.Float32.flix"),
-  new FlixTest("Test.Exp.Float64", "main/test/flix/Test.Exp.Float64.flix"),
-
-  //
-  // Force.
-  //
-  new FlixTest("Test.Exp.Force", "main/test/flix/Test.Exp.Force.flix"),
-
-  //
-  // Hole.
-  //
-  new FlixTest("Test.Exp.Hole", "main/test/flix/Test.Exp.Hole.flix")(Options.TestWithLibAll),
-
-  //
-  // IfThenElse.
-  //
-  new FlixTest("Test.Exp.IfThenElse", "main/test/flix/Test.Exp.IfThenElse.flix"),
-
-  //
-  // Infix.
-  //
-  new FlixTest("Test.Exp.Infix", "main/test/flix/Test.Exp.Infix.flix"),
-
-  //
-  // Int.
-  //
-  new FlixTest("Test.Exp.Int8", "main/test/flix/Test.Exp.Int8.flix"),
-  new FlixTest("Test.Exp.Int16", "main/test/flix/Test.Exp.Int16.flix"),
-  new FlixTest("Test.Exp.Int32", "main/test/flix/Test.Exp.Int32.flix"),
-  new FlixTest("Test.Exp.Int64", "main/test/flix/Test.Exp.Int64.flix"),
-
-  //
-  // Interpolation.
-  //
-  new FlixTest("Test.Exp.Interpolation", "main/test/flix/Test.Exp.Interpolation.flix"),
-
-  //
   // JVM.
   //
   new FlixTest("Test.Exp.Jvm.GetField", "main/test/flix/Test.Exp.Jvm.GetField.flix"),


### PR DESCRIPTION
Related to https://github.com/flix/flix/issues/3144

In this PR

- Block
- Cast
- Char
- Choose
- Concurrency
- Default
- Discard
- Effects
- Floats
- Force
- Hole
- IfThenElse
- Infix
- Int
- Interpolation