### PR TITLE
fix: make traverse implementations run left-to-right

### DIFF
--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -1315,8 +1315,8 @@ namespace DelayList {
     pub def traverse(f: a -> m[b] \ ef, l: DelayList[a]): m[DelayList[b]] \ ef with Applicative[m] =
         def loop(ll, k) = match ll {
             case ENil         => k(Applicative.point(ENil))
-            case ECons(x, xs) => loop(xs, ks -> k(consA(f(x), ks)))
-            case LCons(x, xs) => loop(force xs, ks -> k(consA(f(x), ks)))
+            case ECons(x, xs) => {let ans = f(x); loop(xs, ks -> k(consA(ans, ks)))}
+            case LCons(x, xs) => {let ans = f(x); loop(force xs, ks -> k(consA(ans, ks)))}
             case LList(xs)    => loop(force xs, k)
         };
         loop(l, upcast(identity)) // NB: Cast required because the identity continuation is pure,

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -1377,7 +1377,7 @@ namespace List {
         List.foldRight((x, acc) -> DelayMap.insert(fst(x), snd(x), acc), DelayMap.empty(), l)
 
     ///
-    /// Helper function for `sequence`.
+    /// Helper function for `sequence` and `traverse`.
     ///
     /// Builds an "applicative list" from a head of one applicative action and an
     /// applicative list of the tail.
@@ -1399,31 +1399,15 @@ namespace List {
         loop(l, identity)
 
     ///
-    /// Helper function for `traverse`.
-    ///
-    /// Builds an "applicative DList" from a head of one applicative action and an
-    /// applicative list of the tail.
-    ///
-    /// This is a version of `consA` except it builds a DList rather than a regular
-    /// List within the applicative context. We use the DList within `traverse` to
-    /// avoid having to reverse the accumulated results list at the end of the traversal.
-    ///
-    def consAD(mx: f[a], ml: f[List[a] -> List[a]]): f[List[a]-> List[a]] with Applicative[f] =
-        use Functor.{<$>};
-        use Applicative.{<*>};
-        (((ks, x) -> (k -> x :: k) >> ks) <$> ml) <*> mx
-
-
-    ///
     /// Returns the result of applying the applicative mapping function `f` to all the elements of the
     /// list `l` going from left to right.
     ///
     pub def traverse(f: a -> m[b] \ ef, l: List[a]): m[List[b]] \ ef with Applicative[m] =
-        def loop(ll, acc) = match ll {
-            case Nil     => Applicative.ap(acc, Applicative.point(Nil))
-            case x :: xs => let ans = f(x); loop(xs, consAD(ans, acc))
+        def loop(ll, k) = match ll {
+            case Nil     => k(Applicative.point(Nil))
+            case x :: xs => {let ans = f(x); loop(xs, ks -> k(consA(ans, ks)))}
         };
-        loop(l, Applicative.point(upcast(identity)))
+        loop(l, upcast(identity))
 
     ///
     /// Merges the two lists `l1` and `l2`. Assuming they are both sorted.

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -906,7 +906,7 @@ namespace Nec {
     pub def traverse(f: a -> m[b] \ ef, c: Nec[a]): m[Nec[b]] \ ef with Applicative[m] =
         def loop(l2, k) = match viewLeft(l2) {
             case OneLeft(x)      => k(NecOne <$> f(x))
-            case SomeLeft(x, rs) => loop(rs, ks -> k(consA(f(x), ks)))
+            case SomeLeft(x, rs) => {let ans = f(x); loop(rs, ks -> k(consA(ans, ks)))}
         };
         loop(c, upcast(identity))
 

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -906,20 +906,23 @@ namespace RedBlackTree {
     ///
     /// Build a node applicatively.
     ///
-    /// This is a helper function for `mapAWithKeyHelper`.
+    /// This is a helper function for `mapAWithKey`.
     ///
     def nodeA(color: Color, left: m[RedBlackTree[k, v]], k: k, value: m[v], right: m[RedBlackTree[k, v]]): m[RedBlackTree[k, v]] with Applicative[m] =
-        ((((l, v, r) -> Node(color, l, k, v, r)) `Functor.map` left) `Applicative.ap` value) `Applicative.ap` right
+        use Functor.{<$>};
+        use Applicative.{<*>};
+        ((((l, v, r) -> Node(color, l, k, v, r)) <$> left) <*> value) <*> right
 
     ///
     /// Returns a RedBlackTree with mappings `k => f(v)` for every `k => v` in `t`.
     ///
     pub def mapAWithKey(f: (k, v1) -> m[v2] \ ef, t: RedBlackTree[k, v1]): m[RedBlackTree[k, v2]] \ ef with Applicative[m] =
         def loop(tt, k) = match tt {
-            case Node(color, left, key, v, right) => loop(left, kl -> loop(right, kr -> k(nodeA(color, kl, key, f(key, v), kr))))
+            case Node(color, left, key, v, right) => loop(left, kl -> {let ans = f(key, v); loop(right, kr -> k(nodeA(color, kl, key, ans, kr)))})
             case _                                => k(Applicative.point(Leaf))
         };
         loop(t, upcast(identity))
+
 
     ///
     /// Applies `cmp` over the tree `t` in parallel and optionally returns the lowest

--- a/main/test/ca/uwaterloo/flix/library/TestChain.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestChain.flix
@@ -1759,36 +1759,24 @@ namespace TestChain {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def sequence01(): Bool = region r {
-        let st = ref 0 @ r;
-        let c = Chain.map(x -> {st := x; Identity(x)}, Chain.empty());
-        let ans = Chain.sequence(c);
-        ans == Identity(Chain.empty()) and deref st == 0
-    }
+    def sequence01(): Bool =
+        let c: Chain[Identity[Int32]] = Chain.empty();
+        Chain.sequence(c) == Identity(Chain.empty())
 
     @test
-    def sequence02(): Bool = region r {
-        let st = ref 0 @ r;
-        let c = Chain.map(x -> {st := x; Identity(x)}, Chain.singleton(1));
-        let ans = Chain.sequence(c);
-        ans == Identity(Chain.singleton(1)) and deref st == 1
-    }
+    def sequence02(): Bool =
+        let c = Chain.singleton(Identity(1));
+        Chain.sequence(c) == Identity(Chain.singleton(1))
 
     @test
-    def sequence03(): Bool = region r {
-        let st = ref 0 @ r;
-        let c = Chain.map(x -> {st := x; Identity(x)}, List.toChain(1 :: 2 :: Nil));
-        let ans = Chain.sequence(c);
-        ans == Identity(List.toChain(1 :: 2 :: Nil)) and deref st == 2
-    }
+    def sequence03(): Bool =
+        let c = List.toChain(Identity(1) :: Identity(2) :: Nil);
+        Chain.sequence(c) == Identity(List.toChain(1 :: 2 :: Nil))
 
     @test
-    def sequence04(): Bool = region r {
-        let st = ref 0 @ r;
-        let c = Chain.map(x -> {st := x; Identity(x)}, List.toChain(1 :: 2 :: 3 :: Nil));
-        let ans = Chain.sequence(c);
-        ans == Identity(List.toChain(1 :: 2 :: 3 :: Nil)) and deref st == 3
-    }
+    def sequence04(): Bool =
+        let c = List.toChain(Identity(1) :: Identity(2) :: Identity(3) :: Nil);
+        Chain.sequence(c) == Identity(List.toChain(1 :: 2 :: 3 :: Nil))
 
     /////////////////////////////////////////////////////////////////////////////
     // traverse                                                                //

--- a/main/test/ca/uwaterloo/flix/library/TestChain.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestChain.flix
@@ -1754,6 +1754,77 @@ namespace TestChain {
     def sortWith13(): Bool =
         Chain.sortWith(flip(cmp), List.toChain(2 :: 3 :: 0 :: 4 :: 1 :: 2 :: Nil)) == List.toChain(4 :: 3 :: 2 :: 2 :: 1 :: 0 :: Nil)
 
+    /////////////////////////////////////////////////////////////////////////////
+    // sequence                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def sequence01(): Bool = region r {
+        let st = ref 0 @ r;
+        let c = Chain.map(x -> {st := x; Identity(x)}, Chain.empty());
+        let ans = Chain.sequence(c);
+        ans == Identity(Chain.empty()) and deref st == 0
+    }
+
+    @test
+    def sequence02(): Bool = region r {
+        let st = ref 0 @ r;
+        let c = Chain.map(x -> {st := x; Identity(x)}, Chain.singleton(1));
+        let ans = Chain.sequence(c);
+        ans == Identity(Chain.singleton(1)) and deref st == 1
+    }
+
+    @test
+    def sequence03(): Bool = region r {
+        let st = ref 0 @ r;
+        let c = Chain.map(x -> {st := x; Identity(x)}, List.toChain(1 :: 2 :: Nil));
+        let ans = Chain.sequence(c);
+        ans == Identity(List.toChain(1 :: 2 :: Nil)) and deref st == 2
+    }
+
+    @test
+    def sequence04(): Bool = region r {
+        let st = ref 0 @ r;
+        let c = Chain.map(x -> {st := x; Identity(x)}, List.toChain(1 :: 2 :: 3 :: Nil));
+        let ans = Chain.sequence(c);
+        ans == Identity(List.toChain(1 :: 2 :: 3 :: Nil)) and deref st == 3
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // traverse                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def traverse01(): Bool = region r {
+        let st = ref 0 @ r;
+        let c = Chain.empty();
+        let ans = Chain.traverse(x -> {st := x; Identity(x)}, c);
+        ans == Identity(Chain.empty()) and deref st == 0
+    }
+
+    @test
+    def traverse02(): Bool = region r {
+        let st = ref 0 @ r;
+        let c = Chain.singleton(1);
+        let ans = Chain.traverse(x -> {st := x; Identity(x)}, c);
+        ans == Identity(Chain.singleton(1)) and deref st == 1
+    }
+
+    @test
+    def traverse03(): Bool = region r {
+        let st = ref 0 @ r;
+        let c = List.toChain(1 :: 2 :: Nil);
+        let ans = Chain.traverse(x -> {st := x; Identity(x)}, c);
+        ans == Identity(List.toChain(1 :: 2 :: Nil)) and deref st == 2
+    }
+
+    @test
+    def traverse04(): Bool = region r {
+        let st = ref 0 @ r;
+        let c = List.toChain(1 :: 2 :: 3 :: Nil);
+        let ans = Chain.traverse(x -> {st := x; Identity(x)}, c);
+        ans == Identity(List.toChain(1 :: 2 :: 3 :: Nil)) and deref st == 3
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // join                                                                    //

--- a/main/test/ca/uwaterloo/flix/library/TestDelayList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestDelayList.flix
@@ -2938,6 +2938,66 @@ namespace TestDelayList {
         DelayList.ap(f, l) |> DelayList.toList == 1 :: 5 :: 0 :: 8 :: Nil
 
     /////////////////////////////////////////////////////////////////////////////
+    // sequence                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def sequence01(): Bool =
+        let l: DelayList[Identity[Int32]] = ENil;
+        DelayList.sequence(l) == Identity(ENil)
+
+    @test
+    def sequence02(): Bool =
+        let l = List.toDelayList(Identity(1) :: Nil);
+        DelayList.sequence(l) == Identity(List.toDelayList(1 :: Nil))
+
+    @test
+    def sequence03(): Bool =
+        let l = List.toDelayList(Identity(1) :: Identity(2) :: Nil);
+        DelayList.sequence(l) == Identity(List.toDelayList(1 :: 2 :: Nil))
+
+    @test
+    def sequence04(): Bool =
+        let l = List.toDelayList(Identity(1) :: Identity(2) :: Identity(3) :: Nil);
+        DelayList.sequence(l) == Identity(List.toDelayList(1 :: 2 :: 3 :: Nil))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // traverse                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def traverse01(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = ENil;
+        let ans = DelayList.traverse(x -> {st := x; Identity(x)}, l);
+        ans == Identity(ENil) and deref st == 0
+    }
+
+    @test
+    def traverse02(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = List.toDelayList(1 :: Nil);
+        let ans = DelayList.traverse(x -> {st := x; Identity(x)}, l);
+        ans == Identity(List.toDelayList(1 :: Nil)) and deref st == 1
+    }
+
+    @test
+    def traverse03(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = List.toDelayList(1 :: 2 :: Nil);
+        let ans = DelayList.traverse(x -> {st := x; Identity(x)}, l);
+        ans == Identity(List.toDelayList(1 :: 2 :: Nil)) and deref st == 2
+    }
+
+    @test
+    def traverse04(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = List.toDelayList(1 :: 2 :: 3 :: Nil);
+        let ans = DelayList.traverse(x -> {st := x; Identity(x)}, l);
+        ans == Identity(List.toDelayList(1 :: 2 :: 3 :: Nil)) and deref st == 3
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
     // shuffle                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -2749,37 +2749,30 @@ def distinctWith09(): Bool =
     // sequence                                                                //
     /////////////////////////////////////////////////////////////////////////////
 
-    @test
-    def sequence01(): Bool = region r {
-        let st = ref 0 @ r;
-        let l = List.map(x -> {st := x; Identity(x)}, Nil);
-        let ans = List.sequence(l);
-        ans == Identity(Nil) and deref st == 0
-    }
+    /// TODO - this does not test order of effects.
+    /// We need a more "effective" monad than Identity to show that effects are
+    /// sequenced in left-to-right order.
+    /// This applies to the `sequence` tests on the other container types as well.
 
     @test
-    def sequence02(): Bool = region r {
-        let st = ref 0 @ r;
-        let l = List.map(x -> {st := x; Identity(x)}, 1 :: Nil);
-        let ans = List.sequence(l);
-        ans == Identity(1 :: Nil) and deref st == 1
-    }
+    def sequence01(): Bool =
+        let l: List[Identity[Int32]] = Nil;
+        List.sequence(l) == Identity(Nil)
 
     @test
-    def sequence03(): Bool = region r {
-        let st = ref 0 @ r;
-        let l = List.map(x -> {st := x; Identity(x)}, 1 :: 2 :: Nil);
-        let ans = List.sequence(l);
-        ans == Identity(1 :: 2 :: Nil) and deref st == 2
-    }
+    def sequence02(): Bool =
+        let l = Identity(1) :: Nil;
+        List.sequence(l) == Identity(1 :: Nil)
 
     @test
-    def sequence04(): Bool = region r {
-        let st = ref 0 @ r;
-        let l = List.map(x -> {st := x; Identity(x)}, 1 :: 2 :: 3 :: Nil);
-        let ans = List.sequence(l);
-        ans == Identity(1 :: 2 :: 3 :: Nil) and deref st == 3
-    }
+    def sequence03(): Bool =
+        let l = Identity(1) :: Identity(2) :: Nil;
+        List.sequence(l) == Identity(1 :: 2 :: Nil)
+
+    @test
+    def sequence04(): Bool =
+        let l = Identity(1) :: Identity(2) :: Identity(3) :: Nil;
+        List.sequence(l) == Identity(1 :: 2 :: 3 :: Nil)
 
     /////////////////////////////////////////////////////////////////////////////
     // traverse                                                                //

--- a/main/test/ca/uwaterloo/flix/library/TestMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMap.flix
@@ -2505,6 +2505,101 @@ def query18(): Bool =
         List.zip(l, List.reverse(l)) |> List.toMap |> Map.iteratorValues(r) |> Iterator.toList == List.range(0, 100) |> List.reverse
     }
 
+    /////////////////////////////////////////////////////////////////////////////
+    // sequence                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def sequence01(): Bool =
+        let m: Map[Int32, Identity[Char]] = Map#{};
+        Map.sequence(m) == Identity(Map#{})
+
+    @test
+    def sequence02(): Bool =
+        let m = Map#{1 => Identity('a')};
+        Map.sequence(m) == Identity(Map#{1 => 'a'})
+
+    @test
+    def sequence03(): Bool =
+        let m = Map#{1 => Identity('a'), 2 => Identity('b')};
+        Map.sequence(m) == Identity(Map#{1 => 'a', 2 => 'b'})
+
+    @test
+    def sequence04(): Bool =
+        let m = Map#{1 => Identity('a'), 2 => Identity('b'), 3 => Identity('c')};
+        Map.sequence(m) == Identity(Map#{1 => 'a', 2 => 'b', 3 => 'c'})
+
+    /////////////////////////////////////////////////////////////////////////////
+    // traverse                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def traverse01(): Bool = region r {
+        let st = ref '#' @ r;
+        let m: Map[Int32, Char] = Map#{};
+        let ans = Map.traverse(x -> {st := x; Identity(x)}, m);
+        ans == Identity(Map#{}) and deref st == '#'
+    }
+
+    @test
+    def traverse02(): Bool = region r {
+        let st = ref '#' @ r;
+        let m = Map#{1 => 'a'};
+        let ans = Map.traverse(x -> {st := x; Identity(x)}, m);
+        ans == Identity(Map#{1 => 'a'}) and deref st == 'a'
+    }
+
+    @test
+    def traverse03(): Bool = region r {
+        let st = ref '#' @ r;
+        let m = Map#{1 => 'a', 2 => 'b'};
+        let ans = Map.traverse(x -> {st := x; Identity(x)}, m);
+        ans == Identity(Map#{1 => 'a', 2 => 'b'}) and deref st == 'b'
+    }
+
+    @test
+    def traverse04(): Bool = region r {
+        let st = ref '#' @ r;
+        let m = Map#{1 => 'a', 2 => 'b', 3 => 'c'};
+        let ans = Map.traverse(x -> {st := x; Identity(x)}, m);
+        ans == Identity(Map#{1 => 'a', 2 => 'b', 3 => 'c'}) and deref st == 'c'
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // traverseWithKey                                                         //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def traverseWithKey01(): Bool = region r {
+        let st = ref (0, '#') @ r;
+        let m: Map[Int32, Char] = Map#{};
+        let ans = Map.traverseWithKey((k, v) -> {st := (k, v); Identity(v)}, m);
+        ans == Identity(Map#{}) and deref st == (0, '#')
+    }
+
+    @test
+    def traverseWithKey02(): Bool = region r {
+        let st = ref (0, '#') @ r;
+        let m = Map#{1 => 'a'};
+        let ans = Map.traverseWithKey((k, v) -> {st := (k, v); Identity(v)}, m);
+        ans == Identity(Map#{1 => 'a'}) and deref st == (1, 'a')
+    }
+
+    @test
+    def traverseWithKey03(): Bool = region r {
+        let st = ref (0, '#') @ r;
+        let m = Map#{1 => 'a', 2 => 'b'};
+        let ans = Map.traverseWithKey((k, v) -> {st := (k, v); Identity(v)}, m);
+        ans == Identity(Map#{1 => 'a', 2 => 'b'}) and deref st == (2, 'b')
+    }
+
+    @test
+    def traverseWithKey04(): Bool = region r {
+        let st = ref (0, '#') @ r;
+        let m = Map#{1 => 'a', 2 => 'b', 3 => 'c'};
+        let ans = Map.traverseWithKey((k, v) -> {st := (k, v); Identity(v)}, m);
+        ans == Identity(Map#{1 => 'a', 2 => 'b', 3 => 'c'}) and deref st == (3, 'c')
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // joinKeys                                                                //

--- a/main/test/ca/uwaterloo/flix/library/TestNec.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestNec.flix
@@ -1386,6 +1386,21 @@ namespace TestNec {
     @test
     def sequence04(): Bool = Nec.sequence(necOf3(Some(1), Some(2), Some(3))) == Some(necOf3(1, 2, 3))
 
+    @test
+    def sequence05(): Bool =
+        let l = Nec.singleton(Identity(1));
+        Nec.sequence(l) == Identity(Nec.singleton(1))
+
+    @test
+    def sequence06(): Bool =
+        let l = necOf2(Identity(1), Identity(2));
+        Nec.sequence(l) == Identity(necOf2(1, 2))
+
+    @test
+    def sequence07(): Bool =
+        let l = necOf3(Identity(1), Identity(2), Identity(3));
+        Nec.sequence(l) == Identity(necOf3(1, 2, 3))
+
     /////////////////////////////////////////////////////////////////////////////
     // traverse                                                                //
     /////////////////////////////////////////////////////////////////////////////
@@ -1401,6 +1416,30 @@ namespace TestNec {
 
     @test
     def traverse04(): Bool = Nec.traverse(_ -> None: Option[Int32], necOf2(1, 2)) == None
+
+    @test
+    def traverse05(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = Nec.singleton(1);
+        let ans = Nec.traverse(x -> {st := x; Identity(x)}, l);
+        ans == Identity(Nec.singleton(1)) and deref st == 1
+    }
+
+    @test
+    def traverse06(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = necOf2(1, 2);
+        let ans = Nec.traverse(x -> {st := x; Identity(x)}, l);
+        ans == Identity(necOf2(1, 2)) and deref st == 2
+    }
+
+    @test
+    def traverse07(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = necOf3(1, 2, 3);
+        let ans = Nec.traverse(x -> {st := x; Identity(x)}, l);
+        ans == Identity(necOf3(1, 2, 3)) and deref st == 3
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // join                                                                    //

--- a/main/test/ca/uwaterloo/flix/library/TestNel.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestNel.flix
@@ -994,6 +994,53 @@ namespace TestNel {
     }
 
     /////////////////////////////////////////////////////////////////////////////
+    // sequence                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def sequence01(): Bool =
+        let l = Nel.singleton(Identity(1));
+        Nel.sequence(l) == Identity(Nel.singleton(1))
+
+    @test
+    def sequence02(): Bool =
+        let l = Nel.cons(Identity(1), Nel.singleton(Identity(2)));
+        Nel.sequence(l) == Identity(Nel.cons(1, Nel.singleton(2)))
+
+    @test
+    def sequence03(): Bool =
+        let l = Nel.cons(Identity(1), Nel.cons(Identity(2), Nel.singleton(Identity(3))));
+        Nel.sequence(l) == Identity(Nel.cons(1, Nel.cons(2, Nel.singleton(3))))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // traverse                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def traverse01(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = Nel.singleton(1);
+        let ans = Nel.traverse(x -> {st := x; Identity(x)}, l);
+        ans == Identity(Nel.singleton(1)) and deref st == 1
+    }
+
+    @test
+    def traverse02(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = Nel.cons(1, Nel.singleton(2));
+        let ans = Nel.traverse(x -> {st := x; Identity(x)}, l);
+        ans == Identity(Nel.cons(1, Nel.singleton(2))) and deref st == 2
+    }
+
+    @test
+    def traverse03(): Bool = region r {
+        let st = ref 0 @ r;
+        let l = Nel.cons(1, Nel.cons(2, Nel.singleton(3)));
+        let ans = Nel.traverse(x -> {st := x; Identity(x)}, l);
+        ans == Identity(Nel.cons(1, Nel.cons(2, Nel.singleton(3)))) and deref st == 3
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
     // toMapWith                                                               //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestRedBlackTree.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestRedBlackTree.flix
@@ -825,6 +825,45 @@ namespace TestRedBlackTree {
         d1 `MutDeque.sameElements` d2
     }
 
+
+    /////////////////////////////////////////////////////////////////////////////
+    // mapAWithKey (aka traverseWithKey)                                       //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def mapAWithKey01(): Bool = region r {
+        let st = ref '#' @ r;
+        let t: RedBlackTree.RedBlackTree[Int32, Char] = RedBlackTree.empty();
+        let ans = RedBlackTree.mapAWithKey((_, x) -> {st := x; Identity(x)}, t);
+        ans == Identity(RedBlackTree.empty()) and deref st == '#'
+    }
+
+    @test
+    def mapAWithKey02(): Bool = region r {
+        let st = ref '#' @ r;
+        let t = RedBlackTree.empty() |> RedBlackTree.insert(1, 'a');
+        let ans = RedBlackTree.mapAWithKey((_, x) -> {st := x; Identity(x)}, t);
+        ans == Identity(RedBlackTree.empty() |> RedBlackTree.insert(1, 'a')) and deref st == 'a'
+    }
+
+    @test
+    def mapAWithKey03(): Bool = region r {
+        let st = ref '#' @ r;
+        let t = RedBlackTree.empty() |> RedBlackTree.insert(1, 'a') |> RedBlackTree.insert(2, 'b');
+        let ans = RedBlackTree.mapAWithKey((_, x) -> {st := x; Identity(x)}, t);
+        ans == Identity(RedBlackTree.empty() |> RedBlackTree.insert(1, 'a') |> RedBlackTree.insert(2, 'b')) and deref st == 'b'
+    }
+
+    @test
+    def mapAWithKey04(): Bool = region r {
+        let st = ref '#' @ r;
+        let t = RedBlackTree.empty() |> RedBlackTree.insert(1, 'a') |> RedBlackTree.insert(2, 'b') |> RedBlackTree.insert(3, 'c');
+        let ans = RedBlackTree.mapAWithKey((_, x) -> {st := x; Identity(x)}, t);
+        ans == Identity(RedBlackTree.empty()
+                            |> RedBlackTree.insert(1, 'a')
+                            |> RedBlackTree.insert(2, 'b') |> RedBlackTree.insert(3, 'c')) and deref st == 'c'
+    }
+
     /////////////////////////////////////////////////////////////////////////////
     // iterator                                                                //
     /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR fixes the `traverse` implementations for `DelayList`, `Nec` and `RedBlackTree` (called `mapAWithKey`) to go left-to-right (this is a prelude to implementing `Traverse.mapAccumLeft` with mutable state).
    
It also simplifies the `List.traverse` fix from two days ago so the helper function `consAD` is no longer needed, and it adds `sequence` and `traverse` tests for the container types than provide them in their APIs.
    
The `sequence` tests for `List` from two days ago overstated their "effectiveness" (pun intended). The effects `sequence01` etc. were supposed to show were actually being performed by the `List.map` calls that preprocessed the input and not by the call to `List.sequence`. To show `List.sequence` running effects in left-to-right order, we would need a monad that does something effective unlike Identity. For the time being I've just simplified the tests so they show Identity being "lifted" from each element in the input list to the outer type constructor of the result list. To show that effects are run in left-to-right order we will need an imperative monad in the stdlib or implement a local one in the test suite.

This caveat for the `sequence` tests doesn't apply to the `traverse` tests because `traverse` is supplied with a function to run in the traversal and this function can be effective.