### PR TITLE
fix: change restrictable enum index from `<>` to `[]`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -227,7 +227,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       }
 
       def RestrictionParameter: Rule1[ParsedAst.TypeParam] = rule {
-        "<" ~ optWS ~ SP ~ Names.Variable ~ push(None: Option[ParsedAst.Kind]) ~ SP ~ optWS ~ ">" ~> ParsedAst.TypeParam
+        "[" ~ optWS ~ SP ~ Names.Variable ~ push(None: Option[ParsedAst.Kind]) ~ SP ~ optWS ~ "]" ~> ParsedAst.TypeParam
       }
 
       rule {


### PR DESCRIPTION
Related to #5229

This work
```
restrictable enum List[s][t] {
    case Nil
    case Cons(t, List[s][t])
    case Cons2(t, List[s, t])
}

def head(l: List[Cons][t]): t = ???
```