### PR TITLE
ci: use head commits for community build

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -50,25 +50,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 17
+      - name: Check out project head
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.repo }}
       - name: Download Flix JAR
         uses: actions/download-artifact@v3
         with:
           name: flix-jar
-      - name: Initialize Flix Package
-        run: |
-          java -jar flix.jar init
-          
-          # Remove example code to avoid conflicts.
-          rm src/Main.flix
-          rm test/TestMain.flix
-      - name: Download Project Package
-        uses: robinraju/release-downloader@v1.7
-        with: 
-          repository: ${{ matrix.repo }}
-          latest: true
-          fileName: "*.fpkg"
-          out-file-path: lib/${{ matrix.repo }}
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build community project
         timeout-minutes: 10
         run: |


### PR DESCRIPTION
The community build runner now checks out the head commit of each repository, instead of getting the latest release.

This change makes it so that community build owners do not have to draft a new release every time a change is made to the Flix compiler. Instead, they can simply add a new commit to their repository.

I think this is nice as it lightens the load of maintaining a community build, and establishes a reasonable guideline for community build owners: the repo head should track Flix development head, and releases can be pinned to Flix releases (instead of halfway between two Flix releases)