### PR TITLE
feat: New select syntax

### DIFF
--- a/examples/select-with-defaults-and-timers.flix
+++ b/examples/select-with-defaults-and-timers.flix
@@ -9,8 +9,8 @@ def slow(x: Int32, s: Sender[Int32]): Unit \ IO =
 /// Returns the default value `1` if `c` is not ready.
 def recvWithDefault(r: Receiver[Int32]): Int32 \ IO =
     select {
-        case x <- r => x
-        case _      => 1
+        case x <- recv(r) => x
+        case _            => 1
     }
 
 /// Reads a value from the channel `c`.
@@ -19,8 +19,8 @@ def recvWithTimeout(c: Receiver[Int32]): Int32 \ IO =
     use Time/Duration.fromSeconds;
     let t = Channel.timeout(fromSeconds(1));
     select {
-        case x <- c => x
-        case _ <- t => 2
+        case x <- recv(c) => x
+        case _ <- recv(t) => 2
     }
 
 /// Creates two channels `c1` and `c2`.

--- a/examples/using-channels-and-select.flix
+++ b/examples/using-channels-and-select.flix
@@ -28,8 +28,8 @@ def main(): Unit \ IO = {
     spawn meow(s2, 3);
     spawn hiss(s3, 7);
     select {
-        case m <- r1 => m |> println
-        case m <- r2 => m |> println
-        case m <- r3 => m |> println
+        case m <- recv(r1) => m |> println
+        case m <- recv(r2) => m |> println
+        case m <- recv(r3) => m |> println
     }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1000,7 +1000,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     def SelectChannel: Rule1[ParsedAst.Expression.SelectChannel] = {
       def SelectChannelRule: Rule1[ParsedAst.SelectChannelRule] = rule {
-        keyword("case") ~ WS ~ Names.Variable ~ optWS ~ atomic("<-") ~ optWS ~ Expression ~ optWS ~ atomic("=>") ~ optWS ~ Stm ~> ParsedAst.SelectChannelRule
+        keyword("case") ~ WS ~ Names.Variable ~ optWS ~ atomic("<-") ~ optWS ~ optional(atomic("Channel.")) ~ atomic("recv") ~ optWS ~ "(" ~ optWS ~ Expression ~ optWS ~ ")" ~ optWS ~ atomic("=>") ~ optWS ~ Stm ~> ParsedAst.SelectChannelRule
       }
 
       def SelectChannelDefault: Rule1[ParsedAst.Expression] = rule {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -50,7 +50,7 @@ class TestRedundancy extends FunSuite with TestUtils {
            |def f(): Int32 \ IO =
            |    let (_, r) = Channel.buffered(1);
            |    select {
-           |        case _x <- r => _x
+           |        case _x <- recv(r) => _x
            |    }
            |
        """.stripMargin
@@ -260,8 +260,8 @@ class TestRedundancy extends FunSuite with TestUtils {
         |    let (s, r) = Channel.buffered(1);
         |    Channel.send(456, s);
         |    select {
-        |        case y <- r => y
-        |        case x <- r => x
+        |        case y <- recv(r) => y
+        |        case x <- recv(r) => x
         |    }
         |
       """.stripMargin
@@ -741,7 +741,7 @@ class TestRedundancy extends FunSuite with TestUtils {
            |def f(): Int32 \ IO =
            |    let (_, r) = Channel.unbuffered();
            |    select {
-           |        case x <- r => 123
+           |        case x <- recv(r) => 123
            |    }
            |
        """.stripMargin
@@ -755,8 +755,8 @@ class TestRedundancy extends FunSuite with TestUtils {
            |def f(): Int32 \ IO =
            |    let (_, r) = Channel.unbuffered();
            |    select {
-           |        case x <- r => x
-           |        case x <- r => 123
+           |        case x <- recv(r) => x
+           |        case x <- recv(r) => 123
            |    }
            |
        """.stripMargin

--- a/main/test/flix/Test.Exp.Concurrency.Select.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Select.flix
@@ -5,7 +5,7 @@ namespace Test/Exp/Concurrency/Select {
         let (s1, r1) = Channel.buffered(1);
         spawn Channel.send(1, s1);
         select {
-            case x <- r1 => x == 1
+            case x <- recv(r1) => x == 1
         }
 
     @test
@@ -15,8 +15,8 @@ namespace Test/Exp/Concurrency/Select {
         spawn Channel.send(1, s1);
         spawn Channel.send(2, s2);
         select {
-            case x <- r1 => x == 1
-            case x <- r2 => x == 2
+            case x <- recv(r1) => x == 1
+            case x <- recv(r2) => x == 2
         }
 
     @test
@@ -28,9 +28,9 @@ namespace Test/Exp/Concurrency/Select {
         spawn Channel.send(2, s2);
         spawn Channel.send(3, s3);
         select {
-            case x <- r1 => x == 1
-            case x <- r2 => x == 2
-            case x <- r3 => x == 3
+            case x <- recv(r1) => x == 1
+            case x <- recv(r2) => x == 2
+            case x <- recv(r3) => x == 3
         }
 
     @test
@@ -44,14 +44,14 @@ namespace Test/Exp/Concurrency/Select {
         spawn Channel.send(3, s3);
         spawn Channel.send(4, s4);
         select {
-            case x <- r1 => x == 1
-            case x <- r1 => x == 1
-            case x <- r2 => x == 2
-            case x <- r2 => x == 2
-            case x <- r3 => x == 3
-            case x <- r3 => x == 3
-            case x <- r4 => x == 4
-            case x <- r4 => x == 4
+            case x <- recv(r1) => x == 1
+            case x <- recv(r1) => x == 1
+            case x <- recv(r2) => x == 2
+            case x <- recv(r2) => x == 2
+            case x <- recv(r3) => x == 3
+            case x <- recv(r3) => x == 3
+            case x <- recv(r4) => x == 4
+            case x <- recv(r4) => x == 4
         }
 
     @test
@@ -65,14 +65,14 @@ namespace Test/Exp/Concurrency/Select {
         spawn Channel.send(3, s3);
         spawn Channel.send(4, s4);
         select {
-            case x <- r4 => x == 4
-            case x <- r3 => x == 3
-            case x <- r2 => x == 2
-            case x <- r1 => x == 1
-            case x <- r4 => x == 4
-            case x <- r3 => x == 3
-            case x <- r2 => x == 2
-            case x <- r1 => x == 1
+            case x <- recv(r4) => x == 4
+            case x <- recv(r3) => x == 3
+            case x <- recv(r2) => x == 2
+            case x <- recv(r1) => x == 1
+            case x <- recv(r4) => x == 4
+            case x <- recv(r3) => x == 3
+            case x <- recv(r2) => x == 2
+            case x <- recv(r1) => x == 1
         }
 
     @test
@@ -83,10 +83,10 @@ namespace Test/Exp/Concurrency/Select {
         let (_, r4) = Channel.buffered(1);
         spawn Channel.send(1, s2);
         select {
-            case _ <- r4 => false
-            case _ <- r3 => false
-            case x <- r2 => x == 1
-            case _ <- r1 => false
+            case _ <- recv(r4) => false
+            case _ <- recv(r3) => false
+            case x <- recv(r2) => x == 1
+            case _ <- recv(r1) => false
         }
 
     @test
@@ -100,24 +100,24 @@ namespace Test/Exp/Concurrency/Select {
         spawn Channel.send(3i32, s3);
         spawn Channel.send(4i64, s4);
         select {
-            case x <- r4 => x == 4i64
-            case x <- r3 => x == 3i32
-            case x <- r2 => x == 2i16
-            case x <- r1 => x == 1i8
+            case x <- recv(r4) => x == 4i64
+            case x <- recv(r3) => x == 3i32
+            case x <- recv(r2) => x == 2i16
+            case x <- recv(r1) => x == 1i8
         }
 
     @test
     def testSelectDefault01(): Bool \ IO =
         select {
-            case x <- {let (_, r) = Channel.buffered(1); r} => x
-            case _                                          => true
+            case x <- recv({let (_, r) = Channel.buffered(1); r}) => x
+            case _                                                => true
         }
 
     @test
     def testSelectDefault02(): Bool \ IO =
         (1 + select {
-            case _ <- {let (_, r) = Channel.buffered(2); r} => 2
-            case _                                          => 1
+            case _ <- recv({let (_, r) = Channel.buffered(2); r}) => 2
+            case _                                                => 1
         }) == 2
 
     @test
@@ -128,27 +128,27 @@ namespace Test/Exp/Concurrency/Select {
         let (s12, r12) = Channel.buffered(0);
         let (s13, r13) = Channel.buffered(0);
         spawn { Channel.send((), s13) ; () } ; spawn { Channel.send((), s12) ; () } ; spawn { Channel.send((), s11) ; () } ; spawn { Channel.send((), s10) ; () } ; spawn { Channel.send((), s9) ; () } ; select {
-        case _ <- r13 => select {
-        case _ <- r11 => ()
-        case _ <- r11 => ()
+        case _ <- recv(r13) => select {
+        case _ <- recv(r11) => ()
+        case _ <- recv(r11) => ()
         } ; Channel.recv(r9) ; Channel.recv(r10) ; Channel.recv(r12) ; let (s42, r42) = Channel.buffered(0);
         let (s43, r43) = Channel.buffered(0);
         let (s44, r44) = Channel.buffered(0);
         let (s45, r45) = Channel.buffered(0);
         spawn { Channel.send((), s45) ; () } ; spawn { Channel.send((), s44) ; () } ; spawn { Channel.send((), s43) ; () } ; spawn { Channel.send((), s42) ; () } ; select {
-        case _ <- r43 => Channel.recv(r42) ; Channel.recv(r44) ; Channel.recv(r45)
-        case _ <- r42 => Channel.recv(r45) ; Channel.recv(r43) ; Channel.recv(r44) ; ()
+        case _ <- recv(r43) => Channel.recv(r42) ; Channel.recv(r44) ; Channel.recv(r45)
+        case _ <- recv(r42) => Channel.recv(r45) ; Channel.recv(r43) ; Channel.recv(r44) ; ()
         }
-        case _ <- r13 => select {
-        case _ <- r11 => ()
-        case _ <- r11 => ()
+        case _ <- recv(r13) => select {
+        case _ <- recv(r11) => ()
+        case _ <- recv(r11) => ()
         } ; Channel.recv(r9) ; Channel.recv(r10) ; Channel.recv(r12) ; let (s42, r42) = Channel.buffered(0);
         let (s43, r43) = Channel.buffered(0);
         let (s44, r44) = Channel.buffered(0);
         let (s45, r45) = Channel.buffered(0);
         spawn { Channel.send((), s45) ; () } ; spawn { Channel.send((), s44) ; () } ; spawn { Channel.send((), s43) ; () } ; spawn { Channel.send((), s42) ; () } ; select {
-        case _ <- r43 => Channel.recv(r42) ; Channel.recv(r44) ; Channel.recv(r45) ; ()
-        case _ <- r42 => Channel.recv(r45) ; Channel.recv(r43) ; Channel.recv(r44)
+        case _ <- recv(r43) => Channel.recv(r42) ; Channel.recv(r44) ; Channel.recv(r45) ; ()
+        case _ <- recv(r42) => Channel.recv(r45) ; Channel.recv(r43) ; Channel.recv(r44)
         }
         };
         ()
@@ -161,9 +161,9 @@ namespace Test/Exp/Concurrency/Select {
         let (s12, r12) = Channel.buffered(0);
         let (s13, r13) = Channel.buffered(0);
         spawn { Channel.send((), s13) ; () } ; spawn { Channel.send((), s12) ; () } ; if (false) { spawn { Channel.send((), s11) ; () } ; spawn { Channel.send((), s10) ; () } ; if (true) { () } else { () } } else { spawn { Channel.send((), s11) ; () } ; spawn { Channel.send((), s10) ; () } ; if (true) { () } else { () } } ; select {
-        case _ <- r10 => Channel.recv(r13) ; Channel.recv(r12) ; Channel.recv(r11)
-        case _ <- r13 => Channel.recv(r12) ; Channel.recv(r10) ; Channel.recv(r11) ; ()
-        case _ <- r11 => Channel.recv(r13) ; Channel.recv(r12) ; Channel.recv(r10) ; ()
+        case _ <- recv(r10) => Channel.recv(r13) ; Channel.recv(r12) ; Channel.recv(r11)
+        case _ <- recv(r13) => Channel.recv(r12) ; Channel.recv(r10) ; Channel.recv(r11) ; ()
+        case _ <- recv(r11) => Channel.recv(r13) ; Channel.recv(r12) ; Channel.recv(r10) ; ()
         };
         ()
     }
@@ -179,26 +179,26 @@ namespace Test/Exp/Concurrency/Select {
         let (s139, r139) = Channel.buffered(0);
         let (s140, r140) = Channel.buffered(0);
         spawn { Channel.send((), s141) ; () } ; spawn { Channel.send((), s140) ; () } ; spawn { Channel.send((), s139) ; () } ; spawn { Channel.send((), s141) ; () } ; spawn { Channel.send((), s140) ; () } ; spawn { Channel.send((), s139) ; () } ; spawn { Channel.send((), s141) ; () } ; spawn { Channel.send((), s140) ; () } ; spawn { Channel.send((), s139) ; () } ; spawn { select {
-        case _ <- r141 => Channel.recv(r140) ; Channel.recv(r139) ; ()
+        case _ <- recv(r141) => Channel.recv(r140) ; Channel.recv(r139) ; ()
         } } ; spawn { select {
-        case _ <- r139 => Channel.recv(r140) ; Channel.recv(r141) ; ()
-        case _ <- r140 => Channel.recv(r141) ; Channel.recv(r139) ; ()
+        case _ <- recv(r139) => Channel.recv(r140) ; Channel.recv(r141) ; ()
+        case _ <- recv(r140) => Channel.recv(r141) ; Channel.recv(r139) ; ()
         } } ; spawn { select {
-        case _ <- r139 => select {
-        case _ <- r140 => ()
-        case _ <- r140 => ()
+        case _ <- recv(r139) => select {
+        case _ <- recv(r140) => ()
+        case _ <- recv(r140) => ()
         } ; Channel.recv(r141) ; ()
-        case _ <- r141 => Channel.recv(r140) ; Channel.recv(r139) ; ()
+        case _ <- recv(r141) => Channel.recv(r140) ; Channel.recv(r139) ; ()
         } } ; spawn { select {
-        case _ <- r15 => Channel.recv(r18) ; Channel.recv(r16) ; Channel.recv(r17) ; Channel.recv(r14) ; ()
-        case _ <- r14 => Channel.recv(r18) ; Channel.recv(r16) ; Channel.recv(r15) ; Channel.recv(r17) ; ()
-        case _ <- r17 => Channel.recv(r15) ; Channel.recv(r18) ; select {
-        case _ <- r16 => ()
-        case _ <- r16 => ()
+        case _ <- recv(r15) => Channel.recv(r18) ; Channel.recv(r16) ; Channel.recv(r17) ; Channel.recv(r14) ; ()
+        case _ <- recv(r14) => Channel.recv(r18) ; Channel.recv(r16) ; Channel.recv(r15) ; Channel.recv(r17) ; ()
+        case _ <- recv(r17) => Channel.recv(r15) ; Channel.recv(r18) ; select {
+        case _ <- recv(r16) => ()
+        case _ <- recv(r16) => ()
         } ; Channel.recv(r14)
-        case _ <- r18 => Channel.recv(r15) ; Channel.recv(r14) ; Channel.recv(r17) ; Channel.recv(r16) ; ()
+        case _ <- recv(r18) => Channel.recv(r15) ; Channel.recv(r14) ; Channel.recv(r17) ; Channel.recv(r16) ; ()
         } } ; spawn { select {
-        case _ <- r16 => Channel.recv(r18) ; Channel.recv(r17) ; Channel.recv(r15) ; Channel.recv(r14) ; ()
+        case _ <- recv(r16) => Channel.recv(r18) ; Channel.recv(r17) ; Channel.recv(r15) ; Channel.recv(r14) ; ()
         } } ;
         ()
     }
@@ -212,17 +212,17 @@ namespace Test/Exp/Concurrency/Select {
         let (s41, r41) = Channel.buffered(0);
         let (s42, r42) = Channel.buffered(0);
         spawn { Channel.send((), s42) ; () } ; spawn { Channel.send((), s41) ; () } ; spawn { Channel.send((), s40) ; () } ; spawn { Channel.send((), s42) ; () } ; spawn { Channel.send((), s41) ; () } ; spawn { Channel.send((), s40) ; () } ; spawn { Channel.send((), s42) ; () } ; spawn { Channel.send((), s41) ; () } ; spawn { Channel.send((), s40) ; () } ; spawn { Channel.send((), s42) ; () } ; spawn { Channel.send((), s41) ; () } ; spawn { Channel.send((), s40) ; () } ; spawn { select {
-        case _ <- r40 => Channel.recv(r41) ; Channel.recv(r42) ; ()
+        case _ <- recv(r40) => Channel.recv(r41) ; Channel.recv(r42) ; ()
         } } ; spawn { select {
-        case _ <- r40 => Channel.recv(r42) ; Channel.recv(r41) ; ()
-        case _ <- r40 => Channel.recv(r42) ; Channel.recv(r41) ; ()
+        case _ <- recv(r40) => Channel.recv(r42) ; Channel.recv(r41) ; ()
+        case _ <- recv(r40) => Channel.recv(r42) ; Channel.recv(r41) ; ()
         } } ; spawn { select {
-        case _ <- r42 => Channel.recv(r40) ; Channel.recv(r41) ; ()
+        case _ <- recv(r42) => Channel.recv(r40) ; Channel.recv(r41) ; ()
         } } ; spawn { select {
-        case _ <- r42 => Channel.recv(r40) ; Channel.recv(r41) ; ()
-        case _ <- r42 => Channel.recv(r40) ; Channel.recv(r41) ; ()
+        case _ <- recv(r42) => Channel.recv(r40) ; Channel.recv(r41) ; ()
+        case _ <- recv(r42) => Channel.recv(r40) ; Channel.recv(r41) ; ()
         } } ; select {
-        case _ <- r10 => Channel.recv(r12) ; Channel.recv(r11) ; ()
+        case _ <- recv(r10) => Channel.recv(r12) ; Channel.recv(r11) ; ()
         };
         ()
     }
@@ -234,32 +234,32 @@ namespace Test/Exp/Concurrency/Select {
         let (s16, r16) = Channel.buffered(0);
         let (s17, r17) = Channel.buffered(0);
         spawn { Channel.send((), s17) ; () } ; spawn { Channel.send((), s16) ; () } ; spawn { Channel.send((), s15) ; () } ; spawn { Channel.send((), s14) ; () } ; spawn { Channel.send((), s17) ; () } ; spawn { Channel.send((), s16) ; () } ; spawn { Channel.send((), s15) ; () } ; spawn { Channel.send((), s14) ; () } ; spawn { Channel.send((), s17) ; () } ; spawn { Channel.send((), s16) ; () } ; spawn { Channel.send((), s15) ; () } ; spawn { Channel.send((), s14) ; () } ; spawn { Channel.send((), s17) ; () } ; spawn { Channel.send((), s16) ; () } ; spawn { Channel.send((), s15) ; () } ; spawn { Channel.send((), s14) ; () } ; spawn { select {
-        case _ <- r17 => Channel.recv(r14) ; Channel.recv(r15) ; Channel.recv(r16)
+        case _ <- recv(r17) => Channel.recv(r14) ; Channel.recv(r15) ; Channel.recv(r16)
         } } ; spawn { select {
-        case _ <- r16 => Channel.recv(r14) ; Channel.recv(r15) ; Channel.recv(r17) ; ()
+        case _ <- recv(r16) => Channel.recv(r14) ; Channel.recv(r15) ; Channel.recv(r17) ; ()
         } } ; spawn { select {
-        case _ <- r17 => Channel.recv(r15) ; Channel.recv(r16) ; Channel.recv(r14) ; let (s171, r171) = Channel.buffered(0);
+        case _ <- recv(r17) => Channel.recv(r15) ; Channel.recv(r16) ; Channel.recv(r14) ; let (s171, r171) = Channel.buffered(0);
         let (s172, r172) = Channel.buffered(0);
         let (s173, r173) = Channel.buffered(0);
         spawn { Channel.send((), s173) ; () } ; spawn { Channel.send((), s172) ; () } ; spawn { Channel.send((), s171) ; () } ; spawn { Channel.send((), s173) ; () } ; spawn { Channel.send((), s172) ; () } ; spawn { Channel.send((), s171) ; () } ; spawn { Channel.send((), s173) ; () } ; spawn { Channel.send((), s172) ; () } ; spawn { Channel.send((), s171) ; () } ; spawn { Channel.send((), s173) ; () } ; spawn { Channel.send((), s172) ; () } ; spawn { Channel.send((), s171) ; () } ; spawn { select {
-        case _ <- r172 => Channel.recv(r173) ; Channel.recv(r171) ; ()
+        case _ <- recv(r172) => Channel.recv(r173) ; Channel.recv(r171) ; ()
         } } ; spawn { select {
-        case _ <- r171 => Channel.recv(r173) ; Channel.recv(r172) ; ()
-        case _ <- r173 => Channel.recv(r172) ; Channel.recv(r171) ; ()
+        case _ <- recv(r171) => Channel.recv(r173) ; Channel.recv(r172) ; ()
+        case _ <- recv(r173) => Channel.recv(r172) ; Channel.recv(r171) ; ()
         } } ; spawn { select {
-        case _ <- r171 => Channel.recv(r173) ; Channel.recv(r172) ; ()
-        case _ <- r173 => Channel.recv(r171) ; Channel.recv(r172) ; ()
-        case _ <- r171 => Channel.recv(r173) ; Channel.recv(r172) ; ()
+        case _ <- recv(r171) => Channel.recv(r173) ; Channel.recv(r172) ; ()
+        case _ <- recv(r173) => Channel.recv(r171) ; Channel.recv(r172) ; ()
+        case _ <- recv(r171) => Channel.recv(r173) ; Channel.recv(r172) ; ()
         } } ; spawn { select {
-        case _ <- r171 => Channel.recv(r173) ; select {
-        case _ <- r172 => ()
-        case _ <- r172 => ()
+        case _ <- recv(r171) => Channel.recv(r173) ; select {
+        case _ <- recv(r172) => ()
+        case _ <- recv(r172) => ()
         } ; ()
-        case _ <- r173 => Channel.recv(r171) ; Channel.recv(r172) ; ()
+        case _ <- recv(r173) => Channel.recv(r171) ; Channel.recv(r172) ; ()
         } } ; ()
-        case _ <- r14 => Channel.recv(r17) ; Channel.recv(r15) ; Channel.recv(r16) ; ()
+        case _ <- recv(r14) => Channel.recv(r17) ; Channel.recv(r15) ; Channel.recv(r16) ; ()
         } } ; spawn { select {
-        case _ <- r17 => Channel.recv(r16) ; Channel.recv(r15) ; Channel.recv(r14) ; ()
+        case _ <- recv(r17) => Channel.recv(r16) ; Channel.recv(r15) ; Channel.recv(r14) ; ()
         } } ;
         ()
     }
@@ -269,12 +269,12 @@ namespace Test/Exp/Concurrency/Select {
         let (s2, r2) = Channel.buffered(0);
         let (s3, r3) = Channel.buffered(0);
         spawn { Channel.send((), s3) ; () } ; spawn { Channel.send((), s2) ; () } ; Channel.recv(r3) ; select {
-        case _ <- r2 => ()
-        case _ <- r2 => ()
+        case _ <- recv(r2) => ()
+        case _ <- recv(r2) => ()
         } ; let (s24, r24) = Channel.buffered(0);
         spawn { select {
-        case _ <- r24 => ()
-        case _ <- r24 => ()
+        case _ <- recv(r24) => ()
+        case _ <- recv(r24) => ()
         } } ; Channel.send((), s24) ;
         ()
     }
@@ -287,26 +287,26 @@ namespace Test/Exp/Concurrency/Select {
         let (s15, r15) = Channel.buffered(0);
         let (s16, r16) = Channel.buffered(0);
         spawn { Channel.send((), s16) ; () } ; spawn { Channel.send((), s15) ; () } ; spawn { Channel.send((), s14) ; () } ; spawn { Channel.send((), s13) ; () } ; spawn { Channel.send((), s12) ; () } ; spawn { Channel.send((), s16) ; () } ; spawn { Channel.send((), s15) ; () } ; spawn { Channel.send((), s14) ; () } ; spawn { Channel.send((), s13) ; () } ; spawn { Channel.send((), s12) ; () } ; spawn { Channel.send((), s16) ; () } ; spawn { Channel.send((), s15) ; () } ; spawn { Channel.send((), s14) ; () } ; spawn { Channel.send((), s13) ; () } ; spawn { Channel.send((), s12) ; () } ; spawn { select {
-        case _ <- r14 => Channel.recv(r12) ; Channel.recv(r13) ; Channel.recv(r15) ; Channel.recv(r16) ; ()
+        case _ <- recv(r14) => Channel.recv(r12) ; Channel.recv(r13) ; Channel.recv(r15) ; Channel.recv(r16) ; ()
         } } ; spawn { select {
-        case _ <- r16 => Channel.recv(r13) ; Channel.recv(r14) ; Channel.recv(r12) ; Channel.recv(r15) ; ()
-        case _ <- r15 => Channel.recv(r14) ; Channel.recv(r13) ; Channel.recv(r16) ; Channel.recv(r12) ; ()
-        case _ <- r12 => Channel.recv(r13) ; Channel.recv(r15) ; Channel.recv(r16) ; Channel.recv(r14) ; let (s180, r180) = Channel.buffered(0);
+        case _ <- recv(r16) => Channel.recv(r13) ; Channel.recv(r14) ; Channel.recv(r12) ; Channel.recv(r15) ; ()
+        case _ <- recv(r15) => Channel.recv(r14) ; Channel.recv(r13) ; Channel.recv(r16) ; Channel.recv(r12) ; ()
+        case _ <- recv(r12) => Channel.recv(r13) ; Channel.recv(r15) ; Channel.recv(r16) ; Channel.recv(r14) ; let (s180, r180) = Channel.buffered(0);
         let (s178, r178) = Channel.buffered(0);
         let (s179, r179) = Channel.buffered(0);
         spawn { Channel.send((), s180) ; () } ; spawn { Channel.send((), s179) ; () } ; spawn { Channel.send((), s178) ; () } ; spawn { Channel.send((), s180) ; () } ; spawn { Channel.send((), s179) ; () } ; spawn { Channel.send((), s178) ; () } ; spawn { select {
-        case _ <- r178 => Channel.recv(r180) ; Channel.recv(r179)
-        case _ <- r179 => select {
-        case _ <- r178 => ()
-        case _ <- r178 => ()
+        case _ <- recv(r178) => Channel.recv(r180) ; Channel.recv(r179)
+        case _ <- recv(r179) => select {
+        case _ <- recv(r178) => ()
+        case _ <- recv(r178) => ()
         } ; Channel.recv(r180) ; ()
         } } ; spawn { select {
-        case _ <- r178 => Channel.recv(r179) ; Channel.recv(r180) ; ()
-        case _ <- r180 => Channel.recv(r178) ; Channel.recv(r179) ; ()
+        case _ <- recv(r178) => Channel.recv(r179) ; Channel.recv(r180) ; ()
+        case _ <- recv(r180) => Channel.recv(r178) ; Channel.recv(r179) ; ()
         } } ; ()
         } } ; spawn { select {
-        case _ <- r14 => Channel.recv(r15) ; Channel.recv(r12) ; Channel.recv(r16) ; Channel.recv(r13) ; ()
-        case _ <- r13 => Channel.recv(r12) ; Channel.recv(r14) ; Channel.recv(r15) ; Channel.recv(r16) ; ()
+        case _ <- recv(r14) => Channel.recv(r15) ; Channel.recv(r12) ; Channel.recv(r16) ; Channel.recv(r13) ; ()
+        case _ <- recv(r13) => Channel.recv(r12) ; Channel.recv(r14) ; Channel.recv(r15) ; Channel.recv(r16) ; ()
         } } ;
         ()
     }
@@ -319,30 +319,30 @@ namespace Test/Exp/Concurrency/Select {
         let (s18, r18) = Channel.buffered(0);
         let (s19, r19) = Channel.buffered(0);
         spawn { Channel.send((), s19) ; () } ; spawn { Channel.send((), s18) ; () } ; spawn { Channel.send((), s17) ; () } ; spawn { Channel.send((), s16) ; () } ; spawn { Channel.send((), s15) ; () } ; spawn { Channel.send((), s19) ; () } ; spawn { Channel.send((), s18) ; () } ; spawn { Channel.send((), s17) ; () } ; spawn { Channel.send((), s16) ; () } ; spawn { Channel.send((), s15) ; () } ; spawn { Channel.send((), s19) ; () } ; spawn { Channel.send((), s18) ; () } ; spawn { Channel.send((), s17) ; () } ; spawn { Channel.send((), s16) ; () } ; spawn { Channel.send((), s15) ; () } ; spawn { Channel.send((), s19) ; () } ; spawn { Channel.send((), s18) ; () } ; spawn { Channel.send((), s17) ; () } ; spawn { Channel.send((), s16) ; () } ; spawn { Channel.send((), s15) ; () } ; spawn { select {
-        case _ <- r15 => Channel.recv(r17) ; Channel.recv(r18) ; Channel.recv(r16) ; Channel.recv(r19) ; ()
+        case _ <- recv(r15) => Channel.recv(r17) ; Channel.recv(r18) ; Channel.recv(r16) ; Channel.recv(r19) ; ()
         } } ; spawn { select {
-        case _ <- r15 => Channel.recv(r19) ; Channel.recv(r18) ; Channel.recv(r16) ; Channel.recv(r17) ; ()
-        case _ <- r18 => Channel.recv(r19) ; Channel.recv(r15) ; Channel.recv(r16) ; Channel.recv(r17) ; ()
-        case _ <- r19 => Channel.recv(r16) ; Channel.recv(r17) ; Channel.recv(r18) ; Channel.recv(r15) ; ()
-        case _ <- r17 => Channel.recv(r15) ; Channel.recv(r18) ; Channel.recv(r16) ; Channel.recv(r19) ; ()
+        case _ <- recv(r15) => Channel.recv(r19) ; Channel.recv(r18) ; Channel.recv(r16) ; Channel.recv(r17) ; ()
+        case _ <- recv(r18) => Channel.recv(r19) ; Channel.recv(r15) ; Channel.recv(r16) ; Channel.recv(r17) ; ()
+        case _ <- recv(r19) => Channel.recv(r16) ; Channel.recv(r17) ; Channel.recv(r18) ; Channel.recv(r15) ; ()
+        case _ <- recv(r17) => Channel.recv(r15) ; Channel.recv(r18) ; Channel.recv(r16) ; Channel.recv(r19) ; ()
         } } ; spawn { select {
-        case _ <- r17 => Channel.recv(r18) ; Channel.recv(r15) ; Channel.recv(r16) ; Channel.recv(r19) ; ()
-        case _ <- r15 => Channel.recv(r17) ; Channel.recv(r16) ; Channel.recv(r18) ; Channel.recv(r19) ; ()
-        case _ <- r16 => Channel.recv(r15) ; Channel.recv(r18) ; Channel.recv(r17) ; Channel.recv(r19) ; ()
-        case _ <- r19 => Channel.recv(r15) ; Channel.recv(r18) ; Channel.recv(r16) ; Channel.recv(r17) ; ()
+        case _ <- recv(r17) => Channel.recv(r18) ; Channel.recv(r15) ; Channel.recv(r16) ; Channel.recv(r19) ; ()
+        case _ <- recv(r15) => Channel.recv(r17) ; Channel.recv(r16) ; Channel.recv(r18) ; Channel.recv(r19) ; ()
+        case _ <- recv(r16) => Channel.recv(r15) ; Channel.recv(r18) ; Channel.recv(r17) ; Channel.recv(r19) ; ()
+        case _ <- recv(r19) => Channel.recv(r15) ; Channel.recv(r18) ; Channel.recv(r16) ; Channel.recv(r17) ; ()
         } } ; spawn { select {
-        case _ <- r17 => Channel.recv(r18) ; Channel.recv(r16) ; Channel.recv(r19) ; Channel.recv(r15) ; ()
-        case _ <- r16 => Channel.recv(r18) ; select {
-        case _ <- r15 => ()
-        case _ <- r15 => ()
+        case _ <- recv(r17) => Channel.recv(r18) ; Channel.recv(r16) ; Channel.recv(r19) ; Channel.recv(r15) ; ()
+        case _ <- recv(r16) => Channel.recv(r18) ; select {
+        case _ <- recv(r15) => ()
+        case _ <- recv(r15) => ()
         } ; Channel.recv(r17) ; Channel.recv(r19) ; let (s214, r214) = Channel.buffered(0);
         let (s215, r215) = Channel.buffered(0);
         let (s216, r216) = Channel.buffered(0);
         let (s217, r217) = Channel.buffered(0);
         spawn { Channel.send((), s217) ; () } ; spawn { Channel.send((), s216) ; () } ; spawn { Channel.send((), s215) ; () } ; spawn { Channel.send((), s214) ; () } ; select {
-        case _ <- r215 => Channel.recv(r214) ; Channel.recv(r216) ; Channel.recv(r217) ; ()
-        case _ <- r214 => Channel.recv(r216) ; Channel.recv(r215) ; Channel.recv(r217) ; ()
-        case _ <- r216 => Channel.recv(r214) ; Channel.recv(r217) ; Channel.recv(r215)
+        case _ <- recv(r215) => Channel.recv(r214) ; Channel.recv(r216) ; Channel.recv(r217) ; ()
+        case _ <- recv(r214) => Channel.recv(r216) ; Channel.recv(r215) ; Channel.recv(r217) ; ()
+        case _ <- recv(r216) => Channel.recv(r214) ; Channel.recv(r217) ; Channel.recv(r215)
         }
         } } ;
         ()
@@ -355,11 +355,11 @@ namespace Test/Exp/Concurrency/Select {
         let (s8, r8) = Channel.buffered(0);
         let (s9, r9) = Channel.buffered(0);
         spawn { select {
-        case _ <- r8 => ()
-        case _ <- r8 => ()
+        case _ <- recv(r8) => ()
+        case _ <- recv(r8) => ()
         } ; Channel.send((), s9) ; () } ; spawn { Channel.recv(r7) ; Channel.send((), s8) ; () } ; spawn { select {
-        case _ <- r6 => ()
-        case _ <- r6 => ()
+        case _ <- recv(r6) => ()
+        case _ <- recv(r6) => ()
         } ; Channel.send((), s7) ; () } ; Channel.send((), s6) ; Channel.recv(r9);
         ()
     }
@@ -375,9 +375,9 @@ namespace Test/Exp/Concurrency/Select {
         spawn { Channel.send((), s11) ; () } ;
         spawn { Channel.send((), s10) ; () } ;
         select {
-            case _ <- r10 => Channel.recv(r13) ; Channel.recv(r12) ; Channel.recv(r11)
-            case _ <- r13 => Channel.recv(r12) ; Channel.recv(r10) ; Channel.recv(r11)
-            case _ <- r11 => Channel.recv(r13) ; Channel.recv(r12) ; Channel.recv(r10)
+            case _ <- recv(r10) => Channel.recv(r13) ; Channel.recv(r12) ; Channel.recv(r11)
+            case _ <- recv(r13) => Channel.recv(r12) ; Channel.recv(r10) ; Channel.recv(r11)
+            case _ <- recv(r11) => Channel.recv(r13) ; Channel.recv(r12) ; Channel.recv(r10)
         };
         ()
     }
@@ -391,7 +391,7 @@ namespace Test/Exp/Concurrency/Select {
         };
 
         select {
-            case x <- mkChan() => x == 42
+            case x <- recv(mkChan()) => x == 42
         }
     }
 
@@ -402,9 +402,9 @@ namespace Test/Exp/Concurrency/Select {
         let (s3, r3) = Channel.buffered(10);
 
         select {
-            case x <- {Channel.send(1, s3); r1} => x + (Channel.recv(r2)) + (Channel.recv(r3)) == 6
-            case x <- {Channel.send(2, s2); r2} => x + (Channel.recv(r1)) + (Channel.recv(r3)) == 6
-            case x <- {Channel.send(3, s1); r3} => x + (Channel.recv(r1)) + (Channel.recv(r2)) == 6
+            case x <- recv({Channel.send(1, s3); r1}) => x + (Channel.recv(r2)) + (Channel.recv(r3)) == 6
+            case x <- recv({Channel.send(2, s2); r2}) => x + (Channel.recv(r1)) + (Channel.recv(r3)) == 6
+            case x <- recv({Channel.send(3, s1); r3}) => x + (Channel.recv(r1)) + (Channel.recv(r2)) == 6
         }
     }
 
@@ -416,10 +416,18 @@ namespace Test/Exp/Concurrency/Select {
 
         def useChan(mr: MyReceiver) : Bool =
             select {
-                case x <- mr => x == 42
+                case x <- recv(mr) => x == 42
             };
 
         Channel.send(42, s);
         useChan(r)
     }
+
+    @test
+    def testSelectOptionalSyntax01(): Bool \ IO = 
+        let (s1, r1) = Channel.buffered(1);
+        spawn Channel.send(1, s1);
+        select {
+            case x <- Channel.recv(r1) => x == 1
+        }
 }

--- a/main/test/flix/Test.Unused.Var.flix
+++ b/main/test/flix/Test.Unused.Var.flix
@@ -59,7 +59,7 @@ namespace Test/Unused/Var {
         let (s, r) = Channel.buffered(1);
         Channel.send(0, s);
         select {
-            case _foo <- r => 123
+            case _foo <- recv(r) => 123
         }
 
     @test
@@ -69,8 +69,8 @@ namespace Test/Unused/Var {
         Channel.send(0, s1);
         Channel.send(0, s2);
         select {
-            case _foo <- r1 => 123
-            case _bar <- r2 => 456
+            case _foo <- recv(r1) => 123
+            case _bar <- recv(r2) => 456
         }
 
     // NB: Compile, but not execute.


### PR DESCRIPTION
This addresses the Update select syntax to case x <- recv(exp) (and optionally case x <- Channel.recv(exp)) task of #4755