### PR TITLE
fix: Provide valid pattern match in `MatchCompleter`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/MatchCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/MatchCompleter.scala
@@ -60,13 +60,14 @@ object MatchCompleter extends Completer {
     }
     val (completion, _) = enm.cases.toList.sortBy(_._1.loc).foldLeft(("", 1))({
       case ((acc, z), (sym, cas)) =>
-        val name = sym.name
+        val enumName = enm.sym.name
+        val caseName = sym.name
         val (str, k) = cas.tpe.typeConstructor match {
-          case Some(TypeConstructor.Unit) => (s"$name => $${${z + 1}:???}", z + 1)
+          case Some(TypeConstructor.Unit) => (s"$enumName.$caseName => $${${z + 1}:???}", z + 1)
           case Some(TypeConstructor.Tuple(arity)) => (List.range(1, arity + 1)
             .map(elem => s"$${${elem + z}:_elem$elem}")
-            .mkString(s"$name(", ", ", s") => $${${arity + z + 1}:???}"), z + arity + 1)
-          case _ => (s"$name($${${z + 1}:_elem}) => $${${z + 2}:???}", z + 2)
+            .mkString(s"$enumName.$caseName(", ", ", s") => $${${arity + z + 1}:???}"), z + arity + 1)
+          case _ => (s"$enumName.$caseName($${${z + 1}:_elem}) => $${${z + 2}:???}", z + 2)
         }
         (acc + "    case " + str + "\n", k)
     })


### PR DESCRIPTION
Fixes an issue when using auto-completion to complete a `match ...`.

Old implementation:
```
enum Color2 {
   case Red, Blue, Green
}

def foo(c: Color2): Unit \ IO =
   match ??? {
      case Red => ???
      case Blue => ???
      case Green => ???
   }
```
New implementation:
```
enum Color2 {
   case Red, Blue, Green
}

def foo(c: Color2): Unit \ IO =
   match ??? {
      case Color2.Red => ???
      case Color2.Blue => ???
      case Color2.Green => ???
   }
```

This is when the user auto-complete `match Color2`.