### PR TITLE
fix: Allow new with protected constructor

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -593,7 +593,7 @@ object Safety {
       // Case 1: Interface. No need for a constructor.
       List.empty
     } else {
-      // Case 2: Class. Must have a public non-zero argument constructor.
+      // Case 2: Class. Must have a non-private zero argument constructor.
       if (hasNonPrivateZeroArgConstructor(clazz))
         List.empty
       else

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -594,7 +594,7 @@ object Safety {
       List.empty
     } else {
       // Case 2: Class. Must have a public non-zero argument constructor.
-      if (hasPublicZeroArgConstructor(clazz))
+      if (hasNonPrivateZeroArgConstructor(clazz))
         List.empty
       else
         List(MissingPublicZeroArgConstructor(clazz, loc))
@@ -676,16 +676,12 @@ object Safety {
   }
 
   /**
-    * Return true if the given `clazz` has public zero argument constructor.
+    * Return true if the given `clazz` has a non-private zero argument constructor.
     */
-  private def hasPublicZeroArgConstructor(clazz: java.lang.Class[_]): Boolean = {
+  private def hasNonPrivateZeroArgConstructor(clazz: java.lang.Class[_]): Boolean = {
     try {
-      // We simply use Class.getConstructor whose documentation states:
-      //
-      // Returns a Constructor object that reflects the specified
-      // public constructor of the class represented by this class object.
-      clazz.getConstructor()
-      true
+      val constructor = clazz.getDeclaredConstructor()
+      !java.lang.reflect.Modifier.isPrivate(constructor.getModifiers())
     } catch {
       case _: NoSuchMethodException => false
     }

--- a/main/src/flix/test/TestClassWithProtectedConstructor.java
+++ b/main/src/flix/test/TestClassWithProtectedConstructor.java
@@ -1,0 +1,6 @@
+package flix.test;
+
+abstract public class TestClassWithProtectedConstructor {
+  protected TestClassWithProtectedConstructor() {
+  }
+}

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -315,4 +315,7 @@ namespace Test/Exp/Jvm/NewObject {
   def testStaticNestedClass01(): ##flix.test.TestClassWithStaticNestedClass$NestedClass \ IO =
     new ##flix.test.TestClassWithStaticNestedClass$NestedClass {}
 
+  @test
+  def testClassWithProtectedConstructor01(): ##flix.test.TestClassWithProtectedConstructor \ IO =
+    new ##flix.test.TestClassWithProtectedConstructor {}
 }


### PR DESCRIPTION
Requiring that the type passed to `new` has a public constructor is too strict: a protected constructor will do just fine.