### PR TITLE
feat: add `toValidation` to `Result`

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -56,3 +56,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Yisrael Union](https://github.com/yisraelU)
 - [Lukas Rønn](https://github.com/LukasRonn)
 - [Magnus Holm Rasmussen](https://github.com/mR4smussen)
+- [Daniel Welch](https://github.com/dtwelch)

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -330,6 +330,15 @@ namespace Result {
     }
 
     ///
+    /// Returns a `Success(v)` if `r` is `Ok(v)`. Otherwise returns a
+    /// `Failure(Nec.singleton(t))` if `r` is `Err(t)`.
+    ///
+    pub def toValidation(r: Result[e, t]): Validation[e, t] = match r {
+        case Ok(v) => Validation.Success(v)
+        case Err(t) => Validation.Failure(Nec.singleton(t))
+    }
+
+    ///
     /// Applies `f` to `v` if `r` is `Ok(v)`. Otherwise does nothing.
     ///
     pub def forEach(f: t -> Unit \ ef, r: Result[e, t]): Unit \ ef = match r {

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -522,7 +522,7 @@ namespace TestResult {
     /////////////////////////////////////////////////////////////////////////////
     // toValidation                                                            //
     /////////////////////////////////////////////////////////////////////////////
-    @test
+    @test 
     pub def toValidation01(): Bool =
         Result.toValidation(Err(1): Result[Unit, Int32]) == Failure(Nec.singleton(1))
 

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -524,11 +524,11 @@ namespace TestResult {
     /////////////////////////////////////////////////////////////////////////////
     @test
     pub def toValidation01(): Bool =
-        Result.toValidation(Err(1): Result[Unit, Int32]) == Failure(Nec.singleton(1))
+        Result.toValidation(Err(1): Result[Int32, Unit]) == Failure(Nec.singleton(1))
 
     @test
     pub def toValidation02(): Bool =
-        Result.toValidation(Ok("s"): Result[String, Unit]) == Success("s")
+        Result.toValidation(Ok("s"): Result[Unit, String]) == Success("s")
 
     /////////////////////////////////////////////////////////////////////////////
     // forEach                                                                 //

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -522,13 +522,13 @@ namespace TestResult {
     /////////////////////////////////////////////////////////////////////////////
     // toValidation                                                            //
     /////////////////////////////////////////////////////////////////////////////
-    @test 
+    @test
     pub def toValidation01(): Bool =
         Result.toValidation(Err(1): Result[Unit, Int32]) == Failure(Nec.singleton(1))
 
     @test
     pub def toValidation02(): Bool =
-        Result.toValidation(Ok("s"): Result[String, Unit]) == Success(Nec.singleton("s"))
+        Result.toValidation(Ok("s"): Result[String, Unit]) == Success("s")
 
     /////////////////////////////////////////////////////////////////////////////
     // forEach                                                                 //

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -520,6 +520,17 @@ namespace TestResult {
     def toOption02(): Bool = Result.toOption(Ok(1)) == Some(1)
 
     /////////////////////////////////////////////////////////////////////////////
+    // toValidation                                                            //
+    /////////////////////////////////////////////////////////////////////////////
+    @test
+    pub def toValidation01(): Bool =
+        Result.toValidation(Err(1): Result[Unit, Int32]) == Failure(Nec.singleton(1))
+
+    @test
+    pub def toValidation02(): Bool =
+        Result.toValidation(Ok("s"): Result[String, Unit]) == Success(Nec.singleton("s"))
+
+    /////////////////////////////////////////////////////////////////////////////
     // forEach                                                                 //
     /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Adds a `toValidation` conversion function to the flix library `Result` type (related to #5532)
(full disclosure: not sure if I flubbed the semantic commit msg format)