### PR TITLE
chore: More static removal

### DIFF
--- a/main/test/flix/Test.Exp.New.flix
+++ b/main/test/flix/Test.Exp.New.flix
@@ -1,22 +1,6 @@
 namespace Test/Exp/New {
 
     @test
-    def testNewMutList1Region01(): MutList[Int32, Static] \ IO =
-        new MutList(Static): MutList[Int32, Static]
-
-    @test
-    def testNewMutList1Region02(): MutList[Int32, Static] \ IO =
-        let l = new MutList(Static);
-        MutList.push!(1, l);
-        l
-
-    @test
-    def testNewMutList1Region03(): MutList[String, Static] \ IO =
-        region _ {
-            new MutList(Static): MutList[String, Static]
-        }
-
-    @test
     def testNewMutList1Region04(): Unit =
         region r {
             discard new MutList(r): MutList[String, r];
@@ -32,35 +16,6 @@ namespace Test/Exp/New {
                 case Some(1) => 1
                 case _       => unreachable!()
             }
-        }
-
-    @test
-    def testNewMutList2RegionsFlat01(): MutList[Int32, Static] \ IO =
-        discard region _ {
-            new MutList(Static): MutList[String, Static]
-        };
-        region _ {
-            new MutList(Static): MutList[Int32, Static]
-        }
-
-    @test
-    def testNewMutList2RegionsFlat02(): MutList[Int32, Static] \ IO =
-        let _ = region r {
-            discard new MutList(r): MutList[String, r];
-            ()
-        };
-        region _ {
-            new MutList(Static): MutList[Int32, Static]
-        }
-
-    @test
-    def testNewMutList2RegionsFlat03(): Unit \ IO =
-        discard region _ {
-            new MutList(Static): MutList[String, Static]
-        };
-        region r {
-            discard new MutList(r): MutList[Int32, r];
-            ()
         }
 
     @test
@@ -225,22 +180,6 @@ namespace Test/Exp/New {
         }
 
     @test
-    def testNewMutMap1Region01(): MutMap[Int32, Int32, Static] \ IO =
-        new MutMap(Static): MutMap[Int32, Int32, Static]
-
-    @test
-    def testNewMutMap1Region02(): MutMap[Int32, Int32, Static] \ IO =
-        let m = new MutMap(Static);
-        MutMap.put!(1, 1, m);
-        m
-
-    @test
-    def testNewMutMap1Region03(): MutMap[Int32, String, Static] \ IO =
-        region _ {
-            new MutMap(Static): MutMap[Int32, String, Static]
-        }
-
-    @test
     def testNewMutMap1Region04(): Unit =
         region r {
             discard new MutMap(r): MutMap[Int32, String, r];
@@ -256,35 +195,6 @@ namespace Test/Exp/New {
                 case Some(1) => 1
                 case _       => unreachable!()
             }
-        }
-
-    @test
-    def testNewMutMap2RegionsFlat01(): MutMap[Int32, Int32, Static] \ IO =
-        discard region _ {
-            new MutMap(Static): MutMap[Int32, String, Static]
-        };
-        region _ {
-            new MutMap(Static): MutMap[Int32, Int32, Static]
-        }
-
-    @test
-    def testNewMutMap2RegionsFlat02(): MutMap[Int32, Int32, Static] \ IO =
-        let _ = region r {
-            discard new MutMap(r): MutMap[Int32, String, r];
-            ()
-        };
-        region _ {
-            new MutMap(Static): MutMap[Int32, Int32, Static]
-        }
-
-    @test
-    def testNewMutMap2RegionsFlat03(): Unit \ IO =
-        discard region _ {
-            new MutMap(Static): MutMap[Int32, String, Static]
-        };
-        region r {
-            discard new MutMap(r): MutMap[Int32, Int32, r];
-            ()
         }
 
     @test

--- a/main/test/flix/Test.Exp.Regions.flix
+++ b/main/test/flix/Test.Exp.Regions.flix
@@ -6,78 +6,6 @@ namespace Test/Exp/Regions {
     // Test cases that mix both multiple regions and multiple data structures.
 
     @test
-    def testRegions0Regions01(): Array[Int32, Static] \ IO =
-        []
-
-    @test
-    def testRegions0Regions02(): MutList[Int32, Static] \ IO =
-        new MutList(Static)
-
-    @test
-    def testRegions0Regions03(): MutMap[Int32, Int32, Static] \ IO =
-        new MutMap(Static)
-
-    @test
-    def testRegions0Regions1Nested01(): Array[Array[Int32, Static], Static] \ IO =
-        []
-
-    @test
-    def testRegions0Regions1Nested02(): MutList[MutList[Int32, Static], Static] \ IO =
-        new MutList(Static)
-
-    @test
-    def testRegions0Regions1Nested03(): MutMap[Int32, MutMap[Int32, Int32, Static], Static] \ IO =
-        new MutMap(Static)
-
-    @test
-    def testRegions0Regions1Nested04(): Array[MutMap[Int32, Int32, Static], Static] \ IO =
-        []
-
-    @test
-    def testRegions0Regions1Nested05(): MutList[Array[Int32, Static], Static] \ IO =
-        new MutList(Static)
-
-    @test
-    def testRegions0Regions1Nested06(): MutMap[Int32, MutList[Int32, Static], Static] \ IO =
-        new MutMap(Static)
-
-    @test
-    def testRegions0Regions1Nested07(): Array[MutList[Int32, Static], Static] \ IO =
-        []
-
-    @test
-    def testRegions0Regions1Nested08(): MutList[MutMap[Int32, Int32, Static], Static] \ IO =
-        new MutList(Static)
-
-    @test
-    def testRegions0Regions1Nested09(): MutMap[Int32, Array[Int32, Static], Static] \ IO =
-        new MutMap(Static)
-
-    @test
-    def testRegions0Regions2Nested01(): Array[MutMap[Int32, MutList[Int32, Static], Static], Static] \ IO =
-        []
-
-    @test
-    def testRegions0Regions2Nested02(): MutList[Array[MutMap[Int32, Int32, Static], Static], Static] \ IO =
-        new MutList(Static)
-
-    @test
-    def testRegions0Regions2Nested03(): MutMap[Int32, MutList[Array[Int32, Static], Static], Static] \ IO =
-        new MutMap(Static)
-
-    @test
-    def testRegions0Regions3Nested01(): Array[MutMap[Int32, MutList[Array[Int32, Static], Static], Static], Static] \ IO =
-        []
-
-    @test
-    def testRegions0Regions3Nested02(): MutList[Array[MutMap[Int32, MutList[Int32, Static], Static], Static], Static] \ IO =
-        new MutList(Static)
-
-    @test
-    def testRegions0Regions3Nested03(): MutMap[Int32, MutList[Array[MutMap[Int32, Int32, Static], Static], Static], Static] \ IO =
-        new MutMap(Static)
-
-    @test
     def testRegions1Region01(): Bool =
         region r {
             let a = [1; 8];
@@ -101,18 +29,18 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions1Region1Nested01(): Bool \ IO =
+    def testRegions1Region1Nested01(): Bool =
         region r {
-            let a = [new MutMap(Static); 8];
+            let a = [new MutMap(r); 8];
             MutMap.put!(1, 1, a[0]);
             MutMap.get(1, a[0]) == Some(1)
         }
 
     @test
-    def testRegions1Region1Nested02(): Bool \ IO =
+    def testRegions1Region1Nested02(): Bool =
         region r {
             let l = new MutList(r);
-            MutList.push!([1; 8] @ Static, l);
+            MutList.push!([1; 8] @ r, l);
             match MutList.pop!(l) {
                 case Some(a) => a `Array.sameElements` [1; 8]
                 case _       => unreachable!()
@@ -120,10 +48,10 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions1Region1Nested03(): Bool \ IO =
+    def testRegions1Region1Nested03(): Bool =
         region r {
             let m = new MutMap(r);
-            let l = new MutList(Static);
+            let l = new MutList(r);
             MutList.push!(1, l);
             MutMap.put!(1, l, m);
             match MutMap.get(1, m) {
@@ -259,83 +187,83 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions2Regions01(): Bool \ IO =
-        region _ {
-            let a1 = [1; 8] @ Static;
+    def testRegions2Regions01(): Bool =
+        region r {
+            let a1 = [1; 8] @ r;
             a1[0] == 1 and 1 ==
             region _ {
-                let a2 = [1; 8] @ Static;
+                let a2 = [1; 8] @ r;
                 a2[0]
             }
         }
 
     @test
-    def testRegions2Regions02(): Bool \ IO =
-        region _ {
-            let l1 = new MutList(Static);
+    def testRegions2Regions02(): Bool =
+        region r {
+            let l1 = new MutList(r);
             MutList.push!(1, l1);
             MutList.pop!(l1) == Some(1) and Some(1) ==
             region _ {
-                let l2 = new MutList(Static);
+                let l2 = new MutList(r);
                 MutList.push!(1, l2);
                 MutList.pop!(l2)
             }
         }
 
     @test
-    def testRegions2Regions03(): Bool \ IO =
-        region _ {
-            let m1 = new MutMap(Static);
+    def testRegions2Regions03(): Bool =
+        region r {
+            let m1 = new MutMap(r);
             MutMap.put!(1, 1, m1);
             MutMap.get(1, m1) == Some(1) and Some(1) ==
             region _ {
-                let m2 = new MutMap(Static);
+                let m2 = new MutMap(r);
                 MutMap.put!(1, 1, m2);
                 MutMap.get(1, m2)
             }
         }
 
     @test
-    def testRegions2Regions04(): Bool \ IO =
+    def testRegions2Regions04(): Bool =
         region r1 {
             let a1 = [1; 8] @ r1;
             a1[0] == 1 and 1 ==
             region _ {
-                let a2 = [1; 8] @ Static;
+                let a2 = [1; 8] @ r1;
                 a2[0]
             }
         }
 
     @test
-    def testRegions2Regions05(): Bool \ IO =
+    def testRegions2Regions05(): Bool =
         region r1 {
             let l1 = new MutList(r1);
             MutList.push!(1, l1);
             MutList.pop!(l1) == Some(1) and Some(1) ==
             region _ {
-                let l2 = new MutList(Static);
+                let l2 = new MutList(r1);
                 MutList.push!(1, l2);
                 MutList.pop!(l2)
             }
         }
 
     @test
-    def testRegions2Regions06(): Bool \ IO =
+    def testRegions2Regions06(): Bool =
         region r1 {
             let m1 = new MutMap(r1);
             MutMap.put!(1, 1, m1);
             MutMap.get(1, m1) == Some(1) and Some(1) ==
             region _ {
-                let m2 = new MutMap(Static);
+                let m2 = new MutMap(r1);
                 MutMap.put!(1, 1, m2);
                 MutMap.get(1, m2)
             }
         }
 
     @test
-    def testRegions2Regions07(): Bool \ IO =
-        region _ {
-            let a1 = [1; 8] @ Static;
+    def testRegions2Regions07(): Bool =
+        region r {
+            let a1 = [1; 8] @ r;
             a1[0] == 1 and 1 ==
             region r2 {
                 let a2 = [1; 8] @ r2;
@@ -344,9 +272,9 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions2Regions08(): Bool \ IO =
-        region _ {
-            let l1 = new MutList(Static);
+    def testRegions2Regions08(): Bool =
+        region r {
+            let l1 = new MutList(r);
             MutList.push!(1, l1);
             MutList.pop!(l1) == Some(1) and Some(1) ==
             region r2 {
@@ -357,9 +285,9 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions2Regions09(): Bool \ IO =
-        region _ {
-            let m1 = new MutMap(Static);
+    def testRegions2Regions09(): Bool =
+        region r {
+            let m1 = new MutMap(r);
             MutMap.put!(1, 1, m1);
             MutMap.get(1, m1) == Some(1) and Some(1) ==
             region r2 {
@@ -616,13 +544,13 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions3Regions01(): Bool \ IO =
+    def testRegions3Regions01(): Bool =
         region r1 {
             let a = [1; 8] @ r1;
             region r2 {
                 let l = new MutList(r2);
                 region _ {
-                    let m = new MutMap(Static);
+                    let m = new MutMap(r1);
                     MutList.push!(1, l);
                     MutMap.put!(1, 1, m);
                     a[0] == 1 and MutList.pop!(l) == Some(1) and MutMap.get(1, m) == Some(1)
@@ -631,9 +559,9 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions3Regions02(): Bool \ IO =
-        region _ {
-            let a = [1; 8] @ Static;
+    def testRegions3Regions02(): Bool =
+        region r {
+            let a = [1; 8] @ r;
             region r2 {
                 let l = new MutList(r2);
                 region r3 {
@@ -646,11 +574,11 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions3Regions03(): Bool \ IO =
+    def testRegions3Regions03(): Bool =
         region r1 {
             let a = [1; 8] @ r1;
             region _ {
-                let l = new MutList(Static);
+                let l = new MutList(r1);
                 region r3 {
                     let m = new MutMap(r3);
                     MutList.push!(1, l);
@@ -676,10 +604,10 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions3Regions1Nested01(): Bool \ IO =
-        region _ {
+    def testRegions3Regions1Nested01(): Bool =
+        region r {
             region r2 {
-                let a: Array[MutList[Int32, Static], r2] = [new MutList(Static); 8] @ r2;
+                let a: Array[MutList[Int32, r], r2] = [new MutList(r); 8] @ r2;
                 region _ {
                     MutList.push!(1, a[0]);
                     MutList.pop!(a[0]) == Some(1)
@@ -688,10 +616,10 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions3Regions1Nested02(): Bool \ IO =
+    def testRegions3Regions1Nested02(): Bool =
         region r1 {
-            region _ {
-                let l: MutList[MutMap[Int32, Int32, r1], Static] = new MutList(Static);
+            region r2 {
+                let l: MutList[MutMap[Int32, Int32, r1], r2] = new MutList(r2);
                 region _ {
                     let m = new MutMap(r1);
                     MutList.push!(m, l);
@@ -722,11 +650,11 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions3Regions2Nested01(): Bool \ IO =
-        region _ {
+    def testRegions3Regions2Nested01(): Bool =
+        region r {
             region r2 {
                 region r3 {
-                    let a: Array[MutMap[Int32, MutList[Int32, r3], r2], Static] = [Reflect.default(); 8] @ Static;
+                    let a: Array[MutMap[Int32, MutList[Int32, r3], r2], r] = [Reflect.default(); 8] @ r;
                     let m = new MutMap(r2);
                     let l = new MutList(r3);
                     MutList.push!(1, l);
@@ -775,14 +703,14 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions3Regions3Nested01(): Bool \ IO =
+    def testRegions3Regions3Nested01(): Bool =
         region r1 {
             let l = new MutList(r1);
             region r2 {
                 region r3 {
-                    let a: Array[MutMap[Int32, MutList[Array[Int32, Static], r1], r2], r3] = [new MutMap(r2); 8] @ r3;
+                    let a: Array[MutMap[Int32, MutList[Array[Int32, r1], r1], r2], r3] = [new MutMap(r2); 8] @ r3;
                     MutMap.put!(1, l, a[0]);
-                    MutList.push!([1; 8] @ Static, l);
+                    MutList.push!([1; 8] @ r1, l);
                     match MutMap.get(1, a[0]) {
                         case Some(k) => MutList.nth(0, k) |> Option.flatMap(Array.nth(0)) == Some(1)
                         case _       => unreachable!()
@@ -833,40 +761,16 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions0RegionsReferences01(): Ref[Array[Int32, Static], Static] \ IO =
-        ref []
-
-    @test
-    def testRegions0RegionsReferences02(): Ref[MutList[Int32, Static], Static] \ IO =
-        ref new MutList(Static)
-
-    @test
-    def testRegions0RegionsReferences03(): Ref[MutMap[Int32, Int32, Static], Static] \ IO =
-        ref new MutMap(Static)
-
-    @test
-    def testRegions0RegionsReferences04(): Ref[Ref[Array[Int32, Static], Static], Static] \ IO =
-        ref ref []
-
-    @test
-    def testRegions0RegionsReferences05(): Ref[Ref[Ref[MutList[Int32, Static], Static], Static], Static] \ IO =
-        ref ref ref new MutList(Static)
-
-    @test
-    def testRegions0RegionsReferences06(): Ref[MutMap[Ref[Int32, Static], Ref[Array[Ref[Int32, Static], Static], Static], Static], Static] \ IO =
-        ref new MutMap(Static)
-
-    @test
-    def testRegions1RegionReferences01(): Bool \ IO =
+    def testRegions1RegionReferences01(): Bool =
         region r {
-            let a = ref ([1; 8] @ r) @ Static;
+            let a = ref ([1; 8] @ r) @ r;
             (deref a)[0] == 1
         }
 
     @test
-    def testRegions1RegionReferences02(): Bool \ IO =
+    def testRegions1RegionReferences02(): Bool =
         region r {
-            let a = [ref 1 @ Static; 8];
+            let a = [ref 1 @ r; 8];
             deref a[0] == 1
         }
 
@@ -894,18 +798,18 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions1Region1NestedReferences01(): Bool \ IO =
+    def testRegions1Region1NestedReferences01(): Bool =
         region r {
-            let a = ref ([new MutMap(Static); 8]) @ Static;
+            let a = ref ([new MutMap(r); 8]) @ r;
             MutMap.put!(1, 1, (deref a)[0]);
             MutMap.get(1, (deref a)[0]) == Some(1)
         }
 
     @test
-    def testRegions1Region1NestedReferences02(): Bool \ IO =
+    def testRegions1Region1NestedReferences02(): Bool =
         region r {
-            let l = ref new MutList(r) @ Static; // Static reference to a MutList in region r
-            MutList.push!(ref ([1; 8] @ Static) @ Static, deref l);
+            let l = ref new MutList(r) @ r; 
+            MutList.push!(ref ([1; 8] @ r) @ r, deref l);
             match MutList.pop!(deref l) {
                 case Some(a) => (deref a) `Array.sameElements` [1; 8]
                 case _       => unreachable!()
@@ -913,10 +817,10 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions1Region1NestedReferences03(): Bool \ IO =
+    def testRegions1Region1NestedReferences03(): Bool =
         region r {
             let m = new MutMap(r);
-            let l = ref new MutList(Static) @ r;
+            let l = ref new MutList(r) @ r;
             MutList.push!(1, deref l);
             MutMap.put!(1, l, m);
             match MutMap.get(1, m) {
@@ -945,10 +849,10 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions1Region2NestedReferences01(): Bool \ IO =
+    def testRegions1Region2NestedReferences01(): Bool =
         region r {
-            let a = ref [ref new MutMap(r) @ Static; 8] @ Static;
-            let l = ref new MutList(r) @ Static;
+            let a = ref [ref new MutMap(r) @ r; 8] @ r;
+            let l = ref new MutList(r) @ r;
             MutList.push!(1, deref l);
             MutMap.put!(1, l, deref (deref a)[0]);
             match MutMap.get(1, deref (deref a)[0]) {
@@ -958,9 +862,9 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions1Region2NestedReferences02(): Bool \ IO =
+    def testRegions1Region2NestedReferences02(): Bool =
         region r {
-            let l = ref new MutList(r) @ Static;
+            let l = ref new MutList(r) @ r;
             let a = ref [ref new MutMap(r) @ r; 8] @ r @ r;
             MutMap.put!(1, 1, deref (deref a)[0]);
             MutList.push!(a, deref l);
@@ -987,11 +891,11 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions1Region3NestedReferences01(): Bool \ IO =
+    def testRegions1Region3NestedReferences01(): Bool =
         region r {
-            let a = ref [ref new MutMap(r) @ Static; 8] @ r @ Static;
-            let l = ref new MutList(r) @ Static;
-            MutList.push!(ref [1; 8] @ r @ Static, deref l);
+            let a = ref [ref new MutMap(r) @ r; 8] @ r @ r;
+            let l = ref new MutList(r) @ r;
+            MutList.push!(ref [1; 8] @ r @ r, deref l);
             MutMap.put!(1, l, deref (deref a)[0]);
             match MutMap.get(1, deref (deref a)[0]) {
                 case Some(k) => match MutList.pop!(deref k) {
@@ -1003,11 +907,11 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions1Region3NestedReferences02(): Bool \ IO =
+    def testRegions1Region3NestedReferences02(): Bool =
         region r {
             let l = ref new MutList(r) @ r;
             let a = ref [ref new MutMap(r) @ r; 8] @ r @ r;
-            let l1 = ref new MutList(r) @ Static;
+            let l1 = ref new MutList(r) @ r;
             MutList.push!(1, deref l1);
             MutMap.put!(1, l1, deref (deref a)[0]);
             MutList.push!(a, deref l);
@@ -1039,12 +943,12 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions2RegionsReferences01(): Bool \ IO =
+    def testRegions2RegionsReferences01(): Bool =
         region r1 {
             let a1 = ref [1; 8] @ r1 @ r1;
             (deref a1)[0] == 1 and 1 ==
             region _ {
-                let a2 = ref [1; 8] @ Static @ r1;
+                let a2 = ref [1; 8] @ r1 @ r1;
                 (deref a2)[0]
             }
         }
@@ -1255,13 +1159,13 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions3RegionsReferences01(): Bool \ IO =
+    def testRegions3RegionsReferences01(): Bool =
         region r1 {
-            let a = ref [1; 8] @ r1 @ Static;
+            let a = ref [1; 8] @ r1 @ r1;
             region r2 {
                 let l = ref new MutList(r2) @ r1;
                 region _ {
-                    let m = ref new MutMap(Static) @ r2;
+                    let m = ref new MutMap(r1) @ r2;
                     MutList.push!(1, deref l);
                     MutMap.put!(1, 1, deref m);
                     (deref a)[0] == 1 and MutList.pop!(deref l) == Some(1) and MutMap.get(1, deref m) == Some(1)
@@ -1270,9 +1174,9 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions3RegionsReferences02(): Bool \ IO =
-        region _ {
-            let a = ref [1; 8] @ Static @ Static;
+    def testRegions3RegionsReferences02(): Bool =
+        region r {
+            let a = ref [1; 8] @ r @ r;
             region r2 {
                 let l = ref new MutList(r2) @ r2;
                 region r3 {
@@ -1285,11 +1189,11 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions3RegionsReferences03(): Bool \ IO =
+    def testRegions3RegionsReferences03(): Bool =
         region r1 {
             let a = ref [1; 8] @ r1 @ r1;
             region _ {
-                let l = ref new MutList(Static) @ r1;
+                let l = ref new MutList(r1) @ r1;
                 region r3 {
                     let m = ref new MutMap(r3) @ r1;
                     MutList.push!(1, deref l);
@@ -1315,10 +1219,10 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions3Regions1NestedReferences01(): Bool \ IO =
-        region _ {
+    def testRegions3Regions1NestedReferences01(): Bool =
+        region r {
             region r2 {
-                let a: Ref[Array[Ref[MutList[Int32, Static], r2], r2], r2] = ref [ref new MutList(Static) @ r2; 8] @ r2 @ r2;
+                let a: Ref[Array[Ref[MutList[Int32, r], r2], r2], r2] = ref [ref new MutList(r) @ r2; 8] @ r2 @ r2;
                 region _ {
                     MutList.push!(1, deref (deref a)[0]);
                     MutList.pop!(deref (deref a)[0]) == Some(1)
@@ -1327,12 +1231,12 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions3Regions1NestedReferences02(): Bool \ IO =
+    def testRegions3Regions1NestedReferences02(): Bool =
         region r1 {
             region _ {
-                let l: Ref[MutList[Ref[MutMap[Int32, Int32, r1], Static], Static], r1] = ref new MutList(Static) @ r1;
+                let l: Ref[MutList[Ref[MutMap[Int32, Int32, r1], r1], r1], r1] = ref new MutList(r1) @ r1;
                 region _ {
-                    let m = ref new MutMap(r1) @ Static;
+                    let m = ref new MutMap(r1) @ r1;
                     MutList.push!(m, deref l);
                     MutMap.put!(1, 1, deref m);
                     match MutList.pop!(deref l) {
@@ -1361,13 +1265,13 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions3Regions2NestedReferences01(): Bool \ IO =
-        region _ {
+    def testRegions3Regions2NestedReferences01(): Bool =
+        region r {
             region r2 {
                 region r3 {
-                    let a: Ref[Array[Ref[MutMap[Int32, Ref[MutList[Int32, r3], Static], r2], r3], Static], r2] = ref [Reflect.default(); 8] @ Static @ r2;
+                    let a: Ref[Array[Ref[MutMap[Int32, Ref[MutList[Int32, r3], r], r2], r3], r], r2] = ref [Reflect.default(); 8] @ r @ r2;
                     let m = ref new MutMap(r2) @ r3;
-                    let l = ref new MutList(r3) @ Static;
+                    let l = ref new MutList(r3) @ r;
                     MutList.push!(1, deref l);
                     MutMap.put!(1, l, deref m);
                     (deref a)[0] = m;
@@ -1414,14 +1318,14 @@ namespace Test/Exp/Regions {
         }
 
     @test
-    def testRegions3Regions3NestedReferences01(): Bool \ IO =
+    def testRegions3Regions3NestedReferences01(): Bool =
         region r1 {
             region r2 {
                 let l = ref new MutList(r1) @ r2;
                 region r3 {
-                    let a: Ref[Array[Ref[MutMap[Int32, Ref[MutList[Ref[Array[Int32, Static], r1], r1], r2], r2], r3], r3], Static] = ref [ref new MutMap(r2) @ r3; 8] @ r3 @ Static;
+                    let a: Ref[Array[Ref[MutMap[Int32, Ref[MutList[Ref[Array[Int32, r1], r1], r1], r2], r2], r3], r3], r1] = ref [ref new MutMap(r2) @ r3; 8] @ r3 @ r1;
                     MutMap.put!(1, l, deref (deref a)[0]);
-                    MutList.push!(ref [1; 8] @ Static @ r1, deref l);
+                    MutList.push!(ref [1; 8] @ r1 @ r1, deref l);
                     match MutMap.get(1, deref (deref a)[0]) {
                         case Some(k) => MutList.nth(0, deref k) |> Option.flatMap(arr -> Array.nth(0, deref arr)) == Some(1)
                         case _       => unreachable!()
@@ -1494,7 +1398,7 @@ namespace Test/Exp/Regions {
         }
 
     @test
-     def testRegionExit01(): Bool \ IO = 
+     def testRegionExit01(): Bool = 
          let x  = ref false;
          region r {
              spawn { Thread.sleep(Time/Duration.fromSeconds(1)); x := true } @ r


### PR DESCRIPTION
As per #5131

In some of these cases, I've chosen to delete tests referring to `Static` rather than rewrite them becase they already seem to be covered elsewhere.

I probably could have deleted more of the tests within `Test.Exp.Regions.flix` because they seem to be explicitly testing `Static` but erred on the side of caution.