### PR TITLE
feat: Add `choose` to weeder

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -261,13 +261,13 @@ object NamedAst {
 
   object RestrictableChoicePattern {
 
-    sealed trait VarPlace
+    sealed trait VarOrWild
 
-    case class Wild(loc: SourceLocation) extends VarPlace
+    case class Wild(loc: SourceLocation) extends VarOrWild
 
-    case class Var(sym: Symbol.VarSym, loc: SourceLocation) extends VarPlace
+    case class Var(sym: Symbol.VarSym, loc: SourceLocation) extends VarOrWild
 
-    case class Tag(qname: Name.QName, pat: List[VarPlace], loc: SourceLocation) extends RestrictableChoicePattern
+    case class Tag(qname: Name.QName, pat: List[VarOrWild], loc: SourceLocation) extends RestrictableChoicePattern
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -119,6 +119,8 @@ object NamedAst {
 
     case class RelationalChoose(star: Boolean, exps: List[NamedAst.Expression], rules: List[NamedAst.RelationalChoiceRule], loc: SourceLocation) extends NamedAst.Expression
 
+    case class RestrictableChoose(star: Boolean, exp: NamedAst.Expression, rules: List[NamedAst.RestrictableChoiceRule], loc: SourceLocation) extends NamedAst.Expression
+
     case class Tuple(elms: List[NamedAst.Expression], loc: SourceLocation) extends NamedAst.Expression
 
     case class RecordEmpty(loc: SourceLocation) extends NamedAst.Expression
@@ -255,6 +257,20 @@ object NamedAst {
 
   }
 
+  sealed trait RestrictableChoicePattern
+
+  object RestrictableChoicePattern {
+
+    sealed trait VarPlace
+
+    case class Wild(loc: SourceLocation) extends VarPlace
+
+    case class Var(sym: Symbol.VarSym, loc: SourceLocation) extends VarPlace
+
+    case class Tag(qname: Name.QName, pat: List[VarPlace], loc: SourceLocation) extends RestrictableChoicePattern
+
+  }
+
   sealed trait Predicate
 
   object Predicate {
@@ -386,6 +402,8 @@ object NamedAst {
   case class HandlerRule(op: Name.Ident, fparams: List[NamedAst.FormalParam], exp: NamedAst.Expression)
 
   case class RelationalChoiceRule(pat: List[NamedAst.RelationalChoicePattern], exp: NamedAst.Expression)
+
+  case class RestrictableChoiceRule(pat: NamedAst.RestrictableChoicePattern, exp: NamedAst.Expression)
 
   case class MatchRule(pat: NamedAst.Pattern, guard: Option[NamedAst.Expression], exp: NamedAst.Expression)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -254,13 +254,13 @@ object WeededAst {
 
   object RestrictableChoicePattern {
 
-    sealed trait VarPlace
+    sealed trait VarOrWild
 
-    case class Wild(loc: SourceLocation) extends VarPlace
+    case class Wild(loc: SourceLocation) extends VarOrWild
 
-    case class Var(ident: Name.Ident, loc: SourceLocation) extends VarPlace
+    case class Var(ident: Name.Ident, loc: SourceLocation) extends VarOrWild
 
-    case class Tag(qname: Name.QName, pat: List[VarPlace], loc: SourceLocation) extends RestrictableChoicePattern
+    case class Tag(qname: Name.QName, pat: List[VarOrWild], loc: SourceLocation) extends RestrictableChoicePattern
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -110,6 +110,8 @@ object WeededAst {
 
     case class RelationalChoose(star: Boolean, exps: List[WeededAst.Expression], rules: List[WeededAst.RelationalChoiceRule], loc: SourceLocation) extends WeededAst.Expression
 
+    case class RestrictableChoose(star: Boolean, exp: WeededAst.Expression, rules: List[WeededAst.RestrictableChoiceRule], loc: SourceLocation) extends WeededAst.Expression
+
     case class Tuple(elms: List[WeededAst.Expression], loc: SourceLocation) extends WeededAst.Expression
 
     case class RecordEmpty(loc: SourceLocation) extends WeededAst.Expression
@@ -246,6 +248,22 @@ object WeededAst {
 
   }
 
+  sealed trait RestrictableChoicePattern {
+    def loc: SourceLocation
+  }
+
+  object RestrictableChoicePattern {
+
+    sealed trait VarPlace
+
+    case class Wild(loc: SourceLocation) extends VarPlace
+
+    case class Var(ident: Name.Ident, loc: SourceLocation) extends VarPlace
+
+    case class Tag(qname: Name.QName, pat: List[VarPlace], loc: SourceLocation) extends RestrictableChoicePattern
+
+  }
+
 
   sealed trait Predicate
 
@@ -376,6 +394,8 @@ object WeededAst {
   case class HandlerRule(op: Name.Ident, fparams: List[WeededAst.FormalParam], exp: WeededAst.Expression)
 
   case class RelationalChoiceRule(pat: List[WeededAst.RelationalChoicePattern], exp: WeededAst.Expression)
+
+  case class RestrictableChoiceRule(pat: WeededAst.RestrictableChoicePattern, exp: WeededAst.Expression)
 
   case class TypeConstraint(clazz: Name.QName, tpe: WeededAst.Type, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -390,6 +390,29 @@ object WeederError {
   }
 
   /**
+    * An error raised to indicate an unsupported restrictable choose rule.
+    *
+    * @param summary  a summary of the error.
+    * @param short    a short name for the arrow pointing to the location.
+    * @param loc      the location where the error occurs.
+    */
+  case class UnsupportedRestrictableChooseRule(summary: String, short: String, loc: SourceLocation) extends WeederError {
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> $summary
+         |
+         |${code(loc, short)}
+         |""".stripMargin
+    }
+
+    /**
+      * Returns a formatted string with helpful suggestions.
+      */
+    def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
     * An error raised to indicate that the variable `name` occurs multiple times in the same pattern.
     *
     * @param name the name of the variable.

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -390,19 +390,49 @@ object WeederError {
   }
 
   /**
-    * An error raised to indicate an unsupported restrictable choose rule.
+    * An error raised to indicate the presence of a guard in a restrictable choice rule.
     *
-    * @param summary  a summary of the error.
-    * @param short    a short name for the arrow pointing to the location.
-    * @param loc      the location where the error occurs.
+    * @param star whether the choose is of the star kind.
+    * @param loc  the location where the error occurs.
     */
-  case class UnsupportedRestrictableChooseRule(summary: String, short: String, loc: SourceLocation) extends WeederError {
+  case class RestrictableChoiceGuard(star: Boolean, loc: SourceLocation) extends WeederError {
+    private val operationName: String = if (star) "choose*" else "choose"
+
+    def summary: String = s"cases of $operationName do not allow guards."
+
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
          |>> $summary
          |
-         |${code(loc, short)}
+         |${code(loc, "Disallowed guard.")}
+         |""".stripMargin
+    }
+
+    /**
+      * Returns a formatted string with helpful suggestions.
+      */
+    def explain(formatter: Formatter): Option[String] = None
+  }
+
+
+  /**
+    * An error raised to indicate an unsupported restrictable choice rule pattern.
+    *
+    * @param star whether the choose is of the star kind.
+    * @param loc  the location where the error occurs.
+    */
+  case class UnsupportedRestrictedChoicePattern(star: Boolean, loc: SourceLocation) extends WeederError {
+    private val operationName: String = if (star) "choose*" else "choose"
+
+    def summary: String = s"Unsupported $operationName pattern, only enums with variables are allowed."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> $summary
+         |
+         |${code(loc, "Unsupported pattern.")}
          |""".stripMargin
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -336,7 +336,7 @@ object Namer {
   /**
     * Performs naming on the given enum `enum0`.
     */
-  private def visitRestrictableEnum(enum0: WeededAst.Declaration.RestrictableEnum, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Enum, NameError] = ???
+  private def visitRestrictableEnum(enum0: WeededAst.Declaration.RestrictableEnum, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Enum, NameError] = ??? // TODO RESTR-VARS
 
   /**
     * Performs naming on the given enum case.

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.{BoundBy, Source}
+import ca.uwaterloo.flix.language.ast.WeededAst.RestrictableChoicePattern
 import ca.uwaterloo.flix.language.ast.{NamedAst, _}
 import ca.uwaterloo.flix.language.errors.NameError
 import ca.uwaterloo.flix.util.Validation._
@@ -668,6 +669,20 @@ object Namer {
         case (es, rs) => NamedAst.Expression.RelationalChoose(star, es, rs, loc)
       }
 
+    case WeededAst.Expression.RestrictableChoose(star, exp, rules, loc) =>
+      val expVal = visitExp(exp, ns0)
+      val rulesVal = traverse(rules) {
+        case WeededAst.RestrictableChoiceRule(pat0, exp0) =>
+          val p = visitRestrictablePattern(pat0)
+          val eVal = visitExp(exp0, ns0)
+          mapN(eVal) {
+            case e => NamedAst.RestrictableChoiceRule(p, e)
+          }
+      }
+      mapN(expVal, rulesVal) {
+        case (es, rs) => NamedAst.Expression.RestrictableChoose(star, es, rs, loc)
+      }
+
     case WeededAst.Expression.Tuple(elms, loc) =>
       traverse(elms)(e => visitExp(e, ns0)) map {
         case es => NamedAst.Expression.Tuple(es, loc)
@@ -1017,6 +1032,24 @@ object Namer {
       case Some(id) =>
         val sym = Symbol.freshVarSym(id, BoundBy.Pattern)
         NamedAst.Pattern.ArrayHeadSpread(sym, elms map visitPattern, loc)
+    }
+  }
+
+  /**
+    * Names the given pattern `pat0`
+    */
+  private def visitRestrictablePattern(pat0: WeededAst.RestrictableChoicePattern)(implicit flix: Flix): NamedAst.RestrictableChoicePattern = {
+    def visitVarPlace(vp: WeededAst.RestrictableChoicePattern.VarPlace): NamedAst.RestrictableChoicePattern.VarPlace = vp match {
+      case RestrictableChoicePattern.Wild(loc) => NamedAst.RestrictableChoicePattern.Wild(loc)
+      case RestrictableChoicePattern.Var(ident, loc) =>
+        // make a fresh variable symbol for the local variable.
+        val sym = Symbol.freshVarSym(ident, BoundBy.Pattern)
+        NamedAst.RestrictableChoicePattern.Var(sym, loc)
+    }
+
+    pat0 match {
+      case WeededAst.RestrictableChoicePattern.Tag(qname, pat, loc) =>
+        NamedAst.RestrictableChoicePattern.Tag(qname, pat.map(visitVarPlace), loc)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -1039,7 +1039,7 @@ object Namer {
     * Names the given pattern `pat0`
     */
   private def visitRestrictablePattern(pat0: WeededAst.RestrictableChoicePattern)(implicit flix: Flix): NamedAst.RestrictableChoicePattern = {
-    def visitVarPlace(vp: WeededAst.RestrictableChoicePattern.VarPlace): NamedAst.RestrictableChoicePattern.VarPlace = vp match {
+    def visitVarPlace(vp: WeededAst.RestrictableChoicePattern.VarOrWild): NamedAst.RestrictableChoicePattern.VarOrWild = vp match {
       case RestrictableChoicePattern.Wild(loc) => NamedAst.RestrictableChoicePattern.Wild(loc)
       case RestrictableChoicePattern.Var(ident, loc) =>
         // make a fresh variable symbol for the local variable.

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -921,6 +921,8 @@ object Resolver {
             case (es, rs) => ResolvedAst.Expression.RelationalChoose(star, es, rs, loc)
           }
 
+        case NamedAst.Expression.RestrictableChoose(star, exp, rules, loc) => ??? // TODO RESTR-VARS
+
         case NamedAst.Expression.Tuple(elms, loc) =>
           val esVal = traverse(elms)(e => visitExp(e, env0, region))
           mapN(esVal) {


### PR DESCRIPTION
related to #5229
Fixes #5244

Only pattern like `case Tag(x...) => ...` are allowed now, and additionally, the body of `choose*` must be `Tag` or `Tag(x...)`