### PR TITLE
feat: create separate unification path for Bool kind

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1503,6 +1503,14 @@ object ParsedAst {
     case class False(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Type
 
     /**
+      * The Impure type constructor.
+      *
+      * @param sp1 the position of the first character in the type.
+      * @param sp2 the position of the last character in the type.
+      */
+    case class Impure(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Type
+
+    /**
       * A type representing an effect set.
       */
     case class EffectSet(sp1: SourcePosition, tpes: Seq[ParsedAst.Type], sp2: SourcePosition) extends ParsedAst.Type

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1503,6 +1503,14 @@ object ParsedAst {
     case class False(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Type
 
     /**
+      * The Pure type constructor.
+      *
+      * @param sp1 the position of the first character in the type.
+      * @param sp2 the position of the last character in the type.
+      */
+    case class Pure(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.Type
+
+    /**
       * The Impure type constructor.
       *
       * @param sp1 the position of the first character in the type.

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -882,19 +882,19 @@ object Type {
   }
 
   /**
-    * Returns the type `Or(tpe1, Or(tpe2, ...))`.
-    */
-  def mkOr(tpes: List[Type], loc: SourceLocation): Type = tpes match {
-    case Nil => Type.False
-    case x :: xs => mkOr(x, mkOr(xs, loc), loc)
-  }
-
-  /**
     * Returns the type `And(tpe1, And(tpe2, ...))`.
     */
   def mkAnd(tpes: List[Type], loc: SourceLocation): Type = tpes match {
     case Nil => Type.True
     case x :: xs => mkAnd(x, mkAnd(xs, loc), loc)
+  }
+
+  /**
+    * Returns the type `Or(tpe1, Or(tpe2, ...))`.
+    */
+  def mkOr(tpes: List[Type], loc: SourceLocation): Type = tpes match {
+    case Nil => Type.False
+    case x :: xs => mkOr(x, mkOr(xs, loc), loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -807,8 +807,6 @@ object Type {
 
   /**
     * Returns the type `Union(tpe1, tpe2)`.
-    *
-    * Must not be used before kinding.
     */
   def mkUnion(tpe1: Type, tpe2: Type, loc: SourceLocation): Type = (tpe1, tpe2) match {
     case (Type.Cst(TypeConstructor.Pure, _), _) => tpe2
@@ -821,24 +819,18 @@ object Type {
 
   /**
     * Returns the type `And(tpe1, And(tpe2, tpe3))`.
-    *
-    * Must not be used before kinding.
     */
   def mkUnion(tpe1: Type, tpe2: Type, tpe3: Type, loc: SourceLocation): Type =
     mkUnion(tpe1, mkUnion(tpe2, tpe3, loc), loc)
 
   /**
     * Returns the type `And(tpe1, And(tpe2, And(tpe3, tpe4)))`.
-    *
-    * Must not be used before kinding.
     */
   def mkUnion(tpe1: Type, tpe2: Type, tpe3: Type, tpe4: Type, loc: SourceLocation): Type =
     mkUnion(tpe1, mkUnion(tpe2, mkUnion(tpe3, tpe4, loc), loc), loc)
 
   /**
     * Returns the type `And(tpe1, And(tpe2, ...))`.
-    *
-    * Must not be used before kinding.
     */
   def mkUnion(tpes: List[Type], loc: SourceLocation): Type = tpes match {
     case Nil => Type.Pure
@@ -847,8 +839,6 @@ object Type {
 
   /**
     * Returns the type `Or(tpe1, tpe2)`.
-    *
-    * Must not be used before kinding.
     */
   def mkIntersection(tpe1: Type, tpe2: Type, loc: SourceLocation): Type = (tpe1, tpe2) match {
     case (Type.Cst(TypeConstructor.Pure, _), _) => Type.Pure
@@ -861,8 +851,6 @@ object Type {
 
   /**
     * Returns the type `Or(tpe1, Or(tpe2, ...))`.
-    *
-    * Must not be used before kinding.
     */
   def mkIntersection(tpes: List[Type], loc: SourceLocation): Type = tpes match {
     case Nil => Type.EffUniv
@@ -871,8 +859,6 @@ object Type {
 
   /**
     * Returns the type `And(tpe1, tpe2)`.
-    *
-    * Must not be used before kinding.
     */
   def mkAnd(tpe1: Type, tpe2: Type, loc: SourceLocation): Type = (tpe1, tpe2) match {
     case (Type.Cst(TypeConstructor.True, _), _) => tpe2
@@ -885,8 +871,6 @@ object Type {
 
   /**
     * Returns the type `Or(tpe1, tpe2)`.
-    *
-    * Must not be used before kinding.
     */
   def mkOr(tpe1: Type, tpe2: Type, loc: SourceLocation): Type = (tpe1, tpe2) match {
     case (Type.Cst(TypeConstructor.True, _), _) => Type.True
@@ -899,8 +883,6 @@ object Type {
 
   /**
     * Returns the type `Or(tpe1, Or(tpe2, ...))`.
-    *
-    * Must not be used before kinding.
     */
   def mkOr(tpes: List[Type], loc: SourceLocation): Type = tpes match {
     case Nil => Type.False
@@ -909,8 +891,6 @@ object Type {
 
   /**
     * Returns the type `And(tpe1, And(tpe2, ...))`.
-    *
-    * Must not be used before kinding.
     */
   def mkAnd(tpes: List[Type], loc: SourceLocation): Type = tpes match {
     case Nil => Type.True
@@ -919,8 +899,6 @@ object Type {
 
   /**
     * Returns the complement of the given type.
-    *
-    * Must not be used before kinding.
     */
   def mkCaseComplement(tpe: Type, sym: Symbol.RestrictableEnumSym, loc: SourceLocation): Type = tpe match {
     case Type.Apply(Type.Cst(TypeConstructor.CaseComplement(_), _), tpe2, _) => tpe2
@@ -930,8 +908,6 @@ object Type {
 
   /**
     * Returns the type `tpe1 + tpe2`
-    *
-    * Must not be used before kinding.
     */
   def mkCaseUnion(tpe1: Type, tpe2: Type, sym: Symbol.RestrictableEnumSym, loc: SourceLocation): Type = (tpe1, tpe2) match {
     case (Type.Cst(TypeConstructor.CaseSet(syms1, _), _), Type.Cst(TypeConstructor.CaseSet(syms2, _), _)) =>
@@ -944,8 +920,6 @@ object Type {
 
   /**
     * Returns the type `tpe1 & tpe2`
-    *
-    * Must not be used before kinding.
     */
   def mkCaseIntersection(tpe1: Type, tpe2: Type, sym: Symbol.RestrictableEnumSym, loc: SourceLocation): Type = (tpe1, tpe2) match {
     case (Type.Cst(TypeConstructor.CaseSet(syms1, _), _), Type.Cst(TypeConstructor.CaseSet(syms2, _), _)) =>
@@ -958,8 +932,6 @@ object Type {
 
   /**
     * Returns the difference of the given types.
-    *
-    * Must not be used before kinding.
     */
   def mkCaseDifference(tpe1: Type, tpe2: Type, sym: Symbol.RestrictableEnumSym, loc: SourceLocation): Type = {
     mkCaseIntersection(tpe1, mkCaseComplement(tpe2, sym, loc), sym, loc)

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -329,7 +329,7 @@ object Type {
   val EffUniv: Type = Type.Cst(TypeConstructor.EffUniv, SourceLocation.Unknown)
 
   /**
-    * Represents the Impure effect. (FALSE in the Boolean algebra.)
+    * Represents the universal effect set.
     */
   val Impure: Type = EffUniv
 
@@ -353,6 +353,16 @@ object Type {
     * NB: This type has kind: * -> (* -> *).
     */
   val Intersection: Type = Type.Cst(TypeConstructor.Intersection, SourceLocation.Unknown)
+
+  /**
+    * Represents the True Boolean algebra value.
+    */
+  val True: Type = Type.Cst(TypeConstructor.True, SourceLocation.Unknown)
+
+  /**
+    * Represents the False Boolean algebra value.
+    */
+  val False: Type = Type.Cst(TypeConstructor.False, SourceLocation.Unknown)
 
   /////////////////////////////////////////////////////////////////////////////
   // Constructors                                                            //

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -336,21 +336,21 @@ object Type {
   /**
     * Represents the Complement type constructor.
     *
-    * NB: This type has kind: * -> *.
+    * NB: This type has kind: Eff -> Eff.
     */
   val Complement: Type = Type.Cst(TypeConstructor.Complement, SourceLocation.Unknown)
 
   /**
     * Represents the Union type constructor.
     *
-    * NB: This type has kind: * -> (* -> *).
+    * NB: This type has kind: Eff -> (Eff -> Eff).
     */
   val Union: Type = Type.Cst(TypeConstructor.Union, SourceLocation.Unknown)
 
   /**
     * Represents the Intersection type constructor.
     *
-    * NB: This type has kind: * -> (* -> *).
+    * NB: This type has kind: Eff -> (Eff -> Eff).
     */
   val Intersection: Type = Type.Cst(TypeConstructor.Intersection, SourceLocation.Unknown)
 
@@ -367,21 +367,21 @@ object Type {
   /**
     * Represents the Not type constructor.
     *
-    * NB: This type has kind: * -> *.
+    * NB: This type has kind: Bool -> Bool.
     */
   val Not: Type = Type.Cst(TypeConstructor.Not, SourceLocation.Unknown)
 
   /**
     * Represents the And type constructor.
     *
-    * NB: This type has kind: * -> (* -> *).
+    * NB: This type has kind: Bool -> (Bool -> Bool).
     */
   val And: Type = Type.Cst(TypeConstructor.And, SourceLocation.Unknown)
 
   /**
     * Represents the Or type constructor.
     *
-    * NB: This type has kind: * -> (* -> *).
+    * NB: This type has kind: Bool -> (Bool -> Bool).
     */
   val Or: Type = Type.Cst(TypeConstructor.Or, SourceLocation.Unknown)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1564,7 +1564,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def Impure: Rule1[ParsedAst.Type] = rule {
-      SP ~ keyword("Impure") ~ SP ~> ParsedAst.Type.False
+      SP ~ keyword("Impure") ~ SP ~> ParsedAst.Type.Impure
     }
 
     def CaseComplement: Rule1[ParsedAst.Type] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1560,7 +1560,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def Pure: Rule1[ParsedAst.Type] = rule {
-      SP ~ keyword("Pure") ~ SP ~> ParsedAst.Type.True
+      SP ~ keyword("Pure") ~ SP ~> ParsedAst.Type.Pure
     }
 
     def Impure: Rule1[ParsedAst.Type] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -704,6 +704,7 @@ object Resolver {
           case "SchemaRow" => Kind.SchemaRow.toSuccess
           case "Predicate" => Kind.Predicate.toSuccess
           case "Region" => Kind.Eff.toSuccess
+          case "Bool" => Kind.Bool.toSuccess
           case _ =>
             lookupRestrictableEnum(qname, env, ns0, root) match {
               case Validation.Success(enum) => Kind.CaseSet(enum.sym).toSuccess
@@ -2317,9 +2318,9 @@ object Resolver {
           case (tpe1, tpe2) => UnkindedType.Apply(tpe1, tpe2, loc)
         }
 
-      case NamedAst.Type.True(loc) => UnkindedType.Cst(TypeConstructor.Pure, loc).toSuccess
+      case NamedAst.Type.True(loc) => UnkindedType.Cst(TypeConstructor.True, loc).toSuccess
 
-      case NamedAst.Type.False(loc) => UnkindedType.Cst(TypeConstructor.EffUniv, loc).toSuccess
+      case NamedAst.Type.False(loc) => UnkindedType.Cst(TypeConstructor.False, loc).toSuccess
 
       case NamedAst.Type.Not(tpe, loc) =>
         mapN(visit(tpe)) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -1031,11 +1031,11 @@ object Typer {
             case KindedAst.RelationalChoiceRule(r, exp0) =>
               val cond = mkOverApprox(isAbsentVars, isPresentVars, r)
               val innerType = Type.freshVar(Kind.Star, exp0.loc)
-              val isAbsentVar = Type.freshVar(Kind.Eff, exp0.loc)
-              val isPresentVar = Type.freshVar(Kind.Eff, exp0.loc)
+              val isAbsentVar = Type.freshVar(Kind.Bool, exp0.loc)
+              val isPresentVar = Type.freshVar(Kind.Bool, exp0.loc)
               for {
                 choiceType <- unifyTypeM(resultType, Type.mkChoice(innerType, isAbsentVar, isPresentVar, loc), loc)
-              } yield (Type.mkUnion(cond, isAbsentVar, loc), Type.mkUnion(cond, isPresentVar, loc), innerType)
+              } yield (Type.mkAnd(cond, isAbsentVar, loc), Type.mkAnd(cond, isPresentVar, loc), innerType)
           }
 
           ///
@@ -1050,8 +1050,8 @@ object Typer {
           ///
           for {
             (isAbsentConds, isPresentConds, innerTypes) <- traverseM(rs.zip(ts))(p => visitRuleBody(p._1, p._2)).map(_.unzip3)
-            isAbsentCond = Type.mkIntersection(isAbsentConds, loc)
-            isPresentCond = Type.mkIntersection(isPresentConds, loc)
+            isAbsentCond = Type.mkOr(isAbsentConds, loc)
+            isPresentCond = Type.mkOr(isPresentConds, loc)
             innerType <- unifyTypeM(innerTypes, loc)
             resultType = Type.mkChoice(innerType, isAbsentCond, isPresentCond, loc)
           } yield resultType
@@ -1065,16 +1065,16 @@ object Typer {
           * If a pattern is `Present` its corresponding `isAbsentVar`  must be `false` (i.e. to prevent the value from being `Absent`).
           */
         def mkUnderApprox(isAbsentVars: List[Type.Var], isPresentVars: List[Type.Var], r: List[KindedAst.RelationalChoicePattern]): Type =
-          isAbsentVars.zip(isPresentVars).zip(r).foldLeft(Type.Pure) {
+          isAbsentVars.zip(isPresentVars).zip(r).foldLeft(Type.True) {
             case (acc, (_, KindedAst.RelationalChoicePattern.Wild(_))) =>
               // Case 1: No constraint is generated for a wildcard.
               acc
             case (acc, ((isAbsentVar, _), KindedAst.RelationalChoicePattern.Present(_, _, _))) =>
               // Case 2: A `Present` pattern forces the `isAbsentVar` to be equal to `false`.
-              Type.mkUnion(acc, Type.mkEquiv(isAbsentVar, Type.EffUniv, loc), loc)
+              Type.mkAnd(acc, Type.mkEquiv(isAbsentVar, Type.False, loc), loc)
             case (acc, ((_, isPresentVar), KindedAst.RelationalChoicePattern.Absent(_))) =>
               // Case 3: An `Absent` pattern forces the `isPresentVar` to be equal to `false`.
-              Type.mkUnion(acc, Type.mkEquiv(isPresentVar, Type.EffUniv, loc), loc)
+              Type.mkAnd(acc, Type.mkEquiv(isPresentVar, Type.False, loc), loc)
           }
 
         /**
@@ -1085,24 +1085,24 @@ object Typer {
           * If a pattern is `Present` it *may* match if its corresponding `isPresentVar`is `true`.
           */
         def mkOverApprox(isAbsentVars: List[Type.Var], isPresentVars: List[Type.Var], r: List[KindedAst.RelationalChoicePattern]): Type =
-          isAbsentVars.zip(isPresentVars).zip(r).foldLeft(Type.Pure) {
+          isAbsentVars.zip(isPresentVars).zip(r).foldLeft(Type.True) {
             case (acc, (_, KindedAst.RelationalChoicePattern.Wild(_))) =>
               // Case 1: No constraint is generated for a wildcard.
               acc
             case (acc, ((isAbsentVar, _), KindedAst.RelationalChoicePattern.Absent(_))) =>
               // Case 2: An `Absent` pattern may match if the `isAbsentVar` is `true`.
-              Type.mkUnion(acc, isAbsentVar, loc)
+              Type.mkAnd(acc, isAbsentVar, loc)
             case (acc, ((_, isPresentVar), KindedAst.RelationalChoicePattern.Present(_, _, _))) =>
               // Case 3: A `Present` pattern may match if the `isPresentVar` is `true`.
-              Type.mkUnion(acc, isPresentVar, loc)
+              Type.mkAnd(acc, isPresentVar, loc)
           }
 
         /**
           * Constructs a disjunction of the constraints of each choice rule.
           */
         def mkOuterDisj(m: List[List[KindedAst.RelationalChoicePattern]], isAbsentVars: List[Type.Var], isPresentVars: List[Type.Var]): Type =
-          m.foldLeft(Type.EffUniv) {
-            case (acc, rule) => Type.mkIntersection(acc, mkUnderApprox(isAbsentVars, isPresentVars, rule), loc)
+          m.foldLeft(Type.False) {
+            case (acc, rule) => Type.mkOr(acc, mkUnderApprox(isAbsentVars, isPresentVars, rule), loc)
           }
 
         /**
@@ -1129,12 +1129,12 @@ object Typer {
         //
         // Introduce an isAbsent variable for each match expression in `exps`.
         //
-        val isAbsentVars = exps0.map(exp0 => Type.freshVar(Kind.Eff, exp0.loc))
+        val isAbsentVars = exps0.map(exp0 => Type.freshVar(Kind.Bool, exp0.loc))
 
         //
         // Introduce an isPresent variable for each math expression in `exps`.
         //
-        val isPresentVars = exps0.map(exp0 => Type.freshVar(Kind.Eff, exp0.loc))
+        val isPresentVars = exps0.map(exp0 => Type.freshVar(Kind.Bool, exp0.loc))
 
         //
         // Extract the choice pattern match matrix.
@@ -1155,7 +1155,7 @@ object Typer {
         // Put everything together.
         //
         for {
-          _ <- unifyBoolM(formula, Type.Pure, loc)
+          _ <- unifySimpleBoolM(formula, Type.True, loc)
           (matchConstrs, matchTyp, matchPur) <- visitMatchExps(exps0, isAbsentVars, isPresentVars)
           _ <- unifyMatchTypesAndRules(matchTyp, rules0)
           (ruleBodyConstrs, ruleBodyTyp, ruleBodyPur) <- visitRuleBodies(rules0)
@@ -1174,8 +1174,8 @@ object Typer {
           if (symUse.sym.name == "Absent") {
             // Case 1.1: Absent Tag.
             val elmVar = Type.freshVar(Kind.Star, loc)
-            val isAbsent = Type.Pure
-            val isPresent = Type.freshVar(Kind.Eff, loc)
+            val isAbsent = Type.True
+            val isPresent = Type.freshVar(Kind.Bool, loc)
             for {
               resultTyp <- unifyTypeM(tvar, Type.mkChoice(elmVar, isAbsent, isPresent, loc), loc)
               resultPur = Type.Pure
@@ -1183,8 +1183,8 @@ object Typer {
           }
           else if (symUse.sym.name == "Present") {
             // Case 1.2: Present Tag.
-            val isAbsent = Type.freshVar(Kind.Eff, loc)
-            val isPresent = Type.Pure
+            val isAbsent = Type.freshVar(Kind.Bool, loc)
+            val isPresent = Type.True
             for {
               (constrs, tpe, pur) <- visitExp(exp)
               resultTyp <- unifyTypeM(tvar, Type.mkChoice(tpe, isAbsent, isPresent, loc), loc)
@@ -2057,7 +2057,7 @@ object Typer {
             TypedAst.RelationalChoiceRule(pat, visitExp(exp, subst0))
         }
         val tpe = subst0(tvar)
-        val pur = Type.mkUnion(rs.map(_.exp.pur), loc)
+        val pur = Type.mkAnd(rs.map(_.exp.pur), loc)
         TypedAst.Expression.RelationalChoose(es, rs, tpe, pur, loc)
 
       case KindedAst.Expression.RestrictableChoose(star, exp, rules, tvar, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -2741,9 +2741,15 @@ object Weeder {
         case (t1, t2) => WeededAst.Type.Intersection(t1, WeededAst.Type.Complement(t2, loc), loc)
       }
 
+    case ParsedAst.Type.Pure(sp1, sp2) =>
+      val loc = mkSL(sp1, sp2)
+      // TODO EFF-MIGRATION rename to Pure
+      WeededAst.Type.Empty(loc).toSuccess
+
     case ParsedAst.Type.Impure(sp1, sp2) =>
-      WeededAst.Type.Complement(WeededAst.Type)
+      val loc = mkSL(sp1, sp2)
       // TODO EFF-MIGRATION create dedicated Impure type
+      WeededAst.Type.Complement(WeededAst.Type.Empty(loc), loc).toSuccess
 
     case ParsedAst.Type.EffectSet(sp1, tpes0, sp2) =>
       val checkVal = traverseX(tpes0)(checkEffectSetMember)
@@ -2754,7 +2760,7 @@ object Weeder {
           val purOpt = tpes.reduceLeftOption({
             case (acc, tpe) => WeededAst.Type.Union(acc, tpe, loc)
           }: (WeededAst.Type, WeededAst.Type) => WeededAst.Type)
-          purOpt.getOrElse(WeededAst.Type.True(loc))
+          purOpt.getOrElse(WeededAst.Type.Empty(loc))
       }
 
     case ParsedAst.Type.CaseSet(sp1, cases, sp2) =>
@@ -3380,6 +3386,8 @@ object Weeder {
     case ParsedAst.Type.Difference(tpe1, _, _) => leftMostSourcePosition(tpe1)
     case ParsedAst.Type.Intersection(tpe1, _, _) => leftMostSourcePosition(tpe1)
     case ParsedAst.Type.Union(tpe1, _, _) => leftMostSourcePosition(tpe1)
+    case ParsedAst.Type.Pure(sp1, _) => sp1
+    case ParsedAst.Type.Impure(sp1, _) => sp1
     case ParsedAst.Type.EffectSet(sp1, _, _) => sp1
     case ParsedAst.Type.CaseComplement(sp1, _, _) => sp1
     case ParsedAst.Type.CaseDifference(tpe1, _, _) => leftMostSourcePosition(tpe1)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -2826,6 +2826,8 @@ object Weeder {
     case _: ParsedAst.Type.Ambiguous => ().toSuccess
     case _: ParsedAst.Type.True => ().toSuccess
     case _: ParsedAst.Type.False => ().toSuccess
+    case _: ParsedAst.Type.Pure => ().toSuccess
+    case _: ParsedAst.Type.Impure => ().toSuccess
     case _ =>
       val sp1 = leftMostSourcePosition(t)
       val sp2 = t.sp2

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -2741,6 +2741,10 @@ object Weeder {
         case (t1, t2) => WeededAst.Type.Intersection(t1, WeededAst.Type.Complement(t2, loc), loc)
       }
 
+    case ParsedAst.Type.Impure(sp1, sp2) =>
+      WeededAst.Type.Complement(WeededAst.Type)
+      // TODO EFF-MIGRATION create dedicated Impure type
+
     case ParsedAst.Type.EffectSet(sp1, tpes0, sp2) =>
       val checkVal = traverseX(tpes0)(checkEffectSetMember)
       val tpesVal = traverse(tpes0)(visitType)

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/BoolUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/BoolUnification.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.util.Result
 import ca.uwaterloo.flix.util.Result.{Ok, ToErr, ToOk}
 import org.sosy_lab.pjbdd.api.DD
 
+// TODO EFF-MIGRATION rename to EffUnification
 object BoolUnification {
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/SimpleBoolFormulaAlgClassic.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/SimpleBoolFormulaAlgClassic.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.util.collection.Bimap
 /**
   * An implementation of the [[BoolAlg]] interface for [[BoolFormula]].
   */
+// TODO EFF-MIGRATION copy-pasted from BoolFormulaAlgClassic -- generalize the trait and deduplicate
 class SimpleBoolFormulaAlgClassic extends BoolFormulaAlg {
 
   override def mkNot(f: BoolFormula): BoolFormula = f match {

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/SimpleBoolFormulaAlgClassic.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/SimpleBoolFormulaAlgClassic.scala
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2022 Magnus Madsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.phase.unification
+import ca.uwaterloo.flix.language.ast.{Type, TypeConstructor}
+import ca.uwaterloo.flix.util.InternalCompilerException
+import ca.uwaterloo.flix.util.collection.Bimap
+
+/**
+  * An implementation of the [[BoolAlg]] interface for [[BoolFormula]].
+  */
+class SimpleBoolFormulaAlgClassic extends BoolFormulaAlg {
+
+  override def mkNot(f: BoolFormula): BoolFormula = f match {
+    case BoolFormula.True =>
+      BoolFormula.False
+
+    case BoolFormula.False =>
+      BoolFormula.True
+
+    case BoolFormula.Not(x) =>
+      x
+
+    // ¬(¬x ∨ y) => x ∧ ¬y
+    case BoolFormula.Or(BoolFormula.Not(x), y) =>
+      mkAnd(x, mkNot(y))
+
+    // ¬(x ∨ ¬y) => ¬x ∧ y
+    case BoolFormula.Or(x, BoolFormula.Not(y)) =>
+      mkAnd(mkNot(x), y)
+
+    case _ => BoolFormula.Not(f)
+  }
+
+  override def mkAnd(f1: BoolFormula, f2: BoolFormula): BoolFormula = (f1, f2) match {
+    // T ∧ x => x
+    case (BoolFormula.True, _) =>
+      f2
+
+    // x ∧ T => x
+    case (_, BoolFormula.True) =>
+      f1
+
+    // F ∧ x => F
+    case (BoolFormula.False, _) =>
+      BoolFormula.False
+
+    // x ∧ F => F
+    case (_, BoolFormula.False) =>
+      BoolFormula.False
+
+    // ¬x ∧ (x ∨ y) => ¬x ∧ y
+    case (BoolFormula.Not(x1), BoolFormula.Or(x2, y)) if x1 == x2 =>
+      mkAnd(mkNot(x1), y)
+
+    // x ∧ ¬x => F
+    case (x1, BoolFormula.Not(x2)) if x1 == x2 =>
+      BoolFormula.False
+
+    // ¬x ∧ x => F
+    case (BoolFormula.Not(x1), x2) if x1 == x2 =>
+      BoolFormula.False
+
+    // x ∧ (x ∧ y) => (x ∧ y)
+    case (x1, BoolFormula.And(x2, y)) if x1 == x2 =>
+      mkAnd(x1, y)
+
+    // x ∧ (y ∧ x) => (x ∧ y)
+    case (x1, BoolFormula.And(y, x2)) if x1 == x2 =>
+      mkAnd(x1, y)
+
+    // (x ∧ y) ∧ x) => (x ∧ y)
+    case (BoolFormula.And(x1, y), x2) if x1 == x2 =>
+      mkAnd(x1, y)
+
+    // (x ∧ y) ∧ y) => (x ∧ y)
+    case (BoolFormula.And(x, y1), y2) if y1 == y2 =>
+      mkAnd(x, y1)
+
+    // x ∧ (x ∨ y) => x
+    case (x1, BoolFormula.Or(x2, _)) if x1 == x2 =>
+      x1
+
+    // (x ∨ y) ∧ x => x
+    case (BoolFormula.Or(x1, _), x2) if x1 == x2 =>
+      x1
+
+    // x ∧ (y ∧ ¬x) => F
+    case (x1, BoolFormula.And(_, BoolFormula.Not(x2))) if x1 == x2 =>
+      BoolFormula.False
+
+    // (¬x ∧ y) ∧ x => F
+    case (BoolFormula.And(BoolFormula.Not(x1), _), x2) if x1 == x2 =>
+      BoolFormula.False
+
+    // x ∧ ¬(x ∨ y) => F
+    case (x1, BoolFormula.Not(BoolFormula.Or(x2, _))) if x1 == x2 =>
+      BoolFormula.False
+
+    // ¬(x ∨ y) ∧ x => F
+    case (BoolFormula.Not(BoolFormula.Or(x1, _)), x2) if x1 == x2 =>
+      BoolFormula.False
+
+    // x ∧ (¬x ∧ y) => F
+    case (x1, BoolFormula.And(BoolFormula.Not(x2), _)) if x1 == x2 =>
+      BoolFormula.False
+
+    // (¬x ∧ y) ∧ x => F
+    case (BoolFormula.And(BoolFormula.Not(x1), _), x2) if x1 == x2 =>
+      BoolFormula.False
+
+    // x ∧ x => x
+    case _ if f1 == f2 => f1
+
+    case _ =>
+      //      val s = s"And($eff1, $eff2)"
+      //      val len = s.length
+      //      if (true) {
+      //        println(s.substring(0, Math.min(len, 300)))
+      //      }
+
+      BoolFormula.And(f1, f2)
+  }
+
+  override def mkOr(f1: BoolFormula, f2: BoolFormula): BoolFormula = (f1, f2) match {
+    // T ∨ x => T
+    case (BoolFormula.True, _) =>
+      BoolFormula.True
+
+    // F ∨ y => y
+    case (BoolFormula.False, _) =>
+      f2
+
+    // x ∨ T => T
+    case (_, BoolFormula.True) =>
+      BoolFormula.True
+
+    // x ∨ F => x
+    case (_, BoolFormula.False) =>
+      f1
+
+    // x ∨ (y ∨ x) => x ∨ y
+    case (x1, BoolFormula.Or(y, x2)) if x1 == x2 =>
+      mkOr(x1, y)
+
+    // (x ∨ y) ∨ x => x ∨ y
+    case (BoolFormula.Or(x1, y), x2) if x1 == x2 =>
+      mkOr(x1, y)
+
+    // ¬x ∨ x => T
+    case (BoolFormula.Not(x), y) if x == y =>
+      BoolFormula.True
+
+    // x ∨ ¬x => T
+    case (x, BoolFormula.Not(y)) if x == y =>
+      BoolFormula.True
+
+    // (¬x ∨ y) ∨ x) => T
+    case (BoolFormula.Or(BoolFormula.Not(x), _), y) if x == y =>
+      BoolFormula.True
+
+    // x ∨ (¬x ∨ y) => T
+    case (x, BoolFormula.Or(BoolFormula.Not(y), _)) if x == y =>
+      BoolFormula.True
+
+    // x ∨ (y ∧ x) => x
+    case (x1, BoolFormula.And(_, x2)) if x1 == x2 => x1
+
+    // (y ∧ x) ∨ x => x
+    case (BoolFormula.And(_, x1), x2) if x1 == x2 => x1
+
+    // x ∨ x => x
+    case _ if f1 == f2 =>
+      f1
+
+    case _ =>
+
+      //              val s = s"Or($eff1, $eff2)"
+      //              val len = s.length
+      //              if (len > 30) {
+      //                println(s.substring(0, Math.min(len, 300)))
+      //              }
+
+      BoolFormula.Or(f1, f2)
+  }
+
+  // No minimization via tabling.
+  override def minimize(f: BoolFormula): BoolFormula = f
+
+  /**
+    * Converts the given type t into a formula.
+    */
+  override def fromType(t: Type, env: Bimap[BoolFormula.VarOrEff, Int]): BoolFormula = Type.eraseTopAliases(t) match {
+    case Type.Var(sym, _) => env.getForward(BoolFormula.VarOrEff.Var(sym)) match {
+      case None => throw InternalCompilerException(s"Unexpected unbound variable: '$sym'.", sym.loc)
+      case Some(x) => mkVar(x)
+    }
+    case Type.True => mkTrue
+    case Type.False => mkFalse
+    case Type.Apply(Type.Cst(TypeConstructor.Not, _), tpe1, _) => mkNot(fromType(tpe1, env))
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.And, _), tpe1, _), tpe2, _) => mkAnd(fromType(tpe1, env), fromType(tpe2, env))
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Or, _), tpe1, _), tpe2, _) => mkOr(fromType(tpe1, env), fromType(tpe2, env))
+    case _ => throw InternalCompilerException(s"Unexpected type: '$t'.", t.loc)
+  }
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/SimpleBoolUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/SimpleBoolUnification.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.util.Result
 import ca.uwaterloo.flix.util.Result.{Ok, ToErr, ToOk}
 import org.sosy_lab.pjbdd.api.DD
 
+// TODO EFF-MIGRATION rename to BoolUnification
 object SimpleBoolUnification {
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/SimpleBoolUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/SimpleBoolUnification.scala
@@ -1,0 +1,160 @@
+/*
+ *  Copyright 2020 Magnus Madsen
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package ca.uwaterloo.flix.language.phase.unification
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast._
+import ca.uwaterloo.flix.util.Result
+import ca.uwaterloo.flix.util.Result.{Ok, ToErr, ToOk}
+import org.sosy_lab.pjbdd.api.DD
+
+object SimpleBoolUnification {
+
+  /**
+    * Returns the most general unifier of the two given Boolean formulas `tpe1` and `tpe2`.
+    */
+  def unify(tpe1: Type, tpe2: Type, renv0: RigidityEnv)(implicit flix: Flix): Result[(Substitution, List[Ast.BroadEqualityConstraint]), UnificationError] = {
+
+    // Give up early if either type contains an associated type.
+    if (Type.hasAssocType(tpe1) || Type.hasAssocType(tpe2)) {
+      return Ok((Substitution.empty, List(Ast.BroadEqualityConstraint(tpe1, tpe2))))
+    }
+
+    implicit val alg: BoolAlg[BoolFormula] = new SimpleBoolFormulaAlgClassic
+    implicit val cache: UnificationCache[BoolFormula] = UnificationCache.GlobalBool
+    val substRes = lookupOrSolve(tpe1, tpe2, renv0)
+
+    substRes.map(subst => (subst, Nil))
+  }
+
+
+  /**
+    * Lookup the unifier of `tpe1` and `tpe2` or solve them.
+    */
+  private def lookupOrSolve[F](tpe1: Type, tpe2: Type, renv0: RigidityEnv)
+                              (implicit flix: Flix, alg: BoolAlg[F], cache: UnificationCache[F]): Result[Substitution, UnificationError] = {
+    //
+    // Translate the types into formulas.
+    //
+    val env = alg.getEnv(List(tpe1, tpe2))
+    val f1 = alg.fromType(tpe1, env)
+    val f2 = alg.fromType(tpe2, env)
+
+    val renv = alg.liftRigidityEnv(renv0, env)
+
+    //
+    // Lookup the query to see if it is already in unification cache.
+    //
+    if (!flix.options.xnoboolcache) {
+      cache.lookup(f1, f2, renv) match {
+        case None => // cache miss: must compute the unification.
+        case Some(subst) =>
+          // cache hit: return the found substitution.
+          return subst.toTypeSubstitution(env).toOk
+      }
+    }
+
+    //
+    // Run the expensive Boolean unification algorithm.
+    //
+    booleanUnification(f1, f2, renv) match {
+      case None => UnificationError.MismatchedBools(tpe1, tpe2).toErr
+      case Some(subst) =>
+        if (!flix.options.xnoboolcache) {
+          cache.put(f1, f2, renv, subst)
+        }
+        subst.toTypeSubstitution(env).toOk
+    }
+  }
+
+  /**
+    * Returns the most general unifier of the two given Boolean formulas `tpe1` and `tpe2`.
+    */
+  private def booleanUnification[F](tpe1: F, tpe2: F, renv: Set[Int])
+                                   (implicit flix: Flix, alg: BoolAlg[F]): Option[BoolSubstitution[F]] = {
+    // The boolean expression we want to show is 0.
+    val query = alg.mkXor(tpe1, tpe2)
+
+    // Compute the variables in the query.
+    val typeVars = alg.freeVars(query).toList
+
+    // Compute the flexible variables.
+    val flexibleTypeVars = typeVars.filterNot(renv.contains)
+
+    // Determine the order in which to eliminate the variables.
+    val freeVars = computeVariableOrder(flexibleTypeVars)
+
+    // Eliminate all variables.
+    try {
+      val subst = successiveVariableElimination(query, freeVars)
+
+      //    if (!subst.isEmpty) {
+      //      val s = subst.toString
+      //      val len = s.length
+      //      if (len > 50) {
+      //        println(s.substring(0, Math.min(len, 300)))
+      //        println()
+      //      }
+      //    }
+
+      Some(subst)
+    } catch {
+      case ex: BoolUnificationException => None
+    }
+  }
+
+  /**
+    * A heuristic used to determine the order in which to eliminate variable.
+    *
+    * Semantically the order of variables is immaterial. Changing the order may
+    * yield different unifiers, but they are all equivalent. However, changing
+    * the can lead to significant speed-ups / slow-downs.
+    *
+    * We make the following observation:
+    *
+    * We want to have synthetic variables (i.e. fresh variables introduced during
+    * type inference) expressed in terms of real variables (i.e. variables that
+    * actually occur in the source code). We can ensure this by eliminating the
+    * synthetic variables first.
+    */
+  private def computeVariableOrder(l: List[Int]): List[Int] = {
+    l.reverse // TODO have to reverse the order for regions to work
+  }
+
+  /**
+    * Performs success variable elimination on the given boolean expression `f`.
+    *
+    * `flexvs` is the list of remaining flexible variables in the expression.
+    */
+  private def successiveVariableElimination[F](f: F, flexvs: List[Int])(implicit flix: Flix, alg: BoolAlg[F]): BoolSubstitution[F] = flexvs match {
+    case Nil =>
+      // Determine if f is unsatisfiable when all (rigid) variables are made flexible.
+      if (!alg.satisfiable(f))
+        BoolSubstitution.empty
+      else
+        throw BoolUnificationException()
+
+    case x :: xs =>
+      val t0 = BoolSubstitution.singleton(x, alg.mkFalse)(f)
+      val t1 = BoolSubstitution.singleton(x, alg.mkTrue)(f)
+      val se = successiveVariableElimination(alg.mkAnd(t0, t1), xs)
+
+      val f1 = alg.minimize(alg.mkOr(se(t0), alg.mkAnd(alg.mkVar(x), alg.mkNot(se(t1)))))
+      val st = BoolSubstitution.singleton(x, f1)
+      st ++ se
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -96,6 +96,8 @@ object Unification {
         BoolUnification.unify(tpe1, tpe2, renv)
       }
 
+    case (Kind.Bool, Kind.Bool) => SimpleBoolUnification.unify(tpe1, tpe2, renv)
+
     case (Kind.CaseSet(sym1), Kind.CaseSet(sym2)) if sym1 == sym2 =>
       val cases = sym1.universe
       CaseSetUnification.unify(tpe1, tpe2, renv, cases, sym1).map((_, Nil)) // TODO ASSOC-TYPES support in sets

--- a/main/src/library/Choice.flix
+++ b/main/src/library/Choice.flix
@@ -18,7 +18,7 @@
  * The Choice data type.
  */
 @Internal
-pub enum Choice[a: Type, _isAbsent : Eff, _isPresent : Eff] {
+pub enum Choice[a: Type, _isAbsent : Bool, _isPresent : Bool] {
     case Absent
     case Present(a)
 }
@@ -86,8 +86,8 @@ mod Choice {
     /// Returns `c` if it is `Present(v)`. Otherwise returns `default`.
     ///
     @Experimental
-    pub def withDefault[s : Type, a1 : Eff, p1 : Eff, a2 : Eff, p2 : Eff]
-                       (default: {default = Choice[s, a2, p2]}, c: Choice[s, a1, p1]): Choice[s, a1 + a2, p1 & (a1 + p2)] =
+    pub def withDefault[s : Type, a1 : Bool, p1 : Bool, a2 : Bool, p2 : Bool]
+                       (default: {default = Choice[s, a2, p2]}, c: Choice[s, a1, p1]): Choice[s, a1 and a2, p1 or (a1 and p2)] =
         relational_choose* c {
             case Absent     => default.default
             case Present(v) => Present(v)
@@ -99,8 +99,8 @@ mod Choice {
     /// The function `f` must be pure.
     ///
     @Experimental
-    pub def filter[t : Type, a : Eff, p : Eff]
-                  (f: t -> Bool, c: Choice[t, a, p]): Choice[t, a & p, p] =
+    pub def filter[t : Type, a : Bool, p : Bool]
+                  (f: t -> Bool, c: Choice[t, a, p]): Choice[t, a or p, p] =
         relational_choose* c {
             case Absent     => Absent
             case Present(v) => if (f(v)) Present(v) else Absent
@@ -110,7 +110,7 @@ mod Choice {
     /// Returns `Present(f(v))` if `c` is `Present(v)`. Otherwise returns `Absent`.
     ///
     @Experimental
-    pub def map[s: Type, t: Type, a: Eff, p: Eff](f: s -> t, c: Choice[s, a, p]): Choice[t, a, p] =
+    pub def map[s: Type, t: Type, a: Bool, p: Bool](f: s -> t, c: Choice[s, a, p]): Choice[t, a, p] =
         relational_choose* c {
             case Absent     => Absent
             case Present(x) => Present(f(x))
@@ -120,8 +120,8 @@ mod Choice {
     /// Returns `f(v)` if `c` is `Present(v)`. Otherwise returns `Absent`.
     ///
     @Experimental
-    pub def flatMap[s : Type, t : Type, a1 : Eff, p1 : Eff, a2 : Eff, p2 : Eff]
-                   (f: s -> Choice[t, a2, p2], c: Choice[s, a1, p1]): Choice[t, a1 & (p1 + a2), p1 + p2] =
+    pub def flatMap[s : Type, t : Type, a1 : Bool, p1 : Bool, a2 : Bool, p2 : Bool]
+                   (f: s -> Choice[t, a2, p2], c: Choice[s, a1, p1]): Choice[t, a1 or (p1 and a2), p1 and p2] =
         relational_choose* c {
             case Absent     => Absent
             case Present(v) => f(v)
@@ -131,8 +131,8 @@ mod Choice {
     /// Returns `v` if `c` is `Present(v)`. Otherwise returns `Absent`.
     ///
     @Experimental
-    pub def flatten[t : Type, a1 : Eff, p1 : Eff, a2 : Eff, p2 : Eff]
-        (c: Choice[Choice[t, a1, p1], a2, p2]): Choice[t, (a1 + p2) & a2, p1 + p2] =
+    pub def flatten[t : Type, a1 : Bool, p1 : Bool, a2 : Bool, p2 : Bool]
+        (c: Choice[Choice[t, a1, p1], a2, p2]): Choice[t, (a1 and p2) or a2, p1 and p2] =
         relational_choose* c {
             case Absent     => Absent
             case Present(v) => v
@@ -142,7 +142,7 @@ mod Choice {
     /// Returns `Absent` if `c` is `Present(_)`. Otherwise returns `Present(v)`.
     ///
     @Experimental
-    pub def invert[s: Type, a: Eff, p: Eff](c: Choice[s, a, p], v: s): Choice[s, p, a] = relational_choose* c {
+    pub def invert[s: Type, a: Bool, p: Bool](c: Choice[s, a, p], v: s): Choice[s, p, a] = relational_choose* c {
         case Absent     => Present(v)
         case Present(_) => Absent
     }

--- a/main/src/library/File.flix
+++ b/main/src/library/File.flix
@@ -406,7 +406,7 @@ mod File {
     ///
     /// Returns an iterator of the given file `f`
     ///
-    pub def readLinesIter(r: Region[r], f: String): Iterator[Result[String, String], false, r] \ { r, IO } =
+    pub def readLinesIter(r: Region[r], f: String): Iterator[Result[String, String], IO, r] \ { r, IO } =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -446,7 +446,7 @@ mod File {
     /// The options `opts` to apply consists of
     /// `charSet` - the specific charset to be used to decode the bytes.
     ///
-    pub def readLinesIterWith(r: Region[r], opts: {charSet = String}, f: String): Iterator[Result[String, String], false, r] \ { r, IO } =
+    pub def readLinesIterWith(r: Region[r], opts: {charSet = String}, f: String): Iterator[Result[String, String], IO, r] \ { r, IO } =
         try {
             import new java.io.File(String): ##java.io.File \ IO as newFile;
             import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -557,7 +557,7 @@ mod File {
     ///
     /// Returns an iterator of the bytes in the given `file` in chunks of size `chunkSize`.
     ///
-    pub def readChunks(r: Region[r], chunkSize: Int32, f: String): Iterator[Result[String, Array[Int8, r]], false, r] \ IO =
+    pub def readChunks(r: Region[r], chunkSize: Int32, f: String): Iterator[Result[String, Array[Int8, r]], IO, r] \ IO =
         if (0 < chunkSize) {
             try {
                 import new java.io.File(String): ##java.io.File \ IO as newFile;

--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -667,7 +667,7 @@ mod Iterator {
     /// Note - this is not the "best" return type. Ideally it should be `Iterator[a, r, r]` but
     /// then `intercalate` fails.
     ///
-    def ofList(rc: Region[r], xs: List[a]): Iterator[a, true, r] \ r =
+    def ofList(rc: Region[r], xs: List[a]): Iterator[a, Pure, r] \ r =
         let ls = ref xs @ rc;
         let next = () -> {
             match (deref ls) {

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -1,7 +1,7 @@
 ///
 /// Static is a type alias for false and denotes the global lifetime.
 ///
-pub type alias Static = false
+pub type alias Static = Impure
 
 ///
 /// The empty type.

--- a/main/src/library/System.flix
+++ b/main/src/library/System.flix
@@ -30,7 +30,7 @@ mod System {
         ///
         /// See also `Console.readLine` for reading from the console.
         ///
-        pub def readLines(r: Region[r]): Iterator[String, false, r] \ { r, IO } =
+        pub def readLines(r: Region[r]): Iterator[String, IO, r] \ { r, IO } =
             import static get java.lang.System.in: ##java.io.InputStream \ IO as getSystemIn;
             import new java.io.InputStreamReader(##java.io.InputStream): ##java.io.InputStreamReader \ IO as newInputStream;
             import new java.io.BufferedReader(##java.io.Reader): ##java.io.BufferedReader \ IO as newBufferedReader;

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -1367,7 +1367,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
   test("RedundantPurityCast.02") {
     val input =
       raw"""
-           |pub def f(): Array[Int32, false] \ IO =
+           |pub def f(): Array[Int32, Static] \ IO =
            |  let x = Array#{1, 2, 3} @ Static;
            |  unchecked_cast(x as _ \ Pure)
            |

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -325,11 +325,11 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    case E(Int32)
         |}
         |
-        |instance C[E[true]] {
-        |    pub def foo(x: E[true]): Int32 = 1
+        |instance C[E[Pure]] {
+        |    pub def foo(x: E[Pure]): Int32 = 1
         |}
         |
-        |def bar(): Int32 = C.foo(E.E(123))    // E(123) has type E[_], not E[true]
+        |def bar(): Int32 = C.foo(E.E(123))    // E(123) has type E[_], not E[Pure]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[TypeError.MissingInstance](result)
@@ -998,7 +998,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |        case Absent => 1
         |    }
         |
-        |pub enum Choice[a : Type, _isAbsent : Eff, _isPresent : Eff] {
+        |pub enum Choice[a : Type, _isAbsent : Bool, _isPresent : Bool] {
         |    case Absent
         |    case Present(a)
         |}
@@ -1016,7 +1016,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |        case Present(_) => 1
         |    }
         |
-        |pub enum Choice[a : Type, _isAbsent : Eff, _isPresent : Eff] {
+        |pub enum Choice[a : Type, _isAbsent : Bool, _isPresent : Bool] {
         |    case Absent
         |    case Present(a)
         |}
@@ -1518,8 +1518,8 @@ class TestTyper extends AnyFunSuite with TestUtils {
     val input =
     """
       |enum E[a: Type, ef: Eff](Unit)
-      |def f(g: E[Int32, true]): Bool = ???
-      |def mkE(): E[Int32, true] \ ef = ???
+      |def f(g: E[Int32, Pure]): Bool = ???
+      |def mkE(): E[Int32, Pure] \ ef = ???
       |
       |def g(): Bool = f(mkE)
       |""".stripMargin


### PR DESCRIPTION
The names are not great. I propose we follow up:
- rename `BoolUnification` to `EffUnification`
- rename `SimpleBoolUnification` to `BinaryUnification` or something like that. `Bool` is just too overloaded.

This copy-pastes a lot from `BoolUnification`. We should be able to generalize the implementation eventually.