### PR TITLE
feat: gen Frames FramesCons and FramesNil

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -1424,10 +1424,16 @@ object BackendObjType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
       val cm = mkInterface(this.jvmName)
 
+      cm.mkInterfaceMethod(PushMethod)
+      cm.mkInterfaceMethod(ReverseMethod)
       cm.mkInterfaceMethod(ReverseOntoMethod)
 
       cm.closeClassMaker()
     }
+
+    def PushMethod: InterfaceMethod = InterfaceMethod(this.jvmName, "push", mkDescriptor(Frame.toTpe)(Frames.toTpe))
+
+    def ReverseMethod: InterfaceMethod = InterfaceMethod(this.jvmName, "reverse", mkDescriptor()(Frames.toTpe))
 
     def ReverseOntoMethod: InterfaceMethod = InterfaceMethod(this.jvmName, "reverseOnto", mkDescriptor(Frames.toTpe)(Frames.toTpe))
   }
@@ -1440,6 +1446,8 @@ object BackendObjType {
       cm.mkField(HeadField)
       cm.mkField(TailField)
       cm.mkConstructor(Constructor)
+      cm.mkMethod(PushMethod)
+      cm.mkMethod(ReverseMethod)
       cm.mkMethod(ReverseOntoMethod)
 
       cm.closeClassMaker()
@@ -1451,6 +1459,22 @@ object BackendObjType {
 
     def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, IsPublic, Nil, Some(
       thisLoad() ~ INVOKESPECIAL(JavaObject.Constructor) ~ RETURN()
+    ))
+
+    def PushMethod: InstanceMethod = Frames.PushMethod.implementation(this.jvmName, IsFinal, Some(
+      withName(1, Frame.toTpe)(frame =>
+        NEW(FramesCons.jvmName) ~ DUP() ~ INVOKESPECIAL(FramesCons.Constructor) ~
+        DUP() ~ frame.load() ~ PUTFIELD(FramesCons.HeadField) ~
+        DUP() ~ thisLoad() ~ PUTFIELD(FramesCons.TailField) ~
+        xReturn(FramesCons.toTpe)
+      )
+    ))
+
+    def ReverseMethod: InstanceMethod = Frames.ReverseMethod.implementation(this.jvmName, IsFinal, Some(
+      thisLoad() ~
+      NEW(FramesNil.jvmName) ~ DUP() ~ INVOKESPECIAL(FramesNil.Constructor) ~
+      INVOKEVIRTUAL(ReverseOntoMethod) ~
+      xReturn(Frames.toTpe)
     ))
 
     def ReverseOntoMethod: InstanceMethod = Frames.ReverseOntoMethod.implementation(this.jvmName, IsFinal, Some(
@@ -1471,6 +1495,8 @@ object BackendObjType {
       val cm = mkClass(this.jvmName, IsFinal, interfaces = List(Frames.jvmName))
 
       cm.mkConstructor(Constructor)
+      cm.mkMethod(PushMethod)
+      cm.mkMethod(ReverseMethod)
       cm.mkMethod(ReverseOntoMethod)
 
       cm.closeClassMaker()
@@ -1478,6 +1504,22 @@ object BackendObjType {
 
     def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, IsPublic, Nil, Some(
       thisLoad() ~ INVOKESPECIAL(JavaObject.Constructor) ~ RETURN()
+    ))
+
+    def PushMethod: InstanceMethod = Frames.PushMethod.implementation(this.jvmName, IsFinal, Some(
+      withName(1, Frame.toTpe)(frame =>
+        NEW(FramesCons.jvmName) ~ DUP() ~ INVOKESPECIAL(FramesCons.Constructor) ~
+        DUP() ~ frame.load() ~ PUTFIELD(FramesCons.HeadField) ~
+        DUP() ~ thisLoad() ~ PUTFIELD(FramesCons.TailField) ~
+        xReturn(FramesCons.toTpe)
+      )
+    ))
+
+    def ReverseMethod: InstanceMethod = Frames.ReverseMethod.implementation(this.jvmName, IsFinal, Some(
+      thisLoad() ~
+      NEW(FramesNil.jvmName) ~ DUP() ~ INVOKESPECIAL(FramesNil.Constructor) ~
+      INVOKEVIRTUAL(ReverseOntoMethod) ~
+      xReturn(Frames.toTpe)
     ))
 
     def ReverseOntoMethod: InstanceMethod = Frames.ReverseOntoMethod.implementation(this.jvmName, IsFinal, Some(

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -73,6 +73,7 @@ sealed trait BackendObjType {
     case BackendObjType.Value => JvmName(DevFlixRuntime, "Value")
     case BackendObjType.Frame => JvmName(DevFlixRuntime, "Frame")
     case BackendObjType.Thunk => JvmName(DevFlixRuntime, "Thunk")
+    case BackendObjType.Frames => JvmName(DevFlixRuntime, "Frames")
   }
 
   /**
@@ -1414,5 +1415,18 @@ object BackendObjType {
     }
 
     def ApplyMethod: InterfaceMethod = InterfaceMethod(this.jvmName, "apply", mkDescriptor()(Result.toTpe))
+  }
+
+  case object Frames extends BackendObjType {
+
+    def genByteCode()(implicit flix: Flix): Array[Byte] = {
+      val cm = mkInterface(this.jvmName)
+
+      cm.mkInterfaceMethod(ReverseOntoMethod)
+
+      cm.closeClassMaker()
+    }
+
+    def ReverseOntoMethod: InterfaceMethod = InterfaceMethod(this.jvmName, "reverseOnto", mkDescriptor(Frames.toTpe)(Frames.toTpe))
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeInstructions.scala
@@ -102,7 +102,7 @@ object BytecodeInstructions {
   }
 
   // TODO: do this for methods
-  class Variable(tpe: BackendType, index: Int) {
+  class Variable(val tpe: BackendType, index: Int) {
     def load(): InstructionSet = xLoad(tpe, index)
 
     def store(): InstructionSet = xStore(tpe, index)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -120,6 +120,8 @@ object JvmBackend {
       val frameInterface = Map(BackendObjType.Frame.jvmName -> JvmClass(BackendObjType.Frame.jvmName, BackendObjType.Frame.genByteCode()))
       val thunkInterface = Map(BackendObjType.Thunk.jvmName -> JvmClass(BackendObjType.Thunk.jvmName, BackendObjType.Thunk.genByteCode()))
       val framesInterface = Map(BackendObjType.Frames.jvmName -> JvmClass(BackendObjType.Frames.jvmName, BackendObjType.Frames.genByteCode()))
+      val framesConsClass = Map(BackendObjType.FramesCons.jvmName -> JvmClass(BackendObjType.FramesCons.jvmName, BackendObjType.FramesCons.genByteCode()))
+      val framesNilClass = Map(BackendObjType.FramesNil.jvmName -> JvmClass(BackendObjType.FramesNil.jvmName, BackendObjType.FramesNil.genByteCode()))
 
       // Collect all the classes and interfaces together.
       List(
@@ -151,7 +153,9 @@ object JvmBackend {
         valueClass,
         frameInterface,
         thunkInterface,
-        framesInterface
+        framesInterface,
+        framesConsClass,
+        framesNilClass
       ).reduce(_ ++ _)
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -119,6 +119,7 @@ object JvmBackend {
       val valueClass = Map(BackendObjType.Value.jvmName -> JvmClass(BackendObjType.Value.jvmName, BackendObjType.Value.genByteCode()))
       val frameInterface = Map(BackendObjType.Frame.jvmName -> JvmClass(BackendObjType.Frame.jvmName, BackendObjType.Frame.genByteCode()))
       val thunkInterface = Map(BackendObjType.Thunk.jvmName -> JvmClass(BackendObjType.Thunk.jvmName, BackendObjType.Thunk.genByteCode()))
+      val framesInterface = Map(BackendObjType.Frames.jvmName -> JvmClass(BackendObjType.Frames.jvmName, BackendObjType.Frames.genByteCode()))
 
       // Collect all the classes and interfaces together.
       List(
@@ -149,7 +150,8 @@ object JvmBackend {
         resultInterface,
         valueClass,
         frameInterface,
-        thunkInterface
+        thunkInterface,
+        framesInterface
       ).reduce(_ ++ _)
     }
 


### PR DESCRIPTION
From the example code:
```
// TODO: Implement other reverse function.
Frames reverse() { ... }
```
I don't know what the TODO means and `reverse` is actually unused since `Handler` uses `reverseOnto` directly.

Frames:
```java
package dev.flix.runtime;

public interface Frames {
    Frames push(Frame var1);

    Frames reverse();

    Frames reverseOnto(Frames var1);
}
```

FramesCons:
```java
package dev.flix.runtime;

public final class FramesCons implements Frames {
    public final Frame head;
    public final Frames tail;

    public FramesCons() {
    }

    public final Frames push(Frame var1) {
        FramesCons var10000 = new FramesCons();
        var10000.head = var1;
        var10000.tail = this;
        return var10000;
    }

    public final Frames reverse() {
        return this.reverseOnto(new FramesNil());
    }

    public final Frames reverseOnto(Frames var1) {
        Frames var10000 = this.tail;
        FramesCons var10001 = new FramesCons();
        var10001.head = this.head;
        var10001.tail = var1;
        return var10000.reverseOnto(var10001);
    }
}
```

FramesNil:
```java
package dev.flix.runtime;

public final class FramesNil implements Frames {
    public FramesNil() {
    }

    public final Frames push(Frame var1) {
        FramesCons var10000 = new FramesCons();
        var10000.head = var1;
        var10000.tail = this;
        return var10000;
    }

    public final Frames reverse() {
        return this.reverseOnto(new FramesNil());
    }

    public final Frames reverseOnto(Frames var1) {
        return var1;
    }
}
```