### PR TITLE
refactor: make Validation typeclassy

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -88,7 +88,7 @@ object Resolver {
         flatMapN(classesVal, sequence(instancesVal), defsVal, sequence(enumsVal), sequence(effectsVal)) {
           case (classes, instances, defs, enums, effects) =>
             mapN(checkSuperClassDag(classes)) {
-              _ => ResolvedAst.Root(classes, combine(instances), defs, enums.toMap, effects.toMap, taenv, taOrder, root.entryPoint, root.sources)
+              _ => ResolvedAst.Root(classes, combine(instances.toList), defs, enums.toMap, effects.toMap, taenv, taOrder, root.entryPoint, root.sources)
             }
         }
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -118,7 +118,7 @@ object Typer {
     flix.subphase("Instances") {
       val results = ParOps.parMap(root.instances.values.flatten)(visitInstance(_, root, classEnv))
       Validation.sequence(results) map {
-        insts => insts.groupBy(inst => inst.sym.clazz)
+        insts => insts.toList.groupBy(inst => inst.sym.clazz)
       }
     }
 

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -16,7 +16,8 @@
 
 package ca.uwaterloo.flix.util
 
-import scala.collection.mutable
+import scala.+:
+import scala.collection.{IterableOps, SeqOps, mutable}
 
 sealed trait Validation[+T, +E] {
 
@@ -83,11 +84,11 @@ object Validation {
   /**
     * Sequences the given list of validations `xs`.
     */
-  def sequence[T, E](xs: Iterable[Validation[T, E]]): Validation[List[T], E] = {
-    val zero = Success(List.empty[T]): Validation[List[T], E]
+  def sequence[I[X] <: IterableOps[X, I, I[X]], T, E](xs: I[Validation[T, E]]): Validation[I[T], E] = {
+    val zero = Success(xs.iterableFactory.empty): Validation[I[T], E]
     xs.foldRight(zero) {
       case (Success(curValue), Success(accValue)) =>
-        Success(curValue :: accValue)
+        Success(xs.iterableFactory.fill(1)(curValue) ++  accValue)
       case (Success(_), Failure(accErrors)) =>
         Failure(accErrors)
       case (Failure(curErrors), Success(_)) =>
@@ -100,7 +101,7 @@ object Validation {
   /**
     * Sequences the given list of validations `xs`, ignoring non-error results.
     */
-  def sequenceX[T, E](xs: Iterable[Validation[T, E]]): Validation[Unit, E] = {
+  def sequenceX[I[X] <: IterableOps[X, I, I[X]], T, E](xs: I[Validation[T, E]]): Validation[Unit, E] = {
     sequence(xs).map(_ => ())
   }
 


### PR DESCRIPTION
I think I've discovered the way to make Scala return the right type, so that Validation.sequence over an option will give back an option.