### PR TITLE
refactor: bring local uses through Resolver and Kinder

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -68,6 +68,8 @@ object KindedAst {
 
     case class Hole(sym: Symbol.HoleSym, tpe: Type.Var, loc: SourceLocation) extends KindedAst.Expression
 
+    case class Use(sym: Symbol, exp: KindedAst.Expression, loc: SourceLocation) extends KindedAst.Expression
+
     case class Cst(cst: Ast.Constant, loc: SourceLocation) extends KindedAst.Expression
 
     case class Apply(exp: KindedAst.Expression, exps: List[KindedAst.Expression], tpe: Type.Var, pur: Type.Var, eff: Type.Var, loc: SourceLocation) extends KindedAst.Expression

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -69,6 +69,8 @@ object ResolvedAst {
 
     case class Hole(sym: Symbol.HoleSym, loc: SourceLocation) extends ResolvedAst.Expression
 
+    case class Use(sym: Symbol, exp: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
+
     case class Cst(cst: Ast.Constant, loc: SourceLocation) extends ResolvedAst.Expression
 
     case class Apply(exp: ResolvedAst.Expression, exps: List[ResolvedAst.Expression], loc: SourceLocation) extends ResolvedAst.Expression

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -358,6 +358,12 @@ object Kinder {
 
     case ResolvedAst.Expression.Hole(sym, loc) => KindedAst.Expression.Hole(sym, Type.freshVar(Kind.Star, loc.asSynthetic), loc).toSuccess
 
+    case ResolvedAst.Expression.Use(sym, exp0, loc) =>
+      val expVal = visitExp(exp0, kenv0, senv, taenv, henv0, root)
+      mapN(expVal) {
+        case exp => KindedAst.Expression.Use(sym, exp, loc)
+      }
+
     case ResolvedAst.Expression.Cst(cst, loc) => KindedAst.Expression.Cst(cst, loc).toSuccess
 
     case ResolvedAst.Expression.Apply(exp0, exps0, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -516,6 +516,8 @@ object Typer {
       case KindedAst.Expression.Hole(_, tvar, _) =>
         liftM(List.empty, tvar, Type.Pure, Type.Empty)
 
+      case KindedAst.Expression.Use(_, exp, _) => visitExp(exp)
+
       case KindedAst.Expression.Cst(Ast.Constant.Unit, loc) =>
         liftM(List.empty, Type.mkUnit(loc.asSynthetic), Type.Pure, Type.Empty)
 
@@ -1885,6 +1887,9 @@ object Typer {
 
       case KindedAst.Expression.Hole(sym, tpe, loc) =>
         TypedAst.Expression.Hole(sym, subst0(tpe), loc)
+
+      // TODO don't erase
+      case KindedAst.Expression.Use(sym, exp, loc) => visitExp(exp, subst0)
 
       // change null to Unit type
       case KindedAst.Expression.Cst(Ast.Constant.Null, loc) => TypedAst.Expression.Cst(Ast.Constant.Null, Type.Unit, loc)


### PR DESCRIPTION
The checks in Resolver are not correct, but I chose not to take the time to fix them fully since one or two PRs down the line they would have to change again. The changes here should at least not be a regression.

related to #4967 