### PR TITLE
chore: remove flatMap from Validation

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -20,13 +20,12 @@ import ca.uwaterloo.flix.language.ast.Ast.Input
 import ca.uwaterloo.flix.language.ast._
 import ca.uwaterloo.flix.language.fmt.FormatOptions
 import ca.uwaterloo.flix.language.phase._
-import ca.uwaterloo.flix.language.phase.extra.CodeHinter
 import ca.uwaterloo.flix.language.phase.jvm.JvmBackend
 import ca.uwaterloo.flix.language.{CompilationMessage, GenSym}
 import ca.uwaterloo.flix.runtime.CompilationResult
 import ca.uwaterloo.flix.util.Formatter.NoFormatter
 import ca.uwaterloo.flix.util._
-import ca.uwaterloo.flix.util.collection.{ListMap, MultiMap}
+import ca.uwaterloo.flix.util.collection.MultiMap
 
 import java.net.URI
 import java.nio.charset.Charset
@@ -477,6 +476,8 @@ class Flix {
     * Compiles the Flix program and returns a typed ast.
     */
   def check(): Validation[TypedAst.Root, CompilationMessage] = try {
+    import Validation.Implicit.AsMonad
+
     // Mark this object as implicit.
     implicit val flix: Flix = this
 
@@ -537,6 +538,7 @@ class Flix {
     * Compiles the given typed ast to an executable ast.
     */
   def codeGen(typedAst: TypedAst.Root): Validation[CompilationResult, CompilationMessage] = try {
+    import Validation.Implicit.AsMonad
     // Mark this object as implicit.
     implicit val flix: Flix = this
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.ast
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.fmt.{FormatOptions, FormatScheme}
 import ca.uwaterloo.flix.language.phase.unification.{ClassEnvironment, Substitution, Unification, UnificationError}
-import ca.uwaterloo.flix.util.Validation.ToSuccess
+import ca.uwaterloo.flix.util.Validation.{ToSuccess, flatMapN, mapN}
 import ca.uwaterloo.flix.util.collection.ListMap
 import ca.uwaterloo.flix.util.{InternalCompilerException, Validation}
 
@@ -129,12 +129,18 @@ object Scheme {
     val renv = renv1 ++ renv2
 
     // Attempt to unify the two instantiated types.
-    for {
-      subst <- Unification.unifyTypes(sc1.base, sc2.base, renv).toValidation
-      newTconstrs1 <- ClassEnvironment.reduce(sc1.constraints.map(subst.apply), classEnv)
-      newTconstrs2 <- ClassEnvironment.reduce(sc2.constraints.map(subst.apply), classEnv)
-      _ <- Validation.sequence(newTconstrs1.map(ClassEnvironment.entail(newTconstrs2, _, classEnv)))
-    } yield subst
+    flatMapN(Unification.unifyTypes(sc1.base, sc2.base, renv).toValidation) {
+      case subst =>
+        val newTconstrs1Val = ClassEnvironment.reduce(sc1.constraints.map(subst.apply), classEnv)
+        val newTconstrs2Val = ClassEnvironment.reduce(sc2.constraints.map(subst.apply), classEnv)
+        flatMapN(newTconstrs1Val, newTconstrs2Val) {
+          case (newTconstrs1, newTconstrs2) =>
+            mapN(Validation.sequence(newTconstrs1.map(ClassEnvironment.entail(newTconstrs2, _, classEnv)))) {
+              case _ => subst
+            }
+
+        }
+    }
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/ClassEnvironment.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/ClassEnvironment.scala
@@ -41,10 +41,9 @@ object ClassEnvironment {
       ().toSuccess
     } else {
       // Case 2: there is an instance matching tconstr and all of the instance's constraints are entailed by tconstrs0
-      for {
-        tconstrs <- byInst(tconstr, classEnv)
-        _ <- Validation.sequence(tconstrs.map(entail(tconstrs0, _, classEnv)))
-      } yield ()
+      Validation.flatMapN(byInst(tconstr, classEnv)) {
+        case tconstrs => Validation.sequenceX(tconstrs.map(entail(tconstrs0, _, classEnv)))
+      }
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -43,28 +43,6 @@ sealed trait Validation[+T, +E] {
   }
 
   /**
-    * Similar to `map` but does not wrap the result in a [[Validation.Success]].
-    *
-    * Preserves the errors.
-    */
-  // Deprecated. Use flatMapN instead.
-  final def flatMap[U, A >: E](f: T => Validation[U, A]): Validation[U, A] = this match {
-    case Validation.Success(input) => f(input) match {
-      case Validation.Success(value) => Validation.Success(value)
-      case Validation.SoftFailure(value, thatErrors) => Validation.SoftFailure(value, errors #::: thatErrors)
-      case Validation.Failure(thatErrors) => Validation.Failure(errors #::: thatErrors)
-    }
-
-    case Validation.SoftFailure(input, errors) => f(input) match {
-      case Validation.Success(value) => Validation.SoftFailure(value, errors)
-      case Validation.SoftFailure(value, thatErrors) => Validation.SoftFailure(value, errors #::: thatErrors)
-      case Validation.Failure(thatErrors) => Validation.Failure(errors #::: thatErrors)
-    }
-
-    case Validation.Failure(errors) => Validation.Failure(errors)
-  }
-
-  /**
     * Returns the errors in this [[Validation.Success]] or [[Validation.Failure]] object.
     */
   def errors: LazyList[E]
@@ -81,6 +59,40 @@ sealed trait Validation[+T, +E] {
 }
 
 object Validation {
+
+  /**
+    * Implicit class to hide dangerous extensions.
+    */
+  object Implicit {
+
+    /**
+      * Treats the Validation as a monad in order to enable `for`-notation.
+      * Care should be used when enabling this,
+      * as flatMap results in short-circuiting behavior which may not be desirable.
+      */
+    implicit class AsMonad[T, E](v: Validation[T, E]) {
+      /**
+        * Similar to `map` but does not wrap the result in a [[Validation.Success]].
+        *
+        * Preserves the errors.
+        */
+      final def flatMap[U, A >: E](f: T => Validation[U, A]): Validation[U, A] = v match {
+        case Validation.Success(input) => f(input) match {
+          case Validation.Success(value) => Validation.Success(value)
+          case Validation.SoftFailure(value, thatErrors) => Validation.SoftFailure(value, v.errors #::: thatErrors)
+          case Validation.Failure(thatErrors) => Validation.Failure(v.errors #::: thatErrors)
+        }
+
+        case Validation.SoftFailure(input, errors) => f(input) match {
+          case Validation.Success(value) => Validation.SoftFailure(value, errors)
+          case Validation.SoftFailure(value, thatErrors) => Validation.SoftFailure(value, errors #::: thatErrors)
+          case Validation.Failure(thatErrors) => Validation.Failure(errors #::: thatErrors)
+        }
+
+        case Validation.Failure(errors) => Validation.Failure(errors)
+      }
+    }
+  }
 
   /**
     * Represents a successful validation with the empty list.

--- a/main/test/ca/uwaterloo/flix/util/TestValidation.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestValidation.scala
@@ -275,20 +275,22 @@ class TestValidation extends FunSuite {
   }
 
   test("flatMap01") {
-    val result = SoftFailure("foo", LazyList.empty[Exception]).flatMap {
+    val val1 = flatMapN(SoftFailure("foo", LazyList.empty[Exception])) {
       case x => x.toUpperCase.toSuccess
-    }.flatMap {
+    }
+    val val2 = flatMapN(val1) {
       case y => y.reverse.toSuccess
-    }.flatMap {
+    }
+    val result = flatMapN(val2) {
       case z => Success(z + z)
     }
     assertResult(SoftFailure("OOFOOF", LazyList.empty))(result)
   }
 
   test("flatMap02") {
-    val result = SoftFailure("foo", LazyList.empty[Exception]).flatMap {
-      case x => x.toUpperCase.toSuccess[String, Exception].flatMap {
-        case y => y.reverse.toSuccess[String, Exception].flatMap {
+    val result = flatMapN(SoftFailure("foo", LazyList.empty[Exception])) {
+      case x => flatMapN(x.toUpperCase.toSuccess[String, Exception]) {
+        case y => flatMapN(y.reverse.toSuccess[String, Exception]) {
           case z => Success[String, Exception](z + z)
         }
       }
@@ -298,9 +300,9 @@ class TestValidation extends FunSuite {
 
   test("flatMap03") {
     val ex = new RuntimeException()
-    val result = SoftFailure("foo", LazyList.empty[Exception]).flatMap {
-      case x => x.toUpperCase.toSuccess[String, Exception].flatMap {
-        case y => y.reverse.toSuccess[String, Exception].flatMap {
+    val result = flatMapN(SoftFailure("foo", LazyList.empty[Exception])) {
+      case x => flatMapN(x.toUpperCase.toSuccess[String, Exception]) {
+        case y => flatMapN(y.reverse.toSuccess[String, Exception]) {
           case z => SoftFailure[String, Exception](z + z, LazyList(ex))
         }
       }
@@ -310,9 +312,9 @@ class TestValidation extends FunSuite {
 
   test("flatMap04") {
     val ex = new RuntimeException()
-    val result = SoftFailure("foo", LazyList.empty[Exception]).flatMap {
-      case x => x.toUpperCase.toSuccess[String, Exception].flatMap {
-        case y => y.reverse.toSuccess[String, Exception].flatMap {
+    val result = flatMapN(SoftFailure("foo", LazyList.empty[Exception])) {
+      case x => flatMapN(x.toUpperCase.toSuccess[String, Exception]) {
+        case y => flatMapN(y.reverse.toSuccess[String, Exception]) {
           case _ => Failure[String, Exception](LazyList(ex))
         }
       }
@@ -321,11 +323,11 @@ class TestValidation extends FunSuite {
   }
 
   test("flatMap05") {
-    val ex1 = new RuntimeException()
-    val ex2 = new RuntimeException()
-    val result = SoftFailure("abc", LazyList(ex1)).flatMap {
-      case x => x.toUpperCase.toSuccess[String, Exception].flatMap {
-        case y => SoftFailure[String, Exception](y.reverse, LazyList(ex2)).flatMap {
+    val ex1: Exception = new RuntimeException()
+    val ex2: Exception = new RuntimeException()
+    val result = flatMapN(SoftFailure("abc", LazyList(ex1))) {
+      case x => flatMapN(x.toUpperCase.toSuccess[String, Exception]) {
+        case y => flatMapN(SoftFailure[String, Exception](y.reverse, LazyList(ex2))) {
           case z => Success[String, Exception](z + z)
         }
       }
@@ -334,11 +336,11 @@ class TestValidation extends FunSuite {
   }
 
   test("flatMap06") {
-    val ex1 = new RuntimeException()
-    val ex2 = new RuntimeException()
-    val result = "abc".toSuccess[String, Exception].flatMap {
-      case x => SoftFailure(x.toUpperCase, LazyList(ex2)).flatMap {
-        case y => SoftFailure(y.reverse, LazyList(ex1)).flatMap {
+    val ex1: Exception = new RuntimeException()
+    val ex2: Exception = new RuntimeException()
+    val result = flatMapN("abc".toSuccess[String, Exception]) {
+      case x => flatMapN(SoftFailure(x.toUpperCase, LazyList(ex2))) {
+        case y => flatMapN(SoftFailure(y.reverse, LazyList(ex1))) {
           case z => Success[String, Exception](z + z)
         }
       }


### PR DESCRIPTION
fixes #5377. I added an implicit extension method so that Flix.scala does not become a big mess, but I am not sure whether it is worth it.