### PR TITLE
chore: Towards removing Static from Channel code

### DIFF
--- a/main/src/library/Concurrent/Channel.flix
+++ b/main/src/library/Concurrent/Channel.flix
@@ -79,14 +79,14 @@ namespace Concurrent/Channel {
     /// structure on which select can operate.
     ///
     @Internal
-    pub enum Mpmc[a](
-        MpmcAdmin, // admin
-        MutDeque[a, Static] // elementDeque
+    pub enum Mpmc[a: Type, r: Region](
+        MpmcAdmin[r], // admin
+        MutDeque[a, r] // elementDeque
     )
 
     /// Returns the `MpmcAdmin` of `c`.
     @Internal
-    pub def mpmcAdmin(c: Mpmc[a]): MpmcAdmin = {
+    pub def mpmcAdmin(c: Mpmc[a, r]): MpmcAdmin[r] = {
         let Mpmc.Mpmc(admin, _) = c;
         admin
     }
@@ -118,13 +118,13 @@ namespace Concurrent/Channel {
     ///       The condition is notified after each new element. Available space
     ///       is not guaranteed when notified.
     /// )
-    enum MpmcAdmin(
+    enum MpmcAdmin[r: Region](
         Int64, // id
         ReentrantLock, // channelLock
         Bool, // unBuffered
         Int32, // maxSize
-        Ref[Int32, Static], // size
-        MutList[(ReentrantLock, Condition), Static], // waitingGetters
+        Ref[Int32, r], // size
+        MutList[(ReentrantLock, Condition), r], // waitingGetters
         CyclicBarrier, // rendezvous
         Condition // waitingPutters
     )
@@ -135,12 +135,12 @@ namespace Concurrent/Channel {
     /// receiving is syncronized.
     ///
     @Internal
-    pub def newChannel(bufferSize: Int32): Mpmc[a] \ IO =
+    pub def newChannel(r: Region[r], bufferSize: Int32): Mpmc[a, r] \ IO =
         import static dev.flix.runtime.Global.newId(): Int64 \ IO;
         let _bufferCheck = if (bufferSize < 0) bug!("bufferSize < 0") else ();
         let unBuffered = bufferSize == 0;
         let reentrantLock = newLock(fairness());
-        let size = ref 0;
+        let size = ref 0 @ r;
         Mpmc.Mpmc(
             MpmcAdmin.MpmcAdmin(
                 newId(),
@@ -148,19 +148,19 @@ namespace Concurrent/Channel {
                 unBuffered,
                 if (unBuffered) 1 else bufferSize,
                 size,
-                new MutList(Static),
+                new MutList(r),
                 newCyclicBarrier(2),
                 newCondition(reentrantLock)
             ),
-            new MutDeque(Static)
+            new MutDeque(r)
         )
 
     ///
     /// Creates a new channel tuple (sender, receiver)
     ///
     @Internal
-    pub def newChannelTuple(bufferSize: Int32): (Mpmc[a], Mpmc[a]) \ IO =
-        let c = newChannel(bufferSize);
+    pub def newChannelTuple(r: Region[r], bufferSize: Int32): (Mpmc[a, r], Mpmc[a, r]) \ IO =
+        let c = newChannel(r, bufferSize);
         (c, c)
 
     ///
@@ -170,7 +170,7 @@ namespace Concurrent/Channel {
     /// Implements the expression `c <- e`.
     ///
     @Internal
-    pub def put(e: a, c: Mpmc[a]): Unit \ IO =
+    pub def put(e: a, c: Mpmc[a, r]): Unit \ IO =
         let Mpmc.Mpmc(admin, elementDeque) = c;
         let MpmcAdmin.MpmcAdmin(_, channelLock, unBuffered, _, size, _, rendezvous, _) = admin;
         lock(channelLock);
@@ -199,7 +199,7 @@ namespace Concurrent/Channel {
     /// Implements to the expression `<- c`.
     ///
     @Internal
-    pub def get(c: Mpmc[a]): a \ IO =
+    pub def get(c: Mpmc[a, r]): a \ IO =
         let MpmcAdmin.MpmcAdmin(_, channelLock, _, _, _, _, _, _) = mpmcAdmin(c);
         lock(channelLock);
 
@@ -212,7 +212,7 @@ namespace Concurrent/Channel {
     /// Assumes the channel to be non-empty.
     ///
     @Internal
-    pub def unsafeGetAndUnlock(c: Mpmc[a], locks: List[ReentrantLock]): a \ IO = {
+    pub def unsafeGetAndUnlock(c: Mpmc[a, r], locks: List[ReentrantLock]): a \ IO = {
         let Mpmc.Mpmc(admin, elementDeque) = c;
         let MpmcAdmin.MpmcAdmin(_, channelLock, _, _, size, _, _, _) = admin;
         lock(channelLock);
@@ -252,7 +252,7 @@ namespace Concurrent/Channel {
     ///
     @Internal
     pub def selectFrom(
-        channels: List[MpmcAdmin],
+        channels: List[MpmcAdmin[r]],
         blocking: Bool
     ): (Int32, List[ReentrantLock]) \ IO =
         // Create a new lock and condition for this select. The condition is
@@ -277,7 +277,7 @@ namespace Concurrent/Channel {
     /// The channel lock is expected to be held.
     ///
     @Internal
-    def awaitAvailableSpace(c: MpmcAdmin): Unit \ IO =
+    def awaitAvailableSpace(c: MpmcAdmin[r]): Unit \ IO =
         let MpmcAdmin.MpmcAdmin(_, _, _, maxSize, size, _, _, waitingPutters) = c;
         if ((deref size) == maxSize) {
             awaitCondition(waitingPutters);
@@ -295,7 +295,7 @@ namespace Concurrent/Channel {
     ///
     /// The channel lock is expected to be held, and will be unlocked on return.
     ///
-    def getHelper(c: Mpmc[a]): a \ IO =
+    def getHelper(c: Mpmc[a, r]): a \ IO =
         let Mpmc.Mpmc(admin, elementDeque) = c;
         let MpmcAdmin.MpmcAdmin(_, channelLock, _, _, size, waitingGetters, _, _) = admin;
 
@@ -343,7 +343,7 @@ namespace Concurrent/Channel {
     /// otherwise this blocks.
     ///
     def selectHelper(
-        channels: List[MpmcAdmin],
+        channels: List[MpmcAdmin[r]],
         blocking: Bool,
         sortedLocks: List[ReentrantLock],
         selectLock: ReentrantLock,
@@ -409,7 +409,7 @@ namespace Concurrent/Channel {
     /// Add a condition to the list of waiting getters.
     /// The channel lock is expected to be held.
     ///
-    def addGetter(l: ReentrantLock, cond: Condition, c: MpmcAdmin): Unit \ IO =
+    def addGetter(l: ReentrantLock, cond: Condition, c: MpmcAdmin[r]): Unit \ Write(r) =
         let MpmcAdmin.MpmcAdmin(_, _, _, _, _, waitingGetters, _, _) = c;
         MutList.push!((l, cond), waitingGetters)
 
@@ -417,7 +417,7 @@ namespace Concurrent/Channel {
     /// Signals and clears the waiting getters.
     /// The channel lock is expected to be held.
     ///
-    def signalGetters(c: MpmcAdmin): Unit \ IO =
+    def signalGetters(c: MpmcAdmin[r]): Unit \ IO =
         let MpmcAdmin.MpmcAdmin(_, _, _, _, _, waitingGetters, _, _) = c;
 
         // Signal waitingGetters that there is an element available
@@ -437,7 +437,7 @@ namespace Concurrent/Channel {
     /// Signals and clears the waiting putters.
     /// The channel lock is expected to be held, and will be unlocked on return.
     ///
-    def onGetComplete(c: MpmcAdmin): Unit \ IO =
+    def onGetComplete(c: MpmcAdmin[r]): Unit \ IO =
         let MpmcAdmin.MpmcAdmin(_, channelLock, unBuffered, _, _, _, rendezvous, waitingPutters) = c;
 
         // In the unbuffered case, rendezvous with the putter from which we just received a value.

--- a/main/test/ca/uwaterloo/flix/library/TestChannel.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestChannel.flix
@@ -26,32 +26,35 @@
     use Concurrent/Channel.selectFrom
 
     @test
-    def testNew01(): Mpmc[Int32] \ IO = newChannel(0)
+    def testNew01(): Unit \ IO = region r { discard newChannel(r, 0) }
 
     @test
-    def testNew02(): Mpmc[Result[String, a]] \ IO = newChannel(32)
+    def testNew02(): Unit \ IO = region r { discard newChannel(r, 32) }
 
     @test
-    def testGetPut01(): Bool \ IO =
-        let c = newChannel(1);
+    def testGetPut01(): Bool \ IO = region r {
+        let c = newChannel(r, 1);
         put(true, c);
         get(c)
+    }
 
     @test
-    def testGetPut02(): Bool \ IO =
-        let c = newChannel(1);
+    def testGetPut02(): Bool \ IO = region r {
+        let c = newChannel(r, 1);
         put(123, c);
         get(c) == 123
+    }
 
     @test
-    def testGetPut03(): Bool \ IO =
-        let c = newChannel(1);
+    def testGetPut03(): Bool \ IO = region r {
+        let c = newChannel(r, 1);
         put("Hello World!", c);
         get(c) == "Hello World!"
+    }
 
     @test
-    def testSelect01(): Bool \ IO =
-        let c = newChannel(1);
+    def testSelect01(): Bool \ IO = region r {
+        let c = newChannel(r, 1);
         put(2, c);
         match selectFrom(mpmcAdmin(c) :: Nil, true) {
             case (0, locks) =>
@@ -59,10 +62,11 @@
                 i == 2
             case _ => unreachable!()
         }
+    }
 
     @test
-    def testSelect02(): Bool \ IO =
-        let c = newChannel(1);
+    def testSelect02(): Bool \ IO = region r {
+        let c = newChannel(r, 1);
         match selectFrom(mpmcAdmin(c) :: Nil, false) {
             case (0, locks) =>
                 let _ = unsafeGetAndUnlock(c, locks);
@@ -71,11 +75,12 @@
                 true
             case _ => unreachable!()
         }
+    }
 
     @test
-    def testSelect03(): Bool \ IO =
-        let c1: Mpmc[Int32] = newChannel(0);
-        let c2: Mpmc[String] = newChannel(10);
+    def testSelect03(): Bool \ IO = region r {
+        let c1: Mpmc[Int32, r] = newChannel(r, 0);
+        let c2: Mpmc[String, r] = newChannel(r, 10);
 
         put("hey", c2);
 
@@ -88,5 +93,25 @@
                 s == "hey"
             case _ => unreachable!()
         }
+    }
 
+    @test
+    def testSelect04(): Bool \ IO = region r1 {
+        region r2 {
+            let c1: Mpmc[Int32, r1] = newChannel(r1, 0);
+            let c2: Mpmc[String, r2] = newChannel(r2, 10);
+
+            put("hey", c2);
+
+            match selectFrom(mpmcAdmin(c1) :: mpmcAdmin(c2) :: Nil, true) {
+                case (0, locks) =>
+                    let _ = unsafeGetAndUnlock(c1, locks);
+                    bug!("The channel should be empty")
+                case (1, locks) =>
+                    let s = unsafeGetAndUnlock(c2, locks);
+                    s == "hey"
+                case _ => unreachable!()
+            }
+        }
+    }
 }

--- a/main/test/flix/Test.Exp.Concurrency.Select.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Select.flix
@@ -9,452 +9,452 @@ namespace Test/Exp/Concurrency/Select {
         }
     }
 
-    @test
-    def testSelectBuffered02(): Bool \ IO = region r {
-        let (tx1, rx1) = Channel.buffered(r, 1);
-        let (tx2, rx2) = Channel.buffered(r, 1);
-        spawn Channel.send(1, tx1) @ r;
-        spawn Channel.send(2, tx2) @ r;
-        select {
-            case x <- recv(rx1) => x == 1
-            case x <- recv(rx2) => x == 2
-        }
-    }
-
-    @test
-    def testSelectBuffered03(): Bool \ IO = region r {
-        let (tx1, rx1) = Channel.buffered(r, 1);
-        let (tx2, rx2) = Channel.buffered(r, 1);
-        let (tx3, rx3) = Channel.buffered(r, 1);
-        spawn Channel.send(1, tx1) @ r;
-        spawn Channel.send(2, tx2) @ r;
-        spawn Channel.send(3, tx3) @ r;
-        select {
-            case x <- recv(rx1) => x == 1
-            case x <- recv(rx2) => x == 2
-            case x <- recv(rx3) => x == 3
-        }
-    }
-
-    @test
-    def testSelectBuffered04(): Bool \ IO = region r {
-        let (tx1, rx1) = Channel.buffered(r, 1);
-        let (tx2, rx2) = Channel.buffered(r, 1);
-        let (tx3, rx3) = Channel.buffered(r, 1);
-        let (tx4, rx4) = Channel.buffered(r, 1);
-        spawn Channel.send(1, tx1) @ r;
-        spawn Channel.send(2, tx2) @ r;
-        spawn Channel.send(3, tx3) @ r;
-        spawn Channel.send(4, tx4) @ r;
-        select {
-            case x <- recv(rx1) => x == 1
-            case x <- recv(rx1) => x == 1
-            case x <- recv(rx2) => x == 2
-            case x <- recv(rx2) => x == 2
-            case x <- recv(rx3) => x == 3
-            case x <- recv(rx3) => x == 3
-            case x <- recv(rx4) => x == 4
-            case x <- recv(rx4) => x == 4
-        }
-    }
-
-    @test
-    def testSelectBuffered05(): Bool \ IO = region r {
-        let (tx1, rx1) = Channel.buffered(r, 1);
-        let (tx2, rx2) = Channel.buffered(r, 1);
-        let (tx3, rx3) = Channel.buffered(r, 1);
-        let (tx4, rx4) = Channel.buffered(r, 1);
-        spawn Channel.send(1, tx1) @ r;
-        spawn Channel.send(2, tx2) @ r;
-        spawn Channel.send(3, tx3) @ r;
-        spawn Channel.send(4, tx4) @ r;
-        select {
-            case x <- recv(rx4) => x == 4
-            case x <- recv(rx3) => x == 3
-            case x <- recv(rx2) => x == 2
-            case x <- recv(rx1) => x == 1
-            case x <- recv(rx4) => x == 4
-            case x <- recv(rx3) => x == 3
-            case x <- recv(rx2) => x == 2
-            case x <- recv(rx1) => x == 1
-        }
-    }
-
-    @test
-    def testSelectBuffered06(): Bool \ IO = region r {
-        let (_, rx1) = Channel.buffered(r, 1);
-        let (tx2, rx2) = Channel.buffered(r, 1);
-        let (_, rx3) = Channel.buffered(r, 1);
-        let (_, rx4) = Channel.buffered(r, 1);
-        spawn Channel.send(1, tx2) @ r;
-        select {
-            case _ <- recv(rx4) => false
-            case _ <- recv(rx3) => false
-            case x <- recv(rx2) => x == 1
-            case _ <- recv(rx1) => false
-        }
-    }
-
-    @test
-    def testSelectBuffered07(): Bool \ IO = region r {
-        let (tx1, rx1) = Channel.buffered(r, 1);
-        let (tx2, rx2) = Channel.buffered(r, 1);
-        let (tx3, rx3) = Channel.buffered(r, 1);
-        let (tx4, rx4) = Channel.buffered(r, 1);
-        spawn Channel.send(1i8, tx1) @ r;
-        spawn Channel.send(2i16, tx2) @ r;
-        spawn Channel.send(3i32, tx3) @ r;
-        spawn Channel.send(4i64, tx4) @ r;
-        select {
-            case x <- recv(rx4) => x == 4i64
-            case x <- recv(rx3) => x == 3i32
-            case x <- recv(rx2) => x == 2i16
-            case x <- recv(rx1) => x == 1i8
-        }
-    }
-
-    @test
-    def testSelectDefault01(): Bool = region r {
-        select {
-            case x <- recv({let (_, rx) = Channel.buffered(r, 1); rx}) => x
-            case _                                                     => true
-        }
-    }
-
-    @test
-    def testSelectDefault02(): Bool = region r {
-        (1 + select {
-            case _ <- recv({let (_, rx) = Channel.buffered(r, 2); rx}) => 2
-            case _                                                     => 1
-        }) == 2
-    }
-
-    def recvWithDefault(rx: Receiver[Int32, r]): Int32 \ { Read(r), Write(r) } = {
-        select {
-            case x <- Channel.recv(rx) => x
-            case _                     => 1
-        }
-    }
-
-    def mainx(): Int32 \ IO = {
-      let (_, rx) = Channel.buffered(Static, 1);
-      recvWithDefault(rx)
-    }
-
-    @test
-    def testSelectDefault03(): Unit \ IO =
-      // This test is from a bug report so its form is subtle and intentional
-      unsafe_cast println(mainx()) as _ \ IO
-
-    @test
-    def testSelectRandom01(): Unit \ IO = region r {
-        let (tx9, rx9) = Channel.buffered(r, 0);
-        let (tx10, rx10) = Channel.buffered(r, 0);
-        let (tx11, rx11) = Channel.buffered(r, 0);
-        let (tx12, rx12) = Channel.buffered(r, 0);
-        let (tx13, rx13) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx13) ; () } @ r; spawn { Channel.send((), tx12) ; () } @ r; spawn { Channel.send((), tx11) ; () } @ r; spawn { Channel.send((), tx10) ; () } @ r; spawn { Channel.send((), tx9) ; () } @ r; select {
-        case _ <- recv(rx13) => select {
-        case _ <- recv(rx11) => ()
-        case _ <- recv(rx11) => ()
-        } ; Channel.recv(rx9) ; Channel.recv(rx10) ; Channel.recv(rx12) ; let (tx42, rx42) = Channel.buffered(r, 0);
-        let (tx43, rx43) = Channel.buffered(r, 0);
-        let (tx44, rx44) = Channel.buffered(r, 0);
-        let (tx45, rx45) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx45) ; () } @ r; spawn { Channel.send((), tx44) ; () } @ r; spawn { Channel.send((), tx43) ; () } @ r; spawn { Channel.send((), tx42) ; () } @ r; select {
-        case _ <- recv(rx43) => Channel.recv(rx42) ; Channel.recv(rx44) ; Channel.recv(rx45)
-        case _ <- recv(rx42) => Channel.recv(rx45) ; Channel.recv(rx43) ; Channel.recv(rx44) ; ()
-        }
-        case _ <- recv(rx13) => select {
-        case _ <- recv(rx11) => ()
-        case _ <- recv(rx11) => ()
-        } ; Channel.recv(rx9) ; Channel.recv(rx10) ; Channel.recv(rx12) ; let (tx42, rx42) = Channel.buffered(r, 0);
-        let (tx43, rx43) = Channel.buffered(r, 0);
-        let (tx44, rx44) = Channel.buffered(r, 0);
-        let (tx45, rx45) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx45) ; () } @ r; spawn { Channel.send((), tx44) ; () } @ r; spawn { Channel.send((), tx43) ; () } @ r; spawn { Channel.send((), tx42) ; () } @ r; select {
-        case _ <- recv(rx43) => Channel.recv(rx42) ; Channel.recv(rx44) ; Channel.recv(rx45) ; ()
-        case _ <- recv(rx42) => Channel.recv(rx45) ; Channel.recv(rx43) ; Channel.recv(rx44)
-        }
-        };
-        ()
-    }
-
-    @test
-    def testSelectRandom02(): Unit \ IO = region r {
-        let (tx10, rx10) = Channel.buffered(r, 0);
-        let (tx11, rx11) = Channel.buffered(r, 0);
-        let (tx12, rx12) = Channel.buffered(r, 0);
-        let (tx13, rx13) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx13) ; () } @ r; spawn { Channel.send((), tx12) ; () } @ r; if (false) { spawn { Channel.send((), tx11) ; () } @ r; spawn { Channel.send((), tx10) ; () } @ r; if (true) { () } else { () } } else { spawn { Channel.send((), tx11) ; () } @ r; spawn { Channel.send((), tx10) ; () } @ r; if (true) { () } else { () } } ; select {
-        case _ <- recv(rx10) => Channel.recv(rx13) ; Channel.recv(rx12) ; Channel.recv(rx11)
-        case _ <- recv(rx13) => Channel.recv(rx12) ; Channel.recv(rx10) ; Channel.recv(rx11) ; ()
-        case _ <- recv(rx11) => Channel.recv(rx13) ; Channel.recv(rx12) ; Channel.recv(rx10) ; ()
-        };
-        ()
-    }
-
-    @test
-    def testSelectRandom03(): Unit \ IO = region r {
-        let (tx14, rx14) = Channel.buffered(r, 0);
-        let (tx15, rx15) = Channel.buffered(r, 0);
-        let (tx16, rx16) = Channel.buffered(r, 0);
-        let (tx17, rx17) = Channel.buffered(r, 0);
-        let (tx18, rx18) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx18) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx18) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; let (tx141, rx141) = Channel.buffered(r, 0);
-        let (tx139, rx139) = Channel.buffered(r, 0);
-        let (tx140, rx140) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx141) ; () } @ r; spawn { Channel.send((), tx140) ; () } @ r; spawn { Channel.send((), tx139) ; () } @ r; spawn { Channel.send((), tx141) ; () } @ r; spawn { Channel.send((), tx140) ; () } @ r; spawn { Channel.send((), tx139) ; () } @ r; spawn { Channel.send((), tx141) ; () } @ r; spawn { Channel.send((), tx140) ; () } @ r; spawn { Channel.send((), tx139) ; () } @ r; spawn { select {
-        case _ <- recv(rx141) => Channel.recv(rx140) ; Channel.recv(rx139) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx139) => Channel.recv(rx140) ; Channel.recv(rx141) ; ()
-        case _ <- recv(rx140) => Channel.recv(rx141) ; Channel.recv(rx139) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx139) => select {
-        case _ <- recv(rx140) => ()
-        case _ <- recv(rx140) => ()
-        } ; Channel.recv(rx141) ; ()
-        case _ <- recv(rx141) => Channel.recv(rx140) ; Channel.recv(rx139) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx15) => Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx17) ; Channel.recv(rx14) ; ()
-        case _ <- recv(rx14) => Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx15) ; Channel.recv(rx17) ; ()
-        case _ <- recv(rx17) => Channel.recv(rx15) ; Channel.recv(rx18) ; select {
-        case _ <- recv(rx16) => ()
-        case _ <- recv(rx16) => ()
-        } ; Channel.recv(rx14)
-        case _ <- recv(rx18) => Channel.recv(rx15) ; Channel.recv(rx14) ; Channel.recv(rx17) ; Channel.recv(rx16) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx16) => Channel.recv(rx18) ; Channel.recv(rx17) ; Channel.recv(rx15) ; Channel.recv(rx14) ; ()
-        } } @ r;
-        ()
-    }
-
-    @test
-    def testSelectRandom04(): Unit \ IO = region r {
-        let (tx10, rx10) = Channel.buffered(r, 0);
-        let (tx11, rx11) = Channel.buffered(r, 0);
-        let (tx12, rx12) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx12) ; () } @ r; spawn { Channel.send((), tx11) ; () } @ r; spawn { Channel.send((), tx10) ; () } @ r; let (tx40, rx40) = Channel.buffered(r, 0);
-        let (tx41, rx41) = Channel.buffered(r, 0);
-        let (tx42, rx42) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx42) ; () } @ r; spawn { Channel.send((), tx41) ; () } @ r; spawn { Channel.send((), tx40) ; () } @ r; spawn { Channel.send((), tx42) ; () } @ r; spawn { Channel.send((), tx41) ; () } @ r; spawn { Channel.send((), tx40) ; () } @ r; spawn { Channel.send((), tx42) ; () } @ r; spawn { Channel.send((), tx41) ; () } @ r; spawn { Channel.send((), tx40) ; () } @ r; spawn { Channel.send((), tx42) ; () } @ r; spawn { Channel.send((), tx41) ; () } @ r; spawn { Channel.send((), tx40) ; () } @ r; spawn { select {
-        case _ <- recv(rx40) => Channel.recv(rx41) ; Channel.recv(rx42) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx40) => Channel.recv(rx42) ; Channel.recv(rx41) ; ()
-        case _ <- recv(rx40) => Channel.recv(rx42) ; Channel.recv(rx41) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx42) => Channel.recv(rx40) ; Channel.recv(rx41) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx42) => Channel.recv(rx40) ; Channel.recv(rx41) ; ()
-        case _ <- recv(rx42) => Channel.recv(rx40) ; Channel.recv(rx41) ; ()
-        } } @ r; select {
-        case _ <- recv(rx10) => Channel.recv(rx12) ; Channel.recv(rx11) ; ()
-        };
-        ()
-    }
-
-    @test
-    def testSelectRandom05(): Unit \ IO = region r {
-        let (tx14, rx14) = Channel.buffered(r, 0);
-        let (tx15, rx15) = Channel.buffered(r, 0);
-        let (tx16, rx16) = Channel.buffered(r, 0);
-        let (tx17, rx17) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { select {
-        case _ <- recv(rx17) => Channel.recv(rx14) ; Channel.recv(rx15) ; Channel.recv(rx16)
-        } } @ r; spawn { select {
-        case _ <- recv(rx16) => Channel.recv(rx14) ; Channel.recv(rx15) ; Channel.recv(rx17) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx17) => Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx14) ; let (tx171, rx171) = Channel.buffered(r, 0);
-        let (tx172, rx172) = Channel.buffered(r, 0);
-        let (tx173, rx173) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx173) ; () } @ r; spawn { Channel.send((), tx172) ; () } @ r; spawn { Channel.send((), tx171) ; () } @ r; spawn { Channel.send((), tx173) ; () } @ r; spawn { Channel.send((), tx172) ; () } @ r; spawn { Channel.send((), tx171) ; () } @ r; spawn { Channel.send((), tx173) ; () } @ r; spawn { Channel.send((), tx172) ; () } @ r; spawn { Channel.send((), tx171) ; () } @ r; spawn { Channel.send((), tx173) ; () } @ r; spawn { Channel.send((), tx172) ; () } @ r; spawn { Channel.send((), tx171) ; () } @ r; spawn { select {
-        case _ <- recv(rx172) => Channel.recv(rx173) ; Channel.recv(rx171) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx171) => Channel.recv(rx173) ; Channel.recv(rx172) ; ()
-        case _ <- recv(rx173) => Channel.recv(rx172) ; Channel.recv(rx171) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx171) => Channel.recv(rx173) ; Channel.recv(rx172) ; ()
-        case _ <- recv(rx173) => Channel.recv(rx171) ; Channel.recv(rx172) ; ()
-        case _ <- recv(rx171) => Channel.recv(rx173) ; Channel.recv(rx172) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx171) => Channel.recv(rx173) ; select {
-        case _ <- recv(rx172) => ()
-        case _ <- recv(rx172) => ()
-        } ; ()
-        case _ <- recv(rx173) => Channel.recv(rx171) ; Channel.recv(rx172) ; ()
-        } } @ r; ()
-        case _ <- recv(rx14) => Channel.recv(rx17) ; Channel.recv(rx15) ; Channel.recv(rx16) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx17) => Channel.recv(rx16) ; Channel.recv(rx15) ; Channel.recv(rx14) ; ()
-        } } @ r;
-        ()
-    }
-
-    @test
-    def testSelectRandom06(): Unit \ IO = region r {
-        let (tx2, rx2) = Channel.buffered(r, 0);
-        let (tx3, rx3) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx3) ; () } @ r; spawn { Channel.send((), tx2) ; () } @ r; Channel.recv(rx3) ; select {
-        case _ <- recv(rx2) => ()
-        case _ <- recv(rx2) => ()
-        } ; let (tx24, rx24) = Channel.buffered(r, 0);
-        spawn { select {
-        case _ <- recv(rx24) => ()
-        case _ <- recv(rx24) => ()
-        } } @ r; Channel.send((), tx24) ;
-        ()
-    }
-
-    @test
-    def testSelectRandom07(): Unit \ IO = region r {
-        let (tx12, rx12) = Channel.buffered(r, 0);
-        let (tx13, rx13) = Channel.buffered(r, 0);
-        let (tx14, rx14) = Channel.buffered(r, 0);
-        let (tx15, rx15) = Channel.buffered(r, 0);
-        let (tx16, rx16) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx13) ; () } @ r; spawn { Channel.send((), tx12) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx13) ; () } @ r; spawn { Channel.send((), tx12) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx13) ; () } @ r; spawn { Channel.send((), tx12) ; () } @ r; spawn { select {
-        case _ <- recv(rx14) => Channel.recv(rx12) ; Channel.recv(rx13) ; Channel.recv(rx15) ; Channel.recv(rx16) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx16) => Channel.recv(rx13) ; Channel.recv(rx14) ; Channel.recv(rx12) ; Channel.recv(rx15) ; ()
-        case _ <- recv(rx15) => Channel.recv(rx14) ; Channel.recv(rx13) ; Channel.recv(rx16) ; Channel.recv(rx12) ; ()
-        case _ <- recv(rx12) => Channel.recv(rx13) ; Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx14) ; let (tx180, rx180) = Channel.buffered(r, 0);
-        let (tx178, rx178) = Channel.buffered(r, 0);
-        let (tx179, rx179) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx180) ; () } @ r; spawn { Channel.send((), tx179) ; () } @ r; spawn { Channel.send((), tx178) ; () } @ r; spawn { Channel.send((), tx180) ; () } @ r; spawn { Channel.send((), tx179) ; () } @ r; spawn { Channel.send((), tx178) ; () } @ r; spawn { select {
-        case _ <- recv(rx178) => Channel.recv(rx180) ; Channel.recv(rx179)
-        case _ <- recv(rx179) => select {
-        case _ <- recv(rx178) => ()
-        case _ <- recv(rx178) => ()
-        } ; Channel.recv(rx180) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx178) => Channel.recv(rx179) ; Channel.recv(rx180) ; ()
-        case _ <- recv(rx180) => Channel.recv(rx178) ; Channel.recv(rx179) ; ()
-        } } @ r; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx14) => Channel.recv(rx15) ; Channel.recv(rx12) ; Channel.recv(rx16) ; Channel.recv(rx13) ; ()
-        case _ <- recv(rx13) => Channel.recv(rx12) ; Channel.recv(rx14) ; Channel.recv(rx15) ; Channel.recv(rx16) ; ()
-        } } @ r;
-        ()
-    }
-
-    @test
-    def testSelectRandom08(): Unit \ IO = region r {
-        let (tx15, rx15) = Channel.buffered(r, 0);
-        let (tx16, rx16) = Channel.buffered(r, 0);
-        let (tx17, rx17) = Channel.buffered(r, 0);
-        let (tx18, rx18) = Channel.buffered(r, 0);
-        let (tx19, rx19) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx19) ; () } @ r; spawn { Channel.send((), tx18) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx19) ; () } @ r; spawn { Channel.send((), tx18) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx19) ; () } @ r; spawn { Channel.send((), tx18) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx19) ; () } @ r; spawn { Channel.send((), tx18) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { select {
-        case _ <- recv(rx15) => Channel.recv(rx17) ; Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx19) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx15) => Channel.recv(rx19) ; Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx17) ; ()
-        case _ <- recv(rx18) => Channel.recv(rx19) ; Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx17) ; ()
-        case _ <- recv(rx19) => Channel.recv(rx16) ; Channel.recv(rx17) ; Channel.recv(rx18) ; Channel.recv(rx15) ; ()
-        case _ <- recv(rx17) => Channel.recv(rx15) ; Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx19) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx17) => Channel.recv(rx18) ; Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx19) ; ()
-        case _ <- recv(rx15) => Channel.recv(rx17) ; Channel.recv(rx16) ; Channel.recv(rx18) ; Channel.recv(rx19) ; ()
-        case _ <- recv(rx16) => Channel.recv(rx15) ; Channel.recv(rx18) ; Channel.recv(rx17) ; Channel.recv(rx19) ; ()
-        case _ <- recv(rx19) => Channel.recv(rx15) ; Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx17) ; ()
-        } } @ r; spawn { select {
-        case _ <- recv(rx17) => Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx19) ; Channel.recv(rx15) ; ()
-        case _ <- recv(rx16) => Channel.recv(rx18) ; select {
-        case _ <- recv(rx15) => ()
-        case _ <- recv(rx15) => ()
-        } ; Channel.recv(rx17) ; Channel.recv(rx19) ; let (tx214, rx214) = Channel.buffered(r, 0);
-        let (tx215, rx215) = Channel.buffered(r, 0);
-        let (tx216, rx216) = Channel.buffered(r, 0);
-        let (tx217, rx217) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx217) ; () } @ r; spawn { Channel.send((), tx216) ; () } @ r; spawn { Channel.send((), tx215) ; () } @ r; spawn { Channel.send((), tx214) ; () } @ r; select {
-        case _ <- recv(rx215) => Channel.recv(rx214) ; Channel.recv(rx216) ; Channel.recv(rx217) ; ()
-        case _ <- recv(rx214) => Channel.recv(rx216) ; Channel.recv(rx215) ; Channel.recv(rx217) ; ()
-        case _ <- recv(rx216) => Channel.recv(rx214) ; Channel.recv(rx217) ; Channel.recv(rx215)
-        }
-        } } @ r;
-        ()
-    }
-
-    @test
-    def testSelectRandom09(): Unit \ IO = region r {
-        let (tx6, rx6) = Channel.buffered(r, 0);
-        let (tx7, rx7) = Channel.buffered(r, 0);
-        let (tx8, rx8) = Channel.buffered(r, 0);
-        let (tx9, rx9) = Channel.buffered(r, 0);
-        spawn { select {
-        case _ <- recv(rx8) => ()
-        case _ <- recv(rx8) => ()
-        } ; Channel.send((), tx9) ; () } @ r; spawn { Channel.recv(rx7) ; Channel.send((), tx8) ; () } @ r; spawn { select {
-        case _ <- recv(rx6) => ()
-        case _ <- recv(rx6) => ()
-        } ; Channel.send((), tx7) ; () } @ r; Channel.send((), tx6) ; Channel.recv(rx9);
-        ()
-    }
-
-    @test
-    def testSelectRandom10(): Unit \ IO = region r {
-        let (tx10, rx10) = Channel.buffered(r, 0);
-        let (tx11, rx11) = Channel.buffered(r, 0);
-        let (tx12, rx12) = Channel.buffered(r, 0);
-        let (tx13, rx13) = Channel.buffered(r, 0);
-        spawn { Channel.send((), tx13) ; () } @ r;
-        spawn { Channel.send((), tx12) ; () } @ r;
-        spawn { Channel.send((), tx11) ; () } @ r;
-        spawn { Channel.send((), tx10) ; () } @ r;
-        select {
-            case _ <- recv(rx10) => Channel.recv(rx13) ; Channel.recv(rx12) ; Channel.recv(rx11)
-            case _ <- recv(rx13) => Channel.recv(rx12) ; Channel.recv(rx10) ; Channel.recv(rx11)
-            case _ <- recv(rx11) => Channel.recv(rx13) ; Channel.recv(rx12) ; Channel.recv(rx10)
-        };
-        ()
-    }
-
-    @test
-    def testSelectSideEffecting01(): Bool = region r {
-        def mkChan(): Channel[Int32] = {
-            let (tx, rx) = Channel.buffered(r, 1);
-            Channel.send(42, tx);
-            rx
-        };
-
-        select {
-            case x <- recv(mkChan()) => x == 42
-        }
-    }
-
-    @test
-    def testSelectSideEffecting02(): Bool = region r {
-        let (tx1, rx1) = Channel.buffered(r, 10);
-        let (tx2, rx2) = Channel.buffered(r, 10);
-        let (tx3, rx3) = Channel.buffered(r, 10);
-
-        select {
-            case x <- recv({Channel.send(1, tx3); rx1}) => x + (Channel.recv(rx2)) + (Channel.recv(rx3)) == 6
-            case x <- recv({Channel.send(2, tx2); rx2}) => x + (Channel.recv(rx1)) + (Channel.recv(rx3)) == 6
-            case x <- recv({Channel.send(3, tx1); rx3}) => x + (Channel.recv(rx1)) + (Channel.recv(rx2)) == 6
-        }
-    }
-
-    type alias MyReceiver[a: Type, r: Region] = Receiver[a, r]
-
-    @test
-    def testSelectAliasedChannel(): Bool = region r {
-        let (tx, rx) = Channel.buffered(r, 1);
-
-        def useChan(mr: MyReceiver[Int32, r]) : Bool =
-            select {
-                case x <- recv(mr) => x == 42
-            };
-
-        Channel.send(42, tx);
-        useChan(rx)
-    }
-
-    @test
-    def testSelectOptionalSyntax01(): Bool \ IO = region r {
-        let (tx1, rx1) = Channel.buffered(r, 1);
-        spawn Channel.send(1, tx1) @ r;
-        select {
-            case x <- Channel.recv(rx1) => x == 1
-        }
-    }
+//    @test
+//    def testSelectBuffered02(): Bool \ IO = region r {
+//        let (tx1, rx1) = Channel.buffered(r, 1);
+//        let (tx2, rx2) = Channel.buffered(r, 1);
+//        spawn Channel.send(1, tx1) @ r;
+//        spawn Channel.send(2, tx2) @ r;
+//        select {
+//            case x <- recv(rx1) => x == 1
+//            case x <- recv(rx2) => x == 2
+//        }
+//    }
+//
+//    @test
+//    def testSelectBuffered03(): Bool \ IO = region r {
+//        let (tx1, rx1) = Channel.buffered(r, 1);
+//        let (tx2, rx2) = Channel.buffered(r, 1);
+//        let (tx3, rx3) = Channel.buffered(r, 1);
+//        spawn Channel.send(1, tx1) @ r;
+//        spawn Channel.send(2, tx2) @ r;
+//        spawn Channel.send(3, tx3) @ r;
+//        select {
+//            case x <- recv(rx1) => x == 1
+//            case x <- recv(rx2) => x == 2
+//            case x <- recv(rx3) => x == 3
+//        }
+//    }
+//
+//    @test
+//    def testSelectBuffered04(): Bool \ IO = region r {
+//        let (tx1, rx1) = Channel.buffered(r, 1);
+//        let (tx2, rx2) = Channel.buffered(r, 1);
+//        let (tx3, rx3) = Channel.buffered(r, 1);
+//        let (tx4, rx4) = Channel.buffered(r, 1);
+//        spawn Channel.send(1, tx1) @ r;
+//        spawn Channel.send(2, tx2) @ r;
+//        spawn Channel.send(3, tx3) @ r;
+//        spawn Channel.send(4, tx4) @ r;
+//        select {
+//            case x <- recv(rx1) => x == 1
+//            case x <- recv(rx1) => x == 1
+//            case x <- recv(rx2) => x == 2
+//            case x <- recv(rx2) => x == 2
+//            case x <- recv(rx3) => x == 3
+//            case x <- recv(rx3) => x == 3
+//            case x <- recv(rx4) => x == 4
+//            case x <- recv(rx4) => x == 4
+//        }
+//    }
+//
+//    @test
+//    def testSelectBuffered05(): Bool \ IO = region r {
+//        let (tx1, rx1) = Channel.buffered(r, 1);
+//        let (tx2, rx2) = Channel.buffered(r, 1);
+//        let (tx3, rx3) = Channel.buffered(r, 1);
+//        let (tx4, rx4) = Channel.buffered(r, 1);
+//        spawn Channel.send(1, tx1) @ r;
+//        spawn Channel.send(2, tx2) @ r;
+//        spawn Channel.send(3, tx3) @ r;
+//        spawn Channel.send(4, tx4) @ r;
+//        select {
+//            case x <- recv(rx4) => x == 4
+//            case x <- recv(rx3) => x == 3
+//            case x <- recv(rx2) => x == 2
+//            case x <- recv(rx1) => x == 1
+//            case x <- recv(rx4) => x == 4
+//            case x <- recv(rx3) => x == 3
+//            case x <- recv(rx2) => x == 2
+//            case x <- recv(rx1) => x == 1
+//        }
+//    }
+//
+//    @test
+//    def testSelectBuffered06(): Bool \ IO = region r {
+//        let (_, rx1) = Channel.buffered(r, 1);
+//        let (tx2, rx2) = Channel.buffered(r, 1);
+//        let (_, rx3) = Channel.buffered(r, 1);
+//        let (_, rx4) = Channel.buffered(r, 1);
+//        spawn Channel.send(1, tx2) @ r;
+//        select {
+//            case _ <- recv(rx4) => false
+//            case _ <- recv(rx3) => false
+//            case x <- recv(rx2) => x == 1
+//            case _ <- recv(rx1) => false
+//        }
+//    }
+//
+//    @test
+//    def testSelectBuffered07(): Bool \ IO = region r {
+//        let (tx1, rx1) = Channel.buffered(r, 1);
+//        let (tx2, rx2) = Channel.buffered(r, 1);
+//        let (tx3, rx3) = Channel.buffered(r, 1);
+//        let (tx4, rx4) = Channel.buffered(r, 1);
+//        spawn Channel.send(1i8, tx1) @ r;
+//        spawn Channel.send(2i16, tx2) @ r;
+//        spawn Channel.send(3i32, tx3) @ r;
+//        spawn Channel.send(4i64, tx4) @ r;
+//        select {
+//            case x <- recv(rx4) => x == 4i64
+//            case x <- recv(rx3) => x == 3i32
+//            case x <- recv(rx2) => x == 2i16
+//            case x <- recv(rx1) => x == 1i8
+//        }
+//    }
+//
+//    @test
+//    def testSelectDefault01(): Bool = region r {
+//        select {
+//            case x <- recv({let (_, rx) = Channel.buffered(r, 1); rx}) => x
+//            case _                                                     => true
+//        }
+//    }
+//
+//    @test
+//    def testSelectDefault02(): Bool = region r {
+//        (1 + select {
+//            case _ <- recv({let (_, rx) = Channel.buffered(r, 2); rx}) => 2
+//            case _                                                     => 1
+//        }) == 2
+//    }
+//
+//    def recvWithDefault(rx: Receiver[Int32, r]): Int32 \ { Read(r), Write(r) } = {
+//        select {
+//            case x <- Channel.recv(rx) => x
+//            case _                     => 1
+//        }
+//    }
+//
+//    def mainx(): Int32 \ IO = {
+//      let (_, rx) = Channel.buffered(Static, 1);
+//      recvWithDefault(rx)
+//    }
+//
+//    @test
+//    def testSelectDefault03(): Unit \ IO =
+//      // This test is from a bug report so its form is subtle and intentional
+//      unsafe_cast println(mainx()) as _ \ IO
+//
+//    @test
+//    def testSelectRandom01(): Unit \ IO = region r {
+//        let (tx9, rx9) = Channel.buffered(r, 0);
+//        let (tx10, rx10) = Channel.buffered(r, 0);
+//        let (tx11, rx11) = Channel.buffered(r, 0);
+//        let (tx12, rx12) = Channel.buffered(r, 0);
+//        let (tx13, rx13) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx13) ; () } @ r; spawn { Channel.send((), tx12) ; () } @ r; spawn { Channel.send((), tx11) ; () } @ r; spawn { Channel.send((), tx10) ; () } @ r; spawn { Channel.send((), tx9) ; () } @ r; select {
+//        case _ <- recv(rx13) => select {
+//        case _ <- recv(rx11) => ()
+//        case _ <- recv(rx11) => ()
+//        } ; Channel.recv(rx9) ; Channel.recv(rx10) ; Channel.recv(rx12) ; let (tx42, rx42) = Channel.buffered(r, 0);
+//        let (tx43, rx43) = Channel.buffered(r, 0);
+//        let (tx44, rx44) = Channel.buffered(r, 0);
+//        let (tx45, rx45) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx45) ; () } @ r; spawn { Channel.send((), tx44) ; () } @ r; spawn { Channel.send((), tx43) ; () } @ r; spawn { Channel.send((), tx42) ; () } @ r; select {
+//        case _ <- recv(rx43) => Channel.recv(rx42) ; Channel.recv(rx44) ; Channel.recv(rx45)
+//        case _ <- recv(rx42) => Channel.recv(rx45) ; Channel.recv(rx43) ; Channel.recv(rx44) ; ()
+//        }
+//        case _ <- recv(rx13) => select {
+//        case _ <- recv(rx11) => ()
+//        case _ <- recv(rx11) => ()
+//        } ; Channel.recv(rx9) ; Channel.recv(rx10) ; Channel.recv(rx12) ; let (tx42, rx42) = Channel.buffered(r, 0);
+//        let (tx43, rx43) = Channel.buffered(r, 0);
+//        let (tx44, rx44) = Channel.buffered(r, 0);
+//        let (tx45, rx45) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx45) ; () } @ r; spawn { Channel.send((), tx44) ; () } @ r; spawn { Channel.send((), tx43) ; () } @ r; spawn { Channel.send((), tx42) ; () } @ r; select {
+//        case _ <- recv(rx43) => Channel.recv(rx42) ; Channel.recv(rx44) ; Channel.recv(rx45) ; ()
+//        case _ <- recv(rx42) => Channel.recv(rx45) ; Channel.recv(rx43) ; Channel.recv(rx44)
+//        }
+//        };
+//        ()
+//    }
+//
+//    @test
+//    def testSelectRandom02(): Unit \ IO = region r {
+//        let (tx10, rx10) = Channel.buffered(r, 0);
+//        let (tx11, rx11) = Channel.buffered(r, 0);
+//        let (tx12, rx12) = Channel.buffered(r, 0);
+//        let (tx13, rx13) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx13) ; () } @ r; spawn { Channel.send((), tx12) ; () } @ r; if (false) { spawn { Channel.send((), tx11) ; () } @ r; spawn { Channel.send((), tx10) ; () } @ r; if (true) { () } else { () } } else { spawn { Channel.send((), tx11) ; () } @ r; spawn { Channel.send((), tx10) ; () } @ r; if (true) { () } else { () } } ; select {
+//        case _ <- recv(rx10) => Channel.recv(rx13) ; Channel.recv(rx12) ; Channel.recv(rx11)
+//        case _ <- recv(rx13) => Channel.recv(rx12) ; Channel.recv(rx10) ; Channel.recv(rx11) ; ()
+//        case _ <- recv(rx11) => Channel.recv(rx13) ; Channel.recv(rx12) ; Channel.recv(rx10) ; ()
+//        };
+//        ()
+//    }
+//
+//    @test
+//    def testSelectRandom03(): Unit \ IO = region r {
+//        let (tx14, rx14) = Channel.buffered(r, 0);
+//        let (tx15, rx15) = Channel.buffered(r, 0);
+//        let (tx16, rx16) = Channel.buffered(r, 0);
+//        let (tx17, rx17) = Channel.buffered(r, 0);
+//        let (tx18, rx18) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx18) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx18) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; let (tx141, rx141) = Channel.buffered(r, 0);
+//        let (tx139, rx139) = Channel.buffered(r, 0);
+//        let (tx140, rx140) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx141) ; () } @ r; spawn { Channel.send((), tx140) ; () } @ r; spawn { Channel.send((), tx139) ; () } @ r; spawn { Channel.send((), tx141) ; () } @ r; spawn { Channel.send((), tx140) ; () } @ r; spawn { Channel.send((), tx139) ; () } @ r; spawn { Channel.send((), tx141) ; () } @ r; spawn { Channel.send((), tx140) ; () } @ r; spawn { Channel.send((), tx139) ; () } @ r; spawn { select {
+//        case _ <- recv(rx141) => Channel.recv(rx140) ; Channel.recv(rx139) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx139) => Channel.recv(rx140) ; Channel.recv(rx141) ; ()
+//        case _ <- recv(rx140) => Channel.recv(rx141) ; Channel.recv(rx139) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx139) => select {
+//        case _ <- recv(rx140) => ()
+//        case _ <- recv(rx140) => ()
+//        } ; Channel.recv(rx141) ; ()
+//        case _ <- recv(rx141) => Channel.recv(rx140) ; Channel.recv(rx139) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx15) => Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx17) ; Channel.recv(rx14) ; ()
+//        case _ <- recv(rx14) => Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx15) ; Channel.recv(rx17) ; ()
+//        case _ <- recv(rx17) => Channel.recv(rx15) ; Channel.recv(rx18) ; select {
+//        case _ <- recv(rx16) => ()
+//        case _ <- recv(rx16) => ()
+//        } ; Channel.recv(rx14)
+//        case _ <- recv(rx18) => Channel.recv(rx15) ; Channel.recv(rx14) ; Channel.recv(rx17) ; Channel.recv(rx16) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx16) => Channel.recv(rx18) ; Channel.recv(rx17) ; Channel.recv(rx15) ; Channel.recv(rx14) ; ()
+//        } } @ r;
+//        ()
+//    }
+//
+//    @test
+//    def testSelectRandom04(): Unit \ IO = region r {
+//        let (tx10, rx10) = Channel.buffered(r, 0);
+//        let (tx11, rx11) = Channel.buffered(r, 0);
+//        let (tx12, rx12) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx12) ; () } @ r; spawn { Channel.send((), tx11) ; () } @ r; spawn { Channel.send((), tx10) ; () } @ r; let (tx40, rx40) = Channel.buffered(r, 0);
+//        let (tx41, rx41) = Channel.buffered(r, 0);
+//        let (tx42, rx42) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx42) ; () } @ r; spawn { Channel.send((), tx41) ; () } @ r; spawn { Channel.send((), tx40) ; () } @ r; spawn { Channel.send((), tx42) ; () } @ r; spawn { Channel.send((), tx41) ; () } @ r; spawn { Channel.send((), tx40) ; () } @ r; spawn { Channel.send((), tx42) ; () } @ r; spawn { Channel.send((), tx41) ; () } @ r; spawn { Channel.send((), tx40) ; () } @ r; spawn { Channel.send((), tx42) ; () } @ r; spawn { Channel.send((), tx41) ; () } @ r; spawn { Channel.send((), tx40) ; () } @ r; spawn { select {
+//        case _ <- recv(rx40) => Channel.recv(rx41) ; Channel.recv(rx42) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx40) => Channel.recv(rx42) ; Channel.recv(rx41) ; ()
+//        case _ <- recv(rx40) => Channel.recv(rx42) ; Channel.recv(rx41) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx42) => Channel.recv(rx40) ; Channel.recv(rx41) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx42) => Channel.recv(rx40) ; Channel.recv(rx41) ; ()
+//        case _ <- recv(rx42) => Channel.recv(rx40) ; Channel.recv(rx41) ; ()
+//        } } @ r; select {
+//        case _ <- recv(rx10) => Channel.recv(rx12) ; Channel.recv(rx11) ; ()
+//        };
+//        ()
+//    }
+//
+//    @test
+//    def testSelectRandom05(): Unit \ IO = region r {
+//        let (tx14, rx14) = Channel.buffered(r, 0);
+//        let (tx15, rx15) = Channel.buffered(r, 0);
+//        let (tx16, rx16) = Channel.buffered(r, 0);
+//        let (tx17, rx17) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { select {
+//        case _ <- recv(rx17) => Channel.recv(rx14) ; Channel.recv(rx15) ; Channel.recv(rx16)
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx16) => Channel.recv(rx14) ; Channel.recv(rx15) ; Channel.recv(rx17) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx17) => Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx14) ; let (tx171, rx171) = Channel.buffered(r, 0);
+//        let (tx172, rx172) = Channel.buffered(r, 0);
+//        let (tx173, rx173) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx173) ; () } @ r; spawn { Channel.send((), tx172) ; () } @ r; spawn { Channel.send((), tx171) ; () } @ r; spawn { Channel.send((), tx173) ; () } @ r; spawn { Channel.send((), tx172) ; () } @ r; spawn { Channel.send((), tx171) ; () } @ r; spawn { Channel.send((), tx173) ; () } @ r; spawn { Channel.send((), tx172) ; () } @ r; spawn { Channel.send((), tx171) ; () } @ r; spawn { Channel.send((), tx173) ; () } @ r; spawn { Channel.send((), tx172) ; () } @ r; spawn { Channel.send((), tx171) ; () } @ r; spawn { select {
+//        case _ <- recv(rx172) => Channel.recv(rx173) ; Channel.recv(rx171) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx171) => Channel.recv(rx173) ; Channel.recv(rx172) ; ()
+//        case _ <- recv(rx173) => Channel.recv(rx172) ; Channel.recv(rx171) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx171) => Channel.recv(rx173) ; Channel.recv(rx172) ; ()
+//        case _ <- recv(rx173) => Channel.recv(rx171) ; Channel.recv(rx172) ; ()
+//        case _ <- recv(rx171) => Channel.recv(rx173) ; Channel.recv(rx172) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx171) => Channel.recv(rx173) ; select {
+//        case _ <- recv(rx172) => ()
+//        case _ <- recv(rx172) => ()
+//        } ; ()
+//        case _ <- recv(rx173) => Channel.recv(rx171) ; Channel.recv(rx172) ; ()
+//        } } @ r; ()
+//        case _ <- recv(rx14) => Channel.recv(rx17) ; Channel.recv(rx15) ; Channel.recv(rx16) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx17) => Channel.recv(rx16) ; Channel.recv(rx15) ; Channel.recv(rx14) ; ()
+//        } } @ r;
+//        ()
+//    }
+//
+//    @test
+//    def testSelectRandom06(): Unit \ IO = region r {
+//        let (tx2, rx2) = Channel.buffered(r, 0);
+//        let (tx3, rx3) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx3) ; () } @ r; spawn { Channel.send((), tx2) ; () } @ r; Channel.recv(rx3) ; select {
+//        case _ <- recv(rx2) => ()
+//        case _ <- recv(rx2) => ()
+//        } ; let (tx24, rx24) = Channel.buffered(r, 0);
+//        spawn { select {
+//        case _ <- recv(rx24) => ()
+//        case _ <- recv(rx24) => ()
+//        } } @ r; Channel.send((), tx24) ;
+//        ()
+//    }
+//
+//    @test
+//    def testSelectRandom07(): Unit \ IO = region r {
+//        let (tx12, rx12) = Channel.buffered(r, 0);
+//        let (tx13, rx13) = Channel.buffered(r, 0);
+//        let (tx14, rx14) = Channel.buffered(r, 0);
+//        let (tx15, rx15) = Channel.buffered(r, 0);
+//        let (tx16, rx16) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx13) ; () } @ r; spawn { Channel.send((), tx12) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx13) ; () } @ r; spawn { Channel.send((), tx12) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx14) ; () } @ r; spawn { Channel.send((), tx13) ; () } @ r; spawn { Channel.send((), tx12) ; () } @ r; spawn { select {
+//        case _ <- recv(rx14) => Channel.recv(rx12) ; Channel.recv(rx13) ; Channel.recv(rx15) ; Channel.recv(rx16) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx16) => Channel.recv(rx13) ; Channel.recv(rx14) ; Channel.recv(rx12) ; Channel.recv(rx15) ; ()
+//        case _ <- recv(rx15) => Channel.recv(rx14) ; Channel.recv(rx13) ; Channel.recv(rx16) ; Channel.recv(rx12) ; ()
+//        case _ <- recv(rx12) => Channel.recv(rx13) ; Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx14) ; let (tx180, rx180) = Channel.buffered(r, 0);
+//        let (tx178, rx178) = Channel.buffered(r, 0);
+//        let (tx179, rx179) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx180) ; () } @ r; spawn { Channel.send((), tx179) ; () } @ r; spawn { Channel.send((), tx178) ; () } @ r; spawn { Channel.send((), tx180) ; () } @ r; spawn { Channel.send((), tx179) ; () } @ r; spawn { Channel.send((), tx178) ; () } @ r; spawn { select {
+//        case _ <- recv(rx178) => Channel.recv(rx180) ; Channel.recv(rx179)
+//        case _ <- recv(rx179) => select {
+//        case _ <- recv(rx178) => ()
+//        case _ <- recv(rx178) => ()
+//        } ; Channel.recv(rx180) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx178) => Channel.recv(rx179) ; Channel.recv(rx180) ; ()
+//        case _ <- recv(rx180) => Channel.recv(rx178) ; Channel.recv(rx179) ; ()
+//        } } @ r; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx14) => Channel.recv(rx15) ; Channel.recv(rx12) ; Channel.recv(rx16) ; Channel.recv(rx13) ; ()
+//        case _ <- recv(rx13) => Channel.recv(rx12) ; Channel.recv(rx14) ; Channel.recv(rx15) ; Channel.recv(rx16) ; ()
+//        } } @ r;
+//        ()
+//    }
+//
+//    @test
+//    def testSelectRandom08(): Unit \ IO = region r {
+//        let (tx15, rx15) = Channel.buffered(r, 0);
+//        let (tx16, rx16) = Channel.buffered(r, 0);
+//        let (tx17, rx17) = Channel.buffered(r, 0);
+//        let (tx18, rx18) = Channel.buffered(r, 0);
+//        let (tx19, rx19) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx19) ; () } @ r; spawn { Channel.send((), tx18) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx19) ; () } @ r; spawn { Channel.send((), tx18) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx19) ; () } @ r; spawn { Channel.send((), tx18) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { Channel.send((), tx19) ; () } @ r; spawn { Channel.send((), tx18) ; () } @ r; spawn { Channel.send((), tx17) ; () } @ r; spawn { Channel.send((), tx16) ; () } @ r; spawn { Channel.send((), tx15) ; () } @ r; spawn { select {
+//        case _ <- recv(rx15) => Channel.recv(rx17) ; Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx19) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx15) => Channel.recv(rx19) ; Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx17) ; ()
+//        case _ <- recv(rx18) => Channel.recv(rx19) ; Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx17) ; ()
+//        case _ <- recv(rx19) => Channel.recv(rx16) ; Channel.recv(rx17) ; Channel.recv(rx18) ; Channel.recv(rx15) ; ()
+//        case _ <- recv(rx17) => Channel.recv(rx15) ; Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx19) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx17) => Channel.recv(rx18) ; Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx19) ; ()
+//        case _ <- recv(rx15) => Channel.recv(rx17) ; Channel.recv(rx16) ; Channel.recv(rx18) ; Channel.recv(rx19) ; ()
+//        case _ <- recv(rx16) => Channel.recv(rx15) ; Channel.recv(rx18) ; Channel.recv(rx17) ; Channel.recv(rx19) ; ()
+//        case _ <- recv(rx19) => Channel.recv(rx15) ; Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx17) ; ()
+//        } } @ r; spawn { select {
+//        case _ <- recv(rx17) => Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx19) ; Channel.recv(rx15) ; ()
+//        case _ <- recv(rx16) => Channel.recv(rx18) ; select {
+//        case _ <- recv(rx15) => ()
+//        case _ <- recv(rx15) => ()
+//        } ; Channel.recv(rx17) ; Channel.recv(rx19) ; let (tx214, rx214) = Channel.buffered(r, 0);
+//        let (tx215, rx215) = Channel.buffered(r, 0);
+//        let (tx216, rx216) = Channel.buffered(r, 0);
+//        let (tx217, rx217) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx217) ; () } @ r; spawn { Channel.send((), tx216) ; () } @ r; spawn { Channel.send((), tx215) ; () } @ r; spawn { Channel.send((), tx214) ; () } @ r; select {
+//        case _ <- recv(rx215) => Channel.recv(rx214) ; Channel.recv(rx216) ; Channel.recv(rx217) ; ()
+//        case _ <- recv(rx214) => Channel.recv(rx216) ; Channel.recv(rx215) ; Channel.recv(rx217) ; ()
+//        case _ <- recv(rx216) => Channel.recv(rx214) ; Channel.recv(rx217) ; Channel.recv(rx215)
+//        }
+//        } } @ r;
+//        ()
+//    }
+//
+//    @test
+//    def testSelectRandom09(): Unit \ IO = region r {
+//        let (tx6, rx6) = Channel.buffered(r, 0);
+//        let (tx7, rx7) = Channel.buffered(r, 0);
+//        let (tx8, rx8) = Channel.buffered(r, 0);
+//        let (tx9, rx9) = Channel.buffered(r, 0);
+//        spawn { select {
+//        case _ <- recv(rx8) => ()
+//        case _ <- recv(rx8) => ()
+//        } ; Channel.send((), tx9) ; () } @ r; spawn { Channel.recv(rx7) ; Channel.send((), tx8) ; () } @ r; spawn { select {
+//        case _ <- recv(rx6) => ()
+//        case _ <- recv(rx6) => ()
+//        } ; Channel.send((), tx7) ; () } @ r; Channel.send((), tx6) ; Channel.recv(rx9);
+//        ()
+//    }
+//
+//    @test
+//    def testSelectRandom10(): Unit \ IO = region r {
+//        let (tx10, rx10) = Channel.buffered(r, 0);
+//        let (tx11, rx11) = Channel.buffered(r, 0);
+//        let (tx12, rx12) = Channel.buffered(r, 0);
+//        let (tx13, rx13) = Channel.buffered(r, 0);
+//        spawn { Channel.send((), tx13) ; () } @ r;
+//        spawn { Channel.send((), tx12) ; () } @ r;
+//        spawn { Channel.send((), tx11) ; () } @ r;
+//        spawn { Channel.send((), tx10) ; () } @ r;
+//        select {
+//            case _ <- recv(rx10) => Channel.recv(rx13) ; Channel.recv(rx12) ; Channel.recv(rx11)
+//            case _ <- recv(rx13) => Channel.recv(rx12) ; Channel.recv(rx10) ; Channel.recv(rx11)
+//            case _ <- recv(rx11) => Channel.recv(rx13) ; Channel.recv(rx12) ; Channel.recv(rx10)
+//        };
+//        ()
+//    }
+//
+//    @test
+//    def testSelectSideEffecting01(): Bool = region r {
+//        def mkChan(): Channel[Int32] = {
+//            let (tx, rx) = Channel.buffered(r, 1);
+//            Channel.send(42, tx);
+//            rx
+//        };
+//
+//        select {
+//            case x <- recv(mkChan()) => x == 42
+//        }
+//    }
+//
+//    @test
+//    def testSelectSideEffecting02(): Bool = region r {
+//        let (tx1, rx1) = Channel.buffered(r, 10);
+//        let (tx2, rx2) = Channel.buffered(r, 10);
+//        let (tx3, rx3) = Channel.buffered(r, 10);
+//
+//        select {
+//            case x <- recv({Channel.send(1, tx3); rx1}) => x + (Channel.recv(rx2)) + (Channel.recv(rx3)) == 6
+//            case x <- recv({Channel.send(2, tx2); rx2}) => x + (Channel.recv(rx1)) + (Channel.recv(rx3)) == 6
+//            case x <- recv({Channel.send(3, tx1); rx3}) => x + (Channel.recv(rx1)) + (Channel.recv(rx2)) == 6
+//        }
+//    }
+//
+//    type alias MyReceiver[a: Type, r: Region] = Receiver[a, r]
+//
+//    @test
+//    def testSelectAliasedChannel(): Bool = region r {
+//        let (tx, rx) = Channel.buffered(r, 1);
+//
+//        def useChan(mr: MyReceiver[Int32, r]) : Bool =
+//            select {
+//                case x <- recv(mr) => x == 42
+//            };
+//
+//        Channel.send(42, tx);
+//        useChan(rx)
+//    }
+//
+//    @test
+//    def testSelectOptionalSyntax01(): Bool \ IO = region r {
+//        let (tx1, rx1) = Channel.buffered(r, 1);
+//        spawn Channel.send(1, tx1) @ r;
+//        select {
+//            case x <- Channel.recv(rx1) => x == 1
+//        }
+//    }
 }


### PR DESCRIPTION
This is a follow-on from the (now closed) #5175, and definitely still draft.

I think I've hit a roadblock with removing `Static` from the channel code. This compiles and successfully runs the tests within `Test.Exp.Concurrency.Buffered.flix` and `Test.Exp.Concurrency.Unbuffered.flix`. The tests in `Test.Exp.Concurrency.Select.flix` however fail with:

```
# An unexpected error has been detected by the Flix compiler:
#
#   Unable to unify: 'List[MpmcAdmin[b24123]] -> (Bool -> (Int32, List[ReentrantLock]) & Impure)' and 'List[MpmcAdmin] -> (Bool -> (Int32, List[ReentrantLock]) & Impure)'.
```

The problem, I believe, is the [type returned by `mkChannelAdminList`](https://github.com/paulbutcher/flix/blob/bcd47a452306de3de00898f1feb962e5cc5473e9/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala#L1337-L1350), but it's not clear to me what that type should be.

The heart of the problem is, I think, the signature of [`selectFrom`](https://github.com/paulbutcher/flix/blob/bcd47a452306de3de00898f1feb962e5cc5473e9/main/src/library/Concurrent/Channel.flix#L254) which takes an array of `MpmcAdmin`. `MpmcAdmin` now takes a region parameter (as per the recent conversation on Gitter) this represents a list of admin objects which are all in the same region. They might, however, not be in the same region.

[This](https://github.com/paulbutcher/flix/blob/bcd47a452306de3de00898f1feb962e5cc5473e9/main/test/ca/uwaterloo/flix/library/TestChannel.flix#L98-L116) new (failing) test illustrates the problem.

I'm not sure where to go from here? Suggestions gratefully received (@magnus-madsen, @JonathanStarup)?