### PR TITLE
fix: allow predicates with unconstrained terms

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.CompilationMessage
+import ca.uwaterloo.flix.language.{CompilationMessage, ast}
 import ca.uwaterloo.flix.language.ast.Ast._
 import ca.uwaterloo.flix.language.ast.Type.eraseAliases
 import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.Body
@@ -728,13 +728,7 @@ object Stratifier {
     @tailrec
     def visitType(tpe: Type, acc: Map[Name.Pred, Label]): Map[Name.Pred, Label] = tpe match {
       case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(pred), _), predType, _), rest, _) =>
-        val terms = termTypes(predType)
-        val Type.Apply(Type.Cst(den, _), _, _) = predType // same partial match as termTypes
-        val labelDen = den match {
-          case TypeConstructor.Relation => Denotation.Relational
-          case TypeConstructor.Lattice => Denotation.Latticenal
-          case other => throw InternalCompilerException(s"Unexpected non-denotation type constructor: '$other'")
-        }
+        val (terms, labelDen) = termTypesAndDenotation(predType)
         val label = Label(pred, labelDen, terms.length, terms)
         visitType(rest, acc + (pred -> label))
       case _ => acc
@@ -751,12 +745,12 @@ object Stratifier {
     */
   private def labelledGraphOfConstraint(c: Constraint): LabelledGraph = c match {
     case Constraint(_, Predicate.Head.Atom(headPred, den, _, headTpe, _), body0, _) =>
-      val headTerms = termTypes(headTpe)
+      val (headTerms, _) = termTypesAndDenotation(headTpe)
 
       // We add all body predicates and the head to the labels of each edge
       val bodyLabels: Vector[Label] = body0.collect {
         case Body.Atom(bodyPred, den, _, _, _, bodyTpe, _) =>
-          val terms = termTypes(bodyTpe)
+          val (terms, _) = termTypesAndDenotation(bodyTpe)
           Label(bodyPred, den, terms.length, terms)
       }.toVector
 
@@ -777,12 +771,21 @@ object Stratifier {
   /**
     * Returns the term types of the given relational or latticenal type.
     */
-  private def termTypes(tpe: Type): List[Type] = eraseAliases(tpe) match {
-    case Type.Apply(Type.Cst(TypeConstructor.Relation | TypeConstructor.Lattice, _), t, _) => t.baseType match {
-      case Type.Cst(TypeConstructor.Tuple(_), _) => t.typeArguments // Multi-ary
-      case Type.Cst(TypeConstructor.Unit, _) => Nil
-      case _ => List(t) // Unary
+  private def termTypesAndDenotation(tpe: Type): (List[Type], Denotation) = eraseAliases(tpe) match {
+    case Type.Apply(Type.Cst(tc, _), t, _) =>
+      val den = tc match {
+        case TypeConstructor.Relation => Denotation.Relational
+        case TypeConstructor.Lattice => Denotation.Latticenal
+        case _ => throw InternalCompilerException(s"Unexpected non-denotation type constructor: '$tc'")
+      }
+      t.baseType match {
+      case Type.Cst(TypeConstructor.Tuple(_), _) => (t.typeArguments, den) // Multi-ary
+      case Type.Cst(TypeConstructor.Unit, _) => (Nil, den)
+      case _ => (List(t), den) // Unary
     }
+    case _: Type.Var =>
+      // This could occur when querying or projecting a non-existent predicate
+      (Nil, Denotation.Relational)
     case _ => throw InternalCompilerException(s"Unexpected type: '$tpe.'")
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.{CompilationMessage, ast}
+import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.Ast._
 import ca.uwaterloo.flix.language.ast.Type.eraseAliases
 import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.Body
@@ -779,10 +779,10 @@ object Stratifier {
         case _ => throw InternalCompilerException(s"Unexpected non-denotation type constructor: '$tc'")
       }
       t.baseType match {
-      case Type.Cst(TypeConstructor.Tuple(_), _) => (t.typeArguments, den) // Multi-ary
-      case Type.Cst(TypeConstructor.Unit, _) => (Nil, den)
-      case _ => (List(t), den) // Unary
-    }
+        case Type.Cst(TypeConstructor.Tuple(_), _) => (t.typeArguments, den) // Multi-ary
+        case Type.Cst(TypeConstructor.Unit, _) => (Nil, den)
+        case _ => (List(t), den) // Unary
+      }
     case _: Type.Var =>
       // This could occur when querying or projecting a non-existent predicate
       (Nil, Denotation.Relational)

--- a/main/test/flix/Test.Exp.Fixpoint.Constraint.flix
+++ b/main/test/flix/Test.Exp.Fixpoint.Constraint.flix
@@ -73,7 +73,7 @@ namespace Test/Exp/Fixpoint/Constraint {
     }
 
     @test
-    def testPredicateWithTypeVariableTerms(): Bool & Impure = {
+    def testPredicateWithTypeVariableTerms01(): Bool & Impure = {
         let p = #{ A(12). };
         let query1 = query p select () from B();
         let test1 = Array.compare(query1, []) == EqualTo;

--- a/main/test/flix/Test.Exp.Fixpoint.Constraint.flix
+++ b/main/test/flix/Test.Exp.Fixpoint.Constraint.flix
@@ -72,4 +72,15 @@ namespace Test/Exp/Fixpoint/Constraint {
         R(x) :- A(x).
     }
 
+    @test
+    def testPredicateWithTypeVariableTerms(): Bool & Impure = {
+        let p = #{ A(12). };
+        let query1 = query p select () from B();
+        let test1 = Array.compare(query1, []) == EqualTo;
+        let _test2 = solve p project C;
+        let query2 = query (solve p project D) select () from D();
+        let test3 = Array.compare(query2, []) == EqualTo;
+        test1 and test3
+    }
+
 }


### PR DESCRIPTION
Fixes #3193.

When a predicate occurs with a type variable as term type then the stratifier assumes that it is a nullary predicate of relational type. This should be safe since any construct to add facts of the predicate would introduce type constraints.