### PR TITLE
refactor: slice functions given name parameters for start and end (issue #5393)

### DIFF
--- a/examples/larger-examples/datalog/palindrome.flix
+++ b/examples/larger-examples/datalog/palindrome.flix
@@ -3,7 +3,7 @@ def main(): Unit \ IO =
     def trial(input) = {
         let res = input |>
             longestPalindromeSequence |>
-            Option.map(match (b,e) -> String.slice(b, e+1, input)) |>
+            Option.map(match (b,e) -> String.slice(start = b, end = e+1, input)) |>
             Option.getWithDefault("nothing");
         println("> Longest palindrome sequence of ${input} is ${res}")
     };

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -95,10 +95,10 @@ namespace Array {
     pub def length(a: Array[a, r]): Int32 = $ARRAY_LENGTH$(a)
 
     ///
-    /// Returns a fresh array with the elements from the array `a` from index `b` (inclusive) until index `e` (exclusive).
+    /// Returns a fresh array with the elements from the array `a` from index `start` (inclusive) until index `end` (exclusive).
     ///
-    pub def slice(r1: Region[r1], b: Int32, e: Int32, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
-        $ARRAY_SLICE$(r1, a, b, e)
+    pub def slice(r1: Region[r1], start: {start = Int32}, end: {end = Int32}, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
+        $ARRAY_SLICE$(r1, a, start.start, end.end)
 
     ///
     /// Returns the array `a` as a list.

--- a/main/src/library/Console.flix
+++ b/main/src/library/Console.flix
@@ -117,9 +117,9 @@ namespace Console {
             use Option.flatMap;
             let* hex = String.stripPrefix(substr = "#", hexCode);
             if (String.length(hex) == 6) {
-                let* r = String.sliceLeft(2, hex) |> stringToHex;
-                let* g = String.slice(2, 4, hex) |> stringToHex;
-                let* b = String.slice(4, 6, hex) |> stringToHex;
+                let* r = String.sliceLeft(end = 2, hex) |> stringToHex;
+                let* g = String.slice(start = 2, end = 4, hex) |> stringToHex;
+                let* b = String.slice(start = 4, end = 6, hex) |> stringToHex;
                 Some(rgb((r, g, b), text, isFg = true))
             } else Option.None
         };

--- a/main/src/library/File.flix
+++ b/main/src/library/File.flix
@@ -556,7 +556,7 @@ namespace File {
         } else {
             let countBiggest = numberRead < count;
             if (countBiggest) {
-                Array.slice(r, 0, numberRead, bytes)
+                Array.slice(r, start = 0, end = numberRead, bytes)
             } else {
                 bytes
             }

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -754,23 +754,23 @@ namespace List {
         loop(l, identity)
 
     ///
-    /// Returns the sublist of `l` from index `b` (inclusive) to index `e` (exclusive).
+    /// Returns the sublist of `l` from index `start` (inclusive) to index `end` (exclusive).
     ///
-    /// That is, an element at index `i` in `l` is part of the returned sublist if and only if `i >= b` and `i < e`.
-    /// Note: Indices that are out of bounds in `l` are not considered (i.e. slice(b, e, l) = slice(max(0,b), min(length(l),e), l)).
+    /// That is, an element at index `i` in `l` is part of the returned sublist if and only if `i >= start` and `i < end`.
+    /// Note: Indices that are out of bounds in `l` are not considered (i.e. slice(start, end, l) = slice(max(0, start), min(length(l), end), l)).
     ///
-    pub def slice(b: Int32, e: Int32, l: List[a]): List[a] =
+    pub def slice(start: {start = Int32}, end: {end = Int32}, l: List[a]): List[a] =
         def loop(ll, i, k) = match ll {
             case Nil     => k(Nil)
             case x :: xs =>
-                if (i < b)
+                if (i < start.start)
                     loop(xs, i + 1, k)
-                else if (i >= e)
+                else if (i >= end.end)
                     k(Nil)
                 else
                     loop(xs, i + 1, ks -> k(x :: ks))
         };
-        if (b < e) loop(l, 0, identity) else Nil
+        if (start.start < end.end) loop(l, 0, identity) else Nil
 
     ///
     /// Returns a pair of lists `(l1, l2)`.

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -339,10 +339,10 @@ namespace MutDeque {
     def copyElements!(r2: Region[r2], f: Int32, b: Int32, a: Array[a, r1], a1: Array[a, r2]): Unit \ { Read(r1), Write(r2) } =
         let c = Array.length(a);
         if (f < b) { // If this predicate is true the elements do not "wrap around" in the array, i.e. the elements are laid out sequentially from [0 .. b].
-            Array.updateSequence!(0,     Array.slice(r2, f, b, a), a1)
+            Array.updateSequence!(0,     Array.slice(r2, start = f, end = b, a), a1)
         } else {
-            Array.updateSequence!(0,     Array.slice(r2, f, c, a), a1); // Copy the front elements of `a` to a1[0 .. (c - f)].
-            Array.updateSequence!(c - f, Array.slice(r2, 0, b, a), a1)  // Copy the back  elements of `a` to a1[(c - f) .. b].
+            Array.updateSequence!(0,     Array.slice(r2, start = f, end = c, a), a1); // Copy the front elements of `a` to a1[0 .. (c - f)].
+            Array.updateSequence!(c - f, Array.slice(r2, start = 0, end = b, a), a1)  // Copy the back  elements of `a` to a1[(c - f) .. b].
         }
 
     ///

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -270,33 +270,33 @@ namespace String {
     ///
     /// If `b` or `e` are out-of-bounds, return the empty string.
     ///
-    pub def slice(b: Int32, e: Int32, s: String): String = try {
+    pub def slice(start: {start = Int32}, end: {end = Int32}, s: String): String = try {
         import java.lang.String.substring(Int32, Int32): String \ {};
-        substring(s, b, e)
+        substring(s, start.start, end.end)
     } catch {
         case _: ##java.lang.IndexOutOfBoundsException => ""
     }
 
     ///
-    /// Get the substring of `s` to the left of index `e` (exclusive).
+    /// Get the substring of `s` to the left of index `end` (exclusive).
     ///
     /// `sliceLeft == slice(0 , e, s)`
     ///
-    pub def sliceLeft(e: Int32, s: String): String = match length(s) {
-        case len if e > len => ""
-        case _   if e < 0   => ""
-        case _              => slice(0, e, s)
+    pub def sliceLeft(end: {end = Int32}, s: String): String = match length(s) {
+        case len if end.end > len => ""
+        case _   if end.end < 0   => ""
+        case _                    => slice(start = 0, end, s)
     }
 
     ///
-    /// Get the substring of `s` to the right starting at index `b` (inclusive).
+    /// Get the substring of `s` to the right starting at index `start` (inclusive).
     ///
-    /// `sliceRight == slice(b , length(s), s)`
+    /// `sliceRight == slice(start , length(s), s)`
     ///
-    pub def sliceRight(b: Int32, s: String): String = match length(s) {
-        case len if b >= len => ""
-        case _   if b < 0 => ""
-        case len => slice(b, len, s)
+    pub def sliceRight(start: {start = Int32}, s: String): String = match length(s) {
+        case len if start.start >= len => ""
+        case _   if start.start < 0    => ""
+        case len                       => slice(start, end = len, s)
     }
 
     ///
@@ -378,7 +378,7 @@ namespace String {
     /// of `s`.
     ///
     pub def takeLeft(n: Int32, s: String): String =
-        if (n >= length(s)) s else slice(0, n, s)
+        if (n >= length(s)) s else slice(start = 0, end = n, s)
 
     ///
     /// Take the last `n` characters of string `s` from the right.
@@ -388,7 +388,7 @@ namespace String {
     ///
     pub def takeRight(n: Int32, s: String): String =
         let len = length(s);
-        if (n >= len) s else slice(len - n, len, s)
+        if (n >= len) s else slice(start = len - n, end = len, s)
 
     ///
     /// Alias for `dropLeft`.
@@ -404,7 +404,7 @@ namespace String {
         if (n <= 0)
             s
         else
-            slice(n, length(s), s)
+            slice(start = n, end = length(s), s)
 
     ///
     /// Drop the last `n` characters of string `s` from the right.
@@ -414,7 +414,7 @@ namespace String {
     pub def dropRight(n: Int32, s: String): String =
         if (n > 0)
             let len = length(s);
-            slice(0, len - n, s)
+            slice(start = 0, end = len - n, s)
         else
             s
 
@@ -444,7 +444,7 @@ namespace String {
     pub def takeWhileRight(f: Char -> Bool, s: String): String =
         match findIndexOfRight(x -> not (f(x)), s) {
             case None    => s
-            case Some(i) => slice(i + 1, length(s), s)
+            case Some(i) => slice(start = i + 1, end = length(s), s)
         }
 
     ///
@@ -461,7 +461,7 @@ namespace String {
     pub def dropWhileLeft(f: Char -> Bool, s: String): String =
         match findIndexOfLeft(x -> not (f(x)), s) {
             case None    => ""
-            case Some(i) => sliceRight(i, s)
+            case Some(i) => sliceRight(start = i, s)
         }
 
     ///
@@ -473,7 +473,7 @@ namespace String {
     pub def dropWhileRight(f: Char -> Bool, s: String): String =
         match findIndexOfRight(x -> not (f(x)), s) {
             case None    => ""
-            case Some(i) => sliceLeft(i + 1, s)     // must include i
+            case Some(i) => sliceLeft(end = i + 1, s)     // must include i
         }
 
     ///
@@ -485,9 +485,9 @@ namespace String {
     pub def dropWhileAround(f: Char -> Bool, s: String): String =
         match (findIndexOfLeft(x -> not (f(x)), s), findIndexOfRight(x -> not (f(x)), s)) {
             case (None, None)       => ""
-            case (Some(l), None)    => sliceRight(l, s)
-            case (None, Some(r))    => sliceLeft(r, s)
-            case (Some(l), Some(r)) => slice(l, r + 1, s)
+            case (Some(l), None)    => sliceRight(start = l, s)
+            case (None, Some(r))    => sliceLeft(end = r, s)
+            case (Some(l), Some(r)) => slice(start = l, end = r + 1, s)
         }
 
     ///
@@ -501,7 +501,7 @@ namespace String {
         match length(s) {
             case _   if n <= 0  => ("", s)
             case len if n > len => (s, "")
-            case _              => (sliceLeft(n, s), sliceRight(n, s))
+            case _              => (sliceLeft(end = n, s), sliceRight(start = n, s))
         }
 
 
@@ -831,9 +831,9 @@ namespace String {
         let limit = Int32.min(n, length(s));
         def loop(s1, ix) = {
             if (ix >= limit)
-                sliceRight(ix, s1)
+                sliceRight(start = ix, s1)
             else if (not Char.isWhiteSpace(charAt(ix, s1)))
-                sliceRight(ix, s1)
+                sliceRight(start = ix, s1)
             else
                 loop(s1, ix + 1)
         };
@@ -999,7 +999,7 @@ namespace String {
             case _   if w < 3   => ""
             case len            => {
                 let start = len - w + 3;
-                "..." + slice(start, len, s)
+                "..." + slice(start = start, end = len, s)
             }
         }
 
@@ -1015,7 +1015,7 @@ namespace String {
         match length(s) {
             case len if len < w => s
             case _   if w < 3   => ""
-            case _              => slice(0, w - 3, s) + "..."
+            case _              => slice(start = 0, end = w - 3, s) + "..."
         }
 
     ///
@@ -1092,11 +1092,11 @@ namespace String {
             else {
                 match indexOfLeftWithOffset({substr = substr.substr}, {offset = ix}, s) {
                     case None => {
-                        let s1 = sliceRight(ix, s);
+                        let s1 = sliceRight(start = ix, s);
                         Some(s1, maxlen + 1)
                     }
                     case Some(ix2) => {
-                        let s1 = slice(ix, ix2, s);
+                        let s1 = slice(start = ix, end = ix2, s);
                         Some(s1, ix2 + sublen)
                     }
                 }
@@ -1151,8 +1151,8 @@ namespace String {
         let len = length(s);
         let step = pos -> match pos {
             case i if i >= len        => None
-            case i if i + size >= len => Some(sliceRight(i, s), len)
-            case i                    => Some(slice(i, i + size, s), i + size)
+            case i if i + size >= len => Some(sliceRight(start = i, s), len)
+            case i                    => Some(slice(start = i, end = i + size, s), i + size)
         };
         List.unfold(step, 0)
 
@@ -1163,7 +1163,7 @@ namespace String {
     pub def breakOnLeft(substr: {substr = String}, s: String): (String, String) =
         match indexOfLeft({substr = substr.substr}, s) {
             case None    => (s, "")
-            case Some(i) => (sliceLeft(i, s), sliceRight(i, s))
+            case Some(i) => (sliceLeft(end = i, s), sliceRight(start = i, s))
         }
 
     ///
@@ -1174,7 +1174,7 @@ namespace String {
         let sublen = length(substr.substr);
         match indexOfRight({substr = substr.substr}, s) {
             case None    => (s, "")
-            case Some(i) => (sliceLeft(i + sublen, s), sliceRight(i + sublen, s))
+            case Some(i) => (sliceLeft(end  = i + sublen, s), sliceRight(start = i + sublen, s))
         }
 
     ///

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -64,19 +64,19 @@ namespace Vector {
     }
 
     ///
-    /// Version of `Array.updateSequence!` where sub is a vector rather than an array, 
+    /// Version of `Array.updateSequence!` where sub is a vector rather than an array,
     /// so a extra copy of `sub` is avoided.
     ///
     def arrayUpdateSeqV!(i: Int32, sub: Vector[a], arr: Array[a, r]): Unit \ Write(r)  =
         let end = Array.length(arr);
         let subLen = length(sub);
         def loop(ri, wi) = {
-            if (wi >= end or ri >= subLen) 
+            if (wi >= end or ri >= subLen)
                 ()
-            else if (wi < 0) 
+            else if (wi < 0)
                 loop(ri+1, wi+1)
             else {
-                let x = get(ri, sub); 
+                let x = get(ri, sub);
                 Array.put(x, wi, arr);
                 loop(ri+1, wi+1)
             }
@@ -127,7 +127,7 @@ namespace Vector {
     ///
     pub def slice(start: {start = Int32}, end: {end = Int32}, v: Vector[a]): Vector[a] = region rc {
         let arr = toArray(rc, v);
-        Array.slice(rc, start.start, end.end, arr) |> Array.toVector
+        Array.slice(rc, start, end, arr) |> Array.toVector
     }
 
     ///
@@ -392,7 +392,7 @@ namespace Vector {
     ///
     /// The result is a new vector.
     ///
-    pub def map(f: a -> b \ ef, v: Vector[a]): Vector[b] \ ef = 
+    pub def map(f: a -> b \ ef, v: Vector[a]): Vector[b] \ ef =
         init(i -> f(get(i, v)), length(v))
 
 
@@ -437,7 +437,7 @@ namespace Vector {
     ///
     /// This is an explicit helper to avoid code duplication.
     ///
-    def rotateLeftHelper(n: Int32, v: Vector[a]): Vector[a] = 
+    def rotateLeftHelper(n: Int32, v: Vector[a]): Vector[a] =
         let len = length(v);
         let f = ix -> {let readIx = Int32.mod(ix + n, len); get(readIx, v)};
         init(f, len)
@@ -1056,7 +1056,7 @@ namespace Vector {
             Array.put(l, i, arr);
             Array.put(r, i, brr)
             }, v);
-        (Array.toVector(arr), Array.toVector(brr))            
+        (Array.toVector(arr), Array.toVector(brr))
     }
 
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -171,17 +171,17 @@ namespace TestArray {
 
     @test
     def testSlice01(): Bool = region r {
-        Array.slice(r, 0, 1, Array#{1, 2, 3} @ r)[0] == 1
+        Array.slice(r, start = 0, end = 1, Array#{1, 2, 3} @ r)[0] == 1
     }
 
     @test
     def testSlice02(): Bool = region r {
-        Array.slice(r, 1, 2, Array#{1, 2, 3} @ r)[0] == 2
+        Array.slice(r, start = 1, end = 2, Array#{1, 2, 3} @ r)[0] == 2
     }
 
     @test
     def testSlice03(): Bool = region r {
-        Array.slice(r, 2, 3, Array#{1, 2, 3} @ r)[0] == 3
+        Array.slice(r, start = 2, end = 3, Array#{1, 2, 3} @ r)[0] == 3
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -5308,8 +5308,8 @@ namespace TestArray {
     /////////////////////////////////////////////////////////////////////////////
 
     def testSort!VsSortWith!(a: Array[Int32, r]): Bool \ { Read(r) } = region r1 {
-        let b = Array.slice(r1, 0, Array.length(a), a);
-        let c = Array.slice(r1, 0, Array.length(a), a);
+        let b = Array.slice(r1, start = 0, end = Array.length(a), a);
+        let c = Array.slice(r1, start = 0, end = Array.length(a), a);
         Array.sort!(b);
         Array.sortWith!(cmp, c);
         b `sameElements` c
@@ -5437,8 +5437,8 @@ namespace TestArray {
     /////////////////////////////////////////////////////////////////////////////
 
     def testSortBy!VsSortBy(a: Array[Int32, r]) : Bool \ { Read(r) } = region r1 {
-        let b = Array.slice(r1, 0, Array.length(a), a);
-        let c = Array.slice(r1, 0, Array.length(a), a);
+        let b = Array.slice(r1, start = 0, end = Array.length(a), a);
+        let c = Array.slice(r1, start = 0, end = Array.length(a), a);
         Array.sortBy!(identity, b);
         Array.sortBy!(x -> 4 * x + 7, c);
         (b `sameElements` Array.sortBy(r1, x -> 4 * x + 7, a)) and

--- a/main/test/ca/uwaterloo/flix/library/TestList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestList.flix
@@ -1291,46 +1291,46 @@ def init07(): Bool = List.init(2 :: 1 :: 0 :: -1 :: Nil) == Some(2 :: 1 :: 0 :: 
 // slice                                                                   //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def slice01(): Bool = List.slice(0, 0, Nil: List[Unit]) == Nil
+def slice01(): Bool = List.slice(start = 0, end = 0, Nil: List[Unit]) == Nil
 
 @test
-def slice02(): Bool = List.slice(-1, 1, Nil: List[Unit]) == Nil
+def slice02(): Bool = List.slice(start = -1, end = 1, Nil: List[Unit]) == Nil
 
 @test
-def slice03(): Bool = List.slice(0, 0, 1 :: Nil) == Nil
+def slice03(): Bool = List.slice(start = 0, end = 0, 1 :: Nil) == Nil
 
 @test
-def slice04(): Bool = List.slice(0, 1, 1 :: Nil) == 1 :: Nil
+def slice04(): Bool = List.slice(start = 0, end = 1, 1 :: Nil) == 1 :: Nil
 
 @test
-def slice05(): Bool = List.slice(0, 2, 1 :: Nil) == 1 :: Nil
+def slice05(): Bool = List.slice(start = 0, end = 2, 1 :: Nil) == 1 :: Nil
 
 @test
-def slice06(): Bool = List.slice(2, 5, 1 :: Nil) == Nil
+def slice06(): Bool = List.slice(start = 2, end = 5, 1 :: Nil) == Nil
 
 @test
-def slice07(): Bool = List.slice(-1, 1, 1 :: Nil) == 1 :: Nil
+def slice07(): Bool = List.slice(start = -1, end = 1, 1 :: Nil) == 1 :: Nil
 
 @test
-def slice08(): Bool = List.slice(0, 1, 1 :: 2 :: Nil) == 1 :: Nil
+def slice08(): Bool = List.slice(start = 0, end = 1, 1 :: 2 :: Nil) == 1 :: Nil
 
 @test
-def slice09(): Bool = List.slice(0, 2, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
+def slice09(): Bool = List.slice(start = 0, end = 2, 1 :: 2 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def slice10(): Bool = List.slice(1, 2, 1 :: 2 :: Nil) == 2 :: Nil
+def slice10(): Bool = List.slice(start = 1, end = 2, 1 :: 2 :: Nil) == 2 :: Nil
 
 @test
-def slice11(): Bool = List.slice(0, 3, 1 :: 2 :: 3 :: Nil) == 1 :: 2 :: 3 :: Nil
+def slice11(): Bool = List.slice(start = 0, end = 3, 1 :: 2 :: 3 :: Nil) == 1 :: 2 :: 3 :: Nil
 
 @test
-def slice12(): Bool = List.slice(0, 2, 1 :: 2 :: 3 :: Nil) == 1 :: 2 :: Nil
+def slice12(): Bool = List.slice(start = 0, end = 2, 1 :: 2 :: 3 :: Nil) == 1 :: 2 :: Nil
 
 @test
-def slice13(): Bool = List.slice(1, 3, 1 :: 2 :: 3 :: Nil) == 2 :: 3 :: Nil
+def slice13(): Bool = List.slice(start = 1, end = 3, 1 :: 2 :: 3 :: Nil) == 2 :: 3 :: Nil
 
 @test
-def slice14(): Bool = List.slice(1, 2, 1 :: 2 :: 3 :: Nil) == 2 :: Nil
+def slice14(): Bool = List.slice(start = 1, end = 2, 1 :: 2 :: 3 :: Nil) == 2 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
 // partition                                                               //

--- a/main/test/ca/uwaterloo/flix/library/TestString.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestString.flix
@@ -575,150 +575,150 @@ def isSubmatch11(): Bool = String.isSubmatch({regex = "[b]+"}, "aabbbc") == true
 /////////////////////////////////////////////////////////////////////////////
 
 @test
-def slice01(): Bool = String.slice(0, 1, "") == ""
+def slice01(): Bool = String.slice(start = 0, end = 1, "") == ""
 
 @test
-def slice02(): Bool = String.slice(0, 1, "a") == "a"
+def slice02(): Bool = String.slice(start = 0, end = 1, "a") == "a"
 
 @test
-def slice03(): Bool = String.slice(1, 2, "a") == ""
+def slice03(): Bool = String.slice(start = 1, end = 2, "a") == ""
 
 @test
-def slice04(): Bool = String.slice(0, 2, "a") == ""
+def slice04(): Bool = String.slice(start = 0, end = 2, "a") == ""
 
 @test
-def slice05(): Bool = String.slice(-1, 0, "a") == ""
+def slice05(): Bool = String.slice(start = -1, end = 0, "a") == ""
 
 @test
-def slice06(): Bool = String.slice(0, 1, "ab") == "a"
+def slice06(): Bool = String.slice(start = 0, end = 1, "ab") == "a"
 
 @test
-def slice07(): Bool = String.slice(1, 2, "ab") == "b"
+def slice07(): Bool = String.slice(start = 1, end = 2, "ab") == "b"
 
 @test
-def slice08(): Bool = String.slice(0, 2, "ab") == "ab"
+def slice08(): Bool = String.slice(start = 0, end = 2, "ab") == "ab"
 
 @test
-def slice09(): Bool = String.slice(0, 3, "ab") == ""
+def slice09(): Bool = String.slice(start = 0, end = 3, "ab") == ""
 
 @test
-def slice10(): Bool = String.slice(-1, 2, "ab") == ""
+def slice10(): Bool = String.slice(start = -1, end = 2, "ab") == ""
 
 @test
-def slice11(): Bool = String.slice(0, 1, "abc") == "a"
+def slice11(): Bool = String.slice(start = 0, end = 1, "abc") == "a"
 
 @test
-def slice12(): Bool = String.slice(1, 2, "abc") == "b"
+def slice12(): Bool = String.slice(start = 1, end = 2, "abc") == "b"
 
 @test
-def slice13(): Bool = String.slice(2, 3, "abc") == "c"
+def slice13(): Bool = String.slice(start = 2, end = 3, "abc") == "c"
 
 @test
-def slice14(): Bool = String.slice(0, 2, "abc") == "ab"
+def slice14(): Bool = String.slice(start = 0, end = 2, "abc") == "ab"
 
 @test
-def slice15(): Bool = String.slice(1, 3, "abc") == "bc"
+def slice15(): Bool = String.slice(start = 1, end = 3, "abc") == "bc"
 
 @test
-def slice16(): Bool = String.slice(0, 3, "abc") == "abc"
+def slice16(): Bool = String.slice(start = 0, end = 3, "abc") == "abc"
 
 /////////////////////////////////////////////////////////////////////////////
 // sliceLeft                                                               //
 /////////////////////////////////////////////////////////////////////////////
 
 @test
-def sliceLeft01(): Bool = String.sliceLeft(0, "") == ""
+def sliceLeft01(): Bool = String.sliceLeft(end = 0, "") == ""
 
 @test
-def sliceLeft02(): Bool = String.sliceLeft(1, "") == ""
+def sliceLeft02(): Bool = String.sliceLeft(end = 1, "") == ""
 
 @test
-def sliceLeft03(): Bool = String.sliceLeft(1, "a") == "a"
+def sliceLeft03(): Bool = String.sliceLeft(end = 1, "a") == "a"
 
 @test
-def sliceLeft04(): Bool = String.sliceLeft(0, "a") == ""
+def sliceLeft04(): Bool = String.sliceLeft(end = 0, "a") == ""
 
 @test
-def sliceLeft05(): Bool = String.sliceLeft(2, "a") == ""
+def sliceLeft05(): Bool = String.sliceLeft(end = 2, "a") == ""
 
 @test
-def sliceLeft06(): Bool = String.sliceLeft(1, "ab") == "a"
+def sliceLeft06(): Bool = String.sliceLeft(end = 1, "ab") == "a"
 
 @test
-def sliceLeft07(): Bool = String.sliceLeft(2, "ab") == "ab"
+def sliceLeft07(): Bool = String.sliceLeft(end = 2, "ab") == "ab"
 
 @test
-def sliceLeft08(): Bool = String.sliceLeft(0, "ab") == ""
+def sliceLeft08(): Bool = String.sliceLeft(end = 0, "ab") == ""
 
 @test
-def sliceLeft09(): Bool = String.sliceLeft(3, "ab") == ""
+def sliceLeft09(): Bool = String.sliceLeft(end = 3, "ab") == ""
 
 @test
-def sliceLeft10(): Bool = String.sliceLeft(-1, "ab") == ""
+def sliceLeft10(): Bool = String.sliceLeft(end = -1, "ab") == ""
 
 @test
-def sliceLeft11(): Bool = String.sliceLeft(1, "abc") == "a"
+def sliceLeft11(): Bool = String.sliceLeft(end = 1, "abc") == "a"
 
 @test
-def sliceLeft12(): Bool = String.sliceLeft(2, "abc") == "ab"
+def sliceLeft12(): Bool = String.sliceLeft(end = 2, "abc") == "ab"
 
 @test
-def sliceLeft13(): Bool = String.sliceLeft(3, "abc") == "abc"
+def sliceLeft13(): Bool = String.sliceLeft(end = 3, "abc") == "abc"
 
 @test
-def sliceLeft14(): Bool = String.sliceLeft(0, "abc") == ""
+def sliceLeft14(): Bool = String.sliceLeft(end = 0, "abc") == ""
 
 @test
-def sliceLeft15(): Bool = String.sliceLeft(4, "abc") == ""
+def sliceLeft15(): Bool = String.sliceLeft(end = 4, "abc") == ""
 
 @test
-def sliceLeft16(): Bool = String.sliceLeft(-1, "abc") == ""
+def sliceLeft16(): Bool = String.sliceLeft(end = -1, "abc") == ""
 
 /////////////////////////////////////////////////////////////////////////////
 // sliceRight                                                              //
 /////////////////////////////////////////////////////////////////////////////
 
 @test
-def sliceRight01(): Bool = String.sliceRight(0, "") == ""
+def sliceRight01(): Bool = String.sliceRight(start = 0, "") == ""
 
 @test
-def sliceRight02(): Bool = String.sliceRight(1, "") == ""
+def sliceRight02(): Bool = String.sliceRight(start = 1, "") == ""
 
 @test
-def sliceRight03(): Bool = String.sliceRight(1, "a") == ""
+def sliceRight03(): Bool = String.sliceRight(start = 1, "a") == ""
 
 @test
-def sliceRight04(): Bool = String.sliceRight(0, "a") == "a"
+def sliceRight04(): Bool = String.sliceRight(start = 0, "a") == "a"
 
 @test
-def sliceRight05(): Bool = String.sliceRight(1, "a") == ""
+def sliceRight05(): Bool = String.sliceRight(start = 1, "a") == ""
 
 @test
-def sliceRight06(): Bool = String.sliceRight(0, "ab") == "ab"
+def sliceRight06(): Bool = String.sliceRight(start = 0, "ab") == "ab"
 
 @test
-def sliceRight07(): Bool = String.sliceRight(1, "ab") == "b"
+def sliceRight07(): Bool = String.sliceRight(start = 1, "ab") == "b"
 
 @test
-def sliceRight08(): Bool = String.sliceRight(-1, "ab") == ""
+def sliceRight08(): Bool = String.sliceRight(start = -1, "ab") == ""
 
 @test
-def sliceRight09(): Bool = String.sliceRight(2, "ab") == ""
+def sliceRight09(): Bool = String.sliceRight(start = 2, "ab") == ""
 
 @test
-def sliceRight10(): Bool = String.sliceRight(0, "abc") == "abc"
+def sliceRight10(): Bool = String.sliceRight(start = 0, "abc") == "abc"
 
 @test
-def sliceRight11(): Bool = String.sliceRight(1, "abc") == "bc"
+def sliceRight11(): Bool = String.sliceRight(start = 1, "abc") == "bc"
 
 @test
-def sliceRight12(): Bool = String.sliceRight(2, "abc") == "c"
+def sliceRight12(): Bool = String.sliceRight(start = 2, "abc") == "c"
 
 @test
-def sliceRight13(): Bool = String.sliceRight(3, "abc") == ""
+def sliceRight13(): Bool = String.sliceRight(start = 3, "abc") == ""
 
 @test
-def sliceRight14(): Bool = String.sliceRight(-1, "abc") == ""
+def sliceRight14(): Bool = String.sliceRight(start = -1, "abc") == ""
 
 /////////////////////////////////////////////////////////////////////////////
 // findIndexOfLeft                                                         //


### PR DESCRIPTION
This PR changes `slice` functions to use named params for "start" and "end" - without named params I'd sometimes thought the params were "start" and "length" and this has caused bugs.

The String variants `sliceLeft` and `sliceRight` are also changed.