### PR TITLE
ci: increase testing time limit to 15 minutes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,5 +21,5 @@ jobs:
       - name: Build with gradle
         run: ./gradlew clean compileTestScala
       - name: Run tests with timeout
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: ./gradlew test


### PR DESCRIPTION
It seems that 10 minutes was not enough. I still get timeouts.