### PR TITLE
feat: add ToJava class (issue #6348)

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -292,6 +292,7 @@ class Flix {
     "Vector.flix" -> LocalResource.get("/src/library/Vector.flix"),
     "Regex.flix" -> LocalResource.get("/src/library/Regex.flix"),
     "Adaptor.flix" -> LocalResource.get("/src/library/Adaptor.flix"),
+    "ToJava.flix" -> LocalResource.get("/src/library/ToJava.flix"),
   )
 
   /**

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -118,6 +118,11 @@ instance Iterable[Chain] {
     pub def iterator(rc: Region[r], c: Chain[a]): Iterator[a, r, r] \ r = Chain.iterator(rc, c)
 }
 
+instance ToJava[Chain[a]] {
+    type O = ##java.util.List
+    pub def toJava(c: Chain[a]): ##java.util.List \ IO = Adaptor.toList(c)
+}
+
 mod Chain {
     use ViewLeft.{NoneLeft, SomeLeft}
     use ViewRight.{NoneRight, SomeRight}

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -124,6 +124,11 @@ instance Iterable[List] {
     pub def iterator(rc: Region[r], l: List[a]): Iterator[a, r, r] \ r = List.iterator(rc, l)
 }
 
+instance ToJava[List[a]] {
+    type O = ##java.util.List
+    pub def toJava(l: List[a]): ##java.util.List \ IO = Adaptor.toList(l)
+}
+
 mod List {
 
     ///

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -105,6 +105,11 @@ instance Iterable[Map[k]] {
     pub def iterator(rc: Region[r], m: Map[k, v]): Iterator[v, r, r] \ r = Map.iteratorValues(rc, m)
 }
 
+instance ToJava[Map[k, v]] with Order[k] {
+    type O = ##java.util.Map
+    pub def toJava(m: Map[k, v]): ##java.util.Map \ IO = Adaptor.toMap(m)
+}
+
 mod Map {
 
     ///

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -140,6 +140,11 @@ instance Iterable[Nec] {
     pub def iterator(rc: Region[r], l: Nec[a]): Iterator[a, r, r] \ r = Nec.iterator(rc, l)
 }
 
+instance ToJava[Nec[a]] {
+    type O = ##java.util.List
+    pub def toJava(l: Nec[a]): ##java.util.List \ IO = Adaptor.toList(l)
+}
+
 mod Nec {
     use ViewLeft.{OneLeft, SomeLeft}
     use ViewRight.{OneRight, SomeRight}

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -115,6 +115,11 @@ instance Iterable[Nel] {
     pub def iterator(rc: Region[r], l: Nel[a]): Iterator[a, r, r] \ r = Nel.iterator(rc, l)
 }
 
+instance ToJava[Nel[a]] {
+    type O = ##java.util.List
+    pub def toJava(l: Nel[a]): ##java.util.List \ IO = Adaptor.toList(l)
+}
+
 mod Nel {
 
     ///

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -173,3 +173,8 @@ pub def printUnlessUnit(x: a): Unit \ IO with ToString[a] = {
         case _: _ => println(x)
     }
 }
+
+///
+/// Marshals `t` to its Java representation.
+///
+def toJava(t: t): ToJava.O[t] \ IO with ToJava[t] = ToJava.toJava(t)

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -173,8 +173,3 @@ pub def printUnlessUnit(x: a): Unit \ IO with ToString[a] = {
         case _: _ => println(x)
     }
 }
-
-///
-/// Marshals `t` to its Java representation.
-///
-def toJava(t: t): ToJava.O[t] \ IO with ToJava[t] = ToJava.toJava(t)

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -95,6 +95,11 @@ instance Iterable[Set] {
     pub def iterator(rc: Region[r], s: Set[a]): Iterator[a, r, r] \ r = Set.iterator(rc, s)
 }
 
+instance ToJava[Set[a]] with Order[a] {
+    type O = ##java.util.Set
+    pub def toJava(s: Set[a]): ##java.util.Set \ IO = Adaptor.toSet(s)
+}
+
 mod Set {
 
     ///

--- a/main/src/library/ToJava.flix
+++ b/main/src/library/ToJava.flix
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2023 Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+///
+/// A type class for marshaling values to Java.
+///
+pub class ToJava[t: Type] {
+    type O
+    pub def toJava(t: t): ToJava.O[t] \ IO
+}

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -101,6 +101,11 @@ instance Iterable[Vector] {
     pub def iterator(rc: Region[r], v: Vector[a]): Iterator[a, r, r] \ r = Vector.iterator(rc, v)
 }
 
+instance ToJava[Vector[a]] {
+    type O = ##java.util.List
+    pub def toJava(v: Vector[a]): ##java.util.List \ IO = Adaptor.toList(v)
+}
+
 mod Vector {
 
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestToJava.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestToJava.flix
@@ -1,0 +1,180 @@
+/*
+ *  Copyright 2023 Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+mod TestToJava {
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Chain                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def chainToJava01(): Bool \ IO =
+        import static java.util.List.of(): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let l: ##java.util.List = ToJava.toJava(Chain.empty() : Chain[String]);
+        equals(of(), checked_cast(l))
+
+    @test
+    def chainToJava02(): Bool \ IO =
+        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let l: ##java.util.List = ToJava.toJava(Chain.singleton("one"));
+        equals(of(checked_cast("one")), checked_cast(l))
+
+    @test
+    def chainToJava03(): Bool \ IO =
+        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let l: ##java.util.List = ToJava.toJava(Chain.cons("one", Chain.singleton("two")));
+        equals(of(checked_cast("one"), checked_cast("two")), checked_cast(l))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // List                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def listToJava01(): Bool \ IO =
+        import static java.util.List.of(): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let l: ##java.util.List = ToJava.toJava(Nil : List[String]);
+        equals(of(), checked_cast(l))
+
+    @test
+    def listToJava02(): Bool \ IO =
+        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let l: ##java.util.List = ToJava.toJava(List#{"one"});
+        equals(of(checked_cast("one")), checked_cast(l))
+
+    @test
+    def listToJava03(): Bool \ IO =
+        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let l: ##java.util.List = ToJava.toJava(List#{"one", "two"});
+        equals(of(checked_cast("one"), checked_cast("two")), checked_cast(l))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Map                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def mapToJava01(): Bool \ IO =
+        import static java.util.Map.of(): ##java.util.Map \ {};
+        import java.util.Map.equals(##java.lang.Object): Bool \ {};
+        let m: ##java.util.Map = ToJava.toJava(Map#{} : Map[String, String]);
+        equals(of(), checked_cast(m))
+
+    @test
+    def mapToJava02(): Bool \ IO =
+        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
+        import java.util.Map.equals(##java.lang.Object): Bool \ {};
+        let m: ##java.util.Map = ToJava.toJava(Map#{"a" => "one"});
+        equals(of(checked_cast("a"), checked_cast("one")), checked_cast(m))
+
+    @test
+    def mapToJava03(): Bool \ IO =
+        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object, ##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
+        import java.util.Map.equals(##java.lang.Object): Bool \ {};
+        let m: ##java.util.Map = ToJava.toJava(Map#{"a" => "one", "b" => "two"});
+        equals(of(checked_cast("a"), checked_cast("one"), checked_cast("b"), checked_cast("two")), checked_cast(m))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Nec                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def necToJava01(): Bool \ IO =
+        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let l: ##java.util.List = ToJava.toJava(Nec.singleton("one"));
+        equals(of(checked_cast("one")), checked_cast(l))
+
+    @test
+    def necToJava02(): Bool \ IO =
+        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let l: ##java.util.List = ToJava.toJava(Nec.cons("one", Nec.singleton("two")));
+        equals(of(checked_cast("one"), checked_cast("two")), checked_cast(l))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Nel                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def nelToJava01(): Bool \ IO =
+        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let l: ##java.util.List = ToJava.toJava(Nel.singleton("one"));
+        equals(of(checked_cast("one")), checked_cast(l))
+
+    @test
+    def nelToJava02(): Bool \ IO =
+        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let l: ##java.util.List = ToJava.toJava(Nel.cons("one", Nel.singleton("two")));
+        equals(of(checked_cast("one"), checked_cast("two")), checked_cast(l))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Set                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toSet01(): Bool \ IO =
+        import static java.util.Set.of(): ##java.util.Set \ {};
+        import java.util.Set.equals(##java.lang.Object): Bool \ {};
+        let s: ##java.util.Set = ToJava.toJava(Set#{} : Set[String]);
+        equals(of(), checked_cast(s))
+
+    @test
+    def toSet02(): Bool \ IO =
+        import static java.util.Set.of(##java.lang.Object): ##java.util.Set \ {};
+        import java.util.Set.equals(##java.lang.Object): Bool \ {};
+        let s: ##java.util.Set = ToJava.toJava(Set#{"one"});
+        equals(of(checked_cast("one")), checked_cast(s))
+
+    @test
+    def toSet03(): Bool \ IO =
+        import static java.util.Set.of(##java.lang.Object, ##java.lang.Object): ##java.util.Set \ {};
+        import java.util.Set.equals(##java.lang.Object): Bool \ {};
+        let s: ##java.util.Set = ToJava.toJava(Set#{"one", "two"});
+        equals(of(checked_cast("one"), checked_cast("two")), checked_cast(s))
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Vector                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def vectorToJava01(): Bool \ IO =
+        import static java.util.List.of(): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let v: ##java.util.List = ToJava.toJava(Vector#{} : Vector[String]);
+        equals(of(), checked_cast(v))
+
+    @test
+    def vectorToJava02(): Bool \ IO =
+        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let v: ##java.util.List = ToJava.toJava(Vector#{"one"});
+        equals(of(checked_cast("one")), checked_cast(v))
+
+    @test
+    def vectorToJava03(): Bool \ IO =
+        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
+        import java.util.List.equals(##java.lang.Object): Bool \ {};
+        let v: ##java.util.List = ToJava.toJava(Vector#{"one", "two"});
+        equals(of(checked_cast("one"), checked_cast("two")), checked_cast(v))
+
+}


### PR DESCRIPTION
This PR adds the `ToJava` class from issue #6348 and several collection instances.

I think the only contentious instance is for (Flix) Vector which goes to ##java.util.List. Java's ##java.util.Vector would have been an alternative but Vector seems disfavoured in Java now and is not used so much as an argument or a result in API calls.