### PR TITLE
refactor: make zipWithIndex and enumerator consistent with mapWithIndex (issue #5080)

### DIFF
--- a/examples/copying-characters-into-array-with-foreach.flix
+++ b/examples/copying-characters-into-array-with-foreach.flix
@@ -17,7 +17,7 @@ def main(): Unit \ IO = region r {
         // out of bounds errors.
         // It also matches the pattern of the
         // value returned by `enumerator.`
-        foreach ((x, i) <- String.enumerator(r, s);
+        foreach ((i, x) <- String.enumerator(r, s);
                  if i < Array.length(xs))
                     xs[i] = x;
 

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -1419,7 +1419,7 @@ namespace Array {
     ///
     /// Modifying `a` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def enumerator(r1: Region[r1], a: Array[a, r2]): Iterator[(a, Int32), r1 and r2] \ { Write(r1), Read(r2) } =
+    pub def enumerator(r1: Region[r1], a: Array[a, r2]): Iterator[(Int32, a), r1 and r2] \ { Write(r1), Read(r2) } =
         iterator(r1, a) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -908,7 +908,7 @@ namespace Chain {
         Foldable.joinWith(f, sep, c)
 
     ///
-    /// Returns a chain where each element `e` is mapped to `(e, i)` where `i`
+    /// Returns a chain where each element `e` is mapped to `(i, e)` where `i`
     /// is the index of `e`.
     ///
     pub def zipWithIndex(c: Chain[a]): Chain[(Int32, a)] =

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -771,7 +771,7 @@ namespace Chain {
         case None    => [] @ r
         case Some(_) =>
             let arr = Array.new(r, length(c));
-            forEach(match (b, i) -> arr[i] = b, zipWithIndex(c));
+            forEach(match (i, b) -> arr[i] = b, zipWithIndex(c));
             arr
         }
 
@@ -911,10 +911,10 @@ namespace Chain {
     /// Returns a chain where each element `e` is mapped to `(e, i)` where `i`
     /// is the index of `e`.
     ///
-    pub def zipWithIndex(c: Chain[a]): Chain[(a, Int32)] =
+    pub def zipWithIndex(c: Chain[a]): Chain[(Int32, a)] =
         def loop(cc, acc, i) = match viewLeft(cc) {
             case ViewLeft.NoneLeft        => acc
-            case ViewLeft.SomeLeft(a, rs) => loop(rs, snoc(acc, (a, i)), i + 1)
+            case ViewLeft.SomeLeft(a, rs) => loop(rs, snoc(acc, (i, a)), i + 1)
         };
         loop(c, Empty, 0)
 

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -96,7 +96,7 @@ instance ToString[Chain[a]] with ToString[a] {
     pub def toString(c: Chain[a]): String = region r {
         let sb = new StringBuilder(r);
         StringBuilder.appendString!("Chain#{", sb);
-        foreach ((x, i) <- enumerator(r, c)) {
+        foreach ((i, x) <- enumerator(r, c)) {
             if (i < 1)
                 StringBuilder.appendString!("${x}", sb)
             else
@@ -796,7 +796,7 @@ namespace Chain {
     ///
     /// Returns an iterator over `c` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], c: Chain[a]): Iterator[(a, Int32), r] \ Write(r) =
+    pub def enumerator(r: Region[r], c: Chain[a]): Iterator[(Int32, a), r] \ Write(r) =
         iterator(r, c) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -1162,11 +1162,11 @@ namespace DelayList {
     ///
     /// Does not force the tail of `l`.
     ///
-    pub def zipWithIndex(l: DelayList[a]): DelayList[(a, Int32)] =
+    pub def zipWithIndex(l: DelayList[a]): DelayList[(Int32, a)] =
         def loop(ll, i) = match ll {
             case ENil         => ENil
-            case ECons(x, xs) => LCons(((x, i)), lazy loop(      xs, i + 1))
-            case LCons(x, xs) => LCons(((x, i)), lazy loop(force xs, i + 1))
+            case ECons(x, xs) => LCons(((i, x)), lazy loop(      xs, i + 1))
+            case LCons(x, xs) => LCons(((i, x)), lazy loop(force xs, i + 1))
             case LList(xs)    => LList(          lazy loop(force xs, i))
         };
         loop(l, 0)
@@ -1179,7 +1179,7 @@ namespace DelayList {
     @Experimental
     pub def toArray(r: Region[r], l: DelayList[a]): Array[a, r] \ Write(r) =
         let a = Array.new(r, length(l));
-        forEach(match (y, i) -> a[i] = y, zipWithIndex(l));
+        forEach(match (i, y) -> a[i] = y, zipWithIndex(l));
         a
 
     ///

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -130,8 +130,8 @@ namespace DelayList {
     pub def toString(l: DelayList[a]): String with ToString[a] = region r {
         let sb = new StringBuilder(r);
         StringBuilder.appendString!("DelayList(", sb);
-        foreach ((x, i) <- enumerator(r, l)) {
-            if (i == 0)
+        foreach ((i, x) <- enumerator(r, l)) {
+            if (i < 1)
                 StringBuilder.appendString!("${x}", sb)
             else
                 StringBuilder.appendString!(", ${x}", sb)
@@ -1205,7 +1205,7 @@ namespace DelayList {
     ///
     /// Returns an iterator over `l` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], l: DelayList[a]): Iterator[(a, Int32), r] \ Write(r) =
+    pub def enumerator(r: Region[r], l: DelayList[a]): Iterator[(Int32, a), r] \ Write(r) =
         iterator(r, l) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -1157,7 +1157,7 @@ namespace DelayList {
         map(x -> f(fst(x), snd(x)), zip(l1, l2))
 
     ///
-    /// Returns a `DelayList` where each element `e` is mapped to `(e, i)` where `i`
+    /// Returns a `DelayList` where each element `e` is mapped to `(i, e)` where `i`
     /// is the index of `e`.
     ///
     /// Does not force the tail of `l`.

--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -235,7 +235,7 @@ pub class Foldable[t : Type -> Type] {
     ///
     /// Returns an iterator over `t` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], t: t[a]): Iterator[(a, Int32), r] \ Write(r) =
+    pub def enumerator(r: Region[r], t: t[a]): Iterator[(Int32, a), r] \ Write(r) =
         Foldable.iterator(r, t) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/Iterable.flix
+++ b/main/src/library/Iterable.flix
@@ -27,7 +27,7 @@ pub class Iterable[t: Type -> Region -> Type] {
     ///
     /// Returns an iterator over `t` zipped with the indices of the elements.
     ///
-    pub def enumerator(r1: Region[r1], t: t[a, r2]): Iterator[(a, Int32), r1 and r2] \ { Write(r1), Read(r2) } =
+    pub def enumerator(r1: Region[r1], t: t[a, r2]): Iterator[(Int32, a), r1 and r2] \ { Write(r1), Read(r2) } =
         Iterable.iterator(r1, t) |> Iterator.zipWithIndex
 
 }

--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -41,7 +41,7 @@ pub def iterator(r: Region[r], t: t[a]): Iterator[a, r] \ Write(r) with Foldable
 ///
 /// Alias for `Foldable.iterator |> Iterable.enumerator`.
 ///
-pub def enumerator(r: Region[r], t: t[a]): Iterator[(a, Int32), r] \ Write(r) with Foldable[t] =
+pub def enumerator(r: Region[r], t: t[a]): Iterator[(Int32, a), r] \ Write(r) with Foldable[t] =
     Foldable.iterator(r, t) |> Iterable.enumerator(r)
 
 namespace Iterator {
@@ -438,11 +438,11 @@ namespace Iterator {
     /// The original iterator `iter` should *not* be reused.
     ///
     @Lazy
-    pub def zipWithIndex(iter: Iterator[a, r]): Iterator[(a, Int32), r] \ Write(r) =
+    pub def zipWithIndex(iter: Iterator[a, r]): Iterator[(Int32, a), r] \ Write(r) =
         let Iterator(done, next) = iter;
         let i = ref 0 @ Scoped.regionOf(iter);
         let next1 = () -> {
-            let x = (next(), deref i);
+            let x = (deref i, next());
             i := deref i + 1;
             x
         };
@@ -451,7 +451,7 @@ namespace Iterator {
     ///
     /// Alias for `zipWithIndex`.
     ///
-    pub def enumerator(iter: Iterator[a, r]): Iterator[(a, Int32), r] \ Write(r) =
+    pub def enumerator(iter: Iterator[a, r]): Iterator[(Int32, a), r] \ Write(r) =
         zipWithIndex(iter)
 
     ///

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -930,10 +930,10 @@ namespace List {
     /// Returns a list where each element `e` is mapped to `(e, i)` where `i`
     /// is the index of `e`.
     ///
-    pub def zipWithIndex(l: List[a]): List[(a, Int32)] =
+    pub def zipWithIndex(l: List[a]): List[(Int32, a)] =
         def loop(ll, i, k) = match ll {
             case Nil       => k(Nil)
-            case (x :: xs) => loop(xs, i + 1, ks -> k((x, i) :: ks))
+            case (x :: xs) => loop(xs, i + 1, ks -> k((i, x) :: ks))
         };
         loop(l, 0, identity)
 
@@ -1141,7 +1141,7 @@ namespace List {
         case None    => [] @ r
         case Some(_) =>
             let a = Array.new(r, length(l));
-            forEach(match (b, i) -> a[i] = b, zipWithIndex(l));
+            forEach(match (i, b) -> a[i] = b, zipWithIndex(l));
             a
         }
 

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -1312,7 +1312,7 @@ namespace List {
     ///
     /// Returns an iterator over `l` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], l: List[a]): Iterator[(a, Int32), r] \ Write(r) =
+    pub def enumerator(r: Region[r], l: List[a]): Iterator[(Int32, a), r] \ Write(r) =
         iterator(r, l) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -927,7 +927,7 @@ namespace List {
         loop(l1, l2, identity)
 
     ///
-    /// Returns a list where each element `e` is mapped to `(e, i)` where `i`
+    /// Returns a list where each element `e` is mapped to `(i, e)` where `i`
     /// is the index of `e`.
     ///
     pub def zipWithIndex(l: List[a]): List[(Int32, a)] =

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -399,7 +399,7 @@ namespace MutSet {
     ///
     /// Returns an enumerator over `s`.
     ///
-    pub def enumerator(r1: Region[r1], s: MutSet[a, r2]): Iterator[(a, Int32), r1 and r2] \ { Write(r1), Read(r2) } =
+    pub def enumerator(r1: Region[r1], s: MutSet[a, r2]): Iterator[(Int32, a), r1 and r2] \ { Write(r1), Read(r2) } =
         iterator(r1, s) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -126,7 +126,7 @@ instance ToString[Nec[a]] with ToString[a] {
     pub def toString(c: Nec[a]): String = region r {
         let sb = new StringBuilder(r);
         StringBuilder.appendString!("Nec#{", sb);
-        foreach ((x, i) <- enumerator(r, c)) {
+        foreach ((i, x) <- enumerator(r, c)) {
             if (i < 1)
                 StringBuilder.appendString!("${x}", sb)
             else
@@ -674,10 +674,10 @@ namespace Nec {
     /// Returns a Nec where each element `e` is mapped to `(e, i)` where `i`
     /// is the index of `e`.
     ///
-    pub def zipWithIndex(c: Nec[a]): Nec[(a, Int32)] =
+    pub def zipWithIndex(c: Nec[a]): Nec[(Int32, a)] =
         def loop(c1, k, i) = match viewLeft(c1) {
-            case ViewLeft.OneLeft(x)      => k(NecOne(x, i))
-            case ViewLeft.SomeLeft(x, rs) => loop(rs, ks -> k(cons((x, i), ks)), i + 1)
+            case ViewLeft.OneLeft(x)      => k(NecOne(i, x))
+            case ViewLeft.SomeLeft(x, rs) => loop(rs, ks -> k(cons((i, x), ks)), i + 1)
         };
         loop(c, k -> k, 0)
 
@@ -784,7 +784,7 @@ namespace Nec {
     pub def toArray(r: Region[r], c: Nec[a]): Array[a, r] \ Write(r) =
         let x = head(c);
         let arr = Array.repeat(r, length(c), x);
-        forEach(match (b, i) -> arr[i] = b, zipWithIndex(c));
+        forEach(match (i, b) -> arr[i] = b, zipWithIndex(c));
         arr
 
     ///
@@ -818,7 +818,7 @@ namespace Nec {
     ///
     /// Returns an iterator over `c` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], c: Nec[a]): Iterator[(a, Int32), r] \ Write(r) =
+    pub def enumerator(r: Region[r], c: Nec[a]): Iterator[(Int32, a), r] \ Write(r) =
         iterator(r, c) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -671,7 +671,7 @@ namespace Nec {
         loop(c, (ks, ls) -> (ks, ls))
 
     ///
-    /// Returns a Nec where each element `e` is mapped to `(e, i)` where `i`
+    /// Returns a Nec where each element `e` is mapped to `(i, e)` where `i`
     /// is the index of `e`.
     ///
     pub def zipWithIndex(c: Nec[a]): Nec[(Int32, a)] =

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -526,13 +526,13 @@ namespace Nel {
     /// Returns a new non-empty list where each element `e` is mapped to `(e, i)`
     /// where `i` is the index of `e`.
     ///
-    pub def zipWithIndex(l: Nel[a]): Nel[(a, Int32)] =
+    pub def zipWithIndex(l: Nel[a]): Nel[(Int32, a)] =
         def loop(ll, k, i) = match ll {
-            case (x :: xs) => loop(xs, ks -> (k((x, i) :: ks)), i + 1)
+            case (x :: xs) => loop(xs, ks -> (k((i, x) :: ks)), i + 1)
             case Nil       => k(Nil)
         };
         match l {
-            case Nel(x, xs) => Nel((x, 0), loop(xs, identity, 1))
+            case Nel(x, xs) => Nel((0, x), loop(xs, identity, 1))
         }
 
     ///

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -523,7 +523,7 @@ namespace Nel {
         (Nel(a, l1), Nel(b, l2))
 
     ///
-    /// Returns a new non-empty list where each element `e` is mapped to `(e, i)`
+    /// Returns a new non-empty list where each element `e` is mapped to `(i, e)`
     /// where `i` is the index of `e`.
     ///
     pub def zipWithIndex(l: Nel[a]): Nel[(Int32, a)] =

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -577,7 +577,7 @@ namespace Option {
     ///
     /// Returns an iterator over `o` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], o: Option[a]): Iterator[(a, Int32), r] \ Write(r) =
+    pub def enumerator(r: Region[r], o: Option[a]): Iterator[(Int32, a), r] \ Write(r) =
         iterator(r, o) |> Iterator.zipWithIndex
 
 }

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -430,7 +430,7 @@ namespace Result {
     ///
     /// Returns an iterator over `r` zipped with the indices of the elements.
     ///
-    pub def enumerator(reg: Region[reg], r: Result[e, t]): Iterator[(t, Int32), reg] \ Write(reg) =
+    pub def enumerator(reg: Region[reg], r: Result[e, t]): Iterator[(Int32, t), reg] \ Write(reg) =
         iterator(reg, r) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -98,7 +98,7 @@ namespace Set {
     pub def toString(s: Set[a]): String with ToString[a] = region r {
         let sb = new StringBuilder(r);
         StringBuilder.appendString!("Set#{", sb);
-        foreach ((x, i) <- enumerator(r, s)) {
+        foreach ((i, x) <- enumerator(r, s)) {
             if (i == 0)
                 StringBuilder.appendString!("${x}", sb)
             else
@@ -608,7 +608,7 @@ namespace Set {
     ///
     /// Returns an iterator over `s` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], s: Set[a]): Iterator[(a, Int32), r] \ Write(r) =
+    pub def enumerator(r: Region[r], s: Set[a]): Iterator[(Int32, a), r] \ Write(r) =
         iterator(r, s) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -1226,7 +1226,7 @@ namespace String {
     ///
     /// Returns an iterator over `l` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], s: String): Iterator[(Char, Int32), r] \ Write(r) =
+    pub def enumerator(r: Region[r], s: String): Iterator[(Int32, Char), r] \ Write(r) =
         iterator(r, s) |> Iterator.zipWithIndex
 
 }

--- a/main/src/library/StringBuilder.flix
+++ b/main/src/library/StringBuilder.flix
@@ -123,7 +123,7 @@ namespace StringBuilder {
     ///
     /// Returns an iterator over `l` zipped with the indices of the elements.
     ///
-    pub def enumerator(r1: Region[r1], sb: StringBuilder[r2]): Iterator[(Char, Int32), r1 and r2] \ { Read(r2), Write(r1) } =
+    pub def enumerator(r1: Region[r1], sb: StringBuilder[r2]): Iterator[(Int32, Char), r1 and r2] \ { Read(r2), Write(r1) } =
         iterator(r1, sb) |> Iterator.zipWithIndex
 
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestChain.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestChain.flix
@@ -1586,7 +1586,7 @@ namespace TestChain {
 
     @test
     def enumerator02(): Bool = region r {
-        List.toChain(1 :: 2 :: 3 :: Nil) |> Chain.enumerator(r) |> Iterator.toList == (1, 0) :: (2, 1) :: (3, 2) :: Nil
+        List.toChain(1 :: 2 :: 3 :: Nil) |> Chain.enumerator(r) |> Iterator.toList == (0, 1) :: (1, 2) :: (2, 3) :: Nil
     }
 
     @test
@@ -1867,16 +1867,16 @@ namespace TestChain {
     def zipWithIndex01(): Bool = Chain.zipWithIndex(Chain.empty(): Chain[Int32]) == Chain.empty()
 
     @test
-    def zipWithIndex02(): Bool = Chain.zipWithIndex(Chain.singleton(2)) == List.toChain((2, 0) :: Nil)
+    def zipWithIndex02(): Bool = Chain.zipWithIndex(Chain.singleton(2)) == List.toChain((0, 2) :: Nil)
 
     @test
-    def zipWithIndex03(): Bool = Chain.zipWithIndex(List.toChain(1 :: 8 :: Nil)) == List.toChain((1, 0) :: (8, 1) :: Nil)
+    def zipWithIndex03(): Bool = Chain.zipWithIndex(List.toChain(1 :: 8 :: Nil)) == List.toChain((0, 1) :: (1, 8) :: Nil)
 
     @test
-    def zipWithIndex04(): Bool = Chain.zipWithIndex(List.toChain(8 :: 1 :: Nil)) == List.toChain((8, 0) :: (1, 1) :: Nil)
+    def zipWithIndex04(): Bool = Chain.zipWithIndex(List.toChain(8 :: 1 :: Nil)) == List.toChain((0, 8) :: (1, 1) :: Nil)
 
     @test
-    def zipWithIndex05(): Bool = Chain.zipWithIndex(List.toChain(1 :: 4 :: 11 :: 2 :: -22 :: 17 :: Nil)) == List.toChain((1, 0) :: (4, 1) :: (11, 2) :: (2, 3) :: (-22, 4) :: (17, 5) :: Nil)
+    def zipWithIndex05(): Bool = Chain.zipWithIndex(List.toChain(1 :: 4 :: 11 :: 2 :: -22 :: 17 :: Nil)) == List.toChain((0, 1) :: (1, 4) :: (2, 11) :: (3, 2) :: (4, -22) :: (5, 17) :: Nil)
 
     /////////////////////////////////////////////////////////////////////////////
     // shuffle                                                                 //

--- a/main/test/ca/uwaterloo/flix/library/TestDelayList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestDelayList.flix
@@ -1495,24 +1495,24 @@ namespace TestDelayList {
 
     @test
     def zipWithIndex01(): Bool =
-        DelayList.zipWithIndex(ENil: DelayList[Unit]) == ENil: DelayList[(Unit, Int32)]
+        DelayList.zipWithIndex(ENil: DelayList[Unit]) == ENil: DelayList[(Int32, Unit)]
 
     @test
     def zipWithIndex02(): Bool =
-        DelayList.zipWithIndex(ECons(1, ENil)) == ECons((1, 0), ENil)
+        DelayList.zipWithIndex(ECons(1, ENil)) == ECons((0, 1), ENil)
 
     @test
     def zipWithIndex03(): Bool =
-        DelayList.zipWithIndex(LCons(1, lazy ENil)) == LCons((1, 0), lazy ENil)
+        DelayList.zipWithIndex(LCons(1, lazy ENil)) == LCons((0, 1), lazy ENil)
 
     @test
     def zipWithIndex04(): Bool =
-        DelayList.zipWithIndex(LList(lazy ECons(1, ENil))) == LList(lazy ECons((1, 0), ENil))
+        DelayList.zipWithIndex(LList(lazy ECons(1, ENil))) == LList(lazy ECons((0, 1), ENil))
 
     @test
     def zipWithIndex05(): Bool =
         let l = DelayList.zipWithIndex(LList(lazy LList(lazy LCons(5, lazy ECons(7, ENil)))));
-        l == LList(lazy LList(lazy LCons((5, 0), lazy ECons((7, 1), ENil))))
+        l == LList(lazy LList(lazy LCons((0, 5), lazy ECons((1, 7), ENil))))
 
     @test
     def zipWithIndex0(): Bool =
@@ -1525,7 +1525,7 @@ namespace TestDelayList {
             LCons((1, 1), lazy LList(lazy LCons((2, 2), lazy
             LList(lazy LCons((3, 3), lazy LList(lazy
             LCons((4, 4), lazy LList(lazy LCons((5, 5), lazy
-            LList(lazy LCons((10, 6), lazy LList(lazy ENil)))))))))))))))
+            LList(lazy LCons((6, 10), lazy LList(lazy ENil)))))))))))))))
 
     /////////////////////////////////////////////////////////////////////////////
     // reduceLeft                                                              //

--- a/main/test/ca/uwaterloo/flix/library/TestIterator.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterator.flix
@@ -1025,22 +1025,22 @@ namespace TestIterator {
 
     @test
     def zipWithIndex02(): Bool = region r {
-        Iterator.zipWithIndex(Iterator.singleton(r, 2)) |> Iterator.toList == (2, 0) :: Nil
+        Iterator.zipWithIndex(Iterator.singleton(r, 2)) |> Iterator.toList == (0, 2) :: Nil
     }
 
     @test
     def zipWithIndex03(): Bool = region r {
-        Iterator.zipWithIndex(List.iterator(r, 1 :: 8 :: Nil)) |> Iterator.toList == (1, 0) :: (8, 1) :: Nil
+        Iterator.zipWithIndex(List.iterator(r, 1 :: 8 :: Nil)) |> Iterator.toList == (0, 1) :: (1, 8) :: Nil
     }
 
     @test
     def zipWithIndex04(): Bool = region r {
-        Iterator.zipWithIndex(List.iterator(r, 8 :: 1 :: Nil)) |> Iterator.toList == (8, 0) :: (1, 1) :: Nil
+        Iterator.zipWithIndex(List.iterator(r, 8 :: 1 :: Nil)) |> Iterator.toList == (0, 8) :: (1, 1) :: Nil
     }
 
     @test
     def zipWithIndex05(): Bool = region r {
-        Iterator.zipWithIndex(List.iterator(r, 1 :: 4 :: 11 :: 2 :: -22 :: 17 :: Nil)) |> Iterator.toList == (1, 0) :: (4, 1) :: (11, 2) :: (2, 3) :: (-22, 4) :: (17, 5) :: Nil
+        Iterator.zipWithIndex(List.iterator(r, 1 :: 4 :: 11 :: 2 :: -22 :: 17 :: Nil)) |> Iterator.toList == (0, 1) :: (1, 4) :: (2, 11) :: (3, 2) :: (4, -22) :: (5, 17) :: Nil
     }
 
 

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -2734,14 +2734,14 @@ def distinctWith09(): Bool =
         let z = ref Nil @ r;
         let l = 1 :: 2 :: 3 :: Nil;
         foreach ((x, i) <- List.enumerator(r, l)) z := (x, i) :: deref z;
-        List.reverse(deref z) == (1, 0) :: (2, 1) :: (3, 2) :: Nil
+        List.reverse(deref z) == (0, 1) :: (1, 2) :: (2, 3) :: Nil
     }
 
     @test
     def enumerate03(): Bool = region r {
         let z = ref Nil @ r;
         let l = List.range(100, 200);
-        foreach ((x, i) <- List.enumerator(r, l)) z := (x, i) :: deref z;
+        foreach ((i, x) <- List.enumerator(r, l)) z := (x, i) :: deref z;
         List.reverse(deref z) == List.zip(l, List.range(0, 100))
     }
 

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -1609,13 +1609,13 @@ def zipWith06(): Bool = List.zipWith((a, b) -> if (b) a+1 else a, 1 :: 2 :: 3 ::
 def zipWithIndex01(): Bool = List.zipWithIndex(Nil : List[Char]) == Nil
 
 @test
-def zipWithIndex02(): Bool = List.zipWithIndex(1 :: Nil) == (1, 0) :: Nil
+def zipWithIndex02(): Bool = List.zipWithIndex(1 :: Nil) == (0, 1) :: Nil
 
 @test
-def zipWithIndex03(): Bool = List.zipWithIndex("a" :: "b" :: Nil) == ("a", 0) :: ("b", 1) :: Nil
+def zipWithIndex03(): Bool = List.zipWithIndex("a" :: "b" :: Nil) == (0, "a") :: (1, "b") :: Nil
 
 @test
-def zipWithIndex04(): Bool = List.zipWithIndex(List.zipWithIndex(true :: false :: Nil)) == ((true, 0), 0) :: ((false, 1), 1) :: Nil
+def zipWithIndex04(): Bool = List.zipWithIndex(List.zipWithIndex(true :: false :: Nil)) == (0, (0, true)) :: (1, (1, false)) :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // zipWithA                                                                //

--- a/main/test/ca/uwaterloo/flix/library/TestNec.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestNec.flix
@@ -983,23 +983,23 @@ namespace TestNec {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def zipWithIndex01(): Bool = Nec.zipWithIndex(singleton(1)) == singleton((1, 0))
+    def zipWithIndex01(): Bool = Nec.zipWithIndex(singleton(1)) == singleton((0, 1))
 
     @test
-    def zipWithIndex02(): Bool = Nec.zipWithIndex(necOf2(1, 2)) == necOf2((1, 0), (2, 1))
+    def zipWithIndex02(): Bool = Nec.zipWithIndex(necOf2(1, 2)) == necOf2((0, 1), (1, 2))
 
     @test
-    def zipWithIndex03(): Bool = Nec.zipWithIndex(necOf2(2, 1)) == necOf2((2, 0), (1, 1))
+    def zipWithIndex03(): Bool = Nec.zipWithIndex(necOf2(2, 1)) == necOf2((0, 2), (1, 1))
 
     @test
-    def zipWithIndex04(): Bool = Nec.zipWithIndex(necOf3(4, 3, 6)) == necOf3((4, 0), (3, 1), (6, 2))
+    def zipWithIndex04(): Bool = Nec.zipWithIndex(necOf3(4, 3, 6)) == necOf3((0, 4), (1, 3), (2, 6))
 
     @test
-    def zipWithIndex05(): Bool = Nec.zipWithIndex(necOf4(1, 2, 3, 4)) == necOf4((1, 0), (2, 1), (3, 2), (4, 3))
+    def zipWithIndex05(): Bool = Nec.zipWithIndex(necOf4(1, 2, 3, 4)) == necOf4((0, 1), (1, 2), (2, 3), (3, 4))
 
     @test
     def zipWithIndex06(): Bool =
-        Nec.zipWithIndex(necOf8(8, 7, 6, 5, 4, 3, 2, 1)) == necOf8((8, 0), (7, 1), (6, 2), (5, 3), (4, 4), (3, 5), (2, 6), (1, 7))
+        Nec.zipWithIndex(necOf8(8, 7, 6, 5, 4, 3, 2, 1)) == necOf8((0, 8), (1, 7), (2, 6), (3, 5), (4, 4), (5, 3), (6, 2), (7, 1))
 
     /////////////////////////////////////////////////////////////////////////////
     // zipWithA                                                                //

--- a/main/test/ca/uwaterloo/flix/library/TestNel.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestNel.flix
@@ -696,20 +696,20 @@ namespace TestNel {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def zipWithIndex01(): Bool = Nel.zipWithIndex(Nel(1, Nil)) == Nel((1, 0), Nil)
+    def zipWithIndex01(): Bool = Nel.zipWithIndex(Nel(1, Nil)) == Nel((0, 1), Nil)
 
     @test
-    def zipWithIndex02(): Bool = Nel.zipWithIndex(Nel(1, 2 :: Nil)) == Nel((1, 0), (2, 1) :: Nil)
+    def zipWithIndex02(): Bool = Nel.zipWithIndex(Nel(1, 2 :: Nil)) == Nel((0, 1), (1, 2) :: Nil)
 
     @test
-    def zipWithIndex03(): Bool = Nel.zipWithIndex(Nel(2, 1 :: Nil)) == Nel((2, 0), (1, 1) :: Nil)
+    def zipWithIndex03(): Bool = Nel.zipWithIndex(Nel(2, 1 :: Nil)) == Nel((0, 2), (1, 1) :: Nil)
 
     @test
-    def zipWithIndex04(): Bool = Nel.zipWithIndex(Nel(1, 2 :: 3 :: Nil)) == Nel((1, 0), (2, 1) :: (3, 2) :: Nil)
+    def zipWithIndex04(): Bool = Nel.zipWithIndex(Nel(1, 2 :: 3 :: Nil)) == Nel((0, 1), (1, 2) :: (2, 3) :: Nil)
 
     @test
     def zipWithIndex05(): Bool =
-        Nel.zipWithIndex(Nel(1, 2 :: 3 :: 4 :: 5 :: Nil)) == Nel((1, 0), (2, 1) :: (3, 2) :: (4, 3) :: (5, 4) :: Nil)
+        Nel.zipWithIndex(Nel(1, 2 :: 3 :: 4 :: 5 :: Nil)) == Nel((0, 1), (1, 2) :: (2, 3) :: (3, 4) :: (4, 5) :: Nil)
 
     /////////////////////////////////////////////////////////////////////////////
     // zipWithA                                                                //

--- a/main/test/ca/uwaterloo/flix/library/TestString.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestString.flix
@@ -3343,7 +3343,7 @@ def escapeInterpolation04(): String = "$"
 
     @test
     def enumerator02(): Bool = region r {
-        String.enumerator(r, "abc") |> Iterator.toList == ('a', 0) :: ('b', 1) :: ('c', 2) :: Nil
+        String.enumerator(r, "abc") |> Iterator.toList == (0, 'a') :: (1, 'b') :: (2, 'c') :: Nil
     }
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestStringBuilder.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestStringBuilder.flix
@@ -570,7 +570,7 @@ def intercalate06!(): Bool = region r {
     def enumerator02(): Bool = region r {
         let sb = new StringBuilder(r);
         StringBuilder.appendString!("abc", sb);
-        StringBuilder.enumerator(r, sb) |> Iterator.toList == ('a', 0) :: ('b', 1) :: ('c', 2) :: Nil
+        StringBuilder.enumerator(r, sb) |> Iterator.toList == (0, 'a') :: (1, 'b') :: (2, 'c') :: Nil
     }
 
 


### PR DESCRIPTION
This PR changes the argument orders of `zipWithIndex` and `enumerator` so they match `mapWithIndex` - see issue #5080

I think `zipWithIndex` with index first is a good improvement over the status quo - a list of (index, value) pairs seems consistent with how we represent other data e.g. Map (key, value) pairs rather than (value, index) pairs.

Similarly a `foreach` comprehension with an `enumerator` seems more consistent with a traditional for-loop if the loop variables are in (index, value) order.