### PR TITLE
feat: add more functions to Regex (issue #5882)

### DIFF
--- a/main/src/library/Regex.flix
+++ b/main/src/library/Regex.flix
@@ -503,33 +503,6 @@ mod Regex {
     }
 
     ///
-    /// Returns string `s` with every match of the Regex `from` replaced by the string `to`
-    /// within the bounds `(start, end)`.
-    ///
-    /// Returns the empty string if the bounds are invalid.
-    ///
-    pub def replaceWithBounds(from: {from = Regex}, to: {to = String}, start: {start = Int32}, end: {end = Int32}, s: String): String = region rc {
-        import java.util.regex.Matcher.replaceAll(String): String \ rc;
-        match newMatcherWithBounds(rc, from.from, start, end, s) {
-            case Ok(m)  => {let Matcher(m1) = m; replaceAll(m1, to.to)}
-            case Err(_) => ""
-        }
-    }
-    ///
-    /// Returns string `s` with the first match of the regular expression `from` replaced by the string `to`
-    /// within the bounds `(start, end)`.
-    ///
-    /// Returns the empty string if the bounds are invalid.
-    ///
-    pub def replaceFirstWithBounds(from: {from = Regex}, to: {to = String}, start: {start = Int32}, end: {end = Int32}, s: String): String = region rc {
-        import java.util.regex.Matcher.replaceFirst(String): String \ rc;
-        match newMatcherWithBounds(rc, from.from, start, end, s) {
-            case Ok(m)  => {let Matcher(m1) = m; replaceFirst(m1, to.to)}
-            case Err(_) => ""
-        }
-    }
-
-    ///
     /// Return the content of the first occurence of `substr` in `s` from the left within
     /// the bounds `(start, end)`.
     ///

--- a/main/src/library/Regex.flix
+++ b/main/src/library/Regex.flix
@@ -243,6 +243,28 @@ mod Regex {
     }
 
     ///
+    /// Returns `Some(prefix)` of string `s` if its prefix matches `substr`.
+    ///
+    pub def getPrefix(substr: {substr = Regex}, s: String): Option[String] = region rc {
+        let m = newMatcher(rc, substr.substr, s);
+        match firstSubmatch(matcherRange, m) {
+            case Err(_) => None
+            case Ok(r)  => if (r.start == 0) Some(String.takeLeft(r.end, s)) else None
+        }
+    }
+
+    ///
+    /// Returns `Some(suffix)` of string `s` if its suffix matches `substr`.
+    ///
+    pub def getSuffix(substr: {substr = Regex}, s: String): Option[String] = region rc {
+        let m = newMatcher(rc, substr.substr, s);
+        match lastSubmatch(matcherRange, m) {
+            case Err(_) => None
+            case Ok(r)  => if (r.end == String.length(s)) Some(String.dropLeft(r.start, s)) else None
+        }
+    }
+
+    ///
     /// Returns `Some(suffix)` of string `s` if its prefix matches `substr`.
     ///
     pub def stripPrefix(substr: {substr = Regex}, s: String): Option[String] = region rc {
@@ -285,6 +307,26 @@ mod Regex {
     }
 
     ///
+    /// Return the content of the first occurence of `substr` in `s` from the left.
+    ///
+    /// If the Regex `substr` is not present in `s` return None.
+    ///
+    pub def getFirst(substr: {substr = Regex}, s: String): Option[String] = region rc {
+        let m = newMatcher(rc, substr.substr, s);
+        firstSubmatch(matcherContent, m) |> Result.toOption
+    }
+
+    ///
+    /// Return the content of the last occurence of `substr` in `s` from the left.
+    ///
+    /// If the Regex `substr` is not present in `s` return None.
+    ///
+    pub def getLast(substr: {substr = Regex}, s: String): Option[String] = region rc {
+        let m = newMatcher(rc, substr.substr, s);
+        lastSubmatch(matcherContent, m) |> Result.toOption
+    }
+
+    ///
     /// This is `indexOfFirst` with a start offset.
     ///
     /// If the Regex `substr` is not present in `s` return None.
@@ -306,6 +348,32 @@ mod Regex {
         let m = newMatcher(rc, substr.substr, s);
         match setBounds!(start = offset.offset, end = String.length(s), m) {
             case Ok()   => lastSubmatch(matcherStart, m) |> Result.toOption
+            case Err(_) => None
+        }
+    }
+
+    ///
+    /// This is `getFirst` with a start offset.
+    ///
+    /// If the Regex `substr` is not present in `s` return None.
+    ///
+    pub def getFirstWithOffset(substr: {substr = Regex}, offset: {offset = Int32}, s: String): Option[String] = region rc {
+        let m = newMatcher(rc, substr.substr, s);
+        match setBounds!(start = offset.offset, end = String.length(s), m) {
+            case Ok()   => firstSubmatch(matcherContent, m) |> Result.toOption
+            case Err(_) => None
+        }
+    }
+
+    ///
+    /// This is `getLast` with a start offset.
+    ///
+    /// If the Regex `substr` is not present in `s` return None.
+    ///
+    pub def getLastWithOffset(substr: {substr = Regex}, offset: {offset = Int32}, s: String): Option[String] = region rc {
+        let m = newMatcher(rc, substr.substr, s);
+        match setBounds!(start = offset.offset, end = String.length(s), m) {
+            case Ok()   => lastSubmatch(matcherContent, m) |> Result.toOption
             case Err(_) => None
         }
     }

--- a/main/src/library/Regex.flix
+++ b/main/src/library/Regex.flix
@@ -156,7 +156,8 @@ mod Regex {
     ///
     /// Returns the positions of the all the occurrences of `substr` in `s`.
     ///
-    /// Returns `Nil` if `substr` is the empty string.
+    /// If `substr` regexp matches the empty string, positions where an empty match
+    /// has been recognized will be returned.
     ///
     pub def indices(substr: {substr = Regex}, s: String): List[Int32] = region rc {
         let m = newMatcher(rc, substr.substr, s);
@@ -179,7 +180,6 @@ mod Regex {
         }
     }
 
-    ///
     ///
     /// Count the occurrences of `substr` in string `s`.
     ///
@@ -426,6 +426,135 @@ mod Regex {
         }
     }
 
+    ///
+    /// Returns `true` if the entire string `s` is matched by the Regex `rgx`.
+    ///
+    /// Returns `false` if the entire string does not match or the bounds are invalid.
+    ///
+    pub def isMatchWithBounds(rgx: Regex, start: {start = Int32}, end: {end = Int32}, s: String): Bool = region rc {
+        import java.util.regex.Matcher.matches(): Bool \ rc;
+        match newMatcherWithBounds(rc, rgx, start, end, s) {
+            case Ok(m)  => {let Matcher(m1) = m; matches(m1)}
+            case Err(_) => false
+        }
+    }
+
+    ///
+    /// Returns `true` if the string `input` is matched by the Regex `rgx`
+    /// at any position within the string `s` that is within the bounds `(start, end)`.
+    ///
+    /// Returns `false` if there is no match or the bounds are invalid.
+    ///
+    pub def isSubmatchWithBounds(rgx: Regex, start: {start = Int32}, end: {end = Int32}, s: String): Bool = region rc {
+        match newMatcherWithBounds(rc, rgx, start, end, s) {
+            case Ok(m)  => find!(m)
+            case Err(_) => false
+        }
+    }
+
+    ///
+    /// Returns the positions of the all the occurrences of `substr` in `s`
+    /// within the bounds `(start, end)`.
+    ///
+    /// If `substr` regexp matches the empty string, positions where an empty match
+    /// has been recognized will be returned.
+    ///
+    /// Returns `Nil` if there are no matches or the bounds are invalid.
+    ///
+    pub def indicesWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): List[Int32] = region rc {
+        match newMatcherWithBounds(rc, substr.substr, start, end, s) {
+            case Ok(m)  => match foldSubmatches(Chain.snoc, Chain.empty(), matcherStart, m) {
+               case Ok(c)  => Chain.toList(c)
+               case Err(_) => Nil
+            }
+            case Err(_) => Nil
+        }
+    }
+
+    ///
+    /// Returns the contents of the all the occurrences of `substr` in `s`
+    /// within the bounds `(start, end)`.
+    ///
+    /// Returns `Nil` if `substr` is the empty string or the bounds are invalid.
+    ///
+    pub def submatchesWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): List[String] = region rc {
+        match newMatcherWithBounds(rc, substr.substr, start, end, s) {
+            case Ok(m)   => match foldSubmatches(Chain.snoc, Chain.empty(), matcherContent, m) {
+                case Ok(c)  => Chain.toList(c)
+                case Err(_) => Nil
+            }
+            case Err(_) => Nil
+        }
+    }
+
+    ///
+    /// Count the occurrences of `substr` in string `s` within the bounds `(start, end)`.
+    ///
+    /// Returns 0 if the bounds are invalid.
+    ///
+    pub def countSubmatchesWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): Int32 = region rc {
+        match newMatcherWithBounds(rc, substr.substr, start, end, s) {
+            case Ok(m)  => match foldSubmatches((acc, _) -> acc + 1, 0, matcherStart, m) {
+                case Ok(n)  => n
+                case Err(_) => 0
+            }
+            case Err(_) => 0
+        }
+    }
+
+    ///
+    /// Returns string `s` with every match of the Regex `from` replaced by the string `to`
+    /// within the bounds `(start, end)`.
+    ///
+    /// Returns the empty string if the bounds are invalid.
+    ///
+    pub def replaceWithBounds(from: {from = Regex}, to: {to = String}, start: {start = Int32}, end: {end = Int32}, s: String): String = region rc {
+        import java.util.regex.Matcher.replaceAll(String): String \ rc;
+        match newMatcherWithBounds(rc, from.from, start, end, s) {
+            case Ok(m)  => {let Matcher(m1) = m; replaceAll(m1, to.to)}
+            case Err(_) => ""
+        }
+    }
+    ///
+    /// Returns string `s` with the first match of the regular expression `from` replaced by the string `to`
+    /// within the bounds `(start, end)`.
+    ///
+    /// Returns the empty string if the bounds are invalid.
+    ///
+    pub def replaceFirstWithBounds(from: {from = Regex}, to: {to = String}, start: {start = Int32}, end: {end = Int32}, s: String): String = region rc {
+        import java.util.regex.Matcher.replaceFirst(String): String \ rc;
+        match newMatcherWithBounds(rc, from.from, start, end, s) {
+            case Ok(m)  => {let Matcher(m1) = m; replaceFirst(m1, to.to)}
+            case Err(_) => ""
+        }
+    }
+
+    ///
+    /// Return the content of the first occurence of `substr` in `s` from the left within
+    /// the bounds `(start, end)`.
+    ///
+    /// If the Regex `substr` is not present in `s` or the bounds are invalid return `None`.
+    ///
+    pub def getFirstWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): Option[String] = region rc {
+        match newMatcherWithBounds(rc, substr.substr, start, end, s) {
+            case Ok(m)  => firstSubmatch(matcherContent, m) |> Result.toOption
+            case Err(_) => None
+        }
+    }
+
+    ///
+    /// Return the content of the last occurence of `substr` in `s` from the left within
+    /// the bounds `(start, end)`.
+    ///
+    /// If the Regex `substr` is not present in `s` or the bounds are invalid return `None`.
+    ///
+    pub def getLastWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): Option[String] = region rc {
+        match newMatcherWithBounds(rc, substr.substr, start, end, s) {
+            case Ok(m)  => lastSubmatch(matcherContent, m) |> Result.toOption
+            case Err(_) => None
+        }
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     // Internal support for matching using ####java.util.regex.Matcher       //
     ///////////////////////////////////////////////////////////////////////////
@@ -444,6 +573,18 @@ mod Regex {
     def newMatcher(_: Region[r], rgx: Regex, s: String): Matcher[r] \ Write(r) =
         import java.util.regex.Pattern.matcher(##java.lang.CharSequence): ##java.util.regex.Matcher \ r;
         Matcher(matcher(rgx, checked_cast(s)))
+
+    ///
+    /// Create a Matcher for Regex `rgx` on the source String `input` with bounds `start` and `end`.
+    ///
+    /// Returns `Ok(matcher)` if the bounds are valid for the input String `s` otherwise returns `Err(_)`.
+    ///
+    def newMatcherWithBounds(rc: Region[r], rgx: Regex, start: {start = Int32}, end: {end = Int32}, s: String): Result[String, Matcher[r]] \ Write(r) =
+        let m = newMatcher(rc, rgx, s);
+        match setBounds!(start, end, m) {
+            case Ok()     => Ok(m)
+            case Err(msg) => Err(msg)
+        }
 
     ///
     /// Attempt to find the next match. Returns `true` and moves to the next match

--- a/main/test/ca/uwaterloo/flix/library/TestRegex.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestRegex.flix
@@ -1267,62 +1267,6 @@ mod TestRegex {
         Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 4, "::::") == 0
 
     /////////////////////////////////////////////////////////////////////////////
-    // replaceWithBounds                                                       //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @test
-    def replaceWithBounds01(): Bool =
-        Regex.replaceWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 1, "") == ""
-
-    @test
-    def replaceWithBounds02(): Bool =
-        Regex.replaceWithBounds(from = regex"\\p{Blank}+", to = "_", start = -1, end = 10, "A B C") == "A B C"
-
-    @test
-    def replaceWithBounds03(): Bool =
-        Regex.replaceWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 8, "A  B   C") == "A_B_C"
-
-    @test
-    def replaceWithBounds04(): Bool =
-        Regex.replaceWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 3, "ABC") == "ABC"
-
-    @test
-    def replaceWithBounds05(): Bool =
-        Regex.replaceWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 4, "A B  C") == "A_B_ C"
-
-    @test
-    def replaceWithBounds06(): Bool =
-        Regex.replaceWithBounds(from = regex"\\p{Blank}+", to = "_", start = 1, end = 5, " A B  C  ") == " A_B_ C  "
-
-    /////////////////////////////////////////////////////////////////////////////
-    // replaceFirstWithBounds                                                  //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @test
-    def replaceFirstWithBounds01(): Bool =
-        Regex.replaceFirstWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 1, "") == ""
-
-    @test
-    def replaceFirstWithBounds02(): Bool =
-        Regex.replaceFirstWithBounds(from = regex"\\p{Blank}+", to = "_", start = -1, end = 10, "A B C") == ""
-
-    @test
-    def replaceFirstWithBounds03(): Bool =
-        Regex.replaceFirstWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 8, "A  B   C") == "A_B   C"
-
-    @test
-    def replaceFirstWithBounds04(): Bool =
-        Regex.replaceFirstWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 3, "ABC")  == "ABC"
-
-    @test
-    def replaceFirstWithBounds05(): Bool =
-        Regex.replaceFirstWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 4, "A B  C") == "A_B  C"
-
-    @test
-    def replaceFirstWithBounds06(): Bool =
-        Regex.replaceFirstWithBounds(from = regex"\\p{Blank}+", to = "_", start = 2, end = 6, "A B  C") == "A B_C"
-/*
-    /////////////////////////////////////////////////////////////////////////////
     // getFirstWithBounds                                                      //
     /////////////////////////////////////////////////////////////////////////////
 
@@ -1340,27 +1284,27 @@ mod TestRegex {
 
     @test
     def getFirstWithBounds04(): Bool =
-        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 4, "a::b::c") == Some("a")
+        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c") == Some("a")
 
     @test
     def getFirstWithBounds05(): Bool =
-        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "ab") == Some("ab")
+        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 2, "a::b::c") == Some("a")
 
     @test
     def getFirstWithBounds06(): Bool =
-        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "_b") == Some("b")
+        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 3, end = 7, "a::b::c") == Some("b")
 
     @test
     def getFirstWithBounds07(): Bool =
-        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "a_") == Some("a")
+        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 6, end = 7, "a::b::c") == Some("c")
 
     @test
     def getFirstWithBounds08(): Bool =
-        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "ab_") == Some("ab")
+        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 1, end = 6, "a::b::c") == Some("b")
 
     @test
     def getFirstWithBounds09(): Bool =
-        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "_bc") == Some("bc")
+        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 7, end = 9, "a::b::c::") == None
 
     /////////////////////////////////////////////////////////////////////////////
     // getLastWithBounds                                                       //
@@ -1368,41 +1312,38 @@ mod TestRegex {
 
     @test
     def getLastWithBounds01(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "") == None
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "") == None
 
     @test
     def getLastWithBounds02(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "_") == None
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = -1, end = 5, "a::b") == None
 
     @test
     def getLastWithBounds03(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "a") == Some("a")
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "a") == Some("a")
 
     @test
     def getLastWithBounds04(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "__") == None
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c") == Some("c")
 
     @test
     def getLastWithBounds05(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "a_") == Some("a")
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 5, end = 7, "a::b::c") == Some("c")
 
     @test
     def getLastWithBounds06(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "_b") == Some("b")
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 6, "a::b::c") == Some("b")
 
     @test
     def getLastWithBounds07(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "aa") == Some("aa")
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 3, "a::b::c") == Some("a")
 
     @test
     def getLastWithBounds08(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}{2}", start = 2, end = 6, "ab") == Some("ab")
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 1, end = 6, "a::b::c") == Some("b")
 
     @test
     def getLastWithBounds09(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}{2}", start = 2, end = 6, "abcd") == Some("cd")
-
-
-*/
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 2, "::a::b::c") == None
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestRegex.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestRegex.flix
@@ -441,6 +441,61 @@ mod TestRegex {
         Regex.endsWith(suffix = regex"\\p{Alpha}+", "AA BBB CCCC") == true
 
     /////////////////////////////////////////////////////////////////////////////
+    // getPrefix                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def getPrefix01(): Bool =
+        Regex.getPrefix(substr = Regex.unmatchable(), "") == None
+
+    @test
+    def getPrefix02(): Bool =
+        Regex.getPrefix(substr = Regex.unmatchable(), "A B C") == None
+
+    @test
+    def getPrefix03(): Bool =
+        Regex.getPrefix(substr = regex"\\p{Alpha}+", "") == None
+
+    @test
+    def getPrefix04(): Bool =
+        Regex.getPrefix(substr = regex"\\p{Alpha}+", "   A B C") == None
+
+    @test
+    def getPrefix05(): Bool =
+        Regex.getPrefix(substr = regex"\\p{Alpha}+", "A B C") == Some("A")
+
+    @test
+    def getPrefix06(): Bool =
+        Regex.getPrefix(substr = regex"\\p{Alpha}+", "AA BBB CCCC") == Some("AA")
+
+    /////////////////////////////////////////////////////////////////////////////
+    // getSuffix                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def getSuffix01(): Bool =
+        Regex.getSuffix(substr = Regex.unmatchable(), "") == None
+
+    @test
+    def getSuffix02(): Bool =
+        Regex.getSuffix(substr = Regex.unmatchable(), "A B C") == None
+
+    @test
+    def getSuffix03(): Bool =
+        Regex.getSuffix(substr = regex"\\p{Alpha}+", "") == None
+
+    @test
+    def getSuffix04(): Bool =
+        Regex.getSuffix(substr = regex"\\p{Alpha}+", "A B C  ") == None
+
+    @test
+    def getSuffix05(): Bool =
+        Regex.getSuffix(substr = regex"\\p{Alpha}+", "A B C") == Some("C")
+    @test
+    def getSuffix06(): Bool =
+        Regex.getSuffix(substr = regex"\\p{Alpha}+", "AA BBB CCCC") == Some("CCCC")
+
+    /////////////////////////////////////////////////////////////////////////////
     // stripPrefix                                                             //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestRegex.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestRegex.flix
@@ -198,7 +198,6 @@ mod TestRegex {
     def indices13(): Bool =
         Regex.indices(substr = regex":{2}", "::::") == List#{0, 2}
 
-
     /////////////////////////////////////////////////////////////////////////////
     // submatches                                                              //
     /////////////////////////////////////////////////////////////////////////////
@@ -254,7 +253,6 @@ mod TestRegex {
     @test
     def submatches13(): Bool =
         Regex.submatches(substr = regex"\\p{Alpha}+", "::::") == List#{}
-
 
     /////////////////////////////////////////////////////////////////////////////
     // countSubmatches                                                         //
@@ -491,6 +489,7 @@ mod TestRegex {
     @test
     def getSuffix05(): Bool =
         Regex.getSuffix(substr = regex"\\p{Alpha}+", "A B C") == Some("C")
+
     @test
     def getSuffix06(): Bool =
         Regex.getSuffix(substr = regex"\\p{Alpha}+", "AA BBB CCCC") == Some("CCCC")
@@ -546,6 +545,7 @@ mod TestRegex {
     @test
     def stripSuffix05(): Bool =
         Regex.stripSuffix(substr = regex"\\p{Alpha}+", "A B C") == Some("A B ")
+
     @test
     def stripSuffix06(): Bool =
         Regex.stripSuffix(substr = regex"\\p{Alpha}+", "AA BBB CCCC") == Some("AA BBB ")
@@ -631,7 +631,87 @@ mod TestRegex {
         Regex.indexOfLast(substr = regex"\\p{Alpha}{2}", "abcd") == Some(2)
 
     /////////////////////////////////////////////////////////////////////////////
-    // indexOfFirstWithOffset                                                   //
+    // getFirst                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def getFirst01(): Bool =
+        Regex.getFirst(substr = regex"\\p{Alpha}+", "") == None
+
+    @test
+    def getFirst02(): Bool =
+        Regex.getFirst(substr = regex"\\p{Alpha}+", "_") == None
+
+    @test
+    def getFirst03(): Bool =
+        Regex.getFirst(substr = regex"\\p{Alpha}+", "a") == Some("a")
+
+    @test
+    def getFirst04(): Bool =
+        Regex.getFirst(substr = regex"\\p{Alpha}+", "__") == None
+
+    @test
+    def getFirst05(): Bool =
+        Regex.getFirst(substr = regex"\\p{Alpha}+", "ab") == Some("ab")
+
+    @test
+    def getFirst06(): Bool =
+        Regex.getFirst(substr = regex"\\p{Alpha}+", "_b") == Some("b")
+
+    @test
+    def getFirst07(): Bool =
+        Regex.getFirst(substr = regex"\\p{Alpha}+", "a_") == Some("a")
+
+    @test
+    def getFirst08(): Bool =
+        Regex.getFirst(substr = regex"\\p{Alpha}+", "ab_") == Some("ab")
+
+    @test
+    def getFirst09(): Bool =
+        Regex.getFirst(substr = regex"\\p{Alpha}+", "_bc") == Some("bc")
+
+    /////////////////////////////////////////////////////////////////////////////
+    // getLast                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def getLast01(): Bool =
+        Regex.getLast(substr = regex"\\p{Alpha}+", "") == None
+
+    @test
+    def getLast02(): Bool =
+        Regex.getLast(substr = regex"\\p{Alpha}+", "_") == None
+
+    @test
+    def getLast03(): Bool =
+        Regex.getLast(substr = regex"\\p{Alpha}+", "a") == Some("a")
+
+    @test
+    def getLast04(): Bool =
+        Regex.getLast(substr = regex"\\p{Alpha}+", "__") == None
+
+    @test
+    def getLast05(): Bool =
+        Regex.getLast(substr = regex"\\p{Alpha}+", "a_") == Some("a")
+
+    @test
+    def getLast06(): Bool =
+        Regex.getLast(substr = regex"\\p{Alpha}+", "_b") == Some("b")
+
+    @test
+    def getLast07(): Bool =
+        Regex.getLast(substr = regex"\\p{Alpha}+", "aa") == Some("aa")
+
+    @test
+    def getLast08(): Bool =
+        Regex.getLast(substr = regex"\\p{Alpha}{2}", "ab") == Some("ab")
+
+    @test
+    def getLast09(): Bool =
+        Regex.getLast(substr = regex"\\p{Alpha}{2}", "abcd") == Some("cd")
+
+    /////////////////////////////////////////////////////////////////////////////
+    // indexOfFirstWithOffset                                                  //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
@@ -733,6 +813,110 @@ mod TestRegex {
     @test
     def indexOfLastWithOffset13(): Bool =
         Regex.indexOfLastWithOffset(substr = regex"\\p{Alpha}+", offset = 2, "ab __") == None
+
+    /////////////////////////////////////////////////////////////////////////////
+    // getFirstWithOffset                                                      //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def getFirstWithOffset01(): Bool =
+        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "") == None
+
+    @test
+    def getFirstWithOffset02(): Bool =
+        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "_") == None
+
+    @test
+    def getFirstWithOffset03(): Bool =
+        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "a") == Some("a")
+
+    @test
+    def getFirstWithOffset04(): Bool =
+        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "a") == None
+
+    @test
+    def getFirstWithOffset05(): Bool =
+        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "ab") == Some("ab")
+
+    @test
+    def getFirstWithOffset06(): Bool =
+        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "aa") == Some("a")
+
+    @test
+    def getFirstWithOffset07(): Bool =
+        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "_b") == Some("b")
+
+    @test
+    def getFirstWithOffset08(): Bool =
+        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "ab cd") == Some("ab")
+
+    @test
+    def getFirstWithOffset09(): Bool =
+        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "ab cd") == Some("b")
+
+    @test
+    def getFirstWithOffset10(): Bool =
+        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 2, "ab cd") == Some("cd")
+
+    @test
+    def getFirstWithOffset11(): Bool =
+        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 3, "ab cd") == Some("cd")
+
+    /////////////////////////////////////////////////////////////////////////////
+    // getLastWithOffset                                                       //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def getLastWithOffset01(): Bool =
+        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "") == None
+
+    @test
+    def getLastWithOffset02(): Bool =
+        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "_") == None
+
+    @test
+    def getLastWithOffset03(): Bool =
+        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "a") == Some("a")
+
+    @test
+    def getLastWithOffset04(): Bool =
+        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "a") == None
+
+    @test
+    def getLastWithOffset05(): Bool =
+        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "ab") == Some("b")
+
+    @test
+    def getLastWithOffset06(): Bool =
+        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 2, "aa") == None
+
+    @test
+    def getLastWithOffset07(): Bool =
+        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 3, "ab") == None
+
+    @test
+    def getLastWithOffset08(): Bool =
+        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 3, "ab cd") == Some("cd")
+
+    @test
+    def getLastWithOffset09(): Bool =
+        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset= 2, "ab cd") == Some("cd")
+
+    @test
+    def getLastWithOffset10(): Bool =
+        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "ab cd") == Some("cd")
+
+    @test
+    def getLastWithOffset11(): Bool =
+        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "ab cd") == Some("cd")
+
+    @test
+    def getLastWithOffset12(): Bool =
+        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = -1, "ab cd") == None
+
+    @test
+    def getLastWithOffset13(): Bool =
+        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 2, "ab __") == None
 
     /////////////////////////////////////////////////////////////////////////////
     // breakOnFirst                                                            //
@@ -877,5 +1061,348 @@ mod TestRegex {
     @test
     def breakBeforeLast08(): Bool =
         Regex.breakBeforeLast(substr = regex":{2}", "aaa::bbb::ccc") == ("aaa::bbb", "::ccc")
+
+    /////////////////////////////////////////////////////////////////////////////
+    // isMatchWithBounds                                                       //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def isMatchWithBounds01(): Bool =
+        Regex.isMatchWithBounds(regex"a+", start = 0, end = 1, "") == false
+
+    @test
+    def isMatchWithBounds02(): Bool =
+        Regex.isMatchWithBounds(regex"a+", start = 0, end = 1, "a") == true
+
+    @test
+    def isMatchWithBounds03(): Bool =
+        Regex.isMatchWithBounds(regex"a+", start = 0, end = 3, "a") == false
+
+    @test
+    def isMatchWithBounds04(): Bool =
+        Regex.isMatchWithBounds(regex"a+", start = 0, end = 1, "aa") == true
+
+    @test
+    def isMatchWithBounds05(): Bool =
+        Regex.isMatchWithBounds(regex"a+", start = 2, end = 3, "aab") == false
+
+    @test
+    def isMatchWithBounds06(): Bool =
+        Regex.isMatchWithBounds(regex"b+", start = 2, end = 3, "aab") == true
+
+    /////////////////////////////////////////////////////////////////////////////
+    // isSubmatchWithBounds                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def isSubmatchWithBounds01(): Bool =
+        Regex.isSubmatchWithBounds(regex"a+", start = 0, end = 1, "") == false
+
+    @test
+    def isSubmatchWithBounds02(): Bool =
+        Regex.isSubmatchWithBounds(regex"a+", start = 0, end = 1, "a") == true
+
+    @test
+    def isSubmatchWithBounds03(): Bool =
+        Regex.isSubmatchWithBounds(regex"a+", start = 1, end = 2, "aa") == true
+
+    @test
+    def isSubmatchWithBounds04(): Bool =
+        Regex.isSubmatchWithBounds(regex"a+", start = -1, end = 1, "aab") == false
+
+    @test
+    def isSubmatchWithBounds05(): Bool =
+        Regex.isSubmatchWithBounds(regex"a+", start = 0, end = 2, "aab") == true
+
+    @test
+    def isSubmatchWithBounds06(): Bool =
+        Regex.isSubmatchWithBounds(regex"b+", start = 2, end = 3, "aab") == true
+
+    @test
+    def isSubmatchWithBounds07(): Bool =
+        Regex.isSubmatchWithBounds(regex"b+", start = 1, end = 2, "bbbc") == true
+
+    @test
+    def isSubmatchWithBounds08(): Bool =
+        Regex.isSubmatchWithBounds(regex"b+", start = 0, end = 5, "aabbbc") == true
+
+    /////////////////////////////////////////////////////////////////////////////
+    // indicesWithBounds                                                       //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def indicesWithBounds01(): Bool =
+        Regex.indicesWithBounds(substr = regex":{2}", start = 0, end = 1, "") == List#{}
+
+    @test
+    def indicesWithBounds02(): Bool =
+        Regex.indicesWithBounds(substr = regex":{2}", start = -1, end = 10, "a::b::c") == List#{}
+
+    @test
+    def indicesWithBounds03(): Bool =
+        Regex.indicesWithBounds(substr = regex":{2}", start = 0, end = 7, "a::b::c") == List#{1, 4}
+
+    @test
+    def indicesWithBounds04(): Bool =
+        Regex.indicesWithBounds(substr = regex":{2}", start = 0, end = 3, "a::b::c") == List#{1}
+
+    @test
+    def indicesWithBounds05(): Bool =
+        Regex.indicesWithBounds(substr = regex":{2}", start = 3, end = 7, "a::b::c") == List#{4}
+
+    @test
+    def indicesWithBounds06(): Bool =
+        Regex.indicesWithBounds(substr = regex":{2}", start = 0, end = 3, "a:b") == List#{}
+
+    /////////////////////////////////////////////////////////////////////////////
+    // submatchesWithBounds                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def submatchesWithBounds01(): Bool =
+        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "") == List#{}
+
+    @test
+    def submatchesWithBounds02(): Bool =
+        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = -1, end = 10, "a::b::c") == List#{}
+
+    @test
+    def submatchesWithBounds03(): Bool =
+        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 3, "aaa") == List#{"aaa"}
+
+    @test
+    def submatchesWithBounds04(): Bool =
+        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 10, "aaa") == List#{}
+
+    @test
+    def submatchesWithBounds05(): Bool =
+        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 2, "::") == List#{}
+
+    @test
+    def submatchesWithBounds06(): Bool =
+        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 2, "ab") == List#{"ab"}
+
+    @test
+    def submatchesWithBounds07(): Bool =
+        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 3, "::a") == List#{"a"}
+
+    @test
+    def submatchesWithBounds08(): Bool =
+        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 3, "a::") == List#{"a"}
+
+    @test
+    def submatchesWithBounds09(): Bool =
+        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 3, "a::b::") == List#{"a"}
+
+    @test
+    def submatchesWithBounds10(): Bool =
+        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 7, "a::b::c") == List#{"b", "c"}
+
+    @test
+    def submatchesWithBounds11(): Bool =
+        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c:") == List#{"a", "b", "c"}
+
+    @test
+    def submatchesWithBounds12(): Bool =
+        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 6, ":a::b::c") == List#{"a", "b"}
+
+    @test
+    def submatchesWithBounds13(): Bool =
+        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 4, "::::") == List#{}
+
+    /////////////////////////////////////////////////////////////////////////////
+    // countSubmatchesWithBounds                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def countSubmatchesWithBounds01(): Bool =
+        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "") == 0
+
+    @test
+    def countSubmatchesWithBounds02(): Bool =
+        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = -1, end = 10, "a::b::c") == 0
+
+    @test
+    def countSubmatchesWithBounds03(): Bool =
+        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c") == 3
+
+    @test
+    def countSubmatchesWithBounds04(): Bool =
+        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 4, "a::b::c") == 2
+
+    @test
+    def countSubmatchesWithBounds05(): Bool =
+        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 1, end = 7, "a::b::c") == 2
+
+    @test
+    def countSubmatchesWithBounds06(): Bool =
+        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 2, "ab") == 1
+
+    @test
+    def countSubmatchesWithBounds07(): Bool =
+        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 1, end = 3, "::a") == 1
+
+    @test
+    def countSubmatchesWithBounds08(): Bool =
+        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 2, "a::") == 1
+
+    @test
+    def countSubmatchesWithBounds09(): Bool =
+        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 4, "a::b::") == 2
+
+    @test
+    def countSubmatchesWithBounds10(): Bool =
+        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 4, "a::b::c") == 2
+
+    @test
+    def countSubmatchesWithBounds11(): Bool =
+        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 4, end = 8, "a::b::c:") == 1
+
+    @test
+    def countSubmatchesWithBounds12(): Bool =
+        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 4, ":a::b::c") == 1
+
+    @test
+    def countSubmatchesWithBounds13(): Bool =
+        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 4, "::::") == 0
+
+    /////////////////////////////////////////////////////////////////////////////
+    // replaceWithBounds                                                       //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def replaceWithBounds01(): Bool =
+        Regex.replaceWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 1, "") == ""
+
+    @test
+    def replaceWithBounds02(): Bool =
+        Regex.replaceWithBounds(from = regex"\\p{Blank}+", to = "_", start = -1, end = 10, "A B C") == "A B C"
+
+    @test
+    def replaceWithBounds03(): Bool =
+        Regex.replaceWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 8, "A  B   C") == "A_B_C"
+
+    @test
+    def replaceWithBounds04(): Bool =
+        Regex.replaceWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 3, "ABC") == "ABC"
+
+    @test
+    def replaceWithBounds05(): Bool =
+        Regex.replaceWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 4, "A B  C") == "A_B_ C"
+
+    @test
+    def replaceWithBounds06(): Bool =
+        Regex.replaceWithBounds(from = regex"\\p{Blank}+", to = "_", start = 1, end = 5, " A B  C  ") == " A_B_ C  "
+
+    /////////////////////////////////////////////////////////////////////////////
+    // replaceFirstWithBounds                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def replaceFirstWithBounds01(): Bool =
+        Regex.replaceFirstWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 1, "") == ""
+
+    @test
+    def replaceFirstWithBounds02(): Bool =
+        Regex.replaceFirstWithBounds(from = regex"\\p{Blank}+", to = "_", start = -1, end = 10, "A B C") == ""
+
+    @test
+    def replaceFirstWithBounds03(): Bool =
+        Regex.replaceFirstWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 8, "A  B   C") == "A_B   C"
+
+    @test
+    def replaceFirstWithBounds04(): Bool =
+        Regex.replaceFirstWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 3, "ABC")  == "ABC"
+
+    @test
+    def replaceFirstWithBounds05(): Bool =
+        Regex.replaceFirstWithBounds(from = regex"\\p{Blank}+", to = "_", start = 0, end = 4, "A B  C") == "A_B  C"
+
+    @test
+    def replaceFirstWithBounds06(): Bool =
+        Regex.replaceFirstWithBounds(from = regex"\\p{Blank}+", to = "_", start = 2, end = 6, "A B  C") == "A B_C"
+/*
+    /////////////////////////////////////////////////////////////////////////////
+    // getFirstWithBounds                                                      //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def getFirstWithBounds01(): Bool =
+        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "") == None
+
+    @test
+    def getFirstWithBounds02(): Bool =
+        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = -1, end = 5, "a::b") == None
+
+    @test
+    def getFirstWithBounds03(): Bool =
+        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "a") == Some("a")
+
+    @test
+    def getFirstWithBounds04(): Bool =
+        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 4, "a::b::c") == Some("a")
+
+    @test
+    def getFirstWithBounds05(): Bool =
+        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "ab") == Some("ab")
+
+    @test
+    def getFirstWithBounds06(): Bool =
+        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "_b") == Some("b")
+
+    @test
+    def getFirstWithBounds07(): Bool =
+        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "a_") == Some("a")
+
+    @test
+    def getFirstWithBounds08(): Bool =
+        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "ab_") == Some("ab")
+
+    @test
+    def getFirstWithBounds09(): Bool =
+        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "_bc") == Some("bc")
+
+    /////////////////////////////////////////////////////////////////////////////
+    // getLastWithBounds                                                       //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def getLastWithBounds01(): Bool =
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "") == None
+
+    @test
+    def getLastWithBounds02(): Bool =
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "_") == None
+
+    @test
+    def getLastWithBounds03(): Bool =
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "a") == Some("a")
+
+    @test
+    def getLastWithBounds04(): Bool =
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "__") == None
+
+    @test
+    def getLastWithBounds05(): Bool =
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "a_") == Some("a")
+
+    @test
+    def getLastWithBounds06(): Bool =
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "_b") == Some("b")
+
+    @test
+    def getLastWithBounds07(): Bool =
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 6, "aa") == Some("aa")
+
+    @test
+    def getLastWithBounds08(): Bool =
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}{2}", start = 2, end = 6, "ab") == Some("ab")
+
+    @test
+    def getLastWithBounds09(): Bool =
+        Regex.getLastWithBounds(substr = regex"\\p{Alpha}{2}", start = 2, end = 6, "abcd") == Some("cd")
+
+
+*/
 
 }


### PR DESCRIPTION
This PR addresses issue #5882 and adds more functions to Regex particularly to extract matched strings rather than indices of the match and to match within a range of the input string.

Functions added to extra matched text:

~~~

pub def getPrefix(substr: {substr = Regex}, s: String): Option[String]
pub def getSuffix(substr: {substr = Regex}, s: String): Option[String]
pub def getFirst(substr: {substr = Regex}, s: String): Option[String]
pub def getLast(substr: {substr = Regex}, s: String): Option[String]
pub def getFirstWithOffset(substr: {substr = Regex}, offset: {offset = Int32}, s: String): Option[String]
pub def getLastWithOffset(substr: {substr = Regex}, offset: {offset = Int32}, s: String): Option[String]

~~~

`getPrefix` is the content version of `startsWith`
`getSufffix` is the content version of `endsWith`
`getFirst` is the content version of `indexOfFirst`
`getLast` is the content version of `indexOfLast`

Functions added to match within a start and end bounds:

~~~

pub def isMatchWithBounds(rgx: Regex, start: {start = Int32}, end: {end = Int32}, s: String): Bool
pub def isSubmatchWithBounds(rgx: Regex, start: {start = Int32}, end: {end = Int32}, s: String): Bool
pub def indicesWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): List[Int32]
pub def submatchesWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): List[String]
pub def countSubmatchesWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): Int32
pub def getFirstWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): Option[String]
pub def getLastWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): Option[String]

~~~

I tried to add bounded versions of `replaceFirst` and `replace` (all) but the underlying functions in `java.util.regex.Matcher` do not respect bounds set with `Matcher.region()`.
