### PR TITLE
refactor: change Result.try to catch on Java.Lang.Exception, and rename to Result.guard (issue #5465)

### DIFF
--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -446,14 +446,14 @@ namespace Result {
     ///
     /// Returns `Ok(x)` if `f` was invoked without throwing an exception.
     ///
-    /// If `f` throws a Java `RuntimeException`, `Err(e)` is returned
+    /// If `f` throws a Java `Exception`, `Err(e)` is returned
     /// where `e` is the error message.
     ///
-    pub def try(f: Unit -> a \ ef): Result[String, a] \ ef =
+    pub def guard(f: Unit -> a \ ef): Result[String, a] \ ef =
         try {
             Ok(f())
         } catch {
-            case e: ##java.lang.RuntimeException =>
+            case e: ##java.lang.Exception =>
                 import java.lang.Throwable.getMessage(): String \ {};
                 Err(getMessage(e))
         }

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -449,7 +449,7 @@ namespace Result {
     /// If `f` throws a Java `Exception`, `Err(e)` is returned
     /// where `e` is the error message.
     ///
-    pub def guard(f: Unit -> a \ ef): Result[String, a] \ ef =
+    pub def tryCatch(f: Unit -> a \ ef): Result[String, a] \ ef =
         try {
             Ok(f())
         } catch {

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -861,16 +861,16 @@ namespace TestResult {
     }
 
     /////////////////////////////////////////////////////////////////////////////
-    // guard                                                                   //
+    // tryCatch                                                                //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def guard01(): Bool = Result.guard(_ -> 1 / 1) == Ok(1)
+    def tryCatch01(): Bool = Result.tryCatch(_ -> 1 / 1) == Ok(1)
 
     @test
-    def guard02(): Bool = region rc {
+    def tryCatch02(): Bool = region rc {
         let arr = Array#{0} @ rc;
-        Result.guard(_ -> Array.get(10, arr)) |> Result.isErr
+        Result.tryCatch(_ -> Array.get(10, arr)) |> Result.isErr
     }
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -860,4 +860,17 @@ namespace TestResult {
         Ok(1 :: 2 :: 3 :: Nil) |> Result.iterator(r) |> Iterator.toList == (1 :: 2 :: 3 :: Nil) :: Nil
     }
 
+    /////////////////////////////////////////////////////////////////////////////
+    // guard                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def guard01(): Bool = Result.guard(_ -> 1 / 1) == Ok(1)
+
+    @test
+    def guard02(): Bool = region rc {
+        let arr = Array#{0} @ rc;
+        Result.guard(_ -> Array.get(10, arr)) |> Result.isErr
+    }
+
 }


### PR DESCRIPTION
This PR changes `Result.try` to catch / match on `Java.Lang.Exception` rather than `Java.Lang.RuntimeException` as `Java.Lang.Exception` is the base class of all exceptions.

As `try` is a keyword the PR changes it to `guard`. I'm open to discussion and suggestion of alternative names.