### PR TITLE
experiment: a magical unfounded hack to fix everything

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -194,9 +194,9 @@ object Indexer {
     case Expression.Region(_, _) =>
       Index.occurrenceOf(exp0)
 
-    case Expression.Scope(sym, _, exp, _, _, loc) =>
-      val tpe = Type.mkRegion(sym.tvar.ascribedWith(Kind.Bool), loc)
-      Index.occurrenceOf(sym, tpe) ++ visitExp(exp) ++ Index.occurrenceOf(exp0)
+    case Expression.Scope(_, varSym, _, exp, _, _, loc) =>
+      val tpe = Type.mkRegionStar(varSym.tvar.ascribedWith(Kind.Bool), loc)
+      Index.occurrenceOf(varSym, tpe) ++ visitExp(exp) ++ Index.occurrenceOf(exp0)
 
     case Expression.IfThenElse(exp1, exp2, exp3, _, _, _) =>
       visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3) ++ Index.occurrenceOf(exp0)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -313,8 +313,8 @@ object SemanticTokensProvider {
     case Expression.Region(_, _) =>
       Iterator.empty
 
-    case Expression.Scope(sym, _, exp, _, _, _) =>
-      val t = SemanticToken(SemanticTokenType.Variable, Nil, sym.loc)
+    case Expression.Scope(_, varSym, _, exp, _, _, _) =>
+      val t = SemanticToken(SemanticTokenType.Variable, Nil, varSym.loc)
       Iterator(t) ++ visitExp(exp)
 
     case Expression.IfThenElse(exp1, exp2, exp3, _, _, _) =>
@@ -619,7 +619,8 @@ object SemanticTokensProvider {
     case TypeConstructor.Intersection => false
     case TypeConstructor.Difference => false
     case TypeConstructor.Effect(_) => false
-    case TypeConstructor.Region => false
+    case TypeConstructor.RegionToStar => false
+    case TypeConstructor.Region(_) => false
 
     case TypeConstructor.UnkindedEnum(_) => throw InternalCompilerException("Unexpected unkinded type.")
     case TypeConstructor.UnappliedAlias(_) => throw InternalCompilerException("Unexpected unkinded type.")

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -115,7 +115,7 @@ object KindedAst {
 
     case class Region(tpe: Type, loc: SourceLocation) extends KindedAst.Expression
 
-    case class Scope(sym: Symbol.VarSym, regionVar: Type.KindedVar, exp1: KindedAst.Expression, evar: Type.KindedVar, loc: SourceLocation) extends KindedAst.Expression
+    case class Scope(sym: Symbol.RegionSym, varSym: Symbol.VarSym, tvar: Type.KindedVar, exp1: KindedAst.Expression, evar: Type.KindedVar, loc: SourceLocation) extends KindedAst.Expression
 
     case class Match(exp: KindedAst.Expression, rules: List[KindedAst.MatchRule], loc: SourceLocation) extends KindedAst.Expression
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -135,7 +135,7 @@ object NamedAst {
 
     case class Region(tpe: ca.uwaterloo.flix.language.ast.Type, loc: SourceLocation) extends NamedAst.Expression
 
-    case class Scope(sym: Symbol.VarSym, regionVar: Symbol.UnkindedTypeVarSym, exp: NamedAst.Expression, loc: SourceLocation) extends NamedAst.Expression
+    case class Scope(sym: Symbol.RegionSym, varSym: Symbol.VarSym, tvarSym: Symbol.UnkindedTypeVarSym, exp: NamedAst.Expression, loc: SourceLocation) extends NamedAst.Expression
 
     case class Match(exp: NamedAst.Expression, rules: List[NamedAst.MatchRule], loc: SourceLocation) extends NamedAst.Expression
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -116,7 +116,7 @@ object ResolvedAst {
 
     case class Region(tpe: Type, loc: SourceLocation) extends ResolvedAst.Expression
 
-    case class Scope(sym: Symbol.VarSym, regionVar: Symbol.UnkindedTypeVarSym, exp: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
+    case class Scope(sym: Symbol.RegionSym, varSym: Symbol.VarSym, tvarSym: Symbol.UnkindedTypeVarSym, exp: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
 
     case class Match(exp: ResolvedAst.Expression, rules: List[ResolvedAst.MatchRule], loc: SourceLocation) extends ResolvedAst.Expression
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -87,6 +87,13 @@ object Symbol {
   /**
     * Returns a label symbol with the given text.
     */
+  def freshRegionSym(text: String, loc: SourceLocation)(implicit flix: Flix): RegionSym = {
+    new RegionSym(flix.genSym.freshId(), text, loc)
+  }
+
+  /**
+    * Returns a label symbol with the given text.
+    */
   def freshLabel(text: String)(implicit flix: Flix): LabelSym = {
     new LabelSym(flix.genSym.freshId(), text)
   }
@@ -581,6 +588,34 @@ object Symbol {
       * Human readable representation.
       */
     override def toString: String = eff.toString + "." + name
+  }
+
+  /**
+    * Region Symbol.
+    */
+  final class RegionSym(val id: Int, val text: String, val loc: SourceLocation) extends Ordered[RegionSym] {
+    /**
+      * Returns `true` if this symbol is equal to `that` symbol.
+      */
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case that: RegionSym => this.id == that.id
+      case _ => false
+    }
+
+    /**
+      * Returns the hash code of this symbol.
+      */
+    override val hashCode: Int = Objects.hash(id)
+
+    /**
+      * Human readable representation.
+      */
+    override def toString: String = text + Flix.Delimiter + id
+
+    /**
+      * Compares the given region symbols' IDs.
+      */
+    override def compare(that: RegionSym): Int = this.id.compare(that.id)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -68,6 +68,11 @@ sealed trait Type {
     case Type.Apply(tpe1, tpe2, _) => tpe1.regionSyms ++ tpe2.regionSyms
     case Type.Ascribe(tpe, _, _) => tpe.regionSyms
     case Type.Alias(_, _, tpe, _) => tpe.regionSyms
+    case Type.ReadWrite(tpe, _) => tpe.regionSyms
+    case Type.UnkindedArrow(Ast.PurityAndEffect(pur, eff), _, _) =>
+      val list = pur.toList.flatMap(_.regionSyms) ++
+        eff.toList.flatMap(_.flatMap(_.regionSyms))
+      SortedSet.from(list)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -1,6 +1,7 @@
 package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.language.ast.Ast.{EliminatedBy, IntroducedBy}
+import ca.uwaterloo.flix.language.ast.Symbol.RegionSym
 import ca.uwaterloo.flix.language.phase.{Kinder, Resolver, Typer}
 import ca.uwaterloo.flix.util.InternalCompilerException
 
@@ -335,9 +336,16 @@ object TypeConstructor {
   }
 
   /**
-    * A type constructor that represent the type of regions.
+    * A type constructor representing a region constant.
     */
-  case object Region extends TypeConstructor {
+  case class Region(sym: RegionSym) extends TypeConstructor {
+    def kind: Kind = Kind.Bool
+  }
+
+  /**
+    * A type constructor converting a region to a Star type.
+    */
+  case object RegionToStar extends TypeConstructor {
     /**
       * The shape of a region is Region[l].
       */

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -181,7 +181,7 @@ object TypedAst {
       def eff: Type = Type.Pure
     }
 
-    case class Scope(sym: Symbol.VarSym, regionVar: Type.KindedVar, exp: TypedAst.Expression, tpe: Type, eff: Type, loc: SourceLocation) extends TypedAst.Expression
+    case class Scope(sym: Symbol.RegionSym, varSym: Symbol.VarSym, tvar: Type.KindedVar, exp: TypedAst.Expression, tpe: Type, eff: Type, loc: SourceLocation) extends TypedAst.Expression
 
     case class IfThenElse(exp1: TypedAst.Expression, exp2: TypedAst.Expression, exp3: TypedAst.Expression, tpe: Type, eff: Type, loc: SourceLocation) extends TypedAst.Expression
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
@@ -80,7 +80,7 @@ object TypedAstOps {
       case Expression.Region(_, _) =>
         Map.empty
 
-      case Expression.Scope(_, _, exp, _, _, _) =>
+      case Expression.Scope(_, _, _, exp, _, _, _) =>
         visitExp(exp, env0)
 
       case Expression.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
@@ -365,7 +365,7 @@ object TypedAstOps {
     case Expression.Let(_, _, exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
     case Expression.LetRec(_, _, exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
     case Expression.Region(_, _) => Set.empty
-    case Expression.Scope(_, _, exp, _, _, _) => sigSymsOf(exp)
+    case Expression.Scope(_, _, _, exp, _, _, _) => sigSymsOf(exp)
     case Expression.IfThenElse(exp1, exp2, exp3, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2) ++ sigSymsOf(exp3)
     case Expression.Stm(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
     case Expression.Discard(exp, _, _) => sigSymsOf(exp)
@@ -505,8 +505,8 @@ object TypedAstOps {
     case Expression.Region(_, _) =>
       Map.empty
 
-    case Expression.Scope(sym, _, exp, _, _, _) =>
-      freeVars(exp) - sym
+    case Expression.Scope(_, varSym, _, exp, _, _, _) =>
+      freeVars(exp) - varSym
 
     case Expression.IfThenElse(exp1, exp2, exp3, _, _, _) =>
       freeVars(exp1) ++ freeVars(exp2) ++ freeVars(exp3)

--- a/main/src/ca/uwaterloo/flix/language/dbg/FormatExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/FormatExpression.scala
@@ -37,7 +37,7 @@ object FormatExpression {
     case TypedAst.Expression.Let(sym, mod, exp1, exp2, tpe, eff, loc) => s"Let($sym, $mod, $exp1, $exp2)"
     case TypedAst.Expression.LetRec(sym, mod, exp1, exp2, tpe, eff, loc) => s"LetRec($sym, $mod, $exp1, $exp2)"
     case TypedAst.Expression.Region(tpe, loc) => s"Region($tpe)"
-    case TypedAst.Expression.Scope(sym, regionVar, exp, tpe, eff, loc) => s"Scope($sym, $exp)"
+    case TypedAst.Expression.Scope(sym, _, _, exp, tpe, eff, loc) => s"Scope($sym, $exp)"
     case TypedAst.Expression.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) => s"IfThenElse($exp1, $exp2, $exp3)"
     case TypedAst.Expression.Stm(exp1, exp2, _, _, _) => s"Stm($exp1, $exp2)"
     case TypedAst.Expression.Discard(exp, _, _) => s"Discard($exp)"

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -615,29 +615,29 @@ object TypeError {
   /**
     * An error indicating that a region variable escapes its scope.
     *
-    * @param rvar the region variable.
-    * @param tpe  the type wherein the region variable escapes.
-    * @param loc  the location where the error occurred.
+    * @param sym the region symbol.
+    * @param tpe the type wherein the region variable escapes.
+    * @param loc the location where the error occurred.
     */
-  case class RegionVarEscapes(rvar: Type.KindedVar, tpe: Type, loc: SourceLocation) extends TypeError {
-    def summary: String = s"Region variable '${formatWellKindedType(rvar)}' escapes its scope."
+  case class RegionEscapes(sym: Symbol.RegionSym, tpe: Type, loc: SourceLocation) extends TypeError {
+    def summary: String = s"Region symbol '${sym.text}' escapes its scope."
 
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
-         |>> The region variable '${red(formatWellKindedType(rvar))}' escapes its scope.
+         |>> The region symbol '${red(sym.text)}' escapes its scope.
          |
-         |${code(loc, "region variable escapes.")}
+         |${code(loc, "region symbol escapes.")}
          |
          |The escaping expression has type:
          |
          |  ${red(formatWellKindedType(tpe))}
          |
-         |which contains the region variable.
+         |which contains the region symbol.
          |
-         |The region variable was declared here:
+         |The region symbol was declared here:
          |
-         |${code(rvar.loc, "region variable declared here.")}
+         |${code(sym.loc, "region symbol declared here.")}
          |""".stripMargin
     }
 

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
@@ -118,7 +118,8 @@ object FormatType {
       case SimpleType.Lazy => true
       case SimpleType.True => true
       case SimpleType.False => true
-      case SimpleType.Region => true
+      case SimpleType.RegionToStar => true
+      case SimpleType.Region(_, _) => true
       case SimpleType.RecordConstructor(_) => true
       case SimpleType.Record(_) => true
       case SimpleType.RecordExtend(_, _) => true
@@ -181,7 +182,12 @@ object FormatType {
         case Mode.Type => "false"
         case Mode.Effect => "Impure"
       }
-      case SimpleType.Region => "Region"
+      case SimpleType.RegionToStar => "Region"
+      case SimpleType.Region(text, id) =>
+        audience match {
+          case Audience.Internal => s"@${id}"
+          case Audience.External => s"${text}"
+        }
       case SimpleType.Record(fields) =>
         val fieldString = fields.map(visitRecordFieldType).mkString(", ")
         s"{ $fieldString }"

--- a/main/src/ca/uwaterloo/flix/language/fmt/SimpleType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/SimpleType.scala
@@ -77,7 +77,9 @@ object SimpleType {
 
   case object False extends SimpleType
 
-  case object Region extends SimpleType
+  case object RegionToStar extends SimpleType
+
+  case class Region(text: String, id: Int) extends SimpleType
 
   //////////
   // Records
@@ -510,7 +512,8 @@ object SimpleType {
         }
 
       case TypeConstructor.Effect(sym) => mkApply(SimpleType.Name(sym.name), t.typeArguments.map(fromWellKindedType))
-      case TypeConstructor.Region => mkApply(Region, t.typeArguments.map(fromWellKindedType))
+      case TypeConstructor.RegionToStar => mkApply(RegionToStar, t.typeArguments.map(fromWellKindedType))
+      case TypeConstructor.Region(sym) => Region(sym.text, sym.id)
       case _: TypeConstructor.UnappliedAlias => throw InternalCompilerException("Unexpected unapplied alias.")
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
@@ -449,7 +449,10 @@ object Finalize {
 
             case TypeConstructor.Ref => MonoType.Ref(args.head)
 
-            case TypeConstructor.Region =>
+            case TypeConstructor.RegionToStar =>
+              MonoType.Unit // TODO: Should be erased?
+
+            case TypeConstructor.Region(_) =>
               MonoType.Unit // TODO: Should be erased?
 
             case TypeConstructor.Tuple(l) => MonoType.Tuple(args)

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -425,12 +425,12 @@ object Kinder {
     case ResolvedAst.Expression.Region(tpe, loc) =>
       KindedAst.Expression.Region(tpe, loc).toSuccess
 
-    case ResolvedAst.Expression.Scope(sym, regionVar, exp0, loc) =>
-      val rv = Type.KindedVar(regionVar.ascribedWith(Kind.Bool), loc)
+    case ResolvedAst.Expression.Scope(sym, varSym, tvarSym, exp0, loc) =>
+      val tvar = Type.KindedVar(tvarSym.ascribedWith(Kind.Bool), loc)
       val evar = Type.freshVar(Kind.Bool, loc.asSynthetic)
       val expVal = visitExp(exp0, kenv, senv, taenv, root)
       mapN(expVal) {
-        exp => KindedAst.Expression.Scope(sym, rv, exp, evar, loc)
+        exp => KindedAst.Expression.Scope(sym, varSym, tvar, exp, evar, loc)
       }
 
     case ResolvedAst.Expression.Match(exp0, rules0, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -330,12 +330,12 @@ object Lowering {
       // Introduce a Unit value to represent the Region value.
       Expression.Unit(loc)
 
-    case Expression.Scope(sym, regionVar, exp, tpe, eff, loc) =>
+    case Expression.Scope(_, varSym, regionVar, exp, tpe, eff, loc) =>
       // Introduce a Unit value to represent the Region value.
       val mod = Ast.Modifiers.Empty
       val e1 = Expression.Unit(loc)
       val e2 = visitExp(exp)
-      Expression.Let(sym, mod, e1, e2, tpe, eff, loc)
+      Expression.Let(varSym, mod, e1, e2, tpe, eff, loc)
 
     case Expression.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
       val e1 = visitExp(exp1)
@@ -1365,10 +1365,10 @@ object Lowering {
     case Expression.Region(tpe, loc) =>
       Expression.Region(tpe, loc)
 
-    case Expression.Scope(sym, regionVar, exp, tpe, eff, loc) =>
-      val s = subst.getOrElse(sym, sym)
+    case Expression.Scope(sym, varSym, tvar, exp, tpe, eff, loc) =>
+      val v = subst.getOrElse(varSym, varSym)
       val e = substExp(exp, subst)
-      Expression.Scope(s, regionVar, e, tpe, eff, loc)
+      Expression.Scope(sym, v, tvar, e, tpe, eff, loc)
 
     case Expression.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
       val e1 = substExp(exp1, subst)

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
@@ -571,7 +571,7 @@ object Monomorph {
       case Expression.Region(_, loc) =>
         throw InternalCompilerException(s"Unexpected expression near: ${loc.format}.")
 
-      case Expression.Scope(_, _, _, _, _, loc) =>
+      case Expression.Scope(_, _, _, _, _, _, loc) =>
         throw InternalCompilerException(s"Unexpected expression near: ${loc.format}.")
 
       case Expression.FixpointConstraintSet(_, _, _, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -717,16 +717,19 @@ object Namer {
       NamedAst.Expression.Region(tpe, loc).toSuccess
 
     case WeededAst.Expression.Scope(ident, exp, loc) =>
+      // Introduce a fresh region symbol
+      val sym = Symbol.freshRegionSym(ident.name, loc)
+
       // Introduce a fresh variable symbol for the region.
-      val sym = Symbol.freshVarSym(ident, BoundBy.Let)
+      val varSym = Symbol.freshVarSym(ident, BoundBy.Let)
 
-      // Introduce a rigid region variable for the region.
-      val regionVar = Symbol.freshUnkindedTypeVarSym(Ast.VarText.SourceText(sym.text), Rigidity.Rigid, loc)
+      // Introduce a fresh type variable for the region.
+      val tvarSym = Symbol.freshUnkindedTypeVarSym(Ast.VarText.SourceText(ident.name), Rigidity.Flexible, loc)
 
-      val env1 = env0 + (ident.name -> sym)
-      val tenv1 = tenv0 + (ident.name -> regionVar)
+      val env1 = env0 + (ident.name -> varSym)
+      val tenv1 = tenv0 + (ident.name -> tvarSym)
       mapN(visitExp(exp, env1, uenv0, tenv1)) {
-        case e => NamedAst.Expression.Scope(sym, regionVar, e, loc)
+        case e => NamedAst.Expression.Scope(sym, varSym, tvarSym, e, loc)
       }
 
     case WeededAst.Expression.Match(exp, rules, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
@@ -176,7 +176,7 @@ object PatternExhaustiveness {
         } yield tast
         case Expression.Region(_, _) =>
           tast.toSuccess
-        case Expression.Scope(_, _, exp, _, _, _) =>
+        case Expression.Scope(_, _, _, exp, _, _, _) =>
           for {
             _ <- checkPats(exp, root)
           } yield tast

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -363,21 +363,21 @@ object Redundancy {
     case Expression.Region(_, _) =>
       Used.empty
 
-    case Expression.Scope(sym, _, exp, _, _, _) =>
+    case Expression.Scope(_, varSym, _, exp, _, _, _) =>
       // Extend the environment with the variable symbol.
-      val env1 = env0 + sym
+      val env1 = env0 + varSym
 
       // Visit the expression under the extended environment.
       val innerUsed = visitExp(exp, env0, rc)
 
       // Check for shadowing.
-      val shadowedVar = shadowing(sym, env0)
+      val shadowedVar = shadowing(varSym, env0)
 
       // Check if the let-bound variable symbol is dead in exp.
-      if (deadVarSym(sym, innerUsed))
-        (innerUsed ++ shadowedVar) - sym + UnusedVarSym(sym)
+      if (deadVarSym(varSym, innerUsed))
+        (innerUsed ++ shadowedVar) - varSym + UnusedVarSym(varSym)
       else
-        (innerUsed ++ shadowedVar) - sym
+        (innerUsed ++ shadowedVar) - varSym
 
     case Expression.IfThenElse(exp1, exp2, exp3, _, _, _) =>
       val us1 = visitExp(exp1, env0, rc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -726,10 +726,10 @@ object Resolver {
         case NamedAst.Expression.Region(tpe, loc) =>
           ResolvedAst.Expression.Region(tpe, loc).toSuccess
 
-        case NamedAst.Expression.Scope(sym, regionVar, exp, loc) =>
-          val eVal = visitExp(exp, Some(sym))
+        case NamedAst.Expression.Scope(sym, varSym, tvarSym, exp, loc) =>
+          val eVal = visitExp(exp, Some(varSym))
           mapN(eVal) {
-            e => ResolvedAst.Expression.Scope(sym, regionVar, e, loc)
+            e => ResolvedAst.Expression.Scope(sym, varSym, tvarSym, e, loc)
           }
 
         case NamedAst.Expression.Match(exp, rules, loc) =>
@@ -1690,7 +1690,7 @@ object Resolver {
       case "Lazy" => Type.mkLazy(loc).toSuccess
       case "Array" => Type.Cst(TypeConstructor.Array, loc).toSuccess
       case "Ref" => Type.Cst(TypeConstructor.Ref, loc).toSuccess
-      case "Region" => Type.Cst(TypeConstructor.Region, loc).toSuccess
+      case "Region" => Type.Cst(TypeConstructor.RegionToStar, loc).toSuccess
 
       // Disambiguate type.
       case typeName =>
@@ -2619,7 +2619,7 @@ object Resolver {
           ResolvedAst.Expression.Var(sym, sym.tvar, sym.loc)
         case None =>
           // Case 2.2: Use the global region.
-          val tpe = Type.mkRegion(Type.False, loc)
+          val tpe = Type.mkRegionStar(Type.False, loc)
           ResolvedAst.Expression.Region(tpe, loc)
       }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -107,7 +107,7 @@ object Safety {
     case Expression.Region(_, _) =>
       Nil
 
-    case Expression.Scope(_, _, exp, _, _, _) =>
+    case Expression.Scope(_, _, _, exp, _, _, _) =>
       visitExp(exp)
 
     case Expression.IfThenElse(exp1, exp2, exp3, _, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -294,7 +294,7 @@ object Simplifier {
       case TypedAst.Expression.Region(_, _) =>
         throw InternalCompilerException(s"Unexpected expression: $exp0.")
 
-      case TypedAst.Expression.Scope(_, _, _, _, _, _) =>
+      case TypedAst.Expression.Scope(_, _, _, _, _, _, _) =>
         throw InternalCompilerException(s"Unexpected expression: $exp0.")
 
       case TypedAst.Expression.FixpointConstraintSet(_, _, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Statistics.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Statistics.scala
@@ -106,7 +106,7 @@ object Statistics {
       case Expression.Let(sym, mod, exp1, exp2, tpe, eff, loc) => visitExp(exp1) ++ visitExp(exp2)
       case Expression.LetRec(sym, mod, exp1, exp2, tpe, eff, loc) => visitExp(exp1) ++ visitExp(exp2)
       case Expression.Region(tpe, loc) => Counter.empty
-      case Expression.Scope(sym, regionVar, exp, tpe, eff, loc) => visitExp(exp)
+      case Expression.Scope(_, _, _, exp, _, _, _) => visitExp(exp)
       case Expression.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) => visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
       case Expression.Stm(exp1, exp2, tpe, eff, loc) => visitExp(exp1) ++ visitExp(exp2)
       case Expression.Discard(exp, eff, loc) => visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -166,9 +166,9 @@ object Stratifier {
     case Expression.Region(_, _) =>
       exp0.toSuccess
 
-    case Expression.Scope(sym, regionVar, exp, tpe, eff, loc) =>
+    case Expression.Scope(sym, varSym, tvar, exp, tpe, eff, loc) =>
       mapN(visitExp(exp)) {
-        case e => Expression.Scope(sym, regionVar, e, tpe, eff, loc)
+        case e => Expression.Scope(sym, varSym, tvar, e, tpe, eff, loc)
       }
 
     case Expression.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
@@ -531,7 +531,7 @@ object Stratifier {
     case Expression.Region(_, _) =>
       LabelledGraph.empty
 
-    case Expression.Scope(_, _, exp, _, _, _) =>
+    case Expression.Scope(_, _, _, exp, _, _, _) =>
       labelledGraphOfExp(exp)
 
     case Expression.IfThenElse(exp1, exp2, exp3, _, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -990,7 +990,7 @@ object Weeder {
 
     case ParsedAst.Expression.Static(sp1, sp2) =>
       val loc = mkSL(sp1, sp2)
-      val tpe = Type.mkRegion(Type.False, loc)
+      val tpe = Type.mkRegionStar(Type.False, loc)
       WeededAst.Expression.Region(tpe, loc).toSuccess
 
     case ParsedAst.Expression.Scope(sp1, ident, exp, sp2) =>
@@ -2966,7 +2966,7 @@ object Weeder {
     * Returns the region expression `region` if it is non-None. Otherwise returns the global region.
     */
   private def getRegionOrDefault(region: Option[WeededAst.Expression], loc: SourceLocation): WeededAst.Expression = {
-    val tpe = Type.mkRegion(Type.False, loc)
+    val tpe = Type.mkRegionStar(Type.False, loc)
     val exp = WeededAst.Expression.Region(tpe, loc)
     region.getOrElse(exp)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -147,7 +147,7 @@ object CodeHinter {
 
     case Expression.Region(_, _) => Nil
 
-    case Expression.Scope(_, _, exp, _, _, _) =>
+    case Expression.Scope(_, _, _, exp, _, _, _) =>
       visitExp(exp)
 
     case Expression.IfThenElse(exp1, exp2, exp3, _, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/BoolTable.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/BoolTable.scala
@@ -96,11 +96,12 @@ object BoolTable {
     }
 
     // Compute the variables in `tpe`.
-    val tvars = tpe.typeVars.map(_.sym).toList
+    val tvars = tpe.typeVars.toList.map(tvar => BoolFormula.RegionOrVar.Var(tvar.sym))
+    val regions = tpe.regionSyms.toList.map(BoolFormula.RegionOrVar.Region)
 
-    // Construct a bi-directional map from type variables to indices.
+    // Construct a bi-directional map from type variables and regions to indices.
     // The idea is that the first variable becomes x0, the next x1, and so forth.
-    val m = tvars.zipWithIndex.foldLeft(Bimap.empty[Symbol.KindedTypeVarSym, Variable]) {
+    val m = (tvars ++ regions).zipWithIndex.foldLeft(Bimap.empty[BoolFormula.RegionOrVar, Variable]) {
       case (macc, (sym, x)) => macc + (sym -> x)
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/BoolUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/BoolUnification.scala
@@ -174,6 +174,11 @@ object BoolUnification {
     case Type.Cst(cst, loc) => Type.Cst(cst, loc)
     case Type.Apply(tpe1, tpe2, loc) => Type.Apply(flexify(tpe1), flexify(tpe2), loc)
     case Type.Alias(cst, args, tpe, loc) => Type.Alias(cst, args.map(flexify), flexify(tpe), loc)
+    case Type.ReadWrite(tpe, loc) => Type.ReadWrite(flexify(tpe), loc)
+    case Type.UnkindedArrow(Ast.PurityAndEffect(pur0, eff0), arity, loc) =>
+      val pur = pur0.map(flexify)
+      val eff = eff0.map(_.map(flexify))
+      Type.UnkindedArrow(Ast.PurityAndEffect(pur, eff), arity, loc)
   }
 
 

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/InferMonad.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/InferMonad.scala
@@ -104,7 +104,7 @@ case class InferMonad[A](run: (Substitution, RigidityEnv) => Result[(Substitutio
   }
 
   // MATT for debugging
-  lazy val result = run(Substitution.empty, Map.empty).get
+  lazy val result = run(Substitution.empty, RigidityEnv.empty).get
 
   lazy val (subst, renv, value) = result
 

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/InferMonad.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/InferMonad.scala
@@ -91,6 +91,7 @@ case class InferMonad[A](run: (Substitution, RigidityEnv) => Result[(Substitutio
     }
 
     InferMonad(runNext)
+
   }
 
   // TODO: Necessary for pattern matching?
@@ -100,5 +101,20 @@ case class InferMonad[A](run: (Substitution, RigidityEnv) => Result[(Substitutio
       case Ok((subst, renv, t)) => if (f(t)) Ok((subst, renv, t)) else Ok((subst, renv, t))
       case Err(e) => Err(e)
     }
+  }
+
+  // MATT for debugging
+  lazy val result = run(Substitution.empty, Map.empty).get
+
+  lazy val (subst, renv, value) = result
+
+  /**
+    * toString for debugging.
+    * Eagerly evaluates the substitution.
+    *
+    * Must not be called from non-debugging code.
+    */
+  override def toString: String = {
+    result.toString
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -450,6 +450,8 @@ object Unification {
             (tpe, syms0, subst0)
         }
       case Type.UnkindedVar(sym, loc) => throw InternalCompilerException("unexpected unkinded type")
+      case Type.UnkindedArrow(purAndEff, arity, loc) => throw InternalCompilerException("unexpected unkinded type")
+      case Type.ReadWrite(tpe, loc) => throw InternalCompilerException("unexpected unkinded type")
       case Type.Ascribe(tpe, kind, loc) => throw InternalCompilerException("unexpected unkinded type")
       case Type.Cst(TypeConstructor.Region(sym), loc) if reg == sym => (Type.True, syms0, subst0)
       case Type.Cst(cst, loc) => (Type.Cst(cst, loc), syms0, subst0)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRegions.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRegions.scala
@@ -40,7 +40,7 @@ class TestRegions extends FunSuite with TestUtils {
         |    }
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.RegionVarEscapes](result)
+    expectError[TypeError.RegionEscapes](result)
   }
 
   test("RegionVarEscapes.02") {
@@ -60,7 +60,7 @@ class TestRegions extends FunSuite with TestUtils {
         |    }
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.RegionVarEscapes](result)
+    expectError[TypeError.RegionEscapes](result)
   }
 
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1227,7 +1227,7 @@ class TestTyper extends FunSuite with TestUtils {
         |
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.RegionVarEscapes](result)
+    expectError[TypeError.RegionEscapes](result)
   }
 
   test("Test.RegionVarEscapes.02") {
@@ -1244,7 +1244,7 @@ class TestTyper extends FunSuite with TestUtils {
         |
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.RegionVarEscapes](result)
+    expectError[TypeError.RegionEscapes](result)
   }
 
   test("Test.RegionVarEscapes.03") {
@@ -1261,7 +1261,7 @@ class TestTyper extends FunSuite with TestUtils {
         |
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.RegionVarEscapes](result)
+    expectError[TypeError.RegionEscapes](result)
   }
 
   test("Test.RegionVarEscapes.04") {
@@ -1281,7 +1281,7 @@ class TestTyper extends FunSuite with TestUtils {
         |
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.RegionVarEscapes](result)
+    expectError[TypeError.RegionEscapes](result)
   }
 
 //  test("Test.RegionVarEscapes.05") {


### PR DESCRIPTION
This addresses the issues raised by #3902.

The idea is that, when we purify a type, we replace all the type variables it contains, as well as their transitive closure in the substitution, with fresh variables.

So when we do:
```scala
subst = {
    a -> a and b
    b -> c
    c -> c
}
tpe = a

purify(tpe, subst)
// produces
subst = {
    a -> a and b
    b -> c
    c -> c
    a' -> a' and b'
    b' -> c'
    c' -> c'
}
tpe = a'
```

Why does this work? I don't really know; I was just following my heart.