### PR TITLE
fix: simplify constant sets in SVE

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -71,7 +71,7 @@ object Unification {
     (tpe1, tpe2) match {
 
       // don't try to unify effects if the flag is off
-      case (x, y) if x.kind == Kind.Effect && y.kind == Kind.Effect && flix.options.xeffects => Ok(Substitution.empty)
+      case (x, y) if x.kind == Kind.Effect && y.kind == Kind.Effect && !flix.options.xeffects => Ok(Substitution.empty)
 
       case (x: Type.Var, y: Type.Var) => unifyVars(x.asKinded, y.asKinded, renv)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -71,7 +71,7 @@ object Unification {
     (tpe1, tpe2) match {
 
       // don't try to unify effects if the flag is off
-      case (x, y) if x.kind == Kind.Effect && y.kind == Kind.Effect && !flix.options.xeffects => Ok(Substitution.empty)
+      case (x, y) if x.kind == Kind.Effect && y.kind == Kind.Effect && flix.options.xeffects => Ok(Substitution.empty)
 
       case (x: Type.Var, y: Type.Var) => unifyVars(x.asKinded, y.asKinded, renv)
 

--- a/main/test/ca/uwaterloo/flix/language/phase/unification/TestSetUnification.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/unification/TestSetUnification.scala
@@ -155,6 +155,40 @@ class TestSetUnification extends FunSuite with TestUtils {
     assertUnifies(tpe1, tpe2, RigidityEnv.empty)
   }
 
+  test("Test.SetUnification.10") {
+    // (E ∪ F) ∖ E ≐ F
+    val effE = Type.Cst(TypeConstructor.Effect(mkEffectSym("E")), loc)
+    val effF = Type.Cst(TypeConstructor.Effect(mkEffectSym("F")), loc)
+
+    val tpe1 = Type.mkDifference(
+      Type.mkUnion(effE, effF, loc),
+      effE,
+      loc
+    )
+
+    val tpe2 = effF
+
+    assertUnifies(tpe1, tpe2, RigidityEnv.empty)
+  }
+
+  test("Test.SetUnification.11") {
+    // E ∖ E ≐ ∅
+    val effE = Type.Cst(TypeConstructor.Effect(mkEffectSym("E")), loc)
+
+    val tpe1 = Type.mkDifference(effE, effE, loc)
+    val tpe2 = Type.Empty
+
+    assertUnifies(tpe1, tpe2, RigidityEnv.empty)
+  }
+
+  test("Test.SetUnification.12") {
+    // 𝓤 ∖ 𝓤 ≐ ∅
+    val tpe1 = Type.mkDifference(Type.All, Type.All, loc)
+    val tpe2 = Type.Empty
+
+    assertUnifies(tpe1, tpe2, RigidityEnv.empty)
+  }
+
   test("Test.SetUnification.Fail.01") {
     // e! ≐ f!
     val sym1 = mkTypeVarSym("e")


### PR DESCRIPTION
There was an issue with the application of SVE to effect sets:
`{F} - ({E, F} - {E})` should always equal the empty set
But its boolean formula counterpart `F and not ((E or F) and not E)` is not equal to False.

Per discussion, the argument to the base case of the SVE algorithm must be fully reduced: in a simple set form with no free variables.

In order to arrive at this form, I've introduced a simplification function. It represents an effect as a either a positive or negative set of effects and rigid variables, (e.g. `{a, b, c}` or `~{d, e, f}`. Then it converts it back to a regular for use in the SVE algorithm.

With this simplification in place, things _appear_ to work well, in that nothing has broken since introducing the simplification, but I am not sure it is sound. In particular, I am not sure that it is appropriate to treat the type variables as singleton effect constants, when in reality they represent sets of effects.