### PR TITLE
refactor: add consistent naming to `foreach`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -713,7 +713,7 @@ object ParsedAst {
       * @param exp   the body expression.
       * @param sp2   the position of the last character in the expression.
       */
-    case class ForEach(sp1: SourcePosition, frags: Seq[ForeachFragment], exp: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Expression
+    case class ForEach(sp1: SourcePosition, frags: Seq[ForEachFragment], exp: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Expression
 
     /**
       * ForYield Expression.
@@ -2182,9 +2182,9 @@ object ParsedAst {
   /**
     * Represents a super type for foreach expression fragments.
     */
-  sealed trait ForeachFragment
+  sealed trait ForEachFragment
 
-  object ForeachFragment {
+  object ForEachFragment {
 
     /**
       * A foreach fragment, i.e. `x <- xs`.
@@ -2194,7 +2194,7 @@ object ParsedAst {
       * @param exp the iterable expression.
       * @param sp2 the position of the last character in the fragment.
       */
-    case class ForEach(sp1: SourcePosition, pat: ParsedAst.Pattern, exp: ParsedAst.Expression, sp2: SourcePosition) extends ForeachFragment
+    case class ForEach(sp1: SourcePosition, pat: ParsedAst.Pattern, exp: ParsedAst.Expression, sp2: SourcePosition) extends ForEachFragment
 
     /**
       * A foreach guard fragment, i.e. `if x > 1`.
@@ -2203,7 +2203,7 @@ object ParsedAst {
       * @param guard the guard expression.
       * @param sp2   the position of the last character in the fragment.
       */
-    case class Guard(sp1: SourcePosition, guard: ParsedAst.Expression, sp2: SourcePosition) extends ForeachFragment
+    case class Guard(sp1: SourcePosition, guard: ParsedAst.Expression, sp2: SourcePosition) extends ForEachFragment
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -504,15 +504,15 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     def ForEach: Rule1[ParsedAst.Expression.ForEach] = {
 
-      def ForEachFragment: Rule1[ParsedAst.ForeachFragment.ForEach] = rule {
-        SP ~ Pattern ~ WS ~ keyword("<-") ~ WS ~ Expression ~ SP ~> ParsedAst.ForeachFragment.ForEach
+      def ForEachFragment: Rule1[ParsedAst.ForEachFragment.ForEach] = rule {
+        SP ~ Pattern ~ WS ~ keyword("<-") ~ WS ~ Expression ~ SP ~> ParsedAst.ForEachFragment.ForEach
       }
 
-      def GuardFragment: Rule1[ParsedAst.ForeachFragment.Guard] = rule {
-        SP ~ keyword("if") ~ WS ~ Expression ~ SP ~> ParsedAst.ForeachFragment.Guard
+      def GuardFragment: Rule1[ParsedAst.ForEachFragment.Guard] = rule {
+        SP ~ keyword("if") ~ WS ~ Expression ~ SP ~> ParsedAst.ForEachFragment.Guard
       }
 
-      def Fragment: Rule1[ParsedAst.ForeachFragment] = rule {
+      def Fragment: Rule1[ParsedAst.ForEachFragment] = rule {
         ForEachFragment | GuardFragment
       }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -695,7 +695,7 @@ object Weeder {
       val fqn = "Iterator.foreach"
 
       foldRight(frags)(visitExp(exp, senv)) {
-        case (ParsedAst.ForeachFragment.ForEach(sp11, pat, e1, sp12), e0) =>
+        case (ParsedAst.ForEachFragment.ForEach(sp11, pat, e1, sp12), e0) =>
           mapN(visitPattern(pat), visitExp(e1, senv)) {
             case (p, e2) =>
               val loc = mkSL(sp11, sp12).asSynthetic
@@ -704,7 +704,7 @@ object Weeder {
               mkApplyFqn(fqn, fparams, loc)
           }
 
-        case (ParsedAst.ForeachFragment.Guard(sp11, e1, sp12), e0) =>
+        case (ParsedAst.ForEachFragment.Guard(sp11, e1, sp12), e0) =>
           mapN(visitExp(e1, senv)) { e2 =>
             val loc = mkSL(sp11, sp12).asSynthetic
             WeededAst.Expression.IfThenElse(e2, e0, WeededAst.Expression.Unit(loc), loc)

--- a/main/test/flix/Test.Exp.ForEach.flix
+++ b/main/test/flix/Test.Exp.ForEach.flix
@@ -5,14 +5,14 @@ namespace Test/Exp/Foreach {
     //
 
     @test
-    def testForeach01(): Bool = region r {
+    def testForEach01(): Bool = region r {
         let y = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: Nil)) y := x + 1; // Iterator.foreach(match x -> y := x + 1, 1 :: Nil))
         deref y == 2
     }
 
     @test
-    def testForeach02(): Bool = region r {
+    def testForEach02(): Bool = region r {
         let y = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: Nil))
             y := x + 1; // Iterator.foreach(match x -> y := x + 1, 1 :: Nil))
@@ -20,14 +20,14 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach03(): Bool = region r {
+    def testForEach03(): Bool = region r {
         let z = ref 0 @ r;
         foreach ((x, y) <- List.iterator(r, (1, 2) :: (3, 4) :: Nil)) z := deref z + x + y; // Iterator.foreach(match (x, y) -> z := deref z + x + y, (1, 2) :: (3, 4) :: Nil))
         deref z == 10
     }
 
     @test
-    def testForeach04(): Bool = region r {
+    def testForEach04(): Bool = region r {
         let z = ref 0 @ r;
         foreach ((x, y) <- List.iterator(r, (1, 2) :: (3, 4) :: Nil))
             z := deref z + x + y; // Iterator.foreach(match (x, y) -> z := deref z + x + y, (1, 2) :: (3, 4) :: Nil))
@@ -35,7 +35,7 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach05(): Bool = region r {
+    def testForEach05(): Bool = region r {
         let z = ref 0 @ r;
         let l = (1, 2) :: (3, 4) :: Nil;
         foreach ((x, y) <- List.iterator(r, l))
@@ -44,7 +44,7 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach06(): Bool = region r {
+    def testForEach06(): Bool = region r {
         let z = ref 0 @ r;
         let l = (1, 2) :: (3, 4) :: Nil;
         foreach ((x, _) <- List.iterator(r, l))
@@ -53,7 +53,7 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach07(): Bool = region r {
+    def testForEach07(): Bool = region r {
         let z = ref 0 @ r;
         let q = ref 1 @ r;
         let l = (1, 2) :: (3, 4) :: Nil;
@@ -65,7 +65,7 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach08(): Bool = region r {
+    def testForEach08(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil))
             foreach(y <- List.iterator(r, 3 :: 4 :: Nil))
@@ -74,7 +74,7 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach09(): Bool = region r {
+    def testForEach09(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil))
             foreach(y <- List.iterator(r, 3 :: 4 :: Nil))
@@ -84,7 +84,7 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach10(): Bool = region r {
+    def testForEach10(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil)) {
             foreach(y <- List.iterator(r, 3 :: 4 :: Nil))
@@ -95,7 +95,7 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach11(): Bool = region r {
+    def testForEach11(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil)) {
             foreach(y <- List.iterator(r, 3 :: 4 :: Nil)) {
@@ -107,7 +107,7 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach12(): Bool = region r {
+    def testForEach12(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil)) {
             foreach(y <- List.iterator(r, 3 :: 4 :: Nil)) {
@@ -120,7 +120,7 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach13(): Bool = region r {
+    def testForEach13(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil)) {
             foreach(y <- List.iterator(r, 3 :: 4 :: Nil)) {
@@ -131,7 +131,7 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach14(): Bool = region r {
+    def testForEach14(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil)) {
             foreach(y <- List.iterator(r, 3 :: 4 :: Nil))
@@ -141,28 +141,28 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach15(): Bool = region r {
+    def testForEach15(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil)) foreach(y <- List.iterator(r, 3 :: 4 :: Nil)) foreach(_ <- List.iterator(r, List.range(0, 10))) z := deref z + (x * y);
         deref z == (3 * 1) * 10 + (4 * 1) * 10 + (3 * 2) * 10 + (4 * 2) * 10
     }
 
     @test
-    def testForeach16(): Bool = region r {
+    def testForEach16(): Bool = region r {
         let z = ref "" @ r;
         foreach (x <- List.iterator(r, "1" :: "2" :: Nil)) foreach(y <- List.iterator(r, "3" :: "4" :: Nil)) z := deref z + "(${x} * ${y}) + ";
         deref z == "(1 * 3) + (1 * 4) + (2 * 3) + (2 * 4) + "
     }
 
     @test
-    def testForeach17(): Bool = region r {
+    def testForEach17(): Bool = region r {
         let y = ref 0 @ r;
         foreach(   x     <- List.iterator(r,      1 :: Nil)   )y := x + 1; // Iterator.foreach(match x -> y := x + 1, 1 :: Nil))
         deref y == 2
     }
 
     @test
-    def testForeach18(): Bool = region r {
+    def testForEach18(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil);y <- List.iterator(r, 3 :: 4 :: Nil))
                     z := deref z + (x * y);
@@ -170,14 +170,14 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach19(): Bool = region r {
+    def testForEach19(): Bool = region r {
         let z = ref 0 @ r;
         foreach(  x <- List.iterator(r, 1 :: 2 :: Nil)  ;   y  <- List.iterator(r,  3 :: 4 :: Nil) )z := deref z + (x * y);
         deref z == (3 * 1) + (4 * 1) + (3 * 2) + (4 * 2)
     }
 
     @test
-    def testForeach20(): Bool = region r {
+    def testForEach20(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil);
                  y <- List.iterator(r, 3 :: 4 :: Nil))
@@ -186,7 +186,7 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach21(): Bool = region r {
+    def testForEach21(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil);
                  y <- List.iterator(r, 3 :: 4 :: Nil);
@@ -197,21 +197,21 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach22(): Bool = region r {
+    def testForEach22(): Bool = region r {
         let z = ref "" @ r;
         foreach (x <- List.iterator(r, "1" :: "2" :: Nil); y <- List.iterator(r, "3" :: "4" :: Nil)) z := deref z + "(${x} * ${y}) + ";
         deref z == "(1 * 3) + (1 * 4) + (2 * 3) + (2 * 4) + "
     }
 
     @test
-    def testForeach23(): Bool = region r {
+    def testForEach23(): Bool = region r {
         let y = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: 3 :: Nil); if x > 1) y := deref y + x; // Iterator.foreach(match x -> if (x > 1) y := deref y + x else (), 1 :: 2 :: 3 :: Nil))
         deref y == 5
     }
 
     @test
-    def testForeach24(): Bool = region r {
+    def testForEach24(): Bool = region r {
         let y = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: 3 :: Nil);
                  if x > 1)
@@ -220,7 +220,7 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach25(): Bool = region r {
+    def testForEach25(): Bool = region r {
         let y = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: 3 :: Nil);
                  if x > 1) {
@@ -230,7 +230,7 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach26(): Bool = region r {
+    def testForEach26(): Bool = region r {
         let y = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: 3 :: Nil); if x > 1) {
             y := deref y + x // Iterator.foreach(match x -> if (x > 1) y := deref y + x else (), 1 :: 2 :: 3 :: Nil))
@@ -239,7 +239,7 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach27(): Bool = region r {
+    def testForEach27(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil);y <- List.iterator(r, 3 :: 4 :: Nil); if x > 1)
                     z := deref z + (x * y);
@@ -247,14 +247,14 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach28(): Bool = region r {
+    def testForEach28(): Bool = region r {
         let z = ref 0 @ r;
         foreach(  x <- List.iterator(r, 1 :: 2 :: Nil)  ;   y  <- List.iterator(r,  3 :: 4 :: Nil);  if x > 1 and y > 3)z := deref z + (x * y);
         deref z == 4 * 2
     }
 
     @test
-    def testForeach29(): Bool = region r {
+    def testForEach29(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil);
                  y <- List.iterator(r, 3 :: 4 :: Nil); if x > 1 and y > 3)
@@ -263,7 +263,7 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach30(): Bool = region r {
+    def testForEach30(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil);
                  y <- List.iterator(r, 3 :: 4 :: Nil);
@@ -274,21 +274,21 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach31(): Bool = region r {
+    def testForEach31(): Bool = region r {
         let z = ref "" @ r;
         foreach (x <- List.iterator(r, "1" :: "2" :: Nil); y <- List.iterator(r, "3" :: "4" :: Nil); if x != "1") z := deref z + "(${x} * ${y}) + ";
         deref z == "(2 * 3) + (2 * 4) + "
     }
 
     @test
-    def testForeach32(): Bool = region r {
+    def testForEach32(): Bool = region r {
         let y = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: 3 :: Nil); if x > 1) y := deref y + x; // Iterator.foreach(match x -> if (x > 1) y := deref y + x else (), 1 :: 2 :: 3 :: Nil))
         deref y == 5
     }
 
     @test
-    def testForeach33(): Bool = region r {
+    def testForEach33(): Bool = region r {
         let y = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: 3 :: Nil);
                  if x > 1)
@@ -297,35 +297,35 @@ namespace Test/Exp/Foreach {
     }
 
     @test
-    def testForeach35(): Bool = region r {
+    def testForEach35(): Bool = region r {
         let z = ref 0 @ r;
         foreach(  x <- List.iterator(r, 1 :: 2 :: Nil)  ;   if x > 1 ;   y  <- List.iterator(r,  3 :: 4 :: Nil);if y > 3)z := deref z + (x * y);
         deref z == 4 * 2
     }
 
     @test
-    def testForeach36(): Bool = region r {
+    def testForEach36(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil);if x > 1; y <- List.iterator(r, 3 :: 4 :: Nil); if y > 3) z := deref z + (x * y);
         deref z == 4 * 2
     }
 
     @test
-    def testForeach37(): Bool = region r {
+    def testForEach37(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil); if x > 1; y <- List.iterator(r, 3 :: 4 :: Nil); if y > 3) z := deref z + (x * y);
         deref z == 4 * 2
     }
 
     @test
-    def testForeach38(): Bool = region r {
+    def testForEach38(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil); if x > 1; y <- List.iterator(r, 3 :: 4 :: Nil)) z := deref z + (x * y);
         deref z == (3 * 2) + (4 * 2)
     }
 
     @test
-    def testForeach39(): Bool = region r {
+    def testForEach39(): Bool = region r {
         let z = ref 0 @ r;
         foreach (x <- List.iterator(r, 1 :: 2 :: Nil); y <- List.iterator(r, 3 :: 4 :: Nil); if y > 3; if x > 1) z := deref z + (x * y);
         deref z == 4 * 2


### PR DESCRIPTION
`ForEach` was not properly formatted. 