### PR TITLE
chore: rename *Choice* to *Choose*

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -264,12 +264,12 @@ object Indexer {
 
     case Expression.RelationalChoose(exps, rules, _, _, _) =>
       visitExps(exps) ++ traverse(rules) {
-        case RelationalChoiceRule(_, exp) => visitExp(exp)
+        case RelationalChooseRule(_, exp) => visitExp(exp)
       } ++ Index.occurrenceOf(exp0)
 
     case Expression.RestrictableChoose(_, exp, rules, _, _, _) =>
       visitExp(exp) ++ traverse(rules) {
-        case RestrictableChoiceRule(_, body) => visitExp(body)
+        case RestrictableChooseRule(_, body) => visitExp(body)
       } ++ Index.occurrenceOf(exp0)
 
     case Expression.Tag(Ast.CaseSymUse(sym, loc), exp, _, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -112,9 +112,9 @@ object KindedAst {
 
     case class TypeMatch(exp: KindedAst.Expression, rules: List[KindedAst.TypeMatchRule], loc: SourceLocation) extends KindedAst.Expression
 
-    case class RelationalChoose(star: Boolean, exps: List[KindedAst.Expression], rules: List[KindedAst.RelationalChoiceRule], tpe: Type.Var, loc: SourceLocation) extends KindedAst.Expression
+    case class RelationalChoose(star: Boolean, exps: List[KindedAst.Expression], rules: List[KindedAst.RelationalChooseRule], tpe: Type.Var, loc: SourceLocation) extends KindedAst.Expression
 
-    case class RestrictableChoose(star: Boolean, exp: KindedAst.Expression, rules: List[KindedAst.RestrictableChoiceRule], tpe: Type.Var, loc: SourceLocation) extends KindedAst.Expression
+    case class RestrictableChoose(star: Boolean, exp: KindedAst.Expression, rules: List[KindedAst.RestrictableChooseRule], tpe: Type.Var, loc: SourceLocation) extends KindedAst.Expression
 
     case class Tag(sym: Ast.CaseSymUse, exp: KindedAst.Expression, tpe: Type.Var, loc: SourceLocation) extends KindedAst.Expression
 
@@ -242,25 +242,25 @@ object KindedAst {
 
   }
 
-  sealed trait RelationalChoicePattern {
+  sealed trait RelationalChoosePattern {
     def loc: SourceLocation
   }
 
-  object RelationalChoicePattern {
+  object RelationalChoosePattern {
 
-    case class Wild(loc: SourceLocation) extends RelationalChoicePattern
+    case class Wild(loc: SourceLocation) extends RelationalChoosePattern
 
-    case class Absent(loc: SourceLocation) extends RelationalChoicePattern
+    case class Absent(loc: SourceLocation) extends RelationalChoosePattern
 
-    case class Present(sym: Symbol.VarSym, tvar: ast.Type.Var, loc: SourceLocation) extends RelationalChoicePattern
+    case class Present(sym: Symbol.VarSym, tvar: ast.Type.Var, loc: SourceLocation) extends RelationalChoosePattern
 
   }
 
-  sealed trait RestrictableChoicePattern {
+  sealed trait RestrictableChoosePattern {
     def loc: SourceLocation
   }
 
-  object RestrictableChoicePattern {
+  object RestrictableChoosePattern {
 
     sealed trait VarOrWild
 
@@ -268,7 +268,7 @@ object KindedAst {
 
     case class Var(sym: Symbol.VarSym, tvar: Type.Var, loc: SourceLocation) extends VarOrWild
 
-    case class Tag(sym: Ast.RestrictableCaseSymUse, pat: List[VarOrWild], tvar: Type.Var, loc: SourceLocation) extends RestrictableChoicePattern
+    case class Tag(sym: Ast.RestrictableCaseSymUse, pat: List[VarOrWild], tvar: Type.Var, loc: SourceLocation) extends RestrictableChoosePattern
 
   }
 
@@ -318,9 +318,9 @@ object KindedAst {
 
   case class HandlerRule(op: Ast.OpSymUse, fparams: List[KindedAst.FormalParam], exp: KindedAst.Expression, tvar: Type.Var)
 
-  case class RelationalChoiceRule(pat: List[KindedAst.RelationalChoicePattern], exp: KindedAst.Expression)
+  case class RelationalChooseRule(pat: List[KindedAst.RelationalChoosePattern], exp: KindedAst.Expression)
 
-  case class RestrictableChoiceRule(pat: KindedAst.RestrictableChoicePattern, exp: KindedAst.Expression)
+  case class RestrictableChooseRule(pat: KindedAst.RestrictableChoosePattern, exp: KindedAst.Expression)
 
   case class MatchRule(pat: KindedAst.Pattern, guard: Option[KindedAst.Expression], exp: KindedAst.Expression)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
@@ -129,7 +129,7 @@ object LoweredAst {
 
     case class TypeMatch(exp: LoweredAst.Expression, rules: List[LoweredAst.TypeMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends LoweredAst.Expression
 
-    case class RelationalChoose(exps: List[LoweredAst.Expression], rules: List[LoweredAst.RelationalChoiceRule], tpe: Type, eff: Type, loc: SourceLocation) extends LoweredAst.Expression
+    case class RelationalChoose(exps: List[LoweredAst.Expression], rules: List[LoweredAst.RelationalChooseRule], tpe: Type, eff: Type, loc: SourceLocation) extends LoweredAst.Expression
 
     case class Tag(sym: Ast.CaseSymUse, exp: LoweredAst.Expression, tpe: Type, eff: Type, loc: SourceLocation) extends LoweredAst.Expression
 
@@ -245,17 +245,17 @@ object LoweredAst {
 
   }
 
-  sealed trait RelationalChoicePattern {
+  sealed trait RelationalChoosePattern {
     def loc: SourceLocation
   }
 
-  object RelationalChoicePattern {
+  object RelationalChoosePattern {
 
-    case class Wild(loc: SourceLocation) extends RelationalChoicePattern
+    case class Wild(loc: SourceLocation) extends RelationalChoosePattern
 
-    case class Absent(loc: SourceLocation) extends RelationalChoicePattern
+    case class Absent(loc: SourceLocation) extends RelationalChoosePattern
 
-    case class Present(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends RelationalChoicePattern
+    case class Present(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends RelationalChoosePattern
 
   }
 
@@ -319,7 +319,7 @@ object LoweredAst {
 
   case class HandlerRule(op: Ast.OpSymUse, fparams: List[LoweredAst.FormalParam], exp: LoweredAst.Expression)
 
-  case class RelationalChoiceRule(pat: List[LoweredAst.RelationalChoicePattern], exp: LoweredAst.Expression)
+  case class RelationalChooseRule(pat: List[LoweredAst.RelationalChoosePattern], exp: LoweredAst.Expression)
 
   case class MatchRule(pat: LoweredAst.Pattern, guard: Option[LoweredAst.Expression], exp: LoweredAst.Expression)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -129,9 +129,9 @@ object NamedAst {
 
     case class TypeMatch(exp: NamedAst.Expression, rules: List[NamedAst.TypeMatchRule], loc: SourceLocation) extends NamedAst.Expression
 
-    case class RelationalChoose(star: Boolean, exps: List[NamedAst.Expression], rules: List[NamedAst.RelationalChoiceRule], loc: SourceLocation) extends NamedAst.Expression
+    case class RelationalChoose(star: Boolean, exps: List[NamedAst.Expression], rules: List[NamedAst.RelationalChooseRule], loc: SourceLocation) extends NamedAst.Expression
 
-    case class RestrictableChoose(star: Boolean, exp: NamedAst.Expression, rules: List[NamedAst.RestrictableChoiceRule], loc: SourceLocation) extends NamedAst.Expression
+    case class RestrictableChoose(star: Boolean, exp: NamedAst.Expression, rules: List[NamedAst.RestrictableChooseRule], loc: SourceLocation) extends NamedAst.Expression
 
     case class Tuple(elms: List[NamedAst.Expression], loc: SourceLocation) extends NamedAst.Expression
 
@@ -255,21 +255,21 @@ object NamedAst {
 
   }
 
-  sealed trait RelationalChoicePattern
+  sealed trait RelationalChoosePattern
 
-  object RelationalChoicePattern {
+  object RelationalChoosePattern {
 
-    case class Wild(loc: SourceLocation) extends RelationalChoicePattern
+    case class Wild(loc: SourceLocation) extends RelationalChoosePattern
 
-    case class Absent(loc: SourceLocation) extends RelationalChoicePattern
+    case class Absent(loc: SourceLocation) extends RelationalChoosePattern
 
-    case class Present(sym: Symbol.VarSym, loc: SourceLocation) extends RelationalChoicePattern
+    case class Present(sym: Symbol.VarSym, loc: SourceLocation) extends RelationalChoosePattern
 
   }
 
-  sealed trait RestrictableChoicePattern
+  sealed trait RestrictableChoosePattern
 
-  object RestrictableChoicePattern {
+  object RestrictableChoosePattern {
 
     sealed trait VarOrWild
 
@@ -277,7 +277,7 @@ object NamedAst {
 
     case class Var(sym: Symbol.VarSym, loc: SourceLocation) extends VarOrWild
 
-    case class Tag(qname: Name.QName, pat: List[VarOrWild], loc: SourceLocation) extends RestrictableChoicePattern
+    case class Tag(qname: Name.QName, pat: List[VarOrWild], loc: SourceLocation) extends RestrictableChoosePattern
 
   }
 
@@ -418,9 +418,9 @@ object NamedAst {
 
   case class HandlerRule(op: Name.Ident, fparams: List[NamedAst.FormalParam], exp: NamedAst.Expression)
 
-  case class RelationalChoiceRule(pat: List[NamedAst.RelationalChoicePattern], exp: NamedAst.Expression)
+  case class RelationalChooseRule(pat: List[NamedAst.RelationalChoosePattern], exp: NamedAst.Expression)
 
-  case class RestrictableChoiceRule(pat: NamedAst.RestrictableChoicePattern, exp: NamedAst.Expression)
+  case class RestrictableChooseRule(pat: NamedAst.RestrictableChoosePattern, exp: NamedAst.Expression)
 
   case class MatchRule(pat: NamedAst.Pattern, guard: Option[NamedAst.Expression], exp: NamedAst.Expression)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -778,7 +778,7 @@ object ParsedAst {
       * @param rules the rules of the pattern match.
       * @param sp2   the position of the last character in the expression.
       */
-    case class RelationalChoose(sp1: SourcePosition, star: Boolean, exps: Seq[ParsedAst.Expression], rules: Seq[RelationalChoiceRule], sp2: SourcePosition) extends ParsedAst.Expression
+    case class RelationalChoose(sp1: SourcePosition, star: Boolean, exps: Seq[ParsedAst.Expression], rules: Seq[RelationalChooseRule], sp2: SourcePosition) extends ParsedAst.Expression
 
     /**
       * Restrictable Choose Expression.
@@ -1269,9 +1269,9 @@ object ParsedAst {
   /**
     * Relational Choice Patterns.
     */
-  sealed trait RelationalChoicePattern
+  sealed trait RelationalChoosePattern
 
-  object RelationalChoicePattern {
+  object RelationalChoosePattern {
 
     /**
       * A wildcard pattern.
@@ -1279,12 +1279,12 @@ object ParsedAst {
       * @param sp1 the position of the first character in the pattern.
       * @param sp2 the position of the last character in the pattern.
       */
-    case class Wild(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.RelationalChoicePattern
+    case class Wild(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.RelationalChoosePattern
 
     /**
       * An absent pattern.
       */
-    case class Absent(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.RelationalChoicePattern
+    case class Absent(sp1: SourcePosition, sp2: SourcePosition) extends ParsedAst.RelationalChoosePattern
 
     /**
       * A present pattern.
@@ -1293,7 +1293,7 @@ object ParsedAst {
       * @param ident the name of the variable.
       * @param sp2   the position of the last character in the pattern.
       */
-    case class Present(sp1: SourcePosition, ident: Name.Ident, sp2: SourcePosition) extends ParsedAst.RelationalChoicePattern
+    case class Present(sp1: SourcePosition, ident: Name.Ident, sp2: SourcePosition) extends ParsedAst.RelationalChoosePattern
 
   }
 
@@ -1855,7 +1855,7 @@ object ParsedAst {
     * @param exp the body expression of the rule.
     * @param sp2 the position of the first character in the rule.
     */
-  case class RelationalChoiceRule(sp1: SourcePosition, pat: Seq[ParsedAst.RelationalChoicePattern], exp: ParsedAst.Expression, sp2: SourcePosition)
+  case class RelationalChooseRule(sp1: SourcePosition, pat: Seq[ParsedAst.RelationalChoosePattern], exp: ParsedAst.Expression, sp2: SourcePosition)
 
   /**
     * A type match rule consists of a variable, a type, and a body expression.

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -128,9 +128,9 @@ object ResolvedAst {
 
     case class TypeMatch(exp: ResolvedAst.Expression, rules: List[ResolvedAst.TypeMatchRule], loc: SourceLocation) extends ResolvedAst.Expression
 
-    case class RelationalChoose(star: Boolean, exps: List[ResolvedAst.Expression], rules: List[ResolvedAst.RelationalChoiceRule], loc: SourceLocation) extends ResolvedAst.Expression
+    case class RelationalChoose(star: Boolean, exps: List[ResolvedAst.Expression], rules: List[ResolvedAst.RelationalChooseRule], loc: SourceLocation) extends ResolvedAst.Expression
 
-    case class RestrictableChoose(star: Boolean, exp: ResolvedAst.Expression, rules: List[ResolvedAst.RestrictableChoiceRule], loc: SourceLocation) extends ResolvedAst.Expression
+    case class RestrictableChoose(star: Boolean, exp: ResolvedAst.Expression, rules: List[ResolvedAst.RestrictableChooseRule], loc: SourceLocation) extends ResolvedAst.Expression
 
     case class Tag(sym: Ast.CaseSymUse, exp: ResolvedAst.Expression, loc: SourceLocation) extends ResolvedAst.Expression
 
@@ -258,23 +258,23 @@ object ResolvedAst {
 
   }
 
-  sealed trait RelationalChoicePattern {
+  sealed trait RelationalChoosePattern {
     def loc: SourceLocation
   }
 
-  object RelationalChoicePattern {
+  object RelationalChoosePattern {
 
-    case class Wild(loc: SourceLocation) extends RelationalChoicePattern
+    case class Wild(loc: SourceLocation) extends RelationalChoosePattern
 
-    case class Absent(loc: SourceLocation) extends RelationalChoicePattern
+    case class Absent(loc: SourceLocation) extends RelationalChoosePattern
 
-    case class Present(sym: Symbol.VarSym, loc: SourceLocation) extends RelationalChoicePattern
+    case class Present(sym: Symbol.VarSym, loc: SourceLocation) extends RelationalChoosePattern
 
   }
 
-  sealed trait RestrictableChoicePattern
+  sealed trait RestrictableChoosePattern
 
-  object RestrictableChoicePattern {
+  object RestrictableChoosePattern {
 
     sealed trait VarOrWild
 
@@ -282,7 +282,7 @@ object ResolvedAst {
 
     case class Var(sym: Symbol.VarSym, loc: SourceLocation) extends VarOrWild
 
-    case class Tag(sym: Ast.RestrictableCaseSymUse, pat: List[VarOrWild], loc: SourceLocation) extends RestrictableChoicePattern
+    case class Tag(sym: Ast.RestrictableCaseSymUse, pat: List[VarOrWild], loc: SourceLocation) extends RestrictableChoosePattern
 
   }
 
@@ -348,9 +348,9 @@ object ResolvedAst {
 
   case class HandlerRule(op: Ast.OpSymUse, fparams: Seq[ResolvedAst.FormalParam], exp: ResolvedAst.Expression)
 
-  case class RelationalChoiceRule(pat: List[ResolvedAst.RelationalChoicePattern], exp: ResolvedAst.Expression)
+  case class RelationalChooseRule(pat: List[ResolvedAst.RelationalChoosePattern], exp: ResolvedAst.Expression)
 
-  case class RestrictableChoiceRule(pat: ResolvedAst.RestrictableChoicePattern, exp: ResolvedAst.Expression)
+  case class RestrictableChooseRule(pat: ResolvedAst.RestrictableChoosePattern, exp: ResolvedAst.Expression)
 
   case class MatchRule(pat: ResolvedAst.Pattern, guard: Option[ResolvedAst.Expression], exp: ResolvedAst.Expression)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -146,9 +146,9 @@ object TypedAst {
 
     case class TypeMatch(exp: TypedAst.Expression, rules: List[TypedAst.TypeMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends TypedAst.Expression
 
-    case class RelationalChoose(exps: List[TypedAst.Expression], rules: List[TypedAst.RelationalChoiceRule], tpe: Type, eff: Type, loc: SourceLocation) extends TypedAst.Expression
+    case class RelationalChoose(exps: List[TypedAst.Expression], rules: List[TypedAst.RelationalChooseRule], tpe: Type, eff: Type, loc: SourceLocation) extends TypedAst.Expression
 
-    case class RestrictableChoose(star: Boolean, exp: TypedAst.Expression, rules: List[TypedAst.RestrictableChoiceRule], tpe: Type, eff: Type, loc: SourceLocation) extends TypedAst.Expression
+    case class RestrictableChoose(star: Boolean, exp: TypedAst.Expression, rules: List[TypedAst.RestrictableChooseRule], tpe: Type, eff: Type, loc: SourceLocation) extends TypedAst.Expression
 
     case class Tag(sym: Ast.CaseSymUse, exp: TypedAst.Expression, tpe: Type, eff: Type, loc: SourceLocation) extends TypedAst.Expression
 
@@ -300,23 +300,23 @@ object TypedAst {
 
   }
 
-  sealed trait RelationalChoicePattern {
+  sealed trait RelationalChoosePattern {
     def loc: SourceLocation
   }
 
-  object RelationalChoicePattern {
+  object RelationalChoosePattern {
 
-    case class Wild(loc: SourceLocation) extends RelationalChoicePattern
+    case class Wild(loc: SourceLocation) extends RelationalChoosePattern
 
-    case class Absent(loc: SourceLocation) extends RelationalChoicePattern
+    case class Absent(loc: SourceLocation) extends RelationalChoosePattern
 
-    case class Present(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends RelationalChoicePattern
+    case class Present(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends RelationalChoosePattern
 
   }
 
-  sealed trait RestrictableChoicePattern
+  sealed trait RestrictableChoosePattern
 
-  object RestrictableChoicePattern {
+  object RestrictableChoosePattern {
 
     sealed trait VarOrWild
 
@@ -324,7 +324,7 @@ object TypedAst {
 
     case class Var(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends VarOrWild
 
-    case class Tag(sym: Ast.RestrictableCaseSymUse, pat: List[VarOrWild], tpe: Type, loc: SourceLocation) extends RestrictableChoicePattern
+    case class Tag(sym: Ast.RestrictableCaseSymUse, pat: List[VarOrWild], tpe: Type, loc: SourceLocation) extends RestrictableChoosePattern
 
   }
 
@@ -376,9 +376,9 @@ object TypedAst {
 
   case class HandlerRule(op: Ast.OpSymUse, fparams: List[TypedAst.FormalParam], exp: TypedAst.Expression)
 
-  case class RelationalChoiceRule(pat: List[TypedAst.RelationalChoicePattern], exp: TypedAst.Expression)
+  case class RelationalChooseRule(pat: List[TypedAst.RelationalChoosePattern], exp: TypedAst.Expression)
 
-  case class RestrictableChoiceRule(pat: TypedAst.RestrictableChoicePattern, exp: TypedAst.Expression)
+  case class RestrictableChooseRule(pat: TypedAst.RestrictableChoosePattern, exp: TypedAst.Expression)
 
   case class MatchRule(pat: TypedAst.Pattern, guard: Option[TypedAst.Expression], exp: TypedAst.Expression)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -119,9 +119,9 @@ object WeededAst {
 
     case class TypeMatch(exp: WeededAst.Expression, rules: List[WeededAst.TypeMatchRule], loc: SourceLocation) extends WeededAst.Expression
 
-    case class RelationalChoose(star: Boolean, exps: List[WeededAst.Expression], rules: List[WeededAst.RelationalChoiceRule], loc: SourceLocation) extends WeededAst.Expression
+    case class RelationalChoose(star: Boolean, exps: List[WeededAst.Expression], rules: List[WeededAst.RelationalChooseRule], loc: SourceLocation) extends WeededAst.Expression
 
-    case class RestrictableChoose(star: Boolean, exp: WeededAst.Expression, rules: List[WeededAst.RestrictableChoiceRule], loc: SourceLocation) extends WeededAst.Expression
+    case class RestrictableChoose(star: Boolean, exp: WeededAst.Expression, rules: List[WeededAst.RestrictableChooseRule], loc: SourceLocation) extends WeededAst.Expression
 
     case class Tuple(exps: List[WeededAst.Expression], loc: SourceLocation) extends WeededAst.Expression
 
@@ -245,23 +245,23 @@ object WeededAst {
 
   }
 
-  sealed trait RelationalChoicePattern
+  sealed trait RelationalChoosePattern
 
-  object RelationalChoicePattern {
+  object RelationalChoosePattern {
 
-    case class Wild(loc: SourceLocation) extends RelationalChoicePattern
+    case class Wild(loc: SourceLocation) extends RelationalChoosePattern
 
-    case class Absent(loc: SourceLocation) extends RelationalChoicePattern
+    case class Absent(loc: SourceLocation) extends RelationalChoosePattern
 
-    case class Present(ident: Name.Ident, loc: SourceLocation) extends RelationalChoicePattern
+    case class Present(ident: Name.Ident, loc: SourceLocation) extends RelationalChoosePattern
 
   }
 
-  sealed trait RestrictableChoicePattern {
+  sealed trait RestrictableChoosePattern {
     def loc: SourceLocation
   }
 
-  object RestrictableChoicePattern {
+  object RestrictableChoosePattern {
 
     sealed trait VarOrWild
 
@@ -269,7 +269,7 @@ object WeededAst {
 
     case class Var(ident: Name.Ident, loc: SourceLocation) extends VarOrWild
 
-    case class Tag(qname: Name.QName, pat: List[VarOrWild], loc: SourceLocation) extends RestrictableChoicePattern
+    case class Tag(qname: Name.QName, pat: List[VarOrWild], loc: SourceLocation) extends RestrictableChoosePattern
 
   }
 
@@ -408,9 +408,9 @@ object WeededAst {
 
   case class HandlerRule(op: Name.Ident, fparams: List[WeededAst.FormalParam], exp: WeededAst.Expression)
 
-  case class RelationalChoiceRule(pat: List[WeededAst.RelationalChoicePattern], exp: WeededAst.Expression)
+  case class RelationalChooseRule(pat: List[WeededAst.RelationalChoosePattern], exp: WeededAst.Expression)
 
-  case class RestrictableChoiceRule(pat: WeededAst.RestrictableChoicePattern, exp: WeededAst.Expression)
+  case class RestrictableChooseRule(pat: WeededAst.RestrictableChoosePattern, exp: WeededAst.Expression)
 
   case class TypeConstraint(clazz: Name.QName, tpe: WeededAst.Type, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
@@ -194,14 +194,14 @@ object TypedAstOps {
         case (acc, exp) => acc ++ freeVars(exp)
       }
       val rs = rules.foldLeft(Map.empty[Symbol.VarSym, Type]) {
-        case (acc, RelationalChoiceRule(pats, exp)) => acc ++ (freeVars(exp) -- pats.flatMap(freeVars))
+        case (acc, RelationalChooseRule(pats, exp)) => acc ++ (freeVars(exp) -- pats.flatMap(freeVars))
       }
       es ++ rs
 
     case Expression.RestrictableChoose(_, exp, rules, _, _, _) =>
       val e = freeVars(exp)
       val rs = rules.foldLeft(Map.empty[Symbol.VarSym, Type]) {
-        case (acc, RestrictableChoiceRule(pat, exp)) => acc ++ (freeVars(exp) -- freeVars(pat).toList)
+        case (acc, RestrictableChooseRule(pat, exp)) => acc ++ (freeVars(exp) -- freeVars(pat).toList)
       }
       e ++ rs
 
@@ -405,22 +405,22 @@ object TypedAstOps {
   /**
     * Returns the free variables in the given pattern `pat0`.
     */
-  private def freeVars(pat0: RelationalChoicePattern): Set[Symbol.VarSym] = pat0 match {
-    case RelationalChoicePattern.Wild(_) => Set.empty
-    case RelationalChoicePattern.Absent(_) => Set.empty
-    case RelationalChoicePattern.Present(sym, _, _) => Set(sym)
+  private def freeVars(pat0: RelationalChoosePattern): Set[Symbol.VarSym] = pat0 match {
+    case RelationalChoosePattern.Wild(_) => Set.empty
+    case RelationalChoosePattern.Absent(_) => Set.empty
+    case RelationalChoosePattern.Present(sym, _, _) => Set(sym)
   }
 
   /**
     * Returns the free variables in the given restrictable pattern `pat0`.
     */
-  private def freeVars(pat0: RestrictableChoicePattern): Set[Symbol.VarSym] = pat0 match {
-    case RestrictableChoicePattern.Tag(_, pat, _, _) => pat.flatMap(freeVars).toSet
+  private def freeVars(pat0: RestrictableChoosePattern): Set[Symbol.VarSym] = pat0 match {
+    case RestrictableChoosePattern.Tag(_, pat, _, _) => pat.flatMap(freeVars).toSet
   }
 
-  private def freeVars(v: RestrictableChoicePattern.VarOrWild): Option[Symbol.VarSym] = v match {
-    case RestrictableChoicePattern.Wild(_, _) => None
-    case RestrictableChoicePattern.Var(sym, _, _) => Some(sym)
+  private def freeVars(v: RestrictableChoosePattern.VarOrWild): Option[Symbol.VarSym] = v match {
+    case RestrictableChoosePattern.Wild(_, _) => None
+    case RestrictableChoosePattern.Var(sym, _, _) => Some(sym)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.language.dbg.printer
 
 import ca.uwaterloo.flix.language.ast.LoweredAst
-import ca.uwaterloo.flix.language.ast.LoweredAst.{Expression, Pattern, RelationalChoicePattern}
+import ca.uwaterloo.flix.language.ast.LoweredAst.{Expression, Pattern, RelationalChoosePattern}
 import ca.uwaterloo.flix.language.dbg.DocAst
 
 object LoweredAstPrinter {
@@ -91,8 +91,8 @@ object LoweredAstPrinter {
     case Expression.RelationalChoose(exps, rules, tpe, eff, loc) =>
       val expD = DocAst.Expression.Tuple(exps.map(print))
       val rulesD = rules.map {
-        case LoweredAst.RelationalChoiceRule(pat, body) =>
-          val patD = DocAst.Expression.Tuple(pat.map(printRelationalChoicePattern))
+        case LoweredAst.RelationalChooseRule(pat, body) =>
+          val patD = DocAst.Expression.Tuple(pat.map(printRelationalChoosePattern))
           val guardD = None
           val bodyD = print(body)
           (patD, guardD, bodyD)
@@ -168,10 +168,10 @@ object LoweredAstPrinter {
   /**
     * Converts the given pattern into a [[DocAst.Expression]].
     */
-  private def printRelationalChoicePattern(pat: LoweredAst.RelationalChoicePattern): DocAst.Expression = pat match {
-    case RelationalChoicePattern.Wild(loc) => DocAst.Expression.Wild
-    case RelationalChoicePattern.Absent(loc) => DocAst.Expression.Absent
-    case RelationalChoicePattern.Present(sym, tpe, loc) => DocAst.Expression.Present(DocAst.Expression.Var(sym))
+  private def printRelationalChoosePattern(pat: LoweredAst.RelationalChoosePattern): DocAst.Expression = pat match {
+    case RelationalChoosePattern.Wild(loc) => DocAst.Expression.Wild
+    case RelationalChoosePattern.Absent(loc) => DocAst.Expression.Absent
+    case RelationalChoosePattern.Present(sym, tpe, loc) => DocAst.Expression.Present(DocAst.Expression.Var(sym))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -427,7 +427,7 @@ object WeederError {
     * @param star whether the choose is of the star kind.
     * @param loc  the location where the error occurs.
     */
-  case class RestrictableChoiceGuard(star: Boolean, loc: SourceLocation) extends WeederError {
+  case class RestrictableChooseGuard(star: Boolean, loc: SourceLocation) extends WeederError {
     private val operationName: String = if (star) "choose*" else "choose"
 
     def summary: String = s"cases of $operationName do not allow guards."

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -554,14 +554,14 @@ object Kinder {
 
     case ResolvedAst.Expression.RelationalChoose(star, exps0, rules0, loc) =>
       val expsVal = traverse(exps0)(visitExp(_, kenv0, taenv, henv0, root))
-      val rulesVal = traverse(rules0)(visitRelationalChoiceRule(_, kenv0, taenv, henv0, root))
+      val rulesVal = traverse(rules0)(visitRelationalChooseRule(_, kenv0, taenv, henv0, root))
       mapN(expsVal, rulesVal) {
         case (exps, rules) => KindedAst.Expression.RelationalChoose(star, exps, rules, Type.freshVar(Kind.Star, loc.asSynthetic), loc)
       }
 
     case ResolvedAst.Expression.RestrictableChoose(star, exp0, rules0, loc) =>
       val expVal = visitExp(exp0, kenv0, taenv, henv0, root)
-      val rulesVal = traverse(rules0)(visitRestrictableChoiceRule(_, kenv0, taenv, henv0, root))
+      val rulesVal = traverse(rules0)(visitRestrictableChooseRule(_, kenv0, taenv, henv0, root))
       mapN(expVal, rulesVal) {
         case (exp, rules) => KindedAst.Expression.RestrictableChoose(star, exp, rules, Type.freshVar(Kind.Star, loc.asSynthetic), loc)
       }
@@ -987,24 +987,24 @@ object Kinder {
   /**
     * Performs kinding on the given relational choice rule under the given kind environment.
     */
-  private def visitRelationalChoiceRule(rule0: ResolvedAst.RelationalChoiceRule, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], henv: Option[(Type.Var, Type.Var)], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.RelationalChoiceRule, KindError] = rule0 match {
-    case ResolvedAst.RelationalChoiceRule(pat0, exp0) =>
-      val patVal = traverse(pat0)(visitRelationalChoicePattern)
+  private def visitRelationalChooseRule(rule0: ResolvedAst.RelationalChooseRule, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], henv: Option[(Type.Var, Type.Var)], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.RelationalChooseRule, KindError] = rule0 match {
+    case ResolvedAst.RelationalChooseRule(pat0, exp0) =>
+      val patVal = traverse(pat0)(visitRelationalChoosePattern)
       val expVal = visitExp(exp0, kenv, taenv, henv, root)
       mapN(patVal, expVal) {
-        case (pat, exp) => KindedAst.RelationalChoiceRule(pat, exp)
+        case (pat, exp) => KindedAst.RelationalChooseRule(pat, exp)
       }
   }
 
   /**
     * Performs kinding on the given relational choice rule under the given kind environment.
     */
-  private def visitRestrictableChoiceRule(rule0: ResolvedAst.RestrictableChoiceRule, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], henv: Option[(Type.Var, Type.Var)], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.RestrictableChoiceRule, KindError] = rule0 match {
-    case ResolvedAst.RestrictableChoiceRule(pat0, exp0) =>
-      val patVal = visitRestrictableChoicePattern(pat0)
+  private def visitRestrictableChooseRule(rule0: ResolvedAst.RestrictableChooseRule, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], henv: Option[(Type.Var, Type.Var)], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.RestrictableChooseRule, KindError] = rule0 match {
+    case ResolvedAst.RestrictableChooseRule(pat0, exp0) =>
+      val patVal = visitRestrictableChoosePattern(pat0)
       val expVal = visitExp(exp0, kenv, taenv, henv, root)
       mapN(patVal, expVal) {
-        case (pat, exp) => KindedAst.RestrictableChoiceRule(pat, exp)
+        case (pat, exp) => KindedAst.RestrictableChooseRule(pat, exp)
       }
   }
 
@@ -1070,29 +1070,29 @@ object Kinder {
   /**
     * Performs kinding on the given relational choice pattern under the given kind environment.
     */
-  private def visitRelationalChoicePattern(pat0: ResolvedAst.RelationalChoicePattern)(implicit flix: Flix): Validation[KindedAst.RelationalChoicePattern, KindError] = pat0 match {
-    case ResolvedAst.RelationalChoicePattern.Wild(loc) => KindedAst.RelationalChoicePattern.Wild(loc).toSuccess
-    case ResolvedAst.RelationalChoicePattern.Absent(loc) => KindedAst.RelationalChoicePattern.Absent(loc).toSuccess
-    case ResolvedAst.RelationalChoicePattern.Present(sym, loc) => KindedAst.RelationalChoicePattern.Present(sym, Type.freshVar(Kind.Star, loc.asSynthetic), loc).toSuccess
+  private def visitRelationalChoosePattern(pat0: ResolvedAst.RelationalChoosePattern)(implicit flix: Flix): Validation[KindedAst.RelationalChoosePattern, KindError] = pat0 match {
+    case ResolvedAst.RelationalChoosePattern.Wild(loc) => KindedAst.RelationalChoosePattern.Wild(loc).toSuccess
+    case ResolvedAst.RelationalChoosePattern.Absent(loc) => KindedAst.RelationalChoosePattern.Absent(loc).toSuccess
+    case ResolvedAst.RelationalChoosePattern.Present(sym, loc) => KindedAst.RelationalChoosePattern.Present(sym, Type.freshVar(Kind.Star, loc.asSynthetic), loc).toSuccess
   }
 
   /**
     * Performs kinding on the given restrictable choice pattern under the given kind environment.
     */
-  private def visitRestrictableChoicePattern(pat00: ResolvedAst.RestrictableChoicePattern)(implicit flix: Flix): Validation[KindedAst.RestrictableChoicePattern, KindError] = pat00 match {
-    case ResolvedAst.RestrictableChoicePattern.Tag(sym, pat0, loc) =>
-      val patVal = traverse(pat0)(visitRestrictableChoicePatternVarOrWild)
+  private def visitRestrictableChoosePattern(pat00: ResolvedAst.RestrictableChoosePattern)(implicit flix: Flix): Validation[KindedAst.RestrictableChoosePattern, KindError] = pat00 match {
+    case ResolvedAst.RestrictableChoosePattern.Tag(sym, pat0, loc) =>
+      val patVal = traverse(pat0)(visitRestrictableChoosePatternVarOrWild)
       mapN(patVal) {
-        case pat => KindedAst.RestrictableChoicePattern.Tag(sym, pat, Type.freshVar(Kind.Star, loc.asSynthetic), loc)
+        case pat => KindedAst.RestrictableChoosePattern.Tag(sym, pat, Type.freshVar(Kind.Star, loc.asSynthetic), loc)
       }
   }
 
   /**
     * Performs kinding on the given restrictable choice pattern under the given kind environment.
     */
-  private def visitRestrictableChoicePatternVarOrWild(pat0: ResolvedAst.RestrictableChoicePattern.VarOrWild)(implicit flix: Flix): Validation[KindedAst.RestrictableChoicePattern.VarOrWild, KindError] = pat0 match {
-    case ResolvedAst.RestrictableChoicePattern.Wild(loc) => KindedAst.RestrictableChoicePattern.Wild(Type.freshVar(Kind.Star, loc.asSynthetic), loc).toSuccess
-    case ResolvedAst.RestrictableChoicePattern.Var(sym, loc) => KindedAst.RestrictableChoicePattern.Var(sym, Type.freshVar(Kind.Star, loc.asSynthetic), loc).toSuccess
+  private def visitRestrictableChoosePatternVarOrWild(pat0: ResolvedAst.RestrictableChoosePattern.VarOrWild)(implicit flix: Flix): Validation[KindedAst.RestrictableChoosePattern.VarOrWild, KindError] = pat0 match {
+    case ResolvedAst.RestrictableChoosePattern.Wild(loc) => KindedAst.RestrictableChoosePattern.Wild(Type.freshVar(Kind.Star, loc.asSynthetic), loc).toSuccess
+    case ResolvedAst.RestrictableChoosePattern.Var(sym, loc) => KindedAst.RestrictableChoosePattern.Var(sym, Type.freshVar(Kind.Star, loc.asSynthetic), loc).toSuccess
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -453,14 +453,14 @@ object Lowering {
 
     case TypedAst.Expression.RelationalChoose(exps, rules, tpe, eff, loc) =>
       val es = visitExps(exps)
-      val rs = rules.map(visitRelationalChoiceRule)
+      val rs = rules.map(visitRelationalChooseRule)
       val t = visitType(tpe)
       LoweredAst.Expression.RelationalChoose(es, rs, t, eff, loc)
 
     case TypedAst.Expression.RestrictableChoose(_, exp, rules, tpe, eff, loc) =>
       // lower into an ordinary match
       val e = visitExp(exp)
-      val rs = rules.map(visitRestrictableChoiceRule)
+      val rs = rules.map(visitRestrictableChooseRule)
       val t = visitType(tpe)
       LoweredAst.Expression.Match(e, rs, t, eff, loc)
 
@@ -915,30 +915,30 @@ object Lowering {
   /**
     * Lowers the given relational choice rule `rule0`.
     */
-  private def visitRelationalChoiceRule(rule0: TypedAst.RelationalChoiceRule)(implicit root: TypedAst.Root, flix: Flix): LoweredAst.RelationalChoiceRule = rule0 match {
-    case TypedAst.RelationalChoiceRule(pat, exp) =>
+  private def visitRelationalChooseRule(rule0: TypedAst.RelationalChooseRule)(implicit root: TypedAst.Root, flix: Flix): LoweredAst.RelationalChooseRule = rule0 match {
+    case TypedAst.RelationalChooseRule(pat, exp) =>
       val p = pat.map {
-        case TypedAst.RelationalChoicePattern.Wild(loc) => LoweredAst.RelationalChoicePattern.Wild(loc)
-        case TypedAst.RelationalChoicePattern.Absent(loc) => LoweredAst.RelationalChoicePattern.Absent(loc)
-        case TypedAst.RelationalChoicePattern.Present(sym, tpe, loc) =>
+        case TypedAst.RelationalChoosePattern.Wild(loc) => LoweredAst.RelationalChoosePattern.Wild(loc)
+        case TypedAst.RelationalChoosePattern.Absent(loc) => LoweredAst.RelationalChoosePattern.Absent(loc)
+        case TypedAst.RelationalChoosePattern.Present(sym, tpe, loc) =>
           val t = visitType(tpe)
-          LoweredAst.RelationalChoicePattern.Present(sym, t, loc)
+          LoweredAst.RelationalChoosePattern.Present(sym, t, loc)
       }
       val e = visitExp(exp)
-      LoweredAst.RelationalChoiceRule(p, e)
+      LoweredAst.RelationalChooseRule(p, e)
   }
 
   /**
     * Lowers the given restrictable choice rule `rule0` to a match rule.
     */
-  private def visitRestrictableChoiceRule(rule0: TypedAst.RestrictableChoiceRule)(implicit root: TypedAst.Root, flix: Flix): LoweredAst.MatchRule = rule0 match {
-    case TypedAst.RestrictableChoiceRule(pat, exp) =>
+  private def visitRestrictableChooseRule(rule0: TypedAst.RestrictableChooseRule)(implicit root: TypedAst.Root, flix: Flix): LoweredAst.MatchRule = rule0 match {
+    case TypedAst.RestrictableChooseRule(pat, exp) =>
       val e = visitExp(exp)
       pat match {
-        case TypedAst.RestrictableChoicePattern.Tag(sym, pat0, tpe, loc) =>
+        case TypedAst.RestrictableChoosePattern.Tag(sym, pat0, tpe, loc) =>
           val termPatterns = pat0.map {
-            case TypedAst.RestrictableChoicePattern.Var(sym, tpe, loc) => LoweredAst.Pattern.Var(sym, tpe, loc)
-            case TypedAst.RestrictableChoicePattern.Wild(tpe, loc) => LoweredAst.Pattern.Wild(tpe, loc)
+            case TypedAst.RestrictableChoosePattern.Var(sym, tpe, loc) => LoweredAst.Pattern.Var(sym, tpe, loc)
+            case TypedAst.RestrictableChoosePattern.Wild(tpe, loc) => LoweredAst.Pattern.Wild(tpe, loc)
           }
           val pat1 = termPatterns match {
             case Nil => LoweredAst.Pattern.Cst(Constant.Unit, Type.mkUnit(loc), loc)
@@ -1980,9 +1980,9 @@ object Lowering {
     case LoweredAst.Expression.RelationalChoose(exps, rules, tpe, eff, loc) =>
       val es = exps.map(substExp(_, subst))
       val rs = rules map {
-        case LoweredAst.RelationalChoiceRule(pat, exp) =>
+        case LoweredAst.RelationalChooseRule(pat, exp) =>
           // TODO: Substitute in patterns?
-          LoweredAst.RelationalChoiceRule(pat, substExp(exp, subst))
+          LoweredAst.RelationalChooseRule(pat, substExp(exp, subst))
       }
       LoweredAst.Expression.RelationalChoose(es, rs, tpe, eff, loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorph.scala
@@ -448,20 +448,20 @@ object Monomorph {
     case Expression.RelationalChoose(exps, rules, tpe, eff, loc) =>
       val es = exps.map(visitExp(_, env0, subst))
       val rs = rules.map {
-        case RelationalChoiceRule(pat, exp) =>
+        case RelationalChooseRule(pat, exp) =>
           val patAndEnv = pat.map {
-            case RelationalChoicePattern.Wild(loc) => (RelationalChoicePattern.Wild(loc), Map.empty)
-            case RelationalChoicePattern.Absent(loc) => (RelationalChoicePattern.Absent(loc), Map.empty)
-            case RelationalChoicePattern.Present(sym, tpe1, loc) =>
+            case RelationalChoosePattern.Wild(loc) => (RelationalChoosePattern.Wild(loc), Map.empty)
+            case RelationalChoosePattern.Absent(loc) => (RelationalChoosePattern.Absent(loc), Map.empty)
+            case RelationalChoosePattern.Present(sym, tpe1, loc) =>
               val freshVar = Symbol.freshVarSym(sym)
-              (RelationalChoicePattern.Present(freshVar, subst(tpe1), loc), Map(sym -> freshVar))
+              (RelationalChoosePattern.Present(freshVar, subst(tpe1), loc), Map(sym -> freshVar))
           }
           val p = patAndEnv.map(_._1)
           val env1 = patAndEnv.map(_._2).foldLeft(Map.empty[Symbol.VarSym, Symbol.VarSym]) {
             case (acc, m) => acc ++ m
           }
           val e = visitExp(exp, env0 ++ env1, subst)
-          RelationalChoiceRule(p, e)
+          RelationalChooseRule(p, e)
       }
       Expression.RelationalChoose(es, rs, subst(tpe), subst(eff), loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.{BoundBy, Source}
-import ca.uwaterloo.flix.language.ast.WeededAst.RestrictableChoicePattern
+import ca.uwaterloo.flix.language.ast.WeededAst.RestrictableChoosePattern
 import ca.uwaterloo.flix.language.ast.{NamedAst, _}
 import ca.uwaterloo.flix.language.errors.NameError
 import ca.uwaterloo.flix.util.Validation._
@@ -717,16 +717,16 @@ object Namer {
     case WeededAst.Expression.RelationalChoose(star, exps, rules, loc) =>
       val expsVal = traverse(exps)(visitExp(_, ns0))
       val rulesVal = traverse(rules) {
-        case WeededAst.RelationalChoiceRule(pat0, exp0) =>
+        case WeededAst.RelationalChooseRule(pat0, exp0) =>
           val p = pat0.map {
-            case WeededAst.RelationalChoicePattern.Wild(loc) => NamedAst.RelationalChoicePattern.Wild(loc)
-            case WeededAst.RelationalChoicePattern.Absent(loc) => NamedAst.RelationalChoicePattern.Absent(loc)
-            case WeededAst.RelationalChoicePattern.Present(ident, loc) =>
+            case WeededAst.RelationalChoosePattern.Wild(loc) => NamedAst.RelationalChoosePattern.Wild(loc)
+            case WeededAst.RelationalChoosePattern.Absent(loc) => NamedAst.RelationalChoosePattern.Absent(loc)
+            case WeededAst.RelationalChoosePattern.Present(ident, loc) =>
               val sym = Symbol.freshVarSym(ident, BoundBy.Pattern)
-              NamedAst.RelationalChoicePattern.Present(sym, loc)
+              NamedAst.RelationalChoosePattern.Present(sym, loc)
           }
           mapN(visitExp(exp0, ns0)) {
-            case e => NamedAst.RelationalChoiceRule(p, e)
+            case e => NamedAst.RelationalChooseRule(p, e)
           }
       }
       mapN(expsVal, rulesVal) {
@@ -736,11 +736,11 @@ object Namer {
     case WeededAst.Expression.RestrictableChoose(star, exp, rules, loc) =>
       val expVal = visitExp(exp, ns0)
       val rulesVal = traverse(rules) {
-        case WeededAst.RestrictableChoiceRule(pat0, exp0) =>
+        case WeededAst.RestrictableChooseRule(pat0, exp0) =>
           val p = visitRestrictablePattern(pat0)
           val eVal = visitExp(exp0, ns0)
           mapN(eVal) {
-            case e => NamedAst.RestrictableChoiceRule(p, e)
+            case e => NamedAst.RestrictableChooseRule(p, e)
           }
       }
       mapN(expVal, rulesVal) {
@@ -1107,18 +1107,18 @@ object Namer {
   /**
     * Names the given pattern `pat0`
     */
-  private def visitRestrictablePattern(pat0: WeededAst.RestrictableChoicePattern)(implicit flix: Flix): NamedAst.RestrictableChoicePattern = {
-    def visitVarPlace(vp: WeededAst.RestrictableChoicePattern.VarOrWild): NamedAst.RestrictableChoicePattern.VarOrWild = vp match {
-      case RestrictableChoicePattern.Wild(loc) => NamedAst.RestrictableChoicePattern.Wild(loc)
-      case RestrictableChoicePattern.Var(ident, loc) =>
+  private def visitRestrictablePattern(pat0: WeededAst.RestrictableChoosePattern)(implicit flix: Flix): NamedAst.RestrictableChoosePattern = {
+    def visitVarPlace(vp: WeededAst.RestrictableChoosePattern.VarOrWild): NamedAst.RestrictableChoosePattern.VarOrWild = vp match {
+      case RestrictableChoosePattern.Wild(loc) => NamedAst.RestrictableChoosePattern.Wild(loc)
+      case RestrictableChoosePattern.Var(ident, loc) =>
         // make a fresh variable symbol for the local variable.
         val sym = Symbol.freshVarSym(ident, BoundBy.Pattern)
-        NamedAst.RestrictableChoicePattern.Var(sym, loc)
+        NamedAst.RestrictableChoosePattern.Var(sym, loc)
     }
 
     pat0 match {
-      case WeededAst.RestrictableChoicePattern.Tag(qname, pat, loc) =>
-        NamedAst.RestrictableChoicePattern.Tag(qname, pat.map(visitVarPlace), loc)
+      case WeededAst.RestrictableChoosePattern.Tag(qname, pat, loc) =>
+        NamedAst.RestrictableChoosePattern.Tag(qname, pat.map(visitVarPlace), loc)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -969,19 +969,19 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
         "(" ~ optWS ~ oneOrMore(Expression).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")"
       }
 
-      def ChoicePattern: Rule1[ParsedAst.RelationalChoicePattern] = rule {
-        (SP ~ "_" ~ SP ~> ParsedAst.RelationalChoicePattern.Wild) |
-          (SP ~ keyword("Absent") ~ SP ~> ParsedAst.RelationalChoicePattern.Absent) |
-          (SP ~ keyword("Present") ~ optWS ~ "(" ~ Names.Variable ~ ")" ~ SP ~> ParsedAst.RelationalChoicePattern.Present)
+      def ChoicePattern: Rule1[ParsedAst.RelationalChoosePattern] = rule {
+        (SP ~ "_" ~ SP ~> ParsedAst.RelationalChoosePattern.Wild) |
+          (SP ~ keyword("Absent") ~ SP ~> ParsedAst.RelationalChoosePattern.Absent) |
+          (SP ~ keyword("Present") ~ optWS ~ "(" ~ Names.Variable ~ ")" ~ SP ~> ParsedAst.RelationalChoosePattern.Present)
       }
 
-      def CaseOne: Rule1[ParsedAst.RelationalChoiceRule] = namedRule("ChooseCase") {
+      def CaseOne: Rule1[ParsedAst.RelationalChooseRule] = namedRule("ChooseCase") {
         SP ~ keyword("case") ~ WS ~ ChoicePattern ~ WS ~ atomic("=>") ~ WS ~ Expression ~ SP ~>
-          ((sp1: SourcePosition, x: ParsedAst.RelationalChoicePattern, e: ParsedAst.Expression, sp2: SourcePosition) => ParsedAst.RelationalChoiceRule(sp1, Seq(x), e, sp2))
+          ((sp1: SourcePosition, x: ParsedAst.RelationalChoosePattern, e: ParsedAst.Expression, sp2: SourcePosition) => ParsedAst.RelationalChooseRule(sp1, Seq(x), e, sp2))
       }
 
-      def CaseMany: Rule1[ParsedAst.RelationalChoiceRule] = namedRule("ChooseCase") {
-        SP ~ keyword("case") ~ WS ~ "(" ~ optWS ~ oneOrMore(ChoicePattern).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~ WS ~ atomic("=>") ~ WS ~ Expression ~ SP ~> ParsedAst.RelationalChoiceRule
+      def CaseMany: Rule1[ParsedAst.RelationalChooseRule] = namedRule("ChooseCase") {
+        SP ~ keyword("case") ~ WS ~ "(" ~ optWS ~ oneOrMore(ChoicePattern).separatedBy(optWS ~ "," ~ optWS) ~ optWS ~ ")" ~ WS ~ atomic("=>") ~ WS ~ Expression ~ SP ~> ParsedAst.RelationalChooseRule
       }
 
       def ChooseKind: Rule1[Boolean] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -507,7 +507,7 @@ object Redundancy {
     case Expression.RelationalChoose(exps, rules, _, _, _) =>
       val usedMatch = visitExps(exps, env0, rc)
       val usedRules = rules.map {
-        case RelationalChoiceRule(pat, exp) =>
+        case RelationalChooseRule(pat, exp) =>
           // Compute the free variables in the pattern.
           val fvs = freeVars(pat)
 
@@ -534,7 +534,7 @@ object Redundancy {
 
       // Visit each match rule.
       val usedRules = rules map {
-        case RestrictableChoiceRule(pat, body) =>
+        case RestrictableChooseRule(pat, body) =>
           // Compute the free variables in the pattern.
           val fvs = freeVars(pat)
 
@@ -894,8 +894,8 @@ object Redundancy {
   /**
     * Returns the symbols used in the given pattern `pat`.
     */
-  private def visitRestrictablePat(pat0: RestrictableChoicePattern): Used = pat0 match {
-    case RestrictableChoicePattern.Tag(Ast.RestrictableCaseSymUse(sym, _), _, _, _) =>
+  private def visitRestrictablePat(pat0: RestrictableChoosePattern): Used = pat0 match {
+    case RestrictableChoosePattern.Tag(Ast.RestrictableCaseSymUse(sym, _), _, _, _) =>
       // Ignore the pattern since there is only variables, no nesting.
       Used.of(sym.enumSym, sym)
   }
@@ -1050,23 +1050,23 @@ object Redundancy {
   /**
     * Returns the free variables in the list of choice patterns `ps`.
     */
-  private def freeVars(ps: List[RelationalChoicePattern]): Set[Symbol.VarSym] = ps.collect {
-    case RelationalChoicePattern.Present(sym, _, _) => sym
+  private def freeVars(ps: List[RelationalChoosePattern]): Set[Symbol.VarSym] = ps.collect {
+    case RelationalChoosePattern.Present(sym, _, _) => sym
   }.toSet
 
   /**
     * Returns the free variables in the restrictable pattern `p`.
     */
-  private def freeVars(p: RestrictableChoicePattern): Set[Symbol.VarSym] = p match {
-    case RestrictableChoicePattern.Tag(_, pat, _, _) => pat.flatMap(freeVars).toSet
+  private def freeVars(p: RestrictableChoosePattern): Set[Symbol.VarSym] = p match {
+    case RestrictableChoosePattern.Tag(_, pat, _, _) => pat.flatMap(freeVars).toSet
   }
 
   /**
     * Returns the free variables in the VarOrWild.
     */
-  private def freeVars(v: RestrictableChoicePattern.VarOrWild): Option[Symbol.VarSym] = v match {
-    case RestrictableChoicePattern.Wild(_, _) => None
-    case RestrictableChoicePattern.Var(sym, _, _) => Some(sym)
+  private def freeVars(v: RestrictableChoosePattern.VarOrWild): Option[Symbol.VarSym] = v match {
+    case RestrictableChoosePattern.Wild(_, _) => None
+    case RestrictableChoosePattern.Var(sym, _, _) => Some(sym)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
@@ -119,14 +119,14 @@ object Regions {
     case Expression.RelationalChoose(exps, rules, tpe, _, loc) =>
       val expsErrors = exps.flatMap(visitExp)
       val rulesErrors = rules.flatMap {
-        case RelationalChoiceRule(pat, exp) => visitExp(exp)
+        case RelationalChooseRule(pat, exp) => visitExp(exp)
       }
       expsErrors ++ rulesErrors ++ checkType(tpe, loc)
 
     case Expression.RestrictableChoose(_, exp, rules, tpe, _, loc) =>
       val expErrors = visitExp(exp)
       val rulesErrors = rules.flatMap {
-        case RestrictableChoiceRule(_, exp) => visitExp(exp)
+        case RestrictableChooseRule(_, exp) => visitExp(exp)
       }
       expErrors ++ rulesErrors ++ checkType(tpe, loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.{BoundBy, VarText}
-import ca.uwaterloo.flix.language.ast.NamedAst.{Declaration, RestrictableChoicePattern}
+import ca.uwaterloo.flix.language.ast.NamedAst.{Declaration, RestrictableChoosePattern}
 import ca.uwaterloo.flix.language.ast.UnkindedType._
 import ca.uwaterloo.flix.language.ast.{NamedAst, Symbol, _}
 import ca.uwaterloo.flix.language.errors.ResolutionError
@@ -1150,19 +1150,19 @@ object Resolver {
         case NamedAst.Expression.RelationalChoose(star, exps, rules, loc) =>
           val expsVal = traverse(exps)(visitExp(_, env0))
           val rulesVal = traverse(rules) {
-            case NamedAst.RelationalChoiceRule(pat0, exp0) =>
+            case NamedAst.RelationalChooseRule(pat0, exp0) =>
               val p = pat0.map {
-                case NamedAst.RelationalChoicePattern.Wild(loc) => ResolvedAst.RelationalChoicePattern.Wild(loc)
-                case NamedAst.RelationalChoicePattern.Absent(loc) => ResolvedAst.RelationalChoicePattern.Absent(loc)
-                case NamedAst.RelationalChoicePattern.Present(sym, loc) => ResolvedAst.RelationalChoicePattern.Present(sym, loc)
+                case NamedAst.RelationalChoosePattern.Wild(loc) => ResolvedAst.RelationalChoosePattern.Wild(loc)
+                case NamedAst.RelationalChoosePattern.Absent(loc) => ResolvedAst.RelationalChoosePattern.Absent(loc)
+                case NamedAst.RelationalChoosePattern.Present(sym, loc) => ResolvedAst.RelationalChoosePattern.Present(sym, loc)
               }
               val env = pat0.foldLeft(env0) {
-                case (acc, NamedAst.RelationalChoicePattern.Wild(_)) => acc
-                case (acc, NamedAst.RelationalChoicePattern.Absent(_)) => acc
-                case (acc, NamedAst.RelationalChoicePattern.Present(sym, _)) => acc + (sym.text -> Resolution.Var(sym))
+                case (acc, NamedAst.RelationalChoosePattern.Wild(_)) => acc
+                case (acc, NamedAst.RelationalChoosePattern.Absent(_)) => acc
+                case (acc, NamedAst.RelationalChoosePattern.Present(sym, _)) => acc + (sym.text -> Resolution.Var(sym))
               }
               mapN(visitExp(exp0, env)) {
-                case e => ResolvedAst.RelationalChoiceRule(p, e)
+                case e => ResolvedAst.RelationalChooseRule(p, e)
               }
           }
           mapN(expsVal, rulesVal) {
@@ -1172,30 +1172,30 @@ object Resolver {
         case NamedAst.Expression.RestrictableChoose(star, exp, rules, loc) =>
           val expVal = visitExp(exp, env0)
           val rulesVal = traverse(rules) {
-            case NamedAst.RestrictableChoiceRule(pat0, exp0) =>
+            case NamedAst.RestrictableChooseRule(pat0, exp0) =>
               val pVal = pat0 match {
-                case NamedAst.RestrictableChoicePattern.Tag(qname, pat, loc) =>
+                case NamedAst.RestrictableChoosePattern.Tag(qname, pat, loc) =>
                   val tagVal = lookupRestrictableTag(qname, env0, ns0, root)
                   val pats = pat.map {
-                    case NamedAst.RestrictableChoicePattern.Wild(loc) => ResolvedAst.RestrictableChoicePattern.Wild(loc)
-                    case NamedAst.RestrictableChoicePattern.Var(sym, loc) => ResolvedAst.RestrictableChoicePattern.Var(sym, loc)
+                    case NamedAst.RestrictableChoosePattern.Wild(loc) => ResolvedAst.RestrictableChoosePattern.Wild(loc)
+                    case NamedAst.RestrictableChoosePattern.Var(sym, loc) => ResolvedAst.RestrictableChoosePattern.Var(sym, loc)
                   }
                   mapN(tagVal) {
-                    case tag => ResolvedAst.RestrictableChoicePattern.Tag(Ast.RestrictableCaseSymUse(tag.sym, qname.loc), pats, loc)
+                    case tag => ResolvedAst.RestrictableChoosePattern.Tag(Ast.RestrictableCaseSymUse(tag.sym, qname.loc), pats, loc)
                   }
               }
               val env = pat0 match {
-                case RestrictableChoicePattern.Tag(qname, pat, loc) =>
+                case RestrictableChoosePattern.Tag(qname, pat, loc) =>
                   pat.foldLeft(env0) {
-                    case (acc, NamedAst.RestrictableChoicePattern.Var(sym, loc)) => acc + (sym.text -> Resolution.Var(sym))
-                    case (acc, NamedAst.RestrictableChoicePattern.Wild(loc)) => acc
+                    case (acc, NamedAst.RestrictableChoosePattern.Var(sym, loc)) => acc + (sym.text -> Resolution.Var(sym))
+                    case (acc, NamedAst.RestrictableChoosePattern.Wild(loc)) => acc
                   }
               }
 
               val eVal = visitExp(exp0, env)
               flatMapN(pVal, eVal) {
                 case (p, e) =>
-                  ResolvedAst.RestrictableChoiceRule(p, e).toSuccess
+                  ResolvedAst.RestrictableChooseRule(p, e).toSuccess
               }
           }
           mapN(expVal, rulesVal) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -183,11 +183,11 @@ object Safety {
 
       case Expression.RelationalChoose(exps, rules, _, _, _) =>
         exps.flatMap(visit) ++
-          rules.flatMap { case RelationalChoiceRule(_, exp) => visit(exp) }
+          rules.flatMap { case RelationalChooseRule(_, exp) => visit(exp) }
 
       case Expression.RestrictableChoose(_, exp, rules, _, _, _) =>
         visit(exp) ++
-          rules.flatMap { case RestrictableChoiceRule(_, exp) => visit(exp) }
+          rules.flatMap { case RestrictableChooseRule(_, exp) => visit(exp) }
 
       case Expression.Tag(_, exp, _, _, _) =>
         visit(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Statistics.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Statistics.scala
@@ -102,8 +102,8 @@ object Statistics {
       case Expression.Discard(exp, eff, loc) => visitExp(exp)
       case Expression.Match(exp, rules, tpe, eff, loc) => visitExp(exp) ++ Counter.merge(rules.map(visitMatchRule))
       case Expression.TypeMatch(exp, rules, tpe, eff, loc) => visitExp(exp) ++ Counter.merge(rules.map(visitMatchTypeRule))
-      case Expression.RelationalChoose(exps, rules, tpe, eff, loc) => Counter.merge(exps.map(visitExp)) ++ Counter.merge(rules.map(visitRelationalChoiceRule))
-      case Expression.RestrictableChoose(star, exp, rules, tpe, eff, loc) => visitExp(exp) ++ Counter.merge(rules.map(visitRestrictableChoiceRule))
+      case Expression.RelationalChoose(exps, rules, tpe, eff, loc) => Counter.merge(exps.map(visitExp)) ++ Counter.merge(rules.map(visitRelationalChooseRule))
+      case Expression.RestrictableChoose(star, exp, rules, tpe, eff, loc) => visitExp(exp) ++ Counter.merge(rules.map(visitRestrictableChooseRule))
       case Expression.Tag(sym, exp, tpe, eff, loc) => visitExp(exp)
       case Expression.RestrictableTag(sym, exp, tpe, eff, loc) => visitExp(exp)
       case Expression.Tuple(elms, tpe, eff, loc) => Counter.merge(elms.map(visitExp))
@@ -178,15 +178,15 @@ object Statistics {
   /**
     * Counts AST nodes in the given rule.
     */
-  private def visitRelationalChoiceRule(rule: RelationalChoiceRule): Counter = rule match {
-    case RelationalChoiceRule(pat, exp) => visitExp(exp)
+  private def visitRelationalChooseRule(rule: RelationalChooseRule): Counter = rule match {
+    case RelationalChooseRule(pat, exp) => visitExp(exp)
   }
 
   /**
     * Counts AST nodes in the given rule.
     */
-  private def visitRestrictableChoiceRule(rule: RestrictableChoiceRule): Counter = rule match {
-    case RestrictableChoiceRule(_, exp) => visitExp(exp)
+  private def visitRestrictableChooseRule(rule: RestrictableChooseRule): Counter = rule match {
+    case RestrictableChooseRule(_, exp) => visitExp(exp)
   }
 
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -204,7 +204,7 @@ object Stratifier {
     case Expression.RelationalChoose(exps, rules, tpe, eff, loc) =>
       val expsVal = traverse(exps)(visitExp)
       val rulesVal = traverse(rules) {
-        case RelationalChoiceRule(pat, exp) => mapN(visitExp(exp))(RelationalChoiceRule(pat, _))
+        case RelationalChooseRule(pat, exp) => mapN(visitExp(exp))(RelationalChooseRule(pat, _))
       }
       mapN(expsVal, rulesVal) {
         case (es, rs) => Expression.RelationalChoose(es, rs, tpe, eff, loc)
@@ -213,7 +213,7 @@ object Stratifier {
     case Expression.RestrictableChoose(star, exp, rules, tpe, eff, loc) =>
       val expVal = visitExp(exp)
       val rulesVal = traverse(rules) {
-        case RestrictableChoiceRule(pat, body) => mapN(visitExp(body))(RestrictableChoiceRule(pat, _))
+        case RestrictableChooseRule(pat, body) => mapN(visitExp(body))(RestrictableChooseRule(pat, _))
       }
       mapN(expVal, rulesVal) {
         case (e, rs) => Expression.RestrictableChoose(star, e, rs, tpe, eff, loc)
@@ -625,14 +625,14 @@ object Stratifier {
         case (acc, exp) => acc + labelledGraphOfExp(exp)
       }
       val dg2 = rules.foldLeft(LabelledGraph.empty) {
-        case (acc, RelationalChoiceRule(_, exp)) => acc + labelledGraphOfExp(exp)
+        case (acc, RelationalChooseRule(_, exp)) => acc + labelledGraphOfExp(exp)
       }
       dg1 + dg2
 
     case Expression.RestrictableChoose(_, exp, rules, _, _, _) =>
       val dg1 = labelledGraphOfExp(exp)
       val dg2 = rules.foldLeft(LabelledGraph.empty) {
-        case (acc, RestrictableChoiceRule(_, body)) => acc + labelledGraphOfExp(body)
+        case (acc, RestrictableChooseRule(_, body)) => acc + labelledGraphOfExp(body)
       }
       dg1 + dg2
 

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -151,12 +151,12 @@ object CodeHinter {
 
     case Expression.RelationalChoose(exps, rules, _, _, _) =>
       visitExps(exps) ++ rules.flatMap {
-        case RelationalChoiceRule(_, exp) => visitExp(exp)
+        case RelationalChooseRule(_, exp) => visitExp(exp)
       }
 
     case Expression.RestrictableChoose(_, exp, rules, _, _, _) =>
       visitExp(exp) ++ rules.flatMap {
-        case RestrictableChoiceRule(_, body) => visitExp(body)
+        case RestrictableChooseRule(_, body) => visitExp(body)
       }
 
     case Expression.Tag(_, exp, _, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/inference/RestrictableChooseInference.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/inference/RestrictableChooseInference.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.language.phase.inference
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.KindedAst.RestrictableChoicePattern
+import ca.uwaterloo.flix.language.ast.KindedAst.RestrictableChoosePattern
 import ca.uwaterloo.flix.language.ast.{Ast, Kind, KindedAst, Scheme, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.phase.Typer
 import ca.uwaterloo.flix.language.phase.Typer.inferExp
@@ -46,9 +46,9 @@ object RestrictableChooseInference {
     *
     * then it returns { Expr.Var, Expr.Xor, Expr.Cst, Expr.And }.
     */
-  private def dom(rules: List[KindedAst.RestrictableChoiceRule]): Set[Symbol.RestrictableCaseSym] = {
+  private def dom(rules: List[KindedAst.RestrictableChooseRule]): Set[Symbol.RestrictableCaseSym] = {
     rules.map {
-      case KindedAst.RestrictableChoiceRule(KindedAst.RestrictableChoicePattern.Tag(sym, _, _, _), _) => sym.sym
+      case KindedAst.RestrictableChooseRule(KindedAst.RestrictableChoosePattern.Tag(sym, _, _, _), _) => sym.sym
     }.toSet
   }
 
@@ -80,7 +80,7 @@ object RestrictableChooseInference {
 
         // Get the enum symbols for the matched type
         val enumSym = rules0.headOption.getOrElse(throw InternalCompilerException("unexpected empty choose", loc)).pat match {
-          case KindedAst.RestrictableChoicePattern.Tag(sym, _, _, _) => sym.sym.enumSym
+          case KindedAst.RestrictableChoosePattern.Tag(sym, _, _, _) => sym.sym.enumSym
         }
 
         val `enum` = root.restrictableEnums(enumSym)
@@ -92,7 +92,7 @@ object RestrictableChooseInference {
         for {
           // Γ ⊢ e: τ_in
           (constrs, tpe, eff) <- Typer.inferExp(exp0, root)
-          patTpes <- inferRestrictableChoicePatterns(rules0.map(_.pat), root)
+          patTpes <- inferRestrictableChoosePatterns(rules0.map(_.pat), root)
           _ <- unifyTypeM(tpe :: patTpes, loc)
 
           // τ_in = (... + l_i(τ_i) + ...)[φ_in]
@@ -114,7 +114,7 @@ object RestrictableChooseInference {
 
         // Get the enum symbols for the matched type
         val enumSym = rules0.headOption.getOrElse(throw InternalCompilerException("unexpected empty choose", loc)).pat match {
-          case KindedAst.RestrictableChoicePattern.Tag(sym, _, _, _) => sym.sym.enumSym
+          case KindedAst.RestrictableChoosePattern.Tag(sym, _, _, _) => sym.sym.enumSym
         }
 
         val `enum` = root.restrictableEnums(enumSym)
@@ -124,7 +124,7 @@ object RestrictableChooseInference {
         val (enumTypeOut, indexOutVar, targsOut) = instantiatedEnumType(enumSym, `enum`, loc.asSynthetic)
         val (bodyTypes, bodyIndexVars, bodyTargs) = rules0.map(_ => instantiatedEnumType(enumSym, `enum`, loc.asSynthetic)).unzip3
         val patternTagTypes = rules0.map(_.pat match {
-          case RestrictableChoicePattern.Tag(sym, _, _, loc) => Type.Cst(TypeConstructor.CaseSet(SortedSet(sym.sym), enumSym), loc.asSynthetic)
+          case RestrictableChoosePattern.Tag(sym, _, _, loc) => Type.Cst(TypeConstructor.CaseSet(SortedSet(sym.sym), enumSym), loc.asSynthetic)
         })
 
         val domSet = dom(rules0)
@@ -137,7 +137,7 @@ object RestrictableChooseInference {
         for {
           // Γ ⊢ e: τ_in
           (constrs, tpe, eff) <- Typer.inferExp(exp0, root)
-          patTpes <- inferRestrictableChoicePatterns(rules0.map(_.pat), root)
+          patTpes <- inferRestrictableChoosePatterns(rules0.map(_.pat), root)
           _ <- unifyTypeM(tpe :: patTpes, loc)
 
           // τ_in = (... + l^in_i(τ^in_i) + ...)[φ_in]
@@ -316,13 +316,13 @@ object RestrictableChooseInference {
   /**
     * Infers the type of the given restrictable choice pattern `pat0`.
     */
-  private def inferRestrictableChoicePattern(pat0: KindedAst.RestrictableChoicePattern, root: KindedAst.Root)(implicit flix: Flix): InferMonad[Type] = {
+  private def inferRestrictableChoosePattern(pat0: KindedAst.RestrictableChoosePattern, root: KindedAst.Root)(implicit flix: Flix): InferMonad[Type] = {
 
     /**
       * Local pattern visitor.
       */
-    def visit(p: KindedAst.RestrictableChoicePattern): InferMonad[Type] = p match {
-      case KindedAst.RestrictableChoicePattern.Tag(symUse, pat, tvar, loc) =>
+    def visit(p: KindedAst.RestrictableChoosePattern): InferMonad[Type] = p match {
+      case KindedAst.RestrictableChoosePattern.Tag(symUse, pat, tvar, loc) =>
         // Lookup the enum declaration.
         val decl = root.restrictableEnums(symUse.sym.enumSym)
 
@@ -349,16 +349,16 @@ object RestrictableChooseInference {
   /**
     * Infers the type of the given restrictable choice pattern `pat0`.
     */
-  private def inferVarOrWild(pat: KindedAst.RestrictableChoicePattern.VarOrWild, root: KindedAst.Root)(implicit flix: Flix): InferMonad[Type] = pat match {
-    case KindedAst.RestrictableChoicePattern.Wild(tvar, _) => liftM(tvar)
-    case KindedAst.RestrictableChoicePattern.Var(sym, tvar, loc) => unifyTypeM(sym.tvar, tvar, loc)
+  private def inferVarOrWild(pat: KindedAst.RestrictableChoosePattern.VarOrWild, root: KindedAst.Root)(implicit flix: Flix): InferMonad[Type] = pat match {
+    case KindedAst.RestrictableChoosePattern.Wild(tvar, _) => liftM(tvar)
+    case KindedAst.RestrictableChoosePattern.Var(sym, tvar, loc) => unifyTypeM(sym.tvar, tvar, loc)
   }
 
   /**
     * Infers the type of the given patterns `pats0`.
     */
-  private def inferRestrictableChoicePatterns(pats0: List[KindedAst.RestrictableChoicePattern], root: KindedAst.Root)(implicit flix: Flix): InferMonad[List[Type]] = {
-    traverseM(pats0)(inferRestrictableChoicePattern(_, root))
+  private def inferRestrictableChoosePatterns(pats0: List[KindedAst.RestrictableChoosePattern], root: KindedAst.Root)(implicit flix: Flix): InferMonad[List[Type]] = {
+    traverseM(pats0)(inferRestrictableChoosePattern(_, root))
   }
 
 }


### PR DESCRIPTION
It is consistently confusing that the rules are called "Choice" but the expression is called "Choose".