### PR TITLE
chore: check that `BodyPredicate.Loop` does not use non-positively bound variables

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -560,7 +560,12 @@ object Safety {
 
     case Predicate.Body.Guard(exp, _) => visitExp(exp, renv, root)
 
-    case Predicate.Body.Loop(_, exp, _) => visitExp(exp, renv, root)
+    case Predicate.Body.Loop(boundVars, exp, loc) =>
+      // check for non-positively bound negative variables.
+      val fvs = freeVars(exp).keySet intersect quantVars
+      val err1 = ((fvs -- posVars) map (makeIllegalNonPositivelyBoundVariableError(_, loc))).toList
+
+      err1 ::: visitExp(exp, renv, root)
   }
 
   /**
@@ -592,7 +597,10 @@ object Safety {
 
     case Predicate.Body.Guard(_, _) => Set.empty
 
-    case Predicate.Body.Loop(_, _, _) => Set.empty
+    case Predicate.Body.Loop(boundVars, _, _) =>
+      // Tricky: All bound variables are positively defined if their free variables are.
+      // For now, we say that they are not positively defined.
+      Set.empty
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -103,6 +103,22 @@ class TestSafety extends FunSuite with TestUtils {
     expectError[IllegalNonPositivelyBoundVariable](result)
   }
 
+  test("NonPositivelyBoundVariable.04") {
+    val input =
+      """
+        |def main(): Unit =
+        |    let f = (x, y) -> Vector#{(x, y)};
+        |    let _ = #{
+        |        R(0, 0, 0, 0).
+        |        A(1, 2).
+        |        R(x, y, u, v) :- A(x, y), let (u, v) = f(u, v).
+        |    };
+        |    ()
+    """.stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[IllegalNonPositivelyBoundVariable](result)
+  }
+
   // TODO NS-REFACTOR find out if wildcard and wild variable are different
   test("NegativelyBoundWildVariable.01") {
     val input =
@@ -224,6 +240,17 @@ class TestSafety extends FunSuite with TestUtils {
         |    A(12) :- B(12, l), fix C(12; l).
         |}
         |""".stripMargin
+    val result = compile(input, Options.TestWithLibAll)
+    expectError[IllegalRelationalUseOfLatticeVariable](result)
+  }
+
+  test("UseOfLatticeVariable.01") {
+    val input =
+      """
+        |pub def f(): #{ A(Int32), B(Int32; Int32) } = #{
+        |    A(x: Int32) :- B(12; x).
+        |}
+      """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
     expectError[IllegalRelationalUseOfLatticeVariable](result)
   }


### PR DESCRIPTION
…und variables