### PR TITLE
refactor: keep alias for Use expressions in through TypedAst

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -182,7 +182,7 @@ object Indexer {
     case Expression.OpenAs(_, exp, _, _) => // TODO RESTR-VARS sym
       Index.occurrenceOf(exp0) ++ visitExp(exp)
 
-    case Expression.Use(_, _, _) =>
+    case Expression.Use(_, _, _, _) =>
       Index.occurrenceOf(exp0) // TODO NS-REFACTOR add use of sym
 
     case Expression.Lambda(fparam, exp, _, _) =>

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -290,7 +290,7 @@ object SemanticTokensProvider {
 
     case Expression.OpenAs(_, exp, _, _) => visitExp(exp) // TODO RESTR-VARS sym
 
-    case Expression.Use(_, _, _) => Iterator.empty // TODO NS-REFACTOR add token for sym
+    case Expression.Use(_, _, _, _) => Iterator.empty // TODO NS-REFACTOR add token for sym
 
     case Expression.Cst(_, _, _) => Iterator.empty
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -76,7 +76,7 @@ object KindedAst {
 
     case class OpenAs(sym: Symbol.RestrictableEnumSym, exp: KindedAst.Expression, tvar: Type.Var, loc: SourceLocation) extends KindedAst.Expression
 
-    case class Use(sym: Symbol, exp: KindedAst.Expression, loc: SourceLocation) extends KindedAst.Expression
+    case class Use(sym: Symbol, alias: Name.Ident, exp: KindedAst.Expression, loc: SourceLocation) extends KindedAst.Expression
 
     case class Cst(cst: Ast.Constant, loc: SourceLocation) extends KindedAst.Expression
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -91,7 +91,7 @@ object ResolvedAst {
     // TODO RESTR-VARS should be Ast.RestrictableEnumSymUse for LSP
     case class OpenAs(sym: Symbol.RestrictableEnumSym, exp: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
 
-    case class Use(sym: Symbol, exp: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
+    case class Use(sym: Symbol, alias: Name.Ident, exp: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
 
     case class Cst(cst: Ast.Constant, loc: SourceLocation) extends ResolvedAst.Expression
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -121,7 +121,7 @@ object TypedAst {
       def eff: Type = exp.eff
     }
 
-    case class Use(sym: Symbol, exp: TypedAst.Expression, loc: SourceLocation) extends TypedAst.Expression {
+    case class Use(sym: Symbol, alias: Name.Ident, exp: TypedAst.Expression, loc: SourceLocation) extends TypedAst.Expression {
       def tpe: Type = exp.tpe
 
       def pur: Type = exp.pur

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
@@ -36,7 +36,7 @@ object TypedAstOps {
     case Expression.Hole(_, _, _) => Set.empty
     case Expression.HoleWithExp(exp, _, _, _, _) => sigSymsOf(exp)
     case Expression.OpenAs(_, exp, _, _) => sigSymsOf(exp)
-    case Expression.Use(_, exp, _) => sigSymsOf(exp)
+    case Expression.Use(_, _, exp, _) => sigSymsOf(exp)
     case Expression.Lambda(_, exp, _, _) => sigSymsOf(exp)
     case Expression.Apply(exp, exps, _, _, _, _) => sigSymsOf(exp) ++ exps.flatMap(sigSymsOf)
     case Expression.Unary(_, exp, _, _, _, _) => sigSymsOf(exp)
@@ -141,7 +141,7 @@ object TypedAstOps {
     case Expression.OpenAs(_, exp, _, _) =>
       freeVars(exp)
 
-    case Expression.Use(_, exp, _) =>
+    case Expression.Use(_, _, exp, _) =>
       freeVars(exp)
 
     case Expression.Lambda(fparam, exp, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/dbg/FormatExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/FormatExpression.scala
@@ -19,7 +19,7 @@ object FormatExpression {
     case TypedAst.Expression.Hole(sym, _, _) => s"Hole($sym)"
     case TypedAst.Expression.HoleWithExp(exp, _, _, _, _) => s"HoleWithExp($exp)"
     case TypedAst.Expression.OpenAs(sym, exp, _, _) => s"OpenAs($sym, $exp)"
-    case TypedAst.Expression.Use(sym, exp, _) => s"Use($sym, $exp)"
+    case TypedAst.Expression.Use(sym, alias, exp, _) => s"Use($sym, $alias, $exp)"
     case TypedAst.Expression.Lambda(fparam, exp, tpe, loc) => s"Lambda(${FormatFormalParam.format(fparam)}, $exp)"
     case TypedAst.Expression.Apply(exp1, exp2, _, _, _, _) => s"Apply($exp1, $exp2)"
     case TypedAst.Expression.Unary(sop, exp, _, _, _, _) => s"Unary($sop, $exp)"

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -424,10 +424,10 @@ object Kinder {
           KindedAst.Expression.OpenAs(sym, exp, tvar, loc)
       }
 
-    case ResolvedAst.Expression.Use(sym, exp0, loc) =>
+    case ResolvedAst.Expression.Use(sym, alias, exp0, loc) =>
       val expVal = visitExp(exp0, kenv0, senv, taenv, henv0, root)
       mapN(expVal) {
-        case exp => KindedAst.Expression.Use(sym, exp, loc)
+        case exp => KindedAst.Expression.Use(sym, alias, exp, loc)
       }
 
     case ResolvedAst.Expression.Cst(cst, loc) => KindedAst.Expression.Cst(cst, loc).toSuccess

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -375,7 +375,7 @@ object Lowering {
     case TypedAst.Expression.OpenAs(sym, exp, tpe, loc) =>
       visitExp(exp) // TODO RESTR-VARS maybe add to loweredAST
 
-    case TypedAst.Expression.Use(_, exp, _) =>
+    case TypedAst.Expression.Use(_, _, exp, _) =>
       visitExp(exp)
 
     case TypedAst.Expression.Lambda(fparam, exp, tpe, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
@@ -141,7 +141,7 @@ object PatternExhaustiveness {
       case Expression.Hole(_, _, _) => Nil
       case Expression.HoleWithExp(exp, _, _, _, _) => visitExp(exp, root)
       case Expression.OpenAs(_, exp, _, _) => visitExp(exp, root)
-      case Expression.Use(_, exp, _) => visitExp(exp, root)
+      case Expression.Use(_, _, exp, _) => visitExp(exp, root)
       case Expression.Cst(_, _, _) => Nil
       case Expression.Lambda(_, body, _, _) => visitExp(body, root)
       case Expression.Apply(exp, exps, _, _, _, _) => (exp :: exps).flatMap(visitExp(_, root))

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -314,7 +314,7 @@ object Redundancy {
     case Expression.OpenAs(_, exp, _, _) =>
       visitExp(exp, env0, rc)
 
-    case Expression.Use(_, exp, _) =>
+    case Expression.Use(_, alias, exp, _) =>
       visitExp(exp, env0, rc) // TODO NS-REFACTOR check for unused syms
 
     case Expression.Lambda(fparam, exp, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
@@ -67,7 +67,7 @@ object Regions {
     case Expression.OpenAs(_, exp, tpe, loc) =>
       visitExp(exp) ++ checkType(tpe, loc)
 
-    case Expression.Use(_, exp, loc) => visitExp(exp)
+    case Expression.Use(_, _, exp, loc) => visitExp(exp)
 
     case Expression.Lambda(_, exp, tpe, loc) =>
       visitExp(exp) ++ checkType(tpe, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -932,7 +932,7 @@ object Resolver {
                   }
                   mapN(visitExp(exp, env, region)) {
                     // TODO NS-REFACTOR: multiple uses here
-                    case e => ResolvedAst.Expression.Use(getSym(decls.head), e, loc)
+                    case e => ResolvedAst.Expression.Use(getSym(decls.head), alias, e, loc)
                   }.recoverOne {
                     case err: ResolutionError => ResolvedAst.Expression.Error(err)
                   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -105,7 +105,7 @@ object Safety {
       case Expression.OpenAs(_, exp, _, _) =>
         visit(exp)
 
-      case Expression.Use(_, exp, _) =>
+      case Expression.Use(_, _, exp, _) =>
         visit(exp)
 
       case Expression.Lambda(_, exp, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Statistics.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Statistics.scala
@@ -88,7 +88,7 @@ object Statistics {
       case Expression.Hole(sym, tpe, loc) => Counter.empty
       case Expression.HoleWithExp(exp, tpe, pur, eff, loc) => visitExp(exp)
       case Expression.OpenAs(_, exp, _, _) => visitExp(exp)
-      case Expression.Use(_, exp, _) => visitExp(exp)
+      case Expression.Use(_, _, exp, _) => visitExp(exp)
       case Expression.Lambda(fparam, exp, tpe, loc) => visitExp(exp)
       case Expression.Apply(exp, exps, tpe, pur, eff, loc) => visitExp(exp) ++ Counter.merge(exps.map(visitExp))
       case Expression.Unary(sop, exp, tpe, pur, eff, loc) => visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -117,7 +117,7 @@ object Stratifier {
         case e => Expression.OpenAs(sym, e, tpe, loc)
       }
 
-    case Expression.Use(_, exp, _) => visitExp(exp)
+    case Expression.Use(_, _, exp, _) => visitExp(exp)
 
     case Expression.Lambda(fparam, exp, tpe, loc) =>
       mapN(visitExp(exp)) {
@@ -568,7 +568,7 @@ object Stratifier {
     case Expression.OpenAs(_, exp, _, _) =>
       labelledGraphOfExp(exp)
 
-    case Expression.Use(_, exp, _) =>
+    case Expression.Use(_, _, exp, _) =>
       labelledGraphOfExp(exp)
 
     case Expression.Lambda(_, exp, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -530,7 +530,7 @@ object Typer {
 
       case e: KindedAst.Expression.OpenAs => RestrictableChooseInference.inferOpenAs(e, root)
 
-      case KindedAst.Expression.Use(_, exp, _) => visitExp(exp)
+      case KindedAst.Expression.Use(_, alias, exp, _) => visitExp(exp)
 
       case KindedAst.Expression.Cst(Ast.Constant.Unit, loc) =>
         liftM(List.empty, Type.mkUnit(loc.asSynthetic), Type.Pure, Type.Empty)
@@ -2011,9 +2011,9 @@ object Typer {
         val e = visitExp(exp, subst0)
         TypedAst.Expression.OpenAs(sym, e, subst0(tvar), loc)
 
-      case KindedAst.Expression.Use(sym, exp, loc) =>
+      case KindedAst.Expression.Use(sym, alias, exp, loc) =>
         val e = visitExp(exp, subst0)
-        TypedAst.Expression.Use(sym, e, loc)
+        TypedAst.Expression.Use(sym, alias, e, loc)
 
       case KindedAst.Expression.Cst(Ast.Constant.Null, loc) =>
         TypedAst.Expression.Cst(Ast.Constant.Null, Type.Null, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -97,7 +97,7 @@ object CodeHinter {
 
     case Expression.OpenAs(_, exp, _, _) => visitExp(exp)
 
-    case Expression.Use(_, exp, _) => visitExp(exp)
+    case Expression.Use(_, _, exp, _) => visitExp(exp)
 
     case Expression.Cst(_, _, _) => Nil
 


### PR DESCRIPTION
related to #4967. This will allow for checking overlap of use/vars.