### PR TITLE
fix: avoid nullary functions

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -255,7 +255,7 @@ object Simplifier {
         // Wrap the expression in a closure: () -> tpe \ Pure
         val e = visitExp(exp)
         val lambdaTyp = Type.mkArrowWithEffect(Type.Unit, Type.Pure, e.tpe, loc)
-        val fp = SimplifiedAst.FormalParam(Symbol.freshVarSym("spawn", BoundBy.FormalParam, loc), Ast.Modifiers.Empty, Type.mkUnit(loc), loc)
+        val fp = SimplifiedAst.FormalParam(Symbol.freshVarSym("lazy", BoundBy.FormalParam, loc), Ast.Modifiers.Empty, Type.mkUnit(loc), loc)
         val lambdaExp = SimplifiedAst.Expression.Lambda(List(fp), e, lambdaTyp, loc)
         SimplifiedAst.Expression.Lazy(lambdaExp, tpe, loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -247,14 +247,16 @@ object Simplifier {
         val e1 = visitExp(exp1)
         val e2 = visitExp(exp2)
         val lambdaTyp = Type.mkArrowWithEffect(Type.Unit, eff, e1.tpe, loc)
-        val lambdaExp = SimplifiedAst.Expression.Lambda(List(), e1, lambdaTyp, loc)
+        val fp = SimplifiedAst.FormalParam(Symbol.freshVarSym("spawn", BoundBy.FormalParam, loc), Ast.Modifiers.Empty, Type.mkUnit(loc), loc)
+        val lambdaExp = SimplifiedAst.Expression.Lambda(List(fp), e1, lambdaTyp, loc)
         SimplifiedAst.Expression.Spawn(lambdaExp, e2, tpe, loc)
 
       case LoweredAst.Expression.Lazy(exp, tpe, loc) =>
         // Wrap the expression in a closure: () -> tpe \ Pure
         val e = visitExp(exp)
         val lambdaTyp = Type.mkArrowWithEffect(Type.Unit, Type.Pure, e.tpe, loc)
-        val lambdaExp = SimplifiedAst.Expression.Lambda(List(), e, lambdaTyp, loc)
+        val fp = SimplifiedAst.FormalParam(Symbol.freshVarSym("spawn", BoundBy.FormalParam, loc), Ast.Modifiers.Empty, Type.mkUnit(loc), loc)
+        val lambdaExp = SimplifiedAst.Expression.Lambda(List(fp), e, lambdaTyp, loc)
         SimplifiedAst.Expression.Lazy(lambdaExp, tpe, loc)
 
       case LoweredAst.Expression.Force(exp, tpe, _, loc) =>


### PR DESCRIPTION
The only place where we have nullary lambdas/defs is these two places as far as I can see. This causes problems with the new def return type rep.