### PR TITLE
chore: drop `Read(r)` and `Write(r)` in the standard library

### DIFF
--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -19,7 +19,7 @@ mod Array {
     ///
     /// Compares `a` and `b` lexicographically.
     ///
-    pub def compare(a: Array[v, r1], b: Array[v, r2]): Comparison \ Read(r1, r2) with Order[v] =
+    pub def compare(a: Array[v, r1], b: Array[v, r2]): Comparison \ { r1, r2 } with Order[v] =
         let len = Int32.min(Array.length(a), Array.length(b));
         def loop(i) = {
             if (i < len) {
@@ -41,7 +41,7 @@ mod Array {
     ///
     /// Returns a string representation of the given array `a`.
     ///
-    pub def toString(a: Array[a, r]): String \ Read(r) with ToString[a] = region rc2 {
+    pub def toString(a: Array[a, r]): String \ r with ToString[a] = region rc2 {
         let sb = StringBuilder.new(rc2);
         let first = ref true @ rc2;
 
@@ -60,25 +60,25 @@ mod Array {
     ///
     /// Returns a new uninitialized array of length `l` in the region `r`.
     ///
-    pub def new(r: Region[r], l: Int32): Array[a, r] \ Write(r) =
+    pub def new(r: Region[r], l: Int32): Array[a, r] \ r =
         $ARRAY_NEW$(r, Reflect.default(), l)
 
     ///
     /// Retrieves the value at position `i` in the array `a`.
     ///
-    pub def get(i: Int32, a: Array[a, r]): a \ Read(r) =
+    pub def get(i: Int32, a: Array[a, r]): a \ r =
         $ARRAY_LOAD$(a, i)
 
     ///
     /// Stores the value `x` at position `i` in the array `a`.
     ///
-    pub def put(x: a, i: Int32, a: Array[a, r]): Unit \ Write(r) =
+    pub def put(x: a, i: Int32, a: Array[a, r]): Unit \ r =
         $ARRAY_STORE$(a, i, x)
 
     ///
     /// Optionally returns the element at position `i` in the array `a`.
     ///
-    pub def nth(i: Int32, a: Array[a, r]): Option[a] \ Read(r) =
+    pub def nth(i: Int32, a: Array[a, r]): Option[a] \ r =
         if (0 <= i and i < length(a))
             Some(get(i, a))
         else
@@ -97,13 +97,13 @@ mod Array {
     ///
     /// Returns a fresh array with the elements from the array `a` from index `start` (inclusive) until index `end` (exclusive).
     ///
-    pub def slice(r1: Region[r1], start: {start = Int32}, end: {end = Int32}, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
+    pub def slice(r1: Region[r1], start: {start = Int32}, end: {end = Int32}, a: Array[a, r]): Array[a, r1] \ { r, r1 } =
         copyOfRange(r1, start.start, end.end, a)
 
     ///
     /// Returns the array `a` as a list.
     ///
-    pub def toList(a: Array[a, r]): List[a] \ Read(r) =
+    pub def toList(a: Array[a, r]): List[a] \ r =
         def loop(i, acc) = {
             if (i == 0) {
                 acc
@@ -119,7 +119,7 @@ mod Array {
     ///
     /// If `arr` is empty return `None`, otherwise return the Nel wrapped in `Some`.
     ///
-    pub def toNel(arr: Array[a, r]): Option[Nel[a]] \ Read(r) =
+    pub def toNel(arr: Array[a, r]): Option[Nel[a]] \ r =
         def loop(i, acc) = {
             if (i == 0) {
                 acc
@@ -138,7 +138,7 @@ mod Array {
     ///
     /// Returns the array `a` as a `DelayList`.
     ///
-    pub def toDelayList(a: Array[a, r]): DelayList[a] \ Read(r) =
+    pub def toDelayList(a: Array[a, r]): DelayList[a] \ r =
         def loop(i, acc) = {
             if (i < 0)
                 acc
@@ -150,7 +150,7 @@ mod Array {
     ///
     /// Returns the array `arr` as a chain.
     ///
-    pub def toChain(arr: Array[a, r]): Chain[a] \ Read(r) =
+    pub def toChain(arr: Array[a, r]): Chain[a] \ r =
         def loop(i, acc) = {
             if (i == 0) {
                 acc
@@ -166,7 +166,7 @@ mod Array {
     ///
     /// If `arr` is empty return `None`, otherwise return the Nec wrapped in `Some`.
     ///
-    pub def toNec(arr: Array[a, r]): Option[Nec[a]] \ Read(r) =
+    pub def toNec(arr: Array[a, r]): Option[Nec[a]] \ r =
         def loop(i, acc) = {
             if (i == 0) {
                 acc
@@ -185,7 +185,7 @@ mod Array {
     ///
     /// Returns `a` as a MutDeque.
     ///
-    pub def toMutDeque(r1: Region[r1], a: Array[a, r2]): MutDeque[a, r1] \ { Read(r2), Write(r1) }  =
+    pub def toMutDeque(r1: Region[r1], a: Array[a, r2]): MutDeque[a, r1] \ { r2, r1 }  =
         let d = MutDeque.new(r1);
         forEach(x -> MutDeque.pushBack(x, d), a);
         d
@@ -193,7 +193,7 @@ mod Array {
     ///
     /// Returns `a` as a Vector.
     ///
-    pub def toVector(a: Array[a, r]): Vector[a] \ Read(r) = region rc {
+    pub def toVector(a: Array[a, r]): Vector[a] \ r = region rc {
         let arr1 = copyOfRange(rc, 0, length(a), a);
         unchecked_cast(arr1 as Vector[a])
     }
@@ -203,7 +203,7 @@ mod Array {
     ///
     /// Returns `None` if `a` is empty.
     ///
-    pub def head(a: Array[a, r]): Option[a] \ Read(r) =
+    pub def head(a: Array[a, r]): Option[a] \ r =
         if (length(a) > 0) Some(get(0, a)) else None
 
     ///
@@ -211,14 +211,14 @@ mod Array {
     ///
     /// Returns `None` if `a` is empty.
     ///
-    pub def last(a: Array[a, r]): Option[a] \ Read(r) =
+    pub def last(a: Array[a, r]): Option[a] \ r =
         let len = length(a);
         if (len > 0) Some(get(len - 1, a)) else None
 
     ///
     /// Return a new array, appending the elements `b` to elements of `a`.
     ///
-    pub def append(r3: Region[r3], a: Array[a, r1], b: Array[a, r2]): Array[a, r3] \ { Read(r1), Read(r2), Write(r3) } =
+    pub def append(r3: Region[r3], a: Array[a, r1], b: Array[a, r2]): Array[a, r3] \ { r1, r2, r3 } =
         let len1 = length(a);
         let len2 = length(b);
         if (len1 == 0)
@@ -232,7 +232,7 @@ mod Array {
     ///
     /// Returns `true` if and only if `a` contains the element `x`.
     ///
-    pub def memberOf(x: a, a: Array[a, r]): Bool \ Read(r) with Eq[a] =
+    pub def memberOf(x: a, a: Array[a, r]): Bool \ r with Eq[a] =
         exists(y -> y == x, a)
 
     ///
@@ -240,7 +240,7 @@ mod Array {
     ///
     /// Returns `None` if `a` is empty.
     ///
-    pub def minimum(a: Array[a, r]): Option[a] \ Read(r) with Order[a] =
+    pub def minimum(a: Array[a, r]): Option[a] \ r with Order[a] =
         reduceLeft(Order.min, a)
 
     ///
@@ -248,7 +248,7 @@ mod Array {
     ///
     /// Returns `None` if `a` is empty.
     ///
-    pub def minimumBy(cmp: (a, a) -> Comparison, a: Array[a, r]): Option[a] \ Read(r) =
+    pub def minimumBy(cmp: (a, a) -> Comparison, a: Array[a, r]): Option[a] \ r =
         reduceLeft(Order.minBy(cmp), a)
 
     ///
@@ -256,7 +256,7 @@ mod Array {
     ///
     /// Returns `None` if `a` is empty.
     ///
-    pub def maximum(a: Array[a, r]): Option[a] \ Read(r) with Order[a] =
+    pub def maximum(a: Array[a, r]): Option[a] \ r with Order[a] =
         reduceLeft(Order.max, a)
 
     ///
@@ -264,20 +264,20 @@ mod Array {
     ///
     /// Returns `None` if `a` is empty.
     ///
-    pub def maximumBy(cmp: (a, a) -> Comparison, a: Array[a, r]): Option[a] \ Read(r) =
+    pub def maximumBy(cmp: (a, a) -> Comparison, a: Array[a, r]): Option[a] \ r =
         reduceLeft(Order.maxBy(cmp), a)
 
     ///
     /// Alias for `IndexOfLeft`
     ///
-    pub def indexOf(x: a, a: Array[a, r]): Option[Int32] \ Read(r) with Eq[a] =
+    pub def indexOf(x: a, a: Array[a, r]): Option[Int32] \ r with Eq[a] =
         indexOfLeft(x,a)
 
     ///
     /// Optionally returns the position of the first occurrence of `a` in `arr`
     /// searching from left to right.
     ///
-    pub def indexOfLeft(a: a, arr: Array[a, r]): Option[Int32] \ Read(r) with Eq[a] =
+    pub def indexOfLeft(a: a, arr: Array[a, r]): Option[Int32] \ r with Eq[a] =
         def loop(i) = {
             if (i >= length(arr))
                 -1
@@ -293,7 +293,7 @@ mod Array {
     /// Optionally returns the position of the first occurrence of `a` in `arr`
     /// searching from right to left.
     ///
-    pub def indexOfRight(a: a, arr: Array[a, r]): Option[Int32] \ Read(r) with Eq[a] =
+    pub def indexOfRight(a: a, arr: Array[a, r]): Option[Int32] \ r with Eq[a] =
         def loop(i) = {
             if (i < 0)
                 -1
@@ -308,19 +308,19 @@ mod Array {
     ///
     /// Return the positions of the all the occurrences of `a` in `arr`.
     ///
-    pub def indices(r: Region[r], a: a, arr: Array[a, r]): Array[Int32, r] \ { Read(r), Write(r) } with Eq[a] =
+    pub def indices(r: Region[r], a: a, arr: Array[a, r]): Array[Int32, r] \ r with Eq[a] =
         findIndices(r, b -> a == b, arr)
 
     ///
     /// Alias for `findLeft`.
     ///
-    pub def find(f: a -> Bool \ ef, arr: Array[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def find(f: a -> Bool \ ef, arr: Array[a, r]): Option[a] \ { ef, r } =
         findLeft(f, arr)
 
     ///
     /// Optionally returns the first element of `a` that satisfies the predicate `f` when searching from left to right.
     ///
-    pub def findLeft(f: a -> Bool \ ef, arr: Array[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def findLeft(f: a -> Bool \ ef, arr: Array[a, r]): Option[a] \ { ef, r } =
         match findIndexOfLeft(f, arr) {
             case None    => None
             case Some(i) => Some(get(i, arr))
@@ -329,7 +329,7 @@ mod Array {
     ///
     /// Optionally returns the first element of `xs` that satisfies the predicate `f` when searching from right to left.
     ///
-    pub def findRight(f: a -> Bool \ ef, arr: Array[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def findRight(f: a -> Bool \ ef, arr: Array[a, r]): Option[a] \ { ef, r } =
         match findIndexOfRight(x -> f(x), arr) {
             case None    => None
             case Some(i) => Some(get(i, arr))
@@ -340,7 +340,7 @@ mod Array {
     ///
     /// Returns `[]` if `b >= e`.
     ///
-    pub def range(r: Region[r], b: Int32, e: Int32): Array[Int32, r] \ Write(r) =
+    pub def range(r: Region[r], b: Int32, e: Int32): Array[Int32, r] \ r =
         if (b >= e)
             Array#{} @ r
         else {
@@ -353,7 +353,7 @@ mod Array {
     ///
     /// Returns the empty array if `n <= 0`.
     ///
-    pub def repeat(r: Region[r], n: Int32, x: a): Array[a, r] \ Write(r) =
+    pub def repeat(r: Region[r], n: Int32, x: a): Array[a, r] \ r =
         if (n <= 0)
             Array#{} @ r
         else
@@ -362,7 +362,7 @@ mod Array {
     ///
     /// Alias for `scanLeft`.
     ///
-    pub def scan(r: Region[r], f: (b, a) -> b \ ef, s: b, arr: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
+    pub def scan(r: Region[r], f: (b, a) -> b \ ef, s: b, arr: Array[a, r]): Array[b, r] \ { ef, r } =
         scanLeft(r, f, s, arr)
 
     ///
@@ -370,7 +370,7 @@ mod Array {
     ///
     /// That is, the result is of the form: `[s , f(s, x1), f(f(s, x1), x2),  ...]`.
     ///
-    pub def scanLeft(r: Region[r], f: (b, a) -> b \ ef, s: b, arr: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
+    pub def scanLeft(r: Region[r], f: (b, a) -> b \ ef, s: b, arr: Array[a, r]): Array[b, r] \ { ef, r } =
         let len = length(arr) + 1;
         let b = repeat(r, len, s);
         def loop(i, acc) = {
@@ -390,7 +390,7 @@ mod Array {
     ///
     /// That is, the result is of the form: `[..., f(xn-1, f(xn, s)), f(xn, s), s]`.
     ///
-    pub def scanRight(r: Region[r], f: (a, b) -> b \ ef, s: b, a: Array[a, r]): Array[b, r] \ { ef, Read(r), Write(r) } =
+    pub def scanRight(r: Region[r], f: (a, b) -> b \ ef, s: b, a: Array[a, r]): Array[b, r] \ { ef, r } =
         let len = length(a);
         let b = repeat(r, len + 1, s);
         def loop(i, acc) = {
@@ -410,14 +410,14 @@ mod Array {
     ///
     /// The result is a new array.
     ///
-    pub def map(r1: Region[r1], f: a -> b \ ef, a: Array[a, r]): Array[b, r1] \ { ef, Read(r), Write(r1) } =
+    pub def map(r1: Region[r1], f: a -> b \ ef, a: Array[a, r]): Array[b, r1] \ { ef, r, r1 } =
         let len = length(a);
         init(r1, i -> f(get(i, a)), len)
 
     ///
     /// Apply `f` to every element in array `arr`. Array `arr` is mutated.
     ///
-    pub def transform!(f: a -> a \ ef, arr: Array[a, r]): Unit \ { ef, Read(r), Write(r) } =
+    pub def transform!(f: a -> a \ ef, arr: Array[a, r]): Unit \ { ef, r } =
         let len = length(arr);
         def loop(i) = {
             if (i >= len)
@@ -434,14 +434,14 @@ mod Array {
     ///
     /// That is, the result is of the form: `[ f(a[0], 0), f(a[1], 1), ... ]`.
     ///
-    pub def mapWithIndex(r1: Region[r1], f: (Int32, a) -> b \ ef, a: Array[a, r]): Array[b, r1] \ { ef, Read(r), Write(r1) } =
+    pub def mapWithIndex(r1: Region[r1], f: (Int32, a) -> b \ ef, a: Array[a, r]): Array[b, r1] \ { ef, r, r1 } =
         let len = length(a);
         init(r1, i -> f(i, get(i, a)), len)
 
     ///
     /// Apply `f` to every element in array `a` along with that element's index. Array `a` is mutated.
     ///
-    pub def transformWithIndex!(f: (Int32, a) -> a \ ef, arr: Array[a, r]): Unit \ { ef, Read(r), Write(r) } =
+    pub def transformWithIndex!(f: (Int32, a) -> a \ ef, arr: Array[a, r]): Unit \ { ef, r } =
         let len = length(arr);
         def loop(i) = {
             if (i >= len)
@@ -456,14 +456,14 @@ mod Array {
     ///
     /// Returns the result of applying `f` to every element in `a` and concatenating the results.
     ///
-    pub def flatMap(r1: Region[r1], f: a -> Array[b, r1] \ ef, a: Array[a, r]): Array[b, r1] \ { ef, Read(r), Write(r1) } =
+    pub def flatMap(r1: Region[r1], f: a -> Array[b, r1] \ ef, a: Array[a, r]): Array[b, r1] \ { ef, r, r1 } =
         let len = length(a);
         init(r1, i -> f(get(i, a)), len) |> flatten(r1)
 
     ///
     /// Returns the reverse of `a`.
     ///
-    pub def reverse(r1: Region[r1], a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
+    pub def reverse(r1: Region[r1], a: Array[a, r]): Array[a, r1] \ { r, r1 } =
         let len = length(a);
         let end = len - 1;
         init(r1, i -> get(end - i, a), len)
@@ -471,7 +471,7 @@ mod Array {
     ///
     /// Reverse the array `arr`, mutating it in place.
     ///
-    pub def reverse!(arr: Array[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def reverse!(arr: Array[a, r]): Unit \ r =
         let len = length(arr);
         let halflen = len / 2;
         def loop(i, j) = {
@@ -490,7 +490,7 @@ mod Array {
     ///
     /// Rotate the contents of array `arr` by `n` steps to the left.
     ///
-    pub def rotateLeft(r2: Region[r2], n: Int32, arr: Array[a, r1]): Array[a, r2] \ { Read(r1), Write(r2) } =
+    pub def rotateLeft(r2: Region[r2], n: Int32, arr: Array[a, r1]): Array[a, r2] \ { r1, r2 } =
         let len = length(arr);
         if (len < 1)
             Array#{} @ r2
@@ -507,7 +507,7 @@ mod Array {
     ///
     /// This is an explicit helper to avoid code duplication.
     ///
-    def rotateLeftHelper(r2: Region[r2], n: Int32, arr: Array[a, r1]): Array[a, r2] \ { Read(r1), Write(r2) } =
+    def rotateLeftHelper(r2: Region[r2], n: Int32, arr: Array[a, r1]): Array[a, r2] \ { r1, r2 } =
         let len = length(arr);
         let f = i -> { let i1 = n + i; get(i1 `Int32.rem` len, arr) };
         init(r2, f, len)
@@ -515,7 +515,7 @@ mod Array {
     ///
     /// Rotate the contents of array `arr` by `n` steps to the right.
     ///
-    pub def rotateRight(r2: Region[r2], n: Int32, arr: Array[a, r1]): Array[a, r2] \ { Read(r1), Write(r2) } =
+    pub def rotateRight(r2: Region[r2], n: Int32, arr: Array[a, r1]): Array[a, r2] \ { r1, r2 } =
         if (length(arr) < 1)
             Array#{} @ r2
         else
@@ -531,7 +531,7 @@ mod Array {
     ///
     /// This is an explicit helper to avoid code duplication.
     ///
-    def rotateRightHelper(r2: Region[r2], n: Int32, a: Array[a, r1]): Array[a, r2] \ { Read(r1), Write(r2) } =
+    def rotateRightHelper(r2: Region[r2], n: Int32, a: Array[a, r1]): Array[a, r2] \ { r1, r2 } =
         let len = length(a);
         let n1 = n `Int32.rem` len;
         let start = len - n1;
@@ -543,7 +543,7 @@ mod Array {
     ///
     /// Returns a shallow copy of `a` if `i < 0` or `i > length(xs)-1`.
     ///
-    pub def update(r1: Region[r1], i: Int32, x: a, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
+    pub def update(r1: Region[r1], i: Int32, x: a, a: Array[a, r]): Array[a, r1] \ { r, r1 } =
         let len = length(a);
         let f = ix -> if (ix == i) x else get(ix, a);
         init(r1, f, len)
@@ -551,13 +551,13 @@ mod Array {
     ///
     /// Returns a copy of `a` with every occurrence of `from` replaced by `to`.
     ///
-    pub def replace(r1: Region[r1], from: {from = a}, to: {to = a}, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } with Eq[a] =
+    pub def replace(r1: Region[r1], from: {from = a}, to: {to = a}, a: Array[a, r]): Array[a, r1] \ { r, r1 } with Eq[a] =
         map(r1, e -> if (e == from.from) to.to else e, a)
 
     ///
     /// Replace every occurrence of `from` by `to` in the array `a`, mutating it in place.
     ///
-    pub def replace!(from: {from = a}, to: {to = a}, a: Array[a, r]): Unit \ { Read(r), Write(r) } with Eq[a] =
+    pub def replace!(from: {from = a}, to: {to = a}, a: Array[a, r]): Unit \ r with Eq[a] =
         transform!(e -> if (e == from.from) to.to else e, a)
 
     ///
@@ -567,7 +567,7 @@ mod Array {
     /// If `a` becomes depleted then no further patching is done.
     /// If patching occurs at index `i+j` in `b`, then the element at index `j` in `a` is used.
     ///
-    pub def patch(r3: Region[r3], i: Int32, n: Int32, a: Array[a, r1], b: Array[a, r2]): Array[a, r3] \ { Read(r1, r2), Write(r3) } =
+    pub def patch(r3: Region[r3], i: Int32, n: Int32, a: Array[a, r1], b: Array[a, r2]): Array[a, r3] \ { r1, r2, r3 } =
         let len1 = length(a);
         let size = if (n > len1) len1 else n;
         let sub = copyOfRange(r3, 0, size, a);
@@ -580,7 +580,7 @@ mod Array {
     /// If `a` becomes depleted then no further patching is done.
     /// If patching occurs at index `i+j` in `b`, then the element at index `j` in `a` is used.
     ///
-    pub def patch!(i: Int32, n: Int32, a: Array[a, r1], b: Array[a, r2]): Unit \ { Read(r1), Write(r2) } = region rc3 {
+    pub def patch!(i: Int32, n: Int32, a: Array[a, r1], b: Array[a, r2]): Unit \ { r1, r2 } = region rc3 {
         let len1 = length(a);
         let size = if (n > len1) len1 else n;
         let sub = copyOfRange(rc3, 0, size, a);
@@ -590,7 +590,7 @@ mod Array {
     ///
     /// Returns `a` with `x` inserted between every two adjacent elements.
     ///
-    pub def intersperse(r1: Region[r1], x: a, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) }=
+    pub def intersperse(r1: Region[r1], x: a, a: Array[a, r]): Array[a, r1] \ { r, r1 }=
         let len1 = length(a);
         let len2 = len1 + len1 - 1;
         if (len2 <= 0)
@@ -605,7 +605,7 @@ mod Array {
     ///
     /// Returns the concatenation of the elements in `arrs` with the elements of `sep` inserted between every two adjacent elements.
     ///
-    pub def intercalate(r1: Region[r1], sep: Array[a, r], arrs: Array[Array[a, r], r]): Array[a, r1] \ { Read(r), Write(r1) } =
+    pub def intercalate(r1: Region[r1], sep: Array[a, r], arrs: Array[Array[a, r], r]): Array[a, r1] \ { r, r1 } =
         let count = length(arrs);
         let sepLength = length(sep);
         let sepCount = if (count < 2) 0 else count - 1;
@@ -635,7 +635,7 @@ mod Array {
     ///
     /// Helper function for `intercalate` which needs to do sucessive writing.
     ///
-    def arrayWrites(pos: Int32, sub: Array[a, r1], out: Array[a, r2]): Int32 \ { Read(r1), Write(r2) } =
+    def arrayWrites(pos: Int32, sub: Array[a, r1], out: Array[a, r2]): Int32 \ { r1, r2 } =
         updateSequence!(pos, sub, out);
         pos + length(sub)
 
@@ -644,7 +644,7 @@ mod Array {
     ///
     /// Helper function for `intercalate` and `flatten`.
     ///
-    def sumLengths(arrs: Array[Array[a, r1], r2]): Int32 \ Read(r2) =
+    def sumLengths(arrs: Array[Array[a, r1], r2]): Int32 \ r2 =
         foldLeft((acc, a) -> acc + length(a), 0, arrs)
 
     ///
@@ -652,7 +652,7 @@ mod Array {
     ///
     /// Helper function for `intercalate` and `flatten`.
     ///
-    def headArrays(arrs: Array[Array[a, r1], r2]): Option[a] \ Read(r1, r2) =
+    def headArrays(arrs: Array[Array[a, r1], r2]): Option[a] \ { r1, r2 } =
         let len = length(arrs);
         def loop(i) = {
             if (i >= len)
@@ -670,7 +670,7 @@ mod Array {
     ///
     /// Returns `a` if the dimensions of the elements of `a` are mismatched.
     ///
-    pub def transpose(r3: Region[r3], a: Array[Array[a, r1], r2]): Array[Array[a, r3], r3] \ { Read(r1, r2), Write(r3) } =
+    pub def transpose(r3: Region[r3], a: Array[Array[a, r1], r2]): Array[Array[a, r3], r3] \ { r1, r2, r3 } =
         let ilen = length(a);
         if (ilen == 0)
             Array#{} @ r3
@@ -686,13 +686,13 @@ mod Array {
     ///
     /// Helper function for `transpose`.
     ///
-    def uniformHelper(a: Array[Array[a, r1], r2], l: Int32): Bool \ Read(r2) =
+    def uniformHelper(a: Array[Array[a, r1], r2], l: Int32): Bool \ r2 =
         exists(x -> length(x) != l, a)
 
     ///
     /// Returns `true` if and only if `a1` is a prefix of `a2`.
     ///
-    pub def isPrefixOf(a1: Array[a, r1], a2: Array[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
+    pub def isPrefixOf(a1: Array[a, r1], a2: Array[a, r2]): Bool \ { r1, r2 } with Eq[a] =
         let len1 = length(a1);
         if (len1 > length(a2))
             false
@@ -710,7 +710,7 @@ mod Array {
     ///
     /// Returns `true` if and only if `a1` is a infix of `a2`.
     ///
-    pub def isInfixOf(a1: Array[a, r1], a2: Array[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
+    pub def isInfixOf(a1: Array[a, r1], a2: Array[a, r2]): Bool \ { r1, r2 } with Eq[a] =
         let len1 = length(a1);
         let len2 = length(a2);
         if (len1 > len2)
@@ -725,7 +725,7 @@ mod Array {
     ///
     /// Precondition: len1 (length of a1) > 0
     ///
-    def isInfixOfSearch(a1: Array[a, r1], a2: Array[a, r2], len1: Int32, len2: Int32, j: Int32): Bool \ Read(r1, r2) with Eq[a] =
+    def isInfixOfSearch(a1: Array[a, r1], a2: Array[a, r2], len1: Int32, len2: Int32, j: Int32): Bool \ { r1, r2 } with Eq[a] =
         if (j >= len2)
             false
         else if (get(0, a1) == get(j, a2))
@@ -736,7 +736,7 @@ mod Array {
     ///
     /// Helper function for `isInfixOf` - a1 has started matching, scan to see if it all matches.
     ///
-    def isInfixOfCheck(a1: Array[a, r1], a2: Array[a, r2], len1: Int32, len2: Int32, i: Int32, j: Int32): Bool \ Read(r1, r2) with Eq[a] =
+    def isInfixOfCheck(a1: Array[a, r1], a2: Array[a, r2], len1: Int32, len2: Int32, i: Int32, j: Int32): Bool \ { r1, r2 } with Eq[a] =
         if (i >= len1)
             // a1 exhausted, so success
             true
@@ -751,7 +751,7 @@ mod Array {
     ///
     /// Returns `true` if and only if `a1` is a suffix of `a2`.
     ///
-    pub def isSuffixOf(a1: Array[a, r1], a2: Array[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
+    pub def isSuffixOf(a1: Array[a, r1], a2: Array[a, r2]): Bool \ { r1, r2 } with Eq[a] =
         let len1 = length(a1);
         let len2 = length(a2);
         if (len1 > len2)
@@ -770,14 +770,14 @@ mod Array {
     ///
     /// Returns the result of applying `combine` to all the elements in `a`, using `empty` as the initial value.
     ///
-    pub def fold(arr: Array[a, r]): a \ Read(r) with Monoid[a] = foldLeft(Monoid.combine, Monoid.empty(), arr)
+    pub def fold(arr: Array[a, r]): a \ r with Monoid[a] = foldLeft(Monoid.combine, Monoid.empty(), arr)
 
     ///
     /// Applies `f` to a start value `s` and all elements in `a` going from left to right.
     ///
     /// That is, the result is of the form: `f(...f(f(s, a[0]), a[1])..., xn)`.
     ///
-    pub def foldLeft(f: (b, a) -> b \ ef, s: b, arr: Array[a, r]): b \ { ef, Read(r) } =
+    pub def foldLeft(f: (b, a) -> b \ ef, s: b, arr: Array[a, r]): b \ { ef, r } =
         let len = length(arr);
         def loop(i, acc) = {
             if (i >= len)
@@ -792,7 +792,7 @@ mod Array {
     ///
     /// That is, the result is of the form: `f(a[0], ...f(a[n-1], f(a[n], s))...)`.
     ///
-    pub def foldRight(f: (a, b) -> b \ ef, s: b, arr: Array[a, r]): b \ { ef, Read(r) } =
+    pub def foldRight(f: (a, b) -> b \ ef, s: b, arr: Array[a, r]): b \ { ef, r } =
         def loop(i, acc) = {
             if (i < 0)
                 acc
@@ -807,7 +807,7 @@ mod Array {
     /// That is, the result is of the form: `f(a[0], ...f(a[n-1], f(a[n], z))...)`.
     /// A `foldRightWithCont` allows early termination by not calling the continuation.
     ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ {ef,  r}) -> b \ {ef, r}, z: b, arr: Array[a, r]): b \ { ef, Read(r) } =
+    pub def foldRightWithCont(f: (a, Unit -> b \ {ef,  r}) -> b \ {ef, r}, z: b, arr: Array[a, r]): b \ { ef, r } =
         def loop(i) = {
             if (i == length(arr))
                 z
@@ -819,7 +819,7 @@ mod Array {
     ///
     /// Returns the result of mapping each element and combining the results.
     ///
-    pub def foldMap(f: a -> b \ ef, arr: Array[a, r]): b \ { ef, Read(r) } with Monoid[b] =
+    pub def foldMap(f: a -> b \ ef, arr: Array[a, r]): b \ { ef, r } with Monoid[b] =
         foldLeft((acc, x) -> Monoid.combine(acc, f(x)), Monoid.empty(), arr)
 
     ///
@@ -827,7 +827,7 @@ mod Array {
     ///
     /// Returns `None` if `a` is empty.
     ///
-    pub def reduceLeft(f: (a, a) ->  a \ ef, a: Array[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def reduceLeft(f: (a, a) ->  a \ ef, a: Array[a, r]): Option[a] \ { ef, r } =
         let len = length(a);
         def loop(i, acc) = {
             if (i >= len)
@@ -845,7 +845,7 @@ mod Array {
     ///
     /// Returns `None` if `arr` is empty.
     ///
-    pub def reduceRight(f: (a, a) -> a \ ef, arr: Array[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def reduceRight(f: (a, a) -> a \ ef, arr: Array[a, r]): Option[a] \ { ef, r } =
         let len = length(arr);
         def loop(i, acc) = {
             if (i < 0)
@@ -861,25 +861,25 @@ mod Array {
     ///
     /// Returns the number of elements in `a` that satisfy the predicate `f`.
     ///
-    pub def count(f: a -> Bool \ ef, a: Array[a, r]): Int32 \ { ef, Read(r) } =
+    pub def count(f: a -> Bool \ ef, a: Array[a, r]): Int32 \ { ef, r } =
         foldLeft((b, x) -> if (f(x)) b + 1 else b, 0, a)
 
     ///
     /// Returns the sum of all elements in the array `a`.
     ///
-    pub def sum(a: Array[Int32, r]): Int32 \ Read(r) =
+    pub def sum(a: Array[Int32, r]): Int32 \ r =
         foldLeft((acc, x) -> acc + x, 0, a)
 
     ///
     /// Returns the sum of all elements in the array `a` according to the function `f`.
     ///
-    pub def sumWith(f: a -> Int32 \ ef, a: Array[a, r]): Int32 \ { ef, Read(r) } =
+    pub def sumWith(f: a -> Int32 \ ef, a: Array[a, r]): Int32 \ { ef, r } =
         foldLeft((acc, x) -> acc + f(x), 0, a)
 
     ///
     /// Returns the concatenation of the arrays of in the array `arrs`.
     ///
-    pub def flatten(r1: Region[r1], arrs: Array[Array[a, r], r]) : Array[a, r1] \ { Read(r), Write(r1) } =
+    pub def flatten(r1: Region[r1], arrs: Array[Array[a, r], r]) : Array[a, r1] \ { r, r1 } =
         let len = sumLengths(arrs);
         match headArrays(arrs) {
             case None => Array#{} @ r1
@@ -895,7 +895,7 @@ mod Array {
     ///
     /// Returns `false` if `arr` is empty.
     ///
-    pub def exists(f: a -> Bool \ ef, arr: Array[a, r]): Bool \ { ef, Read(r) } =
+    pub def exists(f: a -> Bool \ ef, arr: Array[a, r]): Bool \ { ef, r } =
         let len = length(arr);
         def loop(i) = {
             if (i >= len)
@@ -912,7 +912,7 @@ mod Array {
     ///
     /// Returns `true` if `arr` is empty.
     ///
-    pub def forAll(f: a -> Bool \ ef, arr: Array[a, r]): Bool \ { ef, Read(r) } =
+    pub def forAll(f: a -> Bool \ ef, arr: Array[a, r]): Bool \ { ef, r } =
         let len = length(arr);
         def loop(i) = {
             if (i >= len)
@@ -927,7 +927,7 @@ mod Array {
     ///
     /// Returns an array of every element in `arr` that satisfies the predicate `f`.
     ///
-    pub def filter(r1: Region[r1], f: a -> Bool \ ef, arr: Array[a, r]): Array[a, r1] \ { ef, Read(r), Write(r1) } =
+    pub def filter(r1: Region[r1], f: a -> Bool \ ef, arr: Array[a, r]): Array[a, r1] \ { ef, r, r1 } =
         let len = length(arr);
         if (len < 1) {
             Array#{} @ r1
@@ -956,7 +956,7 @@ mod Array {
     /// `a1` contains all elements of `a` that satisfy the predicate `f`.
     /// `a2` contains all elements of `a` that do not satisfy the predicate `f`.
     ///
-    pub def partition(r1: Region[r1], r2: Region[r2], f: a -> Bool \ ef, a: Array[a, r]): (Array[a, r1], Array[a, r2]) \ { ef, Read(r), Write(r1), Write(r2) } =
+    pub def partition(r1: Region[r1], r2: Region[r2], f: a -> Bool \ ef, a: Array[a, r]): (Array[a, r1], Array[a, r2]) \ { ef, r, r1, r2 } =
         let step = { (x, acc) ->
             let (a1, a2) = acc;
             if (f(x)) (x :: a1, a2) else (a1, x :: a2)
@@ -970,7 +970,7 @@ mod Array {
     /// `a1` is the longest prefix of `a` that satisfies the predicate `f`.
     /// `a2` is the remainder of `a`.
     ///
-    pub def span(r1: Region[r1], r2: Region[r2], f: a -> Bool \ ef, a: Array[a, r]): (Array[a, r1], Array[a, r2]) \ { ef, Read(r), Write(r1), Write(r2) } =
+    pub def span(r1: Region[r1], r2: Region[r2], f: a -> Bool \ ef, a: Array[a, r]): (Array[a, r1], Array[a, r2]) \ { ef, r, r1, r2 } =
         match findIndexOfLeft(x -> not (f(x)), a) {
             case None    => (takeLeft(r1, length(a), a), Array#{} @ r2)
             case Some(i) => (takeLeft(r1, i, a), dropLeft(r2, i, a))
@@ -979,7 +979,7 @@ mod Array {
     ///
     /// Alias for `dropLeft`.
     ///
-    pub def drop(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
+    pub def drop(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { r, r1 } =
         dropLeft(r1, n, a)
 
     ///
@@ -987,7 +987,7 @@ mod Array {
     ///
     /// Returns `[]` if `n > length(a)`.
     ///
-    pub def dropLeft(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
+    pub def dropLeft(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { r, r1 } =
         let len = length(a);
         if (n > len)
             Array#{} @ r1
@@ -1001,7 +1001,7 @@ mod Array {
     ///
     /// Returns `[]` if `n > length(a)`.
     ///
-    pub def dropRight(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
+    pub def dropRight(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { r, r1 } =
         let len = length(a);
         if (n >= len)
             Array#{} @ r1
@@ -1013,13 +1013,13 @@ mod Array {
     ///
     /// Alias for `dropWhileLeft`.
     ///
-    pub def dropWhile(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, Read(r), Write(r1) } =
+    pub def dropWhile(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, r, r1 } =
         dropWhileLeft(r1, f, a)
 
     ///
     /// Returns copy of array `a` without the longest prefix that satisfies the predicate `f`.
     ///
-    pub def dropWhileLeft(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, Read(r), Write(r1) } =
+    pub def dropWhileLeft(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, r, r1 } =
         match findIndexOfLeft(x -> not (f(x)), a) {
             case None    => Array#{} @ r1
             case Some(i) => dropLeft(r1, i, a)
@@ -1028,7 +1028,7 @@ mod Array {
     ///
     /// Returns copy of array `a` without the longest suffix that satisfies the predicate `f`.
     ///
-    pub def dropWhileRight(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, Read(r), Write(r1) } =
+    pub def dropWhileRight(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, r, r1 } =
         match findIndexOfRight(x -> not (f(x)), a) {
             case None    => Array#{} @ r1
             case Some(i) => copyOfRange(r1, 0, i + 1, a)
@@ -1037,7 +1037,7 @@ mod Array {
     ///
     /// Alias for `takeLeft`.
     ///
-    pub def take(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
+    pub def take(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { r, r1 } =
         takeLeft(r1, n, a)
 
     ///
@@ -1045,7 +1045,7 @@ mod Array {
     ///
     /// Returns `a` if `n > length(xs)`.
     ///
-    pub def takeLeft(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
+    pub def takeLeft(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { r, r1 } =
         if (n <= 0)
             Array#{} @ r1
         else {
@@ -1059,7 +1059,7 @@ mod Array {
     ///
     /// Returns `a` if `n > length(xs)`.
     ///
-    pub def takeRight(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
+    pub def takeRight(r1: Region[r1], n: Int32, a: Array[a, r]): Array[a, r1] \ { r, r1 } =
         if (n <= 0)
             Array#{} @ r1
         else {
@@ -1071,13 +1071,13 @@ mod Array {
     ///
     /// Alias for `takeWhileLeft`.
     ///
-    pub def takeWhile(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, Read(r), Write(r1) } =
+    pub def takeWhile(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, r, r1 } =
         takeWhileLeft(r1, f, a)
 
     ///
     /// Returns the longest prefix of `a` that satisfies the predicate `f`.
     ///
-    pub def takeWhileLeft(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, Read(r), Write(r1) } =
+    pub def takeWhileLeft(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, r, r1 } =
         match findIndexOfLeft(x -> not (f(x)), a) {
             case None    => copyOfRange(r1, 0, length(a), a)
             case Some(i) => takeLeft(r1, i, a)
@@ -1086,7 +1086,7 @@ mod Array {
     ///
     /// Returns the longest suffix of `a` that satisfies the predicate `f`.
     ///
-    pub def takeWhileRight(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, Read(r), Write(r1) } =
+    pub def takeWhileRight(r1: Region[r1], f: a -> Bool \ ef, a: Array[a, r]): Array[a, r1] \ { ef, r, r1 } =
         match findIndexOfRight(x -> not (f(x)), a) {
             case None    => copyOfRange(r1, 0, length(a), a)
             case Some(i) => copyOfRange(r1, i + 1, length(a), a)
@@ -1100,14 +1100,14 @@ mod Array {
     ///
     /// The function `f` must be pure.
     ///
-    pub def groupBy(r1: Region[r1], f: (a, a) -> Bool, a: Array[a, r2]): Array[Array[a, r1], r1] \ { Read(r2), Write(r1) } =
+    pub def groupBy(r1: Region[r1], f: (a, a) -> Bool, a: Array[a, r2]): Array[Array[a, r1], r1] \ { r2, r1 } =
         let xs = toList(a);
         groupByHelper(r1, f, xs, Nil) |> List.toArray(r1)
 
     ///
     /// Helper function for `groupBy`.
     ///
-    def groupByHelper(r: Region[r], f: (a, a) -> Bool, xs: List[a], ac: List[Array[a, r]]): List[Array[a, r]] \ Write(r) = match xs {
+    def groupByHelper(r: Region[r], f: (a, a) -> Bool, xs: List[a], ac: List[Array[a, r]]): List[Array[a, r]] \ r = match xs {
         case Nil     => List.reverse(ac)
         case x :: rs =>
             let (r1, r2) = extractHelper(r, f, rs, x :: Nil, Nil);
@@ -1117,7 +1117,7 @@ mod Array {
     ///
     /// Helper function for `groupBy`.
     ///
-    def extractHelper(r: Region[r], f: (a, a) -> Bool, xs: List[a], ps: List[a], ns: List[a]): (Array[a, r], List[a]) \ Write(r) = match xs {
+    def extractHelper(r: Region[r], f: (a, a) -> Bool, xs: List[a], ps: List[a], ns: List[a]): (Array[a, r], List[a]) \ r = match xs {
         case Nil => {
             let a = List.reverse(ps);
             (List.toArray(r, a), List.reverse(ns))
@@ -1147,7 +1147,7 @@ mod Array {
     ///
     /// If either `a` or `b` becomes depleted, then no further elements are added to the resulting array.
     ///
-    pub def zip(r3: Region[r3], a: Array[a, r1], b: Array[b, r2]): Array[(a, b), r3] \ { Read(r1, r2), Write(r3) } =
+    pub def zip(r3: Region[r3], a: Array[a, r1], b: Array[b, r2]): Array[(a, b), r3] \ { r1, r2, r3 } =
         let len = Int32.min(length(a), length(b));
         init(r3, i -> (get(i, a), get(i, b)), len)
 
@@ -1157,7 +1157,7 @@ mod Array {
     ///
     /// If either `a` or `b` becomes depleted, then no further elements are added to the resulting array.
     ///
-    pub def zipWith(r3: Region[r3], f: (a, b) -> c \ ef, a: Array[a, r1], b: Array[b, r2]): Array[c, r3] \ { ef, Read(r1, r2), Write(r3) } =
+    pub def zipWith(r3: Region[r3], f: (a, b) -> c \ ef, a: Array[a, r1], b: Array[b, r2]): Array[c, r3] \ { ef, r1, r2, r3 } =
         let len = Int32.min(length(a), length(b));
         init(r3, i -> f(get(i, a), get(i, b)), len)
 
@@ -1165,7 +1165,7 @@ mod Array {
     /// Returns a pair of arrays, the first containing all first components in `a`
     /// and the second containing all second components in `a`.
     ///
-    pub def unzip(r1: Region[r1], r2: Region[r2], a: Array[(a, b), r3]): (Array[a, r1], Array[b, r2]) \ { Write(r1, r2), Read(r3) } =
+    pub def unzip(r1: Region[r1], r2: Region[r2], a: Array[(a, b), r3]): (Array[a, r1], Array[b, r2]) \ { r1, r2, r3 } =
         let len = length(a);
         if (len <= 0)
             (Array#{} @ r1, Array#{} @ r2)
@@ -1189,14 +1189,14 @@ mod Array {
     ///
     /// Alias for `foldLeft2`.
     ///
-    pub def fold2(f: (c, a, b) -> c \ ef, c: c, a: Array[a, r1], b: Array[b, r2]): c \ { ef, Read(r1, r2) } =
+    pub def fold2(f: (c, a, b) -> c \ ef, c: c, a: Array[a, r1], b: Array[b, r2]): c \ { ef, r1, r2 } =
         foldLeft2(f, c, a, b)
 
     ///
     /// Accumulates the result of applying `f` pairwise to the elements of `a` and `b`
     /// starting with the initial value `c` and going from left to right.
     ///
-    pub def foldLeft2(f: (c, a, b) ->  c \ ef, c: c, a: Array[a, r1], b: Array[b, r2]): c \ { ef, Read(r1, r2) } =
+    pub def foldLeft2(f: (c, a, b) ->  c \ ef, c: c, a: Array[a, r1], b: Array[b, r2]): c \ { ef, r1, r2 } =
         let lena = length(a);
         let lenb = length(b);
         def loop(i, acc) = {
@@ -1211,7 +1211,7 @@ mod Array {
     /// Accumulates the result of applying `f` pairwise to the elements of `a` and `b`
     /// starting with the initial value `c` and going from right to left.
     ///
-    pub def foldRight2(f: (a, b, c) -> c \ ef, c: c, a: Array[a, r1], b: Array[b, r2]): c \ { ef, Read(r1, r2) } =
+    pub def foldRight2(f: (a, b, c) -> c \ ef, c: c, a: Array[a, r1], b: Array[b, r2]): c \ { ef, r1, r2 } =
         def loop(i, j, acc) = {
             if (i < 0 or j < 0)
                 acc
@@ -1225,7 +1225,7 @@ mod Array {
     ///
     /// Collects the results of applying the partial function `f` to every element in `a`.
     ///
-    pub def filterMap(r1: Region[r1], f: a -> Option[b] \ ef, a: Array[a, r]): Array[b, r1] \ { ef, Read(r), Write(r1) } =
+    pub def filterMap(r1: Region[r1], f: a -> Option[b] \ ef, a: Array[a, r]): Array[b, r1] \ { ef, r, r1 } =
         foldRight((x, xs) -> match f(x) {
             case None    => xs
             case Some(b) => b :: xs }, Nil, a) |> List.toArray(r1)
@@ -1235,7 +1235,7 @@ mod Array {
     ///
     /// Returns `None` if every element of `xs` is `None`.
     ///
-    pub def findMap(f: a -> Option[b] \ ef, a: Array[a, r]): Option[b] \ { ef, Read(r) } =
+    pub def findMap(f: a -> Option[b] \ ef, a: Array[a, r]): Option[b] \ { ef, r } =
         let len = length(a);
         def loop(i) = {
             if (i >= len)
@@ -1252,7 +1252,7 @@ mod Array {
     ///
     /// Returns the array `a` as a set.
     ///
-    pub def toSet(a: Array[a, r]): Set[a] \ Read(r) with Order[a] =
+    pub def toSet(a: Array[a, r]): Set[a] \ r with Order[a] =
         foldRight(Set.insert, Set.empty(), a)
 
     ///
@@ -1261,13 +1261,13 @@ mod Array {
     /// If `xs` contains multiple mappings with the same key, `toMap` does not
     /// make any guarantees about which mapping will be in the resulting map.
     ///
-    pub def toMap(a: Array[(a, b), r]): Map[a, b] \ Read(r) with Order[a] =
+    pub def toMap(a: Array[(a, b), r]): Map[a, b] \ r with Order[a] =
         foldRight((x, m) -> Map.insert(fst(x), snd(x), m), Map.empty(), a)
 
     ///
     /// Returns the array `a` as a MutList.
     ///
-    pub def toMutList(r1: Region[r1], a: Array[a, r2]): MutList[a, r1] \ { Read(r2), Write(r1) } =
+    pub def toMutList(r1: Region[r1], a: Array[a, r2]): MutList[a, r1] \ { r2, r1 } =
         let minCap = MutList.minCapacity();
         let len = length(a);
         let c = Order.max(len, minCap);
@@ -1277,13 +1277,13 @@ mod Array {
     ///
     /// Alias for `findIndexOfLeft`.
     ///
-    pub def findIndexOf(f: a -> Bool \ ef, a: Array[a, r]): Option[Int32] \ { ef, Read(r) } =
+    pub def findIndexOf(f: a -> Bool \ ef, a: Array[a, r]): Option[Int32] \ { ef, r } =
         findIndexOfLeft(f,a)
 
     ///
     /// Optionally returns the position of the first element in `x` satisfying `f`.
     ///
-    pub def findIndexOfLeft(f: a -> Bool \ ef, a: Array[a, r]): Option[Int32] \ { ef, Read(r) } =
+    pub def findIndexOfLeft(f: a -> Bool \ ef, a: Array[a, r]): Option[Int32] \ { ef, r } =
         let len = length(a);
         if (len < 1)
             None
@@ -1304,7 +1304,7 @@ mod Array {
     /// Optionally returns the position of the first element in `a` satisfying `f`
     /// searching from right to left.
     ///
-    pub def findIndexOfRight(f: a -> Bool \ ef, a: Array[a, r]): Option[Int32] \ { ef, Read(r) } =
+    pub def findIndexOfRight(f: a -> Bool \ ef, a: Array[a, r]): Option[Int32] \ { ef, r } =
         let len = length(a);
         def loop(i) = {
             if (i < 0)
@@ -1320,7 +1320,7 @@ mod Array {
     ///
     /// Returns the positions of the all the elements in `a` satisfying `f`.
     ///
-    pub def findIndices(r2: Region[r2], f: a -> Bool \ ef, a: Array[a, r1]): Array[Int32, r2] \ { ef, Read(r1), Write(r2) } =
+    pub def findIndices(r2: Region[r2], f: a -> Bool \ ef, a: Array[a, r1]): Array[Int32, r2] \ { ef, r1, r2 } =
         let len = length(a);
         let l = MutList.new(r2);
         def loop(i) = {
@@ -1337,7 +1337,7 @@ mod Array {
     ///
     /// Build an array of length `len` by applying `f` to the successive indices.
     ///
-    pub def init(r: Region[r], f: Int32 -> a \ ef, len: Int32): Array[a, r] \ { ef, Write(r) } =
+    pub def init(r: Region[r], f: Int32 -> a \ ef, len: Int32): Array[a, r] \ { ef, r } =
         if (len <= 0)
             Array#{} @ r
         else {
@@ -1357,7 +1357,7 @@ mod Array {
     ///
     /// Returns `true` if arrays `a` and `b` have the same elements in the same order, i.e. are structurally equal.
     ///
-    pub def sameElements(a: Array[a, r1], b: Array[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
+    pub def sameElements(a: Array[a, r1], b: Array[a, r2]): Bool \ { r1, r2 } with Eq[a] =
         let alen = length(a);
         let blen = length(b);
         def loop(i) = {
@@ -1378,7 +1378,7 @@ mod Array {
     ///
     /// Modifying `a` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(rc: Region[r1], a: Array[a, r2]): Iterator[a, r1 and r2, r1] \ { Write(r1) } =
+    pub def iterator(rc: Region[r1], a: Array[a, r2]): Iterator[a, r1 and r2, r1] \ r1 =
         Iterator.range(rc, 0, length(a)) |> Iterator.map(i -> Array.get(i, a))
 
     ///
@@ -1386,13 +1386,13 @@ mod Array {
     ///
     /// Modifying `a` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def enumerator(rc: Region[r1], a: Array[a, r2]): Iterator[(Int32, a), r1 and r2, r1] \ { Write(r1) } =
+    pub def enumerator(rc: Region[r1], a: Array[a, r2]): Iterator[(Int32, a), r1 and r2, r1] \ r1 =
         iterator(rc, a) |> Iterator.zipWithIndex
 
     ///
     /// Apply the effectful function `f` to all the elements in the array `a`.
     ///
-    pub def forEach(f: a -> Unit \ ef, a: Array[a, r]): Unit \ { ef, Read(r) } =
+    pub def forEach(f: a -> Unit \ ef, a: Array[a, r]): Unit \ { ef, r } =
         let len = length(a);
         def loop(i) = {
             if (i >= len)
@@ -1407,7 +1407,7 @@ mod Array {
     ///
     /// Apply the effectful function `f` to all the elements in the array `a`.
     ///
-    pub def forEachWithIndex(f: (Int32, a) -> Unit \ ef, a: Array[a, r]): Unit \ { ef, Read(r) } =
+    pub def forEachWithIndex(f: (Int32, a) -> Unit \ ef, a: Array[a, r]): Unit \ { ef, r } =
         let len = length(a);
         def loop(i) = {
             if (i >= len)
@@ -1422,7 +1422,7 @@ mod Array {
     ///
     /// Returns a copy of `a` with the elements starting at index `i` replaced by `sub`.
     ///
-    pub def updateSequence(r3: Region[r3], i: Int32, sub: Array[a, r1], a: Array[a, r2]): Array[a, r3] \ { Read(r1, r2), Write(r3) } =
+    pub def updateSequence(r3: Region[r3], i: Int32, sub: Array[a, r1], a: Array[a, r2]): Array[a, r3] \ { r1, r2, r3 } =
         let end = i + length(sub);
         let f = ix -> if (ix >= i and ix < end) get(ix - i, sub) else get(ix, a);
         let len = length(a);
@@ -1431,7 +1431,7 @@ mod Array {
     ///
     /// Update the mutable array `a` with the elements starting at index `i` replaced by `sub`.
     ///
-    pub def updateSequence!(i: Int32, sub: Array[a, r1], a: Array[a, r2]): Unit \ { Read(r1), Write(r2) } =
+    pub def updateSequence!(i: Int32, sub: Array[a, r1], a: Array[a, r2]): Unit \ { r1, r2 } =
         let end = i + length(sub);
         let f = { (ix, _) ->
             if (ix >= i and ix < end)
@@ -1445,14 +1445,14 @@ mod Array {
     /// Returns the concatenation of the string representation
     /// of each element in `a` with `sep` inserted between each element.
     ///
-    pub def join(sep: String, a: Array[a, r]): String \ Read(r) with ToString[a] =
+    pub def join(sep: String, a: Array[a, r]): String \ r with ToString[a] =
         joinWith(ToString.toString, sep, a)
 
     ///
     /// Returns the concatenation of the string representation
     /// of each element in `a` according to `f` with `sep` inserted between each element.
     ///
-    pub def joinWith(f: a -> String \ ef, sep: String, a: Array[a, r]): String \ { ef, Read(r) } = region rc1 {
+    pub def joinWith(f: a -> String \ ef, sep: String, a: Array[a, r]): String \ { ef, r } = region rc1 {
         use StringBuilder.append!;
         let lastSep = String.length(sep);
         let sb = StringBuilder.new(rc1);
@@ -1468,7 +1468,7 @@ mod Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sort(r1: Region[r1], a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } with Order[a] =
+    pub def sort(r1: Region[r1], a: Array[a, r]): Array[a, r1] \ { r, r1 } with Order[a] =
         sortWith(r1, Order.compare, a)
 
     ///
@@ -1479,7 +1479,7 @@ mod Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortBy(r1: Region[r1], f: a -> b, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } with Order[b] =
+    pub def sortBy(r1: Region[r1], f: a -> b, a: Array[a, r]): Array[a, r1] \ { r, r1 } with Order[b] =
         sortWith(r1, Order.compare `on` f, a)
 
     ///
@@ -1490,7 +1490,7 @@ mod Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortWith(r1: Region[r1], cmp: (a,a) -> Comparison, a: Array[a, r]): Array[a, r1] \ { Read(r), Write(r1) } =
+    pub def sortWith(r1: Region[r1], cmp: (a,a) -> Comparison, a: Array[a, r]): Array[a, r1] \ { r, r1 } =
         let len = length(a);
         let b = copyOfRange(r1, 0, len, a);
         sortWith!(cmp, b);
@@ -1504,7 +1504,7 @@ mod Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sort!(a: Array[a, r]): Unit \ { Read(r), Write(r) } with Order[a] =
+    pub def sort!(a: Array[a, r]): Unit \ r with Order[a] =
         sortWith!(Order.compare, a)
 
     ///
@@ -1515,7 +1515,7 @@ mod Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortBy!(f: a -> b, a: Array[a, r]): Unit \ { Read(r), Write(r) } with Order[b] =
+    pub def sortBy!(f: a -> b, a: Array[a, r]): Unit \ r with Order[b] =
         sortWith!(Order.compare `on` f, a)
 
     ///
@@ -1526,7 +1526,7 @@ mod Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortWith!(cmp: (a,a) -> Comparison, a: Array[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def sortWith!(cmp: (a,a) -> Comparison, a: Array[a, r]): Unit \ r =
         sortWithin!(cmp, 0, length(a) - 1, a)
 
     ///
@@ -1538,7 +1538,7 @@ mod Array {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortWithin!(cmp: (a,a) -> Comparison, lo: Int32, hi: Int32, a: Array[a, r]): Unit \ { Read(r), Write(r) }=
+    pub def sortWithin!(cmp: (a,a) -> Comparison, lo: Int32, hi: Int32, a: Array[a, r]): Unit \ r=
         if (lo >= hi)
             ()
         else {
@@ -1552,7 +1552,7 @@ mod Array {
     ///
     /// Precondition: `i` and `j` are within bounds.
     ///
-    pub def swap!(i: Int32, j: Int32, a: Array[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def swap!(i: Int32, j: Int32, a: Array[a, r]): Unit \ r =
         let x = get(i, a);
         let y = get(j, a);
         Array.put(y, i, a);
@@ -1561,7 +1561,7 @@ mod Array {
     ///
     /// Partition step of the Quicksort algorithm.
     ///
-    def quicksortPartition(cmp: (a,a) -> Comparison, a: Array[a, r], lo: Int32, hi: Int32): Int32 \ { Read(r), Write(r) } =
+    def quicksortPartition(cmp: (a,a) -> Comparison, a: Array[a, r], lo: Int32, hi: Int32): Int32 \ r =
         let pivot = get(hi, a);
         let i = forWithAccum(lo, hi, lo, (j,ix) ->
             if (cmp(get(j, a), pivot) == Comparison.LessThan) {
@@ -1595,51 +1595,51 @@ mod Array {
     /// If the range is valid and greater than the length of `a`, the resulting array with have the length of the range
     /// and include the specified range of `a`.
     ///
-    pub def copyOfRange(_: Region[r2], b: Int32, e: Int32, a: Array[a, r1]): Array[a, r2] \ { Read(r1), Write(r2) } =
+    pub def copyOfRange(_: Region[r2], b: Int32, e: Int32, a: Array[a, r1]): Array[a, r2] \ { r1, r2 } =
         // All of the below casts are required to cast the type to `Array[a, ...]`.
         typematch a {
             case arr: Array[Unit, r1] =>
-                import static java.util.Arrays.copyOfRange(Array[##java.lang.Object, r1], Int32, Int32): Array[##java.lang.Object, r2] \ { Read(r1), Write(r2) } as copy;
+                import static java.util.Arrays.copyOfRange(Array[##java.lang.Object, r1], Int32, Int32): Array[##java.lang.Object, r2] \ { r1, r2 } as copy;
                 let arg = unchecked_cast(arr as Array[##java.lang.Object, r1]);
                 unchecked_cast(copy(arg, b, e) as Array[a, r2])
             case arr: Array[Bool, r1] =>
-                import static java.util.Arrays.copyOfRange(Array[Bool, r1], Int32, Int32): Array[Bool, r2] \ { Read(r1), Write(r2) } as copy;
+                import static java.util.Arrays.copyOfRange(Array[Bool, r1], Int32, Int32): Array[Bool, r2] \ { r1, r2 } as copy;
                 unchecked_cast(copy(arr, b, e) as Array[a, r2])
             case arr: Array[Char, r1] =>
-                import static java.util.Arrays.copyOfRange(Array[Char, r1], Int32, Int32): Array[Char, r2] \ { Read(r1), Write(r2) } as copy;
+                import static java.util.Arrays.copyOfRange(Array[Char, r1], Int32, Int32): Array[Char, r2] \ { r1, r2 } as copy;
                 unchecked_cast(copy(arr, b, e) as Array[a, r2])
             case arr: Array[Float32, r1] =>
-                import static java.util.Arrays.copyOfRange(Array[Float32, r1], Int32, Int32): Array[Float32, r2] \ { Read(r1), Write(r2) } as copy;
+                import static java.util.Arrays.copyOfRange(Array[Float32, r1], Int32, Int32): Array[Float32, r2] \ { r1, r2 } as copy;
                 unchecked_cast(copy(arr, b, e) as Array[a, r2])
             case arr: Array[Float64, r1] =>
-                import static java.util.Arrays.copyOfRange(Array[Float64, r1], Int32, Int32): Array[Float64, r2] \ { Read(r1), Write(r2) } as copy;
+                import static java.util.Arrays.copyOfRange(Array[Float64, r1], Int32, Int32): Array[Float64, r2] \ { r1, r2 } as copy;
                 unchecked_cast(copy(arr, b, e) as Array[a, r2])
             case arr: Array[BigDecimal, r1] =>
-                import static java.util.Arrays.copyOfRange(Array[##java.lang.Object, r1], Int32, Int32): Array[##java.lang.Object, r2] \ { Read(r1), Write(r2) } as copy;
+                import static java.util.Arrays.copyOfRange(Array[##java.lang.Object, r1], Int32, Int32): Array[##java.lang.Object, r2] \ { r1, r2 } as copy;
                 let arg = unchecked_cast(arr as Array[##java.lang.Object, r1]);
                 unchecked_cast(copy(arg, b, e) as Array[a, r2])
             case arr: Array[Int8, r1] =>
-                import static java.util.Arrays.copyOfRange(Array[Int8, r1], Int32, Int32): Array[Int8, r2] \ { Read(r1), Write(r2) } as copy;
+                import static java.util.Arrays.copyOfRange(Array[Int8, r1], Int32, Int32): Array[Int8, r2] \ { r1, r2 } as copy;
                 unchecked_cast(copy(arr, b, e) as Array[a, r2])
             case arr: Array[Int16, r1] =>
-                import static java.util.Arrays.copyOfRange(Array[Int16, r1], Int32, Int32): Array[Int16, r2] \ { Read(r1), Write(r2) } as copy;
+                import static java.util.Arrays.copyOfRange(Array[Int16, r1], Int32, Int32): Array[Int16, r2] \ { r1, r2 } as copy;
                 unchecked_cast(copy(arr, b, e) as Array[a, r2])
             case arr: Array[Int32, r1] =>
-                import static java.util.Arrays.copyOfRange(Array[Int32, r1], Int32, Int32): Array[Int32, r2] \ { Read(r1), Write(r2) } as copy;
+                import static java.util.Arrays.copyOfRange(Array[Int32, r1], Int32, Int32): Array[Int32, r2] \ { r1, r2 } as copy;
                 unchecked_cast(copy(arr, b, e) as Array[a, r2])
             case arr: Array[Int64, r1] =>
-                import static java.util.Arrays.copyOfRange(Array[Int64, r1], Int32, Int32): Array[Int64, r2] \ { Read(r1), Write(r2) } as copy;
+                import static java.util.Arrays.copyOfRange(Array[Int64, r1], Int32, Int32): Array[Int64, r2] \ { r1, r2 } as copy;
                 unchecked_cast(copy(arr, b, e) as Array[a, r2])
             case arr: Array[BigInt, r1] =>
-                import static java.util.Arrays.copyOfRange(Array[##java.lang.Object, r1], Int32, Int32): Array[##java.lang.Object, r2] \ { Read(r1), Write(r2) } as copy;
+                import static java.util.Arrays.copyOfRange(Array[##java.lang.Object, r1], Int32, Int32): Array[##java.lang.Object, r2] \ { r1, r2 } as copy;
                 let arg = unchecked_cast(arr as Array[##java.lang.Object, r1]);
                 unchecked_cast(copy(arg, b, e) as Array[a, r2])
             case arr: Array[String, r1] =>
-                import static java.util.Arrays.copyOfRange(Array[##java.lang.Object, r1], Int32, Int32): Array[##java.lang.Object, r2] \ { Read(r1), Write(r2) } as copy;
+                import static java.util.Arrays.copyOfRange(Array[##java.lang.Object, r1], Int32, Int32): Array[##java.lang.Object, r2] \ { r1, r2 } as copy;
                 let arg = unchecked_cast(arr as Array[##java.lang.Object, r1]);
                 unchecked_cast(copy(arg, b, e) as Array[a, r2])
             case arr: Array[a, r1] =>
-                import static java.util.Arrays.copyOfRange(Array[##java.lang.Object, r1], Int32, Int32): Array[##java.lang.Object, r2] \ { Read(r1), Write(r2) } as copy;
+                import static java.util.Arrays.copyOfRange(Array[##java.lang.Object, r1], Int32, Int32): Array[##java.lang.Object, r2] \ { r1, r2 } as copy;
                 let arg = unchecked_cast(arr as Array[##java.lang.Object, r1]);
                 unchecked_cast(copy(arg, b, e) as Array[a, r2])
             case _: _ => unreachable!()

--- a/main/src/library/Benchmark/Bench.Fusion.flix
+++ b/main/src/library/Benchmark/Bench.Fusion.flix
@@ -23,7 +23,7 @@ mod Bench.Fusion {
     ///
     /// Returns a list of `n` concatenated lists with elements from `1` to `1_000`.
     ///
-    pub def input(r: Region[r], n: Int32): Array[Int32, r] \ Write(r) =
+    pub def input(r: Region[r], n: Int32): Array[Int32, r] \ r =
         Array.range(r, 1, n) |>
         Array.flatMap(_ -> Array.range(r, 1, 1_000))
 

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -115,7 +115,7 @@ instance Collectable[Chain] {
 }
 
 instance Iterable[Chain] {
-    pub def iterator(rc: Region[r], c: Chain[a]): Iterator[a, r, r] \ Write(r) = Chain.iterator(rc, c)
+    pub def iterator(rc: Region[r], c: Chain[a]): Iterator[a, r, r] \ r = Chain.iterator(rc, c)
 }
 
 mod Chain {
@@ -747,7 +747,7 @@ mod Chain {
     ///
     /// Returns `c` as a MutDeque.
     ///
-    pub def toMutDeque(r: Region[r], c: Chain[a]): MutDeque[a, r] \ Write(r) =
+    pub def toMutDeque(r: Region[r], c: Chain[a]): MutDeque[a, r] \ r =
         let d = MutDeque.new(r);
         forEach(x -> MutDeque.pushBack(x, d), c);
         d
@@ -755,7 +755,7 @@ mod Chain {
     ///
     /// Returns `c` as a mutable list.
     ///
-    pub def toMutList(r: Region[r], c: Chain[a]): MutList[a, r] \ Write(r) = region rc2 {
+    pub def toMutList(r: Region[r], c: Chain[a]): MutList[a, r] \ r = region rc2 {
         Array.toMutList(r, toArray(rc2, c)) // `Array.toMutList` respects the invariant of `MutList`
     }
 
@@ -777,7 +777,7 @@ mod Chain {
     ///
     /// Returns the chain `c` as an array.
     ///
-    pub def toArray(r: Region[r], c: Chain[a]): Array[a, r] \ Write(r) = match head(c) {
+    pub def toArray(r: Region[r], c: Chain[a]): Array[a, r] \ r = match head(c) {
         case None    => Array#{} @ r
         case Some(_) =>
             let arr = Array.new(r, length(c));
@@ -788,7 +788,7 @@ mod Chain {
     ///
     /// Returns an iterator over `c`.
     ///
-    pub def iterator(rc: Region[r], c: Chain[a]): Iterator[a, r, r] \ Write(r) =
+    pub def iterator(rc: Region[r], c: Chain[a]): Iterator[a, r, r] \ r =
         let cursor = ref viewLeft(c) @ rc;
         let next = () -> match (deref cursor) {
             case ViewLeft.NoneLeft        => None
@@ -802,7 +802,7 @@ mod Chain {
     ///
     /// Returns an iterator over `c` zipped with the indices of the elements.
     ///
-    pub def enumerator(rc: Region[r], c: Chain[a]): Iterator[(Int32, a), r, r] \ Write(r) =
+    pub def enumerator(rc: Region[r], c: Chain[a]): Iterator[(Int32, a), r, r] \ r =
         iterator(rc, c) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/Channel.flix
+++ b/main/src/library/Channel.flix
@@ -20,28 +20,28 @@ mod Channel {
     ///
     /// Returns a new buffered channel with capacity for `n` elements.
     ///
-    pub def buffered(r: Region[r], n: Int32): (Sender[t, r], Receiver[t, r]) \ Write(r) =
+    pub def buffered(r: Region[r], n: Int32): (Sender[t, r], Receiver[t, r]) \ r =
         let m = if (n < 0) 0 else n;
         $CHANNEL_NEW$(r, m)
 
     ///
     /// Returns a new unbuffered channel (i.e. a channel with zero capacity).
     ///
-    pub def unbuffered(r: Region[r]): (Sender[t, r], Receiver[t, r]) \ Write(r) = buffered(r, 0)
+    pub def unbuffered(r: Region[r]): (Sender[t, r], Receiver[t, r]) \ r = buffered(r, 0)
 
     ///
     /// Receives a message from the given channel `r`.
     ///
     /// Blocks until a message is dequeued.
     ///
-    pub def recv(receiver: Receiver[t, r]): t \ { Read(r), Write(r) } = $CHANNEL_GET$(receiver)
+    pub def recv(receiver: Receiver[t, r]): t \ r = $CHANNEL_GET$(receiver)
 
     ///
     /// Sends the message `m` on the given channel `s`.
     ///
     /// Blocks until the message is enqueued.
     ///
-    pub def send(m: t, sender: Sender[t, r]): Unit \ Write(r) with Sendable[t] = $CHANNEL_PUT$(sender, m)
+    pub def send(m: t, sender: Sender[t, r]): Unit \ r with Sendable[t] = $CHANNEL_PUT$(sender, m)
 
     ///
     /// Sends the message `m` on the given channel `s`.
@@ -51,12 +51,12 @@ mod Channel {
     /// Identical to `send` but doesn't require `Sendable`.
     /// It is up to programmer to ensure that race conditions cannot arise due to concurrent access to `m`.
     ///
-    pub def unsafeSend(m: t, sender: Sender[t, r]): Unit \ Write(r) = $CHANNEL_PUT$(sender, m)
+    pub def unsafeSend(m: t, sender: Sender[t, r]): Unit \ r = $CHANNEL_PUT$(sender, m)
 
     ///
     /// Returns a channel that receives the `Unit` message after duration `d`.
     ///
-    pub def timeout(r: Region[r], d: Duration): Receiver[Unit, r] \ { Read(r), Write(r), IO } =
+    pub def timeout(r: Region[r], d: Duration): Receiver[Unit, r] \ { r, IO } =
         let (tx, rx) = Channel.unbuffered(r);
         spawn { Thread.sleep(d); send((), tx) } @ r;
         rx

--- a/main/src/library/Collectable.flix
+++ b/main/src/library/Collectable.flix
@@ -22,6 +22,6 @@ pub class Collectable[m: Type -> Type] {
     ///
     /// Run an Iterator collecting the results.
     ///
-    pub def collect(iter: Iterator[a, ef, r]): m[a] \ {ef, Read(r)} with Order[a]
+    pub def collect(iter: Iterator[a, ef, r]): m[a] \ {ef, r} with Order[a]
 
 }

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -120,7 +120,7 @@ instance Monoid[DelayList[a]] {
 }
 
 instance Iterable[DelayList] {
-    pub def iterator(rc: Region[r], l: DelayList[a]): Iterator[a, r, r] \ Write(r) = DelayList.iterator(rc, l)
+    pub def iterator(rc: Region[r], l: DelayList[a]): Iterator[a, r, r] \ r = DelayList.iterator(rc, l)
 }
 
 mod DelayList {
@@ -1174,7 +1174,7 @@ mod DelayList {
     /// Forces the entire list `l`.
     ///
     @Experimental
-    pub def toArray(r: Region[r], l: DelayList[a]): Array[a, r] \ Write(r) =
+    pub def toArray(r: Region[r], l: DelayList[a]): Array[a, r] \ r =
         let a = Array.new(r, length(l));
         forEach(match (i, y) -> Array.put(y, i, a), zipWithIndex(l));
         a
@@ -1197,7 +1197,7 @@ mod DelayList {
     /// Does not force any elements of the list.
     ///
     @Experimental @Lazy
-    pub def iterator(rc: Region[r], l: DelayList[a]): Iterator[a, r, r] \ Write(r) =
+    pub def iterator(rc: Region[r], l: DelayList[a]): Iterator[a, r, r] \ r =
         let cursor = ref l @ rc;
         let next = () -> match head(deref cursor) {
             case None    => None
@@ -1211,7 +1211,7 @@ mod DelayList {
     ///
     /// Returns an iterator over `l` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], l: DelayList[a]): Iterator[(Int32, a), r, r] \ Write(r) =
+    pub def enumerator(r: Region[r], l: DelayList[a]): Iterator[(Int32, a), r, r] \ r =
         iterator(r, l) |> Iterator.zipWithIndex
 
     ///
@@ -1235,14 +1235,14 @@ mod DelayList {
     /// Forces the entire list `l`.
     ///
     @Experimental
-    pub def toMutList(r: Region[r], l: DelayList[a]): MutList[a, r] \ Write(r) = region rc2 {
+    pub def toMutList(r: Region[r], l: DelayList[a]): MutList[a, r] \ r = region rc2 {
         Array.toMutList(r, toArray(rc2, l)) // `Array.toMutList` respects the invariant of `MutList`.
     }
 
     ///
     /// Returns `l` as a MutDeque.
     ///
-    pub def toMutDeque(r: Region[r], l: DelayList[a]): MutDeque[a, r] \ Write(r) =
+    pub def toMutDeque(r: Region[r], l: DelayList[a]): MutDeque[a, r] \ r =
         let d = MutDeque.new(r);
         forEach(x -> MutDeque.pushBack(x, d), l);
         d

--- a/main/src/library/DelayMap.flix
+++ b/main/src/library/DelayMap.flix
@@ -44,7 +44,7 @@ instance Foldable[DelayMap[k]] {
 }
 
 instance Iterable[DelayMap[k]] {
-    pub def iterator(rc: Region[r], m: DelayMap[k, v]): Iterator[v, r, r] \ Write(r) =
+    pub def iterator(rc: Region[r], m: DelayMap[k, v]): Iterator[v, r, r] \ r =
         DelayMap.iterator(rc, m) |> Iterator.map(snd)
 }
 
@@ -770,7 +770,7 @@ mod DelayMap {
     /// Returns `m` as a mutable map.
     ///
     @Experimental @Parallel
-    pub def toMutMap(rc: Region[r], m: DelayMap[k, v]): MutMap[k, v, r] \ Write(r) =
+    pub def toMutMap(rc: Region[r], m: DelayMap[k, v]): MutMap[k, v, r] \ r =
         MutMap.MutMap(rc, ref toMap(m) @ rc)
 
     ///
@@ -791,7 +791,7 @@ mod DelayMap {
     /// Returns an iterator over all key-value pairs in `m`.
     ///
     @Experimental
-    pub def iterator(rc: Region[r], m: DelayMap[a, b]): Iterator[(a, b), r, r] \ Write(r) =
+    pub def iterator(rc: Region[r], m: DelayMap[a, b]): Iterator[(a, b), r, r] \ r =
         let DMap(t) = m;
         RedBlackTree.iterator(rc, t) |> Iterator.map(match (k, v) -> (k, force v))
 
@@ -799,7 +799,7 @@ mod DelayMap {
     /// Returns the map `m` as a MutDeque of key-value pairs.
     ///
     @Experimental
-    pub def toMutDeque(r: Region[r], m: DelayMap[k, v]): MutDeque[(k, v), r] \ Write(r) =
+    pub def toMutDeque(r: Region[r], m: DelayMap[k, v]): MutDeque[(k, v), r] \ r =
         let m1 = DelayMap.toMap(m);
         Map.toMutDeque(r, m1)
 

--- a/main/src/library/Environment.flix
+++ b/main/src/library/Environment.flix
@@ -19,7 +19,7 @@ mod Environment {
     /// Returns the arguments passed to the program via the command line.
     ///
     pub def getArgs(): List[String] = region rc {
-        import static dev.flix.runtime.Global.getArgs(): Array[String, rc] \ Write(rc);
+        import static dev.flix.runtime.Global.getArgs(): Array[String, rc] \ rc;
         let _ = rc; // Avoids redundancy error.
         Array.toList(getArgs())
     }
@@ -28,9 +28,9 @@ mod Environment {
     /// Returns an map of the current system environment.
     ///
     pub def getEnv(): Map[String, String] = region rc {
-        import static java.lang.System.getenv(): ##java.util.Map \ Write(rc);
-        import java.util.Map.entrySet(): ##java.util.Set \ { Read(rc), Write(rc) };
-        import java.util.Set.iterator(): ##java.util.Iterator \ { Read(rc), Write(rc) };
+        import static java.lang.System.getenv(): ##java.util.Map \ rc;
+        import java.util.Map.entrySet(): ##java.util.Set \ { rc };
+        import java.util.Set.iterator(): ##java.util.Iterator \ { rc };
         let _ = rc; // Avoids redundancy error.
         try {
             let iter = getenv() |> entrySet |> iterator;

--- a/main/src/library/File.flix
+++ b/main/src/library/File.flix
@@ -406,7 +406,7 @@ mod File {
     ///
     /// Returns an iterator of the given file `f`
     ///
-    pub def readLinesIter(r: Region[r], f: String): Iterator[Result[String, String], false, r] \ { Read(r), Write(r), IO } =
+    pub def readLinesIter(r: Region[r], f: String): Iterator[Result[String, String], false, r] \ { r, IO } =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -446,7 +446,7 @@ mod File {
     /// The options `opts` to apply consists of
     /// `charSet` - the specific charset to be used to decode the bytes.
     ///
-    pub def readLinesIterWith(r: Region[r], opts: {charSet = String}, f: String): Iterator[Result[String, String], false, r] \ { Read(r), Write(r), IO } =
+    pub def readLinesIterWith(r: Region[r], opts: {charSet = String}, f: String): Iterator[Result[String, String], false, r] \ { r, IO } =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -485,7 +485,7 @@ mod File {
     ///
     /// Returns an array of all the bytes in the given file `f`.
     ///
-    pub def readBytes(_r: Region[r], f: String): Result[String, Array[Int8, r]] \ { Write(r), IO } =
+    pub def readBytes(_r: Region[r], f: String): Result[String, Array[Int8, r]] \ { r, IO } =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -508,7 +508,7 @@ mod File {
     /// `offset` - the start offset in the given file `f`.
     /// `count` - the number of bytes read.
     ///
-    pub def readBytesWith(r: Region[r], opts: {offset = Int64, count = Int32}, f: String): Result[String, Array[Int8, r]] \ { Read(r), Write(r), IO } =
+    pub def readBytesWith(r: Region[r], opts: {offset = Int64, count = Int32}, f: String): Result[String, Array[Int8, r]] \ { r, IO } =
         if (0 < opts.count) {
             try {
                 import new java.io.File(String): ##java.io.File \ IO as newFile;
@@ -541,7 +541,7 @@ mod File {
     /// Helper function for `readBytesWith`.
     /// Returns an array that corresponds to the bytes actually read from the stream.
     ///
-    def readBytesWithHelper(r: Region[r], bytes: Array[Int8, r], numberRead: Int32, count: Int32): Array[Int8, r] \ { Read(r), Write(r) } =
+    def readBytesWithHelper(r: Region[r], bytes: Array[Int8, r], numberRead: Int32, count: Int32): Array[Int8, r] \ r =
         let nothingRead = (numberRead == -1);
         if (nothingRead) {
             Array#{} @ r
@@ -972,8 +972,8 @@ mod File {
     /// Converts a Java iterator to a Flix Iterator.
     ///
     def fromJavaIter(r: Region[r], iter: ##java.util.Iterator): Iterator[a, r, r] =
-        import java.util.Iterator.hasNext(): Bool \ Read(r);
-        import java.util.Iterator.next(): a \ { Read(r), Write(r) } as getNext;
+        import java.util.Iterator.hasNext(): Bool \ r;
+        import java.util.Iterator.next(): a \ r as getNext;
         let next = () -> {
             if(hasNext(iter)) {
                 getNext(iter) |> Some

--- a/main/src/library/Fixpoint/Compiler.flix
+++ b/main/src/library/Fixpoint/Compiler.flix
@@ -69,7 +69,7 @@ mod Fixpoint {
     /// Note that Eval-Rule is the code emitted by `compileRule`
     /// and Eval-Rule-Incr is the code emitted by `compileRuleIncr`.
     ///
-    def compileStratum(stmts: MutList[RamStmt[v], r], stratum: List[Constraint[v]]): Unit \ Write(r) = region r {
+    def compileStratum(stmts: MutList[RamStmt[v], r], stratum: List[Constraint[v]]): Unit \ r = region r {
         let idb = List.foldRight(match Constraint(HeadAtom(pred, den, terms), _) -> {
             let arity = List.length(terms);
             Map.insert(pred, (arity, den))
@@ -123,7 +123,7 @@ mod Fixpoint {
     ///         end
     ///     end
     ///
-    def compileRule(stmts: MutList[RamStmt[v], r], rule: Constraint[v]): Unit \ Write(r) = match rule {
+    def compileRule(stmts: MutList[RamStmt[v], r], rule: Constraint[v]): Unit \ r = match rule {
         case Constraint(HeadAtom(headSym, headDen, headTerms), body) =>
             let augBody = augmentBody(body);
             let env = unifyVars(augBody);
@@ -178,7 +178,7 @@ mod Fixpoint {
     /// Note that there are two join loops, because there are two positive atoms.
     /// Also note how in the first loop, `B` is the focused atom and `C` is focused in the second loop.
     ///
-    def compileRuleIncr(stmts: MutList[RamStmt[v], r], rule: Constraint[v]): Unit \ Write(r) = match rule {
+    def compileRuleIncr(stmts: MutList[RamStmt[v], r], rule: Constraint[v]): Unit \ r = match rule {
         case Constraint(HeadAtom(headSym, headDen, headTerms), body) =>
             let augBody = augmentBody(body);
             let env = unifyVars(augBody);

--- a/main/src/library/Fixpoint/Interpreter.flix
+++ b/main/src/library/Fixpoint/Interpreter.flix
@@ -22,15 +22,15 @@ mod Fixpoint {
     type alias Database[v: Type, r: Region] = MutMap[RamSym[v], MutMap[Vector[v], v, r], r]
     type alias SearchEnv[v: Type, r: Region] = (Array[Vector[v], r], Array[v, r])
 
-    def interpret(r: Region[r], stmt: RamStmt[v]): Database[v, r] \ Write(r) with Order[v] =
+    def interpret(r: Region[r], stmt: RamStmt[v]): Database[v, r] \ r with Order[v] =
         interpretWithDatabase(r, MutMap.new(r), stmt)
 
-    def interpretWithDatabase(r: Region[r], db: Database[v, r], stmt: RamStmt[v]): Database[v, r] \ { Read(r), Write(r) } with Order[v] =
+    def interpretWithDatabase(r: Region[r], db: Database[v, r], stmt: RamStmt[v]): Database[v, r] \ r with Order[v] =
         masked_cast(notifyPreInterpret(stmt));
         evalStmt(r, db, stmt);
         db
 
-    def evalStmt(r: Region[r], db: Database[v, r], stmt: RamStmt[v]): Unit \ { Read(r), Write(r) } with Order[v] =
+    def evalStmt(r: Region[r], db: Database[v, r], stmt: RamStmt[v]): Unit \ r with Order[v] =
         match stmt {
             case RamStmt.Insert(relOp) => evalOp(r, db, allocEnv(r, 0, relOp), relOp)
             case RamStmt.Merge(srcSym, dstSym) =>
@@ -55,7 +55,7 @@ mod Fixpoint {
             case RamStmt.Comment(_) => ()
         }
 
-    def allocEnv(r: Region[r], depth: Int32, relOp: RelOp[v]): SearchEnv[v, r] \ Write(r) = match relOp {
+    def allocEnv(r: Region[r], depth: Int32, relOp: RelOp[v]): SearchEnv[v, r] \ r = match relOp {
         case RelOp.Search(_, _, body)           => allocEnv(r, depth + 1, body)
         case RelOp.Query(_, _, _, body)         => allocEnv(r, depth + 1, body)
         case RelOp.Functional(_, _, _, body)    => allocEnv(r, depth + 1, body)
@@ -63,7 +63,7 @@ mod Fixpoint {
         case RelOp.If(_, then)                  => allocEnv(r, depth, then)
     }
 
-    def evalOp(r1: Region[r1], db: Database[v, r1], env: SearchEnv[v, r2], op: RelOp[v]): Unit \ { Read(r1), Write(r1), Read(r2), Write(r2) } with Order[v] =
+    def evalOp(r1: Region[r1], db: Database[v, r1], env: SearchEnv[v, r2], op: RelOp[v]): Unit \ { r1, r2 } with Order[v] =
         match op {
             case RelOp.Search(RowVar.Index(i), ramSym, body) =>
                 let (tupleEnv, latEnv) = env;
@@ -116,7 +116,7 @@ mod Fixpoint {
             case _ => ()
         }
 
-    def evalQuery(env: SearchEnv[v, r], query: List[(Int32, RamTerm[v])], tuple: Vector[v]): Comparison \ Read(r) with Order[v] =
+    def evalQuery(env: SearchEnv[v, r], query: List[(Int32, RamTerm[v])], tuple: Vector[v]): Comparison \ r with Order[v] =
         match query {
             case Nil => Comparison.EqualTo
             case (j, t) :: tl => match Vector.get(j, tuple) <=> evalTerm(env, t) {
@@ -125,7 +125,7 @@ mod Fixpoint {
             }
         }
 
-    def evalBoolExp(r1: Region[r1], db: Database[v, r1], env: SearchEnv[v, r2], es: List[BoolExp[v]]): Bool \ { Read(r1), Read(r2) } with Order[v] =
+    def evalBoolExp(r1: Region[r1], db: Database[v, r1], env: SearchEnv[v, r2], es: List[BoolExp[v]]): Bool \ { r1, r2 } with Order[v] =
         List.forAll(exp -> match exp {
             case BoolExp.Empty(ramSym) =>
                 MutMap.isEmpty(MutMap.getWithDefault(ramSym, MutMap.new(r1), db))
@@ -178,7 +178,7 @@ mod Fixpoint {
                 f(v1)(v2)(v3)(v4)(v5)
         }, es)
 
-    def evalTerm(env: SearchEnv[v, r], term: RamTerm[v]): v \ Read(r) = match term {
+    def evalTerm(env: SearchEnv[v, r], term: RamTerm[v]): v \ r = match term {
         case RamTerm.Lit(v) => v
         case RamTerm.RowLoad(RowVar.Index(i), index) =>
             let (tupleEnv, _) = env;

--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -757,7 +757,7 @@ mod Fixpoint {
     ///
     /// Returns the given database `db` as a Datalog value.
     ///
-    def toModel(db: Database[v, r]): Datalog[v] \ Read(r) =
+    def toModel(db: Database[v, r]): Datalog[v] \ r =
         MutMap.toMap(db) |>
         Map.map(MutMap.toMap) |>
         Model

--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -192,7 +192,7 @@ pub class Foldable[t : Type -> Type] {
     ///
     /// Returns `t` as an array.
     ///
-    pub def toArray(r: Region[r], t: t[a]): Array[a, r] \ Write(r) = region rc2 {
+    pub def toArray(r: Region[r], t: t[a]): Array[a, r] \ r = region rc2 {
         let l = MutList.new(rc2);
         Foldable.forEach(a -> MutList.push!(a, l), t);
         MutList.toArray(r, l)
@@ -201,7 +201,7 @@ pub class Foldable[t : Type -> Type] {
     ///
     /// Returns `t` as a `MutDeque`.
     ///
-    pub def toMutDeque(r: Region[r], t: t[a]): MutDeque[a, r] \ Write(r) =
+    pub def toMutDeque(r: Region[r], t: t[a]): MutDeque[a, r] \ r =
         let d = MutDeque.new(r);
         Foldable.forEach(x -> MutDeque.pushBack(x, d), t);
         d
@@ -209,7 +209,7 @@ pub class Foldable[t : Type -> Type] {
     ///
     /// Returns `t` as a mutable list.
     ///
-    pub def toMutList(r: Region[r], t: t[a]): MutList[a, r] \ Write(r) = region rc2 {
+    pub def toMutList(r: Region[r], t: t[a]): MutList[a, r] \ r = region rc2 {
         Array.toMutList(r, Foldable.toArray(rc2, t))
     }
 
@@ -222,7 +222,7 @@ pub class Foldable[t : Type -> Type] {
     ///
     /// Returns the set `s` as a `MutSet`.
     ///
-    pub def toMutSet(r: Region[r], t: t[a]): MutSet[a, r] \ Write(r) with Order[a] =
+    pub def toMutSet(r: Region[r], t: t[a]): MutSet[a, r] \ r with Order[a] =
         let s = MutSet.new(r);
         Foldable.forEach(x -> MutSet.add!(x, s), t);
         s
@@ -248,7 +248,7 @@ pub class Foldable[t : Type -> Type] {
     ///
     /// Returns `t` as a `MutMap`.
     ///
-    pub def toMutMap(r: Region[r], t: t[(k, v)]): MutMap[k, v, r] \ Write(r) with Order[k] =
+    pub def toMutMap(r: Region[r], t: t[(k, v)]): MutMap[k, v, r] \ r with Order[k] =
         let m = MutMap.new(r);
         Foldable.forEach(x -> let (k, v) = x; MutMap.put!(k, v, m), t);
         m

--- a/main/src/library/Iterable.flix
+++ b/main/src/library/Iterable.flix
@@ -22,12 +22,12 @@ pub class Iterable[t: Type -> Type] {
     ///
     /// Returns an iterator over `t`.
     ///
-    pub def iterator(rc: Region[r], t: t[a]): Iterator[a, r, r] \ { Write(r) }
+    pub def iterator(rc: Region[r], t: t[a]): Iterator[a, r, r] \ r
 
     ///
     /// Returns an iterator over `t` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], t: t[a]): Iterator[(Int32, a), r, r] \ Write(r) =
+    pub def enumerator(r: Region[r], t: t[a]): Iterator[(Int32, a), r, r] \ r =
         Iterable.iterator(r, t) |> Iterator.zipWithIndex
 
 }

--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -59,7 +59,7 @@ mod Iterator {
     ///
     /// Returns an iterator containing only a single element, `x`.
     ///
-    pub def singleton(rc: Region[r], x: a): Iterator[a, r, r] \ Write(r) =
+    pub def singleton(rc: Region[r], x: a): Iterator[a, r, r] \ r =
         repeat(rc, 1, x)
 
     ///
@@ -67,7 +67,7 @@ mod Iterator {
     ///
     /// Consumes the head element of `iter`.
     ///
-    pub def next(iter: Iterator[a, ef, r]): Option[a] \ { ef, Read(r) } =
+    pub def next(iter: Iterator[a, ef, r]): Option[a] \ { ef, r } =
         let Iterator(_, iterF) = iter;
         def loop() = match iterF() {
             case Ans(a) => Some(a)
@@ -81,7 +81,7 @@ mod Iterator {
     ///
     /// Returns an empty iterator if `b >= e`.
     ///
-    pub def range(rc: Region[r], b: Int32, e: Int32): Iterator[Int32, r, r] \ Write(r) =
+    pub def range(rc: Region[r], b: Int32, e: Int32): Iterator[Int32, r, r] \ r =
         let pos = ref b @ rc;
         if (e <= b)
             empty(rc)
@@ -98,7 +98,7 @@ mod Iterator {
     ///
     /// Returns an empty iterator if `n < 0`.
     ///
-    pub def repeat(rc: Region[r], n: Int32, x: a): Iterator[a, r, r] \ Write(r) =
+    pub def repeat(rc: Region[r], n: Int32, x: a): Iterator[a, r, r] \ r =
         let ix = ref n @ rc;
         let iterF = () -> {
             let i = deref ix;
@@ -116,7 +116,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def sum(iter: Iterator[Int32, ef, r]): Int32 \ { ef, Read(r) } =
+    pub def sum(iter: Iterator[Int32, ef, r]): Int32 \ { ef, r } =
         foldLeft((acc, x) -> acc + x, 0, iter)
 
     ///
@@ -124,7 +124,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def sumWith(f: a -> Int32 \ ef2, iter: Iterator[a, ef1, r]): Int32 \ { ef1, ef2, Read(r) } =
+    pub def sumWith(f: a -> Int32 \ ef2, iter: Iterator[a, ef1, r]): Int32 \ { ef1, ef2, r } =
         foldLeft((acc, x) -> acc + f(x), 0, iter)
 
     ///
@@ -132,7 +132,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def toArray(rc: Region[r1], iter: Iterator[a, ef, r2]): Array[a, r1] \ { ef, Read(r2), Write(r1) } = region rc1 {
+    pub def toArray(rc: Region[r1], iter: Iterator[a, ef, r2]): Array[a, r1] \ { ef, r2, r1 } = region rc1 {
         let m = MutList.new(rc1);
         forEach(a -> MutList.push!(a, m), iter);
         MutList.toArray(rc, m)
@@ -143,7 +143,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def toVector(iter: Iterator[a, ef, r]): Vector[a] \ { ef, Read(r) } = region rc {
+    pub def toVector(iter: Iterator[a, ef, r]): Vector[a] \ { ef, r } = region rc {
         let m = MutList.new(rc);
         forEach(a -> MutList.push!(a, m), iter);
         MutList.toVector(m)
@@ -154,7 +154,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def toList(iter: Iterator[a, ef, r]): List[a] \ { ef, Read(r) } =
+    pub def toList(iter: Iterator[a, ef, r]): List[a] \ { ef, r } =
         foldRight((a, acc) -> a :: acc, Nil, iter)
 
 
@@ -163,7 +163,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def toChain(iter: Iterator[a, ef, r]): Chain[a] \ { ef, Read(r) } =
+    pub def toChain(iter: Iterator[a, ef, r]): Chain[a] \ { ef, r } =
         foldLeft((acc, a) -> Chain.snoc(acc, a), Chain.empty(), iter)
 
     ///
@@ -171,7 +171,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def toMap(iter: Iterator[(k, v), ef, r]): Map[k, v] \ { ef, Read(r) } with Order[k] =
+    pub def toMap(iter: Iterator[(k, v), ef, r]): Map[k, v] \ { ef, r } with Order[k] =
         foldLeft((acc, a) -> (match (k, v) -> Map.insert(k, v, acc))(a), Map.empty(), iter)
 
     ///
@@ -179,7 +179,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def toNel(iter: Iterator[a, ef, r]): Option[Nel[a]] \ { ef, Read(r) } =
+    pub def toNel(iter: Iterator[a, ef, r]): Option[Nel[a]] \ { ef, r } =
         toList(iter) |> List.toNel
 
     ///
@@ -187,7 +187,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def toNec(iter: Iterator[a, ef, r]): Option[Nec[a]] \ { ef, Read(r) } = match next(iter) {
+    pub def toNec(iter: Iterator[a, ef, r]): Option[Nec[a]] \ { ef, r } = match next(iter) {
         case Some(a) => foldLeft((acc, x) -> Nec.snoc(acc, x), Nec.singleton(a), iter) |> Some
         case None    => None
     }
@@ -197,7 +197,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def toMutDeque(rc: Region[r1], iter: Iterator[a, ef, r2]): MutDeque[a, r1] \ { ef, Read(r2), Write(r1) } =
+    pub def toMutDeque(rc: Region[r1], iter: Iterator[a, ef, r2]): MutDeque[a, r1] \ { ef, r2, r1 } =
         let d = MutDeque.new(rc);
         forEach(x -> MutDeque.pushBack(x, d), iter);
         d
@@ -205,7 +205,7 @@ mod Iterator {
     ///
     /// Returns the contents of `iter` as a set. Consumes the entire iterator.
     ///
-    pub def toSet(iter: Iterator[a, ef, r]): Set[a] \ { ef, Read(r) } with Order[a] =
+    pub def toSet(iter: Iterator[a, ef, r]): Set[a] \ { ef, r } with Order[a] =
         foldLeft((acc, a) -> Set.insert(a, acc), Set.empty(), iter)
 
     ///
@@ -213,7 +213,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def forEach(f: a -> Unit \ ef2, iter: Iterator[a, ef1, r]): Unit \ { ef1, ef2, Read(r) } =
+    pub def forEach(f: a -> Unit \ ef2, iter: Iterator[a, ef1, r]): Unit \ { ef1, ef2, r } =
         let Iterator(_, iterF) = iter;
         def loop() = match iterF() {
             case Skip   => loop()
@@ -227,7 +227,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def forEachWithIndex(f: (Int32, a) -> Unit \ ef2, iter: Iterator[a, ef1, r]): Unit \ { ef1, ef2, Read(r) } =
+    pub def forEachWithIndex(f: (Int32, a) -> Unit \ ef2, iter: Iterator[a, ef1, r]): Unit \ { ef1, ef2, r } =
         let Iterator(_, iterF) = iter;
         def loop(i) = match iterF() {
             case Skip   => loop(i)
@@ -275,7 +275,7 @@ mod Iterator {
     ///
     /// Does *not* consume any elements from the iterator.
     ///
-    pub def mapWithIndex(f: (Int32, a) -> b \ ef2, iter: Iterator[a, ef1, r]): Iterator[b, ef1 and ef2, r] \ Write(r) =
+    pub def mapWithIndex(f: (Int32, a) -> b \ ef2, iter: Iterator[a, ef1, r]): Iterator[b, ef1 and ef2, r] \ r =
         let Iterator(rc, iterF) = iter;
         let ix = ref 0 @ rc;
         let step = x -> match x {
@@ -384,7 +384,7 @@ mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def zipWithIndex(iter: Iterator[a, ef, r]): Iterator[(Int32, a), ef and r, r] \ Write(r) =
+    pub def zipWithIndex(iter: Iterator[a, ef, r]): Iterator[(Int32, a), ef and r, r] \ r =
         let Iterator(rc, _) = iter;
         let ix = ref 0 @ rc;
         map(x -> {let i = deref ix; ix:= i + 1; (i, x)}, iter)
@@ -392,7 +392,7 @@ mod Iterator {
     ///
     /// Alias for `zipWithIndex`.
     ///
-    pub def enumerator(iter: Iterator[a, ef, r]): Iterator[(Int32, a), ef and r, r] \ Write(r) =
+    pub def enumerator(iter: Iterator[a, ef, r]): Iterator[(Int32, a), ef and r, r] \ r =
         zipWithIndex(iter)
 
     ///
@@ -402,7 +402,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def foldLeft(f: (b, a) -> b \ ef2, s: b, iter: Iterator[a, ef1, r]): b \ { ef1, ef2, Read(r) } =
+    pub def foldLeft(f: (b, a) -> b \ ef2, s: b, iter: Iterator[a, ef1, r]): b \ { ef1, ef2, r } =
         let Iterator(_, iterF) = iter;
         def loop(acc) = match iterF() {
             case Skip   => loop(acc)
@@ -418,7 +418,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def foldRight(f: (a, b) -> b \ ef2, s: b, iter: Iterator[a, ef1, r]): b \ { ef1, ef2, Read(r) } =
+    pub def foldRight(f: (a, b) -> b \ ef2, s: b, iter: Iterator[a, ef1, r]): b \ { ef1, ef2, r } =
         let Iterator(_, iterF) = iter;
         def loop(k) = match iterF() {
             case Skip   => loop(k)
@@ -436,7 +436,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ { ef, Read(r) }) -> b \ ef, z: b, iter: Iterator[a, ef, r]): b \ { ef, Read(r) } =
+    pub def foldRightWithCont(f: (a, Unit -> b \ { ef, r }) -> b \ ef, z: b, iter: Iterator[a, ef, r]): b \ { ef, r } =
         let Iterator(_, iterF) = iter;
         def loop() = match iterF() {
             case Skip   => loop()
@@ -448,7 +448,7 @@ mod Iterator {
     ///
     /// Returns the result of mapping each element and combining the results.
     ///
-    pub def foldMap(f: a -> b \ ef2, iter: Iterator[a, ef1, r]): b \ { ef1, ef2, Read(r) } with Monoid[b] =
+    pub def foldMap(f: a -> b \ ef2, iter: Iterator[a, ef1, r]): b \ { ef1, ef2, r } with Monoid[b] =
         foldLeft((acc, x) -> Monoid.combine(acc, f(x)), Monoid.empty(), iter)
 
     ///
@@ -460,7 +460,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def reduceLeft(f: (a, a) -> a \ ef2, iter: Iterator[a, ef1, r]): Option[a] \ { ef1, ef2, Read(r) } =
+    pub def reduceLeft(f: (a, a) -> a \ ef2, iter: Iterator[a, ef1, r]): Option[a] \ { ef1, ef2, r } =
         match next(iter) {
             case Some(x) => foldLeft(f, x, iter) |> Some
             case None    => None
@@ -487,7 +487,7 @@ mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def drop(n: Int32, iter: Iterator[a, ef, r]): Iterator[a, ef and r, r] \ Write(r) =
+    pub def drop(n: Int32, iter: Iterator[a, ef, r]): Iterator[a, ef and r, r] \ r =
         let Iterator(rc, iterF) = iter;
         let ix = ref n @ rc;
         def loop() = {
@@ -512,7 +512,7 @@ mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def take(n: Int32, iter: Iterator[a, ef, r]): Iterator[a, ef and r, r] \ Write(r) =
+    pub def take(n: Int32, iter: Iterator[a, ef, r]): Iterator[a, ef and r, r] \ r =
         let Iterator(rc, iterF) = iter;
         let ix = ref n @ rc;
         def loop() = {
@@ -553,7 +553,7 @@ mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def dropWhile(f: a -> Bool \ ef2, iter: Iterator[a, ef1, r]): Iterator[a, r and ef1 and ef2, r] \ Write(r) =
+    pub def dropWhile(f: a -> Bool \ ef2, iter: Iterator[a, ef1, r]): Iterator[a, r and ef1 and ef2, r] \ r =
         let Iterator(rc, iterF) = iter;
         let start = ref true @ rc;
         def loop() = match iterF() {
@@ -576,7 +576,7 @@ mod Iterator {
     ///
     /// Currently `f` has to generate an iterator with region `r`.
     ///
-    pub def flatMap(f: a -> Iterator[b, ef2, r] \ ef3, ma: Iterator[a, ef1, r]): Iterator[b, r and ef1 and ef2 and ef3, r] \ Write(r) =
+    pub def flatMap(f: a -> Iterator[b, ef2, r] \ ef3, ma: Iterator[a, ef1, r]): Iterator[b, r and ef1 and ef2 and ef3, r] \ r =
         let Iterator(rc, iterF) = ma;
         let innerIter = ref polymorphicEmpty(rc) @ rc;
         let inside = ref false @ rc;
@@ -626,7 +626,7 @@ mod Iterator {
     ///
     /// Does *not* consume any elements from the iterator.
     ///
-    pub def intersperse(sep: a, iter: Iterator[a, ef, r]): Iterator[a, ef and r, r] \ Write(r) =
+    pub def intersperse(sep: a, iter: Iterator[a, ef, r]): Iterator[a, ef and r, r] \ r =
         let Iterator(rc, _) = iter;
         let start = ref true @ rc;
         let step = x ->
@@ -647,7 +647,7 @@ mod Iterator {
     ///
     /// The original iterators `sep` and `iter` should not be reused.
     ///
-    pub def intercalate(sep: t[a], iter: Iterator[Iterator[a, ef, r], ef, r]): Iterator[a, ef and r, r] \ Write(r) with Foldable[t] =
+    pub def intercalate(sep: t[a], iter: Iterator[Iterator[a, ef, r], ef, r]): Iterator[a, ef and r, r] \ r with Foldable[t] =
         let Iterator(rc, _) = iter;
         let start = ref true @ rc;
         let sepL = Foldable.toList(sep);
@@ -667,7 +667,7 @@ mod Iterator {
     /// Note - this is not the "best" return type. Ideally it should be `Iterator[a, r, r]` but
     /// then `intercalate` fails.
     ///
-    def ofList(rc: Region[r], xs: List[a]): Iterator[a, true, r] \ Write(r) =
+    def ofList(rc: Region[r], xs: List[a]): Iterator[a, true, r] \ r =
         let ls = ref xs @ rc;
         let next = () -> {
             match (deref ls) {
@@ -683,7 +683,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def join(sep: String, iter: Iterator[a, ef, r]): String \ { ef, Read(r) } with ToString[a] =
+    pub def join(sep: String, iter: Iterator[a, ef, r]): String \ { ef, r } with ToString[a] =
         joinWith(ToString.toString, sep, iter)
 
     ///
@@ -692,7 +692,7 @@ mod Iterator {
     ///
     /// Consumes the entire iterator.
     ///
-    pub def joinWith(f: a -> String \ ef2, sep: String, iter: Iterator[a, ef1, r]): String \ { ef1, ef2, Read(r) } = region rc {
+    pub def joinWith(f: a -> String \ ef2, sep: String, iter: Iterator[a, ef1, r]): String \ { ef1, ef2, r } = region rc {
         let sb = StringBuilder.new(rc);
         match next(iter) {
             case Some(a) => {
@@ -733,7 +733,7 @@ mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def cons(x: a, iter: Iterator[a, ef, r]): Iterator[a, ef, r] \ Write(r) =
+    pub def cons(x: a, iter: Iterator[a, ef, r]): Iterator[a, ef, r] \ r =
         let Iterator(rc, iterF) = iter;
         let first = ref true @ rc;
         let f = () ->  {
@@ -754,7 +754,7 @@ mod Iterator {
     ///
     /// The original iterator `iter` should *not* be reused.
     ///
-    pub def flatten(iter: Iterator[Iterator[a, ef1, r], ef2, r]): Iterator[a, r and ef1 and ef2, r] \ Write(r) =
+    pub def flatten(iter: Iterator[Iterator[a, ef1, r], ef2, r]): Iterator[a, r and ef1 and ef2, r] \ r =
         flatMap(identity, iter)
 
 }

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -121,7 +121,7 @@ instance Collectable[List] {
 }
 
 instance Iterable[List] {
-    pub def iterator(rc: Region[r], l: List[a]): Iterator[a, r, r] \ Write(r) = List.iterator(rc, l)
+    pub def iterator(rc: Region[r], l: List[a]): Iterator[a, r, r] \ r = List.iterator(rc, l)
 }
 
 mod List {
@@ -1082,7 +1082,7 @@ mod List {
     ///
     /// Returns `l` as a MutDeque.
     ///
-    pub def toMutDeque(r: Region[r], l: List[a]): MutDeque[a, r] \ Write(r) =
+    pub def toMutDeque(r: Region[r], l: List[a]): MutDeque[a, r] \ r =
         let d = MutDeque.new(r);
         forEach(x -> MutDeque.pushBack(x, d), l);
         d
@@ -1090,7 +1090,7 @@ mod List {
     ///
     /// Returns `l` as a mutable list.
     ///
-    pub def toMutList(r: Region[r], l: List[a]): MutList[a, r] \ Write(r) = region rc2 {
+    pub def toMutList(r: Region[r], l: List[a]): MutList[a, r] \ r = region rc2 {
         Array.toMutList(r, toArray(rc2, l)) // `Array.toMutList` respects the invariant of `MutList`
     }
 
@@ -1139,7 +1139,7 @@ mod List {
     ///
     /// Returns the list `l` as an array.
     ///
-    pub def toArray(r: Region[r], l: List[a]): Array[a, r] \ Write(r) = match head(l) {
+    pub def toArray(r: Region[r], l: List[a]): Array[a, r] \ r = match head(l) {
         case None    => Array#{} @ r
         case Some(_) =>
             let a = Array.new(r, length(l));
@@ -1306,7 +1306,7 @@ mod List {
     ///
     /// Returns an iterator over `l`.
     ///
-    pub def iterator(rc: Region[r], xs: List[a]): Iterator[a, r, r] \ Write(r) =
+    pub def iterator(rc: Region[r], xs: List[a]): Iterator[a, r, r] \ r =
         let ls = ref xs @ rc;
         let next = () -> {
             match (deref ls) {
@@ -1319,7 +1319,7 @@ mod List {
     ///
     /// Returns an iterator over `l` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], l: List[a]): Iterator[(Int32, a), r, r] \ Write(r) =
+    pub def enumerator(r: Region[r], l: List[a]): Iterator[(Int32, a), r, r] \ r =
         iterator(r, l) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -102,7 +102,7 @@ instance MeetLattice[Map[k, v]] with Order[k], Eq[v], MeetLattice[v] {
 }
 
 instance Iterable[Map[k]] {
-    pub def iterator(rc: Region[r], m: Map[k, v]): Iterator[v, r, r] \ Write(r) = Map.iteratorValues(rc, m)
+    pub def iterator(rc: Region[r], m: Map[k, v]): Iterator[v, r, r] \ r = Map.iteratorValues(rc, m)
 }
 
 mod Map {
@@ -768,7 +768,7 @@ mod Map {
     ///
     /// Returns `m` as a mutable map.
     ///
-    pub def toMutMap(rc: Region[r], m: Map[k, v]): MutMap[k, v, r] \ Write(r) =
+    pub def toMutMap(rc: Region[r], m: Map[k, v]): MutMap[k, v, r] \ r =
         MutMap.MutMap(rc, ref m @ rc)
 
     ///
@@ -804,7 +804,7 @@ mod Map {
     ///
     /// Returns `m` as a MutDeque.
     ///
-    pub def toMutDeque(r: Region[r], m: Map[k, v]): MutDeque[(k, v), r] \ Write(r) =
+    pub def toMutDeque(r: Region[r], m: Map[k, v]): MutDeque[(k, v), r] \ r =
         let d = MutDeque.new(r);
         forEach((k, v) -> MutDeque.pushBack((k, v), d), m);
         d
@@ -878,20 +878,20 @@ mod Map {
     ///
     /// Returns an iterator over all key-value pairs in `m`.
     ///
-    pub def iterator(rc: Region[r], m: Map[k, v]): Iterator[(k, v), r, r] \ Write(r) =
+    pub def iterator(rc: Region[r], m: Map[k, v]): Iterator[(k, v), r, r] \ r =
         let Map(t) = m;
         RedBlackTree.iterator(rc, t)
 
     ///
     /// Returns an iterator over keys in `m`.
     ///
-    pub def iteratorKeys(r: Region[r], m: Map[k, v]): Iterator[k, r, r] \ Write(r) =
+    pub def iteratorKeys(r: Region[r], m: Map[k, v]): Iterator[k, r, r] \ r =
         iterator(r, m) |> Iterator.map(fst)
 
     ///
     /// Returns an iterator over values in `m`.
     ///
-    pub def iteratorValues(r: Region[r], m: Map[k, v]): Iterator[v, r, r] \ Write(r) =
+    pub def iteratorValues(r: Region[r], m: Map[k, v]): Iterator[v, r, r] \ r =
         iterator(r, m) |> Iterator.map(snd)
 
     ///

--- a/main/src/library/MultiMap.flix
+++ b/main/src/library/MultiMap.flix
@@ -522,7 +522,7 @@ mod MultiMap {
     ///
     /// Returns the MultiMap `m` as a list of singleton key-value pairs in ascending order.
     ///
-    pub def toMutDeque(r: Region[r], m: MultiMap[k, v]): MutDeque[(k, Set[v]), r] \ Write(r) =
+    pub def toMutDeque(r: Region[r], m: MultiMap[k, v]): MutDeque[(k, Set[v]), r] \ r =
         let MultiMap(m1) = m;
         Map.toMutDeque(r, m1)
 
@@ -548,7 +548,7 @@ mod MultiMap {
     ///
     /// Returns an iterator over all key-value pairs in `m` i.e. `k => Set#{v_1, ..., v_n}`.
     ///
-    pub def iterator(rc: Region[r], m: MultiMap[k, v]): Iterator[(k, Set[v]), r, r] \ Write(r) =
+    pub def iterator(rc: Region[r], m: MultiMap[k, v]): Iterator[(k, Set[v]), r, r] \ r =
         let MultiMap(m1) = m;
         Map.iterator(rc, m1)
 

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -61,7 +61,7 @@ mod MutDeque {
     ///
     /// Returns a string representation of the given MutDeque `d`.
     ///
-    pub def toString(d: MutDeque[a, r]): String \ Read(r) with ToString[a] = region rc2 {
+    pub def toString(d: MutDeque[a, r]): String \ r with ToString[a] = region rc2 {
         let sb = StringBuilder.new(rc2);
         StringBuilder.appendString!("MutDeque#{", sb);
         forEachWithIndex((i, x) -> {
@@ -77,13 +77,13 @@ mod MutDeque {
     ///
     /// Returns an empty MutDeque.
     ///
-    pub def new(r: Region[r]): MutDeque[a, r] \ Write(r) =
+    pub def new(r: Region[r]): MutDeque[a, r] \ r =
         MutDeque(r, ref Array.new(r, minCapacity()) @ r, ref 0 @ r, ref 0 @ r)
 
     ///
     /// Returns the number of elements in `d`.
     ///
-    pub def size(d: MutDeque[a, r]): Int32 \ Read(r) =
+    pub def size(d: MutDeque[a, r]): Int32 \ r =
         let MutDeque(_, _, f, b) = d;
         computeSize(capacity(d), deref f, deref b)
 
@@ -99,20 +99,20 @@ mod MutDeque {
     ///
     /// Returns `true` if `d` is empty.
     ///
-    pub def isEmpty(d: MutDeque[a, r]): Bool \ Read(r) =
+    pub def isEmpty(d: MutDeque[a, r]): Bool \ r =
         let MutDeque(_, _, f, b) = d;
         deref f == deref b
 
     ///
     /// Returns the sum of all elements in the deque `d`.
     ///
-    pub def sum(d: MutDeque[Int32, r]): Int32 \ Read(r) =
+    pub def sum(d: MutDeque[Int32, r]): Int32 \ r =
         sumWith(identity, d)
 
     ///
     /// Returns the sum of all elements in the deque `d` according to the function `f`.
     ///
-    pub def sumWith(f: a -> Int32 \ ef, d: MutDeque[a, r]): Int32 \ { ef, Read(r) } =
+    pub def sumWith(f: a -> Int32 \ ef, d: MutDeque[a, r]): Int32 \ { ef, r } =
         foldLeft((acc, x) -> f(x) + acc, 0, d)
 
     ///
@@ -120,7 +120,7 @@ mod MutDeque {
     ///
     /// That is, the result is of the form: `f(...f(f(s, x1), x2)..., xn)`.
     ///
-    pub def foldLeft(f: (b, a) -> b \ ef, s: b, d: MutDeque[a, r]): b \ { ef, Read(r) } =
+    pub def foldLeft(f: (b, a) -> b \ ef, s: b, d: MutDeque[a, r]): b \ { ef, r } =
         let MutDeque(_, ar_, front_, back_) = d;
         let ar = deref ar_;
         let front = deref front_;
@@ -138,7 +138,7 @@ mod MutDeque {
     ///
     /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, s))...)`.
     ///
-    pub def foldRight(f: (a, b) -> b \ ef, s: b, d: MutDeque[a, r]): b \ { ef, Read(r) } =
+    pub def foldRight(f: (a, b) -> b \ ef, s: b, d: MutDeque[a, r]): b \ { ef, r } =
         let MutDeque(_, ar_, front_, back_) = d;
         let ar = deref ar_;
         let front = deref front_;
@@ -159,7 +159,7 @@ mod MutDeque {
     /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, z))...)`.
     /// A `foldRightWithCont` allows early termination by not calling the continuation.
     ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ {ef, r}) -> b \ {ef, r}, s: b, d: MutDeque[a, r]): b \ { ef, Read(r) } =
+    pub def foldRightWithCont(f: (a, Unit -> b \ {ef, r}) -> b \ {ef, r}, s: b, d: MutDeque[a, r]): b \ { ef, r } =
         let MutDeque(_, ar_, front_, back_) = d;
         let ar = deref ar_;
         let front = deref front_;
@@ -176,13 +176,13 @@ mod MutDeque {
     ///
     /// Returns the result of mapping each element and combining the results.
     ///
-    pub def foldMap(f: a -> b \ ef, d: MutDeque[a, r]): b \ { ef, Read(r) } with Monoid[b] =
+    pub def foldMap(f: a -> b \ ef, d: MutDeque[a, r]): b \ { ef, r } with Monoid[b] =
         foldLeft((acc, x) -> Monoid.combine(acc, f(x)), Monoid.empty(), d)
 
     ///
     /// Returns `Some(x)` where `x` is the element at the front. Returns `None` if `d` is empty.
     ///
-    pub def popFront(d: MutDeque[a, r]): Option[a] \ { Read(r), Write(r) } =
+    pub def popFront(d: MutDeque[a, r]): Option[a] \ r =
         if (isEmpty(d)) {
             None
         }
@@ -199,7 +199,7 @@ mod MutDeque {
     ///
     /// Returns `Some(x)` where `x` is the element at the back. Returns `None` if `d` is empty.
     ///
-    pub def popBack(d: MutDeque[a, r]): Option[a] \ { Read(r), Write(r) } =
+    pub def popBack(d: MutDeque[a, r]): Option[a] \ r =
         if (isEmpty(d)) {
             None
         }
@@ -216,7 +216,7 @@ mod MutDeque {
     ///
     /// Pushes `x` to the front of `d`.
     ///
-    pub def pushFront(x: a, d: MutDeque[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def pushFront(x: a, d: MutDeque[a, r]): Unit \ r =
         let MutDeque(_, a, f, _) = d;
         let a1 = deref a;
         let f1 = (deref f - 1) `Int32.mod` capacity(d); // Update index such that it points to an empty index. This will never overlap with the back index.
@@ -227,7 +227,7 @@ mod MutDeque {
     ///
     /// Pushes `x` to the back of `d`.
     ///
-    pub def pushBack(x: a, d: MutDeque[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def pushBack(x: a, d: MutDeque[a, r]): Unit \ r =
         let MutDeque(_, a, _, b) = d;
         let a1 = deref a;
         let b1 = deref b;
@@ -238,7 +238,7 @@ mod MutDeque {
     ///
     /// Optionally returns the front element. Does *not* remove it.
     ///
-    pub def peekFront(d: MutDeque[a, r]): Option[a] \ Read(r) =
+    pub def peekFront(d: MutDeque[a, r]): Option[a] \ r =
         let MutDeque(_, a, f, b) = d;
         let f1 = deref f;
         let b1 = deref b;
@@ -250,7 +250,7 @@ mod MutDeque {
     ///
     /// Optionally returns the back element. Does *not* remove it.
     ///
-    pub def peekBack(d: MutDeque[a, r]): Option[a] \ Read(r) =
+    pub def peekBack(d: MutDeque[a, r]): Option[a] \ r =
         let MutDeque(_, a, f, b) = d;
         let f1 = deref f;
         let b1 = deref b;
@@ -264,19 +264,19 @@ mod MutDeque {
     ///
     /// Doubles the capacity of `d` if the load factor is greater than or equal to `maxLoadFactor`.
     ///
-    def expand!(d: MutDeque[a, r]): Unit \ { Read(r), Write(r) } =
+    def expand!(d: MutDeque[a, r]): Unit \ r =
         if (shouldExpand(d)) grow!(d) else ()
 
     ///
     /// Returns `true` if the load factor is greater than or equal to `maxLoadFactor`.
     ///
-    def shouldExpand(d: MutDeque[a, r]): Bool \ { Read(r), Write(r) } =
+    def shouldExpand(d: MutDeque[a, r]): Bool \ r =
         loadFactorOf(size(d), capacity(d)) >= maxLoadFactor()
 
     ///
     /// Doubles the capacity of `d`.
     ///
-    def grow!(d: MutDeque[a, r]): Unit \ { Read(r), Write(r) } =
+    def grow!(d: MutDeque[a, r]): Unit \ r =
         let MutDeque(r, a, f, b) = d;
         let c = capacity(d);
         let arr = Array.new(r, Int32.leftShift(c, 1));    // Allocate new array `arr` with double the capacity of `a`.
@@ -288,19 +288,19 @@ mod MutDeque {
     ///
     /// Compresses MutDeque `d` if the load factor is less than or equal to `minLoadFactor`.
     ///
-    def compress!(d: MutDeque[a, r]): Unit \ { Read(r), Write(r) } =
+    def compress!(d: MutDeque[a, r]): Unit \ r =
         if (shouldCompress(d)) shrink!(d) else ()
 
     ///
     /// Returns `true` if the load factor is less than or equal to 1 / 4.
     ///
-    def shouldCompress(d: MutDeque[a, r]): Bool \ { Read(r), Write(r) } =
+    def shouldCompress(d: MutDeque[a, r]): Bool \ r =
         loadFactorOf(size(d), capacity(d)) <= minLoadFactor()
 
     ///
     /// Shrinks MutDeque `d` to half its size but never below `minCapacity`.
     ///
-    def shrink!(d: MutDeque[a, r]): Unit \ { Read(r), Write(r) } =
+    def shrink!(d: MutDeque[a, r]): Unit \ r =
         let MutDeque(r, a, f, b) = d;
         let mc = minCapacity();
         let c = capacity(d);
@@ -317,7 +317,7 @@ mod MutDeque {
     ///
     /// Copies the elements from `a` to `a1`. Mutates the array `a1`.
     ///
-    def copyElements!(r2: Region[r2], f: Int32, b: Int32, a: Array[a, r1], a1: Array[a, r2]): Unit \ { Read(r1), Write(r2) } =
+    def copyElements!(r2: Region[r2], f: Int32, b: Int32, a: Array[a, r1], a1: Array[a, r2]): Unit \ { r1, r2 } =
         let c = Array.length(a);
         if (f < b) { // If this predicate is true the elements do not "wrap around" in the array, i.e. the elements are laid out sequentially from [0 .. b].
             Array.updateSequence!(0,     Array.slice(r2, start = f, end = b, a), a1)
@@ -335,14 +335,14 @@ mod MutDeque {
     ///
     /// Returns the capacity of `d`.
     ///
-    def capacity(d: MutDeque[a, r]): Int32 \ Read(r) =
+    def capacity(d: MutDeque[a, r]): Int32 \ r =
         let MutDeque(_, a, _, _) = d;
         Array.length(deref a)
 
     ///
     /// Returns `true` if `MutDeque`s `a` and `b` have the same elements in the same order, i.e. are structurally equal.
     ///
-    pub def sameElements(d1: MutDeque[t, r1], d2: MutDeque[t, r2]): Bool \ Read(r1, r2) with Eq[t] = region rc3 {
+    pub def sameElements(d1: MutDeque[t, r1], d2: MutDeque[t, r2]): Bool \ { r1, r2 } with Eq[t] = region rc3 {
         let aSize = size(d1);
         let bSize = size(d2);
         if (aSize == bSize) {
@@ -360,13 +360,13 @@ mod MutDeque {
     ///
     /// Returns `d` as a `List`.
     ///
-    pub def toList(d: MutDeque[a, r]): List[a] \ Read(r) =
+    pub def toList(d: MutDeque[a, r]): List[a] \ r =
         foldRight((x, acc) -> x :: acc, Nil, d)
 
     ///
     /// Returns `d` as an array.
     ///
-    pub def toArray(r1: Region[r1], d: MutDeque[a, r2]): Array[a, r1] \ { Read(r2), Write(r1) } =
+    pub def toArray(r1: Region[r1], d: MutDeque[a, r2]): Array[a, r1] \ { r2, r1 } =
         let MutDeque(_, a, f, b) = d;
         let len = MutDeque.capacity(d);
         let i = deref f;
@@ -382,14 +382,14 @@ mod MutDeque {
     /// Returns the concatenation of the string representation
     /// of each element in `d` with `sep` inserted between each element.
     ///
-    pub def join(sep: String, d: MutDeque[a, r]): String \ Read(r) with ToString[a] =
+    pub def join(sep: String, d: MutDeque[a, r]): String \ r with ToString[a] =
         joinWith(ToString.toString, sep, d)
 
     ///
     /// Returns the concatenation of the string representation
     /// of each element in `d` according to `f` with `sep` inserted between each element.
     ///
-    pub def joinWith(f: a -> String \ ef, sep: String, d: MutDeque[a, r]): String \ { ef, Read(r) } = region rc1 {
+    pub def joinWith(f: a -> String \ ef, sep: String, d: MutDeque[a, r]): String \ { ef, r } = region rc1 {
         use StringBuilder.append!;
         let lastSep = String.length(sep);
         let sb = StringBuilder.new(rc1);
@@ -402,7 +402,7 @@ mod MutDeque {
     ///
     /// Modifying `d` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(rc: Region[r1], d: MutDeque[a, r2]): Iterator[a, r1 and r2, r1] \ { Write(r1), Read(r2) } =
+    pub def iterator(rc: Region[r1], d: MutDeque[a, r2]): Iterator[a, r1 and r2, r1] \ { r1, r2 } =
         let MutDeque(_, a, f, b) = d;
         let i = ref (deref f) @ rc;
         let next = () -> {
@@ -419,7 +419,7 @@ mod MutDeque {
     ///
     /// Apply the effectful function `f` to all the elements in the MutDeque `d`.
     ///
-    pub def forEach(f: a -> Unit \ ef, d: MutDeque[a, r]): Unit \ { ef, Read(r) } =
+    pub def forEach(f: a -> Unit \ ef, d: MutDeque[a, r]): Unit \ { ef, r } =
         let MutDeque(_, a, front, back) = d;
         let c = capacity(d) - 1;
 
@@ -440,7 +440,7 @@ mod MutDeque {
     /// Apply the effectful function `f` to all the elements in the MutDeque `d`
     /// along with that element's index.
     ///
-    pub def forEachWithIndex(f: (Int32, a) -> Unit \ ef, d: MutDeque[a, r]): Unit \ { ef, Read(r) } = region rc {
+    pub def forEachWithIndex(f: (Int32, a) -> Unit \ ef, d: MutDeque[a, r]): Unit \ { ef, r } = region rc {
         let ix = ref 0 @ rc;
         forEach(x -> {let i = deref ix; f(i, x); ix := i+1}, d)
     }
@@ -448,7 +448,7 @@ mod MutDeque {
     ///
     /// Shuffles a copy of `d` using the Fisher–Yates shuffle.
     ///
-    pub def shuffle(r1: Region[r1], rnd: Random, d: MutDeque[a, r2]): MutDeque[a, r1] \ { Read(r2), Write(r1), NonDet } = region rc3 {
+    pub def shuffle(r1: Region[r1], rnd: Random, d: MutDeque[a, r2]): MutDeque[a, r1] \ { r2, r1, NonDet } = region rc3 {
         toArray(rc3, d) !> Array.shuffle(rnd) |> Array.toMutDeque(r1)
     }
 

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -36,7 +36,7 @@ mod MutList {
     ///
     /// Returns a string representation of the given MutList `l`.
     ///
-    pub def toString(l: MutList[a, r]): String \ Read(r) with ToString[a] = region rc2 {
+    pub def toString(l: MutList[a, r]): String \ r with ToString[a] = region rc2 {
         let sb = StringBuilder.new(rc2);
         StringBuilder.appendString!("MutList#{", sb);
         forEachWithIndex((i, x) -> {
@@ -52,7 +52,7 @@ mod MutList {
     ///
     /// Returns a new empty mutable list with a default capacity.
     ///
-    pub def new(r: Region[r]): MutList[a, r] \ Write(r) =
+    pub def new(r: Region[r]): MutList[a, r] \ r =
         MutList(r, ref Array.new(r, minCapacity()) @ r, ref 0 @ r)
 
     ///
@@ -60,7 +60,7 @@ mod MutList {
     ///
     /// Returns an empty mutable list if `b >= e`.
     ///
-    pub def range(r: Region[r], b: Int32, e: Int32): MutList[Int32, r] \ Write(r) =
+    pub def range(r: Region[r], b: Int32, e: Int32): MutList[Int32, r] \ r =
         let minCap = minCapacity();
         let d = e - b;
         let c = Order.max(d, minCap);
@@ -70,7 +70,7 @@ mod MutList {
     ///
     /// Optionally returns the element at position `i` in the mutable list `v`.
     ///
-    pub def nth(i: Int32, v: MutList[a, r]): Option[a] \ Read(r) =
+    pub def nth(i: Int32, v: MutList[a, r]): Option[a] \ r =
         let MutList(_, a, l) = v;
         if (0 <= i and i < deref l)
             Array.nth(i, deref a)
@@ -80,20 +80,20 @@ mod MutList {
     ///
     /// Returns the number of elements in the given mutable list `v`.
     ///
-    pub def length(v: MutList[a, r]): Int32 \ Read(r) =
+    pub def length(v: MutList[a, r]): Int32 \ r =
         let MutList(_, _, l) = v;
         deref l
 
     ///
     /// Returns `true` if the given mutable list `v` is empty.
     ///
-    pub def isEmpty(v: MutList[a, r]): Bool \ Read(r) =
+    pub def isEmpty(v: MutList[a, r]): Bool \ r =
         length(v) == 0
 
     ///
     /// Returns `true` if the given element `x` is a member of the given mutable list `v`.
     ///
-    pub def memberOf(x: a, v: MutList[a, r]): Bool \ Read(r) with Eq[a] =
+    pub def memberOf(x: a, v: MutList[a, r]): Bool \ r with Eq[a] =
         exists(y -> y == x, v)
 
     ///
@@ -101,7 +101,7 @@ mod MutList {
     ///
     /// Returns `None` if `v` is empty.
     ///
-    pub def minimum(v: MutList[a, r]): Option[a] \ Read(r) with Order[a] =
+    pub def minimum(v: MutList[a, r]): Option[a] \ r with Order[a] =
         reduceLeft(Order.min, v)
 
     ///
@@ -109,7 +109,7 @@ mod MutList {
     ///
     /// Returns `None` if `v` is empty.
     ///
-    pub def minimumBy(cmp: (a, a) -> Comparison, v: MutList[a, r]): Option[a] \ Read(r) =
+    pub def minimumBy(cmp: (a, a) -> Comparison, v: MutList[a, r]): Option[a] \ r =
         reduceLeft(Order.minBy(cmp), v)
 
     ///
@@ -117,7 +117,7 @@ mod MutList {
     ///
     /// Returns `None` if `v` is empty.
     ///
-    pub def maximum(v: MutList[a, r]): Option[a] \ Read(r) with Order[a] =
+    pub def maximum(v: MutList[a, r]): Option[a] \ r with Order[a] =
         reduceLeft(Order.max, v)
 
     ///
@@ -125,7 +125,7 @@ mod MutList {
     ///
     /// Returns `None` if `v` is empty.
     ///
-    pub def maximumBy(cmp: (a, a) -> Comparison, v: MutList[a, r]): Option[a] \ Read(r) =
+    pub def maximumBy(cmp: (a, a) -> Comparison, v: MutList[a, r]): Option[a] \ r =
         reduceLeft(Order.maxBy(cmp), v)
 
     ///
@@ -133,19 +133,19 @@ mod MutList {
     ///
     /// Returns `0` if the given mutable list `v` is empty.
     ///
-    pub def count(f: a -> Bool \ ef, v: MutList[a, r]): Int32 \ { ef, Read(r) } =
+    pub def count(f: a -> Bool \ ef, v: MutList[a, r]): Int32 \ { ef, r } =
         foldLeft((acc, x) -> if (f(x)) acc + 1 else acc, 0, v)
 
     ///
     /// Returns the sum of all elements in the MutList `v`.
     ///
-    pub def sum(v: MutList[Int32, r]): Int32 \ Read(r) =
+    pub def sum(v: MutList[Int32, r]): Int32 \ r =
         foldLeft((acc, x) -> acc + x, 0, v)
 
     ///
     /// Returns the sum of all elements in the MutList `v` according to the function `f`.
     ///
-    pub def sumWith(f: a -> Int32 \ ef, v: MutList[a, r]): Int32 \ { ef, Read(r) } =
+    pub def sumWith(f: a -> Int32 \ ef, v: MutList[a, r]): Int32 \ { ef, r } =
         foldLeft((acc, x) -> acc + f(x), 0, v)
 
     ///
@@ -153,7 +153,7 @@ mod MutList {
     ///
     /// Returns `false` if the given mutable list `v` is empty.
     ///
-    pub def exists(f: a -> Bool \ ef, v: MutList[a, r]): Bool \ { ef, Read(r) } =
+    pub def exists(f: a -> Bool \ ef, v: MutList[a, r]): Bool \ { ef, r } =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -170,7 +170,7 @@ mod MutList {
     ///
     /// Returns `true` if the given mutable list `v` is empty.
     ///
-    pub def forAll(f: a -> Bool \ ef, v: MutList[a, r]): Bool \ { ef, Read(r) } =
+    pub def forAll(f: a -> Bool \ ef, v: MutList[a, r]): Bool \ { ef, r } =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -187,7 +187,7 @@ mod MutList {
     ///
     /// Returns `None` if the given mutable list `v` is empty.
     ///
-    pub def head(v: MutList[a, r]): Option[a] \ Read(r) =
+    pub def head(v: MutList[a, r]): Option[a] \ r =
         let MutList(_, a, _) = v;
         if (isEmpty(v))
             None
@@ -199,7 +199,7 @@ mod MutList {
     ///
     /// Returns `None` if the given mutable list `v` is empty.
     ///
-    pub def last(v: MutList[a, r]): Option[a] \ Read(r) =
+    pub def last(v: MutList[a, r]): Option[a] \ r =
         let MutList(_, a, l) = v;
         let len = deref l;
         if (len > 0) Some(Array.get(len - 1, deref a)) else None
@@ -207,14 +207,14 @@ mod MutList {
     ///
     /// Alias for `IndexOfLeft`
     ///
-    pub def indexOf(x: a, v: MutList[a, r]): Option[Int32] \ Read(r) with Eq[a] =
+    pub def indexOf(x: a, v: MutList[a, r]): Option[Int32] \ r with Eq[a] =
         indexOfLeft(x, v)
 
     ///
     /// Optionally returns the position of the first occurrence of `x` in `v`
     /// searching from left to right.
     ///
-    pub def indexOfLeft(x: a, v: MutList[a, r]): Option[Int32] \ Read(r) with Eq[a] =
+    pub def indexOfLeft(x: a, v: MutList[a, r]): Option[Int32] \ r with Eq[a] =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -230,7 +230,7 @@ mod MutList {
     /// Optionally returns the position of the first occurrence of `x` in `v`
     /// searching from right to left.
     ///
-    pub def indexOfRight(x: a, v: MutList[a, r]): Option[Int32] \ Read(r) with Eq[a] =
+    pub def indexOfRight(x: a, v: MutList[a, r]): Option[Int32] \ r with Eq[a] =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -245,7 +245,7 @@ mod MutList {
     ///
     /// Alias for `findLeft`.
     ///
-    pub def find(f: a -> Bool, v: MutList[a, r]): Option[a] \ Read(r) =
+    pub def find(f: a -> Bool, v: MutList[a, r]): Option[a] \ r =
         findLeft(f, v)
 
     ///
@@ -254,7 +254,7 @@ mod MutList {
     /// Returns `None` if no element satisfies the given predicate `f`.
     /// Returns `None` if the given mutable list `v` is empty.
     ///
-    pub def findLeft(f: a -> Bool, v: MutList[a, r]): Option[a] \ Read(r) =
+    pub def findLeft(f: a -> Bool, v: MutList[a, r]): Option[a] \ r =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -273,7 +273,7 @@ mod MutList {
     /// Returns `None` if no element satisfies the given predicate `f`.
     /// Returns `None` if the given mutable list `v` is empty.
     ///
-    pub def findRight(f: a -> Bool, v: MutList[a, r]): Option[a] \ Read(r) =
+    pub def findRight(f: a -> Bool, v: MutList[a, r]): Option[a] \ r =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -288,13 +288,13 @@ mod MutList {
     ///
     /// Alias for `scanLeft`.
     ///
-    pub def scan(r1: Region[r1], f: (b, a) -> b \ ef, s: b, v: MutList[a, r2]): MutList[b, r1] \ { ef, Read(r2), Write(r1) } =
+    pub def scan(r1: Region[r1], f: (b, a) -> b \ ef, s: b, v: MutList[a, r2]): MutList[b, r1] \ { ef, r2, r1 } =
         scanLeft(r1, f, s, v)
 
     ///
     /// Accumulates the result of applying `f` to `v` going left to right.
     ///
-    pub def scanLeft(r1: Region[r1], f: (b, a) -> b \ ef, s: b, v: MutList[a, r2]): MutList[b, r1] \ { ef, Read(r2), Write(r1) } =
+    pub def scanLeft(r1: Region[r1], f: (b, a) -> b \ ef, s: b, v: MutList[a, r2]): MutList[b, r1] \ { ef, r2, r1 } =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -315,7 +315,7 @@ mod MutList {
     ///
     /// Accumulates the result of applying `f` to `v` going right to left.
     ///
-    pub def scanRight(r1: Region[r1], f: (a, b) -> b \ ef, s: b, v: MutList[a, r2]): MutList[b, r1] \ { ef, Read(r2), Write(r1) } =
+    pub def scanRight(r1: Region[r1], f: (a, b) -> b \ ef, s: b, v: MutList[a, r2]): MutList[b, r1] \ { ef, r2, r1 } =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -338,7 +338,7 @@ mod MutList {
     ///
     /// The result is a new mutable list.
     ///
-    pub def map(r1: Region[r1], f: a -> b \ ef, v: MutList[a, r]): MutList[b, r1] \ { ef, Read(r), Write(r1) } =
+    pub def map(r1: Region[r1], f: a -> b \ ef, v: MutList[a, r]): MutList[b, r1] \ { ef, r, r1 } =
         if (isEmpty(v))
             MutList.new(r1)
         else {
@@ -362,7 +362,7 @@ mod MutList {
     ///
     /// Returns the result of applying `f` to every element in `v` along with that element's index.
     ///
-    pub def mapWithIndex(r1: Region[r1], f: (Int32, a) -> b \ ef, v: MutList[a, r]): MutList[b, r1] \ { ef, Read(r), Write(r1) } =
+    pub def mapWithIndex(r1: Region[r1], f: (Int32, a) -> b \ ef, v: MutList[a, r]): MutList[b, r1] \ { ef, r, r1 } =
         if (isEmpty(v))
             MutList.new(r1)
         else {
@@ -386,7 +386,7 @@ mod MutList {
     ///
     /// Apply `f` to every element in `v`.
     ///
-    pub def transform!(f: a -> a, v: MutList[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def transform!(f: a -> a, v: MutList[a, r]): Unit \ r =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -403,7 +403,7 @@ mod MutList {
     ///
     /// Apply `f` to every element in `v` along with that element's index.
     ///
-    pub def transformWithIndex!(f: (Int32, a) -> a, v: MutList[a, r]): Unit \ Read(r) =
+    pub def transformWithIndex!(f: (Int32, a) -> a, v: MutList[a, r]): Unit \ r =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -422,7 +422,7 @@ mod MutList {
     ///
     /// That is, the result is of the form: `f(...f(f(s, a[0]), a[1])..., xn)`.
     ///
-    pub def foldLeft(f: (b, a) -> b \ ef, s: b, v: MutList[a, r]): b \ { ef, Read(r) } =
+    pub def foldLeft(f: (b, a) -> b \ ef, s: b, v: MutList[a, r]): b \ { ef, r } =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -443,7 +443,7 @@ mod MutList {
     ///
     /// The implementation is tail recursive.
     ///
-    pub def foldRight(f: (a, b) -> b \ ef, s: b, v: MutList[a, r]): b \ { ef, Read(r) } =
+    pub def foldRight(f: (a, b) -> b \ ef, s: b, v: MutList[a, r]): b \ { ef, r } =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -463,7 +463,7 @@ mod MutList {
     /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, z))...)`.
     /// A `foldRightWithCont` allows early termination by not calling the continuation.
     ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ {ef, r}) -> b \ {ef, r}, z: b, v: MutList[a, r]): b \ { ef, Read(r) } =
+    pub def foldRightWithCont(f: (a, Unit -> b \ {ef, r}) -> b \ {ef, r}, z: b, v: MutList[a, r]): b \ { ef, r } =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -479,7 +479,7 @@ mod MutList {
     ///
     /// Returns the result of mapping each element and combining the results.
     ///
-    pub def foldMap(f: a -> b \ ef, v: MutList[a, r]): b \ {ef, Read(r)} with Monoid[b] =
+    pub def foldMap(f: a -> b \ ef, v: MutList[a, r]): b \ {ef, r} with Monoid[b] =
         foldLeft((acc, x) -> Monoid.combine(acc, f(x)), Monoid.empty(), v)
 
     ///
@@ -487,7 +487,7 @@ mod MutList {
     ///
     /// Returns `None` if `v` is empty.
     ///
-    pub def reduceLeft(f: (a, a) -> a \ ef, v: MutList[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def reduceLeft(f: (a, a) -> a \ ef, v: MutList[a, r]): Option[a] \ { ef, r } =
         foldLeft((acc, x) -> match acc {
             case Some(y) => Some(f(y, x))
             case None => Some(x)
@@ -498,7 +498,7 @@ mod MutList {
     ///
     /// Returns `None` if `v` is empty.
     ///
-    pub def reduceRight(f: (a, a) -> a \ ef, v: MutList[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def reduceRight(f: (a, a) -> a \ ef, v: MutList[a, r]): Option[a] \ { ef, r } =
         foldRight((x, acc) -> match acc {
             case Some(y) => Some(f(x, y))
             case None => Some(x)
@@ -507,7 +507,7 @@ mod MutList {
     ///
     /// Removes all elements from the given mutable list `v`.
     ///
-    pub def clear!(v: MutList[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def clear!(v: MutList[a, r]): Unit \ r =
         let MutList(r, a, l) = v;
         a := Array.new(r, Array.length(deref a));
         l := 0
@@ -516,7 +516,7 @@ mod MutList {
     /// Returns a shallow copy of the given mutable list `v`.
     /// The capacity of the copy is equal to the length of the list.
     ///
-    pub def copy(r1: Region[r1], v: MutList[a, r]): MutList[a, r1] \ { Read(r), Write(r1) } =
+    pub def copy(r1: Region[r1], v: MutList[a, r]): MutList[a, r1] \ { r, r1 } =
         let MutList(_, a, l) = v;
         let len = deref l;
         if (len > minCapacity())
@@ -527,7 +527,7 @@ mod MutList {
     ///
     /// Optionally removes and returns the last element in the given mutable list `v`.
     ///
-    pub def pop!(v: MutList[a, r]): Option[a] \ { Read(r), Write(r) } =
+    pub def pop!(v: MutList[a, r]): Option[a] \ r =
         let MutList(_, a, l) = v;
         let len = deref l;
         if (len > 0)
@@ -542,7 +542,7 @@ mod MutList {
     ///
     /// Inserts the given element `x` at the end of the given mutable list `v`.
     ///
-    pub def push!(x: a, v: MutList[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def push!(x: a, v: MutList[a, r]): Unit \ r =
         let MutList(_, a, l) = v;
         let len = deref l;
         if (capacity(v) - len == 0)
@@ -558,7 +558,7 @@ mod MutList {
     ///
     /// If the given index `i` exceeds the length of the mutable list, the element is inserted at the last position.
     ///
-    pub def insert!(x: a, i: Int32, v: MutList[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def insert!(x: a, i: Int32, v: MutList[a, r]): Unit \ r =
         let MutList(r, a, l) = v;
         let len = deref l;
         if (capacity(v) - len == 0)
@@ -576,7 +576,7 @@ mod MutList {
     ///
     /// If the given index `i` exceeds the length of the mutable list, no element is removed.
     ///
-    pub def remove!(i: Int32, v: MutList[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def remove!(i: Int32, v: MutList[a, r]): Unit \ r =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -603,19 +603,19 @@ mod MutList {
     ///
     /// Appends `m` to `v` i.e. inserts all elements from `m` into the end of `v`.
     ///
-    pub def pushAll!(m: m[a], v: MutList[a, r]): Unit \ { Read(r), Write(r) } with Foldable[m] =
+    pub def pushAll!(m: m[a], v: MutList[a, r]): Unit \ r with Foldable[m] =
         Foldable.forEach(x -> MutList.push!(x, v), m)
 
     ///
     /// Appends `m` to `v` i.e. inserts all elements from `m` into the end of `v`.
     ///
-    pub def append!(m: m[a], v: MutList[a, r]): Unit \ { Read(r), Write(r) } with Foldable[m] =
+    pub def append!(m: m[a], v: MutList[a, r]): Unit \ r with Foldable[m] =
         pushAll!(m, v)
 
     ///
     /// Removes all elements from the given mutable list `v` that do not satisfy the given predicate `f`.
     ///
-    pub def retain!(f: a -> Bool, v: MutList[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def retain!(f: a -> Bool, v: MutList[a, r]): Unit \ r =
         let MutList(r, a1, l1) = v;
         let l = MutList.new(r);
         forEach(e -> if (f(e)) push!(e, l) else (), v);
@@ -626,13 +626,13 @@ mod MutList {
     ///
     /// Replaces all occurrences of the `from` with `to` in the given mutable list `v`.
     ///
-    pub def replace!(from: {from = a}, to: {to = a}, v: MutList[a, r]): Unit \ { Read(r), Write(r) } with Eq[a] =
+    pub def replace!(from: {from = a}, to: {to = a}, v: MutList[a, r]): Unit \ r with Eq[a] =
         transform!(e -> if (e == from.from) to.to else e, v)
 
     ///
     /// Reverses the order of the elements in the given mutable list `v`.
     ///
-    pub def reverse!(v: MutList[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def reverse!(v: MutList[a, r]): Unit \ r =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -655,7 +655,7 @@ mod MutList {
     ///
     /// Truncates the mutable list as needed.
     ///
-    def shrinkTo!(n: Int32, v: MutList[a, r]): Unit \ { Read(r), Write(r) } =
+    def shrinkTo!(n: Int32, v: MutList[a, r]): Unit \ r =
         let minCap = minCapacity();
         let capv = capacity(v);
         let MutList(r, a, l) = v;
@@ -671,7 +671,7 @@ mod MutList {
     ///
     /// Shrinks the given mutable list `v` to its actual size.
     ///
-    pub def shrink!(v: MutList[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def shrink!(v: MutList[a, r]): Unit \ r =
         shrinkTo!(length(v), v)
 
     ///
@@ -681,7 +681,7 @@ mod MutList {
     ///
     /// If the given length `l` is negative, all elements are removed.
     ///
-    pub def truncate!(l: Int32, v: MutList[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def truncate!(l: Int32, v: MutList[a, r]): Unit \ r =
         if (l < 0)
             clear!(v)
         else if (l < length(v)) {
@@ -701,27 +701,27 @@ mod MutList {
     ///
     /// The content of the mutable list is unchanged.
     ///
-    pub def reserve!(n: Int32, v: MutList[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def reserve!(n: Int32, v: MutList[a, r]): Unit \ r =
         let MutList(r, a, l) = v;
         a := Array.copyOfRange(r, 0, (deref l) + n, deref a)
 
     ///
     /// Returns `v` as an immutable list.
     ///
-    pub def toList(v: MutList[a, r]): List[a] \ Read(r) =
+    pub def toList(v: MutList[a, r]): List[a] \ r =
         foldRight((x, acc) -> x :: acc, Nil, v)
 
     ///
     /// Returns `v` as an array.
     ///
-    pub def toArray(r1: Region[r1], v: MutList[a, r2]): Array[a, r1] \ { Read(r2), Write(r1) } =
+    pub def toArray(r1: Region[r1], v: MutList[a, r2]): Array[a, r1] \ { r2, r1 } =
         let MutList(_, a, l) = v;
         Array.copyOfRange(r1, 0, deref l, deref a)
 
     ///
     /// Returns `xs` as a vector.
     ///
-    pub def toVector(xs: MutList[a, r]): Vector[a] \ Read(r) = region rc {
+    pub def toVector(xs: MutList[a, r]): Vector[a] \ r = region rc {
         let arr = Array.new(rc, length(xs));
         forEachWithIndex((i, x) -> Array.put(x, i, arr), xs);
         Array.toVector(arr)
@@ -730,13 +730,13 @@ mod MutList {
     ///
     /// Returns the mutable list `xs` as a chain.
     ///
-    pub def toChain(xs: MutList[a, r]): Chain[a] \ Read(r) =
+    pub def toChain(xs: MutList[a, r]): Chain[a] \ r =
         foldLeft((ac, x) -> Chain.snoc(ac, x), Chain.empty(), xs)
 
     ///
     /// Returns `v` as a MutDeque.
     ///
-    pub def toMutDeque(r1: Region[r1], v: MutList[a, r2]): MutDeque[a, r1] \ { Read(r2), Write(r1) }  =
+    pub def toMutDeque(r1: Region[r1], v: MutList[a, r2]): MutDeque[a, r1] \ { r2, r1 }  =
         let d = MutDeque.new(r1);
         forEach(x -> MutDeque.pushBack(x, d), v);
         d
@@ -744,7 +744,7 @@ mod MutList {
     ///
     /// Returns `true` if the mutable lists `v1` and `v2` have the same elements in the same order, i.e. are structurally equal.
     ///
-    pub def sameElements(v1: MutList[a, r1], v2: MutList[a, r2]): Bool \ Read(r1, r2) with Eq[a] =
+    pub def sameElements(v1: MutList[a, r1], v2: MutList[a, r2]): Bool \ { r1, r2 } with Eq[a] =
         let MutList(_, ra1, rl1) = v1;
         let MutList(_, ra2, rl2) = v2;
         let a1 = deref ra1;
@@ -765,14 +765,14 @@ mod MutList {
     /// Returns the concatenation of the string representation
     /// of each element in `v` with `sep` inserted between each element.
     ///
-    pub def join(sep: String, v: MutList[a, r]): String \ Read(r) with ToString[a] =
+    pub def join(sep: String, v: MutList[a, r]): String \ r with ToString[a] =
         joinWith(ToString.toString, sep, v)
 
     ///
     /// Returns the concatenation of the string representation
     /// of each element in `v` according to `f` with `sep` inserted between each element.
     ///
-    pub def joinWith(f: a -> String \ ef, sep: String, v: MutList[a, r]): String \ { ef, Read(r) } = region rc1 {
+    pub def joinWith(f: a -> String \ ef, sep: String, v: MutList[a, r]): String \ { ef, r } = region rc1 {
         let sb = StringBuilder.new(rc1);
         let step = (i, x) ->
             if (i == 0)
@@ -790,7 +790,7 @@ mod MutList {
     ///
     /// Modifying `l` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(rc: Region[r1], l: MutList[a, r2]): Iterator[a, r1 and r2, r1] \ { Write(r1), Read(r2) } =
+    pub def iterator(rc: Region[r1], l: MutList[a, r2]): Iterator[a, r1 and r2, r1] \ { r1, r2 } =
         let MutList(_, a, len) = l;
         let len1 = deref len;
         let ix = ref 0 @ rc;
@@ -809,7 +809,7 @@ mod MutList {
     ///
     /// Applies `f` to all the elements in `v`.
     ///
-    pub def forEach(f: a -> Unit \ ef, v: MutList[a, r]): Unit \ { ef, Read(r) } =
+    pub def forEach(f: a -> Unit \ ef, v: MutList[a, r]): Unit \ { ef, r } =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -826,7 +826,7 @@ mod MutList {
     ///
     /// Applies `f` to all the elements in `v` along with that element's index.
     ///
-    pub def forEachWithIndex(f: (Int32, a) -> Unit \ ef, v: MutList[a, r]): Unit \ { ef, Read(r) } =
+    pub def forEachWithIndex(f: (Int32, a) -> Unit \ ef, v: MutList[a, r]): Unit \ { ef, r } =
         let MutList(_, ra, rl) = v;
         let a = deref ra;
         let l = deref rl;
@@ -845,7 +845,7 @@ mod MutList {
     ///
     /// The mutable list will be shrunk to 1/2 of its size if the load factor is less than 1/4.
     ///
-    pub def compress!(v: MutList[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def compress!(v: MutList[a, r]): Unit \ r =
         let c = capacity(v);
         let len = length(v);
         let loadFactor = Int32.toFloat32(len) / Int32.toFloat32(c);
@@ -861,7 +861,7 @@ mod MutList {
     ///
     /// Returns the capacity of `v`.
     ///
-    def capacity(v: MutList[a, r]): Int32 \ Read(r) =
+    def capacity(v: MutList[a, r]): Int32 \ r =
         let MutList(_, a, _) = v;
         Array.length(deref a)
 
@@ -873,7 +873,7 @@ mod MutList {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sort(r1: Region[r1], v: MutList[a, r]): MutList[a, r1] \ { Read(r), Write(r1) } with Order[a] =
+    pub def sort(r1: Region[r1], v: MutList[a, r]): MutList[a, r1] \ { r, r1 } with Order[a] =
         sortWith(r1, Order.compare, v)
 
     ///
@@ -884,7 +884,7 @@ mod MutList {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortBy(r1: Region[r1], f: a -> b, v: MutList[a, r]): MutList[a, r1] \ { Read(r), Write(r1) } with Order[b] =
+    pub def sortBy(r1: Region[r1], f: a -> b, v: MutList[a, r]): MutList[a, r1] \ { r, r1 } with Order[b] =
         sortWith(r1, Order.compare `on` f, v)
 
     ///
@@ -895,7 +895,7 @@ mod MutList {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortWith(r1: Region[r1], cmp: (a,a) -> Comparison, v: MutList[a, r]): MutList[a, r1] \ { Read(r), Write(r1) } =
+    pub def sortWith(r1: Region[r1], cmp: (a,a) -> Comparison, v: MutList[a, r]): MutList[a, r1] \ { r, r1 } =
         let vCopy = copy(r1, v);
         sortWith!(cmp, vCopy);
         vCopy
@@ -908,7 +908,7 @@ mod MutList {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sort!(v: MutList[a, r]): Unit \ { Read(r), Write(r) } with Order[a] =
+    pub def sort!(v: MutList[a, r]): Unit \ r with Order[a] =
         sortWith!(Order.compare, v)
 
     ///
@@ -919,7 +919,7 @@ mod MutList {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortBy!(f: a -> b, v: MutList[a, r]): Unit \ { Read(r), Write(r) } with Order[b] =
+    pub def sortBy!(f: a -> b, v: MutList[a, r]): Unit \ r with Order[b] =
         sortWith!(Order.compare `on` f, v)
 
     ///
@@ -930,14 +930,14 @@ mod MutList {
     ///
     /// The sort implementation is a Quicksort.
     ///
-    pub def sortWith!(cmp: (a,a) -> Comparison, v: MutList[a, r]): Unit \ { Read(r), Write(r) } =
+    pub def sortWith!(cmp: (a,a) -> Comparison, v: MutList[a, r]): Unit \ r =
         let MutList(_, a, l) = v;
         Array.sortWithin!(cmp, 0, (deref l) - 1, deref a)
 
     ///
     /// Shuffles `v` using the Fisher–Yates shuffle.
     ///
-    pub def shuffle(r1: Region[r1], rnd: Random, v: MutList[a, r1]): MutList[a, r1] \ { Read(r1), Write(r1), NonDet } = region rc2 {
+    pub def shuffle(r1: Region[r1], rnd: Random, v: MutList[a, r1]): MutList[a, r1] \ { r1, NonDet } = region rc2 {
         toArray(rc2, v) !> Array.shuffle(rnd) |> Array.toMutList(r1)
     }
 

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -26,7 +26,7 @@ mod MutMap {
     ///
     /// Returns a string representation of the given MutMap `m`.
     ///
-    pub def toString(m: MutMap[k, v, r]): String \ Read(r) with ToString[k], ToString[v] = region rc {
+    pub def toString(m: MutMap[k, v, r]): String \ r with ToString[k], ToString[v] = region rc {
         let sb = StringBuilder.new(rc);
         StringBuilder.appendString!("MutMap#{", sb);
         forEachWithIndex((i, k, v) -> {
@@ -42,26 +42,26 @@ mod MutMap {
     ///
     /// Returns a fresh empty mutable map.
     ///
-    pub def new(rc: Region[r]): MutMap[k, v, r] \ Write(r) =
+    pub def new(rc: Region[r]): MutMap[k, v, r] \ r =
         MutMap(rc, ref Map.empty() @ rc)
 
     ///
     /// Returns the singleton map where key `k` is mapped to value `v`.
     ///
-    pub def singleton(rc: Region[r], k: k, v: v): MutMap[k, v, r] \ Write(r) with Order[k] =
+    pub def singleton(rc: Region[r], k: k, v: v): MutMap[k, v, r] \ r with Order[k] =
         MutMap(rc, ref Map.singleton(k, v) @ rc)
 
     ///
     /// Returns `true` if and only if the mutable map `m` contains the key `k`.
     ///
-    pub def memberOf(k: k, m: MutMap[k, v, r]): Bool \ Read(r) with Order[k] =
+    pub def memberOf(k: k, m: MutMap[k, v, r]): Bool \ r with Order[k] =
         let MutMap(_, mm) = m;
         Map.memberOf(k, deref mm)
 
     ///
     /// Returns `true` if and only if `m` is the empty map.
     ///
-    pub def isEmpty(m: MutMap[k, v, r]): Bool \ Read(r) =
+    pub def isEmpty(m: MutMap[k, v, r]): Bool \ r =
         let MutMap(_, mm) = m;
         Map.isEmpty(deref mm)
 
@@ -70,7 +70,7 @@ mod MutMap {
     ///
     /// Returns `None` if `m` is empty.
     ///
-    pub def minimumKey(m: MutMap[k, v, r]): Option[(k, v)] \ Read(r) =
+    pub def minimumKey(m: MutMap[k, v, r]): Option[(k, v)] \ r =
         let MutMap(_, mm) = m;
         Map.minimumKey(deref mm)
 
@@ -81,7 +81,7 @@ mod MutMap {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `cmp`.
     ///
-    pub def minimumKeyBy(cmp: (k, k) -> Comparison \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, Read(r) } =
+    pub def minimumKeyBy(cmp: (k, k) -> Comparison \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.minimumKeyBy(cmp, deref mm)
 
@@ -91,7 +91,7 @@ mod MutMap {
     /// Returns `None` if `m` is empty.
     ///
     @Parallel
-    pub def minimumValue(m: MutMap[k, v, r]): Option[(k, v)] \ Read(r) with Order[v] =
+    pub def minimumValue(m: MutMap[k, v, r]): Option[(k, v)] \ r with Order[v] =
         let MutMap(_, mm) = m;
         Map.minimumValue(deref mm)
 
@@ -102,7 +102,7 @@ mod MutMap {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `cmp`.
     ///
-    pub def minimumValueBy(cmp: (v, v) -> Comparison \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, Read(r) } =
+    pub def minimumValueBy(cmp: (v, v) -> Comparison \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.minimumValueBy(cmp, deref mm)
 
@@ -111,7 +111,7 @@ mod MutMap {
     ///
     /// Returns `None` if `m` is empty.
     ///
-    pub def maximumKey(m: MutMap[k, v, r]): Option[(k, v)] \ Read(r) =
+    pub def maximumKey(m: MutMap[k, v, r]): Option[(k, v)] \ r =
         let MutMap(_, mm) = m;
         Map.maximumKey(deref mm)
 
@@ -122,7 +122,7 @@ mod MutMap {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
-    pub def maximumKeyBy(cmp: (k, k) -> Comparison \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, Read(r) } =
+    pub def maximumKeyBy(cmp: (k, k) -> Comparison \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.maximumKeyBy(cmp, deref mm)
 
@@ -132,7 +132,7 @@ mod MutMap {
     /// Returns `None` if `m` is empty.
     ///
     @Parallel
-    pub def maximumValue(m: MutMap[k, v, r]): Option[(k, v)] \ Read(r) with Order[v] =
+    pub def maximumValue(m: MutMap[k, v, r]): Option[(k, v)] \ r with Order[v] =
         let MutMap(_, mm) = m;
         Map.maximumValue(deref mm)
 
@@ -143,28 +143,28 @@ mod MutMap {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `cmp`.
     ///
-    pub def maximumValueBy(cmp: (v, v) -> Comparison \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, Read(r) } =
+    pub def maximumValueBy(cmp: (v, v) -> Comparison \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.maximumValueBy(cmp, deref mm)
 
     ///
     /// Returns the keys of the mutable map `m`.
     ///
-    pub def keysOf(m: MutMap[k, v, r]): Set[k] \ Read(r) with Order[k] =
+    pub def keysOf(m: MutMap[k, v, r]): Set[k] \ r with Order[k] =
         let MutMap(_, mm) = m;
         Map.keysOf(deref mm)
 
     ///
     /// Returns the values of the mutable map `m`.
     ///
-    pub def valuesOf(m: MutMap[k, v, r]): List[v] \ Read(r) =
+    pub def valuesOf(m: MutMap[k, v, r]): List[v] \ r =
         let MutMap(_, mm) = m;
         Map.valuesOf(deref mm)
 
     ///
     /// Returns the size of the mutable map `m`.
     ///
-    pub def size(m: MutMap[k, v, r]): Int32 \ Read(r) =
+    pub def size(m: MutMap[k, v, r]): Int32 \ r =
         let MutMap(_, mm) = m;
         Map.size(deref mm)
 
@@ -173,7 +173,7 @@ mod MutMap {
     ///
     /// Otherwise returns `None`.
     ///
-    pub def get(k: k, m: MutMap[k, v, r]): Option[v] \ Read(r) with Order[k] =
+    pub def get(k: k, m: MutMap[k, v, r]): Option[v] \ r with Order[k] =
         let MutMap(_, mm) = m;
         Map.get(k, deref mm)
 
@@ -182,14 +182,14 @@ mod MutMap {
     ///
     /// Otherwise returns `d`.
     ///
-    pub def getWithDefault(k: k, d: v, m: MutMap[k, v, r]): v \ Read(r) with Order[k] =
+    pub def getWithDefault(k: k, d: v, m: MutMap[k, v, r]): v \ r with Order[k] =
         let MutMap(_, mm) = m;
         Map.getWithDefault(k, d, deref mm)
 
     ///
     /// Updates the mutable map `m` with the binding `k -> v`. Replaces any existing binding.
     ///
-    pub def put!(k: k, v: v, m: MutMap[k, v, r]): Unit \ { Read(r), Write(r) } with Order[k] =
+    pub def put!(k: k, v: v, m: MutMap[k, v, r]): Unit \ r with Order[k] =
         let MutMap(_, mm) = m;
         mm := Map.insert(k, v, deref mm)
 
@@ -198,7 +198,7 @@ mod MutMap {
     ///
     /// Otherwise updates the mutable map `m` with the binding `k -> v`.
     ///
-    pub def putWith!(f: (v, v) -> v \ ef, k: k, v: v, m: MutMap[k, v, r]): Unit \ { ef, Read(r), Write(r) } with Order[k] =
+    pub def putWith!(f: (v, v) -> v \ ef, k: k, v: v, m: MutMap[k, v, r]): Unit \ { ef, r } with Order[k] =
         let MutMap(_, mm) = m;
         mm := Map.insertWith(f, k, v, deref mm)
 
@@ -207,7 +207,7 @@ mod MutMap {
     ///
     /// Otherwise leaves the map is unchanged.
     ///
-    pub def adjust!(f: v -> v \ ef, k: k, m: MutMap[k, v, r]): Unit \ { ef, Read(r), Write(r) } with Order[k] =
+    pub def adjust!(f: v -> v \ ef, k: k, m: MutMap[k, v, r]): Unit \ { ef, r } with Order[k] =
         adjustWithKey!((_, v1) -> f(v1), k, m)
 
     ///
@@ -215,14 +215,14 @@ mod MutMap {
     ///
     /// Otherwise leaves the map is unchanged.
     ///
-    pub def adjustWithKey!(f: (k, v) -> v \ ef, k: k, m: MutMap[k, v, r]): Unit \ { ef, Read(r), Write(r) } with Order[k] =
+    pub def adjustWithKey!(f: (k, v) -> v \ ef, k: k, m: MutMap[k, v, r]): Unit \ { ef, r } with Order[k] =
         let MutMap(_, mm) = m;
         mm := Map.adjustWithKey(f, k, deref mm)
 
     ///
     /// Removes all mappings from the mutable map `m`.
     ///
-    pub def clear!(m: MutMap[k, v, r]): Unit \ { Read(r), Write(r) } =
+    pub def clear!(m: MutMap[k, v, r]): Unit \ r =
         let MutMap(_, mm) = m;
         mm := Map.empty()
 
@@ -231,7 +231,7 @@ mod MutMap {
     ///
     /// Otherwise updates the mutable map `m` with a new mapping `k -> d` and returns d.
     ///
-    pub def getOrElsePut!(k: k, d: v, m: MutMap[k, v, r]): v \ { Read(r), Write(r) } with Order[k] =
+    pub def getOrElsePut!(k: k, d: v, m: MutMap[k, v, r]): v \ r with Order[k] =
         let MutMap(_, mm) = m;
         match Map.get(k, deref mm) {
             case None    => mm := Map.insert(k, d, deref mm); d
@@ -243,19 +243,19 @@ mod MutMap {
     ///
     /// That is, key collisions are resolved by taking the mapping from `m1`.
     ///
-    pub def merge!(m1: MutMap[k, v, r1], m2: MutMap[k, v, r2]): Unit \ { Read(r1, r2), Write(r2) } with Order[k] =
+    pub def merge!(m1: MutMap[k, v, r1], m2: MutMap[k, v, r2]): Unit \ { r1, r2 } with Order[k] =
         mergeWithKey!((_, v1, _) -> v1, m1, m2)
 
     ///
     /// Merges the mutable map `m1` into the mutable map `m2` where key collisions are resolved with the merge function `f`.
     ///
-    pub def mergeWith!(f: (v, v) -> v \ ef, m1: MutMap[k, v, r1], m2: MutMap[k, v, r2]): Unit \ { ef, Read(r1, r2), Write(r2) } with Order[k] =
+    pub def mergeWith!(f: (v, v) -> v \ ef, m1: MutMap[k, v, r1], m2: MutMap[k, v, r2]): Unit \ { ef, r1, r2 } with Order[k] =
         mergeWithKey!(_ -> f, m1, m2)
 
     ///
     /// Merges the mutable map `m1` into the mutable map `m2` where key collisions are resolved with the merge function `f`, taking both the key and values.
     ///
-    pub def mergeWithKey!(f: (k, v, v) -> v \ ef, m1: MutMap[k, v, r1], m2: MutMap[k, v, r2]): Unit \ { ef, Read(r1, r2), Write(r2) } with Order[k] =
+    pub def mergeWithKey!(f: (k, v, v) -> v \ ef, m1: MutMap[k, v, r1], m2: MutMap[k, v, r2]): Unit \ { ef, r1, r2 } with Order[k] =
         let MutMap(_, mm1) = m1;
         let MutMap(_, mm2) = m2;
         mm2 := Map.unionWithKey(f, deref mm1, deref mm2)
@@ -265,7 +265,7 @@ mod MutMap {
     ///
     /// The function `f` must be pure.
     ///
-    pub def refine!(f: v -> Bool, m: MutMap[k, v, r]): Unit \ { Read(r), Write(r) } with Order[k] =
+    pub def refine!(f: v -> Bool, m: MutMap[k, v, r]): Unit \ r with Order[k] =
         refineWithKey!(_ -> f, m)
 
     ///
@@ -273,7 +273,7 @@ mod MutMap {
     ///
     /// The function `f` must be pure.
     ///
-    pub def refineWithKey!(f: (k, v) -> Bool, m: MutMap[k, v, r]): Unit \ { Read(r), Write(r) } with Order[k] =
+    pub def refineWithKey!(f: (k, v) -> Bool, m: MutMap[k, v, r]): Unit \ r with Order[k] =
         let MutMap(_, mm) = m;
         mm := Map.filterWithKey(f, deref mm)
 
@@ -282,28 +282,28 @@ mod MutMap {
     ///
     /// Leaves the map unchanged if the mutable map `m` does not contain any mapping for `k`.
     ///
-    pub def remove!(k: k, m: MutMap[k, v, r]): Unit \ { Read(r), Write(r) } with Order[k] =
+    pub def remove!(k: k, m: MutMap[k, v, r]): Unit \ r with Order[k] =
         let MutMap(_, mm) = m;
         mm := Map.remove(k, deref mm)
 
     ///
     /// Applies the function `f` to every value in the mutable map `m`.
     ///
-    pub def transform!(f: v -> v \ ef, m: MutMap[k, v, r]): Unit \ { ef, Read(r), Write(r) } with Order[k] =
+    pub def transform!(f: v -> v \ ef, m: MutMap[k, v, r]): Unit \ { ef, r } with Order[k] =
         let MutMap(_, mm) = m;
         mm := Map.map(f, deref mm)
 
     ///
     /// Applies the function `f` to every value in the mutable map `m`.
     ///
-    pub def transformWithKey!(f: (k, v) -> v \ ef, m: MutMap[k, v, r]): Unit \ { ef, Read(r), Write(r) } with Order[k] =
+    pub def transformWithKey!(f: (k, v) -> v \ ef, m: MutMap[k, v, r]): Unit \ { ef, r } with Order[k] =
         let MutMap(_, mm) = m;
         mm := Map.mapWithKey(f, deref mm)
 
     ///
     /// Returns `true` if and only if all mappings in the mutable map `m1` occur in the mutable map `m2`.
     ///
-    pub def isSubmapOf(m1: MutMap[k, v, r1], m2: MutMap[k, v, r2]): Bool \ { Read(r1, r2) } with Order[k], Eq[v] =
+    pub def isSubmapOf(m1: MutMap[k, v, r1], m2: MutMap[k, v, r2]): Bool \ { r1, r2 } with Order[k], Eq[v] =
         let MutMap(_, mm1) = m1;
         let MutMap(_, mm2) = m2;
         Map.isSubmapOf(deref mm1, deref mm2)
@@ -311,7 +311,7 @@ mod MutMap {
     ///
     /// Returns `true` if and only if all mappings in the mutable map `m1` occur in the mutable map `m2` and `m1 != m2`.
     ///
-    pub def isProperSubmapOf(m1: MutMap[k, v, r1], m2: MutMap[k, v, r2]): Bool \ { Read(r1, r2) } with Order[k], Eq[v] =
+    pub def isProperSubmapOf(m1: MutMap[k, v, r1], m2: MutMap[k, v, r2]): Bool \ { r1, r2 } with Order[k], Eq[v] =
         let MutMap(_, mm1) = m1;
         let MutMap(_, mm2) = m2;
         Map.isProperSubmapOf(deref mm1, deref mm2)
@@ -321,7 +321,7 @@ mod MutMap {
     ///
     /// The function `f` must be pure.
     ///
-    pub def find(f: (k, v) -> Bool, m: MutMap[k, v, r]): Option[(k, v)] \ Read(r) =
+    pub def find(f: (k, v) -> Bool, m: MutMap[k, v, r]): Option[(k, v)] \ r =
         findLeft(f, m)
 
     ///
@@ -329,7 +329,7 @@ mod MutMap {
     ///
     /// The function `f` must be pure.
     ///
-    pub def findLeft(f: (k, v) -> Bool, m: MutMap[k, v, r]): Option[(k, v)] \ Read(r) =
+    pub def findLeft(f: (k, v) -> Bool, m: MutMap[k, v, r]): Option[(k, v)] \ r =
         let MutMap(_, mm) = m;
         Map.findLeft(f, deref mm)
 
@@ -338,7 +338,7 @@ mod MutMap {
     ///
     /// The function `f` must be pure.
     ///
-    pub def findRight(f: (k, v) -> Bool, m: MutMap[k, v, r]): Option[(k, v)] \ Read(r) =
+    pub def findRight(f: (k, v) -> Bool, m: MutMap[k, v, r]): Option[(k, v)] \ r =
         let MutMap(_, mm) = m;
         Map.findRight(f, deref mm)
 
@@ -347,7 +347,7 @@ mod MutMap {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
-    pub def map(r1: Region[r1], f: v1 -> v2 \ ef, m: MutMap[k, v1, r]): MutMap[k, v2, r1] \ { ef, Read(r), Write(r1) } =
+    pub def map(r1: Region[r1], f: v1 -> v2 \ ef, m: MutMap[k, v1, r]): MutMap[k, v2, r1] \ { ef, r, r1 } =
         mapWithKey(r1, _ -> f, m)
 
     ///
@@ -355,14 +355,14 @@ mod MutMap {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
-    pub def mapWithKey(rc: Region[r1], f: (k, v1) -> v2 \ ef, m: MutMap[k, v1, r]): MutMap[k, v2, r1] \ { ef, Read(r), Write(r1) } =
+    pub def mapWithKey(rc: Region[r1], f: (k, v1) -> v2 \ ef, m: MutMap[k, v1, r]): MutMap[k, v2, r1] \ { ef, r, r1 } =
         let MutMap(_, mm) = m;
         MutMap(rc, ref Map.mapWithKey(f, deref mm) @ rc)
 
     ///
     /// Alias for `foldLeftWithKey`.
     ///
-    pub def foldWithKey(f: (b, k, v) -> b \ ef, i: b, m: MutMap[k, v, r]): b \ { ef, Read(r) }  =
+    pub def foldWithKey(f: (b, k, v) -> b \ ef, i: b, m: MutMap[k, v, r]): b \ { ef, r }  =
         foldLeftWithKey(f, i, m)
 
     ///
@@ -370,7 +370,7 @@ mod MutMap {
     ///
     /// That is, the result is of the form: `f(...f(f(i, v1), v2)..., vn)`.
     ///
-    pub def foldLeft(f: (b, v) -> b \ ef, i: b, m: MutMap[k, v, r]): b \ { ef, Read(r) } =
+    pub def foldLeft(f: (b, v) -> b \ ef, i: b, m: MutMap[k, v, r]): b \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.foldLeft(f, i, deref mm)
 
@@ -379,7 +379,7 @@ mod MutMap {
     ///
     /// That is, the result is of the form: `f(...f(k2, f(k1, i, v1), v2)..., vn)`.
     ///
-    pub def foldLeftWithKey(f: (b, k, v) -> b \ ef, i: b, m: MutMap[k, v, r]): b \ { ef, Read(r) } =
+    pub def foldLeftWithKey(f: (b, k, v) -> b \ ef, i: b, m: MutMap[k, v, r]): b \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.foldLeftWithKey(f, i, deref mm)
 
@@ -388,7 +388,7 @@ mod MutMap {
     ///
     /// That is, the result is of the form: `f(v1, ...f(vn-1, f(vn, s)))`.
     ///
-    pub def foldRight(f: (v, b) -> b \ ef, s: b, m: MutMap[k, v, r]): b \ { ef, Read(r) } =
+    pub def foldRight(f: (v, b) -> b \ ef, s: b, m: MutMap[k, v, r]): b \ { ef, r } =
         foldRightWithKey((_, v, b) -> f(v, b), s, m)
 
     ///
@@ -396,7 +396,7 @@ mod MutMap {
     ///
     /// That is, the result is of the form: `f(k1, v1, ...f(kn-1, vn-1, f(kn, vn, s)))`.
     ///
-    pub def foldRightWithKey(f: (k, v, b) -> b \ ef, s: b, m: MutMap[k, v, r]): b \ { ef, Read(r) } =
+    pub def foldRightWithKey(f: (k, v, b) -> b \ ef, s: b, m: MutMap[k, v, r]): b \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.foldRightWithKey(f, s, deref mm)
 
@@ -406,7 +406,7 @@ mod MutMap {
     /// That is, the result is of the form: `f(v1, ...f(vn-1, f(vn, z)))`.
     /// A `foldRightWithCont` allows early termination by not calling the continuation.
     ///
-    pub def foldRightWithCont(f: (v, Unit -> b \ ef) -> b \ ef, z: b, m: MutMap[k, v, r]): b \ { ef, Read(r) } =
+    pub def foldRightWithCont(f: (v, Unit -> b \ ef) -> b \ ef, z: b, m: MutMap[k, v, r]): b \ { ef, r } =
         foldRightWithKeyCont((_, v, b) -> f(v, b), z, m)
 
     ///
@@ -415,7 +415,7 @@ mod MutMap {
     /// That is, the result is of the form: `f(k1, v1, ...f(kn-1, vn-1, f(kn, vn, z)))`.
     /// A `foldRightWithKeyCont` allows early termination by not calling the continuation.
     ///
-    pub def foldRightWithKeyCont(f: (k, v, Unit -> b \ ef) -> b \ ef, z: b, m: MutMap[k, v, r]): b \ { ef, Read(r) } =
+    pub def foldRightWithKeyCont(f: (k, v, Unit -> b \ ef) -> b \ ef, z: b, m: MutMap[k, v, r]): b \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.foldRightWithKeyCont(f, z, deref mm)
 
@@ -426,7 +426,7 @@ mod MutMap {
     ///
     /// Returns `None` if `m` is the empty map.
     ///
-    pub def reduceLeft(f: (v, v) -> v \ ef, m: MutMap[k, v, r]): Option[v] \ { ef, Read(r) } =
+    pub def reduceLeft(f: (v, v) -> v \ ef, m: MutMap[k, v, r]): Option[v] \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.reduceLeft(f, deref mm)
 
@@ -437,7 +437,7 @@ mod MutMap {
     ///
     /// Returns `None` if `m` is the empty map.
     ///
-    pub def reduceLeftWithKey(f: (k, v, k, v) -> (k, v) \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, Read(r) } =
+    pub def reduceLeftWithKey(f: (k, v, k, v) -> (k, v) \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.reduceLeftWithKey(f, deref mm)
 
@@ -448,7 +448,7 @@ mod MutMap {
     ///
     /// Returns `None` if `m` is the empty map.
     ///
-    pub def reduceRight(f: (v, v) -> v \ ef, m: MutMap[k, v, r]): Option[v] \ { ef, Read(r) } =
+    pub def reduceRight(f: (v, v) -> v \ ef, m: MutMap[k, v, r]): Option[v] \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.reduceRight(f, deref mm)
 
@@ -459,7 +459,7 @@ mod MutMap {
     ///
     /// Returns `None` if `m` is the empty map.
     ///
-    pub def reduceRightWithKey(f: (k, v, k, v) -> (k, v) \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, Read(r) } =
+    pub def reduceRightWithKey(f: (k, v, k, v) -> (k, v) \ ef, m: MutMap[k, v, r]): Option[(k, v)] \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.reduceRightWithKey(f, deref mm)
 
@@ -468,21 +468,21 @@ mod MutMap {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
-    pub def count(f: (k, v) -> Bool \ ef, m: MutMap[k, v, r]): Int32 \ { ef, Read(r) } =
+    pub def count(f: (k, v) -> Bool \ ef, m: MutMap[k, v, r]): Int32 \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.count(f, deref mm)
 
     ///
     /// Returns the sum of all keys in the map `m`.
     ///
-    pub def sumKeys(m: MutMap[Int32, v, r]): Int32 \ Read(r) =
+    pub def sumKeys(m: MutMap[Int32, v, r]): Int32 \ r =
         let MutMap(_, mm) = m;
         Map.sumKeys(deref mm)
 
     ///
     /// Returns the sum of all values in the map `m`.
     ///
-    pub def sumValues(m: MutMap[k, Int32, r]): Int32 \ Read(r) =
+    pub def sumValues(m: MutMap[k, Int32, r]): Int32 \ r =
         let MutMap(_, mm) = m;
         Map.sumValues(deref mm)
 
@@ -491,7 +491,7 @@ mod MutMap {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
-    pub def sumWith(f: (k, v) -> Int32 \ ef, m: MutMap[k, v, r]): Int32 \ { ef, Read(r) } =
+    pub def sumWith(f: (k, v) -> Int32 \ ef, m: MutMap[k, v, r]): Int32 \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.sumWith(f, deref mm)
 
@@ -500,7 +500,7 @@ mod MutMap {
     ///
     /// Returns `false` if `m` is the empty map.
     ///
-    pub def exists(f: (k, v) -> Bool \ ef, m: MutMap[k, v, r]): Bool \ { ef, Read(r) } =
+    pub def exists(f: (k, v) -> Bool \ ef, m: MutMap[k, v, r]): Bool \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.exists(f, deref mm)
 
@@ -509,49 +509,49 @@ mod MutMap {
     ///
     /// Returns `true` if `m` is the empty map.
     ///
-    pub def forAll(f: (k, v) -> Bool \ ef, m: MutMap[k, v, r]): Bool \ { ef, Read(r) } =
+    pub def forAll(f: (k, v) -> Bool \ ef, m: MutMap[k, v, r]): Bool \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.forAll(f, deref mm)
 
     ///
     /// Returns a shallow copy of the mutable map `m`.
     ///
-    pub def copy(rc: Region[r1], m: MutMap[k, v, r]): MutMap[k, v, r1] \ { Read(r), Write(r1) } =
+    pub def copy(rc: Region[r1], m: MutMap[k, v, r]): MutMap[k, v, r1] \ { r, r1 } =
         let MutMap(_, mm) = m;
         MutMap(rc, ref (deref mm) @ rc)
 
     ///
     /// Returns the mutable map `m` as an immutable map.
     ///
-    pub def toMap(m: MutMap[k, v, r]): Map[k, v] \ Read(r) =
+    pub def toMap(m: MutMap[k, v, r]): Map[k, v] \ r =
         let MutMap(_, mm) = m;
         deref mm
 
     ///
     /// Returns `m` as a MutDeque.
     ///
-    pub def toMutDeque(r1: Region[r1], m: MutMap[k, v, r2]): MutDeque[(k, v), r1] \ { Read(r2), Write(r1) } =
+    pub def toMutDeque(r1: Region[r1], m: MutMap[k, v, r2]): MutDeque[(k, v), r1] \ { r2, r1 } =
         let MutMap(_, mm) = m;
         Map.toMutDeque(r1, deref mm)
 
     ///
     /// Returns the mutable map `m` as a list of key-value pairs.
     ///
-    pub def toList(m: MutMap[k, v, r]): List[(k, v)] \ Read(r) =
+    pub def toList(m: MutMap[k, v, r]): List[(k, v)] \ r =
         let MutMap(_, mm) = m;
         Map.toList(deref mm)
 
     ///
     /// Returns the mutable map `m` as a set of key-value pairs.
     ///
-    pub def toSet(m: MutMap[k, v, r]): Set[(k, v)] \ Read(r) with Order[k], Order[v] =
+    pub def toSet(m: MutMap[k, v, r]): Set[(k, v)] \ r with Order[k], Order[v] =
         let MutMap(_, mm) = m;
         Map.toSet(deref mm)
 
     ///
     /// Applies `f` to all the `(key, value)` pairs in the mutable map `m`.
     ///
-    pub def forEach(f: (k, v) -> Unit \ ef, m: MutMap[k, v, r]): Unit \ { ef, Read(r) } =
+    pub def forEach(f: (k, v) -> Unit \ ef, m: MutMap[k, v, r]): Unit \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.forEach(f, deref mm)
 
@@ -559,7 +559,7 @@ mod MutMap {
     /// Apply the effectful function `f` to all the `(key, value)` pairs in the mutable map `m`
     /// along with that element's index.
     ///
-    pub def forEachWithIndex(f: (Int32, k, v) -> Unit \ ef, m: MutMap[k, v, r]): Unit \ { ef, Read(r) } = region rc {
+    pub def forEachWithIndex(f: (Int32, k, v) -> Unit \ ef, m: MutMap[k, v, r]): Unit \ { ef, r } = region rc {
         let ix = ref 0 @ rc;
         forEach((k, v) -> {let i = deref ix; f(i, k, v); ix := i+1}, m)
     }
@@ -567,21 +567,21 @@ mod MutMap {
     ///
     /// Returns an iterator over all key-value pairs in `m`.
     ///
-    pub def iterator(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[(k, v), r1 and r2, r1] \ { Write(r1), Read(r2) } =
+    pub def iterator(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[(k, v), r1 and r2, r1] \ { r1, r2 } =
         let MutMap(_, mm) = m;
         Map.iterator(rc, deref mm) |> Iterator.map(x -> {discard deref mm; x})
 
     ///
     /// Returns an iterator over keys in `m`.
     ///
-    pub def iteratorKeys(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[k, r1 and r2, r1] \ { Write(r1), Read(r2) } =
+    pub def iteratorKeys(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[k, r1 and r2, r1] \ { r1, r2 } =
         let MutMap(_, mm) = m;
         Map.iteratorKeys(rc, deref mm) |> Iterator.map(x -> {discard deref mm; x})
 
     ///
     /// Returns an iterator over values in `m`.
     ///
-    pub def iteratorValues(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[v, r1 and r2, r1] \ { Write(r1), Read(r2) } =
+    pub def iteratorValues(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[v, r1 and r2, r1] \ { r1, r2 } =
         let MutMap(_, mm) = m;
         Map.iteratorValues(rc, deref mm) |> Iterator.map(x -> {discard deref mm; x})
 
@@ -590,28 +590,28 @@ mod MutMap {
     ///
     /// That is, the result is a list of all pairs `(k, v)` where `p(k)` returns `Equal`.
     ///
-    pub def query(p: k -> Comparison \ ef, m: MutMap[k, v, r]): List[(k, v)] \ { ef, Read(r) } =
+    pub def query(p: k -> Comparison \ ef, m: MutMap[k, v, r]): List[(k, v)] \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.query(p, deref mm)
 
     ///
     /// Applies `f` to all key-value pairs `(k, v)` in the mutable map `m` where `p(k)` returns `EqualTo`.
     ///
-    pub def queryWith(p: k -> Comparison \ ef1, f: (k, v) -> Unit \ ef2, m: MutMap[k, v, r]): Unit \ { ef1, ef2, Read(r) } =
+    pub def queryWith(p: k -> Comparison \ ef1, f: (k, v) -> Unit \ ef2, m: MutMap[k, v, r]): Unit \ { ef1, ef2, r } =
         let MutMap(_, mm) = m;
         Map.queryWith(p, f, deref mm)
 
     ///
     /// Returns `true` if MutMaps `a` and `b` have the same elements, i.e. are structurally equal.
     ///
-    pub def sameElements(a: MutMap[k, v, r1], b: MutMap[k, v, r2]): Bool \ Read(r1, r2) with Order[k], Eq[v] =
+    pub def sameElements(a: MutMap[k, v, r1], b: MutMap[k, v, r2]): Bool \ { r1, r2 } with Order[k], Eq[v] =
         (MutMap.isSubmapOf(a, b) and MutMap.isSubmapOf(b, a))
 
     ///
     /// Returns the concatenation of the string representation of each key `k`
     /// in `m` with `sep` inserted between each element.
     ///
-    pub def joinKeys(sep: String, m: MutMap[k, v, r]): String \ Read(r) with ToString[k] =
+    pub def joinKeys(sep: String, m: MutMap[k, v, r]): String \ r with ToString[k] =
         let MutMap(_, mm) = m;
         Map.joinKeys(sep, deref mm)
 
@@ -619,7 +619,7 @@ mod MutMap {
     /// Returns the concatenation of the string representation of each value `v`
     /// in `m` with `sep` inserted between each element.
     ///
-    pub def joinValues(sep: String, m: MutMap[k, v, r]): String \ Read(r) with ToString[v] =
+    pub def joinValues(sep: String, m: MutMap[k, v, r]): String \ r with ToString[v] =
         let MutMap(_, mm) = m;
         Map.joinValues(sep, deref mm)
 
@@ -627,7 +627,7 @@ mod MutMap {
     /// Returns the concatenation of the string representation of each key-value pair
     /// `k => v` in `m` according to `f` with `sep` inserted between each element.
     ///
-    pub def joinWith(f: (k, v) -> String \ ef, sep: String, m: MutMap[k, v, r]): String \ { ef, Read(r) } =
+    pub def joinWith(f: (k, v) -> String \ ef, sep: String, m: MutMap[k, v, r]): String \ { ef, r } =
         let MutMap(_, mm) = m;
         Map.joinWith(f, sep, deref mm)
 

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -26,7 +26,7 @@ mod MutSet {
     ///
     /// Returns a string representation of the given mutable set `s`.
     ///
-    pub def toString(s: MutSet[a, r]): String \Read(r) with ToString[a] = region rc {
+    pub def toString(s: MutSet[a, r]): String \r with ToString[a] = region rc {
         let sb = StringBuilder.new(rc);
         StringBuilder.appendString!("MutSet#{", sb);
         forEachWithIndex((i, x) -> {
@@ -42,46 +42,46 @@ mod MutSet {
     ///
     /// Returns a fresh empty set.
     ///
-    pub def new(rc: Region[r]): MutSet[a, r] \ { Write(r) } =
+    pub def new(rc: Region[r]): MutSet[a, r] \ r =
         MutSet(rc, ref Set.empty() @ rc)
 
     ///
     /// Returns the singleton set containing `x`.
     ///
-    pub def singleton(rc: Region[r], x: a): MutSet[a, r] \ Write(r) with Order[a] =
+    pub def singleton(rc: Region[r], x: a): MutSet[a, r] \ r with Order[a] =
         MutSet(rc, ref Set.singleton(x) @ rc)
 
     ///
     /// Adds the element `x` to the mutable set `s`.
     ///
-    pub def add!(x: a, s: MutSet[a, r]): Unit \ { Read(r), Write(r) } with Order[a] =
+    pub def add!(x: a, s: MutSet[a, r]): Unit \ r with Order[a] =
         let MutSet(_, ms) = s;
         ms := Set.insert(x, deref ms)
 
     ///
     /// Adds all elements in the collection `m` to the mutable set `s`.
     ///
-    pub def addAll!(m: m[a], s: MutSet[a, r]): Unit \ { Read(r), Write(r) } with Order[a], Foldable[m] =
+    pub def addAll!(m: m[a], s: MutSet[a, r]): Unit \ r with Order[a], Foldable[m] =
         Foldable.forEach(x -> add!(x, s), m)
 
     ///
     /// Removes all elements from the mutable set `s`.
     ///
-    pub def clear!(s: MutSet[a, r]): Unit \ { Write(r) } =
+    pub def clear!(s: MutSet[a, r]): Unit \ r =
         let MutSet(_, ms) = s;
         ms := Set.empty()
 
     ///
     /// Removes the element `x` from the mutable set `s`.
     ///
-    pub def remove!(x: a, s: MutSet[a, r]): Unit \ { Read(r), Write(r) } with Order[a] =
+    pub def remove!(x: a, s: MutSet[a, r]): Unit \ r with Order[a] =
         let MutSet(_, ms) = s;
         ms := Set.remove(x, deref ms)
 
     ///
     /// Removes all elements in the collection `m` from the mutable set `s`.
     ///
-    pub def removeAll!(m: m[a], s: MutSet[a, r]): Unit \ { Read(r), Write(r) } with Order[a], Foldable[m] =
+    pub def removeAll!(m: m[a], s: MutSet[a, r]): Unit \ r with Order[a], Foldable[m] =
         let MutSet(_, ms) = s;
         let s2 = Foldable.toSet(m);
         ms := Set.difference(deref ms, s2)
@@ -89,7 +89,7 @@ mod MutSet {
     ///
     /// Removes all elements from the mutable set `s` that are not in collection `m`.
     ///
-    pub def retainAll!(m: m[a], s: MutSet[a, r]): Unit \ { Read(r), Write(r) } with Order[a], Foldable[m] =
+    pub def retainAll!(m: m[a], s: MutSet[a, r]): Unit \ r with Order[a], Foldable[m] =
         let MutSet(_, ms) = s;
         let s2 = Foldable.toSet(m);
         ms := Set.intersection(s2, deref ms)
@@ -99,7 +99,7 @@ mod MutSet {
     ///
     /// The function `f` must be pure.
     ///
-    pub def refine!(f: a -> Bool, s: MutSet[a, r]): Unit \ { Read(r), Write(r) } with Order[a] =
+    pub def refine!(f: a -> Bool, s: MutSet[a, r]): Unit \ r with Order[a] =
         let MutSet(_, ms) = s;
         ms := Set.filter(f, deref ms)
 
@@ -108,28 +108,28 @@ mod MutSet {
     ///
     /// The mutable set `s` is unchanged if the element `from` is not in it.
     ///
-    pub def replace!(from: {from = a}, to: {to = a}, s: MutSet[a, r]): Unit \ { Read(r), Write(r) } with Order[a] =
+    pub def replace!(from: {from = a}, to: {to = a}, s: MutSet[a, r]): Unit \ r with Order[a] =
         let MutSet(_, ms) = s;
         ms := Set.replace(from = from.from, to = to.to, deref ms)
 
     ///
     /// Applies the function `f` to every element in the mutable set `s`.
     ///
-    pub def transform!(f: a -> a \ ef, s: MutSet[a, r]): Unit \ { ef, Read(r), Write(r) } with Order[a] =
+    pub def transform!(f: a -> a \ ef, s: MutSet[a, r]): Unit \ { ef, r } with Order[a] =
         let MutSet(_, ms) = s;
         ms := Set.map(f, deref ms)
 
     ///
     /// Returns true if and only if `s` is the empty set.
     ///
-    pub def isEmpty(s: MutSet[a, r]): Bool \ { Read(r) } =
+    pub def isEmpty(s: MutSet[a, r]): Bool \ r =
         let MutSet(_, ms) = s;
         Set.isEmpty(deref ms)
 
     ///
     /// Returns true if and only if `x` is a member of the mutable set `s`.
     ///
-    pub def memberOf(x: a, s: MutSet[a, r]): Bool \ { Read(r) } with Order[a] =
+    pub def memberOf(x: a, s: MutSet[a, r]): Bool \ r with Order[a] =
         let MutSet(_, ms) = s;
         Set.memberOf(x, deref ms)
 
@@ -138,7 +138,7 @@ mod MutSet {
     ///
     /// Returns `None` if `s` is empty.
     ///
-    pub def minimum(s: MutSet[a, r]): Option[a] \ { Read(r) } =
+    pub def minimum(s: MutSet[a, r]): Option[a] \ r =
         let MutSet(_, ms) = s;
         Set.minimum(deref ms)
 
@@ -149,7 +149,7 @@ mod MutSet {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
-    pub def minimumBy(cmp: (a, a) -> Comparison \ ef, s: MutSet[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def minimumBy(cmp: (a, a) -> Comparison \ ef, s: MutSet[a, r]): Option[a] \ { ef, r } =
         let MutSet(_, ms) = s;
         Set.minimumBy(cmp, deref ms)
 
@@ -158,7 +158,7 @@ mod MutSet {
     ///
     /// Returns `None` if `s` is empty.
     ///
-    pub def maximum(s: MutSet[a, r]): Option[a] \ { Read(r) } =
+    pub def maximum(s: MutSet[a, r]): Option[a] \ r =
         let MutSet(_, ms) = s;
         Set.maximum(deref ms)
 
@@ -169,21 +169,21 @@ mod MutSet {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
-    pub def maximumBy(cmp: (a, a) -> Comparison \ ef, s: MutSet[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def maximumBy(cmp: (a, a) -> Comparison \ ef, s: MutSet[a, r]): Option[a] \ { ef, r } =
         let MutSet(_, ms) = s;
         Set.maximumBy(cmp, deref ms)
 
     ///
     /// Returns the size of the mutable set `s`.
     ///
-    pub def size(s: MutSet[a, r]): Int32 \ { Read(r) } =
+    pub def size(s: MutSet[a, r]): Int32 \ r =
         let MutSet(_, ms) = s;
         Set.size(deref ms)
 
     ///
     /// Returns true if and only if every element in the mutable set `s1` appears in the mutable set `s2`.
     ///
-    pub def isSubsetOf(s1: MutSet[a, r1], s2: MutSet[a, r2]): Bool \ { Read(r1, r2) } with Order[a] =
+    pub def isSubsetOf(s1: MutSet[a, r1], s2: MutSet[a, r2]): Bool \ { r1, r2 } with Order[a] =
         let MutSet(_, ms1) = s1;
         let MutSet(_, ms2) = s2;
         Set.isSubsetOf(deref ms1, deref ms2)
@@ -191,7 +191,7 @@ mod MutSet {
     ///
     /// Returns true if and only if every element in the mutable set `s1` appears in the mutable set `s2` and `s1 != s2`.
     ///
-    pub def isProperSubsetOf(s1: MutSet[a, r1], s2: MutSet[a, r2]): Bool \ { Read(r1, r2) } with Order[a] =
+    pub def isProperSubsetOf(s1: MutSet[a, r1], s2: MutSet[a, r2]): Bool \ { r1, r2 } with Order[a] =
         let MutSet(_, ms1) = s1;
         let MutSet(_, ms2) = s2;
         Set.isProperSubsetOf(deref ms1, deref ms2)
@@ -201,7 +201,7 @@ mod MutSet {
     ///
     /// The function `f` must be pure.
     ///
-    pub def find(f: a -> Bool, s: MutSet[a, r]): Option[a] \ { Read(r) } =
+    pub def find(f: a -> Bool, s: MutSet[a, r]): Option[a] \ r =
         findLeft(f, s)
 
     ///
@@ -209,7 +209,7 @@ mod MutSet {
     ///
     /// The function `f` must be pure.
     ///
-    pub def findLeft(f: a -> Bool, s: MutSet[a, r]): Option[a] \ { Read(r) } =
+    pub def findLeft(f: a -> Bool, s: MutSet[a, r]): Option[a] \ r =
         let MutSet(_, ms) = s;
         Set.findLeft(f, deref ms)
 
@@ -218,7 +218,7 @@ mod MutSet {
     ///
     /// The function `f` must be pure.
     ///
-    pub def findRight(f: a -> Bool, s: MutSet[a, r]): Option[a] \ { Read(r) } =
+    pub def findRight(f: a -> Bool, s: MutSet[a, r]): Option[a] \ r =
         let MutSet(_, ms) = s;
         Set.findRight(f, deref ms)
 
@@ -227,7 +227,7 @@ mod MutSet {
     ///
     /// That is, the result is of the form: `f(...f(f(i, x1), x2)..., xn)`.
     ///
-    pub def foldLeft(f: (b, a) -> b \ ef, i: b, s: MutSet[a, r]): b \ { ef, Read(r) } =
+    pub def foldLeft(f: (b, a) -> b \ ef, i: b, s: MutSet[a, r]): b \ { ef, r } =
         let MutSet(_, ms) = s;
         Set.foldLeft(f, i, deref ms)
 
@@ -236,7 +236,7 @@ mod MutSet {
     ///
     /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, z))...)`.
     ///
-    pub def foldRight(f: (a, b) -> b \ ef, z: b, s: MutSet[a, r]): b \ { ef, Read(r) } =
+    pub def foldRight(f: (a, b) -> b \ ef, z: b, s: MutSet[a, r]): b \ { ef, r } =
         let MutSet(_, ms) = s;
         Set.foldRight(f, z, deref ms)
 
@@ -246,14 +246,14 @@ mod MutSet {
     /// That is, the result is of the form: `f(x1, ...f(xn-1, f(xn, z))...)`.
     /// A `foldRightWithCont` allows early termination by not calling the continuation.
     ///
-    pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, z: b, s: MutSet[a, r]): b \ { ef, Read(r) } =
+    pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, z: b, s: MutSet[a, r]): b \ { ef, r } =
         let MutSet(_, ms) = s;
         Set.foldRightWithCont(f, z, deref ms)
 
     ///
     /// Returns the result of mapping each element and combining the results.
     ///
-    pub def foldMap(f: a -> b \ ef, s: MutSet[a, r]): b \ {ef, Read(r)} with Monoid[b] =
+    pub def foldMap(f: a -> b \ ef, s: MutSet[a, r]): b \ {ef, r} with Monoid[b] =
         foldLeft((acc, x) -> Monoid.combine(acc, f(x)), Monoid.empty(), s)
 
     ///
@@ -263,7 +263,7 @@ mod MutSet {
     ///
     /// Returns `None` if `s` is the empty set.
     ///
-    pub def reduceLeft(f: (a, a) -> a \ ef, s: MutSet[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def reduceLeft(f: (a, a) -> a \ ef, s: MutSet[a, r]): Option[a] \ { ef, r } =
         let MutSet(_, ms) = s;
         Set.reduceLeft(f, deref ms)
 
@@ -274,7 +274,7 @@ mod MutSet {
     ///
     /// Returns `None` if `s` is the empty set.
     ///
-    pub def reduceRight(f: (a, a) -> a \ ef, s: MutSet[a, r]): Option[a] \ { ef, Read(r) } =
+    pub def reduceRight(f: (a, a) -> a \ ef, s: MutSet[a, r]): Option[a] \ { ef, r } =
         let MutSet(_, ms) = s;
         Set.reduceRight(f, deref ms)
 
@@ -283,14 +283,14 @@ mod MutSet {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
-    pub def count(f: a -> Bool \ ef, s: MutSet[a, r]): Int32 \ { ef, Read(r) } =
+    pub def count(f: a -> Bool \ ef, s: MutSet[a, r]): Int32 \ { ef, r } =
         let MutSet(_, ms) = s;
         Set.count(f, deref ms)
 
     ///
     /// Returns the sum of all elements in the mutable set `s`.
     ///
-    pub def sum(s: MutSet[Int32, r]): Int32 \ { Read(r) } =
+    pub def sum(s: MutSet[Int32, r]): Int32 \ r =
         let MutSet(_, ms) = s;
         Set.sum(deref ms)
 
@@ -299,7 +299,7 @@ mod MutSet {
     ///
     /// Purity reflective: Runs in parallel when given a pure function `f`.
     ///
-    pub def sumWith(f: a -> Int32 \ ef, s: MutSet[a, r]): Int32 \ { ef, Read(r) } =
+    pub def sumWith(f: a -> Int32 \ ef, s: MutSet[a, r]): Int32 \ { ef, r } =
         let MutSet(_, ms) = s;
         Set.sumWith(f, deref ms)
 
@@ -308,7 +308,7 @@ mod MutSet {
     ///
     /// Returns `false` if `s` is the empty set.
     ///
-    pub def exists(f: a -> Bool \ ef, s: MutSet[a, r]): Bool \ { ef, Read(r) } =
+    pub def exists(f: a -> Bool \ ef, s: MutSet[a, r]): Bool \ { ef, r } =
         let MutSet(_, ms) = s;
         Set.exists(f, deref ms)
 
@@ -317,14 +317,14 @@ mod MutSet {
     ///
     /// Returns `true` if `s` is the empty set.
     ///
-    pub def forAll(f: a -> Bool \ ef, s: MutSet[a, r]): Bool \ { ef, Read(r) } =
+    pub def forAll(f: a -> Bool \ ef, s: MutSet[a, r]): Bool \ { ef, r } =
         let MutSet(_, ms) = s;
         Set.forAll(f, deref ms)
 
     ///
     /// Returns a shallow copy of the mutable set `s`.
     ///
-    pub def copy(r1: Region[r1], s: MutSet[a, r]): MutSet[a, r1] \ { Read(r), Write(r1) } =
+    pub def copy(r1: Region[r1], s: MutSet[a, r]): MutSet[a, r1] \ { r, r1 } =
         let MutSet(_, ms) = s;
         MutSet(r1, ref (deref ms) @ r1)
 
@@ -336,7 +336,7 @@ mod MutSet {
     ///
     /// The function `f` must be pure.
     ///
-    pub def partition(r1: Region[r1], r2: Region[r2], f: a -> Bool, s: MutSet[a, r]): (MutSet[a, r1], MutSet[a, r2]) \ { Read(r), Write(r1), Write(r2) } with Order[a] =
+    pub def partition(r1: Region[r1], r2: Region[r2], f: a -> Bool, s: MutSet[a, r]): (MutSet[a, r1], MutSet[a, r2]) \ { r, r1, r2 } with Order[a] =
         let MutSet(_, ms) = s;
         let (ys, zs) = Set.partition(f, deref ms);
         (MutSet(r1, ref ys @ r1), MutSet(r2, ref zs @ r2))
@@ -344,14 +344,14 @@ mod MutSet {
     ///
     /// Returns the mutable set `s` as an immutable set.
     ///
-    pub def toSet(s: MutSet[a, r]): Set[a] \ { Read(r) } =
+    pub def toSet(s: MutSet[a, r]): Set[a] \ r =
         let MutSet(_, ms) = s;
         deref ms
 
     ///
     /// Returns the mutable set `s` as a list.
     ///
-    pub def toList(s: MutSet[a, r]): List[a] \ { Read(r) } =
+    pub def toList(s: MutSet[a, r]): List[a] \ r =
         let MutSet(_, ms) = s;
         Set.toList(deref ms)
 
@@ -361,28 +361,28 @@ mod MutSet {
     /// If `s` contains multiple mappings with the same key, `toMap` does not
     /// make any guarantees about which mapping will be in the resulting map.
     ///
-    pub def toMap(s: MutSet[(a, b), r]): Map[a, b] \ { Read(r) } with Order[a] =
+    pub def toMap(s: MutSet[(a, b), r]): Map[a, b] \ r with Order[a] =
         let MutSet(_, ms) = s;
         Set.toMap(deref ms)
 
     ///
     /// Returns the mutable set `s` as a MutDeque.
     ///
-    pub def toMutDeque(r1: Region[r1], s: MutSet[a, r2]): MutDeque[a, r1] \ { Read(r2), Write(r1) } =
+    pub def toMutDeque(r1: Region[r1], s: MutSet[a, r2]): MutDeque[a, r1] \ { r2, r1 } =
         let MutSet(_, ms) = s;
         Set.toMutDeque(r1, deref ms)
 
     ///
     /// Applies `f` to every element of the mutable set `s`.
     ///
-    pub def forEach(f: a -> Unit \ ef, s: MutSet[a, r]): Unit \ { ef, Read(r) } =
+    pub def forEach(f: a -> Unit \ ef, s: MutSet[a, r]): Unit \ { ef, r } =
         let MutSet(_, ms) = s;
         Set.forEach(f, deref ms)
 
     ///
     /// Applies `f` to every element of the mutable set `s` along with that element's index.
     ///
-    pub def forEachWithIndex(f: (Int32, a) -> Unit \ ef, s: MutSet[a, r]): Unit \ { ef, Read(r) } = region rc {
+    pub def forEachWithIndex(f: (Int32, a) -> Unit \ ef, s: MutSet[a, r]): Unit \ { ef, r } = region rc {
         let ix = ref 0 @ rc;
         forEach(x -> {let i = deref ix; f(i, x); ix := i+1}, s)
     }
@@ -390,27 +390,27 @@ mod MutSet {
     ///
     /// Returns an iterator over `s`.
     ///
-    pub def iterator(rc: Region[r1], s: MutSet[a, r2]): Iterator[a, r1 and r2, r1] \ { Write(r1), Read(r2) } =
+    pub def iterator(rc: Region[r1], s: MutSet[a, r2]): Iterator[a, r1 and r2, r1] \ { r1, r2 } =
         let MutSet(_, ms) = s;
         Set.iterator(rc, deref ms) |> Iterator.map(x -> {discard deref ms; x})
 
     ///
     /// Returns an enumerator over `s`.
     ///
-    pub def enumerator(rc: Region[r1], s: MutSet[a, r2]): Iterator[(Int32, a), r1 and r2, r1] \ { Write(r1), Read(r2) } =
+    pub def enumerator(rc: Region[r1], s: MutSet[a, r2]): Iterator[(Int32, a), r1 and r2, r1] \ { r1, r2 } =
         iterator(rc, s) |> Iterator.zipWithIndex
 
     ///
     /// Returns `true` if MutSets `a` and `b` have the same elements, i.e. are structurally equal.
     ///
-    pub def sameElements(a: MutSet[a, r], b: MutSet[a, r]): Bool \ { Read(r) } with Order[a] =
+    pub def sameElements(a: MutSet[a, r], b: MutSet[a, r]): Bool \ r with Order[a] =
         MutSet.isSubsetOf(a, b) and MutSet.isSubsetOf(b, a)
 
     ///
     /// Returns the concatenation of the string representation
     /// of each element in `s` with `sep` inserted between each element.
     ///
-    pub def join(sep: String, s: MutSet[a, r]): String \ { Read(r) } with ToString[a] =
+    pub def join(sep: String, s: MutSet[a, r]): String \ r with ToString[a] =
         let MutSet(_, ms) = s;
         Set.join(sep, deref ms)
 
@@ -418,7 +418,7 @@ mod MutSet {
     /// Returns the concatenation of the string representation
     /// of each element in `s` according to `f` with `sep` inserted between each element.
     ///
-    pub def joinWith(f: a -> String \ ef, sep: String, s: MutSet[a, r]): String \ { ef, Read(r) } =
+    pub def joinWith(f: a -> String \ ef, sep: String, s: MutSet[a, r]): String \ { ef, r } =
         let MutSet(_, ms) = s;
         Set.joinWith(f, sep, deref ms)
 

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -116,7 +116,7 @@ instance Reducible[Nec] {
     override pub def memberOf(a: a, l: Nec[a]): Bool with Eq[a] = Nec.memberOf(a, l)
     override pub def dropWhile(f: a -> Bool \ ef, l: Nec[a]): List[a] \ ef = Nec.dropWhileLeft(f, l)
     override pub def takeWhile(f: a -> Bool \ ef, l: Nec[a]): List[a] \ ef = Nec.takeWhileLeft(f, l)
-    override pub def toArray(r: Region[r], l: Nec[a]): Array[a, r] \ Write(r) = Nec.toArray(r, l)
+    override pub def toArray(r: Region[r], l: Nec[a]): Array[a, r] \ r = Nec.toArray(r, l)
     override pub def toList(l: Nec[a]): List[a] = Nec.toList(l)
 }
 
@@ -136,7 +136,7 @@ instance ToString[Nec[a]] with ToString[a] {
 }
 
 instance Iterable[Nec] {
-    pub def iterator(r: Region[r], l: Nec[a]): Iterator[a, r, r] \ Write(r) = Nec.iterator(r, l)
+    pub def iterator(r: Region[r], l: Nec[a]): Iterator[a, r, r] \ r = Nec.iterator(r, l)
 }
 
 mod Nec {
@@ -745,7 +745,7 @@ mod Nec {
     ///
     /// Returns `c` as a MutDeque.
     ///
-    pub def toMutDeque(r: Region[r], c: Nec[a]): MutDeque[a, r] \ Write(r)  =
+    pub def toMutDeque(r: Region[r], c: Nec[a]): MutDeque[a, r] \ r  =
         let d = MutDeque.new(r);
         forEach(x -> MutDeque.pushBack(x, d), c);
         d
@@ -753,7 +753,7 @@ mod Nec {
     ///
     /// Returns `c` as a mutable list.
     ///
-    pub def toMutList(r: Region[r], c: Nec[a]): MutList[a, r] \ Write(r) = region rc2 {
+    pub def toMutList(r: Region[r], c: Nec[a]): MutList[a, r] \ r = region rc2 {
         Array.toMutList(r, toArray(rc2, c)) // `Array.toMutList` respects the invariant of `MutList`
     }
 
@@ -782,7 +782,7 @@ mod Nec {
     ///
     /// Returns the Nec `c` as an array.
     ///
-    pub def toArray(r: Region[r], c: Nec[a]): Array[a, r] \ Write(r) =
+    pub def toArray(r: Region[r], c: Nec[a]): Array[a, r] \ r =
         let x = head(c);
         let arr = Array.repeat(r, length(c), x);
         forEach(match (i, b) -> Array.put(b, i, arr), zipWithIndex(c));
@@ -791,13 +791,13 @@ mod Nec {
     ///
     /// Returns an iterator over `c`.
     ///
-    pub def iterator(rc: Region[r], c: Nec[a]): Iterator[a, r, r] \ Write(r) =
+    pub def iterator(rc: Region[r], c: Nec[a]): Iterator[a, r, r] \ r =
         iteratorHelper(rc, Some(viewLeft(c)))
 
     ///
     /// Returns an iterator over `l`.
     ///
-    def iteratorHelper(rc: Region[r], vl: Option[ViewLeft[a]]): Iterator[a, r, r] \ Write(r) =
+    def iteratorHelper(rc: Region[r], vl: Option[ViewLeft[a]]): Iterator[a, r, r] \ r =
         let cursor = ref vl @ rc;
         let next = () -> match (deref cursor) {
             case None             => None
@@ -815,13 +815,13 @@ mod Nec {
     ///
     /// Returns an iterator over `c` zipped with the indices of the elements.
     ///
-    pub def enumerator(rc: Region[r], c: Nec[a]): Iterator[(Int32, a), r, r] \ Write(r) =
+    pub def enumerator(rc: Region[r], c: Nec[a]): Iterator[(Int32, a), r, r] \ r =
         iterator(rc, c) |> Iterator.zipWithIndex
 
     ///
     /// Helper for the `sort` functions.
     ///
-    def fromArray(arr: Array[a, r]): Option[Nec[a]] \ Read(r) =
+    def fromArray(arr: Array[a, r]): Option[Nec[a]] \ r =
         def loop(ix, end, acc) = if (ix >= end) acc else {let x = Array.get(ix, arr); loop(ix+1, end, snoc(acc, x))};
         let len = Array.length(arr);
         if (len < 1)

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -102,7 +102,7 @@ instance Reducible[Nel] {
     override pub def memberOf(a: a, l: Nel[a]): Bool with Eq[a] = Nel.memberOf(a, l)
     override pub def dropWhile(f: a -> Bool \ ef, l: Nel[a]): List[a] \ ef = Nel.dropWhile(f, l)
     override pub def takeWhile(f: a -> Bool \ ef, l: Nel[a]): List[a] \ ef = Nel.takeWhile(f, l)
-    override pub def toArray(rc: Region[r], l: Nel[a]): Array[a, r] \ Write(r) = Nel.toArray(rc, l)
+    override pub def toArray(rc: Region[r], l: Nel[a]): Array[a, r] \ r = Nel.toArray(rc, l)
     override pub def toList(l: Nel[a]): List[a] = Nel.toList(l)
 }
 
@@ -111,7 +111,7 @@ instance SemiGroup[Nel[a]] {
 }
 
 instance Iterable[Nel] {
-    pub def iterator(rc: Region[r], l: Nel[a]): Iterator[a, r, r] \ Write(r) = Nel.iterator(rc, l)
+    pub def iterator(rc: Region[r], l: Nel[a]): Iterator[a, r, r] \ r = Nel.iterator(rc, l)
 }
 
 mod Nel {
@@ -545,13 +545,13 @@ mod Nel {
     ///
     /// Returns `l` as an array.
     ///
-    pub def toArray(r: Region[r], l: Nel[a]): Array[a, r] \ Write(r) =
+    pub def toArray(r: Region[r], l: Nel[a]): Array[a, r] \ r =
         l |> toList |> List.toArray(r)
 
     ///
     /// Returns `l` as a MutDeque.
     ///
-    pub def toMutDeque(r: Region[r], l: Nel[a]): MutDeque[a, r] \ Write(r) =
+    pub def toMutDeque(r: Region[r], l: Nel[a]): MutDeque[a, r] \ r =
         let d = MutDeque.new(r);
         forEach(x -> MutDeque.pushBack(x, d), l);
         d
@@ -614,14 +614,14 @@ mod Nel {
     ///
     /// Returns an iterator over `l`.
     ///
-    pub def iterator(rc: Region[r], l: Nel[a]): Iterator[a, r, r] \ Write(r) =
+    pub def iterator(rc: Region[r], l: Nel[a]): Iterator[a, r, r] \ r =
        let Nel(x, xs) = l;
        List.iterator(rc, x :: xs)
 
     ///
     /// Returns an iterator over `l` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], l: Nel[a]): Iterator[(Int32, a), r, r] \ Write(r) =
+    pub def enumerator(r: Region[r], l: Nel[a]): Iterator[(Int32, a), r, r] \ r =
         iterator(r, l) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -150,7 +150,7 @@ instance Monoid[Option[a]] with Monoid[a] {
 instance CommutativeMonoid[Option[a]] with CommutativeMonoid[a]
 
 instance Iterable[Option] {
-    pub def iterator(rc: Region[r], o: Option[a]): Iterator[a, r, r] \ Write(r) = Option.iterator(rc, o)
+    pub def iterator(rc: Region[r], o: Option[a]): Iterator[a, r, r] \ r = Option.iterator(rc, o)
 }
 
 mod Option {
@@ -560,7 +560,7 @@ mod Option {
     ///
     /// Returns an iterator over `o` with 1 element or an empty iterator if `o` is `None`.
     ///
-    pub def iterator(rc: Region[r], o: Option[a]): Iterator[a, r, r] \ Write(r) = match o {
+    pub def iterator(rc: Region[r], o: Option[a]): Iterator[a, r, r] \ r = match o {
         case None    => Iterator.empty(rc)
         case Some(x) => Iterator.singleton(rc, x)
     }
@@ -568,7 +568,7 @@ mod Option {
     ///
     /// Returns an iterator over `o` zipped with the indices of the elements.
     ///
-    pub def enumerator(rc: Region[r], o: Option[a]): Iterator[(Int32, a), r, r] \ Write(r) =
+    pub def enumerator(rc: Region[r], o: Option[a]): Iterator[(Int32, a), r, r] \ r =
         iterator(rc, o) |> Iterator.zipWithIndex
 
 }

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -87,7 +87,7 @@ instance Filterable[RedBlackTree[k]] with Order[k] {
 instance Witherable[RedBlackTree[k]] with Order[k]
 
 instance Iterable[RedBlackTree[k]] {
-    pub def iterator(rc: Region[r], t: RedBlackTree[k, v]): Iterator[v, r, r] \ Write(r) =
+    pub def iterator(rc: Region[r], t: RedBlackTree[k, v]): Iterator[v, r, r] \ r =
             RedBlackTree.iterator(rc, t) |> Iterator.map(snd)
 }
 
@@ -799,7 +799,7 @@ mod RedBlackTree {
     ///
     /// Returns the tree `t` as a MutDeque. Elements are ordered from smallest (left) to largest (right).
     ///
-    pub def toMutDeque(r: Region[r], t: RedBlackTree[k, v]): MutDeque[(k, v), r] \ Write(r) =
+    pub def toMutDeque(r: Region[r], t: RedBlackTree[k, v]): MutDeque[(k, v), r] \ r =
         let d = MutDeque.new(r);
         forEach((k, v) -> let x = (k, v); MutDeque.pushBack(x, d), t);
         d
@@ -963,7 +963,7 @@ mod RedBlackTree {
     ///
     /// Returns an iterator over `t`.
     ///
-    pub def iterator(rc: Region[r], t: RedBlackTree[k, v]): Iterator[(k, v), r, r] \ Write(r) =
+    pub def iterator(rc: Region[r], t: RedBlackTree[k, v]): Iterator[(k, v), r, r] \ r =
         let stack1 = leftmost(t, Nil);
         let state = ref stack1 @ rc;
         let next = () -> match (deref state) {

--- a/main/src/library/Reducible.flix
+++ b/main/src/library/Reducible.flix
@@ -246,7 +246,7 @@ pub class Reducible[t: Type -> Type] {
     ///
     /// Returns `t` as an array.
     ///
-    pub def toArray(rc: Region[r], t: t[a]): Array[a, r] \ Write(r) =
+    pub def toArray(rc: Region[r], t: t[a]): Array[a, r] \ r =
         let v = MutList.new(rc);
         Reducible.foldLeft((_, a) -> MutList.push!(a, v), (), t);
         MutList.toArray(rc, v)

--- a/main/src/library/Ref.flix
+++ b/main/src/library/Ref.flix
@@ -19,19 +19,19 @@ mod Ref {
     ///
     /// Returns a new reference to `x` in the region `rh`.
     ///
-    pub def new(rh: Region[r], x: a): Ref[a, r] \ Write(r) =
+    pub def new(rh: Region[r], x: a): Ref[a, r] \ r =
         ref x @ rh
 
     ///
     /// Returns the element referenced by `rf`.
     ///
-    pub def get(rf: Ref[a, r]): a \ Read(r) =
+    pub def get(rf: Ref[a, r]): a \ r =
         deref rf
 
     ///
     /// Updates `rf` to reference `x`.
     ///
-    pub def put(x: a, rf: Ref[a, r]): Unit \ Write(r) =
+    pub def put(x: a, rf: Ref[a, r]): Unit \ r =
         rf := x
 
     ///
@@ -39,7 +39,7 @@ mod Ref {
     ///
     /// I.e. if `rf` references `x` then `rf` is updated to reference `f(x)`.
     ///
-    pub def transform(f: a -> a \ ef, rf: Ref[a, r]): Unit \ { Read(r), Write(r), ef } =
+    pub def transform(f: a -> a \ ef, rf: Ref[a, r]): Unit \ { r, ef } =
         rf := f(Ref.get(rf))
 
 }

--- a/main/src/library/Regex.flix
+++ b/main/src/library/Regex.flix
@@ -195,7 +195,7 @@ mod Regex {
     /// Splits the string `s` around matches of the Regex `regex`.
     ///
     pub def split(regex: {regex = Regex}, s: String): List[String] = region rc {
-        import java.util.regex.Pattern.split(##java.lang.CharSequence): Array[String, rc] \ Write(rc);
+        import java.util.regex.Pattern.split(##java.lang.CharSequence): Array[String, rc] \ rc;
         let _ = rc; // This avoids a redundancy error.
         Array.toList(split(regex.regex, checked_cast(s)))
     }
@@ -543,7 +543,7 @@ mod Regex {
     ///
     /// Create a Matcher for Regex `rgx` on the source String `input`.
     ///
-    def newMatcher(_: Region[r], rgx: Regex, s: String): Matcher[r] \ Write(r) =
+    def newMatcher(_: Region[r], rgx: Regex, s: String): Matcher[r] \ r =
         import java.util.regex.Pattern.matcher(##java.lang.CharSequence): ##java.util.regex.Matcher \ r;
         Matcher(matcher(rgx, checked_cast(s)))
 
@@ -552,7 +552,7 @@ mod Regex {
     ///
     /// Returns `Ok(matcher)` if the bounds are valid for the input String `s` otherwise returns `Err(_)`.
     ///
-    def newMatcherWithBounds(rc: Region[r], rgx: Regex, start: {start = Int32}, end: {end = Int32}, s: String): Result[String, Matcher[r]] \ Write(r) =
+    def newMatcherWithBounds(rc: Region[r], rgx: Regex, start: {start = Int32}, end: {end = Int32}, s: String): Result[String, Matcher[r]] \ r =
         let m = newMatcher(rc, rgx, s);
         match setBounds!(start, end, m) {
             case Ok()     => Ok(m)
@@ -565,7 +565,7 @@ mod Regex {
     ///
     /// The internal state of the matcher is updated.
     ///
-    def find!(m: Matcher[r]): Bool \ Write(r) =
+    def find!(m: Matcher[r]): Bool \ r =
         import java.util.regex.Matcher.find(): Bool \ r;
         let Matcher(m1) = m;
         find(m1)
@@ -577,7 +577,7 @@ mod Regex {
     ///
     /// The internal state of the matcher is updated.
     ///
-    def findFrom!(pos: Int32, m: Matcher[r]): Bool \ Write(r) =
+    def findFrom!(pos: Int32, m: Matcher[r]): Bool \ r =
         Result.tryCatch(_ -> {
             import java.util.regex.Matcher.find(Int32): Bool \ r;
             let Matcher(m1) = m;
@@ -596,7 +596,7 @@ mod Regex {
     /// Note - there are no primitive Java functions for right-to-left scanning provided
     /// by Java's JDK so the performance of `findLast!` is disadvantaged compared to `find!`.
     ///
-    def findLast!(m: Matcher[r]): Bool \ Write(r) =
+    def findLast!(m: Matcher[r]): Bool \ r =
         def loop(lastPos) = {
             match find!(m) {
                 case true  => {let pos1 = matcherStart(m); loop(pos1)}
@@ -617,7 +617,7 @@ mod Regex {
     ///
     /// Set the bounds of the matcher's region.
     ///
-    def setBounds!(start: {start = Int32}, end: {end = Int32}, m: Matcher[r]): Result[String, Unit] \ Write(r) =
+    def setBounds!(start: {start = Int32}, end: {end = Int32}, m: Matcher[r]): Result[String, Unit] \ r =
         Result.tryCatch(_ -> {
             import java.util.regex.Matcher.region(Int32, Int32): ##java.util.regex.Matcher \ r as region1;
             let Matcher(m1) = m;
@@ -628,7 +628,7 @@ mod Regex {
     ///
     /// Return the start position of the current match of Matcher `m`.
     ///
-    def matcherStart(m: Matcher[r]): Result[String, Int32] \ Read(r) =
+    def matcherStart(m: Matcher[r]): Result[String, Int32] \ r =
         Result.tryCatch(_ -> {
             import java.util.regex.Matcher.start(): Int32 \ r;
             let Matcher(m1) = m;
@@ -638,7 +638,7 @@ mod Regex {
     ///
     /// Return the end position of the current match of Matcher `m`.
     ///
-    def matcherEnd(m: Matcher[r]): Result[String, Int32] \ Read(r) =
+    def matcherEnd(m: Matcher[r]): Result[String, Int32] \ r =
         Result.tryCatch(_ -> {
             import java.util.regex.Matcher.end(): Int32 \ r;
             let Matcher(m1) = m;
@@ -648,7 +648,7 @@ mod Regex {
     ///
     /// Return the start and end positions of the matcher `m`.
     ///
-    def matcherRange(m: Matcher[r]): Result[String, {start = Int32, end = Int32}] \ Read(r) =
+    def matcherRange(m: Matcher[r]): Result[String, {start = Int32, end = Int32}] \ r =
         forM (s <- matcherStart(m);
               e <- matcherEnd(m))
         yield ({start = s, end = e})
@@ -657,7 +657,7 @@ mod Regex {
     ///
     /// Return the text content of the current match of matcher `m`.
     ///
-    def matcherContent(m: Matcher[r]): Result[String, String] \ Read(r) =
+    def matcherContent(m: Matcher[r]): Result[String, String] \ r =
         Result.tryCatch(_ -> {
             import java.util.regex.Matcher.group(): String \ r;
             let Matcher(m1) = m;
@@ -667,14 +667,14 @@ mod Regex {
     ///
     /// `MatchQuery` is a read query applied to a the current match of a `Matcher`.
     ///
-    pub type alias MatchQuery[a: Type, r: Region] = Matcher[r] -> Result[String, a] \ Read(r)
+    pub type alias MatchQuery[a: Type, r: Region] = Matcher[r] -> Result[String, a] \ r
 
     ///
     /// Returns the first result found by applying the query `asks` to `m` going from left to right.
     ///
     /// If the query `asks` or no match is found `Err(_)` is returned.
     ///
-    def firstSubmatch(asks: MatchQuery[a, r], m: Matcher[r]): Result[String, a] \ { Read(r), Write(r) } =
+    def firstSubmatch(asks: MatchQuery[a, r], m: Matcher[r]): Result[String, a] \ r =
         if (find!(m))
             asks(m)
         else
@@ -686,7 +686,7 @@ mod Regex {
     ///
     /// If the query `asks` or no match is found `Err(_)` is returned.
     ///
-    def lastSubmatch(asks: MatchQuery[a, r], m: Matcher[r]): Result[String, a] \ { Read(r), Write(r) } =
+    def lastSubmatch(asks: MatchQuery[a, r], m: Matcher[r]): Result[String, a] \ r =
         if (findLast!(m))
             asks(m)
         else
@@ -700,7 +700,7 @@ mod Regex {
     /// `f` is applied to the result of applying the query `asks` and the folds accumulating value.
     /// The initial accumulating value is `x`.
     ///
-    def foldSubmatches(f: (b, a) -> b \ ef, x: b, asks: MatchQuery[a, r], m: Matcher[r]): Result[String, b] \ { Read(r), Write(r), ef } =
+    def foldSubmatches(f: (b, a) -> b \ ef, x: b, asks: MatchQuery[a, r], m: Matcher[r]): Result[String, b] \ { r, ef } =
         def loop(acc) = {
             match find!(m) {
                 case true  => match asks(m) {

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -414,7 +414,7 @@ mod Result {
     ///
     /// Returns an iterator over `r` with 1 element or an empty iterator if `r` is `Err`.
     ///
-    pub def iterator(rc: Region[r], r: Result[e, t]): Iterator[t, r, r] \ Write(r) = match r {
+    pub def iterator(rc: Region[r], r: Result[e, t]): Iterator[t, r, r] \ r = match r {
         case Err(_) => Iterator.empty(rc)
         case Ok(x)  => Iterator.singleton(rc, x)
     }
@@ -422,7 +422,7 @@ mod Result {
     ///
     /// Returns an iterator over `r` zipped with the indices of the elements.
     ///
-    pub def enumerator(rc: Region[r], r: Result[e, t]): Iterator[(Int32, t), r, r] \ Write(r) =
+    pub def enumerator(rc: Region[r], r: Result[e, t]): Iterator[(Int32, t), r, r] \ r =
         iterator(rc, r) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -92,7 +92,7 @@ instance Collectable[Set] {
 }
 
 instance Iterable[Set] {
-    pub def iterator(rc: Region[r], s: Set[a]): Iterator[a, r, r] \ Write(r) = Set.iterator(rc, s)
+    pub def iterator(rc: Region[r], s: Set[a]): Iterator[a, r, r] \ r = Set.iterator(rc, s)
 }
 
 mod Set {
@@ -525,7 +525,7 @@ mod Set {
     ///
     /// Returns `s` as a MutDeque.
     ///
-    pub def toMutDeque(r: Region[r], s: Set[a]): MutDeque[a, r] \ Write(r) =
+    pub def toMutDeque(r: Region[r], s: Set[a]): MutDeque[a, r] \ r =
         let d = MutDeque.new(r);
         forEach(x -> MutDeque.pushBack(x, d), s);
         d
@@ -533,7 +533,7 @@ mod Set {
     ///
     /// Returns the set `s` as a `MutSet`.
     ///
-    pub def toMutSet(rc: Region[r], s: Set[a]): MutSet[a, r] \ Write(r) =
+    pub def toMutSet(rc: Region[r], s: Set[a]): MutSet[a, r] \ r =
         MutSet.MutSet(rc, ref s @ rc)
 
     ///
@@ -588,14 +588,14 @@ mod Set {
     ///
     /// Returns an iterator over `s`.
     ///
-    pub def iterator(rc: Region[r], s: Set[a]): Iterator[a, r, r] \ Write(r) =
+    pub def iterator(rc: Region[r], s: Set[a]): Iterator[a, r, r] \ r =
         let Set(t) = s;
         RedBlackTree.iterator(rc, t) |> Iterator.map(fst)
 
     ///
     /// Returns an iterator over `s` zipped with the indices of the elements.
     ///
-    pub def enumerator(r: Region[r], s: Set[a]): Iterator[(Int32, a), r, r] \ Write(r) =
+    pub def enumerator(r: Region[r], s: Set[a]): Iterator[(Int32, a), r, r] \ r =
         iterator(r, s) |> Iterator.zipWithIndex
 
     ///

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -64,7 +64,7 @@ mod String {
     /// Splits the string `s` around matches of the regular expression `regex`.
     ///
     pub def split(regex: {regex = String}, s: String): List[String] = region rc {
-        import java.lang.String.split(String): Array[String, rc] \ Write(rc);
+        import java.lang.String.split(String): Array[String, rc] \ rc;
         let _ = rc; // This avoids a redundancy error.
         Array.toList(split(s, regex.regex))
     }
@@ -107,7 +107,7 @@ mod String {
     ///
     /// Returns the given string `s` as an array of characters.
     ///
-    pub def toArray(r: Region[r], s: String): Array[Char, r] \ Write(r) =
+    pub def toArray(r: Region[r], s: String): Array[Char, r] \ r =
         Array.init(r, i -> charAt(i, s), length(s))
 
     ///
@@ -289,9 +289,9 @@ mod String {
     /// Helper function for `isSubmatch`.
     ///
     def isSubmatchHelper(pattern: String, s: String): Bool = region rc {
-        import static java.util.regex.Pattern.compile(String): ##java.util.regex.Pattern \ Write(rc);
-        import java.util.regex.Pattern.matcher(##java.lang.CharSequence): ##java.util.regex.Matcher \ Read(rc);
-        import java.util.regex.Matcher.find(Int32): Bool \ Write(rc);
+        import static java.util.regex.Pattern.compile(String): ##java.util.regex.Pattern \ rc;
+        import java.util.regex.Pattern.matcher(##java.lang.CharSequence): ##java.util.regex.Matcher \ rc;
+        import java.util.regex.Matcher.find(Int32): Bool \ rc;
         let _ = rc; // This avoids a redundancy error.
         try {
             let p1 = compile(pattern);
@@ -1092,7 +1092,7 @@ mod String {
     ///
     /// Helper function for `levenshteinDistance`.
     ///
-    def arraySwap(a: Array[Int32, r1], b : Array[Int32, r2]): Unit \ { Read(r2), Write(r1) } =
+    def arraySwap(a: Array[Int32, r1], b : Array[Int32, r2]): Unit \ { r2, r1 } =
         forIndex(0, Array.length(a) - 1, {i ->  Array.put(Array.get(i, b), i, a) })
 
     ///
@@ -1286,13 +1286,13 @@ mod String {
     ///
     /// Returns an iterator over `s`.
     ///
-    pub def iterator(rc: Region[r], s: String): Iterator[Char, r, r] \ Write(r) =
+    pub def iterator(rc: Region[r], s: String): Iterator[Char, r, r] \ r =
         Iterator.range(rc, 0, length(s)) |> Iterator.map(i -> charAt(i, s))
 
     ///
     /// Returns an iterator over `l` zipped with the indices of the elements.
     ///
-    pub def enumerator(rc: Region[r], s: String): Iterator[(Int32, Char), r, r] \ Write(r) =
+    pub def enumerator(rc: Region[r], s: String): Iterator[(Int32, Char), r, r] \ r =
         iterator(rc, s) |> Iterator.zipWithIndex
 
 }

--- a/main/src/library/StringBuilder.flix
+++ b/main/src/library/StringBuilder.flix
@@ -24,14 +24,14 @@ mod StringBuilder {
     ///
     /// Returns a new mutable StringBuilder.
     ///
-    pub def new(_: Region[r]): StringBuilder[r] \ Write(r) =
+    pub def new(_: Region[r]): StringBuilder[r] \ r =
         import new java.lang.StringBuilder(): ##java.lang.StringBuilder \ r as newStringBuilder;
         StringBuilder(newStringBuilder())
 
     ///
     /// Append `x` to the StringBuilder `sb`.
     ///
-    pub def append!(x: a, sb: StringBuilder[r]): Unit \ Write(r) with ToString[a] =
+    pub def append!(x: a, sb: StringBuilder[r]): Unit \ r with ToString[a] =
         let s = ToString.toString(x);
         s `appendString!` sb;
         ()
@@ -39,7 +39,7 @@ mod StringBuilder {
     ///
     /// Append the String `s` to the StringBuilder `sb`.
     ///
-    pub def appendString!(s: String, sb: StringBuilder[r]): Unit \ Write(r) =
+    pub def appendString!(s: String, sb: StringBuilder[r]): Unit \ r =
         import java.lang.StringBuilder.append(String): ##java.lang.StringBuilder \ r;
         let StringBuilder(msb) = sb;
         discard msb `append` s;
@@ -48,45 +48,45 @@ mod StringBuilder {
     ///
     /// Append the system line separator to the StringBuilder `sb`.
     ///
-    pub def appendLineSeparator!(sb: StringBuilder[r]): Unit \ Write(r) =
+    pub def appendLineSeparator!(sb: StringBuilder[r]): Unit \ r =
         String.lineSeparator() `appendString!` sb
 
     ///
     /// Append the String `s` followed by the system line separator to the StringBuilder `sb`.
     ///
-    pub def appendLine!(s: String, sb: StringBuilder[r]): Unit \ Write(r) =
+    pub def appendLine!(s: String, sb: StringBuilder[r]): Unit \ r =
         s `appendString!` sb;
         appendLineSeparator!(sb)
 
     ///
     /// Appends `f(x)` to the string builder `sb`.
     ///
-    pub def appendLineWith!(f: a -> String \ ef, x: a, sb: StringBuilder[r]): Unit \ { ef, Write(r) } =
+    pub def appendLineWith!(f: a -> String \ ef, x: a, sb: StringBuilder[r]): Unit \ { ef, r } =
         f(x) `appendString!` sb;
         appendLineSeparator!(sb)
 
     ///
     /// Appends each string in the array `a` to the string builder `sb`.
     ///
-    pub def appendLines!(a: Array[String, r1], sb: StringBuilder[r2]): Unit \ { Read(r1), Write(r2) } =
+    pub def appendLines!(a: Array[String, r1], sb: StringBuilder[r2]): Unit \ { r1, r2 } =
         Array.forEach(x -> appendLine!(x, sb), a)
 
     ///
     /// Appends `f(x)` for each x in the foldable collection `t` to the string builder `sb`.
     ///
-    pub def appendLinesWith(f: a -> String \ ef, t: t[a], sb: StringBuilder[r]): Unit \ { ef, Write(r) } with Foldable[t] =
+    pub def appendLinesWith(f: a -> String \ ef, t: t[a], sb: StringBuilder[r]): Unit \ { ef, r } with Foldable[t] =
         Foldable.forEach(x -> appendLineWith!(f, x, sb), t)
 
     ///
     /// Appends `f(x)` for each x in array `a` to the string builder `sb`.
     ///
-    pub def appendLinesWith!(f: a -> String \ ef, a: Array[a, r1], sb: StringBuilder[r2]): Unit \ { ef, Read(r1), Write(r2) } =
+    pub def appendLinesWith!(f: a -> String \ ef, a: Array[a, r1], sb: StringBuilder[r2]): Unit \ { ef, r1, r2 } =
         Array.forEach(x -> appendLineWith!(f, x, sb), a)
 
     ///
     /// Append the array of strings `a` separating each pair of string with `sep` to the StringBuilder `sb`.
     ///
-    pub def intercalate!(sep: String, a: Array[String, r1], sb: StringBuilder[r2]): Unit \ { Read(r1), Write(r2) } =
+    pub def intercalate!(sep: String, a: Array[String, r1], sb: StringBuilder[r2]): Unit \ { r1, r2 } =
         let append1! = (i, s) ->
             if (i > 0) {
                 appendString!(sep, sb);
@@ -99,21 +99,21 @@ mod StringBuilder {
     ///
     /// Returns an iterator over `sb`.
     ///
-    pub def iterator(rc: Region[r1], sb: StringBuilder[r2]): Iterator[Char, r1 and r2, r1] \ { Read(r2), Write(r1) } =
-        import java.lang.StringBuilder.charAt(Int32): Char \ Read(r2);
+    pub def iterator(rc: Region[r1], sb: StringBuilder[r2]): Iterator[Char, r1 and r2, r1] \ { r2, r1 } =
+        import java.lang.StringBuilder.charAt(Int32): Char \ r2;
         let StringBuilder(msb) = sb;
         Iterator.range(rc, 0, length(sb)) |> Iterator.map(i -> charAt(msb, i))
 
     ///
     /// Returns an iterator over `l` zipped with the indices of the elements.
     ///
-    pub def enumerator(r1: Region[r1], sb: StringBuilder[r2]): Iterator[(Int32, Char), r1 and r2, r1] \ { Read(r2), Write(r1) } =
+    pub def enumerator(r1: Region[r1], sb: StringBuilder[r2]): Iterator[(Int32, Char), r1 and r2, r1] \ { r2, r1 } =
         iterator(r1, sb) |> Iterator.zipWithIndex
 
     ///
     /// Return the length of the StringBuilder `sb`.
     ///
-    pub def length(sb: StringBuilder[r]): Int32 \ Read(r) =
+    pub def length(sb: StringBuilder[r]): Int32 \ r =
         import java.lang.StringBuilder.length(): Int32 \ r;
         let StringBuilder(msb) = sb;
         length(msb)
@@ -121,7 +121,7 @@ mod StringBuilder {
     ///
     /// Convert the StringBuilder `sb` to a string.
     ///
-    pub def toString(sb: StringBuilder[r]): String \ Read(r) =
+    pub def toString(sb: StringBuilder[r]): String \ r =
         import java.lang.StringBuilder.toString(): String \ r;
         let StringBuilder(msb) = sb;
         toString(msb)

--- a/main/src/library/System.flix
+++ b/main/src/library/System.flix
@@ -30,7 +30,7 @@ mod System {
         ///
         /// See also `Console.readLine` for reading from the console.
         ///
-        pub def readLines(r: Region[r]): Iterator[String, false, r] \ { Read(r), Write(r), IO } =
+        pub def readLines(r: Region[r]): Iterator[String, false, r] \ { r, IO } =
             import static get java.lang.System.in: ##java.io.InputStream \ IO as getSystemIn;
             import new java.io.InputStreamReader(##java.io.InputStream): ##java.io.InputStreamReader \ IO as newInputStream;
             import new java.io.BufferedReader(##java.io.Reader): ##java.io.BufferedReader \ IO as newBufferedReader;

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -98,7 +98,7 @@ instance Collectable[Vector] {
 }
 
 instance Iterable[Vector] {
-    pub def iterator(rc: Region[r], v: Vector[a]): Iterator[a, r, r] \ Write(r) = Vector.iterator(rc, v)
+    pub def iterator(rc: Region[r], v: Vector[a]): Iterator[a, r, r] \ r = Vector.iterator(rc, v)
 }
 
 mod Vector {
@@ -148,7 +148,7 @@ mod Vector {
     /// Version of `Array.updateSequence!` where sub is a vector rather than an array,
     /// so a extra copy of `sub` is avoided.
     ///
-    def arrayUpdateSeqV!(i: Int32, sub: Vector[a], arr: Array[a, r]): Unit \ Write(r)  =
+    def arrayUpdateSeqV!(i: Int32, sub: Vector[a], arr: Array[a, r]): Unit \ r  =
         let end = Array.length(arr);
         let subLen = length(sub);
         def loop(ri, wi) = {
@@ -213,7 +213,7 @@ mod Vector {
     ///
     /// Returns the vector `v` as an array.
     ///
-    pub def toArray(rc: Region[r], v: Vector[a]): Array[a, r] \ Write(r) =
+    pub def toArray(rc: Region[r], v: Vector[a]): Array[a, r] \ r =
         let arr = Array.new(rc, length(v));
         forEachWithIndex((i, x) -> Array.put(x, i, arr), v);
         arr
@@ -264,7 +264,7 @@ mod Vector {
     ///
     /// Returns `v` as a MutDeque.
     ///
-    pub def toMutDeque(rc: Region[r], v: Vector[a]): MutDeque[a, r] \ Write(r)   =
+    pub def toMutDeque(rc: Region[r], v: Vector[a]): MutDeque[a, r] \ r   =
         let d = MutDeque.new(rc);
         forEach(x -> MutDeque.pushBack(x, d), v);
         d
@@ -522,7 +522,7 @@ mod Vector {
     ///
     /// Helper for `sequence`, `traverse` and `zipWithA`.
     ///
-    def putA!(mx: m[a], i: Int32, marr: m[Array[a, r]]): m[Array[a, r]] \ Write(r) with Applicative[m] =
+    def putA!(mx: m[a], i: Int32, marr: m[Array[a, r]]): m[Array[a, r]] \ r with Applicative[m] =
         use Functor.{<$>};
         use Applicative.{<*>};
         (((x, arr) -> {Array.put(x, i, arr); arr}) <$> mx) <*> marr
@@ -1271,7 +1271,7 @@ mod Vector {
     ///
     /// Returns the array `a` as a MutList.
     ///
-    pub def toMutList(rc: Region[r], v: Vector[a]): MutList[a, r] \ Write(r) =
+    pub def toMutList(rc: Region[r], v: Vector[a]): MutList[a, r] \ r =
         toArray(rc, v) |> Array.toMutList(rc)
 
     ///
@@ -1363,7 +1363,7 @@ mod Vector {
     ///
     /// Returns an iterator over `v`
     ///
-    pub def iterator(rc: Region[r], v: Vector[a]): Iterator[a, r, r] \ { Write(r) } =
+    pub def iterator(rc: Region[r], v: Vector[a]): Iterator[a, r, r] \ r =
         Iterator.range(rc, 0, length(v)) |> Iterator.map(i -> get(i, v))
 
     ///
@@ -1371,7 +1371,7 @@ mod Vector {
     ///
     /// Modifying `a` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def enumerator(rc: Region[r], v: Vector[a]): Iterator[(Int32, a), r, r] \ { Write(r) } =
+    pub def enumerator(rc: Region[r], v: Vector[a]): Iterator[(Int32, a), r, r] \ r =
         iterator(rc, v) |> Iterator.zipWithIndex
 
 


### PR DESCRIPTION
Fixes #5886