### PR TITLE
chore: unify effect set syntax

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -66,7 +66,7 @@ object NamedAst {
     case class RestrictableCase(sym: Symbol.RestrictableCaseSym, tpe: NamedAst.Type, loc: SourceLocation) extends NamedAst.Declaration
   }
 
-  case class Spec(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, tparams: NamedAst.TypeParams, fparams: List[NamedAst.FormalParam], retTpe: NamedAst.Type, purAndEff: PurityAndEffect, tconstrs: List[NamedAst.TypeConstraint], econstrs: List[NamedAst.EqualityConstraint], loc: SourceLocation)
+  case class Spec(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, tparams: NamedAst.TypeParams, fparams: List[NamedAst.FormalParam], retTpe: NamedAst.Type, pur: Option[NamedAst.Type], tconstrs: List[NamedAst.TypeConstraint], econstrs: List[NamedAst.EqualityConstraint], loc: SourceLocation)
 
 
   sealed trait UseOrImport {
@@ -167,13 +167,13 @@ object NamedAst {
 
     case class Assign(exp1: NamedAst.Expression, exp2: NamedAst.Expression, loc: SourceLocation) extends NamedAst.Expression
 
-    case class Ascribe(exp: NamedAst.Expression, expectedType: Option[NamedAst.Type], expectedEff: NamedAst.PurityAndEffect, loc: SourceLocation) extends NamedAst.Expression
+    case class Ascribe(exp: NamedAst.Expression, expectedType: Option[NamedAst.Type], expectedEff: Option[NamedAst.Type], loc: SourceLocation) extends NamedAst.Expression
 
     case class InstanceOf(exp: NamedAst.Expression, className: String, loc: SourceLocation) extends NamedAst.Expression
 
     case class CheckedCast(cast: Ast.CheckedCastType, exp: NamedAst.Expression, loc: SourceLocation) extends NamedAst.Expression
 
-    case class UncheckedCast(exp: NamedAst.Expression, declaredType: Option[NamedAst.Type], declaredEff: NamedAst.PurityAndEffect, loc: SourceLocation) extends NamedAst.Expression
+    case class UncheckedCast(exp: NamedAst.Expression, declaredType: Option[NamedAst.Type], declaredEff: Option[NamedAst.Type], loc: SourceLocation) extends NamedAst.Expression
 
     case class UncheckedMaskingCast(exp: NamedAst.Expression, loc: SourceLocation) extends NamedAst.Expression
 
@@ -343,7 +343,7 @@ object NamedAst {
 
     case class Lattice(tpes: List[NamedAst.Type], loc: SourceLocation) extends NamedAst.Type
 
-    case class Arrow(tparams: List[NamedAst.Type], purAndEff: NamedAst.PurityAndEffect, tresult: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
+    case class Arrow(tparams: List[NamedAst.Type], pur: Option[NamedAst.Type], tresult: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
 
     case class Apply(tpe1: NamedAst.Type, tpe2: NamedAst.Type, loc: SourceLocation) extends NamedAst.Type
 
@@ -422,7 +422,7 @@ object NamedAst {
 
   }
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[NamedAst.FormalParam], exp: NamedAst.Expression, tpe: NamedAst.Type, purAndEff: PurityAndEffect, loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[NamedAst.FormalParam], exp: NamedAst.Expression, tpe: NamedAst.Type, pur: Option[NamedAst.Type], loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, className: String, exp: NamedAst.Expression)
 
@@ -459,8 +459,6 @@ object NamedAst {
   case class TypeConstraint(clazz: Name.QName, tpe: NamedAst.Type, loc: SourceLocation)
 
   case class EqualityConstraint(qname: Name.QName, tpe1: NamedAst.Type, tpe2: NamedAst.Type, loc: SourceLocation)
-
-  case class PurityAndEffect(pur: Option[Type], eff: Option[List[Type]])
 
   case class ParYieldFragment(pat: Pattern, exp: Expression, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1395,7 +1395,9 @@ object ParsedAst {
   /**
     * Types.
     */
-  sealed trait Type
+  sealed trait Type {
+    def sp2: SourcePosition
+  }
 
   object Type {
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1562,6 +1562,24 @@ object ParsedAst {
     case class Complement(sp1: SourcePosition, tpe: ParsedAst.Type, sp2: SourcePosition) extends ParsedAst.Type
 
     /**
+      * A type representing a read of a region.
+      *
+      * @param sp1 the position of the first character in the type.
+      * @param tpes the regions.
+      * @param sp2 the position of the last character in the type.
+      */
+    case class Read(sp1: SourcePosition, tpes: Seq[ParsedAst.Type], sp2: SourcePosition) extends ParsedAst.Type
+
+    /**
+      * A type representing a read of a region.
+      *
+      * @param sp1 the position of the first character in the type.
+      * @param tpes the regions.
+      * @param sp2 the position of the last character in the type.
+      */
+    case class Write(sp1: SourcePosition, tpes: Seq[ParsedAst.Type], sp2: SourcePosition) extends ParsedAst.Type
+
+    /**
       * A type representing a case set.
       *
       * @param sp1   the position of the first character in the type.
@@ -1613,38 +1631,6 @@ object ParsedAst {
       * @param sp2  the position of the last character in the type.
       */
     case class Ascribe(tpe: ParsedAst.Type, kind: ParsedAst.Kind, sp2: SourcePosition) extends ParsedAst.Type
-
-  }
-
-  /**
-    * Represents a purity.
-    */
-  sealed trait Purity
-
-  object Purity {
-
-    /**
-      * Represents a purity variable.
-      *
-      * @param sp1   the position of the first character in the type.
-      * @param ident the variable name.
-      * @param sp2   the position of the last character in the type.
-      */
-    case class Var(sp1: SourcePosition, ident: Name.Ident, sp2: SourcePosition) extends ParsedAst.Purity
-
-    /**
-      * Represents a read of the region variables `idents`.
-      *
-      * @param idents the region variables that are read.
-      */
-    case class Read(idents: Seq[Name.Ident]) extends ParsedAst.Purity
-
-    /**
-      * Represents a write of the region variables `idents`.
-      *
-      * @param idents the region variables that are written.
-      */
-    case class Write(idents: Seq[Name.Ident]) extends ParsedAst.Purity
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -74,13 +74,13 @@ object ParsedAst {
       * @param tparams    the type parameters.
       * @param fparamsOpt the formal parameters.
       * @param tpe        the declared type.
-      * @param purAndEff  the declared purity.
+      * @param pur        the declared purity.
       * @param exp        the expression.
       * @param tconstrs   the type constraints.
       * @param econstrs   the equality constraints.
       * @param sp2        the position of the last character in the declaration.
       */
-    case class Def(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, purAndEff: ParsedAst.PurityAndEffect, tconstrs: Seq[ParsedAst.TypeConstraint], econstrs: Seq[ParsedAst.EqualityConstraint], exp: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Declaration
+    case class Def(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.Type], tconstrs: Seq[ParsedAst.TypeConstraint], econstrs: Seq[ParsedAst.EqualityConstraint], exp: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Declaration
 
     /**
       * Signature Declaration.
@@ -93,12 +93,12 @@ object ParsedAst {
       * @param tparams    the type parameters.
       * @param fparamsOpt the formal parameters.
       * @param tpe        the declared type.
-      * @param purAndEff  the declared purity.
+      * @param pur        the declared purity.
       * @param tconstrs   the type constraints.
       * @param exp        the optional expression.
       * @param sp2        the position of the last character in the declaration.
       */
-    case class Sig(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, purAndEff: ParsedAst.PurityAndEffect, tconstrs: Seq[ParsedAst.TypeConstraint], exp: Option[ParsedAst.Expression], sp2: SourcePosition) extends ParsedAst.Declaration.LawOrSig
+    case class Sig(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.Type], tconstrs: Seq[ParsedAst.TypeConstraint], exp: Option[ParsedAst.Expression], sp2: SourcePosition) extends ParsedAst.Declaration.LawOrSig
 
     /**
       * Law Declaration.
@@ -129,7 +129,7 @@ object ParsedAst {
       * @param tconstrs   the type constraints.
       * @param sp2        the position of the last character in the declaration.
       */
-    case class Op(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, purAndEff: ParsedAst.PurityAndEffect, tconstrs: Seq[ParsedAst.TypeConstraint], sp2: SourcePosition)
+    case class Op(doc: ParsedAst.Doc, ann: Seq[ParsedAst.Annotation], mod: Seq[ParsedAst.Modifier], sp1: SourcePosition, ident: Name.Ident, tparams: ParsedAst.TypeParams, fparamsOpt: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.Type], tconstrs: Seq[ParsedAst.TypeConstraint], sp2: SourcePosition)
 
     /**
       * Enum Declaration.
@@ -730,7 +730,7 @@ object ParsedAst {
       * @param exp2    the body expression.
       * @param sp2     the position of the last character in the expression.
       */
-    case class LetRecDef(sp1: SourcePosition, ident: Name.Ident, fparams: Seq[ParsedAst.FormalParam], typeAndEff: Option[(ParsedAst.Type, ParsedAst.PurityAndEffect)], exp1: ParsedAst.Expression, exp2: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Expression
+    case class LetRecDef(sp1: SourcePosition, ident: Name.Ident, fparams: Seq[ParsedAst.FormalParam], typeAndEff: Option[(ParsedAst.Type, Option[ParsedAst.Type])], exp1: ParsedAst.Expression, exp2: ParsedAst.Expression, sp2: SourcePosition) extends ParsedAst.Expression
 
     /**
       * Let Import Expression.
@@ -995,12 +995,12 @@ object ParsedAst {
     /**
       * Ascribe Expression.
       *
-      * @param exp       the expression.
-      * @param tpe       the optional type.
-      * @param purAndEff the optional purity and effect.
-      * @param sp2       the position of the last character in the expression.
+      * @param exp the expression.
+      * @param tpe the optional type.
+      * @param pur the optional purity.
+      * @param sp2 the position of the last character in the expression.
       */
-    case class Ascribe(exp: ParsedAst.Expression, tpe: Option[ParsedAst.Type], purAndEff: ParsedAst.PurityAndEffect, sp2: SourcePosition) extends ParsedAst.Expression
+    case class Ascribe(exp: ParsedAst.Expression, tpe: ParsedAst.Type, pur: Option[ParsedAst.Type], sp2: SourcePosition) extends ParsedAst.Expression
 
     /**
       * InstanceOf expression.
@@ -1032,13 +1032,13 @@ object ParsedAst {
     /**
       * Unchecked Cast Expression.
       *
-      * @param sp1       the position of the first character in the expression.
-      * @param exp       the expression.
-      * @param tpe       the optional type.
-      * @param purAndEff the optional purity and effect.
-      * @param sp2       the position of the last character in the expression.
+      * @param sp1 the position of the first character in the expression.
+      * @param exp the expression.
+      * @param tpe the optional type.
+      * @param pur the optional purity.
+      * @param sp2 the position of the last character in the expression.
       */
-    case class UncheckedCast(sp1: SourcePosition, exp: ParsedAst.Expression, tpe: Option[ParsedAst.Type], purAndEff: ParsedAst.PurityAndEffect, sp2: SourcePosition) extends ParsedAst.Expression
+    case class UncheckedCast(sp1: SourcePosition, exp: ParsedAst.Expression, tpe: ParsedAst.Type, pur: Option[ParsedAst.Type], sp2: SourcePosition) extends ParsedAst.Expression
 
     /**
       * Unchecked Masking Cast expression
@@ -1469,23 +1469,23 @@ object ParsedAst {
     /**
       * Unary Polymorphic Arrow Type.
       *
-      * @param tpe1      the argument type.
-      * @param tpe2      the result type.
-      * @param purAndEff the optional purity and effect.
-      * @param sp2       the position of the last character in the type.
+      * @param tpe1 the argument type.
+      * @param tpe2 the result type.
+      * @param pur  the optional purity.
+      * @param sp2  the position of the last character in the type.
       */
-    case class UnaryPolymorphicArrow(tpe1: ParsedAst.Type, tpe2: ParsedAst.Type, purAndEff: ParsedAst.PurityAndEffect, sp2: SourcePosition) extends ParsedAst.Type
+    case class UnaryPolymorphicArrow(tpe1: ParsedAst.Type, tpe2: ParsedAst.Type, pur: Option[ParsedAst.Type], sp2: SourcePosition) extends ParsedAst.Type
 
     /**
       * Effect Polymorphic Arrow Type.
       *
-      * @param sp1       the position of the first character in the type.
-      * @param tparams   the arguments types.
-      * @param tresult   the result type.
-      * @param purAndEff the optional purity and effect.
-      * @param sp2       the position of the last character in the type.
+      * @param sp1     the position of the first character in the type.
+      * @param tparams the arguments types.
+      * @param tresult the result type.
+      * @param pur     the optional purity.
+      * @param sp2     the position of the last character in the type.
       */
-    case class PolymorphicArrow(sp1: SourcePosition, tparams: Seq[ParsedAst.Type], tresult: ParsedAst.Type, purAndEff: ParsedAst.PurityAndEffect, sp2: SourcePosition) extends ParsedAst.Type
+    case class PolymorphicArrow(sp1: SourcePosition, tparams: Seq[ParsedAst.Type], tresult: ParsedAst.Type, pur: Option[ParsedAst.Type], sp2: SourcePosition) extends ParsedAst.Type
 
     /**
       * Native Type.
@@ -1522,36 +1522,44 @@ object ParsedAst {
     case class False(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Type
 
     /**
-      * The Not type constructor.
-      *
-      * @param sp1 the position of the first character in the type.
-      * @param tpe the negated type.
-      * @param sp2 the position of the last character in the type.
-      */
-    case class Not(sp1: SourcePosition, tpe: ParsedAst.Type, sp2: SourcePosition) extends ParsedAst.Type
-
-    /**
-      * The And type constructor.
-      *
-      * @param tpe1 the 1st type.
-      * @param tpe2 the 2nd type.
-      * @param sp2  the position of the last character in the type.
-      */
-    case class And(tpe1: ParsedAst.Type, tpe2: ParsedAst.Type, sp2: SourcePosition) extends ParsedAst.Type
-
-    /**
-      * The Or type constructor.
-      *
-      * @param tpe1 the 1st type.
-      * @param tpe2 the 2nd type.
-      * @param sp2  the position of the last character in the type.
-      */
-    case class Or(tpe1: ParsedAst.Type, tpe2: ParsedAst.Type, sp2: SourcePosition) extends ParsedAst.Type
-
-    /**
       * A type representing an effect set.
       */
-    case class Effect(sp1: SourcePosition, eff: ParsedAst.EffectSet, sp2: SourcePosition) extends ParsedAst.Type
+    case class EffectSet(sp1: SourcePosition, tpes: Seq[ParsedAst.Type], sp2: SourcePosition) extends ParsedAst.Type
+
+    /**
+      * A type representing a union of two effect set formulas.
+      *
+      * @param tpe1 the 1st type.
+      * @param tpe2 the 2nd type.
+      * @param sp2  the position of the last character in the type.
+      */
+    case class Union(tpe1: ParsedAst.Type, tpe2: ParsedAst.Type, sp2: SourcePosition) extends ParsedAst.Type
+
+    /**
+      * A type representing an intersection of two effect set formulas.
+      *
+      * @param tpe1 the 1st type.
+      * @param tpe2 the 2nd type.
+      * @param sp2  the position of the last character in the type.
+      */
+    case class Intersection(tpe1: ParsedAst.Type, tpe2: ParsedAst.Type, sp2: SourcePosition) extends ParsedAst.Type
+
+    /**
+      * A type representing a difference of two effect set formulas.
+      *
+      * @param tpe1 the 1st type.
+      * @param tpe2 the 2nd type.
+      * @param sp2  the position of the last character in the type.
+      */
+    case class Difference(tpe1: ParsedAst.Type, tpe2: ParsedAst.Type, sp2: SourcePosition) extends ParsedAst.Type
+
+    /**
+      * A type representing the complement of a effect set formula.
+      *
+      * @param tpe the complemented type.
+      * @param sp2 the position of the last character in the type.
+      */
+    case class Complement(sp1: SourcePosition, tpe: ParsedAst.Type, sp2: SourcePosition) extends ParsedAst.Type
 
     /**
       * A type representing a case set.
@@ -1606,120 +1614,6 @@ object ParsedAst {
       */
     case class Ascribe(tpe: ParsedAst.Type, kind: ParsedAst.Kind, sp2: SourcePosition) extends ParsedAst.Type
 
-  }
-
-  /**
-    * Effect Set
-    */
-  sealed trait EffectSet
-
-  object EffectSet {
-    /**
-      * Represents an effect set with a single effect.
-      *
-      * @param sp1 the position of the first character in the set.
-      * @param eff the effect.
-      * @param sp2 the position of the last character in the set.
-      */
-    case class Singleton(sp1: SourcePosition, eff: Effect, sp2: SourcePosition) extends EffectSet
-
-    /**
-      * Represents the empty effect set. Written as `{ }` or `{ Pure ` depending on the syntactic context.
-      *
-      * @param sp1 the position of the first character in the set.
-      * @param sp2 the position of the last character in the set.
-      */
-    case class Pure(sp1: SourcePosition, sp2: SourcePosition) extends EffectSet
-
-    /**
-      * Represents a set of effects.
-      *
-      * @param sp1  the position of the first character in the set.
-      * @param effs the effects.
-      * @param sp2  the position of the last character in the set.
-      */
-    case class Set(sp1: SourcePosition, effs: Seq[Effect], sp2: SourcePosition) extends EffectSet
-  }
-
-  /**
-    * A single effect.
-    */
-  sealed trait Effect
-
-  object Effect {
-    /**
-      * Effect variable.
-      *
-      * @param sp1   the position of the first character in the effect.
-      * @param ident the name of the variable.
-      * @param sp2   the position of the last character in the effect.
-      */
-    case class Var(sp1: SourcePosition, ident: Name.Ident, sp2: SourcePosition) extends ParsedAst.Effect
-
-    /**
-      * Represents a read of the region variables `regs`.
-      *
-      * @param regs the region variables that are read.
-      */
-    case class Read(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
-
-    /**
-      * Represents a write of the region variables `regs`.
-      *
-      * @param regs the region variables that are written.
-      */
-    case class Write(sp1: SourcePosition, regs: Seq[Name.Ident], sp2: SourcePosition) extends ParsedAst.Effect
-
-    /**
-      * Represents the Impure effect.
-      * This is the "top" effect, i.e., the set of all effects.
-      *
-      * @param sp1 the position of the first character in the effect.
-      * @param sp2 the position of the last character in the effect.
-      */
-    case class Impure(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Effect
-
-    /**
-      * Represents a reference to an declared effect.
-      *
-      * @param sp1  the position of the first character in the effect.
-      * @param name the fully qualified name of the effect.
-      * @param sp2  the position of the last character in the effect.
-      */
-    case class Eff(sp1: SourcePosition, name: Name.QName, sp2: SourcePosition) extends ParsedAst.Effect
-
-    /**
-      * Represents the complement of an effect set.
-      *
-      * @param sp1 the position of the first character in the effect.
-      * @param eff the complemented effect.
-      * @param sp2 the position of the last character in the effect.
-      */
-    case class Complement(sp1: SourcePosition, eff: ParsedAst.Effect, sp2: SourcePosition) extends ParsedAst.Effect
-
-    /**
-      * Represents the union of effect sets.
-      *
-      * @param eff1 the first effect.
-      * @param effs the other effects.
-      */
-    case class Union(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
-
-    /**
-      * Represents the intersection of effect sets.
-      *
-      * @param eff1 the first effect.
-      * @param effs the other effects.
-      */
-    case class Intersection(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
-
-    /**
-      * Represents the difference of effect sets.
-      *
-      * @param eff1 the first effect.
-      * @param effs the other effects.
-      */
-    case class Difference(eff1: ParsedAst.Effect, effs: Seq[ParsedAst.Effect]) extends ParsedAst.Effect
   }
 
   /**
@@ -2085,75 +1979,75 @@ object ParsedAst {
     /**
       * Constructor Invocation.
       *
-      * @param fqn       the fully-qualified name of the constructor.
-      * @param sig       the types of the formal parameters.
-      * @param tpe       the return type of the constructor.
-      * @param purAndEff the purity and effect of the constructor.
-      * @param ident     the name given to the imported constructor.
+      * @param fqn   the fully-qualified name of the constructor.
+      * @param sig   the types of the formal parameters.
+      * @param tpe   the return type of the constructor.
+      * @param pur   the purity of the constructor.
+      * @param ident the name given to the imported constructor.
       */
-    case class Constructor(fqn: Name.JavaName, sig: Seq[ParsedAst.Type], tpe: Type, purAndEff: PurityAndEffect, ident: Name.Ident) extends JvmOp
+    case class Constructor(fqn: Name.JavaName, sig: Seq[ParsedAst.Type], tpe: Type, pur: Option[ParsedAst.Type], ident: Name.Ident) extends JvmOp
 
     /**
       * Method Invocation.
       *
-      * @param fqn       the fully-qualified name of the method.
-      * @param sig       the types of the formal parameters.
-      * @param tpe       the return type of the imported method.
-      * @param purAndEff the purity and effect of the imported method.
-      * @param ident     the optional name given to the imported method.
+      * @param fqn   the fully-qualified name of the method.
+      * @param sig   the types of the formal parameters.
+      * @param tpe   the return type of the imported method.
+      * @param pur   the purity of the imported method.
+      * @param ident the optional name given to the imported method.
       */
-    case class Method(fqn: Name.JavaName, sig: Seq[ParsedAst.Type], tpe: Type, purAndEff: PurityAndEffect, ident: Option[Name.Ident]) extends JvmOp
+    case class Method(fqn: Name.JavaName, sig: Seq[ParsedAst.Type], tpe: Type, pur: Option[ParsedAst.Type], ident: Option[Name.Ident]) extends JvmOp
 
     /**
       * Static Method Invocation.
       *
-      * @param fqn       the fully-qualified name of the static method.
-      * @param sig       the declared types of the formal parameters.
-      * @param tpe       the return type of the imported method.
-      * @param purAndEff the purity and effect of the imported method.
-      * @param ident     the optional name given to the imported method.
+      * @param fqn   the fully-qualified name of the static method.
+      * @param sig   the declared types of the formal parameters.
+      * @param tpe   the return type of the imported method.
+      * @param pur   the purity of the imported method.
+      * @param ident the optional name given to the imported method.
       */
-    case class StaticMethod(fqn: Name.JavaName, sig: Seq[ParsedAst.Type], tpe: Type, purAndEff: PurityAndEffect, ident: Option[Name.Ident]) extends JvmOp
+    case class StaticMethod(fqn: Name.JavaName, sig: Seq[ParsedAst.Type], tpe: Type, pur: Option[ParsedAst.Type], ident: Option[Name.Ident]) extends JvmOp
 
     /**
       * Get Object Field.
       *
-      * @param fqn       the fully-qualified name of the field.
-      * @param tpe       the return type of the generated function.
-      * @param purAndEff the purity and effect of the generated function.
-      * @param ident     the name given to the imported field.
+      * @param fqn   the fully-qualified name of the field.
+      * @param tpe   the return type of the generated function.
+      * @param pur   the purity of the generated function.
+      * @param ident the name given to the imported field.
       */
-    case class GetField(fqn: Name.JavaName, tpe: Type, purAndEff: PurityAndEffect, ident: Name.Ident) extends JvmOp
+    case class GetField(fqn: Name.JavaName, tpe: Type, pur: Option[ParsedAst.Type], ident: Name.Ident) extends JvmOp
 
     /**
       * Put ObjectField.
       *
-      * @param fqn       the fully-qualified name of the field.
-      * @param tpe       the return type of the generated function.
-      * @param purAndEff the purity and effect of the generated function.
-      * @param ident     the name given to the imported field.
+      * @param fqn   the fully-qualified name of the field.
+      * @param tpe   the return type of the generated function.
+      * @param pur   the purity of the generated function.
+      * @param ident the name given to the imported field.
       */
-    case class PutField(fqn: Name.JavaName, tpe: Type, purAndEff: PurityAndEffect, ident: Name.Ident) extends JvmOp
+    case class PutField(fqn: Name.JavaName, tpe: Type, pur: Option[ParsedAst.Type], ident: Name.Ident) extends JvmOp
 
     /**
       * Get Static Field.
       *
-      * @param fqn       the fully-qualified name of the field.
-      * @param tpe       the return type of the generated function.
-      * @param purAndEff the purity and effect of the generated function.
-      * @param ident     the name given to the imported field.
+      * @param fqn   the fully-qualified name of the field.
+      * @param tpe   the return type of the generated function.
+      * @param pur   the purity of the generated function.
+      * @param ident the name given to the imported field.
       */
-    case class GetStaticField(fqn: Name.JavaName, tpe: Type, purAndEff: PurityAndEffect, ident: Name.Ident) extends JvmOp
+    case class GetStaticField(fqn: Name.JavaName, tpe: Type, pur: Option[ParsedAst.Type], ident: Name.Ident) extends JvmOp
 
     /**
       * Put Static Field.
       *
-      * @param fqn       the fully-qualified name of the field.
-      * @param tpe       the return type of the generated function.
-      * @param purAndEff the purity and effect of the generated function.
-      * @param ident     the name given to the imported field.
+      * @param fqn   the fully-qualified name of the field.
+      * @param tpe   the return type of the generated function.
+      * @param pur   the purity of the generated function.
+      * @param ident the name given to the imported field.
       */
-    case class PutStaticField(fqn: Name.JavaName, tpe: Type, purAndEff: PurityAndEffect, ident: Name.Ident) extends JvmOp
+    case class PutStaticField(fqn: Name.JavaName, tpe: Type, pur: Option[ParsedAst.Type], ident: Name.Ident) extends JvmOp
 
   }
 
@@ -2167,7 +2061,7 @@ object ParsedAst {
     * @param tpe     the method return type.
     * @param sp2     the position of the last character in the method.
     */
-  case class JvmMethod(sp1: SourcePosition, ident: Name.Ident, fparams: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, purAndEff: ParsedAst.PurityAndEffect, exp: ParsedAst.Expression, sp2: SourcePosition)
+  case class JvmMethod(sp1: SourcePosition, ident: Name.Ident, fparams: Seq[ParsedAst.FormalParam], tpe: ParsedAst.Type, pur: Option[ParsedAst.Type], exp: ParsedAst.Expression, sp2: SourcePosition)
 
   /**
     * Record Operations.
@@ -2287,11 +2181,6 @@ object ParsedAst {
       */
     case object DebugWithLocAndSrc extends DebugKind
   }
-
-  /**
-    * Represents an optional purity and optional effect.
-    */
-  case class PurityAndEffect(pur: Option[Type], eff: Option[EffectSet])
 
   /**
     * Represents a super type for foreach expression fragments.

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -72,7 +72,7 @@ object ResolvedAst {
     case class Op(sym: Symbol.OpSym, spec: ResolvedAst.Spec) extends Declaration
   }
 
-  case class Spec(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, tparams: ResolvedAst.TypeParams, fparams: List[ResolvedAst.FormalParam], tpe: UnkindedType, purAndEff: UnkindedType.PurityAndEffect, tconstrs: List[ResolvedAst.TypeConstraint], econstrs: List[ResolvedAst.EqualityConstraint], loc: SourceLocation)
+  case class Spec(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, tparams: ResolvedAst.TypeParams, fparams: List[ResolvedAst.FormalParam], tpe: UnkindedType, pur: Option[UnkindedType], tconstrs: List[ResolvedAst.TypeConstraint], econstrs: List[ResolvedAst.EqualityConstraint], loc: SourceLocation)
 
   sealed trait Expression {
     def loc: SourceLocation
@@ -168,13 +168,13 @@ object ResolvedAst {
 
     case class Assign(exp1: ResolvedAst.Expression, exp2: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
 
-    case class Ascribe(exp: ResolvedAst.Expression, expectedType: Option[UnkindedType], expectedEff: UnkindedType.PurityAndEffect, loc: SourceLocation) extends ResolvedAst.Expression
+    case class Ascribe(exp: ResolvedAst.Expression, expectedType: Option[UnkindedType], expectedEff: Option[UnkindedType], loc: SourceLocation) extends ResolvedAst.Expression
 
     case class InstanceOf(exp: ResolvedAst.Expression, clazz: java.lang.Class[_], loc: SourceLocation) extends ResolvedAst.Expression
 
     case class CheckedCast(cast: Ast.CheckedCastType, exp: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
 
-    case class UncheckedCast(exp: ResolvedAst.Expression, declaredType: Option[UnkindedType], declaredEff: UnkindedType.PurityAndEffect, loc: SourceLocation) extends ResolvedAst.Expression
+    case class UncheckedCast(exp: ResolvedAst.Expression, declaredType: Option[UnkindedType], declaredEff: Option[UnkindedType], loc: SourceLocation) extends ResolvedAst.Expression
 
     case class UncheckedMaskingCast(exp: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
 
@@ -342,7 +342,7 @@ object ResolvedAst {
 
   }
 
-  case class JvmMethod(ident: Name.Ident, fparams: Seq[ResolvedAst.FormalParam], exp: ResolvedAst.Expression, tpe: UnkindedType, purAndEff: UnkindedType.PurityAndEffect, loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: Seq[ResolvedAst.FormalParam], exp: ResolvedAst.Expression, tpe: UnkindedType, pur: Option[UnkindedType], loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[_], exp: ResolvedAst.Expression)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -37,9 +37,9 @@ object WeededAst {
 
     case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, clazz: Name.QName, tpe: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], assocs: List[WeededAst.Declaration.AssocTypeDef], defs: List[WeededAst.Declaration.Def], loc: SourceLocation) extends WeededAst.Declaration
 
-    case class Sig(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: Option[WeededAst.Expression], tpe: WeededAst.Type, purAndEff: PurityAndEffect, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation)
+    case class Sig(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: Option[WeededAst.Expression], tpe: WeededAst.Type, pur: Option[WeededAst.Type], tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation)
 
-    case class Def(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: WeededAst.Expression, tpe: WeededAst.Type, purAndEff: PurityAndEffect, tconstrs: List[WeededAst.TypeConstraint], constrs: List[WeededAst.EqualityConstraint], loc: SourceLocation) extends WeededAst.Declaration
+    case class Def(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: WeededAst.Expression, tpe: WeededAst.Type, pur: Option[WeededAst.Type], tconstrs: List[WeededAst.TypeConstraint], constrs: List[WeededAst.EqualityConstraint], loc: SourceLocation) extends WeededAst.Declaration
 
     case class Law(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, ident: Name.Ident, tparams: WeededAst.KindedTypeParams, fparams: List[WeededAst.FormalParam], exp: WeededAst.Expression, tpe: WeededAst.Type, pur: WeededAst.Type, tconstrs: List[WeededAst.TypeConstraint], loc: SourceLocation) extends WeededAst.Declaration
 
@@ -155,13 +155,13 @@ object WeededAst {
 
     case class Assign(exp1: WeededAst.Expression, exp2: WeededAst.Expression, loc: SourceLocation) extends WeededAst.Expression
 
-    case class Ascribe(exp: WeededAst.Expression, expectedType: Option[WeededAst.Type], expectedEff: WeededAst.PurityAndEffect, loc: SourceLocation) extends WeededAst.Expression
+    case class Ascribe(exp: WeededAst.Expression, expectedType: Option[WeededAst.Type], expectedEff: Option[WeededAst.Type], loc: SourceLocation) extends WeededAst.Expression
 
     case class InstanceOf(exp: WeededAst.Expression, className: String, loc: SourceLocation) extends WeededAst.Expression
 
     case class CheckedCast(cast: Ast.CheckedCastType, exp: WeededAst.Expression, loc: SourceLocation) extends WeededAst.Expression
 
-    case class UncheckedCast(exp: WeededAst.Expression, declaredType: Option[WeededAst.Type], declaredEff: WeededAst.PurityAndEffect, loc: SourceLocation) extends WeededAst.Expression
+    case class UncheckedCast(exp: WeededAst.Expression, declaredType: Option[WeededAst.Type], declaredEff: Option[WeededAst.Type], loc: SourceLocation) extends WeededAst.Expression
 
     case class UncheckedMaskingCast(exp: WeededAst.Expression, loc: SourceLocation) extends WeededAst.Expression
 
@@ -332,7 +332,7 @@ object WeededAst {
 
     case class Native(fqn: String, loc: SourceLocation) extends WeededAst.Type
 
-    case class Arrow(tparams: List[WeededAst.Type], purAndEff: PurityAndEffect, tresult: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
+    case class Arrow(tparams: List[WeededAst.Type], pur: Option[WeededAst.Type], tresult: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
 
     case class Apply(tpe1: WeededAst.Type, tpe2: WeededAst.Type, loc: SourceLocation) extends WeededAst.Type
 
@@ -410,7 +410,7 @@ object WeededAst {
 
   }
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[WeededAst.FormalParam], exp: WeededAst.Expression, tpe: WeededAst.Type, purAndEff: PurityAndEffect, loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[WeededAst.FormalParam], exp: WeededAst.Expression, tpe: WeededAst.Type, pur: Option[WeededAst.Type], loc: SourceLocation)
 
   case class CatchRule(ident: Name.Ident, className: String, exp: WeededAst.Expression)
 
@@ -441,8 +441,6 @@ object WeededAst {
     case class Kinded(ident: Name.Ident, kind: WeededAst.Kind) extends TypeParam
 
   }
-
-  case class PurityAndEffect(pur: Option[Type], eff: Option[List[Type]])
 
   case class ParYieldFragment(pat: WeededAst.Pattern, exp: WeededAst.Expression, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -1112,4 +1112,24 @@ object WeederError {
     override def explain(formatter: Formatter): Option[String] = None
   }
 
+  /**
+    * An error raised to indicate an illegal effect set member.
+    *
+    * @param loc the location where the error occurred.
+    */
+  case class IllegalEffectSetMember(loc: SourceLocation) extends WeederError {
+    override def summary: String = "Illegal effect set member."
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Illegal effect set member.
+         |
+         |${code(loc, s"Effect sets may only contain variables and constants.")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -1376,7 +1376,9 @@ object Kinder {
 
   }
 
-  // MATT docs
+  /**
+    * Performs kinding on the given purity, assuming it to be Pure if it is absent.
+    */
   private def visitPurityDefaultPure(tpe: Option[UnkindedType], kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[Type, KindError] = tpe match {
     case None => Type.mkTrue(SourceLocation.Unknown).toSuccess
     case Some(t) => visitType(t, Kind.Bool, kenv, taenv, root)

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -365,11 +365,11 @@ object Kinder {
     * Adds `quantifiers` to the generated scheme's quantifier list.
     */
   private def visitSpec(spec0: ResolvedAst.Spec, quantifiers: List[Symbol.KindedTypeVarSym], kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Spec, KindError] = spec0 match {
-    case ResolvedAst.Spec(doc, ann, mod, tparams0, fparams0, tpe0, purAndEff0, tconstrs0, econstrs0, loc) =>
+    case ResolvedAst.Spec(doc, ann, mod, tparams0, fparams0, tpe0, pur0, tconstrs0, econstrs0, loc) =>
       val tparamsVal = traverse(tparams0.tparams)(visitTypeParam(_, kenv)).map(_.flatten)
       val fparamsVal = traverse(fparams0)(visitFormalParam(_, kenv, taenv, root))
       val tpeVal = visitType(tpe0, Kind.Star, kenv, taenv, root)
-      val purAndEffVal = visitPurityAndEffect(purAndEff0, kenv, taenv, root)
+      val purAndEffVal = visitPurityDefaultPure(pur0, kenv, taenv, root)
       val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint(_, kenv, taenv, root))
       val econstrsVal = traverse(econstrs0)(visitEqualityConstraint(_, kenv, taenv, root))
 
@@ -702,8 +702,8 @@ object Kinder {
     case ResolvedAst.Expression.Ascribe(exp0, expectedType0, expectedEff0, loc) =>
       val expVal = visitExp(exp0, kenv0, taenv, henv0, root)
       val expectedTypeVal = traverseOpt(expectedType0)(visitType(_, Kind.Star, kenv0, taenv, root))
-      val expectedPurAndEffVal = visitOptionalPurityAndEffect(expectedEff0, kenv0, taenv, root)
-      mapN(expVal, expectedTypeVal, expectedPurAndEffVal) {
+      val expectedPurVal = traverseOpt(expectedEff0)(visitType(_, Kind.Bool, kenv0, taenv, root))
+      mapN(expVal, expectedTypeVal, expectedPurVal) {
         case (exp, expectedType, expectedPur) =>
           KindedAst.Expression.Ascribe(exp, expectedType, expectedPur, Type.freshVar(Kind.Star, loc.asSynthetic), loc)
       }.recoverOne {
@@ -730,8 +730,8 @@ object Kinder {
     case ResolvedAst.Expression.UncheckedCast(exp0, declaredType0, declaredEff0, loc) =>
       val expVal = visitExp(exp0, kenv0, taenv, henv0, root)
       val declaredTypeVal = traverseOpt(declaredType0)(visitType(_, Kind.Star, kenv0, taenv, root))
-      val declaredPurAndEffVal = visitOptionalPurityAndEffect(declaredEff0, kenv0, taenv, root)
-      mapN(expVal, declaredTypeVal, declaredPurAndEffVal) {
+      val declaredPurVal = traverseOpt(declaredEff0)(visitType(_, Kind.Bool, kenv0, taenv, root))
+      mapN(expVal, declaredTypeVal, declaredPurVal) {
         case (exp, declaredType, declaredPur) =>
           KindedAst.Expression.UncheckedCast(exp, declaredType, declaredPur, Type.freshVar(Kind.Star, loc.asSynthetic), loc)
       }.recoverOne {
@@ -1252,12 +1252,12 @@ object Kinder {
           }
       }
 
-    case UnkindedType.Arrow(purAndEff, arity, loc) =>
+    case UnkindedType.Arrow(pur0, arity, loc) =>
       val kind = Kind.mkArrow(arity)
       unify(kind, expectedKind) match {
         case Some(_) =>
-          val purAndEffVal = visitPurityAndEffect(purAndEff, kenv, taenv, root)
-          mapN(purAndEffVal) {
+          val purVal = visitPurityDefaultPure(pur0, kenv, taenv, root)
+          mapN(purVal) {
             case pur => Type.mkApply(Type.Cst(TypeConstructor.Arrow(arity), loc), List(pur), loc)
           }
         case None => KindError.UnexpectedKind(expectedKind = expectedKind, actualKind = kind, loc).toFailure
@@ -1376,6 +1376,12 @@ object Kinder {
 
   }
 
+  // MATT docs
+  private def visitPurityDefaultPure(tpe: Option[UnkindedType], kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[Type, KindError] = tpe match {
+    case None => Type.mkTrue(SourceLocation.Unknown).toSuccess
+    case Some(t) => visitType(t, Kind.Bool, kenv, taenv, root)
+  }
+
   /**
     * Performs kinding on the given type constraint under the given kind environment.
     */
@@ -1468,12 +1474,12 @@ object Kinder {
     * Performs kinding on the given JVM method.
     */
   private def visitJvmMethod(method: ResolvedAst.JvmMethod, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], henv: Option[(Type.Var, Type.Var)], root: ResolvedAst.Root)(implicit flix: Flix) = method match {
-    case ResolvedAst.JvmMethod(_, fparams, exp, tpe0, pur, loc) =>
+    case ResolvedAst.JvmMethod(_, fparams, exp, tpe0, pur0, loc) =>
       val fparamsVal = traverse(fparams)(visitFormalParam(_, kenv, taenv, root))
       val expVal = visitExp(exp, kenv, taenv, henv, root)
-      val purAndEffVal = visitType(pur, Kind.Bool, kenv, taenv, root)
+      val purVal = visitPurityDefaultPure(pur0, kenv, taenv, root)
       val tpeVal = visitType(tpe0, Kind.Wild, kenv, taenv, root)
-      mapN(fparamsVal, expVal, tpeVal, purAndEffVal) {
+      mapN(fparamsVal, expVal, tpeVal, purVal) {
         case (f, e, tpe, pur) => KindedAst.JvmMethod(method.ident, f, e, tpe, pur, loc)
       }
   }
@@ -1484,15 +1490,15 @@ object Kinder {
     * as in the case of a class type parameter used in a sig or law.
     */
   private def inferSpec(spec0: ResolvedAst.Spec, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindEnv, KindError] = spec0 match {
-    case ResolvedAst.Spec(_, _, _, _, fparams, tpe, purAndEff, tconstrs, _, _) => // TODO ASSOC-TYPES use econstrs for inference?
+    case ResolvedAst.Spec(_, _, _, _, fparams, tpe, pur0, tconstrs, _, _) => // TODO ASSOC-TYPES use econstrs for inference?
       val fparamKenvsVal = traverse(fparams)(inferFormalParam(_, kenv, taenv, root))
       val tpeKenvVal = inferType(tpe, Kind.Star, kenv, taenv, root)
-      val effKenvVal = inferPurityAndEffect(purAndEff, kenv, taenv, root)
+      val effKenvsVal = traverse(pur0)(inferType(_, Kind.Bool, kenv, taenv, root))
       val tconstrsKenvsVal = traverse(tconstrs)(inferTypeConstraint(_, kenv, taenv, root))
 
-      flatMapN(fparamKenvsVal, tpeKenvVal, effKenvVal, tconstrsKenvsVal) {
-        case (fparamKenvs, tpeKenv, effKenv, tconstrKenvs) =>
-          KindEnv.merge(fparamKenvs ::: tpeKenv :: effKenv :: tconstrKenvs)
+      flatMapN(fparamKenvsVal, tpeKenvVal, effKenvsVal, tconstrsKenvsVal) {
+        case (fparamKenvs, tpeKenv, effKenvs, tconstrKenvs) =>
+          KindEnv.merge(fparamKenvs ::: tpeKenv :: effKenvs ::: tconstrKenvs)
       }
 
   }
@@ -1569,15 +1575,15 @@ object Kinder {
       val kind = getClassKind(clazz)
       inferType(arg, kind, kenv0, taenv, root)
 
-    case UnkindedType.Arrow(purAndEff, _, _) =>
-      val purAndEffKenvVal = inferPurityAndEffect(purAndEff, kenv0, taenv, root)
+    case UnkindedType.Arrow(pur, _, _) =>
+      val purKenvsVal = traverse(pur)(inferType(_, Kind.Bool, kenv0, taenv, root))
       val argKenvVal = fold(tpe.typeArguments, KindEnv.empty) {
         case (acc, targ) => flatMapN(inferType(targ, Kind.Star, kenv0, taenv, root)) {
           kenv => acc ++ kenv
         }
       }
-      flatMapN(purAndEffKenvVal, argKenvVal) {
-        case (purAndEffKenv, argKenv) => purAndEffKenv ++ argKenv
+      flatMapN(purKenvsVal, argKenvVal) {
+        case (purKenvs, argKenv) => KindEnv.merge(purKenvs :+ argKenv)
       }
 
     case UnkindedType.ReadWrite(t, _) => inferType(t, Kind.Bool, kenv0, taenv, root)
@@ -1646,20 +1652,6 @@ object Kinder {
     case _: UnkindedType.Apply => throw InternalCompilerException("unexpected type application", tpe.loc)
     case _: UnkindedType.UnappliedAlias => throw InternalCompilerException("unexpected unapplied alias", tpe.loc)
     case _: UnkindedType.UnappliedAssocType => throw InternalCompilerException("unexpected unapplied associated type", tpe.loc)
-  }
-
-  /**
-    * Infers the given purity and effect under the kind environment.
-    */
-  private def inferPurityAndEffect(purAndEff0: UnkindedType.PurityAndEffect, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindEnv, KindError] = purAndEff0 match {
-    // Case 1: Eff missing. No inference to do.
-    case UnkindedType.PurityAndEffect(_, None) => KindEnv.empty.toSuccess
-    // Case 2: Eff present. Infer as Bool.
-    case UnkindedType.PurityAndEffect(_, Some(effs)) =>
-      val kenvsVal = traverse(effs)(inferType(_, Kind.Bool, kenv, taenv, root))
-      flatMapN(kenvsVal) {
-        case kenvs => KindEnv.merge(kenvs)
-      }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -476,18 +476,18 @@ object Namer {
     * Performs naming on the given signature declaration `sig`.
     */
   private def visitSig(sig: WeededAst.Declaration.Sig, ns0: Name.NName, classSym: Symbol.ClassSym)(implicit flix: Flix): Validation[NamedAst.Declaration.Sig, NameError] = sig match {
-    case WeededAst.Declaration.Sig(doc, ann, mod0, ident, tparams0, fparams0, exp0, tpe0, purAndEff0, tconstrs0, loc) =>
-      val tparams = getTypeParamsFromFormalParams(tparams0, fparams0, tpe0, purAndEff0)
+    case WeededAst.Declaration.Sig(doc, ann, mod0, ident, tparams0, fparams0, exp0, tpe0, pur0, tconstrs0, loc) =>
+      val tparams = getTypeParamsFromFormalParams(tparams0, fparams0, tpe0, pur0)
 
       // First visit all the top-level information
       val mod = visitModifiers(mod0, ns0)
       val fparamsVal = getFormalParams(fparams0)
       val tpeVal = visitType(tpe0)
-      val purAndEffVal = visitPurityAndEffect(purAndEff0)
+      val purVal = traverseOpt(pur0)(visitType)
       val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint(_, ns0))
 
-      flatMapN(fparamsVal, tpeVal, purAndEffVal, tconstrsVal) {
-        case (fparams, tpe, purAndEff, tconstrs) =>
+      flatMapN(fparamsVal, tpeVal, purVal, tconstrsVal) {
+        case (fparams, tpe, pur, tconstrs) =>
           val econstrs = Nil // TODO ASSOC-TYPES allow eq-constrs here
 
           // Then visit the parts depending on the parameters
@@ -497,7 +497,7 @@ object Namer {
             case exp =>
 
               val sym = Symbol.mkSigSym(classSym, ident)
-              val spec = NamedAst.Spec(doc, ann, mod, tparams, fparams, tpe, purAndEff, tconstrs, econstrs, loc)
+              val spec = NamedAst.Spec(doc, ann, mod, tparams, fparams, tpe, pur, tconstrs, econstrs, loc)
               NamedAst.Declaration.Sig(sym, spec, exp)
           }
       }
@@ -507,21 +507,21 @@ object Namer {
     * Performs naming on the given definition declaration `decl0`.
     */
   private def visitDef(decl0: WeededAst.Declaration.Def, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Def, NameError] = decl0 match {
-    case WeededAst.Declaration.Def(doc, ann, mod0, ident, tparams0, fparams0, exp, tpe0, purAndEff0, tconstrs0, econstrs0, loc) =>
+    case WeededAst.Declaration.Def(doc, ann, mod0, ident, tparams0, fparams0, exp, tpe0, pur0, tconstrs0, econstrs0, loc) =>
       flix.subtask(ident.name, sample = true)
 
-      val tparams = getTypeParamsFromFormalParams(tparams0, fparams0, tpe0, purAndEff0)
+      val tparams = getTypeParamsFromFormalParams(tparams0, fparams0, tpe0, pur0)
 
       // First visit all the top-level information
       val mod = visitModifiers(mod0, ns0)
       val fparamsVal = getFormalParams(fparams0)
       val tpeVal = visitType(tpe0)
-      val purAndEffVal = visitPurityAndEffect(purAndEff0)
+      val purVal = traverseOpt(pur0)(visitType)
       val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint(_, ns0))
       val econstrsVal = traverse(econstrs0)(visitEqualityConstraint(_, ns0))
 
-      flatMapN(fparamsVal, tpeVal, purAndEffVal, tconstrsVal, econstrsVal) {
-        case (fparams, tpe, purAndEff, tconstrs, econstrs) =>
+      flatMapN(fparamsVal, tpeVal, purVal, tconstrsVal, econstrsVal) {
+        case (fparams, tpe, pur, tconstrs, econstrs) =>
 
           // Then visit the parts depending on the parameters
           val expVal = visitExp(exp, ns0)
@@ -530,7 +530,7 @@ object Namer {
             case e =>
 
               val sym = Symbol.mkDefnSym(ns0, ident)
-              val spec = NamedAst.Spec(doc, ann, mod, tparams, fparams, tpe, purAndEff, tconstrs, econstrs, loc)
+              val spec = NamedAst.Spec(doc, ann, mod, tparams, fparams, tpe, pur, tconstrs, econstrs, loc)
               NamedAst.Declaration.Def(sym, spec, e)
           }
       }
@@ -565,11 +565,11 @@ object Namer {
       mapN(fparamsVal, tpeVal, tconstrsVal) {
         case (fparams, tpe, tconstrs) =>
           val tparams = NamedAst.TypeParams.Kinded(Nil) // operations are monomorphic
-          val purAndEff = NamedAst.PurityAndEffect(None, None) // operations are pure
+          val pur = None // operations are pure
           val econstrs = Nil // TODO ASSOC-TYPES allow econstrs here
 
           val sym = Symbol.mkOpSym(effSym, ident)
-          val spec = NamedAst.Spec(doc, ann, mod, tparams, fparams, tpe, purAndEff, tconstrs, econstrs, loc)
+          val spec = NamedAst.Spec(doc, ann, mod, tparams, fparams, tpe, pur, tconstrs, econstrs, loc)
           NamedAst.Declaration.Op(sym, spec)
       }
   }
@@ -834,7 +834,7 @@ object Namer {
     case WeededAst.Expression.Ascribe(exp, expectedType, expectedEff, loc) =>
       val expVal = visitExp(exp, ns0)
       val expectedTypVal = traverseOpt(expectedType)(visitType)
-      val expectedEffVal = visitPurityAndEffect(expectedEff): Validation[NamedAst.PurityAndEffect, NameError]
+      val expectedEffVal = traverseOpt(expectedEff)(visitType)
 
       mapN(expVal, expectedTypVal, expectedEffVal) {
         case (e, t, f) => NamedAst.Expression.Ascribe(e, t, f, loc)
@@ -855,7 +855,7 @@ object Namer {
     case WeededAst.Expression.UncheckedCast(exp, declaredType, declaredEff, loc) =>
       val expVal = visitExp(exp, ns0)
       val declaredTypVal = traverseOpt(declaredType)(visitType)
-      val declaredEffVal = visitPurityAndEffect(declaredEff): Validation[NamedAst.PurityAndEffect, NameError]
+      val declaredEffVal = traverseOpt(declaredEff)(visitType)
 
       mapN(expVal, declaredTypVal, declaredEffVal) {
         case (e, t, f) => NamedAst.Expression.UncheckedCast(e, t, f, loc)
@@ -1227,12 +1227,12 @@ object Namer {
       case WeededAst.Type.Native(fqn, loc) =>
         NamedAst.Type.Native(fqn, loc).toSuccess
 
-      case WeededAst.Type.Arrow(tparams0, purAndEff0, tresult0, loc) =>
+      case WeededAst.Type.Arrow(tparams0, pur0, tresult0, loc) =>
         val tparamsVal = traverse(tparams0)(visit)
-        val purAndEffVal = visitPurityAndEffect(purAndEff0)
+        val purVal = traverseOpt(pur0)(visitType)
         val tresultVal = visit(tresult0)
-        mapN(tparamsVal, purAndEffVal, tresultVal) {
-          case (tparams, purAndEff, tresult) => NamedAst.Type.Arrow(tparams, purAndEff, tresult, loc)
+        mapN(tparamsVal, purVal, tresultVal) {
+          case (tparams, pur, tresult) => NamedAst.Type.Arrow(tparams, pur, tresult, loc)
         }
 
       case WeededAst.Type.Apply(tpe1, tpe2, loc) =>
@@ -1351,18 +1351,6 @@ object Namer {
   }
 
   /**
-    * Performs naming on the given purity and effect.
-    */
-  private def visitPurityAndEffect(purAndEff: WeededAst.PurityAndEffect)(implicit flix: Flix): Validation[NamedAst.PurityAndEffect, NameError.TypeNameError] = purAndEff match {
-    case WeededAst.PurityAndEffect(pur0, eff0) =>
-      val purVal = traverseOpt(pur0)(visitType)
-      val effVal = traverseOpt(eff0)(effs => traverse(effs)(visitType))
-      mapN(purVal, effVal) {
-        case (pur, eff) => NamedAst.PurityAndEffect(pur, eff)
-      }
-  }
-
-  /**
     * Returns all the free variables in the given pattern `pat0`.
     */
   private def freeVars(pat0: WeededAst.Pattern): List[Name.Ident] = pat0 match {
@@ -1405,7 +1393,7 @@ object Namer {
     case WeededAst.Type.Relation(ts, loc) => ts.flatMap(freeTypeVars)
     case WeededAst.Type.Lattice(ts, loc) => ts.flatMap(freeTypeVars)
     case WeededAst.Type.Native(fqm, loc) => Nil
-    case WeededAst.Type.Arrow(tparams, WeededAst.PurityAndEffect(pur, eff), tresult, loc) => tparams.flatMap(freeTypeVars) ::: pur.toList.flatMap(freeTypeVars) ::: eff.toList.flatMap(_.flatMap(freeTypeVars)) ::: freeTypeVars(tresult)
+    case WeededAst.Type.Arrow(tparams, pur, tresult, loc) => tparams.flatMap(freeTypeVars) ::: pur.toList.flatMap(freeTypeVars) ::: freeTypeVars(tresult)
     case WeededAst.Type.Apply(tpe1, tpe2, loc) => freeTypeVars(tpe1) ++ freeTypeVars(tpe2)
     case WeededAst.Type.True(loc) => Nil
     case WeededAst.Type.False(loc) => Nil
@@ -1472,13 +1460,13 @@ object Namer {
     * Translates the given weeded JvmMethod to a named JvmMethod.
     */
   private def visitJvmMethod(method: WeededAst.JvmMethod, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.JvmMethod, NameError] = method match {
-    case WeededAst.JvmMethod(ident, fparams0, exp0, tpe0, purAndEff0, loc) =>
+    case WeededAst.JvmMethod(ident, fparams0, exp0, tpe0, pur0, loc) =>
       flatMapN(traverse(fparams0)(visitFormalParam): Validation[List[NamedAst.FormalParam], NameError]) {
         case fparams =>
           val exp = visitExp(exp0, ns0)
           val tpe = visitType(tpe0)
-          val purAndEff = visitPurityAndEffect(purAndEff0)
-          mapN(exp, tpe, purAndEff) {
+          val pur = traverseOpt(pur0)(visitType)
+          mapN(exp, tpe, pur) {
             case (e, t, p) => NamedAst.JvmMethod(ident, fparams, e, t, p, loc)
           }
       }: Validation[NamedAst.JvmMethod, NameError]
@@ -1517,9 +1505,9 @@ object Namer {
   /**
     * Performs naming on the given type parameters `tparams0` from the given formal params `fparams` and overall type `tpe`.
     */
-  private def getTypeParamsFromFormalParams(tparams0: WeededAst.TypeParams, fparams: List[WeededAst.FormalParam], tpe: WeededAst.Type, purAndEff: WeededAst.PurityAndEffect)(implicit flix: Flix): NamedAst.TypeParams = {
+  private def getTypeParamsFromFormalParams(tparams0: WeededAst.TypeParams, fparams: List[WeededAst.FormalParam], tpe: WeededAst.Type, pur: Option[WeededAst.Type])(implicit flix: Flix): NamedAst.TypeParams = {
     tparams0 match {
-      case WeededAst.TypeParams.Elided => getImplicitTypeParamsFromFormalParams(fparams, tpe, purAndEff)
+      case WeededAst.TypeParams.Elided => getImplicitTypeParamsFromFormalParams(fparams, tpe, pur)
       case WeededAst.TypeParams.Unkinded(tparams) => getExplicitTypeParams(tparams)
       case WeededAst.TypeParams.Kinded(tparams) => getExplicitKindedTypeParams(tparams)
 
@@ -1562,7 +1550,7 @@ object Namer {
   /**
     * Returns the implicit type parameters constructed from the given formal parameters and type.
     */
-  private def getImplicitTypeParamsFromFormalParams(fparams: List[WeededAst.FormalParam], tpe: WeededAst.Type, purAndEff: WeededAst.PurityAndEffect)(implicit flix: Flix): NamedAst.TypeParams = {
+  private def getImplicitTypeParamsFromFormalParams(fparams: List[WeededAst.FormalParam], tpe: WeededAst.Type, pur: Option[WeededAst.Type])(implicit flix: Flix): NamedAst.TypeParams = {
     // Compute the type variables that occur in the formal parameters.
     val fparamTvars = fparams.flatMap {
       case WeededAst.FormalParam(_, _, Some(tpe), _) => freeTypeVars(tpe)
@@ -1571,11 +1559,9 @@ object Namer {
 
     val tpeTvars = freeTypeVars(tpe)
 
-    val WeededAst.PurityAndEffect(pur, eff) = purAndEff
     val purTvars = pur.toList.flatMap(freeTypeVars)
-    val effTvars = eff.getOrElse(Nil).flatMap(freeTypeVars)
 
-    val tparams = (fparamTvars ::: tpeTvars ::: purTvars ::: effTvars).distinct.map {
+    val tparams = (fparamTvars ::: tpeTvars ::: purTvars).distinct.map {
       ident => NamedAst.TypeParam.Implicit(ident, mkTypeVarSym(ident), ident.loc)
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -433,7 +433,9 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       Types.EffectSet | Type
     }
 
-    Type ~ optional(optWS ~ "\\" ~ optWS ~ EffectFirstType)
+    rule {
+      Type ~ optional(optWS ~ "\\" ~ optWS ~ EffectFirstType)
+    }
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -426,14 +426,14 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     SP ~ Names.Attribute ~ optWS ~ ":" ~ optWS ~ Type ~ SP ~> ParsedAst.Attribute
   }
 
-  def TypeAndEffect: Rule2[ParsedAst.Type, ParsedAst.PurityAndEffect] = rule {
-    Type ~ PurityAndEffect
-  }
+  def TypeAndEffect: Rule2[ParsedAst.Type, Option[ParsedAst.Type]] = {
 
-  def PurityAndEffect: Rule1[ParsedAst.PurityAndEffect] = {
-    rule {
-      optional(optWS ~ "&" ~ optWS ~ Type) ~ optional(optWS ~ "\\" ~ optWS ~ Effects.EffectSetOrEmpty) ~> ParsedAst.PurityAndEffect
+    // First tries to parse the type as an effect set, so that {} is interpreted as a set rather than a record
+    def EffectFirstType: Rule1[ParsedAst.Type] = rule {
+      Types.EffectSet | Type
     }
+
+    Type ~ optional(optWS ~ "\\" ~ optWS ~ EffectFirstType)
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -798,27 +798,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def Ascribe: Rule1[ParsedAst.Expression] = rule {
-      FAppend ~ optional(optWS ~ ":" ~ optWS ~ TypAndPurFragment ~ SP ~> ParsedAst.Expression.Ascribe)
-    }
-
-    def TypAndPurFragment: Rule2[Option[ParsedAst.Type], ParsedAst.PurityAndEffect] = {
-
-      def PurAndEffOnly: Rule2[Option[ParsedAst.Type], ParsedAst.PurityAndEffect] = rule {
-        // lookahead for purity/effect syntax
-        &("&" | "\\") ~ push(None) ~ PurityAndEffect
-      }
-
-      def SomeType: Rule1[Option[ParsedAst.Type]] = rule {
-        Type ~> ((o: ParsedAst.Type) => Some(o))
-      }
-
-      def Both: Rule2[Option[ParsedAst.Type], ParsedAst.PurityAndEffect] = rule {
-        SomeType ~ PurityAndEffect
-      }
-
-      rule {
-        PurAndEffOnly | Both
-      }
+      FAppend ~ optional(optWS ~ ":" ~ optWS ~ TypeAndEffect ~ SP ~> ParsedAst.Expression.Ascribe)
     }
 
     def Primary: Rule1[ParsedAst.Expression] = rule {
@@ -841,26 +821,8 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       SP ~ keyword("checked_ecast") ~ optWS ~ "(" ~ optWS ~ Expression ~ optWS ~ ")" ~ SP ~> ParsedAst.Expression.CheckedEffectCast
     }
 
-    def UncheckedCast: Rule1[ParsedAst.Expression] = {
-      def PurAndEffOnly: Rule2[Option[ParsedAst.Type], ParsedAst.PurityAndEffect] = rule {
-        "_" ~ optWS ~ &("&" | "\\") ~ push(None) ~ PurityAndEffect
-      }
-
-      def SomeType: Rule1[Option[ParsedAst.Type]] = rule {
-        Type ~> ((o: ParsedAst.Type) => Some(o))
-      }
-
-      def Both: Rule2[Option[ParsedAst.Type], ParsedAst.PurityAndEffect] = rule {
-        SomeType ~ PurityAndEffect
-      }
-
-      def TypeAndPurity: Rule2[Option[ParsedAst.Type], ParsedAst.PurityAndEffect] = rule {
-        PurAndEffOnly | Both
-      }
-
-      rule {
-        SP ~ keyword("unchecked_cast") ~ optWS ~ "(" ~ Expression ~ WS ~ "as" ~ optWS ~ TypeAndPurity ~ optWS ~ ")" ~ SP ~> ParsedAst.Expression.UncheckedCast
-      }
+    def UncheckedCast: Rule1[ParsedAst.Expression] = rule {
+      SP ~ keyword("unchecked_cast") ~ optWS ~ "(" ~ Expression ~ WS ~ "as" ~ optWS ~ TypeAndEffect ~ optWS ~ ")" ~ SP ~> ParsedAst.Expression.UncheckedCast
     }
 
     def UncheckedMaskingCast: Rule1[ParsedAst.Expression.UncheckedMaskingCast] = rule {
@@ -902,11 +864,11 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def LetRecDef: Rule1[ParsedAst.Expression.LetRecDef] = {
-      def SomeTypeAndEffect: Rule1[Option[(ParsedAst.Type, ParsedAst.PurityAndEffect)]] = rule {
-        ":" ~ optWS ~ TypeAndEffect ~ optWS ~> ((tpe: ParsedAst.Type, purAndEff: ParsedAst.PurityAndEffect) => Some((tpe, purAndEff)))
+      def SomeTypeAndEffect: Rule1[Option[(ParsedAst.Type, Option[ParsedAst.Type])]] = rule {
+        ":" ~ optWS ~ TypeAndEffect ~ optWS ~> ((tpe: ParsedAst.Type, pur: Option[ParsedAst.Type]) => Some((tpe, pur)))
       }
 
-      def NoTypeAndEffect: Rule1[Option[(ParsedAst.Type, ParsedAst.PurityAndEffect)]] = rule {
+      def NoTypeAndEffect: Rule1[Option[(ParsedAst.Type, Option[ParsedAst.Type])]] = rule {
         push(None)
       }
 
@@ -961,8 +923,8 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
         "(" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")"
       }
 
-      def Ascription: Rule2[ParsedAst.Type, ParsedAst.PurityAndEffect] = rule {
-        ":" ~ optWS ~ Type ~ PurityAndEffect
+      def Ascription: Rule2[ParsedAst.Type, Option[ParsedAst.Type]] = rule {
+        ":" ~ optWS ~ TypeAndEffect
       }
 
       def Import: Rule1[ParsedAst.JvmOp] = rule {
@@ -1485,15 +1447,25 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def CaseIntersection: Rule1[ParsedAst.Type] = rule {
-      Or ~ zeroOrMore(WS ~ atomic("&&") ~ WS ~ Type ~ SP ~> ParsedAst.Type.CaseIntersection)
+      UnionOrDifference ~ zeroOrMore(WS ~ atomic("&") ~ WS ~ Type ~ SP ~> ParsedAst.Type.CaseIntersection)
     }
 
-    def Or: Rule1[ParsedAst.Type] = rule {
-      And ~ zeroOrMore(WS ~ keyword("or") ~ WS ~ Type ~ SP ~> ParsedAst.Type.Or)
+    def UnionOrDifference: Rule1[ParsedAst.Type] = {
+      def UnionTail = rule {
+        WS ~ atomic("+") ~ WS ~ Type ~ SP ~> ParsedAst.Type.Union
+      }
+
+      def DifferenceTail = rule {
+        WS ~ atomic("-") ~ WS ~ Type ~ SP ~> ParsedAst.Type.Difference
+      }
+
+      rule {
+        Intersection ~ zeroOrMore(UnionTail | DifferenceTail)
+      }
     }
 
-    def And: Rule1[ParsedAst.Type] = rule {
-      Ascribe ~ zeroOrMore(WS ~ keyword("and") ~ WS ~ Type ~ SP ~> ParsedAst.Type.And)
+    def Intersection: Rule1[ParsedAst.Type] = rule {
+      Ascribe ~ zeroOrMore(WS ~ atomic("&") ~ WS ~ Type ~ SP ~> ParsedAst.Type.Intersection)
     }
 
     def Ascribe: Rule1[ParsedAst.Type] = rule {
@@ -1505,7 +1477,9 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def Primary: Rule1[ParsedAst.Type] = rule {
-      Arrow | Tuple | Record | RecordRow | Schema | SchemaRow | CaseSet | CaseComplement | Native | True | False | Pure | Impure | Not | Var | Ambiguous | Effect
+      // NB: Record must come before EffectSet as they overlap
+      // NB: CaseComplement must come before Complement as the overlap
+      Arrow | Tuple | Record | RecordRow | Schema | SchemaRow | CaseSet | EffectSet | CaseComplement | Complement | Native | True | False | Pure | Impure | Var | Ambiguous
     }
 
     def Arrow: Rule1[ParsedAst.Type] = {
@@ -1552,6 +1526,10 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       SP ~ atomic("#(") ~ optWS ~ zeroOrMore(RelPredicateWithTypes | LatPredicateWithTypes | PredicateWithAlias).separatedBy(optWS ~ "," ~ optWS) ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ ")" ~ SP ~> ParsedAst.Type.SchemaRow
     }
 
+    def EffectSet: Rule1[ParsedAst.Type] = rule {
+      SP ~ "{" ~ optWS ~ zeroOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ "}" ~ SP ~> ParsedAst.Type.EffectSet
+    }
+
     private def PredicateWithAlias: Rule1[ParsedAst.PredicateType.PredicateWithAlias] = rule {
       SP ~ Names.QualifiedPredicate ~ optional(TypeArguments) ~ SP ~> ParsedAst.PredicateType.PredicateWithAlias
     }
@@ -1584,14 +1562,14 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       SP ~ keyword("Impure") ~ SP ~> ParsedAst.Type.False
     }
 
-    def Not: Rule1[ParsedAst.Type] = rule {
-      // NB: We must not use Type here because it gives the wrong precedence.
-      SP ~ keyword("not") ~ WS ~ Apply ~ SP ~> ParsedAst.Type.Not
-    }
-
     def CaseComplement: Rule1[ParsedAst.Type] = rule {
       // NB: We must not use Type here because it gives the wrong precedence.
       SP ~ "~~" ~ optWS ~ Apply ~ SP ~> ParsedAst.Type.CaseComplement
+    }
+
+    def Complement: Rule1[ParsedAst.Type] = rule {
+      // NB: We must not use Type here because it gives the wrong precedence.
+      SP ~ "~" ~ optWS ~ Apply ~ SP ~> ParsedAst.Type.CaseComplement
     }
 
     def Var: Rule1[ParsedAst.Type] = rule {
@@ -1602,10 +1580,6 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       SP ~ Names.QualifiedType ~ SP ~> ParsedAst.Type.Ambiguous
     }
 
-    def Effect: Rule1[ParsedAst.Type] = rule {
-      SP ~ Effects.NonSingletonEffectSet ~ SP ~> ParsedAst.Type.Effect
-    }
-
     def CaseSet: Rule1[ParsedAst.Type] = rule {
       SP ~ "<" ~ optWS ~ zeroOrMore(Names.QName).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ">" ~ SP ~> ParsedAst.Type.CaseSet
     }
@@ -1614,103 +1588,6 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       "[" ~ optWS ~ oneOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ "]"
     }
 
-  }
-
-  object Effects {
-
-    // This should only be used where the effect is unambiguously an effect.
-    // NOT where it might be some other type, since this overlaps with the empty record type.
-    def EffectSetOrEmpty: Rule1[ParsedAst.EffectSet] = {
-      def Empty: Rule1[ParsedAst.EffectSet] = rule {
-        SP ~ "{" ~ optWS ~ "}" ~ SP ~> ParsedAst.EffectSet.Pure
-      }
-
-      rule {
-        Empty | EffectSet
-      }
-    }
-
-    def NonSingletonEffectSet: Rule1[ParsedAst.EffectSet] = rule {
-      // NB: Pure must come before Set since they overlap
-      Pure | Set
-    }
-
-    def EffectSet: Rule1[ParsedAst.EffectSet] = rule {
-      // NB: Pure must come before Set since they overlap
-      Pure | Set | Singleton
-    }
-
-    def Singleton: Rule1[ParsedAst.EffectSet] = rule {
-      SP ~ Effect ~ SP ~> ParsedAst.EffectSet.Singleton
-    }
-
-    def Pure: Rule1[ParsedAst.EffectSet] = rule {
-      SP ~ "{" ~ optWS ~ keyword("Pure") ~ optWS ~ "}" ~ SP ~> ParsedAst.EffectSet.Pure
-    }
-
-    def Set: Rule1[ParsedAst.EffectSet] = rule {
-      SP ~ "{" ~ optWS ~ oneOrMore(Effect).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ "}" ~ SP ~> ParsedAst.EffectSet.Set
-    }
-
-    def Effect: Rule1[ParsedAst.Effect] = rule {
-      Binary | SimpleEffect
-    }
-
-    def Var: Rule1[ParsedAst.Effect] = rule {
-      SP ~ Names.Variable ~ SP ~> ParsedAst.Effect.Var
-    }
-
-    def Read: Rule1[ParsedAst.Effect] = rule {
-      SP ~ keyword("Read") ~ optWS ~ "(" ~ optWS ~ oneOrMore(Names.Variable).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~ SP ~> ParsedAst.Effect.Read
-    }
-
-    def Write: Rule1[ParsedAst.Effect] = rule {
-      SP ~ keyword("Write") ~ optWS ~ "(" ~ optWS ~ oneOrMore(Names.Variable).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~ SP ~> ParsedAst.Effect.Write
-    }
-
-    def Impure: Rule1[ParsedAst.Effect] = rule {
-      SP ~ keyword("Impure") ~ SP ~> ParsedAst.Effect.Impure
-    }
-
-    def Eff: Rule1[ParsedAst.Effect] = rule {
-      SP ~ Names.QualifiedEffect ~ SP ~> ParsedAst.Effect.Eff
-    }
-
-    def Complement: Rule1[ParsedAst.Effect] = rule {
-      SP ~ operatorX("~") ~ optWS ~ SimpleEffect ~ SP ~> ParsedAst.Effect.Complement
-    }
-
-    def UnionTail = rule {
-      operatorX("+") ~ optWS ~ oneOrMore(SimpleEffect).separatedBy(optWS ~ "+" ~ optWS) ~> ParsedAst.Effect.Union
-    }
-
-    def IntersectionTail = rule {
-      operatorX("&") ~ optWS ~ oneOrMore(SimpleEffect).separatedBy(optWS ~ "&" ~ optWS) ~> ParsedAst.Effect.Intersection
-    }
-
-    def DifferenceTail = rule {
-      operatorX("-") ~ optWS ~ oneOrMore(SimpleEffect).separatedBy(optWS ~ "-" ~ optWS) ~> ParsedAst.Effect.Difference
-    }
-
-    def BinaryTail = rule {
-      UnionTail | DifferenceTail | IntersectionTail
-    }
-
-    // We only allow chains of like operators.
-    // Unlike operators must be parenthesized.
-    // Illegal: a + b + c - d + e
-    // Legal: ((a + b + c) - d) + e
-    def Binary: Rule1[ParsedAst.Effect] = rule {
-      SimpleEffect ~ optional(optWS ~ BinaryTail)
-    }
-
-    def SimpleEffect: Rule1[ParsedAst.Effect] = rule {
-      Var | Impure | Read | Write | Eff | Complement | Parens
-    }
-
-    def Parens: Rule1[ParsedAst.Effect] = rule {
-      "(" ~ Effect ~ ")"
-    }
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1480,8 +1480,9 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     def Primary: Rule1[ParsedAst.Type] = rule {
       // NB: Record must come before EffectSet as they overlap
-      // NB: CaseComplement must come before Complement as the overlap
-      Arrow | Tuple | Record | RecordRow | Schema | SchemaRow | CaseSet | EffectSet | CaseComplement | Complement | Native | True | False | Pure | Impure | Var | Ambiguous
+      // NB: CaseComplement must come before Complement as they overlap
+      Arrow | Tuple | Record | RecordRow | Schema | SchemaRow | CaseSet | EffectSet | CaseComplement | Complement |
+        Native | True | False | Pure | Impure | Read | Write | Var | Ambiguous
     }
 
     def Arrow: Rule1[ParsedAst.Type] = {
@@ -1562,6 +1563,14 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     def Impure: Rule1[ParsedAst.Type] = rule {
       SP ~ keyword("Impure") ~ SP ~> ParsedAst.Type.False
+    }
+
+    def Read: Rule1[ParsedAst.Type] = rule {
+      SP ~ keyword("Read") ~ "(" ~ oneOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ ")" ~ SP ~> ParsedAst.Type.Read
+    }
+
+    def Write: Rule1[ParsedAst.Type] = rule {
+      SP ~ keyword("Write") ~ "(" ~ oneOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ ")" ~ SP ~> ParsedAst.Type.Write
     }
 
     def CaseComplement: Rule1[ParsedAst.Type] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1449,7 +1449,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def CaseIntersection: Rule1[ParsedAst.Type] = rule {
-      UnionOrDifference ~ zeroOrMore(WS ~ atomic("&") ~ WS ~ Type ~ SP ~> ParsedAst.Type.CaseIntersection)
+      UnionOrDifference ~ zeroOrMore(WS ~ atomic("&&") ~ WS ~ Type ~ SP ~> ParsedAst.Type.CaseIntersection)
     }
 
     def UnionOrDifference: Rule1[ParsedAst.Type] = {

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -515,7 +515,7 @@ object Resolver {
     * Performs name resolution on the given spec `s0` in the given namespace `ns0`.
     */
   def resolveSpec(s0: NamedAst.Spec, tconstr: Option[ResolvedAst.TypeConstraint], env0: ListMap[String, Resolution], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.Spec, ResolutionError] = s0 match {
-    case NamedAst.Spec(doc, ann, mod, tparams0, fparams0, tpe0, purAndEff0, tconstrs0, econstrs0, loc) =>
+    case NamedAst.Spec(doc, ann, mod, tparams0, fparams0, tpe0, pur0, tconstrs0, econstrs0, loc) =>
       val tparamsVal = resolveTypeParams(tparams0, env0, ns0, root)
       flatMapN(tparamsVal) {
         case tparams =>
@@ -525,14 +525,14 @@ object Resolver {
             case fparams =>
               val env = env1 ++ mkFormalParamEnv(fparams)
               val tpeVal = resolveType(tpe0, Wildness.AllowWild, env, taenv, ns0, root)
-              val purAndEffVal = resolvePurityAndEffect(purAndEff0, Wildness.AllowWild, env, taenv, ns0, root)
+              val purVal = traverseOpt(pur0)(resolveType(_, Wildness.AllowWild, env, taenv, ns0, root))
               val tconstrsVal = traverse(tconstrs0)(resolveTypeConstraint(_, env, taenv, ns0, root))
               val econstrsVal = traverse(econstrs0)(resolveEqualityConstraint(_, env, taenv, ns0, root))
 
-              mapN(tpeVal, purAndEffVal, tconstrsVal, econstrsVal) {
-                case (tpe, purAndEff, tconstrs, econstrs) =>
+              mapN(tpeVal, purVal, tconstrsVal, econstrsVal) {
+                case (tpe, pur, tconstrs, econstrs) =>
                   // add the inherited type constraint to the the list
-                  ResolvedAst.Spec(doc, ann, mod, tparams, fparams, tpe, purAndEff, tconstr.toList ::: tconstrs, econstrs, loc)
+                  ResolvedAst.Spec(doc, ann, mod, tparams, fparams, tpe, pur, tconstr.toList ::: tconstrs, econstrs, loc)
               }
           }
       }
@@ -645,7 +645,7 @@ object Resolver {
         case Enum(sym, loc) => ().toSuccess
         case RestrictableEnum(sym, loc) => ().toSuccess
         case Apply(tpe1, tpe2, loc) => traverseX(List(tpe1, tpe2))(checkAssocTypes)
-        case Arrow(UnkindedType.PurityAndEffect(pur, eff), arity, loc) => traverseX(pur.toList ::: eff.getOrElse(Nil))(checkAssocTypes)
+        case Arrow(pur, arity, loc) => traverseX(pur.toList)(checkAssocTypes)
         case ReadWrite(tpe, loc) => checkAssocTypes(tpe)
         case CaseSet(cases, loc) => ().toSuccess
         case CaseComplement(tpe, loc) => checkAssocTypes(tpe)
@@ -686,7 +686,7 @@ object Resolver {
     * A signature spec is legal if it contains the class's type variable in its formal parameters or return type.
     */
   private def checkSigSpec(sym: Symbol.SigSym, spec0: ResolvedAst.Spec, tvar: Symbol.UnkindedTypeVarSym): Validation[Unit, ResolutionError] = spec0 match {
-    case ResolvedAst.Spec(doc, ann, mod, tparams, fparams, tpe, purAndEff, tconstrs, econstrs, loc) =>
+    case ResolvedAst.Spec(doc, ann, mod, tparams, fparams, tpe, pur, tconstrs, econstrs, loc) =>
       val tpes = tpe :: fparams.flatMap(_.tpe)
       val tvars = tpes.flatMap(_.definiteTypeVars).to(SortedSet)
       if (tvars.contains(tvar)) {
@@ -1315,11 +1315,8 @@ object Resolver {
           }
 
         case NamedAst.Expression.Ascribe(exp, expectedType, expectedEff, loc) =>
-          val expectedTypVal = expectedType match {
-            case None => (None: Option[UnkindedType]).toSuccess
-            case Some(t) => mapN(resolveType(t, Wildness.AllowWild, env0, taenv, ns0, root))(x => Some(x))
-          }
-          val expectedEffVal = resolvePurityAndEffect(expectedEff, Wildness.AllowWild, env0, taenv, ns0, root)
+          val expectedTypVal = traverseOpt(expectedType)(resolveType(_, Wildness.AllowWild, env0, taenv, ns0, root))
+          val expectedEffVal = traverseOpt(expectedEff)(resolveType(_, Wildness.AllowWild, env0, taenv, ns0, root))
 
           val eVal = visitExp(exp, env0)
           mapN(eVal, expectedTypVal, expectedEffVal) {
@@ -1341,11 +1338,8 @@ object Resolver {
           }
 
         case NamedAst.Expression.UncheckedCast(exp, declaredType, declaredEff, loc) =>
-          val declaredTypVal = declaredType match {
-            case None => (None: Option[UnkindedType]).toSuccess
-            case Some(t) => mapN(resolveType(t, Wildness.ForbidWild, env0, taenv, ns0, root))(x => Some(x))
-          }
-          val declaredEffVal = resolvePurityAndEffect(declaredEff, Wildness.ForbidWild, env0, taenv, ns0, root)
+          val declaredTypVal = traverseOpt(declaredType)(resolveType(_, Wildness.ForbidWild, env0, taenv, ns0, root))
+          val declaredEffVal = traverseOpt(declaredEff)(resolveType(_, Wildness.ForbidWild, env0, taenv, ns0, root))
 
           val eVal = visitExp(exp, env0)
           mapN(eVal, declaredTypVal, declaredEffVal) {
@@ -1672,15 +1666,15 @@ object Resolver {
         * Performs name resolution on the given JvmMethod `method` in the namespace `ns0`.
         */
       def visitJvmMethod(method: NamedAst.JvmMethod, env0: ListMap[String, Resolution], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[ResolvedAst.JvmMethod, ResolutionError] = method match {
-        case NamedAst.JvmMethod(ident, fparams, exp, tpe, purAndEff, loc) =>
+        case NamedAst.JvmMethod(ident, fparams, exp, tpe, pur, loc) =>
           val fparamsVal = resolveFormalParams(fparams, env0, taenv, ns0, root)
           flatMapN(fparamsVal) {
             case fparams =>
               val env = env0 ++ mkFormalParamEnv(fparams)
               val expVal = visitExp(exp, env)
               val tpeVal = resolveType(tpe, Wildness.ForbidWild, env, taenv, ns0, root)
-              val purAndEffVal = resolvePurityAndEffect(purAndEff, Wildness.ForbidWild, env, taenv, ns0, root)
-              mapN(expVal, tpeVal, purAndEffVal) {
+              val purVal = traverseOpt(pur)(resolveType(_, Wildness.ForbidWild, env, taenv, ns0, root))
+              mapN(expVal, tpeVal, purVal) {
                 case (e, t, p) => ResolvedAst.JvmMethod(ident, fparams, e, t, p, loc)
               }
           }
@@ -2325,12 +2319,12 @@ object Resolver {
           case clazz => flixifyType(clazz, loc)
         }
 
-      case NamedAst.Type.Arrow(tparams0, purAndEff0, tresult0, loc) =>
-        val tparamsVal = traverse(tparams0)(visit(_))
+      case NamedAst.Type.Arrow(tparams0, pur0, tresult0, loc) =>
+        val tparamsVal = traverse(tparams0)(visit)
         val tresultVal = visit(tresult0)
-        val purAndEffVal = semiResolvePurityAndEffect(purAndEff0, wildness, env, ns0, root)
-        mapN(tparamsVal, tresultVal, purAndEffVal) {
-          case (tparams, tresult, purAndEff) => mkUncurriedArrowWithEffect(tparams, purAndEff, tresult, loc)
+        val purVal = traverseOpt(pur0)(visit)
+        mapN(tparamsVal, tresultVal, purVal) {
+          case (tparams, tresult, pur) => mkUncurriedArrowWithEffect(tparams, pur, tresult, loc)
         }
 
       case NamedAst.Type.Apply(base0, targ0, loc) =>
@@ -2501,10 +2495,10 @@ object Resolver {
           resolvedArgs => UnkindedType.mkApply(baseType, resolvedArgs, tpe0.loc)
         }
 
-      case UnkindedType.Arrow(purAndEff, arity, loc) =>
-        val purAndEffVal = finishResolvePurityAndEffect(purAndEff, taenv)
+      case UnkindedType.Arrow(pur, arity, loc) =>
+        val purVal = traverseOpt(pur)(finishResolveType(_, taenv))
         val targsVal = traverse(targs)(finishResolveType(_, taenv))
-        mapN(purAndEffVal, targsVal) {
+        mapN(purVal, targsVal) {
           case (p, ts) => UnkindedType.mkApply(UnkindedType.Arrow(p, arity, loc), ts, tpe0.loc)
         }
 
@@ -2558,39 +2552,6 @@ object Resolver {
     val tVal = semiResolveType(tpe0, wildness, env, ns0, root)
     flatMapN(tVal) {
       t => finishResolveType(t, taenv)
-    }
-  }
-
-  /**
-    * Partially resolves the given purity and effect.
-    */
-  private def semiResolvePurityAndEffect(purAndEff0: NamedAst.PurityAndEffect, wildness: Wildness, env: ListMap[String, Resolution], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[UnkindedType.PurityAndEffect, ResolutionError] = purAndEff0 match {
-    case NamedAst.PurityAndEffect(pur0, eff0) =>
-      val purVal = traverseOpt(pur0)(semiResolveType(_, wildness, env, ns0, root))
-      val effVal = traverseOpt(eff0)(effs => traverse(effs)(semiResolveType(_, wildness, env, ns0, root)))
-      mapN(purVal, effVal) {
-        case (pur, eff) => UnkindedType.PurityAndEffect(pur, eff)
-      }
-  }
-
-  /**
-    * Finishes resolution of the given purity and effect.
-    */
-  private def finishResolvePurityAndEffect(purAndEff0: UnkindedType.PurityAndEffect, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias]): Validation[UnkindedType.PurityAndEffect, ResolutionError] = purAndEff0 match {
-    case UnkindedType.PurityAndEffect(pur0, eff0) =>
-      val purVal = traverseOpt(pur0)(finishResolveType(_, taenv))
-      val effVal = traverseOpt(eff0)(effs => traverse(effs)(finishResolveType(_, taenv)))
-      mapN(purVal, effVal) {
-        case (pur, eff) => UnkindedType.PurityAndEffect(pur, eff)
-      }
-  }
-
-  /**
-    * Performs name resolution on the given purity and effect `purAndEff0` in the given namespace `ns0`.
-    */
-  private def resolvePurityAndEffect(purAndEff0: NamedAst.PurityAndEffect, wildness: Wildness, env: ListMap[String, Resolution], taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], ns0: Name.NName, root: NamedAst.Root)(implicit flix: Flix): Validation[UnkindedType.PurityAndEffect, ResolutionError] = {
-    flatMapN(semiResolvePurityAndEffect(purAndEff0, wildness, env, ns0, root)) {
-      case purAndEff => finishResolvePurityAndEffect(purAndEff, taenv)
     }
   }
 
@@ -3580,7 +3541,7 @@ object Resolver {
     * Creates an environment from the given spec.
     */
   private def mkSpecEnv(spec: ResolvedAst.Spec): ListMap[String, Resolution] = spec match {
-    case ResolvedAst.Spec(doc, ann, mod, tparams, fparams, tpe, purAndEff, tconstrs, econstrs, loc) =>
+    case ResolvedAst.Spec(doc, ann, mod, tparams, fparams, tpe, pur, tconstrs, econstrs, loc) =>
       mkTypeParamEnv(tparams.tparams) ++ mkFormalParamEnv(fparams)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -2794,6 +2794,28 @@ object Weeder {
           purOpt.getOrElse(WeededAst.Type.True(loc))
       }
 
+    case ParsedAst.Type.Read(sp1, tpes0, sp2) =>
+      val tpesVal = traverse(tpes0)(visitType)
+      val loc = mkSL(sp1, sp2)
+      mapN(tpesVal) {
+        case tpes =>
+          val purOpt = tpes.reduceLeftOption({
+            case (acc, tpe) => WeededAst.Type.And(acc, WeededAst.Type.Read(tpe, loc), loc)
+          }: (WeededAst.Type, WeededAst.Type) => WeededAst.Type)
+          purOpt.getOrElse(WeededAst.Type.True(loc))
+      }
+
+    case ParsedAst.Type.Write(sp1, tpes0, sp2) =>
+      val tpesVal = traverse(tpes0)(visitType)
+      val loc = mkSL(sp1, sp2)
+      mapN(tpesVal) {
+        case tpes =>
+          val purOpt = tpes.reduceLeftOption({
+            case (acc, tpe) => WeededAst.Type.And(acc, WeededAst.Type.Write(tpe, loc), loc)
+          }: (WeededAst.Type, WeededAst.Type) => WeededAst.Type)
+          purOpt.getOrElse(WeededAst.Type.True(loc))
+      }
+
     case ParsedAst.Type.CaseSet(sp1, cases, sp2) =>
       val loc = mkSL(sp1, sp2)
       WeededAst.Type.CaseSet(cases.toList, loc).toSuccess
@@ -3424,6 +3446,8 @@ object Weeder {
     case ParsedAst.Type.Intersection(tpe1, _, _) => leftMostSourcePosition(tpe1)
     case ParsedAst.Type.Union(tpe1, _, _) => leftMostSourcePosition(tpe1)
     case ParsedAst.Type.EffectSet(sp1, _, _) => sp1
+    case ParsedAst.Type.Read(sp1, _, _) => sp1
+    case ParsedAst.Type.Write(sp1, _, _) => sp1
     case ParsedAst.Type.CaseComplement(sp1, _, _) => sp1
     case ParsedAst.Type.CaseDifference(tpe1, _, _) => leftMostSourcePosition(tpe1)
     case ParsedAst.Type.CaseIntersection(tpe1, _, _) => leftMostSourcePosition(tpe1)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1801,7 +1801,8 @@ object Weeder {
       val tVal = visitTypeNoWild(declaredType)
       val fVal = traverseOpt(declaredEff)(visitType)
       mapN(eVal, tVal, fVal) {
-        case (e, t, f) => WeededAst.Expression.UncheckedCast(e, t, f, mkSL(sp1, sp2))
+        case (e, t, f) =>
+          WeededAst.Expression.UncheckedCast(e, t, f, mkSL(sp1, sp2))
       }
 
     case ParsedAst.Expression.UncheckedMaskingCast(sp1, exp, sp2) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -2773,6 +2773,15 @@ object Weeder {
         case (t1, t2) => WeededAst.Type.Or(t1, t2, mkSL(sp1, sp2))
       }
 
+    case ParsedAst.Type.Difference(tpe1, tpe2, sp2) =>
+      val sp1 = leftMostSourcePosition(tpe1)
+      val t1Val = visitType(tpe1)
+      val t2Val = visitType(tpe2)
+      val loc = mkSL(sp1, sp2)
+      mapN(t1Val, t2Val) {
+        case (t1, t2) => WeededAst.Type.And(t1, WeededAst.Type.Not(t2, loc), loc)
+      }
+
     case ParsedAst.Type.EffectSet(sp1, tpes0, sp2) =>
       val checkVal = traverseX(tpes0)(checkEffectSetElement)
       val tpesVal = traverse(tpes0)(visitType)
@@ -3410,6 +3419,11 @@ object Weeder {
     case ParsedAst.Type.Apply(tpe1, _, _) => leftMostSourcePosition(tpe1)
     case ParsedAst.Type.True(sp1, _) => sp1
     case ParsedAst.Type.False(sp1, _) => sp1
+    case ParsedAst.Type.Complement(sp1, _, _) => sp1
+    case ParsedAst.Type.Difference(tpe1, _, _) => leftMostSourcePosition(tpe1)
+    case ParsedAst.Type.Intersection(tpe1, _, _) => leftMostSourcePosition(tpe1)
+    case ParsedAst.Type.Union(tpe1, _, _) => leftMostSourcePosition(tpe1)
+    case ParsedAst.Type.EffectSet(sp1, _, _) => sp1
     case ParsedAst.Type.CaseComplement(sp1, _, _) => sp1
     case ParsedAst.Type.CaseDifference(tpe1, _, _) => leftMostSourcePosition(tpe1)
     case ParsedAst.Type.CaseIntersection(tpe1, _, _) => leftMostSourcePosition(tpe1)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -18,9 +18,9 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.{Denotation, Fixity}
-import ca.uwaterloo.flix.language.ast.ParsedAst.{Effect, EffectSet, TypeParams}
-import ca.uwaterloo.flix.language.ast.WeededAst.Pattern
-import ca.uwaterloo.flix.language.ast._
+import ca.uwaterloo.flix.language.ast.ParsedAst.{TypeParams}
+import ca.uwaterloo.flix.language.ast.WeededAst.{Pattern}
+import ca.uwaterloo.flix.language.ast.{Type, _}
 import ca.uwaterloo.flix.language.errors.WeederError
 import ca.uwaterloo.flix.language.errors.WeederError._
 import ca.uwaterloo.flix.util.Validation._
@@ -181,7 +181,7 @@ object Weeder {
     * Performs weeding on the given sig declaration `s0`.
     */
   private def visitSig(s0: ParsedAst.Declaration.Sig)(implicit flix: Flix): Validation[List[WeededAst.Declaration.Sig], WeederError] = s0 match {
-    case ParsedAst.Declaration.Sig(doc0, ann, mods, sp1, ident, tparams0, fparams0, tpe0, purOrEff, tconstrs0, exp0, sp2) =>
+    case ParsedAst.Declaration.Sig(doc0, ann, mods, sp1, ident, tparams0, fparams0, tpe0, pur0, tconstrs0, exp0, sp2) =>
       val doc = visitDoc(doc0)
 
       val annVal = visitAnnotations(ann)
@@ -190,14 +190,14 @@ object Weeder {
       val identVal = visitName(ident)
       val tparamsVal = visitKindedTypeParams(tparams0)
       val formalsVal = visitFormalParams(fparams0, Presence.Required)
-      val purAndEff = visitPurityAndEffect(purOrEff)
+      val tpeVal = visitType(tpe0)
+      val purVal = traverseOpt(pur0)(visitType)
       val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint)
       val expVal = traverseOpt(exp0)(visitExp(_, SyntacticEnv.Top))
 
-      mapN(annVal, modVal, pubVal, identVal, tparamsVal, formalsVal, tconstrsVal, expVal) {
-        case (as, mod, _, _, tparams, fparams, tconstrs, exp) =>
-          val tpe = visitType(tpe0)
-          List(WeededAst.Declaration.Sig(doc, as, mod, ident, tparams, fparams, exp, tpe, purAndEff, tconstrs, mkSL(sp1, sp2)))
+      mapN(annVal, modVal, pubVal, identVal, tparamsVal, formalsVal, tpeVal, purVal, tconstrsVal, expVal) {
+        case (as, mod, _, _, tparams, fparams, tpe, pur, tconstrs, exp) =>
+          List(WeededAst.Declaration.Sig(doc, as, mod, ident, tparams, fparams, exp, tpe, pur, tconstrs, mkSL(sp1, sp2)))
       }
   }
 
@@ -207,16 +207,16 @@ object Weeder {
   private def visitInstance(i0: ParsedAst.Declaration.Instance)(implicit flix: Flix): Validation[List[WeededAst.Declaration.Instance], WeederError] = i0 match {
     case ParsedAst.Declaration.Instance(doc0, ann0, mods0, sp1, clazz, tpe0, tconstrs0, assocs0, defs0, sp2) =>
       val doc = visitDoc(doc0)
-      val tpe = visitType(tpe0)
 
       val annVal = visitAnnotations(ann0)
       val modsVal = visitModifiers(mods0, legalModifiers = Set.empty)
+      val tpeVal = visitType(tpe0)
       val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint)
       val defsVal = traverse(defs0)(visitInstanceDef)
       val assocsVal = traverse(assocs0)(visitAssocTypeDef)
 
-      mapN(annVal, modsVal, assocsVal, defsVal, tconstrsVal) {
-        case (ann, mods, assocs, defs, tconstrs) =>
+      mapN(annVal, modsVal, tpeVal, assocsVal, defsVal, tconstrsVal) {
+        case (ann, mods, tpe, assocs, defs, tconstrs) =>
           List(WeededAst.Declaration.Instance(doc, ann, mods, clazz, tpe, tconstrs, assocs.flatten, defs.flatten, mkSL(sp1, sp2)))
       }
 
@@ -240,7 +240,7 @@ object Weeder {
     * Performs weeding on the given def declaration `d0`.
     */
   private def visitDef(d0: ParsedAst.Declaration.Def, legalModifiers: Set[Ast.Modifier], requiresPublic: Boolean)(implicit flix: Flix): Validation[List[WeededAst.Declaration.Def], WeederError] = d0 match {
-    case ParsedAst.Declaration.Def(doc0, ann, mods, sp1, ident, tparams0, fparams0, tpe0, purOrEff, tconstrs0, econstrs0, exp0, sp2) =>
+    case ParsedAst.Declaration.Def(doc0, ann, mods, sp1, ident, tparams0, fparams0, tpe0, pur0, tconstrs0, econstrs0, exp0, sp2) =>
       flix.subtask(ident.name, sample = true)
 
       val doc = visitDoc(doc0)
@@ -251,14 +251,14 @@ object Weeder {
       val expVal = visitExp(exp0, SyntacticEnv.Top)
       val tparamsVal = visitKindedTypeParams(tparams0)
       val formalsVal = visitFormalParams(fparams0, Presence.Required)
-      val purAndEff = visitPurityAndEffect(purOrEff)
+      val tpeVal = visitType(tpe0)
+      val purVal = traverseOpt(pur0)(visitType)
       val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint)
       val econstrsVal = traverse(econstrs0)(visitEqualityConstraint)
 
-      mapN(annVal, modVal, pubVal, identVal, tparamsVal, formalsVal, expVal, tconstrsVal, econstrsVal) {
-        case (as, mod, _, _, tparams, fparams, exp, tconstrs, econstrs) =>
-          val tpe = visitType(tpe0)
-          List(WeededAst.Declaration.Def(doc, as, mod, ident, tparams, fparams, exp, tpe, purAndEff, tconstrs, econstrs, mkSL(sp1, sp2)))
+      mapN(annVal, modVal, pubVal, identVal, tparamsVal, formalsVal, tpeVal, purVal, expVal, tconstrsVal, econstrsVal) {
+        case (as, mod, _, _, tparams, fparams, tpe, pur, exp, tconstrs, econstrs) =>
+          List(WeededAst.Declaration.Def(doc, as, mod, ident, tparams, fparams, exp, tpe, pur, tconstrs, econstrs, mkSL(sp1, sp2)))
       }
   }
 
@@ -278,11 +278,10 @@ object Weeder {
 
       mapN(annVal, modVal, identVal, tparamsVal, formalsVal, expVal, tconstrsVal) {
         case (ann, mod, _, tparams, fs, exp, tconstrs) =>
-          val ts = fs.map(_.tpe.get)
-          val purAndEff = WeededAst.PurityAndEffect(None, None)
+          val pur = None
           val tpe = WeededAst.Type.Ambiguous(Name.mkQName("Bool"), ident.loc)
           val econstrs = Nil // TODO ASSOC-TYPES allow econstrs here
-          List(WeededAst.Declaration.Def(doc, ann, mod, ident, tparams, fs, exp, tpe, purAndEff, tconstrs, econstrs, mkSL(sp1, sp2)))
+          List(WeededAst.Declaration.Def(doc, ann, mod, ident, tparams, fs, exp, tpe, pur, tconstrs, econstrs, mkSL(sp1, sp2)))
       }
   }
 
@@ -307,7 +306,7 @@ object Weeder {
     * Performs weeding on the given effect operation.
     */
   private def visitOp(d0: ParsedAst.Declaration.Op)(implicit flix: Flix): Validation[WeededAst.Declaration.Op, WeederError] = d0 match {
-    case ParsedAst.Declaration.Op(doc0, ann0, mod0, sp1, ident, tparams0, fparamsOpt0, tpe0, purAndEff0, tconstrs0, sp2) =>
+    case ParsedAst.Declaration.Op(doc0, ann0, mod0, sp1, ident, tparams0, fparamsOpt0, tpe0, pur0, tconstrs0, sp2) =>
       val doc = visitDoc(doc0)
       val annVal = visitAnnotations(ann0)
       val modVal = visitModifiers(mod0, legalModifiers = Set(Ast.Modifier.Public))
@@ -315,14 +314,12 @@ object Weeder {
       val identVal = visitName(ident)
       val tparamsVal = requireNoTypeParams(tparams0)
       val fparamsVal = visitFormalParams(fparamsOpt0, Presence.Required)
-      val tpe = visitType(tpe0)
+      val tpeVal = visitType(tpe0)
       val unitVal = requireUnit(tpe0, ident.loc)
-      val purAndEffVal = requireNoEffect(purAndEff0, ident.loc)
+      val purVal = requireNoEffect(pur0, ident.loc)
       val tconstrsVal = traverse(tconstrs0)(visitTypeConstraint)
-      mapN(annVal, modVal, pubVal, identVal, tparamsVal, fparamsVal, unitVal, purAndEffVal, tconstrsVal) {
-        case (ann, mod, _, _, _, fparams, _, _, tconstrs) =>
-          val ts = fparams.map(_.tpe.get)
-          val purAndEff = WeededAst.PurityAndEffect(None, None)
+      mapN(annVal, modVal, pubVal, identVal, tparamsVal, fparamsVal, tpeVal, unitVal, purVal, tconstrsVal) {
+        case (ann, mod, _, _, _, fparams, tpe, _, _, tconstrs) =>
           WeededAst.Declaration.Op(doc, ann, mod, ident, fparams, tpe, tconstrs, mkSL(sp1, sp2));
       }
   }
@@ -341,17 +338,26 @@ object Weeder {
         // Case 1: empty enum
         case (None, None) => Map.empty.toSuccess
         // Case 2: singleton enum
-        case (Some(t0), None) => Map(ident -> WeededAst.Case(ident, visitType(t0), mkSL(sp1, sp2))).toSuccess
+        case (Some(t0), None) =>
+          val tVal = visitType(t0)
+          mapN(tVal) {
+            case t => Map(ident -> WeededAst.Case(ident, t, mkSL(sp1, sp2)))
+          }
         // Case 3: multiton enum
         case (None, Some(cs0)) =>
           /*
            * Check for `DuplicateTag`.
            */
+          // TODO clean up
           Validation.fold[ParsedAst.Case, Map[Name.Ident, WeededAst.Case], WeederError](cs0, Map.empty) {
             case (macc, caze: ParsedAst.Case) =>
               val tagName = caze.ident
               macc.get(tagName) match {
-                case None => (macc + (tagName -> visitCase(caze))).toSuccess
+                case None =>
+                  val cazeVal = visitCase(caze)
+                  mapN(cazeVal) {
+                    case caze => (macc + (tagName -> caze))
+                  }
                 case Some(otherTag) =>
                   val enumName = ident.name
                   val loc1 = otherTag.ident.loc
@@ -389,7 +395,11 @@ object Weeder {
         // Case 1: empty enum
         case (None, None) => Map.empty.toSuccess
         // Case 2: singleton enum
-        case (Some(t0), None) => Map(ident -> WeededAst.RestrictableCase(ident, visitType(t0), mkSL(sp1, sp2))).toSuccess
+        case (Some(t0), None) =>
+          val tVal = visitType(t0)
+          mapN(tVal) {
+            case t => Map(ident -> WeededAst.RestrictableCase(ident, t, mkSL(sp1, sp2)))
+          }
         // Case 3: multiton enum
         case (None, Some(cs0)) =>
           /*
@@ -399,7 +409,11 @@ object Weeder {
             case (macc, caze: ParsedAst.RestrictableCase) =>
               val tagName = caze.ident
               macc.get(tagName) match {
-                case None => (macc + (tagName -> visitRestrictableCase(caze))).toSuccess
+                case None =>
+                  val cazeVal = visitRestrictableCase(caze)
+                  mapN(cazeVal) {
+                    case caze => (macc + (tagName -> caze))
+                  }
                 case Some(otherTag) =>
                   val enumName = ident.name
                   val loc1 = otherTag.ident.loc
@@ -425,19 +439,27 @@ object Weeder {
   /**
     * Performs weeding on the given enum case `c0`.
     */
-  private def visitCase(c0: ParsedAst.Case)(implicit flix: Flix): WeededAst.Case = c0 match {
+  private def visitCase(c0: ParsedAst.Case)(implicit flix: Flix): Validation[WeededAst.Case, WeederError] = c0 match {
     case ParsedAst.Case(sp1, ident, tpe0, sp2) =>
-      val tpe = tpe0.map(visitType).getOrElse(WeededAst.Type.Unit(ident.loc))
-      WeededAst.Case(ident, tpe, mkSL(sp1, sp2))
+      val tpeVal = traverseOpt(tpe0)(visitType)
+      mapN(tpeVal) {
+        case tpeOpt =>
+          val tpe = tpeOpt.getOrElse(WeededAst.Type.Unit(ident.loc))
+          WeededAst.Case(ident, tpe, mkSL(sp1, sp2))
+      }
   }
 
   /**
     * Performs weeding on the given enum case `c0`.
     */
-  private def visitRestrictableCase(c0: ParsedAst.RestrictableCase)(implicit flix: Flix): WeededAst.RestrictableCase = c0 match {
+  private def visitRestrictableCase(c0: ParsedAst.RestrictableCase)(implicit flix: Flix): Validation[WeededAst.RestrictableCase, WeederError] = c0 match {
     case ParsedAst.RestrictableCase(sp1, ident, tpe0, sp2) =>
-      val tpe = tpe0.map(visitType).getOrElse(WeededAst.Type.Unit(ident.loc))
-      WeededAst.RestrictableCase(ident, tpe, mkSL(sp1, sp2))
+      val tpeVal = traverseOpt(tpe0)(visitType)
+      mapN(tpeVal) {
+        case tpeOpt =>
+          val tpe = tpeOpt.getOrElse(WeededAst.Type.Unit(ident.loc))
+          WeededAst.RestrictableCase(ident, tpe, mkSL(sp1, sp2))
+      }
   }
 
   /**
@@ -448,10 +470,10 @@ object Weeder {
       val doc = visitDoc(doc0)
       val modVal = visitModifiers(mod0, legalModifiers = Set(Ast.Modifier.Public))
       val tparamsVal = visitTypeParams(tparams0)
+      val tpeVal = visitType(tpe0)
 
-      mapN(modVal, tparamsVal) {
-        case (mod, tparams) =>
-          val tpe = visitType(tpe0)
+      mapN(modVal, tparamsVal, tpeVal) {
+        case (mod, tparams, tpe) =>
           List(WeededAst.Declaration.TypeAlias(doc, mod, ident, tparams, tpe, mkSL(sp1, sp2)))
       }
   }
@@ -490,15 +512,17 @@ object Weeder {
     case ParsedAst.Declaration.AssocTypeDef(doc0, mod0, sp1, ident, args0, tpe0, sp2) =>
       val doc = visitDoc(doc0)
       val modVal = visitModifiers(mod0, legalModifiers = Set(Ast.Modifier.Public))
-      val argVal = args0.map(visitType).toList match {
+      val argVal0 = args0.toList match {
         case hd :: Nil => hd.toSuccess
         case ts => NonUnaryAssocType(ts.length, ident.loc).toFailure
       }
-      val tpe = visitType(tpe0)
+      // TODO avoid short-circuiting with flatMap
+      val argVal = flatMapN(argVal)(visitType)
+      val tpeVal = visitType(tpe0)
       val loc = mkSL(sp1, sp2)
 
-      mapN(modVal, argVal) {
-        case (mod, arg) =>
+      mapN(modVal, argVal, tpeVal) {
+        case (mod, arg, tpe) =>
           List(WeededAst.Declaration.AssocTypeDef(doc, mod, ident, arg, tpe, loc))
       }
   }
@@ -512,14 +536,14 @@ object Weeder {
       val loc = mkSL(sp1, sp2)
       val modVal = visitModifiers(mod0, legalModifiers = Set(Ast.Modifier.Public))
       val tparamsVal = visitTypeParams(tparams0)
+      val termTypesVal = traverse(attr)(a => visitType(a.tpe))
 
       //
       // Rewrite the relation declaration to a type alias.
       //
-      mapN(modVal, tparamsVal) {
-        case (mod, tparams) =>
-          val termTypes = attr.map(a => visitType(a.tpe))
-          val tpe = WeededAst.Type.Relation(termTypes.toList, ident.loc)
+      mapN(modVal, tparamsVal, termTypesVal) {
+        case (mod, tparams, termTypes) =>
+          val tpe = WeededAst.Type.Relation(termTypes, ident.loc)
           List(WeededAst.Declaration.TypeAlias(doc, mod, ident, tparams, tpe, loc))
       }
   }
@@ -533,14 +557,14 @@ object Weeder {
       val loc = mkSL(sp1, sp2)
       val modVal = visitModifiers(mod0, legalModifiers = Set(Ast.Modifier.Public))
       val tparamsVal = visitTypeParams(tparams0)
+      val termTypesVal = traverse(attr)(a => visitType(a.tpe))
 
       //
       // Rewrite the lattice declaration to a type alias.
       //
-      mapN(modVal, tparamsVal) {
-        case (mod, tparams) =>
-          val termTypes = attr.map(a => visitType(a.tpe))
-          val tpe = WeededAst.Type.Lattice(termTypes.toList, ident.loc)
+      mapN(modVal, tparamsVal, termTypesVal) {
+        case (mod, tparams, termTypes) =>
+          val tpe = WeededAst.Type.Lattice(termTypes, ident.loc)
           List(WeededAst.Declaration.TypeAlias(doc, mod, ident, tparams, tpe, loc))
       }
   }
@@ -1187,31 +1211,31 @@ object Weeder {
       // Visit the inner expression exp2.
       //
       impl match {
-        case ParsedAst.JvmOp.Constructor(fqn, sig, tpe0, purAndEff0, ident) =>
+        case ParsedAst.JvmOp.Constructor(fqn, sig0, tpe0, pur0, ident) =>
+
+          val tsVal = traverse(sig0)(visitType)
+          val e2Val = visitExp(exp2, senv)
+          val tpeVal = visitType(tpe0)
+          val purVal = traverseOpt(pur0)(visitType)
+
           //
           // Introduce a let-bound lambda: (args...) -> InvokeConstructor(args) as tpe & pur
           //
-          mapN(visitExp(exp2, senv)) {
-            case e2 =>
+          mapN(tsVal, e2Val, tpeVal, purVal) {
+            case (ts, e2, tpe, pur) =>
               // Compute the class name.
               val className = fqn.toString
-
-              val tpe = visitType(tpe0)
-              val purAndEff = visitPurityAndEffect(purAndEff0)
 
               //
               // Case 1: No arguments.
               //
-              if (sig.isEmpty) {
+              if (ts.isEmpty) {
                 val fparam = WeededAst.FormalParam(Name.Ident(sp1, "_", sp2), Ast.Modifiers.Empty, Some(WeededAst.Type.Unit(loc)), loc)
                 val call = WeededAst.Expression.InvokeConstructor(className, Nil, Nil, loc)
-                val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), purAndEff, loc)
+                val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), pur, loc)
                 val e1 = WeededAst.Expression.Lambda(fparam, lambdaBody, loc)
-                return WeededAst.Expression.Let(ident, Ast.Modifiers.Empty, e1, e2, loc).toSuccess
+                return WeededAst.Expression.Let(ident, Ast.Modifiers.Empty, e1, e2, loc).toSuccess // MATT evil early return
               }
-
-              // Compute the types of declared parameters.
-              val ts = sig.map(visitType).toList
 
               // Introduce a formal parameter (of appropriate type) for each declared argument.
               val fs = ts.zipWithIndex.map {
@@ -1229,27 +1253,28 @@ object Weeder {
 
               // Assemble the lambda expression.
               val call = WeededAst.Expression.InvokeConstructor(className, as, ts, loc)
-              val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), purAndEff, loc)
+              val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), pur, loc)
               val e1 = mkCurried(fs, lambdaBody, loc)
               WeededAst.Expression.Let(ident, Ast.Modifiers.Empty, e1, e2, loc)
           }
 
-        case ParsedAst.JvmOp.Method(fqn, sig, tpe0, purAndEff0, identOpt) =>
+        case ParsedAst.JvmOp.Method(fqn, sig0, tpe0, pur0, identOpt) =>
+
+          val classMethodVal = parseClassAndMember(fqn)
+          val tsVal = traverse(sig0)(visitType)
+          val tpeVal = visitType(tpe0)
+          val purVal = traverseOpt(pur0)(visitType)
+          val e2Val = visitExp(exp2, senv)
+
           //
           // Introduce a let-bound lambda: (obj, args...) -> InvokeMethod(obj, args) as tpe & pur
           //
-          mapN(parseClassAndMember(fqn), visitExp(exp2, senv)) {
-            case ((className, methodName), e2) =>
+          mapN(classMethodVal, tsVal, tpeVal, purVal, e2Val) {
+            case ((className, methodName), ts, tpe, pur, e2) =>
               // Compute the name of the let-bound variable.
               val ident = identOpt.getOrElse(Name.Ident(fqn.sp1, methodName, fqn.sp2))
 
               val receiverType = WeededAst.Type.Native(className, loc)
-
-              val tpe = visitType(tpe0)
-              val purAndEff = visitPurityAndEffect(purAndEff0)
-
-              // Compute the types of declared parameters.
-              val ts = sig.map(visitType).toList
 
               // Introduce a formal parameter for the object argument.
               val objId = Name.Ident(sp1, "obj" + Flix.Delimiter, sp2)
@@ -1272,37 +1297,38 @@ object Weeder {
 
               // Assemble the lambda expression.
               val call = WeededAst.Expression.InvokeMethod(className, methodName, as.head, as.tail, ts, tpe, loc)
-              val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), purAndEff, loc)
+              val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), pur, loc)
               val e1 = mkCurried(fs, lambdaBody, loc)
               WeededAst.Expression.Let(ident, Ast.Modifiers.Empty, e1, e2, loc)
           }
 
-        case ParsedAst.JvmOp.StaticMethod(fqn, sig, tpe0, purAndEff0, identOpt) =>
+        case ParsedAst.JvmOp.StaticMethod(fqn, sig0, tpe0, pur0, identOpt) =>
+
+          val classMethodVal = parseClassAndMember(fqn)
+          val tsVal = traverse(sig0)(visitType)
+          val tpeVal = visitType(tpe0)
+          val purVal = traverseOpt(pur0)(visitType)
+          val e2Val = visitExp(exp2, senv)
+
           //
           // Introduce a let-bound lambda: (args...) -> InvokeStaticMethod(args) as tpe & pur
           //
-          mapN(parseClassAndMember(fqn), visitExp(exp2, senv)) {
-            case ((className, methodName), e2) =>
+          mapN(classMethodVal, tsVal, tpeVal, purVal, e2Val) {
+            case ((className, methodName), ts, tpe, pur, e2) =>
 
               // Compute the name of the let-bound variable.
               val ident = identOpt.getOrElse(Name.Ident(fqn.sp1, methodName, fqn.sp2))
 
-              val tpe = visitType(tpe0)
-              val purAndEff = visitPurityAndEffect(purAndEff0)
-
               //
               // Case 1: No arguments.
               //
-              if (sig.isEmpty) {
+              if (ts.isEmpty) {
                 val fparam = WeededAst.FormalParam(Name.Ident(sp1, "_", sp2), Ast.Modifiers.Empty, Some(WeededAst.Type.Unit(loc)), loc)
                 val call = WeededAst.Expression.InvokeStaticMethod(className, methodName, Nil, Nil, tpe, loc)
-                val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), purAndEff, loc)
+                val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), pur, loc)
                 val e1 = WeededAst.Expression.Lambda(fparam, lambdaBody, loc)
                 return WeededAst.Expression.Let(ident, Ast.Modifiers.Empty, e1, e2, loc).toSuccess
               }
-
-              // Compute the types of declared parameters.
-              val ts = sig.map(visitType).toList
 
               // Introduce a formal parameter (of appropriate type) for each declared argument.
               val fs = ts.zipWithIndex.map {
@@ -1320,38 +1346,45 @@ object Weeder {
 
               // Assemble the lambda expression.
               val call = WeededAst.Expression.InvokeStaticMethod(className, methodName, as, ts, tpe, loc)
-              val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), purAndEff, loc)
+              val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), pur, loc)
               val e1 = mkCurried(fs, lambdaBody, loc)
               WeededAst.Expression.Let(ident, Ast.Modifiers.Empty, e1, e2, loc)
           }
 
-        case ParsedAst.JvmOp.GetField(fqn, tpe0, purAndEff0, ident) =>
+        case ParsedAst.JvmOp.GetField(fqn, tpe0, pur0, ident) =>
+
+          val classMethodVal = parseClassAndMember(fqn)
+          val tpeVal = visitType(tpe0)
+          val purVal = traverseOpt(pur0)(visitType)
+          val e2Val = visitExp(exp2, senv)
+
           //
           // Introduce a let-bound lambda: o -> GetField(o) as tpe & pur
           //
-          mapN(parseClassAndMember(fqn), visitExp(exp2, senv)) {
-
-            case ((className, fieldName), e2) =>
-              val tpe = visitType(tpe0)
-              val purAndEff = visitPurityAndEffect(purAndEff0)
+          mapN(classMethodVal, tpeVal, purVal, e2Val) {
+            case ((className, fieldName), tpe, pur, e2) =>
 
               val objectId = Name.Ident(sp1, "o" + Flix.Delimiter, sp2)
               val objectExp = WeededAst.Expression.Ambiguous(Name.mkQName(objectId), loc)
               val objectParam = WeededAst.FormalParam(objectId, Ast.Modifiers.Empty, None, loc)
               val call = WeededAst.Expression.GetField(className, fieldName, objectExp, loc)
-              val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), purAndEff, loc)
+              val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), pur, loc)
               val e1 = WeededAst.Expression.Lambda(objectParam, lambdaBody, loc)
               WeededAst.Expression.Let(ident, Ast.Modifiers.Empty, e1, e2, loc)
           }
 
-        case ParsedAst.JvmOp.PutField(fqn, tpe0, purAndEff0, ident) =>
+        case ParsedAst.JvmOp.PutField(fqn, tpe0, pur0, ident) =>
+
+          val classMethodVal = parseClassAndMember(fqn)
+          val tpeVal = visitType(tpe0)
+          val purVal = traverseOpt(pur0)(visitType)
+          val e2Val = visitExp(exp2, senv)
+
           //
           // Introduce a let-bound lambda: (o, v) -> PutField(o, v) as tpe & pur
           //
-          mapN(parseClassAndMember(fqn), visitExp(exp2, senv)) {
-            case ((className, fieldName), e2) =>
-              val tpe = visitType(tpe0)
-              val purAndEff = visitPurityAndEffect(purAndEff0)
+          mapN(classMethodVal, tpeVal, purVal, e2Val) {
+            case ((className, fieldName), tpe, pur, e2) =>
 
               val objectId = Name.Ident(sp1, "o" + Flix.Delimiter, sp2)
               val valueId = Name.Ident(sp1, "v" + Flix.Delimiter, sp2)
@@ -1360,51 +1393,60 @@ object Weeder {
               val objectParam = WeededAst.FormalParam(objectId, Ast.Modifiers.Empty, None, loc)
               val valueParam = WeededAst.FormalParam(valueId, Ast.Modifiers.Empty, None, loc)
               val call = WeededAst.Expression.PutField(className, fieldName, objectExp, valueExp, loc)
-              val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), purAndEff, loc)
+              val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), pur, loc)
               val e1 = mkCurried(objectParam :: valueParam :: Nil, lambdaBody, loc)
               WeededAst.Expression.Let(ident, Ast.Modifiers.Empty, e1, e2, loc)
           }
 
-        case ParsedAst.JvmOp.GetStaticField(fqn, tpe0, purAndEff0, ident) =>
+        case ParsedAst.JvmOp.GetStaticField(fqn, tpe0, pur0, ident) =>
+
+          val classMethodVal = parseClassAndMember(fqn)
+          val tpeVal = visitType(tpe0)
+          val purVal = traverseOpt(pur0)(visitType)
+          val e2Val = visitExp(exp2, senv)
+
           //
           // Introduce a let-bound lambda: _: Unit -> GetStaticField.
           //
-          mapN(parseClassAndMember(fqn), visitExp(exp2, senv)) {
-            case ((className, fieldName), e2) =>
-              val tpe = visitType(tpe0)
-              val purAndEff = visitPurityAndEffect(purAndEff0)
+          mapN(classMethodVal, tpeVal, purVal, e2Val) {
+            case ((className, fieldName), tpe, pur, e2) =>
 
               val unitId = Name.Ident(sp1, "_", sp2)
               val unitParam = WeededAst.FormalParam(unitId, Ast.Modifiers.Empty, Some(WeededAst.Type.Unit(loc)), loc)
               val call = WeededAst.Expression.GetStaticField(className, fieldName, loc)
-              val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), purAndEff, loc)
+              val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), pur, loc)
               val e1 = WeededAst.Expression.Lambda(unitParam, lambdaBody, loc)
               WeededAst.Expression.Let(ident, Ast.Modifiers.Empty, e1, e2, loc)
           }
 
-        case ParsedAst.JvmOp.PutStaticField(fqn, tpe0, purAndEff0, ident) =>
+        case ParsedAst.JvmOp.PutStaticField(fqn, tpe0, pur0, ident) =>
+
+          val classMethodVal = parseClassAndMember(fqn)
+          val tpeVal = visitType(tpe0)
+          val purVal = traverseOpt(pur0)(visitType)
+          val e2Val = visitExp(exp2, senv)
+
           //
           // Introduce a let-bound lambda: x -> PutStaticField(x).
           //
-          mapN(parseClassAndMember(fqn), visitExp(exp2, senv)) {
-            case ((className, fieldName), e2) =>
-              val tpe = visitType(tpe0)
-              val purAndEff = visitPurityAndEffect(purAndEff0)
+          mapN(classMethodVal, tpeVal, purVal, e2Val) {
+            case ((className, fieldName), tpe, pur, e2) =>
 
               val valueId = Name.Ident(sp1, "v" + Flix.Delimiter, sp2)
               val valueExp = WeededAst.Expression.Ambiguous(Name.mkQName(valueId), loc)
               val valueParam = WeededAst.FormalParam(valueId, Ast.Modifiers.Empty, None, loc)
               val call = WeededAst.Expression.PutStaticField(className, fieldName, valueExp, loc)
-              val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), purAndEff, loc)
+              val lambdaBody = WeededAst.Expression.UncheckedCast(call, Some(tpe), pur, loc)
               val e1 = WeededAst.Expression.Lambda(valueParam, lambdaBody, loc)
               WeededAst.Expression.Let(ident, Ast.Modifiers.Empty, e1, e2, loc)
           }
       }
 
     case ParsedAst.Expression.NewObject(sp1, tpe, methods, sp2) =>
-      mapN(traverse(methods)(visitJvmMethod(_, senv))) {
-        case ms =>
-          val t = visitType(tpe)
+      val tVal = visitType(tpe)
+      val msVal = traverse(methods)(visitJvmMethod(_, senv))
+      mapN(tVal, msVal) {
+        case (t, ms) =>
           WeededAst.Expression.NewObject(t, ms, mkSL(sp1, sp2))
       }.recoverOne {
         case err: WeederError => WeededAst.Expression.Error(err)
@@ -1437,11 +1479,11 @@ object Weeder {
     case ParsedAst.Expression.TypeMatch(sp1, exp, rules, sp2) =>
       val loc = mkSL(sp1, sp2)
       val rulesVal = traverse(rules) {
-        case ParsedAst.MatchTypeRule(ident, tpe, body) =>
-          val t = visitType(tpe)
-          mapN(visitExp(body, senv)) {
-            // Pattern match without guard.
-            case e => WeededAst.MatchTypeRule(ident, t, e)
+        case ParsedAst.MatchTypeRule(ident, tpe0, body0) =>
+          val tpeVal = visitType(tpe0)
+          val bodyVal = visitExp(body0, senv)
+          mapN(tpeVal, bodyVal) {
+            case (tpe, body) => WeededAst.MatchTypeRule(ident, tpe, body)
           }
       }
       mapN(visitExp(exp, senv), rulesVal) {
@@ -2273,7 +2315,7 @@ object Weeder {
     visit(chars0.toList, Nil)
   }
 
-    /**
+  /**
     * Performs weeding on the given literal.
     */
   private def weedLiteral(lit0: ParsedAst.Literal)(implicit flix: Flix): Validation[Ast.Constant, WeederError.IllegalLiteral] = lit0 match {
@@ -2343,8 +2385,8 @@ object Weeder {
     case ParsedAst.Literal.Regex(sp1, chars, sp2) =>
       flatMapN(weedCharSequence(chars)) {
         case string => toRegexPattern(string, mkSL(sp1, sp2)) map {
-            case patt => Ast.Constant.Regex(patt)
-          }
+          case patt => Ast.Constant.Regex(patt)
+        }
       }
   }
 
@@ -2617,14 +2659,6 @@ object Weeder {
   }
 
   /**
-    * Returns an error if an effect is present.
-    */
-  private def requireNoEffect(purAndEff: ParsedAst.PurityAndEffect, loc: SourceLocation): Validation[Unit, WeederError] = purAndEff match {
-    case ParsedAst.PurityAndEffect(None, None) => ().toSuccess
-    case ParsedAst.PurityAndEffect(_, _) => WeederError.IllegalOperationEffect(loc).toFailure
-  }
-
-  /**
     * Returns an error if the type is not Unit.
     */
   private def requireUnit(tpe: ParsedAst.Type, loc: SourceLocation): Validation[Unit, WeederError] = tpe match {
@@ -2633,160 +2667,228 @@ object Weeder {
   }
 
   /**
+    * Returns an error if a type is present.
+    */
+  private def requireNoEffect(tpe: Option[ParsedAst.Type], loc: SourceLocation): Validation[Unit, WeederError] = tpe match {
+    case Some(_) => WeederError.IllegalOperationEffect(loc)
+    case None => ().toSuccess
+  }
+
+  /**
     * Weeds the given parsed type `tpe`.
     */
-  private def visitType(tpe: ParsedAst.Type): WeededAst.Type = tpe match {
-    case ParsedAst.Type.Var(sp1, ident, sp2) => visitEffectIdent(ident)
+  private def visitType(tpe: ParsedAst.Type): Validation[WeededAst.Type, WeederError] = tpe match {
+    case ParsedAst.Type.Var(sp1, ident, sp2) => visitEffectIdent(ident).toSuccess
 
-    case ParsedAst.Type.Ambiguous(sp1, qname, sp2) => WeededAst.Type.Ambiguous(qname, mkSL(sp1, sp2))
+    case ParsedAst.Type.Ambiguous(sp1, qname, sp2) => WeededAst.Type.Ambiguous(qname, mkSL(sp1, sp2)).toSuccess
 
-    case ParsedAst.Type.Tuple(sp1, elms, sp2) => WeededAst.Type.Tuple(elms.toList.map(visitType), mkSL(sp1, sp2))
+    case ParsedAst.Type.Tuple(sp1, elms0, sp2) =>
+      val elmsVal = traverse(elms0)(visitType)
+      mapN(elmsVal) {
+        case elms => WeededAst.Type.Tuple(elms, mkSL(sp1, sp2))
+      }
 
     case ParsedAst.Type.Record(sp1, fields, restOpt, sp2) =>
-      val row = buildRecordRow(fields, restOpt, mkSL(sp1, sp2))
-      WeededAst.Type.Record(row, mkSL(sp1, sp2))
+      val rowVal = buildRecordRow(fields, restOpt, mkSL(sp1, sp2))
+      mapN(rowVal) {
+        case row => WeededAst.Type.Record(row, mkSL(sp1, sp2))
+      }
 
     case ParsedAst.Type.RecordRow(sp1, fields, restOpt, sp2) =>
       buildRecordRow(fields, restOpt, mkSL(sp1, sp2))
 
     case ParsedAst.Type.Schema(sp1, predicates, restOpt, sp2) =>
-      val row = buildSchemaRow(predicates, restOpt, mkSL(sp1, sp2))
-      WeededAst.Type.Schema(row, mkSL(sp1, sp2))
+      val rowVal = buildSchemaRow(predicates, restOpt, mkSL(sp1, sp2))
+      mapN(rowVal) {
+        case row => WeededAst.Type.Schema(row, mkSL(sp1, sp2))
+      }
 
     case ParsedAst.Type.SchemaRow(sp1, predicates, restOpt, sp2) =>
       buildSchemaRow(predicates, restOpt, mkSL(sp1, sp2))
 
-    case ParsedAst.Type.UnaryPolymorphicArrow(tpe1, tpe2, purAndEff0, sp2) =>
+    case ParsedAst.Type.UnaryPolymorphicArrow(tpe1, tpe2, pur0, sp2) =>
       val loc = mkSL(leftMostSourcePosition(tpe1), sp2)
-      val t1 = visitType(tpe1)
-      val t2 = visitType(tpe2)
-      val purAndEff = visitPurityAndEffect(purAndEff0)
-      mkArrow(t1, purAndEff, t2, loc)
+      val t1Val = visitType(tpe1)
+      val t2Val = visitType(tpe2)
+      val purVal = traverseOpt(pur0)(visitType)
+      mapN(t1Val, t2Val, purVal) {
+        case (t1, t2, pur) => mkArrow(t1, pur, t2, loc)
+      }
 
-    case ParsedAst.Type.PolymorphicArrow(sp1, tparams, tresult, purAndEff0, sp2) =>
+    case ParsedAst.Type.PolymorphicArrow(sp1, tparams, tresult, pur0, sp2) =>
       val loc = mkSL(sp1, sp2)
-      val ts = tparams.map(visitType)
-      val tr = visitType(tresult)
-      val purAndEff = visitPurityAndEffect(purAndEff0)
-      mkCurriedArrow(ts, purAndEff, tr, loc)
+      val tsVal = traverse(tparams)(visitType)
+      val trVal = visitType(tresult)
+      val purVal = traverseOpt(pur0)(visitType)
+      mapN(tsVal, trVal, purVal) {
+        case (ts, tr, pur) => mkCurriedArrow(ts, pur, tr, loc)
+      }
 
     case ParsedAst.Type.Native(sp1, fqn, sp2) =>
-      WeededAst.Type.Native(fqn.toString, mkSL(sp1, sp2))
+      WeededAst.Type.Native(fqn.toString, mkSL(sp1, sp2)).toSuccess
 
-    case ParsedAst.Type.Apply(t1, args, sp2) =>
+    case ParsedAst.Type.Apply(tpe1, args0, sp2) =>
       // Curry the type arguments.
-      val sp1 = leftMostSourcePosition(t1)
-      args.foldLeft(visitType(t1)) {
-        case (acc, t2) => WeededAst.Type.Apply(acc, visitType(t2), mkSL(sp1, sp2))
+      val sp1 = leftMostSourcePosition(tpe1)
+      val t1Val = visitType(tpe1)
+      val argsVal = traverse(args0)(visitType)
+      mapN(t1Val, argsVal) {
+        case (t1, args) =>
+          args.foldLeft(t1) {
+            case (acc, t2) => WeededAst.Type.Apply(acc, t2, mkSL(sp1, sp2))
+          }
       }
 
     case ParsedAst.Type.True(sp1, sp2) =>
-      WeededAst.Type.True(mkSL(sp1, sp2))
+      WeededAst.Type.True(mkSL(sp1, sp2)).toSuccess
 
     case ParsedAst.Type.False(sp1, sp2) =>
-      WeededAst.Type.False(mkSL(sp1, sp2))
+      WeededAst.Type.False(mkSL(sp1, sp2)).toSuccess
 
-    case ParsedAst.Type.Not(sp1, tpe, sp2) =>
-      val t = visitType(tpe)
-      WeededAst.Type.Not(t, mkSL(sp1, sp2))
+    case ParsedAst.Type.Complement(sp1, tpe, sp2) =>
+      val tVal = visitType(tpe)
+      mapN(tVal) {
+        case t => WeededAst.Type.Not(t, mkSL(sp1, sp2))
+      }
 
-    case ParsedAst.Type.And(tpe1, tpe2, sp2) =>
+    case ParsedAst.Type.Union(tpe1, tpe2, sp2) =>
       val sp1 = leftMostSourcePosition(tpe1)
-      val t1 = visitType(tpe1)
-      val t2 = visitType(tpe2)
-      WeededAst.Type.And(t1, t2, mkSL(sp1, sp2))
+      val t1Val = visitType(tpe1)
+      val t2Val = visitType(tpe2)
+      mapN(t1Val, t2Val) {
+        case (t1, t2) => WeededAst.Type.And(t1, t2, mkSL(sp1, sp2))
+      }
 
-    case ParsedAst.Type.Or(tpe1, tpe2, sp2) =>
+    case ParsedAst.Type.Intersection(tpe1, tpe2, sp2) =>
       val sp1 = leftMostSourcePosition(tpe1)
-      val t1 = visitType(tpe1)
-      val t2 = visitType(tpe2)
-      WeededAst.Type.Or(t1, t2, mkSL(sp1, sp2))
+      val t1Val = visitType(tpe1)
+      val t2Val = visitType(tpe2)
+      mapN(t1Val, t2Val) {
+        case (t1, t2) => WeededAst.Type.Or(t1, t2, mkSL(sp1, sp2))
+      }
 
-    case ParsedAst.Type.Effect(sp1, eff0, sp2) =>
+    case ParsedAst.Type.EffectSet(sp1, tpes0, sp2) =>
+      val checkVal = traverse(tpes0)(checkEffectSetElement)
+      val tpesVal = traverse(tpes0)(visitType)
       val loc = mkSL(sp1, sp2)
-      val effs = visitEffectSet(eff0)
-      // NB: safe to reduce since effs is never empty
-      val effOpt = effs.reduceLeftOption({
-        case (acc, eff) => WeededAst.Type.Union(acc, eff, loc)
-      }: (WeededAst.Type, WeededAst.Type) => WeededAst.Type)
-      effOpt.getOrElse(WeededAst.Type.Empty(loc))
+      mapN(checkVal, tpesVal) {
+        case ((), tpes) =>
+          val purOpt = tpes.reduceLeftOption({
+          case (acc, tpe) => WeededAst.Type.And(acc, tpe, loc)
+        })
+        purOpt.getOrElse(WeededAst.Type.True(loc))
+      }
 
     case ParsedAst.Type.CaseSet(sp1, cases, sp2) =>
       val loc = mkSL(sp1, sp2)
-      WeededAst.Type.CaseSet(cases.toList, loc)
+      WeededAst.Type.CaseSet(cases.toList, loc).toSuccess
 
     case ParsedAst.Type.CaseUnion(tpe1, tpe2, sp2) =>
       val sp1 = leftMostSourcePosition(tpe1)
       val loc = mkSL(sp1, sp2)
-      val t1 = visitType(tpe1)
-      val t2 = visitType(tpe2)
-      WeededAst.Type.CaseUnion(t1, t2, loc)
+      val t1Val = visitType(tpe1)
+      val t2Val = visitType(tpe2)
+      mapN(t1Val, t2Val) {
+        case (t1, t2) => WeededAst.Type.CaseUnion(t1, t2, loc)
+      }
 
     case ParsedAst.Type.CaseIntersection(tpe1, tpe2, sp2) =>
       val sp1 = leftMostSourcePosition(tpe1)
       val loc = mkSL(sp1, sp2)
-      val t1 = visitType(tpe1)
-      val t2 = visitType(tpe2)
-      WeededAst.Type.CaseIntersection(t1, t2, loc)
+      val t1Val = visitType(tpe1)
+      val t2Val = visitType(tpe2)
+      mapN(t1Val, t2Val) {
+        case (t1, t2) => WeededAst.Type.CaseIntersection(t1, t2, loc)
+      }
 
     case ParsedAst.Type.CaseDifference(tpe1, tpe2, sp2) =>
       val sp1 = leftMostSourcePosition(tpe1)
       val loc = mkSL(sp1, sp2)
-      val t1 = visitType(tpe1)
-      val t2 = visitType(tpe2)
-      WeededAst.Type.CaseIntersection(t1, WeededAst.Type.CaseComplement(t2, loc), loc)
+      val t1Val = visitType(tpe1)
+      val t2Val = visitType(tpe2)
+      mapN(t1Val, t2Val) {
+        case (t1, t2) => WeededAst.Type.CaseIntersection(t1, WeededAst.Type.CaseComplement(t2, loc), loc)
+      }
 
     case ParsedAst.Type.CaseComplement(sp1, tpe, sp2) =>
       val loc = mkSL(sp1, sp2)
-      val t = visitType(tpe)
-      WeededAst.Type.CaseComplement(t, loc)
+      val tVal = visitType(tpe)
+      mapN(tVal) {
+        case t => WeededAst.Type.CaseComplement(t, loc)
+      }
 
     case ParsedAst.Type.Ascribe(tpe, kind, sp2) =>
       val sp1 = leftMostSourcePosition(tpe)
-      val t = visitType(tpe)
+      val tVal = visitType(tpe)
       val k = visitKind(kind)
-      WeededAst.Type.Ascribe(t, k, mkSL(sp1, sp2))
+      mapN(tVal) {
+        case t => WeededAst.Type.Ascribe(t, k, mkSL(sp1, sp2))
+      }
+  }
+
+  // MATT docs
+  private def checkEffectSetElement(t: ParsedAst.Type): Validation[Unit, WeederError] = t match {
+    case _: ParsedAst.Type.Var => ().toSuccess
+    case _: ParsedAst.Type.Ambiguous => ().toSuccess
+    case _ => ??? // MATT weedererror bad type in set
   }
 
   /**
     * Builds a record row from the given fields and optional rest variable.
     */
-  private def buildRecordRow(fields: Seq[ParsedAst.RecordFieldType], restOpt: Option[Name.Ident], loc: SourceLocation): WeededAst.Type = {
+  private def buildRecordRow(fields0: Seq[ParsedAst.RecordFieldType], restOpt: Option[Name.Ident], loc: SourceLocation): Validation[WeededAst.Type, WeederError] = {
     // If rest is absent, then it is the empty record row
     val rest = restOpt match {
       case None => WeededAst.Type.RecordRowEmpty(loc)
       case Some(name) => WeededAst.Type.Var(name, name.loc)
     }
 
-    fields.foldRight(rest) {
-      case (ParsedAst.RecordFieldType(ssp1, ident, t, ssp2), acc) =>
-        WeededAst.Type.RecordRowExtend(Name.mkField(ident), visitType(t), acc, mkSL(ssp1, ssp2))
+    val fieldsVal = traverse(fields0) {
+      case ParsedAst.RecordFieldType(sp1, ident, tpe, sp2) =>
+        mapN(visitType(tpe)) {
+          case t => (Name.mkField(ident), tpe)
+        }
     }
+
+    mapN(fieldsVal) {
+      case fields =>
+        fields.foldRight(rest) {
+          case ((field, tpe), acc) =>
+            WeededAst.Type.RecordRowExtend(field, tpe, acc, loc)
+        }
+    }
+
   }
 
   /**
     * Builds a schema row from the given predicates and optional rest identifier.
     */
-  private def buildSchemaRow(predicates: Seq[ParsedAst.PredicateType], restOpt: Option[Name.Ident], loc: SourceLocation): WeededAst.Type = {
+  private def buildSchemaRow(predicates: Seq[ParsedAst.PredicateType], restOpt: Option[Name.Ident], loc: SourceLocation): Validation[WeededAst.Type, WeederError] = {
     // If rest is absent, then it is the empty schema row
     val rest = restOpt match {
       case None => WeededAst.Type.SchemaRowEmpty(loc)
       case Some(name) => WeededAst.Type.Var(name, name.loc)
     }
 
-    predicates.foldRight(rest) {
+    // TODO should be non-short-circuiting
+    Validation.foldRight(predicates)(rest.toSuccess) {
       case (ParsedAst.PredicateType.PredicateWithAlias(ssp1, qname, targs, ssp2), acc) =>
-        val ts = targs match {
-          case None => Nil
-          case Some(xs) => xs.map(visitType).toList
+        val tsVal = traverse(targs.getOrElse(Nil))(visitType)
+        mapN(tsVal) {
+          case ts => WeededAst.Type.SchemaRowExtendByAlias(qname, ts, acc, mkSL(ssp1, ssp2))
         }
-        WeededAst.Type.SchemaRowExtendByAlias(qname, ts, acc, mkSL(ssp1, ssp2))
 
-      case (ParsedAst.PredicateType.RelPredicateWithTypes(ssp1, name, ts, ssp2), acc) =>
-        WeededAst.Type.SchemaRowExtendByTypes(name, Ast.Denotation.Relational, ts.toList.map(visitType), acc, mkSL(ssp1, ssp2))
+      case (ParsedAst.PredicateType.RelPredicateWithTypes(ssp1, name, ts0, ssp2), acc) =>
+        val tsVal = traverse(ts0)(visitType)
+        mapN(tsVal) {
+          case ts => WeededAst.Type.SchemaRowExtendByTypes(name, Ast.Denotation.Relational, ts, acc, mkSL(ssp1, ssp2))
+        }
 
       case (ParsedAst.PredicateType.LatPredicateWithTypes(ssp1, name, ts, tpe, ssp2), acc) =>
-        WeededAst.Type.SchemaRowExtendByTypes(name, Ast.Denotation.Latticenal, ts.toList.map(visitType) ::: visitType(tpe) :: Nil, acc, mkSL(ssp1, ssp2))
+        val tsVal = traverse(ts :+ tpe)(visitType)
+        mapN(tsVal) {
+          case ts => WeededAst.Type.SchemaRowExtendByTypes(name, Ast.Denotation.Latticenal, ts, acc, mkSL(ssp1, ssp2))
+        }
     }
   }
 
@@ -2795,18 +2897,18 @@ object Weeder {
     *
     * In other words, the type is of the form `tpe1 ->{eff} tpe2`
     */
-  private def mkArrow(tpe1: WeededAst.Type, purAndEff: WeededAst.PurityAndEffect, tpe2: WeededAst.Type, loc: SourceLocation): WeededAst.Type =
-    WeededAst.Type.Arrow(List(tpe1), purAndEff, tpe2, loc.asSynthetic)
+  private def mkArrow(tpe1: WeededAst.Type, pur: Option[WeededAst.Type], tpe2: WeededAst.Type, loc: SourceLocation): WeededAst.Type =
+    WeededAst.Type.Arrow(List(tpe1), pur, tpe2, loc.asSynthetic)
 
   /**
     * Returns a sequence of arrow types type from `tparams` to `tresult` where every arrow is pure except the last which has effect `eff`.
     *
     * In other words, the type is of the form `tpe1 ->> tpe2 ->> ... ->{eff} tresult`.
     */
-  private def mkCurriedArrow(tparams: Seq[WeededAst.Type], purAndEff: WeededAst.PurityAndEffect, tresult: WeededAst.Type, loc: SourceLocation): WeededAst.Type = {
+  private def mkCurriedArrow(tparams: Seq[WeededAst.Type], pur: Option[WeededAst.Type], tresult: WeededAst.Type, loc: SourceLocation): WeededAst.Type = {
     val l = loc.asSynthetic
-    val base = mkArrow(tparams.last, purAndEff, tresult, l)
-    tparams.init.foldRight(base)(mkArrow(_, WeededAst.PurityAndEffect(None, None), _, l))
+    val base = mkArrow(tparams.last, pur, tresult, l)
+    tparams.init.foldRight(base)(mkArrow(_, None, _, l))
   }
 
   /**
@@ -2819,82 +2921,6 @@ object Weeder {
       WeededAst.Type.Complement(tpe2, loc),
       loc
     )
-  }
-
-  /**
-    * Weeds the given parsed optional purity and effect `purAndEff`.
-    */
-  private def visitPurityAndEffect(purAndEff: ParsedAst.PurityAndEffect): WeededAst.PurityAndEffect = purAndEff match {
-    case ParsedAst.PurityAndEffect(pur0, eff0) =>
-      val pur = pur0.map(visitType)
-      val eff = eff0.map(visitEffectSet)
-      WeededAst.PurityAndEffect(pur, eff)
-  }
-
-  /**
-    * Weeds the given effect set.
-    */
-  private def visitEffectSet(eff0: ParsedAst.EffectSet): List[WeededAst.Type] = eff0 match {
-    case EffectSet.Singleton(_, eff, _) => List(visitSingleEffect(eff))
-    case EffectSet.Pure(sp1, sp2) => Nil
-    case EffectSet.Set(sp1, effs0, sp2) => effs0.map(visitSingleEffect).toList
-  }
-
-  /**
-    * Weeds the given single effect.
-    */
-  private def visitSingleEffect(eff0: ParsedAst.Effect): WeededAst.Type = {
-    val leftSp = leftMostSourcePosition(eff0)
-    val loc = mkSL(leftSp, rightMostSourcePosition(eff0))
-
-    eff0 match {
-      case ParsedAst.Effect.Var(sp1, ident, sp2) => visitEffectIdent(ident)
-
-      case ParsedAst.Effect.Read(sp1, idents, sp2) =>
-        idents.map(ident => WeededAst.Type.Read(WeededAst.Type.Var(ident, ident.loc), ident.loc): WeededAst.Type)
-          .reduceOption(WeededAst.Type.And(_, _, loc))
-          .getOrElse(WeededAst.Type.True(loc))
-
-      case ParsedAst.Effect.Write(sp1, idents, sp2) =>
-        idents.map(ident => WeededAst.Type.Write(WeededAst.Type.Var(ident, ident.loc), ident.loc): WeededAst.Type)
-          .reduceOption(WeededAst.Type.And(_, _, loc))
-          .getOrElse(WeededAst.Type.True(loc))
-
-      case ParsedAst.Effect.Impure(sp1, sp2) => WeededAst.Type.False(mkSL(sp1, sp2))
-
-      case ParsedAst.Effect.Eff(sp1, name, sp2) => WeededAst.Type.Ambiguous(name, loc)
-
-      case ParsedAst.Effect.Complement(sp1, eff, sp2) =>
-        val innerEff = visitSingleEffect(eff)
-        WeededAst.Type.Complement(innerEff, loc)
-
-      case ParsedAst.Effect.Union(eff1, effs) =>
-        val innerEff1 = visitSingleEffect(eff1)
-        effs.foldLeft(innerEff1) {
-          case (acc, innerEff0) =>
-            val innerEff = visitSingleEffect(innerEff0)
-            val innerLoc = mkSL(leftSp, rightMostSourcePosition(innerEff0))
-            WeededAst.Type.Union(acc, innerEff, innerLoc)
-        }
-
-      case ParsedAst.Effect.Intersection(eff1, effs) =>
-        val innerEff1 = visitSingleEffect(eff1)
-        effs.foldLeft(innerEff1) {
-          case (acc, innerEff0) =>
-            val innerEff = visitSingleEffect(innerEff0)
-            val innerLoc = mkSL(leftSp, rightMostSourcePosition(innerEff0))
-            WeededAst.Type.Intersection(acc, innerEff, innerLoc)
-        }
-
-      case ParsedAst.Effect.Difference(eff1, effs) =>
-        val innerEff1 = visitSingleEffect(eff1)
-        effs.foldLeft(innerEff1) {
-          case (acc, innerEff0) =>
-            val innerEff = visitSingleEffect(innerEff0)
-            val innerLoc = mkSL(leftSp, rightMostSourcePosition(innerEff0))
-            mkDifference(acc, innerEff, innerLoc)
-        }
-    }
   }
 
   /**
@@ -3088,6 +3114,7 @@ object Weeder {
     * Performs weeding on the given effect `ident`.
     * Checks whether it is actually the keyword `Static`.
     */
+    // TODO remove
   private def visitEffectIdent(ident: Name.Ident): WeededAst.Type = {
     if (ident.name == "Static")
       WeededAst.Type.False(ident.loc)
@@ -3363,10 +3390,6 @@ object Weeder {
     case ParsedAst.Type.Apply(tpe1, _, _) => leftMostSourcePosition(tpe1)
     case ParsedAst.Type.True(sp1, _) => sp1
     case ParsedAst.Type.False(sp1, _) => sp1
-    case ParsedAst.Type.Not(sp1, _, _) => sp1
-    case ParsedAst.Type.And(tpe1, _, _) => leftMostSourcePosition(tpe1)
-    case ParsedAst.Type.Or(tpe1, _, _) => leftMostSourcePosition(tpe1)
-    case ParsedAst.Type.Effect(sp1, _, _) => sp1
     case ParsedAst.Type.CaseComplement(sp1, _, _) => sp1
     case ParsedAst.Type.CaseDifference(tpe1, _, _) => leftMostSourcePosition(tpe1)
     case ParsedAst.Type.CaseIntersection(tpe1, _, _) => leftMostSourcePosition(tpe1)
@@ -3375,31 +3398,6 @@ object Weeder {
     case ParsedAst.Type.Ascribe(tpe, _, _) => leftMostSourcePosition(tpe)
   }
 
-  @tailrec
-  private def leftMostSourcePosition(eff: ParsedAst.Effect): SourcePosition = eff match {
-    case Effect.Var(sp1, _, _) => sp1
-    case Effect.Read(sp1, _, _) => sp1
-    case Effect.Write(sp1, _, _) => sp1
-    case Effect.Impure(sp1, _) => sp1
-    case Effect.Eff(sp1, _, _) => sp1
-    case Effect.Complement(sp1, _, _) => sp1
-    case Effect.Union(eff1, _) => leftMostSourcePosition(eff1)
-    case Effect.Intersection(eff1, _) => leftMostSourcePosition(eff1)
-    case Effect.Difference(eff1, _) => leftMostSourcePosition(eff1)
-  }
-
-  @tailrec
-  private def rightMostSourcePosition(eff: ParsedAst.Effect): SourcePosition = eff match {
-    case Effect.Var(_, _, sp2) => sp2
-    case Effect.Read(_, _, sp2) => sp2
-    case Effect.Write(_, _, sp2) => sp2
-    case Effect.Impure(_, sp2) => sp2
-    case Effect.Eff(_, _, sp2) => sp2
-    case Effect.Complement(_, _, sp2) => sp2
-    case Effect.Union(eff1, effs) => rightMostSourcePosition(effs.lastOption.getOrElse(eff1))
-    case Effect.Intersection(eff1, effs) => rightMostSourcePosition(effs.lastOption.getOrElse(eff1))
-    case Effect.Difference(eff1, effs) => rightMostSourcePosition(effs.lastOption.getOrElse(eff1))
-  }
 
   /**
     * Returns the left most source position in the sub-tree of the kind `kind`.

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -347,6 +347,18 @@ object Validation {
     (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8) => (t9: T9) => f(t1, t2, t3, t4, t5, t6, t7, t8, t9)
 
   /**
+    * Returns `f` with the last parameter curried.
+    */
+  private def curry[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => T11): (T1, T2, T3, T4, T5, T6, T7, T8, T9) => T10 => T11 =
+    (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9) => (t10: T10) => f(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)
+
+  /**
+    * Returns `f` with the last parameter curried.
+    */
+  private def curry[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => T12): (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => T11 => T12 =
+    (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10) => (t11: T11) => f(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)
+
+  /**
     * Maps over t1.
     */
   def mapN[T1, U, E](t1: Validation[T1, E])
@@ -421,6 +433,26 @@ object Validation {
                                                      t7: Validation[T7, E], t8: Validation[T8, E], t9: Validation[T9, E])
                                                     (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => U): Validation[U, E] =
     ap(mapN(t1, t2, t3, t4, t5, t6, t7, t8)(curry(f)))(t9)
+
+  /**
+    * Maps over t1, t2, t3, t4, t5, t6, t7, t8, t9, and t10
+    */
+  def mapN[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, U, E](t1: Validation[T1, E], t2: Validation[T2, E], t3: Validation[T3, E],
+                                                          t4: Validation[T4, E], t5: Validation[T5, E], t6: Validation[T6, E],
+                                                          t7: Validation[T7, E], t8: Validation[T8, E], t9: Validation[T9, E],
+                                                          t10: Validation[T10, E])
+                                                         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => U): Validation[U, E] =
+    ap(mapN(t1, t2, t3, t4, t5, t6, t7, t8, t9)(curry(f)))(t10)
+
+  /**
+    * Maps over t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, and t11
+    */
+  def mapN[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, U, E](t1: Validation[T1, E], t2: Validation[T2, E], t3: Validation[T3, E],
+                                                               t4: Validation[T4, E], t5: Validation[T5, E], t6: Validation[T6, E],
+                                                               t7: Validation[T7, E], t8: Validation[T8, E], t9: Validation[T9, E],
+                                                               t10: Validation[T10, E], t11: Validation[T11, E])
+                                                              (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => U): Validation[U, E] =
+    ap(mapN(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)(curry(f)))(t11)
 
   /**
     * FlatMaps over t1.

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -1648,7 +1648,7 @@ mod Array {
     ///
     /// Shuffles `a` using the Fisher–Yates shuffle.
     ///
-    pub def shuffle(rnd: Random, a: Array[a, r]): Unit & r \ NonDet =
+    pub def shuffle(rnd: Random, a: Array[a, r]): Unit \ {r, NonDet} =
         let len = Array.length(a);
         def loop(i) = {
             if (i > 0) {

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -1378,7 +1378,7 @@ mod Array {
     ///
     /// Modifying `a` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(rc: Region[r1], a: Array[a, r2]): Iterator[a, r1 and r2, r1] \ { Write(r1) } =
+    pub def iterator(rc: Region[r1], a: Array[a, r2]): Iterator[a, r1 + r2, r1] \ { Write(r1) } =
         Iterator.range(rc, 0, length(a)) |> Iterator.map(i -> Array.get(i, a))
 
     ///
@@ -1386,7 +1386,7 @@ mod Array {
     ///
     /// Modifying `a` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def enumerator(rc: Region[r1], a: Array[a, r2]): Iterator[(Int32, a), r1 and r2, r1] \ { Write(r1) } =
+    pub def enumerator(rc: Region[r1], a: Array[a, r2]): Iterator[(Int32, a), r1 + r2, r1] \ { Write(r1) } =
         iterator(rc, a) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/Choice.flix
+++ b/main/src/library/Choice.flix
@@ -87,7 +87,7 @@ mod Choice {
     ///
     @Experimental
     pub def withDefault[s : Type, a1 : Bool, p1 : Bool, a2 : Bool, p2 : Bool]
-                       (default: {default = Choice[s, a2, p2]}, c: Choice[s, a1, p1]): Choice[s, a1 and a2, p1 or (a1 and p2)] =
+                       (default: {default = Choice[s, a2, p2]}, c: Choice[s, a1, p1]): Choice[s, a1 + a2, p1 & (a1 + p2)] =
         relational_choose* c {
             case Absent     => default.default
             case Present(v) => Present(v)
@@ -121,7 +121,7 @@ mod Choice {
     ///
     @Experimental
     pub def flatMap[s : Type, t : Type, a1 : Bool, p1 : Bool, a2 : Bool, p2 : Bool]
-                   (f: s -> Choice[t, a2, p2], c: Choice[s, a1, p1]): Choice[t, a1 or (p1 and a2), p1 and p2] =
+                   (f: s -> Choice[t, a2, p2], c: Choice[s, a1, p1]): Choice[t, a1 & (p1 + a2), p1 + p2] =
         relational_choose* c {
             case Absent     => Absent
             case Present(v) => f(v)
@@ -132,7 +132,7 @@ mod Choice {
     ///
     @Experimental
     pub def flatten[t : Type, a1 : Bool, p1 : Bool, a2 : Bool, p2 : Bool]
-        (c: Choice[Choice[t, a1, p1], a2, p2]): Choice[t, (a1 and p2) or a2, p1 and p2] =
+        (c: Choice[Choice[t, a1, p1], a2, p2]): Choice[t, (a1 + p2) & a2, p1 + p2] =
         relational_choose* c {
             case Absent     => Absent
             case Present(v) => v

--- a/main/src/library/Choice.flix
+++ b/main/src/library/Choice.flix
@@ -100,7 +100,7 @@ mod Choice {
     ///
     @Experimental
     pub def filter[t : Type, a : Bool, p : Bool]
-                  (f: t -> Bool, c: Choice[t, a, p]): Choice[t, a or p, p] =
+                  (f: t -> Bool, c: Choice[t, a, p]): Choice[t, a & p, p] =
         relational_choose* c {
             case Absent     => Absent
             case Present(v) => if (f(v)) Present(v) else Absent

--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -244,7 +244,7 @@ mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def filter(f: a -> Bool \ ef2, iter: Iterator[a, ef1, r]): Iterator[a, ef1 and ef2, r] =
+    pub def filter(f: a -> Bool \ ef2, iter: Iterator[a, ef1, r]): Iterator[a, ef1 + ef2, r] =
         let Iterator(rc, iterF) = iter;
         let step = x -> match x {
             case Ans(a) => if (f(a)) Ans(a) else Skip
@@ -259,7 +259,7 @@ mod Iterator {
     ///
     /// Does *not* consume any elements from the iterator.
     ///
-    pub def map(f: a -> b \ ef2, iter: Iterator[a, ef1, r]): Iterator[b, ef1 and ef2, r] =
+    pub def map(f: a -> b \ ef2, iter: Iterator[a, ef1, r]): Iterator[b, ef1 + ef2, r] =
         let Iterator(rc, iterF) = iter;
         let step = x -> match x {
             case Ans(a) => Ans(f(a))
@@ -275,7 +275,7 @@ mod Iterator {
     ///
     /// Does *not* consume any elements from the iterator.
     ///
-    pub def mapWithIndex(f: (Int32, a) -> b \ ef2, iter: Iterator[a, ef1, r]): Iterator[b, ef1 and ef2, r] \ Write(r) =
+    pub def mapWithIndex(f: (Int32, a) -> b \ ef2, iter: Iterator[a, ef1, r]): Iterator[b, ef1 + ef2, r] \ Write(r) =
         let Iterator(rc, iterF) = iter;
         let ix = ref 0 @ rc;
         let step = x -> match x {
@@ -301,7 +301,7 @@ mod Iterator {
     ///
     /// The original iterators `iterA` and `iterB` should *not* be reused.
     ///
-    pub def append(iter1: Iterator[a, ef1, r], iter2: Iterator[a, ef2, r]): Iterator[a, ef1 and ef2, r] =
+    pub def append(iter1: Iterator[a, ef1, r], iter2: Iterator[a, ef2, r]): Iterator[a, ef1 + ef2, r] =
         let Iterator(rc, iter1F) = iter1;
         let Iterator(_, iter2F) = iter2;
         def loop2(x) = match x {
@@ -329,7 +329,7 @@ mod Iterator {
     ///
     /// An iterator should *never* be zipped with itself.
     ///
-    pub def zip(iterA: Iterator[a, ef1, r1], iterB: Iterator[b, ef2, r2]): Iterator[(a, b), r2 and ef1 and ef2, r1] =
+    pub def zip(iterA: Iterator[a, ef1, r1], iterB: Iterator[b, ef2, r2]): Iterator[(a, b), r2 + ef1 + ef2, r1] =
         zipWith((a, b) -> (a, b), iterA, iterB)
 
     ///
@@ -344,7 +344,7 @@ mod Iterator {
     ///
     /// An iterator should *never* be zipped with itself.
     ///
-    pub def zipWith(f: (a, b) -> c \ ef3, iterA: Iterator[a, ef1, r1], iterB: Iterator[b, ef2, r2]): Iterator[c, r2 and ef1 and ef2 and ef3, r1] =
+    pub def zipWith(f: (a, b) -> c \ ef3, iterA: Iterator[a, ef1, r1], iterB: Iterator[b, ef2, r2]): Iterator[c, r2 + ef1 + ef2 + ef3, r1] =
         let Iterator(rc, iter1F) = iterA;
         let Iterator(_,  iter2F) = iterB;
         let step = (l, r) -> match (l, r) {
@@ -384,7 +384,7 @@ mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def zipWithIndex(iter: Iterator[a, ef, r]): Iterator[(Int32, a), ef and r, r] \ Write(r) =
+    pub def zipWithIndex(iter: Iterator[a, ef, r]): Iterator[(Int32, a), ef + r, r] \ Write(r) =
         let Iterator(rc, _) = iter;
         let ix = ref 0 @ rc;
         map(x -> {let i = deref ix; ix:= i + 1; (i, x)}, iter)
@@ -392,7 +392,7 @@ mod Iterator {
     ///
     /// Alias for `zipWithIndex`.
     ///
-    pub def enumerator(iter: Iterator[a, ef, r]): Iterator[(Int32, a), ef and r, r] \ Write(r) =
+    pub def enumerator(iter: Iterator[a, ef, r]): Iterator[(Int32, a), ef + r, r] \ Write(r) =
         zipWithIndex(iter)
 
     ///
@@ -487,7 +487,7 @@ mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def drop(n: Int32, iter: Iterator[a, ef, r]): Iterator[a, ef and r, r] \ Write(r) =
+    pub def drop(n: Int32, iter: Iterator[a, ef, r]): Iterator[a, ef + r, r] \ Write(r) =
         let Iterator(rc, iterF) = iter;
         let ix = ref n @ rc;
         def loop() = {
@@ -512,7 +512,7 @@ mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def take(n: Int32, iter: Iterator[a, ef, r]): Iterator[a, ef and r, r] \ Write(r) =
+    pub def take(n: Int32, iter: Iterator[a, ef, r]): Iterator[a, ef + r, r] \ Write(r) =
         let Iterator(rc, iterF) = iter;
         let ix = ref n @ rc;
         def loop() = {
@@ -536,7 +536,7 @@ mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def takeWhile(f: a -> Bool \ ef2, iter: Iterator[a, ef1, r]): Iterator[a, ef1 and ef2, r]=
+    pub def takeWhile(f: a -> Bool \ ef2, iter: Iterator[a, ef1, r]): Iterator[a, ef1 + ef2, r]=
         let Iterator(rc, iterF) = iter;
         def loop(x) = match x {
             case Ans(a) => if (f(a)) Ans(a) else Done
@@ -553,7 +553,7 @@ mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def dropWhile(f: a -> Bool \ ef2, iter: Iterator[a, ef1, r]): Iterator[a, r and ef1 and ef2, r] \ Write(r) =
+    pub def dropWhile(f: a -> Bool \ ef2, iter: Iterator[a, ef1, r]): Iterator[a, r + ef1 + ef2, r] \ Write(r) =
         let Iterator(rc, iterF) = iter;
         let start = ref true @ rc;
         def loop() = match iterF() {
@@ -576,7 +576,7 @@ mod Iterator {
     ///
     /// Currently `f` has to generate an iterator with region `r`.
     ///
-    pub def flatMap(f: a -> Iterator[b, ef2, r] \ ef3, ma: Iterator[a, ef1, r]): Iterator[b, r and ef1 and ef2 and ef3, r] \ Write(r) =
+    pub def flatMap(f: a -> Iterator[b, ef2, r] \ ef3, ma: Iterator[a, ef1, r]): Iterator[b, r + ef1 + ef2 + ef3, r] \ Write(r) =
         let Iterator(rc, iterF) = ma;
         let innerIter = ref polymorphicEmpty(rc) @ rc;
         let inside = ref false @ rc;
@@ -626,7 +626,7 @@ mod Iterator {
     ///
     /// Does *not* consume any elements from the iterator.
     ///
-    pub def intersperse(sep: a, iter: Iterator[a, ef, r]): Iterator[a, ef and r, r] \ Write(r) =
+    pub def intersperse(sep: a, iter: Iterator[a, ef, r]): Iterator[a, ef + r, r] \ Write(r) =
         let Iterator(rc, _) = iter;
         let start = ref true @ rc;
         let step = x ->
@@ -647,7 +647,7 @@ mod Iterator {
     ///
     /// The original iterators `sep` and `iter` should not be reused.
     ///
-    pub def intercalate(sep: t[a], iter: Iterator[Iterator[a, ef, r], ef, r]): Iterator[a, ef and r, r] \ Write(r) with Foldable[t] =
+    pub def intercalate(sep: t[a], iter: Iterator[Iterator[a, ef, r], ef, r]): Iterator[a, ef + r, r] \ Write(r) with Foldable[t] =
         let Iterator(rc, _) = iter;
         let start = ref true @ rc;
         let sepL = Foldable.toList(sep);
@@ -712,7 +712,7 @@ mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def filterMap(f: a -> Option[b] \ ef2, iter: Iterator[a, ef1, r]): Iterator[b, ef1 and ef2, r] =
+    pub def filterMap(f: a -> Option[b] \ ef2, iter: Iterator[a, ef1, r]): Iterator[b, ef1 + ef2, r] =
         let Iterator(rc, iterF) = iter;
         let step = x -> match x {
             case Ans(a) => match (f(a)) {
@@ -754,7 +754,7 @@ mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def flatten(iter: Iterator[Iterator[a, ef1, r], ef2, r]): Iterator[a, r and ef1 and ef2, r] \ Write(r) =
+    pub def flatten(iter: Iterator[Iterator[a, ef1, r], ef2, r]): Iterator[a, r + ef1 + ef2, r] \ Write(r) =
         flatMap(identity, iter)
 
 }

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -402,7 +402,7 @@ mod MutDeque {
     ///
     /// Modifying `d` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(rc: Region[r1], d: MutDeque[a, r2]): Iterator[a, r1 and r2, r1] \ { Write(r1), Read(r2) } =
+    pub def iterator(rc: Region[r1], d: MutDeque[a, r2]): Iterator[a, r1 + r2, r1] \ { Write(r1), Read(r2) } =
         let MutDeque(_, a, f, b) = d;
         let i = ref (deref f) @ rc;
         let next = () -> {

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -790,7 +790,7 @@ mod MutList {
     ///
     /// Modifying `l` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(rc: Region[r1], l: MutList[a, r2]): Iterator[a, r1 and r2, r1] \ { Write(r1), Read(r2) } =
+    pub def iterator(rc: Region[r1], l: MutList[a, r2]): Iterator[a, r1 + r2, r1] \ { Write(r1), Read(r2) } =
         let MutList(_, a, len) = l;
         let len1 = deref len;
         let ix = ref 0 @ rc;

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -567,21 +567,21 @@ mod MutMap {
     ///
     /// Returns an iterator over all key-value pairs in `m`.
     ///
-    pub def iterator(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[(k, v), r1 and r2, r1] \ { Write(r1), Read(r2) } =
+    pub def iterator(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[(k, v), r1 + r2, r1] \ { Write(r1), Read(r2) } =
         let MutMap(_, mm) = m;
         Map.iterator(rc, deref mm) |> Iterator.map(x -> {discard deref mm; x})
 
     ///
     /// Returns an iterator over keys in `m`.
     ///
-    pub def iteratorKeys(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[k, r1 and r2, r1] \ { Write(r1), Read(r2) } =
+    pub def iteratorKeys(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[k, r1 + r2, r1] \ { Write(r1), Read(r2) } =
         let MutMap(_, mm) = m;
         Map.iteratorKeys(rc, deref mm) |> Iterator.map(x -> {discard deref mm; x})
 
     ///
     /// Returns an iterator over values in `m`.
     ///
-    pub def iteratorValues(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[v, r1 and r2, r1] \ { Write(r1), Read(r2) } =
+    pub def iteratorValues(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[v, r1 + r2, r1] \ { Write(r1), Read(r2) } =
         let MutMap(_, mm) = m;
         Map.iteratorValues(rc, deref mm) |> Iterator.map(x -> {discard deref mm; x})
 

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -390,14 +390,14 @@ mod MutSet {
     ///
     /// Returns an iterator over `s`.
     ///
-    pub def iterator(rc: Region[r1], s: MutSet[a, r2]): Iterator[a, r1 and r2, r1] \ { Write(r1), Read(r2) } =
+    pub def iterator(rc: Region[r1], s: MutSet[a, r2]): Iterator[a, r1 + r2, r1] \ { Write(r1), Read(r2) } =
         let MutSet(_, ms) = s;
         Set.iterator(rc, deref ms) |> Iterator.map(x -> {discard deref ms; x})
 
     ///
     /// Returns an enumerator over `s`.
     ///
-    pub def enumerator(rc: Region[r1], s: MutSet[a, r2]): Iterator[(Int32, a), r1 and r2, r1] \ { Write(r1), Read(r2) } =
+    pub def enumerator(rc: Region[r1], s: MutSet[a, r2]): Iterator[(Int32, a), r1 + r2, r1] \ { Write(r1), Read(r2) } =
         iterator(rc, s) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/StringBuilder.flix
+++ b/main/src/library/StringBuilder.flix
@@ -99,7 +99,7 @@ mod StringBuilder {
     ///
     /// Returns an iterator over `sb`.
     ///
-    pub def iterator(rc: Region[r1], sb: StringBuilder[r2]): Iterator[Char, r1 and r2, r1] \ { Read(r2), Write(r1) } =
+    pub def iterator(rc: Region[r1], sb: StringBuilder[r2]): Iterator[Char, r1 + r2, r1] \ { Read(r2), Write(r1) } =
         import java.lang.StringBuilder.charAt(Int32): Char \ Read(r2);
         let StringBuilder(msb) = sb;
         Iterator.range(rc, 0, length(sb)) |> Iterator.map(i -> charAt(msb, i))
@@ -107,7 +107,7 @@ mod StringBuilder {
     ///
     /// Returns an iterator over `l` zipped with the indices of the elements.
     ///
-    pub def enumerator(r1: Region[r1], sb: StringBuilder[r2]): Iterator[(Int32, Char), r1 and r2, r1] \ { Read(r2), Write(r1) } =
+    pub def enumerator(r1: Region[r1], sb: StringBuilder[r2]): Iterator[(Int32, Char), r1 + r2, r1] \ { Read(r2), Write(r1) } =
         iterator(r1, sb) |> Iterator.zipWithIndex
 
     ///

--- a/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
@@ -69,9 +69,9 @@ class TestInstances extends AnyFunSuite with TestUtils {
       """
         |class C[a]
         |
-        |instance C[a -> b & p \ ef1]
+        |instance C[a -> b \ ef1]
         |
-        |instance C[x -> y & q \ ef2]
+        |instance C[x -> y \ ef2]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[InstanceError.OverlappingInstances](result)
@@ -185,7 +185,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
       """
         |class C[a]
         |
-        |instance C[Int32 -> b & e]
+        |instance C[Int32 -> b \ e]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[InstanceError.ComplexInstanceType](result)
@@ -233,7 +233,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
       """
         |class C[a]
         |
-        |instance C[a -> a & p \ ef]
+        |instance C[a -> a \ ef]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[InstanceError.DuplicateTypeVariableOccurrence](result)
@@ -363,7 +363,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
     val input =
       """
         |class C[a] {
-        |    pub def f(x: a, y: Int32): Int32 & e
+        |    pub def f(x: a, y: Int32): Int32 \ e
         |}
         |
         |instance C[Bool] {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
@@ -200,7 +200,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
         |
         |class C[a]
         |
-        |instance C[Box[a] -> b & e]
+        |instance C[Box[a] -> b \ e]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[InstanceError.ComplexInstanceType](result)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -327,7 +327,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   }
 
   test("IllegalEffect.03") {
-    val input = raw"def f(): Int32 = 1: \ Int32"
+    val input = raw"def f(): Int32 = 1: _ \ Int32"
     val result = compile(input, DefaultOptions)
     expectError[KindError](result)
   }
@@ -438,7 +438,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Expression.Ascribe.02") {
     val input =
       """
-        |def f(): Int32 = 1: \ Unit
+        |def f(): Int32 = 1: _ \ Unit
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -1292,8 +1292,8 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
 
   test("UselessExpression.03") {
     val input =
-      s"""
-         |def hof(f: a -> b & e, x: a): b & e = f(x)
+      """
+         |def hof(f: a -> b & e, x: a): b \ e = f(x)
          |
          |def f(): Unit =
          |    hof(x -> (x, 21), 42);
@@ -1356,8 +1356,8 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
 
   test("RedundantPurityCast.01") {
     val input =
-      s"""
-         |pub def f(): Int32 = unchecked_cast(123 as _ & Pure)
+      """
+         |pub def f(): Int32 = unchecked_cast(123 as _ \ Pure)
          |
        """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
@@ -1369,7 +1369,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
       raw"""
            |pub def f(): Array[Int32, false] \ IO =
            |  let x = Array#{1, 2, 3} @ Static;
-           |  unchecked_cast(x as _ & Pure)
+           |  unchecked_cast(x as _ \ Pure)
            |
        """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
@@ -1729,8 +1729,8 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     val input =
       """
         |def f(): Unit & Impure =
-        |    import new java.lang.StringBuilder(): ##java.lang.StringBuilder & Impure as newStringBuilder;
-        |    import new java.lang.Object(): ##java.lang.Object & Impure as newObject;
+        |    import new java.lang.StringBuilder(): ##java.lang.StringBuilder \ Impure as newStringBuilder;
+        |    import new java.lang.Object(): ##java.lang.Object \ Impure as newObject;
         |    let _ =
         |        if (true)
         |            checked_cast((newObject(), newObject()))

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -1293,7 +1293,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
   test("UselessExpression.03") {
     val input =
       """
-         |def hof(f: a -> b & e, x: a): b \ e = f(x)
+         |def hof(f: a -> b \ e, x: a): b \ e = f(x)
          |
          |def f(): Unit =
          |    hof(x -> (x, 21), 42);

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -1728,7 +1728,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
   test("RedundantCheckedTypeCast.05") {
     val input =
       """
-        |def f(): Unit & Impure =
+        |def f(): Unit \ Impure =
         |    import new java.lang.StringBuilder(): ##java.lang.StringBuilder \ Impure as newStringBuilder;
         |    import new java.lang.Object(): ##java.lang.Object \ Impure as newObject;
         |    let _ =

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -1407,7 +1407,8 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("IllegalWildType.04") {
     val input =
       """
-        |def foo(): String = unchecked_cast(123 as _)
+        |enum E[_]
+        |def foo(): String = unchecked_cast(123 as E[_])
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[ResolutionError.IllegalWildType](result)

--- a/main/test/flix/Test.Kind.Class.flix
+++ b/main/test/flix/Test.Kind.Class.flix
@@ -46,7 +46,7 @@ mod Test.Kind.Class {
             mod Mix {
                 // ensure we use `m`'s annotation
                 class CTypeBoolType[m: Type -> Bool -> Type] {
-                    pub def fAndM(f: a -> b \ ef1, x: m[a, ef2]): m[b, ef1 and ef2]
+                    pub def fAndM(f: a -> b \ ef1, x: m[a, ef2]): m[b, ef1 + ef2]
                 }
             }
         }


### PR DESCRIPTION
This removes the `and` syntax from the parser. `+` now means `and`, and `&` means `or`. 

After this PR we should be able to re-enable most of the disabled tests, 