### PR TITLE
In-progress REPL simplification/rationalisation

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -107,10 +107,10 @@ object Main {
       options = options.copy(progress = false)
     }
 
+    val cwd = Paths.get(".").toAbsolutePath.normalize()
+
     // check if command was passed.
     try {
-      val cwd = Paths.get(".").toAbsolutePath.normalize()
-
       cmdOpts.command match {
         case Command.None =>
         // nop, continue
@@ -149,6 +149,12 @@ object Main {
           val result = Packager.test(cwd, o)
           System.exit(getCode(result))
 
+        case Command.Repl =>
+          val source = if (cmdOpts.files.isEmpty) Left(cwd) else Right(cmdOpts.files)
+          val shell = new Shell(source, options)
+          shell.loop()
+          System.exit(0)
+
         case Command.Install(project) =>
           val o = options.copy(progress = false)
           val result = Packager.install(project, cwd, o)
@@ -184,10 +190,9 @@ object Main {
       System.exit(0)
     }
 
-    // check if running in interactive mode.
-    val interactive = cmdOpts.interactive || (cmdOpts.command == Command.None && cmdOpts.files.isEmpty)
-    if (interactive) {
-      val shell = new Shell(cmdOpts.files.toList.map(_.toPath), options)
+    // check if we should start a REPL
+    if (cmdOpts.command == Command.None && cmdOpts.files.isEmpty) {
+      val shell = new Shell(Left(cwd), options)
       shell.loop()
       System.exit(0)
     }
@@ -263,7 +268,6 @@ object Main {
                      documentor: Boolean = false,
                      entryPoint: Option[String] = None,
                      explain: Boolean = false,
-                     interactive: Boolean = false,
                      json: Boolean = false,
                      listen: Option[Int] = None,
                      lsp: Option[Int] = None,
@@ -306,6 +310,8 @@ object Main {
 
     case object Test extends Command
 
+    case object Repl extends Command
+
     case class Install(project: String) extends Command
 
   }
@@ -345,6 +351,8 @@ object Main {
 
       cmd("test").action((_, c) => c.copy(command = Command.Test)).text("  runs the tests for the current project.")
 
+      cmd("repl").action((_, c) => c.copy(command = Command.Repl)).text("  starts a repl for the current project, or provided Flix source files.")
+
       cmd("install").text("  installs the Flix package from the given GitHub <owner>/<repo>")
         .children(
           arg[String]("project").action((project, c) => c.copy(command = Command.Install(project)))
@@ -370,9 +378,6 @@ object Main {
         text("provides suggestions on how to solve a problem")
 
       help("help").text("prints this usage information.")
-
-      opt[Unit]("interactive").action((_, c) => c.copy(interactive = true)).
-        text("enables interactive mode.")
 
       opt[Unit]("json").action((_, c) => c.copy(json = true)).
         text("enables json output.")

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
@@ -36,16 +36,6 @@ object Command {
   case object Reload extends Command
 
   /**
-    * Watches source paths for changes.
-    */
-  case object Watch extends Command
-
-  /**
-    * Unwatches source paths for changes.
-    */
-  case object Unwatch extends Command
-
-  /**
     * Terminates the shell.
     */
   case object Quit extends Command
@@ -91,18 +81,6 @@ object Command {
     //
     if (input == ":r" || input == ":reload")
       return Command.Reload
-
-    //
-    // Watch
-    //
-    if (input == ":watch" || input == ":w")
-      return Command.Watch
-
-    //
-    // Unwatch
-    //
-    if (input == ":unwatch" || input == ":uw")
-      return Command.Unwatch
 
     //
     // Quit

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -51,6 +51,8 @@ class Shell(source: Either[Path, Seq[File]], options: Options) {
     */
   private val flix: Flix = new Flix().setFormatter(AnsiTerminalFormatter)
 
+  private val sourceFiles = new SourceFiles(source)
+
   /**
     * Continuously reads a line of input from the terminal, parses and executes it.
     */
@@ -142,6 +144,7 @@ class Shell(source: Either[Path, Seq[File]], options: Options) {
     * Reloads every source path.
     */
   private def execReload()(implicit terminal: Terminal): Validation[CompilationResult, CompilationMessage] = {
+    sourceFiles.addSourcesAndPackages(flix)
 
     compile()
   }

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -236,7 +236,7 @@ class Shell(source: Either[Path, Seq[File]], options: Options) {
   /**
     * Compile
     */
-private def compile(entryPoint: Option[Symbol.DefnSym] = None)(implicit terminal: Terminal): Validation[CompilationResult, CompilationMessage] = {
+  private def compile(entryPoint: Option[Symbol.DefnSym] = None)(implicit terminal: Terminal): Validation[CompilationResult, CompilationMessage] = {
 
     this.flix.setOptions(options.copy(entryPoint = entryPoint))
 

--- a/main/src/ca/uwaterloo/flix/runtime/shell/SourceFiles.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/SourceFiles.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Paul Butcher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package ca.uwaterloo.flix.runtime.shell
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.tools.Packager
+
+import java.nio.file.Path
+import java.io.File
+
+class SourceFiles(source: Either[Path, Seq[File]]) {
+
+  var currentSources: Set[Path] = Set.empty
+  var currentLibs: Set[Path] = Set.empty
+
+  def addSourcesAndPackages(flix: Flix) = {
+    source match {
+      case Left(path) =>
+        val sourceFiles = getSourceFiles(path)
+        val (packages, libraries) = getPackagesAndLibraries(path)
+
+        currentSources = sourceFiles ++ packages
+        for (file <- currentSources)
+          flix.addSourcePath(file)
+
+        currentLibs = libraries
+        for (file <- currentLibs)
+          flix.addJar(file)
+
+      case Right(files) =>
+        currentSources = files.map(_.toPath).toSet
+        for (file <- currentSources)
+          flix.addSourcePath(file)
+    }
+  }
+
+  private def filterByExt(files: Seq[Path], ext: String): Set[Path] = {
+    files.filter(_.getFileName.toString.endsWith(ext)).toSet
+  }
+
+  private def getSourceFiles(path: Path): Set[Path] = {
+    val sourceFiles = Packager.getAllFiles(Packager.getSourceDirectory(path))
+    val testFiles = Packager.getAllFiles(Packager.getTestDirectory(path))
+    filterByExt(sourceFiles ++ testFiles, ".flix").toSet
+  }
+  
+  private def getPackagesAndLibraries(path: Path): (Set[Path], Set[Path]) = {
+    val libraryDirectory = Packager.getLibraryDirectory(path)
+    if (libraryDirectory.toFile.isDirectory) {
+      val files = Packager.getAllFiles(libraryDirectory)
+      val packages = filterByExt(files, ".fpkg")
+      val libraries = filterByExt(files, ".jar")
+      (packages, libraries)
+    } else {
+      (Set.empty, Set.empty)
+    }
+  }
+}

--- a/main/src/ca/uwaterloo/flix/tools/Packager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Packager.scala
@@ -518,7 +518,7 @@ object Packager {
   /**
     * Returns all files in the given path `p`.
     */
-  private def getAllFiles(p: Path): List[Path] = {
+  def getAllFiles(p: Path): List[Path] = {
     val visitor = new FileVisitor
     Files.walkFileTree(p, visitor)
     visitor.result.toList

--- a/main/src/ca/uwaterloo/flix/tools/Packager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Packager.scala
@@ -398,7 +398,7 @@ object Packager {
   /**
     * Returns `true` if the given path `p` appears to be a flix project path.
     */
-  private def isProjectPath(p: Path): Boolean =
+  def isProjectPath(p: Path): Boolean =
     Files.exists(getSourceDirectory(p)) &&
       Files.exists(getTestDirectory(p)) &&
       Files.exists(getHistoryFile(p)) &&
@@ -428,17 +428,17 @@ object Packager {
   /**
     * Returns the path to the library directory relative to the given path `p`.
     */
-  private def getLibraryDirectory(p: Path): Path = p.resolve("./lib/").normalize()
+  def getLibraryDirectory(p: Path): Path = p.resolve("./lib/").normalize()
 
   /**
     * Returns the path to the source directory relative to the given path `p`.
     */
-  private def getSourceDirectory(p: Path): Path = p.resolve("./src/").normalize()
+  def getSourceDirectory(p: Path): Path = p.resolve("./src/").normalize()
 
   /**
     * Returns the path to the test directory relative to the given path `p`.
     */
-  private def getTestDirectory(p: Path): Path = p.resolve("./test/").normalize()
+  def getTestDirectory(p: Path): Path = p.resolve("./test/").normalize()
 
   /**
     * Returns the path to the HISTORY file relative to the given path `p`.

--- a/main/test/ca/uwaterloo/flix/TestMain.scala
+++ b/main/test/ca/uwaterloo/flix/TestMain.scala
@@ -57,6 +57,12 @@ class TestMain extends FunSuite {
     assert(opts.command == Main.Command.Test)
   }
 
+  test("repl") {
+    val args = Array("repl")
+    val opts = Main.parseCmdOpts(args).get
+    assert(opts.command == Main.Command.Repl)
+  }
+
   test("--args --abc --def") {
     val args = Array("--args", "--abc --def")
     val opts = Main.parseCmdOpts(args).get
@@ -86,12 +92,6 @@ class TestMain extends FunSuite {
     val args = Array("--entrypoint", "foo", "p.flix")
     val opts = Main.parseCmdOpts(args).get
     assert(opts.entryPoint.nonEmpty)
-  }
-
-  test("--interactive") {
-    val args = Array("--interactive", "p.flix")
-    val opts = Main.parseCmdOpts(args).get
-    assert(opts.interactive)
   }
 
   test("--json") {


### PR DESCRIPTION
This is definitely not ready to be merged, but I'm creating this PR because I'm confused and would appreciate guidance.

I thought that incremental compilation would mean that performing a second compilation after the first would not re-compile a file on disk that had changed unless it was re-added to the `Flix` object with `addSourcePath`. It seems that I'm mistaken about this because with this code if I run `flix repl` to load the current project and then change a file on disk, that file is recompiled.

Looking at the code within `Flix.scala`, I'm not surprised that this doesn't work. I can see that there's a `changeSet` maintained, but files are only ever added to it: nothing ever marks a file as compiled and therefore unchanged.

Am I understanding the intent correctly, but incremental compilation is broken? Or am I misunderstanding the intent?