### PR TITLE
chore: rename `Command.Doc` to `Command.Info`

### DIFF
--- a/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Command.scala
@@ -38,7 +38,7 @@ object Command {
   /**
     * Displays documentation about the fqn s
     */
-  case class Doc(s: String) extends Command
+  case class Info(s: String) extends Command
 
   /**
     * Creates a new project in the current directory
@@ -123,11 +123,11 @@ object Command {
       return Command.Reload
 
     //
-    // Doc
+    // Info
     //
-    val docPattern = raw":d(oc)?\s+(\S+)\s*".r
+    val infoPattern = raw":i(nfo)?\s+(\S+)\s*".r
     input match {
-      case docPattern(_, s) => return Command.Doc(s)
+      case infoPattern(_, s) => return Command.Info(s)
       case _ => // no-op
     }
 

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -154,7 +154,7 @@ class Shell(bootstrap: Bootstrap, options: Options) {
   private def execute(cmd: Command)(implicit terminal: Terminal): Unit = cmd match {
     case Command.Nop => // nop
     case Command.Reload => execReload()
-    case Command.Doc(s) => execDoc(s)
+    case Command.Info(s) => execInfo(s)
     case Command.Quit => execQuit()
     case Command.Help => execHelp()
     case Command.Praise => execPraise()
@@ -187,7 +187,7 @@ class Shell(bootstrap: Bootstrap, options: Options) {
   /**
     * Displays documentation for the given identifier
     */
-  private def execDoc(s: String)(implicit terminal: Terminal): Unit = {
+  private def execInfo(s: String)(implicit terminal: Terminal): Unit = {
     val w = terminal.writer()
     val classSym = Symbol.mkClassSym(s)
     val defnSym = Symbol.mkDefnSym(s)
@@ -236,7 +236,7 @@ class Shell(bootstrap: Bootstrap, options: Options) {
     w.println("  Command       Arguments     Purpose")
     w.println()
     w.println("  :reload :r                  Recompiles every source file.")
-    w.println("  :doc :d       <fqn>         Displays documentation for <fqn>.")
+    w.println("  :info :i      <fqn>         Displays documentation for <fqn>.")
     w.println("  :init                       Creates a new project in the current directory.")
     w.println("  :check :c                   Checks the current project for errors.")
     w.println("  :build :b                   Builds (i.e. compiles) the current project.")


### PR DESCRIPTION
I understood this to include the command itself as well: `:doc / :d` -> `:info / :i`

Fixes #5918