### PR TITLE
fix: check variable essentialness in regions checks

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
@@ -448,7 +448,10 @@ object Regions {
     }
   }
 
-  // MATT docs
+  /**
+    * Returns true iff the type variable `tvar` is essential to the boolean formula `tpe`.
+    * Assumes that `tvar` is present in the type.
+    */
   def essentialToBool(tvar: Type.Var, tpe: Type)(implicit flix: Flix): Boolean = {
     val t0 = tpe.map {
       case t if t == tvar => Type.False
@@ -463,7 +466,9 @@ object Regions {
     !sameType(t0, t1)
   }
 
-  // MATT docs
+  /**
+    * Extracts all the boolean formulas from the given type `t0`.
+    */
   private def boolTypesOf(t0: Type): List[Type] = t0 match {
     case t if t.kind == Kind.Bool => List(t)
     case _: Type.Var => Nil
@@ -478,6 +483,11 @@ object Regions {
   private def sameType(t1: Type, t2: Type)(implicit flix: Flix): Boolean = {
     val tvars = t1.typeVars ++ t2.typeVars
 
+    /**
+      * Evaluates the given boolean formula,
+      * where `trueVars` are the variables ascribed the value TRUE,
+      * and all other variables are ascribed the value FALSE.
+      */
     def eval(tpe: Type, trueVars: SortedSet[Type.Var]): Boolean = tpe match {
       case Type.True => true
       case Type.False => false

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/BoolUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/BoolUnification.scala
@@ -118,7 +118,8 @@ object BoolUnification {
     * synthetic variables first.
     */
   private def computeVariableOrder(l: List[Int]): List[Int] = {
-    l.reverse // TODO have to reverse the order for regions to work
+//    l.reverse // TODO have to reverse the order for regions to work
+    l // MATT hacky test
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/BoolUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/BoolUnification.scala
@@ -118,8 +118,7 @@ object BoolUnification {
     * synthetic variables first.
     */
   private def computeVariableOrder(l: List[Int]): List[Int] = {
-//    l.reverse // TODO have to reverse the order for regions to work
-    l // MATT hacky test
+    l.reverse // TODO have to reverse the order for regions to work
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -391,12 +391,8 @@ object Unification {
       // Apply the current substitution to `tpe`.
       val t = TypeMinimization.minimizeType(s(tpe))
 
-      // Compute the type and effect variables that occur in `t`.
-//      val fvs = t.typeVars
-
-      // Ensure that `rvar` does not occur in `t` (e.g. being returned or as an effect).
-//      if (fvs.contains(rvar)) {
-      if (Regions.relevantTo(rvar, t)) {
+      // Check whether the region variable is essential to the type.
+      if (Regions.essentialTo(rvar, t)) {
         Err(TypeError.RegionVarEscapes(rvar, t, rvar.loc))
       } else
         Ok((s, renv, ()))

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -391,10 +391,8 @@ object Unification {
       // Apply the current substitution to `tpe`.
       val t = s(tpe)
 
-      val min = TypeMinimization.minimizeType(t)
-
       // Compute the type and effect variables that occur in `t`.
-      val fvs = min.typeVars
+      val fvs = t.typeVars
 
       // Ensure that `rvar` does not occur in `t` (e.g. being returned or as an effect).
 //      if (fvs.contains(rvar)) {

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.language.phase.unification
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast._
 import ca.uwaterloo.flix.language.errors.TypeError
+import ca.uwaterloo.flix.language.phase.Regions
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
 import ca.uwaterloo.flix.util.{InternalCompilerException, Result}
 
@@ -390,11 +391,14 @@ object Unification {
       // Apply the current substitution to `tpe`.
       val t = s(tpe)
 
+      val min = TypeMinimization.minimizeType(t)
+
       // Compute the type and effect variables that occur in `t`.
-      val fvs = t.typeVars
+      val fvs = min.typeVars
 
       // Ensure that `rvar` does not occur in `t` (e.g. being returned or as an effect).
-      if (fvs.contains(rvar)) {
+//      if (fvs.contains(rvar)) {
+      if (Regions.relevantTo(rvar, t)) {
         Err(TypeError.RegionVarEscapes(rvar, t, rvar.loc))
       } else
         Ok((s, renv, ()))

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -389,10 +389,10 @@ object Unification {
   def noEscapeM(rvar: Type.Var, tpe: Type)(implicit flix: Flix): InferMonad[Unit] =
     InferMonad { case (s, renv) =>
       // Apply the current substitution to `tpe`.
-      val t = s(tpe)
+      val t = TypeMinimization.minimizeType(s(tpe))
 
       // Compute the type and effect variables that occur in `t`.
-      val fvs = t.typeVars
+//      val fvs = t.typeVars
 
       // Ensure that `rvar` does not occur in `t` (e.g. being returned or as an effect).
 //      if (fvs.contains(rvar)) {


### PR DESCRIPTION
The problem is that the region checks assume that a type is fully minimized, but our minimization technique is not a true minimization, in that irrelevant variables may remain inside. This means that a region variable that is actually irrelevant to the formula may still appear in the formula and therefore be identified as escaping.

I've made a change where we no longer rely on minimization, and we instead explicitly check whether the variable is relevant to the formula. To see if a variable `r` is relevant in a type `t`, I calculate `t0 = t[r -> false]` and `t1 = t[r -> true]`. Then I check if `t0 == t1` modulo Boolean equivalence (where all type variables are rigid).

This seems to work, but we move from a state of "variable elimination order is related to errors" to "variable elimination order is related to Boolean formula explosion"