### PR TITLE
feat: add `Bool.fromString`

### DIFF
--- a/main/src/library/Bool.flix
+++ b/main/src/library/Bool.flix
@@ -84,10 +84,17 @@ namespace Bool {
     /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
     ///
     @Time(1) @Space(1)
-    pub def fromString(s: String): Option[Bool] = match String.trim(s) {
-        case "true"  => Some(true)
-        case "false" => Some(false)
-        case _       => None
-    }
+    pub def fromString(s: String): Opt[Bool] =
+        import java.lang.String.strip(): String \ {};
+        match strip(s) {
+            case "true"  => S(true)
+            case "false" => S(false)
+            case _       => N
+        }
 
+}
+
+pub enum Opt[a] {
+    case S(a)
+    case N
 }

--- a/main/src/library/Bool.flix
+++ b/main/src/library/Bool.flix
@@ -87,14 +87,14 @@ namespace Bool {
     pub def fromString(s: String): Opt[Bool] =
         import java.lang.String.strip(): String \ {};
         match strip(s) {
-            case "true"  => S(true)
-            case "false" => S(false)
-            case _       => N
+            case "true"  => Opt.Some(true)
+            case "false" => Opt.Some(false)
+            case _       => Opt.None
         }
 
-}
+    pub enum Opt[a] {
+        case Some(a)
+        case None
+    }
 
-pub enum Opt[a] {
-    case S(a)
-    case N
 }

--- a/main/src/library/Bool.flix
+++ b/main/src/library/Bool.flix
@@ -92,7 +92,7 @@ namespace Bool {
             case _       => Opt.None
         }
 
-    pub enum Opt[a] {
+    pub enum Opt[a] with Eq {
         case Some(a)
         case None
     }

--- a/main/src/library/Bool.flix
+++ b/main/src/library/Bool.flix
@@ -79,4 +79,15 @@ namespace Bool {
     ///
     pub def <==>(x: Bool, y: Bool): Bool = x == y
 
+    ///
+    /// Parse the string `s` as a Bool, leading or trailing whitespace is trimmed.
+    /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
+    ///
+    @Time(1) @Space(1)
+    pub def fromString(s: String): Option[Bool] = match String.trim(s) {
+        case "true"  => Some(true)
+        case "false" => Some(false)
+        case _       => None
+    }
+
 }

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -614,9 +614,11 @@ namespace Option {
     ///
     /// Returns `o` as an `Option` type.
     ///
-    pub def fromOpt(o: Opt[a]): Option[a] = match o {
-        case S(a) => Some(a)
-        case N    => None
-    }
+    pub def fromOpt(o: Bool.Opt[a]): Option[a] =
+        use Bool.Opt;
+        match o {
+            case Opt.Some(a) => Some(a)
+            case Opt.None    => None
+        }
 
 }

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -611,4 +611,12 @@ namespace Option {
     pub def enumerator(r: Region[r], o: Option[a]): Iterator[(a, Int32), r] \ Write(r) =
         iterator(r, o) |> Iterator.zipWithIndex
 
+    ///
+    /// Returns
+    ///
+    pub def fromOpt(o: Opt[a]): Option[a] = match o {
+        case S(a) => Some(a)
+        case N    => None
+    }
+
 }

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -612,7 +612,7 @@ namespace Option {
         iterator(r, o) |> Iterator.zipWithIndex
 
     ///
-    /// Returns
+    /// Returns `o` as an `Option` type.
     ///
     pub def fromOpt(o: Opt[a]): Option[a] = match o {
         case S(a) => Some(a)

--- a/main/test/ca/uwaterloo/flix/library/TestBool.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestBool.flix
@@ -151,4 +151,19 @@ namespace Bool {
     @test
     def fromString05(): Bool = Bool.fromString("false") == Some(false)
 
+    @test
+    def fromString06(): Bool = Bool.fromString("   false") == Some(false)
+
+    @test
+    def fromString07(): Bool = Bool.fromString("yes") == None
+
+    @test
+    def fromString08(): Bool = Bool.fromString("no") == None
+
+    @test
+    def fromString09(): Bool = Bool.fromString("true 1") == None
+
+    @test
+    def fromString10(): Bool = Bool.fromString("0false") == None
+
 }

--- a/main/test/ca/uwaterloo/flix/library/TestBool.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestBool.flix
@@ -132,4 +132,23 @@ namespace Bool {
     @test
     def orTest04(): Bool = or(true, lazy true) == true
 
+    /////////////////////////////////////////////////////////////////////////////
+    // fromString                                                              //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def fromString01(): Bool = Bool.fromString("Bad") == None
+
+    @test
+    def fromString02(): Bool = Bool.fromString(" true") == Some(true)
+
+    @test
+    def fromString03(): Bool = Bool.fromString("true ") == Some(true)
+
+    @test
+    def fromString04(): Bool = Bool.fromString("true") == Some(true)
+
+    @test
+    def fromString05(): Bool = Bool.fromString("false") == Some(false)
+
 }


### PR DESCRIPTION
Do we want this behavior which is easy to reason about or do we want the `java.lang.Boolean.parseBoolean` behavior which returns `true` if the string was `"true"` and returns `false` on all other input?

https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/lang/Boolean.html#parseBoolean(java.lang.String)

Closes https://github.com/flix/flix/issues/4568