### PR TITLE
feat: add Order instance to Chain (issue #5408)

### DIFF
--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -33,6 +33,10 @@ instance Eq[Chain[a]] with Eq[a] {
     pub def eq(c1: Chain[a], c2: Chain[a]): Bool = Chain.equals(c1, c2)
 }
 
+instance Order[Chain[a]] with Order[a] {
+    pub def compare(c1: Chain[a], c2: Chain[a]): Comparison = Chain.compare(c1, c2)
+}
+
 instance SemiGroup[Chain[a]] {
     pub def combine(c1: Chain[a], c2: Chain[a]): Chain[a] = Chain.append(c1, c2)
 }
@@ -839,8 +843,23 @@ namespace Chain {
         match (viewLeft(c1), viewLeft(c2)) {
             case (ViewLeft.NoneLeft, ViewLeft.NoneLeft)                           => true
             case (ViewLeft.SomeLeft(x, xs), ViewLeft.SomeLeft(y, ys)) if (x == y) => equals(xs, ys)
-            case _                                              => false
+            case _                                                                => false
         }
+
+    ///
+    /// Compares chains `c1` and `c2` lexicographically.
+    ///
+    pub def compare(c1: Chain[a], c2: Chain[a]): Comparison with Order[a] =
+        def loop(v1, v2) = match (v1, v2) {
+            case (SomeLeft(_, _), NoneLeft)         => Comparison.GreaterThan
+            case (NoneLeft, NoneLeft)               => Comparison.EqualTo
+            case (NoneLeft, SomeLeft(_, _))         => Comparison.LessThan
+            case (SomeLeft(l, ls), SomeLeft(r, rs)) => match (l <=> r) {
+                case Comparison.EqualTo => loop(viewLeft(ls), viewLeft(rs))
+                case cmp                => cmp
+            }
+        };
+        loop(viewLeft(c1), viewLeft(c2))
 
     ///
     /// Sort chain `c` so that elements are ordered from low to high according to their `Order` instance.

--- a/main/test/ca/uwaterloo/flix/library/TestChain.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestChain.flix
@@ -1662,6 +1662,86 @@ namespace TestChain {
         Chain.toNec(List.toChain(1 :: 2 :: Nil)) == Some(Nec.cons(1, Nec.singleton(2)))
 
     /////////////////////////////////////////////////////////////////////////////
+    // equals                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def equals01(): Bool =
+        (Chain.empty(): Chain[Int32]) `Chain.equals` (Chain.empty(): Chain[Int32])
+
+    @test
+    def equals02(): Bool =
+        Chain.singleton(1) `Chain.equals` Chain.singleton(1)
+
+    @test
+    def equals03(): Bool =
+        (Chain.empty() |> Chain.cons(1)) `Chain.equals` Chain.singleton(1)
+
+    @test
+    def equals04(): Bool =
+        (Chain.empty() `Chain.snoc` 1) `Chain.equals` Chain.singleton(1)
+
+    @test
+    def equals05(): Bool =
+        (Chain.empty() `Chain.snoc` 1) `Chain.equals` (Chain.empty() |> Chain.cons(1))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // compare                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def compare01(): Bool =
+        (Chain.empty(): Chain[Int32]) `Chain.compare` (Chain.empty(): Chain[Int32]) == Comparison.EqualTo
+
+    @test
+    def compare02(): Bool =
+        Chain.singleton(1) `Chain.compare` Chain.empty() == Comparison.GreaterThan
+
+    @test
+    def compare03(): Bool =
+        Chain.empty() `Chain.compare` Chain.singleton(1) == Comparison.LessThan
+
+    @test
+    def compare04(): Bool =
+        Chain.singleton(1) `Chain.compare` Chain.singleton(1) == Comparison.EqualTo
+
+    @test
+    def compare05(): Bool =
+        Chain.singleton(1) `Chain.compare` Chain.singleton(2) == Comparison.LessThan
+
+    @test
+    def compare06(): Bool =
+        Chain.singleton(2) `Chain.compare` Chain.singleton(1) == Comparison.GreaterThan
+
+    @test
+    def compare07(): Bool =
+        Chain.singleton(1) `Chain.compare` List.toChain(1 :: 2 :: Nil) == Comparison.LessThan
+
+    @test
+    def compare08(): Bool =
+        List.toChain(1 :: 2 :: Nil) `Chain.compare` Chain.singleton(1) == Comparison.GreaterThan
+
+    @test
+    def compare09(): Bool =
+        Chain.singleton(1) `Chain.compare` List.toChain(0 :: 0 :: Nil) == Comparison.GreaterThan
+
+    @test
+    def compare10(): Bool =
+        List.toChain(0 :: 0 :: Nil)  `Chain.compare` Chain.singleton(1) == Comparison.LessThan
+
+    @test
+    def compare11(): Bool =
+        List.toChain(1 :: 2 :: Nil) `Chain.compare` List.toChain(1 :: 1 :: Nil) == Comparison.GreaterThan
+
+    @test
+    def compare12(): Bool =
+        List.toChain(1 :: 2 :: Nil) `Chain.compare` List.toChain(1 :: 3 :: Nil) == Comparison.LessThan
+
+    @test
+    def compare13(): Bool =
+        List.toChain(1 :: 2 :: 3 :: 4 :: Nil) `Chain.compare` List.toChain(1 :: 2 :: 3 :: 4 :: Nil) == Comparison.EqualTo
+
+    /////////////////////////////////////////////////////////////////////////////
     // sort                                                                    //
     /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This PR adds an `Order` instance to `Chain`.

`compare` is provided by a function inside the `Chain` module - `equals` already worked like this and directly implementing `compare` in the instance would be a bit ugly due to needing to use the view constructors with qualified names.