### PR TITLE
feat: improve `toString` of function objects

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -472,7 +472,7 @@ object BytecodeInstructions {
   def composeN(ins: List[InstructionSet]): InstructionSet =
     ins.foldLeft(nop())(compose)
 
-  /***
+  /**
     * Sequential composition with `sep` between elements.
     */
   def joinN(ins: List[InstructionSet], sep: InstructionSet): InstructionSet = ins match {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -56,9 +56,15 @@ object BytecodeInstructions {
 
   type InstructionSet = F => F
 
+  /**
+    * Returns the sequential composition of the two instructions.
+    */
+  def compose(i1: InstructionSet, i2: InstructionSet): InstructionSet =
+    f => i2(i1(f))
+
   implicit class ComposeOps(i1: InstructionSet) {
     def ~(i2: InstructionSet): InstructionSet =
-      f => i2(i1(f))
+      compose(i1, i2)
   }
 
   //
@@ -462,6 +468,18 @@ object BytecodeInstructions {
     case BackendType.Array(BackendType.Float64) => INVOKESTATIC(BackendObjType.Arrays.Float64ArrToString)
     case BackendType.Array(BackendType.Reference(_) | BackendType.Array(_)) => INVOKESTATIC(BackendObjType.Arrays.DeepToString)
   }
+
+  def composeN(ins: List[InstructionSet]): InstructionSet =
+    ins.foldLeft(nop())(compose)
+
+  /***
+    * Sequential composition with `sep` between elements.
+    */
+  def joinN(ins: List[InstructionSet], sep: InstructionSet): InstructionSet = ins match {
+    case Nil => nop()
+    case head :: next => head ~ composeN(next.map(e => sep ~ e))
+  }
+
 
   //
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Private ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/main/test/ca/uwaterloo/flix/library/TestPrelude.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestPrelude.flix
@@ -318,3 +318,26 @@ def testRecordStringify03(): Bool = {
     let s = stringify({something = {}, other = {single = 8}});
     s == "{something = {}, other = {single = 8}}" or s == "{other = {single = 8}, something = {}}"
 }
+
+@test
+def testFunctionStringify01(): Bool = {
+    def f(x: Int32): Int32 = x;
+    let s = stringify(f);
+    s == "Int32 -> Int32"
+}
+
+def toIntFunction(x: a, g: a -> Int32): Int32 = g(x)
+
+@test
+def testFunctionStringify02(): Bool = {
+    let s = stringify(toIntFunction(true));
+    s == "Obj -> Int32"
+}
+
+def thunkFunction(x: a): String -> a = _ -> x
+
+@test
+def testFunctionStringify03(): Bool = {
+    let s = stringify((thunkFunction(42), thunkFunction('a')));
+    s == "(Obj -> Int32, Obj -> Char)"
+}


### PR DESCRIPTION
Realted to #4664.

Functions print their (java, i.e. no String or Unit) erased type, so `Int32 -> Int32`, `Obj -> Bool` etc. I've programmed other arities `() -> Int32` and `(Int32, Float32) -> Char` but I don't think any can exist