### PR TITLE
refactor: new syntax for `opaque type`

### DIFF
--- a/examples/datalog/stratifier.flix
+++ b/examples/datalog/stratifier.flix
@@ -3,15 +3,15 @@ namespace Stratifier {
     use List.{map, flatMap, partition};
     use Array.toMap;
 
-    opaque type Program = List[Constraint]
-    opaque type Constraint = (HeadAtom, List[BodyAtom])
-    opaque type Atom = PredicateSymbol
-    opaque type HeadAtom = Atom
+    enum Program(List[Constraint])
+    enum Constraint((HeadAtom, List[BodyAtom]))
+    enum Atom(PredicateSymbol)
+    enum HeadAtom(Atom)
     enum BodyAtom {
         case Positive(Atom)
         case Negative(Atom)
     }
-    opaque type PredicateSymbol with Boxable, ToString, Eq, Order = String
+    enum PredicateSymbol(String) with Boxable, ToString, Eq, Order
 
     // A :- B leads to (A, true, B)
     type alias PrecedenceEdge = (PredicateSymbol, Bool, PredicateSymbol)

--- a/examples/deriving-type-classes.flix
+++ b/examples/deriving-type-classes.flix
@@ -18,7 +18,7 @@ type alias Year = Int32
 type alias Day = Int32
 
 /// The Date type derives the type classes Eq and Order
-opaque type Date with Eq, Order = (Year, Month, Day)
+enum Date(Year, Month, Day) with Eq, Order
 
 /// We implement our own instance of ToString for Date
 /// since we don't want the default "Date(1948, December, 10)"

--- a/examples/opaque-types.flix
+++ b/examples/opaque-types.flix
@@ -3,10 +3,10 @@
 /// would otherwise be the same. For example:
 
 /// An opaque type for US dollars.
-opaque type USD = Int32
+enum USD(Int32)
 
 /// An opaque type for Canadian dollars.
-opaque type CAD = Int32
+enum CAD(Int32)
 
 ///
 /// A function that adds two US dollar amounts.

--- a/examples/opaque-types.flix
+++ b/examples/opaque-types.flix
@@ -1,11 +1,11 @@
-/// An opaque type declares a new type that is different from any other
-/// existing type. Opaque types can be used to differentiate types that
+/// An enum declares a new type that is different from any other
+/// existing type. enums can be used to differentiate types that
 /// would otherwise be the same. For example:
 
-/// An opaque type for US dollars.
+/// An enum for US dollars.
 enum USD(Int32)
 
-/// An opaque type for Canadian dollars.
+/// An enum for Canadian dollars.
 enum CAD(Int32)
 
 ///

--- a/examples/simple-card-game.flix
+++ b/examples/simple-card-game.flix
@@ -16,7 +16,7 @@ enum Rank with Eq, Order {
 }
 
 // A Card type deriving an Eq instance
-opaque type Card with Eq = (Rank, Suit)
+enum Card(Rank, Suit) with Eq
 
 // An instance of ToString for Ranks
 instance ToString[Rank] {

--- a/main/src/library/Concurrent/Condition.flix
+++ b/main/src/library/Concurrent/Condition.flix
@@ -19,7 +19,7 @@ namespace Concurrent/Condition {
     ///
     /// A wrapper around a Java Condition.
     ///
-    pub opaque type Condition = ##java.util.concurrent.locks.Condition
+    pub enum Condition(##java.util.concurrent.locks.Condition)
 
     ///
     /// An enum reflecting the two exceptions occurring in condition methods, lock state errors and thread interruptions.

--- a/main/src/library/Concurrent/ReentrantLock.flix
+++ b/main/src/library/Concurrent/ReentrantLock.flix
@@ -19,7 +19,7 @@ namespace Concurrent/ReentrantLock {
     ///
     /// A wrapper around a Java ReentrantLock.
     ///
-    pub opaque type ReentrantLock = ##java.util.concurrent.locks.ReentrantLock
+    pub enum ReentrantLock(##java.util.concurrent.locks.ReentrantLock)
 
     ///
     /// Creates an instance of ReentrantLock with the given fairness policy.

--- a/main/src/library/Fixpoint/Ast/PrecedenceGraph.flix
+++ b/main/src/library/Fixpoint/Ast/PrecedenceGraph.flix
@@ -16,7 +16,7 @@
 use Fixpoint/Shared.PredSym;
 
 namespace Fixpoint/Ast {
-    pub opaque type PrecedenceGraph = Set[PrecedenceEdge]
+    pub enum PrecedenceGraph(Set[PrecedenceEdge])
 
     pub enum PrecedenceEdge with Eq, Order {
         case StrongEdge(PredSym, PredSym)

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -17,7 +17,7 @@
 ///
 /// The Mutable Map type.
 ///
-opaque type MutMap[k: Type, v: Type, r: Region] = Ref[Map[k, v], r]
+enum MutMap[k: Type, v: Type, r: Region](Ref[Map[k, v], r])
 
 instance Scoped[MutMap[k, v]] {
     pub def regionOf(_: MutMap[k, v, r]): Region[r] = () as Region[r]

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -17,7 +17,7 @@
 ///
 /// The Mutable Map type.
 ///
-opaque type MutMap[k: Type, v: Type, r: Region] = ScopedRef[Map[k, v], r]
+enum MutMap[k: Type, v: Type, r: Region](ScopedRef[Map[k, v], r])
 
 instance Scoped[MutMap[k, v]] {
     pub def regionOf(_: MutMap[k, v, r]): Region[r] = () as Region[r]

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -17,7 +17,7 @@
 ///
 /// The Mutable Set type.
 ///
-opaque type MutSet[t: Type, r: Region] = ScopedRef[Set[t], r]
+enum MutSet[t: Type, r: Region](ScopedRef[Set[t], r])
 
 instance Newable[MutSet[t]] {
     pub def new(r: Region[r]): MutSet[t, r] \ { Write(r) } = MutSet.new(r)

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -17,7 +17,7 @@
 ///
 /// The Mutable Set type.
 ///
-opaque type MutSet[t: Type, r: Region] = Ref[Set[t], r]
+enum MutSet[t: Type, r: Region](Ref[Set[t], r])
 
 instance Newable[MutSet[t]] {
     pub def new(r: Region[r]): MutSet[t, r] \ { Write(r) } = MutSet.new(r)

--- a/main/src/library/Random.flix
+++ b/main/src/library/Random.flix
@@ -87,6 +87,6 @@ namespace Random {
     ///
     /// Represents a random number generator.
     ///
-    pub opaque type Random = ##java.util.Random
+    pub enum Random(##java.util.Random)
 
 }

--- a/main/src/library/StringBuilder.flix
+++ b/main/src/library/StringBuilder.flix
@@ -17,7 +17,7 @@
 ///
 /// Represents a StringBuilder.
 ///
-opaque type StringBuilder[_: Region] = ##java.lang.StringBuilder
+enum StringBuilder[_: Region](##java.lang.StringBuilder)
 
 instance Newable[StringBuilder] {
     pub def new(r: Region[r]): StringBuilder[r] \ Write(r) = StringBuilder.new(r)

--- a/main/src/library/Time/Instant.flix
+++ b/main/src/library/Time/Instant.flix
@@ -19,7 +19,7 @@ namespace Time {
     ///
     /// A wrapper around a Java instant.
     ///
-    opaque type Instant = ##java.time.Instant
+    enum Instant(##java.time.Instant)
 
     namespace Instant {
 

--- a/main/src/library/Traversable.flix
+++ b/main/src/library/Traversable.flix
@@ -79,7 +79,7 @@ namespace Traversable {
     /// We use an Impure continuation so we can internally cast the `ef` of `mapAccumLeft` and not lose
     /// impurity information.
     ///
-    opaque type ContStateLeft[ka, s, a] = (a -> s -> ka & Impure) -> s -> ka & Impure
+    enum ContStateLeft[ka, s, a]((a -> s -> ka & Impure) -> s -> ka & Impure)
 
     ///
     /// Helper function for ContStateLeft's implementations of `map` and `ap`.
@@ -132,7 +132,7 @@ namespace Traversable {
     ///
     /// ContStateRight is exactly the same as ContStateLeft except the evaluation order of `ap` is flipped.
     ///
-    opaque type ContStateRight[ka, s, a] = (a -> s -> ka & Impure) -> s -> ka & Impure
+    enum ContStateRight[ka, s, a] = (a -> s -> ka & Impure) -> s -> ka & Impure
 
     ///
     /// Helper function for ContStateRight's implementations of `map` and `ap`.

--- a/main/src/library/Traversable.flix
+++ b/main/src/library/Traversable.flix
@@ -132,7 +132,7 @@ namespace Traversable {
     ///
     /// ContStateRight is exactly the same as ContStateLeft except the evaluation order of `ap` is flipped.
     ///
-    enum ContStateRight[ka, s, a] = (a -> s -> ka & Impure) -> s -> ka & Impure
+    enum ContStateRight[ka, s, a]((a -> s -> ka & Impure) -> s -> ka & Impure)
 
     ///
     /// Helper function for ContStateRight's implementations of `map` and `ap`.

--- a/main/test/ca/uwaterloo/flix/library/TestFoldable.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFoldable.flix
@@ -21,7 +21,7 @@ namespace TestFoldable {
     /// To test foldLeftM, foldRightM, foreachM we want a monad with
     /// "side-effects" so we can log direction of travel.
 
-    opaque type Logger[i, a] = (Chain[i], a)
+    enum Logger[i, a](Chain[i], a)
 
     def tell(x: i): Logger[i, Unit] = Logger((Chain.singleton(x), ()))
 

--- a/main/test/flix/Test.Dec.OpaqueType.flix
+++ b/main/test/flix/Test.Dec.OpaqueType.flix
@@ -1,47 +1,47 @@
 namespace Test/Dec/OpaqueType {
 
     /**
-     * An opaque type for degrees celsius.
+     * An enum for degrees celsius.
      */
     enum Celsius(Int32)
 
     /**
-     * An opaque type for degrees fahrenheit.
+     * An enum for degrees fahrenheit.
      */
     enum Fahrenheit(Int32)
 
     /**
-     * An opaque type for united states dollars.
+     * An enum for united states dollars.
      */
     enum USD(Float64)
 
     /**
-     * An opaque type for canadian dollars.
+     * An enum for canadian dollars.
      */
     enum CAD(Float64)
 
     /**
-     * An opaque type for an Option.
+     * An enum for an Option.
      */
     enum A(Option[Int32])
 
     /**
-     * An opaque type for a Result.
+     * An enum for a Result.
      */
     enum B(Result[Int32, String])
 
     /**
-     * An opaque type for a polymorphic pair.
+     * An enum for a polymorphic pair.
      */
     enum Pair[a, b](a, b)
 
     /**
-     * An opaque type for a polymorphic Result.
+     * An enum for a polymorphic Result.
      */
     enum C[a](Result[a, Int32])
 
     /**
-     * An opaque type for a polymorphic Result.
+     * An enum for a polymorphic Result.
      */
     enum D[a, b, c](Result[a, Result[b, c]])
 
@@ -158,12 +158,12 @@ namespace Test/Dec/OpaqueType {
     type alias Z[a] = Option[a]
 
     /**
-     * An opaque type for with a type alias.
+     * An enum for with a type alias.
      */
     enum U(Option[X])
 
     /**
-     * An opaque type for with a type alias.
+     * An enum for with a type alias.
      */
     enum V(Result[X, Y])
 

--- a/main/test/flix/Test.Dec.OpaqueType.flix
+++ b/main/test/flix/Test.Dec.OpaqueType.flix
@@ -3,47 +3,47 @@ namespace Test/Dec/OpaqueType {
     /**
      * An opaque type for degrees celsius.
      */
-    opaque type Celsius = Int32
+    enum Celsius(Int32)
 
     /**
      * An opaque type for degrees fahrenheit.
      */
-    opaque type Fahrenheit = Int32
+    enum Fahrenheit(Int32)
 
     /**
      * An opaque type for united states dollars.
      */
-    opaque type USD = Float64
+    enum USD(Float64)
 
     /**
      * An opaque type for canadian dollars.
      */
-    opaque type CAD = Float64
+    enum CAD(Float64)
 
     /**
      * An opaque type for an Option.
      */
-    opaque type A = Option[Int32]
+    enum A(Option[Int32])
 
     /**
      * An opaque type for a Result.
      */
-    opaque type B = Result[Int32, String]
+    enum B(Result[Int32, String])
 
     /**
      * An opaque type for a polymorphic pair.
      */
-    opaque type Pair[a, b] = (a, b)
+    enum Pair[a, b](a, b)
 
     /**
      * An opaque type for a polymorphic Result.
      */
-    opaque type C[a] = Result[a, Int32]
+    enum C[a](Result[a, Int32])
 
     /**
      * An opaque type for a polymorphic Result.
      */
-    opaque type D[a, b, c] = Result[a, Result[b, c]]
+    enum D[a, b, c](Result[a, Result[b, c]])
 
     @test
     def testOpaqueType01(): Celsius = Celsius(123)
@@ -160,12 +160,12 @@ namespace Test/Dec/OpaqueType {
     /**
      * An opaque type for with a type alias.
      */
-    opaque type U = Option[X]
+    enum U(Option[X])
 
     /**
      * An opaque type for with a type alias.
      */
-    opaque type V = Result[X, Y]
+    enum V(Result[X, Y])
 
     @test
     def testOpaqueType26(): U = U(None)

--- a/main/test/flix/Test.Dec.TopLevel.flix
+++ b/main/test/flix/Test.Dec.TopLevel.flix
@@ -10,7 +10,7 @@ enum E2 {
     case C2
 }
 
-opaque type Ot = Bool
+enum Ot(Bool)
 
 type alias Ta = Bool
 

--- a/main/test/flix/Test.Dec.TypeAlias.flix
+++ b/main/test/flix/Test.Dec.TypeAlias.flix
@@ -106,32 +106,32 @@ namespace Test/Dec/TypeAlias {
     def testTypeAlias20(): E[Int32] = Err("Hello World")
 
     /**
-     * An opaque type for Int.
+     * An enum for Int.
      */
     enum X(Int32)
 
     /**
-     * An opaque type for Option.
+     * An enum for Option.
      */
     enum Y[a](Option[a])
 
     /**
-     * An opaque type for Result.
+     * An enum for Result.
      */
     enum Z[a, b](Result[a, b])
 
     /**
-     * A type alias for an opaque type.
+     * A type alias for an enum.
      */
     type alias U = X
 
     /**
-     * A type alias for a polymorphic opaque type.
+     * A type alias for a polymorphic enum.
      */
     type alias V[a] = Y[a]
 
     /**
-     * A type alias for a polymorphic opaque type.
+     * A type alias for a polymorphic enum.
      */
     type alias W[a, b] = Z[a, b]
 

--- a/main/test/flix/Test.Dec.TypeAlias.flix
+++ b/main/test/flix/Test.Dec.TypeAlias.flix
@@ -108,17 +108,17 @@ namespace Test/Dec/TypeAlias {
     /**
      * An opaque type for Int.
      */
-    opaque type X = Int32
+    enum X(Int32)
 
     /**
      * An opaque type for Option.
      */
-    opaque type Y[a] = Option[a]
+    enum Y[a](Option[a])
 
     /**
      * An opaque type for Result.
      */
-    opaque type Z[a, b] = Result[a, b]
+    enum Z[a, b](Result[a, b])
 
     /**
      * A type alias for an opaque type.

--- a/main/test/flix/Test.Derives.Eq.flix
+++ b/main/test/flix/Test.Derives.Eq.flix
@@ -39,7 +39,7 @@ namespace Test/Derives/Eq {
         case RecursiveCase(MutRecursiveEnum1)
     }
 
-    pub opaque type OpaqueType with Eq = Int32
+    pub enum OpaqueType(Int32) with Eq
 
     @test
     def testEq01(): Bool = Enum.EmptyCase == Enum.EmptyCase

--- a/main/test/flix/Test.Derives.Hash.flix
+++ b/main/test/flix/Test.Derives.Hash.flix
@@ -40,7 +40,7 @@ namespace Test/Derives/Hash {
         case RecursiveCase(MutRecursiveEnum1)
     }
 
-    pub opaque type OpaqueType with Hash = Int32
+    pub enum OpaqueType(Int32) with Hash
 
     @test
     def testHashEq01(): Bool = hash(Enum.EmptyCase) == hash(Enum.EmptyCase)

--- a/main/test/flix/Test.Derives.Order.flix
+++ b/main/test/flix/Test.Derives.Order.flix
@@ -40,7 +40,7 @@ namespace Test/Derives/Order {
         case RecursiveCase(MutRecursiveEnum1)
     }
 
-    pub opaque type OpaqueType with Eq, Order = Int32
+    pub enum OpaqueType(Int32) with Eq, Order
 
     @test
     def testEq01(): Bool = compare(Enum.EmptyCase, Enum.EmptyCase) == EqualTo

--- a/main/test/flix/Test.Derives.ToString.flix
+++ b/main/test/flix/Test.Derives.ToString.flix
@@ -38,7 +38,7 @@ namespace Test/Derives/ToString {
         case RecursiveCase(MutRecursiveEnum1)
     }
 
-    pub opaque type OpaqueType with ToString = Int32
+    pub enum OpaqueType(Int32) with ToString
 
     @test
     def testToString01(): Bool = "${Enum.EmptyCase}" == "EmptyCase"

--- a/main/test/flix/Test.Exp.Lambda.Match.flix
+++ b/main/test/flix/Test.Exp.Lambda.Match.flix
@@ -1,10 +1,10 @@
 namespace Test/Exp/Lambda/Match {
 
-    opaque type Celsius = Int32
-    opaque type Fahrenheit = Int32
+    enum Celsius(Int32)
+    enum Fahrenheit(Int32)
 
-    opaque type EU = Celsius
-    opaque type US = Fahrenheit
+    enum EU(Celsius)
+    enum US(Fahrenheit)
 
     @test
     def testLambdaMatch01(): Int32 -> Int32 = match x -> x

--- a/main/test/flix/Test.Use.Type.flix
+++ b/main/test/flix/Test.Use.Type.flix
@@ -37,12 +37,12 @@ namespace A {
             case USD,
             case CAD
         }
-        pub opaque type Kelvin = Int32
+        pub enum Kelvin(Int32)
         pub type alias Meter = Int32
     }
 }
 
 namespace B {
-    pub opaque type Kilogram = Int32
+    pub enum Kilogram(Int32)
     pub type alias Acre = Int32
 }


### PR DESCRIPTION
Related to #3086