### PR TITLE
chore: add jaschdoc/flix-parsers to community build

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -41,6 +41,7 @@ jobs:
           - "mlutze/fcwg"
           - "JonathanStarup/Flix-ANSI-Terminal"
           - "mlutze/flix-json"
+          - "jaschdoc/flix-parsers"
     runs-on: ubuntu-latest
     steps:
       - name: Set up Java

--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -41,7 +41,6 @@ jobs:
           - "mlutze/fcwg"
           - "JonathanStarup/Flix-ANSI-Terminal"
           - "mlutze/flix-json"
-          - "jaschdoc/flix-parsers"
     runs-on: ubuntu-latest
     steps:
       - name: Set up Java


### PR DESCRIPTION
I made a (WIP) parser library which I think will fit nicely in the community project test suite.