### PR TITLE
refactor: rewrite backend to use field objects

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/AsmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/AsmOps.scala
@@ -370,7 +370,7 @@ object AsmOps {
     mv.visitTypeInsn(NEW, className.toInternalName)
     mv.visitInsn(DUP2)
     mv.visitInsn(SWAP)
-    mv.visitMethodInsn(INVOKESPECIAL, className.toInternalName, "<init>", s"(${JvmName.ReifiedSourceLocation.toDescriptor})${JvmType.Void.toDescriptor}", false)
+    mv.visitMethodInsn(INVOKESPECIAL, className.toInternalName, "<init>", s"(${BackendObjType.ReifiedSourceLocation.toDescriptor})${JvmType.Void.toDescriptor}", false)
     mv.visitInsn(ATHROW)
   }
 
@@ -385,7 +385,7 @@ object AsmOps {
     mv.visitInsn(SWAP)
     mv.visitLdcInsn(hole)
     mv.visitInsn(SWAP)
-    mv.visitMethodInsn(INVOKESPECIAL, className.toInternalName, "<init>", s"(${BackendObjType.String.toDescriptor}${JvmName.ReifiedSourceLocation.toDescriptor})${JvmType.Void.toDescriptor}", false)
+    mv.visitMethodInsn(INVOKESPECIAL, className.toInternalName, "<init>", s"(${BackendObjType.String.toDescriptor}${BackendObjType.ReifiedSourceLocation.toDescriptor})${JvmType.Void.toDescriptor}", false)
     mv.visitInsn(ATHROW)
   }
 
@@ -393,14 +393,15 @@ object AsmOps {
     * Generates code which instantiate a reified source location.
     */
   def compileReifiedSourceLocation(mv: MethodVisitor, loc: SourceLocation): Unit = {
-    mv.visitTypeInsn(NEW, JvmName.ReifiedSourceLocation.toInternalName)
+    val RslType = BackendObjType.ReifiedSourceLocation
+    mv.visitTypeInsn(NEW, RslType.jvmName.toInternalName)
     mv.visitInsn(DUP)
     mv.visitLdcInsn(loc.source.name)
     mv.visitLdcInsn(loc.beginLine)
     mv.visitLdcInsn(loc.beginCol)
     mv.visitLdcInsn(loc.endLine)
     mv.visitLdcInsn(loc.endCol)
-    mv.visitMethodInsn(INVOKESPECIAL, JvmName.ReifiedSourceLocation.toInternalName, JvmName.ConstructorMethod, GenReifiedSourceLocationClass.ConstructorDescriptor.toDescriptor, false)
+    mv.visitMethodInsn(INVOKESPECIAL, RslType.jvmName.toInternalName, JvmName.ConstructorMethod, RslType.ConstructorDescriptor.toDescriptor, false)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -18,9 +18,11 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.phase.jvm.BackendObjType.mkName
-import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{InstanceField, InstanceMethod, InterfaceMethod, StaticField}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker._
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor.mkDescriptor
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.{DevFlixRuntime, JavaLang, RootPackage}
+import ca.uwaterloo.flix.language.phase.jvm.JvmName.{DevFlixRuntime, JavaLang, MethodDescriptor, RootPackage}
 
 /**
   * Represents all Flix types that are objects on the JVM (array is an exception).
@@ -43,6 +45,8 @@ sealed trait BackendObjType {
     case BackendObjType.RecordExtend(_, value, _) => JvmName(RootPackage, mkName("RecordExtend", value))
     case BackendObjType.Record => JvmName(RootPackage, s"IRecord${Flix.Delimiter}")
     case BackendObjType.Native(className) => className
+    case BackendObjType.ReifiedSourceLocation => JvmName(DevFlixRuntime, "ReifiedSourceLocation")
+    case BackendObjType.Global => JvmName(DevFlixRuntime, "Global")
   }
 
   /**
@@ -76,7 +80,7 @@ object BackendObjType {
 
 
   case object Unit extends BackendObjType {
-    def InstanceField: StaticField = StaticField(this.jvmName, "INSTANCE", this.toTpe)
+    def InstanceField: StaticField = StaticField(this.jvmName, IsPublic, IsFinal, "INSTANCE", this.toTpe)
   }
 
   case object BigInt extends BackendObjType
@@ -88,7 +92,7 @@ object BackendObjType {
   case class Lazy(tpe: BackendType) extends BackendObjType
 
   case class Ref(tpe: BackendType) extends BackendObjType {
-    def ValueField: InstanceField = InstanceField(this.jvmName, "value", tpe)
+    def ValueField: InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, "value", tpe)
   }
 
   case class Tuple(elms: List[BackendType]) extends BackendObjType
@@ -98,7 +102,7 @@ object BackendObjType {
   case class Arrow(args: List[BackendType], result: BackendType) extends BackendObjType {
     def continuation: BackendObjType.Continuation = Continuation(result.toErased)
 
-    def ArgField(index: Int): InstanceField = InstanceField(this.jvmName, s"arg$index", args(index))
+    def ArgField(index: Int): InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, s"arg$index", args(index))
 
     def ResultField: InstanceField = continuation.ResultField
 
@@ -108,7 +112,7 @@ object BackendObjType {
   }
 
   case class Continuation(result: BackendType) extends BackendObjType {
-    def ResultField: InstanceField = InstanceField(this.jvmName, "result", result)
+    def ResultField: InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, "result", result)
 
     def InvokeMethod: InstanceMethod = InstanceMethod(this.jvmName, "invoke", mkDescriptor()(this.toTpe))
 
@@ -118,7 +122,7 @@ object BackendObjType {
   case object RecordEmpty extends BackendObjType {
     def interface: BackendObjType.Record.type = Record
 
-    def InstanceField: StaticField = StaticField(this.jvmName, "INSTANCE", this.toTpe)
+    def InstanceField: StaticField = StaticField(this.jvmName, IsPublic, IsFinal, "INSTANCE", this.toTpe)
 
     def LookupFieldMethod: InstanceMethod = interface.LookupFieldMethod.implementation(this.jvmName)
 
@@ -128,11 +132,11 @@ object BackendObjType {
   case class RecordExtend(field: String, value: BackendType, rest: BackendType) extends BackendObjType {
     def interface: BackendObjType.Record.type = Record
 
-    def LabelField: InstanceField = InstanceField(this.jvmName, "label", BackendObjType.String.toTpe)
+    def LabelField: InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, "label", BackendObjType.String.toTpe)
 
-    def ValueField: InstanceField = InstanceField(this.jvmName, "value", value)
+    def ValueField: InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, "value", value)
 
-    def RestField: InstanceField = InstanceField(this.jvmName, "rest", interface.toTpe)
+    def RestField: InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, "rest", interface.toTpe)
 
     def LookupFieldMethod: InstanceMethod = interface.LookupFieldMethod.implementation(this.jvmName)
 
@@ -156,9 +160,47 @@ object BackendObjType {
   //  case class Lattice(tpes: List[BackendType]) extends BackendObjType
 
   /**
-    * Represents a JVM type not represented in Flix like `java.lang.Object` or `dev.flix.runtime.ReifiedSourceLocation`.
+    * Represents a JVM type not represented in BackendObjType.
     * This should not be used for `java.lang.String` for example since `BackendObjType.String`
     * represents this type.
     */
   case class Native(className: JvmName) extends BackendObjType
+
+
+  case object ReifiedSourceLocation extends BackendObjType {
+    def ConstructorDescriptor: MethodDescriptor =
+      mkDescriptor(BackendObjType.String.toTpe, BackendType.Int32, BackendType.Int32, BackendType.Int32, BackendType.Int32)(VoidableType.Void)
+
+    def SourceField: InstanceField =
+      InstanceField(this.jvmName, IsPublic, IsFinal, "source", BackendObjType.String.toTpe)
+
+    def BeginLineField: InstanceField =
+      InstanceField(this.jvmName, IsPublic, IsFinal, "beginLine", BackendType.Int32)
+
+    def BeginColField: InstanceField =
+      InstanceField(this.jvmName, IsPublic, IsFinal, "beginCol", BackendType.Int32)
+
+    def EndLineField: InstanceField =
+      InstanceField(this.jvmName, IsPublic, IsFinal, "endLine", BackendType.Int32)
+
+    def EndColField: InstanceField =
+      InstanceField(this.jvmName, IsPublic, IsFinal, "endCol", BackendType.Int32)
+  }
+
+  case object Global extends BackendObjType {
+    def NewIdMethod: StaticMethod = StaticMethod(this.jvmName, "newId",
+      mkDescriptor()(BackendType.Int64))
+
+    def GetArgsMethod: StaticMethod = StaticMethod(this.jvmName, "getArgs",
+      mkDescriptor()(BackendType.Array(BackendObjType.String.toTpe)))
+
+    def SetArgsMethod: StaticMethod = StaticMethod(this.jvmName, "setArgs",
+      mkDescriptor(BackendType.Array(BackendObjType.String.toTpe))(VoidableType.Void))
+
+    def CounterField: StaticField =
+      StaticField(this.jvmName, IsPrivate, IsFinal, "counter", JvmName.AtomicLong.toTpe)
+
+    def ArgsField: StaticField = StaticField(this.jvmName, IsPrivate, IsFinal, "args",
+      BackendType.Array(BackendObjType.String.toTpe))
+  }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -17,6 +17,7 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions.Branch.{FalseBranch, TrueBranch}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.{InstanceField, StaticField}
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
 import org.objectweb.asm.{Label, MethodVisitor, Opcodes}
 
@@ -185,13 +186,13 @@ object BytecodeInstructions {
     f
   }
 
-  def GETFIELD(className: JvmName, fieldName: String, fieldType: BackendType): InstructionSet = f => {
-    f.visitFieldInstruction(Opcodes.GETFIELD, className, fieldName, fieldType)
+  def GETFIELD(field: InstanceField): InstructionSet = f => {
+    f.visitFieldInstruction(Opcodes.GETFIELD, field.clazz, field.name, field.tpe)
     f
   }
 
-  def GETSTATIC(className: JvmName, fieldName: String, fieldType: BackendType): InstructionSet = f => {
-    f.visitFieldInstruction(Opcodes.GETSTATIC, className, fieldName, fieldType)
+  def GETSTATIC(field: StaticField): InstructionSet = f => {
+    f.visitFieldInstruction(Opcodes.GETSTATIC, field.clazz, field.name, field.tpe)
     f
   }
 
@@ -290,13 +291,13 @@ object BytecodeInstructions {
     f
   }
 
-  def PUTFIELD(className: JvmName, fieldName: String, fieldType: BackendType): InstructionSet = f => {
-    f.visitFieldInstruction(Opcodes.PUTFIELD, className, fieldName, fieldType)
+  def PUTFIELD(field: InstanceField): InstructionSet = f => {
+    f.visitFieldInstruction(Opcodes.PUTFIELD, field.clazz, field.name, field.tpe)
     f
   }
 
-  def PUTSTATIC(className: JvmName, fieldName: String, fieldType: BackendType): InstructionSet = f => {
-    f.visitFieldInstruction(Opcodes.PUTSTATIC, className, fieldName, fieldType)
+  def PUTSTATIC(field: StaticField): InstructionSet = f => {
+    f.visitFieldInstruction(Opcodes.PUTSTATIC, field.clazz, field.name, field.tpe)
     f
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenContinuationAbstractClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenContinuationAbstractClasses.scala
@@ -58,7 +58,7 @@ object GenContinuationAbstractClasses {
     val cm = ClassMaker.mkAbstractClass(contType.jvmName, interfaces = List(JvmName.Runnable))
     cm.mkObjectConstructor(IsPublic)
     // essentially an abstract field
-    contType.ResultField.mkField(cm, IsPublic, NotFinal)
+    cm.mkField(contType.ResultField)
     contType.InvokeMethod.mkAbstractMethod(cm)
     contType.UnwindMethod.mkMethod(cm, genUnwindMethod(contType), IsPublic, IsFinal)
     cm.mkMethod(genRunMethod(contType), "run", NothingToVoid, IsPublic, IsFinal)
@@ -78,7 +78,7 @@ object GenContinuationAbstractClasses {
             currentCont.store()
         } ~
           previousCont.load() ~
-          contType.ResultField.getField() ~
+          GETFIELD(contType.ResultField) ~
           xReturn(contType.result)
       }
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunctionAbstractClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunctionAbstractClasses.scala
@@ -55,8 +55,9 @@ object GenFunctionAbstractClasses {
 
     cm.mkConstructor(genConstructor(cont), MethodDescriptor.NothingToVoid, IsPublic)
 
-    for (argIndex <- arrow.args.indices)
-      arrow.ArgField(argIndex).mkField(cm, IsPublic, NotFinal)
+    for (argIndex <- arrow.args.indices) {
+      cm.mkField(arrow.ArgField(argIndex))
+    }
 
     cm.closeClassMaker()
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenGlobalClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenGlobalClass.scala
@@ -17,9 +17,9 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.BackendObjType.Global
 import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions._
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final._
-import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.StaticField
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility._
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
 import org.objectweb.asm.Opcodes
@@ -29,51 +29,39 @@ import org.objectweb.asm.Opcodes
   */
 object GenGlobalClass {
 
-  private val newIdMethodName: String = "newId"
-  private val counterField: StaticField =
-    StaticField(JvmName.Global, "counter", JvmName.AtomicLong.toTpe)
-
-  private val getArgsMethodName: String = "getArgs"
-  val SetArgsMethodName: String = "setArgs"
-  private val argsField: StaticField = StaticField(JvmName.Global, "args",
-    BackendType.Array(BackendObjType.String.toTpe))
-
   def gen()(implicit flix: Flix): Map[JvmName, JvmClass] = {
-    Map(JvmName.Global -> JvmClass(JvmName.Global, genByteCode()))
+    val name = Global.jvmName
+    Map(name -> JvmClass(name, genByteCode()))
   }
 
   private def genByteCode()(implicit flix: Flix): Array[Byte] = {
-    val cm = ClassMaker.mkClass(JvmName.Global, IsFinal)
+    val cm = ClassMaker.mkClass(Global.jvmName, IsFinal)
 
     cm.mkObjectConstructor(IsPrivate)
     cm.mkStaticConstructor(genStaticConstructor())
-    counterField.mkStaticField(cm, IsPrivate, IsFinal)
-    cm.mkStaticMethod(genNewIdMethod(), newIdMethodName,
-      MethodDescriptor(Nil, BackendType.Int64),
-      IsPublic, IsFinal)
+    cm.mkField(Global.CounterField)
+    cm.mkStaticMethod(genNewIdMethod(), Global.NewIdMethod.name,
+      Global.NewIdMethod.d, IsPublic, IsFinal)
 
-    argsField.mkStaticField(cm, IsPrivate, NotFinal)
-    val stringArrayType = BackendType.Array(BackendObjType.String.toTpe)
-    cm.mkStaticMethod(genGetArgsMethod(), getArgsMethodName,
-      MethodDescriptor(Nil, stringArrayType),
-      IsPublic, IsFinal)
-    cm.mkStaticMethod(genSetArgsMethod(), SetArgsMethodName,
-      MethodDescriptor(List(stringArrayType), VoidableType.Void),
-      IsPublic, IsFinal)
+    cm.mkField(Global.ArgsField)
+    cm.mkStaticMethod(genGetArgsMethod(), Global.GetArgsMethod.name,
+      Global.GetArgsMethod.d, IsPublic, IsFinal)
+    cm.mkStaticMethod(genSetArgsMethod(), Global.SetArgsMethod.name,
+      Global.SetArgsMethod.d, IsPublic, IsFinal)
     cm.closeClassMaker()
   }
 
   private def genStaticConstructor(): InstructionSet =
     NEW(JvmName.AtomicLong) ~
       DUP() ~ invokeConstructor(JvmName.AtomicLong) ~
-      counterField.putStaticField() ~
+      PUTSTATIC(Global.CounterField) ~
       ICONST_0() ~
       ANEWARRAY(BackendObjType.String.jvmName) ~
-      argsField.putStaticField() ~
+      PUTSTATIC(Global.ArgsField) ~
       RETURN()
 
   private def genNewIdMethod()(implicit flix: Flix): InstructionSet =
-    counterField.getStaticField() ~
+    GETSTATIC(Global.CounterField) ~
       INVOKEVIRTUAL(JvmName.AtomicLong, "getAndIncrement",
         MethodDescriptor(Nil, BackendType.Int64)) ~
       LRETURN()
@@ -91,16 +79,16 @@ object GenGlobalClass {
   }
 
   private def genGetArgsMethod()(implicit flix: Flix): InstructionSet =
-    argsField.getStaticField() ~
+    GETSTATIC(Global.ArgsField) ~
       ARRAYLENGTH() ~
       ANEWARRAY(BackendObjType.String.jvmName) ~
       ASTORE(0) ~
       // the new array is now created, now to copy the args
-      argsField.getStaticField() ~
+      GETSTATIC(Global.ArgsField) ~
       ICONST_0() ~
       ALOAD(0) ~
       ICONST_0() ~
-      argsField.getStaticField() ~ ARRAYLENGTH() ~
+      GETSTATIC(Global.ArgsField) ~ ARRAYLENGTH() ~
       arrayCopy() ~
       ALOAD(0) ~
       ARETURN()
@@ -117,6 +105,6 @@ object GenGlobalClass {
       ICONST_0() ~
       ALOAD(0) ~ ARRAYLENGTH() ~
       arrayCopy() ~
-      ALOAD(1) ~ argsField.putStaticField() ~ RETURN()
+      ALOAD(1) ~ PUTSTATIC(Global.ArgsField) ~ RETURN()
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenMainClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenMainClass.scala
@@ -115,8 +115,8 @@ object GenMainClass {
 
     // Save the args in `dev.flix.runtime.Global.setArgs(..)`.
     val setArgsDescriptor = s"(${AsmOps.getArrayType(JvmType.String)})${JvmType.Void.toDescriptor}"
-    main.visitMethodInsn(INVOKESTATIC, JvmName.Global.toInternalName,
-      GenGlobalClass.SetArgsMethodName, setArgsDescriptor, false)
+    main.visitMethodInsn(INVOKESTATIC, BackendObjType.Global.jvmName.toInternalName,
+      BackendObjType.Global.SetArgsMethod.name, setArgsDescriptor, false)
 
     // Push `Unit` on the stack.
     main.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName,

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRecordEmptyClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRecordEmptyClass.scala
@@ -59,7 +59,7 @@ object GenRecordEmptyClass {
 
     cm.mkStaticConstructor(genStaticConstructor())
     cm.mkObjectConstructor(IsPrivate)
-    RecordEmpty.InstanceField.mkStaticField(cm, IsPublic, IsFinal)
+    cm.mkField(RecordEmpty.InstanceField)
     RecordEmpty.LookupFieldMethod.mkMethod(cm, genLookupFieldMethod(), IsPublic, IsFinal)
     RecordEmpty.RestrictFieldMethod.mkMethod(cm, genRestrictFieldMethod(), IsPublic, IsFinal)
 
@@ -70,7 +70,7 @@ object GenRecordEmptyClass {
     NEW(RecordEmpty.jvmName) ~
       DUP() ~
       invokeConstructor(RecordEmpty.jvmName, MethodDescriptor.NothingToVoid) ~
-      RecordEmpty.InstanceField.putStaticField() ~
+      PUTSTATIC(RecordEmpty.InstanceField) ~
       RETURN()
 
   private def genLookupFieldMethod(): InstructionSet =

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRecordExtendClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRecordExtendClasses.scala
@@ -66,9 +66,9 @@ object GenRecordExtendClasses {
 
     cm.mkObjectConstructor(IsPublic)
 
-    extendType.LabelField.mkField(cm, IsPublic, NotFinal)
-    extendType.ValueField.mkField(cm, IsPublic, NotFinal)
-    extendType.RestField.mkField(cm, IsPublic, NotFinal)
+    cm.mkField(extendType.LabelField)
+    cm.mkField(extendType.ValueField)
+    cm.mkField(extendType.RestField)
 
     extendType.LookupFieldMethod.mkMethod(cm, genLookupFieldMethod(extendType), IsPublic, IsFinal)
     extendType.RestrictFieldMethod.mkMethod(cm, genRestrictFieldMethod(extendType), IsPublic, IsFinal)
@@ -80,7 +80,7 @@ object GenRecordExtendClasses {
     * Compares the label of `this`and `ALOAD(1)` and executes the designated branch.
     */
   private def caseOnLabelEquality(extendType: BackendObjType.RecordExtend)(cases: Branch => InstructionSet): InstructionSet =
-    thisLoad() ~ extendType.LabelField.getField() ~
+    thisLoad() ~ GETFIELD(extendType.LabelField) ~
       ALOAD(1) ~
       INVOKEVIRTUAL(BackendObjType.String.jvmName, "equals", mkDescriptor(JvmName.Object.toTpe)(BackendType.Bool)) ~
       branch(Condition.Bool)(cases)
@@ -90,7 +90,7 @@ object GenRecordExtendClasses {
       case TrueBranch =>
         thisLoad() ~ ARETURN()
       case FalseBranch =>
-        thisLoad() ~ extendType.RestField.getField() ~
+        thisLoad() ~ GETFIELD(extendType.RestField) ~
           ALOAD(1) ~
           BackendObjType.Record.LookupFieldMethod.invokeInterface() ~
           ARETURN()
@@ -99,14 +99,14 @@ object GenRecordExtendClasses {
   private def genRestrictFieldMethod(extendType: BackendObjType.RecordExtend)(implicit root: Root, flix: Flix): InstructionSet =
     caseOnLabelEquality(extendType) {
       case TrueBranch =>
-        thisLoad() ~ extendType.RestField.getField() ~
+        thisLoad() ~ GETFIELD(extendType.RestField) ~
           ARETURN()
       case FalseBranch =>
         thisLoad() ~
-          DUP() ~ extendType.RestField.getField() ~
+          DUP() ~ GETFIELD(extendType.RestField) ~
           ALOAD(1) ~
           BackendObjType.Record.RestrictFieldMethod.invokeInterface() ~
-          extendType.RestField.putField() ~
+          PUTFIELD(extendType.RestField) ~
           thisLoad() ~ ARETURN()
     }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRefClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRefClasses.scala
@@ -33,7 +33,7 @@ object GenRefClasses {
   private def genRefClass(refType: BackendObjType.Ref)(implicit root: Root, flix: Flix): Array[Byte] = {
     val cm = ClassMaker.mkClass(refType.jvmName, IsFinal)
 
-    refType.ValueField.mkField(cm, IsPublic, NotFinal)
+    cm.mkField(refType.ValueField)
     cm.mkObjectConstructor(IsPublic)
 
     cm.closeClassMaker()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenUnitClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenUnitClass.scala
@@ -32,7 +32,7 @@ object GenUnitClass {
     val cm = mkClass(BackendObjType.Unit.jvmName, IsFinal)
 
     // Singleton instance
-    BackendObjType.Unit.InstanceField.mkStaticField(cm, IsPublic, IsFinal)
+    cm.mkField(BackendObjType.Unit.InstanceField)
 
     cm.mkStaticConstructor(genStaticConstructor())
     cm.mkObjectConstructor(IsPrivate)
@@ -43,6 +43,6 @@ object GenUnitClass {
   private def genStaticConstructor(): InstructionSet =
     NEW(BackendObjType.Unit.jvmName) ~
       DUP() ~ invokeConstructor(BackendObjType.Unit.jvmName) ~
-      BackendObjType.Unit.InstanceField.putStaticField() ~
+      PUTSTATIC(BackendObjType.Unit.InstanceField) ~
       RETURN()
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -44,7 +44,8 @@ object JvmName {
   object MethodDescriptor {
     val NothingToVoid: MethodDescriptor = MethodDescriptor(Nil, VoidableType.Void)
 
-    def mkDescriptor(argument: BackendType*)(result: VoidableType): MethodDescriptor = MethodDescriptor(argument.toList, result)
+    def mkDescriptor(argument: BackendType*)(result: VoidableType): MethodDescriptor =
+      MethodDescriptor(argument.toList, result)
   }
 
   /**
@@ -101,11 +102,9 @@ object JvmName {
 
   // TODO: These could be BackendObjType objects to allow method/field objects
   val FlixError: JvmName = JvmName(DevFlixRuntime, "FlixError")
-  val Global: JvmName = JvmName(DevFlixRuntime, "Global")
   val HoleError: JvmName = JvmName(DevFlixRuntime, "HoleError")
   val MatchError: JvmName = JvmName(DevFlixRuntime, "MatchError")
   val ProxyObject: JvmName = JvmName(DevFlixRuntime, "ProxyObject")
-  val ReifiedSourceLocation: JvmName = JvmName(DevFlixRuntime, "ReifiedSourceLocation")
   val SelectChoice: JvmName = JvmName(List("ca", "uwaterloo", "flix", "runtime", "interpreter"), "SelectChoice")
 
   // Deprecated: Should not be used in new code.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmType.scala
@@ -106,7 +106,6 @@ object JvmType {
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Flix Types ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   //
 
-  val ReifiedSourceLocation: JvmType.Reference = Reference(JvmName.ReifiedSourceLocation)
   val Unit: JvmType.Reference = Reference(BackendObjType.Unit.jvmName)
 
   //


### PR DESCRIPTION
Field objects are used to hold all permanent information about a field which is used in generation and code. Related to #2591.