### PR TITLE
feat: add specific boolean unification errors

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -310,7 +310,63 @@ object TypeError {
       s"""${line(kind, source.name)}
          |>> Unable to unify the Boolean formulas: '${red(formatType(baseType1, Some(renv)))}' and '${red(formatType(baseType2, Some(renv)))}'.
          |
-         |${code(loc, "mismatched boolean formulas.")}
+         |${code(loc, "mismatched Boolean formulas.")}
+         |
+         |Type One: ${cyan(formatType(fullType1, Some(renv)))}
+         |Type Two: ${magenta(formatType(fullType2, Some(renv)))}
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+    * Mismatched Effect Formulas.
+    *
+    * @param baseType1 the first effect formula.
+    * @param baseType2 the second effect formula.
+    * @param fullType1 the first full type in which the first effect formula occurs.
+    * @param fullType2 the second full type in which the second effect formula occurs.
+    * @param renv      the rigidity environment.
+    * @param loc       the location where the error occurred.
+    */
+  case class MismatchedEffects(baseType1: Type, baseType2: Type, fullType1: Type, fullType2: Type, renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
+    def summary: String = s"Unable to unify the effect formulas '${formatType(baseType1, Some(renv))}' and '${formatType(baseType2, Some(renv))}'."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Unable to unify the effect formulas: '${red(formatType(baseType1, Some(renv)))}' and '${red(formatType(baseType2, Some(renv)))}'.
+         |
+         |${code(loc, "mismatched effect formulas.")}
+         |
+         |Type One: ${cyan(formatType(fullType1, Some(renv)))}
+         |Type Two: ${magenta(formatType(fullType2, Some(renv)))}
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+    * Mismatched Case Set Formulas.
+    *
+    * @param baseType1 the first case set formula.
+    * @param baseType2 the second case set formula.
+    * @param fullType1 the first full type in which the first case set formula occurs.
+    * @param fullType2 the second full type in which the second case set formula occurs.
+    * @param renv      the rigidity environment.
+    * @param loc       the location where the error occurred.
+    */
+  case class MismatchedCaseSets(baseType1: Type, baseType2: Type, fullType1: Type, fullType2: Type, renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
+    def summary: String = s"Unable to unify the case set formulas '${formatType(baseType1, Some(renv))}' and '${formatType(baseType2, Some(renv))}'."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Unable to unify the case set formulas: '${red(formatType(baseType1, Some(renv)))}' and '${red(formatType(baseType2, Some(renv)))}'.
+         |
+         |${code(loc, "mismatched case set formulas.")}
          |
          |Type One: ${cyan(formatType(fullType1, Some(renv)))}
          |Type Two: ${magenta(formatType(fullType2, Some(renv)))}
@@ -330,7 +386,7 @@ object TypeError {
     * @param renv      the rigidity environment.
     * @param loc       the location where the error occurred.
     */
-  case class MismatchedArrowBools(baseType1: Type, baseType2: Type, fullType1: Type, fullType2: Type, renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
+  case class MismatchedArrowEffects(baseType1: Type, baseType2: Type, fullType1: Type, fullType2: Type, renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
     def summary: String = s"Mismatched Pure and Effectful Functions."
 
     def message(formatter: Formatter): String = {

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/CaseSetUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/CaseSetUnification.scala
@@ -98,7 +98,7 @@ object CaseSetUnification {
       case SetUnificationException =>
         val t1 = toCaseType(tpe1, sym, env, SourceLocation.Unknown)
         val t2 = toCaseType(tpe2, sym, env, SourceLocation.Unknown)
-        Err(UnificationError.MismatchedBools(t1, t2)) // TODO make setty
+        Err(UnificationError.MismatchedCaseSets(t1, t2))
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification.scala
@@ -162,7 +162,7 @@ object EffUnification {
     // Run the expensive Boolean unification algorithm.
     //
     booleanUnification(f1, f2, renv) match {
-      case None => UnificationError.MismatchedBools(tpe1, tpe2).toErr
+      case None => UnificationError.MismatchedEffects(tpe1, tpe2).toErr
       case Some(subst) =>
         if (!flix.options.xnoboolcache) {
           cache.put(f1, f2, renv, subst)

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -185,11 +185,17 @@ object Unification {
           }
 
         case Result.Err(UnificationError.MismatchedBools(baseType1, baseType2)) =>
+          Err(TypeError.MismatchedBools(baseType1, baseType2, type1, type2, renv, loc))
+
+        case Result.Err(UnificationError.MismatchedEffects(baseType1, baseType2)) =>
           (tpe1.typeConstructor, tpe2.typeConstructor) match {
-            case (Some(TypeConstructor.Arrow(_)), _) => Err(TypeError.MismatchedArrowBools(baseType1, baseType2, type1, type2, renv, loc))
-            case (_, Some(TypeConstructor.Arrow(_))) => Err(TypeError.MismatchedArrowBools(baseType1, baseType2, type1, type2, renv, loc))
-            case _ => Err(TypeError.MismatchedBools(baseType1, baseType2, type1, type2, renv, loc))
+            case (Some(TypeConstructor.Arrow(_)), _) => Err(TypeError.MismatchedArrowEffects(baseType1, baseType2, type1, type2, renv, loc))
+            case (_, Some(TypeConstructor.Arrow(_))) => Err(TypeError.MismatchedArrowEffects(baseType1, baseType2, type1, type2, renv, loc))
+            case _ => Err(TypeError.MismatchedEffects(baseType1, baseType2, type1, type2, renv, loc))
           }
+
+        case Result.Err(UnificationError.MismatchedCaseSets(baseType1, baseType2)) =>
+          Err(TypeError.MismatchedCaseSets(baseType1, baseType2, type1, type2, renv, loc))
 
         case Result.Err(UnificationError.MismatchedArity(_, _)) =>
           Err(TypeError.MismatchedArity(tpe1, tpe2, renv, loc))
@@ -265,7 +271,7 @@ object Unification {
       case TypeError.MismatchedBools(_, _, fullType1, fullType2, renv, loc) =>
         TypeError.UnexpectedArgument(sym, i, fullType1, fullType2, renv, loc)
 
-      case TypeError.MismatchedArrowBools(_, _, fullType1, fullType2, renv, loc) =>
+      case TypeError.MismatchedArrowEffects(_, _, fullType1, fullType2, renv, loc) =>
         TypeError.UnexpectedArgument(sym, i, fullType1, fullType2, renv, loc)
 
       case TypeError.MismatchedTypes(_, _, fullType1, fullType2, renv, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/UnificationError.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/UnificationError.scala
@@ -41,6 +41,22 @@ object UnificationError {
   case class MismatchedBools(tpe1: Type, tpe2: Type) extends UnificationError
 
   /**
+    * An unification error due to a mismatch between the effect formulas `tpe1` and `tpe2`.
+    *
+    * @param tpe1 the first effect formula.
+    * @param tpe2 the second effect formula.
+    */
+  case class MismatchedEffects(tpe1: Type, tpe2: Type) extends UnificationError
+
+  /**
+    * An unification error due to a mismatch between the case set formulas `tpe1` and `tpe2`.
+    *
+    * @param tpe1 the first case set formula.
+    * @param tpe2 the second case set formula.
+    */
+  case class MismatchedCaseSets(tpe1: Type, tpe2: Type) extends UnificationError
+
+  /**
     * An unification error due to a mismatch between the arity of `ts1` and `ts2`.
     *
     * @param ts1 the first list of types.

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -448,7 +448,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.Arity1.02") {
@@ -469,7 +469,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.Arity1.03") {
@@ -490,7 +490,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.Arity1.04") {
@@ -511,7 +511,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.AbsentAbsent.01") {
@@ -532,7 +532,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.AbsentAbsent.02") {
@@ -553,7 +553,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.AbsentAbsent.03") {
@@ -574,7 +574,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.AbsentAbsent.IfThenElse.01") {
@@ -595,7 +595,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.AbsentAbsent.IfThenElse.02") {
@@ -616,7 +616,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.AbsentPresent.01") {
@@ -637,7 +637,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.AbsentPresent.02") {
@@ -658,7 +658,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.AbsentPresent.03") {
@@ -679,7 +679,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.AbsentPresent.IfThenElse.01") {
@@ -700,7 +700,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.AbsentPresent.IfThenElse.02") {
@@ -721,7 +721,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.TwoCases.01") {
@@ -743,7 +743,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.TwoCases.02") {
@@ -765,7 +765,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.TwoCases.03") {
@@ -787,7 +787,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.TwoCases.04") {
@@ -809,7 +809,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.ThreeCases.01") {
@@ -832,7 +832,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.ThreeCases.02") {
@@ -855,7 +855,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.If.01") {
@@ -877,7 +877,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.If.02") {
@@ -899,7 +899,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.If.03") {
@@ -921,7 +921,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.If.04") {
@@ -943,7 +943,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.If.05") {
@@ -965,7 +965,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("TestChoose.If.06") {
@@ -987,7 +987,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("Test.Choice.Param.01") {
@@ -1047,7 +1047,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("Test.Choice.Empty.02") {
@@ -1071,7 +1071,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("Test.ChooseStar.01") {
@@ -1096,7 +1096,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("Test.ChooseStar.02") {
@@ -1120,7 +1120,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    isAbsent(f(Absent))
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("Test.ChooseStar.03") {
@@ -1144,7 +1144,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    isAbsent(f(Present(123), Present(456)))
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedBools](result)
   }
 
   test("Test.ImpureDeclaredAsPure.01") {
@@ -1399,7 +1399,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |def foo(): Unit = disjoint(_ -> do E.op(), _ -> do E.op())
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[TypeError.MismatchedArrowBools](result)
+    expectError[TypeError.MismatchedArrowEffects](result)
   }
 
   // TODO EFF-MIGRATION temporarily disabled
@@ -1441,7 +1441,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |     g()
         |""".stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[TypeError.MismatchedBools](result)
+    expectError[TypeError.MismatchedEffects](result)
   }
 
   test("TestParYield.02") {
@@ -1452,7 +1452,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |     g()
         |""".stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[TypeError.MismatchedBools](result)
+    expectError[TypeError.MismatchedEffects](result)
   }
 
   test("TestParYield.03") {
@@ -1463,7 +1463,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |     g()
         |""".stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[TypeError.MismatchedBools](result)
+    expectError[TypeError.MismatchedEffects](result)
   }
 
   test("TestParYield.04") {
@@ -1570,7 +1570,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    case Expr.Var(_) => true
         |}
         |""".stripMargin
-    expectError[TypeError.MismatchedBools](compile(input, Options.TestWithLibNix))
+    expectError[TypeError.MismatchedCaseSets](compile(input, Options.TestWithLibNix))
   }
 
   test("TestChoose.02") {
@@ -1593,7 +1593,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |     h(Expr.Var)
         | }
         |""".stripMargin
-    expectError[TypeError.MismatchedArrowBools](compile(input, Options.TestWithLibNix))
+    expectError[TypeError.MismatchedCaseSets](compile(input, Options.TestWithLibNix))
   }
 
   test("TestChoose.03") {
@@ -1621,7 +1621,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |     h(cstOrNotOrVar)
         | }
         |""".stripMargin
-    expectError[TypeError.MismatchedArrowBools](compile(input, Options.TestWithLibNix))
+    expectError[TypeError.MismatchedCaseSets](compile(input, Options.TestWithLibNix))
   }
 
   test("TestChooseStar.01") {
@@ -1641,7 +1641,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    }
         |}
         |""".stripMargin
-    expectError[TypeError.MismatchedBools](compile(input, Options.TestWithLibNix))
+    expectError[TypeError.MismatchedCaseSets](compile(input, Options.TestWithLibNix))
   }
 
   test("TestChooseStar.02") {
@@ -1663,7 +1663,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    }
         |}
         |""".stripMargin
-    expectError[TypeError.MismatchedBools](compile(input, Options.TestWithLibNix))
+    expectError[TypeError.MismatchedCaseSets](compile(input, Options.TestWithLibNix))
   }
 
   test("TestChooseStar.03") {
@@ -1685,7 +1685,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    }
         |}
         |""".stripMargin
-    expectError[TypeError.MismatchedBools](compile(input, Options.TestWithLibNix))
+    expectError[TypeError.MismatchedCaseSets](compile(input, Options.TestWithLibNix))
   }
 
   test("TestChooseStar.04") {
@@ -1708,7 +1708,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    }
         |}
         |""".stripMargin
-    expectError[TypeError.MismatchedBools](compile(input, Options.TestWithLibNix))
+    expectError[TypeError.MismatchedCaseSets](compile(input, Options.TestWithLibNix))
   }
 
   test("TestChooseStar.05") {
@@ -1729,7 +1729,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    }
         |}
         |""".stripMargin
-    expectError[TypeError.MismatchedBools](compile(input, Options.TestWithLibNix))
+    expectError[TypeError.MismatchedCaseSets](compile(input, Options.TestWithLibNix))
   }
 
   test("TestChooseStar.06") {
@@ -1747,7 +1747,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    case E.C    => E.C
         |}
         |""".stripMargin
-    expectError[TypeError.UnexpectedArgument](compile(input, Options.TestWithLibNix))
+    expectError[TypeError.MismatchedCaseSets](compile(input, Options.TestWithLibNix))
   }
 
   test("TestCaseSetAnnotation.01") {
@@ -1763,7 +1763,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    case Color.Green => false
         |}
         |""".stripMargin
-    expectError[TypeError.MismatchedBools](compile(input, Options.TestWithLibNix))
+    expectError[TypeError.MismatchedCaseSets](compile(input, Options.TestWithLibNix))
   }
 
   test("TestCaseSetAnnotation.02") {
@@ -1780,7 +1780,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    case Color.Blue => Color.Blue
         |}
         |""".stripMargin
-    expectError[TypeError.MismatchedBools](compile(input, Options.TestWithLibNix))
+    expectError[TypeError.MismatchedCaseSets](compile(input, Options.TestWithLibNix))
   }
 
   test("TestCaseSetAnnotation.03") {
@@ -1796,7 +1796,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    case Color.Blue => false
         |}
         |""".stripMargin
-    expectError[TypeError.MismatchedBools](compile(input, Options.TestWithLibNix))
+    expectError[TypeError.MismatchedCaseSets](compile(input, Options.TestWithLibNix))
   }
 
   test("TestCaseSetAnnotation.04") {
@@ -1809,7 +1809,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |// Wrong minus parsing
         |def isRed(c: Color[s -- <Color.Red> ++ <Color.Green>]): Color[(s -- <Color.Red>) ++ <Color.Green>] = c
         |""".stripMargin
-    expectError[TypeError.MismatchedBools](compile(input, Options.TestWithLibNix))
+    expectError[TypeError.MismatchedCaseSets](compile(input, Options.TestWithLibNix))
   }
 
   test("TestLetRec.01") {


### PR DESCRIPTION
fixes #6066

```
❌ -- Type Error --------------------------------------------------

>> Unable to unify the Boolean formulas: 'true' and 'false'.

152 | def test02(): Bool = mkTrue() == mkNot(mkTrue())
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
                           mismatched Boolean formulas.

Type One: A[true] -> (A[true] -> Bool)
Type Two: A[true] -> (A[false] -> Bool)
```