### PR TITLE
refactor: `RamStmt` to use `List`

### DIFF
--- a/main/src/library/Fixpoint/Ast/BodyPredicate.flix
+++ b/main/src/library/Fixpoint/Ast/BodyPredicate.flix
@@ -61,12 +61,12 @@ namespace Fixpoint/Ast {
             };
             match body {
                 case BodyAtom(predSym, Relational, p, f, terms) =>
-                    "${polarityPrefix(p)}${fixityPrefix(f)}${predSym}(${terms |> List.map(toString) |> String.intercalate(", ")})"
+                    "${polarityPrefix(p)}${fixityPrefix(f)}${predSym}(${terms |> List.join(", ")})"
                 case BodyAtom(predSym, Latticenal(_), p, f, terms) =>
                     let (keyTerms, latticeTerms) = List.splitAt(List.length(terms)-1, terms);
                     match List.head(latticeTerms) {
                         case None    => "${polarityPrefix(p)}${fixityPrefix(f)}${predSym}()"
-                        case Some(l) => "${polarityPrefix(p)}${fixityPrefix(f)}${predSym}(${keyTerms |> List.map(toString) |> String.intercalate(", ")}; ${l})"
+                        case Some(l) => "${polarityPrefix(p)}${fixityPrefix(f)}${predSym}(${keyTerms |> List.join(", ")}; ${l})"
                     }
                 case Guard0(_) => "<clo>()"
                 case Guard1(_, v) => "<clo>(${v})"

--- a/main/src/library/Fixpoint/Compiler.flix
+++ b/main/src/library/Fixpoint/Compiler.flix
@@ -45,7 +45,7 @@ namespace Fixpoint {
                     Map.insertWith(List.append, ruleStratum, rule :: Nil)
             }, Map#{}, rules) |>
             Map.foreach(_ -> (x -> List.toArray(x, Static)) >> compileStratum(stmts));
-            RamStmt.Seq(MutList.toArray(stmts, Static))
+            RamStmt.Seq(MutList.toList(stmts))
         case _ => bug!("Datalog normalization bug")
     }
 
@@ -102,7 +102,7 @@ namespace Fixpoint {
                 BoolExp.Empty(RamSym.Delta(predSym, arity, den))
             }, idb) |>
             Map.valuesOf;
-        let untilBody = RamStmt.Seq(MutList.toArray(loopBody, Static));
+        let untilBody = RamStmt.Seq(MutList.toList(loopBody));
         let fixpoint = RamStmt.Until(loopTest, untilBody);
         MutList.push!(fixpoint, stmts)
 

--- a/main/src/library/Fixpoint/IndexSelection.flix
+++ b/main/src/library/Fixpoint/IndexSelection.flix
@@ -69,7 +69,7 @@ namespace Fixpoint {
         case RamStmt.Merge(_, _) => stmt
         case RamStmt.Assign(_, _) => stmt
         case RamStmt.Purge(_) => stmt
-        case RamStmt.Seq(xs) => RamStmt.Seq(Array.map(queryStmt, xs))
+        case RamStmt.Seq(xs) => RamStmt.Seq(List.map(queryStmt, xs))
         case RamStmt.Until(test, body) => RamStmt.Until(test, queryStmt(body))
         case RamStmt.Comment(_) => stmt
     }

--- a/main/src/library/Fixpoint/Interpreter.flix
+++ b/main/src/library/Fixpoint/Interpreter.flix
@@ -63,7 +63,7 @@ namespace Fixpoint {
         case RamStmt.Assign(lhs, rhs) =>
             MutMap.put!(lhs, MutMap.getWithDefault(rhs, new MutMap(Static), db), db)
         case RamStmt.Purge(ramSym) => MutMap.remove!(ramSym, db)
-        case RamStmt.Seq(stmts) => Array.foreach(evalStmt(db), stmts)
+        case RamStmt.Seq(stmts) => List.foreach(evalStmt(db), stmts)
         case RamStmt.Until(test, body) =>
             if (evalBoolExp(db, ([], []), test)) {
                 ()

--- a/main/src/library/Fixpoint/Ram/RamStmt.flix
+++ b/main/src/library/Fixpoint/Ram/RamStmt.flix
@@ -24,7 +24,7 @@ namespace Fixpoint/Ram {
         case Merge(RamSym[v], RamSym[v])
         case Assign(RamSym[v], RamSym[v])
         case Purge(RamSym[v])
-        case Seq(Array[RamStmt[v], Static])
+        case Seq(List[RamStmt[v]])
         case Until(List[BoolExp[v]], RamStmt[v])
         case Comment(String)
     }
@@ -37,11 +37,11 @@ namespace Fixpoint/Ram {
                 case Merge(src, dst) => "merge ${src} into ${dst}"
                 case Assign(lhs, rhs) => "${lhs} := ${rhs}"
                 case Purge(ramSym) => "purge ${ramSym}"
-                case Seq(xs) => Array.join(";${nl}", xs)
+                case Seq(xs) => List.join(";${nl}", xs)
                 case Until(test, body) =>
-                    let tst = List.map(ToString.toString, test) |> String.intercalate(" Λ ");
+                    let tst = test |> List.join(" Λ ");
                     "until(${tst}) do${nl}${String.indent(4, "${body}")}end"
                 case Comment(comment) => "// ${comment}"
-            } as & Pure
+            }
     }
 }

--- a/main/src/library/Fixpoint/Ram/RelOp.flix
+++ b/main/src/library/Fixpoint/Ram/RelOp.flix
@@ -37,11 +37,9 @@ namespace Fixpoint/Ram {
                     }, " ∧ ", prefixQuery);
                     "query {${var} ∈ ${ramSym} | ${query}} do${nl}${String.indent(4, "${body}")}end"
                 case Project(terms, ramSym) =>
-                    "project (${terms |> List.map(ToString.toString) |> String.intercalate(", ")}) into ${ramSym}"
+                    "project (${terms |> List.join(", ")}) into ${ramSym}"
                 case If(test, then) =>
-                    let tst =
-                        List.map(ToString.toString, test) |>
-                        String.intercalate(" ∧ ");
+                    let tst = test |> List.join(" ∧ ");
                     "if(${tst}) then${nl}${String.indent(4, "${then}")}end"
             }
     }

--- a/main/src/library/Fixpoint/Simplifier.flix
+++ b/main/src/library/Fixpoint/Simplifier.flix
@@ -33,7 +33,7 @@ namespace Fixpoint {
     ///     end
     ///
     def simplifyStmt(stmt: RamStmt[v]): RamStmt[v] & Impure =
-        Option.getWithDefault(RamStmt.Seq([]), simplifyHelper(Set#{}, stmt))
+        Option.getWithDefault(RamStmt.Seq(Nil), simplifyHelper(Set#{}, stmt))
 
     def simplifyHelper(stratum: Set[RamSym[v]], stmt: RamStmt[v]): Option[RamStmt[v]] & Impure = match stmt {
         case RamStmt.Insert(op) =>
@@ -64,7 +64,7 @@ namespace Fixpoint {
         case RamStmt.Assign(_, _) => Some(stmt)
         case RamStmt.Purge(_) => Some(stmt)
         case RamStmt.Seq(xs) =>
-            Some(RamStmt.Seq(Array.filterMap(simplifyHelper(stratum), xs)))
+            Some(RamStmt.Seq(List.filterMap(simplifyHelper(stratum), xs)))
         case RamStmt.Until(test, body) =>
             let newStratum = List.foldLeft(acc -> e -> match e {
                 case BoolExp.Empty(ramSym) => Set.insert(ramSym, acc)

--- a/main/src/library/Fixpoint/VarsToIndices.flix
+++ b/main/src/library/Fixpoint/VarsToIndices.flix
@@ -27,7 +27,7 @@ namespace Fixpoint {
         case RamStmt.Merge(_, _) => stmt
         case RamStmt.Assign(_, _) => stmt
         case RamStmt.Purge(_) => stmt
-        case RamStmt.Seq(xs) => RamStmt.Seq(Array.map(lowerStmt, xs))
+        case RamStmt.Seq(xs) => RamStmt.Seq(List.map(lowerStmt, xs))
         case RamStmt.Until(test, body) => RamStmt.Until(test, lowerStmt(body))
         case RamStmt.Comment(_) => stmt
     }


### PR DESCRIPTION
Part of #3896.

Also uses `list |> List.join(", ")` instead of `list |> List.map(ToString.toString) |> String.intercalate(", ")`