### PR TITLE
refactor: Swap type arguments of Result and Validation (issue #5191)

### DIFF
--- a/examples/type-aliases.flix
+++ b/examples/type-aliases.flix
@@ -6,8 +6,8 @@ type alias M = Map[Int32, String]
 /// A function that returns a map of type M.
 def f(): M = Map#{ 1 => "Hello", 2 => "World"}
 
-// A polymorphic type alias for the type Map[a, Result[Int32, String]].
-type alias N[a] = Map[a, Result[Int32, String]]
+// A polymorphic type alias for the type Map[a, Result[String, Int32]].
+type alias N[a] = Map[a, Result[String, Int32]]
 
 /// A function that returns a map of type N.
 def g(): N[Int32] = Map#{ 1 => Ok(123), 2 => Err("Hello") }

--- a/main/src/library/Concurrent/Condition.flix
+++ b/main/src/library/Concurrent/Condition.flix
@@ -41,7 +41,7 @@ namespace Concurrent {
         /// Causes the current thread to wait until it is signalled or interrupted.
         ///
         @Internal
-        pub def await(condition: Condition): Result[Unit, ConditionError] \ IO =
+        pub def await(condition: Condition): Result[ConditionError, Unit] \ IO =
             import java.util.concurrent.locks.Condition.await(): Unit \ IO;
             let Condition(c) = condition;
             try {
@@ -57,7 +57,7 @@ namespace Concurrent {
         /// given the supplied nanosTimeout value upon return, or a value less than or equal to zero if it timed out.
         ///
         @Internal
-        pub def awaitTimeout(condition: Condition, timeout: Int64): Result[Int64, ConditionError] \ IO =
+        pub def awaitTimeout(condition: Condition, timeout: Int64): Result[ConditionError, Int64] \ IO =
             import java.util.concurrent.locks.Condition.awaitNanos(Int64): Int64 \ IO;
             let Condition(c) = condition;
             try {
@@ -71,7 +71,7 @@ namespace Concurrent {
         /// Causes the current thread to wait until it is signalled.
         ///
         @Internal
-        pub def awaitUninterruptibly(condition: Condition): Result[Unit, ##java.lang.IllegalMonitorStateException] \ IO =
+        pub def awaitUninterruptibly(condition: Condition): Result[##java.lang.IllegalMonitorStateException, Unit] \ IO =
             import java.util.concurrent.locks.Condition.awaitUninterruptibly(): Unit \ IO;
             let Condition(c) = condition;
             try {
@@ -84,7 +84,7 @@ namespace Concurrent {
         /// Wakes up one waiting thread.
         ///
         @Internal
-        pub def signal(condition: Condition): Result[Unit, ##java.lang.IllegalMonitorStateException] \ IO =
+        pub def signal(condition: Condition): Result[##java.lang.IllegalMonitorStateException, Unit] \ IO =
             import java.util.concurrent.locks.Condition.signal(): Unit \ IO;
             let Condition(c) = condition;
             try {
@@ -97,7 +97,7 @@ namespace Concurrent {
         /// Wakes up all waiting threads.
         ///
         @Internal
-        pub def signalAll(condition: Condition): Result[Unit, ##java.lang.IllegalMonitorStateException] \ IO =
+        pub def signalAll(condition: Condition): Result[##java.lang.IllegalMonitorStateException, Unit] \ IO =
             import java.util.concurrent.locks.Condition.signalAll(): Unit \ IO;
             let Condition(c) = condition;
             try {

--- a/main/src/library/Concurrent/ReentrantLock.flix
+++ b/main/src/library/Concurrent/ReentrantLock.flix
@@ -61,7 +61,7 @@ namespace Concurrent {
         /// Acquires the lock unless the current thread is interrupted.
         ///
         @Internal
-        pub def lockInterruptibly(lock: ReentrantLock): Result[Unit, ##java.lang.InterruptedException] \ IO =
+        pub def lockInterruptibly(lock: ReentrantLock): Result[##java.lang.InterruptedException, Unit] \ IO =
             import java.util.concurrent.locks.ReentrantLock.lockInterruptibly(): Unit \ IO;
             let ReentrantLock(l) = lock;
             try {
@@ -92,7 +92,7 @@ namespace Concurrent {
         /// Acquires the lock if it is not held by another thread within the given waiting time (nanos) and the current thread has not been interrupted.
         ///
         @Internal
-        pub def tryLockNanos(lock: ReentrantLock, nanosTimeout: Int64): Result[Bool, ##java.lang.InterruptedException] \ IO =
+        pub def tryLockNanos(lock: ReentrantLock, nanosTimeout: Int64): Result[##java.lang.InterruptedException, Bool] \ IO =
             import java.util.concurrent.locks.ReentrantLock.tryLock(Int64, ##java.util.concurrent.TimeUnit): Bool \ IO;
             import static get java.util.concurrent.TimeUnit.NANOSECONDS: ##java.util.concurrent.TimeUnit \ IO as nano;
             let ReentrantLock(l) = lock;
@@ -106,7 +106,7 @@ namespace Concurrent {
         /// Attempts to release this lock.
         ///
         @Internal
-        pub def unlock(lock: ReentrantLock): Result[Unit, ##java.lang.IllegalMonitorStateException] \ IO =
+        pub def unlock(lock: ReentrantLock): Result[##java.lang.IllegalMonitorStateException, Unit] \ IO =
             import java.util.concurrent.locks.ReentrantLock.unlock(): Unit \ IO;
             let ReentrantLock(l) = lock;
             try {

--- a/main/src/library/File.flix
+++ b/main/src/library/File.flix
@@ -28,7 +28,7 @@ namespace File {
     ///
     /// Returns the last access time of the given file `f` in milliseconds.
     ///
-    pub def accessTime(f: String): Result[Int64, String] \ IO =
+    pub def accessTime(f: String): Result[String, Int64] \ IO =
         try {
             use Result.flatMap;
             import java.nio.file.attribute.BasicFileAttributes.lastAccessTime(): ##java.nio.file.attribute.FileTime \ IO;
@@ -48,7 +48,7 @@ namespace File {
     ///
     /// Returns the creation time of the given file `f` in milliseconds.
     ///
-    pub def creationTime(f: String): Result[Int64, String] \ IO =
+    pub def creationTime(f: String): Result[String, Int64] \ IO =
         try {
             use Result.flatMap;
             import java.nio.file.attribute.BasicFileAttributes.creationTime(): ##java.nio.file.attribute.FileTime \ IO;
@@ -68,7 +68,7 @@ namespace File {
     ///
     /// Returns the last-modified timestamp of the given file `f` in milliseconds
     ///
-    pub def modificationTime(f: String): Result[Int64, String] \ IO =
+    pub def modificationTime(f: String): Result[String, Int64] \ IO =
         try {
             use Result.flatMap;
             import java.nio.file.attribute.BasicFileAttributes.lastModifiedTime(): ##java.nio.file.attribute.FileTime \ IO;
@@ -88,7 +88,7 @@ namespace File {
     ///
     /// Returns the size of the given file `f` in bytes.
     ///
-    pub def size(f: String): Result[Int64, String] \ IO =
+    pub def size(f: String): Result[String, Int64] \ IO =
         try {
             use Result.flatMap;
             import java.nio.file.attribute.BasicFileAttributes.size(): Int64 \ IO;
@@ -106,7 +106,7 @@ namespace File {
     ///
     /// Returns the BacisFileAttributes of the file `f`.
     ///
-    def getAttributes(f: String): Result[##java.nio.file.attribute.BasicFileAttributes, String] \ IO = region r {
+    def getAttributes(f: String): Result[String, ##java.nio.file.attribute.BasicFileAttributes] \ IO = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -128,7 +128,7 @@ namespace File {
     ///
     /// Returns the type of the given file `f`.
     ///
-    pub def fileType(f: String): Result[FileType, String] \ IO =
+    pub def fileType(f: String): Result[String, FileType] \ IO =
         use Result.flatMap;
 
         let* isFile = File.isRegularFile(f);
@@ -154,7 +154,7 @@ namespace File {
     ///
     /// Returns the statistics of the given file `f`.
     ///
-    pub def stat(f: String): Result[StatInfo, String] \ IO =
+    pub def stat(f: String): Result[String, StatInfo] \ IO =
         use Result.flatMap;
 
         let* fileAccessTime = accessTime(f);
@@ -174,7 +174,7 @@ namespace File {
     ///
     /// Returns `true` if the given file `f` exists.
     ///
-    pub def exists(f: String): Result[Bool, String] \ IO =
+    pub def exists(f: String): Result[String, Bool] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.exists(): Bool \ IO;
@@ -188,7 +188,7 @@ namespace File {
     ///
     /// Returns `true` is the given file `f` is a directory.
     ///
-    pub def isDirectory(f: String): Result[Bool, String] \ IO =
+    pub def isDirectory(f: String): Result[String, Bool] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.isDirectory(): Bool \ IO;
@@ -202,7 +202,7 @@ namespace File {
     ///
     /// Returns `true` if the given file `f` is a regular file.
     ///
-    pub def isRegularFile(f: String): Result[Bool, String] \ IO = region r {
+    pub def isRegularFile(f: String): Result[String, Bool] \ IO = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -221,7 +221,7 @@ namespace File {
     ///
     /// Returns `true` if the given file `f` is readable.
     ///
-    pub def isReadable(f: String): Result[Bool, String] \ IO =
+    pub def isReadable(f: String): Result[String, Bool] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.canRead(): Bool \ IO;
@@ -235,7 +235,7 @@ namespace File {
     ///
     /// Returns `true` if the given file `f` is a symbolic link.
     ///
-    pub def isSymbolicLink(f: String): Result[Bool, String] \ IO =
+    pub def isSymbolicLink(f: String): Result[String, Bool] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -253,7 +253,7 @@ namespace File {
     ///
     /// Returns `true` if the given file `f` is writable.
     ///
-    pub def isWritable(f: String): Result[Bool, String] \ IO =
+    pub def isWritable(f: String): Result[String, Bool] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.canWrite(): Bool \ IO;
@@ -267,7 +267,7 @@ namespace File {
     ///
     /// Returns `true` if the given file `f` is executable.
     ///
-    pub def isExecutable(f: String): Result[Bool, String] \ IO =
+    pub def isExecutable(f: String): Result[String, Bool] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.canExecute(): Bool \ IO;
@@ -340,7 +340,7 @@ namespace File {
     /// Helper function for `readWith` and `readBytesWith`.
     /// Tries to skip the requested number of bytes `bytes to skip` in `f` over `i + 1` iterations.
     ///
-    def skip(i: Int64, bytesToSkip: Int64, stream: ##java.io.FileInputStream, f: String): Result[Unit, String] \ IO =
+    def skip(i: Int64, bytesToSkip: Int64, stream: ##java.io.FileInputStream, f: String): Result[String, Unit] \ IO =
         try {
             if (0i64 <= i) {
                 import java.io.FileInputStream.skip(Int64): Int64 \ IO as javaSkip;
@@ -361,7 +361,7 @@ namespace File {
     ///
     /// Returns a list of all the lines in the given file `f`.
     ///
-    pub def readLines(f: String): Result[List[String], String] \ IO = try {
+    pub def readLines(f: String): Result[String, List[String]] \ IO = try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
             import static java.nio.file.Files.newBufferedReader(##java.nio.file.Path): ##java.io.BufferedReader \ IO;
@@ -394,7 +394,7 @@ namespace File {
     /// The options `opts` to apply consists of
     /// `charSet` - the specific charset to be used to decode the bytes.
     ///
-    pub def readLinesWith(opts: {charSet = String}, f: String): Result[List[String], String] \ IO =
+    pub def readLinesWith(opts: {charSet = String}, f: String): Result[String, List[String]] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -489,7 +489,7 @@ namespace File {
     ///
     /// Returns an array of all the bytes in the given file `f`.
     ///
-    pub def readBytes(_r: Region[r], f: String): Result[Array[Int8, r], String] \ { Write(r), IO } =
+    pub def readBytes(_r: Region[r], f: String): Result[String, Array[Int8, r]] \ { Write(r), IO } =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -512,7 +512,7 @@ namespace File {
     /// `offset` - the start offset in the given file `f`.
     /// `count` - the number of bytes read.
     ///
-    pub def readBytesWith(r: Region[r], opts: {offset = Int64, count = Int32}, f: String): Result[Array[Int8, r], String] \ { Read(r), Write(r), IO } =
+    pub def readBytesWith(r: Region[r], opts: {offset = Int64, count = Int32}, f: String): Result[String, Array[Int8, r]] \ { Read(r), Write(r), IO } =
         if (0 < opts.count) {
             try {
                 import new java.io.File(String): ##java.io.File \ IO as newFile;
@@ -561,7 +561,7 @@ namespace File {
     ///
     /// Returns an iterator of the bytes in the given `file` in chunks of size `chunkSize`.
     ///
-    pub def readChunks(r: Region[r], chunkSize: Int32, f: String): Iterator[Result[Array[Int8, r], String], r] \ IO =
+    pub def readChunks(r: Region[r], chunkSize: Int32, f: String): Iterator[Result[String, Array[Int8, r]], r] \ IO =
         if (0 < chunkSize) {
             try {
                 import new java.io.File(String): ##java.io.File \ IO as newFile;
@@ -608,7 +608,7 @@ namespace File {
     ///
     /// Returns `true` if the file was created.
     ///
-    pub def write(f: String, data: t): Result[Bool, String] \ IO with ToString[t] =
+    pub def write(f: String, data: t): Result[String, Bool] \ IO with ToString[t] =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import new java.io.PrintWriter(##java.io.File): ##java.io.PrintWriter \ IO as newPrintWriter;
@@ -643,7 +643,7 @@ namespace File {
     ///
     /// Returns `true` if the file `f` was created, and `false` if `f` was overwritten.
     ///
-    pub def writeLines(f: String, data: f[String]): Result[Bool, String] \ IO with Foldable[f] =
+    pub def writeLines(f: String, data: f[String]): Result[String, Bool] \ IO with Foldable[f] =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import new java.io.PrintWriter(##java.io.File): ##java.io.PrintWriter \ IO as newPrintWriter;
@@ -676,7 +676,7 @@ namespace File {
     ///
     /// Returns `true` if the file `f` was created, and `false` if `data` was appended to an existing `f`.
     ///
-    pub def append(f: String, data: t): Result[Bool, String] \ IO with ToString[t] =
+    pub def append(f: String, data: t): Result[String, Bool] \ IO with ToString[t] =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import new java.io.FileWriter(##java.io.File, Bool): ##java.io.FileWriter \ IO as newFileWriter;
@@ -712,7 +712,7 @@ namespace File {
     ///
     /// Returns `true` if the file `f` was created, and `false` if `data` was appended to an existing `f`.
     ///
-    pub def appendLines(f: String, data: f[String]): Result[Bool, String] \ IO with Foldable[f] =
+    pub def appendLines(f: String, data: f[String]): Result[String, Bool] \ IO with Foldable[f] =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import new java.io.FileWriter(##java.io.File, Bool): ##java.io.FileWriter \ IO as newFileWriter;
@@ -750,7 +750,7 @@ namespace File {
     ///
     /// Returns `true` if the file `f` was created, and `false` if `f` was overwritten.
     ///
-    pub def writeBytes(f: String, data: f[Int8]): Result[Bool, String] \ IO with Foldable[f] = region r {
+    pub def writeBytes(f: String, data: f[Int8]): Result[String, Bool] \ IO with Foldable[f] = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import new java.io.FileOutputStream(##java.io.File): ##java.io.FileOutputStream \ IO as newFileStream;
@@ -787,7 +787,7 @@ namespace File {
     ///
     /// Returns `true` if the file `f` was created, and `false` if `data` was appended to an existing `f`.
     ///
-    pub def appendBytes(f: String, data: f[Int8]): Result[Bool, String] \ IO with Foldable[f] = region r {
+    pub def appendBytes(f: String, data: f[Int8]): Result[String, Bool] \ IO with Foldable[f] = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import new java.io.FileOutputStream(##java.io.File, Bool): ##java.io.FileOutputStream \ IO as newFileStream;
@@ -824,7 +824,7 @@ namespace File {
     ///
     /// Returns `true` if the file `f` was created, and `false` if `f` was overwritten.
     ///
-    pub def truncate(f: String): Result[Bool, String] \ IO =
+    pub def truncate(f: String): Result[String, Bool] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import new java.io.PrintWriter(##java.io.File): ##java.io.PrintWriter \ IO as newPrintWriter;
@@ -857,7 +857,7 @@ namespace File {
     /// Returns `Ok(false)` if the directory `d` already existed and is a directory.
     /// Returns `Err(msg)` if the directory could not be created.
     ///
-    pub def mkdir(d: String): Result[Bool, String] \ IO =
+    pub def mkdir(d: String): Result[String, Bool] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.mkdir(): Bool \ IO;
@@ -877,7 +877,7 @@ namespace File {
     /// Returns `Ok(false)` if the directory `d` already existed and is a directory.
     /// Returns `Err(msg)` if the directory could not be created.
     ///
-    pub def mkdirs(d: String): Result[Bool, String] \ IO =
+    pub def mkdirs(d: String): Result[String, Bool] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.mkdirs(): Bool \ IO;
@@ -896,7 +896,7 @@ namespace File {
     ///
     /// Does not recursively traverse the directory.
     ///
-    pub def list(f: String): Result[List[String], String] \ IO = region r {
+    pub def list(f: String): Result[String, List[String]] \ IO = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.listFiles(): Array[##java.io.File, r] \ IO;
@@ -924,7 +924,7 @@ namespace File {
     ///
     /// Does not recursively traverse the directory.
     ///
-    pub def listWithIter(r: Region[r], f: String): Result[Iterator[String, r], String] \ IO =
+    pub def listWithIter(r: Region[r], f: String): Result[String, Iterator[String, r]] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -951,7 +951,7 @@ namespace File {
     ///
     /// Recursively traverses the directory.
     ///
-    pub def walk(r: Region[r], f: String): Result[Iterator[String, r], String] \ IO =
+    pub def walk(r: Region[r], f: String): Result[String, Iterator[String, r]] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -998,7 +998,7 @@ namespace File {
     /// - `dst` is a subpath of `src`, or
     /// - an I/O error occurred.
     ///
-    pub def move(src: {src = String} , dst: String): Result[Unit, String] \ IO = region r {
+    pub def move(src: {src = String} , dst: String): Result[String, Unit] \ IO = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -1027,7 +1027,7 @@ namespace File {
     /// - `dst` is not a directory, or
     /// - an I/O error occurred.
     ///
-    pub def moveInto(src: {src = String} , dst: String): Result[Unit, String] \ IO =
+    pub def moveInto(src: {src = String} , dst: String): Result[String, Unit] \ IO =
         try {
             match File.isDirectory(dst) {
                 case Ok(true)  => {
@@ -1058,7 +1058,7 @@ namespace File {
     /// Returns `Ok(())` if `src` was moved.
     /// Returns `Err(msg)` if `src` was not moved, or an I/O error occurred.
     ///
-    pub def moveOver(src: {src = String}, dst: String): Result[Unit, String] \ IO = region r {
+    pub def moveOver(src: {src = String}, dst: String): Result[String, Unit] \ IO = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -1089,7 +1089,7 @@ namespace File {
     /// - `dst` is a subpath of `src`, or
     /// - an I/O error occurred.
     ///
-    pub def copy(src: {src = String} , dst: String): Result[Unit, String] \ IO = region r {
+    pub def copy(src: {src = String} , dst: String): Result[String, Unit] \ IO = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -1118,7 +1118,7 @@ namespace File {
     /// - `dst` is not a directory, or
     /// - an I/O error occurred.
     ///
-    pub def copyInto(src: {src = String} , dst: String): Result[Unit, String] \ IO =
+    pub def copyInto(src: {src = String} , dst: String): Result[String, Unit] \ IO =
         try {
             match File.isDirectory(dst) {
                 case Ok(true)  => {
@@ -1149,7 +1149,7 @@ namespace File {
     /// Returns `Ok(())` if `src` was copied.
     /// Returns `Err(msg)` if `src` was not copied, or an I/O error occurred.
     ///
-    pub def copyOver(src: {src = String}, dst: String): Result[Unit, String] \ IO = region r {
+    pub def copyOver(src: {src = String}, dst: String): Result[String, Unit] \ IO = region r {
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -1176,7 +1176,7 @@ namespace File {
     ///
     /// If `f` is a directory it must be empty.
     ///
-    pub def delete(f: String): Result[Unit, String] \ IO =
+    pub def delete(f: String): Result[String, Unit] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -1198,7 +1198,7 @@ namespace File {
     ///
     /// If `f` is a directory it must be empty.
     ///
-    pub def deleteIfExists(f: String): Result[Bool, String] \ IO =
+    pub def deleteIfExists(f: String): Result[String, Bool] \ IO =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;

--- a/main/src/library/GetOpt.flix
+++ b/main/src/library/GetOpt.flix
@@ -298,7 +298,7 @@ namespace GetOpt {
     ///
     /// It returns `Err(Ambiguous(xs))` if `xc` identifies more than one option descriptor.
     ///
-    def findOptionByName(optname: String, optDescrs: List[OptionDescr[a]]): Result[OptionDescr[a], GetOptionFailure[a]] =
+    def findOptionByName(optname: String, optDescrs: List[OptionDescr[a]]): Result[GetOptionFailure[a], OptionDescr[a]] =
         let getWith     = p -> List.filterMap(o -> { let xs = o.optionNames; if (List.exists(p(optname), xs)) Some(o) else None}, optDescrs);
         /// Exact match of `optname` ...
         let exact       = getWith((x,y) -> x == y): List[OptionDescr[a]];
@@ -317,7 +317,7 @@ namespace GetOpt {
     ///
     /// It returns `Err(Ambiguous(xs))` if `xc` identifies more than one option descriptor.
     ///
-    def findOptionById(xc: Char, optDescrs: List[OptionDescr[a]]): Result[OptionDescr[a], GetOptionFailure[a]] =
+    def findOptionById(xc: Char, optDescrs: List[OptionDescr[a]]): Result[GetOptionFailure[a], OptionDescr[a]] =
         /// This finds 0, 1, or more results. "more" is a failure (ambiguous), 0 is ignored, 1 is success.
         let options = List.filterMap(o -> { let ss = o.optionIds; if (List.exists(s -> s == xc, ss)) Some(o) else None}, optDescrs);
         match options {

--- a/main/src/library/GetOpt.flix
+++ b/main/src/library/GetOpt.flix
@@ -151,7 +151,7 @@ namespace GetOpt {
     ///
     pub def getOpt(ordering: ArgOrder[a],
                    optDescriptors: List[OptionDescr[a]],
-                   sourceArgs: List[String]): Validation[{options = List[a], nonOptions = List[String]}, String] =
+                   sourceArgs: List[String]): Validation[String, {options = List[a], nonOptions = List[String]}] =
         let answers = getOpt1(ordering, optDescriptors, sourceArgs);
         match answers.errors ::: List.map(errUnrec, answers.unknowns) {
             case Nil => Validation.Success({options = answers.options, nonOptions = answers.nonOptions})

--- a/main/src/library/Int32.flix
+++ b/main/src/library/Int32.flix
@@ -291,7 +291,7 @@ namespace Int32 {
     /// Leading or trailing whitespace is trimmed.
     /// A successful parse is wrapped with `Ok(x)`, a parse failure is indicated by `Err(_)`.
     ///
-    pub def parse(radix: Int32, s: String): Result[Int32, String] =
+    pub def parse(radix: Int32, s: String): Result[String, Int32] =
         try {
             import java.lang.String.strip(): String \ {};
             import static java.lang.Integer.parseInt(String, Int32): Int32 \ {};

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -291,7 +291,7 @@ namespace Int64 {
     /// Leading or trailing whitespace is trimmed.
     /// A successful parse is wrapped with `Ok(x)`, a parse failure is indicated by `Err(_)`.
     ///
-    pub def parse(radix: Int32, s: String): Result[Int64, String] = try {
+    pub def parse(radix: Int32, s: String): Result[String, Int64] = try {
         import java.lang.String.strip(): String \ {};
         import static java.lang.Long.parseLong(String, Int32): Int64 \ {};
         Ok(parseLong(strip(s), radix))

--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -27,7 +27,7 @@ instance Scoped[Iterator[a]] {
 }
 
 instance Iterable[Iterator] {
-    pub def iterator(r1: Region[r1], iter: Iterator[a, r2]): Iterator[a, r1 and r2] \ { Write(r1), Read(r2) } = 
+    pub def iterator(r1: Region[r1], iter: Iterator[a, r2]): Iterator[a, r1 and r2] \ { Write(r1), Read(r2) } =
         let _ = r1; // Avoid redundancy error
         unsafe_cast iter as Iterator[a, r1 and r2] \ { Write(r1), Read(r2) }
 }
@@ -529,7 +529,7 @@ namespace Iterator {
     /// If `f` returns `Err(e)`, then the iterator is depleted.
     ///
     @Lazy
-    pub def unfoldWithOk(r: Region[r], f: Unit -> Result[a, b] \ ef): Iterator[a, r and ef] \ Write(r) =
+    pub def unfoldWithOk(r: Region[r], f: Unit -> Result[e, a] \ ef): Iterator[a, r and ef] \ Write(r) =
         let cursor = ref None @ r;
         let done = () -> match deref cursor {
             case None    => match f() {
@@ -883,7 +883,7 @@ namespace Iterator {
     /// If any stage of the iterator is `Err(e)` then `Err(e)` is returned (first fail).
     /// If the iterator has no errors then the result is wrapped with `Ok`.
     ///
-    pub def toResultList(iter: Iterator[Result[a, e], r]): Result[List[a], e] \ Read(r) =
+    pub def toResultList(iter: Iterator[Result[e, a], r]): Result[e, List[a]] \ Read(r) =
         let Iterator(done, next) = iter;
         def loop(fk, sk) = {
             if (done())

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -1237,7 +1237,7 @@ namespace List {
     ///
     /// `next` should return `Err(e)` to signal that an error occurred. The function returns `Err(e)`.
     ///
-    pub def unfoldWithOkIter(next: Unit -> Result[Option[a], e] \ ef): Result[List[a], e] \ ef =
+    pub def unfoldWithOkIter(next: Unit -> Result[e, Option[a]] \ ef): Result[e, List[a]] \ ef =
         def loop(k) = match next() {
             case Ok(None)    => k(Ok(Nil))
             case Err(e)      => k(Err(e))

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -456,7 +456,7 @@ namespace Option {
     ///
     /// Returns the Validation value `Success(v)` if `o` is `Some(v)`. Otherwise lifts `e` into Validation's `Failure`.
     ///
-    pub def toSuccess(e: e, o: Option[t]): Validation[t, e] = match o {
+    pub def toSuccess(e: e, o: Option[t]): Validation[e, t] = match o {
         case None    => Validation.Failure(Nec.singleton(e))
         case Some(a) => Validation.Success(a)
     }
@@ -464,7 +464,7 @@ namespace Option {
     ///
     /// Returns `e` into Validation's `Failure` if `o` is `Some(e)`. Otherwise returns `Success(d)`.
     ///
-    pub def toFailure(d: t, o: Option[e]): Validation[t, e] = match o {
+    pub def toFailure(d: t, o: Option[e]): Validation[e, t] = match o {
         case None    => Validation.Success(d)
         case Some(e) => Validation.Failure(Nec.singleton(e))
     }

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -440,7 +440,7 @@ namespace Option {
     ///
     /// Returns the Option value `Ok(v)` if `o` is `Some(v)`. Otherwise returns `Err(e)`.
     ///
-    pub def toOk(e: e, o: Option[t]): Result[t, e] = match o {
+    pub def toOk(e: e, o: Option[t]): Result[e, t] = match o {
         case None    => Err(e)
         case Some(a) => Ok(a)
     }
@@ -448,7 +448,7 @@ namespace Option {
     ///
     /// Returns the Option value `Err(e)` if `o` is `Some(e)`. Otherwise returns `Ok(d)`.
     ///
-    pub def toErr(d: t, o: Option[e]): Result[t, e] = match o {
+    pub def toErr(d: t, o: Option[e]): Result[e, t] = match o {
         case None    => Ok(d)
         case Some(e) => Err(e)
     }

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -21,13 +21,13 @@
 /// The constructor `Ok(v)` represents the successful value `v`,
 /// whereas the constructor `Err(v)` represents the error value `v`.
 ///
-pub enum Result[t, e] with Eq, Order, ToString, Sendable {
+pub enum Result[e, t] with Eq, Order, ToString, Sendable {
     case Ok(t),
     case Err(e)
 }
 
-instance Hash[Result[t, e]] with Hash[t], Hash[e] {
-    pub def hash(r: Result[t, e]): Int32 = match r {
+instance Hash[Result[e, t]] with Hash[t], Hash[e] {
+    pub def hash(r: Result[e, t]): Int32 = match r {
         case Ok(v)  => 5381 + 113 * Hash.hash(v)
         case Err(v) => 5351 + 97 * Hash.hash(v)
     }
@@ -38,7 +38,7 @@ namespace Result {
     ///
     /// Returns `true` iff `r` is `Ok(v)`.
     ///
-    pub def isOk(r: Result[t, e]): Bool = match r {
+    pub def isOk(r: Result[e, t]): Bool = match r {
         case Ok(_)  => true
         case Err(_) => false
     }
@@ -46,7 +46,7 @@ namespace Result {
     ///
     /// Returns `true` iff `r` is `Err(w)`.
     ///
-    pub def isErr(r: Result[t, e]): Bool = match r {
+    pub def isErr(r: Result[e, t]): Bool = match r {
         case Ok(_)  => false
         case Err(_) => true
     }
@@ -54,7 +54,7 @@ namespace Result {
     ///
     /// Returns `v` if `r` is `Ok(v)`. Otherwise returns `d`.
     ///
-    pub def getWithDefault(d: t, r: Result[t, e]): t = match r {
+    pub def getWithDefault(d: t, r: Result[e, t]): t = match r {
         case Ok(v)  => v
         case Err(_) => d
     }
@@ -62,7 +62,7 @@ namespace Result {
     ///
     /// Returns `Ok(v)` if `r` is `Ok(v)`. Otherwise returns `default`.
     ///
-    pub def withDefault(default: {default = Result[t, e2]}, r: Result[t, e1]): Result[t, e2] = match r {
+    pub def withDefault(default: {default = Result[e2, t]}, r: Result[e1, t]): Result[e2, t] = match r {
         case Ok(v)  => Ok(v)
         case Err(_) => default.default
     }
@@ -70,7 +70,7 @@ namespace Result {
     ///
     /// Returns `Ok(to)` if `r` is `Ok(from)`. Otherwise returns `r`.
     ///
-    pub def replace(from: {from = t}, to: {to = t}, r: Result[t, e]): Result[t, e] with Eq[t] = match r {
+    pub def replace(from: {from = t}, to: {to = t}, r: Result[e, t]): Result[e, t] with Eq[t] = match r {
         case Ok(v)  => Ok(if (v == from.from) to.to else v)
         case Err(_) => r
     }
@@ -78,7 +78,7 @@ namespace Result {
     ///
     /// Returns `true` if `r` is `Ok(v)` and the predicate `f(v)` evaluates to `true`. Otherwise returns `false`.
     ///
-    pub def exists(f: t -> Bool \ ef, r: Result[t, e]): Bool \ ef = match r {
+    pub def exists(f: t -> Bool \ ef, r: Result[e, t]): Bool \ ef = match r {
         case Ok(t)  => f(t)
         case Err(_) => false
     }
@@ -87,7 +87,7 @@ namespace Result {
     /// Returns `true` if `r` is `Ok(v)` and the predicate `f(v)` evaluates to `true` or if `r` is `Err(w)`.
     /// Otherwise returns `false`.
     ///
-    pub def forAll(f: t -> Bool \ ef, r: Result[t, e]): Bool \ ef = match r {
+    pub def forAll(f: t -> Bool \ ef, r: Result[e, t]): Bool \ ef = match r {
         case Ok(t)  => f(t)
         case Err(_) => true
     }
@@ -95,7 +95,7 @@ namespace Result {
     ///
     /// Returns `Ok(f(v))` if `r` is `Ok(v)`. Returns `Err(w)` if `r` is `Err(w)`.
     ///
-    pub def map(f: t1 -> t2 \ ef, r: Result[t1, e]): Result[t2, e] \ ef = match r {
+    pub def map(f: t1 -> t2 \ ef, r: Result[e, t1]): Result[e, t2] \ ef = match r {
         case Ok(v)  => Ok(f(v))
         case Err(w) => Err(w)
     }
@@ -103,7 +103,7 @@ namespace Result {
     ///
     /// Returns `Err(f(e))` if `r` is `Err(e)`. Returns `Ok(v)` if `r` is `Ok(v)`.
     ///
-    pub def mapErr(f: e1 -> e2 \ ef, r: Result[t, e1]): Result[t, e2] \ ef = match r {
+    pub def mapErr(f: e1 -> e2 \ ef, r: Result[e1, t]): Result[e2, t] \ ef = match r {
         case Ok(v)  => Ok(v)
         case Err(w) => Err(f(w))
     }
@@ -112,7 +112,7 @@ namespace Result {
     ///
     /// Returns `f(v)` if `r` is `Ok(v)`. Returns `Err(w)` if `r` is `Err(w)`.
     ///
-    pub def flatMap(f: t1 -> Result[t2, e] \ ef, r: Result[t1, e]): Result[t2, e] \ ef = match r {
+    pub def flatMap(f: t1 -> Result[e, t2] \ ef, r: Result[e, t1]): Result[e, t2] \ ef = match r {
         case Ok(v)  => f(v)
         case Err(w) => Err(w)
     }
@@ -120,7 +120,7 @@ namespace Result {
     ///
     /// Returns `v` if `r` is `Ok(v)`. Returns `Err(w)` if `r` is `Err(w)`.
     ///
-    pub def flatten(r: Result[Result[t, e], e]): Result[t, e] = match r {
+    pub def flatten(r: Result[e, Result[e, t]]): Result[e, t] = match r {
         case Ok(v)  => v
         case Err(w) => Err(w)
     }
@@ -128,7 +128,7 @@ namespace Result {
     ///
     /// Returns `1` if `r` is `Ok(v)` and the predicate `f(v)` evaluates to `true`. Otherwise returns `0`.
     ///
-    pub def count(f: t -> Bool \ ef, r: Result[t, e]): Int32 \ ef = match r {
+    pub def count(f: t -> Bool \ ef, r: Result[e, t]): Int32 \ ef = match r {
         case Ok(v)  => if (f(v)) 1 else 0
         case Err(_) => 0
     }
@@ -136,19 +136,19 @@ namespace Result {
     ///
     /// Returns `v` if `r` is `Ok(v)` else `0`.
     ///
-    pub def sum(r: Result[Int32, e]): Int32 =
+    pub def sum(r: Result[e, Int32]): Int32 =
         foldLeft((acc, x) -> acc + x, 0, r)
 
     ///
     /// Returns `f(v)` if `r` is `Ok(v)` else `0`.
     ///
-    pub def sumWith(f: t -> Int32 \ ef, r: Result[t, e]): Int32 \ ef =
+    pub def sumWith(f: t -> Int32 \ ef, r: Result[e, t]): Int32 \ ef =
         foldLeft((acc, x) -> acc + f(x), 0, r)
 
     ///
     /// Returns `v` if `r` is `Ok(v)` else `0`.
     ///
-    pub def product(r: Result[Int32, e]): Int32 =
+    pub def product(r: Result[e, Int32]): Int32 =
         if (isErr(r))
             1
         else
@@ -157,7 +157,7 @@ namespace Result {
     ///
     /// Returns `f(v)` if `r` is `Ok(v)` else `0`.
     ///
-    pub def productWith(f: t -> Int32 \ ef, r: Result[t, e]): Int32 \ ef =
+    pub def productWith(f: t -> Int32 \ ef, r: Result[e, t]): Int32 \ ef =
         if (isErr(r))
             1
         else
@@ -168,7 +168,7 @@ namespace Result {
     ///
     /// The function `f` must be pure.
     ///
-    pub def find(f: t -> Bool, r: Result[t, e]): Option[t] = match r {
+    pub def find(f: t -> Bool, r: Result[e, t]): Option[t] = match r {
         case Ok(v)  => if (f(v)) Some(v) else None
         case Err(_) => None
     }
@@ -176,7 +176,7 @@ namespace Result {
     ///
     /// Returns `f(z, v)` if `r` is `Ok(v)`. Otherwise returns `z`.
     ///
-    pub def foldLeft(f: (a, t) -> a \ ef, z: a, r: Result[t, e]): a \ ef = match r {
+    pub def foldLeft(f: (a, t) -> a \ ef, z: a, r: Result[e, t]): a \ ef = match r {
         case Ok(v)  => f(z, v)
         case Err(_) => z
     }
@@ -184,7 +184,7 @@ namespace Result {
     ///
     /// Returns `f(v, z)` if `r` is `Ok(v)`. Otherwise returns `z`.
     ///
-    pub def foldRight(f: (t, a) -> a \ ef, z: a, r: Result[t, e]): a \ ef = match r {
+    pub def foldRight(f: (t, a) -> a \ ef, z: a, r: Result[e, t]): a \ ef = match r {
         case Ok(v)  => f(v, z)
         case Err(_) => z
     }
@@ -194,7 +194,7 @@ namespace Result {
     ///
     /// A `foldRightWithCont` allows early termination by not calling the continuation.
     ///
-    pub def foldRightWithCont(f: (t, Unit -> a \ ef) -> a \ ef, z: a, r: Result[t, e]): a \ ef = match r {
+    pub def foldRightWithCont(f: (t, Unit -> a \ ef) -> a \ ef, z: a, r: Result[e, t]): a \ ef = match r {
         case Ok(v)  => f(v, upcast(_ -> z))
         case Err(_) => z
     }
@@ -203,7 +203,7 @@ namespace Result {
     /// Returns `Ok(v1 :: v2 :: ... :: vn)` if each of `l_i` is `Ok(v_i)`.
     /// Otherwise returns the first `Err` encountered.
     ///
-    pub def sequence(l: List[Result[a, e]]): Result[List[a], e] =
+    pub def sequence(l: List[Result[e, a]]): Result[e, List[a]] =
         def loop(ll, k) = match ll {
             case Nil         => k(Nil)
             case Err(e) :: _ => Err(e)
@@ -215,7 +215,7 @@ namespace Result {
     /// Returns `Some(v1 :: v2 :: ... v :: vn)` if each of `f(l_i)` is `Ok(v_i)`.
     /// Otherwise returns the first `Err` encountered.
     ///
-    pub def traverse(f: a -> Result[b, e] \ ef, l: List[a]): Result[List[b], e] \ ef =
+    pub def traverse(f: a -> Result[e, b] \ ef, l: List[a]): Result[e, List[b]] \ ef =
         def loop(ll, k) = match ll {
             case Nil     => k(Nil)
             case x :: xs => match f(x) {
@@ -231,7 +231,7 @@ namespace Result {
     /// This function is the "forgetful" version of `traverse`, use it when the you want the effect
     /// of applying `f` to each element but do not care about collecting the results.
     ///
-    pub def traverseX(f: a -> Result[b, e] \ ef, l: List[a]): Result[Unit, e] \ ef = match l {
+    pub def traverseX(f: a -> Result[e, b] \ ef, l: List[a]): Result[e, Unit] \ ef = match l {
         case Nil     => Ok()
         case x :: xs => match f(x) {
             case Ok(_)  => traverseX(f, xs)
@@ -249,7 +249,7 @@ namespace Result {
     /// If `f` is successfully applied to all elements in `l` the result is of the form:
     /// `Ok(f(...f(f(s, x1), x2)..., xn))`.
     ///
-    pub def foldLeftM(f: (b, a) -> Result[b, e] \ ef, s: b, l: List[a]): Result[b, e] \ ef = match l {
+    pub def foldLeftM(f: (b, a) -> Result[e, b] \ ef, s: b, l: List[a]): Result[e, b] \ ef = match l {
         case Nil     => Ok(s)
         case x :: xs => match f(s, x) {
             case Ok(s1) => foldLeftM(f, s1, xs)
@@ -267,7 +267,7 @@ namespace Result {
     /// If `f` is successfully applied to all elements in `l` the result is of the form:
     /// `Ok(f(x1, ...f(xn-1, f(xn, s))...))`.
     ///
-    pub def foldRightM(f: (a, b) -> Result[b, e] \ ef, s: b, l: List[a]): Result[b, e] \ ef =
+    pub def foldRightM(f: (a, b) -> Result[e, b] \ ef, s: b, l: List[a]): Result[e, b] \ ef =
         def loop(ll, k) = match ll {
             case Nil     => k(s)
             case x :: xs => loop(xs, s1 -> match f(x, s1) {
@@ -280,7 +280,7 @@ namespace Result {
     ///
     /// Returns a one-element list of the value `v` if `r` is `Ok(v)`. Otherwise returns the empty list.
     ///
-    pub def toList(r: Result[t, e]): List[t] = match r {
+    pub def toList(r: Result[e, t]): List[t] = match r {
         case Ok(v)  => v :: Nil
         case Err(_) => Nil
     }
@@ -288,7 +288,7 @@ namespace Result {
     ///
     /// Returns a one-element set of the value `v` if `r` is `Ok(v)`. Otherwise returns the empty set.
     ///
-    pub def toSet(r: Result[t, e]): Set[t] with Order[t] = match r {
+    pub def toSet(r: Result[e, t]): Set[t] with Order[t] = match r {
         case Ok(v)  => Set.singleton(v)
         case Err(_) => Set.empty()
     }
@@ -296,7 +296,7 @@ namespace Result {
     ///
     /// Returns a singleton map with the mapping `k -> v` if `o` is `Ok((k, v))`. Otherwise returns the empty map.
     ///
-    pub def toMap(r: Result[(k, v), e]): Map[k, v] with Order[k] = match r {
+    pub def toMap(r: Result[e, (k, v)]): Map[k, v] with Order[k] = match r {
         case Ok((k, v)) => Map.singleton(k, v)
         case Err(_)     => Map.empty()
     }
@@ -310,7 +310,7 @@ namespace Result {
     ///
     /// Returns `Some(v)` if `r` is `Ok(v)`. Otherwise returns `None`.
     ///
-    pub def toOption(r: Result[t, e]): Option[t] = match r {
+    pub def toOption(r: Result[e, t]): Option[t] = match r {
         case Ok(v)  => Some(v)
         case Err(_) => None
     }
@@ -318,7 +318,7 @@ namespace Result {
     ///
     /// Applies `f` to `v` if `r` is `Ok(v)`. Otherwise does nothing.
     ///
-    pub def forEach(f: t -> Unit \ ef, r: Result[t, e]): Unit \ ef = match r {
+    pub def forEach(f: t -> Unit \ ef, r: Result[e, t]): Unit \ ef = match r {
         case Ok(v)  => f(v)
         case Err(_) => ()
     }
@@ -326,7 +326,7 @@ namespace Result {
     ///
     /// Applies the function in `r1` to the value in `r2`.
     ///
-    pub def ap(r1: Result[t -> u \ ef, e], r2: Result[t, e]): Result[u, e] \ ef = match r1 {
+    pub def ap(r1: Result[e, t -> u \ ef], r2: Result[e, t]): Result[e, u] \ ef = match r1 {
         case Err(e) => Err(e)
         case Ok(f)  => match r2 {
             case Ok(a)  => Ok(f(a))
@@ -339,7 +339,7 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if either of `r1` and `r2` are `Err(e)`.
     ///
-    pub def lift2(f: (t1, t2) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e]): Result[u, e] \ ef =
+    pub def lift2(f: (t1, t2) -> u \ ef, r1: Result[e, t1], r2: Result[e, t2]): Result[e, u] \ ef =
         ap(map(f, r1), r2)
 
     ///
@@ -347,7 +347,7 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2` and `r3` are `Err(e)`.
     ///
-    pub def lift3(f: (t1, t2, t3) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e]): Result[u, e] \ ef =
+    pub def lift3(f: (t1, t2, t3) -> u \ ef, r1: Result[e, t1], r2: Result[e, t2], r3: Result[e, t3]): Result[e, u] \ ef =
         ap(lift2(f, r1, r2), r3)
 
     ///
@@ -355,7 +355,7 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2`, `r3` and `r4` are `Err(e)`.
     ///
-    pub def lift4(f: (t1, t2, t3, t4) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e], r4: Result[t4, e]): Result[u, e] \ ef =
+    pub def lift4(f: (t1, t2, t3, t4) -> u \ ef, r1: Result[e, t1], r2: Result[e, t2], r3: Result[e, t3], r4: Result[e, t4]): Result[e, u] \ ef =
         ap(lift3(f, r1, r2, r3), r4)
 
     ///
@@ -363,7 +363,7 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2`, ... `r5` are `Err(e)`.
     ///
-    pub def lift5(f: (t1, t2, t3, t4, t5) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e], r4: Result[t4, e], r5: Result[t5, e]): Result[u, e] \ ef =
+    pub def lift5(f: (t1, t2, t3, t4, t5) -> u \ ef, r1: Result[e, t1], r2: Result[e, t2], r3: Result[e, t3], r4: Result[e, t4], r5: Result[e, t5]): Result[e, u] \ ef =
         ap(lift4(f, r1, r2, r3, r4), r5)
 
     ///
@@ -371,7 +371,7 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2`, ... `r6` are `Err(e)`.
     ///
-    pub def lift6(f: (t1, t2, t3, t4, t5, t6) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e], r4: Result[t4, e], r5: Result[t5, e], r6: Result[t6, e]): Result[u, e] \ ef =
+    pub def lift6(f: (t1, t2, t3, t4, t5, t6) -> u \ ef, r1: Result[e, t1], r2: Result[e, t2], r3: Result[e, t3], r4: Result[e, t4], r5: Result[e, t5], r6: Result[e, t6]): Result[e, u] \ ef =
         ap(lift5(f, r1, r2, r3, r4, r5), r6)
 
     ///
@@ -379,7 +379,7 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2`, ... `r7` are `Err(e)`.
     ///
-    pub def lift7(f: (t1, t2, t3, t4, t5, t6, t7) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e], r4: Result[t4, e], r5: Result[t5, e], r6: Result[t6, e], r7: Result[t7, e]): Result[u, e] \ ef=
+    pub def lift7(f: (t1, t2, t3, t4, t5, t6, t7) -> u \ ef, r1: Result[e, t1], r2: Result[e, t2], r3: Result[e, t3], r4: Result[e, t4], r5: Result[e, t5], r6: Result[e, t6], r7: Result[e, t7]): Result[e, u] \ ef=
         ap(lift6(f, r1, r2, r3, r4, r5, r6), r7)
 
     ///
@@ -387,7 +387,7 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2`, ... `r8` are `Err(e)`.
     ///
-    pub def lift8(f: (t1, t2, t3, t4, t5, t6, t7, t8) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e], r4: Result[t4, e], r5: Result[t5, e], r6: Result[t6, e], r7: Result[t7, e], r8: Result[t8, e]): Result[u, e] \ ef =
+    pub def lift8(f: (t1, t2, t3, t4, t5, t6, t7, t8) -> u \ ef, r1: Result[e, t1], r2: Result[e, t2], r3: Result[e, t3], r4: Result[e, t4], r5: Result[e, t5], r6: Result[e, t6], r7: Result[e, t7], r8: Result[e, t8]): Result[e, u] \ ef =
         ap(lift7(f, r1, r2, r3, r4, r5, r6, r7), r8)
 
     ///
@@ -395,7 +395,7 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2`, ... `r9` are `Err(e)`.
     ///
-    pub def lift9(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e], r4: Result[t4, e], r5: Result[t5, e], r6: Result[t6, e], r7: Result[t7, e], r8: Result[t8, e], r9: Result[t9, e]): Result[u, e] \ ef =
+    pub def lift9(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9) -> u \ ef, r1: Result[e, t1], r2: Result[e, t2], r3: Result[e, t3], r4: Result[e, t4], r5: Result[e, t5], r6: Result[e, t6], r7: Result[e, t7], r8: Result[e, t8], r9: Result[e, t9]): Result[e, u] \ ef =
         ap(lift8(f, r1, r2, r3, r4, r5, r6, r7, r8), r9)
 
     ///
@@ -403,13 +403,13 @@ namespace Result {
     ///
     /// Returns the first `Err(e)` value if any of `r1`, `r2`, ... `r10` are `Err(e)`.
     ///
-    pub def lift10(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) -> u \ ef, r1: Result[t1, e], r2: Result[t2, e], r3: Result[t3, e], r4: Result[t4, e], r5: Result[t5, e], r6: Result[t6, e], r7: Result[t7, e], r8: Result[t8, e], r9: Result[t9, e], r10: Result[t10, e]): Result[u, e] \ ef =
+    pub def lift10(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) -> u \ ef, r1: Result[e, t1], r2: Result[e, t2], r3: Result[e, t3], r4: Result[e, t4], r5: Result[e, t5], r6: Result[e, t6], r7: Result[e, t7], r8: Result[e, t8], r9: Result[e, t9], r10: Result[e, t10]): Result[e, u] \ ef =
         ap(lift9(f, r1, r2, r3, r4, r5, r6, r7, r8, r9), r10)
 
     ///
     /// Returns an iterator over `r` with 1 element or an empty iterator if `r` is `Err`.
     ///
-    pub def iterator(reg: Region[reg], r: Result[t, e]): Iterator[t, reg] \ Write(reg) = match r {
+    pub def iterator(reg: Region[reg], r: Result[e, t]): Iterator[t, reg] \ Write(reg) = match r {
         case Err(_) => new Iterator(reg)
         case Ok(x)  => Iterator.singleton(reg, x)
     }
@@ -417,7 +417,7 @@ namespace Result {
     ///
     /// Returns an iterator over `r` zipped with the indices of the elements.
     ///
-    pub def enumerator(reg: Region[reg], r: Result[t, e]): Iterator[(t, Int32), reg] \ Write(reg) =
+    pub def enumerator(reg: Region[reg], r: Result[e, t]): Iterator[(t, Int32), reg] \ Write(reg) =
         iterator(reg, r) |> Iterator.zipWithIndex
 
     ///
@@ -426,7 +426,7 @@ namespace Result {
     /// If `f` throws a Java `RuntimeException`, `Err(e)` is returned
     /// where `e` is the error message.
     ///
-    pub def try(f: Unit -> a \ ef): Result[a, String] \ ef =
+    pub def try(f: Unit -> a \ ef): Result[String, a] \ ef =
         try {
             Ok(f())
         } catch {

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -26,7 +26,7 @@ pub enum Result[e, t] with Eq, Order, ToString, Sendable {
     case Err(e)
 }
 
-instance Hash[Result[e, t]] with Hash[t], Hash[e] {
+instance Hash[Result[e, t]] with Hash[e], Hash[t] {
     pub def hash(r: Result[e, t]): Int32 = match r {
         case Ok(v)  => 5381 + 113 * Hash.hash(v)
         case Err(v) => 5351 + 97 * Hash.hash(v)

--- a/main/src/library/Validation.flix
+++ b/main/src/library/Validation.flix
@@ -17,20 +17,20 @@
 ///
 /// The Validation type.
 ///
-pub enum Validation[t, e] with Eq, Order, ToString, Sendable {
+pub enum Validation[e, t] with Eq, Order, ToString, Sendable {
     case Success(t),
     case Failure(Nec[e])
 }
 
-instance Hash[Validation[t, e]] with Hash[t], Hash[e] {
-    pub def hash(x: Validation[t, e]): Int32 = match x {
+instance Hash[Validation[e, t]] with Hash[e], Hash[t] {
+    pub def hash(x: Validation[e, t]): Int32 = match x {
         case Validation.Success(v) => 5407 + 197 * Hash.hash(v)
         case Validation.Failure(v) => 5413 + 199 * Hash.hash(v)
     }
 }
 
-instance SemiGroup[Validation[t, e]] with SemiGroup[t] {
-    pub def combine(x: Validation[t, e], y: Validation[t, e]): Validation[t, e] = match (x, y) {
+instance SemiGroup[Validation[e, t]] with SemiGroup[t] {
+    pub def combine(x: Validation[e, t], y: Validation[e, t]): Validation[e, t] = match (x, y) {
         case (Validation.Success(x1), Validation.Success(y1))       => Validation.Success(SemiGroup.combine(x1, y1))
         case (Validation.Failure(es1), Validation.Failure(es2))     => Validation.Failure(Nec.append(es1, es2))
         case (Validation.Failure(_), _)                             => x
@@ -38,8 +38,8 @@ instance SemiGroup[Validation[t, e]] with SemiGroup[t] {
     }
 }
 
-instance Monoid[Validation[t, e]] with Monoid[t] {
-    pub def empty(): Validation[t, e] = Validation.Success(Monoid.empty())
+instance Monoid[Validation[e, t]] with Monoid[t] {
+    pub def empty(): Validation[e, t] = Validation.Success(Monoid.empty())
 }
 
 namespace Validation {
@@ -47,7 +47,7 @@ namespace Validation {
     ///
     /// Applies the function in `v1` to the value in `v2`.
     ///
-    pub def ap(v1: Validation[t -> u \ ef, e], v2: Validation[t, e]): Validation[u, e] \ ef = match (v1, v2) {
+    pub def ap(v1: Validation[e, t -> u \ ef], v2: Validation[e, t]): Validation[e, u] \ ef = match (v1, v2) {
         case (Success(f), Success(v)) => Success(f(v))
         case (Success(_), Failure(e)) => Failure(e)
         case (Failure(e), Success(_)) => Failure(e)
@@ -57,31 +57,31 @@ namespace Validation {
     ///
     /// Chain two functions, returns the product of their results.
     ///
-    pub def product(fa: Validation[t1, e], fb: Validation[t2, e]): Validation[(t1, t2), e] =
+    pub def product(fa: Validation[e, t1], fb: Validation[e, t2]): Validation[e, (t1, t2)] =
         ap(map((a, b) -> (a, b), fa), fb)
 
     ///
     /// Chain three functions, returns the product of their results.
     ///
-    pub def product3(fa: Validation[t1, e], fb: Validation[t2, e], fc: Validation[t3, e]): Validation[(t1, t2, t3), e] =
+    pub def product3(fa: Validation[e, t1], fb: Validation[e, t2], fc: Validation[e, t3]): Validation[e, (t1, t2, t3)] =
         ap(ap(map((a, b, c) -> (a, b, c), fa), fb), fc)
 
     ///
     /// Chain four functions, returns the product of their results.
     ///
-    pub def product4(fa: Validation[t1, e], fb: Validation[t2, e], fc: Validation[t3, e], fd: Validation[t4, e]): Validation[(t1, t2, t3, t4), e] =
+    pub def product4(fa: Validation[e, t1], fb: Validation[e, t2], fc: Validation[e, t3], fd: Validation[e, t4]): Validation[e, (t1, t2, t3, t4)] =
         ap(ap(ap(map((a, b, c, d) -> (a, b, c, d), fa), fb), fc), fd)
 
     ///
     /// Chain five functions, returns the product of their results.
     ///
-    pub def product5(fa: Validation[t1, e], fb: Validation[t2, e], fc: Validation[t3, e], fd: Validation[t4, e], fe: Validation[t5, e]): Validation[(t1, t2, t3, t4, t5), e] =
+    pub def product5(fa: Validation[e, t1], fb: Validation[e, t2], fc: Validation[e, t3], fd: Validation[e, t4], fe: Validation[e, t5]): Validation[e, (t1, t2, t3, t4, t5)] =
         ap(ap(ap(ap(map((a, b, c, d, e) -> (a, b, c, d, e), fa), fb), fc), fd), fe)
 
     ///
     /// Returns `t` if `v` is `Success(t).` Otherwise returns `d`.
     ///
-    pub def getWithDefault(d: t, v: Validation[t, e]): t = match v {
+    pub def getWithDefault(d: t, v: Validation[e, t]): t = match v {
         case Success(t) => t
         case Failure(_) => d
     }
@@ -89,7 +89,7 @@ namespace Validation {
     ///
     /// Returns `v` if it is `Success(v)`. Otherwise returns `default`.
     ///
-    pub def withDefault(default: {default = Validation[t, e]}, v: Validation[t, e]): Validation[t, e] = match v {
+    pub def withDefault(default: {default = Validation[e, t]}, v: Validation[e, t]): Validation[e, t] = match v {
         case Success(_) => v
         case Failure(_) => default.default
     }
@@ -99,7 +99,7 @@ namespace Validation {
     ///
     /// Returns `false` if `v` is `Failure`.
     ///
-    pub def exists(f: t -> Bool \ ef, v: Validation[t, e]): Bool \ ef = match v {
+    pub def exists(f: t -> Bool \ ef, v: Validation[e, t]): Bool \ ef = match v {
         case Success(t) => f(t)
         case Failure(_) => false
     }
@@ -107,7 +107,7 @@ namespace Validation {
     ///
     /// Returns `true` if `v` is `Success(t)` and `f(t)` is true or if `v` is `Failure`.
     ///
-    pub def forAll(f: t -> Bool \ ef, v: Validation[t, e]): Bool \ ef = match v {
+    pub def forAll(f: t -> Bool \ ef, v: Validation[e, t]): Bool \ ef = match v {
         case Success(t) => f(t)
         case Failure(_) => true
     }
@@ -115,7 +115,7 @@ namespace Validation {
     ///
     /// Returns `Success(f(v))` if `o` is `Success(v)`. Otherwise returns `v`.
     ///
-    pub def map(f: t -> u \ ef, v: Validation[t, e]): Validation[u, e] \ ef = match v {
+    pub def map(f: t -> u \ ef, v: Validation[e, t]): Validation[e, u] \ ef = match v {
         case Success(t) => Success(f(t))
         case Failure(e) => Failure(e)
     }
@@ -125,7 +125,7 @@ namespace Validation {
     ///
     /// Otherwise returns `Failure(e1 :: ... :: en)` with all of the failures concatenated.
     ///
-    pub def sequence(l: List[Validation[t, e]]): Validation[List[t], e] =
+    pub def sequence(l: List[Validation[e, t]]): Validation[e, List[t]] =
         def loop(ll, k) = match ll {
             case Nil              => k(Nil)
             case Success(x) :: xs => loop(xs, ks -> k(x :: ks))
@@ -138,7 +138,7 @@ namespace Validation {
     ///
     /// Otherwise returns `Failure(e1 :: ... :: en)` with all of the failures concatenated.
     ///
-    pub def traverse(f: a -> Validation[b, e] \ ef, l: List[a]): Validation[List[b], e] \ ef =
+    pub def traverse(f: a -> Validation[e, b] \ ef, l: List[a]): Validation[e, List[b]] \ ef =
         def loop(ll, k) = match ll {
             case Nil     => k(Nil)
             case x :: xs => match f(x) {
@@ -156,7 +156,7 @@ namespace Validation {
     /// This function is the "forgetful" version of `traverse`, use it when the you want the effect
     /// of applying `f` to each element but do not care about collecting the results.
     ///
-    pub def traverseX(f: a -> Validation[b, e] \ ef, l: List[a]): Validation[Unit, e] \ ef = match l {
+    pub def traverseX(f: a -> Validation[e, b] \ ef, l: List[a]): Validation[e, Unit] \ ef = match l {
         case Nil     => Success()
         case x :: xs => match f(x) {
             case Success(_) => traverseX(f, xs)
@@ -167,7 +167,7 @@ namespace Validation {
     ///
     /// Helper function for `sequence`, `traverse` and `traverseX`. Collects a chain of failures.
     ///
-    def collectFailuresWith(f: a -> Validation[b, e] \ ef, l: List[a], acc: Nec[e]): Validation[c, e] \ ef = match l {
+    def collectFailuresWith(f: a -> Validation[e, b] \ ef, l: List[a], acc: Nec[e]): Validation[e, c] \ ef = match l {
         case Nil     => Failure(acc)
         case x :: xs => match f(x) {
             case Success(_) => collectFailuresWith(f, xs, acc)
@@ -181,7 +181,7 @@ namespace Validation {
     /// Returns `Some(t)` if `v` is `Success(t)`.
     /// Returns `None` otherwise.
     ///
-    pub def toOption(v: Validation[t, e]): Option[t] = match v {
+    pub def toOption(v: Validation[e, t]): Option[t] = match v {
         case Success(t) => Some(t)
         case Failure(_) => None
     }
@@ -192,7 +192,7 @@ namespace Validation {
     /// Returns `Ok(t)` if `v` is `Success(t)`.
     /// Returns `Err(e)` if `v` is `Failure(e)`.
     ///
-    pub def toResult(v: Validation[t, e]): Result[Nec[e], t] = match v {
+    pub def toResult(v: Validation[e, t]): Result[Nec[e], t] = match v {
         case Success(t) => Ok(t)
         case Failure(e) => Err(e)
     }
@@ -203,7 +203,7 @@ namespace Validation {
     /// Returns `t :: Nil` if `v` is `Success(v)`.
     /// Returns `Nil` if `v` is `Failure(e)`.
     ///
-    pub def toList(v: Validation[t, e]): List[t] = match v {
+    pub def toList(v: Validation[e, t]): List[t] = match v {
         case Success(t) => t :: Nil
         case Failure(_) => Nil
     }
@@ -213,7 +213,7 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if either or both of `v1` or `v2` are `Failure(xs1)`.
     ///
-    pub def lift2(f: (t1, t2) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e]): Validation[u, e] \ ef =
+    pub def lift2(f: (t1, t2) -> u \ ef, v1: Validation[e, t1], v2: Validation[e, t2]): Validation[e, u] \ ef =
         ap(map(f, v1), v2)
 
     ///
@@ -221,7 +221,7 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2` and `v3` are `Failure(xs1)`.
     ///
-    pub def lift3(f: (t1, t2, t3) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e]): Validation[u, e] \ ef =
+    pub def lift3(f: (t1, t2, t3) -> u \ ef, v1: Validation[e, t1], v2: Validation[e, t2], v3: Validation[e, t3]): Validation[e, u] \ ef =
         ap(lift2(f, v1, v2), v3)
 
     ///
@@ -229,7 +229,7 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, `v3` and `v4` are `Failure(xs1)`.
     ///
-    pub def lift4(f: (t1, t2, t3, t4) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e]): Validation[u, e] \ ef=
+    pub def lift4(f: (t1, t2, t3, t4) -> u \ ef, v1: Validation[e, t1], v2: Validation[e, t2], v3: Validation[e, t3], v4: Validation[e, t4]): Validation[e, u] \ ef=
         ap(lift3(f, v1, v2, v3), v4)
 
     ///
@@ -237,7 +237,7 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v5` are `Failure(xs1)`.
     ///
-    pub def lift5(f: (t1, t2, t3, t4, t5) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e]): Validation[u, e] \ ef =
+    pub def lift5(f: (t1, t2, t3, t4, t5) -> u \ ef, v1: Validation[e, t1], v2: Validation[e, t2], v3: Validation[e, t3], v4: Validation[e, t4], v5: Validation[e, t5]): Validation[e, u] \ ef =
         ap(lift4(f, v1, v2, v3, v4), v5)
 
     ///
@@ -245,7 +245,7 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v6` are `Failure(xs1)`.
     ///
-    pub def lift6(f: (t1, t2, t3, t4, t5, t6) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e]): Validation[u, e] \ ef =
+    pub def lift6(f: (t1, t2, t3, t4, t5, t6) -> u \ ef, v1: Validation[e, t1], v2: Validation[e, t2], v3: Validation[e, t3], v4: Validation[e, t4], v5: Validation[e, t5], v6: Validation[e, t6]): Validation[e, u] \ ef =
         ap(lift5(f, v1, v2, v3, v4, v5), v6)
 
     ///
@@ -253,7 +253,7 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v7` are `Failure(xs1)`.
     ///
-    pub def lift7(f: (t1, t2, t3, t4, t5, t6, t7) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e]): Validation[u, e] \ ef=
+    pub def lift7(f: (t1, t2, t3, t4, t5, t6, t7) -> u \ ef, v1: Validation[e, t1], v2: Validation[e, t2], v3: Validation[e, t3], v4: Validation[e, t4], v5: Validation[e, t5], v6: Validation[e, t6], v7: Validation[e, t7]): Validation[e, u] \ ef=
         ap(lift6(f, v1, v2, v3, v4, v5, v6), v7)
 
     ///
@@ -261,7 +261,7 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v8` are `Failure(xs1)`.
     ///
-    pub def lift8(f: (t1, t2, t3, t4, t5, t6, t7, t8) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e], v8: Validation[t8, e]): Validation[u, e] \ ef =
+    pub def lift8(f: (t1, t2, t3, t4, t5, t6, t7, t8) -> u \ ef, v1: Validation[e, t1], v2: Validation[e, t2], v3: Validation[e, t3], v4: Validation[e, t4], v5: Validation[e, t5], v6: Validation[e, t6], v7: Validation[e, t7], v8: Validation[e, t8]): Validation[e, u] \ ef =
         ap(lift7(f, v1, v2, v3, v4, v5, v6, v7), v8)
 
     ///
@@ -269,7 +269,7 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v9` are `Failure(xs1)`.
     ///
-    pub def lift9(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e], v8: Validation[t8, e], v9: Validation[t9, e]): Validation[u, e] \ ef =
+    pub def lift9(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9) -> u \ ef, v1: Validation[e, t1], v2: Validation[e, t2], v3: Validation[e, t3], v4: Validation[e, t4], v5: Validation[e, t5], v6: Validation[e, t6], v7: Validation[e, t7], v8: Validation[e, t8], v9: Validation[e, t9]): Validation[e, u] \ ef =
         ap(lift8(f, v1, v2, v3, v4, v5, v6, v7, v8), v9)
 
     ///
@@ -277,7 +277,7 @@ namespace Validation {
     ///
     /// Returns the concatenation of all the failures as `Failure(xs)` if any of `v1`, `v2`, ... `v10` are `Failure(xs1)`.
     ///
-    pub def lift10(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) -> u \ ef, v1: Validation[t1, e], v2: Validation[t2, e], v3: Validation[t3, e], v4: Validation[t4, e], v5: Validation[t5, e], v6: Validation[t6, e], v7: Validation[t7, e], v8: Validation[t8, e], v9: Validation[t9, e], v10: Validation[t10, e]): Validation[u, e] \ ef =
+    pub def lift10(f: (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) -> u \ ef, v1: Validation[e, t1], v2: Validation[e, t2], v3: Validation[e, t3], v4: Validation[e, t4], v5: Validation[e, t5], v6: Validation[e, t6], v7: Validation[e, t7], v8: Validation[e, t8], v9: Validation[e, t9], v10: Validation[e, t10]): Validation[e, u] \ ef =
         ap(lift9(f, v1, v2, v3, v4, v5, v6, v7, v8, v9), v10)
 
 }

--- a/main/src/library/Validation.flix
+++ b/main/src/library/Validation.flix
@@ -192,7 +192,7 @@ namespace Validation {
     /// Returns `Ok(t)` if `v` is `Success(t)`.
     /// Returns `Err(e)` if `v` is `Failure(e)`.
     ///
-    pub def toResult(v: Validation[t, e]): Result[t, Nec[e]] = match v {
+    pub def toResult(v: Validation[t, e]): Result[Nec[e], t] = match v {
         case Success(t) => Ok(t)
         case Failure(e) => Err(e)
     }

--- a/main/test/ca/uwaterloo/flix/library/TestGetOpt.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestGetOpt.flix
@@ -63,12 +63,12 @@ namespace TestGetOpt {
         ::  {optionIds = 'h':: Nil,         optionNames = "height" :: Nil,              argDescriptor = ReqArg(height, "HEIGHT"),   explanation = "image HEIGHT" }
         :: Nil
 
-    def assertSuccessWith(x: Validation[a, e], test: a -> Bool): Bool  = match x {
+    def assertSuccessWith(x: Validation[e, a], test: a -> Bool): Bool  = match x {
         case Success(x1) => test(x1)
         case Failure(_) => false
     }
 
-    def assertFailureWith(x: Validation[a, e], test: Nec[e] -> Bool): Bool  = match x {
+    def assertFailureWith(x: Validation[e, a], test: Nec[e] -> Bool): Bool  = match x {
         case Success(_) => false
         case Failure(es) => test(es)
     }

--- a/main/test/ca/uwaterloo/flix/library/TestIterator.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterator.flix
@@ -1769,18 +1769,18 @@ namespace TestIterator {
 
     @test
     def toResultList01(): Bool = region r {
-        (Nil: List[Result[Int32, String]]) |> List.iterator(r) |>
+        (Nil: List[Result[String, Int32]]) |> List.iterator(r) |>
             Iterator.toResultList == Ok(Nil)
     }
     @test
     def toResultList02(): Bool = region r {
-        ((Ok(1) :: Nil): List[Result[Int32, String]]) |> List.iterator(r) |>
+        ((Ok(1) :: Nil): List[Result[String, Int32]]) |> List.iterator(r) |>
             Iterator.toResultList == Ok(1 :: Nil)
     }
 
     @test
     def toResultList03(): Bool = region r {
-        ((Ok(1) :: Ok(2) :: Ok(3) :: Nil): List[Result[Int32, String]]) |> List.iterator(r) |>
+        ((Ok(1) :: Ok(2) :: Ok(3) :: Nil): List[Result[String, Int32]]) |> List.iterator(r) |>
             Iterator.toResultList == Ok(1 :: 2 :: 3 :: Nil)
     }
 

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -2351,7 +2351,7 @@ def unfoldWithOkIter01(): Bool \ IO =
         } else {
             Ok(Some(deref x))
         };
-    List.unfoldWithOkIter(step): Result[_, Unit] == Ok(Nil)
+    List.unfoldWithOkIter(step): Result[Unit, _] == Ok(Nil)
 
 @test
 def unfoldWithOkIter02(): Bool \ IO =
@@ -2375,7 +2375,7 @@ def unfoldWithOkIter03(): Bool \ IO =
         } else {
             Ok(None)
         };
-    List.unfoldWithOkIter(step): Result[_, Unit] == Ok(1 :: 2 :: 3 :: 4 :: Nil)
+    List.unfoldWithOkIter(step): Result[Unit, _] == Ok(1 :: 2 :: 3 :: 4 :: Nil)
 
 /////////////////////////////////////////////////////////////////////////////
 // distinct                                                                //

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -49,16 +49,16 @@ namespace TestResult {
     // withDefault                                                             //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def withDefault01(): Bool = Result.withDefault({default = Ok(2)}, Ok(1)): Result[_, Unit] == Ok(1)
+    def withDefault01(): Bool = Result.withDefault({default = Ok(2)}, Ok(1)): Result[Unit, Int32] == Ok(1)
 
     @test
     def withDefault02(): Bool = Result.withDefault({default = Err(false)}, Ok(1)) == Ok(1)
 
     @test
-    def withDefault03(): Bool = Result.withDefault({default = Ok(2)}, Err(false)): Result[_, Unit] == Ok(2)
+    def withDefault03(): Bool = Result.withDefault({default = Ok(2)}, Err(false)): Result[Unit, Int32] == Ok(2)
 
     @test
-    def withDefault04(): Bool = Result.withDefault({default = Err(true)}, Err(false)): Result[Unit, _] == Err(true)
+    def withDefault04(): Bool = Result.withDefault({default = Err(true)}, Err(false)): Result[Bool, Unit] == Err(true)
 
     /////////////////////////////////////////////////////////////////////////////
     // replace                                                                 //
@@ -67,13 +67,13 @@ namespace TestResult {
     def replace01(): Bool = Result.replace(from = 3, to = 4, Err(false)) == Err(false)
 
     @test
-    def replace02(): Bool = Result.replace(from = 3, to = 4, Ok(2): Result[_, Unit]) == Ok(2)
+    def replace02(): Bool = Result.replace(from = 3, to = 4, Ok(2): Result[Unit, Int32]) == Ok(2)
 
     @test
-    def replace03(): Bool = Result.replace(from = 3, to = 4, Ok(3)): Result[_, Unit] == Ok(4)
+    def replace03(): Bool = Result.replace(from = 3, to = 4, Ok(3)): Result[Unit, Int32] == Ok(4)
 
     @test
-    def replace04(): Bool = Result.replace(from = 3, to = 4, Ok(4)): Result[_, Unit] == Ok(4)
+    def replace04(): Bool = Result.replace(from = 3, to = 4, Ok(4)): Result[Unit, Int32] == Ok(4)
 
     /////////////////////////////////////////////////////////////////////////////
     // exists                                                                  //
@@ -106,10 +106,10 @@ namespace TestResult {
     def map01(): Bool = Result.map(i -> i == 2, Err(-1ii)) == Err(-1ii)
 
     @test
-    def map02(): Bool = Result.map(i -> i == 2, Ok(1)): Result[_, Unit] == Ok(false)
+    def map02(): Bool = Result.map(i -> i == 2, Ok(1)): Result[Unit, Bool] == Ok(false)
 
     @test
-    def map03(): Bool = Result.map(i -> i == 2, Ok(2)): Result[_, Unit] == Ok(true)
+    def map03(): Bool = Result.map(i -> i == 2, Ok(2)): Result[Unit, Bool] == Ok(true)
 
     /////////////////////////////////////////////////////////////////////////////
     // mapErr                                                                  //
@@ -118,10 +118,10 @@ namespace TestResult {
     def mapErr01(): Bool = Result.mapErr(i -> i == 2, Ok(1)) == Ok(1)
 
     @test
-    def mapErr02(): Bool = Result.mapErr(i -> i == 2, Err(1)): Result[Unit, _] == Err(false)
+    def mapErr02(): Bool = Result.mapErr(i -> i == 2, Err(1)): Result[Bool, Unit] == Err(false)
 
     @test
-    def mapErr03(): Bool = Result.mapErr(i -> i == 2, Err(2)): Result[Unit, _] == Err(true)
+    def mapErr03(): Bool = Result.mapErr(i -> i == 2, Err(2)): Result[Bool, Unit] == Err(true)
 
     /////////////////////////////////////////////////////////////////////////////
     // flatMap                                                                 //
@@ -140,19 +140,19 @@ namespace TestResult {
     /////////////////////////////////////////////////////////////////////////////
     @test
     def flatten01(): Bool = {
-        let err: Result[Int32, _] = Err(42);
+        let err: Result[Int32, Unit] = Err(42);
         Result.flatten(Ok(err)) == Err(42)
     }
 
     @test
     def flatten02(): Bool = {
-        let err: Result[Result[String, _], _] = Err(42);
+        let err: Result[Int32, Result[Int32, Int32]] = Err(42);
         Result.flatten(err) == Err(42)
     }
 
     @test
     def flatten03(): Bool = {
-        let err: Result[_, Bool] = Ok(Ok(42));
+        let err: Result[Int32, Result[Int32, Int32]] = Ok(Ok(42));
         Result.flatten(err) == Ok(42)
     }
 
@@ -296,16 +296,16 @@ namespace TestResult {
     // sequence                                                                //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def sequence01(): Bool = Result.sequence(Nil): Result[List[Unit], Unit] == Ok(Nil)
+    def sequence01(): Bool = Result.sequence(Nil): Result[Unit, List[Unit]] == Ok(Nil)
 
     @test
-    def sequence02(): Bool = Result.sequence(Ok(1) :: Nil): Result[_, Unit] == Ok(1 :: Nil)
+    def sequence02(): Bool = Result.sequence(Ok(1) :: Nil): Result[Unit, List[Int32]] == Ok(1 :: Nil)
 
     @test
-    def sequence03(): Bool = Result.sequence(Ok(1) :: Ok(2) :: Nil): Result[_, Unit] == Ok(1 :: 2 :: Nil)
+    def sequence03(): Bool = Result.sequence(Ok(1) :: Ok(2) :: Nil): Result[Unit, List[Int32]] == Ok(1 :: 2 :: Nil)
 
     @test
-    def sequence04(): Bool = Result.sequence(Ok(1) :: Ok(2) :: Ok(3) :: Nil): Result[_, Unit] == Ok(1 :: 2 :: 3 :: Nil)
+    def sequence04(): Bool = Result.sequence(Ok(1) :: Ok(2) :: Ok(3) :: Nil): Result[Unit, List[Int32]] == Ok(1 :: 2 :: 3 :: Nil)
 
     @test
     def sequence05(): Bool = Result.sequence(Err("one") :: Ok(2) :: Ok(3) :: Nil) == Err("one")
@@ -320,16 +320,16 @@ namespace TestResult {
     // traverse                                                                //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def traverse01(): Bool = Result.traverse(x -> Ok(x + 1), Nil): Result[_, Unit] == Ok(Nil)
+    def traverse01(): Bool = Result.traverse(x -> Ok(x + 1), Nil): Result[Unit, List[Int32]] == Ok(Nil)
 
     @test
-    def traverse02(): Bool = Result.traverse(x -> Ok(x + 1), 1 :: Nil): Result[_, Unit] == Ok(2 :: Nil)
+    def traverse02(): Bool = Result.traverse(x -> Ok(x + 1), 1 :: Nil): Result[Unit, List[Int32]] == Ok(2 :: Nil)
 
     @test
-    def traverse03(): Bool = Result.traverse(x -> Ok(x + 1), 1 :: 2 :: Nil): Result[_, Unit] == Ok(2 :: 3 :: Nil)
+    def traverse03(): Bool = Result.traverse(x -> Ok(x + 1), 1 :: 2 :: Nil): Result[Unit, List[Int32]] == Ok(2 :: 3 :: Nil)
 
     @test
-    def traverse04(): Bool = Result.traverse(x -> Ok(x + 1), 1 :: 2 :: 3 :: Nil): Result[_, Unit] == Ok(2 :: 3 :: 4 :: Nil)
+    def traverse04(): Bool = Result.traverse(x -> Ok(x + 1), 1 :: 2 :: 3 :: Nil): Result[Unit, List[Int32]] == Ok(2 :: 3 :: 4 :: Nil)
 
     @test
     def traverse05(): Bool = Result.traverse(x -> if (x == 1) Err("one") else Ok(x), 1 :: 2 :: 3 :: Nil) == Err("one")
@@ -341,22 +341,22 @@ namespace TestResult {
     def traverse07(): Bool = Result.traverse(x -> if (x == 2) Err("two") else Ok(x), 1 :: 2 :: 3 :: Nil) == Err("two")
 
     @test
-    def traverse08(): Bool = Result.traverse(_ -> Ok(42), 1 :: 2 :: 3 :: Nil): Result[_, Unit] == Ok(42 :: 42 :: 42 :: Nil)
+    def traverse08(): Bool = Result.traverse(_ -> Ok(42), 1 :: 2 :: 3 :: Nil): Result[Unit, List[Int32]] == Ok(42 :: 42 :: 42 :: Nil)
 
     /////////////////////////////////////////////////////////////////////////////
     // traverseX                                                               //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def traverseX01(): Bool = Result.traverseX(x -> Ok(x + 1), Nil): Result[_, Unit] == Ok()
+    def traverseX01(): Bool = Result.traverseX(x -> Ok(x + 1), Nil): Result[String, Unit] == Ok()
 
     @test
-    def traverseX02(): Bool = Result.traverseX(x -> Ok(x + 1), 1 :: Nil): Result[_, Unit] == Ok()
+    def traverseX02(): Bool = Result.traverseX(x -> Ok(x + 1), 1 :: Nil): Result[String, Unit] == Ok()
 
     @test
-    def traverseX03(): Bool = Result.traverseX(x -> Ok(x + 1), 1 :: 2 :: Nil): Result[_, Unit] == Ok()
+    def traverseX03(): Bool = Result.traverseX(x -> Ok(x + 1), 1 :: 2 :: Nil): Result[String, Unit] == Ok()
 
     @test
-    def traverseX04(): Bool = Result.traverseX(x -> Ok(x + 1), 1 :: 2 :: 3 :: Nil): Result[_, Unit] == Ok()
+    def traverseX04(): Bool = Result.traverseX(x -> Ok(x + 1), 1 :: 2 :: 3 :: Nil): Result[String, Unit] == Ok()
 
     @test
     def traverseX05(): Bool = Result.traverseX(x -> if (x == 1) Err("one") else Ok(x), 1 :: 2 :: 3 :: Nil) == Err("one")
@@ -368,7 +368,7 @@ namespace TestResult {
     def traverseX07(): Bool = Result.traverseX(x -> if (x == 2) Err("two") else Ok(x), 1 :: 2 :: 3 :: Nil) == Err("two")
 
     @test
-    def traverseX08(): Bool = Result.traverseX(_ -> Ok(42), 1 :: 2 :: 3 :: Nil): Result[_, Unit] == Ok()
+    def traverseX08(): Bool = Result.traverseX(_ -> Ok(42), 1 :: 2 :: 3 :: Nil): Result[String, Unit] == Ok()
 
     /////////////////////////////////////////////////////////////////////////////
     // foldLeftM                                                               //
@@ -422,7 +422,7 @@ namespace TestResult {
     // toList                                                                  //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def toList01(): Bool = Result.toList(Err(-1ii): Result[Unit, _]) == Nil
+    def toList01(): Bool = Result.toList(Err(-1ii): Result[BigInt, Unit]) == Nil
 
     @test
     def toList02(): Bool = Result.toList(Ok(1)) == 1 :: Nil
@@ -431,7 +431,7 @@ namespace TestResult {
     // toSet                                                                   //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def toSet01(): Bool = Result.toSet(Err(-1ii): Result[Unit, _]) == Set#{}
+    def toSet01(): Bool = Result.toSet(Err(-1ii): Result[BigInt, Unit]) == Set#{}
 
     @test
     def toSet02(): Bool = Result.toSet(Ok(1)) == Set#{1}
@@ -440,7 +440,7 @@ namespace TestResult {
     // toMap                                                                   //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def toMap01(): Bool = Result.toMap(Err(-1ii): Result[(Unit, Unit), _]) == Map#{}
+    def toMap01(): Bool = Result.toMap(Err(-1ii): Result[BigInt, (Unit, Unit)]) == Map#{}
 
     @test
     def toMap02(): Bool = Result.toMap(Ok((1, true))) == Map#{1 => true}
@@ -473,7 +473,7 @@ namespace TestResult {
     // toOption                                                                //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def toOption01(): Bool = Result.toOption(Err(-1ii): Result[Unit, _]) == None
+    def toOption01(): Bool = Result.toOption(Err(-1ii): Result[BigInt, Unit]) == None
 
     @test
     def toOption02(): Bool = Result.toOption(Ok(1)) == Some(1)
@@ -498,23 +498,23 @@ namespace TestResult {
     // ap                                                                      //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def ap01(): Bool = Result.ap(Ok(x -> x + 1), Ok(123)): Result[_, Unit] == Ok(124)
+    def ap01(): Bool = Result.ap(Ok(x -> x + 1), Ok(123)): Result[String, Int32] == Ok(124)
 
     @test
     def ap02(): Bool = Result.ap(Ok(x -> x + 1), Err("b")) == Err("b")
 
     @test
-    def ap03(): Bool = Result.ap(Err("a"), Ok(123)): Result[Int32, _] == Err("a")
+    def ap03(): Bool = Result.ap(Err("a"), Ok(123)): Result[String, Int32] == Err("a")
 
     @test
-    def ap04(): Bool = Result.ap(Err("a"), Err("b")): Result[Unit, _] == Err("a")
+    def ap04(): Bool = Result.ap(Err("a"), Err("b")): Result[String, Int32] == Err("a")
 
     /////////////////////////////////////////////////////////////////////////////
     // lift2                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift201(): Bool = Result.lift2((x1,x2) -> x1 + x2, Ok(123), Ok(1)): Result[_, Unit] == Ok(124)
+    def lift201(): Bool = Result.lift2((x1,x2) -> x1 + x2, Ok(123), Ok(1)): Result[String, Int32] == Ok(124)
 
     @test
     def lift202(): Bool = Result.lift2((x1,x2) -> x1 + x2, Ok(123), Err("e1")) == Err("e1")
@@ -523,14 +523,14 @@ namespace TestResult {
     def lift203(): Bool = Result.lift2((x1,x2) -> x1 + x2, Err("e1"), Ok(1)) == Err("e1")
 
     @test
-    def lift204(): Bool = Result.lift2((x1,x2) -> x1 + x2, Err("e1"), Err("e2"): Result[Int32, String]) == Err("e1")
+    def lift204(): Bool = Result.lift2((x1,x2) -> x1 + x2, Err("e1"), Err("e2"): Result[String, Int32]) == Err("e1")
 
     /////////////////////////////////////////////////////////////////////////////
     // lift3                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift301(): Bool = Result.lift3((x1,x2,x3) -> x1 + x2 + x3, Ok(123), Ok(1), Ok(2)): Result[_, Unit] == Ok(126)
+    def lift301(): Bool = Result.lift3((x1,x2,x3) -> x1 + x2 + x3, Ok(123), Ok(1), Ok(2)): Result[String, Int32] == Ok(126)
 
     @test
     def lift302(): Bool = Result.lift3((x1,x2,x3) -> x1 + x2 + x3, Ok(123), Ok(1), Err("e1")) == Err("e1")
@@ -548,14 +548,14 @@ namespace TestResult {
     def lift306(): Bool = Result.lift3((x1,x2,x3) -> x1 + x2 + x3, Err("e1"), Ok(1), Err("e2")) == Err("e1")
 
     @test
-    def lift307(): Bool = Result.lift3((x1,x2,x3) -> x1 + x2 + x3, Err("e1"), Err("e2"), Err("e3"): Result[Int32, String]) == Err("e1")
+    def lift307(): Bool = Result.lift3((x1,x2,x3) -> x1 + x2 + x3, Err("e1"), Err("e2"), Err("e3"): Result[String, Int32]) == Err("e1")
 
     /////////////////////////////////////////////////////////////////////////////
     // lift4                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift401(): Bool = Result.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Ok(123), Ok(1), Ok(2), Ok(3)): Result[_, Unit] == Ok(129)
+    def lift401(): Bool = Result.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Ok(123), Ok(1), Ok(2), Ok(3)): Result[String, Int32] == Ok(129)
 
     @test
     def lift402(): Bool = Result.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Ok(123), Ok(1), Ok(2), Err("e1")) == Err("e1")
@@ -570,14 +570,14 @@ namespace TestResult {
     def lift405(): Bool = Result.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Err("e1"), Ok(1), Ok(2), Ok(3)) == Err("e1")
 
     @test
-    def lift406(): Bool = Result.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Err("e1"), Err("e2"), Err("e3"), Err("e4"): Result[Int32, String]) == Err("e1")
+    def lift406(): Bool = Result.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Err("e1"), Err("e2"), Err("e3"), Err("e4"): Result[String, Int32]) == Err("e1")
 
     /////////////////////////////////////////////////////////////////////////////
     // lift5                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift501(): Bool = Result.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4)): Result[_, Unit] == Ok(133)
+    def lift501(): Bool = Result.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4)): Result[String, Int32] == Ok(133)
 
     @test
     def lift502(): Bool = Result.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Ok(123), Ok(1), Ok(2), Ok(3), Err("e1")) == Err("e1")
@@ -595,14 +595,14 @@ namespace TestResult {
     def lift506(): Bool = Result.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Err("e1"), Ok(1), Ok(2), Ok(3), Ok(4)) == Err("e1")
 
     @test
-    def lift507(): Bool = Result.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Err("e1"), Err("e2"), Err("e3"), Err("e4"), Err("e5"): Result[Int32, String]) == Err("e1")
+    def lift507(): Bool = Result.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Err("e1"), Err("e2"), Err("e3"), Err("e4"), Err("e5"): Result[String, Int32]) == Err("e1")
 
     /////////////////////////////////////////////////////////////////////////////
     // lift6                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift601(): Bool = Result.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5)): Result[_, Unit] == Ok(138)
+    def lift601(): Bool = Result.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5)): Result[String, Int32] == Ok(138)
 
     @test
     def lift602(): Bool = Result.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4), Err("e1")) == Err("e1")
@@ -623,14 +623,14 @@ namespace TestResult {
     def lift607(): Bool = Result.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Err("e1"), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5)) == Err("e1")
 
     @test
-    def lift608(): Bool = Result.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Err("e1"), Err("e2"), Err("e3"), Err("e4"), Err("e5"), Err("e6"): Result[Int32, String]) == Err("e1")
+    def lift608(): Bool = Result.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Err("e1"), Err("e2"), Err("e3"), Err("e4"), Err("e5"), Err("e6"): Result[String, Int32]) == Err("e1")
 
     /////////////////////////////////////////////////////////////////////////////
     // lift7                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift701(): Bool = Result.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Ok(6)): Result[_, Unit] == Ok(144)
+    def lift701(): Bool = Result.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Ok(6)): Result[String, Int32] == Ok(144)
 
     @test
     def lift702(): Bool = Result.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Err("e1")) == Err("e1")
@@ -654,14 +654,14 @@ namespace TestResult {
     def lift708(): Bool = Result.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Err("e1"), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Ok(6)) == Err("e1")
 
     @test
-    def lift709(): Bool = Result.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Err("e1"), Err("e2"), Err("e3"), Err("e4"), Err("e5"), Err("e6"), Err("e7"): Result[Int32, String]) == Err("e1")
+    def lift709(): Bool = Result.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Err("e1"), Err("e2"), Err("e3"), Err("e4"), Err("e5"), Err("e6"), Err("e7"): Result[String, Int32]) == Err("e1")
 
     /////////////////////////////////////////////////////////////////////////////
     // lift8                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift801(): Bool = Result.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Ok(6), Ok(7)): Result[_, Unit] == Ok(151)
+    def lift801(): Bool = Result.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Ok(6), Ok(7)): Result[String, Int32] == Ok(151)
 
     @test
     def lift802(): Bool = Result.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Ok(6), Err("e1")) == Err("e1")
@@ -688,14 +688,14 @@ namespace TestResult {
     def lift809(): Bool = Result.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Err("e1"), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Ok(6), Ok(7)) == Err("e1")
 
     @test
-    def lift810(): Bool = Result.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Err("e1"), Err("e2"), Err("e3"), Err("e4"), Err("e5"), Err("e6"), Err("e7"), Err("e8"): Result[Int32, String]) == Err("e1")
+    def lift810(): Bool = Result.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Err("e1"), Err("e2"), Err("e3"), Err("e4"), Err("e5"), Err("e6"), Err("e7"), Err("e8"): Result[String, Int32]) == Err("e1")
 
     /////////////////////////////////////////////////////////////////////////////
     // lift9                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift901(): Bool = Result.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Ok(6), Ok(7), Ok(8)): Result[_, Unit] == Ok(159)
+    def lift901(): Bool = Result.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Ok(6), Ok(7), Ok(8)): Result[String, Int32] == Ok(159)
 
     @test
     def lift902(): Bool = Result.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Ok(6), Ok(7), Err("e1")) == Err("e1")
@@ -725,14 +725,14 @@ namespace TestResult {
     def lift910(): Bool = Result.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Err("e1"), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Ok(6), Ok(7), Ok(8)) == Err("e1")
 
     @test
-    def lift911(): Bool = Result.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Err("e1"), Err("e2"), Err("e3"), Err("e4"), Err("e5"), Err("e6"), Err("e7"), Err("e8"), Err("e9"): Result[Int32, String]) == Err("e1")
+    def lift911(): Bool = Result.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Err("e1"), Err("e2"), Err("e3"), Err("e4"), Err("e5"), Err("e6"), Err("e7"), Err("e8"), Err("e9"): Result[String, Int32]) == Err("e1")
 
     /////////////////////////////////////////////////////////////////////////////
     // lift10                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift1001(): Bool = Result.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Ok(6), Ok(7), Ok(8), Ok(9)): Result[_, Unit] == Ok(168)
+    def lift1001(): Bool = Result.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Ok(6), Ok(7), Ok(8), Ok(9)): Result[String, Int32] == Ok(168)
 
     @test
     def lift1002(): Bool = Result.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Ok(123), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Ok(6), Ok(7), Ok(8), Err("e1")) == Err("e1")
@@ -765,26 +765,26 @@ namespace TestResult {
     def lift1011(): Bool = Result.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Err("e1"), Ok(1), Ok(2), Ok(3), Ok(4), Ok(5), Ok(6), Ok(7), Ok(8), Ok(9)) == Err("e1")
 
     @test
-    def lift1012(): Bool = Result.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Err("e1"), Err("e2"), Err("e3"), Err("e4"), Err("e5"), Err("e6"), Err("e7"), Err("e8"), Err("e9"), Err("e10"): Result[Int32, String]) == Err("e1")
+    def lift1012(): Bool = Result.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Err("e1"), Err("e2"), Err("e3"), Err("e4"), Err("e5"), Err("e6"), Err("e7"), Err("e8"), Err("e9"), Err("e10"): Result[String, Int32]) == Err("e1")
 
     /////////////////////////////////////////////////////////////////////////////
     // hash                                                                    //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def hash01(): Bool = hash(Err(()): Result[Unit, _]) == hash(Err(()): Result[Unit, _])
+    def hash01(): Bool = hash(Err(()): Result[Unit, Unit]) == hash(Err(()): Result[Unit, Unit])
 
     @test
-    def hash02(): Bool = hash(Ok(()): Result[_, Unit]) != hash(Err(()): Result[Unit, _])
+    def hash02(): Bool = hash(Ok(()): Result[Unit, Unit]) != hash(Err(()): Result[Unit, Unit])
 
     @test
-    def hash03(): Bool = hash(Ok("Success"): Result[_, Unit]) == hash(Ok("Success"): Result[_, Unit])
+    def hash03(): Bool = hash(Ok("Success"): Result[Unit, String]) == hash(Ok("Success"): Result[Unit, String])
 
     @test
-    def hash04(): Bool = hash(Ok("Success"): Result[_, String]) != hash(Err("Error"): Result[String, _])
+    def hash04(): Bool = hash(Ok("Success"): Result[String, String]) != hash(Err("Error"): Result[String, String])
 
     @test
-    def hash05(): Bool = hash(Err(13i8): Result[Unit, _]) != hash(Err(255i16): Result[Unit, _])
+    def hash05(): Bool = hash(Err(13i8): Result[Int8, Unit]) != hash(Err(255i16): Result[Int16, Unit])
 
 
     /////////////////////////////////////////////////////////////////////////////

--- a/main/test/ca/uwaterloo/flix/library/TestValidation.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestValidation.flix
@@ -358,10 +358,10 @@ namespace TestValidation {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def toResult01(): Bool = (Success(123) |> Validation.toResult): Result[_, Nec[Unit]] == Ok(123)
+    def toResult01(): Bool = (Success(123) |> Validation.toResult): Result[Nec[Unit], _] == Ok(123)
 
     @test
-    def toResult02(): Bool = (Failure(singleton(42)) |> Validation.toResult): Result[Unit, _] == Err(singleton(42))
+    def toResult02(): Bool = (Failure(singleton(42)) |> Validation.toResult): Result[_, Unit] == Err(singleton(42))
 
     /////////////////////////////////////////////////////////////////////////////
     // toList                                                                  //

--- a/main/test/ca/uwaterloo/flix/library/TestValidation.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestValidation.flix
@@ -42,25 +42,25 @@ namespace TestValidation {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def ap01(): Bool = Validation.ap(Success(x -> x + 1), Success(123)): Validation[_, Unit] == Success(124)
+    def ap01(): Bool = Validation.ap(Success(x -> x + 1), Success(123)): Validation[Int32, Int32] == Success(124)
 
     @test
     def ap02(): Bool = Validation.ap(Success(x -> x + 1), Failure(singleton(42))) == Failure(singleton(42))
 
     @test
-    def ap03(): Bool = Validation.ap(Failure(singleton(42)), Success(123)): Validation[Unit, _] == Failure(singleton(42))
+    def ap03(): Bool = Validation.ap(Failure(singleton(42)), Success(123)): Validation[Int32, Int32] == Failure(singleton(42))
 
     @test
-    def ap04(): Bool = Validation.ap(Failure(singleton(123)), (Failure(singleton(456)))): Validation[Unit, _] == Failure(necOf2(123, 456))
+    def ap04(): Bool = Validation.ap(Failure(singleton(123)), (Failure(singleton(456)))): Validation[Int32, Int32] == Failure(necOf2(123, 456))
 
     @test
-    def ap05(): Bool = Validation.ap(Failure(necOf2(1, 2)), (Failure(singleton(3)))): Validation[Unit, _] == Failure(necOf3(1, 2, 3))
+    def ap05(): Bool = Validation.ap(Failure(necOf2(1, 2)), (Failure(singleton(3)))): Validation[Int32, Int32] == Failure(necOf3(1, 2, 3))
 
     @test
-    def ap06(): Bool = Validation.ap(Failure(singleton(1)), (Failure(necOf2(2, 3)))): Validation[Unit, _] == Failure(necOf3(1, 2, 3))
+    def ap06(): Bool = Validation.ap(Failure(singleton(1)), (Failure(necOf2(2, 3)))): Validation[Int32, Int32] == Failure(necOf3(1, 2, 3))
 
     @test
-    def ap07(): Bool = Validation.ap(Failure(necOf2(1, 2)), (Failure(necOf2(3, 4)))): Validation[Unit, _] == Failure(necOf4(1, 2, 3, 4))
+    def ap07(): Bool = Validation.ap(Failure(necOf2(1, 2)), (Failure(necOf2(3, 4)))): Validation[Int32, Int32] == Failure(necOf4(1, 2, 3, 4))
 
     /////////////////////////////////////////////////////////////////////////////
     // product                                                                 //
@@ -221,7 +221,7 @@ namespace TestValidation {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def withDefault01(): Bool = Validation.withDefault(default = Success(2), Success(1)): Validation[_, Unit] == Success(1)
+    def withDefault01(): Bool = Validation.withDefault(default = Success(2), Success(1)): Validation[Int32, Int32] == Success(1)
 
     @test
     def withDefault02(): Bool = Validation.withDefault(default = Failure(singleton(1)), Success(1)) == Success(1)
@@ -230,7 +230,7 @@ namespace TestValidation {
     def withDefault03(): Bool = Validation.withDefault(default = Success(2), Failure(singleton(1))) == Success(2)
 
     @test
-    def withDefault04(): Bool = Validation.withDefault(default = Failure(singleton(2)), Failure(singleton(1))): Validation[Unit, _] == Failure(singleton(2))
+    def withDefault04(): Bool = Validation.withDefault(default = Failure(singleton(2)), Failure(singleton(1))): Validation[Int32, Int32] == Failure(singleton(2))
 
     /////////////////////////////////////////////////////////////////////////////
     // exists                                                                  //
@@ -257,35 +257,35 @@ namespace TestValidation {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def map01(): Bool = Validation.map(x -> x, Success(123)): Validation[_, Unit] == Success(123)
+    def map01(): Bool = Validation.map(x -> x, Success(123)): Validation[Int32, Int32] == Success(123)
 
     @test
-    def map02(): Bool = Validation.map(x -> x + 1, Success(123)): Validation[_, Unit] == Success(124)
+    def map02(): Bool = Validation.map(x -> x + 1, Success(123)): Validation[Int32, Int32] == Success(124)
 
     @test
-    def map03(): Bool = Validation.map(x -> x, Failure(singleton(123))): Validation[Unit, _] == Failure(singleton(123))
+    def map03(): Bool = Validation.map(x -> x, Failure(singleton(123))): Validation[Int32, Int32] == Failure(singleton(123))
 
     @test
-    def map04(): Bool = (Success(123): Validation[_, Unit]) |> Validation.map(x -> x + 1) |> Validation.map(x -> x * 2)  == Success(248)
+    def map04(): Bool = (Success(123): Validation[Int32, Int32]) |> Validation.map(x -> x + 1) |> Validation.map(x -> x * 2)  == Success(248)
 
     /////////////////////////////////////////////////////////////////////////////
     // sequence                                                                //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def sequence01(): Bool = Validation.sequence(Success(1) :: Nil): Validation[_, Unit] == Success(1 :: Nil)
+    def sequence01(): Bool = Validation.sequence(Success(1) :: Nil): Validation[Int32, List[Int32]] == Success(1 :: Nil)
 
     @test
-    def sequence02(): Bool = Validation.sequence(Success(1) :: Success(2) :: Nil): Validation[_, Unit] == Success(1 :: 2 :: Nil)
+    def sequence02(): Bool = Validation.sequence(Success(1) :: Success(2) :: Nil): Validation[Int32, List[Int32]] == Success(1 :: 2 :: Nil)
 
     @test
-    def sequence03(): Bool = Validation.sequence(Success(1) :: Success(2) :: Success(3) :: Nil): Validation[_, Unit] == Success(1 :: 2 :: 3 :: Nil)
+    def sequence03(): Bool = Validation.sequence(Success(1) :: Success(2) :: Success(3) :: Nil): Validation[Int32, List[Int32]] == Success(1 :: 2 :: 3 :: Nil)
 
     @test
-    def sequence04(): Bool = Validation.sequence(Failure(singleton(1)) :: Nil): Validation[List[Unit], _] == Failure(singleton(1))
+    def sequence04(): Bool = Validation.sequence(Failure(singleton(1)) :: Nil): Validation[Int32, List[Int32]] == Failure(singleton(1))
 
     @test
-    def sequence05(): Bool = Validation.sequence(Failure(singleton(1)) :: Failure(singleton(2)) :: Nil): Validation[List[Unit], _] == Failure(necOf2(1, 2))
+    def sequence05(): Bool = Validation.sequence(Failure(singleton(1)) :: Failure(singleton(2)) :: Nil): Validation[Int32, List[Int32]] == Failure(necOf2(1, 2))
 
     @test
     def sequence06(): Bool = Validation.sequence(Success(1) :: Failure(singleton(42)) :: Nil) == Failure(singleton(42))
@@ -298,19 +298,19 @@ namespace TestValidation {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def traverse01(): Bool = Validation.traverse(x -> Success(x + 1), 1 :: Nil): Validation[_, Unit] == Success(2 :: Nil)
+    def traverse01(): Bool = Validation.traverse(x -> Success(x + 1), 1 :: Nil): Validation[Int32, List[Int32]] == Success(2 :: Nil)
 
     @test
-    def traverse02(): Bool = Validation.traverse(x -> Success(x + 1), 1 :: 2 :: Nil): Validation[_, Unit] == Success(2 :: 3 :: Nil)
+    def traverse02(): Bool = Validation.traverse(x -> Success(x + 1), 1 :: 2 :: Nil): Validation[Int32, List[Int32]] == Success(2 :: 3 :: Nil)
 
     @test
-    def traverse03(): Bool = Validation.traverse(x -> Success(x + 1), 1 :: 2 :: 3 :: Nil): Validation[_, Unit] == Success(2 :: 3 :: 4 :: Nil)
+    def traverse03(): Bool = Validation.traverse(x -> Success(x + 1), 1 :: 2 :: 3 :: Nil): Validation[Int32, List[Int32]] == Success(2 :: 3 :: 4 :: Nil)
 
     @test
-    def traverse04(): Bool = Validation.traverse(x -> Failure(singleton(x)), 1 :: 2 :: 3 :: Nil): Validation[List[Unit], _] == Failure(necOf3(1, 2, 3))
+    def traverse04(): Bool = Validation.traverse(x -> Failure(singleton(x)), 1 :: 2 :: 3 :: Nil): Validation[Int32, List[Int32]] == Failure(necOf3(1, 2, 3))
 
     @test
-    def traverse05(): Bool = Validation.traverse(x -> Failure(necOf2(x, x)), 1 :: 2 :: 3 :: Nil): Validation[List[Unit], _] == Failure(necOf6(1, 1, 2, 2, 3, 3))
+    def traverse05(): Bool = Validation.traverse(x -> Failure(necOf2(x, x)), 1 :: 2 :: 3 :: Nil): Validation[Int32, List[Int32]] == Failure(necOf6(1, 1, 2, 2, 3, 3))
 
     @test
     def traverse06(): Bool = Validation.traverse(x -> if (x != 2) Success(x + 1) else Failure(singleton(42)), 1 :: 2 :: 3 :: Nil) == Failure(singleton(42))
@@ -323,13 +323,13 @@ namespace TestValidation {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def traverseX01(): Bool = Validation.traverseX(x -> Success(x + 1), 1 :: Nil): Validation[_, Unit] == Success()
+    def traverseX01(): Bool = Validation.traverseX(x -> Success(x + 1), 1 :: Nil): Validation[Int32, Unit] == Success()
 
     @test
-    def traverseX02(): Bool = Validation.traverseX(x -> Success(x + 1), 1 :: 2 :: Nil): Validation[_, Unit] == Success()
+    def traverseX02(): Bool = Validation.traverseX(x -> Success(x + 1), 1 :: 2 :: Nil): Validation[Int32, Unit] == Success()
 
     @test
-    def traverseX03(): Bool = Validation.traverseX(x -> Success(x + 1), 1 :: 2 :: 3 :: Nil): Validation[_, Unit] == Success()
+    def traverseX03(): Bool = Validation.traverseX(x -> Success(x + 1), 1 :: 2 :: 3 :: Nil): Validation[Int32, Unit] == Success()
 
     @test
     def traverseX04(): Bool = Validation.traverseX(x -> Failure(singleton(x)), 1 :: 2 :: 3 :: Nil) == Failure(necOf3(1, 2, 3))
@@ -358,10 +358,10 @@ namespace TestValidation {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def toResult01(): Bool = (Success(123) |> Validation.toResult): Result[Nec[Unit], _] == Ok(123)
+    def toResult01(): Bool = (Success(123) |> Validation.toResult): Result[Nec[Int32], Int32] == Ok(123)
 
     @test
-    def toResult02(): Bool = (Failure(singleton(42)) |> Validation.toResult): Result[_, Unit] == Err(singleton(42))
+    def toResult02(): Bool = (Failure(singleton(42)) |> Validation.toResult): Result[Nec[Int32], Int32] == Err(singleton(42))
 
     /////////////////////////////////////////////////////////////////////////////
     // toList                                                                  //
@@ -371,14 +371,14 @@ namespace TestValidation {
     def toList01(): Bool = (Success(123) |> Validation.toList) == 123 :: Nil
 
     @test
-    def toList02(): Bool = ((Failure(singleton(42)): Validation[Unit, _]) |> Validation.toList) == Nil
+    def toList02(): Bool = ((Failure(singleton(42)): Validation[Int32, Int32]) |> Validation.toList) == Nil
 
     /////////////////////////////////////////////////////////////////////////////
     // lift2                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift201(): Bool = Validation.lift2((x1,x2) -> x1 + x2, Success(123), Success(1)): Validation[_, Unit] == Success(124)
+    def lift201(): Bool = Validation.lift2((x1,x2) -> x1 + x2, Success(123), Success(1)): Validation[String, Int32] == Success(124)
 
     @test
     def lift202(): Bool = Validation.lift2((x1,x2) -> x1 + x2, Success(123), Failure(singleton("e1"))) == Failure(singleton("e1"))
@@ -387,14 +387,14 @@ namespace TestValidation {
     def lift203(): Bool = Validation.lift2((x1,x2) -> x1 + x2, Failure(singleton("e1")), Success(1)) == Failure(singleton("e1"))
 
     @test
-    def lift204(): Bool = Validation.lift2((x1,x2) -> x1 + x2, Failure(singleton("e1")), Failure(singleton("e2")): Validation[Int32, String]) == Failure(necOf2("e1", "e2"))
+    def lift204(): Bool = Validation.lift2((x1,x2) -> x1 + x2, Failure(singleton("e1")), Failure(singleton("e2")): Validation[String, Int32]) == Failure(necOf2("e1", "e2"))
 
     /////////////////////////////////////////////////////////////////////////////
     // lift3                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift301(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Success(123), Success(1), Success(2)): Validation[_, Unit] == Success(126)
+    def lift301(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Success(123), Success(1), Success(2)): Validation[String, Int32] == Success(126)
 
     @test
     def lift302(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Success(123), Success(1), Failure(singleton("e1"))) == Failure(singleton("e1"))
@@ -412,14 +412,14 @@ namespace TestValidation {
     def lift306(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Failure(singleton("e1")), Success(1), Failure(singleton("e2"))) == Failure(necOf2("e1", "e2"))
 
     @test
-    def lift307(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")): Validation[Int32, String]) == Failure(necOf3("e1", "e2", "e3"))
+    def lift307(): Bool = Validation.lift3((x1,x2,x3) -> x1 + x2 + x3, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")): Validation[String, Int32]) == Failure(necOf3("e1", "e2", "e3"))
 
     /////////////////////////////////////////////////////////////////////////////
     // lift4                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift401(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Success(123), Success(1), Success(2), Success(3)): Validation[_, Unit] == Success(129)
+    def lift401(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Success(123), Success(1), Success(2), Success(3)): Validation[String, Int32] == Success(129)
 
     @test
     def lift402(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Success(123), Success(1), Success(2), Failure(singleton("e1"))) == Failure(singleton("e1"))
@@ -434,14 +434,14 @@ namespace TestValidation {
     def lift405(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Failure(singleton("e1")), Success(1), Success(2), Success(3)) == Failure(singleton("e1"))
 
     @test
-    def lift406(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")): Validation[Int32, String]) == Failure(necOf4("e1", "e2", "e3", "e4"))
+    def lift406(): Bool = Validation.lift4((x1,x2,x3,x4) -> x1 + x2 + x3 + x4, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")): Validation[String, Int32]) == Failure(necOf4("e1", "e2", "e3", "e4"))
 
     /////////////////////////////////////////////////////////////////////////////
     // lift5                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift501(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Success(123), Success(1), Success(2), Success(3), Success(4)): Validation[_, Unit] == Success(133)
+    def lift501(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Success(123), Success(1), Success(2), Success(3), Success(4)): Validation[String, Int32] == Success(133)
 
     @test
     def lift502(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Success(123), Success(1), Success(2), Success(3), Failure(singleton("e1"))) == Failure(singleton("e1"))
@@ -459,14 +459,14 @@ namespace TestValidation {
     def lift506(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Failure(singleton("e1")), Success(1), Success(2), Success(3), Success(4)) == Failure(singleton("e1"))
 
     @test
-    def lift507(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")): Validation[Int32, String]) == Failure(necOf5("e1", "e2", "e3", "e4", "e5"))
+    def lift507(): Bool = Validation.lift5((x1,x2,x3,x4,x5) -> x1 + x2 + x3 + x4 + x5, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")): Validation[String, Int32]) == Failure(necOf5("e1", "e2", "e3", "e4", "e5"))
 
     /////////////////////////////////////////////////////////////////////////////
     // lift6                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift601(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5)): Validation[_, Unit] == Success(138)
+    def lift601(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5)): Validation[String, Int32] == Success(138)
 
     @test
     def lift602(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Success(123), Success(1), Success(2), Success(3), Success(4), Failure(singleton("e1"))) == Failure(singleton("e1"))
@@ -487,14 +487,14 @@ namespace TestValidation {
     def lift607(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Failure(singleton("e1")), Success(1), Success(2), Success(3), Success(4), Success(5)) == Failure(singleton("e1"))
 
     @test
-    def lift608(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")), Failure(singleton("e6")): Validation[Int32, String]) == Failure(necOf6("e1", "e2", "e3", "e4", "e5", "e6"))
+    def lift608(): Bool = Validation.lift6((x1,x2,x3,x4,x5,x6) -> x1 + x2 + x3 + x4 + x5 + x6, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")), Failure(singleton("e6")): Validation[String, Int32]) == Failure(necOf6("e1", "e2", "e3", "e4", "e5", "e6"))
 
     /////////////////////////////////////////////////////////////////////////////
     // lift7                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift701(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6)): Validation[_, Unit] == Success(144)
+    def lift701(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6)): Validation[String, Int32] == Success(144)
 
     @test
     def lift702(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Failure(singleton("e1"))) == Failure(singleton("e1"))
@@ -518,14 +518,14 @@ namespace TestValidation {
     def lift708(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Failure(singleton("e1")), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6)) == Failure(singleton("e1"))
 
     @test
-    def lift709(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")), Failure(singleton("e6")), Failure(singleton("e7")): Validation[Int32, String]) == Failure(necOf7("e1", "e2", "e3", "e4", "e5", "e6", "e7"))
+    def lift709(): Bool = Validation.lift7((x1,x2,x3,x4,x5,x6,x7) -> x1 + x2 + x3 + x4 + x5 + x6 + x7, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")), Failure(singleton("e6")), Failure(singleton("e7")): Validation[String, Int32]) == Failure(necOf7("e1", "e2", "e3", "e4", "e5", "e6", "e7"))
 
     /////////////////////////////////////////////////////////////////////////////
     // lift8                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift801(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7)): Validation[_, Unit] == Success(151)
+    def lift801(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7)): Validation[String, Int32] == Success(151)
 
     @test
     def lift802(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Failure(singleton("e1"))) == Failure(singleton("e1"))
@@ -552,14 +552,14 @@ namespace TestValidation {
     def lift809(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Failure(singleton("e1")), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7)) == Failure(singleton("e1"))
 
     @test
-    def lift810(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")), Failure(singleton("e6")), Failure(singleton("e7")), Failure(singleton("e8")): Validation[Int32, String]) == Failure(necOf8("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8"))
+    def lift810(): Bool = Validation.lift8((x1,x2,x3,x4,x5,x6,x7,x8) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")), Failure(singleton("e6")), Failure(singleton("e7")), Failure(singleton("e8")): Validation[String, Int32]) == Failure(necOf8("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8"))
 
     /////////////////////////////////////////////////////////////////////////////
     // lift9                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift901(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8)): Validation[_, Unit] == Success(159)
+    def lift901(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8)): Validation[String, Int32] == Success(159)
 
     @test
     def lift902(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Failure(singleton("e1"))) == Failure(singleton("e1"))
@@ -589,14 +589,14 @@ namespace TestValidation {
     def lift910(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Failure(singleton("e1")), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8)) == Failure(singleton("e1"))
 
     @test
-    def lift911(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")), Failure(singleton("e6")), Failure(singleton("e7")), Failure(singleton("e8")), Failure(singleton("e9")): Validation[Int32, String]) == Failure(necOf9("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9"))
+    def lift911(): Bool = Validation.lift9((x1,x2,x3,x4,x5,x6,x7,x8,x9) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")), Failure(singleton("e6")), Failure(singleton("e7")), Failure(singleton("e8")), Failure(singleton("e9")): Validation[String, Int32]) == Failure(necOf9("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9"))
 
     /////////////////////////////////////////////////////////////////////////////
     // lift10                                                                  //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def lift1001(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8), Success(9)): Validation[_, Unit] == Success(168)
+    def lift1001(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8), Success(9)): Validation[String, Int32] == Success(168)
 
     @test
     def lift1002(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Success(123), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8), Failure(singleton("e1"))) == Failure(singleton("e1"))
@@ -629,25 +629,25 @@ namespace TestValidation {
     def lift1011(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Failure(singleton("e1")), Success(1), Success(2), Success(3), Success(4), Success(5), Success(6), Success(7), Success(8), Success(9)) == Failure(singleton("e1"))
 
     @test
-    def lift1012(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")), Failure(singleton("e6")), Failure(singleton("e7")), Failure(singleton("e8")), Failure(singleton("e9")), Failure(singleton("e10")): Validation[Int32, String]) == Failure(necOf10("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9", "e10"))
+    def lift1012(): Bool = Validation.lift10((x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) -> x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10, Failure(singleton("e1")), Failure(singleton("e2")), Failure(singleton("e3")), Failure(singleton("e4")), Failure(singleton("e5")), Failure(singleton("e6")), Failure(singleton("e7")), Failure(singleton("e8")), Failure(singleton("e9")), Failure(singleton("e10")): Validation[String, Int32]) == Failure(necOf10("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9", "e10"))
 
     /////////////////////////////////////////////////////////////////////////////
     // hash                                                                    //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def hash01(): Bool = hash(Success(()): Validation[_, Unit]) == hash(Success(()): Validation[_, Unit])
+    def hash01(): Bool = hash(Success(()): Validation[Unit, Unit]) == hash(Success(()): Validation[Unit, Unit])
 
     @test
-    def hash02(): Bool = hash(Success(()): Validation[_, Unit]) != hash(Failure(necOf2((), ())): Validation[Unit, _])
+    def hash02(): Bool = hash(Success(()): Validation[Unit, Unit]) != hash(Failure(necOf2((), ())): Validation[Unit, Unit])
 
     @test
-    def hash03(): Bool = hash(Success(1, 2): Validation[_, Unit]) == hash(Success(1, 2): Validation[_, Unit])
+    def hash03(): Bool = hash(Success(1, 2): Validation[Unit, (Int32, Int32)]) == hash(Success(1, 2): Validation[Unit, (Int32, Int32)])
 
     @test
-    def hash04(): Bool = hash(Success(1, 2, 3): Validation[_, Unit]) != hash(Success(1, 3, 2): Validation[_, Unit])
+    def hash04(): Bool = hash(Success(1, 2, 3): Validation[Unit, (Int32, Int32, Int32)]) != hash(Success(1, 3, 2): Validation[Unit, (Int32, Int32, Int32)])
 
     @test
-    def hash05(): Bool = hash(Success(singleton(1)): Validation[_, Int32]) != hash(Failure(singleton(1)): Validation[Nec[Int32], _])
+    def hash05(): Bool = hash(Success(singleton(1)): Validation[Int32, Nec[Int32]]) != hash(Failure(singleton(1)): Validation[Int32, Nec[Int32]])
 
 }

--- a/main/test/flix/Test.Dec.Enum.Singleton.flix
+++ b/main/test/flix/Test.Dec.Enum.Singleton.flix
@@ -28,7 +28,7 @@ namespace Test/Dec/Enum/Singleton {
     /**
      * An enum for a Result.
      */
-    enum B(Result[Int32, String])
+    enum B(Result[String, Int32])
 
     /**
      * An enum for a polymorphic pair.
@@ -38,12 +38,12 @@ namespace Test/Dec/Enum/Singleton {
     /**
      * An enum for a polymorphic Result.
      */
-    enum C[a](Result[a, Int32])
+    enum C[a](Result[Int32, a])
 
     /**
      * An enum for a polymorphic Result.
      */
-    enum D[a, b, c](Result[a, Result[b, c]])
+    enum D[a, b, c](Result[Result[c, b], a])
 
     @test
     def testOpaqueType01(): Celsius = Celsius.Celsius(123)
@@ -184,19 +184,19 @@ namespace Test/Dec/Enum/Singleton {
     }
 
     @test
-    def testOpaqueType30(): V = V.V(Ok(true))
+    def testOpaqueType30(): V = V.V(Err(true))
 
     @test
-    def testOpaqueType31(): Bool = match V.V(Ok(true)) {
-        case V.V(x) => x == Ok(true)
+    def testOpaqueType31(): Bool = match V.V(Err(true)) {
+        case V.V(x) => x == Err(true)
     }
 
     @test
-    def testOpaqueType32(): V = V.V(Err(123))
+    def testOpaqueType32(): V = V.V(Ok(123))
 
     @test
-    def testOpaqueType33(): Bool = match V.V(Err(123)) {
-        case V.V(x) => x == Err(123)
+    def testOpaqueType33(): Bool = match V.V(Ok(123)) {
+        case V.V(x) => x == Ok(123)
     }
 
 }

--- a/main/test/flix/Test.Dec.TypeAlias.flix
+++ b/main/test/flix/Test.Dec.TypeAlias.flix
@@ -28,7 +28,7 @@ namespace Test/Dec/TypeAlias {
     /**
      * A type alias for a Result.
      */
-    type alias B = Result[Bool, Int32]
+    type alias B = Result[Int32, Bool]
 
     /**
      * A polymorphic type alias for a Option.
@@ -43,7 +43,7 @@ namespace Test/Dec/TypeAlias {
     /**
      * A partially polymorphic type alias for a Result.
      */
-    type alias E[a] = Result[a, String]
+    type alias E[a] = Result[String, a]
 
     @test
     def testTypeAlias01(): Celsius = 123
@@ -88,10 +88,10 @@ namespace Test/Dec/TypeAlias {
     def testTypeAlias14(): C[Int32] = Some(123)
 
     @test
-    def testTypeAlias15(): D[Bool, Int32] = Ok(true)
+    def testTypeAlias15(): D[Bool, Int32] = Ok(123)
 
     @test
-    def testTypeAlias16(): D[Bool, Int32] = Err(123)
+    def testTypeAlias16(): D[Bool, Int32] = Err(true)
 
     @test
     def testTypeAlias17(): E[Bool] = Ok(true)
@@ -151,10 +151,10 @@ namespace Test/Dec/TypeAlias {
     def testTypeAlias25(): V[Int32] = Y.Y(Some(123))
 
     @test
-    def testTypeAlias26(): W[Bool, Int32] = Z.Z(Ok(true))
+    def testTypeAlias26(): W[Bool, Int32] = Z.Z(Ok(123))
 
     @test
-    def testTypeAlias27(): W[Bool, Int32] = Z.Z(Err(123))
+    def testTypeAlias27(): W[Bool, Int32] = Z.Z(Err(true))
 
     ///
     /// Type-level if-then-else

--- a/main/test/flix/Test.Def.Generalization.flix
+++ b/main/test/flix/Test.Def.Generalization.flix
@@ -22,7 +22,7 @@ namespace Test/Def/Generalization {
     def testGen06(): Option[a] -> Option[a] = x -> x
 
     @test
-    def testGen07(): Result[t, e] -> Result[t, e] = x -> x
+    def testGen07(): Result[e, t] -> Result[e, t] = x -> x
 
     @test
     def testGen09(): {f = a} -> {f = a} = x -> x
@@ -92,40 +92,40 @@ namespace Test/Def/Generalization {
     def testLeq04(): List[Option[a]] = Nil
 
     @test
-    def testLeq05(): List[Result[t, e]] = Nil
+    def testLeq05(): List[Result[e, t]] = Nil
 
     @test
-    def testLeq06(): Result[Int32, a] = Ok(21)
+    def testLeq06(): Result[e, Int32] = Ok(21)
 
     @test
-    def testLeq07(): Result[Int32, Bool] = Ok(21)
+    def testLeq07(): Result[Bool, Int32] = Ok(21)
 
     @test
-    def testLeq08(): Result[Int32, String] = Ok(21)
+    def testLeq08(): Result[String, Int32] = Ok(21)
 
     @test
-    def testLeq09(): Result[Int32, Result[t, e]] = Ok(21)
+    def testLeq09(): Result[Result[e, t], Int32] = Ok(21)
 
     @test
-    def testLeq10(): Result[a, Int32] = Err(21)
+    def testLeq10(): Result[Int32, a] = Err(21)
 
     @test
-    def testLeq11(): Result[Bool, Int32] = Err(21)
+    def testLeq11(): Result[Int32, Bool] = Err(21)
 
     @test
-    def testLeq12(): Result[String, Int32] = Err(21)
+    def testLeq12(): Result[Int32, String] = Err(21)
 
     @test
-    def testLeq13(): Result[Result[t, e], Int32] = Err(21)
+    def testLeq13(): Result[Int32, Result[e, t]] = Err(21)
 
     @test
-    def testLeq14(): List[Result[Int32, Option[a]]] = Ok(21) :: Nil
+    def testLeq14(): List[Result[Option[a], Int32]] = Ok(21) :: Nil
 
     @test
-    def testLeq15(): List[Result[Int32, Result[t, e]]] = Ok(21) :: Nil
+    def testLeq15(): List[Result[Result[e, t], Int32]] = Ok(21) :: Nil
 
     @test
-    def testLeq16(): List[Result[Int32, Map[k, v]]] = Ok(21) :: Nil
+    def testLeq16(): List[Result[Map[k, v], Int32]] = Ok(21) :: Nil
 
     @test
     def testLeq17(): a -> (b -> a) = x -> (_ -> x)

--- a/main/test/flix/Test.Equality.Tag.flix
+++ b/main/test/flix/Test.Equality.Tag.flix
@@ -7,10 +7,10 @@ namespace Test/Equality/Tag {
     def testEqTag02(): Bool = Some(42) == Some(42)
 
     @test
-    def testEqTag03(): Bool = Ok(42): Result[_, Unit] == Ok(42)
+    def testEqTag03(): Bool = Ok(42): Result[Unit, _] == Ok(42)
 
     @test
-    def testEqTag04(): Bool = Err(42): Result[Unit, _] == Err(42)
+    def testEqTag04(): Bool = Err(42): Result[_, Unit] == Err(42)
 
     @test
     def testEqTag05(): Bool = Nil: List[Unit] == Nil
@@ -19,10 +19,10 @@ namespace Test/Equality/Tag {
     def testEqTag06(): Bool = (42 :: Nil) == (42 :: Nil)
 
     @test
-    def testEqTag07(): Bool = Some(Ok(42)): Option[Result[_, Unit]] == Some(Ok(42))
+    def testEqTag07(): Bool = Some(Ok(42)): Option[Result[Unit, _]] == Some(Ok(42))
 
     @test
-    def testEqTag08(): Bool = Ok(Some(42)): Result[_, Unit] == Ok(Some(42))
+    def testEqTag08(): Bool = Ok(Some(42)): Result[Unit, _] == Ok(Some(42))
 
     @test
     def testEqTag09(): Bool = Some((Ok(1) :: Err(2) :: Nil)) == Some((Ok(1) :: Err(2) :: Nil))
@@ -34,10 +34,10 @@ namespace Test/Equality/Tag {
     def testNeqTag02(): Bool = Some(21) != Some(42)
 
     @test
-    def testNeqTag03(): Bool = Ok(21): Result[_, Unit] != Ok(42)
+    def testNeqTag03(): Bool = Ok(21): Result[Unit, _] != Ok(42)
 
     @test
-    def testNeqTag04(): Bool = Err(21): Result[Unit, _] != Err(42)
+    def testNeqTag04(): Bool = Err(21): Result[_, Unit] != Err(42)
 
     @test
     def testNeqTag05(): Bool = Nil != (42 :: Nil)
@@ -49,7 +49,7 @@ namespace Test/Equality/Tag {
     def testNeqTag07(): Bool = Some(Ok(21)) != Some(Err(42))
 
     @test
-    def testNeqTag08(): Bool = Ok(None): Result[Option[Int32], Unit] != Ok(Some(42))
+    def testNeqTag08(): Bool = Ok(None): Result[Unit, Option[Int32]] != Ok(Some(42))
 
     @test
     def testNeqTag09(): Bool = Some((Ok(1) :: Err(2) :: Nil)) != Some((Err(1) :: Ok(2) :: Nil))

--- a/main/test/flix/Test.Exp.Binary.Spaceship.flix
+++ b/main/test/flix/Test.Exp.Binary.Spaceship.flix
@@ -110,22 +110,22 @@ namespace Test/Exp/Binary/Spaceship {
     def testBinarySpaceship36(): Bool = (Some(123) <=> None) == GreaterThan
 
     @test
-    def testBinarySpaceship37(): Bool = ((Ok(123): Result[_, Unit]) <=> Ok(123)) == EqualTo
+    def testBinarySpaceship37(): Bool = ((Ok(123): Result[Unit, _]) <=> Ok(123)) == EqualTo
 
     @test
-    def testBinarySpaceship38(): Bool = ((Ok(123): Result[_, Unit]) <=> Ok(456)) == LessThan
+    def testBinarySpaceship38(): Bool = ((Ok(123): Result[Unit, _]) <=> Ok(456)) == LessThan
 
     @test
-    def testBinarySpaceship39(): Bool = ((Ok(456): Result[_, Unit]) <=> Ok(123)) == GreaterThan
+    def testBinarySpaceship39(): Bool = ((Ok(456): Result[Unit, _]) <=> Ok(123)) == GreaterThan
 
     @test
-    def testBinarySpaceship40(): Bool = ((Err(123): Result[Unit, _]) <=> Err(123)) == EqualTo
+    def testBinarySpaceship40(): Bool = ((Err(123): Result[_, Unit]) <=> Err(123)) == EqualTo
 
     @test
-    def testBinarySpaceship41(): Bool = ((Err(123): Result[Unit, _]) <=> Err(456)) == LessThan
+    def testBinarySpaceship41(): Bool = ((Err(123): Result[_, Unit]) <=> Err(456)) == LessThan
 
     @test
-    def testBinarySpaceship42(): Bool = ((Err(456): Result[Unit, _]) <=> Err(123)) == GreaterThan
+    def testBinarySpaceship42(): Bool = ((Err(456): Result[_, Unit]) <=> Err(123)) == GreaterThan
 
     @test
     def testBinarySpaceship43(): Bool = (Ok(123) <=> Err(123)) == LessThan
@@ -134,19 +134,19 @@ namespace Test/Exp/Binary/Spaceship {
     def testBinarySpaceship44(): Bool = (Err(123) <=> Ok(123)) == GreaterThan
 
     @test
-    def testBinarySpaceship45(): Bool = ((None: Option[Result[_, Unit]]) <=> Some(Ok(123))) == LessThan
+    def testBinarySpaceship45(): Bool = ((None: Option[Result[Unit, _]]) <=> Some(Ok(123))) == LessThan
 
     @test
-    def testBinarySpaceship46(): Bool = ((Some(Ok(123)): Option[Result[_, Unit]]) <=> None) == GreaterThan
+    def testBinarySpaceship46(): Bool = ((Some(Ok(123)): Option[Result[Unit, _]]) <=> None) == GreaterThan
 
     @test
-    def testBinarySpaceship47(): Bool = ((Some(Ok(123)): Option[Result[_, Unit]]) <=> Some(Ok(123))) == EqualTo
+    def testBinarySpaceship47(): Bool = ((Some(Ok(123)): Option[Result[Unit, _]]) <=> Some(Ok(123))) == EqualTo
 
     @test
-    def testBinarySpaceship48(): Bool = ((Some(Ok(123)): Option[Result[_, Unit]]) <=> Some(Ok(456))) == LessThan
+    def testBinarySpaceship48(): Bool = ((Some(Ok(123)): Option[Result[Unit, _]]) <=> Some(Ok(456))) == LessThan
 
     @test
-    def testBinarySpaceship49(): Bool = ((Some(Ok(456)): Option[Result[_, Unit]]) <=> Some(Ok(123))) == GreaterThan
+    def testBinarySpaceship49(): Bool = ((Some(Ok(456)): Option[Result[Unit, _]]) <=> Some(Ok(123))) == GreaterThan
 
     @test
     def testBinarySpaceship50(): Bool = (Some(Ok(123)) <=> Some(Err("hello"))) == LessThan
@@ -155,13 +155,13 @@ namespace Test/Exp/Binary/Spaceship {
     def testBinarySpaceship51(): Bool = (Some(Err("hello")) <=> Some(Ok(123))) == GreaterThan
 
     @test
-    def testBinarySpaceship52(): Bool = ((Some(Ok(None)): Option[Result[Option[Unit], Unit]]) <=> Some(Ok(None))) == EqualTo
+    def testBinarySpaceship52(): Bool = ((Some(Ok(None)): Option[Result[Unit, Option[Unit]]]) <=> Some(Ok(None))) == EqualTo
 
     @test
-    def testBinarySpaceship53(): Bool = ((Some(Ok(None)): Option[Result[Option[Int32], Unit]]) <=> Some(Ok(Some(123)))) == LessThan
+    def testBinarySpaceship53(): Bool = ((Some(Ok(None)): Option[Result[Unit, Option[Int32]]]) <=> Some(Ok(Some(123)))) == LessThan
 
     @test
-    def testBinarySpaceship54(): Bool = ((Some(Ok(Some(123))): Option[Result[Option[Int32], Unit]]) <=> Some(Ok(None))) == GreaterThan
+    def testBinarySpaceship54(): Bool = ((Some(Ok(Some(123))): Option[Result[Unit, Option[Int32]]]) <=> Some(Ok(None))) == GreaterThan
 
     @test
     def testBinarySpaceship55(): Bool = ((111, 222) <=> (111, 222)) == EqualTo

--- a/main/test/flix/Test.Exp.Concurrency.Buffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Buffered.flix
@@ -13,7 +13,7 @@ namespace Test/Exp/Concurrency/Buffered {
         Channel.send(true, tx);
         true == Channel.recv(rx)
     }
-    
+
     @test
     def testBufferedChannel03(): Bool \ {} = region r {
         let (tx, rx) = Channel.buffered(r, 1);
@@ -48,7 +48,7 @@ namespace Test/Exp/Concurrency/Buffered {
         Channel.send(42i32, tx);
         42i32 == Channel.recv(rx)
     }
-    
+
     @test
     def testBufferedChannel08(): Bool \ {} = region r {
         let (tx, rx) = Channel.buffered(r, 1);
@@ -76,7 +76,7 @@ namespace Test/Exp/Concurrency/Buffered {
         Channel.send(None, tx);
         None == Channel.recv(rx)
     }
-    
+
     @test
     def testBufferedChannel12(): Bool \ {} = region r {
         let (tx, rx) = Channel.buffered(r, 1);
@@ -86,14 +86,14 @@ namespace Test/Exp/Concurrency/Buffered {
 
     @test
     def testBufferedChannel13(): Bool \ {} = region r {
-        let (tx, rx): (Sender[Result[Int32, String], _], Receiver[Result[Int32, String], _]) = Channel.buffered(r, 1);
+        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.buffered(r, 1);
         Channel.send(Ok(123), tx);
         Ok(123) == Channel.recv(rx)
     }
 
     @test
     def testBufferedChannel14(): Bool \ {} = region r {
-        let (tx, rx): (Sender[Result[Int32, String], _], Receiver[Result[Int32, String], _]) = Channel.buffered(r, 1);
+        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.buffered(r, 1);
         Channel.send(Err("Goodbye World!"), tx);
         Err("Goodbye World!") == Channel.recv(rx)
     }
@@ -127,14 +127,14 @@ namespace Test/Exp/Concurrency/Buffered {
         spawn Channel.send(true, tx) @ r;
         true == Channel.recv(rx)
     }
-    
+
     @test
     def testBufferedChannelWithSpawn03(): Bool \ IO = region r {
         let (tx, rx) = Channel.buffered(r, 1);
         spawn Channel.send(123.456f32, tx) @ r;
         123.456f32 == Channel.recv(rx)
     }
-    
+
     @test
     def testBufferedChannelWithSpawn04(): Bool \ IO = region r {
         let (tx, rx) = Channel.buffered(r, 1);
@@ -155,7 +155,7 @@ namespace Test/Exp/Concurrency/Buffered {
         spawn Channel.send(42i16, tx) @ r;
         42i16 == Channel.recv(rx)
     }
-    
+
     @test
     def testBufferedChannelWithSpawn07(): Bool \ IO = region r {
         let (tx, rx) = Channel.buffered(r, 1);
@@ -200,14 +200,14 @@ namespace Test/Exp/Concurrency/Buffered {
 
     @test
     def testBufferedChannelWithSpawn13(): Bool \ IO = region r {
-        let (tx, rx): (Sender[Result[Int32, String], _], Receiver[Result[Int32, String], _]) = Channel.buffered(r, 1);
+        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.buffered(r, 1);
         spawn Channel.send(Ok(123), tx) @ r;
         Ok(123) == Channel.recv(rx)
     }
 
     @test
     def testBufferedChannelWithSpawn14(): Bool \ IO = region r {
-        let (tx, rx): (Sender[Result[Int32, String], _], Receiver[Result[Int32, String], _]) = Channel.buffered(r, 1);
+        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.buffered(r, 1);
         spawn Channel.send(Err("Goodbye World!"), tx) @ r;
         Err("Goodbye World!") == Channel.recv(rx)
     }

--- a/main/test/flix/Test.Exp.Concurrency.Unbuffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Unbuffered.flix
@@ -48,7 +48,7 @@ namespace Test/Exp/Concurrency/Unbuffered {
         spawn Channel.send(42i32, tx) @ r;
         42i32 == Channel.recv(rx)
     }
-    
+
     @test
     def testUnbufferedChannelPutGet08(): Bool \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
@@ -62,49 +62,49 @@ namespace Test/Exp/Concurrency/Unbuffered {
         spawn Channel.send(42ii, tx) @ r;
         42ii == Channel.recv(rx)
     }
-    
+
     @test
     def testUnbufferedChannelPutGet10(): Bool \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
         spawn Channel.send("Hello World!", tx) @ r;
         "Hello World!" == Channel.recv(rx)
     }
-    
+
     @test
     def testUnbufferedChannelPutGet11(): Bool \ IO = region r {
         let (tx, rx): (Sender[Option[Int32], _], Receiver[Option[Int32], _]) = Channel.unbuffered(r);
         spawn Channel.send(None, tx) @ r;
         None == Channel.recv(rx)
     }
-    
+
     @test
     def testUnbufferedChannelPutGet12(): Bool \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
         spawn Channel.send(Some(123), tx) @ r;
         Some(123) == Channel.recv(rx)
     }
-    
+
     @test
     def testUnbufferedChannelPutGet13(): Bool \ IO = region r {
-        let (tx, rx): (Sender[Result[Int32, String], _], Receiver[Result[Int32, String], _]) = Channel.unbuffered(r);
+        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.unbuffered(r);
         spawn Channel.send(Ok(123), tx) @ r;
         Ok(123) == Channel.recv(rx)
     }
-    
+
     @test
     def testUnbufferedChannelPutGet14(): Bool \ IO = region r {
-        let (tx, rx): (Sender[Result[Int32, String], _], Receiver[Result[Int32, String], _]) = Channel.unbuffered(r);
+        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.unbuffered(r);
         spawn Channel.send(Err("Goodbye World!"), tx) @ r;
         Err("Goodbye World!") == Channel.recv(rx)
     }
-    
+
     @test
     def testUnbufferedChannelPutGet15(): Bool \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
         spawn Channel.unsafeSend([1, 2, 3], tx) @ r;
         2 == (Channel.recv(rx))[1]
     }
-    
+
     @test
     def testUnbufferedChannelPutGet16(): Bool \ IO = region r {
         let (tx1, rx1) = Channel.unbuffered(r);
@@ -113,112 +113,112 @@ namespace Test/Exp/Concurrency/Unbuffered {
         spawn Channel.send(42, tx2) @ r;
         42 == Channel.recv(Channel.recv(rx1))
     }
-    
+
     @test
     def testUnbufferedChannelGetPut01(): Unit \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
         spawn Channel.recv(rx) @ r;
         Channel.send((), tx)
     }
-    
+
     @test
     def testUnbufferedChannelGetPut02(): Unit \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
         spawn Channel.recv(rx) @ r;
         Channel.send(true, tx)
     }
-    
+
     @test
     def testUnbufferedChannelGetPut03(): Unit \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
         spawn Channel.recv(rx) @ r;
         Channel.send(123.456f32, tx)
     }
-    
+
     @test
     def testUnbufferedChannelGetPut04(): Unit \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
         spawn Channel.recv(rx) @ r;
         Channel.send(123.456f64, tx)
     }
-    
+
     @test
     def testUnbufferedChannelGetPut05(): Unit \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
         spawn Channel.recv(rx) @ r;
         Channel.send(42i8, tx)
     }
-    
+
     @test
     def testUnbufferedChannelGetPut06(): Unit \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
         spawn Channel.recv(rx) @ r;
         Channel.send(42i16, tx)
     }
-    
+
     @test
     def testUnbufferedChannelGetPut07(): Unit \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
         spawn Channel.recv(rx) @ r;
         Channel.send(42i32, tx)
     }
-    
+
     @test
     def testUnbufferedChannelGetPut08(): Unit \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
         spawn Channel.recv(rx) @ r;
         Channel.send(42i64, tx)
     }
-    
+
     @test
     def testUnbufferedChannelGetPut09(): Unit \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
         spawn Channel.recv(rx) @ r;
         Channel.send(42ii, tx)
     }
-    
+
     @test
     def testUnbufferedChannelGetPut10(): Unit \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
         spawn Channel.recv(rx) @ r;
         Channel.send("Hello World!", tx)
     }
-    
+
     @test
     def testUnbufferedChannelGetPut11(): Unit \ IO = region r {
         let (tx, rx): (Sender[Option[Int32], _], Receiver[Option[Int32], _]) = Channel.unbuffered(r);
         spawn Channel.recv(rx) @ r;
         Channel.send(None, tx)
     }
-    
+
     @test
     def testUnbufferedChannelGetPut12(): Unit \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
         spawn Channel.recv(rx) @ r;
         Channel.send(Some(123), tx)
     }
-    
+
     @test
     def testUnbufferedChannelGetPut13(): Unit \ IO = region r {
-        let (tx, rx): (Sender[Result[Int32, String], _], Receiver[Result[Int32, String], _]) = Channel.unbuffered(r);
+        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.unbuffered(r);
         spawn Channel.recv(rx) @ r;
         Channel.send(Ok(123), tx)
     }
-    
+
     @test
     def testUnbufferedChannelGetPut14(): Unit \ IO = region r {
-        let (tx, rx): (Sender[Result[Int32, String], _], Receiver[Result[Int32, String], _]) = Channel.unbuffered(r);
+        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.unbuffered(r);
         spawn Channel.recv(rx) @ r;
         Channel.send(Err("Goodbye World!"), tx)
     }
-    
+
     @test
     def testUnbufferedChannelGetPut15(): Unit \ IO = region r {
         let (tx, rx) = Channel.unbuffered(r);
         spawn Channel.recv(rx) @ r;
         Channel.unsafeSend([1, 2, 3], tx)
     }
-    
+
     @test
     def testUnbufferedChannelGetPut16(): Unit \ IO = region r {
         let (tx1, rx1) = Channel.unbuffered(r);

--- a/main/test/flix/Test.Exp.Interpolation.flix
+++ b/main/test/flix/Test.Exp.Interpolation.flix
@@ -187,7 +187,7 @@ namespace Test/Exp/Interpolation {
 
     @test
     def interpolation35(): Bool =
-        let x = Ok(Some(123)): Result[Option[Int32], Int32];
+        let x = Ok(Some(123)): Result[Int32, Option[Int32]];
         "${x}" == "Ok(Some(123))"
 
     @test

--- a/main/test/flix/Test.Exp.Let.MatchStar.flix
+++ b/main/test/flix/Test.Exp.Let.MatchStar.flix
@@ -62,59 +62,59 @@ namespace Test/Exp/LetMatchStar {
       Some(x + y + z + w)
 
     @test
-    def testResult01(): Result[Int32, String] =
+    def testResult01(): Result[String, Int32] =
         use Result.flatMap;
         let* _ = Err("Hello World");
         Err("Hello World")
 
     @test
-    def testResult02(): Result[Int32, String] =
+    def testResult02(): Result[String, Int32] =
         use Result.flatMap;
         let* _ = Ok(123);
         Err("Hello World")
 
     @test
-    def testResult03(): Result[Int32, String] =
+    def testResult03(): Result[String, Int32] =
         use Result.flatMap;
         let* x = Err("Hello World");
         Ok(x + 1)
 
     @test
-    def testResult04(): Result[Int32, String] =
+    def testResult04(): Result[String, Int32] =
         use Result.flatMap;
         let* x = Ok(123);
         Ok(x + 1)
 
     @test
-    def testResult05(): Result[Int32, String] =
+    def testResult05(): Result[String, Int32] =
         use Result.flatMap;
         let* _ = Ok(123);
         let* _ = Ok(456);
         Err("Hello World")
 
     @test
-    def testResult06(): Result[Int32, String] =
+    def testResult06(): Result[String, Int32] =
         use Result.flatMap;
         let* x = Ok(123);
         let* _ = Ok(456);
         Ok(x + 1)
 
     @test
-    def testResult07(): Result[Int32, String] =
+    def testResult07(): Result[String, Int32] =
       use Result.flatMap;
       let* _ = Ok(123);
       let* y = Ok(456);
       Ok(y + 1)
 
     @test
-    def testResult08(): Result[Int32, String] =
+    def testResult08(): Result[String, Int32] =
       use Result.flatMap;
       let* x = Ok(123);
       let* y = Ok(456);
       Ok(x + y)
 
     @test
-    def testResult09(): Result[Int32, String] =
+    def testResult09(): Result[String, Int32] =
       use Result.flatMap;
       let* x = Ok(123);
       let y = 456;

--- a/main/test/flix/Test.Exp.Ref.Deref.flix
+++ b/main/test/flix/Test.Exp.Ref.Deref.flix
@@ -93,13 +93,13 @@ namespace Test/Exp/Ref/Deref {
     @test
     def testDeref16(): Bool = region r {
         let l = ref Ok(42) @ r;
-        deref l: Ref[Result[_, Unit], _] == Ok(42)
+        deref l: Ref[Result[Unit, _], _] == Ok(42)
     }
 
     @test
     def testDeref17(): Bool = region r {
         let l = ref Err("Goodbye World!") @ r;
-        deref l: Ref[Result[Unit, _], _] == Err("Goodbye World!")
+        deref l: Ref[Result[_, Unit], _] == Err("Goodbye World!")
     }
 
     @test

--- a/main/test/flix/Test.Exp.Ref.Ref.flix
+++ b/main/test/flix/Test.Exp.Ref.Ref.flix
@@ -49,10 +49,10 @@ namespace Test/Exp/Ref/Ref {
     def testRef16(): Unit = region r { discard ref Some(42) @ r }
 
     @test
-    def testRef17(): Unit = region r { discard ref Ok(42): Result[Int32, String] @ r }
+    def testRef17(): Unit = region r { discard ref Ok(42): Result[String, Int32] @ r }
 
     @test
-    def testRef18(): Unit = region r { discard ref Err("Goodbye World!"): Result[Int32, String] @ r }
+    def testRef18(): Unit = region r { discard ref Err("Goodbye World!"): Result[String, Int32] @ r }
 
     @test
     def testRefRegion01(): Unit = // Pure

--- a/main/test/flix/Test.Exp.Tuple.flix
+++ b/main/test/flix/Test.Exp.Tuple.flix
@@ -124,10 +124,10 @@ namespace Test/Exp/Tuple {
     def testResultTuple04(): (Result[Int32, Int32], Result[Int32, Int32]) = (Err(1), Err(2))
 
     @test
-    def testResultTuple05(): Result[Int32, (Int32, Int32)] = Ok(1)
+    def testResultTuple05(): Result[(Int32, Int32), Int32] = Ok(1)
 
     @test
-    def testResultTuple06(): Result[Int32, (Int32, Int32)] = Err((1, 2))
+    def testResultTuple06(): Result[(Int32, Int32), Int32] = Err((1, 2))
 
     @test
     def testListTuple01(): (List[Int32], List[Int32]) = (Nil, Nil)

--- a/main/test/flix/Test.Term.Lit.Result.flix
+++ b/main/test/flix/Test.Term.Lit.Result.flix
@@ -13,8 +13,8 @@ namespace Test/Term/Lit/Result {
     @test
     def testLitResult02(): Bool =
         let p = #{
-            A(Ok("Hello World"): Result[String, Int32]).
-            B(Ok("Hello World"): Result[String, Int32]).
+            A(Ok("Hello World"): Result[Int32, String]).
+            B(Ok("Hello World"): Result[Int32, String]).
             R(x) :- A(x), B(x).
         };
         let r = query p select x from R(x);

--- a/main/test/flix/Test.Term.Var.CapturedVar.flix
+++ b/main/test/flix/Test.Term.Var.CapturedVar.flix
@@ -297,7 +297,7 @@ namespace Test/Term/Lit/Var/CapturedVar {
     ///////////////////////////////////////////////////////////////////////////////
     @test
     def testResultCapturedVar01(): Bool =
-        let c: Result[Int32, String] = Ok(123);
+        let c: Result[String, Int32] = Ok(123);
         let x = #R(c).;
         let y = #R(c) :- R(c).;
         let r = query x, y select 42 from R(c);
@@ -305,7 +305,7 @@ namespace Test/Term/Lit/Var/CapturedVar {
 
     @test
     def testResultCapturedVar02(): Bool =
-        let c: Result[Int32, String] = Err("goodbye world!");
+        let c: Result[String, Int32] = Err("goodbye world!");
         let x = #R(c).;
         let y = #R(c) :- R(c).;
         let r = query x, y select 42 from R(c);

--- a/main/test/flix/Test.TypeAlias.Rel.flix
+++ b/main/test/flix/Test.TypeAlias.Rel.flix
@@ -24,7 +24,7 @@ namespace Test/TypeAlias/Rel {
 
     rel D(x: List[Int32])
     rel E(x: Option[Int32])
-    rel F(x: Result[Bool, String])
+    rel F(x: Result[String, Bool])
 
     @test
     def testTypeAlias04(): #{D} = #{


### PR DESCRIPTION
This PR changes the order of the type arguments of `Result` and `Validation` so they are compatible with the `Functor` etc. classes. Work to add `Functor`, `Applicative` and `Monad` instances will be done in a follow up PR.


Mostly I've changed as little as possible, the exceptions are in the library suite tests - `TestResult.flix` and `TestValidation.flix`. Here I've changed type ascriptions to use fully specified type names rather than wildcards. I initially tried to just flip the existing type arguments but I  found it very confusing trying to track which tests I'd changed.

In other tests I've tried to keep type wildcards where they were used so that it doesn't reduce the number of tests that validate type wildcards are working.