### PR TITLE
fix: Towards fixing duplicate names

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -229,6 +229,8 @@ class Flix {
     "Fixpoint/Ram/RowVar.flix" -> LocalResource.get("/src/library/Fixpoint/Ram/RowVar.flix"),
 
     "Fixpoint/Shared/PredSym.flix" -> LocalResource.get("/src/library/Fixpoint/Shared/PredSym.flix"),
+    
+    "Fixpoint/Tuple/Tuple.flix" -> LocalResource.get("/src/library/Fixpoint/Tuple/Tuple.flix"),
 
     "Graph.flix" -> LocalResource.get("/src/library/Graph.flix"),
   )

--- a/main/src/library/Fixpoint/Interpreter.flix
+++ b/main/src/library/Fixpoint/Interpreter.flix
@@ -19,61 +19,6 @@ use Fixpoint/Ast.Denotation
 use Fixpoint/Tuple.Tuple
 
 namespace Fixpoint {
-    namespace Tuple {
-
-        ///
-        /// Uses unsafe immutable array internally for performance.
-        ///
-        pub opaque enum Tuple[v] {
-            case Tuple(Array[v, Static])
-        }
-
-        // NB: Unsafe instance.
-        instance Eq[Tuple[v]] with Eq[v] {
-            pub def eq(x: Tuple[v], y: Tuple[v]): Bool =
-                let Tuple(a) = x;
-                let Tuple(b) = y;
-                Array.sameElements(a, b) as \ {}
-        }
-
-        // NB: Unsafe instance.
-        instance Order[Tuple[v]] with Order[v] {
-            pub def compare(x: Tuple[v], y: Tuple[v]): Comparison =
-                let Tuple(a) = x;
-                let Tuple(b) = y;
-                Array.compare(a, b) as \ {}
-        }
-
-        ///
-        /// Creates an empty tuple consisting of the elements in `l`.
-        ///
-        pub def new(l: f[v]): Tuple[v] with Foldable[f] =
-            Tuple(Foldable.toArray(Static, l)) as \ {}
-
-        ///
-        /// Converts `t` to a list.
-        ///
-        pub def toList(t: Tuple[v]): List[v] = {
-            let Tuple(a) = t;
-            Array.toList(a)
-        } as \ {}
-
-        ///
-        /// Returns the length of `t`.
-        ///
-        pub def length(t: Tuple[v]): Int32 =
-            let Tuple(a) = t;
-            Array.length(a)
-
-        ///
-        /// Returns the value at index `i` in `t`.
-        /// Throws a runtime exception if `v` is out of bounds.
-        ///
-        pub def valueAt(t: Tuple[v], v: Int32): v = {
-            let Tuple(a) = t;
-            a[v]
-        } as \ {}
-    }
 
     type alias Database[v: Type, r: Region] = MutMap[RamSym[v], MutMap[Tuple[v], v, r], r]
     type alias SearchEnv[v: Type, r: Region] = (Array[Tuple[v], r], Array[v, r])

--- a/main/src/library/Fixpoint/Tuple/Tuple.flix
+++ b/main/src/library/Fixpoint/Tuple/Tuple.flix
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Benjamin Dahse
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Fixpoint/Tuple {
+
+    ///
+    /// Uses unsafe immutable array internally for performance.
+    ///
+    pub opaque enum Tuple[v] {
+        case Tuple(Array[v, Static])
+    }
+
+    // NB: Unsafe instance.
+    instance Eq[Tuple[v]] with Eq[v] {
+        pub def eq(x: Tuple[v], y: Tuple[v]): Bool =
+            let Tuple(a) = x;
+            let Tuple(b) = y;
+            Array.sameElements(a, b) as \ {}
+    }
+
+    // NB: Unsafe instance.
+    instance Order[Tuple[v]] with Order[v] {
+        pub def compare(x: Tuple[v], y: Tuple[v]): Comparison =
+            let Tuple(a) = x;
+            let Tuple(b) = y;
+            Array.compare(a, b) as \ {}
+    }
+
+    ///
+    /// Creates an empty tuple consisting of the elements in `l`.
+    ///
+    pub def new(l: f[v]): Tuple[v] with Foldable[f] =
+        Tuple(Foldable.toArray(Static, l)) as \ {}
+
+    ///
+    /// Converts `t` to a list.
+    ///
+    pub def toList(t: Tuple[v]): List[v] = {
+        let Tuple(a) = t;
+        Array.toList(a)
+    } as \ {}
+
+    ///
+    /// Returns the length of `t`.
+    ///
+    pub def length(t: Tuple[v]): Int32 =
+        let Tuple(a) = t;
+        Array.length(a)
+
+    ///
+    /// Returns the value at index `i` in `t`.
+    /// Throws a runtime exception if `v` is out of bounds.
+    ///
+    pub def valueAt(t: Tuple[v], v: Int32): v = {
+        let Tuple(a) = t;
+        a[v]
+    } as \ {}
+}

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -921,18 +921,18 @@ class TestNamer extends FunSuite with TestUtils {
     expectError[NameError.DuplicateUpperName](result)
   }
 
-  // test("DuplicateUpperName.23") {
-  //   val input =
-  //     """
-  //       |import java.sql.Statement
-  //       |use A.Statement
-  //       |namespace A {
-  //       |    enum Statement
-  //       |}
-  //       |""".stripMargin
-  //   val result = compile(input, Options.TestWithLibNix)
-  //   expectError[NameError.DuplicateUpperName](result)
-  // }
+  ignore("DuplicateUpperName.23") {
+    val input =
+      """
+        |import java.sql.Statement
+        |use A.Statement
+        |namespace A {
+        |    enum Statement
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
 
   test("DuplicateUpperName.24") {
     val input =

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -901,6 +901,52 @@ class TestNamer extends FunSuite with TestUtils {
     expectError[NameError.DuplicateUpperName](result)
   }
 
+  test("DuplicateUpperName.21") {
+    val input =
+      """
+        |import java.sql.Statement
+        |enum Statement
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
+
+  test("DuplicateUpperName.22") {
+    val input =
+      """
+        |enum Statement
+        |type alias Statement = Int
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
+
+  // test("DuplicateUpperName.23") {
+  //   val input =
+  //     """
+  //       |import java.sql.Statement
+  //       |use A.Statement
+  //       |namespace A {
+  //       |    enum Statement
+  //       |}
+  //       |""".stripMargin
+  //   val result = compile(input, Options.TestWithLibNix)
+  //   expectError[NameError.DuplicateUpperName](result)
+  // }
+
+  test("DuplicateUpperName.24") {
+    val input =
+      """
+        |use A.Statement
+        |namespace A {
+        |    enum Statement
+        |}
+        |enum Statement
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
+
   test("SuspiciousTypeVarName.01") {
     val input =
       s"""

--- a/main/test/flix/Test.Use.Type.flix
+++ b/main/test/flix/Test.Use.Type.flix
@@ -1,12 +1,13 @@
-use A.Color
-use A/B.Currency
-use A/B.Kelvin
-use A.{Color => MyColor}
-use A/B.{Currency => MyCurrency}
-use A/B.Meter
-use A/B.{Meter => MyMeter}
 
 namespace X {
+    use A.Color
+    use A/B.Currency
+    use A/B.Kelvin
+    use A.{Color => MyColor}
+    use A/B.{Currency => MyCurrency}
+    use A/B.Meter
+    use A/B.{Meter => MyMeter}
+
     pub def f(): Color = Color.Red
     pub def g(): Color = Color.Red
     pub def h(): Currency = Currency.USD


### PR DESCRIPTION
Part of  #4649

This fixes cases where the names of classes, enums, aliases, or effects clash with the names of used or imported types. It doesn't fix the case where used types clash with imported types (see commented out test in `TestNamer` for an example).

I think that the right way to address the latter is to merge `ImportEnv` into `UseEnv`, but that involves largely undoing the change I made a while ago to plumb `ImportEnv` through the namer. Given that that means hundreds of lines changing (eugh!) I wanted to check this in separately.

A note about testing: To test this exhaustively, we would have to test every possible combination of classes, enums, aliases, effects, uses and imports, with various different levels of nesting. I've only added a subset of the missing combinations: I'm not sure how much value there is in adding all the combinations, but will do so if we think it useful.