### PR TITLE
chore: Make term level and type level region names distinct

### DIFF
--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -49,9 +49,9 @@ namespace Array {
     ///
     /// Returns a string representation of the given array `a`.
     ///
-    pub def toString(a: Array[a, r]): String \ Read(r) with ToString[a] = region r2 {
-        let sb = new StringBuilder(r2);
-        let first = ref true @ r2;
+    pub def toString(a: Array[a, r]): String \ Read(r) with ToString[a] = region reg2 {
+        let sb = new StringBuilder(reg2);
+        let first = ref true @ reg2;
 
         StringBuilder.appendString!("[", sb);
 
@@ -71,8 +71,8 @@ namespace Array {
     /// Equivalent to the expression `[x; l]`.
     ///
     @Time(l) @Space(l)
-    pub def new(r: Region[r], x: a, l: Int32): Array[a, r] \ Write(r) =
-        [x; l] @ r
+    pub def new(reg: Region[r], x: a, l: Int32): Array[a, r] \ Write(r) =
+        [x; l] @ reg
 
     ///
     /// Optionally returns the element at position `i` in the array `a`.
@@ -198,8 +198,8 @@ namespace Array {
     ///
     /// Returns `a` as a MutDeque.
     ///
-    pub def toMutDeque(r1: Region[r1], a: Array[a, r2]): MutDeque[a, r1] \ { Read(r2), Write(r1) }  =
-        let d = new MutDeque(r1);
+    pub def toMutDeque(reg1: Region[r1], a: Array[a, r2]): MutDeque[a, r1] \ { Read(r2), Write(r1) }  =
+        let d = new MutDeque(reg1);
         foreach(x -> MutDeque.pushBack(x, d), a);
         d
 
@@ -227,13 +227,13 @@ namespace Array {
     ///
     @Time(length(a) + length(b)) @Space(length(a) + length(b))
     pub def append(a: Array[a, r1], b: Array[a, r2]): Array[a, r1] \ { Read(r2), Write(r1) } =
-        let r1 = Scoped.regionOf(a);
+        let reg1 = Scoped.regionOf(a);
         let len1 = length(a);
         let len2 = length(b);
         if (len1 == 0)
-            copyOfRange(r1, 0, len2, b)
+            copyOfRange(reg1, 0, len2, b)
         else {
-            let out = copyOfRange(r1, 0, len1 + len2, a);
+            let out = copyOfRange(reg1, 0, len1 + len2, a);
             updateSequence!(len1, b, out);
             out
         }
@@ -358,12 +358,12 @@ namespace Array {
     /// Returns `[]` if `b >= e`.
     ///
     @Time(e - b) @Space(e - b)
-    pub def range(r: Region[r], b: Int32, e: Int32): Array[Int32, r] \ Write(r) =
+    pub def range(reg: Region[r], b: Int32, e: Int32): Array[Int32, r] \ Write(r) =
         if (b >= e)
-            [] @ r
+            [] @ reg
         else {
             let f = x -> x + b;
-            init(r, f, e - b)
+            init(reg, f, e - b)
         }
 
     ///
@@ -372,11 +372,11 @@ namespace Array {
     /// Returns `[]` if `n <= 0`.
     ///
     @Time(n) @Space(n)
-    pub def repeat(r: Region[r], n: Int32, x: a): Array[a, r] \ Write(r) =
+    pub def repeat(reg: Region[r], n: Int32, x: a): Array[a, r] \ Write(r) =
         if (n <= 0)
-            [] @ r
+            [] @ reg
         else
-            new(r, x, n)
+            new(reg, x, n)
 
     ///
     /// Alias for `scanLeft`.
@@ -391,8 +391,8 @@ namespace Array {
     ///
     pub def scanLeft(f: (b, a) -> b \ ef, s: b, arr: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let len = length(arr) + 1;
-        let r = Scoped.regionOf(arr);
-        let b = new(r, s, len);
+        let reg = Scoped.regionOf(arr);
+        let b = new(reg, s, len);
         def loop(i, acc) = {
             if (i >= len)
                 ()
@@ -412,8 +412,8 @@ namespace Array {
     ///
     pub def scanRight(f: (a, b) -> b \ ef, s: b, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
-        let b = new(r, s, len + 1);
+        let reg = Scoped.regionOf(a);
+        let b = new(reg, s, len + 1);
         def loop(i, acc) = {
             if (i < 0)
                 ()
@@ -434,8 +434,8 @@ namespace Array {
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def map(f: a -> b \ ef, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
-        init(r, i -> f(a[i]), len)
+        let reg = Scoped.regionOf(a);
+        init(reg, i -> f(a[i]), len)
 
     ///
     /// Apply `f` to every element in array `arr`. Array `arr` is mutated.
@@ -461,8 +461,8 @@ namespace Array {
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def mapWithIndex(f: (Int32, a) -> b \ ef, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
-        init(r, i -> f(i, a[i]), len)
+        let reg = Scoped.regionOf(a);
+        init(reg, i -> f(i, a[i]), len)
 
     ///
     /// Apply `f` to every element in array `a` along with that element's index. Array `a` is mutated.
@@ -486,8 +486,8 @@ namespace Array {
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def flatMap(f: a -> Array[b, r] \ ef, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
-        init(r, i -> f(a[i]), len) |> flatten
+        let reg = Scoped.regionOf(a);
+        init(reg, i -> f(a[i]), len) |> flatten
 
     ///
     /// Returns the reverse of `a`.
@@ -496,8 +496,8 @@ namespace Array {
     pub def reverse(a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(a);
         let end = len - 1;
-        let r = Scoped.regionOf(a);
-        init(r, i -> a[end - i], len)
+        let reg = Scoped.regionOf(a);
+        init(reg, i -> a[end - i], len)
 
     ///
     /// Reverse the array `arr`, mutating it in place.
@@ -542,9 +542,9 @@ namespace Array {
     ///
     def rotateLeftHelper(n: Int32, arr: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(arr);
-        let r = Scoped.regionOf(arr);
+        let reg = Scoped.regionOf(arr);
         let f = i -> { let i1 = n + i; arr[i1 rem len] };
-        init(r, f, len)
+        init(reg, f, len)
 
     ///
     /// Rotate the contents of array `arr` by `n` steps to the right.
@@ -568,11 +568,11 @@ namespace Array {
     ///
     def rotateRightHelper(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
+        let reg = Scoped.regionOf(a);
         let n1 = n rem len;
         let start = len - n1;
         let f = i -> { let i1 = start + i; a[i1 rem len]};
-        init(r, f, len)
+        init(reg, f, len)
 
     ///
     /// Returns a copy of `a` with the element at index `i` replaced by `x`.
@@ -582,9 +582,9 @@ namespace Array {
     @Time(length(a)) @Space(length(a))
     pub def update(i: Int32, x: a, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
+        let reg = Scoped.regionOf(a);
         let f = ix -> if (ix == i) x else a[ix];
-        init(r, f, len)
+        init(reg, f, len)
 
     ///
     /// Returns a copy of `a` with every occurrence of `from` replaced by `to`.
@@ -610,9 +610,9 @@ namespace Array {
     @Time(n) @Space(length(b))
     pub def patch(i: Int32, n: Int32, a: Array[a, r1], b: Array[a, r2]): Array[a, r2] \ { Read(r1, r2), Write(r2) } =
         let len1 = length(a);
-        let r2 = Scoped.regionOf(b);
+        let reg2 = Scoped.regionOf(b);
         let size = if (n > len1) len1 else n;
-        let sub = copyOfRange(r2, 0, size, a);
+        let sub = copyOfRange(reg2, 0, size, a);
         updateSequence(i, sub, b)
 
     ///
@@ -625,9 +625,9 @@ namespace Array {
     @Time(n) @Space(1)
     pub def patch!(i: Int32, n: Int32, a: Array[a, r1], b: Array[a, r2]): Unit \ { Read(r1), Write(r2) } =
         let len1 = length(a);
-        let r2 = Scoped.regionOf(b);
+        let reg2 = Scoped.regionOf(b);
         let size = if (n > len1) len1 else n;
-        let sub = copyOfRange(r2, 0, size, a);
+        let sub = copyOfRange(reg2, 0, size, a);
         updateSequence!(i, sub, b)
 
     ///
@@ -637,11 +637,11 @@ namespace Array {
     pub def intersperse(x: a, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) }=
         let len1 = length(a);
         let len2 = len1 + len1 - 1;
-        let r = Scoped.regionOf(a);
+        let reg = Scoped.regionOf(a);
         if (len2 <= 0)
-            [] @ r
+            [] @ reg
         else {
-            let b = new(r, x, len2);
+            let b = new(reg, x, len2);
             let f = { (i, v) -> let j = i + i; b[j] = v };
             foreachWithIndex(f, a);
             b
@@ -652,15 +652,15 @@ namespace Array {
     ///
     @Time(length(arrs)) @Space(length(arrs))
     pub def intercalate(sep: Array[a, r], arrs: Array[Array[a, r], r]): Array[a, r] \ { Read(r), Write(r) } =
-        let r = Scoped.regionOf(arrs);
+        let reg = Scoped.regionOf(arrs);
         let count = length(arrs);
         let sepLength = length(sep);
         let sepCount = if (count < 2) 0 else count - 1;
         let len = sumLengths(arrs) + (sepCount * sepLength);
         match headArrays(arrs) {
-            case None    => [] @ r
+            case None    => [] @ reg
             case Some(x) =>
-                let out = new(r, x, len);
+                let out = new(reg, x, len);
                 let overwrite = { (st, a) ->
                     let (pos,i) = st;
                     if (i == 0) {
@@ -720,16 +720,16 @@ namespace Array {
     @Time(length(a) * length(a)) @Space(length(a) * length(a))
     pub def transpose(a: Array[Array[a, r1], r2]): Array[Array[a, r1], r2] \ { Read(r1, r2), Write(r1, r2) } =
         let ilen = length(a);
-        let r2 = Scoped.regionOf(a);
+        let reg2 = Scoped.regionOf(a);
         if (ilen == 0)
-            [] @ r2
+            [] @ reg2
         else {
-            let r1 = Scoped.regionOf(a[0]);
+            let reg1 = Scoped.regionOf(a[0]);
             let jlen = length(a[0]);
             if (jlen == 0 or uniformHelper(a, jlen))
                 a
             else
-                init(r2, i -> init(r1, j -> a[j][i], ilen), jlen)
+                init(reg2, i -> init(reg1, j -> a[j][i], ilen), jlen)
         }
 
     ///
@@ -953,11 +953,11 @@ namespace Array {
     @Time(length(arrs)) @Space(length(arrs))
     pub def flatten(arrs: Array[Array[a, r], r]) : Array[a, r] \ { Read(r), Write(r) } =
         let len = sumLengths(arrs);
-        let r = Scoped.regionOf(arrs);
+        let reg = Scoped.regionOf(arrs);
         match headArrays(arrs) {
-            case None => [] @ r
+            case None => [] @ reg
             case Some(x) => {
-                let out = new(r, x, len);
+                let out = new(reg, x, len);
                 discard foldLeft((pos, a) -> arrayWrites(pos, a, out), 0, arrs);
                 out
             }
@@ -1005,11 +1005,11 @@ namespace Array {
     @Time(time(f) * length(arr)) @Space(space(f) * length(arr))
     pub def filter(f: a -> Bool \ ef, arr: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
         let len = length(arr);
-        let r = Scoped.regionOf(arr);
+        let reg = Scoped.regionOf(arr);
         if (len < 1) {
-            [] @ r
+            [] @ reg
         } else {
-            let out = new(r, arr[0], len);
+            let out = new(reg, arr[0], len);
             def loop(i, j) = {
                 if (i >= len)
                     j
@@ -1024,7 +1024,7 @@ namespace Array {
                 }
             };
             let endPos = loop(0, 0);
-            copyOfRange(r, 0, endPos, out)
+            copyOfRange(reg, 0, endPos, out)
         }
 
     ///
@@ -1040,8 +1040,8 @@ namespace Array {
             if (f(x)) (x :: a1, a2) else (a1, x :: a2)
         };
         let (xs, ys) = foldRight(step, (Nil, Nil), a);
-        let r = Scoped.regionOf(a);
-        (List.toArray(r, xs), List.toArray(r, ys))
+        let reg = Scoped.regionOf(a);
+        (List.toArray(reg, xs), List.toArray(reg, ys))
 
     ///
     /// Returns a pair of arrays `(a1, a2)`.
@@ -1051,9 +1051,9 @@ namespace Array {
     ///
     @Time(time(f) * length(a)) @Space()
     pub def span(f: a -> Bool \ ef, a: Array[a, r]): (Array[a, r], Array[a, r]) \ { ef, Read(r), Write(r) }=
-        let r = Scoped.regionOf(a);
+        let reg = Scoped.regionOf(a);
         match findIndexOfLeft(x -> not (f(x)), a) {
-            case None    => (takeLeft(length(a), a), [] @ r)
+            case None    => (takeLeft(length(a), a), [] @ reg)
             case Some(i) => (takeLeft(i, a), dropLeft(i, a))
         }
 
@@ -1072,12 +1072,12 @@ namespace Array {
     @Time(length(a) - n) @Space(length(a) - n)
     pub def dropLeft(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
+        let reg = Scoped.regionOf(a);
         if (n > len)
-            [] @ r
+            [] @ reg
         else {
             let start = if (n < 0) 0 else n;
-            copyOfRange(r, start, len, a)
+            copyOfRange(reg, start, len, a)
         }
 
     ///
@@ -1087,13 +1087,13 @@ namespace Array {
     ///
     @Time(length(a) - n) @Space(length(a) - n)
     pub def dropRight(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
-        let r = Scoped.regionOf(a);
+        let reg = Scoped.regionOf(a);
         let len = length(a);
         if (n >= len)
-            [] @ r
+            [] @ reg
         else {
             let end = if (n < 0) len else len - n;
-            copyOfRange(r, 0, end, a)
+            copyOfRange(reg, 0, end, a)
         }
 
     ///
@@ -1108,9 +1108,9 @@ namespace Array {
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def dropWhileLeft(f: a -> Bool \ ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
-        let r = Scoped.regionOf(a);
+        let reg = Scoped.regionOf(a);
         match findIndexOfLeft(x -> not (f(x)), a) {
-            case None    => [] @ r
+            case None    => [] @ reg
             case Some(i) => dropLeft(i, a)
         }
 
@@ -1119,10 +1119,10 @@ namespace Array {
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def dropWhileRight(f: a -> Bool \ ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
-        let r = Scoped.regionOf(a);
+        let reg = Scoped.regionOf(a);
         match findIndexOfRight(x -> not (f(x)), a) {
-            case None    => [] @ r
-            case Some(i) => copyOfRange(r, 0, i + 1, a)
+            case None    => [] @ reg
+            case Some(i) => copyOfRange(reg, 0, i + 1, a)
         }
 
     ///
@@ -1139,13 +1139,13 @@ namespace Array {
     ///
     @Time(n) @Space(n)
     pub def takeLeft(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
-        let r = Scoped.regionOf(a);
+        let reg = Scoped.regionOf(a);
         if (n <= 0)
-            [] @ r
+            [] @ reg
         else {
             let len = length(a);
             let end = if (n > len) len else n;
-            copyOfRange(r, 0, end, a)
+            copyOfRange(reg, 0, end, a)
         }
 
     ///
@@ -1155,13 +1155,13 @@ namespace Array {
     ///
     @Time(n) @Space(n)
     pub def takeRight(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
-        let r = Scoped.regionOf(a);
+        let reg = Scoped.regionOf(a);
         if (n <= 0)
-            [] @ r
+            [] @ reg
         else {
             let len = length(a);
             let start = if (n > len) 0 else len - n;
-            copyOfRange(r, start, len, a)
+            copyOfRange(reg, start, len, a)
         }
 
     ///
@@ -1192,10 +1192,10 @@ namespace Array {
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def takeWhileRight(f: a -> Bool \ ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
-        let r = Scoped.regionOf(a);
+        let reg = Scoped.regionOf(a);
         match findIndexOfRight(x -> not (f(x)), a) {
-            case None    => copyOfRange(r, 0, length(a), a)
-            case Some(i) => copyOfRange(r, i + 1, length(a), a)
+            case None    => copyOfRange(reg, 0, length(a), a)
+            case Some(i) => copyOfRange(reg, i + 1, length(a), a)
         }
 
     ///
@@ -1207,34 +1207,34 @@ namespace Array {
     /// The function `f` must be pure.
     ///
     @Time(time(f) * length(a) * length(a)) @Space(space(f) * length(a))
-    pub def groupBy(r1: Region[r1], f: (a, a) -> Bool, a: Array[a, r2]): Array[Array[a, r1], r2] \ { Read(r2), Write(r2, r1) } =
+    pub def groupBy(reg1: Region[r1], f: (a, a) -> Bool, a: Array[a, r2]): Array[Array[a, r1], r2] \ { Read(r2), Write(r2, r1) } =
         let xs = toList(a);
-        let r2 = Scoped.regionOf(a);
-        groupByHelper(r1, f, xs, Nil) |> List.toArray(r2)
+        let reg2 = Scoped.regionOf(a);
+        groupByHelper(reg1, f, xs, Nil) |> List.toArray(reg2)
 
     ///
     /// Helper function for `groupBy`.
     ///
-    def groupByHelper(r: Region[r], f: (a, a) -> Bool, xs: List[a], ac: List[Array[a, r]]): List[Array[a, r]] \ Write(r) = match xs {
+    def groupByHelper(reg: Region[r], f: (a, a) -> Bool, xs: List[a], ac: List[Array[a, r]]): List[Array[a, r]] \ Write(r) = match xs {
         case Nil     => List.reverse(ac)
         case x :: rs =>
-            let (r1, r2) = extractHelper(r, f, rs, x :: Nil, Nil);
-            groupByHelper(r, f, r2, r1 :: ac)
+            let (r1, r2) = extractHelper(reg, f, rs, x :: Nil, Nil);
+            groupByHelper(reg, f, r2, r1 :: ac)
     }
 
     ///
     /// Helper function for `groupBy`.
     ///
-    def extractHelper(r: Region[r], f: (a, a) -> Bool, xs: List[a], ps: List[a], ns: List[a]): (Array[a, r], List[a]) \ Write(r) = match xs {
+    def extractHelper(reg: Region[r], f: (a, a) -> Bool, xs: List[a], ps: List[a], ns: List[a]): (Array[a, r], List[a]) \ Write(r) = match xs {
         case Nil => {
             let a = List.reverse(ps);
-            (List.toArray(r, a), List.reverse(ns))
+            (List.toArray(reg, a), List.reverse(ns))
         }
         case x :: rs =>
             if (agreeHelper(f, x, ps))
-                extractHelper(r, f, rs, x :: ps, ns)
+                extractHelper(reg, f, rs, x :: ps, ns)
             else
-                extractHelper(r, f, rs, ps, x :: ns)
+                extractHelper(reg, f, rs, ps, x :: ns)
     }
 
     ///
@@ -1258,8 +1258,8 @@ namespace Array {
     @Time(Int32.min(length(a), length(b))) @Space(Int32.min(length(a), length(b)))
     pub def zip(a: Array[a, r1], b: Array[b, r2]): Array[(a, b), r2] \ { Read(r1, r2), Write(r2) } =
         let len = Int32.min(length(a), length(b));
-        let r2 = Scoped.regionOf(b);
-        init(r2, i -> (a[i], b[i]), len)
+        let reg2 = Scoped.regionOf(b);
+        init(reg2, i -> (a[i], b[i]), len)
 
     ///
     /// Returns an array where the element at index `i` is `f(x, y)` where
@@ -1270,22 +1270,22 @@ namespace Array {
     @Time(time(f) * Int32.min(length(a), length(b))) @Space(space(f) * Int32.min(length(a), length(b)))
     pub def zipWith(f: (a, b) -> c \ ef, a: Array[a, r1], b: Array[b, r2]): Array[c, r2] \ { ef, Read(r1, r2), Write(r2) } =
         let len = Int32.min(length(a), length(b));
-        let r2 = Scoped.regionOf(b);
-        init(r2, i -> f(a[i], b[i]), len)
+        let reg2 = Scoped.regionOf(b);
+        init(reg2, i -> f(a[i], b[i]), len)
 
     ///
     /// Returns a pair of arrays, the first containing all first components in `a`
     /// and the second containing all second components in `a`.
     ///
     @Time(length(a)) @Space(length(a))
-    pub def unzip(r1: Region[r1], r2: Region[r2], a: Array[(a, b), r3]): (Array[a, r1], Array[b, r2]) \ { Write(r1, r2), Read(r3) } =
+    pub def unzip(reg1: Region[r1], reg2: Region[r2], a: Array[(a, b), r3]): (Array[a, r1], Array[b, r2]) \ { Write(r1, r2), Read(r3) } =
         let len = length(a);
         if (len <= 0)
-            ([] @ r1, [] @ r2)
+            ([] @ reg1, [] @ reg2)
         else {
             let (x, y) = a[0];
-            let arr = new(r1, x, len);
-            let brr = new(r2, y, len);
+            let arr = new(reg1, x, len);
+            let brr = new(reg2, y, len);
             def loop(i) = {
                 if (i < len) {
                     let (l, r) = a[i];
@@ -1343,10 +1343,10 @@ namespace Array {
     ///
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def filterMap(f: a -> Option[b] \ ef, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
-        let r = Scoped.regionOf(a);
+        let reg = Scoped.regionOf(a);
         foldRight((x, xs) -> match f(x) {
             case None    => xs
-            case Some(b) => b :: xs }, Nil, a) |> List.toArray(r)
+            case Some(b) => b :: xs }, Nil, a) |> List.toArray(reg)
 
     ///
     /// Returns the first non-None result of applying the partial function `f` to each element of `xs`.
@@ -1388,12 +1388,12 @@ namespace Array {
     ///
     /// Returns the array `a` as a MutList.
     ///
-    pub def toMutList(r1: Region[r1], a: Array[a, r2]): MutList[a, r1] \ { Read(r2), Write(r1) } =
+    pub def toMutList(reg1: Region[r1], a: Array[a, r2]): MutList[a, r1] \ { Read(r2), Write(r1) } =
         let minCap = MutList.minCapacity();
         let len = length(a);
         let c = Order.max(len, minCap);
-        let copy = copyOfRange(r1, 0, c, a);
-        MutList(ref copy @ r1, ref len @ r1)
+        let copy = copyOfRange(reg1, 0, c, a);
+        MutList(ref copy @ reg1, ref len @ reg1)
 
     ///
     /// Alias for `findIndexOfLeft`.
@@ -1447,8 +1447,8 @@ namespace Array {
     @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def findIndices(f: a -> Bool \ ef, a: Array[a, r]): Array[Int32, r] \ { ef, Read(r), Write(r) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
-        let l = new MutList(r);
+        let reg = Scoped.regionOf(a);
+        let l = new MutList(reg);
         def loop(i) = {
             if (i >= len)
                 ()
@@ -1458,18 +1458,18 @@ namespace Array {
             }
         };
         loop(0);
-        MutList.toArray(r, l)
+        MutList.toArray(reg, l)
 
     ///
     /// Build an array of length `len` by applying `f` to the successive indices.
     ///
     @Time(time(f) * len) @Space(space(f) * len)
-    pub def init(r: Region[r], f: Int32 -> a \ ef, len: Int32): Array[a, r] \ { ef, Write(r) } =
+    pub def init(reg: Region[r], f: Int32 -> a \ ef, len: Int32): Array[a, r] \ { ef, Write(r) } =
         if (len <= 0)
-            [] @ r
+            [] @ reg
         else {
             let x = f(0);
-            let a = [x; len] @ r;
+            let a = [x; len] @ reg;
             def loop(i) = {
                 if (i < len) {
                     a[i] = f(i);
@@ -1507,8 +1507,8 @@ namespace Array {
     /// Modifying `a` while using an iterator has undefined behavior and is dangerous.
     ///
     pub def iterator(a: Array[a, r]): Iterator[a, r] \ Write(r) =
-        let r = Scoped.regionOf(a);
-        let i = ref 0 @ r;
+        let reg = Scoped.regionOf(a);
+        let i = ref 0 @ reg;
         let done = () -> deref i == length(a);
         let next = () -> {
             let x = a[deref i];
@@ -1565,8 +1565,8 @@ namespace Array {
         let end = i + length(sub);
         let f = ix -> if (ix >= i and ix < end) sub[ix - i] else a[ix];
         let len = length(a);
-        let r2 = Scoped.regionOf(a);
-        init(r2, f, len)
+        let reg2 = Scoped.regionOf(a);
+        init(reg2, f, len)
 
     ///
     /// Update the mutable array `a` with the elements starting at index `i` replaced by `sub`.
@@ -1593,10 +1593,10 @@ namespace Array {
     /// Returns the concatenation of the string representation
     /// of each element in `a` according to `f` with `sep` inserted between each element.
     ///
-    pub def joinWith(f: a -> String \ ef, sep: String, a: Array[a, r]): String \ { ef, Read(r) } = region r1 {
+    pub def joinWith(f: a -> String \ ef, sep: String, a: Array[a, r]): String \ { ef, Read(r) } = region reg1 {
         use StringBuilder.append!;
         let lastSep = String.length(sep);
-        let sb = new StringBuilder(r1);
+        let sb = new StringBuilder(reg1);
         foreach(x -> { append!(f(x), sb); append!(sep, sb) }, a);
         StringBuilder.toString(sb) |> String.dropRight(lastSep)
     }
@@ -1633,8 +1633,8 @@ namespace Array {
     ///
     pub def sortWith(cmp: (a,a) -> Comparison, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
-        let b = copyOfRange(r, 0, len, a);
+        let reg = Scoped.regionOf(a);
+        let b = copyOfRange(reg, 0, len, a);
         sortWith!(cmp, b);
         b
 

--- a/main/src/library/Benchmark/Bench.Fusion.flix
+++ b/main/src/library/Benchmark/Bench.Fusion.flix
@@ -22,15 +22,15 @@ namespace Bench/Fusion {
     ///
     /// Returns a list of `n` concatenated lists with elements from `1` to `1_000`.
     ///
-    pub def input(r: Region[r], n: Int32): Array[Int32, r] \ Write(r) =
-        Array.range(r, 1, n) |>
-        Array.flatMap(_ -> Array.range(r, 1, 1_000))
+    pub def input(reg: Region[r], n: Int32): Array[Int32, r] \ Write(r) =
+        Array.range(reg, 1, n) |>
+        Array.flatMap(_ -> Array.range(reg, 1, 1_000))
 
     ////////////////////////////////////////////////////////////////////////////
     /// Biboudis Suite                                                       ///
     ////////////////////////////////////////////////////////////////////////////
-    pub def biboudisSuite(n: Int32): List[Benchmark] = region r {
-        let l = input(r, n);
+    pub def biboudisSuite(n: Int32): List[Benchmark] = region reg {
+        let l = input(reg, n);
         // List
         listLength(l) ::
         listFilterLength(l) ::

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -69,7 +69,7 @@ instance Foldable[Chain] {
     pub def foldLeft(f: (b, a) -> b \ ef, s: b, c: Chain[a]): b \ ef = Chain.foldLeft(f, s, c)
     pub def foldRight(f: (a, b) -> b \ ef, s: b, c: Chain[a]): b \ ef = Chain.foldRight(f, s, c)
     pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, s: b, c: Chain[a]): b \ ef = Chain.foldRightWithCont(f, s, c)
-    override pub def iterator(r: Region[r], c: Chain[a]): Iterator[a, r] \ Write(r) = Chain.iterator(r, c)
+    override pub def iterator(reg: Region[r], c: Chain[a]): Iterator[a, r] \ Write(r) = Chain.iterator(reg, c)
 }
 
 instance UnorderedFoldable[Chain] {
@@ -93,10 +93,10 @@ instance Filterable[Chain] {
 instance Witherable[Chain]
 
 instance ToString[Chain[a]] with ToString[a] {
-    pub def toString(c: Chain[a]): String = region r {
-        let sb = new StringBuilder(r);
+    pub def toString(c: Chain[a]): String = region reg {
+        let sb = new StringBuilder(reg);
         StringBuilder.appendString!("Chain#{", sb);
-        foreach ((x, i) <- enumerator(r, c)) {
+        foreach ((x, i) <- enumerator(reg, c)) {
             if (i < 1)
                 StringBuilder.appendString!("${x}", sb)
             else
@@ -737,16 +737,16 @@ namespace Chain {
     ///
     /// Returns `c` as a MutDeque.
     ///
-    pub def toMutDeque(r: Region[r], c: Chain[a]): MutDeque[a, r] \ Write(r) =
-        let d = new MutDeque(r);
+    pub def toMutDeque(reg: Region[r], c: Chain[a]): MutDeque[a, r] \ Write(r) =
+        let d = new MutDeque(reg);
         Chain.foreach(x -> MutDeque.pushBack(x, d), c);
         d
 
     ///
     /// Returns `c` as a mutable list.
     ///
-    pub def toMutList(r: Region[r], c: Chain[a]): MutList[a, r] \ Write(r) = region r2 {
-        Array.toMutList(r, toArray(r2, c)) // `Array.toMutList` respects the invariant of `MutList`
+    pub def toMutList(reg: Region[r], c: Chain[a]): MutList[a, r] \ Write(r) = region reg2 {
+        Array.toMutList(reg, toArray(reg2, c)) // `Array.toMutList` respects the invariant of `MutList`
     }
 
     ///
@@ -767,10 +767,10 @@ namespace Chain {
     ///
     /// Returns the chain `c` as an array.
     ///
-    pub def toArray(r: Region[r], c: Chain[a]): Array[a, r] \ Write(r) = match head(c) {
-        case None    => [] @ r
+    pub def toArray(reg: Region[r], c: Chain[a]): Array[a, r] \ Write(r) = match head(c) {
+        case None    => [] @ reg
         case Some(x) =>
-            let arr = [x; length(c)] @ r;
+            let arr = [x; length(c)] @ reg;
             foreach(match (b, i) -> arr[i] = b, zipWithIndex(c));
             arr
         }
@@ -778,8 +778,8 @@ namespace Chain {
     ///
     /// Returns an iterator over `c`.
     ///
-    pub def iterator(r: Region[r], c: Chain[a]): Iterator[a, r] \ Write(r) =
-        let cursor = ref viewLeft(c) @ r;
+    pub def iterator(reg: Region[r], c: Chain[a]): Iterator[a, r] \ Write(r) =
+        let cursor = ref viewLeft(c) @ reg;
         let done = () -> match (deref cursor) {
             case NoneLeft    => true
             case SomeLeft(_) => false
@@ -796,8 +796,8 @@ namespace Chain {
     ///
     /// Returns an iterator over `c` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], c: Chain[a]): Iterator[(a, Int32), r] \ Write(r) =
-        iterator(r, c) |> Iterator.zipWithIndex
+    pub def enumerator(reg: Region[r], c: Chain[a]): Iterator[(a, Int32), r] \ Write(r) =
+        iterator(reg, c) |> Iterator.zipWithIndex
 
     ///
     /// Returns the chain `c` as a Nel.
@@ -837,8 +837,8 @@ namespace Chain {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sort(c: Chain[a]): Chain[a] with Order[a] = region r {
-        toArray(r, c) !> Array.sort! |> Array.toChain
+    pub def sort(c: Chain[a]): Chain[a] with Order[a] = region reg {
+        toArray(reg, c) !> Array.sort! |> Array.toChain
     }
 
     /// Sort chain `c` so that elements are ordered from low to high according to the `Order` instance
@@ -848,8 +848,8 @@ namespace Chain {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortBy(f: a -> b, c: Chain[a]): Chain[a] with Order[b] = region r {
-        toArray(r, c) !> Array.sortBy!(f) |> Array.toChain
+    pub def sortBy(f: a -> b, c: Chain[a]): Chain[a] with Order[b] = region reg {
+        toArray(reg, c) !> Array.sortBy!(f) |> Array.toChain
     }
 
     ///
@@ -859,8 +859,8 @@ namespace Chain {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortWith(cmp: (a,a) -> Comparison, c: Chain[a]): Chain[a] = region r {
-        toArray(r, c) !> Array.sortWith!(cmp) |> Array.toChain
+    pub def sortWith(cmp: (a,a) -> Comparison, c: Chain[a]): Chain[a] = region reg {
+        toArray(reg, c) !> Array.sortWith!(cmp) |> Array.toChain
     }
 
     ///
@@ -921,8 +921,8 @@ namespace Chain {
     ///
     /// Shuffles `c` using the Fisher–Yates shuffle.
     ///
-    pub def shuffle(rnd: Random.Random, c: Chain[a]): Chain[a] \ NonDet = region r {
-        toArray(r, c) !> Array.shuffle(rnd) |> Array.toChain
+    pub def shuffle(rnd: Random.Random, c: Chain[a]): Chain[a] \ NonDet = region reg {
+        toArray(reg, c) !> Array.shuffle(rnd) |> Array.toChain
     }
 
 }

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -71,7 +71,7 @@ instance Foldable[DelayList] {
     pub def foldLeft(f: (b, a) -> b \ ef, s: b, l: DelayList[a]): b \ ef = DelayList.foldLeft(f, s, l)
     pub def foldRight(f: (a, b) -> b \ ef, s: b, l: DelayList[a]): b \ ef = DelayList.foldRight(f, s, l)
     pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, s: b, l: DelayList[a]): b \ ef = DelayList.foldRightWithCont(f, s, l)
-    override pub def iterator(r: Region[r], l: DelayList[a]): Iterator[a, r] \ Write(r) = DelayList.iterator(r, l)
+    override pub def iterator(reg: Region[r], l: DelayList[a]): Iterator[a, r] \ Write(r) = DelayList.iterator(reg, l)
 }
 
 instance UnorderedFoldable[DelayList] {
@@ -127,10 +127,10 @@ namespace DelayList {
     /// Forces the entire list `l`.
     ///
     @Experimental
-    pub def toString(l: DelayList[a]): String with ToString[a] = region r {
-        let sb = new StringBuilder(r);
+    pub def toString(l: DelayList[a]): String with ToString[a] = region reg {
+        let sb = new StringBuilder(reg);
         StringBuilder.appendString!("DelayList(", sb);
-        foreach ((x, i) <- enumerator(r, l)) {
+        foreach ((x, i) <- enumerator(reg, l)) {
             if (i == 0)
                 StringBuilder.appendString!("${x}", sb)
             else
@@ -1170,8 +1170,8 @@ namespace DelayList {
     /// Forces the entire list `l`.
     ///
     @Experimental
-    pub def toArray(r: Region[r], l: DelayList[a]): Array[a, r] \ Write(r) =
-        let a = [Reflect.default(); length(l)] @ r;
+    pub def toArray(reg: Region[r], l: DelayList[a]): Array[a, r] \ Write(r) =
+        let a = [Reflect.default(); length(l)] @ reg;
         foreach(match (y, i) -> a[i] = y, zipWithIndex(l));
         a
 
@@ -1181,8 +1181,8 @@ namespace DelayList {
     /// Does not force any elements of the list.
     ///
     @Experimental @Lazy
-    pub def iterator(r: Region[r], l: DelayList[a]): Iterator[a, r] \ Write(r) =
-        let cursor = ref l @ r;
+    pub def iterator(reg: Region[r], l: DelayList[a]): Iterator[a, r] \ Write(r) =
+        let cursor = ref l @ reg;
         let done = () -> match head(deref cursor) {
             case None    => true
             case Some(_) => false
@@ -1198,8 +1198,8 @@ namespace DelayList {
     ///
     /// Returns an iterator over `l` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], l: DelayList[a]): Iterator[(a, Int32), r] \ Write(r) =
-        iterator(r, l) |> Iterator.zipWithIndex
+    pub def enumerator(reg: Region[r], l: DelayList[a]): Iterator[(a, Int32), r] \ Write(r) =
+        iterator(reg, l) |> Iterator.zipWithIndex
 
     ///
     /// Returns `l` as a `List`.
@@ -1222,15 +1222,15 @@ namespace DelayList {
     /// Forces the entire list `l`.
     ///
     @Experimental
-    pub def toMutList(r: Region[r], l: DelayList[a]): MutList[a, r] \ Write(r) = region r2 {
-        Array.toMutList(r, toArray(r2, l)) // `Array.toMutList` respects the invariant of `MutList`.
+    pub def toMutList(reg: Region[r], l: DelayList[a]): MutList[a, r] \ Write(r) = region reg2 {
+        Array.toMutList(reg, toArray(reg2, l)) // `Array.toMutList` respects the invariant of `MutList`.
     }
 
     ///
     /// Returns `l` as a MutDeque.
     ///
-    pub def toMutDeque(r: Region[r], l: DelayList[a]): MutDeque[a, r] \ Write(r) =
-        let d = new MutDeque(r);
+    pub def toMutDeque(reg: Region[r], l: DelayList[a]): MutDeque[a, r] \ Write(r) =
+        let d = new MutDeque(reg);
         DelayList.foreach(x -> MutDeque.pushBack(x, d), l);
         d
 
@@ -1328,8 +1328,8 @@ namespace DelayList {
     ///
     /// Shuffles `l` using the Fisher–Yates shuffle.
     ///
-    pub def shuffle(rnd: Random.Random, l: DelayList[a]): DelayList[a] \ NonDet = region r {
-        toArray(r, l) !> Array.shuffle(rnd) |> Array.toDelayList
+    pub def shuffle(rnd: Random.Random, l: DelayList[a]): DelayList[a] \ NonDet = region reg {
+        toArray(reg, l) !> Array.shuffle(rnd) |> Array.toDelayList
     }
 
 }

--- a/main/src/library/DelayMap.flix
+++ b/main/src/library/DelayMap.flix
@@ -42,8 +42,8 @@ instance Foldable[DelayMap[k]] {
     pub def foldLeft(f: (b, v) -> b \ ef, s: b, m: DelayMap[k, v]): b \ ef = DelayMap.foldLeft(f, s, m)
     pub def foldRight(f: (v, b) -> b \ ef, s: b, m: DelayMap[k, v]): b \ ef = DelayMap.foldRight(f, s, m)
     pub def foldRightWithCont(f: (v, Unit -> b \ ef) -> b \ ef, s: b, m: DelayMap[k, v]): b \ ef = DelayMap.foldRightWithCont(f, s, m)
-    override pub def iterator(r: Region[r], m: DelayMap[k, v]): Iterator[v, r] \ Write(r) =
-        DelayMap.iterator(r, m) |> Iterator.mapL(match (_, v) -> v)
+    override pub def iterator(reg: Region[r], m: DelayMap[k, v]): Iterator[v, r] \ Write(r) =
+        DelayMap.iterator(reg, m) |> Iterator.mapL(match (_, v) -> v)
 }
 
 namespace DelayMap {
@@ -52,12 +52,12 @@ namespace DelayMap {
     /// Returns a string representation of the given `DelayMap` `m`.
     ///
     @Experimental
-    pub def toString(m: DelayMap[k, v]): String with ToString[k], ToString[v] = region r {
-        let sb = new StringBuilder(r);
+    pub def toString(m: DelayMap[k, v]): String with ToString[k], ToString[v] = region reg {
+        let sb = new StringBuilder(reg);
         let _ = parallelForce(m);
         let first = ref true;
         StringBuilder.appendString!("DelayMap#{", sb);
-        foreach ((k, v) <- DelayMap.iterator(r, m)) {
+        foreach ((k, v) <- DelayMap.iterator(reg, m)) {
             if (deref first) {
                 first := false;
                 StringBuilder.appendString!("${k} => ${v}", sb)
@@ -773,8 +773,8 @@ namespace DelayMap {
     /// Returns `m` as a mutable set.
     ///
     @Experimental @Parallel
-    pub def toMutMap(r: Region[r], m: DelayMap[k, v]): MutMap[k, v, r] \ Write(r) =
-        MutMap(ref toMap(m) @ r)
+    pub def toMutMap(reg: Region[r], m: DelayMap[k, v]): MutMap[k, v, r] \ Write(r) =
+        MutMap(ref toMap(m) @ reg)
 
     ///
     /// Returns the map `m` as a set of key-value pairs.
@@ -794,17 +794,17 @@ namespace DelayMap {
     /// Returns an iterator over all key-value pairs in `m`.
     ///
     @Experimental
-    pub def iterator(r: Region[r], m: DelayMap[a, b]): Iterator[(a, b), r] \ Write(r) =
+    pub def iterator(reg: Region[r], m: DelayMap[a, b]): Iterator[(a, b), r] \ Write(r) =
         let DMap(t) = m;
-        RedBlackTree.iterator(r, t) |> Iterator.mapL(match (k, v) -> (k, force v))
+        RedBlackTree.iterator(reg, t) |> Iterator.mapL(match (k, v) -> (k, force v))
 
     ///
     /// Returns the map `m` as a MutDeque of key-value pairs.
     ///
     @Experimental
-    pub def toMutDeque(r: Region[r], m: DelayMap[k, v]): MutDeque[(k, v), r] \ Write(r) =
+    pub def toMutDeque(reg: Region[r], m: DelayMap[k, v]): MutDeque[(k, v), r] \ Write(r) =
         let m1 = DelayMap.toMap(m);
-        Map.toMutDeque(r, m1)
+        Map.toMutDeque(reg, m1)
 
     ///
     /// Applies `f` to every element of `xs`.

--- a/main/src/library/Fixpoint/Interpreter.flix
+++ b/main/src/library/Fixpoint/Interpreter.flix
@@ -23,8 +23,8 @@ namespace Fixpoint {
     type alias Database[v: Type, r: Region] = MutMap[RamSym[v], MutMap[Tuple[v], v, r], r]
     type alias SearchEnv[v: Type, r: Region] = (Array[Tuple[v], r], Array[v, r])
 
-    def interpret(r: Region[r], stmt: RamStmt[v]): Database[v, r] \ Write(r) with Order[v] =
-        interpretWithDatabase(new MutMap(r), stmt)
+    def interpret(reg: Region[r], stmt: RamStmt[v]): Database[v, r] \ Write(r) with Order[v] =
+        interpretWithDatabase(new MutMap(reg), stmt)
 
     def interpretWithDatabase(db: Database[v, r], stmt: RamStmt[v]): Database[v, r] \ { Read(r), Write(r) } with Order[v] =
         notifyPreInterpret(stmt) as \ r; // This casts away the impure effect of notify
@@ -32,23 +32,23 @@ namespace Fixpoint {
         db
 
     def evalStmt(db: Database[v, r], stmt: RamStmt[v]): Unit \ { Read(r), Write(r) } with Order[v] =
-        let r = Scoped.regionOf(db);
+        let reg = Scoped.regionOf(db);
         match stmt {
-            case RamStmt.Insert(relOp) => evalOp(db, allocEnv(r, 0, relOp), relOp)
+            case RamStmt.Insert(relOp) => evalOp(db, allocEnv(reg, 0, relOp), relOp)
             case RamStmt.Merge(srcSym, dstSym) =>
-                let dst = MutMap.getOrElsePut!(dstSym, new MutMap(r), db);
+                let dst = MutMap.getOrElsePut!(dstSym, new MutMap(reg), db);
                 match toDenotation(srcSym) {
                     case Denotation.Relational =>
-                        MutMap.merge!(MutMap.getWithDefault(srcSym, new MutMap(r), db), dst)
+                        MutMap.merge!(MutMap.getWithDefault(srcSym, new MutMap(reg), db), dst)
                     case Denotation.Latticenal(_, _, lub, _) =>
-                        MutMap.mergeWith!(lub, MutMap.getWithDefault(srcSym, new MutMap(r), db), dst)
+                        MutMap.mergeWith!(lub, MutMap.getWithDefault(srcSym, new MutMap(reg), db), dst)
                 }
             case RamStmt.Assign(lhs, rhs) =>
-                MutMap.put!(lhs, MutMap.getWithDefault(rhs, new MutMap(r), db), db)
+                MutMap.put!(lhs, MutMap.getWithDefault(rhs, new MutMap(reg), db), db)
             case RamStmt.Purge(ramSym) => MutMap.remove!(ramSym, db)
             case RamStmt.Seq(stmts) => List.foreach(evalStmt(db), stmts)
             case RamStmt.Until(test, body) =>
-                if (evalBoolExp(db, ([] @ r, [] @ r), test)) {
+                if (evalBoolExp(db, ([] @ reg, [] @ reg), test)) {
                     ()
                 } else {
                     evalStmt(db, body);
@@ -57,15 +57,15 @@ namespace Fixpoint {
             case RamStmt.Comment(_) => ()
         }
 
-    def allocEnv(r: Region[r], depth: Int32, relOp: RelOp[v]): SearchEnv[v, r] \ Write(r) = match relOp {
-        case RelOp.Search(_, _, body) => allocEnv(r, depth + 1, body)
-        case RelOp.Query(_, _, _, body) => allocEnv(r, depth + 1, body)
-        case RelOp.Project(_) => (Array.new(r, Fixpoint/Tuple.new(Nil), depth), Array.new(r, Reflect.default(), depth))
-        case RelOp.If(_, then) => allocEnv(r, depth, then)
+    def allocEnv(reg: Region[r], depth: Int32, relOp: RelOp[v]): SearchEnv[v, r] \ Write(r) = match relOp {
+        case RelOp.Search(_, _, body) => allocEnv(reg, depth + 1, body)
+        case RelOp.Query(_, _, _, body) => allocEnv(reg, depth + 1, body)
+        case RelOp.Project(_) => (Array.new(reg, Fixpoint/Tuple.new(Nil), depth), Array.new(reg, Reflect.default(), depth))
+        case RelOp.If(_, then) => allocEnv(reg, depth, then)
     }
 
     def evalOp(db: Database[v, r1], env: SearchEnv[v, r2], op: RelOp[v]): Unit \ { Read(r1), Write(r1), Read(r2), Write(r2) } with Order[v] =
-        let r1 = Scoped.regionOf(db);
+        let reg1 = Scoped.regionOf(db);
         match op {
             case RelOp.Search(RowVar.Index(i), ramSym, body) =>
                 let (tupleEnv, latEnv) = env;
@@ -73,16 +73,16 @@ namespace Fixpoint {
                     tupleEnv[i] = t;
                     latEnv[i] = l;
                     evalOp(db, env, body)
-                }, MutMap.getWithDefault(ramSym, new MutMap(r1), db))
+                }, MutMap.getWithDefault(ramSym, new MutMap(reg1), db))
             case RelOp.Query(RowVar.Index(i), ramSym, query, body) =>
                 let (tupleEnv, latEnv) = env;
                 MutMap.queryWith(evalQuery(env, query), t -> l -> {
                     tupleEnv[i] = t;
                     latEnv[i] = l;
                     evalOp(db, env, body)
-                }, MutMap.getWithDefault(ramSym, new MutMap(r1), db))
+                }, MutMap.getWithDefault(ramSym, new MutMap(reg1), db))
             case RelOp.Project(terms, ramSym) =>
-                let rel = MutMap.getOrElsePut!(ramSym, new MutMap(r1), db);
+                let rel = MutMap.getOrElsePut!(ramSym, new MutMap(reg1), db);
                 match toDenotation(ramSym) {
                     case Denotation.Relational =>
                         let tuple = Fixpoint/Tuple.new(List.map(evalTerm(env), terms));
@@ -119,12 +119,12 @@ namespace Fixpoint {
         }
 
     def evalBoolExp(db: Database[v, r1], env: SearchEnv[v, r2], es: List[BoolExp[v]]): Bool \ { Read(r1), Read(r2) } with Order[v] =
-        let r1 = Scoped.regionOf(db);
+        let reg1 = Scoped.regionOf(db);
         List.forall(exp -> match exp {
             case BoolExp.Empty(ramSym) =>
-                MutMap.isEmpty(MutMap.getWithDefault(ramSym, new MutMap(r1), db))
+                MutMap.isEmpty(MutMap.getWithDefault(ramSym, new MutMap(reg1), db))
             case BoolExp.NotMemberOf(terms, ramSym) =>
-                let rel = MutMap.getWithDefault(ramSym, new MutMap(r1), db);
+                let rel = MutMap.getWithDefault(ramSym, new MutMap(reg1), db);
                 match toDenotation(ramSym) {
                     case Denotation.Relational =>
                         let tuple = Fixpoint/Tuple.new(List.map(evalTerm(env), terms));

--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -210,19 +210,19 @@ pub class Foldable[t : Type -> Type] {
     ///
     /// Returns `t` as an array.
     ///
-    pub def toArray(r: Region[r], t: t[a]): Array[a, r] \ Write(r) = region r2 {
-        let l = new MutList(r2);
+    pub def toArray(reg: Region[r], t: t[a]): Array[a, r] \ Write(r) = region reg2 {
+        let l = new MutList(reg2);
         Foldable.foreach(a -> MutList.push!(a, l), t);
-        MutList.toArray(r, l)
+        MutList.toArray(reg, l)
     }
 
     ///
     /// Returns an iterator over `t`.
     ///
-    pub def iterator(r: Region[r], t: t[a]): Iterator[a, r] \ Write(r) =
-        let arr = Foldable.toArray(r, t);
+    pub def iterator(reg: Region[r], t: t[a]): Iterator[a, r] \ Write(r) =
+        let arr = Foldable.toArray(reg, t);
         let len = Array.length(arr);
-        let i = ref 0 @ r;
+        let i = ref 0 @ reg;
         let done = () -> (deref i) >= len;
         let next = () -> {
             let j = deref i;
@@ -235,22 +235,22 @@ pub class Foldable[t : Type -> Type] {
     ///
     /// Returns an iterator over `t` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], t: t[a]): Iterator[(a, Int32), r] \ Write(r) =
-        Foldable.iterator(r, t) |> Iterator.zipWithIndex
+    pub def enumerator(reg: Region[r], t: t[a]): Iterator[(a, Int32), r] \ Write(r) =
+        Foldable.iterator(reg, t) |> Iterator.zipWithIndex
 
     ///
     /// Returns `t` as a `MutDeque`.
     ///
-    pub def toMutDeque(r: Region[r], t: t[a]): MutDeque[a, r] \ Write(r) =
-        let d = new MutDeque(r);
+    pub def toMutDeque(reg: Region[r], t: t[a]): MutDeque[a, r] \ Write(r) =
+        let d = new MutDeque(reg);
         Foldable.foreach(x -> MutDeque.pushBack(x, d), t);
         d
 
     ///
     /// Returns `t` as a mutable list.
     ///
-    pub def toMutList(r: Region[r], t: t[a]): MutList[a, r] \ Write(r) = region r2 {
-        Array.toMutList(r, Foldable.toArray(r2, t))
+    pub def toMutList(reg: Region[r], t: t[a]): MutList[a, r] \ Write(r) = region reg2 {
+        Array.toMutList(reg, Foldable.toArray(reg2, t))
     }
 
     ///
@@ -262,8 +262,8 @@ pub class Foldable[t : Type -> Type] {
     ///
     /// Returns the set `s` as a `MutSet`.
     ///
-    pub def toMutSet(r: Region[r], t: t[a]): MutSet[a, r] \ Write(r) with Order[a] =
-        let s = new MutSet(r);
+    pub def toMutSet(reg: Region[r], t: t[a]): MutSet[a, r] \ Write(r) with Order[a] =
+        let s = new MutSet(reg);
         Foldable.foreach(x -> MutSet.add!(x, s), t);
         s
 
@@ -288,8 +288,8 @@ pub class Foldable[t : Type -> Type] {
     ///
     /// Returns `t` as a `MutMap`.
     ///
-    pub def toMutMap(r: Region[r], t: t[(k, v)]): MutMap[k, v, r] \ Write(r) with Order[k] =
-        let m = new MutMap(r);
+    pub def toMutMap(reg: Region[r], t: t[(k, v)]): MutMap[k, v, r] \ Write(r) with Order[k] =
+        let m = new MutMap(reg);
         Foldable.foreach(x -> let (k, v) = x; MutMap.put!(k, v, m), t);
         m
 
@@ -384,10 +384,10 @@ pub class Foldable[t : Type -> Type] {
     /// Returns the concatenation of the string representation
     /// of each element in `t` according to `f` with `sep` inserted between each element.
     ///
-    pub def joinWith(f: a -> String \ ef, sep: String, t: t[a]): String \ ef = region r {
+    pub def joinWith(f: a -> String \ ef, sep: String, t: t[a]): String \ ef = region reg {
         use StringBuilder.append!;
         let lastSep = String.length(sep);
-        let sb = new StringBuilder(r);
+        let sb = new StringBuilder(reg);
         t |> Foldable.foreach(x -> { append!(f(x), sb); append!(sep, sb) });
         StringBuilder.toString(sb) |> String.dropRight(lastSep)
     }

--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -19,7 +19,7 @@ pub enum Iterator[a: Type, r: Region] {
 }
 
 instance Newable[Iterator[a]] {
-    pub def new(r: Region[r]): Iterator[a, r] \ { Read(r), Write(r) } = Iterator.new(r)
+    pub def new(reg: Region[r]): Iterator[a, r] \ { Read(r), Write(r) } = Iterator.new(reg)
 }
 
 instance Scoped[Iterator[a]] {
@@ -33,14 +33,14 @@ instance Iterable[Iterator] {
 ///
 /// Alias for `Foldable.iterator`.
 ///
-pub def iterator(r: Region[r], t: t[a]): Iterator[a, r] \ Write(r) with Foldable[t] =
-    Foldable.iterator(r, t)
+pub def iterator(reg: Region[r], t: t[a]): Iterator[a, r] \ Write(r) with Foldable[t] =
+    Foldable.iterator(reg, t)
 
 ///
 /// Alias for `Foldable.iterator |> Iterable.enumerator`.
 ///
-pub def enumerator(r: Region[r], t: t[a]): Iterator[(a, Int32), r] \ Write(r) with Foldable[t] =
-    Foldable.iterator(r, t) |> Iterable.enumerator
+pub def enumerator(reg: Region[r], t: t[a]): Iterator[(a, Int32), r] \ Write(r) with Foldable[t] =
+    Foldable.iterator(reg, t) |> Iterable.enumerator
 
 namespace Iterator {
 
@@ -65,8 +65,8 @@ namespace Iterator {
     ///
     /// Returns an iterator containing only a single element, `x`.
     ///
-    pub def singleton(r: Region[r], x: a): Iterator[a, r] \ Write(r) =
-        let d = ref false @ r;
+    pub def singleton(reg: Region[r], x: a): Iterator[a, r] \ Write(r) =
+        let d = ref false @ reg;
         let done = () -> deref d;
         let next = () -> {
             if (done()) {
@@ -106,8 +106,8 @@ namespace Iterator {
     /// Returns an empty iterator if `b >= e`.
     ///
     @Lazy
-    pub def range(r: Region[r], b: Int32, e: Int32): Iterator[Int32, r] \ Write(r) =
-        let i = ref b @ r;
+    pub def range(reg: Region[r], b: Int32, e: Int32): Iterator[Int32, r] \ Write(r) =
+        let i = ref b @ reg;
         let done = () -> deref i >= e;
         let next = () -> {
                 let res = deref i;
@@ -127,8 +127,8 @@ namespace Iterator {
     /// Returns an empty iterator if `n < 0`.
     ///
     @Lazy
-    pub def repeat(r: Region[r], n: Int32, x: a): Iterator[a, r] \ Write(r) =
-        let i = ref 0 @ r;
+    pub def repeat(reg: Region[r], n: Int32, x: a): Iterator[a, r] \ Write(r) =
+        let i = ref 0 @ reg;
         let done = () -> deref i >= n;
         let next = () -> {
               let j = deref i;
@@ -185,10 +185,10 @@ namespace Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def toArray(r1: Region[r1], iter: Iterator[a, r2]): Array[a, r1] \ { Read(r2), Write(r1) } = region r0 {
-        let m = new MutList(r0);
+    pub def toArray(reg1: Region[r1], iter: Iterator[a, r2]): Array[a, r1] \ { Read(r2), Write(r1) } = region reg0 {
+        let m = new MutList(reg0);
         foreach(a -> MutList.push!(a, m), iter);
-        MutList.toArray(r1, m)
+        MutList.toArray(reg1, m)
     }
 
     ///
@@ -234,8 +234,8 @@ namespace Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def toMutDeque(r1: Region[r1], iter: Iterator[a, r2]): MutDeque[a, r1] \ { Read(r2), Write(r1) }  =
-        let d = new MutDeque(r1);
+    pub def toMutDeque(reg1: Region[r1], iter: Iterator[a, r2]): MutDeque[a, r1] \ { Read(r2), Write(r1) }  =
+        let d = new MutDeque(reg1);
         foreach(x -> MutDeque.pushBack(x, d), iter);
         d
 
@@ -527,8 +527,8 @@ namespace Iterator {
     /// If `f` returns `Err(e)`, then the iterator is depleted.
     ///
     @Lazy
-    pub def unfoldWithOk(r: Region[r], f: Unit -> Result[a, b] \ ef): Iterator[a, r and ef] \ Write(r) =
-        let cursor = ref None @ r;
+    pub def unfoldWithOk(reg: Region[r], f: Unit -> Result[a, b] \ ef): Iterator[a, r and ef] \ Write(r) =
+        let cursor = ref None @ reg;
         let done = () -> match deref cursor {
             case None    => match f() {
                 case Err(_) => true
@@ -562,8 +562,8 @@ namespace Iterator {
             iter
         else
             let Iterator(done, next) = iter;
-            discard region r2 {
-                let i = ref (n - 1) @ r2; // Subtract 1 since `forward` consumes 1 element before applying `f`.
+            discard region reg2 {
+                let i = ref (n - 1) @ reg2; // Subtract 1 since `forward` consumes 1 element before applying `f`.
                 let f = _ -> if (deref i <= 0) true else { i := deref i - 1; false };
                 forward(f, done, next)
             };
@@ -581,12 +581,12 @@ namespace Iterator {
     ///
     @Lazy
     pub def takeL(n: Int32, iter: Iterator[a, r]): Iterator[a, r] \ Write(r) =
-        let r = Scoped.regionOf(iter);
+        let reg = Scoped.regionOf(iter);
         if (n < 0)
-            new Iterator(r)
+            new Iterator(reg)
         else
             let Iterator(done, next) = iter;
-            let i = ref 0 @ r;
+            let i = ref 0 @ reg;
             let done1 = () -> done() or (deref i) >= n;
             let next1 = () -> {
                 let x = next();
@@ -703,10 +703,10 @@ namespace Iterator {
     pub def intercalate(iterA: Iterator[a, r1], iterB: Iterator[Iterator[a, r2], r3]): Iterator[a, r1 and r2 and r3] \ Write(r1, r3) =
         let Iterator(doneA, nextA) = iterA;
         let Iterator(doneB, nextB) = iterB;
-        let r1 = Scoped.regionOf(iterA);
-        let xs = ref Nil @ r1;
-        let r3 = Scoped.regionOf(iterB);
-        let isReversed = ref false @ r1;
+        let reg1 = Scoped.regionOf(iterA);
+        let xs = ref Nil @ reg1;
+        let reg3 = Scoped.regionOf(iterB);
+        let isReversed = ref false @ reg1;
         let nextAA = () -> {
             let x = nextA();
             xs := x :: deref xs;
@@ -725,11 +725,11 @@ namespace Iterator {
             else
                 false
         };
-        let cursor = ref None @ r3;
+        let cursor = ref None @ reg3;
         let mkCursor = i -> { // Appends an iterator with the contents of `iterA`. Boolean formula: r1 and formula of i
             if (deref isReversed)
                 // `iterA` has been consumed, so construct a new one from `xs`
-                cursor := Some(append(i, List.iterator(r1, deref xs)))
+                cursor := Some(append(i, List.iterator(reg1, deref xs)))
             else
                 cursor := Some(append(i, Iterator(doneAA, nextAA)))
         };
@@ -738,7 +738,7 @@ namespace Iterator {
                 case None    => true
                 case Some(i) =>
                     if (doneB())
-                        cursor := Some(append(i, new Iterator(r1))) // Has Boolean formula r2 since it is the last iterator of `iterB`.
+                        cursor := Some(append(i, new Iterator(reg1))) // Has Boolean formula r2 since it is the last iterator of `iterB`.
                     else                                                     // Has to be appended with an empty iterator to satisfy formula `r1 and formula of i` in `mkCursor`
                         mkCursor(i);                                         // Same reason for appending with empty iterator below
                     false
@@ -749,7 +749,7 @@ namespace Iterator {
                     case None     => true
                     case Some(i1) =>
                         if (doneB())
-                            cursor := Some(append(i1, new Iterator(r1)))
+                            cursor := Some(append(i1, new Iterator(reg1)))
                         else
                             mkCursor(i1);
                         false
@@ -785,8 +785,8 @@ namespace Iterator {
         if (done())
             ""
         else
-            region r {
-                let sb = new StringBuilder(r);
+            region reg {
+                let sb = new StringBuilder(reg);
                 let g = x -> { StringBuilder.append!(sep, sb); StringBuilder.append!(f(x), sb) };
                 StringBuilder.append!(f(next()), sb); // Safe to call next, done was check above.
                 foreach(g, iter);
@@ -854,9 +854,9 @@ namespace Iterator {
     @Lazy
     pub def dropWhileL(f: a -> Bool, iter: Iterator[a, r]): Iterator[a, r] \ { Read(r), Write(r) } =
         let Iterator(done, next) = iter;
-        let r = Scoped.regionOf(iter);
-        let front = ref None @ r;
-        let forwarded = ref false @ r;
+        let reg = Scoped.regionOf(iter);
+        let front = ref None @ reg;
+        let forwarded = ref false @ reg;
         let done1 = () -> if (deref forwarded) done() else match forward(a -> not f(a), done, next) {
             case None    => true
             case Some(x) =>

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -88,7 +88,7 @@ instance Foldable[List] {
     pub def foldLeft(f: (b, a) -> b \ ef, s: b, l: List[a]): b \ ef = List.foldLeft(f, s, l)
     pub def foldRight(f: (a, b) -> b \ ef, s: b, l: List[a]): b \ ef = List.foldRight(f, s, l)
     pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, s: b, l: List[a]): b \ ef = List.foldRightWithCont(f, s, l)
-    override pub def iterator(r: Region[r], l: List[a]): Iterator[a, r] \ Write(r) = List.iterator(r, l)
+    override pub def iterator(reg: Region[r], l: List[a]): Iterator[a, r] \ Write(r) = List.iterator(reg, l)
 }
 
 instance UnorderedFoldable[List] {
@@ -124,9 +124,9 @@ namespace List {
     ///
     /// Renders the list `l` to a String.
     ///
-    pub def toString(l: List[a]): String with ToString[a] = region r {
-        let sb = new StringBuilder(r);
-        foreach (x <- iterator(r, l))
+    pub def toString(l: List[a]): String with ToString[a] = region reg {
+        let sb = new StringBuilder(reg);
+        foreach (x <- iterator(reg, l))
             StringBuilder.appendString!("${x} :: ", sb);
         StringBuilder.appendString!("Nil", sb);
         StringBuilder.toString(sb)
@@ -1140,16 +1140,16 @@ namespace List {
     ///
     /// Returns `l` as a MutDeque.
     ///
-    pub def toMutDeque(r: Region[r], l: List[a]): MutDeque[a, r] \ Write(r) =
-        let d = new MutDeque(r);
+    pub def toMutDeque(reg: Region[r], l: List[a]): MutDeque[a, r] \ Write(r) =
+        let d = new MutDeque(reg);
         List.foreach(x -> MutDeque.pushBack(x, d), l);
         d
 
     ///
     /// Returns `l` as a mutable list.
     ///
-    pub def toMutList(r: Region[r], l: List[a]): MutList[a, r] \ Write(r) = region r2 {
-        Array.toMutList(r, toArray(r2, l)) // `Array.toMutList` respects the invariant of `MutList`
+    pub def toMutList(reg: Region[r], l: List[a]): MutList[a, r] \ Write(r) = region reg2 {
+        Array.toMutList(reg, toArray(reg2, l)) // `Array.toMutList` respects the invariant of `MutList`
     }
 
     ///
@@ -1191,10 +1191,10 @@ namespace List {
     /// Returns the list `l` as an array.
     ///
     @Time(length(l)) @Space(length(l))
-    pub def toArray(r: Region[r], l: List[a]): Array[a, r] \ Write(r) = match head(l) {
-        case None    => [] @ r
+    pub def toArray(reg: Region[r], l: List[a]): Array[a, r] \ Write(r) = match head(l) {
+        case None    => [] @ reg
         case Some(x) =>
-            let a = [x; length(l)] @ r;
+            let a = [x; length(l)] @ reg;
             foreach(match (b, i) -> a[i] = b, zipWithIndex(l));
             a
         }
@@ -1226,8 +1226,8 @@ namespace List {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sort(l: List[a]): List[a] with Order[a] = region r {
-        toArray(r, l) !> Array.sort! |> Array.toList
+    pub def sort(l: List[a]): List[a] with Order[a] = region reg {
+        toArray(reg, l) !> Array.sort! |> Array.toList
     }
 
     /// Sort list `l` so that elements are ordered from low to high according to the `Order` instance
@@ -1237,8 +1237,8 @@ namespace List {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortBy(f: a -> b, l: List[a]): List[a] with Order[b] = region r {
-        toArray(r, l) !> Array.sortBy!(f) |> Array.toList
+    pub def sortBy(f: a -> b, l: List[a]): List[a] with Order[b] = region reg {
+        toArray(reg, l) !> Array.sortBy!(f) |> Array.toList
     }
 
     ///
@@ -1248,8 +1248,8 @@ namespace List {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortWith(cmp: (a,a) -> Comparison, l: List[a]): List[a] = region r {
-        toArray(r, l) !> Array.sortWith!(cmp) |> Array.toList
+    pub def sortWith(cmp: (a,a) -> Comparison, l: List[a]): List[a] = region reg {
+        toArray(reg, l) !> Array.sortWith!(cmp) |> Array.toList
     }
 
     ///
@@ -1349,8 +1349,8 @@ namespace List {
     ///
     /// Returns an iterator over `l`.
     ///
-    pub def iterator(r: Region[r], l: List[a]): Iterator[a, r] \ Write(r) =
-        let cursor = ref l @ r;
+    pub def iterator(reg: Region[r], l: List[a]): Iterator[a, r] \ Write(r) =
+        let cursor = ref l @ reg;
         let done = () -> match (deref cursor) {
             case Nil => true
             case _   => false
@@ -1366,8 +1366,8 @@ namespace List {
     ///
     /// Returns an iterator over `l` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], l: List[a]): Iterator[(a, Int32), r] \ Write(r) =
-        iterator(r, l) |> Iterator.zipWithIndex
+    pub def enumerator(reg: Region[r], l: List[a]): Iterator[(a, Int32), r] \ Write(r) =
+        iterator(reg, l) |> Iterator.zipWithIndex
 
     ///
     /// Returns the association list `l` as a `DelayMap`.
@@ -1431,8 +1431,8 @@ namespace List {
     ///
     /// Shuffles `l` using the Fisher–Yates shuffle.
     ///
-    pub def shuffle(rnd: Random.Random, l: List[a]): List[a] \ NonDet = region r {
-        toArray(r, l) !> Array.shuffle(rnd) |> Array.toList
+    pub def shuffle(rnd: Random.Random, l: List[a]): List[a] \ NonDet = region reg {
+        toArray(reg, l) !> Array.shuffle(rnd) |> Array.toList
     }
 
 }

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -54,7 +54,7 @@ instance Foldable[Map[k]] {
     pub def foldLeft(f: (b, v) -> b \ ef, s: b, m: Map[k, v]): b \ ef = Map.foldLeft(f, s, m)
     pub def foldRight(f: (v, b) -> b \ ef, s: b, m: Map[k, v]): b \ ef = Map.foldRight(f, s, m)
     pub def foldRightWithCont(f: (v, Unit -> b \ ef) -> b \ ef, s: b, m: Map[k, v]): b \ ef = Map.foldRightWithCont(f, s, m)
-    override pub def iterator(r: Region[r], m: Map[k, v]): Iterator[v, r] \ Write(r) = Map.iteratorValues(r, m)
+    override pub def iterator(reg: Region[r], m: Map[k, v]): Iterator[v, r] \ Write(r) = Map.iteratorValues(reg, m)
 }
 
 instance UnorderedFoldable[Map[k]] {
@@ -111,11 +111,11 @@ namespace Map {
     ///
     /// Returns a string representation of the given map `m`.
     ///
-    pub def toString(m: Map[k, v]): String with ToString[k], ToString[v] = region r {
-        let sb = new StringBuilder(r);
+    pub def toString(m: Map[k, v]): String with ToString[k], ToString[v] = region reg {
+        let sb = new StringBuilder(reg);
         StringBuilder.appendString!("Map#{", sb);
-        let first = ref true @ r;
-        foreach ((k, v) <- Map.iterator(r, m)) {
+        let first = ref true @ reg;
+        foreach ((k, v) <- Map.iterator(reg, m)) {
             if (deref first) {
                 first := false;
                 StringBuilder.appendString!("${k} => ${v}", sb)
@@ -843,8 +843,8 @@ namespace Map {
     /// Returns `m` as a mutable set.
     ///
     @Time(1) @Space(1)
-    pub def toMutMap(r: Region[r], m: Map[k, v]): MutMap[k, v, r] \ Write(r) =
-        MutMap(ref m @ r)
+    pub def toMutMap(reg: Region[r], m: Map[k, v]): MutMap[k, v, r] \ Write(r) =
+        MutMap(ref m @ reg)
 
     ///
     /// Returns the map `m` as a list of key-value pairs.
@@ -881,8 +881,8 @@ namespace Map {
     ///
     /// Returns `m` as a MutDeque.
     ///
-    pub def toMutDeque(r: Region[r], m: Map[k, v]): MutDeque[(k, v), r] \ Write(r) =
-        let d = new MutDeque(r);
+    pub def toMutDeque(reg: Region[r], m: Map[k, v]): MutDeque[(k, v), r] \ Write(r) =
+        let d = new MutDeque(reg);
         Map.foreach((k, v) -> MutDeque.pushBack((k, v), d), m);
         d
 
@@ -948,21 +948,21 @@ namespace Map {
     ///
     /// Returns an iterator over all key-value pairs in `m`.
     ///
-    pub def iterator(r: Region[r], m: Map[k, v]): Iterator[(k, v), r] \ Write(r) =
+    pub def iterator(reg: Region[r], m: Map[k, v]): Iterator[(k, v), r] \ Write(r) =
         let Map(t) = m;
-        RedBlackTree.iterator(r, t)
+        RedBlackTree.iterator(reg, t)
 
     ///
     /// Returns an iterator over keys in `m`.
     ///
-    pub def iteratorKeys(r: Region[r], m: Map[k, v]): Iterator[k, r] \ Write(r) =
-        iterator(r, m) |> Iterator.mapL(match (k, _) -> k)
+    pub def iteratorKeys(reg: Region[r], m: Map[k, v]): Iterator[k, r] \ Write(r) =
+        iterator(reg, m) |> Iterator.mapL(match (k, _) -> k)
 
     ///
     /// Returns an iterator over values in `m`.
     ///
-    pub def iteratorValues(r: Region[r], m: Map[k, v]): Iterator[v, r] \ Write(r) =
-        iterator(r, m) |> Iterator.mapL(match (_, v) -> v)
+    pub def iteratorValues(reg: Region[r], m: Map[k, v]): Iterator[v, r] \ Write(r) =
+        iterator(reg, m) |> Iterator.mapL(match (_, v) -> v)
 
     ///
     /// Returns `m` as a `DelayMap`.

--- a/main/src/library/MultiMap.flix
+++ b/main/src/library/MultiMap.flix
@@ -81,11 +81,11 @@ namespace MultiMap {
     ///
     /// Returns a string representation of `m`.
     ///
-    pub def toString(m: MultiMap[k, v]): String with ToString[k], ToString[v] = region r {
-        let sb = new StringBuilder(r);
+    pub def toString(m: MultiMap[k, v]): String with ToString[k], ToString[v] = region reg {
+        let sb = new StringBuilder(reg);
         let first = ref true;
         StringBuilder.appendString!("MultiMap#{", sb);
-        foreach ((k, v) <- MultiMap.iterator(r, m)) {
+        foreach ((k, v) <- MultiMap.iterator(reg, m)) {
             if (deref first) {
                 first := false;
                 StringBuilder.appendString!("${k} => ${v}", sb)
@@ -550,9 +550,9 @@ namespace MultiMap {
     ///
     /// Returns the MultiMap `m` as a list of singleton key-value pairs in ascending order.
     ///
-    pub def toMutDeque(r: Region[r], m: MultiMap[k, v]): MutDeque[(k, Set[v]), r] \ Write(r) =
+    pub def toMutDeque(reg: Region[r], m: MultiMap[k, v]): MutDeque[(k, Set[v]), r] \ Write(r) =
         let MultiMap(m1) = m;
-        Map.toMutDeque(r, m1)
+        Map.toMutDeque(reg, m1)
 
     // No traversable functions due to Order constraint that's outside the `Traversable` class.
 
@@ -566,8 +566,8 @@ namespace MultiMap {
     ///
     /// Returns an iterator over all key-value pairs in `m` i.e. `k => Set#{v_1, ..., v_n}`.
     ///
-    pub def iterator(r: Region[r], m: MultiMap[k, v]): Iterator[(k, Set[v]), r] \ Write(r) =
+    pub def iterator(reg: Region[r], m: MultiMap[k, v]): Iterator[(k, Set[v]), r] \ Write(r) =
         let MultiMap(m1) = m;
-        Map.iterator(r, m1)
+        Map.iterator(reg, m1)
 
 }

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -32,7 +32,7 @@ pub enum MutDeque[a: Type, r: Region] {
 }
 
 instance Newable[MutDeque[a]] {
-    pub def new(r: Region[r]): MutDeque[a, r] \ Write(r) = MutDeque.new(r)
+    pub def new(reg: Region[r]): MutDeque[a, r] \ Write(r) = MutDeque.new(reg)
 }
 
 instance Scoped[MutDeque[a]] {
@@ -73,8 +73,8 @@ namespace MutDeque {
     ///
     /// Returns an empty MutDeque.
     ///
-    pub def new(r: Region[r]): MutDeque[a, r] \ Write(r) =
-        MutDeque(ref [Reflect.default(); minCapacity()] @ r @ r, ref 0 @ r, ref 0 @ r)
+    pub def new(reg: Region[r]): MutDeque[a, r] \ Write(r) =
+        MutDeque(ref [Reflect.default(); minCapacity()] @ reg @ reg, ref 0 @ reg, ref 0 @ reg)
 
     ///
     /// Returns the number of elements in `d`.
@@ -376,17 +376,17 @@ namespace MutDeque {
     ///
     /// Returns `d` as an array.
     ///
-    pub def toArray(r1: Region[r1], d: MutDeque[a, r2]): Array[a, r1] \ { Read(r2), Write(r1) } =
+    pub def toArray(reg1: Region[r1], d: MutDeque[a, r2]): Array[a, r1] \ { Read(r2), Write(r1) } =
         let MutDeque(a, f, b) = d;
         let len = MutDeque.capacity(d);
         let i = deref f;
         let j = deref b;
         if (i == j)
-            [] @ r1
+            [] @ reg1
         else if (i  < j)
-            Array.copyOfRange(r1, i, j, deref a)
+            Array.copyOfRange(reg1, i, j, deref a)
         else
-            Array.append(Array.copyOfRange(r1, i, len, deref a), Array.copyOfRange(r1, 0, j, deref a))
+            Array.append(Array.copyOfRange(reg1, i, len, deref a), Array.copyOfRange(reg1, 0, j, deref a))
 
     ///
     /// Returns the concatenation of the string representation
@@ -399,10 +399,10 @@ namespace MutDeque {
     /// Returns the concatenation of the string representation
     /// of each element in `d` according to `f` with `sep` inserted between each element.
     ///
-    pub def joinWith(f: a -> String \ ef, sep: String, d: MutDeque[a, r]): String \ { ef, Read(r) } = region r1 {
+    pub def joinWith(f: a -> String \ ef, sep: String, d: MutDeque[a, r]): String \ { ef, Read(r) } = region reg1 {
         use StringBuilder.append!;
         let lastSep = String.length(sep);
-        let sb = new StringBuilder(r1);
+        let sb = new StringBuilder(reg1);
         foreach(x -> { append!(f(x), sb); append!(sep, sb) }, d);
         StringBuilder.toString(sb) |> String.dropRight(lastSep)
     }
@@ -413,9 +413,9 @@ namespace MutDeque {
     /// Modifying `d` while using an iterator has undefined behavior and is dangerous.
     ///
     pub def iterator(d: MutDeque[a, r]): Iterator[a, r] \ Write(r) =
-        let r = Scoped.regionOf(d);
+        let reg = Scoped.regionOf(d);
         let MutDeque(a, f, b) = d;
-        let i = ref (deref f) @ r;
+        let i = ref (deref f) @ reg;
         let done = () -> deref i == deref b;
         let next = () -> {
             let x = (deref a)[deref i];
@@ -447,8 +447,8 @@ namespace MutDeque {
     ///
     /// Shuffles a copy of `d` using the Fisher–Yates shuffle.
     ///
-    pub def shuffle(r1: Region[r1], rnd: Random.Random, d: MutDeque[a, r2]): MutDeque[a, r1] \ { Read(r2), Write(r1), NonDet } = region r3 {
-        toArray(r3, d) !> Array.shuffle(rnd) |> Array.toMutDeque(r1)
+    pub def shuffle(reg1: Region[r1], rnd: Random.Random, d: MutDeque[a, r2]): MutDeque[a, r1] \ { Read(r2), Write(r1), NonDet } = region reg3 {
+        toArray(reg3, d) !> Array.shuffle(rnd) |> Array.toMutDeque(reg1)
     }
 
 }

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -26,7 +26,7 @@ pub enum MutList[a: Type, r: Region] {
 }
 
 instance Newable[MutList[a]] {
-    pub def new(r: Region[r]): MutList[a, r] \ Write(r) = MutList.new(r)
+    pub def new(reg: Region[r]): MutList[a, r] \ Write(r) = MutList.new(reg)
 }
 
 instance Scoped[MutList[a]] {
@@ -48,20 +48,20 @@ namespace MutList {
     ///
     /// Returns a new empty mutable list with a default capacity.
     ///
-    pub def new(r: Region[r]): MutList[a, r] \ Write(r) =
-        MutList(ref ([Reflect.default(); minCapacity()] @ r) @ r, ref 0 @ r)
+    pub def new(reg: Region[r]): MutList[a, r] \ Write(r) =
+        MutList(ref ([Reflect.default(); minCapacity()] @ reg) @ reg, ref 0 @ reg)
 
     ///
     /// Returns a mutable list of all integers between `b` (inclusive) and `e` (exclusive).
     ///
     /// Returns an empty mutable list if `b >= e`.
     ///
-    pub def range(r: Region[r], b: Int32, e: Int32): MutList[Int32, r] \ Write(r) =
+    pub def range(reg: Region[r], b: Int32, e: Int32): MutList[Int32, r] \ Write(r) =
         let minCap = minCapacity();
         let d = e - b;
         let c = Order.max(d, minCap);
         let f = i -> { let x = b + i; if (x < e) x else Reflect.default() };
-        MutList(ref Array.init(r, f, c) @ r, ref d @ r)
+        MutList(ref Array.init(reg, f, c) @ reg, ref d @ reg)
 
     ///
     /// Optionally returns the element at position `i` in the mutable list `v`.
@@ -309,12 +309,12 @@ namespace MutList {
     /// Accumulates the result of applying `f` to `v` going left to right.
     ///
     pub def scanLeft(f: (b, a) -> b \ ef, s: b, v: MutList[a, r]): MutList[b, r] \ { ef, Read(r), Write(r) } =
-        let r = Scoped.regionOf(v);
+        let reg = Scoped.regionOf(v);
         let MutList(ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
         let n = l + 1;
-        let b = [s; n] @ r;
+        let b = [s; n] @ reg;
         def loop(i, acc) = {
             if (i >= n)
                 ()
@@ -325,7 +325,7 @@ namespace MutList {
             }
         };
         loop(1, s);
-        MutList(ref b @ r, ref n @ r)
+        MutList(ref b @ reg, ref n @ reg)
 
     ///
     /// Accumulates the result of applying `f` to `v` going right to left.
@@ -335,8 +335,8 @@ namespace MutList {
         let a = deref ra;
         let l = deref rl;
         let n = l + 1;
-        let r = Scoped.regionOf(v);
-        let b = [s; n] @ r;
+        let reg = Scoped.regionOf(v);
+        let b = [s; n] @ reg;
         def loop(i, acc) = {
             if (i < 0)
                 ()
@@ -347,7 +347,7 @@ namespace MutList {
             }
         };
         loop(l - 1, s);
-        MutList(ref b @ r, ref n @ r)
+        MutList(ref b @ reg, ref n @ reg)
 
     ///
     /// Apply `f` to every element in `v`.
@@ -355,15 +355,15 @@ namespace MutList {
     /// The result is a new mutable list.
     ///
     pub def map(f: a -> b \ ef, v: MutList[a, r]): MutList[b, r] \ { ef, Read(r), Write(r) } =
-        let r = Scoped.regionOf(v);
+        let reg = Scoped.regionOf(v);
         if (isEmpty(v))
-            new MutList(r)
+            new MutList(reg)
         else {
             let MutList(ra, rl) = v;
             let a = deref ra;
             let l = deref rl;
             let x = f(a[0]);
-            let b = [x; Array.length(a)] @ r;
+            let b = [x; Array.length(a)] @ reg;
             def loop(i) = {
                 if (i >= l)
                     ()
@@ -373,22 +373,22 @@ namespace MutList {
                 }
             };
             loop(1);
-            MutList(ref b @ r, ref l @ r)
+            MutList(ref b @ reg, ref l @ reg)
         }
 
     ///
     /// Returns the result of applying `f` to every element in `v` along with that element's index.
     ///
     pub def mapWithIndex(f: (Int32, a) -> b \ ef, v: MutList[a, r]): MutList[b, r] \ { ef, Read(r), Write(r) } =
-        let r = Scoped.regionOf(v);
+        let reg = Scoped.regionOf(v);
         if (isEmpty(v))
-            new MutList(r)
+            new MutList(reg)
         else {
             let MutList(ra, rl) = v;
             let a = deref ra;
             let l = deref rl;
             let x = f(0, a[0]);
-            let b = [x; Array.length(a)] @ r;
+            let b = [x; Array.length(a)] @ reg;
             def loop(i) = {
                 if (i >= l)
                     ()
@@ -398,7 +398,7 @@ namespace MutList {
                 }
             };
             loop(1);
-            MutList(ref b @ r, ref l @ r)
+            MutList(ref b @ reg, ref l @ reg)
         }
 
     ///
@@ -537,11 +537,11 @@ namespace MutList {
     pub def copy(v: MutList[a, r]): MutList[a, r] \ { Read(r), Write(r) } =
         let MutList(a, l) = v;
         let len = deref l;
-        let r = Scoped.regionOf(v);
+        let reg = Scoped.regionOf(v);
         if (len > minCapacity())
-            MutList(ref Array.copyOfRange(r, 0, len, deref a) @ r, ref len @ r)
+            MutList(ref Array.copyOfRange(reg, 0, len, deref a) @ reg, ref len @ reg)
         else
-            MutList(ref Array.copyOfRange(r, 0, capacity(v), deref a) @ r, ref len @ r)
+            MutList(ref Array.copyOfRange(reg, 0, capacity(v), deref a) @ reg, ref len @ reg)
 
     ///
     /// Optionally removes and returns the last element in the given mutable list `v`.
@@ -636,8 +636,8 @@ namespace MutList {
     ///
     pub def retain!(f: a -> Bool, v: MutList[a, r]): Unit \ { Read(r), Write(r) } =
         let MutList(a1, l1) = v;
-        let r = Scoped.regionOf(v);
-        let l = new MutList(r);
+        let reg = Scoped.regionOf(v);
+        let l = new MutList(reg);
         foreach(e -> if (f(e)) push!(e, l) else (), v);
         let MutList(a2, l2) = l;
         a1 := deref a2;
@@ -734,9 +734,9 @@ namespace MutList {
     ///
     /// Returns `v` as an array.
     ///
-    pub def toArray(r1: Region[r1], v: MutList[a, r2]): Array[a, r1] \ { Read(r2), Write(r1) } =
+    pub def toArray(reg1: Region[r1], v: MutList[a, r2]): Array[a, r1] \ { Read(r2), Write(r1) } =
         let MutList(a, l) = v;
-        Array.copyOfRange(r1, 0, deref l, deref a)
+        Array.copyOfRange(reg1, 0, deref l, deref a)
 
     ///
     /// Returns the mutable list `xs` as a chain.
@@ -747,8 +747,8 @@ namespace MutList {
     ///
     /// Returns `v` as a MutDeque.
     ///
-    pub def toMutDeque(r1: Region[r1], v: MutList[a, r2]): MutDeque[a, r1] \ { Read(r2), Write(r1) }  =
-        let d = new MutDeque(r1);
+    pub def toMutDeque(reg1: Region[r1], v: MutList[a, r2]): MutDeque[a, r1] \ { Read(r2), Write(r1) }  =
+        let d = new MutDeque(reg1);
         MutList.foreach(x -> MutDeque.pushBack(x, d), v);
         d
 
@@ -783,8 +783,8 @@ namespace MutList {
     /// Returns the concatenation of the string representation
     /// of each element in `v` according to `f` with `sep` inserted between each element.
     ///
-    pub def joinWith(f: a -> String \ ef, sep: String, v: MutList[a, r]): String \ { ef, Read(r) } = region r1 {
-        let sb = new StringBuilder(r1);
+    pub def joinWith(f: a -> String \ ef, sep: String, v: MutList[a, r]): String \ { ef, Read(r) } = region reg1 {
+        let sb = new StringBuilder(reg1);
         let step = (i, x) ->
             if (i == 0)
                 StringBuilder.appendString!(f(x), sb)
@@ -802,9 +802,9 @@ namespace MutList {
     /// Modifying `l` while using an iterator has undefined behavior and is dangerous.
     ///
     pub def iterator(l: MutList[a, r]): Iterator[a, r] \ Write(r) =
-        let r = Scoped.regionOf(l);
+        let reg = Scoped.regionOf(l);
         let MutList(a, len) = l;
-        let i = ref 0 @ r;
+        let i = ref 0 @ reg;
         let done = () -> deref i == deref len;
         let next = () -> {
             let x = (deref a)[deref i];
@@ -944,8 +944,8 @@ namespace MutList {
     ///
     /// Shuffles `v` using the Fisher–Yates shuffle.
     ///
-    pub def shuffle(r1: Region[r1], rnd: Random.Random, v: MutList[a, r1]): MutList[a, r1] \ { Read(r1), Write(r1), NonDet } = region r2 {
-        toArray(r2, v) !> Array.shuffle(rnd) |> Array.toMutList(r1)
+    pub def shuffle(reg1: Region[r1], rnd: Random.Random, v: MutList[a, r1]): MutList[a, r1] \ { Read(r1), Write(r1), NonDet } = region reg2 {
+        toArray(reg2, v) !> Array.shuffle(rnd) |> Array.toMutList(reg1)
     }
 
 }

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -24,7 +24,7 @@ instance Scoped[MutMap[k, v]] {
 }
 
 instance Newable[MutMap[k, v]] {
-    pub def new(r: Region[r]): MutMap[k, v, r] \ Write(r) = MutMap.new(r)
+    pub def new(reg: Region[r]): MutMap[k, v, r] \ Write(r) = MutMap.new(reg)
 }
 
 namespace MutMap {
@@ -32,14 +32,14 @@ namespace MutMap {
     ///
     /// Returns a fresh empty mutable map.
     ///
-    pub def new(r: Region[r]): MutMap[k, v, r] \ Write(r) =
-        MutMap(ref Map.empty() @ r)
+    pub def new(reg: Region[r]): MutMap[k, v, r] \ Write(r) =
+        MutMap(ref Map.empty() @ reg)
 
     ///
     /// Returns the singleton map where key `k` is mapped to value `v`.
     ///
-    pub def singleton(r: Region[r], k: k, v: v): MutMap[k, v, r] \ Write(r) with Order[k] =
-        MutMap(ref Map.singleton(k, v) @ r)
+    pub def singleton(reg: Region[r], k: k, v: v): MutMap[k, v, r] \ Write(r) with Order[k] =
+        MutMap(ref Map.singleton(k, v) @ reg)
 
     ///
     /// Returns `true` if and only if the mutable map `m` contains the key `k`.
@@ -582,24 +582,24 @@ namespace MutMap {
     ///
     pub def iterator(m: MutMap[k, v, r]): Iterator[(k, v), r] \ Write(r) =
         let MutMap(mm) = m;
-        let r = Scoped.regionOf(m);
-        Map.iterator(r, deref mm)
+        let reg = Scoped.regionOf(m);
+        Map.iterator(reg, deref mm)
 
     ///
     /// Returns an iterator over keys in `m`.
     ///
     pub def iteratorKeys(m: MutMap[k, v, r]): Iterator[k, r] \ Write(r) =
         let MutMap(mm) = m;
-        let r = Scoped.regionOf(m);
-        Map.iteratorKeys(r, deref mm)
+        let reg = Scoped.regionOf(m);
+        Map.iteratorKeys(reg, deref mm)
 
     ///
     /// Returns an iterator over values in `m`.
     ///
     pub def iteratorValues(m: MutMap[k, v, r]): Iterator[v, r] \ Write(r) =
         let MutMap(mm) = m;
-        let r = Scoped.regionOf(m);
-        Map.iteratorValues(r, deref mm)
+        let reg = Scoped.regionOf(m);
+        Map.iteratorValues(reg, deref mm)
 
     ///
     /// Extracts a range of key-value pairs from the mutable map `m`.

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -20,7 +20,7 @@
 enum MutSet[t: Type, r: Region](Ref[Set[t], r])
 
 instance Newable[MutSet[t]] {
-    pub def new(r: Region[r]): MutSet[t, r] \ { Write(r) } = MutSet.new(r)
+    pub def new(reg: Region[r]): MutSet[t, r] \ { Write(r) } = MutSet.new(reg)
 }
 
 instance Scoped[MutSet[t]] {
@@ -36,14 +36,14 @@ namespace MutSet {
     ///
     /// Returns a fresh empty set.
     ///
-    pub def new(r: Region[r]): MutSet[a, r] \ { Write(r) } =
-        MutSet(ref Set.empty() @ r)
+    pub def new(reg: Region[r]): MutSet[a, r] \ { Write(r) } =
+        MutSet(ref Set.empty() @ reg)
 
     ///
     /// Returns the singleton set containing `x`.
     ///
-    pub def singleton(r: Region[r], x: a): MutSet[a, r] \ Write(r) with Order[a] =
-        MutSet(ref Set.singleton(x) @ r)
+    pub def singleton(reg: Region[r], x: a): MutSet[a, r] \ Write(r) with Order[a] =
+        MutSet(ref Set.singleton(x) @ reg)
 
     ///
     /// Adds the element `x` to the mutable set `s`.
@@ -399,8 +399,8 @@ namespace MutSet {
     ///
     pub def iterator(s: MutSet[a, r]): Iterator[a, r] \ Write(r) =
         let MutSet(ms) = s;
-        let r = Scoped.regionOf(s);
-        Set.iterator(r, deref ms)
+        let reg = Scoped.regionOf(s);
+        Set.iterator(reg, deref ms)
 
     ///
     /// Returns an iterator over `s`.

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -86,7 +86,7 @@ instance Foldable[Nec] {
     pub def foldLeft(f: (b, a) -> b \ ef, s: b, c: Nec[a]): b \ ef = Nec.foldLeft(f, s, c)
     pub def foldRight(f: (a, b) -> b \ ef, s: b, c: Nec[a]): b \ ef = Nec.foldRight(f, s, c)
     pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, s: b, c: Nec[a]): b \ ef = Nec.foldRightWithCont(f, s, c)
-    override pub def iterator(r: Region[r], c: Nec[a]): Iterator[a, r] \ Write(r) = Nec.iterator(r, c)
+    override pub def iterator(reg: Region[r], c: Nec[a]): Iterator[a, r] \ Write(r) = Nec.iterator(reg, c)
 }
 
 instance UnorderedFoldable[Nec] {
@@ -117,16 +117,16 @@ instance Reducible[Nec] {
     override pub def memberOf(a: a, l: Nec[a]): Bool with Eq[a] = Nec.memberOf(a, l)
     override pub def dropWhile(f: a -> Bool \ ef, l: Nec[a]): List[a] \ ef = Nec.dropWhileLeft(f, l)
     override pub def takeWhile(f: a -> Bool \ ef, l: Nec[a]): List[a] \ ef = Nec.takeWhileLeft(f, l)
-    override pub def toArray(r: Region[r], l: Nec[a]): Array[a, r] \ Write(r) = Nec.toArray(r, l)
-    override pub def iterator(r: Region[r], l: Nec[a]): Iterator[a, r] \ Write(r) = Nec.iterator(r, l)
+    override pub def toArray(reg: Region[r], l: Nec[a]): Array[a, r] \ Write(r) = Nec.toArray(reg, l)
+    override pub def iterator(reg: Region[r], l: Nec[a]): Iterator[a, r] \ Write(r) = Nec.iterator(reg, l)
     override pub def toList(l: Nec[a]): List[a] = Nec.toList(l)
 }
 
 instance ToString[Nec[a]] with ToString[a] {
-    pub def toString(c: Nec[a]): String = region r {
-        let sb = new StringBuilder(r);
+    pub def toString(c: Nec[a]): String = region reg {
+        let sb = new StringBuilder(reg);
         StringBuilder.appendString!("Nec#{", sb);
-        foreach ((x, i) <- enumerator(r, c)) {
+        foreach ((x, i) <- enumerator(reg, c)) {
             if (i < 1)
                 StringBuilder.appendString!("${x}", sb)
             else
@@ -744,16 +744,16 @@ namespace Nec {
     ///
     /// Returns `c` as a MutDeque.
     ///
-    pub def toMutDeque(r: Region[r], c: Nec[a]): MutDeque[a, r] \ Write(r)  =
-        let d = new MutDeque(r);
+    pub def toMutDeque(reg: Region[r], c: Nec[a]): MutDeque[a, r] \ Write(r)  =
+        let d = new MutDeque(reg);
         foreach(x -> MutDeque.pushBack(x, d), c);
         d
 
     ///
     /// Returns `c` as a mutable list.
     ///
-    pub def toMutList(r: Region[r], c: Nec[a]): MutList[a, r] \ Write(r) = region r2 {
-        Array.toMutList(r, toArray(r2, c)) // `Array.toMutList` respects the invariant of `MutList`
+    pub def toMutList(reg: Region[r], c: Nec[a]): MutList[a, r] \ Write(r) = region reg2 {
+        Array.toMutList(reg, toArray(reg2, c)) // `Array.toMutList` respects the invariant of `MutList`
     }
 
     ///
@@ -781,23 +781,23 @@ namespace Nec {
     ///
     /// Returns the Nec `c` as an array.
     ///
-    pub def toArray(r: Region[r], c: Nec[a]): Array[a, r] \ Write(r) =
+    pub def toArray(reg: Region[r], c: Nec[a]): Array[a, r] \ Write(r) =
         let x = head(c);
-        let arr = [x; length(c)] @ r;
+        let arr = [x; length(c)] @ reg;
         foreach(match (b, i) -> arr[i] = b, zipWithIndex(c));
         arr
 
     ///
     /// Returns an iterator over `c`.
     ///
-    pub def iterator(r: Region[r], c: Nec[a]): Iterator[a, r] \ Write(r) =
-        iteratorHelper(r, Some(viewLeft(c)))
+    pub def iterator(reg: Region[r], c: Nec[a]): Iterator[a, r] \ Write(r) =
+        iteratorHelper(reg, Some(viewLeft(c)))
 
     ///
     /// Returns an iterator over `l`.
     ///
-    def iteratorHelper(r: Region[r], vl: Option[ViewLeft[a]]): Iterator[a, r] \ Write(r) =
-        let cursor = ref vl @ r;
+    def iteratorHelper(reg: Region[r], vl: Option[ViewLeft[a]]): Iterator[a, r] \ Write(r) =
+        let cursor = ref vl @ reg;
         let done = () -> match (deref cursor) {
             case None    => true
             case Some(_) => false
@@ -818,8 +818,8 @@ namespace Nec {
     ///
     /// Returns an iterator over `c` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], c: Nec[a]): Iterator[(a, Int32), r] \ Write(r) =
-        iterator(r, c) |> Iterator.zipWithIndex
+    pub def enumerator(reg: Region[r], c: Nec[a]): Iterator[(a, Int32), r] \ Write(r) =
+        iterator(reg, c) |> Iterator.zipWithIndex
 
     ///
     /// Helper for the `sort` functions.
@@ -842,8 +842,8 @@ namespace Nec {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sort(c: Nec[a]): Nec[a] with Order[a] = region r {
-        let ans = toArray(r, c) !> Array.sort! |> fromArray;
+    pub def sort(c: Nec[a]): Nec[a] with Order[a] = region reg {
+        let ans = toArray(reg, c) !> Array.sort! |> fromArray;
         match ans {
             case Some(n1) => n1
             case None     => unreachable!()
@@ -858,8 +858,8 @@ namespace Nec {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortBy(f: a -> b, c: Nec[a]): Nec[a] with Order[b] = region r {
-        let ans = toArray(r, c) !> Array.sortBy!(f) |> fromArray;
+    pub def sortBy(f: a -> b, c: Nec[a]): Nec[a] with Order[b] = region reg {
+        let ans = toArray(reg, c) !> Array.sortBy!(f) |> fromArray;
         match ans {
             case Some(n1) => n1
             case None     => unreachable!()
@@ -873,8 +873,8 @@ namespace Nec {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortWith(cmp: (a, a) -> Comparison, c: Nec[a]): Nec[a] = region r {
-        let ans = toArray(r, c) !> Array.sortWith!(cmp) |> fromArray;
+    pub def sortWith(cmp: (a, a) -> Comparison, c: Nec[a]): Nec[a] = region reg {
+        let ans = toArray(reg, c) !> Array.sortWith!(cmp) |> fromArray;
         match ans {
             case Some(n1) => n1
             case None     => unreachable!()
@@ -1017,8 +1017,8 @@ namespace Nec {
     ///
     /// Optionally returns the Nec `c` shuffled using the Fisher–Yates shuffle.
     ///
-    pub def shuffle(rnd: Random.Random, c: Nec[a]): Option[Nec[a]] \ NonDet = region r {
-        toArray(r, c) !> Array.shuffle(rnd) |> Array.toNec
+    pub def shuffle(rnd: Random.Random, c: Nec[a]): Option[Nec[a]] \ NonDet = region reg {
+        toArray(reg, c) !> Array.shuffle(rnd) |> Array.toNec
     }
 
 }

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -74,7 +74,7 @@ instance Foldable[Nel] {
     pub def foldLeft(f: (b, a) -> b \ ef, s: b, l: Nel[a]): b \ ef = Nel.foldLeft(f, s, l)
     pub def foldRight(f: (a, b) -> b \ ef, s: b, l: Nel[a]): b \ ef = Nel.foldRight(f, s, l)
     pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, s: b, l: Nel[a]): b \ ef = Nel.foldRightWithCont(f, s, l)
-    override pub def iterator(r: Region[r], l: Nel[a]): Iterator[a, r] \ Write(r) = Nel.iterator(r, l)
+    override pub def iterator(reg: Region[r], l: Nel[a]): Iterator[a, r] \ Write(r) = Nel.iterator(reg, l)
 }
 
 instance UnorderedFoldable[Nel] {
@@ -105,8 +105,8 @@ instance Reducible[Nel] {
     override pub def memberOf(a: a, l: Nel[a]): Bool with Eq[a] = Nel.memberOf(a, l)
     override pub def dropWhile(f: a -> Bool \ ef, l: Nel[a]): List[a] \ ef = Nel.dropWhile(f, l)
     override pub def takeWhile(f: a -> Bool \ ef, l: Nel[a]): List[a] \ ef = Nel.takeWhile(f, l)
-    override pub def toArray(r: Region[r], l: Nel[a]): Array[a, r] \ Write(r) = Nel.toArray(r, l)
-    override pub def iterator(r: Region[r], l: Nel[a]): Iterator[a, r] \ Write(r) = Nel.iterator(r, l)
+    override pub def toArray(reg: Region[r], l: Nel[a]): Array[a, r] \ Write(r) = Nel.toArray(reg, l)
+    override pub def iterator(reg: Region[r], l: Nel[a]): Iterator[a, r] \ Write(r) = Nel.iterator(reg, l)
     override pub def toList(l: Nel[a]): List[a] = Nel.toList(l)
 }
 
@@ -119,9 +119,9 @@ namespace Nel {
     ///
     /// Returns a string representation of the given non-empty list `l`.
     ///
-    pub def toString(l: Nel[a]): String with ToString[a] = region r {
+    pub def toString(l: Nel[a]): String with ToString[a] = region reg {
         let Nel(x, xs) = l;
-        let sb = new StringBuilder(r);
+        let sb = new StringBuilder(reg);
         StringBuilder.appendString!("Nel(${x}, ", sb);
 
         let list = List.toString(xs);
@@ -586,14 +586,14 @@ namespace Nel {
     ///
     /// Returns `l` as an array.
     ///
-    pub def toArray(r: Region[r], l: Nel[a]): Array[a, r] \ Write(r) =
-        l |> toList |> List.toArray(r)
+    pub def toArray(reg: Region[r], l: Nel[a]): Array[a, r] \ Write(r) =
+        l |> toList |> List.toArray(reg)
 
     ///
     /// Returns `l` as a MutDeque.
     ///
-    pub def toMutDeque(r: Region[r], l: Nel[a]): MutDeque[a, r] \ Write(r) =
-        let d = new MutDeque(r);
+    pub def toMutDeque(reg: Region[r], l: Nel[a]): MutDeque[a, r] \ Write(r) =
+        let d = new MutDeque(reg);
         foreach(x -> MutDeque.pushBack(x, d), l);
         d
 
@@ -613,8 +613,8 @@ namespace Nel {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sort(l: Nel[a]): Nel[a] with Order[a] = region r {
-        let list = toArray(r, l) !> Array.sort! |> Array.toList;
+    pub def sort(l: Nel[a]): Nel[a] with Order[a] = region reg {
+        let list = toArray(reg, l) !> Array.sort! |> Array.toList;
         match list {
             case x :: xs => Nel(x, xs)
             case _       => unreachable!()
@@ -629,8 +629,8 @@ namespace Nel {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortBy(f: a -> b, l: Nel[a]): Nel[a] with Order[b] = region r {
-        let list = toArray(r, l) !> Array.sortBy!(f) |> Array.toList;
+    pub def sortBy(f: a -> b, l: Nel[a]): Nel[a] with Order[b] = region reg {
+        let list = toArray(reg, l) !> Array.sortBy!(f) |> Array.toList;
         match list {
             case x :: xs => Nel(x, xs)
             case _       => unreachable!()
@@ -645,8 +645,8 @@ namespace Nel {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortWith(cmp: (a,a) -> Comparison, l: Nel[a]): Nel[a] = region r {
-        let list = toArray(r, l) !> Array.sortWith!(cmp) |> Array.toList;
+    pub def sortWith(cmp: (a,a) -> Comparison, l: Nel[a]): Nel[a] = region reg {
+        let list = toArray(reg, l) !> Array.sortWith!(cmp) |> Array.toList;
         match list {
             case x :: xs => Nel(x, xs)
             case _       => unreachable!()
@@ -656,9 +656,9 @@ namespace Nel {
     ///
     /// Returns an iterator over `l`.
     ///
-    pub def iterator(r: Region[r], l: Nel[a]): Iterator[a, r] \ Write(r) =
+    pub def iterator(reg: Region[r], l: Nel[a]): Iterator[a, r] \ Write(r) =
        let Nel(x, xs) = l;
-       List.iterator(r, x :: xs)
+       List.iterator(reg, x :: xs)
 
     ///
     /// Returns the result of applying the applicative mapping function `f` to all the elements of the
@@ -717,8 +717,8 @@ namespace Nel {
     ///
     /// Optionally returns the Nel `l` shuffled using the Fisher–Yates shuffle.
     ///
-    pub def shuffle(rnd: Random.Random, l: Nel[a]): Option[Nel[a]] \ NonDet = region r {
-        toArray(r, l) !> Array.shuffle(rnd) |> Array.toNel
+    pub def shuffle(rnd: Random.Random, l: Nel[a]): Option[Nel[a]] \ NonDet = region reg {
+        toArray(reg, l) !> Array.shuffle(rnd) |> Array.toNel
     }
 
 }

--- a/main/src/library/Newable.flix
+++ b/main/src/library/Newable.flix
@@ -21,5 +21,5 @@ class Newable[n: Region -> Type] {
     ///
     /// Returns a fresh `n` parameterized by `t` allocated in region `r`.
     ///
-    pub def new[r: Region](r: Region[r]): n[r] \ { Read(r), Write(r) }
+    pub def new[r: Region](reg: Region[r]): n[r] \ { Read(r), Write(r) }
 }

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -101,7 +101,7 @@ instance Foldable[Option] {
     pub def foldLeft(f: (b, a) -> b \ ef, s: b, o: Option[a]): b \ ef = Option.foldLeft(f, s, o)
     pub def foldRight(f: (a, b) -> b \ ef, s: b, o: Option[a]): b \ ef = Option.foldRight(f, o, s)
     pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, s: b, o: Option[a]): b \ ef = Option.foldRightWithCont(f, o, s)
-    override pub def iterator(r: Region[r], o: Option[a]): Iterator[a, r] \ Write(r) = Option.iterator(r, o)
+    override pub def iterator(reg: Region[r], o: Option[a]): Iterator[a, r] \ Write(r) = Option.iterator(reg, o)
 }
 
 instance UnorderedFoldable[Option] {
@@ -600,15 +600,15 @@ namespace Option {
     ///
     /// Returns an iterator over `o` with 1 element or an empty iterator if `o` is `None`.
     ///
-    pub def iterator(r: Region[r], o: Option[a]): Iterator[a, r] \ Write(r) = match o {
-        case None    => new Iterator(r)
-        case Some(x) => Iterator.singleton(r, x)
+    pub def iterator(reg: Region[r], o: Option[a]): Iterator[a, r] \ Write(r) = match o {
+        case None    => new Iterator(reg)
+        case Some(x) => Iterator.singleton(reg, x)
     }
 
     ///
     /// Returns an iterator over `o` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], o: Option[a]): Iterator[(a, Int32), r] \ Write(r) =
-        iterator(r, o) |> Iterator.zipWithIndex
+    pub def enumerator(reg: Region[r], o: Option[a]): Iterator[(a, Int32), r] \ Write(r) =
+        iterator(reg, o) |> Iterator.zipWithIndex
 
 }

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -64,8 +64,8 @@ namespace RedBlackTree {
         pub def foldLeft(f: (b, v) -> b \ ef, s: b, t: RedBlackTree[k, v]): b \ ef = foldLeft((acc, _, v) -> f(acc, v), s, t)
         pub def foldRight(f: (v, b) -> b \ ef, s: b, t: RedBlackTree[k, v]): b \ ef = foldRight((_, v, acc) -> f(v, acc), s, t)
         pub def foldRightWithCont(f: (v, Unit -> b \ ef) -> b \ ef, s: b, t: RedBlackTree[k, v]): b \ ef = foldRightWithCont((_, v, acc) -> f(v, acc), s, t)
-        override pub def iterator(r: Region[r], t: RedBlackTree[k, v]): Iterator[v, r] \ Write(r) =
-            iterator(r, t) |> Iterator.mapL(match (_, v) -> v)
+        override pub def iterator(reg: Region[r], t: RedBlackTree[k, v]): Iterator[v, r] \ Write(r) =
+            iterator(reg, t) |> Iterator.mapL(match (_, v) -> v)
     }
 
     instance UnorderedFoldable[RedBlackTree[k]] {
@@ -583,8 +583,8 @@ namespace RedBlackTree {
     ///
     /// That is, the result is a list of all pairs `f(k, v)` where `p(k)` returns `Equal`.
     ///
-    pub def query(p: k -> Comparison \ ef1, f: (k, v) -> a \ ef2, t: RedBlackTree[k, v]): List[a] \ { ef1, ef2 } = region r {
-        let buffer = new MutList(r);
+    pub def query(p: k -> Comparison \ ef1, f: (k, v) -> a \ ef2, t: RedBlackTree[k, v]): List[a] \ { ef1, ef2 } = region reg {
+        let buffer = new MutList(reg);
         let g = k -> v -> MutList.push!(f(k, v), buffer);
         queryWith(p, g, t);
         MutList.toList(buffer)
@@ -899,8 +899,8 @@ namespace RedBlackTree {
     ///
     /// Returns the tree `t` as a MutDeque. Elements are ordered from smallest (left) to largest (right).
     ///
-    pub def toMutDeque(r: Region[r], t: RedBlackTree[k, v]): MutDeque[(k, v), r] \ Write(r) =
-        let d = new MutDeque(r);
+    pub def toMutDeque(reg: Region[r], t: RedBlackTree[k, v]): MutDeque[(k, v), r] \ Write(r) =
+        let d = new MutDeque(reg);
         RedBlackTree.foreach((k, v) -> let x = (k, v); MutDeque.pushBack(x, d), t);
         d
 
@@ -1023,10 +1023,10 @@ namespace RedBlackTree {
     /// Returns the concatenation of the string representation of each key-value pair
     /// `k => v` in `t` according to `f` with `sep` inserted between each element.
     ///
-    pub def joinWith(f: (k, v) -> String \ ef, sep: String, t: RedBlackTree[k, v]): String \ ef = region r {
+    pub def joinWith(f: (k, v) -> String \ ef, sep: String, t: RedBlackTree[k, v]): String \ ef = region reg {
         use StringBuilder.append!;
         let lastSep = String.length(sep);
-        let sb = new StringBuilder(r);
+        let sb = new StringBuilder(reg);
         foreach((k, v) -> { append!(f(k, v), sb); append!(sep, sb) }, t);
         StringBuilder.toString(sb) |> String.dropRight(lastSep)
     }
@@ -1068,9 +1068,9 @@ namespace RedBlackTree {
     ///
     /// Returns an iterator over `t`.
     ///
-    pub def iterator(r: Region[r], t: RedBlackTree[k, v]): Iterator[(k, v), r] \ Write(r) =
+    pub def iterator(reg: Region[r], t: RedBlackTree[k, v]): Iterator[(k, v), r] \ Write(r) =
         let stack1 = leftmost(t, Nil);
-        let state = ref stack1 @ r;
+        let state = ref stack1 @ reg;
         let done = () -> match (deref state) {
             case Nil => true
             case _   => false

--- a/main/src/library/Reducible.flix
+++ b/main/src/library/Reducible.flix
@@ -258,16 +258,16 @@ pub class Reducible[t: Type -> Type] {
     ///
     /// Returns `t` as an array.
     ///
-    pub def toArray(r: Region[r], t: t[a]): Array[a, r] \ Write(r) =
-        let v = new MutList(r);
+    pub def toArray(reg: Region[r], t: t[a]): Array[a, r] \ Write(r) =
+        let v = new MutList(reg);
         Reducible.foldLeft((_, a) -> MutList.push!(a, v), (), t);
-        MutList.toArray(r, v)
+        MutList.toArray(reg, v)
 
     ///
     /// Returns an iterator over `t`.
     ///
-    pub def iterator(r: Region[r], t: t[a]): Iterator[a, r] \ Write(r) =
-        Reducible.toArray(r, t) |> Array.iterator
+    pub def iterator(reg: Region[r], t: t[a]): Iterator[a, r] \ Write(r) =
+        Reducible.toArray(reg, t) |> Array.iterator
 
     ///
     /// Returns `t` as a list.

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -431,7 +431,7 @@ namespace Result {
     ///
     /// Returns an iterator over `r` with 1 element or an empty iterator if `r` is `Err`.
     ///
-    pub def iterator(reg: Region[reg], r: Result[t, e]): Iterator[t, reg] \ Write(reg) = match r {
+    pub def iterator(reg: Region[r], r: Result[t, e]): Iterator[t, r] \ Write(r) = match r {
         case Err(_) => new Iterator(reg)
         case Ok(x)  => Iterator.singleton(reg, x)
     }
@@ -439,7 +439,7 @@ namespace Result {
     ///
     /// Returns an iterator over `r` zipped with the indices of the elements.
     ///
-    pub def enumerator(reg: Region[reg], r: Result[t, e]): Iterator[(t, Int32), reg] \ Write(reg) =
+    pub def enumerator(reg: Region[r], r: Result[t, e]): Iterator[(t, Int32), r] \ Write(r) =
         iterator(reg, r) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -67,7 +67,7 @@ instance Foldable[Set] {
     pub def foldLeft(f: (b, a) -> b \ ef, s: b, s1: Set[a]): b \ ef = Set.foldLeft(f, s, s1)
     pub def foldRight(f: (a, b) -> b \ ef, s: b, s1: Set[a]): b \ ef = Set.foldRight(f, s, s1)
     pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, s: b, s1: Set[a]): b \ ef = Set.foldRightWithCont(f, s, s1)
-    override pub def iterator(r: Region[r], s: Set[a]): Iterator[a, r] \ Write(r) = Set.iterator(r, s)
+    override pub def iterator(reg: Region[r], s: Set[a]): Iterator[a, r] \ Write(r) = Set.iterator(reg, s)
 }
 
 instance UnorderedFoldable[Set] {
@@ -97,10 +97,10 @@ namespace Set {
     ///
     /// Returns a string representation of the given set `s`.
     ///
-    pub def toString(s: Set[a]): String with ToString[a] = region r {
-        let sb = new StringBuilder(r);
+    pub def toString(s: Set[a]): String with ToString[a] = region reg {
+        let sb = new StringBuilder(reg);
         StringBuilder.appendString!("Set#{", sb);
-        foreach ((x, i) <- enumerator(r, s)) {
+        foreach ((x, i) <- enumerator(reg, s)) {
             if (i == 0)
                 StringBuilder.appendString!("${x}", sb)
             else
@@ -571,16 +571,16 @@ namespace Set {
     ///
     /// Returns `s` as a MutDeque.
     ///
-    pub def toMutDeque(r: Region[r], s: Set[a]): MutDeque[a, r] \ Write(r) =
-        let d = new MutDeque(r);
+    pub def toMutDeque(reg: Region[r], s: Set[a]): MutDeque[a, r] \ Write(r) =
+        let d = new MutDeque(reg);
         Set.foreach(x -> MutDeque.pushBack(x, d), s);
         d
 
     ///
     /// Returns the set `s` as a `MutSet`.
     ///
-    pub def toMutSet(r: Region[r], s: Set[a]): MutSet[a, r] \ Write(r) =
-        MutSet(ref s @ r)
+    pub def toMutSet(reg: Region[r], s: Set[a]): MutSet[a, r] \ Write(r) =
+        MutSet(ref s @ reg)
 
     ///
     /// Applies `f` to every element of `s`.
@@ -628,15 +628,15 @@ namespace Set {
     ///
     /// Returns an iterator over `s`.
     ///
-    pub def iterator(r: Region[r], s: Set[a]): Iterator[a, r] \ Write(r) =
+    pub def iterator(reg: Region[r], s: Set[a]): Iterator[a, r] \ Write(r) =
         let Set(t) = s;
-        RedBlackTree.iterator(r, t) |> Iterator.mapL(fst)
+        RedBlackTree.iterator(reg, t) |> Iterator.mapL(fst)
 
     ///
     /// Returns an iterator over `s` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], s: Set[a]): Iterator[(a, Int32), r] \ Write(r) =
-        iterator(r, s) |> Iterator.zipWithIndex
+    pub def enumerator(reg: Region[r], s: Set[a]): Iterator[(a, Int32), r] \ Write(r) =
+        iterator(reg, s) |> Iterator.zipWithIndex
 
     ///
     /// Returns the concatenation of the string representation

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -65,9 +65,9 @@ namespace String {
     ///
     /// Splits the string `s` around matches of the regular expression `regex`.
     ///
-    pub def split(regex: {regex = String}, s: String): List[String] = region r {
-        import java.lang.String.split(String): Array[String, r] \ Write(r);
-        let _ = r; // This avoids a redundancy error.
+    pub def split(regex: {regex = String}, s: String): List[String] = region reg {
+        import java.lang.String.split(String): Array[String, reg] \ Write(reg);
+        let _ = reg; // This avoids a redundancy error.
         Array.toList(split(s, regex.regex))
     }
 
@@ -115,8 +115,8 @@ namespace String {
     /// Returns the given string `s` as an array of characters.
     ///
     @Time(length(s)) @Space(length(s))
-    pub def toArray(r: Region[r], s: String): Array[Char, r] \ Write(r) =
-        Array.init(r, i -> charAt(i, s), length(s))
+    pub def toArray(reg: Region[r], s: String): Array[Char, r] \ Write(r) =
+        Array.init(reg, i -> charAt(i, s), length(s))
 
     ///
     /// Build a string of length `len` by applying `f` to the successive indices.
@@ -130,8 +130,8 @@ namespace String {
     ///
     /// Assumes that `len > 0`.
     ///
-    def initHelper(f: Int32 -> Char \ ef, len: Int32): String \ ef = region r {
-        let sb = new StringBuilder(r);
+    def initHelper(f: Int32 -> Char \ ef, len: Int32): String \ ef = region reg {
+        let sb = new StringBuilder(reg);
         def loop(i) = {
             if (i >= len)
                 StringBuilder.toString(sb)
@@ -148,8 +148,8 @@ namespace String {
     /// Concatenate a list of strings into a single string.
     ///
     @Time(List.length(xs)) @Space(List.length(xs))
-    pub def flatten(xs: List[String]): String = region r {
-        let sb = new StringBuilder(r);
+    pub def flatten(xs: List[String]): String = region reg {
+        let sb = new StringBuilder(reg);
         List.foreach(x -> StringBuilder.appendString!(x, sb), xs);
         StringBuilder.toString(sb)
     }
@@ -159,9 +159,9 @@ namespace String {
     /// each pair of strings.
     ///
     @Time(length(sep) * List.length(xs)) @Space(length(sep) * List.length(xs))
-    pub def intercalate(sep: String, xs: List[String]): String = region r {
-        let sb = new StringBuilder(r);
-        let arr = List.toArray(r, xs);
+    pub def intercalate(sep: String, xs: List[String]): String = region reg {
+        let sb = new StringBuilder(reg);
+        let arr = List.toArray(reg, xs);
         StringBuilder.intercalate!(sep, arr, sb);
         StringBuilder.toString(sb)
     }
@@ -173,8 +173,8 @@ namespace String {
     @Time(List.length(xs)) @Space(List.length(xs))
     pub def intercalateChar(sep: Char, xs: List[String]): String = match xs {
         case Nil     => ""
-        case x :: rs => region r {
-            let sb = new StringBuilder(r);
+        case x :: rs => region reg {
+            let sb = new StringBuilder(reg);
             StringBuilder.appendString!(x, sb);
             let appendStep = s -> { StringBuilder.append!(sep, sb); StringBuilder.appendString!(s, sb) };
             List.foreach(appendStep, rs);
@@ -270,11 +270,11 @@ namespace String {
     ///
     /// Helper function for `isSubmatch`.
     ///
-    def isSubmatchHelper(pattern: String, s: String): Bool = region r {
-        import static java.util.regex.Pattern.compile(String): ##java.util.regex.Pattern \ Write(r);
-        import java.util.regex.Pattern.matcher(##java.lang.CharSequence): ##java.util.regex.Matcher \ Read(r);
-        import java.util.regex.Matcher.find(Int32): Bool \ Write(r);
-        let _ = r; // This avoids a redundancy error.
+    def isSubmatchHelper(pattern: String, s: String): Bool = region reg {
+        import static java.util.regex.Pattern.compile(String): ##java.util.regex.Pattern \ Write(reg);
+        import java.util.regex.Pattern.matcher(##java.lang.CharSequence): ##java.util.regex.Matcher \ Read(reg);
+        import java.util.regex.Matcher.find(Int32): Bool \ Write(reg);
+        let _ = reg; // This avoids a redundancy error.
         try {
             let p1 = compile(pattern);
             let m1 = matcher(p1, upcast s);
@@ -603,8 +603,8 @@ namespace String {
     ///
     /// Build a string from the seed value `x` applying the function `f` until `f` returns `None`.
     ///
-    pub def unfold(f: b -> Option[(Char, b)] \ ef, x: b): String \ ef = region r {
-        let sb = new StringBuilder(r);
+    pub def unfold(f: b -> Option[(Char, b)] \ ef, x: b): String \ ef = region reg {
+        let sb = new StringBuilder(reg);
         def loop(a) = {
             let a1 = f(a);
             match a1 {
@@ -626,8 +626,8 @@ namespace String {
     ///
     /// `next` should return `None` to signal the end of building the string.
     ///
-    pub def unfoldWithIter(f: Unit -> Option[Char] \ ef): String \ ef = region r {
-        let sb = new StringBuilder(r);
+    pub def unfoldWithIter(f: Unit -> Option[Char] \ ef): String \ ef = region reg {
+        let sb = new StringBuilder(reg);
         def loop() = {
             match f() {
                 case None    => StringBuilder.toString(sb)
@@ -645,8 +645,8 @@ namespace String {
     ///
     /// This is a version of `unfold` where `f` generates substrings rather than chars.
     ///
-    pub def unfoldString(f: b -> Option[(String, b)] \ ef, x: b) : String \ ef = region r {
-        let sb = new StringBuilder(r);
+    pub def unfoldString(f: b -> Option[(String, b)] \ ef, x: b) : String \ ef = region reg {
+        let sb = new StringBuilder(reg);
         def loop(a) = {
             let a1 = f(a);
             match a1 {
@@ -668,8 +668,8 @@ namespace String {
     ///
     /// `next` should return `None` to signal the end of building the string.
     ///
-    pub def unfoldStringWithIter(f: Unit -> Option[String] \ ef): String \ ef = region r {
-        let sb = new StringBuilder(r);
+    pub def unfoldStringWithIter(f: Unit -> Option[String] \ ef): String \ ef = region reg {
+        let sb = new StringBuilder(reg);
         def loop() = {
             match f() {
                 case None    => StringBuilder.toString(sb)
@@ -844,8 +844,8 @@ namespace String {
     ///
     /// Helper function for `indent`.
     ///
-    def indentHelper(n: Int32, s: String): String = region r {
-        let sb = new StringBuilder(r);
+    def indentHelper(n: Int32, s: String): String = region reg {
+        let sb = new StringBuilder(reg);
         let prefix = repeat(n, " ");
         let step = x -> {
             StringBuilder.appendString!(prefix, sb);
@@ -875,8 +875,8 @@ namespace String {
     ///
     /// Helper function for `stripIndent`.
     ///
-    def stripIndentHelper(n: Int32, s: String): String = region r {
-        let sb = new StringBuilder(r);
+    def stripIndentHelper(n: Int32, s: String): String = region reg {
+        let sb = new StringBuilder(reg);
         let limit = Int32.min(n, length(s));
         def loop(s1, ix) = {
             if (ix >= limit)
@@ -912,8 +912,8 @@ namespace String {
     /// ending the result string with the system dependent line separator.
     ///
     @Time(List.length(a)) @Space(List.length(a))
-    pub def unlines(a: List[String]): String = region r {
-        let sb = new StringBuilder(r);
+    pub def unlines(a: List[String]): String = region reg {
+        let sb = new StringBuilder(reg);
         List.foreach(x -> StringBuilder.appendLine!(x, sb), a);
         StringBuilder.toString(sb)
     }
@@ -935,8 +935,8 @@ namespace String {
     @Time(List.length(l)) @Space(List.length(l))
     pub def unwords(l: List[String]): String = match l {
         case Nil     => ""
-        case x :: xs => region r {
-            let sb = new StringBuilder(r);
+        case x :: xs => region reg {
+            let sb = new StringBuilder(reg);
             StringBuilder.appendString!(x, sb);
             let f = s -> { StringBuilder.append!(' ', sb); StringBuilder.appendString!(s, sb) };
             List.foreach(f, xs);
@@ -1082,11 +1082,11 @@ namespace String {
     /// string `s` into string `t`.
     ///
     @Time(length(s) * length(t)) @Space(length(s) * length(t))
-    pub def levenshteinDistance(s: String, t: String): Int32 = region r {
+    pub def levenshteinDistance(s: String, t: String): Int32 = region reg {
         let m = length(s);
         let n = length(t);
-        let v0 = Array.new(r, 0, n + 1);
-        let v1 = Array.new(r, 0, n + 1);
+        let v0 = Array.new(reg, 0, n + 1);
+        let v1 = Array.new(reg, 0, n + 1);
         forIndex(0, n, i -> v0[i] = i);
         forIndex(0, m - 1, i -> {
             v1[0] = i + 1;
@@ -1273,9 +1273,9 @@ namespace String {
     ///
     /// Returns an iterator over `s`.
     ///
-    pub def iterator(r: Region[r], s: String): Iterator[Char, r] \ Write(r) =
+    pub def iterator(reg: Region[r], s: String): Iterator[Char, r] \ Write(r) =
         let len = length(s);
-        let i = ref 0 @ r;
+        let i = ref 0 @ reg;
         let done = () -> deref i >= len;
         let next = () -> {
             let x = charAt(deref i, s);
@@ -1287,7 +1287,7 @@ namespace String {
     ///
     /// Returns an iterator over `l` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], s: String): Iterator[(Char, Int32), r] \ Write(r) =
-        iterator(r, s) |> Iterator.zipWithIndex
+    pub def enumerator(reg: Region[r], s: String): Iterator[(Char, Int32), r] \ Write(r) =
+        iterator(reg, s) |> Iterator.zipWithIndex
 
 }

--- a/main/src/library/StringBuilder.flix
+++ b/main/src/library/StringBuilder.flix
@@ -20,7 +20,7 @@
 enum StringBuilder[_: Region](##java.lang.StringBuilder)
 
 instance Newable[StringBuilder] {
-    pub def new(r: Region[r]): StringBuilder[r] \ Write(r) = StringBuilder.new(r)
+    pub def new(reg: Region[r]): StringBuilder[r] \ Write(r) = StringBuilder.new(reg)
 }
 
 instance Scoped[StringBuilder] {
@@ -107,11 +107,11 @@ namespace StringBuilder {
     ///
     /// Returns an iterator over `sb`.
     ///
-    pub def iterator(r1: Region[r1], sb: StringBuilder[r2]): Iterator[Char, r1 and r2] \ { Read(r2), Write(r1) } =
+    pub def iterator(reg1: Region[r1], sb: StringBuilder[r2]): Iterator[Char, r1 and r2] \ { Read(r2), Write(r1) } =
         import java.lang.StringBuilder.charAt(Int32): Char \ Read(r2);
         let StringBuilder(msb) = sb;
         let len = length(sb);
-        let i = ref 0 @ r1;
+        let i = ref 0 @ reg1;
         let done = () -> { deref i >= len } as \ {r1, r2};
         let next = () -> {
             let x = charAt(msb, deref i);


### PR DESCRIPTION
As per discussion on Gitter, this PR changes term level region variables to `reg` (or `reg1`, ...) instead of `r` to make them distinct from type level region variables.