### PR TITLE
chore: Remove Static from File.flix

### DIFF
--- a/main/src/library/File.flix
+++ b/main/src/library/File.flix
@@ -106,11 +106,11 @@ namespace File {
     ///
     /// Returns the BacisFileAttributes of the file `f`.
     ///
-    def getAttributes(f: String): Result[##java.nio.file.attribute.BasicFileAttributes, String] \ IO =
+    def getAttributes(f: String): Result[##java.nio.file.attribute.BasicFileAttributes, String] \ IO = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
-            import static java.nio.file.Files.readAttributes(##java.nio.file.Path, ##java.lang.Class, Array[##java.nio.file.LinkOption, Static]): ##java.nio.file.attribute.BasicFileAttributes \ IO;
+            import static java.nio.file.Files.readAttributes(##java.nio.file.Path, ##java.lang.Class, Array[##java.nio.file.LinkOption, r]): ##java.nio.file.attribute.BasicFileAttributes \ IO;
             import static java.lang.Class.forName(String): ##java.lang.Class \ IO;
 
             let javaFile = newFile(f);
@@ -123,6 +123,7 @@ namespace File {
                 import java.lang.Throwable.getMessage(): String \ IO;
                 Err(getMessage(ex))
         }
+    }
 
     ///
     /// Returns the type of the given file `f`.
@@ -201,11 +202,11 @@ namespace File {
     ///
     /// Returns `true` if the given file `f` is a regular file.
     ///
-    pub def isRegularFile(f: String): Result[Bool, String] \ IO =
+    pub def isRegularFile(f: String): Result[Bool, String] \ IO = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
-            import static java.nio.file.Files.isRegularFile(##java.nio.file.Path, Array[##java.nio.file.LinkOption, Static]): Bool \ IO;
+            import static java.nio.file.Files.isRegularFile(##java.nio.file.Path, Array[##java.nio.file.LinkOption, r]): Bool \ IO;
             let javaFile = newFile(f);
             let javaPath = toPath(javaFile);
             let isRegular = isRegularFile(javaPath, []);
@@ -215,6 +216,7 @@ namespace File {
                 import java.lang.Throwable.getMessage(): String \ IO;
                 Err(getMessage(ex))
         }
+    }
 
     ///
     /// Returns `true` if the given file `f` is readable.
@@ -301,14 +303,14 @@ namespace File {
     /// `count` - the number of bytes read.
     /// `charSet` - the specific charset to be used to decode the bytes.
     ///
-    pub def readWith(opts: {offset = Int64, count = Int32, charSet = String}, f : String): Result[String, String] \ IO =
+    pub def readWith(opts: {offset = Int64, count = Int32, charSet = String}, f : String): Result[String, String] \ IO = region r {
         if (0 < opts.count) {
             try {
                 import new java.io.File(String): ##java.io.File \ IO as newFile;
                 import new java.io.FileInputStream(##java.io.File): ##java.io.FileInputStream \ IO as newInputStream;
-                import java.io.FileInputStream.read(Array[Int8, Static], Int32, Int32): Int32 \ IO;
+                import java.io.FileInputStream.read(Array[Int8, r], Int32, Int32): Int32 \ IO;
                 import static java.nio.charset.Charset.forName(String): ##java.nio.charset.Charset \ IO;
-                import new java.lang.String(Array[Int8, Static], ##java.nio.charset.Charset): String \ IO as newString;
+                import new java.lang.String(Array[Int8, r], ##java.nio.charset.Charset): String \ IO as newString;
 
                 let javaFile = newFile(f);
                 let stream = newInputStream(javaFile);
@@ -332,6 +334,7 @@ namespace File {
         } else {
             Err("The argument `count` has to be a non negative number when calling `File.readWith`.")
         }
+    }
 
     ///
     /// Helper function for `readWith` and `readBytesWith`.
@@ -411,7 +414,7 @@ namespace File {
     ///
     /// Returns an iterator of the given file `f`
     ///
-    pub def readLinesIter(f: String): Iterator[Result[String, String], Static] \ IO =
+    pub def readLinesIter(r: Region[r], f: String): Iterator[Result[String, String], r] \ { Read(r), Write(r), IO } =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -421,18 +424,18 @@ namespace File {
             let javaFile = newFile(f);
             let javaPath = toPath(javaFile);
             let reader = newBufferedReader(javaPath);
-            let line = ref readLine(reader);
+            let line = ref readLine(reader) @ r;
 
             let done = () -> Object.isNull(deref line);
             let next = () -> {
                 try {
                     let l = deref line;
-                    line := readLine(reader);
+                    line := unsafe_cast readLine(reader) as _ \ Read(r);
                     Ok(l)
                 } catch {
                     case ex: ##java.io.IOException => {
                         line := unsafe_cast null as String;
-                        import java.lang.Throwable.getMessage(): String \ IO;
+                        import java.lang.Throwable.getMessage(): String \ {};
                         Err(getMessage(ex))
                     }
                 }
@@ -440,8 +443,8 @@ namespace File {
             Iterator(done, next)
         } catch {
             case ex: ##java.io.IOException =>
-                import java.lang.Throwable.getMessage(): String \ IO;
-                Iterator.singleton(Static, Err(getMessage(ex)))
+                import java.lang.Throwable.getMessage(): String \ {};
+                Iterator.singleton(r, Err(getMessage(ex)))
         }
 
     ///
@@ -449,7 +452,7 @@ namespace File {
     /// The options `opts` to apply consists of
     /// `charSet` - the specific charset to be used to decode the bytes.
     ///
-    pub def readLinesIterWith(opts: {charSet = String}, f: String): Iterator[Result[String, String], Static] \ IO =
+    pub def readLinesIterWith(r: Region[r], opts: {charSet = String}, f: String): Iterator[Result[String, String], r] \ { Read(r), Write(r), IO } =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -460,18 +463,18 @@ namespace File {
             let javaFile = newFile(f);
             let javaPath = toPath(javaFile);
             let reader = newBufferedReader(javaPath, forName(opts.charSet));
-            let line = ref readLine(reader);
+            let line = ref readLine(reader) @ r;
 
             let done = () -> Object.isNull(deref line);
             let next = () -> {
                 try {
                     let l = deref line;
-                    line := readLine(reader);
+                    line := unsafe_cast readLine(reader) as _ \ Read(r);
                     Ok(l)
                 } catch {
                     case ex: ##java.io.IOException => {
                         line := unsafe_cast null as String;
-                        import java.lang.Throwable.getMessage(): String \ IO;
+                        import java.lang.Throwable.getMessage(): String \ {};
                         Err(getMessage(ex))
                     }
                 }
@@ -479,18 +482,18 @@ namespace File {
             Iterator(done, next)
         } catch {
             case ex: ##java.io.IOException =>
-                import java.lang.Throwable.getMessage(): String \ IO;
-                Iterator.singleton(Static, Err(getMessage(ex)))
+                import java.lang.Throwable.getMessage(): String \ {};
+                Iterator.singleton(r, Err(getMessage(ex)))
         }
 
     ///
     /// Returns an array of all the bytes in the given file `f`.
     ///
-    pub def readBytes(f: String): Result[Array[Int8, Static], String] \ IO =
+    pub def readBytes(_r: Region[r], f: String): Result[Array[Int8, r], String] \ { Write(r), IO } =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
-            import static java.nio.file.Files.readAllBytes(##java.nio.file.Path): Array[Int8, Static] \ IO;
+            import static java.nio.file.Files.readAllBytes(##java.nio.file.Path): Array[Int8, r] \ IO;
 
             let javaFile = newFile(f);
             let javaPath = toPath(javaFile);
@@ -509,7 +512,7 @@ namespace File {
     /// `offset` - the start offset in the given file `f`.
     /// `count` - the number of bytes read.
     ///
-    pub def readBytesWith(opts: {offset = Int64, count = Int32}, f: String): Result[Array[Int8, Static], String] \ IO =
+    pub def readBytesWith(r: Region[r], opts: {offset = Int64, count = Int32}, f: String): Result[Array[Int8, r], String] \ { Read(r), Write(r), IO } =
         if (0 < opts.count) {
             try {
                 import new java.io.File(String): ##java.io.File \ IO as newFile;
@@ -520,9 +523,9 @@ namespace File {
                 let stream = newInputStream(javaFile);
                 match skip((opts.offset / 10_000i64), opts.offset, stream, f) {
                     case Ok(_)    => {
-                        let bytes = [0i8; opts.count];
-                        let numberRead = read(stream, bytes, 0, opts.count);
-                        let res = readBytesWithHelper(bytes, numberRead, opts.count);
+                        let bytes = [0i8; opts.count] @ r;
+                        let numberRead = read(stream, unsafe_cast bytes as Array[Int8, Static], 0, opts.count);
+                        let res = readBytesWithHelper(r, bytes, numberRead, opts.count);
                         Ok(res)
                     }
                     case Err(msg) => Err(msg)
@@ -533,7 +536,7 @@ namespace File {
                     Err(getMessage(ex))
             }
         } else if (opts.count == 0) {
-            Ok([])
+            Ok([] @ r)
         } else {
             Err("The argument `count` has to be a non negative number when calling `File.readBytesWith`.")
         }
@@ -542,14 +545,14 @@ namespace File {
     /// Helper function for `readBytesWith`.
     /// Returns an array that corresponds to the bytes actually read from the stream.
     ///
-    def readBytesWithHelper(bytes: Array[Int8, Static], numberRead: Int32, count: Int32): Array[Int8, Static] \ IO =
+    def readBytesWithHelper(r: Region[r], bytes: Array[Int8, r], numberRead: Int32, count: Int32): Array[Int8, r] \ { Read(r), Write(r) } =
         let nothingRead = (numberRead == -1);
         if (nothingRead) {
-            []
+            [] @ r
         } else {
             let countBiggest = numberRead < count;
             if (countBiggest) {
-                Array.slice(Static, 0, numberRead, bytes)
+                Array.slice(r, 0, numberRead, bytes)
             } else {
                 bytes
             }
@@ -558,7 +561,7 @@ namespace File {
     ///
     /// Returns an iterator of the bytes in the given `file` in chunks of size `chunkSize`.
     ///
-    pub def readChunks(chunkSize: Int32, f: String): Iterator[Result[Array[Int8, Static], String], Static] \ IO =
+    pub def readChunks(r: Region[r], chunkSize: Int32, f: String): Iterator[Result[Array[Int8, r], String], r] \ IO =
         if (0 < chunkSize) {
             try {
                 import new java.io.File(String): ##java.io.File \ IO as newFile;
@@ -567,21 +570,21 @@ namespace File {
 
                 let javaFile = newFile(f);
                 let stream = newInputStream(javaFile);
-                let bytes = ref [0i8; chunkSize];
-                let numberRead = ref read(stream, deref bytes);
+                let bytes = ref [0i8; chunkSize] @ r @ r;
+                let numberRead = ref unsafe_cast read(stream, unsafe_cast deref bytes as Array[Int8, Static]) as _ \ Read(r) @ r;
 
                 let done = () -> deref numberRead == -1;
                 let next = () -> {
                     try {
                         let chunk = deref bytes;
-                        bytes := [0i8; chunkSize];
+                        bytes := [0i8; chunkSize] @ r;
                         let accRead = deref numberRead;
-                        numberRead := read(stream, deref bytes);
-                        Ok(readBytesWithHelper(chunk, accRead, chunkSize))
+                        numberRead := unsafe_cast read(stream, unsafe_cast deref bytes as Array[Int8, Static]) as _ \ Read(r);
+                        Ok(readBytesWithHelper(r, chunk, accRead, chunkSize))
                     } catch {
                         case ex: ##java.io.IOException => {
                             numberRead := -1;
-                            import java.lang.Throwable.getMessage(): String \ IO;
+                            import java.lang.Throwable.getMessage(): String \ {};
                             Err(getMessage(ex))
                         }
                     }
@@ -589,13 +592,13 @@ namespace File {
                 Iterator(done, next)
             } catch {
                 case ex: ##java.io.IOException =>
-                    import java.lang.Throwable.getMessage(): String \ IO;
-                    Iterator.singleton(Static, Err(getMessage(ex)))
+                    import java.lang.Throwable.getMessage(): String \ {};
+                    Iterator.singleton(r, Err(getMessage(ex)))
             }
         } else if (chunkSize == 0) {
-            Iterator.new(Static)
+            Iterator.new(r)
         } else {
-            Iterator.singleton(Static, Err("The argument `chunkSize` has to be a non negative number when calling `File.readChunks`."))
+            Iterator.singleton(r, Err("The argument `chunkSize` has to be a non negative number when calling `File.readChunks`."))
         }
 
     ///
@@ -894,7 +897,7 @@ namespace File {
     pub def list(f: String): Result[List[String], String] \ IO = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
-            import java.io.File.listFiles(): Array[##java.io.File, Static] \ IO;
+            import java.io.File.listFiles(): Array[##java.io.File, r] \ IO;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
             import java.nio.file.Path.toString(): String \ IO as pathToString;
 
@@ -919,7 +922,7 @@ namespace File {
     ///
     /// Does not recursively traverse the directory.
     ///
-    pub def listWithIter(f: String): Result[Iterator[String, Static], String] \ IO =
+    pub def listWithIter(r: Region[r], f: String): Result[Iterator[String, r], String] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -932,7 +935,7 @@ namespace File {
             let javaStream = newDirectoryStream(javaPath);
             let javaIter = iterator(javaStream);
 
-            let iter = fromJavaIter(javaIter);
+            let iter = fromJavaIter(r, javaIter);
             Ok(Iterator.mapL(pathToString, iter))
         } catch {
             case ex: ##java.io.IOException =>
@@ -946,7 +949,7 @@ namespace File {
     ///
     /// Recursively traverses the directory.
     ///
-    pub def walk(f: String): Result[Iterator[String, Static], String] \ IO =
+    pub def walk(r: Region[r], f: String): Result[Iterator[String, r], String] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -959,7 +962,7 @@ namespace File {
             let javaStream = walk(javaPath, []);
             let javaIter = iterator(upcast javaStream);
 
-            let iter = fromJavaIter(javaIter);
+            let iter = fromJavaIter(r, javaIter);
             Ok(Iterator.mapL(pathToString, iter))
         } catch {
             case ex: ##java.io.IOException =>
@@ -970,9 +973,9 @@ namespace File {
     ///
     /// Converts a Java iterator to a Flix Iterator.
     ///
-    def fromJavaIter(iter: ##java.util.Iterator): Iterator[a, Static] =
-        import java.util.Iterator.hasNext(): Bool \ IO;
-        import java.util.Iterator.next(): a \ IO as getNext;
+    def fromJavaIter(_r: Region[r], iter: ##java.util.Iterator): Iterator[a, r] =
+        import java.util.Iterator.hasNext(): Bool \ Read(r);
+        import java.util.Iterator.next(): a \ { Read(r), Write(r) } as getNext;
 
         let done = () -> not hasNext(iter);
         let next = () -> {

--- a/main/src/library/File.flix
+++ b/main/src/library/File.flix
@@ -517,14 +517,14 @@ namespace File {
             try {
                 import new java.io.File(String): ##java.io.File \ IO as newFile;
                 import new java.io.FileInputStream(##java.io.File): ##java.io.FileInputStream \ IO as newInputStream;
-                import java.io.FileInputStream.read(Array[Int8, Static], Int32, Int32): Int32 \ IO;
+                import java.io.FileInputStream.read(Array[Int8, r], Int32, Int32): Int32 \ IO;
 
                 let javaFile = newFile(f);
                 let stream = newInputStream(javaFile);
                 match skip((opts.offset / 10_000i64), opts.offset, stream, f) {
                     case Ok(_)    => {
                         let bytes = [0i8; opts.count] @ r;
-                        let numberRead = read(stream, unsafe_cast bytes as Array[Int8, Static], 0, opts.count);
+                        let numberRead = read(stream, bytes, 0, opts.count);
                         let res = readBytesWithHelper(r, bytes, numberRead, opts.count);
                         Ok(res)
                     }
@@ -566,12 +566,12 @@ namespace File {
             try {
                 import new java.io.File(String): ##java.io.File \ IO as newFile;
                 import new java.io.FileInputStream(##java.io.File): ##java.io.FileInputStream \ IO as newInputStream;
-                import java.io.FileInputStream.read(Array[Int8, Static]): Int32 \ IO;
+                import java.io.FileInputStream.read(Array[Int8, r]): Int32 \ IO;
 
                 let javaFile = newFile(f);
                 let stream = newInputStream(javaFile);
                 let bytes = ref [0i8; chunkSize] @ r @ r;
-                let numberRead = ref unsafe_cast read(stream, unsafe_cast deref bytes as Array[Int8, Static]) as _ \ Read(r) @ r;
+                let numberRead = ref unsafe_cast read(stream, deref bytes) as _ \ Read(r) @ r;
 
                 let done = () -> deref numberRead == -1;
                 let next = () -> {
@@ -579,7 +579,7 @@ namespace File {
                         let chunk = deref bytes;
                         bytes := [0i8; chunkSize] @ r;
                         let accRead = deref numberRead;
-                        numberRead := unsafe_cast read(stream, unsafe_cast deref bytes as Array[Int8, Static]) as _ \ Read(r);
+                        numberRead := unsafe_cast read(stream, deref bytes) as _ \ Read(r);
                         Ok(readBytesWithHelper(r, chunk, accRead, chunkSize))
                     } catch {
                         case ex: ##java.io.IOException => {
@@ -750,12 +750,12 @@ namespace File {
     ///
     /// Returns `true` if the file `f` was created, and `false` if `f` was overwritten.
     ///
-    pub def writeBytes(f: String, data: f[Int8]): Result[Bool, String] \ IO with Foldable[f] =
+    pub def writeBytes(f: String, data: f[Int8]): Result[Bool, String] \ IO with Foldable[f] = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import new java.io.FileOutputStream(##java.io.File): ##java.io.FileOutputStream \ IO as newFileStream;
             import new java.io.PrintWriter(##java.io.OutputStream): ##java.io.PrintWriter \ IO as newPrintWriter;
-            import java.io.FileOutputStream.write(Array[Int8, Static]): Unit \ IO;
+            import java.io.FileOutputStream.write(Array[Int8, r]): Unit \ IO;
             import java.io.PrintWriter.close(): Unit \ IO;
             import java.io.PrintWriter.checkError(): Bool \ IO;
 
@@ -765,7 +765,7 @@ namespace File {
             let fileStream = newFileStream(javaFile);
             let printWriter = newPrintWriter(upcast fileStream);
 
-            let dataAsArray = Foldable.toArray(Static, data);
+            let dataAsArray = Foldable.toArray(r, data);
             write(fileStream, dataAsArray);
             close(printWriter);
 
@@ -780,18 +780,19 @@ namespace File {
                 import java.lang.Throwable.getMessage(): String \ IO;
                 Err(getMessage(ex))
         }
+    }
 
     ///
     /// Appends `data` to the given `f`.
     ///
     /// Returns `true` if the file `f` was created, and `false` if `data` was appended to an existing `f`.
     ///
-    pub def appendBytes(f: String, data: f[Int8]): Result[Bool, String] \ IO with Foldable[f] =
+    pub def appendBytes(f: String, data: f[Int8]): Result[Bool, String] \ IO with Foldable[f] = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import new java.io.FileOutputStream(##java.io.File, Bool): ##java.io.FileOutputStream \ IO as newFileStream;
             import new java.io.PrintWriter(##java.io.OutputStream): ##java.io.PrintWriter \ IO as newPrintWriter;
-            import java.io.FileOutputStream.write(Array[Int8, Static]): Unit \ IO;
+            import java.io.FileOutputStream.write(Array[Int8, r]): Unit \ IO;
             import java.io.PrintWriter.close(): Unit \ IO;
             import java.io.PrintWriter.checkError(): Bool \ IO;
 
@@ -802,7 +803,7 @@ namespace File {
             let fileStream = newFileStream(javaFile, true);
             let printWriter = newPrintWriter(upcast fileStream);
 
-            let dataAsArray = Foldable.toArray(Static, data);
+            let dataAsArray = Foldable.toArray(r, data);
             write(fileStream, dataAsArray);
 
             close(printWriter);
@@ -818,6 +819,7 @@ namespace File {
                 import java.lang.Throwable.getMessage(): String \ IO;
                 Err(getMessage(ex))
         }
+    }
 
     ///
     /// Returns `true` if the file `f` was created, and `false` if `f` was overwritten.
@@ -953,13 +955,13 @@ namespace File {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
-            import static java.nio.file.Files.walk(##java.nio.file.Path, Array[##java.nio.file.FileVisitOption, Static]): ##java.util.stream.Stream \ IO;
+            import static java.nio.file.Files.walk(##java.nio.file.Path, Array[##java.nio.file.FileVisitOption, r]): ##java.util.stream.Stream \ IO;
             import java.util.stream.BaseStream.iterator(): ##java.util.Iterator \ IO;
             import java.nio.file.Path.toString(): String \ {} as pathToString;
 
             let javaFile = newFile(f);
             let javaPath = toPath(javaFile);
-            let javaStream = walk(javaPath, []);
+            let javaStream = walk(javaPath, [] @ r);
             let javaIter = iterator(upcast javaStream);
 
             let iter = fromJavaIter(r, javaIter);
@@ -996,23 +998,24 @@ namespace File {
     /// - `dst` is a subpath of `src`, or
     /// - an I/O error occurred.
     ///
-    pub def move(src: {src = String} , dst: String): Result[Unit, String] \ IO =
+    pub def move(src: {src = String} , dst: String): Result[Unit, String] \ IO = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
-            import static java.nio.file.Files.move(##java.nio.file.Path, ##java.nio.file.Path, Array[##java.nio.file.CopyOption, Static]): ##java.nio.file.Path \ IO;
+            import static java.nio.file.Files.move(##java.nio.file.Path, ##java.nio.file.Path, Array[##java.nio.file.CopyOption, r]): ##java.nio.file.Path \ IO;
 
             let srcFile = newFile(src.src);
             let srcPath = toPath(srcFile);
             let dstFile = newFile(dst);
             let dstPath = toPath(dstFile);
-            discard move(srcPath, dstPath, []);
+            discard move(srcPath, dstPath, [] @ r);
             Ok()
         } catch {
             case ex: ##java.io.IOException =>
                 import java.lang.Throwable.getMessage(): String \ IO;
                 Err(getMessage(ex))
         }
+    }
 
     ///
     /// Moves a file or directory from path `src` to directory `dst`.
@@ -1055,11 +1058,11 @@ namespace File {
     /// Returns `Ok(())` if `src` was moved.
     /// Returns `Err(msg)` if `src` was not moved, or an I/O error occurred.
     ///
-    pub def moveOver(src: {src = String}, dst: String): Result[Unit, String] \ IO =
+    pub def moveOver(src: {src = String}, dst: String): Result[Unit, String] \ IO = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
-            import static java.nio.file.Files.move(##java.nio.file.Path, ##java.nio.file.Path, Array[##java.nio.file.CopyOption, Static]): ##java.nio.file.Path \ IO;
+            import static java.nio.file.Files.move(##java.nio.file.Path, ##java.nio.file.Path, Array[##java.nio.file.CopyOption, r]): ##java.nio.file.Path \ IO;
             import static get java.nio.file.StandardCopyOption.REPLACE_EXISTING: ##java.nio.file.StandardCopyOption \ IO as getOverwrite;
 
             let dstFile = newFile(dst);
@@ -1067,7 +1070,7 @@ namespace File {
 
             let srcFile = newFile(src.src);
             let srcPath = toPath(srcFile);
-            discard move(srcPath, dstPath, [upcast getOverwrite()]);
+            discard move(srcPath, dstPath, [upcast getOverwrite()] @ r);
 
             Ok()
         } catch {
@@ -1075,6 +1078,7 @@ namespace File {
                 import java.lang.Throwable.getMessage(): String \ IO;
                 Err(getMessage(ex))
         }
+    }
 
     ///
     /// Copies a file or directory from path `src` to path `dst`.
@@ -1085,23 +1089,24 @@ namespace File {
     /// - `dst` is a subpath of `src`, or
     /// - an I/O error occurred.
     ///
-    pub def copy(src: {src = String} , dst: String): Result[Unit, String] \ IO =
+    pub def copy(src: {src = String} , dst: String): Result[Unit, String] \ IO = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
-            import static java.nio.file.Files.copy(##java.nio.file.Path, ##java.nio.file.Path, Array[##java.nio.file.CopyOption, Static]): ##java.nio.file.Path \ IO;
+            import static java.nio.file.Files.copy(##java.nio.file.Path, ##java.nio.file.Path, Array[##java.nio.file.CopyOption, r]): ##java.nio.file.Path \ IO;
 
             let srcFile = newFile(src.src);
             let srcPath = toPath(srcFile);
             let dstFile = newFile(dst);
             let dstPath = toPath(dstFile);
-            discard copy(srcPath, dstPath, []);
+            discard copy(srcPath, dstPath, [] @ r);
             Ok()
         } catch {
             case ex: ##java.io.IOException =>
                 import java.lang.Throwable.getMessage(): String \ IO;
                 Err(getMessage(ex))
         }
+    }
 
     ///
     /// Copies a file or directory from path `src` to directory `dst`.
@@ -1144,11 +1149,11 @@ namespace File {
     /// Returns `Ok(())` if `src` was copied.
     /// Returns `Err(msg)` if `src` was not copied, or an I/O error occurred.
     ///
-    pub def copyOver(src: {src = String}, dst: String): Result[Unit, String] \ IO =
+    pub def copyOver(src: {src = String}, dst: String): Result[Unit, String] \ IO = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
-            import static java.nio.file.Files.copy(##java.nio.file.Path, ##java.nio.file.Path, Array[##java.nio.file.CopyOption, Static]): ##java.nio.file.Path \ IO;
+            import static java.nio.file.Files.copy(##java.nio.file.Path, ##java.nio.file.Path, Array[##java.nio.file.CopyOption, r]): ##java.nio.file.Path \ IO;
             import static get java.nio.file.StandardCopyOption.REPLACE_EXISTING: ##java.nio.file.StandardCopyOption \ IO as getOverwrite;
 
             let dstFile = newFile(dst);
@@ -1156,7 +1161,7 @@ namespace File {
 
             let srcFile = newFile(src.src);
             let srcPath = toPath(srcFile);
-            discard copy(srcPath, dstPath, [upcast getOverwrite()]);
+            discard copy(srcPath, dstPath, [upcast getOverwrite()] @ r);
 
             Ok()
         } catch {
@@ -1164,6 +1169,7 @@ namespace File {
                 import java.lang.Throwable.getMessage(): String \ IO;
                 Err(getMessage(ex))
         }
+    }
 
     ///
     /// Deletes the given file or directory `f`.

--- a/main/test/ca/uwaterloo/flix/library/TestFile.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFile.flix
@@ -202,107 +202,120 @@ namespace TestFile {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def testReadLinesIter01(): Bool \ IO =
-        match readLinesIter("./LICENSE.md") {
+    def testReadLinesIter01(): Bool \ IO = region r {
+        match readLinesIter(r, "./LICENSE.md") {
             case Iterator(_, next) => Result.isOk(next())
         }
+    }
 
     @test
-    def testReadLinesIter02(): Bool \ IO =
-        match readLinesIter("./LICENSE.md") {
+    def testReadLinesIter02(): Bool \ IO = region r {
+        match readLinesIter(r, "./LICENSE.md") {
             case Iterator(done, _) => done() == false
         }
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // readLinesIterWith                                                       //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def testReadLinesIterWithWith01(): Bool \ IO =
-        match readLinesIterWith({charSet = "utf8"}, "./LICENSE.md") {
+    def testReadLinesIterWithWith01(): Bool \ IO = region r {
+        match readLinesIterWith(r, {charSet = "utf8"}, "./LICENSE.md") {
             case Iterator(_, next) => Result.isOk(next())
         }
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // readBytes                                                               //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def testReadBytes01(): Bool \ IO =
-        Result.isOk(readBytes("./LICENSE.md"))
+    def testReadBytes01(): Bool \ IO = region r {
+        Result.isOk(readBytes(r, "./LICENSE.md"))
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // readBytesWith                                                           //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def testReadBytesWith01(): Bool \ IO =
-        Result.isOk(readBytesWith({offset = 2i64, count = 2}, "./LICENSE.md"))
+    def testReadBytesWith01(): Bool \ IO = region r {
+        Result.isOk(readBytesWith(r, {offset = 2i64, count = 2}, "./LICENSE.md"))
+    }
 
     @test
-    def testReadBytesWith02(): Bool \ IO =
-        match readBytesWith({offset = 2i64, count = 2}, "./LICENSE.md") {
+    def testReadBytesWith02(): Bool \ IO = region r {
+        match readBytesWith(r, {offset = 2i64, count = 2}, "./LICENSE.md") {
             case Ok(v) => Array.length(v) == 2
             case _     => false
         }
+    }
 
     @test
-    def testReadBytesWith03(): Bool \ IO =
-        match readBytesWith({offset = 10i64, count = 4}, "./LICENSE.md") {
+    def testReadBytesWith03(): Bool \ IO = region r {
+        match readBytesWith(r, {offset = 10i64, count = 4}, "./LICENSE.md") {
             case Ok(v) => v `Array.sameElements` [101i8, 110i8, 115i8, 101i8]
             case _     => false
         }
+    }
 
     @test
-    def testReadBytesWith04(): Bool \ IO =
-        match readBytesWith({offset = 0i64, count = 0}, "./LICENSE.md") {
+    def testReadBytesWith04(): Bool \ IO = region r {
+        match readBytesWith(r, {offset = 0i64, count = 0}, "./LICENSE.md") {
             case Ok(v) => v `Array.sameElements` []
             case _     => false
         }
+    }
 
     @test
-    def testReadBytesWith05(): Bool \ IO =
-        match readBytesWith({offset = -10i64, count = 0}, "./LICENSE.md") {
+    def testReadBytesWith05(): Bool \ IO = region r {
+        match readBytesWith(r, {offset = -10i64, count = 0}, "./LICENSE.md") {
             case Ok(v) => v `Array.sameElements` []
             case _     => false
         }
+    }
 
     @test
-    def testReadBytesWith06(): Bool \ IO =
-        Result.isErr(readBytesWith({offset = 0i64, count = -10}, "./LICENSE.md"))
+    def testReadBytesWith06(): Bool \ IO = region r {
+        Result.isErr(readBytesWith(r, {offset = 0i64, count = -10}, "./LICENSE.md"))
+    }
 
     @test
-    def testReadBytesWith07(): Bool \ IO =
-        Result.isErr(readBytesWith({offset = -10i64, count = 10}, "./LICENSE.md"))
-
+    def testReadBytesWith07(): Bool \ IO = region r {
+        Result.isErr(readBytesWith(r, {offset = -10i64, count = 10}, "./LICENSE.md"))
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // readChunks                                                              //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def testReadChunks01(): Bool \ IO =
-        match readChunks(2, "./LICENSE.md") {
+    def testReadChunks01(): Bool \ IO = region r {
+        match readChunks(r, 2, "./LICENSE.md") {
             case Iterator(_, next) => Result.isOk(next())
         }
+    }
 
     @test
-    def testReadChunks02(): Bool \ IO =
-        match readChunks(2, "./LICENSE.md") {
+    def testReadChunks02(): Bool \ IO = region r {
+        match readChunks(r, 2, "./LICENSE.md") {
             case Iterator(done, _) => done() == false
         }
+    }
 
     @test
-    def testReadChunks03(): Bool \ IO =
-        match readChunks(0, "./LICENSE.md") {
+    def testReadChunks03(): Bool \ IO = region r {
+        match readChunks(r, 0, "./LICENSE.md") {
             case Iterator(done, _) => done()
         }
+    }
 
     @test
-    def testReadChunks04(): Bool \ IO =
-        match readChunks(-10, "./LICENSE.md") {
+    def testReadChunks04(): Bool \ IO = region r {
+        match readChunks(r, -10, "./LICENSE.md") {
             case Iterator(_, next) => Result.isErr(next())
         }
-
+    }
 
 }


### PR DESCRIPTION
As per #5131

This goes some way towards removing `Static` from `File.flix`, on the assumption that [this](https://github.com/flix/flix/issues/5131#issuecomment-1362754812) is correct.

I've not been able to go as far as I'd like because it turns out that Java interop doesn't know how to cope with arrays in any region other than `Static`. So I'll address that next.