### PR TITLE
refactor: resolve uses and imports in Resolver

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -180,7 +180,7 @@ object Indexer {
       Index.occurrenceOf(exp0) ++ visitExp(exp)
 
     case Expression.Use(_, _, _) =>
-      Index.occurrenceOf(exp0) // TODO add use of sym
+      Index.occurrenceOf(exp0) // TODO NS-REFACTOR add use of sym
 
     case Expression.Lambda(fparam, exp, _, _) =>
       visitFormalParam(fparam) ++ visitExp(exp) ++ Index.occurrenceOf(exp0)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -288,7 +288,7 @@ object SemanticTokensProvider {
 
     case Expression.HoleWithExp(exp, _, _, _, _) => visitExp(exp)
 
-    case Expression.Use(_, _, _) => Iterator.empty // TODO add token for sym
+    case Expression.Use(_, _, _) => Iterator.empty // TODO NS-REFACTOR add token for sym
 
     case Expression.Cst(_, _, _) => Iterator.empty
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -651,8 +651,12 @@ object Ast {
   case class AliasConstructor(sym: Symbol.TypeAliasSym, loc: SourceLocation)
 
   /**
-    * A use of a symbol in a `use` construct.
+    * A use of a Flix symbol or import of a Java class.
     */
-  case class Use(sym: Symbol, loc: SourceLocation)
+  sealed trait UseOrImport
+  object UseOrImport {
+    case class Use(sym: Symbol, alias: Name.Ident, loc: SourceLocation) extends UseOrImport
+    case class Import(clazz: Class[_], alias: Name.Ident, loc: SourceLocation) extends UseOrImport
+  }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -655,7 +655,15 @@ object Ast {
     */
   sealed trait UseOrImport
   object UseOrImport {
+
+    /**
+      * A use of a Flix declaration symbol.
+      */
     case class Use(sym: Symbol, alias: Name.Ident, loc: SourceLocation) extends UseOrImport
+
+    /**
+      * An import of a Java class.
+      */
     case class Import(clazz: Class[_], alias: Name.Ident, loc: SourceLocation) extends UseOrImport
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -30,7 +30,7 @@ object KindedAst {
                   enums: Map[Symbol.EnumSym, KindedAst.Enum],
                   effects: Map[Symbol.EffectSym, KindedAst.Effect],
                   typeAliases: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias],
-                  uses: Map[Symbol.ModuleSym, List[Ast.Use]],
+                  uses: Map[Symbol.ModuleSym, List[Ast.UseOrImport]],
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],
                   names: MultiMap[List[String], String])

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -46,13 +46,15 @@ object NamedAst {
 
     case class Def(sym: Symbol.DefnSym, spec: NamedAst.Spec, exp: NamedAst.Expression) extends NamedAst.Declaration
 
-    case class Enum(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.EnumSym, tparams: NamedAst.TypeParams, derives: List[Name.QName], cases: Map[String, NamedAst.Case], tpe: NamedAst.Type, loc: SourceLocation) extends NamedAst.Declaration
+    case class Enum(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.EnumSym, tparams: NamedAst.TypeParams, derives: List[Name.QName], cases: Map[String, NamedAst.Declaration.Case], tpe: NamedAst.Type, loc: SourceLocation) extends NamedAst.Declaration
 
     case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.TypeAliasSym, tparams: NamedAst.TypeParams, tpe: NamedAst.Type, loc: SourceLocation) extends NamedAst.Declaration
 
     case class Effect(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[NamedAst.Declaration.Op], loc: SourceLocation) extends NamedAst.Declaration
 
     case class Op(sym: Symbol.OpSym, spec: NamedAst.Spec) extends NamedAst.Declaration
+
+    case class Case(sym: Symbol.CaseSym, tpe: NamedAst.Type) extends NamedAst.Declaration
   }
 
   case class Spec(doc: Ast.Doc, ann: List[NamedAst.Annotation], mod: Ast.Modifiers, tparams: NamedAst.TypeParams, fparams: List[NamedAst.FormalParam], retTpe: NamedAst.Type, purAndEff: PurityAndEffect, tconstrs: List[NamedAst.TypeConstraint], loc: SourceLocation)
@@ -85,6 +87,9 @@ object NamedAst {
     case class Var(sym: Symbol.VarSym, loc: SourceLocation) extends NamedAst.Expression
 
     case class DefOrSig(name: Name.QName, env: Map[String, Symbol.VarSym], loc: SourceLocation) extends NamedAst.Expression
+
+    // TODO remove after moving var resolution to Resolver
+    case class UnqualifiedDefOrSig(name: Name.Ident, env: Map[String, Symbol.VarSym], loc: SourceLocation) extends NamedAst.Expression
 
     case class Hole(name: Option[Name.Ident], loc: SourceLocation) extends NamedAst.Expression
 
@@ -367,8 +372,6 @@ object NamedAst {
   case class Annotation(name: Ast.Annotation, args: List[NamedAst.Expression], loc: SourceLocation)
 
   case class Attribute(ident: Name.Ident, tpe: NamedAst.Type, loc: SourceLocation)
-
-  case class Case(sym: Symbol.CaseSym, tpe: NamedAst.Type)
 
   case class ConstrainedType(ident: Name.Ident, classes: List[Name.QName])
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -88,7 +88,7 @@ object NamedAst {
 
     case class DefOrSig(name: Name.QName, env: Map[String, Symbol.VarSym], loc: SourceLocation) extends NamedAst.Expression
 
-    // TODO remove after moving var resolution to Resolver
+    // TODO NS-REFACTOR remove after moving var resolution to Resolver
     case class UnqualifiedDefOrSig(name: Name.Ident, env: Map[String, Symbol.VarSym], loc: SourceLocation) extends NamedAst.Expression
 
     case class Hole(name: Option[Name.Ident], loc: SourceLocation) extends NamedAst.Expression

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -29,30 +29,36 @@ object ResolvedAst {
                   enums: Map[Symbol.EnumSym, ResolvedAst.Enum],
                   effects: Map[Symbol.EffectSym, ResolvedAst.Effect],
                   typeAliases: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias],
-                  uses: Map[Symbol.ModuleSym, List[Ast.Use]],
+                  uses: Map[Symbol.ModuleSym, List[Ast.UseOrImport]],
                   taOrder: List[Symbol.TypeAliasSym],
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],
                   names: MultiMap[List[String], String])
 
   // TODO use ResolvedAst.Law for laws
-  case class Class(doc: Ast.Doc, ann: List[ResolvedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: ResolvedAst.TypeParam, superClasses: List[ResolvedAst.TypeConstraint], sigs: Map[Symbol.SigSym, ResolvedAst.Sig], laws: List[ResolvedAst.Def], loc: SourceLocation)
+  case class CompilationUnit(usesAndImports: List[Ast.UseOrImport], decls: List[Declaration], loc: SourceLocation)
+  case class Namespace(sym: Symbol.ModuleSym, usesAndImports: List[Ast.UseOrImport], decls: List[Declaration], loc: SourceLocation) extends Declaration
+  case class Class(doc: Ast.Doc, ann: List[ResolvedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: ResolvedAst.TypeParam, superClasses: List[ResolvedAst.TypeConstraint], sigs: Map[Symbol.SigSym, ResolvedAst.Sig], laws: List[ResolvedAst.Def], loc: SourceLocation) extends Declaration
 
-  case class Instance(doc: Ast.Doc, ann: List[ResolvedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.InstanceSym, tpe: UnkindedType, tconstrs: List[ResolvedAst.TypeConstraint], defs: List[ResolvedAst.Def], ns: Name.NName, loc: SourceLocation)
+  case class Instance(doc: Ast.Doc, ann: List[ResolvedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.InstanceSym, tpe: UnkindedType, tconstrs: List[ResolvedAst.TypeConstraint], defs: List[ResolvedAst.Def], ns: Name.NName, loc: SourceLocation) extends Declaration
 
-  case class Sig(sym: Symbol.SigSym, spec: ResolvedAst.Spec, exp: Option[ResolvedAst.Expression])
+  case class Sig(sym: Symbol.SigSym, spec: ResolvedAst.Spec, exp: Option[ResolvedAst.Expression]) extends Declaration
 
-  case class Def(sym: Symbol.DefnSym, spec: ResolvedAst.Spec, exp: ResolvedAst.Expression)
+  case class Def(sym: Symbol.DefnSym, spec: ResolvedAst.Spec, exp: ResolvedAst.Expression) extends Declaration
 
   case class Spec(doc: Ast.Doc, ann: List[ResolvedAst.Annotation], mod: Ast.Modifiers, tparams: ResolvedAst.TypeParams, fparams: List[ResolvedAst.FormalParam], tpe: UnkindedType, purAndEff: UnkindedType.PurityAndEffect, tconstrs: List[ResolvedAst.TypeConstraint], loc: SourceLocation)
 
-  case class Enum(doc: Ast.Doc, ann: List[ResolvedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.EnumSym, tparams: ResolvedAst.TypeParams, derives: List[Ast.Derivation], cases: List[ResolvedAst.Case], tpe: UnkindedType, loc: SourceLocation)
+  case class Enum(doc: Ast.Doc, ann: List[ResolvedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.EnumSym, tparams: ResolvedAst.TypeParams, derives: List[Ast.Derivation], cases: List[ResolvedAst.Case], tpe: UnkindedType, loc: SourceLocation) extends Declaration
 
-  case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.TypeAliasSym, tparams: ResolvedAst.TypeParams, tpe: UnkindedType, loc: SourceLocation)
+  case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.TypeAliasSym, tparams: ResolvedAst.TypeParams, tpe: UnkindedType, loc: SourceLocation) extends Declaration
 
-  case class Effect(doc: Ast.Doc, ann: List[ResolvedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[ResolvedAst.Op], loc: SourceLocation)
+  case class Effect(doc: Ast.Doc, ann: List[ResolvedAst.Annotation], mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[ResolvedAst.Op], loc: SourceLocation) extends Declaration
 
-  case class Op(sym: Symbol.OpSym, spec: ResolvedAst.Spec)
+  case class Op(sym: Symbol.OpSym, spec: ResolvedAst.Spec) extends Declaration
+
+  // MATT make Declaration object
+  // MATT or maybe kill this if unneeded
+  sealed trait Declaration
 
   sealed trait Expression {
     def loc: SourceLocation

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -56,8 +56,7 @@ object ResolvedAst {
 
   case class Op(sym: Symbol.OpSym, spec: ResolvedAst.Spec) extends Declaration
 
-  // MATT make Declaration object
-  // MATT or maybe kill this if unneeded
+  // TODO NS-REFACTOR make Declaration object
   sealed trait Declaration
 
   sealed trait Expression {

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -33,7 +33,7 @@ object TypedAst {
                   enums: Map[Symbol.EnumSym, TypedAst.Enum],
                   effects: Map[Symbol.EffectSym, TypedAst.Effect],
                   typeAliases: Map[Symbol.TypeAliasSym, TypedAst.TypeAlias],
-                  uses: Map[Symbol.ModuleSym, List[Ast.Use]],
+                  uses: Map[Symbol.ModuleSym, List[Ast.UseOrImport]],
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],
                   classEnv: Map[Symbol.ClassSym, Ast.ClassContext],

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -71,8 +71,7 @@ object Namer {
   private def visitUnit(unit: WeededAst.CompilationUnit)(implicit flix: Flix): Validation[NamedAst.CompilationUnit, NameError] = unit match {
     case WeededAst.CompilationUnit(usesAndImports0, decls0, loc) =>
       val usesAndImports = usesAndImports0.map(visitUseOrImport)
-      val uenv = UseEnv.mk(usesAndImports)
-      val declsVal = traverse(decls0)(visitDecl(_, uenv, Name.RootNS))
+      val declsVal = traverse(decls0)(visitDecl(_, Name.RootNS))
       mapN(declsVal) {
         case decls => NamedAst.CompilationUnit(usesAndImports, decls, loc)
       }
@@ -81,15 +80,15 @@ object Namer {
   /**
     * Performs naming on the given declaration.
     */
-  private def visitDecl(decl0: WeededAst.Declaration, uenv: UseEnv, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration, NameError] = decl0 match {
+  private def visitDecl(decl0: WeededAst.Declaration, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration, NameError] = decl0 match {
     case decl: WeededAst.Declaration.Namespace => visitNamespace(decl, ns0)
     // TODO remove needless tenvs from visitClass, visitInstance, visitEffect
-    case decl: WeededAst.Declaration.Class => visitClass(decl, uenv, Map.empty, ns0)
-    case decl: WeededAst.Declaration.Instance => visitInstance(decl, uenv, Map.empty, ns0)
-    case decl: WeededAst.Declaration.Def => visitDef(decl, uenv, Map.empty, ns0, Nil)
-    case decl: WeededAst.Declaration.Enum => visitEnum(decl, uenv, ns0)
-    case decl: WeededAst.Declaration.TypeAlias => visitTypeAlias(decl, uenv, ns0)
-    case decl: WeededAst.Declaration.Effect => visitEffect(decl, uenv, Map.empty, ns0)
+    case decl: WeededAst.Declaration.Class => visitClass(decl, Map.empty, ns0)
+    case decl: WeededAst.Declaration.Instance => visitInstance(decl, Map.empty, ns0)
+    case decl: WeededAst.Declaration.Def => visitDef(decl, Map.empty, ns0, Nil)
+    case decl: WeededAst.Declaration.Enum => visitEnum(decl, ns0)
+    case decl: WeededAst.Declaration.TypeAlias => visitTypeAlias(decl, ns0)
+    case decl: WeededAst.Declaration.Effect => visitEffect(decl, Map.empty, ns0)
     case decl: WeededAst.Declaration.Law => throw InternalCompilerException("unexpected law", decl.loc)
   }
 
@@ -100,8 +99,7 @@ object Namer {
     case WeededAst.Declaration.Namespace(name, usesAndImports0, decls0, loc) =>
       val ns = Name.NName(name.sp1, ns0.idents ::: name.idents, name.sp2)
       val usesAndImports = usesAndImports0.map(visitUseOrImport)
-      val uenv = UseEnv.mk(usesAndImports)
-      val declsVal = traverse(decls0)(visitDecl(_, uenv, ns))
+      val declsVal = traverse(decls0)(visitDecl(_, ns))
       val sym = new Symbol.ModuleSym(ns.parts)
       mapN(declsVal) {
         case decls => NamedAst.Declaration.Namespace(sym, usesAndImports, decls, loc)
@@ -110,28 +108,25 @@ object Namer {
 
   private def tableUnit(unit: NamedAst.CompilationUnit, table0: SymbolTable): Validation[SymbolTable, NameError] = unit match {
     case NamedAst.CompilationUnit(usesAndImports, decls, loc) =>
-      val uenv = UseEnv.mk(usesAndImports)
       fold(decls, table0) {
-        case (acc, decl) => tableDecl(decl, uenv, acc)
+        case (acc, decl) => tableDecl(decl, acc)
       }
   }
 
-  private def tableDecl(decl: NamedAst.Declaration, uenv0: UseEnv, table0: SymbolTable): Validation[SymbolTable, NameError] = decl match {
+  private def tableDecl(decl: NamedAst.Declaration, table0: SymbolTable): Validation[SymbolTable, NameError] = decl match {
     case NamedAst.Declaration.Namespace(sym, usesAndImports, decls, loc) =>
       // reset the uenv
-      val uenv = UseEnv.mk(usesAndImports)
       val table1 = fold(decls, table0) {
-        case (table, d) => tableDecl(d, uenv, table)
+        case (table, d) => tableDecl(d, table)
       }
       mapN(table1)(addUsesToTable(_, sym.ns, usesAndImports))
 
     case NamedAst.Declaration.Class(doc, ann, mod, sym, tparam, superClasses, sigs, laws, loc) =>
-      val table1Val = tryAddToTable(table0, sym.namespace, sym.name, decl, uenv0)
+      val table1Val = tryAddToTable(table0, sym.namespace, sym.name, decl)
       // reset the uenv inside the class
-      val uenv = UseEnv.empty
       flatMapN(table1Val) {
         case table1 => fold(sigs, table1) {
-          case (table, d) => tableDecl(d, uenv, table)
+          case (table, d) => tableDecl(d, table)
         }
       }
 
@@ -139,36 +134,38 @@ object Namer {
       addInstanceToTable(table0, ns, clazz.ident.name, inst).toSuccess
 
     case NamedAst.Declaration.Sig(sym, spec, exp) =>
-      tryAddToTable(table0, sym.namespace, sym.name, decl, uenv0)
+      tryAddToTable(table0, sym.namespace, sym.name, decl)
 
     case NamedAst.Declaration.Def(sym, spec, exp) =>
-      tryAddToTable(table0, sym.namespace, sym.name, decl, uenv0)
+      tryAddToTable(table0, sym.namespace, sym.name, decl)
 
     case NamedAst.Declaration.Enum(doc, ann, mod, sym, tparams, derives, cases, tpe, loc) =>
-      tryAddToTable(table0, sym.namespace, sym.name, decl, uenv0)
+      tryAddToTable(table0, sym.namespace, sym.name, decl)
 
     case NamedAst.Declaration.TypeAlias(doc, mod, sym, tparams, tpe, loc) =>
-      tryAddToTable(table0, sym.namespace, sym.name, decl, uenv0)
+      tryAddToTable(table0, sym.namespace, sym.name, decl)
 
     case NamedAst.Declaration.Effect(doc, ann, mod, sym, ops, loc) =>
-      val table1Val = tryAddToTable(table0, sym.namespace, sym.name, decl, uenv0)
+      val table1Val = tryAddToTable(table0, sym.namespace, sym.name, decl)
       // reset the uenv inside the effect
-      val uenv = UseEnv.empty
       flatMapN(table1Val) {
         case table1 => fold(ops, table1) {
-          case (table, d) => tableDecl(d, uenv, table)
+          case (table, d) => tableDecl(d, table)
         }
       }
 
     case NamedAst.Declaration.Op(sym, spec) =>
-      tryAddToTable(table0, sym.namespace, sym.name, decl, uenv0)
+      tryAddToTable(table0, sym.namespace, sym.name, decl)
+
+      // skip cases for now
+    case NamedAst.Declaration.Case(_, _) => table0.toSuccess
   }
 
   /**
     * Tries to add the given declaration to the table.
     */
-  private def tryAddToTable(table: SymbolTable, ns: List[String], name: String, decl: NamedAst.Declaration, uenv: UseEnv): Validation[SymbolTable, NameError] = {
-    lookupName(name, ns, table, uenv) match {
+  private def tryAddToTable(table: SymbolTable, ns: List[String], name: String, decl: NamedAst.Declaration): Validation[SymbolTable, NameError] = {
+    lookupName(name, ns, table) match {
       case LookupResult.NotDefined => addDeclToTable(table, ns, name, decl).toSuccess
       case LookupResult.AlreadyDefined(loc) => mkDuplicateNamePair(name, getSymLocation(decl), loc)
     }
@@ -247,30 +244,20 @@ object Namer {
   /**
     * Looks up the uppercase name in the given namespace and root.
     */
-  private def lookupName(name: String, ns0: List[String], table: SymbolTable, uenv: UseEnv): NameLookupResult = {
+  private def lookupName(name: String, ns0: List[String], table: SymbolTable): NameLookupResult = {
     val symbols0 = table.symbols.getOrElse(ns0, Map.empty)
-    (symbols0.get(name), uenv.lowerNames.get(name), uenv.upperNames.get(name), uenv.tags.get(name), uenv.imports.get(name)) match {
+    symbols0.get(name) match {
       // Case 1: The name is unused.
-      case (None, None, None, None, None) => LookupResult.NotDefined
+      case None => LookupResult.NotDefined
       // Case 2: An symbol with the name already exists.
-      case (Some(upperName), None, None, None, None) => LookupResult.AlreadyDefined(getSymLocation(upperName))
-      // Case 3: A use with the same name already exists.
-      case (None, Some(use), None, None, None) => LookupResult.AlreadyDefined(use.loc)
-      // Case 3: A use with the same name already exists.
-      case (None, None, Some(use), None, None) => LookupResult.AlreadyDefined(use.loc)
-      // Case 3: A use with the same name already exists.
-      case (None, None, None, Some((_, use)), None) => LookupResult.AlreadyDefined(use.loc)
-      // Case 4: An import with the same name already exists.
-      case (None, None, None, None, Some(imp)) => LookupResult.AlreadyDefined(SourceLocation.mk(imp.sp1, imp.sp2))
-      // Impossible.
-      case _ => throw InternalCompilerException("Unexpected duplicate name found.", SourceLocation.Unknown)
+      case Some(decl) => LookupResult.AlreadyDefined(getSymLocation(decl))
     }
   }
 
   /**
     * Performs naming on the given constraint `c0` under the given environments `env0`, `uenv0`, and `tenv0`.
     */
-  private def visitConstraint(c0: WeededAst.Constraint, outerEnv: Map[String, Symbol.VarSym], uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Constraint, NameError] = c0 match {
+  private def visitConstraint(c0: WeededAst.Constraint, outerEnv: Map[String, Symbol.VarSym], tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Constraint, NameError] = c0 match {
     case WeededAst.Constraint(h, bs, loc) =>
       // Find the variables visible in the head and rule scope of the constraint.
       // Remove any variables already in the outer environment.
@@ -296,7 +283,7 @@ object Namer {
       }
 
       // Perform naming on the head and body predicates.
-      mapN(visitHeadPredicate(h, outerEnv, headEnv, ruleEnv, uenv0, tenv0, ns0), traverse(bs)(b => visitBodyPredicate(b, outerEnv, headEnv, ruleEnv, uenv0, tenv0, ns0))) {
+      mapN(visitHeadPredicate(h, outerEnv, headEnv, ruleEnv, tenv0, ns0), traverse(bs)(b => visitBodyPredicate(b, outerEnv, headEnv, ruleEnv, tenv0, ns0))) {
         case (head, body) =>
           val headParams = headEnv.map {
             case (_, sym) => NamedAst.ConstraintParam.HeadParam(sym, NamedAst.Type.Var(sym.tvar.sym.withoutKind, loc), sym.loc)
@@ -313,7 +300,7 @@ object Namer {
   /**
     * Performs naming on the given enum `enum0`.
     */
-  private def visitEnum(enum0: WeededAst.Declaration.Enum, uenv0: UseEnv, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Enum, NameError] = enum0 match {
+  private def visitEnum(enum0: WeededAst.Declaration.Enum, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Enum, NameError] = enum0 match {
     case WeededAst.Declaration.Enum(doc, ann0, mod0, ident, tparams0, derives, cases0, loc) =>
       val sym = Symbol.mkEnumSym(ns0, ident)
 
@@ -327,13 +314,13 @@ object Namer {
         case (tacc, tvar) => NamedAst.Type.Apply(tacc, tvar, tvar.loc)
       }
 
-      val annVal = traverse(ann0)(visitAnnotation(_, Map.empty, uenv0, tenv, ns0))
+      val annVal = traverse(ann0)(visitAnnotation(_, Map.empty, tenv, ns0))
       val mod = visitModifiers(mod0, ns0)
-      val casesVal = traverse(cases0)(visitCase(_, sym, uenv0, tenv))
+      val casesVal = traverse(cases0)(visitCase(_, sym, tenv))
 
       mapN(annVal, casesVal) {
         case (ann, cases) =>
-          val caseMap = cases.foldLeft(Map.empty[String, NamedAst.Case]) {
+          val caseMap = cases.foldLeft(Map.empty[String, NamedAst.Declaration.Case]) {
             case (acc, caze) => acc + (caze.sym.name -> caze)
           }
           NamedAst.Declaration.Enum(doc, ann, mod, sym, tparams, derives, caseMap, enumType, loc)
@@ -344,24 +331,24 @@ object Namer {
   /**
     * Performs naming on the given enum case.
     */
-  private def visitCase(case0: WeededAst.Case, enumSym: Symbol.EnumSym, uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym])(implicit flix: Flix): Validation[NamedAst.Case, NameError] = case0 match {
+  private def visitCase(case0: WeededAst.Case, enumSym: Symbol.EnumSym, tenv0: Map[String, Symbol.UnkindedTypeVarSym])(implicit flix: Flix): Validation[NamedAst.Declaration.Case, NameError] = case0 match {
     case WeededAst.Case(ident, tpe0) =>
-      mapN(visitType(tpe0, allowWild = false, uenv0, tenv0)) {
+      mapN(visitType(tpe0, allowWild = false, tenv0)) {
         case tpe =>
           val caseSym = Symbol.mkCaseSym(enumSym, ident)
-          NamedAst.Case(caseSym, tpe)
+          NamedAst.Declaration.Case(caseSym, tpe)
       }
   }
 
   /**
     * Performs naming on the given type alias `alias0`.
     */
-  private def visitTypeAlias(alias0: WeededAst.Declaration.TypeAlias, uenv0: UseEnv, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.TypeAlias, NameError] = alias0 match {
+  private def visitTypeAlias(alias0: WeededAst.Declaration.TypeAlias, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.TypeAlias, NameError] = alias0 match {
     case WeededAst.Declaration.TypeAlias(doc, mod0, ident, tparams0, tpe0, loc) =>
       val mod = visitModifiers(mod0, ns0)
       val tparams = getTypeParams(tparams0)
       val tenv = getTypeEnv(tparams.tparams)
-      mapN(visitType(tpe0, allowWild = false, uenv0, tenv)) {
+      mapN(visitType(tpe0, allowWild = false, tenv)) {
         tpe =>
           val sym = Symbol.mkTypeAliasSym(ns0, ident)
           NamedAst.Declaration.TypeAlias(doc, mod, sym, tparams, tpe, loc)
@@ -371,7 +358,7 @@ object Namer {
   /**
     * Performs naming on the given class `clazz`.
     */
-  private def visitClass(clazz: WeededAst.Declaration.Class, uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Class, NameError] = clazz match {
+  private def visitClass(clazz: WeededAst.Declaration.Class, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Class, NameError] = clazz match {
     case WeededAst.Declaration.Class(doc, ann0, mod0, ident, tparams0, superClasses0, signatures, laws0, loc) =>
       val sym = Symbol.mkClassSym(ns0, ident)
       val mod = visitModifiers(mod0, ns0)
@@ -379,10 +366,10 @@ object Namer {
       val tenv = getTypeEnv(List(tparam))
       val tconstr = NamedAst.TypeConstraint(Name.mkQName(ident), NamedAst.Type.Var(tparam.sym, tparam.loc.asSynthetic), sym.loc.asSynthetic)
 
-      val annVal = traverse(ann0)(visitAnnotation(_, Map.empty, uenv0, tenv, ns0))
-      val superClassesVal = traverse(superClasses0)(visitTypeConstraint(_, uenv0, tenv, ns0))
-      val sigsVal = traverse(signatures)(visitSig(_, uenv0, tenv, ns0, ident, sym, tparam))
-      val lawsVal = traverse(laws0)(visitDef(_, uenv0, tenv, ns0, List(tconstr)))
+      val annVal = traverse(ann0)(visitAnnotation(_, Map.empty, tenv, ns0))
+      val superClassesVal = traverse(superClasses0)(visitTypeConstraint(_, tenv, ns0))
+      val sigsVal = traverse(signatures)(visitSig(_, tenv, ns0, ident, sym, tparam))
+      val lawsVal = traverse(laws0)(visitDef(_, tenv, ns0, List(tconstr)))
 
       mapN(annVal, superClassesVal, sigsVal, lawsVal) {
         case (ann, superClasses, sigs, laws) =>
@@ -393,21 +380,20 @@ object Namer {
   /**
     * Performs naming on the given instance `instance`.
     */
-  private def visitInstance(instance: WeededAst.Declaration.Instance, uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Instance, NameError] = instance match {
+  private def visitInstance(instance: WeededAst.Declaration.Instance, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Instance, NameError] = instance match {
     case WeededAst.Declaration.Instance(doc, ann0, mod, clazz, tpe0, tconstrs0, defs0, loc) =>
       val tparams = getImplicitTypeParamsFromTypes(List(tpe0))
       val tenv = tenv0 ++ getTypeEnv(tparams.tparams)
 
-      val annVal = traverse(ann0)(visitAnnotation(_, Map.empty, uenv0, tenv, ns0))
-      val tpeVal = visitType(tpe0, allowWild = true, uenv0, tenv)
-      val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint(_, uenv0, tenv, ns0))
+      val annVal = traverse(ann0)(visitAnnotation(_, Map.empty, tenv, ns0))
+      val tpeVal = visitType(tpe0, allowWild = true, tenv)
+      val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint(_, tenv, ns0))
       flatMapN(annVal, tpeVal, tconstrsVal) {
         case (ann, tpe, tconstrs) =>
-          val qualifiedClass = getClassOrEffect(clazz, uenv0)
-          val instTconstr = NamedAst.TypeConstraint(qualifiedClass, tpe, clazz.loc)
-          val defsVal = traverse(defs0)(visitDef(_, uenv0, tenv, ns0, List(instTconstr)))
+          val instTconstr = NamedAst.TypeConstraint(clazz, tpe, clazz.loc)
+          val defsVal = traverse(defs0)(visitDef(_, tenv, ns0, List(instTconstr)))
           mapN(defsVal) {
-            defs => NamedAst.Declaration.Instance(doc, ann, mod, qualifiedClass, tpe, tconstrs, defs, ns0.parts, loc)
+            defs => NamedAst.Declaration.Instance(doc, ann, mod, clazz, tpe, tconstrs, defs, ns0.parts, loc)
           }
       }
   }
@@ -416,10 +402,9 @@ object Namer {
   /**
     * Performs naming on the given type constraint `tconstr`.
     */
-  private def visitTypeConstraint(tconstr: WeededAst.TypeConstraint, uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.TypeConstraint, NameError] = tconstr match {
-    case WeededAst.TypeConstraint(clazz0, tparam0, loc) =>
-      val clazz = getClassOrEffect(clazz0, uenv0)
-      mapN(visitType(tparam0, allowWild = false, uenv0, tenv0)) {
+  private def visitTypeConstraint(tconstr: WeededAst.TypeConstraint, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.TypeConstraint, NameError] = tconstr match {
+    case WeededAst.TypeConstraint(clazz, tparam0, loc) =>
+      mapN(visitType(tparam0, allowWild = false, tenv0)) {
         tparam => NamedAst.TypeConstraint(clazz, tparam, loc)
       }
   }
@@ -427,26 +412,26 @@ object Namer {
   /**
     * Performs naming on the given signature declaration `sig` under the given environments `env0`, `uenv0`, and `tenv0`.
     */
-  private def visitSig(sig: WeededAst.Declaration.Sig, uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName, classIdent: Name.Ident, classSym: Symbol.ClassSym, classTparam: NamedAst.TypeParam)(implicit flix: Flix): Validation[NamedAst.Declaration.Sig, NameError] = sig match {
+  private def visitSig(sig: WeededAst.Declaration.Sig, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName, classIdent: Name.Ident, classSym: Symbol.ClassSym, classTparam: NamedAst.TypeParam)(implicit flix: Flix): Validation[NamedAst.Declaration.Sig, NameError] = sig match {
     case WeededAst.Declaration.Sig(doc, ann, mod0, ident, tparams0, fparams0, exp0, tpe0, purAndEff0, tconstrs0, loc) =>
-      val tparams = getTypeParamsFromFormalParams(tparams0, fparams0, tpe0, purAndEff0, uenv0, tenv0)
+      val tparams = getTypeParamsFromFormalParams(tparams0, fparams0, tpe0, purAndEff0, tenv0)
       val tenv = tenv0 ++ getTypeEnv(tparams.tparams)
 
       // First visit all the top-level information
       val sigTypeCheckVal = checkSigType(ident, classTparam, fparams0, tpe0, purAndEff0, ident.loc)
       val mod = visitModifiers(mod0, ns0)
-      val fparamsVal = getFormalParams(fparams0, uenv0, tenv)
-      val tpeVal = visitType(tpe0, allowWild = true, uenv0, tenv)
-      val purAndEffVal = visitPurityAndEffect(purAndEff0, allowWild = true, uenv0, tenv)
-      val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint(_, uenv0, tenv, ns0))
+      val fparamsVal = getFormalParams(fparams0, tenv)
+      val tpeVal = visitType(tpe0, allowWild = true, tenv)
+      val purAndEffVal = visitPurityAndEffect(purAndEff0, allowWild = true, tenv)
+      val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint(_, tenv, ns0))
 
       flatMapN(sigTypeCheckVal, fparamsVal, tpeVal, purAndEffVal, tconstrsVal) {
         case (_, fparams, tpe, purAndEff, tconstrs) =>
 
           // Then visit the parts depending on the parameters
           val env0 = getVarEnv(fparams)
-          val annVal = traverse(ann)(visitAnnotation(_, env0, uenv0, tenv, ns0))
-          val expVal = traverseOpt(exp0)(visitExp(_, env0, uenv0, tenv, ns0))
+          val annVal = traverse(ann)(visitAnnotation(_, env0, tenv, ns0))
+          val expVal = traverseOpt(exp0)(visitExp(_, env0, tenv, ns0))
 
           mapN(annVal, expVal) {
             case (as, exp) =>
@@ -479,27 +464,27 @@ object Namer {
   /**
     * Performs naming on the given definition declaration `decl0` under the given environments `env0`, `uenv0`, and `tenv0`, with type constraints `tconstrs`.
     */
-  private def visitDef(decl0: WeededAst.Declaration.Def, uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName, addedTconstrs: List[NamedAst.TypeConstraint])(implicit flix: Flix): Validation[NamedAst.Declaration.Def, NameError] = decl0 match {
+  private def visitDef(decl0: WeededAst.Declaration.Def, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName, addedTconstrs: List[NamedAst.TypeConstraint])(implicit flix: Flix): Validation[NamedAst.Declaration.Def, NameError] = decl0 match {
     case WeededAst.Declaration.Def(doc, ann, mod0, ident, tparams0, fparams0, exp, tpe0, purAndEff0, tconstrs0, loc) =>
       flix.subtask(ident.name, sample = true)
 
-      val tparams = getTypeParamsFromFormalParams(tparams0, fparams0, tpe0, purAndEff0, uenv0, tenv0)
+      val tparams = getTypeParamsFromFormalParams(tparams0, fparams0, tpe0, purAndEff0, tenv0)
       val tenv = tenv0 ++ getTypeEnv(tparams.tparams)
 
       // First visit all the top-level information
       val mod = visitModifiers(mod0, ns0)
-      val fparamsVal = getFormalParams(fparams0, uenv0, tenv)
-      val tpeVal = visitType(tpe0, allowWild = true, uenv0, tenv)
-      val purAndEffVal = visitPurityAndEffect(purAndEff0, allowWild = true, uenv0, tenv)
-      val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint(_, uenv0, tenv, ns0))
+      val fparamsVal = getFormalParams(fparams0, tenv)
+      val tpeVal = visitType(tpe0, allowWild = true, tenv)
+      val purAndEffVal = visitPurityAndEffect(purAndEff0, allowWild = true, tenv)
+      val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint(_, tenv, ns0))
 
       flatMapN(fparamsVal, tpeVal, purAndEffVal, tconstrsVal) {
         case (fparams, tpe, purAndEff, tconstrs) =>
 
           // Then visit the parts depending on the parameters
           val env0 = getVarEnv(fparams)
-          val annVal = traverse(ann)(visitAnnotation(_, env0, uenv0, tenv, ns0))
-          val expVal = visitExp(exp, env0, uenv0, tenv, ns0)
+          val annVal = traverse(ann)(visitAnnotation(_, env0, tenv, ns0))
+          val expVal = visitExp(exp, env0, tenv, ns0)
 
           mapN(annVal, expVal) {
             case (as, e) =>
@@ -517,13 +502,13 @@ object Namer {
   /**
     * Performs naming on the given effect `eff0` under the given environments `env0`, `uenv0`, and `tenv0`.
     */
-  private def visitEffect(eff0: WeededAst.Declaration.Effect, uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Effect, NameError] = eff0 match {
+  private def visitEffect(eff0: WeededAst.Declaration.Effect, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Effect, NameError] = eff0 match {
     case WeededAst.Declaration.Effect(doc, ann0, mod0, ident, ops0, loc) =>
       val sym = Symbol.mkEffectSym(ns0, ident)
 
-      val annVal = traverse(ann0)(visitAnnotation(_, Map.empty, uenv0, tenv0, ns0))
+      val annVal = traverse(ann0)(visitAnnotation(_, Map.empty, tenv0, ns0))
       val mod = visitModifiers(mod0, ns0)
-      val opsVal = traverse(ops0)(visitOp(_, uenv0, tenv0, ns0, sym))
+      val opsVal = traverse(ops0)(visitOp(_, tenv0, ns0, sym))
 
       mapN(annVal, opsVal) {
         case (ann, ops) => NamedAst.Declaration.Effect(doc, ann, mod, sym, ops, loc)
@@ -533,20 +518,20 @@ object Namer {
   /**
     * Performs naming on the given effect operation `op0` under the given environments `env0`, `uenv0`, and `tenv0`.
     */
-  private def visitOp(op0: WeededAst.Declaration.Op, uenv0: UseEnv, tenv: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName, effSym: Symbol.EffectSym)(implicit flix: Flix): Validation[NamedAst.Declaration.Op, NameError] = op0 match {
+  private def visitOp(op0: WeededAst.Declaration.Op, tenv: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName, effSym: Symbol.EffectSym)(implicit flix: Flix): Validation[NamedAst.Declaration.Op, NameError] = op0 match {
     case WeededAst.Declaration.Op(doc, ann0, mod0, ident, fparams0, tpe0, tconstrs0, loc) =>
       // First visit all the top-level information
       val mod = visitModifiers(mod0, ns0)
-      val fparamsVal = getFormalParams(fparams0, uenv0, tenv)
-      val tpeVal = visitType(tpe0, allowWild = true, uenv0, tenv)
-      val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint(_, uenv0, tenv, ns0))
+      val fparamsVal = getFormalParams(fparams0, tenv)
+      val tpeVal = visitType(tpe0, allowWild = true, tenv)
+      val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint(_, tenv, ns0))
 
       flatMapN(fparamsVal, tpeVal, tconstrsVal) {
         case (fparams, tpe, tconstrs) =>
 
           // Then visit the parts depending on the parameters
           val env0 = getVarEnv(fparams)
-          val annVal = traverse(ann0)(visitAnnotation(_, env0, uenv0, tenv, ns0))
+          val annVal = traverse(ann0)(visitAnnotation(_, env0, tenv, ns0))
 
           mapN(annVal) {
             ann =>
@@ -564,7 +549,7 @@ object Namer {
   /**
     * Performs naming on the given expression `exp0` under the given environments `env0`, `uenv0`, and `tenv0`.
     */
-  private def visitExp(exp0: WeededAst.Expression, env0: Map[String, Symbol.VarSym], uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Expression, NameError] = exp0 match {
+  private def visitExp(exp0: WeededAst.Expression, env0: Map[String, Symbol.VarSym], tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Expression, NameError] = exp0 match {
 
     case WeededAst.Expression.Wild(loc) =>
       NamedAst.Expression.Wild(loc).toSuccess
@@ -576,35 +561,27 @@ object Namer {
       // the ident name.
       val name = ident.name
 
-      // lookup the name in the var and use environments.
-      (env0.get(name), uenv0.lowerNames.get(name)) match {
-        case (None, None) =>
-          // Case 1: the name is a top-level function.
-          NamedAst.Expression.DefOrSig(Name.mkQName(ident), env0, loc).toSuccess
-        case (None, Some(actualQName)) =>
-          // Case 2: the name is a use def.
-          NamedAst.Expression.DefOrSig(actualQName, env0, loc).toSuccess
-        case (Some(sym), None) =>
-          // Case 4: the name is a variable.
-          NamedAst.Expression.Var(sym, loc).toSuccess
-        case (Some(sym), Some(qname)) =>
-          // Case 5.1: the name is ambiguous: var-def
-          NameError.AmbiguousVarOrUse(name, loc, sym.loc, qname.loc).toFailure
+      // TODO move this lookup to Resolver
+      // lookup the name in the var environment
+      env0.get(name) match {
+        // Case 1: not found, assume it is a function
+        case None => NamedAst.Expression.UnqualifiedDefOrSig(ident, env0, loc).toSuccess
+        // Case 2: found a var
+        case Some(sym) => NamedAst.Expression.Var(sym, loc).toSuccess
       }
 
     case WeededAst.Expression.Hole(name, loc) =>
       NamedAst.Expression.Hole(name, loc).toSuccess
 
     case WeededAst.Expression.HoleWithExp(exp, loc) =>
-      mapN(visitExp(exp, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp, env0, tenv0, ns0)) {
         case e => NamedAst.Expression.HoleWithExp(e, loc)
       }
 
     case WeededAst.Expression.Use(uses0, exp, loc) =>
       val uses = uses0.map(visitUseOrImport)
-      val uenv = uenv0.addAll(uses)
 
-      mapN(visitExp(exp, env0, uenv, tenv0, ns0)) {
+      mapN(visitExp(exp, env0, tenv0, ns0)) {
         case e => uses.foldRight(e) {
           case (use, acc) => NamedAst.Expression.Use(use, acc, loc)
         }
@@ -613,60 +590,60 @@ object Namer {
     case WeededAst.Expression.Cst(cst, loc) => NamedAst.Expression.Cst(cst, loc).toSuccess
 
     case WeededAst.Expression.Apply(exp, exps, loc) =>
-      mapN(visitExp(exp, env0, uenv0, tenv0, ns0), traverse(exps)(visitExp(_, env0, uenv0, tenv0, ns0))) {
+      mapN(visitExp(exp, env0, tenv0, ns0), traverse(exps)(visitExp(_, env0, tenv0, ns0))) {
         case (e, es) => NamedAst.Expression.Apply(e, es, loc)
       }
 
     case WeededAst.Expression.Lambda(fparam0, exp, loc) =>
-      flatMapN(visitFormalParam(fparam0, uenv0, tenv0)) {
+      flatMapN(visitFormalParam(fparam0, tenv0)) {
         case p =>
           val env1 = env0 + (p.sym.text -> p.sym)
-          mapN(visitExp(exp, env1, uenv0, tenv0, ns0)) {
+          mapN(visitExp(exp, env1, tenv0, ns0)) {
             case e => NamedAst.Expression.Lambda(p, e, loc)
           }
       }
 
     case WeededAst.Expression.Unary(sop, exp, loc) =>
-      visitExp(exp, env0, uenv0, tenv0, ns0) map {
+      visitExp(exp, env0, tenv0, ns0) map {
         case e => NamedAst.Expression.Unary(sop, e, loc)
       }
 
     case WeededAst.Expression.Binary(sop, exp1, exp2, loc) =>
-      mapN(visitExp(exp1, env0, uenv0, tenv0, ns0), visitExp(exp2, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp1, env0, tenv0, ns0), visitExp(exp2, env0, tenv0, ns0)) {
         case (e1, e2) => NamedAst.Expression.Binary(sop, e1, e2, loc)
       }
 
     case WeededAst.Expression.IfThenElse(exp1, exp2, exp3, loc) =>
-      val e1 = visitExp(exp1, env0, uenv0, tenv0, ns0)
-      val e2 = visitExp(exp2, env0, uenv0, tenv0, ns0)
-      val e3 = visitExp(exp3, env0, uenv0, tenv0, ns0)
+      val e1 = visitExp(exp1, env0, tenv0, ns0)
+      val e2 = visitExp(exp2, env0, tenv0, ns0)
+      val e3 = visitExp(exp3, env0, tenv0, ns0)
       mapN(e1, e2, e3) {
         NamedAst.Expression.IfThenElse(_, _, _, loc)
       }
 
     case WeededAst.Expression.Stm(exp1, exp2, loc) =>
-      val e1 = visitExp(exp1, env0, uenv0, tenv0, ns0)
-      val e2 = visitExp(exp2, env0, uenv0, tenv0, ns0)
+      val e1 = visitExp(exp1, env0, tenv0, ns0)
+      val e2 = visitExp(exp2, env0, tenv0, ns0)
       mapN(e1, e2) {
         NamedAst.Expression.Stm(_, _, loc)
       }
 
     case WeededAst.Expression.Discard(exp, loc) =>
-      visitExp(exp, env0, uenv0, tenv0, ns0) map {
+      visitExp(exp, env0, tenv0, ns0) map {
         case e => NamedAst.Expression.Discard(e, loc)
       }
 
     case WeededAst.Expression.Let(ident, mod, exp1, exp2, loc) =>
       // make a fresh variable symbol for the local variable.
       val sym = Symbol.freshVarSym(ident, BoundBy.Let)
-      mapN(visitExp(exp1, env0, uenv0, tenv0, ns0), visitExp(exp2, env0 + (ident.name -> sym), uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp1, env0, tenv0, ns0), visitExp(exp2, env0 + (ident.name -> sym), tenv0, ns0)) {
         case (e1, e2) => NamedAst.Expression.Let(sym, mod, e1, e2, loc)
       }
 
     case WeededAst.Expression.LetRec(ident, mod, exp1, exp2, loc) =>
       val sym = Symbol.freshVarSym(ident, BoundBy.Let)
       val env1 = env0 + (ident.name -> sym)
-      mapN(visitExp(exp1, env1, uenv0, tenv0, ns0), visitExp(exp2, env1, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp1, env1, tenv0, ns0), visitExp(exp2, env1, tenv0, ns0)) {
         case (e1, e2) => NamedAst.Expression.LetRec(sym, mod, e1, e2, loc)
       }
 
@@ -682,20 +659,20 @@ object Namer {
 
       val env1 = env0 + (ident.name -> sym)
       val tenv1 = tenv0 + (ident.name -> regionVar)
-      mapN(visitExp(exp, env1, uenv0, tenv1, ns0)) {
+      mapN(visitExp(exp, env1, tenv1, ns0)) {
         case e => NamedAst.Expression.Scope(sym, regionVar, e, loc)
       }
 
     case WeededAst.Expression.Match(exp, rules, loc) =>
-      val expVal = visitExp(exp, env0, uenv0, tenv0, ns0)
+      val expVal = visitExp(exp, env0, tenv0, ns0)
       val rulesVal = traverse(rules) {
         case WeededAst.MatchRule(pat, guard, body) =>
           // extend the environment with every variable occurring in the pattern
           // and perform naming on the rule guard and body under the extended environment.
-          val (p, env1) = visitPattern(pat, uenv0)
+          val (p, env1) = visitPattern(pat)
           val extendedEnv = env0 ++ env1
-          val gVal = traverseOpt(guard)(visitExp(_, extendedEnv, uenv0, tenv0, ns0))
-          val bVal = visitExp(body, extendedEnv, uenv0, tenv0, ns0)
+          val gVal = traverseOpt(guard)(visitExp(_, extendedEnv, tenv0, ns0))
+          val bVal = visitExp(body, extendedEnv, tenv0, ns0)
           mapN(gVal, bVal) {
             case (g, b) => NamedAst.MatchRule(p, g, b)
           }
@@ -705,7 +682,7 @@ object Namer {
       }
 
     case WeededAst.Expression.TypeMatch(exp, rules, loc) =>
-      val expVal = visitExp(exp, env0, uenv0, tenv0, ns0)
+      val expVal = visitExp(exp, env0, tenv0, ns0)
       val rulesVal = traverse(rules) {
         case WeededAst.MatchTypeRule(ident, tpe, body) =>
           // extend the environment with the variable
@@ -713,7 +690,7 @@ object Namer {
           val sym = Symbol.freshVarSym(ident, BoundBy.Pattern)
           val env1 = Map(ident.name -> sym)
           val extendedEnv = env0 ++ env1
-          mapN(visitType(tpe, allowWild = true, uenv0, tenv0), visitExp(body, extendedEnv, uenv0, tenv0, ns0)) {
+          mapN(visitType(tpe, allowWild = true, tenv0), visitExp(body, extendedEnv, tenv0, ns0)) {
             case (t, b) => NamedAst.MatchTypeRule(sym, t, b)
           }
       }
@@ -722,7 +699,7 @@ object Namer {
       }
 
     case WeededAst.Expression.Choose(star, exps, rules, loc) =>
-      val expsVal = traverse(exps)(visitExp(_, env0, uenv0, tenv0, ns0))
+      val expsVal = traverse(exps)(visitExp(_, env0, tenv0, ns0))
       val rulesVal = traverse(rules) {
         case WeededAst.ChoiceRule(pat0, exp0) =>
           val env1 = pat0.foldLeft(Map.empty[String, Symbol.VarSym]) {
@@ -735,7 +712,7 @@ object Namer {
             case WeededAst.ChoicePattern.Absent(loc) => NamedAst.ChoicePattern.Absent(loc)
             case WeededAst.ChoicePattern.Present(ident, loc) => NamedAst.ChoicePattern.Present(env1(ident.name), loc)
           }
-          mapN(visitExp(exp0, env0 ++ env1, uenv0, tenv0, ns0)) {
+          mapN(visitExp(exp0, env0 ++ env1, tenv0, ns0)) {
             case e => NamedAst.ChoiceRule(p, e)
           }
       }
@@ -743,8 +720,7 @@ object Namer {
         case (es, rs) => NamedAst.Expression.Choose(star, es, rs, loc)
       }
 
-    case WeededAst.Expression.Tag(enumOpt0, tag0, expOpt, loc) =>
-      val (enumOpt, tag) = getDisambiguatedTag(enumOpt0, tag0, uenv0)
+    case WeededAst.Expression.Tag(enumOpt, tag, expOpt, loc) =>
 
       expOpt match {
         case None =>
@@ -752,13 +728,13 @@ object Namer {
           NamedAst.Expression.Tag(enumOpt, tag, None, loc).toSuccess
         case Some(exp) =>
           // Case 2: The tag has an expression. Perform naming on it.
-          visitExp(exp, env0, uenv0, tenv0, ns0) map {
+          visitExp(exp, env0, tenv0, ns0) map {
             case e => NamedAst.Expression.Tag(enumOpt, tag, Some(e), loc)
           }
       }
 
     case WeededAst.Expression.Tuple(elms, loc) =>
-      traverse(elms)(e => visitExp(e, env0, uenv0, tenv0, ns0)) map {
+      traverse(elms)(e => visitExp(e, env0, tenv0, ns0)) map {
         case es => NamedAst.Expression.Tuple(es, loc)
       }
 
@@ -766,125 +742,124 @@ object Namer {
       NamedAst.Expression.RecordEmpty(loc).toSuccess
 
     case WeededAst.Expression.RecordSelect(exp, field, loc) =>
-      mapN(visitExp(exp, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp, env0, tenv0, ns0)) {
         case e => NamedAst.Expression.RecordSelect(e, field, loc)
       }
 
     case WeededAst.Expression.RecordExtend(field, value, rest, loc) =>
-      mapN(visitExp(value, env0, uenv0, tenv0, ns0), visitExp(rest, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(value, env0, tenv0, ns0), visitExp(rest, env0, tenv0, ns0)) {
         case (v, r) => NamedAst.Expression.RecordExtend(field, v, r, loc)
       }
 
     case WeededAst.Expression.RecordRestrict(field, rest, loc) =>
-      mapN(visitExp(rest, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(rest, env0, tenv0, ns0)) {
         case r => NamedAst.Expression.RecordRestrict(field, r, loc)
       }
 
     case WeededAst.Expression.New(qname, exp, loc) =>
-      mapN(traverseOpt(exp)(visitExp(_, env0, uenv0, tenv0, ns0))) {
+      mapN(traverseOpt(exp)(visitExp(_, env0, tenv0, ns0))) {
         case e => NamedAst.Expression.New(qname, e, loc)
       }
 
     case WeededAst.Expression.ArrayLit(exps, exp, loc) =>
-      mapN(traverse(exps)(visitExp(_, env0, uenv0, tenv0, ns0)), traverseOpt(exp)(visitExp(_, env0, uenv0, tenv0, ns0))) {
+      mapN(traverse(exps)(visitExp(_, env0, tenv0, ns0)), traverseOpt(exp)(visitExp(_, env0, tenv0, ns0))) {
         case (es, e) => NamedAst.Expression.ArrayLit(es, e, loc)
       }
 
     case WeededAst.Expression.ArrayNew(exp1, exp2, exp3, loc) =>
-      mapN(visitExp(exp1, env0, uenv0, tenv0, ns0), visitExp(exp2, env0, uenv0, tenv0, ns0), traverseOpt(exp3)(visitExp(_, env0, uenv0, tenv0, ns0))) {
+      mapN(visitExp(exp1, env0, tenv0, ns0), visitExp(exp2, env0, tenv0, ns0), traverseOpt(exp3)(visitExp(_, env0, tenv0, ns0))) {
         case (e1, e2, e3) => NamedAst.Expression.ArrayNew(e1, e2, e3, loc)
       }
 
     case WeededAst.Expression.ArrayLoad(base, index, loc) =>
-      mapN(visitExp(base, env0, uenv0, tenv0, ns0), visitExp(index, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(base, env0, tenv0, ns0), visitExp(index, env0, tenv0, ns0)) {
         case (b, i) => NamedAst.Expression.ArrayLoad(b, i, loc)
       }
 
     case WeededAst.Expression.ArrayStore(base, index, elm, loc) =>
-      mapN(visitExp(base, env0, uenv0, tenv0, ns0), visitExp(index, env0, uenv0, tenv0, ns0), visitExp(elm, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(base, env0, tenv0, ns0), visitExp(index, env0, tenv0, ns0), visitExp(elm, env0, tenv0, ns0)) {
         case (b, i, e) => NamedAst.Expression.ArrayStore(b, i, e, loc)
       }
 
     case WeededAst.Expression.ArrayLength(base, loc) =>
-      visitExp(base, env0, uenv0, tenv0, ns0) map {
+      visitExp(base, env0, tenv0, ns0) map {
         case b => NamedAst.Expression.ArrayLength(b, loc)
       }
 
     case WeededAst.Expression.ArraySlice(base, startIndex, endIndex, loc) =>
-      mapN(visitExp(base, env0, uenv0, tenv0, ns0), visitExp(startIndex, env0, uenv0, tenv0, ns0), visitExp(endIndex, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(base, env0, tenv0, ns0), visitExp(startIndex, env0, tenv0, ns0), visitExp(endIndex, env0, tenv0, ns0)) {
         case (b, i1, i2) => NamedAst.Expression.ArraySlice(b, i1, i2, loc)
       }
 
     case WeededAst.Expression.Ref(exp1, exp2, loc) =>
-      mapN(visitExp(exp1, env0, uenv0, tenv0, ns0), traverseOpt(exp2)(visitExp(_, env0, uenv0, tenv0, ns0))) {
+      mapN(visitExp(exp1, env0, tenv0, ns0), traverseOpt(exp2)(visitExp(_, env0, tenv0, ns0))) {
         case (e1, e2) =>
           NamedAst.Expression.Ref(e1, e2, loc)
       }
 
     case WeededAst.Expression.Deref(exp, loc) =>
-      visitExp(exp, env0, uenv0, tenv0, ns0) map {
+      visitExp(exp, env0, tenv0, ns0) map {
         case e =>
           NamedAst.Expression.Deref(e, loc)
       }
 
     case WeededAst.Expression.Assign(exp1, exp2, loc) =>
-      mapN(visitExp(exp1, env0, uenv0, tenv0, ns0), visitExp(exp2, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp1, env0, tenv0, ns0), visitExp(exp2, env0, tenv0, ns0)) {
         case (e1, e2) =>
           NamedAst.Expression.Assign(e1, e2, loc)
       }
 
     case WeededAst.Expression.Ascribe(exp, expectedType, expectedEff, loc) =>
-      val expVal = visitExp(exp, env0, uenv0, tenv0, ns0)
+      val expVal = visitExp(exp, env0, tenv0, ns0)
       val expectedTypVal = expectedType match {
         case None => (None: Option[NamedAst.Type]).toSuccess
-        case Some(t) => mapN(visitType(t, allowWild = true, uenv0, tenv0))(x => Some(x))
+        case Some(t) => mapN(visitType(t, allowWild = true, tenv0))(x => Some(x))
       }
-      val expectedEffVal = visitPurityAndEffect(expectedEff, allowWild = true, uenv0, tenv0)
+      val expectedEffVal = visitPurityAndEffect(expectedEff, allowWild = true, tenv0)
 
       mapN(expVal, expectedTypVal, expectedEffVal) {
         case (e, t, f) => NamedAst.Expression.Ascribe(e, t, f, loc)
       }
 
     case WeededAst.Expression.Cast(exp, declaredType, declaredEff, loc) =>
-      val expVal = visitExp(exp, env0, uenv0, tenv0, ns0)
+      val expVal = visitExp(exp, env0, tenv0, ns0)
       val declaredTypVal = declaredType match {
         case None => (None: Option[NamedAst.Type]).toSuccess
-        case Some(t) => mapN(visitType(t, allowWild = false, uenv0, tenv0))(x => Some(x))
+        case Some(t) => mapN(visitType(t, allowWild = false, tenv0))(x => Some(x))
       }
-      val declaredEffVal = visitPurityAndEffect(declaredEff, allowWild = false, uenv0, tenv0)
+      val declaredEffVal = visitPurityAndEffect(declaredEff, allowWild = false, tenv0)
 
       mapN(expVal, declaredTypVal, declaredEffVal) {
         case (e, t, f) => NamedAst.Expression.Cast(e, t, f, loc)
       }
 
     case WeededAst.Expression.Mask(exp, loc) =>
-      mapN(visitExp(exp, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp, env0, tenv0, ns0)) {
         case e => NamedAst.Expression.Mask(e, loc)
       }
 
     case WeededAst.Expression.Upcast(exp, loc) =>
-      mapN(visitExp(exp, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp, env0, tenv0, ns0)) {
         case e => NamedAst.Expression.Upcast(e, loc)
       }
 
     case WeededAst.Expression.Supercast(exp, loc) =>
-      mapN(visitExp(exp, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp, env0, tenv0, ns0)) {
         case e => NamedAst.Expression.Supercast(e, loc)
       }
 
     case WeededAst.Expression.Without(exp, eff, loc) =>
-      val expVal = visitExp(exp, env0, uenv0, tenv0, ns0)
-      val f = getClassOrEffect(eff, uenv0)
+      val expVal = visitExp(exp, env0, tenv0, ns0)
       mapN(expVal) {
-        e => NamedAst.Expression.Without(e, f, loc)
+        e => NamedAst.Expression.Without(e, eff, loc)
       }
 
     case WeededAst.Expression.TryCatch(exp, rules, loc) =>
-      val expVal = visitExp(exp, env0, uenv0, tenv0, ns0)
+      val expVal = visitExp(exp, env0, tenv0, ns0)
       val rulesVal = traverse(rules) {
         case WeededAst.CatchRule(ident, className, body) =>
           val sym = Symbol.freshVarSym(ident, BoundBy.CatchRule)
-          val bodyVal = visitExp(body, env0 + (ident.name -> sym), uenv0, tenv0, ns0)
+          val bodyVal = visitExp(body, env0 + (ident.name -> sym), tenv0, ns0)
           mapN(bodyVal) {
             b => NamedAst.CatchRule(sym, className, b)
           }
@@ -894,17 +869,16 @@ object Namer {
         case (e, rs) => NamedAst.Expression.TryCatch(e, rs, loc)
       }
 
-    case WeededAst.Expression.TryWith(e0, eff0, rules0, loc) =>
-      val eVal = visitExp(e0, env0, uenv0, tenv0, ns0)
-      val eff = getClassOrEffect(eff0, uenv0)
+    case WeededAst.Expression.TryWith(e0, eff, rules0, loc) =>
+      val eVal = visitExp(e0, env0, tenv0, ns0)
       val rulesVal = traverse(rules0) {
         case WeededAst.HandlerRule(op, fparams0, body0) =>
-          val fparamsVal = traverse(fparams0)(visitFormalParam(_, uenv0, tenv0))
+          val fparamsVal = traverse(fparams0)(visitFormalParam(_, tenv0))
           flatMapN(fparamsVal) {
             fparams =>
               // visit the body with the fparams in the env
               val env = env0 ++ getVarEnv(fparams)
-              val bodyVal = visitExp(body0, env, uenv0, tenv0, ns0)
+              val bodyVal = visitExp(body0, env, tenv0, ns0)
               mapN(bodyVal)(NamedAst.HandlerRule(op, fparams, _))
           }
       }
@@ -912,56 +886,49 @@ object Namer {
         case (e, rules) => NamedAst.Expression.TryWith(e, eff, rules, loc)
       }
 
-    case WeededAst.Expression.Do(op0, exps0, loc) =>
-      // lookup the op in the use environment if it is not qualified
-      val op = if (op0.isQualified) {
-        op0
-      } else {
-        uenv0.lowerNames.getOrElse(op0.ident.name, op0)
-      }
-
-      val expsVal = traverse(exps0)(visitExp(_, env0, uenv0, tenv0, ns0))
+    case WeededAst.Expression.Do(op, exps0, loc) =>
+      val expsVal = traverse(exps0)(visitExp(_, env0, tenv0, ns0))
       mapN(expsVal) {
         exps => NamedAst.Expression.Do(op, exps, loc)
       }
 
     case WeededAst.Expression.Resume(exp, loc) =>
-      val expVal = visitExp(exp, env0, uenv0, tenv0, ns0)
+      val expVal = visitExp(exp, env0, tenv0, ns0)
       mapN(expVal) {
         e => NamedAst.Expression.Resume(e, loc)
       }
 
     case WeededAst.Expression.InvokeConstructor(className, args, sig, loc) =>
-      val argsVal = traverse(args)(visitExp(_, env0, uenv0, tenv0, ns0))
-      val sigVal = traverse(sig)(visitType(_, allowWild = false, uenv0, tenv0))
+      val argsVal = traverse(args)(visitExp(_, env0, tenv0, ns0))
+      val sigVal = traverse(sig)(visitType(_, allowWild = false, tenv0))
       mapN(argsVal, sigVal) {
         case (as, sig) => NamedAst.Expression.InvokeConstructor(className, as, sig, loc)
       }
 
     case WeededAst.Expression.InvokeMethod(className, methodName, exp, args, sig, retTpe, loc) =>
-      val expVal = visitExp(exp, env0, uenv0, tenv0, ns0)
-      val argsVal = traverse(args)(visitExp(_, env0, uenv0, tenv0, ns0))
-      val sigVal = traverse(sig)(visitType(_, allowWild = false, uenv0, tenv0))
-      val retVal = visitType(retTpe, allowWild = false, uenv0, tenv0)
+      val expVal = visitExp(exp, env0, tenv0, ns0)
+      val argsVal = traverse(args)(visitExp(_, env0, tenv0, ns0))
+      val sigVal = traverse(sig)(visitType(_, allowWild = false, tenv0))
+      val retVal = visitType(retTpe, allowWild = false, tenv0)
       mapN(expVal, argsVal, sigVal, retVal) {
         case (e, as, sig, ret) => NamedAst.Expression.InvokeMethod(className, methodName, e, as, sig, ret, loc)
       }
 
     case WeededAst.Expression.InvokeStaticMethod(className, methodName, args, sig, retTpe, loc) =>
-      val argsVal = traverse(args)(visitExp(_, env0, uenv0, tenv0, ns0))
-      val sigVal = traverse(sig)(visitType(_, allowWild = false, uenv0, tenv0))
-      val retVal = visitType(retTpe, allowWild = false, uenv0, tenv0)
+      val argsVal = traverse(args)(visitExp(_, env0, tenv0, ns0))
+      val sigVal = traverse(sig)(visitType(_, allowWild = false, tenv0))
+      val retVal = visitType(retTpe, allowWild = false, tenv0)
       mapN(argsVal, sigVal, retVal) {
         case (as, sig, ret) => NamedAst.Expression.InvokeStaticMethod(className, methodName, as, sig, ret, loc)
       }
 
     case WeededAst.Expression.GetField(className, fieldName, exp, loc) =>
-      mapN(visitExp(exp, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp, env0, tenv0, ns0)) {
         case e => NamedAst.Expression.GetField(className, fieldName, e, loc)
       }
 
     case WeededAst.Expression.PutField(className, fieldName, exp1, exp2, loc) =>
-      mapN(visitExp(exp1, env0, uenv0, tenv0, ns0), visitExp(exp2, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp1, env0, tenv0, ns0), visitExp(exp2, env0, tenv0, ns0)) {
         case (e1, e2) => NamedAst.Expression.PutField(className, fieldName, e1, e2, loc)
       }
 
@@ -969,29 +936,29 @@ object Namer {
       NamedAst.Expression.GetStaticField(className, fieldName, loc).toSuccess
 
     case WeededAst.Expression.PutStaticField(className, fieldName, exp, loc) =>
-      mapN(visitExp(exp, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp, env0, tenv0, ns0)) {
         case e => NamedAst.Expression.PutStaticField(className, fieldName, e, loc)
       }
 
     case WeededAst.Expression.NewObject(tpe, methods, loc) =>
-      mapN(visitType(tpe, allowWild = false, uenv0, tenv0), traverse(methods)(visitJvmMethod(_, env0, uenv0, tenv0, ns0))) {
+      mapN(visitType(tpe, allowWild = false, tenv0), traverse(methods)(visitJvmMethod(_, env0, tenv0, ns0))) {
         case (tpe, ms) =>
           val name = s"Anon$$${flix.genSym.freshId()}"
           NamedAst.Expression.NewObject(name, tpe, ms, loc)
       }
 
     case WeededAst.Expression.NewChannel(exp1, exp2, loc) =>
-      mapN(visitExp(exp1, env0, uenv0, tenv0, ns0), visitExp(exp2, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp1, env0, tenv0, ns0), visitExp(exp2, env0, tenv0, ns0)) {
         case (e1, e2) => NamedAst.Expression.NewChannel(e1, e2, loc)
       }
 
     case WeededAst.Expression.GetChannel(exp, loc) =>
-      visitExp(exp, env0, uenv0, tenv0, ns0) map {
+      visitExp(exp, env0, tenv0, ns0) map {
         case e => NamedAst.Expression.GetChannel(e, loc)
       }
 
     case WeededAst.Expression.PutChannel(exp1, exp2, loc) =>
-      mapN(visitExp(exp1, env0, uenv0, tenv0, ns0), visitExp(exp2, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp1, env0, tenv0, ns0), visitExp(exp2, env0, tenv0, ns0)) {
         case (e1, e2) => NamedAst.Expression.PutChannel(e1, e2, loc)
       }
 
@@ -1001,13 +968,13 @@ object Namer {
           // make a fresh variable symbol for the local recursive variable.
           val sym = Symbol.freshVarSym(ident, BoundBy.SelectRule)
           val env1 = env0 + (ident.name -> sym)
-          mapN(visitExp(chan, env0, uenv0, tenv0, ns0), visitExp(body, env1, uenv0, tenv0, ns0)) {
+          mapN(visitExp(chan, env0, tenv0, ns0), visitExp(body, env1, tenv0, ns0)) {
             case (c, b) => NamedAst.SelectChannelRule(sym, c, b)
           }
       }
 
       val defaultVal = default match {
-        case Some(exp) => visitExp(exp, env0, uenv0, tenv0, ns0) map {
+        case Some(exp) => visitExp(exp, env0, tenv0, ns0) map {
           case e => Some(e)
         }
         case None => None.toSuccess
@@ -1018,13 +985,13 @@ object Namer {
       }
 
     case WeededAst.Expression.Spawn(exp1, exp2, loc) =>
-      mapN(visitExp(exp1, env0, uenv0, tenv0, ns0), visitExp(exp2, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp1, env0, tenv0, ns0), visitExp(exp2, env0, tenv0, ns0)) {
         case (e1, e2) =>
           NamedAst.Expression.Spawn(e1, e2, loc)
       }
 
     case WeededAst.Expression.Par(exp, loc) =>
-      mapN(visitExp(exp, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp, env0, tenv0, ns0)) {
         case e => NamedAst.Expression.Par(e, loc)
       }
 
@@ -1034,63 +1001,63 @@ object Namer {
 
       val fragsVal = traverse(frags) {
         case WeededAst.ParYieldFragment(pat, e, l) =>
-          val (p, env1) = visitPattern(pat, uenv0)
+          val (p, env1) = visitPattern(pat)
           finalEnv = finalEnv ++ env1
-          mapN(visitExp(e, env0, uenv0, tenv0, ns0)) {
+          mapN(visitExp(e, env0, tenv0, ns0)) {
             case e1 => NamedAst.ParYieldFragment(p, e1, l)
           }
       }
 
       // Combine everything
-      mapN(fragsVal, visitExp(exp, finalEnv, uenv0, tenv0, ns0)) {
+      mapN(fragsVal, visitExp(exp, finalEnv, tenv0, ns0)) {
         case (fs, e) => NamedAst.Expression.ParYield(fs, e, loc)
       }
 
     case WeededAst.Expression.Lazy(exp, loc) =>
-      visitExp(exp, env0, uenv0, tenv0, ns0) map {
+      visitExp(exp, env0, tenv0, ns0) map {
         case e => NamedAst.Expression.Lazy(e, loc)
       }
 
     case WeededAst.Expression.Force(exp, loc) =>
-      visitExp(exp, env0, uenv0, tenv0, ns0) map {
+      visitExp(exp, env0, tenv0, ns0) map {
         case e => NamedAst.Expression.Force(e, loc)
       }
 
     case WeededAst.Expression.FixpointConstraintSet(cs0, loc) =>
-      mapN(traverse(cs0)(visitConstraint(_, env0, uenv0, tenv0, ns0))) {
+      mapN(traverse(cs0)(visitConstraint(_, env0, tenv0, ns0))) {
         case cs =>
           NamedAst.Expression.FixpointConstraintSet(cs, loc)
       }
 
     case WeededAst.Expression.FixpointLambda(pparams, exp, loc) =>
-      val psVal = traverse(pparams)(visitPredicateParam(_, uenv0, tenv0))
-      val expVal = visitExp(exp, env0, uenv0, tenv0, ns0)
+      val psVal = traverse(pparams)(visitPredicateParam(_, tenv0))
+      val expVal = visitExp(exp, env0, tenv0, ns0)
       mapN(psVal, expVal) {
         case (ps, e) => NamedAst.Expression.FixpointLambda(ps, e, loc)
       }
 
     case WeededAst.Expression.FixpointMerge(exp1, exp2, loc) =>
-      mapN(visitExp(exp1, env0, uenv0, tenv0, ns0), visitExp(exp2, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp1, env0, tenv0, ns0), visitExp(exp2, env0, tenv0, ns0)) {
         case (e1, e2) => NamedAst.Expression.FixpointMerge(e1, e2, loc)
       }
 
     case WeededAst.Expression.FixpointSolve(exp, loc) =>
-      visitExp(exp, env0, uenv0, tenv0, ns0) map {
+      visitExp(exp, env0, tenv0, ns0) map {
         case e => NamedAst.Expression.FixpointSolve(e, loc)
       }
 
     case WeededAst.Expression.FixpointFilter(ident, exp, loc) =>
-      mapN(visitExp(exp, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp, env0, tenv0, ns0)) {
         case e => NamedAst.Expression.FixpointFilter(ident, e, loc)
       }
 
     case WeededAst.Expression.FixpointInject(exp, pred, loc) =>
-      mapN(visitExp(exp, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp, env0, tenv0, ns0)) {
         case e => NamedAst.Expression.FixpointInject(e, pred, loc)
       }
 
     case WeededAst.Expression.FixpointProject(pred, exp1, exp2, loc) =>
-      mapN(visitExp(exp1, env0, uenv0, tenv0, ns0), visitExp(exp2, env0, uenv0, tenv0, ns0)) {
+      mapN(visitExp(exp1, env0, tenv0, ns0), visitExp(exp2, env0, tenv0, ns0)) {
         case (e1, e2) => NamedAst.Expression.FixpointProject(pred, e1, e2, loc)
       }
   }
@@ -1098,7 +1065,7 @@ object Namer {
   /**
     * Names the given pattern `pat0` and returns map from variable names to variable symbols.
     */
-  private def visitPattern(pat0: WeededAst.Pattern, uenv0: UseEnv)(implicit flix: Flix): (NamedAst.Pattern, Map[String, Symbol.VarSym]) = {
+  private def visitPattern(pat0: WeededAst.Pattern)(implicit flix: Flix): (NamedAst.Pattern, Map[String, Symbol.VarSym]) = {
     val m = mutable.Map.empty[String, Symbol.VarSym]
 
     def visit(p: WeededAst.Pattern): NamedAst.Pattern = p match {
@@ -1111,8 +1078,7 @@ object Namer {
 
       case WeededAst.Pattern.Cst(cst, loc) => NamedAst.Pattern.Cst(cst, loc)
 
-      case WeededAst.Pattern.Tag(enumOpt0, tag0, pat, loc) =>
-        val (enumOpt, tag) = getDisambiguatedTag(enumOpt0, tag0, uenv0)
+      case WeededAst.Pattern.Tag(enumOpt, tag, pat, loc) =>
         NamedAst.Pattern.Tag(enumOpt, tag, visit(pat), loc)
 
       case WeededAst.Pattern.Tuple(elms, loc) => NamedAst.Pattern.Tuple(elms map visit, loc)
@@ -1147,7 +1113,7 @@ object Namer {
     *
     * Every variable in the pattern must be bound by the environment.
     */
-  private def visitPattern(pat0: WeededAst.Pattern, env0: Map[String, Symbol.VarSym], uenv0: UseEnv)(implicit flix: Flix): NamedAst.Pattern = {
+  private def visitPattern(pat0: WeededAst.Pattern, env0: Map[String, Symbol.VarSym])(implicit flix: Flix): NamedAst.Pattern = {
     def visit(p: WeededAst.Pattern): NamedAst.Pattern = p match {
       case WeededAst.Pattern.Wild(loc) => NamedAst.Pattern.Wild(loc)
       case WeededAst.Pattern.Var(ident, loc) =>
@@ -1155,8 +1121,7 @@ object Namer {
         NamedAst.Pattern.Var(sym, loc)
       case WeededAst.Pattern.Cst(cst, loc) => NamedAst.Pattern.Cst(cst, loc)
 
-      case WeededAst.Pattern.Tag(enumOpt0, tag0, pat, loc) =>
-        val (enumOpt, tag) = getDisambiguatedTag(enumOpt0, tag0, uenv0)
+      case WeededAst.Pattern.Tag(enumOpt, tag, pat, loc) =>
         NamedAst.Pattern.Tag(enumOpt, tag, visit(pat), loc)
 
       case WeededAst.Pattern.Tuple(elms, loc) => NamedAst.Pattern.Tuple(elms map visit, loc)
@@ -1186,30 +1151,30 @@ object Namer {
   /**
     * Names the given head predicate `head` under the given environments `env0`, `uenv0`, and `tenv0`.
     */
-  private def visitHeadPredicate(head: WeededAst.Predicate.Head, outerEnv: Map[String, Symbol.VarSym], headEnv0: Map[String, Symbol.VarSym], ruleEnv0: Map[String, Symbol.VarSym], uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Predicate.Head, NameError] = head match {
+  private def visitHeadPredicate(head: WeededAst.Predicate.Head, outerEnv: Map[String, Symbol.VarSym], headEnv0: Map[String, Symbol.VarSym], ruleEnv0: Map[String, Symbol.VarSym], tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Predicate.Head, NameError] = head match {
     case WeededAst.Predicate.Head.Atom(pred, den, terms, loc) =>
       for {
-        ts <- traverse(terms)(t => visitExp(t, outerEnv ++ headEnv0 ++ ruleEnv0, uenv0, tenv0, ns0))
+        ts <- traverse(terms)(t => visitExp(t, outerEnv ++ headEnv0 ++ ruleEnv0, tenv0, ns0))
       } yield NamedAst.Predicate.Head.Atom(pred, den, ts, loc)
   }
 
   /**
     * Names the given body predicate `body` under the given environments `env0`, `uenv0`, and `tenv0`.
     */
-  private def visitBodyPredicate(body: WeededAst.Predicate.Body, outerEnv: Map[String, Symbol.VarSym], headEnv0: Map[String, Symbol.VarSym], ruleEnv0: Map[String, Symbol.VarSym], uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Predicate.Body, NameError] = body match {
+  private def visitBodyPredicate(body: WeededAst.Predicate.Body, outerEnv: Map[String, Symbol.VarSym], headEnv0: Map[String, Symbol.VarSym], ruleEnv0: Map[String, Symbol.VarSym], tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Predicate.Body, NameError] = body match {
     case WeededAst.Predicate.Body.Atom(pred, den, polarity, fixity, terms, loc) =>
-      val ts = terms.map(t => visitPattern(t, outerEnv ++ ruleEnv0, uenv0))
+      val ts = terms.map(t => visitPattern(t, outerEnv ++ ruleEnv0))
       NamedAst.Predicate.Body.Atom(pred, den, polarity, fixity, ts, loc).toSuccess
 
     case WeededAst.Predicate.Body.Guard(exp, loc) =>
       for {
-        e <- visitExp(exp, outerEnv ++ headEnv0 ++ ruleEnv0, uenv0, tenv0, ns0)
+        e <- visitExp(exp, outerEnv ++ headEnv0 ++ ruleEnv0, tenv0, ns0)
       } yield NamedAst.Predicate.Body.Guard(e, loc)
 
     case WeededAst.Predicate.Body.Loop(idents, exp, loc) =>
       val varSyms = idents.map(ident => headEnv0(ident.name))
       for {
-        e <- visitExp(exp, outerEnv ++ headEnv0 ++ ruleEnv0, uenv0, tenv0, ns0)
+        e <- visitExp(exp, outerEnv ++ headEnv0 ++ ruleEnv0, tenv0, ns0)
       } yield NamedAst.Predicate.Body.Loop(varSyms, e, loc)
 
   }
@@ -1235,7 +1200,7 @@ object Namer {
   /**
     * Names the given type `tpe` under the given environments `uenv0` and `tenv0`.
     */
-  private def visitType(t0: WeededAst.Type, allowWild: Boolean, uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym])(implicit flix: Flix): Validation[NamedAst.Type, NameError] = {
+  private def visitType(t0: WeededAst.Type, allowWild: Boolean, tenv0: Map[String, Symbol.UnkindedTypeVarSym])(implicit flix: Flix): Validation[NamedAst.Type, NameError] = {
     def visit(tpe0: WeededAst.Type): Validation[NamedAst.Type, NameError] = tpe0 match {
       case WeededAst.Type.Unit(loc) => NamedAst.Type.Unit(loc).toSuccess
 
@@ -1263,27 +1228,15 @@ object Namer {
       case WeededAst.Type.Ambiguous(qname, loc) =>
         if (qname.isUnqualified) {
           val name = qname.ident.name
-          // Disambiguate the qname.
-          (tenv0.get(name), uenv0.upperNames.get(name), uenv0.imports.get(name)) match {
-            case (None, None, None) =>
-              // Case 1: the name is top-level type.
-              NamedAst.Type.Ambiguous(qname, loc).toSuccess
 
-            case (Some(tvar), None, None) =>
+          tenv0.get(name) match {
+            case None =>
+              // Case 1: the name is not a variable, resolve it later
+              NamedAst.Type.Ambiguous(qname, loc).toSuccess
+            case Some(tvar) =>
+              // TODO resolve this in Resolver instead
               // Case 2: the name is a type variable.
               NamedAst.Type.Var(tvar, loc).toSuccess
-
-            case (None, Some(actualQName), None) =>
-              // Case 3: the name is a use.
-              NamedAst.Type.Ambiguous(actualQName, loc).toSuccess
-
-            case (None, None, Some(name)) =>
-              // Case 4: the name is an imported class or interface
-              NamedAst.Type.Native(name.toString, SourceLocation.mk(name.sp1, name.sp2)).toSuccess
-
-            case _ =>
-              // Case 4: the name is ambiguous.
-              throw InternalCompilerException(s"Unexpected ambiguous type.", loc)
           }
         }
         else
@@ -1312,14 +1265,9 @@ object Namer {
 
       case WeededAst.Type.SchemaRowExtendByAlias(qname, targs, rest, loc) =>
         // Disambiguate the qname.
-        val name = if (qname.isUnqualified) {
-          uenv0.upperNames.getOrElse(qname.ident.name, qname)
-        } else {
-          qname
-        }
 
         mapN(traverse(targs)(visit(_)), visit(rest)) {
-          case (ts, r) => NamedAst.Type.SchemaRowExtendWithAlias(name, ts, r, loc)
+          case (ts, r) => NamedAst.Type.SchemaRowExtendWithAlias(qname, ts, r, loc)
         }
 
       case WeededAst.Type.SchemaRowExtendByTypes(ident, den, tpes, rest, loc) =>
@@ -1347,7 +1295,7 @@ object Namer {
 
       case WeededAst.Type.Arrow(tparams0, purAndEff0, tresult0, loc) =>
         val tparamsVal = traverse(tparams0)(visit)
-        val purAndEffVal = visitPurityAndEffect(purAndEff0, allowWild, uenv0, tenv0)
+        val purAndEffVal = visitPurityAndEffect(purAndEff0, allowWild, tenv0)
         val tresultVal = visit(tresult0)
         mapN(tparamsVal, purAndEffVal, tresultVal) {
           case (tparams, purAndEff, tresult) => NamedAst.Type.Arrow(tparams, purAndEff, tresult, loc)
@@ -1441,10 +1389,10 @@ object Namer {
   /**
     * Performs naming on the given purity and effect.
     */
-  private def visitPurityAndEffect(purAndEff: WeededAst.PurityAndEffect, allowWild: Boolean, uenv: UseEnv, tenv: Map[String, Symbol.UnkindedTypeVarSym])(implicit flix: Flix): Validation[NamedAst.PurityAndEffect, NameError] = purAndEff match {
+  private def visitPurityAndEffect(purAndEff: WeededAst.PurityAndEffect, allowWild: Boolean, tenv: Map[String, Symbol.UnkindedTypeVarSym])(implicit flix: Flix): Validation[NamedAst.PurityAndEffect, NameError] = purAndEff match {
     case WeededAst.PurityAndEffect(pur0, eff0) =>
-      val purVal = traverseOpt(pur0)(visitType(_, allowWild, uenv, tenv))
-      val effVal = traverseOpt(eff0)(effs => traverse(effs)(visitType(_, allowWild, uenv, tenv)))
+      val purVal = traverseOpt(pur0)(visitType(_, allowWild, tenv))
+      val effVal = traverseOpt(eff0)(effs => traverse(effs)(visitType(_, allowWild, tenv)))
       mapN(purVal, effVal) {
         case (pur, eff) => NamedAst.PurityAndEffect(pur, eff)
       }
@@ -1703,9 +1651,9 @@ object Namer {
   /**
     * Translates the given weeded annotation to a named annotation.
     */
-  private def visitAnnotation(ann: WeededAst.Annotation, env0: Map[String, Symbol.VarSym], uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Annotation, NameError] = ann match {
+  private def visitAnnotation(ann: WeededAst.Annotation, env0: Map[String, Symbol.VarSym], tenv0: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Annotation, NameError] = ann match {
     case WeededAst.Annotation(name, args, loc) =>
-      mapN(traverse(args)(visitExp(_, env0, uenv0, tenv0, ns0))) {
+      mapN(traverse(args)(visitExp(_, env0, tenv0, ns0))) {
         case as => NamedAst.Annotation(name, as, loc)
       }
   }
@@ -1726,7 +1674,7 @@ object Namer {
   /**
     * Translates the given weeded formal parameter to a named formal parameter.
     */
-  private def visitFormalParam(fparam: WeededAst.FormalParam, uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym])(implicit flix: Flix): Validation[NamedAst.FormalParam, NameError] = fparam match {
+  private def visitFormalParam(fparam: WeededAst.FormalParam, tenv0: Map[String, Symbol.UnkindedTypeVarSym])(implicit flix: Flix): Validation[NamedAst.FormalParam, NameError] = fparam match {
     case WeededAst.FormalParam(ident, mod, optType, loc) =>
       // Generate a fresh variable symbol for the identifier.
       val freshSym = Symbol.freshVarSym(ident, BoundBy.FormalParam)
@@ -1734,7 +1682,7 @@ object Namer {
       // Compute the type of the formal parameter or use the type variable of the symbol.
       val tpeVal = optType match {
         case None => NamedAst.Type.Var(freshSym.tvar.sym.withoutKind, loc).toSuccess
-        case Some(t) => visitType(t, allowWild = true, uenv0, tenv0)
+        case Some(t) => visitType(t, allowWild = true, tenv0)
       }
 
       val src = optType match {
@@ -1751,12 +1699,12 @@ object Namer {
   /**
     * Translates the given weeded predicate parameter to a named predicate parameter.
     */
-  private def visitPredicateParam(pparam: WeededAst.PredicateParam, uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym])(implicit flix: Flix): Validation[NamedAst.PredicateParam, NameError] = pparam match {
+  private def visitPredicateParam(pparam: WeededAst.PredicateParam, tenv0: Map[String, Symbol.UnkindedTypeVarSym])(implicit flix: Flix): Validation[NamedAst.PredicateParam, NameError] = pparam match {
     case WeededAst.PredicateParam.PredicateParamUntyped(pred, loc) =>
       NamedAst.PredicateParam.PredicateParamUntyped(pred, loc).toSuccess
 
     case WeededAst.PredicateParam.PredicateParamWithType(pred, den, tpes, loc) =>
-      mapN(traverse(tpes)(visitType(_, allowWild = false, uenv0, tenv0))) {
+      mapN(traverse(tpes)(visitType(_, allowWild = false, tenv0))) {
         case ts => NamedAst.PredicateParam.PredicateParamWithType(pred, den, ts, loc)
       }
   }
@@ -1764,13 +1712,13 @@ object Namer {
   /**
     * Translates the given weeded JvmMethod to a named JvmMethod.
     */
-  private def visitJvmMethod(method: WeededAst.JvmMethod, env: Map[String, Symbol.VarSym], uenv: UseEnv, tenv: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.JvmMethod, NameError] = method match {
+  private def visitJvmMethod(method: WeededAst.JvmMethod, env: Map[String, Symbol.VarSym], tenv: Map[String, Symbol.UnkindedTypeVarSym], ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.JvmMethod, NameError] = method match {
     case WeededAst.JvmMethod(ident, fparams0, exp0, tpe0, purAndEff0, loc) =>
-      flatMapN(traverse(fparams0)(visitFormalParam(_, uenv, tenv))) {
+      flatMapN(traverse(fparams0)(visitFormalParam(_, tenv))) {
         case fparams =>
-          val exp = visitExp(exp0, env ++ getVarEnv(fparams), uenv, tenv, ns0)
-          val tpe = visitType(tpe0, allowWild = false, uenv, tenv)
-          val purAndEff = visitPurityAndEffect(purAndEff0, allowWild = false, uenv, tenv)
+          val exp = visitExp(exp0, env ++ getVarEnv(fparams), tenv, ns0)
+          val tpe = visitType(tpe0, allowWild = false, tenv)
+          val purAndEff = visitPurityAndEffect(purAndEff0, allowWild = false, tenv)
           mapN(exp, tpe, purAndEff) {
             case (e, t, p) => NamedAst.JvmMethod(ident, fparams, e, t, p, loc)
           }
@@ -1796,8 +1744,8 @@ object Namer {
   /**
     * Performs naming on the given formal parameters `fparam0` under the given environments `uenv0` and `tenv0`.
     */
-  private def getFormalParams(fparams0: List[WeededAst.FormalParam], uenv0: UseEnv, tenv0: Map[String, Symbol.UnkindedTypeVarSym])(implicit flix: Flix): Validation[List[NamedAst.FormalParam], NameError] = {
-    traverse(fparams0)(visitFormalParam(_, uenv0, tenv0))
+  private def getFormalParams(fparams0: List[WeededAst.FormalParam], tenv0: Map[String, Symbol.UnkindedTypeVarSym])(implicit flix: Flix): Validation[List[NamedAst.FormalParam], NameError] = {
+    traverse(fparams0)(visitFormalParam(_, tenv0))
   }
 
 
@@ -1826,7 +1774,7 @@ object Namer {
   /**
     * Performs naming on the given type parameters `tparams0` from the given formal params `fparams` and overall type `tpe`.
     */
-  private def getTypeParamsFromFormalParams(tparams0: WeededAst.TypeParams, fparams: List[WeededAst.FormalParam], tpe: WeededAst.Type, purAndEff: WeededAst.PurityAndEffect, uenv: UseEnv, tenv: Map[String, Symbol.UnkindedTypeVarSym])(implicit flix: Flix): NamedAst.TypeParams = {
+  private def getTypeParamsFromFormalParams(tparams0: WeededAst.TypeParams, fparams: List[WeededAst.FormalParam], tpe: WeededAst.Type, purAndEff: WeededAst.PurityAndEffect, tenv: Map[String, Symbol.UnkindedTypeVarSym])(implicit flix: Flix): NamedAst.TypeParams = {
     tparams0 match {
       case WeededAst.TypeParams.Elided => getImplicitTypeParamsFromFormalParams(fparams, tpe, purAndEff, tenv)
       case WeededAst.TypeParams.Unkinded(tparams0) => getExplicitTypeParams(tparams0)
@@ -1909,51 +1857,6 @@ object Namer {
   }
 
   /**
-    * Disambiguate the given tag `tag0` with the given optional enum name `enumOpt0` under the given use environment `uenv0`.
-    */
-  private def getDisambiguatedTag(enumOpt0: Option[Name.QName], tag0: Name.Ident, uenv0: UseEnv): (Option[Name.QName], Name.Ident) = {
-    enumOpt0 match {
-      case None =>
-        // Case 1: The tag is unqualified. Look it up in the use environment.
-        uenv0.tags.get(tag0.name) match {
-          case None =>
-            // Case 1.1: The tag is unqualified and does not appear in the use environment. Leave it as is.
-            (None, tag0)
-          case Some((actualQName, actualTag)) =>
-            // Case 1.2: The tag is unqualified and appears in the use environment. Use the actual qualified name and actual tag.
-            (Some(actualQName), actualTag)
-        }
-      case Some(qname) =>
-        // Case 2: The tag is qualified. Check if it fully-qualified.
-        if (qname.isUnqualified) {
-          // Case 2.1: The tag is only qualified by one name. Look it up in the use environment.
-          uenv0.upperNames.get(qname.ident.name) match {
-            case None =>
-              // Case 2.1.1: The qualified name is not in the use environment. Do not touch it.
-              (Some(qname), tag0)
-            case Some(actualQName) =>
-              // Case 2.1.2: The qualified name is in the use environment. Use it instead.
-              (Some(actualQName), tag0)
-          }
-        } else {
-          // Case 2.2: The tag is fully-qualified. Do not touch it.
-          (Some(qname), tag0)
-        }
-    }
-  }
-
-  /**
-    * Looks up the class or effect in the given UseEnv.
-    */
-  private def getClassOrEffect(qname: Name.QName, uenv0: UseEnv): Name.QName = {
-    if (qname.isQualified) {
-      qname
-    } else {
-      uenv0.upperNames.getOrElse(qname.ident.name, qname)
-    }
-  }
-
-  /**
     * Gets the location of the symbol of the declaration.
     */
   private def getSymLocation(f: NamedAst.Declaration): SourceLocation = f match {
@@ -1964,6 +1867,7 @@ object Namer {
     case NamedAst.Declaration.TypeAlias(doc, mod, sym, tparams, tpe, loc) => sym.loc
     case NamedAst.Declaration.Effect(doc, ann, mod, sym, ops, loc) => sym.loc
     case NamedAst.Declaration.Op(sym, spec) => sym.loc
+    case NamedAst.Declaration.Case(sym, tpe) => sym.loc
     case NamedAst.Declaration.Instance(doc, ann, mod, clazz, tpe, tconstrs, defs, ns, loc) => throw InternalCompilerException("Unexpected instance", loc)
     case NamedAst.Declaration.Namespace(sym, usesAndImports, decls, loc) => throw InternalCompilerException("Unexpected namespace", loc)
   }
@@ -1983,58 +1887,6 @@ object Namer {
     case WeededAst.UseOrImport.UseUpper(qname, alias, loc) => NamedAst.UseOrImport.UseTypeOrClass(qname, alias, loc)
     case WeededAst.UseOrImport.UseTag(qname, tag, alias, loc) => NamedAst.UseOrImport.UseTag(qname, tag, alias, loc)
     case WeededAst.UseOrImport.Import(name, alias, loc) => NamedAst.UseOrImport.Import(name, alias, loc)
-  }
-
-  /**
-    * Companion object for the [[UseEnv]] class.
-    */
-  private object UseEnv {
-    val empty: UseEnv = UseEnv(Map.empty, Map.empty, Map.empty, Map.empty)
-
-    /**
-      * Builds a UseEnv from the given uses and imports.
-      */
-    def mk(usesAndImports: List[NamedAst.UseOrImport]): UseEnv = UseEnv.empty.addAll(usesAndImports)
-  }
-
-  /**
-    * Represents an environment of "imported" names, including defs, types, tags, and Java classes/interfaces.
-    */
-  private case class UseEnv(lowerNames: Map[String, Name.QName], upperNames: Map[String, Name.QName], tags: Map[String, (Name.QName, Name.Ident)], imports: Map[String, Name.JavaName]) {
-    /**
-      * Binds the lowercase name `s` to the qualified name `n`.
-      */
-    def addLower(s: String, n: Name.QName): UseEnv = copy(lowerNames = lowerNames + (s -> n))
-
-    /**
-      * Binds the uppercase name `s` to the qualified name `n`.
-      */
-    def addUpper(s: String, n: Name.QName): UseEnv = copy(upperNames = upperNames + (s -> n))
-
-    /**
-      * Binds the tag name `s` to the qualified name `n` and tag `t`.
-      */
-    def addTag(s: String, n: Name.QName, t: Name.Ident): UseEnv = copy(tags = tags + (s -> (n, t)))
-
-    /**
-      * Binds the Java class/interface `s` to the qualified name `n`.
-      */
-    def addImport(s: String, n: Name.JavaName): UseEnv = copy(imports = imports + (s -> n))
-
-    /**
-      * Adds the use or import to the UseEnv.
-      */
-    def addUseOrImport(useOrImport: NamedAst.UseOrImport): UseEnv = useOrImport match {
-      case NamedAst.UseOrImport.UseDefOrSig(qname, alias, loc) => addLower(alias.name, qname)
-      case NamedAst.UseOrImport.UseTypeOrClass(qname, alias, loc) => addUpper(alias.name, qname)
-      case NamedAst.UseOrImport.UseTag(qname, tag, alias, loc) => addTag(alias.name, qname, tag)
-      case NamedAst.UseOrImport.Import(name, alias, loc) => addImport(alias.name, name)
-    }
-
-    /**
-      * Adds all the uses or imports to the UseEnv.
-      */
-    def addAll(usesAndImports: List[NamedAst.UseOrImport]): UseEnv = usesAndImports.foldLeft(this)(_.addUseOrImport(_))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -106,6 +106,9 @@ object Namer {
       }
   }
 
+  /**
+    * Adds symbols from the compilation unit to the table.
+    */
   private def tableUnit(unit: NamedAst.CompilationUnit, table0: SymbolTable): Validation[SymbolTable, NameError] = unit match {
     case NamedAst.CompilationUnit(usesAndImports, decls, loc) =>
       fold(decls, table0) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -50,7 +50,7 @@ object Namer {
 
         mapN(tableVal) {
           case SymbolTable(symbols0, instances0, uses0) =>
-            // TODO remove use of NName
+            // TODO NS-REFACTOR remove use of NName
             val symbols = symbols0.map {
               case (k, v) => Name.mkUnlocatedNName(k) -> v
             }
@@ -82,7 +82,7 @@ object Namer {
     */
   private def visitDecl(decl0: WeededAst.Declaration, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration, NameError] = decl0 match {
     case decl: WeededAst.Declaration.Namespace => visitNamespace(decl, ns0)
-    // TODO remove needless tenvs from visitClass, visitInstance, visitEffect
+    // TODO NS-REFACTOR remove needless tenvs from visitClass, visitInstance, visitEffect
     case decl: WeededAst.Declaration.Class => visitClass(decl, Map.empty, ns0)
     case decl: WeededAst.Declaration.Instance => visitInstance(decl, Map.empty, ns0)
     case decl: WeededAst.Declaration.Def => visitDef(decl, Map.empty, ns0, Nil)
@@ -564,7 +564,7 @@ object Namer {
       // the ident name.
       val name = ident.name
 
-      // TODO move this lookup to Resolver
+      // TODO NS-REFACTOR move this lookup to Resolver
       // lookup the name in the var environment
       env0.get(name) match {
         // Case 1: not found, assume it is a function
@@ -1237,7 +1237,7 @@ object Namer {
               // Case 1: the name is not a variable, resolve it later
               NamedAst.Type.Ambiguous(qname, loc).toSuccess
             case Some(tvar) =>
-              // TODO resolve this in Resolver instead
+              // TODO NS-REFACTOR resolve this in Resolver instead
               // Case 2: the name is a type variable.
               NamedAst.Type.Var(tvar, loc).toSuccess
           }

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -285,7 +285,7 @@ object Redundancy {
       visitExp(exp, env0, rc)
 
     case Expression.Use(_, exp, _) =>
-      visitExp(exp, env0, rc) // TODO check for unused syms
+      visitExp(exp, env0, rc) // TODO NS-REFACTOR check for unused syms
 
     case Expression.Lambda(fparam, exp, _, _) =>
       // Extend the environment with the variable symbol.

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -19,11 +19,12 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.BoundBy
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration
-import ca.uwaterloo.flix.language.ast.UnkindedType.{mkAnd, mkComplement, mkEffect, mkEnum, mkIntersection, mkNot, mkOr, mkPredicate, mkUncurriedArrowWithEffect, mkUnion}
+import ca.uwaterloo.flix.language.ast.UnkindedType._
 import ca.uwaterloo.flix.language.ast.{Symbol, _}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 import ca.uwaterloo.flix.util.Validation._
-import ca.uwaterloo.flix.util.{Graph, InternalCompilerException, ParOps, Validation}
+import ca.uwaterloo.flix.util.collection.ListMap
+import ca.uwaterloo.flix.util.{Graph, InternalCompilerException, Validation}
 
 import java.lang.reflect.{Constructor, Field, Method, Modifier}
 import scala.collection.mutable
@@ -58,64 +59,244 @@ object Resolver {
     * Performs name resolution on the given program `root`.
     */
   def run(root: NamedAst.Root, oldRoot: ResolvedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Validation[ResolvedAst.Root, ResolutionError] = flix.phase("Resolver") {
-    val typeAliases = root.symbols.map {
-      case (ns, map0) =>
-        val map = map0.collect {
-          case (name, alias: NamedAst.Declaration.TypeAlias) => (name, alias)
-        }
-        (ns, map)
-    }
 
     val usesVal = root.uses.map {
       case (ns, uses0) =>
-        mapN(traverse(uses0)(visitUse(_, ns, root))) {
+        mapN(traverse(uses0)(visitUseOrImport(_, ns, root))) {
           u => (new Symbol.ModuleSym(ns.parts) -> u)
         }
     }
 
     // Type aliases must be processed first in order to provide a `taenv` for looking up type alias symbols.
-    flatMapN(resolveTypeAliases(typeAliases, root)) {
-      case (taenv, taOrder) =>
+    flatMapN(sequence(usesVal), resolveTypeAliases(root)) {
+      case (uses, (taenv, taOrder)) =>
 
-        val classesVal = resolveClasses(root, taenv, oldRoot, changeSet)
-
-        val instancesVal = root.instances.flatMap {
-          case (ns0, instances0) => instances0.map {
-            case (_, instances) => traverse(instances)(resolveInstance(_, taenv, ns0, root)) map {
-              case is => is.head.sym.clazz -> is
-            }
-          }
-        }
-
-        val defsVal = resolveDefs(root, taenv, oldRoot, changeSet)
-
-        val enumsVal = root.symbols.flatMap {
-          case (ns0, classesAndEffectsAndEnums) => classesAndEffectsAndEnums.collect {
-            case (_, enum: NamedAst.Declaration.Enum) => resolveEnum(enum, taenv, ns0, root) map {
-              case d => d.sym -> d
-            }
-          }
-        }
-
-        val effectsVal = root.symbols.flatMap {
-          case (ns0, classesAndEffects) => classesAndEffects.collect {
-            case (_, effect: NamedAst.Declaration.Effect) => resolveEffect(effect, taenv, ns0, root) map {
-              case e => e.sym -> e
-            }
-          }
-        }
-
-        flatMapN(classesVal, sequence(instancesVal), defsVal, sequence(enumsVal), sequence(effectsVal), sequence(usesVal)) {
-          case (classes, instances, defs, enums, effects, uses) =>
-            mapN(checkSuperClassDag(classes)) {
-              _ =>
-                val flatUses = uses.map {
-                  case (sym, list) => (sym, list.flatten)
-                }
-                ResolvedAst.Root(classes, combine(instances), defs, enums.toMap, effects.toMap, taenv, combine(flatUses), taOrder, root.entryPoint, root.sources, root.names)
+        val unitsVal = traverse(root.units.values)(visitUnit(_, taenv, root))
+        flatMapN(unitsVal) {
+          case units =>
+            val table = SymbolTable.traverse(units)(tableUnit)
+            mapN(checkSuperClassDag(table.classes)) {
+              case () =>
+                ResolvedAst.Root(
+                  table.classes,
+                  table.instances.m, // TODO use ListMap elsewhere for this too
+                  table.defs,
+                  table.enums,
+                  table.effects,
+                  table.typeAliases,
+                  uses.toMap,
+                  taOrder,
+                  root.entryPoint,
+                  root.sources,
+                  root.names
+                )
             }
         }
     }
+  }
+
+  private def tableUnit(unit: ResolvedAst.CompilationUnit): SymbolTable = unit match {
+    case ResolvedAst.CompilationUnit(_, decls, _) => SymbolTable.traverse(decls)(tableDecl)
+  }
+
+  private def tableDecl(decl: ResolvedAst.Declaration): SymbolTable = decl match {
+    case ResolvedAst.Namespace(_, _, decls, _) => SymbolTable.traverse(decls)(tableDecl)
+    case clazz: ResolvedAst.Class => SymbolTable.empty.addClass(clazz)
+    case inst: ResolvedAst.Instance => SymbolTable.empty.addInstance(inst)
+    case defn: ResolvedAst.Def => SymbolTable.empty.addDef(defn)
+    case enum: ResolvedAst.Enum => SymbolTable.empty.addEnum(enum)
+    case alias: ResolvedAst.TypeAlias => SymbolTable.empty.addTypeAlias(alias)
+    case effect: ResolvedAst.Effect => SymbolTable.empty.addEffect(effect)
+    case ResolvedAst.Op(sym, _) => throw InternalCompilerException(s"Unexpected declaration: $sym")
+    case ResolvedAst.Sig(sym, _, _) => throw InternalCompilerException(s"Unexpected declaration: $sym")
+  }
+
+  private def semiResolveTypeAliases(root: NamedAst.Root)(implicit flix: Flix): Validation[Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ResolutionError] = {
+    fold(root.units.values, Map.empty[Symbol.TypeAliasSym, ResolvedAst.TypeAlias]) {
+      case (acc, unit) => mapN(semiResolveTypeAliasesInUnit(unit, root)) {
+        case aliases => aliases.foldLeft(acc) {
+          case (innerAcc, alias) => innerAcc + (alias.sym -> alias)
+        }
+      }
+    }
+  }
+
+  private def semiResolveTypeAliasesInUnit(unit: NamedAst.CompilationUnit, root: NamedAst.Root)(implicit flix: Flix): Validation[List[ResolvedAst.TypeAlias], ResolutionError] = unit match {
+    case NamedAst.CompilationUnit(usesAndImports0, decls, loc) =>
+      val usesAndImportsVal = traverse(usesAndImports0)(visitUseOrImport(_, Name.RootNS, root))
+      flatMapN(usesAndImportsVal) {
+        case usesAndImports =>
+          val uenv = mkUseEnv(usesAndImports, root)
+          val namespaces = decls.collect {
+            case ns: NamedAst.Declaration.Namespace => ns
+          }
+          val aliases0 = decls.collect {
+            case alias: NamedAst.Declaration.TypeAlias => alias
+          }
+          val aliasesVal = traverse(aliases0)(semiResolveTypeAlias(_, uenv, Name.RootNS, root))
+          val nsVal = traverse(namespaces)(semiResolveTypeAliasesInNamespace(_, root))
+          mapN(aliasesVal, nsVal) {
+            case (aliases, ns) => aliases ::: ns.flatten
+          }
+      }
+  }
+
+  private def semiResolveTypeAliasesInNamespace(ns0: NamedAst.Declaration.Namespace, root: NamedAst.Root)(implicit flix: Flix): Validation[List[ResolvedAst.TypeAlias], ResolutionError] = ns0 match {
+    case NamedAst.Declaration.Namespace(sym, usesAndImports0, decls, loc) =>
+      val ns = Name.mkUnlocatedNName(sym.ns)
+      val usesAndImportsVal = traverse(usesAndImports0)(visitUseOrImport(_, ns, root))
+      flatMapN(usesAndImportsVal) {
+        case usesAndImports =>
+          val uenv = mkUseEnv(usesAndImports, root)
+          val namespaces = decls.collect {
+            case ns: NamedAst.Declaration.Namespace => ns
+          }
+          val aliases0 = decls.collect {
+            case alias: NamedAst.Declaration.TypeAlias => alias
+          }
+          val aliasesVal = traverse(aliases0)(semiResolveTypeAlias(_, uenv, ns, root))
+          val nsVal = traverse(namespaces)(semiResolveTypeAliasesInNamespace(_, root))
+          mapN(aliasesVal, nsVal) {
+            case (aliases, ns) => aliases ::: ns.flatten
+          }
+      }
+  }
+
+  /**
+    * Partially resolves the type alias.
+    *
+    * Type aliases within the type are given temporary placeholders.
+    */
+  def semiResolveTypeAlias(alias: NamedAst.Declaration.TypeAlias, uenv: ListMap[String, DeclarationOrJavaClass], ns: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.TypeAlias, ResolutionError] = alias match {
+    case NamedAst.Declaration.TypeAlias(doc, mod, sym, tparams0, tpe0, loc) =>
+      val tparams = resolveTypeParams(tparams0, ns, root)
+      semiResolveType(tpe0, uenv, ns, root) map {
+        tpe => ResolvedAst.TypeAlias(doc, mod, sym, tparams, tpe, loc)
+      }
+  }
+
+  /**
+    * Resolves the type aliases in the given root.
+    *
+    * Returns a pair:
+    *   - a map of type alias symbols to their AST nodes
+    *   - a list of the aliases in a processing order,
+    *     such that any alias only depends on those earlier in the list
+    */
+  def resolveTypeAliases(root: NamedAst.Root)(implicit flix: Flix): Validation[(Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], List[Symbol.TypeAliasSym]), ResolutionError] = {
+    for {
+      semiResolved <- semiResolveTypeAliases(root)
+      orderedSyms <- findResolutionOrder(semiResolved.values)
+      orderedSemiResolved = orderedSyms.map(semiResolved)
+      aliases <- finishResolveTypeAliases(orderedSemiResolved)
+    } yield (aliases, orderedSyms)
+
+  }
+
+  /**
+    * Gets a list of all type aliases used in the partially resolved type tpe0.
+    */
+  def getAliasUses(tpe0: UnkindedType): List[Symbol.TypeAliasSym] = tpe0 match {
+    case _: UnkindedType.Var => Nil
+    case UnkindedType.Ascribe(tpe, _, _) => getAliasUses(tpe)
+    case UnkindedType.UnappliedAlias(sym, _) => sym :: Nil
+    case _: UnkindedType.Cst => Nil
+    case UnkindedType.Apply(tpe1, tpe2, _) => getAliasUses(tpe1) ::: getAliasUses(tpe2)
+    case _: UnkindedType.Arrow => Nil
+    case UnkindedType.ReadWrite(tpe, loc) => getAliasUses(tpe)
+    case _: UnkindedType.Enum => Nil
+    case _: UnkindedType.Alias => throw InternalCompilerException("unexpected applied alias")
+  }
+
+  /**
+    * Create a list of CyclicTypeAliases errors, one for each type alias.
+    */
+  def mkCycleErrors[T](cycle: List[Symbol.TypeAliasSym]): Validation.Failure[T, ResolutionError] = {
+    val errors = cycle.map {
+      sym => ResolutionError.CyclicTypeAliases(cycle, sym.loc)
+    }
+    Validation.Failure(LazyList.from(errors))
+  }
+
+  /**
+    * Gets the resolution order for the aliases.
+    *
+    * Any alias only depends on those earlier in the list
+    */
+  def findResolutionOrder(aliases: Iterable[ResolvedAst.TypeAlias]): Validation[List[Symbol.TypeAliasSym], ResolutionError] = {
+    val aliasSyms = aliases.map(_.sym)
+    val aliasLookup = aliases.map(alias => alias.sym -> alias).toMap
+    val getUses = (sym: Symbol.TypeAliasSym) => getAliasUses(aliasLookup(sym).tpe)
+
+    Graph.topologicalSort(aliasSyms, getUses) match {
+      case Graph.TopologicalSort.Sorted(sorted) => sorted.toSuccess
+      case Graph.TopologicalSort.Cycle(path) => mkCycleErrors(path)
+    }
+  }
+
+  /**
+    * Finishes the resolution of the given type aliases.
+    *
+    * Replaces placeholder type alias constructors with the real type aliases.
+    *
+    * The given aliases must be in resolution order.
+    */
+  def finishResolveTypeAliases(aliases0: List[ResolvedAst.TypeAlias]): Validation[Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ResolutionError] = {
+    Validation.fold(aliases0, Map.empty[Symbol.TypeAliasSym, ResolvedAst.TypeAlias]) {
+      case (taenv, ResolvedAst.TypeAlias(doc, mod, sym, tparams, tpe0, loc)) =>
+        finishResolveType(tpe0, taenv) map {
+          tpe =>
+            val alias = ResolvedAst.TypeAlias(doc, mod, sym, tparams, tpe, loc)
+            taenv + (sym -> alias)
+        }
+    }
+  }
+
+  private def visitUnit(unit: NamedAst.CompilationUnit, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.CompilationUnit, ResolutionError] = unit match {
+    case NamedAst.CompilationUnit(usesAndImports0, decls0, loc) =>
+      val usesAndImportsVal = traverse(usesAndImports0)(visitUseOrImport(_, Name.RootNS, root))
+      flatMapN(usesAndImportsVal) {
+        case usesAndImports =>
+          val uenv = mkUseEnv(usesAndImports, root)
+          val declsVal = traverse(decls0)(visitDecl(_, uenv, taenv, Name.RootNS, root))
+          mapN(declsVal) {
+            case decls => ResolvedAst.CompilationUnit(usesAndImports, decls, loc)
+          }
+      }
+  }
+
+  private def visitDecl(decl: NamedAst.Declaration, uenv0: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Declaration, ResolutionError] = decl match {
+    case Declaration.Namespace(sym, usesAndImports0, decls0, loc) =>
+      // TODO move to helper for consistency
+      val usesAndImportsVal = traverse(usesAndImports0)(visitUseOrImport(_, ns0, root))
+      flatMapN(usesAndImportsVal) {
+        case usesAndImports =>
+          // reset the uenv
+          val uenv = mkUseEnv(usesAndImports, root)
+          // use the new namespace
+          val ns = Name.mkUnlocatedNName(sym.ns)
+          val declsVal = traverse(decls0)(visitDecl(_, uenv, taenv, ns, root))
+          mapN(declsVal) {
+            case decls => ResolvedAst.Namespace(sym, usesAndImports, decls, loc)
+          }
+      }
+    case clazz@Declaration.Class(doc, ann, mod, sym, tparam, superClasses, sigs, laws, loc) =>
+      resolveClass(clazz, uenv0, taenv, ns0, root)
+    case inst@Declaration.Instance(doc, ann, mod, clazz, tpe, tconstrs, defs, ns, loc) =>
+      resolveInstance(inst, uenv0, taenv, ns0, root)
+    case sig@Declaration.Sig(sym, spec, exp) =>
+      resolveSig(sig, uenv0, taenv, ns0, root)
+    case defn@Declaration.Def(sym, spec, exp) =>
+      resolveDef(defn, uenv0, taenv, ns0, root)
+    case enum@Declaration.Enum(doc, ann, mod, sym, tparams, derives, cases, tpe, loc) =>
+      resolveEnum(enum, uenv0, taenv, ns0, root)
+    case Declaration.TypeAlias(doc, mod, sym, tparams, tpe, loc) =>
+      taenv(sym).toSuccess
+    case eff@Declaration.Effect(doc, ann, mod, sym, ops, loc) =>
+      resolveEffect(eff, uenv0, taenv, ns0, root)
+    case op@Declaration.Op(sym, spec) =>
+      resolveOp(op, uenv0, taenv, ns0, root)
+    case Declaration.Case(sym, tpe) => throw InternalCompilerException("unexpected case")
   }
 
   /**
@@ -150,139 +331,23 @@ object Resolver {
     }
   }
 
-  /**
-    * Resolves the type aliases in the given root.
-    *
-    * Returns a pair:
-    *   - a map of type alias symbols to their AST nodes
-    *   - a list of the aliases in a processing order,
-    *     such that any alias only depends on those earlier in the list
-    */
-  private def resolveTypeAliases(aliases0: Map[Name.NName, Map[String, NamedAst.Declaration.TypeAlias]], root: NamedAst.Root)(implicit flix: Flix): Validation[(Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], List[Symbol.TypeAliasSym]), ResolutionError] = {
-
-    /**
-      * Partially resolves the type alias.
-      *
-      * Type aliases within the type are given temporary placeholders.
-      */
-    def semiResolveTypeAlias(alias: NamedAst.Declaration.TypeAlias, ns: Name.NName): Validation[ResolvedAst.TypeAlias, ResolutionError] = alias match {
-      case NamedAst.Declaration.TypeAlias(doc, mod, sym, tparams0, tpe0, loc) =>
-        val tparams = resolveTypeParams(tparams0, ns, root)
-        semiResolveType(tpe0, ns, root) map {
-          tpe => ResolvedAst.TypeAlias(doc, mod, sym, tparams, tpe, loc)
-        }
-    }
-
-    /**
-      * Gets a list of all type aliases used in the partially resolved type tpe0.
-      */
-    def getAliasUses(tpe0: UnkindedType): List[Symbol.TypeAliasSym] = tpe0 match {
-      case _: UnkindedType.Var => Nil
-      case UnkindedType.Ascribe(tpe, _, _) => getAliasUses(tpe)
-      case UnkindedType.UnappliedAlias(sym, _) => sym :: Nil
-      case _: UnkindedType.Cst => Nil
-      case UnkindedType.Apply(tpe1, tpe2, _) => getAliasUses(tpe1) ::: getAliasUses(tpe2)
-      case _: UnkindedType.Arrow => Nil
-      case UnkindedType.ReadWrite(tpe, loc) => getAliasUses(tpe)
-      case _: UnkindedType.Enum => Nil
-      case _: UnkindedType.Alias => throw InternalCompilerException("unexpected applied alias", tpe0.loc)
-    }
-
-    /**
-      * Create a list of CyclicTypeAliases errors, one for each type alias.
-      */
-    def mkCycleErrors[T](cycle: List[Symbol.TypeAliasSym]): Validation.Failure[T, ResolutionError] = {
-      val errors = cycle.map {
-        sym => ResolutionError.CyclicTypeAliases(cycle, sym.loc)
-      }
-      Validation.Failure(LazyList.from(errors))
-    }
-
-    /**
-      * Gets the resolution order for the aliases.
-      *
-      * Any alias only depends on those earlier in the list
-      */
-    def findResolutionOrder(aliases: Iterable[ResolvedAst.TypeAlias]): Validation[List[Symbol.TypeAliasSym], ResolutionError] = {
-      val aliasSyms = aliases.map(_.sym)
-      val aliasLookup = aliases.map(alias => alias.sym -> alias).toMap
-      val getUses = (sym: Symbol.TypeAliasSym) => getAliasUses(aliasLookup(sym).tpe)
-
-      Graph.topologicalSort(aliasSyms, getUses) match {
-        case Graph.TopologicalSort.Sorted(sorted) => sorted.toSuccess
-        case Graph.TopologicalSort.Cycle(path) => mkCycleErrors(path)
-      }
-    }
-
-    /**
-      * Finishes the resolution of the given type aliases.
-      *
-      * Replaces placeholder type alias constructors with the real type aliases.
-      *
-      * The given aliases must be in resolution order.
-      */
-    def finishResolveTypeAliases(aliases0: List[ResolvedAst.TypeAlias]): Validation[Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ResolutionError] = {
-      Validation.fold(aliases0, Map.empty[Symbol.TypeAliasSym, ResolvedAst.TypeAlias]) {
-        case (taenv, ResolvedAst.TypeAlias(doc, mod, sym, tparams, tpe0, loc)) =>
-          finishResolveType(tpe0, taenv) map {
-            tpe =>
-              val alias = ResolvedAst.TypeAlias(doc, mod, sym, tparams, tpe, loc)
-              taenv + (sym -> alias)
-          }
-      }
-    }
-
-    // Extract all the aliases and namespaces from the map.
-    val aliasesMap0 = for {
-      (ns, aliasesInNs) <- aliases0
-      (_, alias) <- aliasesInNs
-    } yield (alias, ns)
-
-    // Partially resolve the aliases
-    val semiAliasesVal = traverse(aliasesMap0) {
-      case (alias, ns) => semiResolveTypeAlias(alias, ns)
-    }
-
-    flatMapN(semiAliasesVal) {
-      // Get the resolution order
-      semiAliases =>
-        flatMapN(findResolutionOrder(semiAliases)) {
-          sortedSyms =>
-            // Create mapping for the partially resolved aliases
-            val semiAliasEnv = semiAliases.map(alias => alias.sym -> alias).toMap
-
-            // Get the sorted aliases from the mapping
-            val sortedAliases = sortedSyms.map(semiAliasEnv)
-
-            // Resolve the sorted aliases
-            val aliasesVal = finishResolveTypeAliases(sortedAliases)
-
-            mapN(aliasesVal) {
-              aliases => (aliases, sortedSyms)
-            }
-
-        }
-    }
-  }
-
-
   object Constraints {
 
     /**
       * Performs name resolution on the given `constraints` in the given namespace `ns0`.
       */
-    def resolve(constraints: List[NamedAst.Constraint], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[List[ResolvedAst.Constraint], ResolutionError] = {
-      traverse(constraints)(c => resolve(c, taenv, ns0, root))
+    def resolve(constraints: List[NamedAst.Constraint], uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[List[ResolvedAst.Constraint], ResolutionError] = {
+      traverse(constraints)(c => resolve(c, uenv, taenv, ns0, root))
     }
 
     /**
       * Performs name resolution on the given constraint `c0` in the given namespace `ns0`.
       */
-    def resolve(c0: NamedAst.Constraint, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Constraint, ResolutionError] = c0 match {
+    def resolve(c0: NamedAst.Constraint, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Constraint, ResolutionError] = c0 match {
       case NamedAst.Constraint(cparams0, head0, body0, loc) =>
-        val cparamsVal = traverse(cparams0)(p => Params.resolve(p, taenv, ns0, root))
-        val headVal = Predicates.Head.resolve(head0, taenv, ns0, root)
-        val bodyVal = traverse(body0)(Predicates.Body.resolve(_, taenv, ns0, root))
+        val cparamsVal = traverse(cparams0)(p => Params.resolve(p, uenv, taenv, ns0, root))
+        val headVal = Predicates.Head.resolve(head0, uenv, taenv, ns0, root)
+        val bodyVal = traverse(body0)(Predicates.Body.resolve(_, uenv, taenv, ns0, root))
         mapN(cparamsVal, headVal, bodyVal) {
           case (cparams, head, body) => ResolvedAst.Constraint(cparams, head, body, loc)
         }
@@ -293,38 +358,14 @@ object Resolver {
   /**
     * Resolves all the classes in the given root.
     */
-  private def resolveClasses(root: NamedAst.Root, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], oldRoot: ResolvedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Validation[Map[Symbol.ClassSym, ResolvedAst.Class], ResolutionError] = {
-
-    val rootClasses = for {
-      (ns, classesAndEffects) <- root.symbols
-      clazz <- classesAndEffects.collect { case (_, clazz: NamedAst.Declaration.Class) => clazz }
-    } yield clazz.sym -> (clazz, ns)
-
-    val (staleClasses, freshClasses) = changeSet.partition(rootClasses, oldRoot.classes)
-
-    val results = ParOps.parMap(staleClasses.values) {
-      case (clazz, ns) => resolveClass(clazz, taenv, ns, root)
-    }
-
-    Validation.sequence(results) map {
-      res =>
-        res.foldLeft(freshClasses) {
-          case (acc, clazz) => acc + (clazz.sym -> clazz)
-        }
-    }
-  }
-
-  /**
-    * Resolves all the classes in the given root.
-    */
-  def resolveClass(c0: NamedAst.Declaration.Class, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Class, ResolutionError] = c0 match {
+  def resolveClass(c0: NamedAst.Declaration.Class, uenv0: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Class, ResolutionError] = c0 match {
     case NamedAst.Declaration.Class(doc, ann0, mod, sym, tparam0, superClasses0, signatures, laws0, loc) =>
       val tparam = Params.resolveTparam(tparam0)
-      val annVal = traverse(ann0)(visitAnnotation(_, taenv, ns0, root))
-      val sigsListVal = traverse(signatures)(resolveSig(_, taenv, ns0, root))
+      val annVal = traverse(ann0)(visitAnnotation(_, uenv0, taenv, ns0, root))
+      val sigsListVal = traverse(signatures)(resolveSig(_, uenv0, taenv, ns0, root))
       // ignore the parameter of the super class; we don't use it
-      val superClassesVal = traverse(superClasses0)(tconstr => resolveSuperClass(tconstr, taenv, ns0, root))
-      val lawsVal = traverse(laws0)(resolveDef(_, taenv, ns0, root))
+      val superClassesVal = traverse(superClasses0)(tconstr => resolveSuperClass(tconstr, uenv0, taenv, ns0, root))
+      val lawsVal = traverse(laws0)(resolveDef(_, uenv0, taenv, ns0, root))
       mapN(annVal, sigsListVal, superClassesVal, lawsVal) {
         case (ann, sigsList, superClasses, laws) =>
           val sigs = sigsList.map(sig => (sig.sym, sig)).toMap
@@ -335,13 +376,13 @@ object Resolver {
   /**
     * Performs name resolution on the given instance `i0` in the given namespace `ns0`.
     */
-  def resolveInstance(i0: NamedAst.Declaration.Instance, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Instance, ResolutionError] = i0 match {
+  def resolveInstance(i0: NamedAst.Declaration.Instance, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Instance, ResolutionError] = i0 match {
     case NamedAst.Declaration.Instance(doc, ann0, mod, clazz0, tpe0, tconstrs0, defs0, ns, loc) =>
-      val annVal = traverse(ann0)(visitAnnotation(_, taenv, ns0, root))
-      val clazzVal = lookupClassForImplementation(clazz0, ns0, root)
-      val tpeVal = resolveType(tpe0, taenv, ns0, root)
-      val tconstrsVal = traverse(tconstrs0)(resolveTypeConstraint(_, taenv, ns0, root))
-      val defsVal = traverse(defs0)(resolveDef(_, taenv, ns0, root))
+      val annVal = traverse(ann0)(visitAnnotation(_, uenv, taenv, ns0, root))
+      val clazzVal = lookupClassForImplementation(clazz0, uenv, ns0, root)
+      val tpeVal = resolveType(tpe0, uenv, taenv, ns0, root)
+      val tconstrsVal = traverse(tconstrs0)(resolveTypeConstraint(_, uenv, taenv, ns0, root))
+      val defsVal = traverse(defs0)(resolveDef(_, uenv, taenv, ns0, root))
       mapN(annVal, clazzVal, tpeVal, tconstrsVal, defsVal) {
         case (ann, clazz, tpe, tconstrs, defs) =>
           val sym = Symbol.freshInstanceSym(clazz.sym, clazz0.loc)
@@ -352,53 +393,24 @@ object Resolver {
   /**
     * Performs name resolution on the given signature `s0` in the given namespace `ns0`.
     */
-  def resolveSig(s0: NamedAst.Declaration.Sig, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Sig, ResolutionError] = s0 match {
+  def resolveSig(s0: NamedAst.Declaration.Sig, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Sig, ResolutionError] = s0 match {
     case NamedAst.Declaration.Sig(sym, spec0, exp0) =>
-      val specVal = resolveSpec(spec0, taenv, ns0, root)
-      val expVal = traverseOpt(exp0)(Expressions.resolve(_, taenv, ns0, root))
+      val specVal = resolveSpec(spec0, uenv, taenv, ns0, root)
+      val expVal = traverseOpt(exp0)(Expressions.resolve(_, uenv, taenv, ns0, root))
       mapN(specVal, expVal) {
         case (spec, exp) => ResolvedAst.Sig(sym, spec, exp)
       }
   }
 
   /**
-    * Resolves all the definitions in the given root.
-    */
-  private def resolveDefs(root: NamedAst.Root, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], oldRoot: ResolvedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Validation[Map[Symbol.DefnSym, ResolvedAst.Def], ResolutionError] = {
-    def getDef(defOrSig: NamedAst.Declaration): Option[NamedAst.Declaration.Def] = defOrSig match {
-      case d: NamedAst.Declaration.Def => Some(d)
-      case _ => None
-    }
-
-    val rootDefs = for {
-      (ns, symbols) <- root.symbols
-      (_, symbol) <- symbols
-      defn <- getDef(symbol)
-    } yield defn.sym -> (defn, ns)
-
-    val (staleDefs, freshDefs) = changeSet.partition(rootDefs, oldRoot.defs)
-
-    val results = ParOps.parMap(staleDefs.values) {
-      case (defn, ns) => resolveDef(defn, taenv, ns, root)
-    }
-
-    Validation.sequence(results) map {
-      res =>
-        res.foldLeft(freshDefs) {
-          case (acc, defn) => acc + (defn.sym -> defn)
-        }
-    }
-  }
-
-  /**
     * Performs name resolution on the given definition `d0` in the given namespace `ns0`.
     */
-  def resolveDef(d0: NamedAst.Declaration.Def, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Def, ResolutionError] = d0 match {
+  def resolveDef(d0: NamedAst.Declaration.Def, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Def, ResolutionError] = d0 match {
     case NamedAst.Declaration.Def(sym, spec0, exp0) =>
       flix.subtask(sym.toString, sample = true)
 
-      val specVal = resolveSpec(spec0, taenv, ns0, root)
-      val expVal = Expressions.resolve(exp0, taenv, ns0, root)
+      val specVal = resolveSpec(spec0, uenv, taenv, ns0, root)
+      val expVal = Expressions.resolve(exp0, uenv, taenv, ns0, root)
       mapN(specVal, expVal) {
         case (spec, exp) => ResolvedAst.Def(sym, spec, exp)
       }
@@ -407,15 +419,15 @@ object Resolver {
   /**
     * Performs name resolution on the given spec `s0` in the given namespace `ns0`.
     */
-  def resolveSpec(s0: NamedAst.Spec, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Spec, ResolutionError] = s0 match {
+  def resolveSpec(s0: NamedAst.Spec, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Spec, ResolutionError] = s0 match {
     case NamedAst.Spec(doc, ann0, mod, tparams0, fparams0, tpe0, purAndEff0, tconstrs0, loc) =>
 
       val tparams = resolveTypeParams(tparams0, ns0, root)
-      val fparamsVal = resolveFormalParams(fparams0, taenv, ns0, root)
-      val annVal = traverse(ann0)(visitAnnotation(_, taenv, ns0, root))
-      val tpeVal = resolveType(tpe0, taenv, ns0, root)
-      val purAndEffVal = resolvePurityAndEffect(purAndEff0, taenv, ns0, root)
-      val tconstrsVal = traverse(tconstrs0)(resolveTypeConstraint(_, taenv, ns0, root))
+      val fparamsVal = resolveFormalParams(fparams0, uenv, taenv, ns0, root)
+      val annVal = traverse(ann0)(visitAnnotation(_, uenv, taenv, ns0, root))
+      val tpeVal = resolveType(tpe0, uenv, taenv, ns0, root)
+      val purAndEffVal = resolvePurityAndEffect(purAndEff0, uenv, taenv, ns0, root)
+      val tconstrsVal = traverse(tconstrs0)(resolveTypeConstraint(_, uenv, taenv, ns0, root))
 
       mapN(fparamsVal, annVal, tpeVal, purAndEffVal, tconstrsVal) {
         case (fparams, ann, tpe, purAndEff, tconstrs) =>
@@ -426,13 +438,13 @@ object Resolver {
   /**
     * Performs name resolution on the given enum `e0` in the given namespace `ns0`.
     */
-  def resolveEnum(e0: NamedAst.Declaration.Enum, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Enum, ResolutionError] = e0 match {
+  def resolveEnum(e0: NamedAst.Declaration.Enum, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Enum, ResolutionError] = e0 match {
     case NamedAst.Declaration.Enum(doc, ann0, mod, sym, tparams0, derives0, cases0, tpe0, loc) =>
-      val annVal = traverse(ann0)(visitAnnotation(_, taenv, ns0, root))
+      val annVal = traverse(ann0)(visitAnnotation(_, uenv, taenv, ns0, root))
       val tparams = resolveTypeParams(tparams0, ns0, root)
-      val derivesVal = resolveDerivations(derives0, ns0, root)
-      val casesVal = traverse(cases0.values)(resolveCase(_, taenv, ns0, root))
-      val tpeVal = resolveType(tpe0, taenv, ns0, root)
+      val derivesVal = resolveDerivations(derives0, uenv, ns0, root)
+      val casesVal = traverse(cases0.values)(resolveCase(_, uenv, taenv, ns0, root))
+      val tpeVal = resolveType(tpe0, uenv, taenv, ns0, root)
       mapN(annVal, derivesVal, casesVal, tpeVal) {
         case (ann, derives, cases, tpe) =>
           ResolvedAst.Enum(doc, ann, mod, sym, tparams, derives, cases, tpe, loc)
@@ -442,9 +454,9 @@ object Resolver {
   /**
     * Performs name resolution on the given case `caze0` in the given namespace `ns0`.
     */
-  private def resolveCase(caze0: NamedAst.Case, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Case, ResolutionError] = caze0 match {
-    case NamedAst.Case(sym, tpe0) =>
-      val tpeVal = resolveType(tpe0, taenv, ns0, root)
+  private def resolveCase(caze0: NamedAst.Declaration.Case, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Case, ResolutionError] = caze0 match {
+    case NamedAst.Declaration.Case(sym, tpe0) =>
+      val tpeVal = resolveType(tpe0, uenv, taenv, ns0, root)
       mapN(tpeVal) {
         tpe => ResolvedAst.Case(sym, tpe)
       }
@@ -453,10 +465,11 @@ object Resolver {
   /**
     * Performs name resolution on the given effect `eff0` in the given namespace `ns0`.
     */
-  private def resolveEffect(eff0: NamedAst.Declaration.Effect, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Effect, ResolutionError] = eff0 match {
+  private def resolveEffect(eff0: NamedAst.Declaration.Effect, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Effect, ResolutionError] = eff0 match {
     case NamedAst.Declaration.Effect(doc, ann0, mod, sym, ops0, loc) =>
-      val annVal = traverse(ann0)(visitAnnotation(_, taenv, ns0, root))
-      val opsVal = traverse(ops0)(resolveOp(_, taenv, ns0, root))
+      // TODO maybe start a new uenv
+      val annVal = traverse(ann0)(visitAnnotation(_, uenv, taenv, ns0, root))
+      val opsVal = traverse(ops0)(resolveOp(_, uenv, taenv, ns0, root))
       mapN(annVal, opsVal) {
         case (ann, ops) => ResolvedAst.Effect(doc, ann, mod, sym, ops, loc)
       }
@@ -465,9 +478,9 @@ object Resolver {
   /**
     * Performs name resolution on the given effect operation `op0` in the given namespace `ns0`.
     */
-  private def resolveOp(op0: NamedAst.Declaration.Op, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Op, ResolutionError] = op0 match {
+  private def resolveOp(op0: NamedAst.Declaration.Op, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Op, ResolutionError] = op0 match {
     case NamedAst.Declaration.Op(sym, spec0) =>
-      val specVal = resolveSpec(spec0, taenv, ns0, root)
+      val specVal = resolveSpec(spec0, uenv, taenv, ns0, root)
       mapN(specVal) {
         spec => ResolvedAst.Op(sym, spec)
       }
@@ -476,8 +489,8 @@ object Resolver {
   /**
     * Performs name resolution on the given annotation `a0` in the given namespace `ns0`.
     */
-  private def visitAnnotation(a0: NamedAst.Annotation, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Annotation, ResolutionError] = {
-    val argsVal = traverse(a0.args)(Expressions.resolve(_, taenv, ns0, root))
+  private def visitAnnotation(a0: NamedAst.Annotation, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Annotation, ResolutionError] = {
+    val argsVal = traverse(a0.args)(Expressions.resolve(_, uenv, taenv, ns0, root))
     mapN(argsVal) {
       args => ResolvedAst.Annotation(a0.name, args, a0.loc)
     }
@@ -488,7 +501,7 @@ object Resolver {
     /**
       * Performs name resolution on the given expression `exp0` in the namespace `ns0`.
       */
-    def resolve(exp0: NamedAst.Expression, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Expression, ResolutionError] = {
+    def resolve(exp0: NamedAst.Expression, uenv00: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Expression, ResolutionError] = {
 
       /**
         * Creates `arity` fresh fparams for use in a curried def or sig application.
@@ -556,10 +569,10 @@ object Resolver {
       /**
         * Resolve the application expression, performing currying over the subexpressions.
         */
-      def visitApply(exp: NamedAst.Expression.Apply, region: Option[Symbol.VarSym]): Validation[ResolvedAst.Expression, ResolutionError] = exp match {
+      def visitApply(exp: NamedAst.Expression.Apply, uenv0: ListMap[String, DeclarationOrJavaClass], region: Option[Symbol.VarSym]): Validation[ResolvedAst.Expression, ResolutionError] = exp match {
         case NamedAst.Expression.Apply(exp0, exps0, loc) =>
-          val expVal = visitExp(exp0, region)
-          val expsVal = traverse(exps0)(visitExp(_, region))
+          val expVal = visitExp(exp0, uenv0, region)
+          val expsVal = traverse(exps0)(visitExp(_, uenv0, region))
           mapN(expVal, expsVal) {
             case (e, es) =>
               es.foldLeft(e) {
@@ -571,10 +584,10 @@ object Resolver {
       /**
         * Resolve the application expression, applying `defn` to `exps`.
         */
-      def visitApplyDef(app: NamedAst.Expression.Apply, defn: NamedAst.Declaration.Def, exps: List[NamedAst.Expression], region: Option[Symbol.VarSym], innerLoc: SourceLocation, outerLoc: SourceLocation): Validation[ResolvedAst.Expression, ResolutionError] = {
+      def visitApplyDef(app: NamedAst.Expression.Apply, defn: NamedAst.Declaration.Def, exps: List[NamedAst.Expression], uenv0: ListMap[String, DeclarationOrJavaClass], region: Option[Symbol.VarSym], innerLoc: SourceLocation, outerLoc: SourceLocation): Validation[ResolvedAst.Expression, ResolutionError] = {
         if (defn.spec.fparams.length == exps.length) {
           // Case 1: Hooray! We can call the function directly.
-          val esVal = traverse(exps)(visitExp(_, region))
+          val esVal = traverse(exps)(visitExp(_, uenv0, region))
           mapN(esVal) {
             es =>
               val base = ResolvedAst.Expression.Def(defn.sym, innerLoc)
@@ -582,17 +595,17 @@ object Resolver {
           }
         } else {
           // Case 2: We have to curry. (See below).
-          visitApply(app, region)
+          visitApply(app, uenv0, region)
         }
       }
 
       /**
         * Resolve the application expression, applying `sig` to `exps`.
         */
-      def visitApplySig(app: NamedAst.Expression.Apply, sig: NamedAst.Declaration.Sig, exps: List[NamedAst.Expression], region: Option[Symbol.VarSym], innerLoc: SourceLocation, outerLoc: SourceLocation): Validation[ResolvedAst.Expression, ResolutionError] = {
+      def visitApplySig(app: NamedAst.Expression.Apply, sig: NamedAst.Declaration.Sig, exps: List[NamedAst.Expression], uenv0: ListMap[String, DeclarationOrJavaClass], region: Option[Symbol.VarSym], innerLoc: SourceLocation, outerLoc: SourceLocation): Validation[ResolvedAst.Expression, ResolutionError] = {
         if (sig.spec.fparams.length == exps.length) {
           // Case 1: Hooray! We can call the function directly.
-          val esVal = traverse(exps)(visitExp(_, region))
+          val esVal = traverse(exps)(visitExp(_, uenv0, region))
           mapN(esVal) {
             case es =>
               val base = ResolvedAst.Expression.Sig(sig.sym, innerLoc)
@@ -600,7 +613,7 @@ object Resolver {
           }
         } else {
           // Case 2: We have to curry. (See below).
-          visitApply(app, region)
+          visitApply(app, uenv0, region)
         }
       }
 
@@ -608,7 +621,7 @@ object Resolver {
       /**
         * Local visitor.
         */
-      def visitExp(e0: NamedAst.Expression, region: Option[Symbol.VarSym]): Validation[ResolvedAst.Expression, ResolutionError] = e0 match {
+      def visitExp(e0: NamedAst.Expression, uenv0: ListMap[String, DeclarationOrJavaClass], region: Option[Symbol.VarSym]): Validation[ResolvedAst.Expression, ResolutionError] = e0 match {
 
         case NamedAst.Expression.Wild(loc) =>
           ResolvedAst.Expression.Wild(loc).toSuccess
@@ -616,8 +629,14 @@ object Resolver {
         case NamedAst.Expression.Var(sym, loc) =>
           ResolvedAst.Expression.Var(sym, sym.tvar.withoutKind, loc).toSuccess
 
+        case NamedAst.Expression.UnqualifiedDefOrSig(ident, env, loc) =>
+          mapN(lookupDefOrSig(Name.mkQName(ident), uenv0, ns0, env, root)) {
+            case DefOrSig.Def(defn) => visitDef(defn, loc)
+            case DefOrSig.Sig(sig) => visitSig(sig, loc)
+          }
+
         case NamedAst.Expression.DefOrSig(qname, env, loc) =>
-          mapN(lookupDefOrSig(qname, ns0, env, root)) {
+          mapN(lookupDefOrSig(qname, uenv0, ns0, env, root)) {
             case DefOrSig.Def(defn) => visitDef(defn, loc)
             case DefOrSig.Sig(sig) => visitSig(sig, loc)
           }
@@ -630,43 +649,58 @@ object Resolver {
           ResolvedAst.Expression.Hole(sym, loc).toSuccess
 
         case NamedAst.Expression.HoleWithExp(exp, loc) =>
-          val eVal = visitExp(exp, region)
+          val eVal = visitExp(exp, uenv0, region)
           mapN(eVal) {
             case e => ResolvedAst.Expression.HoleWithExp(e, loc)
           }
 
         case NamedAst.Expression.Use(use, exp, loc) =>
-          // Lookup the used name to ensure that it exists.
+          // Lookup the used name and add it to the env
           use match {
-            case NamedAst.UseOrImport.UseDefOrSig(qname, _, _) =>
-              flatMapN(lookupDefOrSig(qname, ns0, Map.empty, root)) {
-                case DefOrSig.Def(defn) => mapN(visitExp(exp, region)) {
-                  case e => ResolvedAst.Expression.Use(defn.sym, e, loc)
-                }
-                case DefOrSig.Sig(sig) => mapN(visitExp(exp, region)) {
-                  case e => ResolvedAst.Expression.Use(sig.sym, e, loc)
-                }
+            // MATT we can simplify all these into lookupName and then add result to uenv
+            case NamedAst.UseOrImport.UseDefOrSig(qname, alias, _) =>
+              flatMapN(lookupDefOrSig(qname, uenv0, ns0, Map.empty, root)) {
+                case DefOrSig.Def(defn) =>
+                  val uenv = uenv0 + (alias.name -> DeclarationOrJavaClass.Declaration(defn))
+                  mapN(visitExp(exp, uenv, region)) {
+                    case e => ResolvedAst.Expression.Use(defn.sym, e, loc)
+                  }
+                case DefOrSig.Sig(sig) =>
+                  val uenv = uenv0 + (alias.name -> DeclarationOrJavaClass.Declaration(sig))
+                  mapN(visitExp(exp, uenv, region)) {
+                    case e => ResolvedAst.Expression.Use(sig.sym, e, loc)
+                  }
               }
 
-            case NamedAst.UseOrImport.UseTypeOrClass(qname, _, _) =>
-              lookupType(qname, ns0, root) match {
-                case TypeLookupResult.Enum(enum0) => mapN(visitExp(exp, region)) {
-                  case e => ResolvedAst.Expression.Use(enum0.sym, e, loc)
-                }
-                case TypeLookupResult.TypeAlias(typeAlias) => mapN(visitExp(exp, region)) {
-                  case e => ResolvedAst.Expression.Use(typeAlias.sym, e, loc)
-                }
-                case TypeLookupResult.Effect(eff) => mapN(visitExp(exp, region)) {
-                  case e => ResolvedAst.Expression.Use(eff.sym, e, loc)
-                }
+            case NamedAst.UseOrImport.UseTypeOrClass(qname, alias, _) =>
+              lookupType(qname, uenv0, ns0, root) match {
+                case TypeLookupResult.Enum(enum0) =>
+                  val uenv = uenv0 + (alias.name -> DeclarationOrJavaClass.Declaration(enum0))
+                  mapN(visitExp(exp, uenv, region)) {
+                    case e => ResolvedAst.Expression.Use(enum0.sym, e, loc)
+                  }
+                case TypeLookupResult.TypeAlias(typeAlias) =>
+                  val uenv = uenv0 + (alias.name -> DeclarationOrJavaClass.Declaration(typeAlias))
+                  mapN(visitExp(exp, uenv, region)) {
+                    case e => ResolvedAst.Expression.Use(typeAlias.sym, e, loc)
+                  }
+                case TypeLookupResult.Effect(eff) =>
+                  val uenv = uenv0 + (alias.name -> DeclarationOrJavaClass.Declaration(eff))
+                  mapN(visitExp(exp, uenv, region)) {
+                    case e => ResolvedAst.Expression.Use(eff.sym, e, loc)
+                  }
                 case TypeLookupResult.NotFound => ResolutionError.UndefinedType(qname, ns0, loc).toFailure
+                case TypeLookupResult.JavaClass(_) => throw InternalCompilerException("unexpected Java class")
               }
 
-            case NamedAst.UseOrImport.UseTag(qname, tag, _, _) =>
-              flatMapN(lookupEnumByTag(Some(qname), tag, ns0, root)) {
-                case enum0 => mapN(visitExp(exp, region)) {
-                  case e => ResolvedAst.Expression.Use(enum0.sym, e, loc)
-                }
+            case NamedAst.UseOrImport.UseTag(qname, tag, alias, _) =>
+              flatMapN(lookupEnumByTag(Some(qname), tag, uenv0, ns0, root)) {
+                case enum0 =>
+                  val caze = enum0.cases(tag.name)
+                  val uenv = uenv0 + (alias.name -> DeclarationOrJavaClass.Declaration(caze))
+                  mapN(visitExp(exp, uenv, region)) {
+                    case e => ResolvedAst.Expression.Use(caze.sym, e, loc)
+                  }
               }
 
             case NamedAst.UseOrImport.Import(_, _, loc) => throw InternalCompilerException("unexpected import", loc)
@@ -675,64 +709,64 @@ object Resolver {
         case NamedAst.Expression.Cst(cst, loc) => ResolvedAst.Expression.Cst(cst, loc).toSuccess
 
         case app@NamedAst.Expression.Apply(NamedAst.Expression.DefOrSig(qname, env, innerLoc), exps, outerLoc) =>
-          flatMapN(lookupDefOrSig(qname, ns0, env, root)) {
-            case DefOrSig.Def(defn) => visitApplyDef(app, defn, exps, region, innerLoc, outerLoc)
-            case DefOrSig.Sig(sig) => visitApplySig(app, sig, exps, region, innerLoc, outerLoc)
+          flatMapN(lookupDefOrSig(qname, uenv0, ns0, env, root)) {
+            case DefOrSig.Def(defn) => visitApplyDef(app, defn, exps, uenv0, region, innerLoc, outerLoc)
+            case DefOrSig.Sig(sig) => visitApplySig(app, sig, exps, uenv0, region, innerLoc, outerLoc)
           }
 
         case app@NamedAst.Expression.Apply(_, _, _) =>
-          visitApply(app, region)
+          visitApply(app, uenv0, region)
 
         case NamedAst.Expression.Lambda(fparam, exp, loc) =>
-          val pVal = Params.resolve(fparam, taenv, ns0, root)
-          val eVal = visitExp(exp, region)
+          val pVal = Params.resolve(fparam, uenv0, taenv, ns0, root)
+          val eVal = visitExp(exp, uenv0, region)
           mapN(pVal, eVal) {
             case (p, e) => ResolvedAst.Expression.Lambda(p, e, loc)
           }
 
         case NamedAst.Expression.Unary(sop, exp, loc) =>
-          val eVal = visitExp(exp, region)
+          val eVal = visitExp(exp, uenv0, region)
           mapN(eVal) {
             e => ResolvedAst.Expression.Unary(sop, e, loc)
           }
 
         case NamedAst.Expression.Binary(sop, exp1, exp2, loc) =>
-          val e1Val = visitExp(exp1, region)
-          val e2Val = visitExp(exp2, region)
+          val e1Val = visitExp(exp1, uenv0, region)
+          val e2Val = visitExp(exp2, uenv0, region)
           mapN(e1Val, e2Val) {
             case (e1, e2) => ResolvedAst.Expression.Binary(sop, e1, e2, loc)
           }
 
         case NamedAst.Expression.IfThenElse(exp1, exp2, exp3, loc) =>
-          val e1Val = visitExp(exp1, region)
-          val e2Val = visitExp(exp2, region)
-          val e3Val = visitExp(exp3, region)
+          val e1Val = visitExp(exp1, uenv0, region)
+          val e2Val = visitExp(exp2, uenv0, region)
+          val e3Val = visitExp(exp3, uenv0, region)
           mapN(e1Val, e2Val, e3Val) {
             case (e1, e2, e3) => ResolvedAst.Expression.IfThenElse(e1, e2, e3, loc)
           }
 
         case NamedAst.Expression.Stm(exp1, exp2, loc) =>
-          val e1Val = visitExp(exp1, region)
-          val e2Val = visitExp(exp2, region)
+          val e1Val = visitExp(exp1, uenv0, region)
+          val e2Val = visitExp(exp2, uenv0, region)
           mapN(e1Val, e2Val) {
             case (e1, e2) => ResolvedAst.Expression.Stm(e1, e2, loc)
           }
 
         case NamedAst.Expression.Discard(exp, loc) =>
-          visitExp(exp, region) map {
+          visitExp(exp, uenv0, region) map {
             case e => ResolvedAst.Expression.Discard(e, loc)
           }
 
         case NamedAst.Expression.Let(sym, mod, exp1, exp2, loc) =>
-          val e1Val = visitExp(exp1, region)
-          val e2Val = visitExp(exp2, region)
+          val e1Val = visitExp(exp1, uenv0, region)
+          val e2Val = visitExp(exp2, uenv0, region)
           mapN(e1Val, e2Val) {
             case (e1, e2) => ResolvedAst.Expression.Let(sym, mod, e1, e2, loc)
           }
 
         case NamedAst.Expression.LetRec(sym, mod, exp1, exp2, loc) =>
-          val e1Val = visitExp(exp1, region)
-          val e2Val = visitExp(exp2, region)
+          val e1Val = visitExp(exp1, uenv0, region)
+          val e2Val = visitExp(exp2, uenv0, region)
           mapN(e1Val, e2Val) {
             case (e1, e2) => ResolvedAst.Expression.LetRec(sym, mod, e1, e2, loc)
           }
@@ -741,7 +775,7 @@ object Resolver {
           ResolvedAst.Expression.Region(tpe, loc).toSuccess
 
         case NamedAst.Expression.Scope(sym, regionVar, exp, loc) =>
-          val eVal = visitExp(exp, Some(sym))
+          val eVal = visitExp(exp, uenv0, Some(sym))
           mapN(eVal) {
             e => ResolvedAst.Expression.Scope(sym, regionVar, e, loc)
           }
@@ -749,15 +783,15 @@ object Resolver {
         case NamedAst.Expression.Match(exp, rules, loc) =>
           val rulesVal = traverse(rules) {
             case NamedAst.MatchRule(pat, guard, body) =>
-              val pVal = Patterns.resolve(pat, ns0, root)
-              val gVal = traverseOpt(guard)(visitExp(_, region))
-              val bVal = visitExp(body, region)
+              val pVal = Patterns.resolve(pat, uenv0, ns0, root)
+              val gVal = traverseOpt(guard)(visitExp(_, uenv0, region))
+              val bVal = visitExp(body, uenv0, region)
               mapN(pVal, gVal, bVal) {
                 case (p, g, b) => ResolvedAst.MatchRule(p, g, b)
               }
           }
 
-          val eVal = visitExp(exp, region)
+          val eVal = visitExp(exp, uenv0, region)
           val rsVal = rulesVal
           mapN(eVal, rsVal) {
             case (e, rs) => ResolvedAst.Expression.Match(e, rs, loc)
@@ -766,21 +800,21 @@ object Resolver {
         case NamedAst.Expression.TypeMatch(exp, rules, loc) =>
           val rulesVal = traverse(rules) {
             case NamedAst.MatchTypeRule(sym, tpe, body) =>
-              val tVal = resolveType(tpe, taenv, ns0, root)
-              val bVal = visitExp(body, region)
+              val tVal = resolveType(tpe, uenv0, taenv, ns0, root)
+              val bVal = visitExp(body, uenv0, region)
               mapN(tVal, bVal) {
                 case (t, b) => ResolvedAst.MatchTypeRule(sym, t, b)
               }
           }
 
-          val eVal = visitExp(exp, region)
+          val eVal = visitExp(exp, uenv0, region)
           val rsVal = rulesVal
           mapN(eVal, rsVal) {
             case (e, rs) => ResolvedAst.Expression.TypeMatch(e, rs, loc)
           }
 
         case NamedAst.Expression.Choose(star, exps, rules, loc) =>
-          val expsVal = traverse(exps)(visitExp(_, region))
+          val expsVal = traverse(exps)(visitExp(_, uenv0, region))
           val rulesVal = traverse(rules) {
             case NamedAst.ChoiceRule(pat0, exp0) =>
               val p = pat0.map {
@@ -788,7 +822,7 @@ object Resolver {
                 case NamedAst.ChoicePattern.Absent(loc) => ResolvedAst.ChoicePattern.Absent(loc)
                 case NamedAst.ChoicePattern.Present(sym, loc) => ResolvedAst.ChoicePattern.Present(sym, loc)
               }
-              mapN(visitExp(exp0, region)) {
+              mapN(visitExp(exp0, uenv0, region)) {
                 case e => ResolvedAst.ChoiceRule(p, e)
               }
           }
@@ -798,11 +832,11 @@ object Resolver {
 
         case NamedAst.Expression.Tag(enum, tag, expOpt, loc) => expOpt match {
           case None =>
-            // Case 1: The tag has does not have an expression.
+            // Case 1: The tag does not have an expression.
             // Either it is implicitly Unit or the tag is used as a function.
 
             // Lookup the enum to determine the type of the tag.
-            lookupEnumByTag(enum, tag, ns0, root) map {
+            lookupEnumByTag(enum, tag, uenv0, ns0, root) map {
               case decl =>
                 // Retrieve the relevant case.
                 val caze = decl.cases(tag.name)
@@ -834,8 +868,8 @@ object Resolver {
             }
           case Some(exp) =>
             // Case 2: The tag has an expression. Perform resolution on it.
-            val dVal = lookupEnumByTag(enum, tag, ns0, root)
-            val eVal = visitExp(exp, region)
+            val dVal = lookupEnumByTag(enum, tag, uenv0, ns0, root)
+            val eVal = visitExp(exp, uenv0, region)
             mapN(dVal, eVal) {
               case (d, e) =>
                 // Retrieve the relevant case.
@@ -846,7 +880,7 @@ object Resolver {
         }
 
         case NamedAst.Expression.Tuple(elms, loc) =>
-          val esVal = traverse(elms)(e => visitExp(e, region))
+          val esVal = traverse(elms)(e => visitExp(e, uenv0, region))
           mapN(esVal) {
             es => ResolvedAst.Expression.Tuple(es, loc)
           }
@@ -855,26 +889,26 @@ object Resolver {
           ResolvedAst.Expression.RecordEmpty(loc).toSuccess
 
         case NamedAst.Expression.RecordSelect(base, field, loc) =>
-          val bVal = visitExp(base, region)
+          val bVal = visitExp(base, uenv0, region)
           mapN(bVal) {
             b => ResolvedAst.Expression.RecordSelect(b, field, loc)
           }
 
         case NamedAst.Expression.RecordExtend(field, value, rest, loc) =>
-          val vVal = visitExp(value, region)
-          val rVal = visitExp(rest, region)
+          val vVal = visitExp(value, uenv0, region)
+          val rVal = visitExp(rest, uenv0, region)
           mapN(vVal, rVal) {
             case (v, r) => ResolvedAst.Expression.RecordExtend(field, v, r, loc)
           }
 
         case NamedAst.Expression.RecordRestrict(field, rest, loc) =>
-          val rVal = visitExp(rest, region)
+          val rVal = visitExp(rest, uenv0, region)
           mapN(rVal) {
             r => ResolvedAst.Expression.RecordRestrict(field, r, loc)
           }
 
         case NamedAst.Expression.New(qname, exp, loc) =>
-          val erVal = traverseOpt(exp)(visitExp(_, region))
+          val erVal = traverseOpt(exp)(visitExp(_, uenv0, region))
           mapN(erVal) {
             er =>
               ///
@@ -891,8 +925,8 @@ object Resolver {
           }
 
         case NamedAst.Expression.ArrayLit(exps, exp, loc) =>
-          val esVal = traverse(exps)(visitExp(_, region))
-          val erVal = traverseOpt(exp)(visitExp(_, region))
+          val esVal = traverse(exps)(visitExp(_, uenv0, region))
+          val erVal = traverseOpt(exp)(visitExp(_, uenv0, region))
           mapN(esVal, erVal) {
             case (es, er) =>
               val reg = getExplicitOrImplicitRegion(er, region, loc)
@@ -900,9 +934,9 @@ object Resolver {
           }
 
         case NamedAst.Expression.ArrayNew(exp1, exp2, exp3, loc) =>
-          val e1Val = visitExp(exp1, region)
-          val e2Val = visitExp(exp2, region)
-          val erVal = traverseOpt(exp3)(visitExp(_, region))
+          val e1Val = visitExp(exp1, uenv0, region)
+          val e2Val = visitExp(exp2, uenv0, region)
+          val erVal = traverseOpt(exp3)(visitExp(_, uenv0, region))
           mapN(e1Val, e2Val, erVal) {
             case (e1, e2, er) =>
               val reg = getExplicitOrImplicitRegion(er, region, loc)
@@ -910,37 +944,37 @@ object Resolver {
           }
 
         case NamedAst.Expression.ArrayLoad(base, index, loc) =>
-          val bVal = visitExp(base, region)
-          val iVal = visitExp(index, region)
+          val bVal = visitExp(base, uenv0, region)
+          val iVal = visitExp(index, uenv0, region)
           mapN(bVal, iVal) {
             case (b, i) => ResolvedAst.Expression.ArrayLoad(b, i, loc)
           }
 
         case NamedAst.Expression.ArrayStore(base, index, elm, loc) =>
-          val bVal = visitExp(base, region)
-          val iVal = visitExp(index, region)
-          val eVal = visitExp(elm, region)
+          val bVal = visitExp(base, uenv0, region)
+          val iVal = visitExp(index, uenv0, region)
+          val eVal = visitExp(elm, uenv0, region)
           mapN(bVal, iVal, eVal) {
             case (b, i, e) => ResolvedAst.Expression.ArrayStore(b, i, e, loc)
           }
 
         case NamedAst.Expression.ArrayLength(base, loc) =>
-          val bVal = visitExp(base, region)
+          val bVal = visitExp(base, uenv0, region)
           mapN(bVal) {
             b => ResolvedAst.Expression.ArrayLength(b, loc)
           }
 
         case NamedAst.Expression.ArraySlice(base, startIndex, endIndex, loc) =>
-          val bVal = visitExp(base, region)
-          val i1Val = visitExp(startIndex, region)
-          val i2Val = visitExp(endIndex, region)
+          val bVal = visitExp(base, uenv0, region)
+          val i1Val = visitExp(startIndex, uenv0, region)
+          val i2Val = visitExp(endIndex, uenv0, region)
           mapN(bVal, i1Val, i2Val) {
             case (b, i1, i2) => ResolvedAst.Expression.ArraySlice(b, i1, i2, loc)
           }
 
         case NamedAst.Expression.Ref(exp1, exp2, loc) =>
-          val e1Val = visitExp(exp1, region)
-          val e2Val = traverseOpt(exp2)(visitExp(_, region))
+          val e1Val = visitExp(exp1, uenv0, region)
+          val e2Val = traverseOpt(exp2)(visitExp(_, uenv0, region))
           mapN(e1Val, e2Val) {
             case (e1, e2) =>
               val reg = getExplicitOrImplicitRegion(e2, region, loc)
@@ -948,14 +982,14 @@ object Resolver {
           }
 
         case NamedAst.Expression.Deref(exp, loc) =>
-          val eVal = visitExp(exp, region)
+          val eVal = visitExp(exp, uenv0, region)
           mapN(eVal) {
             e => ResolvedAst.Expression.Deref(e, loc)
           }
 
         case NamedAst.Expression.Assign(exp1, exp2, loc) =>
-          val e1Val = visitExp(exp1, region)
-          val e2Val = visitExp(exp2, region)
+          val e1Val = visitExp(exp1, uenv0, region)
+          val e2Val = visitExp(exp2, uenv0, region)
           mapN(e1Val, e2Val) {
             case (e1, e2) => ResolvedAst.Expression.Assign(e1, e2, loc)
           }
@@ -963,11 +997,11 @@ object Resolver {
         case NamedAst.Expression.Ascribe(exp, expectedType, expectedEff, loc) =>
           val expectedTypVal = expectedType match {
             case None => (None: Option[UnkindedType]).toSuccess
-            case Some(t) => mapN(resolveType(t, taenv, ns0, root))(x => Some(x))
+            case Some(t) => mapN(resolveType(t, uenv0, taenv, ns0, root))(x => Some(x))
           }
-          val expectedEffVal = resolvePurityAndEffect(expectedEff, taenv, ns0, root)
+          val expectedEffVal = resolvePurityAndEffect(expectedEff, uenv0, taenv, ns0, root)
 
-          val eVal = visitExp(exp, region)
+          val eVal = visitExp(exp, uenv0, region)
           mapN(eVal, expectedTypVal, expectedEffVal) {
             case (e, t, f) => ResolvedAst.Expression.Ascribe(e, t, f, loc)
           }
@@ -975,28 +1009,28 @@ object Resolver {
         case NamedAst.Expression.Cast(exp, declaredType, declaredEff, loc) =>
           val declaredTypVal = declaredType match {
             case None => (None: Option[UnkindedType]).toSuccess
-            case Some(t) => mapN(resolveType(t, taenv, ns0, root))(x => Some(x))
+            case Some(t) => mapN(resolveType(t, uenv0, taenv, ns0, root))(x => Some(x))
           }
-          val declaredEffVal = resolvePurityAndEffect(declaredEff, taenv, ns0, root)
+          val declaredEffVal = resolvePurityAndEffect(declaredEff, uenv0, taenv, ns0, root)
 
-          val eVal = visitExp(exp, region)
+          val eVal = visitExp(exp, uenv0, region)
           mapN(eVal, declaredTypVal, declaredEffVal) {
             case (e, t, f) => ResolvedAst.Expression.Cast(e, t, f, loc)
           }
 
         case NamedAst.Expression.Mask(exp, loc) =>
-          val eVal = visitExp(exp, region)
+          val eVal = visitExp(exp, uenv0, region)
           mapN(eVal) {
             case e => ResolvedAst.Expression.Mask(e, loc)
           }
 
         case NamedAst.Expression.Upcast(exp, loc) =>
-          mapN(visitExp(exp, region)) {
+          mapN(visitExp(exp, uenv0, region)) {
             case e => ResolvedAst.Expression.Upcast(e, loc)
           }
 
         case NamedAst.Expression.Supercast(exp, loc) =>
-          mapN(visitExp(exp, region)) {
+          mapN(visitExp(exp, uenv0, region)) {
             case e => ResolvedAst.Expression.Supercast(e, loc)
           }
 
@@ -1004,20 +1038,20 @@ object Resolver {
           val rulesVal = traverse(rules) {
             case NamedAst.CatchRule(sym, className, body) =>
               val clazzVal = lookupJvmClass(className, sym.loc)
-              val bVal = visitExp(body, region)
+              val bVal = visitExp(body, uenv0, region)
               mapN(clazzVal, bVal) {
                 case (clazz, b) => ResolvedAst.CatchRule(sym, clazz, b)
               }
           }
 
-          val eVal = visitExp(exp, region)
+          val eVal = visitExp(exp, uenv0, region)
           mapN(eVal, rulesVal) {
             case (e, rs) => ResolvedAst.Expression.TryCatch(e, rs, loc)
           }
 
         case NamedAst.Expression.Without(exp, eff, loc) =>
-          val eVal = visitExp(exp, region)
-          val fVal = lookupEffect(eff, ns0, root)
+          val eVal = visitExp(exp, uenv0, region)
+          val fVal = lookupEffect(eff, uenv0, ns0, root)
           mapN(eVal, fVal) {
             case (e, f) =>
               val effUse = Ast.EffectSymUse(f.sym, eff.loc)
@@ -1025,16 +1059,16 @@ object Resolver {
           }
 
         case NamedAst.Expression.TryWith(exp, eff, rules, loc) =>
-          val eVal = visitExp(exp, region)
-          val fVal = lookupEffect(eff, ns0, root)
+          val eVal = visitExp(exp, uenv0, region)
+          val fVal = lookupEffect(eff, uenv0, ns0, root)
           flatMapN(eVal, fVal) {
             case (e, f) =>
               val effUse = Ast.EffectSymUse(f.sym, eff.loc)
               val rulesVal = traverse(rules) {
                 case NamedAst.HandlerRule(ident, fparams, body) =>
                   val opVal = findOpInEffect(ident, f)
-                  val fparamsVal = resolveFormalParams(fparams, taenv, ns0, root)
-                  val bodyVal = visitExp(body, region)
+                  val fparamsVal = resolveFormalParams(fparams, uenv0, taenv, ns0, root)
+                  val bodyVal = visitExp(body, uenv0, region)
                   mapN(opVal, fparamsVal, bodyVal) {
                     case (o, fp, b) =>
                       val opUse = Ast.OpSymUse(o.sym, ident.loc)
@@ -1047,8 +1081,8 @@ object Resolver {
           }
 
         case NamedAst.Expression.Do(op, exps, loc) =>
-          val opVal = lookupOp(op, ns0, root)
-          val expsVal = traverse(exps)(visitExp(_, region))
+          val opVal = lookupOp(op, uenv0, ns0, root)
+          val expsVal = traverse(exps)(visitExp(_, uenv0, region))
           mapN(opVal, expsVal) {
             case (o, es) =>
               val opUse = Ast.OpSymUse(o.sym, op.loc)
@@ -1056,14 +1090,14 @@ object Resolver {
           }
 
         case NamedAst.Expression.Resume(exp, loc) =>
-          val expVal = visitExp(exp, region)
+          val expVal = visitExp(exp, uenv0, region)
           mapN(expVal) {
             e => ResolvedAst.Expression.Resume(e, loc)
           }
 
         case NamedAst.Expression.InvokeConstructor(className, args, sig, loc) =>
-          val argsVal = traverse(args)(visitExp(_, region))
-          val sigVal = traverse(sig)(resolveType(_, taenv, ns0, root))
+          val argsVal = traverse(args)(visitExp(_, uenv0, region))
+          val sigVal = traverse(sig)(resolveType(_, uenv0, taenv, ns0, root))
           flatMapN(sigVal, argsVal) {
             case (ts, as) =>
               mapN(lookupJvmConstructor(className, ts, loc)) {
@@ -1072,10 +1106,10 @@ object Resolver {
           }
 
         case NamedAst.Expression.InvokeMethod(className, methodName, exp, args, sig, retTpe, loc) =>
-          val expVal = visitExp(exp, region)
-          val argsVal = traverse(args)(visitExp(_, region))
-          val sigVal = traverse(sig)(resolveType(_, taenv, ns0, root))
-          val retVal = resolveType(retTpe, taenv, ns0, root)
+          val expVal = visitExp(exp, uenv0, region)
+          val argsVal = traverse(args)(visitExp(_, uenv0, region))
+          val sigVal = traverse(sig)(resolveType(_, uenv0, taenv, ns0, root))
+          val retVal = resolveType(retTpe, uenv0, taenv, ns0, root)
           val clazzVal = lookupJvmClass(className, loc)
           flatMapN(sigVal, expVal, argsVal, retVal, clazzVal) {
             case (ts, e, as, ret, clazz) =>
@@ -1085,9 +1119,9 @@ object Resolver {
           }
 
         case NamedAst.Expression.InvokeStaticMethod(className, methodName, args, sig, retTpe, loc) =>
-          val argsVal = traverse(args)(visitExp(_, region))
-          val sigVal = traverse(sig)(resolveType(_, taenv, ns0, root))
-          val retVal = resolveType(retTpe, taenv, ns0, root)
+          val argsVal = traverse(args)(visitExp(_, uenv0, region))
+          val sigVal = traverse(sig)(resolveType(_, uenv0, taenv, ns0, root))
+          val retVal = resolveType(retTpe, uenv0, taenv, ns0, root)
           val clazzVal = lookupJvmClass(className, loc)
           flatMapN(sigVal, argsVal, retVal, clazzVal) {
             case (ts, as, ret, clazz) =>
@@ -1099,7 +1133,7 @@ object Resolver {
         case NamedAst.Expression.GetField(className, fieldName, exp, loc) =>
           flatMapN(lookupJvmClass(className, loc)) {
             case clazz =>
-              mapN(lookupJvmField(clazz, fieldName, static = false, loc), visitExp(exp, region)) {
+              mapN(lookupJvmField(clazz, fieldName, static = false, loc), visitExp(exp, uenv0, region)) {
                 case (field, e) => ResolvedAst.Expression.GetField(field, clazz, e, loc)
               }
           }
@@ -1107,7 +1141,7 @@ object Resolver {
         case NamedAst.Expression.PutField(className, fieldName, exp1, exp2, loc) =>
           flatMapN(lookupJvmClass(className, loc)) {
             case clazz =>
-              mapN(lookupJvmField(clazz, fieldName, static = false, loc), visitExp(exp1, region), visitExp(exp2, region)) {
+              mapN(lookupJvmField(clazz, fieldName, static = false, loc), visitExp(exp1, uenv0, region), visitExp(exp2, uenv0, region)) {
                 case (field, e1, e2) => ResolvedAst.Expression.PutField(field, clazz, e1, e2, loc)
               }
           }
@@ -1123,13 +1157,13 @@ object Resolver {
         case NamedAst.Expression.PutStaticField(className, fieldName, exp, loc) =>
           flatMapN(lookupJvmClass(className, loc)) {
             case clazz =>
-              mapN(lookupJvmField(clazz, fieldName, static = true, loc), visitExp(exp, region)) {
+              mapN(lookupJvmField(clazz, fieldName, static = true, loc), visitExp(exp, uenv0, region)) {
                 case (field, e) => ResolvedAst.Expression.PutStaticField(field, e, loc)
               }
           }
 
         case NamedAst.Expression.NewObject(name, tpe, methods, loc) =>
-          flatMapN(resolveType(tpe, taenv, ns0, root), traverse(methods)(visitJvmMethod(_, taenv, ns0, root))) {
+          flatMapN(resolveType(tpe, uenv0, taenv, ns0, root), traverse(methods)(visitJvmMethod(_, uenv0, taenv, ns0, root))) {
             case (t, ms) =>
               //
               // Check that the type is a JVM type (after type alias erasure).
@@ -1142,21 +1176,21 @@ object Resolver {
           }
 
         case NamedAst.Expression.NewChannel(exp1, exp2, loc) =>
-          val e1Val = visitExp(exp1, region)
-          val e2Val = visitExp(exp2, region)
+          val e1Val = visitExp(exp1, uenv0, region)
+          val e2Val = visitExp(exp2, uenv0, region)
           mapN(e1Val, e2Val) {
             case (e1, e2) => ResolvedAst.Expression.NewChannel(e1, e2, loc)
           }
 
         case NamedAst.Expression.GetChannel(exp, loc) =>
-          val eVal = visitExp(exp, region)
+          val eVal = visitExp(exp, uenv0, region)
           mapN(eVal) {
             e => ResolvedAst.Expression.GetChannel(e, loc)
           }
 
         case NamedAst.Expression.PutChannel(exp1, exp2, loc) =>
-          val e1Val = visitExp(exp1, region)
-          val e2Val = visitExp(exp2, region)
+          val e1Val = visitExp(exp1, uenv0, region)
+          val e2Val = visitExp(exp2, uenv0, region)
           mapN(e1Val, e2Val) {
             case (e1, e2) => ResolvedAst.Expression.PutChannel(e1, e2, loc)
           }
@@ -1164,8 +1198,8 @@ object Resolver {
         case NamedAst.Expression.SelectChannel(rules, default, loc) =>
           val rulesVal = traverse(rules) {
             case NamedAst.SelectChannelRule(sym, chan, body) =>
-              val cVal = visitExp(chan, region)
-              val bVal = visitExp(body, region)
+              val cVal = visitExp(chan, uenv0, region)
+              val bVal = visitExp(body, uenv0, region)
               mapN(cVal, bVal) {
                 case (c, b) => ResolvedAst.SelectChannelRule(sym, c, b)
               }
@@ -1173,7 +1207,7 @@ object Resolver {
 
           val defaultVal = default match {
             case Some(exp) =>
-              val eVal = visitExp(exp, region)
+              val eVal = visitExp(exp, uenv0, region)
               mapN(eVal) {
                 e => Some(e)
               }
@@ -1185,8 +1219,8 @@ object Resolver {
           }
 
         case NamedAst.Expression.Spawn(exp1, exp2, loc) =>
-          val e1Val = visitExp(exp1, region)
-          val e2Val = visitExp(exp2, region)
+          val e1Val = visitExp(exp1, uenv0, region)
+          val e2Val = visitExp(exp2, uenv0, region)
           mapN(e1Val, e2Val) {
             case (e1, e2) =>
               val reg = getExplicitOrImplicitRegion(Some(e2), region, loc)
@@ -1194,77 +1228,77 @@ object Resolver {
           }
 
         case NamedAst.Expression.Par(exp, loc) =>
-          mapN(visitExp(exp, region)) {
+          mapN(visitExp(exp, uenv0, region)) {
             e => ResolvedAst.Expression.Par(e, loc)
           }
 
         case NamedAst.Expression.ParYield(frags, exp, loc) =>
           val fragsVal = traverse(frags) {
             case NamedAst.ParYieldFragment(pat, e0, l0) =>
-              val pVal = Patterns.resolve(pat, ns0, root)
-              val e0Val = visitExp(e0, region)
+              val pVal = Patterns.resolve(pat, uenv0, ns0, root)
+              val e0Val = visitExp(e0, uenv0, region)
               mapN(pVal, e0Val) {
                 case (p, e1) => ResolvedAst.ParYieldFragment(p, e1, l0)
               }
           }
 
-          mapN(fragsVal, visitExp(exp, region)) {
+          mapN(fragsVal, visitExp(exp, uenv0, region)) {
             case (fs, e) => ResolvedAst.Expression.ParYield(fs, e, loc)
           }
 
         case NamedAst.Expression.Lazy(exp, loc) =>
-          val eVal = visitExp(exp, region)
+          val eVal = visitExp(exp, uenv0, region)
           mapN(eVal) {
             e => ResolvedAst.Expression.Lazy(e, loc)
           }
 
         case NamedAst.Expression.Force(exp, loc) =>
-          val eVal = visitExp(exp, region)
+          val eVal = visitExp(exp, uenv0, region)
           mapN(eVal) {
             e => ResolvedAst.Expression.Force(e, loc)
           }
 
         case NamedAst.Expression.FixpointConstraintSet(cs0, loc) =>
-          val csVal = traverse(cs0)(Constraints.resolve(_, taenv, ns0, root))
+          val csVal = traverse(cs0)(Constraints.resolve(_, uenv0, taenv, ns0, root))
           mapN(csVal) {
             cs => ResolvedAst.Expression.FixpointConstraintSet(cs, loc)
           }
 
         case NamedAst.Expression.FixpointLambda(pparams, exp, loc) =>
-          val psVal = traverse(pparams)(Params.resolve(_, taenv, ns0, root))
-          val eVal = visitExp(exp, region)
+          val psVal = traverse(pparams)(Params.resolve(_, uenv0, taenv, ns0, root))
+          val eVal = visitExp(exp, uenv0, region)
           mapN(psVal, eVal) {
             case (ps, e) => ResolvedAst.Expression.FixpointLambda(ps, e, loc)
           }
 
         case NamedAst.Expression.FixpointMerge(exp1, exp2, loc) =>
-          val e1Val = visitExp(exp1, region)
-          val e2Val = visitExp(exp2, region)
+          val e1Val = visitExp(exp1, uenv0, region)
+          val e2Val = visitExp(exp2, uenv0, region)
           mapN(e1Val, e2Val) {
             case (e1, e2) => ResolvedAst.Expression.FixpointMerge(e1, e2, loc)
           }
 
         case NamedAst.Expression.FixpointSolve(exp, loc) =>
-          val eVal = visitExp(exp, region)
+          val eVal = visitExp(exp, uenv0, region)
           mapN(eVal) {
             e => ResolvedAst.Expression.FixpointSolve(e, loc)
           }
 
         case NamedAst.Expression.FixpointFilter(pred, exp, loc) =>
-          val eVal = visitExp(exp, region)
+          val eVal = visitExp(exp, uenv0, region)
           mapN(eVal) {
             e => ResolvedAst.Expression.FixpointFilter(pred, e, loc)
           }
 
         case NamedAst.Expression.FixpointInject(exp, pred, loc) =>
-          val eVal = visitExp(exp, region)
+          val eVal = visitExp(exp, uenv0, region)
           mapN(eVal) {
             e => ResolvedAst.Expression.FixpointInject(e, pred, loc)
           }
 
         case NamedAst.Expression.FixpointProject(pred, exp1, exp2, loc) =>
-          val e1Val = visitExp(exp1, region)
-          val e2Val = visitExp(exp2, region)
+          val e1Val = visitExp(exp1, uenv0, region)
+          val e2Val = visitExp(exp2, uenv0, region)
           mapN(e1Val, e2Val) {
             case (e1, e2) => ResolvedAst.Expression.FixpointProject(pred, e1, e2, loc)
           }
@@ -1273,18 +1307,18 @@ object Resolver {
       /**
         * Performs name resolution on the given JvmMethod `method` in the namespace `ns0`.
         */
-      def visitJvmMethod(method: NamedAst.JvmMethod, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.JvmMethod, ResolutionError] = method match {
+      def visitJvmMethod(method: NamedAst.JvmMethod, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.JvmMethod, ResolutionError] = method match {
         case NamedAst.JvmMethod(ident, fparams, exp, tpe, purAndEff, loc) =>
-          val fparamsVal = resolveFormalParams(fparams, taenv, ns0, root)
-          val expVal = visitExp(exp, None)
-          val tpeVal = resolveType(tpe, taenv, ns0, root)
-          val purAndEffVal = resolvePurityAndEffect(purAndEff, taenv, ns0, root)
+          val fparamsVal = resolveFormalParams(fparams, uenv, taenv, ns0, root)
+          val expVal = visitExp(exp, uenv, None)
+          val tpeVal = resolveType(tpe, uenv, taenv, ns0, root)
+          val purAndEffVal = resolvePurityAndEffect(purAndEff, uenv, taenv, ns0, root)
           mapN(fparamsVal, expVal, tpeVal, purAndEffVal) {
             case (f, e, t, p) => ResolvedAst.JvmMethod(ident, f, e, t, p, loc)
           }
       }
 
-      visitExp(exp0, None)
+      visitExp(exp0, uenv00, None)
     }
 
   }
@@ -1294,7 +1328,7 @@ object Resolver {
     /**
       * Performs name resolution on the given pattern `pat0` in the namespace `ns0`.
       */
-    def resolve(pat0: NamedAst.Pattern, ns0: Name.NName, root: NamedAst.Root): Validation[ResolvedAst.Pattern, ResolutionError] = {
+    def resolve(pat0: NamedAst.Pattern, uenv: ListMap[String, DeclarationOrJavaClass], ns0: Name.NName, root: NamedAst.Root): Validation[ResolvedAst.Pattern, ResolutionError] = {
 
       def visit(p0: NamedAst.Pattern): Validation[ResolvedAst.Pattern, ResolutionError] = p0 match {
         case NamedAst.Pattern.Wild(loc) => ResolvedAst.Pattern.Wild(loc).toSuccess
@@ -1304,7 +1338,7 @@ object Resolver {
         case NamedAst.Pattern.Cst(cst, loc) => ResolvedAst.Pattern.Cst(cst, loc).toSuccess
 
         case NamedAst.Pattern.Tag(enum, tag, pat, loc) =>
-          val dVal = lookupEnumByTag(enum, tag, ns0, root)
+          val dVal = lookupEnumByTag(enum, tag, uenv, ns0, root)
           val pVal = visit(pat)
           mapN(dVal, pVal) {
             case (d, p) =>
@@ -1348,9 +1382,9 @@ object Resolver {
       /**
         * Performs name resolution on the given head predicate `h0` in the given namespace `ns0`.
         */
-      def resolve(h0: NamedAst.Predicate.Head, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Predicate.Head, ResolutionError] = h0 match {
+      def resolve(h0: NamedAst.Predicate.Head, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Predicate.Head, ResolutionError] = h0 match {
         case NamedAst.Predicate.Head.Atom(pred, den, terms, loc) =>
-          val tsVal = traverse(terms)(t => Expressions.resolve(t, taenv, ns0, root))
+          val tsVal = traverse(terms)(t => Expressions.resolve(t, uenv, taenv, ns0, root))
           mapN(tsVal) {
             ts => ResolvedAst.Predicate.Head.Atom(pred, den, ts, loc)
           }
@@ -1361,21 +1395,21 @@ object Resolver {
       /**
         * Performs name resolution on the given body predicate `b0` in the given namespace `ns0`.
         */
-      def resolve(b0: NamedAst.Predicate.Body, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Predicate.Body, ResolutionError] = b0 match {
+      def resolve(b0: NamedAst.Predicate.Body, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Predicate.Body, ResolutionError] = b0 match {
         case NamedAst.Predicate.Body.Atom(pred, den, polarity, fixity, terms, loc) =>
-          val tsVal = traverse(terms)(t => Patterns.resolve(t, ns0, root))
+          val tsVal = traverse(terms)(t => Patterns.resolve(t, uenv, ns0, root))
           mapN(tsVal) {
             ts => ResolvedAst.Predicate.Body.Atom(pred, den, polarity, fixity, ts, loc)
           }
 
         case NamedAst.Predicate.Body.Guard(exp, loc) =>
-          val eVal = Expressions.resolve(exp, taenv, ns0, root)
+          val eVal = Expressions.resolve(exp, uenv, taenv, ns0, root)
           mapN(eVal) {
             e => ResolvedAst.Predicate.Body.Guard(e, loc)
           }
 
         case NamedAst.Predicate.Body.Loop(varSyms, exp, loc) =>
-          val eVal = Expressions.resolve(exp, taenv, ns0, root)
+          val eVal = Expressions.resolve(exp, uenv, taenv, ns0, root)
           mapN(eVal) {
             e => ResolvedAst.Predicate.Body.Loop(varSyms, e, loc)
           }
@@ -1389,14 +1423,14 @@ object Resolver {
     /**
       * Performs name resolution on the given constraint parameter `cparam0` in the given namespace `ns0`.
       */
-    def resolve(cparam0: NamedAst.ConstraintParam, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.ConstraintParam, ResolutionError] = cparam0 match {
+    def resolve(cparam0: NamedAst.ConstraintParam, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.ConstraintParam, ResolutionError] = cparam0 match {
       case NamedAst.ConstraintParam.HeadParam(sym, tpe0, loc) =>
-        val tpeVal = resolveType(tpe0, taenv, ns0, root)
+        val tpeVal = resolveType(tpe0, uenv, taenv, ns0, root)
         mapN(tpeVal) {
           case tpe => ResolvedAst.ConstraintParam.HeadParam(sym, tpe, loc)
         }
       case NamedAst.ConstraintParam.RuleParam(sym, tpe0, loc) =>
-        val tpeVal = resolveType(tpe0, taenv, ns0, root)
+        val tpeVal = resolveType(tpe0, uenv, taenv, ns0, root)
         mapN(tpeVal) {
           case tpe => ResolvedAst.ConstraintParam.RuleParam(sym, tpe, loc)
         }
@@ -1405,8 +1439,8 @@ object Resolver {
     /**
       * Performs name resolution on the given formal parameter `fparam0` in the given namespace `ns0`.
       */
-    def resolve(fparam0: NamedAst.FormalParam, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.FormalParam, ResolutionError] = {
-      val tVal = resolveType(fparam0.tpe, taenv, ns0, root)
+    def resolve(fparam0: NamedAst.FormalParam, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.FormalParam, ResolutionError] = {
+      val tVal = resolveType(fparam0.tpe, uenv, taenv, ns0, root)
       mapN(tVal) {
         t => ResolvedAst.FormalParam(fparam0.sym, fparam0.mod, t, fparam0.src, fparam0.loc)
       }
@@ -1415,12 +1449,12 @@ object Resolver {
     /**
       * Performs name resolution on the given predicate parameter `pparam0` in the given namespace `ns0`.
       */
-    def resolve(pparam0: NamedAst.PredicateParam, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.PredicateParam, ResolutionError] = pparam0 match {
+    def resolve(pparam0: NamedAst.PredicateParam, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.PredicateParam, ResolutionError] = pparam0 match {
       case NamedAst.PredicateParam.PredicateParamUntyped(pred, loc) =>
         ResolvedAst.PredicateParam.PredicateParamUntyped(pred, loc).toSuccess
 
       case NamedAst.PredicateParam.PredicateParamWithType(pred, den, tpes, loc) =>
-        mapN(traverse(tpes)(resolveType(_, taenv, ns0, root))) {
+        mapN(traverse(tpes)(resolveType(_, uenv, taenv, ns0, root))) {
           case ts => ResolvedAst.PredicateParam.PredicateParamWithType(pred, den, ts, loc)
         }
 
@@ -1452,8 +1486,8 @@ object Resolver {
   /**
     * Performs name resolution on the given formal parameters `fparams0`.
     */
-  def resolveFormalParams(fparams0: List[NamedAst.FormalParam], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[List[ResolvedAst.FormalParam], ResolutionError] = {
-    traverse(fparams0)(fparam => Params.resolve(fparam, taenv, ns0, root))
+  def resolveFormalParams(fparams0: List[NamedAst.FormalParam], uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[List[ResolvedAst.FormalParam], ResolutionError] = {
+    traverse(fparams0)(fparam => Params.resolve(fparam, uenv, taenv, ns0, root))
   }
 
   /**
@@ -1471,10 +1505,10 @@ object Resolver {
   /**
     * Performs name resolution on the given type constraint `tconstr0`.
     */
-  def resolveTypeConstraint(tconstr0: NamedAst.TypeConstraint, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.TypeConstraint, ResolutionError] = tconstr0 match {
+  def resolveTypeConstraint(tconstr0: NamedAst.TypeConstraint, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.TypeConstraint, ResolutionError] = tconstr0 match {
     case NamedAst.TypeConstraint(clazz0, tpe0, loc) =>
-      val classVal = lookupClass(clazz0, ns0, root)
-      val tpeVal = resolveType(tpe0, taenv, ns0, root)
+      val classVal = lookupClass(clazz0, uenv, ns0, root)
+      val tpeVal = resolveType(tpe0, uenv, taenv, ns0, root)
 
       mapN(classVal, tpeVal) {
         case (clazz, tpe) =>
@@ -1486,10 +1520,10 @@ object Resolver {
   /**
     * Performs name resolution on the given superclass constraint `tconstr0`.
     */
-  def resolveSuperClass(tconstr0: NamedAst.TypeConstraint, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.TypeConstraint, ResolutionError] = tconstr0 match {
+  def resolveSuperClass(tconstr0: NamedAst.TypeConstraint, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.TypeConstraint, ResolutionError] = tconstr0 match {
     case NamedAst.TypeConstraint(clazz0, tpe0, loc) =>
-      val classVal = lookupClassForImplementation(clazz0, ns0, root)
-      val tpeVal = resolveType(tpe0, taenv, ns0, root)
+      val classVal = lookupClassForImplementation(clazz0, uenv, ns0, root)
+      val tpeVal = resolveType(tpe0, uenv, taenv, ns0, root)
 
       mapN(classVal, tpeVal) {
         case (clazz, tpe) =>
@@ -1501,8 +1535,8 @@ object Resolver {
   /**
     * Performs name resolution on the given list of derivations `derives0`.
     */
-  def resolveDerivations(qnames: List[Name.QName], ns0: Name.NName, root: NamedAst.Root): Validation[List[Ast.Derivation], ResolutionError] = {
-    val derivesVal = Validation.traverse(qnames)(resolveDerivation(_, ns0, root))
+  def resolveDerivations(qnames: List[Name.QName], uenv: ListMap[String, DeclarationOrJavaClass], ns0: Name.NName, root: NamedAst.Root): Validation[List[Ast.Derivation], ResolutionError] = {
+    val derivesVal = Validation.traverse(qnames)(resolveDerivation(_, uenv, ns0, root))
     flatMapN(derivesVal) {
       derives =>
         val derivesWithIndex = derives.zipWithIndex
@@ -1536,8 +1570,8 @@ object Resolver {
   /**
     * Performs name resolution on the given of derivation `derive0`.
     */
-  def resolveDerivation(derive0: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[Ast.Derivation, ResolutionError] = {
-    val clazzVal = lookupClass(derive0, ns0, root)
+  def resolveDerivation(derive0: Name.QName, uenv: ListMap[String, DeclarationOrJavaClass], ns0: Name.NName, root: NamedAst.Root): Validation[Ast.Derivation, ResolutionError] = {
+    val clazzVal = lookupClass(derive0, uenv, ns0, root)
     flatMapN(clazzVal) {
       clazz =>
         mapN(checkDerivable(clazz.sym, derive0.loc)) {
@@ -1560,10 +1594,10 @@ object Resolver {
   /**
     * Finds the class with the qualified name `qname` in the namespace `ns0`, for the purposes of implementation.
     */
-  def lookupClassForImplementation(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Class, ResolutionError] = {
-    val classOpt = tryLookupName(qname, ns0, root.symbols)
+  def lookupClassForImplementation(qname: Name.QName, uenv: ListMap[String, DeclarationOrJavaClass], ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Class, ResolutionError] = {
+    val classOpt = tryLookupName2(qname, uenv, ns0, root)
     classOpt match {
-      case Some(clazz: NamedAst.Declaration.Class) =>
+      case DeclarationOrJavaClass.Declaration(clazz: NamedAst.Declaration.Class) :: Nil =>
         getClassAccessibility(clazz, ns0) match {
           case ClassAccessibility.Accessible => clazz.toSuccess
           case ClassAccessibility.Sealed => ResolutionError.SealedClass(clazz.sym, ns0, qname.loc).toFailure
@@ -1576,10 +1610,10 @@ object Resolver {
   /**
     * Finds the class with the qualified name `qname` in the namespace `ns0`.
     */
-  def lookupClass(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Class, ResolutionError] = {
-    val classOpt = tryLookupName(qname, ns0, root.symbols)
+  def lookupClass(qname: Name.QName, uenv: ListMap[String, DeclarationOrJavaClass], ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Class, ResolutionError] = {
+    val classOpt = tryLookupName2(qname, uenv, ns0, root)
     classOpt match {
-      case Some(clazz: NamedAst.Declaration.Class) =>
+      case DeclarationOrJavaClass.Declaration(clazz: NamedAst.Declaration.Class) :: Nil =>
         getClassAccessibility(clazz, ns0) match {
           case ClassAccessibility.Accessible | ClassAccessibility.Sealed => clazz.toSuccess
           case ClassAccessibility.Inaccessible => ResolutionError.InaccessibleClass(clazz.sym, ns0, qname.loc).toFailure
@@ -1591,24 +1625,25 @@ object Resolver {
   /**
     * Looks up the definition or signature with qualified name `qname` in the namespace `ns0`.
     */
-  private def lookupDefOrSig(qname: Name.QName, ns0: Name.NName, env: Map[String, Symbol.VarSym], root: NamedAst.Root): Validation[DefOrSig, ResolutionError] = {
-    val defOrSigOpt = tryLookupName(qname, ns0, root.symbols)
+  private def lookupDefOrSig(qname: Name.QName, uenv: ListMap[String, DeclarationOrJavaClass], ns0: Name.NName, env: Map[String, Symbol.VarSym], root: NamedAst.Root): Validation[DefOrSig, ResolutionError] = {
+    // first look in the local env
+    val defOrSigOpt = tryLookupName2(qname, uenv, ns0, root)
 
     defOrSigOpt match {
-      case None => ResolutionError.UndefinedName(qname, ns0, env, qname.loc).toFailure
-      case Some(defn: NamedAst.Declaration.Def) =>
+      case Nil => ResolutionError.UndefinedName(qname, ns0, env, qname.loc).toFailure
+      case DeclarationOrJavaClass.Declaration(defn: NamedAst.Declaration.Def) :: Nil =>
         if (isDefAccessible(defn, ns0)) {
           DefOrSig.Def(defn).toSuccess
         } else {
           ResolutionError.InaccessibleDef(defn.sym, ns0, qname.loc).toFailure
         }
-      case Some(sig: NamedAst.Declaration.Sig) =>
+      case DeclarationOrJavaClass.Declaration(sig: NamedAst.Declaration.Sig) :: Nil =>
         if (isSigAccessible(sig, ns0)) {
           DefOrSig.Sig(sig).toSuccess
         } else {
           ResolutionError.InaccessibleSig(sig.sym, ns0, qname.loc).toFailure
         }
-      case Some(_) => ResolutionError.UndefinedName(qname, ns0, env, qname.loc).toFailure
+      case _ => ResolutionError.UndefinedName(qname, ns0, env, qname.loc).toFailure
 
     }
   }
@@ -1616,11 +1651,11 @@ object Resolver {
   /**
     * Looks up the effect operation with qualified name `qname` in the namespace `ns0`.
     */
-  private def lookupOp(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Op, ResolutionError] = {
-    val opOpt = tryLookupName(qname, ns0, root.symbols)
+  private def lookupOp(qname: Name.QName, uenv: ListMap[String, DeclarationOrJavaClass], ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Op, ResolutionError] = {
+    val opOpt = tryLookupName2(qname, uenv, ns0, root)
 
     opOpt match {
-      case Some(op: NamedAst.Declaration.Op) =>
+      case DeclarationOrJavaClass.Declaration(op: NamedAst.Declaration.Op) :: Nil =>
         if (isOpAccessible(op, ns0)) {
           op.toSuccess
         } else {
@@ -1644,14 +1679,25 @@ object Resolver {
     }
   }
 
+  // TODO can replace uses of this by direct case lookup later
+
   /**
     * Finds the enum that matches the given qualified name `qname` and `tag` in the namespace `ns0`.
     */
-  def lookupEnumByTag(qnameOpt: Option[Name.QName], tag: Name.Ident, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Enum, ResolutionError] = {
+  def lookupEnumByTag(qnameOpt: Option[Name.QName], tag: Name.Ident, uenv: ListMap[String, DeclarationOrJavaClass], ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Enum, ResolutionError] = {
     // Determine whether the name is qualified.
     qnameOpt match {
       case None =>
         // Case 1: The name is unqualified.
+
+        // Case 1.1. The name is in the uenv.
+        uenv(tag.name) collectFirst {
+          case DeclarationOrJavaClass.Declaration(caze: NamedAst.Declaration.Case) =>
+            root.symbols.getOrElse(Name.mkUnlocatedNName(caze.sym.enumSym.namespace), Map.empty).get(caze.sym.enumSym.name) match {
+              case Some(enum: NamedAst.Declaration.Enum) => return enum.toSuccess
+              case _ => throw InternalCompilerException("Unexpected missing enum")
+            }
+        }
 
         // Find all matching enums in the current namespace.
         val namespaceMatches = mutable.Set.empty[NamedAst.Declaration.Enum]
@@ -1724,9 +1770,17 @@ object Resolver {
         }
 
         val enumOpt = if (qname.isUnqualified) {
-          // The name is unqualified (e.g. Option.None), so first search the current namespace,
+          // The name is unqualified (e.g. Option.None),
+          // First search the use env for the enum.
+          // then search the current namespace,
           // if it's not found there, search the root namespace.
-          lookupEnumInNs(ns0).orElse(lookupEnumInNs(Name.RootNS))
+          uenv(qname.ident.name).collectFirst {
+            case DeclarationOrJavaClass.Declaration(e: NamedAst.Declaration.Enum) => e
+          }.orElse {
+            lookupEnumInNs(ns0)
+          }.orElse {
+            lookupEnumInNs(Name.RootNS)
+          }
         } else {
           // The name is qualified (e.g. Foo/Bar/Baz.Qux) so search in the Foo/Bar/Baz namespace.
           lookupEnumInNs(qname.namespace)
@@ -1771,7 +1825,7 @@ object Resolver {
     *
     * Type aliases are given temporary placeholders.
     */
-  private def semiResolveType(tpe0: NamedAst.Type, ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[UnkindedType, ResolutionError] = tpe0 match {
+  private def semiResolveType(tpe0: NamedAst.Type, uenv: ListMap[String, DeclarationOrJavaClass], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[UnkindedType, ResolutionError] = tpe0 match {
     case NamedAst.Type.Var(sym, loc) => UnkindedType.Var(sym, loc).toSuccess
 
     case NamedAst.Type.Unit(loc) => UnkindedType.Cst(TypeConstructor.Unit, loc).toSuccess
@@ -1800,20 +1854,22 @@ object Resolver {
 
       // Disambiguate type.
       case typeName =>
-        lookupType(qname, ns0, root) match {
+        lookupType(qname, uenv, ns0, root) match {
           case TypeLookupResult.Enum(enum) => getEnumTypeIfAccessible(enum, ns0, loc)
           case TypeLookupResult.TypeAlias(typeAlias) => getTypeAliasTypeIfAccessible(typeAlias, ns0, root, loc)
           case TypeLookupResult.Effect(eff) => getEffectTypeIfAccessible(eff, ns0, root, loc)
+          case TypeLookupResult.JavaClass(clazz) => flixifyType(clazz, loc).toSuccess
           case TypeLookupResult.NotFound => ResolutionError.UndefinedType(qname, ns0, loc).toFailure
         }
     }
 
     case NamedAst.Type.Ambiguous(qname, loc) =>
       // Disambiguate type.
-      lookupType(qname, ns0, root) match {
+      lookupType(qname, uenv, ns0, root) match {
         case TypeLookupResult.Enum(enum) => getEnumTypeIfAccessible(enum, ns0, loc)
         case TypeLookupResult.TypeAlias(typeAlias) => getTypeAliasTypeIfAccessible(typeAlias, ns0, root, loc)
         case TypeLookupResult.Effect(eff) => getEffectTypeIfAccessible(eff, ns0, root, loc)
+        case TypeLookupResult.JavaClass(clazz) => flixifyType(clazz, loc).toSuccess
         case TypeLookupResult.NotFound => ResolutionError.UndefinedType(qname, ns0, loc).toFailure
       }
 
@@ -1821,7 +1877,7 @@ object Resolver {
       mkEnum(sym, loc).toSuccess
 
     case NamedAst.Type.Tuple(elms0, loc) =>
-      val elmsVal = traverse(elms0)(tpe => semiResolveType(tpe, ns0, root))
+      val elmsVal = traverse(elms0)(tpe => semiResolveType(tpe, uenv, ns0, root))
       mapN(elmsVal) {
         elms => UnkindedType.mkTuple(elms, loc)
       }
@@ -1829,14 +1885,14 @@ object Resolver {
     case NamedAst.Type.RecordRowEmpty(loc) => UnkindedType.Cst(TypeConstructor.RecordRowEmpty, loc).toSuccess
 
     case NamedAst.Type.RecordRowExtend(field, value, rest, loc) =>
-      val vVal = semiResolveType(value, ns0, root)
-      val rVal = semiResolveType(rest, ns0, root)
+      val vVal = semiResolveType(value, uenv, ns0, root)
+      val rVal = semiResolveType(rest, uenv, ns0, root)
       mapN(vVal, rVal) {
         case (v, r) => UnkindedType.mkRecordRowExtend(field, v, r, loc)
       }
 
     case NamedAst.Type.Record(row, loc) =>
-      val rVal = semiResolveType(row, ns0, root)
+      val rVal = semiResolveType(row, uenv, ns0, root)
       mapN(rVal) {
         r => UnkindedType.mkRecord(r, loc)
       }
@@ -1845,11 +1901,11 @@ object Resolver {
 
     case NamedAst.Type.SchemaRowExtendWithAlias(qname, targs, rest, loc) =>
       // Lookup the type alias.
-      flatMapN(lookupTypeAlias(qname, ns0, root)) {
+      flatMapN(lookupTypeAlias(qname, uenv, ns0, root)) {
         typeAlias =>
           val tVal = getTypeAliasTypeIfAccessible(typeAlias, ns0, root, loc)
-          val tsVal = traverse(targs)(semiResolveType(_, ns0, root))
-          val rVal = semiResolveType(rest, ns0, root)
+          val tsVal = traverse(targs)(semiResolveType(_, uenv, ns0, root))
+          val rVal = semiResolveType(rest, uenv, ns0, root)
           mapN(tVal, tsVal, rVal) {
             case (t, ts, r) =>
               val app = UnkindedType.mkApply(t, ts, loc)
@@ -1858,8 +1914,8 @@ object Resolver {
       }
 
     case NamedAst.Type.SchemaRowExtendWithTypes(ident, den, tpes, rest, loc) =>
-      val tsVal = traverse(tpes)(semiResolveType(_, ns0, root))
-      val rVal = semiResolveType(rest, ns0, root)
+      val tsVal = traverse(tpes)(semiResolveType(_, uenv, ns0, root))
+      val rVal = semiResolveType(rest, uenv, ns0, root)
       mapN(tsVal, rVal) {
         case (ts, r) =>
           val pred = mkPredicate(den, ts, loc)
@@ -1867,59 +1923,39 @@ object Resolver {
       }
 
     case NamedAst.Type.Schema(row, loc) =>
-      val rVal = semiResolveType(row, ns0, root)
+      val rVal = semiResolveType(row, uenv, ns0, root)
       mapN(rVal) {
         r => UnkindedType.mkSchema(r, loc)
       }
 
     case NamedAst.Type.Relation(tpes, loc) =>
-      val tsVal = traverse(tpes)(semiResolveType(_, ns0, root))
+      val tsVal = traverse(tpes)(semiResolveType(_, uenv, ns0, root))
       mapN(tsVal) {
         ts => UnkindedType.mkRelation(ts, loc)
       }
 
     case NamedAst.Type.Lattice(tpes, loc) =>
-      val tsVal = traverse(tpes)(semiResolveType(_, ns0, root))
+      val tsVal = traverse(tpes)(semiResolveType(_, uenv, ns0, root))
       mapN(tsVal) {
         ts => UnkindedType.mkLattice(ts, loc)
       }
 
     case NamedAst.Type.Native(fqn, loc) =>
-      fqn match {
-        case "java.math.BigDecimal" => UnkindedType.Cst(TypeConstructor.BigDecimal, loc).toSuccess
-        case "java.math.BigInteger" => UnkindedType.Cst(TypeConstructor.BigInt, loc).toSuccess
-        case "java.lang.String" => UnkindedType.Cst(TypeConstructor.Str, loc).toSuccess
-        case "java.util.function.Function" => UnkindedType.mkImpureArrow(UnkindedType.mkObject(loc), UnkindedType.mkObject(loc), loc).toSuccess
-        case "java.util.function.Consumer" => UnkindedType.mkImpureArrow(UnkindedType.mkObject(loc), UnkindedType.mkUnit(loc), loc).toSuccess
-        case "java.util.function.Predicate" => UnkindedType.mkImpureArrow(UnkindedType.mkObject(loc), UnkindedType.mkBool(loc), loc).toSuccess
-        case "java.util.function.IntFunction" => UnkindedType.mkImpureArrow(UnkindedType.mkInt32(loc), UnkindedType.mkObject(loc), loc).toSuccess
-        case "java.util.function.IntConsumer" => UnkindedType.mkImpureArrow(UnkindedType.mkInt32(loc), UnkindedType.mkUnit(loc), loc).toSuccess
-        case "java.util.function.IntPredicate" => UnkindedType.mkImpureArrow(UnkindedType.mkInt32(loc), UnkindedType.mkBool(loc), loc).toSuccess
-        case "java.util.function.IntUnaryOperator" => UnkindedType.mkImpureArrow(UnkindedType.mkInt32(loc), UnkindedType.mkInt32(loc), loc).toSuccess
-        case "java.util.function.LongFunction" => UnkindedType.mkImpureArrow(UnkindedType.mkInt64(loc), UnkindedType.mkObject(loc), loc).toSuccess
-        case "java.util.function.LongConsumer" => UnkindedType.mkImpureArrow(UnkindedType.mkInt64(loc), UnkindedType.mkUnit(loc), loc).toSuccess
-        case "java.util.function.LongPredicate" => UnkindedType.mkImpureArrow(UnkindedType.mkInt64(loc), UnkindedType.mkBool(loc), loc).toSuccess
-        case "java.util.function.LongUnaryOperator" => UnkindedType.mkImpureArrow(UnkindedType.mkInt64(loc), UnkindedType.mkInt64(loc), loc).toSuccess
-        case "java.util.function.DoubleFunction" => UnkindedType.mkImpureArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkObject(loc), loc).toSuccess
-        case "java.util.function.DoubleConsumer" => UnkindedType.mkImpureArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkUnit(loc), loc).toSuccess
-        case "java.util.function.DoublePredicate" => UnkindedType.mkImpureArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkBool(loc), loc).toSuccess
-        case "java.util.function.DoubleUnaryOperator" => UnkindedType.mkImpureArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkFloat64(loc), loc).toSuccess
-        case _ => lookupJvmClass(fqn, loc) map {
-          case clazz => UnkindedType.Cst(TypeConstructor.Native(clazz), loc)
-        }
+      mapN(lookupJvmClass(fqn, loc)) {
+        case clazz => flixifyType(clazz, loc)
       }
 
     case NamedAst.Type.Arrow(tparams0, purAndEff0, tresult0, loc) =>
-      val tparamsVal = traverse(tparams0)(semiResolveType(_, ns0, root))
-      val tresultVal = semiResolveType(tresult0, ns0, root)
-      val purAndEffVal = semiResolvePurityAndEffect(purAndEff0, ns0, root)
+      val tparamsVal = traverse(tparams0)(semiResolveType(_, uenv, ns0, root))
+      val tresultVal = semiResolveType(tresult0, uenv, ns0, root)
+      val purAndEffVal = semiResolvePurityAndEffect(purAndEff0, uenv, ns0, root)
       mapN(tparamsVal, tresultVal, purAndEffVal) {
         case (tparams, tresult, purAndEff) => mkUncurriedArrowWithEffect(tparams, purAndEff, tresult, loc)
       }
 
     case NamedAst.Type.Apply(base0, targ0, loc) =>
-      val tpe1Val = semiResolveType(base0, ns0, root)
-      val tpe2Val = semiResolveType(targ0, ns0, root)
+      val tpe1Val = semiResolveType(base0, uenv, ns0, root)
+      val tpe2Val = semiResolveType(targ0, uenv, ns0, root)
       mapN(tpe1Val, tpe2Val) {
         case (tpe1, tpe2) => UnkindedType.Apply(tpe1, tpe2, loc)
       }
@@ -1929,49 +1965,49 @@ object Resolver {
     case NamedAst.Type.False(loc) => UnkindedType.Cst(TypeConstructor.False, loc).toSuccess
 
     case NamedAst.Type.Not(tpe, loc) =>
-      mapN(semiResolveType(tpe, ns0, root)) {
+      mapN(semiResolveType(tpe, uenv, ns0, root)) {
         case t => mkNot(t, loc)
       }
 
     case NamedAst.Type.And(tpe1, tpe2, loc) =>
-      mapN(semiResolveType(tpe1, ns0, root), semiResolveType(tpe2, ns0, root)) {
+      mapN(semiResolveType(tpe1, uenv, ns0, root), semiResolveType(tpe2, uenv, ns0, root)) {
         case (t1, t2) => mkAnd(t1, t2, loc)
       }
 
     case NamedAst.Type.Or(tpe1, tpe2, loc) =>
-      mapN(semiResolveType(tpe1, ns0, root), semiResolveType(tpe2, ns0, root)) {
+      mapN(semiResolveType(tpe1, uenv, ns0, root), semiResolveType(tpe2, uenv, ns0, root)) {
         case (t1, t2) => mkOr(t1, t2, loc)
       }
 
     case NamedAst.Type.Complement(tpe, loc) =>
-      mapN(semiResolveType(tpe, ns0, root)) {
+      mapN(semiResolveType(tpe, uenv, ns0, root)) {
         t => mkComplement(t, loc)
       }
 
     case NamedAst.Type.Union(tpe1, tpe2, loc) =>
-      mapN(semiResolveType(tpe1, ns0, root), semiResolveType(tpe2, ns0, root)) {
+      mapN(semiResolveType(tpe1, uenv, ns0, root), semiResolveType(tpe2, uenv, ns0, root)) {
         case (t1, t2) => mkUnion(t1, t2, loc)
       }
 
     case NamedAst.Type.Intersection(tpe1, tpe2, loc) =>
-      mapN(semiResolveType(tpe1, ns0, root), semiResolveType(tpe2, ns0, root)) {
+      mapN(semiResolveType(tpe1, uenv, ns0, root), semiResolveType(tpe2, uenv, ns0, root)) {
         case (t1, t2) => mkIntersection(t1, t2, loc)
       }
 
     case NamedAst.Type.Read(tpe, loc) =>
-      mapN(semiResolveType(tpe, ns0, root)) {
+      mapN(semiResolveType(tpe, uenv, ns0, root)) {
         case t => UnkindedType.ReadWrite(t, loc)
       }
 
     case NamedAst.Type.Write(tpe, loc) =>
-      mapN(semiResolveType(tpe, ns0, root)) {
+      mapN(semiResolveType(tpe, uenv, ns0, root)) {
         case t => UnkindedType.ReadWrite(t, loc)
       }
 
     case NamedAst.Type.Empty(loc) => UnkindedType.Cst(TypeConstructor.Empty, loc).toSuccess
 
     case NamedAst.Type.Ascribe(tpe, kind, loc) =>
-      mapN(semiResolveType(tpe, ns0, root)) {
+      mapN(semiResolveType(tpe, uenv, ns0, root)) {
         t => UnkindedType.Ascribe(t, kind, loc)
       }
 
@@ -2060,8 +2096,8 @@ object Resolver {
   /**
     * Performs name resolution on the given type `tpe0` in the given namespace `ns0`.
     */
-  def resolveType(tpe0: NamedAst.Type, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[UnkindedType, ResolutionError] = {
-    val tVal = semiResolveType(tpe0, ns0, root)
+  def resolveType(tpe0: NamedAst.Type, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[UnkindedType, ResolutionError] = {
+    val tVal = semiResolveType(tpe0, uenv, ns0, root)
     flatMapN(tVal) {
       t => finishResolveType(t, taenv)
     }
@@ -2070,10 +2106,10 @@ object Resolver {
   /**
     * Partially resolves the given purity and effect.
     */
-  private def semiResolvePurityAndEffect(purAndEff0: NamedAst.PurityAndEffect, ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[UnkindedType.PurityAndEffect, ResolutionError] = purAndEff0 match {
+  private def semiResolvePurityAndEffect(purAndEff0: NamedAst.PurityAndEffect, uenv: ListMap[String, DeclarationOrJavaClass], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[UnkindedType.PurityAndEffect, ResolutionError] = purAndEff0 match {
     case NamedAst.PurityAndEffect(pur0, eff0) =>
-      val purVal = traverseOpt(pur0)(semiResolveType(_, ns0, root))
-      val effVal = traverseOpt(eff0)(effs => traverse(effs)(semiResolveType(_, ns0, root)))
+      val purVal = traverseOpt(pur0)(semiResolveType(_, uenv, ns0, root))
+      val effVal = traverseOpt(eff0)(effs => traverse(effs)(semiResolveType(_, uenv, ns0, root)))
       mapN(purVal, effVal) {
         case (pur, eff) => UnkindedType.PurityAndEffect(pur, eff)
       }
@@ -2094,8 +2130,8 @@ object Resolver {
   /**
     * Performs name resolution on the given purity and effect `purAndEff0` in the given namespace `ns0`.
     */
-  private def resolvePurityAndEffect(purAndEff0: NamedAst.PurityAndEffect, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[UnkindedType.PurityAndEffect, ResolutionError] = {
-    flatMapN(semiResolvePurityAndEffect(purAndEff0, ns0, root)) {
+  private def resolvePurityAndEffect(purAndEff0: NamedAst.PurityAndEffect, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[UnkindedType.PurityAndEffect, ResolutionError] = {
+    flatMapN(semiResolvePurityAndEffect(purAndEff0, uenv, ns0, root)) {
       case purAndEff => finishResolvePurityAndEffect(purAndEff, taenv)
     }
   }
@@ -2113,6 +2149,7 @@ object Resolver {
       case res: TypeLookupResult.Enum => res
       case res: TypeLookupResult.TypeAlias => res
       case res: TypeLookupResult.Effect => res
+      case res: TypeLookupResult.JavaClass => res
       case TypeLookupResult.NotFound => other
     }
   }
@@ -2134,6 +2171,11 @@ object Resolver {
     case class Effect(eff: NamedAst.Declaration.Effect) extends TypeLookupResult
 
     /**
+      * The result is a Java class.
+      */
+    case class JavaClass(clazz: Class[_]) extends TypeLookupResult
+
+    /**
       * The type cannot be found.
       */
     case object NotFound extends TypeLookupResult
@@ -2142,14 +2184,14 @@ object Resolver {
   /**
     * Looks up the ambiguous type.
     */
-  private def lookupType(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): TypeLookupResult = {
+  private def lookupType(qname: Name.QName, uenv: ListMap[String, DeclarationOrJavaClass], ns0: Name.NName, root: NamedAst.Root): TypeLookupResult = {
 
     /**
       * Looks up the type in the given namespace.
       */
-    def lookupIn(ns: Name.NName): TypeLookupResult = {
-      val upperNamesInNamespace = root.symbols.getOrElse(ns, Map.empty)
-      upperNamesInNamespace.get(qname.ident.name) match {
+    def lookupInNamespace(ns: Name.NName): TypeLookupResult = {
+      val symbolsInNamespace = root.symbols.getOrElse(ns, Map.empty)
+      symbolsInNamespace.get(qname.ident.name) match {
         case None =>
           // Case 1: name not found
           TypeLookupResult.NotFound
@@ -2168,26 +2210,44 @@ object Resolver {
       }
     }
 
+    def lookupInUseEnv(name: String): TypeLookupResult = uenv(name).collectFirst {
+      case DeclarationOrJavaClass.Declaration(alias: NamedAst.Declaration.TypeAlias) =>
+        // Case 1: found a type alias
+        TypeLookupResult.TypeAlias(alias)
+      case DeclarationOrJavaClass.Declaration(enum: NamedAst.Declaration.Enum) =>
+        // Case 2: found an enum
+        TypeLookupResult.Enum(enum)
+      case DeclarationOrJavaClass.Declaration(effect: NamedAst.Declaration.Effect) =>
+        // Case 3: found an effect
+        TypeLookupResult.Effect(effect)
+      case DeclarationOrJavaClass.JavaClass(clazz) =>
+        // Case 4: found a Java class
+        TypeLookupResult.JavaClass(clazz)
+    }.getOrElse(TypeLookupResult.NotFound)
+
     if (qname.isUnqualified) {
-      // Case 1: The name is unqualified. Lookup in the current namespace.
-      lookupIn(ns0).orElse {
-        // Case 1.1: The name was not found in the current namespace. Try the root namespace.
-        lookupIn(Name.RootNS)
+      // Case 1. The name is unqualified. Look it up in the use environment.
+      lookupInUseEnv(qname.ident.name).orElse {
+        // Case 1: The name is unqualified. Lookup in the current namespace.
+        lookupInNamespace(ns0).orElse {
+          // Case 1.1: The name was not found in the current namespace. Try the root namespace.
+          lookupInNamespace(Name.RootNS)
+        }
       }
     } else {
       // Case 2: The name is qualified. Look it up in its namespace.
-      lookupIn(qname.namespace)
+      lookupInNamespace(qname.namespace)
     }
   }
 
   /**
     * Optionally returns the type alias with the given `name` in the given namespace `ns0`.
     */
-  private def lookupTypeAlias(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.TypeAlias, ResolutionError] = {
-    val symOpt = tryLookupName(qname, ns0, root.symbols)
+  private def lookupTypeAlias(qname: Name.QName, uenv: ListMap[String, DeclarationOrJavaClass], ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.TypeAlias, ResolutionError] = {
+    val symOpt = tryLookupName2(qname, uenv, ns0, root)
 
     symOpt match {
-      case Some(alias: NamedAst.Declaration.TypeAlias) => getTypeAliasIfAccessible(alias, ns0, qname.loc)
+      case DeclarationOrJavaClass.Declaration(alias: NamedAst.Declaration.TypeAlias) :: Nil => getTypeAliasIfAccessible(alias, ns0, qname.loc)
       case _ => ResolutionError.UndefinedName(qname, ns0, Map.empty, qname.loc).toFailure
     }
   }
@@ -2195,18 +2255,40 @@ object Resolver {
   /**
     * Looks up the definition or signature with qualified name `qname` in the namespace `ns0`.
     */
-  private def lookupEffect(qname: Name.QName, ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Effect, ResolutionError] = {
-    val classOrEffOrEnumOpt = tryLookupName(qname, ns0, root.symbols)
+  private def lookupEffect(qname: Name.QName, uenv: ListMap[String, DeclarationOrJavaClass], ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Effect, ResolutionError] = {
+    val symOpt = tryLookupName2(qname, uenv, ns0, root)
 
-    classOrEffOrEnumOpt match {
-      case Some(eff: NamedAst.Declaration.Effect) => getEffectIfAccessible(eff, ns0, qname.loc)
+    symOpt match {
+      case DeclarationOrJavaClass.Declaration(eff: NamedAst.Declaration.Effect) :: Nil => getEffectIfAccessible(eff, ns0, qname.loc)
       case _ => ResolutionError.UndefinedEffect(qname, ns0, qname.loc).toFailure
+    }
+  }
+
+
+  private def tryLookupName2(qname: Name.QName, uenv: ListMap[String, DeclarationOrJavaClass], ns0: Name.NName, root: NamedAst.Root): List[DeclarationOrJavaClass] = {
+    if (qname.isUnqualified) {
+      // Case 1 Unqualified name. Try in the use environment.
+      uenv(qname.ident.name) match {
+        // Case 1.1 It's not in the uenv.
+        case Nil =>
+          // Case 1.1.1 Try in the local namespace
+          root.symbols.getOrElse(ns0, Map.empty).get(qname.ident.name).map(DeclarationOrJavaClass.Declaration).orElse {
+            // Case 1.1.2 Try in the root namespace
+            root.symbols.getOrElse(Name.RootNS, Map.empty).get(qname.ident.name).map(DeclarationOrJavaClass.Declaration)
+          }.toList
+        // Case 1.2 It is in the uenv, return the results
+        case l => l
+      }
+    } else {
+      // Case 2. Qualified name. Look it up directly.
+      root.symbols.getOrElse(qname.namespace, Map.empty).get(qname.ident.name).map(DeclarationOrJavaClass.Declaration).toList
     }
   }
 
   /**
     * Tries to lookup the name in the given namespace, using the given namespace map.
     */
+  @deprecated("tryLookupName2")
   private def tryLookupName[T](qname: Name.QName, ns0: Name.NName, map: Map[Name.NName, Map[String, T]]): Option[T] = {
     if (qname.isUnqualified) {
       // Case 1: Unqualified name. Lookup in the current namespace.
@@ -2797,37 +2879,118 @@ object Resolver {
     case Declaration.TypeAlias(doc, mod, sym, tparams, tpe, loc) => sym
     case Declaration.Effect(doc, ann, mod, sym, ops, loc) => sym
     case Declaration.Op(sym, spec) => sym
+    case Declaration.Case(sym, tpe) => sym
     case Declaration.Instance(doc, ann, mod, clazz, tpe, tconstrs, defs, ns, loc) => throw InternalCompilerException("unexpected instance", loc)
+  }
+
+  // TODO limit the set of symbols that can be in useOrImport
+  // MATT docs
+  private def infallableLookupSym(sym: Symbol, root: NamedAst.Root)(implicit flix: Flix): NamedAst.Declaration = sym match {
+    case sym: Symbol.DefnSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
+    case sym: Symbol.EnumSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
+    case sym: Symbol.CaseSym => root.symbols(Name.mkUnlocatedNName(sym.enumSym.namespace))(sym.enumSym.name).asInstanceOf[NamedAst.Declaration.Enum].cases(sym.name)
+    case sym: Symbol.ClassSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
+    case sym: Symbol.SigSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
+    case sym: Symbol.TypeAliasSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
+    case sym: Symbol.EffectSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
+    case sym: Symbol.OpSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
+    case sym: Symbol.ModuleSym => throw InternalCompilerException(s"unexpected symbol $sym")
+    case sym: Symbol.VarSym => throw InternalCompilerException(s"unexpected symbol $sym")
+    case sym: Symbol.KindedTypeVarSym => throw InternalCompilerException(s"unexpected symbol $sym")
+    case sym: Symbol.UnkindedTypeVarSym => throw InternalCompilerException(s"unexpected symbol $sym")
+    case sym: Symbol.LabelSym => throw InternalCompilerException(s"unexpected symbol $sym")
+    case sym: Symbol.HoleSym => throw InternalCompilerException(s"unexpected symbol $sym")
+    case sym: Symbol.InstanceSym => throw InternalCompilerException(s"unexpected symbol $sym")
   }
 
   /**
     * Resolves the given Use.
     */
-  private def visitUse(use: NamedAst.UseOrImport, ns: Name.NName, root: NamedAst.Root): Validation[Option[Ast.Use], ResolutionError] = use match {
-    case NamedAst.UseOrImport.UseDefOrSig(qname, _, loc) => tryLookupName(qname, ns, root.symbols) match {
-      case None => ResolutionError.UndefinedName(qname, ns, Map.empty, loc).toFailure
-      case Some(value) =>
-        val sym = getSym(value)
-        Some(Ast.Use(sym, loc)).toSuccess
+  private def visitUseOrImport(useOrImport: NamedAst.UseOrImport, ns: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[Ast.UseOrImport, ResolutionError] = useOrImport match {
+    case NamedAst.UseOrImport.UseDefOrSig(qname, alias, loc) => tryLookupName2(qname, ListMap.empty, ns, root) match {
+      // Case 1: No matches. Error.
+      case Nil => ResolutionError.UndefinedName(qname, ns, Map.empty, loc).toFailure
+      // Case 2: A match. Map it to a use.
+      case DeclarationOrJavaClass.Declaration(d) :: Nil => Ast.UseOrImport.Use(getSym(d), alias, loc).toSuccess
+      // Case 3: Impossible. Hard error.
+      case _ => throw InternalCompilerException("unexpected conflicted imports")
     }
-    case NamedAst.UseOrImport.UseTypeOrClass(qname, _, loc) => tryLookupName(qname, ns, root.symbols) match {
-      case None => ResolutionError.UndefinedName(qname, ns, Map.empty, loc).toFailure
-      case Some(value) =>
-        val sym = getSym(value)
-        Some(Ast.Use(sym, loc)).toSuccess
+    case NamedAst.UseOrImport.UseTypeOrClass(qname, alias, loc) => tryLookupName2(qname, ListMap.empty, ns, root) match {
+      // Case 1: No matches. Error.
+      case Nil => ResolutionError.UndefinedName(qname, ns, Map.empty, loc).toFailure
+      // Case 2: A match. Map it to a use.
+      case DeclarationOrJavaClass.Declaration(d) :: Nil => Ast.UseOrImport.Use(getSym(d), alias, loc).toSuccess
+      // Case 3: Impossible. Hard error.
+      case _ => throw InternalCompilerException("unexpected conflicted imports")
     }
 
-    case NamedAst.UseOrImport.UseTag(qname, tag, _, loc) => tryLookupName(qname, ns, root.symbols) match {
-      case Some(e: NamedAst.Declaration.Enum) =>
+    case NamedAst.UseOrImport.UseTag(qname, tag, alias, loc) => tryLookupName2(qname, ListMap.empty, ns, root) match {
+      // Case 1: No matches. Error.
+      case Nil => ResolutionError.UndefinedName(qname, ns, Map.empty, loc).toFailure
+      // Case 2: A Match. Look up the case and map it to a use.
+      case DeclarationOrJavaClass.Declaration(e: NamedAst.Declaration.Enum) :: Nil =>
+        // Check that each tag exists.
         e.cases.get(tag.name) match {
-          case Some(NamedAst.Case(sym, _)) => Some(Ast.Use(sym, loc)).toSuccess
+          case Some(NamedAst.Declaration.Case(sym, _)) => Ast.UseOrImport.Use(sym, alias, loc).toSuccess
           case None => ResolutionError.UndefinedTag(tag.name, ns, loc).toFailure
         }
-      case _ => ResolutionError.UndefinedName(qname, ns, Map.empty, loc).toFailure
+      case _ => throw InternalCompilerException("unexpected non-enum")
     }
 
-    // TODO: skipping import for now
-    case NamedAst.UseOrImport.Import(_, _, _) => None.toSuccess
+    case NamedAst.UseOrImport.Import(name, alias, loc) =>
+      val clazzVal = lookupJvmClass(name.toString, loc)
+      mapN(clazzVal) {
+        case clazz => Ast.UseOrImport.Import(clazz, alias, loc)
+      }
+  }
+
+  /**
+    * Creates a use environment from the given uses and imports.
+    */
+  private def mkUseEnv(usesAndImports: List[Ast.UseOrImport], root: NamedAst.Root)(implicit flix: Flix): ListMap[String, DeclarationOrJavaClass] = {
+    appendAllUseEnv(ListMap.empty, usesAndImports, root)
+  }
+
+  /**
+    * Adds the given use or import to the use environment.
+    */
+  private def appendUseEnv(uenv: ListMap[String, DeclarationOrJavaClass], useOrImport: Ast.UseOrImport, root: NamedAst.Root)(implicit flix: Flix): ListMap[String, DeclarationOrJavaClass] = useOrImport match {
+    case Ast.UseOrImport.Use(sym, alias, loc) =>
+      val decl = infallableLookupSym(sym, root)
+      uenv + (alias.name -> DeclarationOrJavaClass.Declaration(decl))
+    case Ast.UseOrImport.Import(clazz, alias, loc) => uenv + (alias.name -> DeclarationOrJavaClass.JavaClass(clazz))
+  }
+
+  /**
+    * Adds the given uses and imports to the use environment.
+    */
+  private def appendAllUseEnv(uenv: ListMap[String, DeclarationOrJavaClass], usesAndImports: List[Ast.UseOrImport], root: NamedAst.Root)(implicit flix: Flix): ListMap[String, DeclarationOrJavaClass] = {
+    usesAndImports.foldLeft(uenv)(appendUseEnv(_, _, root))
+  }
+
+  /**
+    * Converts the class into a Flix type.
+    */
+  private def flixifyType(clazz: Class[_], loc: SourceLocation): UnkindedType = clazz.getName match {
+    case "java.math.BigDecimal" => UnkindedType.Cst(TypeConstructor.BigDecimal, loc)
+    case "java.math.BigInteger" => UnkindedType.Cst(TypeConstructor.BigInt, loc)
+    case "java.lang.String" => UnkindedType.Cst(TypeConstructor.Str, loc)
+    case "java.util.function.Function" => UnkindedType.mkImpureArrow(UnkindedType.mkObject(loc), UnkindedType.mkObject(loc), loc)
+    case "java.util.function.Consumer" => UnkindedType.mkImpureArrow(UnkindedType.mkObject(loc), UnkindedType.mkUnit(loc), loc)
+    case "java.util.function.Predicate" => UnkindedType.mkImpureArrow(UnkindedType.mkObject(loc), UnkindedType.mkBool(loc), loc)
+    case "java.util.function.IntFunction" => UnkindedType.mkImpureArrow(UnkindedType.mkInt32(loc), UnkindedType.mkObject(loc), loc)
+    case "java.util.function.IntConsumer" => UnkindedType.mkImpureArrow(UnkindedType.mkInt32(loc), UnkindedType.mkUnit(loc), loc)
+    case "java.util.function.IntPredicate" => UnkindedType.mkImpureArrow(UnkindedType.mkInt32(loc), UnkindedType.mkBool(loc), loc)
+    case "java.util.function.IntUnaryOperator" => UnkindedType.mkImpureArrow(UnkindedType.mkInt32(loc), UnkindedType.mkInt32(loc), loc)
+    case "java.util.function.LongFunction" => UnkindedType.mkImpureArrow(UnkindedType.mkInt64(loc), UnkindedType.mkObject(loc), loc)
+    case "java.util.function.LongConsumer" => UnkindedType.mkImpureArrow(UnkindedType.mkInt64(loc), UnkindedType.mkUnit(loc), loc)
+    case "java.util.function.LongPredicate" => UnkindedType.mkImpureArrow(UnkindedType.mkInt64(loc), UnkindedType.mkBool(loc), loc)
+    case "java.util.function.LongUnaryOperator" => UnkindedType.mkImpureArrow(UnkindedType.mkInt64(loc), UnkindedType.mkInt64(loc), loc)
+    case "java.util.function.DoubleFunction" => UnkindedType.mkImpureArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkObject(loc), loc)
+    case "java.util.function.DoubleConsumer" => UnkindedType.mkImpureArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkUnit(loc), loc)
+    case "java.util.function.DoublePredicate" => UnkindedType.mkImpureArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkBool(loc), loc)
+    case "java.util.function.DoubleUnaryOperator" => UnkindedType.mkImpureArrow(UnkindedType.mkFloat64(loc), UnkindedType.mkFloat64(loc), loc)
+    case _ => UnkindedType.Cst(TypeConstructor.Native(clazz), loc)
   }
 
   /**
@@ -2866,5 +3029,62 @@ object Resolver {
     case class Def(defn: NamedAst.Declaration.Def) extends DefOrSig
 
     case class Sig(sig: NamedAst.Declaration.Sig) extends DefOrSig
+  }
+
+  /**
+    * Union of symbols and Java Names.
+    */
+  private sealed trait DeclarationOrJavaClass
+
+  private object DeclarationOrJavaClass {
+    case class Declaration(decl: NamedAst.Declaration) extends DeclarationOrJavaClass
+
+    case class JavaClass(clazz: Class[_]) extends DeclarationOrJavaClass
+  }
+
+  /**
+    * A table of all the symbols in the program.
+    */
+  private case class SymbolTable(classes: Map[Symbol.ClassSym, ResolvedAst.Class],
+                                 instances: ListMap[Symbol.ClassSym, ResolvedAst.Instance],
+                                 defs: Map[Symbol.DefnSym, ResolvedAst.Def],
+                                 enums: Map[Symbol.EnumSym, ResolvedAst.Enum],
+                                 effects: Map[Symbol.EffectSym, ResolvedAst.Effect],
+                                 typeAliases: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias]) {
+    def addClass(clazz: ResolvedAst.Class): SymbolTable = copy(classes = classes + (clazz.sym -> clazz))
+
+    def addDef(defn: ResolvedAst.Def): SymbolTable = copy(defs = defs + (defn.sym -> defn))
+
+    def addEnum(enum: ResolvedAst.Enum): SymbolTable = copy(enums = enums + (enum.sym -> enum))
+
+    def addEffect(effect: ResolvedAst.Effect): SymbolTable = copy(effects = effects + (effect.sym -> effect))
+
+    def addTypeAlias(alias: ResolvedAst.TypeAlias): SymbolTable = copy(typeAliases = typeAliases + (alias.sym -> alias))
+
+    def addInstance(inst: ResolvedAst.Instance): SymbolTable = copy(instances = instances + (inst.sym.clazz -> inst))
+
+    def ++(that: SymbolTable): SymbolTable = {
+      SymbolTable(
+        classes = this.classes ++ that.classes,
+        instances = this.instances ++ that.instances,
+        defs = this.defs ++ that.defs,
+        enums = this.enums ++ that.enums,
+        effects = this.effects ++ that.effects,
+        typeAliases = this.typeAliases ++ that.typeAliases
+      )
+    }
+  }
+
+  private object SymbolTable {
+    val empty: SymbolTable = SymbolTable(Map.empty, ListMap.empty, Map.empty, Map.empty, Map.empty, Map.empty)
+
+    /**
+      * Traverses `xs`, gathering the symbols from each element by applying the function `f`.
+      */
+    def traverse[T](xs: Iterable[T])(f: T => SymbolTable): SymbolTable = {
+      xs.foldLeft(SymbolTable.empty) {
+        case (acc, x) => acc ++ f(x)
+      }
+    }
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -79,7 +79,7 @@ object Resolver {
               case () =>
                 ResolvedAst.Root(
                   table.classes,
-                  table.instances.m, // TODO use ListMap elsewhere for this too
+                  table.instances.m, // TODO NS-REFACTOR use ListMap elsewhere for this too
                   table.defs,
                   table.enums,
                   table.effects,
@@ -288,7 +288,7 @@ object Resolver {
     */
   private def visitDecl(decl: NamedAst.Declaration, uenv0: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Declaration, ResolutionError] = decl match {
     case Declaration.Namespace(sym, usesAndImports0, decls0, loc) =>
-      // TODO move to helper for consistency
+      // TODO NS-REFACTOR move to helper for consistency
       val usesAndImportsVal = traverse(usesAndImports0)(visitUseOrImport(_, ns0, root))
       flatMapN(usesAndImportsVal) {
         case usesAndImports =>
@@ -488,7 +488,7 @@ object Resolver {
     */
   private def resolveEffect(eff0: NamedAst.Declaration.Effect, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Effect, ResolutionError] = eff0 match {
     case NamedAst.Declaration.Effect(doc, ann0, mod, sym, ops0, loc) =>
-      // TODO maybe start a new uenv
+      // TODO NS-REFACTOR maybe start a new uenv
       val annVal = traverse(ann0)(visitAnnotation(_, uenv, taenv, ns0, root))
       val opsVal = traverse(ops0)(resolveOp(_, uenv, taenv, ns0, root))
       mapN(annVal, opsVal) {
@@ -1704,8 +1704,6 @@ object Resolver {
       case Some(op) => op.toSuccess
     }
   }
-
-  // TODO can replace uses of this by direct case lookup later
 
   /**
     * Finds the enum that matches the given qualified name `qname` and `tag` in the namespace `ns0`.

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -714,6 +714,17 @@ object Resolver {
             case DefOrSig.Sig(sig) => visitApplySig(app, sig, exps, uenv0, region, innerLoc, outerLoc)
           }
 
+        case app@NamedAst.Expression.Apply(NamedAst.Expression.UnqualifiedDefOrSig(ident, env, innerLoc), exps, outerLoc) =>
+          tryLookupName2(Name.mkQName(ident), uenv0, ns0, root) match {
+            // If the name is a declaration or sig, use it.
+            case DeclarationOrJavaClass.Declaration(defn: NamedAst.Declaration.Def) :: _ =>
+              visitApplyDef(app, defn, exps, uenv0, region, innerLoc, outerLoc)
+            case DeclarationOrJavaClass.Declaration(sig: NamedAst.Declaration.Sig) :: _ =>
+              visitApplySig(app, sig, exps, uenv0, region, innerLoc, outerLoc)
+            // If not, assume it's a lambda and visit normally.
+            case _ => visitApply(app, uenv0, region)
+          }
+
         case app@NamedAst.Expression.Apply(_, _, _) =>
           visitApply(app, uenv0, region)
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -23,35 +23,35 @@ import org.scalatest.FunSuite
 
 class TestNamer extends FunSuite with TestUtils {
 
-  // TODO NS-REFACTOR move these to Redundancy
+  // TODO NS-REFACTOR move to Redundancy
+  ignore("AmbiguousVarOrUse.01") {
+    val input =
+      s"""
+         |def foo(): Bool =
+         |    use Foo.f;
+         |    let f = _ -> true;
+         |    f(123)
+         |
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.AmbiguousVarOrUse](result)
+  }
 
-//  test("AmbiguousVarOrUse.01") {
-//    val input =
-//      s"""
-//         |def foo(): Bool =
-//         |    use Foo.f;
-//         |    let f = _ -> true;
-//         |    f(123)
-//         |
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.AmbiguousVarOrUse](result)
-//  }
-//
-//  test("AmbiguousVarOrUse.02") {
-//    val input =
-//      s"""
-//         |def foo(): Bool =
-//         |    use Foo.f;
-//         |    let f = _ -> true;
-//         |    use Foo.g;
-//         |    let g = _ -> true;
-//         |    f(g(123))
-//         |
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.AmbiguousVarOrUse](result)
-//  }
+  // TODO NS-REFACTOR move to Redundancy
+  ignore("AmbiguousVarOrUse.02") {
+    val input =
+      s"""
+         |def foo(): Bool =
+         |    use Foo.f;
+         |    let f = _ -> true;
+         |    use Foo.g;
+         |    let g = _ -> true;
+         |    f(g(123))
+         |
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.AmbiguousVarOrUse](result)
+  }
 
   test("DuplicateLowerName.01") {
     val input =
@@ -233,411 +233,427 @@ class TestNamer extends FunSuite with TestUtils {
     expectError[NameError.DuplicateLowerName](result)
   }
 
-  // TODO NS-REFACTOR these errors will be moved to Redundancy
-//  test("DuplicateUseLower.01") {
-//    val input =
-//      s"""
-//         |def foo(): Bool =
-//         |    use A.f;
-//         |    use B.f;
-//         |    f() == f()
-//         |
-//         |namespace A {
-//         |    def f(): Int = 1
-//         |}
-//         |
-//         |namespace B {
-//         |    def f(): Int = 1
-//         |}
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUseLower](result)
-//  }
-//
-//  test("DuplicateUseLower.02") {
-//    val input =
-//      s"""
-//         |use A.f
-//         |use B.f
-//         |
-//         |def foo(): Bool =
-//         |    f() == f()
-//         |
-//         |namespace A {
-//         |    pub def f(): Int = 1
-//         |}
-//         |
-//         |namespace B {
-//         |    pub def f(): Int = 1
-//         |}
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUseLower](result)
-//  }
-//
-//  test("DuplicateUseLower.03") {
-//    val input =
-//      s"""
-//         |use A.f
-//         |
-//         |def foo(): Bool =
-//         |    use B.f;
-//         |    f() == f()
-//         |
-//         |namespace A {
-//         |    pub def f(): Int = 1
-//         |}
-//         |
-//         |namespace B {
-//         |    pub def f(): Int = 1
-//         |}
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUseLower](result)
-//  }
-//
-//  test("DuplicateUseLower.04") {
-//    val input =
-//      s"""
-//         |def foo(): Bool =
-//         |    use A.{f => g, f => g};
-//         |    g() == g()
-//         |
-//         |namespace A {
-//         |    pub def f(): Int = 1
-//         |}
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUseLower](result)
-//  }
-//
-//
-//  test("DuplicateUseLower.05") {
-//    val input =
-//      s"""
-//         |namespace T {
-//         |    def foo(): Bool =
-//         |        use A.f;
-//         |        use B.f;
-//         |        f() == f()
-//         |}
-//         |
-//         |namespace A {
-//         |    pub def f(): Int = 1
-//         |}
-//         |
-//         |namespace B {
-//         |    pub def f(): Int = 1
-//         |}
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUseLower](result)
-//  }
-//
-//  test("DuplicateUseLower.06") {
-//    val input =
-//      s"""
-//         |namespace T {
-//         |    use A.f
-//         |    use B.f
-//         |    def foo(): Bool =
-//         |        f() == f()
-//         |}
-//         |
-//         |namespace A {
-//         |    pub def f(): Int = 1
-//         |}
-//         |
-//         |namespace B {
-//         |    pub def f(): Int = 1
-//         |}
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUseLower](result)
-//  }
-//
-//  test("DuplicateUseLower.07") {
-//    val input =
-//      s"""
-//         |namespace T {
-//         |    use A.{f => g, f => g}
-//         |    def foo(): Bool =
-//         |        g() == g()
-//         |}
-//         |
-//         |namespace A {
-//         |    pub def f(): Int = 1
-//         |}
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUseLower](result)
-//  }
-//
-//  test("DuplicateUseLower.08") {
-//    val input =
-//      s"""
-//         |namespace T {
-//         |    use A.f
-//         |    def foo(): Bool =
-//         |        use B.f;
-//         |        f() == f()
-//         |}
-//         |
-//         |namespace A {
-//         |    pub def f(): Int = 1
-//         |}
-//         |
-//         |namespace B {
-//         |    pub def f(): Int = 1
-//         |}
-//         |""".stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUseLower](result)
-//  }
-//
-//  test("DuplicateUseUpper.01") {
-//    val input =
-//      s"""
-//         |def foo(): Bool =
-//         |    use A.Color;
-//         |    use B.Color;
-//         |    true
-//         |
-//         |namespace A {
-//         |    enum Color {
-//         |        case Red, Blue
-//         |    }
-//         |}
-//         |
-//         |namespace B {
-//         |    enum Color {
-//         |        case Red, Blue
-//         |    }
-//         |}
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUpperName](result)
-//  }
-//
-//  test("DuplicateUseUpper.02") {
-//    val input =
-//      s"""
-//         |use A.Color
-//         |use B.Color
-//         |
-//         |def foo(): Bool = true
-//         |
-//         |namespace A {
-//         |    enum Color {
-//         |        case Red, Blue
-//         |    }
-//         |}
-//         |
-//         |namespace B {
-//         |    enum Color {
-//         |        case Red, Blue
-//         |    }
-//         |}
-//         |
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUpperName](result)
-//  }
-//
-//  test("DuplicateUseUpper.03") {
-//    val input =
-//      s"""
-//         |namespace T {
-//         |    use A.Color
-//         |    use B.Color
-//         |    def foo(): Bool =
-//         |        true
-//         |}
-//         |
-//         |namespace A {
-//         |    enum Color {
-//         |        case Red, Blue
-//         |    }
-//         |}
-//         |
-//         |namespace B {
-//         |    enum Color {
-//         |        case Red, Blue
-//         |    }
-//         |}
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUpperName](result)
-//  }
-//
-//  test("DuplicateUseTag.01") {
-//    val input =
-//      s"""
-//         |def foo(): Bool =
-//         |    use A.Color.Red;
-//         |    use B.Color.Red;
-//         |    Red == Red
-//         |
-//         |namespace A {
-//         |    enum Color {
-//         |        case Red, Blu
-//         |    }
-//         |}
-//         |
-//         |namespace B {
-//         |    enum Color {
-//         |        case Red, Blu
-//         |    }
-//         |}
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUseTag](result)
-//  }
-//
-//  test("DuplicateUseTag.02") {
-//    val input =
-//      s"""
-//         |use A.Color.Red
-//         |use B.Color.Red
-//         |def foo(): Bool =
-//         |    Red == Red
-//         |
-//         |namespace A {
-//         |    enum Color {
-//         |        case Red, Blu
-//         |    }
-//         |}
-//         |
-//         |namespace B {
-//         |    enum Color {
-//         |        case Red, Blu
-//         |    }
-//         |}
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUseTag](result)
-//  }
-//
-//  test("DuplicateUseTag.03") {
-//    val input =
-//      s"""
-//         |
-//         |use A.Color.Red
-//         |def foo(): Bool =
-//         |    use B.Color.Red;
-//         |    Red == Red
-//         |
-//         |namespace A {
-//         |    enum Color {
-//         |        case Red, Blu
-//         |    }
-//         |}
-//         |
-//         |namespace B {
-//         |    enum Color {
-//         |        case Red, Blu
-//         |    }
-//         |}
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUseTag](result)
-//  }
-//
-//  test("DuplicateUseTag.04") {
-//    val input =
-//      s"""
-//         |def foo(): Bool =
-//         |    use B.Color.{Red => R};
-//         |    use B.Color.{Blu => R};
-//         |    R == R
-//         |
-//         |namespace A {
-//         |    enum Color {
-//         |        case Red, Blu
-//         |    }
-//         |}
-//         |
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUseTag](result)
-//  }
-//
-//  test("DuplicateUseTag.05") {
-//    val input =
-//      s"""
-//         |namespace T {
-//         |    use A.Color.Red
-//         |    use B.Color.Red
-//         |    def foo(): Bool =
-//         |        Red == Red
-//         |}
-//         |
-//         |def foo(): Bool =
-//         |    use A.Color.Red;
-//         |    use B.Color.Red;
-//         |    Red == Red
-//         |
-//         |namespace A {
-//         |    enum Color {
-//         |        case Red, Blu
-//         |    }
-//         |}
-//         |
-//         |namespace B {
-//         |    enum Color {
-//         |        case Red, Blu
-//         |    }
-//         |}
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUseTag](result)
-//  }
-//
-//  test("DuplicateUseTag.06") {
-//    val input =
-//      s"""
-//         |namespace T {
-//         |    use A.Color.Red
-//         |    def foo(): Bool =
-//         |        use B.Color.Red;
-//         |        Red == Red
-//         |}
-//         |
-//         |namespace A {
-//         |    enum Color {
-//         |        case Red, Blu
-//         |    }
-//         |}
-//         |
-//         |namespace B {
-//         |    enum Color {
-//         |        case Red, Blu
-//         |    }
-//         |}
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUseTag](result)
-//  }
-//
-//  test("DuplicateUseTag.07") {
-//    val input =
-//      s"""
-//         |namespace T {
-//         |    use B.Color.{Red => R}
-//         |    use B.Color.{Blu => R}
-//         |    def foo(): Bool =
-//         |        R == R
-//         |}
-//         |namespace A {
-//         |    enum Color {
-//         |        case Red, Blu
-//         |    }
-//         |}
-//         |
-//       """.stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUseTag](result)
-//  }
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseLower.01") {
+    val input =
+      s"""
+         |def foo(): Bool =
+         |    use A.f;
+         |    use B.f;
+         |    f() == f()
+         |
+         |namespace A {
+         |    def f(): Int = 1
+         |}
+         |
+         |namespace B {
+         |    def f(): Int = 1
+         |}
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUseLower](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseLower.02") {
+    val input =
+      s"""
+         |use A.f
+         |use B.f
+         |
+         |def foo(): Bool =
+         |    f() == f()
+         |
+         |namespace A {
+         |    pub def f(): Int = 1
+         |}
+         |
+         |namespace B {
+         |    pub def f(): Int = 1
+         |}
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUseLower](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseLower.03") {
+    val input =
+      s"""
+         |use A.f
+         |
+         |def foo(): Bool =
+         |    use B.f;
+         |    f() == f()
+         |
+         |namespace A {
+         |    pub def f(): Int = 1
+         |}
+         |
+         |namespace B {
+         |    pub def f(): Int = 1
+         |}
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUseLower](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseLower.04") {
+    val input =
+      s"""
+         |def foo(): Bool =
+         |    use A.{f => g, f => g};
+         |    g() == g()
+         |
+         |namespace A {
+         |    pub def f(): Int = 1
+         |}
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUseLower](result)
+  }
+
+
+  ignore("DuplicateUseLower.05") {
+    val input =
+      s"""
+         |namespace T {
+         |    def foo(): Bool =
+         |        use A.f;
+         |        use B.f;
+         |        f() == f()
+         |}
+         |
+         |namespace A {
+         |    pub def f(): Int = 1
+         |}
+         |
+         |namespace B {
+         |    pub def f(): Int = 1
+         |}
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUseLower](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseLower.06") {
+    val input =
+      s"""
+         |namespace T {
+         |    use A.f
+         |    use B.f
+         |    def foo(): Bool =
+         |        f() == f()
+         |}
+         |
+         |namespace A {
+         |    pub def f(): Int = 1
+         |}
+         |
+         |namespace B {
+         |    pub def f(): Int = 1
+         |}
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUseLower](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseLower.07") {
+    val input =
+      s"""
+         |namespace T {
+         |    use A.{f => g, f => g}
+         |    def foo(): Bool =
+         |        g() == g()
+         |}
+         |
+         |namespace A {
+         |    pub def f(): Int = 1
+         |}
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUseLower](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseLower.08") {
+    val input =
+      s"""
+         |namespace T {
+         |    use A.f
+         |    def foo(): Bool =
+         |        use B.f;
+         |        f() == f()
+         |}
+         |
+         |namespace A {
+         |    pub def f(): Int = 1
+         |}
+         |
+         |namespace B {
+         |    pub def f(): Int = 1
+         |}
+         |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUseLower](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseUpper.01") {
+    val input =
+      s"""
+         |def foo(): Bool =
+         |    use A.Color;
+         |    use B.Color;
+         |    true
+         |
+         |namespace A {
+         |    enum Color {
+         |        case Red, Blue
+         |    }
+         |}
+         |
+         |namespace B {
+         |    enum Color {
+         |        case Red, Blue
+         |    }
+         |}
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseUpper.02") {
+    val input =
+      s"""
+         |use A.Color
+         |use B.Color
+         |
+         |def foo(): Bool = true
+         |
+         |namespace A {
+         |    enum Color {
+         |        case Red, Blue
+         |    }
+         |}
+         |
+         |namespace B {
+         |    enum Color {
+         |        case Red, Blue
+         |    }
+         |}
+         |
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseUpper.03") {
+    val input =
+      s"""
+         |namespace T {
+         |    use A.Color
+         |    use B.Color
+         |    def foo(): Bool =
+         |        true
+         |}
+         |
+         |namespace A {
+         |    enum Color {
+         |        case Red, Blue
+         |    }
+         |}
+         |
+         |namespace B {
+         |    enum Color {
+         |        case Red, Blue
+         |    }
+         |}
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseTag.01") {
+    val input =
+      s"""
+         |def foo(): Bool =
+         |    use A.Color.Red;
+         |    use B.Color.Red;
+         |    Red == Red
+         |
+         |namespace A {
+         |    enum Color {
+         |        case Red, Blu
+         |    }
+         |}
+         |
+         |namespace B {
+         |    enum Color {
+         |        case Red, Blu
+         |    }
+         |}
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUseTag](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseTag.02") {
+    val input =
+      s"""
+         |use A.Color.Red
+         |use B.Color.Red
+         |def foo(): Bool =
+         |    Red == Red
+         |
+         |namespace A {
+         |    enum Color {
+         |        case Red, Blu
+         |    }
+         |}
+         |
+         |namespace B {
+         |    enum Color {
+         |        case Red, Blu
+         |    }
+         |}
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUseTag](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseTag.03") {
+    val input =
+      s"""
+         |
+         |use A.Color.Red
+         |def foo(): Bool =
+         |    use B.Color.Red;
+         |    Red == Red
+         |
+         |namespace A {
+         |    enum Color {
+         |        case Red, Blu
+         |    }
+         |}
+         |
+         |namespace B {
+         |    enum Color {
+         |        case Red, Blu
+         |    }
+         |}
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUseTag](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseTag.04") {
+    val input =
+      s"""
+         |def foo(): Bool =
+         |    use B.Color.{Red => R};
+         |    use B.Color.{Blu => R};
+         |    R == R
+         |
+         |namespace A {
+         |    enum Color {
+         |        case Red, Blu
+         |    }
+         |}
+         |
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUseTag](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseTag.05") {
+    val input =
+      s"""
+         |namespace T {
+         |    use A.Color.Red
+         |    use B.Color.Red
+         |    def foo(): Bool =
+         |        Red == Red
+         |}
+         |
+         |def foo(): Bool =
+         |    use A.Color.Red;
+         |    use B.Color.Red;
+         |    Red == Red
+         |
+         |namespace A {
+         |    enum Color {
+         |        case Red, Blu
+         |    }
+         |}
+         |
+         |namespace B {
+         |    enum Color {
+         |        case Red, Blu
+         |    }
+         |}
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUseTag](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseTag.06") {
+    val input =
+      s"""
+         |namespace T {
+         |    use A.Color.Red
+         |    def foo(): Bool =
+         |        use B.Color.Red;
+         |        Red == Red
+         |}
+         |
+         |namespace A {
+         |    enum Color {
+         |        case Red, Blu
+         |    }
+         |}
+         |
+         |namespace B {
+         |    enum Color {
+         |        case Red, Blu
+         |    }
+         |}
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUseTag](result)
+  }
+
+  // TODO NS-REFACTOR move to redundancy
+  ignore("DuplicateUseTag.07") {
+    val input =
+      s"""
+         |namespace T {
+         |    use B.Color.{Red => R}
+         |    use B.Color.{Blu => R}
+         |    def foo(): Bool =
+         |        R == R
+         |}
+         |namespace A {
+         |    enum Color {
+         |        case Red, Blu
+         |    }
+         |}
+         |
+       """.stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUseTag](result)
+  }
 
   test("DuplicateUpperName.01") {
     val input =
@@ -903,17 +919,17 @@ class TestNamer extends FunSuite with TestUtils {
     expectError[NameError.DuplicateUpperName](result)
   }
 
-  // TODO NS-REFACTOR move to redundancy
-//  test("DuplicateUpperName.21") {
-//    val input =
-//      """
-//        |import java.sql.Statement
-//        |enum Statement
-//        |""".stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUpperName](result)
-//  }
-//
+  // TODO NS-REFACTOR move to Redundancy
+  ignore("DuplicateUpperName.21") {
+    val input =
+      """
+        |import java.sql.Statement
+        |enum Statement
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
+
   test("DuplicateUpperName.22") {
     val input =
       """
@@ -925,64 +941,67 @@ class TestNamer extends FunSuite with TestUtils {
   }
 
   // TODO NS-REFACTOR move to Redundancy
-//  test("DuplicateUpperName.23") {
-//    val input =
-//      """
-//        |use A.Statement
-//        |enum Statement
-//        |""".stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUpperName](result)
-//  }
-//
-//  test("DuplicateUpperName.24") {
-//    val input =
-//      """
-//        |namespace A {
-//        |    import java.sql.Statement
-//        |    enum Statement
-//        |}
-//        |""".stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUpperName](result)
-//  }
+  ignore("DuplicateUpperName.23") {
+    val input =
+      """
+        |use A.Statement
+        |enum Statement
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
 
-  // TODO NS-REFACTOR move these tests to Redundancy
-//  test("DuplicateUpperName.25") {
-//    val input =
-//      """
-//        |namespace A {
-//        |    use B.Statement
-//        |    import java.sql.Statement
-//        |}
-//        |""".stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUpperName](result)
-//  }
-//
-//  test("DuplicateUpperName.26") {
-//    val input =
-//      """
-//        |enum Statement
-//        |namespace A {
-//        |    use B.Statement
-//        |}
-//        |""".stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUpperName](result)
-//  }
-//
-//  test("DuplicateUpperName.27") {
-//    val input =
-//      """
-//        |enum Statement
-//        |namespace A {
-//        |    import B.Statement
-//        |}
-//        |""".stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUpperName](result)
-//  }
+  // TODO NS-REFACTOR move to Redundancy
+  ignore("DuplicateUpperName.24") {
+    val input =
+      """
+        |namespace A {
+        |    import java.sql.Statement
+        |    enum Statement
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
+
+  // TODO NS-REFACTOR move to Redundancy
+  ignore("DuplicateUpperName.25") {
+    val input =
+      """
+        |namespace A {
+        |    use B.Statement
+        |    import java.sql.Statement
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
+
+  // TODO NS-REFACTOR move to Redundancy
+  ignore("DuplicateUpperName.26") {
+    val input =
+      """
+        |enum Statement
+        |namespace A {
+        |    use B.Statement
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
+
+  // TODO NS-REFACTOR move to Redundancy
+  ignore("DuplicateUpperName.27") {
+    val input =
+      """
+        |enum Statement
+        |namespace A {
+        |    import B.Statement
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
 
   test("SuspiciousTypeVarName.01") {
     val input =
@@ -1159,50 +1178,53 @@ class TestNamer extends FunSuite with TestUtils {
     expectError[NameError.IllegalSignature](result)
   }
 
-  // TODO NS-REFACTOR move these tests to Redundancy
-//  test("DuplicateImport.01") {
-//    val input =
-//      """
-//        |import java.lang.StringBuffer
-//        |import java.lang.StringBuffer
-//        |""".stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUpperName](result)
-//  }
-//
-//  test("DuplicateImport.02") {
-//    val input =
-//      """
-//        |import java.lang.{StringBuffer => StringThingy}
-//        |import java.lang.{StringBuffer => StringThingy}
-//        |""".stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUpperName](result)
-//  }
-//
-//  test("DuplicateImport.03") {
-//    val input =
-//      """
-//        |namespace A {
-//        |    import java.lang.StringBuffer
-//        |    import java.lang.StringBuffer
-//        |}
-//        |""".stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUpperName](result)
-//  }
-//
-//  test("DuplicateImport.04") {
-//    val input =
-//      """
-//        |namespace A {
-//        |    import java.lang.{StringBuffer => StringThingy}
-//        |    import java.lang.{StringBuilder => StringThingy}
-//        |}
-//        |""".stripMargin
-//    val result = compile(input, Options.TestWithLibNix)
-//    expectError[NameError.DuplicateUpperName](result)
-//  }
+  // TODO NS-REFACTOR move to Redundancy
+  ignore("DuplicateImport.01") {
+    val input =
+      """
+        |import java.lang.StringBuffer
+        |import java.lang.StringBuffer
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
+
+  // TODO NS-REFACTOR move to Redundancy
+  ignore("DuplicateImport.02") {
+    val input =
+      """
+        |import java.lang.{StringBuffer => StringThingy}
+        |import java.lang.{StringBuffer => StringThingy}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
+
+  // TODO NS-REFACTOR move to Redundancy
+  ignore("DuplicateImport.03") {
+    val input =
+      """
+        |namespace A {
+        |    import java.lang.StringBuffer
+        |    import java.lang.StringBuffer
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
+
+  // TODO NS-REFACTOR move to Redundancy
+  ignore("DuplicateImport.04") {
+    val input =
+      """
+        |namespace A {
+        |    import java.lang.{StringBuffer => StringThingy}
+        |    import java.lang.{StringBuilder => StringThingy}
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[NameError.DuplicateUpperName](result)
+  }
 
   test("IllegalWildType.01") {
     val input =

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -23,33 +23,35 @@ import org.scalatest.FunSuite
 
 class TestNamer extends FunSuite with TestUtils {
 
-  test("AmbiguousVarOrUse.01") {
-    val input =
-      s"""
-         |def foo(): Bool =
-         |    use Foo.f;
-         |    let f = _ -> true;
-         |    f(123)
-         |
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.AmbiguousVarOrUse](result)
-  }
+  // TODO move these to Redundancy
 
-  test("AmbiguousVarOrUse.02") {
-    val input =
-      s"""
-         |def foo(): Bool =
-         |    use Foo.f;
-         |    let f = _ -> true;
-         |    use Foo.g;
-         |    let g = _ -> true;
-         |    f(g(123))
-         |
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.AmbiguousVarOrUse](result)
-  }
+//  test("AmbiguousVarOrUse.01") {
+//    val input =
+//      s"""
+//         |def foo(): Bool =
+//         |    use Foo.f;
+//         |    let f = _ -> true;
+//         |    f(123)
+//         |
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.AmbiguousVarOrUse](result)
+//  }
+//
+//  test("AmbiguousVarOrUse.02") {
+//    val input =
+//      s"""
+//         |def foo(): Bool =
+//         |    use Foo.f;
+//         |    let f = _ -> true;
+//         |    use Foo.g;
+//         |    let g = _ -> true;
+//         |    f(g(123))
+//         |
+//       """.stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.AmbiguousVarOrUse](result)
+//  }
 
   test("DuplicateLowerName.01") {
     val input =
@@ -901,16 +903,17 @@ class TestNamer extends FunSuite with TestUtils {
     expectError[NameError.DuplicateUpperName](result)
   }
 
-  test("DuplicateUpperName.21") {
-    val input =
-      """
-        |import java.sql.Statement
-        |enum Statement
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUpperName](result)
-  }
-
+  // TODO move to redundancy
+//  test("DuplicateUpperName.21") {
+//    val input =
+//      """
+//        |import java.sql.Statement
+//        |enum Statement
+//        |""".stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUpperName](result)
+//  }
+//
   test("DuplicateUpperName.22") {
     val input =
       """
@@ -921,27 +924,28 @@ class TestNamer extends FunSuite with TestUtils {
     expectError[NameError.DuplicateUpperName](result)
   }
 
-  test("DuplicateUpperName.23") {
-    val input =
-      """
-        |use A.Statement
-        |enum Statement
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUpperName](result)
-  }
-
-  test("DuplicateUpperName.24") {
-    val input =
-      """
-        |namespace A {
-        |    import java.sql.Statement
-        |    enum Statement
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[NameError.DuplicateUpperName](result)
-  }
+  // TODO move to Redundancy
+//  test("DuplicateUpperName.23") {
+//    val input =
+//      """
+//        |use A.Statement
+//        |enum Statement
+//        |""".stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUpperName](result)
+//  }
+//
+//  test("DuplicateUpperName.24") {
+//    val input =
+//      """
+//        |namespace A {
+//        |    import java.sql.Statement
+//        |    enum Statement
+//        |}
+//        |""".stripMargin
+//    val result = compile(input, Options.TestWithLibNix)
+//    expectError[NameError.DuplicateUpperName](result)
+//  }
 
   // TODO move these tests to Redundancy
 //  test("DuplicateUpperName.25") {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -23,7 +23,7 @@ import org.scalatest.FunSuite
 
 class TestNamer extends FunSuite with TestUtils {
 
-  // TODO move these to Redundancy
+  // TODO NS-REFACTOR move these to Redundancy
 
 //  test("AmbiguousVarOrUse.01") {
 //    val input =
@@ -233,7 +233,7 @@ class TestNamer extends FunSuite with TestUtils {
     expectError[NameError.DuplicateLowerName](result)
   }
 
-  // TODO these errors will be moved to Redundancy
+  // TODO NS-REFACTOR these errors will be moved to Redundancy
 //  test("DuplicateUseLower.01") {
 //    val input =
 //      s"""
@@ -903,7 +903,7 @@ class TestNamer extends FunSuite with TestUtils {
     expectError[NameError.DuplicateUpperName](result)
   }
 
-  // TODO move to redundancy
+  // TODO NS-REFACTOR move to redundancy
 //  test("DuplicateUpperName.21") {
 //    val input =
 //      """
@@ -924,7 +924,7 @@ class TestNamer extends FunSuite with TestUtils {
     expectError[NameError.DuplicateUpperName](result)
   }
 
-  // TODO move to Redundancy
+  // TODO NS-REFACTOR move to Redundancy
 //  test("DuplicateUpperName.23") {
 //    val input =
 //      """
@@ -947,7 +947,7 @@ class TestNamer extends FunSuite with TestUtils {
 //    expectError[NameError.DuplicateUpperName](result)
 //  }
 
-  // TODO move these tests to Redundancy
+  // TODO NS-REFACTOR move these tests to Redundancy
 //  test("DuplicateUpperName.25") {
 //    val input =
 //      """
@@ -1159,7 +1159,7 @@ class TestNamer extends FunSuite with TestUtils {
     expectError[NameError.IllegalSignature](result)
   }
 
-  // TODO move these tests to Redundancy
+  // TODO NS-REFACTOR move these tests to Redundancy
 //  test("DuplicateImport.01") {
 //    val input =
 //      """

--- a/main/test/flix/Test.Java.Function.flix
+++ b/main/test/flix/Test.Java.Function.flix
@@ -20,18 +20,18 @@ namespace Test/Java/Function {
     import java.util.stream.DoubleStream
     import java.util.stream.Stream
 
-    @Test
-    def testFunction(): Bool \ IO = {
-        import static java.util.stream.Stream.of(Object): Stream \ IO;
-        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
-        import java.util.Optional.get(): Object;
-        import java.lang.Object.toString(): String;
-        let mkObject = i -> new Object {
-            def toString(_this: Object): String = "${i}"
-        };
-        let stream = of(mkObject(42));
-        toString(get(findFirst(stream))) == "42"
-    }
+//    @Test
+//    def testFunction(): Bool \ IO = {
+//        import static java.util.stream.Stream.of(Object): Stream \ IO;
+//        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
+//        import java.util.Optional.get(): Object;
+//        import java.lang.Object.toString(): String;
+//        let mkObject = i -> new Object {
+//            def toString(_this: Object): String = "${i}"
+//        };
+//        let stream = of(mkObject(42));
+//        toString(get(findFirst(stream))) == "42"
+//    }
 
     @Test
     def testConsumer(): Bool \ IO = {
@@ -47,163 +47,163 @@ namespace Test/Java/Function {
         deref st == "8"
     }
 
-    @Test
-    def testPredicate(): Bool \ IO = {
-        import static java.util.stream.Stream.of(Array[Object, Static]): Stream \ IO;
-        import java.util.stream.Stream.filter(Predicate): Stream \ IO;
-        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
-        import java.util.Optional.get(): Object;
-        import java.lang.Object.toString(): String;
-        let mkObject = i -> new Object {
-            def toString(_this: Object): String = "${i}"
-        };
-        let stream0 = of([mkObject(1), mkObject(2), mkObject(3), mkObject(4), mkObject(5)]);
-        let stream1 = filter(stream0, obj -> toString(obj) == "5");
-        toString(get(findFirst(stream1))) == "5"
-    }
-
-    @Test
-    def testIntFunction(): Bool \ IO = {
-        import static java.util.stream.IntStream.of(Int32): IntStream \ IO;
-        import java.util.stream.IntStream.mapToObj(IntFunction): Stream \ IO;
-        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
-        import java.util.Optional.get(): Object;
-        import java.lang.Object.toString(): String;
-        let stream0 = of(42);
-        let f = i -> new Object {
-            def toString(_this: Object): String = "${i}"
-        };
-        let stream1 = mapToObj(stream0, f);
-        toString(get(findFirst(stream1))) == "42"
-    }
-
-    @Test
-    def testIntConsumer(): Bool \ IO = {
-        import static java.util.stream.IntStream.range(Int32, Int32): IntStream \ IO;
-        import java.util.stream.IntStream.forEach(IntConsumer): Unit \ IO;
-        let st = ref 0;
-        let stream = range(0, 9);
-        let _ = forEach(stream, i -> st := i);
-        deref st == 8
-    }
-
-    @Test
-    def testIntPredicate(): Bool \ IO = {
-        import static java.util.stream.IntStream.range(Int32, Int32): IntStream \ IO;
-        import java.util.stream.IntStream.filter(IntPredicate): IntStream \ IO;
-        import java.util.stream.IntStream.sum(): Int32 \ IO;
-        let stream0 = range(0, 9);
-        let stream1 = filter(stream0, upcast(i -> i mod 2 == 0));
-        sum(stream1) == 20
-    }
-
-    @Test
-    def testIntUnaryOperator(): Bool \ IO = {
-        import static java.util.stream.IntStream.of(Int32): IntStream \ IO;
-        import java.util.stream.IntStream.map(IntUnaryOperator): IntStream \ IO;
-        import java.util.stream.IntStream.sum(): Int32 \ IO;
-        let stream0 = of(5);
-        let stream1 = map(stream0, upcast(i -> i+7));
-        sum(stream1) == 12
-    }
-
-    @Test
-    def testLongFunction(): Bool \ IO = {
-        import static java.util.stream.LongStream.of(Int64): LongStream \ IO;
-        import java.util.stream.LongStream.mapToObj(LongFunction): Stream \ IO;
-        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
-        import java.util.Optional.get(): Object;
-        import java.lang.Object.toString(): String;
-        let stream0 = of(42i64);
-        let f = i -> new Object {
-            def toString(_this: Object): String = "${i}"
-        };
-        let stream1 = mapToObj(stream0, f);
-        toString(get(findFirst(stream1))) == "42"
-    }
-
-    @Test
-    def testLongConsumer(): Bool \ IO = {
-        import static java.util.stream.LongStream.range(Int64, Int64): LongStream \ IO;
-        import java.util.stream.LongStream.forEach(LongConsumer): Unit \ IO;
-        let st = ref 0i64;
-        let stream = range(0i64, 9i64);
-        let _ = forEach(stream, i -> st := i);
-        deref st == 8i64
-    }
-
-    @Test
-    def testLongPredicate(): Bool \ IO = {
-        import static java.util.stream.LongStream.range(Int64, Int64): LongStream \ IO;
-        import java.util.stream.LongStream.filter(LongPredicate): LongStream \ IO;
-        import java.util.stream.LongStream.sum(): Int64 \ IO;
-        let stream0 = range(0i64, 9i64);
-        let stream1 = filter(stream0, upcast(i -> i mod 2i64 == 0i64));
-        sum(stream1) == 20i64
-    }
-
-    @Test
-    def testLongUnaryOperator(): Bool \ IO = {
-        import static java.util.stream.LongStream.of(Int64): LongStream \ IO;
-        import java.util.stream.LongStream.map(LongUnaryOperator): LongStream \ IO;
-        import java.util.stream.LongStream.sum(): Int64 \ IO;
-        let stream0 = of(5i64);
-        let stream1 = map(stream0, upcast(i -> i+7i64));
-        sum(stream1) == 12i64
-    }
-
-    @Test
-    def testDoubleFunction(): Bool \ IO = {
-        import static java.util.stream.DoubleStream.of(Float64): DoubleStream \ IO;
-        import java.util.stream.DoubleStream.mapToObj(DoubleFunction): Stream \ IO;
-        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
-        import java.util.Optional.get(): Object;
-        import java.lang.Object.toString(): String;
-        let stream0 = of(42.0f64);
-        let f = d -> new Object {
-            def toString(_this: Object): String = match Float64.tryToInt32(d) {
-                case Some(i) => "${i}"
-                case None    => ""
-           }
-        };
-        let stream1 = mapToObj(stream0, f);
-        toString(get(findFirst(stream1))) == "42"
-    }
-
-    @Test
-    def testDoubleConsumer(): Bool \ IO = {
-        import static java.util.stream.DoubleStream.of(Array[Float64, Static]): DoubleStream \ IO;
-        import java.util.stream.DoubleStream.forEach(DoubleConsumer): Unit \ IO;
-        let st = ref 0.0f64;
-        let stream = of([0.0f64, 1.0f64, 2.0f64, 3.0f64, 4.0f64, 5.0f64, 6.0f64, 7.0f64, 8.0f64]);
-        let _ = forEach(stream, i -> st := i);
-        let last = deref st;
-        Float64.tryToInt32(last) == Some(8)
-    }
-
-    @Test
-    def testDoublePredicate(): Bool \ IO = {
-        import static java.util.stream.DoubleStream.of(Array[Float64, Static]): DoubleStream \ IO;
-        import java.util.stream.DoubleStream.filter(DoublePredicate): DoubleStream \ IO;
-        import java.util.stream.DoubleStream.sum(): Float64 \ IO;
-        let stream0 = of([0.0f64, 1.0f64, 2.0f64, 3.0f64, 4.0f64, 5.0f64, 6.0f64, 7.0f64, 8.0f64]);
-        let stream1 = filter(stream0, upcast(d -> match Float64.tryToInt32(d) {
-            case Some(i) => i mod 2 == 0
-            case None    => false
-            }));
-        let tot = sum(stream1);
-        Float64.tryToInt32(tot) == Some(20)
-    }
-
-    @Test
-    def testDoubleUnaryOperator(): Bool \ IO = {
-        import static java.util.stream.DoubleStream.of(Float64): DoubleStream \ IO;
-        import java.util.stream.DoubleStream.map(DoubleUnaryOperator): DoubleStream \ IO;
-        import java.util.stream.DoubleStream.sum(): Float64 \ IO;
-        let stream0 = of(5.0f64);
-        let stream1 = map(stream0, upcast(d -> d + 7.0f64));
-        let tot = sum(stream1);
-        Float64.tryToInt32(tot) == Some(12)
-    }
+//    @Test
+//    def testPredicate(): Bool \ IO = {
+//        import static java.util.stream.Stream.of(Array[Object, Static]): Stream \ IO;
+//        import java.util.stream.Stream.filter(Predicate): Stream \ IO;
+//        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
+//        import java.util.Optional.get(): Object;
+//        import java.lang.Object.toString(): String;
+//        let mkObject = i -> new Object {
+//            def toString(_this: Object): String = "${i}"
+//        };
+//        let stream0 = of([mkObject(1), mkObject(2), mkObject(3), mkObject(4), mkObject(5)]);
+//        let stream1 = filter(stream0, obj -> toString(obj) == "5");
+//        toString(get(findFirst(stream1))) == "5"
+//    }
+//
+//    @Test
+//    def testIntFunction(): Bool \ IO = {
+//        import static java.util.stream.IntStream.of(Int32): IntStream \ IO;
+//        import java.util.stream.IntStream.mapToObj(IntFunction): Stream \ IO;
+//        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
+//        import java.util.Optional.get(): Object;
+//        import java.lang.Object.toString(): String;
+//        let stream0 = of(42);
+//        let f = i -> new Object {
+//            def toString(_this: Object): String = "${i}"
+//        };
+//        let stream1 = mapToObj(stream0, f);
+//        toString(get(findFirst(stream1))) == "42"
+//    }
+//
+//    @Test
+//    def testIntConsumer(): Bool \ IO = {
+//        import static java.util.stream.IntStream.range(Int32, Int32): IntStream \ IO;
+//        import java.util.stream.IntStream.forEach(IntConsumer): Unit \ IO;
+//        let st = ref 0;
+//        let stream = range(0, 9);
+//        let _ = forEach(stream, i -> st := i);
+//        deref st == 8
+//    }
+//
+//    @Test
+//    def testIntPredicate(): Bool \ IO = {
+//        import static java.util.stream.IntStream.range(Int32, Int32): IntStream \ IO;
+//        import java.util.stream.IntStream.filter(IntPredicate): IntStream \ IO;
+//        import java.util.stream.IntStream.sum(): Int32 \ IO;
+//        let stream0 = range(0, 9);
+//        let stream1 = filter(stream0, upcast(i -> i mod 2 == 0));
+//        sum(stream1) == 20
+//    }
+//
+//    @Test
+//    def testIntUnaryOperator(): Bool \ IO = {
+//        import static java.util.stream.IntStream.of(Int32): IntStream \ IO;
+//        import java.util.stream.IntStream.map(IntUnaryOperator): IntStream \ IO;
+//        import java.util.stream.IntStream.sum(): Int32 \ IO;
+//        let stream0 = of(5);
+//        let stream1 = map(stream0, upcast(i -> i+7));
+//        sum(stream1) == 12
+//    }
+//
+//    @Test
+//    def testLongFunction(): Bool \ IO = {
+//        import static java.util.stream.LongStream.of(Int64): LongStream \ IO;
+//        import java.util.stream.LongStream.mapToObj(LongFunction): Stream \ IO;
+//        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
+//        import java.util.Optional.get(): Object;
+//        import java.lang.Object.toString(): String;
+//        let stream0 = of(42i64);
+//        let f = i -> new Object {
+//            def toString(_this: Object): String = "${i}"
+//        };
+//        let stream1 = mapToObj(stream0, f);
+//        toString(get(findFirst(stream1))) == "42"
+//    }
+//
+//    @Test
+//    def testLongConsumer(): Bool \ IO = {
+//        import static java.util.stream.LongStream.range(Int64, Int64): LongStream \ IO;
+//        import java.util.stream.LongStream.forEach(LongConsumer): Unit \ IO;
+//        let st = ref 0i64;
+//        let stream = range(0i64, 9i64);
+//        let _ = forEach(stream, i -> st := i);
+//        deref st == 8i64
+//    }
+//
+//    @Test
+//    def testLongPredicate(): Bool \ IO = {
+//        import static java.util.stream.LongStream.range(Int64, Int64): LongStream \ IO;
+//        import java.util.stream.LongStream.filter(LongPredicate): LongStream \ IO;
+//        import java.util.stream.LongStream.sum(): Int64 \ IO;
+//        let stream0 = range(0i64, 9i64);
+//        let stream1 = filter(stream0, upcast(i -> i mod 2i64 == 0i64));
+//        sum(stream1) == 20i64
+//    }
+//
+//    @Test
+//    def testLongUnaryOperator(): Bool \ IO = {
+//        import static java.util.stream.LongStream.of(Int64): LongStream \ IO;
+//        import java.util.stream.LongStream.map(LongUnaryOperator): LongStream \ IO;
+//        import java.util.stream.LongStream.sum(): Int64 \ IO;
+//        let stream0 = of(5i64);
+//        let stream1 = map(stream0, upcast(i -> i+7i64));
+//        sum(stream1) == 12i64
+//    }
+//
+//    @Test
+//    def testDoubleFunction(): Bool \ IO = {
+//        import static java.util.stream.DoubleStream.of(Float64): DoubleStream \ IO;
+//        import java.util.stream.DoubleStream.mapToObj(DoubleFunction): Stream \ IO;
+//        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
+//        import java.util.Optional.get(): Object;
+//        import java.lang.Object.toString(): String;
+//        let stream0 = of(42.0f64);
+//        let f = d -> new Object {
+//            def toString(_this: Object): String = match Float64.tryToInt32(d) {
+//                case Some(i) => "${i}"
+//                case None    => ""
+//           }
+//        };
+//        let stream1 = mapToObj(stream0, f);
+//        toString(get(findFirst(stream1))) == "42"
+//    }
+//
+//    @Test
+//    def testDoubleConsumer(): Bool \ IO = {
+//        import static java.util.stream.DoubleStream.of(Array[Float64, Static]): DoubleStream \ IO;
+//        import java.util.stream.DoubleStream.forEach(DoubleConsumer): Unit \ IO;
+//        let st = ref 0.0f64;
+//        let stream = of([0.0f64, 1.0f64, 2.0f64, 3.0f64, 4.0f64, 5.0f64, 6.0f64, 7.0f64, 8.0f64]);
+//        let _ = forEach(stream, i -> st := i);
+//        let last = deref st;
+//        Float64.tryToInt32(last) == Some(8)
+//    }
+//
+//    @Test
+//    def testDoublePredicate(): Bool \ IO = {
+//        import static java.util.stream.DoubleStream.of(Array[Float64, Static]): DoubleStream \ IO;
+//        import java.util.stream.DoubleStream.filter(DoublePredicate): DoubleStream \ IO;
+//        import java.util.stream.DoubleStream.sum(): Float64 \ IO;
+//        let stream0 = of([0.0f64, 1.0f64, 2.0f64, 3.0f64, 4.0f64, 5.0f64, 6.0f64, 7.0f64, 8.0f64]);
+//        let stream1 = filter(stream0, upcast(d -> match Float64.tryToInt32(d) {
+//            case Some(i) => i mod 2 == 0
+//            case None    => false
+//            }));
+//        let tot = sum(stream1);
+//        Float64.tryToInt32(tot) == Some(20)
+//    }
+//
+//    @Test
+//    def testDoubleUnaryOperator(): Bool \ IO = {
+//        import static java.util.stream.DoubleStream.of(Float64): DoubleStream \ IO;
+//        import java.util.stream.DoubleStream.map(DoubleUnaryOperator): DoubleStream \ IO;
+//        import java.util.stream.DoubleStream.sum(): Float64 \ IO;
+//        let stream0 = of(5.0f64);
+//        let stream1 = map(stream0, upcast(d -> d + 7.0f64));
+//        let tot = sum(stream1);
+//        Float64.tryToInt32(tot) == Some(12)
+//    }
 
 }

--- a/main/test/flix/Test.Java.Function.flix
+++ b/main/test/flix/Test.Java.Function.flix
@@ -20,18 +20,18 @@ namespace Test/Java/Function {
     import java.util.stream.DoubleStream
     import java.util.stream.Stream
 
-//    @Test
-//    def testFunction(): Bool \ IO = {
-//        import static java.util.stream.Stream.of(Object): Stream \ IO;
-//        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
-//        import java.util.Optional.get(): Object;
-//        import java.lang.Object.toString(): String;
-//        let mkObject = i -> new Object {
-//            def toString(_this: Object): String = "${i}"
-//        };
-//        let stream = of(mkObject(42));
-//        toString(get(findFirst(stream))) == "42"
-//    }
+    @Test
+    def testFunction(): Bool \ IO = {
+        import static java.util.stream.Stream.of(Object): Stream \ IO;
+        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
+        import java.util.Optional.get(): Object;
+        import java.lang.Object.toString(): String;
+        let mkObject = i -> new Object {
+            def toString(_this: Object): String = "${i}"
+        };
+        let stream = of(mkObject(42));
+        toString(get(findFirst(stream))) == "42"
+    }
 
     @Test
     def testConsumer(): Bool \ IO = {
@@ -47,163 +47,163 @@ namespace Test/Java/Function {
         deref st == "8"
     }
 
-//    @Test
-//    def testPredicate(): Bool \ IO = {
-//        import static java.util.stream.Stream.of(Array[Object, Static]): Stream \ IO;
-//        import java.util.stream.Stream.filter(Predicate): Stream \ IO;
-//        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
-//        import java.util.Optional.get(): Object;
-//        import java.lang.Object.toString(): String;
-//        let mkObject = i -> new Object {
-//            def toString(_this: Object): String = "${i}"
-//        };
-//        let stream0 = of([mkObject(1), mkObject(2), mkObject(3), mkObject(4), mkObject(5)]);
-//        let stream1 = filter(stream0, obj -> toString(obj) == "5");
-//        toString(get(findFirst(stream1))) == "5"
-//    }
-//
-//    @Test
-//    def testIntFunction(): Bool \ IO = {
-//        import static java.util.stream.IntStream.of(Int32): IntStream \ IO;
-//        import java.util.stream.IntStream.mapToObj(IntFunction): Stream \ IO;
-//        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
-//        import java.util.Optional.get(): Object;
-//        import java.lang.Object.toString(): String;
-//        let stream0 = of(42);
-//        let f = i -> new Object {
-//            def toString(_this: Object): String = "${i}"
-//        };
-//        let stream1 = mapToObj(stream0, f);
-//        toString(get(findFirst(stream1))) == "42"
-//    }
-//
-//    @Test
-//    def testIntConsumer(): Bool \ IO = {
-//        import static java.util.stream.IntStream.range(Int32, Int32): IntStream \ IO;
-//        import java.util.stream.IntStream.forEach(IntConsumer): Unit \ IO;
-//        let st = ref 0;
-//        let stream = range(0, 9);
-//        let _ = forEach(stream, i -> st := i);
-//        deref st == 8
-//    }
-//
-//    @Test
-//    def testIntPredicate(): Bool \ IO = {
-//        import static java.util.stream.IntStream.range(Int32, Int32): IntStream \ IO;
-//        import java.util.stream.IntStream.filter(IntPredicate): IntStream \ IO;
-//        import java.util.stream.IntStream.sum(): Int32 \ IO;
-//        let stream0 = range(0, 9);
-//        let stream1 = filter(stream0, upcast(i -> i mod 2 == 0));
-//        sum(stream1) == 20
-//    }
-//
-//    @Test
-//    def testIntUnaryOperator(): Bool \ IO = {
-//        import static java.util.stream.IntStream.of(Int32): IntStream \ IO;
-//        import java.util.stream.IntStream.map(IntUnaryOperator): IntStream \ IO;
-//        import java.util.stream.IntStream.sum(): Int32 \ IO;
-//        let stream0 = of(5);
-//        let stream1 = map(stream0, upcast(i -> i+7));
-//        sum(stream1) == 12
-//    }
-//
-//    @Test
-//    def testLongFunction(): Bool \ IO = {
-//        import static java.util.stream.LongStream.of(Int64): LongStream \ IO;
-//        import java.util.stream.LongStream.mapToObj(LongFunction): Stream \ IO;
-//        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
-//        import java.util.Optional.get(): Object;
-//        import java.lang.Object.toString(): String;
-//        let stream0 = of(42i64);
-//        let f = i -> new Object {
-//            def toString(_this: Object): String = "${i}"
-//        };
-//        let stream1 = mapToObj(stream0, f);
-//        toString(get(findFirst(stream1))) == "42"
-//    }
-//
-//    @Test
-//    def testLongConsumer(): Bool \ IO = {
-//        import static java.util.stream.LongStream.range(Int64, Int64): LongStream \ IO;
-//        import java.util.stream.LongStream.forEach(LongConsumer): Unit \ IO;
-//        let st = ref 0i64;
-//        let stream = range(0i64, 9i64);
-//        let _ = forEach(stream, i -> st := i);
-//        deref st == 8i64
-//    }
-//
-//    @Test
-//    def testLongPredicate(): Bool \ IO = {
-//        import static java.util.stream.LongStream.range(Int64, Int64): LongStream \ IO;
-//        import java.util.stream.LongStream.filter(LongPredicate): LongStream \ IO;
-//        import java.util.stream.LongStream.sum(): Int64 \ IO;
-//        let stream0 = range(0i64, 9i64);
-//        let stream1 = filter(stream0, upcast(i -> i mod 2i64 == 0i64));
-//        sum(stream1) == 20i64
-//    }
-//
-//    @Test
-//    def testLongUnaryOperator(): Bool \ IO = {
-//        import static java.util.stream.LongStream.of(Int64): LongStream \ IO;
-//        import java.util.stream.LongStream.map(LongUnaryOperator): LongStream \ IO;
-//        import java.util.stream.LongStream.sum(): Int64 \ IO;
-//        let stream0 = of(5i64);
-//        let stream1 = map(stream0, upcast(i -> i+7i64));
-//        sum(stream1) == 12i64
-//    }
-//
-//    @Test
-//    def testDoubleFunction(): Bool \ IO = {
-//        import static java.util.stream.DoubleStream.of(Float64): DoubleStream \ IO;
-//        import java.util.stream.DoubleStream.mapToObj(DoubleFunction): Stream \ IO;
-//        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
-//        import java.util.Optional.get(): Object;
-//        import java.lang.Object.toString(): String;
-//        let stream0 = of(42.0f64);
-//        let f = d -> new Object {
-//            def toString(_this: Object): String = match Float64.tryToInt32(d) {
-//                case Some(i) => "${i}"
-//                case None    => ""
-//           }
-//        };
-//        let stream1 = mapToObj(stream0, f);
-//        toString(get(findFirst(stream1))) == "42"
-//    }
-//
-//    @Test
-//    def testDoubleConsumer(): Bool \ IO = {
-//        import static java.util.stream.DoubleStream.of(Array[Float64, Static]): DoubleStream \ IO;
-//        import java.util.stream.DoubleStream.forEach(DoubleConsumer): Unit \ IO;
-//        let st = ref 0.0f64;
-//        let stream = of([0.0f64, 1.0f64, 2.0f64, 3.0f64, 4.0f64, 5.0f64, 6.0f64, 7.0f64, 8.0f64]);
-//        let _ = forEach(stream, i -> st := i);
-//        let last = deref st;
-//        Float64.tryToInt32(last) == Some(8)
-//    }
-//
-//    @Test
-//    def testDoublePredicate(): Bool \ IO = {
-//        import static java.util.stream.DoubleStream.of(Array[Float64, Static]): DoubleStream \ IO;
-//        import java.util.stream.DoubleStream.filter(DoublePredicate): DoubleStream \ IO;
-//        import java.util.stream.DoubleStream.sum(): Float64 \ IO;
-//        let stream0 = of([0.0f64, 1.0f64, 2.0f64, 3.0f64, 4.0f64, 5.0f64, 6.0f64, 7.0f64, 8.0f64]);
-//        let stream1 = filter(stream0, upcast(d -> match Float64.tryToInt32(d) {
-//            case Some(i) => i mod 2 == 0
-//            case None    => false
-//            }));
-//        let tot = sum(stream1);
-//        Float64.tryToInt32(tot) == Some(20)
-//    }
-//
-//    @Test
-//    def testDoubleUnaryOperator(): Bool \ IO = {
-//        import static java.util.stream.DoubleStream.of(Float64): DoubleStream \ IO;
-//        import java.util.stream.DoubleStream.map(DoubleUnaryOperator): DoubleStream \ IO;
-//        import java.util.stream.DoubleStream.sum(): Float64 \ IO;
-//        let stream0 = of(5.0f64);
-//        let stream1 = map(stream0, upcast(d -> d + 7.0f64));
-//        let tot = sum(stream1);
-//        Float64.tryToInt32(tot) == Some(12)
-//    }
+    @Test
+    def testPredicate(): Bool \ IO = {
+        import static java.util.stream.Stream.of(Array[Object, Static]): Stream \ IO;
+        import java.util.stream.Stream.filter(Predicate): Stream \ IO;
+        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
+        import java.util.Optional.get(): Object;
+        import java.lang.Object.toString(): String;
+        let mkObject = i -> new Object {
+            def toString(_this: Object): String = "${i}"
+        };
+        let stream0 = of([mkObject(1), mkObject(2), mkObject(3), mkObject(4), mkObject(5)]);
+        let stream1 = filter(stream0, obj -> toString(obj) == "5");
+        toString(get(findFirst(stream1))) == "5"
+    }
+
+    @Test
+    def testIntFunction(): Bool \ IO = {
+        import static java.util.stream.IntStream.of(Int32): IntStream \ IO;
+        import java.util.stream.IntStream.mapToObj(IntFunction): Stream \ IO;
+        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
+        import java.util.Optional.get(): Object;
+        import java.lang.Object.toString(): String;
+        let stream0 = of(42);
+        let f = i -> new Object {
+            def toString(_this: Object): String = "${i}"
+        };
+        let stream1 = mapToObj(stream0, f);
+        toString(get(findFirst(stream1))) == "42"
+    }
+
+    @Test
+    def testIntConsumer(): Bool \ IO = {
+        import static java.util.stream.IntStream.range(Int32, Int32): IntStream \ IO;
+        import java.util.stream.IntStream.forEach(IntConsumer): Unit \ IO;
+        let st = ref 0;
+        let stream = range(0, 9);
+        let _ = forEach(stream, i -> st := i);
+        deref st == 8
+    }
+
+    @Test
+    def testIntPredicate(): Bool \ IO = {
+        import static java.util.stream.IntStream.range(Int32, Int32): IntStream \ IO;
+        import java.util.stream.IntStream.filter(IntPredicate): IntStream \ IO;
+        import java.util.stream.IntStream.sum(): Int32 \ IO;
+        let stream0 = range(0, 9);
+        let stream1 = filter(stream0, upcast(i -> i mod 2 == 0));
+        sum(stream1) == 20
+    }
+
+    @Test
+    def testIntUnaryOperator(): Bool \ IO = {
+        import static java.util.stream.IntStream.of(Int32): IntStream \ IO;
+        import java.util.stream.IntStream.map(IntUnaryOperator): IntStream \ IO;
+        import java.util.stream.IntStream.sum(): Int32 \ IO;
+        let stream0 = of(5);
+        let stream1 = map(stream0, upcast(i -> i+7));
+        sum(stream1) == 12
+    }
+
+    @Test
+    def testLongFunction(): Bool \ IO = {
+        import static java.util.stream.LongStream.of(Int64): LongStream \ IO;
+        import java.util.stream.LongStream.mapToObj(LongFunction): Stream \ IO;
+        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
+        import java.util.Optional.get(): Object;
+        import java.lang.Object.toString(): String;
+        let stream0 = of(42i64);
+        let f = i -> new Object {
+            def toString(_this: Object): String = "${i}"
+        };
+        let stream1 = mapToObj(stream0, f);
+        toString(get(findFirst(stream1))) == "42"
+    }
+
+    @Test
+    def testLongConsumer(): Bool \ IO = {
+        import static java.util.stream.LongStream.range(Int64, Int64): LongStream \ IO;
+        import java.util.stream.LongStream.forEach(LongConsumer): Unit \ IO;
+        let st = ref 0i64;
+        let stream = range(0i64, 9i64);
+        let _ = forEach(stream, i -> st := i);
+        deref st == 8i64
+    }
+
+    @Test
+    def testLongPredicate(): Bool \ IO = {
+        import static java.util.stream.LongStream.range(Int64, Int64): LongStream \ IO;
+        import java.util.stream.LongStream.filter(LongPredicate): LongStream \ IO;
+        import java.util.stream.LongStream.sum(): Int64 \ IO;
+        let stream0 = range(0i64, 9i64);
+        let stream1 = filter(stream0, upcast(i -> i mod 2i64 == 0i64));
+        sum(stream1) == 20i64
+    }
+
+    @Test
+    def testLongUnaryOperator(): Bool \ IO = {
+        import static java.util.stream.LongStream.of(Int64): LongStream \ IO;
+        import java.util.stream.LongStream.map(LongUnaryOperator): LongStream \ IO;
+        import java.util.stream.LongStream.sum(): Int64 \ IO;
+        let stream0 = of(5i64);
+        let stream1 = map(stream0, upcast(i -> i+7i64));
+        sum(stream1) == 12i64
+    }
+
+    @Test
+    def testDoubleFunction(): Bool \ IO = {
+        import static java.util.stream.DoubleStream.of(Float64): DoubleStream \ IO;
+        import java.util.stream.DoubleStream.mapToObj(DoubleFunction): Stream \ IO;
+        import java.util.stream.Stream.findFirst(): ##java.util.Optional \ IO;
+        import java.util.Optional.get(): Object;
+        import java.lang.Object.toString(): String;
+        let stream0 = of(42.0f64);
+        let f = d -> new Object {
+            def toString(_this: Object): String = match Float64.tryToInt32(d) {
+                case Some(i) => "${i}"
+                case None    => ""
+           }
+        };
+        let stream1 = mapToObj(stream0, f);
+        toString(get(findFirst(stream1))) == "42"
+    }
+
+    @Test
+    def testDoubleConsumer(): Bool \ IO = {
+        import static java.util.stream.DoubleStream.of(Array[Float64, Static]): DoubleStream \ IO;
+        import java.util.stream.DoubleStream.forEach(DoubleConsumer): Unit \ IO;
+        let st = ref 0.0f64;
+        let stream = of([0.0f64, 1.0f64, 2.0f64, 3.0f64, 4.0f64, 5.0f64, 6.0f64, 7.0f64, 8.0f64]);
+        let _ = forEach(stream, i -> st := i);
+        let last = deref st;
+        Float64.tryToInt32(last) == Some(8)
+    }
+
+    @Test
+    def testDoublePredicate(): Bool \ IO = {
+        import static java.util.stream.DoubleStream.of(Array[Float64, Static]): DoubleStream \ IO;
+        import java.util.stream.DoubleStream.filter(DoublePredicate): DoubleStream \ IO;
+        import java.util.stream.DoubleStream.sum(): Float64 \ IO;
+        let stream0 = of([0.0f64, 1.0f64, 2.0f64, 3.0f64, 4.0f64, 5.0f64, 6.0f64, 7.0f64, 8.0f64]);
+        let stream1 = filter(stream0, upcast(d -> match Float64.tryToInt32(d) {
+            case Some(i) => i mod 2 == 0
+            case None    => false
+            }));
+        let tot = sum(stream1);
+        Float64.tryToInt32(tot) == Some(20)
+    }
+
+    @Test
+    def testDoubleUnaryOperator(): Bool \ IO = {
+        import static java.util.stream.DoubleStream.of(Float64): DoubleStream \ IO;
+        import java.util.stream.DoubleStream.map(DoubleUnaryOperator): DoubleStream \ IO;
+        import java.util.stream.DoubleStream.sum(): Float64 \ IO;
+        let stream0 = of(5.0f64);
+        let stream1 = map(stream0, upcast(d -> d + 7.0f64));
+        let tot = sum(stream1);
+        Float64.tryToInt32(tot) == Some(12)
+    }
 
 }


### PR DESCRIPTION
Follow-ups:
* rename things to `visitX` in resolver
* improve use of `QName`: a `QName` _is qualified_, otherwise it should just be an `ident`