### PR TITLE
chore: Remove (almost) all regionOfs from Array.flix

### DIFF
--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -308,8 +308,8 @@ namespace Array {
     ///
     /// Return the positions of the all the occurrences of `a` in `arr`.
     ///
-    pub def indices(a: a, arr: Array[a, r]): Array[Int32, r] \ { Read(r), Write(r) } with Eq[a] =
-        findIndices(b -> a == b, arr)
+    pub def indices(r: Region[r], a: a, arr: Array[a, r]): Array[Int32, r] \ { Read(r), Write(r) } with Eq[a] =
+        findIndices(r, b -> a == b, arr)
 
     ///
     /// Alias for `findLeft`.
@@ -362,17 +362,16 @@ namespace Array {
     ///
     /// Alias for `scanLeft`.
     ///
-    pub def scan(f: (b, a) -> b \ ef, s: b, arr: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
-        scanLeft(f, s, arr)
+    pub def scan(r: Region[r], f: (b, a) -> b \ ef, s: b, arr: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
+        scanLeft(r, f, s, arr)
 
     ///
     /// Accumulates the result of applying `f` to `arr` going left to right.
     ///
     /// That is, the result is of the form: `[s , f(s, x1), f(f(s, x1), x2),  ...]`.
     ///
-    pub def scanLeft(f: (b, a) -> b \ ef, s: b, arr: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
+    pub def scanLeft(r: Region[r], f: (b, a) -> b \ ef, s: b, arr: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let len = length(arr) + 1;
-        let r = Scoped.regionOf(arr);
         let b = new(r, s, len);
         def loop(i, acc) = {
             if (i >= len)
@@ -391,9 +390,8 @@ namespace Array {
     ///
     /// That is, the result is of the form: `[..., f(xn-1, f(xn, s)), f(xn, s), s]`.
     ///
-    pub def scanRight(f: (a, b) -> b \ ef, s: b, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
+    pub def scanRight(r: Region[r], f: (a, b) -> b \ ef, s: b, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
         let b = new(r, s, len + 1);
         def loop(i, acc) = {
             if (i < 0)
@@ -492,15 +490,15 @@ namespace Array {
     ///
     /// Rotate the contents of array `arr` by `n` steps to the left.
     ///
-    pub def rotateLeft(n: Int32, arr: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
+    pub def rotateLeft(r2: Region[r2], n: Int32, arr: Array[a, r1]): Array[a, r2] \ { Read(r1), Write(r2) } =
         let len = length(arr);
         if (len < 1)
-            [] @ Scoped.regionOf(arr)
+            [] @ r2
         else
             if (n < 0)
-                rotateRightHelper(Int32.abs(n), arr)
+                rotateRightHelper(r2, Int32.abs(n), arr)
             else
-                rotateLeftHelper(n, arr)
+                rotateLeftHelper(r2, n, arr)
 
     ///
     /// Helper function for `rotateLeft` and `rotateRight`.
@@ -509,23 +507,22 @@ namespace Array {
     ///
     /// This is an explicit helper to avoid code duplication.
     ///
-    def rotateLeftHelper(n: Int32, arr: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
+    def rotateLeftHelper(r2: Region[r2], n: Int32, arr: Array[a, r1]): Array[a, r2] \ { Read(r1), Write(r2) } =
         let len = length(arr);
-        let r = Scoped.regionOf(arr);
         let f = i -> { let i1 = n + i; arr[i1 rem len] };
-        init(r, f, len)
+        init(r2, f, len)
 
     ///
     /// Rotate the contents of array `arr` by `n` steps to the right.
     ///
-    pub def rotateRight(n: Int32, arr: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
+    pub def rotateRight(r2: Region[r2], n: Int32, arr: Array[a, r1]): Array[a, r2] \ { Read(r1), Write(r2) } =
         if (length(arr) < 1)
-            [] @ Scoped.regionOf(arr)
+            [] @ r2
         else
             if (n < 0)
-                rotateLeftHelper(Int32.abs(n), arr)
+                rotateLeftHelper(r2, Int32.abs(n), arr)
             else
-                rotateRightHelper(n, arr)
+                rotateRightHelper(r2, n, arr)
 
     ///
     /// Helper function for `rotateRight` and `rotateLeft`.
@@ -534,13 +531,12 @@ namespace Array {
     ///
     /// This is an explicit helper to avoid code duplication.
     ///
-    def rotateRightHelper(n: Int32, a: Array[a, r]): Array[a, r] \ { Read(r), Write(r) } =
+    def rotateRightHelper(r2: Region[r2], n: Int32, a: Array[a, r1]): Array[a, r2] \ { Read(r1), Write(r2) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
         let n1 = n rem len;
         let start = len - n1;
         let f = i -> { let i1 = start + i; a[i1 rem len]};
-        init(r, f, len)
+        init(r2, f, len)
 
     ///
     /// Returns a copy of `a` with the element at index `i` replaced by `x`.
@@ -584,12 +580,12 @@ namespace Array {
     /// If `a` becomes depleted then no further patching is done.
     /// If patching occurs at index `i+j` in `b`, then the element at index `j` in `a` is used.
     ///
-    pub def patch!(i: Int32, n: Int32, a: Array[a, r1], b: Array[a, r2]): Unit \ { Read(r1), Write(r2) } =
+    pub def patch!(i: Int32, n: Int32, a: Array[a, r1], b: Array[a, r2]): Unit \ { Read(r1), Write(r2) } = region r3 {
         let len1 = length(a);
-        let r2 = Scoped.regionOf(b);
         let size = if (n > len1) len1 else n;
-        let sub = copyOfRange(r2, 0, size, a);
+        let sub = copyOfRange(r3, 0, size, a);
         updateSequence!(i, sub, b)
+    }
 
     ///
     /// Returns `a` with `x` inserted between every two adjacent elements.
@@ -1128,10 +1124,9 @@ namespace Array {
     ///
     /// The function `f` must be pure.
     ///
-    pub def groupBy(r1: Region[r1], f: (a, a) -> Bool, a: Array[a, r2]): Array[Array[a, r1], r2] \ { Read(r2), Write(r2, r1) } =
+    pub def groupBy(r1: Region[r1], f: (a, a) -> Bool, a: Array[a, r2]): Array[Array[a, r1], r1] \ { Read(r2), Write(r1) } =
         let xs = toList(a);
-        let r2 = Scoped.regionOf(a);
-        groupByHelper(r1, f, xs, Nil) |> List.toArray(r2)
+        groupByHelper(r1, f, xs, Nil) |> List.toArray(r1)
 
     ///
     /// Helper function for `groupBy`.
@@ -1349,10 +1344,9 @@ namespace Array {
     ///
     /// Returns the positions of the all the elements in `a` satisfying `f`.
     ///
-    pub def findIndices(f: a -> Bool \ ef, a: Array[a, r]): Array[Int32, r] \ { ef, Read(r), Write(r) } =
+    pub def findIndices(r2: Region[r2], f: a -> Bool \ ef, a: Array[a, r1]): Array[Int32, r2] \ { ef, Read(r1), Write(r2) } =
         let len = length(a);
-        let r = Scoped.regionOf(a);
-        let l = new MutList(r);
+        let l = new MutList(r2);
         def loop(i) = {
             if (i >= len)
                 ()
@@ -1362,7 +1356,7 @@ namespace Array {
             }
         };
         loop(0);
-        MutList.toArray(r, l)
+        MutList.toArray(r2, l)
 
     ///
     /// Build an array of length `len` by applying `f` to the successive indices.

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -529,43 +529,43 @@ namespace TestArray {
 
     @test
     def indices01(): Bool = region r {
-        let a = Array.indices(0, []: Array[Int32, r]);
+        let a = Array.indices(r, 0, []: Array[Int32, r]);
         Array.sameElements(a, []: Array[Int32, r])
     }
 
     @test
     def indices02(): Bool = region r {
-        let a = Array.indices(0, [1]);
+        let a = Array.indices(r, 0, [1]);
         Array.sameElements(a, []: Array[Int32, r])
     }
 
     @test
     def indices03(): Bool = region r {
-        let a = Array.indices(1, [1]);
+        let a = Array.indices(r, 1, [1]);
         Array.sameElements(a, [0])
     }
 
     @test
     def indices04(): Bool = region r {
-        let a = Array.indices(0, [1,2]);
+        let a = Array.indices(r, 0, [1,2]);
         Array.sameElements(a, []: Array[Int32, r])
     }
 
     @test
     def indices05(): Bool = region r {
-        let a = Array.indices(1, [1,2]);
+        let a = Array.indices(r, 1, [1,2]);
         Array.sameElements(a, [0])
     }
 
     @test
     def indices06(): Bool = region r {
-        let a = Array.indices(2, [1,2]);
+        let a = Array.indices(r, 2, [1,2]);
         Array.sameElements(a, [1])
     }
 
     @test
     def indices07(): Bool = region r {
-        let a = Array.indices(1, [1,1]);
+        let a = Array.indices(r, 1, [1,1]);
         Array.sameElements(a, [0,1])
     }
     /////////////////////////////////////////////////////////////////////////////
@@ -765,43 +765,43 @@ namespace TestArray {
 
     @test
     def scan01(): Bool = region r {
-        let a = Array.scan((i, b) -> if (b) i + 1 else i + 2, 1, []);
+        let a = Array.scan(r, (i, b) -> if (b) i + 1 else i + 2, 1, []);
         Array.sameElements(a, [1])
     }
 
     @test
     def scan02(): Bool = region r {
-        let a = Array.scan((i, b) -> if (b) i + 1 else i + 2, 1, [false]);
+        let a = Array.scan(r, (i, b) -> if (b) i + 1 else i + 2, 1, [false]);
         Array.sameElements(a, [1,3])
     }
 
     @test
     def scan03(): Bool = region r {
-        let a = Array.scan((i, b) -> if (b) i + 1 else i + 2, 1, [true]);
+        let a = Array.scan(r, (i, b) -> if (b) i + 1 else i + 2, 1, [true]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def scan04(): Bool = region r {
-        let a = Array.scan((i, b) -> if (b) i + 1 else i + 2, 1, [false,false]);
+        let a = Array.scan(r, (i, b) -> if (b) i + 1 else i + 2, 1, [false,false]);
         Array.sameElements(a, [1,3,5])
     }
 
     @test
     def scan05(): Bool = region r {
-        let a = Array.scan((i, b) -> if (b) i + 1 else i + 2, 1, [false,true]);
+        let a = Array.scan(r, (i, b) -> if (b) i + 1 else i + 2, 1, [false,true]);
         Array.sameElements(a, [1,3,4])
     }
 
     @test
     def scan06(): Bool = region r {
-        let a = Array.scan((i, b) -> if (b) i + 1 else i + 2, 1, [true,false]);
+        let a = Array.scan(r, (i, b) -> if (b) i + 1 else i + 2, 1, [true,false]);
         Array.sameElements(a, [1,2,4])
     }
 
     @test
     def scan07(): Bool = region r {
-        let a = Array.scan((i, b) -> if (b) i + 1 else i + 2, 1, [true,true]);
+        let a = Array.scan(r, (i, b) -> if (b) i + 1 else i + 2, 1, [true,true]);
         Array.sameElements(a, [1,2,3])
     }
 
@@ -811,43 +811,43 @@ namespace TestArray {
 
     @test
     def scanLeft01(): Bool = region r {
-        let a = Array.scanLeft((i, b) -> if (b) i + 1 else i + 2, 1, []: Array[Bool, _]);
+        let a = Array.scanLeft(r, (i, b) -> if (b) i + 1 else i + 2, 1, []: Array[Bool, _]);
         Array.sameElements(a, [1])
     }
 
     @test
     def scanLeft02(): Bool = region r {
-        let a = Array.scanLeft((i, b) -> if (b) i + 1 else i + 2, 1, [false]);
+        let a = Array.scanLeft(r, (i, b) -> if (b) i + 1 else i + 2, 1, [false]);
         Array.sameElements(a, [1,3])
     }
 
     @test
     def scanLeft03(): Bool = region r {
-        let a = Array.scanLeft((i, b) -> if (b) i + 1 else i + 2, 1, [true]);
+        let a = Array.scanLeft(r, (i, b) -> if (b) i + 1 else i + 2, 1, [true]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def scanLeft04(): Bool = region r {
-        let a = Array.scanLeft((i, b) -> if (b) i + 1 else i + 2, 1, [false,false]);
+        let a = Array.scanLeft(r, (i, b) -> if (b) i + 1 else i + 2, 1, [false,false]);
         Array.sameElements(a, [1,3,5])
     }
 
     @test
     def scanLeft05(): Bool = region r {
-        let a = Array.scanLeft((i, b) -> if (b) i + 1 else i + 2, 1, [false,true]);
+        let a = Array.scanLeft(r, (i, b) -> if (b) i + 1 else i + 2, 1, [false,true]);
         Array.sameElements(a, [1,3,4])
     }
 
     @test
     def scanLeft06(): Bool = region r {
-        let a = Array.scanLeft((i, b) -> if (b) i + 1 else i + 2, 1, [true,false]);
+        let a = Array.scanLeft(r, (i, b) -> if (b) i + 1 else i + 2, 1, [true,false]);
         Array.sameElements(a, [1,2,4])
     }
 
     @test
     def scanLeft07(): Bool = region r {
-        let a = Array.scanLeft((i, b) -> if (b) i + 1 else i + 2, 1, [true,true]);
+        let a = Array.scanLeft(r, (i, b) -> if (b) i + 1 else i + 2, 1, [true,true]);
         Array.sameElements(a, [1,2,3])
     }
 
@@ -857,43 +857,43 @@ namespace TestArray {
 
     @test
     def scanRight01(): Bool = region r {
-        let a = Array.scanRight((b, i) -> if (b) i + 1 else i + 2, 1, []);
+        let a = Array.scanRight(r, (b, i) -> if (b) i + 1 else i + 2, 1, []);
         Array.sameElements(a, [1])
     }
 
     @test
     def scanRight02(): Bool = region r {
-        let a = Array.scanRight((b, i) -> if (b) i + 1 else i + 2, 1, [false]);
+        let a = Array.scanRight(r, (b, i) -> if (b) i + 1 else i + 2, 1, [false]);
         Array.sameElements(a, [3,1])
     }
 
     @test
     def scanRight03(): Bool = region r {
-        let a = Array.scanRight((b, i) -> if (b) i + 1 else i + 2, 1, [true]);
+        let a = Array.scanRight(r, (b, i) -> if (b) i + 1 else i + 2, 1, [true]);
         Array.sameElements(a, [2,1])
     }
 
     @test
     def scanRight04(): Bool = region r {
-        let a = Array.scanRight((b, i) -> if (b) i + 1 else i + 2, 1, [false,false]);
+        let a = Array.scanRight(r, (b, i) -> if (b) i + 1 else i + 2, 1, [false,false]);
         Array.sameElements(a, [5,3,1])
     }
 
     @test
     def scanRight05(): Bool = region r {
-        let a = Array.scanRight((b, i) -> if (b) i + 1 else i + 2, 1, [false,true]);
+        let a = Array.scanRight(r, (b, i) -> if (b) i + 1 else i + 2, 1, [false,true]);
         Array.sameElements(a, [4,2,1])
     }
 
     @test
     def scanRight06(): Bool = region r {
-        let a = Array.scanRight((b, i) -> if (b) i + 1 else i + 2, 1, [true,false]);
+        let a = Array.scanRight(r, (b, i) -> if (b) i + 1 else i + 2, 1, [true,false]);
         Array.sameElements(a, [4,3,1])
     }
 
     @test
     def scanRight07(): Bool = region r {
-        let a = Array.scanRight((b, i) -> if (b) i + 1 else i + 2, 1, [true,true]);
+        let a = Array.scanRight(r, (b, i) -> if (b) i + 1 else i + 2, 1, [true,true]);
         Array.sameElements(a, [3,2,1])
     }
 
@@ -1208,67 +1208,67 @@ namespace TestArray {
 
     @test
     def rotateLeft01(): Bool = region r {
-        let a = Array.rotateLeft(0, []: Array[Int32, _]);
+        let a = Array.rotateLeft(r, 0, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def rotateLeft02(): Bool = region r {
-        let a = Array.rotateLeft(1, []: Array[Int32, _]);
+        let a = Array.rotateLeft(r, 1, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def rotateLeft03(): Bool = region r {
-        let a = Array.rotateLeft(0, [1]);
+        let a = Array.rotateLeft(r, 0, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def rotateLeft04(): Bool = region r {
-        let a = Array.rotateLeft(0, [1,2]);
+        let a = Array.rotateLeft(r, 0, [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def rotateLeft05(): Bool = region r {
-        let a = Array.rotateLeft(1, [1,2]);
+        let a = Array.rotateLeft(r, 1, [1,2]);
         Array.sameElements(a, [2,1])
     }
 
     @test
     def rotateLeft06(): Bool = region r {
-        let a = Array.rotateLeft(2, [1,2]);
+        let a = Array.rotateLeft(r, 2, [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def rotateLeft07(): Bool = region r {
-        let a = Array.rotateLeft(3, [1,2]);
+        let a = Array.rotateLeft(r, 3, [1,2]);
         Array.sameElements(a, [2,1])
     }
 
     @test
     def rotateLeft08(): Bool = region r {
-        let a = Array.rotateLeft(-1, [1,2]);
+        let a = Array.rotateLeft(r, -1, [1,2]);
         Array.sameElements(a, [2,1])
     }
 
     @test
     def rotateLeft09(): Bool = region r {
-        let a = Array.rotateLeft(0, [1,2,3]);
+        let a = Array.rotateLeft(r, 0, [1,2,3]);
         Array.sameElements(a, [1,2,3])
     }
 
     @test
     def rotateLeft10(): Bool = region r {
-        let a = Array.rotateLeft(1, [1,2,3]);
+        let a = Array.rotateLeft(r, 1, [1,2,3]);
         Array.sameElements(a, [2,3,1])
     }
 
     @test
     def rotateLeft11(): Bool = region r {
-        let a = Array.rotateLeft(2, [1,2,3]);
+        let a = Array.rotateLeft(r, 2, [1,2,3]);
         Array.sameElements(a, [3,1,2])
     }
 
@@ -1278,67 +1278,67 @@ namespace TestArray {
 
     @test
     def rotateRight01(): Bool = region r {
-        let a = Array.rotateRight(0, []: Array[Int32, _]);
+        let a = Array.rotateRight(r, 0, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def rotateRight02(): Bool = region r {
-        let a = Array.rotateRight(1, []: Array[Int32, _]);
+        let a = Array.rotateRight(r, 1, []: Array[Int32, _]);
         Array.sameElements(a, []: Array[Int32, _])
     }
 
     @test
     def rotateRight03(): Bool = region r {
-        let a = Array.rotateRight(0, [1]);
+        let a = Array.rotateRight(r, 0, [1]);
         Array.sameElements(a, [1])
     }
 
     @test
     def rotateRight04(): Bool = region r {
-        let a = Array.rotateRight(0, [1,2]);
+        let a = Array.rotateRight(r, 0, [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def rotateRight05(): Bool = region r {
-        let a = Array.rotateRight(1, [1,2]);
+        let a = Array.rotateRight(r, 1, [1,2]);
         Array.sameElements(a, [2,1])
     }
 
     @test
     def rotateRight06(): Bool = region r {
-        let a = Array.rotateRight(2, [1,2]);
+        let a = Array.rotateRight(r, 2, [1,2]);
         Array.sameElements(a, [1,2])
     }
 
     @test
     def rotateRight07(): Bool = region r {
-        let a = Array.rotateRight(3, [1,2]);
+        let a = Array.rotateRight(r, 3, [1,2]);
         Array.sameElements(a, [2,1])
     }
 
     @test
     def rotateRight08(): Bool = region r {
-        let a = Array.rotateRight(-1, [1,2]);
+        let a = Array.rotateRight(r, -1, [1,2]);
         Array.sameElements(a, [2,1])
     }
 
     @test
     def rotateRight09(): Bool = region r {
-        let a = Array.rotateRight(0, [1,2,3]);
+        let a = Array.rotateRight(r, 0, [1,2,3]);
         Array.sameElements(a, [1,2,3])
     }
 
     @test
     def rotateRight10(): Bool = region r {
-        let a = Array.rotateRight(1, [1,2,3]);
+        let a = Array.rotateRight(r, 1, [1,2,3]);
         Array.sameElements(a, [3,1,2])
     }
 
     @test
     def rotateRight11(): Bool = region r {
-        let a = Array.rotateRight(2, [1,2,3]);
+        let a = Array.rotateRight(r, 2, [1,2,3]);
         Array.sameElements(a, [2,3,1])
     }
 
@@ -4445,43 +4445,43 @@ namespace TestArray {
 
     @test
     def findIndices01(): Bool = region r {
-        let a = Array.findIndices(i -> i > 2, []: Array[Int32, r]);
+        let a = Array.findIndices(r, i -> i > 2, []: Array[Int32, r]);
         Array.sameElements(a, []: Array[Int32, r])
     }
 
     @test
     def findIndices02(): Bool = region r {
-        let a = Array.findIndices(i -> i > 2, [1]);
+        let a = Array.findIndices(r, i -> i > 2, [1]);
         Array.sameElements(a, []: Array[Int32, r])
     }
 
     @test
     def findIndices03(): Bool = region r {
-        let a = Array.findIndices(i -> i > 2, [3]);
+        let a = Array.findIndices(r, i -> i > 2, [3]);
         Array.sameElements(a, [0])
     }
 
     @test
     def findIndices04(): Bool = region r {
-        let a = Array.findIndices(i -> i > 2, [1,2]);
+        let a = Array.findIndices(r, i -> i > 2, [1,2]);
         Array.sameElements(a, [] : Array[Int32, r])
     }
 
     @test
     def findIndices05(): Bool = region r {
-        let a = Array.findIndices(i -> i > 2, [6,-6]);
+        let a = Array.findIndices(r, i -> i > 2, [6,-6]);
         Array.sameElements(a, [0])
     }
 
     @test
     def findIndices06(): Bool = region r {
-        let a = Array.findIndices(i -> i > 2, [-6,6]);
+        let a = Array.findIndices(r, i -> i > 2, [-6,6]);
         Array.sameElements(a, [1])
     }
 
     @test
     def findIndices07(): Bool = region r {
-        let a = Array.findIndices(i -> i > 2, [6,7]);
+        let a = Array.findIndices(r, i -> i > 2, [6,7]);
         Array.sameElements(a, [0,1])
     }
 


### PR DESCRIPTION
As per discussion in #5131

This PR removes all calls to `regionOf` from Array.flix, apart from the one in `iterator`.

I *think* I've got this right from the POV of "functions that allocate a new data structure should take a region parameter".

I think that this is mostly uncontroversial, with the possible exception of `groupBy` which used to return arrays allocated in two different regions, and I've modified it to use a single region for the new arrays it creates.