### PR TITLE
chore: Remove sender and receiver monotypes

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
@@ -58,10 +58,6 @@ object MonoType {
 
   case class Array(tpe: MonoType) extends MonoType
 
-  case class Sender(tpe: MonoType) extends MonoType
-
-  case class Receiver(tpe: MonoType) extends MonoType
-
   case class Lazy(tpe: MonoType) extends MonoType
 
   case class Ref(tpe: MonoType) extends MonoType

--- a/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
@@ -416,9 +416,9 @@ object Finalize {
 
             case TypeConstructor.RecordRowEmpty => MonoType.RecordEmpty()
 
-            case TypeConstructor.Sender => MonoType.Sender(args.head)
+            case TypeConstructor.Sender => throw new InternalCompilerException("Unexpected Sender")
 
-            case TypeConstructor.Receiver => MonoType.Receiver(args.head)
+            case TypeConstructor.Receiver => throw new InternalCompilerException("Unexpected Receiver")
 
             case TypeConstructor.Lazy => MonoType.Lazy(args.head)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -259,7 +259,9 @@ object Lowering {
   private def visitExp(exp0: Expression)(implicit root: Root, flix: Flix): Expression = exp0 match {
     case Expression.Unit(_) => exp0
 
-    case Expression.Null(_, _) => exp0
+    case Expression.Null(tpe, loc) => 
+      val t = visitType(tpe)
+      Expression.Null(t, loc)
 
     case Expression.True(_) => exp0
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -129,7 +129,7 @@ object BackendType {
     case MonoType.Int32 => Int32
     case MonoType.Int64 => Int64
     case MonoType.Unit | MonoType.BigDecimal | MonoType.BigInt | MonoType.Str | MonoType.Array(_) |
-         MonoType.Sender(_) | MonoType.Receiver(_)  | MonoType.Lazy(_) | MonoType.Ref(_) | MonoType.Tuple(_) | MonoType.Enum(_, _) |
+         MonoType.Lazy(_) | MonoType.Ref(_) | MonoType.Tuple(_) | MonoType.Enum(_, _) |
          MonoType.Arrow(_, _) | MonoType.RecordEmpty() | MonoType.RecordExtend(_, _, _) |
          MonoType.SchemaEmpty() | MonoType.SchemaExtend(_, _, _) | MonoType.Relation(_) |
          MonoType.Lattice(_) | MonoType.Native(_) | MonoType.Var(_) => BackendObjType.JavaObject.toTpe

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -65,8 +65,6 @@ object JvmOps {
 
     // Compound
     case MonoType.Array(_) => JvmType.Object
-    case MonoType.Sender(_) => JvmType.Object
-    case MonoType.Receiver(_) => JvmType.Object
     case MonoType.Lazy(_) => JvmType.Object
     case MonoType.Ref(_) => getRefClassType(tpe)
     case MonoType.Tuple(_) => getTupleClassType(tpe.asInstanceOf[MonoType.Tuple])
@@ -756,8 +754,6 @@ object JvmOps {
     case MonoType.Str => Type.Str
     case MonoType.Array(elm) => Type.mkArray(hackMonoType2Type(elm), Type.Impure, SourceLocation.Unknown)
     case MonoType.Lazy(tpe) => Type.mkLazy(hackMonoType2Type(tpe), SourceLocation.Unknown)
-    case MonoType.Sender(elm) => Type.mkSender(hackMonoType2Type(elm), SourceLocation.Unknown)
-    case MonoType.Receiver(elm) => Type.mkReceiver(hackMonoType2Type(elm), SourceLocation.Unknown)
     case MonoType.Native(clazz) => Type.mkNative(clazz, SourceLocation.Unknown)
     case MonoType.Ref(elm) => Type.mkRef(hackMonoType2Type(elm), Type.False, SourceLocation.Unknown)
     case MonoType.Arrow(targs, tresult) => Type.mkPureCurriedArrow(targs map hackMonoType2Type, hackMonoType2Type(tresult), SourceLocation.Unknown)
@@ -1104,8 +1100,6 @@ object JvmOps {
       case MonoType.Str => Set(tpe)
 
       case MonoType.Array(elm) => nestedTypesOf(elm) + tpe
-      case MonoType.Sender(elm) => nestedTypesOf(elm) + tpe
-      case MonoType.Receiver(elm) => nestedTypesOf(elm) + tpe
       case MonoType.Lazy(elm) => nestedTypesOf(elm) + tpe
       case MonoType.Ref(elm) => nestedTypesOf(elm) + tpe
       case MonoType.Tuple(elms) => elms.flatMap(nestedTypesOf).toSet + tpe


### PR DESCRIPTION
This fixes the Remove MonoType.Channel task of #4755