### PR TITLE
feat: Handle uncaught exceptions in spawned threads

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -1010,10 +1010,10 @@ object BackendObjType {
     // private final ConcurrentLinkedQueue<Thread> threads = new ConcurrentLinkedQueue<Thread>();
     def ThreadsField: InstanceField = InstanceField(this.jvmName, IsPrivate, IsFinal, "threads", BackendObjType.ConcurrentLinkedQueue.toTpe)
 
-    // private Thread parentThread = Thread.currentThread();
+    // private final Thread parentThread = Thread.currentThread();
     def ParentThreadField: InstanceField = InstanceField(this.jvmName, IsPrivate, IsFinal, "parentThread", JvmName.Thread.toTpe)
 
-    // private volatile Throwable childException = null;
+    // private final volatile Throwable childException = null;
     def ChildExceptionField: InstanceField = InstanceField(this.jvmName, IsPrivate, IsFinal, "childException", JvmName.Throwable.toTpe)
 
     def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, IsPublic, Nil, Some(

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -995,7 +995,7 @@ object BackendObjType {
       val cm = mkClass(this.jvmName, IsFinal)
 
       cm.mkField(ThreadsField)
-      cm.mkField(ParentThreadField)
+      cm.mkField(RegionThreadField)
       cm.mkField(ChildExceptionField)
 
       cm.mkConstructor(Constructor)
@@ -1011,8 +1011,8 @@ object BackendObjType {
     // private final ConcurrentLinkedQueue<Thread> threads = new ConcurrentLinkedQueue<Thread>();
     def ThreadsField: InstanceField = InstanceField(this.jvmName, IsPrivate, IsFinal, NotVolatile, "threads", BackendObjType.ConcurrentLinkedQueue.toTpe)
 
-    // private final Thread parentThread = Thread.currentThread();
-    def ParentThreadField: InstanceField = InstanceField(this.jvmName, IsPrivate, IsFinal, NotVolatile, "parentThread", JvmName.Thread.toTpe)
+    // private final Thread regionThread = Thread.currentThread();
+    def RegionThreadField: InstanceField = InstanceField(this.jvmName, IsPrivate, IsFinal, NotVolatile, "regionThread", JvmName.Thread.toTpe)
 
     // private volatile Throwable childException = null;
     def ChildExceptionField: InstanceField = InstanceField(this.jvmName, IsPrivate, NotFinal, IsVolatile, "childException", JvmName.Throwable.toTpe)
@@ -1023,7 +1023,7 @@ object BackendObjType {
       DUP() ~ invokeConstructor(BackendObjType.ConcurrentLinkedQueue.jvmName, MethodDescriptor.NothingToVoid) ~
       PUTFIELD(ThreadsField) ~
       thisLoad() ~ INVOKESTATIC(Thread.CurrentThreadMethod) ~
-      PUTFIELD(ParentThreadField) ~
+      PUTFIELD(RegionThreadField) ~
       thisLoad() ~ ACONST_NULL() ~
       PUTFIELD(ChildExceptionField) ~
       RETURN()
@@ -1070,12 +1070,12 @@ object BackendObjType {
 
     // final public void reportChildException(Throwable e) {
     //   childException = e;
-    //   parentThread.interrupt();
+    //   regionThread.interrupt();
     // }
     def ReportChildExceptionMethod: InstanceMethod = InstanceMethod(this.jvmName, IsPublic, IsFinal, "reportChildException", mkDescriptor(JvmName.Throwable.toTpe)(VoidableType.Void), Some(
       thisLoad() ~ ALOAD(1) ~ 
       PUTFIELD(ChildExceptionField) ~
-      thisLoad() ~ GETFIELD(ParentThreadField) ~ 
+      thisLoad() ~ GETFIELD(RegionThreadField) ~ 
       INVOKEVIRTUAL(Thread.InterruptMethod) ~
       RETURN()
     ))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -22,6 +22,7 @@ import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions.Branch._
 import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions._
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, IsPublic}
+import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.{IsVolatile, NotVolatile}
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker._
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor.mkDescriptor
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.{DevFlixRuntime, JavaLang, JavaUtil, JavaUtilConcurrent, MethodDescriptor, RootPackage}
@@ -118,7 +119,7 @@ object BackendObjType {
         RETURN()
     ))
 
-    def InstanceField: StaticField = StaticField(this.jvmName, IsPublic, IsFinal, "INSTANCE", this.toTpe)
+    def InstanceField: StaticField = StaticField(this.jvmName, IsPublic, IsFinal, NotVolatile, "INSTANCE", this.toTpe)
 
     private def ToStringMethod: InstanceMethod = JavaObject.ToStringMethod.implementation(this.jvmName, Some(
       pushString("()") ~ ARETURN()
@@ -145,7 +146,7 @@ object BackendObjType {
       thisLoad() ~ INVOKESPECIAL(JavaObject.Constructor) ~ RETURN()
     ))
 
-    def ValueField: InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, "value", tpe)
+    def ValueField: InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, NotVolatile, "value", tpe)
   }
 
   case class Tuple(elms: List[BackendType]) extends BackendObjType
@@ -390,7 +391,7 @@ object BackendObjType {
       thisLoad() ~ INVOKESPECIAL(continuation.Constructor) ~ RETURN()
     ))
 
-    def ArgField(index: Int): InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, s"arg$index", args(index))
+    def ArgField(index: Int): InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, NotVolatile, s"arg$index", args(index))
 
     def ToStringMethod: InstanceMethod = {
       val argString = args match {
@@ -422,7 +423,7 @@ object BackendObjType {
       thisLoad() ~ INVOKESPECIAL(JavaObject.Constructor) ~ RETURN()
     ))
 
-    def ResultField: InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, "result", result)
+    def ResultField: InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, NotVolatile, "result", result)
 
     def InvokeMethod: AbstractMethod = AbstractMethod(this.jvmName, IsPublic, "invoke", mkDescriptor()(this.toTpe))
 
@@ -476,7 +477,7 @@ object BackendObjType {
 
     def interface: Record.type = Record
 
-    def InstanceField: StaticField = StaticField(this.jvmName, IsPublic, IsFinal, "INSTANCE", this.toTpe)
+    def InstanceField: StaticField = StaticField(this.jvmName, IsPublic, IsFinal, NotVolatile, "INSTANCE", this.toTpe)
 
     def LookupFieldMethod: InstanceMethod = interface.LookupFieldMethod.implementation(this.jvmName, IsFinal, Some(
       throwUnsupportedOperationException(
@@ -520,11 +521,11 @@ object BackendObjType {
       thisLoad() ~ INVOKESPECIAL(JavaObject.Constructor) ~ RETURN()
     ))
 
-    def LabelField: InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, "label", String.toTpe)
+    def LabelField: InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, NotVolatile, "label", String.toTpe)
 
-    def ValueField: InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, "value", value)
+    def ValueField: InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, NotVolatile, "value", value)
 
-    def RestField: InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, "rest", Record.toTpe)
+    def RestField: InstanceField = InstanceField(this.jvmName, IsPublic, NotFinal, NotVolatile, "rest", Record.toTpe)
 
     def LookupFieldMethod: InstanceMethod = Record.LookupFieldMethod.implementation(this.jvmName, IsFinal, Some(
       caseOnLabelEquality {
@@ -660,19 +661,19 @@ object BackendObjType {
       ))
 
     def SourceField: InstanceField =
-      InstanceField(this.jvmName, IsPublic, IsFinal, "source", String.toTpe)
+      InstanceField(this.jvmName, IsPublic, IsFinal, NotVolatile, "source", String.toTpe)
 
     def BeginLineField: InstanceField =
-      InstanceField(this.jvmName, IsPublic, IsFinal, "beginLine", BackendType.Int32)
+      InstanceField(this.jvmName, IsPublic, IsFinal, NotVolatile, "beginLine", BackendType.Int32)
 
     def BeginColField: InstanceField =
-      InstanceField(this.jvmName, IsPublic, IsFinal, "beginCol", BackendType.Int32)
+      InstanceField(this.jvmName, IsPublic, IsFinal, NotVolatile, "beginCol", BackendType.Int32)
 
     def EndLineField: InstanceField =
-      InstanceField(this.jvmName, IsPublic, IsFinal, "endLine", BackendType.Int32)
+      InstanceField(this.jvmName, IsPublic, IsFinal, NotVolatile, "endLine", BackendType.Int32)
 
     def EndColField: InstanceField =
-      InstanceField(this.jvmName, IsPublic, IsFinal, "endCol", BackendType.Int32)
+      InstanceField(this.jvmName, IsPublic, IsFinal, NotVolatile, "endCol", BackendType.Int32)
 
     private def ToStringMethod: InstanceMethod = JavaObject.ToStringMethod.implementation(this.jvmName, Some(
       // create string builder
@@ -806,10 +807,10 @@ object BackendObjType {
       ))
 
     def CounterField: StaticField =
-      StaticField(this.jvmName, IsPrivate, IsFinal, "counter", JvmName.AtomicLong.toTpe)
+      StaticField(this.jvmName, IsPrivate, IsFinal, NotVolatile, "counter", JvmName.AtomicLong.toTpe)
 
     def ArgsField: StaticField =
-      StaticField(this.jvmName, IsPrivate, IsFinal, "args", BackendType.Array(String.toTpe))
+      StaticField(this.jvmName, IsPrivate, IsFinal, NotVolatile, "args", BackendType.Array(String.toTpe))
 
     private def arrayCopy(): InstructionSet = (f: F) => {
       f.visitMethodInstruction(Opcodes.INVOKESTATIC, JvmName.System, "arraycopy",
@@ -872,10 +873,10 @@ object BackendObjType {
       ))
 
     private def HoleField: InstanceField =
-      InstanceField(this.jvmName, IsPrivate, IsFinal, "hole", String.toTpe)
+      InstanceField(this.jvmName, IsPrivate, IsFinal, NotVolatile, "hole", String.toTpe)
 
     private def LocationField: InstanceField =
-      InstanceField(this.jvmName, IsPrivate, IsFinal, "location", ReifiedSourceLocation.toTpe)
+      InstanceField(this.jvmName, IsPrivate, IsFinal, NotVolatile, "location", ReifiedSourceLocation.toTpe)
 
     private def EqualsMethod: InstanceMethod = JavaObject.EqualsMethod.implementation(this.jvmName, Some(
       withName(1, JavaObject.toTpe) { other =>
@@ -952,7 +953,7 @@ object BackendObjType {
         RETURN()
     ))
 
-    def LocationField: InstanceField = InstanceField(this.jvmName, IsPublic, IsFinal, "location", ReifiedSourceLocation.toTpe)
+    def LocationField: InstanceField = InstanceField(this.jvmName, IsPublic, IsFinal, NotVolatile, "location", ReifiedSourceLocation.toTpe)
 
     private def EqualsMethod: InstanceMethod = JavaObject.EqualsMethod.implementation(this.jvmName, Some(
       withName(1, JavaObject.toTpe) { otherObj =>
@@ -1008,13 +1009,13 @@ object BackendObjType {
     }
 
     // private final ConcurrentLinkedQueue<Thread> threads = new ConcurrentLinkedQueue<Thread>();
-    def ThreadsField: InstanceField = InstanceField(this.jvmName, IsPrivate, IsFinal, "threads", BackendObjType.ConcurrentLinkedQueue.toTpe)
+    def ThreadsField: InstanceField = InstanceField(this.jvmName, IsPrivate, IsFinal, NotVolatile, "threads", BackendObjType.ConcurrentLinkedQueue.toTpe)
 
     // private final Thread parentThread = Thread.currentThread();
-    def ParentThreadField: InstanceField = InstanceField(this.jvmName, IsPrivate, IsFinal, "parentThread", JvmName.Thread.toTpe)
+    def ParentThreadField: InstanceField = InstanceField(this.jvmName, IsPrivate, IsFinal, NotVolatile, "parentThread", JvmName.Thread.toTpe)
 
-    // private final volatile Throwable childException = null;
-    def ChildExceptionField: InstanceField = InstanceField(this.jvmName, IsPrivate, IsFinal, "childException", JvmName.Throwable.toTpe)
+    // private volatile Throwable childException = null;
+    def ChildExceptionField: InstanceField = InstanceField(this.jvmName, IsPrivate, NotFinal, IsVolatile, "childException", JvmName.Throwable.toTpe)
 
     def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, IsPublic, Nil, Some(
       thisLoad() ~ INVOKESPECIAL(JavaObject.Constructor) ~ 
@@ -1106,7 +1107,7 @@ object BackendObjType {
     }
 
     // private final Region r;
-    def RegionField: InstanceField = InstanceField(this.jvmName, IsPrivate, IsFinal, "r", BackendObjType.Region.toTpe)
+    def RegionField: InstanceField = InstanceField(this.jvmName, IsPrivate, IsFinal, NotVolatile, "r", BackendObjType.Region.toTpe)
 
     // UncaughtExceptionHandler(Region r) { this.r = r; }
     def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, IsPublic, BackendObjType.Region.toTpe :: Nil, Some(

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -286,6 +286,21 @@ object GenExpression {
       // Adding source line number for debugging
       addSourceLine(visitor, loc)
 
+      // Introduce a label for before the try block.
+      val beforeTryBlock = new Label()
+
+      // Introduce a label for after the try block.
+      val afterTryBlock = new Label()
+
+      // Introduce a label for the finally block.
+      val finallyBlock = new Label()
+
+      // Introduce a label after the finally block.
+      val afterFinally = new Label()
+
+      // Emit try finally block.
+      visitor.visitTryCatchBlock(beforeTryBlock, afterTryBlock, finallyBlock, null)
+
       // Create an instance of Region
       visitor.visitTypeInsn(NEW, BackendObjType.Region.jvmName.toInternalName)
       visitor.visitInsn(DUP)
@@ -296,6 +311,7 @@ object GenExpression {
       visitor.visitVarInsn(iStore, sym.getStackOffset + 1)
 
       // Compile the scope body
+      visitor.visitLabel(beforeTryBlock)
       compileExpression(exp, visitor, currentClass, lenv0, entryPoint)
 
       // When we exit the scope, call the region's `exit` method
@@ -303,6 +319,25 @@ object GenExpression {
       visitor.visitVarInsn(iLoad, sym.getStackOffset + 1)
       visitor.visitMethodInsn(INVOKEVIRTUAL, BackendObjType.Region.jvmName.toInternalName, BackendObjType.Region.ExitMethod.name, 
         BackendObjType.Region.ExitMethod.d.toDescriptor, false)
+      visitor.visitLabel(afterTryBlock)
+
+      // Compile the finally block which gets called if no exception is thrown
+      visitor.visitVarInsn(iLoad, sym.getStackOffset + 1)
+      visitor.visitMethodInsn(INVOKEVIRTUAL, BackendObjType.Region.jvmName.toInternalName, BackendObjType.Region.ReThrowChildExceptionMethod.name,
+        BackendObjType.Region.ReThrowChildExceptionMethod.d.toDescriptor, false)
+      visitor.visitJumpInsn(GOTO, afterFinally)
+
+      // Compile the finally block which gets called if an exception is thrown
+      visitor.visitLabel(finallyBlock)
+      visitor.visitVarInsn(AsmOps.getStoreInstruction(JvmType.Reference(JvmName.Throwable)),
+        sym.getStackOffset + 2)
+      visitor.visitVarInsn(iLoad, sym.getStackOffset + 1)
+      visitor.visitMethodInsn(INVOKEVIRTUAL, BackendObjType.Region.jvmName.toInternalName, BackendObjType.Region.ReThrowChildExceptionMethod.name,
+        BackendObjType.Region.ReThrowChildExceptionMethod.d.toDescriptor, false)
+      visitor.visitVarInsn(AsmOps.getLoadInstruction(JvmType.Reference(JvmName.Throwable)),
+        sym.getStackOffset + 2)
+      visitor.visitInsn(ATHROW)
+      visitor.visitLabel(afterFinally)
 
     case Expression.Is(sym, exp, loc) =>
       // Adding source line number for debugging

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -329,13 +329,9 @@ object GenExpression {
 
       // Compile the finally block which gets called if an exception is thrown
       visitor.visitLabel(finallyBlock)
-      visitor.visitVarInsn(AsmOps.getStoreInstruction(JvmType.Reference(JvmName.Throwable)),
-        sym.getStackOffset + 2)
       visitor.visitVarInsn(iLoad, sym.getStackOffset + 1)
       visitor.visitMethodInsn(INVOKEVIRTUAL, BackendObjType.Region.jvmName.toInternalName, BackendObjType.Region.ReThrowChildExceptionMethod.name,
         BackendObjType.Region.ReThrowChildExceptionMethod.d.toDescriptor, false)
-      visitor.visitVarInsn(AsmOps.getLoadInstruction(JvmType.Reference(JvmName.Throwable)),
-        sym.getStackOffset + 2)
       visitor.visitInsn(ATHROW)
       visitor.visitLabel(afterFinally)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenUncaughtExceptionHandlerClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenUncaughtExceptionHandlerClass.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Paul Butcher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.phase.jvm
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.phase.jvm.BackendObjType.UncaughtExceptionHandler
+
+object GenUncaughtExceptionHandlerClass {
+  def gen()(implicit flix: Flix): Map[JvmName, JvmClass] = {
+    Map(UncaughtExceptionHandler.jvmName -> JvmClass(UncaughtExceptionHandler.jvmName, UncaughtExceptionHandler.genByteCode()))
+  }
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -190,6 +190,11 @@ object JvmBackend {
       val regionClass = GenRegionClass.gen()
 
       //
+      // Generate the UncaughtExceptionHandler class.
+      //
+      val uncaughtExceptionHandlerClass = GenUncaughtExceptionHandlerClass.gen()
+
+      //
       // Collect all the classes and interfaces together.
       //
       List(
@@ -215,7 +220,8 @@ object JvmBackend {
         holeErrorClass,
         matchErrorClass,
         globalClass,
-        regionClass
+        regionClass,
+        uncaughtExceptionHandlerClass
       ).reduce(_ ++ _)
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -108,6 +108,7 @@ object JvmName {
   val Short: JvmName = JvmName(JavaLang, "Short")
   val System: JvmName = JvmName(JavaLang, "System")
   val Thread: JvmName = JvmName(JavaLang, "Thread")
+  val Throwable: JvmName = JvmName(JavaLang, "Throwable")
   val UnsupportedOperationException: JvmName = JvmName(JavaLang, "UnsupportedOperationException")
 
   //

--- a/main/test/flix/Test.Exp.Concurrency.Spawn.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Spawn.flix
@@ -59,4 +59,34 @@ namespace Test/Exp/Concurrency/Spawn {
 //        let a = [1, 2, 3] @ r;
 //        spawn () @ Scoped.regionOf(a)
 //    }
+
+    @test
+    def testExceptionsInChildThread01(): Bool \ IO = 
+        try {
+            region r {
+                spawn {
+                    spawn { String.concat(unsafe_cast null as String, "foo") } @ r
+                } @ r;
+                Thread.sleep(Time/Duration.fromSeconds(1));
+                false
+            }
+        } catch {
+            case _: ##java.lang.NullPointerException => true
+        }
+
+
+    @test
+    def testExceptionsInChildThread02(): Bool \ IO = region r {
+        spawn {
+            spawn { 
+                try {
+                    String.concat(unsafe_cast null as String, "foo")
+                } catch {
+                    case _: ##java.lang.NullPointerException => ""
+                }
+            } @ r
+        } @ r;
+        Thread.sleep(Time/Duration.fromSeconds(1));
+        true
+    }
 }


### PR DESCRIPTION
This is the first step towards addressing #5123 (there's more to do, but I wanted to keep the PR as small as possible).

This PR:

* Adds code to generate `UncaughtExceptionHandler`
* Modifies `Region` as discussed
* Modifies the code generated for `Scope` as discussed
* Adds a couple of tests to confirm that things work as expected
* Temporarily removes support for virtual threads (I'll reinstate in the next PR)

I'll create followup PRs to:

* Reinstate support for virtual threads
* Switch from uninterruptible to interruptible locking where appropriate

I was contemplating whether we should wrap re-thrown exceptions to make it clear that they've been re-thrown in a thread other than the one in which they originated, but this doesn't seem to be what [`StructuredTaskScope`](https://download.java.net/java/early_access/loom/docs/api/jdk.incubator.concurrent/jdk/incubator/concurrent/StructuredTaskScope.html) does, and I guess we should probably use that as our guide (given that we'll probably be moving to using it at some point).