### PR TITLE
feat: evaluate literals and variables in calling thread in `ParYield`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -1626,7 +1626,7 @@ object Lowering {
     */
   private def mkParYield(frags: List[LoweredAst.ParYieldFragment], exp: LoweredAst.Expression, tpe: Type, pur: Type, eff: Type, loc: SourceLocation)(implicit flix: Flix): LoweredAst.Expression = {
     // Partition fragments into complex and simple exps.
-    val (complex, simple) = frags.partition(spawnable)
+    val (complex, simple) = frags.partition(isSpawnable)
 
     // Only generate channels for n-1 fragments. We use the current thread for the last fragment.
     val (fs, last) = complex.splitAt(complex.length - 1)
@@ -1660,12 +1660,11 @@ object Lowering {
   /**
     * Returns `true` if the ParYield fragment should be spawned in a thread. Wrapper for `isSimple`.
     */
-  private def spawnable(frag: LoweredAst.ParYieldFragment): Boolean = !isSimple(frag.exp)
+  private def isSpawnable(frag: LoweredAst.ParYieldFragment): Boolean = !isSimple(frag.exp)
 
   /**
     * Returns `true` if `exp0` is either a literal or a variable.
     */
-  @tailrec
   private def isSimple(exp0: LoweredAst.Expression): Boolean = exp0 match {
     case LoweredAst.Expression.Var(_, _, _) => true
     case LoweredAst.Expression.Cst(_: Ast.Constant, _, _) => true

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -1669,7 +1669,6 @@ object Lowering {
   private def isSimple(exp0: LoweredAst.Expression): Boolean = exp0 match {
     case LoweredAst.Expression.Var(_, _, _) => true
     case LoweredAst.Expression.Cst(_: Ast.Constant, _, _) => true
-    case LoweredAst.Expression.Scope(_, _, exp, _, _, _, _) => isSimple(exp)
     case _ => false
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -1625,8 +1625,8 @@ object Lowering {
     * Returns a desugared [[TypedAst.Expression.ParYield]] expression as a nested match-expression.
     */
   private def mkParYield(frags: List[LoweredAst.ParYieldFragment], exp: LoweredAst.Expression, tpe: Type, pur: Type, eff: Type, loc: SourceLocation)(implicit flix: Flix): LoweredAst.Expression = {
-    // Partition fragments into simple and complex exps.
-    val (simple, complex) = frags.partition(spawnable)
+    // Partition fragments into complex and simple exps.
+    val (complex, simple) = frags.partition(spawnable)
 
     // Only generate channels for n-1 fragments. We use the current thread for the last fragment.
     val (fs, last) = complex.splitAt(frags.length - 1)

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -1673,7 +1673,6 @@ object Lowering {
     case _ => false
   }
 
-
   /**
     * Returns a tuple expression that is evaluated in parallel.
     *

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -1658,14 +1658,14 @@ object Lowering {
   }
 
   /**
-    * Returns `true` if the ParYield fragment should be spawned in a thread. Wrapper for `isSimple`.
+    * Returns `true` if the ParYield fragment should be spawned in a thread. Wrapper for `isVarOrCst`.
     */
-  private def isSpawnable(frag: LoweredAst.ParYieldFragment): Boolean = !isSimple(frag.exp)
+  private def isSpawnable(frag: LoweredAst.ParYieldFragment): Boolean = !isVarOrCst(frag.exp)
 
   /**
     * Returns `true` if `exp0` is either a literal or a variable.
     */
-  private def isSimple(exp0: LoweredAst.Expression): Boolean = exp0 match {
+  private def isVarOrCst(exp0: LoweredAst.Expression): Boolean = exp0 match {
     case LoweredAst.Expression.Var(_, _, _) => true
     case LoweredAst.Expression.Cst(_: Ast.Constant, _, _) => true
     case _ => false

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -1629,7 +1629,7 @@ object Lowering {
     val (complex, simple) = frags.partition(spawnable)
 
     // Only generate channels for n-1 fragments. We use the current thread for the last fragment.
-    val (fs, last) = complex.splitAt(frags.length - 1)
+    val (fs, last) = complex.splitAt(complex.length - 1)
 
     // Generate symbols for each channel.
     val chanSymsWithPatAndExp = fs.map { case LoweredAst.ParYieldFragment(p, e, l) => (p, mkLetSym("channel", l.asSynthetic), e) }

--- a/main/test/flix/Test.Exp.ParYield.flix
+++ b/main/test/flix/Test.Exp.ParYield.flix
@@ -70,8 +70,8 @@ namespace Test/Exp/ParYield {
     def testParYield16(): Int32 =
         let c = 2;
         par (
-            a <- 1;              // Simple variable
-            b <- c;              // Simple variable
+            a <- 1;              // Constant
+            b <- c;              // Variable lookup
             d <- (let a = 3; a); // Spawn into thread
             e <- (let b = 4; b)  // Last complex expression
         ) yield a + b + d + e
@@ -80,24 +80,24 @@ namespace Test/Exp/ParYield {
     def testParYield17(): Int32 =
         let c = 2;
         par (
-            a <- 1;              // Simple variable
-            b <- c;              // Simple variable
+            a <- 1;              // Constant
+            b <- c;              // Variable lookup
             d <- (let a = 3; a); // Spawn into thread
             e <- (let b = 4; b); // Last complex expression
-            f <- 5;              // Simple variable
-            g <- 6               // Simple variable
+            f <- 5;              // Constant
+            g <- 6               // Constant
         ) yield a + b + d + e + f + g
 
     @test
     def testParYield18(): Int32 =
         let c = 2;
         par (
-            a <- 1;              // Simple variable
-            b <- c;              // Simple variable
+            a <- 1;              // Constant
+            b <- c;              // Variable lookup
             d <- (let a = 3; a); // Spawn into thread
             e <- (let b = 4; b); // Spawn into thread
-            f <- 5;              // Simple variable
-            g <- 6;              // Simple variable
+            f <- 5;              // Constant
+            g <- 6;              // Constant
             h <- (let b = 7; b)  // Last complex expression
         ) yield a + b + d + e + f + g + h
 
@@ -105,28 +105,28 @@ namespace Test/Exp/ParYield {
     def testParYield19(): Int32 =
         let c = 2;
         par (
-            a <- 1;              // Simple variable
-            b <- c;              // Simple variable
+            a <- 1;              // Constant
+            b <- c;              // Variable lookup
             d <- (let a = 3; a); // Spawn into thread
             e <- (let b = 4; b); // Spawn into thread
-            f <- 5;              // Simple variable
-            g <- 6;              // Simple variable
+            f <- 5;              // Constant
+            g <- 6;              // Constant
             h <- (let b = 7; b); // Last complex expression
-            i <- 8               // Simple variable
+            i <- 8               // Constant
         ) yield a + b + d + e + f + g + h + i
 
     @test
     def testParYield20(): Int32 =
         let c = 2;
         par (
-            a <- 1;              // Simple variable
-            b <- c;              // Simple variable
+            a <- 1;              // Constant
+            b <- c;              // Variable lookup
             d <- (let a = 3; a); // Spawn into thread
-            e <- 4;              // Simple variable
+            e <- 4;              // Constant
             f <- (let b = 5; b); // Spawn into thread
-            g <- 6;              // Simple variable
+            g <- 6;              // Constant
             h <- (let b = 7; b); // Last complex expression
-            i <- 8               // Simple variable
+            i <- 8               // Constant
         ) yield a + b + d + e + f + g + h + i
 
 }

--- a/main/test/flix/Test.Exp.ParYield.flix
+++ b/main/test/flix/Test.Exp.ParYield.flix
@@ -115,4 +115,18 @@ namespace Test/Exp/ParYield {
             i <- 8               // Simple variable
         ) yield a + b + d + e + f + g + h + i
 
+    @test
+    def testParYield20(): Int32 =
+        let c = 2;
+        par (
+            a <- 1;              // Simple variable
+            b <- c;              // Simple variable
+            d <- (let a = 3; a); // Spawn into thread
+            f <- 4;              // Simple variable
+            e <- (let b = 5; b); // Spawn into thread
+            g <- 6;              // Simple variable
+            h <- (let b = 7; b); // Last complex expression
+            i <- 8               // Simple variable
+        ) yield a + b + d + e + f + g + h + i
+
 }

--- a/main/test/flix/Test.Exp.ParYield.flix
+++ b/main/test/flix/Test.Exp.ParYield.flix
@@ -72,8 +72,8 @@ namespace Test/Exp/ParYield {
         par (
             a <- 1;              // Simple variable
             b <- c;              // Simple variable
-            d <- (let a = 1; a); // Spawn into thread
-            e <- (let b = 1; b)  // Last complex expression
+            d <- (let a = 3; a); // Spawn into thread
+            e <- (let b = 4; b)  // Last complex expression
         ) yield a + b + d + e
 
     @test
@@ -82,10 +82,10 @@ namespace Test/Exp/ParYield {
         par (
             a <- 1;              // Simple variable
             b <- c;              // Simple variable
-            d <- (let a = 1; a); // Spawn into thread
-            e <- (let b = 1; b); // Last complex expression
-            f <- 1;              // Simple variable
-            g <- 1               // Simple variable
+            d <- (let a = 3; a); // Spawn into thread
+            e <- (let b = 4; b); // Last complex expression
+            f <- 5;              // Simple variable
+            g <- 6               // Simple variable
         ) yield a + b + d + e + f + g
 
     @test
@@ -94,11 +94,11 @@ namespace Test/Exp/ParYield {
         par (
             a <- 1;              // Simple variable
             b <- c;              // Simple variable
-            d <- (let a = 1; a); // Spawn into thread
-            e <- (let b = 1; b); // Spawn into thread
-            f <- 1;              // Simple variable
-            g <- 1;              // Simple variable
-            h <- (let b = 1; b)  // Last complex expression
+            d <- (let a = 3; a); // Spawn into thread
+            e <- (let b = 4; b); // Spawn into thread
+            f <- 5;              // Simple variable
+            g <- 6;              // Simple variable
+            h <- (let b = 7; b)  // Last complex expression
         ) yield a + b + d + e + f + g + h
 
     @test
@@ -107,12 +107,12 @@ namespace Test/Exp/ParYield {
         par (
             a <- 1;              // Simple variable
             b <- c;              // Simple variable
-            d <- (let a = 1; a); // Spawn into thread
-            e <- (let b = 1; b); // Spawn into thread
-            f <- 1;              // Simple variable
-            g <- 1;              // Simple variable
-            h <- (let b = 1; b); // Last complex expression
-            i <- 1               // Simple variable
+            d <- (let a = 3; a); // Spawn into thread
+            e <- (let b = 4; b); // Spawn into thread
+            f <- 5;              // Simple variable
+            g <- 6;              // Simple variable
+            h <- (let b = 7; b); // Last complex expression
+            i <- 8               // Simple variable
         ) yield a + b + d + e + f + g + h + i
 
 }

--- a/main/test/flix/Test.Exp.ParYield.flix
+++ b/main/test/flix/Test.Exp.ParYield.flix
@@ -66,4 +66,53 @@ namespace Test/Exp/ParYield {
     def testParYield15(): Bool =
         (par (a <- 5; b <- (let a = 1; a); c <- 6) yield a + b + c) == 12
 
+    @test
+    def testParYield16(): Int32 =
+        let c = 2;
+        par (
+            a <- 1;              // Simple variable
+            b <- c;              // Simple variable
+            d <- (let a = 1; a); // Spawn into thread
+            e <- (let b = 1; b)  // Last complex expression
+        ) yield a + b + d + e
+
+    @test
+    def testParYield17(): Int32 =
+        let c = 2;
+        par (
+            a <- 1;              // Simple variable
+            b <- c;              // Simple variable
+            d <- (let a = 1; a); // Spawn into thread
+            e <- (let b = 1; b); // Last complex expression
+            f <- 1;              // Simple variable
+            g <- 1               // Simple variable
+        ) yield a + b + d + e + f + g
+
+    @test
+    def testParYield18(): Int32 =
+        let c = 2;
+        par (
+            a <- 1;              // Simple variable
+            b <- c;              // Simple variable
+            d <- (let a = 1; a); // Spawn into thread
+            e <- (let b = 1; b); // Spawn into thread
+            f <- 1;              // Simple variable
+            g <- 1;              // Simple variable
+            h <- (let b = 1; b)  // Last complex expression
+        ) yield a + b + d + e + f + g + h
+
+    @test
+    def testParYield19(): Int32 =
+        let c = 2;
+        par (
+            a <- 1;              // Simple variable
+            b <- c;              // Simple variable
+            d <- (let a = 1; a); // Spawn into thread
+            e <- (let b = 1; b); // Spawn into thread
+            f <- 1;              // Simple variable
+            g <- 1;              // Simple variable
+            h <- (let b = 1; b); // Last complex expression
+            i <- 1               // Simple variable
+        ) yield a + b + d + e + f + g + h + i
+
 }

--- a/main/test/flix/Test.Exp.ParYield.flix
+++ b/main/test/flix/Test.Exp.ParYield.flix
@@ -122,8 +122,8 @@ namespace Test/Exp/ParYield {
             a <- 1;              // Simple variable
             b <- c;              // Simple variable
             d <- (let a = 3; a); // Spawn into thread
-            f <- 4;              // Simple variable
-            e <- (let b = 5; b); // Spawn into thread
+            e <- 4;              // Simple variable
+            f <- (let b = 5; b); // Spawn into thread
             g <- 6;              // Simple variable
             h <- (let b = 7; b); // Last complex expression
             i <- 8               // Simple variable


### PR DESCRIPTION
Suppose we have
```flix
let b = 1;
par (
        a <- b;
        c <- 2;
        e <- exp1;
        f <- exp2
    ) yield exp3
```

This PR changes `ParYield` to no longer spawn threads for `a` and `c` since these are just a variable lookup and a literal respectively.

Related to https://github.com/flix/flix/issues/4609