### PR TITLE
Demonstrate channel race condition

### DIFF
--- a/main/test/flix/Test.Exp.Concurrency.Select.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Select.flix
@@ -259,35 +259,100 @@ namespace Test/Exp/Concurrency/Select {
         let (tx15, rx15) = Channel.buffered(r, 0);
         let (tx16, rx16) = Channel.buffered(r, 0);
         let (tx17, rx17) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { select {
-        case _ <- recv(rx17) => Channel.recv(rx14) ; Channel.recv(rx15) ; Channel.recv(rx16)
-        } } @ r; spawn { select {
-        case _ <- recv(rx16) => Channel.recv(rx14) ; Channel.recv(rx15) ; Channel.recv(rx17) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx17) => Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx14) ; let (tx171, rx171) = Channel.buffered(r, 0);
-        let (tx172, rx172) = Channel.buffered(r, 0);
-        let (tx173, rx173) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx173) ; () } @ r; spawn { Channel.send((), tx172) ; () } @ r; spawn { Channel.send((), tx171) ; () } @ r; spawn { Channel.send((), tx173) ; () } @ r; spawn { Channel.send((), tx172) ; () } @ r; spawn { Channel.send((), tx171) ; () } @ r; spawn { Channel.send((), tx173) ; () } @ r; spawn { Channel.send((), tx172) ; () } @ r; spawn { Channel.send((), tx171) ; () } @ r; spawn { Channel.send((), tx173) ; () } @ r; spawn { Channel.send((), tx172) ; () } @ r; spawn { Channel.send((), tx171) ; () } @ r; spawn { select {
-        case _ <- recv(rx172) => Channel.recv(rx173) ; Channel.recv(rx171) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx171) => Channel.recv(rx173) ; Channel.recv(rx172) ; ()
-        case _ <- recv(rx173) => Channel.recv(rx172) ; Channel.recv(rx171) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx171) => Channel.recv(rx173) ; Channel.recv(rx172) ; ()
-        case _ <- recv(rx173) => Channel.recv(rx171) ; Channel.recv(rx172) ; ()
-        case _ <- recv(rx171) => Channel.recv(rx173) ; Channel.recv(rx172) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx171) => Channel.recv(rx173) ; select {
-        case _ <- recv(rx172) => ()
-        case _ <- recv(rx172) => ()
-        } ; ()
-        case _ <- recv(rx173) => Channel.recv(rx171) ; Channel.recv(rx172) ; ()
-        } } @ r; ()
-        case _ <- recv(rx14) => Channel.recv(rx17) ; Channel.recv(rx15) ; Channel.recv(rx16) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx17) => Channel.recv(rx16) ; Channel.recv(rx15) ; Channel.recv(rx14) ; ()
-        } } @ r;
-        ()
+
+        let (txd, rxd) = Channel.buffered(r, 100);
+
+        spawn { Channel.send((), tx17); Channel.send((), txd) } @ r; 
+        spawn { Channel.send((), tx16); Channel.send((), txd) } @ r; 
+        spawn { Channel.send((), tx15); Channel.send((), txd) } @ r; 
+        spawn { Channel.send((), tx14); Channel.send((), txd) } @ r; 
+        spawn { Channel.send((), tx17); Channel.send((), txd) } @ r; 
+        spawn { Channel.send((), tx16); Channel.send((), txd) } @ r; 
+        spawn { Channel.send((), tx15); Channel.send((), txd) } @ r; 
+        spawn { Channel.send((), tx14); Channel.send((), txd) } @ r; 
+        spawn { Channel.send((), tx17); Channel.send((), txd) } @ r; 
+        spawn { Channel.send((), tx16); Channel.send((), txd) } @ r; 
+        spawn { Channel.send((), tx15); Channel.send((), txd) } @ r; 
+        spawn { Channel.send((), tx14); Channel.send((), txd) } @ r; 
+        spawn { Channel.send((), tx17); Channel.send((), txd) } @ r; 
+        spawn { Channel.send((), tx16); Channel.send((), txd) } @ r; 
+        spawn { Channel.send((), tx15); Channel.send((), txd) } @ r; 
+        spawn { Channel.send((), tx14); Channel.send((), txd) } @ r; 
+        spawn { 
+            select {
+                case _ <- recv(rx17) => Channel.recv(rx14) ; Channel.recv(rx15) ; Channel.recv(rx16)
+            };
+            Channel.send((), txd)
+        } @ r; 
+        spawn { 
+            select {
+                case _ <- recv(rx16) => Channel.recv(rx14) ; Channel.recv(rx15) ; Channel.recv(rx17)
+            };
+            Channel.send((), txd)
+        } @ r; 
+        spawn { 
+            select {
+                case _ <- recv(rx17) => 
+                    Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx14) ; let (tx171, rx171) = Channel.buffered(r, 0);
+                    let (tx172, rx172) = Channel.buffered(r, 0);
+                    let (tx173, rx173) = Channel.buffered(r, 0);
+                    spawn { Channel.send((), tx173); Channel.send((), txd) } @ r; 
+                    spawn { Channel.send((), tx172); Channel.send((), txd) } @ r; 
+                    spawn { Channel.send((), tx171); Channel.send((), txd) } @ r; 
+                    spawn { Channel.send((), tx173); Channel.send((), txd) } @ r; 
+                    spawn { Channel.send((), tx172); Channel.send((), txd) } @ r; 
+                    spawn { Channel.send((), tx171); Channel.send((), txd) } @ r; 
+                    spawn { Channel.send((), tx173); Channel.send((), txd) } @ r; 
+                    spawn { Channel.send((), tx172); Channel.send((), txd) } @ r; 
+                    spawn { Channel.send((), tx171); Channel.send((), txd) } @ r; 
+                    spawn { Channel.send((), tx173); Channel.send((), txd) } @ r; 
+                    spawn { Channel.send((), tx172); Channel.send((), txd) } @ r; 
+                    spawn { Channel.send((), tx171); Channel.send((), txd) } @ r; 
+                    spawn { 
+                        select {
+                            case _ <- recv(rx172) => Channel.recv(rx173) ; Channel.recv(rx171)
+                        };
+                        Channel.send((), txd)
+                    } @ r; 
+                    spawn { 
+                        select {
+                            case _ <- recv(rx171) => Channel.recv(rx173) ; Channel.recv(rx172)
+                            case _ <- recv(rx173) => Channel.recv(rx172) ; Channel.recv(rx171)
+                        };
+                        Channel.send((), txd)
+                    } @ r; 
+                    spawn { 
+                        select {
+                            case _ <- recv(rx171) => Channel.recv(rx173) ; Channel.recv(rx172)
+                            case _ <- recv(rx173) => Channel.recv(rx171) ; Channel.recv(rx172)
+                            case _ <- recv(rx171) => Channel.recv(rx173) ; Channel.recv(rx172)
+                        };
+                        Channel.send((), txd)
+                    } @ r; 
+                    spawn { 
+                        select {
+                            case _ <- recv(rx171) => Channel.recv(rx173) ; 
+                                select {
+                                    case _ <- recv(rx172) => ()
+                                    case _ <- recv(rx172) => ()
+                                }
+                            case _ <- recv(rx173) => Channel.recv(rx171) ; Channel.recv(rx172)
+                        };
+                        Channel.send((), txd)
+                    } @ r; 
+                    ()
+                case _ <- recv(rx14) => Channel.recv(rx17) ; Channel.recv(rx15) ; Channel.recv(rx16)
+            } ;
+            Channel.send((), txd)
+        } @ r;
+        spawn { 
+            select {
+                case _ <- recv(rx17) => Channel.recv(rx16) ; Channel.recv(rx15) ; Channel.recv(rx14)
+            };
+            Channel.send((), txd)
+        } @ r;
+
+        List.range(0, 36) |> List.forEach(_ -> Channel.recv(rxd))
     }
 
     @test


### PR DESCRIPTION
While working on #4850 I stumbled over what I believe to be a race condition in our channel code. This PR has a modified version of one of the Channel tests `testSelectRandom05` which demonstrates the problem.

The changes I've made are:

1. Reformatting to make it easier to read the test
2. Introduction of a new channel `(txd, rxd)` which every single `spawn` sends to just before it exits
3. A loop at the end of the test to ensure that exactly as many writes are made to this channel as threads are spawned.

For me, this passes about 80% of the time, and hangs 20% of the time (indicating that at least one thread has failed to exit).