### PR TITLE
refactor: fix `Expression.Resume` case in `ClosureConv`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/ClosureConv.scala
@@ -479,7 +479,7 @@ object ClosureConv {
 
       case Expression.Resume(exp, tpe, loc) =>
         val e = visitExp(exp)
-        Expression.Resume(exp, tpe, loc)
+        Expression.Resume(e, tpe, loc)
 
       case Expression.InvokeConstructor(constructor, args, tpe, purity, loc) =>
         val as = args.map(visitExp)


### PR DESCRIPTION
The visited exp was unused