### PR TITLE
fix: Test output

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/Tester.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Tester.scala
@@ -190,7 +190,7 @@ object Tester {
           result match {
             case java.lang.Boolean.FALSE =>
               // Case 1: Assertion Error.
-              queue.add(TestEvent.Failure(sym, "Assertion Error" :: Nil, Duration(elapsed)))
+              queue.add(TestEvent.Failure(sym, "Assertion Error" :: redirect.stdOut ++ redirect.stdErr, Duration(elapsed)))
 
             case _ =>
               if (redirect.stdErr.isEmpty) {


### PR DESCRIPTION
Fixes #5459

This PR:

* Adds `TeeOutputStream` and uses it to both immediately output stdout and stderr, and collect the output
* Modifies `runTest` so that both stdout and stderr are printed in the event of a test failing