### PR TITLE
feat: Abbreviate instead of hide long inlay hints

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/InlayHintProvider.scala
@@ -53,10 +53,10 @@ object InlayHintProvider {
         val label = ": " + FormatType.formatType(minType)
 
         // Hide long inlay hints.
-        if (isTypeVar(minType) || label.length >= 14)
+        if (isTypeVar(minType))
           None
         else
-          Some(InlayHint(pos, label, Some(InlayHintKind.Type), Nil, ""))
+          Some(InlayHint(pos, abbreviate(label, 14), Some(InlayHintKind.Type), Nil, ""))
     }
   }
 
@@ -67,5 +67,16 @@ object InlayHintProvider {
     case Type.Var(_, _) => true
     case _ => false
   }
+
+  /**
+    * Returns `s` if it less than or equal to `l` chars.
+    *
+    * Otherwise returns a prefix of `s` with …
+    */
+  private def abbreviate(s: String, l: Int): String =
+    if (s.length <= l)
+      s
+    else
+      s.substring(0, l - 1) + "…"
 
 }


### PR DESCRIPTION
This modifies inlay hints so that instead of hiding long hints, they're now abbreviated. So instead of this:

<img width="758" alt="Screenshot-2022-10-08-at-16 08 04" src="https://user-images.githubusercontent.com/61163/194716084-ab12b373-907f-4c3b-97c7-1a574bfa074c.png">

We now have this:

<img width="758" alt="Screenshot 2022-10-08 at 16 48 12" src="https://user-images.githubusercontent.com/61163/194716088-c15b9af5-d8cc-422e-9afd-36e8659c18a4.png">

A couple of things to perhaps consider before merging this:

* I've left the length of a "long" inlay hint at 14 characters. Other languages [apparently use 30 characters](https://github.com/ionide/ionide-vscode-fsharp/issues/1694), we might want to follow suit?
* I've (almost) copied the `truncate` function from `ProgressBar.scala`, which might not be the right thing to do. Is there somewhere where this kind of utility should live?
* The difference between my copy of `truncate` and the one in `ProgressBar.scala` is that I'm using the Unicode ellipsis character `…` instead of three periods `...`. This strikes me as the right thing to do given that space is at a premium in inlay hints, but I'm open to being persuaded otherwise.