### PR TITLE
fix: introduce `Name.Java`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Name.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Name.scala
@@ -291,4 +291,18 @@ object Name {
     override def toString: String = name
   }
 
+  /**
+    * Java Name.
+    *
+    * @param sp1  the position of the first character in the identifier.
+    * @param fqn  the fully qualified name.
+    * @param sp2  the position of the last character in the identifier.
+    */
+  case class JavaName(sp1: SourcePosition, fqn: Seq[String], sp2: SourcePosition) {
+
+    /**
+      * Human readable representation.
+      */
+    override def toString: String = fqn.mkString(".")
+  }
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -305,7 +305,7 @@ object ParsedAst {
       * @param name the Java class or interface name.
       * @param sp2  the position of the last character.
       */
-    case class Import(sp1: SourcePosition, name: Seq[String], sp2: SourcePosition) extends ParsedAst.Import
+    case class Import(sp1: SourcePosition, name: Name.JavaName, sp2: SourcePosition) extends ParsedAst.Import
 
   }
 
@@ -1493,7 +1493,7 @@ object ParsedAst {
       * @param fqn the fully qualified Java name.
       * @param sp2 the position of the last character in the type.
       */
-    case class Native(sp1: SourcePosition, fqn: Seq[String], sp2: SourcePosition) extends ParsedAst.Type
+    case class Native(sp1: SourcePosition, fqn: Name.JavaName, sp2: SourcePosition) extends ParsedAst.Type
 
     /**
       * Type Application.
@@ -1916,7 +1916,7 @@ object ParsedAst {
     * @param fqn   the fully-qualified Java name.
     * @param exp   the body expression.
     */
-  case class CatchRule(ident: Name.Ident, fqn: Seq[String], exp: ParsedAst.Expression)
+  case class CatchRule(ident: Name.Ident, fqn: Name.JavaName, exp: ParsedAst.Expression)
 
   /**
     * Effect handler rule.
@@ -2039,7 +2039,7 @@ object ParsedAst {
       * @param purAndEff the purity and effect of the constructor.
       * @param ident     the name given to the imported constructor.
       */
-    case class Constructor(fqn: Seq[String], sig: Seq[ParsedAst.Type], tpe: Type, purAndEff: PurityAndEffect, ident: Name.Ident) extends JvmOp
+    case class Constructor(fqn: Name.JavaName, sig: Seq[ParsedAst.Type], tpe: Type, purAndEff: PurityAndEffect, ident: Name.Ident) extends JvmOp
 
     /**
       * Method Invocation.
@@ -2050,7 +2050,7 @@ object ParsedAst {
       * @param purAndEff the purity and effect of the imported method.
       * @param ident     the optional name given to the imported method.
       */
-    case class Method(fqn: Seq[String], sig: Seq[ParsedAst.Type], tpe: Type, purAndEff: PurityAndEffect, ident: Option[Name.Ident]) extends JvmOp
+    case class Method(fqn: Name.JavaName, sig: Seq[ParsedAst.Type], tpe: Type, purAndEff: PurityAndEffect, ident: Option[Name.Ident]) extends JvmOp
 
     /**
       * Static Method Invocation.
@@ -2061,7 +2061,7 @@ object ParsedAst {
       * @param purAndEff the purity and effect of the imported method.
       * @param ident     the optional name given to the imported method.
       */
-    case class StaticMethod(fqn: Seq[String], sig: Seq[ParsedAst.Type], tpe: Type, purAndEff: PurityAndEffect, ident: Option[Name.Ident]) extends JvmOp
+    case class StaticMethod(fqn: Name.JavaName, sig: Seq[ParsedAst.Type], tpe: Type, purAndEff: PurityAndEffect, ident: Option[Name.Ident]) extends JvmOp
 
     /**
       * Get Object Field.
@@ -2071,7 +2071,7 @@ object ParsedAst {
       * @param purAndEff the purity and effect of the generated function.
       * @param ident     the name given to the imported field.
       */
-    case class GetField(fqn: Seq[String], tpe: Type, purAndEff: PurityAndEffect, ident: Name.Ident) extends JvmOp
+    case class GetField(fqn: Name.JavaName, tpe: Type, purAndEff: PurityAndEffect, ident: Name.Ident) extends JvmOp
 
     /**
       * Put ObjectField.
@@ -2081,7 +2081,7 @@ object ParsedAst {
       * @param purAndEff the purity and effect of the generated function.
       * @param ident     the name given to the imported field.
       */
-    case class PutField(fqn: Seq[String], tpe: Type, purAndEff: PurityAndEffect, ident: Name.Ident) extends JvmOp
+    case class PutField(fqn: Name.JavaName, tpe: Type, purAndEff: PurityAndEffect, ident: Name.Ident) extends JvmOp
 
     /**
       * Get Static Field.
@@ -2091,7 +2091,7 @@ object ParsedAst {
       * @param purAndEff the purity and effect of the generated function.
       * @param ident     the name given to the imported field.
       */
-    case class GetStaticField(fqn: Seq[String], tpe: Type, purAndEff: PurityAndEffect, ident: Name.Ident) extends JvmOp
+    case class GetStaticField(fqn: Name.JavaName, tpe: Type, purAndEff: PurityAndEffect, ident: Name.Ident) extends JvmOp
 
     /**
       * Put Static Field.
@@ -2101,7 +2101,7 @@ object ParsedAst {
       * @param purAndEff the purity and effect of the generated function.
       * @param ident     the name given to the imported field.
       */
-    case class PutStaticField(fqn: Seq[String], tpe: Type, purAndEff: PurityAndEffect, ident: Name.Ident) extends JvmOp
+    case class PutStaticField(fqn: Name.JavaName, tpe: Type, purAndEff: PurityAndEffect, ident: Name.Ident) extends JvmOp
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1832,8 +1832,8 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       capture((CharPredicate.Alpha | anyOf("_$")) ~ zeroOrMore(CharPredicate.AlphaNum | anyOf("_$")))
     }
 
-    def JavaName: Rule1[Seq[String]] = rule {
-      oneOrMore(JavaIdentifier).separatedBy(".")
+    def JavaName: Rule1[Name.JavaName] = rule {
+      SP ~ oneOrMore(JavaIdentifier).separatedBy(".") ~ SP ~> Name.JavaName
     }
 
     def JavaMethod: Rule1[Name.Ident] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -455,7 +455,7 @@ object Weeder {
     * Performs weeding on the given import `i0`.
     */
   private def visitImport(i0: ParsedAst.Import): Validation[WeededAst.Declaration, WeederError] = i0 match {
-    case ParsedAst.Imports.Import(sp1, name, sp2) =>
+    case ParsedAst.Imports.Import(sp1, Name.JavaName(_, name, _), sp2) =>
       val loc = mkSL(sp1, sp2)
       val doc = Ast.Doc(Nil, loc)
       val mod = Ast.Modifiers.Empty
@@ -853,7 +853,7 @@ object Weeder {
           mapN(visitExp(exp2, senv)) {
             case e2 =>
               // Compute the class name.
-              val className = fqn.mkString(".")
+              val className = fqn.toString
 
               val tpe = visitType(tpe0)
               val purAndEff = visitPurityAndEffect(purAndEff0)
@@ -897,10 +897,10 @@ object Weeder {
           //
           // Introduce a let-bound lambda: (obj, args...) -> InvokeMethod(obj, args) as tpe & pur
           //
-          mapN(parseClassAndMember(fqn, loc), visitExp(exp2, senv)) {
+          mapN(parseClassAndMember(fqn), visitExp(exp2, senv)) {
             case ((className, methodName), e2) =>
               // Compute the name of the let-bound variable.
-              val ident = identOpt.getOrElse(Name.Ident(sp1, methodName, sp2))
+              val ident = identOpt.getOrElse(Name.Ident(fqn.sp1, methodName, fqn.sp2))
 
               val receiverType = WeededAst.Type.Native(className, loc)
 
@@ -940,11 +940,11 @@ object Weeder {
           //
           // Introduce a let-bound lambda: (args...) -> InvokeStaticMethod(args) as tpe & pur
           //
-          mapN(parseClassAndMember(fqn, loc), visitExp(exp2, senv)) {
+          mapN(parseClassAndMember(fqn), visitExp(exp2, senv)) {
             case ((className, methodName), e2) =>
 
               // Compute the name of the let-bound variable.
-              val ident = identOpt.getOrElse(Name.Ident(sp1, methodName, sp2))
+              val ident = identOpt.getOrElse(Name.Ident(fqn.sp1, methodName, fqn.sp2))
 
               val tpe = visitType(tpe0)
               val purAndEff = visitPurityAndEffect(purAndEff0)
@@ -988,7 +988,7 @@ object Weeder {
           //
           // Introduce a let-bound lambda: o -> GetField(o) as tpe & pur
           //
-          mapN(parseClassAndMember(fqn, loc), visitExp(exp2, senv)) {
+          mapN(parseClassAndMember(fqn), visitExp(exp2, senv)) {
 
             case ((className, fieldName), e2) =>
               val tpe = visitType(tpe0)
@@ -1007,7 +1007,7 @@ object Weeder {
           //
           // Introduce a let-bound lambda: (o, v) -> PutField(o, v) as tpe & pur
           //
-          mapN(parseClassAndMember(fqn, loc), visitExp(exp2, senv)) {
+          mapN(parseClassAndMember(fqn), visitExp(exp2, senv)) {
             case ((className, fieldName), e2) =>
               val tpe = visitType(tpe0)
               val purAndEff = visitPurityAndEffect(purAndEff0)
@@ -1028,7 +1028,7 @@ object Weeder {
           //
           // Introduce a let-bound lambda: _: Unit -> GetStaticField.
           //
-          mapN(parseClassAndMember(fqn, loc), visitExp(exp2, senv)) {
+          mapN(parseClassAndMember(fqn), visitExp(exp2, senv)) {
             case ((className, fieldName), e2) =>
               val tpe = visitType(tpe0)
               val purAndEff = visitPurityAndEffect(purAndEff0)
@@ -1045,7 +1045,7 @@ object Weeder {
           //
           // Introduce a let-bound lambda: x -> PutStaticField(x).
           //
-          mapN(parseClassAndMember(fqn, loc), visitExp(exp2, senv)) {
+          mapN(parseClassAndMember(fqn), visitExp(exp2, senv)) {
             case ((className, fieldName), e2) =>
               val tpe = visitType(tpe0)
               val purAndEff = visitPurityAndEffect(purAndEff0)
@@ -1473,7 +1473,7 @@ object Weeder {
       val rulesVal = traverse(rules) {
         case ParsedAst.CatchRule(ident, fqn, body) =>
           visitExp(body, senv) map {
-            case b => WeededAst.CatchRule(ident, fqn.mkString("."), b)
+            case b => WeededAst.CatchRule(ident, fqn.toString, b)
           }
       }
 
@@ -2388,7 +2388,7 @@ object Weeder {
       mkCurriedArrow(ts, purAndEff, tr, loc)
 
     case ParsedAst.Type.Native(sp1, fqn, sp2) =>
-      WeededAst.Type.Native(fqn.mkString("."), mkSL(sp1, sp2))
+      WeededAst.Type.Native(fqn.toString, mkSL(sp1, sp2))
 
     case ParsedAst.Type.Apply(t1, args, sp2) =>
       // Curry the type arguments.
@@ -3102,17 +3102,18 @@ object Weeder {
   /**
     * Returns the class and member name constructed from the given fully-qualified name `fqn`.
     */
-  private def parseClassAndMember(fqn: Seq[String], loc: SourceLocation): Validation[(String, String), WeederError] = {
-    // Ensure that the fqn has at least two components.
-    if (fqn.length == 1) {
-      return WeederError.IllegalJvmFieldOrMethodName(loc).toFailure
-    }
+  private def parseClassAndMember(fqn: Name.JavaName): Validation[(String, String), WeederError] = fqn match {
+    case Name.JavaName(sp1, components, sp2) =>
+      // Ensure that the fqn has at least two components.
+      if (components.length == 1) {
+        return WeederError.IllegalJvmFieldOrMethodName(mkSL(sp1, sp2)).toFailure
+      }
 
-    // Compute the class and member name.
-    val className = fqn.dropRight(1).mkString(".")
-    val memberName = fqn.last
+      // Compute the class and member name.
+      val className = components.dropRight(1).mkString(".")
+      val memberName = components.last
 
-    (className, memberName).toSuccess
+      (className, memberName).toSuccess
   }
 
   /**

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -1,3 +1,33 @@
+import java.lang.Object;
+import flix.test.TestBoolArrayInterface;
+import flix.test.TestBoolInterface;
+import flix.test.TestCharArrayInterface;
+import flix.test.TestCharInterface;
+import flix.test.TestClass;
+import flix.test.TestClassWithDefaultConstructor;
+import flix.test.TestClassWithNonDefaultConstructor;
+import flix.test.TestDefaultMethods;
+import flix.test.TestFloat32ArrayInterface;
+import flix.test.TestFloat32Interface;
+import flix.test.TestFloat64ArrayInterface;
+import flix.test.TestFloat64Interface;
+import flix.test.TestFunctionalInterface;
+import flix.test.TestGenericInterface;
+import flix.test.TestGenericMethod;
+import flix.test.TestInt8ArrayInterface;
+import flix.test.TestInt16ArrayInterface;
+import flix.test.TestInt16Interface;
+import flix.test.TestInt32ArrayInterface;
+import flix.test.TestInt32Interface;
+import flix.test.TestInt64ArrayInterface;
+import flix.test.TestInt64Interface;
+import flix.test.TestNonPublicInterface;
+import flix.test.TestOverloadedMethods;
+import flix.test.TestStackOffsets;
+import flix.test.TestThrowingInterface;
+import flix.test.TestVarargsInterface;
+import flix.test.TestVoidInterface;
+
 namespace Test/Exp/Jvm/NewObject {
 
   def implementSerializable(): ##java.io.Serializable & Impure =
@@ -44,156 +74,156 @@ namespace Test/Exp/Jvm/NewObject {
 
   @test
   def testVoidInterface01(): Bool & Impure =
-    import static flix.test.TestVoidInterface.runTest(##flix.test.TestVoidInterface): Bool;
-    let anon = object ##flix.test.TestVoidInterface {
-      def testMethod(_this: ##flix.test.TestVoidInterface): Unit = ()
+    import static flix.test.TestVoidInterface.runTest(TestVoidInterface): Bool;
+    let anon = object TestVoidInterface {
+      def testMethod(_this: TestVoidInterface): Unit = ()
     };
     runTest(anon)
 
   @test
   def testBoolInterface01(): Bool & Impure =
-    import static flix.test.TestBoolInterface.runTest(##flix.test.TestBoolInterface): Bool;
-    let anon = object ##flix.test.TestBoolInterface {
-      def testMethod(_this: ##flix.test.TestBoolInterface, x: Bool): Bool = not x
+    import static flix.test.TestBoolInterface.runTest(TestBoolInterface): Bool;
+    let anon = object TestBoolInterface {
+      def testMethod(_this: TestBoolInterface, x: Bool): Bool = not x
     };
     runTest(anon)
 
   @test
   def testCharInterface01(): Bool & Impure =
-    import static flix.test.TestCharInterface.runTest(##flix.test.TestCharInterface): Bool;
-    let anon = object ##flix.test.TestCharInterface {
-      def testMethod(_this: ##flix.test.TestCharInterface, x: Char): Char = Char.toUpperCase(x)
+    import static flix.test.TestCharInterface.runTest(TestCharInterface): Bool;
+    let anon = object TestCharInterface {
+      def testMethod(_this: TestCharInterface, x: Char): Char = Char.toUpperCase(x)
     };
     runTest(anon)
 
   @test
   def testInt16Interface01(): Bool & Impure =
-    import static flix.test.TestInt16Interface.runTest(##flix.test.TestInt16Interface): Bool;
-    let anon = object ##flix.test.TestInt16Interface {
-      def testMethod(_this: ##flix.test.TestInt16Interface, x: Int16): Int16 = x + 1i16
+    import static flix.test.TestInt16Interface.runTest(TestInt16Interface): Bool;
+    let anon = object TestInt16Interface {
+      def testMethod(_this: TestInt16Interface, x: Int16): Int16 = x + 1i16
     };
     runTest(anon)
 
   @test
   def testInt32Interface01(): Bool & Impure =
-    import static flix.test.TestInt32Interface.runTest(##flix.test.TestInt32Interface): Bool;
-    let anon = object ##flix.test.TestInt32Interface {
-      def testMethod(_this: ##flix.test.TestInt32Interface, x: Int32): Int32 = x + 1
+    import static flix.test.TestInt32Interface.runTest(TestInt32Interface): Bool;
+    let anon = object TestInt32Interface {
+      def testMethod(_this: TestInt32Interface, x: Int32): Int32 = x + 1
     };
     runTest(anon)
 
   @test
   def testInt64Interface01(): Bool & Impure =
-    import static flix.test.TestInt64Interface.runTest(##flix.test.TestInt64Interface): Bool;
-    let anon = object ##flix.test.TestInt64Interface {
-      def testMethod(_this: ##flix.test.TestInt64Interface, x: Int64): Int64 = x + 1i64
+    import static flix.test.TestInt64Interface.runTest(TestInt64Interface): Bool;
+    let anon = object TestInt64Interface {
+      def testMethod(_this: TestInt64Interface, x: Int64): Int64 = x + 1i64
     };
     runTest(anon)
 
   @test
   def testFloat32Interface01(): Bool & Impure =
-    import static flix.test.TestFloat32Interface.runTest(##flix.test.TestFloat32Interface): Bool;
-    let anon = object ##flix.test.TestFloat32Interface {
-      def testMethod(_this: ##flix.test.TestFloat32Interface, x: Float32): Float32 = x + 0.23f32
+    import static flix.test.TestFloat32Interface.runTest(TestFloat32Interface): Bool;
+    let anon = object TestFloat32Interface {
+      def testMethod(_this: TestFloat32Interface, x: Float32): Float32 = x + 0.23f32
     };
     runTest(anon)
 
   @test
   def testFloat64Interface01(): Bool & Impure =
-    import static flix.test.TestFloat64Interface.runTest(##flix.test.TestFloat64Interface): Bool;
-    let anon = object ##flix.test.TestFloat64Interface {
-      def testMethod(_this: ##flix.test.TestFloat64Interface, x: Float64): Float64 = x + 0.23f64
+    import static flix.test.TestFloat64Interface.runTest(TestFloat64Interface): Bool;
+    let anon = object TestFloat64Interface {
+      def testMethod(_this: TestFloat64Interface, x: Float64): Float64 = x + 0.23f64
     };
     runTest(anon)
 
   @test
   def testBoolArrayInterface01(): Bool & Impure =
-    import static flix.test.TestBoolArrayInterface.runTest(##flix.test.TestBoolArrayInterface): Bool;
-    let anon = object ##flix.test.TestBoolArrayInterface {
-      def testMethod(_this: ##flix.test.TestBoolArrayInterface, xs: Array[Bool, Static]): Array[Bool, Static] = 
+    import static flix.test.TestBoolArrayInterface.runTest(TestBoolArrayInterface): Bool;
+    let anon = object TestBoolArrayInterface {
+      def testMethod(_this: TestBoolArrayInterface, xs: Array[Bool, Static]): Array[Bool, Static] = 
         xs |> Array.map(x -> not x)
     };
     runTest(anon)
 
   @test
   def testCharArrayInterface01(): Bool & Impure =
-    import static flix.test.TestCharArrayInterface.runTest(##flix.test.TestCharArrayInterface): Bool;
-    let anon = object ##flix.test.TestCharArrayInterface {
-      def testMethod(_this: ##flix.test.TestCharArrayInterface, xs: Array[Char, Static]): Array[Char, Static] = 
+    import static flix.test.TestCharArrayInterface.runTest(TestCharArrayInterface): Bool;
+    let anon = object TestCharArrayInterface {
+      def testMethod(_this: TestCharArrayInterface, xs: Array[Char, Static]): Array[Char, Static] = 
         xs |> Array.map(Char.toUpperCase)
     };
     runTest(anon)
 
   @test
   def testInt8ArrayInterface01(): Bool & Impure =
-    import static flix.test.TestInt8ArrayInterface.runTest(##flix.test.TestInt8ArrayInterface): Bool;
-    let anon = object ##flix.test.TestInt8ArrayInterface {
-      def testMethod(_this: ##flix.test.TestInt8ArrayInterface, xs: Array[Int8, Static]): Array[Int8, Static] = 
+    import static flix.test.TestInt8ArrayInterface.runTest(TestInt8ArrayInterface): Bool;
+    let anon = object TestInt8ArrayInterface {
+      def testMethod(_this: TestInt8ArrayInterface, xs: Array[Int8, Static]): Array[Int8, Static] = 
         xs |> Array.map(x -> x + 1i8)
     };
     runTest(anon)
 
   @test
   def testInt16ArrayInterface01(): Bool & Impure =
-    import static flix.test.TestInt16ArrayInterface.runTest(##flix.test.TestInt16ArrayInterface): Bool;
-    let anon = object ##flix.test.TestInt16ArrayInterface {
-      def testMethod(_this: ##flix.test.TestInt16ArrayInterface, xs: Array[Int16, Static]): Array[Int16, Static] = 
+    import static flix.test.TestInt16ArrayInterface.runTest(TestInt16ArrayInterface): Bool;
+    let anon = object TestInt16ArrayInterface {
+      def testMethod(_this: TestInt16ArrayInterface, xs: Array[Int16, Static]): Array[Int16, Static] = 
         xs |> Array.map(x -> x + 1i16)
     };
     runTest(anon)
 
   @test
   def testInt32ArrayInterface01(): Bool & Impure =
-    import static flix.test.TestInt32ArrayInterface.runTest(##flix.test.TestInt32ArrayInterface): Bool;
-    let anon = object ##flix.test.TestInt32ArrayInterface {
-      def testMethod(_this: ##flix.test.TestInt32ArrayInterface, xs: Array[Int32, Static]): Array[Int32, Static] = 
+    import static flix.test.TestInt32ArrayInterface.runTest(TestInt32ArrayInterface): Bool;
+    let anon = object TestInt32ArrayInterface {
+      def testMethod(_this: TestInt32ArrayInterface, xs: Array[Int32, Static]): Array[Int32, Static] = 
         xs |> Array.map(x -> x + 1)
     };
     runTest(anon)
 
   @test
   def testInt64ArrayInterface01(): Bool & Impure =
-    import static flix.test.TestInt64ArrayInterface.runTest(##flix.test.TestInt64ArrayInterface): Bool;
-    let anon = object ##flix.test.TestInt64ArrayInterface {
-      def testMethod(_this: ##flix.test.TestInt64ArrayInterface, xs: Array[Int64, Static]): Array[Int64, Static] = 
+    import static flix.test.TestInt64ArrayInterface.runTest(TestInt64ArrayInterface): Bool;
+    let anon = object TestInt64ArrayInterface {
+      def testMethod(_this: TestInt64ArrayInterface, xs: Array[Int64, Static]): Array[Int64, Static] = 
         xs |> Array.map(x -> x + 1i64)
     };
     runTest(anon)
 
   @test
   def testFloat32ArrayInterface01(): Bool & Impure =
-    import static flix.test.TestFloat32ArrayInterface.runTest(##flix.test.TestFloat32ArrayInterface): Bool;
-    let anon = object ##flix.test.TestFloat32ArrayInterface {
-      def testMethod(_this: ##flix.test.TestFloat32ArrayInterface, xs: Array[Float32, Static]): Array[Float32, Static] = 
+    import static flix.test.TestFloat32ArrayInterface.runTest(TestFloat32ArrayInterface): Bool;
+    let anon = object TestFloat32ArrayInterface {
+      def testMethod(_this: TestFloat32ArrayInterface, xs: Array[Float32, Static]): Array[Float32, Static] = 
         xs |> Array.map(x -> x + 0.5f32)
     };
     runTest(anon)
 
   @test
   def testFloat64ArrayInterface01(): Bool & Impure =
-    import static flix.test.TestFloat64ArrayInterface.runTest(##flix.test.TestFloat64ArrayInterface): Bool;
-    let anon = object ##flix.test.TestFloat64ArrayInterface {
-      def testMethod(_this: ##flix.test.TestFloat64ArrayInterface, xs: Array[Float64, Static]): Array[Float64, Static] = 
+    import static flix.test.TestFloat64ArrayInterface.runTest(TestFloat64ArrayInterface): Bool;
+    let anon = object TestFloat64ArrayInterface {
+      def testMethod(_this: TestFloat64ArrayInterface, xs: Array[Float64, Static]): Array[Float64, Static] = 
         xs |> Array.map(x -> x + 0.5f64)
     };
     runTest(anon)
 
   @test 
   def testStackOffsets01(): Bool & Impure =
-    import static flix.test.TestStackOffsets.runTest(##flix.test.TestStackOffsets): Bool;
-    let anon = object ##flix.test.TestStackOffsets {
-      def testMethod(_this: ##flix.test.TestStackOffsets, a: Bool, b: Char, c: Int8, d: Int16, e: Int32, f: Int64, g: Float32, h: Float64): String = 
+    import static flix.test.TestStackOffsets.runTest(TestStackOffsets): Bool;
+    let anon = object TestStackOffsets {
+      def testMethod(_this: TestStackOffsets, a: Bool, b: Char, c: Int8, d: Int16, e: Int32, f: Int64, g: Float32, h: Float64): String = 
         "${a}, ${b}, ${c}, ${d}, ${e}, ${f}, ${g}, ${h}"
     };
     runTest(anon)
 
   @test
   def testOverloadedMethods01(): Bool & Impure =
-    import static flix.test.TestOverloadedMethods.runTest(##flix.test.TestOverloadedMethods): Bool;
-    let anon = object ##flix.test.TestOverloadedMethods {
-      def overloadedMethod(_this: ##flix.test.TestOverloadedMethods): Int32 = 42
-      def overloadedMethod(_this: ##flix.test.TestOverloadedMethods, x: Int32): Int32 = x + 1
-      def overloadedMethod(_this: ##flix.test.TestOverloadedMethods, x: String, y: Float64, z: Float64): String = "${x}${y / z}"
+    import static flix.test.TestOverloadedMethods.runTest(TestOverloadedMethods): Bool;
+    let anon = object TestOverloadedMethods {
+      def overloadedMethod(_this: TestOverloadedMethods): Int32 = 42
+      def overloadedMethod(_this: TestOverloadedMethods, x: Int32): Int32 = x + 1
+      def overloadedMethod(_this: TestOverloadedMethods, x: String, y: Float64, z: Float64): String = "${x}${y / z}"
     };
     runTest(anon)
 
@@ -201,8 +231,8 @@ namespace Test/Exp/Jvm/NewObject {
   def testDefaultMethods01(): Bool & Impure =
     import flix.test.TestDefaultMethods.methodWithNoImplementation(Int32): Int32;
     import flix.test.TestDefaultMethods.methodWithDefaultImplementation(Int32): Int32;
-    let anon = object ##flix.test.TestDefaultMethods {
-      def methodWithNoImplementation(_this: ##flix.test.TestDefaultMethods, x: Int32): Int32 = x + 1
+    let anon = object TestDefaultMethods {
+      def methodWithNoImplementation(_this: TestDefaultMethods, x: Int32): Int32 = x + 1
     };
     methodWithNoImplementation(anon, 1) == 2 and methodWithDefaultImplementation(anon, 1) == 43
 
@@ -210,17 +240,17 @@ namespace Test/Exp/Jvm/NewObject {
   def testDefaultMethods02(): Bool & Impure =
     import flix.test.TestDefaultMethods.methodWithNoImplementation(Int32): Int32;
     import flix.test.TestDefaultMethods.methodWithDefaultImplementation(Int32): Int32;
-    let anon = object ##flix.test.TestDefaultMethods {
-      def methodWithNoImplementation(_this: ##flix.test.TestDefaultMethods, x: Int32): Int32 = x + 1
-      def methodWithDefaultImplementation(_this: ##flix.test.TestDefaultMethods, x: Int32): Int32 = x + 2
+    let anon = object TestDefaultMethods {
+      def methodWithNoImplementation(_this: TestDefaultMethods, x: Int32): Int32 = x + 1
+      def methodWithDefaultImplementation(_this: TestDefaultMethods, x: Int32): Int32 = x + 2
     };
     methodWithNoImplementation(anon, 1) == 2 and methodWithDefaultImplementation(anon, 1) == 3
 
   @test
   def testGenericInterface01(): Bool & Impure =
-    import static flix.test.TestGenericInterface.runTest(##flix.test.TestGenericInterface): Bool;
-    let anon = object ##flix.test.TestGenericInterface {
-      def testMethod(_this: ##flix.test.TestGenericInterface, x: ##java.lang.Object): ##java.lang.Object = 
+    import static flix.test.TestGenericInterface.runTest(TestGenericInterface): Bool;
+    let anon = object TestGenericInterface {
+      def testMethod(_this: TestGenericInterface, x: ##java.lang.Object): ##java.lang.Object = 
         let str = x as String;
         "${str}, ${str}" as ##java.lang.Object
     };
@@ -228,49 +258,46 @@ namespace Test/Exp/Jvm/NewObject {
 
   @test
   def testGenericMethod01(): Bool & Impure =
-    import static flix.test.TestGenericMethod.runTest(##flix.test.TestGenericMethod): Bool;
-    let anon = object ##flix.test.TestGenericMethod {
-      def testMethod(_this: ##flix.test.TestGenericMethod, x: ##java.lang.Object): ##java.lang.Object = 
+    import static flix.test.TestGenericMethod.runTest(TestGenericMethod): Bool;
+    let anon = object TestGenericMethod {
+      def testMethod(_this: TestGenericMethod, x: ##java.lang.Object): ##java.lang.Object = 
         let str = x as String;
         "${str}, ${str}" as ##java.lang.Object
     };
     runTest(anon)
 
-  type alias TestGenericInterface = ##flix.test.TestGenericInterface
-  type alias JavaObject = ##java.lang.Object
-  
   @test
   def testAliasesInObject01(): Bool & Impure =
     import static flix.test.TestGenericInterface.runTest(TestGenericInterface): Bool;
     let anon = object TestGenericInterface {
-      def testMethod(_this: TestGenericInterface, x: JavaObject): JavaObject = 
+      def testMethod(_this: TestGenericInterface, x: Object): Object = 
         let str = x as String;
-        "${str}, ${str}" as JavaObject
+        "${str}, ${str}" as Object
     };
     runTest(anon)
 
   @test
   def testVarargsInterface01(): Bool & Impure =
-    import static flix.test.TestVarargsInterface.runTest(##flix.test.TestVarargsInterface): Bool;
-    let anon = object ##flix.test.TestVarargsInterface {
-      def testMethod(_this: ##flix.test.TestVarargsInterface, xs: Array[Int32, Static]): Int32 = 
+    import static flix.test.TestVarargsInterface.runTest(TestVarargsInterface): Bool;
+    let anon = object TestVarargsInterface {
+      def testMethod(_this: TestVarargsInterface, xs: Array[Int32, Static]): Int32 = 
         xs |> Array.sum
     };
     runTest(anon)
 
   @test
   def testThrowingInterface01(): Bool & Impure =
-    import static flix.test.TestThrowingInterface.runTest(##flix.test.TestThrowingInterface): Bool;
-    let anon = object ##flix.test.TestThrowingInterface {
-      def testMethod(_this: ##flix.test.TestThrowingInterface): Unit = ()
+    import static flix.test.TestThrowingInterface.runTest(TestThrowingInterface): Bool;
+    let anon = object TestThrowingInterface {
+      def testMethod(_this: TestThrowingInterface): Unit = ()
     };
     runTest(anon)
 
   @test
   def testFunctionalInterface01(): Bool & Impure =
-    import static flix.test.TestFunctionalInterface.runTest(##flix.test.TestFunctionalInterface): Bool;
-    let anon = object ##flix.test.TestFunctionalInterface {
-      def testMethod(_this: ##flix.test.TestFunctionalInterface, x: Int32): Int32 = x + 1
+    import static flix.test.TestFunctionalInterface.runTest(TestFunctionalInterface): Bool;
+    let anon = object TestFunctionalInterface {
+      def testMethod(_this: TestFunctionalInterface, x: Int32): Int32 = x + 1
     };
     runTest(anon)
 
@@ -278,8 +305,8 @@ namespace Test/Exp/Jvm/NewObject {
   def testClassWithDefaultConstructor01(): Bool & Impure =
     import flix.test.TestClassWithDefaultConstructor.abstractMethod(Int32): Int32;
     import flix.test.TestClassWithDefaultConstructor.concreteMethod(String): String;
-    let anon = object ##flix.test.TestClassWithDefaultConstructor {
-      def abstractMethod(_this: ##flix.test.TestClassWithDefaultConstructor, x: Int32): Int32 = x + 1
+    let anon = object TestClassWithDefaultConstructor {
+      def abstractMethod(_this: TestClassWithDefaultConstructor, x: Int32): Int32 = x + 1
     };
     abstractMethod(anon, 1) == 2 and
       concreteMethod(anon, "bar") == "foobar"
@@ -288,9 +315,9 @@ namespace Test/Exp/Jvm/NewObject {
   def testClassWithDefaultConstructor02(): Bool & Impure =
     import flix.test.TestClassWithDefaultConstructor.abstractMethod(Int32): Int32;
     import flix.test.TestClassWithDefaultConstructor.concreteMethod(String): String;
-    let anon = object ##flix.test.TestClassWithDefaultConstructor {
-      def abstractMethod(_this: ##flix.test.TestClassWithDefaultConstructor, x: Int32): Int32 = x + 1
-      def concreteMethod(_this: ##flix.test.TestClassWithDefaultConstructor, y: String): String = "flix: ${y}"
+    let anon = object TestClassWithDefaultConstructor {
+      def abstractMethod(_this: TestClassWithDefaultConstructor, x: Int32): Int32 = x + 1
+      def concreteMethod(_this: TestClassWithDefaultConstructor, y: String): String = "flix: ${y}"
     };
     abstractMethod(anon, 1) == 2 and
       concreteMethod(anon, "bar") == "flix: bar"


### PR DESCRIPTION
Fixes #4363

I've deliberately kept the changes in this PR minimal, but that does lead to some odditites such as `ParsedAst.Imports.Import` wrapping a `JavaName` with source positions which now already exist within `JavaName`.