### PR TITLE
fix: Lowered priority and removed dot snippet when choosing the `ModCompletion`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -220,8 +220,8 @@ sealed trait Completion {
       val name = modSym.toString
       CompletionItem(
         label = name,
-        sortText = Priority.normal(name),
-        textEdit = TextEdit(context.range, s"$name."),
+        sortText = Priority.low(name),
+        textEdit = TextEdit(context.range, name),
         kind = CompletionItemKind.Module)
   }
 }


### PR DESCRIPTION
<img width="253" alt="image" src="https://github.com/flix/flix/assets/74200345/becaff6c-2ad2-4a67-8ac3-a569c76e2074">
