### PR TITLE
feat: add `Vector` type

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -74,6 +74,7 @@ object CompletionProvider {
   // Built-in types with type parameters
   private val BuiltinTypeNamesWithTypeParameters: List[(String, List[String])] = List(
     ("Array", List("a", "r")),
+    ("Vector", List("a")),
     ("Ref", List("a", "r")),
     ("Sender", List("t", "r")),
     ("Receiver", List("t", "r")),

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -635,6 +635,7 @@ object SemanticTokensProvider {
     case TypeConstructor.RestrictableEnum(_, _) => true
     case TypeConstructor.Native(_) => true
     case TypeConstructor.Array => true
+    case TypeConstructor.Vector => true
     case TypeConstructor.Ref => true
     case TypeConstructor.True => true
     case TypeConstructor.False => true

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -229,6 +229,16 @@ object TypeConstructor {
   }
 
   /**
+    * A type constructor that represent the type of vectors.
+    */
+  case object Vector extends TypeConstructor {
+    /**
+      * The shape of an array is `Array[t]`.
+      */
+    def kind: Kind = Kind.Star ->: Kind.Star
+  }
+
+  /**
     * A type constructor that represent the type of references.
     */
   case object Ref extends TypeConstructor {

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
@@ -163,6 +163,7 @@ object FormatType {
       case SimpleType.BigInt => true
       case SimpleType.Str => true
       case SimpleType.Array => true
+      case SimpleType.Vector => true
       case SimpleType.Ref => true
       case SimpleType.Sender => true
       case SimpleType.Receiver => true
@@ -225,6 +226,7 @@ object FormatType {
       case SimpleType.BigInt => "BigInt"
       case SimpleType.Str => "String"
       case SimpleType.Array => "Array"
+      case SimpleType.Vector => "Vector"
       case SimpleType.Ref => "Ref"
       case SimpleType.Sender => "Sender"
       case SimpleType.Receiver => "Receiver"

--- a/main/src/ca/uwaterloo/flix/language/fmt/SimpleType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/SimpleType.scala
@@ -69,6 +69,8 @@ object SimpleType {
 
   case object Array extends SimpleType
 
+  case object Vector extends SimpleType
+
   case object Ref extends SimpleType
 
   case object Sender extends SimpleType
@@ -433,6 +435,7 @@ object SimpleType {
             case _ :: _ :: _ => throw new OverAppliedType(t.loc)
           }
         case TypeConstructor.Array => mkApply(Array, t.typeArguments.map(visit))
+        case TypeConstructor.Vector => mkApply(Vector, t.typeArguments.map(visit))
         case TypeConstructor.Sender => mkApply(Sender, t.typeArguments.map(visit))
         case TypeConstructor.Receiver => mkApply(Receiver, t.typeArguments.map(visit))
         case TypeConstructor.Lazy => mkApply(Lazy, t.typeArguments.map(visit))

--- a/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Finalize.scala
@@ -411,6 +411,8 @@ object Finalize {
 
             case TypeConstructor.Array => MonoType.Array(args.head)
 
+            case TypeConstructor.Vector => MonoType.Array(args.head)
+
             case TypeConstructor.Ref => MonoType.Ref(args.head)
 
             case TypeConstructor.RegionToStar => MonoType.Region

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -1322,6 +1322,7 @@ object Namer {
     case "bigint" => true
     case "string" => true
     case "array" => true
+    case "vector" => true
     case "ref" => true
     case "pure" => true
     case "impure" => true

--- a/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
@@ -83,6 +83,8 @@ object PatternExhaustiveness {
 
     case object Array extends TyCon
 
+    case object Vector extends TyCon
+
     case class Enum(name: String, sym: EnumSym, numArgs: Int, args: List[TyCon]) extends TyCon
 
   }
@@ -570,6 +572,7 @@ object PatternExhaustiveness {
     case TyCon.Wild => 0
     case TyCon.Tuple(args) => args.size
     case TyCon.Array => 0
+    case TyCon.Vector => 0
     case TyCon.Enum(_, _, numArgs, _) => numArgs
   }
 
@@ -632,6 +635,7 @@ object PatternExhaustiveness {
     case TyCon.Wild => "_"
     case TyCon.Tuple(args) => "(" + args.foldRight("")((x, xs) => if (xs == "") prettyPrintCtor(x) + xs else prettyPrintCtor(x) + ", " + xs) + ")"
     case TyCon.Array => "Array"
+    case TyCon.Vector => "Vector"
     case TyCon.Enum(name, _, num_args, args) => if (num_args == 0) name else name + prettyPrintCtor(TyCon.Tuple(args))
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2150,7 +2150,7 @@ object Resolver {
         case "Receiver" => UnkindedType.Cst(TypeConstructor.Receiver, loc).toSuccess
         case "Lazy" => UnkindedType.Cst(TypeConstructor.Lazy, loc).toSuccess
         case "Array" => UnkindedType.Cst(TypeConstructor.Array, loc).toSuccess
-        case "Vector2" => UnkindedType.Cst(TypeConstructor.Vector, loc).toSuccess
+        case "Vector" => UnkindedType.Cst(TypeConstructor.Vector, loc).toSuccess
         case "Ref" => UnkindedType.Cst(TypeConstructor.Ref, loc).toSuccess
         case "Region" => UnkindedType.Cst(TypeConstructor.RegionToStar, loc).toSuccess
 

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -18,8 +18,6 @@
 /// A Vector data type which is fundamentally like Array but is immutable.
 ///
 
-type alias Vector[a] = Array[a, true]
-
 namespace Vector {
 
     ///
@@ -34,9 +32,9 @@ namespace Vector {
                     loop(i + 1)
                 else
                     cmp
-            } else if (i < Array.length(a)) {
+            } else if (i < length(a)) {
                 Comparison.GreaterThan
-            } else if (i < Array.length(b)) {
+            } else if (i < length(b)) {
                 Comparison.LessThan
             } else {
                 Comparison.EqualTo
@@ -101,7 +99,7 @@ namespace Vector {
     /// Retrieves the value at position `i` in the vector `v`.
     ///
     pub def get(i: Int32, v: Vector[a]): a =
-        Array.get(i, v)
+        Array.get(i, unsafe_cast v as Array[a, true])
 
     ///
     /// Optionally returns the element at position `i` in the vector `v`.
@@ -120,7 +118,8 @@ namespace Vector {
     ///
     /// Returns the length of the vector `v`.
     ///
-    pub def length(v: Vector[a]): Int32 = Array.length(v)
+    pub def length(v: Vector[a]): Int32 =
+        Array.length(unsafe_cast v as Array[a, true])
 
     ///
     /// Returns a fresh array with the elements from the vector `v` from index `b` (inclusive) until index `e` (exclusive).


### PR DESCRIPTION
This PR adds the `Vector` type and uses it in `Vector.flix`. Thus this brings us closer to a standalone `Vector` type.

This should enable us to write type class instances. 

The next steps would be to add compiler intrinsics for `Vector` operations to get rid of unsafe casts.