### PR TITLE
docs: remove old todo

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Operator.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Operator.scala
@@ -105,7 +105,6 @@ object BinaryOperator {
   /**
     * Modulus.
     */
-  // TODO: Rename to remainder?
   case object Modulo extends ArithmeticOperator
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Operator.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Operator.scala
@@ -103,9 +103,9 @@ object BinaryOperator {
   case object Divide extends ArithmeticOperator
 
   /**
-    * Modulus.
+    * Remainder.
     */
-  case object Modulo extends ArithmeticOperator
+  case object Remainder extends ArithmeticOperator
 
   /**
     * Exponentiate.

--- a/main/src/ca/uwaterloo/flix/language/ast/SemanticOperator.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SemanticOperator.scala
@@ -844,7 +844,7 @@ object SemanticOperatorOps {
 
     case SemanticOperator.Int8Op.Rem | SemanticOperator.Int16Op.Rem | SemanticOperator.Int16Op.Rem
          | SemanticOperator.Int32Op.Rem | SemanticOperator.Int64Op.Rem
-         | SemanticOperator.BigIntOp.Rem => BinaryOperator.Modulo
+         | SemanticOperator.BigIntOp.Rem => BinaryOperator.Remainder
 
     case SemanticOperator.Float32Op.Exp | SemanticOperator.Float64Op.Exp | SemanticOperator.Int8Op.Exp
          | SemanticOperator.Int16Op.Exp | SemanticOperator.Int16Op.Exp | SemanticOperator.Int32Op.Exp

--- a/main/src/ca/uwaterloo/flix/language/dbg/PrettyExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/PrettyExpression.scala
@@ -67,7 +67,7 @@ object PrettyExpression {
         case BinaryOperator.Minus => s"${pretty(exp1)} - ${pretty(exp2)}"
         case BinaryOperator.Times => s"${pretty(exp1)} * ${pretty(exp2)}"
         case BinaryOperator.Divide => s"${pretty(exp1)} / ${pretty(exp2)}"
-        case BinaryOperator.Modulo => s"${pretty(exp1)} % ${pretty(exp2)}"
+        case BinaryOperator.Remainder => s"${pretty(exp1)} % ${pretty(exp2)}"
         case BinaryOperator.Exponentiate => s"${pretty(exp1)} ** ${pretty(exp2)}"
         case BinaryOperator.Less => s"${pretty(exp1)} < ${pretty(exp2)}"
         case BinaryOperator.LessEqual => s"${pretty(exp1)} <= ${pretty(exp2)}"

--- a/main/src/ca/uwaterloo/flix/language/dbg/PrettyPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/PrettyPrinter.scala
@@ -479,7 +479,7 @@ object PrettyPrinter {
       case BinaryOperator.Minus => "-"
       case BinaryOperator.Times => "*"
       case BinaryOperator.Divide => "/"
-      case BinaryOperator.Modulo => "%"
+      case BinaryOperator.Remainder => "%"
       case BinaryOperator.Exponentiate => "**"
       case BinaryOperator.Less => "<"
       case BinaryOperator.LessEqual => "<="

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -1416,7 +1416,7 @@ object GenExpression {
         case BinaryOperator.Plus => (IADD, LADD, FADD, DADD, "add")
         case BinaryOperator.Minus => (ISUB, LSUB, FSUB, DSUB, "subtract")
         case BinaryOperator.Times => (IMUL, LMUL, FMUL, DMUL, "multiply")
-        case BinaryOperator.Modulo => (IREM, LREM, FREM, DREM, "remainder")
+        case BinaryOperator.Remainder => (IREM, LREM, FREM, DREM, "remainder")
         case BinaryOperator.Divide => (IDIV, LDIV, FDIV, DDIV, "divide")
         case BinaryOperator.Exponentiate => throw InternalCompilerException("BinaryOperator.Exponentiate already handled.")
       }


### PR DESCRIPTION
The todo comment had been there since 2017. I think it's okay to call it `Modulo`.