### PR TITLE
chore: scopt: 4.0.1 → 4.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation('org.parboiled:parboiled_2.13:2.4.1')
     implementation('org.scalactic:scalactic_2.13:3.2.15')
     implementation("org.scala-lang.modules:scala-parallel-collections_2.13:0.2.0")
-    implementation('com.github.scopt:scopt_2.13:4.0.1')
+    implementation('com.github.scopt:scopt_2.13:4.1.0')
     implementation('com.google.guava:guava:31.1-jre')
 
     // implementation("io.github.p-org.solvers:pjbdd:1.0.10-10-v5")


### PR DESCRIPTION
From 4.0.1 (2021-05-13) to 4.1.0 (2022-07-02)

From

```
+--- com.github.scopt:scopt_2.13:4.0.1
|    \--- org.scala-lang:scala-library:2.13.4 -> 2.13.11
```

To

```
+--- com.github.scopt:scopt_2.13:4.1.0
|    \--- org.scala-lang:scala-library:2.13.8 -> 2.13.11
```