### PR TITLE
Added void types to Prelude.flix

### DIFF
--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -4,6 +4,11 @@
 pub type alias Static = false
 
 ///
+/// The empty type.
+///
+pub enum Void
+
+///
 /// An enum that holds type information where a witness is not available.
 ///
 pub enum Proxy[_] {


### PR DESCRIPTION
added above 'Proxy':

///
/// The empty type.
///
pub enum Void