### PR TITLE
refactor: ReducedAst def return type

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -28,7 +28,7 @@ object ReducedAst {
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
-  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], stmt: Stmt, tpe: Type, loc: SourceLocation)
+  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], stmt: Stmt, tpe: Type, purity: Type, loc: SourceLocation)
 
   case class Enum(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, cases: Map[Symbol.CaseSym, Case], tpe: Type, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
@@ -37,13 +37,13 @@ object ReducedAstPrinter {
         DocAst.Enum(ann, mod, sym, Nil, cases)
     }.toList
     val defs = root.defs.values.map {
-      case ReducedAst.Def(ann, mod, sym, cparams, fparams, stmt, tpe, _) =>
+      case ReducedAst.Def(ann, mod, sym, cparams, fparams, stmt, tpe, _, _) =>
         DocAst.Def(
           ann,
           mod,
           sym,
           (cparams ++ fparams).map(printFormalParam),
-          TypePrinter.print(tpe),
+          DocAst.Type.Arrow(Nil, TypePrinter.print(tpe)),
           print(stmt)
         )
     }.toList

--- a/main/src/ca/uwaterloo/flix/language/phase/MonoTyper.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/MonoTyper.scala
@@ -39,7 +39,8 @@ object MonoTyper {
     val cs = def0.cparams.map(visitFormalParam)
     val fs = def0.fparams.map(visitFormalParam)
     val s = visitStmt(def0.stmt)
-    val tpe = visitType(def0.tpe)
+    val tpe0 = visitType(def0.tpe)
+    val tpe = MonoType.Arrow(fs.map(_.tpe), tpe0)
     MonoTypedAst.Def(def0.ann, def0.mod, def0.sym, cs, fs, s, tpe, def0.loc)
   }
 
@@ -227,9 +228,9 @@ object MonoTyper {
 
             case TypeConstructor.True => MonoType.Unit
             case TypeConstructor.False => MonoType.Unit
-            case TypeConstructor.Not=> MonoType.Unit
+            case TypeConstructor.Not => MonoType.Unit
             case TypeConstructor.And => MonoType.Unit
-            case TypeConstructor.Or=> MonoType.Unit
+            case TypeConstructor.Or => MonoType.Unit
 
             case TypeConstructor.Pure => MonoType.Unit
             case TypeConstructor.EffUniv => MonoType.Unit

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -33,13 +33,12 @@ object Reducer {
   }
 
   private def visitDef(d: LiftedAst.Def): ReducedAst.Def = d match {
-    case LiftedAst.Def(ann, mod, sym, cparams, fparams, exp, tpe0, purity, loc) =>
+    case LiftedAst.Def(ann, mod, sym, cparams, fparams, exp, tpe, purity, loc) =>
       val cs = cparams.map(visitFormalParam)
       val fs = fparams.map(visitFormalParam)
       val e = visitExpr(exp)
-      val tpe = Type.mkUncurriedArrowWithEffect(fparams.map(_.tpe), purity, tpe0, tpe0.loc)
       val stmt = ReducedAst.Stmt.Ret(e, e.tpe, e.loc)
-      ReducedAst.Def(ann, mod, sym, cs, fs, stmt, tpe, loc)
+      ReducedAst.Def(ann, mod, sym, cs, fs, stmt, tpe, purity, loc)
   }
 
   private def visitEnum(d: LiftedAst.Enum): ReducedAst.Enum = d match {


### PR DESCRIPTION
Related to #6113

I've noted that the purity is unused on defs in SimplifiedAst, LiftedAst/OccurrenceAst, and ReducedAst. It is then erased in MonoTypedAst. The optimizer uses the def calls to look at purity, not looking at the definition itself.

Should we remove this unused purity information on defs or keep it around? In my opinion, it seems sensible to store it. It might be important for implementing handlers at some point.  Do you have input @mlutze?