### PR TITLE
fix: Allow underscores within math, greek, and operator names

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1757,21 +1757,21 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       * A greek identifier.
       */
     def GreekName: Rule1[Name.Ident] = rule {
-      SP ~ capture(oneOrMore(Letters.GreekLetter)) ~ SP ~> Name.Ident
+      SP ~ capture(optional("_") ~ oneOrMore(Letters.GreekLetter)) ~ SP ~> Name.Ident
     }
 
     /**
       * A math identifier.
       */
     def MathName: Rule1[Name.Ident] = rule {
-      SP ~ capture(oneOrMore(Letters.MathLetter)) ~ SP ~> Name.Ident
+      SP ~ capture(optional("_") ~ oneOrMore(Letters.MathLetter)) ~ SP ~> Name.Ident
     }
 
     /**
       * An operator identifier.
       */
     def OperatorName: Rule1[Name.Ident] = rule {
-      SP ~ capture(oneOrMore(Letters.OperatorLetter)) ~ SP ~> Name.Ident
+      SP ~ capture(optional("_") ~ oneOrMore(Letters.OperatorLetter)) ~ SP ~> Name.Ident
     }
 
     /**
@@ -1825,7 +1825,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     def QualifiedType: Rule1[Name.QName] = UpperCaseQName
 
     def Variable: Rule1[Name.Ident] = rule {
-      LowerCaseName | Wildcard | GreekName | MathName
+      LowerCaseName | GreekName | MathName | Wildcard
     }
 
     def JavaIdentifier: Rule1[String] = rule {

--- a/main/test/flix/Test.Unused.Def.flix
+++ b/main/test/flix/Test.Unused.Def.flix
@@ -1,0 +1,21 @@
+namespace Test/Unused/Def {
+
+    // NB: Compile, but not execute.
+    def _unusedDef01(): Int32 =
+        ?hole
+
+    // NB: Compile, but not execute.
+    // Unused math name
+    def _√(): Int32 =
+        ?hole
+
+    // NB: Compile, but not execute.
+    // Unused greek name
+    def _Χαίρετε(): Int32 =
+        ?hole
+
+    // NB: Compile, but not execute.
+    // Unused operator name
+    def _>==>(): Int32 =
+        ?hole
+}

--- a/main/test/flix/Test.Unused.Var.flix
+++ b/main/test/flix/Test.Unused.Var.flix
@@ -90,4 +90,19 @@ namespace Test/Unused/Var {
             case foo => ?hole
         }
 
+    @test
+    def testUnusedVar15(): Int32 =
+        let _⊆ = 123;
+        456
+
+    @test
+    def testUnusedVar16(): Int32 =
+        let _αναγνωριστικό = 123;
+        456
+
+    // Operator names not currently allowed for variables
+    // @test
+    // def testUnusedVar17(): Int32 =
+    //     let _<*> = 123;
+    //     456
 }


### PR DESCRIPTION
Fixes #4422