### PR TITLE
refactor: replace uses of seqM with traverseM

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -20,10 +20,10 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.Ast.VarText.FallbackText
 import ca.uwaterloo.flix.language.ast.Ast.{Denotation, Stratification}
-import ca.uwaterloo.flix.language.ast._
 import ca.uwaterloo.flix.language.ast.Type.getFlixType
+import ca.uwaterloo.flix.language.ast._
 import ca.uwaterloo.flix.language.errors.TypeError
-import ca.uwaterloo.flix.language.phase.unification.InferMonad.seqM
+import ca.uwaterloo.flix.language.phase.unification.InferMonad.{seqM, traverseM}
 import ca.uwaterloo.flix.language.phase.unification.TypeMinimization.minimizeScheme
 import ca.uwaterloo.flix.language.phase.unification.Unification._
 import ca.uwaterloo.flix.language.phase.unification._
@@ -425,7 +425,7 @@ object Typer {
       // Perform type inference on the arguments.
       //
       val result = for {
-        (constrs, tpes, purs, effs) <- seqM(exps.map(inferExp(_, root))).map(unzip4)
+        (constrs, tpes, purs, effs) <- traverseM(exps)(inferExp(_, root)).map(unzip4)
         _ <- unifyTypeM(Type.Pure :: purs, loc)
         _ <- unifyTypeM(Type.Empty :: effs, loc)
       } yield Type.Int32
@@ -537,7 +537,7 @@ object Typer {
         val lambdaBodyEff = Type.freshVar(Kind.Effect, loc, text = FallbackText("eff"))
         for {
           (constrs1, tpe, pur, eff) <- visitExp(exp)
-          (constrs2, tpes, purs, effs) <- seqM(exps.map(visitExp)).map(unzip4)
+          (constrs2, tpes, purs, effs) <- traverseM(exps)(visitExp).map(unzip4)
           lambdaType <- unifyTypeM(tpe, Type.mkUncurriedArrowWithEffect(tpes, lambdaBodyPur, lambdaBodyEff, lambdaBodyType, loc), loc)
           resultTyp <- unifyTypeM(tvar, lambdaBodyType, loc)
           resultPur <- unifyBoolM(pvar, Type.mkAnd(lambdaBodyPur :: pur :: purs, loc), loc)
@@ -882,9 +882,9 @@ object Typer {
           (constrs, tpe, pur, eff) <- visitExp(exp)
           patternTypes <- inferPatterns(patterns, root)
           patternType <- unifyTypeM(tpe :: patternTypes, loc)
-          (guardConstrs, guardTypes, guardPurs, guardEffs) <- seqM(guards map visitExp).map(unzip4)
+          (guardConstrs, guardTypes, guardPurs, guardEffs) <- traverseM(guards)(visitExp).map(unzip4)
           guardType <- unifyTypeM(Type.Bool :: guardTypes, loc)
-          (bodyConstrs, bodyTypes, bodyPurs, bodyEffs) <- seqM(bodies map visitExp).map(unzip4)
+          (bodyConstrs, bodyTypes, bodyPurs, bodyEffs) <- traverseM(bodies)(visitExp).map(unzip4)
           resultTyp <- unifyTypeM(bodyTypes, loc)
           resultPur = Type.mkAnd(pur :: guardPurs ::: bodyPurs, loc)
           resultEff = Type.mkUnion(eff :: guardEffs ::: bodyEffs, loc)
@@ -896,10 +896,10 @@ object Typer {
         for {
           (constrs, tpe, pur, eff) <- visitExp(exp)
           // rigidify all the type vars in the rules
-          _ <- seqM(rules.flatMap(rule => rule.tpe.typeVars.toList.map(rigidifyM)))
+          _ <- traverseM(rules.flatMap(rule => rule.tpe.typeVars.toList))(rigidifyM)
           // unify each rule's variable with its type
-          _ <- seqM(rules.map(rule => unifyTypeM(rule.sym.tvar, rule.tpe, rule.sym.loc)))
-          (bodyConstrs, bodyTypes, bodyPurs, bodyEffs) <- seqM(bodies map visitExp).map(unzip4)
+          _ <- traverseM(rules)(rule => unifyTypeM(rule.sym.tvar, rule.tpe, rule.sym.loc))
+          (bodyConstrs, bodyTypes, bodyPurs, bodyEffs) <- traverseM(bodies)(visitExp).map(unzip4)
           resultTyp <- unifyTypeM(bodyTypes, loc)
           resultPur = Type.mkAnd(pur :: bodyPurs, loc)
           resultEff = Type.mkUnion(eff :: bodyEffs, loc)
@@ -921,9 +921,9 @@ object Typer {
             } yield (constrs, freshElmVar, pur, eff)
           }
 
-          seqM(exps.zip(isAbsentVars.zip(isPresentVars)).map {
+          traverseM(exps.zip(isAbsentVars.zip(isPresentVars))) {
             case (matchExp, (isAbsentVar, isPresentVar)) => visitMatchExp(matchExp, isAbsentVar, isPresentVar)
-          }).map(unzip4)
+          }.map(unzip4)
         }
 
         /**
@@ -936,7 +936,7 @@ object Typer {
             case KindedAst.ChoiceRule(_, exp0) => visitExp(exp0)
           }
 
-          seqM(rs.map(visitRuleBody)).map(unzip4)
+          traverseM(rs)(visitRuleBody).map(unzip4)
         }
 
         /**
@@ -967,7 +967,7 @@ object Typer {
           /// Otherwise construct a new Choice type with isAbsent and isPresent conditions that depend on each pattern row.
           ///
           for {
-            (isAbsentConds, isPresentConds, innerTypes) <- seqM(rs.zip(ts).map(p => visitRuleBody(p._1, p._2))).map(_.unzip3)
+            (isAbsentConds, isPresentConds, innerTypes) <- traverseM(rs.zip(ts))((p => visitRuleBody(p._1, p._2))).map(_.unzip3)
             isAbsentCond = Type.mkOr(isAbsentConds, loc)
             isPresentCond = Type.mkOr(isPresentConds, loc)
             innerType <- unifyTypeM(innerTypes, loc)
@@ -1028,7 +1028,7 @@ object Typer {
           */
         def unifyMatchTypesAndRules(matchTypes: List[Type], rs: List[KindedAst.ChoiceRule]): InferMonad[List[List[Type]]] = {
           def unifyWithRule(r: KindedAst.ChoiceRule): InferMonad[List[Type]] = {
-            seqM(matchTypes.zip(r.pat).map {
+            traverseM(matchTypes.zip(r.pat)) {
               case (matchType, KindedAst.ChoicePattern.Wild(_)) =>
                 // Case 1: The pattern is wildcard. No variable is bound and there is type to constrain.
                 liftM(matchType)
@@ -1038,10 +1038,10 @@ object Typer {
               case (matchType, KindedAst.ChoicePattern.Present(sym, tvar, loc)) =>
                 // Case 3: The pattern is `Present`. Must constraint the type of the local variable with the type of the match expression.
                 unifyTypeM(matchType, sym.tvar, tvar, loc)
-            })
+            }
           }
 
-          seqM(rs.map(unifyWithRule))
+          traverseM(rs)(unifyWithRule)
         }
 
         //
@@ -1141,7 +1141,7 @@ object Typer {
 
       case KindedAst.Expression.Tuple(elms, loc) =>
         for {
-          (elementConstrs, elementTypes, elementPurs, elementEffs) <- seqM(elms.map(visitExp)).map(unzip4)
+          (elementConstrs, elementTypes, elementPurs, elementEffs) <- traverseM(elms)(visitExp).map(unzip4)
           resultPur = Type.mkAnd(elementPurs, loc)
           resultEff = Type.mkUnion(elementEffs, loc)
         } yield (elementConstrs.flatten, Type.mkTuple(elementTypes, loc), resultPur, resultEff)
@@ -1201,7 +1201,7 @@ object Typer {
         val regionVar = Type.freshVar(Kind.Bool, loc, text = FallbackText("region"))
         val regionType = Type.mkRegion(regionVar, loc)
         for {
-          (constrs1, elmTypes, pur1, eff1) <- seqM(exps.map(visitExp)).map(unzip4)
+          (constrs1, elmTypes, pur1, eff1) <- traverseM(exps)(visitExp).map(unzip4)
           (constrs2, tpe2, pur2, eff2) <- visitExp(exp)
           _ <- expectTypeM(expected = regionType, actual = tpe2, loc)
           elmTyp <- unifyTypeAllowEmptyM(elmTypes, Kind.Star, loc)
@@ -1379,13 +1379,12 @@ object Typer {
           if (expected.length != actual.length) {
             InferMonad.errPoint(TypeError.InvalidOpParamCount(op, expected = expected.length, actual = actual.length, loc))
           } else {
-            val fparams = (expected zip actual) map {
+            traverseM(expected zip actual) {
               case (ex, ac) =>
                 for {
                   _ <- expectTypeM(expected = ex.tpe, actual = ac.tpe, ac.loc)
                 } yield ()
-            }
-            seqM(fparams).map(_ => ())
+            }.map(_ => ())
           }
         }
 
@@ -1413,7 +1412,7 @@ object Typer {
         val effType = Type.Cst(TypeConstructor.Effect(effUse.sym), effUse.loc)
         for {
           (tconstrs, tpe, pur, eff) <- visitExp(exp)
-          (tconstrss, _, purs, effs) <- seqM(rules.map(visitHandlerRule)).map(unzip4)
+          (tconstrss, _, purs, effs) <- traverseM(rules)(visitHandlerRule).map(unzip4)
           resultTconstrs = (tconstrs :: tconstrss).flatten
           resultTpe <- unifyTypeM(tvar, tpe, loc)
           resultPur = Type.mkAnd(pur :: purs, loc)
@@ -1461,7 +1460,7 @@ object Typer {
       case KindedAst.Expression.InvokeConstructor(constructor, args, loc) =>
         val classType = getFlixType(constructor.getDeclaringClass)
         for {
-          (constrs, _, _, effs) <- seqM(args.map(visitExp)).map(unzip4)
+          (constrs, _, _, effs) <- traverseM(args)(visitExp).map(unzip4)
           resultTyp = classType
           resultPur = Type.Impure
           resultEff = Type.mkUnion(effs, loc)
@@ -1473,7 +1472,7 @@ object Typer {
         for {
           (baseConstrs, baseTyp, _, baseEff) <- visitExp(exp)
           objectTyp <- unifyTypeM(baseTyp, classType, loc)
-          (constrs, tpes, purs, effs) <- seqM(args.map(visitExp)).map(unzip4)
+          (constrs, tpes, purs, effs) <- traverseM(args)(visitExp).map(unzip4)
           resultTyp = getFlixType(method.getReturnType)
           resultPur = Type.Impure
           resultEff = Type.mkUnion(effs, loc)
@@ -1482,7 +1481,7 @@ object Typer {
       case KindedAst.Expression.InvokeStaticMethod(method, args, loc) =>
         val returnType = getFlixType(method.getReturnType)
         for {
-          (constrs, tpes, purs, effs) <- seqM(args.map(visitExp)).map(unzip4)
+          (constrs, tpes, purs, effs) <- traverseM(args)(visitExp).map(unzip4)
           resultTyp = returnType
           resultPur = Type.Impure
           resultEff = Type.mkUnion(effs, loc)
@@ -1545,14 +1544,14 @@ object Typer {
             }
 
             for {
-              _ <- seqM(fparams.map(inferParam))
+              _ <- traverseM(fparams)(inferParam)
               (constrs, bodyTpe, bodyPur, bodyEff) <- visitExp(exp)
               _ <- expectTypeM(expected = returnTpe, actual = bodyTpe, exp.loc)
             } yield (constrs, returnTpe, bodyPur, bodyEff)
         }
 
         for {
-          (constrs, _, _, _) <- seqM(methods map inferJvmMethod).map(unzip4)
+          (constrs, _, _, _) <- traverseM(methods)(inferJvmMethod).map(unzip4)
           resultTyp = getFlixType(clazz)
           resultPur = Type.Impure
           resultEff = Type.Empty
@@ -1622,7 +1621,7 @@ object Typer {
           }
 
         for {
-          (ruleConstrs, ruleTypes, _, ruleEffs) <- seqM(rules.map(inferSelectRule)).map(unzip4)
+          (ruleConstrs, ruleTypes, _, ruleEffs) <- traverseM(rules)(inferSelectRule).map(unzip4)
           (defaultConstrs, defaultType, _, defaultEff) <- inferDefaultRule(default)
           resultCon = ruleConstrs.flatten ++ defaultConstrs
           resultTyp <- unifyTypeM(tvar :: defaultType :: ruleTypes, loc)
@@ -1664,7 +1663,7 @@ object Typer {
 
       case KindedAst.Expression.FixpointConstraintSet(cs, tvar, loc) =>
         for {
-          (constrs, constraintTypes) <- seqM(cs.map(visitConstraint)).map(_.unzip)
+          (constrs, constraintTypes) <- traverseM(cs)(visitConstraint).map(_.unzip)
           schemaRow <- unifyTypeAllowEmptyM(constraintTypes, Kind.SchemaRow, loc)
           resultTyp <- unifyTypeM(tvar, Type.mkSchema(schemaRow, loc), loc)
         } yield (constrs.flatten, resultTyp, Type.Pure, Type.Empty)
@@ -1827,7 +1826,7 @@ object Typer {
       //
       for {
         (constrs1, headPredicateType) <- inferHeadPredicate(head0, root)
-        (constrs2, bodyPredicateTypes) <- seqM(body0.map(b => inferBodyPredicate(b, root))).map(_.unzip)
+        (constrs2, bodyPredicateTypes) <- traverseM(body0)(b => inferBodyPredicate(b, root)).map(_.unzip)
         bodyPredicateType <- unifyTypeAllowEmptyM(bodyPredicateTypes, Kind.SchemaRow, loc)
         resultType <- unifyTypeM(headPredicateType, bodyPredicateType, loc)
       } yield (constrs1 ++ constrs2.flatten, resultType)
@@ -2494,19 +2493,19 @@ object Typer {
 
       case KindedAst.Pattern.Tuple(elms, loc) =>
         for {
-          elementTypes <- seqM(elms map visit)
+          elementTypes <- traverseM(elms)(visit)
         } yield Type.mkTuple(elementTypes, loc)
 
       case KindedAst.Pattern.Array(elms, tvar, loc) =>
         for {
-          elementTypes <- seqM(elms map visit)
+          elementTypes <- traverseM(elms)(visit)
           elementType <- unifyTypeAllowEmptyM(elementTypes, Kind.Star, loc)
           resultType <- unifyTypeM(tvar, Type.mkArray(elementType, Type.False, loc), loc)
         } yield resultType
 
       case KindedAst.Pattern.ArrayTailSpread(elms, varSym, tvar, loc) =>
         for {
-          elementTypes <- seqM(elms map visit)
+          elementTypes <- traverseM(elms)(visit)
           elementType <- unifyTypeAllowEmptyM(elementTypes, Kind.Star, loc)
           arrayType <- unifyTypeM(tvar, Type.mkArray(elementType, Type.False, loc), loc)
           resultType <- unifyTypeM(varSym.tvar, arrayType, loc)
@@ -2514,7 +2513,7 @@ object Typer {
 
       case KindedAst.Pattern.ArrayHeadSpread(varSym, elms, tvar, loc) =>
         for {
-          elementTypes <- seqM(elms map visit)
+          elementTypes <- traverseM(elms)(visit)
           elementType <- unifyTypeAllowEmptyM(elementTypes, Kind.Star, loc)
           arrayType <- unifyTypeM(tvar, Type.mkArray(elementType, Type.False, loc), loc)
           resultType <- unifyTypeM(varSym.tvar, arrayType, loc)
@@ -2529,7 +2528,7 @@ object Typer {
     * Infers the type of the given patterns `pats0`.
     */
   private def inferPatterns(pats0: List[KindedAst.Pattern], root: KindedAst.Root)(implicit flix: Flix): InferMonad[List[Type]] = {
-    seqM(pats0.map(p => inferPattern(p, root)))
+    traverseM(pats0)(inferPattern(_, root))
   }
 
   /**
@@ -2579,7 +2578,7 @@ object Typer {
       // Adds additional type constraints if the denotation is a lattice.
       val restRow = Type.freshVar(Kind.SchemaRow, loc, text = FallbackText("row"))
       for {
-        (termConstrs, termTypes, termPurs, termEffs) <- seqM(terms.map(inferExp(_, root))).map(unzip4)
+        (termConstrs, termTypes, termPurs, termEffs) <- traverseM(terms)(inferExp(_, root)).map(unzip4)
         pureTermPurs <- unifyBoolM(Type.Pure, Type.mkAnd(termPurs, loc), loc)
         pureTermEffs <- unifyTypeM(Type.Empty, Type.mkUnion(termEffs, loc), loc)
         predicateType <- unifyTypeM(tvar, mkRelationOrLatticeType(pred.name, den, termTypes, root, loc), loc)
@@ -2603,7 +2602,7 @@ object Typer {
     case KindedAst.Predicate.Body.Atom(pred, den, polarity, fixity, terms, tvar, loc) =>
       val restRow = Type.freshVar(Kind.SchemaRow, loc, text = FallbackText("row"))
       for {
-        termTypes <- seqM(terms.map(inferPattern(_, root)))
+        termTypes <- traverseM(terms)(inferPattern(_, root))
         predicateType <- unifyTypeM(tvar, mkRelationOrLatticeType(pred.name, den, termTypes, root, loc), loc)
         tconstrs = getTermTypeClassConstraints(den, termTypes, root, loc)
       } yield (tconstrs, Type.mkSchemaRowExtend(pred, predicateType, restRow, loc))

--- a/main/src/ca/uwaterloo/flix/util/Result.scala
+++ b/main/src/ca/uwaterloo/flix/util/Result.scala
@@ -24,7 +24,7 @@ import scala.annotation.tailrec
   * @tparam T the type of the value.
   * @tparam E the type of the error.
   */
-sealed trait Result[T, E] {
+sealed trait Result[+T, E] {
 
   /**
     * Retrieves the value from `this` result.


### PR DESCRIPTION
There should be almost no semantic change here ultimately. We may get a slight speedup by short-circuiting inference over lists. The point of this is that it better communicates what is going on: What we do in InferMonad is more like Validation.traverse because it does not collect error, unlike Validation.sequence.