### PR TITLE
fix: Don't require that java.lang.Object methods are implemented

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -641,8 +641,9 @@ object Safety {
     val implemented = flixMethods.keySet
 
     val javaMethods = getJavaMethodSignatures(clazz)
+    val objectMethods = getJavaMethodSignatures(classOf[Object]).keySet
     val canImplement = javaMethods.keySet
-    val mustImplement = canImplement.filter(m => isAbstractMethod(javaMethods(m)))
+    val mustImplement = canImplement.filter(m => isAbstractMethod(javaMethods(m)) && !objectMethods.contains(m))
 
     //
     // Check that there are no unimplemented methods.

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -281,6 +281,14 @@ namespace Test/Exp/Jvm/NewObject {
     runTest(anon)
 
   @test
+  def testFunctionalInterface02(): Bool \ IO =
+    import java.util.Comparator.compare(##java.lang.Object, ##java.lang.Object): Int32;
+    let anon = new ##java.util.Comparator {
+      def compare(_this: ##java.util.Comparator, _t: ##java.lang.Object, _u: ##java.lang.Object): Int32 = 0
+    };
+    compare(anon, "foo" as Object, "bar" as Object) == 0
+
+  @test
   def testClassWithDefaultConstructor01(): Bool \ IO =
     import flix.test.TestClassWithDefaultConstructor.abstractMethod(Int32): Int32;
     import flix.test.TestClassWithDefaultConstructor.concreteMethod(String): String;


### PR DESCRIPTION
Fixes #4759