### PR TITLE
fix: exhaustive pattern in datalog engine

### DIFF
--- a/main/src/library/Fixpoint/IndexSelection.flix
+++ b/main/src/library/Fixpoint/IndexSelection.flix
@@ -148,7 +148,10 @@ namespace Fixpoint {
     def prefixHelper(i: Int32, prefix: List[BoolExp[v]], rest: List[BoolExp[v]], eqs: List[List[BoolExp[v]]]): (List[BoolExp[v]], List[BoolExp[v]]) =
         match eqs {
             case e :: es =>
-                let (p, r) = List.partition(match BoolExp.Eq(RamTerm.RowLoad(_, j), _) -> i == j, e);
+                let (p, r) = List.partition(be -> match be {
+                    case BoolExp.Eq(RamTerm.RowLoad(_, j), _) => i == j
+                    case _ => ???
+                }, e);
                 prefixHelper(i + 1, prefix ::: p, rest ::: r, es)
             case Nil => (prefix, rest)
         }


### PR DESCRIPTION
Fixes #4027.

This `???` case follows mutiple other `???` cases for non `Eq` bool exps so this code is unreachable.