### PR TITLE
style: update effect syntax from `' e` -> `\ ef` in lib

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -66,7 +66,7 @@ instance Functor[List] {
 
 instance Applicative[List] {
     pub def point(a: a) : List[a] = List.point(a)
-    pub def ap(f: List[a -> b \ e], x: List[a]) : List[b] \ e = List.ap(f, x)
+    pub def ap(f: List[a -> b \ ef], x: List[a]) : List[b] \ ef = List.ap(f, x)
 }
 
 instance Monad[List] {
@@ -354,7 +354,7 @@ namespace List {
     /// For argument lists `l1 = x1, x2, ...` and `l2 = y1, y2, ...` the results appear in the order
     /// `f(x1,y1), f(x1,y2), ..., f(x2,y1), f(x2,y2), ...`.
     ///
-    pub def lift2(f: t1 -> t2 -> r \ e, l1: List[t1], l2: List[t2]): List[r] \ e = Applicative.liftA2(f, l1, l2)
+    pub def lift2(f: t1 -> t2 -> r \ ef, l1: List[t1], l2: List[t2]): List[r] \ ef = Applicative.liftA2(f, l1, l2)
 
     ///
     /// Lift a ternary function to work on lists of its original arguments, returning a list
@@ -368,15 +368,15 @@ namespace List {
     /// ...
     /// ```
     ///
-    pub def lift3(f: t1 -> t2 -> t3 -> r \ e, l1: List[t1], l2: List[t2], l3: List[t3]): List[r] \ e = Applicative.liftA3(f, l1, l2, l3)
+    pub def lift3(f: t1 -> t2 -> t3 -> r \ ef, l1: List[t1], l2: List[t2], l3: List[t3]): List[r] \ ef = Applicative.liftA3(f, l1, l2, l3)
 
     /// Lift a 4-ary function to work on lists of its original arguments, returning a list
     /// of applying all combinations of arguments. The results appear in the order extending the pattern from `lift3`.
-    pub def lift4(f: t1 -> t2 -> t3 -> t4 -> r \ e, l1: List[t1], l2: List[t2], l3: List[t3], l4: List[t4]): List[r] \ e = Applicative.liftA4(f, l1, l2, l3, l4)
+    pub def lift4(f: t1 -> t2 -> t3 -> t4 -> r \ ef, l1: List[t1], l2: List[t2], l3: List[t3], l4: List[t4]): List[r] \ ef = Applicative.liftA4(f, l1, l2, l3, l4)
 
     /// Lift a 5-ary function to work on lists of its original arguments, returning a list
     /// of applying all combinations of arguments. The results appear in the order extending the pattern from `lift3`.
-    pub def lift5(f: t1 -> t2 -> t3 -> t4 -> t5 -> r \ e, l1: List[t1], l2: List[t2], l3: List[t3], l4: List[t4], l5: List[t5]): List[r] \ e = Applicative.liftA5(f, l1, l2, l3, l4, l5)
+    pub def lift5(f: t1 -> t2 -> t3 -> t4 -> t5 -> r \ ef, l1: List[t1], l2: List[t2], l3: List[t3], l4: List[t4], l5: List[t5]): List[r] \ ef = Applicative.liftA5(f, l1, l2, l3, l4, l5)
 
     ///
     /// Returns the result of applying `f` to every element in `l` along with that element's index.

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -68,13 +68,13 @@ instance Functor[Option] {
 instance Applicative[Option] {
     pub def point(x: a) : Option[a] = Option.point(x)
 
-    pub def ap(f: Option[a -> b \ e], x: Option[a]) : Option[b] \ e = Option.ap(f, x)
+    pub def ap(f: Option[a -> b \ ef], x: Option[a]) : Option[b] \ ef = Option.ap(f, x)
 
     // Same as the default implementation using `map` and `ap` but with less indirection.
-    override pub def liftA2(f: t1 -> t2 -> r \ e, x1: Option[t1], x2: Option[t2]): Option[r] \ e = Option.lift2(f, x1, x2)
-    override pub def liftA3(f: t1 -> t2 -> t3 -> r \ e, x1: Option[t1], x2: Option[t2], x3: Option[t3]): Option[r] \ e = Option.lift3(f, x1, x2, x3)
-    override pub def liftA4(f: t1 -> t2 -> t3 -> t4 -> r \ e, x1: Option[t1], x2: Option[t2], x3: Option[t3], x4: Option[t4]): Option[r] \ e = Option.lift4(f, x1, x2, x3, x4)
-    override pub def liftA5(f: t1 -> t2 -> t3 -> t4 -> t5 -> r \ e, x1: Option[t1], x2: Option[t2], x3: Option[t3], x4: Option[t4], x5: Option[t5]): Option[r] \ e = Option.lift5(f, x1, x2, x3, x4, x5)
+    override pub def liftA2(f: t1 -> t2 -> r \ ef, x1: Option[t1], x2: Option[t2]): Option[r] \ ef = Option.lift2(f, x1, x2)
+    override pub def liftA3(f: t1 -> t2 -> t3 -> r \ ef, x1: Option[t1], x2: Option[t2], x3: Option[t3]): Option[r] \ ef = Option.lift3(f, x1, x2, x3)
+    override pub def liftA4(f: t1 -> t2 -> t3 -> t4 -> r \ ef, x1: Option[t1], x2: Option[t2], x3: Option[t3], x4: Option[t4]): Option[r] \ ef = Option.lift4(f, x1, x2, x3, x4)
+    override pub def liftA5(f: t1 -> t2 -> t3 -> t4 -> t5 -> r \ ef, x1: Option[t1], x2: Option[t2], x3: Option[t3], x4: Option[t4], x5: Option[t5]): Option[r] \ ef = Option.lift5(f, x1, x2, x3, x4, x5)
 }
 
 instance Monad[Option] {
@@ -233,7 +233,7 @@ namespace Option {
     /// If both arguments are `Some`, return a `Some` containing the result of applying the function inside
     /// `f` to the value inside `x`. Otherwise return `None`.
     ///
-    pub def ap(f: Option[a -> b \ e], x: Option[a]) : Option[b] \ e =
+    pub def ap(f: Option[a -> b \ ef], x: Option[a]) : Option[b] \ ef =
         match f {
             case None    => None
             case Some(g) => match x {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
@@ -69,7 +69,7 @@ class TestInstances extends FunSuite with TestUtils {
       """
         |class C[a]
         |
-        |instance C[a -> b & p \ e]
+        |instance C[a -> b & p \ ef]
         |
         |instance C[x -> y & q \ f]
         |""".stripMargin
@@ -233,7 +233,7 @@ class TestInstances extends FunSuite with TestUtils {
       """
         |class C[a]
         |
-        |instance C[a -> a & p \ e]
+        |instance C[a -> a & p \ ef]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[InstanceError.DuplicateTypeVariableOccurrence](result)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -1077,7 +1077,7 @@ class TestRedundancy extends FunSuite with TestUtils {
       """
         |namespace N {
         |    eff E
-        |    def foo(): Unit \ E = ??? as \ E
+        |    def foo(): Unit \ ef = ??? as \ ef
         |}
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -857,7 +857,7 @@ class TestResolver extends FunSuite with TestUtils {
   test("UndefinedType.05") {
     val input =
       """
-        |def f(): Unit \ E = ???
+        |def f(): Unit \ ef = ???
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[ResolutionError.UndefinedType](result)
@@ -866,7 +866,7 @@ class TestResolver extends FunSuite with TestUtils {
   test("UndefinedType.06") {
     val input =
       """
-        |def f(x: a -> b \ E): Unit = ???
+        |def f(x: a -> b \ ef): Unit = ???
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[ResolutionError.UndefinedType](result)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1323,7 +1323,7 @@ class TestTyper extends FunSuite with TestUtils {
         |    pub def op(x: String): Unit
         |}
         |
-        |def foo(): Unit \ E = do E.op("hello", "world")
+        |def foo(): Unit \ ef = do E.op("hello", "world")
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[TypeError.InvalidOpParamCount](result)
@@ -1353,7 +1353,7 @@ class TestTyper extends FunSuite with TestUtils {
         |    pub def op(x: String): Unit
         |}
         |
-        |def foo(): Unit \ E = do E.op(123)
+        |def foo(): Unit \ ef = do E.op(123)
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[TypeError.UnexpectedType](result)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -725,7 +725,7 @@ class TestWeeder extends FunSuite with TestUtils {
     val input =
       """
         |eff E {
-        |    def op(): Unit \ E
+        |    def op(): Unit \ ef
         |}
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)

--- a/main/test/flix/Test.Dec.Class.flix
+++ b/main/test/flix/Test.Dec.Class.flix
@@ -87,7 +87,7 @@ namespace Test/Dec/Class {
 
     namespace Test09 {
         class Eff[e : Bool] {
-            pub def isPure(f: a -> b \ e): Bool
+            pub def isPure(f: a -> b \ ef): Bool
         }
 
         instance Eff[Pure] {

--- a/main/test/flix/Test.Dec.Class.flix
+++ b/main/test/flix/Test.Dec.Class.flix
@@ -86,7 +86,7 @@ namespace Test/Dec/Class {
     }
 
     namespace Test09 {
-        class Eff[e : Bool] {
+        class Eff[ef : Bool] {
             pub def isPure(f: a -> b \ ef): Bool
         }
 

--- a/main/test/flix/Test.Def.Generalization.flix
+++ b/main/test/flix/Test.Def.Generalization.flix
@@ -43,7 +43,7 @@ namespace Test/Def/Generalization {
     def testGen14(): (a -> a \ IO) -> (a -> a \ IO) = x -> x
 
     @test
-    def testGen15(): (a -> a \ e) -> (a -> a \ e) = x -> x
+    def testGen15(): (a -> a \ ef) -> (a -> a \ ef) = x -> x
 
     @test
     def testGen16(): a -> (b -> a) = x -> (_ -> x)
@@ -152,7 +152,7 @@ namespace Test/Def/Generalization {
     def testLeq24(): {x :: Int32} -> {x :: Int32} = r -> {x = 21 | r}
 
     @test
-    def testLeq25(): (Unit -> b \ e) -> b \ e = f -> f()
+    def testLeq25(): (Unit -> b \ ef) -> b \ ef = f -> f()
 
     @test
     def testLeq26(): (Unit -> b) -> b = f -> f()

--- a/main/test/flix/Test.Eff.Advanced.flix
+++ b/main/test/flix/Test.Eff.Advanced.flix
@@ -58,19 +58,19 @@ namespace Test/Eff/Advanced {
     def requiresImpure(_f: a -> b \ IO): Unit = ()
 
     /// A function that requires a pure and an impure function.
-    def requiresPureAndImpure1(_f: a -> b \ e, _g: a -> b & (not e)): Unit = ()
+    def requiresPureAndImpure1(_f: a -> b \ ef, _g: a -> b & (not e)): Unit = ()
 
     /// A function that requires a pure and an impure function.
-    def requiresPureAndImpure2(_f: a -> b & (not e), _g: a -> b \ e): Unit = ()
+    def requiresPureAndImpure2(_f: a -> b & (not e), _g: a -> b \ ef): Unit = ()
 
     /// A function that requires at most one pure function.
-    def requiresAtmostOnePure1(_f: a -> b \ e1, _g: a -> b & (not e1 and e2)): Unit = ()
+    def requiresAtmostOnePure1(_f: a -> b \ ef1, _g: a -> b & (not ef1 and ef2)): Unit = ()
 
     /// A function that requires at most one pure function.
-    def requiresAtmostOnePure2(_f: a -> b & (not e1 and e2), _g: a -> b \ e1): Unit = ()
+    def requiresAtmostOnePure2(_f: a -> b & (not ef1 and ef2), _g: a -> b \ ef1): Unit = ()
 
     // First and last must be the same. Middle must be the inverse.
-    def requiresTwoAndOne(_f: a -> b \ e, _g: a -> b & (not e), _h: a -> b \ e): Unit = ()
+    def requiresTwoAndOne(_f: a -> b \ ef, _g: a -> b & (not e), _h: a -> b \ ef): Unit = ()
 
     // A unSAT instance.
     //pub def yikes(_f: a -> b & {{(x \/ y \/ z) /\ (x \/ y \/ not z) /\ (x \/ not y \/ z) /\ (x \/ not y \/ not z) /\ (not x \/ y \/ z) /\ (not x \/ y \/ not z) /\ (not x \/ not y \/ z) /\ (not x \/ not y \/ not z)}}): Unit = ()

--- a/main/test/flix/Test.Eff.Polymorphism.flix
+++ b/main/test/flix/Test.Eff.Polymorphism.flix
@@ -117,6 +117,6 @@ namespace Test/Eff/Polymorphism {
 
     def impure(): Unit \ IO = discard [42]; ()
 
-    def flip(f: (a, b) -> c \ e): (b, a) -> c \ e = (x, y) -> f(y, x)
+    def flip(f: (a, b) -> c \ ef): (b, a) -> c \ ef = (x, y) -> f(y, x)
 
 }

--- a/main/test/flix/Test.Exp.Effect.flix
+++ b/main/test/flix/Test.Exp.Effect.flix
@@ -116,5 +116,5 @@ namespace Test/Exp/Effect {
         pub def println(x: String): Unit
     }
 
-    pub enum Do[e: Eff](Unit -> Unit \ e)
+    pub enum Do[e: Eff](Unit -> Unit \ ef)
 }

--- a/main/test/flix/Test.Exp.Effect.flix
+++ b/main/test/flix/Test.Exp.Effect.flix
@@ -116,5 +116,5 @@ namespace Test/Exp/Effect {
         pub def println(x: String): Unit
     }
 
-    pub enum Do[e: Eff](Unit -> Unit \ ef)
+    pub enum Do[ef: Eff](Unit -> Unit \ ef)
 }

--- a/main/test/flix/Test.Exp.Record.Polymorphism.flix
+++ b/main/test/flix/Test.Exp.Record.Polymorphism.flix
@@ -91,6 +91,6 @@ namespace Test/Exp/Record/Polymorphism {
         let p4 = p3 |> withAgeAndSex(23, "m");
         p4.age == 23 and p4.sex == "m"
 
-    def |>(x: a, f: a -> b \ e): b \ e = f(x)
+    def |>(x: a, f: a -> b \ ef): b \ ef = f(x)
 
 }

--- a/main/test/flix/Test.Exp.ReifyEff.flix
+++ b/main/test/flix/Test.Exp.ReifyEff.flix
@@ -7,7 +7,7 @@ namespace Test/Exp/ReifyEff {
     def reify02(): Bool = not hof(_ -> 123 as \ IO)
 
     @test
-    def reify03(): Bool = not hof(_ -> 123 as \ E)
+    def reify03(): Bool = not hof(_ -> 123 as \ ef)
 
     @test
     def reify04(): Bool = hof((x -> x) >> (y -> y))
@@ -22,19 +22,19 @@ namespace Test/Exp/ReifyEff {
     def reify07(): Bool = not hof((x -> x as \ IO) >> (y -> y as \ IO))
 
     @test
-    def reify08(): Bool = not hof((x -> x) >> (y -> y as \ E))
+    def reify08(): Bool = not hof((x -> x) >> (y -> y as \ ef))
 
     @test
-    def reify09(): Bool = not hof((x -> x as \ E) >> (y -> y))
+    def reify09(): Bool = not hof((x -> x as \ ef) >> (y -> y))
 
     @test
-    def reify10(): Bool = not hof((x -> x as \ E) >> (y -> y as \ E))
+    def reify10(): Bool = not hof((x -> x as \ ef) >> (y -> y as \ ef))
 
     @test
-    def reify11(): Bool = not hof((x -> x as \ E) >> (y -> y as \ IO))
+    def reify11(): Bool = not hof((x -> x as \ ef) >> (y -> y as \ IO))
 
     @test
-    def reify12(): Bool = not hof((x -> x as \ IO) >> (y -> y as \ E))
+    def reify12(): Bool = not hof((x -> x as \ IO) >> (y -> y as \ ef))
 
     def hof(f: a -> b \ ef): Bool = reifyEff(f) {
         case Pure(_) => true


### PR DESCRIPTION
Just some minor housekeeping to keep effect signatures consistent in the code base.