### PR TITLE
chore: change ref initializations in tests to use explicit regions (part of issue #5215)

### DIFF
--- a/examples/imperative-style-foreach-loops.flix
+++ b/examples/imperative-style-foreach-loops.flix
@@ -54,7 +54,7 @@ def main(): Unit \ IO = region r {
     /// expression in the foreach loop must be
     /// of type unit.
     ///
-    let z = ref Nil;
+    let z = ref Nil @ r;
     foreach (x <- l)
         z := x :: deref z;
 
@@ -65,7 +65,7 @@ def main(): Unit \ IO = region r {
     /// However, foreach-loops can be much easier
     /// to read than `foreach` function calls.
     ///
-    let q = ref Nil;
+    let q = ref Nil @ r;
     List.iterator(r, l) |>
     Iterator.forEach(match x -> q := x :: deref q);
 
@@ -74,7 +74,7 @@ def main(): Unit \ IO = region r {
     /// foreach-loops.
     ///
     let k = 4 :: 5 :: 6 :: Nil;
-    let w = ref Nil;
+    let w = ref Nil @ r;
     foreach (a <- l) {
         w := a :: deref w;
         foreach (b <- k)
@@ -86,7 +86,7 @@ def main(): Unit \ IO = region r {
     /// to the functional style expression
     /// below.
     ///
-    let v = ref Nil;
+    let v = ref Nil @ r;
     List.iterator(r, l) |>
     Iterator.forEach(match a -> {
         v := a :: deref v;
@@ -104,7 +104,7 @@ def main(): Unit \ IO = region r {
     /// This may be familiar to you if you have
     /// some experience with Scala's for-loops.
     ///
-    let e = ref Nil;
+    let e = ref Nil @ r;
     foreach (a <- l;
              b <- k)
                 e := (a, b) :: deref e;
@@ -113,7 +113,7 @@ def main(): Unit \ IO = region r {
     /// The equivalent functional style expression
     /// has a bit more visual noise.
     ///
-    let e1 = ref Nil;
+    let e1 = ref Nil @ r;
     List.iterator(r, l) |>
     Iterator.forEach(match a -> {
         List.iterator(r, k) |>
@@ -134,7 +134,7 @@ def main(): Unit \ IO = region r {
     /// Again, this is similar to Scala's
     /// for-loops.
     ///
-    let c = ref Nil;
+    let c = ref Nil @ r;
     foreach (a <- l;
              if a > 1;
              b <- k;
@@ -145,7 +145,7 @@ def main(): Unit \ IO = region r {
     /// Alternatively, we can put a single guard
     /// at the end of the parenthesis.
     ///
-    let d = ref Nil;
+    let d = ref Nil @ r;
     foreach (a <- l;
              b <- k;
              if a > 1 and b < 6)
@@ -167,7 +167,7 @@ def main(): Unit \ IO = region r {
     /// the same parenthesis, match on the exact pattern
     /// and include guards.
     ///
-    let cf = ref Nil;
+    let cf = ref Nil @ r;
     List.iterator(r, l) |>
     Iterator.forEach(match a -> {
         List.iterator(r, k) |>

--- a/main/test/ca/uwaterloo/flix/library/TestDelayList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestDelayList.flix
@@ -428,22 +428,23 @@ namespace TestDelayList {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def mapFusion01(): Bool \ IO =
-        let l = ref Nil;
+    def mapFusion01(): Bool = region r {
+        let l = ref Nil @ r;
         discard (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.map(x -> { l := "a" :: deref l; x }) |>
         DelayList.map(x -> { l := "b" :: deref l; x });
         List.reverse(deref l) == ("a" :: "a" :: "a" :: "b" :: "b" :: "b" :: Nil)
+    }
 
     @test
-    def mapFusion02(): Bool \ IO =
-        let l = ref Nil;
+    def mapFusion02(): Bool \ IO = region r {
+        let l = ref Nil @ r;
         discard unsafe_cast (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.map(x -> unsafe_cast { l := "a" :: deref l; x } as _ \ {}) |>
         DelayList.map(x -> unsafe_cast { l := "b" :: deref l; x } as _ \ {}) |>
         DelayList.toList as _ \ IO;
         List.reverse(deref l) == ("a" :: "b" :: "a" :: "b" :: "a" :: "b" :: Nil)
-
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // filter (pure)                                                           //
@@ -545,65 +546,69 @@ namespace TestDelayList {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def filterFusion01(): Bool \ IO =
-        let l = ref Nil;
+    def filterFusion01(): Bool= region r {
+        let l = ref Nil @ r;
         discard (1 :: 2 :: 3 :: Nil) |> List.toDelayList     |>
         DelayList.filter(_ -> { l := "a" :: deref l; true }) |>
         DelayList.filter(_ -> { l := "b" :: deref l; true });
         List.reverse(deref l) == ("a" :: "a" :: "a" :: "b" :: "b" :: "b" :: Nil)
+    }
 
     @test
-    def filterFusion02(): Bool \ IO =
-        let l = ref Nil;
+    def filterFusion02(): Bool \ IO = region r {
+        let l = ref Nil @ r;
         discard unsafe_cast (1 :: 2 :: 3 :: Nil) |> List.toDelayList  |>
         DelayList.filter(_x -> unsafe_cast { l := "a" :: deref l; true } as _ \ {}) |>
         DelayList.filter(_x -> unsafe_cast { l := "b" :: deref l; true } as _ \ {}) |>
         DelayList.toList as _ \ IO;
         List.reverse(deref l) == ("a" :: "b" :: "a" :: "b" :: "a" :: "b" :: Nil)
-
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // map filter fusion                                                       //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def mapFilterFusion01(): Bool \ IO =
-        let l = ref Nil;
+    def mapFilterFusion01(): Bool = region r {
+        let l = ref Nil @ r;
         discard (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.map(   x -> { l := "a" :: deref l; x }) |>
         DelayList.filter(_ -> { l := "b" :: deref l; true });
         List.reverse(deref l) == ("a" :: "a" :: "a" :: "b" :: "b" :: "b" :: Nil)
+    }
 
     @test
-    def mapFilterFusion02(): Bool \ IO =
-        let l = ref Nil;
+    def mapFilterFusion02(): Bool \ IO = region r {
+        let l = ref Nil @ r;
         discard unsafe_cast (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.map(   x -> unsafe_cast { l := "a" :: deref l; x }    as _ \ {}) |>
         DelayList.filter(_ -> unsafe_cast { l := "b" :: deref l; true } as _ \ {}) |>
         DelayList.toList as _ \ IO;
         List.reverse(deref l) == ("a" :: "b" :: "a" :: "b" :: "a" :: "b" :: Nil)
-
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // filter map fusion                                                       //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def filterThenMapFusion01(): Bool \ IO =
-        let l = ref Nil;
+    def filterThenMapFusion01(): Bool = region r {
+        let l = ref Nil @ r;
         discard (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.filter(_ -> { l := "a" :: deref l; true }) |>
         DelayList.map(   x -> { l := "b" :: deref l; x    });
         List.reverse(deref l) == ("a" :: "a" :: "a" :: "b" :: "b" :: "b" :: Nil)
+    }
 
     @test
-    def filterThenMapFusion02(): Bool \ IO =
-        let l = ref Nil;
+    def filterThenMapFusion02(): Bool \ IO = region r {
+        let l = ref Nil @ r;
         discard unsafe_cast (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.filter(_ -> unsafe_cast { l := "a" :: deref l; true } as _ \ {}) |>
         DelayList.map(   x -> unsafe_cast { l := "b" :: deref l; x    } as _ \ {}) |>
         DelayList.toList as _ \ IO;
         List.reverse(deref l) == ("a" :: "b" :: "a" :: "b" :: "a" :: "b" :: Nil)
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // foldLeft                                                                //
@@ -1522,21 +1527,23 @@ namespace TestDelayList {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def zipWithFusion01(): Bool \ IO =
-        let l = ref Nil;
+    def zipWithFusion01(): Bool = region r {
+        let l = ref Nil @ r;
         discard (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.zipWith((x, y) -> { l := "a" :: deref l; (x, y) }, ECons(1, ECons(2, ECons(3, ENil)))) |>
         DelayList.zipWith((x, y) -> { l := "b" :: deref l; (x, y) }, ECons(1, ECons(2, ECons(3, ENil))));
         List.reverse(deref l) == ("a" :: "a" :: "a" :: "b" :: "b" :: "b" :: Nil)
+    }
 
     @test
-    def zipWithFusion02(): Bool \ IO =
-        let l = ref Nil;
+    def zipWithFusion02(): Bool \ IO = region r {
+        let l = ref Nil @ r;
         discard unsafe_cast (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.zipWith((x, y) -> unsafe_cast { l := "a" :: deref l; (x, y) } as _ \ {}, ECons(1, ECons(2, ECons(3, ENil)))) |>
         DelayList.zipWith((x, y) -> unsafe_cast { l := "b" :: deref l; (x, y) } as _ \ {}, ECons(1, ECons(2, ECons(3, ENil)))) |>
         DelayList.toList as _ \ IO;
         List.reverse(deref l) == ("a" :: "b" :: "a" :: "b" :: "a" :: "b" :: Nil)
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // zipWithIndex                                                            //
@@ -1826,22 +1833,23 @@ namespace TestDelayList {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def flatMapFusion01(): Bool \ IO =
-        let l = ref Nil;
+    def flatMapFusion01(): Bool = region r {
+        let l = ref Nil @ r;
         discard (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.flatMap(i -> { l := "a" :: deref l; ECons(i, ENil) }) |>
         DelayList.flatMap(i -> { l := "b" :: deref l; ECons(i, ENil) });
         List.reverse(deref l) == ("a" :: "a" :: "a" :: "b" :: "b" :: "b" :: Nil)
+    }
 
     @test
-    def flatMapFusion02(): Bool \ IO =
-        let l = ref Nil;
+    def flatMapFusion02(): Bool \ IO = region r {
+        let l = ref Nil @ r;
         discard unsafe_cast (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.flatMap(i -> unsafe_cast { l := "a" :: deref l; ECons(i, ENil) } as _ \ {}) |>
         DelayList.flatMap(i -> unsafe_cast { l := "b" :: deref l; ECons(i, ENil) } as _ \ {}) |>
         DelayList.toList as _ \ IO;
         List.reverse(deref l) == ("a" :: "b" :: "a" :: "b" :: "a" :: "b" :: Nil)
-
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // memberOf                                                                //
@@ -2083,23 +2091,24 @@ namespace TestDelayList {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def mapWithIndexFusion01(): Bool \ IO =
-        let l = ref Nil;
+    def mapWithIndexFusion01(): Bool = region r {
+        let l = ref Nil @ r;
         discard (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.mapWithIndex((_, x) -> { l := "a" :: deref l; x }) |>
         DelayList.mapWithIndex((_, x) -> { l := "b" :: deref l; x }) |>
         DelayList.toList;
         List.reverse(deref l) == ("a" :: "a" :: "a" :: "b" :: "b" :: "b" :: Nil)
+    }
 
     @test
-    def mapWithIndexFusion02(): Bool \ IO =
-        let l = ref Nil;
+    def mapWithIndexFusion02(): Bool \ IO = region r {
+        let l = ref Nil @ r;
         discard unsafe_cast (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.mapWithIndex((_, x) -> unsafe_cast { l := "a" :: deref l; x } as _ \ {}) |>
         DelayList.mapWithIndex((_, x) -> unsafe_cast { l := "b" :: deref l; x } as _ \ {}) |>
         DelayList.toList as _ \ IO;
         List.reverse(deref l) == ("a" :: "b" :: "a" :: "b" :: "a" :: "b" :: Nil)
-
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // intercalate                                                             //
@@ -2315,40 +2324,43 @@ namespace TestDelayList {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def takeWhileFusion01(): Bool \ IO =
-        let l = ref Nil;
+    def takeWhileFusion01(): Bool = region r {
+        let l = ref Nil @ r;
         discard (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.takeWhile(i -> { l := "a" :: deref l; i < 4 }) |>
         DelayList.takeWhile(i -> { l := "b" :: deref l; i < 4 });
         List.reverse(deref l) == ("a" :: "a" :: "a" :: "b" :: "b" :: "b" :: Nil)
+    }
 
     @test
-    def takeWhileFusion02(): Bool \ IO =
-        let l = ref Nil;
+    def takeWhileFusion02(): Bool \ IO = region r {
+        let l = ref Nil @ r;
         discard unsafe_cast (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.takeWhile(i -> unsafe_cast { l := "a" :: deref l; i < 4 } as _ \ {}) |>
         DelayList.takeWhile(i -> unsafe_cast { l := "b" :: deref l; i < 4 } as _ \ {}) |>
         DelayList.toList as _ \ IO;
         List.reverse(deref l) == ("a" :: "b" :: "a" :: "b" :: "a" :: "b" :: Nil)
+    }
 
     @test
-    def takeWhileFusion03(): Bool \ IO =
-        let l = ref Nil;
+    def takeWhileFusion03(): Bool \ IO = region r {
+        let l = ref Nil @ r;
         discard unsafe_cast (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.takeWhile(i -> unsafe_cast { l := "a" :: deref l; i < 3 } as _ \ {}) |>
         DelayList.takeWhile(i -> unsafe_cast { l := "b" :: deref l; i < 2 } as _ \ {}) |>
         DelayList.toList as _ \ IO;
         List.reverse(deref l) == ("a" :: "b" :: "a" :: "b" :: Nil)
+    }
 
     @test
-    def takeWhileFusion04(): Bool \ IO =
-        let l = ref Nil;
+    def takeWhileFusion04(): Bool \ IO = region r {
+        let l = ref Nil @ r;
         discard unsafe_cast (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.takeWhile(i -> unsafe_cast { l := "a" :: deref l; i < 3 } as _ \ {}) |>
         DelayList.takeWhile(i -> unsafe_cast { l := "b" :: deref l; i < 3 } as _ \ {}) |>
         DelayList.toList as _ \ IO;
         List.reverse(deref l) == ("a" :: "b" :: "a" :: "b" :: "a" :: Nil)
-
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // dropWhile (pure)                                                        //
@@ -2466,40 +2478,43 @@ namespace TestDelayList {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def dropWhileFusion01(): Bool \ IO =
-        let l = ref Nil;
+    def dropWhileFusion01(): Bool = region r {
+        let l = ref Nil @ r;
         discard (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.dropWhile(i -> { l := "a" :: deref l; i < 3 }) |>
         DelayList.dropWhile(i -> { l := "b" :: deref l; i < 4 });
         List.reverse(deref l) == ("a" :: "a" :: "a" :: "b" :: Nil)
+    }
 
     @test
-    def dropWhileFusion02(): Bool \ IO =
-        let l = ref Nil;
+    def dropWhileFusion02(): Bool \ IO = region r {
+        let l = ref Nil @ r;
         discard unsafe_cast (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.dropWhile(i -> unsafe_cast { l := "a" :: deref l; i < 3 } as _ \ {}) |>
         DelayList.dropWhile(i -> unsafe_cast { l := "b" :: deref l; i < 4 } as _ \ {}) |>
         DelayList.toList as _ \ IO;
         List.reverse(deref l) == ("a" :: "a" :: "a" :: "b" :: Nil)
+    }
 
     @test
-    def dropWhileFusion03(): Bool \ IO =
-        let l = ref Nil;
+    def dropWhileFusion03(): Bool \ IO = region r {
+        let l = ref Nil @ r;
         discard unsafe_cast (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.dropWhile(i -> unsafe_cast { l := "a" :: deref l; i < 1 } as _ \ {}) |>
         DelayList.dropWhile(i -> unsafe_cast { l := "b" :: deref l; i < 3 } as _ \ {}) |>
         DelayList.toList as _ \ IO;
         List.reverse(deref l) == ("a" :: "b" :: "b" :: "b" :: Nil)
+    }
 
     @test
-    def dropWhileFusion04(): Bool \ IO =
-        let l = ref Nil;
+    def dropWhileFusion04(): Bool \ IO = region r {
+        let l = ref Nil @ r;
         discard unsafe_cast (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.dropWhile(i -> unsafe_cast { l := "a" :: deref l; i < 2 } as _ \ {}) |>
         DelayList.dropWhile(i -> unsafe_cast { l := "b" :: deref l; i < 3 } as _ \ {}) |>
         DelayList.toList as _ \ IO;
         List.reverse(deref l) == ("a" :: "a" :: "b" :: "b" :: Nil)
-
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // findMap                                                                 //
@@ -2672,22 +2687,23 @@ namespace TestDelayList {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def filterMapFusion01(): Bool \ IO =
-        let l = ref Nil;
+    def filterMapFusion01(): Bool = region r {
+        let l = ref Nil @ r;
         discard (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.filterMap(x -> { l := "a" :: deref l; Some(x) }) |>
         DelayList.filterMap(x -> { l := "b" :: deref l; Some(x) });
         List.reverse(deref l) == ("a" :: "a" :: "a" :: "b" :: "b" :: "b" :: Nil)
+    }
 
     @test
-    def filterMapFusion02(): Bool \ IO =
-        let l = ref Nil;
+    def filterMapFusion02(): Bool \ IO = region r {
+        let l = ref Nil @ r;
         discard unsafe_cast (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.filterMap(x -> unsafe_cast { l := "a" :: deref l; Some(x) } as _ \ {}) |>
         DelayList.filterMap(x -> unsafe_cast { l := "b" :: deref l; Some(x) } as _ \ {}) |>
         DelayList.toList as _ \ IO;
         List.reverse(deref l) == ("a" :: "b" :: "a" :: "b" :: "a" :: "b" :: Nil)
-
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // partition                                                               //
@@ -2796,23 +2812,24 @@ namespace TestDelayList {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def spanSpanFusion01(): Bool \ IO =
-        let l = ref Nil;
+    def spanSpanFusion01(): Bool = region r {
+        let l = ref Nil @ r;
         discard (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
         DelayList.span(x -> { l := "a" :: deref l; x < 3 }) |> fst |>
         DelayList.span(x -> { l := "b" :: deref l; x < 3 }); // The working list is `1 :: 2 :: Nil`
         List.reverse(deref l) == ("a" :: "a" :: "a" :: "b" :: "b" :: Nil)
+    }
 
     //@test
-    //def spanSpanFusion02(): Bool \ IO =
-    //    let l = ref Nil;
+    //def spanSpanFusion02(): Bool = region r {
+    //    let l = ref Nil @ r;
     //    let _ =
     //    (1 :: 2 :: 3 :: Nil) |> List.toDelayList |>
     //    DelayList.span(x -> unsafe_cast { l := "a" :: deref l; x < 3 } as _ \ {}) |> fst |>
     //    DelayList.span(x -> unsafe_cast { l := "b" :: deref l; x < 3 } as _ \ {}) |> fst |>
     //    DelayList.toList;
     //    List.reverse(deref l) == ("a" :: "b" :: "a" :: "b" :: "a" :: Nil)
-
+    //}
 
     /////////////////////////////////////////////////////////////////////////////
     // sum                                                                     //

--- a/main/test/ca/uwaterloo/flix/library/TestDelayMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestDelayMap.flix
@@ -90,8 +90,8 @@ namespace TestDelayMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def insertWithFusion01(): Bool \ IO =
-        let l = ref Nil;
+    def insertWithFusion01(): Bool = region r {
+        let l = ref Nil @ r;
         discard List.toDelayMap((1, 1) :: Nil) |>
             DelayMap.insertWith((v, _) -> { l := "a" :: deref l; v }, 1, 1) |>
             DelayMap.insertWith((v, _) -> { l := "a" :: deref l; v }, 1, 1) |>
@@ -100,10 +100,11 @@ namespace TestDelayMap {
             DelayMap.insertWith((v, _) -> { l := "b" :: deref l; v }, 1, 1) |>
             DelayMap.insertWith((v, _) -> { l := "b" :: deref l; v }, 1, 1);
         List.reverse(deref l) == "a" :: "a" :: "a" :: "b" :: "b" :: "b" :: Nil
+    }
 
     //@test
-    //def insertWithFusion02(): Bool \ IO =
-    //    let l = ref Nil;
+    //def insertWithFusion02(): Bool = region r {
+    //    let l = ref Nil @ r;
     //    let m = List.toDelayMap((1, 1) :: Nil) |>
     //    DelayMap.insertWith((v, _) -> unsafe_cast { l := "a" :: deref l; v } as _ \ {}, 1, 1) |>
     //    DelayMap.insertWith((v, _) -> unsafe_cast { l := "a" :: deref l; v } as _ \ {}, 1, 1) |>
@@ -113,7 +114,7 @@ namespace TestDelayMap {
     //    DelayMap.insertWith((v, _) -> unsafe_cast { l := "b" :: deref l; v } as _ \ {}, 1, 1);
     //    let _ = DelayMap.toMap(m);
     //    List.reverse(deref l) == "a" :: "a" :: "a" :: "b" :: "b" :: "b" :: Nil
-
+    //}
 
     /////////////////////////////////////////////////////////////////////////////
     // count                                                                   //
@@ -264,22 +265,23 @@ namespace TestDelayMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def mapFusion01(): Bool \ IO =
-        let l = ref Nil;
+    def mapFusion01(): Bool = region r {
+        let l = ref Nil @ r;
         discard ((1, 1) :: (2, 2) :: (3, 3) :: Nil) |> List.toDelayMap |>
             DelayMap.map(v -> { l := "a" :: deref l; v }) |>
             DelayMap.map(v -> { l := "b" :: deref l; v });
         List.reverse(deref l) == "a" :: "a" :: "a" :: "b" :: "b" :: "b" :: Nil
+    }
 
     //@test
-    //def mapFusion02(): Bool \ IO =
-    //    let l = ref Nil;
+    //def mapFusion02(): Bool = region r {
+    //    let l = ref Nil @ r;
     //    let m = ((1, 1) :: (2, 2) :: (3, 3) :: Nil) |> List.toDelayMap |>
     //    DelayMap.map(v -> unsafe_cast { l := "a" :: deref l; v } as _ \ {}) |>
     //    DelayMap.map(v -> unsafe_cast { l := "b" :: deref l; v } as _ \ {});
     //    let _ = DelayMap.toMap(m);
     //    List.reverse(deref l) == "a" :: "b" :: "a" :: "b" :: "a" :: "b" :: Nil
-
+    //}
 
     /////////////////////////////////////////////////////////////////////////////
     // mapWithKey                                                              //
@@ -753,22 +755,23 @@ namespace TestDelayMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def unionWithKeyFusion01(): Bool \ IO =
-        let l = ref Nil;
+    def unionWithKeyFusion01(): Bool = region r {
+        let l = ref Nil @ r;
         discard Map#{1 => 1, 2 => 2, 3 => 3} |> Map.toDelayMap |>
             DelayMap.unionWithKey((_, _, v) -> { l := "a" :: deref l; v }, Map.toDelayMap(Map#{1 => 1, 2 => 2, 3 => 3})) |>
             DelayMap.unionWithKey((_, _, v) -> { l := "b" :: deref l; v }, Map.toDelayMap(Map#{1 => 1, 2 => 2, 3 => 3}));
         List.reverse(deref l) == ("a" :: "a" :: "a" :: "b" :: "b" :: "b" :: Nil)
+    }
 
     //@test
-    //def unionWithKeyFusion02(): Bool \ IO =
-    //    let l = ref Nil;
+    //def unionWithKeyFusion02(): Bool = region r {
+    //    let l = ref Nil @ r;
     //    let m = Map#{1 => 1, 2 => 2, 3 => 3} |> Map.toDelayMap |>
     //    DelayMap.unionWithKey((_, _, v) -> unsafe_cast { l := "a" :: deref l; v } as _ \ {}, Map.toDelayMap(Map#{1 => 1, 2 => 2, 3 => 3})) |>
     //    DelayMap.unionWithKey((_, _, v) -> unsafe_cast { l := "b" :: deref l; v } as _ \ {}, Map.toDelayMap(Map#{1 => 1, 2 => 2, 3 => 3}));
     //    let _ = DelayMap.toMap(m);
     //    List.reverse(deref l) == "a" :: "b" :: "a" :: "b" :: "a" :: "b" :: Nil
-
+    //}
 
     /////////////////////////////////////////////////////////////////////////////
     // adjust                                                                  //
@@ -1046,8 +1049,8 @@ namespace TestDelayMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def updateWithKeyFusion01(): Bool \ IO =
-        let l = ref Nil;
+    def updateWithKeyFusion01(): Bool = region r {
+        let l = ref Nil @ r;
         discard Map.toDelayMap(Map#{1 => 1, 2 => 2, 3 => 3}) |>
             DelayMap.updateWithKey((_, v) -> { l := "a" :: deref l; Some(v) }, 1) |>
             DelayMap.updateWithKey((_, v) -> { l := "a" :: deref l; Some(v) }, 2) |>
@@ -1056,10 +1059,11 @@ namespace TestDelayMap {
             DelayMap.updateWithKey((_, v) -> { l := "b" :: deref l; Some(v) }, 2) |>
             DelayMap.updateWithKey((_, v) -> { l := "b" :: deref l; Some(v) }, 3);
         List.reverse(deref l) == "a" :: "a" :: "a" :: "b" :: "b" :: "b" :: Nil
+    }
 
     //@test
-    //def updateWithKeyFusion02(): Bool \ IO =
-    //    let l = ref Nil;
+    //def updateWithKeyFusion02(): Bool = region r {
+    //    let l = ref Nil @ r;
     //    let _ = Map.toDelayMap(Map#{1 => 1, 2 => 2, 3 => 3}) |>
     //        DelayMap.updateWithKey((_, v) -> unsafe_cast { l := "a" :: deref l; Some(v) } as _ \ {}, 1) |>
     //        DelayMap.updateWithKey((_, v) -> unsafe_cast { l := "a" :: deref l; Some(v) } as _ \ {}, 2) |>
@@ -1069,7 +1073,7 @@ namespace TestDelayMap {
     //        DelayMap.updateWithKey((_, v) -> unsafe_cast { l := "b" :: deref l; Some(v) } as _ \ {}, 3) |>
     //        DelayMap.toMap;
     //    List.reverse(deref l) == "a" :: "b" :: "a" :: "b" :: "a" :: "b" :: Nil
-
+    //}
 
     /////////////////////////////////////////////////////////////////////////////
     // size                                                                    //
@@ -1397,7 +1401,7 @@ namespace TestDelayMap {
 
     @test
     def forEach01(): Bool = region r {
-        let ri = ref 21;
+        let ri = ref 21 @ r;
         Map#{} |> Map.toDelayMap |>
             DelayMap.forEach((k, _) -> ri := k);
         21 == deref ri
@@ -1405,7 +1409,7 @@ namespace TestDelayMap {
 
     @test
     def forEach02(): Bool = region r {
-        let ri = ref 21;
+        let ri = ref 21 @ r;
         Map#{1 => "Hello World!"} |> Map.toDelayMap |>
             DelayMap.forEach((k, _) -> ri := k);
         1 == deref ri

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -2297,8 +2297,8 @@ def unfold06(): Bool =
 /////////////////////////////////////////////////////////////////////////////
 
 @test
-def unfoldWithIter01(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter01(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (true)
             None
@@ -2308,10 +2308,11 @@ def unfoldWithIter01(): Bool \ IO =
             Some(c)
         };
     List.unfoldWithIter(step) == Nil
+}
 
 @test
-def unfoldWithIter02(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter02(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x > 0)
             None
@@ -2321,10 +2322,11 @@ def unfoldWithIter02(): Bool \ IO =
             Some(c)
         };
     List.unfoldWithIter(step) == '0' :: Nil
+}
 
 @test
-def unfoldWithIter03(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter03(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x > 1)
             None
@@ -2334,10 +2336,11 @@ def unfoldWithIter03(): Bool \ IO =
             Some(c)
         };
     List.unfoldWithIter(step) == '0' :: '1' :: Nil
+}
 
 @test
-def unfoldWithIter04(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter04(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x >= 10)
             None
@@ -2347,10 +2350,11 @@ def unfoldWithIter04(): Bool \ IO =
             Some(c)
         };
     List.unfoldWithIter(step) == '0' :: '1' :: '2' :: '3' :: '4' :: '5' :: '6' :: '7' :: '8' :: '9' :: Nil
+}
 
 @test
-def unfoldWithIter05(): Bool \ IO =
-    let x = ref 5;
+def unfoldWithIter05(): Bool = region r {
+    let x = ref 5 @ r;
     let step = () ->
         if (deref x >= 10)
             None
@@ -2360,10 +2364,11 @@ def unfoldWithIter05(): Bool \ IO =
             Some(c)
         };
     List.unfoldWithIter(step) == '5' :: '6' :: '7' :: '8' :: '9' :: Nil
+}
 
 @test
-def unfoldWithIter06(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter06(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x >= 10)
             None
@@ -2373,15 +2378,15 @@ def unfoldWithIter06(): Bool \ IO =
             Some(c)
         };
     List.unfoldWithIter(step) == '0' :: '2' :: '4' :: '6' :: '8' :: Nil
-
+}
 
 /////////////////////////////////////////////////////////////////////////////
 // unfoldWithOkIter                                                        //
 /////////////////////////////////////////////////////////////////////////////
 
 @test
-def unfoldWithOkIter01(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithOkIter01(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (true) {
             Ok(None)
@@ -2389,10 +2394,11 @@ def unfoldWithOkIter01(): Bool \ IO =
             Ok(Some(deref x))
         };
     List.unfoldWithOkIter(step): Result[Unit, _] == Ok(Nil)
+}
 
 @test
-def unfoldWithOkIter02(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithOkIter02(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (true) {
             Err(deref x)
@@ -2400,10 +2406,11 @@ def unfoldWithOkIter02(): Bool \ IO =
             Ok(Some(deref x))
         };
     List.unfoldWithOkIter(step) == Err(0)
+}
 
 @test
-def unfoldWithOkIter03(): Bool \ IO =
-    let x = ref 1;
+def unfoldWithOkIter03(): Bool = region r {
+    let x = ref 1 @ r;
     let step = () ->
         if (deref x rem 5 > 0) {
             let c = deref x;
@@ -2413,6 +2420,7 @@ def unfoldWithOkIter03(): Bool \ IO =
             Ok(None)
         };
     List.unfoldWithOkIter(step): Result[Unit, _] == Ok(1 :: 2 :: 3 :: 4 :: Nil)
+}
 
 /////////////////////////////////////////////////////////////////////////////
 // distinct                                                                //

--- a/main/test/ca/uwaterloo/flix/library/TestMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMap.flix
@@ -1971,8 +1971,8 @@ def unfold06(): Bool =
 /////////////////////////////////////////////////////////////////////////////
 
 @test
-def unfoldWithIter01(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter01(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (true)
             None
@@ -1983,10 +1983,11 @@ def unfoldWithIter01(): Bool \ IO =
             Some(k, v)
         };
     Map.unfoldWithIter(step) == Map#{}
+}
 
 @test
-def unfoldWithIter02(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter02(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x > 0)
             None
@@ -1997,10 +1998,11 @@ def unfoldWithIter02(): Bool \ IO =
             Some(k, v)
         };
     Map.unfoldWithIter(step) == Map#{0 => '0'}
+}
 
 @test
-def unfoldWithIter03(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter03(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x > 1)
             None
@@ -2011,10 +2013,11 @@ def unfoldWithIter03(): Bool \ IO =
             Some(k, v)
         };
     Map.unfoldWithIter(step) == Map#{0 => '0', 1 => '1'}
+}
 
 @test
-def unfoldWithIter04(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter04(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x >= 10)
             None
@@ -2025,10 +2028,11 @@ def unfoldWithIter04(): Bool \ IO =
             Some(k, v)
         };
     Map.unfoldWithIter(step) == Map#{0 => '0', 1 => '1', 2 => '2', 3 => '3', 4 => '4', 5 => '5', 6 => '6', 7 => '7', 8 => '8', 9 => '9'}
+}
 
 @test
-def unfoldWithIter05(): Bool \ IO =
-    let x = ref 5;
+def unfoldWithIter05(): Bool = region r {
+    let x = ref 5 @ r;
     let step = () ->
         if (deref x >= 10)
             None
@@ -2039,10 +2043,11 @@ def unfoldWithIter05(): Bool \ IO =
             Some(k, v)
         };
     Map.unfoldWithIter(step) == Map#{5 => '5', 6 => '6', 7 => '7', 8 => '8', 9 => '9'}
+}
 
 @test
-def unfoldWithIter06(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter06(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x >= 10)
             None
@@ -2053,6 +2058,7 @@ def unfoldWithIter06(): Bool \ IO =
             Some(k, v)
         };
     Map.unfoldWithIter(step) == Map#{0 => '0', 2 => '2', 4 => '4', 6 => '6', 8 => '8'}
+}
 
 /////////////////////////////////////////////////////////////////////////////
 // inverse                                                                 //

--- a/main/test/ca/uwaterloo/flix/library/TestMultiMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMultiMap.flix
@@ -1377,8 +1377,8 @@ namespace TestMultiMap {
     @test
     def forEach02(): Bool =
         region r {
-            let rk = ref 0;
-            let rv = ref 0;
+            let rk = ref 0 @ r;
+            let rv = ref 0 @ r;
             let m = singleton(1, 4);
             MultiMap.forEach((k, v) -> {rk := k; rv := v}, m);
             deref rk == 1 and deref rv == 4
@@ -1407,8 +1407,8 @@ namespace TestMultiMap {
     @test
     def forEach05(): Bool =
         region r {
-            let rk = ref 0;
-            let rv = ref 0;
+            let rk = ref 0 @ r;
+            let rv = ref 0 @ r;
             let m = singleton(1, 4) |> insert(2, 4) |> insert(1, 1) |> insert(3, 3);
             MultiMap.forEach((k, v) -> {rk := k; rv := v}, m);
             deref rk == 3 and deref rv == 3
@@ -1466,8 +1466,8 @@ namespace TestMultiMap {
     def forEachWithIndex05(): Bool =
         region r {
             let ri = ref 0 @ r;
-            let rk = ref 0;
-            let rv = ref 0;
+            let rk = ref 0 @ r;
+            let rv = ref 0 @ r;
             let m = singleton(1, 4) |> insert(2, 4) |> insert(1, 1) |> insert(3, 3);
             MultiMap.forEachWithIndex((i, k, v) -> {ri := i; rk := k; rv := v}, m);
             deref ri == 3 and deref rk == 3 and deref rv == 3

--- a/main/test/ca/uwaterloo/flix/library/TestMutList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutList.flix
@@ -1696,7 +1696,7 @@ namespace TestMutList {
         // Pop 76 element such that the load factor is strictly lower than 1 / 4.
         let v = MutList.range(r, 0, 100);
         let c = capacity(v);
-        let i = ref 0;
+        let i = ref 0 @ r;
         let f = _ -> {
             if (deref i < 76) {
                 discard MutList.pop!(v);

--- a/main/test/ca/uwaterloo/flix/library/TestOption.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestOption.flix
@@ -94,10 +94,11 @@ def map02(): Bool = Option.map(i -> 2*i, Some(1)) == Some(2)
 def map03(): Bool = Option.map(i -> 2*i, Some(2)) == Some(4)
 
 @test
-def map04(): Bool \ IO =
-    let n = ref 2;
+def map04(): Bool = region r {
+    let n = ref 2 @ r;
     discard Option.map(i -> n := i, Some(4));
     4 == deref n
+}
 
 /////////////////////////////////////////////////////////////////////////////
 // toList                                                                  //
@@ -535,14 +536,14 @@ def unzip02(): Bool = Option.unzip(Some((1, true))) == (Some(1), Some(true))
 
 @test
 def forEach01(): Bool = region r {
-    let ri = ref 21;
+    let ri = ref 21 @ r;
     Option.forEach(x -> ri := x, None);
     21 == deref ri
 }
 
 @test
 def forEach02(): Bool = region r {
-    let ri = ref 21;
+    let ri = ref 21 @ r;
     Option.forEach(x -> ri := x, Some(42));
     42 == deref ri
 }

--- a/main/test/ca/uwaterloo/flix/library/TestReducible.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestReducible.flix
@@ -49,8 +49,8 @@ namespace TestReducible {
         Reducible.reduceLeft((acc, a) -> (acc - a) * ((a rem 2) + 1), Nel.Nel(100, 1 :: 2 :: 3 :: Nil)) == 386
 
     @test
-    def reduceLeft08(): Bool \ IO =
-        let l = ref Nil;
+    def reduceLeft08(): Bool = region r {
+        let l = ref Nil @ r;
         // `f` uses 0 as a control value, since the first element of a `reduce` is located in `acc`.
         let f = (acc, a) -> {
             if (acc == 0)
@@ -61,7 +61,7 @@ namespace TestReducible {
         };
         discard Reducible.reduceLeft(f, Nel.Nel(3, 2 :: 1 :: Nil));
         (deref l) == 1 :: 2 :: 3 :: Nil
-
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // reduceRight                                                             //
@@ -96,8 +96,8 @@ namespace TestReducible {
         Reducible.reduceRight((a, acc) -> (acc - a) * ((a rem 2) + 1), Nel.Nel(1, 2 :: 3 :: 100 :: Nil)) == 382
 
     @test
-    def reduceRight08(): Bool \ IO =
-        let l = ref Nil;
+    def reduceRight08(): Bool = region r {
+        let l = ref Nil @ r;
         // `f` uses 0 as a control value, since the first element of a `reduce` is located in `acc`.
         let f = (a, acc) -> {
             if (acc == 0)
@@ -108,7 +108,7 @@ namespace TestReducible {
         };
         discard Reducible.reduceRight(f, Nel.Nel(1, 2 :: 3 :: Nil));
         (deref l) == 1 :: 2 :: 3 :: Nil
-
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // reduce                                                                  //
@@ -173,11 +173,11 @@ namespace TestReducible {
         Reducible.foldLeft((acc, a) -> (acc - a) * ((a rem 2) + 1), 100, Nel.Nel(1, 2 :: 3 :: Nil)) == 386
 
     @test
-    def foldLeft07(): Bool \ IO =
-        let l = ref Nil;
+    def foldLeft07(): Bool = region r {
+        let l = ref Nil @ r;
         discard Reducible.foldLeft((_, x) -> { l := x :: deref l; x == 1 }, false, Nel.Nel(3, 2 :: 1 :: Nil));
         (deref l) == 1 :: 2 :: 3 :: Nil
-
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // foldRight                                                               //
@@ -208,11 +208,11 @@ namespace TestReducible {
         Reducible.foldRight((a, acc) -> (acc - a) * ((a rem 2) + 1), 100, Nel.Nel(1, 2 :: 3 :: Nil)) == 382
 
     @test
-    def foldRight07(): Bool \ IO =
-        let l = ref Nil;
+    def foldRight07(): Bool = region r {
+        let l = ref Nil @ r;
         discard Reducible.foldRight((x, _) -> { l := x :: deref l; x == 1 }, false, Nel.Nel(1, 2 :: 3 :: Nil));
         (deref l) == 1 :: 2 :: 3 :: Nil
-
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // foldRightWithCont                                                       //
@@ -243,11 +243,11 @@ namespace TestReducible {
         Reducible.foldRightWithCont((a, k) -> (k() - a) * ((a rem 2) + 1), 100, Nel.Nel(1, 2 :: 3 :: Nil)) == 382
 
     @test
-    def foldRightWithCont07(): Bool \ IO =
-        let l = ref Nil;
+    def foldRightWithCont07(): Bool = region r {
+        let l = ref Nil @ r;
         discard Reducible.foldRightWithCont((x, _) -> { l := x :: deref l; x == 1 }, false, Nel.Nel(1, 2 :: 3 :: Nil));
         (deref l) == 1 :: 2 :: 3 :: Nil
-
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // head                                                                    //
@@ -599,11 +599,11 @@ namespace TestReducible {
         Reducible.findLeft(x -> x == 3, Nel.Nel(1, 2 :: 3 :: Nil)) == Some(3)
 
     @test
-    def findLeft07(): Bool \ IO =
-        let l = ref Nil;
+    def findLeft07(): Bool = region r {
+        let l = ref Nil @ r;
         discard Reducible.findLeft(x -> { l := x :: deref l; x == 1 }, Nel.Nel(3, 2 :: 1 :: Nil));
         (deref l) == 1 :: 2 :: 3 :: Nil
-
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // findRight                                                               //
@@ -634,11 +634,11 @@ namespace TestReducible {
         Reducible.findRight(x -> x == 3, Nel.Nel(1, 2 :: 3 :: Nil)) == Some(3)
 
     @test
-    def findRight07(): Bool \ IO =
-        let l = ref Nil;
+    def findRight07(): Bool = region r {
+        let l = ref Nil @ r;
         discard Reducible.findRight(x -> { l := x :: deref l; x == 1 }, Nel.Nel(1, 2 :: 3 :: Nil));
         (deref l) == 1 :: 2 :: 3 :: Nil
-
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     // memberOf                                                                //

--- a/main/test/ca/uwaterloo/flix/library/TestSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSet.flix
@@ -1405,8 +1405,8 @@ def unfold06(): Bool =
 /////////////////////////////////////////////////////////////////////////////
 
 @test
-def unfoldWithIter01(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter01(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (true)
             None
@@ -1416,10 +1416,11 @@ def unfoldWithIter01(): Bool \ IO =
             Some(c)
         };
     Set.unfoldWithIter(step) == Set#{}
+}
 
 @test
-def unfoldWithIter02(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter02(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x > 0)
             None
@@ -1429,10 +1430,11 @@ def unfoldWithIter02(): Bool \ IO =
             Some(c)
         };
     Set.unfoldWithIter(step) == Set#{'0'}
+}
 
 @test
-def unfoldWithIter03(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter03(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x > 1)
             None
@@ -1442,10 +1444,11 @@ def unfoldWithIter03(): Bool \ IO =
             Some(c)
         };
     Set.unfoldWithIter(step) == Set#{'0', '1'}
+}
 
 @test
-def unfoldWithIter04(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter04(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x >= 10)
             None
@@ -1455,10 +1458,11 @@ def unfoldWithIter04(): Bool \ IO =
             Some(c)
         };
     Set.unfoldWithIter(step) == Set#{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
+}
 
 @test
-def unfoldWithIter05(): Bool \ IO =
-    let x = ref 5;
+def unfoldWithIter05(): Bool = region r {
+    let x = ref 5 @ r;
     let step = () ->
         if (deref x >= 10)
             None
@@ -1468,10 +1472,11 @@ def unfoldWithIter05(): Bool \ IO =
             Some(c)
         };
     Set.unfoldWithIter(step) == Set#{'5', '6', '7', '8', '9'}
+}
 
 @test
-def unfoldWithIter06(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter06(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x >= 10)
             None
@@ -1481,6 +1486,7 @@ def unfoldWithIter06(): Bool \ IO =
             Some(c)
         };
     Set.unfoldWithIter(step) == Set#{'0', '2', '4', '6', '8'}
+}
 
     /////////////////////////////////////////////////////////////////////////////
     // toString                                                                //

--- a/main/test/ca/uwaterloo/flix/library/TestString.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestString.flix
@@ -1486,8 +1486,8 @@ def unfold08(): Bool =
 /////////////////////////////////////////////////////////////////////////////
 
 @test
-def unfoldWithIter01(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter01(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (true)
             None
@@ -1497,10 +1497,11 @@ def unfoldWithIter01(): Bool \ IO =
             Some(c)
         };
     String.unfoldWithIter(step) == ""
+}
 
 @test
-def unfoldWithIter02(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter02(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x > 0)
             None
@@ -1510,10 +1511,11 @@ def unfoldWithIter02(): Bool \ IO =
             Some(c)
         };
     String.unfoldWithIter(step) == "a"
+}
 
 @test
-def unfoldWithIter03(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter03(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x > 1)
             None
@@ -1523,10 +1525,11 @@ def unfoldWithIter03(): Bool \ IO =
             Some(c)
         };
     String.unfoldWithIter(step) == "ab"
+}
 
 @test
-def unfoldWithIter04(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter04(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x >= 10)
             None
@@ -1536,10 +1539,11 @@ def unfoldWithIter04(): Bool \ IO =
             Some(c)
         };
     String.unfoldWithIter(step) == "abcdefghij"
+}
 
 @test
-def unfoldWithIter05(): Bool \ IO =
-    let x = ref 5;
+def unfoldWithIter05(): Bool = region r {
+    let x = ref 5 @ r;
     let step = () ->
         if (deref x >= 10)
             None
@@ -1549,10 +1553,11 @@ def unfoldWithIter05(): Bool \ IO =
             Some(c)
         };
     String.unfoldWithIter(step) == "fghij"
+}
 
 @test
-def unfoldWithIter06(): Bool \ IO =
-    let x = ref 0;
+def unfoldWithIter06(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x >= 10)
             None
@@ -1562,6 +1567,7 @@ def unfoldWithIter06(): Bool \ IO =
             Some(c)
         };
     String.unfoldWithIter(step) == "acegi"
+}
 
 /////////////////////////////////////////////////////////////////////////////
 // unfoldString                                                            //
@@ -1605,8 +1611,8 @@ def unfoldString08(): Bool =
 /////////////////////////////////////////////////////////////////////////////
 
 @test
-def unfoldStringWithIter01(): Bool \ IO =
-    let x = ref 0;
+def unfoldStringWithIter01(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (true)
             None
@@ -1618,10 +1624,11 @@ def unfoldStringWithIter01(): Bool \ IO =
             Some(s)
         };
     String.unfoldStringWithIter(step) == ""
+}
 
 @test
-def unfoldStringWithIter02(): Bool \ IO =
-    let x = ref 0;
+def unfoldStringWithIter02(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x > 0)
             None
@@ -1633,10 +1640,11 @@ def unfoldStringWithIter02(): Bool \ IO =
             Some(s)
         };
     String.unfoldStringWithIter(step) == "Aa."
+}
 
 @test
-def unfoldStringWithIter03(): Bool \ IO =
-    let x = ref 0;
+def unfoldStringWithIter03(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x > 1)
             None
@@ -1648,10 +1656,11 @@ def unfoldStringWithIter03(): Bool \ IO =
             Some(s)
         };
     String.unfoldStringWithIter(step) == "Aa.Bb."
+}
 
 @test
-def unfoldStringWithIter04(): Bool \ IO =
-    let x = ref 0;
+def unfoldStringWithIter04(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x >= 10)
             None
@@ -1663,10 +1672,11 @@ def unfoldStringWithIter04(): Bool \ IO =
             Some(s)
         };
     String.unfoldStringWithIter(step) == "Aa.Bb.Cc.Dd.Ee.Ff.Gg.Hh.Ii.Jj."
+}
 
 @test
-def unfoldStringWithIter05(): Bool \ IO =
-    let x = ref 5;
+def unfoldStringWithIter05(): Bool = region r {
+    let x = ref 5 @ r;
     let step = () ->
         if (deref x >= 10)
             None
@@ -1678,10 +1688,11 @@ def unfoldStringWithIter05(): Bool \ IO =
             Some(s)
         };
     String.unfoldStringWithIter(step) == "Ff.Gg.Hh.Ii.Jj."
+}
 
 @test
-def unfoldStringWithIter06(): Bool \ IO =
-    let x = ref 0;
+def unfoldStringWithIter06(): Bool = region r {
+    let x = ref 0 @ r;
     let step = () ->
         if (deref x >= 10)
             None
@@ -1693,6 +1704,7 @@ def unfoldStringWithIter06(): Bool \ IO =
             Some(s)
         };
     String.unfoldStringWithIter(step) == "Aa.Cc.Ee.Gg.Ii."
+}
 
 /////////////////////////////////////////////////////////////////////////////
 // exists                                                                  //

--- a/main/test/flix/Test.Exp.Discard.flix
+++ b/main/test/flix/Test.Exp.Discard.flix
@@ -117,14 +117,14 @@ namespace Test/Exp/Discard {
 
 
     @test
-    def testBuilderDiscard01(): Bool \ IO =
-        let counter = ref 0;
+    def testBuilderDiscard01(): Bool = region rh {
+        let counter = ref 0 @ rh;
         def increaseBy(i, c) = {
             c := deref c + i;
             c
         };
         discard counter |> increaseBy(2) |> increaseBy(5);
         deref counter == 7
-
+    }
 
 }

--- a/main/test/flix/Test.Exp.IfThenElse.flix
+++ b/main/test/flix/Test.Exp.IfThenElse.flix
@@ -113,22 +113,25 @@ namespace Test/Exp/IfThenElse {
             (if (true) true else false)
 
     @test
-    def testIfThenElseBooleanFolding01(): Bool \ IO =
-        let y = ref 1;
+    def testIfThenElseBooleanFolding01(): Bool = region rh {
+        let y = ref 1 @ rh;
         let r =
             if ({y := 2; true} or true)
                 deref y
             else
                 3;
         r == 2
+    }
 
     @test
-    def testIfThenElseBooleanFolding02(): Bool \ IO =
-        let y = ref 1;
+    def testIfThenElseBooleanFolding02(): Bool = region rh {
+        let y = ref 1 @ rh;
         let r =
             if ({y := 2; true} and false)
                 3
             else
                 deref y;
         r == 2
+    }
+
 }

--- a/main/test/flix/Test.Exp.Let.Rec.flix
+++ b/main/test/flix/Test.Exp.Let.Rec.flix
@@ -178,9 +178,10 @@ namespace Test/Exp/LetRec {
     /// Nested definitions with type ascription
     ///
     @test
-    def testLetRecAscribed03(): Bool \ Impure =
-        def incr(x): Int \ Impure = x := deref x + 1;
-        let r = ref 1;
+    def testLetRecAscribed03(): Bool = region rh {
+        def incr(x): Int \ { Read(rh), Write(rh) } = x := deref x + 1;
+        let r = ref 1 @ rh;
         incr(r);
         deref r == 2
+    }
 }

--- a/main/test/flix/Test.Exp.Mask.flix
+++ b/main/test/flix/Test.Exp.Mask.flix
@@ -7,8 +7,8 @@ namespace Test/Exp/Mask {
     def testMask02(): Bool = $MASK$(deref (ref true))
 
     @test
-    def testMask03(): Bool \ IO = {
-        let r = ref false;
+    def testMask03(): Bool = region rh {
+        let r = ref false @ rh;
         $MASK$(r := true);
         deref r
     }

--- a/main/test/flix/Test.Exp.Regions.flix
+++ b/main/test/flix/Test.Exp.Regions.flix
@@ -794,7 +794,7 @@ namespace Test/Exp/Regions {
     @test
     def testRegions1Region1NestedReferences02(): Bool =
         region r {
-            let l = ref new MutList(r) @ r; 
+            let l = ref new MutList(r) @ r;
             MutList.push!(ref (Array.repeat(r, 8, 1)) @ r, deref l);
             match MutList.pop!(deref l) {
                 case Some(a) => (deref a) `Array.sameElements` Array.repeat(r, 8, 1)
@@ -1384,10 +1384,11 @@ namespace Test/Exp/Regions {
         }
 
     @test
-     def testRegionExit01(): Bool \ IO =
-         let x  = ref false;
-         region r {
-             spawn { Thread.sleep(Time/Duration.fromSeconds(1)); x := true } @ r
+     def testRegionExit01(): Bool \ IO = region r1 {
+         let x  = ref false @ r1;
+         region r2 {
+             spawn { Thread.sleep(Time/Duration.fromSeconds(1)); x := true } @ r2
          };
          deref x
+     }
 }

--- a/main/test/flix/Test.Java.Function.flix
+++ b/main/test/flix/Test.Java.Function.flix
@@ -41,7 +41,7 @@ namespace Test/Java/Function {
         let mkObject = i -> new Object {
             def toString(_this: Object): String = "${i}"
         };
-        let st = ref "<none>";
+        let st = ref "<none>" @ Static;
         let stream = of(mkObject(8));
         let _ = forEach(stream, obj -> let s1 = toString(obj); st := s1);
         deref st == "8"
@@ -81,7 +81,7 @@ namespace Test/Java/Function {
     def testIntConsumer(): Bool \ IO = {
         import static java.util.stream.IntStream.range(Int32, Int32): IntStream \ IO;
         import java.util.stream.IntStream.forEach(IntConsumer): Unit \ IO;
-        let st = ref 0;
+        let st = ref 0 @ Static;
         let stream = range(0, 9);
         let _ = forEach(stream, i -> st := i);
         deref st == 8
@@ -126,7 +126,7 @@ namespace Test/Java/Function {
     def testLongConsumer(): Bool \ IO = {
         import static java.util.stream.LongStream.range(Int64, Int64): LongStream \ IO;
         import java.util.stream.LongStream.forEach(LongConsumer): Unit \ IO;
-        let st = ref 0i64;
+        let st = ref 0i64 @ Static;
         let stream = range(0i64, 9i64);
         let _ = forEach(stream, i -> st := i);
         deref st == 8i64
@@ -174,8 +174,8 @@ namespace Test/Java/Function {
     def testDoubleConsumer(): Bool \ IO = {
         import static java.util.stream.DoubleStream.of(Array[Float64, Static]): DoubleStream \ IO;
         import java.util.stream.DoubleStream.forEach(DoubleConsumer): Unit \ IO;
-        let st = ref 0.0f64;
-        let stream = of([0.0f64, 1.0f64, 2.0f64, 3.0f64, 4.0f64, 5.0f64, 6.0f64, 7.0f64, 8.0f64]);
+        let st = ref 0.0f64 @ Static;
+        let stream = of([0.0f64, 1.0f64, 2.0f64, 3.0f64, 4.0f64, 5.0f64, 6.0f64, 7.0f64, 8.0f64] @ Static);
         let _ = forEach(stream, i -> st := i);
         let last = deref st;
         Float64.tryToInt32(last) == Some(8)


### PR DESCRIPTION
This PR changes tests and one example to use explicit regions for ref initializations where they had previously used an implicit region.

Ref initializations without explicit regions were identified with this grep (first a match grep then a not match grep). There might still be some instances the grep didn't find.

> find . -name "*.flix" | xargs grep -n " ref " | grep -v "@"


Fusion tests (`TestDelayList` / `TestDelayMap`) - I've added explicit region to all, if a test doesn't use a cast to IO I've removed IO from the type signature.

For the `__Consumer` tests in `Test.Java.Function.flix` I have unfortunately had to use the Static region to get them to compile - this seems a instance of this issue: "Java function interfaces seem to be hardcoded to use Static?" #5172 

