### PR TITLE
feat: add Adaptor module (issue #6331)

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -293,6 +293,7 @@ class Flix {
     "Graph.flix" -> LocalResource.get("/src/library/Graph.flix"),
     "Vector.flix" -> LocalResource.get("/src/library/Vector.flix"),
     "Regex.flix" -> LocalResource.get("/src/library/Regex.flix"),
+    "Adaptor.flix" -> LocalResource.get("/src/library/Adaptor.flix"),
   )
 
   /**

--- a/main/src/library/Adaptor.flix
+++ b/main/src/library/Adaptor.flix
@@ -1,0 +1,167 @@
+/*
+ *  Copyright 2023 Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+mod Adaptor {
+
+    ///
+    /// Returns a comparator for elements of type `a`.
+    ///
+    /// The comparator is backed by the ordering on `a`.
+    ///
+    /// Note: Currently requires a Proxy (until Java types support generics).
+    ///
+    pub def comparator(_: Proxy[a]): ##java.util.Comparator \ IO with Order[a] =
+        let f1 = (o1, o2) -> {
+            let a = unchecked_cast(o1 as a);
+            let b = unchecked_cast(o2 as a);
+            Order.compare(a, b) |> Comparison.toInt
+        };
+        new ##java.util.Comparator {
+            def compare(_this: ##java.util.Comparator, t: ##java.lang.Object, u: ##java.lang.Object): Int32 =
+                f1(t, u)
+        }
+
+    ///
+    /// Returns all elements in the given Java List as a Flix List.
+    ///
+    pub def fromList(l: ##java.util.List): List[a] = region rc {
+        import java.util.List.iterator(): ##java.util.Iterator \ rc;
+        iterator(l) |> fromIterator(rc, Proxy.Proxy: Proxy[a]) |> Iterator.toList
+    }
+
+    ///
+    /// Returns all elements in the given Java Set as a Flix Set.
+    ///
+    /// WARNING: The Flix Set will use the ordering defined on `a`.
+    ///
+    pub def fromSet(l: ##java.util.Set): Set[a] with Order[a] = region rc {
+        import java.util.Set.iterator(): ##java.util.Iterator \ rc;
+        iterator(l) |> fromIterator(rc, Proxy.Proxy: Proxy[a]) |> Iterator.toSet
+    }
+
+    ///
+    /// Returns all key-value pairs in the given Java Map as a Flix Map.
+    ///
+    /// WARNING: The Flix Map will use the ordering defined on `k`.
+    ///
+    pub def fromMap(m: ##java.util.Map): Map[k, v] with Order[k] = region rc {
+        def step(acc, entry) = {
+            let (k, v) = entry;
+            Map.insert(k, v, acc)
+        };
+        mapIterator(rc, m) |> Iterator.foldLeft(step, Map.empty())
+    }
+
+    ///
+    /// Helper function for `fromMap`.
+    ///
+    def mapIterator(rc: Region[r], m: ##java.util.Map): Iterator[(k, v), r, r] \ r =
+        import java.util.Map.entrySet(): ##java.util.Set \ r;
+        import java.util.Set.iterator(): ##java.util.Iterator \ r;
+        import java.util.Iterator.hasNext(): Bool \ r;
+        import java.util.Iterator.next(): ##java.lang.Object \ r;
+        import java.util.Map$Entry.getKey(): ##java.lang.Object \ {};
+        import java.util.Map$Entry.getValue(): ##java.lang.Object \ {};
+        let entries = entrySet(m);
+        let iter = iterator(entries);
+        let getNext = () -> match hasNext(iter) {
+            case true  => {
+                let entry = {let obj = next(iter); unchecked_cast(obj as ##java.util.Map$Entry)};
+                let k = {let okey = getKey(entry); unchecked_cast(okey as k)};
+                let v = {let ovalue = getValue(entry); unchecked_cast(ovalue as v)};
+                Some((k, v))
+            }
+            case false => None
+        };
+        Iterator.iterate(rc, getNext)
+
+    ///
+    /// Returns a fresh Flix `Iterator` from the Java iterator `iter`.
+    ///
+    pub def fromIterator(rc: Region[r], _: Proxy[a], iter: ##java.util.Iterator): Iterator[a, r, r] =
+        import java.util.Iterator.hasNext(): Bool \ r;
+        import java.util.Iterator.next(): ##java.lang.Object \ r;
+        let step = () -> {
+            match hasNext(iter) {
+                case true  => next(iter) |> (o -> unchecked_cast(o as a)) |> Some
+                case false => None
+            }
+        };
+        let iterF = () -> checked_ecast(step());
+        Iterator.iterate(rc, iterF)
+
+    ///
+    /// Alias for `toArrayList`.
+    ///
+    pub def toList(ma: m[a]): ##java.util.List \ IO with Foldable[m] = checked_cast(toArrayList(ma))
+
+    ///
+    /// Returns the elements of the given foldable `ma` as a new Java `ArrayList`.
+    ///
+    /// Creates a fresh `ArrayList` and copies all elements in `ma` into it.
+    ///
+    pub def toArrayList(ma: m[a]): ##java.util.ArrayList \ IO with Foldable[m] =
+        import new java.util.ArrayList(): ##java.util.ArrayList \ IO as newArrayList;
+        import java.util.ArrayList.add(##java.lang.Object): Bool \ IO;
+        let alist = newArrayList();
+        Foldable.forEach(x -> discard add(alist, unchecked_cast(x as ##java.lang.Object)), ma);
+        alist
+
+    ///
+    /// Returns the elements of the given foldable `ma` as a new Java `LinkedList`.
+    ///
+    /// Creates a fresh `LinkedList` and copies all elements in `ma` into it.
+    ///
+    pub def toLinkedList(ma: m[a]): ##java.util.LinkedList \ IO with Foldable[m] =
+        import new java.util.LinkedList(): ##java.util.LinkedList \ IO as newLinkedList;
+        import java.util.LinkedList.add(##java.lang.Object): Bool \ IO;
+        let llist = newLinkedList();
+        Foldable.forEach(x -> discard add(llist, unchecked_cast(x as ##java.lang.Object)), ma);
+        llist
+
+    ///
+    /// Alias for `toTreeSet`.
+    ///
+    pub def toSet(ma: m[a]): ##java.util.Set \ IO with Order[a], Foldable[m] = checked_cast(toTreeSet(ma))
+
+    ///
+    /// Returns the elements of the given foldable `ma` as a new `TreeSet`.
+    ///
+    pub def toTreeSet(ma: m[a]): ##java.util.TreeSet \ IO with Order[a], Foldable[m] =
+        import new java.util.TreeSet(): ##java.util.TreeSet \ IO as newTreeSet;
+        import java.util.TreeSet.add(##java.lang.Object): Bool \ IO;
+        let tset = newTreeSet();
+        Foldable.forEach(x -> discard add(tset, unchecked_cast(x as ##java.lang.Object)), ma);
+        tset
+
+    ///
+    /// Alias for `toTreeMap`.
+    ///
+    pub def toMap(m: Map[k, v]): ##java.util.Map \ IO with Order[k] = checked_cast(toTreeMap(m))
+
+    ///
+    /// Returns all key-value pairs of the given map `m` as a new `TreeMap`.
+    ///
+    /// The `TreeMap` uses a `Comparator` constructed from the `Order` on `k`.
+    ///
+    pub def toTreeMap(m: Map[k, v]): ##java.util.TreeMap \ IO with Order[k] =
+        import new java.util.TreeMap(): ##java.util.TreeMap \ IO as newTreeMap;
+        import java.util.TreeMap.put(##java.lang.Object, ##java.lang.Object): ##java.lang.Object \ IO;
+        let tmap = newTreeMap();
+        Map.forEach((k, v) -> discard put(tmap, unchecked_cast(k as ##java.lang.Object), unchecked_cast(v as ##java.lang.Object)), m);
+        tmap
+
+}

--- a/main/test/ca/uwaterloo/flix/library/TestAdaptor.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestAdaptor.flix
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2023 Stephen Tetley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mod TestAdaptor {
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Comparator                                                              //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def comparator01(): Bool \ IO =
+        import java.util.Comparator.compare(##java.lang.Object, ##java.lang.Object): Int32 \ {};
+        let c1 = Adaptor.comparator(Proxy.Proxy: Proxy[String]);
+        compare(c1, checked_cast("aaaa"), checked_cast("aaaa")) == 0
+
+    @test
+    def comparator02(): Bool \ IO =
+        import java.util.Comparator.compare(##java.lang.Object, ##java.lang.Object): Int32 \ {};
+        let c1 = Adaptor.comparator(Proxy.Proxy: Proxy[String]);
+        compare(c1, checked_cast("aaaa"), checked_cast("bbbb")) == -1
+
+    @test
+    def comparator03(): Bool \ IO =
+        import java.util.Comparator.compare(##java.lang.Object, ##java.lang.Object): Int32 \ {};
+        let c1 = Adaptor.comparator(Proxy.Proxy: Proxy[String]);
+        compare(c1, checked_cast("bbbb"), checked_cast("aaaa")) == 1
+
+    /////////////////////////////////////////////////////////////////////////////
+    // fromList                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def fromList01(): Bool \ {} =
+        import static java.util.List.of(): ##java.util.List \ {};
+        let l = of();
+        Adaptor.fromList(l) == (List#{} : List[String])
+
+    @test
+    def fromList02(): Bool \ {} =
+        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
+        let l = of(checked_cast("hello"));
+        Adaptor.fromList(l) == List#{"hello"}
+
+    @test
+    def fromList03(): Bool \ {} =
+        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
+        let l = of(checked_cast("hello"), checked_cast("world"));
+        Adaptor.fromList(l) == List#{"hello", "world"}
+
+    /////////////////////////////////////////////////////////////////////////////
+    // fromSet                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def fromSet01(): Bool \ {} =
+        import static java.util.Set.of(): ##java.util.Set \ {};
+        let s = of();
+        Adaptor.fromSet(s) == (Set#{} : Set[String])
+
+    @test
+    def fromSet02(): Bool \ {} =
+        import static java.util.Set.of(##java.lang.Object): ##java.util.Set \ {};
+        let s = of(checked_cast("hello"));
+        Adaptor.fromSet(s) == Set#{"hello"}
+
+    @test
+    def fromSet03(): Bool \ {} =
+        import static java.util.Set.of(##java.lang.Object, ##java.lang.Object): ##java.util.Set \ {};
+        let s = of(checked_cast("hello"), checked_cast("world"));
+        Adaptor.fromSet(s) == Set#{"hello", "world"}
+
+    /////////////////////////////////////////////////////////////////////////////
+    // fromMap                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def fromMap01(): Bool \ {} =
+        import static java.util.Map.of(): ##java.util.Map \ {};
+        let m = of();
+        Adaptor.fromMap(m) == (Map#{} : Map[String, String])
+
+    @test
+    def fromMap02(): Bool \ {} =
+        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
+        let m = of(checked_cast("a"), checked_cast("hello"));
+        Adaptor.fromMap(m) == Map#{"a" => "hello"}
+
+    @test
+    def fromMap03(): Bool \ {} =
+        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object, ##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
+        let m = of(checked_cast("a"), checked_cast("hello"), checked_cast("b"), checked_cast("world"));
+        Adaptor.fromMap(m) == Map#{"a" => "hello", "b" => "world"}
+
+    /////////////////////////////////////////////////////////////////////////////
+    // fromIterator                                                            //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def fromIterator01(): Bool \ {} = region rc {
+        import static java.util.List.of(): ##java.util.List \ {};
+        import java.util.List.iterator(): ##java.util.Iterator \ {};
+        let iter = of() |> iterator;
+        let flixIter = Adaptor.fromIterator(rc, Proxy.Proxy: Proxy[String], iter);
+        Iterator.toList(flixIter) == (Nil : List[String])
+    }
+
+    @test
+    def fromIterator02(): Bool \ {} = region rc {
+        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
+        import java.util.List.iterator(): ##java.util.Iterator \ {};
+        let iter = of(checked_cast("hello")) |> iterator;
+        let flixIter = Adaptor.fromIterator(rc, Proxy.Proxy: Proxy[String], iter);
+        Iterator.toList(flixIter) == List#{"hello"}
+    }
+
+
+    @test
+    def fromIterator03(): Bool \ {} = region rc {
+        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
+        import java.util.List.iterator(): ##java.util.Iterator \ {};
+        let iter = of(checked_cast("hello"), checked_cast("world")) |> iterator;
+        let flixIter = Adaptor.fromIterator(rc, Proxy.Proxy: Proxy[String], iter);
+        Iterator.toList(flixIter) == List#{"hello", "world"}
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toList                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toList01(): Bool \ IO =
+        import static java.util.List.of(): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let l = Adaptor.toList(Nil : List[String]);
+        equals(of(), checked_cast(l))
+
+    @test
+    def toList02(): Bool \ IO =
+        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let l = Adaptor.toList(List#{"hello"});
+        equals(of(checked_cast("hello")), checked_cast(l))
+
+    @test
+    def toList03(): Bool \ IO =
+        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let l = Adaptor.toList(List#{"hello", "world"});
+        equals(of(checked_cast("hello"), checked_cast("world")), checked_cast(l))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toArrayList                                                             //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toArrayList01(): Bool \ IO =
+        import new java.util.ArrayList(##java.util.Collection): ##java.util.ArrayList \ {} as newArrayList;
+        import static java.util.List.of(): ##java.util.List \ {};
+        import java.util.ArrayList.equals(##java.lang.Object): Bool \ {};
+        let l = Adaptor.toArrayList(Nil : List[String]);
+        equals(newArrayList(unchecked_cast(of() as ##java.util.Collection)), checked_cast(l))
+
+    @test
+    def toArrayList02(): Bool \ IO =
+        import new java.util.ArrayList(##java.util.Collection): ##java.util.ArrayList \ {} as newArrayList;
+        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
+        import java.util.ArrayList.equals(##java.lang.Object): Bool \ {};
+        let l = Adaptor.toArrayList(List#{"hello"});
+        equals(newArrayList(unchecked_cast(of(checked_cast("hello")) as ##java.util.Collection)), checked_cast(l))
+
+    @test
+    def toArrayList03(): Bool \ IO =
+        import new java.util.ArrayList(##java.util.Collection): ##java.util.ArrayList \ {} as newArrayList;
+        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
+        import java.util.ArrayList.equals(##java.lang.Object): Bool \ {};
+        let l = Adaptor.toArrayList(List#{"hello", "world"});
+        equals(newArrayList(unchecked_cast(of(checked_cast("hello"), checked_cast("world")) as ##java.util.Collection)), checked_cast(l))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toLinkedList                                                            //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toLinkedList01(): Bool \ IO =
+        import new java.util.LinkedList(##java.util.Collection): ##java.util.LinkedList \ {} as newLinkedList;
+        import static java.util.List.of(): ##java.util.List \ {};
+        import java.util.LinkedList.equals(##java.lang.Object): Bool \ {};
+        let l = Adaptor.toLinkedList(Nil : List[String]);
+        equals(newLinkedList(unchecked_cast(of() as ##java.util.Collection)), checked_cast(l))
+
+    @test
+    def toLinkedList02(): Bool \ IO =
+        import new java.util.LinkedList(##java.util.Collection): ##java.util.LinkedList \ {} as newLinkedList;
+        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
+        import java.util.LinkedList.equals(##java.lang.Object): Bool \ {};
+        let l = Adaptor.toLinkedList(List#{"hello"});
+        equals(newLinkedList(unchecked_cast(of(checked_cast("hello")) as ##java.util.Collection)), checked_cast(l))
+
+    @test
+    def toLinkedList03(): Bool \ IO =
+        import new java.util.LinkedList(##java.util.Collection): ##java.util.LinkedList \ {} as newLinkedList;
+        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
+        import java.util.LinkedList.equals(##java.lang.Object): Bool \ {};
+        let l = Adaptor.toLinkedList(List#{"hello", "world"});
+        equals(newLinkedList(unchecked_cast(of(checked_cast("hello"), checked_cast("world")) as ##java.util.Collection)), checked_cast(l))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toSet                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toSet01(): Bool \ IO =
+        import static java.util.Set.of(): ##java.util.Set \ {};
+        import java.util.Set.equals(##java.lang.Object): Bool \ {};
+        let s = Adaptor.toSet(Set#{} : Set[String]);
+        equals(of(), checked_cast(s))
+
+    @test
+    def toSet02(): Bool \ IO =
+        import static java.util.Set.of(##java.lang.Object): ##java.util.Set \ {};
+        import java.util.Set.equals(##java.lang.Object): Bool \ {};
+        let s = Adaptor.toSet(Set#{"hello"});
+        equals(of(checked_cast("hello")), checked_cast(s))
+
+    @test
+    def toSet03(): Bool \ IO =
+        import static java.util.Set.of(##java.lang.Object, ##java.lang.Object): ##java.util.Set \ {};
+        import java.util.Set.equals(##java.lang.Object): Bool \ {};
+        let s = Adaptor.toSet(Set#{"hello", "world"});
+        equals(of(checked_cast("hello"), checked_cast("world")), checked_cast(s))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toTreeSet                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toTreeSet01(): Bool \ IO =
+        import new java.util.TreeSet(##java.util.Collection): ##java.util.TreeSet \ {} as newTreeSet;
+        import static java.util.List.of(): ##java.util.List \ {};
+        import java.util.TreeSet.equals(##java.lang.Object): Bool \ {};
+        let s = Adaptor.toTreeSet(Set#{} : Set[String]);
+        equals(newTreeSet(unchecked_cast(of() as ##java.util.Collection)), checked_cast(s))
+
+    @test
+    def toTreeSet02(): Bool \ IO =
+        import new java.util.TreeSet(##java.util.Collection): ##java.util.TreeSet \ {} as newTreeSet;
+        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
+        import java.util.TreeSet.equals(##java.lang.Object): Bool \ {};
+        let s = Adaptor.toTreeSet(Set#{"hello"});
+        equals(newTreeSet(unchecked_cast(of(checked_cast("hello")) as ##java.util.Collection)), checked_cast(s))
+
+    @test
+    def toTreeSet03(): Bool \ IO =
+        import new java.util.TreeSet(##java.util.Collection): ##java.util.TreeSet \ {} as newTreeSet;
+        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
+        import java.util.TreeSet.equals(##java.lang.Object): Bool \ {};
+        let s = Adaptor.toTreeSet(Set#{"hello", "world"});
+        equals(newTreeSet(unchecked_cast(of(checked_cast("hello"), checked_cast("world")) as ##java.util.Collection)), checked_cast(s))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toMap                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toMap01(): Bool \ IO =
+        import static java.util.Map.of(): ##java.util.Map \ {};
+        import java.util.Map.equals(##java.lang.Object): Bool \ {};
+        let m = Adaptor.toMap(Map#{} : Map[String, String]);
+        equals(of(), checked_cast(m))
+
+    @test
+    def toMap02(): Bool \ IO =
+        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
+        import java.util.Map.equals(##java.lang.Object): Bool \ {};
+        let m = Adaptor.toMap(Map#{"a" => "hello"});
+        equals(of(checked_cast("a"), checked_cast("hello")), checked_cast(m))
+
+    @test
+    def toMap03(): Bool \ IO =
+        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object, ##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
+        import java.util.Map.equals(##java.lang.Object): Bool \ {};
+        let m = Adaptor.toMap(Map#{"a" => "hello", "b" => "world"});
+        equals(of(checked_cast("a"), checked_cast("hello"), checked_cast("b"), checked_cast("world")), checked_cast(m))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toTreeMap                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toTreeMap01(): Bool \ IO =
+        import new java.util.TreeMap(##java.util.Map): ##java.util.TreeMap \ {} as newTreeMap;
+        import static java.util.Map.of(): ##java.util.Map \ {};
+        import java.util.TreeMap.equals(##java.lang.Object): Bool \ {};
+        let m = Adaptor.toTreeMap(Map#{} : Map[String, String]);
+        equals(newTreeMap(of()), checked_cast(m))
+
+    @test
+    def toTreeMap02(): Bool \ IO =
+        import new java.util.TreeMap(##java.util.Map): ##java.util.TreeMap \ {} as newTreeMap;
+        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
+        import java.util.TreeMap.equals(##java.lang.Object): Bool \ {};
+        let m = Adaptor.toTreeMap(Map#{"a" => "hello"});
+        equals(newTreeMap(of(checked_cast("a"), checked_cast("hello"))), checked_cast(m))
+
+    @test
+    def toTreeMap03(): Bool \ IO =
+        import new java.util.TreeMap(##java.util.Map): ##java.util.TreeMap \ {} as newTreeMap;
+        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object, ##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
+        import java.util.TreeMap.equals(##java.lang.Object): Bool \ {};
+        let m = Adaptor.toTreeMap(Map#{"a" => "hello", "b" => "world"});
+        equals(newTreeMap(of(checked_cast("a"), checked_cast("hello"), checked_cast("b"), checked_cast("world"))), checked_cast(m))
+
+
+}


### PR DESCRIPTION
This PR adds a module `Adaptor` for marshaling between Flix and Java.

Currently it just covers collection marshaling as per sub issues #6332 and #6333. 

Iterators - I've actually implemented `fromIterator` rather than `toIterator`, i.e. make a Flix Iterator from a Java one. Java Iterators have a (`hasNext`, `next`) API whereas Flix iterators have just a `next` API (which the return type being Option - None shows the iterator is finished). I think its possible to make a Java iterator from a Flix one with a one element buffer but it would be rather involved so I haven't look at it so far.

Marshaling collection elements (not the collection itself) is currently done with casting this means we can't have numbers and chars in collections (Java overcomes this with object types for prim types `java.lang.Character` for `char`, `java.lang.Integer` for `int` etc.). At some point we might need to use e.g a type class to make marshaling elements more controllable.

Because of this restriction on element types, the tests just test collections with `String` elements at the moment.

