### PR TITLE
fix: remove extra parentheses from union type formatting

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.language.fmt
 
 import ca.uwaterloo.flix.language.ast.Ast.VarText
-import ca.uwaterloo.flix.language.ast.{Kind, Rigidity, SourceLocation, Symbol, Type}
+import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Symbol, Type}
 
 object FormatType {
   /**
@@ -92,7 +92,6 @@ object FormatType {
       case SimpleType.And(_) => false
       case SimpleType.Or(_) => false
       case SimpleType.Complement(_) => false
-      case SimpleType.Union(_) => false
       case SimpleType.Intersection(_) => false
       case SimpleType.Difference(_, _) => false
       case SimpleType.PureArrow(_, _) => false
@@ -143,6 +142,7 @@ object FormatType {
       case SimpleType.Apply(_, _) => true
       case SimpleType.Var(_, _, _, _) => true
       case SimpleType.Tuple(_) => true
+      case SimpleType.Union(_) => true
     }
 
     /**

--- a/main/test/ca/uwaterloo/flix/language/fmt/TestFormatType.scala
+++ b/main/test/ca/uwaterloo/flix/language/fmt/TestFormatType.scala
@@ -486,4 +486,21 @@ class TestFormatType extends FunSuite with TestUtils {
 
     assert(actual == expected)
   }
+
+  test("FormatType.Eff.External.04") {
+    val ef1 = Type.KindedVar(new Symbol.KindedTypeVarSym(1, Ast.VarText.SourceText("ef1"), Kind.Star, false, loc), loc)
+    val ef2 = Type.KindedVar(new Symbol.KindedTypeVarSym(2, Ast.VarText.SourceText("ef2"), Kind.Star, false, loc), loc)
+    val e = Type.Cst(TypeConstructor.Effect(new Symbol.EffectSym(Nil, "E", loc)), loc)
+
+    val tpe = Type.mkIntersection(
+      Type.mkUnion(ef1, ef2, loc),
+      e,
+      loc
+    )
+
+    val expected = "{ef1, ef2} & E"
+    val actual = FormatType.formatWellKindedType(tpe)(Audience.External)
+
+    assert(actual == expected)
+  }
 }


### PR DESCRIPTION
changes from `({ef1, ef2}) & E` to `{ef1, ef2} & E`