### PR TITLE
feat: generalize `Array.unzip`

### DIFF
--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -1278,9 +1278,8 @@ namespace Array {
     /// and the second containing all second components in `a`.
     ///
     @Time(length(a)) @Space(length(a))
-    pub def unzip(a: Array[(a, b), r]): (Array[a, r], Array[b, r]) \ { Read(r), Write(r) } =
-        let r = Scoped.regionOf(a);
-        init2(r, r, i -> a[i], length(a))
+    pub def unzip(r1: Region[r1], r2: Region[r2], a: Array[(a, b), r3]): (Array[a, r1], Array[b, r2]) \ { Write(r1, r2), Read(r3) } =
+        init2(r1, r2, i -> a[i], length(a))
 
     ///
     /// Alias for `foldLeft2`.

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -3982,6 +3982,17 @@ namespace TestArray {
         Array.sameElements(a, [1,2,3]) and Array.sameElements(b, [true,true,false])
     }
 
+    @test
+    def unzip05(): Bool = region r1 { region r2 {
+        unzip05Aux(r1, [(1, "1"), (2, "2"), (3, "3")] @ r2) `Array.sameElements` [1, 2, 3]
+    }}
+
+    def unzip05Aux(r1: Region[r1], a: Array[(a, b), r2]): Array[a, r1] \ { Write(r1), Read(r2) } =
+        region r3 {
+            // snd is local, fst is for caller
+            Array.unzip(r1, r3, a) |> fst
+        }
+
     /////////////////////////////////////////////////////////////////////////////
     // fold2                                                                   //
     /////////////////////////////////////////////////////////////////////////////

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -3960,25 +3960,25 @@ namespace TestArray {
 
     @test
     def unzip01(): Bool = region r {
-        let (a,b) = Array.unzip([]: Array[(Unit, Unit), _]);
+        let (a,b) = Array.unzip(r, r, []: Array[(Unit, Unit), _]);
         Array.sameElements(a, []) and Array.sameElements(b, [])
     }
 
     @test
     def unzip02(): Bool = region r {
-        let (a,b) = Array.unzip([(1, true)]);
+        let (a,b) = Array.unzip(r, r, [(1, true)]);
         Array.sameElements(a, [1]) and Array.sameElements(b, [true])
     }
 
     @test
     def unzip03(): Bool = region r {
-        let (a,b) = Array.unzip([(1, true), (2, true)]);
+        let (a,b) = Array.unzip(r, r, [(1, true), (2, true)]);
         Array.sameElements(a, [1,2])  and Array.sameElements(b, [true,true])
     }
 
     @test
     def unzip04(): Bool = region r {
-        let (a,b) = Array.unzip([(1, true), (2, true), (3, false)]);
+        let (a,b) = Array.unzip(r, r, [(1, true), (2, true), (3, false)]);
         Array.sameElements(a, [1,2,3]) and Array.sameElements(b, [true,true,false])
     }
 


### PR DESCRIPTION
Makes `Array.unzip` take two regions in which to put the unzipped arrays.