### PR TITLE
fix: use `unsafe_cast` in Shell

### DIFF
--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -305,7 +305,7 @@ class Shell(sourceProvider: SourceProvider, options: Options) {
         // Cast the println to allow escaping effects
         val src =
           s"""def ${main.name}(): Unit \\ IO =
-             |println($s) as \\ IO
+             |unsafe_cast println($s) as \\ IO
              |""".stripMargin
         flix.addSourceCode("<shell>", src)
         run(main)


### PR DESCRIPTION
Closes https://github.com/flix/flix/issues/5008