### PR TITLE
feat: single backslash at the end of the line acts as continuation

### DIFF
--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -62,6 +62,14 @@ class Shell(sourceProvider: SourceProvider, options: Options) {
   private var isFirstCompile = true
 
   /**
+    * Remove any backslashes from escaped new lines from the given string
+    */
+  def unescapeLine(s: String) = {
+    val escapedLineEnd = raw"\\\n".r
+    escapedLineEnd.replaceAllIn(s, "\n")
+  }
+
+  /**
     * Continuously reads a line of input from the terminal, parses and executes it.
     */
   def loop(): Unit = {
@@ -78,6 +86,7 @@ class Shell(sourceProvider: SourceProvider, options: Options) {
     val reader = LineReaderBuilder
       .builder()
       .appName("flix")
+      .parser(new ShellParser)
       .terminal(terminal)
       .build()
     reader.setOpt(LineReader.Option.DISABLE_EVENT_EXPANSION)
@@ -92,7 +101,7 @@ class Shell(sourceProvider: SourceProvider, options: Options) {
       // Repeatedly try to read an input from the line reader.
       while (!Thread.currentThread().isInterrupted) {
         // Try to read a command.
-        val line = reader.readLine(prompt)
+        val line = unescapeLine(reader.readLine(prompt))
 
         // Parse the command.
         val cmd = Command.parse(line)

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -24,7 +24,7 @@ import ca.uwaterloo.flix.runtime.CompilationResult
 import ca.uwaterloo.flix.util.Formatter.AnsiTerminalFormatter
 import ca.uwaterloo.flix.util._
 
-import org.jline.reader.{EndOfFileException, LineReaderBuilder, UserInterruptException}
+import org.jline.reader.{EndOfFileException, LineReader, LineReaderBuilder, UserInterruptException}
 import org.jline.terminal.{Terminal, TerminalBuilder}
 
 import java.nio.file._
@@ -80,6 +80,7 @@ class Shell(sourceProvider: SourceProvider, options: Options) {
       .appName("flix")
       .terminal(terminal)
       .build()
+    reader.setOpt(LineReader.Option.DISABLE_EVENT_EXPANSION)
 
     // Print the welcome banner.
     printWelcomeBanner()

--- a/main/src/ca/uwaterloo/flix/runtime/shell/ShellParser.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/ShellParser.scala
@@ -22,7 +22,14 @@ import org.jline.reader.Parser.ParseContext
 import scala.jdk.CollectionConverters._
 
 /**
-  * Minimal implementation of `ParsedLine`, necessary to keep jline happy
+  * Minimal implementation of `ParsedLine`, necessary to keep jline happy.
+  * 
+  * JLine uses these values to implement syntax highlighting, line continuation on 
+  * unclosed string, brackets, etc. Because we have all of this functionality 
+  * switched off, we just need to return something that conforms to the `ParsedLine`
+  * interface.
+  * 
+  * https://github.com/jline/jline3/blob/master/reader/src/main/java/org/jline/reader/ParsedLine.java
   */
 class Parsed(s: String) extends ParsedLine {
 

--- a/main/src/ca/uwaterloo/flix/runtime/shell/ShellParser.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/ShellParser.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Paul Butcher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package ca.uwaterloo.flix.runtime.shell
+
+import org.jline.reader.{EOFError, ParsedLine, Parser}
+import org.jline.reader.Parser.ParseContext
+
+import scala.jdk.CollectionConverters._
+
+/**
+  * Minimal implementation of `ParsedLine`, necessary to keep jline happy
+  */
+class Parsed(s: String) extends ParsedLine {
+
+  def wordIndex(): Int = -1
+  def word() = ""
+  def wordCursor(): Int = -1
+  def words() = Nil.asJava
+  def cursor() = -1
+  def line() = s
+}
+
+/**
+  * Implementation of jline's `Parser` to trigger jline's line continuation functionality
+  */
+class ShellParser extends Parser {
+  def parse(s: String, cursor: Int, context: Parser.ParseContext): ParsedLine = {
+    
+    // If the last character in the string is a backslash, throw `EOFError` to trigger line continuation
+    if (s.lastOption == Some('\\'))
+      throw new EOFError(-1, -1, "Escaped new line", "newline")
+
+    new Parsed(s)
+  }
+}

--- a/main/src/library/Validation.flix
+++ b/main/src/library/Validation.flix
@@ -83,7 +83,7 @@ namespace Validation {
     /// Returns `t` if `v` is `Success(t).` Otherwise returns `d`.
     ///
     @Time(1) @Space(1)
-    pub def getWithDefault( d: t, v: Validation[t, e]): t = match v {
+    pub def getWithDefault(d: t, v: Validation[t, e]): t = match v {
         case Success(t) => t
         case Failure(_) => d
     }
@@ -132,15 +132,10 @@ namespace Validation {
     /// Otherwise returns `Failure(e1 :: ... :: en)` with all of the failures concatenated.
     ///
     pub def sequence(l: List[Validation[t, e]]): Validation[List[t], e] =
-        def loopFailure(ll, acc) = match ll {
-            case Nil              => Failure(acc)
-            case Success(_) :: xs => loopFailure(xs, acc)
-            case Failure(e) :: xs => loopFailure(xs, Nec.append(acc, e))
-        };
         def loop(ll, k) = match ll {
             case Nil              => k(Nil)
             case Success(x) :: xs => loop(xs, ks -> k(x :: ks))
-            case Failure(e) :: xs => loopFailure(xs, e)
+            case Failure(e) :: xs => collectFailuresWith(identity, xs, e)
         };
         loop(l, ks -> Success(ks))
 
@@ -150,18 +145,11 @@ namespace Validation {
     /// Otherwise returns `Failure(e1 :: ... :: en)` with all of the failures concatenated.
     ///
     pub def traverse(f: a -> Validation[b, e] & ef, l: List[a]): Validation[List[b], e] & ef =
-        def loopFailure(ll, acc) = match ll {
-            case Nil     => Failure(acc)
-            case x :: xs => match f(x) {
-                case Success(_) => loopFailure(xs, acc)
-                case Failure(y) => loopFailure(xs, Nec.append(acc, y))
-            }
-        };
         def loop(ll, k) = match ll {
             case Nil     => k(Nil)
             case x :: xs => match f(x) {
                 case Success(y) => loop(xs, ks -> k(y :: ks))
-                case Failure(y) => loopFailure(xs, y)
+                case Failure(y) => collectFailuresWith(f, xs, y)
             }
         };
         loop(l, ks -> Success(ks))
@@ -174,22 +162,24 @@ namespace Validation {
     /// This function is the "forgetful" version of `traverse`, use it when the you want the effect
     /// of applying `f` to each element but do not care about collecting the results.
     ///
-    pub def traverseX(f: a -> Validation[b, e] & ef, l: List[a]): Validation[Unit, e] & ef =
-        def loopFailure(ll, acc) = match ll {
-            case Nil     => Failure(acc)
-            case x :: xs => match f(x) {
-                case Success(_) => loopFailure(xs, acc)
-                case Failure(e) => loopFailure(xs, Nec.append(acc, e))
-            }
-        };
-        def loop(ll) = match ll {
-            case Nil     => Success()
-            case x :: xs => match f(x) {
-                case Success(_) => loop(xs)
-                case Failure(e) => loopFailure(xs, e)
-            }
-        };
-        loop(l)
+    pub def traverseX(f: a -> Validation[b, e] & ef, l: List[a]): Validation[Unit, e] & ef = match l {
+        case Nil     => Success()
+        case x :: xs => match f(x) {
+            case Success(_) => traverseX(f, xs)
+            case Failure(e) => collectFailuresWith(f, xs, e)
+        }
+    }
+
+    ///
+    /// Helper function for `sequence`, `traverse` and `traverseX`. Collects a chain of failures.
+    ///
+    def collectFailuresWith(f: a -> Validation[b, e] & ef, l: List[a], acc: Nec[e]): Validation[c, e] & ef = match l {
+        case Nil     => Failure(acc)
+        case x :: xs => match f(x) {
+            case Success(_) => collectFailuresWith(f, xs, acc)
+            case Failure(e) => collectFailuresWith(f, xs, Nec.append(acc, e))
+        }
+    }
 
     ///
     /// Converts a Validation to an Option.


### PR DESCRIPTION
I will freely admit that this is heading towards "voodoo programming". Jline does an awful lot, and the documentation is unhelpfully sparse, so I've cobbled this together by reading the source and looking at examples of other projects that use jline.

But, it does seem to do the right thing:

```
flix> 1 + \                                                                     
> 2
3                                                                               
flix> def myFunction(x: Int32): Int32 = \
> x + 1
Ok.                                                                             
flix> myFunction(1)
2 
```