### PR TITLE
feat: Disallow semi-colons

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -151,7 +151,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
   def UsesOrImports: Rule1[Seq[ParsedAst.UseOrImport]] = rule {
     // It is important for documentation comments that whitespace is not consumed if no uses are present
-    oneOrMore(optWS ~ (Use | Import) ~ ((optWS ~ ";") | WS)) | push(Seq.empty)
+    oneOrMore(optWS ~ (Use | Import) ~ WS) | push(Seq.empty)
   }
 
   def Decls: Rule1[Seq[ParsedAst.Declaration]] = rule {


### PR DESCRIPTION
Follow-on for #4507, this can be merged whenever we decide we want to move from optional semi-colons after top-level uses and imports to no semi-colons.