### PR TITLE
Make ids more readable in error messages

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -22,8 +22,6 @@ import ca.uwaterloo.flix.language.fmt.FormatType.formatWellKindedType
 import ca.uwaterloo.flix.language.fmt._
 import ca.uwaterloo.flix.util.Formatter
 
-import scala.collection.mutable
-
 /**
   * A common super-type for type errors.
   */

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -22,6 +22,8 @@ import ca.uwaterloo.flix.language.fmt.FormatType.formatWellKindedType
 import ca.uwaterloo.flix.language.fmt._
 import ca.uwaterloo.flix.util.Formatter
 
+import scala.collection.mutable
+
 /**
   * A common super-type for type errors.
   */
@@ -31,6 +33,7 @@ sealed trait TypeError extends CompilationMessage {
 
 object TypeError {
   implicit val audience: Audience = Audience.External
+  implicit val context = new ReadableContext
 
   /**
     * Generalization Error.

--- a/main/src/ca/uwaterloo/flix/language/fmt/Context.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/Context.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Paul Butcher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.fmt
+
+import scala.collection.mutable
+
+trait Context {
+  def getReadableAlias(id: Int): Int
+}
+
+class ReadableContext extends Context {
+  private val tempIds = mutable.Map[Int, Int]()
+  private var nextId = 0
+
+  def getReadableAlias(id: Int): Int =
+    tempIds.getOrElseUpdate(id, {nextId += 1; nextId})
+}
+
+class RawContext extends Context {
+  def getReadableAlias(id: Int) = id
+}

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
@@ -22,7 +22,7 @@ object FormatType {
   /**
     * Transforms the given well-kinded type into a string.
     */
-  def formatWellKindedType(tpe: Type)(implicit audience: Audience): String = {
+  def formatWellKindedType(tpe: Type)(implicit audience: Audience, context: Context = new RawContext): String = {
     // TODO: Remove after we're confident in the formatter.
     try {
       format(SimpleType.fromWellKindedType(tpe))
@@ -42,7 +42,7 @@ object FormatType {
   /**
     * Transforms the given type into a string.
     */
-  private def format(tpe00: SimpleType)(implicit audience: Audience): String = {
+  private def format(tpe00: SimpleType)(implicit audience: Audience, context: Context): String = {
 
     /**
       * Wraps the given type with parentheses.
@@ -257,16 +257,17 @@ object FormatType {
         val strings = tpes.map(visit(_, Mode.Type))
         string + strings.mkString("[", ", ", "]")
       case SimpleType.Var(id, kind, rigidity, text) =>
+        val readableId = context.getReadableAlias(id)
         val prefix: String = kind match {
-          case Kind.Wild => "_" + id.toString
-          case Kind.Beef => "_b" + id.toString
-          case Kind.Star => "t" + id
-          case Kind.Bool => "b" + id
-          case Kind.Effect => "e" + id
-          case Kind.RecordRow => "r" + id
-          case Kind.SchemaRow => "s" + id
-          case Kind.Predicate => "'" + id.toString
-          case Kind.Arrow(_, _) => "'" + id.toString
+          case Kind.Wild => "_" + readableId.toString
+          case Kind.Beef => "_b" + readableId.toString
+          case Kind.Star => "t" + readableId
+          case Kind.Bool => "b" + readableId
+          case Kind.Effect => "e" + readableId
+          case Kind.RecordRow => "r" + readableId
+          case Kind.SchemaRow => "s" + readableId
+          case Kind.Predicate => "'" + readableId.toString
+          case Kind.Arrow(_, _) => "'" + readableId.toString
         }
         val suffix = rigidity match {
           case Rigidity.Flexible => ""
@@ -278,7 +279,7 @@ object FormatType {
           case Audience.External => text match {
             case VarText.Absent => string
             case VarText.SourceText(s) => s
-            case VarText.FallbackText(s) => "?" + s + id.toString
+            case VarText.FallbackText(s) => "?" + s + context.getReadableAlias(id).toString
           }
         }
 
@@ -299,5 +300,4 @@ object FormatType {
 
     case object Type extends Mode
   }
-
 }

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
@@ -300,4 +300,5 @@ object FormatType {
 
     case object Type extends Mode
   }
+
 }


### PR DESCRIPTION
This change creates more readable ids for use in error messages, tranforming (for example):

```
>> Unable to unify the types: 'List[t15714969]' and 'Int32'.

3 |     1 :: 2 :: 3 :: 4 :: Nil |> List.flatMap(x -> x / 2)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^
                                   mismatched types.

Type One: (t15714967 -> List[t15714969] & ?eff15714964) -> (List[t15714967] -> 
List[t15714969] & ?eff15714964)
Type Two: (Int32 -> Int32) -> ?result15714956 & ?eff15714958
```

into this:

```
>> Unable to unify the types: 'List[t1]' and 'Int32'.

3 |     1 :: 2 :: 3 :: 4 :: Nil |> List.flatMap(x -> x / 2)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^
                                   mismatched types.

Type One: (t2 -> List[t1] & ?eff3) -> (List[t2] -> List[t1] & ?eff3)
Type Two: (Int32 -> Int32) -> ?result5 & ?eff4
```
