### PR TITLE
chore: prettify `MutList.flix`

### DIFF
--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -305,11 +305,12 @@ namespace MutList {
     /// Accumulates the result of applying `f` to `v` going left to right.
     ///
     pub def scanLeft(f: (b, a) -> b & ef, s: b, v: MutList[a, r]): MutList[b, r] \ { ef, Read(r), Write(r) } =
+        let r = Scoped.regionOf(v);
         let MutList(ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
         let n = l + 1;
-        let b = [s; n] @ Scoped.regionOf(v);
+        let b = [s; n] @ r;
         def loop(i, acc) = {
             if (i >= n)
                 ()
@@ -320,7 +321,7 @@ namespace MutList {
             }
         };
         loop(1, s);
-        MutList(ref b @ Scoped.regionOf(v), ref n @ Scoped.regionOf(v))
+        MutList(ref b @ r, ref n @ r)
 
     ///
     /// Accumulates the result of applying `f` to `v` going right to left.
@@ -330,7 +331,8 @@ namespace MutList {
         let a = deref ra;
         let l = deref rl;
         let n = l + 1;
-        let b = [s; n] @ Scoped.regionOf(v);
+        let r = Scoped.regionOf(v);
+        let b = [s; n] @ r;
         def loop(i, acc) = {
             if (i < 0)
                 ()
@@ -341,7 +343,7 @@ namespace MutList {
             }
         };
         loop(l - 1, s);
-        MutList(ref b @ Scoped.regionOf(v), ref n @ Scoped.regionOf(v))
+        MutList(ref b @ r, ref n @ r)
 
     ///
     /// Apply `f` to every element in `v`.
@@ -349,14 +351,15 @@ namespace MutList {
     /// The result is a new mutable list.
     ///
     pub def map(f: a -> b & ef, v: MutList[a, r]): MutList[b, r] \ { ef, Read(r), Write(r) } =
+        let r = Scoped.regionOf(v);
         if (isEmpty(v))
-            new(Scoped.regionOf(v))
+            new MutList(r)
         else {
             let MutList(ra, rl) = v;
             let a = deref ra;
             let l = deref rl;
             let x = f(a[0]);
-            let b = [x; Array.length(a)] @ Scoped.regionOf(v);
+            let b = [x; Array.length(a)] @ r;
             def loop(i) = {
                 if (i >= l)
                     ()
@@ -366,21 +369,22 @@ namespace MutList {
                 }
             };
             loop(1);
-            MutList(ref b @ Scoped.regionOf(v), ref l @ Scoped.regionOf(v))
+            MutList(ref b @ r, ref l @ r)
         }
 
     ///
     /// Returns the result of applying `f` to every element in `v` along with that element's index.
     ///
     pub def mapWithIndex(f: (a, Int32) -> b & ef, v: MutList[a, r]): MutList[b, r] \ { ef, Read(r), Write(r) } =
+        let r = Scoped.regionOf(v);
         if (isEmpty(v))
-            new(Scoped.regionOf(v))
+            new MutList(r)
         else {
             let MutList(ra, rl) = v;
             let a = deref ra;
             let l = deref rl;
             let x = f(a[0], 0);
-            let b = [x; Array.length(a)] @ Scoped.regionOf(v);
+            let b = [x; Array.length(a)] @ r;
             def loop(i) = {
                 if (i >= l)
                     ()
@@ -390,7 +394,7 @@ namespace MutList {
                 }
             };
             loop(1);
-            MutList(ref b @ Scoped.regionOf(v), ref l @ Scoped.regionOf(v))
+            MutList(ref b @ r, ref l @ r)
         }
 
     ///
@@ -497,10 +501,11 @@ namespace MutList {
     ///
     /// Returns `None` if `v` is empty.
     ///
-    pub def reduceLeft(f: (a, a) -> a & ef, v: MutList[a, r]): Option[a] \ { ef, Read(r) } = foldLeft((acc, x) -> match acc {
-        case Some(y) => Some(f(y, x))
-        case None => Some(x)
-    }, None, v)
+    pub def reduceLeft(f: (a, a) -> a & ef, v: MutList[a, r]): Option[a] \ { ef, Read(r) } =
+        foldLeft((acc, x) -> match acc {
+            case Some(y) => Some(f(y, x))
+            case None => Some(x)
+        }, None, v)
 
     ///
     /// Applies `f` to all elements in `v` going from right to left until a single value `v` is obtained. Returns `Some(v)`.
@@ -627,7 +632,8 @@ namespace MutList {
     ///
     pub def retain!(f: a -> Bool, v: MutList[a, r]): Unit \ { Read(r), Write(r) } =
         let MutList(a1, l1) = v;
-        let l = new(Scoped.regionOf(v));
+        let r = Scoped.regionOf(v);
+        let l = new MutList(r);
         foreach(e -> if (f(e)) push!(e, l) else (), v);
         let MutList(a2, l2) = l;
         a1 := deref a2;
@@ -675,7 +681,8 @@ namespace MutList {
             a := Array.copyOfRange(0, newCap, deref a, Scoped.regionOf(v));
             l := Order.min(len, newCap)
         }
-        else ()
+        else
+            ()
 
     ///
     /// Shrinks the given mutable list `v` to its actual size.
@@ -834,7 +841,8 @@ namespace MutList {
             else
                 shrinkTo!(c / 2, v)
         }
-        else ()
+        else
+            ()
 
     ///
     /// Returns the capacity of `v`.


### PR DESCRIPTION
I was going over `MutList` while working on #3582 and decided to reduce some of the verbosity in `MutList` that had been introduced when adding regions.