### PR TITLE
refactor: set up for effect inference

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -70,13 +70,14 @@ object Indexer {
     * Returns a reverse index for the given `spec`.
     */
   private def visitSpec(spec: Spec): Index = spec match {
-    case Spec(_, _, _, tparams, fparams, declaredScheme, retTpe, eff, _) =>
+    case Spec(_, _, _, tparams, fparams, declaredScheme, retTpe, pur, eff, _) =>
       val idx1 = traverse(tparams)(visitTypeParam)
       val idx2 = traverse(fparams)(visitFormalParam)
       val idx3 = traverse(declaredScheme.constraints)(visitTypeConstraint)
       val idx4 = visitType(retTpe)
-      val idx5 = visitType(eff)
-      idx1 ++ idx2 ++ idx3 ++ idx4 ++ idx5
+      val idx5 = visitType(pur)
+      val idx6 = visitType(eff)
+      idx1 ++ idx2 ++ idx3 ++ idx4 ++ idx5 ++ idx6
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -241,13 +241,13 @@ object CompletionProvider {
   }
 
   private def getLabelForNameAndSpec(name: String, spec: TypedAst.Spec): String = spec match {
-    case TypedAst.Spec(_, _, _, _, fparams, _, retTpe0, eff0, _) =>
+    case TypedAst.Spec(_, _, _, _, fparams, _, retTpe0, pur0, eff0, _) => // TODO use eff
       val args = fparams.map {
         fparam => s"${fparam.sym.text}: ${FormatType.formatWellKindedType(fparam.tpe)}"
       }
 
       val retTpe = FormatType.formatWellKindedType(retTpe0)
-      val eff = eff0 match {
+      val eff = pur0 match {
         case Type.Cst(TypeConstructor.True, _) => "Pure"
         case Type.Cst(TypeConstructor.False, _) => "Impure"
         case e => FormatType.formatWellKindedType(e)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -205,13 +205,14 @@ object SemanticTokensProvider {
     * Returns all semantic tokens in the given `spec`.
     */
   private def visitSpec(spec: Spec): Iterator[SemanticToken] = spec match {
-    case Spec(_, _, _, tparams, fparams, sc, retTpe, eff, _) =>
+    case Spec(_, _, _, tparams, fparams, sc, retTpe, pur, eff, _) =>
       val st1 = visitTypeParams(tparams)
       val st2 = visitFormalParams(fparams)
       val st3 = sc.constraints.iterator.flatMap(visitTypeConstraint)
       val st4 = visitType(retTpe)
-      val st5 = visitType(eff)
-      st1 ++ st2 ++ st3 ++ st4 ++ st5
+      val st5 = visitType(pur)
+      val st6 = visitType(eff)
+      st1 ++ st2 ++ st3 ++ st4 ++ st5 ++ st6
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -942,6 +942,14 @@ object Type {
   def mkUnion(tpe1: Type, tpe2: Type, loc: SourceLocation): Type = Type.mkApply(Type.Cst(TypeConstructor.Union, loc), List(tpe1, tpe2), loc)
 
   /**
+    * Returns the union of all the given types.
+    */
+  def mkUnion(tpes: List[Type], loc: SourceLocation): Type = tpes match {
+    case Nil => Type.Empty
+    case (x :: xs) => mkUnion(x, mkUnion(xs, loc), loc)
+  }
+
+  /**
     * Returns a Region type for the given region argument `r` with the given source location `loc`.
     */
   def mkRegion(r: Type, loc: SourceLocation): Type =

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -939,7 +939,11 @@ object Type {
     *
     * Must not be used before kinding.
     */
-  def mkUnion(tpe1: Type, tpe2: Type, loc: SourceLocation): Type = Type.mkApply(Type.Cst(TypeConstructor.Union, loc), List(tpe1, tpe2), loc)
+  def mkUnion(tpe1: Type, tpe2: Type, loc: SourceLocation): Type = (tpe1, tpe2) match {
+    case (Empty, t) => t
+    case (t, Empty) => t
+    case _ => mkApply(Type.Cst(TypeConstructor.Union, loc), List(tpe1, tpe2), loc)
+  }
 
   /**
     * Returns the union of all the given types.

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -43,7 +43,7 @@ object TypedAst {
 
   case class Def(sym: Symbol.DefnSym, spec: TypedAst.Spec, impl: TypedAst.Impl)
 
-  case class Spec(doc: Ast.Doc, ann: List[TypedAst.Annotation], mod: Ast.Modifiers, tparams: List[TypedAst.TypeParam], fparams: List[TypedAst.FormalParam], declaredScheme: Scheme, retTpe: Type, pur: Type, loc: SourceLocation)
+  case class Spec(doc: Ast.Doc, ann: List[TypedAst.Annotation], mod: Ast.Modifiers, tparams: List[TypedAst.TypeParam], fparams: List[TypedAst.FormalParam], declaredScheme: Scheme, retTpe: Type, pur: Type, eff: Type, loc: SourceLocation)
 
   case class Impl(exp: TypedAst.Expression, inferredScheme: Scheme)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/EntryPoint.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EntryPoint.scala
@@ -127,7 +127,7 @@ object EntryPoint {
     * Returns a flag indicating whether the args should be passed to this function or ignored.
     */
   private def checkEntryPointArgs(defn: TypedAst.Def, classEnv: Map[Symbol.ClassSym, Ast.ClassContext])(implicit flix: Flix): Validation[Unit, EntryPointError] = defn match {
-    case TypedAst.Def(sym, TypedAst.Spec(_, _, _, _, _, declaredScheme, _, _, _), _) =>
+    case TypedAst.Def(sym, TypedAst.Spec(_, _, _, _, _, declaredScheme, _, _, _, _), _) =>
       val unitSc = Scheme.generalize(Nil, Type.Unit)
 
       // First check that there's exactly one argument.
@@ -159,7 +159,7 @@ object EntryPoint {
     * Returns a flag indicating whether the result should be printed, cast, or unchanged.
     */
   private def checkEntryPointResult(defn: TypedAst.Def, root: TypedAst.Root, classEnv: Map[Symbol.ClassSym, Ast.ClassContext])(implicit flix: Flix): Validation[Unit, EntryPointError] = defn match {
-    case TypedAst.Def(sym, TypedAst.Spec(_, _, _, _, _, declaredScheme, _, _, _), _) =>
+    case TypedAst.Def(sym, TypedAst.Spec(_, _, _, _, _, declaredScheme, _, _, _, _), _) =>
       val resultTpe = declaredScheme.base.arrowResultType
       val unitSc = Scheme.generalize(Nil, Type.Unit)
       val resultSc = Scheme.generalize(Nil, resultTpe)
@@ -197,6 +197,7 @@ object EntryPoint {
       declaredScheme = EntryPointScheme,
       retTpe = Type.Unit,
       pur = Type.Impure,
+      eff = Type.Empty,
       loc = SourceLocation.Unknown
     )
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -223,10 +223,10 @@ object Lowering {
     * Lowers the given `spec0`.
     */
   private def visitSpec(spec0: Spec)(implicit root: Root, flix: Flix): Spec = spec0 match {
-    case Spec(doc, ann, mod, tparams, fparams, declaredScheme, retTpe, eff, loc) =>
+    case Spec(doc, ann, mod, tparams, fparams, declaredScheme, retTpe, pur, eff, loc) =>
       val fs = fparams.map(visitFormalParam)
       val ds = visitScheme(declaredScheme)
-      Spec(doc, ann, mod, tparams, fs, ds, retTpe, eff, loc)
+      Spec(doc, ann, mod, tparams, fs, ds, retTpe, pur, eff, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -1068,7 +1068,7 @@ object Typer {
           (elementConstrs, elementTypes, elementPurs, elementEffs) <- seqM(elms.map(visitExp)).map(unzip4)
           resultPur = Type.mkAnd(elementPurs, loc)
           resultEff = Type.mkUnion(elementEffs, loc)
-        } yield (elementConstrs.flatten, Type.mkTuple(elementTypes, loc), resultPur)
+        } yield (elementConstrs.flatten, Type.mkTuple(elementTypes, loc), resultPur, resultEff)
 
       case KindedAst.Expression.RecordEmpty(loc) =>
         liftM(List.empty, Type.mkRecord(Type.RecordRowEmpty, loc), Type.Pure, Type.Empty)
@@ -1213,7 +1213,7 @@ object Typer {
           resultTyp <- unifyTypeM(tvar, Type.mkRef(tpe1, regionVar, loc), loc)
           resultPur <- unifyTypeM(evar, Type.mkAnd(pur1, pur2, regionVar, loc), loc)
           resultEff = Type.mkUnion(eff1, eff2, loc) // MATT need evar?
-        } yield (constrs1 ++ constrs2, resultTyp, resultPur)
+        } yield (constrs1 ++ constrs2, resultTyp, resultPur, resultEff)
 
       case KindedAst.Expression.Deref(exp, tvar, evar, loc) =>
         val elmVar = Type.freshVar(Kind.Star, loc, Rigidity.Flexible, text = FallbackText("elm"))

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -224,15 +224,10 @@ object Unification {
   def liftM(tpe: Type): InferMonad[Type] = InferMonad { case (s, renv) => Ok((s, renv, s(tpe))) }
 
   /**
-    * Lifts the given type `tpe` and effect `eff` into the inference monad.
+    * Lifts the given type constraints, type, purity, and effect into the inference monad.
     */
-  def liftM(tpe: Type, eff: Type): InferMonad[(Type, Type)] = InferMonad { case (s, renv) => Ok((s, renv, (s(tpe), s(eff)))) }
-
-  /**
-    * Lifts the given type `tpe` and effect `eff` into the inference monad.
-    */
-  def liftM(constraints: List[Ast.TypeConstraint], tpe: Type, eff: Type): InferMonad[(List[Ast.TypeConstraint], Type, Type)] =
-    InferMonad { case (s, renv) => Ok((s, renv, (constraints.map(s.apply), s(tpe), s(eff)))) }
+  def liftM(tconstrs: List[Ast.TypeConstraint], tpe: Type, pur: Type, eff: Type): InferMonad[(List[Ast.TypeConstraint], Type, Type, Type)] =
+    InferMonad { case (s, renv) => Ok((s, renv, (tconstrs.map(s.apply), s(tpe), s(pur), s(eff))))}
 
   /**
     * Unifies the two given types `tpe1` and `tpe2` lifting their unified types and

--- a/main/src/ca/uwaterloo/flix/util/collection/ListOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/ListOps.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Matthew Lutze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.util.collection
+
+/**
+  * Operations on lists.
+  */
+object ListOps {
+
+  /**
+    * Unzips the given list of 4-tuples into 4 lists.
+    */
+  def unzip4[T1, T2, T3, T4](list: List[(T1, T2, T3, T4)]): (List[T1], List[T2], List[T3], List[T4]) = {
+    list.foldRight((Nil: List[T1], Nil: List[T2], Nil: List[T3], Nil: List[T4])) {
+      case ((h1, h2, h3, h4), (t1, t2, t3, t4)) => (h1 :: t1, h2 :: t2, h3 :: t3, h4 :: t4)
+    }
+  }
+}


### PR DESCRIPTION
Adds the inference logic to the Typer for the effect sets.

This currently doesn't do anything because a hack is added to type unification which makes it succeed automatically if the types have kind `Effect`.

~depends on #4057~
related to #4050 