### PR TITLE
feat: Improve tests and error messages for static nested classes

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -573,12 +573,12 @@ object ResolutionError {
     * @param loc  the location of the class name.
     */
   case class UndefinedJvmClass(name: String, loc: SourceLocation) extends ResolutionError {
-    def summary: String = s"Undefined class: '${name}'."
+    def summary: String = s"Undefined Java class: '${name}'."
 
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
-         |>> Undefined class '${red(name)}'.
+         |>> Undefined Java class '${red(name)}'.
          |
          |${code(loc, "undefined class.")}
          |""".stripMargin
@@ -587,7 +587,12 @@ object ResolutionError {
     /**
       * Returns a formatted string with helpful suggestions.
       */
-    def explain(formatter: Formatter): Option[String] = None
+    def explain(formatter: Formatter): Option[String] = {
+      if (raw".*\.[A-Z].*\.[A-Z].*".r matches name)
+        Some(s"Static nested classes should be specified using '$$', e.g. java.util.Locale$$Builder")
+      else
+        None
+    }
   }
 
   /**

--- a/main/src/flix/test/TestClassWithStaticNestedClass.java
+++ b/main/src/flix/test/TestClassWithStaticNestedClass.java
@@ -1,0 +1,8 @@
+package flix.test;
+
+public class TestClassWithStaticNestedClass {
+
+  public interface NestedClass {
+
+  }
+}

--- a/main/test/flix/Test.Exp.Jvm.InvokeConstructor.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeConstructor.flix
@@ -54,4 +54,9 @@ namespace Test/Exp/Jvm/InvokeConstructor {
     def testInvokeObjectConstructor01(): ##java.lang.Object \ IO =
         import new java.lang.String(String): ##java.lang.Object \ IO as newString;
         newString("Hello World")
+
+    @test
+    def testInvokeStaticNestedConstructor01(): ##java.util.Locale$Builder \ IO =
+        import new java.util.Locale$Builder(): ##java.util.Locale$Builder as newBuilder;
+        newBuilder()
 }

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -311,4 +311,8 @@ namespace Test/Exp/Jvm/NewObject {
     };
     toString(anon) == "[1, 2, 3, 4, 5, 6]"
 
+  @test
+  def testStaticNestedClass01(): ##flix.test.TestClassWithStaticNestedClass$NestedClass \ IO =
+    new ##flix.test.TestClassWithStaticNestedClass$NestedClass {}
+
 }


### PR DESCRIPTION
Fixes #4663

It turns out that this already works: the trick is to use '$' to separate the nested class instead of '.'.

I've added a few tests to confirm that this works, and improved the error messages to make this more discoverable.