### PR TITLE
refactor: remove `new` from LSP completer

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
@@ -65,7 +65,6 @@ object KeywordCompleter extends Completer {
       "let",
       "match",
       "mod",
-      "new",
       "not",
       "null",
       "opaque",


### PR DESCRIPTION
I'm not sure if there are other lines that should be removed for the LSP part.

Related to https://github.com/flix/flix/issues/5217