### PR TITLE
refactor: use regions in `_.toMutMap`

### DIFF
--- a/main/src/library/DelayMap.flix
+++ b/main/src/library/DelayMap.flix
@@ -730,6 +730,13 @@ namespace DelayMap {
         MutMap(ref toMap(m)) as MutMap[k, v, Impure]
 
     ///
+    /// Returns `m` as a mutable set.
+    ///
+    @Experimental @Parallel
+    pub def toMutMapRegion(m: DelayMap[k, v], r: Region[r]): MutMap[k, v, r] \ Write(r) =
+        MutMap(ref toMap(m) @ r)
+
+    ///
     /// Returns the map `m` as a set of key-value pairs.
     ///
     @Experimental

--- a/main/src/library/DelayMap.flix
+++ b/main/src/library/DelayMap.flix
@@ -726,14 +726,7 @@ namespace DelayMap {
     /// Returns `m` as a mutable set.
     ///
     @Experimental @Parallel
-    pub def toMutMap(m: DelayMap[k, v]): MutMap[k, v, Impure] & Impure =
-        MutMap(ref toMap(m)) as MutMap[k, v, Impure]
-
-    ///
-    /// Returns `m` as a mutable set.
-    ///
-    @Experimental @Parallel
-    pub def toMutMapRegion(m: DelayMap[k, v], r: Region[r]): MutMap[k, v, r] \ Write(r) =
+    pub def toMutMap(m: DelayMap[k, v], r: Region[r]): MutMap[k, v, r] \ Write(r) =
         MutMap(ref toMap(m) @ r)
 
     ///

--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -55,7 +55,7 @@ namespace Fixpoint {
             case Datalog(_) => compiler(d) |> interpret |> toModel
             case Model(_) => d
             case Join(Model(m), cs) =>
-                let db = static |> (Map.map(mm -> Map.toMutMapRegion(mm, static), m) |> Map.toMutMapRegion);
+                let db = static |> (Map.map(mm -> Map.toMutMap(mm, static), m) |> Map.toMutMap);
                 compiler(cs) |> interpretWithDatabase(db) |> toModel
             case _ => bug!("Datalog normalization bug")
         };

--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -55,8 +55,7 @@ namespace Fixpoint {
             case Datalog(_) => compiler(d) |> interpret |> toModel
             case Model(_) => d
             case Join(Model(m), cs) =>
-                let ms = Map.map(mm -> MutMap(ref mm), m); // Was `let db = Map.map(Map.toMutMap, m) |> Map.toMutMap;`
-                let db = MutMap(ref ms);
+                let db = static |> (Map.map(mm -> Map.toMutMapRegion(mm, static), m) |> Map.toMutMapRegion);
                 compiler(cs) |> interpretWithDatabase(db) |> toModel
             case _ => bug!("Datalog normalization bug")
         };

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -775,6 +775,13 @@ namespace Map {
         MutMap(ref m) as MutMap[k, v, Impure]
 
     ///
+    /// Returns `m` as a mutable set.
+    ///
+    @Time(1) @Space(1)
+    pub def toMutMapRegion(m: Map[k, v], r: Region[r]): MutMap[k, v, r] \ Write(r) =
+        MutMap(ref m @ r)
+
+    ///
     /// Returns the map `m` as a list of key-value pairs.
     ///
     @Time(size(m)) @Space(size(m))

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -771,14 +771,7 @@ namespace Map {
     /// Returns `m` as a mutable set.
     ///
     @Time(1) @Space(1)
-    pub def toMutMap(m: Map[k, v]): MutMap[k, v, Impure] & Impure =
-        MutMap(ref m) as MutMap[k, v, Impure]
-
-    ///
-    /// Returns `m` as a mutable set.
-    ///
-    @Time(1) @Space(1)
-    pub def toMutMapRegion(m: Map[k, v], r: Region[r]): MutMap[k, v, r] \ Write(r) =
+    pub def toMutMap(m: Map[k, v], r: Region[r]): MutMap[k, v, r] \ Write(r) =
         MutMap(ref m @ r)
 
     ///


### PR DESCRIPTION
Related to #3610 