### PR TITLE
fix: Revert "chore: update Scala 2 version"

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -51,4 +51,3 @@ By adding your name to this document, you agree to release all your contribution
 - [Darius Tan](https://github.com/thinking-tower)
 - [Paul Butcher](https://github.com/paulbutcher)
 - [Daniel Anker Hermansen](https://github.com/Daniel-Anker-Hermansen)
-- [Stéphane Micheloud](https://github.com/michelou)

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.scala-lang:scala-library:2.13.10'
-    implementation 'org.scala-lang:scala-reflect:2.13.10'
+    implementation 'org.scala-lang:scala-library:2.13.5'
+    implementation 'org.scala-lang:scala-reflect:2.13.5'
 
     implementation files('lib/org.java_websocket-1.3.9.jar')
     implementation files('lib/org.jline-3.5.1.jar')

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1326,10 +1326,10 @@ object Weeder {
       mapN(visitExp(exp1, senv), visitExp(exp2, senv)) {
         case (e1, e2) =>
           val loc = mkSL(sp1, sp2)
-          val enum0 = Name.mkQName("List", sp1, sp2)
+          val enum = Name.mkQName("List", sp1, sp2)
           val tag = Name.Ident(sp1, "Cons", sp2)
           val exp = WeededAst.Expression.Tuple(List(e1, e2), loc)
-          WeededAst.Expression.Tag(Some(enum0), tag, Some(exp), loc)
+          WeededAst.Expression.Tag(Some(enum), tag, Some(exp), loc)
       }
 
     case ParsedAst.Expression.FAppend(exp1, sp1, sp2, exp2) =>
@@ -2143,10 +2143,10 @@ object Weeder {
         mapN(visitPattern(pat1), visitPattern(pat2)) {
           case (hd, tl) =>
             val loc = mkSL(sp1, sp2)
-            val enum0 = Name.mkQName("List", sp1, sp2)
+            val enum = Name.mkQName("List", sp1, sp2)
             val tag = Name.Ident(sp1, "Cons", sp2)
             val pat = WeededAst.Pattern.Tuple(List(hd, tl), loc)
-            WeededAst.Pattern.Tag(Some(enum0), tag, pat, loc)
+            WeededAst.Pattern.Tag(Some(enum), tag, pat, loc)
         }
 
     }


### PR DESCRIPTION
Unfortunately there is a severe performance regression in the newer Scala compiler.

See e.g.:

![image](https://user-images.githubusercontent.com/2287953/201693176-95737f66-022e-4a76-bff9-a3ae19ae9cbf.png)

I can confirm this locally too. 