### PR TITLE
fix: do not stylize Unit as Enum

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -287,9 +287,7 @@ object SemanticTokensProvider {
 
     case Expression.Hole(_, _, _) => Iterator.empty
 
-    case Expression.Unit(loc) =>
-      val t = SemanticToken(SemanticTokenType.EnumMember, Nil, loc)
-      Iterator(t)
+    case Expression.Unit(_) => Iterator.empty
 
     case Expression.Null(_, _) => Iterator.empty
 
@@ -553,9 +551,7 @@ object SemanticTokensProvider {
       val t = SemanticToken(o, Nil, loc)
       Iterator(t)
 
-    case Pattern.Unit(loc) =>
-      val t = SemanticToken(SemanticTokenType.EnumMember, Nil, loc)
-      Iterator(t)
+    case Pattern.Unit(_) => Iterator.empty
 
     case Pattern.True(_) => Iterator.empty
 


### PR DESCRIPTION
Italicizing the `()` felt out of place to me. It's subjective, but here's the change:

### Before
![Screenshot from 2022-07-13 16-42-29](https://user-images.githubusercontent.com/19153692/178764700-8e9e103f-1d26-4ccf-ba51-1463e759b5dd.png)

### After
![Screenshot from 2022-07-13 16-51-42](https://user-images.githubusercontent.com/19153692/178764778-438351fa-6fba-457f-8717-1b9e48c3dbd9.png)
