### PR TITLE
ci: run community builds sequentially

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -35,6 +35,8 @@ jobs:
     strategy:
       # collect all the failures
       fail-fast: false
+      # run them one at a time
+      max-parallel: 1
       matrix:
         repo:
           - "magnus-madsen/helloworld"


### PR DESCRIPTION
We've gotten a lot of 403 errors recently, which may be due to rate limiting from the GitHub API.

This changes the CI to run the community builds one at a time, which may improve the odds of the API calls succeeding.