### PR TITLE
refactor: remove ClosureInfo

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -17,19 +17,18 @@
 package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.language.ast.Ast.Source
-import ca.uwaterloo.flix.language.phase.jvm.{AnonClassInfo, ClosureInfo}
+import ca.uwaterloo.flix.language.phase.jvm.AnonClassInfo
 
 import java.lang.reflect.Method
 
 object ErasedAst {
 
-  val empty: Root = Root(Map.empty, Map.empty, None, Map.empty, Set.empty, Set.empty)
+  val empty: Root = Root(Map.empty, Map.empty, None, Map.empty, Set.empty)
 
   case class Root(defs: Map[Symbol.DefnSym, Def],
                   enums: Map[Symbol.EnumSym, Enum],
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],
-                  closures: Set[ClosureInfo],
                   anonClasses: Set[AnonClassInfo])
 
   case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], stmt: Stmt, tpe: MonoType, loc: SourceLocation) {

--- a/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
@@ -17,6 +17,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.Ast.BoundBy
 import ca.uwaterloo.flix.language.ast.{Ast, LiftedAst, SimplifiedAst, Symbol, Type}
 import ca.uwaterloo.flix.util.InternalCompilerException
 
@@ -99,7 +100,9 @@ object LambdaLift {
         val mod = Ast.Modifiers(Ast.Modifier.Synthetic :: Nil)
 
         // Construct the closure parameters
-        val cs = cparams.map(visitFormalParam)
+        val cs = if (cparams.isEmpty)
+          List(LiftedAst.FormalParam(Symbol.freshVarSym("_lift", BoundBy.FormalParam, loc), Ast.Modifiers.Empty, Type.mkUnit(loc), loc))
+        else cparams.map(visitFormalParam)
 
         // Construct the formal parameters.
         val fs = fparams.map(visitFormalParam)
@@ -111,7 +114,9 @@ object LambdaLift {
         m += (freshSymbol -> defn)
 
         // Construct the closure args.
-        val closureArgs = freeVars.map {
+        val closureArgs =  if (freeVars.isEmpty)
+          List(LiftedAst.Expression.Cst(Ast.Constant.Unit, Type.mkUnit(loc), loc))
+        else freeVars.map {
           case SimplifiedAst.FreeVar(sym, tpe) => LiftedAst.Expression.Var(sym, tpe, sym.loc)
         }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -247,7 +247,7 @@ object Simplifier {
         val e1 = visitExp(exp1)
         val e2 = visitExp(exp2)
         val lambdaTyp = Type.mkArrowWithEffect(Type.Unit, eff, e1.tpe, loc)
-        val fp = SimplifiedAst.FormalParam(Symbol.freshVarSym("spawn", BoundBy.FormalParam, loc), Ast.Modifiers.Empty, Type.mkUnit(loc), loc)
+        val fp = SimplifiedAst.FormalParam(Symbol.freshVarSym("_spawn", BoundBy.FormalParam, loc), Ast.Modifiers.Empty, Type.mkUnit(loc), loc)
         val lambdaExp = SimplifiedAst.Expression.Lambda(List(fp), e1, lambdaTyp, loc)
         SimplifiedAst.Expression.Spawn(lambdaExp, e2, tpe, loc)
 
@@ -255,7 +255,7 @@ object Simplifier {
         // Wrap the expression in a closure: () -> tpe \ Pure
         val e = visitExp(exp)
         val lambdaTyp = Type.mkArrowWithEffect(Type.Unit, Type.Pure, e.tpe, loc)
-        val fp = SimplifiedAst.FormalParam(Symbol.freshVarSym("lazy", BoundBy.FormalParam, loc), Ast.Modifiers.Empty, Type.mkUnit(loc), loc)
+        val fp = SimplifiedAst.FormalParam(Symbol.freshVarSym("_lazy", BoundBy.FormalParam, loc), Ast.Modifiers.Empty, Type.mkUnit(loc), loc)
         val lambdaExp = SimplifiedAst.Expression.Lambda(List(fp), e, lambdaTyp, loc)
         SimplifiedAst.Expression.Lazy(lambdaExp, tpe, loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClosureInfo.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClosureInfo.scala
@@ -1,8 +1,0 @@
-package ca.uwaterloo.flix.language.phase.jvm
-
-import ca.uwaterloo.flix.language.ast.{MonoType, Symbol}
-
-/**
-  * Meta information about a closure.
-  */
-case class ClosureInfo(sym: Symbol.DefnSym, closureArgTypes: List[MonoType], tpe: MonoType)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -40,11 +40,6 @@ object JvmBackend {
     val allClasses = flix.subphase("CodeGen") {
 
       //
-      // Compute the set of closures in the program.
-      //
-      val closures = root.closures
-
-      //
       // Compute the set of namespaces in the program.
       //
       val namespaces = JvmOps.namespacesOf(root)
@@ -99,7 +94,7 @@ object JvmBackend {
       //
       // Generate closure classes for each closure in the program.
       //
-      val closureClasses = GenClosureClasses.gen(closures)
+      val closureClasses = GenClosureClasses.gen(root.defs)
 
       //
       // Generate enum interfaces for each enum type in the program.


### PR DESCRIPTION
Related to #6113

- Remove `ClosureInfo` (and their collection) and instead generate closures based on the `cparams` of defs
- Ensure that `cparams` for closures are always non-empty by adding a unit cparam if it is.
  - Another option is to actually separate closures/defs with a flag or a new case class, in which case it would be okay to have empty cparams

Metrics
- 8 % decrease in code size (from the clarification of closures vs defs)
- performance of eraser/backend seems slightly faster, hard to say
- Might slow down flix runtime a little with the added unit args