### PR TITLE
fix: Use platform class loader, not bootstrap class loader

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/FlixClassLoader.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/FlixClassLoader.scala
@@ -26,10 +26,10 @@ import scala.collection.mutable
   *
   * @param classes A map from internal names (strings) to JvmClasses.
   * 
-  * We pass null as the `ClassLoader` parent to avoid it delegating to the system classloader
+  * We pass the platform class loader as the parent to avoid it delegating to the system classloader
   * (otherwise compiled Flix code has access to all classes within the compiler)
   */
-class FlixClassLoader(classes: Map[String, JvmClass])(implicit flix: Flix) extends ClassLoader(null) {
+class FlixClassLoader(classes: Map[String, JvmClass])(implicit flix: Flix) extends ClassLoader(ClassLoader.getPlatformClassLoader()) {
 
   /**
     * An internal cache of already loaded classes.

--- a/main/src/ca/uwaterloo/flix/util/ExternalJarLoader.scala
+++ b/main/src/ca/uwaterloo/flix/util/ExternalJarLoader.scala
@@ -20,10 +20,10 @@ import java.net.{URL, URLClassLoader}
 /**
   * A class loader to which JARs can be added dynamically.
   * 
-  * We pass null as the `ClassLoader` parent to avoid it delegating to the system classloader
+  * We pass the platform class loader as the parent to avoid it delegating to the system classloader
   * (otherwise compiled Flix code has access to all classes within the compiler)
   */
-class ExternalJarLoader extends URLClassLoader(Array.empty, null) {
+class ExternalJarLoader extends URLClassLoader(Array.empty, ClassLoader.getPlatformClassLoader()) {
 
   Thread.currentThread().setContextClassLoader(this)
 

--- a/main/test/flix/Test.Import.flix
+++ b/main/test/flix/Test.Import.flix
@@ -35,7 +35,12 @@ namespace Test/Import {
     let sb = newStringBuffer("Hello world");
     let subStr = subSequence(sb, 6, 11) as String;
     Assert.eq(subStr, "world")
-}
+
+  @test
+  def testImport04(): ##java.sql.Time \ IO =
+    import new java.sql.Time(Int64): ##java.sql.Time \ IO as newTime;
+    newTime(1000i64)
+  }
 
 namespace Test/Import {
   // Doesn't cause an error because different scope from above


### PR DESCRIPTION
Fixes #4898

Apologies: this was me being dense.

The original code passed `null` as the parent classloader, which means the bootstrap classloader. This knows how to load built-in packages like `java.lang` and `java.util`, but not `java.sql`.

This change switches to the platform class loader which does know how to load those classes (but still isn't the full system class loader, so still doesn't give compiled code access to compiler internals).