### PR TITLE
refactor: remove head/rule split for constraint params

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -275,15 +275,7 @@ object KindedAst {
 
   case class Constraint(cparams: List[KindedAst.ConstraintParam], head: KindedAst.Predicate.Head, body: List[KindedAst.Predicate.Body], loc: SourceLocation)
 
-  sealed trait ConstraintParam
-
-  object ConstraintParam {
-
-    case class HeadParam(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends KindedAst.ConstraintParam
-
-    case class RuleParam(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends KindedAst.ConstraintParam
-
-  }
+  case class ConstraintParam(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation)
 
   case class FormalParam(sym: Symbol.VarSym, mod: Ast.Modifiers, tpe: Type, src: Ast.TypeSource, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -377,15 +377,7 @@ object NamedAst {
 
   case class Constraint(cparams: List[NamedAst.ConstraintParam], head: NamedAst.Predicate.Head, body: List[NamedAst.Predicate.Body], loc: SourceLocation)
 
-  sealed trait ConstraintParam
-
-  object ConstraintParam {
-
-    case class HeadParam(sym: Symbol.VarSym, tpe: NamedAst.Type, loc: SourceLocation) extends NamedAst.ConstraintParam
-
-    case class RuleParam(sym: Symbol.VarSym, tpe: NamedAst.Type, loc: SourceLocation) extends NamedAst.ConstraintParam
-
-  }
+  case class ConstraintParam(sym: Symbol.VarSym, tpe: NamedAst.Type, loc: SourceLocation)
 
   case class FormalParam(sym: Symbol.VarSym, mod: Ast.Modifiers, tpe: NamedAst.Type, src: Ast.TypeSource, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -296,15 +296,7 @@ object ResolvedAst {
 
   case class Constraint(cparams: List[ResolvedAst.ConstraintParam], head: ResolvedAst.Predicate.Head, body: List[ResolvedAst.Predicate.Body], loc: SourceLocation)
 
-  sealed trait ConstraintParam
-
-  object ConstraintParam {
-
-    case class HeadParam(sym: Symbol.VarSym, tpe: UnkindedType, loc: SourceLocation) extends ResolvedAst.ConstraintParam
-
-    case class RuleParam(sym: Symbol.VarSym, tpe: UnkindedType, loc: SourceLocation) extends ResolvedAst.ConstraintParam
-
-  }
+  case class ConstraintParam(sym: Symbol.VarSym, tpe: UnkindedType, loc: SourceLocation)
 
   case class FormalParam(sym: Symbol.VarSym, mod: Ast.Modifiers, tpe: UnkindedType, src: Ast.TypeSource, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -372,21 +372,7 @@ object TypedAst {
 
   case class Constraint(cparams: List[TypedAst.ConstraintParam], head: TypedAst.Predicate.Head, body: List[TypedAst.Predicate.Body], loc: SourceLocation)
 
-  sealed trait ConstraintParam {
-    def sym: Symbol.VarSym
-
-    def tpe: Type
-
-    def loc: SourceLocation
-  }
-
-  object ConstraintParam {
-
-    case class HeadParam(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends TypedAst.ConstraintParam
-
-    case class RuleParam(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends TypedAst.ConstraintParam
-
-  }
+  case class ConstraintParam(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation)
 
   case class FormalParam(sym: Symbol.VarSym, mod: Ast.Modifiers, tpe: Type, src: Ast.TypeSource, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -952,15 +952,10 @@ object Kinder {
     * Performs kinding on the given constraint param under the given kind environment.
     */
   private def visitConstraintParam(cparam0: ResolvedAst.ConstraintParam, kenv: KindEnv, senv: Map[Symbol.UnkindedTypeVarSym, Symbol.UnkindedTypeVarSym], taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.ConstraintParam, KindError] = cparam0 match {
-    case ResolvedAst.ConstraintParam.HeadParam(sym, tpe0, loc) =>
+    case ResolvedAst.ConstraintParam(sym, tpe0, loc) =>
       val tpeVal = visitType(tpe0, Kind.Star, kenv, senv, taenv, root)
       mapN(tpeVal) {
-        case tpe => KindedAst.ConstraintParam.HeadParam(sym, tpe, loc)
-      }
-    case ResolvedAst.ConstraintParam.RuleParam(sym, tpe0, loc) =>
-      val tpeVal = visitType(tpe0, Kind.Star, kenv, senv, taenv, root)
-      mapN(tpeVal) {
-        case tpe => KindedAst.ConstraintParam.RuleParam(sym, tpe, loc)
+        case tpe => KindedAst.ConstraintParam(sym, tpe, loc)
       }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -289,10 +289,10 @@ object Namer {
       mapN(visitHeadPredicate(h, outerEnv, headEnv, ruleEnv, tenv0, ns0), traverse(bs)(b => visitBodyPredicate(b, outerEnv, headEnv, ruleEnv, tenv0, ns0))) {
         case (head, body) =>
           val headParams = headEnv.map {
-            case (_, sym) => NamedAst.ConstraintParam.HeadParam(sym, NamedAst.Type.Var(sym.tvar.sym.withoutKind, loc), sym.loc)
+            case (_, sym) => NamedAst.ConstraintParam(sym, NamedAst.Type.Var(sym.tvar.sym.withoutKind, loc), sym.loc)
           }
           val ruleParam = ruleEnv.map {
-            case (_, sym) => NamedAst.ConstraintParam.RuleParam(sym, NamedAst.Type.Var(sym.tvar.sym.withoutKind, loc), sym.loc)
+            case (_, sym) => NamedAst.ConstraintParam(sym, NamedAst.Type.Var(sym.tvar.sym.withoutKind, loc), sym.loc)
           }
           val cparams = (headParams ++ ruleParam).toList
           NamedAst.Constraint(cparams, head, body, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1450,15 +1450,10 @@ object Resolver {
       * Performs name resolution on the given constraint parameter `cparam0` in the given namespace `ns0`.
       */
     def resolve(cparam0: NamedAst.ConstraintParam, uenv: ListMap[String, DeclarationOrJavaClass], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.ConstraintParam, ResolutionError] = cparam0 match {
-      case NamedAst.ConstraintParam.HeadParam(sym, tpe0, loc) =>
+      case NamedAst.ConstraintParam(sym, tpe0, loc) =>
         val tpeVal = resolveType(tpe0, uenv, taenv, ns0, root)
         mapN(tpeVal) {
-          case tpe => ResolvedAst.ConstraintParam.HeadParam(sym, tpe, loc)
-        }
-      case NamedAst.ConstraintParam.RuleParam(sym, tpe0, loc) =>
-        val tpeVal = resolveType(tpe0, uenv, taenv, ns0, root)
-        mapN(tpeVal) {
-          case tpe => ResolvedAst.ConstraintParam.RuleParam(sym, tpe, loc)
+          case tpe => ResolvedAst.ConstraintParam(sym, tpe, loc)
         }
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -2478,10 +2478,8 @@ object Typer {
 
       // Reassemble the constraint parameters.
       val cparams = cparams0.map {
-        case KindedAst.ConstraintParam.HeadParam(sym, tpe, l) =>
-          TypedAst.ConstraintParam.HeadParam(sym, subst0(tpe), l)
-        case KindedAst.ConstraintParam.RuleParam(sym, tpe, l) =>
-          TypedAst.ConstraintParam.RuleParam(sym, subst0(tpe), l)
+        case KindedAst.ConstraintParam(sym, tpe, l) =>
+          TypedAst.ConstraintParam(sym, subst0(tpe), l)
       }
 
       // Reassemble the constraint.


### PR DESCRIPTION
related to #4967, doing separately since it extends beyond Namer/Resolver