### PR TITLE
refactor: rename `ScopedArray` -> `Array`

### DIFF
--- a/examples/datalog/merge_intervals.flix
+++ b/examples/datalog/merge_intervals.flix
@@ -3,7 +3,7 @@
 /// all overlapping intervals, and return an array of the non-overlapping
 /// intervals that cover all the intervals in the input.
 
-def merge(intervals: List[(Int32, Int32)]): Array[(Int32, Int32)] & Pure =
+def merge(intervals: List[(Int32, Int32)]): FooArray[(Int32, Int32)] & Pure =
     let i = project intervals into Interval;
     let lp = #{
         /// [a, ..., c, ..., b, ..., d]

--- a/examples/datalog/merge_intervals.flix
+++ b/examples/datalog/merge_intervals.flix
@@ -3,7 +3,7 @@
 /// all overlapping intervals, and return an array of the non-overlapping
 /// intervals that cover all the intervals in the input.
 
-def merge(intervals: List[(Int32, Int32)]): FooArray[(Int32, Int32)] & Pure =
+def merge(intervals: List[(Int32, Int32)]): UnscopedArray[(Int32, Int32)] & Pure =
     let i = project intervals into Interval;
     let lp = #{
         /// [a, ..., c, ..., b, ..., d]

--- a/examples/koans/friend-suggestions.flix
+++ b/examples/koans/friend-suggestions.flix
@@ -1,4 +1,4 @@
-pub def friendSuggestions(friends: List[(person, person)]): Array[(person, person)] with Boxable[person] =
+pub def friendSuggestions(friends: List[(person, person)]): FooArray[(person, person)] with Boxable[person] =
     let f = project friends into Friend;
     let lp = #{
         Suggestion(me, nf) :-

--- a/examples/koans/friend-suggestions.flix
+++ b/examples/koans/friend-suggestions.flix
@@ -1,4 +1,4 @@
-pub def friendSuggestions(friends: List[(person, person)]): FooArray[(person, person)] with Boxable[person] =
+pub def friendSuggestions(friends: List[(person, person)]): UnscopedArray[(person, person)] with Boxable[person] =
     let f = project friends into Friend;
     let lp = #{
         Suggestion(me, nf) :-

--- a/examples/koans/half-siblings.flix
+++ b/examples/koans/half-siblings.flix
@@ -1,4 +1,4 @@
-pub def halfSiblings(siblings: List[(person, person)]): FooArray[(person, person)] with Boxable[person] =
+pub def halfSiblings(siblings: List[(person, person)]): UnscopedArray[(person, person)] with Boxable[person] =
     let s = project siblings into Sibling;
     let lp: #{ Sibling(person, person), Parent(person, person), HalfSibling(person, person) } = #{
         Sibling(x, y) :- Parent(x, p), Parent(y, p), if x != y.

--- a/examples/koans/half-siblings.flix
+++ b/examples/koans/half-siblings.flix
@@ -1,4 +1,4 @@
-pub def halfSiblings(siblings: List[(person, person)]): Array[(person, person)] with Boxable[person] =
+pub def halfSiblings(siblings: List[(person, person)]): FooArray[(person, person)] with Boxable[person] =
     let s = project siblings into Sibling;
     let lp: #{ Sibling(person, person), Parent(person, person), HalfSibling(person, person) } = #{
         Sibling(x, y) :- Parent(x, p), Parent(y, p), if x != y.

--- a/examples/koans/heirs-and-usurpers.flix
+++ b/examples/koans/heirs-and-usurpers.flix
@@ -1,4 +1,4 @@
-pub def heirsAndUsurpers(parents: List[(person, person)], emperors: List[person]): {heirs :: FooArray[person], usurpers :: FooArray[person]} with Boxable[person] =
+pub def heirsAndUsurpers(parents: List[(person, person)], emperors: List[person]): {heirs :: UnscopedArray[person], usurpers :: UnscopedArray[person]} with Boxable[person] =
     let p = project parents into Parent;
     let e = project emperors into Emperor;
     let lp = #{

--- a/examples/koans/heirs-and-usurpers.flix
+++ b/examples/koans/heirs-and-usurpers.flix
@@ -1,4 +1,4 @@
-pub def heirsAndUsurpers(parents: List[(person, person)], emperors: List[person]): {heirs :: Array[person], usurpers :: Array[person]} with Boxable[person] =
+pub def heirsAndUsurpers(parents: List[(person, person)], emperors: List[person]): {heirs :: FooArray[person], usurpers :: FooArray[person]} with Boxable[person] =
     let p = project parents into Parent;
     let e = project emperors into Emperor;
     let lp = #{

--- a/examples/koans/os-process-classification.flix
+++ b/examples/koans/os-process-classification.flix
@@ -1,4 +1,4 @@
-pub def orphansAndZombies(processes: List[(processId, String, processId)], rootId: processId): {orphans :: FooArray[processId], zombies :: FooArray[processId]} with Boxable[processId] =
+pub def orphansAndZombies(processes: List[(processId, String, processId)], rootId: processId): {orphans :: UnscopedArray[processId], zombies :: UnscopedArray[processId]} with Boxable[processId] =
     let p = project processes into Process;
     let lp = #{
         Zombie(pid) :- Process(pid, "dead", parent), Process(parent, "alive", _).

--- a/examples/koans/os-process-classification.flix
+++ b/examples/koans/os-process-classification.flix
@@ -1,4 +1,4 @@
-pub def orphansAndZombies(processes: List[(processId, String, processId)], rootId: processId): {orphans :: Array[processId], zombies :: Array[processId]} with Boxable[processId] =
+pub def orphansAndZombies(processes: List[(processId, String, processId)], rootId: processId): {orphans :: FooArray[processId], zombies :: FooArray[processId]} with Boxable[processId] =
     let p = project processes into Process;
     let lp = #{
         Zombie(pid) :- Process(pid, "dead", parent), Process(parent, "alive", _).

--- a/examples/koans/unconnected-roads.flix
+++ b/examples/koans/unconnected-roads.flix
@@ -1,4 +1,4 @@
-pub def unconnected(roads: List[(city, city)]): Array[(city, city)] with Boxable[city] =
+pub def unconnected(roads: List[(city, city)]): FooArray[(city, city)] with Boxable[city] =
     let r = project roads into Road;
     let lp = #{
         City(x) :- Road(x, _).

--- a/examples/koans/unconnected-roads.flix
+++ b/examples/koans/unconnected-roads.flix
@@ -1,4 +1,4 @@
-pub def unconnected(roads: List[(city, city)]): FooArray[(city, city)] with Boxable[city] =
+pub def unconnected(roads: List[(city, city)]): UnscopedArray[(city, city)] with Boxable[city] =
     let r = project roads into Road;
     let lp = #{
         City(x) :- Road(x, _).

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
@@ -169,7 +169,7 @@ object FormatType {
       case SimpleType.Int64 => "Int64"
       case SimpleType.BigInt => "BigInt"
       case SimpleType.Str => "String"
-      case SimpleType.ScopedArray => "ScopedArray"
+      case SimpleType.ScopedArray => "Array"
       case SimpleType.ScopedRef => "Ref"
       case SimpleType.Channel => "Channel"
       case SimpleType.Lazy => "Lazy"

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1688,7 +1688,7 @@ object Resolver {
       case "String" => Type.mkString(loc).toSuccess
       case "Channel" => Type.mkChannel(loc).toSuccess
       case "Lazy" => Type.mkLazy(loc).toSuccess
-      case "ScopedArray" => Type.Cst(TypeConstructor.ScopedArray, loc).toSuccess
+      case "Array" => Type.Cst(TypeConstructor.ScopedArray, loc).toSuccess
       case "Ref" => Type.Cst(TypeConstructor.ScopedRef, loc).toSuccess
       case "Region" => Type.Cst(TypeConstructor.Region, loc).toSuccess
 

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-instance Scoped[ScopedArray[a]] {
-    pub def regionOf(_: ScopedArray[a, r]): Region[r] = () as Region[r]
+instance Scoped[Array[a]] {
+    pub def regionOf(_: Array[a, r]): Region[r] = () as Region[r]
 }
 
 namespace Array {
@@ -23,7 +23,7 @@ namespace Array {
     ///
     /// Compares `a` and `b` lexicographically.
     ///
-    pub def compare(a: ScopedArray[v, r1], b: ScopedArray[v, r2]): Comparison \ Read(r1, r2) with Order[v] =
+    pub def compare(a: Array[v, r1], b: Array[v, r2]): Comparison \ Read(r1, r2) with Order[v] =
         let len = Int32.min(Array.length(a), Array.length(b));
         def loop(i) = {
             if (i < len) {
@@ -45,7 +45,7 @@ namespace Array {
     ///
     /// Returns a string representation of the given array `a`.
     ///
-    pub def toString(a: ScopedArray[a, r]): String \ Read(r) with ToString[a] =
+    pub def toString(a: Array[a, r]): String \ Read(r) with ToString[a] =
         def loop(i, acc) =
             if (i < a.length) {
                 if (i == 0) loop(i + 1, "${a[i]}")
@@ -61,7 +61,7 @@ namespace Array {
     /// Equivalent to the expression `[x; l]`.
     ///
     @Time(l) @Space(l)
-    pub def new(x: a, l: Int32, r: Region[r]): ScopedArray[a, r] \ Write(r) =
+    pub def new(x: a, l: Int32, r: Region[r]): Array[a, r] \ Write(r) =
         [x; l] @ r
 
     ///
@@ -70,7 +70,7 @@ namespace Array {
     /// Equivalent to the expression `a[i]`.
     ///
     @Time(1) @Space(1)
-    pub def get(i: Int32, a: ScopedArray[a, r]): a \ Read(r) = a[i]
+    pub def get(i: Int32, a: Array[a, r]): a \ Read(r) = a[i]
 
     ///
     /// Stores the value `x` at position `i` in the array `a`.
@@ -78,20 +78,20 @@ namespace Array {
     /// Equivalent to the expression `a[i] = x`.
     ///
     @Time(1) @Space(1)
-    pub def put(x: a, i: Int32, a: ScopedArray[a, r]): ScopedArray[a, r] \ Write(r) =
+    pub def put(x: a, i: Int32, a: Array[a, r]): Array[a, r] \ Write(r) =
         a[i] = x; a
 
     ///
     /// Returns `true` if the given array `a` is empty.
     ///
     @Time(1) @Space(1)
-    pub def isEmpty(a: ScopedArray[a, r]): Bool = a.length == 0
+    pub def isEmpty(a: Array[a, r]): Bool = a.length == 0
 
     ///
     /// Returns the length of the array `a`.
     ///
     @Time(1) @Space(1)
-    pub def length(a: ScopedArray[a, r]): Int32 = a.length
+    pub def length(a: Array[a, r]): Int32 = a.length
 
     ///
     /// Returns a fresh array with the elements from the array `a` from index `b` (inclusive) until index `e` (exclusive).
@@ -99,13 +99,13 @@ namespace Array {
     /// Equivalent to the expression `a[b..e]`.
     ///
     @Time(e - b) @Space(e - b)
-    pub def slice(b: Int32, e: Int32, a: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } = a[b..e]
+    pub def slice(b: Int32, e: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } = a[b..e]
 
     ///
     /// Returns the array `a` as a list.
     ///
     @Time(length(a)) @Space(length(a))
-    pub def toList(a: ScopedArray[a, r]): List[a] \ Read(r) =
+    pub def toList(a: Array[a, r]): List[a] \ Read(r) =
         def loop(i, acc) = {
             if (i == 0) {
                 acc
@@ -119,7 +119,7 @@ namespace Array {
     ///
     /// Returns the array `a` as a `DelayList`.
     ///
-    pub def toDelayList(a: ScopedArray[a, r]): DelayList[a] \ Read(r) =
+    pub def toDelayList(a: Array[a, r]): DelayList[a] \ Read(r) =
         def loop(i, acc) = {
             if (i < 0)
                 acc
@@ -131,7 +131,7 @@ namespace Array {
     ///
     /// Returns the array `arr` as a chain.
     ///
-    pub def toChain(arr: ScopedArray[a, r]): Chain[a] \ Read(r) =
+    pub def toChain(arr: Array[a, r]): Chain[a] \ Read(r) =
         def loop(i, acc) = {
             if (i == 0) {
                 acc
@@ -148,7 +148,7 @@ namespace Array {
     /// Returns `None` if `a` is empty.
     ///
     @Time(1) @Space(1)
-    pub def head(a: ScopedArray[a, r]): Option[a] \ Read(r) =
+    pub def head(a: Array[a, r]): Option[a] \ Read(r) =
         if (length(a) > 0) Some(a[0]) else None
 
     ///
@@ -157,7 +157,7 @@ namespace Array {
     /// Returns `None` if `a` is empty.
     ///
     @Time(1) @Space(1)
-    pub def last(a: ScopedArray[a, r]): Option[a] \ Read(r) =
+    pub def last(a: Array[a, r]): Option[a] \ Read(r) =
         let len = length(a);
         if (len > 0) Some(a[len-1]) else None
 
@@ -165,7 +165,7 @@ namespace Array {
     /// Return a new array, appending the elements `b` to elements of `a`.
     ///
     @Time(length(a) + length(b)) @Space(length(a) + length(b))
-    pub def append(a: ScopedArray[a, r1], b: ScopedArray[a, r2]): ScopedArray[a, r1] \ { Read(r2), Write(r1) } =
+    pub def append(a: Array[a, r1], b: Array[a, r2]): Array[a, r1] \ { Read(r2), Write(r1) } =
         let len1 = length(a);
         let len2 = length(b);
         if (len1 == 0)
@@ -181,7 +181,7 @@ namespace Array {
     /// Returns `true` if and only if `a` contains the element `x`.
     ///
     @Time(length(a)) @Space(1)
-    pub def memberOf(x: a, a: ScopedArray[a, r]): Bool \ Read(r) with Eq[a] =
+    pub def memberOf(x: a, a: Array[a, r]): Bool \ Read(r) with Eq[a] =
         exists(y -> y == x, a)
 
     ///
@@ -189,7 +189,7 @@ namespace Array {
     ///
     /// Returns `None` if `a` is empty.
     ///
-    pub def minimum(a: ScopedArray[a, r]): Option[a] \ Read(r) with Order[a] =
+    pub def minimum(a: Array[a, r]): Option[a] \ Read(r) with Order[a] =
         reduceLeft(Order.min, a)
 
     ///
@@ -197,7 +197,7 @@ namespace Array {
     ///
     /// Returns `None` if `a` is empty.
     ///
-    pub def minimumBy(cmp: (a, a) -> Comparison, a: ScopedArray[a, r]): Option[a] \ Read(r) =
+    pub def minimumBy(cmp: (a, a) -> Comparison, a: Array[a, r]): Option[a] \ Read(r) =
         reduceLeft(Order.minBy(cmp), a)
 
     ///
@@ -205,7 +205,7 @@ namespace Array {
     ///
     /// Returns `None` if `a` is empty.
     ///
-    pub def maximum(a: ScopedArray[a, r]): Option[a] \ Read(r) with Order[a] =
+    pub def maximum(a: Array[a, r]): Option[a] \ Read(r) with Order[a] =
         reduceLeft(Order.max, a)
 
     ///
@@ -213,14 +213,14 @@ namespace Array {
     ///
     /// Returns `None` if `a` is empty.
     ///
-    pub def maximumBy(cmp: (a, a) -> Comparison, a: ScopedArray[a, r]): Option[a] \ Read(r) =
+    pub def maximumBy(cmp: (a, a) -> Comparison, a: Array[a, r]): Option[a] \ Read(r) =
         reduceLeft(Order.maxBy(cmp), a)
 
     ///
     /// Alias for `IndexOfLeft`
     ///
     @Time(length(a)) @Space(1)
-    pub def indexOf(x: a, a: ScopedArray[a, r]): Option[Int32] \ Read(r) with Eq[a] =
+    pub def indexOf(x: a, a: Array[a, r]): Option[Int32] \ Read(r) with Eq[a] =
         indexOfLeft(x,a)
 
     ///
@@ -228,7 +228,7 @@ namespace Array {
     /// searching from left to right.
     ///
     @Time(length(arr)) @Space(1)
-    pub def indexOfLeft(a: a, arr: ScopedArray[a, r]): Option[Int32] \ Read(r) with Eq[a] =
+    pub def indexOfLeft(a: a, arr: Array[a, r]): Option[Int32] \ Read(r) with Eq[a] =
         def loop(i) = {
             if (i >= arr.length)
                 -1
@@ -245,7 +245,7 @@ namespace Array {
     /// searching from right to left.
     ///
     @Time(length(arr)) @Space(1)
-    pub def indexOfRight(a: a, arr: ScopedArray[a, r]): Option[Int32] \ Read(r) with Eq[a] =
+    pub def indexOfRight(a: a, arr: Array[a, r]): Option[Int32] \ Read(r) with Eq[a] =
         def loop(i) = {
             if (i < 0)
                 -1
@@ -268,14 +268,14 @@ namespace Array {
     /// Alias for `findLeft`.
     ///
     @Time(time(f) * length(arr)) @Space(space(f))
-    pub def find(f: a -> Bool & ef, arr: ScopedArray[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def find(f: a -> Bool & ef, arr: Array[a, r]): Option[a] \ { ef, Read(r) } =
         findLeft(f, arr)
 
     ///
     /// Optionally returns the first element of `a` that satisfies the predicate `f` when searching from left to right.
     ///
     @Time(time(f) * length(arr)) @Space(space(f))
-    pub def findLeft(f: a -> Bool & ef, arr: ScopedArray[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def findLeft(f: a -> Bool & ef, arr: Array[a, r]): Option[a] \ { ef, Read(r) } =
         match findIndexOfLeft(f, arr) {
             case None    => None
             case Some(i) => Some(arr[i])
@@ -285,7 +285,7 @@ namespace Array {
     /// Optionally returns the first element of `xs` that satisfies the predicate `f` when searching from right to left.
     ///
     @Time(time(f) * length(arr)) @Space(space(f))
-    pub def findRight(f: a -> Bool & ef, arr: ScopedArray[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def findRight(f: a -> Bool & ef, arr: Array[a, r]): Option[a] \ { ef, Read(r) } =
         match findIndexOfRight(x -> f(x), arr) {
             case None    => None
             case Some(i) => Some(arr[i])
@@ -297,7 +297,7 @@ namespace Array {
     /// Returns `[]` if `b >= e`.
     ///
     @Time(e - b) @Space(e - b)
-    pub def range(b: Int32, e: Int32, r: Region[r]): ScopedArray[Int32, r] \ Write(r) =
+    pub def range(b: Int32, e: Int32, r: Region[r]): Array[Int32, r] \ Write(r) =
         if (b >= e)
             [] @ r
         else {
@@ -311,7 +311,7 @@ namespace Array {
     /// Returns `[]` if `n <= 0`.
     ///
     @Time(n) @Space(n)
-    pub def repeat(n: Int32, x: a, r: Region[r]): ScopedArray[a, r] \ Write(r) =
+    pub def repeat(n: Int32, x: a, r: Region[r]): Array[a, r] \ Write(r) =
         if (n <= 0)
             [] @ r
         else
@@ -320,7 +320,7 @@ namespace Array {
     ///
     /// Alias for `scanLeft`.
     ///
-    pub def scan(f: (b, a) -> b & ef, s: b, arr: ScopedArray[a, r]): ScopedArray[b, r] \ { ef, Read(r), Write(r) } =
+    pub def scan(f: (b, a) -> b & ef, s: b, arr: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         scanLeft(f, s, arr)
 
     ///
@@ -328,7 +328,7 @@ namespace Array {
     ///
     /// That is, the result is of the form: `[s , f(s, x1), f(f(s, x1), x2),  ...]`.
     ///
-    pub def scanLeft(f: (b, a) -> b & ef, s: b, arr: ScopedArray[a, r]): ScopedArray[b, r] \ { ef, Read(r), Write(r) } =
+    pub def scanLeft(f: (b, a) -> b & ef, s: b, arr: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let len = length(arr) + 1;
         let b = new(s, len, Scoped.regionOf(arr));
         def loop(i, acc) = {
@@ -348,7 +348,7 @@ namespace Array {
     ///
     /// That is, the result is of the form: `[..., f(xn-1, f(xn, s)), f(xn, s), s]`.
     ///
-    pub def scanRight(f: (a, b) -> b & ef, s: b, a: ScopedArray[a, r]): ScopedArray[b, r] \ { ef, Read(r), Write(r) } =
+    pub def scanRight(f: (a, b) -> b & ef, s: b, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let len = length(a);
         let b = new(s, len + 1, Scoped.regionOf(a));
         def loop(i, acc) = {
@@ -369,7 +369,7 @@ namespace Array {
     /// The result is a new array.
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
-    pub def map(f: a -> b & ef, a: ScopedArray[a, r]): ScopedArray[b, r] \ { ef, Read(r), Write(r) } =
+    pub def map(f: a -> b & ef, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let len = length(a);
         init(i -> f(a[i]), len, Scoped.regionOf(a))
 
@@ -377,7 +377,7 @@ namespace Array {
     /// Apply `f` to every element in array `arr`. Array `arr` is mutated.
     ///
     @Time(time(f) * length(arr)) @Space(space(f) * length(arr))
-    pub def transform!(f: a -> a & ef, arr: ScopedArray[a, r]): Unit \ { ef, Read(r), Write(r) } =
+    pub def transform!(f: a -> a & ef, arr: Array[a, r]): Unit \ { ef, Read(r), Write(r) } =
         let len = length(arr);
         def loop(i) = {
             if (i >= len)
@@ -395,7 +395,7 @@ namespace Array {
     /// That is, the result is of the form: `[ f(a[0], 0), f(a[1], 1), ... ]`.
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
-    pub def mapWithIndex(f: (a, Int32) -> b & ef, a: ScopedArray[a, r]): ScopedArray[b, r] \ { ef, Read(r), Write(r) } =
+    pub def mapWithIndex(f: (a, Int32) -> b & ef, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let len = length(a);
         init(i -> f(a[i], i), len, Scoped.regionOf(a))
 
@@ -403,7 +403,7 @@ namespace Array {
     /// Apply `f` to every element in array `a` along with that element's index. Array `a` is mutated.
     ///
     @Time(time(f) * length(arr)) @Space(space(f))
-    pub def transformWithIndex!(f: (a, Int32) -> a & ef, arr: ScopedArray[a, r]): Unit \ { ef, Read(r), Write(r) } =
+    pub def transformWithIndex!(f: (a, Int32) -> a & ef, arr: Array[a, r]): Unit \ { ef, Read(r), Write(r) } =
         let len = length(arr);
         def loop(i) = {
             if (i >= len)
@@ -427,7 +427,7 @@ namespace Array {
     /// Returns the reverse of `a`.
     ///
     @Time(length(a)) @Space(length(a))
-    pub def reverse(a: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } =
+    pub def reverse(a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(a);
         let end = len - 1;
         init(i -> a[end - i], len, Scoped.regionOf(a))
@@ -436,7 +436,7 @@ namespace Array {
     /// Reverse the array `arr`, mutating it in place.
     ///
     @Time(length(arr)) @Space(1)
-    pub def reverse!(arr: ScopedArray[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def reverse!(arr: Array[a, r]): Unit \ { Read(r), Write(r) } =
         let len = length(arr);
         let halflen = len / 2;
         def loop(i, j) = {
@@ -456,7 +456,7 @@ namespace Array {
     /// Rotate the contents of array `arr` by `n` steps to the left.
     ///
     @Time(n) @Space(length(arr))
-    pub def rotateLeft(n: Int32, arr: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } =
+    pub def rotateLeft(n: Int32, arr: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(arr);
         if (len < 1)
             [] @ Scoped.regionOf(arr)
@@ -473,7 +473,7 @@ namespace Array {
     ///
     /// This is an explicit helper to avoid code duplication.
     ///
-    def rotateLeftHelper(n: Int32, arr: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } =
+    def rotateLeftHelper(n: Int32, arr: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(arr);
         let f = i -> { let i1 = n + i; arr[i1 rem len] };
         init(f, len, Scoped.regionOf(arr))
@@ -482,7 +482,7 @@ namespace Array {
     /// Rotate the contents of array `arr` by `n` steps to the right.
     ///
     @Time(n) @Space(length(arr))
-    pub def rotateRight(n: Int32, arr: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } =
+    pub def rotateRight(n: Int32, arr: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         if (length(arr) < 1)
             [] @ Scoped.regionOf(arr)
         else
@@ -498,7 +498,7 @@ namespace Array {
     ///
     /// This is an explicit helper to avoid code duplication.
     ///
-    def rotateRightHelper(n: Int32, a: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } =
+    def rotateRightHelper(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(a);
         let n1 = n rem len;
         let start = len - n1;
@@ -511,7 +511,7 @@ namespace Array {
     /// Returns a shallow copy of `a` if `i < 0` or `i > length(xs)-1`.
     ///
     @Time(length(a)) @Space(length(a))
-    pub def update(i: Int32, x: a, a: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } =
+    pub def update(i: Int32, x: a, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let f = ix -> if (ix == i) x else a[ix];
         init(f, length(a), Scoped.regionOf(a))
 
@@ -519,14 +519,14 @@ namespace Array {
     /// Returns a copy of `a` with every occurrence of `from` replaced by `to`.
     ///
     @Time(length(a)) @Space(length(a))
-    pub def replace(from: {from :: a}, to: {to :: a}, a: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } with Eq[a] =
+    pub def replace(from: {from :: a}, to: {to :: a}, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } with Eq[a] =
         map(e -> if (e == from.from) to.to else e, a)
 
     ///
     /// Replace every occurrence of `from` by `to` in the array `a`, mutating it in place.
     ///
     @Time(length(a)) @Space(1)
-    pub def replace!(from: {from :: a}, to: {to :: a}, a: ScopedArray[a, r]): Unit \ { Read(r), Write(r) } with Eq[a] =
+    pub def replace!(from: {from :: a}, to: {to :: a}, a: Array[a, r]): Unit \ { Read(r), Write(r) } with Eq[a] =
         transform!(e -> if (e == from.from) to.to else e, a)
 
     ///
@@ -537,7 +537,7 @@ namespace Array {
     /// If patching occurs at index `i+j` in `b`, then the element at index `j` in `a` is used.
     ///
     @Time(n) @Space(length(b))
-    pub def patch(i: Int32, n: Int32, a: ScopedArray[a, r1], b: ScopedArray[a, r2]): ScopedArray[a, r2] \ { Read(r1, r2), Write(r2) } =
+    pub def patch(i: Int32, n: Int32, a: Array[a, r1], b: Array[a, r2]): Array[a, r2] \ { Read(r1, r2), Write(r2) } =
         let len1 = length(a);
         let size = if (n > len1) len1 else n;
         let sub = copyOfRange(0, size, a, Scoped.regionOf(b));
@@ -551,7 +551,7 @@ namespace Array {
     /// If patching occurs at index `i+j` in `b`, then the element at index `j` in `a` is used.
     ///
     @Time(n) @Space(1)
-    pub def patch!(i: Int32, n: Int32, a: ScopedArray[a, r1], b: ScopedArray[a, r2]): Unit \ { Read(r1), Write(r2) } =
+    pub def patch!(i: Int32, n: Int32, a: Array[a, r1], b: Array[a, r2]): Unit \ { Read(r1), Write(r2) } =
         let len1 = length(a);
         let size = if (n > len1) len1 else n;
         let sub = copyOfRange(0, size, a, Scoped.regionOf(b));
@@ -561,7 +561,7 @@ namespace Array {
     /// Returns `a` with `x` inserted between every two adjacent elements.
     ///
     @Time(length(a)) @Space(length(a))
-    pub def intersperse(x: a, a: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) }=
+    pub def intersperse(x: a, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) }=
         let len1 = length(a);
         let len2 = len1 + len1 - 1;
         let r = Scoped.regionOf(a);
@@ -608,7 +608,7 @@ namespace Array {
     ///
     /// Helper function for `intercalate` which needs to do sucessive writing.
     ///
-    def arrayWrites(pos: Int32, sub: ScopedArray[a, r1], out: ScopedArray[a, r2]): Int32 \ { Read(r1), Write(r2) } =
+    def arrayWrites(pos: Int32, sub: Array[a, r1], out: Array[a, r2]): Int32 \ { Read(r1), Write(r2) } =
         updateSequence!(pos, sub, out);
         pos + length(sub)
 
@@ -617,7 +617,7 @@ namespace Array {
     ///
     /// Helper function for `intercalate` and `flatten`.
     ///
-    def sumLengths(arrs: ScopedArray[ScopedArray[a, r1], r2]): Int32 \ Read(r2) =
+    def sumLengths(arrs: Array[Array[a, r1], r2]): Int32 \ Read(r2) =
         foldLeft((acc, a) -> acc + length(a), 0, arrs)
 
     ///
@@ -625,7 +625,7 @@ namespace Array {
     ///
     /// Helper function for `intercalate` and `flatten`.
     ///
-    def headArrays(arrs: ScopedArray[ScopedArray[a, r1], r2]): Option[a] \ Read(r1, r2) =
+    def headArrays(arrs: Array[Array[a, r1], r2]): Option[a] \ Read(r1, r2) =
         let len = length(arrs);
         def loop(i) = {
             if (i >= len)
@@ -644,7 +644,7 @@ namespace Array {
     /// Returns `a` if the dimensions of the elements of `a` are mismatched.
     ///
     @Time(length(a) * length(a)) @Space(length(a) * length(a))
-    pub def transpose(a: ScopedArray[ScopedArray[a, r1], r2]): ScopedArray[ScopedArray[a, r1], r2] \ { Read(r1, r2), Write(r1, r2) } =
+    pub def transpose(a: Array[Array[a, r1], r2]): Array[Array[a, r1], r2] \ { Read(r1, r2), Write(r1, r2) } =
         let ilen = length(a);
         let r2 = Scoped.regionOf(a);
         if (ilen == 0)
@@ -661,14 +661,14 @@ namespace Array {
     ///
     /// Helper function for `transpose`.
     ///
-    def uniformHelper(a: ScopedArray[ScopedArray[a, r1], r2], l: Int32): Bool \ Read(r2) =
+    def uniformHelper(a: Array[Array[a, r1], r2], l: Int32): Bool \ Read(r2) =
         exists(x -> length(x) != l, a)
 
     ///
     /// Returns `true` if and only if `a1` is a prefix of `a2`.
     ///
     @Time(length(a1)) @Space(1)
-    pub def isPrefixOf(a1: ScopedArray[a, r1], a2: ScopedArray[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
+    pub def isPrefixOf(a1: Array[a, r1], a2: Array[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
         let len1 = length(a1);
         if (len1 > length(a2))
             false
@@ -687,7 +687,7 @@ namespace Array {
     /// Returns `true` if and only if `a1` is a infix of `a2`.
     ///
     @Time(length(a1)) @Space(1)
-    pub def isInfixOf(a1: ScopedArray[a, r1], a2: ScopedArray[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
+    pub def isInfixOf(a1: Array[a, r1], a2: Array[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
         let len1 = length(a1);
         let len2 = length(a2);
         if (len1 > len2)
@@ -702,7 +702,7 @@ namespace Array {
     ///
     /// Precondition: len1 (length of a1) > 0
     ///
-    def isInfixOfSearch(a1: ScopedArray[a, r1], a2: ScopedArray[a, r2], len1: Int32, len2: Int32, j: Int32): Bool \ Read(r1, r2) with Eq[a] =
+    def isInfixOfSearch(a1: Array[a, r1], a2: Array[a, r2], len1: Int32, len2: Int32, j: Int32): Bool \ Read(r1, r2) with Eq[a] =
         if (j >= len2)
             false
         else if (a1[0] == a2[j])
@@ -713,7 +713,7 @@ namespace Array {
     ///
     /// Helper function for `isInfixOf` - a1 has started matching, scan to see if it all matches.
     ///
-    def isInfixOfCheck(a1: ScopedArray[a, r1], a2: ScopedArray[a, r2], len1: Int32, len2: Int32, i: Int32, j: Int32): Bool \ Read(r1, r2) with Eq[a] =
+    def isInfixOfCheck(a1: Array[a, r1], a2: Array[a, r2], len1: Int32, len2: Int32, i: Int32, j: Int32): Bool \ Read(r1, r2) with Eq[a] =
         if (i >= len1)
             // a1 exhausted, so success
             true
@@ -729,7 +729,7 @@ namespace Array {
     /// Returns `true` if and only if `a1` is a suffix of `a2`.
     ///
     @Time(length(a1)) @Space(1)
-    pub def isSuffixOf(a1: ScopedArray[a, r1], a2: ScopedArray[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
+    pub def isSuffixOf(a1: Array[a, r1], a2: Array[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
         let len1 = length(a1);
         let len2 = length(a2);
         if (len1 > len2)
@@ -748,14 +748,14 @@ namespace Array {
     ///
     /// Returns the result of applying `combine` to all the elements in `a`, using `empty` as the initial value.
     ///
-    pub def fold(arr: ScopedArray[a, r]): a \ Read(r) with Monoid[a] = foldLeft(Monoid.combine, Monoid.empty(), arr)
+    pub def fold(arr: Array[a, r]): a \ Read(r) with Monoid[a] = foldLeft(Monoid.combine, Monoid.empty(), arr)
 
     ///
     /// Applies `f` to a start value `s` and all elements in `a` going from left to right.
     ///
     /// That is, the result is of the form: `f(...f(f(s, a[0]), a[1])..., xn)`.
     ///
-    pub def foldLeft(f: (b, a) -> b & ef, s: b, arr: ScopedArray[a, r]): b \ { ef, Read(r) } =
+    pub def foldLeft(f: (b, a) -> b & ef, s: b, arr: Array[a, r]): b \ { ef, Read(r) } =
         let len = length(arr);
         def loop(i, acc) = {
             if (i >= len)
@@ -770,7 +770,7 @@ namespace Array {
     ///
     /// That is, the result is of the form: `f(a[0], ...f(a[n-1], f(a[n], s))...)`.
     ///
-    pub def foldRight(f: (a, b) -> b & ef, s: b, arr: ScopedArray[a, r]): b \ { ef, Read(r) } =
+    pub def foldRight(f: (a, b) -> b & ef, s: b, arr: Array[a, r]): b \ { ef, Read(r) } =
         def loop(i, acc) = {
             if (i < 0)
                 acc
@@ -785,7 +785,7 @@ namespace Array {
     /// That is, the result is of the form: `f(a[0], ...f(a[n-1], f(a[n], z))...)`.
     /// A `foldRightWithCont` allows early termination by not calling the continuation.
     ///
-    pub def foldRightWithCont(f: (a, Unit -> b & ef and r) -> b & ef and r, z: b, arr: ScopedArray[a, r]): b \ { ef, Read(r) } =
+    pub def foldRightWithCont(f: (a, Unit -> b & ef and r) -> b & ef and r, z: b, arr: Array[a, r]): b \ { ef, Read(r) } =
         def loop(i) = {
             if (i == length(arr))
                 z
@@ -805,7 +805,7 @@ namespace Array {
     ///
     /// Returns `None` if `a` is empty.
     ///
-    pub def reduceLeft(f: (a, a) ->  a & ef, a: ScopedArray[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def reduceLeft(f: (a, a) ->  a & ef, a: Array[a, r]): Option[a] \ { ef, Read(r) } =
         let len = length(a);
         def loop(i, acc) = {
             if (i >= len)
@@ -823,7 +823,7 @@ namespace Array {
     ///
     /// Returns `None` if `arr` is empty.
     ///
-    pub def reduceRight(f: (a, a) -> a & ef, arr: ScopedArray[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def reduceRight(f: (a, a) -> a & ef, arr: Array[a, r]): Option[a] \ { ef, Read(r) } =
         let len = length(arr);
         def loop(i, acc) = {
             if (i < 0)
@@ -840,25 +840,25 @@ namespace Array {
     /// Returns the number of elements in `a` that satisfy the predicate `f`.
     ///
     @Time(time(f) * length(a)) @Space(space(f))
-    pub def count(f: a -> Bool & ef, a: ScopedArray[a, r]): Int32 \ { ef, Read(r) } =
+    pub def count(f: a -> Bool & ef, a: Array[a, r]): Int32 \ { ef, Read(r) } =
         foldLeft((b, x) -> if (f(x)) b + 1 else b, 0, a)
 
     ///
     /// Returns the sum of all elements in the array `a`.
     ///
-    pub def sum(a: ScopedArray[Int32, r]): Int32 \ Read(r) =
+    pub def sum(a: Array[Int32, r]): Int32 \ Read(r) =
         foldLeft((acc, x) -> acc + x, 0, a)
 
     ///
     /// Returns the sum of all elements in the array `a` according to the function `f`.
     ///
-    pub def sumWith(f: a -> Int32 & ef, a: ScopedArray[a, r]): Int32 \ { ef, Read(r) } =
+    pub def sumWith(f: a -> Int32 & ef, a: Array[a, r]): Int32 \ { ef, Read(r) } =
         foldLeft((acc, x) -> acc + f(x), 0, a)
 
     ///
     /// Returns the product of all elements in the array `a`.
     ///
-    pub def product(a: ScopedArray[Int32, r]): Int32 \ Read(r) =
+    pub def product(a: Array[Int32, r]): Int32 \ Read(r) =
         if (isEmpty(a))
             0
         else
@@ -867,7 +867,7 @@ namespace Array {
     ///
     /// Returns the product of all elements in the array `a` according to the function `f`.
     ///
-    pub def productWith(f: a -> Int32 & ef, a: ScopedArray[a, r]): Int32 \ { ef, Read(r) } =
+    pub def productWith(f: a -> Int32 & ef, a: Array[a, r]): Int32 \ { ef, Read(r) } =
         if (isEmpty(a))
             0
         else
@@ -896,7 +896,7 @@ namespace Array {
     /// The function `f` must be pure.
     ///
     @Time(time(f) * length(arr)) @Space(space(f))
-    pub def exists(f: a -> Bool, arr: ScopedArray[a, r]): Bool \ Read(r) =
+    pub def exists(f: a -> Bool, arr: Array[a, r]): Bool \ Read(r) =
         let len = length(arr);
         def loop(i) = {
             if (i >= len)
@@ -914,7 +914,7 @@ namespace Array {
     /// Returns `true` if `arr` is empty.
     ///
     @Time(time(f) * length(arr)) @Space(space(f))
-    pub def forall(f: a -> Bool, arr: ScopedArray[a, r]): Bool \ Read(r) =
+    pub def forall(f: a -> Bool, arr: Array[a, r]): Bool \ Read(r) =
         let len = length(arr);
         def loop(i) = {
             if (i >= len)
@@ -930,7 +930,7 @@ namespace Array {
     /// Returns an array of every element in `arr` that satisfies the predicate `f`.
     ///
     @Time(time(f) * length(arr)) @Space(space(f) * length(arr))
-    pub def filter(f: a -> Bool & ef, arr: ScopedArray[a, r]): ScopedArray[a, r] \ { ef, Read(r), Write(r) } =
+    pub def filter(f: a -> Bool & ef, arr: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
         let len = length(arr);
         let r = Scoped.regionOf(arr);
         if (len < 1) {
@@ -961,7 +961,7 @@ namespace Array {
     /// `a2` contains all elements of `a` that do not satisfy the predicate `f`.
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
-    pub def partition(f: a -> Bool & ef, a: ScopedArray[a, r]): (ScopedArray[a, r], ScopedArray[a, r]) \ { ef, Read(r), Write(r) } =
+    pub def partition(f: a -> Bool & ef, a: Array[a, r]): (Array[a, r], Array[a, r]) \ { ef, Read(r), Write(r) } =
         let step = { (x, acc) ->
             let (a1, a2) = acc;
             if (f(x)) (x :: a1, a2) else (a1, x :: a2)
@@ -977,7 +977,7 @@ namespace Array {
     /// `a2` is the remainder of `a`.
     ///
     @Time(time(f) * length(a)) @Space()
-    pub def span(f: a -> Bool & ef, a: ScopedArray[a, r]): (ScopedArray[a, r], ScopedArray[a, r]) \ { ef, Read(r), Write(r) }=
+    pub def span(f: a -> Bool & ef, a: Array[a, r]): (Array[a, r], Array[a, r]) \ { ef, Read(r), Write(r) }=
         let r = Scoped.regionOf(a);
         match findIndexOfLeft(x -> not (f(x)), a) {
             case None    => (takeLeft(length(a), a), [] @ r)
@@ -988,7 +988,7 @@ namespace Array {
     /// Alias for `dropLeft`.
     ///
     @Time(length(a) - n) @Space(length(a) - n)
-    pub def drop(n: Int32, a: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } =
+    pub def drop(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         dropLeft(n, a)
 
     ///
@@ -997,7 +997,7 @@ namespace Array {
     /// Returns `[]` if `n > length(a)`.
     ///
     @Time(length(a) - n) @Space(length(a) - n)
-    pub def dropLeft(n: Int32, a: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } =
+    pub def dropLeft(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(a);
         let r = Scoped.regionOf(a);
         if (n > len)
@@ -1013,7 +1013,7 @@ namespace Array {
     /// Returns `[]` if `n > length(a)`.
     ///
     @Time(length(a) - n) @Space(length(a) - n)
-    pub def dropRight(n: Int32, a: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } =
+    pub def dropRight(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let r = Scoped.regionOf(a);
         let len = length(a);
         if (n >= len)
@@ -1027,14 +1027,14 @@ namespace Array {
     /// Alias for `dropWhileLeft`.
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
-    pub def dropWhile(f: a -> Bool & ef, a: ScopedArray[a, r]): ScopedArray[a, r] \ { ef, Read(r), Write(r) } =
+    pub def dropWhile(f: a -> Bool & ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
         dropWhileLeft(f, a)
 
     ///
     /// Returns copy of array `a` without the longest prefix that satisfies the predicate `f`.
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
-    pub def dropWhileLeft(f: a -> Bool & ef, a: ScopedArray[a, r]): ScopedArray[a, r] \ { ef, Read(r), Write(r) } =
+    pub def dropWhileLeft(f: a -> Bool & ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
         let r = Scoped.regionOf(a);
         match findIndexOfLeft(x -> not (f(x)), a) {
             case None    => [] @ r
@@ -1045,7 +1045,7 @@ namespace Array {
     /// Returns copy of array `a` without the longest suffix that satisfies the predicate `f`.
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
-    pub def dropWhileRight(f: a -> Bool & ef, a: ScopedArray[a, r]): ScopedArray[a, r] \ { ef, Read(r), Write(r) } =
+    pub def dropWhileRight(f: a -> Bool & ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
         let r = Scoped.regionOf(a);
         match findIndexOfRight(x -> not (f(x)), a) {
             case None    => [] @ r
@@ -1056,7 +1056,7 @@ namespace Array {
     /// Alias for `takeLeft`.
     ///
     @Time(n) @Space(n)
-    pub def take(n: Int32, a: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } =
+    pub def take(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         takeLeft(n, a)
 
     ///
@@ -1065,7 +1065,7 @@ namespace Array {
     /// Returns `a` if `n > length(xs)`.
     ///
     @Time(n) @Space(n)
-    pub def takeLeft(n: Int32, a: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } =
+    pub def takeLeft(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let r = Scoped.regionOf(a);
         if (n <= 0)
             [] @ r
@@ -1081,7 +1081,7 @@ namespace Array {
     /// Returns `a` if `n > length(xs)`.
     ///
     @Time(n) @Space(n)
-    pub def takeRight(n: Int32, a: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } =
+    pub def takeRight(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let r = Scoped.regionOf(a);
         if (n <= 0)
             [] @ r
@@ -1097,7 +1097,7 @@ namespace Array {
     /// The function `f` must be pure.
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
-    pub def takeWhile(f: a -> Bool & ef, a: ScopedArray[a, r]): ScopedArray[a, r] \ { ef, Read(r), Write(r) } =
+    pub def takeWhile(f: a -> Bool & ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
         takeWhileLeft(f, a)
 
     ///
@@ -1106,7 +1106,7 @@ namespace Array {
     /// The function `f` must be pure.
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
-    pub def takeWhileLeft(f: a -> Bool & ef, a: ScopedArray[a, r]): ScopedArray[a, r] \ { ef, Read(r), Write(r) } =
+    pub def takeWhileLeft(f: a -> Bool & ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
         match findIndexOfLeft(x -> not (f(x)), a) {
             case None    => a
             case Some(i) => takeLeft(i, a)
@@ -1118,7 +1118,7 @@ namespace Array {
     /// The function `f` must be pure.
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
-    pub def takeWhileRight(f: a -> Bool & ef, a: ScopedArray[a, r]): ScopedArray[a, r] \ { ef, Read(r), Write(r) } =
+    pub def takeWhileRight(f: a -> Bool & ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
         let r = Scoped.regionOf(a);
         match findIndexOfRight(x -> not (f(x)), a) {
             case None    => copyOfRange(0, length(a), a, r)
@@ -1134,7 +1134,7 @@ namespace Array {
     /// The function `f` must be pure.
     ///
     @Time(time(f) * length(a) * length(a)) @Space(space(f) * length(a))
-    pub def groupBy(f: (a, a) -> Bool, a: ScopedArray[a, r1], r2: Region[r2]): ScopedArray[ScopedArray[a, r2], r1] \ { Read(r1), Write(r1, r2) } =
+    pub def groupBy(f: (a, a) -> Bool, a: Array[a, r1], r2: Region[r2]): Array[Array[a, r2], r1] \ { Read(r1), Write(r1, r2) } =
         let xs = toList(a);
         let r1 = Scoped.regionOf(a);
         (groupByHelper(f, xs, Nil, r2) |> List.toArray)(r1)
@@ -1142,7 +1142,7 @@ namespace Array {
     ///
     /// Helper function for `groupBy`.
     ///
-    def groupByHelper(f: (a, a) -> Bool, xs: List[a], ac: List[ScopedArray[a, r]], r: Region[r]): List[ScopedArray[a, r]] \ Write(r) = match xs {
+    def groupByHelper(f: (a, a) -> Bool, xs: List[a], ac: List[Array[a, r]], r: Region[r]): List[Array[a, r]] \ Write(r) = match xs {
         case Nil     => List.reverse(ac)
         case x :: rs =>
             let (r1, r2) = extractHelper(f, rs, x :: Nil, Nil, r);
@@ -1152,7 +1152,7 @@ namespace Array {
     ///
     /// Helper function for `groupBy`.
     ///
-    def extractHelper(f: (a, a) -> Bool, xs: List[a], ps: List[a], ns: List[a], r: Region[r]): (ScopedArray[a, r], List[a]) \ Write(r) = match xs {
+    def extractHelper(f: (a, a) -> Bool, xs: List[a], ps: List[a], ns: List[a], r: Region[r]): (Array[a, r], List[a]) \ Write(r) = match xs {
         case Nil => {
             let a = List.reverse(ps);
             (List.toArray(a, r), List.reverse(ns))
@@ -1183,7 +1183,7 @@ namespace Array {
     /// If either `a` or `b` becomes depleted, then no further elements are added to the resulting array.
     ///
     @Time(Int32.min(length(a), length(b))) @Space(Int32.min(length(a), length(b)))
-    pub def zip(a: ScopedArray[a, r1], b: ScopedArray[b, r2]): ScopedArray[(a, b), r2] \ { Read(r1, r2), Write(r2) } =
+    pub def zip(a: Array[a, r1], b: Array[b, r2]): Array[(a, b), r2] \ { Read(r1, r2), Write(r2) } =
         let len = Int32.min(length(a), length(b));
         init(i -> (a[i], b[i]), len, Scoped.regionOf(b))
 
@@ -1194,7 +1194,7 @@ namespace Array {
     /// If either `a` or `b` becomes depleted, then no further elements are added to the resulting array.
     ///
     @Time(time(f) * Int32.min(length(a), length(b))) @Space(space(f) * Int32.min(length(a), length(b)))
-    pub def zipWith(f: (a, b) -> c & ef, a: ScopedArray[a, r1], b: ScopedArray[b, r2]): ScopedArray[c, r2] \ { ef, Read(r1, r2), Write(r2) } =
+    pub def zipWith(f: (a, b) -> c & ef, a: Array[a, r1], b: Array[b, r2]): Array[c, r2] \ { ef, Read(r1, r2), Write(r2) } =
         let len = Int32.min(length(a), length(b));
         init(i -> f(a[i], b[i]), len, Scoped.regionOf(b))
 
@@ -1203,7 +1203,7 @@ namespace Array {
     /// and the second containing all second components in `a`.
     ///
     @Time(length(a)) @Space(length(a))
-    pub def unzip(a: ScopedArray[(a, b), r]): (ScopedArray[a, r], ScopedArray[b, r]) \ { Read(r), Write(r) } =
+    pub def unzip(a: Array[(a, b), r]): (Array[a, r], Array[b, r]) \ { Read(r), Write(r) } =
         let r = Scoped.regionOf(a);
         init2(i -> a[i], length(a), r, r)
 
@@ -1211,7 +1211,7 @@ namespace Array {
     /// Alias for `foldLeft2`.
     ///
     @Time(time(f) * Int32.min(length(a), length(b))) @Space(space(f))
-    pub def fold2(f: (c, a, b) -> c & ef, c: c, a: ScopedArray[a, r1], b: ScopedArray[b, r2]): c \ { ef, Read(r1, r2) } =
+    pub def fold2(f: (c, a, b) -> c & ef, c: c, a: Array[a, r1], b: Array[b, r2]): c \ { ef, Read(r1, r2) } =
         foldLeft2(f, c, a, b)
 
     ///
@@ -1219,7 +1219,7 @@ namespace Array {
     /// starting with the initial value `c` and going from left to right.
     ///
     @Time(time(f) * Int32.min(length(a), length(b))) @Space(space(f))
-    pub def foldLeft2(f: (c, a, b) ->  c & ef, c: c, a: ScopedArray[a, r1], b: ScopedArray[b, r2]): c \ { ef, Read(r1, r2) } =
+    pub def foldLeft2(f: (c, a, b) ->  c & ef, c: c, a: Array[a, r1], b: Array[b, r2]): c \ { ef, Read(r1, r2) } =
         let lena = length(a);
         let lenb = length(b);
         def loop(i, acc) = {
@@ -1235,7 +1235,7 @@ namespace Array {
     /// starting with the initial value `c` and going from right to left.
     ///
     @Time(time(f) * Int32.min(length(a), length(b))) @Space(space(f))
-    pub def foldRight2(f: (a, b, c) -> c & ef, c: c, a: ScopedArray[a, r1], b: ScopedArray[b, r2]): c \ { ef, Read(r1, r2) } =
+    pub def foldRight2(f: (a, b, c) -> c & ef, c: c, a: Array[a, r1], b: Array[b, r2]): c \ { ef, Read(r1, r2) } =
         def loop(i, j, acc) = {
             if (i < 0 or j < 0)
                 acc
@@ -1250,7 +1250,7 @@ namespace Array {
     /// Collects the results of applying the partial function `f` to every element in `a`.
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
-    pub def filterMap(f: a -> Option[b] & ef, a: ScopedArray[a, r]): ScopedArray[b, r] \ { ef, Read(r), Write(r) } =
+    pub def filterMap(f: a -> Option[b] & ef, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let r = Scoped.regionOf(a);
         (foldRight((x, xs) -> match f(x) {
             case None    => xs
@@ -1262,7 +1262,7 @@ namespace Array {
     /// Returns `None` if every element of `xs` is `None`.
     ///
     @Time(time(f) * length(a)) @Space(space(f))
-    pub def findMap(f: a -> Option[b] & ef, a: ScopedArray[a, r]): Option[b] \ { ef, Read(r) } =
+    pub def findMap(f: a -> Option[b] & ef, a: Array[a, r]): Option[b] \ { ef, Read(r) } =
         let len = length(a);
         def loop(i) = {
             if (i >= len)
@@ -1280,7 +1280,7 @@ namespace Array {
     /// Returns the array `a` as a set.
     ///
     @Time(length(a)) @Space(length(a))
-    pub def toSet(a: ScopedArray[a, r]): Set[a] \ Read(r) with Order[a] =
+    pub def toSet(a: Array[a, r]): Set[a] \ Read(r) with Order[a] =
         foldRight(Set.insert, Set.empty(), a)
 
     ///
@@ -1290,13 +1290,13 @@ namespace Array {
     /// make any guarantees about which mapping will be in the resulting map.
     ///
     @Time(length(a)) @Space(length(a))
-    pub def toMap(a: ScopedArray[(a, b), r]): Map[a, b] \ Read(r) with Order[a] =
+    pub def toMap(a: Array[(a, b), r]): Map[a, b] \ Read(r) with Order[a] =
         foldRight((x, m) -> Map.insert(fst(x), snd(x), m), Map.empty(), a)
 
     ///
     /// Returns the array `a` as a MutList.
     ///
-    pub def toMutList(a: ScopedArray[a, r1], r2: Region[r2]): MutList[a, r2] \ { Read(r1), Write(r2) } =
+    pub def toMutList(a: Array[a, r1], r2: Region[r2]): MutList[a, r2] \ { Read(r1), Write(r2) } =
         let minCap = MutList.minCapacity();
         let len = length(a);
         let c = Order.max(len, minCap);
@@ -1306,14 +1306,14 @@ namespace Array {
     /// Alias for `findIndexOfLeft`.
     ///
     @Time(time(f) * length(a)) @Space(space(f))
-    pub def findIndexOf(f: a -> Bool & ef, a: ScopedArray[a, r]): Option[Int32] \ { ef, Read(r) } =
+    pub def findIndexOf(f: a -> Bool & ef, a: Array[a, r]): Option[Int32] \ { ef, Read(r) } =
         findIndexOfLeft(f,a)
 
     ///
     /// Optionally returns the position of the first element in `x` satisfying `f`.
     ///
     @Time(time(f) * length(a)) @Space(space(f))
-    pub def findIndexOfLeft(f: a -> Bool & ef, a: ScopedArray[a, r]): Option[Int32] \ { ef, Read(r) } =
+    pub def findIndexOfLeft(f: a -> Bool & ef, a: Array[a, r]): Option[Int32] \ { ef, Read(r) } =
         let len = length(a);
         if (len < 1)
             None
@@ -1335,7 +1335,7 @@ namespace Array {
     /// searching from right to left.
     ///
     @Time(time(f) * length(a)) @Space(space(f))
-    pub def findIndexOfRight(f: a -> Bool & ef, a: ScopedArray[a, r]): Option[Int32] \ { ef, Read(r) } =
+    pub def findIndexOfRight(f: a -> Bool & ef, a: Array[a, r]): Option[Int32] \ { ef, Read(r) } =
         let len = length(a);
         def loop(i) = {
             if (i < 0)
@@ -1370,7 +1370,7 @@ namespace Array {
     /// Build an array of length `len` by applying `f` to the successive indices.
     ///
     @Time(time(f) * len) @Space(space(f) * len)
-    pub def init(f: Int32 -> a & ef, len: Int32, r: Region[r]): ScopedArray[a, r] \ { ef, Write(r) } =
+    pub def init(f: Int32 -> a & ef, len: Int32, r: Region[r]): Array[a, r] \ { ef, Write(r) } =
         if (len <= 0)
             [] @ r
         else {
@@ -1391,7 +1391,7 @@ namespace Array {
     /// Build a pair of arrays of length `len` by applying `f` to the successive indices.
     ///
     @Time(time(f) * len) @Space(space(f) * len)
-    pub def init2(f: Int32 -> (a, b) & ef, len: Int32, r1: Region[r1], r2: Region[r2]): (ScopedArray[a, r1], ScopedArray[b, r2]) \ { ef, Write(r1, r2) } =
+    pub def init2(f: Int32 -> (a, b) & ef, len: Int32, r1: Region[r1], r2: Region[r2]): (Array[a, r1], Array[b, r2]) \ { ef, Write(r1, r2) } =
         if (len <= 0)
             ([] @ r1, [] @ r2)
         else {
@@ -1415,7 +1415,7 @@ namespace Array {
     /// Returns `true` if arrays `a` and `b` have the same elements, i.e. are structurally equal.
     ///
     @Time(length(a)) @Space(1)
-    pub def sameElements(a: ScopedArray[a, r1], b: ScopedArray[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
+    pub def sameElements(a: Array[a, r1], b: Array[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
         let alen = length(a);
         let blen = length(b);
         def loop(i) = {
@@ -1436,7 +1436,7 @@ namespace Array {
     /// Apply the effectful function `f` to all the elements in the array `a`.
     ///
     @Time(time(f) * length(a)) @Space(space(f))
-    pub def foreach(f: a -> Unit & ef, a: ScopedArray[a, r]): Unit \ { ef, Read(r) } =
+    pub def foreach(f: a -> Unit & ef, a: Array[a, r]): Unit \ { ef, Read(r) } =
         let len = length(a);
         def loop(i) = {
             if (i >= len)
@@ -1455,7 +1455,7 @@ namespace Array {
     /// Apply the effectful function `f` to all the elements in the array `a`.
     ///
     @Time(time(f) * length(a)) @Space(space(f))
-    pub def foreachWithIndex(f: (a, Int32) -> Unit & ef, a: ScopedArray[a, r]): Unit \ { ef, Read(r) } =
+    pub def foreachWithIndex(f: (a, Int32) -> Unit & ef, a: Array[a, r]): Unit \ { ef, Read(r) } =
         let len = length(a);
         def loop(i) = {
             if (i >= len)
@@ -1474,7 +1474,7 @@ namespace Array {
     /// Returns a copy of `a` with the elements starting at index `i` replaced by `sub`.
     ///
     @Time(length(a)) @Space(length(a))
-    pub def updateSequence(i: Int32, sub: ScopedArray[a, r1], a: ScopedArray[a, r2]): ScopedArray[a, r2] \ { Read(r1, r2), Write(r2) } =
+    pub def updateSequence(i: Int32, sub: Array[a, r1], a: Array[a, r2]): Array[a, r2] \ { Read(r1, r2), Write(r2) } =
         let end = i + length(sub);
         let f = ix -> if (ix >= i and ix < end) sub[ix - i] else a[ix];
         init(f, length(a), Scoped.regionOf(a))
@@ -1483,7 +1483,7 @@ namespace Array {
     /// Update the mutable array `a` with the elements starting at index `i` replaced by `sub`.
     ///
     @Time(length(a)) @Space(1)
-    pub def updateSequence!(i: Int32, sub: ScopedArray[a, r1], a: ScopedArray[a, r2]): Unit \ { Read(r1), Write(r2) } =
+    pub def updateSequence!(i: Int32, sub: Array[a, r1], a: Array[a, r2]): Unit \ { Read(r1), Write(r2) } =
         let end = i + length(sub);
         let f = { (_,ix) ->
             if (ix >= i and ix < end)
@@ -1497,14 +1497,14 @@ namespace Array {
     /// Returns the concatenation of the string representation
     /// of each element in `a` with `sep` inserted between each element.
     ///
-    pub def join(sep: String, a: ScopedArray[a, r]): String \ Read(r) with ToString[a] =
+    pub def join(sep: String, a: Array[a, r]): String \ Read(r) with ToString[a] =
         joinWith(ToString.toString, sep, a)
 
     ///
     /// Returns the concatenation of the string representation
     /// of each element in `a` according to `f` with `sep` inserted between each element.
     ///
-    pub def joinWith(f: a -> String & ef, sep: String, a: ScopedArray[a, r]): String \ { ef, Read(r) } = region r1 {
+    pub def joinWith(f: a -> String & ef, sep: String, a: Array[a, r]): String \ { ef, Read(r) } = region r1 {
         use StringBuilder.append!;
         let lastSep = String.length(sep);
         let sb = new StringBuilder(r1);
@@ -1520,7 +1520,7 @@ namespace Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sort(a: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } with Order[a] =
+    pub def sort(a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } with Order[a] =
         sortWith(Order.compare, a)
 
     ///
@@ -1531,7 +1531,7 @@ namespace Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortBy(f: a -> b, a: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } with Order[b] =
+    pub def sortBy(f: a -> b, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } with Order[b] =
         sortWith(Order.compare `on` f, a)
 
     ///
@@ -1542,7 +1542,7 @@ namespace Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortWith(cmp: (a,a) -> Comparison, a: ScopedArray[a, r]): ScopedArray[a, r] \ { Read(r), Write(r) } =
+    pub def sortWith(cmp: (a,a) -> Comparison, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(a);
         let b = copyOfRange(0, len, a, Scoped.regionOf(a));
         sortWith!(cmp, b);
@@ -1556,7 +1556,7 @@ namespace Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sort!(a: ScopedArray[a, r]): Unit \ { Read(r), Write(r) } with Order[a] =
+    pub def sort!(a: Array[a, r]): Unit \ { Read(r), Write(r) } with Order[a] =
         sortWith!(Order.compare, a)
 
     ///
@@ -1567,7 +1567,7 @@ namespace Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortBy!(f: a -> b, a: ScopedArray[a, r]): Unit \ { Read(r), Write(r) } with Order[b] =
+    pub def sortBy!(f: a -> b, a: Array[a, r]): Unit \ { Read(r), Write(r) } with Order[b] =
         sortWith!(Order.compare `on` f, a)
 
     ///
@@ -1578,7 +1578,7 @@ namespace Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortWith!(cmp: (a,a) -> Comparison, a: ScopedArray[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def sortWith!(cmp: (a,a) -> Comparison, a: Array[a, r]): Unit \ { Read(r), Write(r) } =
         sortWithin!(cmp, 0, length(a) - 1, a)
 
     ///
@@ -1590,7 +1590,7 @@ namespace Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortWithin!(cmp: (a,a) -> Comparison, lo: Int32, hi: Int32, a: ScopedArray[a, r]): Unit \ { Read(r), Write(r) }=
+    pub def sortWithin!(cmp: (a,a) -> Comparison, lo: Int32, hi: Int32, a: Array[a, r]): Unit \ { Read(r), Write(r) }=
         if (lo >= hi)
             ()
         else {
@@ -1604,7 +1604,7 @@ namespace Array {
     ///
     /// Precondition: `i` and `j` are within bounds.
     ///
-    pub def swap!(i: Int32, j: Int32, a: ScopedArray[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def swap!(i: Int32, j: Int32, a: Array[a, r]): Unit \ { Read(r), Write(r) } =
         let x = a[i];
         let y = a[j];
         a[i] = y;
@@ -1614,7 +1614,7 @@ namespace Array {
     ///
     /// Partition step of the Quicksort algorithm.
     ///
-    def quicksortPartition(cmp: (a,a) -> Comparison, a: ScopedArray[a, r], lo: Int32, hi: Int32): Int32 \ { Read(r), Write(r) } =
+    def quicksortPartition(cmp: (a,a) -> Comparison, a: Array[a, r], lo: Int32, hi: Int32): Int32 \ { Read(r), Write(r) } =
         let pivot = a[hi];
         let i = forWithAccum(lo, hi, lo, (j,ix) ->
             if (cmp(a[j], pivot) == LessThan) {
@@ -1649,58 +1649,58 @@ namespace Array {
     /// If the range is valid and greater than the length of `a`, the resulting array with have the length of the range
     /// and include the specified range of `a`.
     ///
-    pub def copyOfRange(b: Int32, e: Int32, a: ScopedArray[a, r1], _: Region[r2]): ScopedArray[a, r2] \ { Read(r1), Write(r2) } =
+    pub def copyOfRange(b: Int32, e: Int32, a: Array[a, r1], _: Region[r2]): Array[a, r2] \ { Read(r1), Write(r2) } =
         match (reifyType a) {
             case ErasedType =>
                 let arr = a as FooArray[##java.lang.Object];
-                import static java.util.Arrays.copyOfRange(FooArray[##java.lang.Object], Int32, Int32): ScopedArray[##java.lang.Object, r2] & r1 and r2 as copy;
-                copy(arr, b, e) as ScopedArray[a, r2]
+                import static java.util.Arrays.copyOfRange(FooArray[##java.lang.Object], Int32, Int32): Array[##java.lang.Object, r2] & r1 and r2 as copy;
+                copy(arr, b, e) as Array[a, r2]
             case ReifiedUnit =>
                 let arr = a as FooArray[Unit];
-                import static java.util.Arrays.copyOfRange(FooArray[Unit], Int32, Int32): ScopedArray[Unit, r2] & r1 and r2 as copy;
-                copy(arr, b, e) as ScopedArray[a, r2]
+                import static java.util.Arrays.copyOfRange(FooArray[Unit], Int32, Int32): Array[Unit, r2] & r1 and r2 as copy;
+                copy(arr, b, e) as Array[a, r2]
             case ReifiedBool =>
                 let arr = a as FooArray[Bool];
-                import static java.util.Arrays.copyOfRange(FooArray[Bool], Int32, Int32): ScopedArray[Bool, r2] & r1 and r2 as copy;
-                copy(arr, b, e) as ScopedArray[a, r2]
+                import static java.util.Arrays.copyOfRange(FooArray[Bool], Int32, Int32): Array[Bool, r2] & r1 and r2 as copy;
+                copy(arr, b, e) as Array[a, r2]
             case ReifiedChar =>
                 let arr = a as FooArray[Char];
-                import static java.util.Arrays.copyOfRange(FooArray[Char], Int32, Int32): ScopedArray[Char, r2] & r1 and r2 as copy;
-                copy(arr, b, e) as ScopedArray[a, r2]
+                import static java.util.Arrays.copyOfRange(FooArray[Char], Int32, Int32): Array[Char, r2] & r1 and r2 as copy;
+                copy(arr, b, e) as Array[a, r2]
             case ReifiedFloat32 =>
                 let arr = a as FooArray[Float32];
-                import static java.util.Arrays.copyOfRange(FooArray[Float32], Int32, Int32): ScopedArray[Float32, r2] & r1 and r2 as copy;
-                copy(arr, b, e) as ScopedArray[a, r2]
+                import static java.util.Arrays.copyOfRange(FooArray[Float32], Int32, Int32): Array[Float32, r2] & r1 and r2 as copy;
+                copy(arr, b, e) as Array[a, r2]
             case ReifiedFloat64 =>
                 let arr = a as FooArray[Float64];
-                import static java.util.Arrays.copyOfRange(FooArray[Float64], Int32, Int32): ScopedArray[Float64, r2] & r1 and r2 as copy;
-                copy(arr, b, e) as ScopedArray[a, r2]
+                import static java.util.Arrays.copyOfRange(FooArray[Float64], Int32, Int32): Array[Float64, r2] & r1 and r2 as copy;
+                copy(arr, b, e) as Array[a, r2]
             case ReifiedInt8 =>
                 let arr = a as FooArray[Int8];
-                import static java.util.Arrays.copyOfRange(FooArray[Int8], Int32, Int32): ScopedArray[Int8, r2] & r1 and r2 as copy;
-                copy(arr, b, e) as ScopedArray[a, r2]
+                import static java.util.Arrays.copyOfRange(FooArray[Int8], Int32, Int32): Array[Int8, r2] & r1 and r2 as copy;
+                copy(arr, b, e) as Array[a, r2]
             case ReifiedInt16 =>
                 let arr = a as FooArray[Int16];
-                import static java.util.Arrays.copyOfRange(FooArray[Int16], Int32, Int32): ScopedArray[Int16, r2] & r1 and r2 as copy;
-                copy(arr, b, e) as ScopedArray[a, r2]
+                import static java.util.Arrays.copyOfRange(FooArray[Int16], Int32, Int32): Array[Int16, r2] & r1 and r2 as copy;
+                copy(arr, b, e) as Array[a, r2]
             case ReifiedInt32 =>
                 let arr = a as FooArray[Int32];
-                import static java.util.Arrays.copyOfRange(FooArray[Int32], Int32, Int32): ScopedArray[Int32, r2] & r1 and r2 as copy;
-                copy(arr, b, e) as ScopedArray[a, r2]
+                import static java.util.Arrays.copyOfRange(FooArray[Int32], Int32, Int32): Array[Int32, r2] & r1 and r2 as copy;
+                copy(arr, b, e) as Array[a, r2]
             case ReifiedInt64 =>
                 let arr = a as FooArray[Int64];
-                import static java.util.Arrays.copyOfRange(FooArray[Int64], Int32, Int32): ScopedArray[Int64, r2] & r1 and r2 as copy;
-                copy(arr, b, e) as ScopedArray[a, r2]
+                import static java.util.Arrays.copyOfRange(FooArray[Int64], Int32, Int32): Array[Int64, r2] & r1 and r2 as copy;
+                copy(arr, b, e) as Array[a, r2]
             case ReifiedArray(_) =>
                 let arr = a as FooArray[##java.lang.Object];
-                import static java.util.Arrays.copyOfRange(FooArray[##java.lang.Object], Int32, Int32): ScopedArray[##java.lang.Object, r2] & r1 and r2 as copy;
-                copy(arr, b, e) as ScopedArray[a, r2]
+                import static java.util.Arrays.copyOfRange(FooArray[##java.lang.Object], Int32, Int32): Array[##java.lang.Object, r2] & r1 and r2 as copy;
+                copy(arr, b, e) as Array[a, r2]
         }
 
    ///
    /// Returns an iterator over `a`.
    ///
-   pub def toIterator(a: ScopedArray[a, r]): Iterator[a] & Impure =
+   pub def toIterator(a: Array[a, r]): Iterator[a] & Impure =
        let len = Array.length(a);
        let copy = copyOfRange(0, len, a, static);
        let i = ref 0;

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -261,7 +261,7 @@ namespace Array {
     /// Return the positions of the all the occurrences of `a` in `arr`.
     ///
     @Time(length(arr)) @Space(length(arr))
-    pub def indices(a: a, arr: FooArray[a]): FooArray[Int32] & Impure with Eq[a] =
+    pub def indices(a: a, arr: UnscopedArray[a]): UnscopedArray[Int32] & Impure with Eq[a] =
         findIndices(b -> a == b, arr)
 
     ///
@@ -419,7 +419,7 @@ namespace Array {
     /// Returns the result of applying `f` to every element in `a` and concatenating the results.
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
-    pub def flatMap(f: a -> FooArray[b] & ef, a: FooArray[a]): FooArray[b] & Impure =
+    pub def flatMap(f: a -> UnscopedArray[b] & ef, a: UnscopedArray[a]): UnscopedArray[b] & Impure =
         let len = length(a);
         init(i -> f(a[i]), len, static) |> flatten
 
@@ -578,7 +578,7 @@ namespace Array {
     /// Returns the concatenation of the elements in `arrs` with the elements of `sep` inserted between every two adjacent elements.
     ///
     @Time(length(arrs)) @Space(length(arrs))
-    pub def intercalate(sep: FooArray[a], arrs: FooArray[FooArray[a]]): FooArray[a] & Impure =
+    pub def intercalate(sep: UnscopedArray[a], arrs: UnscopedArray[UnscopedArray[a]]): UnscopedArray[a] & Impure =
         let count = length(arrs);
         let sepLength = length(sep);
         let sepCount = if (count < 2) 0 else count - 1;
@@ -797,7 +797,7 @@ namespace Array {
     ///
     /// Returns the result of mapping each element and combining the results.
     ///
-    pub def foldMap(f: a -> b & ef, arr: FooArray[a]): b & Impure with Monoid[b] =
+    pub def foldMap(f: a -> b & ef, arr: UnscopedArray[a]): b & Impure with Monoid[b] =
         foldLeft((acc, x) -> Monoid.combine(acc, f(x)), Monoid.empty(), arr)
 
     ///
@@ -877,7 +877,7 @@ namespace Array {
     /// Returns the concatenation of the arrays of in the array `arrs`.
     ///
     @Time(length(arrs)) @Space(length(arrs))
-    pub def flatten(arrs: FooArray[FooArray[a]]) : FooArray[a] & Impure =
+    pub def flatten(arrs: UnscopedArray[UnscopedArray[a]]) : UnscopedArray[a] & Impure =
         let len = sumLengths(arrs);
         match headArrays(arrs) {
             case None => []
@@ -1352,7 +1352,7 @@ namespace Array {
     /// Returns the positions of the all the elements in `a` satisfying `f`.
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
-    pub def findIndices(f: a -> Bool & ef, a: FooArray[a]): FooArray[Int32] & Impure =
+    pub def findIndices(f: a -> Bool & ef, a: UnscopedArray[a]): UnscopedArray[Int32] & Impure =
         let len = length(a);
         let l = new MutList(static);
         def loop(i) = {
@@ -1652,48 +1652,48 @@ namespace Array {
     pub def copyOfRange(b: Int32, e: Int32, a: Array[a, r1], _: Region[r2]): Array[a, r2] \ { Read(r1), Write(r2) } =
         match (reifyType a) {
             case ErasedType =>
-                let arr = a as FooArray[##java.lang.Object];
-                import static java.util.Arrays.copyOfRange(FooArray[##java.lang.Object], Int32, Int32): Array[##java.lang.Object, r2] & r1 and r2 as copy;
+                let arr = a as UnscopedArray[##java.lang.Object];
+                import static java.util.Arrays.copyOfRange(UnscopedArray[##java.lang.Object], Int32, Int32): Array[##java.lang.Object, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as Array[a, r2]
             case ReifiedUnit =>
-                let arr = a as FooArray[Unit];
-                import static java.util.Arrays.copyOfRange(FooArray[Unit], Int32, Int32): Array[Unit, r2] & r1 and r2 as copy;
+                let arr = a as UnscopedArray[Unit];
+                import static java.util.Arrays.copyOfRange(UnscopedArray[Unit], Int32, Int32): Array[Unit, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as Array[a, r2]
             case ReifiedBool =>
-                let arr = a as FooArray[Bool];
-                import static java.util.Arrays.copyOfRange(FooArray[Bool], Int32, Int32): Array[Bool, r2] & r1 and r2 as copy;
+                let arr = a as UnscopedArray[Bool];
+                import static java.util.Arrays.copyOfRange(UnscopedArray[Bool], Int32, Int32): Array[Bool, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as Array[a, r2]
             case ReifiedChar =>
-                let arr = a as FooArray[Char];
-                import static java.util.Arrays.copyOfRange(FooArray[Char], Int32, Int32): Array[Char, r2] & r1 and r2 as copy;
+                let arr = a as UnscopedArray[Char];
+                import static java.util.Arrays.copyOfRange(UnscopedArray[Char], Int32, Int32): Array[Char, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as Array[a, r2]
             case ReifiedFloat32 =>
-                let arr = a as FooArray[Float32];
-                import static java.util.Arrays.copyOfRange(FooArray[Float32], Int32, Int32): Array[Float32, r2] & r1 and r2 as copy;
+                let arr = a as UnscopedArray[Float32];
+                import static java.util.Arrays.copyOfRange(UnscopedArray[Float32], Int32, Int32): Array[Float32, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as Array[a, r2]
             case ReifiedFloat64 =>
-                let arr = a as FooArray[Float64];
-                import static java.util.Arrays.copyOfRange(FooArray[Float64], Int32, Int32): Array[Float64, r2] & r1 and r2 as copy;
+                let arr = a as UnscopedArray[Float64];
+                import static java.util.Arrays.copyOfRange(UnscopedArray[Float64], Int32, Int32): Array[Float64, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as Array[a, r2]
             case ReifiedInt8 =>
-                let arr = a as FooArray[Int8];
-                import static java.util.Arrays.copyOfRange(FooArray[Int8], Int32, Int32): Array[Int8, r2] & r1 and r2 as copy;
+                let arr = a as UnscopedArray[Int8];
+                import static java.util.Arrays.copyOfRange(UnscopedArray[Int8], Int32, Int32): Array[Int8, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as Array[a, r2]
             case ReifiedInt16 =>
-                let arr = a as FooArray[Int16];
-                import static java.util.Arrays.copyOfRange(FooArray[Int16], Int32, Int32): Array[Int16, r2] & r1 and r2 as copy;
+                let arr = a as UnscopedArray[Int16];
+                import static java.util.Arrays.copyOfRange(UnscopedArray[Int16], Int32, Int32): Array[Int16, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as Array[a, r2]
             case ReifiedInt32 =>
-                let arr = a as FooArray[Int32];
-                import static java.util.Arrays.copyOfRange(FooArray[Int32], Int32, Int32): Array[Int32, r2] & r1 and r2 as copy;
+                let arr = a as UnscopedArray[Int32];
+                import static java.util.Arrays.copyOfRange(UnscopedArray[Int32], Int32, Int32): Array[Int32, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as Array[a, r2]
             case ReifiedInt64 =>
-                let arr = a as FooArray[Int64];
-                import static java.util.Arrays.copyOfRange(FooArray[Int64], Int32, Int32): Array[Int64, r2] & r1 and r2 as copy;
+                let arr = a as UnscopedArray[Int64];
+                import static java.util.Arrays.copyOfRange(UnscopedArray[Int64], Int32, Int32): Array[Int64, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as Array[a, r2]
             case ReifiedArray(_) =>
-                let arr = a as FooArray[##java.lang.Object];
-                import static java.util.Arrays.copyOfRange(FooArray[##java.lang.Object], Int32, Int32): Array[##java.lang.Object, r2] & r1 and r2 as copy;
+                let arr = a as UnscopedArray[##java.lang.Object];
+                import static java.util.Arrays.copyOfRange(UnscopedArray[##java.lang.Object], Int32, Int32): Array[##java.lang.Object, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as Array[a, r2]
         }
 

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -261,7 +261,7 @@ namespace Array {
     /// Return the positions of the all the occurrences of `a` in `arr`.
     ///
     @Time(length(arr)) @Space(length(arr))
-    pub def indices(a: a, arr: Array[a]): Array[Int32] & Impure with Eq[a] =
+    pub def indices(a: a, arr: FooArray[a]): FooArray[Int32] & Impure with Eq[a] =
         findIndices(b -> a == b, arr)
 
     ///
@@ -419,7 +419,7 @@ namespace Array {
     /// Returns the result of applying `f` to every element in `a` and concatenating the results.
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
-    pub def flatMap(f: a -> Array[b] & ef, a: Array[a]): Array[b] & Impure =
+    pub def flatMap(f: a -> FooArray[b] & ef, a: FooArray[a]): FooArray[b] & Impure =
         let len = length(a);
         init(i -> f(a[i]), len, static) |> flatten
 
@@ -578,7 +578,7 @@ namespace Array {
     /// Returns the concatenation of the elements in `arrs` with the elements of `sep` inserted between every two adjacent elements.
     ///
     @Time(length(arrs)) @Space(length(arrs))
-    pub def intercalate(sep: Array[a], arrs: Array[Array[a]]): Array[a] & Impure =
+    pub def intercalate(sep: FooArray[a], arrs: FooArray[FooArray[a]]): FooArray[a] & Impure =
         let count = length(arrs);
         let sepLength = length(sep);
         let sepCount = if (count < 2) 0 else count - 1;
@@ -797,7 +797,7 @@ namespace Array {
     ///
     /// Returns the result of mapping each element and combining the results.
     ///
-    pub def foldMap(f: a -> b & ef, arr: Array[a]): b & Impure with Monoid[b] =
+    pub def foldMap(f: a -> b & ef, arr: FooArray[a]): b & Impure with Monoid[b] =
         foldLeft((acc, x) -> Monoid.combine(acc, f(x)), Monoid.empty(), arr)
 
     ///
@@ -877,7 +877,7 @@ namespace Array {
     /// Returns the concatenation of the arrays of in the array `arrs`.
     ///
     @Time(length(arrs)) @Space(length(arrs))
-    pub def flatten(arrs: Array[Array[a]]) : Array[a] & Impure =
+    pub def flatten(arrs: FooArray[FooArray[a]]) : FooArray[a] & Impure =
         let len = sumLengths(arrs);
         match headArrays(arrs) {
             case None => []
@@ -1352,7 +1352,7 @@ namespace Array {
     /// Returns the positions of the all the elements in `a` satisfying `f`.
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
-    pub def findIndices(f: a -> Bool & ef, a: Array[a]): Array[Int32] & Impure =
+    pub def findIndices(f: a -> Bool & ef, a: FooArray[a]): FooArray[Int32] & Impure =
         let len = length(a);
         let l = new MutList(static);
         def loop(i) = {
@@ -1652,48 +1652,48 @@ namespace Array {
     pub def copyOfRange(b: Int32, e: Int32, a: ScopedArray[a, r1], _: Region[r2]): ScopedArray[a, r2] \ { Read(r1), Write(r2) } =
         match (reifyType a) {
             case ErasedType =>
-                let arr = a as Array[##java.lang.Object];
-                import static java.util.Arrays.copyOfRange(Array[##java.lang.Object], Int32, Int32): ScopedArray[##java.lang.Object, r2] & r1 and r2 as copy;
+                let arr = a as FooArray[##java.lang.Object];
+                import static java.util.Arrays.copyOfRange(FooArray[##java.lang.Object], Int32, Int32): ScopedArray[##java.lang.Object, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as ScopedArray[a, r2]
             case ReifiedUnit =>
-                let arr = a as Array[Unit];
-                import static java.util.Arrays.copyOfRange(Array[Unit], Int32, Int32): ScopedArray[Unit, r2] & r1 and r2 as copy;
+                let arr = a as FooArray[Unit];
+                import static java.util.Arrays.copyOfRange(FooArray[Unit], Int32, Int32): ScopedArray[Unit, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as ScopedArray[a, r2]
             case ReifiedBool =>
-                let arr = a as Array[Bool];
-                import static java.util.Arrays.copyOfRange(Array[Bool], Int32, Int32): ScopedArray[Bool, r2] & r1 and r2 as copy;
+                let arr = a as FooArray[Bool];
+                import static java.util.Arrays.copyOfRange(FooArray[Bool], Int32, Int32): ScopedArray[Bool, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as ScopedArray[a, r2]
             case ReifiedChar =>
-                let arr = a as Array[Char];
-                import static java.util.Arrays.copyOfRange(Array[Char], Int32, Int32): ScopedArray[Char, r2] & r1 and r2 as copy;
+                let arr = a as FooArray[Char];
+                import static java.util.Arrays.copyOfRange(FooArray[Char], Int32, Int32): ScopedArray[Char, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as ScopedArray[a, r2]
             case ReifiedFloat32 =>
-                let arr = a as Array[Float32];
-                import static java.util.Arrays.copyOfRange(Array[Float32], Int32, Int32): ScopedArray[Float32, r2] & r1 and r2 as copy;
+                let arr = a as FooArray[Float32];
+                import static java.util.Arrays.copyOfRange(FooArray[Float32], Int32, Int32): ScopedArray[Float32, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as ScopedArray[a, r2]
             case ReifiedFloat64 =>
-                let arr = a as Array[Float64];
-                import static java.util.Arrays.copyOfRange(Array[Float64], Int32, Int32): ScopedArray[Float64, r2] & r1 and r2 as copy;
+                let arr = a as FooArray[Float64];
+                import static java.util.Arrays.copyOfRange(FooArray[Float64], Int32, Int32): ScopedArray[Float64, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as ScopedArray[a, r2]
             case ReifiedInt8 =>
-                let arr = a as Array[Int8];
-                import static java.util.Arrays.copyOfRange(Array[Int8], Int32, Int32): ScopedArray[Int8, r2] & r1 and r2 as copy;
+                let arr = a as FooArray[Int8];
+                import static java.util.Arrays.copyOfRange(FooArray[Int8], Int32, Int32): ScopedArray[Int8, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as ScopedArray[a, r2]
             case ReifiedInt16 =>
-                let arr = a as Array[Int16];
-                import static java.util.Arrays.copyOfRange(Array[Int16], Int32, Int32): ScopedArray[Int16, r2] & r1 and r2 as copy;
+                let arr = a as FooArray[Int16];
+                import static java.util.Arrays.copyOfRange(FooArray[Int16], Int32, Int32): ScopedArray[Int16, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as ScopedArray[a, r2]
             case ReifiedInt32 =>
-                let arr = a as Array[Int32];
-                import static java.util.Arrays.copyOfRange(Array[Int32], Int32, Int32): ScopedArray[Int32, r2] & r1 and r2 as copy;
+                let arr = a as FooArray[Int32];
+                import static java.util.Arrays.copyOfRange(FooArray[Int32], Int32, Int32): ScopedArray[Int32, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as ScopedArray[a, r2]
             case ReifiedInt64 =>
-                let arr = a as Array[Int64];
-                import static java.util.Arrays.copyOfRange(Array[Int64], Int32, Int32): ScopedArray[Int64, r2] & r1 and r2 as copy;
+                let arr = a as FooArray[Int64];
+                import static java.util.Arrays.copyOfRange(FooArray[Int64], Int32, Int32): ScopedArray[Int64, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as ScopedArray[a, r2]
             case ReifiedArray(_) =>
-                let arr = a as Array[##java.lang.Object];
-                import static java.util.Arrays.copyOfRange(Array[##java.lang.Object], Int32, Int32): ScopedArray[##java.lang.Object, r2] & r1 and r2 as copy;
+                let arr = a as FooArray[##java.lang.Object];
+                import static java.util.Arrays.copyOfRange(FooArray[##java.lang.Object], Int32, Int32): ScopedArray[##java.lang.Object, r2] & r1 and r2 as copy;
                 copy(arr, b, e) as ScopedArray[a, r2]
         }
 

--- a/main/src/library/Benchmark.flix
+++ b/main/src/library/Benchmark.flix
@@ -59,7 +59,7 @@ namespace Benchmark {
     /// Runs all benchmarks in `bs`. Attempts to spend no more than `budget` time.
     ///
     @Experimental
-    pub def runWithBudget(bs: Array[Benchmark], budget: Int64): Int32 & Impure =
+    pub def runWithBudget(bs: FooArray[Benchmark], budget: Int64): Int32 & Impure =
         if (bs.length == 0) {
             println("No benchmarks");
             1
@@ -82,7 +82,7 @@ namespace Benchmark {
     ///
     /// Runs every benchmark in `bs` once and estimates its duration.
     ///
-    def warmupAndEstimate(bs: Array[Benchmark]): Array[(Benchmark, Int64)] & Impure = {
+    def warmupAndEstimate(bs: FooArray[Benchmark]): FooArray[(Benchmark, Int64)] & Impure = {
         print("Warmup: ");
         bs |> Array.map(b -> {
             let time = runBenchmarkOnce(b);
@@ -94,7 +94,7 @@ namespace Benchmark {
     ///
     /// Runs all the given benchmarks with estimates `bs` and the given time `budget`.
     ///
-    def runAll(bs: Array[(Benchmark, Int64)], budget: Int64): Unit & Impure = {
+    def runAll(bs: FooArray[(Benchmark, Int64)], budget: Int64): Unit & Impure = {
         let budgetPerBenchmark = budget / (Int32.toInt64(bs.length));
         bs |> Array.foreach(match (b, cost) ->
             let iters = iterations(cost, budgetPerBenchmark);

--- a/main/src/library/Benchmark.flix
+++ b/main/src/library/Benchmark.flix
@@ -59,7 +59,7 @@ namespace Benchmark {
     /// Runs all benchmarks in `bs`. Attempts to spend no more than `budget` time.
     ///
     @Experimental
-    pub def runWithBudget(bs: FooArray[Benchmark], budget: Int64): Int32 & Impure =
+    pub def runWithBudget(bs: UnscopedArray[Benchmark], budget: Int64): Int32 & Impure =
         if (bs.length == 0) {
             println("No benchmarks");
             1
@@ -82,7 +82,7 @@ namespace Benchmark {
     ///
     /// Runs every benchmark in `bs` once and estimates its duration.
     ///
-    def warmupAndEstimate(bs: FooArray[Benchmark]): FooArray[(Benchmark, Int64)] & Impure = {
+    def warmupAndEstimate(bs: UnscopedArray[Benchmark]): UnscopedArray[(Benchmark, Int64)] & Impure = {
         print("Warmup: ");
         bs |> Array.map(b -> {
             let time = runBenchmarkOnce(b);
@@ -94,7 +94,7 @@ namespace Benchmark {
     ///
     /// Runs all the given benchmarks with estimates `bs` and the given time `budget`.
     ///
-    def runAll(bs: FooArray[(Benchmark, Int64)], budget: Int64): Unit & Impure = {
+    def runAll(bs: UnscopedArray[(Benchmark, Int64)], budget: Int64): Unit & Impure = {
         let budgetPerBenchmark = budget / (Int32.toInt64(bs.length));
         bs |> Array.foreach(match (b, cost) ->
             let iters = iterations(cost, budgetPerBenchmark);

--- a/main/src/library/Benchmark/Bench.Chain.flix
+++ b/main/src/library/Benchmark/Bench.Chain.flix
@@ -41,13 +41,13 @@ def chainAppendMany(xs: Chain[a], ys: List[Chain[a]]): Chain[a] = match ys {
 ///////////////////////////////////////////////////////////////////////////////
 /// ofArray                                                               ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listOfArray(l: FooArray[Int32]): Benchmark =
+pub def listOfArray(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("List.ofArray", () -> {
         l |>
         Array.toList
     } as & Pure)
 
-pub def chainOfArray(l: FooArray[Int32]): Benchmark =
+pub def chainOfArray(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("Chain.ofArray", () -> {
         l |>
         Array.toChain
@@ -57,14 +57,14 @@ pub def chainOfArray(l: FooArray[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// cons                                                                    ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listCons(l: FooArray[Int32]): Benchmark =
+pub def listCons(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("List.cons", () -> {
         l |>
         Array.toList |>
         listConsMany(Nil)
     } as & Pure)
 
-pub def chainCons(l: FooArray[Int32]): Benchmark =
+pub def chainCons(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("Chain.cons", () -> {
         l |>
         Array.toList |>
@@ -74,14 +74,14 @@ pub def chainCons(l: FooArray[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// snoc                                                                    ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listSnoc(l: FooArray[Int32]): Benchmark =
+pub def listSnoc(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("List.snoc", () -> {
         l |>
         Array.toList |>
         listSnocMany(Nil)
     } as & Pure)
 
-pub def chainSnoc(l: FooArray[Int32]): Benchmark =
+pub def chainSnoc(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("Chain.snoc", () -> {
         l |>
         Array.toList |>
@@ -91,13 +91,13 @@ pub def chainSnoc(l: FooArray[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// append                                                                    ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listAppend(l: FooArray[Int32]): Benchmark =
+pub def listAppend(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("List.append", () -> {
         let l1 = Array.toList(l);
         listAppendMany(l1, List.map(List.repeat(3), l1))
     } as & Pure)
 
-pub def chainAppend(l: FooArray[Int32]): Benchmark =
+pub def chainAppend(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("Chain.append", () -> {
         let c1 = Array.toChain(l);
         let l1 = Array.toList(l);
@@ -108,7 +108,7 @@ pub def chainAppend(l: FooArray[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// Chain Suite                                                             ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def chainSuite(n: Int32): FooArray[Benchmark] & Impure =
+pub def chainSuite(n: Int32): UnscopedArray[Benchmark] & Impure =
     let l = Array.range(1, n, static);
     [
         // Consing and Array.toList / Array.toChain should be pretty much the same

--- a/main/src/library/Benchmark/Bench.Chain.flix
+++ b/main/src/library/Benchmark/Bench.Chain.flix
@@ -41,13 +41,13 @@ def chainAppendMany(xs: Chain[a], ys: List[Chain[a]]): Chain[a] = match ys {
 ///////////////////////////////////////////////////////////////////////////////
 /// ofArray                                                               ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listOfArray(l: Array[Int32]): Benchmark =
+pub def listOfArray(l: FooArray[Int32]): Benchmark =
     defBenchmark("List.ofArray", () -> {
         l |>
         Array.toList
     } as & Pure)
 
-pub def chainOfArray(l: Array[Int32]): Benchmark =
+pub def chainOfArray(l: FooArray[Int32]): Benchmark =
     defBenchmark("Chain.ofArray", () -> {
         l |>
         Array.toChain
@@ -57,14 +57,14 @@ pub def chainOfArray(l: Array[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// cons                                                                    ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listCons(l: Array[Int32]): Benchmark =
+pub def listCons(l: FooArray[Int32]): Benchmark =
     defBenchmark("List.cons", () -> {
         l |>
         Array.toList |>
         listConsMany(Nil)
     } as & Pure)
 
-pub def chainCons(l: Array[Int32]): Benchmark =
+pub def chainCons(l: FooArray[Int32]): Benchmark =
     defBenchmark("Chain.cons", () -> {
         l |>
         Array.toList |>
@@ -74,14 +74,14 @@ pub def chainCons(l: Array[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// snoc                                                                    ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listSnoc(l: Array[Int32]): Benchmark =
+pub def listSnoc(l: FooArray[Int32]): Benchmark =
     defBenchmark("List.snoc", () -> {
         l |>
         Array.toList |>
         listSnocMany(Nil)
     } as & Pure)
 
-pub def chainSnoc(l: Array[Int32]): Benchmark =
+pub def chainSnoc(l: FooArray[Int32]): Benchmark =
     defBenchmark("Chain.snoc", () -> {
         l |>
         Array.toList |>
@@ -91,13 +91,13 @@ pub def chainSnoc(l: Array[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// append                                                                    ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listAppend(l: Array[Int32]): Benchmark =
+pub def listAppend(l: FooArray[Int32]): Benchmark =
     defBenchmark("List.append", () -> {
         let l1 = Array.toList(l);
         listAppendMany(l1, List.map(List.repeat(3), l1))
     } as & Pure)
 
-pub def chainAppend(l: Array[Int32]): Benchmark =
+pub def chainAppend(l: FooArray[Int32]): Benchmark =
     defBenchmark("Chain.append", () -> {
         let c1 = Array.toChain(l);
         let l1 = Array.toList(l);
@@ -108,7 +108,7 @@ pub def chainAppend(l: Array[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// Chain Suite                                                             ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def chainSuite(n: Int32): Array[Benchmark] & Impure =
+pub def chainSuite(n: Int32): FooArray[Benchmark] & Impure =
     let l = Array.range(1, n, static);
     [
         // Consing and Array.toList / Array.toChain should be pretty much the same

--- a/main/src/library/Benchmark/Bench.Fixpoint.flix
+++ b/main/src/library/Benchmark/Bench.Fixpoint.flix
@@ -3,7 +3,7 @@ namespace Bench/Fixpoint {
     use Benchmark.Benchmark;
     use Benchmark.defBenchmark;
 
-    pub def benchmarks(): Array[Benchmark] & Impure = [
+    pub def benchmarks(): FooArray[Benchmark] & Impure = [
         benchmarkProjectInto(),
         benchmarkSelect(),
         benchmarkSolve(),
@@ -13,7 +13,7 @@ namespace Bench/Fixpoint {
         benchmarkCompile()
     ] |> Array.flatten
 
-    pub def benchmarkProjectInto(): Array[Benchmark] & Impure =
+    pub def benchmarkProjectInto(): FooArray[Benchmark] & Impure =
         let mkFacts = n -> List.range(1, n) |> List.map(x -> (x, x));
         let facts04 = mkFacts(2 ** 4);
         let facts08 = mkFacts(2 ** 8);
@@ -28,7 +28,7 @@ namespace Bench/Fixpoint {
             defBenchmark("Project (Int, Int) into A (n = ${2 ** 20})", () -> { project facts20 into A })
         ]
 
-    pub def benchmarkSelect(): Array[Benchmark] & Impure =
+    pub def benchmarkSelect(): FooArray[Benchmark] & Impure =
         let mkFacts = n -> (project (List.range(1, n) |> List.map(x -> (x, x))) into A);
         let facts04 = mkFacts(2 ** 4);
         let facts08 = mkFacts(2 ** 8);
@@ -43,7 +43,7 @@ namespace Bench/Fixpoint {
             defBenchmark("Select (Int, Int) from A (n = ${2 ** 20})", () -> { query facts20 select (x, y) from A(x, y) })
         ]
 
-    pub def benchmarkSolve(): Array[Benchmark] & Impure =
+    pub def benchmarkSolve(): FooArray[Benchmark] & Impure =
         let mkEdges = n -> project (List.range(1, n) |> List.map(x -> (x, x + 1))) into Edge;
         let p = #{
             Path(x, y) :- Edge(x, y).
@@ -70,7 +70,7 @@ namespace Bench/Fixpoint {
             //defBenchmark("Solve (Closure) (n = ${2048 ** 2})", () -> { solve p, edges2048 })
         ]
 
-    pub def benchmarkCrossProduct2(): Array[Benchmark] & Impure =
+    pub def benchmarkCrossProduct2(): FooArray[Benchmark] & Impure =
         let mkA = n -> project (List.range(1, n) |> List.map(x -> (0, x))) into A;
         let mkB = n -> project (List.range(1, n) |> List.map(x -> (0, x))) into B;
         let p = #{
@@ -95,7 +95,7 @@ namespace Bench/Fixpoint {
             //defBenchmark("Solve (Cross Product 2) (n = ${2048 ** 2})", () -> { solve p, facts2048 })
         ]
 
-    pub def benchmarkCrossProduct3(): Array[Benchmark] & Impure =
+    pub def benchmarkCrossProduct3(): FooArray[Benchmark] & Impure =
         let mkA = n -> project (List.range(1, n) |> List.map(x -> (0, x))) into A;
         let mkB = n -> project (List.range(1, n) |> List.map(x -> (0, x))) into B;
         let mkC = n -> project (List.range(1, n) |> List.map(x -> (0, x))) into C;
@@ -113,7 +113,7 @@ namespace Bench/Fixpoint {
            // defBenchmark("Solve (Cross Product 3) (n = ${  128 ** 3})", () -> { solve p,  facts128 })
         ]
 
-    pub def benchmarkSolveIntersect(): Array[Benchmark] & Impure =
+    pub def benchmarkSolveIntersect(): FooArray[Benchmark] & Impure =
         let mkA = n -> project (List.range(1, n) |> List.map(x -> (0, x))) into A;
         let mkB = n -> project (List.range(n / 2, n + n / 2) |> List.map(x -> (0, x))) into B;
         let p = #{
@@ -134,7 +134,7 @@ namespace Bench/Fixpoint {
             //defBenchmark("Solve (Intersect) (n = ${2 ** 21})", () -> { solve p, facts21 })
         ]
 
-    pub def benchmarkCompile(): Array[Benchmark] & Impure =
+    pub def benchmarkCompile(): FooArray[Benchmark] & Impure =
         let mkRules = n -> List.range(1, n) |> List.foldLeft((acc, _) -> acc <+> #{
                 A(x, y, z) :- A(z, y, x).
                 A(x: Int32, y: Int32, z: Int32) :- A(x, y, z), B(x, y, z), C(x, y, z).

--- a/main/src/library/Benchmark/Bench.Fixpoint.flix
+++ b/main/src/library/Benchmark/Bench.Fixpoint.flix
@@ -3,7 +3,7 @@ namespace Bench/Fixpoint {
     use Benchmark.Benchmark;
     use Benchmark.defBenchmark;
 
-    pub def benchmarks(): FooArray[Benchmark] & Impure = [
+    pub def benchmarks(): UnscopedArray[Benchmark] & Impure = [
         benchmarkProjectInto(),
         benchmarkSelect(),
         benchmarkSolve(),
@@ -13,7 +13,7 @@ namespace Bench/Fixpoint {
         benchmarkCompile()
     ] |> Array.flatten
 
-    pub def benchmarkProjectInto(): FooArray[Benchmark] & Impure =
+    pub def benchmarkProjectInto(): UnscopedArray[Benchmark] & Impure =
         let mkFacts = n -> List.range(1, n) |> List.map(x -> (x, x));
         let facts04 = mkFacts(2 ** 4);
         let facts08 = mkFacts(2 ** 8);
@@ -28,7 +28,7 @@ namespace Bench/Fixpoint {
             defBenchmark("Project (Int, Int) into A (n = ${2 ** 20})", () -> { project facts20 into A })
         ]
 
-    pub def benchmarkSelect(): FooArray[Benchmark] & Impure =
+    pub def benchmarkSelect(): UnscopedArray[Benchmark] & Impure =
         let mkFacts = n -> (project (List.range(1, n) |> List.map(x -> (x, x))) into A);
         let facts04 = mkFacts(2 ** 4);
         let facts08 = mkFacts(2 ** 8);
@@ -43,7 +43,7 @@ namespace Bench/Fixpoint {
             defBenchmark("Select (Int, Int) from A (n = ${2 ** 20})", () -> { query facts20 select (x, y) from A(x, y) })
         ]
 
-    pub def benchmarkSolve(): FooArray[Benchmark] & Impure =
+    pub def benchmarkSolve(): UnscopedArray[Benchmark] & Impure =
         let mkEdges = n -> project (List.range(1, n) |> List.map(x -> (x, x + 1))) into Edge;
         let p = #{
             Path(x, y) :- Edge(x, y).
@@ -70,7 +70,7 @@ namespace Bench/Fixpoint {
             //defBenchmark("Solve (Closure) (n = ${2048 ** 2})", () -> { solve p, edges2048 })
         ]
 
-    pub def benchmarkCrossProduct2(): FooArray[Benchmark] & Impure =
+    pub def benchmarkCrossProduct2(): UnscopedArray[Benchmark] & Impure =
         let mkA = n -> project (List.range(1, n) |> List.map(x -> (0, x))) into A;
         let mkB = n -> project (List.range(1, n) |> List.map(x -> (0, x))) into B;
         let p = #{
@@ -95,7 +95,7 @@ namespace Bench/Fixpoint {
             //defBenchmark("Solve (Cross Product 2) (n = ${2048 ** 2})", () -> { solve p, facts2048 })
         ]
 
-    pub def benchmarkCrossProduct3(): FooArray[Benchmark] & Impure =
+    pub def benchmarkCrossProduct3(): UnscopedArray[Benchmark] & Impure =
         let mkA = n -> project (List.range(1, n) |> List.map(x -> (0, x))) into A;
         let mkB = n -> project (List.range(1, n) |> List.map(x -> (0, x))) into B;
         let mkC = n -> project (List.range(1, n) |> List.map(x -> (0, x))) into C;
@@ -113,7 +113,7 @@ namespace Bench/Fixpoint {
            // defBenchmark("Solve (Cross Product 3) (n = ${  128 ** 3})", () -> { solve p,  facts128 })
         ]
 
-    pub def benchmarkSolveIntersect(): FooArray[Benchmark] & Impure =
+    pub def benchmarkSolveIntersect(): UnscopedArray[Benchmark] & Impure =
         let mkA = n -> project (List.range(1, n) |> List.map(x -> (0, x))) into A;
         let mkB = n -> project (List.range(n / 2, n + n / 2) |> List.map(x -> (0, x))) into B;
         let p = #{
@@ -134,7 +134,7 @@ namespace Bench/Fixpoint {
             //defBenchmark("Solve (Intersect) (n = ${2 ** 21})", () -> { solve p, facts21 })
         ]
 
-    pub def benchmarkCompile(): FooArray[Benchmark] & Impure =
+    pub def benchmarkCompile(): UnscopedArray[Benchmark] & Impure =
         let mkRules = n -> List.range(1, n) |> List.foldLeft((acc, _) -> acc <+> #{
                 A(x, y, z) :- A(z, y, x).
                 A(x: Int32, y: Int32, z: Int32) :- A(x, y, z), B(x, y, z), C(x, y, z).

--- a/main/src/library/Benchmark/Bench.Fusion.flix
+++ b/main/src/library/Benchmark/Bench.Fusion.flix
@@ -11,21 +11,21 @@ use Benchmark.defBenchmark;
 ///////////////////////////////////////////////////////////////////////////////
 /// length                                                                  ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listLength(l: Array[Int32]): Benchmark =
+pub def listLength(l: FooArray[Int32]): Benchmark =
     defBenchmark("List.length", () -> {
         l |>
         Array.toList |>
         List.length
     } as & Pure)
 
-pub def delayListLength(l: Array[Int32]): Benchmark =
+pub def delayListLength(l: FooArray[Int32]): Benchmark =
     defBenchmark("DelayList.length", () -> {
         l |>
         Array.toDelayList |>
         DelayList.length
     } as & Pure)
 
-pub def streamLength(l: Array[Int32]): Benchmark =
+pub def streamLength(l: FooArray[Int32]): Benchmark =
     defBenchmark("Stream.length", () -> {
         l |>
         Array.toStream |>
@@ -35,7 +35,7 @@ pub def streamLength(l: Array[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// filter length                                                           ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listFilterLength(l: Array[Int32]): Benchmark =
+pub def listFilterLength(l: FooArray[Int32]): Benchmark =
     defBenchmark("List.filterLength", () -> {
         l |>
         Array.toList |>
@@ -43,7 +43,7 @@ pub def listFilterLength(l: Array[Int32]): Benchmark =
         List.length
     } as & Pure)
 
-pub def delayListFilterLength(l: Array[Int32]): Benchmark =
+pub def delayListFilterLength(l: FooArray[Int32]): Benchmark =
     defBenchmark("DelayList.filterLength", () -> {
         l |>
         Array.toDelayList |>
@@ -51,7 +51,7 @@ pub def delayListFilterLength(l: Array[Int32]): Benchmark =
         DelayList.length
     } as & Pure)
 
-pub def streamFilterLength(l: Array[Int32]): Benchmark =
+pub def streamFilterLength(l: FooArray[Int32]): Benchmark =
     defBenchmark("Stream.filterLength", () -> {
         l |>
         Array.toStream |>
@@ -62,7 +62,7 @@ pub def streamFilterLength(l: Array[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// filter map length                                                       ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listFilterMapLength(l: Array[Int32]): Benchmark =
+pub def listFilterMapLength(l: FooArray[Int32]): Benchmark =
     defBenchmark("List.filterMapLength", () -> {
         l |>
         Array.toList |>
@@ -71,7 +71,7 @@ pub def listFilterMapLength(l: Array[Int32]): Benchmark =
         List.length
     } as & Pure)
 
-pub def delayListFilterMapLength(l: Array[Int32]): Benchmark =
+pub def delayListFilterMapLength(l: FooArray[Int32]): Benchmark =
     defBenchmark("DelayList.filterMapLength", () -> {
         l |>
         Array.toDelayList |>
@@ -80,7 +80,7 @@ pub def delayListFilterMapLength(l: Array[Int32]): Benchmark =
         DelayList.length
     } as & Pure)
 
-pub def streamFilterMapLength(l: Array[Int32]): Benchmark =
+pub def streamFilterMapLength(l: FooArray[Int32]): Benchmark =
     defBenchmark("Stream.filterMapLength", () -> {
         l |>
         Array.toStream |>
@@ -92,21 +92,21 @@ pub def streamFilterMapLength(l: Array[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// sum                                                                     ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listSum(l: Array[Int32]): Benchmark =
+pub def listSum(l: FooArray[Int32]): Benchmark =
     defBenchmark("List.sum", () -> {
         l |>
         Array.toList |>
         List.sum
     } as & Pure)
 
-pub def delayListSum(l: Array[Int32]): Benchmark =
+pub def delayListSum(l: FooArray[Int32]): Benchmark =
     defBenchmark("DelayList.sum", () -> {
         l |>
         Array.toDelayList |>
         DelayList.sum
     } as & Pure)
 
-pub def streamSum(l: Array[Int32]): Benchmark =
+pub def streamSum(l: FooArray[Int32]): Benchmark =
     defBenchmark("Stream.sum", () -> {
         l |>
         Array.toStream |>
@@ -116,7 +116,7 @@ pub def streamSum(l: Array[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// filter sum                                                              ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listFilterSum(l: Array[Int32]): Benchmark =
+pub def listFilterSum(l: FooArray[Int32]): Benchmark =
     defBenchmark("List.filterSum", () -> {
         l |>
         Array.toList |>
@@ -124,7 +124,7 @@ pub def listFilterSum(l: Array[Int32]): Benchmark =
         List.sum
     } as & Pure)
 
-pub def delayListFilterSum(l: Array[Int32]): Benchmark =
+pub def delayListFilterSum(l: FooArray[Int32]): Benchmark =
     defBenchmark("DelayList.filterSum", () -> {
         l |>
         Array.toDelayList |>
@@ -132,7 +132,7 @@ pub def delayListFilterSum(l: Array[Int32]): Benchmark =
         DelayList.sum
     } as & Pure)
 
-pub def streamFilterSum(l: Array[Int32]): Benchmark =
+pub def streamFilterSum(l: FooArray[Int32]): Benchmark =
     defBenchmark("Stream.filterSum", () -> {
         l |>
         Array.toStream |>
@@ -143,7 +143,7 @@ pub def streamFilterSum(l: Array[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// filter map sum                                                          ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listFilterMapSum(l: Array[Int32]): Benchmark =
+pub def listFilterMapSum(l: FooArray[Int32]): Benchmark =
     defBenchmark("List.filterMapSum", () -> {
         l |>
         Array.toList |>
@@ -152,7 +152,7 @@ pub def listFilterMapSum(l: Array[Int32]): Benchmark =
         List.sum
     } as & Pure)
 
-pub def delayListFilterMapSum(l: Array[Int32]): Benchmark =
+pub def delayListFilterMapSum(l: FooArray[Int32]): Benchmark =
     defBenchmark("DelayList.filterMapSum", () -> {
         l |>
         Array.toDelayList |>
@@ -161,7 +161,7 @@ pub def delayListFilterMapSum(l: Array[Int32]): Benchmark =
         DelayList.sum
     } as & Pure)
 
-pub def streamFilterMapSum(l: Array[Int32]): Benchmark =
+pub def streamFilterMapSum(l: FooArray[Int32]): Benchmark =
     defBenchmark("Stream.filterMapSum", () -> {
         l |>
         Array.toStream |>
@@ -173,7 +173,7 @@ pub def streamFilterMapSum(l: Array[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// filter8                                                                 ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listFilter8(l: Array[Int32]): Benchmark =
+pub def listFilter8(l: FooArray[Int32]): Benchmark =
     defBenchmark("List.filter8", () -> {
         l |>
         Array.toList |>
@@ -188,7 +188,7 @@ pub def listFilter8(l: Array[Int32]): Benchmark =
         List.length
     } as & Pure)
 
-pub def delayListFilter8(l: Array[Int32]): Benchmark =
+pub def delayListFilter8(l: FooArray[Int32]): Benchmark =
     defBenchmark("DelayList.filter8", () -> {
         l |>
         Array.toDelayList |>
@@ -203,7 +203,7 @@ pub def delayListFilter8(l: Array[Int32]): Benchmark =
         DelayList.length
     } as & Pure)
 
-pub def streamFilter8(l: Array[Int32]): Benchmark =
+pub def streamFilter8(l: FooArray[Int32]): Benchmark =
     defBenchmark("Stream.filter8", () -> {
         l |>
         Array.toStream |>
@@ -221,7 +221,7 @@ pub def streamFilter8(l: Array[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// map8                                                                    ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listMap8(l: Array[Int32]): Benchmark =
+pub def listMap8(l: FooArray[Int32]): Benchmark =
     defBenchmark("List.map8", () -> {
         l |>
         Array.toList |>
@@ -236,7 +236,7 @@ pub def listMap8(l: Array[Int32]): Benchmark =
         List.length
     } as & Pure)
 
-pub def delayListMap8(l: Array[Int32]): Benchmark =
+pub def delayListMap8(l: FooArray[Int32]): Benchmark =
     defBenchmark("DelayList.map8", () -> {
         l |>
         Array.toDelayList |>
@@ -251,7 +251,7 @@ pub def delayListMap8(l: Array[Int32]): Benchmark =
         DelayList.length
     } as & Pure)
 
-pub def streamMap8(l: Array[Int32]): Benchmark =
+pub def streamMap8(l: FooArray[Int32]): Benchmark =
     defBenchmark("Stream.map8", () -> {
         l |>
         Array.toStream |>
@@ -269,7 +269,7 @@ pub def streamMap8(l: Array[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// flatMap take sum                                                        ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listFlatMapTakeSum(l: Array[Int32]): Benchmark =
+pub def listFlatMapTakeSum(l: FooArray[Int32]): Benchmark =
     let l2 = List.range(1, 10);
     defBenchmark("List.flatMapTakeSum", () -> {
         l |>
@@ -279,7 +279,7 @@ pub def listFlatMapTakeSum(l: Array[Int32]): Benchmark =
         List.sum
     } as & Pure)
 
-pub def delayListFlatMapTakeSum(l: Array[Int32]): Benchmark =
+pub def delayListFlatMapTakeSum(l: FooArray[Int32]): Benchmark =
     let l2 = DelayList.range(1, 10);
     defBenchmark("DelayList.flatMapTakeSum", () -> {
         l |>
@@ -289,7 +289,7 @@ pub def delayListFlatMapTakeSum(l: Array[Int32]): Benchmark =
         DelayList.sum
     } as & Pure)
 
-pub def streamFlatMapTakeSum(l: Array[Int32]): Benchmark =
+pub def streamFlatMapTakeSum(l: FooArray[Int32]): Benchmark =
     let l2 = Stream.range(1, 10);
     defBenchmark("Stream.flatMapTakeSum", () -> {
         l |>
@@ -302,7 +302,7 @@ pub def streamFlatMapTakeSum(l: Array[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// cartesian                                                               ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listCartesian(l: Array[Int32]): Benchmark =
+pub def listCartesian(l: FooArray[Int32]): Benchmark =
     let l2 = List.range(1, 10);
     defBenchmark("List.cartesian", () -> {
         l |>
@@ -311,7 +311,7 @@ pub def listCartesian(l: Array[Int32]): Benchmark =
         List.sum
     } as & Pure)
 
-pub def delayListCartesian(l: Array[Int32]): Benchmark =
+pub def delayListCartesian(l: FooArray[Int32]): Benchmark =
     let l2 = DelayList.range(1, 10);
     defBenchmark("DelayList.cartesian", () -> {
         l |>
@@ -320,7 +320,7 @@ pub def delayListCartesian(l: Array[Int32]): Benchmark =
         DelayList.sum
     } as & Pure)
 
-pub def streamCartesian(l: Array[Int32]): Benchmark =
+pub def streamCartesian(l: FooArray[Int32]): Benchmark =
     let l2 = Stream.range(1, 10);
     defBenchmark("Stream.cartesian", () -> {
         l |>
@@ -336,14 +336,14 @@ pub def streamCartesian(l: Array[Int32]): Benchmark =
 ///
 /// Returns a list of `n` concatenated lists with elements from `1` to `1_000`.
 ///
-pub def input(n: Int32): Array[Int32] & Impure =
+pub def input(n: Int32): FooArray[Int32] & Impure =
     Array.range(1, n, static) |>
     Array.flatMap(_ -> Array.range(1, 1_000, static))
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Biboudis Suite                                                          ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def biboudisSuite(n: Int32): Array[Benchmark] & Impure =
+pub def biboudisSuite(n: Int32): FooArray[Benchmark] & Impure =
     let l = input(n);
     [
         // List

--- a/main/src/library/Benchmark/Bench.Fusion.flix
+++ b/main/src/library/Benchmark/Bench.Fusion.flix
@@ -11,21 +11,21 @@ use Benchmark.defBenchmark;
 ///////////////////////////////////////////////////////////////////////////////
 /// length                                                                  ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listLength(l: FooArray[Int32]): Benchmark =
+pub def listLength(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("List.length", () -> {
         l |>
         Array.toList |>
         List.length
     } as & Pure)
 
-pub def delayListLength(l: FooArray[Int32]): Benchmark =
+pub def delayListLength(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("DelayList.length", () -> {
         l |>
         Array.toDelayList |>
         DelayList.length
     } as & Pure)
 
-pub def streamLength(l: FooArray[Int32]): Benchmark =
+pub def streamLength(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("Stream.length", () -> {
         l |>
         Array.toStream |>
@@ -35,7 +35,7 @@ pub def streamLength(l: FooArray[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// filter length                                                           ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listFilterLength(l: FooArray[Int32]): Benchmark =
+pub def listFilterLength(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("List.filterLength", () -> {
         l |>
         Array.toList |>
@@ -43,7 +43,7 @@ pub def listFilterLength(l: FooArray[Int32]): Benchmark =
         List.length
     } as & Pure)
 
-pub def delayListFilterLength(l: FooArray[Int32]): Benchmark =
+pub def delayListFilterLength(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("DelayList.filterLength", () -> {
         l |>
         Array.toDelayList |>
@@ -51,7 +51,7 @@ pub def delayListFilterLength(l: FooArray[Int32]): Benchmark =
         DelayList.length
     } as & Pure)
 
-pub def streamFilterLength(l: FooArray[Int32]): Benchmark =
+pub def streamFilterLength(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("Stream.filterLength", () -> {
         l |>
         Array.toStream |>
@@ -62,7 +62,7 @@ pub def streamFilterLength(l: FooArray[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// filter map length                                                       ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listFilterMapLength(l: FooArray[Int32]): Benchmark =
+pub def listFilterMapLength(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("List.filterMapLength", () -> {
         l |>
         Array.toList |>
@@ -71,7 +71,7 @@ pub def listFilterMapLength(l: FooArray[Int32]): Benchmark =
         List.length
     } as & Pure)
 
-pub def delayListFilterMapLength(l: FooArray[Int32]): Benchmark =
+pub def delayListFilterMapLength(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("DelayList.filterMapLength", () -> {
         l |>
         Array.toDelayList |>
@@ -80,7 +80,7 @@ pub def delayListFilterMapLength(l: FooArray[Int32]): Benchmark =
         DelayList.length
     } as & Pure)
 
-pub def streamFilterMapLength(l: FooArray[Int32]): Benchmark =
+pub def streamFilterMapLength(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("Stream.filterMapLength", () -> {
         l |>
         Array.toStream |>
@@ -92,21 +92,21 @@ pub def streamFilterMapLength(l: FooArray[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// sum                                                                     ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listSum(l: FooArray[Int32]): Benchmark =
+pub def listSum(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("List.sum", () -> {
         l |>
         Array.toList |>
         List.sum
     } as & Pure)
 
-pub def delayListSum(l: FooArray[Int32]): Benchmark =
+pub def delayListSum(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("DelayList.sum", () -> {
         l |>
         Array.toDelayList |>
         DelayList.sum
     } as & Pure)
 
-pub def streamSum(l: FooArray[Int32]): Benchmark =
+pub def streamSum(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("Stream.sum", () -> {
         l |>
         Array.toStream |>
@@ -116,7 +116,7 @@ pub def streamSum(l: FooArray[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// filter sum                                                              ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listFilterSum(l: FooArray[Int32]): Benchmark =
+pub def listFilterSum(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("List.filterSum", () -> {
         l |>
         Array.toList |>
@@ -124,7 +124,7 @@ pub def listFilterSum(l: FooArray[Int32]): Benchmark =
         List.sum
     } as & Pure)
 
-pub def delayListFilterSum(l: FooArray[Int32]): Benchmark =
+pub def delayListFilterSum(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("DelayList.filterSum", () -> {
         l |>
         Array.toDelayList |>
@@ -132,7 +132,7 @@ pub def delayListFilterSum(l: FooArray[Int32]): Benchmark =
         DelayList.sum
     } as & Pure)
 
-pub def streamFilterSum(l: FooArray[Int32]): Benchmark =
+pub def streamFilterSum(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("Stream.filterSum", () -> {
         l |>
         Array.toStream |>
@@ -143,7 +143,7 @@ pub def streamFilterSum(l: FooArray[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// filter map sum                                                          ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listFilterMapSum(l: FooArray[Int32]): Benchmark =
+pub def listFilterMapSum(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("List.filterMapSum", () -> {
         l |>
         Array.toList |>
@@ -152,7 +152,7 @@ pub def listFilterMapSum(l: FooArray[Int32]): Benchmark =
         List.sum
     } as & Pure)
 
-pub def delayListFilterMapSum(l: FooArray[Int32]): Benchmark =
+pub def delayListFilterMapSum(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("DelayList.filterMapSum", () -> {
         l |>
         Array.toDelayList |>
@@ -161,7 +161,7 @@ pub def delayListFilterMapSum(l: FooArray[Int32]): Benchmark =
         DelayList.sum
     } as & Pure)
 
-pub def streamFilterMapSum(l: FooArray[Int32]): Benchmark =
+pub def streamFilterMapSum(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("Stream.filterMapSum", () -> {
         l |>
         Array.toStream |>
@@ -173,7 +173,7 @@ pub def streamFilterMapSum(l: FooArray[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// filter8                                                                 ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listFilter8(l: FooArray[Int32]): Benchmark =
+pub def listFilter8(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("List.filter8", () -> {
         l |>
         Array.toList |>
@@ -188,7 +188,7 @@ pub def listFilter8(l: FooArray[Int32]): Benchmark =
         List.length
     } as & Pure)
 
-pub def delayListFilter8(l: FooArray[Int32]): Benchmark =
+pub def delayListFilter8(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("DelayList.filter8", () -> {
         l |>
         Array.toDelayList |>
@@ -203,7 +203,7 @@ pub def delayListFilter8(l: FooArray[Int32]): Benchmark =
         DelayList.length
     } as & Pure)
 
-pub def streamFilter8(l: FooArray[Int32]): Benchmark =
+pub def streamFilter8(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("Stream.filter8", () -> {
         l |>
         Array.toStream |>
@@ -221,7 +221,7 @@ pub def streamFilter8(l: FooArray[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// map8                                                                    ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listMap8(l: FooArray[Int32]): Benchmark =
+pub def listMap8(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("List.map8", () -> {
         l |>
         Array.toList |>
@@ -236,7 +236,7 @@ pub def listMap8(l: FooArray[Int32]): Benchmark =
         List.length
     } as & Pure)
 
-pub def delayListMap8(l: FooArray[Int32]): Benchmark =
+pub def delayListMap8(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("DelayList.map8", () -> {
         l |>
         Array.toDelayList |>
@@ -251,7 +251,7 @@ pub def delayListMap8(l: FooArray[Int32]): Benchmark =
         DelayList.length
     } as & Pure)
 
-pub def streamMap8(l: FooArray[Int32]): Benchmark =
+pub def streamMap8(l: UnscopedArray[Int32]): Benchmark =
     defBenchmark("Stream.map8", () -> {
         l |>
         Array.toStream |>
@@ -269,7 +269,7 @@ pub def streamMap8(l: FooArray[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// flatMap take sum                                                        ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listFlatMapTakeSum(l: FooArray[Int32]): Benchmark =
+pub def listFlatMapTakeSum(l: UnscopedArray[Int32]): Benchmark =
     let l2 = List.range(1, 10);
     defBenchmark("List.flatMapTakeSum", () -> {
         l |>
@@ -279,7 +279,7 @@ pub def listFlatMapTakeSum(l: FooArray[Int32]): Benchmark =
         List.sum
     } as & Pure)
 
-pub def delayListFlatMapTakeSum(l: FooArray[Int32]): Benchmark =
+pub def delayListFlatMapTakeSum(l: UnscopedArray[Int32]): Benchmark =
     let l2 = DelayList.range(1, 10);
     defBenchmark("DelayList.flatMapTakeSum", () -> {
         l |>
@@ -289,7 +289,7 @@ pub def delayListFlatMapTakeSum(l: FooArray[Int32]): Benchmark =
         DelayList.sum
     } as & Pure)
 
-pub def streamFlatMapTakeSum(l: FooArray[Int32]): Benchmark =
+pub def streamFlatMapTakeSum(l: UnscopedArray[Int32]): Benchmark =
     let l2 = Stream.range(1, 10);
     defBenchmark("Stream.flatMapTakeSum", () -> {
         l |>
@@ -302,7 +302,7 @@ pub def streamFlatMapTakeSum(l: FooArray[Int32]): Benchmark =
 ///////////////////////////////////////////////////////////////////////////////
 /// cartesian                                                               ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def listCartesian(l: FooArray[Int32]): Benchmark =
+pub def listCartesian(l: UnscopedArray[Int32]): Benchmark =
     let l2 = List.range(1, 10);
     defBenchmark("List.cartesian", () -> {
         l |>
@@ -311,7 +311,7 @@ pub def listCartesian(l: FooArray[Int32]): Benchmark =
         List.sum
     } as & Pure)
 
-pub def delayListCartesian(l: FooArray[Int32]): Benchmark =
+pub def delayListCartesian(l: UnscopedArray[Int32]): Benchmark =
     let l2 = DelayList.range(1, 10);
     defBenchmark("DelayList.cartesian", () -> {
         l |>
@@ -320,7 +320,7 @@ pub def delayListCartesian(l: FooArray[Int32]): Benchmark =
         DelayList.sum
     } as & Pure)
 
-pub def streamCartesian(l: FooArray[Int32]): Benchmark =
+pub def streamCartesian(l: UnscopedArray[Int32]): Benchmark =
     let l2 = Stream.range(1, 10);
     defBenchmark("Stream.cartesian", () -> {
         l |>
@@ -336,14 +336,14 @@ pub def streamCartesian(l: FooArray[Int32]): Benchmark =
 ///
 /// Returns a list of `n` concatenated lists with elements from `1` to `1_000`.
 ///
-pub def input(n: Int32): FooArray[Int32] & Impure =
+pub def input(n: Int32): UnscopedArray[Int32] & Impure =
     Array.range(1, n, static) |>
     Array.flatMap(_ -> Array.range(1, 1_000, static))
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Biboudis Suite                                                          ///
 ///////////////////////////////////////////////////////////////////////////////
-pub def biboudisSuite(n: Int32): FooArray[Benchmark] & Impure =
+pub def biboudisSuite(n: Int32): UnscopedArray[Benchmark] & Impure =
     let l = input(n);
     [
         // List

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -766,7 +766,7 @@ namespace Chain {
     ///
     /// Returns the chain `c` as an array.
     ///
-    pub def toArray(c: Chain[a], r: Region[r]): ScopedArray[a, r] \ Write(r) = match head(c) {
+    pub def toArray(c: Chain[a], r: Region[r]): Array[a, r] \ Write(r) = match head(c) {
         case None => [] @ r
         case Some(x) =>
             let arr = [x; length(c)] @ r;

--- a/main/src/library/Concurrent/Channel.flix
+++ b/main/src/library/Concurrent/Channel.flix
@@ -176,7 +176,7 @@ namespace Concurrent/Channel {
     /// the index of the channel. Returns None if the default case is chosen.
     ///
     @Internal
-    pub def select(channels: Array[Mpmc], hasDefault: Bool): Option[(Int32, Boxed)] & Impure =
+    pub def select(channels: FooArray[Mpmc], hasDefault: Bool): Option[(Int32, Boxed)] & Impure =
         // Create a new lock and condition for this select. The condition is
         // potentially put into the waiting getters of the channels if a
         // default isn't defined.
@@ -269,7 +269,7 @@ namespace Concurrent/Channel {
     /// has an element in the array along with its index. Returns false if the
     /// default case is chosen (no element was immediately available).
     ///
-    def selectHelper(channels: Array[Mpmc], hasDefault: Bool, sortedChannels: Array[Mpmc], selectLock: Concurrent/ReentrantLock.ReentrantLock, selectCondition: Concurrent/Condition.Condition): Option[(Int32, Boxed)] & Impure =
+    def selectHelper(channels: FooArray[Mpmc], hasDefault: Bool, sortedChannels: FooArray[Mpmc], selectLock: Concurrent/ReentrantLock.ReentrantLock, selectCondition: Concurrent/Condition.Condition): Option[(Int32, Boxed)] & Impure =
         // bug if the thread is interrupted
         if (threadInterrupted()) bug!("thread interrupted") else
 
@@ -337,14 +337,14 @@ namespace Concurrent/Channel {
     ///
     /// Locks the given channels.
     ///
-    def lockChannels(a: Array[Mpmc]): Unit & Impure =
+    def lockChannels(a: FooArray[Mpmc]): Unit & Impure =
         let lockChannel = match Mpmc(_, channelLock, _, _, _, _, _) -> lock(channelLock);
         Array.foreach(lockChannel, a)
 
     ///
     /// Unlocks the given channels.
     ///
-    def unlockChannels(a: Array[Mpmc]): Unit & Impure =
+    def unlockChannels(a: FooArray[Mpmc]): Unit & Impure =
         let unlockChannel = match Mpmc(_, lock, _, _, _, _, _) -> unlock(lock);
         // TODO: Optimization possibility. Golang unlocks their channels in
         // reverse order.
@@ -355,7 +355,7 @@ namespace Concurrent/Channel {
     /// Retrieves the element of the first channel in the array that has one,
     /// if such a channel exists. A runtime error ocurrs if i is out of bounds.
     ///
-    def firstAvailableElement(i: Int32, channels: Array[Mpmc]): Option[(Int32, Boxed)] & Impure =
+    def firstAvailableElement(i: Int32, channels: FooArray[Mpmc]): Option[(Int32, Boxed)] & Impure =
         if (i < 0 or i >= Array.length(channels)) {
             // i is out of bounds
             bug!("Implementation error: out of bounds ${i}, length ${Array.length(channels)}")

--- a/main/src/library/Concurrent/Channel.flix
+++ b/main/src/library/Concurrent/Channel.flix
@@ -176,7 +176,7 @@ namespace Concurrent/Channel {
     /// the index of the channel. Returns None if the default case is chosen.
     ///
     @Internal
-    pub def select(channels: FooArray[Mpmc], hasDefault: Bool): Option[(Int32, Boxed)] & Impure =
+    pub def select(channels: UnscopedArray[Mpmc], hasDefault: Bool): Option[(Int32, Boxed)] & Impure =
         // Create a new lock and condition for this select. The condition is
         // potentially put into the waiting getters of the channels if a
         // default isn't defined.
@@ -269,7 +269,7 @@ namespace Concurrent/Channel {
     /// has an element in the array along with its index. Returns false if the
     /// default case is chosen (no element was immediately available).
     ///
-    def selectHelper(channels: FooArray[Mpmc], hasDefault: Bool, sortedChannels: FooArray[Mpmc], selectLock: Concurrent/ReentrantLock.ReentrantLock, selectCondition: Concurrent/Condition.Condition): Option[(Int32, Boxed)] & Impure =
+    def selectHelper(channels: UnscopedArray[Mpmc], hasDefault: Bool, sortedChannels: UnscopedArray[Mpmc], selectLock: Concurrent/ReentrantLock.ReentrantLock, selectCondition: Concurrent/Condition.Condition): Option[(Int32, Boxed)] & Impure =
         // bug if the thread is interrupted
         if (threadInterrupted()) bug!("thread interrupted") else
 
@@ -337,14 +337,14 @@ namespace Concurrent/Channel {
     ///
     /// Locks the given channels.
     ///
-    def lockChannels(a: FooArray[Mpmc]): Unit & Impure =
+    def lockChannels(a: UnscopedArray[Mpmc]): Unit & Impure =
         let lockChannel = match Mpmc(_, channelLock, _, _, _, _, _) -> lock(channelLock);
         Array.foreach(lockChannel, a)
 
     ///
     /// Unlocks the given channels.
     ///
-    def unlockChannels(a: FooArray[Mpmc]): Unit & Impure =
+    def unlockChannels(a: UnscopedArray[Mpmc]): Unit & Impure =
         let unlockChannel = match Mpmc(_, lock, _, _, _, _, _) -> unlock(lock);
         // TODO: Optimization possibility. Golang unlocks their channels in
         // reverse order.
@@ -355,7 +355,7 @@ namespace Concurrent/Channel {
     /// Retrieves the element of the first channel in the array that has one,
     /// if such a channel exists. A runtime error ocurrs if i is out of bounds.
     ///
-    def firstAvailableElement(i: Int32, channels: FooArray[Mpmc]): Option[(Int32, Boxed)] & Impure =
+    def firstAvailableElement(i: Int32, channels: UnscopedArray[Mpmc]): Option[(Int32, Boxed)] & Impure =
         if (i < 0 or i >= Array.length(channels)) {
             // i is out of bounds
             bug!("Implementation error: out of bounds ${i}, length ${Array.length(channels)}")

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -1165,7 +1165,7 @@ namespace DelayList {
     /// Forces the entire list `l`.
     ///
     @Experimental
-    pub def toArray(l: DelayList[a], r: Region[r]): ScopedArray[a, r] \ Write(r) =
+    pub def toArray(l: DelayList[a], r: Region[r]): Array[a, r] \ Write(r) =
         let a = [$DEFAULT$; length(l)] @ r;
         let f = (i, y) -> { a[i] = y; i + 1 };
         foldLeft(f, 0, l);

--- a/main/src/library/Environment.flix
+++ b/main/src/library/Environment.flix
@@ -19,7 +19,7 @@ namespace Environment {
     /// Returns the arguments passed to the program via the command line.
     ///
     pub def getArgs(): List[String] =
-        import static dev.flix.runtime.Global.getArgs(): Array[String] & Impure;
+        import static dev.flix.runtime.Global.getArgs(): FooArray[String] & Impure;
         Array.toList(getArgs()) as & Pure
 
     ///

--- a/main/src/library/Environment.flix
+++ b/main/src/library/Environment.flix
@@ -19,7 +19,7 @@ namespace Environment {
     /// Returns the arguments passed to the program via the command line.
     ///
     pub def getArgs(): List[String] =
-        import static dev.flix.runtime.Global.getArgs(): FooArray[String] & Impure;
+        import static dev.flix.runtime.Global.getArgs(): UnscopedArray[String] & Impure;
         Array.toList(getArgs()) as & Pure
 
     ///

--- a/main/src/library/File.flix
+++ b/main/src/library/File.flix
@@ -110,7 +110,7 @@ namespace File {
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.readAttributes(##java.nio.file.Path, ##java.lang.Class, FooArray[##java.nio.file.LinkOption]): ##java.nio.file.attribute.BasicFileAttributes & Impure;
+            import static java.nio.file.Files.readAttributes(##java.nio.file.Path, ##java.lang.Class, UnscopedArray[##java.nio.file.LinkOption]): ##java.nio.file.attribute.BasicFileAttributes & Impure;
             import static java.lang.Class.forName(String): ##java.lang.Class & Impure;
 
             let javaFile = newFile(f);
@@ -205,7 +205,7 @@ namespace File {
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.isRegularFile(##java.nio.file.Path, FooArray[##java.nio.file.LinkOption]): Bool & Impure;
+            import static java.nio.file.Files.isRegularFile(##java.nio.file.Path, UnscopedArray[##java.nio.file.LinkOption]): Bool & Impure;
             let javaFile = newFile(f);
             let javaPath = toPath(javaFile);
             let isRegular = isRegularFile(javaPath, []);
@@ -304,9 +304,9 @@ namespace File {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import new java.io.FileInputStream(##java.io.File): ##java.io.FileInputStream & Impure as newInputStream;
             import java.io.FileInputStream.skip(Int64): Int64 & Impure;
-            import java.io.FileInputStream.read(FooArray[Int8], Int32, Int32): Int32 & Impure;
+            import java.io.FileInputStream.read(UnscopedArray[Int8], Int32, Int32): Int32 & Impure;
             import static java.nio.charset.Charset.forName(String): ##java.nio.charset.Charset & Impure;
-            import new java.lang.String(FooArray[Int8], ##java.nio.charset.Charset): String & Impure as newString;
+            import new java.lang.String(UnscopedArray[Int8], ##java.nio.charset.Charset): String & Impure as newString;
 
             let javaFile = newFile(f);
             let stream = newInputStream(javaFile);
@@ -454,11 +454,11 @@ namespace File {
     ///
     /// Returns an array of all the bytes in the given file `f`.
     ///
-    pub def readBytes(f: String): Result[FooArray[Int8], String] & Impure =
+    pub def readBytes(f: String): Result[UnscopedArray[Int8], String] & Impure =
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.readAllBytes(##java.nio.file.Path): FooArray[Int8] & Impure;
+            import static java.nio.file.Files.readAllBytes(##java.nio.file.Path): UnscopedArray[Int8] & Impure;
 
             let javaFile = newFile(f);
             let javaPath = toPath(javaFile);
@@ -477,12 +477,12 @@ namespace File {
     /// `offset` - the start offset in the given file `f`.
     /// `count` - the number of bytes read.
     ///
-    pub def readBytesWith(opts: {offset :: Int64, count :: Int32}, f: String): Result[FooArray[Int8], String] & Impure =
+    pub def readBytesWith(opts: {offset :: Int64, count :: Int32}, f: String): Result[UnscopedArray[Int8], String] & Impure =
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import new java.io.FileInputStream(##java.io.File): ##java.io.FileInputStream & Impure as newInputStream;
             import java.io.FileInputStream.skip(Int64): Int64 & Impure;
-            import java.io.FileInputStream.read(FooArray[Int8], Int32, Int32): Int32 & Impure;
+            import java.io.FileInputStream.read(UnscopedArray[Int8], Int32, Int32): Int32 & Impure;
 
             let javaFile = newFile(f);
             let stream = newInputStream(javaFile);
@@ -503,7 +503,7 @@ namespace File {
     /// Helper function for `readBytesWith`.
     /// Returns an array that corresponds to the bytes actually read from the stream.
     ///
-    def readBytesWithHelper(bytes: FooArray[Int8], numberRead: Int32, count: Int32): FooArray[Int8] & Impure =
+    def readBytesWithHelper(bytes: UnscopedArray[Int8], numberRead: Int32, count: Int32): UnscopedArray[Int8] & Impure =
         let nothingRead = (numberRead == -1);
         if (nothingRead) {
             []
@@ -519,11 +519,11 @@ namespace File {
     ///
     /// Returns an iterator of the bytes in the given `file` in chunks of size `chunkSize`.
     ///
-    pub def readChunks(f: String, chunkSize: Int32): Iterator[Result[FooArray[Int8], String]] & Impure =
+    pub def readChunks(f: String, chunkSize: Int32): Iterator[Result[UnscopedArray[Int8], String]] & Impure =
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import new java.io.FileInputStream(##java.io.File): ##java.io.FileInputStream & Impure as newInputStream;
-            import java.io.FileInputStream.read(FooArray[Int8]): Int32 & Impure;
+            import java.io.FileInputStream.read(UnscopedArray[Int8]): Int32 & Impure;
 
             let javaFile = newFile(f);
             let stream = newInputStream(javaFile);
@@ -707,7 +707,7 @@ namespace File {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import new java.io.FileOutputStream(##java.io.File): ##java.io.FileOutputStream & Impure as newFileStream;
             import new java.io.PrintWriter(##java.io.OutputStream): ##java.io.PrintWriter & Impure as newPrintWriter;
-            import java.io.FileOutputStream.write(FooArray[Int8]): Unit & Impure;
+            import java.io.FileOutputStream.write(UnscopedArray[Int8]): Unit & Impure;
             import java.io.PrintWriter.close(): Unit & Impure;
             import java.io.PrintWriter.checkError(): Bool & Impure;
 
@@ -743,7 +743,7 @@ namespace File {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import new java.io.FileOutputStream(##java.io.File, Bool): ##java.io.FileOutputStream & Impure as newFileStream;
             import new java.io.PrintWriter(##java.io.OutputStream): ##java.io.PrintWriter & Impure as newPrintWriter;
-            import java.io.FileOutputStream.write(FooArray[Int8]): Unit & Impure;
+            import java.io.FileOutputStream.write(UnscopedArray[Int8]): Unit & Impure;
             import java.io.PrintWriter.close(): Unit & Impure;
             import java.io.PrintWriter.checkError(): Bool & Impure;
 
@@ -849,7 +849,7 @@ namespace File {
     pub def list(f: String): Result[List[String], String] & Impure =
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
-            import java.io.File.listFiles(): FooArray[##java.io.File] & Impure;
+            import java.io.File.listFiles(): UnscopedArray[##java.io.File] & Impure;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
             import java.nio.file.Path.toString(): String & Impure as pathToString;
 
@@ -904,7 +904,7 @@ namespace File {
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.walk(##java.nio.file.Path, FooArray[##java.nio.file.FileVisitOption]): ##java.util.stream.Stream & Impure;
+            import static java.nio.file.Files.walk(##java.nio.file.Path, UnscopedArray[##java.nio.file.FileVisitOption]): ##java.util.stream.Stream & Impure;
             import java.util.stream.BaseStream.iterator(): ##java.util.Iterator & Impure;
             import java.nio.file.Path.toString(): String & Pure as pathToString;
 
@@ -951,7 +951,7 @@ namespace File {
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.move(##java.nio.file.Path, ##java.nio.file.Path, FooArray[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
+            import static java.nio.file.Files.move(##java.nio.file.Path, ##java.nio.file.Path, UnscopedArray[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
 
             let srcFile = newFile(src.src);
             let srcPath = toPath(srcFile);
@@ -1010,7 +1010,7 @@ namespace File {
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.move(##java.nio.file.Path, ##java.nio.file.Path, FooArray[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
+            import static java.nio.file.Files.move(##java.nio.file.Path, ##java.nio.file.Path, UnscopedArray[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
             import static get java.nio.file.StandardCopyOption.REPLACE_EXISTING: ##java.nio.file.StandardCopyOption & Impure as getOverwrite;
 
             let dstFile = newFile(dst);
@@ -1040,7 +1040,7 @@ namespace File {
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.copy(##java.nio.file.Path, ##java.nio.file.Path, FooArray[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
+            import static java.nio.file.Files.copy(##java.nio.file.Path, ##java.nio.file.Path, UnscopedArray[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
 
             let srcFile = newFile(src.src);
             let srcPath = toPath(srcFile);
@@ -1099,7 +1099,7 @@ namespace File {
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.copy(##java.nio.file.Path, ##java.nio.file.Path, FooArray[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
+            import static java.nio.file.Files.copy(##java.nio.file.Path, ##java.nio.file.Path, UnscopedArray[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
             import static get java.nio.file.StandardCopyOption.REPLACE_EXISTING: ##java.nio.file.StandardCopyOption & Impure as getOverwrite;
 
             let dstFile = newFile(dst);

--- a/main/src/library/File.flix
+++ b/main/src/library/File.flix
@@ -110,7 +110,7 @@ namespace File {
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.readAttributes(##java.nio.file.Path, ##java.lang.Class, Array[##java.nio.file.LinkOption]): ##java.nio.file.attribute.BasicFileAttributes & Impure;
+            import static java.nio.file.Files.readAttributes(##java.nio.file.Path, ##java.lang.Class, FooArray[##java.nio.file.LinkOption]): ##java.nio.file.attribute.BasicFileAttributes & Impure;
             import static java.lang.Class.forName(String): ##java.lang.Class & Impure;
 
             let javaFile = newFile(f);
@@ -205,7 +205,7 @@ namespace File {
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.isRegularFile(##java.nio.file.Path, Array[##java.nio.file.LinkOption]): Bool & Impure;
+            import static java.nio.file.Files.isRegularFile(##java.nio.file.Path, FooArray[##java.nio.file.LinkOption]): Bool & Impure;
             let javaFile = newFile(f);
             let javaPath = toPath(javaFile);
             let isRegular = isRegularFile(javaPath, []);
@@ -304,9 +304,9 @@ namespace File {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import new java.io.FileInputStream(##java.io.File): ##java.io.FileInputStream & Impure as newInputStream;
             import java.io.FileInputStream.skip(Int64): Int64 & Impure;
-            import java.io.FileInputStream.read(Array[Int8], Int32, Int32): Int32 & Impure;
+            import java.io.FileInputStream.read(FooArray[Int8], Int32, Int32): Int32 & Impure;
             import static java.nio.charset.Charset.forName(String): ##java.nio.charset.Charset & Impure;
-            import new java.lang.String(Array[Int8], ##java.nio.charset.Charset): String & Impure as newString;
+            import new java.lang.String(FooArray[Int8], ##java.nio.charset.Charset): String & Impure as newString;
 
             let javaFile = newFile(f);
             let stream = newInputStream(javaFile);
@@ -454,11 +454,11 @@ namespace File {
     ///
     /// Returns an array of all the bytes in the given file `f`.
     ///
-    pub def readBytes(f: String): Result[Array[Int8], String] & Impure =
+    pub def readBytes(f: String): Result[FooArray[Int8], String] & Impure =
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.readAllBytes(##java.nio.file.Path): Array[Int8] & Impure;
+            import static java.nio.file.Files.readAllBytes(##java.nio.file.Path): FooArray[Int8] & Impure;
 
             let javaFile = newFile(f);
             let javaPath = toPath(javaFile);
@@ -477,12 +477,12 @@ namespace File {
     /// `offset` - the start offset in the given file `f`.
     /// `count` - the number of bytes read.
     ///
-    pub def readBytesWith(opts: {offset :: Int64, count :: Int32}, f: String): Result[Array[Int8], String] & Impure =
+    pub def readBytesWith(opts: {offset :: Int64, count :: Int32}, f: String): Result[FooArray[Int8], String] & Impure =
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import new java.io.FileInputStream(##java.io.File): ##java.io.FileInputStream & Impure as newInputStream;
             import java.io.FileInputStream.skip(Int64): Int64 & Impure;
-            import java.io.FileInputStream.read(Array[Int8], Int32, Int32): Int32 & Impure;
+            import java.io.FileInputStream.read(FooArray[Int8], Int32, Int32): Int32 & Impure;
 
             let javaFile = newFile(f);
             let stream = newInputStream(javaFile);
@@ -503,7 +503,7 @@ namespace File {
     /// Helper function for `readBytesWith`.
     /// Returns an array that corresponds to the bytes actually read from the stream.
     ///
-    def readBytesWithHelper(bytes: Array[Int8], numberRead: Int32, count: Int32): Array[Int8] & Impure =
+    def readBytesWithHelper(bytes: FooArray[Int8], numberRead: Int32, count: Int32): FooArray[Int8] & Impure =
         let nothingRead = (numberRead == -1);
         if (nothingRead) {
             []
@@ -519,11 +519,11 @@ namespace File {
     ///
     /// Returns an iterator of the bytes in the given `file` in chunks of size `chunkSize`.
     ///
-    pub def readChunks(f: String, chunkSize: Int32): Iterator[Result[Array[Int8], String]] & Impure =
+    pub def readChunks(f: String, chunkSize: Int32): Iterator[Result[FooArray[Int8], String]] & Impure =
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import new java.io.FileInputStream(##java.io.File): ##java.io.FileInputStream & Impure as newInputStream;
-            import java.io.FileInputStream.read(Array[Int8]): Int32 & Impure;
+            import java.io.FileInputStream.read(FooArray[Int8]): Int32 & Impure;
 
             let javaFile = newFile(f);
             let stream = newInputStream(javaFile);
@@ -707,7 +707,7 @@ namespace File {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import new java.io.FileOutputStream(##java.io.File): ##java.io.FileOutputStream & Impure as newFileStream;
             import new java.io.PrintWriter(##java.io.OutputStream): ##java.io.PrintWriter & Impure as newPrintWriter;
-            import java.io.FileOutputStream.write(Array[Int8]): Unit & Impure;
+            import java.io.FileOutputStream.write(FooArray[Int8]): Unit & Impure;
             import java.io.PrintWriter.close(): Unit & Impure;
             import java.io.PrintWriter.checkError(): Bool & Impure;
 
@@ -743,7 +743,7 @@ namespace File {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import new java.io.FileOutputStream(##java.io.File, Bool): ##java.io.FileOutputStream & Impure as newFileStream;
             import new java.io.PrintWriter(##java.io.OutputStream): ##java.io.PrintWriter & Impure as newPrintWriter;
-            import java.io.FileOutputStream.write(Array[Int8]): Unit & Impure;
+            import java.io.FileOutputStream.write(FooArray[Int8]): Unit & Impure;
             import java.io.PrintWriter.close(): Unit & Impure;
             import java.io.PrintWriter.checkError(): Bool & Impure;
 
@@ -849,7 +849,7 @@ namespace File {
     pub def list(f: String): Result[List[String], String] & Impure =
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
-            import java.io.File.listFiles(): Array[##java.io.File] & Impure;
+            import java.io.File.listFiles(): FooArray[##java.io.File] & Impure;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
             import java.nio.file.Path.toString(): String & Impure as pathToString;
 
@@ -904,7 +904,7 @@ namespace File {
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.walk(##java.nio.file.Path, Array[##java.nio.file.FileVisitOption]): ##java.util.stream.Stream & Impure;
+            import static java.nio.file.Files.walk(##java.nio.file.Path, FooArray[##java.nio.file.FileVisitOption]): ##java.util.stream.Stream & Impure;
             import java.util.stream.BaseStream.iterator(): ##java.util.Iterator & Impure;
             import java.nio.file.Path.toString(): String & Pure as pathToString;
 
@@ -951,7 +951,7 @@ namespace File {
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.move(##java.nio.file.Path, ##java.nio.file.Path, Array[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
+            import static java.nio.file.Files.move(##java.nio.file.Path, ##java.nio.file.Path, FooArray[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
 
             let srcFile = newFile(src.src);
             let srcPath = toPath(srcFile);
@@ -1010,7 +1010,7 @@ namespace File {
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.move(##java.nio.file.Path, ##java.nio.file.Path, Array[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
+            import static java.nio.file.Files.move(##java.nio.file.Path, ##java.nio.file.Path, FooArray[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
             import static get java.nio.file.StandardCopyOption.REPLACE_EXISTING: ##java.nio.file.StandardCopyOption & Impure as getOverwrite;
 
             let dstFile = newFile(dst);
@@ -1040,7 +1040,7 @@ namespace File {
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.copy(##java.nio.file.Path, ##java.nio.file.Path, Array[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
+            import static java.nio.file.Files.copy(##java.nio.file.Path, ##java.nio.file.Path, FooArray[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
 
             let srcFile = newFile(src.src);
             let srcPath = toPath(srcFile);
@@ -1099,7 +1099,7 @@ namespace File {
         try {
             import new java.io.File(String): ##java.io.File & Impure as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path & Impure;
-            import static java.nio.file.Files.copy(##java.nio.file.Path, ##java.nio.file.Path, Array[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
+            import static java.nio.file.Files.copy(##java.nio.file.Path, ##java.nio.file.Path, FooArray[##java.nio.file.CopyOption]): ##java.nio.file.Path & Impure;
             import static get java.nio.file.StandardCopyOption.REPLACE_EXISTING: ##java.nio.file.StandardCopyOption & Impure as getOverwrite;
 
             let dstFile = newFile(dst);

--- a/main/src/library/Fixpoint/Ast/BodyPredicate.flix
+++ b/main/src/library/Fixpoint/Ast/BodyPredicate.flix
@@ -19,14 +19,14 @@ use Fixpoint/Shared.PredSym;
 
 namespace Fixpoint/Ast {
     pub enum BodyPredicate[v] {
-        case BodyAtom(PredSym, Denotation[v], Polarity, Fixity, FooArray[BodyTerm[v]])
+        case BodyAtom(PredSym, Denotation[v], Polarity, Fixity, UnscopedArray[BodyTerm[v]])
         case Guard0(Unit -> Bool)
         case Guard1(v -> Bool, VarSym)
         case Guard2(v -> v -> Bool, VarSym, VarSym)
         case Guard3(v -> v -> v -> Bool, VarSym, VarSym, VarSym)
         case Guard4(v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym)
         case Guard5(v -> v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, VarSym)
-        case Loop1(v -> FooArray[v])
+        case Loop1(v -> UnscopedArray[v])
     }
 
     instance PredSymsOf[BodyPredicate[v]] {

--- a/main/src/library/Fixpoint/Ast/BodyPredicate.flix
+++ b/main/src/library/Fixpoint/Ast/BodyPredicate.flix
@@ -19,14 +19,14 @@ use Fixpoint/Shared.PredSym;
 
 namespace Fixpoint/Ast {
     pub enum BodyPredicate[v] {
-        case BodyAtom(PredSym, Denotation[v], Polarity, Fixity, Array[BodyTerm[v]])
+        case BodyAtom(PredSym, Denotation[v], Polarity, Fixity, FooArray[BodyTerm[v]])
         case Guard0(Unit -> Bool)
         case Guard1(v -> Bool, VarSym)
         case Guard2(v -> v -> Bool, VarSym, VarSym)
         case Guard3(v -> v -> v -> Bool, VarSym, VarSym, VarSym)
         case Guard4(v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym)
         case Guard5(v -> v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, VarSym)
-        case Loop1(v -> Array[v])
+        case Loop1(v -> FooArray[v])
     }
 
     instance PredSymsOf[BodyPredicate[v]] {

--- a/main/src/library/Fixpoint/Ast/Constraint.flix
+++ b/main/src/library/Fixpoint/Ast/Constraint.flix
@@ -21,7 +21,7 @@ use Fixpoint/Shared.PredSym;
 
 namespace Fixpoint/Ast {
     pub enum Constraint[v] {
-        case Constraint(HeadPredicate[v], FooArray[BodyPredicate[v]])
+        case Constraint(HeadPredicate[v], UnscopedArray[BodyPredicate[v]])
     }
 
     instance PredSymsOf[Constraint[v]] {

--- a/main/src/library/Fixpoint/Ast/Constraint.flix
+++ b/main/src/library/Fixpoint/Ast/Constraint.flix
@@ -21,7 +21,7 @@ use Fixpoint/Shared.PredSym;
 
 namespace Fixpoint/Ast {
     pub enum Constraint[v] {
-        case Constraint(HeadPredicate[v], Array[BodyPredicate[v]])
+        case Constraint(HeadPredicate[v], FooArray[BodyPredicate[v]])
     }
 
     instance PredSymsOf[Constraint[v]] {

--- a/main/src/library/Fixpoint/Ast/Datalog.flix
+++ b/main/src/library/Fixpoint/Ast/Datalog.flix
@@ -24,7 +24,7 @@ use Fixpoint/Ram.RamSym;
 
 namespace Fixpoint/Ast {
     pub enum Datalog[v] {
-        case Datalog(Array[Constraint[v]], Array[Constraint[v]])
+        case Datalog(FooArray[Constraint[v]], FooArray[Constraint[v]])
         case Model(Map[RamSym[v], Map[Tuple[v], v]])
         case Join(Datalog[v], Datalog[v])
     }

--- a/main/src/library/Fixpoint/Ast/Datalog.flix
+++ b/main/src/library/Fixpoint/Ast/Datalog.flix
@@ -24,7 +24,7 @@ use Fixpoint/Ram.RamSym;
 
 namespace Fixpoint/Ast {
     pub enum Datalog[v] {
-        case Datalog(FooArray[Constraint[v]], FooArray[Constraint[v]])
+        case Datalog(UnscopedArray[Constraint[v]], UnscopedArray[Constraint[v]])
         case Model(Map[RamSym[v], Map[Tuple[v], v]])
         case Join(Datalog[v], Datalog[v])
     }

--- a/main/src/library/Fixpoint/Ast/HeadPredicate.flix
+++ b/main/src/library/Fixpoint/Ast/HeadPredicate.flix
@@ -19,7 +19,7 @@ use Fixpoint/Shared.PredSym;
 
 namespace Fixpoint/Ast {
     pub enum HeadPredicate[v] {
-        case HeadAtom(PredSym, Denotation[v], FooArray[HeadTerm[v]])
+        case HeadAtom(PredSym, Denotation[v], UnscopedArray[HeadTerm[v]])
     }
 
     instance PredSymsOf[HeadPredicate[v]] {

--- a/main/src/library/Fixpoint/Ast/HeadPredicate.flix
+++ b/main/src/library/Fixpoint/Ast/HeadPredicate.flix
@@ -19,7 +19,7 @@ use Fixpoint/Shared.PredSym;
 
 namespace Fixpoint/Ast {
     pub enum HeadPredicate[v] {
-        case HeadAtom(PredSym, Denotation[v], Array[HeadTerm[v]])
+        case HeadAtom(PredSym, Denotation[v], FooArray[HeadTerm[v]])
     }
 
     instance PredSymsOf[HeadPredicate[v]] {

--- a/main/src/library/Fixpoint/Compiler.flix
+++ b/main/src/library/Fixpoint/Compiler.flix
@@ -67,7 +67,7 @@ namespace Fixpoint {
     /// Note that Eval-Rule is the code emitted by `compileRule`
     /// and Eval-Rule-Incr is the code emitted by `compileRuleIncr`.
     ///
-    def compileStratum(stmts: MutList[RamStmt[v], Impure], stratum: Array[Constraint[v]]): Unit & Impure with ToString[v] =
+    def compileStratum(stmts: MutList[RamStmt[v], Impure], stratum: FooArray[Constraint[v]]): Unit & Impure with ToString[v] =
         let idb = Array.foldRight(match Constraint(HeadAtom(pred, den, terms), _) -> {
             let arity = Array.length(terms);
             Map.insert(pred, (arity, den))
@@ -251,7 +251,7 @@ namespace Fixpoint {
     ///
     /// Note that row variables not unique across rules.
     ///
-    def augmentBody(body: Array[BodyPredicate[v]]): Array[(BodyPredicate[v], RowVar)] & Impure =
+    def augmentBody(body: FooArray[BodyPredicate[v]]): FooArray[(BodyPredicate[v], RowVar)] & Impure =
         Array.mapWithIndex(atom -> i -> match atom {
             case BodyAtom(predSym, _, Polarity.Positive, _, _) => (atom, RowVar.Named("${predSym}$${i}"))
             case _ => (atom, RowVar.Named("IfYouSeeThisYouFoundABug"))
@@ -266,7 +266,7 @@ namespace Fixpoint {
     /// `x` is mapped to B$1[0] because `x` occurs positively in the second atom.
     /// `s` is mapped to the glb of all its positive occurences because it is latticenal.
     ///
-    def unifyVars(body: Array[(BodyPredicate[v], RowVar)]): Map[VarSym, RamTerm[v]] & Impure =
+    def unifyVars(body: FooArray[(BodyPredicate[v], RowVar)]): Map[VarSym, RamTerm[v]] & Impure =
         Array.foldLeft(acc -> match (atom, rowVar) -> match atom {
             case BodyAtom(_, denotation, Polarity.Positive, _, terms) =>
                 Array.mapWithIndex(term -> i -> (term, i), terms) |>
@@ -302,7 +302,7 @@ namespace Fixpoint {
     /// (2) comes from the negative atom `not A(x)`.
     /// (3) is a function call that computes the expression `x > 0`.
     ///
-    def compileBody(env: Map[VarSym, RamTerm[v]], body: Array[(BodyPredicate[v], RowVar)]): List[BoolExp[v]] & Impure =
+    def compileBody(env: Map[VarSym, RamTerm[v]], body: FooArray[(BodyPredicate[v], RowVar)]): List[BoolExp[v]] & Impure =
         Array.foldRight(match (atom, rowVar) -> acc ->
             let compileBodyTerm = term -> j -> match term {
                 case BodyTerm.Wild      => RamTerm.RowLoad(rowVar, j)

--- a/main/src/library/Fixpoint/Compiler.flix
+++ b/main/src/library/Fixpoint/Compiler.flix
@@ -67,7 +67,7 @@ namespace Fixpoint {
     /// Note that Eval-Rule is the code emitted by `compileRule`
     /// and Eval-Rule-Incr is the code emitted by `compileRuleIncr`.
     ///
-    def compileStratum(stmts: MutList[RamStmt[v], Impure], stratum: FooArray[Constraint[v]]): Unit & Impure with ToString[v] =
+    def compileStratum(stmts: MutList[RamStmt[v], Impure], stratum: UnscopedArray[Constraint[v]]): Unit & Impure with ToString[v] =
         let idb = Array.foldRight(match Constraint(HeadAtom(pred, den, terms), _) -> {
             let arity = Array.length(terms);
             Map.insert(pred, (arity, den))
@@ -251,7 +251,7 @@ namespace Fixpoint {
     ///
     /// Note that row variables not unique across rules.
     ///
-    def augmentBody(body: FooArray[BodyPredicate[v]]): FooArray[(BodyPredicate[v], RowVar)] & Impure =
+    def augmentBody(body: UnscopedArray[BodyPredicate[v]]): UnscopedArray[(BodyPredicate[v], RowVar)] & Impure =
         Array.mapWithIndex(atom -> i -> match atom {
             case BodyAtom(predSym, _, Polarity.Positive, _, _) => (atom, RowVar.Named("${predSym}$${i}"))
             case _ => (atom, RowVar.Named("IfYouSeeThisYouFoundABug"))
@@ -266,7 +266,7 @@ namespace Fixpoint {
     /// `x` is mapped to B$1[0] because `x` occurs positively in the second atom.
     /// `s` is mapped to the glb of all its positive occurences because it is latticenal.
     ///
-    def unifyVars(body: FooArray[(BodyPredicate[v], RowVar)]): Map[VarSym, RamTerm[v]] & Impure =
+    def unifyVars(body: UnscopedArray[(BodyPredicate[v], RowVar)]): Map[VarSym, RamTerm[v]] & Impure =
         Array.foldLeft(acc -> match (atom, rowVar) -> match atom {
             case BodyAtom(_, denotation, Polarity.Positive, _, terms) =>
                 Array.mapWithIndex(term -> i -> (term, i), terms) |>
@@ -302,7 +302,7 @@ namespace Fixpoint {
     /// (2) comes from the negative atom `not A(x)`.
     /// (3) is a function call that computes the expression `x > 0`.
     ///
-    def compileBody(env: Map[VarSym, RamTerm[v]], body: FooArray[(BodyPredicate[v], RowVar)]): List[BoolExp[v]] & Impure =
+    def compileBody(env: Map[VarSym, RamTerm[v]], body: UnscopedArray[(BodyPredicate[v], RowVar)]): List[BoolExp[v]] & Impure =
         Array.foldRight(match (atom, rowVar) -> acc ->
             let compileBodyTerm = term -> j -> match term {
                 case BodyTerm.Wild      => RamTerm.RowLoad(rowVar, j)

--- a/main/src/library/Fixpoint/Interpreter.flix
+++ b/main/src/library/Fixpoint/Interpreter.flix
@@ -20,7 +20,7 @@ use Fixpoint/Ast.Denotation;
 namespace Fixpoint {
 
     enum Tuple[v] {
-        case Tuple(FooArray[v])
+        case Tuple(UnscopedArray[v])
     }
 
     // NB: Unsafe instance.
@@ -40,7 +40,7 @@ namespace Fixpoint {
     }
 
     type alias Database[v] = MutMap[RamSym[v], MutMap[Tuple[v], v, Impure], Impure]
-    type alias SearchEnv[v] = (FooArray[Tuple[v]], FooArray[v])
+    type alias SearchEnv[v] = (UnscopedArray[Tuple[v]], UnscopedArray[v])
 
     def interpret(stmt: RamStmt[v]): Database[v] & Impure with Order[v], ToString[v] =
         interpretWithDatabase(new MutMap(static), stmt)
@@ -122,7 +122,7 @@ namespace Fixpoint {
             case _ => ()
         }
 
-    def evalQuery(env: SearchEnv[v], i: Int32, query: FooArray[(Int32, RamTerm[v])], tuple: Tuple[v]): Comparison & Impure with Order[v], ToString[v] =
+    def evalQuery(env: SearchEnv[v], i: Int32, query: UnscopedArray[(Int32, RamTerm[v])], tuple: Tuple[v]): Comparison & Impure with Order[v], ToString[v] =
         if (i >= Array.length(query))
             EqualTo
         else {

--- a/main/src/library/Fixpoint/Interpreter.flix
+++ b/main/src/library/Fixpoint/Interpreter.flix
@@ -20,7 +20,7 @@ use Fixpoint/Ast.Denotation;
 namespace Fixpoint {
 
     enum Tuple[v] {
-        case Tuple(Array[v])
+        case Tuple(FooArray[v])
     }
 
     // NB: Unsafe instance.
@@ -40,7 +40,7 @@ namespace Fixpoint {
     }
 
     type alias Database[v] = MutMap[RamSym[v], MutMap[Tuple[v], v, Impure], Impure]
-    type alias SearchEnv[v] = (Array[Tuple[v]], Array[v])
+    type alias SearchEnv[v] = (FooArray[Tuple[v]], FooArray[v])
 
     def interpret(stmt: RamStmt[v]): Database[v] & Impure with Order[v], ToString[v] =
         interpretWithDatabase(new MutMap(static), stmt)
@@ -122,7 +122,7 @@ namespace Fixpoint {
             case _ => ()
         }
 
-    def evalQuery(env: SearchEnv[v], i: Int32, query: Array[(Int32, RamTerm[v])], tuple: Tuple[v]): Comparison & Impure with Order[v], ToString[v] =
+    def evalQuery(env: SearchEnv[v], i: Int32, query: FooArray[(Int32, RamTerm[v])], tuple: Tuple[v]): Comparison & Impure with Order[v], ToString[v] =
         if (i >= Array.length(query))
             EqualTo
         else {

--- a/main/src/library/Fixpoint/Ram/BoolExp.flix
+++ b/main/src/library/Fixpoint/Ram/BoolExp.flix
@@ -17,7 +17,7 @@
 namespace Fixpoint/Ram {
     pub enum BoolExp[v] {
         case Empty(RamSym[v])
-        case NotMemberOf(FooArray[RamTerm[v]], RamSym[v])
+        case NotMemberOf(UnscopedArray[RamTerm[v]], RamSym[v])
         case Eq(RamTerm[v], RamTerm[v])
         case Leq(v -> v -> Bool, RamTerm[v], RamTerm[v])
         case Guard0(Unit -> Bool)

--- a/main/src/library/Fixpoint/Ram/BoolExp.flix
+++ b/main/src/library/Fixpoint/Ram/BoolExp.flix
@@ -17,7 +17,7 @@
 namespace Fixpoint/Ram {
     pub enum BoolExp[v] {
         case Empty(RamSym[v])
-        case NotMemberOf(Array[RamTerm[v]], RamSym[v])
+        case NotMemberOf(FooArray[RamTerm[v]], RamSym[v])
         case Eq(RamTerm[v], RamTerm[v])
         case Leq(v -> v -> Bool, RamTerm[v], RamTerm[v])
         case Guard0(Unit -> Bool)

--- a/main/src/library/Fixpoint/Ram/RamStmt.flix
+++ b/main/src/library/Fixpoint/Ram/RamStmt.flix
@@ -22,7 +22,7 @@ namespace Fixpoint/Ram {
         case Merge(RamSym[v], RamSym[v])
         case Assign(RamSym[v], RamSym[v])
         case Purge(RamSym[v])
-        case Seq(Array[RamStmt[v]])
+        case Seq(FooArray[RamStmt[v]])
         case Until(List[BoolExp[v]], RamStmt[v])
         case Comment(String)
     }

--- a/main/src/library/Fixpoint/Ram/RamStmt.flix
+++ b/main/src/library/Fixpoint/Ram/RamStmt.flix
@@ -22,7 +22,7 @@ namespace Fixpoint/Ram {
         case Merge(RamSym[v], RamSym[v])
         case Assign(RamSym[v], RamSym[v])
         case Purge(RamSym[v])
-        case Seq(FooArray[RamStmt[v]])
+        case Seq(UnscopedArray[RamStmt[v]])
         case Until(List[BoolExp[v]], RamStmt[v])
         case Comment(String)
     }

--- a/main/src/library/Fixpoint/Ram/RelOp.flix
+++ b/main/src/library/Fixpoint/Ram/RelOp.flix
@@ -17,8 +17,8 @@
 namespace Fixpoint/Ram {
     pub enum RelOp[v] {
         case Search(RowVar, RamSym[v], RelOp[v])
-        case Query(RowVar, RamSym[v], Array[(Int32, RamTerm[v])], RelOp[v])
-        case Project(Array[RamTerm[v]], RamSym[v])
+        case Query(RowVar, RamSym[v], FooArray[(Int32, RamTerm[v])], RelOp[v])
+        case Project(FooArray[RamTerm[v]], RamSym[v])
         case If(List[BoolExp[v]], RelOp[v])
     }
 

--- a/main/src/library/Fixpoint/Ram/RelOp.flix
+++ b/main/src/library/Fixpoint/Ram/RelOp.flix
@@ -17,8 +17,8 @@
 namespace Fixpoint/Ram {
     pub enum RelOp[v] {
         case Search(RowVar, RamSym[v], RelOp[v])
-        case Query(RowVar, RamSym[v], FooArray[(Int32, RamTerm[v])], RelOp[v])
-        case Project(FooArray[RamTerm[v]], RamSym[v])
+        case Query(RowVar, RamSym[v], UnscopedArray[(Int32, RamTerm[v])], RelOp[v])
+        case Project(UnscopedArray[RamTerm[v]], RamSym[v])
         case If(List[BoolExp[v]], RelOp[v])
     }
 

--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -112,7 +112,7 @@ namespace Fixpoint {
     /// Renames every predicate symbol in `d` with a fresh name, except for those in `preds`.
     ///
     @Internal
-    pub def rename(preds: FooArray[PredSym], d: Datalog[v]): Datalog[v] with Order[v], ToString[v] = {
+    pub def rename(preds: UnscopedArray[PredSym], d: Datalog[v]): Datalog[v] with Order[v], ToString[v] = {
         use Fixpoint/PredSymsOf.predSymsOf;
         use Fixpoint/SubstitutePredSym.substitute;
 
@@ -480,7 +480,7 @@ namespace Fixpoint {
              box(v15)]
         , p, ts) as & Pure
 
-    def projectIntoX[f: Type -> Type, t: Type, ef: Bool](f: t -> FooArray[Boxed] & ef, p: PredSym, ts: f[t]): Datalog[Boxed] & Impure with Foldable[f] =
+    def projectIntoX[f: Type -> Type, t: Type, ef: Bool](f: t -> UnscopedArray[Boxed] & ef, p: PredSym, ts: f[t]): Datalog[Boxed] & Impure with Foldable[f] =
         let db = new MutMap(static);
         Foldable.foldLeft(() -> t -> {
             let vs = f(t);
@@ -495,14 +495,14 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts0(p: PredSym, d: Datalog[Boxed]): FooArray[v] with Boxable[v] =
+    pub def facts0(p: PredSym, d: Datalog[Boxed]): UnscopedArray[v] with Boxable[v] =
         factsOf(_ -> () as v, p, d) as & Pure
 
     ///
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts1(p: PredSym, d: Datalog[Boxed]): FooArray[v] with Boxable[v] =
+    pub def facts1(p: PredSym, d: Datalog[Boxed]): UnscopedArray[v] with Boxable[v] =
         let f = terms -> unbox(terms[0]);
         factsOf(f, p, d) as & Pure
 
@@ -510,7 +510,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts2(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2)] with Boxable[t1], Boxable[t2] =
+    pub def facts2(p: PredSym, d: Datalog[Boxed]): UnscopedArray[(t1, t2)] with Boxable[t1], Boxable[t2] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]));
         factsOf(f, p, d) as & Pure
 
@@ -518,7 +518,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts3(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3)] with Boxable[t1], Boxable[t2], Boxable[t3] =
+    pub def facts3(p: PredSym, d: Datalog[Boxed]): UnscopedArray[(t1, t2, t3)] with Boxable[t1], Boxable[t2], Boxable[t3] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]));
         factsOf(f, p, d) as & Pure
 
@@ -526,7 +526,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts4(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4] =
+    pub def facts4(p: PredSym, d: Datalog[Boxed]): UnscopedArray[(t1, t2, t3, t4)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]));
         factsOf(f, p, d) as & Pure
 
@@ -534,7 +534,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts5(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5] =
+    pub def facts5(p: PredSym, d: Datalog[Boxed]): UnscopedArray[(t1, t2, t3, t4, t5)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]));
         factsOf(f, p, d) as & Pure
 
@@ -542,7 +542,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts6(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6] =
+    pub def facts6(p: PredSym, d: Datalog[Boxed]): UnscopedArray[(t1, t2, t3, t4, t5, t6)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]));
         factsOf(f, p, d) as & Pure
 
@@ -550,7 +550,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts7(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7] =
+    pub def facts7(p: PredSym, d: Datalog[Boxed]): UnscopedArray[(t1, t2, t3, t4, t5, t6, t7)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]));
         factsOf(f, p, d) as & Pure
 
@@ -558,7 +558,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts8(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8] =
+    pub def facts8(p: PredSym, d: Datalog[Boxed]): UnscopedArray[(t1, t2, t3, t4, t5, t6, t7, t8)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]));
         factsOf(f, p, d) as & Pure
 
@@ -566,7 +566,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts9(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9] =
+    pub def facts9(p: PredSym, d: Datalog[Boxed]): UnscopedArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]));
         factsOf(f, p, d) as & Pure
 
@@ -574,7 +574,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts10(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10] =
+    pub def facts10(p: PredSym, d: Datalog[Boxed]): UnscopedArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]));
         factsOf(f, p, d) as & Pure
 
@@ -582,7 +582,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts11(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11] =
+    pub def facts11(p: PredSym, d: Datalog[Boxed]): UnscopedArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]));
         factsOf(f, p, d) as & Pure
 
@@ -590,7 +590,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts12(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12] =
+    pub def facts12(p: PredSym, d: Datalog[Boxed]): UnscopedArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]), unbox(terms[11]));
         factsOf(f, p, d) as & Pure
 
@@ -598,7 +598,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts13(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13] =
+    pub def facts13(p: PredSym, d: Datalog[Boxed]): UnscopedArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]), unbox(terms[11]), unbox(terms[12]));
         factsOf(f, p, d) as & Pure
 
@@ -606,7 +606,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts14(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13], Boxable[t14] =
+    pub def facts14(p: PredSym, d: Datalog[Boxed]): UnscopedArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13], Boxable[t14] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]), unbox(terms[11]), unbox(terms[12]), unbox(terms[13]));
         factsOf(f, p, d) as & Pure
 
@@ -614,14 +614,14 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts15(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13], Boxable[t14], Boxable[t15] =
+    pub def facts15(p: PredSym, d: Datalog[Boxed]): UnscopedArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13], Boxable[t14], Boxable[t15] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]), unbox(terms[11]), unbox(terms[12]), unbox(terms[13]), unbox(terms[14]));
         factsOf(f, p, d) as & Pure
 
     ///
     /// Returns an array of facts associated with the given predicate symbol `p` in the given Datalog program `d`.
     ///
-    def factsOf(f: FooArray[v] -> t & ef, p: PredSym, d: Datalog[v]): FooArray[t] & Impure = match d {
+    def factsOf(f: UnscopedArray[v] -> t & ef, p: PredSym, d: Datalog[v]): UnscopedArray[t] & Impure = match d {
         case Datalog(_, cs) =>
             let pFacts = new MutList(static);
             Array.foreach(c -> match c {

--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -112,7 +112,7 @@ namespace Fixpoint {
     /// Renames every predicate symbol in `d` with a fresh name, except for those in `preds`.
     ///
     @Internal
-    pub def rename(preds: Array[PredSym], d: Datalog[v]): Datalog[v] with Order[v], ToString[v] = {
+    pub def rename(preds: FooArray[PredSym], d: Datalog[v]): Datalog[v] with Order[v], ToString[v] = {
         use Fixpoint/PredSymsOf.predSymsOf;
         use Fixpoint/SubstitutePredSym.substitute;
 
@@ -480,7 +480,7 @@ namespace Fixpoint {
              box(v15)]
         , p, ts) as & Pure
 
-    def projectIntoX[f: Type -> Type, t: Type, ef: Bool](f: t -> Array[Boxed] & ef, p: PredSym, ts: f[t]): Datalog[Boxed] & Impure with Foldable[f] =
+    def projectIntoX[f: Type -> Type, t: Type, ef: Bool](f: t -> FooArray[Boxed] & ef, p: PredSym, ts: f[t]): Datalog[Boxed] & Impure with Foldable[f] =
         let db = new MutMap(static);
         Foldable.foldLeft(() -> t -> {
             let vs = f(t);
@@ -495,14 +495,14 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts0(p: PredSym, d: Datalog[Boxed]): Array[v] with Boxable[v] =
+    pub def facts0(p: PredSym, d: Datalog[Boxed]): FooArray[v] with Boxable[v] =
         factsOf(_ -> () as v, p, d) as & Pure
 
     ///
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts1(p: PredSym, d: Datalog[Boxed]): Array[v] with Boxable[v] =
+    pub def facts1(p: PredSym, d: Datalog[Boxed]): FooArray[v] with Boxable[v] =
         let f = terms -> unbox(terms[0]);
         factsOf(f, p, d) as & Pure
 
@@ -510,7 +510,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts2(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2)] with Boxable[t1], Boxable[t2] =
+    pub def facts2(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2)] with Boxable[t1], Boxable[t2] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]));
         factsOf(f, p, d) as & Pure
 
@@ -518,7 +518,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts3(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3)] with Boxable[t1], Boxable[t2], Boxable[t3] =
+    pub def facts3(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3)] with Boxable[t1], Boxable[t2], Boxable[t3] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]));
         factsOf(f, p, d) as & Pure
 
@@ -526,7 +526,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts4(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4] =
+    pub def facts4(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]));
         factsOf(f, p, d) as & Pure
 
@@ -534,7 +534,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts5(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5] =
+    pub def facts5(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]));
         factsOf(f, p, d) as & Pure
 
@@ -542,7 +542,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts6(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6] =
+    pub def facts6(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]));
         factsOf(f, p, d) as & Pure
 
@@ -550,7 +550,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts7(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7] =
+    pub def facts7(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]));
         factsOf(f, p, d) as & Pure
 
@@ -558,7 +558,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts8(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8] =
+    pub def facts8(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]));
         factsOf(f, p, d) as & Pure
 
@@ -566,7 +566,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts9(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8, t9)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9] =
+    pub def facts9(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]));
         factsOf(f, p, d) as & Pure
 
@@ -574,7 +574,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts10(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10] =
+    pub def facts10(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]));
         factsOf(f, p, d) as & Pure
 
@@ -582,7 +582,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts11(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11] =
+    pub def facts11(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]));
         factsOf(f, p, d) as & Pure
 
@@ -590,7 +590,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts12(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12] =
+    pub def facts12(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]), unbox(terms[11]));
         factsOf(f, p, d) as & Pure
 
@@ -598,7 +598,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts13(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13] =
+    pub def facts13(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]), unbox(terms[11]), unbox(terms[12]));
         factsOf(f, p, d) as & Pure
 
@@ -606,7 +606,7 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts14(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13], Boxable[t14] =
+    pub def facts14(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13], Boxable[t14] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]), unbox(terms[11]), unbox(terms[12]), unbox(terms[13]));
         factsOf(f, p, d) as & Pure
 
@@ -614,14 +614,14 @@ namespace Fixpoint {
     /// Returns all facts in `d` associated with the predicate symbol `p`.
     ///
     @Internal
-    pub def facts15(p: PredSym, d: Datalog[Boxed]): Array[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13], Boxable[t14], Boxable[t15] =
+    pub def facts15(p: PredSym, d: Datalog[Boxed]): FooArray[(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)] with Boxable[t1], Boxable[t2], Boxable[t3], Boxable[t4], Boxable[t5], Boxable[t6], Boxable[t7], Boxable[t8], Boxable[t9], Boxable[t10], Boxable[t11], Boxable[t12], Boxable[t13], Boxable[t14], Boxable[t15] =
         let f = terms -> (unbox(terms[0]), unbox(terms[1]), unbox(terms[2]), unbox(terms[3]), unbox(terms[4]), unbox(terms[5]), unbox(terms[6]), unbox(terms[7]), unbox(terms[8]), unbox(terms[9]), unbox(terms[10]), unbox(terms[11]), unbox(terms[12]), unbox(terms[13]), unbox(terms[14]));
         factsOf(f, p, d) as & Pure
 
     ///
     /// Returns an array of facts associated with the given predicate symbol `p` in the given Datalog program `d`.
     ///
-    def factsOf(f: Array[v] -> t & ef, p: PredSym, d: Datalog[v]): Array[t] & Impure = match d {
+    def factsOf(f: FooArray[v] -> t & ef, p: PredSym, d: Datalog[v]): FooArray[t] & Impure = match d {
         case Datalog(_, cs) =>
             let pFacts = new MutList(static);
             Array.foreach(c -> match c {

--- a/main/src/library/Fixpoint/ToString.flix
+++ b/main/src/library/Fixpoint/ToString.flix
@@ -19,6 +19,6 @@ namespace Fixpoint {
     /// Helper function to implement `ToString`.
     ///
     @Internal
-    pub def commaSeparate(a: ScopedArray[v, r]): String \ Read(r) with ToString[v] =
+    pub def commaSeparate(a: Array[v, r]): String \ Read(r) with ToString[v] =
         Array.join(", ", a)
 }

--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -198,7 +198,7 @@ pub class Foldable[t : Type -> Type] {
     ///
     /// Returns `t` as an array.
     ///
-    pub def toArray(t: t[a], r: Region[r]): ScopedArray[a, r] \ Write(r) =
+    pub def toArray(t: t[a], r: Region[r]): Array[a, r] \ Write(r) =
         let v = new MutList(r);
         Foldable.foreach(a -> MutList.push!(a, v), t);
         MutList.toArray(v, r)

--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -166,7 +166,7 @@ namespace Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def toArray(iter: Iterator[a], r: Region[r]): ScopedArray[a, r] & Impure =
+    pub def toArray(iter: Iterator[a], r: Region[r]): Array[a, r] & Impure =
         let m = new MutList(r);
         foreach(a -> MutList.push!(a, m), iter);
         MutList.toArray(m, r)

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -1154,7 +1154,7 @@ namespace List {
     /// Returns the list `l` as an array.
     ///
     @Time(length(l)) @Space(length(l))
-    pub def toArray(l: List[a], r: Region[r]): ScopedArray[a, r] \ Write(r) = match head(l) {
+    pub def toArray(l: List[a], r: Region[r]): Array[a, r] \ Write(r) = match head(l) {
         case None    => [] @ r
         case Some(x) =>
             let a = [x; length(l)] @ r;

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -28,7 +28,7 @@
 /// and the back index always points to the first empty index (going clockwise).
 ///
 pub enum MutDeque[a: Type, r: Region] {
-    case MutDeque(Ref[ScopedArray[a, r], r], Ref[Int32, r], Ref[Int32, r])
+    case MutDeque(Ref[Array[a, r], r], Ref[Int32, r], Ref[Int32, r])
 }
 
 
@@ -299,7 +299,7 @@ namespace MutDeque {
     ///
     /// Copies the elements from `a` to `a1`. Mutates the array `a1`.
     ///
-    def copyElements!(f: Int32, b: Int32, a: ScopedArray[a, r], a1: ScopedArray[a, r]): Unit \ { Read(r), Write(r) } =
+    def copyElements!(f: Int32, b: Int32, a: Array[a, r], a1: Array[a, r]): Unit \ { Read(r), Write(r) } =
         let c = Array.length(a);
         if (f < b) { // If this predicate is true the elements do not "wrap around" in the array, i.e. the elements are laid out sequentially from [0 .. b].
             Array.updateSequence!(0,     a[f .. b], a1)

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -22,7 +22,7 @@
 ///   - The capacity of the array is always 8 or more.
 ///
 pub enum MutList[a: Type, r: Region] {
-    case MutList(Ref[ScopedArray[a, r], r], Ref[Int32, r])
+    case MutList(Ref[Array[a, r], r], Ref[Int32, r])
 }
 
 instance Newable[MutList[a]] {
@@ -717,7 +717,7 @@ namespace MutList {
     ///
     /// Returns `v` as an array.
     ///
-    pub def toArray(v: MutList[a, r1], r2: Region[r2]): ScopedArray[a, r2] \ { Read(r1), Write(r2) } =
+    pub def toArray(v: MutList[a, r1], r2: Region[r2]): Array[a, r2] \ { Read(r1), Write(r2) } =
         let MutList(a, l) = v;
         Array.copyOfRange(0, deref l, deref a, r2)
 

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -101,7 +101,7 @@ instance Reducible[Nec] {
     override pub def memberOf(a: a, l: Nec[a]): Bool with Eq[a] = Nec.memberOf(a, l)
     override pub def dropWhile(f: a -> Bool & ef, l: Nec[a]): List[a] & ef = Nec.dropWhileLeft(f, l)
     override pub def takeWhile(f: a -> Bool & ef, l: Nec[a]): List[a] & ef = Nec.takeWhileLeft(f, l)
-    override pub def toArray(l: Nec[a], r: Region[r]): ScopedArray[a, r] \ Write(r) = Nec.toArray(l, r)
+    override pub def toArray(l: Nec[a], r: Region[r]): Array[a, r] \ Write(r) = Nec.toArray(l, r)
     override pub def toIterator(l: Nec[a]): Iterator[a] & Impure = Nec.toIterator(l)
     override pub def toList(l: Nec[a]): List[a] = Nec.toList(l)
 }
@@ -754,7 +754,7 @@ namespace Nec {
     ///
     /// Returns the Nec `c` as an array.
     ///
-    pub def toArray(c: Nec[a], r: Region[r]): ScopedArray[a, r] \ Write(r) =
+    pub def toArray(c: Nec[a], r: Region[r]): Array[a, r] \ Write(r) =
         let x = head(c);
         let arr = [x; length(c)] @ r;
         let f = (i, b) -> { arr[i] = b; i + 1 };
@@ -791,7 +791,7 @@ namespace Nec {
     ///
     /// Helper for the `sort` functions.
     ///
-    def fromArray(arr: ScopedArray[a, r]): Option[Nec[a]] \ Read(r) =
+    def fromArray(arr: Array[a, r]): Option[Nec[a]] \ Read(r) =
         def loop(ix, end, acc) = if (ix >= end) acc else {let x = arr[ix]; loop(ix+1, end, snoc(acc, x))};
         let len = Array.length(arr);
         if (len < 1)

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -95,7 +95,7 @@ instance Reducible[Nel] {
     override pub def memberOf(a: a, l: Nel[a]): Bool with Eq[a] = Nel.memberOf(a, l)
     override pub def dropWhile(f: a -> Bool & ef, l: Nel[a]): List[a] & ef = Nel.dropWhile(f, l)
     override pub def takeWhile(f: a -> Bool & ef, l: Nel[a]): List[a] & ef = Nel.takeWhile(f, l)
-    override pub def toArray(l: Nel[a], r: Region[r]): ScopedArray[a, r] \ Write(r) = Nel.toArray(l, r)
+    override pub def toArray(l: Nel[a], r: Region[r]): Array[a, r] \ Write(r) = Nel.toArray(l, r)
     override pub def toIterator(l: Nel[a]): Iterator[a] & Impure = Nel.toIterator(l)
     override pub def toList(l: Nel[a]): List[a] = Nel.toList(l)
 }
@@ -554,7 +554,7 @@ namespace Nel {
     ///
     /// Returns `l` as an array.
     ///
-    pub def toArray(l: Nel[a], r: Region[r]): ScopedArray[a, r] \ Write(r) =
+    pub def toArray(l: Nel[a], r: Region[r]): Array[a, r] \ Write(r) =
         (l |> toList |> List.toArray)(r)
 
     ///

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -1,7 +1,7 @@
 ///
 /// FooArray[t] is a type alias for a scoped array with a global lifetime.
 ///
-pub type alias FooArray[t] = ScopedArray[t, false]
+pub type alias FooArray[t] = Array[t, false]
 
 ///
 /// The Reified Flix Bools.

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -1,7 +1,7 @@
 ///
-/// Array[t] is a type alias for a scoped array with a global lifetime.
+/// FooArray[t] is a type alias for a scoped array with a global lifetime.
 ///
-pub type alias Array[t] = ScopedArray[t, false]
+pub type alias FooArray[t] = ScopedArray[t, false]
 
 ///
 /// The Reified Flix Bools.

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -1,7 +1,7 @@
 ///
-/// FooArray[t] is a type alias for a scoped array with a global lifetime.
+/// UnscopedArray[t] is a type alias for a scoped array with a global lifetime.
 ///
-pub type alias FooArray[t] = Array[t, false]
+pub type alias UnscopedArray[t] = Array[t, false]
 
 ///
 /// The Reified Flix Bools.

--- a/main/src/library/Random.flix
+++ b/main/src/library/Random.flix
@@ -19,7 +19,7 @@ namespace Random {
     ///
     /// Returns `None` if the given array `a` is empty.
     ///
-    pub def choose(r: Random, a: FooArray[a]): Option[a] & Impure =
+    pub def choose(r: Random, a: UnscopedArray[a]): Option[a] & Impure =
         if (a.length == 0) {
             None
         } else {

--- a/main/src/library/Random.flix
+++ b/main/src/library/Random.flix
@@ -19,7 +19,7 @@ namespace Random {
     ///
     /// Returns `None` if the given array `a` is empty.
     ///
-    pub def choose(r: Random, a: Array[a]): Option[a] & Impure =
+    pub def choose(r: Random, a: FooArray[a]): Option[a] & Impure =
         if (a.length == 0) {
             None
         } else {

--- a/main/src/library/Reducible.flix
+++ b/main/src/library/Reducible.flix
@@ -258,7 +258,7 @@ pub class Reducible[t: Type -> Type] {
     ///
     /// Returns `t` as an array.
     ///
-    pub def toArray(t: t[a], r: Region[r]): ScopedArray[a, r] \ Write(r) =
+    pub def toArray(t: t[a], r: Region[r]): Array[a, r] \ Write(r) =
         let v = new MutList(r);
         Reducible.foldLeft((_, a) -> MutList.push!(a, v), (), t);
         MutList.toArray(v, r)

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -113,7 +113,7 @@ namespace String {
     /// Returns the given string `s` as an array of characters.
     ///
     @Time(length(s)) @Space(length(s))
-    pub def toArray(s: String, r: Region[r]): ScopedArray[Char, r] \ Write(r) =
+    pub def toArray(s: String, r: Region[r]): Array[Char, r] \ Write(r) =
         Array.init(i -> charAt(i, s), length(s), r)
 
     ///

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -66,7 +66,7 @@ namespace String {
     /// Splits the string `s` around matches of the regular expression `regex`.
     ///
     pub def split(regex: {regex :: String}, s: String): List[String] =
-        import java.lang.String.split(String): Array[String] & Pure;
+        import java.lang.String.split(String): FooArray[String] & Pure;
         Array.toList(split(s, regex.regex)) as & Pure
 
     ///
@@ -1148,7 +1148,7 @@ namespace String {
     ///
     /// Helper function for `levenshteinDistance`.
     ///
-    def arraySwap(a: Array[Int32], b : Array[Int32]): Unit & Impure =
+    def arraySwap(a: FooArray[Int32], b : FooArray[Int32]): Unit & Impure =
         forIndex(0, Array.length(a) - 1, {i ->  a[i] = b[i]})
 
     ///
@@ -1158,7 +1158,7 @@ namespace String {
     /// If either `a` or `b` becomes depleted, then no further elements are added to the resulting array.
     ///
     @Time(Int32.min(length(a), length(b))) @Space(Int32.min(length(a), length(b)))
-    pub def zip(a: String, b: String): Array[(Char, Char)] & Impure =
+    pub def zip(a: String, b: String): FooArray[(Char, Char)] & Impure =
         let len = Int32.min(length(a), length(b));
         Array.init(i -> (charAt(i, a), charAt(i, b)), len, static)
 

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -66,7 +66,7 @@ namespace String {
     /// Splits the string `s` around matches of the regular expression `regex`.
     ///
     pub def split(regex: {regex :: String}, s: String): List[String] =
-        import java.lang.String.split(String): FooArray[String] & Pure;
+        import java.lang.String.split(String): UnscopedArray[String] & Pure;
         Array.toList(split(s, regex.regex)) as & Pure
 
     ///
@@ -1148,7 +1148,7 @@ namespace String {
     ///
     /// Helper function for `levenshteinDistance`.
     ///
-    def arraySwap(a: FooArray[Int32], b : FooArray[Int32]): Unit & Impure =
+    def arraySwap(a: UnscopedArray[Int32], b : UnscopedArray[Int32]): Unit & Impure =
         forIndex(0, Array.length(a) - 1, {i ->  a[i] = b[i]})
 
     ///
@@ -1158,7 +1158,7 @@ namespace String {
     /// If either `a` or `b` becomes depleted, then no further elements are added to the resulting array.
     ///
     @Time(Int32.min(length(a), length(b))) @Space(Int32.min(length(a), length(b)))
-    pub def zip(a: String, b: String): FooArray[(Char, Char)] & Impure =
+    pub def zip(a: String, b: String): UnscopedArray[(Char, Char)] & Impure =
         let len = Int32.min(length(a), length(b));
         Array.init(i -> (charAt(i, a), charAt(i, b)), len, static)
 

--- a/main/src/library/StringBuilder.flix
+++ b/main/src/library/StringBuilder.flix
@@ -76,19 +76,19 @@ namespace StringBuilder {
     ///
     /// Appends each string in the array `a` to the string builder `sb`.
     ///
-    pub def appendLines!(a: ScopedArray[String, r1], sb: StringBuilder[r2]): Unit \ { Read(r1), Write(r2) } =
+    pub def appendLines!(a: Array[String, r1], sb: StringBuilder[r2]): Unit \ { Read(r1), Write(r2) } =
         Array.foreach(x -> appendLine!(x, sb), a)
 
     ///
     /// Appends `f(x)` for each x in array `a` to the string builder `sb`.
     ///
-    pub def appendLinesWith!(f: a -> String & ef, a: ScopedArray[a, r1], sb: StringBuilder[r2]): Unit \ { ef, Read(r1), Write(r2) } =
+    pub def appendLinesWith!(f: a -> String & ef, a: Array[a, r1], sb: StringBuilder[r2]): Unit \ { ef, Read(r1), Write(r2) } =
         Array.foreach(x -> appendLineWith!(f, x, sb), a)
 
     ///
     /// Append the array of strings `a` separating each pair of string with `sep` to the StringBuilder `sb`.
     ///
-    pub def intercalate!(sep: String, a: ScopedArray[String, r1], sb: StringBuilder[r2]): Unit \ { Read(r1), Write(r2) } =
+    pub def intercalate!(sep: String, a: Array[String, r1], sb: StringBuilder[r2]): Unit \ { Read(r1), Write(r2) } =
         let append1! = (s,i) ->
             if (i > 0) {
                 appendString!(sep, sb);

--- a/main/src/library/ToString.flix
+++ b/main/src/library/ToString.flix
@@ -185,8 +185,8 @@ instance ToString[(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, 
     }
 }
 
-instance ToString[ScopedArray[a, false]] with ToString[a] {
-    pub def toString(a: ScopedArray[a, false]): String =
+instance ToString[Array[a, false]] with ToString[a] {
+    pub def toString(a: Array[a, false]): String =
         def loop(i, acc) =
             if (i < a.length) {
                 if (i == 0) loop(i + 1, "${a[i]}") as & Pure

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -408,13 +408,13 @@ namespace TestArray {
 
 @test
 def indices01(): Bool & Impure =
-    let a = Array.indices(0, []: Array[Int32]);
-    Array.sameElements(a, []: Array[Int32])
+    let a = Array.indices(0, []: FooArray[Int32]);
+    Array.sameElements(a, []: FooArray[Int32])
 
 @test
 def indices02(): Bool & Impure =
     let a = Array.indices(0, [1]);
-    Array.sameElements(a, []: Array[Int32])
+    Array.sameElements(a, []: FooArray[Int32])
 
 @test
 def indices03(): Bool & Impure =
@@ -424,7 +424,7 @@ def indices03(): Bool & Impure =
 @test
 def indices04(): Bool & Impure =
     let a = Array.indices(0, [1,2]);
-    Array.sameElements(a, []: Array[Int32])
+    Array.sameElements(a, []: FooArray[Int32])
 
 @test
 def indices05(): Bool & Impure =
@@ -956,12 +956,12 @@ def indices07(): Bool & Impure =
 @test
 def flatMap01(): Bool & Impure =
     let a = Array.flatMap(i -> Array.repeat(i, i, static), []);
-    Array.sameElements(a, []: Array[Int32])
+    Array.sameElements(a, []: FooArray[Int32])
 
 @test
 def flatMap02(): Bool & Impure =
     let a = Array.flatMap(i -> Array.repeat(i, i, static), [0]);
-    Array.sameElements(a, []: Array[Int32])
+    Array.sameElements(a, []: FooArray[Int32])
 
 @test
 def flatMap03(): Bool & Impure =
@@ -1780,22 +1780,22 @@ def flatMap06(): Bool & Impure =
 
     @test
     def intercalate01(): Bool & Impure = // crashes with regions
-        let a = Array.intercalate([]: Array[Int32], []: Array[Array[Int32]]);
-        Array.sameElements(a, []: Array[Int32])
+        let a = Array.intercalate([]: FooArray[Int32], []: FooArray[FooArray[Int32]]);
+        Array.sameElements(a, []: FooArray[Int32])
 
 @test
 def intercalate02(): Bool & Impure =
-    let a = Array.intercalate([]: Array[Int32], [[1]]);
+    let a = Array.intercalate([]: FooArray[Int32], [[1]]);
     Array.sameElements(a, [1])
 
     @test
     def intercalate03(): Bool & Impure = // crashes with regions
-        let a = Array.intercalate([11,12,13], []: Array[Array[Int32]]);
-        Array.sameElements(a, []: Array[Int32])
+        let a = Array.intercalate([11,12,13], []: FooArray[FooArray[Int32]]);
+        Array.sameElements(a, []: FooArray[Int32])
 
 @test
 def intercalate04(): Bool & Impure =
-    let a = Array.intercalate([]: Array[Int32], [[1],[2,3]]);
+    let a = Array.intercalate([]: FooArray[Int32], [[1],[2,3]]);
     Array.sameElements(a, [1,2,3])
 
 @test
@@ -1805,7 +1805,7 @@ def intercalate05(): Bool & Impure =
 
 @test
 def intercalate06(): Bool & Impure =
-    let a = Array.intercalate([]: Array[Int32], [[1],[2,3],[4]]);
+    let a = Array.intercalate([]: FooArray[Int32], [[1],[2,3],[4]]);
     Array.sameElements(a, [1,2,3,4])
 
 @test
@@ -2580,13 +2580,13 @@ def intercalate07(): Bool & Impure =
 
 @test
 def flatten01(): Bool & Impure =
-    let a = Array.flatten([]: Array[Array[Int32]]);
-    Array.sameElements(a, []: Array[Int32])
+    let a = Array.flatten([]: FooArray[FooArray[Int32]]);
+    Array.sameElements(a, []: FooArray[Int32])
 
 @test
 def flatten02(): Bool & Impure =
-    let a = Array.flatten([[]]: Array[Array[Int32]]);
-    Array.sameElements(a, []: Array[Int32])
+    let a = Array.flatten([[]]: FooArray[FooArray[Int32]]);
+    Array.sameElements(a, []: FooArray[Int32])
 
 @test
 def flatten03(): Bool & Impure =
@@ -2600,8 +2600,8 @@ def flatten04(): Bool & Impure =
 
 @test
 def flatten05(): Bool & Impure =
-    let a = Array.flatten([[],[]]: Array[Array[Int32]]);
-    Array.sameElements(a, []: Array[Int32])
+    let a = Array.flatten([[],[]]: FooArray[FooArray[Int32]]);
+    Array.sameElements(a, []: FooArray[Int32])
 
 @test
 def flatten06(): Bool & Impure =
@@ -4276,13 +4276,13 @@ def flatten10(): Bool & Impure =
 
 @test
 def findIndices01(): Bool & Impure =
-    let a = Array.findIndices(i -> i > 2, []: Array[Int32]);
-    Array.sameElements(a, []: Array[Int32])
+    let a = Array.findIndices(i -> i > 2, []: FooArray[Int32]);
+    Array.sameElements(a, []: FooArray[Int32])
 
 @test
 def findIndices02(): Bool & Impure =
     let a = Array.findIndices(i -> i > 2, [1]);
-    Array.sameElements(a, []: Array[Int32])
+    Array.sameElements(a, []: FooArray[Int32])
 
 @test
 def findIndices03(): Bool & Impure =
@@ -4292,7 +4292,7 @@ def findIndices03(): Bool & Impure =
 @test
 def findIndices04(): Bool & Impure =
     let a = Array.findIndices(i -> i > 2, [1,2]);
-    Array.sameElements(a, [] : Array[Int32])
+    Array.sameElements(a, [] : FooArray[Int32])
 
 @test
 def findIndices05(): Bool & Impure =
@@ -5640,7 +5640,7 @@ def findIndices07(): Bool & Impure =
 
     @test
     def toIterator01(): Bool & Impure =
-        []: Array[Int32] |> Array.toIterator |> Iterator.toList == Nil
+        []: FooArray[Int32] |> Array.toIterator |> Iterator.toList == Nil
 
     @test
     def toIterator02(): Bool & Impure =

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -408,13 +408,13 @@ namespace TestArray {
 
 @test
 def indices01(): Bool & Impure =
-    let a = Array.indices(0, []: FooArray[Int32]);
-    Array.sameElements(a, []: FooArray[Int32])
+    let a = Array.indices(0, []: UnscopedArray[Int32]);
+    Array.sameElements(a, []: UnscopedArray[Int32])
 
 @test
 def indices02(): Bool & Impure =
     let a = Array.indices(0, [1]);
-    Array.sameElements(a, []: FooArray[Int32])
+    Array.sameElements(a, []: UnscopedArray[Int32])
 
 @test
 def indices03(): Bool & Impure =
@@ -424,7 +424,7 @@ def indices03(): Bool & Impure =
 @test
 def indices04(): Bool & Impure =
     let a = Array.indices(0, [1,2]);
-    Array.sameElements(a, []: FooArray[Int32])
+    Array.sameElements(a, []: UnscopedArray[Int32])
 
 @test
 def indices05(): Bool & Impure =
@@ -956,12 +956,12 @@ def indices07(): Bool & Impure =
 @test
 def flatMap01(): Bool & Impure =
     let a = Array.flatMap(i -> Array.repeat(i, i, static), []);
-    Array.sameElements(a, []: FooArray[Int32])
+    Array.sameElements(a, []: UnscopedArray[Int32])
 
 @test
 def flatMap02(): Bool & Impure =
     let a = Array.flatMap(i -> Array.repeat(i, i, static), [0]);
-    Array.sameElements(a, []: FooArray[Int32])
+    Array.sameElements(a, []: UnscopedArray[Int32])
 
 @test
 def flatMap03(): Bool & Impure =
@@ -1780,22 +1780,22 @@ def flatMap06(): Bool & Impure =
 
     @test
     def intercalate01(): Bool & Impure = // crashes with regions
-        let a = Array.intercalate([]: FooArray[Int32], []: FooArray[FooArray[Int32]]);
-        Array.sameElements(a, []: FooArray[Int32])
+        let a = Array.intercalate([]: UnscopedArray[Int32], []: UnscopedArray[UnscopedArray[Int32]]);
+        Array.sameElements(a, []: UnscopedArray[Int32])
 
 @test
 def intercalate02(): Bool & Impure =
-    let a = Array.intercalate([]: FooArray[Int32], [[1]]);
+    let a = Array.intercalate([]: UnscopedArray[Int32], [[1]]);
     Array.sameElements(a, [1])
 
     @test
     def intercalate03(): Bool & Impure = // crashes with regions
-        let a = Array.intercalate([11,12,13], []: FooArray[FooArray[Int32]]);
-        Array.sameElements(a, []: FooArray[Int32])
+        let a = Array.intercalate([11,12,13], []: UnscopedArray[UnscopedArray[Int32]]);
+        Array.sameElements(a, []: UnscopedArray[Int32])
 
 @test
 def intercalate04(): Bool & Impure =
-    let a = Array.intercalate([]: FooArray[Int32], [[1],[2,3]]);
+    let a = Array.intercalate([]: UnscopedArray[Int32], [[1],[2,3]]);
     Array.sameElements(a, [1,2,3])
 
 @test
@@ -1805,7 +1805,7 @@ def intercalate05(): Bool & Impure =
 
 @test
 def intercalate06(): Bool & Impure =
-    let a = Array.intercalate([]: FooArray[Int32], [[1],[2,3],[4]]);
+    let a = Array.intercalate([]: UnscopedArray[Int32], [[1],[2,3],[4]]);
     Array.sameElements(a, [1,2,3,4])
 
 @test
@@ -2580,13 +2580,13 @@ def intercalate07(): Bool & Impure =
 
 @test
 def flatten01(): Bool & Impure =
-    let a = Array.flatten([]: FooArray[FooArray[Int32]]);
-    Array.sameElements(a, []: FooArray[Int32])
+    let a = Array.flatten([]: UnscopedArray[UnscopedArray[Int32]]);
+    Array.sameElements(a, []: UnscopedArray[Int32])
 
 @test
 def flatten02(): Bool & Impure =
-    let a = Array.flatten([[]]: FooArray[FooArray[Int32]]);
-    Array.sameElements(a, []: FooArray[Int32])
+    let a = Array.flatten([[]]: UnscopedArray[UnscopedArray[Int32]]);
+    Array.sameElements(a, []: UnscopedArray[Int32])
 
 @test
 def flatten03(): Bool & Impure =
@@ -2600,8 +2600,8 @@ def flatten04(): Bool & Impure =
 
 @test
 def flatten05(): Bool & Impure =
-    let a = Array.flatten([[],[]]: FooArray[FooArray[Int32]]);
-    Array.sameElements(a, []: FooArray[Int32])
+    let a = Array.flatten([[],[]]: UnscopedArray[UnscopedArray[Int32]]);
+    Array.sameElements(a, []: UnscopedArray[Int32])
 
 @test
 def flatten06(): Bool & Impure =
@@ -4276,13 +4276,13 @@ def flatten10(): Bool & Impure =
 
 @test
 def findIndices01(): Bool & Impure =
-    let a = Array.findIndices(i -> i > 2, []: FooArray[Int32]);
-    Array.sameElements(a, []: FooArray[Int32])
+    let a = Array.findIndices(i -> i > 2, []: UnscopedArray[Int32]);
+    Array.sameElements(a, []: UnscopedArray[Int32])
 
 @test
 def findIndices02(): Bool & Impure =
     let a = Array.findIndices(i -> i > 2, [1]);
-    Array.sameElements(a, []: FooArray[Int32])
+    Array.sameElements(a, []: UnscopedArray[Int32])
 
 @test
 def findIndices03(): Bool & Impure =
@@ -4292,7 +4292,7 @@ def findIndices03(): Bool & Impure =
 @test
 def findIndices04(): Bool & Impure =
     let a = Array.findIndices(i -> i > 2, [1,2]);
-    Array.sameElements(a, [] : FooArray[Int32])
+    Array.sameElements(a, [] : UnscopedArray[Int32])
 
 @test
 def findIndices05(): Bool & Impure =
@@ -5640,7 +5640,7 @@ def findIndices07(): Bool & Impure =
 
     @test
     def toIterator01(): Bool & Impure =
-        []: FooArray[Int32] |> Array.toIterator |> Iterator.toList == Nil
+        []: UnscopedArray[Int32] |> Array.toIterator |> Iterator.toList == Nil
 
     @test
     def toIterator02(): Bool & Impure =

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -138,7 +138,7 @@ namespace TestArray {
 
     @test
     def testToList01(): Bool = region r {
-        Array.toList([]: ScopedArray[Unit, _]) == Nil
+        Array.toList([]: Array[Unit, _]) == Nil
     }
 
     @test
@@ -157,7 +157,7 @@ namespace TestArray {
 
     @test
     def head01(): Bool = region r {
-        Array.head([]: ScopedArray[Int32, _]) == None
+        Array.head([]: Array[Int32, _]) == None
     }
 
     @test
@@ -205,31 +205,31 @@ namespace TestArray {
 
     @test
     def append01(): Bool = region r {
-        let a = Array.append([]: ScopedArray[Int32, _], []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.append([]: Array[Int32, _], []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def append02(): Bool = region r {
-        let a = Array.append([]: ScopedArray[Int32, _], [1]);
+        let a = Array.append([]: Array[Int32, _], [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def append03(): Bool = region r {
-        let a = Array.append([]: ScopedArray[Int32, _], [1,2]);
+        let a = Array.append([]: Array[Int32, _], [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def append04(): Bool = region r {
-        let a = Array.append([1], []: ScopedArray[Int32, _]);
+        let a = Array.append([1], []: Array[Int32, _]);
         Array.sameElements(a, [1])
     }
 
     @test
     def append05(): Bool = region r {
-        let a = Array.append([1,2], []: ScopedArray[Int32, _]);
+        let a = Array.append([1,2], []: Array[Int32, _]);
         Array.sameElements(a, [1,2])
     }
 
@@ -257,7 +257,7 @@ namespace TestArray {
 
     @test
     def memberOf01(): Bool = region r {
-        Array.memberOf(0, []: ScopedArray[Int32, _]) == false
+        Array.memberOf(0, []: Array[Int32, _]) == false
     }
 
     @test
@@ -296,7 +296,7 @@ namespace TestArray {
 
     @test
     def indexOf01(): Bool = region r {
-        Array.indexOf(0, []: ScopedArray[Int32, _]) == None
+        Array.indexOf(0, []: Array[Int32, _]) == None
     }
 
     @test
@@ -330,7 +330,7 @@ namespace TestArray {
 
     @test
     def indexOfLeft01(): Bool = region r {
-        Array.indexOfLeft(0, []: ScopedArray[Int32, _]) == None
+        Array.indexOfLeft(0, []: Array[Int32, _]) == None
     }
 
     @test
@@ -369,7 +369,7 @@ namespace TestArray {
 
     @test
     def indexOfRight01(): Bool = region r {
-        Array.indexOfRight(0, []: ScopedArray[Int32, _]) == None
+        Array.indexOfRight(0, []: Array[Int32, _]) == None
     }
 
     @test
@@ -565,13 +565,13 @@ def indices07(): Bool & Impure =
     @test
     def range01(): Bool = region r {
         let a = Array.range(1, 0, r);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def range02(): Bool = region r {
         let a = Array.range(1, 1, r);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -605,13 +605,13 @@ def indices07(): Bool & Impure =
     @test
     def repeat01(): Bool = region r {
         let a = Array.repeat(-1, 1, r);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def repeat02(): Bool = region r {
         let a = Array.repeat(0, 1, r);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -684,7 +684,7 @@ def indices07(): Bool & Impure =
 
     @test
     def scanLeft01(): Bool = region r {
-        let a = Array.scanLeft((i, b) -> if (b) i + 1 else i + 2, 1, []: ScopedArray[Bool, _]);
+        let a = Array.scanLeft((i, b) -> if (b) i + 1 else i + 2, 1, []: Array[Bool, _]);
         Array.sameElements(a, [1])
     }
 
@@ -777,7 +777,7 @@ def indices07(): Bool & Impure =
     @test
     def map01(): Bool = region r {
         let a = Array.map(i -> i > 2, []);
-        Array.sameElements(a, []: ScopedArray[Bool, _])
+        Array.sameElements(a, []: Array[Bool, _])
     }
 
     @test
@@ -822,9 +822,9 @@ def indices07(): Bool & Impure =
 
     @test
     def transform01!(): Bool = region r {
-        let a: ScopedArray[Int32, _] = [];
+        let a: Array[Int32, _] = [];
         Array.transform!(x -> x+1, a);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -855,7 +855,7 @@ def indices07(): Bool & Impure =
     @test
     def mapWithIndex01(): Bool = region r {
         let a = Array.mapWithIndex((e, i) -> if (i < 1) e > 2 else e <= 2, []);
-        Array.sameElements(a, []: ScopedArray[Bool, _])
+        Array.sameElements(a, []: Array[Bool, _])
     }
 
     @test
@@ -900,9 +900,9 @@ def indices07(): Bool & Impure =
 
     @test
     def transformWithIndex01!(): Bool = region r {
-        let a = []: ScopedArray[Int32, _];
+        let a = []: Array[Int32, _];
         Array.transformWithIndex!((e, i) -> if (i < 1) e + 10 else e, a);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -989,8 +989,8 @@ def flatMap06(): Bool & Impure =
 
     @test
     def reverse01(): Bool = region r {
-        let a = Array.reverse([]: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.reverse([]: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -1029,9 +1029,9 @@ def flatMap06(): Bool & Impure =
 
     @test
     def reverse01!(): Bool = region r {
-        let a: ScopedArray[Int32, _] = [];
+        let a: Array[Int32, _] = [];
         Array.reverse!(a);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -1075,14 +1075,14 @@ def flatMap06(): Bool & Impure =
 
     @test
     def rotateLeft01(): Bool = region r {
-        let a = Array.rotateLeft(0, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.rotateLeft(0, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def rotateLeft02(): Bool = region r {
-        let a = Array.rotateLeft(1, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.rotateLeft(1, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -1145,14 +1145,14 @@ def flatMap06(): Bool & Impure =
 
     @test
     def rotateRight01(): Bool = region r {
-        let a = Array.rotateRight(0, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.rotateRight(0, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def rotateRight02(): Bool = region r {
-        let a = Array.rotateRight(1, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.rotateRight(1, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -1215,8 +1215,8 @@ def flatMap06(): Bool & Impure =
 
     @test
     def update01(): Bool = region r {
-        let a = Array.update(0, 2, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.update(0, 2, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -1262,7 +1262,7 @@ def flatMap06(): Bool & Impure =
     @test
     def replace01(): Bool = region r {
         let a = Array.replace(from = 3, to = 4, []);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -1313,9 +1313,9 @@ def flatMap06(): Bool & Impure =
 
     @test
     def replace01!(): Bool = region r {
-        let a: ScopedArray[Int32, _] = [];
+        let a: Array[Int32, _] = [];
         Array.replace!(from = 3, to = 4, a);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -1373,14 +1373,14 @@ def flatMap06(): Bool & Impure =
 
     @test
     def patch01(): Bool = region r {
-        let a = Array.patch(0, 0, []: ScopedArray[Int32, _], []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.patch(0, 0, []: Array[Int32, _], []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def patch02(): Bool = region r {
         let a = Array.patch(0, 2, [1,2], []);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -1545,16 +1545,16 @@ def flatMap06(): Bool & Impure =
 
     @test
     def patch01!(): Bool = region r {
-        let a = []: ScopedArray[Int32, _];
-        Array.patch!(0, 0, []: ScopedArray[Int32, _], a);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = []: Array[Int32, _];
+        Array.patch!(0, 0, []: Array[Int32, _], a);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def patch02!(): Bool = region r {
-        let a = []: ScopedArray[Int32, _];
+        let a = []: Array[Int32, _];
         Array.patch!(0, 2, [1,2], a);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -1746,7 +1746,7 @@ def flatMap06(): Bool & Impure =
     @test
     def intersperse01(): Bool = region r {
         let a = Array.intersperse(11, []);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -1826,21 +1826,21 @@ def intercalate07(): Bool & Impure =
 
     @test
     def transpose02(): Bool = region r {
-        let a: ScopedArray[ScopedArray[Int32, _], _] = Array.transpose([[]]);
+        let a: Array[Array[Int32, _], _] = Array.transpose([[]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == Nil :: Nil
     }
 
     @test
     def transpose03(): Bool = region r {
-        let a: ScopedArray[ScopedArray[Int32, _], _] = Array.transpose([[], []]);
+        let a: Array[Array[Int32, _], _] = Array.transpose([[], []]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == Nil :: Nil :: Nil
     }
 
     @test
     def transpose04(): Bool = region r {
-        let a: ScopedArray[ScopedArray[Int32, _], _] = Array.transpose([[], [], []]);
+        let a: Array[Array[Int32, _], _] = Array.transpose([[], [], []]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == Nil :: Nil :: Nil :: Nil
     }
@@ -1977,17 +1977,17 @@ def intercalate07(): Bool & Impure =
 
     @test
     def isPrefixOf01(): Bool = region r {
-        Array.isPrefixOf([]: ScopedArray[Int32, _], []: ScopedArray[Int32, _])
+        Array.isPrefixOf([]: Array[Int32, _], []: Array[Int32, _])
     }
 
     @test
     def isPrefixOf02(): Bool = region r {
-        Array.isPrefixOf([1], []: ScopedArray[Int32, _]) == false
+        Array.isPrefixOf([1], []: Array[Int32, _]) == false
     }
 
     @test
     def isPrefixOf03(): Bool = region r {
-        Array.isPrefixOf([]: ScopedArray[Int32, _], [1])
+        Array.isPrefixOf([]: Array[Int32, _], [1])
     }
 
     @test
@@ -2007,7 +2007,7 @@ def intercalate07(): Bool & Impure =
 
     @test
     def isPrefixOf07(): Bool = region r {
-        Array.isPrefixOf([]: ScopedArray[Int32, _], [1,2])
+        Array.isPrefixOf([]: Array[Int32, _], [1,2])
     }
 
     @test
@@ -2046,17 +2046,17 @@ def intercalate07(): Bool & Impure =
 
     @test
     def isInfixOf01(): Bool = region r {
-        Array.isInfixOf([]: ScopedArray[Int32, _], []: ScopedArray[Int32, _])
+        Array.isInfixOf([]: Array[Int32, _], []: Array[Int32, _])
     }
 
     @test
     def isInfixOf02(): Bool = region r {
-        Array.isInfixOf([1], []: ScopedArray[Int32, _]) == false
+        Array.isInfixOf([1], []: Array[Int32, _]) == false
     }
 
     @test
     def isInfixOf03(): Bool = region r {
-        Array.isInfixOf([]: ScopedArray[Int32, _], [1])
+        Array.isInfixOf([]: Array[Int32, _], [1])
     }
 
     @test
@@ -2076,7 +2076,7 @@ def intercalate07(): Bool & Impure =
 
     @test
     def isInfixOf07(): Bool = region r {
-        Array.isInfixOf([]: ScopedArray[Int32, _], [1,2])
+        Array.isInfixOf([]: Array[Int32, _], [1,2])
     }
 
     @test
@@ -2115,17 +2115,17 @@ def intercalate07(): Bool & Impure =
 
     @test
     def isSuffixOf01(): Bool = region r {
-        Array.isSuffixOf([]: ScopedArray[Int32, _], []: ScopedArray[Int32, _])
+        Array.isSuffixOf([]: Array[Int32, _], []: Array[Int32, _])
     }
 
     @test
     def isSuffixOf02(): Bool = region r {
-        Array.isSuffixOf([1], []: ScopedArray[Int32, _]) == false
+        Array.isSuffixOf([1], []: Array[Int32, _]) == false
     }
 
     @test
     def isSuffixOf03(): Bool = region r {
-        Array.isSuffixOf([]: ScopedArray[Int32, _], [1])
+        Array.isSuffixOf([]: Array[Int32, _], [1])
     }
 
     @test
@@ -2145,7 +2145,7 @@ def intercalate07(): Bool & Impure =
 
     @test
     def isSuffixOf07(): Bool = region r {
-        Array.isSuffixOf([]: ScopedArray[Int32, _], [1,2])
+        Array.isSuffixOf([]: Array[Int32, _], [1,2])
     }
 
     @test
@@ -2184,7 +2184,7 @@ def intercalate07(): Bool & Impure =
 
     @test
     def testSameElements01(): Bool = region r {
-        ([]: ScopedArray[Int32, _]) `sameElements` ([]: ScopedArray[Int32, _])
+        ([]: Array[Int32, _]) `sameElements` ([]: Array[Int32, _])
     }
 
     @test
@@ -2228,7 +2228,7 @@ def intercalate07(): Bool & Impure =
 
     @test
     def testCompare01(): Bool = region r {
-        ([]: ScopedArray[Int32, _]) `Array.compare` ([]: ScopedArray[Int32, _]) == EqualTo
+        ([]: Array[Int32, _]) `Array.compare` ([]: Array[Int32, _]) == EqualTo
     }
 
     @test
@@ -2297,7 +2297,7 @@ def intercalate07(): Bool & Impure =
 
     @test
     def fold01(): Bool = region r {
-        Array.fold([]: ScopedArray[Unit, _]) == ()
+        Array.fold([]: Array[Unit, _]) == ()
     }
 
     @test
@@ -2412,7 +2412,7 @@ def intercalate07(): Bool & Impure =
 
     @test
     def reduceLeft01(): Bool = region r {
-        Array.reduceLeft((a, b) -> a - b, []: ScopedArray[Int32, _]) == None
+        Array.reduceLeft((a, b) -> a - b, []: Array[Int32, _]) == None
     }
 
     @test
@@ -2441,7 +2441,7 @@ def intercalate07(): Bool & Impure =
 
     @test
     def reduceRight01(): Bool = region r {
-        Array.reduceRight((a, b) -> a - b, []: ScopedArray[Int32, _]) == None
+        Array.reduceRight((a, b) -> a - b, []: Array[Int32, _]) == None
     }
 
     @test
@@ -2634,7 +2634,7 @@ def flatten10(): Bool & Impure =
 
     @test
     def exists01(): Bool = region r {
-        Array.exists(i -> i > 3, []: ScopedArray[Int32, _]) == false
+        Array.exists(i -> i > 3, []: Array[Int32, _]) == false
     }
 
     @test
@@ -2683,7 +2683,7 @@ def flatten10(): Bool & Impure =
 
     @test
     def forall01(): Bool = region r {
-        Array.forall(i -> i > 3, []: ScopedArray[Int32, _]) == true
+        Array.forall(i -> i > 3, []: Array[Int32, _]) == true
     }
 
     @test
@@ -2737,14 +2737,14 @@ def flatten10(): Bool & Impure =
 
     @test
     def filter01(): Bool = region r {
-        let a = Array.filter(i -> i > 3, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.filter(i -> i > 3, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def filter02(): Bool = region r {
         let a = Array.filter(i -> i > 3, [2]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -2756,7 +2756,7 @@ def flatten10(): Bool & Impure =
     @test
     def filter04(): Bool = region r {
         let a = Array.filter(i -> i > 3, [1,3]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -2789,26 +2789,26 @@ def flatten10(): Bool & Impure =
 
     @test
     def partition01(): Bool = region r {
-        let (a,b) = Array.partition(i -> i > 3, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _]) and Array.sameElements(b, []: ScopedArray[Int32, _])
+        let (a,b) = Array.partition(i -> i > 3, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _]) and Array.sameElements(b, []: Array[Int32, _])
     }
 
     @test
     def partition02(): Bool = region r {
         let (a,b) = Array.partition(i -> i > 3, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _]) and Array.sameElements(b, [1])
+        Array.sameElements(a, []: Array[Int32, _]) and Array.sameElements(b, [1])
     }
 
     @test
     def partition03(): Bool = region r {
         let (a,b) = Array.partition(i -> i > 3, [4]);
-        Array.sameElements(a, [4]) and Array.sameElements(b, []: ScopedArray[Int32, _])
+        Array.sameElements(a, [4]) and Array.sameElements(b, []: Array[Int32, _])
     }
 
     @test
     def partition04(): Bool = region r {
         let (a,b) = Array.partition(i -> i > 3, [1,2]);
-        Array.sameElements(a, []: ScopedArray[Int32, _]) and Array.sameElements(b, [1,2])
+        Array.sameElements(a, []: Array[Int32, _]) and Array.sameElements(b, [1,2])
     }
 
     @test
@@ -2826,7 +2826,7 @@ def flatten10(): Bool & Impure =
     @test
     def partition07(): Bool = region r {
         let (a,b) = Array.partition(i -> i > 3, [5,8]);
-        Array.sameElements(a, [5,8]) and Array.sameElements(b, []: ScopedArray[Int32, _])
+        Array.sameElements(a, [5,8]) and Array.sameElements(b, []: Array[Int32, _])
     }
 
     @test
@@ -2841,32 +2841,32 @@ def flatten10(): Bool & Impure =
 
     @test
     def span01(): Bool = region r {
-        let (a,b) = Array.span(i -> i > 3, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _]) and Array.sameElements(b, []: ScopedArray[Int32, _])
+        let (a,b) = Array.span(i -> i > 3, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _]) and Array.sameElements(b, []: Array[Int32, _])
     }
 
     @test
     def span02(): Bool = region r {
         let (a,b) = Array.span(i -> i > 3, [1]);
-        Array.sameElements(a,[]: ScopedArray[Int32, _]) and Array.sameElements(b, [1])
+        Array.sameElements(a,[]: Array[Int32, _]) and Array.sameElements(b, [1])
     }
 
     @test
     def span03(): Bool = region r {
         let (a,b) = Array.span(i -> i > 3, [4]);
-        Array.sameElements(a, [4]) and Array.sameElements(b, []: ScopedArray[Int32, _])
+        Array.sameElements(a, [4]) and Array.sameElements(b, []: Array[Int32, _])
     }
 
     @test
     def span04(): Bool = region r {
         let (a,b) = Array.span(i -> i > 3, [1,2]);
-        Array.sameElements(a, []: ScopedArray[Int32, _]) and Array.sameElements(b, [1,2])
+        Array.sameElements(a, []: Array[Int32, _]) and Array.sameElements(b, [1,2])
     }
 
     @test
     def span05(): Bool = region r {
         let (a,b) = Array.span(i -> i > 3, [1,5]);
-        Array.sameElements(a, []: ScopedArray[Int32, _]) and Array.sameElements(b, [1,5])
+        Array.sameElements(a, []: Array[Int32, _]) and Array.sameElements(b, [1,5])
     }
 
     @test
@@ -2878,7 +2878,7 @@ def flatten10(): Bool & Impure =
     @test
     def span07(): Bool = region r {
         let (a,b) = Array.span(i -> i > 3, [5,8]);
-        Array.sameElements(a, [5,8]) and Array.sameElements(b, []: ScopedArray[Int32, _])
+        Array.sameElements(a, [5,8]) and Array.sameElements(b, []: Array[Int32, _])
     }
 
     @test
@@ -2893,20 +2893,20 @@ def flatten10(): Bool & Impure =
 
     @test
     def drop01(): Bool = region r {
-        let a = Array.drop(-1, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.drop(-1, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def drop02(): Bool = region r {
-        let a = Array.drop(0, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.drop(0, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def drop03(): Bool = region r {
-        let a = Array.drop(1, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.drop(1, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -2924,13 +2924,13 @@ def flatten10(): Bool & Impure =
     @test
     def drop06(): Bool = region r {
         let a = Array.drop(1, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def drop07(): Bool = region r {
         let a = Array.drop(2, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -2948,7 +2948,7 @@ def flatten10(): Bool & Impure =
     @test
     def drop10(): Bool = region r {
         let a = Array.drop(2, [1,2]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -2969,20 +2969,20 @@ def flatten10(): Bool & Impure =
 
     @test
     def dropLeft01(): Bool = region r {
-        let a = Array.dropLeft(-1, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.dropLeft(-1, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropLeft02(): Bool = region r {
-        let a = Array.dropLeft(0, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.dropLeft(0, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropLeft03(): Bool = region r {
-        let a = Array.dropLeft(1, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.dropLeft(1, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3000,13 +3000,13 @@ def flatten10(): Bool & Impure =
     @test
     def dropLeft06(): Bool = region r {
         let a = Array.dropLeft(1, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropLeft07(): Bool = region r {
         let a = Array.dropLeft(2, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3024,7 +3024,7 @@ def flatten10(): Bool & Impure =
     @test
     def dropLeft10(): Bool = region r {
         let a = Array.dropLeft(2, [1,2]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3045,20 +3045,20 @@ def flatten10(): Bool & Impure =
 
     @test
     def dropRight01(): Bool = region r {
-        let a = Array.dropRight(-1, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.dropRight(-1, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropRight02(): Bool = region r {
-        let a = Array.dropRight(0, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.dropRight(0, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropRight03(): Bool = region r {
-        let a = Array.dropRight(1, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.dropRight(1, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3076,13 +3076,13 @@ def flatten10(): Bool & Impure =
     @test
     def dropRight06(): Bool = region r {
         let a = Array.dropRight(1, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropRight07(): Bool = region r {
         let a = Array.dropRight(2, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3100,7 +3100,7 @@ def flatten10(): Bool & Impure =
     @test
     def dropRight10(): Bool = region r {
         let a = Array.dropRight(2, [1,2]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3122,7 +3122,7 @@ def flatten10(): Bool & Impure =
     @test
     def dropWhile01(): Bool = region r {
         let a = Array.dropWhile(i -> i > 3, []);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3134,7 +3134,7 @@ def flatten10(): Bool & Impure =
     @test
     def dropWhile03(): Bool = region r {
         let a = Array.dropWhile(i -> i > 3, [4]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3158,7 +3158,7 @@ def flatten10(): Bool & Impure =
     @test
     def dropWhile07(): Bool = region r {
         let a = Array.dropWhile(i -> i > 3, [5,8]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3174,7 +3174,7 @@ def flatten10(): Bool & Impure =
     @test
     def dropWhileLeft01(): Bool = region r {
         let a = Array.dropWhileLeft(i -> i > 3, []);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3186,7 +3186,7 @@ def flatten10(): Bool & Impure =
     @test
     def dropWhileLeft03(): Bool = region r {
         let a = Array.dropWhileLeft(i -> i > 3, [4]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3210,7 +3210,7 @@ def flatten10(): Bool & Impure =
     @test
     def dropWhileLeft07(): Bool = region r {
         let a = Array.dropWhileLeft(i -> i > 3, [5,8]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3226,7 +3226,7 @@ def flatten10(): Bool & Impure =
     @test
     def dropWhileRight01(): Bool = region r {
         let a = Array.dropWhileRight(i -> i > 3, []);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3238,7 +3238,7 @@ def flatten10(): Bool & Impure =
     @test
     def dropWhileRight03(): Bool = region r {
         let a = Array.dropWhileRight(i -> i > 3, [4]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3262,7 +3262,7 @@ def flatten10(): Bool & Impure =
     @test
     def dropWhileRight07(): Bool = region r {
         let a = Array.dropWhileRight(i -> i > 3, [5,8]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3277,32 +3277,32 @@ def flatten10(): Bool & Impure =
 
     @test
     def take01(): Bool = region r {
-        let a = Array.take(-1, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.take(-1, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def take02(): Bool = region r {
-        let a = Array.take(0, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.take(0, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def take03(): Bool = region r {
-        let a = Array.take(1, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.take(1, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def take04(): Bool = region r {
         let a = Array.take(-1, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def take05(): Bool = region r {
         let a = Array.take(0, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
 
     }
     @test
@@ -3320,7 +3320,7 @@ def flatten10(): Bool & Impure =
     @test
     def take08(): Bool = region r {
         let a = Array.take(0, [1,2]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3353,32 +3353,32 @@ def flatten10(): Bool & Impure =
 
     @test
     def takeLeft01(): Bool = region r {
-        let a = Array.takeLeft(-1, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.takeLeft(-1, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeLeft02(): Bool = region r {
-        let a = Array.takeLeft(0, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.takeLeft(0, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeLeft03(): Bool = region r {
-        let a = Array.takeLeft(1, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.takeLeft(1, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeLeft04(): Bool = region r {
         let a = Array.takeLeft(-1, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeLeft05(): Bool = region r {
         let a = Array.takeLeft(0, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3396,7 +3396,7 @@ def flatten10(): Bool & Impure =
     @test
     def takeLeft08(): Bool = region r {
         let a = Array.takeLeft(0, [1,2]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3429,32 +3429,32 @@ def flatten10(): Bool & Impure =
 
     @test
     def takeRight01(): Bool = region r {
-        let a = Array.takeRight(-1, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.takeRight(-1, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeRight02(): Bool = region r {
-        let a = Array.takeRight(0, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.takeRight(0, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeRight03(): Bool = region r {
-        let a = Array.takeRight(1, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.takeRight(1, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeRight04(): Bool = region r {
         let a = Array.takeRight(-1, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeRight05(): Bool = region r {
         let a = Array.takeRight(0, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3472,7 +3472,7 @@ def flatten10(): Bool & Impure =
     @test
     def takeRight08(): Bool = region r {
         let a = Array.takeRight(0, [1,2]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3505,14 +3505,14 @@ def flatten10(): Bool & Impure =
 
     @test
     def takeWhile01(): Bool = region r {
-        let a = Array.takeWhile(i -> i > 3, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.takeWhile(i -> i > 3, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhile02(): Bool = region r {
         let a = Array.takeWhile(i -> i > 3, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3524,13 +3524,13 @@ def flatten10(): Bool & Impure =
     @test
     def takeWhile04(): Bool = region r {
         let a = Array.takeWhile(i -> i > 3, [1,2]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhile05(): Bool = region r {
         let a = Array.takeWhile(i -> i > 3, [1,5]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3557,14 +3557,14 @@ def flatten10(): Bool & Impure =
 
     @test
     def takeWhileLeft01(): Bool = region r {
-        let a = Array.takeWhileLeft(i -> i > 3, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.takeWhileLeft(i -> i > 3, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhileLeft02(): Bool = region r {
         let a = Array.takeWhileLeft(i -> i > 3, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3576,13 +3576,13 @@ def flatten10(): Bool & Impure =
     @test
     def takeWhileLeft04(): Bool = region r {
         let a = Array.takeWhileLeft(i -> i > 3, [1,2]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhileLeft05(): Bool = region r {
         let a = Array.takeWhileLeft(i -> i > 3, [1,5]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3609,14 +3609,14 @@ def flatten10(): Bool & Impure =
 
     @test
     def takeWhileRight01(): Bool = region r {
-        let a = Array.takeWhileRight(i -> i > 3, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.takeWhileRight(i -> i > 3, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhileRight02(): Bool = region r {
         let a = Array.takeWhileRight(i -> i > 3, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3628,7 +3628,7 @@ def flatten10(): Bool & Impure =
     @test
     def takeWhileRight04(): Bool = region r {
         let a = Array.takeWhileRight(i -> i > 3, [1,2]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3640,7 +3640,7 @@ def flatten10(): Bool & Impure =
     @test
     def takeWhileRight06(): Bool = region r {
         let a = Array.takeWhileRight(i -> i > 3, [5,1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -3661,7 +3661,7 @@ def flatten10(): Bool & Impure =
 
     @test
     def groupBy01(): Bool = region r {
-        let arr = Array.groupBy((a, b) -> a > 3 or b > 8, []: ScopedArray[Int32, _], r);
+        let arr = Array.groupBy((a, b) -> a > 3 or b > 8, []: Array[Int32, _], r);
         let xs = Array.toList(arr) |> List.map(Array.toList);
         xs == Nil
     }
@@ -3714,20 +3714,20 @@ def flatten10(): Bool & Impure =
 
     @test
     def zip01(): Bool = region r {
-        let a = Array.zip([]: ScopedArray[Int32, _], []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[(Int32, Int32), _])
+        let a = Array.zip([]: Array[Int32, _], []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[(Int32, Int32), _])
     }
 
     @test
     def zip02(): Bool = region r {
-        let a = Array.zip([1], []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[(Int32, Int32), _])
+        let a = Array.zip([1], []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[(Int32, Int32), _])
     }
 
     @test
     def zip03(): Bool = region r {
-        let a = Array.zip([]: ScopedArray[Int32, _], [2]);
-        Array.sameElements(a, []: ScopedArray[(Int32, Int32), _])
+        let a = Array.zip([]: Array[Int32, _], [2]);
+        Array.sameElements(a, []: Array[(Int32, Int32), _])
     }
 
     @test
@@ -3760,20 +3760,20 @@ def flatten10(): Bool & Impure =
 
     @test
     def zipWith01(): Bool = region r {
-        let arr = Array.zipWith((a, b) -> if (b) a + 1 else a, []: ScopedArray[Int32, _], []: ScopedArray[Bool, _]);
-        Array.sameElements(arr, []: ScopedArray[Int32, _])
+        let arr = Array.zipWith((a, b) -> if (b) a + 1 else a, []: Array[Int32, _], []: Array[Bool, _]);
+        Array.sameElements(arr, []: Array[Int32, _])
     }
 
     @test
     def zipWith02(): Bool = region r {
-        let arr = Array.zipWith((a, b) -> if (b) a + 1 else a, [1], []: ScopedArray[Bool, _]);
-        Array.sameElements(arr, []: ScopedArray[Int32, _])
+        let arr = Array.zipWith((a, b) -> if (b) a + 1 else a, [1], []: Array[Bool, _]);
+        Array.sameElements(arr, []: Array[Int32, _])
     }
 
     @test
     def zipWith03(): Bool = region r {
-        let arr = Array.zipWith((a, b) -> if (b) a + 1 else a, []: ScopedArray[Int32, _], [true]);
-        Array.sameElements(arr, []: ScopedArray[Int32, _])
+        let arr = Array.zipWith((a, b) -> if (b) a + 1 else a, []: Array[Int32, _], [true]);
+        Array.sameElements(arr, []: Array[Int32, _])
     }
 
     @test
@@ -3802,7 +3802,7 @@ def flatten10(): Bool & Impure =
 
     @test
     def unzip01(): Bool = region r {
-        let (a,b) = Array.unzip([]: ScopedArray[(Unit, Unit), _]);
+        let (a,b) = Array.unzip([]: Array[(Unit, Unit), _]);
         Array.sameElements(a, []) and Array.sameElements(b, [])
     }
 
@@ -3830,7 +3830,7 @@ def flatten10(): Bool & Impure =
 
     @test
     def fold201(): Bool = region r {
-        Array.fold2((c, a, b) -> if (b) a + c else a * c, 4, []: ScopedArray[Int32, _], []: ScopedArray[Bool, _]) == 4
+        Array.fold2((c, a, b) -> if (b) a + c else a * c, 4, []: Array[Int32, _], []: Array[Bool, _]) == 4
     }
 
     @test
@@ -3885,17 +3885,17 @@ def flatten10(): Bool & Impure =
 
     @test
     def foldLeft201(): Bool = region r {
-        Array.foldLeft2((c, a, b) -> if (b) a + c else a * c, 4, []: ScopedArray[Int32, _], []: ScopedArray[Bool, _]) == 4
+        Array.foldLeft2((c, a, b) -> if (b) a + c else a * c, 4, []: Array[Int32, _], []: Array[Bool, _]) == 4
     }
 
     @test
     def foldLeft202(): Bool = region r {
-        Array.foldLeft2((c, a, b) -> if (b) a + c else a * c, 4, [1], []: ScopedArray[Bool, _]) == 4
+        Array.foldLeft2((c, a, b) -> if (b) a + c else a * c, 4, [1], []: Array[Bool, _]) == 4
     }
 
     @test
     def foldLeft203(): Bool = region r {
-        Array.foldLeft2((c, a, b) -> if (b) a + c else a * c, 4, []: ScopedArray[Int32, _], [true]) == 4
+        Array.foldLeft2((c, a, b) -> if (b) a + c else a * c, 4, []: Array[Int32, _], [true]) == 4
     }
 
     @test
@@ -3940,17 +3940,17 @@ def flatten10(): Bool & Impure =
 
     @test
     def foldRight201(): Bool = region r {
-        Array.foldRight2((a, b, c) -> if (b) a + c else a * c, 4, []: ScopedArray[Int32, _], []: ScopedArray[Bool, _]) == 4
+        Array.foldRight2((a, b, c) -> if (b) a + c else a * c, 4, []: Array[Int32, _], []: Array[Bool, _]) == 4
     }
 
     @test
     def foldRight202(): Bool = region r {
-        Array.foldRight2((a, b, c) -> if (b) a + c else a * c, 4, [1], []: ScopedArray[Bool, _]) == 4
+        Array.foldRight2((a, b, c) -> if (b) a + c else a * c, 4, [1], []: Array[Bool, _]) == 4
     }
 
     @test
     def foldRight203(): Bool = region r {
-        Array.foldRight2((a, b, c) -> if (b) a + c else a * c, 4, []: ScopedArray[Int32, _], [true]) == 4
+        Array.foldRight2((a, b, c) -> if (b) a + c else a * c, 4, []: Array[Int32, _], [true]) == 4
     }
 
     @test
@@ -3995,14 +3995,14 @@ def flatten10(): Bool & Impure =
 
     @test
     def filterMap01(): Bool = region r {
-        let a = Array.filterMap(i -> if (i rem 2 == 0) Some(i/2) else None, []: ScopedArray[Int32, _]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        let a = Array.filterMap(i -> if (i rem 2 == 0) Some(i/2) else None, []: Array[Int32, _]);
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def filterMap02(): Bool = region r {
         let a = Array.filterMap(i -> if (i rem 2 == 0) Some(i/2) else None, [1]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -4014,7 +4014,7 @@ def flatten10(): Bool & Impure =
     @test
     def filterMap04(): Bool = region r {
         let a = Array.filterMap(i -> if (i rem 2 == 0) Some(i/2) else None, [1,3]);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -4047,7 +4047,7 @@ def flatten10(): Bool & Impure =
 
     @test
     def findMap01(): Bool = region r {
-        Array.findMap(i -> if (i rem 2 == 0) Some(i/2) else None, []: ScopedArray[Int32, _]) == None
+        Array.findMap(i -> if (i rem 2 == 0) Some(i/2) else None, []: Array[Int32, _]) == None
     }
 
     @test
@@ -4091,7 +4091,7 @@ def flatten10(): Bool & Impure =
 
     @test
     def toSet01(): Bool = region r {
-        Array.toSet([]: ScopedArray[Int32, _]) == Set#{}
+        Array.toSet([]: Array[Int32, _]) == Set#{}
     }
 
     @test
@@ -4135,7 +4135,7 @@ def flatten10(): Bool & Impure =
 
     @test
     def toMap01(): Bool = region r {
-        Array.toMap([]: ScopedArray[(Int32, Bool), _]) == Map#{}
+        Array.toMap([]: Array[(Int32, Bool), _]) == Map#{}
     }
 
     @test
@@ -4159,7 +4159,7 @@ def flatten10(): Bool & Impure =
 
     @test
     def findIndexOf01(): Bool = region r {
-        Array.findIndexOf(i -> i > 2, []: ScopedArray[Int32, _]) == None
+        Array.findIndexOf(i -> i > 2, []: Array[Int32, _]) == None
     }
 
     @test
@@ -4198,7 +4198,7 @@ def flatten10(): Bool & Impure =
 
     @test
     def findIndexOfLeft01(): Bool = region r {
-        Array.findIndexOfLeft(i -> i > 2, []: ScopedArray[Int32, _]) == None
+        Array.findIndexOfLeft(i -> i > 2, []: Array[Int32, _]) == None
     }
 
     @test
@@ -4237,7 +4237,7 @@ def flatten10(): Bool & Impure =
 
     @test
     def findIndexOfRight01(): Bool = region r {
-        Array.findIndexOfRight(i -> i > 2, []: ScopedArray[Int32, _]) == None
+        Array.findIndexOfRight(i -> i > 2, []: Array[Int32, _]) == None
     }
 
     @test
@@ -4316,13 +4316,13 @@ def findIndices07(): Bool & Impure =
     @test
     def init01(): Bool = region r {
         let a = Array.init(x -> x, 0, r);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def init02(): Bool = region r {
         let a = Array.init(x -> x, -1, r);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -4350,13 +4350,13 @@ def findIndices07(): Bool & Impure =
     @test
     def init201(): Bool = region r {
         let (a,b) = Array.init2(x -> (x, true), 0, r, r);
-        Array.sameElements(a, []: ScopedArray[Int32, _]) and Array.sameElements(b, []: ScopedArray[Bool, _])
+        Array.sameElements(a, []: Array[Int32, _]) and Array.sameElements(b, []: Array[Bool, _])
     }
 
     @test
     def init202(): Bool = region r {
         let (a,b) = Array.init2(x -> (x, true), -1, r, r);
-        Array.sameElements(a, []: ScopedArray[Int32, _]) and Array.sameElements(b, []: ScopedArray[Bool, _])
+        Array.sameElements(a, []: Array[Int32, _]) and Array.sameElements(b, []: Array[Bool, _])
     }
 
     @test
@@ -4384,50 +4384,50 @@ def findIndices07(): Bool & Impure =
 
     @test
     def sameElements01(): Bool = region r {
-        let a = []: ScopedArray[Int32, _];
-        let b = []: ScopedArray[Int32, _];
+        let a = []: Array[Int32, _];
+        let b = []: Array[Int32, _];
         Array.sameElements(a,b) == true
     }
 
     @test
     def sameElements02(): Bool = region r {
-        let a = [1]: ScopedArray[Int32, _];
-        let b = []: ScopedArray[Int32, _];
+        let a = [1]: Array[Int32, _];
+        let b = []: Array[Int32, _];
         Array.sameElements(a,b) == false
     }
 
     @test
     def sameElements03(): Bool = region r {
-        let a = []: ScopedArray[Int32, _];
-        let b = [1]: ScopedArray[Int32, _];
+        let a = []: Array[Int32, _];
+        let b = [1]: Array[Int32, _];
         Array.sameElements(a,b) == false
     }
 
     @test
     def sameElements04(): Bool = region r {
-        let a = [1]: ScopedArray[Int32, _];
-        let b = [1]: ScopedArray[Int32, _];
+        let a = [1]: Array[Int32, _];
+        let b = [1]: Array[Int32, _];
         Array.sameElements(a,b) == true
     }
 
     @test
     def sameElements05(): Bool = region r {
-        let a = [1]: ScopedArray[Int32, _];
-        let b = [0]: ScopedArray[Int32, _];
+        let a = [1]: Array[Int32, _];
+        let b = [0]: Array[Int32, _];
         Array.sameElements(a,b) == false
     }
 
     @test
     def sameElements06(): Bool = region r {
-        let a = [1,2]: ScopedArray[Int32, _];
-        let b = [1,2]: ScopedArray[Int32, _];
+        let a = [1,2]: Array[Int32, _];
+        let b = [1,2]: Array[Int32, _];
         Array.sameElements(a,b) == true
     }
 
     @test
     def sameElements07(): Bool = region r {
-        let a = [1,2]: ScopedArray[Int32, _];
-        let b = [2,1]: ScopedArray[Int32, _];
+        let a = [1,2]: Array[Int32, _];
+        let b = [2,1]: Array[Int32, _];
         Array.sameElements(a,b) == false
     }
 
@@ -4437,7 +4437,7 @@ def findIndices07(): Bool & Impure =
 
     @test
     def foreach01(): Bool = region r {
-        let a = []: ScopedArray[Int32, _];
+        let a = []: Array[Int32, _];
         let sb = new StringBuilder(r);
         let fn = x -> if (x > 0) StringBuilder.append!('T', sb) else StringBuilder.append!('F', sb);
         Array.foreach(fn, a);
@@ -4477,7 +4477,7 @@ def findIndices07(): Bool & Impure =
 
     @test
     def foreachWithIndex01(): Bool = region r {
-        let a = []: ScopedArray[Float32, _];
+        let a = []: Array[Float32, _];
         let sb = new StringBuilder(r);
         let fn = (_,ix) -> if (ix > 0) StringBuilder.append!('T', sb) else StringBuilder.append!('F', sb);
         Array.foreachWithIndex(fn, a);
@@ -4526,14 +4526,14 @@ def findIndices07(): Bool & Impure =
 
     @test
     def updateSequence01(): Bool = region r {
-         let a = Array.updateSequence(0, []: ScopedArray[Int32, _], []: ScopedArray[Int32, _]);
-         Array.sameElements(a, []: ScopedArray[Int32, _])
+         let a = Array.updateSequence(0, []: Array[Int32, _], []: Array[Int32, _]);
+         Array.sameElements(a, []: Array[Int32, _])
      }
 
     @test
     def updateSequence02(): Bool = region r {
         let a = Array.updateSequence(0, [1,2], []);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -4698,16 +4698,16 @@ def findIndices07(): Bool & Impure =
 
     @test
     def updateSequence01!(): Bool = region r {
-         let a = []: ScopedArray[Int32, _];
-         Array.updateSequence!(0, []: ScopedArray[Int32, _], a);
-         Array.sameElements(a, []: ScopedArray[Int32, _])
+         let a = []: Array[Int32, _];
+         Array.updateSequence!(0, []: Array[Int32, _], a);
+         Array.sameElements(a, []: Array[Int32, _])
      }
 
     @test
     def updateSequence02!(): Bool = region r {
-        let a = []: ScopedArray[Int32, _];
+        let a = []: Array[Int32, _];
         Array.updateSequence!(0, [1,2], a);
-        Array.sameElements(a, []: ScopedArray[Int32, _])
+        Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
@@ -4904,8 +4904,8 @@ def findIndices07(): Bool & Impure =
 
     @test
     def sortWith01(): Bool = region r {
-        let a = Array.sortWith(cmp, []: ScopedArray[Int32, _]);
-        a `sameElements` []: ScopedArray[Int32, _]
+        let a = Array.sortWith(cmp, []: Array[Int32, _]);
+        a `sameElements` []: Array[Int32, _]
     }
 
     @test
@@ -4984,12 +4984,12 @@ def findIndices07(): Bool & Impure =
     // sort                                                                    //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortVsSortWith(a: ScopedArray[Int32, r]): Bool \ { Read(r), Write(r) } =
+    def testSortVsSortWith(a: Array[Int32, r]): Bool \ { Read(r), Write(r) } =
         Array.sort(a) `sameElements` Array.sortWith(cmp, a)
 
     @test
     def sort01(): Bool = region r {
-        testSortVsSortWith([]: ScopedArray[Int32, _])
+        testSortVsSortWith([]: Array[Int32, _])
     }
 
     @test
@@ -5038,9 +5038,9 @@ def findIndices07(): Bool & Impure =
 
     @test
     def sortWith01!(): Bool = region r {
-        let a = []: ScopedArray[Int32, _];
+        let a = []: Array[Int32, _];
         Array.sortWith(cmp, a);
-        a `sameElements` []: ScopedArray[Int32, _]
+        a `sameElements` []: Array[Int32, _]
     }
 
     @test
@@ -5131,7 +5131,7 @@ def findIndices07(): Bool & Impure =
     // sort!                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSort!VsSortWith!(a: ScopedArray[Int32, r]): Bool \ { Read(r), Write(r) } =
+    def testSort!VsSortWith!(a: Array[Int32, r]): Bool \ { Read(r), Write(r) } =
         let b = Array.slice(0, Array.length(a), a);
         let c = Array.slice(0, Array.length(a), a);
         Array.sort!(b);
@@ -5140,7 +5140,7 @@ def findIndices07(): Bool & Impure =
 
     @test
     def sort!01(): Bool = region r {
-        testSort!VsSortWith!([]: ScopedArray[Int32, _])
+        testSort!VsSortWith!([]: Array[Int32, _])
     }
 
     @test
@@ -5187,14 +5187,14 @@ def findIndices07(): Bool & Impure =
     // sortBy                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortByVsSort(a: ScopedArray[Int32, r]): Bool \ { Read(r), Write(r) } =
+    def testSortByVsSort(a: Array[Int32, r]): Bool \ { Read(r), Write(r) } =
         (Array.sortBy(identity, a) `sameElements` Array.sort(a)) and
         (Array.sortBy(x -> 4 * x + 7, a) `sameElements` Array.sort(a)) and
         (Array.sortBy(x -> -x, a) `sameElements` Array.sortWith(flip(cmp),a))
 
     @test
     def sortBy01(): Bool = region r {
-        testSortByVsSort([]: ScopedArray[Int32, _])
+        testSortByVsSort([]: Array[Int32, _])
     }
 
     @test
@@ -5258,7 +5258,7 @@ def findIndices07(): Bool & Impure =
     // sortBy!                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortBy!VsSortBy(a: ScopedArray[Int32, r]) : Bool \ { Read(r), Write(r) } =
+    def testSortBy!VsSortBy(a: Array[Int32, r]) : Bool \ { Read(r), Write(r) } =
         let b = Array.slice(0, Array.length(a), a);
         let c = Array.slice(0, Array.length(a), a);
         Array.sortBy!(identity, b);
@@ -5268,7 +5268,7 @@ def findIndices07(): Bool & Impure =
 
     @test
     def sortBy!01(): Bool = region r {
-        testSortBy!VsSortBy([]: ScopedArray[Int32, _])
+        testSortBy!VsSortBy([]: Array[Int32, _])
     }
 
     @test
@@ -5317,7 +5317,7 @@ def findIndices07(): Bool & Impure =
 
     @test
     def minimumBy01(): Bool = region r {
-        Array.minimumBy((x, y) -> x <=> y, []: ScopedArray[Int32, _]) == None
+        Array.minimumBy((x, y) -> x <=> y, []: Array[Int32, _]) == None
     }
 
     @test
@@ -5343,7 +5343,7 @@ def findIndices07(): Bool & Impure =
 
     @test
     def maximumBy01(): Bool = region r {
-        Array.maximumBy((x, y) -> x <=> y, []: ScopedArray[Int32, _]) == None
+        Array.maximumBy((x, y) -> x <=> y, []: Array[Int32, _]) == None
     }
 
     @test
@@ -5444,7 +5444,7 @@ def findIndices07(): Bool & Impure =
 
     @test
     def toDelayList01(): Bool = region r {
-        ([] @ r): ScopedArray[Unit, _] |> Array.toDelayList == DelayList.empty()
+        ([] @ r): Array[Unit, _] |> Array.toDelayList == DelayList.empty()
     }
 
     @test
@@ -5468,7 +5468,7 @@ def findIndices07(): Bool & Impure =
 
     @test
     def toChain01(): Bool = region r {
-        Array.toChain([]: ScopedArray[Unit, _]) == Chain.empty(): Chain[Unit]
+        Array.toChain([]: Array[Unit, _]) == Chain.empty(): Chain[Unit]
     }
 
     @test
@@ -5671,7 +5671,7 @@ def findIndices07(): Bool & Impure =
 
     @test
     def join01(): Bool = region r {
-        Array.join(",", ([] @ r): ScopedArray[Int32, _]) == ""
+        Array.join(",", ([] @ r): Array[Int32, _]) == ""
     }
 
     @test
@@ -5716,7 +5716,7 @@ def findIndices07(): Bool & Impure =
 
     @test
     def joinWith05(): Bool = region r {
-        let a: ScopedArray[Int32, _] = [] @ r;
+        let a: Array[Int32, _] = [] @ r;
         let s = Array.joinWith(Int32.toString, ",", a);
         s == ""
     }
@@ -5763,7 +5763,7 @@ def findIndices07(): Bool & Impure =
 
     @test
     def toMutList01(): Bool = region r {
-        MutList.sameElements(Array.toMutList(([] @ r): ScopedArray[Int32, _], r), new MutList(r))
+        MutList.sameElements(Array.toMutList(([] @ r): Array[Int32, _], r), new MutList(r))
     }
 
     @test

--- a/main/test/ca/uwaterloo/flix/library/TestMutList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutList.flix
@@ -1815,7 +1815,7 @@ namespace TestMutList {
 
     @test
     def sortWith01(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList(([] @ r): ScopedArray[Int32, _], r));
+        let a = MutList.sortWith(cmp, Array.toMutList(([] @ r): Array[Int32, _], r));
         a `sameElements` Array.toMutList([] @ r, r)
     }
 
@@ -1901,7 +1901,7 @@ namespace TestMutList {
 
     @test
     def sort01(): Bool = region r {
-        testSortVsSortWith(Array.toMutList([]: ScopedArray[Int32, _], r))
+        testSortVsSortWith(Array.toMutList([]: Array[Int32, _], r))
     }
 
     @test
@@ -1950,9 +1950,9 @@ namespace TestMutList {
 
     @test
     def sortWith01!(): Bool = region r {
-        let a = Array.toMutList([]: ScopedArray[Int32, _], r);
+        let a = Array.toMutList([]: Array[Int32, _], r);
         MutList.sortWith(cmp, a);
-        a `sameElements` Array.toMutList([]: ScopedArray[Int32, _], r)
+        a `sameElements` Array.toMutList([]: Array[Int32, _], r)
     }
 
     @test
@@ -2051,7 +2051,7 @@ namespace TestMutList {
 
     @test
     def sort!01(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList([]: ScopedArray[Int32, _], r))
+        testSort!VsSortWith!(Array.toMutList([]: Array[Int32, _], r))
     }
 
     @test
@@ -2106,7 +2106,7 @@ namespace TestMutList {
 
     @test
     def sortBy01(): Bool = region r {
-        testSortByVsSort(Array.toMutList([]: ScopedArray[Int32, _], r))
+        testSortByVsSort(Array.toMutList([]: Array[Int32, _], r))
     }
 
     @test
@@ -2181,7 +2181,7 @@ namespace TestMutList {
 
     @test
     def sortBy!01(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList([]: ScopedArray[Int32, _], r))
+        testSortBy!VsSortBy(Array.toMutList([]: Array[Int32, _], r))
     }
 
     @test

--- a/main/test/ca/uwaterloo/flix/library/TestString.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestString.flix
@@ -2925,17 +2925,17 @@ def levenshteinDistance07(): Bool =
 @test
 def zip01(): Bool & Impure =
     let a = String.zip("", "");
-    Array.sameElements(a, []: FooArray[(Char,Char)])
+    Array.sameElements(a, []: UnscopedArray[(Char,Char)])
 
 @test
 def zip02(): Bool & Impure =
     let a = String.zip("a", "");
-    Array.sameElements(a, []: FooArray[(Char, Char)])
+    Array.sameElements(a, []: UnscopedArray[(Char, Char)])
 
 @test
 def zip03(): Bool & Impure =
     let a = String.zip("", "1");
-    Array.sameElements(a, []: FooArray[(Char, Char)])
+    Array.sameElements(a, []: UnscopedArray[(Char, Char)])
 
 @test
 def zip04(): Bool & Impure =

--- a/main/test/ca/uwaterloo/flix/library/TestString.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestString.flix
@@ -2925,17 +2925,17 @@ def levenshteinDistance07(): Bool =
 @test
 def zip01(): Bool & Impure =
     let a = String.zip("", "");
-    Array.sameElements(a, []: Array[(Char,Char)])
+    Array.sameElements(a, []: FooArray[(Char,Char)])
 
 @test
 def zip02(): Bool & Impure =
     let a = String.zip("a", "");
-    Array.sameElements(a, []: Array[(Char, Char)])
+    Array.sameElements(a, []: FooArray[(Char, Char)])
 
 @test
 def zip03(): Bool & Impure =
     let a = String.zip("", "1");
-    Array.sameElements(a, []: Array[(Char, Char)])
+    Array.sameElements(a, []: FooArray[(Char, Char)])
 
 @test
 def zip04(): Bool & Impure =

--- a/main/test/ca/uwaterloo/flix/library/TestStringBuilder.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestStringBuilder.flix
@@ -428,7 +428,7 @@ def appendLines04!(): Bool = region r {
 @test
 def appendLinesWith01!(): Bool = region r {
     let sb = new StringBuilder(r);
-    StringBuilder.appendLinesWith!(Int32.toString, ([] @ r): ScopedArray[Int32, _], sb);
+    StringBuilder.appendLinesWith!(Int32.toString, ([] @ r): Array[Int32, _], sb);
     StringBuilder.toString(sb) == ""
 }
 

--- a/main/test/flix/Test.Def.Generalization.flix
+++ b/main/test/flix/Test.Def.Generalization.flix
@@ -16,7 +16,7 @@ namespace Test/Def/Generalization {
     def testGen04(): String -> String = x -> x
 
     @test
-    def testGen05(): FooArray[a] -> FooArray[a] = x -> x
+    def testGen05(): UnscopedArray[a] -> UnscopedArray[a] = x -> x
 
     @test
     def testGen06(): Option[a] -> Option[a] = x -> x

--- a/main/test/flix/Test.Def.Generalization.flix
+++ b/main/test/flix/Test.Def.Generalization.flix
@@ -16,7 +16,7 @@ namespace Test/Def/Generalization {
     def testGen04(): String -> String = x -> x
 
     @test
-    def testGen05(): Array[a] -> Array[a] = x -> x
+    def testGen05(): FooArray[a] -> FooArray[a] = x -> x
 
     @test
     def testGen06(): Option[a] -> Option[a] = x -> x

--- a/main/test/flix/Test.Exp.Concurrency.Buffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Buffered.flix
@@ -86,7 +86,7 @@ namespace Test/Exp/Concurrency/Buffered {
 
     @test
     def testBufferedChannel15(): Bool & Impure =
-        let c = chan FooArray[Int32] 1;
+        let c = chan UnscopedArray[Int32] 1;
         c <- [1, 2, 3];
         2 == (<- c)[1]
 
@@ -184,7 +184,7 @@ namespace Test/Exp/Concurrency/Buffered {
 
     @test
     def testBufferedChannelWithSpawn15(): Bool & Impure =
-        let c = chan FooArray[Int32] 1;
+        let c = chan UnscopedArray[Int32] 1;
         spawn c <- [1, 2, 3];
         2 == (<- c)[1]
 

--- a/main/test/flix/Test.Exp.Concurrency.Buffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Buffered.flix
@@ -86,7 +86,7 @@ namespace Test/Exp/Concurrency/Buffered {
 
     @test
     def testBufferedChannel15(): Bool & Impure =
-        let c = chan Array[Int32] 1;
+        let c = chan FooArray[Int32] 1;
         c <- [1, 2, 3];
         2 == (<- c)[1]
 
@@ -184,7 +184,7 @@ namespace Test/Exp/Concurrency/Buffered {
 
     @test
     def testBufferedChannelWithSpawn15(): Bool & Impure =
-        let c = chan Array[Int32] 1;
+        let c = chan FooArray[Int32] 1;
         spawn c <- [1, 2, 3];
         2 == (<- c)[1]
 

--- a/main/test/flix/Test.Exp.Concurrency.Unbuffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Unbuffered.flix
@@ -86,7 +86,7 @@ namespace Test/Exp/Concurrency/Unbuffered {
 
     @test
     def testUnbufferedChannelPutGet15(): Bool & Impure =
-        let c = chan Array[Int32] 0;
+        let c = chan FooArray[Int32] 0;
         spawn c <- [1, 2, 3];
         2 == (<- c)[1]
 
@@ -184,7 +184,7 @@ namespace Test/Exp/Concurrency/Unbuffered {
 
     @test
     def testUnbufferedChannelGetPut15(): Unit & Impure =
-        let c = chan Array[Int32] 0;
+        let c = chan FooArray[Int32] 0;
         spawn <- c;
         c <- [1, 2, 3]
 

--- a/main/test/flix/Test.Exp.Concurrency.Unbuffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Unbuffered.flix
@@ -86,7 +86,7 @@ namespace Test/Exp/Concurrency/Unbuffered {
 
     @test
     def testUnbufferedChannelPutGet15(): Bool & Impure =
-        let c = chan FooArray[Int32] 0;
+        let c = chan UnscopedArray[Int32] 0;
         spawn c <- [1, 2, 3];
         2 == (<- c)[1]
 
@@ -184,7 +184,7 @@ namespace Test/Exp/Concurrency/Unbuffered {
 
     @test
     def testUnbufferedChannelGetPut15(): Unit & Impure =
-        let c = chan FooArray[Int32] 0;
+        let c = chan UnscopedArray[Int32] 0;
         spawn <- c;
         c <- [1, 2, 3]
 

--- a/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.flix
@@ -42,7 +42,7 @@ namespace Test/Exp/Jvm/InvokeStaticMethod {
 
     @test
     def testInvokeInterfaceStaticMethod02(): ##java.nio.file.Path & Impure =
-        import static java.nio.file.Path.of(String, Array[String]): ##java.nio.file.Path & Impure as of1;
+        import static java.nio.file.Path.of(String, FooArray[String]): ##java.nio.file.Path & Impure as of1;
         try {
             of1("end", ["p1", "p2", "p3"])
         } catch {

--- a/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.flix
@@ -42,7 +42,7 @@ namespace Test/Exp/Jvm/InvokeStaticMethod {
 
     @test
     def testInvokeInterfaceStaticMethod02(): ##java.nio.file.Path & Impure =
-        import static java.nio.file.Path.of(String, FooArray[String]): ##java.nio.file.Path & Impure as of1;
+        import static java.nio.file.Path.of(String, UnscopedArray[String]): ##java.nio.file.Path & Impure as of1;
         try {
             of1("end", ["p1", "p2", "p3"])
         } catch {

--- a/main/test/flix/Test.Exp.Lazy.flix
+++ b/main/test/flix/Test.Exp.Lazy.flix
@@ -49,12 +49,12 @@ namespace Test/Exp/Lazy {
         lazy "string"
 
     @test
-    def testArrayOfIntLazy01(): Lazy[Array[Int32]] & Impure =
+    def testArrayOfIntLazy01(): Lazy[FooArray[Int32]] & Impure =
         let array = [1, 2];
         lazy array
 
     @test
-    def testArrayOfStringLazy01(): Lazy[Array[String]] & Impure =
+    def testArrayOfStringLazy01(): Lazy[FooArray[String]] & Impure =
         let array = ["str", "str2"];
         lazy array
 

--- a/main/test/flix/Test.Exp.Lazy.flix
+++ b/main/test/flix/Test.Exp.Lazy.flix
@@ -49,12 +49,12 @@ namespace Test/Exp/Lazy {
         lazy "string"
 
     @test
-    def testArrayOfIntLazy01(): Lazy[FooArray[Int32]] & Impure =
+    def testArrayOfIntLazy01(): Lazy[UnscopedArray[Int32]] & Impure =
         let array = [1, 2];
         lazy array
 
     @test
-    def testArrayOfStringLazy01(): Lazy[FooArray[String]] & Impure =
+    def testArrayOfStringLazy01(): Lazy[UnscopedArray[String]] & Impure =
         let array = ["str", "str2"];
         lazy array
 

--- a/main/test/flix/Test.Exp.Match.Array.flix
+++ b/main/test/flix/Test.Exp.Match.Array.flix
@@ -1,73 +1,73 @@
 namespace Test/Exp/Match/Array {
 
     @test
-    def testMatchEmptyUnitArray01(): Bool & Impure = match ([]: FooArray[Unit]) {
+    def testMatchEmptyUnitArray01(): Bool & Impure = match ([]: UnscopedArray[Unit]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyBoolArray01(): Bool & Impure = match ([]: FooArray[Bool]) {
+    def testMatchEmptyBoolArray01(): Bool & Impure = match ([]: UnscopedArray[Bool]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyCharArray01(): Bool & Impure = match ([]: FooArray[Char]) {
+    def testMatchEmptyCharArray01(): Bool & Impure = match ([]: UnscopedArray[Char]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyFloat32Array01(): Bool & Impure = match ([]: FooArray[Float32]) {
+    def testMatchEmptyFloat32Array01(): Bool & Impure = match ([]: UnscopedArray[Float32]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyFloat64Array01(): Bool & Impure = match ([]: FooArray[Float64]) {
+    def testMatchEmptyFloat64Array01(): Bool & Impure = match ([]: UnscopedArray[Float64]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyInt8Array01(): Bool & Impure = match ([]: FooArray[Int8]) {
+    def testMatchEmptyInt8Array01(): Bool & Impure = match ([]: UnscopedArray[Int8]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyInt16Array01(): Bool & Impure = match ([]: FooArray[Int16]) {
+    def testMatchEmptyInt16Array01(): Bool & Impure = match ([]: UnscopedArray[Int16]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyInt64Array01(): Bool & Impure = match ([]: FooArray[Int64]) {
+    def testMatchEmptyInt64Array01(): Bool & Impure = match ([]: UnscopedArray[Int64]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyStringArray01(): Bool & Impure = match ([]: FooArray[String]) {
+    def testMatchEmptyStringArray01(): Bool & Impure = match ([]: UnscopedArray[String]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyBigIntArray01(): Bool & Impure = match ([]: FooArray[BigInt]) {
+    def testMatchEmptyBigIntArray01(): Bool & Impure = match ([]: UnscopedArray[BigInt]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyOptionIntArray01(): Bool & Impure = match ([]: FooArray[Option[Int32]]) {
+    def testMatchEmptyOptionIntArray01(): Bool & Impure = match ([]: UnscopedArray[Option[Int32]]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyResultArray01(): Bool & Impure = match ([]: FooArray[Result[Int32,String]]) {
+    def testMatchEmptyResultArray01(): Bool & Impure = match ([]: UnscopedArray[Result[Int32,String]]) {
         case [] => true
         case _  => false
     }

--- a/main/test/flix/Test.Exp.Match.Array.flix
+++ b/main/test/flix/Test.Exp.Match.Array.flix
@@ -1,73 +1,73 @@
 namespace Test/Exp/Match/Array {
 
     @test
-    def testMatchEmptyUnitArray01(): Bool & Impure = match ([]: Array[Unit]) {
+    def testMatchEmptyUnitArray01(): Bool & Impure = match ([]: FooArray[Unit]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyBoolArray01(): Bool & Impure = match ([]: Array[Bool]) {
+    def testMatchEmptyBoolArray01(): Bool & Impure = match ([]: FooArray[Bool]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyCharArray01(): Bool & Impure = match ([]: Array[Char]) {
+    def testMatchEmptyCharArray01(): Bool & Impure = match ([]: FooArray[Char]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyFloat32Array01(): Bool & Impure = match ([]: Array[Float32]) {
+    def testMatchEmptyFloat32Array01(): Bool & Impure = match ([]: FooArray[Float32]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyFloat64Array01(): Bool & Impure = match ([]: Array[Float64]) {
+    def testMatchEmptyFloat64Array01(): Bool & Impure = match ([]: FooArray[Float64]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyInt8Array01(): Bool & Impure = match ([]: Array[Int8]) {
+    def testMatchEmptyInt8Array01(): Bool & Impure = match ([]: FooArray[Int8]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyInt16Array01(): Bool & Impure = match ([]: Array[Int16]) {
+    def testMatchEmptyInt16Array01(): Bool & Impure = match ([]: FooArray[Int16]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyInt64Array01(): Bool & Impure = match ([]: Array[Int64]) {
+    def testMatchEmptyInt64Array01(): Bool & Impure = match ([]: FooArray[Int64]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyStringArray01(): Bool & Impure = match ([]: Array[String]) {
+    def testMatchEmptyStringArray01(): Bool & Impure = match ([]: FooArray[String]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyBigIntArray01(): Bool & Impure = match ([]: Array[BigInt]) {
+    def testMatchEmptyBigIntArray01(): Bool & Impure = match ([]: FooArray[BigInt]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyOptionIntArray01(): Bool & Impure = match ([]: Array[Option[Int32]]) {
+    def testMatchEmptyOptionIntArray01(): Bool & Impure = match ([]: FooArray[Option[Int32]]) {
         case [] => true
         case _  => false
     }
 
     @test
-    def testMatchEmptyResultArray01(): Bool & Impure = match ([]: Array[Result[Int32,String]]) {
+    def testMatchEmptyResultArray01(): Bool & Impure = match ([]: FooArray[Result[Int32,String]]) {
         case [] => true
         case _  => false
     }

--- a/main/test/flix/Test.Exp.Null.flix
+++ b/main/test/flix/Test.Exp.Null.flix
@@ -10,7 +10,7 @@ namespace Test/Exp/Null {
     def testNullString01(): String = null as String
 
     @test
-    def testNullArray01(): Array[String] = null as Array[String]
+    def testNullArray01(): FooArray[String] = null as FooArray[String]
 
     @test
     def testNullChannel01(): Channel[String] = null as Channel[String]

--- a/main/test/flix/Test.Exp.Null.flix
+++ b/main/test/flix/Test.Exp.Null.flix
@@ -10,7 +10,7 @@ namespace Test/Exp/Null {
     def testNullString01(): String = null as String
 
     @test
-    def testNullArray01(): FooArray[String] = null as FooArray[String]
+    def testNullArray01(): UnscopedArray[String] = null as UnscopedArray[String]
 
     @test
     def testNullChannel01(): Channel[String] = null as Channel[String]

--- a/main/test/flix/Test.Exp.ReifyType.flix
+++ b/main/test/flix/Test.Exp.ReifyType.flix
@@ -55,55 +55,55 @@ namespace Test/Exp/ReifyType {
     def reifyInt6402(): Bool = reflect(1i64) == ReifiedInt64
 
     @test
-    def reifyArrayUnit3201(): Bool = reifyType FooArray[Unit] == ReifiedArray(ReifiedUnit)
+    def reifyArrayUnit3201(): Bool = reifyType UnscopedArray[Unit] == ReifiedArray(ReifiedUnit)
 
     @test
     def reifyArrayUnit3202(): Bool & Impure = reflect([()]) == ReifiedArray(ReifiedUnit)
 
     @test
-    def reifyArrayBool3201(): Bool = reifyType FooArray[Bool] == ReifiedArray(ReifiedBool)
+    def reifyArrayBool3201(): Bool = reifyType UnscopedArray[Bool] == ReifiedArray(ReifiedBool)
 
     @test
     def reifyArrayBool3202(): Bool & Impure = reflect([false]) == ReifiedArray(ReifiedBool)
 
     @test
-    def reifyArrayChar3201(): Bool = reifyType FooArray[Char] == ReifiedArray(ReifiedChar)
+    def reifyArrayChar3201(): Bool = reifyType UnscopedArray[Char] == ReifiedArray(ReifiedChar)
 
     @test
     def reifyArrayChar3202(): Bool & Impure = reflect(['b']) == ReifiedArray(ReifiedChar)
 
     @test
-    def reifyArrayFloat3201(): Bool = reifyType FooArray[Float32] == ReifiedArray(ReifiedFloat32)
+    def reifyArrayFloat3201(): Bool = reifyType UnscopedArray[Float32] == ReifiedArray(ReifiedFloat32)
 
     @test
     def reifyArrayFloat3202(): Bool & Impure = reflect([1.0f32]) == ReifiedArray(ReifiedFloat32)
 
     @test
-    def reifyArrayFloat6401(): Bool = reifyType FooArray[Float64] == ReifiedArray(ReifiedFloat64)
+    def reifyArrayFloat6401(): Bool = reifyType UnscopedArray[Float64] == ReifiedArray(ReifiedFloat64)
 
     @test
     def reifyArrayFloat6402(): Bool & Impure = reflect([1.0f64]) == ReifiedArray(ReifiedFloat64)
 
     @test
-    def reifyArrayInt801(): Bool = reifyType FooArray[Int8] == ReifiedArray(ReifiedInt8)
+    def reifyArrayInt801(): Bool = reifyType UnscopedArray[Int8] == ReifiedArray(ReifiedInt8)
 
     @test
     def reifyArrayInt802(): Bool & Impure = reflect([1i8]) == ReifiedArray(ReifiedInt8)
 
     @test
-    def reifyArrayInt1601(): Bool = reifyType FooArray[Int16] == ReifiedArray(ReifiedInt16)
+    def reifyArrayInt1601(): Bool = reifyType UnscopedArray[Int16] == ReifiedArray(ReifiedInt16)
 
     @test
     def reifyArrayInt1602(): Bool & Impure = reflect([1i16]) == ReifiedArray(ReifiedInt16)
 
     @test
-    def reifyArrayInt3201(): Bool = reifyType FooArray[Int32] == ReifiedArray(ReifiedInt32)
+    def reifyArrayInt3201(): Bool = reifyType UnscopedArray[Int32] == ReifiedArray(ReifiedInt32)
 
     @test
     def reifyArrayInt3202(): Bool & Impure = reflect([1]) == ReifiedArray(ReifiedInt32)
 
     @test
-    def reifyArrayInt6401(): Bool = reifyType FooArray[Int64] == ReifiedArray(ReifiedInt64)
+    def reifyArrayInt6401(): Bool = reifyType UnscopedArray[Int64] == ReifiedArray(ReifiedInt64)
 
     @test
     def reifyArrayInt6402(): Bool & Impure = reflect([1i64]) == ReifiedArray(ReifiedInt64)

--- a/main/test/flix/Test.Exp.ReifyType.flix
+++ b/main/test/flix/Test.Exp.ReifyType.flix
@@ -55,55 +55,55 @@ namespace Test/Exp/ReifyType {
     def reifyInt6402(): Bool = reflect(1i64) == ReifiedInt64
 
     @test
-    def reifyArrayUnit3201(): Bool = reifyType Array[Unit] == ReifiedArray(ReifiedUnit)
+    def reifyArrayUnit3201(): Bool = reifyType FooArray[Unit] == ReifiedArray(ReifiedUnit)
 
     @test
     def reifyArrayUnit3202(): Bool & Impure = reflect([()]) == ReifiedArray(ReifiedUnit)
 
     @test
-    def reifyArrayBool3201(): Bool = reifyType Array[Bool] == ReifiedArray(ReifiedBool)
+    def reifyArrayBool3201(): Bool = reifyType FooArray[Bool] == ReifiedArray(ReifiedBool)
 
     @test
     def reifyArrayBool3202(): Bool & Impure = reflect([false]) == ReifiedArray(ReifiedBool)
 
     @test
-    def reifyArrayChar3201(): Bool = reifyType Array[Char] == ReifiedArray(ReifiedChar)
+    def reifyArrayChar3201(): Bool = reifyType FooArray[Char] == ReifiedArray(ReifiedChar)
 
     @test
     def reifyArrayChar3202(): Bool & Impure = reflect(['b']) == ReifiedArray(ReifiedChar)
 
     @test
-    def reifyArrayFloat3201(): Bool = reifyType Array[Float32] == ReifiedArray(ReifiedFloat32)
+    def reifyArrayFloat3201(): Bool = reifyType FooArray[Float32] == ReifiedArray(ReifiedFloat32)
 
     @test
     def reifyArrayFloat3202(): Bool & Impure = reflect([1.0f32]) == ReifiedArray(ReifiedFloat32)
 
     @test
-    def reifyArrayFloat6401(): Bool = reifyType Array[Float64] == ReifiedArray(ReifiedFloat64)
+    def reifyArrayFloat6401(): Bool = reifyType FooArray[Float64] == ReifiedArray(ReifiedFloat64)
 
     @test
     def reifyArrayFloat6402(): Bool & Impure = reflect([1.0f64]) == ReifiedArray(ReifiedFloat64)
 
     @test
-    def reifyArrayInt801(): Bool = reifyType Array[Int8] == ReifiedArray(ReifiedInt8)
+    def reifyArrayInt801(): Bool = reifyType FooArray[Int8] == ReifiedArray(ReifiedInt8)
 
     @test
     def reifyArrayInt802(): Bool & Impure = reflect([1i8]) == ReifiedArray(ReifiedInt8)
 
     @test
-    def reifyArrayInt1601(): Bool = reifyType Array[Int16] == ReifiedArray(ReifiedInt16)
+    def reifyArrayInt1601(): Bool = reifyType FooArray[Int16] == ReifiedArray(ReifiedInt16)
 
     @test
     def reifyArrayInt1602(): Bool & Impure = reflect([1i16]) == ReifiedArray(ReifiedInt16)
 
     @test
-    def reifyArrayInt3201(): Bool = reifyType Array[Int32] == ReifiedArray(ReifiedInt32)
+    def reifyArrayInt3201(): Bool = reifyType FooArray[Int32] == ReifiedArray(ReifiedInt32)
 
     @test
     def reifyArrayInt3202(): Bool & Impure = reflect([1]) == ReifiedArray(ReifiedInt32)
 
     @test
-    def reifyArrayInt6401(): Bool = reifyType Array[Int64] == ReifiedArray(ReifiedInt64)
+    def reifyArrayInt6401(): Bool = reifyType FooArray[Int64] == ReifiedArray(ReifiedInt64)
 
     @test
     def reifyArrayInt6402(): Bool & Impure = reflect([1i64]) == ReifiedArray(ReifiedInt64)

--- a/main/test/flix/Test.Exp.Tag.flix
+++ b/main/test/flix/Test.Exp.Tag.flix
@@ -12,8 +12,8 @@ namespace Test/Exp/Tag {
         case OfInt64(Int64)
         case OfBigInt(BigInt)
         case OfString(String)
-        case OfArrayOfInt(FooArray[Int32])
-        case OfArrayOfString(FooArray[String])
+        case OfArrayOfInt(UnscopedArray[Int32])
+        case OfArrayOfString(UnscopedArray[String])
         case OfTuple(Bool, Char, String)
     }
 

--- a/main/test/flix/Test.Exp.Tag.flix
+++ b/main/test/flix/Test.Exp.Tag.flix
@@ -12,8 +12,8 @@ namespace Test/Exp/Tag {
         case OfInt64(Int64)
         case OfBigInt(BigInt)
         case OfString(String)
-        case OfArrayOfInt(Array[Int32])
-        case OfArrayOfString(Array[String])
+        case OfArrayOfInt(FooArray[Int32])
+        case OfArrayOfString(FooArray[String])
         case OfTuple(Bool, Char, String)
     }
 


### PR DESCRIPTION
Closes #3593

The old `Array` has been renamed to `UnscopedArray`