### PR TITLE
chore: shorten toString for Ast.Source

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -77,6 +77,8 @@ object Ast {
     }
 
     override def hashCode(): Int = input.hashCode()
+
+    override def toString: String = name
   }
 
   /**


### PR DESCRIPTION
Should make debugging faster. related to #6300