### PR TITLE
refactor: change Option.toOk and related functions to subject last (fixes #3748)

### DIFF
--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -412,7 +412,7 @@ namespace Option {
     /// Returns the Option value `Ok(v)` if `o` is `Some(v)`. Otherwise returns `Err(e)`.
     ///
     @Time(1) @Space(1)
-    pub def toOk(o: Option[t], e: e): Result[t, e] = match o {
+    pub def toOk(e: e, o: Option[t]): Result[t, e] = match o {
         case None    => Err(e)
         case Some(a) => Ok(a)
     }
@@ -421,7 +421,7 @@ namespace Option {
     /// Returns the Option value `Err(e)` if `o` is `Some(e)`. Otherwise returns `Ok(d)`.
     ///
     @Time(1) @Space(1)
-    pub def toErr(o: Option[e], d: t): Result[t, e] = match o {
+    pub def toErr(d: t, o: Option[e]): Result[t, e] = match o {
         case None    => Ok(d)
         case Some(e) => Err(e)
     }
@@ -430,7 +430,7 @@ namespace Option {
     /// Returns the Validation value `Success(v)` if `o` is `Some(v)`. Otherwise lifts `e` into Validation's `Failure`.
     ///
     @Time(1) @Space(1)
-    pub def toSuccess(o: Option[t], e: e): Validation[t, e] = match o {
+    pub def toSuccess(e: e, o: Option[t]): Validation[t, e] = match o {
         case None    => Failure(Nec.singleton(e))
         case Some(a) => Success(a)
     }
@@ -439,7 +439,7 @@ namespace Option {
     /// Returns `e` into Validation's `Failure` if `o` is `Some(e)`. Otherwise returns `Success(d)`.
     ///
     @Time(1) @Space(1)
-    pub def toFailure(o: Option[e], d: t): Validation[t, e] = match o {
+    pub def toFailure(d: t, o: Option[e]): Validation[t, e] = match o {
         case None    => Success(d)
         case Some(e) => Failure(Nec.singleton(e))
     }

--- a/main/test/ca/uwaterloo/flix/library/TestOption.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestOption.flix
@@ -154,37 +154,37 @@ def toMapWith05(): Bool =
 // toOk                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toOk01(): Bool = Option.toOk(None: Option[Unit], "err") == Err("err")
+def toOk01(): Bool = Option.toOk("err", None: Option[Unit]) == Err("err")
 
 @test
-def toOk02(): Bool = Option.toOk(Some(1), "err") == Ok(1)
+def toOk02(): Bool = Option.toOk("err", Some(1)) == Ok(1)
 
 /////////////////////////////////////////////////////////////////////////////
 // toErr                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toErr01(): Bool = Option.toErr(None: Option[Unit], "default") == Ok("default")
+def toErr01(): Bool = Option.toErr("default", None: Option[Unit]) == Ok("default")
 
 @test
-def toErr02(): Bool = Option.toErr(Some("err"), "default") == Err("err")
+def toErr02(): Bool = Option.toErr("default", Some("err")) == Err("err")
 
 /////////////////////////////////////////////////////////////////////////////
 // toSuccess                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toSuccess01(): Bool = Option.toSuccess(None: Option[Unit], "err") == Failure(Nec.singleton("err"))
+def toSuccess01(): Bool = Option.toSuccess("err", None: Option[Unit]) == Failure(Nec.singleton("err"))
 
 @test
-def toSuccess02(): Bool = Option.toSuccess(Some(1), "err") == Success(1)
+def toSuccess02(): Bool = Option.toSuccess("err", Some(1)) == Success(1)
 
 /////////////////////////////////////////////////////////////////////////////
 // toFailure                                                               //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def toFailure01(): Bool = Option.toFailure(None: Option[Unit], "default") == Success("default")
+def toFailure01(): Bool = Option.toFailure("default", None: Option[Unit]) == Success("default")
 
 @test
-def toFailure02(): Bool = Option.toFailure(Some("err"), "default") == Failure(Nec.singleton("err"))
+def toFailure02(): Bool = Option.toFailure("default", Some("err")) == Failure(Nec.singleton("err"))
 
 /////////////////////////////////////////////////////////////////////////////
 // withDefault                                                             //


### PR DESCRIPTION
This PR changes the `Option` functions `toOk`, `toErr`, `toSuccess` and `toFailure` to be subject last.

`TestAll` implies the functions aren't used elsewhere in the stdlib or tests so the changes are limited to `Option.flix` and `TestOption.flix`.