### PR TITLE
fix: lsp complete function arguments correctly.

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -280,9 +280,12 @@ object CompletionProvider {
 
   private def getLabelForNameAndSpec(name: String, spec: TypedAst.Spec)(implicit flix: Flix): String = spec match {
     case TypedAst.Spec(_, _, _, _, fparams, _, retTpe0, pur0, eff0, _, _) =>
-      val args = fparams.map {
-        fparam => s"${fparam.sym.text}: ${FormatType.formatType(fparam.tpe)}"
-      }
+      val args = if (fparams.length == 1 && fparams(0).tpe.typeConstructor == Some(TypeConstructor.Unit)) 
+        Nil
+      else
+        fparams.map {
+          fparam => s"${fparam.sym.text}: ${FormatType.formatType(fparam.tpe)}"
+        }
 
       val retTpe = FormatType.formatType(retTpe0)
 


### PR DESCRIPTION
```
def foo(): Unit = ???

foo (position 1)

"Hello world!" |> foo (position 2)
```

At position 1 it would complete as ```foo(?_unit)``` which this changes to ```foo()```
At position 2 it would complete as ```foo``` which this changes to not being suggested as the pipeline requires at least one argument.