### PR TITLE
refactor: change supercast syntax

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -245,9 +245,9 @@ object SafetyError {
       Some({
         s"""Did you try to supercast two types at the same time? e.g.
            |
-           |  if (true) supercast(a) else supercast(b)
+           |  if (true) super_cast exp1 else super_cast exp2
            |
-           |where a and b are Java types
+           |where exp1 and exp2 have Java types.
            |""".stripMargin
       })
   }
@@ -280,9 +280,9 @@ object SafetyError {
       Some({
         s"""Did you try to supercast two types at the same time? e.g.
            |
-           |  if (true) supercast(a) else supercast(b)
+           |  if (true) super_cast exp1 else super_cast exp2
            |
-           |where a and b are Java types
+           |where exp1 and exp2 have Java types.
            |""".stripMargin
       })
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -709,7 +709,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def Supercast: Rule1[ParsedAst.Expression] = rule {
-      SP ~ keyword("supercast") ~ "(" ~ Expression ~ ")" ~ SP ~> ParsedAst.Expression.Supercast
+      SP ~ keyword("super_cast") ~ WS ~ Expression ~ SP ~> ParsedAst.Expression.Supercast
     }
 
     def Ascribe: Rule1[ParsedAst.Expression] = rule {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -1338,7 +1338,7 @@ class TestRedundancy extends FunSuite with TestUtils {
         |    import new java.lang.Object(): ##java.lang.Object \ Impure as newObject;
         |    let _ =
         |        if (true)
-        |            supercast(newObject())
+        |            super_cast newObject()
         |        else
         |            newObject();
         |    ()
@@ -1357,7 +1357,7 @@ class TestRedundancy extends FunSuite with TestUtils {
         |        if (true)
         |            newStringBuilder()
         |        else
-        |            supercast(newStringBuilder());
+        |            super_cast newStringBuilder();
         |    ()
         |""".stripMargin
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -512,7 +512,7 @@ class TestSafety extends FunSuite with TestUtils {
         |    import new java.lang.Object(): ##java.lang.Object \ Impure as newObject;
         |    let _ =
         |        if (true)
-        |            supercast(1 as \ Impure)
+        |            super_cast (1 as \ Impure);
         |        else
         |            newObject();
         |    ()
@@ -531,7 +531,7 @@ class TestSafety extends FunSuite with TestUtils {
         |        if (true)
         |            1 as \ Impure
         |        else
-        |            supercast(newObject());
+        |            super_cast newObject();
         |    ()
         |""".stripMargin
 
@@ -547,7 +547,7 @@ class TestSafety extends FunSuite with TestUtils {
         |    import new java.lang.StringBuilder(): ##java.lang.StringBuilder \ Impure as newStringBuilder;
         |    let _ =
         |        if (true)
-        |            supercast(newObject())
+        |            super_cast newObject();
         |        else
         |            newStringBuilder();
         |    ()
@@ -565,9 +565,9 @@ class TestSafety extends FunSuite with TestUtils {
         |    import new java.lang.StringBuilder(): ##java.lang.StringBuilder \ Impure as newStringBuilder;
         |    let _ =
         |        if (true)
-        |            supercast(newObject())
+        |            super_cast newObject();
         |        else
-        |            supercast(newStringBuilder());
+        |            super_cast newStringBuilder();
         |    ()
         |""".stripMargin
 
@@ -582,9 +582,9 @@ class TestSafety extends FunSuite with TestUtils {
         |    import new java.lang.StringBuilder(): ##java.lang.StringBuilder \ Impure as newStringBuilder;
         |    let _ =
         |        if (true)
-        |            supercast(newStringBuilder())
+        |            super_cast newStringBuilder();
         |        else
-        |            supercast(newStringBuilder());
+        |            super_cast newStringBuilder();
         |    ()
         |""".stripMargin
 
@@ -593,7 +593,7 @@ class TestSafety extends FunSuite with TestUtils {
   }
 
   test("TestSupercast.06") {
-    val input = "def f(): ##java.lang.Object = supercast(\"hello\")"
+    val input = "def f(): ##java.lang.Object = super_cast \"hello\""
     val result = compile(input, Options.TestWithLibNix)
     expectError[SafetyError.ToTypeVariableSupercast](result)
   }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -512,7 +512,7 @@ class TestSafety extends FunSuite with TestUtils {
         |    import new java.lang.Object(): ##java.lang.Object \ Impure as newObject;
         |    let _ =
         |        if (true)
-        |            super_cast (1 as \ Impure);
+        |            super_cast (1 as \ Impure)
         |        else
         |            newObject();
         |    ()
@@ -547,7 +547,7 @@ class TestSafety extends FunSuite with TestUtils {
         |    import new java.lang.StringBuilder(): ##java.lang.StringBuilder \ Impure as newStringBuilder;
         |    let _ =
         |        if (true)
-        |            super_cast newObject();
+        |            super_cast newObject()
         |        else
         |            newStringBuilder();
         |    ()
@@ -565,7 +565,7 @@ class TestSafety extends FunSuite with TestUtils {
         |    import new java.lang.StringBuilder(): ##java.lang.StringBuilder \ Impure as newStringBuilder;
         |    let _ =
         |        if (true)
-        |            super_cast newObject();
+        |            super_cast newObject()
         |        else
         |            super_cast newStringBuilder();
         |    ()
@@ -582,7 +582,7 @@ class TestSafety extends FunSuite with TestUtils {
         |    import new java.lang.StringBuilder(): ##java.lang.StringBuilder \ Impure as newStringBuilder;
         |    let _ =
         |        if (true)
-        |            super_cast newStringBuilder();
+        |            super_cast newStringBuilder()
         |        else
         |            super_cast newStringBuilder();
         |    ()

--- a/main/test/flix/Test.Exp.Supercast.flix
+++ b/main/test/flix/Test.Exp.Supercast.flix
@@ -5,7 +5,7 @@ namespace Test/Exp/Supercast {
         import new java.lang.Object(): ##java.lang.Object \ Impure as newObject;
         import new java.lang.StringBuilder(): ##java.lang.StringBuilder \ Impure as newStringBuilder;
         if (true)
-            supercast(newStringBuilder())
+            super_cast newStringBuilder()
         else
             newObject()
 
@@ -16,13 +16,13 @@ namespace Test/Exp/Supercast {
         if (true)
             newObject()
         else
-            supercast(newStringBuilder())
+            super_cast newStringBuilder()
 
     @test
     def testSupercast03(): Unit \ Impure =
         import new java.lang.StringBuilder(): ##java.lang.StringBuilder \ Impure as newStringBuilder;
         let f = (_: ##java.lang.CharSequence) -> ();
-        f(supercast(newStringBuilder()))
+        f(super_cast newStringBuilder())
 
     @test
     def testSupercast04(): Unit \ Impure =
@@ -30,27 +30,27 @@ namespace Test/Exp/Supercast {
         import java.lang.StringBuilder.append(String): ##java.lang.StringBuilder \ Impure;
         let f = (_: ##java.lang.CharSequence) -> ();
         let sb = newStringBuilder();
-        f(supercast(append(sb, "Hello")))
+        f(super_cast append(sb, "Hello"))
 
     @test
     def testSupercast05(): Unit \ Impure =
         import new java.lang.StringBuilder(): ##java.lang.StringBuilder \ Impure as newStringBuilder;
         let f = (_: ##java.lang.Comparable) -> ();
-        f(supercast(newStringBuilder()))
+        f(super_cast newStringBuilder())
 
     @test
     def testSupercast06(): Unit =
         let f = (_: ##java.lang.CharSequence) -> ();
-        f(supercast("hello"))
+        f(super_cast "hello")
 
     @test
     def testSupercast07(): Unit =
         let f = (_: ##java.lang.Number) -> ();
-        f(supercast(123ii))
+        f(super_cast 123ii)
 
     @test
     def testSupercast08(): Unit =
         let f = (_: ##java.lang.Number) -> ();
-        f(supercast(1.23ff))
+        f(super_cast 1.23ff)
 
 }


### PR DESCRIPTION
Changes supercast syntax from `supercast(e)` to `super_cast e`

Related to https://github.com/flix/flix/issues/4939