### PR TITLE
feat: improve tuple java `toString`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenTagClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenTagClasses.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.ErasedAst.Root
+import ca.uwaterloo.flix.language.ast.MonoType
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes._
 
@@ -217,6 +218,10 @@ object GenTagClasses {
   }
 
   def compileToStringMethod(visitor: ClassWriter, classType: JvmType.Reference, tag: TagInfo)(implicit root: Root, flix: Flix): Unit = {
+    val printParanthesis = tag.tagType match {
+      case MonoType.Tuple(_) => false
+      case _ => true
+    }
     val method = visitor.visitMethod(ACC_PUBLIC + ACC_FINAL, "toString", AsmOps.getMethodDescriptor(Nil, JvmType.String), null, null)
     method.visitLdcInsn("") // for last join call
 
@@ -224,7 +229,7 @@ object GenTagClasses {
     method.visitTypeInsn(ANEWARRAY, "java/lang/String")
     method.visitInsn(DUP)
     method.visitInsn(ICONST_0)
-    method.visitLdcInsn(tag.sym.name + "." + tag.tag + "(")
+    method.visitLdcInsn(tag.tag + (if (printParanthesis) "(" else ""))
     method.visitInsn(AASTORE)
     method.visitInsn(DUP)
     method.visitInsn(ICONST_1)
@@ -234,7 +239,7 @@ object GenTagClasses {
     method.visitInsn(AASTORE)
     method.visitInsn(DUP)
     method.visitInsn(ICONST_2)
-    method.visitLdcInsn(")")
+    method.visitLdcInsn(if (printParanthesis) ")" else "")
     method.visitInsn(AASTORE)
     method.visitMethodInsn(INVOKESTATIC, JvmType.String.name.toInternalName, "join", "(Ljava/lang/CharSequence;[Ljava/lang/CharSequence;)Ljava/lang/String;", false)
     method.visitInsn(ARETURN)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenTupleClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenTupleClasses.scala
@@ -125,7 +125,7 @@ object GenTupleClasses {
     // Emit the code for `getBoxedValue()` method
     compileGetBoxedValueMethod(visitor, classType, targs)
 
-    compileToStringMethod(visitor, targs)
+    compileToStringMethod(visitor, classType)
 
     // Generate `hashCode` method
     AsmOps.compileExceptionThrowerMethod(visitor, ACC_PUBLIC + ACC_FINAL, "hashCode", AsmOps.getMethodDescriptor(Nil, JvmType.PrimInt),
@@ -220,11 +220,31 @@ object GenTupleClasses {
     constructor.visitEnd()
   }
 
-  def compileToStringMethod(visitor: ClassWriter, targs: List[JvmType])(implicit root: Root, flix: Flix): Unit = {
+  def compileToStringMethod(visitor: ClassWriter, classType: JvmType.Reference)(implicit root: Root, flix: Flix): Unit = {
     val method = visitor.visitMethod(ACC_PUBLIC + ACC_FINAL, "toString", AsmOps.getMethodDescriptor(Nil, JvmType.String), null, null)
-    method.visitLdcInsn(s"Tuple${targs.length}")
+    method.visitInsn(ICONST_3)
+    method.visitTypeInsn(ANEWARRAY, JvmType.String.name.toInternalName)
+    method.visitInsn(DUP)
+    method.visitInsn(ICONST_0)
+    method.visitLdcInsn("(")
+    method.visitInsn(AASTORE)
+    method.visitInsn(DUP)
+    method.visitInsn(ICONST_1)
+    method.visitLdcInsn(", ")
+    method.visitVarInsn(ALOAD, 0)
+    method.visitMethodInsn(INVOKEVIRTUAL, classType.name.toInternalName, "getBoxedValue", s"()[Ljava/lang/Object;", false)
+    method.visitMethodInsn(INVOKESTATIC, "java/lang/String", "join", "(Ljava/lang/CharSequence;[Ljava/lang/CharSequence;)Ljava/lang/String;", false)
+    method.visitInsn(AASTORE)
+    method.visitInsn(DUP)
+    method.visitInsn(ICONST_2)
+    method.visitLdcInsn(")")
+    method.visitInsn(AASTORE)
+    method.visitVarInsn(ASTORE, 1)
+    method.visitLdcInsn("")
+    method.visitVarInsn(ALOAD, 1)
+    method.visitMethodInsn(INVOKESTATIC, "java/lang/String", "join", "(Ljava/lang/CharSequence;[Ljava/lang/CharSequence;)Ljava/lang/String;", false)
     method.visitInsn(ARETURN)
-    method.visitMaxs(1, 1)
+    method.visitMaxs(999, 999)
     method.visitEnd()
   }
 


### PR DESCRIPTION
Related to #4664.

* Tuples are `(a, b, c, d)`, using java toString of the elements
* Tags omit parentheses for tuples to avoid `Test((1, 2))`.
* Tags only use their tag, not their enum