### PR TITLE
feat: new restrictable tag type rule

### DIFF
--- a/examples/larger-examples/restrictable-variants/boolean-formulas.flix
+++ b/examples/larger-examples/restrictable-variants/boolean-formulas.flix
@@ -16,15 +16,6 @@ def size(e: Expr[s]): Int32 = choose e {
     case Expr.Xor(x, y) => size(x) + size(y) + 1
 }
 
-def traverse(e: Expr[s]): Expr[s] = choose* e {
-    case Expr.Cst(b) => Expr.Cst(b)
-    case Expr.Var(v) => Expr.Var(v)
-    case Expr.Not(x) => open Expr.Not(x)
-    case Expr.And(x, y) => open Expr.And(traverse(x), traverse(y))
-    case Expr.Or(x, y) => open Expr.Or(traverse(x), traverse(y))
-    case Expr.Xor(x, y) => open Expr.Xor(traverse(x), traverse(y))
-}
-
 def simplify(e: Expr[s]): Expr[(s -- <Expr.Xor>) ++ <Expr.Not, Expr.And, Expr.Or>] =
     choose* e {
         case Expr.Var(x) => Expr.Var(x)

--- a/examples/larger-examples/restrictable-variants/boolean-formulas.flix
+++ b/examples/larger-examples/restrictable-variants/boolean-formulas.flix
@@ -16,24 +16,36 @@ def size(e: Expr[s]): Int32 = choose e {
     case Expr.Xor(x, y) => size(x) + size(y) + 1
 }
 
-def simplify(e: Expr[s]): Expr[(s -- <Expr.Xor>) ++ <Expr.Not>] =
+def traverse(e: Expr[s]): Expr[s] = choose* e {
+    case Expr.Cst(b) => Expr.Cst(b)
+    case Expr.Var(v) => Expr.Var(v)
+    case Expr.Not(x) => open Expr.Not(x)
+    case Expr.And(x, y) => open Expr.And(traverse(x), traverse(y))
+    case Expr.Or(x, y) => open Expr.Or(traverse(x), traverse(y))
+    case Expr.Xor(x, y) => open Expr.Xor(traverse(x), traverse(y))
+}
+
+def simplify(e: Expr[s]): Expr[(s -- <Expr.Xor>) ++ <Expr.Not, Expr.And, Expr.Or>] =
     choose* e {
         case Expr.Var(x) => Expr.Var(x)
         case Expr.Cst(b) => Expr.Cst(b)
-        case Expr.Not(x) => open Expr.Not(open_as Expr simplify(x))
-        case Expr.And(x, y) => Expr.And(???, ???)
-        case Expr.Or(x, y) => Expr.Or(???, ???)
-        case Expr.Xor(x, y) => Expr.Not(???)
+        case Expr.Not(x) => open Expr.Not(simplify(x))
+        case Expr.And(x, y) => open Expr.And(simplify(x), simplify(y))
+        case Expr.Or(x, y) => open Expr.Or(simplify(x), simplify(y))
+        case Expr.Xor(x, y) =>
+            let xx = simplify(x);
+            let yy = simplify(y);
+            open Expr.Or(open Expr.And(xx, open Expr.Not(yy)), open Expr.And(open Expr.Not(xx), yy))
     }
 
 def subst(e: Expr[s]): Expr[(s -- <Expr.Var>) ++ <Expr.Cst>] =
     choose* e {
-        case Expr.Var(x) => Expr.Cst(true)
+        case Expr.Var(_) => Expr.Cst(true)
         case Expr.Cst(b) => Expr.Cst(b)
-        case Expr.Not(x) => open Expr.Not(open_as Expr subst(x))
-        case Expr.Or(x, y) => Expr.Or(???, ???)
-        case Expr.And(x, y) => Expr.And(???, ???)
-        case Expr.Xor(x, y) => Expr.Xor(???, ???)
+        case Expr.Not(x) => open Expr.Not(subst(x))
+        case Expr.Or(x, y) => open Expr.Or(subst(x), subst(y))
+        case Expr.And(x, y) => open Expr.And(subst(x), subst(y))
+        case Expr.Xor(x, y) => open Expr.Xor(subst(x), subst(y))
     }
 
 def fasteval(e: Expr[s -- <Expr.Var, Expr.Xor>]): Bool =
@@ -50,10 +62,10 @@ def eval(e: Expr[s]): Bool = {
 }
 
 def main(): Unit \ IO = {
-    let input: Expr[<Expr.Not, Expr.Var>] = open Expr.Not(open Expr.Var(42));
+    let input = open Expr.Not(open Expr.Var(42));
     println("input is '${toString(input)}'");
     println("input size ${size(input)}");
-    println("input evaluates to ${eval(input)}");
+    println("input evaluates to '${eval(input)}' (all variables mapped to 'true'");
     let fls = Expr.Cst(false);
     println("input ${if (eq(input, fls)) "is" else "is not"} equal to '${toString(fls)}'")
 }

--- a/examples/larger-examples/restrictable-variants/sequences.flix
+++ b/examples/larger-examples/restrictable-variants/sequences.flix
@@ -25,13 +25,13 @@ def map(f: Int32 -> Int32, s: Seq[i]): Seq[i] =
     choose* s {
         case Seq.Nil         => Seq.Nil
         case Seq.One(x)      => Seq.One(f(x))
-        case Seq.Cons(x, xs) => open Seq.Cons(f(x), open_as Seq map(f, xs))
+        case Seq.Cons(x, xs) => open Seq.Cons(f(x), map(f, xs))
 }
 
 def append(w: Int32, s: Seq[i]): Seq[<Seq.One, Seq.Cons>] =
     choose* s {
         case Seq.Nil         => Seq.One(w)
-        case Seq.One(x)      => open Seq.Cons(x, open Seq.One(x))
+        case Seq.One(x)      => open Seq.Cons(x, Seq.One(x))
         case Seq.Cons(x, xs) => open Seq.Cons(x, append(w, xs))
     }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1916,21 +1916,4 @@ class TestTyper extends FunSuite with TestUtils {
         |""".stripMargin
     expectError[TypeError.GeneralizationError](compile(input, Options.TestWithLibNix))
   }
-
-  test("TestCaseSetAnnotation.05") {
-    val input =
-      """
-        |restrictable enum Binary[s] {
-        |    case Zero(Binary[s]), One(Binary[s]), End
-        |}
-        |
-        |// forgot open on recursive variable use
-        |def id(b: Binary[s]): Binary[s] = choose* b {
-        |    case Binary.Zero(x) => open Binary.Zero(id(x))
-        |    case Binary.One(x) => open Binary.One(id(x))
-        |    case Binary.End => Binary.End
-        |}
-        |""".stripMargin
-    expectError[TypeError.MismatchedBools](compile(input, Options.TestWithLibNix))
-  }
 }


### PR DESCRIPTION
* `open Tag(...)` uses the schema instantiation `t -> Enum[s][targs...]` and then returns the type `Enum[s + {Tag}][targs...]`
    * this means that an open tag might still have an upper bound, compared to the previous rule
    * this means that for nested tags, the inner expression does not have to include the constructed label
* `Tag(...)` uses the schema instantiation `t -> Enum[{Tag}][targs...]` and returns `Enum[{Tag}][targs...]`
    * This rule exist to limit type variables for non-recurse tags
    * `open Tag` for non-recusive tags have no upperbound
    * For non-recursive tags, `open_as Enum Enum.Tag(...)` is equivalent to `open Enum.Tag(...)`.