### PR TITLE
ci: increase testing time limits

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,5 +21,5 @@ jobs:
       - name: Build with gradle
         run: ./gradlew clean compileTestScala
       - name: Run tests with timeout
-        timeout-minutes: 9
+        timeout-minutes: 10
         run: ./gradlew test

--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: Build jar
         run: ./gradlew jar
       - name: Build community projects
+        timeout-minutes: 10
         run: |
           # Sanity check: Make sure the project build directory does not exist.
           test ! -e ${{ env.PROJ_DIR }}


### PR DESCRIPTION
We have had some timeouts recently. I guess we are simply naturally approaching the limit as we add more tests. This increases the limit by 11% and adds a timeout to the community build.