### PR TITLE
refactor: use 1 label in `BoolOp.And` and `BoolOp.Or` byte code

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -208,16 +208,12 @@ object GenExpression {
         val List(exp1, exp2) = exps
         sop match {
           case BoolOp.And =>
-            val andFalseBranch = new Label()
             val andEnd = new Label()
             compileExpression(exp1, visitor, currentClass, lenv0, entryPoint)
-            visitor.visitJumpInsn(IFEQ, andFalseBranch)
+            visitor.visitInsn(DUP)
+            visitor.visitJumpInsn(IFEQ, andEnd)
+            visitor.visitInsn(POP)
             compileExpression(exp2, visitor, currentClass, lenv0, entryPoint)
-            visitor.visitJumpInsn(IFEQ, andFalseBranch)
-            visitor.visitInsn(ICONST_1)
-            visitor.visitJumpInsn(GOTO, andEnd)
-            visitor.visitLabel(andFalseBranch)
-            visitor.visitInsn(ICONST_0)
             visitor.visitLabel(andEnd)
 
           case BoolOp.Or =>


### PR DESCRIPTION
Also, hopefully, makes `and` & `or` faster :rocket: :crossed_fingers: 

Closes https://github.com/flix/flix/issues/5853