### PR TITLE
fix: show proper error message when requesting to show WIP phases

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
@@ -64,6 +64,8 @@ object ShowAstProvider {
         case "LateTreeShaker" => astObject(phase, AstPrinter.formatLiftedAst(flix.getLateTreeShakerAst))
         case "Reducer" => astObject(phase, AstPrinter.formatReducedAst(flix.getReducerAst))
         case "VarNumbering" => astObject(phase, AstPrinter.formatReducedAst(flix.getVarNumberingAst))
+        case "MonoTyper" => astObject(phase, "Work In Progress")
+        case "Eraser" => astObject(phase, "Work In Progress")
         case _ =>
           astObject(phase, s"Unknown phase: '$phase'. Try one of these ${phases.map(s => s"'$s'").mkString(", ")}")
       }


### PR DESCRIPTION
Fixes this problem:
```
// Eraser.flixir

Unknown phase: 'Eraser'. Try one of these 'Parser', 'Weeder', 'Kinder', 'Resolver', 'TypedAst', 'Documentor', 'Lowering', 'EarlyTreeShaker', 'Monomorph', 'MonomorphEnums', 'Simplifier', 'ClosureConv', 'LambdaLift', 'Tailrec', 'Optimizer', 'LateTreeShaker', 'Reducer', 'VarNumbering', 'MonoTyper', 'Eraser'
```