### PR TITLE
chore: fix typos ` -> " in comments

### DIFF
--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -1025,10 +1025,10 @@ mod String {
     ///
     /// Abbreviate the string `s` if it exceeds the width `w`.
     ///
-    /// If the length of `s` exceeds `w` and `w >= 3" then `s` is truncated and the first
+    /// If the length of `s` exceeds `w` and `w >= 3` then `s` is truncated and the first
     /// three characters are replaced with ellipses.
     ///
-    /// If the length of `s` exceeds `w` and `w < 3" then the empty string is returned.
+    /// If the length of `s` exceeds `w` and `w < 3` then the empty string is returned.
     ///
     pub def abbreviateLeft(w: Int32, s: String): String =
         match length(s) {
@@ -1043,10 +1043,10 @@ mod String {
     ///
     /// Abbreviate the string `s` if it exceeds the width `w`.
     ///
-    /// If the length of `s` exceeds `w` and `w >= 3" then `s` is truncated and the last
+    /// If the length of `s` exceeds `w` and `w >= 3` then `s` is truncated and the last
     /// three characters are replaced with ellipses.
     ///
-    /// If the length of `s` exceeds `w` and `w < 3" then the empty string is returned.
+    /// If the length of `s` exceeds `w` and `w < 3` then the empty string is returned.
     ///
     pub def abbreviateRight(w: Int32, s: String): String =
         match length(s) {


### PR DESCRIPTION
There are a few typos in the comments of `String.flix` where `"`s are used instead of `` ` ``.