### PR TITLE
refactor: add region to MutSet and MutMap (issue #5350)

### DIFF
--- a/main/src/library/DelayMap.flix
+++ b/main/src/library/DelayMap.flix
@@ -767,11 +767,11 @@ namespace DelayMap {
         Map.Map(RedBlackTree.mapWithKey((_, v) -> force v, t))
 
     ///
-    /// Returns `m` as a mutable set.
+    /// Returns `m` as a mutable map.
     ///
     @Experimental @Parallel
-    pub def toMutMap(r: Region[r], m: DelayMap[k, v]): MutMap[k, v, r] \ Write(r) =
-        MutMap.MutMap(ref toMap(m) @ r)
+    pub def toMutMap(rc: Region[r], m: DelayMap[k, v]): MutMap[k, v, r] \ Write(r) =
+        MutMap.MutMap(rc, ref toMap(m) @ rc)
 
     ///
     /// Returns the map `m` as a set of key-value pairs.

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -802,10 +802,10 @@ namespace Map {
         Map.foldLeftWithKey(f, empty(), m)
 
     ///
-    /// Returns `m` as a mutable set.
+    /// Returns `m` as a mutable map.
     ///
-    pub def toMutMap(r: Region[r], m: Map[k, v]): MutMap[k, v, r] \ Write(r) =
-        MutMap.MutMap(ref m @ r)
+    pub def toMutMap(rc: Region[r], m: Map[k, v]): MutMap[k, v, r] \ Write(r) =
+        MutMap.MutMap(rc, ref m @ rc)
 
     ///
     /// Returns the map `m` as a list of key-value pairs.

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -17,7 +17,9 @@
 ///
 /// The Mutable Map type.
 ///
-enum MutMap[k: Type, v: Type, r: Region](Ref[Map[k, v], r])
+pub enum MutMap[k: Type, v: Type, r: Region] {
+    case MutMap(Region[r], Ref[Map[k, v], r])
+}
 
 instance Newable[MutMap[k, v]] {
     pub def new(r: Region[r]): MutMap[k, v, r] \ Write(r) = MutMap.new(r)
@@ -44,27 +46,27 @@ namespace MutMap {
     ///
     /// Returns a fresh empty mutable map.
     ///
-    pub def new(r: Region[r]): MutMap[k, v, r] \ Write(r) =
-        MutMap(ref Map.empty() @ r)
+    pub def new(rc: Region[r]): MutMap[k, v, r] \ Write(r) =
+        MutMap(rc, ref Map.empty() @ rc)
 
     ///
     /// Returns the singleton map where key `k` is mapped to value `v`.
     ///
-    pub def singleton(r: Region[r], k: k, v: v): MutMap[k, v, r] \ Write(r) with Order[k] =
-        MutMap(ref Map.singleton(k, v) @ r)
+    pub def singleton(rc: Region[r], k: k, v: v): MutMap[k, v, r] \ Write(r) with Order[k] =
+        MutMap(rc, ref Map.singleton(k, v) @ rc)
 
     ///
     /// Returns `true` if and only if the mutable map `m` contains the key `k`.
     ///
     pub def memberOf(k: k, m: MutMap[k, v, r]): Bool \ Read(r) with Order[k] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.memberOf(k, deref mm)
 
     ///
     /// Returns `true` if and only if `m` is the empty map.
     ///
     pub def isEmpty(m: MutMap[k, v, r]): Bool \ Read(r) =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.isEmpty(deref mm)
 
     ///
@@ -73,7 +75,7 @@ namespace MutMap {
     /// Returns `None` if `m` is empty.
     ///
     pub def minimumKey(m: MutMap[k, v, r]): Option[(k, v)] \ Read(r) =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.minimumKey(deref mm)
 
     ///
@@ -84,7 +86,7 @@ namespace MutMap {
     /// Purity reflective: Runs in parallel when given a pure function `cmp`.
     ///
     pub def minimumKeyBy(cmp: (k, k) -> Comparison \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.minimumKeyBy(cmp, deref mm)
 
     ///
@@ -94,7 +96,7 @@ namespace MutMap {
     ///
     @Parallel
     pub def minimumValue(m: MutMap[k, v, r]): Option[(k, v)] \ Read(r) with Order[v] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.minimumValue(deref mm)
 
     ///
@@ -105,7 +107,7 @@ namespace MutMap {
     /// Purity reflective: Runs in parallel when given a pure function `cmp`.
     ///
     pub def minimumValueBy(cmp: (v, v) -> Comparison \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.minimumValueBy(cmp, deref mm)
 
     ///
@@ -114,7 +116,7 @@ namespace MutMap {
     /// Returns `None` if `m` is empty.
     ///
     pub def maximumKey(m: MutMap[k, v, r]): Option[(k, v)] \ Read(r) =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.maximumKey(deref mm)
 
     ///
@@ -125,7 +127,7 @@ namespace MutMap {
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
     pub def maximumKeyBy(cmp: (k, k) -> Comparison \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.maximumKeyBy(cmp, deref mm)
 
     ///
@@ -135,7 +137,7 @@ namespace MutMap {
     ///
     @Parallel
     pub def maximumValue(m: MutMap[k, v, r]): Option[(k, v)] \ Read(r) with Order[v] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.maximumValue(deref mm)
 
     ///
@@ -146,28 +148,28 @@ namespace MutMap {
     /// Purity reflective: Runs in parallel when given a pure function `cmp`.
     ///
     pub def maximumValueBy(cmp: (v, v) -> Comparison \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.maximumValueBy(cmp, deref mm)
 
     ///
     /// Returns the keys of the mutable map `m`.
     ///
     pub def keysOf(m: MutMap[k, v, r]): Set[k] \ Read(r) with Order[k] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.keysOf(deref mm)
 
     ///
     /// Returns the values of the mutable map `m`.
     ///
     pub def valuesOf(m: MutMap[k, v, r]): List[v] \ Read(r) =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.valuesOf(deref mm)
 
     ///
     /// Returns the size of the mutable map `m`.
     ///
     pub def size(m: MutMap[k, v, r]): Int32 \ Read(r) =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.size(deref mm)
 
     ///
@@ -176,7 +178,7 @@ namespace MutMap {
     /// Otherwise returns `None`.
     ///
     pub def get(k: k, m: MutMap[k, v, r]): Option[v] \ Read(r) with Order[k] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.get(k, deref mm)
 
     ///
@@ -185,14 +187,14 @@ namespace MutMap {
     /// Otherwise returns `d`.
     ///
     pub def getWithDefault(k: k, d: v, m: MutMap[k, v, r]): v \ Read(r) with Order[k] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.getWithDefault(k, d, deref mm)
 
     ///
     /// Updates the mutable map `m` with the binding `k -> v`. Replaces any existing binding.
     ///
     pub def put!(k: k, v: v, m: MutMap[k, v, r]): Unit \ { Read(r), Write(r) } with Order[k] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         mm := Map.insert(k, v, deref mm)
 
     ///
@@ -201,7 +203,7 @@ namespace MutMap {
     /// Otherwise updates the mutable map `m` with the binding `k -> v`.
     ///
     pub def putWith!(f: (v, v) -> v \ ef, k: k, v: v, m: MutMap[k, v, r]): Unit \ { ef, Read(r), Write(r) } with Order[k] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         mm := Map.insertWith(f, k, v, deref mm)
 
     ///
@@ -218,14 +220,14 @@ namespace MutMap {
     /// Otherwise leaves the map is unchanged.
     ///
     pub def adjustWithKey!(f: (k, v) -> v \ ef, k: k, m: MutMap[k, v, r]): Unit \ { ef, Read(r), Write(r) } with Order[k] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         mm := Map.adjustWithKey(f, k, deref mm)
 
     ///
     /// Removes all mappings from the mutable map `m`.
     ///
     pub def clear!(m: MutMap[k, v, r]): Unit \ { Read(r), Write(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         mm := Map.empty()
 
     ///
@@ -234,7 +236,7 @@ namespace MutMap {
     /// Otherwise updates the mutable map `m` with a new mapping `k -> d` and returns d.
     ///
     pub def getOrElsePut!(k: k, d: v, m: MutMap[k, v, r]): v \ { Read(r), Write(r) } with Order[k] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         match Map.get(k, deref mm) {
             case None    => mm := Map.insert(k, d, deref mm); d
             case Some(v) => v
@@ -258,8 +260,8 @@ namespace MutMap {
     /// Merges the mutable map `m1` into the mutable map `m2` where key collisions are resolved with the merge function `f`, taking both the key and values.
     ///
     pub def mergeWithKey!(f: (k, v, v) -> v \ ef, m1: MutMap[k, v, r1], m2: MutMap[k, v, r2]): Unit \ { ef, Read(r1, r2), Write(r2) } with Order[k] =
-        let MutMap(mm1) = m1;
-        let MutMap(mm2) = m2;
+        let MutMap(_, mm1) = m1;
+        let MutMap(_, mm2) = m2;
         mm2 := Map.unionWithKey(f, deref mm1, deref mm2)
 
     ///
@@ -276,7 +278,7 @@ namespace MutMap {
     /// The function `f` must be pure.
     ///
     pub def refineWithKey!(f: (k, v) -> Bool, m: MutMap[k, v, r]): Unit \ { Read(r), Write(r) } with Order[k] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         mm := Map.filterWithKey(f, deref mm)
 
     ///
@@ -285,37 +287,37 @@ namespace MutMap {
     /// Leaves the map unchanged if the mutable map `m` does not contain any mapping for `k`.
     ///
     pub def remove!(k: k, m: MutMap[k, v, r]): Unit \ { Read(r), Write(r) } with Order[k] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         mm := Map.remove(k, deref mm)
 
     ///
     /// Applies the function `f` to every value in the mutable map `m`.
     ///
     pub def transform!(f: v -> v \ ef, m: MutMap[k, v, r]): Unit \ { ef, Read(r), Write(r) } with Order[k] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         mm := Map.map(f, deref mm)
 
     ///
     /// Applies the function `f` to every value in the mutable map `m`.
     ///
     pub def transformWithKey!(f: (k, v) -> v \ ef, m: MutMap[k, v, r]): Unit \ { ef, Read(r), Write(r) } with Order[k] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         mm := Map.mapWithKey(f, deref mm)
 
     ///
     /// Returns `true` if and only if all mappings in the mutable map `m1` occur in the mutable map `m2`.
     ///
     pub def isSubmapOf(m1: MutMap[k, v, r1], m2: MutMap[k, v, r2]): Bool \ { Read(r1, r2) } with Order[k], Eq[v] =
-        let MutMap(mm1) = m1;
-        let MutMap(mm2) = m2;
+        let MutMap(_, mm1) = m1;
+        let MutMap(_, mm2) = m2;
         Map.isSubmapOf(deref mm1, deref mm2)
 
     ///
     /// Returns `true` if and only if all mappings in the mutable map `m1` occur in the mutable map `m2` and `m1 != m2`.
     ///
     pub def isProperSubmapOf(m1: MutMap[k, v, r1], m2: MutMap[k, v, r2]): Bool \ { Read(r1, r2) } with Order[k], Eq[v] =
-        let MutMap(mm1) = m1;
-        let MutMap(mm2) = m2;
+        let MutMap(_, mm1) = m1;
+        let MutMap(_, mm2) = m2;
         Map.isProperSubmapOf(deref mm1, deref mm2)
 
     ///
@@ -332,7 +334,7 @@ namespace MutMap {
     /// The function `f` must be pure.
     ///
     pub def findLeft(f: (k, v) -> Bool, m: MutMap[k, v, r]): Option[(k, v)] \ Read(r) =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.findLeft(f, deref mm)
 
     ///
@@ -341,7 +343,7 @@ namespace MutMap {
     /// The function `f` must be pure.
     ///
     pub def findRight(f: (k, v) -> Bool, m: MutMap[k, v, r]): Option[(k, v)] \ Read(r) =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.findRight(f, deref mm)
 
     ///
@@ -357,9 +359,9 @@ namespace MutMap {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
-    pub def mapWithKey(r1: Region[r1], f: (k, v1) -> v2 \ ef, m: MutMap[k, v1, r]): MutMap[k, v2, r1] \ { ef, Read(r), Write(r1) } =
-        let MutMap(mm) = m;
-        MutMap(ref Map.mapWithKey(f, deref mm) @ r1)
+    pub def mapWithKey(rc: Region[r1], f: (k, v1) -> v2 \ ef, m: MutMap[k, v1, r]): MutMap[k, v2, r1] \ { ef, Read(r), Write(r1) } =
+        let MutMap(_, mm) = m;
+        MutMap(rc, ref Map.mapWithKey(f, deref mm) @ rc)
 
     ///
     /// Alias for `foldLeftWithKey`.
@@ -373,7 +375,7 @@ namespace MutMap {
     /// That is, the result is of the form: `f(...f(f(i, v1), v2)..., vn)`.
     ///
     pub def foldLeft(f: (b, v) -> b \ ef, i: b, m: MutMap[k, v, r]): b \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.foldLeft(f, i, deref mm)
 
     ///
@@ -382,7 +384,7 @@ namespace MutMap {
     /// That is, the result is of the form: `f(...f(k2, f(k1, i, v1), v2)..., vn)`.
     ///
     pub def foldLeftWithKey(f: (b, k, v) -> b \ ef, i: b, m: MutMap[k, v, r]): b \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.foldLeftWithKey(f, i, deref mm)
 
     ///
@@ -399,7 +401,7 @@ namespace MutMap {
     /// That is, the result is of the form: `f(k1, v1, ...f(kn-1, vn-1, f(kn, vn, s)))`.
     ///
     pub def foldRightWithKey(f: (k, v, b) -> b \ ef, s: b, m: MutMap[k, v, r]): b \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.foldRightWithKey(f, s, deref mm)
 
     ///
@@ -418,7 +420,7 @@ namespace MutMap {
     /// A `foldRightWithKeyCont` allows early termination by not calling the continuation.
     ///
     pub def foldRightWithKeyCont(f: (k, v, Unit -> b \ ef) -> b \ ef, z: b, m: MutMap[k, v, r]): b \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.foldRightWithKeyCont(f, z, deref mm)
 
     ///
@@ -429,7 +431,7 @@ namespace MutMap {
     /// Returns `None` if `m` is the empty map.
     ///
     pub def reduceLeft(f: (v, v) -> v \ ef, m: MutMap[k, v, r]): Option[v] \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.reduceLeft(f, deref mm)
 
     ///
@@ -440,7 +442,7 @@ namespace MutMap {
     /// Returns `None` if `m` is the empty map.
     ///
     pub def reduceLeftWithKey(f: (k, v, k, v) -> (k, v) \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.reduceLeftWithKey(f, deref mm)
 
     ///
@@ -451,7 +453,7 @@ namespace MutMap {
     /// Returns `None` if `m` is the empty map.
     ///
     pub def reduceRight(f: (v, v) -> v \ ef, m: MutMap[k, v, r]): Option[v] \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.reduceRight(f, deref mm)
 
     ///
@@ -462,7 +464,7 @@ namespace MutMap {
     /// Returns `None` if `m` is the empty map.
     ///
     pub def reduceRightWithKey(f: (k, v, k, v) -> (k, v) \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.reduceRightWithKey(f, deref mm)
 
     ///
@@ -471,21 +473,21 @@ namespace MutMap {
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
     pub def count(f: (k, v) -> Bool \ ef, m: MutMap[k, v, r]): Int32 \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.count(f, deref mm)
 
     ///
     /// Returns the sum of all keys in the map `m`.
     ///
     pub def sumKeys(m: MutMap[Int32, v, r]): Int32 \ Read(r) =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.sumKeys(deref mm)
 
     ///
     /// Returns the sum of all values in the map `m`.
     ///
     pub def sumValues(m: MutMap[k, Int32, r]): Int32 \ Read(r) =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.sumValues(deref mm)
 
     ///
@@ -494,21 +496,21 @@ namespace MutMap {
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
     pub def sumWith(f: (k, v) -> Int32 \ ef, m: MutMap[k, v, r]): Int32 \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.sumWith(f, deref mm)
 
     ///
     /// Returns the product of all keys in the mutable map `m`.
     ///
     pub def productKeys(m: MutMap[Int32, v, r]): Int32 \ Read(r) =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.productKeys(deref mm)
 
     ///
     /// Returns the product of all values in the mutable map `m`.
     ///
     pub def productValues(m: MutMap[k, Int32, r]): Int32 \ Read(r) =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.productValues(deref mm)
 
     ///
@@ -517,7 +519,7 @@ namespace MutMap {
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
     pub def productWith(f: (k, v) -> Int32 \ ef, m: MutMap[k, v, r]): Int32 \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.productWith(f, deref mm)
 
     ///
@@ -526,7 +528,7 @@ namespace MutMap {
     /// Returns `false` if `m` is the empty map.
     ///
     pub def exists(f: (k, v) -> Bool \ ef, m: MutMap[k, v, r]): Bool \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.exists(f, deref mm)
 
     ///
@@ -535,49 +537,49 @@ namespace MutMap {
     /// Returns `true` if `m` is the empty map.
     ///
     pub def forAll(f: (k, v) -> Bool \ ef, m: MutMap[k, v, r]): Bool \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.forAll(f, deref mm)
 
     ///
     /// Returns a shallow copy of the mutable map `m`.
     ///
-    pub def copy(r1: Region[r1], m: MutMap[k, v, r]): MutMap[k, v, r1] \ { Read(r), Write(r1) } =
-        let MutMap(mm) = m;
-        MutMap(ref (deref mm) @ r1)
+    pub def copy(rc: Region[r1], m: MutMap[k, v, r]): MutMap[k, v, r1] \ { Read(r), Write(r1) } =
+        let MutMap(_, mm) = m;
+        MutMap(rc, ref (deref mm) @ rc)
 
     ///
     /// Returns the mutable map `m` as an immutable map.
     ///
     pub def toMap(m: MutMap[k, v, r]): Map[k, v] \ Read(r) =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         deref mm
 
     ///
     /// Returns `m` as a MutDeque.
     ///
     pub def toMutDeque(r1: Region[r1], m: MutMap[k, v, r2]): MutDeque[(k, v), r1] \ { Read(r2), Write(r1) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.toMutDeque(r1, deref mm)
 
     ///
     /// Returns the mutable map `m` as a list of key-value pairs.
     ///
     pub def toList(m: MutMap[k, v, r]): List[(k, v)] \ Read(r) =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.toList(deref mm)
 
     ///
     /// Returns the mutable map `m` as a set of key-value pairs.
     ///
     pub def toSet(m: MutMap[k, v, r]): Set[(k, v)] \ Read(r) with Order[k], Order[v] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.toSet(deref mm)
 
     ///
     /// Applies `f` to all the `(key, value)` pairs in the mutable map `m`.
     ///
     pub def forEach(f: (k, v) -> Unit \ ef, m: MutMap[k, v, r]): Unit \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.forEach(f, deref mm)
 
     ///
@@ -593,21 +595,21 @@ namespace MutMap {
     /// Returns an iterator over all key-value pairs in `m`.
     ///
     pub def iterator(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[(k, v), r1 and r2, r1] \ { Write(r1), Read(r2) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.iterator(rc, deref mm) |> Iterator.map(x -> {discard deref mm; x})
 
     ///
     /// Returns an iterator over keys in `m`.
     ///
     pub def iteratorKeys(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[k, r1 and r2, r1] \ { Write(r1), Read(r2) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.iteratorKeys(rc, deref mm) |> Iterator.map(x -> {discard deref mm; x})
 
     ///
     /// Returns an iterator over values in `m`.
     ///
     pub def iteratorValues(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[v, r1 and r2, r1] \ { Write(r1), Read(r2) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.iteratorValues(rc, deref mm) |> Iterator.map(x -> {discard deref mm; x})
 
     ///
@@ -616,14 +618,14 @@ namespace MutMap {
     /// That is, the result is a list of all pairs `(k, v)` where `p(k)` returns `Equal`.
     ///
     pub def query(p: k -> Comparison \ ef, m: MutMap[k, v, r]): List[(k, v)] \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.query(p, deref mm)
 
     ///
     /// Applies `f` to all key-value pairs `(k, v)` in the mutable map `m` where `p(k)` returns `EqualTo`.
     ///
     pub def queryWith(p: k -> Comparison \ ef1, f: (k, v) -> Unit \ ef2, m: MutMap[k, v, r]): Unit \ { ef1, ef2, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.queryWith(p, f, deref mm)
 
     ///
@@ -637,7 +639,7 @@ namespace MutMap {
     /// in `m` with `sep` inserted between each element.
     ///
     pub def joinKeys(sep: String, m: MutMap[k, v, r]): String \ Read(r) with ToString[k] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.joinKeys(sep, deref mm)
 
     ///
@@ -645,7 +647,7 @@ namespace MutMap {
     /// in `m` with `sep` inserted between each element.
     ///
     pub def joinValues(sep: String, m: MutMap[k, v, r]): String \ Read(r) with ToString[v] =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.joinValues(sep, deref mm)
 
     ///
@@ -653,7 +655,7 @@ namespace MutMap {
     /// `k => v` in `m` according to `f` with `sep` inserted between each element.
     ///
     pub def joinWith(f: (k, v) -> String \ ef, sep: String, m: MutMap[k, v, r]): String \ { ef, Read(r) } =
-        let MutMap(mm) = m;
+        let MutMap(_, mm) = m;
         Map.joinWith(f, sep, deref mm)
 
 }

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -17,7 +17,9 @@
 ///
 /// The Mutable Set type.
 ///
-enum MutSet[t: Type, r: Region](Ref[Set[t], r])
+pub enum MutSet[t: Type, r: Region] {
+    case MutSet(Region[r], Ref[Set[t], r])
+}
 
 instance Newable[MutSet[t]] {
     pub def new(r: Region[r]): MutSet[t, r] \ { Write(r) } = MutSet.new(r)
@@ -44,20 +46,20 @@ namespace MutSet {
     ///
     /// Returns a fresh empty set.
     ///
-    pub def new(r: Region[r]): MutSet[a, r] \ { Write(r) } =
-        MutSet(ref Set.empty() @ r)
+    pub def new(rc: Region[r]): MutSet[a, r] \ { Write(r) } =
+        MutSet(rc, ref Set.empty() @ rc)
 
     ///
     /// Returns the singleton set containing `x`.
     ///
-    pub def singleton(r: Region[r], x: a): MutSet[a, r] \ Write(r) with Order[a] =
-        MutSet(ref Set.singleton(x) @ r)
+    pub def singleton(rc: Region[r], x: a): MutSet[a, r] \ Write(r) with Order[a] =
+        MutSet(rc, ref Set.singleton(x) @ rc)
 
     ///
     /// Adds the element `x` to the mutable set `s`.
     ///
     pub def add!(x: a, s: MutSet[a, r]): Unit \ { Read(r), Write(r) } with Order[a] =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         ms := Set.insert(x, deref ms)
 
     ///
@@ -70,21 +72,21 @@ namespace MutSet {
     /// Removes all elements from the mutable set `s`.
     ///
     pub def clear!(s: MutSet[a, r]): Unit \ { Write(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         ms := Set.empty()
 
     ///
     /// Removes the element `x` from the mutable set `s`.
     ///
     pub def remove!(x: a, s: MutSet[a, r]): Unit \ { Read(r), Write(r) } with Order[a] =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         ms := Set.remove(x, deref ms)
 
     ///
     /// Removes all elements in the collection `m` from the mutable set `s`.
     ///
     pub def removeAll!(m: m[a], s: MutSet[a, r]): Unit \ { Read(r), Write(r) } with Order[a], Foldable[m] =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         let s2 = Foldable.toSet(m);
         ms := Set.difference(deref ms, s2)
 
@@ -92,7 +94,7 @@ namespace MutSet {
     /// Removes all elements from the mutable set `s` that are not in collection `m`.
     ///
     pub def retainAll!(m: m[a], s: MutSet[a, r]): Unit \ { Read(r), Write(r) } with Order[a], Foldable[m] =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         let s2 = Foldable.toSet(m);
         ms := Set.intersection(s2, deref ms)
 
@@ -102,7 +104,7 @@ namespace MutSet {
     /// The function `f` must be pure.
     ///
     pub def refine!(f: a -> Bool, s: MutSet[a, r]): Unit \ { Read(r), Write(r) } with Order[a] =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         ms := Set.filter(f, deref ms)
 
     ///
@@ -111,28 +113,28 @@ namespace MutSet {
     /// The mutable set `s` is unchanged if the element `from` is not in it.
     ///
     pub def replace!(from: {from = a}, to: {to = a}, s: MutSet[a, r]): Unit \ { Read(r), Write(r) } with Order[a] =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         ms := Set.replace(from = from.from, to = to.to, deref ms)
 
     ///
     /// Applies the function `f` to every element in the mutable set `s`.
     ///
     pub def transform!(f: a -> a \ ef, s: MutSet[a, r]): Unit \ { ef, Read(r), Write(r) } with Order[a] =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         ms := Set.map(f, deref ms)
 
     ///
     /// Returns true if and only if `s` is the empty set.
     ///
     pub def isEmpty(s: MutSet[a, r]): Bool \ { Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.isEmpty(deref ms)
 
     ///
     /// Returns true if and only if `x` is a member of the mutable set `s`.
     ///
     pub def memberOf(x: a, s: MutSet[a, r]): Bool \ { Read(r) } with Order[a] =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.memberOf(x, deref ms)
 
     ///
@@ -141,7 +143,7 @@ namespace MutSet {
     /// Returns `None` if `s` is empty.
     ///
     pub def minimum(s: MutSet[a, r]): Option[a] \ { Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.minimum(deref ms)
 
     ///
@@ -152,7 +154,7 @@ namespace MutSet {
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
     pub def minimumBy(cmp: (a, a) -> Comparison \ ef, s: MutSet[a, r]): Option[a] \ { ef, Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.minimumBy(cmp, deref ms)
 
     ///
@@ -161,7 +163,7 @@ namespace MutSet {
     /// Returns `None` if `s` is empty.
     ///
     pub def maximum(s: MutSet[a, r]): Option[a] \ { Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.maximum(deref ms)
 
     ///
@@ -172,30 +174,30 @@ namespace MutSet {
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
     pub def maximumBy(cmp: (a, a) -> Comparison \ ef, s: MutSet[a, r]): Option[a] \ { ef, Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.maximumBy(cmp, deref ms)
 
     ///
     /// Returns the size of the mutable set `s`.
     ///
     pub def size(s: MutSet[a, r]): Int32 \ { Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.size(deref ms)
 
     ///
     /// Returns true if and only if every element in the mutable set `s1` appears in the mutable set `s2`.
     ///
     pub def isSubsetOf(s1: MutSet[a, r1], s2: MutSet[a, r2]): Bool \ { Read(r1, r2) } with Order[a] =
-        let MutSet(ms1) = s1;
-        let MutSet(ms2) = s2;
+        let MutSet(_, ms1) = s1;
+        let MutSet(_, ms2) = s2;
         Set.isSubsetOf(deref ms1, deref ms2)
 
     ///
     /// Returns true if and only if every element in the mutable set `s1` appears in the mutable set `s2` and `s1 != s2`.
     ///
     pub def isProperSubsetOf(s1: MutSet[a, r1], s2: MutSet[a, r2]): Bool \ { Read(r1, r2) } with Order[a] =
-        let MutSet(ms1) = s1;
-        let MutSet(ms2) = s2;
+        let MutSet(_, ms1) = s1;
+        let MutSet(_, ms2) = s2;
         Set.isProperSubsetOf(deref ms1, deref ms2)
 
     ///
@@ -212,7 +214,7 @@ namespace MutSet {
     /// The function `f` must be pure.
     ///
     pub def findLeft(f: a -> Bool, s: MutSet[a, r]): Option[a] \ { Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.findLeft(f, deref ms)
 
     ///
@@ -221,7 +223,7 @@ namespace MutSet {
     /// The function `f` must be pure.
     ///
     pub def findRight(f: a -> Bool, s: MutSet[a, r]): Option[a] \ { Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.findRight(f, deref ms)
 
     ///
@@ -230,7 +232,7 @@ namespace MutSet {
     /// That is, the result is of the form: `f(...f(f(i, x1), x2)..., xn)`.
     ///
     pub def foldLeft(f: (b, a) -> b \ ef, i: b, s: MutSet[a, r]): b \ { ef, Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.foldLeft(f, i, deref ms)
 
     ///
@@ -239,7 +241,7 @@ namespace MutSet {
     /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, z))...)`.
     ///
     pub def foldRight(f: (a, b) -> b \ ef, z: b, s: MutSet[a, r]): b \ { ef, Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.foldRight(f, z, deref ms)
 
     ///
@@ -249,7 +251,7 @@ namespace MutSet {
     /// A `foldRightWithCont` allows early termination by not calling the continuation.
     ///
     pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, z: b, s: MutSet[a, r]): b \ { ef, Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.foldRightWithCont(f, z, deref ms)
 
     ///
@@ -266,7 +268,7 @@ namespace MutSet {
     /// Returns `None` if `s` is the empty set.
     ///
     pub def reduceLeft(f: (a, a) -> a \ ef, s: MutSet[a, r]): Option[a] \ { ef, Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.reduceLeft(f, deref ms)
 
     ///
@@ -277,7 +279,7 @@ namespace MutSet {
     /// Returns `None` if `s` is the empty set.
     ///
     pub def reduceRight(f: (a, a) -> a \ ef, s: MutSet[a, r]): Option[a] \ { ef, Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.reduceRight(f, deref ms)
 
     ///
@@ -286,15 +288,15 @@ namespace MutSet {
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
     pub def count(f: a -> Bool \ ef, s: MutSet[a, r]): Int32 \ { ef, Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.count(f, deref ms)
 
     ///
     /// Returns the sum of all elements in the mutable set `s`.
     ///
     pub def sum(s: MutSet[Int32, r]): Int32 \ { Read(r) } =
-        let MutSet(ss) = s;
-        Set.sum(deref ss)
+        let MutSet(_, ms) = s;
+        Set.sum(deref ms)
 
     ///
     /// Returns the sum of all elements in the mutable set `s` according to the function `f`.
@@ -302,15 +304,15 @@ namespace MutSet {
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
     pub def sumWith(f: a -> Int32 \ ef, s: MutSet[a, r]): Int32 \ { ef, Read(r) } =
-        let MutSet(ss) = s;
-        Set.sumWith(f, deref ss)
+        let MutSet(_, ms) = s;
+        Set.sumWith(f, deref ms)
 
     ///
     /// Returns the product of all elements in the set `s`.
     ///
     pub def product(s: MutSet[Int32, r]): Int32 \ { Read(r) } =
-        let MutSet(ss) = s;
-        Set.product(deref ss)
+        let MutSet(_, ms) = s;
+        Set.product(deref ms)
 
     ///
     /// Returns the product of all elements in the set `s` according to the function `f`.
@@ -318,8 +320,8 @@ namespace MutSet {
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
     pub def productWith(f: a -> Int32 \ ef, s: MutSet[a, r]): Int32 \ { ef, Read(r) } =
-        let MutSet(ss) = s;
-        Set.productWith(f, deref ss)
+        let MutSet(_, ms) = s;
+        Set.productWith(f, deref ms)
 
     ///
     /// Returns `true` if and only if at least one element in the mutable set `s` satisfies the predicate function `f`.
@@ -327,7 +329,7 @@ namespace MutSet {
     /// Returns `false` if `s` is the empty set.
     ///
     pub def exists(f: a -> Bool \ ef, s: MutSet[a, r]): Bool \ { ef, Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.exists(f, deref ms)
 
     ///
@@ -336,15 +338,15 @@ namespace MutSet {
     /// Returns `true` if `s` is the empty set.
     ///
     pub def forAll(f: a -> Bool \ ef, s: MutSet[a, r]): Bool \ { ef, Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.forAll(f, deref ms)
 
     ///
     /// Returns a shallow copy of the mutable set `s`.
     ///
     pub def copy(r1: Region[r1], s: MutSet[a, r]): MutSet[a, r1] \ { Read(r), Write(r1) } =
-        let MutSet(ms) = s;
-        MutSet(ref (deref ms) @ r1)
+        let MutSet(_, ms) = s;
+        MutSet(r1, ref (deref ms) @ r1)
 
     ///
     /// Returns a pair of mutable sets `(s1, s2)` such that:
@@ -355,22 +357,22 @@ namespace MutSet {
     /// The function `f` must be pure.
     ///
     pub def partition(r1: Region[r1], r2: Region[r2], f: a -> Bool, s: MutSet[a, r]): (MutSet[a, r1], MutSet[a, r2]) \ { Read(r), Write(r1), Write(r2) } with Order[a] =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         let (ys, zs) = Set.partition(f, deref ms);
-        (MutSet(ref ys @ r1), MutSet(ref zs @ r2))
+        (MutSet(r1, ref ys @ r1), MutSet(r2, ref zs @ r2))
 
     ///
     /// Returns the mutable set `s` as an immutable set.
     ///
     pub def toSet(s: MutSet[a, r]): Set[a] \ { Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         deref ms
 
     ///
     /// Returns the mutable set `s` as a list.
     ///
     pub def toList(s: MutSet[a, r]): List[a] \ { Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.toList(deref ms)
 
     ///
@@ -380,21 +382,21 @@ namespace MutSet {
     /// make any guarantees about which mapping will be in the resulting map.
     ///
     pub def toMap(s: MutSet[(a, b), r]): Map[a, b] \ { Read(r) } with Order[a] =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.toMap(deref ms)
 
     ///
     /// Returns the mutable set `s` as a MutDeque.
     ///
     pub def toMutDeque(r1: Region[r1], s: MutSet[a, r2]): MutDeque[a, r1] \ { Read(r2), Write(r1) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.toMutDeque(r1, deref ms)
 
     ///
     /// Applies `f` to every element of the mutable set `s`.
     ///
     pub def forEach(f: a -> Unit \ ef, s: MutSet[a, r]): Unit \ { ef, Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.forEach(f, deref ms)
 
     ///
@@ -409,7 +411,7 @@ namespace MutSet {
     /// Returns an iterator over `s`.
     ///
     pub def iterator(rc: Region[r1], s: MutSet[a, r2]): Iterator[a, r1 and r2, r1] \ { Write(r1), Read(r2) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.iterator(rc, deref ms) |> Iterator.map(x -> {discard deref ms; x})
 
     ///
@@ -429,7 +431,7 @@ namespace MutSet {
     /// of each element in `s` with `sep` inserted between each element.
     ///
     pub def join(sep: String, s: MutSet[a, r]): String \ { Read(r) } with ToString[a] =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.join(sep, deref ms)
 
     ///
@@ -437,7 +439,7 @@ namespace MutSet {
     /// of each element in `s` according to `f` with `sep` inserted between each element.
     ///
     pub def joinWith(f: a -> String \ ef, sep: String, s: MutSet[a, r]): String \ { ef, Read(r) } =
-        let MutSet(ms) = s;
+        let MutSet(_, ms) = s;
         Set.joinWith(f, sep, deref ms)
 
 }

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -560,8 +560,8 @@ namespace Set {
     ///
     /// Returns the set `s` as a `MutSet`.
     ///
-    pub def toMutSet(r: Region[r], s: Set[a]): MutSet[a, r] \ Write(r) =
-        MutSet.MutSet(ref s @ r)
+    pub def toMutSet(rc: Region[r], s: Set[a]): MutSet[a, r] \ Write(r) =
+        MutSet.MutSet(rc, ref s @ rc)
 
     ///
     /// Applies `f` to every element of `s`.

--- a/main/test/ca/uwaterloo/flix/library/TestMutMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutMap.flix
@@ -21,21 +21,21 @@ namespace TestMutMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def toString01(): Bool = region r {
-        let m: MutMap[Int32, Int32, r] = new MutMap(r);
+    def toString01(): Bool = region rc {
+        let m: MutMap[Int32, Int32, _] = new MutMap(rc);
         MutMap.toString(m) == "MutMap#{}"
     }
 
     @test
-    def toString02(): Bool = region r {
-        let m = new MutList(r);
+    def toString02(): Bool = region rc {
+        let m = new MutList(rc);
         MutMap.put!(1, 101, m);
         MutMap.toString(m) == "MutMap#{1 => 101}"
     }
 
     @test
-    def toString03(): Bool = region r {
-        let m = new MutMap(r);
+    def toString03(): Bool = region rc {
+        let m = new MutMap(rc);
         MutMap.put!(1, 101, m);
         MutMap.put!(2, 102, m);
         MutMap.put!(3, 103, m);
@@ -49,53 +49,53 @@ namespace TestMutMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def sameElements01(): Bool = region r {
-        let m1 = new MutMap(r): MutMap[Int32, Int32, _];
-        let m2 = new MutMap(r): MutMap[Int32, Int32, _];
+    def sameElements01(): Bool = region rc {
+        let m1 = new MutMap(rc): MutMap[Int32, Int32, _];
+        let m2 = new MutMap(rc): MutMap[Int32, Int32, _];
         MutMap.sameElements(m1, m2)
     }
 
     @test
-    def sameElements02(): Bool = region r {
-        let m = new MutMap(r);
+    def sameElements02(): Bool = region rc {
+        let m = new MutMap(rc);
         MutMap.put!(1, "a", m);
 
-        let m2 = new MutMap(r);
+        let m2 = new MutMap(rc);
         MutMap.put!(1, "a", m2);
 
         MutMap.sameElements(m, m2)
     }
 
     @test
-    def sameElements03(): Bool = region r {
-        let m = new MutMap(r);
+    def sameElements03(): Bool = region rc {
+        let m = new MutMap(rc);
         MutMap.put!(1, "a", m);
         MutMap.put!(1, "b", m);
 
-        let m2 = new MutMap(r);
+        let m2 = new MutMap(rc);
         MutMap.put!(1, "a", m2);
 
         not MutMap.sameElements(m, m2)
     }
 
     @test
-    def sameElements04(): Bool = region r {
-        let m = new MutMap(r);
+    def sameElements04(): Bool = region rc {
+        let m = new MutMap(rc);
         MutMap.put!(1, "a", m);
         MutMap.put!(2, "b", m);
 
-        let m2 = new MutMap(r);
+        let m2 = new MutMap(rc);
         MutMap.put!(1, "a", m2);
 
         not MutMap.sameElements(m, m2)
     }
 
     @test
-    def sameElements05(): Bool = region r {
-        let m = new MutMap(r);
+    def sameElements05(): Bool = region rc {
+        let m = new MutMap(rc);
         MutMap.put!(1, "a", m);
 
-        let m2 = new MutMap(r);
+        let m2 = new MutMap(rc);
         MutMap.put!(1, "a", m2);
         MutMap.put!(2, "b", m2);
 
@@ -103,13 +103,13 @@ namespace TestMutMap {
     }
 
     @test
-    def sameElements06(): Bool = region r {
-        let m = new MutMap(r);
+    def sameElements06(): Bool = region rc {
+        let m = new MutMap(rc);
         MutMap.put!(2, "b", m);
         MutMap.put!(3, "c", m);
         MutMap.put!(1, "a", m);
 
-        let m2 = new MutMap(r);
+        let m2 = new MutMap(rc);
         MutMap.put!(1, "a", m2);
         MutMap.put!(2, "b", m2);
         MutMap.put!(3, "c", m2);
@@ -122,17 +122,17 @@ namespace TestMutMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def merge01(): Bool = region r {
-        let m1 = new MutMap(r): MutMap[Int32, Int32, _];
-        let m2 = new MutMap(r): MutMap[Int32, Int32, _];
+    def merge01(): Bool = region rc {
+        let m1 = new MutMap(rc): MutMap[Int32, Int32, _];
+        let m2 = new MutMap(rc): MutMap[Int32, Int32, _];
         MutMap.mergeWithKey!((_, v, _) -> v, m1, m2);
         MutMap.isEmpty(m2)
     }
 
     @test
-    def merge02(): Bool = region r {
-        let m1 = new MutMap(r);
-        let m2 = new MutMap(r);
+    def merge02(): Bool = region rc {
+        let m1 = new MutMap(rc);
+        let m2 = new MutMap(rc);
         MutMap.put!(1, 0, m1);
         MutMap.put!(2, 0, m2);
         MutMap.mergeWithKey!((_, v, _) -> v, m1, m2);
@@ -145,37 +145,37 @@ namespace TestMutMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def sumValues01(): Bool = region r {
-        new MutMap(r) |> MutMap.sumValues == 0
+    def sumValues01(): Bool = region rc {
+        new MutMap(rc) |> MutMap.sumValues == 0
     }
 
     @test
-    def sumValues02(): Bool = region r {
-        MutMap(ref Map#{1 => 1}) |>
+    def sumValues02(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1}) |>
             MutMap.sumValues == 1
     }
 
     @test
-    def sumValues03(): Bool = region r {
-        MutMap(ref Map#{1 => 1, 2 => 2, 3 => 3}) |>
+    def sumValues03(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1, 2 => 2, 3 => 3}) |>
             MutMap.sumValues == 6
     }
 
     @test
-    def sumValues04(): Bool = region r {
-        MutMap(ref Map#{1 => 1, 2 => 2, 3 => 3, -3 => -3}) |>
+    def sumValues04(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1, 2 => 2, 3 => 3, -3 => -3}) |>
             MutMap.sumValues == 3
     }
 
     @test
-    def sumValues05(): Bool = region r {
-        MutMap(ref Map#{-1 => -1, -2 => -2, -3 => -3, -4 => -4}) |>
+    def sumValues05(): Bool = region rc {
+        Map.toMutMap(rc, Map#{-1 => -1, -2 => -2, -3 => -3, -4 => -4}) |>
             MutMap.sumValues == -10
     }
 
     @test
-    def sumValues06(): Bool = region r {
-        MutMap(ref Map#{10 => 10, -10 => -10}) |>
+    def sumValues06(): Bool = region rc {
+        Map.toMutMap(rc, Map#{10 => 10, -10 => -10}) |>
             MutMap.sumValues == 0
     }
 
@@ -185,37 +185,37 @@ namespace TestMutMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def sumKeys01(): Bool = region r {
-        new MutMap(r) |> MutMap.sumKeys == 0
+    def sumKeys01(): Bool = region rc {
+        new MutMap(rc) |> MutMap.sumKeys == 0
     }
 
     @test
-    def sumKeys02(): Bool = region r {
-        MutMap(ref Map#{1 => 1}) |>
+    def sumKeys02(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1}) |>
             MutMap.sumKeys == 1
     }
 
     @test
-    def sumKeys03(): Bool = region r {
-        MutMap(ref Map#{1 => 1, 2 => 2, 3 => 3}) |>
+    def sumKeys03(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1, 2 => 2, 3 => 3}) |>
             MutMap.sumKeys == 6
     }
 
     @test
-    def sumKeys04(): Bool = region r {
-        MutMap(ref Map#{1 => 1, 2 => 2, 3 => 3, -3 => -3}) |>
+    def sumKeys04(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1, 2 => 2, 3 => 3, -3 => -3}) |>
             MutMap.sumKeys == 3
     }
 
     @test
-    def sumKeys05(): Bool = region r {
-        MutMap(ref Map#{-1 => -1, -2 => -2, -5 => -3, -4 => -4}) |>
+    def sumKeys05(): Bool = region rc {
+        Map.toMutMap(rc, Map#{-1 => -1, -2 => -2, -5 => -3, -4 => -4}) |>
             MutMap.sumKeys == -12
     }
 
     @test
-    def sumKeys06(): Bool = region r {
-        MutMap(ref Map#{10 => 10, -10 => -10}) |>
+    def sumKeys06(): Bool = region rc {
+        Map.toMutMap(rc, Map#{10 => 10, -10 => -10}) |>
             MutMap.sumKeys == 0
     }
 
@@ -225,37 +225,37 @@ namespace TestMutMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def sumWith01(): Bool = region r {
-        new MutMap(r) |> MutMap.sumWith((k, v) -> k + v) == 0
+    def sumWith01(): Bool = region rc {
+        new MutMap(rc) |> MutMap.sumWith((k, v) -> k + v) == 0
     }
 
     @test
-    def sumWith02(): Bool = region r {
-        MutMap(ref Map#{1 => 1}) |>
+    def sumWith02(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1}) |>
             MutMap.sumWith((k, v) -> k + v) == 2
     }
 
     @test
-    def sumWith03(): Bool = region r {
-        MutMap(ref Map#{1 => 1, 2 => 2, 3 => 3}) |>
+    def sumWith03(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1, 2 => 2, 3 => 3}) |>
             MutMap.sumWith((k, v) -> k + v) == 12
     }
 
     @test
-    def sumWith04(): Bool = region r {
-        MutMap(ref Map#{1 => 1, 2 => 2, 3 => 3, -3 => -3}) |>
+    def sumWith04(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1, 2 => 2, 3 => 3, -3 => -3}) |>
             MutMap.sumWith((k, v) -> k + v) == 6
     }
 
     @test
-    def sumWith05(): Bool = region r {
-        MutMap(ref Map#{-1 => -1, -2 => -2, -3 => -3, -4 => -4}) |>
+    def sumWith05(): Bool = region rc {
+        Map.toMutMap(rc, Map#{-1 => -1, -2 => -2, -3 => -3, -4 => -4}) |>
             MutMap.sumWith((k, v) -> k + v) == -20
     }
 
     @test
-    def sumWith06(): Bool = region r {
-        MutMap(ref Map#{10 => 10, -10 => -10}) |>
+    def sumWith06(): Bool = region rc {
+        Map.toMutMap(rc, Map#{10 => 10, -10 => -10}) |>
             MutMap.sumWith((k, v) -> k + v) == 0
     }
 
@@ -265,37 +265,37 @@ namespace TestMutMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def productValues01(): Bool = region r {
-        new MutMap(r) |> MutMap.productValues == 1
+    def productValues01(): Bool = region rc {
+        new MutMap(rc) |> MutMap.productValues == 1
     }
 
     @test
-    def productValues02(): Bool = region r {
-        MutMap(ref Map#{1 => 1}) |>
+    def productValues02(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1}) |>
             MutMap.productValues == 1
     }
 
     @test
-    def productValues03(): Bool = region r {
-        MutMap(ref Map#{1 => 1, 2 => 2, 3 => 3}) |>
+    def productValues03(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1, 2 => 2, 3 => 3}) |>
             MutMap.productValues == 6
     }
 
     @test
-    def productValues04(): Bool = region r {
-        MutMap(ref Map#{1 => 1, 2 => 2, 3 => 3, -3 => -3}) |>
+    def productValues04(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1, 2 => 2, 3 => 3, -3 => -3}) |>
             MutMap.productValues == -18
     }
 
     @test
-    def productValues05(): Bool = region r {
-        MutMap(ref Map#{-1 => -1, -2 => -2, -5 => -3, -4 => -4}) |>
+    def productValues05(): Bool = region rc {
+        Map.toMutMap(rc, Map#{-1 => -1, -2 => -2, -5 => -3, -4 => -4}) |>
             MutMap.productValues == 24
     }
 
     @test
-    def productValues06(): Bool = region r {
-        MutMap(ref Map#{10 => 10, -10 => -10}) |>
+    def productValues06(): Bool = region rc {
+        Map.toMutMap(rc, Map#{10 => 10, -10 => -10}) |>
             MutMap.productValues == -100
     }
 
@@ -305,37 +305,37 @@ namespace TestMutMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def productKeys01(): Bool = region r {
-        new MutMap(r) |> MutMap.productValues == 1
+    def productKeys01(): Bool = region rc {
+        new MutMap(rc) |> MutMap.productValues == 1
     }
 
     @test
-    def productKeys02(): Bool = region r {
-        MutMap(ref Map#{1 => 1}) |>
+    def productKeys02(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1}) |>
             MutMap.productKeys == 1
     }
 
     @test
-    def productKeys03(): Bool = region r {
-        MutMap(ref Map#{1 => 1, 2 => 2, 3 => 3}) |>
+    def productKeys03(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1, 2 => 2, 3 => 3}) |>
             MutMap.productKeys == 6
     }
 
     @test
-    def productKeys04(): Bool = region r {
-        MutMap(ref Map#{1 => 1, 2 => 2, 3 => 3, -3 => -3}) |>
+    def productKeys04(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1, 2 => 2, 3 => 3, -3 => -3}) |>
             MutMap.productKeys == -18
     }
 
     @test
-    def productKeys05(): Bool = region r {
-        MutMap(ref Map#{-1 => -1, -2 => -2, -5 => -3, -4 => -4}) |>
+    def productKeys05(): Bool = region rc {
+        Map.toMutMap(rc, Map#{-1 => -1, -2 => -2, -5 => -3, -4 => -4}) |>
             MutMap.productKeys == 40
     }
 
     @test
-    def productKeys06(): Bool = region r {
-        MutMap(ref Map#{10 => 10, -10 => -10}) |>
+    def productKeys06(): Bool = region rc {
+        Map.toMutMap(rc, Map#{10 => 10, -10 => -10}) |>
             MutMap.productKeys == -100
     }
 
@@ -345,37 +345,37 @@ namespace TestMutMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def productWith01(): Bool = region r {
-        new MutMap(r) |> MutMap.productWith((k, v) -> k + v) == 1
+    def productWith01(): Bool = region rc {
+        new MutMap(rc) |> MutMap.productWith((k, v) -> k + v) == 1
     }
 
     @test
-    def productWith02(): Bool = region r {
-        MutMap(ref Map#{1 => 1}) |>
+    def productWith02(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1}) |>
             MutMap.productWith((k, v) -> k + v) == 2
     }
 
     @test
-    def productWith03(): Bool = region r {
-        MutMap(ref Map#{1 => 1, 2 => 2, 3 => 3}) |>
+    def productWith03(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1, 2 => 2, 3 => 3}) |>
             MutMap.productWith((k, v) -> k + v) == 48
     }
 
     @test
-    def productWith04(): Bool = region r {
-        MutMap(ref Map#{1 => 1, 2 => 2, 3 => 3, -3 => -3}) |>
+    def productWith04(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1, 2 => 2, 3 => 3, -3 => -3}) |>
             MutMap.productWith((k, v) -> k + v) == -288
     }
 
     @test
-    def productWith05(): Bool = region r {
-        MutMap(ref Map#{-1 => -1, -2 => -2, -3 => -3, -4 => -4}) |>
+    def productWith05(): Bool = region rc {
+        Map.toMutMap(rc, Map#{-1 => -1, -2 => -2, -3 => -3, -4 => -4}) |>
             MutMap.productWith((k, v) -> k + v) == 384
     }
 
     @test
-    def productWith06(): Bool = region r {
-        MutMap(ref Map#{10 => 10, -10 => -10}) |>
+    def productWith06(): Bool = region rc {
+        Map.toMutMap(rc, Map#{10 => 10, -10 => -10}) |>
             MutMap.productWith((k, v) -> k + v) == -400
     }
 
@@ -385,23 +385,23 @@ namespace TestMutMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def joinKeys01(): Bool = region r {
-        new MutMap(r): MutMap[Int32, Int32, _] |> MutMap.joinKeys(",") == ""
+    def joinKeys01(): Bool = region rc {
+        new MutMap(rc): MutMap[Int32, Int32, _] |> MutMap.joinKeys(",") == ""
     }
 
     @test
-    def joinKeys02(): Bool = region r {
-        MutMap(ref Map#{1 => 1}) |> MutMap.joinKeys(",") == "1"
+    def joinKeys02(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1}) |> MutMap.joinKeys(",") == "1"
     }
 
     @test
-    def joinKeys03(): Bool = region r {
-        MutMap(ref Map#{0 => 1, 1 => 2, 2 => 2}) |> MutMap.joinKeys(",") == "0,1,2"
+    def joinKeys03(): Bool = region rc {
+        Map.toMutMap(rc, Map#{0 => 1, 1 => 2, 2 => 2}) |> MutMap.joinKeys(",") == "0,1,2"
     }
 
     @test
-    def joinKeys04(): Bool = region r {
-        MutMap(ref Map#{"0" => 1, "1" => 2, "2" => 2}) |> MutMap.joinKeys(",") == "0,1,2"
+    def joinKeys04(): Bool = region rc {
+        Map.toMutMap(rc, Map#{"0" => 1, "1" => 2, "2" => 2}) |> MutMap.joinKeys(",") == "0,1,2"
     }
 
 
@@ -410,23 +410,23 @@ namespace TestMutMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def joinValues01(): Bool = region r {
-        new MutMap(r): MutMap[Int32, Int32, _] |> MutMap.joinValues(",") == ""
+    def joinValues01(): Bool = region rc {
+        new MutMap(rc): MutMap[Int32, Int32, _] |> MutMap.joinValues(",") == ""
     }
 
     @test
-    def joinValues02(): Bool = region r {
-        MutMap(ref Map#{1 => 1}) |> MutMap.joinValues(",") == "1"
+    def joinValues02(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1}) |> MutMap.joinValues(",") == "1"
     }
 
     @test
-    def joinValues03(): Bool = region r {
-        MutMap(ref Map#{0 => 1, 1 => 2, 2 => 2}) |> MutMap.joinValues(",") == "1,2,2"
+    def joinValues03(): Bool = region rc {
+        Map.toMutMap(rc, Map#{0 => 1, 1 => 2, 2 => 2}) |> MutMap.joinValues(",") == "1,2,2"
     }
 
     @test
-    def joinValues04(): Bool = region r {
-        MutMap(ref Map#{0 => "1", 1 => "2", 2 => "2"}) |> MutMap.joinValues(",") == "1,2,2"
+    def joinValues04(): Bool = region rc {
+        Map.toMutMap(rc, Map#{0 => "1", 1 => "2", 2 => "2"}) |> MutMap.joinValues(",") == "1,2,2"
     }
 
 
@@ -435,26 +435,26 @@ namespace TestMutMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def joinWith01(): Bool = region r {
-        new MutMap(r): MutMap[Int32, Int32, _] |>
+    def joinWith01(): Bool = region rc {
+        new MutMap(rc): MutMap[Int32, Int32, _] |>
             MutMap.joinWith((k, v) -> "${k} => ${v}", ",") == ""
     }
 
     @test
-    def joinWith02(): Bool = region r {
-        MutMap(ref Map#{1 => 1}) |>
+    def joinWith02(): Bool = region rc {
+        Map.toMutMap(rc, Map#{1 => 1}) |>
             MutMap.joinWith((k, v) -> "${k} => ${v}", ", ") == "1 => 1"
     }
 
     @test
-    def joinWith03(): Bool = region r {
-        MutMap(ref Map#{0 => 1, 1 => 2, 2 => 2}) |>
+    def joinWith03(): Bool = region rc {
+        Map.toMutMap(rc, Map#{0 => 1, 1 => 2, 2 => 2}) |>
             MutMap.joinWith((k, v) -> "${k} => ${v}", ", ") == "0 => 1, 1 => 2, 2 => 2"
     }
 
     @test
-    def joinWith04(): Bool = region r {
-        MutMap(ref Map#{0 => "1", 1 => "2", 2 => "2"}) |>
+    def joinWith04(): Bool = region rc {
+        Map.toMutMap(rc, Map#{0 => "1", 1 => "2", 2 => "2"}) |>
             MutMap.joinWith((k, v) -> "${k} => ${v}", ", ") == "0 => 1, 1 => 2, 2 => 2"
     }
 
@@ -464,32 +464,32 @@ namespace TestMutMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def toMutDeque01(): Bool = region r {
-        let m: MutMap[Int32, Int32, _] = new MutMap(r);
-        let d1 = MutMap.toMutDeque(r, m);
+    def toMutDeque01(): Bool = region rc {
+        let m: MutMap[Int32, Int32, _] = new MutMap(rc);
+        let d1 = MutMap.toMutDeque(rc, m);
 
-        let d2 = new MutDeque(r);
+        let d2 = new MutDeque(rc);
 
         d1 `MutDeque.sameElements` d2
     }
 
     @test
-    def toMutDeque02(): Bool = region r {
-        let m = MutMap(ref Map#{1 => 2});
-        let d1 = MutMap.toMutDeque(r, m);
+    def toMutDeque02(): Bool = region rc {
+        let m = Map.toMutMap(rc, Map#{1 => 2});
+        let d1 = MutMap.toMutDeque(rc, m);
 
-        let d2 = new MutDeque(r);
+        let d2 = new MutDeque(rc);
         MutDeque.pushBack((1, 2), d2);
 
         d1 `MutDeque.sameElements` d2
     }
 
     @test
-    def toMutDeque03(): Bool = region r {
-        let m = MutMap(ref Map#{1 => 2, 3 => 4, 5 => 6});
-        let d1 = MutMap.toMutDeque(r, m);
+    def toMutDeque03(): Bool = region rc {
+        let m = Map.toMutMap(rc, Map#{1 => 2, 3 => 4, 5 => 6});
+        let d1 = MutMap.toMutDeque(rc, m);
 
-        let d2 = new MutDeque(r);
+        let d2 = new MutDeque(rc);
         MutDeque.pushBack((3, 4), d2);
         MutDeque.pushBack((5, 6), d2);
         MutDeque.pushFront((1, 2), d2);
@@ -498,11 +498,11 @@ namespace TestMutMap {
     }
 
     @test
-    def toMutDeque04(): Bool = region r {
-        let m = MutMap(ref Map#{1 => 'a', 2 => 'b', 3 => 'c'});
-        let d1 = MutMap.toMutDeque(r, m);
+    def toMutDeque04(): Bool = region rc {
+        let m = Map.toMutMap(rc, Map#{1 => 'a', 2 => 'b', 3 => 'c'});
+        let d1 = MutMap.toMutDeque(rc, m);
 
-        let d2 = new MutDeque(r);
+        let d2 = new MutDeque(rc);
         MutDeque.pushFront((3, 'c'), d2);
         MutDeque.pushFront((2, 'b'), d2);
         MutDeque.pushFront((1, 'a'), d2);
@@ -515,26 +515,26 @@ namespace TestMutMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def forEach01(): Bool = region r {
-        let m = new MutMap(r);
-        let ri = ref 21 @ r;
+    def forEach01(): Bool = region rc {
+        let m = new MutMap(rc);
+        let ri = ref 21 @ rc;
         MutMap.forEach((k, v) -> ri := k+v, m);
         21 == deref ri
     }
 
     @test
-    def forEach02(): Bool = region r {
-        let m = new MutMap(r);
-        let ri = ref 21 @ r;
+    def forEach02(): Bool = region rc {
+        let m = new MutMap(rc);
+        let ri = ref 21 @ rc;
         MutMap.put!(0, 100, m);
         MutMap.forEach((k, v) -> ri := k+v, m);
         100 == deref ri
     }
 
     @test
-    def forEach03(): Bool = region r {
-        let m = new MutMap(r);
-        let ri = ref 21 @ r;
+    def forEach03(): Bool = region rc {
+        let m = new MutMap(rc);
+        let ri = ref 21 @ rc;
         MutMap.put!(0, 100, m);
         MutMap.put!(1, 101, m);
         MutMap.put!(2, 102, m);
@@ -547,26 +547,26 @@ namespace TestMutMap {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def forEachWithIndex01(): Bool = region r {
-        let m = new MutMap(r);
-        let ri = ref 21 @ r;
+    def forEachWithIndex01(): Bool = region rc {
+        let m = new MutMap(rc);
+        let ri = ref 21 @ rc;
         MutMap.forEachWithIndex((i, _, _) -> ri := i, m);
         21 == deref ri
     }
 
     @test
-    def forEachWithIndex02(): Bool = region r {
-        let m = new MutMap(r);
-        let ri = ref 21 @ r;
+    def forEachWithIndex02(): Bool = region rc {
+        let m = new MutMap(rc);
+        let ri = ref 21 @ rc;
         MutMap.put!(0, 100, m);
         MutMap.forEachWithIndex((i, _, _) -> ri := i, m);
         0 == deref ri
     }
 
     @test
-    def forEachWithIndex03(): Bool = region r {
-        let m = new MutMap(r);
-        let ri = ref 21 @ r;
+    def forEachWithIndex03(): Bool = region rc {
+        let m = new MutMap(rc);
+        let ri = ref 21 @ rc;
         MutMap.put!(0, 100, m);
         MutMap.put!(1, 101, m);
         MutMap.put!(2, 102, m);

--- a/main/test/ca/uwaterloo/flix/library/TestMutSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutSet.flix
@@ -21,21 +21,21 @@ namespace TestMutSet {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def toString01(): Bool = region r {
-        let s: MutSet[Int32, r] = new MutSet(r);
+    def toString01(): Bool = region rc {
+        let s: MutSet[Int32, rc] = new MutSet(rc);
         MutSet.toString(s) == "MutSet#{}"
     }
 
     @test
-    def toString02(): Bool = region r {
-        let s = new MutSet(r);
+    def toString02(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.toString(s) == "MutSet#{1}"
     }
 
     @test
-    def toString03(): Bool = region r {
-        let s = new MutSet(r);
+    def toString03(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.add!(2, s);
         MutSet.add!(3, s);
@@ -49,42 +49,42 @@ namespace TestMutSet {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def sameElements01(): Bool = region r {
-        let s1 = new MutSet(r): MutSet[Int32, _];
-        let s2 = new MutSet(r): MutSet[Int32, _];
+    def sameElements01(): Bool = region rc {
+        let s1 = new MutSet(rc): MutSet[Int32, _];
+        let s2 = new MutSet(rc): MutSet[Int32, _];
         MutSet.sameElements(s1, s2)
     }
 
     @test
-    def sameElements02(): Bool = region r {
-        let s1 = new MutSet(r);
+    def sameElements02(): Bool = region rc {
+        let s1 = new MutSet(rc);
         MutSet.add!(1, s1);
 
-        let s2 = new MutSet(r);
+        let s2 = new MutSet(rc);
         MutSet.add!(1, s2);
 
         MutSet.sameElements(s1, s2)
     }
 
     @test
-    def sameElements03(): Bool = region r {
-        let s1 = new MutSet(r);
+    def sameElements03(): Bool = region rc {
+        let s1 = new MutSet(rc);
         MutSet.add!(1, s1);
 
-        let s2 = new MutSet(r);
+        let s2 = new MutSet(rc);
         MutSet.add!(2, s2);
 
         not MutSet.sameElements(s1, s2)
     }
 
     @test
-    def sameElements04(): Bool = region r {
-        let s1 = new MutSet(r);
+    def sameElements04(): Bool = region rc {
+        let s1 = new MutSet(rc);
         MutSet.add!(1, s1);
         MutSet.add!(2, s1);
         MutSet.add!(3, s1);
 
-        let s2 = new MutSet(r);
+        let s2 = new MutSet(rc);
         MutSet.add!(2, s2);
         MutSet.add!(3, s2);
         MutSet.add!(1, s2);
@@ -93,13 +93,13 @@ namespace TestMutSet {
     }
 
     @test
-    def sameElements05(): Bool = region r {
-        let s1 = new MutSet(r);
+    def sameElements05(): Bool = region rc {
+        let s1 = new MutSet(rc);
         MutSet.add!("a", s1);
         MutSet.add!("b", s1);
         MutSet.add!("c", s1);
 
-        let s2 = new MutSet(r);
+        let s2 = new MutSet(rc);
         MutSet.add!("c", s2);
         MutSet.add!("a", s2);
         MutSet.add!("b", s2);
@@ -108,13 +108,13 @@ namespace TestMutSet {
     }
 
     @test
-    def setSameElements06(): Bool = region r {
-        let s1 = new MutSet(r);
+    def setSameElements06(): Bool = region rc {
+        let s1 = new MutSet(rc);
         MutSet.add!("a", s1);
         MutSet.add!("b", s1);
         MutSet.add!("c", s1);
 
-        let s2 = new MutSet(r);
+        let s2 = new MutSet(rc);
         MutSet.add!("c", s2);
         MutSet.add!("a", s2);
 
@@ -132,17 +132,17 @@ namespace TestMutSet {
     // Thus not all tests end with a simple comparison of two sets.
 
     @test
-    def addAll01(): Bool = region r {
-        let s1 = new MutSet(r): MutSet[Int32, _];
-        let s2 = new MutSet(r): MutSet[Int32, _];
+    def addAll01(): Bool = region rc {
+        let s1 = new MutSet(rc): MutSet[Int32, _];
+        let s2 = new MutSet(rc): MutSet[Int32, _];
         MutSet.addAll!(MutSet.toSet(s1), s2);
         MutSet.isEmpty(s2)
     }
 
     @test
-    def addAll02(): Bool = region r {
-        let s1 = new MutSet(r);
-        let s2 = new MutSet(r);
+    def addAll02(): Bool = region rc {
+        let s1 = new MutSet(rc);
+        let s2 = new MutSet(rc);
         MutSet.add!(1, s1);
         MutSet.add!(1, s1);
         MutSet.addAll!(MutSet.toSet(s1), s2);
@@ -150,9 +150,9 @@ namespace TestMutSet {
     }
 
     @test
-    def addAll03(): Bool = region r {
-        let s1 = new MutSet(r);
-        let s2 = new MutSet(r);
+    def addAll03(): Bool = region rc {
+        let s1 = new MutSet(rc);
+        let s2 = new MutSet(rc);
         MutSet.add!(1, s1);
         MutSet.add!(2, s1);
         MutSet.addAll!(MutSet.toSet(s1), s2);
@@ -160,9 +160,9 @@ namespace TestMutSet {
     }
 
     @test
-    def addAll04(): Bool = region r {
-        let s1 = new MutSet(r);
-        let s2 = new MutSet(r);
+    def addAll04(): Bool = region rc {
+        let s1 = new MutSet(rc);
+        let s2 = new MutSet(rc);
         MutSet.add!(1, s1);
         MutSet.add!(2, s1);
         MutSet.add!(3, s1);
@@ -185,8 +185,8 @@ namespace TestMutSet {
     }
 
     @test
-    def addAll06(): Bool = region r {
-        let s1 = new MutSet(r);
+    def addAll06(): Bool = region rc {
+        let s1 = new MutSet(rc);
         MutSet.add!("a", s1);
         MutSet.add!("b", s1);
         MutSet.add!("c", s1);
@@ -204,20 +204,20 @@ namespace TestMutSet {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def sum01(): Bool = region r {
-        new MutSet(r) |> MutSet.sum == 0
+    def sum01(): Bool = region rc {
+        new MutSet(rc) |> MutSet.sum == 0
     }
 
     @test
-    def sum02(): Bool = region r {
-        let s = new MutSet(r);
+    def sum02(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.sum(s) == 1
     }
 
     @test
-    def sum03(): Bool = region r {
-        let s = new MutSet(r);
+    def sum03(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.add!(2, s);
         MutSet.add!(3, s);
@@ -225,8 +225,8 @@ namespace TestMutSet {
     }
 
     @test
-    def sum04(): Bool = region r {
-        let s = new MutSet(r);
+    def sum04(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.add!(2, s);
         MutSet.add!(3, s);
@@ -235,8 +235,8 @@ namespace TestMutSet {
     }
 
     @test
-    def sum05(): Bool = region r {
-        let s = new MutSet(r);
+    def sum05(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.add!(2, s);
         MutSet.add!(-3, s);
@@ -245,8 +245,8 @@ namespace TestMutSet {
     }
 
     @test
-    def sum06(): Bool = region r {
-        let s = new MutSet(r);
+    def sum06(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(10, s);
         MutSet.add!(-10, s);
         MutSet.sum(s) == 0
@@ -258,20 +258,20 @@ namespace TestMutSet {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def sumWith01(): Bool = region r {
-        new MutSet(r) |> MutSet.sumWith(x -> x + 1) == 0
+    def sumWith01(): Bool = region rc {
+        new MutSet(rc) |> MutSet.sumWith(x -> x + 1) == 0
     }
 
     @test
-    def sumWith02(): Bool = region r {
-        let s = new MutSet(r);
+    def sumWith02(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.sumWith(x -> x + 1, s) == 2
     }
 
     @test
-    def sumWith03(): Bool = region r {
-        let s = new MutSet(r);
+    def sumWith03(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.add!(2, s);
         MutSet.add!(3, s);
@@ -279,8 +279,8 @@ namespace TestMutSet {
     }
 
     @test
-    def sumWith04(): Bool = region r {
-        let s = new MutSet(r);
+    def sumWith04(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.add!(2, s);
         MutSet.add!(3, s);
@@ -289,8 +289,8 @@ namespace TestMutSet {
     }
 
     @test
-    def sumWith05(): Bool = region r {
-        let s = new MutSet(r);
+    def sumWith05(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(-1, s);
         MutSet.add!(-2, s);
         MutSet.add!(-3, s);
@@ -299,8 +299,8 @@ namespace TestMutSet {
     }
 
     @test
-    def sumWith06(): Bool = region r {
-        let s = new MutSet(r);
+    def sumWith06(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(10, s);
         MutSet.add!(-10, s);
         MutSet.sumWith(x -> x + 1, s) == 2
@@ -312,20 +312,20 @@ namespace TestMutSet {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def product01(): Bool = region r {
-        MutSet.product(new MutSet(r)) == 1
+    def product01(): Bool = region rc {
+        MutSet.product(new MutSet(rc)) == 1
     }
 
     @test
-    def product02(): Bool = region r {
-        let s = new MutSet(r);
+    def product02(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.product(s) == 1
     }
 
     @test
-    def product03(): Bool = region r {
-        let s = new MutSet(r);
+    def product03(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.add!(2, s);
         MutSet.add!(3, s);
@@ -333,8 +333,8 @@ namespace TestMutSet {
     }
 
     @test
-    def product04(): Bool = region r {
-        let s = new MutSet(r);
+    def product04(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.add!(2, s);
         MutSet.add!(3, s);
@@ -343,8 +343,8 @@ namespace TestMutSet {
     }
 
     @test
-    def product05(): Bool = region r {
-        let s = new MutSet(r);
+    def product05(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(-1, s);
         MutSet.add!(-2, s);
         MutSet.add!(-3, s);
@@ -353,8 +353,8 @@ namespace TestMutSet {
     }
 
     @test
-    def product06(): Bool = region r {
-        let s = new MutSet(r);
+    def product06(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(10, s);
         MutSet.add!(-10, s);
         MutSet.product(s) == -100
@@ -366,20 +366,20 @@ namespace TestMutSet {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def productWith01(): Bool = region r {
-        new MutSet(r) |> MutSet.productWith(x -> x + 1) == 1
+    def productWith01(): Bool = region rc {
+        new MutSet(rc) |> MutSet.productWith(x -> x + 1) == 1
     }
 
     @test
-    def productWith02(): Bool = region r {
-        let s = new MutSet(r);
+    def productWith02(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.productWith(x -> x + 1, s) == 2
     }
 
     @test
-    def productWith03(): Bool = region r {
-        let s = new MutSet(r);
+    def productWith03(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.add!(2, s);
         MutSet.add!(3, s);
@@ -387,8 +387,8 @@ namespace TestMutSet {
     }
 
     @test
-    def productWith04(): Bool = region r {
-        let s = new MutSet(r);
+    def productWith04(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.add!(2, s);
         MutSet.add!(3, s);
@@ -397,8 +397,8 @@ namespace TestMutSet {
     }
 
     @test
-    def productWith05(): Bool = region r {
-        let s = new MutSet(r);
+    def productWith05(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(-2, s);
         MutSet.add!(-3, s);
         MutSet.add!(-4, s);
@@ -407,8 +407,8 @@ namespace TestMutSet {
     }
 
     @test
-    def productWith06(): Bool = region r {
-        let s = new MutSet(r);
+    def productWith06(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(10, s);
         MutSet.add!(-10, s);
         MutSet.productWith(x -> x + 1, s) == -99
@@ -420,21 +420,21 @@ namespace TestMutSet {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def join01(): Bool = region r {
-        let s: MutSet[Int32, _] = new MutSet(r);
+    def join01(): Bool = region rc {
+        let s: MutSet[Int32, _] = new MutSet(rc);
         MutSet.join(",", s) == ""
     }
 
     @test
-    def join02(): Bool = region r {
-        let s = new MutSet(r);
+    def join02(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.join(",", s) == "1"
     }
 
     @test
-    def join03(): Bool = region r {
-        let s = new MutSet(r);
+    def join03(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.add!(2, s);
         MutSet.add!(3, s);
@@ -442,8 +442,8 @@ namespace TestMutSet {
     }
 
     @test
-    def join04(): Bool = region r {
-        let s = new MutSet(r);
+    def join04(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!("1", s);
         MutSet.add!("2", s);
         MutSet.add!("3", s);
@@ -456,28 +456,28 @@ namespace TestMutSet {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def foldRight01(): Bool = region r {
-        MutSet.foldRight((e, acc) -> (acc - e) * (e `Int32.rem` 2 + 1), 100, new MutSet(r)) == 100
+    def foldRight01(): Bool = region rc {
+        MutSet.foldRight((e, acc) -> (acc - e) * (e `Int32.rem` 2 + 1), 100, new MutSet(rc)) == 100
     }
 
     @test
-    def foldRight02(): Bool = region r {
-        let s = new MutSet(r);
+    def foldRight02(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.foldRight((e, acc) -> (acc - e) * (e `Int32.rem` 2 + 1), 100, s) == 198
     }
 
     @test
-    def foldRight03(): Bool = region r {
-        let s = new MutSet(r);
+    def foldRight03(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(2, s);
         MutSet.add!(1, s);
         MutSet.foldRight((e, acc) -> (acc - e) * (e `Int32.rem` 2 + 1), 100, s) == 194
     }
 
     @test
-    def foldRight04(): Bool = region r {
-        let s = new MutSet(r);
+    def foldRight04(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(3, s);
         MutSet.add!(2, s);
         MutSet.add!(1, s);
@@ -489,28 +489,28 @@ namespace TestMutSet {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def foldRightWithCont01(): Bool = region r {
-        MutSet.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.rem` 2 + 1), 100, new MutSet(r)) == 100
+    def foldRightWithCont01(): Bool = region rc {
+        MutSet.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.rem` 2 + 1), 100, new MutSet(rc)) == 100
     }
 
     @test
-    def foldRightWithCont02(): Bool = region r {
-        let s = new MutSet(r);
+    def foldRightWithCont02(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.rem` 2 + 1), 100, s) == 198
     }
 
     @test
-    def foldRightWithCont03(): Bool = region r {
-        let s = new MutSet(r);
+    def foldRightWithCont03(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(2, s);
         MutSet.add!(1, s);
         MutSet.foldRightWithCont((e, k) -> (k() - e) * (e `Int32.rem` 2 + 1), 100, s) == 194
     }
 
     @test
-    def foldRightWithCont04(): Bool = region r {
-        let s = new MutSet(r);
+    def foldRightWithCont04(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(3, s);
         MutSet.add!(2, s);
         MutSet.add!(1, s);
@@ -522,28 +522,28 @@ namespace TestMutSet {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def foldMap01(): Bool = region r {
-        MutSet.foldMap(x -> 2 * x, new MutSet(r): MutSet[Int32, _]) == 0
+    def foldMap01(): Bool = region rc {
+        MutSet.foldMap(x -> 2 * x, new MutSet(rc): MutSet[Int32, _]) == 0
     }
 
     @test
-    def foldMap02(): Bool = region r {
-        let s = new MutSet(r);
+    def foldMap02(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.add!(2, s);
         MutSet.foldMap(x -> 2 * x, s) == 6
     }
 
     @test
-    def foldMap03(): Bool = region r {
-        let s = new MutSet(r);
+    def foldMap03(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!("a", s);
         MutSet.foldMap(x -> if (x == "a") "b" else x, s) == "b"
     }
 
     @test
-    def foldMap04(): Bool = region r {
-        let s = new MutSet(r);
+    def foldMap04(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!("a", s);
         MutSet.add!("b", s);
         MutSet.add!("c", s);
@@ -551,8 +551,8 @@ namespace TestMutSet {
     }
 
     @test
-    def foldMap05(): Bool = region r {
-        let s = new MutSet(r);
+    def foldMap05(): Bool = region rc {
+        let s = new MutSet(rc);
         MutSet.add!(1, s);
         MutSet.add!(2, s);
         MutSet.add!(3, s);
@@ -565,32 +565,32 @@ namespace TestMutSet {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def toMutDeque01(): Bool = region r {
+    def toMutDeque01(): Bool = region rc {
         let s: Set[Int32] = Set#{};
-        let d1 = MutSet.toMutDeque(r, Set.toMutSet(r, s));
+        let d1 = MutSet.toMutDeque(rc, Set.toMutSet(rc, s));
 
-        let d2 = new MutDeque(r);
+        let d2 = new MutDeque(rc);
 
         d1 `MutDeque.sameElements` d2
     }
 
     @test
-    def toMutDeque02(): Bool = region r {
+    def toMutDeque02(): Bool = region rc {
         let s = Set#{1};
-        let d1 = MutSet.toMutDeque(r, Set.toMutSet(r, s));
+        let d1 = MutSet.toMutDeque(rc, Set.toMutSet(rc, s));
 
-        let d2 = new MutDeque(r);
+        let d2 = new MutDeque(rc);
         MutDeque.pushBack(1, d2);
 
         d1 `MutDeque.sameElements` d2
     }
 
     @test
-    def toMutDeque03(): Bool = region r {
+    def toMutDeque03(): Bool = region rc {
         let s = Set#{1, 3, 6};
-        let d1 = MutSet.toMutDeque(r, Set.toMutSet(r, s));
+        let d1 = MutSet.toMutDeque(rc, Set.toMutSet(rc, s));
 
-        let d2 = new MutDeque(r);
+        let d2 = new MutDeque(rc);
         MutDeque.pushBack(3, d2);
         MutDeque.pushBack(6, d2);
         MutDeque.pushFront(1, d2);
@@ -599,11 +599,11 @@ namespace TestMutSet {
     }
 
     @test
-    def toMutDeque04(): Bool = region r {
+    def toMutDeque04(): Bool = region rc {
         let s = Set#{7, 1, 3, 6};
-        let d1 = MutSet.toMutDeque(r, Set.toMutSet(r, s));
+        let d1 = MutSet.toMutDeque(rc, Set.toMutSet(rc, s));
 
-        let d2 = new MutDeque(r);
+        let d2 = new MutDeque(rc);
         MutDeque.pushFront(7, d2);
         MutDeque.pushFront(6, d2);
         MutDeque.pushFront(3, d2);
@@ -617,26 +617,26 @@ namespace TestMutSet {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def forEach01(): Bool = region r {
-        let s = new MutSet(r);
-        let ri = ref 21 @ r;
+    def forEach01(): Bool = region rc {
+        let s = new MutSet(rc);
+        let ri = ref 21 @ rc;
         MutSet.forEach(x -> ri := x, s);
         21 == deref ri
     }
 
     @test
-    def forEach02(): Bool = region r {
-        let s = new MutSet(r);
-        let ri = ref 21 @ r;
+    def forEach02(): Bool = region rc {
+        let s = new MutSet(rc);
+        let ri = ref 21 @ rc;
         MutSet.add!(0, s);
         MutSet.forEach(x -> ri := x, s);
         0 == deref ri
     }
 
     @test
-    def forEach03(): Bool = region r {
-        let s = new MutSet(r);
-        let ri = ref 21 @ r;
+    def forEach03(): Bool = region rc {
+        let s = new MutSet(rc);
+        let ri = ref 21 @ rc;
         MutSet.add!(0, s);
         MutSet.add!(1, s);
         MutSet.add!(2, s);
@@ -649,26 +649,26 @@ namespace TestMutSet {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def forEachWithIndex01(): Bool = region r {
-        let s = new MutSet(r);
-        let ri = ref 21 @ r;
+    def forEachWithIndex01(): Bool = region rc {
+        let s = new MutSet(rc);
+        let ri = ref 21 @ rc;
         MutSet.forEachWithIndex((i, _) -> ri := i, s);
         21 == deref ri
     }
 
     @test
-    def forEachWithIndex02(): Bool = region r {
-        let s = new MutSet(r);
-        let ri = ref 21 @ r;
+    def forEachWithIndex02(): Bool = region rc {
+        let s = new MutSet(rc);
+        let ri = ref 21 @ rc;
         MutSet.add!(100, s);
         MutSet.forEachWithIndex((i, _) -> ri := i, s);
         0 == deref ri
     }
 
     @test
-    def forEachWithIndex03(): Bool = region r {
-        let s = new MutSet(r);
-        let ri = ref 21 @ r;
+    def forEachWithIndex03(): Bool = region rc {
+        let s = new MutSet(rc);
+        let ri = ref 21 @ rc;
         MutSet.add!(100, s);
         MutSet.add!(101, s);
         MutSet.add!(102, s);


### PR DESCRIPTION
This PR adds a region into the enum for `MutSet` and `MutMap` (`MutDeque` and `MutList` carried a region already).

It also changes `TestMutSet` and `TestMutMap` to use `rc` as the region name in region blocks.