### PR TITLE
fix: create proper error for associated types as class instance parameters

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
@@ -213,6 +213,32 @@ object InstanceError {
   }
 
   /**
+    * Error indicating an associated type in an instance type.
+    *
+    * @param assoc the type alias.
+    * @param clazz the class symbol.
+    * @param loc   the location where the error occurred.
+    */
+  case class IllegalAssocTypeInstance(assoc: Symbol.AssocTypeSym, clazz: Symbol.ClassSym, loc: SourceLocation) extends InstanceError {
+    override def summary: String = "Associated type in instance type."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Illegal use of associated type '${red(assoc.name)}' in instance declaration for '${red(clazz.name)}'.
+         |${code(loc, s"illegal use of associated type")}
+         |""".stripMargin
+
+    }
+
+    def explain(formatter: Formatter): Option[String] = Some({
+      import formatter._
+      s"${underline("Tip:")} A type class instance cannot use an associated type. Use the full type."
+    })
+
+  }
+
+  /**
     * Error indicating an orphan instance.
     *
     * @param tpe the instance type.

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -122,7 +122,7 @@ object Instances {
           }
           errs0
         case Type.Alias(alias, _, _, _) => List(InstanceError.IllegalTypeAliasInstance(alias.sym, clazz.sym, clazz.loc))
-        case Type.AssocType(assoc, _, _, loc) => throw InternalCompilerException("unexpected associated type", loc) // TODO ASSOC-TYPES real error
+        case Type.AssocType(assoc, _, _, loc) => List(InstanceError.IllegalAssocTypeInstance(assoc.sym, clazz.sym, loc))
       }
     }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
@@ -600,6 +600,21 @@ class TestInstances extends FunSuite with TestUtils {
     expectError[InstanceError.IllegalTypeAliasInstance](result)
   }
 
+  test("Test.AssocTypeInstance.01") {
+    val input =
+      """
+        |class C[a] {
+        |    type T[a]: Type
+        |}
+        |
+        |class D[a]
+        |
+        |instance D[C.T[a]]
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[InstanceError.IllegalAssocTypeInstance](result)
+  }
+
   test("Test.MissingConstraint.01") {
     val input =
       """


### PR DESCRIPTION
related to #5647