### PR TITLE
feat: object code generation

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
@@ -266,8 +266,9 @@ object ClosureConv {
     case Expression.NewObject(clazz, tpe, purity, methods0, loc) =>
       val methods = methods0 map {
         case JvmMethod(ident, fparams, exp, retTpe, purity, loc) =>
-          val closure = mkLambdaClosure(fparams, exp, retTpe, loc)
-          JvmMethod(ident, fparams, closure, retTpe, purity, loc)
+          val cloType = Type.mkPureUncurriedArrow(fparams.map(_.tpe), retTpe, loc)
+          val clo = mkLambdaClosure(fparams, exp, cloType, loc)
+          JvmMethod(ident, fparams, clo, retTpe, purity, loc)
       }
       Expression.NewObject(clazz, tpe, purity, methods, loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
@@ -266,7 +266,7 @@ object ClosureConv {
     case Expression.NewObject(clazz, tpe, purity, methods0, loc) =>
       val methods = methods0 map {
         case JvmMethod(ident, fparams, exp, retTpe, purity, loc) =>
-          val cloType = Type.mkPureUncurriedArrow(fparams.map(_.tpe), retTpe, loc)
+          val cloType = Type.mkImpureUncurriedArrow(fparams.map(_.tpe), retTpe, loc)
           val clo = mkLambdaClosure(fparams, exp, cloType, loc)
           JvmMethod(ident, fparams, clo, retTpe, purity, loc)
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
@@ -547,7 +547,7 @@ object Monomorph {
         Expression.PutStaticField(field, e, tpe, pur, eff, loc)
 
       case Expression.NewObject(clazz, tpe, pur, eff, methods0, loc) =>
-        val methods = methods0.map(visitJvmMethod)
+        val methods = methods0.map(visitJvmMethod(_, env0))
         Expression.NewObject(clazz, subst0(tpe), pur, eff, methods, loc)
 
       case Expression.NewChannel(exp, tpe, pur, eff, loc) =>
@@ -703,10 +703,10 @@ object Monomorph {
           else envs.reduce(_ ++ _) ++ Map(sym -> freshSym))
     }
 
-    def visitJvmMethod(method: JvmMethod) = method match {
+    def visitJvmMethod(method: JvmMethod, env0: Map[Symbol.VarSym, Symbol.VarSym]) = method match {
       case JvmMethod(ident, fparams0, exp0, tpe, pur, eff, loc) =>
-        val (fparams, env0) = specializeFormalParams(fparams0, subst0)
-        val exp = visitExp(exp0, env0)
+        val (fparams, env1) = specializeFormalParams(fparams0, subst0)
+        val exp = visitExp(exp0, env0 ++ env1)
         JvmMethod(ident, fparams, exp, subst0(tpe), pur, eff, loc)
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/TreeShaker.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TreeShaker.scala
@@ -256,7 +256,7 @@ object TreeShaker {
       visitExp(exp)
 
     case Expression.NewObject(_, _, _, methods, _) =>
-      Set.empty
+      visitExps(methods.map(_.clo))
 
     case Expression.NewChannel(exp, _, _) =>
       visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -88,7 +88,7 @@ object GenAnonymousClasses {
         constructor.visitInsn(POP)
       }
 
-      constructor.visitFieldInsn(PUTFIELD, currentClass.name.toInternalName, s"m$i", JvmOps.getErasedJvmType(m.clo.tpe).toDescriptor)
+      constructor.visitFieldInsn(PUTFIELD, currentClass.name.toInternalName, s"m$i", JvmOps.getClosureAbstractClassType(m.clo.tpe).toDescriptor)
     }
 
     constructor.visitInsn(RETURN)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -55,9 +55,10 @@ object GenAnonymousClasses {
     visitor.visit(AsmOps.JavaVersion, ACC_PUBLIC + ACC_FINAL, className.toInternalName, null,
       superClass.toInternalName, Array(asm.Type.getInternalName(obj.clazz)))
 
-    compileConstructor(JvmType.Reference(className), superClass, obj.methods, visitor)
+    val currentClass = JvmType.Reference(className)
+    compileConstructor(currentClass, superClass, obj.methods, visitor)
 
-    obj.methods.zipWithIndex.foreach { case (m, i) => compileMethod(m, i, visitor) }
+    obj.methods.zipWithIndex.foreach { case (m, i) => compileMethod(currentClass, m, i, visitor) }
 
     visitor.visitEnd()
     visitor.toByteArray
@@ -100,19 +101,35 @@ object GenAnonymousClasses {
   /**
     * Method
     */
-  private def compileMethod(method: JvmMethod, i: Int, classVisitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = method match {
+  private def compileMethod(currentClass: JvmType.Reference, method: JvmMethod, i: Int, classVisitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = method match {
     case JvmMethod(ident, fparams, clo, tpe, loc) =>
-      AsmOps.compileField(classVisitor, s"m$i", JvmOps.getClosureAbstractClassType(method.clo.tpe), isStatic = false, isPrivate = false)
+      val closureAbstractClass = JvmOps.getClosureAbstractClassType(method.clo.tpe)
+      val functionInterface = JvmOps.getFunctionInterfaceType(method.clo.tpe)
+      val backendContinuationType = BackendObjType.Continuation(BackendType.toErasedBackendType(method.retTpe))
+
+      AsmOps.compileField(classVisitor, s"m$i", closureAbstractClass, isStatic = false, isPrivate = false)
 
       // Drop the first formal parameter (which always represents `this`)
       val paramTypes = fparams.tail.map(f => JvmOps.getJvmType(f.tpe))
       val returnType = JvmOps.getJvmType(tpe)
       val methodVisitor = classVisitor.visitMethod(ACC_PUBLIC, ident.name, AsmOps.getMethodDescriptor(paramTypes, returnType), null, null)
 
-      methodVisitor.visitTypeInsn(NEW, JvmName.UnsupportedOperationException.toInternalName)
-      methodVisitor.visitInsn(DUP)
-      methodVisitor.visitMethodInsn(INVOKESPECIAL, JvmName.UnsupportedOperationException.toInternalName, "<init>", MethodDescriptor.NothingToVoid.toDescriptor, false)
-      methodVisitor.visitInsn(ATHROW)
+      methodVisitor.visitVarInsn(ALOAD, 0)
+      methodVisitor.visitFieldInsn(GETFIELD, currentClass.name.toInternalName, s"m$i", closureAbstractClass.toDescriptor)
+
+      methodVisitor.visitMethodInsn(INVOKEVIRTUAL, closureAbstractClass.name.toInternalName, GenClosureAbstractClasses.GetUniqueThreadClosureFunctionName, AsmOps.getMethodDescriptor(Nil, closureAbstractClass), false)
+
+      fparams.zipWithIndex.foreach { case (arg, i) => 
+        methodVisitor.visitInsn(DUP)
+        methodVisitor.visitVarInsn(ALOAD, i)
+        methodVisitor.visitFieldInsn(PUTFIELD, functionInterface.name.toInternalName,
+          s"arg$i", JvmOps.getErasedJvmType(arg.tpe).toDescriptor)
+      }
+      methodVisitor.visitMethodInsn(INVOKEVIRTUAL, functionInterface.name.toInternalName,
+        backendContinuationType.UnwindMethod.name, AsmOps.getMethodDescriptor(Nil, JvmOps.getErasedJvmType(tpe)), false)
+      AsmOps.castIfNotPrim(methodVisitor, JvmOps.getJvmType(tpe))
+
+      methodVisitor.visitInsn(AsmOps.getReturnInstruction(JvmOps.getJvmType(method.retTpe)))
 
       methodVisitor.visitMaxs(999, 999)
       methodVisitor.visitEnd()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -642,7 +642,9 @@ object JvmOps {
         visitExp(exp)
 
       case Expression.NewObject(_, _, methods, _) =>
-        Set.empty
+        methods.foldLeft(Set.empty[ClosureInfo]) {
+          case (sacc, JvmMethod(_, _, clo, _, _)) => visitExp(clo)
+        }
 
       case Expression.NewChannel(exp, _, _) => visitExp(exp)
 

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -8,7 +8,7 @@ namespace Test/Exp/Jvm/NewObject {
 
   def implementIterable(): ##java.lang.Iterable & Impure =
     object ##java.lang.Iterable { 
-      def iterator(_this: ##java.lang.Object): ##java.util.Iterator & Impure = () as ##java.util.Iterator
+      def iterator(_this: ##java.lang.Object): ##java.util.Iterator & Impure = null as ##java.util.Iterator
     }
 
   def implementComparable(): ##java.lang.Comparable & Impure =
@@ -62,20 +62,12 @@ namespace Test/Exp/Jvm/NewObject {
   def testImplementInterface07(): Bool & Impure =
     import java.lang.Iterable.iterator(): ##java.util.Iterator & Impure;
     let anon = implementIterable();
-    try {
-      let _it = iterator(anon);
-      false
-    } catch {
-      case _: ##java.lang.UnsupportedOperationException => true
-    }
+    let _it = iterator(anon);
+    true
   
   @test
   def testImplementInterface08(): Bool & Impure =
     import java.lang.Comparable.compareTo(##java.lang.Object): Int32 & Pure;
     let anon = implementComparable();
-    try {
-      compareTo(anon, anon as ##java.lang.Object) == 0
-    } catch {
-      case _: ##java.lang.UnsupportedOperationException => true
-    }
+    compareTo(anon, anon as ##java.lang.Object) == 0
 }


### PR DESCRIPTION
This is definitely not ready to be merged, but I've hit a problem that I think I need assistance with.

I'm halfway through and you're definitely seeing how the sausage gets made. The structure isn't right, the method is still throwing an exception, and I've not written any comments, so please don't worry too much about those things.

I've fixed a couple of problems that became apparent as I was working through this:

* The type of the closure needed to be set to an arrow type
* The `NewObject` case within `closuresOf` was returning `Set.empty` (blush).

Given the following Flix:

```
@test
def f():Int32 & Impure =
    import java.lang.Comparable.compareTo(##java.lang.Object): Int32 & Impure;
    let x = 0;
    let anon = object ##java.lang.Comparable {
        def compareTo(_this: ##java.lang.Comparable, _that: ##java.lang.Object) : Int32 = x + 1
    };
    compareTo(anon, () as ##java.lang.Object)
```

This crashes with `Exception in thread "main" java.util.NoSuchElementException` on this line:

https://github.com/paulbutcher/flix/blob/object-codegen/main/src/ca/uwaterloo/flix/language/phase/jvm/GenClosureClasses.scala#L97

I guess that I should be doing something to add the symbol to `root.defs`? But I'm not sure what?