### PR TITLE
refactor: add extra region paramater to functions on Array, etc. that return new Arrays etc. (issue #4962)

### DIFF
--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -18,9 +18,9 @@ instance Scoped[Array[a]] {
     pub def regionOf(_: Array[a, r]): Region[r] = unsafe_cast () as Region[r]
 }
 
-instance Iterable[Array] {
-    pub def iterator(a: Array[a, r]): Iterator[a, r] \ Write(r) = Array.iterator(a)
-}
+/// instance Iterable[Array] {
+///    pub def iterator(a: Array[a, r]): Iterator[a, r] \ Write(r) = Array.iterator(a)
+/// }
 
 namespace Array {
 
@@ -105,7 +105,8 @@ namespace Array {
     ///
     /// Equivalent to the expression `a[b..e]`.
     ///
-    pub def slice(b: Int32, e: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } = a[b..e]
+    pub def slice(_: Region[r1], b: Int32, e: Int32, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
+        unsafe_cast a[b..e] as Array[a, r1] \ { Read(r), Write(r1) }
 
     ///
     /// Returns the array `a` as a list.
@@ -217,14 +218,13 @@ namespace Array {
     ///
     /// Return a new array, appending the elements `b` to elements of `a`.
     ///
-    pub def append(a: Array[a, r1], b: Array[a, r2]): Array[a, r1] \ { Read(r2), Write(r1) } =
-        let r1 = Scoped.regionOf(a);
+    pub def append(r3: Region[r3], a: Array[a, r1], b: Array[a, r2]): Array[a, r3] \ { Read(r1), Read(r2), Write(r3) } =
         let len1 = length(a);
         let len2 = length(b);
         if (len1 == 0)
-            copyOfRange(r1, 0, len2, b)
+            copyOfRange(r3, 0, len2, b)
         else {
-            let out = copyOfRange(r1, 0, len1 + len2, a);
+            let out = copyOfRange(r3, 0, len1 + len2, a);
             updateSequence!(len1, b, out);
             out
         }
@@ -412,10 +412,9 @@ namespace Array {
     ///
     /// The result is a new array.
     ///
-    pub def map(f: a -> b \ ef, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
+    pub def map(r1: Region[r1], f: a -> b \ ef, a: Array[a, r]): Array[b, r1] \ { ef, Read(r), Write(r1) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
-        init(r, i -> f(a[i]), len)
+        init(r1, i -> f(a[i]), len)
 
     ///
     /// Apply `f` to every element in array `arr`. Array `arr` is mutated.
@@ -437,10 +436,9 @@ namespace Array {
     ///
     /// That is, the result is of the form: `[ f(a[0], 0), f(a[1], 1), ... ]`.
     ///
-    pub def mapWithIndex(f: (Int32, a) -> b \ ef, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
+    pub def mapWithIndex(r1: Region[r1], f: (Int32, a) -> b \ ef, a: Array[a, r]): Array[b, r1] \ { ef, Read(r), Write(r1) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
-        init(r, i -> f(i, a[i]), len)
+        init(r1, i -> f(i, a[i]), len)
 
     ///
     /// Apply `f` to every element in array `a` along with that element's index. Array `a` is mutated.
@@ -460,19 +458,17 @@ namespace Array {
     ///
     /// Returns the result of applying `f` to every element in `a` and concatenating the results.
     ///
-    pub def flatMap(f: a -> Array[b, r] \ ef, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
+    pub def flatMap(r1: Region[r1], f: a -> Array[b, r1] \ ef, a: Array[a, r]): Array[b, r1] \ { ef, Read(r), Write(r1) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
-        init(r, i -> f(a[i]), len) |> flatten
+        init(r1, i -> f(a[i]), len) |> flatten(r1)
 
     ///
     /// Returns the reverse of `a`.
     ///
-    pub def reverse(a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
+    pub def reverse(r1: Region[r1], a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
         let len = length(a);
         let end = len - 1;
-        let r = Scoped.regionOf(a);
-        init(r, i -> a[end - i], len)
+        init(r1, i -> a[end - i], len)
 
     ///
     /// Reverse the array `arr`, mutating it in place.
@@ -551,17 +547,16 @@ namespace Array {
     ///
     /// Returns a shallow copy of `a` if `i < 0` or `i > length(xs)-1`.
     ///
-    pub def update(i: Int32, x: a, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
+    pub def update(r1: Region[r1], i: Int32, x: a, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
         let f = ix -> if (ix == i) x else a[ix];
-        init(r, f, len)
+        init(r1, f, len)
 
     ///
     /// Returns a copy of `a` with every occurrence of `from` replaced by `to`.
     ///
-    pub def replace(from: {from = a}, to: {to = a}, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } with Eq[a] =
-        map(e -> if (e == from.from) to.to else e, a)
+    pub def replace(r1: Region[r1], from: {from = a}, to: {to = a}, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } with Eq[a] =
+        map(r1, e -> if (e == from.from) to.to else e, a)
 
     ///
     /// Replace every occurrence of `from` by `to` in the array `a`, mutating it in place.
@@ -576,12 +571,11 @@ namespace Array {
     /// If `a` becomes depleted then no further patching is done.
     /// If patching occurs at index `i+j` in `b`, then the element at index `j` in `a` is used.
     ///
-    pub def patch(i: Int32, n: Int32, a: Array[a, r1], b: Array[a, r2]): Array[a, r2] \ { Read(r1, r2), Write(r2) } =
+    pub def patch(r3: Region[r3], i: Int32, n: Int32, a: Array[a, r1], b: Array[a, r2]): Array[a, r3] \ { Read(r1, r2), Write(r3) } =
         let len1 = length(a);
-        let r2 = Scoped.regionOf(b);
         let size = if (n > len1) len1 else n;
-        let sub = copyOfRange(r2, 0, size, a);
-        updateSequence(i, sub, b)
+        let sub = copyOfRange(r3, 0, size, a);
+        updateSequence(r3, i, sub, b)
 
     ///
     /// Update the mutable array `b` replacing `n` elements starting at index `i` with the corresponding elements of array `a`.
@@ -600,14 +594,13 @@ namespace Array {
     ///
     /// Returns `a` with `x` inserted between every two adjacent elements.
     ///
-    pub def intersperse(x: a, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) }=
+    pub def intersperse(r1: Region[r1], x: a, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) }=
         let len1 = length(a);
         let len2 = len1 + len1 - 1;
-        let r = Scoped.regionOf(a);
         if (len2 <= 0)
-            [] @ r
+            [] @ r1
         else {
-            let b = new(r, x, len2);
+            let b = new(r1, x, len2);
             let f = { (i, v) -> let j = i + i; b[j] = v };
             forEachWithIndex(f, a);
             b
@@ -616,16 +609,15 @@ namespace Array {
     ///
     /// Returns the concatenation of the elements in `arrs` with the elements of `sep` inserted between every two adjacent elements.
     ///
-    pub def intercalate(sep: Array[a, r], arrs: Array[Array[a, r], r]): Array[a, r] \ { Read(r), Write(r) } =
-        let r = Scoped.regionOf(arrs);
+    pub def intercalate(r1: Region[r1], sep: Array[a, r], arrs: Array[Array[a, r], r]): Array[a, r1] \ { Read(r), Write(r1) } =
         let count = length(arrs);
         let sepLength = length(sep);
         let sepCount = if (count < 2) 0 else count - 1;
         let len = sumLengths(arrs) + (sepCount * sepLength);
         match headArrays(arrs) {
-            case None    => [] @ r
+            case None    => [] @ r1
             case Some(x) =>
-                let out = new(r, x, len);
+                let out = new(r1, x, len);
                 let overwrite = { (st, a) ->
                     let (pos,i) = st;
                     if (i == 0) {
@@ -682,18 +674,17 @@ namespace Array {
     ///
     /// Returns `a` if the dimensions of the elements of `a` are mismatched.
     ///
-    pub def transpose(a: Array[Array[a, r1], r2]): Array[Array[a, r1], r2] \ { Read(r1, r2), Write(r1, r2) } =
+    pub def transpose(r3: Region[r3], a: Array[Array[a, r1], r2]): Array[Array[a, r3], r3] \ { Read(r1, r2), Write(r3) } =
         let ilen = length(a);
-        let r2 = Scoped.regionOf(a);
         if (ilen == 0)
-            [] @ r2
+            [] @ r3
         else {
-            let r1 = Scoped.regionOf(a[0]);
             let jlen = length(a[0]);
             if (jlen == 0 or uniformHelper(a, jlen))
-                a
+                // Non-transposing nested copy
+                init(r3, i -> copyOfRange(r3, 0, jlen, a[i]), ilen)
             else
-                init(r2, i -> init(r1, j -> a[j][i], ilen), jlen)
+                init(r3, i -> init(r3, j -> a[j][i], ilen), jlen)
         }
 
     ///
@@ -910,13 +901,12 @@ namespace Array {
     ///
     /// Returns the concatenation of the arrays of in the array `arrs`.
     ///
-    pub def flatten(arrs: Array[Array[a, r], r]) : Array[a, r] \ { Read(r), Write(r) } =
+    pub def flatten(r1: Region[r1], arrs: Array[Array[a, r], r]) : Array[a, r1] \ { Read(r), Write(r1) } =
         let len = sumLengths(arrs);
-        let r = Scoped.regionOf(arrs);
         match headArrays(arrs) {
-            case None => [] @ r
+            case None => [] @ r1
             case Some(x) => {
-                let out = new(r, x, len);
+                let out = new(r1, x, len);
                 discard foldLeft((pos, a) -> arrayWrites(pos, a, out), 0, arrs);
                 out
             }
@@ -959,13 +949,12 @@ namespace Array {
     ///
     /// Returns an array of every element in `arr` that satisfies the predicate `f`.
     ///
-    pub def filter(f: a -> Bool \ ef, arr: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
+    pub def filter(r1: Region[r1], f: a -> Bool \ ef, arr: Array[a, r]): Array[a, r1] \ { ef, Read(r), Write(r1) } =
         let len = length(arr);
-        let r = Scoped.regionOf(arr);
         if (len < 1) {
-            [] @ r
+            [] @ r1
         } else {
-            let out = new(r, arr[0], len);
+            let out = new(r1, arr[0], len);
             def loop(i, j) = {
                 if (i >= len)
                     j
@@ -980,23 +969,22 @@ namespace Array {
                 }
             };
             let endPos = loop(0, 0);
-            copyOfRange(r, 0, endPos, out)
+            copyOfRange(r1, 0, endPos, out)
         }
 
     ///
-    /// Returns a pair of lists `(a1, a2)`.
+    /// Returns a pair of arrays `(a1, a2)`.
     ///
     /// `a1` contains all elements of `a` that satisfy the predicate `f`.
     /// `a2` contains all elements of `a` that do not satisfy the predicate `f`.
     ///
-    pub def partition(f: a -> Bool \ ef, a: Array[a, r]): (Array[a, r], Array[a, r]) \ { ef, Read(r), Write(r) } =
+    pub def partition(r1: Region[r1], r2: Region[r2], f: a -> Bool \ ef, a: Array[a, r]): (Array[a, r1], Array[a, r2]) \ { ef, Read(r), Write(r1), Write(r2) } =
         let step = { (x, acc) ->
             let (a1, a2) = acc;
             if (f(x)) (x :: a1, a2) else (a1, x :: a2)
         };
         let (xs, ys) = foldRight(step, (Nil, Nil), a);
-        let r = Scoped.regionOf(a);
-        (List.toArray(r, xs), List.toArray(r, ys))
+        (List.toArray(r1, xs), List.toArray(r2, ys))
 
     ///
     /// Returns a pair of arrays `(a1, a2)`.
@@ -1004,32 +992,30 @@ namespace Array {
     /// `a1` is the longest prefix of `a` that satisfies the predicate `f`.
     /// `a2` is the remainder of `a`.
     ///
-    pub def span(f: a -> Bool \ ef, a: Array[a, r]): (Array[a, r], Array[a, r]) \ { ef, Read(r), Write(r) }=
-        let r = Scoped.regionOf(a);
+    pub def span(r1: Region[r1], r2: Region[r2], f: a -> Bool \ ef, a: Array[a, r]): (Array[a, r1], Array[a, r2]) \ { ef, Read(r), Write(r1), Write(r2) } =
         match findIndexOfLeft(x -> not (f(x)), a) {
-            case None    => (takeLeft(length(a), a), [] @ r)
-            case Some(i) => (takeLeft(i, a), dropLeft(i, a))
+            case None    => (takeLeft(r1, length(a), a), [] @ r2)
+            case Some(i) => (takeLeft(r1, i, a), dropLeft(r2, i, a))
         }
 
     ///
     /// Alias for `dropLeft`.
     ///
-    pub def drop(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
-        dropLeft(n, a)
+    pub def drop(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
+        dropLeft(r1, n, a)
 
     ///
     /// Returns a copy of array `a`, dropping the first `n` elements.
     ///
     /// Returns `[]` if `n > length(a)`.
     ///
-    pub def dropLeft(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
+    pub def dropLeft(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
         if (n > len)
-            [] @ r
+            [] @ r1
         else {
             let start = if (n < 0) 0 else n;
-            copyOfRange(r, start, len, a)
+            copyOfRange(r1, start, len, a)
         }
 
     ///
@@ -1037,61 +1023,57 @@ namespace Array {
     ///
     /// Returns `[]` if `n > length(a)`.
     ///
-    pub def dropRight(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
-        let r = Scoped.regionOf(a);
+    pub def dropRight(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
         let len = length(a);
         if (n >= len)
-            [] @ r
+            [] @ r1
         else {
             let end = if (n < 0) len else len - n;
-            copyOfRange(r, 0, end, a)
+            copyOfRange(r1, 0, end, a)
         }
 
     ///
     /// Alias for `dropWhileLeft`.
     ///
-    pub def dropWhile(f: a -> Bool \ ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
-        dropWhileLeft(f, a)
+    pub def dropWhile(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, Read(r), Write(r1) } =
+        dropWhileLeft(r1, f, a)
 
     ///
     /// Returns copy of array `a` without the longest prefix that satisfies the predicate `f`.
     ///
-    pub def dropWhileLeft(f: a -> Bool \ ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
-        let r = Scoped.regionOf(a);
+    pub def dropWhileLeft(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, Read(r), Write(r1) } =
         match findIndexOfLeft(x -> not (f(x)), a) {
-            case None    => [] @ r
-            case Some(i) => dropLeft(i, a)
+            case None    => [] @ r1
+            case Some(i) => dropLeft(r1, i, a)
         }
 
     ///
     /// Returns copy of array `a` without the longest suffix that satisfies the predicate `f`.
     ///
-    pub def dropWhileRight(f: a -> Bool \ ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
-        let r = Scoped.regionOf(a);
+    pub def dropWhileRight(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, Read(r), Write(r1) } =
         match findIndexOfRight(x -> not (f(x)), a) {
-            case None    => [] @ r
-            case Some(i) => copyOfRange(r, 0, i + 1, a)
+            case None    => [] @ r1
+            case Some(i) => copyOfRange(r1, 0, i + 1, a)
         }
 
     ///
     /// Alias for `takeLeft`.
     ///
-    pub def take(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
-        takeLeft(n, a)
+    pub def take(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
+        takeLeft(r1, n, a)
 
     ///
     /// Returns a fresh array taking first `n` elements of `a`.
     ///
     /// Returns `a` if `n > length(xs)`.
     ///
-    pub def takeLeft(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
-        let r = Scoped.regionOf(a);
+    pub def takeLeft(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
         if (n <= 0)
-            [] @ r
+            [] @ r1
         else {
             let len = length(a);
             let end = if (n > len) len else n;
-            copyOfRange(r, 0, end, a)
+            copyOfRange(r1, 0, end, a)
         }
 
     ///
@@ -1099,14 +1081,13 @@ namespace Array {
     ///
     /// Returns `a` if `n > length(xs)`.
     ///
-    pub def takeRight(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
-        let r = Scoped.regionOf(a);
+    pub def takeRight(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
         if (n <= 0)
-            [] @ r
+            [] @ r1
         else {
             let len = length(a);
             let start = if (n > len) 0 else len - n;
-            copyOfRange(r, start, len, a)
+            copyOfRange(r1, start, len, a)
         }
 
     ///
@@ -1114,18 +1095,18 @@ namespace Array {
     ///
     /// The function `f` must be pure.
     ///
-    pub def takeWhile(f: a -> Bool \ ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
-        takeWhileLeft(f, a)
+    pub def takeWhile(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, Read(r), Write(r1) } =
+        takeWhileLeft(r1, f, a)
 
     ///
     /// Returns the longest prefix of `a` that satisfies the predicate `f`.
     ///
     /// The function `f` must be pure.
     ///
-    pub def takeWhileLeft(f: a -> Bool \ ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
+    pub def takeWhileLeft(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, Read(r), Write(r1) } =
         match findIndexOfLeft(x -> not (f(x)), a) {
-            case None    => a
-            case Some(i) => takeLeft(i, a)
+            case None    => copyOfRange(r1, 0, length(a), a)
+            case Some(i) => takeLeft(r1, i, a)
         }
 
     ///
@@ -1133,11 +1114,10 @@ namespace Array {
     ///
     /// The function `f` must be pure.
     ///
-    pub def takeWhileRight(f: a -> Bool \ ef, a: Array[a, r]): Array[a, r] \ { ef, Read(r), Write(r) } =
-        let r = Scoped.regionOf(a);
+    pub def takeWhileRight(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, Read(r), Write(r1) } =
         match findIndexOfRight(x -> not (f(x)), a) {
-            case None    => copyOfRange(r, 0, length(a), a)
-            case Some(i) => copyOfRange(r, i + 1, length(a), a)
+            case None    => copyOfRange(r1, 0, length(a), a)
+            case Some(i) => copyOfRange(r1, i + 1, length(a), a)
         }
 
     ///
@@ -1196,10 +1176,9 @@ namespace Array {
     ///
     /// If either `a` or `b` becomes depleted, then no further elements are added to the resulting array.
     ///
-    pub def zip(a: Array[a, r1], b: Array[b, r2]): Array[(a, b), r2] \ { Read(r1, r2), Write(r2) } =
+    pub def zip(r3: Region[r3], a: Array[a, r1], b: Array[b, r2]): Array[(a, b), r3] \ { Read(r1, r2), Write(r3) } =
         let len = Int32.min(length(a), length(b));
-        let r2 = Scoped.regionOf(b);
-        init(r2, i -> (a[i], b[i]), len)
+        init(r3, i -> (a[i], b[i]), len)
 
     ///
     /// Returns an array where the element at index `i` is `f(x, y)` where
@@ -1207,10 +1186,9 @@ namespace Array {
     ///
     /// If either `a` or `b` becomes depleted, then no further elements are added to the resulting array.
     ///
-    pub def zipWith(f: (a, b) -> c \ ef, a: Array[a, r1], b: Array[b, r2]): Array[c, r2] \ { ef, Read(r1, r2), Write(r2) } =
+    pub def zipWith(r3: Region[r3], f: (a, b) -> c \ ef, a: Array[a, r1], b: Array[b, r2]): Array[c, r3] \ { ef, Read(r1, r2), Write(r3) } =
         let len = Int32.min(length(a), length(b));
-        let r2 = Scoped.regionOf(b);
-        init(r2, i -> f(a[i], b[i]), len)
+        init(r3, i -> f(a[i], b[i]), len)
 
     ///
     /// Returns a pair of arrays, the first containing all first components in `a`
@@ -1276,11 +1254,10 @@ namespace Array {
     ///
     /// Collects the results of applying the partial function `f` to every element in `a`.
     ///
-    pub def filterMap(f: a -> Option[b] \ ef, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
-        let r = Scoped.regionOf(a);
+    pub def filterMap(r1: Region[r1], f: a -> Option[b] \ ef, a: Array[a, r]): Array[b, r1] \ { ef, Read(r), Write(r1) } =
         foldRight((x, xs) -> match f(x) {
             case None    => xs
-            case Some(b) => b :: xs }, Nil, a) |> List.toArray(r)
+            case Some(b) => b :: xs }, Nil, a) |> List.toArray(r1)
 
     ///
     /// Returns the first non-None result of applying the partial function `f` to each element of `xs`.
@@ -1431,12 +1408,12 @@ namespace Array {
     ///
     /// Modifying `a` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(a: Array[a, r]): Iterator[a, r] \ Write(r) =
-        let r = Scoped.regionOf(a);
-        let i = ref 0 @ r;
+    pub def iterator(r1: Region[r1], a: Array[a, r]): Iterator[a, r1] \ { Read(r), Write(r1) } =
+        let i = ref 0 @ r1;
+        let a1 = copyOfRange(r1, 0, length(a), a);  // TODO - avoid this copy...
         let done = () -> deref i == length(a);
         let next = () -> {
-            let x = a[deref i];
+            let x = a1[deref i];
             i := deref i + 1;
             x
         };
@@ -1447,8 +1424,8 @@ namespace Array {
     ///
     /// Modifying `a` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def enumerator(a: Array[a, r]): Iterator[(a, Int32), r] \ { Read(r), Write(r) } =
-        iterator(a) |> Iterator.zipWithIndex
+    pub def enumerator(r1: Region[r1], a: Array[a, r]): Iterator[(a, Int32), r1] \ { Read(r), Write(r1) } =
+        iterator(r1, a) |> Iterator.zipWithIndex
 
     ///
     /// Apply the effectful function `f` to all the elements in the array `a`.
@@ -1483,12 +1460,11 @@ namespace Array {
     ///
     /// Returns a copy of `a` with the elements starting at index `i` replaced by `sub`.
     ///
-    pub def updateSequence(i: Int32, sub: Array[a, r1], a: Array[a, r2]): Array[a, r2] \ { Read(r1, r2), Write(r2) } =
+    pub def updateSequence(r3: Region[r3], i: Int32, sub: Array[a, r1], a: Array[a, r2]): Array[a, r3] \ { Read(r1, r2), Write(r3) } =
         let end = i + length(sub);
         let f = ix -> if (ix >= i and ix < end) sub[ix - i] else a[ix];
         let len = length(a);
-        let r2 = Scoped.regionOf(a);
-        init(r2, f, len)
+        init(r3, f, len)
 
     ///
     /// Update the mutable array `a` with the elements starting at index `i` replaced by `sub`.
@@ -1530,8 +1506,8 @@ namespace Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sort(a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } with Order[a] =
-        sortWith(Order.compare, a)
+    pub def sort(r1: Region[r1], a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } with Order[a] =
+        sortWith(r1, Order.compare, a)
 
     ///
     /// Returns a sorted copy of array `a`, where the elements are ordered from low to high according to
@@ -1541,8 +1517,8 @@ namespace Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortBy(f: a -> b, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } with Order[b] =
-        sortWith(Order.compare `on` f, a)
+    pub def sortBy(r1: Region[r1], f: a -> b, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } with Order[b] =
+        sortWith(r1, Order.compare `on` f, a)
 
     ///
     /// Returns a sorted copy of array `a`, where the elements are ordered from low to high according to
@@ -1552,10 +1528,9 @@ namespace Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortWith(cmp: (a,a) -> Comparison, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
+    pub def sortWith(r1: Region[r1], cmp: (a,a) -> Comparison, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
-        let b = copyOfRange(r, 0, len, a);
+        let b = copyOfRange(r1, 0, len, a);
         sortWith!(cmp, b);
         b
 

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -682,7 +682,7 @@ namespace Array {
             let jlen = length(a[0]);
             if (jlen == 0 or uniformHelper(a, jlen))
                 // Non-transposing nested copy
-                init(r3, i -> copyOfRange(r3, 0, jlen, a[i]), ilen)
+                init(r3, i -> copyOfRange(r3, 0, length(a[i]), a[i]), ilen)
             else
                 init(r3, i -> init(r3, j -> a[j][i], ilen), jlen)
         }

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -18,9 +18,9 @@ instance Scoped[Array[a]] {
     pub def regionOf(_: Array[a, r]): Region[r] = unsafe_cast () as Region[r]
 }
 
-/// instance Iterable[Array] {
-///    pub def iterator(a: Array[a, r]): Iterator[a, r] \ Write(r) = Array.iterator(a)
-/// }
+instance Iterable[Array] {
+    pub def iterator(a: Array[a, r]): Iterator[a, r] \ Write(r) = Array.iterator(a)
+}
 
 namespace Array {
 
@@ -1408,12 +1408,12 @@ namespace Array {
     ///
     /// Modifying `a` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(r1: Region[r1], a: Array[a, r]): Iterator[a, r1] \ { Read(r), Write(r1) } =
-        let i = ref 0 @ r1;
-        let a1 = copyOfRange(r1, 0, length(a), a);  // TODO - avoid this copy...
+    pub def iterator(a: Array[a, r]): Iterator[a, r] \ Write(r) =
+        let r = Scoped.regionOf(a);
+        let i = ref 0 @ r;
         let done = () -> deref i == length(a);
         let next = () -> {
-            let x = a1[deref i];
+            let x = a[deref i];
             i := deref i + 1;
             x
         };
@@ -1424,8 +1424,8 @@ namespace Array {
     ///
     /// Modifying `a` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def enumerator(r1: Region[r1], a: Array[a, r]): Iterator[(a, Int32), r1] \ { Read(r), Write(r1) } =
-        iterator(r1, a) |> Iterator.zipWithIndex
+    pub def enumerator(a: Array[a, r]): Iterator[(a, Int32), r] \ { Read(r), Write(r) } =
+        iterator(a) |> Iterator.zipWithIndex
 
     ///
     /// Apply the effectful function `f` to all the elements in the array `a`.

--- a/main/src/library/Benchmark.flix
+++ b/main/src/library/Benchmark.flix
@@ -70,7 +70,7 @@ namespace Benchmark {
             let t = nanoTime();
             printHeader();
             println("");
-            let benchmarksWithEstimates = warmupAndEstimate(bs);
+            let benchmarksWithEstimates = warmupAndEstimate(Static, bs);
             println("");
             println("");
             printCols();
@@ -84,9 +84,9 @@ namespace Benchmark {
     ///
     /// Runs every benchmark in `bs` once and estimates its duration.
     ///
-    def warmupAndEstimate(bs: Array[Benchmark, r]): Array[(Benchmark, Int64), r] \ IO = {
+    def warmupAndEstimate(r1: Region[r1], bs: Array[Benchmark, r]): Array[(Benchmark, Int64), r1] \ IO = {
         Console.print("Warmup: ");
-        bs |> Array.map(b -> {
+        bs |> Array.map(r1, b -> {
             let time = runBenchmarkOnce(b);
             Console.print(".");
             (b, time)

--- a/main/src/library/Concurrent/Channel.flix
+++ b/main/src/library/Concurrent/Channel.flix
@@ -133,8 +133,8 @@ namespace Concurrent/Channel {
             ),
             new MutDeque(Static)
         )
-    
-    /// 
+
+    ///
     /// Creates a new channel tuple (sender, receiver)
     ///
     @Internal
@@ -250,8 +250,8 @@ namespace Concurrent/Channel {
 
         // Sort locks to avoid deadlocks
         let sortedLocks = channels |>
-            Array.sortBy(match MpmcAdmin(id, _, _, _, _, _, _) -> id) |>
-            Array.map(match MpmcAdmin(_, rlock, _, _, _, _, _) -> rlock);
+            Array.sortBy(Static, match MpmcAdmin(id, _, _, _, _, _, _) -> id) |>
+            Array.map(Static, match MpmcAdmin(_, rlock, _, _, _, _, _) -> rlock);
         selectHelper(channels, blocking, sortedLocks, selectLock, selectCondition)
 
     ///
@@ -354,7 +354,7 @@ namespace Concurrent/Channel {
                  randomized to avoid starvation scenarios).
         */
         let index = channels |>
-            Array.mapWithIndex(i -> match MpmcAdmin(_, _, _, _, size, _, _) -> {
+            Array.mapWithIndex(Static, i -> match MpmcAdmin(_, _, _, _, size, _, _) -> {
                 (deref size > 0, i)
             }) |>
             Array.findLeft(match (b, _) -> b) |>

--- a/main/src/library/File.flix
+++ b/main/src/library/File.flix
@@ -549,7 +549,7 @@ namespace File {
         } else {
             let countBiggest = numberRead < count;
             if (countBiggest) {
-                Array.slice(0, numberRead, bytes)
+                Array.slice(Static, 0, numberRead, bytes)
             } else {
                 bytes
             }
@@ -891,7 +891,7 @@ namespace File {
     ///
     /// Does not recursively traverse the directory.
     ///
-    pub def list(f: String): Result[List[String], String] \ IO =
+    pub def list(f: String): Result[List[String], String] \ IO = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.listFiles(): Array[##java.io.File, Static] \ IO;
@@ -901,7 +901,7 @@ namespace File {
             let javaList = f |> newFile |> listFiles;
 
             if (not Object.isNull(javaList)) {
-                let paths = javaList |> Array.map(toPath) |> Array.map(pathToString);
+                let paths = javaList |> Array.map(r, toPath >> pathToString);
                 Ok(Array.toList(paths))
             } else {
                 Err("An error occurred when trying to list the file: '${f}'.")
@@ -911,6 +911,7 @@ namespace File {
                 import java.lang.Throwable.getMessage(): String \ IO;
                 Err(getMessage(ex))
         }
+    }
 
     ///
     /// Returns an Iterator naming the files and directories in the directory `f`.

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -386,7 +386,7 @@ namespace MutDeque {
         else if (i  < j)
             Array.copyOfRange(r1, i, j, deref a)
         else
-            Array.append(Array.copyOfRange(r1, i, len, deref a), Array.copyOfRange(r1, 0, j, deref a))
+            Array.append(r1, Array.copyOfRange(r1, i, len, deref a), Array.copyOfRange(r1, 0, j, deref a))
 
     ///
     /// Returns the concatenation of the string representation

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -39,9 +39,9 @@ instance Scoped[MutDeque[a]] {
     pub def regionOf(_: MutDeque[a, r]): Region[r] = unsafe_cast () as Region[r]
 }
 
-// instance Iterable[MutDeque] {
-//     pub def iterator(d: MutDeque[a, r]): Iterator[a, r] \ Write(r) = MutDeque.iterator(d)
-// }
+instance Iterable[MutDeque] {
+    pub def iterator(d: MutDeque[a, r]): Iterator[a, r] \ Write(r) = MutDeque.iterator(d)
+}
 
 namespace MutDeque {
 
@@ -412,17 +412,14 @@ namespace MutDeque {
     ///
     /// Modifying `d` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(r1: Region[r1], d: MutDeque[a, r]): Iterator[a, r1] \ { Read(r), Write(r1) } =
+    pub def iterator(d: MutDeque[a, r]): Iterator[a, r] \ Write(r) =
+        let r = Scoped.regionOf(d);
         let MutDeque(a, f, b) = d;
-        let i = ref (deref f) @ r1;
-        let arr = deref a;
-        let arr1 = Array.copyOfRange(r1, 0, Array.length(arr), arr);  // TODO - avoid this copy...
-        let a1 = ref arr1 @ r1;
-        let done = () -> deref i == unsafe_cast deref b as _ \ r1;
+        let i = ref (deref f) @ r;
+        let done = () -> deref i == deref b;
         let next = () -> {
-            let x = (deref a1)[deref i];
-            let cap = unsafe_cast capacity(d) as _ \ r1;
-            i := deref i + 1 &&& (cap - 1);
+            let x = (deref a)[deref i];
+            i := deref i + 1 &&& (capacity(d) - 1);
             x
         };
         Iterator(done, next)

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -39,9 +39,9 @@ instance Scoped[MutDeque[a]] {
     pub def regionOf(_: MutDeque[a, r]): Region[r] = unsafe_cast () as Region[r]
 }
 
-instance Iterable[MutDeque] {
-    pub def iterator(d: MutDeque[a, r]): Iterator[a, r] \ Write(r) = MutDeque.iterator(d)
-}
+// instance Iterable[MutDeque] {
+//     pub def iterator(d: MutDeque[a, r]): Iterator[a, r] \ Write(r) = MutDeque.iterator(d)
+// }
 
 namespace MutDeque {
 
@@ -412,14 +412,17 @@ namespace MutDeque {
     ///
     /// Modifying `d` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(d: MutDeque[a, r]): Iterator[a, r] \ Write(r) =
-        let r = Scoped.regionOf(d);
+    pub def iterator(r1: Region[r1], d: MutDeque[a, r]): Iterator[a, r1] \ { Read(r), Write(r1) } =
         let MutDeque(a, f, b) = d;
-        let i = ref (deref f) @ r;
-        let done = () -> deref i == deref b;
+        let i = ref (deref f) @ r1;
+        let arr = deref a;
+        let arr1 = Array.copyOfRange(r1, 0, Array.length(arr), arr);  // TODO - avoid this copy...
+        let a1 = ref arr1 @ r1;
+        let done = () -> deref i == unsafe_cast deref b as _ \ r1;
         let next = () -> {
-            let x = (deref a)[deref i];
-            i := deref i + 1 &&& (capacity(d) - 1);
+            let x = (deref a1)[deref i];
+            let cap = unsafe_cast capacity(d) as _ \ r1;
+            i := deref i + 1 &&& (cap - 1);
             x
         };
         Iterator(done, next)

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -33,9 +33,9 @@ instance Scoped[MutList[a]] {
     pub def regionOf(_: MutList[a, r]): Region[r] = unsafe_cast () as Region[r]
 }
 
-// instance Iterable[MutList] {
-//     pub def iterator(l: MutList[a, r]): Iterator[a, r] \ Write(r) = MutList.iterator(l)
-// }
+instance Iterable[MutList] {
+    pub def iterator(l: MutList[a, r]): Iterator[a, r] \ Write(r) = MutList.iterator(l)
+}
 
 namespace MutList {
 
@@ -798,16 +798,13 @@ namespace MutList {
     ///
     /// Modifying `l` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(r1: Region[r1], l: MutList[a, r]): Iterator[a, r1] \ { Read(r), Write(r1) } =
+    pub def iterator(l: MutList[a, r]): Iterator[a, r] \ Write(r) =
+        let r = Scoped.regionOf(l);
         let MutList(a, len) = l;
-        let i = ref 0 @ r1;
-        let arr = deref a;
-        let arr1 = Array.copyOfRange(r1, 0, Array.length(arr), arr);  // TODO - avoid this copy...
-        let len1 = ref (deref len) @ r1;
-        let a1 = ref arr1 @ r1;
-        let done = () -> deref i == deref len1;
+        let i = ref 0 @ r;
+        let done = () -> deref i == deref len;
         let next = () -> {
-            let x = (deref a1)[deref i];
+            let x = (deref a)[deref i];
             i := deref i + 1;
             x
         };

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -33,9 +33,9 @@ instance Scoped[MutList[a]] {
     pub def regionOf(_: MutList[a, r]): Region[r] = unsafe_cast () as Region[r]
 }
 
-instance Iterable[MutList] {
-    pub def iterator(l: MutList[a, r]): Iterator[a, r] \ Write(r) = MutList.iterator(l)
-}
+// instance Iterable[MutList] {
+//     pub def iterator(l: MutList[a, r]): Iterator[a, r] \ Write(r) = MutList.iterator(l)
+// }
 
 namespace MutList {
 
@@ -354,16 +354,15 @@ namespace MutList {
     ///
     /// The result is a new mutable list.
     ///
-    pub def map(f: a -> b \ ef, v: MutList[a, r]): MutList[b, r] \ { ef, Read(r), Write(r) } =
-        let r = Scoped.regionOf(v);
+    pub def map(r1: Region[r1], f: a -> b \ ef, v: MutList[a, r]): MutList[b, r1] \ { ef, Read(r), Write(r1) } =
         if (isEmpty(v))
-            new MutList(r)
+            new MutList(r1)
         else {
             let MutList(ra, rl) = v;
             let a = deref ra;
             let l = deref rl;
             let x = f(a[0]);
-            let b = [x; Array.length(a)] @ r;
+            let b = [x; Array.length(a)] @ r1;
             def loop(i) = {
                 if (i >= l)
                     ()
@@ -373,22 +372,21 @@ namespace MutList {
                 }
             };
             loop(1);
-            MutList(ref b @ r, ref l @ r)
+            MutList(ref b @ r1, ref l @ r1)
         }
 
     ///
     /// Returns the result of applying `f` to every element in `v` along with that element's index.
     ///
-    pub def mapWithIndex(f: (Int32, a) -> b \ ef, v: MutList[a, r]): MutList[b, r] \ { ef, Read(r), Write(r) } =
-        let r = Scoped.regionOf(v);
+    pub def mapWithIndex(r1: Region[r1], f: (Int32, a) -> b \ ef, v: MutList[a, r]): MutList[b, r1] \ { ef, Read(r), Write(r1) } =
         if (isEmpty(v))
-            new MutList(r)
+            new MutList(r1)
         else {
             let MutList(ra, rl) = v;
             let a = deref ra;
             let l = deref rl;
             let x = f(0, a[0]);
-            let b = [x; Array.length(a)] @ r;
+            let b = [x; Array.length(a)] @ r1;
             def loop(i) = {
                 if (i >= l)
                     ()
@@ -398,7 +396,7 @@ namespace MutList {
                 }
             };
             loop(1);
-            MutList(ref b @ r, ref l @ r)
+            MutList(ref b @ r1, ref l @ r1)
         }
 
     ///
@@ -534,14 +532,13 @@ namespace MutList {
     /// Returns a shallow copy of the given mutable list `v`.
     /// The capacity of the copy is equal to the length of the list.
     ///
-    pub def copy(v: MutList[a, r]): MutList[a, r] \ { Read(r), Write(r) } =
+    pub def copy(r1: Region[r1], v: MutList[a, r]): MutList[a, r1] \ { Read(r), Write(r1) } =
         let MutList(a, l) = v;
         let len = deref l;
-        let r = Scoped.regionOf(v);
         if (len > minCapacity())
-            MutList(ref Array.copyOfRange(r, 0, len, deref a) @ r, ref len @ r)
+            MutList(ref Array.copyOfRange(r1, 0, len, deref a) @ r1, ref len @ r1)
         else
-            MutList(ref Array.copyOfRange(r, 0, capacity(v), deref a) @ r, ref len @ r)
+            MutList(ref Array.copyOfRange(r1, 0, capacity(v), deref a) @ r1, ref len @ r1)
 
     ///
     /// Optionally removes and returns the last element in the given mutable list `v`.
@@ -801,13 +798,16 @@ namespace MutList {
     ///
     /// Modifying `l` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(l: MutList[a, r]): Iterator[a, r] \ Write(r) =
-        let r = Scoped.regionOf(l);
+    pub def iterator(r1: Region[r1], l: MutList[a, r]): Iterator[a, r1] \ { Read(r), Write(r1) } =
         let MutList(a, len) = l;
-        let i = ref 0 @ r;
-        let done = () -> deref i == deref len;
+        let i = ref 0 @ r1;
+        let arr = deref a;
+        let arr1 = Array.copyOfRange(r1, 0, Array.length(arr), arr);  // TODO - avoid this copy...
+        let len1 = ref (deref len) @ r1;
+        let a1 = ref arr1 @ r1;
+        let done = () -> deref i == deref len1;
         let next = () -> {
-            let x = (deref a)[deref i];
+            let x = (deref a1)[deref i];
             i := deref i + 1;
             x
         };
@@ -880,8 +880,8 @@ namespace MutList {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sort(v: MutList[a, r]): MutList[a, r] \ { Read(r), Write(r) } with Order[a] =
-        sortWith(Order.compare, v)
+    pub def sort(r1: Region[r1], v: MutList[a, r]): MutList[a, r1] \ { Read(r), Write(r1) } with Order[a] =
+        sortWith(r1, Order.compare, v)
 
     ///
     /// Returns a sorted copy of MutList `v`, where the elements are ordered from low to high according to
@@ -891,8 +891,8 @@ namespace MutList {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortBy(f: a -> b, v: MutList[a, r]): MutList[a, r] \ { Read(r), Write(r) } with Order[b] =
-        sortWith(Order.compare `on` f, v)
+    pub def sortBy(r1: Region[r1], f: a -> b, v: MutList[a, r]): MutList[a, r1] \ { Read(r), Write(r1) } with Order[b] =
+        sortWith(r1, Order.compare `on` f, v)
 
     ///
     /// Returns a sorted copy of MutList `v`, where the elements are ordered from low to high according to
@@ -902,8 +902,8 @@ namespace MutList {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortWith(cmp: (a,a) -> Comparison, v: MutList[a, r]): MutList[a, r] \ { Read(r), Write(r) } =
-        let vCopy = copy(v);
+    pub def sortWith(r1: Region[r1], cmp: (a,a) -> Comparison, v: MutList[a, r]): MutList[a, r1] \ { Read(r), Write(r1) } =
+        let vCopy = copy(r1, v);
         sortWith!(cmp, vCopy);
         vCopy
 

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -580,23 +580,26 @@ namespace MutMap {
     ///
     /// Returns an iterator over all key-value pairs in `m`.
     ///
-    pub def iterator(r1: Region[r1], m: MutMap[k, v, r]): Iterator[(k, v), r1] \ { Read(r), Write(r1) } =
+    pub def iterator(m: MutMap[k, v, r]): Iterator[(k, v), r] \ Write(r) =
         let MutMap(mm) = m;
-        Map.iterator(r1, deref mm)
+        let r = Scoped.regionOf(m);
+        Map.iterator(r, deref mm)
 
     ///
     /// Returns an iterator over keys in `m`.
     ///
-    pub def iteratorKeys(r1: Region[r1], m: MutMap[k, v, r]): Iterator[k, r1] \ { Read(r), Write(r1) } =
+    pub def iteratorKeys(m: MutMap[k, v, r]): Iterator[k, r] \ Write(r) =
         let MutMap(mm) = m;
-        Map.iteratorKeys(r1, deref mm)
+        let r = Scoped.regionOf(m);
+        Map.iteratorKeys(r, deref mm)
 
     ///
     /// Returns an iterator over values in `m`.
     ///
-    pub def iteratorValues(r1: Region[r1], m: MutMap[k, v, r]): Iterator[v, r1] \ { Read(r), Write(r1) } =
+    pub def iteratorValues(m: MutMap[k, v, r]): Iterator[v, r] \ Write(r) =
         let MutMap(mm) = m;
-        Map.iteratorValues(r1, deref mm)
+        let r = Scoped.regionOf(m);
+        Map.iteratorValues(r, deref mm)
 
     ///
     /// Extracts a range of key-value pairs from the mutable map `m`.

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -342,8 +342,8 @@ namespace MutMap {
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
     @ParallelWhenPure
-    pub def map(f: v1 -> v2 \ ef, m: MutMap[k, v1, r]): MutMap[k, v2, r] \ { ef, Read(r), Write(r) } =
-        mapWithKey(_ -> f, m)
+    pub def map(r1: Region[r1], f: v1 -> v2 \ ef, m: MutMap[k, v1, r]): MutMap[k, v2, r1] \ { ef, Read(r), Write(r1) } =
+        mapWithKey(r1, _ -> f, m)
 
     ///
     /// Returns a map with mappings `k => f(k, v)` for every `k => v` in `m`.
@@ -351,9 +351,9 @@ namespace MutMap {
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
     @ParallelWhenPure
-    pub def mapWithKey(f: (k, v1) -> v2 \ ef, m: MutMap[k, v1, r]): MutMap[k, v2, r] \ { ef, Read(r), Write(r) } =
+    pub def mapWithKey(r1: Region[r1], f: (k, v1) -> v2 \ ef, m: MutMap[k, v1, r]): MutMap[k, v2, r1] \ { ef, Read(r), Write(r1) } =
         let MutMap(mm) = m;
-        MutMap(ref Map.mapWithKey(f, deref mm) @ Scoped.regionOf(m))
+        MutMap(ref Map.mapWithKey(f, deref mm) @ r1)
 
     ///
     /// Alias for `foldLeftWithKey`.
@@ -538,9 +538,9 @@ namespace MutMap {
     ///
     /// Returns a shallow copy of the mutable map `m`.
     ///
-    pub def copy(m: MutMap[k, v, r]): MutMap[k, v, r] \ { Read(r), Write(r) } =
+    pub def copy(r1: Region[r1], m: MutMap[k, v, r]): MutMap[k, v, r1] \ { Read(r), Write(r1) } =
         let MutMap(mm) = m;
-        MutMap(ref (deref mm) @ Scoped.regionOf(m))
+        MutMap(ref (deref mm) @ r1)
 
     ///
     /// Returns the mutable map `m` as an immutable map.
@@ -580,26 +580,23 @@ namespace MutMap {
     ///
     /// Returns an iterator over all key-value pairs in `m`.
     ///
-    pub def iterator(m: MutMap[k, v, r]): Iterator[(k, v), r] \ Write(r) =
+    pub def iterator(r1: Region[r1], m: MutMap[k, v, r]): Iterator[(k, v), r1] \ { Read(r), Write(r1) } =
         let MutMap(mm) = m;
-        let r = Scoped.regionOf(m);
-        Map.iterator(r, deref mm)
+        Map.iterator(r1, deref mm)
 
     ///
     /// Returns an iterator over keys in `m`.
     ///
-    pub def iteratorKeys(m: MutMap[k, v, r]): Iterator[k, r] \ Write(r) =
+    pub def iteratorKeys(r1: Region[r1], m: MutMap[k, v, r]): Iterator[k, r1] \ { Read(r), Write(r1) } =
         let MutMap(mm) = m;
-        let r = Scoped.regionOf(m);
-        Map.iteratorKeys(r, deref mm)
+        Map.iteratorKeys(r1, deref mm)
 
     ///
     /// Returns an iterator over values in `m`.
     ///
-    pub def iteratorValues(m: MutMap[k, v, r]): Iterator[v, r] \ Write(r) =
+    pub def iteratorValues(r1: Region[r1], m: MutMap[k, v, r]): Iterator[v, r1] \ { Read(r), Write(r1) } =
         let MutMap(mm) = m;
-        let r = Scoped.regionOf(m);
-        Map.iteratorValues(r, deref mm)
+        Map.iteratorValues(r1, deref mm)
 
     ///
     /// Extracts a range of key-value pairs from the mutable map `m`.

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -27,9 +27,9 @@ instance Scoped[MutSet[t]] {
     pub def regionOf(_: MutSet[t, r]): Region[r] = unsafe_cast () as Region[r]
 }
 
-// instance Iterable[MutSet] {
-//     pub def iterator(s: MutSet[a, r]): Iterator[a, r] \ Write(r) = MutSet.iterator(s)
-// }
+instance Iterable[MutSet] {
+    pub def iterator(s: MutSet[a, r]): Iterator[a, r] \ Write(r) = MutSet.iterator(s)
+}
 
 namespace MutSet {
 
@@ -397,15 +397,16 @@ namespace MutSet {
     ///
     /// Returns an iterator over `s`.
     ///
-    pub def iterator(r1: Region[r1], s: MutSet[a, r]): Iterator[a, r1] \ { Read(r), Write(r1) } =
+    pub def iterator(s: MutSet[a, r]): Iterator[a, r] \ Write(r) =
         let MutSet(ms) = s;
-        Set.iterator(r1, deref ms)
+        let r = Scoped.regionOf(s);
+        Set.iterator(r, deref ms)
 
     ///
-    /// Returns an iterator over `s`.
+    /// Returns an enumerator over `s`.
     ///
-    pub def enumerator(r1: Region[r1], s: MutSet[a, r]): Iterator[(a, Int32), r1] \ { Read(r), Write(r1) } =
-        iterator(r1, s) |> Iterator.zipWithIndex
+    pub def enumerator(s: MutSet[a, r]): Iterator[(a, Int32), r] \ Write(r) =
+        iterator(s) |> Iterator.zipWithIndex
 
     ///
     /// Returns `true` if MutSets `a` and `b` have the same elements, i.e. are structurally equal.

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -27,9 +27,9 @@ instance Scoped[MutSet[t]] {
     pub def regionOf(_: MutSet[t, r]): Region[r] = unsafe_cast () as Region[r]
 }
 
-instance Iterable[MutSet] {
-    pub def iterator(s: MutSet[a, r]): Iterator[a, r] \ Write(r) = MutSet.iterator(s)
-}
+// instance Iterable[MutSet] {
+//     pub def iterator(s: MutSet[a, r]): Iterator[a, r] \ Write(r) = MutSet.iterator(s)
+// }
 
 namespace MutSet {
 
@@ -339,22 +339,22 @@ namespace MutSet {
     ///
     /// Returns a shallow copy of the mutable set `s`.
     ///
-    pub def copy(s: MutSet[a, r]): MutSet[a, r] \ { Read(r), Write(r) } =
+    pub def copy(r1: Region[r1], s: MutSet[a, r]): MutSet[a, r1] \ { Read(r), Write(r1) } =
         let MutSet(ms) = s;
-        MutSet(ref (deref ms) @ Scoped.regionOf(s))
+        MutSet(ref (deref ms) @ r1)
 
     ///
     /// Returns a pair of mutable sets `(s1, s2)` such that:
     //
     /// `s1` contains all elements of the mutable set `s` that satisfy the predicate function `f`.
-    /// `s2` contains all elements of teh mutable set `s` that do not satisfy the predicate function `f`.
+    /// `s2` contains all elements of the mutable set `s` that do not satisfy the predicate function `f`.
     ///
     /// The function `f` must be pure.
     ///
-    pub def partition(f: a -> Bool, s: MutSet[a, r]): (MutSet[a, r], MutSet[a, r]) \ { Read(r), Write(r) } with Order[a] =
+    pub def partition(r1: Region[r1], r2: Region[r2], f: a -> Bool, s: MutSet[a, r]): (MutSet[a, r1], MutSet[a, r2]) \ { Read(r), Write(r1), Write(r2) } with Order[a] =
         let MutSet(ms) = s;
         let (ys, zs) = Set.partition(f, deref ms);
-        (MutSet(ref ys @ Scoped.regionOf(s)), MutSet(ref zs @ Scoped.regionOf(s)))
+        (MutSet(ref ys @ r1), MutSet(ref zs @ r2))
 
     ///
     /// Returns the mutable set `s` as an immutable set.
@@ -397,16 +397,15 @@ namespace MutSet {
     ///
     /// Returns an iterator over `s`.
     ///
-    pub def iterator(s: MutSet[a, r]): Iterator[a, r] \ Write(r) =
+    pub def iterator(r1: Region[r1], s: MutSet[a, r]): Iterator[a, r1] \ { Read(r), Write(r1) } =
         let MutSet(ms) = s;
-        let r = Scoped.regionOf(s);
-        Set.iterator(r, deref ms)
+        Set.iterator(r1, deref ms)
 
     ///
     /// Returns an iterator over `s`.
     ///
-    pub def enumerator(s: MutSet[a, r]): Iterator[(a, Int32), r] \ Write(r) =
-        iterator(s) |> Iterator.zipWithIndex
+    pub def enumerator(r1: Region[r1], s: MutSet[a, r]): Iterator[(a, Int32), r1] \ { Read(r), Write(r1) } =
+        iterator(r1, s) |> Iterator.zipWithIndex
 
     ///
     /// Returns `true` if MutSets `a` and `b` have the same elements, i.e. are structurally equal.

--- a/main/src/library/Reducible.flix
+++ b/main/src/library/Reducible.flix
@@ -267,7 +267,7 @@ pub class Reducible[t: Type -> Type] {
     /// Returns an iterator over `t`.
     ///
     pub def iterator(r: Region[r], t: t[a]): Iterator[a, r] \ Write(r) =
-        Reducible.toArray(r, t) |> Array.iterator
+        Reducible.toArray(r, t) |> Array.iterator(r)
 
     ///
     /// Returns `t` as a list.

--- a/main/src/library/Reducible.flix
+++ b/main/src/library/Reducible.flix
@@ -267,7 +267,7 @@ pub class Reducible[t: Type -> Type] {
     /// Returns an iterator over `t`.
     ///
     pub def iterator(r: Region[r], t: t[a]): Iterator[a, r] \ Write(r) =
-        Reducible.toArray(r, t) |> Array.iterator(r)
+        Reducible.toArray(r, t) |> Array.iterator
 
     ///
     /// Returns `t` as a list.

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -156,17 +156,17 @@ namespace TestArray {
 
     @test
     def testSlice01(): Bool = region r {
-        Array.slice(0, 1, [1, 2, 3])[0] == 1
+        Array.slice(r, 0, 1, [1, 2, 3])[0] == 1
     }
 
     @test
     def testSlice02(): Bool = region r {
-        Array.slice(1, 2, [1, 2, 3])[0] == 2
+        Array.slice(r, 1, 2, [1, 2, 3])[0] == 2
     }
 
     @test
     def testSlice03(): Bool = region r {
-        Array.slice(2, 3, [1, 2, 3])[0] == 3
+        Array.slice(r, 2, 3, [1, 2, 3])[0] == 3
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -5272,12 +5272,13 @@ namespace TestArray {
     // sort!                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSort!VsSortWith!(a: Array[Int32, r]): Bool \ { Read(r), Write(r) } =
-        let b = Array.slice(0, Array.length(a), a);
-        let c = Array.slice(0, Array.length(a), a);
+    def testSort!VsSortWith!(a: Array[Int32, r]): Bool \ { Read(r), Write(r) } = region r1 {
+        let b = Array.slice(r1, 0, Array.length(a), a);
+        let c = Array.slice(r1, 0, Array.length(a), a);
         Array.sort!(b);
         Array.sortWith!(cmp, c);
         b `sameElements` c
+    }
 
     @test
     def sort!01(): Bool = region r {
@@ -5399,13 +5400,14 @@ namespace TestArray {
     // sortBy!                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortBy!VsSortBy(a: Array[Int32, r]) : Bool \ { Read(r), Write(r) } =
-        let b = Array.slice(0, Array.length(a), a);
-        let c = Array.slice(0, Array.length(a), a);
+    def testSortBy!VsSortBy(a: Array[Int32, r]) : Bool \ { Read(r), Write(r) } = region r1 {
+        let b = Array.slice(r1, 0, Array.length(a), a);
+        let c = Array.slice(r1, 0, Array.length(a), a);
         Array.sortBy!(identity, b);
         Array.sortBy!(x -> 4 * x + 7, c);
         (b `sameElements` Array.sortBy(x -> 4 * x + 7, a)) and
         (c `sameElements` Array.sortBy(identity, a))
+    }
 
     @test
     def sortBy!01(): Bool = region r {

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -326,49 +326,49 @@ namespace TestArray {
 
     @test
     def append01(): Bool = region r {
-        let a = Array.append([]: Array[Int32, _], []: Array[Int32, _]);
+        let a = Array.append(r, []: Array[Int32, _], []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def append02(): Bool = region r {
-        let a = Array.append([]: Array[Int32, _], [1]);
+        let a = Array.append(r, []: Array[Int32, _], [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def append03(): Bool = region r {
-        let a = Array.append([]: Array[Int32, _], [1,2]);
+        let a = Array.append(r, []: Array[Int32, _], [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def append04(): Bool = region r {
-        let a = Array.append([1], []: Array[Int32, _]);
+        let a = Array.append(r, [1], []: Array[Int32, _]);
         Array.sameElements(a, [1])
     }
 
     @test
     def append05(): Bool = region r {
-        let a = Array.append([1,2], []: Array[Int32, _]);
+        let a = Array.append(r, [1,2], []: Array[Int32, _]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def append06(): Bool = region r {
-        let a = Array.append([1], [2]);
+        let a = Array.append(r, [1], [2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def append07(): Bool = region r {
-        let a = Array.append([1,2], [3]);
+        let a = Array.append(r, [1,2], [3]);
         Array.sameElements(a, [1,2,3])
     }
 
     @test
     def append08(): Bool = region r {
-        let a = Array.append([1], [2,3]);
+        let a = Array.append(r, [1], [2,3]);
         Array.sameElements(a, [1,2,3])
     }
 
@@ -903,43 +903,43 @@ namespace TestArray {
 
     @test
     def map01(): Bool = region r {
-        let a = Array.map(i -> i > 2, []);
+        let a = Array.map(r, i -> i > 2, []);
         Array.sameElements(a, []: Array[Bool, _])
     }
 
     @test
     def map02(): Bool = region r {
-        let a = Array.map(i -> i > 2, [1]);
+        let a = Array.map(r, i -> i > 2, [1]);
         Array.sameElements(a, [false])
     }
 
     @test
     def map03(): Bool = region r {
-        let a = Array.map(i -> i > 2, [3]);
+        let a = Array.map(r, i -> i > 2, [3]);
         Array.sameElements(a, [true])
     }
 
     @test
     def map04(): Bool = region r {
-        let a = Array.map(i -> i > 2, [1,2]);
+        let a = Array.map(r, i -> i > 2, [1,2]);
         Array.sameElements(a, [false,false])
     }
 
     @test
     def map05(): Bool = region r {
-        let a = Array.map(i -> i > 2, [1,8]);
+        let a = Array.map(r, i -> i > 2, [1,8]);
         Array.sameElements(a, [false, true])
     }
 
     @test
     def map06(): Bool = region r {
-        let a = Array.map(i -> i > 2, [8,1]);
+        let a = Array.map(r, i -> i > 2, [8,1]);
         Array.sameElements(a, [true,false])
     }
 
     @test
     def map07(): Bool = region r {
-        let a = Array.map(i -> i > 2, [7,8]);
+        let a = Array.map(r, i -> i > 2, [7,8]);
         Array.sameElements(a, [true,true])
     }
 
@@ -981,43 +981,43 @@ namespace TestArray {
 
     @test
     def mapWithIndex01(): Bool = region r {
-        let a = Array.mapWithIndex((i, e) -> if (i < 1) e > 2 else e <= 2, []);
+        let a = Array.mapWithIndex(r, (i, e) -> if (i < 1) e > 2 else e <= 2, []);
         Array.sameElements(a, []: Array[Bool, _])
     }
 
     @test
     def mapWithIndex02(): Bool = region r {
-        let a = Array.mapWithIndex((i, e) -> if (i < 1) e > 2 else e <= 2, [1]);
+        let a = Array.mapWithIndex(r, (i, e) -> if (i < 1) e > 2 else e <= 2, [1]);
         Array.sameElements(a, [false])
     }
 
     @test
     def mapWithIndex03(): Bool = region r {
-        let a = Array.mapWithIndex((i, e) -> if (i < 1) e > 2 else e <= 2, [3]);
+        let a = Array.mapWithIndex(r, (i, e) -> if (i < 1) e > 2 else e <= 2, [3]);
         Array.sameElements(a, [true])
     }
 
     @test
     def mapWithIndex04(): Bool = region r {
-        let a = Array.mapWithIndex((i, e) -> if (i < 1) e > 2 else e <= 2, [1,2]);
+        let a = Array.mapWithIndex(r, (i, e) -> if (i < 1) e > 2 else e <= 2, [1,2]);
         Array.sameElements(a, [false,true])
     }
 
     @test
     def mapWithIndex05(): Bool = region r {
-        let a = Array.mapWithIndex((i, e) -> if (i < 1) e > 2 else e <= 2, [1,8]);
+        let a = Array.mapWithIndex(r, (i, e) -> if (i < 1) e > 2 else e <= 2, [1,8]);
         Array.sameElements(a, [false,false])
     }
 
     @test
     def mapWithIndex06(): Bool = region r {
-        let a = Array.mapWithIndex((i, e) -> if (i < 1) e > 2 else e <= 2, [8,1]);
+        let a = Array.mapWithIndex(r, (i, e) -> if (i < 1) e > 2 else e <= 2, [8,1]);
         Array.sameElements(a, [true,true])
     }
 
     @test
     def mapWithIndex07(): Bool = region r {
-        let a = Array.mapWithIndex((i, e) -> if (i < 1) e > 2 else e <= 2, [7,8]);
+        let a = Array.mapWithIndex(r, (i, e) -> if (i < 1) e > 2 else e <= 2, [7,8]);
         Array.sameElements(a, [true,false])
     }
 
@@ -1082,37 +1082,37 @@ namespace TestArray {
 
     @test
     def flatMap01(): Bool = region r {
-        let a = Array.flatMap(i -> Array.repeat(r, i, i), []);
+        let a = Array.flatMap(r, i -> Array.repeat(r, i, i), []);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def flatMap02(): Bool = region r {
-        let a = Array.flatMap(i -> Array.repeat(r, i, i), [0]);
+        let a = Array.flatMap(r, i -> Array.repeat(r, i, i), [0]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def flatMap03(): Bool = region r {
-        let a = Array.flatMap(i -> Array.repeat(r, i, i), [1]);
+        let a = Array.flatMap(r, i -> Array.repeat(r, i, i), [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def flatMap04(): Bool = region r {
-        let a = Array.flatMap(i -> Array.repeat(r, i, i), [2]);
+        let a = Array.flatMap(r, i -> Array.repeat(r, i, i), [2]);
         Array.sameElements(a, [2,2])
     }
 
     @test
     def flatMap05(): Bool = region r {
-        let a = Array.flatMap(i -> Array.repeat(r, i, i), [1,2]);
+        let a = Array.flatMap(r, i -> Array.repeat(r, i, i), [1,2]);
         Array.sameElements(a, [1,2,2])
     }
 
     @test
     def flatMap06(): Bool = region r {
-        let a = Array.flatMap(i -> Array.repeat(r, i, i), [2,3]);
+        let a = Array.flatMap(r, i -> Array.repeat(r, i, i), [2,3]);
         Array.sameElements(a, [2,2,3,3,3])
     }
 
@@ -1122,37 +1122,37 @@ namespace TestArray {
 
     @test
     def reverse01(): Bool = region r {
-        let a = Array.reverse([]: Array[Int32, _]);
+        let a = Array.reverse(r, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def reverse02(): Bool = region r {
-        let a = Array.reverse([1]);
+        let a = Array.reverse(r, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def reverse03(): Bool = region r {
-        let a = Array.reverse([1,2]);
+        let a = Array.reverse(r, [1,2]);
         Array.sameElements(a, [2,1])
     }
 
     @test
     def reverse04(): Bool = region r {
-        let a = Array.reverse([1,1]);
+        let a = Array.reverse(r, [1,1]);
         Array.sameElements(a, [1,1])
     }
 
     @test
     def reverse05(): Bool = region r {
-        let a = Array.reverse([1,2,3]);
+        let a = Array.reverse(r, [1,2,3]);
         Array.sameElements(a, [3,2,1])
     }
 
     @test
     def reverse06(): Bool = region r {
-        let a = Array.reverse([1,2,3,4]);
+        let a = Array.reverse(r, [1,2,3,4]);
         Array.sameElements(a, [4,3,2,1])
     }
 
@@ -1348,43 +1348,43 @@ namespace TestArray {
 
     @test
     def update01(): Bool = region r {
-        let a = Array.update(0, 2, []: Array[Int32, _]);
+        let a = Array.update(r, 0, 2, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def update02(): Bool = region r {
-        let a = Array.update(-1, 2, [1]);
+        let a = Array.update(r, -1, 2, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def update03(): Bool = region r {
-        let a = Array.update(0, 2, [1]);
+        let a = Array.update(r, 0, 2, [1]);
         Array.sameElements(a, [2])
     }
 
     @test
     def update04(): Bool = region r {
-        let a = Array.update(1, 2, [1]);
+        let a = Array.update(r, 1, 2, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def update05(): Bool = region r {
-        let a = Array.update(0, 5, [1,2]);
+        let a = Array.update(r, 0, 5, [1,2]);
         Array.sameElements(a, [5,2])
     }
 
     @test
     def update06(): Bool = region r {
-        let a = Array.update(1, 5, [1,2]);
+        let a = Array.update(r, 1, 5, [1,2]);
         Array.sameElements(a, [1,5])
     }
 
     @test
     def update07(): Bool = region r {
-        let a = Array.update(2, 5, [1,2]);
+        let a = Array.update(r, 2, 5, [1,2]);
         Array.sameElements(a, [1,2])
     }
 
@@ -1394,49 +1394,49 @@ namespace TestArray {
 
     @test
     def replace01(): Bool = region r {
-        let a = Array.replace(from = 3, to = 4, []);
+        let a = Array.replace(r, from = 3, to = 4, []);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def replace02(): Bool = region r {
-        let a = Array.replace(from = 3, to = 4, [1]);
+        let a = Array.replace(r, from = 3, to = 4, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def replace03(): Bool = region r {
-        let a = Array.replace(from = 3, to = 4, [3]);
+        let a = Array.replace(r, from = 3, to = 4, [3]);
         Array.sameElements(a, [4])
     }
 
     @test
     def replace04(): Bool = region r {
-        let a = Array.replace(from = 3, to = 4, [4]);
+        let a = Array.replace(r, from = 3, to = 4, [4]);
         Array.sameElements(a, [4])
     }
 
     @test
     def replace05(): Bool = region r {
-        let a = Array.replace(from = 3, to = 4, [1, 2]);
+        let a = Array.replace(r, from = 3, to = 4, [1, 2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def replace06(): Bool = region r {
-        let a = Array.replace(from = 3, to = 4, [1,3]);
+        let a = Array.replace(r, from = 3, to = 4, [1,3]);
         Array.sameElements(a, [1,4])
     }
 
     @test
     def replace07(): Bool = region r {
-        let a = Array.replace(from = 3, to = 4, [3,4]);
+        let a = Array.replace(r, from = 3, to = 4, [3,4]);
         Array.sameElements(a, [4,4])
     }
 
     @test
     def replace08(): Bool = region r {
-        let a = Array.replace(from = 3, to = 4, [3,3]);
+        let a = Array.replace(r, from = 3, to = 4, [3,3]);
         Array.sameElements(a, [4,4])
     }
 
@@ -1506,169 +1506,169 @@ namespace TestArray {
 
     @test
     def patch01(): Bool = region r {
-        let a = Array.patch(0, 0, []: Array[Int32, _], []: Array[Int32, _]);
+        let a = Array.patch(r, 0, 0, []: Array[Int32, _], []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def patch02(): Bool = region r {
-        let a = Array.patch(0, 2, [1,2], []);
+        let a = Array.patch(r, 0, 2, [1,2], []);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def patch03(): Bool = region r {
-        let a = Array.patch(0, 2, [], [1,2]);
+        let a = Array.patch(r, 0, 2, [], [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def patch04(): Bool = region r {
-        let a = Array.patch(-3, 3, [1,2,4], [1,2]);
+        let a = Array.patch(r, -3, 3, [1,2,4], [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def patch05(): Bool = region r {
-        let a = Array.patch(2, 3, [1,2,4], [1,2]);
+        let a = Array.patch(r, 2, 3, [1,2,4], [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def patch06(): Bool = region r {
-        let a = Array.patch(0, 0, [], [1]);
+        let a = Array.patch(r, 0, 0, [], [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def patch07(): Bool = region r {
-        let a = Array.patch(1, 0, [2], [1]);
+        let a = Array.patch(r, 1, 0, [2], [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def patch08(): Bool = region r {
-        let a = Array.patch(0, 1, [2], [1]);
+        let a = Array.patch(r, 0, 1, [2], [1]);
         Array.sameElements(a, [2])
     }
 
     @test
     def patch09(): Bool = region r {
-        let a = Array.patch(0, 2, [2,4], [1]);
+        let a = Array.patch(r, 0, 2, [2,4], [1]);
         Array.sameElements(a, [2])
     }
 
     @test
     def patch10(): Bool = region r {
-        let a = Array.patch(-1, 2, [2,4], [1]);
+        let a = Array.patch(r, -1, 2, [2,4], [1]);
         Array.sameElements(a, [4])
     }
 
     @test
     def patch11(): Bool = region r {
-        let a = Array.patch(-1, 2, [3,4], [1,2]);
+        let a = Array.patch(r, -1, 2, [3,4], [1,2]);
         Array.sameElements(a, [4,2])
     }
 
     @test
     def patch12(): Bool = region r {
-        let a = Array.patch(1, 2, [3,4], [1,2]);
+        let a = Array.patch(r, 1, 2, [3,4], [1,2]);
         Array.sameElements(a, [1,3])
     }
 
     @test
     def patch13(): Bool = region r {
-        let a = Array.patch(-2, 2, [3,4], [1,2]);
+        let a = Array.patch(r, -2, 2, [3,4], [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def patch14(): Bool = region r {
-        let a = Array.patch(2, 2, [3,4], [1,2]);
+        let a = Array.patch(r, 2, 2, [3,4], [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def patch15(): Bool = region r {
-        let a = Array.patch(1, 1, [3], [1,2]);
+        let a = Array.patch(r, 1, 1, [3], [1,2]);
         Array.sameElements(a, [1,3])
     }
 
     @test
     def patch16(): Bool = region r {
-        let a = Array.patch(0, 2, [3,4], [1,2]);
+        let a = Array.patch(r, 0, 2, [3,4], [1,2]);
         Array.sameElements(a, [3,4])
     }
 
     @test
     def patch17(): Bool = region r {
-        let a = Array.patch(0, 1, [4], [1, 2, 3]);
+        let a = Array.patch(r, 0, 1, [4], [1, 2, 3]);
         Array.sameElements(a, [4, 2, 3])
     }
 
     @test
     def patch18(): Bool = region r {
-        let a = Array.patch(1, 1, [4], [1, 2, 3]);
+        let a = Array.patch(r, 1, 1, [4], [1, 2, 3]);
         Array.sameElements(a, [1, 4, 3])
     }
 
     @test
     def patch19(): Bool = region r {
-        let a = Array.patch(2, 1, [4], [1, 2, 3]);
+        let a = Array.patch(r, 2, 1, [4], [1, 2, 3]);
         Array.sameElements(a, [1, 2, 4])
     }
 
     @test
     def patch20(): Bool = region r {
-        let a = Array.patch(0, 2, [4, 5], [1, 2, 3]);
+        let a = Array.patch(r, 0, 2, [4, 5], [1, 2, 3]);
         Array.sameElements(a, [4, 5, 3])
     }
 
     @test
     def patch21(): Bool = region r {
-        let a = Array.patch(1, 2, [4, 5], [1, 2, 3]);
+        let a = Array.patch(r, 1, 2, [4, 5], [1, 2, 3]);
         Array.sameElements(a, [1, 4, 5])
     }
 
     @test
     def patch22(): Bool = region r {
-        let a = Array.patch(0, 2, [4, 5, 6], [1, 2, 3]);
+        let a = Array.patch(r, 0, 2, [4, 5, 6], [1, 2, 3]);
         Array.sameElements(a, [4, 5, 3])
     }
 
     @test
     def patch23(): Bool = region r {
-        let a = Array.patch(0, 3, [4, 5, 6], [1, 2, 3]);
+        let a = Array.patch(r, 0, 3, [4, 5, 6], [1, 2, 3]);
         Array.sameElements(a, [4, 5, 6])
     }
 
     @test
     def patch24(): Bool = region r {
-        let a = Array.patch(2, 4, [14, 15, 16, 17], [1, 2, 3, 4, 5, 6, 7]);
+        let a = Array.patch(r, 2, 4, [14, 15, 16, 17], [1, 2, 3, 4, 5, 6, 7]);
         Array.sameElements(a, [1, 2, 14, 15, 16, 17, 7])
     }
 
     @test
     def patch25(): Bool = region r {
-        let a = Array.patch(-2, 4, [14, 15, 16, 17], [1, 2, 3, 4, 5, 6, 7]);
+        let a = Array.patch(r, -2, 4, [14, 15, 16, 17], [1, 2, 3, 4, 5, 6, 7]);
         Array.sameElements(a, [16, 17, 3, 4, 5, 6, 7])
     }
 
     @test
     def patch26(): Bool = region r {
-        let a = Array.patch(4, 5, [14, 15, 16, 17], [1, 2, 3, 4, 5, 6, 7]);
+        let a = Array.patch(r, 4, 5, [14, 15, 16, 17], [1, 2, 3, 4, 5, 6, 7]);
         Array.sameElements(a, [1, 2, 3, 4, 14, 15, 16])
     }
 
     @test
     def patch27(): Bool = region r {
-        let a = Array.patch(4, 2, [14, 15, 16, 17], [1, 2, 3, 4, 5, 6, 7]);
+        let a = Array.patch(r, 4, 2, [14, 15, 16, 17], [1, 2, 3, 4, 5, 6, 7]);
         Array.sameElements(a, [1, 2, 3, 4, 14, 15, 7])
     }
 
     @test
     def patch28(): Bool = region r {
-        let a = Array.patch(-1, 10, [-1, -2, -3, -4, -5, -6, -7, -8], [1, 2, 3, 4, 5, 6, 7]);
+        let a = Array.patch(r, -1, 10, [-1, -2, -3, -4, -5, -6, -7, -8], [1, 2, 3, 4, 5, 6, 7]);
         Array.sameElements(a, [-2, -3, -4, -5, -6, -7, -8])
     }
 
@@ -1878,31 +1878,31 @@ namespace TestArray {
 
     @test
     def intersperse01(): Bool = region r {
-        let a = Array.intersperse(11, []);
+        let a = Array.intersperse(r, 11, []);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def intersperse02(): Bool = region r {
-        let a = Array.intersperse(11, [1]);
+        let a = Array.intersperse(r, 11, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def intersperse03(): Bool = region r {
-        let a = Array.intersperse(11, [1,2]);
+        let a = Array.intersperse(r, 11, [1,2]);
         Array.sameElements(a, [1,11,2])
     }
 
     @test
     def intersperse04(): Bool = region r {
-        let a = Array.intersperse(11, [1,2,3]);
+        let a = Array.intersperse(r, 11, [1,2,3]);
         Array.sameElements(a, [1,11,2,11,3])
     }
 
     @test
     def intersperse05(): Bool = region r {
-        let a = Array.intersperse(11, [1,2,3,4]);
+        let a = Array.intersperse(r, 11, [1,2,3,4]);
         Array.sameElements(a, [1,11,2,11,3,11,4])
     }
 
@@ -1913,43 +1913,43 @@ namespace TestArray {
 
     @test
     def intercalate01(): Bool = region r {
-        let a = Array.intercalate([]: Array[Int32, r], []: Array[Array[Int32, r], r]);
+        let a = Array.intercalate(r, []: Array[Int32, r], []: Array[Array[Int32, r], r]);
         Array.sameElements(a, []: Array[Int32, r])
     }
 
     @test
     def intercalate02(): Bool = region r {
-        let a = Array.intercalate([]: Array[Int32, r], [[1]]);
+        let a = Array.intercalate(r, []: Array[Int32, r], [[1]]);
         Array.sameElements(a, [1])
     }
 
     @test
     def intercalate03(): Bool = region r {
-        let a = Array.intercalate([11,12,13], []: Array[Array[Int32, r], r]);
+        let a = Array.intercalate(r, [11,12,13], []: Array[Array[Int32, r], r]);
         Array.sameElements(a, []: Array[Int32, r])
     }
 
     @test
     def intercalate04(): Bool = region r {
-        let a = Array.intercalate([]: Array[Int32, r], [[1],[2,3]]);
+        let a = Array.intercalate(r, []: Array[Int32, r], [[1],[2,3]]);
         Array.sameElements(a, [1,2,3])
     }
 
     @test
     def intercalate05(): Bool = region r {
-        let a = Array.intercalate([11,12,13], [[1],[2,3]]);
+        let a = Array.intercalate(r, [11,12,13], [[1],[2,3]]);
         Array.sameElements(a, [1,11,12,13,2,3])
     }
 
     @test
     def intercalate06(): Bool = region r {
-        let a = Array.intercalate([]: Array[Int32, r], [[1],[2,3],[4]]);
+        let a = Array.intercalate(r, []: Array[Int32, r], [[1],[2,3],[4]]);
         Array.sameElements(a, [1,2,3,4])
     }
 
     @test
     def intercalate07(): Bool = region r {
-        let a = Array.intercalate([11,12,13], [[1],[2,3],[4]]);
+        let a = Array.intercalate(r, [11,12,13], [[1],[2,3],[4]]);
         Array.sameElements(a, [1,11,12,13,2,3,11,12,13,4])
     }
 
@@ -1959,154 +1959,154 @@ namespace TestArray {
 
     @test
     def transpose01(): Bool = region r {
-        let a = Array.transpose([]);
+        let a = Array.transpose(r, []);
         let b = Array.toList(a) |> List.map(Array.toList);
         b: List[List[Unit]] == Nil
     }
 
     @test
     def transpose02(): Bool = region r {
-        let a: Array[Array[Int32, _], _] = Array.transpose([[]]);
+        let a: Array[Array[Int32, _], _] = Array.transpose(r, [[]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == Nil :: Nil
     }
 
     @test
     def transpose03(): Bool = region r {
-        let a: Array[Array[Int32, _], _] = Array.transpose([[], []]);
+        let a: Array[Array[Int32, _], _] = Array.transpose(r, [[], []]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == Nil :: Nil :: Nil
     }
 
     @test
     def transpose04(): Bool = region r {
-        let a: Array[Array[Int32, _], _] = Array.transpose([[], [], []]);
+        let a: Array[Array[Int32, _], _] = Array.transpose(r, [[], [], []]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == Nil :: Nil :: Nil :: Nil
     }
 
     @test
     def transpose05(): Bool = region r {
-        let a = Array.transpose([ [1] ]);
+        let a = Array.transpose(r, [ [1] ]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: Nil) :: Nil
     }
 
     @test
     def transpose06(): Bool = region r {
-        let a = Array.transpose([[1,2]]);
+        let a = Array.transpose(r, [[1,2]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: Nil) :: (2 :: Nil) :: Nil
     }
 
     @test
     def transpose07(): Bool = region r {
-        let a = Array.transpose([[1, 2, 3]]);
+        let a = Array.transpose(r, [[1, 2, 3]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: Nil) :: (2 :: Nil) :: (3 :: Nil) :: Nil
     }
 
     @test
     def transpose08(): Bool = region r {
-        let a = Array.transpose([[1, 2, 3, 4]]);
+        let a = Array.transpose(r, [[1, 2, 3, 4]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: Nil) :: (2 :: Nil) :: (3 :: Nil) :: (4 :: Nil) :: Nil
     }
 
     @test
     def transpose09(): Bool = region r {
-        let a = Array.transpose([[1], [2]]);
+        let a = Array.transpose(r, [[1], [2]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b ==   (1 :: 2 :: Nil) :: Nil
     }
 
     @test
     def transpose10(): Bool = region r {
-        let a = Array.transpose([[1], [2], [3]]);
+        let a = Array.transpose(r, [[1], [2], [3]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b ==  (1 :: 2 :: 3 :: Nil) :: Nil
     }
 
     @test
     def transpose11(): Bool = region r {
-        let a = Array.transpose([[1], [2], [3], [4]]);
+        let a = Array.transpose(r, [[1], [2], [3], [4]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: 2 :: 3 :: 4 :: Nil) :: Nil
     }
 
     @test
     def transpose12(): Bool = region r {
-        let a = Array.transpose([[1, 2], [3, 4]]);
+        let a = Array.transpose(r, [[1, 2], [3, 4]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: 3 :: Nil) :: (2 :: 4 :: Nil) :: Nil
     }
 
     @test
     def transpose13(): Bool = region r {
-        let a = Array.transpose([[1, 2, 3], [4, 5, 6]]);
+        let a = Array.transpose(r, [[1, 2, 3], [4, 5, 6]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: 4 :: Nil) :: (2 :: 5 :: Nil) :: (3 :: 6 :: Nil) :: Nil
     }
 
     @test
     def transpose14(): Bool = region r {
-        let a = Array.transpose([[1, 2, 3, 4], [5, 6, 7, 8]]);
+        let a = Array.transpose(r, [[1, 2, 3, 4], [5, 6, 7, 8]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: 5 :: Nil) :: (2 :: 6 :: Nil) :: (3 :: 7 :: Nil) :: (4 :: 8 :: Nil) :: Nil
     }
 
     @test
     def transpose15(): Bool = region r {
-        let a = Array.transpose([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]);
+        let a = Array.transpose(r, [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: 6 :: Nil) :: (2 :: 7 :: Nil) :: (3 :: 8 :: Nil) :: (4 :: 9 :: Nil) :: (5 :: 10 :: Nil) :: Nil
     }
 
     @test
     def transpose16(): Bool = region r {
-        let a = Array.transpose([[1, 2], [3, 4], [5, 6]]);
+        let a = Array.transpose(r, [[1, 2], [3, 4], [5, 6]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: 3 :: 5 :: Nil) :: (2 :: 4 :: 6 :: Nil) :: Nil
     }
 
     @test
     def transpose17(): Bool = region r {
-        let a = Array.transpose([[1, 2], [3, 4], [5, 6], [7,8]]);
+        let a = Array.transpose(r, [[1, 2], [3, 4], [5, 6], [7,8]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: 3 :: 5 :: 7 :: Nil) :: (2 :: 4 :: 6 :: 8 :: Nil) :: Nil
     }
 
     @test
     def transpose18(): Bool = region r {
-        let a = Array.transpose([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]);
+        let a = Array.transpose(r, [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: 3 :: 5 :: 7 :: 9 :: Nil) :: (2 :: 4 :: 6 :: 8 :: 10 :: Nil) :: Nil
     }
 
     @test
     def transpose19(): Bool = region r {
-        let a = Array.transpose([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
+        let a = Array.transpose(r, [[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: 4 :: 7 :: Nil) :: (2 :: 5 :: 8 :: Nil) :: (3 :: 6 :: 9 :: Nil) :: Nil
     }
 
     @test
     def transpose20(): Bool = region r {
-        let a = Array.transpose([[1, 2, 3], [4, 5], [7, 8, 9]]);
+        let a = Array.transpose(r, [[1, 2, 3], [4, 5], [7, 8, 9]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: 2 :: 3 :: Nil) :: (4 :: 5 :: Nil) :: (7 :: 8 :: 9 :: Nil) :: Nil
     }
 
     @test
     def transpose21(): Bool = region r {
-        let a = Array.transpose([[1, 2, 3], [], [7, 8, 9]]);
+        let a = Array.transpose(r, [[1, 2, 3], [], [7, 8, 9]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: 2 :: 3 :: Nil) :: Nil :: (7 :: 8 :: 9 :: Nil) :: Nil
     }
 
     @test
     def transpose22(): Bool = region r {
-        let a = Array.transpose([[1, 2, 3], [4, 5, 6], [7, 8, 9, 10]]);
+        let a = Array.transpose(r, [[1, 2, 3], [4, 5, 6], [7, 8, 9, 10]]);
         let b = Array.toList(a) |> List.map(Array.toList);
         b == (1 :: 2 :: 3 :: Nil) :: (4 :: 5 :: 6 :: Nil) :: (7 :: 8 :: 9 :: 10 :: Nil) :: Nil
     }
@@ -2729,61 +2729,61 @@ namespace TestArray {
 
     @test
     def flatten01(): Bool = region r {
-        let a = Array.flatten([]: Array[Array[Int32, r], r]);
+        let a = Array.flatten(r, []: Array[Array[Int32, r], r]);
         Array.sameElements(a, []: Array[Int32, r])
     }
 
     @test
     def flatten02(): Bool = region r {
-        let a = Array.flatten([[]]: Array[Array[Int32, r], r]);
+        let a = Array.flatten(r, [[]]: Array[Array[Int32, r], r]);
         Array.sameElements(a, []: Array[Int32, r])
     }
 
     @test
     def flatten03(): Bool = region r {
-        let a = Array.flatten([[1]]);
+        let a = Array.flatten(r, [[1]]);
         Array.sameElements(a, [1])
     }
 
     @test
     def flatten04(): Bool = region r {
-        let a= Array.flatten([[1,2]]);
+        let a= Array.flatten(r, [[1,2]]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def flatten05(): Bool = region r {
-        let a = Array.flatten([[],[]]: Array[Array[Int32, r], r]);
+        let a = Array.flatten(r, [[],[]]: Array[Array[Int32, r], r]);
         Array.sameElements(a, []: Array[Int32, r])
     }
 
     @test
     def flatten06(): Bool = region r {
-        let a = Array.flatten([[1],[]]);
+        let a = Array.flatten(r, [[1],[]]);
         Array.sameElements(a, [1])
     }
 
     @test
     def flatten07(): Bool = region r {
-        let a = Array.flatten([[],[1]]);
+        let a = Array.flatten(r, [[],[1]]);
         Array.sameElements(a, [1])
     }
 
     @test
     def flatten08(): Bool = region r {
-        let a = Array.flatten([[1],[2]]);
+        let a = Array.flatten(r, [[1],[2]]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def flatten09(): Bool = region r {
-        let a = Array.flatten([[1,2],[3,4,5]]);
+        let a = Array.flatten(r, [[1,2],[3,4,5]]);
         Array.sameElements(a, [1,2,3,4,5])
     }
 
     @test
     def flatten10(): Bool = region r {
-        let a = Array.flatten([[1],[2,3],[4]]);
+        let a = Array.flatten(r, [[1],[2,3],[4]]);
         Array.sameElements(a, [1,2,3,4])
     }
     /////////////////////////////////////////////////////////////////////////////
@@ -2895,49 +2895,49 @@ namespace TestArray {
 
     @test
     def filter01(): Bool = region r {
-        let a = Array.filter(i -> i > 3, []: Array[Int32, _]);
+        let a = Array.filter(r, i -> i > 3, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def filter02(): Bool = region r {
-        let a = Array.filter(i -> i > 3, [2]);
+        let a = Array.filter(r, i -> i > 3, [2]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def filter03(): Bool = region r {
-        let a = Array.filter(i -> i > 3, [4]);
+        let a = Array.filter(r, i -> i > 3, [4]);
         Array.sameElements(a, [4])
     }
 
     @test
     def filter04(): Bool = region r {
-        let a = Array.filter(i -> i > 3, [1,3]);
+        let a = Array.filter(r, i -> i > 3, [1,3]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def filter05(): Bool = region r {
-        let a = Array.filter(i -> i > 3, [1,8]);
+        let a = Array.filter(r, i -> i > 3, [1,8]);
         Array.sameElements(a, [8])
     }
 
     @test
     def filter06(): Bool = region r {
-        let a = Array.filter(i -> i > 3, [8,1]);
+        let a = Array.filter(r, i -> i > 3, [8,1]);
         Array.sameElements(a, [8])
     }
 
     @test
     def filter07(): Bool = region r {
-        let a = Array.filter(i -> i > 3, [8,9]);
+        let a = Array.filter(r, i -> i > 3, [8,9]);
         Array.sameElements(a, [8,9])
     }
 
     @test
     def filter08(): Bool = region r {
-        let a = Array.filter(i -> i > 3, [1,4,11,2,-22,17]);
+        let a = Array.filter(r, i -> i > 3, [1,4,11,2,-22,17]);
         Array.sameElements(a, [4,11,17])
     }
 
@@ -2947,49 +2947,49 @@ namespace TestArray {
 
     @test
     def partition01(): Bool = region r {
-        let (a,b) = Array.partition(i -> i > 3, []: Array[Int32, _]);
+        let (a,b) = Array.partition(r, r, i -> i > 3, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _]) and Array.sameElements(b, []: Array[Int32, _])
     }
 
     @test
     def partition02(): Bool = region r {
-        let (a,b) = Array.partition(i -> i > 3, [1]);
+        let (a,b) = Array.partition(r, r, i -> i > 3, [1]);
         Array.sameElements(a, []: Array[Int32, _]) and Array.sameElements(b, [1])
     }
 
     @test
     def partition03(): Bool = region r {
-        let (a,b) = Array.partition(i -> i > 3, [4]);
+        let (a,b) = Array.partition(r, r, i -> i > 3, [4]);
         Array.sameElements(a, [4]) and Array.sameElements(b, []: Array[Int32, _])
     }
 
     @test
     def partition04(): Bool = region r {
-        let (a,b) = Array.partition(i -> i > 3, [1,2]);
+        let (a,b) = Array.partition(r, r, i -> i > 3, [1,2]);
         Array.sameElements(a, []: Array[Int32, _]) and Array.sameElements(b, [1,2])
     }
 
     @test
     def partition05(): Bool = region r {
-        let (a,b) = Array.partition(i -> i > 3, [1,5]);
+        let (a,b) = Array.partition(r, r, i -> i > 3, [1,5]);
         Array.sameElements(a, [5]) and Array.sameElements(b, [1])
     }
 
     @test
     def partition06(): Bool = region r {
-        let (a,b) = Array.partition(i -> i > 3, [5,1]);
+        let (a,b) = Array.partition(r, r, i -> i > 3, [5,1]);
         Array.sameElements(a, [5]) and Array.sameElements(b, [1])
     }
 
     @test
     def partition07(): Bool = region r {
-        let (a,b) = Array.partition(i -> i > 3, [5,8]);
+        let (a,b) = Array.partition(r, r, i -> i > 3, [5,8]);
         Array.sameElements(a, [5,8]) and Array.sameElements(b, []: Array[Int32, _])
     }
 
     @test
     def partition08(): Bool = region r {
-        let (a,b) = Array.partition(i -> i > 3, [4, -3, -5, 1, 2, 16, 7, 1, 7]);
+        let (a,b) = Array.partition(r, r, i -> i > 3, [4, -3, -5, 1, 2, 16, 7, 1, 7]);
         Array.sameElements(a, [4, 16, 7, 7]) and Array.sameElements(b, [-3, -5, 1, 2, 1])
     }
 
@@ -2999,49 +2999,49 @@ namespace TestArray {
 
     @test
     def span01(): Bool = region r {
-        let (a,b) = Array.span(i -> i > 3, []: Array[Int32, _]);
+        let (a,b) = Array.span(r, r, i -> i > 3, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _]) and Array.sameElements(b, []: Array[Int32, _])
     }
 
     @test
     def span02(): Bool = region r {
-        let (a,b) = Array.span(i -> i > 3, [1]);
+        let (a,b) = Array.span(r, r, i -> i > 3, [1]);
         Array.sameElements(a,[]: Array[Int32, _]) and Array.sameElements(b, [1])
     }
 
     @test
     def span03(): Bool = region r {
-        let (a,b) = Array.span(i -> i > 3, [4]);
+        let (a,b) = Array.span(r, r, i -> i > 3, [4]);
         Array.sameElements(a, [4]) and Array.sameElements(b, []: Array[Int32, _])
     }
 
     @test
     def span04(): Bool = region r {
-        let (a,b) = Array.span(i -> i > 3, [1,2]);
+        let (a,b) = Array.span(r, r, i -> i > 3, [1,2]);
         Array.sameElements(a, []: Array[Int32, _]) and Array.sameElements(b, [1,2])
     }
 
     @test
     def span05(): Bool = region r {
-        let (a,b) = Array.span(i -> i > 3, [1,5]);
+        let (a,b) = Array.span(r, r, i -> i > 3, [1,5]);
         Array.sameElements(a, []: Array[Int32, _]) and Array.sameElements(b, [1,5])
     }
 
     @test
     def span06(): Bool = region r {
-        let (a,b) = Array.span(i -> i > 3, [5,1]);
+        let (a,b) = Array.span(r, r, i -> i > 3, [5,1]);
         Array.sameElements(a, [5]) and Array.sameElements(b, [1])
     }
 
     @test
     def span07(): Bool = region r {
-        let (a,b) = Array.span(i -> i > 3, [5,8]);
+        let (a,b) = Array.span(r, r, i -> i > 3, [5,8]);
         Array.sameElements(a, [5,8]) and Array.sameElements(b, []: Array[Int32, _])
     }
 
     @test
     def span08(): Bool = region r {
-        let (a,b) = Array.span(i -> i > 3, [4, 6, -3, 11, -5, 1, 2, 16, 7, 1, 7]);
+        let (a,b) = Array.span(r, r, i -> i > 3, [4, 6, -3, 11, -5, 1, 2, 16, 7, 1, 7]);
         Array.sameElements(a, [4, 6]) and Array.sameElements(b, [-3, 11, -5, 1, 2, 16, 7, 1, 7])
     }
 
@@ -3051,73 +3051,73 @@ namespace TestArray {
 
     @test
     def drop01(): Bool = region r {
-        let a = Array.drop(-1, []: Array[Int32, _]);
+        let a = Array.drop(r, -1, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def drop02(): Bool = region r {
-        let a = Array.drop(0, []: Array[Int32, _]);
+        let a = Array.drop(r, 0, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def drop03(): Bool = region r {
-        let a = Array.drop(1, []: Array[Int32, _]);
+        let a = Array.drop(r, 1, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def drop04(): Bool = region r {
-        let a = Array.drop(-1, [1]);
+        let a = Array.drop(r, -1, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def drop05(): Bool = region r {
-        let a = Array.drop(0, [1]);
+        let a = Array.drop(r, 0, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def drop06(): Bool = region r {
-        let a = Array.drop(1, [1]);
+        let a = Array.drop(r, 1, [1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def drop07(): Bool = region r {
-        let a = Array.drop(2, [1]);
+        let a = Array.drop(r, 2, [1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def drop08(): Bool = region r {
-        let a = Array.drop(0, [1,2]);
+        let a = Array.drop(r, 0, [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def drop09(): Bool = region r {
-        let a = Array.drop(1, [1,2]);
+        let a = Array.drop(r, 1, [1,2]);
         Array.sameElements(a, [2])
     }
 
     @test
     def drop10(): Bool = region r {
-        let a = Array.drop(2, [1,2]);
+        let a = Array.drop(r, 2, [1,2]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def drop11(): Bool = region r {
-        let a = Array.drop(2, [1,2,3,4,5,6]);
+        let a = Array.drop(r, 2, [1,2,3,4,5,6]);
         Array.sameElements(a, [3,4,5,6])
     }
 
     @test
     def drop12(): Bool = region r {
-        let a = Array.drop(4, [1,2,3,4,5,6]);
+        let a = Array.drop(r, 4, [1,2,3,4,5,6]);
         Array.sameElements(a, [5,6])
     }
 
@@ -3127,73 +3127,73 @@ namespace TestArray {
 
     @test
     def dropLeft01(): Bool = region r {
-        let a = Array.dropLeft(-1, []: Array[Int32, _]);
+        let a = Array.dropLeft(r, -1, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropLeft02(): Bool = region r {
-        let a = Array.dropLeft(0, []: Array[Int32, _]);
+        let a = Array.dropLeft(r, 0, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropLeft03(): Bool = region r {
-        let a = Array.dropLeft(1, []: Array[Int32, _]);
+        let a = Array.dropLeft(r, 1, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropLeft04(): Bool = region r {
-        let a = Array.dropLeft(-1, [1]);
+        let a = Array.dropLeft(r, -1, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def dropLeft05(): Bool = region r {
-        let a = Array.dropLeft(0, [1]);
+        let a = Array.dropLeft(r, 0, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def dropLeft06(): Bool = region r {
-        let a = Array.dropLeft(1, [1]);
+        let a = Array.dropLeft(r, 1, [1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropLeft07(): Bool = region r {
-        let a = Array.dropLeft(2, [1]);
+        let a = Array.dropLeft(r, 2, [1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropLeft08(): Bool = region r {
-        let a = Array.dropLeft(0, [1,2]);
+        let a = Array.dropLeft(r, 0, [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def dropLeft09(): Bool = region r {
-        let a = Array.dropLeft(1, [1,2]);
+        let a = Array.dropLeft(r, 1, [1,2]);
         Array.sameElements(a, [2])
     }
 
     @test
     def dropLeft10(): Bool = region r {
-        let a = Array.dropLeft(2, [1,2]);
+        let a = Array.dropLeft(r, 2, [1,2]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropLeft11(): Bool = region r {
-        let a = Array.dropLeft(2, [1,2,3,4,5,6]);
+        let a = Array.dropLeft(r, 2, [1,2,3,4,5,6]);
         Array.sameElements(a, [3,4,5,6])
     }
 
     @test
     def dropLeft12(): Bool = region r {
-        let a = Array.dropLeft(4, [1,2,3,4,5,6]);
+        let a = Array.dropLeft(r, 4, [1,2,3,4,5,6]);
         Array.sameElements(a, [5,6])
     }
 
@@ -3203,73 +3203,73 @@ namespace TestArray {
 
     @test
     def dropRight01(): Bool = region r {
-        let a = Array.dropRight(-1, []: Array[Int32, _]);
+        let a = Array.dropRight(r, -1, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropRight02(): Bool = region r {
-        let a = Array.dropRight(0, []: Array[Int32, _]);
+        let a = Array.dropRight(r, 0, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropRight03(): Bool = region r {
-        let a = Array.dropRight(1, []: Array[Int32, _]);
+        let a = Array.dropRight(r, 1, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropRight04(): Bool = region r {
-        let a = Array.dropRight(-1, [1]);
+        let a = Array.dropRight(r, -1, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def dropRight05(): Bool = region r {
-        let a = Array.dropRight(0, [1]);
+        let a = Array.dropRight(r, 0, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def dropRight06(): Bool = region r {
-        let a = Array.dropRight(1, [1]);
+        let a = Array.dropRight(r, 1, [1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropRight07(): Bool = region r {
-        let a = Array.dropRight(2, [1]);
+        let a = Array.dropRight(r, 2, [1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropRight08(): Bool = region r {
-        let a = Array.dropRight(0, [1,2]);
+        let a = Array.dropRight(r, 0, [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def dropRight09(): Bool = region r {
-        let a = Array.dropRight(1, [1,2]);
+        let a = Array.dropRight(r, 1, [1,2]);
         Array.sameElements(a, [1])
     }
 
     @test
     def dropRight10(): Bool = region r {
-        let a = Array.dropRight(2, [1,2]);
+        let a = Array.dropRight(r, 2, [1,2]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropRight11(): Bool = region r {
-        let a = Array.dropRight(2, [1,2,3,4,5,6]);
+        let a = Array.dropRight(r, 2, [1,2,3,4,5,6]);
         Array.sameElements(a, [1,2,3,4])
     }
 
     @test
     def dropRight12(): Bool = region r {
-        let a = Array.dropRight(4, [1,2,3,4,5,6]);
+        let a = Array.dropRight(r, 4, [1,2,3,4,5,6]);
         Array.sameElements(a, [1,2])
     }
 
@@ -3279,49 +3279,49 @@ namespace TestArray {
 
     @test
     def dropWhile01(): Bool = region r {
-        let a = Array.dropWhile(i -> i > 3, []);
+        let a = Array.dropWhile(r, i -> i > 3, []);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropWhile02(): Bool = region r {
-        let a = Array.dropWhile(i -> i > 3, [1]);
+        let a = Array.dropWhile(r, i -> i > 3, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def dropWhile03(): Bool = region r {
-        let a = Array.dropWhile(i -> i > 3, [4]);
+        let a = Array.dropWhile(r, i -> i > 3, [4]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropWhile04(): Bool = region r {
-        let a = Array.dropWhile(i -> i > 3, [1,2]);
+        let a = Array.dropWhile(r, i -> i > 3, [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def dropWhile05(): Bool = region r {
-        let a = Array.dropWhile(i -> i > 3, [1,5]);
+        let a = Array.dropWhile(r, i -> i > 3, [1,5]);
         Array.sameElements(a, [1,5])
     }
 
     @test
     def dropWhile06(): Bool = region r {
-        let a = Array.dropWhile(i -> i > 3, [5,1]);
+        let a = Array.dropWhile(r, i -> i > 3, [5,1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def dropWhile07(): Bool = region r {
-        let a = Array.dropWhile(i -> i > 3, [5,8]);
+        let a = Array.dropWhile(r, i -> i > 3, [5,8]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropWhile08(): Bool = region r {
-        let a = Array.dropWhile(i -> i > 3, [4, 6, -3, 11, -5, 1, 2, 16, 7, 1, 7]);
+        let a = Array.dropWhile(r, i -> i > 3, [4, 6, -3, 11, -5, 1, 2, 16, 7, 1, 7]);
         Array.sameElements(a, [-3, 11, -5, 1, 2, 16, 7, 1, 7])
     }
 
@@ -3331,49 +3331,49 @@ namespace TestArray {
 
     @test
     def dropWhileLeft01(): Bool = region r {
-        let a = Array.dropWhileLeft(i -> i > 3, []);
+        let a = Array.dropWhileLeft(r, i -> i > 3, []);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropWhileLeft02(): Bool = region r {
-        let a = Array.dropWhileLeft(i -> i > 3, [1]);
+        let a = Array.dropWhileLeft(r, i -> i > 3, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def dropWhileLeft03(): Bool = region r {
-        let a = Array.dropWhileLeft(i -> i > 3, [4]);
+        let a = Array.dropWhileLeft(r, i -> i > 3, [4]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropWhileLeft04(): Bool = region r {
-        let a = Array.dropWhileLeft(i -> i > 3, [1,2]);
+        let a = Array.dropWhileLeft(r, i -> i > 3, [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def dropWhileLeft05(): Bool = region r {
-        let a = Array.dropWhileLeft(i -> i > 3, [1,5]);
+        let a = Array.dropWhileLeft(r, i -> i > 3, [1,5]);
         Array.sameElements(a, [1,5])
     }
 
     @test
     def dropWhileLeft06(): Bool = region r {
-        let a = Array.dropWhileLeft(i -> i > 3, [5,1]);
+        let a = Array.dropWhileLeft(r, i -> i > 3, [5,1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def dropWhileLeft07(): Bool = region r {
-        let a = Array.dropWhileLeft(i -> i > 3, [5,8]);
+        let a = Array.dropWhileLeft(r, i -> i > 3, [5,8]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropWhileLeft08(): Bool = region r {
-        let a = Array.dropWhileLeft(i -> i > 3, [4, 6, -3, 11, -5, 1, 2, 16, 7, 1, 7]);
+        let a = Array.dropWhileLeft(r, i -> i > 3, [4, 6, -3, 11, -5, 1, 2, 16, 7, 1, 7]);
         Array.sameElements(a, [-3, 11, -5, 1, 2, 16, 7, 1, 7])
     }
 
@@ -3383,49 +3383,49 @@ namespace TestArray {
 
     @test
     def dropWhileRight01(): Bool = region r {
-        let a = Array.dropWhileRight(i -> i > 3, []);
+        let a = Array.dropWhileRight(r, i -> i > 3, []);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropWhileRight02(): Bool = region r {
-        let a = Array.dropWhileRight(i -> i > 3, [1]);
+        let a = Array.dropWhileRight(r, i -> i > 3, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def dropWhileRight03(): Bool = region r {
-        let a = Array.dropWhileRight(i -> i > 3, [4]);
+        let a = Array.dropWhileRight(r, i -> i > 3, [4]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropWhileRight04(): Bool = region r {
-        let a = Array.dropWhileRight(i -> i > 3, [1,2]);
+        let a = Array.dropWhileRight(r, i -> i > 3, [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def dropWhileRight05(): Bool = region r {
-        let a = Array.dropWhileRight(i -> i > 3, [1,5]);
+        let a = Array.dropWhileRight(r, i -> i > 3, [1,5]);
         Array.sameElements(a, [1])
     }
 
     @test
     def dropWhileRight06(): Bool = region r {
-        let a = Array.dropWhileRight(i -> i > 3, [5,1]);
+        let a = Array.dropWhileRight(r, i -> i > 3, [5,1]);
         Array.sameElements(a, [5,1])
     }
 
     @test
     def dropWhileRight07(): Bool = region r {
-        let a = Array.dropWhileRight(i -> i > 3, [5,8]);
+        let a = Array.dropWhileRight(r, i -> i > 3, [5,8]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def dropWhileRight08(): Bool = region r {
-        let a = Array.dropWhileRight(i -> i > 3, [4, 6, -3, 11, -5, 1, 2, 16, 7, 1, 7]);
+        let a = Array.dropWhileRight(r, i -> i > 3, [4, 6, -3, 11, -5, 1, 2, 16, 7, 1, 7]);
         Array.sameElements(a, [4, 6, -3, 11, -5, 1, 2, 16, 7, 1])
     }
 
@@ -3435,73 +3435,73 @@ namespace TestArray {
 
     @test
     def take01(): Bool = region r {
-        let a = Array.take(-1, []: Array[Int32, _]);
+        let a = Array.take(r, -1, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def take02(): Bool = region r {
-        let a = Array.take(0, []: Array[Int32, _]);
+        let a = Array.take(r, 0, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def take03(): Bool = region r {
-        let a = Array.take(1, []: Array[Int32, _]);
+        let a = Array.take(r, 1, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def take04(): Bool = region r {
-        let a = Array.take(-1, [1]);
+        let a = Array.take(r, -1, [1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def take05(): Bool = region r {
-        let a = Array.take(0, [1]);
+        let a = Array.take(r, 0, [1]);
         Array.sameElements(a, []: Array[Int32, _])
 
     }
     @test
     def take06(): Bool = region r {
-        let a = Array.take(1, [1]);
+        let a = Array.take(r, 1, [1]);
         Array.sameElements(a, [1])
 
     }
     @test
     def take07(): Bool = region r {
-        let a = Array.take(2, [1]);
+        let a = Array.take(r, 2, [1]);
         Array.sameElements(a, [1])
 
     }
     @test
     def take08(): Bool = region r {
-        let a = Array.take(0, [1,2]);
+        let a = Array.take(r, 0, [1,2]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def take09(): Bool = region r {
-        let a = Array.take(1, [1,2]);
+        let a = Array.take(r, 1, [1,2]);
         Array.sameElements(a, [1])
     }
 
     @test
     def take10(): Bool = region r {
-        let a = Array.take(2, [1,2]);
+        let a = Array.take(r, 2, [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def take11(): Bool = region r {
-        let a = Array.take(2, [1,2,3,4,5,6]);
+        let a = Array.take(r, 2, [1,2,3,4,5,6]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def take12(): Bool = region r {
-        let a = Array.take(4, [1,2,3,4,5,6]);
+        let a = Array.take(r, 4, [1,2,3,4,5,6]);
         Array.sameElements(a, [1,2,3,4])
     }
 
@@ -3511,73 +3511,73 @@ namespace TestArray {
 
     @test
     def takeLeft01(): Bool = region r {
-        let a = Array.takeLeft(-1, []: Array[Int32, _]);
+        let a = Array.takeLeft(r, -1, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeLeft02(): Bool = region r {
-        let a = Array.takeLeft(0, []: Array[Int32, _]);
+        let a = Array.takeLeft(r, 0, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeLeft03(): Bool = region r {
-        let a = Array.takeLeft(1, []: Array[Int32, _]);
+        let a = Array.takeLeft(r, 1, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeLeft04(): Bool = region r {
-        let a = Array.takeLeft(-1, [1]);
+        let a = Array.takeLeft(r, -1, [1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeLeft05(): Bool = region r {
-        let a = Array.takeLeft(0, [1]);
+        let a = Array.takeLeft(r, 0, [1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeLeft06(): Bool = region r {
-        let a = Array.takeLeft(1, [1]);
+        let a = Array.takeLeft(r, 1, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def takeLeft07(): Bool = region r {
-        let a = Array.takeLeft(2, [1]);
+        let a = Array.takeLeft(r, 2, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def takeLeft08(): Bool = region r {
-        let a = Array.takeLeft(0, [1,2]);
+        let a = Array.takeLeft(r, 0, [1,2]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeLeft09(): Bool = region r {
-        let a = Array.takeLeft(1, [1,2]);
+        let a = Array.takeLeft(r, 1, [1,2]);
         Array.sameElements(a, [1])
     }
 
     @test
     def takeLeft10(): Bool = region r {
-        let a = Array.takeLeft(2, [1,2]);
+        let a = Array.takeLeft(r, 2, [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def takeLeft11(): Bool = region r {
-        let a = Array.takeLeft(2, [1,2,3,4,5,6]);
+        let a = Array.takeLeft(r, 2, [1,2,3,4,5,6]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def takeLeft12(): Bool = region r {
-        let a = Array.takeLeft(4, [1,2,3,4,5,6]);
+        let a = Array.takeLeft(r, 4, [1,2,3,4,5,6]);
         Array.sameElements(a, [1,2,3,4])
     }
 
@@ -3587,73 +3587,73 @@ namespace TestArray {
 
     @test
     def takeRight01(): Bool = region r {
-        let a = Array.takeRight(-1, []: Array[Int32, _]);
+        let a = Array.takeRight(r, -1, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeRight02(): Bool = region r {
-        let a = Array.takeRight(0, []: Array[Int32, _]);
+        let a = Array.takeRight(r, 0, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeRight03(): Bool = region r {
-        let a = Array.takeRight(1, []: Array[Int32, _]);
+        let a = Array.takeRight(r, 1, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeRight04(): Bool = region r {
-        let a = Array.takeRight(-1, [1]);
+        let a = Array.takeRight(r, -1, [1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeRight05(): Bool = region r {
-        let a = Array.takeRight(0, [1]);
+        let a = Array.takeRight(r, 0, [1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeRight06(): Bool = region r {
-        let a = Array.takeRight(1, [1]);
+        let a = Array.takeRight(r, 1, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def takeRight07(): Bool = region r {
-        let a = Array.takeRight(2, [1]);
+        let a = Array.takeRight(r, 2, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def takeRight08(): Bool = region r {
-        let a = Array.takeRight(0, [1,2]);
+        let a = Array.takeRight(r, 0, [1,2]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeRight09(): Bool = region r {
-        let a = Array.takeRight(1, [1,2]);
+        let a = Array.takeRight(r, 1, [1,2]);
         Array.sameElements(a, [2])
     }
 
     @test
     def takeRight10(): Bool = region r {
-        let a = Array.takeRight(2, [1,2]);
+        let a = Array.takeRight(r, 2, [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def takeRight11(): Bool = region r {
-        let a = Array.takeRight(2, [1,2,3,4,5,6]);
+        let a = Array.takeRight(r, 2, [1,2,3,4,5,6]);
         Array.sameElements(a, [5,6])
     }
 
     @test
     def takeRight12(): Bool = region r {
-        let a = Array.takeRight(4, [1,2,3,4,5,6]);
+        let a = Array.takeRight(r, 4, [1,2,3,4,5,6]);
         Array.sameElements(a, [3,4,5,6])
     }
 
@@ -3663,49 +3663,49 @@ namespace TestArray {
 
     @test
     def takeWhile01(): Bool = region r {
-        let a = Array.takeWhile(i -> i > 3, []: Array[Int32, _]);
+        let a = Array.takeWhile(r, i -> i > 3, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhile02(): Bool = region r {
-        let a = Array.takeWhile(i -> i > 3, [1]);
+        let a = Array.takeWhile(r, i -> i > 3, [1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhile03(): Bool = region r {
-        let a = Array.takeWhile(i -> i > 3, [4]);
+        let a = Array.takeWhile(r, i -> i > 3, [4]);
         Array.sameElements(a, [4])
     }
 
     @test
     def takeWhile04(): Bool = region r {
-        let a = Array.takeWhile(i -> i > 3, [1,2]);
+        let a = Array.takeWhile(r, i -> i > 3, [1,2]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhile05(): Bool = region r {
-        let a = Array.takeWhile(i -> i > 3, [1,5]);
+        let a = Array.takeWhile(r, i -> i > 3, [1,5]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhile06(): Bool = region r {
-        let a = Array.takeWhile(i -> i > 3, [5,1]);
+        let a = Array.takeWhile(r, i -> i > 3, [5,1]);
         Array.sameElements(a, [5])
     }
 
     @test
     def takeWhile07(): Bool = region r {
-        let a = Array.takeWhile(i -> i > 3, [5,8]);
+        let a = Array.takeWhile(r, i -> i > 3, [5,8]);
         Array.sameElements(a, [5,8])
     }
 
     @test
     def takeWhile08(): Bool = region r {
-        let a = Array.takeWhile(i -> i > 3, [4, 6, -3, 11, -5, 1, 2, 16, 7, 1, 7]);
+        let a = Array.takeWhile(r, i -> i > 3, [4, 6, -3, 11, -5, 1, 2, 16, 7, 1, 7]);
         Array.sameElements(a, [4, 6])
     }
 
@@ -3715,49 +3715,49 @@ namespace TestArray {
 
     @test
     def takeWhileLeft01(): Bool = region r {
-        let a = Array.takeWhileLeft(i -> i > 3, []: Array[Int32, _]);
+        let a = Array.takeWhileLeft(r, i -> i > 3, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhileLeft02(): Bool = region r {
-        let a = Array.takeWhileLeft(i -> i > 3, [1]);
+        let a = Array.takeWhileLeft(r, i -> i > 3, [1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhileLeft03(): Bool = region r {
-        let a = Array.takeWhileLeft(i -> i > 3, [4]);
+        let a = Array.takeWhileLeft(r, i -> i > 3, [4]);
         Array.sameElements(a, [4])
     }
 
     @test
     def takeWhileLeft04(): Bool = region r {
-        let a = Array.takeWhileLeft(i -> i > 3, [1,2]);
+        let a = Array.takeWhileLeft(r, i -> i > 3, [1,2]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhileLeft05(): Bool = region r {
-        let a = Array.takeWhileLeft(i -> i > 3, [1,5]);
+        let a = Array.takeWhileLeft(r, i -> i > 3, [1,5]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhileLeft06(): Bool = region r {
-        let a = Array.takeWhileLeft(i -> i > 3, [5,1]);
+        let a = Array.takeWhileLeft(r, i -> i > 3, [5,1]);
         Array.sameElements(a, [5])
     }
 
     @test
     def takeWhileLeft07(): Bool = region r {
-        let a = Array.takeWhileLeft(i -> i > 3, [5,8]);
+        let a = Array.takeWhileLeft(r, i -> i > 3, [5,8]);
         Array.sameElements(a, [5,8])
     }
 
     @test
     def takeWhileLeft08(): Bool = region r {
-        let a = Array.takeWhileLeft(i -> i > 3, [4, 6, -3, 11, -5, 1, 2, 16, 7, 1, 7]);
+        let a = Array.takeWhileLeft(r, i -> i > 3, [4, 6, -3, 11, -5, 1, 2, 16, 7, 1, 7]);
         Array.sameElements(a, [4, 6])
     }
 
@@ -3767,49 +3767,49 @@ namespace TestArray {
 
     @test
     def takeWhileRight01(): Bool = region r {
-        let a = Array.takeWhileRight(i -> i > 3, []: Array[Int32, _]);
+        let a = Array.takeWhileRight(r, i -> i > 3, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhileRight02(): Bool = region r {
-        let a = Array.takeWhileRight(i -> i > 3, [1]);
+        let a = Array.takeWhileRight(r, i -> i > 3, [1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhileRight03(): Bool = region r {
-        let a = Array.takeWhileRight(i -> i > 3, [4]);
+        let a = Array.takeWhileRight(r, i -> i > 3, [4]);
         Array.sameElements(a, [4])
     }
 
     @test
     def takeWhileRight04(): Bool = region r {
-        let a = Array.takeWhileRight(i -> i > 3, [1,2]);
+        let a = Array.takeWhileRight(r, i -> i > 3, [1,2]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhileRight05(): Bool = region r {
-        let a = Array.takeWhileRight(i -> i > 3, [1,5]);
+        let a = Array.takeWhileRight(r, i -> i > 3, [1,5]);
         Array.sameElements(a, [5])
     }
 
     @test
     def takeWhileRight06(): Bool = region r {
-        let a = Array.takeWhileRight(i -> i > 3, [5,1]);
+        let a = Array.takeWhileRight(r, i -> i > 3, [5,1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def takeWhileRight07(): Bool = region r {
-        let a = Array.takeWhileRight(i -> i > 3, [5,8]);
+        let a = Array.takeWhileRight(r, i -> i > 3, [5,8]);
         Array.sameElements(a, [5,8])
     }
 
     @test
     def takeWhileRight08(): Bool = region r {
-        let a = Array.takeWhileRight(i -> i > 3, [4, 6, -3, 11, -5, 1, 2, 16, 7, 1, 7]);
+        let a = Array.takeWhileRight(r, i -> i > 3, [4, 6, -3, 11, -5, 1, 2, 16, 7, 1, 7]);
         Array.sameElements(a, [7])
     }
 
@@ -3872,43 +3872,43 @@ namespace TestArray {
 
     @test
     def zip01(): Bool = region r {
-        let a = Array.zip([]: Array[Int32, _], []: Array[Int32, _]);
+        let a = Array.zip(r, []: Array[Int32, _], []: Array[Int32, _]);
         Array.sameElements(a, []: Array[(Int32, Int32), _])
     }
 
     @test
     def zip02(): Bool = region r {
-        let a = Array.zip([1], []: Array[Int32, _]);
+        let a = Array.zip(r, [1], []: Array[Int32, _]);
         Array.sameElements(a, []: Array[(Int32, Int32), _])
     }
 
     @test
     def zip03(): Bool = region r {
-        let a = Array.zip([]: Array[Int32, _], [2]);
+        let a = Array.zip(r, []: Array[Int32, _], [2]);
         Array.sameElements(a, []: Array[(Int32, Int32), _])
     }
 
     @test
     def zip04(): Bool = region r {
-        let a = Array.zip([1], [2]);
+        let a = Array.zip(r, [1], [2]);
         Array.sameElements(a, [(1, 2)])
     }
 
     @test
     def zip05(): Bool = region r {
-        let a = Array.zip([1,3], [2,4]);
+        let a = Array.zip(r, [1,3], [2,4]);
         Array.sameElements(a, [(1, 2), (3, 4)])
     }
 
     @test
     def zip06(): Bool = region r {
-        let a = Array.zip([1,3,5], [2,4,6]);
+        let a = Array.zip(r, [1,3,5], [2,4,6]);
         Array.sameElements(a, [(1, 2), (3, 4), (5, 6)])
     }
 
     @test
     def zip07(): Bool = region r {
-        let a = Array.zip([1,3,5,7], [2,4,6,8]);
+        let a = Array.zip(r, [1,3,5,7], [2,4,6,8]);
         Array.sameElements(a, [(1, 2), (3, 4), (5, 6), (7, 8)])
     }
 
@@ -3918,37 +3918,37 @@ namespace TestArray {
 
     @test
     def zipWith01(): Bool = region r {
-        let arr = Array.zipWith((a, b) -> if (b) a + 1 else a, []: Array[Int32, _], []: Array[Bool, _]);
+        let arr = Array.zipWith(r, (a, b) -> if (b) a + 1 else a, []: Array[Int32, _], []: Array[Bool, _]);
         Array.sameElements(arr, []: Array[Int32, _])
     }
 
     @test
     def zipWith02(): Bool = region r {
-        let arr = Array.zipWith((a, b) -> if (b) a + 1 else a, [1], []: Array[Bool, _]);
+        let arr = Array.zipWith(r, (a, b) -> if (b) a + 1 else a, [1], []: Array[Bool, _]);
         Array.sameElements(arr, []: Array[Int32, _])
     }
 
     @test
     def zipWith03(): Bool = region r {
-        let arr = Array.zipWith((a, b) -> if (b) a + 1 else a, []: Array[Int32, _], [true]);
+        let arr = Array.zipWith(r, (a, b) -> if (b) a + 1 else a, []: Array[Int32, _], [true]);
         Array.sameElements(arr, []: Array[Int32, _])
     }
 
     @test
     def zipWith04(): Bool = region r {
-        let arr = Array.zipWith((a, b) -> if (b) a + 1 else a, [1], [true]);
+        let arr = Array.zipWith(r, (a, b) -> if (b) a + 1 else a, [1], [true]);
         Array.sameElements(arr, [2])
     }
 
     @test
     def zipWith05(): Bool = region r {
-        let arr = Array.zipWith((a, b) -> if (b) a + 1 else a, [1], [false]);
+        let arr = Array.zipWith(r, (a, b) -> if (b) a + 1 else a, [1], [false]);
         Array.sameElements(arr, [1])
     }
 
     @test
     def zipWith06(): Bool = region r {
-        let arr = Array.zipWith((a, b) -> if (b) a + 1 else a,
+        let arr = Array.zipWith(r, (a, b) -> if (b) a + 1 else a,
                         [1, 2, 3, 4, 5, 6, 7, 8],
                         [false, true, true, false, false, true, true, true]);
         Array.sameElements(arr, [1, 3, 4, 4, 5, 7, 8, 9])
@@ -4164,49 +4164,49 @@ namespace TestArray {
 
     @test
     def filterMap01(): Bool = region r {
-        let a = Array.filterMap(i -> if (i rem 2 == 0) Some(i/2) else None, []: Array[Int32, _]);
+        let a = Array.filterMap(r, i -> if (i rem 2 == 0) Some(i/2) else None, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def filterMap02(): Bool = region r {
-        let a = Array.filterMap(i -> if (i rem 2 == 0) Some(i/2) else None, [1]);
+        let a = Array.filterMap(r, i -> if (i rem 2 == 0) Some(i/2) else None, [1]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def filterMap03(): Bool = region r {
-        let a = Array.filterMap(i -> if (i rem 2 == 0) Some(i/2) else None, [2]);
+        let a = Array.filterMap(r, i -> if (i rem 2 == 0) Some(i/2) else None, [2]);
         Array.sameElements(a, [1])
     }
 
     @test
     def filterMap04(): Bool = region r {
-        let a = Array.filterMap(i -> if (i rem 2 == 0) Some(i/2) else None, [1,3]);
+        let a = Array.filterMap(r, i -> if (i rem 2 == 0) Some(i/2) else None, [1,3]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def filterMap05(): Bool = region r {
-        let a = Array.filterMap(i -> if (i rem 2 == 0) Some(i/2) else None, [1,4]);
+        let a = Array.filterMap(r, i -> if (i rem 2 == 0) Some(i/2) else None, [1,4]);
         Array.sameElements(a, [2])
     }
 
     @test
     def filterMap06(): Bool = region r {
-        let a = Array.filterMap(i -> if (i rem 2 == 0) Some(i/2) else None, [6,-1]);
+        let a = Array.filterMap(r, i -> if (i rem 2 == 0) Some(i/2) else None, [6,-1]);
         Array.sameElements(a, [3])
     }
 
     @test
     def filterMap07(): Bool = region r {
-        let a = Array.filterMap(i -> if (i rem 2 == 0) Some(i/2) else None, [8,6]);
+        let a = Array.filterMap(r, i -> if (i rem 2 == 0) Some(i/2) else None, [8,6]);
         Array.sameElements(a, [4,3])
     }
 
     @test
     def filterMap08(): Bool = region r {
-        let a = Array.filterMap(i -> if (i rem 2 == 0) Some(i/2) else None, [0,1,2,3,4,5,10]);
+        let a = Array.filterMap(r, i -> if (i rem 2 == 0) Some(i/2) else None, [0,1,2,3,4,5,10]);
         Array.sameElements(a, [0,1,2,5])
     }
 
@@ -4667,169 +4667,169 @@ namespace TestArray {
 
     @test
     def updateSequence01(): Bool = region r {
-         let a = Array.updateSequence(0, []: Array[Int32, _], []: Array[Int32, _]);
+         let a = Array.updateSequence(r, 0, []: Array[Int32, _], []: Array[Int32, _]);
          Array.sameElements(a, []: Array[Int32, _])
      }
 
     @test
     def updateSequence02(): Bool = region r {
-        let a = Array.updateSequence(0, [1,2], []);
+        let a = Array.updateSequence(r, 0, [1,2], []);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def updateSequence03(): Bool = region r {
-        let a = Array.updateSequence(0, [], [1,2]);
+        let a = Array.updateSequence(r, 0, [], [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def updateSequence04(): Bool = region r {
-        let a = Array.updateSequence(-3, [1,2,4], [1,2]);
+        let a = Array.updateSequence(r, -3, [1,2,4], [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def updateSequence05(): Bool = region r {
-        let a = Array.updateSequence(2, [1,2,4], [1,2]);
+        let a = Array.updateSequence(r, 2, [1,2,4], [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def updateSequence06(): Bool = region r {
-        let a = Array.updateSequence(0, [], [1]);
+        let a = Array.updateSequence(r, 0, [], [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def updateSequence07(): Bool = region r {
-        let a = Array.updateSequence(1, [2], [1]);
+        let a = Array.updateSequence(r, 1, [2], [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def updateSequence08(): Bool = region r {
-        let a = Array.updateSequence(0, [2], [1]);
+        let a = Array.updateSequence(r, 0, [2], [1]);
         Array.sameElements(a, [2])
     }
 
     @test
     def updateSequence09(): Bool = region r {
-        let a = Array.updateSequence(0, [2,4], [1]);
+        let a = Array.updateSequence(r, 0, [2,4], [1]);
         Array.sameElements(a, [2])
     }
 
     @test
     def updateSequence10(): Bool = region r {
-        let a = Array.updateSequence(-1, [2,4], [1]);
+        let a = Array.updateSequence(r, -1, [2,4], [1]);
         Array.sameElements(a, [4])
     }
 
     @test
     def updateSequence11(): Bool = region r {
-        let a = Array.updateSequence(-1, [3,4], [1,2]);
+        let a = Array.updateSequence(r, -1, [3,4], [1,2]);
         Array.sameElements(a, [4,2])
     }
 
     @test
     def updateSequence12(): Bool = region r {
-        let a = Array.updateSequence(1, [3,4], [1,2]);
+        let a = Array.updateSequence(r, 1, [3,4], [1,2]);
         Array.sameElements(a, [1,3])
     }
 
     @test
     def updateSequence13(): Bool = region r {
-        let a = Array.updateSequence(-2, [3,4], [1,2]);
+        let a = Array.updateSequence(r, -2, [3,4], [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def updateSequence14(): Bool = region r {
-        let a = Array.updateSequence(2, [3,4], [1,2]);
+        let a = Array.updateSequence(r, 2, [3,4], [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def updateSequence15(): Bool = region r {
-        let a = Array.updateSequence(1, [3], [1,2]);
+        let a = Array.updateSequence(r, 1, [3], [1,2]);
         Array.sameElements(a, [1,3])
     }
 
     @test
     def updateSequence16(): Bool = region r {
-        let a = Array.updateSequence(0, [3,4], [1,2]);
+        let a = Array.updateSequence(r, 0, [3,4], [1,2]);
         Array.sameElements(a, [3,4])
     }
 
     @test
     def updateSequence17(): Bool = region r {
-        let a = Array.updateSequence(0, [4], [1, 2, 3]);
+        let a = Array.updateSequence(r, 0, [4], [1, 2, 3]);
         Array.sameElements(a, [4, 2, 3])
     }
 
     @test
     def updateSequence18(): Bool = region r {
-        let a = Array.updateSequence(1, [4], [1, 2, 3]);
+        let a = Array.updateSequence(r, 1, [4], [1, 2, 3]);
         Array.sameElements(a, [1, 4, 3])
     }
 
     @test
     def updateSequence19(): Bool = region r {
-        let a = Array.updateSequence(2, [4], [1, 2, 3]);
+        let a = Array.updateSequence(r, 2, [4], [1, 2, 3]);
         Array.sameElements(a, [1, 2, 4])
     }
 
     @test
     def updateSequence20(): Bool = region r {
-        let a = Array.updateSequence(0, [4, 5], [1, 2, 3]);
+        let a = Array.updateSequence(r, 0, [4, 5], [1, 2, 3]);
         Array.sameElements(a, [4, 5, 3])
     }
 
     @test
     def updateSequence21(): Bool = region r {
-        let a = Array.updateSequence(1, [4, 5], [1, 2, 3]);
+        let a = Array.updateSequence(r, 1, [4, 5], [1, 2, 3]);
         Array.sameElements(a, [1, 4, 5])
     }
 
     @test
     def updateSequence22(): Bool = region r {
-        let a = Array.updateSequence(-1, [4, 5, 6], [1, 2, 3]);
+        let a = Array.updateSequence(r, -1, [4, 5, 6], [1, 2, 3]);
         Array.sameElements(a, [5, 6, 3])
     }
 
     @test
     def updateSequence23(): Bool = region r {
-        let a = Array.updateSequence(0, [4, 5, 6], [1, 2, 3]);
+        let a = Array.updateSequence(r, 0, [4, 5, 6], [1, 2, 3]);
         Array.sameElements(a, [4, 5, 6])
     }
 
     @test
     def updateSequence24(): Bool = region r {
-        let a = Array.updateSequence(2, [14, 15, 16, 17], [1, 2, 3, 4, 5, 6, 7]);
+        let a = Array.updateSequence(r, 2, [14, 15, 16, 17], [1, 2, 3, 4, 5, 6, 7]);
         Array.sameElements(a, [1, 2, 14, 15, 16, 17, 7])
     }
 
     @test
     def updateSequence25(): Bool = region r {
-        let a = Array.updateSequence(-2, [14, 15, 16, 17], [1, 2, 3, 4, 5, 6, 7]);
+        let a = Array.updateSequence(r, -2, [14, 15, 16, 17], [1, 2, 3, 4, 5, 6, 7]);
         Array.sameElements(a, [16, 17, 3, 4, 5, 6, 7])
     }
 
     @test
     def updateSequence26(): Bool = region r {
-        let a = Array.updateSequence(4, [14, 15, 16, 17], [1, 2, 3, 4, 5, 6, 7]);
+        let a = Array.updateSequence(r, 4, [14, 15, 16, 17], [1, 2, 3, 4, 5, 6, 7]);
         Array.sameElements(a, [1, 2, 3, 4, 14, 15, 16])
     }
 
     @test
     def updateSequence27(): Bool = region r {
-        let a = Array.updateSequence(4, [14, 15], [1, 2, 3, 4, 5, 6, 7]);
+        let a = Array.updateSequence(r, 4, [14, 15], [1, 2, 3, 4, 5, 6, 7]);
         Array.sameElements(a, [1, 2, 3, 4, 14, 15, 7])
     }
 
     @test
     def updateSequence28(): Bool = region r {
-        let a = Array.updateSequence(-1, [-1, -2, -3, -4, -5, -6, -7, -8], [1, 2, 3, 4, 5, 6, 7]);
+        let a = Array.updateSequence(r, -1, [-1, -2, -3, -4, -5, -6, -7, -8], [1, 2, 3, 4, 5, 6, 7]);
         Array.sameElements(a, [-2, -3, -4, -5, -6, -7, -8])
     }
 
@@ -5045,79 +5045,79 @@ namespace TestArray {
 
     @test
     def sortWith01(): Bool = region r {
-        let a = Array.sortWith(cmp, []: Array[Int32, _]);
+        let a = Array.sortWith(r, cmp, []: Array[Int32, _]);
         a `sameElements` []: Array[Int32, _]
     }
 
     @test
     def sortWith02(): Bool = region r {
-        let a = Array.sortWith(cmp, [0]);
+        let a = Array.sortWith(r, cmp, [0]);
         a `sameElements` [0]
     }
 
     @test
     def sortWith03(): Bool = region r {
-        let a = Array.sortWith(cmp, [0,1]);
+        let a = Array.sortWith(r, cmp, [0,1]);
         a `sameElements` [0,1]
     }
 
     @test
     def sortWith04(): Bool = region r {
-        let a = Array.sortWith(cmp, [1,0]);
+        let a = Array.sortWith(r, cmp, [1,0]);
         a `sameElements` [0,1]
     }
 
     @test
     def sortWith05(): Bool = region r {
-        let a = Array.sortWith(cmp, [1,1]);
+        let a = Array.sortWith(r, cmp, [1,1]);
         a `sameElements` [1,1]
     }
 
     @test
     def sortWith06(): Bool = region r {
-        let a = Array.sortWith(cmp, [0,1,2,3,4,5]);
+        let a = Array.sortWith(r, cmp, [0,1,2,3,4,5]);
         a `sameElements` [0,1,2,3,4,5]
     }
 
     @test
     def sortWith07(): Bool = region r {
-        let a = Array.sortWith(cmp, [5,4,3,2,1,0]);
+        let a = Array.sortWith(r, cmp, [5,4,3,2,1,0]);
         a `sameElements` [0,1,2,3,4,5]
     }
 
     @test
     def sortWith08(): Bool = region r {
-        let a = Array.sortWith(cmp, [5,3,0,4,1,2]);
+        let a = Array.sortWith(r, cmp, [5,3,0,4,1,2]);
         a `sameElements` [0,1,2,3,4,5]
     }
 
     @test
     def sortWith09(): Bool = region r {
-        let a = Array.sortWith(cmp, [2,3,0,4,1,2]);
+        let a = Array.sortWith(r, cmp, [2,3,0,4,1,2]);
         a `sameElements` [0,1,2,2,3,4]
     }
 
     @test
     def sortWith10(): Bool = region r {
-        let a = Array.sortWith(flip(cmp), [0,1,2,3,4,5]);
+        let a = Array.sortWith(r, flip(cmp), [0,1,2,3,4,5]);
         a `sameElements` [5,4,3,2,1,0]
     }
 
     @test
     def sortWith11(): Bool = region r {
-        let a = Array.sortWith(flip(cmp), [5,4,3,2,1,0]);
+        let a = Array.sortWith(r, flip(cmp), [5,4,3,2,1,0]);
         a `sameElements` [5,4,3,2,1,0]
     }
 
     @test
     def sortWith12(): Bool = region r {
-        let a = Array.sortWith(flip(cmp), [5,3,0,4,1,2]);
+        let a = Array.sortWith(r, flip(cmp), [5,3,0,4,1,2]);
         a `sameElements` [5,4,3,2,1,0]
     }
 
     @test
     def sortWith13(): Bool = region r {
-        let a = Array.sortWith(flip(cmp), [2,3,0,4,1,2]);
+        let a = Array.sortWith(r, flip(cmp), [2,3,0,4,1,2]);
         a `sameElements` [4,3,2,2,1,0]
     }
 
@@ -5125,52 +5125,52 @@ namespace TestArray {
     // sort                                                                    //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortVsSortWith(a: Array[Int32, r]): Bool \ { Read(r), Write(r) } =
-        Array.sort(a) `sameElements` Array.sortWith(cmp, a)
+    def testSortVsSortWith(r1: Region[r1], a: Array[Int32, r]): Bool \ { Read(r), Write(r1) } =
+        Array.sort(r1, a) `sameElements` Array.sortWith(r1, cmp, a)
 
     @test
     def sort01(): Bool = region r {
-        testSortVsSortWith([]: Array[Int32, _])
+        testSortVsSortWith(r, []: Array[Int32, _])
     }
 
     @test
     def sort02(): Bool = region r {
-        testSortVsSortWith([0])
+        testSortVsSortWith(r, [0])
     }
 
     @test
     def sort03(): Bool = region r {
-        testSortVsSortWith([0,1])
+        testSortVsSortWith(r, [0,1])
     }
 
     @test
     def sort04(): Bool = region r {
-        testSortVsSortWith([1,0])
+        testSortVsSortWith(r, [1,0])
     }
 
     @test
     def sort05(): Bool = region r {
-        testSortVsSortWith([1,1])
+        testSortVsSortWith(r, [1,1])
     }
 
     @test
     def sort06(): Bool = region r {
-        testSortVsSortWith([0,1,2,3,4,5])
+        testSortVsSortWith(r, [0,1,2,3,4,5])
     }
 
     @test
     def sort07(): Bool = region r {
-        testSortVsSortWith([5,4,3,2,1,0])
+        testSortVsSortWith(r, [5,4,3,2,1,0])
     }
 
     @test
     def sort08(): Bool = region r {
-        testSortVsSortWith([5,3,0,4,1,2])
+        testSortVsSortWith(r, [5,3,0,4,1,2])
     }
 
     @test
     def sort09(): Bool = region r {
-        testSortVsSortWith([2,3,0,4,1,2])
+        testSortVsSortWith(r, [2,3,0,4,1,2])
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -5329,54 +5329,54 @@ namespace TestArray {
     // sortBy                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortByVsSort(a: Array[Int32, r]): Bool \ { Read(r), Write(r) } =
-        (Array.sortBy(identity, a) `sameElements` Array.sort(a)) and
-        (Array.sortBy(x -> 4 * x + 7, a) `sameElements` Array.sort(a)) and
-        (Array.sortBy(x -> -x, a) `sameElements` Array.sortWith(flip(cmp),a))
+    def testSortByVsSort(r1: Region[r1], a: Array[Int32, r]): Bool \ { Read(r), Write(r1) } =
+        (Array.sortBy(r1, identity, a) `sameElements` Array.sort(r1, a)) and
+        (Array.sortBy(r1, x -> 4 * x + 7, a) `sameElements` Array.sort(r1, a)) and
+        (Array.sortBy(r1, x -> -x, a) `sameElements` Array.sortWith(r1, flip(cmp),a))
 
     @test
     def sortBy01(): Bool = region r {
-        testSortByVsSort([]: Array[Int32, _])
+        testSortByVsSort(r, []: Array[Int32, _])
     }
 
     @test
     def sortBy02(): Bool = region r {
-        testSortByVsSort([0])
+        testSortByVsSort(r, [0])
     }
 
     @test
     def sortBy03(): Bool = region r {
-        testSortByVsSort([0,1])
+        testSortByVsSort(r, [0,1])
     }
 
     @test
     def sortBy04(): Bool = region r {
-        testSortByVsSort([1,0])
+        testSortByVsSort(r, [1,0])
     }
 
     @test
     def sortBy05(): Bool = region r {
-        testSortByVsSort([1,1])
+        testSortByVsSort(r, [1,1])
     }
 
     @test
     def sortBy06(): Bool = region r {
-        testSortByVsSort([0,1,2,3,4,5])
+        testSortByVsSort(r, [0,1,2,3,4,5])
     }
 
     @test
     def sortBy07(): Bool = region r {
-        testSortByVsSort([5,4,3,2,1,0])
+        testSortByVsSort(r, [5,4,3,2,1,0])
     }
 
     @test
     def sortBy08(): Bool = region r {
-        testSortByVsSort([5,3,0,4,1,2])
+        testSortByVsSort(r, [5,3,0,4,1,2])
     }
 
     @test
     def sortBy09(): Bool = region r {
-        testSortByVsSort([2,3,0,4,1,2])
+        testSortByVsSort(r, [2,3,0,4,1,2])
     }
 
     enum R {
@@ -5392,7 +5392,7 @@ namespace TestArray {
 
     @test
     def sortBy10(): Bool = region reg {
-        Array.sortBy(r -> let R(x) = r; x.i, [R({i = 2, s = "A"}), R({i = 1, s = "B"}), R({i = 3, s = "C"})])
+        Array.sortBy(reg, r -> let R(x) = r; x.i, [R({i = 2, s = "A"}), R({i = 1, s = "B"}), R({i = 3, s = "C"})])
         `sameElements` [R({i = 1, s = "B"}), R({i = 2, s = "A"}), R({i = 3, s = "C"})]
     }
 
@@ -5400,58 +5400,57 @@ namespace TestArray {
     // sortBy!                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortBy!VsSortBy(a: Array[Int32, r]) : Bool \ { Read(r), Write(r) } = region r1 {
+    def testSortBy!VsSortBy(r1: Region[r1], a: Array[Int32, r]) : Bool \ { Read(r), Write(r1) } =
         let b = Array.slice(r1, 0, Array.length(a), a);
         let c = Array.slice(r1, 0, Array.length(a), a);
         Array.sortBy!(identity, b);
         Array.sortBy!(x -> 4 * x + 7, c);
-        (b `sameElements` Array.sortBy(x -> 4 * x + 7, a)) and
-        (c `sameElements` Array.sortBy(identity, a))
-    }
+        (b `sameElements` Array.sortBy(r1, x -> 4 * x + 7, a)) and
+        (c `sameElements` Array.sortBy(r1, identity, a))
 
     @test
     def sortBy!01(): Bool = region r {
-        testSortBy!VsSortBy([]: Array[Int32, _])
+        testSortBy!VsSortBy(r, []: Array[Int32, _])
     }
 
     @test
     def sortBy!02(): Bool = region r {
-        testSortBy!VsSortBy([0])
+        testSortBy!VsSortBy(r, [0])
     }
 
     @test
     def sortBy!03(): Bool = region r {
-        testSortBy!VsSortBy([0,1])
+        testSortBy!VsSortBy(r, [0,1])
     }
 
     @test
     def sortBy!04(): Bool = region r {
-        testSortBy!VsSortBy([1,0])
+        testSortBy!VsSortBy(r, [1,0])
     }
 
     @test
     def sortBy!05(): Bool = region r {
-        testSortBy!VsSortBy([1,1])
+        testSortBy!VsSortBy(r, [1,1])
     }
 
     @test
     def sortBy!06(): Bool = region r {
-        testSortBy!VsSortBy([0,1,2,3,4,5])
+        testSortBy!VsSortBy(r, [0,1,2,3,4,5])
     }
 
     @test
     def sortBy!07(): Bool = region r {
-        testSortBy!VsSortBy([5,4,3,2,1,0])
+        testSortBy!VsSortBy(r, [5,4,3,2,1,0])
     }
 
     @test
     def sortBy!08(): Bool = region r {
-        testSortBy!VsSortBy([5,3,0,4,1,2])
+        testSortBy!VsSortBy(r, [5,3,0,4,1,2])
     }
 
     @test
     def sortBy!09(): Bool = region r {
-        testSortBy!VsSortBy([2,3,0,4,1,2])
+        testSortBy!VsSortBy(r, [2,3,0,4,1,2])
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -5767,13 +5766,13 @@ namespace TestArray {
     def copyOfRange25(): Bool \ IO =
         let a = Array.copyOfRange(Static, 0, 3, [['a', 'b', 'c'], ['d', 'e', 'f', 'g'], ['h']]);
         let b = [['a', 'b', 'c'], ['d', 'e', 'f', 'g'], ['h']];
-        Array.flatten(a) `sameElements` Array.flatten(b)
+        Array.flatten(Static, a) `sameElements` Array.flatten(Static, b)
 
     @test
     def copyOfRange26(): Bool \ IO =
         let a = Array.copyOfRange(Static, 1, 3, [['a', 'b', 'c'], ['d', 'e', 'f', 'g'], ['h']]);
         let b = [['d', 'e', 'f', 'g'], ['h']];
-        Array.flatten(a) `sameElements` Array.flatten(b)
+        Array.flatten(Static, a) `sameElements` Array.flatten(Static, b)
 
     @test
     def copyOfRange27(): Bool \ IO =
@@ -5792,13 +5791,13 @@ namespace TestArray {
     def copyOfRange30(): Bool \ IO =
         let a = Array.copyOfRange(Static, 0, 3, [[Some('a'), Some('b'), Some('c')], [Some('d'), Some('e'), Some('f'), Some('g')], [None]]);
         let b = [[Some('a'), Some('b'), Some('c')], [Some('d'), Some('e'), Some('f'), Some('g')], [None]];
-        Array.flatten(a) `sameElements` Array.flatten(b)
+        Array.flatten(Static, a) `sameElements` Array.flatten(Static, b)
 
     @test
     def copyOfRange31(): Bool \ IO =
         let a = Array.copyOfRange(Static, 1, 3, [[Some('a'), Some('b'), Some('c')], [Some('d'), Some('e'), Some('f'), Some('g')], [None]]);
         let b = [[Some('d'), Some('e'), Some('f'), Some('g')], [None]];
-        Array.flatten(a) `sameElements` Array.flatten(b)
+        Array.flatten(Static, a) `sameElements` Array.flatten(Static, b)
 
 
     /////////////////////////////////////////////////////////////////////////////

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -5125,52 +5125,53 @@ namespace TestArray {
     // sort                                                                    //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortVsSortWith(r1: Region[r1], a: Array[Int32, r]): Bool \ { Read(r), Write(r1) } =
+    def testSortVsSortWith(a: Array[Int32, r]): Bool \ { Read(r) } = region r1 {
         Array.sort(r1, a) `sameElements` Array.sortWith(r1, cmp, a)
+    }
 
     @test
     def sort01(): Bool = region r {
-        testSortVsSortWith(r, []: Array[Int32, _])
+        testSortVsSortWith([]: Array[Int32, _])
     }
 
     @test
     def sort02(): Bool = region r {
-        testSortVsSortWith(r, [0])
+        testSortVsSortWith([0])
     }
 
     @test
     def sort03(): Bool = region r {
-        testSortVsSortWith(r, [0,1])
+        testSortVsSortWith([0,1])
     }
 
     @test
     def sort04(): Bool = region r {
-        testSortVsSortWith(r, [1,0])
+        testSortVsSortWith([1,0])
     }
 
     @test
     def sort05(): Bool = region r {
-        testSortVsSortWith(r, [1,1])
+        testSortVsSortWith([1,1])
     }
 
     @test
     def sort06(): Bool = region r {
-        testSortVsSortWith(r, [0,1,2,3,4,5])
+        testSortVsSortWith([0,1,2,3,4,5])
     }
 
     @test
     def sort07(): Bool = region r {
-        testSortVsSortWith(r, [5,4,3,2,1,0])
+        testSortVsSortWith([5,4,3,2,1,0])
     }
 
     @test
     def sort08(): Bool = region r {
-        testSortVsSortWith(r, [5,3,0,4,1,2])
+        testSortVsSortWith([5,3,0,4,1,2])
     }
 
     @test
     def sort09(): Bool = region r {
-        testSortVsSortWith(r, [2,3,0,4,1,2])
+        testSortVsSortWith([2,3,0,4,1,2])
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -5272,7 +5273,7 @@ namespace TestArray {
     // sort!                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSort!VsSortWith!(a: Array[Int32, r]): Bool \ { Read(r), Write(r) } = region r1 {
+    def testSort!VsSortWith!(a: Array[Int32, r]): Bool \ { Read(r) } = region r1 {
         let b = Array.slice(r1, 0, Array.length(a), a);
         let c = Array.slice(r1, 0, Array.length(a), a);
         Array.sort!(b);
@@ -5329,54 +5330,55 @@ namespace TestArray {
     // sortBy                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortByVsSort(r1: Region[r1], a: Array[Int32, r]): Bool \ { Read(r), Write(r1) } =
+    def testSortByVsSort(a: Array[Int32, r]): Bool \ { Read(r) } = region r1 {
         (Array.sortBy(r1, identity, a) `sameElements` Array.sort(r1, a)) and
         (Array.sortBy(r1, x -> 4 * x + 7, a) `sameElements` Array.sort(r1, a)) and
         (Array.sortBy(r1, x -> -x, a) `sameElements` Array.sortWith(r1, flip(cmp),a))
+    }
 
     @test
     def sortBy01(): Bool = region r {
-        testSortByVsSort(r, []: Array[Int32, _])
+        testSortByVsSort([]: Array[Int32, _])
     }
 
     @test
     def sortBy02(): Bool = region r {
-        testSortByVsSort(r, [0])
+        testSortByVsSort([0])
     }
 
     @test
     def sortBy03(): Bool = region r {
-        testSortByVsSort(r, [0,1])
+        testSortByVsSort([0,1])
     }
 
     @test
     def sortBy04(): Bool = region r {
-        testSortByVsSort(r, [1,0])
+        testSortByVsSort([1,0])
     }
 
     @test
     def sortBy05(): Bool = region r {
-        testSortByVsSort(r, [1,1])
+        testSortByVsSort([1,1])
     }
 
     @test
     def sortBy06(): Bool = region r {
-        testSortByVsSort(r, [0,1,2,3,4,5])
+        testSortByVsSort([0,1,2,3,4,5])
     }
 
     @test
     def sortBy07(): Bool = region r {
-        testSortByVsSort(r, [5,4,3,2,1,0])
+        testSortByVsSort([5,4,3,2,1,0])
     }
 
     @test
     def sortBy08(): Bool = region r {
-        testSortByVsSort(r, [5,3,0,4,1,2])
+        testSortByVsSort([5,3,0,4,1,2])
     }
 
     @test
     def sortBy09(): Bool = region r {
-        testSortByVsSort(r, [2,3,0,4,1,2])
+        testSortByVsSort([2,3,0,4,1,2])
     }
 
     enum R {
@@ -5400,57 +5402,58 @@ namespace TestArray {
     // sortBy!                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortBy!VsSortBy(r1: Region[r1], a: Array[Int32, r]) : Bool \ { Read(r), Write(r1) } =
+    def testSortBy!VsSortBy(a: Array[Int32, r]) : Bool \ { Read(r) } = region r1 {
         let b = Array.slice(r1, 0, Array.length(a), a);
         let c = Array.slice(r1, 0, Array.length(a), a);
         Array.sortBy!(identity, b);
         Array.sortBy!(x -> 4 * x + 7, c);
         (b `sameElements` Array.sortBy(r1, x -> 4 * x + 7, a)) and
         (c `sameElements` Array.sortBy(r1, identity, a))
+    }
 
     @test
     def sortBy!01(): Bool = region r {
-        testSortBy!VsSortBy(r, []: Array[Int32, _])
+        testSortBy!VsSortBy([]: Array[Int32, _])
     }
 
     @test
     def sortBy!02(): Bool = region r {
-        testSortBy!VsSortBy(r, [0])
+        testSortBy!VsSortBy([0])
     }
 
     @test
     def sortBy!03(): Bool = region r {
-        testSortBy!VsSortBy(r, [0,1])
+        testSortBy!VsSortBy([0,1])
     }
 
     @test
     def sortBy!04(): Bool = region r {
-        testSortBy!VsSortBy(r, [1,0])
+        testSortBy!VsSortBy([1,0])
     }
 
     @test
     def sortBy!05(): Bool = region r {
-        testSortBy!VsSortBy(r, [1,1])
+        testSortBy!VsSortBy([1,1])
     }
 
     @test
     def sortBy!06(): Bool = region r {
-        testSortBy!VsSortBy(r, [0,1,2,3,4,5])
+        testSortBy!VsSortBy([0,1,2,3,4,5])
     }
 
     @test
     def sortBy!07(): Bool = region r {
-        testSortBy!VsSortBy(r, [5,4,3,2,1,0])
+        testSortBy!VsSortBy([5,4,3,2,1,0])
     }
 
     @test
     def sortBy!08(): Bool = region r {
-        testSortBy!VsSortBy(r, [5,3,0,4,1,2])
+        testSortBy!VsSortBy([5,3,0,4,1,2])
     }
 
     @test
     def sortBy!09(): Bool = region r {
-        testSortBy!VsSortBy(r, [2,3,0,4,1,2])
+        testSortBy!VsSortBy([2,3,0,4,1,2])
     }
 
     /////////////////////////////////////////////////////////////////////////////

--- a/main/test/ca/uwaterloo/flix/library/TestMutList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutList.flix
@@ -637,25 +637,25 @@ namespace TestMutList {
 
     @test
     def map01(): Bool = region r {
-        let v = MutList.map(x -> x * 2, MutList.range(r, 0, 6));
+        let v = MutList.map(r, x -> x * 2, MutList.range(r, 0, 6));
         MutList.sameElements(v, Array.toMutList(r, [0, 2, 4, 6, 8, 10]))
     }
 
     @test
     def map02(): Bool = region r {
-        let v = MutList.map(identity, MutList.range(r, 0, 10));
+        let v = MutList.map(r, identity, MutList.range(r, 0, 10));
         MutList.sameElements(v, MutList.range(r, 0, 10))
     }
 
     @test
     def map03(): Bool = region r {
-        let v = MutList.map(identity, new MutList(r): MutList[Unit, _]);
+        let v = MutList.map(r, identity, new MutList(r): MutList[Unit, _]);
         MutList.sameElements(v, new MutList(r))
     }
 
     @test
     def map04(): Bool = region r {
-        let v = MutList.map(x -> x + 1, MutList.range(r, 0, 100));
+        let v = MutList.map(r, x -> x + 1, MutList.range(r, 0, 100));
         MutList.sameElements(v, MutList.range(r, 1, 101))
     }
 
@@ -699,19 +699,19 @@ namespace TestMutList {
 
     @test
     def mapWithIndex01(): Bool = region r {
-        let v = MutList.mapWithIndex((i, _) -> if (i < 3) 0 else 1, MutList.range(r, 0, 6));
+        let v = MutList.mapWithIndex(r, (i, _) -> if (i < 3) 0 else 1, MutList.range(r, 0, 6));
         MutList.sameElements(v, Array.toMutList(r, [0, 0, 0, 1, 1, 1]))
     }
 
     @test
     def mapWithIndex02(): Bool = region r {
-        let v = MutList.mapWithIndex((i, x) -> if (x == 8 and i == 1) 42 else 0, MutList.range(r, 7, 10));
+        let v = MutList.mapWithIndex(r, (i, x) -> if (x == 8 and i == 1) 42 else 0, MutList.range(r, 7, 10));
         MutList.sameElements(v, Array.toMutList(r, [0, 42, 0]))
     }
 
     @test
     def mapWithIndex03(): Bool = region r {
-        let v = MutList.mapWithIndex((i, _) -> if (i == 0) 42 else 0, new MutList(r));
+        let v = MutList.mapWithIndex(r, (i, _) -> if (i == 0) 42 else 0, new MutList(r));
         MutList.sameElements(v, new MutList(r))
     }
 
@@ -949,14 +949,14 @@ namespace TestMutList {
     @test
     def copy01(): Bool = region r {
         let v1 = MutList.range(r, 0, 6);
-        let v2 = MutList.copy(v1);
+        let v2 = MutList.copy(r, v1);
         v1 `sameElements` v2
     }
 
     @test
     def copy02(): Bool = region r {
         let v1 = MutList.range(r, 0, 100);
-        let v2 = MutList.copy(v1);
+        let v2 = MutList.copy(r, v1);
         MutList.transform!(x -> x + 1, v2);
         MutList.last(v1) == Some(99) and MutList.last(v2) == Some(100)
     }
@@ -964,7 +964,7 @@ namespace TestMutList {
     @test
     def copy03(): Bool = region r {
         let v1 = MutList.range(r, 0, 6);
-        let v2 = MutList.copy(v1);
+        let v2 = MutList.copy(r, v1);
         MutList.clear!(v1);
         MutList.length(v1) == 0 and MutList.length(v2) == 6
     }
@@ -973,7 +973,7 @@ namespace TestMutList {
     def copy04(): Bool = region r {
         let v1 = MutList.range(r, 0, 1000);
         let MutList(l1, n1) = v1;
-        let MutList(l2, n2) = MutList.copy(v1);
+        let MutList(l2, n2) = MutList.copy(r, v1);
         (deref n1 == deref n2) and (deref l1 `Array.sameElements` deref l2)
     }
 
@@ -981,7 +981,7 @@ namespace TestMutList {
     def copy05(): Bool = region r {
         let v1 = MutList.range(r, 0, 3);
         let MutList(l1, n1) = v1;
-        let MutList(l2, n2) = MutList.copy(v1);
+        let MutList(l2, n2) = MutList.copy(r, v1);
         (deref n1 == deref n2) and (deref l1 `Array.sameElements` deref l2) and
             (Array.length(deref l2) == 8)
     }
@@ -1924,80 +1924,80 @@ namespace TestMutList {
 
     @test
     def sortWith01(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList(r, ([] @ r): Array[Int32, r]));
+        let a = MutList.sortWith(r, cmp, Array.toMutList(r, ([] @ r): Array[Int32, r]));
         a `sameElements` Array.toMutList(r, [] @ r)
     }
 
     @test
     def sortWith02(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList(r, [0]));
+        let a = MutList.sortWith(r, cmp, Array.toMutList(r, [0]));
         a `sameElements` Array.toMutList(r, [0])
     }
 
     @test
     def sortWith03(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList(r, [0,1]));
+        let a = MutList.sortWith(r, cmp, Array.toMutList(r, [0,1]));
         a `sameElements` Array.toMutList(r, [0,1])
     }
 
     @test
     def sortWith04(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList(r, [1,0]));
+        let a = MutList.sortWith(r, cmp, Array.toMutList(r, [1,0]));
         a `sameElements` Array.toMutList(r, [0,1])
     }
 
     @test
     def sortWith05(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList(r, [1,1]));
+        let a = MutList.sortWith(r, cmp, Array.toMutList(r, [1,1]));
         a `sameElements` Array.toMutList(r, [1,1])
     }
 
     @test
     def sortWith06(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList(r, [0,1,2,3,4,5]));
+        let a = MutList.sortWith(r, cmp, Array.toMutList(r, [0,1,2,3,4,5]));
         a `sameElements` Array.toMutList(r, [0,1,2,3,4,5])
     }
 
     @test
     def sortWith07(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList(r, [5,4,3,2,1,0]));
+        let a = MutList.sortWith(r, cmp, Array.toMutList(r, [5,4,3,2,1,0]));
         a `sameElements` Array.toMutList(r, [0,1,2,3,4,5])
     }
 
     @test
     def sortWith08(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList(r, [5,3,0,4,1,2]));
+        let a = MutList.sortWith(r, cmp, Array.toMutList(r, [5,3,0,4,1,2]));
         a `sameElements` Array.toMutList(r, [0,1,2,3,4,5])
     }
 
     @test
     def sortWith09(): Bool = region r {
-        let a = MutList.sortWith(cmp, Array.toMutList(r, [2,3,0,4,1,2]));
+        let a = MutList.sortWith(r, cmp, Array.toMutList(r, [2,3,0,4,1,2]));
         a `sameElements` Array.toMutList(r, [0,1,2,2,3,4])
     }
 
     @test
     def sortWith10(): Bool = region r {
-        let a = MutList.sortWith(flip(cmp), Array.toMutList(r, [0,1,2,3,4,5]));
+        let a = MutList.sortWith(r, flip(cmp), Array.toMutList(r, [0,1,2,3,4,5]));
         a `sameElements` Array.toMutList(r, [5,4,3,2,1,0])
     }
 
     @test
     def sortWith11(): Bool = region r {
-        let a = MutList.sortWith(flip(cmp), Array.toMutList(r, [5,4,3,2,1,0]));
+        let a = MutList.sortWith(r, flip(cmp), Array.toMutList(r, [5,4,3,2,1,0]));
         a `sameElements` Array.toMutList(r, [5,4,3,2,1,0])
     }
 
     @test
     def sortWith12(): Bool = region r {
-        let a = MutList.sortWith(flip(cmp), Array.toMutList(r, [5,3,0,4,1,2]));
+        let a = MutList.sortWith(r, flip(cmp), Array.toMutList(r, [5,3,0,4,1,2]));
         a `sameElements` Array.toMutList(r, [5,4,3,2,1,0])
     }
 
 
     @test
     def sortWith13(): Bool = region r {
-        let a = MutList.sortWith(flip(cmp), Array.toMutList(r, [2,3,0,4,1,2]));
+        let a = MutList.sortWith(r, flip(cmp), Array.toMutList(r, [2,3,0,4,1,2]));
         a `sameElements` Array.toMutList(r, [4,3,2,2,1,0])
     }
 
@@ -2005,52 +2005,53 @@ namespace TestMutList {
     // sort                                                                    //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortVsSortWith(a: MutList[Int32, r]): Bool \ { Read(r), Write(r) } =
-        MutList.sort(a) `sameElements` MutList.sortWith(cmp, a)
+    def testSortVsSortWith(r: Region[r], a: MutList[Int32, r]): Bool \ { Read(r), Write(r) } =
+        MutList.sort(r, a) `sameElements` MutList.sortWith(r, cmp, a)
+
 
     @test
     def sort01(): Bool = region r {
-        testSortVsSortWith(Array.toMutList(r, []: Array[Int32, r]))
+        testSortVsSortWith(r, Array.toMutList(r, []: Array[Int32, r]))
     }
 
     @test
     def sort02(): Bool = region r {
-        testSortVsSortWith(Array.toMutList(r, [0]))
+        testSortVsSortWith(r, Array.toMutList(r, [0]))
     }
 
     @test
     def sort03(): Bool = region r {
-        testSortVsSortWith(Array.toMutList(r, [0,1]))
+        testSortVsSortWith(r, Array.toMutList(r, [0,1]))
     }
 
     @test
     def sort04(): Bool = region r {
-        testSortVsSortWith(Array.toMutList(r, [1,0]))
+        testSortVsSortWith(r, Array.toMutList(r, [1,0]))
     }
 
     @test
     def sort05(): Bool = region r {
-        testSortVsSortWith(Array.toMutList(r, [1,1]))
+        testSortVsSortWith(r, Array.toMutList(r, [1,1]))
     }
 
     @test
     def sort06(): Bool = region r {
-        testSortVsSortWith(Array.toMutList(r, [0,1,2,3,4,5]))
+        testSortVsSortWith(r, Array.toMutList(r, [0,1,2,3,4,5]))
     }
 
     @test
     def sort07(): Bool = region r {
-        testSortVsSortWith(Array.toMutList(r, [5,4,3,2,1,0]))
+        testSortVsSortWith(r, Array.toMutList(r, [5,4,3,2,1,0]))
     }
 
     @test
     def sort08(): Bool = region r {
-        testSortVsSortWith(Array.toMutList(r, [5,3,0,4,1,2]))
+        testSortVsSortWith(r, Array.toMutList(r, [5,3,0,4,1,2]))
     }
 
     @test
     def sort09(): Bool = region r {
-        testSortVsSortWith(Array.toMutList(r, [2,3,0,4,1,2]))
+        testSortVsSortWith(r, Array.toMutList(r, [2,3,0,4,1,2]))
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -2151,56 +2152,56 @@ namespace TestMutList {
     // sort!                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSort!VsSortWith!(a: MutList[Int32, r]): Bool \ { Read(r), Write(r) } =
-        let b = MutList.copy(a);
-        let c = MutList.copy(a);
+    def testSort!VsSortWith!(r1: Region[r1], a: MutList[Int32, r]): Bool \ { Read(r), Write(r1) } =
+        let b = MutList.copy(r1, a);
+        let c = MutList.copy(r1, a);
         MutList.sort!(b);
         MutList.sortWith!(cmp, c);
         b `sameElements` c
 
     @test
     def sort!01(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList(r, []: Array[Int32, r]))
+        testSort!VsSortWith!(r, Array.toMutList(r, []: Array[Int32, r]))
     }
 
     @test
     def sort!02(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList(r, [0]))
+        testSort!VsSortWith!(r, Array.toMutList(r, [0]))
     }
 
     @test
     def sort!03(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList(r, [0,1]))
+        testSort!VsSortWith!(r, Array.toMutList(r, [0,1]))
     }
 
     @test
     def sort!04(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList(r, [1,0]))
+        testSort!VsSortWith!(r, Array.toMutList(r, [1,0]))
     }
 
     @test
     def sort!05(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList(r, [1,1]))
+        testSort!VsSortWith!(r, Array.toMutList(r, [1,1]))
     }
 
     @test
     def sort!06(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList(r, [0,1,2,3,4,5]))
+        testSort!VsSortWith!(r, Array.toMutList(r, [0,1,2,3,4,5]))
     }
 
     @test
     def sort!07(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList(r, [5,4,3,2,1,0]))
+        testSort!VsSortWith!(r, Array.toMutList(r, [5,4,3,2,1,0]))
     }
 
     @test
     def sort!08(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList(r, [5,3,0,4,1,2]))
+        testSort!VsSortWith!(r, Array.toMutList(r, [5,3,0,4,1,2]))
     }
 
     @test
     def sort!09(): Bool = region r {
-        testSort!VsSortWith!(Array.toMutList(r, [2,3,0,4,1,2]))
+        testSort!VsSortWith!(r, Array.toMutList(r, [2,3,0,4,1,2]))
     }
 
 
@@ -2208,54 +2209,54 @@ namespace TestMutList {
     // sortBy                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortByVsSort(a: MutList[Int32, r]): Bool \ { Read(r), Write(r) } =
-        (MutList.sortBy(identity, a) `sameElements` MutList.sort(a)) and
-        (MutList.sortBy(x -> 4 * x + 7, a) `sameElements` MutList.sort(a)) and
-        (MutList.sortBy(x -> -x, a) `sameElements` MutList.sortWith(flip(cmp),a))
+    def testSortByVsSort(r1: Region[r1], a: MutList[Int32, r]): Bool \ { Read(r), Write(r1) } =
+        (MutList.sortBy(r1, identity, a) `sameElements` MutList.sort(r1, a)) and
+        (MutList.sortBy(r1, x -> 4 * x + 7, a) `sameElements` MutList.sort(r1, a)) and
+        (MutList.sortBy(r1, x -> -x, a) `sameElements` MutList.sortWith(r1, flip(cmp),a))
 
     @test
     def sortBy01(): Bool = region r {
-        testSortByVsSort(Array.toMutList(r, []: Array[Int32, r]))
+        testSortByVsSort(r, Array.toMutList(r, []: Array[Int32, r]))
     }
 
     @test
     def sortBy02(): Bool = region r {
-        testSortByVsSort(Array.toMutList(r, [0]))
+        testSortByVsSort(r, Array.toMutList(r, [0]))
     }
 
     @test
     def sortBy03(): Bool = region r {
-        testSortByVsSort(Array.toMutList(r, [0,1]))
+        testSortByVsSort(r, Array.toMutList(r, [0,1]))
     }
 
     @test
     def sortBy04(): Bool = region r {
-        testSortByVsSort(Array.toMutList(r, [1,0]))
+        testSortByVsSort(r, Array.toMutList(r, [1,0]))
     }
 
     @test
     def sortBy05(): Bool = region r {
-        testSortByVsSort(Array.toMutList(r, [1,1]))
+        testSortByVsSort(r, Array.toMutList(r, [1,1]))
     }
 
     @test
     def sortBy06(): Bool = region r {
-        testSortByVsSort(Array.toMutList(r, [0,1,2,3,4,5]))
+        testSortByVsSort(r, Array.toMutList(r, [0,1,2,3,4,5]))
     }
 
     @test
     def sortBy07(): Bool = region r {
-        testSortByVsSort(Array.toMutList(r, [5,4,3,2,1,0]))
+        testSortByVsSort(r, Array.toMutList(r, [5,4,3,2,1,0]))
     }
 
     @test
     def sortBy08(): Bool = region r {
-        testSortByVsSort(Array.toMutList(r, [5,3,0,4,1,2]))
+        testSortByVsSort(r, Array.toMutList(r, [5,3,0,4,1,2]))
     }
 
     @test
     def sortBy09(): Bool = region r {
-        testSortByVsSort(Array.toMutList(r, [2,3,0,4,1,2]))
+        testSortByVsSort(r, Array.toMutList(r, [2,3,0,4,1,2]))
     }
 
     enum R {
@@ -2271,7 +2272,7 @@ namespace TestMutList {
 
     @test
     def sortBy10(): Bool = region r {
-        MutList.sortBy(rr -> let R(x) = rr; x.i, Array.toMutList(r, [R({i = 2, s = "A"}), R({i = 1, s = "B"}), R({i = 3, s = "C"})] @ r))
+        MutList.sortBy(r, rr -> let R(x) = rr; x.i, Array.toMutList(r, [R({i = 2, s = "A"}), R({i = 1, s = "B"}), R({i = 3, s = "C"})] @ r))
         `sameElements` Array.toMutList(r, [R({i = 1, s = "B"}), R({i = 2, s = "A"}), R({i = 3, s = "C"})] @ r)
     }
 
@@ -2280,57 +2281,57 @@ namespace TestMutList {
     // sortBy!                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortBy!VsSortBy(a: MutList[Int32, r]): Bool \ { Read(r), Write(r) } =
-        let b = MutList.copy(a);
-        let c = MutList.copy(a);
+    def testSortBy!VsSortBy(r1: Region[r1], a: MutList[Int32, r]): Bool \ { Read(r), Write(r1) } =
+        let b = MutList.copy(r1, a);
+        let c = MutList.copy(r1, a);
         MutList.sortBy!(identity, b);
         MutList.sortBy!(x -> 4 * x + 7, c);
-        (b `sameElements` MutList.sortBy(x -> 4 * x + 7, a)) and
-        (c `sameElements` MutList.sortBy(identity, a))
+        (b `sameElements` MutList.sortBy(r1, x -> 4 * x + 7, a)) and
+        (c `sameElements` MutList.sortBy(r1, identity, a))
 
     @test
     def sortBy!01(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList(r, []: Array[Int32, r]))
+        testSortBy!VsSortBy(r, Array.toMutList(r, []: Array[Int32, r]))
     }
 
     @test
     def sortBy!02(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList(r, [0]))
+        testSortBy!VsSortBy(r, Array.toMutList(r, [0]))
     }
 
     @test
     def sortBy!03(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList(r, [0,1]))
+        testSortBy!VsSortBy(r, Array.toMutList(r, [0,1]))
     }
 
     @test
     def sortBy!04(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList(r, [1,0]))
+        testSortBy!VsSortBy(r, Array.toMutList(r, [1,0]))
     }
 
     @test
     def sortBy!05(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList(r, [1,1]))
+        testSortBy!VsSortBy(r, Array.toMutList(r, [1,1]))
     }
 
     @test
     def sortBy!06(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList(r, [0,1,2,3,4,5]))
+        testSortBy!VsSortBy(r, Array.toMutList(r, [0,1,2,3,4,5]))
     }
 
     @test
     def sortBy!07(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList(r, [5,4,3,2,1,0]))
+        testSortBy!VsSortBy(r, Array.toMutList(r, [5,4,3,2,1,0]))
     }
 
     @test
     def sortBy!08(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList(r, [5,3,0,4,1,2]))
+        testSortBy!VsSortBy(r, Array.toMutList(r, [5,3,0,4,1,2]))
     }
 
     @test
     def sortBy!09(): Bool = region r {
-        testSortBy!VsSortBy(Array.toMutList(r, [2,3,0,4,1,2]))
+        testSortBy!VsSortBy(r, Array.toMutList(r, [2,3,0,4,1,2]))
     }
 
 

--- a/main/test/ca/uwaterloo/flix/library/TestMutList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutList.flix
@@ -2005,53 +2005,53 @@ namespace TestMutList {
     // sort                                                                    //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortVsSortWith(r: Region[r], a: MutList[Int32, r]): Bool \ { Read(r), Write(r) } =
-        MutList.sort(r, a) `sameElements` MutList.sortWith(r, cmp, a)
-
+    def testSortVsSortWith(a: MutList[Int32, r]): Bool \ { Read(r) } = region r1 {
+        MutList.sort(r1, a) `sameElements` MutList.sortWith(r1, cmp, a)
+    }
 
     @test
     def sort01(): Bool = region r {
-        testSortVsSortWith(r, Array.toMutList(r, []: Array[Int32, r]))
+        testSortVsSortWith(Array.toMutList(r, []: Array[Int32, r]))
     }
 
     @test
     def sort02(): Bool = region r {
-        testSortVsSortWith(r, Array.toMutList(r, [0]))
+        testSortVsSortWith(Array.toMutList(r, [0]))
     }
 
     @test
     def sort03(): Bool = region r {
-        testSortVsSortWith(r, Array.toMutList(r, [0,1]))
+        testSortVsSortWith(Array.toMutList(r, [0,1]))
     }
 
     @test
     def sort04(): Bool = region r {
-        testSortVsSortWith(r, Array.toMutList(r, [1,0]))
+        testSortVsSortWith(Array.toMutList(r, [1,0]))
     }
 
     @test
     def sort05(): Bool = region r {
-        testSortVsSortWith(r, Array.toMutList(r, [1,1]))
+        testSortVsSortWith(Array.toMutList(r, [1,1]))
     }
 
     @test
     def sort06(): Bool = region r {
-        testSortVsSortWith(r, Array.toMutList(r, [0,1,2,3,4,5]))
+        testSortVsSortWith(Array.toMutList(r, [0,1,2,3,4,5]))
     }
 
     @test
     def sort07(): Bool = region r {
-        testSortVsSortWith(r, Array.toMutList(r, [5,4,3,2,1,0]))
+        testSortVsSortWith(Array.toMutList(r, [5,4,3,2,1,0]))
     }
 
     @test
     def sort08(): Bool = region r {
-        testSortVsSortWith(r, Array.toMutList(r, [5,3,0,4,1,2]))
+        testSortVsSortWith(Array.toMutList(r, [5,3,0,4,1,2]))
     }
 
     @test
     def sort09(): Bool = region r {
-        testSortVsSortWith(r, Array.toMutList(r, [2,3,0,4,1,2]))
+        testSortVsSortWith(Array.toMutList(r, [2,3,0,4,1,2]))
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -2152,56 +2152,57 @@ namespace TestMutList {
     // sort!                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSort!VsSortWith!(r1: Region[r1], a: MutList[Int32, r]): Bool \ { Read(r), Write(r1) } =
+    def testSort!VsSortWith!(a: MutList[Int32, r]): Bool \ { Read(r) } = region r1 {
         let b = MutList.copy(r1, a);
         let c = MutList.copy(r1, a);
         MutList.sort!(b);
         MutList.sortWith!(cmp, c);
         b `sameElements` c
+    }
 
     @test
     def sort!01(): Bool = region r {
-        testSort!VsSortWith!(r, Array.toMutList(r, []: Array[Int32, r]))
+        testSort!VsSortWith!(Array.toMutList(r, []: Array[Int32, r]))
     }
 
     @test
     def sort!02(): Bool = region r {
-        testSort!VsSortWith!(r, Array.toMutList(r, [0]))
+        testSort!VsSortWith!(Array.toMutList(r, [0]))
     }
 
     @test
     def sort!03(): Bool = region r {
-        testSort!VsSortWith!(r, Array.toMutList(r, [0,1]))
+        testSort!VsSortWith!(Array.toMutList(r, [0,1]))
     }
 
     @test
     def sort!04(): Bool = region r {
-        testSort!VsSortWith!(r, Array.toMutList(r, [1,0]))
+        testSort!VsSortWith!(Array.toMutList(r, [1,0]))
     }
 
     @test
     def sort!05(): Bool = region r {
-        testSort!VsSortWith!(r, Array.toMutList(r, [1,1]))
+        testSort!VsSortWith!(Array.toMutList(r, [1,1]))
     }
 
     @test
     def sort!06(): Bool = region r {
-        testSort!VsSortWith!(r, Array.toMutList(r, [0,1,2,3,4,5]))
+        testSort!VsSortWith!(Array.toMutList(r, [0,1,2,3,4,5]))
     }
 
     @test
     def sort!07(): Bool = region r {
-        testSort!VsSortWith!(r, Array.toMutList(r, [5,4,3,2,1,0]))
+        testSort!VsSortWith!(Array.toMutList(r, [5,4,3,2,1,0]))
     }
 
     @test
     def sort!08(): Bool = region r {
-        testSort!VsSortWith!(r, Array.toMutList(r, [5,3,0,4,1,2]))
+        testSort!VsSortWith!(Array.toMutList(r, [5,3,0,4,1,2]))
     }
 
     @test
     def sort!09(): Bool = region r {
-        testSort!VsSortWith!(r, Array.toMutList(r, [2,3,0,4,1,2]))
+        testSort!VsSortWith!(Array.toMutList(r, [2,3,0,4,1,2]))
     }
 
 
@@ -2209,54 +2210,55 @@ namespace TestMutList {
     // sortBy                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortByVsSort(r1: Region[r1], a: MutList[Int32, r]): Bool \ { Read(r), Write(r1) } =
+    def testSortByVsSort(a: MutList[Int32, r]): Bool \ { Read(r) } = region r1 {
         (MutList.sortBy(r1, identity, a) `sameElements` MutList.sort(r1, a)) and
         (MutList.sortBy(r1, x -> 4 * x + 7, a) `sameElements` MutList.sort(r1, a)) and
         (MutList.sortBy(r1, x -> -x, a) `sameElements` MutList.sortWith(r1, flip(cmp),a))
+    }
 
     @test
     def sortBy01(): Bool = region r {
-        testSortByVsSort(r, Array.toMutList(r, []: Array[Int32, r]))
+        testSortByVsSort(Array.toMutList(r, []: Array[Int32, r]))
     }
 
     @test
     def sortBy02(): Bool = region r {
-        testSortByVsSort(r, Array.toMutList(r, [0]))
+        testSortByVsSort(Array.toMutList(r, [0]))
     }
 
     @test
     def sortBy03(): Bool = region r {
-        testSortByVsSort(r, Array.toMutList(r, [0,1]))
+        testSortByVsSort(Array.toMutList(r, [0,1]))
     }
 
     @test
     def sortBy04(): Bool = region r {
-        testSortByVsSort(r, Array.toMutList(r, [1,0]))
+        testSortByVsSort(Array.toMutList(r, [1,0]))
     }
 
     @test
     def sortBy05(): Bool = region r {
-        testSortByVsSort(r, Array.toMutList(r, [1,1]))
+        testSortByVsSort(Array.toMutList(r, [1,1]))
     }
 
     @test
     def sortBy06(): Bool = region r {
-        testSortByVsSort(r, Array.toMutList(r, [0,1,2,3,4,5]))
+        testSortByVsSort(Array.toMutList(r, [0,1,2,3,4,5]))
     }
 
     @test
     def sortBy07(): Bool = region r {
-        testSortByVsSort(r, Array.toMutList(r, [5,4,3,2,1,0]))
+        testSortByVsSort(Array.toMutList(r, [5,4,3,2,1,0]))
     }
 
     @test
     def sortBy08(): Bool = region r {
-        testSortByVsSort(r, Array.toMutList(r, [5,3,0,4,1,2]))
+        testSortByVsSort(Array.toMutList(r, [5,3,0,4,1,2]))
     }
 
     @test
     def sortBy09(): Bool = region r {
-        testSortByVsSort(r, Array.toMutList(r, [2,3,0,4,1,2]))
+        testSortByVsSort(Array.toMutList(r, [2,3,0,4,1,2]))
     }
 
     enum R {
@@ -2281,57 +2283,58 @@ namespace TestMutList {
     // sortBy!                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 
-    def testSortBy!VsSortBy(r1: Region[r1], a: MutList[Int32, r]): Bool \ { Read(r), Write(r1) } =
+    def testSortBy!VsSortBy(a: MutList[Int32, r]): Bool \ { Read(r) } = region r1 {
         let b = MutList.copy(r1, a);
         let c = MutList.copy(r1, a);
         MutList.sortBy!(identity, b);
         MutList.sortBy!(x -> 4 * x + 7, c);
         (b `sameElements` MutList.sortBy(r1, x -> 4 * x + 7, a)) and
         (c `sameElements` MutList.sortBy(r1, identity, a))
+    }
 
     @test
     def sortBy!01(): Bool = region r {
-        testSortBy!VsSortBy(r, Array.toMutList(r, []: Array[Int32, r]))
+        testSortBy!VsSortBy(Array.toMutList(r, []: Array[Int32, r]))
     }
 
     @test
     def sortBy!02(): Bool = region r {
-        testSortBy!VsSortBy(r, Array.toMutList(r, [0]))
+        testSortBy!VsSortBy(Array.toMutList(r, [0]))
     }
 
     @test
     def sortBy!03(): Bool = region r {
-        testSortBy!VsSortBy(r, Array.toMutList(r, [0,1]))
+        testSortBy!VsSortBy(Array.toMutList(r, [0,1]))
     }
 
     @test
     def sortBy!04(): Bool = region r {
-        testSortBy!VsSortBy(r, Array.toMutList(r, [1,0]))
+        testSortBy!VsSortBy(Array.toMutList(r, [1,0]))
     }
 
     @test
     def sortBy!05(): Bool = region r {
-        testSortBy!VsSortBy(r, Array.toMutList(r, [1,1]))
+        testSortBy!VsSortBy(Array.toMutList(r, [1,1]))
     }
 
     @test
     def sortBy!06(): Bool = region r {
-        testSortBy!VsSortBy(r, Array.toMutList(r, [0,1,2,3,4,5]))
+        testSortBy!VsSortBy(Array.toMutList(r, [0,1,2,3,4,5]))
     }
 
     @test
     def sortBy!07(): Bool = region r {
-        testSortBy!VsSortBy(r, Array.toMutList(r, [5,4,3,2,1,0]))
+        testSortBy!VsSortBy(Array.toMutList(r, [5,4,3,2,1,0]))
     }
 
     @test
     def sortBy!08(): Bool = region r {
-        testSortBy!VsSortBy(r, Array.toMutList(r, [5,3,0,4,1,2]))
+        testSortBy!VsSortBy(Array.toMutList(r, [5,3,0,4,1,2]))
     }
 
     @test
     def sortBy!09(): Bool = region r {
-        testSortBy!VsSortBy(r, Array.toMutList(r, [2,3,0,4,1,2]))
+        testSortBy!VsSortBy(Array.toMutList(r, [2,3,0,4,1,2]))
     }
 
 

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -120,7 +120,7 @@ namespace Test/Exp/Jvm/NewObject {
     import static dev.flix.test.TestBoolArrayInterface.runTest(TestBoolArrayInterface): Bool;
     let anon = new TestBoolArrayInterface {
       def testMethod(_this: TestBoolArrayInterface, xs: Array[Bool, Static]): Array[Bool, Static] =
-        xs |> Array.map(x -> not x)
+        xs |> Array.map(Static, x -> not x)
     };
     runTest(anon)
 
@@ -129,7 +129,7 @@ namespace Test/Exp/Jvm/NewObject {
     import static dev.flix.test.TestCharArrayInterface.runTest(TestCharArrayInterface): Bool;
     let anon = new TestCharArrayInterface {
       def testMethod(_this: TestCharArrayInterface, xs: Array[Char, Static]): Array[Char, Static] =
-        xs |> Array.map(Char.toUpperCase)
+        xs |> Array.map(Static, Char.toUpperCase)
     };
     runTest(anon)
 
@@ -138,7 +138,7 @@ namespace Test/Exp/Jvm/NewObject {
     import static dev.flix.test.TestInt8ArrayInterface.runTest(TestInt8ArrayInterface): Bool;
     let anon = new TestInt8ArrayInterface {
       def testMethod(_this: TestInt8ArrayInterface, xs: Array[Int8, Static]): Array[Int8, Static] =
-        xs |> Array.map(x -> x + 1i8)
+        xs |> Array.map(Static, x -> x + 1i8)
     };
     runTest(anon)
 
@@ -147,7 +147,7 @@ namespace Test/Exp/Jvm/NewObject {
     import static dev.flix.test.TestInt16ArrayInterface.runTest(TestInt16ArrayInterface): Bool;
     let anon = new TestInt16ArrayInterface {
       def testMethod(_this: TestInt16ArrayInterface, xs: Array[Int16, Static]): Array[Int16, Static] =
-        xs |> Array.map(x -> x + 1i16)
+        xs |> Array.map(Static, x -> x + 1i16)
     };
     runTest(anon)
 
@@ -156,7 +156,7 @@ namespace Test/Exp/Jvm/NewObject {
     import static dev.flix.test.TestInt32ArrayInterface.runTest(TestInt32ArrayInterface): Bool;
     let anon = new TestInt32ArrayInterface {
       def testMethod(_this: TestInt32ArrayInterface, xs: Array[Int32, Static]): Array[Int32, Static] =
-        xs |> Array.map(x -> x + 1)
+        xs |> Array.map(Static, x -> x + 1)
     };
     runTest(anon)
 
@@ -165,7 +165,7 @@ namespace Test/Exp/Jvm/NewObject {
     import static dev.flix.test.TestInt64ArrayInterface.runTest(TestInt64ArrayInterface): Bool;
     let anon = new TestInt64ArrayInterface {
       def testMethod(_this: TestInt64ArrayInterface, xs: Array[Int64, Static]): Array[Int64, Static] =
-        xs |> Array.map(x -> x + 1i64)
+        xs |> Array.map(Static, x -> x + 1i64)
     };
     runTest(anon)
 
@@ -174,7 +174,7 @@ namespace Test/Exp/Jvm/NewObject {
     import static dev.flix.test.TestFloat32ArrayInterface.runTest(TestFloat32ArrayInterface): Bool;
     let anon = new TestFloat32ArrayInterface {
       def testMethod(_this: TestFloat32ArrayInterface, xs: Array[Float32, Static]): Array[Float32, Static] =
-        xs |> Array.map(x -> x + 0.5f32)
+        xs |> Array.map(Static, x -> x + 0.5f32)
     };
     runTest(anon)
 
@@ -183,7 +183,7 @@ namespace Test/Exp/Jvm/NewObject {
     import static dev.flix.test.TestFloat64ArrayInterface.runTest(TestFloat64ArrayInterface): Bool;
     let anon = new TestFloat64ArrayInterface {
       def testMethod(_this: TestFloat64ArrayInterface, xs: Array[Float64, Static]): Array[Float64, Static] =
-        xs |> Array.map(x -> x + 0.5f64)
+        xs |> Array.map(Static, x -> x + 0.5f64)
     };
     runTest(anon)
 

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -315,7 +315,7 @@ namespace Test/Exp/Jvm/NewObject {
     let x = [1, 2, 3];
     let y = [4, 5, 6];
     let anon = new ##java.lang.Object {
-      def toString(_this: ##java.lang.Object): String = Array.toString(Array.append(x, y))
+      def toString(_this: ##java.lang.Object): String = Array.toString(Array.append(Static, x, y))
     };
     toString(anon) == "[1, 2, 3, 4, 5, 6]"
 


### PR DESCRIPTION
This PR adds an "output" region parameter to the signatures of functions on mutables (Array, MutDeque, MutList, MutMap, MutSet) that return new mutables.

Exception - `iterator` and `enumerator` functions and the `Iterable` class left untouched. Firstly, I was having to do extra copying / casting or both to fit using a new region inside the interator. Secondly and a worse problem, changing the signature of the `Iterable` class was having some strange name resolution problems that I couldn't resolve e.g. the (non-mutable) `Set.toString` stopped compiling where it uses `enumerator` in the comprehension.

The naming scheme of the new region params in the function signatures probably needs some discussion. I've wanted to avoid calling the region var `r` as `r` is usually used as a type variable in the existing Array (or MutList...) type and this looks like it would be confusing. I've given the new regions indices so they are usually `r1` but sometimes the existing mutables already use indexed type vars, e.g:

~~~

pub def transpose(r3: Region[r3], a: Array[Array[a, r1], r2]): Array[Array[a, r3], r3] \ { Read(r1, r2), Write(r3) } = ...

~~~

Maybe using `rn` as a mnemonic for "r(egion) n(ew)" would be reasonable choice for the variable name, type var names could continue to use an increasing index:

~~~

pub def transpose(rn: Region[r3], a: Array[Array[a, r1], r2]): Array[Array[a, r3], r3] \ { Read(r1, r2), Write(r3) } = ...

~~~
