### PR TITLE
feat: add Functor Applicative and Monad instances to Result and Validation (issue #5191)

### DIFF
--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -33,6 +33,19 @@ instance Hash[Result[e, t]] with Hash[e], Hash[t] {
     }
 }
 
+instance Functor[Result[e]] {
+    pub def map(f: a -> b \ ef, x: Result[e, a]): Result[e, b] \ ef = Result.map(f, x)
+}
+
+instance Applicative[Result[e]] {
+    pub def point(a: a) : Result[e, a] = Ok(a)
+    pub def ap(f: Result[e, a -> b \ ef], x: Result[e, a]): Result[e, b] \ ef = Result.ap(f, x)
+}
+
+instance Monad[Result[e]] {
+    pub def flatMap(f: a -> Result[e, b] \ ef, x : Result[e, a]): Result[e, b] \ ef = Result.flatMap(f, x)
+}
+
 namespace Result {
 
     ///

--- a/main/src/library/Validation.flix
+++ b/main/src/library/Validation.flix
@@ -42,6 +42,16 @@ instance Monoid[Validation[e, t]] with Monoid[t] {
     pub def empty(): Validation[e, t] = Validation.Success(Monoid.empty())
 }
 
+instance Functor[Validation[e]] {
+    pub def map(f: a -> b \ ef, x: Validation[e, a]): Validation[e, b] \ ef = Validation.map(f, x)
+}
+
+instance Applicative[Validation[e]] {
+    pub def point(a: a) : Validation[e, a] = Validation.Success(a)
+    pub def ap(f: Validation[e, a -> b \ ef], x: Validation[e, a]): Validation[e, b] \ ef = Validation.ap(f, x)
+}
+
+
 namespace Validation {
 
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -18,6 +18,46 @@ namespace TestResult {
 
     use Hash.hash
 
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Functor.map                                                             //
+    /////////////////////////////////////////////////////////////////////////////
+    @test
+    def functor_map01(): Bool = Functor.map(i -> i == 2, Err(-1ii)) == Err(-1ii)
+
+    @test
+    def functor_map02(): Bool = Functor.map(i -> i == 2, Ok(1)): Result[Unit, Bool] == Ok(false)
+
+    @test
+    def functor_map03(): Bool = Functor.map(i -> i == 2, Ok(2)): Result[Unit, Bool] == Ok(true)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Monad.flatMap                                                           //
+    /////////////////////////////////////////////////////////////////////////////
+    @test
+    def monad_flatMap01(): Bool = Monad.flatMap(i -> if (i == 2) Ok(i) else Err(false), Err(true)) == Err(true)
+
+    @test
+    def monad_flatMap02(): Bool = Monad.flatMap(i -> if (i == 2) Ok(i) else Err(false), Ok(1)) == Err(false)
+
+    @test
+    def monad_flatMap03(): Bool = Monad.flatMap(i -> if (i == 2) Ok(2*i) else Err(false), Ok(2)) == Ok(4)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Applicative.ap                                                          //
+    /////////////////////////////////////////////////////////////////////////////
+    @test
+    def applicative_ap01(): Bool = Applicative.ap(Ok(x -> x + 1), Ok(123)): Result[String, Int32] == Ok(124)
+
+    @test
+    def applicative_ap02(): Bool = Applicative.ap(Ok(x -> x + 1), Err("b")) == Err("b")
+
+    @test
+    def applicative_ap03(): Bool = Applicative.ap(Err("a"), Ok(123)): Result[String, Int32] == Err("a")
+
+    @test
+    def applicative_ap04(): Bool = Applicative.ap(Err("a"), Err("b")): Result[String, Int32] == Err("a")
+
     /////////////////////////////////////////////////////////////////////////////
     // isOk                                                                    //
     /////////////////////////////////////////////////////////////////////////////
@@ -134,6 +174,7 @@ namespace TestResult {
 
     @test
     def flatMap03(): Bool = Result.flatMap(i -> if (i == 2) Ok(2*i) else Err(false), Ok(2)) == Ok(4)
+
 
     /////////////////////////////////////////////////////////////////////////////
     // flatten                                                                 //

--- a/main/test/ca/uwaterloo/flix/library/TestValidation.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestValidation.flix
@@ -38,6 +38,32 @@ namespace TestValidation {
     def necOf10(p: a, q: a, r: a, s: a, t: a, u: a, v: a, w: a, x: a, y: a): Nec[a] = cons(p, cons(q, cons(r, cons(s, cons(t, cons(u, cons(v, cons(w, cons(x, singleton(y))))))))))
 
     /////////////////////////////////////////////////////////////////////////////
+    // Functor.map                                                             //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def functor_map01(): Bool = Functor.map(x -> x, Success(123)): Validation[Int32, Int32] == Success(123)
+
+    @test
+    def functor_map02(): Bool = Functor.map(x -> x + 1, Success(123)): Validation[Int32, Int32] == Success(124)
+
+    @test
+    def functor_map03(): Bool = Functor.map(x -> x, Failure(singleton(123))): Validation[Int32, Int32] == Failure(singleton(123))
+
+    @test
+    def functor_map04(): Bool = (Success(123): Validation[Int32, Int32]) |> Functor.map(x -> x + 1) |> Functor.map(x -> x * 2)  == Success(248)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Applicative.ap                                                          //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def applicative_ap01(): Bool = Applicative.ap(Success(x -> x + 1), Success(123)): Validation[Int32, Int32] == Success(124)
+
+    @test
+    def applicative_ap02(): Bool = Applicative.ap(Success(x -> x + 1), Failure(singleton(42))) == Failure(singleton(42))
+
+    /////////////////////////////////////////////////////////////////////////////
     // ap                                                                      //
     /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This PR adds `Functor`, `Applicative` and `Monad` instances to `Result` and `Functor` and `Applicative` instances to `Validation` (which doesn't have a valid implementation of `flatMap`).

Second part of three of issue #5191 "Swap type arguments of Result and Validation".