### PR TITLE
fix: Calling a constructor that takes an array argument

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -803,24 +803,12 @@ object GenExpression {
       visitor.visitTypeInsn(NEW, declaration)
       // Duplicate the reference since the first argument for a constructor call is the reference to the object
       visitor.visitInsn(DUP)
-      // Evaluate arguments left-to-right and push them onto the stack.
-      for (arg <- args) {
-        compileExpression(arg, visitor, currentClass, lenv0, entryPoint)
-        // Cast the argument to the right type.
-        arg.tpe match {
-          // NB: This is not exhaustive. In the new backend we should handle all types, including multidim arrays.
-          case MonoType.Array(MonoType.Float32) => visitor.visitTypeInsn(CHECKCAST, "[F")
-          case MonoType.Array(MonoType.Float64) => visitor.visitTypeInsn(CHECKCAST, "[D")
-          case MonoType.Array(MonoType.Int8) => visitor.visitTypeInsn(CHECKCAST, "[B")
-          case MonoType.Array(MonoType.Int16) => visitor.visitTypeInsn(CHECKCAST, "[S")
-          case MonoType.Array(MonoType.Int32) => visitor.visitTypeInsn(CHECKCAST, "[I")
-          case MonoType.Array(MonoType.Int64) => visitor.visitTypeInsn(CHECKCAST, "[J")
-          case MonoType.Native(clazz) =>
-            val argType = asm.Type.getInternalName(clazz)
-            visitor.visitTypeInsn(CHECKCAST, argType)
-          case _ => // nop
-        }
-      }
+      // Retrieve the signature.
+      val signature = constructor.getParameterTypes
+
+      // Invoke the constructor
+      compileInvoke(visitor, args, signature, currentClass, lenv0, entryPoint)
+
       // Call the constructor
       visitor.visitMethodInsn(INVOKESPECIAL, declaration, "<init>", descriptor, false)
 
@@ -836,25 +824,9 @@ object GenExpression {
       // Retrieve the signature.
       val signature = method.getParameterTypes
 
-      // Evaluate arguments left-to-right and push them onto the stack.
-      for ((arg, argType) <- args.zip(signature)) {
-        compileExpression(arg, visitor, currentClass, lenv0, entryPoint)
-        if (!argType.isPrimitive) {
-          // NB: Really just a hack because the backend does not support array JVM types properly.
-          visitor.visitTypeInsn(CHECKCAST, asm.Type.getInternalName(argType))
-        } else {
-          arg.tpe match {
-            // NB: This is not exhaustive. In the new backend we should handle all types, including multidim arrays.
-            case MonoType.Array(MonoType.Float32) => visitor.visitTypeInsn(CHECKCAST, "[F")
-            case MonoType.Array(MonoType.Float64) => visitor.visitTypeInsn(CHECKCAST, "[D")
-            case MonoType.Array(MonoType.Int8) => visitor.visitTypeInsn(CHECKCAST, "[B")
-            case MonoType.Array(MonoType.Int16) => visitor.visitTypeInsn(CHECKCAST, "[S")
-            case MonoType.Array(MonoType.Int32) => visitor.visitTypeInsn(CHECKCAST, "[I")
-            case MonoType.Array(MonoType.Int64) => visitor.visitTypeInsn(CHECKCAST, "[J")
-            case _ => // nop
-          }
-        }
-      }
+      // Invoke the method
+      compileInvoke(visitor, args, signature, currentClass, lenv0, entryPoint)
+
       val declaration = asm.Type.getInternalName(method.getDeclaringClass)
       val name = method.getName
       val descriptor = asm.Type.getMethodDescriptor(method)
@@ -874,24 +846,7 @@ object GenExpression {
     case Expression.InvokeStaticMethod(method, args, _, loc) =>
       addSourceLine(visitor, loc)
       val signature = method.getParameterTypes
-      for ((arg, argType) <- args.zip(signature)) {
-        compileExpression(arg, visitor, currentClass, lenv0, entryPoint)
-        if (!argType.isPrimitive) {
-          // NB: Really just a hack because the backend does not support array JVM types properly.
-          visitor.visitTypeInsn(CHECKCAST, asm.Type.getInternalName(argType))
-        } else {
-          arg.tpe match {
-            // NB: This is not exhaustive. In the new backend we should handle all types, including multidim arrays.
-            case MonoType.Array(MonoType.Float32) => visitor.visitTypeInsn(CHECKCAST, "[F")
-            case MonoType.Array(MonoType.Float64) => visitor.visitTypeInsn(CHECKCAST, "[D")
-            case MonoType.Array(MonoType.Int8) => visitor.visitTypeInsn(CHECKCAST, "[B")
-            case MonoType.Array(MonoType.Int16) => visitor.visitTypeInsn(CHECKCAST, "[S")
-            case MonoType.Array(MonoType.Int32) => visitor.visitTypeInsn(CHECKCAST, "[I")
-            case MonoType.Array(MonoType.Int64) => visitor.visitTypeInsn(CHECKCAST, "[J")
-            case _ => // nop
-          }
-        }
-      }
+      compileInvoke(visitor, args, signature, currentClass, lenv0, entryPoint)
       val declaration = asm.Type.getInternalName(method.getDeclaringClass)
       val name = method.getName
       val descriptor = asm.Type.getMethodDescriptor(method)
@@ -1690,4 +1645,25 @@ object GenExpression {
     visitor.visitLineNumber(loc.beginLine, label)
   }
 
+  private def compileInvoke(visitor: MethodVisitor, args: List[Expression], signature: Array[Class[_ <: Object]], currentClass: JvmType.Reference, lenv0: Map[Symbol.LabelSym, Label], entryPoint: Label)(implicit root: Root, flix: Flix): Unit = {
+    // Evaluate arguments left-to-right and push them onto the stack.
+    for ((arg, argType) <- args.zip(signature)) {
+      compileExpression(arg, visitor, currentClass, lenv0, entryPoint)
+      if (!argType.isPrimitive) {
+        // NB: Really just a hack because the backend does not support array JVM types properly.
+        visitor.visitTypeInsn(CHECKCAST, asm.Type.getInternalName(argType))
+      } else {
+        arg.tpe match {
+          // NB: This is not exhaustive. In the new backend we should handle all types, including multidim arrays.
+          case MonoType.Array(MonoType.Float32) => visitor.visitTypeInsn(CHECKCAST, "[F")
+          case MonoType.Array(MonoType.Float64) => visitor.visitTypeInsn(CHECKCAST, "[D")
+          case MonoType.Array(MonoType.Int8) => visitor.visitTypeInsn(CHECKCAST, "[B")
+          case MonoType.Array(MonoType.Int16) => visitor.visitTypeInsn(CHECKCAST, "[S")
+          case MonoType.Array(MonoType.Int32) => visitor.visitTypeInsn(CHECKCAST, "[I")
+          case MonoType.Array(MonoType.Int64) => visitor.visitTypeInsn(CHECKCAST, "[J")
+          case _ => // nop
+        }
+      }
+    }
+  }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -806,8 +806,7 @@ object GenExpression {
       // Retrieve the signature.
       val signature = constructor.getParameterTypes
 
-      // Invoke the constructor
-      compileInvoke(visitor, args, signature, currentClass, lenv0, entryPoint)
+      pushArgs(visitor, args, signature, currentClass, lenv0, entryPoint)
 
       // Call the constructor
       visitor.visitMethodInsn(INVOKESPECIAL, declaration, "<init>", descriptor, false)
@@ -824,8 +823,7 @@ object GenExpression {
       // Retrieve the signature.
       val signature = method.getParameterTypes
 
-      // Invoke the method
-      compileInvoke(visitor, args, signature, currentClass, lenv0, entryPoint)
+      pushArgs(visitor, args, signature, currentClass, lenv0, entryPoint)
 
       val declaration = asm.Type.getInternalName(method.getDeclaringClass)
       val name = method.getName
@@ -846,7 +844,7 @@ object GenExpression {
     case Expression.InvokeStaticMethod(method, args, _, loc) =>
       addSourceLine(visitor, loc)
       val signature = method.getParameterTypes
-      compileInvoke(visitor, args, signature, currentClass, lenv0, entryPoint)
+      pushArgs(visitor, args, signature, currentClass, lenv0, entryPoint)
       val declaration = asm.Type.getInternalName(method.getDeclaringClass)
       val name = method.getName
       val descriptor = asm.Type.getMethodDescriptor(method)
@@ -1645,7 +1643,10 @@ object GenExpression {
     visitor.visitLineNumber(loc.beginLine, label)
   }
 
-  private def compileInvoke(visitor: MethodVisitor, args: List[Expression], signature: Array[Class[_ <: Object]], currentClass: JvmType.Reference, lenv0: Map[Symbol.LabelSym, Label], entryPoint: Label)(implicit root: Root, flix: Flix): Unit = {
+  /**
+    * Pushes arguments onto the stack ready to invoke a method
+    */
+  private def pushArgs(visitor: MethodVisitor, args: List[Expression], signature: Array[Class[_ <: Object]], currentClass: JvmType.Reference, lenv0: Map[Symbol.LabelSym, Label], entryPoint: Label)(implicit root: Root, flix: Flix): Unit = {
     // Evaluate arguments left-to-right and push them onto the stack.
     for ((arg, argType) <- args.zip(signature)) {
       compileExpression(arg, visitor, currentClass, lenv0, entryPoint)

--- a/main/test/flix/Test.Exp.Jvm.InvokeConstructor.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeConstructor.flix
@@ -59,4 +59,9 @@ namespace Test/Exp/Jvm/InvokeConstructor {
     def testInvokeStaticNestedConstructor01(): ##java.util.Locale$Builder \ IO =
         import new java.util.Locale$Builder(): ##java.util.Locale$Builder as newBuilder;
         newBuilder()
+
+    @test
+    def testInvokeConstructorWithArrayParam(): ##java.net.URLClassLoader \ IO =
+        import new java.net.URLClassLoader(Array[##java.net.URL, _]): ##java.net.URLClassLoader \ IO as newClassLoader;
+        newClassLoader([])
 }

--- a/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeStaticMethod.flix
@@ -53,4 +53,11 @@ namespace Test/Exp/Jvm/InvokeStaticMethod {
     def testInvokeInheritedStaticMethod01(): Bool =
         import static flix.test.TestClassWithInheritedMethod.staticMethod(Int32): Int32 \ {};
         staticMethod(1) == 2
+
+    @test
+    def testInvokeStaticMethodWithArrayParam(): Bool \ IO =
+        import static java.util.Arrays.fill(Array[##java.lang.Object, _], ##java.lang.Object): Unit \ IO;
+        let a = ["this", "that"];
+        fill(a as Array[##java.lang.Object, _], "foo" as ##java.lang.Object);
+        true
 }


### PR DESCRIPTION
This fixes calling a constructor which takes an array argument (calling methods and static methods with array arguments already works).

The problem was that the code to put the arguments on the stack for constructors was different from the equivalent code for methods and static methods. This PR pulls that code out into a separate method to ensure that it's always done the same way.