### PR TITLE
fix: Allow Ident to be marked as synthetic

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Name.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Name.scala
@@ -105,6 +105,20 @@ object Name {
       * Human readable representation.
       */
     override def toString: String = name
+
+    /**
+      * Convert this Ident to synthetic
+      */
+    def asSynthetic = new SyntheticIdent(sp1, name, sp2)
+  }
+
+  /**
+    * Synthetic Identifier
+    *
+    * Behaves just like Ident, but reports its `loc` as synthetic.
+    */
+  class SyntheticIdent(sp1: SourcePosition, name: String, sp2: SourcePosition) extends Ident(sp1, name, sp2) {
+    override def loc: SourceLocation = SourceLocation.mk(sp1, sp2, SourceKind.Synthetic)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1796,7 +1796,7 @@ object Weeder {
     val loc = mkSL(sp1, sp2).asSynthetic
 
     // The name of the lambda parameter.
-    val ident = Name.Ident(sp1, "pat" + Flix.Delimiter + flix.genSym.freshId(), sp2)
+    val ident = Name.Ident(sp1, "pat" + Flix.Delimiter + flix.genSym.freshId(), sp2).asSynthetic
 
     // Construct the body of the lambda expression.
     val varOrRef = WeededAst.Expression.VarOrDefOrSig(ident, loc)


### PR DESCRIPTION
As per discussion on Gitter, this allows lambda parameters to be marked as synthetic (which means that syntax colouring is correct for match lambdas).