### PR TITLE
fix: Use interruptible locking in Channel code

### DIFF
--- a/main/src/library/Concurrent/Channel.flix
+++ b/main/src/library/Concurrent/Channel.flix
@@ -349,8 +349,6 @@ namespace Concurrent/Channel {
         selectLock: ReentrantLock,
         selectCondition: Condition
     ): (Int32, List[ReentrantLock]) \ IO =
-        // bug if the thread is interrupted
-        if (threadInterrupted()) bug!("thread interrupted") else
 
         // Lock all locks in sorted order. This avoids the case
         // where a channel receives an element while the later channels are
@@ -455,25 +453,13 @@ namespace Concurrent/Channel {
     // ------------- Helper Methods --------------------------------------------
 
 
-    ///
-    /// Wrapper for `java.lang.Thread:interrupted()`.
-    ///
-    def threadInterrupted(): Bool \ IO =
-        import static java.lang.Thread.interrupted(): Bool \ IO;
-        interrupted()
 
     ///
-    /// Unsafe wrapper for `Concurrent/Condition.awaitUninterruptibly(c)` that
-    /// handles `Err` with `bug!`.
+    /// Unsafe wrapper for `Concurrent/Condition.await(c)` 
     /// The channel lock is expected to be held.
     ///
     def awaitCondition(c: Condition): Unit \ IO =
-        match Concurrent/Condition.awaitUninterruptibly(c) {
-            case Ok(_) => ()
-            case Err(_) =>
-                // Error: await without holding the corresponding lock
-                bug!("Implementation error: lock not held")
-        }
+        Concurrent/Condition.await(c)
 
     ///
     /// Unsafe wrapper for `Concurrent/Condition.signalAll(c)` that handles

--- a/main/src/library/Concurrent/Condition.flix
+++ b/main/src/library/Concurrent/Condition.flix
@@ -27,29 +27,14 @@ namespace Concurrent {
         use Concurrent.Condition;
         use Concurrent.Condition.Condition;
 
-
-        ///
-        /// An enum reflecting the two exceptions occurring in condition methods, lock state errors and thread interruptions.
-        ///
-        @Internal
-        pub enum ConditionError {
-            case MonitorStateError(##java.lang.IllegalMonitorStateException)
-            case InterruptedError(##java.lang.InterruptedException)
-        }
-
         ///
         /// Causes the current thread to wait until it is signalled or interrupted.
         ///
         @Internal
-        pub def await(condition: Condition): Result[ConditionError, Unit] \ IO =
+        pub def await(condition: Condition): Unit \ IO =
             import java.util.concurrent.locks.Condition.await(): Unit \ IO;
             let Condition(c) = condition;
-            try {
-                Ok(await(c))
-            } catch {
-                case e: ##java.lang.InterruptedException => Err(ConditionError.InterruptedError(e))
-                case e: ##java.lang.IllegalMonitorStateException => Err(ConditionError.MonitorStateError(e))
-            }
+            await(c)
 
         ///
         /// Causes the current thread to wait until it is signalled or interrupted, or the specified waiting
@@ -57,28 +42,10 @@ namespace Concurrent {
         /// given the supplied nanosTimeout value upon return, or a value less than or equal to zero if it timed out.
         ///
         @Internal
-        pub def awaitTimeout(condition: Condition, timeout: Int64): Result[ConditionError, Int64] \ IO =
+        pub def awaitTimeout(condition: Condition, timeout: Int64): Int64 \ IO =
             import java.util.concurrent.locks.Condition.awaitNanos(Int64): Int64 \ IO;
             let Condition(c) = condition;
-            try {
-                Ok(awaitNanos(c, timeout))
-            } catch {
-                case e: ##java.lang.InterruptedException => Err(ConditionError.InterruptedError(e))
-                case e: ##java.lang.IllegalMonitorStateException => Err(ConditionError.MonitorStateError(e))
-            }
-
-        ///
-        /// Causes the current thread to wait until it is signalled.
-        ///
-        @Internal
-        pub def awaitUninterruptibly(condition: Condition): Result[##java.lang.IllegalMonitorStateException, Unit] \ IO =
-            import java.util.concurrent.locks.Condition.awaitUninterruptibly(): Unit \ IO;
-            let Condition(c) = condition;
-            try {
-                Ok(awaitUninterruptibly(c))
-            } catch {
-                case e: ##java.lang.IllegalMonitorStateException => Err(e)
-            }
+            awaitNanos(c, timeout)
 
         ///
         /// Wakes up one waiting thread.

--- a/main/test/ca/uwaterloo/flix/language/TestFlixErrors.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestFlixErrors.scala
@@ -79,4 +79,33 @@ class TestFlixErrors extends FunSuite with TestUtils {
     expectRuntimeError(result, "HoleError")
   }
 
+  test("SpawnedThreadError.03") {
+     val input = 
+      """
+        |def main(): Unit \ IO = region r {
+        |    spawn { 
+        |        spawn { String.concat(unsafe_cast null as String, "foo") } @ r
+        |    } @ r;
+        |    Thread.sleep(Time/Duration.fromSeconds(1))
+        |}
+      """.stripMargin
+    val result = compile(input, Options.DefaultTest)
+    expectRuntimeError(result, "NullPointerException")
+  }
+
+  test("SpawnedThreadError.04") {
+     val input = 
+      """
+        |def main(): Unit \ IO = region r {
+        |    let (_tx, rx) = Channel.unbuffered(r);
+        |    spawn { 
+        |        spawn { String.concat(unsafe_cast null as String, "foo") } @ r
+        |    } @ r;
+        |    discard Channel.recv(rx)
+        |}
+      """.stripMargin
+    val result = compile(input, Options.DefaultTest)
+    expectRuntimeError(result, "NullPointerException")
+  }
+
 }


### PR DESCRIPTION
Further towards #5123

This switches locks within the channel code to be interruptible, and adds a couple of tests which manufacture deadlock within channel code and confirm that it can be interrupted.