### PR TITLE
refactor: shorten names in `ErasedAst`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -30,7 +30,7 @@ object ErasedAst {
                   closures: Set[ClosureInfo],
                   anonClasses: Set[AnonClassInfo])
 
-  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, formals: List[ErasedAst.FormalParam], exp: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) {
+  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, formals: List[ErasedAst.FormalParam], exp: Expr, tpe: MonoType, loc: SourceLocation) {
     var method: Method = _
   }
 
@@ -46,35 +46,35 @@ object ErasedAst {
 
     case class Var(sym: Symbol.VarSym, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Binary(sop: SemanticOperator, exp1: ErasedAst.Expr, exp2: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
+    case class Binary(sop: SemanticOperator, exp1: Expr, exp2: Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class IfThenElse(exp1: ErasedAst.Expr, exp2: ErasedAst.Expr, exp3: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
+    case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Branch(exp: ErasedAst.Expr, branches: Map[Symbol.LabelSym, ErasedAst.Expr], tpe: MonoType, loc: SourceLocation) extends Expr
+    case class Branch(exp: Expr, branches: Map[Symbol.LabelSym, Expr], tpe: MonoType, loc: SourceLocation) extends Expr
 
     case class JumpTo(sym: Symbol.LabelSym, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Let(sym: Symbol.VarSym, exp1: ErasedAst.Expr, exp2: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
+    case class Let(sym: Symbol.VarSym, exp1: Expr, exp2: Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class LetRec(varSym: Symbol.VarSym, index: Int, defSym: Symbol.DefnSym, exp1: ErasedAst.Expr, exp2: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
+    case class LetRec(varSym: Symbol.VarSym, index: Int, defSym: Symbol.DefnSym, exp1: Expr, exp2: Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Scope(sym: Symbol.VarSym, exp: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
+    case class Scope(sym: Symbol.VarSym, exp: Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class TryCatch(exp: ErasedAst.Expr, rules: List[ErasedAst.CatchRule], tpe: MonoType, loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Expr, rules: List[ErasedAst.CatchRule], tpe: MonoType, loc: SourceLocation) extends Expr
 
     case class NewObject(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[ErasedAst.JvmMethod], loc: SourceLocation) extends Expr
 
     case class Intrinsic0(op: ErasedAst.IntrinsicOperator0, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Intrinsic1(op: ErasedAst.IntrinsicOperator1, exp: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
+    case class Intrinsic1(op: ErasedAst.IntrinsicOperator1, exp: Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Intrinsic2(op: ErasedAst.IntrinsicOperator2, exp1: ErasedAst.Expr, exp2: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
+    case class Intrinsic2(op: ErasedAst.IntrinsicOperator2, exp1: Expr, exp2: Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Intrinsic3(op: ErasedAst.IntrinsicOperator3, exp1: ErasedAst.Expr, exp2: ErasedAst.Expr, exp3: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
+    case class Intrinsic3(op: ErasedAst.IntrinsicOperator3, exp1: Expr, exp2: Expr, exp3: Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class IntrinsicN(op: ErasedAst.IntrinsicOperatorN, exps: List[ErasedAst.Expr], tpe: MonoType, loc: SourceLocation) extends Expr
+    case class IntrinsicN(op: ErasedAst.IntrinsicOperatorN, exps: List[Expr], tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Intrinsic1N(op: ErasedAst.IntrinsicOperator1N, exp: ErasedAst.Expr, exps: List[ErasedAst.Expr], tpe: MonoType, loc: SourceLocation) extends Expr
+    case class Intrinsic1N(op: ErasedAst.IntrinsicOperator1N, exp: Expr, exps: List[Expr], tpe: MonoType, loc: SourceLocation) extends Expr
 
   }
 
@@ -228,9 +228,9 @@ object ErasedAst {
 
   case class Case(sym: Symbol.CaseSym, tpeDeprecated: MonoType, loc: SourceLocation)
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[ErasedAst.FormalParam], clo: ErasedAst.Expr, retTpe: MonoType, loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[ErasedAst.FormalParam], clo: Expr, retTpe: MonoType, loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[_], exp: ErasedAst.Expr)
+  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[_], exp: Expr)
 
   case class FormalParam(sym: Symbol.VarSym, tpe: MonoType)
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -30,51 +30,51 @@ object ErasedAst {
                   closures: Set[ClosureInfo],
                   anonClasses: Set[AnonClassInfo])
 
-  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, formals: List[ErasedAst.FormalParam], exp: ErasedAst.Expression, tpe: MonoType, loc: SourceLocation) {
+  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, formals: List[ErasedAst.FormalParam], exp: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) {
     var method: Method = _
   }
 
   case class Enum(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, cases: Map[Symbol.CaseSym, ErasedAst.Case], tpeDeprecated: MonoType, loc: SourceLocation)
 
-  sealed trait Expression {
+  sealed trait Expr {
     def tpe: MonoType
 
     def loc: SourceLocation
   }
 
-  object Expression {
+  object Expr {
 
-    case class Var(sym: Symbol.VarSym, tpe: MonoType, loc: SourceLocation) extends Expression
+    case class Var(sym: Symbol.VarSym, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Binary(sop: SemanticOperator, exp1: ErasedAst.Expression, exp2: ErasedAst.Expression, tpe: MonoType, loc: SourceLocation) extends Expression
+    case class Binary(sop: SemanticOperator, exp1: ErasedAst.Expr, exp2: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class IfThenElse(exp1: ErasedAst.Expression, exp2: ErasedAst.Expression, exp3: ErasedAst.Expression, tpe: MonoType, loc: SourceLocation) extends Expression
+    case class IfThenElse(exp1: ErasedAst.Expr, exp2: ErasedAst.Expr, exp3: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Branch(exp: ErasedAst.Expression, branches: Map[Symbol.LabelSym, ErasedAst.Expression], tpe: MonoType, loc: SourceLocation) extends Expression
+    case class Branch(exp: ErasedAst.Expr, branches: Map[Symbol.LabelSym, ErasedAst.Expr], tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class JumpTo(sym: Symbol.LabelSym, tpe: MonoType, loc: SourceLocation) extends Expression
+    case class JumpTo(sym: Symbol.LabelSym, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Let(sym: Symbol.VarSym, exp1: ErasedAst.Expression, exp2: ErasedAst.Expression, tpe: MonoType, loc: SourceLocation) extends Expression
+    case class Let(sym: Symbol.VarSym, exp1: ErasedAst.Expr, exp2: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class LetRec(varSym: Symbol.VarSym, index: Int, defSym: Symbol.DefnSym, exp1: ErasedAst.Expression, exp2: ErasedAst.Expression, tpe: MonoType, loc: SourceLocation) extends Expression
+    case class LetRec(varSym: Symbol.VarSym, index: Int, defSym: Symbol.DefnSym, exp1: ErasedAst.Expr, exp2: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Scope(sym: Symbol.VarSym, exp: ErasedAst.Expression, tpe: MonoType, loc: SourceLocation) extends Expression
+    case class Scope(sym: Symbol.VarSym, exp: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class TryCatch(exp: ErasedAst.Expression, rules: List[ErasedAst.CatchRule], tpe: MonoType, loc: SourceLocation) extends Expression
+    case class TryCatch(exp: ErasedAst.Expr, rules: List[ErasedAst.CatchRule], tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class NewObject(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[ErasedAst.JvmMethod], loc: SourceLocation) extends Expression
+    case class NewObject(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[ErasedAst.JvmMethod], loc: SourceLocation) extends Expr
 
-    case class Intrinsic0(op: ErasedAst.IntrinsicOperator0, tpe: MonoType, loc: SourceLocation) extends Expression
+    case class Intrinsic0(op: ErasedAst.IntrinsicOperator0, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Intrinsic1(op: ErasedAst.IntrinsicOperator1, exp: ErasedAst.Expression, tpe: MonoType, loc: SourceLocation) extends Expression
+    case class Intrinsic1(op: ErasedAst.IntrinsicOperator1, exp: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Intrinsic2(op: ErasedAst.IntrinsicOperator2, exp1: ErasedAst.Expression, exp2: ErasedAst.Expression, tpe: MonoType, loc: SourceLocation) extends Expression
+    case class Intrinsic2(op: ErasedAst.IntrinsicOperator2, exp1: ErasedAst.Expr, exp2: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Intrinsic3(op: ErasedAst.IntrinsicOperator3, exp1: ErasedAst.Expression, exp2: ErasedAst.Expression, exp3: ErasedAst.Expression, tpe: MonoType, loc: SourceLocation) extends Expression
+    case class Intrinsic3(op: ErasedAst.IntrinsicOperator3, exp1: ErasedAst.Expr, exp2: ErasedAst.Expr, exp3: ErasedAst.Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class IntrinsicN(op: ErasedAst.IntrinsicOperatorN, exps: List[ErasedAst.Expression], tpe: MonoType, loc: SourceLocation) extends Expression
+    case class IntrinsicN(op: ErasedAst.IntrinsicOperatorN, exps: List[ErasedAst.Expr], tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Intrinsic1N(op: ErasedAst.IntrinsicOperator1N, exp: ErasedAst.Expression, exps: List[ErasedAst.Expression], tpe: MonoType, loc: SourceLocation) extends Expression
+    case class Intrinsic1N(op: ErasedAst.IntrinsicOperator1N, exp: ErasedAst.Expr, exps: List[ErasedAst.Expr], tpe: MonoType, loc: SourceLocation) extends Expr
 
   }
 
@@ -228,9 +228,9 @@ object ErasedAst {
 
   case class Case(sym: Symbol.CaseSym, tpeDeprecated: MonoType, loc: SourceLocation)
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[ErasedAst.FormalParam], clo: ErasedAst.Expression, retTpe: MonoType, loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[ErasedAst.FormalParam], clo: ErasedAst.Expr, retTpe: MonoType, loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[_], exp: ErasedAst.Expression)
+  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[_], exp: ErasedAst.Expr)
 
   case class FormalParam(sym: Symbol.VarSym, tpe: MonoType)
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -198,7 +198,7 @@ object ErasedAst {
 
     case class Closure(sym: Symbol.DefnSym) extends IntrinsicOperatorN
 
-   case class ApplyDef(sym: Symbol.DefnSym) extends IntrinsicOperatorN
+    case class ApplyDef(sym: Symbol.DefnSym) extends IntrinsicOperatorN
 
     case class ApplyDefTail(sym: Symbol.DefnSym) extends IntrinsicOperatorN
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -198,11 +198,11 @@ object ErasedAst {
 
     case class Closure(sym: Symbol.DefnSym) extends IntrinsicOperatorN
 
-    case class ApplyDef(sym: Symbol.DefnSym) extends IntrinsicOperatorN
+   case class ApplyDef(sym: Symbol.DefnSym) extends IntrinsicOperatorN
 
     case class ApplyDefTail(sym: Symbol.DefnSym) extends IntrinsicOperatorN
 
-    case class ApplySelfTail(sym: Symbol.DefnSym, formals: List[ErasedAst.FormalParam]) extends IntrinsicOperatorN
+    case class ApplySelfTail(sym: Symbol.DefnSym, formals: List[FormalParam]) extends IntrinsicOperatorN
 
     case object Tuple extends IntrinsicOperatorN
 
@@ -228,7 +228,7 @@ object ErasedAst {
 
   case class Case(sym: Symbol.CaseSym, tpeDeprecated: MonoType, loc: SourceLocation)
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[ErasedAst.FormalParam], clo: Expr, retTpe: MonoType, loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], clo: Expr, retTpe: MonoType, loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[_], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -23,18 +23,18 @@ import java.lang.reflect.{Constructor, Field, Method}
 
 object ErasedAst {
 
-  case class Root(defs: Map[Symbol.DefnSym, ErasedAst.Def],
-                  enums: Map[Symbol.EnumSym, ErasedAst.Enum],
+  case class Root(defs: Map[Symbol.DefnSym, Def],
+                  enums: Map[Symbol.EnumSym, Enum],
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],
                   closures: Set[ClosureInfo],
                   anonClasses: Set[AnonClassInfo])
 
-  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, formals: List[ErasedAst.FormalParam], exp: Expr, tpe: MonoType, loc: SourceLocation) {
+  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, formals: List[FormalParam], exp: Expr, tpe: MonoType, loc: SourceLocation) {
     var method: Method = _
   }
 
-  case class Enum(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, cases: Map[Symbol.CaseSym, ErasedAst.Case], tpeDeprecated: MonoType, loc: SourceLocation)
+  case class Enum(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, cases: Map[Symbol.CaseSym, Case], tpeDeprecated: MonoType, loc: SourceLocation)
 
   sealed trait Expr {
     def tpe: MonoType
@@ -60,9 +60,9 @@ object ErasedAst {
 
     case class Scope(sym: Symbol.VarSym, exp: Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class TryCatch(exp: Expr, rules: List[ErasedAst.CatchRule], tpe: MonoType, loc: SourceLocation) extends Expr
+    case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class NewObject(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[ErasedAst.JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
     case class Intrinsic0(op: IntrinsicOperator0, tpe: MonoType, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -64,17 +64,17 @@ object ErasedAst {
 
     case class NewObject(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[ErasedAst.JvmMethod], loc: SourceLocation) extends Expr
 
-    case class Intrinsic0(op: ErasedAst.IntrinsicOperator0, tpe: MonoType, loc: SourceLocation) extends Expr
+    case class Intrinsic0(op: IntrinsicOperator0, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Intrinsic1(op: ErasedAst.IntrinsicOperator1, exp: Expr, tpe: MonoType, loc: SourceLocation) extends Expr
+    case class Intrinsic1(op: IntrinsicOperator1, exp: Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Intrinsic2(op: ErasedAst.IntrinsicOperator2, exp1: Expr, exp2: Expr, tpe: MonoType, loc: SourceLocation) extends Expr
+    case class Intrinsic2(op: IntrinsicOperator2, exp1: Expr, exp2: Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Intrinsic3(op: ErasedAst.IntrinsicOperator3, exp1: Expr, exp2: Expr, exp3: Expr, tpe: MonoType, loc: SourceLocation) extends Expr
+    case class Intrinsic3(op: IntrinsicOperator3, exp1: Expr, exp2: Expr, exp3: Expr, tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class IntrinsicN(op: ErasedAst.IntrinsicOperatorN, exps: List[Expr], tpe: MonoType, loc: SourceLocation) extends Expr
+    case class IntrinsicN(op: IntrinsicOperatorN, exps: List[Expr], tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class Intrinsic1N(op: ErasedAst.IntrinsicOperator1N, exp: Expr, exps: List[Expr], tpe: MonoType, loc: SourceLocation) extends Expr
+    case class Intrinsic1N(op: IntrinsicOperator1N, exp: Expr, exps: List[Expr], tpe: MonoType, loc: SourceLocation) extends Expr
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -73,188 +73,188 @@ object Eraser {
   /**
     * Translates the given expression `exp0` to the ErasedAst.
     */
-  private def visitExp(exp0: FinalAst.Expression)(implicit ctx: Context): ErasedAst.Expression = exp0 match {
+  private def visitExp(exp0: FinalAst.Expression)(implicit ctx: Context): ErasedAst.Expr = exp0 match {
     case FinalAst.Expression.Cst(cst, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator0.Cst(cst)
-      ErasedAst.Expression.Intrinsic0(op, tpe, loc)
+      ErasedAst.Expr.Intrinsic0(op, tpe, loc)
 
     case FinalAst.Expression.Var(sym, tpe, loc) =>
-      ErasedAst.Expression.Var(sym, tpe, loc)
+      ErasedAst.Expr.Var(sym, tpe, loc)
 
     case FinalAst.Expression.Closure(sym, exps, tpe, loc) =>
       ctx.closures += ClosureInfo(sym, exps.map(_.tpe), tpe)
       val op = ErasedAst.IntrinsicOperatorN.Closure(sym)
-      ErasedAst.Expression.IntrinsicN(op, exps.map(visitExp), tpe, loc)
+      ErasedAst.Expr.IntrinsicN(op, exps.map(visitExp), tpe, loc)
 
     case FinalAst.Expression.ApplyClo(exp, exps, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1N.ApplyClo
-      ErasedAst.Expression.Intrinsic1N(op, visitExp(exp), exps.map(visitExp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1N(op, visitExp(exp), exps.map(visitExp), tpe, loc)
 
     case FinalAst.Expression.ApplyDef(sym, exps, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperatorN.ApplyDef(sym)
-      ErasedAst.Expression.IntrinsicN(op, exps.map(visitExp), tpe, loc)
+      ErasedAst.Expr.IntrinsicN(op, exps.map(visitExp), tpe, loc)
 
     case FinalAst.Expression.ApplyCloTail(exp, exps, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1N.ApplyCloTail
-      ErasedAst.Expression.Intrinsic1N(op, visitExp(exp), exps.map(visitExp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1N(op, visitExp(exp), exps.map(visitExp), tpe, loc)
 
     case FinalAst.Expression.ApplyDefTail(sym, exps, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperatorN.ApplyDefTail(sym)
-      ErasedAst.Expression.IntrinsicN(op, exps.map(visitExp), tpe, loc)
+      ErasedAst.Expr.IntrinsicN(op, exps.map(visitExp), tpe, loc)
 
     case FinalAst.Expression.ApplySelfTail(sym, formals0, exps, tpe, loc) =>
       val formals = formals0.map {
         case FinalAst.FormalParam(formalSym, formalTpe) => ErasedAst.FormalParam(formalSym, formalTpe)
       }
       val op = ErasedAst.IntrinsicOperatorN.ApplySelfTail(sym, formals)
-      ErasedAst.Expression.IntrinsicN(op, exps.map(visitExp), tpe, loc)
+      ErasedAst.Expr.IntrinsicN(op, exps.map(visitExp), tpe, loc)
 
     case FinalAst.Expression.Unary(sop, _, exp, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1.Unary(sop)
-      ErasedAst.Expression.Intrinsic1(op, visitExp(exp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1(op, visitExp(exp), tpe, loc)
 
     case FinalAst.Expression.Binary(sop, op, exp1, exp2, tpe, loc) =>
-      ErasedAst.Expression.Binary(sop, visitExp(exp1), visitExp(exp2), tpe, loc)
+      ErasedAst.Expr.Binary(sop, visitExp(exp1), visitExp(exp2), tpe, loc)
 
     case FinalAst.Expression.IfThenElse(exp1, exp2, exp3, tpe, loc) =>
-      ErasedAst.Expression.IfThenElse(visitExp(exp1), visitExp(exp2), visitExp(exp3), tpe, loc)
+      ErasedAst.Expr.IfThenElse(visitExp(exp1), visitExp(exp2), visitExp(exp3), tpe, loc)
 
     case FinalAst.Expression.Branch(exp, branches0, tpe, loc) =>
       val branches = branches0.map {
         case (branchLabel, branchExp) => (branchLabel, visitExp(branchExp))
       }
-      ErasedAst.Expression.Branch(visitExp(exp), branches, tpe, loc)
+      ErasedAst.Expr.Branch(visitExp(exp), branches, tpe, loc)
 
     case FinalAst.Expression.JumpTo(sym, tpe, loc) =>
-      ErasedAst.Expression.JumpTo(sym, tpe, loc)
+      ErasedAst.Expr.JumpTo(sym, tpe, loc)
 
     case FinalAst.Expression.Let(sym, exp1, exp2, tpe, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      ErasedAst.Expression.Let(sym, e1, e2, tpe, loc)
+      ErasedAst.Expr.Let(sym, e1, e2, tpe, loc)
 
     case FinalAst.Expression.LetRec(varSym, index, defSym, exp1, exp2, tpe, loc) =>
       val e1 = visitExp(exp1)
       val e2 = visitExp(exp2)
-      ErasedAst.Expression.LetRec(varSym, index, defSym, e1, e2, tpe, loc)
+      ErasedAst.Expr.LetRec(varSym, index, defSym, e1, e2, tpe, loc)
 
     case FinalAst.Expression.Region(tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator0.Region
-      ErasedAst.Expression.Intrinsic0(op, tpe, loc)
+      ErasedAst.Expr.Intrinsic0(op, tpe, loc)
 
     case FinalAst.Expression.Scope(sym, exp, tpe, loc) =>
-      ErasedAst.Expression.Scope(sym, visitExp(exp), tpe, loc)
+      ErasedAst.Expr.Scope(sym, visitExp(exp), tpe, loc)
 
     case FinalAst.Expression.ScopeExit(exp1, exp2, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator2.ScopeExit
-      ErasedAst.Expression.Intrinsic2(op, visitExp(exp1), visitExp(exp2), tpe, loc)
+      ErasedAst.Expr.Intrinsic2(op, visitExp(exp1), visitExp(exp2), tpe, loc)
 
     case FinalAst.Expression.Is(sym, exp, loc) =>
       val op = ErasedAst.IntrinsicOperator1.Is(sym)
-      ErasedAst.Expression.Intrinsic1(op, visitExp(exp), MonoType.Bool, loc)
+      ErasedAst.Expr.Intrinsic1(op, visitExp(exp), MonoType.Bool, loc)
 
     case FinalAst.Expression.Tag(sym, exp, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1.Tag(sym)
-      ErasedAst.Expression.Intrinsic1(op, visitExp(exp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1(op, visitExp(exp), tpe, loc)
 
     case FinalAst.Expression.Untag(sym, exp, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1.Untag(sym)
-      ErasedAst.Expression.Intrinsic1(op, visitExp(exp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1(op, visitExp(exp), tpe, loc)
 
     case FinalAst.Expression.Index(base, idx, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1.Index(idx)
-      ErasedAst.Expression.Intrinsic1(op, visitExp(base), tpe, loc)
+      ErasedAst.Expr.Intrinsic1(op, visitExp(base), tpe, loc)
 
     case FinalAst.Expression.Tuple(exps, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperatorN.Tuple
-      ErasedAst.Expression.IntrinsicN(op, exps.map(visitExp), tpe, loc)
+      ErasedAst.Expr.IntrinsicN(op, exps.map(visitExp), tpe, loc)
 
     case FinalAst.Expression.RecordEmpty(tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator0.RecordEmpty
-      ErasedAst.Expression.Intrinsic0(op, tpe, loc)
+      ErasedAst.Expr.Intrinsic0(op, tpe, loc)
 
     case FinalAst.Expression.RecordSelect(exp, field, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1.RecordSelect(field)
-      ErasedAst.Expression.Intrinsic1(op, visitExp(exp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1(op, visitExp(exp), tpe, loc)
 
     case FinalAst.Expression.RecordExtend(field, exp1, exp2, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator2.RecordExtend(field)
-      ErasedAst.Expression.Intrinsic2(op, visitExp(exp1), visitExp(exp2), tpe, loc)
+      ErasedAst.Expr.Intrinsic2(op, visitExp(exp1), visitExp(exp2), tpe, loc)
 
     case FinalAst.Expression.RecordRestrict(field, exp, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1.RecordRestrict(field)
-      ErasedAst.Expression.Intrinsic1(op, visitExp(exp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1(op, visitExp(exp), tpe, loc)
 
     case FinalAst.Expression.ArrayLit(exps, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperatorN.ArrayLit
-      ErasedAst.Expression.IntrinsicN(op, exps.map(visitExp), tpe, loc)
+      ErasedAst.Expr.IntrinsicN(op, exps.map(visitExp), tpe, loc)
 
     case FinalAst.Expression.ArrayNew(exp1, exp2, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator2.ArrayNew
-      ErasedAst.Expression.Intrinsic2(op, visitExp(exp1), visitExp(exp2), tpe, loc)
+      ErasedAst.Expr.Intrinsic2(op, visitExp(exp1), visitExp(exp2), tpe, loc)
 
     case FinalAst.Expression.ArrayLoad(exp1, exp2, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator2.ArrayLoad
-      ErasedAst.Expression.Intrinsic2(op, visitExp(exp1), visitExp(exp2), tpe, loc)
+      ErasedAst.Expr.Intrinsic2(op, visitExp(exp1), visitExp(exp2), tpe, loc)
 
     case FinalAst.Expression.ArrayStore(exp1, exp2, exp3, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator3.ArrayStore
-      ErasedAst.Expression.Intrinsic3(op, visitExp(exp1), visitExp(exp2), visitExp(exp3), tpe, loc)
+      ErasedAst.Expr.Intrinsic3(op, visitExp(exp1), visitExp(exp2), visitExp(exp3), tpe, loc)
 
     case FinalAst.Expression.ArrayLength(exp, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1.ArrayLength
-      ErasedAst.Expression.Intrinsic1(op, visitExp(exp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1(op, visitExp(exp), tpe, loc)
 
     case FinalAst.Expression.Ref(exp, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1.Ref
-      ErasedAst.Expression.Intrinsic1(op, visitExp(exp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1(op, visitExp(exp), tpe, loc)
 
     case FinalAst.Expression.Deref(exp, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1.Deref
-      ErasedAst.Expression.Intrinsic1(op, visitExp(exp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1(op, visitExp(exp), tpe, loc)
 
     case FinalAst.Expression.Assign(exp1, exp2, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator2.Assign
-      ErasedAst.Expression.Intrinsic2(op, visitExp(exp1), visitExp(exp2), tpe, loc)
+      ErasedAst.Expr.Intrinsic2(op, visitExp(exp1), visitExp(exp2), tpe, loc)
 
     case FinalAst.Expression.Cast(exp, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1.Cast
-      ErasedAst.Expression.Intrinsic1(op, visitExp(exp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1(op, visitExp(exp), tpe, loc)
 
     case FinalAst.Expression.TryCatch(exp, rules0, tpe, loc) =>
       val rules = rules0.map {
         case FinalAst.CatchRule(catchSym, catchClazz, catchExp) =>
           ErasedAst.CatchRule(catchSym, catchClazz, visitExp(catchExp))
       }
-      ErasedAst.Expression.TryCatch(visitExp(exp), rules, tpe, loc)
+      ErasedAst.Expr.TryCatch(visitExp(exp), rules, tpe, loc)
 
     case FinalAst.Expression.InvokeConstructor(constructor, exps, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperatorN.InvokeConstructor(constructor)
-      ErasedAst.Expression.IntrinsicN(op, exps.map(visitExp), tpe, loc)
+      ErasedAst.Expr.IntrinsicN(op, exps.map(visitExp), tpe, loc)
 
     case FinalAst.Expression.InvokeMethod(method, exp, exps, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1N.InvokeMethod(method)
-      ErasedAst.Expression.Intrinsic1N(op, visitExp(exp), exps.map(visitExp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1N(op, visitExp(exp), exps.map(visitExp), tpe, loc)
 
     case FinalAst.Expression.InvokeStaticMethod(method, exps, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperatorN.InvokeStaticMethod(method)
-      ErasedAst.Expression.IntrinsicN(op, exps.map(visitExp), tpe, loc)
+      ErasedAst.Expr.IntrinsicN(op, exps.map(visitExp), tpe, loc)
 
     case FinalAst.Expression.GetField(field, exp, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1.GetField(field)
-      ErasedAst.Expression.Intrinsic1(op, visitExp(exp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1(op, visitExp(exp), tpe, loc)
 
     case FinalAst.Expression.PutField(field, exp1, exp2, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator2.PutField(field)
-      ErasedAst.Expression.Intrinsic2(op, visitExp(exp1), visitExp(exp2), tpe, loc)
+      ErasedAst.Expr.Intrinsic2(op, visitExp(exp1), visitExp(exp2), tpe, loc)
 
     case FinalAst.Expression.GetStaticField(field, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator0.GetStaticField(field)
-      ErasedAst.Expression.Intrinsic0(op, tpe, loc)
+      ErasedAst.Expr.Intrinsic0(op, tpe, loc)
 
     case FinalAst.Expression.PutStaticField(field, exp, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1.PutStaticField(field)
-      ErasedAst.Expression.Intrinsic1(op, visitExp(exp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1(op, visitExp(exp), tpe, loc)
 
     case FinalAst.Expression.NewObject(name, clazz, tpe, methods0, loc) =>
       val methods = methods0.map {
@@ -263,27 +263,27 @@ object Eraser {
           ErasedAst.JvmMethod(ident, f, visitExp(clo), retTpe, loc)
       }
       ctx.anonClasses += AnonClassInfo(name, clazz, tpe, methods, loc)
-      ErasedAst.Expression.NewObject(name, clazz, tpe, methods, loc)
+      ErasedAst.Expr.NewObject(name, clazz, tpe, methods, loc)
 
     case FinalAst.Expression.Spawn(exp1, exp2, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator2.Spawn
-      ErasedAst.Expression.Intrinsic2(op, visitExp(exp1), visitExp(exp2), tpe, loc)
+      ErasedAst.Expr.Intrinsic2(op, visitExp(exp1), visitExp(exp2), tpe, loc)
 
     case FinalAst.Expression.Lazy(exp, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1.Lazy
-      ErasedAst.Expression.Intrinsic1(op, visitExp(exp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1(op, visitExp(exp), tpe, loc)
 
     case FinalAst.Expression.Force(exp, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator1.Force
-      ErasedAst.Expression.Intrinsic1(op, visitExp(exp), tpe, loc)
+      ErasedAst.Expr.Intrinsic1(op, visitExp(exp), tpe, loc)
 
     case FinalAst.Expression.HoleError(sym, tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator0.HoleError(sym)
-      ErasedAst.Expression.Intrinsic0(op, tpe, loc)
+      ErasedAst.Expr.Intrinsic0(op, tpe, loc)
 
     case FinalAst.Expression.MatchError(tpe, loc) =>
       val op = ErasedAst.IntrinsicOperator0.MatchError
-      ErasedAst.Expression.Intrinsic0(op, tpe, loc)
+      ErasedAst.Expr.Intrinsic0(op, tpe, loc)
   }
 
   private case class Context(closures: mutable.Set[ClosureInfo], anonClasses: mutable.Set[AnonClassInfo])

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenClosureClasses.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.ErasedAst.{Def, Expression, FormalParam, Root}
+import ca.uwaterloo.flix.language.ast.ErasedAst.{Def, FormalParam, Root}
 import ca.uwaterloo.flix.language.ast.MonoType
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
 import ca.uwaterloo.flix.util.ParOps

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -655,7 +655,7 @@ object JvmOps {
       formalParamTypes ++ expressionTypes + defn.tpe
     }
 
-    def visitExps(exps: Iterable[Expression]): Set[MonoType] = {
+    def visitExps(exps: Iterable[Expr]): Set[MonoType] = {
       exps.foldLeft(Set.empty[MonoType]) {
         case (sacc, e) => sacc ++ visitExp(e)
       }
@@ -664,30 +664,30 @@ object JvmOps {
     /**
       * Returns the set of types which occur in the given expression `exp0`.
       */
-    def visitExp(exp0: Expression): Set[MonoType] = (exp0 match {
-      case Expression.Var(_, _, _) => Set.empty
+    def visitExp(exp0: Expr): Set[MonoType] = (exp0 match {
+      case Expr.Var(_, _, _) => Set.empty
 
-      case Expression.Binary(_, exp1, exp2, _, _) => visitExp(exp1) ++ visitExp(exp2)
+      case Expr.Binary(_, exp1, exp2, _, _) => visitExp(exp1) ++ visitExp(exp2)
 
-      case Expression.IfThenElse(exp1, exp2, exp3, _, _) => visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
+      case Expr.IfThenElse(exp1, exp2, exp3, _, _) => visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
 
-      case Expression.Branch(exp, branches, _, _) =>
+      case Expr.Branch(exp, branches, _, _) =>
         val exps = branches.map {
           case (_, e) => e
         }
         visitExp(exp) ++ visitExps(exps)
 
-      case Expression.JumpTo(_, _, _) => Set.empty
+      case Expr.JumpTo(_, _, _) => Set.empty
 
-      case Expression.Let(_, exp1, exp2, _, _) => visitExp(exp1) ++ visitExp(exp2)
+      case Expr.Let(_, exp1, exp2, _, _) => visitExp(exp1) ++ visitExp(exp2)
 
-      case Expression.LetRec(_, _, _, exp1, exp2, _, _) => visitExp(exp1) ++ visitExp(exp2)
+      case Expr.LetRec(_, _, _, exp1, exp2, _, _) => visitExp(exp1) ++ visitExp(exp2)
 
-      case Expression.Scope(_, exp, _, _) => visitExp(exp)
+      case Expr.Scope(_, exp, _, _) => visitExp(exp)
 
-      case Expression.TryCatch(exp, rules, _, _) => visitExp(exp) ++ visitExps(rules.map(_.exp))
+      case Expr.TryCatch(exp, rules, _, _) => visitExp(exp) ++ visitExps(rules.map(_.exp))
 
-      case Expression.NewObject(_, _, _, methods, _) =>
+      case Expr.NewObject(_, _, _, methods, _) =>
         methods.foldLeft(Set.empty[MonoType]) {
           case (sacc, JvmMethod(_, fparams, clo, retTpe, _)) =>
             val fs = fparams.foldLeft(Set(retTpe)) {
@@ -696,17 +696,17 @@ object JvmOps {
             sacc ++ fs ++ visitExp(clo)
         }
 
-      case Expression.Intrinsic0(_, tpe, _) => Set(tpe)
+      case Expr.Intrinsic0(_, tpe, _) => Set(tpe)
 
-      case Expression.Intrinsic1(_, exp, tpe, _) => visitExp(exp) + tpe
+      case Expr.Intrinsic1(_, exp, tpe, _) => visitExp(exp) + tpe
 
-      case Expression.Intrinsic2(_, exp1, exp2, tpe, _) => visitExp(exp1) ++ visitExp(exp2) + tpe
+      case Expr.Intrinsic2(_, exp1, exp2, tpe, _) => visitExp(exp1) ++ visitExp(exp2) + tpe
 
-      case Expression.Intrinsic3(_, exp1, exp2, exp3, tpe, _) => visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3) + tpe
+      case Expr.Intrinsic3(_, exp1, exp2, exp3, tpe, _) => visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3) + tpe
 
-      case Expression.IntrinsicN(_, exps, tpe, _) => visitExps(exps) + tpe
+      case Expr.IntrinsicN(_, exps, tpe, _) => visitExps(exps) + tpe
 
-      case Expression.Intrinsic1N(_, exp, exps, tpe, _) => visitExp(exp) ++ visitExps(exps) + tpe
+      case Expr.Intrinsic1N(_, exp, exps, tpe, _) => visitExp(exp) ++ visitExps(exps) + tpe
 
     }) ++ Set(exp0.tpe)
 


### PR DESCRIPTION
Removes `ErasedAst` prefix from names in `ErasedAst`.

- Rename `ErasedAst.Expression` -> `ErasedAst.Expr`
- Rename `ErasedAst.Expression` -> `Expr`
- Rename `ErasedAst.IntrinsicOperatorX` -> `IntrinsicOperatorX`
- Rename `ErasedAst.X` -> `X`

Closes https://github.com/flix/flix/issues/5564