### PR TITLE
feat: add IntPredicate to the translated functional interfaces (see issue #4721)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/UnkindedType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/UnkindedType.scala
@@ -199,6 +199,13 @@ object UnkindedType {
   }
 
   /**
+   * Returns the Bool type.
+   */
+  def mkBool(loc: SourceLocation): UnkindedType = {
+    UnkindedType.Cst(TypeConstructor.Bool, loc)
+  }
+
+  /**
     * Returns the ##java.lang.Object type.
     */
   def mkObject(loc: SourceLocation): UnkindedType = {

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -47,6 +47,7 @@ object Resolver {
     * Java classes for primitives and Object
     */
   private val Int = classOf[Int]
+  private val Boolean = classOf[Boolean]
   private val Object = classOf[AnyRef]
 
   /**
@@ -1868,6 +1869,7 @@ object Resolver {
         case "java.lang.String" => UnkindedType.Cst(TypeConstructor.Str, loc).toSuccess
         case "java.util.function.IntFunction" => UnkindedType.mkImpureArrow(UnkindedType.mkInt32(loc), UnkindedType.mkObject(loc), loc).toSuccess
         case "java.util.function.IntUnaryOperator" => UnkindedType.mkImpureArrow(UnkindedType.mkInt32(loc), UnkindedType.mkInt32(loc), loc).toSuccess
+        case "java.util.function.IntPredicate" => UnkindedType.mkImpureArrow(UnkindedType.mkInt32(loc), UnkindedType.mkBool(loc), loc).toSuccess
 
         case _ => lookupJvmClass(fqn, loc) map {
           case clazz => UnkindedType.Cst(TypeConstructor.Native(clazz), loc)
@@ -2681,6 +2683,7 @@ object Resolver {
         flatMapN(targsVal) {
           case Int :: Object :: Nil => Class.forName("java.util.function.IntFunction").toSuccess
           case Int :: Int :: Nil => Class.forName("java.util.function.IntUnaryOperator").toSuccess
+          case Int :: Boolean :: Nil => Class.forName("java.util.function.IntPredicate").toSuccess
           case _ => ResolutionError.IllegalType(tpe, loc).toFailure
         }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -163,6 +163,7 @@ object BackendObjType {
       def jvmName: JvmName = this match {
         case IntFunction => JvmName.IntFunction
         case IntUnaryOperator => JvmName.IntUnaryOperator
+        case IntPredicate => JvmName.IntPredicate
       }
 
       /**
@@ -184,6 +185,13 @@ object BackendObjType {
               DUP() ~ ILOAD(1) ~ PUTFIELD(ArgField(0)) ~
               INVOKEVIRTUAL(continuation.UnwindMethod) ~ IRETURN()
           ))
+        case IntPredicate => InstanceMethod(this.jvmName, IsPublic, IsFinal, "test",
+          mkDescriptor(BackendType.Int32)(BackendType.Bool),
+          Some(
+            thisLoad() ~
+              DUP() ~ ILOAD(1) ~ PUTFIELD(ArgField(0)) ~
+              INVOKEVIRTUAL(continuation.UnwindMethod) ~ IRETURN()
+          ))
       }
     }
 
@@ -192,6 +200,9 @@ object BackendObjType {
 
     // Int32 -> Int32
     case object IntUnaryOperator extends FunctionInterface
+
+    // Int32 -> Bool
+    case object IntPredicate extends FunctionInterface
 
     /**
       * Returns the specialized java function interface of the function type.
@@ -202,6 +213,8 @@ object BackendObjType {
           Some(IntFunction)
         case (BackendType.Int32 :: Nil, BackendType.Int32) =>
           Some(IntUnaryOperator)
+        case (BackendType.Int32 :: Nil, BackendType.Bool) =>
+          Some(IntPredicate)
         case _ => None
       }
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -87,6 +87,7 @@ object JvmName {
   val Float: JvmName = JvmName(JavaLang, "Float")
   val IntFunction: JvmName = JvmName(JavaUtilFunction, "IntFunction")
   val IntUnaryOperator: JvmName = JvmName(JavaUtilFunction, "IntUnaryOperator")
+  val IntPredicate: JvmName = JvmName(JavaUtilFunction, "IntPredicate")
   val Integer: JvmName = JvmName(JavaLang, "Integer")
   val Long: JvmName = JvmName(JavaLang, "Long")
   val Math: JvmName = JvmName(JavaLang, "Math")

--- a/main/test/flix/Test.Java.Function.flix
+++ b/main/test/flix/Test.Java.Function.flix
@@ -2,6 +2,7 @@ namespace Test/Java/Function {
     import java.lang.Object
     import java.util.function.IntFunction
     import java.util.function.IntUnaryOperator
+    import java.util.function.IntPredicate
     import java.util.stream.IntStream
     import java.util.stream.Stream
 
@@ -29,4 +30,15 @@ namespace Test/Java/Function {
        let stream1 = map(stream0, upcast(i -> i+7));
        sum(stream1) == 12
    }
+
+  @Test
+  def testIntPredicate(): Bool \ IO = {
+       import static java.util.stream.IntStream.range(Int32, Int32): IntStream \ IO;
+       import java.util.stream.IntStream.filter(IntPredicate): IntStream \ IO;
+       import java.util.stream.IntStream.sum(): Int32 \ IO;
+       let stream0 = range(0, 9);
+       let stream1 = filter(stream0, upcast(i -> i mod 2 == 0));
+       sum(stream1) == 20
+   }
+
 }


### PR DESCRIPTION
This PR adds `IntPredicate` the Java functional interface of functions `Int32 -> Bool`.

The code is patterned after the `IntUnaryOperator` code so hopefully there is nothing suprising.

A test is in the module `Test.Java.Function.flix`.