### PR TITLE
ci: remove mlutze/fcwg from community build

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -38,7 +38,6 @@ jobs:
       matrix:
         repo:
           - "magnus-madsen/helloworld"
-          - "mlutze/fcwg"
           - "JonathanStarup/Flix-ANSI-Terminal"
           - "mlutze/flix-json"
     runs-on: ubuntu-latest


### PR DESCRIPTION
This project is no longer maintained.