### PR TITLE
refactor: add `addSourceLine` in `GenExpression` before failable exprs

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -42,29 +42,23 @@ object GenExpression {
 
     case Expr.Cst(cst, tpe, loc) => cst match {
       case Ast.Constant.Unit =>
-        addSourceLine(mv, loc)
         mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName,
           BackendObjType.Unit.InstanceField.name, BackendObjType.Unit.toDescriptor)
 
       case Ast.Constant.Null =>
-        addSourceLine(mv, loc)
         mv.visitInsn(ACONST_NULL)
         AsmOps.castIfNotPrim(mv, JvmOps.getJvmType(tpe))
 
       case Ast.Constant.Bool(true) =>
-        addSourceLine(mv, loc)
         mv.visitInsn(ICONST_1)
 
       case Ast.Constant.Bool(false) =>
-        addSourceLine(mv, loc)
         mv.visitInsn(ICONST_0)
 
       case Ast.Constant.Char(c) =>
-        addSourceLine(mv, loc)
         compileInt(c)
 
       case Ast.Constant.Float32(f) =>
-        addSourceLine(mv, loc)
         f match {
           case 0f => mv.visitInsn(FCONST_0)
           case 1f => mv.visitInsn(FCONST_1)
@@ -73,7 +67,6 @@ object GenExpression {
         }
 
       case Ast.Constant.Float64(d) =>
-        addSourceLine(mv, loc)
         d match {
           case 0d => mv.visitInsn(DCONST_0)
           case 1d => mv.visitInsn(DCONST_1)
@@ -81,6 +74,7 @@ object GenExpression {
         }
 
       case Ast.Constant.BigDecimal(dd) =>
+        // Can fail with NumberFormatException
         addSourceLine(mv, loc)
         mv.visitTypeInsn(NEW, BackendObjType.BigDecimal.jvmName.toInternalName)
         mv.visitInsn(DUP)
@@ -89,22 +83,19 @@ object GenExpression {
           AsmOps.getMethodDescriptor(List(JvmType.String), JvmType.Void), false)
 
       case Ast.Constant.Int8(b) =>
-        addSourceLine(mv, loc)
         compileInt(b)
 
       case Ast.Constant.Int16(s) =>
-        addSourceLine(mv, loc)
         compileInt(s)
 
       case Ast.Constant.Int32(i) =>
-        addSourceLine(mv, loc)
         compileInt(i)
 
       case Ast.Constant.Int64(l) =>
-        addSourceLine(mv, loc)
         compileLong(l)
 
       case Ast.Constant.BigInt(ii) =>
+        // Can fail with NumberFormatException
         addSourceLine(mv, loc)
         mv.visitTypeInsn(NEW, BackendObjType.BigInt.jvmName.toInternalName)
         mv.visitInsn(DUP)
@@ -113,10 +104,10 @@ object GenExpression {
           AsmOps.getMethodDescriptor(List(JvmType.String), JvmType.Void), false)
 
       case Ast.Constant.Str(s) =>
-        addSourceLine(mv, loc)
         mv.visitLdcInsn(s)
 
       case Ast.Constant.Regex(patt) =>
+        // Can fail with PatternSyntaxException
         addSourceLine(mv, loc)
         mv.visitLdcInsn(patt.pattern)
         mv.visitMethodInsn(INVOKESTATIC, JvmName.Regex.toInternalName, "compile",

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -1312,8 +1312,6 @@ object GenExpression {
       mv.visitJumpInsn(GOTO, ctx.entryPoint)
 
     case Expr.IfThenElse(exp1, exp2, exp3, _, loc) =>
-      // Adding source line number for debugging
-      addSourceLine(mv, loc)
       val ifElse = new Label()
       val ifEnd = new Label()
       compileExpr(exp1)
@@ -1325,8 +1323,6 @@ object GenExpression {
       mv.visitLabel(ifEnd)
 
     case Expr.Branch(exp, branches, _, loc) =>
-      // Adding source line number for debugging
-      addSourceLine(mv, loc)
       // Calculating the updated jumpLabels map
       val updatedJumpLabels = branches.foldLeft(ctx.lenv)((map, branch) => map + (branch._1 -> new Label()))
       val ctx1 = ctx.copy(lenv = updatedJumpLabels)
@@ -1349,14 +1345,10 @@ object GenExpression {
       mv.visitLabel(endLabel)
 
     case Expr.JumpTo(sym, _, loc) =>
-      // Adding source line number for debugging
-      addSourceLine(mv, loc)
       // Jumping to the label
       mv.visitJumpInsn(GOTO, ctx.lenv(sym))
 
     case Expr.Let(sym, exp1, exp2, _, loc) =>
-      // Adding source line number for debugging
-      addSourceLine(mv, loc)
       compileExpr(exp1)
       // Jvm Type of the `exp1`
       val jvmType = JvmOps.getJvmType(exp1.tpe)
@@ -1366,8 +1358,6 @@ object GenExpression {
       compileExpr(exp2)
 
     case Expr.LetRec(varSym, index, defSym, exp1, exp2, _, loc) =>
-      // Adding source line number for debugging
-      addSourceLine(mv, loc)
       // Jvm Type of the `exp1`
       val jvmType = JvmOps.getJvmType(exp1.tpe)
       // Store instruction for `jvmType`
@@ -1488,7 +1478,6 @@ object GenExpression {
       mv.visitLabel(afterTryAndCatch)
 
     case Expr.NewObject(name, _, tpe, methods, loc) =>
-      addSourceLine(mv, loc)
       val className = JvmName(ca.uwaterloo.flix.language.phase.jvm.JvmName.RootPackage, name).toInternalName
       mv.visitTypeInsn(NEW, className)
       mv.visitInsn(DUP)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -1105,114 +1105,99 @@ object GenExpression {
 
       case AtomicOp.BoxBool =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitMethodInsn(INVOKESTATIC, "java/lang/Boolean", "valueOf", "(Z)Ljava/lang/Boolean;", false)
 
       case AtomicOp.BoxInt8 =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "valueOf", "(B)Ljava/lang/Byte;", false)
 
       case AtomicOp.BoxInt16 =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitMethodInsn(INVOKESTATIC, "java/lang/Short", "valueOf", "(S)Ljava/lang/Short;", false)
 
       case AtomicOp.BoxInt32 =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitMethodInsn(INVOKESTATIC, "java/lang/Integer", "valueOf", "(I)Ljava/lang/Integer;", false)
 
       case AtomicOp.BoxInt64 =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitMethodInsn(INVOKESTATIC, "java/lang/Long", "valueOf", "(J)Ljava/lang/Long;", false)
 
       case AtomicOp.BoxChar =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitMethodInsn(INVOKESTATIC, "java/lang/Character", "valueOf", "(C)Ljava/lang/Character;", false)
 
       case AtomicOp.BoxFloat32 =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitMethodInsn(INVOKESTATIC, "java/lang/Float", "valueOf", "(F)Ljava/lang/Float;", false)
 
       case AtomicOp.BoxFloat64 =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitMethodInsn(INVOKESTATIC, "java/lang/Double", "valueOf", "(D)Ljava/lang/Double;", false)
 
       case AtomicOp.UnboxBool =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitTypeInsn(CHECKCAST, "java/lang/Boolean")
         mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Boolean", "booleanValue", "()Z", false)
 
       case AtomicOp.UnboxInt8 =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitTypeInsn(CHECKCAST, "java/lang/Character")
         mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Character", "charValue", "()C", false)
 
       case AtomicOp.UnboxInt16 =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitTypeInsn(CHECKCAST, "java/lang/Short")
         mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Short", "shortValue", "()S", false)
 
       case AtomicOp.UnboxInt32 =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitTypeInsn(CHECKCAST, "java/lang/Integer")
         mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Integer", "intValue", "()I", false)
 
       case AtomicOp.UnboxInt64 =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitTypeInsn(CHECKCAST, "java/lang/Long")
         mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Long", "longValue", "()J", false)
 
       case AtomicOp.UnboxChar =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitTypeInsn(CHECKCAST, "java/lang/Character")
         mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Character", "charValue", "()C", false)
 
       case AtomicOp.UnboxFloat32 =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitTypeInsn(CHECKCAST, "java/lang/Float")
         mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Float", "floatValue", "()F", false)
 
       case AtomicOp.UnboxFloat64 =>
         val List(exp) = exps
-        addSourceLine(mv, loc)
         compileExpr(exp)
         mv.visitTypeInsn(CHECKCAST, "java/lang/Double")
         mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Double", "doubleValue", "()D", false)
 
-
       case AtomicOp.HoleError(sym) =>
+        // Add source line number for debugging (failable by design)
         addSourceLine(mv, loc)
         AsmOps.compileThrowHoleError(mv, sym.toString, loc)
 
       case AtomicOp.MatchError =>
+        // Add source line number for debugging (failable by design)
         addSourceLine(mv, loc)
         AsmOps.compileThrowFlixError(mv, BackendObjType.MatchError.jvmName, loc)
     }


### PR DESCRIPTION
May require a thorough review. There are some expressions I'm unsure about. For instance, is `NewObject` failable? It should have been type checked, so no runtime should happen.

Closes https://github.com/flix/flix/issues/5852