### PR TITLE
refactor: rework `JvmMethod`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -91,9 +91,9 @@ object ErasedAst {
 
   case class Case(sym: Symbol.CaseSym, tpe: MonoType, loc: SourceLocation)
 
-  case class JvmMethodSpec(ident: Name.Ident, fparams: List[FormalParam], tpe: MonoType, loc: SourceLocation)
+  case class JvmMethodSpec(ident: Name.Ident, fparams: List[FormalParam], tpe: MonoType, purity: Purity, loc: SourceLocation)
 
-  case class JvmMethodImpl(ident: Name.Ident, fparams: List[FormalParam], clo: Expr, retTpe: MonoType, loc: SourceLocation)
+  case class JvmMethodImpl(ident: Name.Ident, fparams: List[FormalParam], clo: Expr, tpe: MonoType, purity: Purity, loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[_], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -28,7 +28,7 @@ object ErasedAst {
                   enums: Map[Symbol.EnumSym, Enum],
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],
-                  anonClasses: Set[AnonClassInfo])
+                  anonClasses: Set[AnonClass])
 
   case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], stmt: Stmt, tpe: MonoType, loc: SourceLocation) {
     var method: Method = _
@@ -71,7 +71,7 @@ object ErasedAst {
 
     case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class NewObject(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[JvmMethodWithExpr], loc: SourceLocation) extends Expr
+    case class NewObject(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[JvmMethodImpl], loc: SourceLocation) extends Expr
 
   }
 
@@ -87,13 +87,13 @@ object ErasedAst {
 
   }
 
-  case class AnonClassInfo(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[JvmMethod], loc: SourceLocation)
+  case class AnonClass(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[JvmMethodSpec], loc: SourceLocation)
 
   case class Case(sym: Symbol.CaseSym, tpe: MonoType, loc: SourceLocation)
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], tpe: MonoType, loc: SourceLocation)
+  case class JvmMethodSpec(ident: Name.Ident, fparams: List[FormalParam], tpe: MonoType, loc: SourceLocation)
 
-  case class JvmMethodWithExpr(ident: Name.Ident, fparams: List[FormalParam], clo: Expr, retTpe: MonoType, loc: SourceLocation)
+  case class JvmMethodImpl(ident: Name.Ident, fparams: List[FormalParam], clo: Expr, retTpe: MonoType, loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[_], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -72,7 +72,7 @@ object ErasedAst {
 
     case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: MonoType, loc: SourceLocation) extends Expr
 
-    case class NewObject(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[JvmMethodWithExpr], loc: SourceLocation) extends Expr
 
   }
 
@@ -90,7 +90,9 @@ object ErasedAst {
 
   case class Case(sym: Symbol.CaseSym, tpe: MonoType, loc: SourceLocation)
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], clo: Expr, retTpe: MonoType, loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], tpe: MonoType, loc: SourceLocation)
+
+  case class JvmMethodWithExpr(ident: Name.Ident, fparams: List[FormalParam], clo: Expr, retTpe: MonoType, loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[_], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ErasedAst.scala
@@ -17,7 +17,6 @@
 package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.language.ast.Ast.Source
-import ca.uwaterloo.flix.language.phase.jvm.AnonClassInfo
 
 import java.lang.reflect.Method
 
@@ -87,6 +86,8 @@ object ErasedAst {
     case class Ret(expr: Expr, tpe: MonoType, loc: SourceLocation) extends Stmt
 
   }
+
+  case class AnonClassInfo(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[JvmMethod], loc: SourceLocation)
 
   case class Case(sym: Symbol.CaseSym, tpe: MonoType, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -93,9 +93,9 @@ object ReducedAst {
 
   case class Case(sym: Symbol.CaseSym, tpe: MonoType, loc: SourceLocation)
 
-  case class JvmMethodSpec(ident: Name.Ident, fparams: List[FormalParam], retTpe: MonoType, purity: Purity, loc: SourceLocation)
+  case class JvmMethodSpec(ident: Name.Ident, fparams: List[FormalParam], tpe: MonoType, purity: Purity, loc: SourceLocation)
 
-  case class JvmMethodImpl(ident: Name.Ident, fparams: List[FormalParam], clo: Expr, retTpe: MonoType, purity: Purity, loc: SourceLocation)
+  case class JvmMethodImpl(ident: Name.Ident, fparams: List[FormalParam], clo: Expr, tpe: MonoType, purity: Purity, loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[_], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -21,10 +21,11 @@ import ca.uwaterloo.flix.language.ast.Purity.Pure
 
 object ReducedAst {
 
-  val empty: Root = Root(Map.empty, Map.empty, None, Map.empty)
+  val empty: Root = Root(Map.empty, Map.empty, Set.empty, None, Map.empty)
 
   case class Root(defs: Map[Symbol.DefnSym, Def],
                   enums: Map[Symbol.EnumSym, Enum],
+                  anonClasses: Set[AnonClass],
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
@@ -72,7 +73,7 @@ object ReducedAst {
 
     case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class NewObject(name: String, clazz: java.lang.Class[_], tpe: MonoType, purity: Purity, methods: List[JvmMethod], loc: SourceLocation) extends Expr
+    case class NewObject(name: String, clazz: java.lang.Class[_], tpe: MonoType, purity: Purity, methods: List[JvmMethodImpl], loc: SourceLocation) extends Expr
 
   }
 
@@ -88,11 +89,13 @@ object ReducedAst {
 
   }
 
-  case class AnonClassInfo(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[JvmMethod], loc: SourceLocation)
+  case class AnonClass(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[JvmMethodSpec], loc: SourceLocation)
 
   case class Case(sym: Symbol.CaseSym, tpe: MonoType, loc: SourceLocation)
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], clo: Expr, retTpe: MonoType, purity: Purity, loc: SourceLocation)
+  case class JvmMethodSpec(ident: Name.Ident, fparams: List[FormalParam], retTpe: MonoType, purity: Purity, loc: SourceLocation)
+
+  case class JvmMethodImpl(ident: Name.Ident, fparams: List[FormalParam], clo: Expr, retTpe: MonoType, purity: Purity, loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[_], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -88,6 +88,8 @@ object ReducedAst {
 
   }
 
+  case class AnonClassInfo(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[JvmMethod], loc: SourceLocation)
+
   case class Case(sym: Symbol.CaseSym, tpe: MonoType, loc: SourceLocation)
 
   case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], clo: Expr, retTpe: MonoType, purity: Purity, loc: SourceLocation)

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ErasedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ErasedAstPrinter.scala
@@ -74,7 +74,7 @@ object ErasedAstPrinter {
     })
     case NewObject(name, clazz, tpe, methods, _) =>
       DocAst.Expression.NewObject(name, clazz, MonoTypePrinter.print(tpe), methods.map {
-        case JvmMethodWithExpr(ident, fparams, clo, retTpe, _) =>
+        case JvmMethodImpl(ident, fparams, clo, retTpe, _) =>
           DocAst.JvmMethod(ident, fparams.map(printFormalParam), print(clo), MonoTypePrinter.print(retTpe))
       })
   }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ErasedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ErasedAstPrinter.scala
@@ -74,7 +74,7 @@ object ErasedAstPrinter {
     })
     case NewObject(name, clazz, tpe, methods, _) =>
       DocAst.Expression.NewObject(name, clazz, MonoTypePrinter.print(tpe), methods.map {
-        case JvmMethod(ident, fparams, clo, retTpe, _) =>
+        case JvmMethodWithExpr(ident, fparams, clo, retTpe, _) =>
           DocAst.JvmMethod(ident, fparams.map(printFormalParam), print(clo), MonoTypePrinter.print(retTpe))
       })
   }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ErasedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ErasedAstPrinter.scala
@@ -74,8 +74,8 @@ object ErasedAstPrinter {
     })
     case NewObject(name, clazz, tpe, methods, _) =>
       DocAst.Expression.NewObject(name, clazz, MonoTypePrinter.print(tpe), methods.map {
-        case JvmMethodImpl(ident, fparams, clo, retTpe, _) =>
-          DocAst.JvmMethod(ident, fparams.map(printFormalParam), print(clo), MonoTypePrinter.print(retTpe))
+        case JvmMethodImpl(ident, fparams, clo, tpe, _, _) =>
+          DocAst.JvmMethod(ident, fparams.map(printFormalParam), print(clo), MonoTypePrinter.print(tpe))
       })
   }
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
@@ -72,8 +72,8 @@ object ReducedAstPrinter {
       case ReducedAst.CatchRule(sym, clazz, exp) => (sym, clazz, print(exp))
     })
     case Expr.NewObject(name, clazz, tpe, _, methods, _) => DocAst.Expression.NewObject(name, clazz, MonoTypePrinter.print(tpe), methods.map{
-      case ReducedAst.JvmMethodImpl(ident, fparams, clo, retTpe, _, _) =>
-        DocAst.JvmMethod(ident, fparams.map(printFormalParam), print(clo), MonoTypePrinter.print(retTpe))
+      case ReducedAst.JvmMethodImpl(ident, fparams, clo, tpe, _, _) =>
+        DocAst.JvmMethod(ident, fparams.map(printFormalParam), print(clo), MonoTypePrinter.print(tpe))
     })
   }
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
@@ -72,7 +72,7 @@ object ReducedAstPrinter {
       case ReducedAst.CatchRule(sym, clazz, exp) => (sym, clazz, print(exp))
     })
     case Expr.NewObject(name, clazz, tpe, _, methods, _) => DocAst.Expression.NewObject(name, clazz, MonoTypePrinter.print(tpe), methods.map{
-      case ReducedAst.JvmMethod(ident, fparams, clo, retTpe, _, _) =>
+      case ReducedAst.JvmMethodImpl(ident, fparams, clo, retTpe, _, _) =>
         DocAst.JvmMethod(ident, fparams.map(printFormalParam), print(clo), MonoTypePrinter.print(retTpe))
     })
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -30,9 +30,9 @@ object Eraser {
     val anonClasses = root.anonClasses.map {
       case ReducedAst.AnonClass(name, clazz, tpe, methods, loc) =>
         val ms = methods.map {
-          case ReducedAst.JvmMethodSpec(ident, fparams, retTpe, _, loc) =>
+          case ReducedAst.JvmMethodSpec(ident, fparams, tpe, purity, loc) =>
             val fs = fparams.map(visitFormalParam)
-            ErasedAst.JvmMethodSpec(ident, fs, retTpe, loc)
+            ErasedAst.JvmMethodSpec(ident, fs, tpe, purity, loc)
         }
         ErasedAst.AnonClass(name, clazz, tpe, ms, loc)
     }
@@ -107,9 +107,9 @@ object Eraser {
 
     case ReducedAst.Expr.NewObject(name, clazz, tpe, _, methods0, loc) =>
       val methods = methods0.map {
-        case ReducedAst.JvmMethodImpl(ident, fparams, clo, retTpe, _, loc) =>
+        case ReducedAst.JvmMethodImpl(ident, fparams, clo, tpe, purity, loc) =>
           val f = fparams.map(visitFormalParam)
-          ErasedAst.JvmMethodImpl(ident, f, visitExpr(clo), retTpe, loc)
+          ErasedAst.JvmMethodImpl(ident, f, visitExpr(clo), tpe, purity, loc)
       }
       ErasedAst.Expr.NewObject(name, clazz, tpe, methods, loc)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -20,21 +20,24 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.ErasedAst
 import ca.uwaterloo.flix.language.ast.ReducedAst
 
-import scala.collection.mutable
-
 object Eraser {
 
   def run(root: ReducedAst.Root)(implicit flix: Flix): ErasedAst.Root = flix.phase("Eraser") {
 
-    //
-    // A mutable set to hold all type information about all closures in the AST.
-    //
-    implicit val ctx: Context = Context(mutable.Set.empty)
-
     val defs = root.defs.map { case (k, v) => k -> visitDef(v) }
     val enums = root.enums.map { case (k, v) => k -> visitEnum(v) }
 
-    ErasedAst.Root(defs, enums, root.entryPoint, root.sources, ctx.anonClasses.toSet)
+    val anonClasses = root.anonClasses.map {
+      case ReducedAst.AnonClass(name, clazz, tpe, methods, loc) =>
+        val ms = methods.map {
+          case ReducedAst.JvmMethodSpec(ident, fparams, retTpe, _, loc) =>
+            val fs = fparams.map(visitFormalParam)
+            ErasedAst.JvmMethodSpec(ident, fs, retTpe, loc)
+        }
+        ErasedAst.AnonClass(name, clazz, tpe, ms, loc)
+    }
+
+    ErasedAst.Root(defs, enums, root.entryPoint, root.sources, anonClasses)
   }
 
   private def visitEnum(enum0: ReducedAst.Enum): ErasedAst.Enum = {
@@ -42,14 +45,14 @@ object Eraser {
     ErasedAst.Enum(enum0.ann, enum0.mod, enum0.sym, cases, enum0.tpe, enum0.loc)
   }
 
-  private def visitDef(def0: ReducedAst.Def)(implicit ctx: Context): ErasedAst.Def = {
+  private def visitDef(def0: ReducedAst.Def): ErasedAst.Def = {
     val cs = def0.cparams.map(visitFormalParam)
     val fs = def0.fparams.map(visitFormalParam)
     val stmt = visitStmt(def0.stmt)
     ErasedAst.Def(def0.ann, def0.mod, def0.sym, cs, fs, stmt, def0.tpe, def0.loc)
   }
 
-  private def visitExpr(exp0: ReducedAst.Expr)(implicit ctx: Context): ErasedAst.Expr = exp0 match {
+  private def visitExpr(exp0: ReducedAst.Expr): ErasedAst.Expr = exp0 match {
     case ReducedAst.Expr.Cst(cst, tpe, loc) =>
       ErasedAst.Expr.Cst(cst, tpe, loc)
 
@@ -104,20 +107,14 @@ object Eraser {
 
     case ReducedAst.Expr.NewObject(name, clazz, tpe, _, methods0, loc) =>
       val methods = methods0.map {
-        case ReducedAst.JvmMethod(ident, fparams, clo, retTpe, _, loc) =>
+        case ReducedAst.JvmMethodImpl(ident, fparams, clo, retTpe, _, loc) =>
           val f = fparams.map(visitFormalParam)
-          ErasedAst.JvmMethodWithExpr(ident, f, visitExpr(clo), retTpe, loc)
+          ErasedAst.JvmMethodImpl(ident, f, visitExpr(clo), retTpe, loc)
       }
-      val anonClassMethods = methods0.map {
-        case ReducedAst.JvmMethod(ident, fparams, _, retTpe, _, loc) =>
-          val f = fparams.map(visitFormalParam)
-          ErasedAst.JvmMethod(ident, f, retTpe, loc)
-      }
-      ctx.anonClasses += ErasedAst.AnonClassInfo(name, clazz, tpe, anonClassMethods, loc)
       ErasedAst.Expr.NewObject(name, clazz, tpe, methods, loc)
   }
 
-  private def visitStmt(stmt: ReducedAst.Stmt)(implicit ctx: Context): ErasedAst.Stmt = stmt match {
+  private def visitStmt(stmt: ReducedAst.Stmt): ErasedAst.Stmt = stmt match {
     case ReducedAst.Stmt.Ret(expr, tpe, loc) =>
       val e = visitExpr(expr)
       ErasedAst.Stmt.Ret(e, tpe, loc)
@@ -129,8 +126,5 @@ object Eraser {
 
   private def visitFormalParam(p: ReducedAst.FormalParam): ErasedAst.FormalParam =
     ErasedAst.FormalParam(p.sym, p.mod, p.tpe, p.loc)
-
-  private case class Context(anonClasses: mutable.Set[ErasedAst.AnonClassInfo])
-
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -107,9 +107,14 @@ object Eraser {
       val methods = methods0.map {
         case ReducedAst.JvmMethod(ident, fparams, clo, retTpe, _, loc) =>
           val f = fparams.map(visitFormalParam)
-          ErasedAst.JvmMethod(ident, f, visitExpr(clo), retTpe, loc)
+          ErasedAst.JvmMethodWithExpr(ident, f, visitExpr(clo), retTpe, loc)
       }
-      ctx.anonClasses += AnonClassInfo(name, clazz, tpe, methods, loc)
+      val anonClassMethods = methods0.map {
+        case ReducedAst.JvmMethod(ident, fparams, _, retTpe, _, loc) =>
+          val f = fparams.map(visitFormalParam)
+          ErasedAst.JvmMethod(ident, f, retTpe, loc)
+      }
+      ctx.anonClasses += AnonClassInfo(name, clazz, tpe, anonClassMethods, loc)
       ErasedAst.Expr.NewObject(name, clazz, tpe, methods, loc)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -19,7 +19,6 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.ErasedAst
 import ca.uwaterloo.flix.language.ast.ReducedAst
-import ca.uwaterloo.flix.language.phase.jvm.AnonClassInfo
 
 import scala.collection.mutable
 
@@ -114,7 +113,7 @@ object Eraser {
           val f = fparams.map(visitFormalParam)
           ErasedAst.JvmMethod(ident, f, retTpe, loc)
       }
-      ctx.anonClasses += AnonClassInfo(name, clazz, tpe, anonClassMethods, loc)
+      ctx.anonClasses += ErasedAst.AnonClassInfo(name, clazz, tpe, anonClassMethods, loc)
       ErasedAst.Expr.NewObject(name, clazz, tpe, methods, loc)
   }
 
@@ -131,6 +130,7 @@ object Eraser {
   private def visitFormalParam(p: ReducedAst.FormalParam): ErasedAst.FormalParam =
     ErasedAst.FormalParam(p.sym, p.mod, p.tpe, p.loc)
 
-  private case class Context(anonClasses: mutable.Set[AnonClassInfo])
+  private case class Context(anonClasses: mutable.Set[ErasedAst.AnonClassInfo])
+
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/AnonClassInfo.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/AnonClassInfo.scala
@@ -1,5 +1,0 @@
-package ca.uwaterloo.flix.language.phase.jvm
-
-import ca.uwaterloo.flix.language.ast.{ErasedAst, MonoType, SourceLocation}
-
-case class AnonClassInfo(name: String, clazz: java.lang.Class[_], tpe: MonoType, methods: List[ErasedAst.JvmMethod], loc: SourceLocation)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -33,7 +33,7 @@ object GenAnonymousClasses {
   /**
     * Returns the set of anonymous classes for the given set of objects
     */
-  def gen(objs: Set[AnonClassInfo])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
+  def gen(objs: Set[AnonClass])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
     //
     // Generate an anonymous class for each object and collect the results in a map.
     //
@@ -49,7 +49,7 @@ object GenAnonymousClasses {
   /**
     * Returns the bytecode for the anonoymous class
     */
-  private def genByteCode(className: JvmName, obj: AnonClassInfo)(implicit root: Root, flix: Flix): Array[Byte] = {
+  private def genByteCode(className: JvmName, obj: AnonClass)(implicit root: Root, flix: Flix): Array[Byte] = {
     val visitor = AsmOps.mkClassWriter()
 
     val superClass = if (obj.clazz.isInterface())
@@ -77,7 +77,7 @@ object GenAnonymousClasses {
   /**
     * Constructor of the class
     */
-  private def compileConstructor(currentClass: JvmType.Reference, superClass: String, methods: List[JvmMethod], visitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = {
+  private def compileConstructor(currentClass: JvmType.Reference, superClass: String, methods: List[JvmMethodSpec], visitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = {
     val constructor = visitor.visitMethod(ACC_PUBLIC, JvmName.ConstructorMethod, MethodDescriptor.NothingToVoid.toDescriptor, null, null)
 
     // Invoke the superclass constructor
@@ -116,8 +116,8 @@ object GenAnonymousClasses {
   /**
     * Method
     */
-  private def compileMethod(currentClass: JvmType.Reference, method: JvmMethod, cloName: String, classVisitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = method match {
-    case JvmMethod(ident, fparams, tpe, loc) =>
+  private def compileMethod(currentClass: JvmType.Reference, method: JvmMethodSpec, cloName: String, classVisitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = method match {
+    case JvmMethodSpec(ident, fparams, tpe, loc) =>
       val methodType = MonoType.Arrow(fparams.map(_.tpe), tpe)
       val closureAbstractClass = JvmOps.getClosureAbstractClassType(methodType)
       val functionInterface = JvmOps.getFunctionInterfaceType(methodType)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -117,7 +117,7 @@ object GenAnonymousClasses {
     * Method
     */
   private def compileMethod(currentClass: JvmType.Reference, method: JvmMethodSpec, cloName: String, classVisitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = method match {
-    case JvmMethodSpec(ident, fparams, tpe, loc) =>
+    case JvmMethodSpec(ident, fparams, tpe, _, _) =>
       val methodType = MonoType.Arrow(fparams.map(_.tpe), tpe)
       val closureAbstractClass = JvmOps.getClosureAbstractClassType(methodType)
       val functionInterface = JvmOps.getFunctionInterfaceType(methodType)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -117,10 +117,11 @@ object GenAnonymousClasses {
     * Method
     */
   private def compileMethod(currentClass: JvmType.Reference, method: JvmMethod, cloName: String, classVisitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = method match {
-    case JvmMethod(ident, fparams, clo, tpe, loc) =>
-      val closureAbstractClass = JvmOps.getClosureAbstractClassType(method.clo.tpe)
-      val functionInterface = JvmOps.getFunctionInterfaceType(method.clo.tpe)
-      val backendContinuationType = BackendObjType.Continuation(BackendType.toErasedBackendType(method.retTpe))
+    case JvmMethod(ident, fparams, tpe, loc) =>
+      val methodType = MonoType.Arrow(fparams.map(_.tpe), tpe)
+      val closureAbstractClass = JvmOps.getClosureAbstractClassType(methodType)
+      val functionInterface = JvmOps.getFunctionInterfaceType(methodType)
+      val backendContinuationType = BackendObjType.Continuation(BackendType.toErasedBackendType(method.tpe))
 
       // Create the field that will store the closure implementing the body of the method
       AsmOps.compileField(classVisitor, cloName, closureAbstractClass, isStatic = false, isPrivate = false, isVolatile = false)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -582,8 +582,8 @@ object JvmOps {
 
       case Expr.NewObject(_, _, _, methods, _) =>
         methods.foldLeft(Set.empty[MonoType]) {
-          case (sacc, JvmMethodImpl(_, fparams, clo, retTpe, _)) =>
-            val fs = fparams.foldLeft(Set(retTpe)) {
+          case (sacc, JvmMethodImpl(_, fparams, clo, tpe, _, _)) =>
+            val fs = fparams.foldLeft(Set(tpe)) {
               case (acc, FormalParam(_, _, tpe, _)) => acc + tpe
             }
             sacc ++ fs ++ visitExp(clo)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -582,7 +582,7 @@ object JvmOps {
 
       case Expr.NewObject(_, _, _, methods, _) =>
         methods.foldLeft(Set.empty[MonoType]) {
-          case (sacc, JvmMethodWithExpr(_, fparams, clo, retTpe, _)) =>
+          case (sacc, JvmMethodImpl(_, fparams, clo, retTpe, _)) =>
             val fs = fparams.foldLeft(Set(retTpe)) {
               case (acc, FormalParam(_, _, tpe, _)) => acc + tpe
             }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -582,7 +582,7 @@ object JvmOps {
 
       case Expr.NewObject(_, _, _, methods, _) =>
         methods.foldLeft(Set.empty[MonoType]) {
-          case (sacc, JvmMethod(_, fparams, clo, retTpe, _)) =>
+          case (sacc, JvmMethodWithExpr(_, fparams, clo, retTpe, _)) =>
             val fs = fparams.foldLeft(Set(retTpe)) {
               case (acc, FormalParam(_, _, tpe, _)) => acc + tpe
             }


### PR DESCRIPTION
This splits `JvmMethod` into two: `JvmMethodSpec` and `JvmMethodImpl`. 

Now `NewObject` depends on `JvmMethodImpl`, whereas `anonClasses` uses `JvmMethodSpec`.

This is in preparation for removal of the `ErasedAst` phase.