### PR TITLE
refactor: bring tree structure to Resolver

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Name.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Name.scala
@@ -66,6 +66,14 @@ object Name {
   def extendNName(ns: NName, ident: Ident): NName = NName(ident.sp1, ns.idents :+ ident, ident.sp2)
 
   /**
+    * Builds an unlocated name from the given namespace parts.
+    */
+  def mkUnlocatedNName(parts: List[String]): NName = {
+    val idents = parts.map(Ident(SourcePosition.Unknown, _, SourcePosition.Unknown))
+    NName(SourcePosition.Unknown, idents, SourcePosition.Unknown)
+  }
+
+  /**
     * Identifier.
     *
     * @param sp1  the position of the first character in the identifier.

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -36,6 +36,8 @@ object NamedAst {
 
   object Declaration {
 
+    case class Namespace(sym: Symbol.ModuleSym, uses: List[NamedAst.Use], imports: List[NamedAst.Import], decls: List[NamedAst.Declaration], loc: SourceLocation) extends NamedAst.Declaration
+
     case class Class(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: NamedAst.TypeParam, superClasses: List[NamedAst.TypeConstraint], sigs: List[NamedAst.Declaration.Sig], laws: List[NamedAst.Declaration.Def], loc: SourceLocation) extends NamedAst.Declaration
 
     case class Instance(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, clazz: Name.QName, tpe: NamedAst.Type, tconstrs: List[NamedAst.TypeConstraint], defs: List[NamedAst.Declaration.Def], loc: SourceLocation) extends NamedAst.Declaration
@@ -53,10 +55,13 @@ object NamedAst {
     case class Op(sym: Symbol.OpSym, spec: NamedAst.Spec) extends NamedAst.Declaration
   }
 
-  case class Spec(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, tparams: NamedAst.TypeParams, fparams: List[NamedAst.FormalParam], retTpe: NamedAst.Type, purAndEff: PurityAndEffect, tconstrs: List[NamedAst.TypeConstraint], loc: SourceLocation) extends NamedAst.Declaration
+  case class Spec(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, tparams: NamedAst.TypeParams, fparams: List[NamedAst.FormalParam], retTpe: NamedAst.Type, purAndEff: PurityAndEffect, tconstrs: List[NamedAst.TypeConstraint], loc: SourceLocation)
 
 
-  sealed trait Use
+  sealed trait Use {
+    def alias: Name.Ident
+    def loc: SourceLocation
+  }
 
   object Use {
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -23,6 +23,7 @@ object NamedAst {
 
   case class Root(symbols: Map[Name.NName, Map[String, NamedAst.Declaration]],
                   instances: Map[Name.NName, Map[String, List[NamedAst.Declaration.Instance]]],
+                  uses: Map[Name.NName, List[NamedAst.UseOrImport]],
                   units: Map[Ast.Source, NamedAst.CompilationUnit],
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -40,7 +40,7 @@ object NamedAst {
 
     case class Class(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: NamedAst.TypeParam, superClasses: List[NamedAst.TypeConstraint], sigs: List[NamedAst.Declaration.Sig], laws: List[NamedAst.Declaration.Def], loc: SourceLocation) extends NamedAst.Declaration
 
-    case class Instance(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, clazz: Name.QName, tpe: NamedAst.Type, tconstrs: List[NamedAst.TypeConstraint], defs: List[NamedAst.Declaration.Def], loc: SourceLocation) extends NamedAst.Declaration
+    case class Instance(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, clazz: Name.QName, tpe: NamedAst.Type, tconstrs: List[NamedAst.TypeConstraint], defs: List[NamedAst.Declaration.Def], ns: List[String], loc: SourceLocation) extends NamedAst.Declaration
 
     case class Sig(sym: Symbol.SigSym, spec: NamedAst.Spec, exp: Option[NamedAst.Expression]) extends NamedAst.Declaration
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -24,19 +24,19 @@ object NamedAst {
   case class Root(symbols: Map[Name.NName, Map[String, NamedAst.Declaration]],
                   instances: Map[Name.NName, Map[String, List[NamedAst.Declaration.Instance]]],
                   units: Map[Ast.Source, NamedAst.CompilationUnit],
-                  uses: Map[Name.NName, List[NamedAst.Use]],
+                  uses: Map[Name.NName, List[NamedAst.UseOrImport]],
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],
                   names: MultiMap[List[String], String])
 
-  case class CompilationUnit(uses: List[NamedAst.Use], imports: List[NamedAst.Import], decls: List[NamedAst.Declaration], loc: SourceLocation)
+  case class CompilationUnit(usesAndImports: List[NamedAst.UseOrImport], decls: List[NamedAst.Declaration], loc: SourceLocation)
   // TODO change laws to NamedAst.Law
 
   sealed trait Declaration
 
   object Declaration {
 
-    case class Namespace(sym: Symbol.ModuleSym, uses: List[NamedAst.Use], imports: List[NamedAst.Import], decls: List[NamedAst.Declaration], loc: SourceLocation) extends NamedAst.Declaration
+    case class Namespace(sym: Symbol.ModuleSym, usesAndImports: List[NamedAst.UseOrImport], decls: List[NamedAst.Declaration], loc: SourceLocation) extends NamedAst.Declaration
 
     case class Class(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: NamedAst.TypeParam, superClasses: List[NamedAst.TypeConstraint], sigs: List[NamedAst.Declaration.Sig], laws: List[NamedAst.Declaration.Def], loc: SourceLocation) extends NamedAst.Declaration
 
@@ -58,22 +58,21 @@ object NamedAst {
   case class Spec(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, tparams: NamedAst.TypeParams, fparams: List[NamedAst.FormalParam], retTpe: NamedAst.Type, purAndEff: PurityAndEffect, tconstrs: List[NamedAst.TypeConstraint], loc: SourceLocation)
 
 
-  sealed trait Use {
+  sealed trait UseOrImport {
     def alias: Name.Ident
     def loc: SourceLocation
   }
 
-  object Use {
+  object UseOrImport {
 
-    case class UseDefOrSig(qname: Name.QName, alias: Name.Ident, loc: SourceLocation) extends NamedAst.Use
+    case class UseDefOrSig(qname: Name.QName, alias: Name.Ident, loc: SourceLocation) extends NamedAst.UseOrImport
 
-    case class UseTypeOrClass(qname: Name.QName, alias: Name.Ident, loc: SourceLocation) extends NamedAst.Use
+    case class UseTypeOrClass(qname: Name.QName, alias: Name.Ident, loc: SourceLocation) extends NamedAst.UseOrImport
 
-    case class UseTag(qname: Name.QName, tag: Name.Ident, alias: Name.Ident, loc: SourceLocation) extends NamedAst.Use
+    case class UseTag(qname: Name.QName, tag: Name.Ident, alias: Name.Ident, loc: SourceLocation) extends NamedAst.UseOrImport
 
+    case class Import(name: Name.JavaName, alias: Name.Ident, loc: SourceLocation) extends NamedAst.UseOrImport
   }
-
-  case class Import(name: Name.JavaName, alias: Name.Ident, loc: SourceLocation)
 
   sealed trait Expression {
     def loc: SourceLocation
@@ -89,7 +88,7 @@ object NamedAst {
 
     case class Hole(name: Option[Name.Ident], loc: SourceLocation) extends NamedAst.Expression
 
-    case class Use(use: NamedAst.Use, exp: NamedAst.Expression, loc: SourceLocation) extends NamedAst.Expression
+    case class Use(use: NamedAst.UseOrImport, exp: NamedAst.Expression, loc: SourceLocation) extends NamedAst.Expression
 
     case class Cst(cst: Ast.Constant, loc: SourceLocation) extends NamedAst.Expression
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -24,7 +24,6 @@ object NamedAst {
   case class Root(symbols: Map[Name.NName, Map[String, NamedAst.Declaration]],
                   instances: Map[Name.NName, Map[String, List[NamedAst.Declaration.Instance]]],
                   units: Map[Ast.Source, NamedAst.CompilationUnit],
-                  uses: Map[Name.NName, List[NamedAst.UseOrImport]],
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],
                   names: MultiMap[List[String], String])

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -21,43 +21,40 @@ import ca.uwaterloo.flix.util.collection.MultiMap
 
 object NamedAst {
 
-  case class Root(symbols: Map[Name.NName, Map[String, NamedAst.NamedSymbol]],
-                  instances: Map[Name.NName, Map[String, List[NamedAst.Instance]]],
+  case class Root(symbols: Map[Name.NName, Map[String, NamedAst.Declaration]],
+                  instances: Map[Name.NName, Map[String, List[NamedAst.Declaration.Instance]]],
+                  units: Map[Ast.Source, NamedAst.CompilationUnit],
                   uses: Map[Name.NName, List[NamedAst.Use]],
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],
                   names: MultiMap[List[String], String])
 
+  case class CompilationUnit(uses: List[NamedAst.Use], imports: List[NamedAst.Import], decls: List[NamedAst.Declaration], loc: SourceLocation)
   // TODO change laws to NamedAst.Law
-  case class Class(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: NamedAst.TypeParam, superClasses: List[NamedAst.TypeConstraint], sigs: List[NamedAst.Sig], laws: List[NamedAst.Def], loc: SourceLocation)
 
-  case class Instance(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, clazz: Name.QName, tpe: NamedAst.Type, tconstrs: List[NamedAst.TypeConstraint], defs: List[NamedAst.Def], loc: SourceLocation)
+  sealed trait Declaration
 
-  sealed trait NamedSymbol
-  object NamedSymbol {
+  object Declaration {
 
-    case class Class(c: NamedAst.Class) extends NamedAst.NamedSymbol
-    case class Def(d: NamedAst.Def) extends NamedAst.NamedSymbol
-    case class Effect(e: NamedAst.Effect) extends NamedAst.NamedSymbol
-    case class Enum(e: NamedAst.Enum) extends NamedAst.NamedSymbol
-    case class Op(o: NamedAst.Op) extends NamedAst.NamedSymbol
-    case class Sig(s: NamedAst.Sig) extends NamedAst.NamedSymbol
-    case class TypeAlias(a: NamedAst.TypeAlias) extends NamedAst.NamedSymbol
+    case class Class(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: NamedAst.TypeParam, superClasses: List[NamedAst.TypeConstraint], sigs: List[NamedAst.Declaration.Sig], laws: List[NamedAst.Declaration.Def], loc: SourceLocation) extends NamedAst.Declaration
+
+    case class Instance(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, clazz: Name.QName, tpe: NamedAst.Type, tconstrs: List[NamedAst.TypeConstraint], defs: List[NamedAst.Declaration.Def], loc: SourceLocation) extends NamedAst.Declaration
+
+    case class Sig(sym: Symbol.SigSym, spec: NamedAst.Spec, exp: Option[NamedAst.Expression]) extends NamedAst.Declaration
+
+    case class Def(sym: Symbol.DefnSym, spec: NamedAst.Spec, exp: NamedAst.Expression) extends NamedAst.Declaration
+
+    case class Enum(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.EnumSym, tparams: NamedAst.TypeParams, derives: List[Name.QName], cases: Map[String, NamedAst.Case], tpe: NamedAst.Type, loc: SourceLocation) extends NamedAst.Declaration
+
+    case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.TypeAliasSym, tparams: NamedAst.TypeParams, tpe: NamedAst.Type, loc: SourceLocation) extends NamedAst.Declaration
+
+    case class Effect(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[NamedAst.Declaration.Op], loc: SourceLocation) extends NamedAst.Declaration
+
+    case class Op(sym: Symbol.OpSym, spec: NamedAst.Spec) extends NamedAst.Declaration
   }
 
-  case class Sig(sym: Symbol.SigSym, spec: NamedAst.Spec, exp: Option[NamedAst.Expression])
+  case class Spec(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, tparams: NamedAst.TypeParams, fparams: List[NamedAst.FormalParam], retTpe: NamedAst.Type, purAndEff: PurityAndEffect, tconstrs: List[NamedAst.TypeConstraint], loc: SourceLocation) extends NamedAst.Declaration
 
-  case class Def(sym: Symbol.DefnSym, spec: NamedAst.Spec, exp: NamedAst.Expression)
-
-  case class Spec(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, tparams: NamedAst.TypeParams, fparams: List[NamedAst.FormalParam], retTpe: NamedAst.Type, purAndEff: PurityAndEffect, tconstrs: List[NamedAst.TypeConstraint], loc: SourceLocation)
-
-  case class Enum(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.EnumSym, tparams: NamedAst.TypeParams, derives: List[Name.QName], cases: Map[String, NamedAst.Case], tpe: NamedAst.Type, loc: SourceLocation)
-
-  case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.TypeAliasSym, tparams: NamedAst.TypeParams, tpe: NamedAst.Type, loc: SourceLocation)
-
-  case class Effect(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[NamedAst.Op], loc: SourceLocation)
-
-  case class Op(sym: Symbol.OpSym, spec: NamedAst.Spec)
 
   sealed trait Use
 
@@ -70,6 +67,8 @@ object NamedAst {
     case class UseTag(qname: Name.QName, tag: Name.Ident, alias: Name.Ident, loc: SourceLocation) extends NamedAst.Use
 
   }
+
+  case class Import(name: Name.JavaName, alias: Name.Ident, loc: SourceLocation)
 
   sealed trait Expression {
     def loc: SourceLocation

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -506,6 +506,11 @@ object Symbol {
       * Human readable representation.
       */
     override def toString: String = clazz.toString + "." + name
+
+    /**
+      * The symbol's namespace.
+      */
+    def namespace: List[String] = clazz.namespace :+ clazz.name
   }
 
   /**
@@ -633,6 +638,11 @@ object Symbol {
       * Human readable representation.
       */
     override def toString: String = eff.toString + "." + name
+
+    /**
+      * The symbol's namespace.
+      */
+    def namespace: List[String] = eff.namespace :+ eff.name
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -23,13 +23,13 @@ object WeededAst {
 
   case class Root(units: Map[Ast.Source, WeededAst.CompilationUnit], entryPoint: Option[Symbol.DefnSym], names: MultiMap[List[String], String])
 
-  case class CompilationUnit(uses: List[WeededAst.Use], imports: List[WeededAst.Import], decls: List[WeededAst.Declaration], loc: SourceLocation)
+  case class CompilationUnit(usesAndImports: List[WeededAst.UseOrImport], decls: List[WeededAst.Declaration], loc: SourceLocation)
 
   sealed trait Declaration
 
   object Declaration {
 
-    case class Namespace(name: Name.NName, uses: List[WeededAst.Use], imports: List[WeededAst.Import], decls: List[WeededAst.Declaration], loc: SourceLocation) extends WeededAst.Declaration
+    case class Namespace(name: Name.NName, usesAndImports: List[WeededAst.UseOrImport], decls: List[WeededAst.Declaration], loc: SourceLocation) extends WeededAst.Declaration
 
     // TODO change laws to WeededAst.Law
     case class Class(doc: Ast.Doc, ann: List[WeededAst.Annotation], mod: Ast.Modifiers, ident: Name.Ident, tparam: WeededAst.TypeParam, superClasses: List[WeededAst.TypeConstraint], sigs: List[WeededAst.Declaration.Sig], laws: List[WeededAst.Declaration.Def], loc: SourceLocation) extends WeededAst.Declaration
@@ -52,19 +52,19 @@ object WeededAst {
 
   }
 
-  sealed trait Use
+  sealed trait UseOrImport
 
-  object Use {
+  object UseOrImport {
 
-    case class UseLower(qname: Name.QName, alias: Name.Ident, loc: SourceLocation) extends WeededAst.Use
+    case class UseLower(qname: Name.QName, alias: Name.Ident, loc: SourceLocation) extends WeededAst.UseOrImport
 
-    case class UseUpper(qname: Name.QName, alias: Name.Ident, loc: SourceLocation) extends WeededAst.Use
+    case class UseUpper(qname: Name.QName, alias: Name.Ident, loc: SourceLocation) extends WeededAst.UseOrImport
 
-    case class UseTag(qname: Name.QName, tag: Name.Ident, alias: Name.Ident, loc: SourceLocation) extends WeededAst.Use
+    case class UseTag(qname: Name.QName, tag: Name.Ident, alias: Name.Ident, loc: SourceLocation) extends WeededAst.UseOrImport
 
+    case class Import(name: Name.JavaName, alias: Name.Ident, loc: SourceLocation) extends WeededAst.UseOrImport
   }
 
-  case class Import(name: Name.JavaName, alias: Name.Ident, loc: SourceLocation)
 
   sealed trait Expression {
     def loc: SourceLocation
@@ -80,7 +80,7 @@ object WeededAst {
 
     case class Hole(name: Option[Name.Ident], loc: SourceLocation) extends WeededAst.Expression
 
-    case class Use(uses: List[WeededAst.Use], exp: WeededAst.Expression, loc: SourceLocation) extends WeededAst.Expression
+    case class Use(uses: List[WeededAst.UseOrImport], exp: WeededAst.Expression, loc: SourceLocation) extends WeededAst.Expression
 
     case class Cst(cst: Ast.Constant, loc: SourceLocation) extends WeededAst.Expression
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -64,13 +64,7 @@ object WeededAst {
 
   }
 
-  sealed trait Import
-
-  object Import {
-
-    case class Import(name: Name.JavaName, alias: Name.Ident, loc: SourceLocation) extends WeededAst.Import
-
-  }
+  case class Import(name: Name.JavaName, alias: Name.Ident, loc: SourceLocation)
 
   sealed trait Expression {
     def loc: SourceLocation

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -2042,7 +2042,7 @@ object Namer {
     /**
       * Adds all the uses or imports to the UseEnv.
       */
-    def addAll(usesAndImports: List[NamedAst.UseOrImport]): UseEnv = usesAndImports.foldLeft(UseEnv.empty)(_.addUseOrImport(_))
+    def addAll(usesAndImports: List[NamedAst.UseOrImport]): UseEnv = usesAndImports.foldLeft(this)(_.addUseOrImport(_))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -136,8 +136,8 @@ object Namer {
         }
       }
 
-    case inst@Declaration.Instance(doc, ann, mod, clazz, tpe, tconstrs, defs, loc) =>
-      addInstanceToTable(table0, clazz.namespace.parts, clazz.ident.name, inst).toSuccess
+    case inst@Declaration.Instance(doc, ann, mod, clazz, tpe, tconstrs, defs, ns, loc) =>
+      addInstanceToTable(table0, ns, clazz.ident.name, inst).toSuccess
 
     case Declaration.Sig(sym, spec, exp) =>
       tryAddToTable(table0, sym.namespace, sym.name, decl, uenv0)
@@ -422,7 +422,7 @@ object Namer {
           val instTconstr = NamedAst.TypeConstraint(qualifiedClass, tpe, clazz.loc)
           val defsVal = traverse(defs0)(visitDef(_, uenv0, tenv, ns0, List(instTconstr)))
           mapN(defsVal) {
-            defs => NamedAst.Declaration.Instance(doc, ann, mod, qualifiedClass, tpe, tconstrs, defs, loc)
+            defs => NamedAst.Declaration.Instance(doc, ann, mod, qualifiedClass, tpe, tconstrs, defs, ns0.parts, loc)
           }
       }
   }
@@ -1972,7 +1972,7 @@ object Namer {
     case Declaration.TypeAlias(doc, mod, sym, tparams, tpe, loc) => sym.loc
     case Declaration.Effect(doc, ann, mod, sym, ops, loc) => sym.loc
     case Declaration.Op(sym, spec) => sym.loc
-    case Declaration.Instance(doc, ann, mod, clazz, tpe, tconstrs, defs, loc) => throw InternalCompilerException("Unexpected instance")
+    case Declaration.Instance(doc, ann, mod, clazz, tpe, tconstrs, defs, ns, loc) => throw InternalCompilerException("Unexpected instance")
     case Declaration.Namespace(sym, usesAndImports, decls, loc) => throw InternalCompilerException("Unexpected namespace")
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -109,8 +109,10 @@ object Resolver {
           case (classes, instances, defs, enums, effects, uses) =>
             mapN(checkSuperClassDag(classes)) {
               _ =>
-                val finalUses =
-                ResolvedAst.Root(classes, combine(instances), defs, enums.toMap, effects.toMap, taenv, combine(uses), taOrder, root.entryPoint, root.sources, root.names)
+                val flatUses = uses.map {
+                  case (sym, list) => (sym, list.flatten)
+                }
+                ResolvedAst.Root(classes, combine(instances), defs, enums.toMap, effects.toMap, taenv, combine(flatUses), taOrder, root.entryPoint, root.sources, root.names)
             }
         }
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -61,7 +61,7 @@ object Resolver {
     val typeAliases = root.symbols.map {
       case (ns, map0) =>
         val map = map0.collect {
-          case (name, NamedAst.Declaration.TypeAlias(alias)) => (name, alias)
+          case (name, alias: NamedAst.Declaration.TypeAlias) => (name, alias)
         }
         (ns, map)
     }
@@ -91,7 +91,7 @@ object Resolver {
 
         val enumsVal = root.symbols.flatMap {
           case (ns0, classesAndEffectsAndEnums) => classesAndEffectsAndEnums.collect {
-            case (_, NamedAst.Declaration.Enum(enum)) => resolveEnum(enum, taenv, ns0, root) map {
+            case (_, enum: NamedAst.Declaration.Enum) => resolveEnum(enum, taenv, ns0, root) map {
               case d => d.sym -> d
             }
           }
@@ -99,7 +99,7 @@ object Resolver {
 
         val effectsVal = root.symbols.flatMap {
           case (ns0, classesAndEffects) => classesAndEffects.collect {
-            case (_, NamedAst.Declaration.Effect(effect)) => resolveEffect(effect, taenv, ns0, root) map {
+            case (_, effect: NamedAst.Declaration.Effect) => resolveEffect(effect, taenv, ns0, root) map {
               case e => e.sym -> e
             }
           }
@@ -154,15 +154,15 @@ object Resolver {
     *   - a list of the aliases in a processing order,
     *     such that any alias only depends on those earlier in the list
     */
-  private def resolveTypeAliases(aliases0: Map[Name.NName, Map[String, NamedAst.TypeAlias]], root: NamedAst.Root)(implicit flix: Flix): Validation[(Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], List[Symbol.TypeAliasSym]), ResolutionError] = {
+  private def resolveTypeAliases(aliases0: Map[Name.NName, Map[String, NamedAst.Declaration.TypeAlias]], root: NamedAst.Root)(implicit flix: Flix): Validation[(Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], List[Symbol.TypeAliasSym]), ResolutionError] = {
 
     /**
       * Partially resolves the type alias.
       *
       * Type aliases within the type are given temporary placeholders.
       */
-    def semiResolveTypeAlias(alias: NamedAst.TypeAlias, ns: Name.NName): Validation[ResolvedAst.TypeAlias, ResolutionError] = alias match {
-      case NamedAst.TypeAlias(doc, mod, sym, tparams0, tpe0, loc) =>
+    def semiResolveTypeAlias(alias: NamedAst.Declaration.TypeAlias, ns: Name.NName): Validation[ResolvedAst.TypeAlias, ResolutionError] = alias match {
+      case NamedAst.Declaration.TypeAlias(doc, mod, sym, tparams0, tpe0, loc) =>
         val tparams = resolveTypeParams(tparams0, ns, root)
         semiResolveType(tpe0, ns, root) map {
           tpe => ResolvedAst.TypeAlias(doc, mod, sym, tparams, tpe, loc)
@@ -293,7 +293,7 @@ object Resolver {
 
     val rootClasses = for {
       (ns, classesAndEffects) <- root.symbols
-      clazz <- classesAndEffects.collect { case (_, NamedAst.Declaration.Class(c)) => c }
+      clazz <- classesAndEffects.collect { case (_, clazz: NamedAst.Declaration.Class) => clazz }
     } yield clazz.sym -> (clazz, ns)
 
     val (staleClasses, freshClasses) = changeSet.partition(rootClasses, oldRoot.classes)
@@ -313,8 +313,8 @@ object Resolver {
   /**
     * Resolves all the classes in the given root.
     */
-  def resolveClass(c0: NamedAst.Class, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Class, ResolutionError] = c0 match {
-    case NamedAst.Class(doc, ann0, mod, sym, tparam0, superClasses0, signatures, laws0, loc) =>
+  def resolveClass(c0: NamedAst.Declaration.Class, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Class, ResolutionError] = c0 match {
+    case NamedAst.Declaration.Class(doc, ann0, mod, sym, tparam0, superClasses0, signatures, laws0, loc) =>
       val tparam = Params.resolveTparam(tparam0)
       val annVal = traverse(ann0)(visitAnnotation(_, taenv, ns0, root))
       val sigsListVal = traverse(signatures)(resolveSig(_, taenv, ns0, root))
@@ -331,8 +331,8 @@ object Resolver {
   /**
     * Performs name resolution on the given instance `i0` in the given namespace `ns0`.
     */
-  def resolveInstance(i0: NamedAst.Instance, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Instance, ResolutionError] = i0 match {
-    case NamedAst.Instance(doc, ann0, mod, clazz0, tpe0, tconstrs0, defs0, loc) =>
+  def resolveInstance(i0: NamedAst.Declaration.Instance, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Instance, ResolutionError] = i0 match {
+    case NamedAst.Declaration.Instance(doc, ann0, mod, clazz0, tpe0, tconstrs0, defs0, loc) =>
       val annVal = traverse(ann0)(visitAnnotation(_, taenv, ns0, root))
       val clazzVal = lookupClassForImplementation(clazz0, ns0, root)
       val tpeVal = resolveType(tpe0, taenv, ns0, root)
@@ -348,8 +348,8 @@ object Resolver {
   /**
     * Performs name resolution on the given signature `s0` in the given namespace `ns0`.
     */
-  def resolveSig(s0: NamedAst.Sig, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Sig, ResolutionError] = s0 match {
-    case NamedAst.Sig(sym, spec0, exp0) =>
+  def resolveSig(s0: NamedAst.Declaration.Sig, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Sig, ResolutionError] = s0 match {
+    case NamedAst.Declaration.Sig(sym, spec0, exp0) =>
       val specVal = resolveSpec(spec0, taenv, ns0, root)
       val expVal = traverseOpt(exp0)(Expressions.resolve(_, taenv, ns0, root))
       mapN(specVal, expVal) {
@@ -361,8 +361,8 @@ object Resolver {
     * Resolves all the definitions in the given root.
     */
   private def resolveDefs(root: NamedAst.Root, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], oldRoot: ResolvedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Validation[Map[Symbol.DefnSym, ResolvedAst.Def], ResolutionError] = {
-    def getDef(defOrSig: NamedAst.Declaration): Option[NamedAst.Def] = defOrSig match {
-      case NamedAst.Declaration.Def(d) => Some(d)
+    def getDef(defOrSig: NamedAst.Declaration): Option[NamedAst.Declaration.Def] = defOrSig match {
+      case d: NamedAst.Declaration.Def => Some(d)
       case _ => None
     }
 
@@ -389,8 +389,8 @@ object Resolver {
   /**
     * Performs name resolution on the given definition `d0` in the given namespace `ns0`.
     */
-  def resolveDef(d0: NamedAst.Def, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Def, ResolutionError] = d0 match {
-    case NamedAst.Def(sym, spec0, exp0) =>
+  def resolveDef(d0: NamedAst.Declaration.Def, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Def, ResolutionError] = d0 match {
+    case NamedAst.Declaration.Def(sym, spec0, exp0) =>
       flix.subtask(sym.toString, sample = true)
 
       val specVal = resolveSpec(spec0, taenv, ns0, root)
@@ -422,8 +422,8 @@ object Resolver {
   /**
     * Performs name resolution on the given enum `e0` in the given namespace `ns0`.
     */
-  def resolveEnum(e0: NamedAst.Enum, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Enum, ResolutionError] = e0 match {
-    case NamedAst.Enum(doc, ann0, mod, sym, tparams0, derives0, cases0, tpe0, loc) =>
+  def resolveEnum(e0: NamedAst.Declaration.Enum, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Enum, ResolutionError] = e0 match {
+    case NamedAst.Declaration.Enum(doc, ann0, mod, sym, tparams0, derives0, cases0, tpe0, loc) =>
       val annVal = traverse(ann0)(visitAnnotation(_, taenv, ns0, root))
       val tparams = resolveTypeParams(tparams0, ns0, root)
       val derivesVal = resolveDerivations(derives0, ns0, root)
@@ -449,8 +449,8 @@ object Resolver {
   /**
     * Performs name resolution on the given effect `eff0` in the given namespace `ns0`.
     */
-  private def resolveEffect(eff0: NamedAst.Effect, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Effect, ResolutionError] = eff0 match {
-    case NamedAst.Effect(doc, ann0, mod, sym, ops0, loc) =>
+  private def resolveEffect(eff0: NamedAst.Declaration.Effect, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Effect, ResolutionError] = eff0 match {
+    case NamedAst.Declaration.Effect(doc, ann0, mod, sym, ops0, loc) =>
       val annVal = traverse(ann0)(visitAnnotation(_, taenv, ns0, root))
       val opsVal = traverse(ops0)(resolveOp(_, taenv, ns0, root))
       mapN(annVal, opsVal) {
@@ -461,8 +461,8 @@ object Resolver {
   /**
     * Performs name resolution on the given effect operation `op0` in the given namespace `ns0`.
     */
-  private def resolveOp(op0: NamedAst.Op, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Op, ResolutionError] = op0 match {
-    case NamedAst.Op(sym, spec0) =>
+  private def resolveOp(op0: NamedAst.Declaration.Op, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Op, ResolutionError] = op0 match {
+    case NamedAst.Declaration.Op(sym, spec0) =>
       val specVal = resolveSpec(spec0, taenv, ns0, root)
       mapN(specVal) {
         spec => ResolvedAst.Op(sym, spec)
@@ -518,7 +518,7 @@ object Resolver {
       /**
         * Curry the def, wrapping it in lambda expressions.
         */
-      def visitDef(defn: NamedAst.Def, loc: SourceLocation): ResolvedAst.Expression = {
+      def visitDef(defn: NamedAst.Declaration.Def, loc: SourceLocation): ResolvedAst.Expression = {
         // Find the arity of the function definition.
         val arity = defn.spec.fparams.length
 
@@ -535,7 +535,7 @@ object Resolver {
       /**
         * Curry the sig, wrapping it in lambda expressions.
         */
-      def visitSig(sig: NamedAst.Sig, loc: SourceLocation): ResolvedAst.Expression = {
+      def visitSig(sig: NamedAst.Declaration.Sig, loc: SourceLocation): ResolvedAst.Expression = {
         // Find the arity of the function definition.
         val arity = sig.spec.fparams.length
 
@@ -567,7 +567,7 @@ object Resolver {
       /**
         * Resolve the application expression, applying `defn` to `exps`.
         */
-      def visitApplyDef(app: NamedAst.Expression.Apply, defn: NamedAst.Def, exps: List[NamedAst.Expression], region: Option[Symbol.VarSym], innerLoc: SourceLocation, outerLoc: SourceLocation): Validation[ResolvedAst.Expression, ResolutionError] = {
+      def visitApplyDef(app: NamedAst.Expression.Apply, defn: NamedAst.Declaration.Def, exps: List[NamedAst.Expression], region: Option[Symbol.VarSym], innerLoc: SourceLocation, outerLoc: SourceLocation): Validation[ResolvedAst.Expression, ResolutionError] = {
         if (defn.spec.fparams.length == exps.length) {
           // Case 1: Hooray! We can call the function directly.
           val esVal = traverse(exps)(visitExp(_, region))
@@ -585,7 +585,7 @@ object Resolver {
       /**
         * Resolve the application expression, applying `sig` to `exps`.
         */
-      def visitApplySig(app: NamedAst.Expression.Apply, sig: NamedAst.Sig, exps: List[NamedAst.Expression], region: Option[Symbol.VarSym], innerLoc: SourceLocation, outerLoc: SourceLocation): Validation[ResolvedAst.Expression, ResolutionError] = {
+      def visitApplySig(app: NamedAst.Expression.Apply, sig: NamedAst.Declaration.Sig, exps: List[NamedAst.Expression], region: Option[Symbol.VarSym], innerLoc: SourceLocation, outerLoc: SourceLocation): Validation[ResolvedAst.Expression, ResolutionError] = {
         if (sig.spec.fparams.length == exps.length) {
           // Case 1: Hooray! We can call the function directly.
           val esVal = traverse(exps)(visitExp(_, region))
@@ -1545,10 +1545,10 @@ object Resolver {
   /**
     * Finds the class with the qualified name `qname` in the namespace `ns0`, for the purposes of implementation.
     */
-  def lookupClassForImplementation(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Class, ResolutionError] = {
+  def lookupClassForImplementation(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Class, ResolutionError] = {
     val classOpt = tryLookupName(qname, ns0, root.symbols)
     classOpt match {
-      case Some(NamedAst.Declaration.Class(clazz)) =>
+      case Some(clazz: NamedAst.Declaration.Class) =>
         getClassAccessibility(clazz, ns0) match {
           case ClassAccessibility.Accessible => clazz.toSuccess
           case ClassAccessibility.Sealed => ResolutionError.SealedClass(clazz.sym, ns0, qname.loc).toFailure
@@ -1561,10 +1561,10 @@ object Resolver {
   /**
     * Finds the class with the qualified name `qname` in the namespace `ns0`.
     */
-  def lookupClass(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Class, ResolutionError] = {
+  def lookupClass(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Class, ResolutionError] = {
     val classOpt = tryLookupName(qname, ns0, root.symbols)
     classOpt match {
-      case Some(NamedAst.Declaration.Class(clazz)) =>
+      case Some(clazz: NamedAst.Declaration.Class) =>
         getClassAccessibility(clazz, ns0) match {
           case ClassAccessibility.Accessible | ClassAccessibility.Sealed => clazz.toSuccess
           case ClassAccessibility.Inaccessible => ResolutionError.InaccessibleClass(clazz.sym, ns0, qname.loc).toFailure
@@ -1581,13 +1581,13 @@ object Resolver {
 
     defOrSigOpt match {
       case None => ResolutionError.UndefinedName(qname, ns0, env, qname.loc).toFailure
-      case Some(NamedAst.Declaration.Def(defn)) =>
+      case Some(defn: NamedAst.Declaration.Def) =>
         if (isDefAccessible(defn, ns0)) {
           DefOrSig.Def(defn).toSuccess
         } else {
           ResolutionError.InaccessibleDef(defn.sym, ns0, qname.loc).toFailure
         }
-      case Some(NamedAst.Declaration.Sig(sig)) =>
+      case Some(sig: NamedAst.Declaration.Sig) =>
         if (isSigAccessible(sig, ns0)) {
           DefOrSig.Sig(sig).toSuccess
         } else {
@@ -1601,11 +1601,11 @@ object Resolver {
   /**
     * Looks up the effect operation with qualified name `qname` in the namespace `ns0`.
     */
-  private def lookupOp(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Op, ResolutionError] = {
+  private def lookupOp(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Op, ResolutionError] = {
     val opOpt = tryLookupName(qname, ns0, root.symbols)
 
     opOpt match {
-      case Some(NamedAst.Declaration.Op(op)) =>
+      case Some(op: NamedAst.Declaration.Op) =>
         if (isOpAccessible(op, ns0)) {
           op.toSuccess
         } else {
@@ -1618,7 +1618,7 @@ object Resolver {
   /**
     * Looks up the effect operation as a member of the given effect.
     */
-  private def findOpInEffect(ident: Name.Ident, eff: NamedAst.Effect): Validation[NamedAst.Op, ResolutionError] = {
+  private def findOpInEffect(ident: Name.Ident, eff: NamedAst.Declaration.Effect): Validation[NamedAst.Declaration.Op, ResolutionError] = {
     val opOpt = eff.ops.find(o => o.sym.name == ident.name)
     opOpt match {
       case None =>
@@ -1632,16 +1632,16 @@ object Resolver {
   /**
     * Finds the enum that matches the given qualified name `qname` and `tag` in the namespace `ns0`.
     */
-  def lookupEnumByTag(qnameOpt: Option[Name.QName], tag: Name.Ident, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Enum, ResolutionError] = {
+  def lookupEnumByTag(qnameOpt: Option[Name.QName], tag: Name.Ident, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Enum, ResolutionError] = {
     // Determine whether the name is qualified.
     qnameOpt match {
       case None =>
         // Case 1: The name is unqualified.
 
         // Find all matching enums in the current namespace.
-        val namespaceMatches = mutable.Set.empty[NamedAst.Enum]
+        val namespaceMatches = mutable.Set.empty[NamedAst.Declaration.Enum]
         root.symbols.getOrElse(ns0, Map.empty).collect {
-          case (enumName, NamedAst.Declaration.Enum(decl)) =>
+          case (enumName, decl: NamedAst.Declaration.Enum) =>
             for ((enumTag, caze) <- decl.cases) {
               if (tag.name == enumTag) {
                 namespaceMatches += decl
@@ -1668,9 +1668,9 @@ object Resolver {
         }
 
         // Find all matching enums in the root namespace.
-        val globalMatches = mutable.Set.empty[NamedAst.Enum]
+        val globalMatches = mutable.Set.empty[NamedAst.Declaration.Enum]
         root.symbols.getOrElse(Name.RootNS, Map.empty).collect {
-          case (enumName, NamedAst.Declaration.Enum(decl)) =>
+          case (enumName, decl: NamedAst.Declaration.Enum) =>
             for ((enumTag, caze) <- decl.cases) {
               if (tag.name == enumTag) {
                 globalMatches += decl
@@ -1702,9 +1702,9 @@ object Resolver {
       case Some(qname) =>
         // Case 2: The name is qualified.
 
-        def lookupEnumInNs(ns: Name.NName): Option[NamedAst.Enum] = {
+        def lookupEnumInNs(ns: Name.NName): Option[NamedAst.Declaration.Enum] = {
           root.symbols.get(ns).flatMap(_.get(qname.ident.name)).collect {
-            case NamedAst.Declaration.Enum(e) => e
+            case e: NamedAst.Declaration.Enum => e
           }
         }
 
@@ -2106,17 +2106,17 @@ object Resolver {
     /**
       * The result is an enum.
       */
-    case class Enum(enum0: NamedAst.Enum) extends TypeLookupResult
+    case class Enum(enum0: NamedAst.Declaration.Enum) extends TypeLookupResult
 
     /**
       * The result is a type alias.
       */
-    case class TypeAlias(typeAlias: NamedAst.TypeAlias) extends TypeLookupResult
+    case class TypeAlias(typeAlias: NamedAst.Declaration.TypeAlias) extends TypeLookupResult
 
     /**
       * The result is an effect.
       */
-    case class Effect(eff: NamedAst.Effect) extends TypeLookupResult
+    case class Effect(eff: NamedAst.Declaration.Effect) extends TypeLookupResult
 
     /**
       * The type cannot be found.
@@ -2138,13 +2138,13 @@ object Resolver {
         case None =>
           // Case 1: name not found
           TypeLookupResult.NotFound
-        case Some(NamedAst.Declaration.TypeAlias(alias)) =>
+        case Some(alias: NamedAst.Declaration.TypeAlias) =>
           // Case 2: found a type alias
           TypeLookupResult.TypeAlias(alias)
-        case Some(NamedAst.Declaration.Enum(enum)) =>
+        case Some(enum: NamedAst.Declaration.Enum) =>
           // Case 3: found an enum
           TypeLookupResult.Enum(enum)
-        case Some(NamedAst.Declaration.Effect(effect)) =>
+        case Some(effect: NamedAst.Declaration.Effect) =>
           // Case 4: found an effect
           TypeLookupResult.Effect(effect)
         case _ =>
@@ -2168,11 +2168,11 @@ object Resolver {
   /**
     * Optionally returns the type alias with the given `name` in the given namespace `ns0`.
     */
-  private def lookupTypeAlias(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.TypeAlias, ResolutionError] = {
+  private def lookupTypeAlias(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.TypeAlias, ResolutionError] = {
     val symOpt = tryLookupName(qname, ns0, root.symbols)
 
     symOpt match {
-      case Some(NamedAst.Declaration.TypeAlias(alias)) => getTypeAliasIfAccessible(alias, ns0, qname.loc)
+      case Some(alias: NamedAst.Declaration.TypeAlias) => getTypeAliasIfAccessible(alias, ns0, qname.loc)
       case _ => ResolutionError.UndefinedName(qname, ns0, Map.empty, qname.loc).toFailure
     }
   }
@@ -2180,11 +2180,11 @@ object Resolver {
   /**
     * Looks up the definition or signature with qualified name `qname` in the namespace `ns0`.
     */
-  private def lookupEffect(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Effect, ResolutionError] = {
+  private def lookupEffect(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Effect, ResolutionError] = {
     val classOrEffOrEnumOpt = tryLookupName(qname, ns0, root.symbols)
 
     classOrEffOrEnumOpt match {
-      case Some(NamedAst.Declaration.Effect(eff)) => getEffectIfAccessible(eff, ns0, qname.loc)
+      case Some(eff: NamedAst.Declaration.Effect) => getEffectIfAccessible(eff, ns0, qname.loc)
       case _ => ResolutionError.UndefinedEffect(qname, ns0, qname.loc).toFailure
     }
   }
@@ -2226,7 +2226,7 @@ object Resolver {
     *
     * (A: Accessible, S: Sealed, I: Inaccessible)
     */
-  private def getClassAccessibility(class0: NamedAst.Class, ns0: Name.NName): ClassAccessibility = {
+  private def getClassAccessibility(class0: NamedAst.Declaration.Class, ns0: Name.NName): ClassAccessibility = {
 
     val classNs = class0.sym.namespace
     val accessingNs = ns0.idents.map(_.name)
@@ -2254,7 +2254,7 @@ object Resolver {
     * (a) the definition is marked public, or
     * (b) the definition is defined in the namespace `ns0` itself or in a parent of `ns0`.
     */
-  private def isDefAccessible(defn0: NamedAst.Def, ns0: Name.NName): Boolean = {
+  private def isDefAccessible(defn0: NamedAst.Declaration.Def, ns0: Name.NName): Boolean = {
     //
     // Check if the definition is marked public.
     //
@@ -2283,7 +2283,7 @@ object Resolver {
     * (a) the signature is marked public, or
     * (b) the signature is defined in the namespace `ns0` itself or in a parent of `ns0`.
     */
-  private def isSigAccessible(sig0: NamedAst.Sig, ns0: Name.NName): Boolean = {
+  private def isSigAccessible(sig0: NamedAst.Declaration.Sig, ns0: Name.NName): Boolean = {
     //
     // Check if the definition is marked public.
     //
@@ -2313,7 +2313,7 @@ object Resolver {
     * (a) the operation is marked public, or
     * (b) the operation is defined in the namespace `ns0` itself or in a parent of `ns0`.
     */
-  def isOpAccessible(op0: NamedAst.Op, ns0: Name.NName): Boolean = {
+  def isOpAccessible(op0: NamedAst.Declaration.Op, ns0: Name.NName): Boolean = {
     //
     // Check if the definition is marked public.
     //
@@ -2349,7 +2349,7 @@ object Resolver {
     *
     * (A: Accessible, O: Opaque, I: Inaccessible)
     */
-  private def getEnumAccessibility(enum0: NamedAst.Enum, ns0: Name.NName): EnumAccessibility = {
+  private def getEnumAccessibility(enum0: NamedAst.Declaration.Enum, ns0: Name.NName): EnumAccessibility = {
 
     val enumNs = enum0.sym.namespace
     val accessingNs = ns0.idents.map(_.name)
@@ -2380,7 +2380,7 @@ object Resolver {
     * (a) the definition is marked public, or
     * (b) the definition is defined in the namespace `ns0` itself or in a parent of `ns0`.
     */
-  def getEnumIfAccessible(enum0: NamedAst.Enum, ns0: Name.NName, loc: SourceLocation): Validation[NamedAst.Enum, ResolutionError] = {
+  def getEnumIfAccessible(enum0: NamedAst.Declaration.Enum, ns0: Name.NName, loc: SourceLocation): Validation[NamedAst.Declaration.Enum, ResolutionError] = {
     //
     // Check if the definition is marked public.
     //
@@ -2407,7 +2407,7 @@ object Resolver {
     *
     * Otherwise fails with a resolution error.
     */
-  private def getEnumTypeIfAccessible(enum0: NamedAst.Enum, ns0: Name.NName, loc: SourceLocation): Validation[UnkindedType, ResolutionError] =
+  private def getEnumTypeIfAccessible(enum0: NamedAst.Declaration.Enum, ns0: Name.NName, loc: SourceLocation): Validation[UnkindedType, ResolutionError] =
     getEnumIfAccessible(enum0, ns0, loc) map {
       case enum => mkEnum(enum.sym, loc)
     }
@@ -2422,7 +2422,7 @@ object Resolver {
     * (a) the definition is marked public, or
     * (b) the definition is defined in the namespace `ns0` itself or in a parent of `ns0`.
     */
-  private def getTypeAliasIfAccessible(alia0: NamedAst.TypeAlias, ns0: Name.NName, loc: SourceLocation): Validation[NamedAst.TypeAlias, ResolutionError] = {
+  private def getTypeAliasIfAccessible(alia0: NamedAst.Declaration.TypeAlias, ns0: Name.NName, loc: SourceLocation): Validation[NamedAst.Declaration.TypeAlias, ResolutionError] = {
     //
     // Check if the definition is marked public.
     //
@@ -2448,7 +2448,7 @@ object Resolver {
     *
     * Otherwise fails with a resolution error.
     */
-  private def getTypeAliasTypeIfAccessible(alia0: NamedAst.TypeAlias, ns0: Name.NName, root: NamedAst.Root, loc: SourceLocation): Validation[UnkindedType, ResolutionError] = {
+  private def getTypeAliasTypeIfAccessible(alia0: NamedAst.Declaration.TypeAlias, ns0: Name.NName, root: NamedAst.Root, loc: SourceLocation): Validation[UnkindedType, ResolutionError] = {
     getTypeAliasIfAccessible(alia0, ns0, loc) map {
       alias => mkUnappliedTypeAlias(alias.sym, loc)
     }
@@ -2464,7 +2464,7 @@ object Resolver {
     * (a) the definition is marked public, or
     * (b) the definition is defined in the namespace `ns0` itself or in a parent of `ns0`.
     */
-  private def getEffectIfAccessible(eff0: NamedAst.Effect, ns0: Name.NName, loc: SourceLocation): Validation[NamedAst.Effect, ResolutionError] = {
+  private def getEffectIfAccessible(eff0: NamedAst.Declaration.Effect, ns0: Name.NName, loc: SourceLocation): Validation[NamedAst.Declaration.Effect, ResolutionError] = {
     //
     // Check if the definition is marked public.
     //
@@ -2490,7 +2490,7 @@ object Resolver {
     *
     * Otherwise fails with a resolution error.
     */
-  private def getEffectTypeIfAccessible(eff0: NamedAst.Effect, ns0: Name.NName, root: NamedAst.Root, loc: SourceLocation): Validation[UnkindedType, ResolutionError] = {
+  private def getEffectTypeIfAccessible(eff0: NamedAst.Declaration.Effect, ns0: Name.NName, root: NamedAst.Root, loc: SourceLocation): Validation[UnkindedType, ResolutionError] = {
     getEffectIfAccessible(eff0, ns0, loc) map {
       alias => mkEffect(alias.sym, loc)
     }
@@ -2774,13 +2774,15 @@ object Resolver {
     * Gets the proper symbol from the given named symbol.
     */
   private def getSym(symbol: NamedAst.Declaration): Symbol = symbol match {
-    case Declaration.Class(c) => c.sym
-    case Declaration.Def(d) => d.sym
-    case Declaration.Effect(e) => e.sym
-    case Declaration.Enum(e) => e.sym
-    case Declaration.Op(o) => o.sym
-    case Declaration.Sig(s) => s.sym
-    case Declaration.TypeAlias(a) => a.sym
+    case Declaration.Namespace(sym, usesAndImports, decls, loc) => sym
+    case Declaration.Class(doc, ann, mod, sym, tparam, superClasses, sigs, laws, loc) => sym
+    case Declaration.Sig(sym, spec, exp) => sym
+    case Declaration.Def(sym, spec, exp) => sym
+    case Declaration.Enum(doc, ann, mod, sym, tparams, derives, cases, tpe, loc) => sym
+    case Declaration.TypeAlias(doc, mod, sym, tparams, tpe, loc) => sym
+    case Declaration.Effect(doc, ann, mod, sym, ops, loc) => sym
+    case Declaration.Op(sym, spec) => sym
+    case Declaration.Instance(doc, ann, mod, clazz, tpe, tconstrs, defs, loc) => throw InternalCompilerException("unexpected instance")
   }
 
   /**
@@ -2801,7 +2803,7 @@ object Resolver {
     }
 
     case NamedAst.UseOrImport.UseTag(qname, tag, _, loc) => tryLookupName(qname, ns, root.symbols) match {
-      case Some(NamedAst.Declaration.Enum(e)) =>
+      case Some(e: NamedAst.Declaration.Enum) =>
         e.cases.get(tag.name) match {
           case Some(NamedAst.Case(sym, _)) => Ast.Use(sym, loc).toSuccess
           case None => ResolutionError.UndefinedTag(tag.name, ns, loc).toFailure
@@ -2843,8 +2845,8 @@ object Resolver {
   private sealed trait DefOrSig
 
   private object DefOrSig {
-    case class Def(defn: NamedAst.Def) extends DefOrSig
+    case class Def(defn: NamedAst.Declaration.Def) extends DefOrSig
 
-    case class Sig(sig: NamedAst.Sig) extends DefOrSig
+    case class Sig(sig: NamedAst.Declaration.Sig) extends DefOrSig
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -336,7 +336,7 @@ object Resolver {
     * Performs name resolution on the given instance `i0` in the given namespace `ns0`.
     */
   def resolveInstance(i0: NamedAst.Declaration.Instance, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Instance, ResolutionError] = i0 match {
-    case NamedAst.Declaration.Instance(doc, ann0, mod, clazz0, tpe0, tconstrs0, defs0, loc) =>
+    case NamedAst.Declaration.Instance(doc, ann0, mod, clazz0, tpe0, tconstrs0, defs0, ns, loc) =>
       val annVal = traverse(ann0)(visitAnnotation(_, taenv, ns0, root))
       val clazzVal = lookupClassForImplementation(clazz0, ns0, root)
       val tpeVal = resolveType(tpe0, taenv, ns0, root)
@@ -345,7 +345,7 @@ object Resolver {
       mapN(annVal, clazzVal, tpeVal, tconstrsVal, defsVal) {
         case (ann, clazz, tpe, tconstrs, defs) =>
           val sym = Symbol.freshInstanceSym(clazz.sym, clazz0.loc)
-          ResolvedAst.Instance(doc, ann, mod, sym, tpe, tconstrs, defs, ns0, loc)
+          ResolvedAst.Instance(doc, ann, mod, sym, tpe, tconstrs, defs, Name.mkUnlocatedNName(ns), loc)
       }
   }
 
@@ -2788,7 +2788,7 @@ object Resolver {
     case Declaration.TypeAlias(doc, mod, sym, tparams, tpe, loc) => sym
     case Declaration.Effect(doc, ann, mod, sym, ops, loc) => sym
     case Declaration.Op(sym, spec) => sym
-    case Declaration.Instance(doc, ann, mod, clazz, tpe, tconstrs, defs, loc) => throw InternalCompilerException("unexpected instance")
+    case Declaration.Instance(doc, ann, mod, clazz, tpe, tconstrs, defs, ns, loc) => throw InternalCompilerException("unexpected instance")
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -77,22 +77,13 @@ object Weeder {
     * Weeds the given abstract syntax tree.
     */
   private def visitCompilationUnit(src: Ast.Source, unit: ParsedAst.CompilationUnit)(implicit flix: Flix): Validation[(Ast.Source, WeededAst.CompilationUnit), WeederError] = {
-    val allUses = unit.usesOrImports.collect {
-      case u: ParsedAst.Use => u
-    }
-    val usesVal = traverse(allUses)(visitUse)
-
-    val allImports = unit.usesOrImports.collect {
-      case i: ParsedAst.Import => i
-    }
-    val importsVal = traverse(allImports)(visitImport)
-
+    val usesAndImportsVal = traverse(unit.usesOrImports)(visitUseOrImport)
     val declarationsVal = traverse(unit.decls)(visitDecl)
     val loc = mkSL(unit.sp1, unit.sp2)
 
-    mapN(usesVal, importsVal, declarationsVal) {
-      case (uses, imports, decls) =>
-        src -> WeededAst.CompilationUnit(uses.flatten, imports.flatten, decls.flatten, loc)
+    mapN(usesAndImportsVal, declarationsVal) {
+      case (usesAndImports, decls) =>
+        src -> WeededAst.CompilationUnit(usesAndImports.flatten, decls.flatten, loc)
     }
   }
 
@@ -101,20 +92,12 @@ object Weeder {
     */
   private def visitDecl(decl: ParsedAst.Declaration)(implicit flix: Flix): Validation[List[WeededAst.Declaration], WeederError] = decl match {
     case ParsedAst.Declaration.Namespace(sp1, name, usesOrImports, decls, sp2) =>
-      val allUses = usesOrImports.collect {
-        case u: ParsedAst.Use => u
-      }
-      val usesVal = traverse(allUses)(visitUse)
-
-      val allImports = usesOrImports.collect {
-        case i: ParsedAst.Import => i
-      }
-      val importsVal = traverse(allImports)(visitImport)
+      val usesAndImportsVal = traverse(usesOrImports)(visitUseOrImport)
 
       val declarationsVal = traverse(decls)(visitDecl)
 
-      mapN(usesVal, importsVal, declarationsVal) {
-        case (us, is, ds) => List(WeededAst.Declaration.Namespace(name, us.flatten, is.flatten, ds.flatten, mkSL(sp1, sp2)))
+      mapN(usesAndImportsVal, declarationsVal) {
+        case (us, ds) => List(WeededAst.Declaration.Namespace(name, us.flatten, ds.flatten, mkSL(sp1, sp2)))
       }
 
     case d: ParsedAst.Declaration.Def => visitTopDef(d)
@@ -422,44 +405,42 @@ object Weeder {
   }
 
   /**
-    * Performs weeding on the given use `u0`.
+    * Performs weeding on the given use or import `u0`.
     */
-  private def visitUse(u0: ParsedAst.Use): Validation[List[WeededAst.Use], WeederError] = u0 match {
+  private def visitUseOrImport(u0: ParsedAst.UseOrImport): Validation[List[WeededAst.UseOrImport], WeederError] = u0 match {
     case ParsedAst.Use.UseOne(sp1, nname, ident, sp2) =>
       if (ident.isUpper)
-        List(WeededAst.Use.UseUpper(Name.QName(sp1, nname, ident, sp2), ident, mkSL(sp1, sp2))).toSuccess
+        List(WeededAst.UseOrImport.UseUpper(Name.QName(sp1, nname, ident, sp2), ident, mkSL(sp1, sp2))).toSuccess
       else
-        List(WeededAst.Use.UseLower(Name.QName(sp1, nname, ident, sp2), ident, mkSL(sp1, sp2))).toSuccess
+        List(WeededAst.UseOrImport.UseLower(Name.QName(sp1, nname, ident, sp2), ident, mkSL(sp1, sp2))).toSuccess
 
     case ParsedAst.Use.UseMany(_, nname, names, _) =>
-      val us = names.foldRight(Nil: List[WeededAst.Use]) {
+      val us = names.foldRight(Nil: List[WeededAst.UseOrImport]) {
         case (ParsedAst.Use.NameAndAlias(sp1, ident, aliasOpt, sp2), acc) =>
           val alias = aliasOpt.getOrElse(ident)
           if (ident.isUpper)
-            WeededAst.Use.UseUpper(Name.QName(sp1, nname, ident, sp2), alias, mkSL(sp1, sp2)) :: acc
+            WeededAst.UseOrImport.UseUpper(Name.QName(sp1, nname, ident, sp2), alias, mkSL(sp1, sp2)) :: acc
           else
-            WeededAst.Use.UseLower(Name.QName(sp1, nname, ident, sp2), alias, mkSL(sp1, sp2)) :: acc
+            WeededAst.UseOrImport.UseLower(Name.QName(sp1, nname, ident, sp2), alias, mkSL(sp1, sp2)) :: acc
       }
       us.toSuccess
 
     case ParsedAst.Use.UseOneTag(sp1, qname, tag, sp2) =>
-      List(WeededAst.Use.UseTag(qname, tag, tag, mkSL(sp1, sp2))).toSuccess
+      List(WeededAst.UseOrImport.UseTag(qname, tag, tag, mkSL(sp1, sp2))).toSuccess
 
     case ParsedAst.Use.UseManyTag(_, qname, tags, _) =>
-      val us = tags.foldRight(Nil: List[WeededAst.Use]) {
+      val us = tags.foldRight(Nil: List[WeededAst.UseOrImport]) {
         case (ParsedAst.Use.NameAndAlias(sp1, ident, aliasOpt, sp2), acc) =>
           val alias = aliasOpt.getOrElse(ident)
-          WeededAst.Use.UseTag(qname, ident, alias, mkSL(sp1, sp2)) :: acc
+          WeededAst.UseOrImport.UseTag(qname, ident, alias, mkSL(sp1, sp2)) :: acc
       }
       us.toSuccess
-  }
 
-  private def visitImport(i0: ParsedAst.Import): Validation[List[WeededAst.Import], WeederError] = i0 match {
     case ParsedAst.Imports.ImportOne(sp1, name, sp2) =>
       val loc = mkSL(sp1, sp2)
       val alias = name.fqn.last
       if (raw"[A-Z][A-Za-z0-9_!]*".r matches alias) {
-        List(WeededAst.Import.Import(name, Name.Ident(sp1, alias, sp2), loc)).toSuccess
+        List(WeededAst.UseOrImport.Import(name, Name.Ident(sp1, alias, sp2), loc)).toSuccess
       } else {
         WeederError.IllegalJavaClass(alias, loc).toFailure
       }
@@ -470,7 +451,7 @@ object Weeder {
         case ParsedAst.Imports.NameAndAlias(_, name, alias, _) =>
           val fqn = Name.JavaName(pkg.sp1, pkg.fqn :+ name, pkg.sp2)
           val ident = alias.getOrElse(Name.Ident(sp1, name, sp2))
-          WeededAst.Import.Import(fqn, ident, loc)
+          WeededAst.UseOrImport.Import(fqn, ident, loc)
       }
       is.toList.toSuccess
   }
@@ -492,7 +473,7 @@ object Weeder {
       WeededAst.Expression.Hole(name, loc).toSuccess
 
     case ParsedAst.Expression.Use(sp1, use, exp, sp2) =>
-      mapN(visitUse(use), visitExp(exp, senv)) {
+      mapN(visitUseOrImport(use), visitExp(exp, senv)) {
         case (us, e) => WeededAst.Expression.Use(us, e, mkSL(sp1, sp2))
       }
 

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -115,6 +115,13 @@ object Validation {
   def traverse[T, S, E](xs: Iterable[T])(f: T => Validation[S, E]): Validation[List[S], E] = fastTraverse(xs)(f)
 
   /**
+    * Traverses the given map, applying the function `f` to each value.
+    */
+  def traverseValues[K, V1, V2, E](xs: Map[K, V1])(f: V1 => Validation[V2, E]): Validation[Map[K, V2], E] = {
+    
+  }
+
+  /**
     * Traverses `o` applying the function `f` to the value, if it exists.
     */
   def traverseOpt[T, S, E](o: Option[T])(f: T => Validation[S, E]): Validation[Option[S], E] = o match {

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -118,7 +118,9 @@ object Validation {
     * Traverses the given map, applying the function `f` to each value.
     */
   def traverseValues[K, V1, V2, E](xs: Map[K, V1])(f: V1 => Validation[V2, E]): Validation[Map[K, V2], E] = {
-    
+    traverse(xs) {
+      case (k, v0) => mapN(f(v0))(v => k -> v)
+    }.map(_.toMap)
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -231,410 +231,411 @@ class TestNamer extends FunSuite with TestUtils {
     expectError[NameError.DuplicateLowerName](result)
   }
 
-  test("DuplicateUseLower.01") {
-    val input =
-      s"""
-         |def foo(): Bool =
-         |    use A.f;
-         |    use B.f;
-         |    f() == f()
-         |
-         |namespace A {
-         |    def f(): Int = 1
-         |}
-         |
-         |namespace B {
-         |    def f(): Int = 1
-         |}
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUseLower](result)
-  }
-
-  test("DuplicateUseLower.02") {
-    val input =
-      s"""
-         |use A.f
-         |use B.f
-         |
-         |def foo(): Bool =
-         |    f() == f()
-         |
-         |namespace A {
-         |    pub def f(): Int = 1
-         |}
-         |
-         |namespace B {
-         |    pub def f(): Int = 1
-         |}
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUseLower](result)
-  }
-
-  test("DuplicateUseLower.03") {
-    val input =
-      s"""
-         |use A.f
-         |
-         |def foo(): Bool =
-         |    use B.f;
-         |    f() == f()
-         |
-         |namespace A {
-         |    pub def f(): Int = 1
-         |}
-         |
-         |namespace B {
-         |    pub def f(): Int = 1
-         |}
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUseLower](result)
-  }
-
-  test("DuplicateUseLower.04") {
-    val input =
-      s"""
-         |def foo(): Bool =
-         |    use A.{f => g, f => g};
-         |    g() == g()
-         |
-         |namespace A {
-         |    pub def f(): Int = 1
-         |}
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUseLower](result)
-  }
-
-
-  test("DuplicateUseLower.05") {
-    val input =
-      s"""
-         |namespace T {
-         |    def foo(): Bool =
-         |        use A.f;
-         |        use B.f;
-         |        f() == f()
-         |}
-         |
-         |namespace A {
-         |    pub def f(): Int = 1
-         |}
-         |
-         |namespace B {
-         |    pub def f(): Int = 1
-         |}
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUseLower](result)
-  }
-
-  test("DuplicateUseLower.06") {
-    val input =
-      s"""
-         |namespace T {
-         |    use A.f
-         |    use B.f
-         |    def foo(): Bool =
-         |        f() == f()
-         |}
-         |
-         |namespace A {
-         |    pub def f(): Int = 1
-         |}
-         |
-         |namespace B {
-         |    pub def f(): Int = 1
-         |}
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUseLower](result)
-  }
-
-  test("DuplicateUseLower.07") {
-    val input =
-      s"""
-         |namespace T {
-         |    use A.{f => g, f => g}
-         |    def foo(): Bool =
-         |        g() == g()
-         |}
-         |
-         |namespace A {
-         |    pub def f(): Int = 1
-         |}
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUseLower](result)
-  }
-
-  test("DuplicateUseLower.08") {
-    val input =
-      s"""
-         |namespace T {
-         |    use A.f
-         |    def foo(): Bool =
-         |        use B.f;
-         |        f() == f()
-         |}
-         |
-         |namespace A {
-         |    pub def f(): Int = 1
-         |}
-         |
-         |namespace B {
-         |    pub def f(): Int = 1
-         |}
-         |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUseLower](result)
-  }
-
-  test("DuplicateUseUpper.01") {
-    val input =
-      s"""
-         |def foo(): Bool =
-         |    use A.Color;
-         |    use B.Color;
-         |    true
-         |
-         |namespace A {
-         |    enum Color {
-         |        case Red, Blue
-         |    }
-         |}
-         |
-         |namespace B {
-         |    enum Color {
-         |        case Red, Blue
-         |    }
-         |}
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUpperName](result)
-  }
-
-  test("DuplicateUseUpper.02") {
-    val input =
-      s"""
-         |use A.Color
-         |use B.Color
-         |
-         |def foo(): Bool = true
-         |
-         |namespace A {
-         |    enum Color {
-         |        case Red, Blue
-         |    }
-         |}
-         |
-         |namespace B {
-         |    enum Color {
-         |        case Red, Blue
-         |    }
-         |}
-         |
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUpperName](result)
-  }
-
-  test("DuplicateUseUpper.03") {
-    val input =
-      s"""
-         |namespace T {
-         |    use A.Color
-         |    use B.Color
-         |    def foo(): Bool =
-         |        true
-         |}
-         |
-         |namespace A {
-         |    enum Color {
-         |        case Red, Blue
-         |    }
-         |}
-         |
-         |namespace B {
-         |    enum Color {
-         |        case Red, Blue
-         |    }
-         |}
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUpperName](result)
-  }
-
-  test("DuplicateUseTag.01") {
-    val input =
-      s"""
-         |def foo(): Bool =
-         |    use A.Color.Red;
-         |    use B.Color.Red;
-         |    Red == Red
-         |
-         |namespace A {
-         |    enum Color {
-         |        case Red, Blu
-         |    }
-         |}
-         |
-         |namespace B {
-         |    enum Color {
-         |        case Red, Blu
-         |    }
-         |}
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUseTag](result)
-  }
-
-  test("DuplicateUseTag.02") {
-    val input =
-      s"""
-         |use A.Color.Red
-         |use B.Color.Red
-         |def foo(): Bool =
-         |    Red == Red
-         |
-         |namespace A {
-         |    enum Color {
-         |        case Red, Blu
-         |    }
-         |}
-         |
-         |namespace B {
-         |    enum Color {
-         |        case Red, Blu
-         |    }
-         |}
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUseTag](result)
-  }
-
-  test("DuplicateUseTag.03") {
-    val input =
-      s"""
-         |
-         |use A.Color.Red
-         |def foo(): Bool =
-         |    use B.Color.Red;
-         |    Red == Red
-         |
-         |namespace A {
-         |    enum Color {
-         |        case Red, Blu
-         |    }
-         |}
-         |
-         |namespace B {
-         |    enum Color {
-         |        case Red, Blu
-         |    }
-         |}
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUseTag](result)
-  }
-
-  test("DuplicateUseTag.04") {
-    val input =
-      s"""
-         |def foo(): Bool =
-         |    use B.Color.{Red => R};
-         |    use B.Color.{Blu => R};
-         |    R == R
-         |
-         |namespace A {
-         |    enum Color {
-         |        case Red, Blu
-         |    }
-         |}
-         |
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUseTag](result)
-  }
-
-  test("DuplicateUseTag.05") {
-    val input =
-      s"""
-         |namespace T {
-         |    use A.Color.Red
-         |    use B.Color.Red
-         |    def foo(): Bool =
-         |        Red == Red
-         |}
-         |
-         |def foo(): Bool =
-         |    use A.Color.Red;
-         |    use B.Color.Red;
-         |    Red == Red
-         |
-         |namespace A {
-         |    enum Color {
-         |        case Red, Blu
-         |    }
-         |}
-         |
-         |namespace B {
-         |    enum Color {
-         |        case Red, Blu
-         |    }
-         |}
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUseTag](result)
-  }
-
-  test("DuplicateUseTag.06") {
-    val input =
-      s"""
-         |namespace T {
-         |    use A.Color.Red
-         |    def foo(): Bool =
-         |        use B.Color.Red;
-         |        Red == Red
-         |}
-         |
-         |namespace A {
-         |    enum Color {
-         |        case Red, Blu
-         |    }
-         |}
-         |
-         |namespace B {
-         |    enum Color {
-         |        case Red, Blu
-         |    }
-         |}
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUseTag](result)
-  }
-
-  test("DuplicateUseTag.07") {
-    val input =
-      s"""
-         |namespace T {
-         |    use B.Color.{Red => R}
-         |    use B.Color.{Blu => R}
-         |    def foo(): Bool =
-         |        R == R
-         |}
-         |namespace A {
-         |    enum Color {
-         |        case Red, Blu
-         |    }
-         |}
-         |
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUseTag](result)
-  }
+  // TODO these errors will be moved to Redundancy
+//  test("DuplicateUseLower.01") {
+//    val input =
+//      s"""
+//         |def foo(): Bool =
+//         |    use A.f;
+//         |    use B.f;
+//         |    f() == f()
+//         |
+//         |namespace A {
+//         |    def f(): Int = 1
+//         |}
+//         |
+//         |namespace B {
+//         |    def f(): Int = 1
+//         |}
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUseLower](result)
+//  }
+//
+//  test("DuplicateUseLower.02") {
+//    val input =
+//      s"""
+//         |use A.f
+//         |use B.f
+//         |
+//         |def foo(): Bool =
+//         |    f() == f()
+//         |
+//         |namespace A {
+//         |    pub def f(): Int = 1
+//         |}
+//         |
+//         |namespace B {
+//         |    pub def f(): Int = 1
+//         |}
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUseLower](result)
+//  }
+//
+//  test("DuplicateUseLower.03") {
+//    val input =
+//      s"""
+//         |use A.f
+//         |
+//         |def foo(): Bool =
+//         |    use B.f;
+//         |    f() == f()
+//         |
+//         |namespace A {
+//         |    pub def f(): Int = 1
+//         |}
+//         |
+//         |namespace B {
+//         |    pub def f(): Int = 1
+//         |}
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUseLower](result)
+//  }
+//
+//  test("DuplicateUseLower.04") {
+//    val input =
+//      s"""
+//         |def foo(): Bool =
+//         |    use A.{f => g, f => g};
+//         |    g() == g()
+//         |
+//         |namespace A {
+//         |    pub def f(): Int = 1
+//         |}
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUseLower](result)
+//  }
+//
+//
+//  test("DuplicateUseLower.05") {
+//    val input =
+//      s"""
+//         |namespace T {
+//         |    def foo(): Bool =
+//         |        use A.f;
+//         |        use B.f;
+//         |        f() == f()
+//         |}
+//         |
+//         |namespace A {
+//         |    pub def f(): Int = 1
+//         |}
+//         |
+//         |namespace B {
+//         |    pub def f(): Int = 1
+//         |}
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUseLower](result)
+//  }
+//
+//  test("DuplicateUseLower.06") {
+//    val input =
+//      s"""
+//         |namespace T {
+//         |    use A.f
+//         |    use B.f
+//         |    def foo(): Bool =
+//         |        f() == f()
+//         |}
+//         |
+//         |namespace A {
+//         |    pub def f(): Int = 1
+//         |}
+//         |
+//         |namespace B {
+//         |    pub def f(): Int = 1
+//         |}
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUseLower](result)
+//  }
+//
+//  test("DuplicateUseLower.07") {
+//    val input =
+//      s"""
+//         |namespace T {
+//         |    use A.{f => g, f => g}
+//         |    def foo(): Bool =
+//         |        g() == g()
+//         |}
+//         |
+//         |namespace A {
+//         |    pub def f(): Int = 1
+//         |}
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUseLower](result)
+//  }
+//
+//  test("DuplicateUseLower.08") {
+//    val input =
+//      s"""
+//         |namespace T {
+//         |    use A.f
+//         |    def foo(): Bool =
+//         |        use B.f;
+//         |        f() == f()
+//         |}
+//         |
+//         |namespace A {
+//         |    pub def f(): Int = 1
+//         |}
+//         |
+//         |namespace B {
+//         |    pub def f(): Int = 1
+//         |}
+//         |""".stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUseLower](result)
+//  }
+//
+//  test("DuplicateUseUpper.01") {
+//    val input =
+//      s"""
+//         |def foo(): Bool =
+//         |    use A.Color;
+//         |    use B.Color;
+//         |    true
+//         |
+//         |namespace A {
+//         |    enum Color {
+//         |        case Red, Blue
+//         |    }
+//         |}
+//         |
+//         |namespace B {
+//         |    enum Color {
+//         |        case Red, Blue
+//         |    }
+//         |}
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUpperName](result)
+//  }
+//
+//  test("DuplicateUseUpper.02") {
+//    val input =
+//      s"""
+//         |use A.Color
+//         |use B.Color
+//         |
+//         |def foo(): Bool = true
+//         |
+//         |namespace A {
+//         |    enum Color {
+//         |        case Red, Blue
+//         |    }
+//         |}
+//         |
+//         |namespace B {
+//         |    enum Color {
+//         |        case Red, Blue
+//         |    }
+//         |}
+//         |
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUpperName](result)
+//  }
+//
+//  test("DuplicateUseUpper.03") {
+//    val input =
+//      s"""
+//         |namespace T {
+//         |    use A.Color
+//         |    use B.Color
+//         |    def foo(): Bool =
+//         |        true
+//         |}
+//         |
+//         |namespace A {
+//         |    enum Color {
+//         |        case Red, Blue
+//         |    }
+//         |}
+//         |
+//         |namespace B {
+//         |    enum Color {
+//         |        case Red, Blue
+//         |    }
+//         |}
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUpperName](result)
+//  }
+//
+//  test("DuplicateUseTag.01") {
+//    val input =
+//      s"""
+//         |def foo(): Bool =
+//         |    use A.Color.Red;
+//         |    use B.Color.Red;
+//         |    Red == Red
+//         |
+//         |namespace A {
+//         |    enum Color {
+//         |        case Red, Blu
+//         |    }
+//         |}
+//         |
+//         |namespace B {
+//         |    enum Color {
+//         |        case Red, Blu
+//         |    }
+//         |}
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUseTag](result)
+//  }
+//
+//  test("DuplicateUseTag.02") {
+//    val input =
+//      s"""
+//         |use A.Color.Red
+//         |use B.Color.Red
+//         |def foo(): Bool =
+//         |    Red == Red
+//         |
+//         |namespace A {
+//         |    enum Color {
+//         |        case Red, Blu
+//         |    }
+//         |}
+//         |
+//         |namespace B {
+//         |    enum Color {
+//         |        case Red, Blu
+//         |    }
+//         |}
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUseTag](result)
+//  }
+//
+//  test("DuplicateUseTag.03") {
+//    val input =
+//      s"""
+//         |
+//         |use A.Color.Red
+//         |def foo(): Bool =
+//         |    use B.Color.Red;
+//         |    Red == Red
+//         |
+//         |namespace A {
+//         |    enum Color {
+//         |        case Red, Blu
+//         |    }
+//         |}
+//         |
+//         |namespace B {
+//         |    enum Color {
+//         |        case Red, Blu
+//         |    }
+//         |}
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUseTag](result)
+//  }
+//
+//  test("DuplicateUseTag.04") {
+//    val input =
+//      s"""
+//         |def foo(): Bool =
+//         |    use B.Color.{Red => R};
+//         |    use B.Color.{Blu => R};
+//         |    R == R
+//         |
+//         |namespace A {
+//         |    enum Color {
+//         |        case Red, Blu
+//         |    }
+//         |}
+//         |
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUseTag](result)
+//  }
+//
+//  test("DuplicateUseTag.05") {
+//    val input =
+//      s"""
+//         |namespace T {
+//         |    use A.Color.Red
+//         |    use B.Color.Red
+//         |    def foo(): Bool =
+//         |        Red == Red
+//         |}
+//         |
+//         |def foo(): Bool =
+//         |    use A.Color.Red;
+//         |    use B.Color.Red;
+//         |    Red == Red
+//         |
+//         |namespace A {
+//         |    enum Color {
+//         |        case Red, Blu
+//         |    }
+//         |}
+//         |
+//         |namespace B {
+//         |    enum Color {
+//         |        case Red, Blu
+//         |    }
+//         |}
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUseTag](result)
+//  }
+//
+//  test("DuplicateUseTag.06") {
+//    val input =
+//      s"""
+//         |namespace T {
+//         |    use A.Color.Red
+//         |    def foo(): Bool =
+//         |        use B.Color.Red;
+//         |        Red == Red
+//         |}
+//         |
+//         |namespace A {
+//         |    enum Color {
+//         |        case Red, Blu
+//         |    }
+//         |}
+//         |
+//         |namespace B {
+//         |    enum Color {
+//         |        case Red, Blu
+//         |    }
+//         |}
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUseTag](result)
+//  }
+//
+//  test("DuplicateUseTag.07") {
+//    val input =
+//      s"""
+//         |namespace T {
+//         |    use B.Color.{Red => R}
+//         |    use B.Color.{Blu => R}
+//         |    def foo(): Bool =
+//         |        R == R
+//         |}
+//         |namespace A {
+//         |    enum Color {
+//         |        case Red, Blu
+//         |    }
+//         |}
+//         |
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUseTag](result)
+//  }
 
   test("DuplicateUpperName.01") {
     val input =

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -943,41 +943,42 @@ class TestNamer extends FunSuite with TestUtils {
     expectError[NameError.DuplicateUpperName](result)
   }
 
-  test("DuplicateUpperName.25") {
-    val input =
-      """
-        |namespace A {
-        |    use B.Statement
-        |    import java.sql.Statement
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUpperName](result)
-  }
-
-  test("DuplicateUpperName.26") {
-    val input =
-      """
-        |enum Statement
-        |namespace A {
-        |    use B.Statement
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUpperName](result)
-  }
-
-  test("DuplicateUpperName.27") {
-    val input =
-      """
-        |enum Statement
-        |namespace A {
-        |    import B.Statement
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUpperName](result)
-  }
+  // TODO move these tests to Redundancy
+//  test("DuplicateUpperName.25") {
+//    val input =
+//      """
+//        |namespace A {
+//        |    use B.Statement
+//        |    import java.sql.Statement
+//        |}
+//        |""".stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUpperName](result)
+//  }
+//
+//  test("DuplicateUpperName.26") {
+//    val input =
+//      """
+//        |enum Statement
+//        |namespace A {
+//        |    use B.Statement
+//        |}
+//        |""".stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUpperName](result)
+//  }
+//
+//  test("DuplicateUpperName.27") {
+//    val input =
+//      """
+//        |enum Statement
+//        |namespace A {
+//        |    import B.Statement
+//        |}
+//        |""".stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUpperName](result)
+//  }
 
   test("SuspiciousTypeVarName.01") {
     val input =
@@ -1154,49 +1155,50 @@ class TestNamer extends FunSuite with TestUtils {
     expectError[NameError.IllegalSignature](result)
   }
 
-  test("DuplicateImport.01") {
-    val input =
-      """
-        |import java.lang.StringBuffer
-        |import java.lang.StringBuffer
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUpperName](result)
-  }
-
-  test("DuplicateImport.02") {
-    val input =
-      """
-        |import java.lang.{StringBuffer => StringThingy}
-        |import java.lang.{StringBuffer => StringThingy}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUpperName](result)
-  }
-
-  test("DuplicateImport.03") {
-    val input =
-      """
-        |namespace A {
-        |    import java.lang.StringBuffer
-        |    import java.lang.StringBuffer
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUpperName](result)
-  }
-
-  test("DuplicateImport.04") {
-    val input =
-      """
-        |namespace A {
-        |    import java.lang.{StringBuffer => StringThingy}
-        |    import java.lang.{StringBuilder => StringThingy}
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUpperName](result)
-  }
+  // TODO move these tests to Redundancy
+//  test("DuplicateImport.01") {
+//    val input =
+//      """
+//        |import java.lang.StringBuffer
+//        |import java.lang.StringBuffer
+//        |""".stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUpperName](result)
+//  }
+//
+//  test("DuplicateImport.02") {
+//    val input =
+//      """
+//        |import java.lang.{StringBuffer => StringThingy}
+//        |import java.lang.{StringBuffer => StringThingy}
+//        |""".stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUpperName](result)
+//  }
+//
+//  test("DuplicateImport.03") {
+//    val input =
+//      """
+//        |namespace A {
+//        |    import java.lang.StringBuffer
+//        |    import java.lang.StringBuffer
+//        |}
+//        |""".stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUpperName](result)
+//  }
+//
+//  test("DuplicateImport.04") {
+//    val input =
+//      """
+//        |namespace A {
+//        |    import java.lang.{StringBuffer => StringThingy}
+//        |    import java.lang.{StringBuilder => StringThingy}
+//        |}
+//        |""".stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUpperName](result)
+//  }
 
   test("IllegalWildType.01") {
     val input =


### PR DESCRIPTION
The Namer is changed to two passes:
1. To transform the tree
2. To build the symbol table.

The symbol table consists of 3 parts:
1. symbols: namespace -> declaration
2. instances: namespace -> declaration
  - instances are treated different
3. uses: namespace -> uses/imports

There are a few TODOs I have accumulated which I didn't think directly relevant to the PR:
1. Avoid using `NName`: I think this may even be removed from the compiler altogether, or at least greatly limited
2. Remove `tenv` from cases in `Namer` where it's not used
3. parallelize the first pass in Namer
  - This could be done now but I am interested in seeing the impact parallel vs. non-parallel

In the next step, uses and imports can be largely moved to `Resolver`, I think.

related to #4967 