### PR TITLE
refactor: rename FunctorFilter to Filterable, issue #4713

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -168,7 +168,7 @@ class Flix {
     "Foldable.flix" -> LocalResource.get("/src/library/Foldable.flix"),
     "FromString.flix" -> LocalResource.get("/src/library/FromString.flix"),
     "Functor.flix" -> LocalResource.get("/src/library/Functor.flix"),
-    "FunctorFilter.flix" -> LocalResource.get("/src/library/FunctorFilter.flix"),
+    "Filterable.flix" -> LocalResource.get("/src/library/Filterable.flix"),
     "Group.flix" -> LocalResource.get("/src/library/Group.flix"),
     "Identity.flix" -> LocalResource.get("/src/library/Identity.flix"),
     "Monad.flix" -> LocalResource.get("/src/library/Monad.flix"),
@@ -229,7 +229,7 @@ class Flix {
     "Fixpoint/Ram/RowVar.flix" -> LocalResource.get("/src/library/Fixpoint/Ram/RowVar.flix"),
 
     "Fixpoint/Shared/PredSym.flix" -> LocalResource.get("/src/library/Fixpoint/Shared/PredSym.flix"),
-    
+
     "Fixpoint/Tuple/Tuple.flix" -> LocalResource.get("/src/library/Fixpoint/Tuple/Tuple.flix"),
 
     "Graph.flix" -> LocalResource.get("/src/library/Graph.flix"),

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -85,7 +85,7 @@ instance Traversable[Chain] {
     pub override def sequence(t: Chain[m[a]]): m[Chain[a]] with Applicative[m] = Chain.sequence(t)
 }
 
-instance FunctorFilter[Chain] {
+instance Filterable[Chain] {
     pub def filterMap(f: a -> Option[b] \ ef, x: Chain[a]): Chain[b] \ ef = Chain.filterMap(f, x)
     pub override def filter(f: a -> Bool \ ef, x: Chain[a]): Chain[a] \ ef = Chain.filter(f, x)
 }

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -104,7 +104,7 @@ instance Traversable[DelayList] {
     pub override def sequence(l: DelayList[m[a]]): m[DelayList[a]] with Applicative[m] = DelayList.sequence(l)
 }
 
-instance FunctorFilter[DelayList] {
+instance Filterable[DelayList] {
     pub def filterMap(f: a -> Option[b] \ ef, x: DelayList[a]): DelayList[b] \ ef = DelayList.filterMap(f, x)
     pub override def filter(f: a -> Bool \ ef, x: DelayList[a]): DelayList[a] \ ef = DelayList.filter(f, x)
 }

--- a/main/src/library/Filterable.flix
+++ b/main/src/library/Filterable.flix
@@ -17,7 +17,7 @@
 ///
 /// A type class for filtering container functors.
 ///
-pub class FunctorFilter[m : Type -> Type] with Functor[m] {
+pub class Filterable[m : Type -> Type] with Functor[m] {
 
     ///
     /// Applies the partial function `f` to every element in `x` collecting the results.
@@ -27,6 +27,6 @@ pub class FunctorFilter[m : Type -> Type] with Functor[m] {
     ///
     /// Applies `f` to every element in `x`. Keeps every element that satisfies `f`.
     ///
-    pub def filter(f: a -> Bool \ ef, t: m[a]): m[a] \ ef = FunctorFilter.filterMap(x -> if (f(x)) Some(x) else None, t)
+    pub def filter(f: a -> Bool \ ef, t: m[a]): m[a] \ ef = Filterable.filterMap(x -> if (f(x)) Some(x) else None, t)
 
 }

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -104,7 +104,7 @@ instance Traversable[List] {
     pub override def sequence(t: List[m[a]]): m[List[a]] with Applicative[m] = List.sequence(t)
 }
 
-instance FunctorFilter[List] {
+instance Filterable[List] {
     pub def filterMap(f: a -> Option[b] \ ef, x: List[a]): List[b] \ ef = List.filterMap(f, x)
     pub override def filter(f: a -> Bool \ ef, x: List[a]): List[a] \ ef = List.filter(f, x)
 }

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -69,7 +69,7 @@ instance Traversable[Map[k]] {
     pub override def sequence(t: Map[k, m[a]]): m[Map[k, a]] with Applicative[m] = Map.sequence(t)
 }
 
-instance FunctorFilter[Map[k]] with Order[k] {
+instance Filterable[Map[k]] with Order[k] {
     pub def filterMap(f: a -> Option[b] \ ef, m: Map[k, a]): Map[k, b] \ ef = Map.filterMap(f, m)
     pub override def filter(f: a -> Bool \ ef, m: Map[k, a]): Map[k, a] \ ef = Map.filter(f, m)
 }

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -127,7 +127,7 @@ instance Traversable[Option] {
 
 }
 
-instance FunctorFilter[Option] {
+instance Filterable[Option] {
     pub def filterMap(f: a -> Option[b] \ ef, o: Option[a]): Option[b] \ ef = Option.flatMap(f, o)
     pub override def filter(f: a -> Bool \ ef, o: Option[a]): Option[a] \ ef = Option.filter(f, o)
 }

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -83,7 +83,7 @@ namespace RedBlackTree {
             mapAWithKey((_, v) -> v, t)
     }
 
-    instance FunctorFilter[RedBlackTree[k]] with Order[k] {
+    instance Filterable[RedBlackTree[k]] with Order[k] {
         pub def filterMap(f: a -> Option[b] \ ef, t: RedBlackTree[k, a]): RedBlackTree[k, b] \ ef = filterMapImplementation(f, t)
         pub override def filter(f: a -> Bool \ ef, t: RedBlackTree[k, a]): RedBlackTree[k, a] \ ef = filterImplementation(f, t)
     }
@@ -1039,8 +1039,8 @@ namespace RedBlackTree {
 
     ///
     /// Temporary hack!
-    /// A concrete implementation of `filter` that the `FunctorFilter` instance can use.
-    /// If `FunctorFilter.filter` calls `filter` it appears to invoke a cycle and the concrete
+    /// A concrete implementation of `filter` that the `Filterable` instance can use.
+    /// If `Filterable.filter` calls `filter` it appears to invoke a cycle and the concrete
     /// implementation is never called.
     ///
     def filterImplementation(f: v -> Bool \ ef, t: RedBlackTree[k, v]): RedBlackTree[k, v] \ ef with Order[k] =
@@ -1056,7 +1056,7 @@ namespace RedBlackTree {
 
     ///
     /// Temporary hack!
-    /// A concrete implementation of `filterMap` that the `FunctorFilter` instance can use.
+    /// A concrete implementation of `filterMap` that the `Filterable` instance can use.
     ///
     def filterMapImplementation(f: a -> Option[b] \ ef, t: RedBlackTree[k, a]): RedBlackTree[k, b] \ ef with Order[k] =
         let step = (acc, k, a) -> match f(a) {

--- a/main/src/library/Witherable.flix
+++ b/main/src/library/Witherable.flix
@@ -18,7 +18,7 @@
 /// A type class for data structures that can be traversed in left-to-right
 /// order with an applicative partial functor.
 ///
-pub class Witherable[t : Type -> Type] with Traversable[t], FunctorFilter[t] {
+pub class Witherable[t : Type -> Type] with Traversable[t], Filterable[t] {
 
     ///
     /// Returns the result of applying the applicative partial mapping function `f` to all the elements of the
@@ -26,7 +26,7 @@ pub class Witherable[t : Type -> Type] with Traversable[t], FunctorFilter[t] {
     ///
     pub def wither(f: a -> m[Option[b]] \ ef, t: t[a]): m[t[b]] \ ef with Applicative[m] =
         use Functor.{<$>};
-        use FunctorFilter.filterMap;
+        use Filterable.filterMap;
         (identity |> filterMap) <$> Traversable.traverse(f, t)
 
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestFilterable.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFilterable.flix
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-namespace TestFunctorFilter {
+namespace TestFilterable {
 
-    use FunctorFilter.{filter, filterMap}
+    use Filterable.{filter, filterMap}
 
     def isOdd(i: Int32): Bool = not (i mod 2 == 0)
 


### PR DESCRIPTION
This PR renames the class `FunctorFilter` to `Filterable`. `Filterable` is the name Haskell and PureScript use for the equivalent class.