### PR TITLE
refactor: use substitution in essentialness check

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
@@ -20,7 +20,7 @@ import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.TypedAst._
 import ca.uwaterloo.flix.language.ast.{Kind, SourceLocation, Type}
 import ca.uwaterloo.flix.language.errors.TypeError
-import ca.uwaterloo.flix.language.phase.unification.TypeMinimization
+import ca.uwaterloo.flix.language.phase.unification.{Substitution, TypeMinimization}
 import ca.uwaterloo.flix.util.Validation._
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps, Validation}
 
@@ -456,16 +456,13 @@ object Regions {
     * Assumes that `tvar` is present in the type.
     */
   def essentialToBool(tvar: Type.Var, tpe: Type)(implicit flix: Flix): Boolean = {
-    val t0 = tpe.map {
-      case t if t == tvar => Type.False
-      case t => t
-    }
+    // t0 = tpe[tvar -> False]
+    val t0 = Substitution.singleton(tvar.sym, Type.False).apply(tpe)
 
-    val t1 = tpe.map {
-      case t if t == tvar => Type.True
-      case t => t
-    }
+    // t1 = tpe[tvar -> True]
+    val t1 = Substitution.singleton(tvar.sym, Type.True).apply(tpe)
 
+    // tvar is essential if t0 != t1
     !sameType(t0, t1)
   }
 


### PR DESCRIPTION
related to #4653. Might even improve performance since substitution does some simplification