### PR TITLE
refactor: use regions in `_.toMutList`

### DIFF
--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -1295,16 +1295,6 @@ namespace Array {
     ///
     /// Returns the array `a` as a MutList.
     ///
-    pub def toMutList(a: ScopedArray[a, r]): MutList[a, r] \ { Read(r), Write(r) } =
-        let minCap = MutList.minCapacity();
-        let len = length(a);
-        let c = Order.max(len, minCap);
-        let r = Scoped.regionOf(a);
-        MutList(ref copyOfRange(0, c, a, r) @ r, ref len @ r)
-
-    ///
-    /// Returns the array `a` as a MutList.
-    ///
     pub def toMutListRegion(a: ScopedArray[a, r1], r2: Region[r2]): MutList[a, r2] \ { Read(r1), Write(r2) } =
         let minCap = MutList.minCapacity();
         let len = length(a);

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -1303,6 +1303,15 @@ namespace Array {
         MutList(ref copyOfRange(0, c, a, r) @ r, ref len @ r)
 
     ///
+    /// Returns the array `a` as a MutList.
+    ///
+    pub def toMutListRegion(a: ScopedArray[a, r1], r2: Region[r2]): MutList[a, r2] \ { Read(r1), Write(r2) } =
+        let minCap = MutList.minCapacity();
+        let len = length(a);
+        let c = Order.max(len, minCap);
+        MutList(ref copyOfRange(0, c, a, r2) @ r2, ref len @ r2)
+
+    ///
     /// Alias for `findIndexOfLeft`.
     ///
     @Time(time(f) * length(a)) @Space(space(f))

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -1295,7 +1295,7 @@ namespace Array {
     ///
     /// Returns the array `a` as a MutList.
     ///
-    pub def toMutListRegion(a: ScopedArray[a, r1], r2: Region[r2]): MutList[a, r2] \ { Read(r1), Write(r2) } =
+    pub def toMutList(a: ScopedArray[a, r1], r2: Region[r2]): MutList[a, r2] \ { Read(r1), Write(r2) } =
         let minCap = MutList.minCapacity();
         let len = length(a);
         let c = Order.max(len, minCap);

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -736,6 +736,13 @@ namespace Chain {
         toArray(c, static) |> Array.toMutList // `Array.toMutList` respects the invariant of `MutList`
 
     ///
+    /// Returns `c` as a mutable list.
+    ///
+    pub def toMutListRegion(c: Chain[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
+        Array.toMutListRegion(toArray(c, r2), r) // `Array.toMutList` respects the invariant of `MutList`
+    }
+
+    ///
     /// Returns the list `c` as a set.
     ///
     pub def toSet(c: Chain[a]): Set[a] with Order[a] =

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -739,7 +739,7 @@ namespace Chain {
     /// Returns `c` as a mutable list.
     ///
     pub def toMutListRegion(c: Chain[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
-        Array.toMutListRegion(toArray(c, r2), r) // `Array.toMutList` respects the invariant of `MutList`
+        Array.toMutListRegion(toArray(c, r2), r) // `Array.toMutListRegion` respects the invariant of `MutList`
     }
 
     ///

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -732,8 +732,8 @@ namespace Chain {
     ///
     /// Returns `c` as a mutable list.
     ///
-    pub def toMutListRegion(c: Chain[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
-        Array.toMutListRegion(toArray(c, r2), r) // `Array.toMutListRegion` respects the invariant of `MutList`
+    pub def toMutList(c: Chain[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
+        Array.toMutList(toArray(c, r2), r) // `Array.toMutList` respects the invariant of `MutList`
     }
 
     ///

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -732,12 +732,6 @@ namespace Chain {
     ///
     /// Returns `c` as a mutable list.
     ///
-    pub def toMutList(c: Chain[a]): MutList[a, Impure] & Impure =
-        toArray(c, static) |> Array.toMutList // `Array.toMutList` respects the invariant of `MutList`
-
-    ///
-    /// Returns `c` as a mutable list.
-    ///
     pub def toMutListRegion(c: Chain[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
         Array.toMutListRegion(toArray(c, r2), r) // `Array.toMutListRegion` respects the invariant of `MutList`
     }

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -1195,6 +1195,16 @@ namespace DelayList {
         toArray(l, static) |> Array.toMutList // `Array.toMutList` respects the invariant of `MutList`.
 
     ///
+    /// Returns `l` as a `List`.
+    ///
+    /// Forces the entire list `l`.
+    ///
+    @Experimental
+    pub def toMutListRegion(l: DelayList[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
+        Array.toMutListRegion(toArray(l, r2), r) // `Array.toMutListRegion` respects the invariant of `MutList`.
+    }
+
+    ///
     /// Returns the association list `l` as a map.
     ///
     /// If `l` contains multiple mappings with the same key, `toMap` does not

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -1191,15 +1191,6 @@ namespace DelayList {
     /// Forces the entire list `l`.
     ///
     @Experimental
-    pub def toMutList(l: DelayList[a]): MutList[a, Impure] & Impure =
-        toArray(l, static) |> Array.toMutList // `Array.toMutList` respects the invariant of `MutList`.
-
-    ///
-    /// Returns `l` as a `List`.
-    ///
-    /// Forces the entire list `l`.
-    ///
-    @Experimental
     pub def toMutListRegion(l: DelayList[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
         Array.toMutListRegion(toArray(l, r2), r) // `Array.toMutListRegion` respects the invariant of `MutList`.
     }

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -1191,8 +1191,8 @@ namespace DelayList {
     /// Forces the entire list `l`.
     ///
     @Experimental
-    pub def toMutListRegion(l: DelayList[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
-        Array.toMutListRegion(toArray(l, r2), r) // `Array.toMutListRegion` respects the invariant of `MutList`.
+    pub def toMutList(l: DelayList[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
+        Array.toMutList(toArray(l, r2), r) // `Array.toMutList` respects the invariant of `MutList`.
     }
 
     ///

--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -222,14 +222,6 @@ pub class Foldable[t : Type -> Type] {
     ///
     /// Returns `t` as a mutable list.
     ///
-    pub def toMutList(t: t[a]): MutList[a, Impure] & Impure =
-        let v = new MutList(static);
-        Foldable.foldRight((x, _) -> MutList.push!(x, v), (), t);
-        v
-
-    ///
-    /// Returns `t` as a mutable list.
-    ///
     pub def toMutListRegion(t: t[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
         Array.toMutListRegion(Foldable.toArray(t, r2), r)
     }

--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -230,10 +230,9 @@ pub class Foldable[t : Type -> Type] {
     ///
     /// Returns `t` as a mutable list.
     ///
-    pub def toMutListRegion(t: t[a], r: Region[r]): MutList[a, r] \ { Read(r), Write(r) } =
-        let v = new MutList(r);
-        Foldable.foldLeft((_, x) -> MutList.push!(x, v), (), t);
-        v
+    pub def toMutListRegion(t: t[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
+        Array.toMutListRegion(Foldable.toArray(t, r2), r)
+    }
 
     ///
     /// Returns `t` as a set.

--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -222,8 +222,8 @@ pub class Foldable[t : Type -> Type] {
     ///
     /// Returns `t` as a mutable list.
     ///
-    pub def toMutListRegion(t: t[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
-        Array.toMutListRegion(Foldable.toArray(t, r2), r)
+    pub def toMutList(t: t[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
+        Array.toMutList(Foldable.toArray(t, r2), r)
     }
 
     ///

--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -228,6 +228,14 @@ pub class Foldable[t : Type -> Type] {
         v
 
     ///
+    /// Returns `t` as a mutable list.
+    ///
+    pub def toMutListRegion(t: t[a], r: Region[r]): MutList[a, r] \ { Read(r), Write(r) } =
+        let v = new MutList(r);
+        Foldable.foldLeft((_, x) -> MutList.push!(x, v), (), t);
+        v
+
+    ///
     /// Returns `t` as a set.
     ///
     pub def toSet(t: t[a]): Set[a] with Order[a] =
@@ -243,7 +251,7 @@ pub class Foldable[t : Type -> Type] {
     /// Returns a map with elements of `s` as keys and `f` applied as values.
     ///
     pub def toMapWith(f: a -> b, s: t[a]): Map[a, b] with Order[a] =
-            Foldable.foldRight((x, acc) -> Map.insert(x, f(x), acc), Map.empty(), s)
+        Foldable.foldRight((x, acc) -> Map.insert(x, f(x), acc), Map.empty(), s)
 
     ///
     /// Returns `t` without the longest prefix that satisfies the predicate `f`.

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -1130,8 +1130,8 @@ namespace List {
     ///
     /// Returns `l` as a mutable list.
     ///
-    pub def toMutListRegion(l: List[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
-        Array.toMutListRegion(toArray(l, r2), r) // `Array.toMutListRegion` respects the invariant of `MutList`
+    pub def toMutList(l: List[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
+        Array.toMutList(toArray(l, r2), r) // `Array.toMutList` respects the invariant of `MutList`
     }
 
     ///

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -1130,14 +1130,6 @@ namespace List {
     ///
     /// Returns `l` as a mutable list.
     ///
-    pub def toMutList(l: List[a]): MutList[a, Impure] & Impure =
-        let v = new MutList(static);
-        foreach(x -> MutList.push!(x, v), l);
-        v
-
-    ///
-    /// Returns `l` as a mutable list.
-    ///
     pub def toMutListRegion(l: List[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
         Array.toMutListRegion(toArray(l, r2), r) // `Array.toMutListRegion` respects the invariant of `MutList`
     }

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -1136,6 +1136,13 @@ namespace List {
         v
 
     ///
+    /// Returns `l` as a mutable list.
+    ///
+    pub def toMutListRegion(l: List[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
+        Array.toMutListRegion(toArray(l, r2), r)
+    }
+
+    ///
     /// Returns the list `l` as a set.
     ///
     @Time(length(l)) @Space(length(l))

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -1139,7 +1139,7 @@ namespace List {
     /// Returns `l` as a mutable list.
     ///
     pub def toMutListRegion(l: List[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
-        Array.toMutListRegion(toArray(l, r2), r)
+        Array.toMutListRegion(toArray(l, r2), r) // `Array.toMutListRegion` respects the invariant of `MutList`
     }
 
     ///

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -710,8 +710,8 @@ namespace Nec {
     ///
     /// Returns `c` as a mutable list.
     ///
-    pub def toMutListRegion(c: Nec[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
-        Array.toMutListRegion(toArray(c, r2), r) // `Array.toMutListRegion` respects the invariant of `MutList`
+    pub def toMutList(c: Nec[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
+        Array.toMutList(toArray(c, r2), r) // `Array.toMutList` respects the invariant of `MutList`
     }
 
     ///

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -710,12 +710,6 @@ namespace Nec {
     ///
     /// Returns `c` as a mutable list.
     ///
-    pub def toMutList(c: Nec[a]): MutList[a, Impure] & Impure =
-        toArray(c, static) |> Array.toMutList // `Array.toMutList` respects the invariant of `MutList`
-
-    ///
-    /// Returns `c` as a mutable list.
-    ///
     pub def toMutListRegion(c: Nec[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
         Array.toMutListRegion(toArray(c, r2), r) // `Array.toMutListRegion` respects the invariant of `MutList`
     }

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -714,6 +714,13 @@ namespace Nec {
         toArray(c, static) |> Array.toMutList // `Array.toMutList` respects the invariant of `MutList`
 
     ///
+    /// Returns `c` as a mutable list.
+    ///
+    pub def toMutListRegion(c: Nec[a], r: Region[r]): MutList[a, r] \ Write(r) = region r2 {
+        Array.toMutListRegion(toArray(c, r2), r) // `Array.toMutListRegion` respects the invariant of `MutList`
+    }
+
+    ///
     /// Returns the list `c` as a set.
     ///
     pub def toSet(c: Nec[a]): Set[a] with Order[a] = foldRight((x, acc) -> Set.insert(x, acc), Set.empty(), c)

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -4602,14 +4602,14 @@ def sortBy!09(): Bool & Impure = testSortBy!VsSortBy([2,3,0,4,1,2])
 
     @test
     def toMutList01(): Bool = region r {
-        MutList.sameElements(Array.toMutListRegion(([] @ r): ScopedArray[Int32, _], r), new MutList(r))
+        MutList.sameElements(Array.toMutList(([] @ r): ScopedArray[Int32, _], r), new MutList(r))
     }
 
     @test
     def toMutList02(): Bool = region r {
         let v = new MutList(r);
         MutList.push!(1, v);
-        MutList.sameElements(Array.toMutListRegion([1] @ r, r), v)
+        MutList.sameElements(Array.toMutList([1] @ r, r), v)
     }
 
     @test
@@ -4618,24 +4618,24 @@ def sortBy!09(): Bool & Impure = testSortBy!VsSortBy([2,3,0,4,1,2])
         MutList.push!(1, v);
         MutList.push!(2, v);
         MutList.push!(3, v);
-        MutList.sameElements(Array.toMutListRegion([1, 2, 3] @ r, r), v)
+        MutList.sameElements(Array.toMutList([1, 2, 3] @ r, r), v)
     }
 
     @test
     def toMutList04(): Bool = region r {
-        MutList.sameElements((Array.range(0, 100, r) |> Array.toMutListRegion)(r), MutList.range(0, 100, r))
+        MutList.sameElements((Array.range(0, 100, r) |> Array.toMutList)(r), MutList.range(0, 100, r))
     }
 
     @test
     def toMutList05(): Bool = region r {
-        let v = Array.toMutListRegion([1, 2, 3] @ r, r);
+        let v = Array.toMutList([1, 2, 3] @ r, r);
         MutList.push!(4, v);
         Array.sameElements(MutList.toArray(v, r), [1, 2, 3, 4] @ r)
     }
 
     @test
     def toMutList06(): Bool = region r {
-        let v = Array.toMutListRegion([1, 2, 3] @ r, r);
+        let v = Array.toMutList([1, 2, 3] @ r, r);
         MutList.push!(4, v);
         let _ = MutList.pop!(v);
         let _ = MutList.pop!(v);

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -4601,42 +4601,47 @@ def sortBy!09(): Bool & Impure = testSortBy!VsSortBy([2,3,0,4,1,2])
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def toMutList01(): Bool & Impure =
-        MutList.sameElements(Array.toMutList([]: Array[Int32]), new MutList(static))
+    def toMutList01(): Bool = region r {
+        MutList.sameElements(Array.toMutListRegion(([] @ r): ScopedArray[Int32, _], r), new MutList(r))
+    }
 
     @test
-    def toMutList02(): Bool & Impure =
-        let v = new MutList(static);
+    def toMutList02(): Bool = region r {
+        let v = new MutList(r);
         MutList.push!(1, v);
-        MutList.sameElements(Array.toMutList([1]), v)
+        MutList.sameElements(Array.toMutListRegion([1] @ r, r), v)
+    }
 
     @test
-    def toMutList03(): Bool & Impure =
-        let v = new MutList(static);
+    def toMutList03(): Bool = region r {
+        let v = new MutList(r);
         MutList.push!(1, v);
         MutList.push!(2, v);
         MutList.push!(3, v);
-        MutList.sameElements(Array.toMutList([1, 2, 3]), v)
+        MutList.sameElements(Array.toMutListRegion([1, 2, 3] @ r, r), v)
+    }
 
     @test
-    def toMutList04(): Bool & Impure =
-        MutList.sameElements(Array.range(0, 100, static) |> Array.toMutList, MutList.range(0, 100, static))
+    def toMutList04(): Bool = region r {
+        MutList.sameElements((Array.range(0, 100, r) |> Array.toMutListRegion)(r), MutList.range(0, 100, r))
+    }
 
     @test
     def toMutList05(): Bool = region r {
-        let v = Array.toMutList([1, 2, 3] @ r);
+        let v = Array.toMutListRegion([1, 2, 3] @ r, r);
         MutList.push!(4, v);
         Array.sameElements(MutList.toArray(v, r), [1, 2, 3, 4] @ r)
     }
 
     @test
-    def toMutList06(): Bool & Impure =
-        let v = Array.toMutList([1, 2, 3]);
+    def toMutList06(): Bool = region r {
+        let v = Array.toMutListRegion([1, 2, 3] @ r, r);
         MutList.push!(4, v);
         let _ = MutList.pop!(v);
         let _ = MutList.pop!(v);
         let _ = MutList.pop!(v);
         let _ = MutList.pop!(v);
-        Array.sameElements(MutList.toArray(v, static), [])
+        Array.sameElements(MutList.toArray(v, r), [] @ r)
+    }
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestChain.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestChain.flix
@@ -1370,22 +1370,22 @@ namespace TestChain {
 
     @test
     def toMutList01(): Bool = region r {
-        Chain.toMutListRegion(Chain.empty(): Chain[Int32], r) `MutList.sameElements` List.toMutListRegion(Nil, r): MutList[Int32, _]
+        Chain.toMutList(Chain.empty(): Chain[Int32], r) `MutList.sameElements` List.toMutList(Nil, r): MutList[Int32, _]
     }
 
     @test
     def toMutList02(): Bool = region r {
-        Chain.toMutListRegion(Chain.singleton(1), r) `MutList.sameElements` List.toMutListRegion(1 :: Nil, r)
+        Chain.toMutList(Chain.singleton(1), r) `MutList.sameElements` List.toMutList(1 :: Nil, r)
     }
 
     @test
     def toMutList03(): Bool = region r {
-        Chain.toMutListRegion(List.toChain(1 :: 2 :: Nil), r) `MutList.sameElements` List.toMutListRegion(1 :: 2 :: Nil, r)
+        Chain.toMutList(List.toChain(1 :: 2 :: Nil), r) `MutList.sameElements` List.toMutList(1 :: 2 :: Nil, r)
     }
 
     @test
     def toMutList04(): Bool = region r {
-        Chain.toMutListRegion(List.toChain(1 :: 2 :: 3 :: Nil), r) `MutList.sameElements` List.toMutListRegion(1 :: 2 :: 3 :: Nil, r)
+        Chain.toMutList(List.toChain(1 :: 2 :: 3 :: Nil), r) `MutList.sameElements` List.toMutList(1 :: 2 :: 3 :: Nil, r)
     }
 
     /////////////////////////////////////////////////////////////////////////////

--- a/main/test/ca/uwaterloo/flix/library/TestChain.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestChain.flix
@@ -1369,20 +1369,24 @@ namespace TestChain {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def toMutList01(): Bool & Impure =
-        Chain.toMutList(Chain.empty(): Chain[Int32]) `MutList.sameElements` List.toMutList(Nil): MutList[Int32, Impure]
+    def toMutList01(): Bool = region r {
+        Chain.toMutListRegion(Chain.empty(): Chain[Int32], r) `MutList.sameElements` List.toMutListRegion(Nil, r): MutList[Int32, _]
+    }
 
     @test
-    def toMutList02(): Bool & Impure =
-        Chain.toMutList(Chain.singleton(1)) `MutList.sameElements` List.toMutList(1 :: Nil)
+    def toMutList02(): Bool = region r {
+        Chain.toMutListRegion(Chain.singleton(1), r) `MutList.sameElements` List.toMutListRegion(1 :: Nil, r)
+    }
 
     @test
-    def toMutList03(): Bool & Impure =
-        Chain.toMutList(List.toChain(1 :: 2 :: Nil)) `MutList.sameElements` List.toMutList(1 :: 2 :: Nil)
+    def toMutList03(): Bool = region r {
+        Chain.toMutListRegion(List.toChain(1 :: 2 :: Nil), r) `MutList.sameElements` List.toMutListRegion(1 :: 2 :: Nil, r)
+    }
 
     @test
-    def toMutList04(): Bool & Impure =
-        Chain.toMutList(List.toChain(1 :: 2 :: 3 :: Nil)) `MutList.sameElements` List.toMutList(1 :: 2 :: 3 :: Nil)
+    def toMutList04(): Bool = region r {
+        Chain.toMutListRegion(List.toChain(1 :: 2 :: 3 :: Nil), r) `MutList.sameElements` List.toMutListRegion(1 :: 2 :: 3 :: Nil, r)
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // toSet                                                                   //

--- a/main/test/ca/uwaterloo/flix/library/TestMutList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutList.flix
@@ -588,7 +588,7 @@ namespace TestMutList {
     @test
     def map01(): Bool = region r {
         let v = MutList.map(x -> x * 2, MutList.range(0, 6, r));
-        MutList.sameElements(v, Array.toMutListRegion([0, 2, 4, 6, 8, 10], r))
+        MutList.sameElements(v, Array.toMutList([0, 2, 4, 6, 8, 10], r))
     }
 
     @test
@@ -618,7 +618,7 @@ namespace TestMutList {
     def transform!01(): Bool = region r {
         let v = MutList.range(0, 6, r);
         MutList.transform!(x -> x * 2, v);
-        MutList.sameElements(v, Array.toMutListRegion([0, 2, 4, 6, 8, 10], r))
+        MutList.sameElements(v, Array.toMutList([0, 2, 4, 6, 8, 10], r))
     }
 
     @test
@@ -650,13 +650,13 @@ namespace TestMutList {
     @test
     def mapWithIndex01(): Bool = region r {
         let v = MutList.mapWithIndex((_, i) -> if (i < 3) 0 else 1, MutList.range(0, 6, r));
-        MutList.sameElements(v, Array.toMutListRegion([0, 0, 0, 1, 1, 1], r))
+        MutList.sameElements(v, Array.toMutList([0, 0, 0, 1, 1, 1], r))
     }
 
     @test
     def mapWithIndex02(): Bool = region r {
         let v = MutList.mapWithIndex((x, i) -> if (x == 8 and i == 1) 42 else 0, MutList.range(7, 10, r));
-        MutList.sameElements(v, Array.toMutListRegion([0, 42, 0], r))
+        MutList.sameElements(v, Array.toMutList([0, 42, 0], r))
     }
 
     @test
@@ -674,14 +674,14 @@ namespace TestMutList {
     def transformWithIndex!01(): Bool = region r {
         let v = MutList.range(0, 6, r);
         MutList.transformWithIndex!((_, i) -> if (i < 3) 0 else 1, v);
-        MutList.sameElements(v, Array.toMutListRegion([0, 0, 0, 1, 1, 1], r))
+        MutList.sameElements(v, Array.toMutList([0, 0, 0, 1, 1, 1], r))
     }
 
     @test
     def transformWithIndex!02(): Bool = region r {
         let v = MutList.range(7, 10, r);
         MutList.transformWithIndex!((x, i) -> if (x == 8 and i == 1) 42 else 0, v);
-        MutList.sameElements(v, Array.toMutListRegion([0, 42, 0], r))
+        MutList.sameElements(v, Array.toMutList([0, 42, 0], r))
     }
 
     @test
@@ -1640,12 +1640,12 @@ namespace TestMutList {
 
     @test
     def toArray01(): Bool = region r {
-        Array.sameElements(MutList.toArray(Array.toMutListRegion([1, 2, 3] @ r, r), r), [1, 2, 3] @ r)
+        Array.sameElements(MutList.toArray(Array.toMutList([1, 2, 3] @ r, r), r), [1, 2, 3] @ r)
     }
 
     @test
     def toArray02(): Bool = region r {
-        let v = Array.toMutListRegion([1, 2, 3], r);
+        let v = Array.toMutList([1, 2, 3], r);
         let a = MutList.toArray(v, r);
         a[1] = 42;
         MutList.get(1, v) == 2
@@ -1653,7 +1653,7 @@ namespace TestMutList {
 
     @test
     def toArray03(): Bool = region r {
-        let v = Array.toMutListRegion([1, 2, 3] @ r, r);
+        let v = Array.toMutList([1, 2, 3] @ r, r);
         MutList.pop!(v);
         MutList.pop!(v);
         Array.length(MutList.toArray(v, r)) == 1
@@ -1733,81 +1733,81 @@ namespace TestMutList {
 
     @test
     def sortWith01(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutListRegion(([] @ r): ScopedArray[Int32, _], r));
-        a `sameElements` Array.toMutListRegion([] @ r, r)
+        let a = MutList.sortWith(cmp, Array.toMutList(([] @ r): ScopedArray[Int32, _], r));
+        a `sameElements` Array.toMutList([] @ r, r)
     }
 
     @test
     def sortWith02(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutListRegion([0], r));
-        a `sameElements` Array.toMutListRegion([0], r)
+        let a = MutList.sortWith(cmp, Array.toMutList([0], r));
+        a `sameElements` Array.toMutList([0], r)
     }
 
     @test
     def sortWith03(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutListRegion([0,1], r));
-        a `sameElements` Array.toMutListRegion([0,1], r)
+        let a = MutList.sortWith(cmp, Array.toMutList([0,1], r));
+        a `sameElements` Array.toMutList([0,1], r)
     }
 
     @test
     def sortWith04(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutListRegion([1,0], r));
-        a `sameElements` Array.toMutListRegion([0,1], r)
+        let a = MutList.sortWith(cmp, Array.toMutList([1,0], r));
+        a `sameElements` Array.toMutList([0,1], r)
     }
 
     @test
     def sortWith05(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutListRegion([1,1], r));
-        a `sameElements` Array.toMutListRegion([1,1], r)
+        let a = MutList.sortWith(cmp, Array.toMutList([1,1], r));
+        a `sameElements` Array.toMutList([1,1], r)
     }
 
     @test
     def sortWith06(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutListRegion([0,1,2,3,4,5], r));
-        a `sameElements` Array.toMutListRegion([0,1,2,3,4,5], r)
+        let a = MutList.sortWith(cmp, Array.toMutList([0,1,2,3,4,5], r));
+        a `sameElements` Array.toMutList([0,1,2,3,4,5], r)
     }
 
     @test
     def sortWith07(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutListRegion([5,4,3,2,1,0], r));
-        a `sameElements` Array.toMutListRegion([0,1,2,3,4,5], r)
+        let a = MutList.sortWith(cmp, Array.toMutList([5,4,3,2,1,0], r));
+        a `sameElements` Array.toMutList([0,1,2,3,4,5], r)
     }
 
     @test
     def sortWith08(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutListRegion([5,3,0,4,1,2], r));
-        a `sameElements` Array.toMutListRegion([0,1,2,3,4,5], r)
+        let a = MutList.sortWith(cmp, Array.toMutList([5,3,0,4,1,2], r));
+        a `sameElements` Array.toMutList([0,1,2,3,4,5], r)
     }
 
     @test
     def sortWith09(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutListRegion([2,3,0,4,1,2], r));
-        a `sameElements` Array.toMutListRegion([0,1,2,2,3,4], r)
+        let a = MutList.sortWith(cmp, Array.toMutList([2,3,0,4,1,2], r));
+        a `sameElements` Array.toMutList([0,1,2,2,3,4], r)
     }
 
     @test
     def sortWith10(): Bool = region r {
-        let a = MutList.sortWith(flip(cmp), Array.toMutListRegion([0,1,2,3,4,5], r));
-        a `sameElements` Array.toMutListRegion([5,4,3,2,1,0], r)
+        let a = MutList.sortWith(flip(cmp), Array.toMutList([0,1,2,3,4,5], r));
+        a `sameElements` Array.toMutList([5,4,3,2,1,0], r)
     }
 
     @test
     def sortWith11(): Bool = region r {
-        let a = MutList.sortWith(flip(cmp), Array.toMutListRegion([5,4,3,2,1,0], r));
-        a `sameElements` Array.toMutListRegion([5,4,3,2,1,0], r)
+        let a = MutList.sortWith(flip(cmp), Array.toMutList([5,4,3,2,1,0], r));
+        a `sameElements` Array.toMutList([5,4,3,2,1,0], r)
     }
 
     @test
     def sortWith12(): Bool = region r {
-        let a = MutList.sortWith(flip(cmp), Array.toMutListRegion([5,3,0,4,1,2], r));
-        a `sameElements` Array.toMutListRegion([5,4,3,2,1,0], r)
+        let a = MutList.sortWith(flip(cmp), Array.toMutList([5,3,0,4,1,2], r));
+        a `sameElements` Array.toMutList([5,4,3,2,1,0], r)
     }
 
 
     @test
     def sortWith13(): Bool = region r {
-        let a = MutList.sortWith(flip(cmp), Array.toMutListRegion([2,3,0,4,1,2], r));
-        a `sameElements` Array.toMutListRegion([4,3,2,2,1,0], r)
+        let a = MutList.sortWith(flip(cmp), Array.toMutList([2,3,0,4,1,2], r));
+        a `sameElements` Array.toMutList([4,3,2,2,1,0], r)
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -1819,47 +1819,47 @@ namespace TestMutList {
 
     @test
     def sort01(): Bool = region r {
-        testSortVsSortWith(Array.toMutListRegion([]: ScopedArray[Int32, _], r))
+        testSortVsSortWith(Array.toMutList([]: ScopedArray[Int32, _], r))
     }
 
     @test
     def sort02(): Bool = region r {
-        testSortVsSortWith(Array.toMutListRegion([0], r))
+        testSortVsSortWith(Array.toMutList([0], r))
     }
 
     @test
     def sort03(): Bool = region r {
-        testSortVsSortWith(Array.toMutListRegion([0,1], r))
+        testSortVsSortWith(Array.toMutList([0,1], r))
     }
 
     @test
     def sort04(): Bool = region r {
-        testSortVsSortWith(Array.toMutListRegion([1,0], r))
+        testSortVsSortWith(Array.toMutList([1,0], r))
     }
 
     @test
     def sort05(): Bool = region r {
-        testSortVsSortWith(Array.toMutListRegion([1,1], r))
+        testSortVsSortWith(Array.toMutList([1,1], r))
     }
 
     @test
     def sort06(): Bool = region r {
-        testSortVsSortWith(Array.toMutListRegion([0,1,2,3,4,5], r))
+        testSortVsSortWith(Array.toMutList([0,1,2,3,4,5], r))
     }
 
     @test
     def sort07(): Bool = region r {
-        testSortVsSortWith(Array.toMutListRegion([5,4,3,2,1,0], r))
+        testSortVsSortWith(Array.toMutList([5,4,3,2,1,0], r))
     }
 
     @test
     def sort08(): Bool = region r {
-        testSortVsSortWith(Array.toMutListRegion([5,3,0,4,1,2], r))
+        testSortVsSortWith(Array.toMutList([5,3,0,4,1,2], r))
     }
 
     @test
     def sort09(): Bool = region r {
-        testSortVsSortWith(Array.toMutListRegion([2,3,0,4,1,2], r))
+        testSortVsSortWith(Array.toMutList([2,3,0,4,1,2], r))
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -1868,92 +1868,92 @@ namespace TestMutList {
 
     @test
     def sortWith01!(): Bool = region r {
-        let a = Array.toMutListRegion([]: ScopedArray[Int32, _], r);
+        let a = Array.toMutList([]: ScopedArray[Int32, _], r);
         MutList.sortWith(cmp, a);
-        a `sameElements` Array.toMutListRegion([]: ScopedArray[Int32, _], r)
+        a `sameElements` Array.toMutList([]: ScopedArray[Int32, _], r)
     }
 
     @test
     def sortWith02!(): Bool = region r {
-        let a = Array.toMutListRegion([0], r);
+        let a = Array.toMutList([0], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutListRegion([0], r)
+        a `sameElements` Array.toMutList([0], r)
     }
 
     @test
     def sortWith03!(): Bool = region r {
-        let a = Array.toMutListRegion([0,1], r);
+        let a = Array.toMutList([0,1], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutListRegion([0,1], r)
+        a `sameElements` Array.toMutList([0,1], r)
     }
 
     @test
     def sortWith04!(): Bool = region r {
-        let a = Array.toMutListRegion([1,0], r);
+        let a = Array.toMutList([1,0], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutListRegion([0,1], r)
+        a `sameElements` Array.toMutList([0,1], r)
     }
     @test
     def sortWith05!(): Bool = region r {
-        let a = Array.toMutListRegion([1,1], r);
+        let a = Array.toMutList([1,1], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutListRegion([1,1], r)
+        a `sameElements` Array.toMutList([1,1], r)
     }
 
     @test
     def sortWith06!(): Bool = region r {
-        let a = Array.toMutListRegion([0,1,2,3,4,5], r);
+        let a = Array.toMutList([0,1,2,3,4,5], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutListRegion([0,1,2,3,4,5], r)
+        a `sameElements` Array.toMutList([0,1,2,3,4,5], r)
     }
 
     @test
     def sortWith07!(): Bool = region r {
-        let a = Array.toMutListRegion([5,4,3,2,1,0], r);
+        let a = Array.toMutList([5,4,3,2,1,0], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutListRegion([0,1,2,3,4,5], r)
+        a `sameElements` Array.toMutList([0,1,2,3,4,5], r)
     }
 
     @test
     def sortWith08!(): Bool = region r {
-        let a = Array.toMutListRegion([5,3,0,4,1,2], r);
+        let a = Array.toMutList([5,3,0,4,1,2], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutListRegion([0,1,2,3,4,5], r)
+        a `sameElements` Array.toMutList([0,1,2,3,4,5], r)
     }
 
     @test
     def sortWith09!(): Bool = region r {
-        let a = Array.toMutListRegion([2,3,0,4,1,2], r);
+        let a = Array.toMutList([2,3,0,4,1,2], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutListRegion([0,1,2,2,3,4], r)
+        a `sameElements` Array.toMutList([0,1,2,2,3,4], r)
     }
 
     @test
     def sortWith10!(): Bool = region r {
-        let a = Array.toMutListRegion([0,1,2,3,4,5], r);
+        let a = Array.toMutList([0,1,2,3,4,5], r);
         MutList.sortWith!(flip(cmp), a);
-        a `sameElements` Array.toMutListRegion([5,4,3,2,1,0], r)
+        a `sameElements` Array.toMutList([5,4,3,2,1,0], r)
     }
 
     @test
     def sortWith11!(): Bool = region r {
-        let a = Array.toMutListRegion([5,4,3,2,1,0], r);
+        let a = Array.toMutList([5,4,3,2,1,0], r);
         MutList.sortWith!(flip(cmp), a);
-        a `sameElements` Array.toMutListRegion([5,4,3,2,1,0], r)
+        a `sameElements` Array.toMutList([5,4,3,2,1,0], r)
     }
 
     @test
     def sortWith12!(): Bool = region r {
-        let a = Array.toMutListRegion([5,3,0,4,1,2], r);
+        let a = Array.toMutList([5,3,0,4,1,2], r);
         MutList.sortWith!(flip(cmp), a);
-        a `sameElements` Array.toMutListRegion([5,4,3,2,1,0], r)
+        a `sameElements` Array.toMutList([5,4,3,2,1,0], r)
     }
 
     @test
     def sortWith13!(): Bool = region r {
-        let a = Array.toMutListRegion([2,3,0,4,1,2], r);
+        let a = Array.toMutList([2,3,0,4,1,2], r);
         MutList.sortWith!(flip(cmp), a);
-        a `sameElements` Array.toMutListRegion([4,3,2,2,1,0], r)
+        a `sameElements` Array.toMutList([4,3,2,2,1,0], r)
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -1969,47 +1969,47 @@ namespace TestMutList {
 
     @test
     def sort!01(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutListRegion([]: ScopedArray[Int32, _], r))
+        testSort!VsSortWith!(Array.toMutList([]: ScopedArray[Int32, _], r))
     }
 
     @test
     def sort!02(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutListRegion([0], r))
+        testSort!VsSortWith!(Array.toMutList([0], r))
     }
 
     @test
     def sort!03(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutListRegion([0,1], r))
+        testSort!VsSortWith!(Array.toMutList([0,1], r))
     }
 
     @test
     def sort!04(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutListRegion([1,0], r))
+        testSort!VsSortWith!(Array.toMutList([1,0], r))
     }
 
     @test
     def sort!05(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutListRegion([1,1], r))
+        testSort!VsSortWith!(Array.toMutList([1,1], r))
     }
 
     @test
     def sort!06(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutListRegion([0,1,2,3,4,5], r))
+        testSort!VsSortWith!(Array.toMutList([0,1,2,3,4,5], r))
     }
 
     @test
     def sort!07(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutListRegion([5,4,3,2,1,0], r))
+        testSort!VsSortWith!(Array.toMutList([5,4,3,2,1,0], r))
     }
 
     @test
     def sort!08(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutListRegion([5,3,0,4,1,2], r))
+        testSort!VsSortWith!(Array.toMutList([5,3,0,4,1,2], r))
     }
 
     @test
     def sort!09(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutListRegion([2,3,0,4,1,2], r))
+        testSort!VsSortWith!(Array.toMutList([2,3,0,4,1,2], r))
     }
 
 
@@ -2024,47 +2024,47 @@ namespace TestMutList {
 
     @test
     def sortBy01(): Bool = region r {
-        testSortByVsSort(Array.toMutListRegion([]: ScopedArray[Int32, _], r))
+        testSortByVsSort(Array.toMutList([]: ScopedArray[Int32, _], r))
     }
 
     @test
     def sortBy02(): Bool = region r {
-        testSortByVsSort(Array.toMutListRegion([0], r))
+        testSortByVsSort(Array.toMutList([0], r))
     }
 
     @test
     def sortBy03(): Bool = region r {
-        testSortByVsSort(Array.toMutListRegion([0,1], r))
+        testSortByVsSort(Array.toMutList([0,1], r))
     }
 
     @test
     def sortBy04(): Bool = region r {
-        testSortByVsSort(Array.toMutListRegion([1,0], r))
+        testSortByVsSort(Array.toMutList([1,0], r))
     }
 
     @test
     def sortBy05(): Bool = region r {
-        testSortByVsSort(Array.toMutListRegion([1,1], r))
+        testSortByVsSort(Array.toMutList([1,1], r))
     }
 
     @test
     def sortBy06(): Bool = region r {
-        testSortByVsSort(Array.toMutListRegion([0,1,2,3,4,5], r))
+        testSortByVsSort(Array.toMutList([0,1,2,3,4,5], r))
     }
 
     @test
     def sortBy07(): Bool = region r {
-        testSortByVsSort(Array.toMutListRegion([5,4,3,2,1,0], r))
+        testSortByVsSort(Array.toMutList([5,4,3,2,1,0], r))
     }
 
     @test
     def sortBy08(): Bool = region r {
-        testSortByVsSort(Array.toMutListRegion([5,3,0,4,1,2], r))
+        testSortByVsSort(Array.toMutList([5,3,0,4,1,2], r))
     }
 
     @test
     def sortBy09(): Bool = region r {
-        testSortByVsSort(Array.toMutListRegion([2,3,0,4,1,2], r))
+        testSortByVsSort(Array.toMutList([2,3,0,4,1,2], r))
     }
 
     enum R {
@@ -2080,8 +2080,8 @@ namespace TestMutList {
 
     @test
     def sortBy10(): Bool = region r {
-        MutList.sortBy(r -> let R(x) = r; x.i, Array.toMutListRegion([R({i = 2, s = "A"}), R({i = 1, s = "B"}), R({i = 3, s = "C"})] @ r, r))
-        `sameElements` Array.toMutListRegion([R({i = 1, s = "B"}), R({i = 2, s = "A"}), R({i = 3, s = "C"})] @ r, r)
+        MutList.sortBy(r -> let R(x) = r; x.i, Array.toMutList([R({i = 2, s = "A"}), R({i = 1, s = "B"}), R({i = 3, s = "C"})] @ r, r))
+        `sameElements` Array.toMutList([R({i = 1, s = "B"}), R({i = 2, s = "A"}), R({i = 3, s = "C"})] @ r, r)
     }
 
 
@@ -2099,47 +2099,47 @@ namespace TestMutList {
 
     @test
     def sortBy!01(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutListRegion([]: ScopedArray[Int32, _], r))
+        testSortBy!VsSortBy(Array.toMutList([]: ScopedArray[Int32, _], r))
     }
 
     @test
     def sortBy!02(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutListRegion([0], r))
+        testSortBy!VsSortBy(Array.toMutList([0], r))
     }
 
     @test
     def sortBy!03(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutListRegion([0,1], r))
+        testSortBy!VsSortBy(Array.toMutList([0,1], r))
     }
 
     @test
     def sortBy!04(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutListRegion([1,0], r))
+        testSortBy!VsSortBy(Array.toMutList([1,0], r))
     }
 
     @test
     def sortBy!05(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutListRegion([1,1], r))
+        testSortBy!VsSortBy(Array.toMutList([1,1], r))
     }
 
     @test
     def sortBy!06(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutListRegion([0,1,2,3,4,5], r))
+        testSortBy!VsSortBy(Array.toMutList([0,1,2,3,4,5], r))
     }
 
     @test
     def sortBy!07(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutListRegion([5,4,3,2,1,0], r))
+        testSortBy!VsSortBy(Array.toMutList([5,4,3,2,1,0], r))
     }
 
     @test
     def sortBy!08(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutListRegion([5,3,0,4,1,2], r))
+        testSortBy!VsSortBy(Array.toMutList([5,3,0,4,1,2], r))
     }
 
     @test
     def sortBy!09(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutListRegion([2,3,0,4,1,2], r))
+        testSortBy!VsSortBy(Array.toMutList([2,3,0,4,1,2], r))
     }
 
 

--- a/main/test/ca/uwaterloo/flix/library/TestMutList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutList.flix
@@ -588,7 +588,7 @@ namespace TestMutList {
     @test
     def map01(): Bool = region r {
         let v = MutList.map(x -> x * 2, MutList.range(0, 6, r));
-        MutList.sameElements(v, Array.toMutList([0, 2, 4, 6, 8, 10]))
+        MutList.sameElements(v, Array.toMutListRegion([0, 2, 4, 6, 8, 10], r))
     }
 
     @test
@@ -618,7 +618,7 @@ namespace TestMutList {
     def transform!01(): Bool = region r {
         let v = MutList.range(0, 6, r);
         MutList.transform!(x -> x * 2, v);
-        MutList.sameElements(v, Array.toMutList([0, 2, 4, 6, 8, 10]))
+        MutList.sameElements(v, Array.toMutListRegion([0, 2, 4, 6, 8, 10], r))
     }
 
     @test
@@ -650,13 +650,13 @@ namespace TestMutList {
     @test
     def mapWithIndex01(): Bool = region r {
         let v = MutList.mapWithIndex((_, i) -> if (i < 3) 0 else 1, MutList.range(0, 6, r));
-        MutList.sameElements(v, Array.toMutList([0, 0, 0, 1, 1, 1]))
+        MutList.sameElements(v, Array.toMutListRegion([0, 0, 0, 1, 1, 1], r))
     }
 
     @test
     def mapWithIndex02(): Bool = region r {
         let v = MutList.mapWithIndex((x, i) -> if (x == 8 and i == 1) 42 else 0, MutList.range(7, 10, r));
-        MutList.sameElements(v, Array.toMutList([0, 42, 0]))
+        MutList.sameElements(v, Array.toMutListRegion([0, 42, 0], r))
     }
 
     @test
@@ -674,14 +674,14 @@ namespace TestMutList {
     def transformWithIndex!01(): Bool = region r {
         let v = MutList.range(0, 6, r);
         MutList.transformWithIndex!((_, i) -> if (i < 3) 0 else 1, v);
-        MutList.sameElements(v, Array.toMutList([0, 0, 0, 1, 1, 1]))
+        MutList.sameElements(v, Array.toMutListRegion([0, 0, 0, 1, 1, 1], r))
     }
 
     @test
     def transformWithIndex!02(): Bool = region r {
         let v = MutList.range(7, 10, r);
         MutList.transformWithIndex!((x, i) -> if (x == 8 and i == 1) 42 else 0, v);
-        MutList.sameElements(v, Array.toMutList([0, 42, 0]))
+        MutList.sameElements(v, Array.toMutListRegion([0, 42, 0], r))
     }
 
     @test
@@ -1640,12 +1640,12 @@ namespace TestMutList {
 
     @test
     def toArray01(): Bool = region r {
-        Array.sameElements(MutList.toArray(Array.toMutList([1, 2, 3] @ r), r), [1, 2, 3] @ r)
+        Array.sameElements(MutList.toArray(Array.toMutListRegion([1, 2, 3] @ r, r), r), [1, 2, 3] @ r)
     }
 
     @test
     def toArray02(): Bool = region r {
-        let v = Array.toMutList([1, 2, 3]);
+        let v = Array.toMutListRegion([1, 2, 3], r);
         let a = MutList.toArray(v, r);
         a[1] = 42;
         MutList.get(1, v) == 2
@@ -1653,7 +1653,7 @@ namespace TestMutList {
 
     @test
     def toArray03(): Bool = region r {
-        let v = Array.toMutList([1, 2, 3] @ r);
+        let v = Array.toMutListRegion([1, 2, 3] @ r, r);
         MutList.pop!(v);
         MutList.pop!(v);
         Array.length(MutList.toArray(v, r)) == 1
@@ -1733,81 +1733,81 @@ namespace TestMutList {
 
     @test
     def sortWith01(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList([]: ScopedArray[Int32, _]));
-        a `sameElements` Array.toMutList([]: ScopedArray[Int32, _])
+        let a = MutList.sortWith(cmp, Array.toMutListRegion(([] @ r): ScopedArray[Int32, _], r));
+        a `sameElements` Array.toMutListRegion([] @ r, r)
     }
 
     @test
     def sortWith02(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList([0]));
-        a `sameElements` Array.toMutList([0])
+        let a = MutList.sortWith(cmp, Array.toMutListRegion([0], r));
+        a `sameElements` Array.toMutListRegion([0], r)
     }
 
     @test
     def sortWith03(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList([0,1]));
-        a `sameElements` Array.toMutList([0,1])
+        let a = MutList.sortWith(cmp, Array.toMutListRegion([0,1], r));
+        a `sameElements` Array.toMutListRegion([0,1], r)
     }
 
     @test
     def sortWith04(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList([1,0]));
-        a `sameElements` Array.toMutList([0,1])
+        let a = MutList.sortWith(cmp, Array.toMutListRegion([1,0], r));
+        a `sameElements` Array.toMutListRegion([0,1], r)
     }
 
     @test
     def sortWith05(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList([1,1]));
-        a `sameElements` Array.toMutList([1,1])
+        let a = MutList.sortWith(cmp, Array.toMutListRegion([1,1], r));
+        a `sameElements` Array.toMutListRegion([1,1], r)
     }
 
     @test
     def sortWith06(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList([0,1,2,3,4,5]));
-        a `sameElements` Array.toMutList([0,1,2,3,4,5])
+        let a = MutList.sortWith(cmp, Array.toMutListRegion([0,1,2,3,4,5], r));
+        a `sameElements` Array.toMutListRegion([0,1,2,3,4,5], r)
     }
 
     @test
     def sortWith07(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList([5,4,3,2,1,0]));
-        a `sameElements` Array.toMutList([0,1,2,3,4,5])
+        let a = MutList.sortWith(cmp, Array.toMutListRegion([5,4,3,2,1,0], r));
+        a `sameElements` Array.toMutListRegion([0,1,2,3,4,5], r)
     }
 
     @test
     def sortWith08(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList([5,3,0,4,1,2]));
-        a `sameElements` Array.toMutList([0,1,2,3,4,5])
+        let a = MutList.sortWith(cmp, Array.toMutListRegion([5,3,0,4,1,2], r));
+        a `sameElements` Array.toMutListRegion([0,1,2,3,4,5], r)
     }
 
     @test
     def sortWith09(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList([2,3,0,4,1,2]));
-        a `sameElements` Array.toMutList([0,1,2,2,3,4])
+        let a = MutList.sortWith(cmp, Array.toMutListRegion([2,3,0,4,1,2], r));
+        a `sameElements` Array.toMutListRegion([0,1,2,2,3,4], r)
     }
 
     @test
     def sortWith10(): Bool = region r {
-        let a = MutList.sortWith(flip(cmp), Array.toMutList([0,1,2,3,4,5]));
-        a `sameElements` Array.toMutList([5,4,3,2,1,0])
+        let a = MutList.sortWith(flip(cmp), Array.toMutListRegion([0,1,2,3,4,5], r));
+        a `sameElements` Array.toMutListRegion([5,4,3,2,1,0], r)
     }
 
     @test
     def sortWith11(): Bool = region r {
-        let a = MutList.sortWith(flip(cmp), Array.toMutList([5,4,3,2,1,0]));
-        a `sameElements` Array.toMutList([5,4,3,2,1,0])
+        let a = MutList.sortWith(flip(cmp), Array.toMutListRegion([5,4,3,2,1,0], r));
+        a `sameElements` Array.toMutListRegion([5,4,3,2,1,0], r)
     }
 
     @test
     def sortWith12(): Bool = region r {
-        let a = MutList.sortWith(flip(cmp), Array.toMutList([5,3,0,4,1,2]));
-        a `sameElements` Array.toMutList([5,4,3,2,1,0])
+        let a = MutList.sortWith(flip(cmp), Array.toMutListRegion([5,3,0,4,1,2], r));
+        a `sameElements` Array.toMutListRegion([5,4,3,2,1,0], r)
     }
 
 
     @test
     def sortWith13(): Bool = region r {
-        let a = MutList.sortWith(flip(cmp), Array.toMutList([2,3,0,4,1,2]));
-        a `sameElements` Array.toMutList([4,3,2,2,1,0])
+        let a = MutList.sortWith(flip(cmp), Array.toMutListRegion([2,3,0,4,1,2], r));
+        a `sameElements` Array.toMutListRegion([4,3,2,2,1,0], r)
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -1819,47 +1819,47 @@ namespace TestMutList {
 
     @test
     def sort01(): Bool = region r {
-        testSortVsSortWith(Array.toMutList([]: ScopedArray[Int32, _]))
+        testSortVsSortWith(Array.toMutListRegion([]: ScopedArray[Int32, _], r))
     }
 
     @test
     def sort02(): Bool = region r {
-        testSortVsSortWith(Array.toMutList([0]))
+        testSortVsSortWith(Array.toMutListRegion([0], r))
     }
 
     @test
     def sort03(): Bool = region r {
-        testSortVsSortWith(Array.toMutList([0,1]))
+        testSortVsSortWith(Array.toMutListRegion([0,1], r))
     }
 
     @test
     def sort04(): Bool = region r {
-        testSortVsSortWith(Array.toMutList([1,0]))
+        testSortVsSortWith(Array.toMutListRegion([1,0], r))
     }
 
     @test
     def sort05(): Bool = region r {
-        testSortVsSortWith(Array.toMutList([1,1]))
+        testSortVsSortWith(Array.toMutListRegion([1,1], r))
     }
 
     @test
     def sort06(): Bool = region r {
-        testSortVsSortWith(Array.toMutList([0,1,2,3,4,5]))
+        testSortVsSortWith(Array.toMutListRegion([0,1,2,3,4,5], r))
     }
 
     @test
     def sort07(): Bool = region r {
-        testSortVsSortWith(Array.toMutList([5,4,3,2,1,0]))
+        testSortVsSortWith(Array.toMutListRegion([5,4,3,2,1,0], r))
     }
 
     @test
     def sort08(): Bool = region r {
-        testSortVsSortWith(Array.toMutList([5,3,0,4,1,2]))
+        testSortVsSortWith(Array.toMutListRegion([5,3,0,4,1,2], r))
     }
 
     @test
     def sort09(): Bool = region r {
-        testSortVsSortWith(Array.toMutList([2,3,0,4,1,2]))
+        testSortVsSortWith(Array.toMutListRegion([2,3,0,4,1,2], r))
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -1868,92 +1868,92 @@ namespace TestMutList {
 
     @test
     def sortWith01!(): Bool = region r {
-        let a = Array.toMutList([]: ScopedArray[Int32, _]);
+        let a = Array.toMutListRegion([]: ScopedArray[Int32, _], r);
         MutList.sortWith(cmp, a);
-        a `sameElements` Array.toMutList([]: ScopedArray[Int32, _])
+        a `sameElements` Array.toMutListRegion([]: ScopedArray[Int32, _], r)
     }
 
     @test
     def sortWith02!(): Bool = region r {
-        let a = Array.toMutList([0]);
+        let a = Array.toMutListRegion([0], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutList([0])
+        a `sameElements` Array.toMutListRegion([0], r)
     }
 
     @test
     def sortWith03!(): Bool = region r {
-        let a = Array.toMutList([0,1]);
+        let a = Array.toMutListRegion([0,1], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutList([0,1])
+        a `sameElements` Array.toMutListRegion([0,1], r)
     }
 
     @test
     def sortWith04!(): Bool = region r {
-        let a = Array.toMutList([1,0]);
+        let a = Array.toMutListRegion([1,0], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutList([0,1])
+        a `sameElements` Array.toMutListRegion([0,1], r)
     }
     @test
     def sortWith05!(): Bool = region r {
-        let a = Array.toMutList([1,1]);
+        let a = Array.toMutListRegion([1,1], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutList([1,1])
+        a `sameElements` Array.toMutListRegion([1,1], r)
     }
 
     @test
     def sortWith06!(): Bool = region r {
-        let a = Array.toMutList([0,1,2,3,4,5]);
+        let a = Array.toMutListRegion([0,1,2,3,4,5], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutList([0,1,2,3,4,5])
+        a `sameElements` Array.toMutListRegion([0,1,2,3,4,5], r)
     }
 
     @test
     def sortWith07!(): Bool = region r {
-        let a = Array.toMutList([5,4,3,2,1,0]);
+        let a = Array.toMutListRegion([5,4,3,2,1,0], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutList([0,1,2,3,4,5])
+        a `sameElements` Array.toMutListRegion([0,1,2,3,4,5], r)
     }
 
     @test
     def sortWith08!(): Bool = region r {
-        let a = Array.toMutList([5,3,0,4,1,2]);
+        let a = Array.toMutListRegion([5,3,0,4,1,2], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutList([0,1,2,3,4,5])
+        a `sameElements` Array.toMutListRegion([0,1,2,3,4,5], r)
     }
 
     @test
     def sortWith09!(): Bool = region r {
-        let a = Array.toMutList([2,3,0,4,1,2]);
+        let a = Array.toMutListRegion([2,3,0,4,1,2], r);
         MutList.sortWith!(cmp, a);
-        a `sameElements` Array.toMutList([0,1,2,2,3,4])
+        a `sameElements` Array.toMutListRegion([0,1,2,2,3,4], r)
     }
 
     @test
     def sortWith10!(): Bool = region r {
-        let a = Array.toMutList([0,1,2,3,4,5]);
+        let a = Array.toMutListRegion([0,1,2,3,4,5], r);
         MutList.sortWith!(flip(cmp), a);
-        a `sameElements` Array.toMutList([5,4,3,2,1,0])
+        a `sameElements` Array.toMutListRegion([5,4,3,2,1,0], r)
     }
 
     @test
     def sortWith11!(): Bool = region r {
-        let a = Array.toMutList([5,4,3,2,1,0]);
+        let a = Array.toMutListRegion([5,4,3,2,1,0], r);
         MutList.sortWith!(flip(cmp), a);
-        a `sameElements` Array.toMutList([5,4,3,2,1,0])
+        a `sameElements` Array.toMutListRegion([5,4,3,2,1,0], r)
     }
 
     @test
     def sortWith12!(): Bool = region r {
-        let a = Array.toMutList([5,3,0,4,1,2]);
+        let a = Array.toMutListRegion([5,3,0,4,1,2], r);
         MutList.sortWith!(flip(cmp), a);
-        a `sameElements` Array.toMutList([5,4,3,2,1,0])
+        a `sameElements` Array.toMutListRegion([5,4,3,2,1,0], r)
     }
 
     @test
     def sortWith13!(): Bool = region r {
-        let a = Array.toMutList([2,3,0,4,1,2]);
+        let a = Array.toMutListRegion([2,3,0,4,1,2], r);
         MutList.sortWith!(flip(cmp), a);
-        a `sameElements` Array.toMutList([4,3,2,2,1,0])
+        a `sameElements` Array.toMutListRegion([4,3,2,2,1,0], r)
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -1969,47 +1969,47 @@ namespace TestMutList {
 
     @test
     def sort!01(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList([]: ScopedArray[Int32, _]))
+        testSort!VsSortWith!(Array.toMutListRegion([]: ScopedArray[Int32, _], r))
     }
 
     @test
     def sort!02(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList([0]))
+        testSort!VsSortWith!(Array.toMutListRegion([0], r))
     }
 
     @test
     def sort!03(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList([0,1]))
+        testSort!VsSortWith!(Array.toMutListRegion([0,1], r))
     }
 
     @test
     def sort!04(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList([1,0]))
+        testSort!VsSortWith!(Array.toMutListRegion([1,0], r))
     }
 
     @test
     def sort!05(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList([1,1]))
+        testSort!VsSortWith!(Array.toMutListRegion([1,1], r))
     }
 
     @test
     def sort!06(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList([0,1,2,3,4,5]))
+        testSort!VsSortWith!(Array.toMutListRegion([0,1,2,3,4,5], r))
     }
 
     @test
     def sort!07(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList([5,4,3,2,1,0]))
+        testSort!VsSortWith!(Array.toMutListRegion([5,4,3,2,1,0], r))
     }
 
     @test
     def sort!08(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList([5,3,0,4,1,2]))
+        testSort!VsSortWith!(Array.toMutListRegion([5,3,0,4,1,2], r))
     }
 
     @test
     def sort!09(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList([2,3,0,4,1,2]))
+        testSort!VsSortWith!(Array.toMutListRegion([2,3,0,4,1,2], r))
     }
 
 
@@ -2024,47 +2024,47 @@ namespace TestMutList {
 
     @test
     def sortBy01(): Bool = region r {
-        testSortByVsSort(Array.toMutList([]: ScopedArray[Int32, _]))
+        testSortByVsSort(Array.toMutListRegion([]: ScopedArray[Int32, _], r))
     }
 
     @test
     def sortBy02(): Bool = region r {
-        testSortByVsSort(Array.toMutList([0]))
+        testSortByVsSort(Array.toMutListRegion([0], r))
     }
 
     @test
     def sortBy03(): Bool = region r {
-        testSortByVsSort(Array.toMutList([0,1]))
+        testSortByVsSort(Array.toMutListRegion([0,1], r))
     }
 
     @test
     def sortBy04(): Bool = region r {
-        testSortByVsSort(Array.toMutList([1,0]))
+        testSortByVsSort(Array.toMutListRegion([1,0], r))
     }
 
     @test
     def sortBy05(): Bool = region r {
-        testSortByVsSort(Array.toMutList([1,1]))
+        testSortByVsSort(Array.toMutListRegion([1,1], r))
     }
 
     @test
     def sortBy06(): Bool = region r {
-        testSortByVsSort(Array.toMutList([0,1,2,3,4,5]))
+        testSortByVsSort(Array.toMutListRegion([0,1,2,3,4,5], r))
     }
 
     @test
     def sortBy07(): Bool = region r {
-        testSortByVsSort(Array.toMutList([5,4,3,2,1,0]))
+        testSortByVsSort(Array.toMutListRegion([5,4,3,2,1,0], r))
     }
 
     @test
     def sortBy08(): Bool = region r {
-        testSortByVsSort(Array.toMutList([5,3,0,4,1,2]))
+        testSortByVsSort(Array.toMutListRegion([5,3,0,4,1,2], r))
     }
 
     @test
     def sortBy09(): Bool = region r {
-        testSortByVsSort(Array.toMutList([2,3,0,4,1,2]))
+        testSortByVsSort(Array.toMutListRegion([2,3,0,4,1,2], r))
     }
 
     enum R {
@@ -2080,8 +2080,8 @@ namespace TestMutList {
 
     @test
     def sortBy10(): Bool = region r {
-        MutList.sortBy(r -> let R(x) = r; x.i, Array.toMutList([R({i = 2, s = "A"}), R({i = 1, s = "B"}), R({i = 3, s = "C"})] @ r))
-        `sameElements` Array.toMutList([R({i = 1, s = "B"}), R({i = 2, s = "A"}), R({i = 3, s = "C"})] @ r)
+        MutList.sortBy(r -> let R(x) = r; x.i, Array.toMutListRegion([R({i = 2, s = "A"}), R({i = 1, s = "B"}), R({i = 3, s = "C"})] @ r, r))
+        `sameElements` Array.toMutListRegion([R({i = 1, s = "B"}), R({i = 2, s = "A"}), R({i = 3, s = "C"})] @ r, r)
     }
 
 
@@ -2099,47 +2099,47 @@ namespace TestMutList {
 
     @test
     def sortBy!01(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList([]: ScopedArray[Int32, _]))
+        testSortBy!VsSortBy(Array.toMutListRegion([]: ScopedArray[Int32, _], r))
     }
 
     @test
     def sortBy!02(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList([0]))
+        testSortBy!VsSortBy(Array.toMutListRegion([0], r))
     }
 
     @test
     def sortBy!03(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList([0,1]))
+        testSortBy!VsSortBy(Array.toMutListRegion([0,1], r))
     }
 
     @test
     def sortBy!04(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList([1,0]))
+        testSortBy!VsSortBy(Array.toMutListRegion([1,0], r))
     }
 
     @test
     def sortBy!05(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList([1,1]))
+        testSortBy!VsSortBy(Array.toMutListRegion([1,1], r))
     }
 
     @test
     def sortBy!06(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList([0,1,2,3,4,5]))
+        testSortBy!VsSortBy(Array.toMutListRegion([0,1,2,3,4,5], r))
     }
 
     @test
     def sortBy!07(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList([5,4,3,2,1,0]))
+        testSortBy!VsSortBy(Array.toMutListRegion([5,4,3,2,1,0], r))
     }
 
     @test
     def sortBy!08(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList([5,3,0,4,1,2]))
+        testSortBy!VsSortBy(Array.toMutListRegion([5,3,0,4,1,2], r))
     }
 
     @test
     def sortBy!09(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList([2,3,0,4,1,2]))
+        testSortBy!VsSortBy(Array.toMutListRegion([2,3,0,4,1,2], r))
     }
 
 

--- a/main/test/ca/uwaterloo/flix/library/TestNec.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestNec.flix
@@ -1018,22 +1018,26 @@ namespace TestNec {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def toMutList01(): Bool & Impure =
-        let m1 = Nec.toMutList(singleton(1));
-        let m2 = MutList.range(1, 2, static);
+    def toMutList01(): Bool = region r {
+        let m1 = Nec.toMutListRegion(singleton(1), r);
+        let m2 = MutList.range(1, 2, r);
         MutList.sameElements(m1, m2)
+    }
 
     @test
-    def toMutList02(): Bool & Impure =
-        let m1 = Nec.toMutList(necOf2(1, 2));
-        let m2 = MutList.range(1, 3, static);
+    def toMutList02(): Bool = region r {
+        let m1 = Nec.toMutListRegion(necOf2(1, 2), r);
+        let m2 = MutList.range(1, 3, r);
         MutList.sameElements(m1, m2)
+    }
 
     @test
-    def toMutList03(): Bool & Impure =
-        let m1 = Nec.toMutList(necOf3(1, 2, 3));
-        let m2 = MutList.range(1, 4, static);
+    def toMutList03(): Bool = region r {
+        let m1 = Nec.toMutListRegion(necOf3(1, 2, 3), r);
+        let m2 = MutList.range(1, 4, r);
         MutList.sameElements(m1, m2)
+    }
+
     /////////////////////////////////////////////////////////////////////////////
     // toSet                                                                   //
     /////////////////////////////////////////////////////////////////////////////

--- a/main/test/ca/uwaterloo/flix/library/TestNec.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestNec.flix
@@ -1019,21 +1019,21 @@ namespace TestNec {
 
     @test
     def toMutList01(): Bool = region r {
-        let m1 = Nec.toMutListRegion(singleton(1), r);
+        let m1 = Nec.toMutList(singleton(1), r);
         let m2 = MutList.range(1, 2, r);
         MutList.sameElements(m1, m2)
     }
 
     @test
     def toMutList02(): Bool = region r {
-        let m1 = Nec.toMutListRegion(necOf2(1, 2), r);
+        let m1 = Nec.toMutList(necOf2(1, 2), r);
         let m2 = MutList.range(1, 3, r);
         MutList.sameElements(m1, m2)
     }
 
     @test
     def toMutList03(): Bool = region r {
-        let m1 = Nec.toMutListRegion(necOf3(1, 2, 3), r);
+        let m1 = Nec.toMutList(necOf3(1, 2, 3), r);
         let m2 = MutList.range(1, 4, r);
         MutList.sameElements(m1, m2)
     }


### PR DESCRIPTION
Related to #3610

- [x] Add `toMutListRegion`
- [x] Refactor uses of `toMutList` -> `toMutListRegion`
- [x] Remove `toMutList`
- [x] Rename `toMutListRegion` -> `toMutList`