### PR TITLE
chore: update scalactic and scalatest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation('org.tomlj:tomlj:1.1.0')
     implementation('org.antlr:antlr4-runtime:4.11.1')
 
-    testImplementation('org.scalatest:scalatest_2.13:3.0.8')
+    testImplementation('org.scalatest:scalatest_2.13:3.2.15')
 }
 
 tasks.withType(ScalaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation('org.json4s:json4s-native_2.13:3.5.5')
     implementation('org.ow2.asm:asm:9.2')
     implementation('org.parboiled:parboiled_2.13:2.2.1')
-    implementation('org.scalactic:scalactic_2.13:3.0.8')
+    implementation('org.scalactic:scalactic_2.13:3.2.15')
     implementation("org.scala-lang.modules:scala-parallel-collections_2.13:0.2.0")
     implementation('com.github.scopt:scopt_2.13:4.0.1')
     implementation('com.google.guava:guava:25.1-jre')

--- a/main/test/ca/uwaterloo/flix/TestMain.scala
+++ b/main/test/ca/uwaterloo/flix/TestMain.scala
@@ -17,9 +17,9 @@
 package ca.uwaterloo.flix
 
 import ca.uwaterloo.flix.util.LibLevel
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestMain extends FunSuite {
+class TestMain extends AnyFunSuite {
 
   test("init") {
     val args = Array("init")

--- a/main/test/ca/uwaterloo/flix/TestUtils.scala
+++ b/main/test/ca/uwaterloo/flix/TestUtils.scala
@@ -21,13 +21,13 @@ import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.SourceLocation
 import ca.uwaterloo.flix.runtime.CompilationResult
 import ca.uwaterloo.flix.util.{Formatter, Options, Validation}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.reflect.ClassTag
 
 trait TestUtils {
 
-  this: FunSuite =>
+  this: AnyFunSuite =>
 
   /**
     * Compiles the given input string `s` with the given compilation options `o`.

--- a/main/test/ca/uwaterloo/flix/language/TestFlixErrors.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestFlixErrors.scala
@@ -19,9 +19,9 @@ package ca.uwaterloo.flix.language
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.runtime.CompilationResult
 import ca.uwaterloo.flix.util.{Options, Validation}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestFlixErrors extends FunSuite with TestUtils {
+class TestFlixErrors extends AnyFunSuite with TestUtils {
 
   def expectRuntimeError(v: Validation[CompilationResult, CompilationMessage], name: String): Unit = {
     expectSuccess(v)

--- a/main/test/ca/uwaterloo/flix/language/TestProgramArgs.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestProgramArgs.scala
@@ -18,9 +18,9 @@ package ca.uwaterloo.flix.language
 
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.util.{Options, Validation}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestProgramArgs extends FunSuite with TestUtils {
+class TestProgramArgs extends AnyFunSuite with TestUtils {
 
   test("ProgramArgs.01") {
     val arg = "Correct"

--- a/main/test/ca/uwaterloo/flix/language/fmt/TestFormatType.scala
+++ b/main/test/ca/uwaterloo/flix/language/fmt/TestFormatType.scala
@@ -18,9 +18,9 @@ package ca.uwaterloo.flix.language.fmt
 
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.ast.{Ast, Kind, Name, SourceLocation, Symbol, Type, TypeConstructor}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestFormatType extends FunSuite with TestUtils {
+class TestFormatType extends AnyFunSuite with TestUtils {
 
   private val loc = SourceLocation.Unknown
   private val standardFormat = FormatOptions(

--- a/main/test/ca/uwaterloo/flix/language/phase/TestDeriver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestDeriver.scala
@@ -19,9 +19,9 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.DerivationError
 import ca.uwaterloo.flix.util.Options
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestDeriver extends FunSuite with TestUtils {
+class TestDeriver extends AnyFunSuite with TestUtils {
   test("DerivationError.EmptyEnum.Eq") {
     val compiled = compile("enum E with Eq", Options.TestWithLibMin)
     expectError[DerivationError.IllegalDerivationForEmptyEnum](compiled)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestEntryPoint.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestEntryPoint.scala
@@ -19,9 +19,9 @@ import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.ast.Symbol
 import ca.uwaterloo.flix.language.errors.EntryPointError
 import ca.uwaterloo.flix.util.Options
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestEntryPoint extends FunSuite with TestUtils {
+class TestEntryPoint extends AnyFunSuite with TestUtils {
 
   test("Test.IllegalEntryPointArg.Main.01") {
     val input =

--- a/main/test/ca/uwaterloo/flix/language/phase/TestIncremental.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestIncremental.scala
@@ -18,11 +18,12 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.errors.TypeError.UnexpectedArgument
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Path
 
-class TestIncremental extends FunSuite with BeforeAndAfter with TestUtils {
+class TestIncremental extends AnyFunSuite with BeforeAndAfter with TestUtils {
 
   private val FileA = "FileA.flix"
   private val FileB = "FileB.flix"

--- a/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
@@ -20,9 +20,9 @@ import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.errors.InstanceError
 import ca.uwaterloo.flix.util.Options
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestInstances extends FunSuite with TestUtils {
+class TestInstances extends AnyFunSuite with TestUtils {
 
   test("Test.OverlappingInstance.01") {
     val input =

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -18,9 +18,9 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.KindError
 import ca.uwaterloo.flix.util.Options
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestKinder extends FunSuite with TestUtils {
+class TestKinder extends AnyFunSuite with TestUtils {
 
   private val DefaultOptions = Options.TestWithLibNix
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -19,9 +19,9 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.NameError
 import ca.uwaterloo.flix.util.Options
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestNamer extends FunSuite with TestUtils {
+class TestNamer extends AnyFunSuite with TestUtils {
 
   test("DuplicateLowerName.01") {
     val input =

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -3,9 +3,9 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.ParseError
 import ca.uwaterloo.flix.util.Options
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestParser extends FunSuite with TestUtils {
+class TestParser extends AnyFunSuite with TestUtils {
 
   test("ParseError.Int.01") {
     val input =

--- a/main/test/ca/uwaterloo/flix/language/phase/TestPatExhaustiveness.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestPatExhaustiveness.scala
@@ -21,9 +21,9 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.errors.NonExhaustiveMatchError
 import ca.uwaterloo.flix.runtime.CompilationResult
 import ca.uwaterloo.flix.util.Options
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestPatExhaustiveness extends FunSuite with TestUtils {
+class TestPatExhaustiveness extends AnyFunSuite with TestUtils {
 
   test("Pattern.Literal.Char.01") {
     val input =

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -3,9 +3,9 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.{RedundancyError, TypeError}
 import ca.uwaterloo.flix.util.Options
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestRedundancy extends FunSuite with TestUtils {
+class TestRedundancy extends AnyFunSuite with TestUtils {
 
   test("HiddenVarSym.Let.01") {
     val input =

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRegions.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRegions.scala
@@ -19,9 +19,9 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.TypeError
 import ca.uwaterloo.flix.util.Options
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestRegions extends FunSuite with TestUtils {
+class TestRegions extends AnyFunSuite with TestUtils {
 
   test("RegionVarEscapes.01") {
     val input =

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -19,9 +19,9 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.ResolutionError
 import ca.uwaterloo.flix.util.Options
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestResolver extends FunSuite with TestUtils {
+class TestResolver extends AnyFunSuite with TestUtils {
 
   // TODO NS-REFACTOR impossible after refactor
   ignore("AmbiguousTag.01") {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -20,9 +20,9 @@ import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.SafetyError
 import ca.uwaterloo.flix.language.errors.SafetyError.{IllegalNegativelyBoundWildcard, IllegalNonPositivelyBoundVariable, IllegalRelationalUseOfLatticeVariable, UnexpectedPatternInBodyAtom}
 import ca.uwaterloo.flix.util.Options
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestSafety extends FunSuite with TestUtils {
+class TestSafety extends AnyFunSuite with TestUtils {
 
   val DefaultOptions: Options = Options.TestWithLibMin
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestStratifier.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestStratifier.scala
@@ -19,9 +19,9 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.StratificationError
 import ca.uwaterloo.flix.util.Options
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestStratifier extends FunSuite with TestUtils {
+class TestStratifier extends AnyFunSuite with TestUtils {
 
   val DefaultOptions: Options = Options.TestWithLibMin
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -19,9 +19,9 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.TypeError
 import ca.uwaterloo.flix.util.Options
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestTyper extends FunSuite with TestUtils {
+class TestTyper extends AnyFunSuite with TestUtils {
 
   test("TestLeq01") {
     val input =

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -19,9 +19,9 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.WeederError
 import ca.uwaterloo.flix.util.Options
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestWeeder extends FunSuite with TestUtils {
+class TestWeeder extends AnyFunSuite with TestUtils {
 
   test("DuplicateTag.01") {
     val input =

--- a/main/test/ca/uwaterloo/flix/language/phase/unification/TestAssocTypeUnification.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/unification/TestAssocTypeUnification.scala
@@ -21,9 +21,9 @@ import ca.uwaterloo.flix.language.ast.{Ast, Kind, Name, RigidityEnv, SourceLocat
 import ca.uwaterloo.flix.util.Result
 import ca.uwaterloo.flix.util.Result.Ok
 import ca.uwaterloo.flix.util.collection.ListMap
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestAssocTypeUnification extends FunSuite with TestUtils {
+class TestAssocTypeUnification extends AnyFunSuite with TestUtils {
 
   private implicit val flix: Flix = new Flix()
   private val loc: SourceLocation = SourceLocation.Unknown

--- a/main/test/ca/uwaterloo/flix/language/phase/unification/TestBdd.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/unification/TestBdd.scala
@@ -2,10 +2,10 @@ package ca.uwaterloo.flix.language.phase.unification
 
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.ast.SourceLocation
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.sosy_lab.pjbdd.api.{Creator, DD}
 
-class TestBdd extends FunSuite with TestUtils {
+class TestBdd extends AnyFunSuite with TestUtils {
 
   val loc: SourceLocation = SourceLocation.Unknown
   val builder: Creator = BddFormulaAlg.GlobalBddBuilder

--- a/main/test/ca/uwaterloo/flix/language/phase/unification/TestBoolFormulaTable.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/unification/TestBoolFormulaTable.scala
@@ -2,9 +2,9 @@ package ca.uwaterloo.flix.language.phase.unification
 
 import ca.uwaterloo.flix.language.phase.unification.BoolFormula._
 import ca.uwaterloo.flix.language.phase.unification.BoolFormulaTable._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestBoolFormulaTable extends FunSuite {
+class TestBoolFormulaTable extends AnyFunSuite {
 
   test("Minimize.True.01") {
     assertResult(expected = True)(actual = minimizeFormula(True))

--- a/main/test/ca/uwaterloo/flix/language/phase/unification/TestCaseSetUnification.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/unification/TestCaseSetUnification.scala
@@ -20,11 +20,11 @@ import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{Ast, Kind, Name, RigidityEnv, SourceLocation, SourcePosition, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.util.Result
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.collection.immutable.SortedSet
 
-class TestCaseSetUnification extends FunSuite with TestUtils {
+class TestCaseSetUnification extends AnyFunSuite with TestUtils {
 
   private implicit val flix: Flix = new Flix()
 

--- a/main/test/ca/uwaterloo/flix/language/phase/unification/TestQMCtoBoolFormula.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/unification/TestQMCtoBoolFormula.scala
@@ -17,9 +17,9 @@
 package ca.uwaterloo.flix.language.phase.unification
 
 import ca.uwaterloo.flix.language.phase.unification.BoolFormula._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestQMCtoBoolFormula extends FunSuite {
+class TestQMCtoBoolFormula extends AnyFunSuite {
 
   val alg: BoolFormulaAlg = new BoolFormulaAlg()
 

--- a/main/test/ca/uwaterloo/flix/language/phase/unification/TestSetUnification.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/unification/TestSetUnification.scala
@@ -20,9 +20,9 @@ import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{Ast, Kind, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.util.Result
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestSetUnification extends FunSuite with TestUtils {
+class TestSetUnification extends AnyFunSuite with TestUtils {
 
   implicit val flix: Flix = new Flix()
 

--- a/main/test/ca/uwaterloo/flix/language/phase/unification/TestUnification.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/unification/TestUnification.scala
@@ -21,9 +21,9 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.{Ast, Kind, Name, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.phase.unification.InferMonad.seqM
 import ca.uwaterloo.flix.util.Result
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestUnification extends FunSuite with TestUtils {
+class TestUnification extends AnyFunSuite with TestUtils {
 
   implicit val flix: Flix = new Flix()
 

--- a/main/test/ca/uwaterloo/flix/tools/TestBootstrap.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestBootstrap.scala
@@ -2,7 +2,7 @@ package ca.uwaterloo.flix.tools
 
 import ca.uwaterloo.flix.api.{Bootstrap, Flix}
 import ca.uwaterloo.flix.util.Options
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.{Files, Path}
 import java.security.{DigestInputStream, MessageDigest}
@@ -12,7 +12,7 @@ import java.util.zip.ZipFile
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
 import scala.util.Using
 
-class TestBootstrap extends FunSuite {
+class TestBootstrap extends AnyFunSuite {
 
   private val ProjectPrefix: String = "flix-project-"
 

--- a/main/test/ca/uwaterloo/flix/tools/TestFlixPackageManager.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestFlixPackageManager.scala
@@ -4,13 +4,13 @@ import ca.uwaterloo.flix.tools.pkg.github.GitHub.Project
 import ca.uwaterloo.flix.tools.pkg.{FlixPackageManager, ManifestParser, PackageError, SemVer}
 import ca.uwaterloo.flix.util.Formatter
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.File
 import java.net.URL
 import java.nio.file.Files
 
-class TestFlixPackageManager extends FunSuite {
+class TestFlixPackageManager extends AnyFunSuite {
   val s: String = File.separator
   val f: Formatter = Formatter.NoFormatter
 

--- a/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
@@ -3,11 +3,11 @@ package ca.uwaterloo.flix.tools
 import ca.uwaterloo.flix.tools.pkg.{Dependency, DependencyKind, ManifestError, ManifestParser, Repository, SemVer}
 import ca.uwaterloo.flix.util.Formatter
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Paths
 
-class TestManifestParser extends FunSuite {
+class TestManifestParser extends AnyFunSuite {
 
   val f: Formatter = Formatter.NoFormatter
   val tomlCorrect: String = {

--- a/main/test/ca/uwaterloo/flix/tools/TestMavenPackageManager.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestMavenPackageManager.scala
@@ -3,12 +3,12 @@ package ca.uwaterloo.flix.tools
 import ca.uwaterloo.flix.tools.pkg.{FlixPackageManager, ManifestParser, MavenPackageManager, PackageError}
 import ca.uwaterloo.flix.util.Formatter
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.File
 import java.nio.file.Files
 
-class TestMavenPackageManager extends FunSuite {
+class TestMavenPackageManager extends AnyFunSuite {
   val s: String = File.separator
   val f: Formatter = Formatter.NoFormatter
 

--- a/main/test/ca/uwaterloo/flix/util/FlixSuite.scala
+++ b/main/test/ca/uwaterloo/flix/util/FlixSuite.scala
@@ -19,12 +19,12 @@ package ca.uwaterloo.flix.util
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.runtime.{CompilationResult, TestFn}
 import ca.uwaterloo.flix.util.Validation.Success
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.{Files, Path, Paths}
 import scala.jdk.CollectionConverters._
 
-class FlixSuite(incremental: Boolean) extends FunSuite {
+class FlixSuite(incremental: Boolean) extends AnyFunSuite {
 
   /**
     * A global Flix instance that is used if incremental compilation is enabled.

--- a/main/test/ca/uwaterloo/flix/util/Ignore.scala
+++ b/main/test/ca/uwaterloo/flix/util/Ignore.scala
@@ -15,9 +15,9 @@
  */
 package ca.uwaterloo.flix.util
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class Ignore(name: String, paths: String*)(implicit options: Options = Options.TestWithLibMin) extends FunSuite {
+class Ignore(name: String, paths: String*)(implicit options: Options = Options.TestWithLibMin) extends AnyFunSuite {
 
   /**
     * Returns the name of the test suite.

--- a/main/test/ca/uwaterloo/flix/util/TestGraph.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestGraph.scala
@@ -1,8 +1,8 @@
 package ca.uwaterloo.flix.util
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestGraph extends FunSuite {
+class TestGraph extends AnyFunSuite {
 
   test("topSort.Cycle.01") {
     val graph = Map(1 -> List(1))

--- a/main/test/ca/uwaterloo/flix/util/TestResult.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestResult.scala
@@ -17,9 +17,9 @@
 package ca.uwaterloo.flix.util
 
 import ca.uwaterloo.flix.util.Result._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TestResult extends FunSuite {
+class TestResult extends AnyFunSuite {
 
   test("get01") {
     assertResult(42)(Ok(42).get)

--- a/main/test/ca/uwaterloo/flix/util/TestValidation.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestValidation.scala
@@ -17,10 +17,10 @@
 package ca.uwaterloo.flix.util
 
 import ca.uwaterloo.flix.util.Validation._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 
-class TestValidation extends FunSuite {
+class TestValidation extends AnyFunSuite {
 
   test("map01") {
     val result = "foo".toSuccess[String, Exception].map {


### PR DESCRIPTION
Split from https://github.com/flix/flix/pull/5751

Scalatest upgrade required a a small rename/import change of

`import org.scalatest.FunSuite` to `import org.scalatest.funsuite.AnyFunSuite`

as per https://www.scalatest.org/release_notes/3.1.0