### PR TITLE
fix: reject `par` `Apply` instead of crashing

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -344,6 +344,6 @@ object SafetyError {
     }
 
     override def explain(formatter: Formatter): Option[String] =
-      Some("Only tuples and function applications can be parallelized with par.")
+      Some("Only tuples can be parallelized with par.")
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -255,9 +255,6 @@ object Safety {
     case Expression.Par(exp: Expression.Tuple, _) =>
       visitExp(exp)
 
-    case Expression.Par(exp: Expression.Apply, _) =>
-      visitExp(exp)
-
     case Expression.Par(e, _) =>
       IllegalParExpression(e, e.loc) :: Nil
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -252,11 +252,12 @@ object Safety {
     case Expression.Spawn(exp, _, _, _, _) =>
       visitExp(exp)
 
-    case Expression.Par(exp: Expression.Tuple, _) =>
-      visitExp(exp)
-
-    case Expression.Par(e, _) =>
-      IllegalParExpression(e, e.loc) :: Nil
+    case Expression.Par(exp, _) =>
+      // Only tuple expressions are allowed to be parallelized with `par`.
+      exp match {
+        case e: Expression.Tuple => visitExp(e)
+        case _ => IllegalParExpression(exp, exp.loc) :: Nil
+      }
 
     case Expression.Lazy(exp, _, _) =>
       visitExp(exp)


### PR DESCRIPTION
Closes  #4491