### PR TITLE
refactor: change array to list in `BodyPredicate.Loop1`

### DIFF
--- a/main/src/library/Fixpoint/Ast/BodyPredicate.flix
+++ b/main/src/library/Fixpoint/Ast/BodyPredicate.flix
@@ -27,7 +27,7 @@ namespace Fixpoint/Ast {
         case Guard3(v -> v -> v -> Bool, VarSym, VarSym, VarSym)
         case Guard4(v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym)
         case Guard5(v -> v -> v -> v -> v -> Bool, VarSym, VarSym, VarSym, VarSym, VarSym)
-        case Loop1(v -> Array[v, Static])
+        case Loop1(v -> List[v])
     }
 
     instance PredSymsOf[BodyPredicate[v]] {


### PR DESCRIPTION
Related to #3896.

sidenote: This is currently unused. The parser has implementation but it results in questionmarks everywhere. Is this a upcomming feature or an abandoned feature @magnus-madsen?

Alternative option 1: remove Loop1 from the flix code (-3 lines)
Alternative option 2: remove Loop1 from the copiler (-150 lines)