### PR TITLE
feat: improve `java.lang.Object.toString` of record objects

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -122,66 +122,6 @@ object BackendObjType {
 
   case object BigInt extends BackendObjType
 
-  case object String extends BackendObjType {
-    def BoolValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "valueOf", mkDescriptor(BackendType.Bool)(this.jvmName.toTpe), None)
-
-    def CharValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "valueOf", mkDescriptor(BackendType.Char)(this.jvmName.toTpe), None)
-
-    // implicit use of Int8 as Int32
-    def Int8ValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "valueOf", mkDescriptor(BackendType.Int32)(this.jvmName.toTpe), None)
-
-    // implicit use of Int16 as Int32
-    def Int16ValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "valueOf", mkDescriptor(BackendType.Int32)(this.jvmName.toTpe), None)
-
-    def Int32ValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "valueOf", mkDescriptor(BackendType.Int32)(this.jvmName.toTpe), None)
-
-    def Int64ValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "valueOf", mkDescriptor(BackendType.Int64)(this.jvmName.toTpe), None)
-
-    def Float32ValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "valueOf", mkDescriptor(BackendType.Float32)(this.jvmName.toTpe), None)
-
-    def Float64ValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "valueOf", mkDescriptor(BackendType.Float64)(this.jvmName.toTpe), None)
-  }
-
-  case object Arrays extends BackendObjType {
-    def BoolArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "toString", mkDescriptor(BackendType.Array(BackendType.Bool))(BackendObjType.String.toTpe), None)
-
-    def CharArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "toString", mkDescriptor(BackendType.Array(BackendType.Char))(BackendObjType.String.toTpe), None)
-
-    def Int8ArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "toString", mkDescriptor(BackendType.Array(BackendType.Int8))(BackendObjType.String.toTpe), None)
-
-    def Int16ArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "toString", mkDescriptor(BackendType.Array(BackendType.Int16))(BackendObjType.String.toTpe), None)
-
-    def Int32ArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "toString", mkDescriptor(BackendType.Array(BackendType.Int32))(BackendObjType.String.toTpe), None)
-
-    def Int64ArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "toString", mkDescriptor(BackendType.Array(BackendType.Int64))(BackendObjType.String.toTpe), None)
-
-    def Float32ArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "toString", mkDescriptor(BackendType.Array(BackendType.Float32))(BackendObjType.String.toTpe), None)
-
-    def Float64ArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "toString", mkDescriptor(BackendType.Array(BackendType.Float64))(BackendObjType.String.toTpe), None)
-
-    def ObjArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "toString", mkDescriptor(BackendType.Array(BackendObjType.JavaObject.toTpe))(BackendObjType.String.toTpe), None)
-
-    def DeepToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
-      "deepToString", mkDescriptor(BackendType.Array(BackendObjType.JavaObject.toTpe))(BackendObjType.String.toTpe), None)
-  }
-
   case class Channel(tpe: BackendType) extends BackendObjType
 
   case class Lazy(tpe: BackendType) extends BackendObjType
@@ -809,6 +749,66 @@ object BackendObjType {
   //
   // Java Types
   //
+
+  case object String extends BackendObjType {
+    def BoolValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "valueOf", mkDescriptor(BackendType.Bool)(this.jvmName.toTpe), None)
+
+    def CharValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "valueOf", mkDescriptor(BackendType.Char)(this.jvmName.toTpe), None)
+
+    // implicit use of Int8 as Int32
+    def Int8ValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "valueOf", mkDescriptor(BackendType.Int32)(this.jvmName.toTpe), None)
+
+    // implicit use of Int16 as Int32
+    def Int16ValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "valueOf", mkDescriptor(BackendType.Int32)(this.jvmName.toTpe), None)
+
+    def Int32ValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "valueOf", mkDescriptor(BackendType.Int32)(this.jvmName.toTpe), None)
+
+    def Int64ValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "valueOf", mkDescriptor(BackendType.Int64)(this.jvmName.toTpe), None)
+
+    def Float32ValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "valueOf", mkDescriptor(BackendType.Float32)(this.jvmName.toTpe), None)
+
+    def Float64ValueOf: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "valueOf", mkDescriptor(BackendType.Float64)(this.jvmName.toTpe), None)
+  }
+
+  case object Arrays extends BackendObjType {
+    def BoolArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "toString", mkDescriptor(BackendType.Array(BackendType.Bool))(BackendObjType.String.toTpe), None)
+
+    def CharArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "toString", mkDescriptor(BackendType.Array(BackendType.Char))(BackendObjType.String.toTpe), None)
+
+    def Int8ArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "toString", mkDescriptor(BackendType.Array(BackendType.Int8))(BackendObjType.String.toTpe), None)
+
+    def Int16ArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "toString", mkDescriptor(BackendType.Array(BackendType.Int16))(BackendObjType.String.toTpe), None)
+
+    def Int32ArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "toString", mkDescriptor(BackendType.Array(BackendType.Int32))(BackendObjType.String.toTpe), None)
+
+    def Int64ArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "toString", mkDescriptor(BackendType.Array(BackendType.Int64))(BackendObjType.String.toTpe), None)
+
+    def Float32ArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "toString", mkDescriptor(BackendType.Array(BackendType.Float32))(BackendObjType.String.toTpe), None)
+
+    def Float64ArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "toString", mkDescriptor(BackendType.Array(BackendType.Float64))(BackendObjType.String.toTpe), None)
+
+    def ObjArrToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "toString", mkDescriptor(BackendType.Array(BackendObjType.JavaObject.toTpe))(BackendObjType.String.toTpe), None)
+
+    def DeepToString: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal,
+      "deepToString", mkDescriptor(BackendType.Array(BackendObjType.JavaObject.toTpe))(BackendObjType.String.toTpe), None)
+  }
 
   case object JavaObject extends BackendObjType {
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -316,8 +316,8 @@ object BackendObjType {
     private def ToStringMethod: InstanceMethod = JavaObject.ToStringMethod.implementation(this.jvmName, Some(
       // save the `rest` for the last recursive call
       thisLoad() ~ GETFIELD(this.RestField) ~
-      // build this segment of the string
-      NEW(StringBuilder.jvmName) ~ DUP() ~ INVOKESPECIAL(StringBuilder.Constructor) ~
+        // build this segment of the string
+        NEW(StringBuilder.jvmName) ~ DUP() ~ INVOKESPECIAL(StringBuilder.Constructor) ~
         pushString("{") ~ INVOKEVIRTUAL(StringBuilder.AppendStringMethod) ~
         thisLoad() ~ GETFIELD(this.LabelField) ~ INVOKEVIRTUAL(StringBuilder.AppendStringMethod) ~
         pushString(" = ") ~ INVOKEVIRTUAL(StringBuilder.AppendStringMethod) ~
@@ -328,9 +328,9 @@ object BackendObjType {
     private def ToTailStringMethod: InstanceMethod = Record.ToTailStringMethod.implementation(this.jvmName, IsFinal, Some(
       withName(1, StringBuilder.toTpe) { sb =>
         // save the `rest` for the last recursive call
-          thisLoad() ~ GETFIELD(this.RestField) ~
-        // build this segment of the string
-        sb.load() ~ pushString(", ") ~ INVOKEVIRTUAL(StringBuilder.AppendStringMethod) ~
+        thisLoad() ~ GETFIELD(this.RestField) ~
+          // build this segment of the string
+          sb.load() ~ pushString(", ") ~ INVOKEVIRTUAL(StringBuilder.AppendStringMethod) ~
           thisLoad() ~ GETFIELD(this.LabelField) ~ INVOKEVIRTUAL(StringBuilder.AppendStringMethod) ~
           pushString(" = ") ~ INVOKEVIRTUAL(StringBuilder.AppendStringMethod) ~
           thisLoad() ~ GETFIELD(this.ValueField) ~ xToString(this.ValueField.tpe) ~ INVOKEVIRTUAL(StringBuilder.AppendStringMethod) ~

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -441,6 +441,28 @@ object BytecodeInstructions {
     case BackendType.Array(_) | BackendType.Reference(_) => ASTORE(index)
   }
 
+  def xToString(tpe: BackendType): InstructionSet = tpe match {
+    case BackendType.Bool => INVOKESTATIC(BackendObjType.String.BoolValueOf)
+    case BackendType.Char => INVOKESTATIC(BackendObjType.String.CharValueOf)
+    case BackendType.Int8 => INVOKESTATIC(BackendObjType.String.Int8ValueOf)
+    case BackendType.Int16 => INVOKESTATIC(BackendObjType.String.Int16ValueOf)
+    case BackendType.Int32 => INVOKESTATIC(BackendObjType.String.Int32ValueOf)
+    case BackendType.Int64 => INVOKESTATIC(BackendObjType.String.Int64ValueOf)
+    case BackendType.Float32 => INVOKESTATIC(BackendObjType.String.Float32ValueOf)
+    case BackendType.Float64 => INVOKESTATIC(BackendObjType.String.Float64ValueOf)
+    case BackendType.Reference(_) => INVOKEVIRTUAL(BackendObjType.JavaObject.ToStringMethod)
+
+    case BackendType.Array(BackendType.Bool) => INVOKESTATIC(BackendObjType.Arrays.BoolArrToString)
+    case BackendType.Array(BackendType.Char) => INVOKESTATIC(BackendObjType.Arrays.CharArrToString)
+    case BackendType.Array(BackendType.Int8) => INVOKESTATIC(BackendObjType.Arrays.Int8ArrToString)
+    case BackendType.Array(BackendType.Int16) => INVOKESTATIC(BackendObjType.Arrays.Int16ArrToString)
+    case BackendType.Array(BackendType.Int32) => INVOKESTATIC(BackendObjType.Arrays.Int32ArrToString)
+    case BackendType.Array(BackendType.Int64) => INVOKESTATIC(BackendObjType.Arrays.Int64ArrToString)
+    case BackendType.Array(BackendType.Float32) => INVOKESTATIC(BackendObjType.Arrays.Float32ArrToString)
+    case BackendType.Array(BackendType.Float64) => INVOKESTATIC(BackendObjType.Arrays.Float64ArrToString)
+    case BackendType.Array(BackendType.Reference(_) | BackendType.Array(_)) => INVOKESTATIC(BackendObjType.Arrays.DeepToString)
+  }
+
   //
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Private ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   //

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -73,8 +73,9 @@ object JvmName {
   //
 
   val JavaLang: List[String] = List("java", "lang")
+  val JavaUtil: List[String] = List("java", "util")
 
-  val AtomicLong: JvmName = JvmName(List("java", "util", "concurrent", "atomic"), "AtomicLong")
+  val AtomicLong: JvmName = JvmName(JavaUtil ::: List("concurrent", "atomic"), "AtomicLong")
   val Boolean: JvmName = JvmName(JavaLang, "Boolean")
   val Byte: JvmName = JvmName(JavaLang, "Byte")
   val Character: JvmName = JvmName(JavaLang, "Character")

--- a/main/test/ca/uwaterloo/flix/library/TestPrelude.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestPrelude.flix
@@ -205,7 +205,7 @@ def testBigIntStringify01(): Bool = stringify(42ii) == "42"
 def testStringStringifyStringify01(): Bool = stringify("Hello World!") == "Hello World!"
 
 
-// TODO update once strings improve
+// TODO update once strings improvec
 @test
 def testArrayOfIntStringify01(): Bool \ IO = stringify([1, 2, 3]) |> String.startsWith(prefix = "[")
 

--- a/main/test/ca/uwaterloo/flix/library/TestPrelude.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestPrelude.flix
@@ -205,7 +205,7 @@ def testBigIntStringify01(): Bool = stringify(42ii) == "42"
 def testStringStringifyStringify01(): Bool = stringify("Hello World!") == "Hello World!"
 
 
-// TODO update once strings improvec
+// TODO update once strings improve
 @test
 def testArrayOfIntStringify01(): Bool \ IO = stringify([1, 2, 3]) |> String.startsWith(prefix = "[")
 
@@ -263,11 +263,11 @@ def testRecordStringify01(): Bool = stringify({field = (1, 2)}) == "{field = (1,
 @test
 def testRecordStringify02(): Bool = {
     let s = stringify({something = (), other = true});
-    s == "{field = (), other = true}" or s == "{other = true, field = ()}"
+    s == "{something = (), other = true}" or s == "{other = true, something = ()}"
 }
 
 @test
 def testRecordStringify03(): Bool = {
-    let s = stringify({something = {}, other = {single = "ton"}});
-    s == "{something = {}, other = {single = "ton"}}" or s == "{other = {single = "ton"}, something = {}}"
+    let s = stringify({something = {}, other = {single = 8}});
+    s == "{something = {}, other = {single = 8}}" or s == "{other = {single = 8}, something = {}}"
 }

--- a/main/test/ca/uwaterloo/flix/library/TestPrelude.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestPrelude.flix
@@ -256,3 +256,18 @@ def testPolyDebugString03(): Bool = debugString(That("Hello World!")) == "That(H
 
 @test
 def testPolyDebugString04(): Bool = debugString(Both(123, "Hello World!")) == "Both(123, Hello World!)"
+
+@test
+def testRecordDebugString01(): Bool = debugString({field = (1, 2)}) == "{field = (1, 2)}"
+
+@test
+def testRecordDebugString02(): Bool = {
+    let s = debugString({something = (), other = true});
+    s == "{field = (), other = true}" or s == "{other = true, field = ()}"
+}
+
+@test
+def testRecordDebugString03(): Bool = {
+    let s = debugString({something = {}, other = {single = "ton"}}});
+    s == "{something = {}, other = {single = "ton"}}" or s == "{other = {single = "ton"}, something = {}}"
+}

--- a/main/test/ca/uwaterloo/flix/library/TestPrelude.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestPrelude.flix
@@ -268,6 +268,6 @@ def testRecordStringify02(): Bool = {
 
 @test
 def testRecordStringify03(): Bool = {
-    let s = stringify({something = {}, other = {single = "ton"}}});
+    let s = stringify({something = {}, other = {single = "ton"}});
     s == "{something = {}, other = {single = "ton"}}" or s == "{other = {single = "ton"}, something = {}}"
 }


### PR DESCRIPTION
Related to #4664.
* `{}` is `{}`
* `{ field = 42}` is `{field = 42}`
* `{ fieldA = 1, fieldB = 123 }` is `{fieldA = 1, fieldB = 123}` (order not defined I suppose)