### PR TITLE
refactor: remove MonoType.Var

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
@@ -82,7 +82,4 @@ object MonoType {
 
   case class Native(clazz: Class[_]) extends MonoType
 
-  // TODO: Should be removed.
-  case class Var(id: Int) extends MonoType
-
 }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypePrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypePrinter.scala
@@ -50,7 +50,6 @@ object MonoTypePrinter {
     case MonoType.SchemaEmpty() => Type.SchemaEmpty
     case MonoType.SchemaExtend(name, tpe, rest) => Type.SchemaExtend(name, print(tpe), print(rest))
     case MonoType.Native(clazz) => Type.Native(clazz)
-    case MonoType.Var(id) => Type.Var(id)
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/MonoTyper.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/MonoTyper.scala
@@ -159,7 +159,6 @@ object MonoTyper {
 
       base match {
         case None => t0 match {
-          case Type.Var(sym, _) => MonoType.Var(sym.id)
           case _ => throw InternalCompilerException(s"Unexpected type: $t0", t0.loc)
         }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -132,6 +132,6 @@ object BackendType {
          MonoType.Array(_) | MonoType.Lazy(_) | MonoType.Ref(_) | MonoType.Tuple(_) |
          MonoType.Enum(_) | MonoType.Arrow(_, _) | MonoType.RecordEmpty() | MonoType.RecordExtend(_, _, _) |
          MonoType.SchemaEmpty() | MonoType.SchemaExtend(_, _, _) | MonoType.Native(_) |
-         MonoType.Var(_) | MonoType.Region => BackendObjType.JavaObject.toTpe
+         MonoType.Region => BackendObjType.JavaObject.toTpe
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -46,9 +46,6 @@ object JvmOps {
     * (Int, Int) -> Bool    =>      Fn2$Int$Int$Bool
     */
   def getJvmType(tpe: MonoType)(implicit root: Root, flix: Flix): JvmType = tpe match {
-    // Polymorphic
-    case MonoType.Var(_) => JvmType.Unit
-
     // Primitives
     case MonoType.Unit => JvmType.Unit
     case MonoType.Bool => JvmType.PrimBool
@@ -661,7 +658,6 @@ object JvmOps {
       case MonoType.SchemaExtend(_, t, rest) => nestedTypesOf(t) ++ nestedTypesOf(rest) + t + rest
 
       case MonoType.Native(_) => Set(tpe)
-      case MonoType.Var(_) => Set.empty
     }
   }
 


### PR DESCRIPTION
Because of #5867, vars are now never present