### PR TITLE
fix: remove closure unit arg

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -31,7 +31,7 @@ object ErasedAst {
                   sources: Map[Source, SourceLocation],
                   anonClasses: Set[AnonClassInfo])
 
-  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], stmt: Stmt, tpe: MonoType, loc: SourceLocation) {
+  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, isClo: Boolean, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], stmt: Stmt, tpe: MonoType, loc: SourceLocation) {
     var method: Method = _
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
@@ -29,7 +29,7 @@ object LiftedAst {
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
-  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[LiftedAst.FormalParam], fparams: List[LiftedAst.FormalParam], exp: LiftedAst.Expression, tpe: Type, loc: SourceLocation)
+  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, isClo: Boolean, sym: Symbol.DefnSym, cparams: List[LiftedAst.FormalParam], fparams: List[LiftedAst.FormalParam], exp: LiftedAst.Expression, tpe: Type, loc: SourceLocation)
 
   case class Enum(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, cases: Map[Symbol.CaseSym, LiftedAst.Case], tpe: Type, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/MonoTypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoTypedAst.scala
@@ -29,7 +29,7 @@ object MonoTypedAst {
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
-  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], stmt: Stmt, tpe: MonoType, loc: SourceLocation) {
+  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, isClo: Boolean, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], stmt: Stmt, tpe: MonoType, loc: SourceLocation) {
     var method: Method = _
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/OccurrenceAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/OccurrenceAst.scala
@@ -28,7 +28,7 @@ object OccurrenceAst {
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
-  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[OccurrenceAst.FormalParam], fparams: List[OccurrenceAst.FormalParam], exp: OccurrenceAst.Expression, context: DefContext, tpe: Type, loc: SourceLocation)
+  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, isClo: Boolean, sym: Symbol.DefnSym, cparams: List[OccurrenceAst.FormalParam], fparams: List[OccurrenceAst.FormalParam], exp: OccurrenceAst.Expression, context: DefContext, tpe: Type, loc: SourceLocation)
 
   case class Enum(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, cases: Map[Symbol.CaseSym, OccurrenceAst.Case], tpe: Type, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -28,7 +28,7 @@ object ReducedAst {
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
-  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], stmt: Stmt, tpe: Type, loc: SourceLocation)
+  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, isClo: Boolean, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], stmt: Stmt, tpe: Type, loc: SourceLocation)
 
   case class Enum(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, cases: Map[Symbol.CaseSym, Case], tpe: Type, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ErasedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ErasedAstPrinter.scala
@@ -38,7 +38,7 @@ object ErasedAstPrinter {
         DocAst.Enum(ann, mod, sym, Nil, cases)
     }.toList
     val defs = root.defs.values.map {
-      case ErasedAst.Def(ann, mod, sym, cparams, fparams, exp, tpe, _) =>
+      case ErasedAst.Def(ann, mod, _, sym, cparams, fparams, exp, tpe, _) =>
         DocAst.Def(
           ann,
           mod,

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
@@ -37,7 +37,7 @@ object LiftedAstPrinter {
         DocAst.Enum(ann, mod, sym, Nil, cases)
     }.toList
     val defs = root.defs.values.map {
-      case LiftedAst.Def(ann, mod, sym, cparams, fparams, exp, tpe, _) =>
+      case LiftedAst.Def(ann, mod, _, sym, cparams, fparams, exp, tpe, _) =>
         DocAst.Def(
           ann,
           mod,

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypedAstPrinter.scala
@@ -38,7 +38,7 @@ object MonoTypedAstPrinter {
         DocAst.Enum(ann, mod, sym, Nil, cases)
     }.toList
     val defs = root.defs.values.map {
-      case MonoTypedAst.Def(ann, mod, sym, cparams, fparams, exp, tpe, _) =>
+      case MonoTypedAst.Def(ann, mod, _, sym, cparams, fparams, exp, tpe, _) =>
         DocAst.Def(
           ann,
           mod,

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
@@ -37,7 +37,7 @@ object ReducedAstPrinter {
         DocAst.Enum(ann, mod, sym, Nil, cases)
     }.toList
     val defs = root.defs.values.map {
-      case ReducedAst.Def(ann, mod, sym, cparams, fparams, stmt, tpe, _) =>
+      case ReducedAst.Def(ann, mod, _, sym, cparams, fparams, stmt, tpe, _) =>
         DocAst.Def(
           ann,
           mod,

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -46,7 +46,7 @@ object Eraser {
     val cs = def0.cparams.map(visitFormalParam)
     val fs = def0.fparams.map(visitFormalParam)
     val stmt = visitStmt(def0.stmt)
-    ErasedAst.Def(def0.ann, def0.mod, def0.sym, cs, fs, stmt, def0.tpe, def0.loc)
+    ErasedAst.Def(def0.ann, def0.mod, def0.isClo, def0.sym, cs, fs, stmt, def0.tpe, def0.loc)
   }
 
   private def visitExpr(exp0: MonoTypedAst.Expr)(implicit ctx: Context): ErasedAst.Expr = exp0 match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Inliner.scala
@@ -76,7 +76,7 @@ object Inliner {
     val fparams = def0.fparams.map {
       case OccurrenceAst.FormalParam(sym, mod, tpe, loc) => LiftedAst.FormalParam(sym, mod, tpe, loc)
     }
-    LiftedAst.Def(def0.ann, def0.mod, def0.sym, cparams, fparams, convertedExp, def0.tpe, def0.loc)
+    LiftedAst.Def(def0.ann, def0.mod, def0.isClo, def0.sym, cparams, fparams, convertedExp, def0.tpe, def0.loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/MonoTyper.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/MonoTyper.scala
@@ -40,7 +40,7 @@ object MonoTyper {
     val fs = def0.fparams.map(visitFormalParam)
     val s = visitStmt(def0.stmt)
     val tpe = visitType(def0.tpe)
-    MonoTypedAst.Def(def0.ann, def0.mod, def0.sym, cs, fs, s, tpe, def0.loc)
+    MonoTypedAst.Def(def0.ann, def0.mod, def0.isClo, def0.sym, cs, fs, s, tpe, def0.loc)
   }
 
   private def visitEnum(enum0: ReducedAst.Enum)(implicit flix: Flix): MonoTypedAst.Enum = enum0 match {

--- a/main/src/ca/uwaterloo/flix/language/phase/OccurrenceAnalyzer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/OccurrenceAnalyzer.scala
@@ -138,7 +138,7 @@ object OccurrenceAnalyzer {
       }
     }
     val defContext = DefContext(isDirectCall, oi.defs.getOrElse(defn.sym, Dead), oi.size, isSelfRecursive)
-    (OccurrenceAst.Def(defn.ann, defn.mod, defn.sym, cparams, fparams, e, defContext, defn.tpe, defn.loc), oi)
+    (OccurrenceAst.Def(defn.ann, defn.mod, defn.isClo, defn.sym, cparams, fparams, e, defContext, defn.tpe, defn.loc), oi)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -33,12 +33,12 @@ object Reducer {
   }
 
   private def visitDef(d: LiftedAst.Def): ReducedAst.Def = d match {
-    case LiftedAst.Def(ann, mod, sym, cparams, fparams, exp, tpe, loc) =>
+    case LiftedAst.Def(ann, mod, isClo, sym, cparams, fparams, exp, tpe, loc) =>
       val cs = cparams.map(visitFormalParam)
       val fs = fparams.map(visitFormalParam)
       val e = visitExpr(exp)
       val s = ReducedAst.Stmt.Ret(e, tpe, loc)
-      ReducedAst.Def(ann, mod, sym, cs, fs, s, tpe, loc)
+      ReducedAst.Def(ann, mod, isClo, sym, cs, fs, s, tpe, loc)
   }
 
   private def visitEnum(d: LiftedAst.Enum): ReducedAst.Enum = d match {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenClosureClasses.scala
@@ -37,7 +37,7 @@ object GenClosureClasses {
     // Generate a closure class for each closure and collect the results in a map.
     //
     ParOps.parAgg(defs.values, Map.empty[JvmName, JvmClass])({
-      case (macc, closure) if closure.cparams.nonEmpty =>
+      case (macc, closure) if closure.isClo =>
         val jvmType = JvmOps.getClosureClassType(closure.sym)
         val jvmName = jvmType.name
         val bytecode = genByteCode(closure)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunctionClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunctionClasses.scala
@@ -38,7 +38,7 @@ object GenFunctionClasses {
     // Generate a function class for each def and collect the results in a map.
     //
     ParOps.parAgg(defs, Map.empty[JvmName, JvmClass])({
-      case (macc, (sym, defn)) if defn.cparams.nonEmpty =>
+      case (macc, (sym, defn)) if defn.isClo =>
         macc // do nothing, these defns should be Closure classes
       case (macc, (sym, defn)) =>
         flix.subtask(sym.toString, sample = true)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenNamespaceClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenNamespaceClasses.scala
@@ -58,7 +58,7 @@ object GenNamespaceClasses {
       BackendObjType.JavaObject.jvmName.toInternalName, null)
 
     // Adding an IFO field and a shim method for each function in `ns` with no captured args
-    for ((_, defn) <- ns.defs if defn.cparams.isEmpty) {
+    for ((_, defn) <- ns.defs if !defn.isClo) {
       // Compile the shim method.
       compileShimMethod(visitor, defn)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -253,7 +253,7 @@ object JvmBackend {
     */
   private def getCompiledDefs(root: Root)(implicit flix: Flix): Map[Symbol.DefnSym, () => AnyRef] =
     root.defs.foldLeft(Map.empty[Symbol.DefnSym, () => AnyRef]) {
-      case (macc, (_, defn)) if defn.cparams.nonEmpty =>
+      case (macc, (_, defn)) if defn.isClo =>
         macc
       case (macc, (sym, _)) =>
         val args: Array[AnyRef] = Array(null)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Loader.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Loader.scala
@@ -41,7 +41,7 @@ object Loader {
       //
       // Decorate each defn in the ast with its method object unless its a closure.
       //
-      for ((sym, defn) <- root.defs if defn.cparams.isEmpty) {
+      for ((sym, defn) <- root.defs if !defn.isClo) {
         // Retrieve the namespace info of sym.
         val nsInfo = JvmOps.getNamespace(sym)
 


### PR DESCRIPTION
Remove the added unit arg in #6117

It seems this cost some runtime performance. This does, however, point to the fact that we should optimize this case. (closure with no captured arguments)