### PR TITLE
feat: handle verifier errors

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -620,6 +620,9 @@ class Flix {
     case ex: InternalCompilerException =>
       CrashHandler.handleCrash(ex)(this)
       throw ex
+    case ex: java.lang.VerifyError =>
+      CrashHandler.handleCrash(ex)(this)
+      throw ex
   }
 
   /**


### PR DESCRIPTION
This means that you automatically get the asts in `build/asts` and you also get a `crash_report_i.txt`