### PR TITLE
test: negative tests for `NewObject`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -175,19 +175,19 @@ object SafetyError {
   /**
     * An error raised to indicate a missing `this` parameter for a method.
     *
-    * @param thisType The expected `this` type.
-    * @param name     The name of the method with the invalid `this` parameter.
-    * @param loc      The source location of the method.
+    * @param clazz The expected `this` type.
+    * @param name  The name of the method with the invalid `this` parameter.
+    * @param loc   The source location of the method.
     */
-  case class MissingThis(thisType: Type, name: String, loc: SourceLocation) extends SafetyError {
+  case class MissingThis(clazz: java.lang.Class[_], name: String, loc: SourceLocation) extends SafetyError {
     def summary: String = s"Missing `this` parameter for method '${name}'."
 
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
-         |>> Missing `this` parameter for method '${red(name)}''.
+         |>> Missing 'this' parameter for method '${red(name)}''.
          |
-         |The `this` parameter should have type ${cyan(thisType.toString)}
+         |The 'this' parameter should have type ${cyan(s"##${clazz.getName}")}
          |
          |${code(loc, "the method occurs here.")}
          |""".stripMargin
@@ -195,7 +195,7 @@ object SafetyError {
 
     def explain(formatter: Formatter): Option[String] = Some({
       s"""
-         | The first argument to any method must be `this`, and must have the same type as the superclass.
+         | The first argument to any method must be 'this', and must have the same type as the superclass.
          |""".stripMargin
     })
   }
@@ -203,20 +203,20 @@ object SafetyError {
   /**
     * An error raised to indicate an invalid `this` parameter for a method.
     *
-    * @param thisType        The expected `this` type.
+    * @param clazz           The expected `this` type.
     * @param illegalThisType The incorrect `this` type.
     * @param name            The name of the method with the invalid `this` parameter.
     * @param loc             The source location of the method.
     */
-  case class IllegalThisType(thisType: Type, illegalThisType: Type, name: String, loc: SourceLocation) extends SafetyError {
+  case class IllegalThisType(clazz: java.lang.Class[_], illegalThisType: Type, name: String, loc: SourceLocation) extends SafetyError {
     def summary: String = s"Invalid `this` parameter for method '${name}'."
 
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
-         |>> Invalid `this` parameter for method '${red(name)}''.
+         |>> Invalid 'this' parameter for method '${red(name)}''.
          |
-         |Expected `this` type is ${cyan(thisType.toString)}, but the first argument is declared as type ${cyan(illegalThisType.toString)}
+         |Expected 'this' type is ${cyan(s"##${clazz.getName}")}, but the first argument is declared as type ${cyan(illegalThisType.toString)}
          |
          |${code(loc, "the method occurs here.")}
          |""".stripMargin
@@ -224,35 +224,44 @@ object SafetyError {
 
     def explain(formatter: Formatter): Option[String] = Some({
       s"""
-         | The first argument to any method must be `this`, and must have the same type as the superclass.
+         | The first argument to any method must be 'this', and must have the same type as the superclass.
          |""".stripMargin
     })
+  }
+
+  private def formatJavaType(t: java.lang.Class[_]) = {
+    if (t.isPrimitive() || t.isArray())
+      Type.getFlixType(t).toString
+    else
+      s"##${t.getName}"
   }
 
   /**
     * An error raised to indicate an unimplemented superclass method
     *
-    * @param thisType The type of the superclass.
-    * @param method   The signature of the unimplemented method
-    * @param loc      The source location of the object derivation.
+    * @param clazz  The type of the superclass.
+    * @param method The unimplemented method.
+    * @param loc    The source location of the object derivation.
     */
-  case class UnimplementedMethod(thisType: Type, method: Safety.MethodSignature, loc: SourceLocation) extends SafetyError {
-    def summary: String = s"No implementation found for method '${method.name}' of superclass '${thisType}'."
+  case class UnimplementedMethod(clazz: java.lang.Class[_], method: java.lang.reflect.Method, loc: SourceLocation) extends SafetyError {
+    def summary: String = s"No implementation found for method '${method.getName}' of superclass '${clazz.getName}'."
 
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
-         |>> No implementation found for method '${red(method.name)}' of superclass '${red(thisType.toString)}'.
+         |>> No implementation found for method '${red(method.getName)}' of superclass '${red(clazz.getName)}'.
          |
          |${code(loc, "the object occurs here.")}
          |""".stripMargin
     }
 
     def explain(formatter: Formatter): Option[String] = Some({
+      val parameterTypes = (clazz +: method.getParameterTypes).map(formatJavaType)
+      val returnType = formatJavaType(method.getReturnType)
       s"""
          | Try adding a method with the following signature:
          |
-         | def ${method.name}(${method.paramTypes.mkString(", ")}): ${method.retTpe}
+         | def ${method.getName}(${parameterTypes.mkString(", ")}): ${returnType}
          |""".stripMargin
     })
   }
@@ -261,17 +270,17 @@ object SafetyError {
     * An error raised to indicate that an object derivation includes a method that doesn't exist
     * in the superclass being implemented.
     *
-    * @param thisType The type of superclass
-    * @param name     The name of the extra method.
-    * @param loc      The source location of the method.
+    * @param clazz The type of superclass
+    * @param name  The name of the extra method.
+    * @param loc   The source location of the method.
     */
-  case class ExtraMethod(thisType: Type, method: Safety.MethodSignature, loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Method '${method.name}' not found in superclass '${thisType}'"
+  case class ExtraMethod(clazz: java.lang.Class[_], name: String, loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Method '${name}' not found in superclass '${clazz.getName}'"
 
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
-         |>> Method '${red(method.name)}' not found in superclass '${red(thisType.toString)}'
+         |>> Method '${red(name)}' not found in superclass '${red(clazz.getName)}'
          |
          |${code(loc, "the method occurs here.")}
          |""".stripMargin

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -292,4 +292,37 @@ object SafetyError {
     def explain(formatter: Formatter): Option[String] = None
   }
 
+  case class NonDefaultConstructor(clazz: java.lang.Class[_], loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Superclass '${clazz.getName}' has a non-default constructor"
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Method Superclass '${red(clazz.getName)}' has a non-default constructor
+         |
+         |${code(loc, "the object occurs here.")}
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = Some(
+      s"""
+        | Flix 'object' statements only support interfaces and classes with default (no-argument) constructors.
+        |""".stripMargin
+    )
+  }
+
+  case class InaccessibleSuperclass(clazz: java.lang.Class[_], loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Superclass '${clazz.getName}' is not public"
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Superclass '${red(clazz.getName)}' is not public
+         |
+         |${code(loc, "the object occurs here.")}
+         |""".stripMargin
+    }
+    
+    def explain(formatter: Formatter): Option[String] = None
+  }
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -229,6 +229,9 @@ object SafetyError {
     })
   }
 
+  /**
+    * Format a Java type suitable for method implementation.
+    */
   private def formatJavaType(t: java.lang.Class[_]) = {
     if (t.isPrimitive() || t.isArray())
       Type.getFlixType(t).toString

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -504,6 +504,9 @@ object Safety {
     }
   }
 
+  /**
+    * Get a Set of MethodSignatures representing the methods of `clazz`. Returns a map to allow subsequent reverse lookup.
+    */
   private def getJavaMethodSignatures(clazz: java.lang.Class[_]): Map[MethodSignature, java.lang.reflect.Method] = {
     val methods = clazz.getMethods.toList.filterNot(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
     methods.foldLeft(Map.empty[MethodSignature, java.lang.reflect.Method]) {
@@ -513,6 +516,9 @@ object Safety {
     }
   }
 
+  /**
+    * Return true if a method is abstract (either because it's a non-default member of an interface, or an abstract method of a class)
+    */
   private def isAbstract(method: java.lang.reflect.Method, clazz: java.lang.Class[_]) = {
     if (clazz.isInterface) {
       !method.isDefault()

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -533,10 +533,10 @@ object Safety {
   private def hasDefaultConstructor(clazz: java.lang.Class[_]): Boolean = {
     try {
       clazz.getConstructor()
+      true
     } catch {
       case _: NoSuchMethodException => false
     }
-    true
   }
 
   /**
@@ -546,7 +546,7 @@ object Safety {
     // 
     // Check that `clazz` doesn't have a non-default constructor
     // 
-    val constructorErrors = if (!clazz.isInterface() || !hasDefaultConstructor(clazz))
+    val constructorErrors = if (!clazz.isInterface() && !hasDefaultConstructor(clazz))
         List(NonDefaultConstructor(clazz, loc))
       else
         List.empty

--- a/main/src/flix/test/TestClassWithNonDefaultConstructor.java
+++ b/main/src/flix/test/TestClassWithNonDefaultConstructor.java
@@ -1,0 +1,6 @@
+package flix.test;
+
+abstract public class TestClassWithNonDefaultConstructor {
+  public TestClassWithNonDefaultConstructor(int x) {
+  }
+}

--- a/main/src/flix/test/TestNonPublicInterface.java
+++ b/main/src/flix/test/TestNonPublicInterface.java
@@ -1,0 +1,4 @@
+package flix.test;
+
+interface TestNonPublicInterface {
+}

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -190,7 +190,7 @@ class TestSafety extends FunSuite with TestUtils {
         |  }
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.IllegalThisType](result)
+    expectError[SafetyError.MissingThis](result)
   }
 
   test("TestInvalidThis.02") {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -226,4 +226,26 @@ class TestSafety extends FunSuite with TestUtils {
     val result = compile(input, Options.TestWithLibNix)
     expectError[SafetyError.ExtraMethod](result)
   }
+
+  test("TestNonDefaultConstructor.01") {
+    val input =
+      """
+        |def f(): ##flix.test.TestClassWithNonDefaultConstructor & Impure = 
+        |  object ##flix.test.TestClassWithNonDefaultConstructor {
+        |  }
+      """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[SafetyError.NonDefaultConstructor](result)
+  }
+
+  test("TestNonPublicInterface.01") {
+    val input =
+      """
+        |def f(): ##flix.test.TestNonPublicInterface & Impure = 
+        |  object ##flix.test.TestNonPublicInterface {
+        |  }
+      """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[SafetyError.InaccessibleSuperclass](result)
+  }
 }

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -236,19 +236,6 @@ namespace Test/Exp/Jvm/NewObject {
     };
     runTest(anon)
 
-  type alias TestGenericInterface = ##flix.test.TestGenericInterface
-  type alias JavaObject = ##java.lang.Object
-  
-  @test
-  def testAliasesInObject01(): Bool & Impure =
-    import static flix.test.TestGenericInterface.runTest(TestGenericInterface): Bool;
-    let anon = object TestGenericInterface {
-      def testMethod(_this: TestGenericInterface, x: JavaObject): JavaObject = 
-        let str = x as String;
-        "${str}, ${str}" as JavaObject
-    };
-    runTest(anon)
-
   @test
   def testVarargsInterface01(): Bool & Impure =
     import static flix.test.TestVarargsInterface.runTest(##flix.test.TestVarargsInterface): Bool;

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -236,6 +236,19 @@ namespace Test/Exp/Jvm/NewObject {
     };
     runTest(anon)
 
+  type alias TestGenericInterface = ##flix.test.TestGenericInterface
+  type alias JavaObject = ##java.lang.Object
+  
+  @test
+  def testAliasesInObject01(): Bool & Impure =
+    import static flix.test.TestGenericInterface.runTest(TestGenericInterface): Bool;
+    let anon = object TestGenericInterface {
+      def testMethod(_this: TestGenericInterface, x: JavaObject): JavaObject = 
+        let str = x as String;
+        "${str}, ${str}" as JavaObject
+    };
+    runTest(anon)
+
   @test
   def testVarargsInterface01(): Bool & Impure =
     import static flix.test.TestVarargsInterface.runTest(##flix.test.TestVarargsInterface): Bool;


### PR DESCRIPTION
This tidies up the existing error case tests, and adds tests for non-default constructors and non-public superclasses.

I think that this completes the non-happy-path tests, but shout if you think I've missed anything!