### PR TITLE
fix: `Console.readLine`

### DIFF
--- a/main/src/library/Console.flix
+++ b/main/src/library/Console.flix
@@ -34,11 +34,11 @@ namespace Console {
         import java.io.Console.readLine(): String \ IO as consoleReadLine;
         try {
             match console() {
-                case Some(c) =>
+                case Option.Some(c) =>
                     let line = consoleReadLine(c);
                     if (Object.isNull(line)) Err("EOF")
                     else Ok(line)
-                case None => Err("No JVM console")
+                case Option.None => Err("No JVM console")
             }
         } catch {
             case e: ##java.io.IOError =>

--- a/main/src/library/Console.flix
+++ b/main/src/library/Console.flix
@@ -26,13 +26,26 @@ namespace Console {
     ///
     /// Reads a single line from the console.
     ///
-    /// Returns `None` if nothing was entered or if no console is presented.
+    /// Returns `Err` if no console is present, there is an IO error, or EOF is found.
     ///
     /// See also `System/StdIn.readLines`.
     ///
-    pub def readLine(): Option[String] \ IO =
+    pub def readLine(): Result[String, String] \ IO = {
         import java.io.Console.readLine(): String \ IO as consoleReadLine;
-        console() |> Option.map(consoleReadLine)
+        try {
+            match console() {
+                case Some(c) =>
+                    let line = consoleReadLine(c);
+                    if (Object.isNull(line)) Err("EOF")
+                    else Ok(line)
+                case None => Err("No JVM console")
+            }
+        } catch {
+            case e: ##java.io.IOError =>
+                import java.lang.Throwable.getMessage(): String;
+                Err(getMessage(e))
+        }
+    }
 
     ///
     /// Converts `x` to a string and prints it to the console.


### PR DESCRIPTION
* Changed the return type from `Option` to `Result` to add an explanation and to signal that `read` shouldn't be reattempted on error.
* Correctly handle null strings