### PR TITLE
feat: add RedBlackTree iterator and enumerator (fixes #4166)

### DIFF
--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -949,7 +949,8 @@ namespace Map {
     /// Returns an iterator over all key-value pairs in `m`.
     ///
     pub def iterator(r: Region[r], m: Map[k, v]): Iterator[(k, v), r] \ Write(r) =
-        List.iterator(r, Map.query(_ -> EqualTo, m))
+        let Map(t) = m;
+        RedBlackTree.iterator(r, t)
 
     ///
     /// Returns an iterator over key-value pairs in `m` zipped with the indices of the elements.

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -1058,4 +1058,48 @@ namespace RedBlackTree {
             case None    => acc
         };
         foldLeft(step, empty(), t)
+
+    ///
+    /// Returns an iterator over `t`.
+    ///
+    pub def iterator(r: Region[r], t: RedBlackTree[k, v]): Iterator[(k, v), r] \ { Write(r) } =
+        let stack1 = leftmost(t, Nil);
+        let state = ref stack1 @ r;
+        let done = () -> match (deref state) {
+            case Nil => true
+            case _   => false
+        };
+        let next = () -> match (deref state) {
+            case Nil                 => bug!("Empty Iterator!")
+            case (k, v, rtree) :: es => {
+                state := leftmost(rtree, es);
+                (k, v)
+            }
+        };
+        Iterator(done, next)
+
+    ///
+    /// This represents pending items `(key, value, right-tree)` encountered while finding the
+    /// leftmost node in a tree to start iterating from.
+    ///
+    type alias IterStack2[k, v] = List[(k, v, RedBlackTree[k,v])]
+
+    ///
+    /// Helper function for `iterator`.
+    /// This is called before iteration starts to find the leftmost node of
+    /// the tree and build a stack of pending items. As the iterator is run it will
+    /// call `leftmost` on pending "right trees" in the stack.
+    ///
+    def leftmost(t: RedBlackTree[k, v], es: IterStack2[k, v]): IterStack2[k, v] = match t {
+        case Leaf                        => es
+        case DoubleBlackLeaf             => es
+        case Node(_, ltree, k, v, rtree) => leftmost(ltree, (k, v, rtree) :: es)
+    }
+
+    ///
+    /// Returns an enumerator over `l` zipped with the indices of the elements.
+    ///
+    pub def enumerator(r: Region[r], t: RedBlackTree[k, v]): Iterator[((k, v), Int32), r] \ { Write(r) } =
+        iterator(r, t) |> Iterator.enumerator
+
 }

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -621,7 +621,8 @@ namespace Set {
     /// Returns an iterator over `s`.
     ///
     pub def iterator(r: Region[r], s: Set[a]): Iterator[a, r] \ Write(r) =
-        toList(s) |> List.iterator(r)
+        let Set(t) = s;
+        RedBlackTree.iterator(r, t) |> Iterator.mapL(fst)
 
     ///
     /// Returns an iterator over `s` zipped with the indices of the elements.

--- a/main/test/ca/uwaterloo/flix/library/TestRedBlackTree.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestRedBlackTree.flix
@@ -823,4 +823,64 @@ namespace TestRedBlackTree {
         d1 `MutDeque.sameElements` d2
     }
 
+    /////////////////////////////////////////////////////////////////////////////
+    // iterator                                                              //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def iterator01(): Bool = region r {
+        RedBlackTree.empty(): RedBlackTree[Int32, Int32] |> RedBlackTree.iterator(r) |> Iterator.toList == Nil
+    }
+
+    @test
+    def iterator02(): Bool = region r {
+        let t = RedBlackTree.empty() |> RedBlackTree.insert(1, 'a') |> RedBlackTree.insert(2, 'b')
+                                     |> RedBlackTree.insert(3, 'c') |> RedBlackTree.insert(4, 'd');
+        RedBlackTree.iterator(r, t) |> Iterator.toList == (1, 'a') :: (2, 'b') :: (3, 'c') :: (4, 'd') :: Nil
+    }
+
+    @test
+    def iterator03(): Bool = region r {
+        let t = RedBlackTree.empty() |> RedBlackTree.insert(4, 'd') |> RedBlackTree.insert(3, 'c')
+                                     |> RedBlackTree.insert(2, 'b') |> RedBlackTree.insert(1, 'a');
+        RedBlackTree.iterator(r, t) |> Iterator.toList == (1, 'a') :: (2, 'b') :: (3, 'c') :: (4, 'd') :: Nil
+    }
+
+    @test
+    def iterator04(): Bool = region r {
+        let l = List.range(1, 100);
+        let t = List.foldLeft((ac, i) -> RedBlackTree.insert(i, i+100, ac), RedBlackTree.empty(), l);
+        RedBlackTree.iterator(r, t) |> Iterator.toList == List.map(i -> (i, i+100), List.range(1, 100))
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // enumerate                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def enumerator01(): Bool = region r {
+        RedBlackTree.empty(): RedBlackTree[Int32, Int32] |> RedBlackTree.enumerator(r) |> Iterator.toList == Nil
+    }
+
+    @test
+    def enumerator02(): Bool = region r {
+        let t = RedBlackTree.empty() |> RedBlackTree.insert(1, 'a') |> RedBlackTree.insert(2, 'b')
+                                     |> RedBlackTree.insert(3, 'c') |> RedBlackTree.insert(4, 'd');
+        RedBlackTree.enumerator(r, t) |> Iterator.toList == ((1, 'a'), 0) :: ((2, 'b'), 1) :: ((3, 'c'), 2) :: ((4, 'd'), 3) :: Nil
+    }
+
+    @test
+    def enumerator03(): Bool = region r {
+        let t = RedBlackTree.empty() |> RedBlackTree.insert(4, 'd') |> RedBlackTree.insert(3, 'c')
+                                     |> RedBlackTree.insert(2, 'b') |> RedBlackTree.insert(1, 'a');
+        RedBlackTree.enumerator(r, t) |> Iterator.toList == ((1, 'a'), 0) :: ((2, 'b'), 1) :: ((3, 'c'), 2) :: ((4, 'd'), 3) :: Nil
+    }
+
+    @test
+    def enumerator04(): Bool = region r {
+        let l = List.range(1, 100);
+        let t = List.foldLeft((ac, i) -> RedBlackTree.insert(i, i+100, ac), RedBlackTree.empty(), l);
+        RedBlackTree.enumerator(r, t) |> Iterator.toList == List.map(i -> ((i, i+100), i-1), List.range(1, 100))
+    }
+
 }


### PR DESCRIPTION
This PR adds an `iterator` to `RedBlackTree` and changes `Set` and `Map` to use the RedBlackTree iterator rather than make an iterator via a conversion to List.

Like `Map` the `RedBlackTree` iterator works over a pair of `(key, value)`. Maybe there is scope to add `keyIterator` and `valueIterator` at some point, but client code can use `Iterator.mapL(fst)` or `Iterator.mapL(snd)` to get this.

I haven't looked at an iterator for `MultiMap` - I think this would need a nested iterator and need a direct implementation rather than be able to reuse `RedBlackTree.iterator`.
