### PR TITLE
feat: code generation for `NewObject`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Paul Butcher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.ErasedAst._
+import ca.uwaterloo.flix.language.phase.jvm.JvmName.RootPackage
+import ca.uwaterloo.flix.util.ParOps
+import org.objectweb.asm.Opcodes._
+
+/**
+  * Generates bytecode for anonymous classes (created through NewObject)
+  */
+
+object GenAnonymousClasses {
+
+  /**
+    * Returns the set of anonymous classes for the given set of objects
+    */
+  def gen(objs: Set[Expression.NewObject])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
+    //
+    // Generate an anonymous class for each object and collect the results in a map.
+    //
+    ParOps.parAgg(objs, Map.empty[JvmName, JvmClass])({
+      case (macc, obj) =>
+        val className = JvmName(RootPackage, "HardcodedAnon")
+        flix.subtask(className.toInternalName, sample = true)
+
+        macc + (className -> JvmClass(className, genByteCode(className, obj)))
+    }, _ ++ _)
+  }
+
+  private def genByteCode(className: JvmName,
+                          obj: Expression.NewObject)(implicit root: Root, flix: Flix): Array[Byte] = {
+    val visitor = AsmOps.mkClassWriter()
+
+    visitor.visit(AsmOps.JavaVersion, ACC_PUBLIC + ACC_FINAL, className.toInternalName, null,
+      null, Array(obj.clazz.getName))
+
+    visitor.visitEnd()
+    visitor.toByteArray
+  }
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -935,8 +935,10 @@ object GenExpression {
 
     case Expression.NewObject(_, tpe, loc) =>
       addSourceLine(visitor, loc)
-      visitor.visitInsn(ACONST_NULL)
-      AsmOps.castIfNotPrim(visitor, JvmOps.getJvmType(tpe))
+      val className = JvmName(ca.uwaterloo.flix.language.phase.jvm.JvmName.RootPackage, "HardcodedAnon").toInternalName
+      visitor.visitTypeInsn(NEW, className)
+      visitor.visitInsn(DUP)
+      visitor.visitMethodInsn(INVOKESPECIAL, className, "<init>", AsmOps.getMethodDescriptor(Nil, JvmType.Void), false)
 
     case Expression.NewChannel(exp, _, loc) =>
       addSourceLine(visitor, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -70,6 +70,11 @@ object JvmBackend {
       // TODO: all the type collection above should maybe have its own subphase
 
       //
+      // Compute the set of anonymous classes (NewObjects) in the program.
+      //
+      val anonClassDefs = JvmOps.anonClassesOf(root)
+
+      //
       // Generate the main class.
       //
       val mainClass = GenMainClass.gen()
@@ -145,6 +150,11 @@ object JvmBackend {
       val lazyClasses = GenLazyClasses.gen(types)
 
       //
+      // Generate anonymous classes.
+      //
+      val anonClasses = GenAnonymousClasses.gen(anonClassDefs)
+
+      //
       // Generate the Unit class.
       //
       val unitClass = GenUnitClass.gen()
@@ -193,6 +203,7 @@ object JvmBackend {
         recordExtendClasses,
         refClasses,
         lazyClasses,
+        anonClasses,
         unitClass,
         flixErrorClass,
         rslClass,

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -1139,6 +1139,221 @@ object JvmOps {
   }
 
   /**
+    * Returns the set of all anonymous classes (NewObjects) in the given AST `root`.
+    */
+  def anonClassesOf(root: Root)(implicit flix: Flix): Set[Expression.NewObject] = {
+    /**
+      * Returns the set of anonymous classes which occur in the given definition `defn0`.
+      */
+    def visitDefn(defn: Def): Set[Expression.NewObject] = {
+      visitExp(defn.exp)
+    }
+
+    /**
+      * Returns the set of anonymouse classes which occur in the given expression `exp0`.
+      */
+    def visitExp(exp0: Expression): Set[Expression.NewObject] = (exp0 match {
+      case Expression.Unit(_) => Set.empty
+
+      case Expression.Null(_, _) => Set.empty
+
+      case Expression.True(_) => Set.empty
+
+      case Expression.False(_) => Set.empty
+
+      case Expression.Char(_, _) => Set.empty
+
+      case Expression.Float32(_, _) => Set.empty
+
+      case Expression.Float64(_, _) => Set.empty
+
+      case Expression.Int8(_, _) => Set.empty
+
+      case Expression.Int16(_, _) => Set.empty
+
+      case Expression.Int32(_, _) => Set.empty
+
+      case Expression.Int64(_, _) => Set.empty
+
+      case Expression.BigInt(_, _) => Set.empty
+
+      case Expression.Str(_, _) => Set.empty
+
+      case Expression.Var(_, _, _) => Set.empty
+
+      case Expression.Closure(_, closureArgs, _, _, _) => closureArgs.foldLeft(Set.empty[Expression.NewObject]) {
+        case (sacc, e) => sacc ++ visitExp(e)
+      }
+
+      case Expression.ApplyClo(exp, args, _, _) => args.foldLeft(visitExp(exp)) {
+        case (sacc, e) => sacc ++ visitExp(e)
+      }
+
+      case Expression.ApplyDef(_, args, _, _) => args.foldLeft(Set.empty[Expression.NewObject]) {
+        case (sacc, e) => sacc ++ visitExp(e)
+      }
+
+      case Expression.ApplyCloTail(exp, args, _, _) => args.foldLeft(visitExp(exp)) {
+        case (sacc, e) => sacc ++ visitExp(e)
+      }
+
+      case Expression.ApplyDefTail(_, args, _, _) => args.foldLeft(Set.empty[Expression.NewObject]) {
+        case (sacc, e) => sacc ++ visitExp(e)
+      }
+
+      case Expression.ApplySelfTail(_, _, args, _, _) => args.foldLeft(Set.empty[Expression.NewObject]) {
+        case (sacc, e) => sacc ++ visitExp(e)
+      }
+
+      case Expression.Unary(_, _, exp, _, _) =>
+        visitExp(exp)
+
+      case Expression.Binary(_, _, exp1, exp2, _, _) =>
+        visitExp(exp1) ++ visitExp(exp2)
+
+      case Expression.IfThenElse(exp1, exp2, exp3, _, _) =>
+        visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
+
+      case Expression.Branch(exp, branches, _, _) => branches.foldLeft(visitExp(exp)) {
+        case (sacc, (_, e)) => sacc ++ visitExp(e)
+      }
+
+      case Expression.JumpTo(_, _, _) => Set.empty
+
+      case Expression.Let(_, exp1, exp2, _, _) => visitExp(exp1) ++ visitExp(exp2)
+
+      case Expression.LetRec(_, _, _, exp1, exp2, _, _) => visitExp(exp1) ++ visitExp(exp2)
+
+      case Expression.Is(_, _, exp, _) => visitExp(exp)
+
+      case Expression.Tag(_, _, exp, _, _) => visitExp(exp)
+
+      case Expression.Untag(_, _, exp, _, _) => visitExp(exp)
+
+      case Expression.Index(base, _, _, _) => visitExp(base)
+
+      case Expression.Tuple(elms, _, _) => elms.foldLeft(Set.empty[Expression.NewObject]) {
+        case (sacc, e) => sacc ++ visitExp(e)
+      }
+
+      case Expression.RecordEmpty(_, _) => Set.empty
+
+      case Expression.RecordSelect(exp, _, _, _) => visitExp(exp)
+
+      case Expression.RecordExtend(_, value, rest, _, _) => visitExp(value) ++ visitExp(rest)
+
+      case Expression.RecordRestrict(_, rest, _, _) => visitExp(rest)
+
+      case Expression.ArrayLit(elms, _, _) => elms.foldLeft(Set.empty[Expression.NewObject]) {
+        case (sacc, e) => sacc ++ visitExp(e)
+      }
+
+      case Expression.ArrayNew(elm, len, _, _) => visitExp(elm) ++ visitExp(len)
+
+      case Expression.ArrayLoad(exp1, exp2, _, _) => visitExp(exp1) ++ visitExp(exp2)
+
+      case Expression.ArrayStore(exp1, exp2, exp3, _, _) => visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
+
+      case Expression.ArrayLength(exp, _, _) => visitExp(exp)
+
+      case Expression.ArraySlice(exp1, exp2, exp3, _, _) => visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
+
+      case Expression.Ref(exp, _, _) => visitExp(exp)
+
+      case Expression.Deref(exp, _, _) => visitExp(exp)
+
+      case Expression.Assign(exp1, exp2, _, _) => visitExp(exp1) ++ visitExp(exp2)
+
+      case Expression.Cast(exp, _, _) => visitExp(exp)
+
+      case Expression.TryCatch(exp, rules, _, _) => rules.foldLeft(visitExp(exp)) {
+        case (sacc, CatchRule(_, _, body)) => sacc ++ visitExp(body)
+      }
+
+      case Expression.InvokeConstructor(_, args, _, _) => args.foldLeft(Set.empty[Expression.NewObject]) {
+        case (sacc, e) => sacc ++ visitExp(e)
+      }
+
+      case Expression.InvokeMethod(_, exp, args, _, _) =>
+        args.foldLeft(visitExp(exp)) {
+          case (sacc, e) => sacc ++ visitExp(e)
+        }
+
+      case Expression.InvokeStaticMethod(_, args, _, _) => args.foldLeft(Set.empty[Expression.NewObject]) {
+        case (sacc, e) => sacc ++ visitExp(e)
+      }
+
+      case Expression.GetField(_, exp, _, _) => visitExp(exp)
+
+      case Expression.PutField(_, exp1, exp2, _, _) => visitExp(exp1) ++ visitExp(exp2)
+
+      case Expression.GetStaticField(_, _, _) => Set.empty
+
+      case Expression.PutStaticField(_, exp, _, _) => visitExp(exp)
+
+      case obj: Expression.NewObject => Set(obj)
+
+      case Expression.NewChannel(exp, _, _) => visitExp(exp)
+
+      case Expression.GetChannel(exp, _, _) => visitExp(exp)
+
+      case Expression.PutChannel(exp1, exp2, _, _) => visitExp(exp1) ++ visitExp(exp2)
+
+      case Expression.SelectChannel(rules, default, _, _) =>
+        val rs = rules.foldLeft(Set.empty[Expression.NewObject])((old, rule) => old ++ visitExp(rule.chan) ++ visitExp(rule.exp))
+        val d = default.map(visitExp).getOrElse(Set.empty)
+        rs ++ d
+
+      case Expression.Spawn(exp, _, _) => visitExp(exp)
+
+      case Expression.Lazy(exp, _, _) => visitExp(exp)
+
+      case Expression.Force(exp, _, _) => visitExp(exp)
+
+      case Expression.HoleError(_, _, _) => Set.empty
+
+      case Expression.MatchError(_, _) => Set.empty
+
+      case Expression.BoxBool(exp, _) => visitExp(exp)
+
+      case Expression.BoxInt8(exp, _) => visitExp(exp)
+
+      case Expression.BoxInt16(exp, _) => visitExp(exp)
+
+      case Expression.BoxInt32(exp, _) => visitExp(exp)
+
+      case Expression.BoxInt64(exp, _) => visitExp(exp)
+
+      case Expression.BoxChar(exp, _) => visitExp(exp)
+
+      case Expression.BoxFloat32(exp, _) => visitExp(exp)
+
+      case Expression.BoxFloat64(exp, _) => visitExp(exp)
+
+      case Expression.UnboxBool(exp, _) => visitExp(exp)
+
+      case Expression.UnboxInt8(exp, _) => visitExp(exp)
+
+      case Expression.UnboxInt16(exp, _) => visitExp(exp)
+
+      case Expression.UnboxInt32(exp, _) => visitExp(exp)
+
+      case Expression.UnboxInt64(exp, _) => visitExp(exp)
+
+      case Expression.UnboxChar(exp, _) => visitExp(exp)
+
+      case Expression.UnboxFloat32(exp, _) => visitExp(exp)
+
+      case Expression.UnboxFloat64(exp, _) => visitExp(exp)
+    })
+
+    // Visit every definition.
+    root.defs.foldLeft(Set.empty[Expression.NewObject]) {
+      case (sacc, (_, defn)) => sacc ++ visitDefn(defn)
+    }
+  }
+
+  /**
     * Writes the given JVM class `clazz` to a sub path under the given `prefixPath`.
     *
     * For example, if the prefix path is `/tmp/` and the class name is Foo.Bar.Baz

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -5,4 +5,24 @@ namespace Test/Exp/Jvm/NewObject {
     import java.lang.Object.toString(): String & Pure;
     let anon = object ##java.io.Serializable { } as ##java.lang.Object;
     toString(anon) |> String.startsWith(prefix = "HardcodedAnon@")
+
+  @test
+  def implementInterface02(): Bool & Impure =
+    import java.lang.Object.hashCode(): Int32 & Pure;
+    let anon = object ##java.io.Serializable { } as ##java.lang.Object;
+    let anon2 = object ##java.io.Serializable { } as ##java.lang.Object;
+    hashCode(anon) != hashCode(anon2)
+
+  @test
+  def implementInterface03(): Bool & Impure =
+    import java.lang.Object.equals(##java.lang.Object): Bool & Pure;
+    let anon = object ##java.io.Serializable { } as ##java.lang.Object;
+    let anon2 = object ##java.io.Serializable { } as ##java.lang.Object;
+    not equals(anon, anon2)
+
+  @test
+  def implementInterface04(): Bool & Impure =
+    import java.lang.Object.toString(): String & Pure;
+    let anon = object ##java.lang.Iterable { } as ##java.lang.Object;
+    toString(anon) |> String.startsWith(prefix = "HardcodedAnon@")
 }

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -2,6 +2,7 @@ namespace Test/Exp/Jvm/NewObject {
 
   @test
   def testImplementInterface01(): Bool & Impure =
-    let _anon = object ##java.io.Serializable { };
-    true
+    import java.lang.Object.toString(): String & Pure;
+    let anon = object ##java.io.Serializable { } as ##java.lang.Object;
+    toString(anon) |> String.startsWith(prefix = "HardcodedAnon@")
 }


### PR DESCRIPTION
This is now successfully creating the bytecode for NewObject, creating an instance of it, and calling the constructor.

No support for method implementations yet, or naming the anonymous class.