### PR TITLE
refactor: refactor Map, Set, and RedBlackTree functions to be effect polymorphic

### DIFF
--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -376,45 +376,36 @@ namespace Map {
     ///
     /// Alias for `findLeft`.
     ///
-    /// The function `f` must be pure.
-    ///
     @Time(time(f) * size(m)) @Space(space(f) * Int32.log2(size(m)))
-    pub def find(f: (k, v) -> Bool, m: Map[k, v]): Option[(k, v)] = findLeft(f, m)
+    pub def find(f: (k, v) -> Bool & ef, m: Map[k, v]): Option[(k, v)] & ef = findLeft(f, m)
 
     ///
     /// Optionally returns the first mapping of `m` that satisfies the predicate `f` when searching from left to right.
     ///
-    /// The function `f` must be pure.
-    ///
     @Time(time(f) * size(m)) @Space(space(f) * Int32.log2(size(m)))
-    pub def findLeft(f: (k, v) -> Bool, m: Map[k, v]): Option[(k, v)] =
+    pub def findLeft(f: (k, v) -> Bool & ef, m: Map[k, v]): Option[(k, v)] & ef =
         let Map(t) = m;
         RedBlackTree.findLeft(f, t)
 
     ///
     /// Optionally returns the first mapping of `m` that satisfies the predicate `f` when searching from right to left.
     ///
-    /// The function `f` must be pure.
-    ///
     @Time(time(f) * size(m)) @Space(space(f) * Int32.log2(size(m)))
-    pub def findRight(f: (k, v) -> Bool, m: Map[k, v]): Option[(k, v)] =
+    pub def findRight(f: (k, v) -> Bool & ef, m: Map[k, v]): Option[(k, v)] & ef =
         let Map(t) = m;
         RedBlackTree.findRight(f, t)
+
     ///
     /// Returns a map of all mappings `k => v` in `m` where `v` satisfies the predicate `f`.
     ///
-    /// The function `f` must be pure.
-    ///
     @Time(time(f) * size(m)) @Space(space(f) * size(m))
-    pub def filter(f: v -> Bool, m: Map[k, v]): Map[k, v] with Order[k] = filterWithKey((_, v) -> f(v), m)
+    pub def filter(f: v -> Bool & ef, m: Map[k, v]): Map[k, v] & ef with Order[k] = filterWithKey((_, v) -> f(v), m)
 
     ///
     /// Returns a map of all mappings `k => v` in `m` where `(k, v)` satisfies the predicate `f`.
     ///
-    /// The function `f` must be pure.
-    ///
     @Time(time(f) * size(m)) @Space(space(f) * size(m))
-    pub def filterWithKey(f: (k, v) -> Bool, m: Map[k, v]): Map[k, v] with Order[k] =
+    pub def filterWithKey(f: (k, v) -> Bool & ef, m: Map[k, v]): Map[k, v] & ef with Order[k] =
         foldLeftWithKey((acc, k, v) -> if (f(k, v)) insert(k, v, acc) else acc, empty(), m)
 
     ///

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -245,10 +245,8 @@ namespace RedBlackTree {
     ///
     /// Optionally returns the first key-value pair in `t` that satisfies the predicate `f` when searching from left to right.
     ///
-    /// The function `f` must be pure.
-    ///
     @Time(time(f) * size(t)) @Space(space(f) * Int32.log2(size(t)))
-    pub def findLeft(f: (k, v) -> Bool, t: RedBlackTree[k, v]): Option[(k, v)] =
+    pub def findLeft(f: (k, v) -> Bool & ef, t: RedBlackTree[k, v]): Option[(k, v)] & ef =
         def loop(tt, sk) = match tt {
             case Node(_, a, k, v, b) => loop(a, kl -> match kl {
                 case None => if (f(k, v)) Some(k, v) else loop(b, kr -> match kr {
@@ -259,15 +257,13 @@ namespace RedBlackTree {
             })
             case _ => sk(None)
         };
-        loop(t, identity)
+        loop(t, k -> k as & ef)
 
     ///
     /// Optionally returns the first key-value pair in `t` that satisfies the predicate `f` when searching from right to left.
     ///
-    /// The function `f` must be pure.
-    ///
     @Time(time(f) * size(t)) @Space(space(f) * Int32.log2(size(t)))
-    pub def findRight(f: (k, v) -> Bool, t: RedBlackTree[k, v]): Option[(k, v)] =
+    pub def findRight(f: (k, v) -> Bool & ef, t: RedBlackTree[k, v]): Option[(k, v)] & ef =
         def loop(tt, sk) = match tt {
             case Node(_, a, k, v, b) => loop(b, kr -> match kr {
                 case None => if (f(k, v)) Some(k, v) else loop(a, kl -> match kl {
@@ -278,7 +274,7 @@ namespace RedBlackTree {
             })
             case _ => sk(None)
         };
-        loop(t, identity)
+        loop(t, k -> k as & ef)
 
     ///
     /// Applies `f` to a start value `s` and all key-value pairs in `t` going from left to right.

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -253,28 +253,22 @@ namespace Set {
     ///
     /// Alias for `findLeft`.
     ///
-    /// The function `f` must be pure.
-    ///
     @Time(time(f) * size(s)) @Space(space(f) * Int32.log2(size(s)))
-    pub def find(f: a -> Bool, s: Set[a]): Option[a] = findLeft(f, s)
+    pub def find(f: a -> Bool & ef, s: Set[a]): Option[a] & ef = findLeft(f, s)
 
     ///
     /// Optionally returns the first element of `s` that satisfies the predicate `f` when searching from left to right.
     ///
-    /// The function `f` must be pure.
-    ///
     @Time(time(f) * size(s)) @Space(space(f) * Int32.log2(size(s)))
-    pub def findLeft(f: a -> Bool, s: Set[a]): Option[a] =
+    pub def findLeft(f: a -> Bool & ef, s: Set[a]): Option[a] & ef =
         let Set(t) = s;
         RedBlackTree.findLeft((x, _) -> f(x), t) |> Option.map(fst)
 
     ///
     /// Optionally returns the first element of `s` that satisfies the predicate `f` when searching from right to left.
     ///
-    /// The function `f` must be pure.
-    ///
     @Time(time(f) * size(s)) @Space(space(f) * Int32.log2(size(s)))
-    pub def findRight(f: a -> Bool, s: Set[a]): Option[a] =
+    pub def findRight(f: a -> Bool & ef, s: Set[a]): Option[a] & ef =
         let Set(t) = s;
         RedBlackTree.findRight((x, _) -> f(x), t) |> Option.map(fst)
 
@@ -413,10 +407,8 @@ namespace Set {
     ///
     /// Returns `false` if `s` is the empty set.
     ///
-    /// The function `f` must be pure.
-    ///
     @Time(time(f) * size(s)) @Space(space(f) * Int32.log2(size(s)))
-    pub def exists(f: a -> Bool, s: Set[a]): Bool =
+    pub def exists(f: a -> Bool & ef, s: Set[a]): Bool & ef =
         let Set(t) = s;
         RedBlackTree.exists((x, _) -> f(x), t)
 
@@ -425,10 +417,8 @@ namespace Set {
     ///
     /// Returns `true` if `s` is the empty set.
     ///
-    /// The function `f` must be pure.
-    ///
     @Time(time(f) * size(s)) @Space(space(f) * Int32.log2(size(s)))
-    pub def forall(f: a -> Bool, s: Set[a]): Bool =
+    pub def forall(f: a -> Bool & ef, s: Set[a]): Bool & ef =
         let Set(t) = s;
         RedBlackTree.forall((x, _) -> f(x), t)
 
@@ -470,10 +460,8 @@ namespace Set {
     ///
     /// Returns the set of all elements of `s` that satisfy the predicate `f`.
     ///
-    /// The function `f` must be pure.
-    ///
     @Time(time(f) * size(s)) @Space(space(f) * size(s))
-    pub def filter(f: a -> Bool, s: Set[a]): Set[a] with Order[a] =
+    pub def filter(f: a -> Bool & ef, s: Set[a]): Set[a] & ef with Order[a] =
         foldLeft((acc, x) -> if (f(x)) insert(x, acc) else acc, empty(), s)
 
     ///
@@ -506,10 +494,8 @@ namespace Set {
     /// `s1` contains all elements of `s` that satisfy the predicate `f`.
     /// `s2` contains all elements of `s` that do not satisfy the predicate `f`.
     ///
-    /// The function `f` must be pure.
-    ///
     @Time(size(s) * Int32.log2(size(s))) @Space(size(s) * Int32.log2(size(s)))
-    pub def partition(f: a -> Bool, s: Set[a]): (Set[a], Set[a]) with Order[a] =
+    pub def partition(f: a -> Bool & ef, s: Set[a]): (Set[a], Set[a]) & ef with Order[a] =
         foldLeft((acc, x) ->
             let (a, b) = acc;
             if (f(x))


### PR DESCRIPTION
This PR changes the Map, Set and RedBlackTree modules so that the `find` functions are effect polymorphic.

Also these others effect polymorphic: 

~~~

Map.filter
Map.filterWithKey

Set.exists
Set.forall
Set.filter
Set.partition

~~~

The find generalizations are needed for PR #3822