### PR TITLE
refactor: reimplement Traversable.mapAccumLeft to use mutable state and remove mapAccumRight

### DIFF
--- a/main/src/library/Traversable.flix
+++ b/main/src/library/Traversable.flix
@@ -15,7 +15,8 @@
  */
 
 ///
-/// A type class for data structures that can be traversed with an applicative functor.
+/// A type class for data structures that can be traversed in left-to-right
+/// order with an applicative functor.
 ///
 pub class Traversable[t : Type -> Type] with Functor[t], Foldable[t] {
 
@@ -65,108 +66,16 @@ namespace Traversable {
     /// of the initial structure, like `foldLeft` it passes an updating accumulator through each step of the traversal.
     ///
     pub def mapAccumLeft(f: (acc, a) -> (acc, b) \ ef, start: acc, t: t[a]): (acc, t[b]) \ ef with Traversable[t] =
-        runContStateLeft(traverse(x1 -> ContStateLeft((k, s) -> let (s1, b) = f(s, x1); k(b, s1)), t), start) as \ ef
-
-    ///
-    /// Helper type for `mapAccumLeft`.
-    ///
-    /// ContStateLeft the type of the State monad implemented in CPS. In this case we just need
-    /// `Applicative.ap` so no Monad instance is defined.
-    ///
-    /// A simple implementation of the State monad bursts the stack when `mapAccumLeft` is run on large
-    /// collections, so use ContState the CPS-State monad instead.
-    ///
-    /// We use an Impure continuation so we can internally cast the `ef` of `mapAccumLeft` and not lose
-    /// impurity information.
-    ///
-    enum ContStateLeft[ef: Eff, ka: Type, s: Type, a: Type]((a -> s -> ka \ {IO, ef}) -> s -> ka \ {IO, ef})
-
-    ///
-    /// Helper function for ContStateLeft's implementations of `map` and `ap`.
-    ///
-    def applyLeft1(ma: ContStateLeft[ef, ka, s, a], st: s, cont: a -> s -> ka \ {IO, ef}): ka \ {IO, ef} =
-        let ContStateLeft(f) = ma;
-        f(cont, st)
-
-    ///
-    /// Returns the result (new state and answer) of applying `ma` to the initial state `st`.
-    ///
-    def runContStateLeft(ma: ContStateLeft[ef, (s, a), s, a], st: s): (s, a) \ {IO, ef} =
-        let ContStateLeft(f) = ma;
-        let cont = (a, s) -> (s, a) as \ {IO, ef};
-        f(cont, st)
-
-
-    instance Functor[ContStateLeft[ef1, ka, s]] {
-        pub def map(f: a -> b \ ef, ma: ContStateLeft[ef1, ka, s, a]): ContStateLeft[ef1, ka, s, b] \ ef =
-            upcast(() -> ContStateLeft((k, s) ->
-                applyLeft1(ma, s, (a, s1) -> k(f(a) as \ IO, s1))
-            ))()
-    }
-
-    instance Applicative[ContStateLeft[ef1, ka, s]] {
-        pub def point(x: a): ContStateLeft[ef1, ka, s, a] =
-            ContStateLeft((k, s) -> k(x, s))
-
-        pub def ap(mf: ContStateLeft[ef1, ka, s, a -> b \ ef], ma: ContStateLeft[ef1, ka, s, a]): ContStateLeft[ef1, ka, s, b] \ ef =
-            upcast(() -> ContStateLeft((k, s) ->
-                applyLeft1(mf, s, (f, s1) ->
-                    applyLeft1(ma, s1, (a, s2) ->
-                        k(f(a) as \ IO, s2)))
-            ))()
-    }
-
-    ///
-    /// Returns the result of applying `f` to the traversable structure `t` and the initial state `acc`.
-    /// The result is a pair of the final state and the updated copy of the structure.
-    ///
-    /// `mapAccumRight` is essentially the combination of `map` and `foldLeft` - like map it returns an updated copy
-    /// of the intial structure, like `foldRight` it passes an updating accumulator through each step of the traversal.
-    ///
-    pub def mapAccumRight(f: (acc, a) -> (acc, b) \ ef, start: acc, t: t[a]): (acc, t[b]) \ ef with Traversable[t] =
-        runContStateRight(traverse(x1 -> ContStateRight((k, s) -> let (s1, b) = f(s, x1); k(b, s1)), t), start) as \ ef
-
-
-    ///
-    /// Helper type for `mapAccumRight`.
-    ///
-    /// ContStateRight is exactly the same as ContStateLeft except the evaluation order of `ap` is flipped.
-    ///
-    enum ContStateRight[ef: Eff, ka: Type, s: Type, a: Type]((a -> s -> ka \ {IO, ef}) -> s -> ka \ {IO, ef})
-
-    ///
-    /// Helper function for ContStateRight's implementations of `map` and `ap`.
-    ///
-    def applyRight1(ma: ContStateRight[ef, ka, s, a], st: s, cont: a -> s -> ka \ {IO, ef}): ka \ {IO, ef} =
-        let ContStateRight(f) = ma;
-        f(cont, st)
-
-    ///
-    /// Returns the result (new state and answer) of applying `ma` to the initial state `st`.
-    ///
-    def runContStateRight(ma: ContStateRight[ef, (s, a), s, a], st: s): (s, a) \ {IO, ef} =
-        let ContStateRight(f) = ma;
-        let cont = (a, s) -> (s, a) as \ {IO, ef};
-        f(cont, st)
-
-
-    instance Functor[ContStateRight[ef1, ka, s]] {
-        pub def map(f: a -> b \ ef, ma: ContStateRight[ef1, ka, s, a]): ContStateRight[ef1, ka, s, b] \ ef =
-            upcast(() -> ContStateRight((k, s) ->
-                applyRight1(ma, s, (a, s1) -> k(f(a) as \ IO, s1))
-            ))()
-    }
-
-    instance Applicative[ContStateRight[ef1, ka, s]] {
-        pub def point(x: a): ContStateRight[ef1, ka, s, a] = ContStateRight((k, s) -> k(x, s))
-
-        pub def ap(mf: ContStateRight[ef1, ka, s, a -> b \ ef], ma: ContStateRight[ef1, ka, s, a]): ContStateRight[ef1, ka, s, b] \ ef =
-            upcast(() -> ContStateRight((k, s) ->
-                applyRight1(ma, s, (a, s1) ->
-                    applyRight1(mf, s1, (f, s2) ->
-                        k(f(a) as \ IO, s2)))
-            ))()
-    }
+        region r {
+            let acc = ref start @ r;
+            let Identity(tb) = t |> Traversable.traverse(x -> {
+                let st = deref acc;
+                let (acc1, b) = f(st, x);
+                acc := acc1;
+                Identity(b)
+            });
+            (deref acc, tb)
+        }
 
 }
 

--- a/main/test/ca/uwaterloo/flix/library/TestTraversable.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestTraversable.flix
@@ -16,7 +16,7 @@
 
 namespace TestTraversable {
 
-    use Traversable.{sequence, traverse, mapAccumLeft, mapAccumRight};
+    use Traversable.{sequence, traverse, mapAccumLeft};
 
 
     /////////////////////////////////////////////////////////////////////////////
@@ -102,21 +102,6 @@ namespace TestTraversable {
     def mapAccumLeftOption02(): Bool =
         let o: Option[Int32] = Some(1);
         mapAccumLeft((acc, x) -> (acc+1, x+acc), 10, o) == (11, Some(11))
-
-    /////////////////////////////////////////////////////////////////////////////
-    // mapAccumRightOption                                                     //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @test
-    def mapAccumRightOption01(): Bool =
-        let o: Option[Int32] = None;
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, o) == (10, None)
-
-    @test
-    def mapAccumRightOption02(): Bool =
-        let o: Option[Int32] = Some(1);
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, o) == (11, Some(11))
-
 
     /////////////////////////////////////////////////////////////////////////////
     // sequenceList                                                            //
@@ -206,30 +191,6 @@ namespace TestTraversable {
         mapAccumLeft((acc, x) -> (acc+1, x+acc), 10, xs) == (13, 11 :: 13 :: 15 :: Nil)
 
     /////////////////////////////////////////////////////////////////////////////
-    // mapAccumRightList                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @test
-    def mapAccumRightList01(): Bool =
-        let xs: List[Int32] = Nil;
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, xs) == (10, Nil)
-
-    @test
-    def mapAccumRightList02(): Bool =
-        let xs: List[Int32] = 1 :: Nil;
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, xs) == (11, 11 :: Nil)
-
-    @test
-    def mapAccumRightList03(): Bool =
-        let xs: List[Int32] = 1 :: 2 :: Nil;
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, xs) == (12, 12 :: 12 :: Nil)
-
-    @test
-    def mapAccumRightList04(): Bool =
-        let xs: List[Int32] = 1 :: 2 :: 3 :: Nil;
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, xs) == (13, 13 :: 13 :: 13 :: Nil)
-
-    /////////////////////////////////////////////////////////////////////////////
     // sequenceNel                                                             //
     /////////////////////////////////////////////////////////////////////////////
 
@@ -295,25 +256,6 @@ namespace TestTraversable {
     def mapAccumLeftNel03(): Bool =
         let xs: Nel[Int32] = Nel(1, 2 :: 3 :: Nil);
         mapAccumLeft((acc, x) -> (acc+1, x+acc), 10, xs) == (13, Nel(11, 13 :: 15 :: Nil))
-
-    /////////////////////////////////////////////////////////////////////////////
-    // mapAccumRightNel                                                        //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @test
-    def mapAccumRightNel01(): Bool =
-        let xs: Nel[Int32] = Nel(1, Nil);
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, xs) == (11, Nel(11, Nil))
-
-    @test
-    def mapAccumRightNel02(): Bool =
-        let xs: Nel[Int32] = Nel(1, 2 :: Nil);
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, xs) == (12, Nel(12, 12 :: Nil))
-
-    @test
-    def mapAccumRightNel03(): Bool =
-        let xs: Nel[Int32] = Nel(1, 2 :: 3 :: Nil);
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, xs) == (13, Nel(13, 13 :: 13 :: Nil))
 
     /////////////////////////////////////////////////////////////////////////////
     // sequenceChain                                                           //
@@ -403,30 +345,6 @@ namespace TestTraversable {
         mapAccumLeft((acc, x) -> (acc+1, x+acc), 10, xs) == (13, List.toChain(11 :: 13 :: 15 :: Nil))
 
     /////////////////////////////////////////////////////////////////////////////
-    // mapAccumRightChain                                                      //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @test
-    def mapAccumRightChain01(): Bool =
-        let xs: Chain[Int32] = Chain.empty();
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, xs) == (10, Chain.empty())
-
-    @test
-    def mapAccumRightChain02(): Bool =
-        let xs: Chain[Int32] = Chain.singleton(1);
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, xs) == (11, Chain.singleton(11))
-
-    @test
-    def mapAccumRightChain03(): Bool =
-        let xs: Chain[Int32] = List.toChain(1 :: 2 :: Nil);
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, xs) == (12, List.toChain(12 :: 12 :: Nil))
-
-    @test
-    def mapAccumRightChain04(): Bool =
-        let xs: Chain[Int32] = List.toChain(1 :: 2 :: 3 :: Nil);
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, xs) == (13, List.toChain(13 :: 13 :: 13 :: Nil))
-
-    /////////////////////////////////////////////////////////////////////////////
     // sequenceMap                                                             //
     /////////////////////////////////////////////////////////////////////////////
 
@@ -512,30 +430,6 @@ namespace TestTraversable {
     def mapAccumLeftMap04(): Bool =
         let m: Map[Int32, Int32]  = Map#{1 => 1, 2 => 2, 3 => 3};
         mapAccumLeft((acc, x) -> (acc+1, x+acc), 10, m) == (13, Map#{1 => 11, 2 => 13, 3 => 15})
-
-    /////////////////////////////////////////////////////////////////////////////
-    // mapAccumRightMap                                                        //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @test
-    def mapAccumRightMap01(): Bool =
-        let m: Map[Int32, Int32] = Map#{};
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, m) == (10, Map#{})
-
-    @test
-    def mapAccumRightMap02(): Bool =
-        let m: Map[Int32, Int32] = Map#{1 => 1};
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, m) == (11, Map#{1 => 11})
-
-    @test
-    def mapAccumRightMap03(): Bool =
-        let m: Map[Int32, Int32]  = Map#{1 => 1, 2 => 2};
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, m) == (12, Map#{1 => 12, 2 => 12})
-
-    @test
-    def mapAccumRightMap04(): Bool =
-        let m: Map[Int32, Int32]  = Map#{1 => 1, 2 => 2, 3 => 3};
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, m) == (13, Map#{1 => 13, 2 => 13, 3 => 13})
 
     /////////////////////////////////////////////////////////////////////////////
     /// Helper for RedBlackTree                                                //
@@ -630,30 +524,5 @@ namespace TestTraversable {
     def mapAccumLeftRedBlackTree04(): Bool =
         let m: RedBlackTree.RedBlackTree[Int32, Int32] = toRedBlackTree((1, 1) :: (2, 2) :: (3, 3) :: Nil);
         mapAccumLeft((acc, x) -> (acc+1, x+acc), 10, m) == (13, toRedBlackTree((1, 11) :: (2, 13) :: (3, 15) :: Nil))
-
-
-    /////////////////////////////////////////////////////////////////////////////
-    // mapAccumRightRedBlackTree                                               //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @test
-    def mapAccumRightRedBlackTree01(): Bool =
-        let m: RedBlackTree.RedBlackTree[Int32, Int32] = RedBlackTree.empty();
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, m) == (10, RedBlackTree.empty())
-
-    @test
-    def mapAccumRightRedBlackTree02(): Bool =
-        let m: RedBlackTree.RedBlackTree[Int32, Int32] = toRedBlackTree((1, 1) :: Nil);
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, m) == (11, toRedBlackTree((1, 11) :: Nil))
-
-    @test
-    def mapAccumRightRedBlackTree03(): Bool =
-        let m: RedBlackTree.RedBlackTree[Int32, Int32] = toRedBlackTree((1, 1) :: (2, 2) :: Nil);
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, m) == (12, toRedBlackTree((1, 12) :: (2, 12) :: Nil))
-
-    @test
-    def mapAccumRightRedBlackTree04(): Bool =
-        let m: RedBlackTree.RedBlackTree[Int32, Int32] = toRedBlackTree((1, 1) :: (2, 2) :: (3, 3) :: Nil);
-        mapAccumRight((acc, x) -> (acc+1, x+acc), 10, m) == (13, toRedBlackTree((1, 13) :: (2, 13) :: (3, 13) :: Nil))
 
 }


### PR DESCRIPTION
This PR re-implements `Traversable.mapAccumLeft` with mutable state. The previous version used a cont-state monad that used casts that were causing problems.

The PR also removes `Traversable.mapAccumRight` - unlike `mapAccumLeft` this cannot be written in terms of `Traverse.traverse`.