### PR TITLE
feat: Allow more characters within user operators

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -102,7 +102,7 @@ object Parser {
     /**
       * An operator letter.
       */
-    val OperatorLetter: CharPredicate = CharPredicate("+-*<>=!&|^$")
+    val OperatorLetter: CharPredicate = CharPredicate("+-*<>=!&|^$:/.")
 
     /**
       * a (upper/lower case) letter, numeral, greek letter, or other legal character.

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -596,7 +596,7 @@ class TestWeeder extends FunSuite with TestUtils {
     val input =
       """
         |class C[a] {
-        |    law ^^^: forall (x: a) . true
+        |    law ^^^ : forall (x: a) . true
         |}
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -1,3 +1,33 @@
+import java.lang.Object;
+import flix.test.TestBoolArrayInterface;
+import flix.test.TestBoolInterface;
+import flix.test.TestCharArrayInterface;
+import flix.test.TestCharInterface;
+import flix.test.TestClass;
+import flix.test.TestClassWithDefaultConstructor;
+import flix.test.TestClassWithNonDefaultConstructor;
+import flix.test.TestDefaultMethods;
+import flix.test.TestFloat32ArrayInterface;
+import flix.test.TestFloat32Interface;
+import flix.test.TestFloat64ArrayInterface;
+import flix.test.TestFloat64Interface;
+import flix.test.TestFunctionalInterface;
+import flix.test.TestGenericInterface;
+import flix.test.TestGenericMethod;
+import flix.test.TestInt8ArrayInterface;
+import flix.test.TestInt16ArrayInterface;
+import flix.test.TestInt16Interface;
+import flix.test.TestInt32ArrayInterface;
+import flix.test.TestInt32Interface;
+import flix.test.TestInt64ArrayInterface;
+import flix.test.TestInt64Interface;
+import flix.test.TestNonPublicInterface;
+import flix.test.TestOverloadedMethods;
+import flix.test.TestStackOffsets;
+import flix.test.TestThrowingInterface;
+import flix.test.TestVarargsInterface;
+import flix.test.TestVoidInterface;
+
 namespace Test/Exp/Jvm/NewObject {
 
   def implementSerializable(): ##java.io.Serializable & Impure =
@@ -44,156 +74,156 @@ namespace Test/Exp/Jvm/NewObject {
 
   @test
   def testVoidInterface01(): Bool & Impure =
-    import static flix.test.TestVoidInterface.runTest(##flix.test.TestVoidInterface): Bool;
-    let anon = object ##flix.test.TestVoidInterface {
-      def testMethod(_this: ##flix.test.TestVoidInterface): Unit = ()
+    import static flix.test.TestVoidInterface.runTest(TestVoidInterface): Bool;
+    let anon = object TestVoidInterface {
+      def testMethod(_this: TestVoidInterface): Unit = ()
     };
     runTest(anon)
 
   @test
   def testBoolInterface01(): Bool & Impure =
-    import static flix.test.TestBoolInterface.runTest(##flix.test.TestBoolInterface): Bool;
-    let anon = object ##flix.test.TestBoolInterface {
-      def testMethod(_this: ##flix.test.TestBoolInterface, x: Bool): Bool = not x
+    import static flix.test.TestBoolInterface.runTest(TestBoolInterface): Bool;
+    let anon = object TestBoolInterface {
+      def testMethod(_this: TestBoolInterface, x: Bool): Bool = not x
     };
     runTest(anon)
 
   @test
   def testCharInterface01(): Bool & Impure =
-    import static flix.test.TestCharInterface.runTest(##flix.test.TestCharInterface): Bool;
-    let anon = object ##flix.test.TestCharInterface {
-      def testMethod(_this: ##flix.test.TestCharInterface, x: Char): Char = Char.toUpperCase(x)
+    import static flix.test.TestCharInterface.runTest(TestCharInterface): Bool;
+    let anon = object TestCharInterface {
+      def testMethod(_this: TestCharInterface, x: Char): Char = Char.toUpperCase(x)
     };
     runTest(anon)
 
   @test
   def testInt16Interface01(): Bool & Impure =
-    import static flix.test.TestInt16Interface.runTest(##flix.test.TestInt16Interface): Bool;
-    let anon = object ##flix.test.TestInt16Interface {
-      def testMethod(_this: ##flix.test.TestInt16Interface, x: Int16): Int16 = x + 1i16
+    import static flix.test.TestInt16Interface.runTest(TestInt16Interface): Bool;
+    let anon = object TestInt16Interface {
+      def testMethod(_this: TestInt16Interface, x: Int16): Int16 = x + 1i16
     };
     runTest(anon)
 
   @test
   def testInt32Interface01(): Bool & Impure =
-    import static flix.test.TestInt32Interface.runTest(##flix.test.TestInt32Interface): Bool;
-    let anon = object ##flix.test.TestInt32Interface {
-      def testMethod(_this: ##flix.test.TestInt32Interface, x: Int32): Int32 = x + 1
+    import static flix.test.TestInt32Interface.runTest(TestInt32Interface): Bool;
+    let anon = object TestInt32Interface {
+      def testMethod(_this: TestInt32Interface, x: Int32): Int32 = x + 1
     };
     runTest(anon)
 
   @test
   def testInt64Interface01(): Bool & Impure =
-    import static flix.test.TestInt64Interface.runTest(##flix.test.TestInt64Interface): Bool;
-    let anon = object ##flix.test.TestInt64Interface {
-      def testMethod(_this: ##flix.test.TestInt64Interface, x: Int64): Int64 = x + 1i64
+    import static flix.test.TestInt64Interface.runTest(TestInt64Interface): Bool;
+    let anon = object TestInt64Interface {
+      def testMethod(_this: TestInt64Interface, x: Int64): Int64 = x + 1i64
     };
     runTest(anon)
 
   @test
   def testFloat32Interface01(): Bool & Impure =
-    import static flix.test.TestFloat32Interface.runTest(##flix.test.TestFloat32Interface): Bool;
-    let anon = object ##flix.test.TestFloat32Interface {
-      def testMethod(_this: ##flix.test.TestFloat32Interface, x: Float32): Float32 = x + 0.23f32
+    import static flix.test.TestFloat32Interface.runTest(TestFloat32Interface): Bool;
+    let anon = object TestFloat32Interface {
+      def testMethod(_this: TestFloat32Interface, x: Float32): Float32 = x + 0.23f32
     };
     runTest(anon)
 
   @test
   def testFloat64Interface01(): Bool & Impure =
-    import static flix.test.TestFloat64Interface.runTest(##flix.test.TestFloat64Interface): Bool;
-    let anon = object ##flix.test.TestFloat64Interface {
-      def testMethod(_this: ##flix.test.TestFloat64Interface, x: Float64): Float64 = x + 0.23f64
+    import static flix.test.TestFloat64Interface.runTest(TestFloat64Interface): Bool;
+    let anon = object TestFloat64Interface {
+      def testMethod(_this: TestFloat64Interface, x: Float64): Float64 = x + 0.23f64
     };
     runTest(anon)
 
   @test
   def testBoolArrayInterface01(): Bool & Impure =
-    import static flix.test.TestBoolArrayInterface.runTest(##flix.test.TestBoolArrayInterface): Bool;
-    let anon = object ##flix.test.TestBoolArrayInterface {
-      def testMethod(_this: ##flix.test.TestBoolArrayInterface, xs: Array[Bool, Static]): Array[Bool, Static] = 
+    import static flix.test.TestBoolArrayInterface.runTest(TestBoolArrayInterface): Bool;
+    let anon = object TestBoolArrayInterface {
+      def testMethod(_this: TestBoolArrayInterface, xs: Array[Bool, Static]): Array[Bool, Static] = 
         xs |> Array.map(x -> not x)
     };
     runTest(anon)
 
   @test
   def testCharArrayInterface01(): Bool & Impure =
-    import static flix.test.TestCharArrayInterface.runTest(##flix.test.TestCharArrayInterface): Bool;
-    let anon = object ##flix.test.TestCharArrayInterface {
-      def testMethod(_this: ##flix.test.TestCharArrayInterface, xs: Array[Char, Static]): Array[Char, Static] = 
+    import static flix.test.TestCharArrayInterface.runTest(TestCharArrayInterface): Bool;
+    let anon = object TestCharArrayInterface {
+      def testMethod(_this: TestCharArrayInterface, xs: Array[Char, Static]): Array[Char, Static] = 
         xs |> Array.map(Char.toUpperCase)
     };
     runTest(anon)
 
   @test
   def testInt8ArrayInterface01(): Bool & Impure =
-    import static flix.test.TestInt8ArrayInterface.runTest(##flix.test.TestInt8ArrayInterface): Bool;
-    let anon = object ##flix.test.TestInt8ArrayInterface {
-      def testMethod(_this: ##flix.test.TestInt8ArrayInterface, xs: Array[Int8, Static]): Array[Int8, Static] = 
+    import static flix.test.TestInt8ArrayInterface.runTest(TestInt8ArrayInterface): Bool;
+    let anon = object TestInt8ArrayInterface {
+      def testMethod(_this: TestInt8ArrayInterface, xs: Array[Int8, Static]): Array[Int8, Static] = 
         xs |> Array.map(x -> x + 1i8)
     };
     runTest(anon)
 
   @test
   def testInt16ArrayInterface01(): Bool & Impure =
-    import static flix.test.TestInt16ArrayInterface.runTest(##flix.test.TestInt16ArrayInterface): Bool;
-    let anon = object ##flix.test.TestInt16ArrayInterface {
-      def testMethod(_this: ##flix.test.TestInt16ArrayInterface, xs: Array[Int16, Static]): Array[Int16, Static] = 
+    import static flix.test.TestInt16ArrayInterface.runTest(TestInt16ArrayInterface): Bool;
+    let anon = object TestInt16ArrayInterface {
+      def testMethod(_this: TestInt16ArrayInterface, xs: Array[Int16, Static]): Array[Int16, Static] = 
         xs |> Array.map(x -> x + 1i16)
     };
     runTest(anon)
 
   @test
   def testInt32ArrayInterface01(): Bool & Impure =
-    import static flix.test.TestInt32ArrayInterface.runTest(##flix.test.TestInt32ArrayInterface): Bool;
-    let anon = object ##flix.test.TestInt32ArrayInterface {
-      def testMethod(_this: ##flix.test.TestInt32ArrayInterface, xs: Array[Int32, Static]): Array[Int32, Static] = 
+    import static flix.test.TestInt32ArrayInterface.runTest(TestInt32ArrayInterface): Bool;
+    let anon = object TestInt32ArrayInterface {
+      def testMethod(_this: TestInt32ArrayInterface, xs: Array[Int32, Static]): Array[Int32, Static] = 
         xs |> Array.map(x -> x + 1)
     };
     runTest(anon)
 
   @test
   def testInt64ArrayInterface01(): Bool & Impure =
-    import static flix.test.TestInt64ArrayInterface.runTest(##flix.test.TestInt64ArrayInterface): Bool;
-    let anon = object ##flix.test.TestInt64ArrayInterface {
-      def testMethod(_this: ##flix.test.TestInt64ArrayInterface, xs: Array[Int64, Static]): Array[Int64, Static] = 
+    import static flix.test.TestInt64ArrayInterface.runTest(TestInt64ArrayInterface): Bool;
+    let anon = object TestInt64ArrayInterface {
+      def testMethod(_this: TestInt64ArrayInterface, xs: Array[Int64, Static]): Array[Int64, Static] = 
         xs |> Array.map(x -> x + 1i64)
     };
     runTest(anon)
 
   @test
   def testFloat32ArrayInterface01(): Bool & Impure =
-    import static flix.test.TestFloat32ArrayInterface.runTest(##flix.test.TestFloat32ArrayInterface): Bool;
-    let anon = object ##flix.test.TestFloat32ArrayInterface {
-      def testMethod(_this: ##flix.test.TestFloat32ArrayInterface, xs: Array[Float32, Static]): Array[Float32, Static] = 
+    import static flix.test.TestFloat32ArrayInterface.runTest(TestFloat32ArrayInterface): Bool;
+    let anon = object TestFloat32ArrayInterface {
+      def testMethod(_this: TestFloat32ArrayInterface, xs: Array[Float32, Static]): Array[Float32, Static] = 
         xs |> Array.map(x -> x + 0.5f32)
     };
     runTest(anon)
 
   @test
   def testFloat64ArrayInterface01(): Bool & Impure =
-    import static flix.test.TestFloat64ArrayInterface.runTest(##flix.test.TestFloat64ArrayInterface): Bool;
-    let anon = object ##flix.test.TestFloat64ArrayInterface {
-      def testMethod(_this: ##flix.test.TestFloat64ArrayInterface, xs: Array[Float64, Static]): Array[Float64, Static] = 
+    import static flix.test.TestFloat64ArrayInterface.runTest(TestFloat64ArrayInterface): Bool;
+    let anon = object TestFloat64ArrayInterface {
+      def testMethod(_this: TestFloat64ArrayInterface, xs: Array[Float64, Static]): Array[Float64, Static] = 
         xs |> Array.map(x -> x + 0.5f64)
     };
     runTest(anon)
 
   @test 
   def testStackOffsets01(): Bool & Impure =
-    import static flix.test.TestStackOffsets.runTest(##flix.test.TestStackOffsets): Bool;
-    let anon = object ##flix.test.TestStackOffsets {
-      def testMethod(_this: ##flix.test.TestStackOffsets, a: Bool, b: Char, c: Int8, d: Int16, e: Int32, f: Int64, g: Float32, h: Float64): String = 
+    import static flix.test.TestStackOffsets.runTest(TestStackOffsets): Bool;
+    let anon = object TestStackOffsets {
+      def testMethod(_this: TestStackOffsets, a: Bool, b: Char, c: Int8, d: Int16, e: Int32, f: Int64, g: Float32, h: Float64): String = 
         "${a}, ${b}, ${c}, ${d}, ${e}, ${f}, ${g}, ${h}"
     };
     runTest(anon)
 
   @test
   def testOverloadedMethods01(): Bool & Impure =
-    import static flix.test.TestOverloadedMethods.runTest(##flix.test.TestOverloadedMethods): Bool;
-    let anon = object ##flix.test.TestOverloadedMethods {
-      def overloadedMethod(_this: ##flix.test.TestOverloadedMethods): Int32 = 42
-      def overloadedMethod(_this: ##flix.test.TestOverloadedMethods, x: Int32): Int32 = x + 1
-      def overloadedMethod(_this: ##flix.test.TestOverloadedMethods, x: String, y: Float64, z: Float64): String = "${x}${y / z}"
+    import static flix.test.TestOverloadedMethods.runTest(TestOverloadedMethods): Bool;
+    let anon = object TestOverloadedMethods {
+      def overloadedMethod(_this: TestOverloadedMethods): Int32 = 42
+      def overloadedMethod(_this: TestOverloadedMethods, x: Int32): Int32 = x + 1
+      def overloadedMethod(_this: TestOverloadedMethods, x: String, y: Float64, z: Float64): String = "${x}${y / z}"
     };
     runTest(anon)
 
@@ -201,8 +231,8 @@ namespace Test/Exp/Jvm/NewObject {
   def testDefaultMethods01(): Bool & Impure =
     import flix.test.TestDefaultMethods.methodWithNoImplementation(Int32): Int32;
     import flix.test.TestDefaultMethods.methodWithDefaultImplementation(Int32): Int32;
-    let anon = object ##flix.test.TestDefaultMethods {
-      def methodWithNoImplementation(_this: ##flix.test.TestDefaultMethods, x: Int32): Int32 = x + 1
+    let anon = object TestDefaultMethods {
+      def methodWithNoImplementation(_this: TestDefaultMethods, x: Int32): Int32 = x + 1
     };
     methodWithNoImplementation(anon, 1) == 2 and methodWithDefaultImplementation(anon, 1) == 43
 
@@ -210,17 +240,17 @@ namespace Test/Exp/Jvm/NewObject {
   def testDefaultMethods02(): Bool & Impure =
     import flix.test.TestDefaultMethods.methodWithNoImplementation(Int32): Int32;
     import flix.test.TestDefaultMethods.methodWithDefaultImplementation(Int32): Int32;
-    let anon = object ##flix.test.TestDefaultMethods {
-      def methodWithNoImplementation(_this: ##flix.test.TestDefaultMethods, x: Int32): Int32 = x + 1
-      def methodWithDefaultImplementation(_this: ##flix.test.TestDefaultMethods, x: Int32): Int32 = x + 2
+    let anon = object TestDefaultMethods {
+      def methodWithNoImplementation(_this: TestDefaultMethods, x: Int32): Int32 = x + 1
+      def methodWithDefaultImplementation(_this: TestDefaultMethods, x: Int32): Int32 = x + 2
     };
     methodWithNoImplementation(anon, 1) == 2 and methodWithDefaultImplementation(anon, 1) == 3
 
   @test
   def testGenericInterface01(): Bool & Impure =
-    import static flix.test.TestGenericInterface.runTest(##flix.test.TestGenericInterface): Bool;
-    let anon = object ##flix.test.TestGenericInterface {
-      def testMethod(_this: ##flix.test.TestGenericInterface, x: ##java.lang.Object): ##java.lang.Object = 
+    import static flix.test.TestGenericInterface.runTest(TestGenericInterface): Bool;
+    let anon = object TestGenericInterface {
+      def testMethod(_this: TestGenericInterface, x: ##java.lang.Object): ##java.lang.Object = 
         let str = x as String;
         "${str}, ${str}" as ##java.lang.Object
     };
@@ -228,49 +258,46 @@ namespace Test/Exp/Jvm/NewObject {
 
   @test
   def testGenericMethod01(): Bool & Impure =
-    import static flix.test.TestGenericMethod.runTest(##flix.test.TestGenericMethod): Bool;
-    let anon = object ##flix.test.TestGenericMethod {
-      def testMethod(_this: ##flix.test.TestGenericMethod, x: ##java.lang.Object): ##java.lang.Object = 
+    import static flix.test.TestGenericMethod.runTest(TestGenericMethod): Bool;
+    let anon = object TestGenericMethod {
+      def testMethod(_this: TestGenericMethod, x: ##java.lang.Object): ##java.lang.Object = 
         let str = x as String;
         "${str}, ${str}" as ##java.lang.Object
     };
     runTest(anon)
 
-  type alias TestGenericInterface = ##flix.test.TestGenericInterface
-  type alias JavaObject = ##java.lang.Object
-  
   @test
   def testAliasesInObject01(): Bool & Impure =
     import static flix.test.TestGenericInterface.runTest(TestGenericInterface): Bool;
     let anon = object TestGenericInterface {
-      def testMethod(_this: TestGenericInterface, x: JavaObject): JavaObject = 
+      def testMethod(_this: TestGenericInterface, x: Object): Object = 
         let str = x as String;
-        "${str}, ${str}" as JavaObject
+        "${str}, ${str}" as Object
     };
     runTest(anon)
 
   @test
   def testVarargsInterface01(): Bool & Impure =
-    import static flix.test.TestVarargsInterface.runTest(##flix.test.TestVarargsInterface): Bool;
-    let anon = object ##flix.test.TestVarargsInterface {
-      def testMethod(_this: ##flix.test.TestVarargsInterface, xs: Array[Int32, Static]): Int32 = 
+    import static flix.test.TestVarargsInterface.runTest(TestVarargsInterface): Bool;
+    let anon = object TestVarargsInterface {
+      def testMethod(_this: TestVarargsInterface, xs: Array[Int32, Static]): Int32 = 
         xs |> Array.sum
     };
     runTest(anon)
 
   @test
   def testThrowingInterface01(): Bool & Impure =
-    import static flix.test.TestThrowingInterface.runTest(##flix.test.TestThrowingInterface): Bool;
-    let anon = object ##flix.test.TestThrowingInterface {
-      def testMethod(_this: ##flix.test.TestThrowingInterface): Unit = ()
+    import static flix.test.TestThrowingInterface.runTest(TestThrowingInterface): Bool;
+    let anon = object TestThrowingInterface {
+      def testMethod(_this: TestThrowingInterface): Unit = ()
     };
     runTest(anon)
 
   @test
   def testFunctionalInterface01(): Bool & Impure =
-    import static flix.test.TestFunctionalInterface.runTest(##flix.test.TestFunctionalInterface): Bool;
-    let anon = object ##flix.test.TestFunctionalInterface {
-      def testMethod(_this: ##flix.test.TestFunctionalInterface, x: Int32): Int32 = x + 1
+    import static flix.test.TestFunctionalInterface.runTest(TestFunctionalInterface): Bool;
+    let anon = object TestFunctionalInterface {
+      def testMethod(_this: TestFunctionalInterface, x: Int32): Int32 = x + 1
     };
     runTest(anon)
 
@@ -278,8 +305,8 @@ namespace Test/Exp/Jvm/NewObject {
   def testClassWithDefaultConstructor01(): Bool & Impure =
     import flix.test.TestClassWithDefaultConstructor.abstractMethod(Int32): Int32;
     import flix.test.TestClassWithDefaultConstructor.concreteMethod(String): String;
-    let anon = object ##flix.test.TestClassWithDefaultConstructor {
-      def abstractMethod(_this: ##flix.test.TestClassWithDefaultConstructor, x: Int32): Int32 = x + 1
+    let anon = object TestClassWithDefaultConstructor {
+      def abstractMethod(_this: TestClassWithDefaultConstructor, x: Int32): Int32 = x + 1
     };
     abstractMethod(anon, 1) == 2 and
       concreteMethod(anon, "bar") == "foobar"
@@ -288,9 +315,9 @@ namespace Test/Exp/Jvm/NewObject {
   def testClassWithDefaultConstructor02(): Bool & Impure =
     import flix.test.TestClassWithDefaultConstructor.abstractMethod(Int32): Int32;
     import flix.test.TestClassWithDefaultConstructor.concreteMethod(String): String;
-    let anon = object ##flix.test.TestClassWithDefaultConstructor {
-      def abstractMethod(_this: ##flix.test.TestClassWithDefaultConstructor, x: Int32): Int32 = x + 1
-      def concreteMethod(_this: ##flix.test.TestClassWithDefaultConstructor, y: String): String = "flix: ${y}"
+    let anon = object TestClassWithDefaultConstructor {
+      def abstractMethod(_this: TestClassWithDefaultConstructor, x: Int32): Int32 = x + 1
+      def concreteMethod(_this: TestClassWithDefaultConstructor, y: String): String = "flix: ${y}"
     };
     abstractMethod(anon, 1) == 2 and
       concreteMethod(anon, "bar") == "flix: bar"


### PR DESCRIPTION
As discussed on Gitter.

I've added `/`, `:`, and `.` to the characters allowed in user operators.

Created as draft because I had to make one, very minor, change to `ReservedName.Law.01` in the Weeder tests.

The problem is that with this change, this

```
class C[a] {
    law ^^^: forall (x: a) . true
}
```

Now parses `^^^:` as one token (i.e. a law with the name `^^^:` rather than a law with the name `^^^` followed by a colon. So the error generated is a parse error, not a `ReservedName` error.

The fix is to change the above to:

```
class C[a] {
    law ^^^ : forall (x: a) . true
}
```

(note the space before the colon).

This is only an issue with laws because other definitions (e.g. `def`) don't allow a colon immediately after the symbol being defined.

I think that this is OK, but we should probably think about it, hence marking this as draft.