### PR TITLE
refactor: check valid field name in records

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1489,8 +1489,8 @@ object Weeder {
         case ParsedAst.RecordField(_, ident, exp, _) =>
           val expVal = visitExp(exp, senv)
 
-          mapN(expVal) {
-            case e => ident -> e
+          mapN(expVal, visitName(ident)) {
+            case (e, _) => ident -> e
           }
       }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1505,25 +1505,27 @@ object Weeder {
 
     case ParsedAst.Expression.RecordSelect(exp, ident, sp2) =>
       val sp1 = leftMostSourcePosition(exp)
-      mapN(visitExp(exp, senv)) {
-        case e => WeededAst.Expression.RecordSelect(e, Name.mkField(ident), mkSL(sp1, sp2))
+      mapN(visitExp(exp, senv), visitName(ident)) {
+        case (e, _) => WeededAst.Expression.RecordSelect(e, Name.mkField(ident), mkSL(sp1, sp2))
       }
 
     case ParsedAst.Expression.RecordOperation(_, ops, rest, _) =>
       // We translate the sequence of record operations into a nested tree using a fold right.
       foldRight(ops)(visitExp(rest, senv)) {
         case (ParsedAst.RecordOp.Extend(sp1, ident, exp, sp2), acc) =>
-          mapN(visitExp(exp, senv)) {
-            case e =>
+          mapN(visitExp(exp, senv), visitName(ident)) {
+            case (e, _) =>
               WeededAst.Expression.RecordExtend(Name.mkField(ident), e, acc, mkSL(sp1, sp2))
           }
 
         case (ParsedAst.RecordOp.Restrict(sp1, ident, sp2), acc) =>
-          WeededAst.Expression.RecordRestrict(Name.mkField(ident), acc, mkSL(sp1, sp2)).toSuccess
+          mapN(visitName(ident)) {
+            case _ => WeededAst.Expression.RecordRestrict(Name.mkField(ident), acc, mkSL(sp1, sp2))
+          }
 
         case (ParsedAst.RecordOp.Update(sp1, ident, exp, sp2), acc) =>
-          mapN(visitExp(exp, senv)) {
-            case e =>
+          mapN(visitExp(exp, senv), visitName(ident)) {
+            case (e, _) =>
               // An update is a restrict followed by an extension.
               val inner = WeededAst.Expression.RecordRestrict(Name.mkField(ident), acc, mkSL(sp1, sp2))
               WeededAst.Expression.RecordExtend(Name.mkField(ident), e, inner, mkSL(sp1, sp2))

--- a/main/test/flix/Test.Exp.Record.Polymorphism.flix
+++ b/main/test/flix/Test.Exp.Record.Polymorphism.flix
@@ -45,7 +45,7 @@ mod Test.Exp.Record.Polymorphism {
     def testRecordPolyExtend02(): Unit =
         let p1 = { fstName = "Luke", lstName = "Skywalker" };
         let p2 = { fstName = "Lucky", lstName = "Luke" };
-        let p3 = { fstName = "Bruce", lstName = "Wayne", alias = "Batman" };
+        let p3 = { fstName = "Bruce", lstName = "Wayne", alias0 = "Batman" };
         let p4 = { name = "Cher" };
         let _p5 = withAgeAndSex(21, "m", p1);
         let _p6 = withAgeAndSex(42, "m", p2);

--- a/main/test/flix/Test.Exp.Record.Polymorphism.flix
+++ b/main/test/flix/Test.Exp.Record.Polymorphism.flix
@@ -45,7 +45,7 @@ mod Test.Exp.Record.Polymorphism {
     def testRecordPolyExtend02(): Unit =
         let p1 = { fstName = "Luke", lstName = "Skywalker" };
         let p2 = { fstName = "Lucky", lstName = "Luke" };
-        let p3 = { fstName = "Bruce", lstName = "Wayne", alias0 = "Batman" };
+        let p3 = { fstName = "Bruce", lstName = "Wayne", aka = "Batman" };
         let p4 = { name = "Cher" };
         let _p5 = withAgeAndSex(21, "m", p1);
         let _p6 = withAgeAndSex(42, "m", p2);


### PR DESCRIPTION
I don't know if this was intentional, but this is currently allowed:
```scala
pub def main(): Unit \ IO =
    let p = { pub = 125, def = 1284, let = 22 };
    println(p.pub);
    println(p.def);
    println(p.let)
```

This PR makes the compiler throw a `WeederError` when using reserved words. Note that Scala disallows reserved words for fields in (case) classes, too.