### PR TITLE
refactor: destruct simplified def type

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
@@ -30,7 +30,7 @@ object SimplifiedAst {
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
-  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, fparams: List[SimplifiedAst.FormalParam], exp: SimplifiedAst.Expression, tpe: Type, loc: SourceLocation)
+  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, fparams: List[SimplifiedAst.FormalParam], exp: SimplifiedAst.Expression, tpe: Type, purity: Type, loc: SourceLocation)
 
   case class Enum(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, cases: Map[Symbol.CaseSym, SimplifiedAst.Case], tpeDeprecated: Type, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
@@ -34,13 +34,13 @@ object SimplifiedAstPrinter {
         DocAst.Enum(ann, mod, sym, cases)
     }.toList
     val defs = root.defs.values.map {
-      case SimplifiedAst.Def(ann, mod, sym, formals, exp, tpe, _) =>
+      case SimplifiedAst.Def(ann, mod, sym, formals, exp, tpe, _, _) =>
         DocAst.Def(
           ann,
           mod,
           sym,
           formals.map(printFormalParam),
-          TypePrinter.print(tpe),
+          DocAst.Type.Arrow(Nil, TypePrinter.print(tpe)),
           print(exp)
         )
     }.toList

--- a/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.{Ast, LiftedAst, Purity, SimplifiedAst, Symbol, Type}
+import ca.uwaterloo.flix.language.ast.{Ast, LiftedAst, SimplifiedAst, Symbol, Type}
 import ca.uwaterloo.flix.util.InternalCompilerException
 
 import scala.collection.mutable

--- a/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.{Ast, LiftedAst, SimplifiedAst, Symbol}
+import ca.uwaterloo.flix.language.ast.{Ast, LiftedAst, Purity, SimplifiedAst, Symbol, Type}
 import ca.uwaterloo.flix.util.InternalCompilerException
 
 import scala.collection.mutable
@@ -56,9 +56,10 @@ object LambdaLift {
     * Performs lambda lifting on the given definition `def0`.
     */
   private def liftDef(def0: SimplifiedAst.Def, m: TopLevel)(implicit flix: Flix): LiftedAst.Def = def0 match {
-    case SimplifiedAst.Def(ann, mod, sym, fparams, exp, tpe, loc) =>
+    case SimplifiedAst.Def(ann, mod, sym, fparams, exp, tpe0, pur, loc) =>
       val fs = fparams.map(visitFormalParam)
-      val e = liftExp(def0.exp, sym, m)
+      val e = liftExp(exp, sym, m)
+      val tpe = Type.mkUncurriedArrowWithEffect(fs.map(_.tpe), pur, tpe0, tpe0.loc.asSynthetic)
 
       LiftedAst.Def(ann, mod, sym, fs, e, tpe, loc)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -40,10 +40,14 @@ object Simplifier {
     /**
       * Translates the given definition `def0` to the SimplifiedAst.
       */
-    def visitDef(def0: LoweredAst.Def): SimplifiedAst.Def = {
-      val fs = def0.spec.fparams.map(visitFormalParam)
-      val exp = visitExp(def0.impl.exp)
-      SimplifiedAst.Def(def0.spec.ann, def0.spec.mod, def0.sym, fs, exp, def0.impl.inferredScheme.base, def0.sym.loc)
+    def visitDef(defn: LoweredAst.Def): SimplifiedAst.Def = defn match {
+      case LoweredAst.Def(sym, spec, impl) =>
+        val fs = spec.fparams.map(visitFormalParam)
+        val exp = visitExp(impl.exp)
+        val funType = impl.inferredScheme.base
+        val retType = funType.arrowResultType
+        val pur = funType.arrowPurityType
+        SimplifiedAst.Def(spec.ann, spec.mod, sym, fs, exp, retType, pur, sym.loc)
     }
 
     /**


### PR DESCRIPTION
After loweredAst, defs store their full type, i.e. `def f(x: Int32): Int32 \ Impure` stores the type `Int32 -> Int32 \ Impure`. This means that code that needs either purity or the return type needs to unsafely destruct the expected arrow type. 

This PR extracts the return type and the purity of the def, since the parameter types are already known form the formal parameters. 

I've asserted that, for all tests, this new implied type (reconstructing it from the formal parameters and the new fields) and the old type is identical. 

The purity should be `Purity` instead of `Type` but monomorph doesn't actually guarantee that at the moment