### PR TITLE
feat: optimize `mkEq` in `CaseSetUnification`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/unification/CaseSetUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/CaseSetUnification.scala
@@ -68,7 +68,7 @@ object CaseSetUnification {
     */
   private def booleanUnification(tpe1: SetFormula, tpe2: SetFormula, renv: Set[Int], univ: Set[Int], sym: Symbol.RestrictableEnumSym, env: Bimap[VarOrCase, Int])(implicit flix: Flix): Result[CaseSetSubstitution, UnificationError] = {
     // The boolean expression we want to show is 0.
-    val query = mkEq(tpe1, tpe2)(univ)
+    val query = minimize(mkEq(tpe1, tpe2)(univ))(univ)
 
     // Compute the variables in the query.
     val typeVars = query.freeVars.toList


### PR DESCRIPTION
Idea: minimize formulas after mkEq duplicates the formula

Its not clear that this is always beneficial, but it is for monomorphization since it instantiates all variables to ``{}` and have crazy big types representing constant sets