### PR TITLE
refactor: use regions in `SearchEnv`

### DIFF
--- a/main/src/library/Fixpoint/Compiler.flix
+++ b/main/src/library/Fixpoint/Compiler.flix
@@ -44,7 +44,7 @@ namespace Fixpoint {
                     let ruleStratum = Map.getWithDefault(p, 0, strat);
                     Map.insertWith(List.append, ruleStratum, rule :: Nil)
             }, Map#{}, rules) |>
-            Map.foreach(_ -> (x -> List.toArray(r, x)) >> compileStratum(stmts));
+            Map.foreach((_, s) -> compileStratum(stmts, s));
             RamStmt.Seq(MutList.toList(stmts))
         }
         case _ => bug!("Datalog normalization bug")
@@ -68,13 +68,13 @@ namespace Fixpoint {
     /// Note that Eval-Rule is the code emitted by `compileRule`
     /// and Eval-Rule-Incr is the code emitted by `compileRuleIncr`.
     ///
-    def compileStratum(stmts: MutList[RamStmt[v], r1], stratum: Array[Constraint[v], r2]): Unit & (r1 and r2) with ToString[v] = region r {
-        let idb = Array.foldRight(match Constraint(HeadAtom(pred, den, terms), _) -> {
+    def compileStratum(stmts: MutList[RamStmt[v], r], stratum: List[Constraint[v]]): Unit & r with ToString[v] = region r {
+        let idb = List.foldRight(match Constraint(HeadAtom(pred, den, terms), _) -> {
             let arity = List.length(terms);
             Map.insert(pred, (arity, den))
         }, Map#{}, stratum);
         let loopBody = new MutList(r);
-        Array.foreach(compileRule(stmts), stratum);
+        List.foreach(compileRule(stmts), stratum);
         Map.foreach(predSym -> match (arity, den) -> {
             let full = RamSym.Full(predSym, arity, den);
             let delta = RamSym.Delta(predSym, arity, den);
@@ -85,7 +85,7 @@ namespace Fixpoint {
             let purge = RamStmt.Purge(RamSym.New(predSym, arity, den));
             MutList.push!(purge, loopBody)
         }, idb);
-        Array.foreach(compileRuleIncr(loopBody), stratum);
+        List.foreach(compileRuleIncr(loopBody), stratum);
         Map.foreach(predSym -> match (arity, den) -> {
             let new = RamSym.New(predSym, arity, den);
             let full = RamSym.Full(predSym, arity, den);

--- a/main/src/library/Fixpoint/Compiler.flix
+++ b/main/src/library/Fixpoint/Compiler.flix
@@ -68,7 +68,7 @@ namespace Fixpoint {
     /// Note that Eval-Rule is the code emitted by `compileRule`
     /// and Eval-Rule-Incr is the code emitted by `compileRuleIncr`.
     ///
-    def compileStratum(stmts: MutList[RamStmt[v], r], stratum: List[Constraint[v]]): Unit & r with ToString[v] = region r {
+    def compileStratum(stmts: MutList[RamStmt[v], r], stratum: List[Constraint[v]]): Unit \ Write(r) with ToString[v] = region r {
         let idb = List.foldRight(match Constraint(HeadAtom(pred, den, terms), _) -> {
             let arity = List.length(terms);
             Map.insert(pred, (arity, den))
@@ -122,7 +122,7 @@ namespace Fixpoint {
     ///         end
     ///     end
     ///
-    def compileRule(stmts: MutList[RamStmt[v], r], rule: Constraint[v]): Unit & r with ToString[v] = match rule {
+    def compileRule(stmts: MutList[RamStmt[v], r], rule: Constraint[v]): Unit \ Write(r) with ToString[v] = match rule {
         case Constraint(HeadAtom(headSym, headDen, headTerms), body) =>
             let augBody = augmentBody(body);
             let env = unifyVars(augBody);
@@ -174,7 +174,7 @@ namespace Fixpoint {
     /// Note that there are two join loops, because there are two positive atoms.
     /// Also note how in the first loop, `B` is the focused atom and `C` is focused in the second loop.
     ///
-    def compileRuleIncr(stmts: MutList[RamStmt[v], r], rule: Constraint[v]): Unit & r with ToString[v] = match rule {
+    def compileRuleIncr(stmts: MutList[RamStmt[v], r], rule: Constraint[v]): Unit \ Write(r) with ToString[v] = match rule {
         case Constraint(HeadAtom(headSym, headDen, headTerms), body) =>
             let augBody = augmentBody(body);
             let env = unifyVars(augBody);

--- a/main/src/library/Fixpoint/Interpreter.flix
+++ b/main/src/library/Fixpoint/Interpreter.flix
@@ -76,20 +76,20 @@ namespace Fixpoint {
     }
 
     type alias Database[v: Type, r: Region] = MutMap[RamSym[v], MutMap[Tuple[v], v, r], r]
-    type alias SearchEnv[v] = (Array[Tuple[v], Static], Array[v, Static])
+    type alias SearchEnv[v: Type, r: Region] = (Array[Tuple[v], r], Array[v, r])
 
-    def interpret(r: Region[r], stmt: RamStmt[v]): Database[v, r] & Impure with Order[v], ToString[v] =
+    def interpret(r: Region[r], stmt: RamStmt[v]): Database[v, r] & r with Order[v], ToString[v] =
         interpretWithDatabase(new MutMap(r), stmt)
 
-    def interpretWithDatabase(db: Database[v, r], stmt: RamStmt[v]): Database[v, r] & Impure with Order[v], ToString[v] =
-        notifyPreInterpret(stmt);
+    def interpretWithDatabase(db: Database[v, r], stmt: RamStmt[v]): Database[v, r] & r with Order[v], ToString[v] =
+        let _ = notifyPreInterpret(stmt) as & Pure;
         evalStmt(db, stmt);
         db
 
-    def evalStmt(db: Database[v, r], stmt: RamStmt[v]): Unit & Impure with Order[v], ToString[v] =
+    def evalStmt(db: Database[v, r], stmt: RamStmt[v]): Unit & r with Order[v], ToString[v] =
         let r = Scoped.regionOf(db);
         match stmt {
-            case RamStmt.Insert(relOp) => evalOp(db, allocEnv(0, relOp), relOp)
+            case RamStmt.Insert(relOp) => evalOp(db, allocEnv(r, 0, relOp), relOp)
             case RamStmt.Merge(srcSym, dstSym) =>
                 let dst = MutMap.getOrElsePut!(dstSym, new MutMap(r), db);
                 match toDenotation(srcSym) {
@@ -103,7 +103,7 @@ namespace Fixpoint {
             case RamStmt.Purge(ramSym) => MutMap.remove!(ramSym, db)
             case RamStmt.Seq(stmts) => List.foreach(evalStmt(db), stmts)
             case RamStmt.Until(test, body) =>
-                if (evalBoolExp(db, ([], []), test)) {
+                if (evalBoolExp(db, ([] @ r, [] @ r), test)) {
                     ()
                 } else {
                     evalStmt(db, body);
@@ -112,15 +112,15 @@ namespace Fixpoint {
             case RamStmt.Comment(_) => ()
         }
 
-    def allocEnv(depth: Int32, relOp: RelOp[v]): SearchEnv[v] & Impure = match relOp {
-        case RelOp.Search(_, _, body) => allocEnv(depth + 1, body)
-        case RelOp.Query(_, _, _, body) => allocEnv(depth + 1, body)
-        case RelOp.Project(_) => (Array.new(Static, Fixpoint/Tuple.new(Nil), depth), Array.new(Static, $DEFAULT$, depth))
-        case RelOp.If(_, then) => allocEnv(depth, then)
+    def allocEnv(r: Region[r], depth: Int32, relOp: RelOp[v]): SearchEnv[v, r] & r = match relOp {
+        case RelOp.Search(_, _, body) => allocEnv(r, depth + 1, body)
+        case RelOp.Query(_, _, _, body) => allocEnv(r, depth + 1, body)
+        case RelOp.Project(_) => (Array.new(r, Fixpoint/Tuple.new(Nil), depth), Array.new(r, $DEFAULT$, depth))
+        case RelOp.If(_, then) => allocEnv(r, depth, then)
     }
 
-    def evalOp(db: Database[v, r], env: SearchEnv[v], op: RelOp[v]): Unit & Impure with Order[v], ToString[v] =
-        let r = Scoped.regionOf(db);
+    def evalOp(db: Database[v, r1], env: SearchEnv[v, r2], op: RelOp[v]): Unit & (r1 and r2) with Order[v], ToString[v] =
+        let r1 = Scoped.regionOf(db);
         match op {
             case RelOp.Search(RowVar.Index(i), ramSym, body) =>
                 let (tupleEnv, latEnv) = env;
@@ -128,16 +128,16 @@ namespace Fixpoint {
                     tupleEnv[i] = t;
                     latEnv[i] = l;
                     evalOp(db, env, body)
-                }, MutMap.getWithDefault(ramSym, new MutMap(r), db))
+                }, MutMap.getWithDefault(ramSym, new MutMap(r1), db))
             case RelOp.Query(RowVar.Index(i), ramSym, query, body) =>
                 let (tupleEnv, latEnv) = env;
                 MutMap.queryWith(evalQuery(env, query), t -> l -> {
                     tupleEnv[i] = t;
                     latEnv[i] = l;
                     evalOp(db, env, body)
-                }, MutMap.getWithDefault(ramSym, new MutMap(r), db))
+                }, MutMap.getWithDefault(ramSym, new MutMap(r1), db))
             case RelOp.Project(terms, ramSym) =>
-                let rel = MutMap.getOrElsePut!(ramSym, new MutMap(r), db);
+                let rel = MutMap.getOrElsePut!(ramSym, new MutMap(r1), db);
                 match toDenotation(ramSym) {
                     case Denotation.Relational =>
                         let tuple = Fixpoint/Tuple.new(List.map(evalTerm(env), terms));
@@ -164,7 +164,7 @@ namespace Fixpoint {
             case _ => ()
         }
 
-    def evalQuery(env: SearchEnv[v], query: List[(Int32, RamTerm[v])], tuple: Tuple[v]): Comparison & Impure with Order[v], ToString[v] =
+    def evalQuery(env: SearchEnv[v, r], query: List[(Int32, RamTerm[v])], tuple: Tuple[v]): Comparison & r with Order[v], ToString[v] =
         match query {
             case Nil => EqualTo
             case (j, t) :: tl => match Fixpoint/Tuple.valueAt(tuple, j) <=> evalTerm(env, t) {
@@ -173,13 +173,13 @@ namespace Fixpoint {
             }
         }
 
-    def evalBoolExp(db: Database[v, r], env: SearchEnv[v], es: List[BoolExp[v]]): Bool & Impure with Order[v], ToString[v] =
-        let r = Scoped.regionOf(db);
+    def evalBoolExp(db: Database[v, r1], env: SearchEnv[v, r2], es: List[BoolExp[v]]): Bool & (r1 and r2) with Order[v], ToString[v] =
+        let r1 = Scoped.regionOf(db);
         List.forall(exp -> match exp {
             case BoolExp.Empty(ramSym) =>
-                MutMap.isEmpty(MutMap.getWithDefault(ramSym, new MutMap(r), db))
+                MutMap.isEmpty(MutMap.getWithDefault(ramSym, new MutMap(r1), db))
             case BoolExp.NotMemberOf(terms, ramSym) =>
-                let rel = MutMap.getWithDefault(ramSym, new MutMap(r), db);
+                let rel = MutMap.getWithDefault(ramSym, new MutMap(r1), db);
                 match toDenotation(ramSym) {
                     case Denotation.Relational =>
                         let tuple = Fixpoint/Tuple.new(List.map(evalTerm(env), terms));
@@ -227,7 +227,7 @@ namespace Fixpoint {
                 f(v1)(v2)(v3)(v4)(v5)
         }, es)
 
-    def evalTerm(env: SearchEnv[v], term: RamTerm[v]): v & Impure with ToString[v] = match term {
+    def evalTerm(env: SearchEnv[v, r], term: RamTerm[v]): v & r with ToString[v] = match term {
         case RamTerm.Lit(v) => v
         case RamTerm.RowLoad(RowVar.Index(i), index) =>
             let (tupleEnv, _) = env;

--- a/main/src/library/Fixpoint/Interpreter.flix
+++ b/main/src/library/Fixpoint/Interpreter.flix
@@ -78,16 +78,15 @@ namespace Fixpoint {
     type alias Database[v: Type, r: Region] = MutMap[RamSym[v], MutMap[Tuple[v], v, r], r]
     type alias SearchEnv[v: Type, r: Region] = (Array[Tuple[v], r], Array[v, r])
 
-    def interpret(r: Region[r], stmt: RamStmt[v]): Database[v, r] & r with Order[v], ToString[v] =
+    def interpret(r: Region[r], stmt: RamStmt[v]): Database[v, r] \ Write(r) with Order[v], ToString[v] =
         interpretWithDatabase(new MutMap(r), stmt)
 
-    def interpretWithDatabase(db: Database[v, r], stmt: RamStmt[v]): Database[v, r] & r with Order[v], ToString[v] = {
-        notifyPreInterpret(stmt);
+    def interpretWithDatabase(db: Database[v, r], stmt: RamStmt[v]): Database[v, r] \ { Read(r), Write(r) } with Order[v], ToString[v] =
+        notifyPreInterpret(stmt) as & r; // This casts away the impure effect of notify
         evalStmt(db, stmt);
         db
-    } as & r // This casts away the impure effect of notify
 
-    def evalStmt(db: Database[v, r], stmt: RamStmt[v]): Unit & r with Order[v], ToString[v] =
+    def evalStmt(db: Database[v, r], stmt: RamStmt[v]): Unit \ { Read(r), Write(r) } with Order[v], ToString[v] =
         let r = Scoped.regionOf(db);
         match stmt {
             case RamStmt.Insert(relOp) => evalOp(db, allocEnv(r, 0, relOp), relOp)
@@ -113,14 +112,14 @@ namespace Fixpoint {
             case RamStmt.Comment(_) => ()
         }
 
-    def allocEnv(r: Region[r], depth: Int32, relOp: RelOp[v]): SearchEnv[v, r] & r = match relOp {
+    def allocEnv(r: Region[r], depth: Int32, relOp: RelOp[v]): SearchEnv[v, r] \ Write(r) = match relOp {
         case RelOp.Search(_, _, body) => allocEnv(r, depth + 1, body)
         case RelOp.Query(_, _, _, body) => allocEnv(r, depth + 1, body)
         case RelOp.Project(_) => (Array.new(r, Fixpoint/Tuple.new(Nil), depth), Array.new(r, $DEFAULT$, depth))
         case RelOp.If(_, then) => allocEnv(r, depth, then)
     }
 
-    def evalOp(db: Database[v, r1], env: SearchEnv[v, r2], op: RelOp[v]): Unit & (r1 and r2) with Order[v], ToString[v] =
+    def evalOp(db: Database[v, r1], env: SearchEnv[v, r2], op: RelOp[v]): Unit \ { Read(r1), Write(r1), Read(r2), Write(r2) } with Order[v], ToString[v] =
         let r1 = Scoped.regionOf(db);
         match op {
             case RelOp.Search(RowVar.Index(i), ramSym, body) =>
@@ -165,7 +164,7 @@ namespace Fixpoint {
             case _ => ()
         }
 
-    def evalQuery(env: SearchEnv[v, r], query: List[(Int32, RamTerm[v])], tuple: Tuple[v]): Comparison & r with Order[v], ToString[v] =
+    def evalQuery(env: SearchEnv[v, r], query: List[(Int32, RamTerm[v])], tuple: Tuple[v]): Comparison \ Read(r) with Order[v], ToString[v] =
         match query {
             case Nil => EqualTo
             case (j, t) :: tl => match Fixpoint/Tuple.valueAt(tuple, j) <=> evalTerm(env, t) {
@@ -174,7 +173,7 @@ namespace Fixpoint {
             }
         }
 
-    def evalBoolExp(db: Database[v, r1], env: SearchEnv[v, r2], es: List[BoolExp[v]]): Bool & (r1 and r2) with Order[v], ToString[v] =
+    def evalBoolExp(db: Database[v, r1], env: SearchEnv[v, r2], es: List[BoolExp[v]]): Bool \ { Read(r1), Read(r2) } with Order[v], ToString[v] =
         let r1 = Scoped.regionOf(db);
         List.forall(exp -> match exp {
             case BoolExp.Empty(ramSym) =>
@@ -228,7 +227,7 @@ namespace Fixpoint {
                 f(v1)(v2)(v3)(v4)(v5)
         }, es)
 
-    def evalTerm(env: SearchEnv[v, r], term: RamTerm[v]): v & r with ToString[v] = match term {
+    def evalTerm(env: SearchEnv[v, r], term: RamTerm[v]): v \ Read(r) with ToString[v] = match term {
         case RamTerm.Lit(v) => v
         case RamTerm.RowLoad(RowVar.Index(i), index) =>
             let (tupleEnv, _) = env;

--- a/main/src/library/Fixpoint/Interpreter.flix
+++ b/main/src/library/Fixpoint/Interpreter.flix
@@ -81,10 +81,11 @@ namespace Fixpoint {
     def interpret(r: Region[r], stmt: RamStmt[v]): Database[v, r] & r with Order[v], ToString[v] =
         interpretWithDatabase(new MutMap(r), stmt)
 
-    def interpretWithDatabase(db: Database[v, r], stmt: RamStmt[v]): Database[v, r] & r with Order[v], ToString[v] =
-        let _ = notifyPreInterpret(stmt) as & Pure;
+    def interpretWithDatabase(db: Database[v, r], stmt: RamStmt[v]): Database[v, r] & r with Order[v], ToString[v] = {
+        notifyPreInterpret(stmt);
         evalStmt(db, stmt);
         db
+    } as & r // This casts away the impure effect of notify
 
     def evalStmt(db: Database[v, r], stmt: RamStmt[v]): Unit & r with Order[v], ToString[v] =
         let r = Scoped.regionOf(db);

--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -33,8 +33,7 @@ namespace Fixpoint {
     ///
     @Internal
     pub def solve(d: Datalog[v]): Datalog[v] with Order[v], ToString[v] =
-        (stratify(d) |>
-        solveWithStratification(d)) as & Pure
+        stratify(d) |> solveWithStratification(d)
 
     ///
     /// Returns the minimal model of the given Datalog program `d`.
@@ -42,8 +41,8 @@ namespace Fixpoint {
     /// A stratification of `d` is given by `stf`.
     ///
     @Internal
-    def solveWithStratification(d: Datalog[v], stf: Map[PredSym, Int32]): Datalog[v] & Impure with Order[v], ToString[v] =
-        notifyPreSolve(d, stf);
+    def solveWithStratification(d: Datalog[v], stf: Map[PredSym, Int32]): Datalog[v] with Order[v], ToString[v] =
+        let _ = notifyPreSolve(d, stf) as & Pure;
         let compiler = cs ->
             compile(cs, stf) |>
             simplifyStmt |>
@@ -54,12 +53,13 @@ namespace Fixpoint {
                 compiler(d) |> interpret(r) |> toModel
             }
             case Model(_) => d
-            case Join(Model(m), cs) =>
-                let db = Map.map(Map.toMutMap(Static), m) |> Map.toMutMap(Static);
+            case Join(Model(m), cs) => region r {
+                let db = Map.map(Map.toMutMap(r), m) |> Map.toMutMap(r);
                 compiler(cs) |> interpretWithDatabase(db) |> toModel
+            }
             case _ => bug!("Datalog normalization bug")
         };
-        notifyPostSolve(model);
+        let _ = notifyPostSolve(model) as & Pure;
         model
 
     ///

--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -768,7 +768,7 @@ namespace Fixpoint {
     @Internal @Unsafe
     pub def unsafeCast(v: a): Datalog[Boxed] = v as Datalog[Boxed]
 
-    def toModel(db: Database[v, r]): Datalog[v] & r =
+    def toModel(db: Database[v, r]): Datalog[v] \ Read(r) =
         MutMap.toMap(db) |>
         Map.map(MutMap.toMap) |>
         Model

--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -41,8 +41,8 @@ namespace Fixpoint {
     /// A stratification of `d` is given by `stf`.
     ///
     @Internal
-    def solveWithStratification(d: Datalog[v], stf: Map[PredSym, Int32]): Datalog[v] with Order[v], ToString[v] =
-        let _ = notifyPreSolve(d, stf) as & Pure;
+    def solveWithStratification(d: Datalog[v], stf: Map[PredSym, Int32]): Datalog[v] with Order[v], ToString[v] = {
+        notifyPreSolve(d, stf);
         let compiler = cs ->
             compile(cs, stf) |>
             simplifyStmt |>
@@ -59,8 +59,9 @@ namespace Fixpoint {
             }
             case _ => bug!("Datalog normalization bug")
         };
-        let _ = notifyPostSolve(model) as & Pure;
+        notifyPostSolve(model);
         model
+    } as & Pure // This casts away the impure effect of notify
 
     ///
     /// Returns the pairwise union of `d1` and `d2`.
@@ -144,11 +145,11 @@ namespace Fixpoint {
             println(s);
             println(d);
             println(r)
-        } as & Pure else ();
+        } else ();
 
         // Return the result.
         r
-    }
+    } as & Pure // This casts away the impure effect of debugging
 
     ///
     /// Insert all facts in the given sequence `f` into the given relation `p`.


### PR DESCRIPTION
Fixes #3896.

With this PR the debugging messages will now be erased by the optimizer. This is probably just the way it is for now.


The remaining impure methods are related to debug messages and the use of `Global.newId`.

The remaining unsafe Pure casts are from the above and then the unsafe implementation of `Tuple`