### PR TITLE
chore: add space after auto-completing keywords

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -94,7 +94,7 @@ object CompletionProvider {
   private def keywordCompletion(name: String)(implicit context: Context, index: Index, root: TypedAst.Root): CompletionItem = {
     CompletionItem(label = name,
       sortText = Priority.keyword(name),
-      textEdit = TextEdit(context.range, name),
+      textEdit = TextEdit(context.range, s"$name "),
       kind = CompletionItemKind.Keyword)
   }
 


### PR DESCRIPTION
Fixes #3959

(I don't think adding a space makes sense after any of the other completions that are currently in place, but let me know if I've missed anything).