### PR TITLE
fix: Add UpperBound to Down

### DIFF
--- a/main/src/library/Down.flix
+++ b/main/src/library/Down.flix
@@ -49,6 +49,10 @@ instance LowerBound[Down[a]] with UpperBound[a] {
     pub def minValue(): Down[a] = Down(UpperBound.maxValue())
 }
 
+instance UpperBound[Down[a]] with LowerBound[a] {
+    pub def maxValue(): Down[a] = Down(LowerBound.minValue())
+}
+
 instance JoinLattice[Down[a]] with MeetLattice[a] {
     pub def leastUpperBound(x: Down[a], y: Down[a]): Down[a] = match (x, y) {
         case (Down(xx), Down(yy)) => Down(xx `MeetLattice.greatestLowerBound` yy)


### PR DESCRIPTION
Fixes #4763

No tests 😱, but there don't seem to be any tests for `Down`? And I guess it's pretty simple?