### PR TITLE
fix: `List.shuffle` tests

### DIFF
--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -2741,31 +2741,31 @@ def distinctWith09(): Bool =
 
     @test
     def shuffle01(): Bool & Impure =
-        let l: List[Int32] = Nil;
-        List.shuffle(Random.new(), l);
+        let l1: List[Int32] = Nil;
+        let l2 = List.shuffle(Random.new(), l1);
 
-        List.length(l) == 0 and List.toSet(l) == Set#{}
+        List.length(l2) == 0 and List.toSet(l2) == Set#{}
 
     @test
     def shuffle02(): Bool & Impure =
-        let l = 1 :: Nil;
-        List.shuffle(Random.new(), l);
+        let l1 = 1 :: Nil;
+        let l2 = List.shuffle(Random.new(), l1);
 
-        List.length(l) == 1 and List.toSet(l) == Set#{1}
+        List.length(l2) == 1 and List.toSet(l2) == Set#{1}
 
     @test
     def shuffle03(): Bool & Impure =
-        let l = 1 :: 2 :: 3 :: Nil;
-        List.shuffle(Random.new(), l);
+        let l1 = 1 :: 2 :: 3 :: Nil;
+        let l2 = List.shuffle(Random.new(), l1);
 
-        List.length(l) == 3 and List.toSet(l) == Set#{1, 2, 3}
+        List.length(l2) == 3 and List.toSet(l2) == Set#{1, 2, 3}
 
     @test
     def shuffle04(): Bool & Impure =
-        let l = 0 :: 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: 9 :: Nil;
-        List.shuffle(Random.new(), l);
+        let l1 = 0 :: 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: 9 :: Nil;
+        let l2 = List.shuffle(Random.new(), l1);
 
-        List.length(l) == 10 and List.toSet(l) == Set#{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+        List.length(l2) == 10 and List.toSet(l2) == Set#{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 
 
 }


### PR DESCRIPTION
The tests were written like shuffle is destructive. @magnus-madsen this was caught by the check in #3667, for our upcoming discussion