### PR TITLE
refactor: remove `Fixpoint.unsafePrint` from examples

### DIFF
--- a/examples/analysis/IDE.flix
+++ b/examples/analysis/IDE.flix
@@ -128,9 +128,7 @@ namespace IDE {
         let f1 = project ide.cfg, ide.callGraph, ide.startNodes, ide.endNodes into CFG, CallGraph, StartNode, EndNode;
         let f2 = project ide.eshIntra, ide.eshCallStart, ide.eshEndReturn into EshIntra, EshCallStart, EshEndReturn;
 
-        let m = solve p, f1, f2;
-
-        (m |> Fixpoint.unsafePrint) as & Impure; // NB: Just for debugging.
+        let _m = solve p, f1, f2;
 
         query p, f1, f2 select (n, d, l) from Results(n, d; l) |> Array.toList
 

--- a/examples/analysis/IFDS.flix
+++ b/examples/analysis/IFDS.flix
@@ -20,7 +20,7 @@ rel Facts(fact: String)
 rel Id(node: String)
 
 // Rules
-def main(): Unit & Impure =
+def main(): Unit =
     let p = #{
         // intraproc
         PathEdge(d1,m,d3) :-

--- a/examples/analysis/IFDS.flix
+++ b/examples/analysis/IFDS.flix
@@ -111,6 +111,5 @@ def main(): Unit & Impure =
         // Entrypoint
         PathEdge("zero","smain","zero").
     };
-    let m = solve p;
-    (m |> Fixpoint.unsafePrint) as & Impure;
+    let _m = solve p;
     ()

--- a/examples/analysis/SUopt.flix
+++ b/examples/analysis/SUopt.flix
@@ -49,7 +49,7 @@ def filter(e: SULattice, p: String): Bool = match e {
   case SULattice.Top => true
 }
 
-def main(): Unit & Impure =
+def main(): Unit =
     let p = #{
         // Rules
         // =========
@@ -95,6 +95,5 @@ def main(): Unit & Impure =
         Kill(l: String; f(b)) :- Store(l,p,_q), Pt(p,b).
         Kill(l;Top) :- Phi(l).
     };
-    let m = solve p;
-    (m |> Fixpoint.unsafePrint) as & Impure;
+    let _m = solve p;
     ()

--- a/examples/misc/FloydWarshall.flix
+++ b/examples/misc/FloydWarshall.flix
@@ -66,7 +66,7 @@ def negativeDist(d: Dist): Bool = match d {
   case _ => false
 }
 
-def main(): Unit & Impure =
+def main(): Unit =
     let p = #{
         // Copy input relation into the ShortestDist lattice
         ShortestDist(a, b; Dst(d)) :- Edge(a, b, d).
@@ -92,8 +92,7 @@ def main(): Unit & Impure =
         Edge("3", "1", 1).
         Edge("3", "4", 30).
     };
-    let m = solve p;
-    (m |> Fixpoint.unsafePrint) as & Impure;
+    let _m = solve p;
     ()
 
 // Expected output


### PR DESCRIPTION
Closes #3529