### PR TITLE
feat: add Collectable type class (issue #5190)

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -195,6 +195,7 @@ class Flix {
     "Traversable.flix" -> LocalResource.get("/src/library/Traversable.flix"),
     "Witherable.flix" -> LocalResource.get("/src/library/Witherable.flix"),
     "UnorderedFoldable.flix" -> LocalResource.get("/src/library/UnorderedFoldable.flix"),
+    "Collectable.flix" -> LocalResource.get("/src/library/Collectable.flix"),
 
     "Validation.flix" -> LocalResource.get("/src/library/Validation.flix"),
 

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -107,6 +107,9 @@ instance ToString[Chain[a]] with ToString[a] {
     }
 }
 
+instance Collectable[Chain] {
+    pub def collect(iter: Iterator[a, r]): Chain[a] \ r with Order[a] = Iterator.toChain(iter)
+}
 
 namespace Chain {
 

--- a/main/src/library/Collectable.flix
+++ b/main/src/library/Collectable.flix
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2023 Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions not
+ *  limitations under the License.
+ */
+
+///
+/// A class representing collections that can be produced from an Iterator.
+///
+pub class Collectable[m: Type -> Type] {
+
+    ///
+    /// Run an Iterator collecting the results.
+    ///
+    pub def collect(iter: Iterator[a, r]): m[a] \ Read(r) with Order[a]
+
+}

--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -201,6 +201,15 @@ namespace Iterator {
     pub def toList(iter: Iterator[a, r]): List[a] \ Read(r) =
         foldRight((a, acc) -> a :: acc, Nil, iter)
 
+
+    ///
+    /// Returns the contents of `iter` as a chain.
+    ///
+    /// Consumes the entire iterator.
+    ///
+    pub def toChain(iter: Iterator[a, r]): Chain[a] \ Read(r) =
+        foldLeft((acc, a) -> Chain.snoc(acc, a), Chain.empty(), iter)
+
     ///
     /// Returns the contents of `iter` as a map.
     ///

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -119,6 +119,10 @@ instance Monoid[List[a]] {
     pub def empty(): List[a] = Nil
 }
 
+instance Collectable[List] {
+    pub def collect(iter: Iterator[a, r]): List[a] \ r with Order[a] = Iterator.toList(iter)
+}
+
 namespace List {
 
     ///

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -90,6 +90,10 @@ instance Monoid[Set[a]] with Order[a] {
 
 instance CommutativeMonoid[Set[a]] with Order[a]
 
+instance Collectable[Set] {
+    pub def collect(iter: Iterator[a, r]): Set[a] \ r with Order[a] = Iterator.toSet(iter)
+}
+
 namespace Set {
 
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestChain.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestChain.flix
@@ -16,6 +16,24 @@
 
 namespace TestChain {
 
+    /////////////////////////////////////////////////////////////////////////////
+    // Collectable.collect                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def collect01(): Bool = region r {
+        Collectable.collect(Iterator.new(r): Iterator[Int32, r]) == Chain.empty()
+    }
+
+    @test
+    def collect02(): Bool = region r {
+        Collectable.collect(Iterator.singleton(r, 1)) == List.toChain(1 :: Nil)
+    }
+
+    @test
+    def collect03(): Bool = region r {
+        Collectable.collect(Iterator.range(r, 1, 3)) == List.toChain(1 :: 2 :: Nil)
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // empty                                                                   //

--- a/main/test/ca/uwaterloo/flix/library/TestIterator.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterator.flix
@@ -368,6 +368,53 @@ namespace TestIterator {
         List.iterator(r, 10 :: -10 :: Nil) |> Iterator.productWith(x -> x + 1) == -99
     }
 
+    /////////////////////////////////////////////////////////////////////////////
+    // toList                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toList01(): Bool = region r {
+        Nil: List[Int32] |> List.iterator(r) |> Iterator.toList == Nil
+    }
+
+    @test
+    def toList02(): Bool = region r {
+        Iterator.range(r, -10, -5) |> Iterator.toList == -10 :: -9 :: -8 :: -7 :: -6 :: Nil
+    }
+
+    @test
+    def toList03(): Bool = region r {
+        Iterator.repeat(r, 3, 1) |> Iterator.toList == 1 :: 1 ::  1 :: Nil
+    }
+
+    @test
+    def toList04(): Bool = region r {
+        Iterator.range(r, -100, 200) |> Iterator.toList == List.range(-100, 200)
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toChain                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toChain01(): Bool = region r {
+        Nil: List[Int32] |> List.iterator(r) |> Iterator.toChain == Chain.empty()
+    }
+
+    @test
+    def toChain02(): Bool = region r {
+        Iterator.range(r, -10, -5) |> Iterator.toChain == List.toChain(-10 :: -9 :: -8 :: -7 :: -6 :: Nil)
+    }
+
+    @test
+    def toChain03(): Bool = region r {
+        Iterator.repeat(r, 3, 1) |> Iterator.toChain == List.toChain(1 :: 1 ::  1 :: Nil)
+    }
+
+    @test
+    def toChain04(): Bool = region r {
+        Iterator.range(r, -100, 200) |> Iterator.toChain == Chain.range(-100, 200)
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // toArray                                                                 //
@@ -451,7 +498,7 @@ namespace TestIterator {
 
 
     /////////////////////////////////////////////////////////////////////////////
-    // toNel.Nel                                                                   //
+    // toNel                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
     @test

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -20,6 +20,24 @@ namespace TestList {
     use Hash.hash
 
 /////////////////////////////////////////////////////////////////////////////
+// Collectable.collect                                                     //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def collect01(): Bool = region r {
+    Collectable.collect(Iterator.new(r): Iterator[Int32, r]) == Nil
+}
+
+@test
+def collect02(): Bool = region r {
+    Collectable.collect(Iterator.singleton(r, 1)) == 1 :: Nil
+}
+
+@test
+def collect03(): Bool = region r {
+    Collectable.collect(Iterator.range(r, 1, 3)) == 1 :: 2 :: Nil
+}
+
+/////////////////////////////////////////////////////////////////////////////
 // isEmpty                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test

--- a/main/test/ca/uwaterloo/flix/library/TestSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSet.flix
@@ -20,6 +20,24 @@ namespace TestSet {
     use Hash.hash
 
 /////////////////////////////////////////////////////////////////////////////
+// Collectable.collect                                                     //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def collect01(): Bool = region r {
+    Collectable.collect(Iterator.new(r): Iterator[Int32, r]) == Set.empty()
+}
+
+@test
+def collect02(): Bool = region r {
+    Collectable.collect(Iterator.singleton(r, 1)) == Set#{1}
+}
+
+@test
+def collect03(): Bool = region r {
+    Collectable.collect(Iterator.range(r, 1, 3)) == Set#{1, 2}
+}
+
+/////////////////////////////////////////////////////////////////////////////
 // size                                                                    //
 /////////////////////////////////////////////////////////////////////////////
 @test


### PR DESCRIPTION
This PR adds a `Collectable` type class with a single function `collect` and instances for `List`, `Chain` and `Set`.

`toChain` has been added to `Iterator` and tests have been added to `TestIterator`  for `toChain` and `toList` (previously missing).

`Collectable.collect` tests are in the respective collection modules.