### PR TITLE
chore: scala: 2.13.5 → 2.13.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.scala-lang:scala-library:2.13.5!!'
-    implementation 'org.scala-lang:scala-reflect:2.13.5!!'
+    implementation 'org.scala-lang:scala-library:2.13.11!!'
+    implementation 'org.scala-lang:scala-reflect:2.13.11!!'
 
     implementation('org.java-websocket:Java-WebSocket:1.5.3')
     implementation('org.jline:jline:3.5.1')
@@ -44,7 +44,8 @@ tasks.withType(ScalaCompile) {
     scalaCompileOptions.additionalParameters = [
             "-language:postfixOps",
             "-Xfatal-warnings",
-            "-Ypatmat-exhaust-depth", "400"
+            "-Ypatmat-exhaust-depth", "400",
+            "-release", "11"
     ]
     compileScala.sourceCompatibility = 11
     compileScala.targetCompatibility = 11


### PR DESCRIPTION
Release flag had to be added manually, additional context https://github.com/gradle/gradle/issues/23962

Related

https://github.com/flix/flix/pull/4896

https://github.com/flix/flix/pull/4916

https://github.com/flix/flix/pull/4896#issuecomment-1509886116

## Main branch

```
time ./gradlew clean jar                   Wed 07 Jun 2023 06:26:25 PM CST
> Task :clean
> Task :compileJava NO-SOURCE
> Task :compileScala
Unexpected javac output: warning: [options] system modules path not set in conjunction with -source 11
1 warning.

> Task :processResources NO-SOURCE
> Task :classes
> Task :jar

BUILD SUCCESSFUL in 1m 7s
3 actionable tasks: 3 executed

________________________________________________________
Executed in   68.28 secs    fish           external
   usr time    1.39 secs    0.00 micros    1.39 secs
   sys time    0.15 secs  545.00 micros    0.15 secs
```

## This PR

```
time ./gradlew clean jar                   Wed 07 Jun 2023 06:46:13 PM CST
> Task :clean
> Task :compileJava NO-SOURCE
> Task :compileScala
Unexpected javac output: warning: [options] system modules path not set in conjunction with -source 11
1 warning.

> Task :processResources NO-SOURCE
> Task :classes
> Task :jar

BUILD SUCCESSFUL in 1m 1s
3 actionable tasks: 3 executed

________________________________________________________
Executed in   62.36 secs    fish           external
   usr time    1.27 secs    0.00 micros    1.27 secs
   sys time    0.13 secs  559.00 micros    0.12 secs
```