### PR TITLE
refactor: rename TypeConstructor.Region -> TypeConstructor.RegionToStar

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -671,7 +671,7 @@ object SemanticTokensProvider {
     case TypeConstructor.Complement => false
     case TypeConstructor.Union => false
     case TypeConstructor.Intersection => false
-    case TypeConstructor.Region => false
+    case TypeConstructor.RegionToStar => false
     case TypeConstructor.Empty => false
     case TypeConstructor.All => false
   }

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -872,7 +872,7 @@ object Type {
     * Returns a Region type for the given region argument `r` with the given source location `loc`.
     */
   def mkRegion(r: Type, loc: SourceLocation): Type =
-    Type.Apply(Type.Cst(TypeConstructor.Region, loc), r, loc)
+    Type.Apply(Type.Cst(TypeConstructor.RegionToStar, loc), r, loc)
 
   /**
     * Returns the type `tpe1 => tpe2`.

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -312,11 +312,11 @@ object TypeConstructor {
   }
 
   /**
-    * A type constructor that represent the type of regions.
+    * A type constructor that converts a region to a Star type.
     */
-  case object Region extends TypeConstructor {
+  case object RegionToStar extends TypeConstructor {
     /**
-      * The shape of a region is Region[l].
+      * The shape of a star-kind region is Region[l].
       */
     def kind: Kind = Kind.Bool ->: Kind.Star
   }

--- a/main/src/ca/uwaterloo/flix/language/fmt/SimpleType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/SimpleType.scala
@@ -524,7 +524,7 @@ object SimpleType {
           }
 
         case TypeConstructor.Effect(sym) => mkApply(SimpleType.Name(sym.name), t.typeArguments.map(visit))
-        case TypeConstructor.Region => mkApply(Region, t.typeArguments.map(visit))
+        case TypeConstructor.RegionToStar => mkApply(Region, t.typeArguments.map(visit))
         case TypeConstructor.Empty => SimpleType.Empty
         case TypeConstructor.All => SimpleType.All
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
@@ -450,7 +450,7 @@ object Finalize {
 
             case TypeConstructor.Ref => MonoType.Ref(args.head)
 
-            case TypeConstructor.Region =>
+            case TypeConstructor.RegionToStar =>
               MonoType.Unit // TODO: Should be erased?
 
             case TypeConstructor.Tuple(l) => MonoType.Tuple(args)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1757,7 +1757,7 @@ object Resolver {
       case "Lazy" => UnkindedType.Cst(TypeConstructor.Lazy, loc).toSuccess
       case "Array" => UnkindedType.Cst(TypeConstructor.Array, loc).toSuccess
       case "Ref" => UnkindedType.Cst(TypeConstructor.Ref, loc).toSuccess
-      case "Region" => UnkindedType.Cst(TypeConstructor.Region, loc).toSuccess
+      case "Region" => UnkindedType.Cst(TypeConstructor.RegionToStar, loc).toSuccess
 
       // Disambiguate type.
       case typeName =>
@@ -2646,7 +2646,7 @@ object Resolver {
         case TypeConstructor.Or => ResolutionError.IllegalType(tpe, loc).toFailure
         case TypeConstructor.RecordRowEmpty => ResolutionError.IllegalType(tpe, loc).toFailure
         case TypeConstructor.RecordRowExtend(_) => ResolutionError.IllegalType(tpe, loc).toFailure
-        case TypeConstructor.Region => ResolutionError.IllegalType(tpe, loc).toFailure
+        case TypeConstructor.RegionToStar => ResolutionError.IllegalType(tpe, loc).toFailure
         case TypeConstructor.Relation => ResolutionError.IllegalType(tpe, loc).toFailure
         case TypeConstructor.SchemaRowEmpty => ResolutionError.IllegalType(tpe, loc).toFailure
         case TypeConstructor.SchemaRowExtend(_) => ResolutionError.IllegalType(tpe, loc).toFailure


### PR DESCRIPTION
Preparing to introduce region syms which will have a type constructor called Region. Related to #4653