### PR TITLE
fix: packager - relax MavenDependency versionTag to just String (issue #6155)

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/pkg/Dependency.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/Dependency.scala
@@ -29,7 +29,7 @@ object Dependency {
 
   case class FlixDependency(repo: Repository, username: String, projectName: String, version: SemVer, kind: DependencyKind) extends Dependency
 
-  case class MavenDependency(groupId: String, artifactId: String, version: SemVer, kind: DependencyKind) extends Dependency
+  case class MavenDependency(groupId: String, artifactId: String, versionTag: String, kind: DependencyKind) extends Dependency
 
   case class JarDependency(url: URL, fileName: String) extends Dependency
 

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
@@ -362,28 +362,16 @@ object ManifestParser {
   }
 
   /**
-    * Converts `depVer` to a String and then to a semantic version
-    * and returns an error if `depVer` is not of the correct format.
-    * Allowed formats are "x.x", "x.x.x", "x.x.x.x" and "x.x.x-x"
+    * A Maven version number is an uninterpreted tag. Maven (the repository) does not
+    * enforce a format for version numbers so we must be liberal about what we accept.
     */
-  def getMavenVersion(depVer: AnyRef, p: Path): Result[SemVer, ManifestError] = {
+  def getMavenVersion(depVer: AnyRef, p: Path): Result[String, ManifestError] = {
     try {
       val version = depVer.asInstanceOf[String]
-      version.split('.') match {
-        case Array(major, minor) => Ok(SemVer(major.toInt, minor.toInt, None, None, None))
-        case Array(major, minor, patch) =>
-          patch.split('-') match {
-            case Array(patch) => Ok(SemVer(major.toInt, minor.toInt, Some(patch.toInt), None, None))
-            case Array(patch, build) => Ok(SemVer(major.toInt, minor.toInt, Some(patch.toInt), None, Some(build)))
-          }
-        case Array(major, minor, patch, build) => Ok(SemVer(major.toInt, minor.toInt, Some(patch.toInt), Some(build.toInt), None))
-        case _ => Err(ManifestError.MavenVersionHasWrongLength(p, version))
-      }
+      Ok(version)
     } catch {
       case e: ClassCastException =>
         Err(ManifestError.DependencyFormatError(p, e.getMessage))
-      case e: NumberFormatException =>
-        Err(ManifestError.VersionNumberWrong(p, depVer.asInstanceOf[String], e.getMessage))
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/tools/pkg/MavenPackageManager.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/MavenPackageManager.scala
@@ -89,7 +89,7 @@ object MavenPackageManager {
   def getMavenDependencyStrings(manifest: Manifest): List[String] = {
     manifest.dependencies.collect {
       case dep: MavenDependency => dep
-    }.map(dep => s"${dep.groupId}:${dep.artifactId}:${dep.version.toString}")
+    }.map(dep => s"${dep.groupId}:${dep.artifactId}:${dep.versionTag}")
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
@@ -121,9 +121,9 @@ class TestManifestParser extends AnyFunSuite {
     assertResult(expected = List(Dependency.FlixDependency(Repository.GitHub, "jls", "tic-tac-toe", SemVer(1, 2, Some(3), None, None), DependencyKind.Production),
                                  Dependency.FlixDependency(Repository.GitHub, "mlutze", "flixball", SemVer(3, 2, Some(1), None, None), DependencyKind.Production),
                                  Dependency.FlixDependency(Repository.GitHub, "fuzzer", "fuzzer", SemVer(1, 2, Some(3), None, None), DependencyKind.Development),
-                                 Dependency.MavenDependency("org.postgresql", "postgresql", SemVer(1, 2, Some(3), Some(4), None), DependencyKind.Production),
-                                 Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", SemVer(4, 7, Some(0), None, Some("M1")), DependencyKind.Production),
-                                 Dependency.MavenDependency("org.junit", "junit", SemVer(1, 2, None, None, None), DependencyKind.Development),
+                                 Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3.4", DependencyKind.Production),
+                                 Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "4.7.0-M1", DependencyKind.Production),
+                                 Dependency.MavenDependency("org.junit", "junit", "1.2", DependencyKind.Development),
                                  Dependency.JarDependency(new URI("https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar").toURL, "myJar.jar")))(actual = {
       ManifestParser.parse(tomlCorrect, null) match {
         case Ok(manifest) => manifest.dependencies
@@ -1243,7 +1243,7 @@ class TestManifestParser extends AnyFunSuite {
     })
   }
 
-  test("Err.mvn-dependencies.format.01") {
+  test("Ok.mvn-dependencies.format.01") {
     val toml = {
       """
         |[package]
@@ -1260,13 +1260,14 @@ class TestManifestParser extends AnyFunSuite {
         |
         |""".stripMargin
     }
-    assertResult(ManifestError.MavenVersionHasWrongLength(null, "470").message(f))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest
+    assertResult(expected = List(Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3", DependencyKind.Production),
+                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "470", DependencyKind.Production)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
       case Err(e) => e.message(f)
     })
   }
 
-  test("Err.mvn-dependencies.format.02") {
+  test("Ok.mvn-dependencies.format.02") {
     val toml = {
       """
         |[package]
@@ -1283,8 +1284,9 @@ class TestManifestParser extends AnyFunSuite {
         |
         |""".stripMargin
     }
-    assertResult(ManifestError.MavenVersionHasWrongLength(null, "47").message(f))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest
+    assertResult(expected = List(Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3", DependencyKind.Production),
+                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "47", DependencyKind.Production)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
       case Err(e) => e.message(f)
     })
   }
@@ -1325,7 +1327,7 @@ class TestManifestParser extends AnyFunSuite {
         |
         |[mvn-dependencies]
         |"org.postgresql:postgresql" = "1.2.3"
-        |"org:eclipse:jetty:jetty-server" = "4.7.0-M1"
+        |"org:eclipse:jetty:jetty-server" = "4.7.0.M1"
         |
         |""".stripMargin
     }
@@ -1335,7 +1337,7 @@ class TestManifestParser extends AnyFunSuite {
     })
   }
 
-  test("Err.mvn-dependencies.numbers.01") {
+  test("Ok.mvn-dependencies.numbers.01") {
     val toml = {
       """
         |[package]
@@ -1352,13 +1354,14 @@ class TestManifestParser extends AnyFunSuite {
         |
         |""".stripMargin
     }
-    assertResult(ManifestError.VersionNumberWrong(null, "a.7.0", "For input string: \"a\"").message(f))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest
+    assertResult(expected = List(Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3", DependencyKind.Production),
+                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "a.7.0", DependencyKind.Production)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
       case Err(e) => e.message(f)
     })
   }
 
-  test("Err.mvn-dependencies.numbers.02") {
+  test("Ok.mvn-dependencies.numbers.02") {
     val toml = {
       """
         |[package]
@@ -1375,13 +1378,14 @@ class TestManifestParser extends AnyFunSuite {
         |
         |""".stripMargin
     }
-    assertResult(ManifestError.VersionNumberWrong(null, "4.b.0", "For input string: \"b\"").message(f))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest
+    assertResult(expected = List(Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3", DependencyKind.Production),
+                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "4.b.0", DependencyKind.Production)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
       case Err(e) => e.message(f)
     })
   }
 
-  test("Err.mvn-dependencies.numbers.03") {
+  test("Ok.mvn-dependencies.numbers.03") {
     val toml = {
       """
         |[package]
@@ -1398,8 +1402,9 @@ class TestManifestParser extends AnyFunSuite {
         |
         |""".stripMargin
     }
-    assertResult(ManifestError.VersionNumberWrong(null, "4.7.c", "For input string: \"c\"").message(f))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest
+    assertResult(expected = List(Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3", DependencyKind.Production),
+                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "4.7.c", DependencyKind.Production)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
       case Err(e) => e.message(f)
     })
   }
@@ -1449,7 +1454,7 @@ class TestManifestParser extends AnyFunSuite {
     })
   }
 
-  test("Err.dev-mvn-dependencies.format.01") {
+  test("Ok.dev-mvn-dependencies.format.01") {
     val toml = {
       """
         |[package]
@@ -1465,13 +1470,13 @@ class TestManifestParser extends AnyFunSuite {
         |
         |""".stripMargin
     }
-    assertResult(ManifestError.MavenVersionHasWrongLength(null, "12").message(f))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest
+    assertResult(expected = List(Dependency.MavenDependency("org.junit", "junit", "12", DependencyKind.Development)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
       case Err(e) => e.message(f)
     })
   }
 
-  test("Err.dev-mvn-dependencies.format.02") {
+  test("Ok.dev-mvn-dependencies.format.02") {
     val toml = {
       """
         |[package]
@@ -1487,8 +1492,8 @@ class TestManifestParser extends AnyFunSuite {
         |
         |""".stripMargin
     }
-    assertResult(ManifestError.MavenVersionHasWrongLength(null, "1.2.3.4.5.6").message(f))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest
+    assertResult(expected = List(Dependency.MavenDependency("org.junit", "junit", "1.2.3.4.5.6", DependencyKind.Development)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
       case Err(e) => e.message(f)
     })
   }
@@ -1537,7 +1542,7 @@ class TestManifestParser extends AnyFunSuite {
     })
   }
 
-  test("Err.dev-mvn-dependencies.numbers.01") {
+  test("Ok.dev-mvn-dependencies.numbers.01") {
     val toml = {
       """
         |[package]
@@ -1553,13 +1558,13 @@ class TestManifestParser extends AnyFunSuite {
         |
         |""".stripMargin
     }
-    assertResult(ManifestError.VersionNumberWrong(null, "a.2.3", "For input string: \"a\"").message(f))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest
+    assertResult(expected = List(Dependency.MavenDependency("org.junit", "junit", "a.2.3", DependencyKind.Development)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
       case Err(e) => e.message(f)
     })
   }
 
-  test("Err.dev-mvn-dependencies.numbers.02") {
+  test("Ok.dev-mvn-dependencies.numbers.02") {
     val toml = {
       """
         |[package]
@@ -1575,13 +1580,13 @@ class TestManifestParser extends AnyFunSuite {
         |
         |""".stripMargin
     }
-    assertResult(ManifestError.VersionNumberWrong(null, "1.b.3", "For input string: \"b\"").message(f))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest
+    assertResult(expected = List(Dependency.MavenDependency("org.junit", "junit", "1.b.3", DependencyKind.Development)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
       case Err(e) => e.message(f)
     })
   }
 
-  test("Err.dev-mvn-dependencies.numbers.03") {
+  test("Ok.dev-mvn-dependencies.numbers.03") {
     val toml = {
       """
         |[package]
@@ -1597,8 +1602,8 @@ class TestManifestParser extends AnyFunSuite {
         |
         |""".stripMargin
     }
-    assertResult(ManifestError.VersionNumberWrong(null, "1.2.c", "For input string: \"c\"").message(f))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest
+    assertResult(expected = List(Dependency.MavenDependency("org.junit", "junit", "1.2.c", DependencyKind.Development)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
       case Err(e) => e.message(f)
     })
   }

--- a/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
@@ -132,6 +132,235 @@ class TestManifestParser extends AnyFunSuite {
     })
   }
 
+  test("Ok.mvn-dependencies.format.01") {
+    val toml = {
+      """
+        |[package]
+        |name = "hello-world"
+        |description = "A simple program"
+        |version = "0.1.0"
+        |flix = "0.33.0"
+        |license = "Apache-2.0"
+        |authors = ["John Doe <john@example.com>"]
+        |
+        |[mvn-dependencies]
+        |"org.postgresql:postgresql" = "1.2.3"
+        |"org.eclipse.jetty:jetty-server" = "470"
+        |
+        |""".stripMargin
+    }
+    assertResult(expected = List(Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3", DependencyKind.Production),
+                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "470", DependencyKind.Production)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
+      case Err(e) => e.message(f)
+    })
+  }
+
+  test("Ok.mvn-dependencies.format.02") {
+    val toml = {
+      """
+        |[package]
+        |name = "hello-world"
+        |description = "A simple program"
+        |version = "0.1.0"
+        |flix = "0.33.0"
+        |license = "Apache-2.0"
+        |authors = ["John Doe <john@example.com>"]
+        |
+        |[mvn-dependencies]
+        |"org.postgresql:postgresql" = "1.2.3"
+        |"org.eclipse.jetty:jetty-server" = "47"
+        |
+        |""".stripMargin
+    }
+    assertResult(expected = List(Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3", DependencyKind.Production),
+                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "47", DependencyKind.Production)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
+      case Err(e) => e.message(f)
+    })
+  }
+
+  test("Ok.mvn-dependencies.numbers.01") {
+    val toml = {
+      """
+        |[package]
+        |name = "hello-world"
+        |description = "A simple program"
+        |version = "0.1.0"
+        |flix = "0.33.0"
+        |license = "Apache-2.0"
+        |authors = ["John Doe <john@example.com>"]
+        |
+        |[mvn-dependencies]
+        |"org.postgresql:postgresql" = "1.2.3"
+        |"org.eclipse.jetty:jetty-server" = "a.7.0"
+        |
+        |""".stripMargin
+    }
+    assertResult(expected = List(Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3", DependencyKind.Production),
+                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "a.7.0", DependencyKind.Production)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
+      case Err(e) => e.message(f)
+    })
+  }
+
+  test("Ok.mvn-dependencies.numbers.02") {
+    val toml = {
+      """
+        |[package]
+        |name = "hello-world"
+        |description = "A simple program"
+        |version = "0.1.0"
+        |flix = "0.33.0"
+        |license = "Apache-2.0"
+        |authors = ["John Doe <john@example.com>"]
+        |
+        |[mvn-dependencies]
+        |"org.postgresql:postgresql" = "1.2.3"
+        |"org.eclipse.jetty:jetty-server" = "4.b.0"
+        |
+        |""".stripMargin
+    }
+    assertResult(expected = List(Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3", DependencyKind.Production),
+                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "4.b.0", DependencyKind.Production)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
+      case Err(e) => e.message(f)
+    })
+  }
+
+  test("Ok.mvn-dependencies.numbers.03") {
+    val toml = {
+      """
+        |[package]
+        |name = "hello-world"
+        |description = "A simple program"
+        |version = "0.1.0"
+        |flix = "0.33.0"
+        |license = "Apache-2.0"
+        |authors = ["John Doe <john@example.com>"]
+        |
+        |[mvn-dependencies]
+        |"org.postgresql:postgresql" = "1.2.3"
+        |"org.eclipse.jetty:jetty-server" = "4.7.c"
+        |
+        |""".stripMargin
+    }
+    assertResult(expected = List(Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3", DependencyKind.Production),
+                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "4.7.c", DependencyKind.Production)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
+      case Err(e) => e.message(f)
+    })
+  }
+  test("Ok.dev-mvn-dependencies.format.01") {
+    val toml = {
+      """
+        |[package]
+        |name = "hello-world"
+        |description = "A simple program"
+        |version = "0.1.0"
+        |flix = "0.33.0"
+        |license = "Apache-2.0"
+        |authors = ["John Doe <john@example.com>"]
+        |
+        |[dev-mvn-dependencies]
+        |"org.junit:junit" = "12"
+        |
+        |""".stripMargin
+    }
+    assertResult(expected = List(Dependency.MavenDependency("org.junit", "junit", "12", DependencyKind.Development)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
+      case Err(e) => e.message(f)
+    })
+  }
+
+  test("Ok.dev-mvn-dependencies.format.02") {
+    val toml = {
+      """
+        |[package]
+        |name = "hello-world"
+        |description = "A simple program"
+        |version = "0.1.0"
+        |flix = "0.33.0"
+        |license = "Apache-2.0"
+        |authors = ["John Doe <john@example.com>"]
+        |
+        |[dev-mvn-dependencies]
+        |"org.junit:junit" = "1.2.3.4.5.6"
+        |
+        |""".stripMargin
+    }
+    assertResult(expected = List(Dependency.MavenDependency("org.junit", "junit", "1.2.3.4.5.6", DependencyKind.Development)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
+      case Err(e) => e.message(f)
+    })
+  }
+
+  test("Ok.dev-mvn-dependencies.numbers.01") {
+    val toml = {
+      """
+        |[package]
+        |name = "hello-world"
+        |description = "A simple program"
+        |version = "0.1.0"
+        |flix = "0.33.0"
+        |license = "Apache-2.0"
+        |authors = ["John Doe <john@example.com>"]
+        |
+        |[dev-mvn-dependencies]
+        |"org.junit:junit" = "a.2.3"
+        |
+        |""".stripMargin
+    }
+    assertResult(expected = List(Dependency.MavenDependency("org.junit", "junit", "a.2.3", DependencyKind.Development)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
+      case Err(e) => e.message(f)
+    })
+  }
+
+  test("Ok.dev-mvn-dependencies.numbers.02") {
+    val toml = {
+      """
+        |[package]
+        |name = "hello-world"
+        |description = "A simple program"
+        |version = "0.1.0"
+        |flix = "0.33.0"
+        |license = "Apache-2.0"
+        |authors = ["John Doe <john@example.com>"]
+        |
+        |[dev-mvn-dependencies]
+        |"org.junit:junit" = "1.b.3"
+        |
+        |""".stripMargin
+    }
+    assertResult(expected = List(Dependency.MavenDependency("org.junit", "junit", "1.b.3", DependencyKind.Development)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
+      case Err(e) => e.message(f)
+    })
+  }
+
+  test("Ok.dev-mvn-dependencies.numbers.03") {
+    val toml = {
+      """
+        |[package]
+        |name = "hello-world"
+        |description = "A simple program"
+        |version = "0.1.0"
+        |flix = "0.33.0"
+        |license = "Apache-2.0"
+        |authors = ["John Doe <john@example.com>"]
+        |
+        |[dev-mvn-dependencies]
+        |"org.junit:junit" = "1.2.c"
+        |
+        |""".stripMargin
+    }
+    assertResult(expected = List(Dependency.MavenDependency("org.junit", "junit", "1.2.c", DependencyKind.Development)))(ManifestParser.parse(toml, null) match {
+      case Ok(manifest) => manifest.dependencies
+      case Err(e) => e.message(f)
+    })
+  }
+
   /*
   * Errors
   * */
@@ -1243,55 +1472,8 @@ class TestManifestParser extends AnyFunSuite {
     })
   }
 
-  test("Ok.mvn-dependencies.format.01") {
-    val toml = {
-      """
-        |[package]
-        |name = "hello-world"
-        |description = "A simple program"
-        |version = "0.1.0"
-        |flix = "0.33.0"
-        |license = "Apache-2.0"
-        |authors = ["John Doe <john@example.com>"]
-        |
-        |[mvn-dependencies]
-        |"org.postgresql:postgresql" = "1.2.3"
-        |"org.eclipse.jetty:jetty-server" = "470"
-        |
-        |""".stripMargin
-    }
-    assertResult(expected = List(Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3", DependencyKind.Production),
-                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "470", DependencyKind.Production)))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest.dependencies
-      case Err(e) => e.message(f)
-    })
-  }
 
-  test("Ok.mvn-dependencies.format.02") {
-    val toml = {
-      """
-        |[package]
-        |name = "hello-world"
-        |description = "A simple program"
-        |version = "0.1.0"
-        |flix = "0.33.0"
-        |license = "Apache-2.0"
-        |authors = ["John Doe <john@example.com>"]
-        |
-        |[mvn-dependencies]
-        |"org.postgresql:postgresql" = "1.2.3"
-        |"org.eclipse.jetty:jetty-server" = "47"
-        |
-        |""".stripMargin
-    }
-    assertResult(expected = List(Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3", DependencyKind.Production),
-                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "47", DependencyKind.Production)))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest.dependencies
-      case Err(e) => e.message(f)
-    })
-  }
-
-  test("Err.mvn-dependencies.format.03") {
+  test("Err.mvn-dependencies.format.01") {
     val toml = {
       """
         |[package]
@@ -1314,7 +1496,7 @@ class TestManifestParser extends AnyFunSuite {
     })
   }
 
-  test("Err.mvn-dependencies.format.04") {
+  test("Err.mvn-dependencies.format.02") {
     val toml = {
       """
         |[package]
@@ -1337,77 +1519,6 @@ class TestManifestParser extends AnyFunSuite {
     })
   }
 
-  test("Ok.mvn-dependencies.numbers.01") {
-    val toml = {
-      """
-        |[package]
-        |name = "hello-world"
-        |description = "A simple program"
-        |version = "0.1.0"
-        |flix = "0.33.0"
-        |license = "Apache-2.0"
-        |authors = ["John Doe <john@example.com>"]
-        |
-        |[mvn-dependencies]
-        |"org.postgresql:postgresql" = "1.2.3"
-        |"org.eclipse.jetty:jetty-server" = "a.7.0"
-        |
-        |""".stripMargin
-    }
-    assertResult(expected = List(Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3", DependencyKind.Production),
-                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "a.7.0", DependencyKind.Production)))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest.dependencies
-      case Err(e) => e.message(f)
-    })
-  }
-
-  test("Ok.mvn-dependencies.numbers.02") {
-    val toml = {
-      """
-        |[package]
-        |name = "hello-world"
-        |description = "A simple program"
-        |version = "0.1.0"
-        |flix = "0.33.0"
-        |license = "Apache-2.0"
-        |authors = ["John Doe <john@example.com>"]
-        |
-        |[mvn-dependencies]
-        |"org.postgresql:postgresql" = "1.2.3"
-        |"org.eclipse.jetty:jetty-server" = "4.b.0"
-        |
-        |""".stripMargin
-    }
-    assertResult(expected = List(Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3", DependencyKind.Production),
-                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "4.b.0", DependencyKind.Production)))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest.dependencies
-      case Err(e) => e.message(f)
-    })
-  }
-
-  test("Ok.mvn-dependencies.numbers.03") {
-    val toml = {
-      """
-        |[package]
-        |name = "hello-world"
-        |description = "A simple program"
-        |version = "0.1.0"
-        |flix = "0.33.0"
-        |license = "Apache-2.0"
-        |authors = ["John Doe <john@example.com>"]
-        |
-        |[mvn-dependencies]
-        |"org.postgresql:postgresql" = "1.2.3"
-        |"org.eclipse.jetty:jetty-server" = "4.7.c"
-        |
-        |""".stripMargin
-    }
-    assertResult(expected = List(Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3", DependencyKind.Production),
-                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "4.7.c", DependencyKind.Production)))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest.dependencies
-      case Err(e) => e.message(f)
-    })
-  }
 
   //Dev-mvn-dependencies
   test("Err.dev-mvn-dependencies.type") {
@@ -1454,51 +1565,7 @@ class TestManifestParser extends AnyFunSuite {
     })
   }
 
-  test("Ok.dev-mvn-dependencies.format.01") {
-    val toml = {
-      """
-        |[package]
-        |name = "hello-world"
-        |description = "A simple program"
-        |version = "0.1.0"
-        |flix = "0.33.0"
-        |license = "Apache-2.0"
-        |authors = ["John Doe <john@example.com>"]
-        |
-        |[dev-mvn-dependencies]
-        |"org.junit:junit" = "12"
-        |
-        |""".stripMargin
-    }
-    assertResult(expected = List(Dependency.MavenDependency("org.junit", "junit", "12", DependencyKind.Development)))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest.dependencies
-      case Err(e) => e.message(f)
-    })
-  }
-
-  test("Ok.dev-mvn-dependencies.format.02") {
-    val toml = {
-      """
-        |[package]
-        |name = "hello-world"
-        |description = "A simple program"
-        |version = "0.1.0"
-        |flix = "0.33.0"
-        |license = "Apache-2.0"
-        |authors = ["John Doe <john@example.com>"]
-        |
-        |[dev-mvn-dependencies]
-        |"org.junit:junit" = "1.2.3.4.5.6"
-        |
-        |""".stripMargin
-    }
-    assertResult(expected = List(Dependency.MavenDependency("org.junit", "junit", "1.2.3.4.5.6", DependencyKind.Development)))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest.dependencies
-      case Err(e) => e.message(f)
-    })
-  }
-
-  test("Err.dev-mvn-dependencies.format.03") {
+  test("Err.dev-mvn-dependencies.format.01") {
     val toml = {
       """
         |[package]
@@ -1520,7 +1587,7 @@ class TestManifestParser extends AnyFunSuite {
     })
   }
 
-  test("Err.dev-mvn-dependencies.format.04") {
+  test("Err.dev-mvn-dependencies.format.02") {
     val toml = {
       """
         |[package]
@@ -1538,72 +1605,6 @@ class TestManifestParser extends AnyFunSuite {
     }
     assertResult(ManifestError.MavenDependencyFormatError(null, "org:junit:junit").message(f))(ManifestParser.parse(toml, null) match {
       case Ok(manifest) => manifest
-      case Err(e) => e.message(f)
-    })
-  }
-
-  test("Ok.dev-mvn-dependencies.numbers.01") {
-    val toml = {
-      """
-        |[package]
-        |name = "hello-world"
-        |description = "A simple program"
-        |version = "0.1.0"
-        |flix = "0.33.0"
-        |license = "Apache-2.0"
-        |authors = ["John Doe <john@example.com>"]
-        |
-        |[dev-mvn-dependencies]
-        |"org.junit:junit" = "a.2.3"
-        |
-        |""".stripMargin
-    }
-    assertResult(expected = List(Dependency.MavenDependency("org.junit", "junit", "a.2.3", DependencyKind.Development)))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest.dependencies
-      case Err(e) => e.message(f)
-    })
-  }
-
-  test("Ok.dev-mvn-dependencies.numbers.02") {
-    val toml = {
-      """
-        |[package]
-        |name = "hello-world"
-        |description = "A simple program"
-        |version = "0.1.0"
-        |flix = "0.33.0"
-        |license = "Apache-2.0"
-        |authors = ["John Doe <john@example.com>"]
-        |
-        |[dev-mvn-dependencies]
-        |"org.junit:junit" = "1.b.3"
-        |
-        |""".stripMargin
-    }
-    assertResult(expected = List(Dependency.MavenDependency("org.junit", "junit", "1.b.3", DependencyKind.Development)))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest.dependencies
-      case Err(e) => e.message(f)
-    })
-  }
-
-  test("Ok.dev-mvn-dependencies.numbers.03") {
-    val toml = {
-      """
-        |[package]
-        |name = "hello-world"
-        |description = "A simple program"
-        |version = "0.1.0"
-        |flix = "0.33.0"
-        |license = "Apache-2.0"
-        |authors = ["John Doe <john@example.com>"]
-        |
-        |[dev-mvn-dependencies]
-        |"org.junit:junit" = "1.2.c"
-        |
-        |""".stripMargin
-    }
-    assertResult(expected = List(Dependency.MavenDependency("org.junit", "junit", "1.2.c", DependencyKind.Development)))(ManifestParser.parse(toml, null) match {
-      case Ok(manifest) => manifest.dependencies
       case Err(e) => e.message(f)
     })
   }


### PR DESCRIPTION
This PR relaxes the Packager so `MavenDependency` now parses the version number of a Maven package dependency a just as `String` and not a `SemVer`. Maven (the repository) does not enforce adherence to SemVars so the Packager has to be relaxed about what it parses. 

I've reordered the tests in `TestManifestParser.scala` so it looks like there are a lot of changes but really this is just changing the Maven dependency parsing examples to "Ok" tests as they no longer fail when the tag is not a strict `SemVer`.