### PR TITLE
refactor: remove time and space annotations

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -206,15 +206,6 @@ object Ast {
     }
 
     /**
-      * An annotation that indicates the space complexity of a function definition.
-      *
-      * @param loc the source location of the annotation.
-      */
-    case class Space(loc: SourceLocation) extends Annotation {
-      override def toString: String = "@Space"
-    }
-
-    /**
       * An AST node that represents a `@Test` annotation.
       *
       * A function marked with `test` is evaluated as part of the test framework.
@@ -223,15 +214,6 @@ object Ast {
       */
     case class Test(loc: SourceLocation) extends Annotation {
       override def toString: String = "@Test"
-    }
-
-    /**
-      * An annotation that indicates the time complexity of a function definition.
-      *
-      * @param loc the source location of the annotation.
-      */
-    case class Time(loc: SourceLocation) extends Annotation {
-      override def toString: String = "@Time"
     }
 
     /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
@@ -315,19 +315,7 @@ object Documentor {
     * Returns the given annotations `ann` as a JSON value.
     */
   private def visitAnnotations(ann: List[Annotation]): JArray = {
-    def isSpace(a: Ast.Annotation): Boolean = a match {
-      case Ast.Annotation.Space(_) => true
-      case _ => false
-    }
-
-    def isTime(a: Ast.Annotation): Boolean = a match {
-      case Ast.Annotation.Time(_) => true
-      case _ => false
-    }
-
-    val filtered = ann.map(_.name).filter(a => !isSpace(a) && !isTime(a))
-
-    JArray(filtered.map(_.toString))
+    JArray(ann.map(_.name).map(_.toString))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -2272,8 +2272,6 @@ object Weeder {
     case "Lazy" => Ast.Annotation.Lazy(ident.loc).toSuccess
     case "LazyWhenPure" => Ast.Annotation.LazyWhenPure(ident.loc).toSuccess
     case "Skip" => Ast.Annotation.Skip(ident.loc).toSuccess
-    case "Space" => Ast.Annotation.Space(ident.loc).toSuccess
-    case "Time" => Ast.Annotation.Time(ident.loc).toSuccess
     case "Unsafe" => Ast.Annotation.Unsafe(ident.loc).toSuccess
     case name => WeederError.UndefinedAnnotation(name, ident.loc).toFailure
   }

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -70,7 +70,6 @@ namespace Array {
     ///
     /// Equivalent to the expression `[x; l]`.
     ///
-    @Time(l) @Space(l)
     pub def new(r: Region[r], x: a, l: Int32): Array[a, r] \ Write(r) =
         [x; l] @ r
 
@@ -88,20 +87,17 @@ namespace Array {
     ///
     /// Equivalent to the expression `a[i] = x`.
     ///
-    @Time(1) @Space(1)
     pub def put(x: a, i: Int32, a: Array[a, r]): Unit \ Write(r) =
         a[i] = x
 
     ///
     /// Returns `true` if the given array `a` is empty.
     ///
-    @Time(1) @Space(1)
     pub def isEmpty(a: Array[a, r]): Bool = a.length == 0
 
     ///
     /// Returns the length of the array `a`.
     ///
-    @Time(1) @Space(1)
     pub def length(a: Array[a, r]): Int32 = a.length
 
     ///
@@ -109,13 +105,11 @@ namespace Array {
     ///
     /// Equivalent to the expression `a[b..e]`.
     ///
-    @Time(e - b) @Space(e - b)
     pub def slice(b: Int32, e: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } = a[b..e]
 
     ///
     /// Returns the array `a` as a list.
     ///
-    @Time(length(a)) @Space(length(a))
     pub def toList(a: Array[a, r]): List[a] \ Read(r) =
         def loop(i, acc) = {
             if (i == 0) {
@@ -208,7 +202,6 @@ namespace Array {
     ///
     /// Returns `None` if `a` is empty.
     ///
-    @Time(1) @Space(1)
     pub def head(a: Array[a, r]): Option[a] \ Read(r) =
         if (length(a) > 0) Some(a[0]) else None
 
@@ -217,7 +210,6 @@ namespace Array {
     ///
     /// Returns `None` if `a` is empty.
     ///
-    @Time(1) @Space(1)
     pub def last(a: Array[a, r]): Option[a] \ Read(r) =
         let len = length(a);
         if (len > 0) Some(a[len-1]) else None
@@ -225,7 +217,6 @@ namespace Array {
     ///
     /// Return a new array, appending the elements `b` to elements of `a`.
     ///
-    @Time(length(a) + length(b)) @Space(length(a) + length(b))
     pub def append(a: Array[a, r1], b: Array[a, r2]): Array[a, r1] \ { Read(r2), Write(r1) } =
         let r1 = Scoped.regionOf(a);
         let len1 = length(a);
@@ -241,7 +232,6 @@ namespace Array {
     ///
     /// Returns `true` if and only if `a` contains the element `x`.
     ///
-    @Time(length(a)) @Space(1)
     pub def memberOf(x: a, a: Array[a, r]): Bool \ Read(r) with Eq[a] =
         exists(y -> y == x, a)
 
@@ -280,7 +270,6 @@ namespace Array {
     ///
     /// Alias for `IndexOfLeft`
     ///
-    @Time(length(a)) @Space(1)
     pub def indexOf(x: a, a: Array[a, r]): Option[Int32] \ Read(r) with Eq[a] =
         indexOfLeft(x,a)
 
@@ -288,7 +277,6 @@ namespace Array {
     /// Optionally returns the position of the first occurrence of `a` in `arr`
     /// searching from left to right.
     ///
-    @Time(length(arr)) @Space(1)
     pub def indexOfLeft(a: a, arr: Array[a, r]): Option[Int32] \ Read(r) with Eq[a] =
         def loop(i) = {
             if (i >= arr.length)
@@ -305,7 +293,6 @@ namespace Array {
     /// Optionally returns the position of the first occurrence of `a` in `arr`
     /// searching from right to left.
     ///
-    @Time(length(arr)) @Space(1)
     pub def indexOfRight(a: a, arr: Array[a, r]): Option[Int32] \ Read(r) with Eq[a] =
         def loop(i) = {
             if (i < 0)
@@ -321,21 +308,18 @@ namespace Array {
     ///
     /// Return the positions of the all the occurrences of `a` in `arr`.
     ///
-    @Time(length(arr)) @Space(length(arr))
     pub def indices(a: a, arr: Array[a, r]): Array[Int32, r] \ { Read(r), Write(r) } with Eq[a] =
         findIndices(b -> a == b, arr)
 
     ///
     /// Alias for `findLeft`.
     ///
-    @Time(time(f) * length(arr)) @Space(space(f))
     pub def find(f: a -> Bool \ ef, arr: Array[a, r]): Option[a] \ { ef, Read(r) } =
         findLeft(f, arr)
 
     ///
     /// Optionally returns the first element of `a` that satisfies the predicate `f` when searching from left to right.
     ///
-    @Time(time(f) * length(arr)) @Space(space(f))
     pub def findLeft(f: a -> Bool \ ef, arr: Array[a, r]): Option[a] \ { ef, Read(r) } =
         match findIndexOfLeft(f, arr) {
             case None    => None
@@ -345,7 +329,6 @@ namespace Array {
     ///
     /// Optionally returns the first element of `xs` that satisfies the predicate `f` when searching from right to left.
     ///
-    @Time(time(f) * length(arr)) @Space(space(f))
     pub def findRight(f: a -> Bool \ ef, arr: Array[a, r]): Option[a] \ { ef, Read(r) } =
         match findIndexOfRight(x -> f(x), arr) {
             case None    => None
@@ -357,7 +340,6 @@ namespace Array {
     ///
     /// Returns `[]` if `b >= e`.
     ///
-    @Time(e - b) @Space(e - b)
     pub def range(r: Region[r], b: Int32, e: Int32): Array[Int32, r] \ Write(r) =
         if (b >= e)
             [] @ r
@@ -371,7 +353,6 @@ namespace Array {
     ///
     /// Returns `[]` if `n <= 0`.
     ///
-    @Time(n) @Space(n)
     pub def repeat(r: Region[r], n: Int32, x: a): Array[a, r] \ Write(r) =
         if (n <= 0)
             [] @ r
@@ -431,7 +412,6 @@ namespace Array {
     ///
     /// The result is a new array.
     ///
-    @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def map(f: a -> b \ ef, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let len = length(a);
         let r = Scoped.regionOf(a);
@@ -440,7 +420,6 @@ namespace Array {
     ///
     /// Apply `f` to every element in array `arr`. Array `arr` is mutated.
     ///
-    @Time(time(f) * length(arr)) @Space(space(f) * length(arr))
     pub def transform!(f: a -> a \ ef, arr: Array[a, r]): Unit \ { ef, Read(r), Write(r) } =
         let len = length(arr);
         def loop(i) = {
@@ -458,7 +437,6 @@ namespace Array {
     ///
     /// That is, the result is of the form: `[ f(a[0], 0), f(a[1], 1), ... ]`.
     ///
-    @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def mapWithIndex(f: (Int32, a) -> b \ ef, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let len = length(a);
         let r = Scoped.regionOf(a);
@@ -467,7 +445,6 @@ namespace Array {
     ///
     /// Apply `f` to every element in array `a` along with that element's index. Array `a` is mutated.
     ///
-    @Time(time(f) * length(arr)) @Space(space(f))
     pub def transformWithIndex!(f: (Int32, a) -> a \ ef, arr: Array[a, r]): Unit \ { ef, Read(r), Write(r) } =
         let len = length(arr);
         def loop(i) = {
@@ -483,7 +460,6 @@ namespace Array {
     ///
     /// Returns the result of applying `f` to every element in `a` and concatenating the results.
     ///
-    @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def flatMap(f: a -> Array[b, r] \ ef, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let len = length(a);
         let r = Scoped.regionOf(a);
@@ -492,7 +468,6 @@ namespace Array {
     ///
     /// Returns the reverse of `a`.
     ///
-    @Time(length(a)) @Space(length(a))
     pub def reverse(a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(a);
         let end = len - 1;
@@ -502,7 +477,6 @@ namespace Array {
     ///
     /// Reverse the array `arr`, mutating it in place.
     ///
-    @Time(length(arr)) @Space(1)
     pub def reverse!(arr: Array[a, r]): Unit \ { Read(r), Write(r) } =
         let len = length(arr);
         let halflen = len / 2;
@@ -522,7 +496,6 @@ namespace Array {
     ///
     /// Rotate the contents of array `arr` by `n` steps to the left.
     ///
-    @Time(n) @Space(length(arr))
     pub def rotateLeft(n: Int32, arr: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(arr);
         if (len < 1)
@@ -549,7 +522,6 @@ namespace Array {
     ///
     /// Rotate the contents of array `arr` by `n` steps to the right.
     ///
-    @Time(n) @Space(length(arr))
     pub def rotateRight(n: Int32, arr: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         if (length(arr) < 1)
             [] @ Scoped.regionOf(arr)
@@ -579,7 +551,6 @@ namespace Array {
     ///
     /// Returns a shallow copy of `a` if `i < 0` or `i > length(xs)-1`.
     ///
-    @Time(length(a)) @Space(length(a))
     pub def update(i: Int32, x: a, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(a);
         let r = Scoped.regionOf(a);
@@ -589,14 +560,12 @@ namespace Array {
     ///
     /// Returns a copy of `a` with every occurrence of `from` replaced by `to`.
     ///
-    @Time(length(a)) @Space(length(a))
     pub def replace(from: {from = a}, to: {to = a}, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } with Eq[a] =
         map(e -> if (e == from.from) to.to else e, a)
 
     ///
     /// Replace every occurrence of `from` by `to` in the array `a`, mutating it in place.
     ///
-    @Time(length(a)) @Space(1)
     pub def replace!(from: {from = a}, to: {to = a}, a: Array[a, r]): Unit \ { Read(r), Write(r) } with Eq[a] =
         transform!(e -> if (e == from.from) to.to else e, a)
 
@@ -607,7 +576,6 @@ namespace Array {
     /// If `a` becomes depleted then no further patching is done.
     /// If patching occurs at index `i+j` in `b`, then the element at index `j` in `a` is used.
     ///
-    @Time(n) @Space(length(b))
     pub def patch(i: Int32, n: Int32, a: Array[a, r1], b: Array[a, r2]): Array[a, r2] \ { Read(r1, r2), Write(r2) } =
         let len1 = length(a);
         let r2 = Scoped.regionOf(b);
@@ -622,7 +590,6 @@ namespace Array {
     /// If `a` becomes depleted then no further patching is done.
     /// If patching occurs at index `i+j` in `b`, then the element at index `j` in `a` is used.
     ///
-    @Time(n) @Space(1)
     pub def patch!(i: Int32, n: Int32, a: Array[a, r1], b: Array[a, r2]): Unit \ { Read(r1), Write(r2) } =
         let len1 = length(a);
         let r2 = Scoped.regionOf(b);
@@ -633,7 +600,6 @@ namespace Array {
     ///
     /// Returns `a` with `x` inserted between every two adjacent elements.
     ///
-    @Time(length(a)) @Space(length(a))
     pub def intersperse(x: a, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) }=
         let len1 = length(a);
         let len2 = len1 + len1 - 1;
@@ -650,7 +616,6 @@ namespace Array {
     ///
     /// Returns the concatenation of the elements in `arrs` with the elements of `sep` inserted between every two adjacent elements.
     ///
-    @Time(length(arrs)) @Space(length(arrs))
     pub def intercalate(sep: Array[a, r], arrs: Array[Array[a, r], r]): Array[a, r] \ { Read(r), Write(r) } =
         let r = Scoped.regionOf(arrs);
         let count = length(arrs);
@@ -717,7 +682,6 @@ namespace Array {
     ///
     /// Returns `a` if the dimensions of the elements of `a` are mismatched.
     ///
-    @Time(length(a) * length(a)) @Space(length(a) * length(a))
     pub def transpose(a: Array[Array[a, r1], r2]): Array[Array[a, r1], r2] \ { Read(r1, r2), Write(r1, r2) } =
         let ilen = length(a);
         let r2 = Scoped.regionOf(a);
@@ -741,7 +705,6 @@ namespace Array {
     ///
     /// Returns `true` if and only if `a1` is a prefix of `a2`.
     ///
-    @Time(length(a1)) @Space(1)
     pub def isPrefixOf(a1: Array[a, r1], a2: Array[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
         let len1 = length(a1);
         if (len1 > length(a2))
@@ -760,7 +723,6 @@ namespace Array {
     ///
     /// Returns `true` if and only if `a1` is a infix of `a2`.
     ///
-    @Time(length(a1)) @Space(1)
     pub def isInfixOf(a1: Array[a, r1], a2: Array[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
         let len1 = length(a1);
         let len2 = length(a2);
@@ -802,7 +764,6 @@ namespace Array {
     ///
     /// Returns `true` if and only if `a1` is a suffix of `a2`.
     ///
-    @Time(length(a1)) @Space(1)
     pub def isSuffixOf(a1: Array[a, r1], a2: Array[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
         let len1 = length(a1);
         let len2 = length(a2);
@@ -913,7 +874,6 @@ namespace Array {
     ///
     /// Returns the number of elements in `a` that satisfy the predicate `f`.
     ///
-    @Time(time(f) * length(a)) @Space(space(f))
     pub def count(f: a -> Bool \ ef, a: Array[a, r]): Int32 \ { ef, Read(r) } =
         foldLeft((b, x) -> if (f(x)) b + 1 else b, 0, a)
 
@@ -950,7 +910,6 @@ namespace Array {
     ///
     /// Returns the concatenation of the arrays of in the array `arrs`.
     ///
-    @Time(length(arrs)) @Space(length(arrs))
     pub def flatten(arrs: Array[Array[a, r], r]) : Array[a, r] \ { Read(r), Write(r) } =
         let len = sumLengths(arrs);
         let r = Scoped.regionOf(arrs);
@@ -968,7 +927,6 @@ namespace Array {
     ///
     /// Returns `false` if `arr` is empty.
     ///
-    @Time(time(f) * length(arr)) @Space(space(f))
     pub def exists(f: a -> Bool \ ef, arr: Array[a, r]): Bool \ { ef, Read(r) } =
         let len = length(arr);
         def loop(i) = {
@@ -986,7 +944,6 @@ namespace Array {
     ///
     /// Returns `true` if `arr` is empty.
     ///
-    @Time(time(f) * length(arr)) @Space(space(f))
     pub def forAll(f: a -> Bool \ ef, arr: Array[a, r]): Bool \ { ef, Read(r) } =
         let len = length(arr);
         def loop(i) = {
@@ -1002,7 +959,6 @@ namespace Array {
     ///
     /// Returns an array of every element in `arr` that satisfies the predicate `f`.
     ///
-    @Time(time(f) * length(arr)) @Space(space(f) * length(arr))
     pub def filter(f: a -> Bool \ ef, arr: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
         let len = length(arr);
         let r = Scoped.regionOf(arr);
@@ -1033,7 +989,6 @@ namespace Array {
     /// `a1` contains all elements of `a` that satisfy the predicate `f`.
     /// `a2` contains all elements of `a` that do not satisfy the predicate `f`.
     ///
-    @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def partition(f: a -> Bool \ ef, a: Array[a, r]): (Array[a, r], Array[a, r]) \ { ef, Read(r), Write(r) } =
         let step = { (x, acc) ->
             let (a1, a2) = acc;
@@ -1049,7 +1004,6 @@ namespace Array {
     /// `a1` is the longest prefix of `a` that satisfies the predicate `f`.
     /// `a2` is the remainder of `a`.
     ///
-    @Time(time(f) * length(a)) @Space()
     pub def span(f: a -> Bool \ ef, a: Array[a, r]): (Array[a, r], Array[a, r]) \ { ef, Read(r), Write(r) }=
         let r = Scoped.regionOf(a);
         match findIndexOfLeft(x -> not (f(x)), a) {
@@ -1060,7 +1014,6 @@ namespace Array {
     ///
     /// Alias for `dropLeft`.
     ///
-    @Time(length(a) - n) @Space(length(a) - n)
     pub def drop(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         dropLeft(n, a)
 
@@ -1069,7 +1022,6 @@ namespace Array {
     ///
     /// Returns `[]` if `n > length(a)`.
     ///
-    @Time(length(a) - n) @Space(length(a) - n)
     pub def dropLeft(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let len = length(a);
         let r = Scoped.regionOf(a);
@@ -1085,7 +1037,6 @@ namespace Array {
     ///
     /// Returns `[]` if `n > length(a)`.
     ///
-    @Time(length(a) - n) @Space(length(a) - n)
     pub def dropRight(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let r = Scoped.regionOf(a);
         let len = length(a);
@@ -1099,14 +1050,12 @@ namespace Array {
     ///
     /// Alias for `dropWhileLeft`.
     ///
-    @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def dropWhile(f: a -> Bool \ ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
         dropWhileLeft(f, a)
 
     ///
     /// Returns copy of array `a` without the longest prefix that satisfies the predicate `f`.
     ///
-    @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def dropWhileLeft(f: a -> Bool \ ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
         let r = Scoped.regionOf(a);
         match findIndexOfLeft(x -> not (f(x)), a) {
@@ -1117,7 +1066,6 @@ namespace Array {
     ///
     /// Returns copy of array `a` without the longest suffix that satisfies the predicate `f`.
     ///
-    @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def dropWhileRight(f: a -> Bool \ ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
         let r = Scoped.regionOf(a);
         match findIndexOfRight(x -> not (f(x)), a) {
@@ -1128,7 +1076,6 @@ namespace Array {
     ///
     /// Alias for `takeLeft`.
     ///
-    @Time(n) @Space(n)
     pub def take(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         takeLeft(n, a)
 
@@ -1137,7 +1084,6 @@ namespace Array {
     ///
     /// Returns `a` if `n > length(xs)`.
     ///
-    @Time(n) @Space(n)
     pub def takeLeft(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let r = Scoped.regionOf(a);
         if (n <= 0)
@@ -1153,7 +1099,6 @@ namespace Array {
     ///
     /// Returns `a` if `n > length(xs)`.
     ///
-    @Time(n) @Space(n)
     pub def takeRight(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
         let r = Scoped.regionOf(a);
         if (n <= 0)
@@ -1169,7 +1114,6 @@ namespace Array {
     ///
     /// The function `f` must be pure.
     ///
-    @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def takeWhile(f: a -> Bool \ ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
         takeWhileLeft(f, a)
 
@@ -1178,7 +1122,6 @@ namespace Array {
     ///
     /// The function `f` must be pure.
     ///
-    @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def takeWhileLeft(f: a -> Bool \ ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
         match findIndexOfLeft(x -> not (f(x)), a) {
             case None    => a
@@ -1190,7 +1133,6 @@ namespace Array {
     ///
     /// The function `f` must be pure.
     ///
-    @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def takeWhileRight(f: a -> Bool \ ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
         let r = Scoped.regionOf(a);
         match findIndexOfRight(x -> not (f(x)), a) {
@@ -1206,7 +1148,6 @@ namespace Array {
     ///
     /// The function `f` must be pure.
     ///
-    @Time(time(f) * length(a) * length(a)) @Space(space(f) * length(a))
     pub def groupBy(r1: Region[r1], f: (a, a) -> Bool, a: Array[a, r2]): Array[Array[a, r1], r2] \ { Read(r2), Write(r2, r1) } =
         let xs = toList(a);
         let r2 = Scoped.regionOf(a);
@@ -1255,7 +1196,6 @@ namespace Array {
     ///
     /// If either `a` or `b` becomes depleted, then no further elements are added to the resulting array.
     ///
-    @Time(Int32.min(length(a), length(b))) @Space(Int32.min(length(a), length(b)))
     pub def zip(a: Array[a, r1], b: Array[b, r2]): Array[(a, b), r2] \ { Read(r1, r2), Write(r2) } =
         let len = Int32.min(length(a), length(b));
         let r2 = Scoped.regionOf(b);
@@ -1267,7 +1207,6 @@ namespace Array {
     ///
     /// If either `a` or `b` becomes depleted, then no further elements are added to the resulting array.
     ///
-    @Time(time(f) * Int32.min(length(a), length(b))) @Space(space(f) * Int32.min(length(a), length(b)))
     pub def zipWith(f: (a, b) -> c \ ef, a: Array[a, r1], b: Array[b, r2]): Array[c, r2] \ { ef, Read(r1, r2), Write(r2) } =
         let len = Int32.min(length(a), length(b));
         let r2 = Scoped.regionOf(b);
@@ -1277,7 +1216,6 @@ namespace Array {
     /// Returns a pair of arrays, the first containing all first components in `a`
     /// and the second containing all second components in `a`.
     ///
-    @Time(length(a)) @Space(length(a))
     pub def unzip(r1: Region[r1], r2: Region[r2], a: Array[(a, b), r3]): (Array[a, r1], Array[b, r2]) \ { Write(r1, r2), Read(r3) } =
         let len = length(a);
         if (len <= 0)
@@ -1302,7 +1240,6 @@ namespace Array {
     ///
     /// Alias for `foldLeft2`.
     ///
-    @Time(time(f) * Int32.min(length(a), length(b))) @Space(space(f))
     pub def fold2(f: (c, a, b) -> c \ ef, c: c, a: Array[a, r1], b: Array[b, r2]): c \ { ef, Read(r1, r2) } =
         foldLeft2(f, c, a, b)
 
@@ -1310,7 +1247,6 @@ namespace Array {
     /// Accumulates the result of applying `f` pairwise to the elements of `a` and `b`
     /// starting with the initial value `c` and going from left to right.
     ///
-    @Time(time(f) * Int32.min(length(a), length(b))) @Space(space(f))
     pub def foldLeft2(f: (c, a, b) ->  c \ ef, c: c, a: Array[a, r1], b: Array[b, r2]): c \ { ef, Read(r1, r2) } =
         let lena = length(a);
         let lenb = length(b);
@@ -1326,7 +1262,6 @@ namespace Array {
     /// Accumulates the result of applying `f` pairwise to the elements of `a` and `b`
     /// starting with the initial value `c` and going from right to left.
     ///
-    @Time(time(f) * Int32.min(length(a), length(b))) @Space(space(f))
     pub def foldRight2(f: (a, b, c) -> c \ ef, c: c, a: Array[a, r1], b: Array[b, r2]): c \ { ef, Read(r1, r2) } =
         def loop(i, j, acc) = {
             if (i < 0 or j < 0)
@@ -1341,7 +1276,6 @@ namespace Array {
     ///
     /// Collects the results of applying the partial function `f` to every element in `a`.
     ///
-    @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def filterMap(f: a -> Option[b] \ ef, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let r = Scoped.regionOf(a);
         foldRight((x, xs) -> match f(x) {
@@ -1353,7 +1287,6 @@ namespace Array {
     ///
     /// Returns `None` if every element of `xs` is `None`.
     ///
-    @Time(time(f) * length(a)) @Space(space(f))
     pub def findMap(f: a -> Option[b] \ ef, a: Array[a, r]): Option[b] \ { ef, Read(r) } =
         let len = length(a);
         def loop(i) = {
@@ -1371,7 +1304,6 @@ namespace Array {
     ///
     /// Returns the array `a` as a set.
     ///
-    @Time(length(a)) @Space(length(a))
     pub def toSet(a: Array[a, r]): Set[a] \ Read(r) with Order[a] =
         foldRight(Set.insert, Set.empty(), a)
 
@@ -1381,7 +1313,6 @@ namespace Array {
     /// If `xs` contains multiple mappings with the same key, `toMap` does not
     /// make any guarantees about which mapping will be in the resulting map.
     ///
-    @Time(length(a)) @Space(length(a))
     pub def toMap(a: Array[(a, b), r]): Map[a, b] \ Read(r) with Order[a] =
         foldRight((x, m) -> Map.insert(fst(x), snd(x), m), Map.empty(), a)
 
@@ -1398,14 +1329,12 @@ namespace Array {
     ///
     /// Alias for `findIndexOfLeft`.
     ///
-    @Time(time(f) * length(a)) @Space(space(f))
     pub def findIndexOf(f: a -> Bool \ ef, a: Array[a, r]): Option[Int32] \ { ef, Read(r) } =
         findIndexOfLeft(f,a)
 
     ///
     /// Optionally returns the position of the first element in `x` satisfying `f`.
     ///
-    @Time(time(f) * length(a)) @Space(space(f))
     pub def findIndexOfLeft(f: a -> Bool \ ef, a: Array[a, r]): Option[Int32] \ { ef, Read(r) } =
         let len = length(a);
         if (len < 1)
@@ -1427,7 +1356,6 @@ namespace Array {
     /// Optionally returns the position of the first element in `a` satisfying `f`
     /// searching from right to left.
     ///
-    @Time(time(f) * length(a)) @Space(space(f))
     pub def findIndexOfRight(f: a -> Bool \ ef, a: Array[a, r]): Option[Int32] \ { ef, Read(r) } =
         let len = length(a);
         def loop(i) = {
@@ -1444,7 +1372,6 @@ namespace Array {
     ///
     /// Returns the positions of the all the elements in `a` satisfying `f`.
     ///
-    @Time(time(f) * length(a)) @Space(space(f) * length(a))
     pub def findIndices(f: a -> Bool \ ef, a: Array[a, r]): Array[Int32, r] \ { ef, Read(r), Write(r) } =
         let len = length(a);
         let r = Scoped.regionOf(a);
@@ -1463,7 +1390,6 @@ namespace Array {
     ///
     /// Build an array of length `len` by applying `f` to the successive indices.
     ///
-    @Time(time(f) * len) @Space(space(f) * len)
     pub def init(r: Region[r], f: Int32 -> a \ ef, len: Int32): Array[a, r] \ { ef, Write(r) } =
         if (len <= 0)
             [] @ r
@@ -1484,7 +1410,6 @@ namespace Array {
     ///
     /// Returns `true` if arrays `a` and `b` have the same elements in the same order, i.e. are structurally equal.
     ///
-    @Time(length(a)) @Space(1)
     pub def sameElements(a: Array[a, r1], b: Array[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
         let alen = length(a);
         let blen = length(b);
@@ -1528,7 +1453,6 @@ namespace Array {
     ///
     /// Apply the effectful function `f` to all the elements in the array `a`.
     ///
-    @Time(time(f) * length(a)) @Space(space(f))
     pub def forEach(f: a -> Unit \ ef, a: Array[a, r]): Unit \ { ef, Read(r) } =
         let len = length(a);
         def loop(i) = {
@@ -1544,7 +1468,6 @@ namespace Array {
     ///
     /// Apply the effectful function `f` to all the elements in the array `a`.
     ///
-    @Time(time(f) * length(a)) @Space(space(f))
     pub def forEachWithIndex(f: (Int32, a) -> Unit \ ef, a: Array[a, r]): Unit \ { ef, Read(r) } =
         let len = length(a);
         def loop(i) = {
@@ -1560,7 +1483,6 @@ namespace Array {
     ///
     /// Returns a copy of `a` with the elements starting at index `i` replaced by `sub`.
     ///
-    @Time(length(a)) @Space(length(a))
     pub def updateSequence(i: Int32, sub: Array[a, r1], a: Array[a, r2]): Array[a, r2] \ { Read(r1, r2), Write(r2) } =
         let end = i + length(sub);
         let f = ix -> if (ix >= i and ix < end) sub[ix - i] else a[ix];
@@ -1571,7 +1493,6 @@ namespace Array {
     ///
     /// Update the mutable array `a` with the elements starting at index `i` replaced by `sub`.
     ///
-    @Time(length(a)) @Space(1)
     pub def updateSequence!(i: Int32, sub: Array[a, r1], a: Array[a, r2]): Unit \ { Read(r1), Write(r2) } =
         let end = i + length(sub);
         let f = { (ix, _) ->

--- a/main/src/library/BigDecimal.flix
+++ b/main/src/library/BigDecimal.flix
@@ -101,7 +101,6 @@ namespace BigDecimal {
     ///
     /// Returns `x` rounded up to a BigDecimal representing the nearest larger integer value.
     ///
-    @Time(1) @Space(1)
     pub def ceil(x: BigDecimal): BigDecimal =
         import java.math.BigDecimal.setScale(Int32, ##java.math.RoundingMode): BigDecimal \ {};
         import static get java.math.RoundingMode.CEILING: ##java.math.RoundingMode \ {} as getCeiling;
@@ -110,7 +109,6 @@ namespace BigDecimal {
     ///
     /// Returns `x` rounded down to a BigDecimal representing the nearest smaller integer value.
     ///
-    @Time(1) @Space(1)
     pub def floor(x: BigDecimal): BigDecimal =
         import java.math.BigDecimal.setScale(Int32, ##java.math.RoundingMode): BigDecimal \ {};
         import static get java.math.RoundingMode.FLOOR: ##java.math.RoundingMode \ {} as getFloor;
@@ -122,7 +120,6 @@ namespace BigDecimal {
     /// The rounding may be upwards or downwards. If the rounding up and rounding down are equally
     /// close, `x` will be rounded to an even value (i.e. `round(0.5ff64) == 0.0ff64`).
     ///
-    @Time(1) @Space(1)
     pub def round(x: BigDecimal): BigDecimal =
         import java.math.BigDecimal.setScale(Int32, ##java.math.RoundingMode): BigDecimal \ {};
         import static get java.math.RoundingMode.HALF_EVEN: ##java.math.RoundingMode \ {} as getHalfEven;
@@ -137,7 +134,6 @@ namespace BigDecimal {
     /// Returns `None` if the numeric value of `x` is outside the range of Int8
     /// (i.e. -128 to 127).
     ///
-    // @Time(1) @Space(1)
     pub def tryToInt8(x: BigDecimal): Option[Int8] =
         tryToInt32(x) |> Option.flatMap(Int32.tryToInt8)
 
@@ -150,7 +146,6 @@ namespace BigDecimal {
     /// Returns `None` if the numeric value of `x` is outside the range of Int16
     /// (i.e. -32768 to 32767).
     ///
-    @Time(1) @Space(1)
     pub def tryToInt16(x: BigDecimal): Option[Int16] =
         tryToInt32(x) |> Option.flatMap(Int32.tryToInt16)
 
@@ -163,7 +158,6 @@ namespace BigDecimal {
     /// Returns `None` if the numeric value of `x` is outside the range of Int32
     /// (i.e. -2147483648 to 2147483647).
     ///
-    @Time(1) @Space(1)
     pub def tryToInt32(x: BigDecimal): Option[Int32] =
         import java.math.BigDecimal.intValue(): Int32 \ {};
         if (x < Int32.toBigDecimal(Int32.minValue()) or x > Int32.toBigDecimal(Int32.maxValue()))
@@ -180,7 +174,6 @@ namespace BigDecimal {
     /// Returns `None` if the numeric value of `x` is outside the range of Int64
     /// (i.e. -9223372036854775808 to 9223372036854775807).
     ///
-    @Time(1) @Space(1)
     pub def tryToInt64(x: BigDecimal): Option[Int64] =
         import java.math.BigDecimal.longValue(): Int64 \ {};
         if (x < Int64.toBigDecimal(Int64.minValue()) or x > Int64.toBigDecimal(Int64.maxValue()))
@@ -191,7 +184,6 @@ namespace BigDecimal {
     ///
     /// Convert `x` to a `BigInt`.
     ///
-    @Time(1) @Space(1)
     pub def toBigInt(x: BigDecimal): BigInt =
         import java.math.BigDecimal.toBigInteger(): BigInt \ {};
         toBigInteger(x)
@@ -205,7 +197,6 @@ namespace BigDecimal {
     /// Returns `None` if the numeric value of `x` is outside the range of Float32
     /// (i.e. 1.4E-45 to 3.4028235E38).
     ///
-    @Time(1) @Space(1)
     pub def tryToFloat32(x: BigDecimal): Option[Float32] =
         import java.math.BigDecimal.floatValue(): Float32 \ {};
         let d = floatValue(x);
@@ -223,7 +214,6 @@ namespace BigDecimal {
     /// Returns `None` if the numeric value of `x` is outside the range of Float64
     /// (i.e 4.9E-324 to 1.7976931348623157E308).
     ///
-    @Time(1) @Space(1)
     pub def tryToFloat64(x: BigDecimal): Option[Float64] =
         import java.math.BigDecimal.doubleValue(): Float64 \ {};
         let d = doubleValue(x);

--- a/main/src/library/Bool.flix
+++ b/main/src/library/Bool.flix
@@ -27,31 +27,26 @@ namespace Bool {
     ///
     /// Alias for logical conjunction.
     ///
-    @Time(1) @Space(1)
     pub def ∧(x: Bool, y: Bool): Bool = x and y
 
     ///
     /// Alias for logical disjunction.
     ///
-    @Time(1) @Space(1)
     pub def ∨(x: Bool, y: Bool): Bool = x or y
 
     ///
     /// Alias for logical implication.
     ///
-    @Time(1) @Space(1)
     pub def →(x: Bool, y: Bool): Bool = not x ∨ y
 
     ///
     /// Alias for logical bi-implication.
     ///
-    @Time(1) @Space(1)
     pub def ↔(x: Bool, y: Bool): Bool = (x → y) ∧ (y → x)
 
     ///
     /// Alias for exclusive or.
     ///
-    @Time(1) @Space(1)
     pub def ⊕(x: Bool, y: Bool): Bool = (x ∨ y) ∧ not (x ∧ y)
 
     ///

--- a/main/src/library/Char.flix
+++ b/main/src/library/Char.flix
@@ -27,7 +27,6 @@ namespace Char {
     ///
     ///  Returns `true` if the given char `c` is an ascii character.
     ///
-    @Time(1) @Space(1)
     pub def isAscii(c: Char): Bool = match toInt32(c) {
         case i if i >= 0x0000 and i <= 0x007F => true        // 'NUL'..'DEL'
         case _ => false
@@ -36,7 +35,6 @@ namespace Char {
     ///
     /// Returns `true` if the given char `c` is a letter character.
     ///
-    @Time(1) @Space(1)
     pub def isLetter(c: Char): Bool =
         import static java.lang.Character.isLetter(Char): Bool \ {};
         isLetter(c)
@@ -45,7 +43,6 @@ namespace Char {
     /// Returns `true` if the given char `c` is a recognized Unicode digit.
     /// This includes the ASCII range 0..9 but also Arabic-Indic digits, Devagari digits and Fullwidth digits.
     ///
-    @Time(1) @Space(1)
     pub def isDigit(c: Char): Bool =
         import static java.lang.Character.isDigit(Char): Bool \ {};
         isDigit(c)
@@ -53,7 +50,6 @@ namespace Char {
     ///
     /// Returns `true` if the given char `c` is strictly in the range of ASCII digits 0...9.
     ///
-    @Time(1) @Space(1)
     pub def isAsciiDigit(c: Char): Bool = match toInt32(c) {
         case i if i >= 0x0030 and i <= 0x0039 => true        // '0'..'9'
         case _ => false
@@ -62,7 +58,6 @@ namespace Char {
     ///
     /// Returns `true` if the given char `c` is in the range 0...7.
     ///
-    @Time(1) @Space(1)
     pub def isOctDigit(c: Char): Bool = match toInt32(c) {
         case i if i >= 0x0030 and i <= 0x0037 => true        // '0'..'7'
         case _ => false
@@ -71,7 +66,6 @@ namespace Char {
     ///
     /// Returns `true` if the given char `c` is in the range 0...F.
     ///
-    @Time(1) @Space(1)
     pub def isHexDigit(c: Char): Bool = match toInt32(c) {
         case i if i >= 0x0030 and i <= 0x0039 => true        // '0'..'9'
         case i if i >= 0x0041 and i <= 0x0046 => true        // 'A'..'F'
@@ -82,7 +76,6 @@ namespace Char {
     ///
     /// Returns `true` if the given char `c` is lowercase.
     ///
-    @Time(1) @Space(1)
     pub def isLowerCase(c: Char): Bool =
         import static java.lang.Character.isLowerCase(Char): Bool \ {};
         isLowerCase(c)
@@ -90,7 +83,6 @@ namespace Char {
     ///
     /// Returns `true` if the given char `c` is uppercase.
     ///
-    @Time(1) @Space(1)
     pub def isUpperCase(c: Char): Bool =
         import static java.lang.Character.isUpperCase(Char): Bool \ {};
         isUpperCase(c)
@@ -98,7 +90,6 @@ namespace Char {
     ///
     /// Returns `true` if the given char `c` is a white space character.
     ///
-    @Time(1) @Space(1)
     pub def isWhiteSpace(c: Char): Bool =
         import static java.lang.Character.isWhitespace(Char): Bool \ {};
         isWhitespace(c)
@@ -108,7 +99,6 @@ namespace Char {
     ///
     /// Returns the original character if it does not have a lowercase version.
     ///
-    @Time(1) @Space(1)
     pub def toLowerCase(c: Char): Char =
         import static java.lang.Character.toLowerCase(Char): Char \ {};
         toLowerCase(c)
@@ -118,7 +108,6 @@ namespace Char {
     ///
     /// Returns the original character if it does not have a uppercase version.
     ///
-    @Time(1) @Space(1)
     pub def toUpperCase(c: Char): Char =
         import static java.lang.Character.toUpperCase(Char): Char \ {};
         toUpperCase(c)
@@ -126,20 +115,17 @@ namespace Char {
     ///
     /// Returns the character `c` as a string.
     ///
-    @Time(1) @Space(1)
     pub def toString(c: Char): String = ToString.toString(c)
 
     ///
     /// Returns the character `c` as an Int32.
     ///
-    @Time(1) @Space(1)
     pub def toInt32(c: Char): Int32 =
         c as Int32
 
     ///
     /// Returns the respective character for the int `i`.
     ///
-    @Time(1) @Space(1)
     pub def fromInt32(i: Int32): Char =
         i as Char
 

--- a/main/src/library/Float32.flix
+++ b/main/src/library/Float32.flix
@@ -27,98 +27,82 @@ namespace Float32 {
     ///
     /// Returns the number of bits used to represent a `Float32`.
     ///
-    @Time(1) @Space(1)
     pub def size(): Int32 = 32
 
     ///
     /// Returns the maximum exponent that a `Float32` may have.
     ///
-    @Time(1) @Space(1)
     pub def maxExponent(): Int32 = 127
 
     ///
     /// Returns the minimum exponent that a `Float32` may have.
     ///
-    @Time(1) @Space(1)
     pub def minExponent(): Int32 = -126
 
     ///
     /// Returns the maximum number representable by a `Float32`.
     ///
-    @Time(1) @Space(1)
     pub def maxValue(): Float32 = (2.0f32 - 2.0f32 ** -23.0f32) * (2.0f32 ** 127.0f32)
 
     ///
     /// Returns the minimum number representable by a `Float32`.
     ///
-    @Time(1) @Space(1)
     pub def minValue(): Float32 = -maxValue()
 
     ///
     /// Returns the minimum positive number representable by a `Float32`.
     ///
-    @Time(1) @Space(1)
     pub def minPositiveValue(): Float32 = 2.0f32 ** -149.0f32
 
     ///
     /// Returns the NaN (not a number) value of type `Float32`.
     ///
-    @Time(1) @Space(1)
     pub def nan(): Float32 = 0.0f32 / 0.0f32
 
     ///
     /// Returns the positive infinity value of type `Float32`.
     ///
-    @Time(1) @Space(1)
     pub def positiveInfinity(): Float32 = 1.0f32 / 0.0f32
 
     ///
     /// Returns the negative infinity value of type `Float32`.
     ///
-    @Time(1) @Space(1)
     pub def negativeInfinity(): Float32 = -1.0f32 / 0.0f32
 
     ///
     /// Returns true if and only if `x` is a non-infinite and non-Nan `Float32` value.
     ///
-    @Time(1) @Space(1)
     pub def isFinite(x: Float32): Bool = x >= minValue() and x <= maxValue()
 
     ///
     /// Returns true if and only if `x` is an infinite and non-Nan `Float32` value.
     ///
-    @Time(1) @Space(1)
     pub def isInfinite(x: Float32): Bool = x == positiveInfinity() or x == negativeInfinity()
 
     ///
     /// Returns true if and only if `x` is the NaN value of type `Float32`.
     ///
-    @Time(1) @Space(1)
     pub def isNan(x: Float32): Bool = x != x
 
     ///
     /// Returns the smaller of `x` and `y`.
     ///
-    @Time(1) @Space(1)
     pub def min(x: Float32, y: Float32): Float32 = if (x <= y) x else y
 
     ///
     /// Returns the larger of `x` and `y`.
     ///
-    @Time(1) @Space(1)
     pub def max(x: Float32, y: Float32): Float32 = if (x >= y) x else y
 
     ///
     /// Return a string representation of `x`.
     ///
-    @Time(1) @Space(1)
     pub def toString(x: Float32): String = ToString.toString(x)
 
     ///
     /// Parse the string `s` as a Float32, leading or trailing whitespace is trimmed.
     /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
     ///
-    @Time(1) @Space(1)
     pub def fromString(s: String): Option[Float32] = try {
         import java.lang.String.strip(): String \ {};
         import static java.lang.Float.parseFloat(String): Float32 \ {};
@@ -136,7 +120,6 @@ namespace Float32 {
     /// Returns `None` if the numeric value of `x` is outside the range of Int8
     /// (i.e. -128 to 127), or it is NaN or infinity.
     ///
-    @Time(1) @Space(1)
     pub def tryToInt8(x: Float32): Option[Int8] =
         import static java.lang.Float.valueOf(Float32): ##java.lang.Float \ {};
         import java.lang.Float.byteValue(): Int8 \ {};
@@ -154,7 +137,6 @@ namespace Float32 {
     /// Returns `None` if the numeric value of `x` is outside the range of Int16
     /// (i.e. -32768 to 32767), or it is NaN or infinity.
     ///
-    @Time(1) @Space(1)
     pub def tryToInt16(x: Float32): Option[Int16] =
         import static java.lang.Float.valueOf(Float32): ##java.lang.Float \ {};
         import java.lang.Float.shortValue(): Int16 \ {};
@@ -175,7 +157,6 @@ namespace Float32 {
     /// Note: while the range of an Int32 is precisely defined using Int32 values, converting this range to
     /// Float32 values is imprecise.
     ///
-    @Time(1) @Space(1)
     pub def tryToInt32(x: Float32): Option[Int32] =
         import static java.lang.Float.valueOf(Float32): ##java.lang.Float \ {};
         import java.lang.Float.intValue(): Int32 \ {};
@@ -196,7 +177,6 @@ namespace Float32 {
     /// Note: while the range of an Int64 is precisely defined using Int64 values, converting
     /// this range to Float32 values is imprecise.
     ///
-    @Time(1) @Space(1)
     pub def tryToInt64(x: Float32): Option[Int64] =
         import static java.lang.Float.valueOf(Float32): ##java.lang.Float \ {};
         import java.lang.Float.longValue(): Int64 \ {};
@@ -212,14 +192,12 @@ namespace Float32 {
     ///
     /// Returns `None` if the value of `x` is NaN or infinity.
     ///
-    @Time(1) @Space(1)
     pub def tryToBigInt(x: Float32): Option[BigInt] =
         Float64.tryToBigInt(toFloat64(x))
 
     ///
     /// Convert `x` to an Float64.
     ///
-    @Time(1) @Space(1)
     pub def toFloat64(x: Float32): Float64 =
         import static java.lang.Float.valueOf(Float32): ##java.lang.Float \ {};
         import java.lang.Float.doubleValue(): Float64 \ {};
@@ -233,7 +211,6 @@ namespace Float32 {
     ///
     /// If `x` is NaN or infinity return `None`.
     ///
-    @Time(1) @Space(1)
     pub def tryToBigDecimal(x: Float32): Option[BigDecimal] =
         toFloat64(x) |> Float64.tryToBigDecimal
 
@@ -257,7 +234,6 @@ namespace Float32 {
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int8 risks masking it.
     ///
-    @Time(1) @Space(1)
     pub def clampToInt8(x: Float32, minimum: Int8, maximum: Int8, nanValue: Int8): Int8 =
         import static java.lang.Float.valueOf(Float32): ##java.lang.Float \ {};
         import java.lang.Float.byteValue(): Int8 \ {};
@@ -276,7 +252,6 @@ namespace Float32 {
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int16 risks masking it.
     ///
-    @Time(1) @Space(1)
     pub def clampToInt16(x: Float32, minimum: Int16, maximum: Int16, nanValue: Int16): Int16 =
         import static java.lang.Float.valueOf(Float32): ##java.lang.Float \ {};
         import java.lang.Float.shortValue(): Int16 \ {};
@@ -295,7 +270,6 @@ namespace Float32 {
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int32 risks masking it.
     ///
-    @Time(1) @Space(1)
     pub def clampToInt32(x: Float32, minimum: Int32, maximum: Int32, nanValue: Int32): Int32 =
         import static java.lang.Float.valueOf(Float32): ##java.lang.Float \ {};
         import java.lang.Float.intValue(): Int32 \ {};
@@ -314,7 +288,6 @@ namespace Float32 {
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int64 risks masking it.
     ///
-    @Time(1) @Space(1)
     pub def clampToInt64(x: Float32, minimum: Int64, maximum: Int64, nanValue: Int64): Int64 =
         import static java.lang.Float.valueOf(Float32): ##java.lang.Float \ {};
         import java.lang.Float.longValue(): Int64 \ {};
@@ -328,7 +301,6 @@ namespace Float32 {
     ///
     /// Returns the absolute value of `x`.
     ///
-    @Time(1) @Space(1)
     pub def abs(x: Float32): Float32 =
         import static java.lang.Math.abs(Float32): Float32 \ {};
         abs(x)
@@ -336,7 +308,6 @@ namespace Float32 {
     ///
     /// Returns `x` rounded up to a Float32 representing the nearest larger integer value.
     ///
-    @Time(1) @Space(1)
     pub def ceil(x: Float32): Float32 =
         import static java.lang.Float.valueOf(Float32): ##java.lang.Float \ {} as valueOfF32;
         import static java.lang.Double.valueOf(Float64): ##java.lang.Double \ {} as valueOfF64;
@@ -349,7 +320,6 @@ namespace Float32 {
     ///
     /// Returns `x` rounded down to a Float32 representing the nearest smaller integer value.
     ///
-    @Time(1) @Space(1)
     pub def floor(x: Float32): Float32 =
         import static java.lang.Float.valueOf(Float32): ##java.lang.Float \ {} as valueOfF32;
         import static java.lang.Double.valueOf(Float64): ##java.lang.Double \ {} as valueOfF64;
@@ -365,7 +335,6 @@ namespace Float32 {
     /// The rounding may be upwards or downwards. If the rounding up and rounding down are equally
     /// close, `x` will be rounded to an even value (i.e. `round(0.5f32) == 0.0f32`).
     ///
-    @Time(1) @Space(1)
     pub def round(x: Float32): Float32 =
         import static java.lang.Float.valueOf(Float32): ##java.lang.Float \ {} as valueOfF32;
         import static java.lang.Double.valueOf(Float64): ##java.lang.Double \ {} as valueOfF64;

--- a/main/src/library/Float64.flix
+++ b/main/src/library/Float64.flix
@@ -27,98 +27,82 @@ namespace Float64 {
     ///
     /// Returns the number of bits used to represent a `Float64`.
     ///
-    @Time(1) @Space(1)
     pub def size(): Int32 = 64
 
     ///
     /// Returns the maximum exponent that a `Float64` may have.
     ///
-    @Time(1) @Space(1)
     pub def maxExponent(): Int32 = 1023
 
     ///
     /// Returns the minimum exponent that a `Float64` may have.
     ///
-    @Time(1) @Space(1)
     pub def minExponent(): Int32 = -1022
 
     ///
     /// Returns the maximum number representable by a `Float64`.
     ///
-    @Time(1) @Space(1)
     pub def maxValue(): Float64 = (2.0f64 - 2.0f64 ** -52.0f64) * (2.0f64 ** 1023.0f64)
 
     ///
     /// Returns the minimum number representable by a `Float64`.
     ///
-    @Time(1) @Space(1)
     pub def minValue(): Float64 = -maxValue()
 
     ///
     /// Returns the minimum positive number representable by a `Float64`.
     ///
-    @Time(1) @Space(1)
     pub def minPositiveValue(): Float64 = 2.0f64 ** -1074.0f64
 
     ///
     /// Returns the NaN (not a number) value of type `Float64`.
     ///
-    @Time(1) @Space(1)
     pub def nan(): Float64 = 0.0f64 / 0.0f64
 
     ///
     /// Returns the positive infinity value of type `Float64`.
     ///
-    @Time(1) @Space(1)
     pub def positiveInfinity(): Float64 = 1.0f64 / 0.0f64
 
     ///
     /// Returns the negative infinity value of type `Float64`.
     ///
-    @Time(1) @Space(1)
     pub def negativeInfinity(): Float64 = -1.0f64 / 0.0f64
 
     ///
     /// Returns true if and only if `x` is a non-infinite and non-Nan `Float64` value.
     ///
-    @Time(1) @Space(1)
     pub def isFinite(x: Float64): Bool = x >= minValue() and x <= maxValue()
 
     ///
     /// Returns true if and only if `x` is an infinite and non-Nan `Float64` value.
     ///
-    @Time(1) @Space(1)
     pub def isInfinite(x: Float64): Bool = x == positiveInfinity() or x == negativeInfinity()
 
     ///
     /// Returns true if and only if `x` is the NaN value of type `Float64`.
     ///
-    @Time(1) @Space(1)
     pub def isNan(x: Float64): Bool = x != x
 
     ///
     /// Returns the smaller of `x` and `y`.
     ///
-    @Time(1) @Space(1)
     pub def min(x: Float64, y: Float64): Float64 = if (x <= y) x else y
 
     ///
     /// Returns the larger of `x` and `y`.
     ///
-    @Time(1) @Space(1)
     pub def max(x: Float64, y: Float64): Float64 = if (x >= y) x else y
 
     ///
     /// Return a string representation of `x`.
     ///
-    @Time(1) @Space(1)
     pub def toString(x: Float64): String = ToString.toString(x)
 
     ///
     /// Parse the string `s` as a Float64, leading or trailing whitespace is trimmed.
     /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
     ///
-    @Time(1) @Space(1)
     pub def fromString(s: String): Option[Float64] = try {
         import java.lang.String.strip(): String \ {};
         import static java.lang.Double.parseDouble(String): Float64 \ {};
@@ -136,7 +120,6 @@ namespace Float64 {
     /// Returns `None` if the numeric value of `x` is outside the range of Int8
     /// (i.e. -128 to 127), or it is NaN or infinity.
     ///
-    @Time(1) @Space(1)
     pub def tryToInt8(x: Float64): Option[Int8] =
         import static java.lang.Double.valueOf(Float64): ##java.lang.Double \ {};
         import java.lang.Double.byteValue(): Int8 \ {};
@@ -154,7 +137,6 @@ namespace Float64 {
     /// Returns `None` if the numeric value of `x` is outside the range of Int16
     /// (i.e. -32768 to 32767), or it is NaN or infinity.
     ///
-    @Time(1) @Space(1)
     pub def tryToInt16(x: Float64): Option[Int16] =
         import static java.lang.Double.valueOf(Float64): ##java.lang.Double \ {};
         import java.lang.Double.shortValue(): Int16 \ {};
@@ -172,7 +154,6 @@ namespace Float64 {
     /// Returns `None` if the numeric value of `x` is outside the range of Int32
     /// (i.e. -2147483648 to 2147483647), or it is NaN or infinity.
     ///
-    @Time(1) @Space(1)
     pub def tryToInt32(x: Float64): Option[Int32] =
         import static java.lang.Double.valueOf(Float64): ##java.lang.Double \ {};
         import java.lang.Double.intValue(): Int32 \ {};
@@ -193,7 +174,6 @@ namespace Float64 {
     /// Note: while the range of an Int64 is precisely defined using Int64 values,
     /// converting this range to Float64 values is imprecise.
     ///
-    @Time(1) @Space(1)
     pub def tryToInt64(x: Float64): Option[Int64] =
         import static java.lang.Double.valueOf(Float64): ##java.lang.Double \ {};
         import java.lang.Double.longValue(): Int64 \ {};
@@ -209,7 +189,6 @@ namespace Float64 {
     ///
     /// Returns `None` if the value of `x` is NaN or infinity.
     ///
-    @Time(1) @Space(1)
     pub def tryToBigInt(x: Float64): Option[BigInt] =
         import static java.math.BigDecimal.valueOf(Float64): BigDecimal \ {};
         import java.math.BigDecimal.toBigInteger(): BigInt \ {};
@@ -232,7 +211,6 @@ namespace Float64 {
     /// If `x` is NaN return `Some(Float32.NaN)``, if `x` is positive or negative infinity return
     /// `Some` wrapping the corresponding Float32 infinity.
     ///
-    @Time(1) @Space(1)
     pub def tryToFloat32(x: Float64): Option[Float32] =
         import static java.lang.Double.valueOf(Float64): ##java.lang.Double \ {};
         import java.lang.Double.floatValue(): Float32 \ {};
@@ -249,7 +227,6 @@ namespace Float64 {
     ///
     /// If `x` is NaN or infinity return `None`.
     ///
-    @Time(1) @Space(1)
     pub def tryToBigDecimal(x: Float64): Option[BigDecimal] =
         import new java.math.BigDecimal(Float64): BigDecimal \ {} as fromFloat64;
         try {
@@ -278,7 +255,6 @@ namespace Float64 {
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int8 risks masking it.
     ///
-    @Time(1) @Space(1)
     pub def clampToInt8(x: Float64, minimum: Int8, maximum: Int8, nanValue: Int8): Int8 =
         import static java.lang.Double.valueOf(Float64): ##java.lang.Double \ {};
         import java.lang.Double.byteValue(): Int8 \ {};
@@ -297,7 +273,6 @@ namespace Float64 {
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int16 risks masking it.
     ///
-    @Time(1) @Space(1)
     pub def clampToInt16(x: Float64, minimum: Int16, maximum: Int16, nanValue: Int16): Int16 =
         import static java.lang.Double.valueOf(Float64): ##java.lang.Double \ {};
         import java.lang.Double.shortValue(): Int16 \ {};
@@ -316,7 +291,6 @@ namespace Float64 {
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int32 risks masking it.
     ///
-    @Time(1) @Space(1)
     pub def clampToInt32(x: Float64, minimum: Int32, maximum: Int32, nanValue: Int32): Int32 =
         import static java.lang.Double.valueOf(Float64): ##java.lang.Double \ {};
         import java.lang.Double.intValue(): Int32 \ {};
@@ -335,7 +309,6 @@ namespace Float64 {
     /// Warning: it is recommended to test `x` for NaN (not-a-number) before calling this
     /// function. Relying on `nanValue` to convert NaN to a permissable Int64 risks masking it.
     ///
-    @Time(1) @Space(1)
     pub def clampToInt64(x: Float64, minimum: Int64, maximum: Int64, nanValue: Int64): Int64 =
         import static java.lang.Double.valueOf(Float64): ##java.lang.Double \ {};
         import java.lang.Double.longValue(): Int64 \ {};
@@ -351,7 +324,6 @@ namespace Float64 {
     ///
     /// Returns `x` clamped within the Float32 range `minimum` to `maximum`.
     ///
-    @Time(1) @Space(1)
     pub def clampToFloat32(x: Float64, minimum: Float32, maximum: Float32): Float32 =
         import static java.lang.Double.valueOf(Float64): ##java.lang.Double \ {};
         import java.lang.Double.floatValue(): Float32 \ {};
@@ -365,7 +337,6 @@ namespace Float64 {
     ///
     /// Returns the absolute value of `x`.
     ///
-    @Time(1) @Space(1)
     pub def abs(x: Float64): Float64 =
         import static java.lang.Math.abs(Float64): Float64 \ {};
         abs(x)
@@ -373,7 +344,6 @@ namespace Float64 {
     ///
     /// Returns `x` rounded up to a Float64 representing the nearest larger integer value.
     ///
-    @Time(1) @Space(1)
     pub def ceil(x: Float64): Float64 =
         import static java.lang.Math.ceil(Float64): Float64 \ {};
         ceil(x)
@@ -381,7 +351,6 @@ namespace Float64 {
     ///
     /// Returns `x` rounded down to a Float64 representing the nearest smaller integer value.
     ///
-    @Time(1) @Space(1)
     pub def floor(x: Float64): Float64 =
         import static java.lang.Math.floor(Float64): Float64 \ {};
         floor(x)
@@ -392,7 +361,6 @@ namespace Float64 {
     /// The rounding may be upwards or downwards. If the rounding up and rounding down are equally
     /// close, `x` will be rounded to an even value (i.e. `round(0.5f64) == 0.0f64`).
     ///
-    @Time(1) @Space(1)
     pub def round(x: Float64): Float64 =
         import static java.lang.Math.rint(Float64): Float64 \ {};
         rint(x)

--- a/main/src/library/Int16.flix
+++ b/main/src/library/Int16.flix
@@ -27,38 +27,32 @@ namespace Int16 {
     ///
     /// Returns the number of bits used to represent an `Int16`.
     ///
-    @Time(1) @Space(1)
     pub def size(): Int32 = 16
 
     ///
     /// Returns the minimum number representable by an `Int16`.
     ///
-    @Time(1) @Space(1)
     pub def minValue(): Int16 = 1i16 <<< (size() - 1)
 
     ///
     /// Returns the maximum number representable by an `Int16`.
     ///
-    @Time(1) @Space(1)
     pub def maxValue(): Int16 = ~~~minValue()
 
     ///
     /// Returns the smaller of `x` and `y`.
     ///
-    @Time(1) @Space(1)
     pub def min(x: Int16, y: Int16): Int16 = if (x <= y) x else y
 
     ///
     /// Returns the larger of `x` and `y`.
     ///
-    @Time(1) @Space(1)
     pub def max(x: Int16, y: Int16): Int16 = if (x >= y) x else y
 
     ///
     /// Returns the absolute value of `x`.
     /// If the absolute value exceeds maxValue(), -1 is returned.
     ///
-    @Time(1) @Space(1)
     pub def abs(x: Int16): Int16 = {
         if      (x >= 0i16)         x
         else if (x == minValue())   -1i16
@@ -69,7 +63,6 @@ namespace Int16 {
     /// Returns the distance between `x` and `y`.
     /// If this distance exceeds maxValue(), -1 is returned.
     ///
-    @Time(1) @Space(1)
     pub def dist(x: Int16, y: Int16): Int16 = {
         if      (x >= 0i16 and y >= 0i16)                abs(x - y)
         else if (x < 0i16 and y < 0i16)                  abs(x - y)
@@ -82,7 +75,6 @@ namespace Int16 {
     /// Returns 1 if x > y, -1 if x < y, and 0 if x = y.
     /// The sign of x - y.
     ///
-    @Time(1) @Space(1)
     pub def compare(x: Int16, y: Int16): Int32 = {
         if      (x == y)    0
         else if (x < y)     -1
@@ -93,7 +85,6 @@ namespace Int16 {
     /// Returns 1 if x > 0, -1 if x < 0, and 0 if x = 0.
     /// The sign of x.
     ///
-    @Time(1) @Space(1)
     pub def signum(x: Int16): Int32 = compare(x, 0i16)
 
     ///
@@ -101,7 +92,6 @@ namespace Int16 {
     /// Only the rightmost 5 bits of `distance` are considered (ie. `distance rem 32`).
     /// A zero is shifted into the leftmost position regardless of sign extension.
     ///
-    @Time(1) @Space(1)
     pub def logicalRightShift(dist: {dist = Int32}, x: Int16): Int16 =
         if (x < 0i16 and dist.dist rem 32 != 0)
             ((x >>> 1) &&& maxValue()) >>> (dist.dist - 1)
@@ -112,7 +102,6 @@ namespace Int16 {
     /// Returns the number of one-bits in the two's complement binary
     /// representation of `x`.
     ///
-    @Time(1) @Space(1)
     pub def bitCount(x: Int16): Int32 = {
         if      (x == 0i16)          0
         else if (x rem 2i16 != 0i16) bitCount(logicalRightShift(dist = 1, x)) + 1
@@ -123,7 +112,6 @@ namespace Int16 {
     /// Returns the the value obtained by rotating the two's complement
     /// binary representation of `x` right by `distance` bits.
     ///
-    @Time(1) @Space(1)
     pub def rotateRight(dist: {dist = Int32}, x: Int16): Int16 =
         let rem = dist.dist rem size();
         let rot = if (rem >= 0) rem else rem + size();
@@ -133,7 +121,6 @@ namespace Int16 {
     /// Returns the the value obtained by rotating the two's complement
     /// binary representation of `x` left by `distance` bits.
     ///
-    @Time(1) @Space(1)
     pub def rotateLeft(dist: {dist = Int32}, x: Int16): Int16 =
         let rem = dist.dist rem size();
         let rot = if (rem >= 0) rem else rem + size();
@@ -143,7 +130,6 @@ namespace Int16 {
     /// Returns the value obtained by reversing the bits in the
     /// two's complement binary representation of `x`.
     ///
-    @Time(1) @Space(1)
     pub def reverse(x: Int16): Int16 = reverseHelper(x, 0, size()-1)
 
     ///
@@ -166,7 +152,6 @@ namespace Int16 {
     /// Possible return values: 0 (rightmost bit) - 15 (leftmost bit)
     ///                         -1 if x = 0
     ///
-    @Time(1) @Space(1)
     pub def highestOneBitPosition(x: Int16): Int32 =
         // Start at bit 15 and scan right
         oneBitPositionHelper(x, size() - 1, -1)
@@ -176,7 +161,6 @@ namespace Int16 {
     /// Possible return values: 0 (rightmost bit) - 15 (leftmost bit)
     ///                         -1 if x = 0
     ///
-    @Time(1) @Space(1)
     pub def lowestOneBitPosition(x: Int16): Int32 =
         // Start at bit 0 and scan left
         oneBitPositionHelper(x, 0, 1)
@@ -199,7 +183,6 @@ namespace Int16 {
     /// of the highest-order/leftmost one-bit in `x`.
     /// Returns 0 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def highestOneBit(x: Int16): Int16 =
         bitPositionToInt16(highestOneBitPosition(x))
 
@@ -208,7 +191,6 @@ namespace Int16 {
     /// of the highest-order/leftmost one-bit in `x`.
     /// Returns 0 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def lowestOneBit(x: Int16): Int16 =
         bitPositionToInt16(lowestOneBitPosition(x))
 
@@ -225,7 +207,6 @@ namespace Int16 {
     /// highest-order/leftmost one-bit in `x`.
     /// Returns 16 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def numberOfLeadingZeros(x: Int16): Int32 =
         if (x == 0i16) size() else size() - 1 - highestOneBitPosition(x)
 
@@ -234,7 +215,6 @@ namespace Int16 {
     /// lowest-order/rightmost one-bit in `x`.
     /// Returns 16 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def numberOfTrailingZeros(x: Int16): Int32 =
         if (x == 0i16) size() else lowestOneBitPosition(x)
 
@@ -243,7 +223,6 @@ namespace Int16 {
     /// Considers the 5 rightmost bits of `pos` (`pos` mod 32).
     /// The bits of x have positions: 0 (rightmost bit) - 15 (leftmost bit)
     ///
-    @Time(1) @Space(1)
     pub def getBit(pos: {pos = Int32}, x: Int16): Int32 =
         if ((x >>> pos.pos) rem 2i16 == 0i16) 0 else 1
 
@@ -252,7 +231,6 @@ namespace Int16 {
     /// Considers the 5 rightmost bits of `pos` (`pos` mod 32).
     /// The bits of x have positions: 0 (rightmost bit) - 15 (leftmost bit)
     ///
-    @Time(1) @Space(1)
     pub def setBit(pos: {pos = Int32}, x: Int16): Int16 = x ||| (1i16 <<< pos.pos)
 
     ///
@@ -260,7 +238,6 @@ namespace Int16 {
     /// Considers the 5 rightmost bits of `pos` (`pos` mod 32).
     /// The bits of x have positions: 0 (rightmost bit) - 15 (leftmost bit)
     ///
-    @Time(1) @Space(1)
     pub def clearBit(pos: {pos = Int32}, x: Int16): Int16 = x &&& ~~~(1i16 <<< pos.pos)
 
     ///
@@ -268,14 +245,12 @@ namespace Int16 {
     /// Considers the 5 rightmost bits of `pos` (`pos` mod 32).
     /// The bits of x have positions: 0 (rightmost bit) - 15 (leftmost bit)
     ///
-    @Time(1) @Space(1)
     pub def flipBit(pos: {pos = Int32}, x: Int16): Int16 = x ^^^ (1i16 <<< pos.pos)
 
     ///
     /// Returns the integer binary logarithm of `x`.
     /// If the given value is 0 or negative, 0 is returned.
     ///
-    @Time(1) @Space(1)
     pub def log2(x: Int16): Int16 =
         if (x <= 0i16) {
             0i16
@@ -287,20 +262,17 @@ namespace Int16 {
     ///
     /// Returns the factorial of `x`.
     ///
-    @Time(factorial(x)) @Space(1)
     pub def factorial(x: Int16): Int32 = toInt32(x) |> Int32.factorial
 
     ///
     /// Return a string representation of `x`.
     ///
-    @Time(1) @Space(1)
     pub def toString(x: Int16): String = ToString.toString(x)
 
     ///
     /// Parse the string `s` as an Int16, leading or trailing whitespace is trimmed.
     /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
     ///
-    @Time(1) @Space(1)
     pub def fromString(s: String): Option[Int16] = try {
         import java.lang.String.strip(): String \ {};
         import static java.lang.Short.parseShort(String): Int16 \ {};
@@ -317,7 +289,6 @@ namespace Int16 {
     /// Returns `None` if the numeric value of `x` is outside the range of Int8
     /// (i.e. -128 to 127).
     ///
-    @Time(1) @Space(1)
     pub def tryToInt8(x: Int16): Option[Int8] =
         import static java.lang.Short.valueOf(Int16): ##java.lang.Short \ {};
         import java.lang.Short.byteValue(): Int8 \ {};
@@ -331,7 +302,6 @@ namespace Int16 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toInt32(x: Int16): Int32 =
         import static java.lang.Short.valueOf(Int16): ##java.lang.Short \ {};
         import java.lang.Short.intValue(): Int32 \ {};
@@ -342,7 +312,6 @@ namespace Int16 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toInt64(x: Int16): Int64 =
         import static java.lang.Short.valueOf(Int16): ##java.lang.Short \ {};
         import java.lang.Short.longValue(): Int64 \ {};
@@ -353,7 +322,6 @@ namespace Int16 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toBigInt(x: Int16): BigInt =
         import static java.lang.Short.valueOf(Int16): ##java.lang.Short \ {} as i16ValueOf;
         import java.lang.Short.longValue(): Int64 \ {};
@@ -365,7 +333,6 @@ namespace Int16 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toFloat32(x: Int16): Float32 =
         import static java.lang.Short.valueOf(Int16): ##java.lang.Short \ {};
         import java.lang.Short.floatValue(): Float32 \ {};
@@ -376,7 +343,6 @@ namespace Int16 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toFloat64(x: Int16): Float64 =
         import static java.lang.Short.valueOf(Int16): ##java.lang.Short \ {};
         import java.lang.Short.doubleValue(): Float64 \ {};
@@ -387,7 +353,6 @@ namespace Int16 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toBigDecimal(x: Int16): BigDecimal =
         import new java.math.BigDecimal(Int32): BigDecimal \ {} as fromInt32;
         Int16.toInt32(x) |> fromInt32
@@ -409,7 +374,6 @@ namespace Int16 {
     ///
     /// Returns `x` clamped within the Int8 range `min` to `max`.
     ///
-    @Time(1) @Space(1)
     pub def clampToInt8(min: {min = Int8}, max: {max = Int8}, x: Int16): Int8 =
         import static java.lang.Short.valueOf(Int16): ##java.lang.Short \ {};
         import java.lang.Short.byteValue(): Int8 \ {};

--- a/main/src/library/Int32.flix
+++ b/main/src/library/Int32.flix
@@ -27,38 +27,32 @@ namespace Int32 {
     ///
     /// Returns the number of bits used to represent an `Int32`.
     ///
-    @Time(1) @Space(1)
     pub def size(): Int32 = 32
 
     ///
     /// Returns the minimum number representable by an `Int32`.
     ///
-    @Time(1) @Space(1)
     pub def minValue(): Int32 = 1 <<< (size() - 1)
 
     ///
     /// Returns the maximum number representable by an `Int32`.
     ///
-    @Time(1) @Space(1)
     pub def maxValue(): Int32 = ~~~minValue()
 
     ///
     /// Returns the smaller of `x` and `y`.
     ///
-    @Time(1) @Space(1)
     pub def min(x: Int32, y: Int32): Int32 = if (x <= y) x else y
 
     ///
     /// Returns the larger of `x` and `y`.
     ///
-    @Time(1) @Space(1)
     pub def max(x: Int32, y: Int32): Int32 = if (x >= y) x else y
 
     ///
     /// Returns the absolute value of `x`.
     /// If the absolute value exceeds maxValue(), -1 is returned.
     ///
-    @Time(1) @Space(1)
     pub def abs(x: Int32): Int32 = {
         if      (x >= 0)            x
         else if (x == minValue())   -1
@@ -69,7 +63,6 @@ namespace Int32 {
     /// Returns the distance between `x` and `y`.
     /// If this distance exceeds maxValue(), -1 is returned.
     ///
-    @Time(1) @Space(1)
     pub def dist(x: Int32, y: Int32): Int32 = {
         if      (x >= 0 and y >= 0)                      abs(x - y)
         else if (x < 0 and y < 0)                        abs(x - y)
@@ -82,7 +75,6 @@ namespace Int32 {
     /// Returns 1 if x > y, -1 if x < y, and 0 if x = y.
     /// The sign of x - y.
     ///
-    @Time(1) @Space(1)
     pub def compare(x: Int32, y: Int32): Int32 = {
         if      (x == y)    0
         else if (x < y)     -1
@@ -93,7 +85,6 @@ namespace Int32 {
     /// Returns 1 if x > 0, -1 if x < 0, and 0 if x = 0.
     /// The sign of x.
     ///
-    @Time(1) @Space(1)
     pub def signum(x: Int32): Int32 = compare(x, 0)
 
     ///
@@ -101,7 +92,6 @@ namespace Int32 {
     /// Only the rightmost 5 bits of `dist` are considered (ie. `dist rem 32`).
     /// A zero is shifted into the leftmost position regardless of sign extension.
     ///
-    @Time(1) @Space(1)
     pub def logicalRightShift(dist: {dist = Int32}, x: Int32): Int32 =
         if (x < 0 and dist.dist rem size() != 0)
             ((x >>> 1) &&& maxValue()) >>> (dist.dist - 1)
@@ -112,7 +102,6 @@ namespace Int32 {
     /// Returns the number of one-bits in the two's complement binary
     /// representation of `x`.
     ///
-    @Time(1) @Space(1)
     pub def bitCount(x: Int32): Int32 = {
         if      (x == 0)       0
         else if (x rem 2 != 0) bitCount(logicalRightShift(dist = 1, x)) + 1
@@ -123,7 +112,6 @@ namespace Int32 {
     /// Returns the the value obtained by rotating the two's complement
     /// binary representation of `x` right by `dist` bits.
     ///
-    @Time(1) @Space(1)
     pub def rotateRight(dist: {dist = Int32}, x: Int32): Int32 =
         (logicalRightShift(dist = dist.dist, x)) ||| (x <<< -dist.dist)
 
@@ -131,7 +119,6 @@ namespace Int32 {
     /// Returns the the value obtained by rotating the two's complement
     /// binary representation of `x` left by `dist` bits.
     ///
-    @Time(1) @Space(1)
     pub def rotateLeft(dist: {dist = Int32}, x: Int32): Int32 =
         (logicalRightShift(dist = -dist.dist, x)) ||| (x <<< dist.dist)
 
@@ -139,7 +126,6 @@ namespace Int32 {
     /// Returns the value obtained by reversing the bits in the
     /// two's complement binary representation of `x`.
     ///
-    @Time(1) @Space(1)
     pub def reverse(x: Int32): Int32 = reverseHelper(x, 0, size()-1)
 
     ///
@@ -151,7 +137,6 @@ namespace Int32 {
     ///
     /// Helper function for `reverse`.
     ///
-    @Time(1) @Space(1)
     def swap(x: Int32, l: Int32, r: Int32): Int32 = match (getBit(pos = l, x), getBit(pos = r, x)) {
         case (1, 0) => clearBit(pos = l, setBit(pos = r, x))
         case (0, 1) => clearBit(pos = r, setBit(pos = l, x))
@@ -163,7 +148,6 @@ namespace Int32 {
     /// Possible return values: 0 (rightmost bit) - 31 (leftmost bit)
     ///                         -1 if x = 0
     ///
-    @Time(1) @Space(1)
     pub def highestOneBitPosition(x: Int32): Int32 =
         // Start at bit 31 and scan right
         oneBitPositionHelper(x, size() - 1, -1)
@@ -173,7 +157,6 @@ namespace Int32 {
     /// Possible return values: 0 (rightmost bit) - 31 (leftmost bit)
     ///                         -1 if x = 0
     ///
-    @Time(1) @Space(1)
     pub def lowestOneBitPosition(x: Int32): Int32 =
         // Start at bit 0 and scan left
         oneBitPositionHelper(x, 0, 1)
@@ -196,7 +179,6 @@ namespace Int32 {
     /// of the highest-order/leftmost one-bit in `x`.
     /// Returns 0 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def highestOneBit(x: Int32): Int32 =
         bitPositionToInt32(highestOneBitPosition(x))
 
@@ -205,7 +187,6 @@ namespace Int32 {
     /// of the highest-order/leftmost one-bit in `x`.
     /// Returns 0 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def lowestOneBit(x: Int32): Int32 =
         bitPositionToInt32(lowestOneBitPosition(x))
 
@@ -214,7 +195,6 @@ namespace Int32 {
     /// Returns a value with a single one-bit at bit number `position`.
     /// Returns 0 if `position` is outside the range 0-31 inclusive.
     ///
-    @Time(1) @Space(1)
     def bitPositionToInt32(position: Int32): Int32 =
         if (position < 0 or position > size() - 1) 0 else 1 <<< position
 
@@ -223,7 +203,6 @@ namespace Int32 {
     /// highest-order/leftmost one-bit in `x`.
     /// Returns 32 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def numberOfLeadingZeros(x: Int32): Int32 =
         size() - 1 - highestOneBitPosition(x)
 
@@ -232,7 +211,6 @@ namespace Int32 {
     /// lowest-order/rightmost one-bit in `x`.
     /// Returns 32 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def numberOfTrailingZeros(x: Int32): Int32 =
         if (x == 0) 32 else lowestOneBitPosition(x)
 
@@ -241,7 +219,6 @@ namespace Int32 {
     /// Considers the 5 rightmost bits of `pos` (`pos` mod 32).
     /// The bits of x have positions: 0 (rightmost bit) - 31 (leftmost bit)
     ///
-    @Time(1) @Space(1)
     pub def getBit(pos: {pos = Int32}, x: Int32): Int32 =
         if ((x >>> pos.pos) rem 2 == 0) 0 else 1
 
@@ -250,7 +227,6 @@ namespace Int32 {
     /// Considers the 5 rightmost bits of `pos` (`pos` mod 32).
     /// The bits of x have positions: 0 (rightmost bit) - 31 (leftmost bit)
     ///
-    @Time(1) @Space(1)
     pub def setBit(pos: {pos = Int32}, x: Int32): Int32 = x ||| (1 <<< pos.pos)
 
     ///
@@ -258,7 +234,6 @@ namespace Int32 {
     /// Considers the 5 rightmost bits of `pos` (`pos` mod 32).
     /// The bits of x have positions: 0 (rightmost bit) - 31 (leftmost bit)
     ///
-    @Time(1) @Space(1)
     pub def clearBit(pos: {pos = Int32}, x: Int32): Int32 = x &&& ~~~(1 <<< pos.pos)
 
     ///
@@ -266,14 +241,12 @@ namespace Int32 {
     /// Considers the 5 rightmost bits of `pos` (`pos` mod 32).
     /// The bits of x have positions: 0 (rightmost bit) - 31 (leftmost bit)
     ///
-    @Time(1) @Space(1)
     pub def flipBit(pos: {pos = Int32}, x: Int32): Int32 = x ^^^ (1 <<< pos.pos)
 
     ///
     /// Returns the integer binary logarithm of `x`.
     /// If the given value is 0 or negative, 0 is returned.
     ///
-    @Time(1) @Space(1)
     pub def log2(x: Int32): Int32 =
         if (x <= 0) {
             0
@@ -285,7 +258,6 @@ namespace Int32 {
     /// Returns the factorial of `x`.
     /// If the given value is negative, 0 is returned.
     ///
-    @Time(factorial(x)) @Space(1)
     pub def factorial(x: Int32): Int32 =
         if (x < 0) {
             0
@@ -300,14 +272,12 @@ namespace Int32 {
     ///
     /// Return a string representation of `x`.
     ///
-    @Time(1) @Space(1)
     pub def toString(x: Int32): String = ToString.toString(x)
 
     ///
     /// Parse the string `s` as an Int32, leading or trailing whitespace is trimmed.
     /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
     ///
-    @Time(1) @Space(1)
     pub def fromString(s: String): Option[Int32] = try {
         import java.lang.String.strip(): String \ {};
         import static java.lang.Integer.parseInt(String): Int32 \ {};
@@ -338,7 +308,6 @@ namespace Int32 {
     /// Returns `None` if the numeric value of `x` is outside the range of Int8
     /// (i.e. -128 to 127).
     ///
-    @Time(1) @Space(1)
     pub def tryToInt8(x: Int32): Option[Int8] =
         import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer \ {};
         import java.lang.Integer.byteValue(): Int8 \ {};
@@ -355,7 +324,6 @@ namespace Int32 {
     /// Returns `None` if the numeric value of `x` is outside the range of Int16
     /// (i.e. -32768 to 32767).
     ///
-    @Time(1) @Space(1)
     pub def tryToInt16(x: Int32): Option[Int16] =
         import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer \ {};
         import java.lang.Integer.shortValue(): Int16 \ {};
@@ -369,7 +337,6 @@ namespace Int32 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toInt64(x: Int32): Int64 =
         import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer \ {};
         import java.lang.Integer.longValue(): Int64 \ {};
@@ -380,7 +347,6 @@ namespace Int32 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toBigInt(x: Int32): BigInt =
         import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer \ {} as i16ValueOf;
         import java.lang.Integer.longValue(): Int64 \ {};
@@ -392,7 +358,6 @@ namespace Int32 {
     ///
     /// The numeric value of `x` may lose precision.
     ///
-    @Time(1) @Space(1)
     pub def toFloat32(x: Int32): Float32 =
         import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer \ {};
         import java.lang.Integer.floatValue(): Float32 \ {};
@@ -403,7 +368,6 @@ namespace Int32 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toFloat64(x: Int32): Float64 =
         import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer \ {};
         import java.lang.Integer.doubleValue(): Float64 \ {};
@@ -414,7 +378,6 @@ namespace Int32 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toBigDecimal(x: Int32): BigDecimal =
         import new java.math.BigDecimal(Int32): BigDecimal \ {} as fromInt32;
         fromInt32(x)
@@ -436,7 +399,6 @@ namespace Int32 {
     ///
     /// Returns `x` clamped within the Int8 range `min` to `max`.
     ///
-    @Time(1) @Space(1)
     pub def clampToInt8(min: {min = Int8}, max: {max = Int8}, x: Int32): Int8 =
         import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer \ {};
         import java.lang.Integer.byteValue(): Int8 \ {};
@@ -450,7 +412,6 @@ namespace Int32 {
     ///
     /// Returns `x` clamped within the Int16 range `min` to `max`.
     ///
-    @Time(1) @Space(1)
     pub def clampToInt16(min: {min = Int16}, max: {max = Int16}, x: Int32): Int16 =
         import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer \ {};
         import java.lang.Integer.shortValue(): Int16 \ {};

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -27,38 +27,32 @@ namespace Int64 {
     ///
     /// Returns the number of bits used to represent an `Int64`.
     ///
-    @Time(1) @Space(1)
     pub def size(): Int32 = 64
 
     ///
     /// Returns the minimum number representable by an `Int64`.
     ///
-    @Time(1) @Space(1)
     pub def minValue(): Int64 = 1i64 <<< (size() - 1)
 
     ///
     /// Returns the maximum number representable by an `Int64`.
     ///
-    @Time(1) @Space(1)
     pub def maxValue(): Int64 = ~~~minValue()
 
     ///
     /// Returns the smaller of `x` and `y`.
     ///
-    @Time(1) @Space(1)
     pub def min(x: Int64, y: Int64): Int64 = if (x <= y) x else y
 
     ///
     /// Returns the larger of `x` and `y`.
     ///
-    @Time(1) @Space(1)
     pub def max(x: Int64, y: Int64): Int64 = if (x >= y) x else y
 
     ///
     /// Returns the absolute value of `x`.
     /// If the absolute value exceeds maxValue(), -1 is returned.
     ///
-    @Time(1) @Space(1)
     pub def abs(x: Int64): Int64 = {
         if      (x >= 0i64)         x
         else if (x == minValue())   -1i64
@@ -69,7 +63,6 @@ namespace Int64 {
     /// Returns the distance between `x` and `y`.
     /// If this distance exceeds maxValue(), -1 is returned.
     ///
-    @Time(1) @Space(1)
     pub def dist(x: Int64, y: Int64): Int64 = {
         if (x >= 0i64 and y >= 0i64)                     abs(x - y)
         else if (x < 0i64 and y < 0i64)                  abs(x - y)
@@ -82,7 +75,6 @@ namespace Int64 {
     /// Returns 1 if x > y, -1 if x < y, and 0 if x = y.
     /// The sign of x - y.
     ///
-    @Time(1) @Space(1)
     pub def compare(x: Int64, y: Int64): Int32 = {
         if (x == y)     0
         else if (x < y) -1
@@ -93,7 +85,6 @@ namespace Int64 {
     /// Returns 1 if x > 0, -1 if x < 0, and 0 if x = 0.
     /// The sign of x.
     ///
-    @Time(1) @Space(1)
     pub def signum(x: Int64): Int32 = compare(x, 0i64)
 
     ///
@@ -101,7 +92,6 @@ namespace Int64 {
     /// Only the rightmost 6 bits of `distance` are considered (ie. `distance rem 64`).
     /// A zero is shifted into the leftmost position regardless of sign extension.
     ///
-    @Time(1) @Space(1)
     pub def logicalRightShift(dist: {dist = Int32}, x: Int64): Int64 =
         if (x < 0i64 and dist.dist rem size() != 0)
             ((x >>> 1) &&& maxValue()) >>> (dist.dist - 1)
@@ -112,7 +102,6 @@ namespace Int64 {
     /// Returns the number of one-bits in the two's complement binary
     /// representation of `x`.
     ///
-    @Time(1) @Space(1)
     pub def bitCount(x: Int64): Int32 = {
         if      (x == 0i64)          0
         else if (x rem 2i64 != 0i64) bitCount(logicalRightShift(dist = 1, x)) + 1
@@ -130,7 +119,6 @@ namespace Int64 {
     /// Returns the the value obtained by rotating the two's complement
     /// binary representation of `x` left by `distance` bits.
     ///
-    @Time(1) @Space(1)
     pub def rotateLeft(dist: {dist = Int32}, x: Int64): Int64 =
         (logicalRightShift(dist = -dist.dist, x)) ||| (x <<< dist.dist)
 
@@ -138,7 +126,6 @@ namespace Int64 {
     /// Returns the value obtained by reversing the bits in the
     /// two's complement binary representation of `x`.
     ///
-    @Time(1) @Space(1)
     pub def reverse(x: Int64): Int64 = reverseHelper(x, 0, size()-1)
 
     ///
@@ -161,7 +148,6 @@ namespace Int64 {
     /// Possible return values: 0 (rightmost bit) - 63 (leftmost bit)
     ///                         -1 if x = 0
     ///
-    @Time(1) @Space(1)
     pub def highestOneBitPosition(x: Int64): Int32 =
         // Start at bit 63 and scan right
         oneBitPositionHelper(x, size() - 1, -1)
@@ -171,7 +157,6 @@ namespace Int64 {
     /// Possible return values: 0 (rightmost bit) - 63 (leftmost bit)
     ///                         -1 if x = 0
     ///
-    @Time(1) @Space(1)
     pub def lowestOneBitPosition(x: Int64): Int32 =
         // Start at bit 0 and scan left
         oneBitPositionHelper(x, 0, 1)
@@ -194,7 +179,6 @@ namespace Int64 {
     /// of the highest-order/leftmost one-bit in `x`.
     /// Returns 0 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def highestOneBit(x: Int64): Int64 =
         bitPositionToInt64(highestOneBitPosition(x))
 
@@ -203,7 +187,6 @@ namespace Int64 {
     /// of the highest-order/leftmost one-bit in `x`.
     /// Returns 0 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def lowestOneBit(x: Int64): Int64 =
         bitPositionToInt64(lowestOneBitPosition(x))
 
@@ -220,7 +203,6 @@ namespace Int64 {
     /// highest-order/leftmost one-bit in `x`.
     /// Returns 64 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def numberOfLeadingZeros(x: Int64): Int32 =
         if (x == 0i64) size() else size() - 1 - highestOneBitPosition(x)
 
@@ -229,7 +211,6 @@ namespace Int64 {
     /// lowest-order/rightmost one-bit in `x`.
     /// Returns 64 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def numberOfTrailingZeros(x: Int64): Int32 =
         if (x == 0i64) size() else lowestOneBitPosition(x)
 
@@ -238,7 +219,6 @@ namespace Int64 {
     /// Considers the 6 rightmost bits of `position` (`position` mod 64).
     /// The bits of x have positions: 0 (rightmost bit) - 63 (leftmost bit).
     ///
-    @Time(1) @Space(1)
     pub def getBit(pos: {pos = Int32}, x: Int64): Int32 =
         if ((x >>> pos.pos) rem 2i64 == 0i64) 0 else 1
 
@@ -247,7 +227,6 @@ namespace Int64 {
     /// Considers the 6 rightmost bits of `position` (`position` mod 64).
     /// The bits of x have positions: 0 (rightmost bit) - 63 (leftmost bit)
     ///
-    @Time(1) @Space(1)
     pub def setBit(pos: {pos = Int32}, x: Int64): Int64 = x ||| (1i64 <<< pos.pos)
 
     ///
@@ -255,7 +234,6 @@ namespace Int64 {
     /// Considers the 6 rightmost bits of `position` (`position` mod 64).
     /// The bits of x have positions: 0 (rightmost bit) - 63 (leftmost bit)
     ///
-    @Time(1) @Space(1)
     pub def clearBit(pos: {pos = Int32}, x: Int64): Int64 = x &&& ~~~(1i64 <<< pos.pos)
 
     ///
@@ -263,14 +241,12 @@ namespace Int64 {
     /// Considers the 6 rightmost bits of `position` (`position` mod 64).
     /// The bits of x have positions: 0 (rightmost bit) - 63 (leftmost bit)
     ///
-    @Time(1) @Space(1)
     pub def flipBit(pos: {pos = Int32}, x: Int64): Int64 = x ^^^ (1i64 <<< pos.pos)
 
     ///
     /// Returns the integer binary logarithm of `x`.
     /// If the given value is 0 or negative, 0 is returned.
     ///
-    @Time(1) @Space(1)
     pub def log2(x: Int64): Int64 =
         if (x <= 0i64) {
             0i64
@@ -282,7 +258,6 @@ namespace Int64 {
     /// Returns the factorial of `x`.
     /// If the given value is negative, 0 is returned.
     ///
-    @Time(factorial(x)) @Space(1)
     pub def factorial(x: Int64): Int64 =
         if (x < 0i64) {
             0i64
@@ -297,14 +272,12 @@ namespace Int64 {
     ///
     /// Return a string representation of `x`.
     ///
-    @Time(1) @Space(1)
     pub def toString(x: Int64): String = ToString.toString(x)
 
     ///
     /// Parse the string `s` as an Int64, leading or trailing whitespace is trimmed.
     /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
     ///
-    @Time(1) @Space(1)
     pub def fromString(s: String): Option[Int64] = try {
         import java.lang.String.strip(): String \ {};
         import static java.lang.Long.parseLong(String): Int64 \ {};
@@ -334,7 +307,6 @@ namespace Int64 {
     /// Returns `None` if the numeric value of `x` is outside the range of Int8
     /// (i.e. -128 to 127).
     ///
-    @Time(1) @Space(1)
     pub def tryToInt8(x: Int64): Option[Int8] =
         import static java.lang.Long.valueOf(Int64): ##java.lang.Long \ {};
         import java.lang.Long.byteValue(): Int8 \ {};
@@ -351,7 +323,6 @@ namespace Int64 {
     /// Returns `None` if the numeric value of `x` is outside the range of Int16
     /// (i.e. -32768 to 32767).
     ///
-    @Time(1) @Space(1)
     pub def tryToInt16(x: Int64): Option[Int16] =
         import static java.lang.Long.valueOf(Int64): ##java.lang.Long \ {};
         import java.lang.Long.shortValue(): Int16 \ {};
@@ -368,7 +339,6 @@ namespace Int64 {
     /// Returns `None` if the numeric value of `x` is outside the range of Int32
     /// (i.e. -2147483648 to 2147483647).
     ///
-    @Time(1) @Space(1)
     pub def tryToInt32(x: Int64): Option[Int32] =
         import static java.lang.Long.valueOf(Int64): ##java.lang.Long \ {};
         import java.lang.Long.intValue(): Int32 \ {};
@@ -381,7 +351,6 @@ namespace Int64 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toBigInt(x: Int64): BigInt =
         import static java.lang.Long.valueOf(Int64): ##java.lang.Long \ {} as i64ValueOf;
         import java.lang.Long.longValue(): Int64 \ {};
@@ -393,7 +362,6 @@ namespace Int64 {
     ///
     /// Warning: The numeric value of `x` may lose precision.
     ///
-    @Time(1) @Space(1)
     pub def toFloat32(x: Int64): Float32 =
         import static java.lang.Long.valueOf(Int64): ##java.lang.Long \ {};
         import java.lang.Long.floatValue(): Float32 \ {};
@@ -404,7 +372,6 @@ namespace Int64 {
     ///
     /// Warning: The numeric value of `x` may lose precision.
     ///
-    @Time(1) @Space(1)
     pub def toFloat64(x: Int64): Float64 =
         import static java.lang.Long.valueOf(Int64): ##java.lang.Long \ {};
         import java.lang.Long.doubleValue(): Float64 \ {};
@@ -415,7 +382,6 @@ namespace Int64 {
     ///
     /// Warning: The numeric value of `x` may lose precision.
     ///
-    @Time(1) @Space(1)
     pub def toBigDecimal(x: Int64): BigDecimal =
         import new java.math.BigDecimal(Int64): BigDecimal \ {} as fromInt64;
         fromInt64(x)
@@ -437,7 +403,6 @@ namespace Int64 {
     ///
     /// Returns `x` clamped within the Int8 range `min` to `max`.
     ///
-    @Time(1) @Space(1)
     pub def clampToInt8(min: {min = Int8}, max: {max = Int8}, x: Int64): Int8 =
         import static java.lang.Long.valueOf(Int64): ##java.lang.Long \ {};
         import java.lang.Long.byteValue(): Int8 \ {};
@@ -450,7 +415,6 @@ namespace Int64 {
     ///
     /// Returns `x` clamped within the Int16 range `min` to `max`.
     ///
-    @Time(1) @Space(1)
     pub def clampToInt16(min: {min = Int16}, max: {max = Int16}, x: Int64): Int16 =
         import static java.lang.Long.valueOf(Int64): ##java.lang.Long \ {};
         import java.lang.Long.shortValue(): Int16 \ {};
@@ -464,7 +428,6 @@ namespace Int64 {
     ///
     /// Returns `x` clamped within the Int32 range `min` to `max`.
     ///
-    @Time(1) @Space(1)
     pub def clampToInt32(min: {min = Int32}, max: {max = Int32}, x: Int64): Int32 =
         import static java.lang.Long.valueOf(Int64): ##java.lang.Long \ {};
         import java.lang.Long.intValue(): Int32 \ {};

--- a/main/src/library/Int8.flix
+++ b/main/src/library/Int8.flix
@@ -27,38 +27,32 @@ namespace Int8 {
     ///
     /// Returns the number of bits used to represent an `Int8`.
     ///
-    @Time(1) @Space(1)
     pub def size(): Int32 = 8
 
     ///
     /// Returns the minimum number representable by an `Int8`.
     ///
-    @Time(1) @Space(1)
     pub def minValue(): Int8 = 1i8 <<< (size() - 1)
 
     ///
     /// Returns the maximum number representable by an `Int8`.
     ///
-    @Time(1) @Space(1)
     pub def maxValue(): Int8 = ~~~minValue()
 
     ///
     /// Returns the smaller of `x` and `y`.
     ///
-    @Time(1) @Space(1)
     pub def min(x: Int8, y: Int8): Int8 = if (x <= y) x else y
 
     ///
     /// Returns the larger of `x` and `y`.
     ///
-    @Time(1) @Space(1)
     pub def max(x: Int8, y: Int8): Int8 = if (x >= y) x else y
 
     ///
     /// Returns the absolute value of `x`.
     /// If the absolute value exceeds maxValue(), -1 is returned.
     ///
-    @Time(1) @Space(1)
     pub def abs(x: Int8): Int8 = {
         if      (x >= 0i8)          x
         else if (x == minValue())   -1i8
@@ -69,7 +63,6 @@ namespace Int8 {
     /// Returns the distance between `x` and `y`.
     /// If this distance exceeds maxValue(), -1 is returned.
     ///
-    @Time(1) @Space(1)
     pub def dist(x: Int8, y: Int8): Int8 = {
         if      (x >= 0i8 and y >= 0i8)                  abs(x - y)
         else if (x < 0i8 and y < 0i8)                    abs(x - y)
@@ -82,7 +75,6 @@ namespace Int8 {
     /// Returns 1 if x > y, -1 if x < y, and 0 if x = y.
     /// The sign of x - y.
     ///
-    @Time(1) @Space(1)
     pub def compare(x: Int8, y: Int8): Int32 = {
         if      (x == y)    0
         else if (x < y)     -1
@@ -93,7 +85,6 @@ namespace Int8 {
     /// Returns 1 if x > 0, -1 if x < 0, and 0 if x = 0.
     /// The sign of x.
     ///
-    @Time(1) @Space(1)
     pub def signum(x: Int8): Int32 = compare(x, 0i8)
 
     ///
@@ -101,7 +92,6 @@ namespace Int8 {
     /// Only the rightmost 5 bits of `distance` are considered (ie. `distance rem 32`).
     /// A zero is shifted into the leftmost position regardless of sign extension.
     ///
-    @Time(1) @Space(1)
     pub def logicalRightShift(dist: {dist = Int32}, x: Int8): Int8 =
         if (x < 0i8 and dist.dist rem 32 != 0)
             ((x >>> 1) &&& maxValue()) >>> (dist.dist - 1)
@@ -112,7 +102,6 @@ namespace Int8 {
     /// Returns the number of one-bits in the two's complement binary
     /// representation of `x`.
     ///
-    @Time(1) @Space(1)
     pub def bitCount(x: Int8): Int32 = {
         if      (x == 0i8)         0
         else if (x rem 2i8 != 0i8) bitCount(logicalRightShift(dist = 1, x)) + 1
@@ -123,7 +112,6 @@ namespace Int8 {
     /// Returns the the value obtained by rotating the two's complement
     /// binary representation of `x` right by `distance` bits.
     ///
-    @Time(1) @Space(1)
     pub def rotateRight(dist: {dist = Int32}, x: Int8): Int8 =
         let rem = dist.dist rem size();
         let rot = if (rem >= 0) rem else rem + size();
@@ -133,7 +121,6 @@ namespace Int8 {
     /// Returns the the value obtained by rotating the two's complement
     /// binary representation of `x` left by `distance` bits.
     ///
-    @Time(1) @Space(1)
     pub def rotateLeft(dist: {dist = Int32}, x: Int8): Int8 =
         let rem = dist.dist rem size();
         let rot = if (rem >= 0) rem else rem + size();
@@ -143,7 +130,6 @@ namespace Int8 {
     /// Returns the value obtained by reversing the bits in the
     /// two's complement binary representation of `x`.
     ///
-    @Time(1) @Space(1)
     pub def reverse(x: Int8): Int8 = reverseHelper(x, 0, size()-1)
 
     ///
@@ -166,7 +152,6 @@ namespace Int8 {
     /// Possible return values: 0 (rightmost bit) - 7 (leftmost bit)
     ///                         -1 if x = 0
     ///
-    @Time(1) @Space(1)
     pub def highestOneBitPosition(x: Int8): Int32 =
         // Start at bit 7 and scan right
         oneBitPositionHelper(x, size() - 1, -1)
@@ -176,7 +161,6 @@ namespace Int8 {
     /// Possible return values: 0 (rightmost bit) - 7 (leftmost bit)
     ///                         -1 if x = 0
     ///
-    @Time(1) @Space(1)
     pub def lowestOneBitPosition(x: Int8): Int32 =
         // Start at bit 0 and scan left
         oneBitPositionHelper(x, 0, 1)
@@ -199,7 +183,6 @@ namespace Int8 {
     /// of the highest-order/leftmost one-bit in `x`.
     /// Returns 0 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def highestOneBit(x: Int8): Int8 =
         bitPositionToInt8(highestOneBitPosition(x))
 
@@ -208,7 +191,6 @@ namespace Int8 {
     /// of the highest-order/leftmost one-bit in `x`.
     /// Returns 0 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def lowestOneBit(x: Int8): Int8 =
         bitPositionToInt8(lowestOneBitPosition(x))
 
@@ -225,7 +207,6 @@ namespace Int8 {
     /// highest-order/leftmost one-bit in `x`.
     /// Returns 8 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def numberOfLeadingZeros(x: Int8): Int32 =
         if (x == 0i8) size() else size() - 1 - highestOneBitPosition(x)
 
@@ -234,7 +215,6 @@ namespace Int8 {
     /// lowest-order/rightmost one-bit in `x`.
     /// Returns 8 if x=0.
     ///
-    @Time(1) @Space(1)
     pub def numberOfTrailingZeros(x: Int8): Int32 =
         if (x == 0i8) size() else lowestOneBitPosition(x)
 
@@ -243,7 +223,6 @@ namespace Int8 {
     /// Considers the 5 rightmost bits of `pos` (`pos` mod 32).
     /// The bits of x have positions: 0 (rightmost bit) - 7 (leftmost bit)
     ///
-    @Time(1) @Space(1)
     pub def getBit(pos: {pos = Int32}, x: Int8): Int32 =
         if ((x >>> pos.pos) rem 2i8 == 0i8) 0 else 1
 
@@ -252,7 +231,6 @@ namespace Int8 {
     /// Considers the 5 rightmost bits of `pos` (`pos` mod 32).
     /// The bits of x have positions: 0 (rightmost bit) - 7 (leftmost bit)
     ///
-    @Time(1) @Space(1)
     pub def setBit(pos: {pos = Int32}, x: Int8): Int8 = x ||| (1i8 <<< pos.pos)
 
     ///
@@ -260,7 +238,6 @@ namespace Int8 {
     /// Considers the 5 rightmost bits of `pos` (`pos` mod 32).
     /// The bits of x have positions: 0 (rightmost bit) - 7 (leftmost bit)
     ///
-    @Time(1) @Space(1)
     pub def clearBit(pos: {pos = Int32}, x: Int8): Int8 = x &&& ~~~(1i8 <<< pos.pos)
 
     ///
@@ -268,14 +245,12 @@ namespace Int8 {
     /// Considers the 5 rightmost bits of `pos` (`pos` mod 32).
     /// The bits of x have positions: 0 (rightmost bit) - 7 (leftmost bit)
     ///
-    @Time(1) @Space(1)
     pub def flipBit(pos: {pos = Int32}, x: Int8): Int8 = x ^^^ (1i8 <<< pos.pos)
 
     ///
     /// Returns the integer binary logarithm of `x`.
     /// If the given value is 0 or negative, 0 is returned.
     ///
-    @Time(1) @Space(1)
     pub def log2(x: Int8): Int8 =
         if (x <= 0i8) {
             0i8
@@ -287,20 +262,17 @@ namespace Int8 {
     ///
     /// Returns the factorial of `x`.
     ///
-    @Time(factorial(x)) @Space(1)
     pub def factorial(x: Int8): Int32 = toInt32(x) |> Int32.factorial
 
     ///
     /// Return a string representation of `x`.
     ///
-    @Time(1) @Space(1)
     pub def toString(x: Int8): String = ToString.toString(x)
 
     ///
     /// Parse the string `s` as an Int8, leading or trailing whitespace is trimmed.
     /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
     ///
-    @Time(1) @Space(1)
     pub def fromString(s: String): Option[Int8] = try {
         import java.lang.String.strip(): String \ {};
         import static java.lang.Byte.parseByte(String): Int8 \ {};
@@ -314,7 +286,6 @@ namespace Int8 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toInt16(x: Int8): Int16 =
         import static java.lang.Byte.valueOf(Int8): ##java.lang.Byte \ {};
         import java.lang.Byte.shortValue(): Int16 \ {};
@@ -325,7 +296,6 @@ namespace Int8 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toInt32(x: Int8): Int32 =
         import static java.lang.Byte.valueOf(Int8): ##java.lang.Byte \ {};
         import java.lang.Byte.intValue(): Int32 \ {};
@@ -336,7 +306,6 @@ namespace Int8 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toInt64(x: Int8): Int64 =
         import static java.lang.Byte.valueOf(Int8): ##java.lang.Byte \ {};
         import java.lang.Byte.longValue(): Int64 \ {};
@@ -347,7 +316,6 @@ namespace Int8 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toBigInt(x: Int8): BigInt =
         import static java.lang.Byte.valueOf(Int8): ##java.lang.Byte \ {} as i8ValueOf;
         import java.lang.Byte.longValue(): Int64 \ {};
@@ -359,7 +327,6 @@ namespace Int8 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toFloat32(x: Int8): Float32 =
         import static java.lang.Byte.valueOf(Int8): ##java.lang.Byte \ {};
         import java.lang.Byte.floatValue(): Float32 \ {};
@@ -370,7 +337,6 @@ namespace Int8 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toFloat64(x: Int8): Float64 =
         import static java.lang.Byte.valueOf(Int8): ##java.lang.Byte \ {};
         import java.lang.Byte.doubleValue(): Float64 \ {};
@@ -381,7 +347,6 @@ namespace Int8 {
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
-    @Time(1) @Space(1)
     pub def toBigDecimal(x: Int8): BigDecimal =
         import new java.math.BigDecimal(Int32): BigDecimal \ {} as fromInt32;
         Int8.toInt32(x) |> fromInt32

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -135,7 +135,6 @@ namespace List {
     ///
     /// Returns true if and only if `l` is the empty list, i.e. `Nil`.
     ///
-    @Time(1) @Space(1)
     pub def isEmpty(l: List[a]): Bool = match l {
         case Nil => true
         case _   => false
@@ -146,7 +145,6 @@ namespace List {
     ///
     /// Returns `None` if `l` is empty.
     ///
-    @Time(1) @Space(1)
     pub def head(l: List[a]): Option[a] = match l {
         case Nil    => None
         case x :: _ => Some(x)
@@ -157,7 +155,6 @@ namespace List {
     ///
     /// Returns `None` if `l` is empty.
     ///
-    @Time(length(l)) @Space(1)
     pub def last(l: List[a]): Option[a] = match l {
         case Nil      => None
         case x :: Nil => Some(x)
@@ -167,7 +164,6 @@ namespace List {
     ///
     /// Returns the length of `l`.
     ///
-    @Time(length(l)) @Space(1)
     pub def length(l: List[a]): Int32 =
         def loop(ll, acc) = match ll {
             case Nil     => acc
@@ -180,14 +176,12 @@ namespace List {
     ///
     /// The infix operator `:::` is an alias for `append` (`l1 ::: l2 = append(l1, l2)`).
     ///
-    @Time(length(l1)) @Space(length(l1))
     pub def append(l1: List[a], l2: List[a]): List[a] =
         foldRight((x, acc) -> x :: acc, l2, l1)
 
     ///
     /// Returns `true` if and only if `l` contains the element `x`.
     ///
-    @Time(length(l)) @Space(1)
     pub def memberOf(a: a, l: List[a]): Bool with Eq[a] = match l {
         case Nil     => false
         case x :: xs => if (a == x) true else memberOf(a, xs)
@@ -238,13 +232,11 @@ namespace List {
     ///
     /// Alias for `findLeft`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f))
     pub def find(f: a -> Bool \ ef, l: List[a]): Option[a] \ ef = findLeft(f, l)
 
     ///
     /// Optionally returns the first element of `l` that satisfies the predicate `f` when searching from left to right.
     ///
-    @Time(time(f) * length(l)) @Space(space(f))
     pub def findLeft(f: a -> Bool \ ef, l: List[a]): Option[a] \ ef = match l {
         case Nil     => None
         case x :: xs => if (f(x)) Some(x) else findLeft(f, xs)
@@ -253,7 +245,6 @@ namespace List {
     ///
     /// Optionally returns the first element of `l` that satisfies the predicate `f` when searching from right to left.
     ///
-    @Time(time(f) * length(l)) @Space(space(f))
     pub def findRight(f: a -> Bool \ ef, l: List[a]): Option[a] \ ef =
         def loop(ll, k) = match ll {
             case Nil     => k()
@@ -266,7 +257,6 @@ namespace List {
     ///
     /// Returns `Nil` if `b >= e`.
     ///
-    @Time(e - b) @Space(e - b)
     pub def range(b: Int32, e: Int32): List[Int32] =
         def loop(i, acc) =
             if (i < b)
@@ -280,7 +270,6 @@ namespace List {
     ///
     /// Returns `Nil` if `n < 0`.
     ///
-    @Time(n) @Space(n)
     pub def repeat(n: Int32, a: a): List[a] =
         def loop(i, acc) =
             if (i >= n)
@@ -385,7 +374,6 @@ namespace List {
     ///
     /// That is, the result is of the form: `f(x1, 0) :: f(x2, 1) :: ...`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f) * length(l))
     pub def mapWithIndex(f: (Int32, a) -> b \ ef, l: List[a]): List[b] \ ef =
         def loop(ll, i, k) = match ll {
             case Nil     => k(Nil)
@@ -398,7 +386,6 @@ namespace List {
     ///
     /// Returns the result of applying `f` to every element in `l` and concatenating the results.
     ///
-    @Time(time(f) * length(l)) @Space(time(f) * length(l))
     pub def flatMap(f: a -> List[b] \ ef, l: List[a]): List[b] \ ef =
         def loop(ll, acc) = match ll {
             case Nil     => acc
@@ -409,7 +396,6 @@ namespace List {
     ///
     /// Returns the reverse of `l`.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def reverse(l: List[a]): List[a] =
         def loop(ll, acc) = match ll {
             case Nil     => acc
@@ -423,7 +409,6 @@ namespace List {
     /// That is, returns a new list where the first `n mod length(l)` elements in `l`
     /// are the last `n mod length(l)` elements of the new list.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def rotateLeft(n: Int32, l: List[a]): List[a] =
         let len = length(l);
         if (len == 0)
@@ -440,7 +425,6 @@ namespace List {
     /// That is, returns a new list where the last `n mod length(l)` elements in `l`
     /// are the first `n mod length(l)` elements of the new list.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def rotateRight(n: Int32, l: List[a]): List[a] = rotateLeft(-n, l)
 
     ///
@@ -448,7 +432,6 @@ namespace List {
     ///
     /// Returns `l` if `i < 0` or `i > length(l)-1`.
     ///
-    @Time(i) @Space(i)
     pub def update(i: Int32, a: a, l: List[a]): List[a] =
         def loop(ll, j, k) = match (j, ll) {
             case (_, Nil)     => k(Nil)
@@ -460,7 +443,6 @@ namespace List {
     ///
     /// Returns `l` with every occurrence of `from` replaced by `to`.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def replace(from: {from = a}, to: {to = a}, l: List[a]): List[a] with Eq[a] = map(e -> if (e == from.from) to.to else e, l)
 
     ///
@@ -470,7 +452,6 @@ namespace List {
     /// If `l1` becomes depleted then no further patching is done.
     /// If patching occurs at index `i+j` in `l2`, then the element at index `j` in `l1` is used.
     ///
-    @Time(n) @Space(length(l2))
     pub def patch(i: Int32, n: Int32, l1: List[a], l2: List[a]): List[a] =
         def loop(ll1, ll2, c, k) = match (ll1, ll2) {
             case (x :: xs, y :: ys) => {
@@ -488,7 +469,6 @@ namespace List {
     ///
     /// That is, `l` is the first permutation and `reverse(l)` is the last permutation.
     ///
-    @Time(Int32.factorial(length(l))) @Space(Int32.factorial(length(l)))
     pub def permutations(l: List[a]): List[List[a]] = match l {
         case Nil => Nil :: Nil
         case _   => permutationHelper(0, l)
@@ -527,7 +507,6 @@ namespace List {
     ///
     /// That is, `l` is the first subsequence and `Nil` is the last subsequence.
     ///
-    @Time(length(l) * length(l)) @Space(length(l) * length(l))
     pub def subsequences(l: List[a]): List[List[a]] = match l {
         case Nil     => Nil :: Nil
         case x :: xs =>
@@ -549,7 +528,6 @@ namespace List {
     ///
     /// Returns `l` with `x` inserted between every two adjacent elements.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def intersperse(a: a, l: List[a]): List[a] =
         def loop(ll, k) = match ll {
             case x1 :: x2 :: xs => loop(x2 :: xs, ks -> k(x1 :: a :: ks))
@@ -562,7 +540,6 @@ namespace List {
     ///
     /// That is, returns `y1 :: x1 ... xn :: y2 :: ... yn-1 :: x1 :: ... :: xn :: yn :: Nil`.
     ///
-    @Time(length(l2) * length(l1)) @Space(length(l2) * length(l1))
     pub def intercalate(l1: List[a], l2: List[List[a]]): List[a] =
         def loop(ll, k) = match ll {
             case Nil            => k(Nil)
@@ -576,7 +553,6 @@ namespace List {
     ///
     /// Returns `l` if the dimensions of the elements of `l` are mismatched.
     ///
-    @Time(length(l) * length(l)) @Space(length(l) * length(l))
     pub def transpose(l: List[List[a]]): List[List[a]] = match l {
         case Nil    => Nil
         case x :: _ =>
@@ -612,7 +588,6 @@ namespace List {
     ///
     /// Returns `true` if and only if `l1` is a prefix of `l2`.
     ///
-    @Time(length(l1)) @Space(1)
     pub def isPrefixOf(l1: List[a], l2: List[a]): Bool with Eq[a] = match (l1, l2) {
         case (Nil, _)           => true
         case (_, Nil)           => false
@@ -622,7 +597,6 @@ namespace List {
     ///
     /// Returns `true` if and only if `l1` is an infix of `l2`.
     ///
-    @Time(length(l1)) @Space(1)
     pub def isInfixOf(l1: List[a], l2: List[a]): Bool with Eq[a] = match (l1, l2) {
         case (Nil, _)     => true
         case (_, Nil)     => false
@@ -632,7 +606,6 @@ namespace List {
     ///
     /// Returns `true` if and only if `l1` is a suffix of `l2`.
     ///
-    @Time(length(l1)) @Space(Int32.max(length(l1), length(l2)))
     pub def isSuffixOf(l1: List[a], l2: List[a]): Bool with Eq[a] = isPrefixOf(reverse(l1), reverse(l2))
 
     ///
@@ -706,7 +679,6 @@ namespace List {
     ///
     /// Returns the number of elements in `l` that satisfy the predicate `f`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f) * length(l))
     pub def count(f: a -> Bool \ ef, l: List[a]): Int32 \ ef =
         foldLeft((acc, x) -> if (f(x)) acc + 1 else acc, 0, l)
 
@@ -725,7 +697,6 @@ namespace List {
     ///
     /// Returns the concatenation of the elements in `l`.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def flatten(l: List[List[a]]): List[a] =
         def loop(ll, k) = match ll {
             case Nil     => k(Nil)
@@ -738,7 +709,6 @@ namespace List {
     ///
     /// Returns `false` if `l` is empty.
     ///
-    @Time(time(f) * length(l)) @Space(space(f))
     pub def exists(f: a -> Bool \ ef, l: List[a]): Bool \ ef = match l {
         case Nil     => false
         case x :: xs => if (f(x)) true else exists(f, xs)
@@ -749,7 +719,6 @@ namespace List {
     ///
     /// Returns `true` if `l` is empty.
     ///
-    @Time(time(f) * length(l)) @Space(space(f))
     pub def forAll(f: a -> Bool \ ef, l: List[a]): Bool \ ef = match l {
         case Nil     => true
         case x :: xs => if (f(x)) forAll(f, xs) else false
@@ -758,7 +727,6 @@ namespace List {
     ///
     /// Returns a list of every element in `l` that satisfies the predicate `f`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f) * length(l))
     pub def filter(f: a -> Bool \ ef, l: List[a]): List[a] \ ef =
         def loop(ll, k) = match ll {
             case Nil     => k(Nil)
@@ -770,7 +738,6 @@ namespace List {
     /// Returns the sublist of `l` without the last element.
     /// Returns `None` if the list `l` is `Nil`.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def init(l: List[a]): Option[List[a]] =
         def loop(ll, k) = match ll {
             case Nil      => None
@@ -785,7 +752,6 @@ namespace List {
     /// That is, an element at index `i` in `l` is part of the returned sublist if and only if `i >= b` and `i < e`.
     /// Note: Indices that are out of bounds in `l` are not considered (i.e. slice(b, e, l) = slice(max(0,b), min(length(l),e), l)).
     ///
-    @Time(e - b) @Space(e - b)
     pub def slice(b: Int32, e: Int32, l: List[a]): List[a] =
         def loop(ll, i, k) = match ll {
             case Nil     => k(Nil)
@@ -805,7 +771,6 @@ namespace List {
     /// `l1` contains all elements of `l` that satisfy the predicate `f`.
     /// `l2` contains all elements of `l` that do not satisfy the predicate `f`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f) * length(l))
     pub def partition(f: a -> Bool \ ef, l: List[a]): (List[a], List[a]) \ ef =
         def loop(ll, k) = match ll {
             case Nil     => k((Nil, Nil))
@@ -825,7 +790,6 @@ namespace List {
     ///
     /// The function `f` must be pure.
     ///
-    @Time(time(f) * length(l)) @Space(space(f) * length(l))
     pub def span(f: a -> Bool, l: List[a]): (List[a], List[a]) =
         def loop(ll, k) = match ll {
             case Nil     => k((Nil, Nil))
@@ -843,7 +807,6 @@ namespace List {
     /// Returns `Nil` if `n > length(l)`.
     /// Returns `l` if `n < 0`.
     ///
-    @Time(n) @Space(length(l) - n)
     pub def drop(n: Int32, l: List[a]): List[a] = match l {
         case _ if n <= 0 => l
         case Nil         => Nil
@@ -853,7 +816,6 @@ namespace List {
     ///
     /// Returns `l` without the longest prefix that satisfies the predicate `f`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f))
     pub def dropWhile(f: a -> Bool \ ef, l: List[a]): List[a] \ ef = match l {
         case Nil     => Nil
         case x :: xs => if (f(x)) dropWhile(f, xs) else l
@@ -865,7 +827,6 @@ namespace List {
     /// Returns `l` if `n > length(l)`.
     /// Returns `Nil` if `n < 0`.
     ///
-    @Time(n) @Space(n)
     pub def take(n: Int32, l: List[a]): List[a] =
         def loop(ll, i, k) =
             if (i <= 0)
@@ -880,7 +841,6 @@ namespace List {
     ///
     /// Returns the longest prefix of `l` that satisfies the predicate `f`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f) * length(l))
     pub def takeWhile(f: a -> Bool \ ef, l: List[a]): List[a] \ ef =
         def loop(ll, k) = match ll {
             case Nil     => k(Nil)
@@ -908,7 +868,6 @@ namespace List {
     ///
     /// The function `f` must be pure.
     ///
-    @Time(time(f) * length(l)) @Space(space(f) * length(l))
     pub def groupBy(f: (a, a) -> Bool, l: List[a]): List[List[a]] =
         def loop(ll, k) = match ll {
             case Nil     => k(Nil)
@@ -945,7 +904,6 @@ namespace List {
     ///
     /// If either `l1` or `l2` becomes depleted, then no further elements are added to the resulting list.
     ///
-    @Time(Int32.min(length(l1), length(l2))) @Space(Int32.min(length(l1), length(l2)))
     pub def zip(l1: List[a], l2: List[b]): List[(a, b)] =
         def loop(ll1, ll2, k) = match (ll1, ll2) {
             case (x :: xs, y :: ys) => loop(xs, ys, ks -> k((x, y) :: ks))
@@ -959,7 +917,6 @@ namespace List {
     ///
     /// If either `l1` or `l2` becomes depleted, then no further elements are added to the resulting list.
     ///
-    @Time(time(f) * Int32.min(length(l1), length(l2))) @Space(space(f) * Int32.min(length(l1), length(l2)))
     pub def zipWith(f: (a, b) -> c \ ef, l1: List[a], l2: List[b]): List[c] \ ef =
         def loop(ll1, ll2, k) = match (ll1, ll2) {
             case (x :: xs, y :: ys) =>
@@ -973,7 +930,6 @@ namespace List {
     /// Returns a list where each element `e` is mapped to `(e, i)` where `i`
     /// is the index of `e`.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def zipWithIndex(l: List[a]): List[(a, Int32)] =
         def loop(ll, i, k) = match ll {
             case Nil       => k(Nil)
@@ -999,7 +955,6 @@ namespace List {
     /// Returns a pair of lists, the first containing all first components in `l`
     /// and the second containing all second components in `l`.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def unzip(l: List[(a, b)]): (List[a], List[b]) =
         def loop(ll, k) = match ll {
             case Nil            => k((Nil, Nil))
@@ -1048,14 +1003,12 @@ namespace List {
     ///
     /// Alias for `foldLeft2`.
     ///
-    @Time(time(f) * Int32.min(length(l1), length(l2))) @Space(space(f) * Int32.min(length(l1), length(l2)))
     pub def fold2(f: (c, a, b) -> c \ ef, c: c, l1: List[a], l2: List[b]): c \ ef = foldLeft2(f, c, l1, l2)
 
     ///
     /// Accumulates the result of applying `f` pairwise to the elements of `l1` and `l2`
     /// starting with the initial value `c` and going from left to right.
     ///
-    @Time(time(f) * Int32.min(length(l1), length(l2))) @Space(space(f) * Int32.min(length(l1), length(l2)))
     pub def foldLeft2(f: (c, a, b) -> c \ ef, c: c, l1: List[a], l2: List[b]): c \ ef = match (l1, l2) {
         case (x :: xs, y :: ys) => foldLeft2(f, f(c, x, y), xs, ys)
         case _                  => c
@@ -1065,7 +1018,6 @@ namespace List {
     /// Accumulates the result of applying `f` pairwise to the elements of `l1` and `l2`
     /// starting with the initial value `c` and going from right to left.
     ///
-    @Time(time(f) * Int32.min(length(l1), length(l2))) @Space(space(f) * Int32.min(length(l1), length(l2)))
     pub def foldRight2(f: (a, b, c) -> c \ ef, c: c, l1: List[a], l2: List[b]): c \ ef =
         def loop(ll1, ll2, k) = match (ll1, ll2) {
             case (x :: xs, y :: ys) => loop(xs, ys, ks -> k(f(x, y, ks)))
@@ -1084,7 +1036,6 @@ namespace List {
     ///
     /// Collects the results of applying the partial function `f` to every element in `l`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f) * length(l))
     pub def filterMap(f: a -> Option[b] \ ef, l: List[a]): List[b] \ ef =
         def loop(ll, k) = match ll {
             case Nil     => k(Nil)
@@ -1100,7 +1051,6 @@ namespace List {
     ///
     /// Returns `None` if every element of `l` is `None`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f))
     pub def findMap(f: a -> Option[b] \ ef, l: List[a]): Option[b] \ ef = match l {
         case Nil     => None
         case x :: xs => match f(x) {
@@ -1155,7 +1105,6 @@ namespace List {
     ///
     /// Returns the list `l` as a set.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def toSet(l: List[a]): Set[a] with Order[a] =
         foldRight((x, acc) -> Set.insert(x, acc), Set.empty(), l)
 
@@ -1165,7 +1114,6 @@ namespace List {
     /// If `l` contains multiple mappings with the same key, `toMap` does not
     /// make any guarantees about which mapping will be in the resulting map.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def toMap(l: List[(a, b)]): Map[a, b] with Order[a] =
         foldRight((x, acc) -> Map.insert(fst(x), snd(x), acc), Map.empty(), l)
 
@@ -1181,7 +1129,6 @@ namespace List {
     ///
     /// Applies `f` to every element of `l`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def forEach(f: a -> Unit \ ef, l: List[a]): Unit \ ef = match l {
         case Nil     => ()
         case x :: xs => f(x); forEach(f, xs)
@@ -1190,7 +1137,6 @@ namespace List {
     ///
     /// Returns the list `l` as an array.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def toArray(r: Region[r], l: List[a]): Array[a, r] \ Write(r) = match head(l) {
         case None    => [] @ r
         case Some(x) =>

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -148,7 +148,6 @@ namespace Map {
     ///
     /// Returns the size of `m`.
     ///
-    @Time(size(m)) @Space(Int32.log2(size(m)))
     pub def size(m: Map[k, v]): Int32 =
         let Map(xs) = m;
         RedBlackTree.size(xs)
@@ -158,7 +157,6 @@ namespace Map {
     ///
     /// `Map#{}` is syntactic sugar for `empty` (`Map#{} = empty()`).
     ///
-    @Time(1) @Space(1)
     pub def empty(): Map[k, v] = Map(RedBlackTree.empty())
 
     ///
@@ -166,13 +164,11 @@ namespace Map {
     ///
     /// `Map#{k => v}` is syntactic sugar for `singleton` (`Map#{k => v} = singleton(k, v)`).
     ///
-    @Time(1) @Space(1)
     pub def singleton(k: k, v: v): Map[k, v] with Order[k] = insert(k, v, empty())
 
     ///
     /// Returns `true` if and only if `m` is the empty map, i.e. `Map(Nil)`.
     ///
-    @Time(1) @Space(1)
     pub def isEmpty(m: Map[k, v]): Bool =
         let Map(t) = m;
         RedBlackTree.isEmpty(t)
@@ -182,7 +178,6 @@ namespace Map {
     ///
     /// Otherwise returns `None`.
     ///
-    @Time(Int32.log2(size(m))) @Space(1)
     pub def get(k: k, m: Map[k, v]): Option[v] with Order[k] =
         let Map(t) = m;
         RedBlackTree.get(k, t)
@@ -192,13 +187,11 @@ namespace Map {
     ///
     /// Otherwise, returns `d`.
     ///
-    @Time(Int32.log2(size(m))) @Space(1)
     pub def getWithDefault(k: k, d: v, m: Map[k, v]): v with Order[k] = Option.getWithDefault(d, get(k, m))
 
     ///
     /// Returns `true` if and only if `m` contains the key `k`.
     ///
-    @Time(Int32.log2(size(m))) @Space(1)
     pub def memberOf(k: k, m: Map[k, v]): Bool with Order[k] =
         let Map(t) = m;
         RedBlackTree.memberOf(k, t)
@@ -330,21 +323,18 @@ namespace Map {
     ///
     /// Returns the keys of `m`.
     ///
-    @Time(size(m)) @Space(size(m) )
     pub def keysOf(m: Map[k, v]): Set[k] with Order[k] =
         foldLeftWithKey((acc, k, _) -> Set.insert(k, acc), Set.empty(), m)
 
     ///
     /// Returns the values of `m`.
     ///
-    @Time(size(m)) @Space(size(m))
     pub def valuesOf(m: Map[k, v]): List[v] =
         foldRight((v, acc) -> v :: acc, Nil, m)
 
     ///
     /// Updates `m` with `k => v`.
     ///
-    @Time(Int32.log2(size(m))) @Space(Int32.log2(size(m)))
     pub def insert(k: k, v: v, m: Map[k, v]): Map[k, v] with Order[k] =
         let Map(t) = m;
         Map(RedBlackTree.insert(k, v, t))
@@ -354,7 +344,6 @@ namespace Map {
     ///
     /// Otherwise, updates `m` with `k => v`.
     ///
-    @Time(time(f) + Int32.log2(size(m))) @Space(space(f) + Int32.log2(size(m)))
     pub def insertWith(f: (v, v) -> v \ ef, k: k, v: v, m: Map[k, v]): Map[k, v] \ ef with Order[k] =
         insertWithKey((_, v1, v2) -> f(v1, v2), k, v, m)
 
@@ -363,7 +352,6 @@ namespace Map {
     ///
     /// Otherwise, updates `m` with `k => v`.
     ///
-    @Time(time(f) + Int32.log2(size(m))) @Space(space(f) + Int32.log2(size(m)))
     pub def insertWithKey(f: (k, v, v) -> v \ ef, k: k, v: v, m: Map[k, v]): Map[k, v] \ ef with Order[k] =
         let Map(t) = m;
         Map(RedBlackTree.insertWith(f, k, v, t))
@@ -373,28 +361,24 @@ namespace Map {
     ///
     /// Otherwise, returns `m`.
     ///
-    @Time(time(f) + Int32.log2(size(m))) @Space(space(f) + Int32.log2(size(m)))
     pub def adjust(f: v -> v \ ef, k: k, m: Map[k, v]): Map[k, v] \ ef with Order[k] =
         adjustWithKey((_, v1) -> f(v1), k, m)
 
     ///
     /// Updates `m` with `k => f(k, v)` if `k => v` is in `m`. Otherwise, returns `m`.
     ///
-    @Time(time(f) + Int32.log2(size(m))) @Space(space(f) + Int32.log2(size(m)))
     pub def adjustWithKey(f: (k, v) -> v \ ef, k: k, m: Map[k, v]): Map[k, v] \ ef with Order[k] =
         updateWithKey((k1, v) -> Some(f(k1, v)), k, m)
 
     ///
     /// Updates `m` with `k => v1` if `k => v` is in `m` and `f(v) = Some(v1)`. Otherwise, returns `m`.
     ///
-    @Time(time(f) + Int32.log2(size(m))) @Space(space(f) + Int32.log2(size(m)))
     pub def update(f: v -> Option[v] \ ef, k: k, m: Map[k, v]): Map[k, v] \ ef with Order[k] =
         updateWithKey((_, v1) -> f(v1), k, m)
 
     ///
     /// Updates `m` with `k => v1` if `k => v` is in `m` and `f(k, v) = Some(v1)`. Otherwise, returns `m`.
     ///
-    @Time(time(f) + Int32.log2(size(m))) @Space(space(f) + Int32.log2(size(m)))
     pub def updateWithKey(f: (k, v) -> Option[v] \ ef, k: k, m: Map[k, v]): Map[k, v] \ ef with Order[k] =
         let Map(t) = m;
         Map(RedBlackTree.updateWith(f, k, t))
@@ -402,7 +386,6 @@ namespace Map {
     ///
     /// Removes the mapping `k` from the map `m`.
     ///
-    @Time(Int32.log2(size(m))) @Space(Int32.log2(size(m)))
     pub def remove(k: k, m: Map[k, v]): Map[k, v] with Order[k] =
         let Map(t) = m;
         Map(RedBlackTree.remove(k, t))
@@ -410,26 +393,22 @@ namespace Map {
     ///
     /// Returns `true` if and only if all mappings in `m1` occur in `m2`.
     ///
-    @Time(size(m1)) @Space(size(m1) * Int32.log2(size(m2)))
     pub def isSubmapOf(m1: Map[k, v], m2: Map[k, v]): Bool with Order[k], Eq[v] = forAll((k, v) -> get(k, m2) == Some(v), m1)
 
     ///
     /// Returns `true` if and only if all mappings in `m1` occur in `m2` and `m1 != m2`.
     ///
-    @Time(size(m1) + size(m2)) @Space(size(m1) * Int32.log2(size(m2)))
     pub def isProperSubmapOf(m1: Map[k, v], m2: Map[k, v]): Bool with Order[k], Eq[v] =
         size(m1) != size(m2) and isSubmapOf(m1, m2)
 
     ///
     /// Alias for `findLeft`.
     ///
-    @Time(time(f) * size(m)) @Space(space(f) * Int32.log2(size(m)))
     pub def find(f: (k, v) -> Bool \ ef, m: Map[k, v]): Option[(k, v)] \ ef = findLeft(f, m)
 
     ///
     /// Optionally returns the first mapping of `m` that satisfies the predicate `f` when searching from left to right.
     ///
-    @Time(time(f) * size(m)) @Space(space(f) * Int32.log2(size(m)))
     pub def findLeft(f: (k, v) -> Bool \ ef, m: Map[k, v]): Option[(k, v)] \ ef =
         let Map(t) = m;
         RedBlackTree.findLeft(f, t)
@@ -437,7 +416,6 @@ namespace Map {
     ///
     /// Optionally returns the first mapping of `m` that satisfies the predicate `f` when searching from right to left.
     ///
-    @Time(time(f) * size(m)) @Space(space(f) * Int32.log2(size(m)))
     pub def findRight(f: (k, v) -> Bool \ ef, m: Map[k, v]): Option[(k, v)] \ ef =
         let Map(t) = m;
         RedBlackTree.findRight(f, t)
@@ -445,13 +423,11 @@ namespace Map {
     ///
     /// Returns a map of all mappings `k => v` in `m` where `v` satisfies the predicate `f`.
     ///
-    @Time(time(f) * size(m)) @Space(space(f) * size(m))
     pub def filter(f: v -> Bool \ ef, m: Map[k, v]): Map[k, v] \ ef with Order[k] = filterWithKey((_, v) -> f(v), m)
 
     ///
     /// Returns a map of all mappings `k => v` in `m` where `(k, v)` satisfies the predicate `f`.
     ///
-    @Time(time(f) * size(m)) @Space(space(f) * size(m))
     pub def filterWithKey(f: (k, v) -> Bool \ ef, m: Map[k, v]): Map[k, v] \ ef with Order[k] =
         foldLeftWithKey((acc, k, v) -> if (f(k, v)) insert(k, v, acc) else acc, empty(), m)
 
@@ -482,7 +458,6 @@ namespace Map {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
-    @Time(time(f) * size(m)) @Space(space(f) * size(m))
     @ParallelWhenPure
     pub def map(f: v1 -> v2 \ ef, m: Map[k, v1]): Map[k, v2] \ ef = mapWithKey((_, v) -> f(v), m)
 
@@ -491,7 +466,6 @@ namespace Map {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
-    @Time(time(f) * size(m)) @Space(space(f) * size(m))
     @ParallelWhenPure
     pub def mapWithKey(f: (k, v1) -> v2 \ ef, m: Map[k, v1]): Map[k, v2] \ ef =
         let Map(t) = m;
@@ -699,7 +673,7 @@ namespace Map {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
-    @ParallelWhenPure @Time(time(f) * size(m)) @Space(space(f) * Int32.log2(size(m)))
+    @ParallelWhenPure
     pub def exists(f: (k, v) -> Bool \ ef, m: Map[k, v]): Bool \ ef =
         let Map(t) = m;
         def e() = RedBlackTree.exists(f, t);
@@ -720,7 +694,7 @@ namespace Map {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
-    @ParallelWhenPure @Time(time(f) * size(m)) @Space(space(f) * Int32.log2(size(m)))
+    @ParallelWhenPure
     pub def forAll(f: (k, v) -> Bool \ ef, m: Map[k, v]): Bool \ ef =
         let Map(t) = m;
         def fa() = RedBlackTree.forAll(f, t);
@@ -739,21 +713,18 @@ namespace Map {
     ///
     /// That is, key collisions are resolved by taking the mapping from `m1`.
     ///
-    @Time(size(m1) * Int32.log2(size(m2))) @Space(size(m1) * Int32.log2(size(m2)))
     pub def union(m1: Map[k, v], m2: Map[k, v]): Map[k, v] with Order[k] =
         unionWithKey((_, v1, _) -> v1, m1, m2)
 
     ///
     /// Returns the union of `m1` and `m2` where key collisions are resolved with the merge function `f`.
     ///
-    @Time(time(f) * size(m1) * Int32.log2(size(m2))) @Space(space(f) * size(m1) *  Int32.log2(size(m2)))
     pub def unionWith(f: (v, v) -> v \ ef, m1: Map[k, v], m2: Map[k, v]): Map[k, v] \ ef with Order[k] =
         unionWithKey((_, v1, v2) -> f(v1, v2), m1, m2)
 
     ///
     /// Returns the union of `m1` and `m2` where key collisions are resolved with the merge function `f`, taking both the key and values.
     ///
-    @Time(time(f) * size(m1) * Int32.log2(size(m2))) @Space(space(f) * size(m1) *  Int32.log2(size(m2)))
     pub def unionWithKey(f: (k, v, v) -> v \ ef, m1: Map[k, v], m2: Map[k, v]): Map[k, v] \ ef with Order[k] =
         use RedBlackTree.{blackHeight, foldRight, insertWith};
         let Map(t1) = m1;
@@ -768,21 +739,18 @@ namespace Map {
     ///
     /// That is, key collisions are resolved by taking the mapping from `m1`.
     ///
-    @Time(size(m1) * Int32.log2(size(m2))) @Space(size(m1) * Int32.log2(size(m2)))
     pub def intersection(m1: Map[k, v], m2: Map[k, v]): Map[k, v] with Order[k] =
         intersectionWithKey((_, v1, _) -> v1, m1, m2)
 
     ///
     /// Returns the intersection of `m1` and `m2` where key collisions are resolved with the merge function `f`.
     ///
-    @Time(time(f) * size(m1) * Int32.log2(size(m2))) @Space(space(f) * size(m1) *  Int32.log2(size(m2)))
     pub def intersectionWith(f: (v, v) -> v \ ef, m1: Map[k, v], m2: Map[k, v]): Map[k, v] \ ef with Order[k] =
         intersectionWithKey((_, v1, v2) -> f(v1, v2), m1, m2)
 
     ///
     /// Returns the intersection of `m1` and `m2` where key collisions are resolved with the merge function `f`, taking both the key and values.
     ///
-    @Time(time(f) * size(m1) * Int32.log2(size(m2))) @Space(space(f) * size(m1) *  Int32.log2(size(m2)))
     pub def intersectionWithKey(f: (k, v, v) -> v \ ef, m1: Map[k, v], m2: Map[k, v]): Map[k, v] \ ef with Order[k] =
         let intersect = filterWithKey((k, _) -> memberOf(k, m1), m2);
         foldRightWithKey((k, v, acc) -> adjustWithKey((key, v1) -> f(key, v, v1), k, acc), intersect, m1)
@@ -792,7 +760,6 @@ namespace Map {
     ///
     /// That is, returns the map `m1` with the keys removed that are in `m2`.
     ///
-    @Time(size(m2) * Int32.log2(size(m1))) @Space(size(m2) * Int32.log2(size(m1)))
     pub def difference(m1: Map[k, v], m2: Map[k, v]): Map[k, v] with Order[k] =
         differenceWithKey((_, _, _) -> None, m1, m2)
 
@@ -803,7 +770,6 @@ namespace Map {
     /// If `f` returns `None` the mapping with `k` is thrown away (proper set difference).
     /// If `f` returns `Some(v)` the mapping `k => v` is included in the result.
     ///
-    @Time(size(f) * size(m2) * Int32.log2(size(m1))) @Space(space(f) * size(m2) * Int32.log2(size(m1)))
     pub def differenceWith(f: (v, v) -> Option[v] \ ef, m1: Map[k, v], m2: Map[k, v]): Map[k, v] \ ef with Order[k] =
         differenceWithKey((_, v1, v2) -> f(v1, v2), m1, m2)
 
@@ -814,7 +780,6 @@ namespace Map {
     /// If `f` returns `None` the mapping with `k` is thrown away (proper set difference).
     /// If `f` returns `Some(v)` the mapping `k => v` is included in the result.
     ///
-    @Time(size(f) * size(m2) * Int32.log2(size(m1))) @Space(space(f) * size(m2) * Int32.log2(size(m1)))
     pub def differenceWithKey(f: (k, v, v) -> Option[v] \ ef, m1: Map[k, v], m2: Map[k, v]): Map[k, v] \ ef with Order[k] =
         let diff = filterWithKey((k, _) -> not memberOf(k, m2), m1);
         let g = (k, v, acc) -> if (memberOf(k, m1))
@@ -841,21 +806,18 @@ namespace Map {
     ///
     /// Returns `m` as a mutable set.
     ///
-    @Time(1) @Space(1)
     pub def toMutMap(r: Region[r], m: Map[k, v]): MutMap[k, v, r] \ Write(r) =
         MutMap(ref m @ r)
 
     ///
     /// Returns the map `m` as a list of key-value pairs.
     ///
-    @Time(size(m)) @Space(size(m))
     pub def toList(m: Map[k, v]): List[(k, v)] =
         foldRightWithKey((k, v, acc) -> (k, v) :: acc, Nil, m)
 
     ///
     /// Returns the map `m` as a set of key-value pairs.
     ///
-    @Time(size(m)) @Space(size(m))
     pub def toSet(m: Map[k, v]): Set[(k, v)] with Order[k], Order[v] =
         foldLeftWithKey((acc, k, v) -> Set.insert((k, v), acc), Set.empty(), m)
 
@@ -888,7 +850,6 @@ namespace Map {
     ///
     /// Applies `f` to every element of `xs`.
     ///
-    @Time(size(f) * size(m)) @Space(space(f) * Int32.log2(size(m)))
     pub def forEach(f: (k, v) -> Unit \ ef, m: Map[k, v]): Unit \ ef =
         let Map(t) = m;
         RedBlackTree.forEach(f, t)

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -134,13 +134,11 @@ namespace Nel {
     ///
     /// Returns a new non-empty list containing the single element `x`.
     ///
-    @Time(1) @Space(1)
     pub def singleton(x: a): Nel[a] = Nel(x, Nil)
 
     ///
     /// Returns the non-empty list `l` prefixed with the new element `x`.
     ///
-    @Time(1) @Space(1)
     pub def cons(x: a, l: Nel[a]): Nel[a] = match l {
         case Nel(y, ys) => Nel(x, y :: ys)
     }
@@ -148,7 +146,6 @@ namespace Nel {
     ///
     /// Returns the first element of `l`.
     ///
-    @Time(1) @Space(1)
     pub def head(l: Nel[a]): a = match l {
         case Nel(x, _) => x
     }
@@ -156,7 +153,6 @@ namespace Nel {
     ///
     /// Returns the last element of `l`.
     ///
-    @Time(length(l)) @Space(1)
     pub def last(l: Nel[a]): a = match l {
         case Nel(x, xs) => Option.getWithDefault(x, List.last(xs))
     }
@@ -164,7 +160,6 @@ namespace Nel {
     ///
     /// Returns all elements in `l` without the last element.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def init(l: Nel[a]): List[a] = match l {
         case Nel(_, Nil) => Nil
         case Nel(x, xs)   => match List.reverse(xs) {
@@ -176,7 +171,6 @@ namespace Nel {
     ///
     /// Returns all elements in `l` without the first element.
     ///
-    @Time(1) @Space(1)
     pub def tail(l: Nel[a]): List[a] = match l {
         case Nel(_, xs) => xs
     }
@@ -184,7 +178,6 @@ namespace Nel {
     ///
     /// Returns the length of `l`.
     ///
-    @Time(length(l)) @Space(1)
     pub def length(l: Nel[a]): Int32 = match l {
         case Nel(_, xs) => 1 + List.length(xs)
     }
@@ -192,7 +185,6 @@ namespace Nel {
     ///
     /// Returns `l2` appended to `l1`.
     ///
-    @Time(length(l1)) @Space(length(l1))
     pub def append(l1: Nel[a], l2: Nel[a]): Nel[a] = match (l1, l2) {
         case (Nel(x, xs), Nel(y, ys)) => Nel(x, xs ::: (y :: ys))
     }
@@ -200,7 +192,6 @@ namespace Nel {
     ///
     /// Returns `true` if and only if `l` contains the element `a`.
     ///
-    @Time(length(l)) @Space(1)
     pub def memberOf(a: a, l: Nel[a]): Bool with Eq[a] = match l {
         case Nel(x, xs) => if (x == a) true else List.memberOf(a, xs)
     }
@@ -232,13 +223,11 @@ namespace Nel {
     ///
     /// Alias for `findLeft`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f))
     pub def find(f: a -> Bool \ ef, l: Nel[a]): Option[a] \ ef = findLeft(f, l)
 
     ///
     /// Optionally returns the first element of `l` that satisfies the predicate `f` when searching from left to right.
     ///
-    @Time(time(f) * length(l)) @Space(space(f))
     pub def findLeft(f: a -> Bool \ ef, l: Nel[a]): Option[a] \ ef = match l {
         case Nel(x, xs) => if (f(x)) Some(x) else List.findLeft(f, xs)
     }
@@ -246,7 +235,6 @@ namespace Nel {
     ///
     /// Optionally returns the first element of `l` that satisfies the predicate `f` when searching from right to left.
     ///
-    @Time(time(f) * length(l)) @Space(space(f))
     pub def findRight(f: a -> Bool \ ef, l: Nel[a]): Option[a] \ ef = match l {
         case Nel(x, xs) => match List.findRight(f, xs) {
             case None    => if (f(x)) Some(x) else None
@@ -259,7 +247,6 @@ namespace Nel {
     ///
     /// That is, the result is of the form: `f(x1) :: f(x2) :: ...`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f) * length(l))
     pub def map(f: a -> b \ ef, l: Nel[a]): Nel[b] \ ef = match l {
         case Nel(x, xs) => Nel(f(x), List.map(f, xs))
     }
@@ -269,7 +256,6 @@ namespace Nel {
     ///
     /// That is, the result is of the form: `f(x1, 0) :: f(x2, 1) :: ...`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f) * length(l))
     pub def mapWithIndex(f: (Int32, a) -> b \ ef, l: Nel[a]): Nel[b] \ ef =
         let Nel(x, xs) = l;
         match List.mapWithIndex(f, x :: xs) {
@@ -300,7 +286,6 @@ namespace Nel {
     ///
     /// Returns the result of applying `f` to every element in `l` and concatenating the results.
     ///
-    @Time(time(f) * length(l)) @Space(time(f) * length(l))
     pub def flatMap(f: a -> Nel[b] \ ef, l: Nel[a]): Nel[b] \ ef = match l {
         case Nel(x, xs) => match f(x) {
             case Nel(y, ys) => Nel(y, ys ::: List.flatMap(z -> toList(f(z)), xs))
@@ -310,7 +295,6 @@ namespace Nel {
     ///
     /// Returns the reverse of `l`.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def reverse(l: Nel[a]): Nel[a] = match l {
         case Nel(x, xs) => match List.reverse(x :: xs) {
             case y :: ys => Nel(y, ys)
@@ -321,7 +305,6 @@ namespace Nel {
     ///
     /// Returns `l` with every occurrence of `from` replaced by `to`.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def replace(from: {from = a}, to: {to = a}, l: Nel[a]): Nel[a] with Eq[a] =
         map(e -> if (e == from.from) to.to else e, l)
 
@@ -330,7 +313,6 @@ namespace Nel {
     ///
     /// That is, `l` is the first permutation and `reverse(l)` is the last permutation.
     ///
-    @Time(Int32.factorial(length(l))) @Space(Int32.factorial(length(l)))
     pub def permutations(l: Nel[a]): Nel[List[a]] = match l {
         case Nel(x, xs) => match List.permutations(x :: xs) {
             case y :: ys => Nel(y, ys)
@@ -343,7 +325,6 @@ namespace Nel {
     ///
     /// That is, `l` is the first subsequence and `Nil` is the last subsequence.
     ///
-    @Time(length(l) * length(l)) @Space(length(l) * length(l))
     pub def subsequences(l: Nel[a]): Nel[List[a]] = match l {
         case Nel(x, xs) => match List.subsequences(x :: xs) {
             case y :: ys => Nel(y, ys)
@@ -354,7 +335,6 @@ namespace Nel {
     ///
     /// Returns `l` with `a` inserted between every two adjacent elements.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def intersperse(a: a, l: Nel[a]): Nel[a] = match l {
         case Nel(x, Nil)  => Nel(x, Nil)
         case Nel(x, xs)   => Nel(x, a :: List.intersperse(a, xs))
@@ -453,7 +433,6 @@ namespace Nel {
     ///
     /// Returns the number of elements in `l` that satisfy the predicate `f`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f) * length(l))
     pub def count(f: a -> Bool \ ef, l: Nel[a]): Int32 \ ef = match l {
         case Nel(x, xs) => (if (f(x)) 1 else 0) + List.count(f, xs)
     }
@@ -485,7 +464,6 @@ namespace Nel {
     ///
     /// Returns the concatenation of the elements in `l`.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def flatten(l: Nel[Nel[a]]): Nel[a] = match l {
         case Nel(Nel(y, ys), xs) => Nel(y, ys ::: List.flatMap(toList, xs))
     }
@@ -493,7 +471,6 @@ namespace Nel {
     ///
     /// Returns `true` if and only if at least one element in `l` satisfies the predicate `f`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f))
     pub def exists(f: a -> Bool \ ef, l: Nel[a]): Bool \ ef = match l {
         case Nel(x, xs) => if (f(x)) true else List.exists(f, xs)
     }
@@ -501,7 +478,6 @@ namespace Nel {
     ///
     /// Returns `true` if and only if all elements in `l` satisfy the predicate `f`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f))
     pub def forAll(f: a -> Bool \ ef, l: Nel[a]): Bool \ ef = match l {
         case Nel(x, xs) => if (f(x)) List.forAll(f, xs) else false
     }
@@ -509,7 +485,6 @@ namespace Nel {
     ///
     /// Returns a list of every element in `l` that satisfies the predicate `f`.
     ///
-    @Time(time(f) * length(l)) @Space(space(f) * length(l))
     pub def filter(f: a -> Bool, l: Nel[a]): List[a] = match l {
         case Nel(x, xs) =>
             if (f(x))
@@ -524,7 +499,6 @@ namespace Nel {
     ///
     /// If either `l1` or `l2` becomes depleted, then no further elements are added to the resulting list.
     ///
-    @Time(Int32.min(length(l1), length(l2))) @Space(Int32.min(length(l1), length(l2)))
     pub def zip(l1: Nel[a], l2: Nel[b]): Nel[(a,b)] = match (l1, l2) {
         case (Nel(x, xs), Nel(y, ys)) => Nel((x, y), List.zip(xs, ys))
     }
@@ -535,7 +509,6 @@ namespace Nel {
     ///
     /// If either `l1` or `l2` becomes depleted, then no further elements are added to the resulting list.
     ///
-    @Time(time(f) * Int32.min(length(l1), length(l2))) @Space(space(f) * Int32.min(length(l1), length(l2)))
     pub def zipWith(f: (a, b) -> c \ ef, l1: Nel[a], l2: Nel[b]): Nel[c] \ ef = match (l1, l2) {
         case (Nel(x, xs), Nel(y, ys)) => Nel(f(x, y), List.zipWith(f, xs, ys))
     }
@@ -544,7 +517,6 @@ namespace Nel {
     /// Returns a pair of non-empty lists, the first containing all first components in `l`
     /// and the second containing all second components in `l`.
     ///
-    @Time(length(l)) @Space(length(l))
     pub def unzip(l: Nel[(a, b)]): (Nel[a], Nel[b]) =
         let Nel((a, b), xs) = l;
         let (l1, l2) = List.unzip(xs);
@@ -578,7 +550,6 @@ namespace Nel {
     ///
     /// Returns `l` as a normal list.
     ///
-    @Time(1) @Space(1)
     pub def toList(l: Nel[a]): List[a] = match l {
         case Nel(x, xs) => x :: xs
     }
@@ -600,7 +571,6 @@ namespace Nel {
     ///
     /// Applies `f` to every element of `l`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def forEach(f: a -> Unit \ ef, l: Nel[a]): Unit \ ef = match l {
         case Nel(x, xs) => f(x); List.forEach(f, xs)
     }

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -155,7 +155,6 @@ namespace Option {
     ///
     /// Returns `true` iff `o` is `None`.
     ///
-    @Time(1) @Space(1)
     pub def isEmpty(o: Option[a]): Bool = match o {
         case None    => true
         case Some(_) => false
@@ -164,7 +163,6 @@ namespace Option {
     ///
     /// Returns `v` if `o` is `Some(v).` Otherwise returns `d`.
     ///
-    @Time(1) @Space(1)
     pub def getWithDefault(d: a, o: Option[a]): a = match o {
         case None    => d
         case Some(v) => v
@@ -173,7 +171,6 @@ namespace Option {
     ///
     /// Returns `o` if it is `Some(v)`. Otherwise returns `default`.
     ///
-    @Time(1) @Space(1)
     pub def withDefault(default: {default = Option[a]}, o: Option[a]): Option[a] = match o {
         case None    => default.default
         case Some(_) => o
@@ -182,7 +179,6 @@ namespace Option {
     ///
     /// Returns `Some(to)` if `o` is `Some(from)`. Otherwise returns `o`.
     ///
-    @Time(1) @Space(1)
     pub def replace(from: {from = a}, to: {to = a}, o: Option[a]): Option[a] with Eq[a] = match o {
         case None    => o
         case Some(v) => Some(if (v == from.from) to.to else v)
@@ -191,7 +187,6 @@ namespace Option {
     ///
     /// Returns `true` if `o` is `Some(v)` and the predicate `f(v)` evaluates to `true`. Otherwise returns `false`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def exists(f: a -> Bool \ ef, o: Option[a]): Bool \ ef = match o {
         case None    => false
         case Some(v) => f(v)
@@ -202,7 +197,6 @@ namespace Option {
     ///
     /// Otherwise returns `false`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def forAll(f: a -> Bool \ ef, o: Option[a]): Bool \ ef = match o {
         case None    => true
         case Some(v) => f(v)
@@ -211,7 +205,6 @@ namespace Option {
     ///
     /// Returns `o` if `o` is `Some(v)` and the predicate `f(v)` is true. Otherwise returns `None`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def filter(f: a -> Bool \ ef, o: Option[a]): Option[a] \ ef = match o {
         case None    => None
         case Some(v) => if (f(v)) o else None
@@ -220,7 +213,6 @@ namespace Option {
     ///
     /// Returns `Some(f(v))` if `o` is `Some(v)`. Otherwise returns `None`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def map(f: a -> b \ ef, o: Option[a]): Option[b] \ ef = match o {
         case None    => None
         case Some(v) => Some(f(v))
@@ -255,7 +247,6 @@ namespace Option {
     ///
     /// Returns `1` if `o` is `Some(v)` and the predicate `f(v)` evaluates to `true`. Otherwise returns `0`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def count(f: a -> Bool \ ef, o: Option[a]): Int32 \ ef = match o {
         case None    => 0
         case Some(v) => if (f(v)) 1 else 0
@@ -290,7 +281,6 @@ namespace Option {
     ///
     /// The function `f` must be pure.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def find(f: a -> Bool, o: Option[a]): Option[a] = match o {
         case None    => None
         case Some(v) => if (f(v)) o else None
@@ -299,7 +289,6 @@ namespace Option {
     ///
     /// Returns `v` if `o` is `Some(v)`. Otherwise returns `None`.
     ///
-    @Time(1) @Space(1)
     pub def flatten(o: Option[Option[a]]): Option[a] = match o {
         case None    => None
         case Some(v) => v
@@ -345,7 +334,6 @@ namespace Option {
     ///
     /// Returns `Some(v1 :: v2 :: ... :: vn)` if each of `xs_i` is `Some(v_i)`. Otherwise returns `None`.
     ///
-    @Time(List.length(l)) @Space(List.length(l))
     pub def sequence(l: List[Option[a]]): Option[List[a]] =
         def loop(ll, k) = match ll {
             case Nil            => k(Nil)
@@ -422,7 +410,6 @@ namespace Option {
     ///
     /// Returns a one-element list of the value `v` if `o` is `Some(v)`. Otherwise returns the empty list.
     ///
-    @Time(1) @Space(1)
     pub def toList(o: Option[a]): List[a] = match o {
         case None    => Nil
         case Some(v) => v :: Nil
@@ -431,7 +418,6 @@ namespace Option {
     ///
     /// Returns a one-element set of the value `v` if `o` is `Some(v)`. Otherwise returns the empty set.
     ///
-    @Time(1) @Space(1)
     pub def toSet(o: Option[a]): Set[a] with Order[a] = match o {
         case None    => Set.empty()
         case Some(v) => Set.singleton(v)
@@ -440,7 +426,6 @@ namespace Option {
     ///
     /// Returns a singleton map with the mapping `k -> v` if `o` is `Some((k, v))`. Otherwise returns the empty map.
     ///
-    @Time(1) @Space(1)
     pub def toMap(o: Option[(k, v)]): Map[k, v] with Order[k] = match o {
         case None         => Map.empty()
         case Some((k, v)) => Map.singleton(k, v)
@@ -455,7 +440,6 @@ namespace Option {
     ///
     /// Returns the Option value `Ok(v)` if `o` is `Some(v)`. Otherwise returns `Err(e)`.
     ///
-    @Time(1) @Space(1)
     pub def toOk(e: e, o: Option[t]): Result[t, e] = match o {
         case None    => Err(e)
         case Some(a) => Ok(a)
@@ -464,7 +448,6 @@ namespace Option {
     ///
     /// Returns the Option value `Err(e)` if `o` is `Some(e)`. Otherwise returns `Ok(d)`.
     ///
-    @Time(1) @Space(1)
     pub def toErr(d: t, o: Option[e]): Result[t, e] = match o {
         case None    => Ok(d)
         case Some(e) => Err(e)
@@ -473,7 +456,6 @@ namespace Option {
     ///
     /// Returns the Validation value `Success(v)` if `o` is `Some(v)`. Otherwise lifts `e` into Validation's `Failure`.
     ///
-    @Time(1) @Space(1)
     pub def toSuccess(e: e, o: Option[t]): Validation[t, e] = match o {
         case None    => Failure(Nec.singleton(e))
         case Some(a) => Success(a)
@@ -482,7 +464,6 @@ namespace Option {
     ///
     /// Returns `e` into Validation's `Failure` if `o` is `Some(e)`. Otherwise returns `Success(d)`.
     ///
-    @Time(1) @Space(1)
     pub def toFailure(d: t, o: Option[e]): Validation[t, e] = match o {
         case None    => Success(d)
         case Some(e) => Failure(Nec.singleton(e))
@@ -491,7 +472,6 @@ namespace Option {
     ///
     /// Returns `Some((v1, v2))` if `o1` is `Some(v1)` and `o2` is `Some(v2)`. Otherwise returns `None`.
     ///
-    @Time(1) @Space(1)
     pub def zip(o1: Option[a], o2: Option[b]): Option[(a, b)] = match (o1, o2) {
         case (None, _)            => None
         case (_, None)            => None
@@ -501,7 +481,6 @@ namespace Option {
     ///
     /// Returns `(Some(v1), Some(v2))` if `o` is `Some((v1, v2))`. Otherwise returns `(None, None)`.
     ///
-    @Time(1) @Space(1)
     pub def unzip(o: Option[(a, b)]): (Option[a], Option[b]) = match o {
         case None           => (None, None)
         case Some((v1, v2)) => (Some(v1), Some(v2))
@@ -510,7 +489,6 @@ namespace Option {
     ///
     /// Applies `f` to `v` if `o` is `Some(v)`. Otherwise does nothing.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def forEach(f: a -> Unit \ ef, o: Option[a]): Unit \ ef = match o {
         case None    => ()
         case Some(v) => f(v)
@@ -521,7 +499,6 @@ namespace Option {
     ///
     /// Returns `None` if either `o1` or `o2` are `None`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift2(f: (t1, t2) -> u \ ef, o1: Option[t1], o2: Option[t2]): Option[u] \ ef =
         ap(map(f, o1), o2)
 
@@ -530,7 +507,6 @@ namespace Option {
     ///
     /// Returns `None` if any of `o1`, `o2` and `o3` are `None`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift3(f: (t1, t2, t3) -> u \ ef, o1: Option[t1], o2: Option[t2], o3: Option[t3]): Option[u] \ ef =
         ap(lift2(f, o1, o2), o3)
 
@@ -539,7 +515,6 @@ namespace Option {
     ///
     /// Returns `None` if any of `o1`, `o2`, `o3` and `o4` are `None`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift4(f: (t1, t2, t3, t4) -> u \ ef, o1: Option[t1], o2: Option[t2], o3: Option[t3], o4: Option[t4]): Option[u] \ ef =
         ap(lift3(f, o1, o2, o3), o4)
 
@@ -548,7 +523,6 @@ namespace Option {
     ///
     /// Returns `None` if any of `o1`, `o2`, ... `o5` are `None`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift5(f: (t1, t2, t3, t4, t5) -> u \ ef, o1: Option[t1], o2: Option[t2], o3: Option[t3], o4: Option[t4], o5: Option[t5]): Option[u] \ ef =
         ap(lift4(f, o1, o2, o3, o4), o5)
 
@@ -557,7 +531,6 @@ namespace Option {
     ///
     /// Returns `None` if any of `o1`, `o2`, ... `o6` are `None`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift6(f: (t1, t2, t3, t4, t5, t6) -> u \ ef, o1: Option[t1], o2: Option[t2], o3: Option[t3], o4: Option[t4], o5: Option[t5], o6: Option[t6]): Option[u] \ ef =
         ap(lift5(f, o1, o2, o3, o4, o5), o6)
 
@@ -566,7 +539,6 @@ namespace Option {
     ///
     /// Returns `None` if any of `o1`, `o2`, ... `o7` are `None`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift7(f: (t1, t2, t3, t4, t5, t6, t7) -> u \ ef, o1: Option[t1], o2: Option[t2], o3: Option[t3], o4: Option[t4], o5: Option[t5], o6: Option[t6], o7: Option[t7]): Option[u] \ ef=
         ap(lift6(f, o1, o2, o3, o4, o5, o6), o7)
 
@@ -575,7 +547,6 @@ namespace Option {
     ///
     /// Returns `None` if any of `o1`, `o2`, ... `o8` are `None`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift8(f: (t1, t2, t3, t4, t5, t6, t7, t8) -> u \ ef, o1: Option[t1], o2: Option[t2], o3: Option[t3], o4: Option[t4], o5: Option[t5], o6: Option[t6], o7: Option[t7], o8: Option[t8]): Option[u] \ ef =
         ap(lift7(f, o1, o2, o3, o4, o5, o6, o7), o8)
 
@@ -584,7 +555,6 @@ namespace Option {
     ///
     /// Returns `None` if any of `o1`, `o2`, ... `o9` are `None`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift9(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9) -> u \ ef, o1: Option[t1], o2: Option[t2], o3: Option[t3], o4: Option[t4], o5: Option[t5], o6: Option[t6], o7: Option[t7], o8: Option[t8], o9: Option[t9]): Option[u] \ ef =
         ap(lift8(f, o1, o2, o3, o4, o5, o6, o7, o8), o9)
 
@@ -593,7 +563,6 @@ namespace Option {
     ///
     /// Returns `None` if any of `o1`, `o2`, ... `o10` are `None`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift10(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) -> u \ ef, o1: Option[t1], o2: Option[t2], o3: Option[t3], o4: Option[t4], o5: Option[t5], o6: Option[t6], o7: Option[t7], o8: Option[t8], o9: Option[t9], o10: Option[t10]): Option[u] \ ef =
         ap(lift9(f, o1, o2, o3, o4, o5, o6, o7, o8, o9), o10)
 

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -165,18 +165,6 @@ pub def upcast(f: a -> b): a -> b \ ef =
     x -> f(x) as \ ef
 
 ///
-/// Meta-programming facility to express the time complexity of a function `f`.
-///
-@Internal
-pub def time(_: a -> Int32): Int32 = 1
-
-///
-/// Meta-programming facility to express the space complexity of a function `f`.
-///
-@Internal
-pub def space(_: a -> Int32): Int32 = 1
-
-///
 /// Prints the argument unless it is ().
 ///
 @Internal

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -125,7 +125,6 @@ namespace RedBlackTree {
     ///
     /// Returns the number of nodes in `t`.
     ///
-    @Time(size(t)) @Space(Int32.log2(size(t)))
     pub def size(t: RedBlackTree[k, v]): Int32 =
         def loop(tt, k) = match tt {
             case Node(_, a, _, _, b) => loop(a, ks -> k(loop(b, ys -> ks + ys + 1)))
@@ -136,13 +135,11 @@ namespace RedBlackTree {
     ///
     /// Returns the empty tree.
     ///
-    @Time(1) @Space(1)
     pub def empty(): RedBlackTree[k, v] = Leaf
 
     ///
     /// Returns `true` if and only if `t` is the empty tree.
     ///
-    @Time(1) @Space(1)
     pub def isEmpty(t: RedBlackTree[k, v]): Bool = match t {
         case Leaf => true
         case _    => false
@@ -153,7 +150,6 @@ namespace RedBlackTree {
     ///
     /// Otherwise, updates `t` with `k => v`.
     ///
-    @Time(Int32.log2(size(t))) @Space(Int32.log2(size(t)))
     pub def insert(k: k, v: v, t: RedBlackTree[k, v]): RedBlackTree[k, v] with Order[k] =
         def loop(tt, sk) = match tt {
             case Leaf                  => sk(Node(Red, Leaf, k, v, Leaf))
@@ -171,7 +167,6 @@ namespace RedBlackTree {
     ///
     /// Otherwise, updates `t` with `k => v`.
     ///
-    @Time(time(f) + Int32.log2(size(t))) @Space(space(f) + Int32.log2(size(t)))
     pub def insertWith(f: (k, v, v) -> v \ ef, k: k, v: v, t: RedBlackTree[k, v]): RedBlackTree[k, v] \ ef with Order[k] =
         def loop(tt, sk) = match tt {
             case Leaf                  => sk(Node(Red, Leaf, k, v, Leaf))
@@ -189,7 +184,6 @@ namespace RedBlackTree {
     ///
     /// Otherwise, returns `t`.
     ///
-    @Time(time(f) + Int32.log2(size(t))) @Space(space(f) + Int32.log2(size(t)))
     pub def updateWith(f: (k, v) -> Option[v] \ ef, k: k, t: RedBlackTree[k, v]): RedBlackTree[k, v] \ ef with Order[k] =
         def loop(tt, sk) = match tt {
             case Leaf                  => sk(tt)
@@ -237,7 +231,6 @@ namespace RedBlackTree {
     ///
     /// Otherwise returns `None`.
     ///
-    @Time(Int32.log2(size(t))) @Space(1)
     pub def get(k: k, t: RedBlackTree[k, v]): Option[v] with Order[k] = match t {
         case Node(_, a, k1, v, b) => match k <=> k1 {
             case LessThan    => get(k, a)
@@ -250,7 +243,6 @@ namespace RedBlackTree {
     ///
     /// Returns `true` if and only if `t` contains the key `k`.
     ///
-    @Time(Int32.log2(size(t))) @Space(1)
     pub def memberOf(k: k, t: RedBlackTree[k, v]): Bool with Order[k] = match t {
         case Node(_, a, k1, _, b) => match k <=> k1 {
            case LessThan    => memberOf(k, a)
@@ -263,7 +255,6 @@ namespace RedBlackTree {
     ///
     /// Optionally returns the first key-value pair in `t` that satisfies the predicate `f` when searching from left to right.
     ///
-    @Time(time(f) * size(t)) @Space(space(f) * Int32.log2(size(t)))
     pub def findLeft(f: (k, v) -> Bool \ ef, t: RedBlackTree[k, v]): Option[(k, v)] \ ef =
         def loop(tt, sk) = match tt {
             case Node(_, a, k, v, b) => loop(a, kl -> match kl {
@@ -280,7 +271,6 @@ namespace RedBlackTree {
     ///
     /// Optionally returns the first key-value pair in `t` that satisfies the predicate `f` when searching from right to left.
     ///
-    @Time(time(f) * size(t)) @Space(space(f) * Int32.log2(size(t)))
     pub def findRight(f: (k, v) -> Bool \ ef, t: RedBlackTree[k, v]): Option[(k, v)] \ ef =
         def loop(tt, sk) = match tt {
             case Node(_, a, k, v, b) => loop(b, kr -> match kr {
@@ -362,7 +352,6 @@ namespace RedBlackTree {
     ///
     /// Returns `false` if `t` is the empty tree.
     ///
-    @Time(time(f) * size(t)) @Space(space(f) * Int32.log2(size(t)))
     pub def exists(f: (k, v) -> Bool \ ef, t: RedBlackTree[k, v]): Bool \ ef = match t {
         case Node(_, a, k, v, b) => if (f(k, v)) true else exists(f, a) or exists(f, b)
         case _                   => false
@@ -414,7 +403,6 @@ namespace RedBlackTree {
     ///
     /// Returns `true` if `t` is the empty tree.
     ///
-    @Time(time(f) * size(t)) @Space(space(f) * Int32.log2(size(t)))
     pub def forAll(f: (k, v) -> Bool \ ef, t: RedBlackTree[k, v]): Bool \ ef = match t {
         case Node(_, a, k, v, b) => if (f(k, v)) forAll(f, a) and forAll(f, b) else false
         case _                   => true
@@ -464,7 +452,6 @@ namespace RedBlackTree {
     ///
     /// Applies `f` to every key-value pair of `t`.
     ///
-    @Time(time(f) * size(t)) @Space(space(f) * Int32.log2(size(t)))
     pub def forEach(f: (k, v) -> Unit \ ef, t: RedBlackTree[k, v]): Unit \ ef = match t {
         case Node(_, a, k, v, b) => forEach(f, a); f(k, v); forEach(f, b)
         case _                   => ()
@@ -603,7 +590,6 @@ namespace RedBlackTree {
     ///
     /// Returns the black height of `t`.
     ///
-    @Time(Int32.log2(size(t))) @Space(1)
     pub def blackHeight(t: RedBlackTree[k, v]): Int32 =
         def loop(tt, acc) = match tt {
             case Node(Black, a, _, _, _) => loop(a, 1 + acc)

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -38,7 +38,6 @@ namespace Result {
     ///
     /// Returns `true` iff `r` is `Ok(v)`.
     ///
-    @Time(1) @Space(1)
     pub def isOk(r: Result[t, e]): Bool = match r {
         case Ok(_)  => true
         case Err(_) => false
@@ -47,7 +46,6 @@ namespace Result {
     ///
     /// Returns `true` iff `r` is `Err(w)`.
     ///
-    @Time(1) @Space(1)
     pub def isErr(r: Result[t, e]): Bool = match r {
         case Ok(_)  => false
         case Err(_) => true
@@ -56,7 +54,6 @@ namespace Result {
     ///
     /// Returns `v` if `r` is `Ok(v)`. Otherwise returns `d`.
     ///
-    @Time(1) @Space(1)
     pub def getWithDefault(d: t, r: Result[t, e]): t = match r {
         case Ok(v)  => v
         case Err(_) => d
@@ -65,7 +62,6 @@ namespace Result {
     ///
     /// Returns `Ok(v)` if `r` is `Ok(v)`. Otherwise returns `default`.
     ///
-    @Time(1) @Space(1)
     pub def withDefault(default: {default = Result[t, e2]}, r: Result[t, e1]): Result[t, e2] = match r {
         case Ok(v)  => Ok(v)
         case Err(_) => default.default
@@ -74,7 +70,6 @@ namespace Result {
     ///
     /// Returns `Ok(to)` if `r` is `Ok(from)`. Otherwise returns `r`.
     ///
-    @Time(1) @Space(1)
     pub def replace(from: {from = t}, to: {to = t}, r: Result[t, e]): Result[t, e] with Eq[t] = match r {
         case Ok(v)  => Ok(if (v == from.from) to.to else v)
         case Err(_) => r
@@ -83,7 +78,6 @@ namespace Result {
     ///
     /// Returns `true` if `r` is `Ok(v)` and the predicate `f(v)` evaluates to `true`. Otherwise returns `false`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def exists(f: t -> Bool \ ef, r: Result[t, e]): Bool \ ef = match r {
         case Ok(t)  => f(t)
         case Err(_) => false
@@ -93,7 +87,6 @@ namespace Result {
     /// Returns `true` if `r` is `Ok(v)` and the predicate `f(v)` evaluates to `true` or if `r` is `Err(w)`.
     /// Otherwise returns `false`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def forAll(f: t -> Bool \ ef, r: Result[t, e]): Bool \ ef = match r {
         case Ok(t)  => f(t)
         case Err(_) => true
@@ -102,7 +95,6 @@ namespace Result {
     ///
     /// Returns `Ok(f(v))` if `r` is `Ok(v)`. Returns `Err(w)` if `r` is `Err(w)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def map(f: t1 -> t2 \ ef, r: Result[t1, e]): Result[t2, e] \ ef = match r {
         case Ok(v)  => Ok(f(v))
         case Err(w) => Err(w)
@@ -111,7 +103,6 @@ namespace Result {
     ///
     /// Returns `Err(f(e))` if `r` is `Err(e)`. Returns `Ok(v)` if `r` is `Ok(v)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def mapErr(f: e1 -> e2 \ ef, r: Result[t, e1]): Result[t, e2] \ ef = match r {
         case Ok(v)  => Ok(v)
         case Err(w) => Err(f(w))
@@ -121,7 +112,6 @@ namespace Result {
     ///
     /// Returns `f(v)` if `r` is `Ok(v)`. Returns `Err(w)` if `r` is `Err(w)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def flatMap(f: t1 -> Result[t2, e] \ ef, r: Result[t1, e]): Result[t2, e] \ ef = match r {
         case Ok(v)  => f(v)
         case Err(w) => Err(w)
@@ -130,7 +120,6 @@ namespace Result {
     ///
     /// Returns `v` if `r` is `Ok(v)`. Returns `Err(w)` if `r` is `Err(w)`.
     ///
-    @Time(1) @Space(1)
     pub def flatten(r: Result[Result[t, e], e]): Result[t, e] = match r {
         case Ok(v)  => v
         case Err(w) => Err(w)
@@ -139,7 +128,6 @@ namespace Result {
     ///
     /// Returns `1` if `r` is `Ok(v)` and the predicate `f(v)` evaluates to `true`. Otherwise returns `0`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def count(f: t -> Bool \ ef, r: Result[t, e]): Int32 \ ef = match r {
         case Ok(v)  => if (f(v)) 1 else 0
         case Err(_) => 0
@@ -180,7 +168,6 @@ namespace Result {
     ///
     /// The function `f` must be pure.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def find(f: t -> Bool, r: Result[t, e]): Option[t] = match r {
         case Ok(v)  => if (f(v)) Some(v) else None
         case Err(_) => None
@@ -189,7 +176,6 @@ namespace Result {
     ///
     /// Returns `f(z, v)` if `r` is `Ok(v)`. Otherwise returns `z`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def foldLeft(f: (a, t) -> a \ ef, z: a, r: Result[t, e]): a \ ef = match r {
         case Ok(v)  => f(z, v)
         case Err(_) => z
@@ -198,7 +184,6 @@ namespace Result {
     ///
     /// Returns `f(v, z)` if `r` is `Ok(v)`. Otherwise returns `z`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def foldRight(f: (t, a) -> a \ ef, z: a, r: Result[t, e]): a \ ef = match r {
         case Ok(v)  => f(v, z)
         case Err(_) => z
@@ -209,7 +194,6 @@ namespace Result {
     ///
     /// A `foldRightWithCont` allows early termination by not calling the continuation.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def foldRightWithCont(f: (t, Unit -> a \ ef) -> a \ ef, z: a, r: Result[t, e]): a \ ef = match r {
         case Ok(v)  => f(v, upcast(_ -> z))
         case Err(_) => z
@@ -296,7 +280,6 @@ namespace Result {
     ///
     /// Returns a one-element list of the value `v` if `r` is `Ok(v)`. Otherwise returns the empty list.
     ///
-    @Time(1) @Space(1)
     pub def toList(r: Result[t, e]): List[t] = match r {
         case Ok(v)  => v :: Nil
         case Err(_) => Nil
@@ -305,7 +288,6 @@ namespace Result {
     ///
     /// Returns a one-element set of the value `v` if `r` is `Ok(v)`. Otherwise returns the empty set.
     ///
-    @Time(1) @Space(1)
     pub def toSet(r: Result[t, e]): Set[t] with Order[t] = match r {
         case Ok(v)  => Set.singleton(v)
         case Err(_) => Set.empty()
@@ -314,7 +296,6 @@ namespace Result {
     ///
     /// Returns a singleton map with the mapping `k -> v` if `o` is `Ok((k, v))`. Otherwise returns the empty map.
     ///
-    @Time(1) @Space(1)
     pub def toMap(r: Result[(k, v), e]): Map[k, v] with Order[k] = match r {
         case Ok((k, v)) => Map.singleton(k, v)
         case Err(_)     => Map.empty()
@@ -329,7 +310,6 @@ namespace Result {
     ///
     /// Returns `Some(v)` if `r` is `Ok(v)`. Otherwise returns `None`.
     ///
-    @Time(1) @Space(1)
     pub def toOption(r: Result[t, e]): Option[t] = match r {
         case Ok(v)  => Some(v)
         case Err(_) => None
@@ -338,7 +318,6 @@ namespace Result {
     ///
     /// Applies `f` to `v` if `r` is `Ok(v)`. Otherwise does nothing.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def forEach(f: t -> Unit \ ef, r: Result[t, e]): Unit \ ef = match r {
         case Ok(v)  => f(v)
         case Err(_) => ()
@@ -347,7 +326,6 @@ namespace Result {
     ///
     /// Applies the function in `r1` to the value in `r2`.
     ///
-    @Time(foldLeft((_, f) -> time(f), 1, r1)) @Space(foldLeft((_, f) -> time(f), 1, r1))
     pub def ap(r1: Result[t -> u \ ef, e], r2: Result[t, e]): Result[u, e] \ ef = match r1 {
         case Err(e) => Err(e)
         case Ok(f)  => match r2 {
@@ -361,7 +339,6 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if either of `r1` and `r2` are `Err(e)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift2(f: (t1, t2) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e]): Result[u, e] \ ef =
         ap(map(f, r1), r2)
 
@@ -370,7 +347,6 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2` and `r3` are `Err(e)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift3(f: (t1, t2, t3) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e]): Result[u, e] \ ef =
         ap(lift2(f, r1, r2), r3)
 
@@ -379,7 +355,6 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2`, `r3` and `r4` are `Err(e)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift4(f: (t1, t2, t3, t4) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e], r4: Result[t4, e]): Result[u, e] \ ef =
         ap(lift3(f, r1, r2, r3), r4)
 
@@ -388,7 +363,6 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2`, ... `r5` are `Err(e)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift5(f: (t1, t2, t3, t4, t5) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e], r4: Result[t4, e], r5: Result[t5, e]): Result[u, e] \ ef =
         ap(lift4(f, r1, r2, r3, r4), r5)
 
@@ -397,7 +371,6 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2`, ... `r6` are `Err(e)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift6(f: (t1, t2, t3, t4, t5, t6) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e], r4: Result[t4, e], r5: Result[t5, e], r6: Result[t6, e]): Result[u, e] \ ef =
         ap(lift5(f, r1, r2, r3, r4, r5), r6)
 
@@ -406,7 +379,6 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2`, ... `r7` are `Err(e)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift7(f: (t1, t2, t3, t4, t5, t6, t7) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e], r4: Result[t4, e], r5: Result[t5, e], r6: Result[t6, e], r7: Result[t7, e]): Result[u, e] \ ef=
         ap(lift6(f, r1, r2, r3, r4, r5, r6), r7)
 
@@ -415,7 +387,6 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2`, ... `r8` are `Err(e)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift8(f: (t1, t2, t3, t4, t5, t6, t7, t8) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e], r4: Result[t4, e], r5: Result[t5, e], r6: Result[t6, e], r7: Result[t7, e], r8: Result[t8, e]): Result[u, e] \ ef =
         ap(lift7(f, r1, r2, r3, r4, r5, r6, r7), r8)
 
@@ -424,7 +395,6 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2`, ... `r9` are `Err(e)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift9(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e], r4: Result[t4, e], r5: Result[t5, e], r6: Result[t6, e], r7: Result[t7, e], r8: Result[t8, e], r9: Result[t9, e]): Result[u, e] \ ef =
         ap(lift8(f, r1, r2, r3, r4, r5, r6, r7, r8), r9)
 
@@ -433,7 +403,6 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2`, ... `r10` are `Err(e)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift10(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e], r4: Result[t4, e], r5: Result[t5, e], r6: Result[t6, e], r7: Result[t7, e], r8: Result[t8, e], r9: Result[t9, e], r10: Result[t10, e]): Result[u, e] \ ef =
         ap(lift9(f, r1, r2, r3, r4, r5, r6, r7, r8, r9), r10)
 

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -131,7 +131,6 @@ namespace Set {
     ///
     /// Returns the size of `s`.
     ///
-    @Time(size(s)) @Space(1)
     pub def size(s: Set[a]): Int32 =
         let Set(t) = s;
         RedBlackTree.size(t)
@@ -141,13 +140,11 @@ namespace Set {
     ///
     /// `Set#{}` is syntactic sugar for `empty` i.e. `Set#{} == empty()`.
     ///
-    @Time(1) @Space(1)
     pub def empty(): Set[a] = Set(RedBlackTree.empty())
 
     ///
     /// Adds `x` to `s`.
     ///
-    @Time(Int32.log2(size(s))) @Space(Int32.log2(size(s)))
     pub def insert(x: a, s: Set[a]): Set[a] with Order[a] =
         let Set(t) = s;
         Set(RedBlackTree.insert(x, (), t))
@@ -155,7 +152,6 @@ namespace Set {
     ///
     /// Removes `x` from `s`.
     ///
-    @Time(Int32.log2(size(s))) @Space(Int32.log2(size(s)))
     pub def remove(x: a, s: Set[a]): Set[a] with Order[a] =
         let Set(t) = s;
         Set(RedBlackTree.remove(x, t))
@@ -163,7 +159,6 @@ namespace Set {
     ///
     /// Returns true if and only if `s` is the empty set.
     ///
-    @Time(1) @Space(1)
     pub def isEmpty(s: Set[a]): Bool =
         let Set(t) = s;
         RedBlackTree.isEmpty(t)
@@ -173,7 +168,6 @@ namespace Set {
     ///
     /// `Set#{x}` is syntactic sugar for `singleton` i.e. `Set#{x} == singleton(x)`.
     ///
-    @Time(1) @Space(1)
     pub def singleton(x: a): Set[a] with Order[a] = insert(x, empty())
 
     ///
@@ -181,7 +175,6 @@ namespace Set {
     ///
     /// Returns `empty()` if `b >= e`.
     ///
-    @Time(e - b) @Space(e - b)
     pub def range(b: Int32, e: Int32): Set[Int32] =
         def loop(i, s) = {
             if (i >= e)
@@ -194,7 +187,6 @@ namespace Set {
     ///
     /// Returns true if and only if `x` is a member of `s`.
     ///
-    @Time(Int32.log2(size(s))) @Space(1)
     pub def memberOf(x: a, s: Set[a]): Bool with Order[a] =
         let Set(t) = s;
         RedBlackTree.memberOf(x, t)
@@ -266,25 +258,21 @@ namespace Set {
     ///
     /// Returns true if and only if every element in `s1` appears in `s2`.
     ///
-    @Time(size(s1)) @Space(size(s1) * Int32.log2(size(s2)))
     pub def isSubsetOf(s1: Set[a], s2: Set[a]): Bool with Order[a] = forAll(x -> memberOf(x, s2), s1)
 
     ///
     /// Returns true if and only if every element in `s1` appears in `s2` and `s != s2`.
     ///
-    @Time(size(s1)) @Space(size(s1) * Int32.log2(size(s2)))
     pub def isProperSubsetOf(s1: Set[a], s2: Set[a]): Bool with Order[a] = size(s1) != size(s2) and isSubsetOf(s1, s2)
 
     ///
     /// Alias for `findLeft`.
     ///
-    @Time(time(f) * size(s)) @Space(space(f) * Int32.log2(size(s)))
     pub def find(f: a -> Bool \ ef, s: Set[a]): Option[a] \ ef = findLeft(f, s)
 
     ///
     /// Optionally returns the first element of `s` that satisfies the predicate `f` when searching from left to right.
     ///
-    @Time(time(f) * size(s)) @Space(space(f) * Int32.log2(size(s)))
     pub def findLeft(f: a -> Bool \ ef, s: Set[a]): Option[a] \ ef =
         let Set(t) = s;
         RedBlackTree.findLeft((x, _) -> f(x), t) |> Option.map(fst)
@@ -292,7 +280,6 @@ namespace Set {
     ///
     /// Optionally returns the first element of `s` that satisfies the predicate `f` when searching from right to left.
     ///
-    @Time(time(f) * size(s)) @Space(space(f) * Int32.log2(size(s)))
     pub def findRight(f: a -> Bool \ ef, s: Set[a]): Option[a] \ ef =
         let Set(t) = s;
         RedBlackTree.findRight((x, _) -> f(x), t) |> Option.map(fst)
@@ -426,7 +413,6 @@ namespace Set {
     ///
     /// Returns the union of the elements in `s`.
     ///
-    @Time(size(s) * Int32.log2(size(s))) @Space(size(s) * Int32.log2(size(s)))
     pub def flatten(s: Set[Set[a]]): Set[a] with Order[a] =
         foldLeft((acc, x) -> union(acc, x), empty(), s)
 
@@ -435,7 +421,6 @@ namespace Set {
     ///
     /// Returns `false` if `s` is the empty set.
     ///
-    @Time(time(f) * size(s)) @Space(space(f) * Int32.log2(size(s)))
     pub def exists(f: a -> Bool \ ef, s: Set[a]): Bool \ ef =
         let Set(t) = s;
         RedBlackTree.exists((x, _) -> f(x), t)
@@ -445,7 +430,6 @@ namespace Set {
     ///
     /// Returns `true` if `s` is the empty set.
     ///
-    @Time(time(f) * size(s)) @Space(space(f) * Int32.log2(size(s)))
     pub def forAll(f: a -> Bool \ ef, s: Set[a]): Bool \ ef =
         let Set(t) = s;
         RedBlackTree.forAll((x, _) -> f(x), t)
@@ -453,8 +437,6 @@ namespace Set {
     ///
     /// Returns the union of `s1` and `s2`.
     ///
-    @Time(Int32.min(size(s1), size(s2)) * Int32.log2(size(s1) + size(s2)))
-    @Space(Int32.min(size(s1), size(s2)) * Int32.log2(size(s1) + size(s2)))
     pub def union(s1: Set[a], s2: Set[a]): Set[a] with Order[a] =
         use RedBlackTree.{blackHeight, foldLeft, insert};
         let Set(t1) = s1;
@@ -467,28 +449,24 @@ namespace Set {
     ///
     /// Returns the intersection of `s1` and `s2`.
     ///
-    @Time(size(s2) * Int32.log2(size(s1))) @Space(size(s2) * Int32.log2(size(s1)))
     pub def intersection(s1: Set[a], s2: Set[a]): Set[a] with Order[a] =
         foldLeft((acc, x) -> if (memberOf(x, s1)) insert(x, acc) else acc, empty(), s2)
 
     ///
     /// Returns the difference of `s1` and `s2`, i.e. `s1 - s2`.
     ///
-    @Time(size(s1) * Int32.log2(size(s2))) @Space(size(s1) * Int32.log2(size(s2)))
     pub def difference(s1: Set[a], s2: Set[a]): Set[a] with Order[a] =
         foldLeft((acc, x) -> if (not memberOf(x, s2)) insert(x, acc) else acc, empty(), s1)
 
     ///
     /// Returns all subsets of `s`.
     ///
-    @Time(size(s) * (1 <<< size(s))) @Space(size(s) * (1 <<< size(s)))
     pub def subsets(s: Set[a]): Set[Set[a]] with Order[a] =
         foldLeft((acc, x) -> union(map(y -> insert(x, y), acc), acc), insert(empty(), empty()), s)
 
     ///
     /// Returns the set of all elements of `s` that satisfy the predicate `f`.
     ///
-    @Time(time(f) * size(s)) @Space(space(f) * size(s))
     pub def filter(f: a -> Bool \ ef, s: Set[a]): Set[a] \ ef with Order[a] =
         foldLeft((acc, x) -> if (f(x)) insert(x, acc) else acc, empty(), s)
 
@@ -503,7 +481,6 @@ namespace Set {
     ///
     /// Returns the result of applying `f` to every element in `s` and taking the union.
     ///
-    @Time(time(f) * size(s) * Int32.log2(size(s))) @Space(space(f) * size(s) * Int32.log2(size(s)))
     pub def flatMap(f: a -> Set[b] \ ef, s: Set[a]): Set[b] \ ef with Order[b] =
         foldLeft((acc, x) -> union(acc, f(x)), empty(), s)
 
@@ -522,7 +499,6 @@ namespace Set {
     ///
     /// Note: The returned set may be smaller than `s`.
     ///
-    @Time(Int32.log2(size(s))) @Space(Int32.log2(size(s)))
     pub def replace(from: {from = a}, to: {to = a}, s: Set[a]): Set[a] with Order[a] =
         if (memberOf(from.from, s)) insert(to.to, remove(from.from, s)) else s
 
@@ -532,7 +508,6 @@ namespace Set {
     /// `s1` contains all elements of `s` that satisfy the predicate `f`.
     /// `s2` contains all elements of `s` that do not satisfy the predicate `f`.
     ///
-    @Time(size(s) * Int32.log2(size(s))) @Space(size(s) * Int32.log2(size(s)))
     pub def partition(f: a -> Bool \ ef, s: Set[a]): (Set[a], Set[a]) \ ef with Order[a] =
         foldLeft((acc, x) ->
             let (a, b) = acc;
@@ -545,7 +520,6 @@ namespace Set {
     ///
     /// Returns the set `s` as a list.
     ///
-    @Time(size(s)) @Space(size(s))
     pub def toList(s: Set[a]): List[a] =
         foldLeft((acc, x) -> x :: acc, Nil, s)
 
@@ -561,7 +535,6 @@ namespace Set {
     /// If `s` contains multiple mappings with the same key, `toMap` does not
     /// make any guarantees about which mapping will be in the resulting map.
     ///
-    @Time(size(s)) @Space(size(s))
     pub def toMap(s: Set[(a, b)]): Map[a, b] with Order[a] =
         foldRight((x, acc) -> let (k, v) = x; Map.insert(k, v, acc), Map#{}, s)
 
@@ -588,7 +561,6 @@ namespace Set {
     ///
     /// Applies `f` to every element of `s`.
     ///
-    @Time(size(f) * size(s)) @Space(space(f) * Int32.log2(size(s)))
     pub def forEach(f: a -> Unit \ ef, s: Set[a]): Unit \ ef =
         let Set(t) = s;
         RedBlackTree.forEach((x, _) -> f(x), t)

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -19,7 +19,6 @@ namespace String {
     ///
     /// Returns the character at position `i` in the string `s`.
     ///
-    @Time(1) @Space(1)
     pub def charAt(i: Int32, s: String): Char =
         import java.lang.String.charAt(Int32): Char \ {};
         charAt(s, i)
@@ -27,7 +26,6 @@ namespace String {
     ///
     /// Returns the string `s1` followed by the string `s2`.
     ///
-    @Time(length(s1) + length(s2)) @Space(length(s1) + length(s2))
     pub def concat(s1: String, s2: String): String =
         import java.lang.String.concat(String): String \ {};
         (s1 `concat` s2)
@@ -35,7 +33,6 @@ namespace String {
     ///
     /// Returns `true` if the string `s` is the empty string.
     ///
-    @Time(1) @Space(1)
     pub def isEmpty(s: String): Bool =
         import java.lang.String.isEmpty(): Bool \ {};
         isEmpty(s)
@@ -43,7 +40,6 @@ namespace String {
     ///
     /// Returns the length of the string `s`.
     ///
-    @Time(1) @Space(1)
     pub def length(s: String): Int32 =
         import java.lang.String.length(): Int32 \ {};
         length(s)
@@ -74,7 +70,6 @@ namespace String {
     ///
     /// Returns the lower case version of the string `s`.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def toLowerCase(s: String): String =
         import java.lang.String.toLowerCase(): String \ {};
         toLowerCase(s)
@@ -82,7 +77,6 @@ namespace String {
     ///
     /// Returns the upper case version of the string `s`.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def toUpperCase(s: String): String =
         import java.lang.String.toUpperCase(): String \ {};
         toUpperCase(s)
@@ -90,7 +84,6 @@ namespace String {
     ///
     /// Returns the given string `s` as a list of characters.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def toList(s: String): List[Char] = List.map(i -> charAt(i, s), List.range(0, length(s)))
 
     ///
@@ -98,7 +91,6 @@ namespace String {
     ///
     /// Returns a new empty string if there is no characters in `s`.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def trim(s: String): String =
         import java.lang.String.trim(): String \ {};
         trim(s)
@@ -106,7 +98,6 @@ namespace String {
     ///
     /// Get the system line separator.
     ///
-    @Time(1) @Space(1)
     pub def lineSeparator(): String =
         import static java.lang.System.lineSeparator(): String \ {};
         lineSeparator()
@@ -114,14 +105,12 @@ namespace String {
     ///
     /// Returns the given string `s` as an array of characters.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def toArray(r: Region[r], s: String): Array[Char, r] \ Write(r) =
         Array.init(r, i -> charAt(i, s), length(s))
 
     ///
     /// Build a string of length `len` by applying `f` to the successive indices.
     ///
-    @Time(time(f) * len) @Space(space(f) * len)
     pub def init(f: Int32 -> Char \ ef, len: Int32): String \ ef =
         if (len <= 0) "" else initHelper(f, len)
 
@@ -147,7 +136,6 @@ namespace String {
     ///
     /// Concatenate a list of strings into a single string.
     ///
-    @Time(List.length(xs)) @Space(List.length(xs))
     pub def flatten(xs: List[String]): String = region r {
         let sb = new StringBuilder(r);
         List.forEach(x -> StringBuilder.appendString!(x, sb), xs);
@@ -158,7 +146,6 @@ namespace String {
     /// Concatenate a list of strings into a single string, inserting the separator `sep` between
     /// each pair of strings.
     ///
-    @Time(length(sep) * List.length(xs)) @Space(length(sep) * List.length(xs))
     pub def intercalate(sep: String, xs: List[String]): String = region r {
         let sb = new StringBuilder(r);
         let arr = List.toArray(r, xs);
@@ -170,7 +157,6 @@ namespace String {
     /// Concatenate a list of strings into a single string, inserting the separator `sep` between
     /// each pair of strings.
     ///
-    @Time(List.length(xs)) @Space(List.length(xs))
     pub def intercalateChar(sep: Char, xs: List[String]): String = match xs {
         case Nil     => ""
         case x :: rs => region r {
@@ -185,7 +171,6 @@ namespace String {
     ///
     /// Returns the result of applying `f` to every character in `s`.
     ///
-    @Time(time(f) * length(s)) @Space(space(f) * length(s))
     pub def map(f: Char -> Char \ ef, s: String): String \ ef =
         let len = length(s);
         init(i -> f(charAt(i, s)), len)
@@ -193,7 +178,6 @@ namespace String {
     ///
     /// Returns the result of applying `f` to every character in `s` along with that character's index.
     ///
-    @Time(time(f) * length(s)) @Space(space(f) * length(s))
     pub def mapWithIndex(f: (Int32, Char) -> Char \ ef, s: String): String \ ef =
         let len = length(s);
         init(i -> f(i, charAt(i, s)), len)
@@ -201,7 +185,6 @@ namespace String {
     ///
     /// Returns the reverse of `s`.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def reverse(s: String) : String =
         let start = length(s) - 1;
         init(i -> charAt(start - i, s), start + 1)
@@ -209,7 +192,6 @@ namespace String {
     ///
     /// Rotate the contents of string `s` by `n` steps to the left.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def rotateLeft(n: Int32, s: String): String =
         if (length(s) < 1)
             ""
@@ -229,7 +211,6 @@ namespace String {
     ///
     /// Rotate the contents of string `s` by `n` steps to the right.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def rotateRight(n: Int32, s: String): String =
         if (length(s) < 1)
             ""
@@ -323,7 +304,6 @@ namespace String {
     ///
     /// Returns `None` if no character in `s` satisfies `f`.
     ///
-    @Time(time(f) * length(s)) @Space(space(f))
     pub def findIndexOfLeft(f: Char -> Bool \ ef, s: String): Option[Int32] \ ef =
         let len = length(s);
         def loop(i) = {
@@ -342,7 +322,6 @@ namespace String {
     ///
     /// If nothing satisfies `f` return None.
     ///
-    @Time(time(f) * length(s)) @Space(space(f))
     pub def findIndexOfRight(f: Char -> Bool, s: String): Option[Int32] =
         def loop(i) = {
             if (i < 0)
@@ -361,7 +340,6 @@ namespace String {
     ///
     /// The function `f` must be pure.
     ///
-    @Time(time(f) * length(s)) @Space(space(f) * length(s))
     pub def findIndices(f: Char -> Bool, s: String): List[Int32] =
         let len = length(s);
         def loop(i, k) = {
@@ -391,7 +369,6 @@ namespace String {
     ///
     /// Alias for `takeLeft`.
     ///
-    @Time(n) @Space(n)
     pub def take(n: Int32, s: String): String = takeLeft(n, s)
 
     ///
@@ -400,7 +377,6 @@ namespace String {
     /// If `n` extends past the end of string `s`, return all the characters
     /// of `s`.
     ///
-    @Time(n) @Space(n)
     pub def takeLeft(n: Int32, s: String): String =
         if (n >= length(s)) s else slice(0, n, s)
 
@@ -410,7 +386,6 @@ namespace String {
     /// If `n` is greater than the length of string `s`, return all the characters
     /// of `s`.
     ///
-    @Time(n) @Space(n)
     pub def takeRight(n: Int32, s: String): String =
         let len = length(s);
         if (n >= len) s else slice(len - n, len, s)
@@ -418,7 +393,6 @@ namespace String {
     ///
     /// Alias for `dropLeft`.
     ///
-    @Time(length(s) - n) @Space(length(s) - n)
     pub def drop(n: Int32, s: String): String = dropLeft(n, s)
 
     ///
@@ -426,7 +400,6 @@ namespace String {
     ///
     /// If `n` extends past the end of string s, return the empty string.
     ///
-    @Time(length(s) - n) @Space(length(s) - n)
     pub def dropLeft(n: Int32, s: String): String =
         if (n <= 0)
             s
@@ -438,7 +411,6 @@ namespace String {
     ///
     /// If `n` is greater than the length of string `s`, return the empty string.
     ///
-    @Time(length(s) - n) @Space(length(s) - n)
     pub def dropRight(n: Int32, s: String): String =
         if (n > 0)
             let len = length(s);
@@ -449,7 +421,6 @@ namespace String {
     ///
     /// Alias for `takeWileLeft`.
     ///
-    @Time(time(f) * length(s)) @Space(space(f) * length(s))
     pub def takeWhile(f: Char -> Bool, s: String): String = takeWhileLeft(f, s)
 
     ///
@@ -458,7 +429,6 @@ namespace String {
     ///
     /// The function `f` must be pure.
     ///
-    @Time(time(f) * length(s)) @Space(space(f) * length(s))
     pub def takeWhileLeft(f: Char -> Bool, s: String): String =
         match findIndexOfLeft(x -> not (f(x)), s) {
             case None    => s
@@ -471,7 +441,6 @@ namespace String {
     ///
     /// The function `f` must be pure.
     ///
-    @Time(time(f) * length(s)) @Space(space(f) * length(s))
     pub def takeWhileRight(f: Char -> Bool, s: String): String =
         match findIndexOfRight(x -> not (f(x)), s) {
             case None    => s
@@ -481,7 +450,6 @@ namespace String {
     ///
     /// Alias for `dropWhileLeft`.
     ///
-    @Time(time(f) * length(s)) @Space(space(f) * length(s))
     pub def dropWhile(f: Char -> Bool, s: String): String = dropWhileLeft(f, s)
 
     ///
@@ -490,7 +458,6 @@ namespace String {
     ///
     /// The function `f` must be pure.
     ///
-    @Time(time(f) * length(s)) @Space(space(f) * length(s))
     pub def dropWhileLeft(f: Char -> Bool, s: String): String =
         match findIndexOfLeft(x -> not (f(x)), s) {
             case None    => ""
@@ -503,7 +470,6 @@ namespace String {
     ///
     /// The function `f` must be pure.
     ///
-    @Time(time(f) * length(s)) @Space(space(f) * length(s))
     pub def dropWhileRight(f: Char -> Bool, s: String): String =
         match findIndexOfRight(x -> not (f(x)), s) {
             case None    => ""
@@ -516,7 +482,6 @@ namespace String {
     ///
     /// The function `f` must be pure.
     ///
-    @Time(time(f) * length(s)) @Space(space(f) * length(s))
     pub def dropWhileAround(f: Char -> Bool, s: String): String =
         match (findIndexOfLeft(x -> not (f(x)), s), findIndexOfRight(x -> not (f(x)), s)) {
             case (None, None)       => ""
@@ -532,7 +497,6 @@ namespace String {
     /// If `n` exceeds the length of string `s`, return the whole string
     /// paired with the empty string.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def splitAt(n: Int32, s: String): (String, String) =
         match length(s) {
             case _   if n <= 0  => ("", s)
@@ -687,7 +651,6 @@ namespace String {
     ///
     /// Returns `false` if `a` is empty.
     ///
-    @Time(time(f) * length(s)) @Space(space(f) * length(s))
     pub def exists(f: Char -> Bool \ ef, s: String): Bool \ ef = match findIndexOfLeft(f, s) {
         case None    => false
         case Some(_) => true
@@ -698,7 +661,6 @@ namespace String {
     ///
     /// Returns `true` if `s` is empty.
     ///
-    @Time(time(f) * length(s)) @Space(space(f) * length(s))
     pub def forAll(f: Char -> Bool \ ef, s: String): Bool \ ef = match findIndexOfLeft(x -> not (f(x)), s) {
         case None    => true
         case Some(_) => false
@@ -709,7 +671,6 @@ namespace String {
     ///
     /// Returns `true` if `s` is empty.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def isAscii(s: String): Bool =
         forAll(Char.isAscii, s)
 
@@ -718,20 +679,17 @@ namespace String {
     ///
     /// Returns `true` if `s` is empty.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def isWhiteSpace(s: String): Bool =
         forAll(Char.isWhiteSpace, s)
 
     ///
     /// Returns string `s` with all leading space characters removed.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def trimLeft(s: String): String = dropWhileLeft(Char.isWhiteSpace, s)
 
     ///
     /// Returns string `s` with all trailing space characters removed.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def trimRight(s: String): String = dropWhileRight(Char.isWhiteSpace, s)
 
     ///
@@ -739,7 +697,6 @@ namespace String {
     ///
     /// Returns the empty string if `n < 0`.
     ///
-    @Time(length(s) * n) @Space(length(s) * n)
     pub def repeat(n: Int32, s: String): String =
         import java.lang.String.repeat(Int32): String \ {};
         if (n < 0)
@@ -750,7 +707,6 @@ namespace String {
     ///
     /// Pad the string `s` at the left with the supplied char `c` to fit the width `w`.
     ///
-    @Time(w) @Space(w)
     pub def padLeft(w: Int32, c: Char, s: String): String =
         let len = length(s);
         if (len >= w)
@@ -761,7 +717,6 @@ namespace String {
     ///
     /// Pad the string `s` at the right with the supplied char `c` to fit the width `w`.
     ///
-    @Time(w) @Space(w)
     pub def padRight(w: Int32, c: Char, s: String): String =
         let len = length(s);
         if (len >= w)
@@ -802,7 +757,6 @@ namespace String {
     ///
     /// Returns `s` if `i < 0` or `i > length(xs)-1`.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def update(i: Int32, a: Char, s: String): String =
         let f = ix -> if (ix == i) a else charAt(ix, s);
         init(f, length(s))
@@ -814,7 +768,6 @@ namespace String {
     /// If `s` becomes depleted then no further patching is done.
     /// If patching occurs at index `i+j` in `s`, then the element at index `j` in `sub` is used.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def patch(i: Int32, n: Int32, sub: String, s: String): String =
         let sublen = length(sub);
         let f = ix ->
@@ -834,7 +787,6 @@ namespace String {
     ///
     /// If the string `s` is empty, then the empty string is returned.
     ///
-    @Time(length(s) + n) @Space(length(s) + n)
     pub def indent(n: Int32, s: String): String =
         if (n <= 0 or length(s) == 0)
             s
@@ -865,7 +817,6 @@ namespace String {
     ///
     /// If the string `s` is empty, then the empty string is returned.
     ///
-    @Time(length(s) + n) @Space(length(s) + n)
     pub def stripIndent(n: Int32, s: String): String =
         if (n <= 0 or length(s) == 0)
             s
@@ -900,7 +851,6 @@ namespace String {
     /// Newline is recognized as any Unicode linebreak sequence including
     /// Windows (carriage return, line feed) or Unix (line feed).
     ///
-    @Time(length(s)) @Space(length(s))
     pub def lines(s: String): List[String] =
         if (isEmpty(s))
             Nil
@@ -911,7 +861,6 @@ namespace String {
     /// Join the list of strings `a` separating each pair of strings and
     /// ending the result string with the system dependent line separator.
     ///
-    @Time(List.length(a)) @Space(List.length(a))
     pub def unlines(a: List[String]): String = region r {
         let sb = new StringBuilder(r);
         List.forEach(x -> StringBuilder.appendLine!(x, sb), a);
@@ -922,7 +871,6 @@ namespace String {
     /// Split the string `s` into an list of words, dividing on one or more white space characters.
     /// Leading and trailing spaces are trimmed.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def words(s: String): List[String] = match trim(s) {
         case s1 if isEmpty(s1) => Nil
         case s1                => split({regex = "\\s+"}, s1)
@@ -932,7 +880,6 @@ namespace String {
     /// Join the array of strings `l` separating each pair of strings with a
     /// single space character.
     ///
-    @Time(List.length(l)) @Space(List.length(l))
     pub def unwords(l: List[String]): String = match l {
         case Nil     => ""
         case x :: xs => region r {
@@ -997,7 +944,6 @@ namespace String {
     ///
     /// Returns the empty string if `s1` and `s2` do not share a common prefix.
     ///
-    @Time(Int32.min(length(s1), length(s2))) @Space(Int32.min(length(s1), length(s2)))
     pub def commonPrefix(s1: String, s2: String): String =
         let len1 = length(s1);
         let len2 = length(s2);
@@ -1020,7 +966,6 @@ namespace String {
     ///
     /// Returns the empty string if `s1` and `s2` do not share a common suffix.
     ///
-    @Time(Int32.min(length(s1), length(s2))) @Space(Int32.min(length(s1), length(s2)))
     pub def commonSuffix(s1: String, s2: String): String =
             def loop(i, j, acc) = {
                 if (i < 0)
@@ -1048,7 +993,6 @@ namespace String {
     ///
     /// If the length of `s` exceeds `w` and `w < 3" then the empty string is returned.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def abbreviateLeft(w: Int32, s: String): String =
         match length(s) {
             case len if len < w => s
@@ -1067,7 +1011,6 @@ namespace String {
     ///
     /// If the length of `s` exceeds `w` and `w < 3" then the empty string is returned.
     ///
-    @Time(length(s)) @Space(length(s))
     pub def abbreviateRight(w: Int32, s: String): String =
         match length(s) {
             case len if len < w => s
@@ -1081,7 +1024,6 @@ namespace String {
     /// The answer is the number deletions, insertions or substitutions needed to turn
     /// string `s` into string `t`.
     ///
-    @Time(length(s) * length(t)) @Space(length(s) * length(t))
     pub def levenshteinDistance(s: String, t: String): Int32 = region r {
         let m = length(s);
         let n = length(t);
@@ -1122,7 +1064,6 @@ namespace String {
     ///
     /// If either `a` or `b` becomes depleted, then no further elements are added to the resulting array.
     ///
-    @Time(Int32.min(length(a), length(b))) @Space(Int32.min(length(a), length(b)))
     pub def zip(a: String, b: String): List[(Char, Char)] =
         let len = Int32.min(length(a), length(b));
         List.unfold(i -> if (i >= len) None else Some((charAt(i, a), charAt(i, b)), i + 1), 0)
@@ -1133,7 +1074,6 @@ namespace String {
     ///
     /// If either `a` or `b` becomes depleted, then no further elements are added to the resulting array.
     ///
-    @Time(Int32.min(length(a), length(b))) @Space(Int32.min(length(a), length(b)))
     pub def zipWith(f: (Char, Char) -> Char \ ef, a: String, b: String): String \ ef =
         let len = Int32.min(length(a), length(b));
         init(i -> f(charAt(i, a), charAt(i, b)), len)
@@ -1196,7 +1136,6 @@ namespace String {
     ///
     /// `k` should be greater than 0.
     ///
-    @Time(length(s) - k) @Space(length(s) - k)
     pub def toChunks(k: Int32, s: String): List[String] =
         if (k <= 0)
             Nil

--- a/main/src/library/Validation.flix
+++ b/main/src/library/Validation.flix
@@ -47,7 +47,6 @@ namespace Validation {
     ///
     /// Applies the function in `v1` to the value in `v2`.
     ///
-    @Time(1) @Space(1)
     pub def ap(v1: Validation[t -> u \ ef, e], v2: Validation[t, e]): Validation[u, e] \ ef = match (v1, v2) {
         case (Success(f), Success(v)) => Success(f(v))
         case (Success(_), Failure(e)) => Failure(e)
@@ -82,7 +81,6 @@ namespace Validation {
     ///
     /// Returns `t` if `v` is `Success(t).` Otherwise returns `d`.
     ///
-    @Time(1) @Space(1)
     pub def getWithDefault(d: t, v: Validation[t, e]): t = match v {
         case Success(t) => t
         case Failure(_) => d
@@ -91,7 +89,6 @@ namespace Validation {
     ///
     /// Returns `v` if it is `Success(v)`. Otherwise returns `default`.
     ///
-    @Time(1) @Space(1)
     pub def withDefault(default: {default = Validation[t, e]}, v: Validation[t, e]): Validation[t, e] = match v {
         case Success(_) => v
         case Failure(_) => default.default
@@ -102,7 +99,6 @@ namespace Validation {
     ///
     /// Returns `false` if `v` is `Failure`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def exists(f: t -> Bool \ ef, v: Validation[t, e]): Bool \ ef = match v {
         case Success(t) => f(t)
         case Failure(_) => false
@@ -111,7 +107,6 @@ namespace Validation {
     ///
     /// Returns `true` if `v` is `Success(t)` and `f(t)` is true or if `v` is `Failure`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def forAll(f: t -> Bool \ ef, v: Validation[t, e]): Bool \ ef = match v {
         case Success(t) => f(t)
         case Failure(_) => true
@@ -120,7 +115,6 @@ namespace Validation {
     ///
     /// Returns `Success(f(v))` if `o` is `Success(v)`. Otherwise returns `v`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def map(f: t -> u \ ef, v: Validation[t, e]): Validation[u, e] \ ef = match v {
         case Success(t) => Success(f(t))
         case Failure(e) => Failure(e)
@@ -187,7 +181,6 @@ namespace Validation {
     /// Returns `Some(t)` if `v` is `Success(t)`.
     /// Returns `None` otherwise.
     ///
-    @Time(1) @Space(1)
     pub def toOption(v: Validation[t, e]): Option[t] = match v {
         case Success(t) => Some(t)
         case Failure(_) => None
@@ -199,7 +192,6 @@ namespace Validation {
     /// Returns `Ok(t)` if `v` is `Success(t)`.
     /// Returns `Err(e)` if `v` is `Failure(e)`.
     ///
-    @Time(1) @Space(1)
     pub def toResult(v: Validation[t, e]): Result[t, Nec[e]] = match v {
         case Success(t) => Ok(t)
         case Failure(e) => Err(e)
@@ -211,7 +203,6 @@ namespace Validation {
     /// Returns `t :: Nil` if `v` is `Success(v)`.
     /// Returns `Nil` if `v` is `Failure(e)`.
     ///
-    @Time(1) @Space(1)
     pub def toList(v: Validation[t, e]): List[t] = match v {
         case Success(t) => t :: Nil
         case Failure(_) => Nil
@@ -222,7 +213,6 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if either or both of `v1` or `v2` are `Failure(xs1)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift2(f: (t1, t2) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e]): Validation[u, e] \ ef =
         ap(map(f, v1), v2)
 
@@ -231,7 +221,6 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2` and `v3` are `Failure(xs1)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift3(f: (t1, t2, t3) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e]): Validation[u, e] \ ef =
         ap(lift2(f, v1, v2), v3)
 
@@ -240,7 +229,6 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, `v3` and `v4` are `Failure(xs1)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift4(f: (t1, t2, t3, t4) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e]): Validation[u, e] \ ef=
         ap(lift3(f, v1, v2, v3), v4)
 
@@ -249,7 +237,6 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v5` are `Failure(xs1)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift5(f: (t1, t2, t3, t4, t5) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e]): Validation[u, e] \ ef =
         ap(lift4(f, v1, v2, v3, v4), v5)
 
@@ -258,7 +245,6 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v6` are `Failure(xs1)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift6(f: (t1, t2, t3, t4, t5, t6) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e]): Validation[u, e] \ ef =
         ap(lift5(f, v1, v2, v3, v4, v5), v6)
 
@@ -267,7 +253,6 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v7` are `Failure(xs1)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift7(f: (t1, t2, t3, t4, t5, t6, t7) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e]): Validation[u, e] \ ef=
         ap(lift6(f, v1, v2, v3, v4, v5, v6), v7)
 
@@ -276,7 +261,6 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v8` are `Failure(xs1)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift8(f: (t1, t2, t3, t4, t5, t6, t7, t8) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e], v8: Validation[t8, e]): Validation[u, e] \ ef =
         ap(lift7(f, v1, v2, v3, v4, v5, v6, v7), v8)
 
@@ -285,7 +269,6 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v9` are `Failure(xs1)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift9(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e], v8: Validation[t8, e], v9: Validation[t9, e]): Validation[u, e] \ ef =
         ap(lift8(f, v1, v2, v3, v4, v5, v6, v7, v8), v9)
 
@@ -294,7 +277,6 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v10` are `Failure(xs1)`.
     ///
-    @Time(time(f)) @Space(space(f))
     pub def lift10(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e], v8: Validation[t8, e], v9: Validation[t9, e], v10: Validation[t10, e]): Validation[u, e] \ ef =
         ap(lift9(f, v1, v2, v3, v4, v5, v6, v7, v8, v9), v10)
 


### PR DESCRIPTION
Removes all @Time and @Space annotations from the library. Related to #4892 