### PR TITLE
feat: add dark mode to HTML documentation

### DIFF
--- a/main/src/resources/doc/styles.css
+++ b/main/src/resources/doc/styles.css
@@ -3,11 +3,11 @@
     --bg-color-2: #fcfcfd;
     --bg-color-3: rgb(248, 249, 250);
 
+    --border-color: rgba(0, 0, 0, 0.07);
+
     --heading-color: rgb(33, 37, 41);
     --text-color: rgb(17, 17, 17);
     --faded-text-color: #8a8a8a;
-
-    --section-arrow-color: rgb(85, 91, 96);
 
     --annotation-color: #b15422;
     --keyword-color: #030303;
@@ -27,6 +27,37 @@
     --eff-color: #ffaefa;
     --type-alias-color: #f9cdad;
     --def-color: #83af9b;
+
+    --shadow-color: rgba(0, 0, 0, 0.05);
+    --highlight-color: rgba(0, 0, 0, 0.3);
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-color-1: #151719;
+        --bg-color-2: #101214;
+        --bg-color-3: #0e0f11;
+
+        --border-color: rgba(255, 255, 255, 0.15);
+    
+        --heading-color: #e6e6e6;
+        --text-color: #f7f7f7;
+        --faded-text-color: #8a8a8a;
+    
+        --annotation-color: #e7a37e;
+        --keyword-color: #fcfcfc;
+        --name-color: #ff6696;
+        --type-color: #6699ff;
+        --kind-color: #999999;
+        --effect-color: #ff944d;
+    
+        --doc-code-color: #ff66b3;
+    
+        --show-hide-color: #68a4fd;
+        --show-hide-hover-color: #3c86f6;
+
+        --shadow-color: rgba(0, 0, 0, 0.5);
+        --highlight-color: hsla(50, 0%, 100%, 0.3);
+    }
 }
 
 html, body {
@@ -74,8 +105,8 @@ h3 {
 
 nav {
     background-color: var(--bg-color-1);
-    box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.05);
-    border-right: 1px solid rgba(0, 0, 0, 0.07);
+    box-shadow: 0 0 10px 0 var(--shadow-color);
+    border-right: 1px solid var(--border-color);
     box-sizing: border-box;
     padding: 0.5rem 1rem;
     height: 100%;
@@ -171,9 +202,9 @@ section > * {
 }
 
 .box {
-    box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 10px 0 var(--shadow-color);
     background-color: var(--bg-color-1);
-    border: 1px solid rgba(0, 0, 0, 0.07);
+    border: 1px solid var(--border-color);
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
     margin-bottom: 0.8rem;
@@ -182,7 +213,7 @@ section > * {
     overflow: auto;
 }
 .box:target {
-    box-shadow: 0 0 14px 0 rgba(0, 0, 0, 0.3);
+    box-shadow: 0 0 14px 0 var(--highlight-color);
 }
 .box code {
     font-size: 0.85rem;
@@ -195,6 +226,7 @@ section > * {
     background-color: var(--bg-color-3);
     padding: 0.2em 0.65em;
     border-radius: 0.375rem;
+    border: 1px solid var(--border-color);
 
     float: right;
 }
@@ -238,7 +270,6 @@ details {
 summary {
     cursor: pointer;
     list-style: none;
-    color: var(--section-arrow-color);
     margin-left: -1.5rem;
 }
 summary::after {


### PR DESCRIPTION
Respects the system preference - A JavaScript toggle could be added.

![image](https://github.com/flix/flix/assets/61235930/67b5ee95-734c-41cd-9a8d-5dfc892601f4)

Text color may need tweaking?