### PR TITLE
feat: add literal case sets

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -637,7 +637,7 @@ object SemanticTokensProvider {
     case TypeConstructor.Effect(_) => true
     case TypeConstructor.RegionToStar => true
     case TypeConstructor.All => true
-    case TypeConstructor.CaseConstant(_) => true
+    case TypeConstructor.CaseConstant(_, _) => true
 
     // invisible
     case TypeConstructor.Arrow(_) => false

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -361,7 +361,7 @@ object TypeConstructor {
   /**
     * A type constructor that represents a case constant.
     */
-  case class CaseConstant(sym: Symbol.RestrictableCaseSym) extends TypeConstructor {
+  case class CaseConstant(sym: Symbol.RestrictableCaseSym, symTail: Set[Symbol.RestrictableCaseSym]) extends TypeConstructor {
     def kind: Kind = Kind.CaseSet(sym.enumSym)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/fmt/SimpleType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/SimpleType.scala
@@ -535,7 +535,10 @@ object SimpleType {
             case _ :: _ :: _ :: _ => throw new OverAppliedType(t.loc)
           }
 
-        case TypeConstructor.CaseConstant(sym) => mkApply(SimpleType.Name(sym.name), t.typeArguments.map(visit))
+        case TypeConstructor.CaseConstant(sym, symTail) =>
+          val cst = Plus(symTail.incl(sym).toList.map(s => SimpleType.Name(s.name)))
+          mkApply(cst, t.typeArguments.map(visit))
+
         case TypeConstructor.CaseComplement(sym) =>
           t.typeArguments.map(visit) match {
             case Nil => Complement(Hole)

--- a/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
@@ -439,7 +439,7 @@ object Finalize {
 
             case TypeConstructor.All => MonoType.Unit
 
-            case TypeConstructor.CaseConstant(sym) => MonoType.Unit
+            case TypeConstructor.CaseConstant(sym, symTail) => MonoType.Unit
             case TypeConstructor.CaseEmpty(sym) => MonoType.Unit
             case TypeConstructor.CaseAll(sym) => MonoType.Unit
             case TypeConstructor.CaseComplement(sym) => MonoType.Unit

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3124,7 +3124,7 @@ object Resolver {
         case TypeConstructor.True => ResolutionError.IllegalType(tpe, loc).toFailure
         case TypeConstructor.Union => ResolutionError.IllegalType(tpe, loc).toFailure
         case TypeConstructor.CaseComplement(_) => ResolutionError.IllegalType(tpe, loc).toFailure
-        case TypeConstructor.CaseConstant(_) => ResolutionError.IllegalType(tpe, loc).toFailure
+        case TypeConstructor.CaseConstant(_, _) => ResolutionError.IllegalType(tpe, loc).toFailure
         case TypeConstructor.CaseEmpty(_) => ResolutionError.IllegalType(tpe, loc).toFailure
         case TypeConstructor.CaseAll(_) => ResolutionError.IllegalType(tpe, loc).toFailure
         case TypeConstructor.CaseIntersection(_) => ResolutionError.IllegalType(tpe, loc).toFailure

--- a/main/src/ca/uwaterloo/flix/language/phase/inference/RestrictableChooseInference.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/inference/RestrictableChooseInference.scala
@@ -116,15 +116,10 @@ object RestrictableChooseInference {
     * Converts the list of restrictable case symbols to a closed set type.
     */
   private def toType(syms: Set[Symbol.RestrictableCaseSym], enumSym: Symbol.RestrictableEnumSym, loc: SourceLocation): Type = {
-    syms.map {
-        case sym => Type.Cst(TypeConstructor.CaseConstant(sym), loc.asSynthetic)
-      }.reduceLeftOption[Type] {
-        case (acc, tpe) => Type.mkApply(
-          Type.Cst(TypeConstructor.CaseUnion(enumSym), loc.asSynthetic),
-          List(acc, tpe),
-          loc.asSynthetic
-        )
-      }.getOrElse(Type.Cst(TypeConstructor.CaseEmpty(enumSym), loc))
+    syms.headOption match {
+      case Some(value) => Type.Cst(TypeConstructor.CaseConstant(value, syms.excl(value)), loc)
+      case None => Type.Cst(TypeConstructor.CaseEmpty(enumSym), loc)
+    }
   }
 
   /**
@@ -249,7 +244,7 @@ object RestrictableChooseInference {
       // φ ∪ {l_i}
       val index = Type.mkCaseUnion(
         Type.freshVar(Kind.CaseSet(enumSym), loc.asSynthetic),
-        Type.Cst(TypeConstructor.CaseConstant(symUse.sym), loc.asSynthetic),
+        Type.Cst(TypeConstructor.CaseConstant(symUse.sym, Set.empty), loc.asSynthetic),
         enumSym,
         loc.asSynthetic
       )
@@ -280,7 +275,7 @@ object RestrictableChooseInference {
       val enumSym = symUse.sym.enumSym
       val enum = root.restrictableEnums(enumSym)
 
-      val caseType = Type.Cst(TypeConstructor.CaseConstant(symUse.sym), symUse.loc)
+      val caseType = Type.Cst(TypeConstructor.CaseConstant(symUse.sym, Set.empty), symUse.loc)
 
       val (enumType, indexVar, _, _) = instantiatedEnumType(enumSym, enum, loc.asSynthetic)
 

--- a/main/test/ca/uwaterloo/flix/language/phase/unification/TestCaseSetUnification.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/unification/TestCaseSetUnification.scala
@@ -52,9 +52,9 @@ class TestCaseSetUnification extends FunSuite with TestUtils {
 
   test("Test.CaseSetUnification.02") {
     // C1 ∪ C2 ∪ C3 ≐ ∅ᶜ
-    val caseC1 = Type.Cst(TypeConstructor.CaseConstant(C1), loc)
-    val caseC2 = Type.Cst(TypeConstructor.CaseConstant(C2), loc)
-    val caseC3 = Type.Cst(TypeConstructor.CaseConstant(C3), loc)
+    val caseC1 = Type.Cst(TypeConstructor.CaseConstant(C1, Set.empty), loc)
+    val caseC2 = Type.Cst(TypeConstructor.CaseConstant(C2, Set.empty), loc)
+    val caseC3 = Type.Cst(TypeConstructor.CaseConstant(C3, Set.empty), loc)
 
     val tpe1 = Type.mkCaseUnion(
       Type.mkCaseUnion(
@@ -106,8 +106,8 @@ class TestCaseSetUnification extends FunSuite with TestUtils {
 
   test("Test.CaseSetUnification.07") {
     // ((C1 ∪ (e ∩ C2)) ∩ C2ᶜ) ∪ ((C2 ∪ (f ∩ C1)) ∩ C1ᶜ) ≐ C1 ∪ C2
-    val caseC1 = Type.Cst(TypeConstructor.CaseConstant(C1), loc)
-    val caseC2 = Type.Cst(TypeConstructor.CaseConstant(C2), loc)
+    val caseC1 = Type.Cst(TypeConstructor.CaseConstant(C1, Set.empty), loc)
+    val caseC2 = Type.Cst(TypeConstructor.CaseConstant(C2, Set.empty), loc)
     val varE = Type.Var(mkTypeVarSym("e", E), loc)
     val varF = Type.Var(mkTypeVarSym("f", E), loc)
 
@@ -155,8 +155,8 @@ class TestCaseSetUnification extends FunSuite with TestUtils {
 
   test("Test.CaseSetUnification.08") {
     // ((C1 ∪ (e ∩ C2)) ∩ C2ᶜ) ≐ C1
-    val caseC1 = Type.Cst(TypeConstructor.CaseConstant(C1), loc)
-    val caseC2 = Type.Cst(TypeConstructor.CaseConstant(C2), loc)
+    val caseC1 = Type.Cst(TypeConstructor.CaseConstant(C1, Set.empty), loc)
+    val caseC2 = Type.Cst(TypeConstructor.CaseConstant(C2, Set.empty), loc)
     val varE = Type.Var(mkTypeVarSym("e", E), loc)
 
     val tpe1 = Type.mkCaseIntersection(
@@ -183,8 +183,8 @@ class TestCaseSetUnification extends FunSuite with TestUtils {
 
   test("Test.CaseSetUnification.09") {
     // C1 ∩ C2ᶜ ≐ C1
-    val caseC1 = Type.Cst(TypeConstructor.CaseConstant(C1), loc)
-    val caseC2 = Type.Cst(TypeConstructor.CaseConstant(C2), loc)
+    val caseC1 = Type.Cst(TypeConstructor.CaseConstant(C1, Set.empty), loc)
+    val caseC2 = Type.Cst(TypeConstructor.CaseConstant(C2, Set.empty), loc)
 
     val tpe1 = Type.mkCaseIntersection(
       caseC1,
@@ -284,9 +284,9 @@ class TestCaseSetUnification extends FunSuite with TestUtils {
 
   test("Test.CaseSetUnification.15") {
     // e - (C1 ∪ C2) ≐ C3
-    val caseC1 = Type.Cst(TypeConstructor.CaseConstant(C1), loc)
-    val caseC2 = Type.Cst(TypeConstructor.CaseConstant(C2), loc)
-    val caseC3 = Type.Cst(TypeConstructor.CaseConstant(C3), loc)
+    val caseC1 = Type.Cst(TypeConstructor.CaseConstant(C1, Set.empty), loc)
+    val caseC2 = Type.Cst(TypeConstructor.CaseConstant(C2, Set.empty), loc)
+    val caseC3 = Type.Cst(TypeConstructor.CaseConstant(C3, Set.empty), loc)
 
     val tpe1 = Type.mkCaseDifference(
       Type.Var(mkTypeVarSym("e", E), loc),
@@ -313,9 +313,9 @@ class TestCaseSetUnification extends FunSuite with TestUtils {
     val varS1 = mkTypeVarSym("s1", Expr)
     val varS2 = mkTypeVarSym("s2", Expr)
 
-    val caseAnd = Type.Cst(TypeConstructor.CaseConstant(And), loc)
-    val caseXor = Type.Cst(TypeConstructor.CaseConstant(Xor), loc)
-    val caseOr = Type.Cst(TypeConstructor.CaseConstant(Or), loc)
+    val caseAnd = Type.Cst(TypeConstructor.CaseConstant(And, Set.empty), loc)
+    val caseXor = Type.Cst(TypeConstructor.CaseConstant(Xor, Set.empty), loc)
+    val caseOr = Type.Cst(TypeConstructor.CaseConstant(Or, Set.empty), loc)
 
     val tpe1 = Type.mkCaseIntersection(
       Type.Var(varS1, loc),
@@ -349,8 +349,8 @@ class TestCaseSetUnification extends FunSuite with TestUtils {
     val varS1 = mkTypeVarSym("s1", Expr)
     val varS2 = mkTypeVarSym("s2", Expr)
 
-    val caseAnd = Type.Cst(TypeConstructor.CaseConstant(And), loc)
-    val caseXor = Type.Cst(TypeConstructor.CaseConstant(Xor), loc)
+    val caseAnd = Type.Cst(TypeConstructor.CaseConstant(And, Set.empty), loc)
+    val caseXor = Type.Cst(TypeConstructor.CaseConstant(Xor, Set.empty), loc)
 
     val tpe1 = Type.mkCaseUnion(
       Type.Var(varS1, loc),
@@ -387,8 +387,8 @@ class TestCaseSetUnification extends FunSuite with TestUtils {
 
   test("Test.CaseSetUnification.Fail.02") {
     // C1 ≐ C2
-    val tpe1 = Type.Cst(TypeConstructor.CaseConstant(C1), loc)
-    val tpe2 = Type.Cst(TypeConstructor.CaseConstant(C2), loc)
+    val tpe1 = Type.Cst(TypeConstructor.CaseConstant(C1, Set.empty), loc)
+    val tpe2 = Type.Cst(TypeConstructor.CaseConstant(C2, Set.empty), loc)
     assertDoesNotUnify(tpe1, tpe2, RigidityEnv.empty, List(C1, C2, C3), E)
   }
 


### PR DESCRIPTION
Now a case set constant can be `Constant(Cst + Var + Not)`

This doesn't in itself make the unification that much faster since it only helps when two constants "touch".

Right now, when trying to minimize by table, a constant like the one above is turned into three variables, one for each singleton, so the number of variables in regards to table lookup is unchanged. 

This PR doesn't introduce any simplifications involving knowledge of the universe, this is both from practical issues and lacking knowledge on my side about when actually materializing the complement is good (maybe always?).