### PR TITLE
chore: write out name of 'Operations' in HTML documentation

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -434,7 +434,7 @@ object HtmlDocumentor {
     sb.append(s"<span class='name'>${esc(eff.sym.name)}</span>")
     sb.append("</code>")
     docSourceLocation(eff.loc)
-    docSubSection("Ops", eff.ops, (o: TypedAst.Op) => docSpec(o.sym.name, o.spec))
+    docSubSection("Operations", eff.ops, (o: TypedAst.Op) => docSpec(o.sym.name, o.spec))
     docDoc(eff.doc)
     sb.append("</div>")
   }


### PR DESCRIPTION
Fixes #6362