### PR TITLE
feat: display version in HTML documentation

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -16,7 +16,7 @@
 
 package ca.uwaterloo.flix.language.phase
 
-import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.api.{Flix, Version}
 import ca.uwaterloo.flix.language.ast.{Ast, SourceLocation, Symbol, Type, TypedAst}
 import ca.uwaterloo.flix.language.fmt.{FormatType, SimpleType}
 import ca.uwaterloo.flix.util.LocalResource
@@ -24,6 +24,7 @@ import ca.uwaterloo.flix.util.LocalResource
 import java.io.IOException
 import java.nio.file.{Files, Path, Paths}
 import com.github.rjeschke.txtmark
+
 import scala.collection.mutable
 
 /**
@@ -222,6 +223,10 @@ object HtmlDocumentor {
     sb.append("<body>")
 
     sb.append("<nav>")
+    sb.append("<div class='flix'>")
+    sb.append("<h2>flix</h2>")
+    sb.append(s"<span class='version'>${Version.CurrentVersion}</span>")
+    sb.append("</div>")
     docSubModules(sortedMods)
     docSideBarSection(
       "Classes",

--- a/main/src/resources/doc/styles.css
+++ b/main/src/resources/doc/styles.css
@@ -5,6 +5,7 @@
 
     --heading-color: rgb(33, 37, 41);
     --text-color: rgb(17, 17, 17);
+    --faded-text-color: #8a8a8a;
 
     --section-arrow-color: rgb(85, 91, 96);
 
@@ -50,7 +51,6 @@ body {
 
 h1, h2 {
     color: var(--heading-color);
-    font-family: Oswald, sans-serif;
     margin-top: 0;
     line-height: 1.2;
 }
@@ -58,6 +58,7 @@ h1 {
     font-size: 4.5rem;
     font-weight: 300;
     margin-bottom: 3rem;
+    font-family: Oswald, sans-serif;
 }
 h2 {
     font-size: 2rem;
@@ -80,6 +81,18 @@ nav {
     height: 100%;
     width: 20rem;
     overflow-y: auto;
+}
+
+nav h2 {
+    font-weight: 700;
+    display: inline-block;
+    margin-bottom: 0.5rem;
+}
+
+.version {
+    color: var(--faded-text-color);
+    margin-left: 0.5rem;
+    font-size: 0.85rem;
 }
 
 nav ul {
@@ -136,9 +149,10 @@ main {
     scroll-behavior: smooth;
 }
 
-hr {
-    color: transparent;
+main h2 {
+    font-family: Oswald, sans-serif;
 }
+
 body > hr {
     margin-top: 1rem;
     margin-bottom: 3rem;


### PR DESCRIPTION
Displayed in the upper left hand corner

![image](https://github.com/flix/flix/assets/61235930/72b071fb-629c-466f-831f-36cd96d1c856)

I think it would be great to add a logo here too.

Related to #6327