### PR TITLE
draft: Channel close

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -119,6 +119,9 @@ class Flix {
     // Reflect
     "Reflect.flix" -> LocalResource.get("/src/library/Reflect.flix"),
 
+    // Closeable
+    "Closeable.flix" -> LocalResource.get("/src/library/Closeable.flix"),
+
     // Debug
     "Debug.flix" -> LocalResource.get("/src/library/Debug.flix"),
   )

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -122,6 +122,9 @@ class Flix {
     // Closeable
     "Closeable.flix" -> LocalResource.get("/src/library/Closeable.flix"),
 
+    // Region
+    "Region.flix" -> LocalResource.get("/src/library/Region.flix"),
+
     // Debug
     "Debug.flix" -> LocalResource.get("/src/library/Debug.flix"),
   )

--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -394,6 +394,9 @@ object Indexer {
       }
       i0 ++ i1 ++ Index.occurrenceOf(exp0)
 
+    case Expression.CloseChannel(exp, _, _, _, _) =>
+      visitExp(exp) ++ Index.occurrenceOf(exp0)
+
     case Expression.Spawn(exp1, exp2, _, _, _, _) =>
       visitExp(exp1) ++ visitExp(exp2) ++ Index.occurrenceOf(exp0)
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -510,6 +510,8 @@ object SemanticTokensProvider {
       val d = default.map(visitExp).getOrElse(Iterator.empty)
       rs ++ d
 
+    case Expression.CloseChannel(exp, _, _, _, _) => visitExp(exp)
+
     case Expression.Spawn(exp1, exp2, _, _, _, _) => visitExp(exp1) ++ visitExp(exp2)
 
     case Expression.Par(exp, _) => visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -194,6 +194,8 @@ object KindedAst {
 
     case class SelectChannel(rules: List[KindedAst.SelectChannelRule], default: Option[KindedAst.Expression], tpe: Type.Var, loc: SourceLocation) extends KindedAst.Expression
 
+    case class CloseChannel(exp: KindedAst.Expression, tpe: Type.Var, loc: SourceLocation) extends KindedAst.Expression
+
     case class Spawn(exp1: KindedAst.Expression, exp2: KindedAst.Expression, loc: SourceLocation) extends KindedAst.Expression
 
     case class Par(exp: Expression, loc: SourceLocation) extends KindedAst.Expression

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -210,6 +210,8 @@ object NamedAst {
 
     case class SelectChannel(rules: List[NamedAst.SelectChannelRule], default: Option[NamedAst.Expression], loc: SourceLocation) extends NamedAst.Expression
 
+    case class CloseChannel(exp: NamedAst.Expression, loc: SourceLocation) extends NamedAst.Expression
+
     case class Spawn(exp1: NamedAst.Expression, exp2: NamedAst.Expression, loc: SourceLocation) extends NamedAst.Expression
 
     case class Par(exp: NamedAst.Expression, loc: SourceLocation) extends NamedAst.Expression

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -210,6 +210,8 @@ object ResolvedAst {
 
     case class SelectChannel(rules: List[ResolvedAst.SelectChannelRule], default: Option[ResolvedAst.Expression], loc: SourceLocation) extends ResolvedAst.Expression
 
+    case class CloseChannel(exp: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
+
     case class Spawn(exp1: ResolvedAst.Expression, exp2: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
 
     case class Par(exp: Expression, loc: SourceLocation) extends ResolvedAst.Expression

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -280,6 +280,8 @@ object TypedAst {
 
     case class SelectChannel(rules: List[TypedAst.SelectChannelRule], default: Option[TypedAst.Expression], tpe: Type, pur: Type, eff: Type, loc: SourceLocation) extends TypedAst.Expression
 
+    case class CloseChannel(exp: TypedAst.Expression, tpe: Type, pur: Type, eff: Type, loc: SourceLocation) extends TypedAst.Expression
+
     case class Spawn(exp1: TypedAst.Expression, exp2: TypedAst.Expression, tpe: Type, pur: Type, eff: Type, loc: SourceLocation) extends TypedAst.Expression
 
     case class Par(exp: TypedAst.Expression, loc: SourceLocation) extends TypedAst.Expression {

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -197,6 +197,8 @@ object WeededAst {
 
     case class SelectChannel(rules: List[WeededAst.SelectChannelRule], exp: Option[WeededAst.Expression], loc: SourceLocation) extends WeededAst.Expression
 
+    case class CloseChannel(exp: WeededAst.Expression, loc: SourceLocation) extends WeededAst.Expression
+
     case class Spawn(exp1: WeededAst.Expression, exp2: WeededAst.Expression, loc: SourceLocation) extends WeededAst.Expression
 
     case class Par(exp: WeededAst.Expression, loc: SourceLocation) extends WeededAst.Expression

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
@@ -94,6 +94,7 @@ object TypedAstOps {
     case Expression.GetChannel(exp, _, _, _, _) => sigSymsOf(exp)
     case Expression.PutChannel(exp1, exp2, _, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
     case Expression.SelectChannel(rules, default, _, _, _, _) => rules.flatMap(rule => sigSymsOf(rule.chan) ++ sigSymsOf(rule.exp)).toSet ++ default.toSet.flatMap(sigSymsOf)
+    case Expression.CloseChannel(exp, _, _, _, _) => sigSymsOf(exp)
     case Expression.Spawn(exp1, exp2, _, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
     case Expression.Par(exp, _) => sigSymsOf(exp)
     case Expression.ParYield(frags, exp, _, _, _, _) => sigSymsOf(exp) ++ frags.flatMap(f => sigSymsOf(f.exp))
@@ -352,6 +353,9 @@ object TypedAstOps {
       rules.foldLeft(d) {
         case (acc, SelectChannelRule(sym, chan, exp)) => acc ++ ((freeVars(chan) ++ freeVars(exp)) - sym)
       }
+
+    case Expression.CloseChannel(exp, _, _, _, _) =>
+      freeVars(exp)
 
     case Expression.Spawn(exp1, exp2, _, _, _, _) =>
       freeVars(exp1) ++ freeVars(exp2)

--- a/main/src/ca/uwaterloo/flix/language/dbg/FormatExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/FormatExpression.scala
@@ -77,6 +77,7 @@ object FormatExpression {
     case TypedAst.Expression.GetChannel(exp, _, _, _, _) => s"GetChannel($exp)"
     case TypedAst.Expression.PutChannel(exp1, exp2, _, _, _, _) => s"PutChannel($exp1, $exp2)"
     case TypedAst.Expression.SelectChannel(rules, default, _, _, _, _) => s"SelectChannel(${rules.mkString(", ")}, $default)"
+    case TypedAst.Expression.CloseChannel(exp, _, _, _, _) => s"CloseChannel($exp)"
     case TypedAst.Expression.Spawn(exp1, exp2, _, _, _, _) => s"Spawn($exp1, $exp2)"
     case TypedAst.Expression.Par(exp, _) => s"Par($exp)"
     case TypedAst.Expression.ParYield(frags, exp, _, _, _, _) => s"ParYield(${frags.mkString(",")}, $exp)"

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -867,6 +867,12 @@ object Kinder {
         case (rules, default) => KindedAst.Expression.SelectChannel(rules, default, Type.freshVar(Kind.Star, loc.asSynthetic), loc)
       }
 
+    case ResolvedAst.Expression.CloseChannel(exp0, loc) =>
+      val expVal = visitExp(exp0, kenv0, senv, taenv, henv0, root)
+      mapN(expVal) {
+        exp => KindedAst.Expression.CloseChannel(exp, Type.freshVar(Kind.Star, loc.asSynthetic), loc)
+      }
+
     case ResolvedAst.Expression.Spawn(exp1, exp2, loc) =>
       val e1Val = visitExp(exp1, kenv0, senv, taenv, henv0, root)
       val e2Val = visitExp(exp2, kenv0, senv, taenv, henv0, root)

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -993,6 +993,11 @@ object Namer {
         case (rs, d) => NamedAst.Expression.SelectChannel(rs, d, loc)
       }
 
+    case WeededAst.Expression.CloseChannel(exp, loc) =>
+      visitExp(exp, ns0) map {
+        case e => NamedAst.Expression.CloseChannel(e, loc)
+      }
+
     case WeededAst.Expression.Spawn(exp1, exp2, loc) =>
       mapN(visitExp(exp1, ns0), visitExp(exp2, ns0)) {
         case (e1, e2) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
@@ -229,6 +229,8 @@ object PatternExhaustiveness {
         val chans = rules.map(_.chan)
         (ruleExps ::: chans ::: default.toList).flatMap(visitExp(_, root))
 
+      case Expression.CloseChannel(exp, _, _, _, _) => visitExp(exp, root)
+
       case Expression.Spawn(exp1, exp2, _, _, _, _) => List(exp1, exp2).flatMap(visitExp(_, root))
       case Expression.Par(exp, _) => visitExp(exp, root)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -764,6 +764,9 @@ object Redundancy {
         case (acc, used) => acc ++ used
       }
 
+    case Expression.CloseChannel(exp, _, _, _, _) =>
+      visitExp(exp, env0, rc)
+
     case Expression.Spawn(exp1, exp2, _, _, _, _) =>
       val us1 = visitExp(exp1, env0, rc)
       val us2 = visitExp(exp2, env0, rc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
@@ -268,6 +268,9 @@ object Regions {
     case Expression.Spawn(exp1, exp2, tpe, _, _, loc) =>
       visitExp(exp1) ++ visitExp(exp2) ++ checkType(tpe, loc)
 
+    case Expression.CloseChannel(exp, tpe, _, _, loc) =>
+      visitExp(exp) ++ checkType(tpe, loc)
+
     case Expression.Par(exp, loc) =>
       visitExp(exp) ++ checkType(exp.tpe, loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1489,6 +1489,12 @@ object Resolver {
             case (rs, d) => ResolvedAst.Expression.SelectChannel(rs, d, loc)
           }
 
+        case NamedAst.Expression.CloseChannel(exp, loc) =>
+          val eVal = visitExp(exp, env0, region)
+          mapN(eVal) {
+            e => ResolvedAst.Expression.CloseChannel(e, loc)
+          }
+
         case NamedAst.Expression.Spawn(exp1, exp2, loc) =>
           val e1Val = visitExp(exp1, env0, region)
           val e2Val = visitExp(exp2, env0, region)

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -302,6 +302,9 @@ object Safety {
         } ++
           default.map(visit).getOrElse(Nil)
 
+      case Expression.CloseChannel(exp, _, _, _, _) =>
+        visit(exp)
+
       case Expression.Spawn(exp1, exp2, _, _, _, _) =>
         visit(exp1) ++ visit(exp2)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Statistics.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Statistics.scala
@@ -146,6 +146,7 @@ object Statistics {
       case Expression.GetChannel(exp, tpe, pur, eff, loc) => visitExp(exp)
       case Expression.PutChannel(exp1, exp2, tpe, pur, eff, loc) => visitExp(exp1) ++ visitExp(exp2)
       case Expression.SelectChannel(rules, default, tpe, pur, eff, loc) => Counter.merge(rules.map(visitSelectChannelRule)) ++ Counter.merge(default.map(visitExp))
+      case Expression.CloseChannel(exp, tpe, pur, eff, loc) => visitExp(exp)
       case Expression.Spawn(exp1, exp2, tpe, pur, eff, loc) => visitExp(exp1) ++ visitExp(exp2)
       case Expression.Par(exp, loc) => visitExp(exp)
       case Expression.ParYield(frags, exp, tpe, pur, eff, loc) => Counter.merge(frags.map(f => visitExp(f.exp))) ++ visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -433,6 +433,11 @@ object Stratifier {
         case (rs, d) => Expression.SelectChannel(rs, d, tpe, pur, eff, loc)
       }
 
+    case Expression.CloseChannel(exp, tpe, pur, eff, loc) =>
+      mapN(visitExp(exp)) {
+        case e => Expression.CloseChannel(e, tpe, pur, eff, loc)
+      }
+
     case Expression.Spawn(exp1, exp2, tpe, pur, eff, loc) =>
       mapN(visitExp(exp1), visitExp(exp2)) {
         case (r, e) => Expression.Spawn(r, e, tpe, pur, eff, loc)
@@ -788,6 +793,9 @@ object Stratifier {
       rules.foldLeft(dg) {
         case (acc, SelectChannelRule(_, exp1, exp2)) => acc + labelledGraphOfExp(exp1) + labelledGraphOfExp(exp2)
       }
+
+    case Expression.CloseChannel(exp, _, _, _, _) =>
+      labelledGraphOfExp(exp)
 
     case Expression.Spawn(exp1, exp2, _, _, _, _) =>
       labelledGraphOfExp(exp1) + labelledGraphOfExp(exp2)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -731,6 +731,7 @@ object Weeder {
           case ("CHANNEL_GET", e1 :: Nil) => WeededAst.Expression.GetChannel(e1, loc).toSuccess
           case ("CHANNEL_PUT", e1 :: e2 :: Nil) => WeededAst.Expression.PutChannel(e1, e2, loc).toSuccess
           case ("CHANNEL_NEW", e1 :: e2 :: Nil) => WeededAst.Expression.NewChannel(e1, e2, loc).toSuccess
+          case ("CHANNEL_CLOSE", e1 :: Nil) => WeededAst.Expression.CloseChannel(e1, loc).toSuccess
 
           case ("ARRAY_NEW", e1 :: e2 :: e3 :: Nil) => WeededAst.Expression.ArrayNew(e1, e2, e3, loc).toSuccess
           case ("ARRAY_LENGTH", e1 :: Nil) => WeededAst.Expression.ArrayLength(e1, loc).toSuccess

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -292,6 +292,9 @@ object CodeHinter {
         case SelectChannelRule(_, chan, exp) => visitExp(chan) ++ visitExp(exp)
       } ++ default.map(visitExp).getOrElse(Nil)
 
+    case Expression.CloseChannel(exp, _, _, _, _) =>
+      visitExp(exp)
+
     case Expression.Spawn(exp1, exp2, _, _, _, _) =>
       visitExp(exp1) ++ visitExp(exp2)
 

--- a/main/src/library/Channel.flix
+++ b/main/src/library/Channel.flix
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+instance Closeable[Receiver[t, r]] {
+    pub def close(receiver: Receiver[t, r]): Unit \ IO = 
+        unsafe_cast $CHANNEL_CLOSE$(receiver) as _ \ IO
+}
+
 namespace Channel {
     use Time.Duration
 
@@ -22,7 +27,9 @@ namespace Channel {
     ///
     pub def buffered(r: Region[r], n: Int32): (Sender[t, r], Receiver[t, r]) \ Write(r) =
         let m = if (n < 0) 0 else n;
-        $CHANNEL_NEW$(r, m)
+        let (sender, receiver) = $CHANNEL_NEW$(r, m);
+        Region.closeOnExit(receiver, r);
+        (sender, receiver)
         
     ///
     /// Returns a new unbuffered channel (i.e. a channel with zero capacity).

--- a/main/src/library/Channel.flix
+++ b/main/src/library/Channel.flix
@@ -28,7 +28,7 @@ namespace Channel {
     pub def buffered(r: Region[r], n: Int32): (Sender[t, r], Receiver[t, r]) \ Write(r) =
         let m = if (n < 0) 0 else n;
         let (sender, receiver) = $CHANNEL_NEW$(r, m);
-        Region.closeOnExit(receiver, r);
+        unsafe_cast Region.closeOnExit(receiver, r) as _ \ Write(r);
         (sender, receiver)
         
     ///

--- a/main/src/library/Concurrent/Channel.flix
+++ b/main/src/library/Concurrent/Channel.flix
@@ -164,6 +164,23 @@ namespace Concurrent/Channel {
         (c, c)
 
     ///
+    /// Closes a channel
+    ///
+    /// We indicate that a channel is closed by setting `size` to a negative number
+    ///
+    @Internal
+    pub def close(c: Mpmc[a]): Unit \ IO =
+        let MpmcAdmin.MpmcAdmin(_, channelLock, _, _, size, _, _, _) = mpmcAdmin(c);
+        lock(channelLock);
+        
+        if (deref size < 0)
+            bug!("Channel used after it's been closed")
+        else
+            size := -1;
+        
+        unlock(channelLock)
+
+    ///
     /// Sends the element `e` on the channel `c`. This is blocking if the
     /// channel is full or unbuffered.
     ///
@@ -174,6 +191,9 @@ namespace Concurrent/Channel {
         let Mpmc.Mpmc(admin, elementDeque) = c;
         let MpmcAdmin.MpmcAdmin(_, channelLock, unBuffered, _, size, _, rendezvous, _) = admin;
         lock(channelLock);
+
+        if (deref size < 0) bug!("Channel used after it's been closed")
+        else ();
 
         // Block until the channel is not full
         awaitAvailableSpace(admin);
@@ -216,6 +236,9 @@ namespace Concurrent/Channel {
         let Mpmc.Mpmc(admin, elementDeque) = c;
         let MpmcAdmin.MpmcAdmin(_, channelLock, _, _, size, _, _, _) = admin;
         lock(channelLock);
+        
+        if (deref size < 0) bug!("Channel used after it's been closed")
+        else ();
 
         // Gets an element from the channel c which must be non-empty
         // and update the size.
@@ -298,6 +321,9 @@ namespace Concurrent/Channel {
     def getHelper(c: Mpmc[a]): a \ IO =
         let Mpmc.Mpmc(admin, elementDeque) = c;
         let MpmcAdmin.MpmcAdmin(_, channelLock, _, _, size, waitingGetters, _, _) = admin;
+        
+        if (deref size < 0) bug!("Channel used after it's been closed")
+        else ();
 
         // Try to get the element (which could already be taken by someone
         // else) and update size.

--- a/main/src/library/Concurrent/Channel.flix
+++ b/main/src/library/Concurrent/Channel.flix
@@ -172,11 +172,12 @@ namespace Concurrent/Channel {
     pub def close(c: Mpmc[a]): Unit \ IO =
         let MpmcAdmin.MpmcAdmin(_, channelLock, _, _, size, _, _, _) = mpmcAdmin(c);
         lock(channelLock);
-        
-        if (deref size < 0)
-            bug!("Channel used after it's been closed")
-        else
-            size := -1;
+
+        match deref size {
+            case sz if sz < 0 => bug!("Channel used after it's been closed")
+            case sz if sz > 0 => bug!("Non-empty channel closed")
+            case _ => size := -1
+        };
         
         unlock(channelLock)
 

--- a/main/test/flix/Test.Exp.Concurrency.Buffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Buffered.flix
@@ -227,4 +227,22 @@ namespace Test/Exp/Concurrency/Buffered {
         spawn Channel.send(42, tx2) @ r;
         42 == Channel.recv(Channel.recv(rx1))
     }
+
+    @test
+    def testBufferedChannelUsedAfterClose01(): Bool \ IO = region rc1 {
+        let (tx1, rx1) = Channel.buffered(rc1, 1);
+        let (tx2, rx2) = Channel.buffered(rc1, 1);
+        spawn {
+            let tx3 = Channel.recv(rx1);
+            let _ = Channel.recv(rx2);
+            Channel.send((), tx3)
+        } @ rc1;
+        region rc2 {
+            let (tx3, _) = Channel.buffered(rc2, 1);
+            Channel.unsafeSend(tx3, tx1)
+        };
+        Channel.send((), tx2);
+        Thread.sleep(Time/Duration.fromSeconds(1));
+        true
+    }
 }

--- a/main/test/flix/Test.Exp.Concurrency.Select.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Select.flix
@@ -136,8 +136,8 @@ namespace Test/Exp/Concurrency/Select {
         }
     }
 
-    def mainx(): Int32 \ IO = {
-      let (_, rx) = Channel.buffered(Static, 1);
+    def mainx(): Int32 = region r {
+      let (_, rx) = Channel.buffered(r, 1);
       recvWithDefault(rx)
     }
 


### PR DESCRIPTION
One of the motivations behind implementing ScopeExit (#5353) was to allow channels to be closed. This PR implements channel close, but is still draft because of a number of issues. I'm increasingly unsure whether we want to close channels at all.

The code in this PR raises an error if:

* A channel is used after it's closed
* A channel is closed when it's non-empty

Regarding the first case, I *thought* that a channel could be used after it's closed by using `unsafeSend` to send it to another thread. This is the test I tried to write to demonstrate this:

```
    @test
    def testBufferedChannelUsedAfterClose01(): Bool \ IO = region rc1 {
        let (tx1, rx1) = Channel.buffered(rc1, 1);
        let (tx2, rx2) = Channel.buffered(rc1, 1);
        spawn {
            let tx3 = Channel.recv(rx1);
            let _ = Channel.recv(rx2);
            Channel.send((), tx3)
        } @ rc1;
        region rc2 {
            let (tx3, _) = Channel.buffered(rc2, 1);
            Channel.unsafeSend(tx3, tx1)
        };
        Channel.send((), tx2);
        Thread.sleep(Time/Duration.fromSeconds(1));
        true
    }
```

But this fails to compile with:

```
-- Type Error -------------------------------------------------- main/test/flix/Test.Exp.Concurrency.Buffered.flix

>> The region variable 'rc2' escapes its scope.

233 |         let (tx1, rx1) = Channel.buffered(rc1, 1);
                               ^^^^^^^^^^^^^^^^^^^^^^^^
                               region variable escapes.

The escaping expression has type:

  (Sender[Sender[Unit, rc2], rc1], Receiver[Sender[Unit, rc2], rc1])
```

Which is impressive! But it makes me wonder if there's ever any situation in which a channel could be used after it's closed? Can someone come up with a test that will demonstrate this?

As for the other error case (closing a channel when it's non-empty) that (unsurprisingly) causes a number of our existing tests to fail. They can be fixed, obviously, but I'm not sure whether we *want* this to be an error? If we do, then we probably need to have some kind of "clear channel" function.

The final issue is with the effect of `Closeable.close`. We discussed this [here](https://github.com/flix/flix/pull/5319#discussion_r1071480078) and decided to make it `IO`. But this causes issues for channels, and needs to be casted away in `Channel.buffered`. Of course, this may be moot if we decide that we don't want to do this for channels at all.