### PR TITLE
chore: Remove type from NewChannel

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -188,7 +188,7 @@ object KindedAst {
 
     case class NewObject(name: String, clazz: java.lang.Class[_], methods: List[KindedAst.JvmMethod], loc: SourceLocation) extends KindedAst.Expression
 
-    case class NewChannel(exp: KindedAst.Expression, tpe: Type, loc: SourceLocation) extends KindedAst.Expression
+    case class NewChannel(exp: KindedAst.Expression, loc: SourceLocation) extends KindedAst.Expression
 
     case class GetChannel(exp: KindedAst.Expression, tpe: Type.Var, loc: SourceLocation) extends KindedAst.Expression
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -188,7 +188,7 @@ object KindedAst {
 
     case class NewObject(name: String, clazz: java.lang.Class[_], methods: List[KindedAst.JvmMethod], loc: SourceLocation) extends KindedAst.Expression
 
-    case class NewChannel(exp: KindedAst.Expression, loc: SourceLocation) extends KindedAst.Expression
+    case class NewChannel(exp: KindedAst.Expression, elemType: Type.Var, loc: SourceLocation) extends KindedAst.Expression
 
     case class GetChannel(exp: KindedAst.Expression, tpe: Type.Var, loc: SourceLocation) extends KindedAst.Expression
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -188,7 +188,7 @@ object KindedAst {
 
     case class NewObject(name: String, clazz: java.lang.Class[_], methods: List[KindedAst.JvmMethod], loc: SourceLocation) extends KindedAst.Expression
 
-    case class NewChannel(exp: KindedAst.Expression, elemType: Type.Var, loc: SourceLocation) extends KindedAst.Expression
+    case class NewChannel(exp: KindedAst.Expression, elmType: Type.Var, loc: SourceLocation) extends KindedAst.Expression
 
     case class GetChannel(exp: KindedAst.Expression, tpe: Type.Var, loc: SourceLocation) extends KindedAst.Expression
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -209,7 +209,7 @@ object NamedAst {
 
     case class NewObject(name: String, tpe: NamedAst.Type, methods: List[JvmMethod], loc: SourceLocation) extends NamedAst.Expression
 
-    case class NewChannel(exp: NamedAst.Expression, tpe: NamedAst.Type, loc: SourceLocation) extends NamedAst.Expression
+    case class NewChannel(exp: NamedAst.Expression, loc: SourceLocation) extends NamedAst.Expression
 
     case class GetChannel(exp: NamedAst.Expression, loc: SourceLocation) extends NamedAst.Expression
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -190,7 +190,7 @@ object ResolvedAst {
 
     case class NewObject(name: String, clazz: java.lang.Class[_], methods: List[JvmMethod], loc: SourceLocation) extends ResolvedAst.Expression
 
-    case class NewChannel(exp: ResolvedAst.Expression, tpe: UnkindedType, loc: SourceLocation) extends ResolvedAst.Expression
+    case class NewChannel(exp: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
 
     case class GetChannel(exp: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -211,7 +211,7 @@ object WeededAst {
 
     case class NewObject(tpe: WeededAst.Type, methods: List[JvmMethod], loc: SourceLocation) extends WeededAst.Expression
 
-    case class NewChannel(exp: WeededAst.Expression, tpe: WeededAst.Type, loc: SourceLocation) extends WeededAst.Expression
+    case class NewChannel(exp: WeededAst.Expression, loc: SourceLocation) extends WeededAst.Expression
 
     case class GetChannel(exp: WeededAst.Expression, loc: SourceLocation) extends WeededAst.Expression
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -717,7 +717,7 @@ object Kinder {
     case ResolvedAst.Expression.NewChannel(exp0, loc) =>
       val expVal = visitExp(exp0, kenv0, senv, taenv, henv0, root)
       mapN(expVal) {
-        case exp => KindedAst.Expression.NewChannel(exp, loc)
+        case exp => KindedAst.Expression.NewChannel(exp, Type.freshVar(Kind.Star, loc.asSynthetic), loc)
       }
 
     case ResolvedAst.Expression.GetChannel(exp0, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -714,11 +714,10 @@ object Kinder {
         methods => KindedAst.Expression.NewObject(name, clazz, methods, loc)
       }
 
-    case ResolvedAst.Expression.NewChannel(exp0, tpe0, loc) =>
+    case ResolvedAst.Expression.NewChannel(exp0, loc) =>
       val expVal = visitExp(exp0, kenv0, senv, taenv, henv0, root)
-      val tpeVal = visitType(tpe0, Kind.Star, kenv0, senv, taenv, root)
-      mapN(expVal, tpeVal) {
-        case (exp, tpe) => KindedAst.Expression.NewChannel(exp, tpe, loc)
+      mapN(expVal) {
+        case exp => KindedAst.Expression.NewChannel(exp, loc)
       }
 
     case ResolvedAst.Expression.GetChannel(exp0, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -1027,9 +1027,9 @@ object Namer {
           NamedAst.Expression.NewObject(name, tpe, ms, loc)
       }
 
-    case WeededAst.Expression.NewChannel(exp, tpe, loc) =>
-      mapN(visitExp(exp, env0, uenv0, ienv0, tenv0, ns0, prog0), visitType(tpe, uenv0, ienv0, tenv0)) {
-        case (e, t) => NamedAst.Expression.NewChannel(e, t, loc)
+    case WeededAst.Expression.NewChannel(exp, loc) =>
+      mapN(visitExp(exp, env0, uenv0, ienv0, tenv0, ns0, prog0)) {
+        case e => NamedAst.Expression.NewChannel(e, loc)
       }
 
     case WeededAst.Expression.GetChannel(exp, loc) =>
@@ -1592,7 +1592,7 @@ object Namer {
     case WeededAst.Expression.GetStaticField(_, _, _) => Nil
     case WeededAst.Expression.PutStaticField(_, _, exp, _) => freeVars(exp)
     case WeededAst.Expression.NewObject(_, methods, _) => methods.flatMap(m => freeVars(m.exp))
-    case WeededAst.Expression.NewChannel(exp, _, _) => freeVars(exp)
+    case WeededAst.Expression.NewChannel(exp, _) => freeVars(exp)
     case WeededAst.Expression.GetChannel(exp, _) => freeVars(exp)
     case WeededAst.Expression.PutChannel(exp1, exp2, _) => freeVars(exp1) ++ freeVars(exp2)
     case WeededAst.Expression.SelectChannel(rules, default, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1112,11 +1112,10 @@ object Resolver {
               }
           }
 
-        case NamedAst.Expression.NewChannel(exp, tpe, loc) =>
-          val tVal = resolveType(tpe, taenv, ns0, root)
+        case NamedAst.Expression.NewChannel(exp, loc) =>
           val eVal = visitExp(exp, region)
-          mapN(tVal, eVal) {
-            case (t, e) => ResolvedAst.Expression.NewChannel(e, t, loc)
+          mapN(eVal) {
+            case e => ResolvedAst.Expression.NewChannel(e, loc)
           }
 
         case NamedAst.Expression.GetChannel(exp, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -1564,7 +1564,7 @@ object Typer {
         for {
           (constrs, tpe, _, eff) <- visitExp(exp)
           _ <- expectTypeM(expected = Type.Int32, actual = tpe, exp.loc)
-          resultTyp <- liftM(Type.mkChannel(tpe, loc))
+          resultTyp <- liftM(Type.freshVar(Kind.Star, loc, text = FallbackText("channel")))
           resultPur = Type.Impure
           resultEff = eff
         } yield (constrs, resultTyp, resultPur, resultEff)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -1560,11 +1560,11 @@ object Typer {
         } yield (constrs.flatten, resultTyp, resultPur, resultEff)
 
 
-      case KindedAst.Expression.NewChannel(exp, declaredType, loc) =>
+      case KindedAst.Expression.NewChannel(exp, loc) =>
         for {
           (constrs, tpe, _, eff) <- visitExp(exp)
           _ <- expectTypeM(expected = Type.Int32, actual = tpe, exp.loc)
-          resultTyp <- liftM(Type.mkChannel(declaredType, loc))
+          resultTyp <- liftM(Type.mkChannel(tpe, loc))
           resultPur = Type.Impure
           resultEff = eff
         } yield (constrs, resultTyp, resultPur, resultEff)
@@ -2253,11 +2253,11 @@ object Typer {
         val ms = methods map visitJvmMethod
         TypedAst.Expression.NewObject(name, clazz, tpe, pur, eff, ms, loc)
 
-      case KindedAst.Expression.NewChannel(exp, tpe, loc) =>
+      case KindedAst.Expression.NewChannel(exp, loc) =>
         val e = visitExp(exp, subst0)
         val pur = Type.Impure
         val eff = e.eff
-        TypedAst.Expression.NewChannel(e, Type.mkChannel(tpe, loc), pur, eff, loc)
+        TypedAst.Expression.NewChannel(e, Type.mkChannel(e.tpe, loc), pur, eff, loc)
 
       case KindedAst.Expression.GetChannel(exp, tvar, loc) =>
         val e = visitExp(exp, subst0)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -1560,11 +1560,11 @@ object Typer {
         } yield (constrs.flatten, resultTyp, resultPur, resultEff)
 
 
-      case KindedAst.Expression.NewChannel(exp, loc) =>
+      case KindedAst.Expression.NewChannel(exp, elmType, loc) =>
         for {
           (constrs, tpe, _, eff) <- visitExp(exp)
           _ <- expectTypeM(expected = Type.Int32, actual = tpe, exp.loc)
-          resultTyp <- liftM(Type.freshVar(Kind.Star, loc, text = FallbackText("channel")))
+          resultTyp <- liftM(elmType)
           resultPur = Type.Impure
           resultEff = eff
         } yield (constrs, resultTyp, resultPur, resultEff)
@@ -2253,11 +2253,11 @@ object Typer {
         val ms = methods map visitJvmMethod
         TypedAst.Expression.NewObject(name, clazz, tpe, pur, eff, ms, loc)
 
-      case KindedAst.Expression.NewChannel(exp, loc) =>
+      case KindedAst.Expression.NewChannel(exp, elmType, loc) =>
         val e = visitExp(exp, subst0)
         val pur = Type.Impure
         val eff = e.eff
-        TypedAst.Expression.NewChannel(e, Type.mkChannel(e.tpe, loc), pur, eff, loc)
+        TypedAst.Expression.NewChannel(e, Type.mkChannel(elmType, loc), pur, eff, loc)
 
       case KindedAst.Expression.GetChannel(exp, tvar, loc) =>
         val e = visitExp(exp, subst0)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -2257,7 +2257,7 @@ object Typer {
         val e = visitExp(exp, subst0)
         val pur = Type.Impure
         val eff = e.eff
-        TypedAst.Expression.NewChannel(e, Type.mkChannel(elmType, loc), pur, eff, loc)
+        TypedAst.Expression.NewChannel(e, Type.mkChannel(subst0(elmType), loc), pur, eff, loc)
 
       case KindedAst.Expression.GetChannel(exp, tvar, loc) =>
         val e = visitExp(exp, subst0)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -1564,7 +1564,7 @@ object Typer {
         for {
           (constrs, tpe, _, eff) <- visitExp(exp)
           _ <- expectTypeM(expected = Type.Int32, actual = tpe, exp.loc)
-          resultTyp <- liftM(elmType)
+          resultTyp <- liftM(Type.mkChannel(elmType, loc))
           resultPur = Type.Impure
           resultEff = eff
         } yield (constrs, resultTyp, resultPur, resultEff)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1561,9 +1561,9 @@ object Weeder {
       }
 
     // TODO SJ: Rewrite to Ascribe(newch, Channel[Int32]), to remove the tpe (and get tvar like everything else)
-    case ParsedAst.Expression.NewChannel(sp1, tpe, exp, sp2) =>
+    case ParsedAst.Expression.NewChannel(sp1, _, exp, sp2) =>
       visitExp(exp, senv) map {
-        case e => WeededAst.Expression.NewChannel(e, visitType(tpe), mkSL(sp1, sp2))
+        case e => WeededAst.Expression.NewChannel(e, mkSL(sp1, sp2))
       }
 
     case ParsedAst.Expression.GetChannel(sp1, exp, sp2) =>

--- a/main/test/flix/Test.Exp.Concurrency.Buffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Buffered.flix
@@ -62,7 +62,7 @@ namespace Test/Exp/Concurrency/Buffered {
 
     @test
     def testBufferedChannel11(): Bool \ IO =
-        let c = chan Option[Int32] 1;
+        let c: Channel[Option[Int32]] = chan Option[Int32] 1;
         Channel.send(None, c);
         None == Channel.recv(c)
 
@@ -74,13 +74,13 @@ namespace Test/Exp/Concurrency/Buffered {
 
     @test
     def testBufferedChannel13(): Bool \ IO =
-        let c = chan Result[Int32, String] 1;
+        let c: Channel[Result[Int32, String]] = chan Result[Int32, String] 1;
         Channel.send(Ok(123), c);
         Ok(123) == Channel.recv(c)
 
     @test
     def testBufferedChannel14(): Bool \ IO =
-        let c = chan Result[Int32, String] 1;
+        let c: Channel[Result[Int32, String]] = chan Result[Int32, String] 1;
         Channel.send(Err("Goodbye World!"), c);
         Err("Goodbye World!") == Channel.recv(c)
 
@@ -160,7 +160,7 @@ namespace Test/Exp/Concurrency/Buffered {
 
     @test
     def testBufferedChannelWithSpawn11(): Bool \ IO =
-        let c = chan Option[Int32] 1;
+        let c: Channel[Option[Int32]] = chan Option[Int32] 1;
         spawn Channel.send(None, c);
         None == Channel.recv(c)
 
@@ -172,13 +172,13 @@ namespace Test/Exp/Concurrency/Buffered {
 
     @test
     def testBufferedChannelWithSpawn13(): Bool \ IO =
-        let c = chan Result[Int32, String] 1;
+        let c: Channel[Result[Int32, String]] = chan Result[Int32, String] 1;
         spawn Channel.send(Ok(123), c);
         Ok(123) == Channel.recv(c)
 
     @test
     def testBufferedChannelWithSpawn14(): Bool \ IO =
-        let c = chan Result[Int32, String] 1;
+        let c: Channel[Result[Int32, String]] = chan Result[Int32, String] 1;
         spawn Channel.send(Err("Goodbye World!"), c);
         Err("Goodbye World!") == Channel.recv(c)
 

--- a/main/test/flix/Test.Exp.Concurrency.Unbuffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Unbuffered.flix
@@ -62,7 +62,7 @@ namespace Test/Exp/Concurrency/Unbuffered {
 
     @test
     def testUnbufferedChannelPutGet11(): Bool \ IO =
-        let c = chan Option[Int32] 0;
+        let c: Channel[Option[Int32]] = chan Option[Int32] 0;
         spawn Channel.send(None, c);
         None == Channel.recv(c)
 
@@ -74,13 +74,13 @@ namespace Test/Exp/Concurrency/Unbuffered {
 
     @test
     def testUnbufferedChannelPutGet13(): Bool \ IO =
-        let c = chan Result[Int32, String] 0;
+        let c: Channel[Result[Int32, String]] = chan Result[Int32, String] 0;
         spawn Channel.send(Ok(123), c);
         Ok(123) == Channel.recv(c)
 
     @test
     def testUnbufferedChannelPutGet14(): Bool \ IO =
-        let c = chan Result[Int32, String] 0;
+        let c: Channel[Result[Int32, String]] = chan Result[Int32, String] 0;
         spawn Channel.send(Err("Goodbye World!"), c);
         Err("Goodbye World!") == Channel.recv(c)
 


### PR DESCRIPTION
This is an attempt to remove the type from NewObject, as discussed in #4755

But this results in errors of the form:

```
- Test.Currying.flix *** FAILED ***
  Unable to compile. Failed with: 6 errors.
  
  -- Type Error -------------------------------------------------- RedBlackTree.flix
  
  >> Expected type: '?elm155501' but found type: 'Bool'.
  
  392 |                         spawn (chanL <- parExists((n - 2) / 2, f, a)); // We divide the rest of the threads as follows:
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                expression has unexpected type.
```

Which I'm not sure I understand.

I'd be grateful for a pointer as to what might be going on @magnus-madsen