### PR TITLE
chore: rename effect-poly error to effectful error

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -139,7 +139,7 @@ object TypeError {
     * @param inferred the inferred effect.
     * @param loc      the location where the error occurred.
     */
-  case class EffectfulDeclaredAsPure(inferred: Type, loc: SourceLocation) extends TypeError {
+  case class EffectfulDeclaredAsPure(inferred: Type, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
     def summary: String = "Effectful function declared as pure."
 
     def message(formatter: Formatter): String = {
@@ -148,6 +148,8 @@ object TypeError {
          |>> ${red("Effectful")} function declared as ${green("pure")}.
          |
          |${code(loc, "effectful function.")}
+         |
+         |The function has the effect: ${FormatEff.formatEff(inferred)}
          |
          |""".stripMargin
     }

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -134,26 +134,26 @@ object TypeError {
   }
 
   /**
-    * Effect polymorphic function declared as pure.
+    * Effectful function declared as pure.
     *
     * @param inferred the inferred effect.
     * @param loc      the location where the error occurred.
     */
-  case class EffectPolymorphicDeclaredAsPure(inferred: Type, loc: SourceLocation) extends TypeError {
-    def summary: String = "Effect polymorphic function declared as pure."
+  case class EffectfulDeclaredAsPure(inferred: Type, loc: SourceLocation) extends TypeError {
+    def summary: String = "Effectful function declared as pure."
 
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
-         |>> ${red("Effect polymorphic")} function declared as ${green("pure")}.
+         |>> ${red("Effectful")} function declared as ${green("pure")}.
          |
-         |${code(loc, "effect polymorphic function.")}
+         |${code(loc, "effectful function.")}
          |
          |""".stripMargin
     }
 
     def explain(formatter: Formatter): Option[String] = Some({
-      """A function whose body is effect polymorphic must be declared as so.
+      """A function must declare all the effects used in its body.
         |
         |For example:
         |

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatEff.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatEff.scala
@@ -22,7 +22,7 @@ object FormatEff {
 
   def formatEff(eff: Type)(implicit flix: Flix): String = eff match {
     case Type.Cst(TypeConstructor.Pure, _) => "Pure"
-    case Type.Cst(TypeConstructor.EffUniv, _) => "Impure"
+    case Type.Cst(TypeConstructor.EffUniv, _) => "IO"
     case _ => FormatType.formatType(eff)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -408,8 +408,8 @@ object Typer {
                       // Case 1: Declared as pure, but impure.
                       return TypeError.ImpureDeclaredAsPure(loc).toFailure
                     } else if (declaredEff == Type.Pure && inferredEff != Type.Pure) {
-                      // Case 2: Declared as pure, but effect polymorphic.
-                      return TypeError.EffectPolymorphicDeclaredAsPure(inferredEff, loc).toFailure
+                      // Case 2: Declared as pure, but effectful.
+                      return TypeError.EffectfulDeclaredAsPure(inferredEff, loc).toFailure
                     } else {
                       // Case 3: Check if it is the effect that cannot be generalized.
                       val inferredEffScheme = Scheme(inferredSc.quantifiers, Nil, Nil, inferredEff)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1179,24 +1179,43 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError.ImpureDeclaredAsPure](result)
   }
 
-  test("Test.EffectPolymorphicDeclaredAsPure.01") {
+  test("Test.EffectfulDeclaredAsPure.01") {
     val input =
       """
         |def f(g: Int32 -> Int32 \ ef): Int32 = g(123)
         |
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.EffectPolymorphicDeclaredAsPure](result)
+    expectError[TypeError.EffectfulDeclaredAsPure](result)
   }
 
-  test("Test.EffectPolymorphicDeclaredAsPure.02") {
+  test("Test.EffectfulDeclaredAsPure.02") {
     val input =
       """
         |def f(g: Int32 -> Int32 \ ef): Int32 \ {} = g(123)
         |
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.EffectPolymorphicDeclaredAsPure](result)
+    expectError[TypeError.EffectfulDeclaredAsPure](result)
+  }
+
+  test("Test.EffectfulDeclaredAsPure.03") {
+    val input =
+      """
+        |eff Print {
+        |    pub def print(): Unit
+        |}
+        |
+        |eff Throw {
+        |    pub def throw(): Unit
+        |}
+        |
+        |def f(): Unit =
+        |    do Print.print();
+        |    do Throw.throw()
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[TypeError.EffectfulDeclaredAsPure](result)
   }
 
   test("Test.EffectGeneralizationError.01") {


### PR DESCRIPTION
fixes #6083. I wanted to do something prettier, but a combination of us not having set effects anymore and annoyances I am blaming on the escaping region bug covinced me to take this lazy approach.