### PR TITLE
feat: add `MonadZero`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -174,6 +174,7 @@ class Flix {
     "Group.flix" -> LocalResource.get("/src/library/Group.flix"),
     "Identity.flix" -> LocalResource.get("/src/library/Identity.flix"),
     "Monad.flix" -> LocalResource.get("/src/library/Monad.flix"),
+    "MonadZero.flix" -> LocalResource.get("/src/library/MonadZero.flix"),
     "Monoid.flix" -> LocalResource.get("/src/library/Monoid.flix"),
     "Reducible.flix" -> LocalResource.get("/src/library/Reducible.flix"),
     "SemiGroup.flix" -> LocalResource.get("/src/library/SemiGroup.flix"),

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -54,6 +54,10 @@ instance Monad[Chain] {
     pub def flatMap(f: a -> Chain[b] & ef, x : Chain[a]) : Chain[b] & ef = Chain.flatMap(f, x)
 }
 
+instance MonadZero[Chain] {
+    pub def empty(): Chain[a] = Chain.empty()
+}
+
 instance Foldable[Chain] {
     pub def foldLeft(f: (b, a) -> b & ef, s: b, c: Chain[a]): b & ef = Chain.foldLeft(f, s, c)
     pub def foldRight(f: (a, b) -> b & ef, s: b, c: Chain[a]): b & ef = Chain.foldRight(f, s, c)

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -75,6 +75,10 @@ instance Monad[DelayList] {
     pub def flatMap(f: a -> DelayList[b] & ef, l: DelayList[a]): DelayList[b] & ef = DelayList.flatMap(f, l)
 }
 
+instance MonadZero[DelayList] {
+    pub def empty(): DelayList[a] = DelayList.empty()
+}
+
 instance Traversable[DelayList] {
     pub def traverse(f: a -> m[b] & ef, l: DelayList[a]): m[DelayList[b]] & ef with Applicative[m] = DelayList.traverse(f, l)
     pub override def sequence(l: DelayList[m[a]]): m[DelayList[a]] with Applicative[m] = DelayList.sequence(l)

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -341,10 +341,9 @@ namespace List {
     /// For `f = f1, f2, ...` and `x = x1, x2, ...` the results appear in the order
     /// `f1(x1), f1(x2), ..., f2(x1), f2(x2), ...`.
     ///
-    pub def ap(f: List[a -> b & e], x: List[a]) : List[b] & e =
+    pub def ap(f: List[a -> b & ef], x: List[a]) : List[b] & ef =
         map(g -> map(g, x), f) |> flatten
 
-    // TODO: Efficient implementations of lift2,...,lift5, redirect liftA2,...,liftA5 to those.
     ///
     /// Lift a binary function to work on lists of its original arguments, returning a list
     /// of applying all combinations of arguments.

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -73,6 +73,10 @@ instance Monad[List] {
     pub def flatMap(f: a -> List[b] & ef, x : List[a]) : List[b] & ef = List.flatMap(f, x)
 }
 
+instance MonadZero[List] {
+    pub def empty(): List[a] = Nil
+}
+
 instance Foldable[List] {
     pub def foldLeft(f: (b, a) -> b & ef, s: b, l: List[a]): b & ef = List.foldLeft(f, s, l)
     pub def foldRight(f: (a, b) -> b & ef, s: b, l: List[a]): b & ef = List.foldRight(f, s, l)

--- a/main/src/library/MonadZero.flix
+++ b/main/src/library/MonadZero.flix
@@ -1,0 +1,22 @@
+/*
+ *  Copyright 2022 Magnus Madsen
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions not
+ *  limitations under the License.
+ */
+
+///
+/// A type class for Monads that have a zero element.
+///
+class MonadZero[m: Type -> Type] with Monad[m] {
+    pub def empty(): m[t]
+}

--- a/main/src/library/MonadZero.flix
+++ b/main/src/library/MonadZero.flix
@@ -18,5 +18,10 @@
 /// A type class for Monads that have a zero element.
 ///
 class MonadZero[m: Type -> Type] with Monad[m] {
+
+    ///
+    /// Returns the zero element of the monad.
+    ///
     pub def empty(): m[t]
+
 }

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -81,6 +81,10 @@ instance Monad[Option] {
     pub def flatMap(f: a -> Option[b] & ef, x : Option[a]) : Option[b] & ef = Option.flatMap(f, x)
 }
 
+instance MonadZero[Option] {
+    pub def empty(): Option[a] = None
+}
+
 instance Foldable[Option] {
     pub def foldLeft(f: (b, a) -> b & ef, s: b, o: Option[a]): b & ef = Option.foldLeft(f, s, o)
     pub def foldRight(f: (a, b) -> b & ef, s: b, o: Option[a]): b & ef = Option.foldRight(f, o, s)


### PR DESCRIPTION
Adds `MonadZero` and instances to `List`, `DelayList`,`Chain`, `Option`.

I tried experimenting with adding `Applicative` and `Monad` instances to `Result` but it seems the `point` function causes problems with the type variable `e` in `Result[t, e]`. Besides, there is no empty element for `Result` so it wouldn't make sense to add a `MonadZero` instance either.

Also, removed a todo from `List` and changed `& e` to `& ef`.

Closes #4214