### PR TITLE
chore: find and replace ##java.math.BigDecimal to BigDecimal

### DIFF
--- a/main/src/library/BigDecimal.flix
+++ b/main/src/library/BigDecimal.flix
@@ -36,7 +36,7 @@ namespace BigDecimal {
     /// Returns the absolute value of `x`.
     ///
     pub def abs(x: BigDecimal): BigDecimal =
-        import java.math.BigDecimal.abs(): ##java.math.BigDecimal \ {};
+        import java.math.BigDecimal.abs(): BigDecimal \ {};
         abs(x)
 
     ///
@@ -48,7 +48,7 @@ namespace BigDecimal {
     /// Returns `1` if `x > y`, `-1` if `x < y`, and `0` if `x = y`.
     ///
     pub def compare(x: BigDecimal, y: BigDecimal): Int32 =
-        import java.math.BigDecimal.compareTo(##java.math.BigDecimal): Int32 \ {};
+        import java.math.BigDecimal.compareTo(BigDecimal): Int32 \ {};
         compareTo(x, y)
 
     ///
@@ -103,7 +103,7 @@ namespace BigDecimal {
     ///
     @Time(1) @Space(1)
     pub def ceil(x: BigDecimal): BigDecimal =
-        import java.math.BigDecimal.setScale(Int32, ##java.math.RoundingMode): ##java.math.BigDecimal \ {};
+        import java.math.BigDecimal.setScale(Int32, ##java.math.RoundingMode): BigDecimal \ {};
         import static get java.math.RoundingMode.CEILING: ##java.math.RoundingMode \ {} as getCeiling;
         setScale(x, 0, getCeiling())
 
@@ -112,7 +112,7 @@ namespace BigDecimal {
     ///
     @Time(1) @Space(1)
     pub def floor(x: BigDecimal): BigDecimal =
-        import java.math.BigDecimal.setScale(Int32, ##java.math.RoundingMode): ##java.math.BigDecimal \ {};
+        import java.math.BigDecimal.setScale(Int32, ##java.math.RoundingMode): BigDecimal \ {};
         import static get java.math.RoundingMode.FLOOR: ##java.math.RoundingMode \ {} as getFloor;
         setScale(x, 0, getFloor())
 
@@ -124,7 +124,7 @@ namespace BigDecimal {
     ///
     @Time(1) @Space(1)
     pub def round(x: BigDecimal): BigDecimal =
-        import java.math.BigDecimal.setScale(Int32, ##java.math.RoundingMode): ##java.math.BigDecimal \ {};
+        import java.math.BigDecimal.setScale(Int32, ##java.math.RoundingMode): BigDecimal \ {};
         import static get java.math.RoundingMode.HALF_EVEN: ##java.math.RoundingMode \ {} as getHalfEven;
         setScale(x, 0, getHalfEven())
 

--- a/main/src/library/Int16.flix
+++ b/main/src/library/Int16.flix
@@ -389,7 +389,7 @@ namespace Int16 {
     ///
     @Time(1) @Space(1)
     pub def toBigDecimal(x: Int16): BigDecimal =
-        import new java.math.BigDecimal(Int32): ##java.math.BigDecimal \ {} as fromInt32;
+        import new java.math.BigDecimal(Int32): BigDecimal \ {} as fromInt32;
         Int16.toInt32(x) |> fromInt32
 
     ///

--- a/main/src/library/Int32.flix
+++ b/main/src/library/Int32.flix
@@ -416,7 +416,7 @@ namespace Int32 {
     ///
     @Time(1) @Space(1)
     pub def toBigDecimal(x: Int32): BigDecimal =
-        import new java.math.BigDecimal(Int32): ##java.math.BigDecimal \ {} as fromInt32;
+        import new java.math.BigDecimal(Int32): BigDecimal \ {} as fromInt32;
         fromInt32(x)
 
     ///

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -417,7 +417,7 @@ namespace Int64 {
     ///
     @Time(1) @Space(1)
     pub def toBigDecimal(x: Int64): BigDecimal =
-        import new java.math.BigDecimal(Int64): ##java.math.BigDecimal \ {} as fromInt64;
+        import new java.math.BigDecimal(Int64): BigDecimal \ {} as fromInt64;
         fromInt64(x)
 
     ///


### PR DESCRIPTION
This PR tidies up the occurrences of `##java.math.BigDecimal` that slipped through the BigDecimal stdlib PR.

`##java.math.BigDecimal` in import signatures is replaced with `BigDecimal`.