### PR TITLE
feat: Set release version at build time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,8 +57,11 @@ sourceSets {
 }
 
 jar {
+    inputs.property("releaseVersion", findProperty("releaseVersion"))
+
     manifest {
         attributes 'Main-Class': 'ca.uwaterloo.flix.Main'
+        attributes 'Implementation-Version': inputs.properties['releaseVersion'] ?: ''
     }
 
     from {
@@ -66,7 +69,7 @@ jar {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
         configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
-    
+
     from('main') {
         include '**/*.flix'
         include '**/*.zip'

--- a/main/src/ca/uwaterloo/flix/api/Version.scala
+++ b/main/src/ca/uwaterloo/flix/api/Version.scala
@@ -20,7 +20,11 @@ object Version {
   /**
     * Represents the current version of Flix.
     */
-  val CurrentVersion: Version = Version(major = 0, minor = 31, revision = 0)
+  val CurrentVersion: Version = {
+    val version = Option(getClass).map(_.getPackage).map(_.getImplementationVersion).getOrElse("0.0.0")
+    val s"$major.$minor.$revision" = version
+    Version(major = major.toInt, minor = minor.toInt, revision = revision.toInt)
+  }
 }
 
 /**


### PR DESCRIPTION
This change allows setting the release version at build time via the `version` property. If no version is set, a `dev` version (0.0.0) is assumed.

This step is a prerequisite in creating a release pipeline.