### PR TITLE
fix: correct equality on strong/weak edges (fixes #3704)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/UllmansAlgorithm.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/UllmansAlgorithm.scala
@@ -41,7 +41,7 @@ object UllmansAlgorithm {
       case _: DependencyEdge.Strong => 7 * Objects.hash(head, body)
     }
 
-    override def equals(obj: Any): Boolean = (this, obj) match {
+    override def equals(that: Any): Boolean = (this, that) match {
       case (DependencyEdge.Weak(head1, body1, _), DependencyEdge.Weak(head2, body2, _)) =>
         head1 == head2 && body1 == body2
       case (DependencyEdge.Strong(head1, body1, _), DependencyEdge.Strong(head2, body2, _)) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/UllmansAlgorithm.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/UllmansAlgorithm.scala
@@ -41,8 +41,11 @@ object UllmansAlgorithm {
       case _: DependencyEdge.Strong => 7 * Objects.hash(head, body)
     }
 
-    override def equals(obj: Any): Boolean = obj match {
-      case that: DependencyEdge => this.head == that.head && this.body == that.body
+    override def equals(obj: Any): Boolean = (this, obj) match {
+      case (DependencyEdge.Weak(head1, body1, _), DependencyEdge.Weak(head2, body2, _)) =>
+        head1 == head2 && body1 == body2
+      case (DependencyEdge.Strong(head1, body1, _), DependencyEdge.Strong(head2, body2, _)) =>
+        head1 == head2 && body1 == body2
       case _ => false
     }
   }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestStratifier.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestStratifier.scala
@@ -239,9 +239,9 @@ class TestStratifier extends FunSuite with TestUtils {
       """
         |pub def f(): Int32 =
         |    let p = #{
-        |        Something42(1; 2) :- fix Something42(2; 3).
+        |        A(1; 2) :- fix A(2; 3).
         |    };
-        |    let ans = query p select (a,b) from Something42(a; b);
+        |    let ans = query p select (a,b) from A(a; b);
         |    Array.length(ans)
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
@@ -253,9 +253,9 @@ class TestStratifier extends FunSuite with TestUtils {
       """
         |pub def f(): Int32 =
         |    let p = #{
-        |        Something42(1; 2) :- Something42(2; 3), fix Something42(2; 3).
+        |        A(1; 2) :- A(2; 3), fix A(2; 3).
         |    };
-        |    let ans = query p select (a,b) from Something42(a; b);
+        |    let ans = query p select (a,b) from A(a; b);
         |    Array.length(ans)
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
@@ -267,9 +267,9 @@ class TestStratifier extends FunSuite with TestUtils {
       """
         |pub def f(): Int32 =
         |    let p = #{
-        |        Something42(1; 2) :- fix Something42(2; 3), Something42(2; 3).
+        |        A(1; 2) :- fix A(2; 3), A(2; 3).
         |    };
-        |    let ans = query p select (a,b) from Something42(a; b);
+        |    let ans = query p select (a,b) from A(a; b);
         |    Array.length(ans)
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
@@ -281,9 +281,9 @@ class TestStratifier extends FunSuite with TestUtils {
       """
         |pub def f(): Int32 =
         |    let p = #{
-        |        Something42(1; 2) :- not Something42(2; 3).
+        |        A(1; 2) :- not A(2; 3).
         |    };
-        |    let ans = query p select (a,b) from Something42(a; b);
+        |    let ans = query p select (a,b) from A(a; b);
         |    Array.length(ans)
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
@@ -295,9 +295,9 @@ class TestStratifier extends FunSuite with TestUtils {
       """
         |pub def f(): Int32 =
         |    let p = #{
-        |        Something42(1; 2) :- Something42(2; 3), not Something42(2; 3).
+        |        A(1; 2) :- A(2; 3), not A(2; 3).
         |    };
-        |    let ans = query p select (a,b) from Something42(a; b);
+        |    let ans = query p select (a,b) from A(a; b);
         |    Array.length(ans)
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
@@ -309,9 +309,9 @@ class TestStratifier extends FunSuite with TestUtils {
       """
         |pub def f(): Int32 =
         |    let p = #{
-        |        Something42(1; 2) :- not Something42(2; 3), Something42(2; 3).
+        |        A(1; 2) :- not A(2; 3), A(2; 3).
         |    };
-        |    let ans = query p select (a,b) from Something42(a; b);
+        |    let ans = query p select (a,b) from A(a; b);
         |    Array.length(ans)
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestStratifier.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestStratifier.scala
@@ -235,4 +235,46 @@ class TestStratifier extends FunSuite with TestUtils {
     expectError[StratificationError](result)
   }
 
+  test("Stratification.15") {
+    val input =
+      """
+        |pub def f(): Int32 =
+        |    let p = #{
+        |        Something42(1; 2) :- fix Something42(2; 3).
+        |    };
+        |    let ans = query p select (a,b) from Something42(a; b);
+        |    Array.length(ans)
+      """.stripMargin
+    val result = compile(input, Options.TestWithLibAll)
+    expectError[StratificationError](result)
+  }
+
+  test("Stratification.16") {
+    val input =
+      """
+        |pub def f(): Int32 =
+        |    let p = #{
+        |        Something42(1; 2) :- Something42(2; 3), fix Something42(2; 3).
+        |    };
+        |    let ans = query p select (a,b) from Something42(a; b);
+        |    Array.length(ans)
+      """.stripMargin
+    val result = compile(input, Options.TestWithLibAll)
+    expectError[StratificationError](result)
+  }
+
+  test("Stratification.17") {
+    val input =
+      """
+        |pub def f(): Int32 =
+        |    let p = #{
+        |        Something42(1; 2) :- fix Something42(2; 3), Something42(2; 3).
+        |    };
+        |    let ans = query p select (a,b) from Something42(a; b);
+        |    Array.length(ans)
+      """.stripMargin
+    val result = compile(input, Options.TestWithLibAll)
+    expectError[StratificationError](result)
+  }
+
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestStratifier.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestStratifier.scala
@@ -241,7 +241,7 @@ class TestStratifier extends FunSuite with TestUtils {
         |    let p = #{
         |        A(1; 2) :- fix A(2; 3).
         |    };
-        |    let ans = query p select (a,b) from A(a; b);
+        |    let ans = query p select (a, b) from A(a; b);
         |    Array.length(ans)
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
@@ -255,7 +255,7 @@ class TestStratifier extends FunSuite with TestUtils {
         |    let p = #{
         |        A(1; 2) :- A(2; 3), fix A(2; 3).
         |    };
-        |    let ans = query p select (a,b) from A(a; b);
+        |    let ans = query p select (a, b) from A(a; b);
         |    Array.length(ans)
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
@@ -269,7 +269,7 @@ class TestStratifier extends FunSuite with TestUtils {
         |    let p = #{
         |        A(1; 2) :- fix A(2; 3), A(2; 3).
         |    };
-        |    let ans = query p select (a,b) from A(a; b);
+        |    let ans = query p select (a, b) from A(a; b);
         |    Array.length(ans)
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
@@ -283,7 +283,7 @@ class TestStratifier extends FunSuite with TestUtils {
         |    let p = #{
         |        A(1; 2) :- not A(2; 3).
         |    };
-        |    let ans = query p select (a,b) from A(a; b);
+        |    let ans = query p select (a, b) from A(a; b);
         |    Array.length(ans)
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
@@ -297,7 +297,7 @@ class TestStratifier extends FunSuite with TestUtils {
         |    let p = #{
         |        A(1; 2) :- A(2; 3), not A(2; 3).
         |    };
-        |    let ans = query p select (a,b) from A(a; b);
+        |    let ans = query p select (a, b) from A(a; b);
         |    Array.length(ans)
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
@@ -311,7 +311,7 @@ class TestStratifier extends FunSuite with TestUtils {
         |    let p = #{
         |        A(1; 2) :- not A(2; 3), A(2; 3).
         |    };
-        |    let ans = query p select (a,b) from A(a; b);
+        |    let ans = query p select (a, b) from A(a; b);
         |    Array.length(ans)
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)


### PR DESCRIPTION
fixes #3704.

The error was these lines in `UllmansAlgorithm.scala` combined with a set used in the graph holding the edges
```
sealed trait DependencyEdge {
  override def equals(obj: Any): Boolean = obj match {
    case that: DependencyEdge => this.head == that.head && this.body == that.body
    case _ => false
  }
}
// ...
case class Weak(head: Name.Pred, body: Name.Pred, loc: SourceLocation) extends DependencyEdge
case class Strong(head: Name.Pred, body: Name.Pred, loc: SourceLocation) extends DependencyEdge
```