### PR TITLE
fix: Make List.traverse effects run left-to-right 

### DIFF
--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -1377,16 +1377,19 @@ namespace List {
         List.foldRight((x, acc) -> DelayMap.insert(fst(x), snd(x), acc), DelayMap.empty(), l)
 
     ///
-    /// Helper function for `traverse` and `sequence`.
+    /// Helper function for `sequence`.
     ///
     /// Builds an "applicative list" from a head of one applicative action and an
     /// applicative list of the tail.
     ///
     def consA(mx: f[a], ml: f[List[a]]): f[List[a]] with Applicative[f] =
-        (((x, xs) -> x :: xs) `Functor.map` mx) `Applicative.ap` ml
+        use Functor.{<$>};
+        use Applicative.{<*>};
+        (((x, xs) -> x :: xs) <$> mx) <*> ml
 
     ///
-    /// Returns the result of running all the actions in the list `l`.
+    /// Returns the result of running all the actions in the list `l` going from left
+    /// to right.
     ///
     pub def sequence(l: List[m[a]]): m[List[a]] with Applicative[m] =
         def loop(ll, k) = match ll {
@@ -1396,15 +1399,31 @@ namespace List {
         loop(l, identity)
 
     ///
+    /// Helper function for `traverse`.
+    ///
+    /// Builds an "applicative DList" from a head of one applicative action and an
+    /// applicative list of the tail.
+    ///
+    /// This is a version of `consA` except it builds a DList rather than a regular
+    /// List within the applicative context. We use the DList within `traverse` to
+    /// avoid having to reverse the accumulated results list at the end of the traversal.
+    ///
+    def consAD(mx: f[a], ml: f[List[a] -> List[a]]): f[List[a]-> List[a]] with Applicative[f] =
+        use Functor.{<$>};
+        use Applicative.{<*>};
+        (((ks, x) -> (k -> x :: k) >> ks) <$> ml) <*> mx
+
+
+    ///
     /// Returns the result of applying the applicative mapping function `f` to all the elements of the
-    /// list `l`.
+    /// list `l` going from left to right.
     ///
     pub def traverse(f: a -> m[b] \ ef, l: List[a]): m[List[b]] \ ef with Applicative[m] =
-        def loop(ll, k) = match ll {
-            case Nil     => k(Applicative.point(Nil))
-            case x :: xs => loop(xs, ks -> k(consA(f(x), ks)))
+        def loop(ll, acc) = match ll {
+            case Nil     => Applicative.ap(acc, Applicative.point(Nil))
+            case x :: xs => let ans = f(x); loop(xs, consAD(ans, acc))
         };
-        loop(l, upcast(identity))
+        loop(l, Applicative.point(upcast(identity)))
 
     ///
     /// Merges the two lists `l1` and `l2`. Assuming they are both sorted.

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -2745,6 +2745,77 @@ def distinctWith09(): Bool =
         List.reverse(deref z) == List.zip(l, List.range(0, 100))
     }
 
+    /////////////////////////////////////////////////////////////////////////////
+    // sequence                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def sequence01(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = List.map(x -> {st := x; Identity(x)}, Nil);
+        let ans = List.sequence(l);
+        ans == Identity(Nil) and deref st == 0
+    }
+
+    @test
+    def sequence02(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = List.map(x -> {st := x; Identity(x)}, 1 :: Nil);
+        let ans = List.sequence(l);
+        ans == Identity(1 :: Nil) and deref st == 1
+    }
+
+    @test
+    def sequence03(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = List.map(x -> {st := x; Identity(x)}, 1 :: 2 :: Nil);
+        let ans = List.sequence(l);
+        ans == Identity(1 :: 2 :: Nil) and deref st == 2
+    }
+
+    @test
+    def sequence04(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = List.map(x -> {st := x; Identity(x)}, 1 :: 2 :: 3 :: Nil);
+        let ans = List.sequence(l);
+        ans == Identity(1 :: 2 :: 3 :: Nil) and deref st == 3
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // traverse                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def traverse01(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = Nil;
+        let ans = List.traverse(x -> {st := x; Identity(x)}, l);
+        ans == Identity(Nil) and deref st == 0
+    }
+
+    @test
+    def traverse02(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = 1 :: Nil;
+        let ans = List.traverse(x -> {st := x; Identity(x)}, l);
+        ans == Identity(1 :: Nil) and deref st == 1
+    }
+
+    @test
+    def traverse03(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = 1 :: 2 :: Nil;
+        let ans = List.traverse(x -> {st := x; Identity(x)}, l);
+        ans == Identity(1 :: 2 :: Nil) and deref st == 2
+    }
+
+    @test
+    def traverse04(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = 1 :: 2 :: 3 :: Nil;
+        let ans = List.traverse(x -> {st := x; Identity(x)}, l);
+        ans == Identity(1 :: 2 :: 3 :: Nil) and deref st == 3
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // merge                                                                   //


### PR DESCRIPTION
While looking at changing `Traversable.mapAccumLeft` to use local mutable state I discovered that `List.traverse` does not run its effects in left-to-right order. Instead, it traverses the List, builds up a stack of effects to run and performs them backwards (the rightmost effect is top of the stack so it is performed first). 

This PR fixes `List.traverse` to perform the effects in left to right order and adds tests so we can see it working.

Counter-intuitively `List.sequence` for all appearances does the same traversal as the original `List.traverse` but it performs the effects in the correct left to right order (I have added tests for `List.sequence` but the implementation is unchanged). 

The new implementation `List.traverse` is a bit tricky - to get left-to-right effects and to not escape the applicative context, the implementation is not in CPS. Instead it it builds an "applicative DList" so we can build the answer list in the correct order and avoid doing a reverse in a post-processing step.