### PR TITLE
feat: Add `LexerError` as a new type of `CompilationMessage`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Token.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Token.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Magnus Madsen
+ * Copyright 2023 Herluf Baggesen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenErrorKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenErrorKind.scala
@@ -15,20 +15,23 @@
  */
 package ca.uwaterloo.flix.language.ast
 
-sealed trait TokenKind
+sealed trait TokenErrorKind
 
-object TokenKind {
+object TokenErrorKind {
 
-  case object LParen extends TokenKind
+  case object UnexpectedChar extends TokenErrorKind
 
-  case object RParen extends TokenKind
+  case object UnterminatedString extends TokenErrorKind
 
-  // TODO: LEXER
+  case object UnterminatedChar extends TokenErrorKind
 
-  case object Eof extends TokenKind
+  case object UnterminatedInfixFunction extends TokenErrorKind
 
-  case class Err(kind: TokenErrorKind) extends TokenKind
+  case object DoubleDottedNumber extends TokenErrorKind
 
+  case object BlockCommentTooDeep extends TokenErrorKind
+
+  case object UnterminatedBlockComment extends TokenErrorKind
+
+  case object UnterminatedBuiltIn extends TokenErrorKind
 }
-
-

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenErrorKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenErrorKind.scala
@@ -19,19 +19,19 @@ sealed trait TokenErrorKind
 
 object TokenErrorKind {
 
+  case object BlockCommentTooDeep extends TokenErrorKind
+
+  case object DoubleDottedNumber extends TokenErrorKind
+
   case object UnexpectedChar extends TokenErrorKind
 
-  case object UnterminatedString extends TokenErrorKind
+  case object UnterminatedBlockComment extends TokenErrorKind
+
+  case object UnterminatedBuiltIn extends TokenErrorKind
 
   case object UnterminatedChar extends TokenErrorKind
 
   case object UnterminatedInfixFunction extends TokenErrorKind
 
-  case object DoubleDottedNumber extends TokenErrorKind
-
-  case object BlockCommentTooDeep extends TokenErrorKind
-
-  case object UnterminatedBlockComment extends TokenErrorKind
-
-  case object UnterminatedBuiltIn extends TokenErrorKind
+  case object UnterminatedString extends TokenErrorKind
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -27,6 +27,27 @@ object TokenKind {
 
   case object Eof extends TokenKind
 
-  case object Err extends TokenKind
+  case class Err(kind: ErrKind) extends TokenKind
 
+}
+
+sealed trait ErrKind
+
+object ErrKind {
+
+  case object UnexpectedChar extends ErrKind
+
+  case object UnterminatedString extends ErrKind
+
+  case object UnterminatedChar extends ErrKind
+
+  case object UnterminatedInfixFunction extends ErrKind
+
+  case object DoubleDottedNumber extends ErrKind
+
+  case object BlockCommentTooDeep extends ErrKind
+
+  case object UnterminatedBlockComment extends ErrKind
+
+  case object UnterminatedBuiltIn extends ErrKind
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
@@ -32,14 +32,14 @@ object LexerError {
    * @param loc the location of char.
    */
   case class UnexpectedChar(s: String, loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Unexpected character '$char'"
+    override def summary: String = s"Unexpected character '$s'."
 
     override def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
          |>> Unexpected character '${red(s)}'.
          |
-         |${code(loc, "found here")}
+         |${code(loc, "Unexpected character.")}
          |
          |""".stripMargin
     }
@@ -53,14 +53,14 @@ object LexerError {
    * @param loc The location of the opening `"`.
    */
   case class UnterminatedString(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Unterminated string"
+    override def summary: String = s"Unterminated string."
 
     override def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
          |>> Unterminated string.
          |
-         |${code(loc, "starts here")}
+         |${code(loc, "String starts here.")}
          |
          |""".stripMargin
     }
@@ -74,14 +74,14 @@ object LexerError {
    * @param loc The location of the opening `'`.
    */
   case class UnterminatedChar(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Unterminated char"
+    override def summary: String = s"Unterminated char."
 
     override def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
          |>> Unterminated char.
          |
-         |${code(loc, "starts here")}
+         |${code(loc, "Char starts here")}
          |
          |""".stripMargin
     }
@@ -95,14 +95,14 @@ object LexerError {
    * @param loc The location of the opening '`'.
    */
   case class UnterminatedInfixFunction(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Unterminated infix function"
+    override def summary: String = s"Unterminated infix function."
 
     override def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
          |>> Unterminated infix function.
          |
-         |${code(loc, "starts here")}
+         |${code(loc, "Infix function starts here.")}
          |
          |""".stripMargin
     }
@@ -116,14 +116,14 @@ object LexerError {
    * @param loc The location of the opening "$".
    */
   case class UnterminatedBuiltin(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Unterminated built-in"
+    override def summary: String = s"Unterminated built-in."
 
     override def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
          |>> Unterminated built-in.
          |
-         |${code(loc, "starts here")}
+         |${code(loc, "Built-in starts here.")}
          |
          |""".stripMargin
     }
@@ -137,14 +137,14 @@ object LexerError {
    * @param loc The location of the opening "\*".
    */
   case class UnterminatedBlockComment(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Unterminated block-comment"
+    override def summary: String = s"Unterminated block-comment."
 
     override def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
          |>> Unterminated block-comment.
          |
-         |${code(loc, "starts here")}
+         |${code(loc, "Block-comment starts here.")}
          |
          |""".stripMargin
     }
@@ -158,21 +158,21 @@ object LexerError {
    * @param loc The location of the opening "\*".
    */
   case class BlockCommentTooDeep(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Block-comment nested too deep"
+    override def summary: String = s"Block-comment nested too deep."
 
     override def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
          |>> Block-comment nested too deep.
          |
-         |${code(loc, "starts here")}
+         |${code(loc, "Block-comment starts here.")}
          |
          |""".stripMargin
     }
 
     override def explain(formatter: Formatter): Option[String] = Some({
       import formatter._
-      s"${underline("Tip:")} Ensure that block-comments are not nested more than 32 levels deep"
+      s"${underline("Tip:")} Ensure that block-comments are not nested more than 32 levels deep."
     })
   }
 
@@ -183,14 +183,14 @@ object LexerError {
    * @param loc The location of the double dotted number literal.
    */
   case class DoubleDottedNumber(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Number has two decimal dots"
+    override def summary: String = s"Number has two decimal dots."
 
     override def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
          |>> Number has two decimal dots.
          |
-         |${code(loc, "number found here")}
+         |${code(loc, "Number found here.")}
          |
          |""".stripMargin
     }

--- a/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
@@ -26,10 +26,10 @@ sealed trait LexerError extends CompilationMessage {
 object LexerError {
 
   /**
-   * An error raised when an unexpected character, such as €, is encountered
+   * An error raised when an unexpected character, such as €, is encountered.
    *
-   * @param s the problematic character. This is a string to handle escaped characters
-   * @param loc  the location of `char`
+   * @param s   the problematic character. This is a string to handle escaped characters.
+   * @param loc the location of char.
    */
   case class UnexpectedChar(s: String, loc: SourceLocation) extends LexerError {
     override def summary: String = s"Unexpected character '$char'"
@@ -48,9 +48,9 @@ object LexerError {
   }
 
   /**
-   * An error raised when an unterminated string is encountered
+   * An error raised when an unterminated string is encountered.
    *
-   * @param loc The location of the opening `"`
+   * @param loc The location of the opening `"`.
    */
   case class UnterminatedString(loc: SourceLocation) extends LexerError {
     override def summary: String = s"Unterminated string"
@@ -69,9 +69,9 @@ object LexerError {
   }
 
   /**
-   * An error raised when an unterminated char is encountered
+   * An error raised when an unterminated char is encountered.
    *
-   * @param loc The location of the opening `'`
+   * @param loc The location of the opening `'`.
    */
   case class UnterminatedChar(loc: SourceLocation) extends LexerError {
     override def summary: String = s"Unterminated char"
@@ -90,9 +90,9 @@ object LexerError {
   }
 
   /**
-   * An error raised when an unterminated infix function is encountered
+   * An error raised when an unterminated infix function is encountered.
    *
-   * @param loc The location of the opening '`'
+   * @param loc The location of the opening '`'.
    */
   case class UnterminatedInfixFunction(loc: SourceLocation) extends LexerError {
     override def summary: String = s"Unterminated infix function"
@@ -111,9 +111,9 @@ object LexerError {
   }
 
   /**
-   * An error raised when an unterminated built-in function is encountered
+   * An error raised when an unterminated built-in function is encountered.
    *
-   * @param loc The location of the opening "$"
+   * @param loc The location of the opening "$".
    */
   case class UnterminatedBuiltin(loc: SourceLocation) extends LexerError {
     override def summary: String = s"Unterminated built-in"
@@ -132,9 +132,9 @@ object LexerError {
   }
 
   /**
-   * An error raised when an unterminated block comment is encountered
+   * An error raised when an unterminated block comment is encountered.
    *
-   * @param loc The location of the opening "\*"
+   * @param loc The location of the opening "\*".
    */
   case class UnterminatedBlockComment(loc: SourceLocation) extends LexerError {
     override def summary: String = s"Unterminated block-comment"
@@ -153,9 +153,9 @@ object LexerError {
   }
 
   /**
-   * An error raised when block-comments are nested too deep
+   * An error raised when block-comments are nested too deep.
    *
-   * @param loc The location of the opening "\*"
+   * @param loc The location of the opening "\*".
    */
   case class BlockCommentTooDeep(loc: SourceLocation) extends LexerError {
     override def summary: String = s"Block-comment nested too deep"
@@ -178,9 +178,9 @@ object LexerError {
 
   /**
    * An error raised when more than one decimal dot is found in a number.
-   * ie. `123.456.78f32`
+   * For instance `123.456.78f32`.
    *
-   * @param loc The location of the double dotted number literal
+   * @param loc The location of the double dotted number literal.
    */
   case class DoubleDottedNumber(loc: SourceLocation) extends LexerError {
     override def summary: String = s"Number has two decimal dots"
@@ -190,7 +190,7 @@ object LexerError {
       s"""${line(kind, source.name)}
          |>> Number has two decimal dots.
          |
-         |${code(loc, "found here")}
+         |${code(loc, "number found here")}
          |
          |""".stripMargin
     }

--- a/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
@@ -24,6 +24,51 @@ sealed trait LexerError extends CompilationMessage {
 }
 
 object LexerError {
+  /**
+   * An error raised when block-comments are nested too deep.
+   *
+   * @param loc The location of the opening "\*".
+   */
+  case class BlockCommentTooDeep(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Block-comment nested too deep."
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Block-comment nested too deep.
+         |
+         |${code(loc, "Block-comment starts here.")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = Some({
+      import formatter._
+      s"${underline("Tip:")} Ensure that block-comments are not nested more than 32 levels deep."
+    })
+  }
+
+  /**
+   * An error raised when more than one decimal dot is found in a number.
+   * For instance `123.456.78f32`.
+   *
+   * @param loc The location of the double dotted number literal.
+   */
+  case class DoubleDottedNumber(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Number has two decimal dots."
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Number has two decimal dots.
+         |
+         |${code(loc, "Number found here.")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
 
   /**
    * An error raised when an unexpected character, such as €, is encountered.
@@ -48,19 +93,40 @@ object LexerError {
   }
 
   /**
-   * An error raised when an unterminated string is encountered.
+   * An error raised when an unterminated block comment is encountered.
    *
-   * @param loc The location of the opening `"`.
+   * @param loc The location of the opening "/ *".
    */
-  case class UnterminatedString(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Unterminated string."
+  case class UnterminatedBlockComment(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Unterminated block-comment."
 
     override def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
-         |>> Unterminated string.
+         |>> Unterminated block-comment.
          |
-         |${code(loc, "String starts here.")}
+         |${code(loc, "Block-comment starts here.")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised when an unterminated built-in function is encountered.
+   *
+   * @param loc The location of the opening "$".
+   */
+  case class UnterminatedBuiltIn(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Unterminated built-in."
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Unterminated built-in.
+         |
+         |${code(loc, "Built-in starts here.")}
          |
          |""".stripMargin
     }
@@ -111,86 +177,19 @@ object LexerError {
   }
 
   /**
-   * An error raised when an unterminated built-in function is encountered.
+   * An error raised when an unterminated string is encountered.
    *
-   * @param loc The location of the opening "$".
+   * @param loc The location of the opening `"`.
    */
-  case class UnterminatedBuiltIn(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Unterminated built-in."
+  case class UnterminatedString(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Unterminated string."
 
     override def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
-         |>> Unterminated built-in.
+         |>> Unterminated string.
          |
-         |${code(loc, "Built-in starts here.")}
-         |
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-   * An error raised when an unterminated block comment is encountered.
-   *
-   * @param loc The location of the opening "/ *".
-   */
-  case class UnterminatedBlockComment(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Unterminated block-comment."
-
-    override def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Unterminated block-comment.
-         |
-         |${code(loc, "Block-comment starts here.")}
-         |
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-   * An error raised when block-comments are nested too deep.
-   *
-   * @param loc The location of the opening "\*".
-   */
-  case class BlockCommentTooDeep(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Block-comment nested too deep."
-
-    override def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Block-comment nested too deep.
-         |
-         |${code(loc, "Block-comment starts here.")}
-         |
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      import formatter._
-      s"${underline("Tip:")} Ensure that block-comments are not nested more than 32 levels deep."
-    })
-  }
-
-  /**
-   * An error raised when more than one decimal dot is found in a number.
-   * For instance `123.456.78f32`.
-   *
-   * @param loc The location of the double dotted number literal.
-   */
-  case class DoubleDottedNumber(loc: SourceLocation) extends LexerError {
-    override def summary: String = s"Number has two decimal dots."
-
-    override def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Number has two decimal dots.
-         |
-         |${code(loc, "Number found here.")}
+         |${code(loc, "String starts here.")}
          |
          |""".stripMargin
     }

--- a/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
@@ -16,5 +16,186 @@
 package ca.uwaterloo.flix.language.errors
 
 import ca.uwaterloo.flix.language.CompilationMessage
+import ca.uwaterloo.flix.language.ast.SourceLocation
+import ca.uwaterloo.flix.util.Formatter
 
-sealed trait LexerError extends CompilationMessage // TODO: LEXER
+sealed trait LexerError extends CompilationMessage {
+  val kind = "Lexer Error"
+}
+
+object LexerError {
+
+  /**
+   * An error raised when an unexpected character, such as €, is encountered
+   *
+   * @param s the problematic character. This is a string to handle escaped characters
+   * @param loc  the location of `char`
+   */
+  case class UnexpectedChar(s: String, loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Unexpected character '$char'"
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Unexpected character '${red(s)}'.
+         |
+         |${code(loc, "found here")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised when an unterminated string is encountered
+   *
+   * @param loc The location of the opening `"`
+   */
+  case class UnterminatedString(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Unterminated string"
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Unterminated string.
+         |
+         |${code(loc, "starts here")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised when an unterminated char is encountered
+   *
+   * @param loc The location of the opening `'`
+   */
+  case class UnterminatedChar(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Unterminated char"
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Unterminated char.
+         |
+         |${code(loc, "starts here")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised when an unterminated infix function is encountered
+   *
+   * @param loc The location of the opening '`'
+   */
+  case class UnterminatedInfixFunction(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Unterminated infix function"
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Unterminated infix function.
+         |
+         |${code(loc, "starts here")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised when an unterminated built-in function is encountered
+   *
+   * @param loc The location of the opening "$"
+   */
+  case class UnterminatedBuiltin(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Unterminated built-in"
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Unterminated built-in.
+         |
+         |${code(loc, "starts here")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised when an unterminated block comment is encountered
+   *
+   * @param loc The location of the opening "\*"
+   */
+  case class UnterminatedBlockComment(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Unterminated block-comment"
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Unterminated block-comment.
+         |
+         |${code(loc, "starts here")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised when block-comments are nested too deep
+   *
+   * @param loc The location of the opening "\*"
+   */
+  case class BlockCommentTooDeep(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Block-comment nested too deep"
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Block-comment nested too deep.
+         |
+         |${code(loc, "starts here")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = Some({
+      import formatter._
+      s"${underline("Tip:")} Ensure that block-comments are not nested more than 32 levels deep"
+    })
+  }
+
+  /**
+   * An error raised when more than one decimal dot is found in a number.
+   * ie. `123.456.78f32`
+   *
+   * @param loc The location of the double dotted number literal
+   */
+  case class DoubleDottedNumber(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Number has two decimal dots"
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Number has two decimal dots.
+         |
+         |${code(loc, "found here")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+}
+

--- a/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Magnus Madsen
+ * Copyright 2023 Herluf Baggesen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
@@ -28,7 +28,7 @@ object LexerError {
   /**
    * An error raised when an unexpected character, such as €, is encountered.
    *
-   * @param s   the problematic character. This is a string to handle escaped characters.
+   * @param s   the problematic character.
    * @param loc the location of char.
    */
   case class UnexpectedChar(s: String, loc: SourceLocation) extends LexerError {
@@ -115,7 +115,7 @@ object LexerError {
    *
    * @param loc The location of the opening "$".
    */
-  case class UnterminatedBuiltin(loc: SourceLocation) extends LexerError {
+  case class UnterminatedBuiltIn(loc: SourceLocation) extends LexerError {
     override def summary: String = s"Unterminated built-in."
 
     override def message(formatter: Formatter): String = {
@@ -134,7 +134,7 @@ object LexerError {
   /**
    * An error raised when an unterminated block comment is encountered.
    *
-   * @param loc The location of the opening "\*".
+   * @param loc The location of the opening "/ *".
    */
   case class UnterminatedBlockComment(loc: SourceLocation) extends LexerError {
     override def summary: String = s"Unterminated block-comment."

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -17,7 +17,8 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.CompilationMessage
-import ca.uwaterloo.flix.language.ast.{Ast, ReadAst, Token}
+import ca.uwaterloo.flix.language.ast.{Ast, ErrKind, ReadAst, SourceKind, SourceLocation, Token, TokenKind}
+import ca.uwaterloo.flix.language.errors.LexerError
 import ca.uwaterloo.flix.util.{ParOps, Validation}
 import ca.uwaterloo.flix.util.Validation._
 
@@ -25,7 +26,11 @@ import scala.collection.mutable
 
 object Lexer {
 
-  def run(root: ReadAst.Root)(implicit flix: Flix): Validation[Map[Ast.Source, Array[Token]], CompilationMessage] = {
+  // TODO: A single source can have more than one error that we would like to report.
+  // For instance there might be an unexpected char multiple spots in the source file.
+  // Therefore run needs to return something like `Validation[Map[Ast.Source, Array[Token]], Array[CompilationMessage]]`
+  // but that seems to clash with the rest of the pipeline. How do we resolve this?
+  def run(root: ReadAst.Root)(implicit flix: Flix): Validation[Map[Ast.Source, Array[Token]], Array[CompilationMessage]] = {
     if (!flix.options.xparser) {
       // New lexer and parser disabled. Return immediately.
       return Map.empty[Ast.Source, Array[Token]].toSuccess
@@ -44,16 +49,16 @@ object Lexer {
     }
   }
 
-  private def lex(s: Ast.Source): Validation[Array[Token], CompilationMessage] = {
+  private def lex(src: Ast.Source): Validation[Array[Token], Array[CompilationMessage]] = {
+    implicit val s: State = new State(src)
     // TODO: LEXER
-    //    implicit val s = new State()
-    //    while (!isAtEnd()) {
-    //      s.start = s.current
-    //      scanToken()
-    //    }
-    //    s.tokens += Token(TokenKind.EofToken, "<eof>")
 
-    Array.empty[Token].toSuccess
+    val hasErrors = s.tokens.exists(t => t.kind.isInstanceOf[TokenKind.Err])
+    if (hasErrors) {
+      s.tokens.flatMap(tokenErrToCompilationMessage).toArray.toFailure
+    } else {
+      s.tokens.toArray.toSuccess
+    }
   }
 
   private def advance()(implicit s: State): Char = ???
@@ -64,11 +69,40 @@ object Lexer {
 
   private def addToken(token: Token)(implicit s: State): Unit = ???
 
-  private class State {
+  // Converts a `Token` of kind `TokenKind.Err` into a CompilationMessage.
+  // NOTE: Why is this necessary?
+  // We would like the lexer to capture as many errors as possible before terminating.
+  // To do this, the lexer will produce error tokens instead of halting,
+  // each holding a kind of the simple type `ErrKind`.
+  // So we need this mapping to produce a `CompilationMessage`, which is a case class, if there were any errors.
+  private def tokenErrToCompilationMessage(t: Token)(implicit s: State): Option[CompilationMessage] = {
+    t.kind match {
+      case TokenKind.Err(e) => e match {
+        case ErrKind.UnexpectedChar | ErrKind.DoubleDottedNumber => Some(
+          LexerError.UnexpectedChar(
+            t.text,
+            SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + t.text.length)
+          )
+        )
+        case ErrKind.UnterminatedString
+             | ErrKind.UnterminatedChar
+             | ErrKind.UnterminatedInfixFunction
+             | ErrKind.UnterminatedBuiltIn
+             | ErrKind.UnterminatedBlockComment
+             | ErrKind.BlockCommentTooDeep => Some(
+          LexerError.UnterminatedString(
+            SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + 1)
+          )
+        )
+      }
+      case _ => None
+    }
+  }
+
+  private class State(val src: Ast.Source) {
     var start: Int = 0
     var current: Int = 0
     var line: Int = 0
     var tokens: mutable.ListBuffer[Token] = mutable.ListBuffer.empty
   }
-
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -78,20 +78,45 @@ object Lexer {
   private def tokenErrToCompilationMessage(t: Token)(implicit s: State): Option[CompilationMessage] = {
     t.kind match {
       case TokenKind.Err(e) => e match {
-        case ErrKind.UnexpectedChar | ErrKind.DoubleDottedNumber => Some(
+        case ErrKind.UnexpectedChar => Some(
           LexerError.UnexpectedChar(
             t.text,
             SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + t.text.length)
           )
         )
-        case ErrKind.UnterminatedString
-             | ErrKind.UnterminatedChar
-             | ErrKind.UnterminatedInfixFunction
-             | ErrKind.UnterminatedBuiltIn
-             | ErrKind.UnterminatedBlockComment
-             | ErrKind.BlockCommentTooDeep => Some(
+        case ErrKind.DoubleDottedNumber => Some(
+          LexerError.DoubleDottedNumber(
+            SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + t.text.length)
+          )
+        )
+        case ErrKind.UnterminatedString => Some(
           LexerError.UnterminatedString(
             SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + 1)
+          )
+        )
+        case ErrKind.UnterminatedChar => Some(
+          LexerError.UnterminatedChar(
+            SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + 1)
+          )
+        )
+        case ErrKind.UnterminatedInfixFunction => Some(
+          LexerError.UnterminatedInfixFunction(
+            SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + 1)
+          )
+        )
+        case ErrKind.UnterminatedBuiltIn => Some(
+          LexerError.UnterminatedBuiltin(
+            SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + 1)
+          )
+        )
+        case ErrKind.UnterminatedBlockComment => Some(
+          LexerError.UnterminatedBlockComment(
+            SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + 1)
+          )
+        )
+        case ErrKind.BlockCommentTooDeep => Some(
+          LexerError.BlockCommentTooDeep(
+            SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + 2)
           )
         )
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -79,14 +79,14 @@ object Lexer {
 
     val loc = SourceLocation(None, s.src, SourceKind.Real, l, c, l, c + o)
     e match {
-      case TokenErrorKind.UnexpectedChar => LexerError.UnexpectedChar(t, loc)
+      case TokenErrorKind.BlockCommentTooDeep => LexerError.BlockCommentTooDeep(loc)
       case TokenErrorKind.DoubleDottedNumber => LexerError.DoubleDottedNumber(loc)
-      case TokenErrorKind.UnterminatedString => LexerError.UnterminatedString(loc)
+      case TokenErrorKind.UnexpectedChar => LexerError.UnexpectedChar(t, loc)
+      case TokenErrorKind.UnterminatedBlockComment => LexerError.UnterminatedBlockComment(loc)
+      case TokenErrorKind.UnterminatedBuiltIn => LexerError.UnterminatedBuiltIn(loc)
       case TokenErrorKind.UnterminatedChar => LexerError.UnterminatedChar(loc)
       case TokenErrorKind.UnterminatedInfixFunction => LexerError.UnterminatedInfixFunction(loc)
-      case TokenErrorKind.UnterminatedBuiltIn => LexerError.UnterminatedBuiltIn(loc)
-      case TokenErrorKind.UnterminatedBlockComment => LexerError.UnterminatedBlockComment(loc)
-      case TokenErrorKind.BlockCommentTooDeep => LexerError.BlockCommentTooDeep(loc)
+      case TokenErrorKind.UnterminatedString => LexerError.UnterminatedString(loc)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Magnus Madsen
+ * Copyright 2023 Herluf Baggesen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.CompilationMessage
-import ca.uwaterloo.flix.language.ast.{Ast, ErrKind, ReadAst, SourceKind, SourceLocation, Token, TokenKind}
+import ca.uwaterloo.flix.language.ast.{Ast, TokenErrorKind, ReadAst, SourceKind, SourceLocation, Token, TokenKind}
 import ca.uwaterloo.flix.language.errors.LexerError
 import ca.uwaterloo.flix.util.{ParOps, Validation}
 import ca.uwaterloo.flix.util.Validation._
@@ -78,43 +78,43 @@ object Lexer {
   private def tokenErrToCompilationMessage(t: Token)(implicit s: State): Option[CompilationMessage] = {
     t.kind match {
       case TokenKind.Err(e) => e match {
-        case ErrKind.UnexpectedChar => Some(
+        case TokenErrorKind.UnexpectedChar => Some(
           LexerError.UnexpectedChar(
             t.text,
             SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + t.text.length)
           )
         )
-        case ErrKind.DoubleDottedNumber => Some(
+        case TokenErrorKind.DoubleDottedNumber => Some(
           LexerError.DoubleDottedNumber(
             SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + t.text.length)
           )
         )
-        case ErrKind.UnterminatedString => Some(
+        case TokenErrorKind.UnterminatedString => Some(
           LexerError.UnterminatedString(
             SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + 1)
           )
         )
-        case ErrKind.UnterminatedChar => Some(
+        case TokenErrorKind.UnterminatedChar => Some(
           LexerError.UnterminatedChar(
             SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + 1)
           )
         )
-        case ErrKind.UnterminatedInfixFunction => Some(
+        case TokenErrorKind.UnterminatedInfixFunction => Some(
           LexerError.UnterminatedInfixFunction(
             SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + 1)
           )
         )
-        case ErrKind.UnterminatedBuiltIn => Some(
+        case TokenErrorKind.UnterminatedBuiltIn => Some(
           LexerError.UnterminatedBuiltin(
             SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + 1)
           )
         )
-        case ErrKind.UnterminatedBlockComment => Some(
+        case TokenErrorKind.UnterminatedBlockComment => Some(
           LexerError.UnterminatedBlockComment(
             SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + 1)
           )
         )
-        case ErrKind.BlockCommentTooDeep => Some(
+        case TokenErrorKind.BlockCommentTooDeep => Some(
           LexerError.BlockCommentTooDeep(
             SourceLocation(None, s.src, SourceKind.Real, t.line, t.col, t.line, t.col + 2)
           )


### PR DESCRIPTION
Write a `LexerError` type for compilation messages when lexing fails. 