### PR TITLE
feat: add FunctorFilter class (related to #3819)

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -178,6 +178,7 @@ class Flix {
     "Reducible.flix" -> LocalResource.get("/src/library/Reducible.flix"),
     "SemiGroup.flix" -> LocalResource.get("/src/library/SemiGroup.flix"),
     "Traversable.flix" -> LocalResource.get("/src/library/Traversable.flix"),
+    "FunctorFilter.flix" -> LocalResource.get("/src/library/FunctorFilter.flix"),
 
     "Validation.flix" -> LocalResource.get("/src/library/Validation.flix"),
 

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -171,6 +171,7 @@ class Flix {
     "ForEach.flix" -> LocalResource.get("/src/library/ForEach.flix"),
     "FromString.flix" -> LocalResource.get("/src/library/FromString.flix"),
     "Functor.flix" -> LocalResource.get("/src/library/Functor.flix"),
+    "FunctorFilter.flix" -> LocalResource.get("/src/library/FunctorFilter.flix"),
     "Group.flix" -> LocalResource.get("/src/library/Group.flix"),
     "Identity.flix" -> LocalResource.get("/src/library/Identity.flix"),
     "Monad.flix" -> LocalResource.get("/src/library/Monad.flix"),
@@ -178,7 +179,6 @@ class Flix {
     "Reducible.flix" -> LocalResource.get("/src/library/Reducible.flix"),
     "SemiGroup.flix" -> LocalResource.get("/src/library/SemiGroup.flix"),
     "Traversable.flix" -> LocalResource.get("/src/library/Traversable.flix"),
-    "FunctorFilter.flix" -> LocalResource.get("/src/library/FunctorFilter.flix"),
 
     "Validation.flix" -> LocalResource.get("/src/library/Validation.flix"),
 

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -69,6 +69,10 @@ instance Traversable[Chain] {
     pub override def sequence(t: Chain[m[a]]): m[Chain[a]] with Applicative[m] = Chain.sequence(t)
 }
 
+instance FunctorFilter[Chain] {
+    pub def filterMap(f: a -> Option[b] & ef, x: Chain[a]): Chain[b] & ef = Chain.filterMap(f, x)
+    pub override def filter(f: a -> Bool & ef, x: Chain[a]): Chain[a] & ef = Chain.filter(f, x)
+}
 
 instance ToString[Chain[a]] with ToString[a] {
     pub def toString(c: Chain[a]): String =

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -95,6 +95,11 @@ instance Iterable[DelayList] {
         DelayList.toIterator(l)
 }
 
+instance FunctorFilter[DelayList] {
+    pub def filterMap(f: a -> Option[b] & ef, x: DelayList[a]): DelayList[b] & ef = DelayList.filterMap(f, x)
+    pub override def filter(f: a -> Bool & ef, x: DelayList[a]): DelayList[a] & ef = DelayList.filter(f, x)
+}
+
 instance SemiGroup[DelayList[a]] {
     pub def combine(l1: DelayList[a], l2: DelayList[a]): DelayList[a] = DelayList.append(l1, l2)
 }

--- a/main/src/library/FunctorFilter.flix
+++ b/main/src/library/FunctorFilter.flix
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2022 Magnus Madsen, Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+///
+/// A type class for filtering container functors.
+///
+pub class FunctorFilter[m : Type -> Type] with Functor[m] {
+
+    ///
+    /// Applies the partial function `f` to every element in `x` collecting the results.
+    ///
+    pub def filterMap(f: a -> Option[b] & ef, t: m[a]): m[b] & ef
+
+    //
+    // Applies `f` to every element in `x`. Keeps every element that satisfies `f`.
+    //
+    pub def filter(f: a -> Bool & ef, t: m[a]): m[a] & ef = FunctorFilter.filterMap(x -> if (f(x)) Some(x) else None, t)
+
+}

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -88,6 +88,11 @@ instance Traversable[List] {
     pub override def sequence(t: List[m[a]]): m[List[a]] with Applicative[m] = List.sequence(t)
 }
 
+instance FunctorFilter[List] {
+    pub def filterMap(f: a -> Option[b] & ef, x: List[a]): List[b] & ef = List.filterMap(f, x)
+    pub override def filter(f: a -> Bool & ef, x: List[a]): List[a] & ef = List.filter(f, x)
+}
+
 instance SemiGroup[List[a]] {
     pub def combine(x: List[a], y: List[a]): List[a] = x ::: y
 }

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -68,6 +68,17 @@ instance Traversable[Map[k]] {
     pub override def sequence(t: Map[k, m[a]]): m[Map[k, a]] with Applicative[m] = Map.sequence(t)
 }
 
+instance FunctorFilter[Map[k]] with Order[k] {
+    pub def filterMap(f: a -> Option[b] & ef, m: Map[k, a]): Map[k, b] & ef =
+        let step = (acc, k, a) -> match f(a) {
+            case Some(b) => Map.insert(k, b, acc)
+            case None    => acc
+        };
+        Map.foldLeftWithKey(step, Map.empty(), m)
+
+    pub override def filter(f: a -> Bool & ef, m: Map[k, a]): Map[k, a] & ef = Map.filter(f, m)
+}
+
 instance SemiGroup[Map[k,v]] with Order[k], SemiGroup[v] {
     pub def combine(x: Map[k,v], y: Map[k,v]): Map[k,v] = Map.unionWith(SemiGroup.combine, x, y)
 }

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -69,13 +69,7 @@ instance Traversable[Map[k]] {
 }
 
 instance FunctorFilter[Map[k]] with Order[k] {
-    pub def filterMap(f: a -> Option[b] & ef, m: Map[k, a]): Map[k, b] & ef =
-        let step = (acc, k, a) -> match f(a) {
-            case Some(b) => Map.insert(k, b, acc)
-            case None    => acc
-        };
-        Map.foldLeftWithKey(step, Map.empty(), m)
-
+    pub def filterMap(f: a -> Option[b] & ef, m: Map[k, a]): Map[k, b] & ef = Map.filterMap(f, m)
     pub override def filter(f: a -> Bool & ef, m: Map[k, a]): Map[k, a] & ef = Map.filter(f, m)
 }
 
@@ -457,6 +451,28 @@ namespace Map {
     @Time(time(f) * size(m)) @Space(space(f) * size(m))
     pub def filterWithKey(f: (k, v) -> Bool & ef, m: Map[k, v]): Map[k, v] & ef with Order[k] =
         foldLeftWithKey((acc, k, v) -> if (f(k, v)) insert(k, v, acc) else acc, empty(), m)
+
+    ///
+    /// Returns a map of all mappings `k => v1` in `m` where applying the function `f` to `v` produces
+    /// a `Some(v1)`. Elements that produce `None` are discarded.
+    ///
+    pub def filterMap(f: a -> Option[b] & ef, m: Map[k, a]): Map[k, b] & ef with Order[k] =
+        let step = (acc, k, a) -> match f(a) {
+            case Some(b) => Map.insert(k, b, acc)
+            case None    => acc
+        };
+        Map.foldLeftWithKey(step, Map.empty(), m)
+
+    ///
+    /// Returns a map of all mappings `k => v1` in `m` where applying the function `f` to `(k, v)` produces
+    /// `Some(v1)`. Elements that produce `None` are discarded.
+    ///
+    pub def filterMapWithKey(f: (k, a) -> Option[b] & ef, m: Map[k, a]): Map[k, b] & ef with Order[k] =
+        let step = (acc, k, a) -> match f(k, a) {
+            case Some(b) => insert(k, b, acc)
+            case None    => acc
+        };
+        foldLeftWithKey(step, Map.empty(), m)
 
     ///
     /// Returns a map with mappings `k => f(v)` for every `k => v` in `m`.

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -110,6 +110,15 @@ instance Traversable[Option] {
 
 }
 
+instance FunctorFilter[Option] {
+    pub def filterMap(f: a -> Option[b] & ef, t: Option[a]): Option[b] & ef = Option.flatMap(f, t)
+
+    pub override def filter(f: a -> Bool & ef, t: Option[a]): Option[a] & ef = match t {
+        case None    => None
+        case Some(x) => if (f(x)) None else Some(x)
+    }
+}
+
 instance SemiGroup[Option[a]] with SemiGroup[a] {
     pub def combine(x: Option[a], y: Option[a]): Option[a] = match (x, y) {
         case (a, None)              => a

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -111,12 +111,8 @@ instance Traversable[Option] {
 }
 
 instance FunctorFilter[Option] {
-    pub def filterMap(f: a -> Option[b] & ef, t: Option[a]): Option[b] & ef = Option.flatMap(f, t)
-
-    pub override def filter(f: a -> Bool & ef, t: Option[a]): Option[a] & ef = match t {
-        case None    => None
-        case Some(x) => if (f(x)) None else Some(x)
-    }
+    pub def filterMap(f: a -> Option[b] & ef, o: Option[a]): Option[b] & ef = Option.flatMap(f, o)
+    pub override def filter(f: a -> Bool & ef, o: Option[a]): Option[a] & ef = Option.filter(f, o)
 }
 
 instance SemiGroup[Option[a]] with SemiGroup[a] {
@@ -202,10 +198,8 @@ namespace Option {
     ///
     /// Returns `o` if `o` is `Some(v)` and the predicate `f(v)` is true. Otherwise returns `None`.
     ///
-    /// The function `f` must be pure.
-    ///
     @Time(time(f)) @Space(space(f))
-    pub def filter(f: a -> Bool, o: Option[a]): Option[a] = match o {
+    pub def filter(f: a -> Bool & ef, o: Option[a]): Option[a] & ef = match o {
         case None    => None
         case Some(v) => if (f(v)) o else None
     }

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -78,6 +78,15 @@ namespace RedBlackTree {
             mapAWithKey((_, v) -> v, t)
     }
 
+    instance FunctorFilter[RedBlackTree[k]] with Order[k] {
+        pub def filterMap(f: a -> Option[b] & ef, t: RedBlackTree[k, a]): RedBlackTree[k, b] & ef =
+            let step = (acc, k, a) -> match f(a) {
+                case Some(b) => insert(k, b, acc)
+                case None    => acc
+            };
+            foldLeft(step, empty(), t)
+    }
+
     ///
     /// The color of a red-black tree node.
     ///

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -78,14 +78,12 @@ namespace RedBlackTree {
             mapAWithKey((_, v) -> v, t)
     }
 
+
     instance FunctorFilter[RedBlackTree[k]] with Order[k] {
-        pub def filterMap(f: a -> Option[b] & ef, t: RedBlackTree[k, a]): RedBlackTree[k, b] & ef =
-            let step = (acc, k, a) -> match f(a) {
-                case Some(b) => insert(k, b, acc)
-                case None    => acc
-            };
-            foldLeft(step, empty(), t)
+        pub def filterMap(f: a -> Option[b] & ef, t: RedBlackTree[k, a]): RedBlackTree[k, b] & ef = filterMapImplementation(f, t)
+        pub override def filter(f: a -> Bool & ef, t: RedBlackTree[k, a]): RedBlackTree[k, a] & ef = filterImplementation(f, t)
     }
+
 
     ///
     /// The color of a red-black tree node.
@@ -1010,4 +1008,37 @@ namespace RedBlackTree {
         StringBuilder.toString(sb) |> String.dropRight(lastSep)
     }
 
+    ///
+    /// Returns a new copy of tree `t` with just the nodes that satisfy the predicate `f`.
+    ///
+    pub def filter(f: v -> Bool & ef, t: RedBlackTree[k, v]): RedBlackTree[k, v] & ef with Order[k] =
+        filterImplementation(f, t)
+
+    ///
+    /// Temporary hack!
+    /// A concrete implementation of `filter` that the `FunctorFilter` instance can use.
+    /// If `FunctorFilter.filter` calls `filter` it appears to invoke a cycle and the concrete
+    /// implementation is never called.
+    ///
+    def filterImplementation(f: v -> Bool & ef, t: RedBlackTree[k, v]): RedBlackTree[k, v] & ef with Order[k] =
+        foldLeft((acc, k, v) -> if (f(v)) insert(k, v, acc) else acc, empty(), t)
+
+    ///
+    /// Collects the results of applying the partial function `f` to every element in `t`.
+    /// This traverses tree `t` and produces a new tree with just nodes where applying f
+    /// produces `Some(_)`.
+    ///
+    pub def filterMap(f: a -> Option[b] & ef, t: RedBlackTree[k, a]): RedBlackTree[k, b] & ef with Order[k] =
+        filterMapImplementation(f, t)
+
+    ///
+    /// Temporary hack!
+    /// A concrete implementation of `filterMap` that the `FunctorFilter` instance can use.
+    ///
+    def filterMapImplementation(f: a -> Option[b] & ef, t: RedBlackTree[k, a]): RedBlackTree[k, b] & ef with Order[k] =
+        let step = (acc, k, a) -> match f(a) {
+            case Some(b) => insert(k, b, acc)
+            case None    => acc
+        };
+        foldLeft(step, empty(), t)
 }

--- a/main/test/ca/uwaterloo/flix/library/TestFunctorFilter.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFunctorFilter.flix
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 Stephen Tetley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace TestFunctorFilter {
+
+    use FunctorFilter.{filter, filterMap};
+
+    def isOdd(i: Int32): Bool = not (i mod 2 == 0)
+
+    def oddPlus10(i: Int32): Option[Int32] = if (isOdd(i)) Some(i + 10) else None
+
+    /////////////////////////////////////////////////////////////////////////////
+    // filterChain                                                             //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def filterChain01(): Bool =
+        filter(isOdd, Chain.empty(): Chain[Int32]) |> Chain.toList == Nil
+
+    @test
+    def filterChain02(): Bool =
+        filter(isOdd, Chain.singleton(1)) |> Chain.toList == 1 :: Nil
+
+    @test
+    def filterChain03(): Bool =
+        filter(isOdd, List.toChain(1 :: 2 :: 3 :: 4 :: Nil)) |> Chain.toList == 1 :: 3 :: Nil
+
+    /////////////////////////////////////////////////////////////////////////////
+    // filterMapChain                                                          //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def filterMapChain01(): Bool =
+        filterMap(oddPlus10, Chain.empty(): Chain[Int32]) |> Chain.toList == Nil
+
+    @test
+    def filterMapChain02(): Bool =
+        filterMap(oddPlus10, Chain.singleton(1)) |> Chain.toList == 11 :: Nil
+
+    @test
+    def filterMapChain03(): Bool =
+        filterMap(oddPlus10, List.toChain(1 :: 2 :: 3 :: 4 :: Nil)) |> Chain.toList == 11 :: 13 :: Nil
+
+    /////////////////////////////////////////////////////////////////////////////
+    // filterOption                                                            //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def filterOption01(): Bool = filter(isOdd, None: Option[Int32]) == None
+
+    @test
+    def filterOption02(): Bool = filter(isOdd, Some(1)) == None
+
+    @test
+    def filterOption03(): Bool = filter(isOdd, Some(2)) == Some(2)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // filterMapOption                                                         //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def filterMapOption01(): Bool = filterMap(oddPlus10, None: Option[Int32]) == None
+
+    @test
+    def filterMapOption02(): Bool = filterMap(oddPlus10, Some(1)) == Some(11)
+
+    @test
+    def filterMapOption03(): Bool = filterMap(oddPlus10, Some(2)) == None
+
+}
+

--- a/main/test/ca/uwaterloo/flix/library/TestFunctorFilter.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFunctorFilter.flix
@@ -182,7 +182,7 @@ namespace TestFunctorFilter {
     @test
     def filterRedBlackTree03(): Bool =
         filter(isOdd, RedBlackTree.empty() |> RedBlackTree.insert(1, 1) |> RedBlackTree.insert(2, 2) |> RedBlackTree.insert(3, 3) |> RedBlackTree.insert(4, 4))
-            |> RedBlackTree.toList == (1, 1) :: (3, 3) :: Nil
+            |> RedBlackTree.toList |> List.sort == (1, 1) :: (3, 3) :: Nil
 
     /////////////////////////////////////////////////////////////////////////////
     // filterMapRedBlackTree                                                   //

--- a/main/test/ca/uwaterloo/flix/library/TestFunctorFilter.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFunctorFilter.flix
@@ -148,10 +148,10 @@ namespace TestFunctorFilter {
     def filterOption01(): Bool = filter(isOdd, None: Option[Int32]) == None
 
     @test
-    def filterOption02(): Bool = filter(isOdd, Some(1)) == None
+    def filterOption02(): Bool = filter(isOdd, Some(1)) == Some(1)
 
     @test
-    def filterOption03(): Bool = filter(isOdd, Some(2)) == Some(2)
+    def filterOption03(): Bool = filter(isOdd, Some(2)) == None
 
     /////////////////////////////////////////////////////////////////////////////
     // filterMapOption                                                         //

--- a/main/test/ca/uwaterloo/flix/library/TestFunctorFilter.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFunctorFilter.flix
@@ -54,6 +54,92 @@ namespace TestFunctorFilter {
     def filterMapChain03(): Bool =
         filterMap(oddPlus10, List.toChain(1 :: 2 :: 3 :: 4 :: Nil)) |> Chain.toList == 11 :: 13 :: Nil
 
+
+    /////////////////////////////////////////////////////////////////////////////
+    // filterDelayList                                                         //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def filterDelayList01(): Bool =
+        filter(isOdd, DelayList.empty(): DelayList[Int32]) |> DelayList.toList == Nil
+
+    @test
+    def filterDelayList02(): Bool =
+        filter(isOdd, DelayList.range(1, 2)) |> DelayList.toList == 1 :: Nil
+
+    @test
+    def filterDelayList03(): Bool =
+        filter(isOdd, DelayList.range(1, 5))  |> DelayList.toList == 1 :: 3 :: Nil
+
+    /////////////////////////////////////////////////////////////////////////////
+    // filterMapDelayList                                                      //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def filterMapDelayList01(): Bool =
+        filterMap(oddPlus10, DelayList.empty(): DelayList[Int32]) |> DelayList.toList == Nil
+
+    @test
+    def filterMapDelayList02(): Bool =
+        filterMap(oddPlus10, DelayList.range(1, 2)) |> DelayList.toList == 11 :: Nil
+
+    @test
+    def filterMapDelayList03(): Bool =
+        filterMap(oddPlus10, DelayList.range(1, 5)) |> DelayList.toList == 11 :: 13 :: Nil
+
+    /////////////////////////////////////////////////////////////////////////////
+    // filterList                                                              //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def filterList01(): Bool = filter(isOdd, Nil: List[Int32]) == Nil
+
+    @test
+    def filterList02(): Bool = filter(isOdd, 1 :: Nil) == 1 :: Nil
+
+    @test
+    def filterList03(): Bool = filter(isOdd, 1 :: 2 :: 3 :: 4 :: Nil) == 1 :: 3 :: Nil
+
+    /////////////////////////////////////////////////////////////////////////////
+    // filterMapList                                                           //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def filterMapList01(): Bool = filterMap(oddPlus10, Nil: List[Int32]) == Nil
+
+    @test
+    def filterMapList02(): Bool = filterMap(oddPlus10, 1 :: Nil) == 11 :: Nil
+
+    @test
+    def filterMapList03(): Bool = filterMap(oddPlus10, 1 :: 2 :: 3 :: 4:: Nil) == 11 :: 13 :: Nil
+
+    /////////////////////////////////////////////////////////////////////////////
+    // filterMap                                                              //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def filterMap01(): Bool = filter(isOdd, Map.empty(): Map[Int32, Int32]) == Map#{}
+
+    @test
+    def filterMap02(): Bool = filter(isOdd, Map#{1 => 1}) == Map#{1 => 1}
+
+    @test
+    def filterMap03(): Bool = filter(isOdd, Map#{1 => 1, 2 => 2, 3 => 3, 4 => 4}) == Map#{1 => 1, 3 => 3}
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // filterMapMap                                                            //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def filterMapMap01(): Bool = filterMap(oddPlus10, Map.empty(): Map[Int32, Int32]) == Map#{}
+
+    @test
+    def filterMapMap02(): Bool = filterMap(oddPlus10, Map#{1 => 1}) == Map#{1 => 11}
+
+    @test
+    def filterMapMap03(): Bool = filterMap(oddPlus10, Map#{1 => 1, 2 => 2, 3 => 3, 4 => 4}) == Map#{1 => 11, 3 => 13}
+
     /////////////////////////////////////////////////////////////////////////////
     // filterOption                                                            //
     /////////////////////////////////////////////////////////////////////////////
@@ -79,6 +165,42 @@ namespace TestFunctorFilter {
 
     @test
     def filterMapOption03(): Bool = filterMap(oddPlus10, Some(2)) == None
+
+    /////////////////////////////////////////////////////////////////////////////
+    // filterRedBlackTree                                                      //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def filterRedBlackTree01(): Bool =
+        filter(isOdd, RedBlackTree.empty(): RedBlackTree.RedBlackTree[Int32, Int32]) == RedBlackTree.empty()
+
+    @test
+    def filterRedBlackTree02(): Bool =
+        filter(isOdd, RedBlackTree.empty() |> RedBlackTree.insert(1, 1))
+            |> RedBlackTree.toList == (1, 1) :: Nil
+
+    @test
+    def filterRedBlackTree03(): Bool =
+        filter(isOdd, RedBlackTree.empty() |> RedBlackTree.insert(1, 1) |> RedBlackTree.insert(2, 2) |> RedBlackTree.insert(3, 3) |> RedBlackTree.insert(4, 4))
+            |> RedBlackTree.toList == (1, 1) :: (3, 3) :: Nil
+
+    /////////////////////////////////////////////////////////////////////////////
+    // filterMapRedBlackTree                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def filterMapRedBlackTree01(): Bool =
+        filterMap(oddPlus10, RedBlackTree.empty(): RedBlackTree.RedBlackTree[Int32, Int32]) == RedBlackTree.empty()
+
+    @test
+    def filterMapMapRedBlackTree02(): Bool =
+        filterMap(oddPlus10, RedBlackTree.empty() |> RedBlackTree.insert(1, 1))
+            |> RedBlackTree.toList |> List.sort == (1, 11) :: Nil
+
+    @test
+    def filterMapRedBlackTree03(): Bool =
+        filterMap(oddPlus10, RedBlackTree.empty() |> RedBlackTree.insert(1, 1) |> RedBlackTree.insert(2, 2) |> RedBlackTree.insert(3, 3) |> RedBlackTree.insert(4, 4))
+            |> RedBlackTree.toList |> List.sort == (1, 11) :: (3, 13) :: Nil
 
 }
 

--- a/main/test/ca/uwaterloo/flix/library/TestMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMap.flix
@@ -653,6 +653,36 @@ def filterWithKey06(): Bool = Map.filterWithKey((k, v) -> k == v, Map#{1 => 1, 2
 def filterWithKey07(): Bool = Map.filterWithKey((k, v) -> k == v, Map#{1 => -1, 2 => -3}) == Map#{}
 
 /////////////////////////////////////////////////////////////////////////////
+// filterMap                                                               //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def filterMap01(): Bool = Map.filterMap(x -> if (x > 1) Some("${x}") else None, Map#{}: Map[Unit, _]) == Map#{}
+
+@test
+def filterMap02(): Bool = Map.filterMap(x -> if (x > 1) Some("${x}") else None, Map#{1 => 1}) == Map#{}
+
+@test
+def filterMap03(): Bool =
+    Map.filterMap(x -> if (x > 1) Some("${x}") else None, Map#{1 => 1, 2 => 2, 3 => 3, 4 => 4})
+        == Map#{2 => "2", 3 => "3", 4 => "4"}
+
+/////////////////////////////////////////////////////////////////////////////
+// filterMapWithKey                                                        //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def filterMapWithKey01(): Bool = Map.filterMapWithKey((k, v) -> if (k == v and v > 1) Some("${v}") else None, Map#{}: Map[Int32, Int32]) == Map#{}
+
+@test
+def filterMapWithKey02(): Bool = Map.filterMapWithKey((k, v) -> if (k == v and v > 1) Some("${v}") else None, Map#{1 => 1}) == Map#{}
+
+@test
+def filterMapWithKey03(): Bool =
+    Map.filterMapWithKey((k, v) -> if (k == v and v > 1) Some("${v}") else None, Map#{1 => 1, 2 => 2, 3 => 3, 4 => 4})
+        == Map#{2 => "2", 3 => "3", 4 => "4"}
+
+/////////////////////////////////////////////////////////////////////////////
 // map                                                                     //
 /////////////////////////////////////////////////////////////////////////////
 @test

--- a/main/test/ca/uwaterloo/flix/library/TestRedBlackTree.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestRedBlackTree.flix
@@ -708,4 +708,40 @@ namespace TestRedBlackTree {
         let Map(t) = Map#{0 => "1", 1 => "2", 2 => "2"};
         RedBlackTree.joinWith((k, v) -> "${k} => ${v}", ", ", t) == "0 => 1, 1 => 2, 2 => 2"
 
+    /////////////////////////////////////////////////////////////////////////////
+    // filter                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def filter01(): Bool =
+        RedBlackTree.filter(x -> x > 1, RedBlackTree.empty(): RedBlackTree.RedBlackTree[Int32, Int32]) == RedBlackTree.empty()
+
+    @test
+    def filter02(): Bool =
+        RedBlackTree.filter(x -> x > 1, RedBlackTree.empty() |> RedBlackTree.insert(1, 1)) == RedBlackTree.empty()
+
+    @test
+    def filter03(): Bool =
+        RedBlackTree.filter(x -> x > 1, RedBlackTree.empty() |> RedBlackTree.insert(1, 1) |> RedBlackTree.insert(2, 2) |> RedBlackTree.insert(3, 3) |> RedBlackTree.insert(4, 4))
+            |> RedBlackTree.toList |> List.sort == (2, 2) :: (3, 3) :: (4, 4) :: Nil
+
+    /////////////////////////////////////////////////////////////////////////////
+    // filter                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def filterMap01(): Bool =
+        RedBlackTree.filterMap(x -> if (x > 1) Some("${x}") else None, RedBlackTree.empty(): RedBlackTree.RedBlackTree[Int32, Int32])
+            == RedBlackTree.empty()
+
+    @test
+    def filterMap02(): Bool =
+        RedBlackTree.filterMap(x -> if (x > 1) Some("${x}") else None, RedBlackTree.empty() |> RedBlackTree.insert(1, 1))
+            == RedBlackTree.empty()
+
+    @test
+    def filterMap03(): Bool =
+        RedBlackTree.filterMap(x -> if (x > 1) Some("${x}") else None, RedBlackTree.empty() |> RedBlackTree.insert(1, 1) |> RedBlackTree.insert(2, 2) |> RedBlackTree.insert(3, 3) |> RedBlackTree.insert(4, 4))
+            |> RedBlackTree.toList |> List.sort == (2, "2") :: (3, "3") :: (4, "4") :: Nil
+
 }


### PR DESCRIPTION
This PR adds the `FunctorFilter` class of issue #3819 and instances for "emptyable" Functor types:

Chain
DelayList
List
Map
Option
RedBlackTree

Tests in the `TestFunctorFilter.flix` file as the existing test modules usually already had tests for `filter` and `filterMap` but they used the versions in the namespace directly rather than resolved the implementations through the `FunctorFilter` class.


If the namespace was missing `filter` / `filterMap` (both in `RedBlackTree` , `filterMap` in `Map`) I added them only via the `FunctorFilter` class.