### PR TITLE
feat: TryWithHandlerCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -189,6 +189,8 @@ object CompletionProvider {
         // A with context could also be just a type context.
         TypeCompleter.getCompletions(context) ++ WithCompleter.getCompletions(context)
 
+      case SyntacticContext.HandlerBody => TryWithHandlerCompleter.getCompletions(context)
+
       //
       // Fallthrough.
       //

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -141,6 +141,8 @@ object CompletionProvider {
   }
 
   private def getCompletions()(implicit context: CompletionContext, flix: Flix, index: Index, root: TypedAst.Root, delta: DeltaContext): Iterable[Completion] = {
+    println("HERE IS THE CONTEXT!!!!!")
+    println(context.sctx.toString)
     context.sctx match {
       //
       // Expressions.
@@ -187,9 +189,12 @@ object CompletionProvider {
       //
       case SyntacticContext.WithClause =>
         // A with context could also be just a type context.
+        println("WITHCLAUSE")
         TypeCompleter.getCompletions(context) ++ WithCompleter.getCompletions(context)
 
-      case SyntacticContext.HandlerBody => TryWithHandlerCompleter.getCompletions(context)
+      case SyntacticContext.HandlerBody =>
+        println("HANDLERBODY")
+        TryWithHandlerCompleter.getCompletions(context)
 
       //
       // Fallthrough.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -93,6 +93,12 @@ sealed trait Completion {
         documentation = documentation,
         insertTextFormat = insertTextFormat,
         kind = CompletionItemKind.Class)
+    case Completion.TryWithCompletion(name) =>
+      CompletionItem(label = name,
+        sortText = name,
+        textEdit = TextEdit(context.range, name),
+        documentation = None,
+        kind = CompletionItemKind.Method)
     case Completion.ImportNewCompletion(constructor, clazz, aliasSuggestion) =>
       val (label, priority, textEdit) = CompletionUtils.getExecutableCompletionInfo(constructor, clazz, aliasSuggestion, context)
       CompletionItem(label = label,
@@ -347,7 +353,7 @@ object Completion {
   case class WithCompletion(name: String, priority: String, textEdit: TextEdit, documentation: Option[String],
                             insertTextFormat: InsertTextFormat) extends Completion
 
-
+  case class TryWithCompletion(name: String) extends Completion
   /**
     * Represents an importNew completion (java constructors)
     *

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TryWithHandlerCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TryWithHandlerCompleter.scala
@@ -8,8 +8,10 @@ import ca.uwaterloo.flix.language.ast.{SourceLocation, Type, TypeConstructor, Ty
 
 object TryWithHandlerCompleter extends Completer {
   override def getCompletions(context: CompletionContext)(implicit flix: Flix, index: Index, root: TypedAst.Root, delta: DeltaContext): Iterable[TryWithCompletion] = {
+    println("looking")
     stripWord(context) match {
       case Some(word) =>
+        println("found word")
         root.effects.flatMap {
           case (sym, eff) =>
             if (matches(sym, word)) {
@@ -21,7 +23,9 @@ object TryWithHandlerCompleter extends Completer {
             }
           case _ => None
         }
-      case None => Nil
+      case None =>
+        println("no word found")
+        Nil
     }
     Nil
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TryWithHandlerCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TryWithHandlerCompleter.scala
@@ -1,0 +1,38 @@
+package ca.uwaterloo.flix.api.lsp.provider.completion
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.api.lsp.Index
+import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.TryWithCompletion
+import ca.uwaterloo.flix.language.ast.Symbol.{CaseSym, EnumSym, OpSym, EffectSym}
+import ca.uwaterloo.flix.language.ast.{SourceLocation, Type, TypeConstructor, TypedAst}
+
+object TryWithHandlerCompleter extends Completer {
+  override def getCompletions(context: CompletionContext)(implicit flix: Flix, index: Index, root: TypedAst.Root, delta: DeltaContext): Iterable[TryWithCompletion] = {
+    stripWord(context) match {
+      case Some(word) =>
+        root.effects.flatMap {
+          case (sym, eff) =>
+            if (matches(sym, word)) {
+              eff.ops.map(op => println(op.toString)) //print every op associated with an effect that matches
+              None
+            }
+            else {
+              None
+            }
+          case _ => None
+        }
+      case None => Nil
+    }
+    Nil
+  }
+
+  private def stripWord(context: CompletionContext): Option[String] = {
+    val regex = raw"\s*try\s*with\s+(.*)".r
+    context.prefix match {
+      case regex(word) => Some(word)
+      case _           => None
+    }
+  }
+
+  private def matches(sym: EffectSym, word: String): Boolean = sym.name.startsWith(word)
+}

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TryWithHandlerCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TryWithHandlerCompleter.scala
@@ -11,11 +11,15 @@ object TryWithHandlerCompleter extends Completer {
     println("looking")
     stripWord(context) match {
       case Some(word) =>
-        println("found word")
+        print("found word: ")
+        println(word)
         root.effects.flatMap {
           case (sym, eff) =>
+            print("here is sym: ")
+            println(sym.toString)
             if (matches(sym, word)) {
-              eff.ops.map(op => println(op.toString)) //print every op associated with an effect that matches
+              println("FOUND MATCHING EFFECT")
+              eff.ops.foreach(op => println(op.toString)) //print every op associated with an effect that matches
               None
             }
             else {
@@ -31,7 +35,7 @@ object TryWithHandlerCompleter extends Completer {
   }
 
   private def stripWord(context: CompletionContext): Option[String] = {
-    val regex = raw"\s*try\s*with\s+(.*)".r
+    val regex = raw".*\s*with\s+(.*)".r
     context.prefix match {
       case regex(word) => Some(word)
       case _           => None

--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -841,6 +841,8 @@ object Ast {
 
     case object WithClause extends SyntacticContext
 
+    case object HandlerBody extends SyntacticContext
+
     case object Unknown extends SyntacticContext
 
     def join(ctx1: SyntacticContext, ctx2: SyntacticContext): SyntacticContext = (ctx1, ctx2) match {

--- a/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ParsedAst.scala
@@ -1930,7 +1930,7 @@ object ParsedAst {
       * @param eff   the effect to be handled.
       * @param rules the handler rules.
       */
-    case class Handler(eff: Name.QName, rules: Option[Seq[ParsedAst.HandlerRule]]) extends CatchOrHandler
+    case class Handler(eff: Name.QName, rules: Seq[ParsedAst.HandlerRule]) extends CatchOrHandler
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -164,6 +164,8 @@ object Parser {
 
       case "WithClause" => SyntacticContext.WithClause
 
+      case "HandlerBody" => SyntacticContext.HandlerBody
+
       case _ => SyntacticContext.Unknown
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -113,7 +113,9 @@ object Parser {
         // Case 1: We have a named rule application. Determine if we know it.
         syntacticContextOf(name) match {
           case SyntacticContext.Unknown =>
-            // println(name)
+            println("UNKNOWN  CASE:::       ")
+            println(name)
+            println("")
             // Case 1.1: The named rule is not one of the contexts. Continue recursively.
             parseRuleTrace(rest)
           case result =>
@@ -132,6 +134,8 @@ object Parser {
     * Returns [[SyntacticContext.Unknown]] if the context cannot be determined.
     */
   private def syntacticContextOf(name: String): SyntacticContext = {
+    print("NAME MATCH:")
+    println(name)
     name match {
       case "Expression" => SyntacticContext.Expr.OtherExpr
       case "Constraint" => SyntacticContext.Expr.Constraint
@@ -166,7 +170,9 @@ object Parser {
 
       case "HandlerBody" => SyntacticContext.HandlerBody
 
-      case _ => SyntacticContext.Unknown
+      case x =>
+        println(x)
+        SyntacticContext.Unknown
     }
   }
 
@@ -1067,7 +1073,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       }
 
       def HandlerBody: Rule1[ParsedAst.CatchOrHandler] = rule {
-        keyword("with") ~ optWS ~ Names.QualifiedEffect ~ optional(optWS ~ "{" ~ optWS ~ zeroOrMore(HandlerRule).separatedBy(CaseSeparator) ~ optWS ~ "}") ~> ParsedAst.CatchOrHandler.Handler
+        keyword("with") ~ optWS ~ Names.QualifiedEffect ~ optWS ~ "{" ~ optWS ~ zeroOrMore(HandlerRule).separatedBy(CaseSeparator) ~ optWS ~ "}" ~> ParsedAst.CatchOrHandler.Handler
       }
 
       def Body: Rule1[ParsedAst.CatchOrHandler] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1824,7 +1824,7 @@ object Weeder {
     // not handling these rules yet
     case ParsedAst.Expression.Try(sp1, exp0, ParsedAst.CatchOrHandler.Handler(eff, rules0), sp2) =>
       val expVal = visitExp(exp0, senv)
-      val rulesVal = traverse(rules0.getOrElse(Seq.empty)) {
+      val rulesVal = traverse(rules0) {
         case ParsedAst.HandlerRule(op, fparams0, body0) =>
           val fparamsVal = visitFormalParams(fparams0, Presence.Forbidden)
           val bodyVal = visitExp(body0, SyntacticEnv.Handler)


### PR DESCRIPTION
(WIP, do not merge)

for Matt to review

the issue is that print statements are not transpiring with either `try (exp) with` or just `with`, even though the parser now seems to be organized properly