### PR TITLE
chore: allow `inject` as an alias for `project`

### DIFF
--- a/examples/datalog/connect-graph.flix
+++ b/examples/datalog/connect-graph.flix
@@ -24,8 +24,8 @@ pub type alias Graph[node] = {
 /// Given the undirected graph described by `nodes` and `edges`, connected components are
 /// found and a relation with the component representative for each node is returned.
 pub def connectedComponentRep(g: Graph[node]): #{ ComponentRep(node, node) | r } with Boxable[node] =
-    let nodes = project g.nodes into Node;
-    let edges = project g.edges into Edge;
+    let nodes = inject g.nodes into Node;
+    let edges = inject g.edges into Edge;
     let reachability = #{
         // `Reachable(n1, n2)` describes that `n1` can reach `n2`.
         // All nodes can reach themselves.

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1043,7 +1043,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       }
 
       rule {
-        SP ~ keyword("project") ~ WS ~ ExpressionPart ~ WS ~ keyword("into") ~ WS ~ ProjectPart ~ SP ~> ParsedAst.Expression.FixpointProjectInto
+        SP ~ (keyword("project") | keyword("inject")) ~ WS ~ ExpressionPart ~ WS ~ keyword("into") ~ WS ~ ProjectPart ~ SP ~> ParsedAst.Expression.FixpointProjectInto
       }
     }
 


### PR DESCRIPTION
Related to #2478