### PR TITLE
fix: add `MissingJvmDependency` error

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -714,6 +714,34 @@ object ResolutionError {
   }
 
   /**
+    * An error raised to indicate that a JVM class's dependency is missing.
+    *
+    * @param className  the name of the class.
+    * @param dependency the full path of the dependency.
+    * @param loc        the location where the error occurred.
+    */
+  case class MissingJvmDependency(className: String, dependency: String, loc: SourceLocation) extends ResolutionError {
+    override def summary: String = s"Missing dependency ${dependency} for JVM class ${className}."
+
+    /**
+      * Returns the formatted error message.
+      */
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Missing dependency ${dependency} for JVM class '${cyan(className)}'.
+         |
+         |${code(loc, s"missing dependency ${dependency}.")}
+         |""".stripMargin
+    }
+
+    /**
+      * Returns a formatted string with helpful suggestions.
+      */
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
     * An error raise to indicate a cycle in the class hierarchy.
     *
     * @param path the super class path from a class to itself.

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2365,6 +2365,7 @@ object Resolver {
     Class.forName(className, initialize, flix.jarLoader).toSuccess
   } catch {
     case ex: ClassNotFoundException => ResolutionError.UndefinedJvmClass(className, loc).toFailure
+    case ex: NoClassDefFoundError => ResolutionError.MissingJvmDependency(className, ex.getMessage, loc).toFailure
   }
 
   /**
@@ -2379,6 +2380,7 @@ object Resolver {
       } catch {
         case ex: ClassNotFoundException => ResolutionError.UndefinedJvmClass(className, loc).toFailure
         case ex: NoSuchMethodException => ResolutionError.UndefinedJvmConstructor(className, sig, clazz.getConstructors.toList, loc).toFailure
+        case ex: NoClassDefFoundError => ResolutionError.MissingJvmDependency(className, ex.getMessage, loc).toFailure
       }
     }
   }
@@ -2402,6 +2404,7 @@ object Resolver {
         case ex: NoSuchMethodException =>
           val candidateMethods = clazz.getMethods.filter(m => m.getName == methodName).toList
           ResolutionError.UndefinedJvmMethod(className, methodName, static, sig, candidateMethods, loc).toFailure
+        case ex: NoClassDefFoundError => ResolutionError.MissingJvmDependency(className, ex.getMessage, loc).toFailure
       }
     }
   }
@@ -2424,6 +2427,7 @@ object Resolver {
         case ex: NoSuchFieldException =>
           val candidateFields = clazz.getFields.toList
           ResolutionError.UndefinedJvmField(className, fieldName, static, candidateFields, loc).toFailure
+        case ex: NoClassDefFoundError => ResolutionError.MissingJvmDependency(className, ex.getMessage, loc).toFailure
       }
     }
   }


### PR DESCRIPTION
fixes #3868 

```
❌ -- Resolution Error -------------------------------------------------- file:///home/matt/Documents/flix-home/flix/personal/flix-sandbox/src/Main.flix

>> Missing dependency jakarta/servlet/http/HttpServletResponse for JVM class 'org.eclipse.jetty.server.Server'.

8 |>     import new org.eclipse.jetty.server.Server(ThreadPool): ##org.eclipse.jetty.server.Server & Impure as newServer;
9 |>     let threadPool = newThreadPool();
10 |>     setThreadPoolName(threadPool, "server");
11 |>     let server = newServer(threadPool);
12 |>     println("Hello World!")

missing dependency jakarta/servlet/http/HttpServletResponse.
```