### PR TITLE
feat: Generate Region.exit and call it

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -24,7 +24,7 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker._
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor.mkDescriptor
-import ca.uwaterloo.flix.language.phase.jvm.JvmName.{DevFlixRuntime, JavaLang, JavaUtil, MethodDescriptor, RootPackage}
+import ca.uwaterloo.flix.language.phase.jvm.JvmName.{DevFlixRuntime, JavaLang, JavaUtil, JavaUtilConcurrent, MethodDescriptor, RootPackage}
 import org.objectweb.asm.Opcodes
 
 /**
@@ -59,7 +59,7 @@ sealed trait BackendObjType {
     case BackendObjType.Arrays => JvmName(JavaUtil, "Arrays")
     case BackendObjType.StringBuilder => JvmName(JavaLang, "StringBuilder")
     case BackendObjType.Objects => JvmName(JavaLang, "Objects")
-    case BackendObjType.ArrayList => JvmName(JavaUtil, "ArrayList")
+    case BackendObjType.ConcurrentLinkedQueue => JvmName(JavaUtilConcurrent, "ConcurrentLinkedQueue")
     case BackendObjType.Thread => JvmName(JavaLang, "Thread")
   }
 
@@ -994,20 +994,27 @@ object BackendObjType {
       cm.mkField(ThreadsField)
       cm.mkConstructor(Constructor)
       cm.mkMethod(SpawnMethod)
+      cm.mkMethod(ExitMethod)
 
       cm.closeClassMaker()
     }
 
-    def ThreadsField: InstanceField = InstanceField(this.jvmName, IsPrivate, IsFinal, "threads", BackendObjType.ArrayList.toTpe)
+    // private ConcurrentLinkedQueue<Thread> threads = new ConcurrentLinkedQueue<Thread>();
+    def ThreadsField: InstanceField = InstanceField(this.jvmName, IsPrivate, IsFinal, "threads", BackendObjType.ConcurrentLinkedQueue.toTpe)
 
     def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, IsPublic, Nil, Some(
       thisLoad() ~ INVOKESPECIAL(JavaObject.Constructor) ~ 
-      thisLoad() ~ NEW(BackendObjType.ArrayList.jvmName) ~
-      DUP() ~ invokeConstructor(BackendObjType.ArrayList.jvmName, MethodDescriptor.NothingToVoid) ~
+      thisLoad() ~ NEW(BackendObjType.ConcurrentLinkedQueue.jvmName) ~
+      DUP() ~ invokeConstructor(BackendObjType.ConcurrentLinkedQueue.jvmName, MethodDescriptor.NothingToVoid) ~
       PUTFIELD(ThreadsField) ~
       RETURN()
     ))
 
+    // final public void spawn(Runnable r) {
+    //   Thread t = new Thread(r);
+    //   t.start();
+    //   threads.add(t);
+    // }
     def SpawnMethod(implicit flix: Flix): InstanceMethod = InstanceMethod(this.jvmName, IsPublic, IsFinal, "spawn", mkDescriptor(JvmName.Runnable.toTpe)(VoidableType.Void), Some(
       (
         if (flix.options.xvirtualthreads) {
@@ -1020,7 +1027,25 @@ object BackendObjType {
       ) ~
       storeWithName(2, BackendObjType.Thread.toTpe) { thread =>
         thisLoad() ~ GETFIELD(ThreadsField) ~ thread.load() ~
-        INVOKEVIRTUAL(ArrayList.AddMethod) ~ POP() ~
+        INVOKEVIRTUAL(ConcurrentLinkedQueue.AddMethod) ~ POP() ~
+        RETURN()
+      }
+    ))
+  
+    // final public void exit() throws InterruptedException {
+    //   Thread t;
+    //   while ((t = threads.poll()) != null)
+    //     t.join();
+    // }
+    def ExitMethod: InstanceMethod = InstanceMethod(this.jvmName, IsPublic, IsFinal, "exit", MethodDescriptor.NothingToVoid, Some(
+      withName(1, BackendObjType.Thread.toTpe) { t =>
+        whileLoop(Condition.NONNULL) {
+          thisLoad() ~ GETFIELD(ThreadsField) ~ 
+          INVOKEVIRTUAL(ConcurrentLinkedQueue.PollMethod) ~
+          CHECKCAST(BackendObjType.Thread.jvmName) ~ DUP() ~ t.store() 
+        } {
+          t.load() ~ INVOKEVIRTUAL(Thread.JoinMethod)
+        } ~
         RETURN()
       }
     ))
@@ -1132,10 +1157,13 @@ object BackendObjType {
 
   }
 
-  case object ArrayList extends BackendObjType {
+  case object ConcurrentLinkedQueue extends BackendObjType {
     
     def AddMethod: InstanceMethod = InstanceMethod(this.jvmName, IsPublic, NotFinal, "add",
       mkDescriptor(JavaObject.toTpe)(BackendType.Bool), None)
+
+    def PollMethod: InstanceMethod = InstanceMethod(this.jvmName, IsPublic, NotFinal, "poll",
+      mkDescriptor()(JavaObject.toTpe), None)
   }
 
   case object Thread extends BackendObjType {
@@ -1145,5 +1173,8 @@ object BackendObjType {
 
     def StartVirtualThreadMethod: StaticMethod = StaticMethod(this.jvmName, IsPublic, IsFinal, "startVirtualThread",
       mkDescriptor(JvmName.Runnable.toTpe)(this.toTpe), None)
+
+    def JoinMethod: InstanceMethod = InstanceMethod(this.jvmName, IsPublic, NotFinal, "join",
+       MethodDescriptor.NothingToVoid, None)
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -361,12 +361,27 @@ object BytecodeInstructions {
     f
   }
 
+  /// do { i } while(c)
   def doWhile(c: Condition)(i: InstructionSet): InstructionSet = f0 => {
     var f = f0
     val start = new Label()
     f.visitLabel(start)
     f = i(f)
     f.visitJumpInstruction(opcodeOf(c), start)
+    f
+  }
+
+  /// while(c(t)) { i }
+  def whileLoop(c: Condition)(t: InstructionSet)(i: InstructionSet): InstructionSet = f0 => {
+    var f = f0
+    val startLabel = new Label()
+    val doneLabel = new Label()
+    f.visitLabel(startLabel)
+    f = t(f)
+    f.visitJumpInstruction(opcodeOf(negated(c)), doneLabel)
+    f = i(f)
+    f.visitJumpInstruction(Opcodes.GOTO, startLabel)
+    f.visitLabel(doneLabel)
     f
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -294,7 +294,15 @@ object GenExpression {
 
       val iStore = AsmOps.getStoreInstruction(JvmType.Reference(BackendObjType.Region.jvmName))
       visitor.visitVarInsn(iStore, sym.getStackOffset + 1)
+
+      // Compile the scope body
       compileExpression(exp, visitor, currentClass, lenv0, entryPoint)
+
+      // When we exit the scope, call the region's `exit` method
+      val iLoad = AsmOps.getLoadInstruction(JvmType.Reference(BackendObjType.Region.jvmName))
+      visitor.visitVarInsn(iLoad, sym.getStackOffset + 1)
+      visitor.visitMethodInsn(INVOKEVIRTUAL, BackendObjType.Region.jvmName.toInternalName, BackendObjType.Region.ExitMethod.name, 
+        BackendObjType.Region.ExitMethod.d.toDescriptor, false)
 
     case Expression.Is(sym, exp, loc) =>
       // Adding source line number for debugging

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -75,6 +75,7 @@ object JvmName {
   val JavaLang: List[String] = List("java", "lang")
   val JavaUtil: List[String] = List("java", "util")
   val JavaUtilFunction: List[String] = JavaUtil ::: List("function")
+  val JavaUtilConcurrent: List[String] = JavaUtil ::: List("concurrent")
 
   val AtomicLong: JvmName = JvmName(JavaUtil ::: List("concurrent", "atomic"), "AtomicLong")
   val Boolean: JvmName = JvmName(JavaLang, "Boolean")

--- a/main/src/library/Concurrent/Channel.flix
+++ b/main/src/library/Concurrent/Channel.flix
@@ -207,7 +207,6 @@ namespace Concurrent/Channel {
         // Gets an element from the channel c which must be non-empty
         // and update the size.
         let optionalElement = MutDeque.popFront(elementDeque);
-        size := deref size - 1;
 
         let value = match optionalElement {
             case None =>
@@ -217,6 +216,7 @@ namespace Concurrent/Channel {
 
             case Some(element) =>
                 // Signal waiting setters that the channel has space
+                size := deref size - 1;
                 signalPutters(admin);
                 unlock(channelLock);
                 element
@@ -289,7 +289,6 @@ namespace Concurrent/Channel {
         // Try to get the element (which could already be taken by someone
         // else) and update size.
         let optionalElement = MutDeque.popFront(elementDeque);
-        size := deref size - 1;
 
         match optionalElement {
             case None => { // No element was found
@@ -317,6 +316,7 @@ namespace Concurrent/Channel {
 
             case Some(e) =>
                 // Signal waiting setters that the channel has space
+                size := deref size - 1;
                 signalPutters(admin);
                 e
         }

--- a/main/test/flix/Test.Exp.Regions.flix
+++ b/main/test/flix/Test.Exp.Regions.flix
@@ -1493,4 +1493,11 @@ namespace Test/Exp/Regions {
             }
         }
 
+    @test
+     def testRegionExit01(): Bool \ IO = 
+         let x  = ref false;
+         region r {
+             spawn { Thread.sleep(Time/Duration.fromSeconds(1)); x := true } @ r
+         };
+         deref x
 }


### PR DESCRIPTION
This replaces #5122 (which I will close).

This completes the Region class tasks of https://github.com/flix/flix/issues/4850 (so the Region class is both being generated and called on scope exit)

It also includes the fix to `size` within the channel code discussed within #5121 because once I addressed the race condition discussed there, I did see occasional failures as a result of this.

With this code, I have run the tests in `Test.Exp.Concurrency.Spawn.flix` 100 times without a single failure.