### PR TITLE
feat: Add region to select effect

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -1661,7 +1661,7 @@ object Typer {
               _ <- unifyTypeM(chanType, Type.mkReceiver(sym.tvar, regionVar, sym.loc), sym.loc)
               resultCon = chanConstrs ++ bodyConstrs
               resultTyp = bodyType
-              resultPur = Type.mkAnd(pur1, pur2, loc)
+              resultPur = Type.mkAnd(pur1, pur2, regionVar, loc)
               resultEff = Type.mkUnion(chanEff, bodyEff, loc)
             } yield (resultCon, resultTyp, resultPur, resultEff)
           }


### PR DESCRIPTION
This is, I think, all that's necessary to address the "Modify the type rule for Select to use the regions of all the Sender[t, r] as its effect." task of #4850?