### PR TITLE
test: Add tests to confirm that parent namespace not visible in child

### DIFF
--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -1070,4 +1070,60 @@ class TestResolver extends FunSuite with TestUtils {
     expectError[ResolutionError.IllegalNonJavaType](result)
   }
 
+  test("ParentNamespaceNotVisible.01") {
+    val input =
+      """
+        |namespace A {
+        |    pub enum X
+        |    namespace B {
+        |        def foo(): X = ???
+        |    }
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ResolutionError.UndefinedType](result)
+  }
+
+  test("ParentNamespaceNotVisible.02") {
+    val input =
+      """
+        |namespace A {
+        |    pub type alias X = Int32
+        |    namespace B {
+        |        def foo(): X = ???
+        |    }
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ResolutionError.UndefinedType](result)
+  }
+
+  test("ParentNamespaceNotVisible.03") {
+    val input =
+      """
+        |namespace A {
+        |    pub class X[a]
+        |    namespace B {
+        |        enum Y
+        |        instance X[Y] 
+        |    }
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ResolutionError.UndefinedClass](result)
+  }
+
+  test("ParentNamespaceNotVisible.04") {
+    val input =
+      """
+        |namespace A {
+        |    pub def x(): Int32 = ???
+        |    namespace B {
+        |        def foo(): Int32 = x()
+        |    }
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ResolutionError.UndefinedName](result)
+  }
 }


### PR DESCRIPTION
Part of #4746

Add tests to confirm that parent namespace declarations are not visible in child namespace