### PR TITLE
style: mark functions as private & remove redundant constructors

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
@@ -72,11 +72,11 @@ object MonoType {
 
   case class Arrow(args: List[MonoType], result: MonoType) extends MonoType
 
-  case class RecordEmpty() extends MonoType
+  case object RecordEmpty extends MonoType
 
   case class RecordExtend(field: String, value: MonoType, rest: MonoType) extends MonoType
 
-  case class SchemaEmpty() extends MonoType
+  case object SchemaEmpty extends MonoType
 
   case class SchemaExtend(name: String, tpe: MonoType, rest: MonoType) extends MonoType
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypePrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypePrinter.scala
@@ -45,9 +45,9 @@ object MonoTypePrinter {
     case MonoType.Tuple(elms) => Type.Tuple(elms.map(print))
     case MonoType.Enum(sym) => Type.Enum(sym, Nil)
     case MonoType.Arrow(args, result) => Type.Arrow(args.map(print), print(result))
-    case MonoType.RecordEmpty() => Type.RecordEmpty
+    case MonoType.RecordEmpty => Type.RecordEmpty
     case MonoType.RecordExtend(field, value, rest) => Type.RecordExtend(field, print(value), print(rest))
-    case MonoType.SchemaEmpty() => Type.SchemaEmpty
+    case MonoType.SchemaEmpty => Type.SchemaEmpty
     case MonoType.SchemaExtend(name, tpe, rest) => Type.SchemaExtend(name, print(tpe), print(rest))
     case MonoType.Native(clazz) => Type.Native(clazz)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -269,7 +269,7 @@ object Simplifier {
 
             case TypeConstructor.Regex => MonoType.Regex
 
-            case TypeConstructor.RecordRowEmpty => MonoType.RecordEmpty()
+            case TypeConstructor.RecordRowEmpty => MonoType.RecordEmpty
 
             case TypeConstructor.Sender => throw InternalCompilerException("Unexpected Sender", tpe.loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -471,7 +471,7 @@ object Simplifier {
 
       val t = visitType(tpe)
 
-      //TODO Intermediate solution (which is correct, but imprecise): Compute the purity of every match rule in rules
+      // TODO Intermediate solution (which is correct, but imprecise): Compute the purity of every match rule in rules
       val jumpPurity = combineAll(rules.map(r => simplifyEffect(r.exp.eff)))
 
       // Create a branch for each rule.
@@ -625,7 +625,7 @@ object Simplifier {
   /**
     * Returns a copy of the given expression `exp0` where every variable symbol has been replaced according to the given substitution `m`.
     */
-  def substitute(exp0: SimplifiedAst.Expr, m: Map[Symbol.VarSym, Symbol.VarSym]): SimplifiedAst.Expr = {
+  private def substitute(exp0: SimplifiedAst.Expr, m: Map[Symbol.VarSym, Symbol.VarSym]): SimplifiedAst.Expr = {
 
     def visitExp(e: SimplifiedAst.Expr): SimplifiedAst.Expr = e match {
       case SimplifiedAst.Expr.Cst(_, _, _) => e
@@ -726,7 +726,7 @@ object Simplifier {
     * Combines purities `p1` and `p2`
     * A combined purity is only pure if both `p1` and `p2` are pure, otherwise it is always impure.
     */
-  def combine(p1: Purity, p2: Purity): Purity = (p1, p2) match {
+  private def combine(p1: Purity, p2: Purity): Purity = (p1, p2) match {
     case (Pure, Pure) => Pure
     case _ => Impure
   }
@@ -735,13 +735,13 @@ object Simplifier {
     * Combine `p1`, `p2` and `p3`
     * A combined purity is only pure if `p1`, `p2` and `p3` are pure, otherwise it is always impure.
     */
-  def combine(p1: Purity, p2: Purity, p3: Purity): Purity = combine(p1, combine(p2, p3))
+  private def combine(p1: Purity, p2: Purity, p3: Purity): Purity = combine(p1, combine(p2, p3))
 
   /**
     * Combine `purities`
     * A combined purity is only pure if every purity in `purities` are pure, otherwise it is always impure.
     */
-  def combineAll(purities: List[Purity]): Purity = purities.foldLeft[Purity](Pure) {
+  private def combineAll(purities: List[Purity]): Purity = purities.foldLeft[Purity](Pure) {
     case (acc, purity) => combine(acc, purity)
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -130,8 +130,8 @@ object BackendType {
     case MonoType.Int64 => Int64
     case MonoType.Unit | MonoType.BigDecimal | MonoType.BigInt | MonoType.Str | MonoType.Regex |
          MonoType.Array(_) | MonoType.Lazy(_) | MonoType.Ref(_) | MonoType.Tuple(_) |
-         MonoType.Enum(_) | MonoType.Arrow(_, _) | MonoType.RecordEmpty() | MonoType.RecordExtend(_, _, _) |
-         MonoType.SchemaEmpty() | MonoType.SchemaExtend(_, _, _) | MonoType.Native(_) |
+         MonoType.Enum(_) | MonoType.Arrow(_, _) | MonoType.RecordEmpty | MonoType.RecordExtend(_, _, _) |
+         MonoType.SchemaEmpty | MonoType.SchemaExtend(_, _, _) | MonoType.Native(_) |
          MonoType.Region => BackendObjType.JavaObject.toTpe
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -65,7 +65,7 @@ object JvmOps {
     case MonoType.Lazy(_) => JvmType.Object
     case MonoType.Ref(_) => getRefClassType(tpe)
     case MonoType.Tuple(_) => getTupleClassType(tpe.asInstanceOf[MonoType.Tuple])
-    case MonoType.RecordEmpty() => getRecordInterfaceType()
+    case MonoType.RecordEmpty => getRecordInterfaceType()
     case MonoType.RecordExtend(_, _, _) => getRecordInterfaceType()
     case MonoType.Enum(sym) => getEnumInterfaceType(sym)
     case MonoType.Arrow(_, _) => getFunctionInterfaceType(tpe)
@@ -645,10 +645,10 @@ object JvmOps {
       case MonoType.Enum(_) => Set(tpe)
       case MonoType.Arrow(targs, tresult) => targs.flatMap(nestedTypesOf).toSet ++ nestedTypesOf(tresult) + tpe
 
-      case MonoType.RecordEmpty() => Set(tpe)
+      case MonoType.RecordEmpty => Set(tpe)
       case MonoType.RecordExtend(_, value, rest) => Set(tpe) ++ nestedTypesOf(value) ++ nestedTypesOf(rest)
 
-      case MonoType.SchemaEmpty() => Set(tpe)
+      case MonoType.SchemaEmpty => Set(tpe)
       case MonoType.SchemaExtend(_, t, rest) => nestedTypesOf(t) ++ nestedTypesOf(rest) + t + rest
 
       case MonoType.Native(_) => Set(tpe)


### PR DESCRIPTION
Small mistakes / smells that I spotted when working on the code. This PR changes the following:
- `MonoType.{SchemaEmpty, RecordEmpty}` are now case objects instead of case classes with empty constructors
- Helper functions in `Simplifier` were public. They are now marked as private.