### PR TITLE
add `:doc` command to REPL

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -136,6 +136,14 @@ object Symbol {
   }
 
   /**
+    * Returns the class symbol for the given fully qualified name
+    */
+  def mkClassSym(fqn: String): ClassSym = split(fqn) match {
+    case None => new ClassSym(Nil, fqn, SourceLocation.Unknown)
+    case Some((ns, name)) => new ClassSym(ns, name, SourceLocation.Unknown)
+  }
+
+  /**
     * Returns the hole symbol for the given name `ident` in the given namespace `ns`.
     */
   def mkHoleSym(ns: NName, ident: Ident): HoleSym = {
@@ -162,6 +170,15 @@ object Symbol {
     */
   def mkTypeAliasSym(ns: NName, ident: Ident): TypeAliasSym = {
     new TypeAliasSym(ns.parts, ident.name, ident.loc)
+  }
+
+  /**
+    * Returns the type alias symbol for the given fully qualified name
+    */
+
+  def mkTypeAliasSym(fqn: String): TypeAliasSym = split(fqn) match {
+    case None => new TypeAliasSym(Nil, fqn, SourceLocation.Unknown)
+    case Some((ns, name)) => new TypeAliasSym(ns, name, SourceLocation.Unknown)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -175,7 +175,6 @@ object Symbol {
   /**
     * Returns the type alias symbol for the given fully qualified name
     */
-
   def mkTypeAliasSym(fqn: String): TypeAliasSym = split(fqn) match {
     case None => new TypeAliasSym(Nil, fqn, SourceLocation.Unknown)
     case Some((ns, name)) => new TypeAliasSym(ns, name, SourceLocation.Unknown)

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
@@ -36,7 +36,7 @@ object Command {
   case object Reload extends Command
 
   /**
-    * Displays documentation
+    * Displays documentation about the fqn s
     */
   case class Doc(s: String) extends Command
 

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
@@ -36,6 +36,11 @@ object Command {
   case object Reload extends Command
 
   /**
+    * Displays documentation
+    */
+  case class Doc(s: String) extends Command
+
+  /**
     * Terminates the shell.
     */
   case object Quit extends Command
@@ -82,6 +87,14 @@ object Command {
     if (input == ":r" || input == ":reload")
       return Command.Reload
 
+    //
+    // Doc
+    //
+    val docPattern = raw":d(oc)?\s+(\S+).*".r
+    input match {
+      case docPattern(_, s) => return Command.Doc(s)
+      case _ => // no-op
+    }
 
     //
     // Quit

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -202,34 +202,29 @@ class Shell(sourceProvider: SourceProvider, options: Options) {
     val enumSym = Symbol.mkEnumSym(s)
     val aliasSym = Symbol.mkTypeAliasSym(s)
 
-    for(r <- root) {
+    root match {
+      case Some(r) =>
+        if(r.classes.contains(classSym)) {
+          val classDecl = r.classes(classSym)
+          w.println(FormatDoc.asMarkDown(classDecl.doc))
+        } else if (r.defs.contains(defnSym)) {
+          val defDecl = r.defs(defnSym)
+          w.println(FormatSignature.asMarkDown(defDecl))
+          w.println(FormatDoc.asMarkDown(defDecl.spec.doc))
+        } else if (r.enums.contains(enumSym)) {
+          val enumDecl = r.enums(enumSym)
+          w.println(FormatDoc.asMarkDown(enumDecl.doc))
+        } else if (r.typeAliases.contains(aliasSym)) {
+          val aliasDecl = r.typeAliases(aliasSym)
+          w.println(FormatType.formatWellKindedType(aliasDecl.tpe))
+          w.println
+          w.println(FormatDoc.asMarkDown(aliasDecl.doc))
+        } else {
+          w.println(s"$s not found")
+        }
 
-      if(r.classes.contains(classSym)) {
-
-        val classDecl = r.classes(classSym)
-        w.println(FormatDoc.asMarkDown(classDecl.doc))
-
-      } else if (r.defs.contains(defnSym)) {
-
-        val defDecl = r.defs(defnSym)
-        w.println(FormatSignature.asMarkDown(defDecl))
-        w.println(FormatDoc.asMarkDown(defDecl.spec.doc))
-
-      } else if (r.enums.contains(enumSym)) {
-
-        val enumDecl = r.enums(enumSym)
-        w.println(FormatDoc.asMarkDown(enumDecl.doc))
-
-      } else if (r.typeAliases.contains(aliasSym)) {
-
-        val aliasDecl = r.typeAliases(aliasSym)
-        w.println(FormatType.formatWellKindedType(aliasDecl.tpe))
-        w.println
-        w.println(FormatDoc.asMarkDown(aliasDecl.doc))
-
-      } else {
-        w.println(s"$s not found")
-      }
+      case None =>
+        w.println("Error: No compilation results available")
     }
   }
 
@@ -249,7 +244,7 @@ class Shell(sourceProvider: SourceProvider, options: Options) {
     w.println("  Command       Arguments     Purpose")
     w.println()
     w.println("  :reload :r                  Recompiles every source file.")
-    w.println("  :doc :d       <identifier>  Displays documentation for <identifier>")
+    w.println("  :doc :d       <fqn>         Displays documentation for <fqn>")
     w.println("  :quit :q                    Terminates the Flix shell.")
     w.println("  :help :h :?                 Shows this helpful information.")
     w.println()

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -197,34 +197,39 @@ class Shell(sourceProvider: SourceProvider, options: Options) {
     */
   private def execDoc(s: String)(implicit terminal: Terminal): Unit = {
     val w = terminal.writer()
+    val classSym = Symbol.mkClassSym(s)
+    val defnSym = Symbol.mkDefnSym(s)
+    val enumSym = Symbol.mkEnumSym(s)
+    val aliasSym = Symbol.mkTypeAliasSym(s)
 
     for(r <- root) {
-      val classSym = Symbol.mkClassSym(s)
+
       if(r.classes.contains(classSym)) {
+
         val classDecl = r.classes(classSym)
         w.println(FormatDoc.asMarkDown(classDecl.doc))
-      }
 
-      val defnSym = Symbol.mkDefnSym(s)
-      if (r.defs.contains(defnSym)) {
+      } else if (r.defs.contains(defnSym)) {
+
         val defDecl = r.defs(defnSym)
         w.println(FormatSignature.asMarkDown(defDecl))
         w.println(FormatDoc.asMarkDown(defDecl.spec.doc))
-      }
 
-      val enumSym = Symbol.mkEnumSym(s)
-      if (r.enums.contains(enumSym)) {
+      } else if (r.enums.contains(enumSym)) {
+
         val enumDecl = r.enums(enumSym)
         w.println(FormatType.formatWellKindedType(enumDecl.tpeDeprecated))
         w.println
         w.println(FormatDoc.asMarkDown(enumDecl.doc))
-      }
 
-      val aliasSym = Symbol.mkTypeAliasSym(s)
-      if (r.typeAliases.contains(aliasSym)) {
+      } else if (r.typeAliases.contains(aliasSym)) {
+
         val aliasDecl = r.typeAliases(aliasSym)
         w.println(FormatType.formatWellKindedType(aliasDecl.tpe))
         w.println(FormatDoc.asMarkDown(aliasDecl.doc))
+
+      } else {
+        w.println(s"$s not found")
       }
     }
   }

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -218,8 +218,6 @@ class Shell(sourceProvider: SourceProvider, options: Options) {
       } else if (r.enums.contains(enumSym)) {
 
         val enumDecl = r.enums(enumSym)
-        w.println(FormatType.formatWellKindedType(enumDecl.tpeDeprecated))
-        w.println
         w.println(FormatDoc.asMarkDown(enumDecl.doc))
 
       } else if (r.typeAliases.contains(aliasSym)) {

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -226,6 +226,7 @@ class Shell(sourceProvider: SourceProvider, options: Options) {
 
         val aliasDecl = r.typeAliases(aliasSym)
         w.println(FormatType.formatWellKindedType(aliasDecl.tpe))
+        w.println
         w.println(FormatDoc.asMarkDown(aliasDecl.doc))
 
       } else {


### PR DESCRIPTION
This implements another of the suggestions within #3989

Draft for now because there are some unanswered questions.

This works reasonably nicely:

<img width="822" alt="Screenshot 2022-07-09 at 11 19 13" src="https://user-images.githubusercontent.com/61163/178101540-fec144ed-d4b5-4d24-b37c-bc173c70d075.png">

But...

I haven't found a way to display the type of a class (so all that's displayed is the documentation):

<img width="822" alt="Screenshot 2022-07-09 at 11 21 27" src="https://user-images.githubusercontent.com/61163/178101632-6c4f176b-efb7-4fc3-9d52-42394f8cd30c.png">

And it would probably make sense to display its signatures (in the same way as does api.flix.dev).

I *have* managed to find a way to display the signature of an enum, but that relies on using `tpeDeprecated` which probably isn't a good thing?

And the formatting can get messy:

<img width="822" alt="Screenshot 2022-07-09 at 11 24 34" src="https://user-images.githubusercontent.com/61163/178101734-3c7b384b-3997-41c3-b043-18167927dc89.png">

So, to do this properly, we probably need to:

* Do something about formatting markdown nicely for terminal output
* Extract some of the code within the documentor phase to re-use here. Or run the documentor when compiling within the repl and make the results available?
