### PR TITLE
chore: cleanup documentation and unused variable in PatternExhaustiveness

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
@@ -529,7 +529,7 @@ object PatternExhaustiveness {
     * If the constructors are a complete signature, then they are exhaustive for the type, and we just have to
     * check that their arguments are also exhaustive
     *
-    * Wildcards are exhaustive, but we need to do some additional checking in that case (@see DefaultMatrix)
+    * Wildcards are exhaustive, but we need to do some additional checking in that case (@see defaultMatrix)
     *
     * @param ctors The ctors that we match with
     * @param root  Root of the expression tree
@@ -695,10 +695,10 @@ object PatternExhaustiveness {
   }
 
   /**
-    * Convert a pattern to a TypeConstructor
+    * Convert a pattern to a TyCon
     *
     * @param pattern The pattern to convert
-    * @return a TypeConstructor representing the given pattern
+    * @return a TyCon representing the given pattern
     */
   private def patToCtor(pattern: TypedAst.Pattern): TyCon = pattern match {
     case Pattern.Wild(_, _) => TyCon.Wild
@@ -738,9 +738,9 @@ object PatternExhaustiveness {
   }
 
   /**
-    * Adds a TypeConstructor to a list of TypeConstructors, using up items in the list if it requires arguments
+    * Adds a `TyCon` to a list of `TyCon`s, using up items in the list if it requires arguments
     *
-    * e.g. rebuildPatter(Foo(a,b), [1,2,3]) => [Foo(1,2), 3]
+    * e.g. rebuildPattern(Foo(a,b), [1,2,3]) => [Foo(1,2), 3]
     *
     * @param tc  The type constructor to add
     * @param lst The list to add to

--- a/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatternExhaustiveness.scala
@@ -718,14 +718,13 @@ object PatternExhaustiveness {
     case Pattern.Cst(Ast.Constant.Str(_), _, _) => TyCon.Str
     case Pattern.Cst(Ast.Constant.Regex(_), _, _) => throw InternalCompilerException("unexpected regex pattern", pattern.loc)
     case Pattern.Cst(Ast.Constant.Null, _, _) => throw InternalCompilerException("unexpected null pattern", pattern.loc)
-    case Pattern.Tag(Ast.CaseSymUse(sym, _), pat, _, _) => {
-      val (args, numArgs) = pat match {
-        case Pattern.Cst(Ast.Constant.Unit, _, _) => (List.empty[TyCon], 0)
-        case Pattern.Tuple(elms, _, _) => (elms.map(patToCtor), elms.length)
-        case a => (List(patToCtor(a)), 1)
+    case Pattern.Tag(Ast.CaseSymUse(sym, _), pat, _, _) =>
+      val args = pat match {
+        case Pattern.Cst(Ast.Constant.Unit, _, _) => List.empty[TyCon]
+        case Pattern.Tuple(elms, _, _) => elms.map(patToCtor)
+        case a => List(patToCtor(a))
       }
       TyCon.Enum(sym.name, sym.enumSym, args)
-    }
     case Pattern.Tuple(elms, _, _) => TyCon.Tuple(elms.map(patToCtor))
     case Pattern.Record(pats, pat, _, _) =>
       val patsVal = pats.map {


### PR DESCRIPTION
I was looking into #6290 but @jaschdoc scooped me 😅 which is totally fine, since I was mostly trying to learn how it works anyway. I did find a few smaller things that seems worth fixing so opening a pull request here.

(Also if people don't mind me asking - what's a good reference for how that phase works? I am reading through [Warnings for pattern matching](https://www.cambridge.org/core/services/aop-cambridge-core/content/view/3165B75113781E2431E3856972940347/S0956796807006223a.pdf/warnings-for-pattern-matching.pdf) which is referenced in the comments, and it still seems like fairly accurate?