### PR TITLE
chore: json4s: 3.5.5 → 3.6.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     implementation('org.java-websocket:Java-WebSocket:1.5.3')
     implementation('org.jline:jline:3.5.1')
-    implementation('org.json4s:json4s-native_2.13:3.5.5')
+    implementation('org.json4s:json4s-native_2.13:3.6.12')
     implementation('org.ow2.asm:asm:9.2')
     implementation('org.parboiled:parboiled_2.13:2.4.1')
     implementation('org.scalactic:scalactic_2.13:3.2.15')


### PR DESCRIPTION
From 3.5.5 (2019-06-08) to 3.6.12 (2021-11-05)

From

```
+--- org.json4s:json4s-native_2.13:3.5.5
|    +--- org.scala-lang:scala-library:2.13.0 -> 2.13.11
|    \--- org.json4s:json4s-core_2.13:3.5.5
|         +--- org.scala-lang:scala-library:2.13.0 -> 2.13.11
|         +--- org.json4s:json4s-ast_2.13:3.5.5
|         |    \--- org.scala-lang:scala-library:2.13.0 -> 2.13.11
|         +--- org.json4s:json4s-scalap_2.13:3.5.5
|         |    \--- org.scala-lang:scala-library:2.13.0 -> 2.13.11
|         +--- com.thoughtworks.paranamer:paranamer:2.8
|         \--- org.scala-lang.modules:scala-xml_2.13:1.2.0 -> 2.1.0
|              \--- org.scala-lang:scala-library:2.13.8 -> 2.13.11
```

To

```
+--- org.json4s:json4s-native_2.13:3.6.12
|    +--- org.scala-lang:scala-library:2.13.7 -> 2.13.11
|    \--- org.json4s:json4s-core_2.13:3.6.12
|         +--- org.scala-lang:scala-library:2.13.7 -> 2.13.11
|         +--- org.json4s:json4s-ast_2.13:3.6.12
|         |    \--- org.scala-lang:scala-library:2.13.7 -> 2.13.11
|         +--- org.json4s:json4s-scalap_2.13:3.6.12
|         |    \--- org.scala-lang:scala-library:2.13.7 -> 2.13.11
|         \--- com.thoughtworks.paranamer:paranamer:2.
```