### PR TITLE
chore: Add $CHANNEL_GET$ to internal syntax and use in Channel.recv.

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -658,6 +658,8 @@ object Weeder {
           case ("STRING_EQ", e1 :: e2 :: Nil) => WeededAst.Expression.Binary(SemanticOperator.StringOp.Eq, e1, e2, loc).toSuccess
           case ("STRING_NEQ", e1 :: e2 :: Nil) => WeededAst.Expression.Binary(SemanticOperator.StringOp.Neq, e1, e2, loc).toSuccess
 
+          case ("CHANNEL_GET", e1 :: Nil) => WeededAst.Expression.GetChannel(e1, loc).toSuccess
+
           case _ => WeederError.IllegalIntrinsic(loc).toFailure
         }
       }

--- a/main/src/library/Channel.flix
+++ b/main/src/library/Channel.flix
@@ -37,7 +37,7 @@ namespace Channel {
     ///
     /// Blocks until a message is dequeued.
     ///
-    pub def recv(r: Receiver[t]): t \ IO = <- r
+    pub def recv(r: Receiver[t]): t \ IO = $CHANNEL_GET$(r)
 
     ///
     /// Sends the message `m` on the given channel `s`.

--- a/main/test/flix/Test.Exp.Concurrency.Buffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Buffered.flix
@@ -4,91 +4,91 @@ namespace Test/Exp/Concurrency/Buffered {
     def testBufferedChannel01(): Bool \ IO =
         let c = chan Unit 1;
         c <- ();
-        () == <- c
+        () == Channel.recv(c)
 
     @test
     def testBufferedChannel02(): Bool \ IO =
         let c = chan Bool 1;
         c <- true;
-        true == <- c
+        true == Channel.recv(c)
 
     @test
     def testBufferedChannel03(): Bool \ IO =
         let c = chan Float32 1;
         c <- 123.456f32;
-        123.456f32 == <- c
+        123.456f32 == Channel.recv(c)
 
     @test
     def testBufferedChannel04(): Bool \ IO =
         let c = chan Float64 1;
         c <- 123.456f64;
-        123.456f64 == <- c
+        123.456f64 == Channel.recv(c)
 
     @test
     def testBufferedChannel05(): Bool \ IO =
         let c = chan Int8 1;
         c <- 42i8;
-        42i8 == <- c
+        42i8 == Channel.recv(c)
 
     @test
     def testBufferedChannel06(): Bool \ IO =
         let c = chan Int16 1;
         c <- 42i16;
-        42i16 == <- c
+        42i16 == Channel.recv(c)
 
     @test
     def testBufferedChannel07(): Bool \ IO =
         let c = chan Int32 1;
         c <- 42i32;
-        42i32 == <- c
+        42i32 == Channel.recv(c)
 
     @test
     def testBufferedChannel08(): Bool \ IO =
         let c = chan Int64 1;
         c <- 42i64;
-        42i64 == <- c
+        42i64 == Channel.recv(c)
 
     @test
     def testBufferedChannel09(): Bool \ IO =
         let c = chan BigInt 1;
         c <- 42ii;
-        42ii == <- c
+        42ii == Channel.recv(c)
 
     @test
     def testBufferedChannel10(): Bool \ IO =
         let c = chan String 1;
         c <- "Hello World!";
-        "Hello World!" == <- c
+        "Hello World!" == Channel.recv(c)
 
     @test
     def testBufferedChannel11(): Bool \ IO =
         let c = chan Option[Int32] 1;
         c <- None;
-        None == <- c
+        None == Channel.recv(c)
 
     @test
     def testBufferedChannel12(): Bool \ IO =
         let c = chan Option[Int32] 1;
         c <- Some(123);
-        Some(123) == <- c
+        Some(123) == Channel.recv(c)
 
     @test
     def testBufferedChannel13(): Bool \ IO =
         let c = chan Result[Int32, String] 1;
         c <- Ok(123);
-        Ok(123) == <- c
+        Ok(123) == Channel.recv(c)
 
     @test
     def testBufferedChannel14(): Bool \ IO =
         let c = chan Result[Int32, String] 1;
         c <- Err("Goodbye World!");
-        Err("Goodbye World!") == <- c
+        Err("Goodbye World!") == Channel.recv(c)
 
     @test
     def testBufferedChannel15(): Bool \ IO =
         let c = chan Array[Int32, Static] 1;
         c <- [1, 2, 3];
-        2 == (<- c)[1]
+        2 == (Channel.recv(c))[1]
 
     @test
     def testBufferedChannel16(): Bool \ IO =
@@ -96,97 +96,97 @@ namespace Test/Exp/Concurrency/Buffered {
         let c2 = chan Int32 1;
         c1 <- c2;
         c2 <- 42;
-        42 == <- <- c1
+        42 == Channel.recv(Channel.recv(c1))
 
     @test
     def testBufferedChannelWithSpawn01(): Bool \ IO =
         let c = chan Unit 1;
         spawn c <- ();
-        () == <- c
+        () == Channel.recv(c)
 
     @test
     def testBufferedChannelWithSpawn02(): Bool \ IO =
         let c = chan Bool 1;
         spawn c <- true;
-        true == <- c
+        true == Channel.recv(c)
 
     @test
     def testBufferedChannelWithSpawn03(): Bool \ IO =
         let c = chan Float32 1;
         spawn c <- 123.456f32;
-        123.456f32 == <- c
+        123.456f32 == Channel.recv(c)
 
     @test
     def testBufferedChannelWithSpawn04(): Bool \ IO =
         let c = chan Float64 1;
         spawn c <- 123.456f64;
-        123.456f64 == <- c
+        123.456f64 == Channel.recv(c)
 
     @test
     def testBufferedChannelWithSpawn05(): Bool \ IO =
         let c = chan Int8 1;
         spawn c <- 42i8;
-        42i8 == <- c
+        42i8 == Channel.recv(c)
 
     @test
     def testBufferedChannelWithSpawn06(): Bool \ IO =
         let c = chan Int16 1;
         spawn c <- 42i16;
-        42i16 == <- c
+        42i16 == Channel.recv(c)
 
     @test
     def testBufferedChannelWithSpawn07(): Bool \ IO =
         let c = chan Int32 1;
         spawn c <- 42i32;
-        42i32 == <- c
+        42i32 == Channel.recv(c)
 
     @test
     def testBufferedChannelWithSpawn08(): Bool \ IO =
         let c = chan Int64 1;
         spawn c <- 42i64;
-        42i64 == <- c
+        42i64 == Channel.recv(c)
 
     @test
     def testBufferedChannelWithSpawn09(): Bool \ IO =
         let c = chan BigInt 1;
         spawn c <- 42ii;
-        42ii == <- c
+        42ii == Channel.recv(c)
 
     @test
     def testBufferedChannelWithSpawn10(): Bool \ IO =
         let c = chan String 1;
         spawn c <- "Hello World!";
-        "Hello World!" == <- c
+        "Hello World!" == Channel.recv(c)
 
     @test
     def testBufferedChannelWithSpawn11(): Bool \ IO =
         let c = chan Option[Int32] 1;
         spawn c <- None;
-        None == <- c
+        None == Channel.recv(c)
 
     @test
     def testBufferedChannelWithSpawn12(): Bool \ IO =
         let c = chan Option[Int32] 1;
         spawn c <- Some(123);
-        Some(123) == <- c
+        Some(123) == Channel.recv(c)
 
     @test
     def testBufferedChannelWithSpawn13(): Bool \ IO =
         let c = chan Result[Int32, String] 1;
         spawn c <- Ok(123);
-        Ok(123) == <- c
+        Ok(123) == Channel.recv(c)
 
     @test
     def testBufferedChannelWithSpawn14(): Bool \ IO =
         let c = chan Result[Int32, String] 1;
         spawn c <- Err("Goodbye World!");
-        Err("Goodbye World!") == <- c
+        Err("Goodbye World!") == Channel.recv(c)
 
     @test
     def testBufferedChannelWithSpawn15(): Bool \ IO =
         let c = chan Array[Int32, Static] 1;
         spawn c <- [1, 2, 3];
-        2 == (<- c)[1]
+        2 == (Channel.recv(c))[1]
 
     @test
     def testBufferedChannelWithSpawn16(): Bool \ IO =
@@ -194,6 +194,6 @@ namespace Test/Exp/Concurrency/Buffered {
         let c2 = chan Int32 1;
         spawn c1 <- c2;
         spawn c2 <- 42;
-        42 == <- <- c1
+        42 == Channel.recv(Channel.recv(c1))
 
 }

--- a/main/test/flix/Test.Exp.Concurrency.Unbuffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Unbuffered.flix
@@ -4,91 +4,91 @@ namespace Test/Exp/Concurrency/Unbuffered {
     def testUnbufferedChannelPutGet01(): Bool \ IO =
         let c = chan Unit 0;
         spawn c <- ();
-        () == <- c
+        () == Channel.recv(c)
 
     @test
     def testUnbufferedChannelPutGet02(): Bool \ IO =
         let c = chan Bool 0;
         spawn c <- true;
-        true == <- c
+        true == Channel.recv(c)
 
     @test
     def testUnbufferedChannelPutGet03(): Bool \ IO =
         let c = chan Float32 0;
         spawn c <- 123.456f32;
-        123.456f32 == <- c
+        123.456f32 == Channel.recv(c)
 
     @test
     def testUnbufferedChannelPutGet04(): Bool \ IO =
         let c = chan Float64 0;
         spawn c <- 123.456f64;
-        123.456f64 == <- c
+        123.456f64 == Channel.recv(c)
 
     @test
     def testUnbufferedChannelPutGet05(): Bool \ IO =
         let c = chan Int8 0;
         spawn c <- 42i8;
-        42i8 == <- c
+        42i8 == Channel.recv(c)
 
     @test
     def testUnbufferedChannelPutGet06(): Bool \ IO =
         let c = chan Int16 0;
         spawn c <- 42i16;
-        42i16 == <- c
+        42i16 == Channel.recv(c)
 
     @test
     def testUnbufferedChannelPutGet07(): Bool \ IO =
         let c = chan Int32 0;
         spawn c <- 42i32;
-        42i32 == <- c
+        42i32 == Channel.recv(c)
 
     @test
     def testUnbufferedChannelPutGet08(): Bool \ IO =
         let c = chan Int64 0;
         spawn c <- 42i64;
-        42i64 == <- c
+        42i64 == Channel.recv(c)
 
     @test
     def testUnbufferedChannelPutGet09(): Bool \ IO =
         let c = chan BigInt 0;
         spawn c <- 42ii;
-        42ii == <- c
+        42ii == Channel.recv(c)
 
     @test
     def testUnbufferedChannelPutGet10(): Bool \ IO =
         let c = chan String 0;
         spawn c <- "Hello World!";
-        "Hello World!" == <- c
+        "Hello World!" == Channel.recv(c)
 
     @test
     def testUnbufferedChannelPutGet11(): Bool \ IO =
         let c = chan Option[Int32] 0;
         spawn c <- None;
-        None == <- c
+        None == Channel.recv(c)
 
     @test
     def testUnbufferedChannelPutGet12(): Bool \ IO =
         let c = chan Option[Int32] 0;
         spawn c <- Some(123);
-        Some(123) == <- c
+        Some(123) == Channel.recv(c)
 
     @test
     def testUnbufferedChannelPutGet13(): Bool \ IO =
         let c = chan Result[Int32, String] 0;
         spawn c <- Ok(123);
-        Ok(123) == <- c
+        Ok(123) == Channel.recv(c)
 
     @test
     def testUnbufferedChannelPutGet14(): Bool \ IO =
         let c = chan Result[Int32, String] 0;
         spawn c <- Err("Goodbye World!");
-        Err("Goodbye World!") == <- c
+        Err("Goodbye World!") == Channel.recv(c)
 
     @test
     def testUnbufferedChannelPutGet15(): Bool \ IO =
         let c = chan Array[Int32, Static] 0;
         spawn c <- [1, 2, 3];
-        2 == (<- c)[1]
+        2 == (Channel.recv(c))[1]
 
     @test
     def testUnbufferedChannelPutGet16(): Bool \ IO =
@@ -96,103 +96,103 @@ namespace Test/Exp/Concurrency/Unbuffered {
         let c2 = chan Int32 0;
         spawn c1 <- c2;
         spawn c2 <- 42;
-        42 == <- <- c1
-
+        42 == Channel.recv(Channel.recv(c1)
+)
     @test
     def testUnbufferedChannelGetPut01(): Unit \ IO =
         let c = chan Unit 0;
-        spawn <- c;
+        spawn Channel.recv(c);
         c <- ()
 
     @test
     def testUnbufferedChannelGetPut02(): Unit \ IO =
         let c = chan Bool 0;
-        spawn <- c;
+        spawn Channel.recv(c);
         c <- true
 
     @test
     def testUnbufferedChannelGetPut03(): Unit \ IO =
         let c = chan Float32 0;
-        spawn <- c;
+        spawn Channel.recv(c);
         c <- 123.456f32
 
     @test
     def testUnbufferedChannelGetPut04(): Unit \ IO =
         let c = chan Float64 0;
-        spawn <- c;
+        spawn Channel.recv(c);
         c <- 123.456f64
 
     @test
     def testUnbufferedChannelGetPut05(): Unit \ IO =
         let c = chan Int8 0;
-        spawn <- c;
+        spawn Channel.recv(c);
         c <- 42i8
     @test
 
     def testUnbufferedChannelGetPut06(): Unit \ IO =
         let c = chan Int16 0;
-        spawn <- c;
+        spawn Channel.recv(c);
         c <- 42i16
 
     @test
     def testUnbufferedChannelGetPut07(): Unit \ IO =
         let c = chan Int32 0;
-        spawn <- c;
+        spawn Channel.recv(c);
         c <- 42i32
 
     @test
     def testUnbufferedChannelGetPut08(): Unit \ IO =
         let c = chan Int64 0;
-        spawn <- c;
+        spawn Channel.recv(c);
         c <- 42i64
 
     @test
     def testUnbufferedChannelGetPut09(): Unit \ IO =
         let c = chan BigInt 0;
-        spawn <- c;
+        spawn Channel.recv(c);
         c <- 42ii
 
     @test
     def testUnbufferedChannelGetPut10(): Unit \ IO =
         let c = chan String 0;
-        spawn <- c;
+        spawn Channel.recv(c);
         c <- "Hello World!"
 
     @test
     def testUnbufferedChannelGetPut11(): Unit \ IO =
         let c = chan Option[Int32] 0;
-        spawn <- c;
+        spawn Channel.recv(c);
         c <- None
 
     @test
     def testUnbufferedChannelGetPut12(): Unit \ IO =
         let c = chan Option[Int32] 0;
-        spawn <- c;
+        spawn Channel.recv(c);
         c <- Some(123)
 
     @test
     def testUnbufferedChannelGetPut13(): Unit \ IO =
         let c = chan Result[Int32, String] 0;
-        spawn <- c;
+        spawn Channel.recv(c);
         c <- Ok(123)
 
     @test
     def testUnbufferedChannelGetPut14(): Unit \ IO =
         let c = chan Result[Int32, String] 0;
-        spawn <- c;
+        spawn Channel.recv(c);
         c <- Err("Goodbye World!")
 
     @test
     def testUnbufferedChannelGetPut15(): Unit \ IO =
         let c = chan Array[Int32, Static] 0;
-        spawn <- c;
+        spawn Channel.recv(c);
         c <- [1, 2, 3]
 
     @test
     def testUnbufferedChannelGetPut16(): Unit \ IO =
         let c1 = chan Channel[Int32] 0;
         let c2 = chan Int32 0;
-        spawn <- <- c1;
+        spawn Channel.recv(Channel.recv(c1));
         spawn c1 <- c2;
         c2 <- 42
 }


### PR DESCRIPTION
This addresses the "Add $CHANNEL_GET(exp)$" task of #4755

I've also changed a number of the channel gets in the tests to use `Channel.recv` (not all of them, but enough to be confident that this works).