### PR TITLE
chore: remove text argument to remSourceCode

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -301,14 +301,12 @@ class Flix {
   }
 
   /**
-    * Removes the given string `text` with the given `name`.
+    * Removes the source code with the given `name`.
     */
-  def remSourceCode(name: String, text: String): Flix = {
+  def remSourceCode(name: String): Flix = {
     if (name == null)
       throw new IllegalArgumentException("'name' must be non-null.")
-    if (text == null)
-      throw new IllegalArgumentException("'text' must be non-null.")
-    remInput(name, Input.Text(name, text, stable = false))
+    remInput(name, Input.Text(name, "", stable = false))
     this
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LanguageServer.scala
@@ -194,7 +194,7 @@ class LanguageServer(port: Int) extends WebSocketServer(new InetSocketAddress("l
     */
   private def remSourceCode(uri: String) = {
     current = false
-    flix.remSourceCode(uri, sources(uri))
+    flix.remSourceCode(uri)
     sources -= uri
   }
 

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -264,7 +264,7 @@ class Shell(initialPaths: List[Path], options: Options) {
           case Validation.Failure(_) =>
             // Compilation failed. Ignore the last fragment.
             fragments.pop()
-            flix.remSourceCode(name, s)
+            flix.remSourceCode(name)
             w.println("Error: Declaration ignored due to previous error(s).")
         }
 


### PR DESCRIPTION
remInput just blanks the text of the given input, so requiring the previous text to be passed is unnecessary.