### PR TITLE
chore: add boilerplate for associated types

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -522,6 +522,7 @@ object Indexer {
     }
     case Type.Apply(tpe1, tpe2, _) => visitType(tpe1) ++ visitType(tpe2)
     case Type.Alias(Ast.AliasConstructor(sym, loc), args, _, _) => Index.occurrenceOf(tpe0) ++ Index.useOf(sym, loc) ++ traverse(args)(visitType)
+    case Type.AssocType(Ast.AssocTypeConstructor(sym, loc), args, _, _) => Index.occurrenceOf(tpe0) ++ traverse(args)(visitType) // TODO ASSOC-TYPES add occurrenc eof assoc type
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -112,7 +112,7 @@ object Indexer {
     * Returns a reverse index for the given instance `instance0`.
     */
   private def visitInstance(instance0: Instance): Index = instance0 match {
-    case Instance(_, _, _, clazz, tpe, tconstrs, defs, _, _) =>
+    case Instance(_, _, _, clazz, tpe, tconstrs, _, defs, _, _) => // TODO ASSOC-TYPES visit assocs
       val idx1 = Index.useOf(clazz.sym, clazz.loc)
       val idx2 = visitType(tpe)
       val idx3 = traverse(tconstrs)(visitTypeConstraint)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -132,7 +132,7 @@ object SemanticTokensProvider {
     * Returns all semantic tokens in the given class `classDecl`.
     */
   private def visitClass(classDecl: TypedAst.Class): Iterator[SemanticToken] = classDecl match {
-    case TypedAst.Class(_, _, _, sym, tparam, superClasses, signatures, laws, _) =>
+    case TypedAst.Class(_, _, _, sym, tparam, superClasses, _, signatures, laws, _) => // TODO ASSOC-TYPES visit assocs
       val t = SemanticToken(SemanticTokenType.Interface, Nil, sym.loc)
       val st1 = Iterator(t)
       val st2 = superClasses.flatMap(visitTypeConstraint)
@@ -146,7 +146,7 @@ object SemanticTokensProvider {
     * Returns all semantic tokens in the given instance `inst0`.
     */
   private def visitInstance(inst0: TypedAst.Instance): Iterator[SemanticToken] = inst0 match {
-    case TypedAst.Instance(_, _, _, sym, tpe, tconstrs, defs, _, _) =>
+    case TypedAst.Instance(_, _, _, sym, tpe, tconstrs, _, defs, _, _) => // TODO ASSOC-TYPES visit assocs
       // NB: we use SemanticTokenType.Class because the OOP "Class" most directly corresponds to the FP "Instance"
       val t = SemanticToken(SemanticTokenType.Class, Nil, sym.loc)
       val st1 = Iterator(t)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -598,6 +598,10 @@ object SemanticTokensProvider {
     case Type.Alias(cst, args, _, _) =>
       val t = SemanticToken(SemanticTokenType.Type, Nil, cst.loc)
       Iterator(t) ++ args.flatMap(visitType).iterator
+
+    case Type.AssocType(cst, args, _, _) =>
+      val t = SemanticToken(SemanticTokenType.Type, Nil, cst.loc)
+      Iterator(t) ++ args.flatMap(visitType).iterator
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
@@ -62,7 +62,7 @@ object SymbolProvider {
     * Returns an Interface SymbolInformation from a Class node.
     */
   private def mkClassSymbolInformation(c: TypedAst.Class) = c match {
-    case TypedAst.Class(_, _, _, sym, _, _, _, _, _) => SymbolInformation(
+    case TypedAst.Class(_, _, _, sym, _, _, _, _, _, _) => SymbolInformation(
       sym.name, SymbolKind.Interface, Nil, deprecated = false, Location(sym.loc.source.name, Range.from(sym.loc)), None,
     )
   }
@@ -72,7 +72,7 @@ object SymbolProvider {
     * It navigates the AST and adds Sig and TypeParam of c and as children DocumentSymbols.
     */
   private def mkClassDocumentSymbol(c: TypedAst.Class): DocumentSymbol = c match {
-    case TypedAst.Class(doc, _, _, sym, tparam, _, signatures, _, _) => DocumentSymbol(
+    case TypedAst.Class(doc, _, _, sym, tparam, _, _, signatures, _, _) => DocumentSymbol( // TODO ASSOC-TYPES visit assocs
       sym.name,
       Some(doc.text),
       SymbolKind.Interface,

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InstanceCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InstanceCompleter.scala
@@ -48,6 +48,10 @@ object InstanceCompleter extends Completer {
         val args = args0.map(replaceText(tvar, _, newText))
         val t = replaceText(tvar, tpe0, newText)
         Type.Alias(sym, args, t, loc)
+
+      case Type.AssocType(sym, args0, kind, loc) =>
+        val args = args0.map(replaceText(tvar, _, newText))
+        Type.AssocType(sym, args, kind, loc)
     }
 
     /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -735,6 +735,11 @@ object Ast {
   case class AliasConstructor(sym: Symbol.TypeAliasSym, loc: SourceLocation)
 
   /**
+    * A constructor for an associated type. (Not a valid type by itself).
+    */
+  case class AssocTypeConstructor(sym: Symbol.AssocTypeSym, loc: SourceLocation)
+
+  /**
     * A use of a Flix symbol or import of a Java class.
     */
   sealed trait UseOrImport

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -52,6 +52,10 @@ object KindedAst {
 
   case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.TypeAliasSym, tparams: List[KindedAst.TypeParam], tpe: Type, loc: SourceLocation)
 
+  case class AssociatedTypeSig(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.AssocTypeSym, tparams: List[KindedAst.TypeParam], kind: Kind, loc: SourceLocation)
+
+  case class AssociatedTypeDef(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, args: List[Type], tpe: Type, loc: SourceLocation)
+
   case class Effect(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[KindedAst.Op], loc: SourceLocation)
 
   case class Op(sym: Symbol.OpSym, spec: KindedAst.Spec)

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -36,9 +36,9 @@ object KindedAst {
                   sources: Map[Source, SourceLocation],
                   names: MultiMap[List[String], String])
 
-  case class Class(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: KindedAst.TypeParam, superClasses: List[Ast.TypeConstraint], sigs: Map[Symbol.SigSym, KindedAst.Sig], laws: List[KindedAst.Def], loc: SourceLocation)
+  case class Class(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: KindedAst.TypeParam, superClasses: List[Ast.TypeConstraint], assocs: List[KindedAst.AssociatedTypeSig], sigs: Map[Symbol.SigSym, KindedAst.Sig], laws: List[KindedAst.Def], loc: SourceLocation)
 
-  case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, clazz: Ast.ClassSymUse, tpe: Type, tconstrs: List[Ast.TypeConstraint], defs: List[KindedAst.Def], ns: Name.NName, loc: SourceLocation)
+  case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, clazz: Ast.ClassSymUse, tpe: Type, tconstrs: List[Ast.TypeConstraint], assocs: List[KindedAst.AssociatedTypeDef], defs: List[KindedAst.Def], ns: Name.NName, loc: SourceLocation)
 
   case class Sig(sym: Symbol.SigSym, spec: KindedAst.Spec, exp: Option[KindedAst.Expression])
 

--- a/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
@@ -34,9 +34,9 @@ object LoweredAst {
                   sources: Map[Source, SourceLocation],
                   classEnv: Map[Symbol.ClassSym, Ast.ClassContext])
 
-  case class Class(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: LoweredAst.TypeParam, superClasses: List[Ast.TypeConstraint], signatures: List[LoweredAst.Sig], laws: List[LoweredAst.Def], loc: SourceLocation)
+  case class Class(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: LoweredAst.TypeParam, superClasses: List[Ast.TypeConstraint], assocs: List[LoweredAst.AssociatedTypeSig], signatures: List[LoweredAst.Sig], laws: List[LoweredAst.Def], loc: SourceLocation)
 
-  case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, clazz: Ast.ClassSymUse, tpe: Type, tconstrs: List[Ast.TypeConstraint], defs: List[LoweredAst.Def], ns: Name.NName, loc: SourceLocation)
+  case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, clazz: Ast.ClassSymUse, tpe: Type, tconstrs: List[Ast.TypeConstraint], assocs: List[LoweredAst.AssociatedTypeDef], defs: List[LoweredAst.Def], ns: Name.NName, loc: SourceLocation)
 
   case class Sig(sym: Symbol.SigSym, spec: LoweredAst.Spec, impl: Option[LoweredAst.Impl])
 
@@ -49,6 +49,12 @@ object LoweredAst {
   case class Enum(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, tparams: List[LoweredAst.TypeParam], derives: List[Ast.Derivation], cases: Map[Symbol.CaseSym, LoweredAst.Case], tpeDeprecated: Type, loc: SourceLocation)
 
   case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.TypeAliasSym, tparams: List[LoweredAst.TypeParam], tpe: Type, loc: SourceLocation)
+
+  // TODO ASSOC-TYPES can probably be combined with KindedAst.AssocTypeSig
+  case class AssociatedTypeSig(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.AssocTypeSym, tparams: List[KindedAst.TypeParam], kind: Kind, loc: SourceLocation)
+
+  // TODO ASSOC-TYPES can probably be combined with KindedAst.AssocTypeSig
+  case class AssociatedTypeDef(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, args: List[Type], tpe: Type, loc: SourceLocation)
 
   case class Effect(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[LoweredAst.Op], loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -39,9 +39,9 @@ object NamedAst {
 
     case class Namespace(sym: Symbol.ModuleSym, usesAndImports: List[NamedAst.UseOrImport], decls: List[NamedAst.Declaration], loc: SourceLocation) extends NamedAst.Declaration
 
-    case class Class(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: NamedAst.TypeParam, superClasses: List[NamedAst.TypeConstraint], sigs: List[NamedAst.Declaration.Sig], laws: List[NamedAst.Declaration.Def], loc: SourceLocation) extends NamedAst.Declaration
+    case class Class(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: NamedAst.TypeParam, superClasses: List[NamedAst.TypeConstraint], assocs: List[NamedAst.Declaration.AssocTypeSig], sigs: List[NamedAst.Declaration.Sig], laws: List[NamedAst.Declaration.Def], loc: SourceLocation) extends NamedAst.Declaration
 
-    case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, clazz: Name.QName, tparams: NamedAst.TypeParams, tpe: NamedAst.Type, tconstrs: List[NamedAst.TypeConstraint], defs: List[NamedAst.Declaration.Def], ns: List[String], loc: SourceLocation) extends NamedAst.Declaration
+    case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, clazz: Name.QName, tparams: NamedAst.TypeParams, tpe: NamedAst.Type, tconstrs: List[NamedAst.TypeConstraint], assocs: List[NamedAst.Declaration.AssocTypeDef], defs: List[NamedAst.Declaration.Def], ns: List[String], loc: SourceLocation) extends NamedAst.Declaration
 
     case class Sig(sym: Symbol.SigSym, spec: NamedAst.Spec, exp: Option[NamedAst.Expression]) extends NamedAst.Declaration
 
@@ -52,6 +52,10 @@ object NamedAst {
     case class RestrictableEnum(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.RestrictableEnumSym, index: NamedAst.TypeParam, tparams: NamedAst.TypeParams, derives: List[Name.QName], cases: List[NamedAst.Declaration.RestrictableCase], loc: SourceLocation) extends NamedAst.Declaration
 
     case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.TypeAliasSym, tparams: NamedAst.TypeParams, tpe: NamedAst.Type, loc: SourceLocation) extends NamedAst.Declaration
+
+    case class AssocTypeSig(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.AssocTypeSym, tparams: NamedAst.TypeParams, kind: NamedAst.Kind, loc: SourceLocation) extends NamedAst.Declaration
+
+    case class AssocTypeDef(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, args: List[NamedAst.Type], tpe: NamedAst.Type, loc: SourceLocation) extends NamedAst.Declaration
 
     case class Effect(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[NamedAst.Declaration.Op], loc: SourceLocation) extends NamedAst.Declaration
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -175,6 +175,32 @@ object ParsedAst {
     case class TypeAlias(doc: ParsedAst.Doc, mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, tpe: ParsedAst.Type, sp2: SourcePosition) extends ParsedAst.Declaration
 
     /**
+      * Associated Type Signature Declaration.
+      *
+      * @param doc     the optional comment associated with the declaration.
+      * @param mod     the associated modifiers.
+      * @param sp1     the position of the first character in the declaration.
+      * @param ident   the name of the type.
+      * @param tparams the type parameters of the type.
+      * @param kind    the kind of the type.
+      * @param sp2     the position of the last character in the declaration.
+      */
+    case class AssocTypeSig(doc: ParsedAst.Doc, mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, kind: ParsedAst.Kind, sp2: SourcePosition)
+
+    /**
+      * Associated Type Declaration.
+      *
+      * @param doc   the optional comment associated with the declaration.
+      * @param mod   the associated modifiers.
+      * @param sp1   the position of the first character in the declaration.
+      * @param ident the name of the type.
+      * @param args  the arguments of the type.
+      * @param tpe   the type of the type.
+      * @param sp2   the position of the last character in the declaration.
+      */
+    case class AssocTypeDef(doc: ParsedAst.Doc, mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, args: Seq[ParsedAst.Type], tpe: ParsedAst.Type, sp2: SourcePosition)
+
+    /**
       * Relation Declaration.
       *
       * @param doc     the optional comment associated with the definition.
@@ -210,24 +236,26 @@ object ParsedAst {
       * @param ident        the name of the definition.
       * @param tparam       the type parameter.
       * @param superClasses the super classes of the class.
+      * @param assocs       the associated types
       * @param lawsAndSigs  the signatures and laws of the class.
       * @param sp2          the position of the last character in the declaration.
       */
-    case class Class(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparam: ParsedAst.TypeParam, superClasses: Seq[ParsedAst.TypeConstraint], lawsAndSigs: Seq[ParsedAst.Declaration.LawOrSig], sp2: SourcePosition) extends ParsedAst.Declaration
+    case class Class(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparam: ParsedAst.TypeParam, superClasses: Seq[ParsedAst.TypeConstraint], assocs: Seq[ParsedAst.Declaration.AssocTypeSig], lawsAndSigs: Seq[ParsedAst.Declaration.LawOrSig], sp2: SourcePosition) extends ParsedAst.Declaration
 
     /**
       * Typeclass instance.
       *
-      * @param doc   the optional comment associated with the declaration.
-      * @param ann   the annotations associated with the declaration.
-      * @param mod   the associated modifiers.
-      * @param sp1   the position of the first character in the declaration.
-      * @param clazz the name of the class.
-      * @param tpe   the type of the instance.
-      * @param defs  the definitions of the instance.
-      * @param sp2   the position of the last character in the declaration.
+      * @param doc    the optional comment associated with the declaration.
+      * @param ann    the annotations associated with the declaration.
+      * @param mod    the associated modifiers.
+      * @param sp1    the position of the first character in the declaration.
+      * @param clazz  the name of the class.
+      * @param tpe    the type of the instance.
+      * @param assocs the associated types
+      * @param defs   the definitions of the instance.
+      * @param sp2    the position of the last character in the declaration.
       */
-    case class Instance(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, clazz: Name.QName, tpe: ParsedAst.Type, constraints: Seq[ParsedAst.TypeConstraint], defs: Seq[ParsedAst.Declaration.Def], sp2: SourcePosition) extends ParsedAst.Declaration
+    case class Instance(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, clazz: Name.QName, tpe: ParsedAst.Type, constraints: Seq[ParsedAst.TypeConstraint], assocs: Seq[ParsedAst.Declaration.AssocTypeDef], defs: Seq[ParsedAst.Declaration.Def], sp2: SourcePosition) extends ParsedAst.Declaration
 
     /**
       * Effect Declaration.

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -63,6 +63,10 @@ object ResolvedAst {
 
     case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.TypeAliasSym, tparams: ResolvedAst.TypeParams, tpe: UnkindedType, loc: SourceLocation) extends Declaration
 
+    case class AssociatedTypeSig(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.AssocTypeSym, tparams: ResolvedAst.TypeParams, kind: Kind, loc: SourceLocation) extends Declaration
+
+    case class AssociatedTypeDef(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.AssocTypeSym, args: List[UnkindedType], tpe: UnkindedType, loc: SourceLocation) extends Declaration
+
     case class Effect(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[ResolvedAst.Declaration.Op], loc: SourceLocation) extends Declaration
 
     case class Op(sym: Symbol.OpSym, spec: ResolvedAst.Spec) extends Declaration

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -45,9 +45,9 @@ object ResolvedAst {
   object Declaration {
     case class Namespace(sym: Symbol.ModuleSym, usesAndImports: List[Ast.UseOrImport], decls: List[Declaration], loc: SourceLocation) extends Declaration
 
-    case class Class(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: ResolvedAst.TypeParam, superClasses: List[ResolvedAst.TypeConstraint], sigs: Map[Symbol.SigSym, ResolvedAst.Declaration.Sig], laws: List[ResolvedAst.Declaration.Def], loc: SourceLocation) extends Declaration
+    case class Class(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: ResolvedAst.TypeParam, superClasses: List[ResolvedAst.TypeConstraint], assocs: List[ResolvedAst.Declaration.AssociatedTypeSig], sigs: Map[Symbol.SigSym, ResolvedAst.Declaration.Sig], laws: List[ResolvedAst.Declaration.Def], loc: SourceLocation) extends Declaration
 
-    case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, clazz: Ast.ClassSymUse, tpe: UnkindedType, tconstrs: List[ResolvedAst.TypeConstraint], defs: List[ResolvedAst.Declaration.Def], ns: Name.NName, loc: SourceLocation) extends Declaration
+    case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, clazz: Ast.ClassSymUse, tpe: UnkindedType, tconstrs: List[ResolvedAst.TypeConstraint], assocs: List[ResolvedAst.Declaration.AssociatedTypeDef], defs: List[ResolvedAst.Declaration.Def], ns: Name.NName, loc: SourceLocation) extends Declaration
 
     case class Sig(sym: Symbol.SigSym, spec: ResolvedAst.Spec, exp: Option[ResolvedAst.Expression]) extends Declaration
 
@@ -65,7 +65,7 @@ object ResolvedAst {
 
     case class AssociatedTypeSig(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.AssocTypeSym, tparams: ResolvedAst.TypeParams, kind: Kind, loc: SourceLocation) extends Declaration
 
-    case class AssociatedTypeDef(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.AssocTypeSym, args: List[UnkindedType], tpe: UnkindedType, loc: SourceLocation) extends Declaration
+    case class AssociatedTypeDef(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, args: List[UnkindedType], tpe: UnkindedType, loc: SourceLocation) extends Declaration
 
     case class Effect(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[ResolvedAst.Declaration.Op], loc: SourceLocation) extends Declaration
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
@@ -65,6 +65,7 @@ object Scheme {
       case Type.Cst(tc, _) => Type.Cst(tc, loc)
       case Type.Apply(tpe1, tpe2, _) => Type.Apply(visitType(tpe1), visitType(tpe2), loc)
       case Type.Alias(sym, args, tpe, _) => Type.Alias(sym, args.map(visitType), visitType(tpe), loc)
+      case Type.AssocType(sym, args, kind, _) => Type.AssocType(sym, args.map(visitType), kind, loc)
     }
 
     val newBase = visitType(baseType)

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -189,6 +189,13 @@ object Symbol {
   }
 
   /**
+    * Returns the associated type symbol for the given name `ident` in the class associated with the given class symbol `classSym`.
+    */
+  def mkAssocTypeSym(classSym: ClassSym, ident: Name.Ident): AssocTypeSym = {
+    new AssocTypeSym(classSym, ident.name, ident.loc)
+  }
+
+  /**
     * Returns the type alias symbol for the given fully qualified name
     */
   def mkTypeAliasSym(fqn: String): TypeAliasSym = split(fqn) match {
@@ -626,6 +633,34 @@ object Symbol {
       * Human readable representation.
       */
     override def toString: String = name
+  }
+
+  /**
+    * Associated Type Symbol.
+    */
+  final class AssocTypeSym(val clazz: Symbol.ClassSym, val name: String, val loc: SourceLocation) extends Symbol {
+    /**
+      * Returns `true` if this symbol is equal to `that` symbol.
+      */
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case that: AssocTypeSym => this.clazz == that.clazz && this.name == that.name
+      case _ => false
+    }
+
+    /**
+      * Returns the hash code of this symbol.
+      */
+    override val hashCode: Int = Objects.hash(clazz, name)
+
+    /**
+      * Human readable representation.
+      */
+    override def toString: String = clazz.toString + "." + name
+
+    /**
+      * The symbol's namespace.
+      */
+    def namespace: List[String] = clazz.namespace :+ clazz.name
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -105,7 +105,7 @@ sealed trait Type {
     case Type.Cst(tc, _) => Some(tc)
     case Type.Apply(t1, _, _) => t1.typeConstructor
     case Type.Alias(_, _, tpe, _) => tpe.typeConstructor
-    case Type.AssocType(_, _, _, loc) => throw InternalCompilerException("unexpected associated type", loc) // TODO ASSOC-TYPE danger!
+    case Type.AssocType(_, _, _, loc) => None // TODO ASSOC-TYPE danger!
   }
 
   /**
@@ -132,7 +132,7 @@ sealed trait Type {
     case Type.Cst(tc, _) => tc :: Nil
     case Type.Apply(t1, t2, _) => t1.typeConstructors ::: t2.typeConstructors
     case Type.Alias(_, _, tpe, _) => tpe.typeConstructors
-    case Type.AssocType(_, _, _, loc) => throw InternalCompilerException("unexpected associated type", loc) // TODO ASSOC-TYPE danger!
+    case Type.AssocType(_, _, _, loc) => Nil // TODO ASSOC-TYPE danger!
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -49,6 +49,7 @@ sealed trait Type {
     case Type.Cst(tc, _) => SortedSet.empty
     case Type.Apply(tpe1, tpe2, _) => tpe1.typeVars ++ tpe2.typeVars
     case Type.Alias(_, args, _, _) => args.flatMap(_.typeVars).to(SortedSet)
+    case Type.AssocType(_, args, _, _) => args.flatMap(_.typeVars).to(SortedSet) // TODO ASSOC-TYPES throw error?
   }
 
   /**
@@ -62,6 +63,7 @@ sealed trait Type {
 
     case Type.Apply(tpe1, tpe2, _) => tpe1.effects ++ tpe2.effects
     case Type.Alias(_, _, tpe, _) => tpe.effects
+    case Type.AssocType(_, args, _, _) => args.flatMap(_.effects).to(SortedSet) // TODO ASSOC-TYPES throw error?
   }
 
   /**
@@ -75,6 +77,7 @@ sealed trait Type {
 
     case Type.Apply(tpe1, tpe2, _) => tpe1.cases ++ tpe2.cases
     case Type.Alias(_, _, tpe, _) => tpe.cases
+    case Type.AssocType(_, args, _, _) => args.flatMap(_.cases).to(SortedSet) // TODO ASSOC-TYPES throw error?
   }
 
   /**
@@ -102,6 +105,7 @@ sealed trait Type {
     case Type.Cst(tc, _) => Some(tc)
     case Type.Apply(t1, _, _) => t1.typeConstructor
     case Type.Alias(_, _, tpe, _) => tpe.typeConstructor
+    case Type.AssocType(_, _, _, loc) => throw InternalCompilerException("unexpected associated type", loc) // TODO ASSOC-TYPE danger!
   }
 
   /**
@@ -128,6 +132,7 @@ sealed trait Type {
     case Type.Cst(tc, _) => tc :: Nil
     case Type.Apply(t1, t2, _) => t1.typeConstructors ::: t2.typeConstructors
     case Type.Alias(_, _, tpe, _) => tpe.typeConstructors
+    case Type.AssocType(_, _, _, loc) => throw InternalCompilerException("unexpected associated type", loc) // TODO ASSOC-TYPE danger!
   }
 
   /**
@@ -158,6 +163,7 @@ sealed trait Type {
     case Type.Cst(_, _) => this
     case Type.Apply(tpe1, tpe2, loc) => Type.Apply(tpe1.map(f), tpe2.map(f), loc)
     case Type.Alias(sym, args, tpe, loc) => Type.Alias(sym, args.map(_.map(f)), tpe.map(f), loc)
+    case Type.AssocType(sym, args, kind, loc) => Type.AssocType(sym, args.map(_.map(f)), kind, loc)
   }
 
   /**
@@ -208,6 +214,7 @@ sealed trait Type {
     case Type.Cst(_, _) => 1
     case Type.Apply(tpe1, tpe2, _) => tpe1.size + tpe2.size + 1
     case Type.Alias(_, _, tpe, _) => tpe.size
+    case Type.AssocType(_, args, kind, _) => args.map(_.size).sum + 1
   }
 
   /**
@@ -454,6 +461,11 @@ object Type {
   case class Alias(cst: Ast.AliasConstructor, args: List[Type], tpe: Type, loc: SourceLocation) extends Type with BaseType {
     override def kind: Kind = tpe.kind
   }
+
+  /**
+    * An associated type.
+    */
+  case class AssocType(cst: Ast.AssocTypeConstructor, args: List[Type], kind: Kind, loc: SourceLocation) extends Type with BaseType
 
   /////////////////////////////////////////////////////////////////////////////
   // Utility Functions                                                       //
@@ -972,6 +984,7 @@ object Type {
     case Type.Cst(_, _) => t
     case Type.Apply(tpe1, tpe2, loc) => Type.Apply(eraseAliases(tpe1), eraseAliases(tpe2), loc)
     case Type.Alias(_, _, tpe, _) => eraseAliases(tpe)
+    case Type.AssocType(cst, args, kind, loc) => Type.AssocType(cst, args.map(eraseAliases), kind, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -41,9 +41,9 @@ object TypedAst {
                   classEnv: Map[Symbol.ClassSym, Ast.ClassContext],
                   names: MultiMap[List[String], String])
 
-  case class Class(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: TypedAst.TypeParam, superClasses: List[Ast.TypeConstraint], signatures: List[TypedAst.Sig], laws: List[TypedAst.Def], loc: SourceLocation)
+  case class Class(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.ClassSym, tparam: TypedAst.TypeParam, superClasses: List[Ast.TypeConstraint], assocs: List[TypedAst.AssociatedTypeSig], signatures: List[TypedAst.Sig], laws: List[TypedAst.Def], loc: SourceLocation)
 
-  case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, clazz: Ast.ClassSymUse, tpe: Type, tconstrs: List[Ast.TypeConstraint], defs: List[TypedAst.Def], ns: Name.NName, loc: SourceLocation)
+  case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, clazz: Ast.ClassSymUse, tpe: Type, tconstrs: List[Ast.TypeConstraint], assocs: List[TypedAst.AssociatedTypeDef], defs: List[TypedAst.Def], ns: Name.NName, loc: SourceLocation)
 
   case class Sig(sym: Symbol.SigSym, spec: TypedAst.Spec, impl: Option[TypedAst.Impl])
 
@@ -58,6 +58,12 @@ object TypedAst {
   case class RestrictableEnum(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.RestrictableEnumSym, index: TypedAst.TypeParam, tparams: List[TypedAst.TypeParam], derives: List[Ast.Derivation], cases: Map[Symbol.RestrictableCaseSym, TypedAst.RestrictableCase], tpeDeprecated: Type, loc: SourceLocation)
 
   case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.TypeAliasSym, tparams: List[TypedAst.TypeParam], tpe: Type, loc: SourceLocation)
+
+  // TODO ASSOC-TYPES can probably be combined with KindedAst.AssocTypeSig
+  case class AssociatedTypeSig(doc: Ast.Doc, mod: Ast.Modifiers, sym: Symbol.AssocTypeSym, tparams: List[KindedAst.TypeParam], kind: Kind, loc: SourceLocation)
+
+  // TODO ASSOC-TYPES can probably be combined with KindedAst.AssocTypeSig
+  case class AssociatedTypeDef(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, args: List[Type], tpe: Type, loc: SourceLocation)
 
   case class Effect(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[TypedAst.Op], loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -33,9 +33,9 @@ object WeededAst {
     case class Namespace(ident: Name.Ident, usesAndImports: List[WeededAst.UseOrImport], decls: List[WeededAst.Declaration], loc: SourceLocation) extends WeededAst.Declaration
 
     // TODO change laws to WeededAst.Law
-    case class Class(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, ident: Name.Ident, tparam: WeededAst.TypeParam, superClasses: List[WeededAst.TypeConstraint], sigs: List[WeededAst.Declaration.Sig], laws: List[WeededAst.Declaration.Def], loc: SourceLocation) extends WeededAst.Declaration
+    case class Class(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, ident: Name.Ident, tparam: WeededAst.TypeParam, superClasses: List[WeededAst.TypeConstraint], assocs: List[WeededAst.Declaration.AssocTypeSig], sigs: List[WeededAst.Declaration.Sig], laws: List[WeededAst.Declaration.Def], loc: SourceLocation) extends WeededAst.Declaration
 
-    case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, clazz: Name.QName, tpe: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], defs: List[WeededAst.Declaration.Def], loc: SourceLocation) extends WeededAst.Declaration
+    case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, clazz: Name.QName, tpe: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], assocs: List[WeededAst.Declaration.AssocTypeDef], defs: List[WeededAst.Declaration.Def], loc: SourceLocation) extends WeededAst.Declaration
 
     case class Sig(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: Option[WeededAst.Expression], tpe: WeededAst.Type, purAndEff: PurityAndEffect, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation)
 
@@ -48,6 +48,10 @@ object WeededAst {
     case class RestrictableEnum(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, ident: Name.Ident, index: WeededAst.TypeParam, tparams: WeededAst.TypeParams, derives: List[Name.QName], cases: List[WeededAst.RestrictableCase], loc: SourceLocation) extends WeededAst.Declaration
 
     case class TypeAlias(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.TypeParams, tpe: WeededAst.Type, loc: SourceLocation) extends WeededAst.Declaration
+
+    case class AssocTypeSig(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.TypeParams, kind: WeededAst.Kind, loc: SourceLocation)
+
+    case class AssocTypeDef(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, args: List[WeededAst.Type], tpe: WeededAst.Type, loc: SourceLocation)
 
     case class Effect(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, ident: Name.Ident, ops: List[WeededAst.Declaration.Op], loc: SourceLocation) extends WeededAst.Declaration
 

--- a/main/src/ca/uwaterloo/flix/language/fmt/SimpleType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/SimpleType.scala
@@ -310,6 +310,8 @@ object SimpleType {
         mkApply(Var(sym.id, sym.kind, sym.isRegion, sym.text), t.typeArguments.map(visit))
       case Type.Alias(cst, args, _, _) =>
         mkApply(Name(cst.sym.name), (args ++ t.typeArguments).map(visit))
+      case Type.AssocType(cst, args, _, _) =>
+        mkApply(Name(cst.sym.name), (args ++ t.typeArguments).map(visit))
       case Type.Cst(tc, _) => tc match {
         case TypeConstructor.Unit => Unit
         case TypeConstructor.Null => Null

--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -115,6 +115,7 @@ object Deriver {
         clazz = Ast.ClassSymUse(eqClassSym, loc),
         tpe = tpe,
         tconstrs = tconstrs,
+        assocs = Nil,
         defs = List(defn),
         ns = Name.RootNS,
         loc = loc
@@ -265,6 +266,7 @@ object Deriver {
         clazz = Ast.ClassSymUse(orderClassSym, loc),
         tpe = tpe,
         tconstrs = tconstrs,
+        assocs = Nil,
         defs = List(defn),
         ns = Name.RootNS,
         loc = loc
@@ -482,6 +484,7 @@ object Deriver {
         clazz = Ast.ClassSymUse(toStringClassSym, loc),
         tpe = tpe,
         tconstrs = tconstrs,
+        assocs = Nil,
         defs = List(defn),
         ns = Name.RootNS,
         loc = loc
@@ -618,6 +621,7 @@ object Deriver {
         tpe = tpe,
         tconstrs = tconstrs,
         defs = List(defn),
+        assocs = Nil,
         ns = Name.RootNS,
         loc = loc
       ).toSuccess
@@ -739,6 +743,7 @@ object Deriver {
         clazz = Ast.ClassSymUse(boxableClassSym, loc),
         tpe = tpe,
         tconstrs = tconstrs,
+        assocs = Nil,
         defs = Nil,
         ns = Name.RootNS,
         loc = loc
@@ -778,6 +783,7 @@ object Deriver {
         tpe = tpe,
         tconstrs = tconstrs,
         defs = Nil,
+        assocs = Nil,
         ns = Name.RootNS,
         loc = loc
       ).toSuccess

--- a/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Documentor.scala
@@ -258,7 +258,7 @@ object Documentor {
     * Returns the given instance `inst` as a JSON value.
     */
   private def visitInstance(sym: Symbol.ClassSym, inst: Instance)(implicit flix: Flix): JObject = inst match {
-    case Instance(_, ann, _, _, tpe, tcs, _, _, loc) =>
+    case Instance(_, ann, _, _, tpe, tcs, _, _, _, loc) => // TODO ASSOC-TYPES visit assocs
       ("sym" -> visitClassSym(sym)) ~
         ("ann" -> visitAnnotations(ann)) ~
         ("tpe" -> visitType(tpe)) ~
@@ -467,7 +467,7 @@ object Documentor {
     * Return the given class `clazz` as a JSON value.
     */
   private def visitClass(cla: Class)(implicit root: Root, flix: Flix): JObject = cla match {
-    case Class(doc, ann, mod, sym, tparam, superClasses, signatures0, _, loc) =>
+    case Class(doc, ann, mod, sym, tparam, superClasses, _, signatures0, _, loc) => // TODO ASSOC-TYPES visit assocs
       val (sigs0, defs0) = signatures0.partition(_.impl.isEmpty)
 
       val sigs = sigs0.sortBy(_.sym.name).map(visitSig)

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -48,7 +48,7 @@ object Instances {
       */
     def checkLawApplication(class0: TypedAst.Class): List[InstanceError] = class0 match {
       // Case 1: lawful class
-      case TypedAst.Class(_, _, mod, _, _, _, sigs, laws, _) if mod.isLawful =>
+      case TypedAst.Class(_, _, mod, _, _, _, _, sigs, laws, _) if mod.isLawful =>
         val usedSigs = laws.foldLeft(Set.empty[Symbol.SigSym]) {
           case (acc, TypedAst.Def(_, _, TypedAst.Impl(exp, _))) => acc ++ TypedAstOps.sigSymsOf(exp)
         }
@@ -57,7 +57,7 @@ object Instances {
           sig => InstanceError.UnlawfulSignature(sig, sig.loc)
         }
       // Case 2: non-lawful class
-      case TypedAst.Class(_, _, mod, _, _, _, _, _, _) => Nil
+      case TypedAst.Class(_, _, _, _, _, _, _, _, _, _) => Nil
     }
 
     /**
@@ -83,7 +83,7 @@ object Instances {
       * * The same namespace as its type.
       */
     def checkOrphan(inst: TypedAst.Instance): List[InstanceError] = inst match {
-      case TypedAst.Instance(_, _, _, clazz, tpe, _, _, ns, _) => tpe.typeConstructor match {
+      case TypedAst.Instance(_, _, _, clazz, tpe, _, _, _, ns, _) => tpe.typeConstructor match {
         // Case 1: Enum type in the same namespace as the instance: not an orphan
         case Some(TypeConstructor.Enum(enumSym, _)) if enumSym.namespace == ns.idents.map(_.name) => Nil
         // Case 2: Any type in the class namespace: not an orphan
@@ -99,7 +99,7 @@ object Instances {
       * * all type arguments are variables or booleans
       */
     def checkSimple(inst: TypedAst.Instance): List[InstanceError] = inst match {
-      case TypedAst.Instance(_, _, _, clazz, tpe, _, _, _, _) => tpe match {
+      case TypedAst.Instance(_, _, _, clazz, tpe, _, _, _, _, _) => tpe match {
         case _: Type.Cst => Nil
         case _: Type.Var => List(InstanceError.ComplexInstanceType(tpe, clazz.sym, clazz.loc))
         case _: Type.Apply =>
@@ -210,7 +210,7 @@ object Instances {
       * and that the constraints on `inst` entail the constraints on the super instance.
       */
     def checkSuperInstances(inst: TypedAst.Instance): List[InstanceError] = inst match {
-      case TypedAst.Instance(_, _, _, clazz, tpe, tconstrs, _, _, _) =>
+      case TypedAst.Instance(_, _, _, clazz, tpe, tconstrs, _, _, _, _) =>
         val superClasses = root.classEnv(clazz.sym).superClasses
         superClasses flatMap {
           superClass =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -121,6 +121,7 @@ object Instances {
           }
           errs0
         case Type.Alias(alias, _, _, _) => List(InstanceError.IllegalTypeAliasInstance(alias.sym, clazz.sym, clazz.loc))
+        case Type.AssocType(assoc, _, _, loc) => throw InternalCompilerException("unexpected associated type", loc) // TODO ASSOC-TYPES real error
       }
     }
 
@@ -148,6 +149,7 @@ object Instances {
       case t: Type.Cst => t
       case Type.Apply(tpe1, tpe2, loc) => Type.Apply(generifyBools(tpe1), generifyBools(tpe2), loc)
       case Type.Alias(cst, args, tpe, loc) => Type.Alias(cst, args.map(generifyBools), generifyBools(tpe), loc)
+      case Type.AssocType(cst, args, kind, loc) => Type.AssocType(cst, args.map(generifyBools), kind, loc)
     }
 
     /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -249,13 +249,14 @@ object Kinder {
     * Performs kinding on the given type class.
     */
   private def visitClass(clazz: ResolvedAst.Declaration.Class, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Class, KindError] = clazz match {
-    case ResolvedAst.Declaration.Class(doc, ann, mod, sym, tparam0, superClasses0, assocs0, sigs0, laws0, loc) => // TODO ASSOC-TYPES
+    case ResolvedAst.Declaration.Class(doc, ann, mod, sym, tparam0, superClasses0, assocs0, sigs0, laws0, loc) =>
       val kenv = getKindEnvFromTypeParamDefaultStar(tparam0)
 
       val tparamsVal = visitTypeParam(tparam0, kenv, Map.empty)
       val superClassesVal = traverse(superClasses0)(visitTypeConstraint(_, kenv, Map.empty, taenv, root))
-      flatMapN(tparamsVal, superClassesVal) {
-        case (tparams, superClasses) =>
+      val assocsVal = traverse(assocs0)(visitAssocTypeSig(_, kenv, Map.empty))
+      flatMapN(tparamsVal, superClassesVal, assocsVal) {
+        case (tparams, superClasses, assocs) =>
           // tparams will always be a singleton
           val tparam = tparams.head
           val sigsVal = traverse(sigs0) {
@@ -263,7 +264,7 @@ object Kinder {
           }
           val lawsVal = traverse(laws0)(visitDef(_, kenv, taenv, root))
           mapN(sigsVal, lawsVal) {
-            case (sigs, laws) => KindedAst.Class(doc, ann, mod, sym, tparam, superClasses, sigs.toMap, laws, loc)
+            case (sigs, laws) => KindedAst.Class(doc, ann, mod, sym, tparam, superClasses, assocs, sigs.toMap, laws, loc)
           }
 
       }
@@ -273,7 +274,7 @@ object Kinder {
     * Performs kinding on the given instance.
     */
   private def visitInstance(inst: ResolvedAst.Declaration.Instance, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Instance, KindError] = inst match {
-    case ResolvedAst.Declaration.Instance(doc, ann, mod, clazz, tpe0, tconstrs0, assocs0, defs0, ns, loc) => // TODO ASSOC-TYPES
+    case ResolvedAst.Declaration.Instance(doc, ann, mod, clazz, tpe0, tconstrs0, assocs0, defs0, ns, loc) =>
       val kind = getClassKind(root.classes(clazz.sym))
 
       val kenvVal = inferType(tpe0, kind, KindEnv.empty, taenv, root)
@@ -281,9 +282,10 @@ object Kinder {
         kenv =>
           val tpeVal = visitType(tpe0, kind, kenv, Map.empty, taenv, root)
           val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint(_, kenv, Map.empty, taenv, root))
+          val assocsVal = traverse(assocs0)(visitAssocTypeDef(_, kenv, Map.empty, taenv, root))
           val defsVal = traverse(defs0)(visitDef(_, kenv, taenv, root))
-          mapN(tpeVal, tconstrsVal, defsVal) {
-            case (tpe, tconstrs, defs) => KindedAst.Instance(doc, ann, mod, clazz, tpe, tconstrs, defs, ns, loc)
+          mapN(tpeVal, tconstrsVal, assocsVal, defsVal) {
+            case (tpe, tconstrs, assocs, defs) => KindedAst.Instance(doc, ann, mod, clazz, tpe, tconstrs, assocs, defs, ns, loc)
           }
       }
   }
@@ -388,6 +390,31 @@ object Kinder {
           val base = Type.mkUncurriedArrowWithEffect(fparams.map(_.tpe), pur, eff, tpe, tpe.loc)
           val sc = Scheme(allQuantifiers, tconstrs, base)
           KindedAst.Spec(doc, ann, mod, tparams, fparams, sc, tpe, pur, eff, tconstrs, loc)
+      }
+  }
+
+  /**
+    * Performs kinding on the given associated type signature under the given kind environment.
+    */
+  private def visitAssocTypeSig(s0: ResolvedAst.Declaration.AssociatedTypeSig, kenv: KindEnv, senv: Map[Symbol.UnkindedTypeVarSym, Symbol.UnkindedTypeVarSym]): Validation[KindedAst.AssociatedTypeSig, KindError] = s0 match {
+    case ResolvedAst.Declaration.AssociatedTypeSig(doc, mod, sym, tparams0, kind, loc) =>
+      val tparamsVal = traverse(tparams0.tparams)(visitTypeParam(_, kenv, senv)).map(_.flatten)
+
+      mapN(tparamsVal) {
+        case tparams => KindedAst.AssociatedTypeSig(doc, mod, sym, tparams, kind, loc)
+      }
+  }
+
+  /**
+    * Performs kinding on the given associated type definition under the given kind environment.
+    */
+  private def visitAssocTypeDef(d0: ResolvedAst.Declaration.AssociatedTypeDef, kenv: KindEnv, senv: Map[Symbol.UnkindedTypeVarSym, Symbol.UnkindedTypeVarSym], taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.AssociatedTypeDef, KindError] = d0 match {
+    case ResolvedAst.Declaration.AssociatedTypeDef(doc, mod, ident, args0, tpe0, loc) =>
+      val argsVal = traverse(args0)(visitType(_, Kind.Wild, kenv, senv, taenv, root)) // TODO ASSOC-TYPES use expected from signature
+      val tpeVal = visitType(tpe0, Kind.Wild, kenv, senv, taenv, root) // TODO ASSOC-TYPES use expected from signature
+
+      mapN(argsVal, tpeVal) {
+        case (args, tpe) => KindedAst.AssociatedTypeDef(doc, mod, ident, args, tpe, loc)
       }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -249,7 +249,7 @@ object Kinder {
     * Performs kinding on the given type class.
     */
   private def visitClass(clazz: ResolvedAst.Declaration.Class, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Class, KindError] = clazz match {
-    case ResolvedAst.Declaration.Class(doc, ann, mod, sym, tparam0, superClasses0, sigs0, laws0, loc) =>
+    case ResolvedAst.Declaration.Class(doc, ann, mod, sym, tparam0, superClasses0, assocs0, sigs0, laws0, loc) => // TODO ASSOC-TYPES
       val kenv = getKindEnvFromTypeParamDefaultStar(tparam0)
 
       val tparamsVal = visitTypeParam(tparam0, kenv, Map.empty)
@@ -273,7 +273,7 @@ object Kinder {
     * Performs kinding on the given instance.
     */
   private def visitInstance(inst: ResolvedAst.Declaration.Instance, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Instance, KindError] = inst match {
-    case ResolvedAst.Declaration.Instance(doc, ann, mod, clazz, tpe0, tconstrs0, defs0, ns, loc) =>
+    case ResolvedAst.Declaration.Instance(doc, ann, mod, clazz, tpe0, tconstrs0, assocs0, defs0, ns, loc) => // TODO ASSOC-TYPES
       val kind = getClassKind(root.classes(clazz.sym))
 
       val kenvVal = inferType(tpe0, kind, KindEnv.empty, taenv, root)

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -1625,6 +1625,17 @@ object Kinder {
         }
       }
 
+    case UnkindedType.AssocType(cst, args, loc) =>
+      val clazz = root.classes(cst.sym.clazz)
+      val kind = getClassKind(clazz)
+
+      // TODO ASSOC-TYPES folding here but should only be one arg
+      fold(args, KindEnv.empty) {
+        case (acc, arg) => flatMapN(inferType(arg, kind, kenv0, taenv, root)) {
+          kenv => acc ++ kenv
+        }
+      }
+
     case UnkindedType.Arrow(purAndEff, _, _) =>
       val purAndEffKenvVal = inferPurityAndEffect(purAndEff, kenv0, taenv, root)
       val argKenvVal = fold(tpe.typeArguments, KindEnv.empty) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -1255,8 +1255,11 @@ object Kinder {
           unify(k0, expectedKind) match {
             case Some(kind) =>
               val innerExpectedKind = getClassKind(clazz)
-              val args = traverse(args0)(visitType(_, innerExpectedKind, kenv, senv, taenv, root))
-              ??? // TODO ASSOC-TYPES define Type.AssocType
+              val argsVal = traverse(args0)(visitType(_, innerExpectedKind, kenv, senv, taenv, root))
+              mapN(argsVal) {
+                case args => Type.AssocType(cst, args, kind, loc)
+              }
+            case None => KindError.UnexpectedKind(expectedKind = expectedKind, actualKind = k0, loc).toFailure
           }
       }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -1363,6 +1363,7 @@ object Kinder {
 
 
     case _: UnkindedType.UnappliedAlias => throw InternalCompilerException("unexpected unapplied alias", tpe0.loc)
+    case _: UnkindedType.UnappliedAssocType => throw InternalCompilerException("unexpected unapplied associated type", tpe0.loc)
 
 
   }
@@ -1681,6 +1682,7 @@ object Kinder {
 
     case _: UnkindedType.Apply => throw InternalCompilerException("unexpected type application", tpe.loc)
     case _: UnkindedType.UnappliedAlias => throw InternalCompilerException("unexpected unapplied alias", tpe.loc)
+    case _: UnkindedType.UnappliedAssocType => throw InternalCompilerException("unexpected unapplied associated type", tpe.loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -913,7 +913,7 @@ object Lowering {
 
       case Type.Alias(sym, args, t, loc) => Type.Alias(sym, args.map(visit), visit(t), loc)
 
-      case Type.AssocType(cst, args, kind, loc) => throw InternalCompilerException("unexpected associated type", loc)
+      case Type.AssocType(cst, args, kind, loc) => Type.AssocType(cst, args.map(visit), kind, loc) // TODO ASSOC-TYPES can't put lowered stuff on right side of assoc type def...
     }
 
     if (tpe0.typeConstructor.contains(TypeConstructor.Schema))

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -906,6 +906,7 @@ object Lowering {
 
       case Type.Alias(sym, args, t, loc) => Type.Alias(sym, args.map(visit), visit(t), loc)
 
+      case Type.AssocType(cst, args, kind, loc) => throw InternalCompilerException("unexpected associated type", loc)
     }
 
     if (tpe0.typeConstructor.contains(TypeConstructor.Schema))

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -23,6 +23,7 @@ import ca.uwaterloo.flix.language.ast.ops.TypedAstOps
 import ca.uwaterloo.flix.language.ast.{Ast, Kind, LoweredAst, Name, Scheme, SourceLocation, SourcePosition, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.util.Validation.ToSuccess
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps, Validation}
+import org.apache.xbean.propertyeditor.PropertyEditors
 
 /**
   * This phase translates AST expressions related to the Datalog subset of the
@@ -197,11 +198,14 @@ object Lowering {
     * Lowers the given instance `inst0`.
     */
   private def visitInstance(inst0: TypedAst.Instance)(implicit root: TypedAst.Root, flix: Flix): LoweredAst.Instance = inst0 match {
-    case TypedAst.Instance(doc, ann, mod, sym, tpe0, tconstrs0, defs0, ns, loc) =>
+    case TypedAst.Instance(doc, ann, mod, sym, tpe0, tconstrs0, assocs0, defs0, ns, loc) =>
       val tpe = visitType(tpe0)
       val tconstrs = tconstrs0.map(visitTypeConstraint)
+      val assocs = assocs0.map {
+        case TypedAst.AssociatedTypeDef(doc, mod, ident, args, tpe, loc) => LoweredAst.AssociatedTypeDef(doc, mod, ident, args, tpe, loc)
+      }
       val defs = defs0.map(visitDef)
-      LoweredAst.Instance(doc, ann, mod, sym, tpe, tconstrs, defs, ns, loc)
+      LoweredAst.Instance(doc, ann, mod, sym, tpe, tconstrs, assocs, defs, ns, loc)
   }
 
   /**
@@ -303,12 +307,15 @@ object Lowering {
     * Lowers the given class `clazz0`, with the given lowered sigs `sigs`.
     */
   private def visitClass(clazz0: TypedAst.Class, sigs: Map[Symbol.SigSym, LoweredAst.Sig])(implicit root: TypedAst.Root, flix: Flix): LoweredAst.Class = clazz0 match {
-    case TypedAst.Class(doc, ann, mod, sym, tparam0, superClasses0, signatures0, laws0, loc) =>
+    case TypedAst.Class(doc, ann, mod, sym, tparam0, superClasses0, assocs0, signatures0, laws0, loc) =>
       val tparam = visitTypeParam(tparam0)
       val superClasses = superClasses0.map(visitTypeConstraint)
+      val assocs = assocs0.map {
+        case TypedAst.AssociatedTypeSig(doc, mod, sym, tparams, kind, loc) => LoweredAst.AssociatedTypeSig(doc, mod, sym, tparams, kind, loc)
+      }
       val signatures = signatures0.map(sig => sigs(sig.sym))
       val laws = laws0.map(visitDef)
-      LoweredAst.Class(doc, ann, mod, sym, tparam, superClasses, signatures, laws, loc)
+      LoweredAst.Class(doc, ann, mod, sym, tparam, superClasses, assocs, signatures, laws, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
@@ -797,10 +797,9 @@ object Monomorph {
       }.collectFirst {
         case (inst, Result.Ok(subst)) => (inst, subst)
       }.get
-      // TODO ASSOC-TYPES continue here
 
-      val as = args.map(eraseType)
-      Type.AssocType(sym, as, kind, loc)
+      val assoc = inst.assocs.find(_.ident.name == sym.sym.name).get
+      subst(assoc.tpe)
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
@@ -792,7 +792,7 @@ object Monomorph {
       // TODO ASSOC-TYPES should lazy map
       // TODO ASSOC-TYPES make prettier
       val (inst, subst) = root.instances(sym.sym.clazz).map {
-        case i@Instance(doc, ann, mod, clazz, tpe, tconstrs, defs, ns, loc) =>
+        case i@Instance(doc, ann, mod, clazz, tpe, tconstrs, assocs, defs, ns, loc) =>
           (i, Unification.unifyTypes(tpe, args.head, RigidityEnv.empty)) // TODO ASSOC-TYPES args should be arg
       }.collectFirst {
         case (inst, Result.Ok(subst)) => (inst, subst)

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.Ast.Modifiers
 import ca.uwaterloo.flix.language.ast.LoweredAst._
 import ca.uwaterloo.flix.language.ast.{Ast, Kind, LoweredAst, RigidityEnv, Scheme, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.errors.ReificationError
-import ca.uwaterloo.flix.language.phase.unification.{Substitution, Unification}
+import ca.uwaterloo.flix.language.phase.unification.{ClassEnvironment, Substitution, Unification}
 import ca.uwaterloo.flix.util.Validation._
 import ca.uwaterloo.flix.util.{InternalCompilerException, Result, Validation}
 
@@ -761,7 +761,7 @@ object Monomorph {
     *
     * Flix does not erase normal types, but it does erase Boolean and caseset formulas.
     */
-  private def eraseType(tpe: Type)(implicit flix: Flix): Type = tpe match {
+  private def eraseType(tpe: Type)(implicit root: Root, flix: Flix): Type = tpe match {
     case Type.Var(sym, loc) =>
       sym.kind match {
         case Kind.CaseSet(enumSym) =>
@@ -788,6 +788,17 @@ object Monomorph {
       Type.Alias(sym, as, t, loc)
 
     case Type.AssocType(sym, args, kind, loc) =>
+      val clazz = root.classes(sym.sym.clazz)
+      // TODO ASSOC-TYPES should lazy map
+      // TODO ASSOC-TYPES make prettier
+      val (inst, subst) = root.instances(sym.sym.clazz).map {
+        case i@Instance(doc, ann, mod, clazz, tpe, tconstrs, defs, ns, loc) =>
+          (i, Unification.unifyTypes(tpe, args.head, RigidityEnv.empty)) // TODO ASSOC-TYPES args should be arg
+      }.collectFirst {
+        case (inst, Result.Ok(subst)) => (inst, subst)
+      }.get
+      // TODO ASSOC-TYPES continue here
+
       val as = args.map(eraseType)
       Type.AssocType(sym, as, kind, loc)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
@@ -787,6 +787,9 @@ object Monomorph {
       val t = eraseType(tpe)
       Type.Alias(sym, as, t, loc)
 
+    case Type.AssocType(sym, args, kind, loc) =>
+      val as = args.map(eraseType)
+      Type.AssocType(sym, as, kind, loc)
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -384,7 +384,7 @@ object Namer {
     * Performs naming on the given class `clazz`.
     */
   private def visitClass(clazz: WeededAst.Declaration.Class, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Class, NameError] = clazz match {
-    case WeededAst.Declaration.Class(doc, ann, mod0, ident, tparams0, superClasses0, signatures, laws0, loc) =>
+    case WeededAst.Declaration.Class(doc, ann, mod0, ident, tparams0, superClasses0, _, signatures, laws0, loc) =>
       val sym = Symbol.mkClassSym(ns0, ident)
       val mod = visitModifiers(mod0, ns0)
       val tparam = getTypeParam(tparams0)
@@ -403,7 +403,7 @@ object Namer {
     * Performs naming on the given instance `instance`.
     */
   private def visitInstance(instance: WeededAst.Declaration.Instance, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Instance, NameError] = instance match {
-    case WeededAst.Declaration.Instance(doc, ann, mod, clazz, tpe0, tconstrs0, defs0, loc) =>
+    case WeededAst.Declaration.Instance(doc, ann, mod, clazz, tpe0, tconstrs0, _, defs0, loc) =>
       val tparams = getImplicitTypeParamsFromTypes(List(tpe0))
 
       val tpeVal = visitType(tpe0)

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -124,15 +124,15 @@ object Namer {
       }
       mapN(table2Val)(addUsesToTable(_, sym.ns, usesAndImports))
 
-    case NamedAst.Declaration.Class(doc, ann, mod, sym, tparam, superClasses, sigs, laws, loc) =>
+    case NamedAst.Declaration.Class(doc, ann, mod, sym, tparam, superClasses, assocs, sigs, laws, loc) =>
       val table1Val = tryAddToTable(table0, sym.namespace, sym.name, decl)
       flatMapN(table1Val) {
-        case table1 => fold(sigs, table1) {
+        case table1 => fold(assocs ++ sigs, table1) {
           case (table, d) => tableDecl(d, table)
         }
       }
 
-    case inst@NamedAst.Declaration.Instance(doc, ann, mod, clazz, tparams, tpe, tconstrs, defs, ns, loc) =>
+    case inst@NamedAst.Declaration.Instance(doc, ann, mod, clazz, tparams, tpe, tconstrs, assocs, defs, ns, loc) =>
       addInstanceToTable(table0, ns, clazz.ident.name, inst).toSuccess
 
     case NamedAst.Declaration.Sig(sym, spec, exp) =>
@@ -160,6 +160,9 @@ object Namer {
     case NamedAst.Declaration.TypeAlias(doc, mod, sym, tparams, tpe, loc) =>
       tryAddToTable(table0, sym.namespace, sym.name, decl)
 
+    case NamedAst.Declaration.AssocTypeSig(doc, mod, sym, tparams, kind, loc) =>
+      tryAddToTable(table0, sym.namespace, sym.name, decl)
+
     case NamedAst.Declaration.Effect(doc, ann, mod, sym, ops, loc) =>
       val table1Val = tryAddToTable(table0, sym.namespace, sym.name, decl)
       flatMapN(table1Val) {
@@ -177,6 +180,10 @@ object Namer {
     case caze@NamedAst.Declaration.RestrictableCase(sym, _, _) =>
       // TODO RESTR-VARS add to case table?
       tryAddToTable(table0, sym.namespace, sym.name, caze)
+
+    case NamedAst.Declaration.AssocTypeDef(doc, mod, ident, args, tpe, loc) =>
+      throw InternalCompilerException("unexpected tabling of associated type definition", loc)
+
   }
 
   /**
@@ -381,21 +388,45 @@ object Namer {
   }
 
   /**
+    * Performs naming on the given associated type signature `s0`.
+    */
+  private def visitAssocTypeSig(s0: WeededAst.Declaration.AssocTypeSig, clazz: Symbol.ClassSym, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.AssocTypeSig, NameError] = s0 match {
+    case WeededAst.Declaration.AssocTypeSig(doc, mod, ident, tparams0, kind0, loc) =>
+      val sym = Symbol.mkAssocTypeSym(clazz, ident)
+      val tparams = getTypeParams(tparams0)
+      val kind = visitKind(kind0)
+      NamedAst.Declaration.AssocTypeSig(doc, mod, sym, tparams, kind, loc).toSuccess
+  }
+
+  /**
+    * Performs naming on the given associated type definition `d0`.
+    */
+  private def visitAssocTypeDef(d0: WeededAst.Declaration.AssocTypeDef, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.AssocTypeDef, NameError] = d0 match {
+    case WeededAst.Declaration.AssocTypeDef(doc, mod, ident, args0, tpe0, loc) =>
+      val argsVal = traverse(args0)(visitType)
+      val tpeVal = visitType(tpe0)
+      mapN(argsVal, tpeVal) {
+        case (args, tpe) => NamedAst.Declaration.AssocTypeDef(doc, mod, ident, args, tpe, loc)
+      }
+  }
+
+  /**
     * Performs naming on the given class `clazz`.
     */
   private def visitClass(clazz: WeededAst.Declaration.Class, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Class, NameError] = clazz match {
-    case WeededAst.Declaration.Class(doc, ann, mod0, ident, tparams0, superClasses0, _, signatures, laws0, loc) =>
+    case WeededAst.Declaration.Class(doc, ann, mod0, ident, tparams0, superClasses0, assocs0, signatures, laws0, loc) =>
       val sym = Symbol.mkClassSym(ns0, ident)
       val mod = visitModifiers(mod0, ns0)
       val tparam = getTypeParam(tparams0)
 
       val superClassesVal = traverse(superClasses0)(visitTypeConstraint(_, ns0))
+      val assocsVal = traverse(assocs0)(visitAssocTypeSig(_, sym, ns0)) // TODO switch param order to match visitSig
       val sigsVal = traverse(signatures)(visitSig(_, ns0, sym))
       val lawsVal = traverse(laws0)(visitDef(_, ns0))
 
-      mapN(superClassesVal, sigsVal, lawsVal) {
-        case (superClasses, sigs, laws) =>
-          NamedAst.Declaration.Class(doc, ann, mod, sym, tparam, superClasses, sigs, laws, loc)
+      mapN(superClassesVal, assocsVal, sigsVal, lawsVal) {
+        case (superClasses, assocs, sigs, laws) =>
+          NamedAst.Declaration.Class(doc, ann, mod, sym, tparam, superClasses, assocs, sigs, laws, loc)
       }
   }
 
@@ -403,16 +434,17 @@ object Namer {
     * Performs naming on the given instance `instance`.
     */
   private def visitInstance(instance: WeededAst.Declaration.Instance, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Instance, NameError] = instance match {
-    case WeededAst.Declaration.Instance(doc, ann, mod, clazz, tpe0, tconstrs0, _, defs0, loc) =>
+    case WeededAst.Declaration.Instance(doc, ann, mod, clazz, tpe0, tconstrs0, assocs0, defs0, loc) =>
       val tparams = getImplicitTypeParamsFromTypes(List(tpe0))
 
       val tpeVal = visitType(tpe0)
       val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint(_, ns0))
-      flatMapN(tpeVal, tconstrsVal) {
-        case (tpe, tconstrs) =>
+      val assocsVal = traverse(assocs0)(visitAssocTypeDef(_, ns0))
+      flatMapN(tpeVal, tconstrsVal, assocsVal) {
+        case (tpe, tconstrs, assocs) =>
           val defsVal = traverse(defs0)(visitDef(_, ns0))
           mapN(defsVal) {
-            defs => NamedAst.Declaration.Instance(doc, ann, mod, clazz, tparams, tpe, tconstrs, defs, ns0.parts, loc)
+            defs => NamedAst.Declaration.Instance(doc, ann, mod, clazz, tparams, tpe, tconstrs, assocs, defs, ns0.parts, loc)
           }
       }
   }
@@ -1538,7 +1570,7 @@ object Namer {
     * Gets the location of the symbol of the declaration.
     */
   private def getSymLocation(f: NamedAst.Declaration): SourceLocation = f match {
-    case NamedAst.Declaration.Class(doc, ann, mod, sym, tparam, superClasses, sigs, laws, loc) => sym.loc
+    case NamedAst.Declaration.Class(doc, ann, mod, sym, tparam, superClasses, assocs, sigs, laws, loc) => sym.loc
     case NamedAst.Declaration.Sig(sym, spec, exp) => sym.loc
     case NamedAst.Declaration.Def(sym, spec, exp) => sym.loc
     case NamedAst.Declaration.Enum(doc, ann, mod, sym, tparams, derives, cases, loc) => sym.loc
@@ -1548,7 +1580,9 @@ object Namer {
     case NamedAst.Declaration.Op(sym, spec) => sym.loc
     case NamedAst.Declaration.Case(sym, tpe, _) => sym.loc
     case NamedAst.Declaration.RestrictableCase(sym, tpe, _) => sym.loc
-    case NamedAst.Declaration.Instance(doc, ann, mod, clazz, tparams, tpe, tconstrs, defs, ns, loc) => throw InternalCompilerException("Unexpected instance", loc)
+    case NamedAst.Declaration.AssocTypeSig(doc, mod, sym, tparams, kind, loc) => sym.loc
+    case NamedAst.Declaration.AssocTypeDef(doc, mod, ident, args, tpe, loc) => throw InternalCompilerException("Unexpected associated type definition", loc)
+    case NamedAst.Declaration.Instance(doc, ann, mod, clazz, tparams, tpe, tconstrs, assocs, defs, ns, loc) => throw InternalCompilerException("Unexpected instance", loc)
     case NamedAst.Declaration.Namespace(sym, usesAndImports, decls, loc) => throw InternalCompilerException("Unexpected namespace", loc)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -239,6 +239,14 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       Documentation ~ Modifiers ~ SP ~ keyword("type") ~ WS ~ keyword("alias") ~ WS ~ Names.Type ~ optWS ~ TypeParams ~ optWS ~ "=" ~ optWS ~ Type ~ SP ~> ParsedAst.Declaration.TypeAlias
     }
 
+    def AssociatedTypeSig: Rule1[ParsedAst.Declaration.AssocTypeSig] = rule {
+      Documentation ~ Modifiers ~ SP ~ keyword("type") ~ WS ~ Names.Type ~ optWS ~ TypeParams ~ optWS ~ ":" ~ optWS ~ Kind ~ SP ~> ParsedAst.Declaration.AssocTypeSig
+    }
+
+    def AssociatedTypeDef: Rule1[ParsedAst.Declaration.AssocTypeDef] = rule {
+      Documentation ~ Modifiers ~ SP ~ keyword("type") ~ WS ~ Names.Type ~ optWS ~ "[" ~ oneOrMore(Type) ~ "]" ~ optWS ~ "=" ~ optWS ~ Type ~ SP ~> ParsedAst.Declaration.AssocTypeDef
+    }
+
     def Relation: Rule1[ParsedAst.Declaration.Relation] = rule {
       Documentation ~ Modifiers ~ SP ~ keyword("rel") ~ WS ~ Names.Predicate ~ optWS ~ TypeParams ~ AttributeList ~ SP ~> ParsedAst.Declaration.Relation
     }
@@ -253,11 +261,11 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       }
 
       def EmptyBody = namedRule("ClassBody") {
-        push(Nil) ~ SP
+        push(Nil) ~ push(Nil) ~ SP
       }
 
       def NonEmptyBody = namedRule("ClassBody") {
-        optWS ~ "{" ~ optWS ~ zeroOrMore(Declarations.Law | Declarations.Sig) ~ optWS ~ "}" ~ SP
+        optWS ~ "{" ~ optWS ~ zeroOrMore(Declarations.AssociatedTypeSig) ~ zeroOrMore(Declarations.Law | Declarations.Sig) ~ optWS ~ "}" ~ SP
       }
 
       rule {
@@ -279,11 +287,11 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       }
 
       def EmptyBody = namedRule("InstanceBody") {
-        push(Nil) ~ SP
+        push(Nil) ~ push(Nil) ~ SP
       }
 
       def NonEmptyBody = namedRule("InstanceBody") {
-        optWS ~ "{" ~ optWS ~ zeroOrMore(Declarations.Def) ~ optWS ~ "}" ~ SP
+        optWS ~ "{" ~ optWS ~ zeroOrMore(Declarations.AssociatedTypeDef) ~ zeroOrMore(Declarations.Def) ~ optWS ~ "}" ~ SP
       }
 
       rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
@@ -363,6 +363,7 @@ object Regions {
     case _: Type.Cst => Nil
     case Type.Apply(tpe1, tpe2, _) => boolTypesOf(tpe1) ::: boolTypesOf(tpe2)
     case Type.Alias(_, _, tpe, _) => boolTypesOf(tpe)
+    case Type.AssocType(_, args, _, _) => args.flatMap(boolTypesOf) // TODO ASSOC-TYPES ???
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -266,6 +266,7 @@ object Resolver {
     case _: UnkindedType.Enum => Nil
     case _: UnkindedType.RestrictableEnum => Nil
     case alias: UnkindedType.Alias => throw InternalCompilerException("unexpected applied alias", alias.loc)
+    case assoc: UnkindedType.AssocType => throw InternalCompilerException("unexpected applied associated type", assoc.loc)
   }
 
   /**
@@ -2494,6 +2495,7 @@ object Resolver {
 
       case _: UnkindedType.Apply => throw InternalCompilerException("unexpected type application", baseType.loc)
       case _: UnkindedType.Alias => throw InternalCompilerException("unexpected resolved alias", baseType.loc)
+      case _: UnkindedType.AssocType => throw InternalCompilerException("unexpected resolved associated type", baseType.loc)
     }
   }
 
@@ -3363,6 +3365,7 @@ object Resolver {
       case _: UnkindedType.CaseComplement => ResolutionError.IllegalType(tpe, loc).toFailure
       case _: UnkindedType.CaseUnion => ResolutionError.IllegalType(tpe, loc).toFailure
       case _: UnkindedType.CaseIntersection => ResolutionError.IllegalType(tpe, loc).toFailure
+      case _: UnkindedType.AssocType => ResolutionError.IllegalType(tpe, loc).toFailure
 
       // Case 6: Unexpected type. Crash.
       case t: UnkindedType.Apply => throw InternalCompilerException(s"unexpected type: $t", loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2415,8 +2415,12 @@ object Resolver {
         }
 
       case UnkindedType.UnappliedAssocType(sym, loc) =>
+        // TODO ASSOC-TYPES for now just assuming that it is applied to exactly the right number
+        // TODO ASSOC-TYPES should check params number like for aliases
         traverse(targs)(finishResolveType(_, taenv)) map {
-          resolvedArgs => UnkindedType.mkApply(baseType, resolvedArgs, tpe0.loc) // TODO ASSOC-TYPES change to proper applied assoc type
+          resolvedArgs =>
+            val cst = Ast.AssocTypeConstructor(sym, loc)
+            UnkindedType.AssocType(cst, resolvedArgs, tpe0.loc)
         }
 
       case _: UnkindedType.Var =>
@@ -3059,7 +3063,7 @@ object Resolver {
     * (b) the class is defined in the namespace `ns0` itself or in a parent of `ns0`.
     */
   private def getAssocTypeIfAccessible(assoc0: NamedAst.Declaration.AssocTypeSig, ns0: Name.NName, loc: SourceLocation): Validation[NamedAst.Declaration.AssocTypeSig, ResolutionError] = {
-   assoc0.toSuccess  // TODO ASSOC-TYPES check class accessibility
+    assoc0.toSuccess // TODO ASSOC-TYPES check class accessibility
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -145,6 +145,8 @@ object Resolver {
     case ResolvedAst.Declaration.RestrictableCase(sym, _, _) => throw InternalCompilerException(s"Unexpected declaration: $sym", sym.loc)
     case ResolvedAst.Declaration.Op(sym, spec) => throw InternalCompilerException(s"Unexpected declaration: $sym", spec.loc)
     case ResolvedAst.Declaration.Sig(sym, spec, _) => throw InternalCompilerException(s"Unexpected declaration: $sym", spec.loc)
+    case ResolvedAst.Declaration.AssociatedTypeSig(_, _, sym, _, _, _) => throw InternalCompilerException(s"Unexpected declaration: $sym", sym.loc)
+    case ResolvedAst.Declaration.AssociatedTypeDef(_, _, ident, _, _, _) => throw InternalCompilerException(s"Unexpected declaration: $ident", ident.loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -51,7 +51,7 @@ object Safety {
     val sendableClass = new Symbol.ClassSym(Nil, "Sendable", SourceLocation.Unknown)
 
     root.instances.getOrElse(sendableClass, Nil) flatMap {
-      case Instance(_, _, _, _, tpe, _, _, _, loc) =>
+      case Instance(_, _, _, _, tpe, _, _, _, _, loc) =>
         if (tpe.typeArguments.exists(_.kind == Kind.Bool))
           List(SafetyError.SendableError(tpe, loc))
         else

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -106,7 +106,7 @@ object Typer {
         case (classSym, clazz) =>
           val instances = instances0.getOrElse(classSym, Nil)
           val envInsts = instances.map {
-            case KindedAst.Instance(_, _, _, _, tpe, tconstrs, _, _, _) => Ast.Instance(tpe, tconstrs)
+            case KindedAst.Instance(_, _, _, _, tpe, tconstrs, _, _, _, _) => Ast.Instance(tpe, tconstrs)
           }
           // ignore the super class parameters since they should all be the same as the class param
           val superClasses = clazz.superClasses.map(_.head.sym)
@@ -139,7 +139,7 @@ object Typer {
     * Reassembles a single class.
     */
   private def visitClass(clazz: KindedAst.Class, root: KindedAst.Root, classEnv: Map[Symbol.ClassSym, Ast.ClassContext])(implicit flix: Flix): Validation[(Symbol.ClassSym, TypedAst.Class), TypeError] = clazz match {
-    case KindedAst.Class(doc, ann, mod, sym, tparam, superClasses, sigs0, laws0, loc) =>
+    case KindedAst.Class(doc, ann, mod, sym, tparam, superClasses, _, sigs0, laws0, loc) => // TODO ASSOC-TYPES
       val tparams = getTypeParams(List(tparam))
       val tconstr = Ast.TypeConstraint(Ast.TypeConstraint.Head(sym, sym.loc), Type.Var(tparam.sym, tparam.loc), sym.loc)
       val sigsVal = traverse(sigs0.values)(visitSig(_, List(tconstr), root, classEnv))
@@ -166,7 +166,7 @@ object Typer {
     * Reassembles a single instance.
     */
   private def visitInstance(inst: KindedAst.Instance, root: KindedAst.Root, classEnv: Map[Symbol.ClassSym, Ast.ClassContext])(implicit flix: Flix): Validation[TypedAst.Instance, TypeError] = inst match {
-    case KindedAst.Instance(doc, ann, mod, sym, tpe, tconstrs, defs0, ns, loc) =>
+    case KindedAst.Instance(doc, ann, mod, sym, tpe, tconstrs, _, defs0, ns, loc) => // TODO ASSOC-TYPES
       val defsVal = traverse(defs0)(visitDefn(_, tconstrs, root, classEnv))
       mapN(defsVal) {
         case defs => TypedAst.Instance(doc, ann, mod, sym, tpe, tconstrs, defs, ns, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -79,6 +79,7 @@ object Typer {
 
         case sym: Symbol.SigSym => new Symbol.ModuleSym(sym.clazz.namespace :+ sym.clazz.name)
         case sym: Symbol.OpSym => new Symbol.ModuleSym(sym.eff.namespace :+ sym.eff.name)
+        case sym: Symbol.AssocTypeSym => new Symbol.ModuleSym(sym.clazz.namespace :+ sym.clazz.name)
 
         case sym: Symbol.CaseSym => throw InternalCompilerException(s"unexpected symbol: $sym", sym.loc)
         case sym: Symbol.RestrictableCaseSym => throw InternalCompilerException(s"unexpected symbol: $sym", sym.loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -497,7 +497,7 @@ object CodeHinter {
     case Type.Cst(_, _) => 0
     case Type.Apply(tpe1, tpe2, _) => numberOfVarOccurs(tpe1) + numberOfVarOccurs(tpe2)
     case Type.Alias(_, _, tpe, _) => numberOfVarOccurs(tpe)
-    case Type.Alias(_, args, _, _) => args.map(numberOfVarOccurs).sum
+    case Type.AssocType(_, args, _, _) => args.map(numberOfVarOccurs).sum
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -497,6 +497,7 @@ object CodeHinter {
     case Type.Cst(_, _) => 0
     case Type.Apply(tpe1, tpe2, _) => numberOfVarOccurs(tpe1) + numberOfVarOccurs(tpe2)
     case Type.Alias(_, _, tpe, _) => numberOfVarOccurs(tpe)
+    case Type.Alias(_, args, _, _) => args.map(numberOfVarOccurs).sum
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/SetUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/SetUnification.scala
@@ -74,6 +74,7 @@ object SetUnification {
     case Type.Apply(tpe1, tpe2, loc) => Type.Apply(eraseIo(tpe1), eraseIo(tpe2), loc)
 
     case _: Type.Alias => throw InternalCompilerException("unexpected type alias", t.loc)
+    case _: Type.AssocType => throw InternalCompilerException("unexpected associated type", t.loc) // TODO ASSOC-TYPE ???
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Substitution.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Substitution.scala
@@ -85,6 +85,9 @@ case class Substitution(m: Map[Symbol.KindedTypeVarSym, Type]) {
           val args = args0.map(visit)
           val tpe = visit(tpe0)
           Type.Alias(sym, args, tpe, loc)
+        case Type.AssocType(cst, args0, kind, loc) =>
+          val args = args0.map(visit)
+          Type.AssocType(cst, args, kind, loc)
       }
 
     // Optimization: Return the type if the substitution is empty. Otherwise visit the type.

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/TypeMinimization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/TypeMinimization.scala
@@ -39,6 +39,7 @@ object TypeMinimization {
       case tpe: Type.Cst => tpe
       case Type.Apply(tpe1, tpe2, loc) => Type.Apply(minimizeType(tpe1), minimizeType(tpe2), loc)
       case Type.Alias(cst, args, tpe, loc) => Type.Alias(cst, args.map(minimizeType), minimizeType(tpe), loc)
+      case Type.AssocType(cst, args, kind, loc) => Type.AssocType(cst, args.map(minimizeType), kind, loc)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -140,6 +140,14 @@ object Unification {
         case Result.Err(e) => Result.Err(e)
       }
 
+    case (Type.AssocType(cst1, args1, kind1, loc1), Type.AssocType(cst2, args2, kind2, loc2)) =>
+      // TODO ASSOC-TYPES evaluate if possible
+      if (args1 == args2) {
+        Result.Ok(Substitution.empty)
+      } else {
+        Result.Err(UnificationError.MismatchedTypes(tpe1, tpe2))
+      }
+
     case _ => Result.Err(UnificationError.MismatchedTypes(tpe1, tpe2))
   }
 

--- a/main/test/flix/experimental/ExperimentalSuite.scala
+++ b/main/test/flix/experimental/ExperimentalSuite.scala
@@ -1,5 +1,33 @@
+/*
+ * Copyright 2022 Matthew Lutze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package flix.experimental
 
-import org.scalatest.Suites
+import ca.uwaterloo.flix.util.{FlixSuite, Options}
 
-class ExperimentalSuite extends Suites
+/**
+  * Suite of tests for which nonstandard testing options are required.
+  *
+  * Intended for work-in-progress features for which maintaining the standard options (e.g. redundancy checking)
+  * would be a burden.
+  *
+  * Tests should be promoted out of this suite and into [[flix.CompilerSuite]]
+  * as soon as they run without special options.
+  */
+class ExperimentalSuite extends FlixSuite(incremental = true) {
+  implicit val options: Options = Options.TestWithLibNix.copy(xallowredundancies = true)
+
+  mkTest("main/test/flix/experimental/Test.Dec.AssocType.flix")
+}

--- a/main/test/flix/experimental/Test.Dec.AssocType.flix
+++ b/main/test/flix/experimental/Test.Dec.AssocType.flix
@@ -3,6 +3,6 @@ mod Test/Dec/AssocType {
     class Coll[a] {
         type Elem[a]: Type
 
-        pub def contains(x: Elem[a], c: a): Bool = ???
+        pub def contains(x: Coll.Elem[a], c: a): Bool = ???
     }
 }

--- a/main/test/flix/experimental/Test.Dec.AssocType.flix
+++ b/main/test/flix/experimental/Test.Dec.AssocType.flix
@@ -1,0 +1,8 @@
+mod Test/Dec/AssocType {
+
+    class Coll[a] {
+        type Elem[a]: Type
+
+        pub def contains(x: Elem[a], c: a): Bool = ???
+    }
+}


### PR DESCRIPTION
Boring tests to be written:
- [ ] NameError in assoc type def
- [ ] NameError in assoc type sig
- [ ] ResolutionError in assoc type def
- [ ] ResolutionError in assoc type sig

Interesting tests to be written:
- [ ] Kindchecking assoc type defs
- [ ] Ensuring termination of reduction
- [ ] MissingInstance
- [ ] Generalization/nonentailment/whatever error
- [ ] Positive tests