### PR TITLE
feat: enable additional LSP features for effect operations

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Entity.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Entity.scala
@@ -96,4 +96,6 @@ object Entity {
     def loc: SourceLocation = op.sym.loc
   }
 
+  case class OpUse(sym: Symbol.OpSym, loc: SourceLocation) extends Entity
+
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
@@ -147,7 +147,7 @@ object Index {
   /**
     * Returns an index with the symbol `sym` used at location `loc.`
     */
-  def useOf(sym: Symbol.OpSym, loc: SourceLocation): Index = Index.empty.copy(opUses = MultiMap.singleton(sym, loc))
+  def useOf(sym: Symbol.OpSym, loc: SourceLocation): Index = Index.empty.copy(opUses = MultiMap.singleton(sym, loc)) + Entity.OpUse(sym, loc)
 
   /**
     * Returns an index with a def of the given `field`.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
@@ -77,6 +77,8 @@ object FindReferencesProvider {
           case _ => mkNotFound(uri, pos)
         }
 
+        case Entity.OpUse(sym, _) => findOpReferences(sym)
+
         case _ => mkNotFound(uri, pos)
 
       }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
@@ -68,6 +68,9 @@ object GotoProvider {
           case _ => mkNotFound(uri, pos)
         }
 
+        case Entity.OpUse(sym, loc) =>
+          ("status" -> "success") ~ ("result" -> LocationLink.fromOpSym(sym, loc).toJSON)
+
         case _ => mkNotFound(uri, pos)
       }
     }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
@@ -74,6 +74,8 @@ object HighlightProvider {
           case _ => mkNotFound(uri, pos)
         }
 
+        case Entity.OpUse(sym, _) => highlightOp(sym)
+
         case _ => mkNotFound(uri, pos)
       }
     }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HoverProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HoverProvider.scala
@@ -55,6 +55,8 @@ object HoverProvider {
 
         case Entity.Type(t) => hoverKind(t, current)
 
+        case Entity.OpUse(sym, loc) => hoverOp(sym, loc, current)
+
         case _ => mkNotFound(uri, pos)
       }
     }
@@ -109,6 +111,21 @@ object HoverProvider {
          |```
          |
          |${FormatDoc.asMarkDown(sigDecl.spec.doc)}
+         |""".stripMargin
+    val contents = MarkupContent(MarkupKind.Markdown, markup)
+    val range = Range.from(loc)
+    val result = ("contents" -> contents.toJSON) ~ ("range" -> range.toJSON)
+    ("status" -> "success") ~ ("result" -> result)
+  }
+
+  private def hoverOp(sym: Symbol.OpSym, loc: SourceLocation, current: Boolean)(implicit index: Index, root: Root): JObject = {
+    val opDecl = root.effects(sym.eff).ops.find(_.sym == sym).get // guaranteed to be present
+    val markup =
+      s"""```flix
+         |${FormatSignature.asMarkDown(opDecl)} ${mkCurrentMsg(current)}
+         |```
+         |
+         |${FormatDoc.asMarkDown(opDecl.spec.doc)}
          |""".stripMargin
     val contents = MarkupContent(MarkupKind.Markdown, markup)
     val range = Range.from(loc)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
@@ -55,7 +55,7 @@ object SymbolProvider {
     val defs = root.defs.values.collect { case d if d.sym.loc.source.name == uri => mkDefDocumentSymbol(d) }
     val classes = root.classes.values.collect { case c if c.sym.loc.source.name == uri => mkClassDocumentSymbol(c) }
     val effs = root.effects.values.collect { case e if e.sym.loc.source.name == uri => mkEffectDocumentSymbol(e) }
-    (classes ++ defs ++ enums).toList
+    (classes ++ defs ++ enums ++ effs).toList
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatSignature.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatSignature.scala
@@ -34,6 +34,13 @@ object FormatSignature {
   }
 
   /**
+    * Returns a markdown string for the signature of the given definition.
+    */
+  def asMarkDown(op: TypedAst.Op)(implicit audience: Audience): String = {
+    formatSpec(op.sym.name, op.spec)
+  }
+
+  /**
     * Returns a markdown string for the given `name` and `spec`.
     */
   private def formatSpec(name: String, spec: TypedAst.Spec)(implicit audience: Audience): String = {


### PR DESCRIPTION
related to #4236 

Enables the following from `Do` expressions:
* Find references
* Go to implementation
* Highlight
* Hover

This also demonstrates the `SymUse` idea I proposed as a larger refactor of LSP, where we consider uses of symbols as entities.