### PR TITLE
refactor: `DocAst` contain ret type directly

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -16,8 +16,7 @@
 
 package ca.uwaterloo.flix.language.dbg
 
-import ca.uwaterloo.flix.language.ast.{Ast, AtomicOp, Name, SourceLocation, Symbol}
-import ca.uwaterloo.flix.util.InternalCompilerException
+import ca.uwaterloo.flix.language.ast.{Ast, Name, Symbol}
 
 import java.lang.reflect.{Constructor, Field, Method}
 
@@ -293,97 +292,6 @@ object DocAst {
     def Present(d: Expression): Expression =
       App(AsIs("Present"), List(d))
 
-    // Temporary function to reduce code duplication until DocAst uses AtomicOp.
-    def fromAtomic(op: AtomicOp, es: List[Expression], tpe: Type, loc: SourceLocation): Expression = op match {
-      case AtomicOp.Closure(sym) => DocAst.Expression.ClosureLifted(sym, es)
-
-      case AtomicOp.Unary(sop) => DocAst.Expression.Unary(printer.OpPrinter.print(sop), es.head)
-
-      case AtomicOp.Binary(sop) =>
-        val List(e1, e2) = es
-        DocAst.Expression.Binary(e1, printer.OpPrinter.print(sop), e2)
-
-      case AtomicOp.Region => DocAst.Expression.Region
-
-      case AtomicOp.ScopeExit =>
-        val List(e1, e2) = es
-        DocAst.Expression.ScopeExit(e1, e2)
-
-      case AtomicOp.Is(sym) => DocAst.Expression.Is(sym, es.head)
-
-      case AtomicOp.Tag(sym) => DocAst.Expression.Tag(sym, es)
-
-      case AtomicOp.Untag(sym) => DocAst.Expression.Untag(sym, es.head)
-
-      case AtomicOp.Index(idx) => DocAst.Expression.Index(idx, es.head)
-
-      case AtomicOp.Tuple => DocAst.Expression.Tuple(es)
-
-      case AtomicOp.RecordEmpty => DocAst.Expression.RecordEmpty
-
-      case AtomicOp.RecordSelect(field) => DocAst.Expression.RecordSelect(field, es.head)
-
-      case AtomicOp.RecordRestrict(field) => DocAst.Expression.RecordRestrict(field, es.head)
-
-      case AtomicOp.ArrayLit => DocAst.Expression.ArrayLit(es)
-
-      case AtomicOp.ArrayNew =>
-        val List(e1, e2) = es
-        DocAst.Expression.ArrayNew(e1, e2)
-
-      case AtomicOp.ArrayLoad =>
-        val List(e1, e2) = es
-        DocAst.Expression.ArrayLoad(e1, e2)
-
-      case AtomicOp.ArrayStore =>
-        val List(e1, e2, e3) = es
-        DocAst.Expression.ArrayStore(e1, e2, e3)
-
-      case AtomicOp.ArrayLength =>
-        DocAst.Expression.ArrayLength(es.head)
-
-      case AtomicOp.Ref => DocAst.Expression.Ref(es.head)
-
-      case AtomicOp.Deref => DocAst.Expression.Deref(es.head)
-
-      case AtomicOp.Assign =>
-        val List(e1, e2) = es
-        DocAst.Expression.Assign(e1, e2)
-
-      case AtomicOp.InstanceOf(clazz) => DocAst.Expression.InstanceOf(es.head, clazz)
-
-      case AtomicOp.Cast => DocAst.Expression.Cast(es.head, tpe)
-
-      case AtomicOp.InvokeConstructor(constructor) => DocAst.Expression.JavaInvokeConstructor(constructor, es)
-
-      case AtomicOp.InvokeMethod(method) => DocAst.Expression.JavaInvokeMethod(method, es.head, es.tail)
-
-      case AtomicOp.InvokeStaticMethod(method) => DocAst.Expression.JavaInvokeStaticMethod(method, es)
-
-      case AtomicOp.GetField(field) => DocAst.Expression.JavaGetField(field, es.head)
-
-      case AtomicOp.PutField(field) =>
-        val List(e1, e2) = es
-        DocAst.Expression.JavaPutField(field, e1, e2)
-
-      case AtomicOp.GetStaticField(field) => DocAst.Expression.JavaGetStaticField(field)
-
-      case AtomicOp.PutStaticField(field) => DocAst.Expression.JavaPutStaticField(field, es.head)
-
-      case AtomicOp.Spawn =>
-        val List(e1, e2) = es
-        DocAst.Expression.Spawn(e1, e2)
-
-      case AtomicOp.Lazy => DocAst.Expression.Lazy(es.head)
-
-      case AtomicOp.Force => DocAst.Expression.Force(es.head)
-
-      case AtomicOp.HoleError(sym) => DocAst.Expression.HoleError(sym)
-
-      case AtomicOp.MatchError => DocAst.Expression.MatchError
-
-      case _ => throw InternalCompilerException(s"Unexpected AtomicOp in LiftedAstPrinter: $op", loc)
-    }
   }
 
   sealed trait Type

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAstFormatter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAstFormatter.scala
@@ -45,14 +45,8 @@ object DocAstFormatter {
         val d = text("enum") +: text(sym.toString) :: tparamsf +: casesf
         ((sym.namespace :+ sym.name: Seq[String], sym.name), d)
     }
-    // remember that the def type includes the arguments
-    // TODO EVIL afoot! change to expect result type directly
     val defs = defs0.map {
-      case Def(_, _, sym, parameters, resType0, body) =>
-        val resType = resType0 match {
-          case Type.Arrow(_, res) => res
-          case _ => Type.AsIs(meta("no return type"))
-        }
+      case Def(_, _, sym, parameters, resType, body) =>
         val name = sym.toString
         val args = parameters.map(aux(_, paren = false))
         val resTypef = formatType(resType, paren = false)

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ErasedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ErasedAstPrinter.scala
@@ -44,7 +44,7 @@ object ErasedAstPrinter {
           mod,
           sym,
           (cparams ++ fparams).map(printFormalParam),
-          DocAst.Type.Arrow(Nil, MonoTypePrinter.print(tpe)),
+          MonoTypePrinter.print(tpe),
           print(exp)
         )
     }.toList

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
@@ -42,7 +42,7 @@ object LiftedAstPrinter {
           mod,
           sym,
           (cparams ++ fparams).map(printFormalParam),
-          DocAst.Type.Arrow(Nil, TypePrinter.print(tpe)),
+          TypePrinter.print(tpe),
           print(exp)
         )
     }.toList

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
@@ -55,7 +55,7 @@ object LiftedAstPrinter {
   def print(e: LiftedAst.Expression): DocAst.Expression = e match {
     case Cst(cst, _, _) => ConstantPrinter.print(cst)
     case Var(sym, _, _) => printVarSym(sym)
-    case ApplyAtomic(op, exps, tpe, _, loc) => DocAst.Expression.fromAtomic(op, exps.map(print), TypePrinter.print(tpe), loc)
+    case ApplyAtomic(op, exps, tpe, _, loc) => OpPrinter.print(op, exps.map(print), TypePrinter.print(tpe))
     case ApplyClo(exp, args, _, _, _) => DocAst.Expression.ApplyClo(print(exp), args.map(print))
     case ApplyDef(sym, args, _, _, _) => DocAst.Expression.ApplyDef(sym, args.map(print))
     case ApplyCloTail(exp, args, _, _, _) => DocAst.Expression.ApplyCloTail(print(exp), args.map(print))

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
@@ -34,13 +34,13 @@ object LoweredAstPrinter {
         DocAst.Enum(ann, mod, sym, tparams.map(printTypeParam), cases)
     }.toList
     val defs = root.defs.values.map {
-      case LoweredAst.Def(sym, LoweredAst.Spec(doc, ann, mod, tparams, fparams, declaredScheme, retTpe, eff, tconstrs, loc), LoweredAst.Impl(exp, inferredScheme)) =>
+      case LoweredAst.Def(sym, LoweredAst.Spec(_, ann, mod, _, fparams, _, retTpe, _, _, _), LoweredAst.Impl(exp, _)) =>
         DocAst.Def(
           ann,
           mod,
           sym,
           fparams.map(printFormalParam),
-          DocAst.Type.Arrow(List(DocAst.Type.AsIs("ignoreme")), TypePrinter.print(retTpe)), // TODO EVIL, EVIL hack due to formatter impl
+          TypePrinter.print(retTpe),
           print(exp)
         )
     }.toList

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
@@ -58,7 +58,7 @@ object LoweredAstPrinter {
     case Expression.Hole(sym, tpe, loc) => DocAst.Expression.Hole(sym)
     case Expression.Lambda(fparam, exp, tpe, loc) => DocAst.Expression.Lambda(List(printFormalParam(fparam)), print(exp))
     case Expression.Apply(exp, exps, tpe, eff, loc) => DocAst.Expression.ApplyClo(print(exp), exps.map(print))
-    case Expression.ApplyAtomic(op, exps, tpe, _, loc) => DocAst.Expression.fromAtomic(op, exps.map(print), TypePrinter.print(tpe), loc)
+    case Expression.ApplyAtomic(op, exps, tpe, _, loc) => OpPrinter.print(op, exps.map(print), TypePrinter.print(tpe))
     case Expression.Let(sym, mod, exp1, exp2, tpe, eff, loc) => DocAst.Expression.Let(DocAst.Expression.Var(sym), None, print(exp1), print(exp2))
     case Expression.LetRec(sym, mod, exp1, exp2, tpe, eff, loc) => DocAst.Expression.LetRec(DocAst.Expression.Var(sym), None, print(exp1), print(exp2))
     case Expression.Scope(sym, regionVar, exp, tpe, eff, loc) => DocAst.Expression.Scope(DocAst.Expression.Var(sym), print(exp))

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypedAstPrinter.scala
@@ -44,7 +44,7 @@ object MonoTypedAstPrinter {
           mod,
           sym,
           (cparams ++ fparams).map(printFormalParam),
-          DocAst.Type.Arrow(Nil, MonoTypePrinter.print(tpe)),
+          MonoTypePrinter.print(tpe),
           print(exp)
         )
     }.toList

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/OpPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/OpPrinter.scala
@@ -171,12 +171,12 @@ object OpPrinter {
     case (AtomicOp.GetStaticField(field), Nil) => JavaGetStaticField(field)
     case (AtomicOp.HoleError(sym), Nil) => HoleError(sym)
     case (AtomicOp.MatchError, Nil) => MatchError
-
     case (AtomicOp.Unary(sop), List(d)) => Unary(OpPrinter.print(sop), d)
+    case (AtomicOp.Binary(sop), List(d1, d2)) => Binary(d1, OpPrinter.print(sop), d2)
     case (AtomicOp.Is(sym), List(d)) => Is(sym, d)
     case (AtomicOp.Tag(sym), List(d)) => Tag(sym, List(d))
     case (AtomicOp.Untag(sym), List(d)) => Untag(sym, d)
-    case (AtomicOp.InstanceOf(_), List(d)) => Unknown
+    case (AtomicOp.InstanceOf(clazz), List(d)) => InstanceOf(d, clazz)
     case (AtomicOp.Cast, List(d)) => Cast(d, tpe)
     case (AtomicOp.Index(idx), List(d)) => Index(idx, d)
     case (AtomicOp.RecordSelect(field), List(d)) => RecordSelect(field, d)
@@ -204,25 +204,20 @@ object OpPrinter {
     case (AtomicOp.UnboxChar, List(d)) => Unbox(d)
     case (AtomicOp.UnboxFloat32, List(d)) => Unbox(d)
     case (AtomicOp.UnboxFloat64, List(d)) => Unbox(d)
-
     case (AtomicOp.Closure(sym), _) => ClosureLifted(sym, ds)
     case (AtomicOp.Tuple, _) => Tuple(ds)
     case (AtomicOp.ArrayLit, _) => ArrayLit(ds)
     case (AtomicOp.InvokeConstructor(constructor), _) => JavaInvokeConstructor(constructor, ds)
     case (AtomicOp.InvokeStaticMethod(method), _) => JavaInvokeStaticMethod(method, ds)
-
-    case (AtomicOp.RecordExtend(field), d1 :: d2 :: Nil) => RecordExtend(field, d1, d2)
-    case (AtomicOp.Assign, d1 :: d2 :: Nil) => Assign(d1, d2)
-    case (AtomicOp.ArrayNew, d1 :: d2 :: Nil) => ArrayNew(d1, d2)
-    case (AtomicOp.ArrayLoad, d1 :: d2 :: Nil) => ArrayLoad(d1, d2)
-    case (AtomicOp.Spawn, d1 :: d2 :: Nil) => Spawn(d1, d2)
-    case (AtomicOp.ScopeExit, d1 :: d2 :: Nil) => ScopeExit(d1, d2)
-    case (AtomicOp.PutField(field), d1 :: d2 :: Nil) => JavaPutField(field, d1, d2)
-
-    case (AtomicOp.ArrayStore, d1 :: d2 :: d3 :: Nil) => ArrayStore(d1, d2, d3)
-
+    case (AtomicOp.RecordExtend(field), List(d1, d2)) => RecordExtend(field, d1, d2)
+    case (AtomicOp.Assign, List(d1, d2)) => Assign(d1, d2)
+    case (AtomicOp.ArrayNew, List(d1, d2)) => ArrayNew(d1, d2)
+    case (AtomicOp.ArrayLoad, List(d1, d2)) => ArrayLoad(d1, d2)
+    case (AtomicOp.Spawn, List(d1, d2)) => Spawn(d1, d2)
+    case (AtomicOp.ScopeExit, List(d1, d2)) => ScopeExit(d1, d2)
+    case (AtomicOp.PutField(field), List(d1, d2)) => JavaPutField(field, d1, d2)
+    case (AtomicOp.ArrayStore, List(d1, d2, d3)) => ArrayStore(d1, d2, d3)
     case (AtomicOp.InvokeMethod(method), d :: rs) => JavaInvokeMethod(method, d, rs)
-
     // fall back if non other applies
     case (op, ds) => App(Meta(op.toString), ds)
   }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
@@ -43,7 +43,7 @@ object ReducedAstPrinter {
           mod,
           sym,
           (cparams ++ fparams).map(printFormalParam),
-          DocAst.Type.Arrow(Nil, TypePrinter.print(tpe)),
+          TypePrinter.print(tpe),
           print(stmt)
         )
     }.toList

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
@@ -42,7 +42,7 @@ object SimplifiedAstPrinter {
           mod,
           sym,
           formals.map(printFormalParam),
-          DocAst.Type.Arrow(Nil, TypePrinter.print(tpe)),
+          TypePrinter.print(tpe),
           print(exp)
         )
     }.toList

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
@@ -59,7 +59,7 @@ object SimplifiedAstPrinter {
     case Lambda(fparams, exp, _, _) => DocAst.Expression.Lambda(fparams.map(printFormalParam), print(exp))
     case Apply(exp, args, _, _, _) => DocAst.Expression.App(print(exp), args.map(print))
     case LambdaClosure(cparams, fparams, _, exp, _, _) => DocAst.Expression.Lambda((cparams ++ fparams).map(printFormalParam), print(exp))
-    case ApplyAtomic(op, exps, tpe, _, loc) => DocAst.Expression.fromAtomic(op, exps.map(print), TypePrinter.print(tpe), loc)
+    case ApplyAtomic(op, exps, tpe, _, loc) => OpPrinter.print(op, exps.map(print), TypePrinter.print(tpe))
     case ApplyClo(exp, args, _, _, _) => DocAst.Expression.ApplyClo(print(exp), args.map(print))
     case ApplyDef(sym, args, _, _, _) => DocAst.Expression.ApplyDef(sym, args.map(print))
     case IfThenElse(exp1, exp2, exp3, _, _, _) => DocAst.Expression.IfThenElse(print(exp1), print(exp2), print(exp3))


### PR DESCRIPTION
* changed the DocAst.Def to have the return type directly
* Removed the `DocAst.Expression.fromAtomic` function since its a duplicate function to `OpPrinter.print`, sorry for the confusing namespaces jakob (note: debug printers should not throw!)