### PR TITLE
fix: highlight region types in VSCode

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -653,6 +653,8 @@ object SemanticTokensProvider {
     case TypeConstructor.True => true
     case TypeConstructor.False => true
     case TypeConstructor.Effect(_) => true
+    case TypeConstructor.RegionToStar => true
+    case TypeConstructor.All => true
 
     // invisible
     case TypeConstructor.Arrow(_) => false
@@ -671,9 +673,7 @@ object SemanticTokensProvider {
     case TypeConstructor.Complement => false
     case TypeConstructor.Union => false
     case TypeConstructor.Intersection => false
-    case TypeConstructor.RegionToStar => false
     case TypeConstructor.Empty => false
-    case TypeConstructor.All => false
   }
 
   /**


### PR DESCRIPTION
Before:
![Screenshot from 2022-10-09 22-38-09](https://user-images.githubusercontent.com/19153692/194778730-27b65b8f-fb32-4151-974c-a90e14754389.png)

After:
![Screenshot from 2022-10-09 22-45-32](https://user-images.githubusercontent.com/19153692/194778738-b7ed03ec-8958-4fa9-af28-dfb131541814.png)
