### PR TITLE
feat: add UnusedEffectSym error

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/RedundancyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/RedundancyError.scala
@@ -93,7 +93,7 @@ object RedundancyError {
   /**
     * An error raised to indicate that the def with the symbol `sym` is not used.
     *
-    * @param sym the unused enum symbol.
+    * @param sym the unused def symbol.
     */
   case class UnusedDefSym(sym: Symbol.DefnSym) extends RedundancyError {
     def summary: String = "Unused definition."
@@ -179,6 +179,37 @@ object RedundancyError {
          |  (1)  Use the case.
          |  (2)  Remove the case.
          |  (3)  Prefix the case with an underscore.
+         |
+         |""".stripMargin
+    })
+
+    def loc: SourceLocation = sym.loc
+  }
+
+  /**
+    * An error raised to indicate that the effect with the symbol `sym` is not used.
+    *
+    * @param sym the unused effect symbol.
+    */
+  case class UnusedEffectSym(sym: Symbol.EffectSym) extends RedundancyError {
+    def summary: String = s"Unused effect '${sym.name}'.'"
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Unused effect '${red(sym.name)}'. The effect is never referenced.
+         |
+         |${code(sym.loc, "unused effect.")}
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = Some({
+      s"""Possible fixes:
+         |
+         |  (1)  Use the effect.
+         |  (2)  Remove the effect.
+         |  (3)  Mark the effect as public.
+         |  (4)  Prefix the effect name with an underscore.
          |
          |""".stripMargin
     })

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -168,6 +168,7 @@ object Redundancy {
   private def checkUnusedEffects(used: Used)(implicit root: Root): Used = {
     root.effects.foldLeft(used) {
       case (acc, (_, decl)) if deadEffect(decl, used) => acc + UnusedEffectSym(decl.sym)
+      case (acc, _) => acc
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -75,7 +75,8 @@ object Redundancy {
       checkUnusedDefs(usedAll)(root) ++
         checkUnusedEnumsAndTags(usedAll)(root) ++
         checkUnusedTypeParamsEnums()(root) ++
-        checkRedundantTypeConstraints()(root)
+        checkRedundantTypeConstraints()(root) ++
+        checkUnusedEffects(usedAll)(root)
 
     // Return the root if successful, otherwise returns all redundancy errors.
     usedRes.toValidation(root)
@@ -158,6 +159,15 @@ object Redundancy {
     root.defs.foldLeft(used) {
       case (acc, (_, decl)) if deadDef(decl, used) => acc + UnusedDefSym(decl.sym)
       case (acc, _) => acc
+    }
+  }
+
+  /**
+    * Checks for unused effect symbols.
+    */
+  private def checkUnusedEffects(used: Used)(implicit root: Root): Used = {
+    root.effects.foldLeft(used) {
+      case (acc, (_, decl)) if deadEffect(decl, used) => acc + UnusedEffectSym(decl.sym)
     }
   }
 
@@ -558,6 +568,9 @@ object Redundancy {
     case Expression.Without(exp, _, _, _, _, _) =>
       visitExp(exp, env0, rc)
 
+    case Expression.Without(exp, effUse, _, _, _, _) =>
+      Used.of(effUse.sym) ++ visitExp(exp, env0, rc)
+
     case Expression.TryCatch(exp, rules, _, _, _, _) =>
       val usedExp = visitExp(exp, env0, rc)
       val usedRules = rules.foldLeft(Used.empty) {
@@ -570,7 +583,7 @@ object Redundancy {
       }
       usedExp ++ usedRules
 
-    case Expression.TryWith(exp, _, rules, _, _, _, _) =>
+    case Expression.TryWith(exp, effUse, rules, _, _, _, _) =>
       val usedExp = visitExp(exp, env0, rc)
       val usedRules = rules.foldLeft(Used.empty) {
         case (acc, HandlerRule(_, fparams, body)) =>
@@ -579,10 +592,10 @@ object Redundancy {
           val dead = syms.filter(deadVarSym(_, usedBody))
           acc ++ usedBody ++ dead.map(UnusedVarSym)
       }
-      usedExp ++ usedRules
+      usedExp ++ Used.of(effUse.sym) ++ usedRules
 
-    case Expression.Do(_, exps, _, _, _) =>
-      visitExps(exps, env0, rc)
+    case Expression.Do(opUse, exps, _, _, _) =>
+      Used.of(opUse.sym.eff) ++ visitExps(exps, env0, rc)
 
     case Expression.Resume(exp, _, _) =>
       visitExp(exp, env0, rc)
@@ -945,6 +958,14 @@ object Redundancy {
     sym.toString == "main" || root.entryPoint.contains(sym)
 
   /**
+    * Returns `true` if the given definition `decl` is unused according to `used`.
+    */
+  private def deadEffect(decl: Effect, used: Used)(implicit root: Root): Boolean =
+      !decl.mod.isPublic &&
+      !decl.sym.name.startsWith("_") &&
+      !used.effectSyms.contains(decl.sym)
+
+  /**
     * Returns `true` if the given `tag` is unused according to the `usedTags`.
     */
   private def deadTag(tag: Name.Tag, usedTags: Set[Name.Tag]): Boolean =
@@ -1007,7 +1028,7 @@ object Redundancy {
     /**
       * Represents the empty set of used symbols.
       */
-    val empty: Used = Used(MultiMap.empty, Set.empty, Set.empty, Set.empty, Set.empty, ListMap.empty, Set.empty)
+    val empty: Used = Used(MultiMap.empty, Set.empty, Set.empty, Set.empty, Set.empty, Set.empty, ListMap.empty, Set.empty)
 
     /**
       * Returns an object where the given enum symbol `sym` and `tag` are marked as used.
@@ -1035,6 +1056,11 @@ object Redundancy {
     def of(sym: Symbol.VarSym): Used = empty.copy(varSyms = Set(sym), occurrencesOf = ListMap.singleton(sym, sym.loc))
 
     /**
+      * Returns an object where the given variable symbol `sym` is marked as used.
+      */
+    def of(sym: Symbol.EffectSym): Used = empty.copy(effectSyms = Set(sym))
+
+    /**
       * Returns an object where the given variable symbols `syms` are marked as used.
       */
     def of(syms: Set[Symbol.VarSym]): Used = empty.copy(
@@ -1053,6 +1079,7 @@ object Redundancy {
                           sigSyms: Set[Symbol.SigSym],
                           holeSyms: Set[Symbol.HoleSym],
                           varSyms: Set[Symbol.VarSym],
+                          effectSyms: Set[Symbol.EffectSym],
                           occurrencesOf: ListMap[Symbol.VarSym, SourceLocation],
                           errors: Set[RedundancyError]) {
 
@@ -1073,6 +1100,7 @@ object Redundancy {
           this.sigSyms ++ that.sigSyms,
           this.holeSyms ++ that.holeSyms,
           this.varSyms ++ that.varSyms,
+          this.effectSyms ++ that.effectSyms,
           this.occurrencesOf ++ that.occurrencesOf,
           this.errors ++ that.errors
         )

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -566,9 +566,6 @@ object Redundancy {
       else
         visitExp(exp, env0, rc)
 
-    case Expression.Without(exp, _, _, _, _, _) =>
-      visitExp(exp, env0, rc)
-
     case Expression.Without(exp, effUse, _, _, _, _) =>
       Used.of(effUse.sym) ++ visitExp(exp, env0, rc)
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -1061,6 +1061,29 @@ class TestRedundancy extends FunSuite with TestUtils {
     expectError[RedundancyError.UnusedDefSym](result)
   }
 
+  test("UnusedEffectSym.01") {
+    val input =
+      """
+        |namespace N {
+        |    eff E
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[RedundancyError.UnusedEffectSym](result)
+  }
+
+  test("UnusedEffectSym.02") {
+    val input =
+      """
+        |namespace N {
+        |    eff E
+        |    def foo(): Unit \ E = ??? as \ E
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[RedundancyError.UnusedEffectSym](result)
+  }
+
   test("DiscardedPureValue.01") {
     val input =
       """

--- a/main/test/flix/Test.Dec.Effect.flix
+++ b/main/test/flix/Test.Dec.Effect.flix
@@ -1,24 +1,24 @@
 namespace Test/Dec/Effect {
-    eff Console {
+    pub eff Console {
         pub def println(s: String): Unit
     }
 
-    eff Fail {
+    pub eff Fail {
         pub def fail(): Unit
     }
 
-    eff State {
+    pub eff State {
         pub def set_(x: Int32): Unit
     }
 
-    eff Threading {
+    pub eff Threading {
         pub def yield(): Unit
         pub def spawn_(f: Unit -> Unit): Unit
     }
 
-    eff Empty
+    pub eff Empty
 
-    eff EmptyWithParens {
+    pub eff EmptyWithParens {
 
     }
 }

--- a/main/test/flix/Test.Exp.ReifyEff.flix
+++ b/main/test/flix/Test.Exp.ReifyEff.flix
@@ -43,5 +43,5 @@ namespace Test/Exp/ReifyEff {
 
     def >>(f: a -> b & ef1, g: b -> c & ef2): a -> c \ { ef1, ef2 } = x -> g(f(x))
 
-    eff E
+    pub eff E
 }


### PR DESCRIPTION
related to #4236

Uses the same rule as enum: use in a type is not enough; it must be used in an expression.