### PR TITLE
feat: Add backend Region class

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
@@ -52,6 +52,8 @@ object MonoType {
 
   case object Str extends MonoType
 
+  case object Region extends MonoType
+
   ///
   /// Compound Types.
   ///

--- a/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
@@ -401,8 +401,7 @@ object Finalize {
 
             case TypeConstructor.Ref => MonoType.Ref(args.head)
 
-            case TypeConstructor.RegionToStar =>
-              MonoType.Unit // TODO: Should be erased?
+            case TypeConstructor.RegionToStar => MonoType.Region
 
             case TypeConstructor.Tuple(l) => MonoType.Tuple(args)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -52,6 +52,7 @@ sealed trait BackendObjType {
     case BackendObjType.FlixError => JvmName(DevFlixRuntime, "FlixError")
     case BackendObjType.HoleError => JvmName(DevFlixRuntime, "HoleError")
     case BackendObjType.MatchError => JvmName(DevFlixRuntime, "MatchError")
+    case BackendObjType.Region => JvmName(DevFlixRuntime, "Region")
     // Java classes
     case BackendObjType.JavaObject => JvmName(JavaLang, "Object")
     case BackendObjType.String => JvmName(JavaLang, "String")
@@ -980,6 +981,21 @@ object BackendObjType {
         DUP() ~ ICONST_0() ~ thisLoad() ~ GETFIELD(LocationField) ~ AASTORE() ~
         INVOKESTATIC(Objects.HashMethod) ~
         IRETURN()
+    ))
+  }
+
+  case object Region extends BackendObjType {
+
+    def genByteCode()(implicit flix: Flix): Array[Byte] = {
+      val cm = mkClass(this.jvmName, IsFinal)
+
+      cm.mkConstructor(Constructor)
+
+      cm.closeClassMaker()
+    }
+
+    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, IsPublic, Nil, Some(
+      thisLoad() ~ INVOKESPECIAL(JavaObject.Constructor) ~ RETURN()
     ))
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -132,6 +132,6 @@ object BackendType {
          MonoType.Lazy(_) | MonoType.Ref(_) | MonoType.Tuple(_) | MonoType.Enum(_, _) |
          MonoType.Arrow(_, _) | MonoType.RecordEmpty() | MonoType.RecordExtend(_, _, _) |
          MonoType.SchemaEmpty() | MonoType.SchemaExtend(_, _, _) | MonoType.Native(_) |
-         MonoType.Var(_) => BackendObjType.JavaObject.toTpe
+         MonoType.Var(_) | MonoType.Region => BackendObjType.JavaObject.toTpe
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -283,13 +283,16 @@ object GenExpression {
       compileConstant(visitor, Ast.Constant.Unit, MonoType.Unit, loc)
 
     case Expression.Scope(sym, exp, _, loc) =>
-      //!TODO: For now just make like `let`
       // Adding source line number for debugging
       addSourceLine(visitor, loc)
-      compileConstant(visitor, Ast.Constant.Unit, MonoType.Unit, loc)
-      val jvmType = JvmOps.getJvmType(MonoType.Unit)
-      // Store instruction for `jvmType`
-      val iStore = AsmOps.getStoreInstruction(jvmType)
+
+      // Create an instance of Region
+      visitor.visitTypeInsn(NEW, BackendObjType.Region.jvmName.toInternalName)
+      visitor.visitInsn(DUP)
+      visitor.visitMethodInsn(INVOKESPECIAL, BackendObjType.Region.jvmName.toInternalName, "<init>",
+        AsmOps.getMethodDescriptor(List(), JvmType.Void), false)
+
+      val iStore = AsmOps.getStoreInstruction(JvmType.Reference(BackendObjType.Region.jvmName))
       visitor.visitVarInsn(iStore, sym.getStackOffset + 1)
       compileExpression(exp, visitor, currentClass, lenv0, entryPoint)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRegionClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenRegionClass.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Paul Butcher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.BackendObjType.Region
+
+object GenRegionClass {
+  def gen()(implicit flix: Flix): Map[JvmName, JvmClass] = {
+    Map(Region.jvmName -> JvmClass(Region.jvmName, Region.genByteCode()))
+  }
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -185,6 +185,11 @@ object JvmBackend {
       val globalClass = GenGlobalClass.gen()
 
       //
+      // Generate the Region class.
+      //
+      val regionClass = GenRegionClass.gen()
+
+      //
       // Collect all the classes and interfaces together.
       //
       List(
@@ -209,7 +214,8 @@ object JvmBackend {
         rslClass,
         holeErrorClass,
         matchErrorClass,
-        globalClass
+        globalClass,
+        regionClass
       ).reduce(_ ++ _)
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -62,6 +62,7 @@ object JvmOps {
     case MonoType.Int64 => JvmType.PrimLong
     case MonoType.BigInt => JvmType.BigInteger
     case MonoType.Str => JvmType.String
+    case MonoType.Region => JvmType.Object
 
     // Compound
     case MonoType.Array(_) => JvmType.Object
@@ -730,6 +731,7 @@ object JvmOps {
     case MonoType.Int64 => Type.Int64
     case MonoType.BigInt => Type.BigInt
     case MonoType.Str => Type.Str
+    case MonoType.Region => Type.mkRegion(Type.Unit, SourceLocation.Unknown) // hack
     case MonoType.Array(elm) => Type.mkArray(hackMonoType2Type(elm), Type.Impure, SourceLocation.Unknown)
     case MonoType.Lazy(tpe) => Type.mkLazy(hackMonoType2Type(tpe), SourceLocation.Unknown)
     case MonoType.Native(clazz) => Type.mkNative(clazz, SourceLocation.Unknown)
@@ -1052,6 +1054,7 @@ object JvmOps {
       case MonoType.Int64 => Set(tpe)
       case MonoType.BigInt => Set(tpe)
       case MonoType.Str => Set(tpe)
+      case MonoType.Region => Set(tpe)
 
       case MonoType.Array(elm) => nestedTypesOf(elm) + tpe
       case MonoType.Lazy(elm) => nestedTypesOf(elm) + tpe


### PR DESCRIPTION
This is the first step towards the "Add a GenRegionClasses which generates a Region class" task of #4850. It's creating a `Region` class in the backend which currently does nothing. But it does type check (finally: working out what to do with MonoTypes was a PITA but I think I've got there eventually).
