### PR TITLE
fix: Disallow java names which aren't also Flix names

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -865,6 +865,9 @@ object WeederError {
     })
   }
 
+  /**
+    * An error raised to indicate that an imported Java name is not a valid Flix identifier
+    */
   case class IllegalJavaClass(name: String, loc: SourceLocation) extends WeederError {
     def summary: String = "${name} is not a valid Flix identifer."
 
@@ -873,7 +876,7 @@ object WeederError {
       s"""${line(kind, source.name)}
          |>> ${red(name)} is not a valid Flix identifer.
          |
-         |${code(loc, "illegal identifer")}
+         |${code(loc, "identifer")}
          |
          |""".stripMargin
     }

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -864,4 +864,27 @@ object WeederError {
          |""".stripMargin
     })
   }
+
+  case class IllegalJavaClass(name: String, loc: SourceLocation) extends WeederError {
+    def summary: String = "${name} is not a valid Flix identifer."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> ${red(name)} is not a valid Flix identifer.
+         |
+         |${code(loc, "illegal identifer")}
+         |
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = Some({
+      s"""Not every valid Java identifer is a valid Flix identifer.
+         |
+         |If you need to use such a class or interface, alias it during import, e.g.:
+         |
+         |    import java.util.{Locale$$Builder => Builder}
+         |""".stripMargin
+    })
+  }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1764,7 +1764,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     /**
       * An uppercase identifier is an uppercase letter optionally followed by any letter, underscore, or prime.
       */
-  def UpperCaseName: Rule1[Name.Ident] = rule {
+    def UpperCaseName: Rule1[Name.Ident] = rule {
       SP ~ capture(optional("_") ~ Letters.UpperLetter ~ zeroOrMore(Letters.LegalLetter)) ~ SP ~> Name.Ident
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -458,7 +458,7 @@ object Weeder {
     case ParsedAst.Imports.ImportOne(sp1, name, sp2) =>
       val loc = mkSL(sp1, sp2)
       val alias = name.fqn.last
-      if (raw"[A-Z][A-Za-z0-9_?]*".r matches alias) {
+      if (raw"[A-Z][A-Za-z0-9_!]*".r matches alias) {
         List(WeededAst.Import.Import(name, Name.Ident(sp1, alias, sp2), loc)).toSuccess
       } else {
         WeederError.IllegalJavaClass(alias, loc).toFailure

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -762,4 +762,13 @@ class TestWeeder extends FunSuite with TestUtils {
     val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.IllegalEnum](result)
   }
+
+  test("IllegalJavaClass.01") {
+    val input =
+      """
+        |import java.util.Locale$Builder
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalJavaClass](result)
+  }
 }


### PR DESCRIPTION
Fixes #4666

This works, but I'm not 100% happy with it: I've had to effectively re-implement the definition of `UpperCaseName`. I'd love to use the same code, but I can't see how I could reuse a portion of the parser?

If there is a way, I'd love to hear about it.