### PR TITLE
feat: NewObject tests

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -512,8 +512,10 @@ object Safety {
   }
 
   /**
-    * Given a class, get sets representing both the methods that can be implemented,
-    * and the methods that must be implemented.
+    * Given a class or interface, returns a pair of the methods that can be implemented and that must be implemented.
+    *
+    * * A (non-static) method can be implemented if it exists in the class.
+    * * A (non-static) method must be implemented if it is abstract.
     */
   private def getJavaMethods(clazz: java.lang.Class[_]): (Set[MethodSignature], Set[MethodSignature]) = {
     val methods = clazz.getMethods().toList.filterNot(m => java.lang.reflect.Modifier.isStatic(m.getModifiers()))

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -495,10 +495,14 @@ object Safety {
   private def getJavaMethodSignatures(methods: List[java.lang.reflect.Method]): Map[MethodSignature, java.lang.reflect.Method] = {
     methods.foldLeft(Map.empty[MethodSignature, java.lang.reflect.Method]) {
       case (acc, m) =>
-        val signature = MethodSignature(m.getName(), 
-          getFlixType(m.getReturnType),
-          m.getParameterTypes().toList.map(getFlixType))
-        acc + (signature -> m)
+        if (!java.lang.reflect.Modifier.isStatic(m.getModifiers())) {
+          val signature = MethodSignature(m.getName(), 
+            getFlixType(m.getReturnType),
+            m.getParameterTypes().toList.map(getFlixType))
+          acc + (signature -> m)
+        } else {
+          acc
+        }
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -17,6 +17,7 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.MonoType
 import ca.uwaterloo.flix.language.ast.ErasedAst._
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.{MethodDescriptor, RootPackage}
 import ca.uwaterloo.flix.util.ParOps
@@ -58,7 +59,7 @@ object GenAnonymousClasses {
     val currentClass = JvmType.Reference(className)
     compileConstructor(currentClass, superClass, obj.methods, visitor)
 
-    obj.methods.zipWithIndex.foreach { case (m, i) => compileMethod(currentClass, m, i, visitor) }
+    obj.methods.zipWithIndex.foreach { case (m, i) => compileMethod(currentClass, m, s"clo$i", visitor) }
 
     visitor.visitEnd()
     visitor.toByteArray
@@ -91,31 +92,40 @@ object GenAnonymousClasses {
   /**
     * Method
     */
-  private def compileMethod(currentClass: JvmType.Reference, method: JvmMethod, i: Int, classVisitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = method match {
+  private def compileMethod(currentClass: JvmType.Reference, method: JvmMethod, cloName: String, classVisitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = method match {
     case JvmMethod(ident, fparams, clo, tpe, loc) =>
       val closureAbstractClass = JvmOps.getClosureAbstractClassType(method.clo.tpe)
       val functionInterface = JvmOps.getFunctionInterfaceType(method.clo.tpe)
       val backendContinuationType = BackendObjType.Continuation(BackendType.toErasedBackendType(method.retTpe))
 
       // Create the field that will store the closure implementing the body of the method
-      AsmOps.compileField(classVisitor, s"clo$i", closureAbstractClass, isStatic = false, isPrivate = false)
+      AsmOps.compileField(classVisitor, cloName, closureAbstractClass, isStatic = false, isPrivate = false)
 
       // Drop the first formal parameter (which always represents `this`)
       val paramTypes = fparams.tail.map(f => JvmOps.getJvmType(f.tpe))
-      val returnType = JvmOps.getJvmType(tpe)
+
+      // Special case: treat Unit as void
+      val returnType = tpe match {
+        case MonoType.Unit => JvmType.Void
+        case _ => JvmOps.getJvmType(tpe)
+      } 
+
       val methodVisitor = classVisitor.visitMethod(ACC_PUBLIC, ident.name, AsmOps.getMethodDescriptor(paramTypes, returnType), null, null)
 
       // Retrieve the closure that implements this method
       methodVisitor.visitVarInsn(ALOAD, 0)
-      methodVisitor.visitFieldInsn(GETFIELD, currentClass.name.toInternalName, s"clo$i", closureAbstractClass.toDescriptor)
+      methodVisitor.visitFieldInsn(GETFIELD, currentClass.name.toInternalName, cloName, closureAbstractClass.toDescriptor)
 
       methodVisitor.visitMethodInsn(INVOKEVIRTUAL, closureAbstractClass.name.toInternalName, GenClosureAbstractClasses.GetUniqueThreadClosureFunctionName,
         AsmOps.getMethodDescriptor(Nil, closureAbstractClass), false)
 
       // Push arguments onto the stack
+      var offset = 0
       fparams.zipWithIndex.foreach { case (arg, i) => 
         methodVisitor.visitInsn(DUP)
-        methodVisitor.visitVarInsn(ALOAD, i)
+        val argType = JvmOps.getJvmType(arg.tpe)
+        methodVisitor.visitVarInsn(AsmOps.getLoadInstruction(argType), offset)
+        offset += AsmOps.getStackSize(argType)
         methodVisitor.visitFieldInsn(PUTFIELD, functionInterface.name.toInternalName,
           s"arg$i", JvmOps.getErasedJvmType(arg.tpe).toDescriptor)
       }
@@ -125,7 +135,11 @@ object GenAnonymousClasses {
         backendContinuationType.UnwindMethod.name, AsmOps.getMethodDescriptor(Nil, JvmOps.getErasedJvmType(tpe)), false)
       AsmOps.castIfNotPrim(methodVisitor, JvmOps.getJvmType(tpe))
 
-      methodVisitor.visitInsn(AsmOps.getReturnInstruction(JvmOps.getJvmType(method.retTpe)))
+      val returnInstruction = returnType match {
+        case JvmType.Void => RETURN
+        case _ => AsmOps.getReturnInstruction(returnType)
+      }
+      methodVisitor.visitInsn(returnInstruction)
 
       methodVisitor.visitMaxs(999, 999)
       methodVisitor.visitEnd()

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -643,7 +643,7 @@ object JvmOps {
 
       case Expression.NewObject(_, _, _, methods, _) =>
         methods.foldLeft(Set.empty[ClosureInfo]) {
-          case (sacc, JvmMethod(_, _, clo, _, _)) => visitExp(clo)
+          case (sacc, JvmMethod(_, _, clo, _, _)) => sacc ++ visitExp(clo)
         }
 
       case Expression.NewChannel(exp, _, _) => visitExp(exp)

--- a/main/src/flix/test/TestClassWithDefaultConstructor.java
+++ b/main/src/flix/test/TestClassWithDefaultConstructor.java
@@ -1,0 +1,16 @@
+package flix.test;
+
+abstract public class TestClassWithDefaultConstructor {
+  int m_x;
+  String m_y;
+
+  public TestClassWithDefaultConstructor() {
+    m_x = 42;
+    m_y = "foo";
+  }
+
+  public abstract int abstractMethod(int x);
+  public String concreteMethod(String y) {
+    return m_y + y;
+  }
+}

--- a/main/src/flix/test/TestDefaultMethods.java
+++ b/main/src/flix/test/TestDefaultMethods.java
@@ -1,0 +1,8 @@
+package flix.test;
+
+public interface TestDefaultMethods {
+  int methodWithNoImplementation(int x);
+  default int methodWithDefaultImplementation(int x) {
+    return x + 42;
+  }
+}

--- a/main/src/flix/test/TestDefaultMethods.java
+++ b/main/src/flix/test/TestDefaultMethods.java
@@ -2,6 +2,7 @@ package flix.test;
 
 public interface TestDefaultMethods {
   int methodWithNoImplementation(int x);
+
   default int methodWithDefaultImplementation(int x) {
     return x + 42;
   }

--- a/main/src/flix/test/TestGenerics.java
+++ b/main/src/flix/test/TestGenerics.java
@@ -1,0 +1,11 @@
+package flix.test;
+
+public interface TestGenerics<T1> {
+  T1 methodOne(T1 x);
+  <T2> T1 methodTwo(T1 x, T2 y);
+
+  static boolean runTest(TestGenerics<String> obj) {
+    return obj.methodOne("foo").equals("foo, foo") &&
+      obj.methodTwo("foo", Integer.valueOf(2)).equals("foo, 2");
+  }
+}

--- a/main/src/flix/test/TestOverloadedMethods.java
+++ b/main/src/flix/test/TestOverloadedMethods.java
@@ -1,0 +1,13 @@
+package flix.test;
+
+public interface TestOverloadedMethods {
+  int overloadedMethod();
+  int overloadedMethod(int x);
+  String overloadedMethod(String x, double y, double z);
+
+  static boolean runTest(TestOverloadedMethods obj) {
+    return obj.overloadedMethod() == 42 &&
+      obj.overloadedMethod(1) == 2 &&
+      obj.overloadedMethod("divided: ", 10.0d, 2.5d).equals("divided: 4.0");
+  }
+}

--- a/main/src/flix/test/TestPrimitiveTypes.java
+++ b/main/src/flix/test/TestPrimitiveTypes.java
@@ -1,0 +1,28 @@
+package flix.test;
+
+public interface TestPrimitiveTypes {
+  void takesAndReturnsVoid();
+  boolean takesAndReturnsBoolean(boolean x);
+  char takesAndReturnsChar(char x);
+  byte takesAndReturnsByte(byte x);
+  short takesAndReturnsShort(short x);
+  int takesAndReturnsInt(int x);
+  long takesAndReturnsLong(long x);
+  float takesAndReturnsFloat(float x);
+  double takesAndReturnsDouble(double x);
+
+  String allTheTypes(boolean a, char b, byte c, short d, int e, long f, float g, double h);
+
+  static boolean runTest(TestPrimitiveTypes obj) {
+    obj.takesAndReturnsVoid();
+    return obj.takesAndReturnsBoolean(false) &&
+      obj.takesAndReturnsChar('a') == 'A' &&
+      obj.takesAndReturnsByte((byte)1) == (byte)2 &&
+      obj.takesAndReturnsShort((short)1) == (short)2 &&
+      obj.takesAndReturnsInt(1) == 2 &&
+      obj.takesAndReturnsLong(1) == 2 &&
+      obj.takesAndReturnsFloat(1.0f) == 2.23f &&
+      obj.takesAndReturnsDouble(1.0d) == 2.23d &&
+      obj.allTheTypes(true, 'a', (byte)1, (short)2, 3, 4, 5.6f, 7.8d).equals("true, a, 1, 2, 3, 4, 5.6, 7.8");
+  }
+}

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -181,15 +181,6 @@ class TestSafety extends FunSuite with TestUtils {
     expectError[IllegalRelationalUseOfLatticeVariable](result)
   }
 
-  test("TestIllegalDerivation.01") {
-    val input =
-      """
-        |def f(): ##java.lang.Thread & Impure = object ##java.lang.Thread {}
-      """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.IllegalObjectDerivation](result)
-  }
-
   test("TestInvalidThis.01") {
     val input =
       """

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -60,4 +60,14 @@ namespace Test/Exp/Jvm/NewObject {
         "${a}, ${b}, ${c}, ${d}, ${e}, ${f}, ${g}, ${h}"
     };
     runTest(anon)
+
+  @test
+  def testOverloadedMethods01(): Bool & Impure =
+    import static flix.test.TestOverloadedMethods.runTest(##flix.test.TestOverloadedMethods): Bool;
+    let anon = object ##flix.test.TestOverloadedMethods {
+      def overloadedMethod(_this: ##flix.test.TestOverloadedMethods): Int32 = 42
+      def overloadedMethod(_this: ##flix.test.TestOverloadedMethods, x: Int32): Int32 = x + 1
+      def overloadedMethod(_this: ##flix.test.TestOverloadedMethods, x: String, y: Float64, z: Float64): String = "${x}${y / z}"
+    };
+    runTest(anon)
 }

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -70,4 +70,23 @@ namespace Test/Exp/Jvm/NewObject {
       def overloadedMethod(_this: ##flix.test.TestOverloadedMethods, x: String, y: Float64, z: Float64): String = "${x}${y / z}"
     };
     runTest(anon)
+
+  @test
+  def testDefaultMethods01(): Bool & Impure =
+    import flix.test.TestDefaultMethods.methodWithNoImplementation(Int32): Int32;
+    import flix.test.TestDefaultMethods.methodWithDefaultImplementation(Int32): Int32;
+    let anon = object ##flix.test.TestDefaultMethods {
+      def methodWithNoImplementation(_this: ##flix.test.TestDefaultMethods, x: Int32): Int32 = x + 1
+    };
+    methodWithNoImplementation(anon, 1) == 2 and methodWithDefaultImplementation(anon, 1) == 43
+
+  @test
+  def testDefaultMethods02(): Bool & Impure =
+    import flix.test.TestDefaultMethods.methodWithNoImplementation(Int32): Int32;
+    import flix.test.TestDefaultMethods.methodWithDefaultImplementation(Int32): Int32;
+    let anon = object ##flix.test.TestDefaultMethods {
+      def methodWithNoImplementation(_this: ##flix.test.TestDefaultMethods, x: Int32): Int32 = x + 1
+      def methodWithDefaultImplementation(_this: ##flix.test.TestDefaultMethods, x: Int32): Int32 = x + 2
+    };
+    methodWithNoImplementation(anon, 1) == 2 and methodWithDefaultImplementation(anon, 1) == 3
 }

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -89,4 +89,19 @@ namespace Test/Exp/Jvm/NewObject {
       def methodWithDefaultImplementation(_this: ##flix.test.TestDefaultMethods, x: Int32): Int32 = x + 2
     };
     methodWithNoImplementation(anon, 1) == 2 and methodWithDefaultImplementation(anon, 1) == 3
+
+  @test
+  def testGenerics01(): Bool & Impure =
+    import static flix.test.TestGenerics.runTest(##flix.test.TestGenerics): Bool;
+    import java.lang.Integer.toString(): String;
+    let anon = object ##flix.test.TestGenerics {
+      def methodOne(_this: ##flix.test.TestGenerics, x: ##java.lang.Object): ##java.lang.Object = 
+        let str = x as String;
+        "${str}, ${str}" as ##java.lang.Object
+      def methodTwo(_this: ##flix.test.TestGenerics, x: ##java.lang.Object, y: ##java.lang.Object): ##java.lang.Object =
+        let str = x as String;
+        let int = y as ##java.lang.Integer;
+        "${str}, ${toString(int)}" as ##java.lang.Object
+    };
+    runTest(anon)
 }

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -6,16 +6,6 @@ namespace Test/Exp/Jvm/NewObject {
   def implementSerializableAgain(): ##java.io.Serializable & Impure =
     object ##java.io.Serializable { }
 
-  def implementIterable(): ##java.lang.Iterable & Impure =
-    object ##java.lang.Iterable { 
-      def iterator(_this: ##java.lang.Iterable): ##java.util.Iterator & Impure = null as ##java.util.Iterator
-    }
-
-  def implementComparable(): ##java.lang.Comparable & Impure =
-    object ##java.lang.Comparable {
-      def compareTo(_this: ##java.lang.Comparable, _that: ##java.lang.Object): Int32 & Pure = 0
-    }
-
   @test
   def testImplementInterface01(): Bool & Impure =
     import java.lang.Object.toString(): String & Pure;
@@ -52,22 +42,22 @@ namespace Test/Exp/Jvm/NewObject {
     let anon2 = implementSerializableAgain() as ##java.lang.Object;
     not equals(getClass(anon) as ##java.lang.Object, getClass(anon2) as ##java.lang.Object)
 
-  @test
-  def testImplementInterface06(): Bool & Impure =
-    import java.lang.Object.toString(): String & Pure;
-    let anon = implementIterable() as ##java.lang.Object;
-    toString(anon) |> String.startsWith(prefix = "Anon")
+  @test 
+  def testPrimitiveTypes01(): Bool & Impure =
+    import static flix.test.TestPrimitiveTypes.runTest(##flix.test.TestPrimitiveTypes): Bool;
+    let anon = object ##flix.test.TestPrimitiveTypes {
+      def takesAndReturnsVoid(_this: ##flix.test.TestPrimitiveTypes): Unit = ()
+      def takesAndReturnsBoolean(_this: ##flix.test.TestPrimitiveTypes, x: Bool): Bool = not x
+      def takesAndReturnsChar(_this: ##flix.test.TestPrimitiveTypes, x: Char): Char = Char.toUpperCase(x)
+      def takesAndReturnsByte(_this: ##flix.test.TestPrimitiveTypes, x: Int8): Int8 = x + 1i8
+      def takesAndReturnsShort(_this: ##flix.test.TestPrimitiveTypes, x: Int16): Int16 = x + 1i16
+      def takesAndReturnsInt(_this: ##flix.test.TestPrimitiveTypes, x: Int32): Int32 = x + 1
+      def takesAndReturnsLong(_this: ##flix.test.TestPrimitiveTypes, x: Int64): Int64 = x + 1i64
+      def takesAndReturnsFloat(_this: ##flix.test.TestPrimitiveTypes, x: Float32): Float32 = x + 1.23f32
+      def takesAndReturnsDouble(_this: ##flix.test.TestPrimitiveTypes, x: Float64): Float64 = x + 1.23
 
-  @test
-  def testImplementInterface07(): Bool & Impure =
-    import java.lang.Iterable.iterator(): ##java.util.Iterator & Impure;
-    let anon = implementIterable();
-    let _it = iterator(anon);
-    true
-  
-  @test
-  def testImplementInterface08(): Bool & Impure =
-    import java.lang.Comparable.compareTo(##java.lang.Object): Int32 & Pure;
-    let anon = implementComparable();
-    compareTo(anon, anon as ##java.lang.Object) == 0
+      def allTheTypes(_this: ##flix.test.TestPrimitiveTypes, a: Bool, b: Char, c: Int8, d: Int16, e: Int32, f: Int64, g: Float32, h: Float64): String = 
+        "${a}, ${b}, ${c}, ${d}, ${e}, ${f}, ${g}, ${h}"
+    };
+    runTest(anon)
 }

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -104,4 +104,25 @@ namespace Test/Exp/Jvm/NewObject {
         "${str}, ${toString(int)}" as ##java.lang.Object
     };
     runTest(anon)
+
+  @test
+  def testClassWithDefaultConstructor01(): Bool & Impure =
+    import flix.test.TestClassWithDefaultConstructor.abstractMethod(Int32): Int32;
+    import flix.test.TestClassWithDefaultConstructor.concreteMethod(String): String;
+    let anon = object ##flix.test.TestClassWithDefaultConstructor {
+      def abstractMethod(_this: ##flix.test.TestClassWithDefaultConstructor, x: Int32): Int32 = x + 1
+    };
+    abstractMethod(anon, 1) == 2 and
+      concreteMethod(anon, "bar") == "foobar"
+
+  @test
+  def testClassWithDefaultConstructor02(): Bool & Impure =
+    import flix.test.TestClassWithDefaultConstructor.abstractMethod(Int32): Int32;
+    import flix.test.TestClassWithDefaultConstructor.concreteMethod(String): String;
+    let anon = object ##flix.test.TestClassWithDefaultConstructor {
+      def abstractMethod(_this: ##flix.test.TestClassWithDefaultConstructor, x: Int32): Int32 = x + 1
+      def concreteMethod(_this: ##flix.test.TestClassWithDefaultConstructor, y: String): String = "flix: ${y}"
+    };
+    abstractMethod(anon, 1) == 2 and
+      concreteMethod(anon, "bar") == "flix: bar"
 }


### PR DESCRIPTION
I'm not done yet, but I think that there's enough here to be worth a review and merge.

This PR implements tests which confirm that `object` can:

* Implement methods taking and returning primitive types.
* Implement overloaded methods.
* Implement interfaces with default methods.
* Implement generic interfaces, and generic methods within an interface.
* Implement methods taking boxed primitive types (within the test for generics).
* Implement classes with a default constructor.

These are all "happy path" tests (i.e. they only test things that should work, not that things that shouldn't work fail correctly.