### PR TITLE
feat: add source location to failed test output

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/Tester.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Tester.scala
@@ -128,6 +128,7 @@ object Tester {
               writer.println()
               for ((sym, output) <- failed; if output.nonEmpty) {
                 writer.println(s"  ${bgRed(" FAIL ")} $sym")
+                writer.println(s"         ${sym.loc.source.name}:${sym.loc.beginLine}")
                 for (line <- output) {
                   writer.println(s"    $line")
                 }


### PR DESCRIPTION
Add the source file name and line of a failing test to the output.
Now:
```
   FAIL  testContains01
    Assertion Error: Does Map contain 43?
      Expected: Map#{bar => 42, foo => 12} contains 43
      Actual:   Map#{bar => 42, foo => 12} does not contain 43
```
With PR:
```
   FAIL  testContains01
         /Users/roland/Documents/code/flix-assertions/test/TestMain.flix:182
    Assertion Error: Does Map contain 43?
      Expected: Map#{bar => 42, foo => 12} contains 43
      Actual:   Map#{bar => 42, foo => 12} does not contain 43
```

See https://github.com/flix/flix/issues/5872