### PR TITLE
feat: allow package manager to work completely offline if everything is already downloaded

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
@@ -73,7 +73,7 @@ object FlixPackageManager {
     GitHub.parseProject(project).flatMap { proj =>
       val lib = Bootstrap.getLibraryDirectory(p)
       val assetName = s"${proj.repo}-$version.$extension"
-      val path = lib.resolve(proj.owner).resolve(proj.repo).resolve(version.toString).resolve(assetName)
+      val path = lib.resolve("github").resolve(proj.owner).resolve(proj.repo).resolve(version.toString).resolve(assetName)
       if (Files.exists(path)) {
         out.println(s"  Cached `${proj.owner}/${proj.repo}.$extension` (v$version).")
         Ok(path)

--- a/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/FlixPackageManager.scala
@@ -98,11 +98,15 @@ object FlixPackageManager {
                 stream => Files.copy(stream, assetPath, StandardCopyOption.REPLACE_EXISTING)
               }
             } catch {
-              case _: IOException => return Err(PackageError.DownloadError(asset))
+              case _: IOException => out.println(s"ERROR."); return Err(PackageError.DownloadError(asset))
             }
-            out.println(s"OK.")
-
-            Ok(assetPath)
+            if(Files.exists(assetPath)) {
+              out.println(s"OK.")
+              Ok(assetPath)
+            } else {
+              out.println(s"ERROR.")
+              Err(PackageError.DownloadError(asset))
+            }
           }
         }
       }

--- a/main/test/ca/uwaterloo/flix/tools/TestFlixPackageManager.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestFlixPackageManager.scala
@@ -318,7 +318,11 @@ class TestFlixPackageManager extends FunSuite {
       }
 
       val path = Files.createTempDirectory("")
-      FlixPackageManager.installAll(List(manifest), path)(System.out) match {
+      val manifests = FlixPackageManager.findTransitiveDependencies(manifest, path)(System.out) match {
+        case Ok(l) => l
+        case Err(e) => fail(e.message(f))
+      }
+      FlixPackageManager.installAll(manifests, path)(System.out) match {
         case Ok(l) =>
           l.head.endsWith(s"magnus-madsen${s}hellouniverse${s}1.0.0${s}hellouniverse-1.0.0.fpkg") &&
           l(1).endsWith(s"magnus-madsen${s}helloworld${s}1.3.0${s}helloworld-1.3.0.fpkg")

--- a/main/test/ca/uwaterloo/flix/tools/TestFlixPackageManager.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestFlixPackageManager.scala
@@ -39,7 +39,7 @@ class TestFlixPackageManager extends FunSuite {
 
       val manifest = ManifestParser.parse(toml, null) match {
         case Ok(m) => m
-        case Err(_) => ??? //should not happen
+        case Err(e) => fail(e.message(f)) //should not happen
       }
 
       val path = Files.createTempDirectory("")
@@ -76,7 +76,7 @@ class TestFlixPackageManager extends FunSuite {
 
       val manifest = ManifestParser.parse(toml, null) match {
         case Ok(m) => m
-        case Err(_) => ??? //should not happen
+        case Err(e) => fail(e.message(f)) //should not happen
       }
 
       val path = Files.createTempDirectory("")
@@ -134,11 +134,11 @@ class TestFlixPackageManager extends FunSuite {
 
       val manifest1 = ManifestParser.parse(toml1, null) match {
         case Ok(m) => m
-        case Err(_) => ??? //should not happen
+        case Err(e) => fail(e.message(f)) //should not happen
       }
       val manifest2 = ManifestParser.parse(toml2, null) match {
         case Ok(m) => m
-        case Err(_) => ??? //should not happen
+        case Err(e) => fail(e.message(f)) //should not happen
       }
 
       val path = Files.createTempDirectory("")
@@ -175,7 +175,7 @@ class TestFlixPackageManager extends FunSuite {
 
       val manifest = ManifestParser.parse(toml, null) match {
         case Ok(m) => m
-        case Err(_) => ??? //should not happen
+        case Err(e) => fail(e.message(f)) //should not happen
       }
 
       val path = Files.createTempDirectory("")
@@ -212,13 +212,13 @@ class TestFlixPackageManager extends FunSuite {
 
       val manifest = ManifestParser.parse(toml, null) match {
         case Ok(m) => m
-        case Err(_) => ??? //should not happen
+        case Err(e) => fail(e.message(f)) //should not happen
       }
 
       val path = Files.createTempDirectory("")
       FlixPackageManager.findTransitiveDependencies(manifest, path)(System.out) match {
         case Ok(l) => l.contains(manifest) && l.exists(m => m.name == "helloworld")
-        case Err(e) => e
+        case Err(e) => e.message(f)
       }
     })
   }
@@ -248,7 +248,7 @@ class TestFlixPackageManager extends FunSuite {
 
       val manifest = ManifestParser.parse(toml, null) match {
         case Ok(m) => m
-        case Err(_) => ??? //should not happen
+        case Err(e) => fail(e.message(f)) //should not happen
       }
 
       val path = Files.createTempDirectory("")
@@ -284,7 +284,7 @@ class TestFlixPackageManager extends FunSuite {
 
       val manifest = ManifestParser.parse(toml, null) match {
         case Ok(m) => m
-        case Err(_) => ???
+        case Err(e) => fail(e.message(f))
       }
 
       val path = Files.createTempDirectory("")
@@ -314,15 +314,14 @@ class TestFlixPackageManager extends FunSuite {
 
       val manifest = ManifestParser.parse(toml, null) match {
         case Ok(m) => m
-        case Err(_) => ??? //should not happen
+        case Err(e) => fail(e.message(f)) //should not happen
       }
 
       val path = Files.createTempDirectory("")
       FlixPackageManager.installAll(List(manifest), path)(System.out) match {
-        case Ok(l) => println(l);
-
+        case Ok(l) =>
           l.head.endsWith(s"magnus-madsen${s}hellouniverse${s}1.0.0${s}hellouniverse-1.0.0.fpkg") &&
-                      l(1).endsWith(s"magnus-madsen${s}helloworld${s}1.3.0${s}helloworld-1.3.0.fpkg")
+          l(1).endsWith(s"magnus-madsen${s}helloworld${s}1.3.0${s}helloworld-1.3.0.fpkg")
         case Err(e) => e.message(f)
       }
     })

--- a/main/test/ca/uwaterloo/flix/tools/TestFlixPackageManager.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestFlixPackageManager.scala
@@ -44,7 +44,7 @@ class TestFlixPackageManager extends FunSuite {
 
       val path = Files.createTempDirectory("")
       FlixPackageManager.installAll(List(manifest), path)(System.out) match {
-        case Ok(l) => l.head.endsWith(s"magnus-madsen${s}helloworld${s}ver1.0.0${s}helloworld.fpkg")
+        case Ok(l) => l.head.endsWith(s"magnus-madsen${s}helloworld${s}1.0.0${s}helloworld-1.0.0.fpkg")
         case Err(e) => e.message(f)
       }
     })
@@ -81,8 +81,8 @@ class TestFlixPackageManager extends FunSuite {
 
       val path = Files.createTempDirectory("")
       FlixPackageManager.installAll(List(manifest), path)(System.out) match {
-        case Ok(l) => l.head.endsWith(s"magnus-madsen${s}helloworld${s}ver1.0.0${s}helloworld.fpkg") &&
-                      l(1).endsWith(s"magnus-madsen${s}helloworld${s}ver1.1.0${s}helloworld.fpkg")
+        case Ok(l) => l.head.endsWith(s"magnus-madsen${s}helloworld${s}1.0.0${s}helloworld-1.0.0.fpkg") &&
+                      l(1).endsWith(s"magnus-madsen${s}helloworld${s}1.1.0${s}helloworld-1.1.0.fpkg")
         case Err(e) => e
       }
     })
@@ -143,8 +143,8 @@ class TestFlixPackageManager extends FunSuite {
 
       val path = Files.createTempDirectory("")
       FlixPackageManager.installAll(List(manifest1, manifest2), path)(System.out) match {
-        case Ok(l) => l.head.endsWith(s"magnus-madsen${s}helloworld${s}ver1.0.0${s}helloworld.fpkg") &&
-                      l(1).endsWith(s"magnus-madsen${s}helloworld${s}ver1.1.0${s}helloworld.fpkg")
+        case Ok(l) => l.head.endsWith(s"magnus-madsen${s}helloworld${s}1.0.0${s}helloworld-1.0.0.fpkg") &&
+                      l(1).endsWith(s"magnus-madsen${s}helloworld${s}1.1.0${s}helloworld-1.1.0.fpkg")
         case Err(e) => e.message(f)
       }
     })
@@ -181,7 +181,7 @@ class TestFlixPackageManager extends FunSuite {
       val path = Files.createTempDirectory("")
       FlixPackageManager.installAll(List(manifest), path)(System.out) //installs the dependency
       FlixPackageManager.installAll(List(manifest), path)(System.out) match { //does nothing
-        case Ok(l) => l.head.endsWith(s"magnus-madsen${s}helloworld${s}ver1.0.0${s}helloworld.fpkg")
+        case Ok(l) => l.head.endsWith(s"magnus-madsen${s}helloworld${s}1.0.0${s}helloworld-1.0.0.fpkg")
         case Err(e) => e.message(f)
       }
     })
@@ -295,6 +295,37 @@ class TestFlixPackageManager extends FunSuite {
     })
   }
 
-  //test: finds transitive dependency
+  test("Install transitive dependency") {
+    assertResult(expected = true)(actual = {
+      val toml = {
+        """
+          |[package]
+          |name = "test"
+          |description = "test"
+          |version = "0.0.0"
+          |flix = "0.0.0"
+          |authors = ["Anna Blume"]
+          |
+          |[dependencies]
+          |"github:magnus-madsen/hellouniverse" = "1.0.0"
+          |
+          |""".stripMargin
+      }
+
+      val manifest = ManifestParser.parse(toml, null) match {
+        case Ok(m) => m
+        case Err(_) => ??? //should not happen
+      }
+
+      val path = Files.createTempDirectory("")
+      FlixPackageManager.installAll(List(manifest), path)(System.out) match {
+        case Ok(l) => println(l);
+
+          l.head.endsWith(s"magnus-madsen${s}hellouniverse${s}1.0.0${s}hellouniverse-1.0.0.fpkg") &&
+                      l(1).endsWith(s"magnus-madsen${s}helloworld${s}1.3.0${s}helloworld-1.3.0.fpkg")
+        case Err(e) => e.message(f)
+      }
+    })
+  }
 
 }


### PR DESCRIPTION
Checks for cached versions of toml and fpkg files before downloading them. Also changes the names of both toml and fpkg files to be "package-version.extension" and stores them in `lib/github/user/package/version`