### PR TITLE
feat: add toString to mutable collections (issue #5214)

### DIFF
--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -55,7 +55,7 @@ namespace Array {
             if (not deref first) StringBuilder.appendString!(", ", sb) else first := false;
             StringBuilder.appendString!("${x}", sb)
         };
-        Array.forEach(f, a);
+        forEach(f, a);
 
         StringBuilder.appendString!("}", sb);
         StringBuilder.toString(sb)

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -67,6 +67,22 @@ namespace MutDeque {
     def maxLoadFactor(): Float32 = 3.0f32 / 4.0f32
 
     ///
+    /// Returns a string representation of the given MutDeque `d`.
+    ///
+    pub def toString(d: MutDeque[a, r]): String \ Read(r) with ToString[a] = region r2 {
+        let sb = new StringBuilder(r2);
+        StringBuilder.appendString!("MutDeque#{", sb);
+        forEachWithIndex((i, x) -> {
+            if (i < 1)
+                StringBuilder.appendString!("${x}", sb)
+            else
+                StringBuilder.appendString!(", ${x}", sb)
+            }, d);
+        StringBuilder.appendString!("}", sb);
+        StringBuilder.toString(sb)
+    }
+
+    ///
     /// Returns an empty MutDeque.
     ///
     pub def new(r: Region[r]): MutDeque[a, r] \ Write(r) =
@@ -439,6 +455,15 @@ namespace MutDeque {
             }
         };
         loop(deref front)
+
+    ///
+    /// Apply the effectful function `f` to all the elements in the MutDeque `d`
+    /// along with that element's index.
+    ///
+    pub def forEachWithIndex(f: (Int32, a) -> Unit \ ef, d: MutDeque[a, r]): Unit \ { ef, Read(r) } = region rh {
+        let ix = ref 0 @ rh;
+        forEach(x -> {let i = deref ix; f(i, x); ix := i+1}, d)
+    }
 
     ///
     /// Shuffles a copy of `d` using the Fisher–Yates shuffle.

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -42,6 +42,22 @@ namespace MutList {
     pub def minCapacity(): Int32 = 8
 
     ///
+    /// Returns a string representation of the given MutList `l`.
+    ///
+    pub def toString(l: MutList[a, r]): String \ Read(r) with ToString[a] = region r2 {
+        let sb = new StringBuilder(r2);
+        StringBuilder.appendString!("MutList#{", sb);
+        forEachWithIndex((i, x) -> {
+            if (i < 1)
+                StringBuilder.appendString!("${x}", sb)
+            else
+                StringBuilder.appendString!(", ${x}", sb)
+            }, l);
+        StringBuilder.appendString!("}", sb);
+        StringBuilder.toString(sb)
+    }
+
+    ///
     /// Returns a new empty mutable list with a default capacity.
     ///
     pub def new(r: Region[r]): MutList[a, r] \ Write(r) =
@@ -820,7 +836,7 @@ namespace MutList {
         loop(0)
 
     ///
-    /// Applies `f` to all the elements in `v`.
+    /// Applies `f` to all the elements in `v` along with that element's index.
     ///
     pub def forEachWithIndex(f: (Int32, a) -> Unit \ ef, v: MutList[a, r]): Unit \ { ef, Read(r) } =
         let MutList(_, ra, rl) = v;

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -30,6 +30,22 @@ instance Newable[MutMap[k, v]] {
 namespace MutMap {
 
     ///
+    /// Returns a string representation of the given MutMap `m`.
+    ///
+    pub def toString(m: MutMap[k, v, r]): String \ Read(r) with ToString[k], ToString[v] = region r {
+        let sb = new StringBuilder(r);
+        StringBuilder.appendString!("MutMap#{", sb);
+        forEachWithIndex((i, k, v) -> {
+            if (i < 1)
+                StringBuilder.appendString!("${k} => ${v}", sb)
+            else
+                StringBuilder.appendString!(", ${k} => ${v}", sb)
+            }, m);
+        StringBuilder.appendString!("}", sb);
+        StringBuilder.toString(sb)
+    }
+
+    ///
     /// Returns a fresh empty mutable map.
     ///
     pub def new(r: Region[r]): MutMap[k, v, r] \ Write(r) =
@@ -562,11 +578,20 @@ namespace MutMap {
         Map.toSet(deref mm)
 
     ///
-    /// Applies `f` to every element in the mutable map `m`.
+    /// Applies `f` to all the `(key, value)` pairs in the mutable map `m`.
     ///
     pub def forEach(f: (k, v) -> Unit \ ef, m: MutMap[k, v, r]): Unit \ { ef, Read(r) } =
         let MutMap(mm) = m;
         Map.forEach(f, deref mm)
+
+    ///
+    /// Apply the effectful function `f` to all the `(key, value)` pairs in the mutable map `m`
+    /// along with that element's index.
+    ///
+    pub def forEachWithIndex(f: (Int32, k, v) -> Unit \ ef, m: MutMap[k, v, r]): Unit \ { ef, Read(r) } = region rh {
+        let ix = ref 0 @ rh;
+        forEach((k, v) -> {let i = deref ix; f(i, k, v); ix := i+1}, m)
+    }
 
     ///
     /// Returns an iterator over all key-value pairs in `m`.

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -30,6 +30,22 @@ instance Scoped[MutSet[t]] {
 namespace MutSet {
 
     ///
+    /// Returns a string representation of the given mutable set `s`.
+    ///
+    pub def toString(s: MutSet[a, r]): String \Read(r) with ToString[a] = region r {
+        let sb = new StringBuilder(r);
+        StringBuilder.appendString!("MutSet#{", sb);
+        forEachWithIndex((i, x) -> {
+            if (i == 0)
+                StringBuilder.appendString!("${x}", sb)
+            else
+                StringBuilder.appendString!(", ${x}", sb)
+        }, s);
+        StringBuilder.appendString!("}", sb);
+        StringBuilder.toString(sb)
+    }
+
+    ///
     /// Returns a fresh empty set.
     ///
     pub def new(r: Region[r]): MutSet[a, r] \ { Write(r) } =
@@ -384,6 +400,14 @@ namespace MutSet {
     pub def forEach(f: a -> Unit \ ef, s: MutSet[a, r]): Unit \ { ef, Read(r) } =
         let MutSet(ms) = s;
         Set.forEach(f, deref ms)
+
+    ///
+    /// Applies `f` to every element of the mutable set `s` along with that element's index.
+    ///
+    pub def forEachWithIndex(f: (Int32, a) -> Unit \ ef, s: MutSet[a, r]): Unit \ { ef, Read(r) } = region rh {
+        let ix = ref 0 @ rh;
+        forEach(x -> {let i = deref ix; f(i, x); ix := i+1}, s)
+    }
 
     ///
     /// Returns an iterator over `s`.

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -106,7 +106,7 @@ namespace Set {
     pub def toString(s: Set[a]): String with ToString[a] = region r {
         let sb = new StringBuilder(r);
         StringBuilder.appendString!("Set#{", sb);
-        Set.forEachWithIndex((i, x) -> {
+        forEachWithIndex((i, x) -> {
             if (i == 0)
                 StringBuilder.appendString!("${x}", sb)
             else

--- a/main/test/ca/uwaterloo/flix/library/TestMutDeque.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutDeque.flix
@@ -17,6 +17,34 @@
 namespace TestMutDeque {
 
     /////////////////////////////////////////////////////////////////////////////
+    // toString                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toString01(): Bool = region r {
+        let d: MutDeque[Int32, r] = new MutDeque(r);
+        MutDeque.toString(d) == "MutDeque#{}"
+    }
+
+    @test
+    def toString02(): Bool = region r {
+        let d: MutDeque[Int32, r] = new MutDeque(r);
+        MutDeque.pushBack(1, d);
+        MutDeque.toString(d) == "MutDeque#{1}"
+    }
+
+    @test
+    def toString03(): Bool = region r {
+        let d: MutDeque[Int32, r] = new MutDeque(r);
+        MutDeque.pushBack(1, d);
+        MutDeque.pushBack(2, d);
+        MutDeque.pushBack(3, d);
+        MutDeque.pushBack(4, d);
+        MutDeque.pushBack(5, d);
+        MutDeque.toString(d) == "MutDeque#{1, 2, 3, 4, 5}"
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
     // size                                                                    //
     /////////////////////////////////////////////////////////////////////////////
 
@@ -1209,6 +1237,36 @@ namespace TestMutDeque {
         List.reverse(deref l) |> List.join("") == "FT"
     }
 
+    /////////////////////////////////////////////////////////////////////////////
+    // forEachWithIndex                                                        //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def forEachWithIndex01(): Bool = region r {
+        let d = new MutDeque(r);
+        let ri = ref 21 @ r;
+        MutDeque.forEachWithIndex((i, _) -> ri := i, d);
+        21 == deref ri
+    }
+
+    @test
+    def forEachWithIndex02(): Bool = region r {
+        let d = new MutDeque(r);
+        let ri = ref 21 @ r;
+        MutDeque.pushBack(0, d);
+        MutDeque.forEachWithIndex((i, _) -> ri := i, d);
+        0 == deref ri
+    }
+
+    @test
+    def forEachWithIndex03(): Bool = region r {
+        let d = new MutDeque(r);
+        let ri = ref 21 @ r;
+        MutDeque.pushBack(0, d);
+        MutDeque.pushBack(1, d);
+        MutDeque.forEachWithIndex((i, _) -> ri := i, d);
+        1 == deref ri
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // shuffle                                                                 //

--- a/main/test/ca/uwaterloo/flix/library/TestMutList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutList.flix
@@ -26,6 +26,33 @@ namespace TestMutList {
         let MutList(_, a, _) = v;
         Array.length(deref a)
 
+    /////////////////////////////////////////////////////////////////////////////
+    // toString                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toString01(): Bool = region r {
+        let l: MutList[Int32, r] = new MutList(r);
+        MutList.toString(l) == "MutList#{}"
+    }
+
+    @test
+    def toString02(): Bool = region r {
+        let l: MutList[Int32, r] = new MutList(r);
+        MutList.push!(1, l);
+        MutList.toString(l) == "MutList#{1}"
+    }
+
+    @test
+    def toString03(): Bool = region r {
+        let l: MutList[Int32, r] = new MutList(r);
+        MutList.push!(1, l);
+        MutList.push!(2, l);
+        MutList.push!(3, l);
+        MutList.push!(4, l);
+        MutList.push!(5, l);
+        MutList.toString(l) == "MutList#{1, 2, 3, 4, 5}"
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // sameElements                                                            //

--- a/main/test/ca/uwaterloo/flix/library/TestMutMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutMap.flix
@@ -17,6 +17,34 @@ namespace TestMutMap {
     use MutMap.MutMap
 
     /////////////////////////////////////////////////////////////////////////////
+    // toString                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toString01(): Bool = region r {
+        let m: MutMap[Int32, Int32, r] = new MutMap(r);
+        MutMap.toString(m) == "MutMap#{}"
+    }
+
+    @test
+    def toString02(): Bool = region r {
+        let m = new MutList(r);
+        MutMap.put!(1, 101, m);
+        MutMap.toString(m) == "MutMap#{1 => 101}"
+    }
+
+    @test
+    def toString03(): Bool = region r {
+        let m = new MutMap(r);
+        MutMap.put!(1, 101, m);
+        MutMap.put!(2, 102, m);
+        MutMap.put!(3, 103, m);
+        MutMap.put!(4, 104, m);
+        MutMap.put!(5, 105, m);
+        MutMap.toString(m) == "MutMap#{1 => 101, 2 => 102, 3 => 103, 4 => 104, 5 => 105}"
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
     // sameElements                                                            //
     /////////////////////////////////////////////////////////////////////////////
 
@@ -480,6 +508,70 @@ namespace TestMutMap {
         MutDeque.pushFront((1, 'a'), d2);
 
         d1 `MutDeque.sameElements` d2
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // forEach                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def forEach01(): Bool = region r {
+        let m = new MutMap(r);
+        let ri = ref 21 @ r;
+        MutMap.forEach((k, v) -> ri := k+v, m);
+        21 == deref ri
+    }
+
+    @test
+    def forEach02(): Bool = region r {
+        let m = new MutMap(r);
+        let ri = ref 21 @ r;
+        MutMap.put!(0, 100, m);
+        MutMap.forEach((k, v) -> ri := k+v, m);
+        100 == deref ri
+    }
+
+    @test
+    def forEach03(): Bool = region r {
+        let m = new MutMap(r);
+        let ri = ref 21 @ r;
+        MutMap.put!(0, 100, m);
+        MutMap.put!(1, 101, m);
+        MutMap.put!(2, 102, m);
+        MutMap.forEach((k, v) -> ri := k+v, m);
+        104 == deref ri
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // forEachWithIndex                                                        //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def forEachWithIndex01(): Bool = region r {
+        let m = new MutMap(r);
+        let ri = ref 21 @ r;
+        MutMap.forEachWithIndex((i, _, _) -> ri := i, m);
+        21 == deref ri
+    }
+
+    @test
+    def forEachWithIndex02(): Bool = region r {
+        let m = new MutMap(r);
+        let ri = ref 21 @ r;
+        MutMap.put!(0, 100, m);
+        MutMap.forEachWithIndex((i, _, _) -> ri := i, m);
+        0 == deref ri
+    }
+
+    @test
+    def forEachWithIndex03(): Bool = region r {
+        let m = new MutMap(r);
+        let ri = ref 21 @ r;
+        MutMap.put!(0, 100, m);
+        MutMap.put!(1, 101, m);
+        MutMap.put!(2, 102, m);
+        MutMap.forEachWithIndex((i, _, _) -> ri := i, m);
+        2 == deref ri
     }
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestMutSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutSet.flix
@@ -17,6 +17,34 @@
 namespace TestMutSet {
 
     /////////////////////////////////////////////////////////////////////////////
+    // toString                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toString01(): Bool = region r {
+        let s: MutSet[Int32, r] = new MutSet(r);
+        MutSet.toString(s) == "MutSet#{}"
+    }
+
+    @test
+    def toString02(): Bool = region r {
+        let s = new MutSet(r);
+        MutSet.add!(1, s);
+        MutSet.toString(s) == "MutSet#{1}"
+    }
+
+    @test
+    def toString03(): Bool = region r {
+        let s = new MutSet(r);
+        MutSet.add!(1, s);
+        MutSet.add!(2, s);
+        MutSet.add!(3, s);
+        MutSet.add!(4, s);
+        MutSet.add!(5, s);
+        MutSet.toString(s) == "MutSet#{1, 2, 3, 4, 5}"
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
     // sameElements                                                            //
     /////////////////////////////////////////////////////////////////////////////
 
@@ -582,6 +610,70 @@ namespace TestMutSet {
         MutDeque.pushFront(1, d2);
 
         d1 `MutDeque.sameElements` d2
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // forEach                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def forEach01(): Bool = region r {
+        let s = new MutSet(r);
+        let ri = ref 21 @ r;
+        MutSet.forEach(x -> ri := x, s);
+        21 == deref ri
+    }
+
+    @test
+    def forEach02(): Bool = region r {
+        let s = new MutSet(r);
+        let ri = ref 21 @ r;
+        MutSet.add!(0, s);
+        MutSet.forEach(x -> ri := x, s);
+        0 == deref ri
+    }
+
+    @test
+    def forEach03(): Bool = region r {
+        let s = new MutSet(r);
+        let ri = ref 21 @ r;
+        MutSet.add!(0, s);
+        MutSet.add!(1, s);
+        MutSet.add!(2, s);
+        MutSet.forEach(x -> ri := x, s);
+        2 == deref ri
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // forEachWithIndex                                                        //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def forEachWithIndex01(): Bool = region r {
+        let s = new MutSet(r);
+        let ri = ref 21 @ r;
+        MutSet.forEachWithIndex((i, _) -> ri := i, s);
+        21 == deref ri
+    }
+
+    @test
+    def forEachWithIndex02(): Bool = region r {
+        let s = new MutSet(r);
+        let ri = ref 21 @ r;
+        MutSet.add!(100, s);
+        MutSet.forEachWithIndex((i, _) -> ri := i, s);
+        0 == deref ri
+    }
+
+    @test
+    def forEachWithIndex03(): Bool = region r {
+        let s = new MutSet(r);
+        let ri = ref 21 @ r;
+        MutSet.add!(100, s);
+        MutSet.add!(101, s);
+        MutSet.add!(102, s);
+        MutSet.forEachWithIndex((i, _) -> ri := i, s);
+        2 == deref ri
     }
 
 }


### PR DESCRIPTION
This PR adds `toString` to `MutDeque`, `MutList`, `MutMap` and `MutSet`.

It also adds `forEachWithIndex` to `MutDeque`, `MutMap` and `MutSet` (`MutList` had it already).

In `Set.flix` and `Array.flix` it removes instances of unnecessary quantification that had slipped into the `toString` functions during  `foreach` changes.

`TestMutMap` and `TestMutSet` didn't have any `forEach` tests - so some have been added as well as `toString` and `forEachWithIndex` tests.