### PR TITLE
refactor: add `MonoType.ArrayMultiDim`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
@@ -60,7 +60,7 @@ object MonoType {
   /// Compound Types.
   ///
 
-  case class ArrayMultiDim(tpe: MonoType, dim: Int) extends MonoType
+  case class Array(tpe: MonoType, dim: Int) extends MonoType
 
   case class Lazy(tpe: MonoType) extends MonoType
 

--- a/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
@@ -60,8 +60,6 @@ object MonoType {
   /// Compound Types.
   ///
 
-  case class Array(tpe: MonoType) extends MonoType
-
   case class ArrayMultiDim(tpe: MonoType, dim: Int) extends MonoType
 
   case class Lazy(tpe: MonoType) extends MonoType

--- a/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
@@ -62,6 +62,8 @@ object MonoType {
 
   case class Array(tpe: MonoType) extends MonoType
 
+  case class ArrayMultiDim(tpe: MonoType, dim: Int) extends MonoType
+
   case class Lazy(tpe: MonoType) extends MonoType
 
   case class Ref(tpe: MonoType) extends MonoType

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypePrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypePrinter.scala
@@ -39,7 +39,7 @@ object MonoTypePrinter {
     case MonoType.Str => Type.Str
     case MonoType.Regex => Type.Regex
     case MonoType.Region => Type.Region
-    case MonoType.Array(tpe) => Type.Array(print(tpe))
+    case MonoType.ArrayMultiDim(tpe, _) => Type.Array(print(tpe))
     case MonoType.Lazy(tpe) => Type.Lazy(print(tpe))
     case MonoType.Ref(tpe) => Type.Ref(print(tpe))
     case MonoType.Tuple(elms) => Type.Tuple(elms.map(print))

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypePrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypePrinter.scala
@@ -39,7 +39,7 @@ object MonoTypePrinter {
     case MonoType.Str => Type.Str
     case MonoType.Regex => Type.Regex
     case MonoType.Region => Type.Region
-    case MonoType.ArrayMultiDim(tpe, _) => Type.Array(print(tpe))
+    case MonoType.Array(tpe, _) => Type.Array(print(tpe))
     case MonoType.Lazy(tpe) => Type.Lazy(print(tpe))
     case MonoType.Ref(tpe) => Type.Ref(print(tpe))
     case MonoType.Tuple(elms) => Type.Tuple(elms.map(print))

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -287,13 +287,11 @@ object Simplifier {
             case TypeConstructor.Native(clazz) => MonoType.Native(clazz)
 
             case TypeConstructor.Array => args.head match {
-              case t@MonoType.Array(_) => MonoType.ArrayMultiDim(t, 2)
               case t@MonoType.ArrayMultiDim(_, dim) => MonoType.ArrayMultiDim(t, dim + 1)
               case t => MonoType.ArrayMultiDim(t, 1)
             }
 
             case TypeConstructor.Vector => args.head match {
-              case t@MonoType.Array(_) => MonoType.ArrayMultiDim(t, 2)
               case t@MonoType.ArrayMultiDim(_, dim) => MonoType.ArrayMultiDim(t, dim + 1)
               case t => MonoType.ArrayMultiDim(t, 1)
             }

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -287,12 +287,12 @@ object Simplifier {
             case TypeConstructor.Native(clazz) => MonoType.Native(clazz)
 
             case TypeConstructor.Array => args.head match {
-              case t@MonoType.ArrayMultiDim(_, dim) => MonoType.ArrayMultiDim(t, dim + 1)
+              case MonoType.ArrayMultiDim(_, dim) => MonoType.ArrayMultiDim(args.head, dim + 1)
               case t => MonoType.ArrayMultiDim(t, 1)
             }
 
             case TypeConstructor.Vector => args.head match {
-              case t@MonoType.ArrayMultiDim(_, dim) => MonoType.ArrayMultiDim(t, dim + 1)
+              case MonoType.ArrayMultiDim(_, dim) => MonoType.ArrayMultiDim(args.head, dim + 1)
               case t => MonoType.ArrayMultiDim(t, 1)
             }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -286,9 +286,17 @@ object Simplifier {
 
             case TypeConstructor.Native(clazz) => MonoType.Native(clazz)
 
-            case TypeConstructor.Array => MonoType.Array(args.head)
+            case TypeConstructor.Array => args.head match {
+              case t@MonoType.Array(_) => MonoType.ArrayMultiDim(t, 2)
+              case t@MonoType.ArrayMultiDim(_, dim) => MonoType.ArrayMultiDim(t, dim + 1)
+              case t => MonoType.ArrayMultiDim(t, 1)
+            }
 
-            case TypeConstructor.Vector => MonoType.Array(args.head)
+            case TypeConstructor.Vector => args.head match {
+              case t@MonoType.Array(_) => MonoType.ArrayMultiDim(t, 2)
+              case t@MonoType.ArrayMultiDim(_, dim) => MonoType.ArrayMultiDim(t, dim + 1)
+              case t => MonoType.ArrayMultiDim(t, 1)
+            }
 
             case TypeConstructor.Ref => MonoType.Ref(args.head)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -287,13 +287,13 @@ object Simplifier {
             case TypeConstructor.Native(clazz) => MonoType.Native(clazz)
 
             case TypeConstructor.Array => args.head match {
-              case MonoType.ArrayMultiDim(_, dim) => MonoType.ArrayMultiDim(args.head, dim + 1)
-              case t => MonoType.ArrayMultiDim(t, 1)
+              case MonoType.Array(_, dim) => MonoType.Array(args.head, dim + 1)
+              case t => MonoType.Array(t, 1)
             }
 
             case TypeConstructor.Vector => args.head match {
-              case MonoType.ArrayMultiDim(_, dim) => MonoType.ArrayMultiDim(args.head, dim + 1)
-              case t => MonoType.ArrayMultiDim(t, 1)
+              case MonoType.Array(_, dim) => MonoType.Array(args.head, dim + 1)
+              case t => MonoType.Array(t, 1)
             }
 
             case TypeConstructor.Ref => MonoType.Ref(args.head)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -129,7 +129,7 @@ object BackendType {
     case MonoType.Int32 => Int32
     case MonoType.Int64 => Int64
     case MonoType.Unit | MonoType.BigDecimal | MonoType.BigInt | MonoType.Str | MonoType.Regex |
-         MonoType.Array(_) | MonoType.Lazy(_) | MonoType.Ref(_) | MonoType.Tuple(_) |
+         MonoType.ArrayMultiDim(_, _) | MonoType.Lazy(_) | MonoType.Ref(_) | MonoType.Tuple(_) |
          MonoType.Enum(_) | MonoType.Arrow(_, _) | MonoType.RecordEmpty | MonoType.RecordExtend(_, _, _) |
          MonoType.SchemaEmpty | MonoType.SchemaExtend(_, _, _) | MonoType.Native(_) |
          MonoType.Region => BackendObjType.JavaObject.toTpe

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -129,7 +129,7 @@ object BackendType {
     case MonoType.Int32 => Int32
     case MonoType.Int64 => Int64
     case MonoType.Unit | MonoType.BigDecimal | MonoType.BigInt | MonoType.Str | MonoType.Regex |
-         MonoType.ArrayMultiDim(_, _) | MonoType.Lazy(_) | MonoType.Ref(_) | MonoType.Tuple(_) |
+         MonoType.Array(_, _) | MonoType.Lazy(_) | MonoType.Ref(_) | MonoType.Tuple(_) |
          MonoType.Enum(_) | MonoType.Arrow(_, _) | MonoType.RecordEmpty | MonoType.RecordExtend(_, _, _) |
          MonoType.SchemaEmpty | MonoType.SchemaExtend(_, _, _) | MonoType.Native(_) |
          MonoType.Region => BackendObjType.JavaObject.toTpe

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -97,7 +97,7 @@ object GenAnonymousClasses {
     * Hacked to half-work for array types. In the new backend we should handle all types, including multidim arrays.
     */
   def getDescriptorHacked(tpe: MonoType)(implicit root: Root, flix: Flix): String = tpe match {
-    case MonoType.Array(t) => s"[${JvmOps.getJvmType(t).toDescriptor}"
+    case MonoType.ArrayMultiDim(t, _) => s"[${JvmOps.getJvmType(t).toDescriptor}"
     case MonoType.Unit => JvmType.Void.toDescriptor
     case _ => JvmOps.getJvmType(tpe).toDescriptor
   }
@@ -153,13 +153,13 @@ object GenAnonymousClasses {
         backendContinuationType.UnwindMethod.name, AsmOps.getMethodDescriptor(Nil, JvmOps.getErasedJvmType(tpe)), false)
 
       tpe match {
-        case MonoType.Array(_) => methodVisitor.visitTypeInsn(CHECKCAST, getDescriptorHacked(tpe))
+        case MonoType.ArrayMultiDim(_, _) => methodVisitor.visitTypeInsn(CHECKCAST, getDescriptorHacked(tpe))
         case _ => AsmOps.castIfNotPrim(methodVisitor, JvmOps.getJvmType(tpe))
       }
 
       val returnInstruction = tpe match {
         case MonoType.Unit => RETURN
-        case MonoType.Array(_) => ARETURN
+        case MonoType.ArrayMultiDim(_, _) => ARETURN
         case _ => AsmOps.getReturnInstruction(JvmOps.getJvmType(tpe))
       }
       methodVisitor.visitInsn(returnInstruction)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -97,7 +97,7 @@ object GenAnonymousClasses {
     * Hacked to half-work for array types. In the new backend we should handle all types, including multidim arrays.
     */
   def getDescriptorHacked(tpe: MonoType)(implicit root: Root, flix: Flix): String = tpe match {
-    case MonoType.ArrayMultiDim(t, _) => s"[${JvmOps.getJvmType(t).toDescriptor}"
+    case MonoType.Array(t, _) => s"[${JvmOps.getJvmType(t).toDescriptor}"
     case MonoType.Unit => JvmType.Void.toDescriptor
     case _ => JvmOps.getJvmType(tpe).toDescriptor
   }
@@ -153,13 +153,13 @@ object GenAnonymousClasses {
         backendContinuationType.UnwindMethod.name, AsmOps.getMethodDescriptor(Nil, JvmOps.getErasedJvmType(tpe)), false)
 
       tpe match {
-        case MonoType.ArrayMultiDim(_, _) => methodVisitor.visitTypeInsn(CHECKCAST, getDescriptorHacked(tpe))
+        case MonoType.Array(_, _) => methodVisitor.visitTypeInsn(CHECKCAST, getDescriptorHacked(tpe))
         case _ => AsmOps.castIfNotPrim(methodVisitor, JvmOps.getJvmType(tpe))
       }
 
       val returnInstruction = tpe match {
         case MonoType.Unit => RETURN
-        case MonoType.ArrayMultiDim(_, _) => ARETURN
+        case MonoType.Array(_, _) => ARETURN
         case _ => AsmOps.getReturnInstruction(JvmOps.getJvmType(tpe))
       }
       methodVisitor.visitInsn(returnInstruction)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -710,7 +710,7 @@ object GenExpression {
         // We push the 'length' of the array on top of stack
         compileInt(exps.length)
         // We get the inner type of the array
-        val jvmType = JvmOps.getJvmType(tpe.asInstanceOf[MonoType.ArrayMultiDim].tpe)
+        val jvmType = JvmOps.getJvmType(tpe.asInstanceOf[MonoType.Array].tpe)
         // Instantiating a new array of type jvmType
         jvmType match {
           case ref: JvmType.Reference => // Happens if the inner type is an object type
@@ -734,7 +734,7 @@ object GenExpression {
       case AtomicOp.ArrayNew =>
         val List(exp1, exp2) = exps
         // We get the inner type of the array
-        val elmType = tpe.asInstanceOf[MonoType.ArrayMultiDim].tpe
+        val elmType = tpe.asInstanceOf[MonoType.Array].tpe
         // We get the JVM Type of elmType.
         val jvmType = JvmOps.getJvmType(elmType)
         // Evaluating the value of the 'default element'
@@ -810,7 +810,7 @@ object GenExpression {
         addSourceLine(mv, loc)
 
         // We get the inner type of the array
-        val jvmType = JvmOps.getErasedJvmType(exp.tpe.asInstanceOf[MonoType.ArrayMultiDim].tpe)
+        val jvmType = JvmOps.getErasedJvmType(exp.tpe.asInstanceOf[MonoType.Array].tpe)
         // Evaluating the 'base'
         compileExpr(exp)
         // Cast the object to array
@@ -1612,12 +1612,12 @@ object GenExpression {
       } else {
         arg.tpe match {
           // NB: This is not exhaustive. In the new backend we should handle all types, including multidim arrays.
-          case MonoType.ArrayMultiDim(MonoType.Float32, _) => mv.visitTypeInsn(CHECKCAST, "[F")
-          case MonoType.ArrayMultiDim(MonoType.Float64, _) => mv.visitTypeInsn(CHECKCAST, "[D")
-          case MonoType.ArrayMultiDim(MonoType.Int8, _) => mv.visitTypeInsn(CHECKCAST, "[B")
-          case MonoType.ArrayMultiDim(MonoType.Int16, _) => mv.visitTypeInsn(CHECKCAST, "[S")
-          case MonoType.ArrayMultiDim(MonoType.Int32, _) => mv.visitTypeInsn(CHECKCAST, "[I")
-          case MonoType.ArrayMultiDim(MonoType.Int64, _) => mv.visitTypeInsn(CHECKCAST, "[J")
+          case MonoType.Array(MonoType.Float32, _) => mv.visitTypeInsn(CHECKCAST, "[F")
+          case MonoType.Array(MonoType.Float64, _) => mv.visitTypeInsn(CHECKCAST, "[D")
+          case MonoType.Array(MonoType.Int8, _) => mv.visitTypeInsn(CHECKCAST, "[B")
+          case MonoType.Array(MonoType.Int16, _) => mv.visitTypeInsn(CHECKCAST, "[S")
+          case MonoType.Array(MonoType.Int32, _) => mv.visitTypeInsn(CHECKCAST, "[I")
+          case MonoType.Array(MonoType.Int64, _) => mv.visitTypeInsn(CHECKCAST, "[J")
           case _ => // nop
         }
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -710,7 +710,7 @@ object GenExpression {
         // We push the 'length' of the array on top of stack
         compileInt(exps.length)
         // We get the inner type of the array
-        val jvmType = JvmOps.getJvmType(tpe.asInstanceOf[MonoType.Array].tpe)
+        val jvmType = JvmOps.getJvmType(tpe.asInstanceOf[MonoType.ArrayMultiDim].tpe)
         // Instantiating a new array of type jvmType
         jvmType match {
           case ref: JvmType.Reference => // Happens if the inner type is an object type
@@ -734,7 +734,7 @@ object GenExpression {
       case AtomicOp.ArrayNew =>
         val List(exp1, exp2) = exps
         // We get the inner type of the array
-        val elmType = tpe.asInstanceOf[MonoType.Array].tpe
+        val elmType = tpe.asInstanceOf[MonoType.ArrayMultiDim].tpe
         // We get the JVM Type of elmType.
         val jvmType = JvmOps.getJvmType(elmType)
         // Evaluating the value of the 'default element'
@@ -810,7 +810,7 @@ object GenExpression {
         addSourceLine(mv, loc)
 
         // We get the inner type of the array
-        val jvmType = JvmOps.getErasedJvmType(exp.tpe.asInstanceOf[MonoType.Array].tpe)
+        val jvmType = JvmOps.getErasedJvmType(exp.tpe.asInstanceOf[MonoType.ArrayMultiDim].tpe)
         // Evaluating the 'base'
         compileExpr(exp)
         // Cast the object to array
@@ -1612,12 +1612,12 @@ object GenExpression {
       } else {
         arg.tpe match {
           // NB: This is not exhaustive. In the new backend we should handle all types, including multidim arrays.
-          case MonoType.Array(MonoType.Float32) => mv.visitTypeInsn(CHECKCAST, "[F")
-          case MonoType.Array(MonoType.Float64) => mv.visitTypeInsn(CHECKCAST, "[D")
-          case MonoType.Array(MonoType.Int8) => mv.visitTypeInsn(CHECKCAST, "[B")
-          case MonoType.Array(MonoType.Int16) => mv.visitTypeInsn(CHECKCAST, "[S")
-          case MonoType.Array(MonoType.Int32) => mv.visitTypeInsn(CHECKCAST, "[I")
-          case MonoType.Array(MonoType.Int64) => mv.visitTypeInsn(CHECKCAST, "[J")
+          case MonoType.ArrayMultiDim(MonoType.Float32, _) => mv.visitTypeInsn(CHECKCAST, "[F")
+          case MonoType.ArrayMultiDim(MonoType.Float64, _) => mv.visitTypeInsn(CHECKCAST, "[D")
+          case MonoType.ArrayMultiDim(MonoType.Int8, _) => mv.visitTypeInsn(CHECKCAST, "[B")
+          case MonoType.ArrayMultiDim(MonoType.Int16, _) => mv.visitTypeInsn(CHECKCAST, "[S")
+          case MonoType.ArrayMultiDim(MonoType.Int32, _) => mv.visitTypeInsn(CHECKCAST, "[I")
+          case MonoType.ArrayMultiDim(MonoType.Int64, _) => mv.visitTypeInsn(CHECKCAST, "[J")
           case _ => // nop
         }
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -61,7 +61,7 @@ object JvmOps {
     case MonoType.Region => JvmType.Object
 
     // Compound
-    case MonoType.ArrayMultiDim(_, _) => JvmType.Object
+    case MonoType.Array(_, _) => JvmType.Object
     case MonoType.Lazy(_) => JvmType.Object
     case MonoType.Ref(_) => getRefClassType(tpe)
     case MonoType.Tuple(_) => getTupleClassType(tpe.asInstanceOf[MonoType.Tuple])
@@ -638,7 +638,7 @@ object JvmOps {
       case MonoType.Regex => Set(tpe)
       case MonoType.Region => Set(tpe)
 
-      case MonoType.ArrayMultiDim(elm, _) => nestedTypesOf(elm) + tpe
+      case MonoType.Array(elm, _) => nestedTypesOf(elm) + tpe
       case MonoType.Lazy(elm) => nestedTypesOf(elm) + tpe
       case MonoType.Ref(elm) => nestedTypesOf(elm) + tpe
       case MonoType.Tuple(elms) => elms.flatMap(nestedTypesOf).toSet + tpe

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -61,7 +61,7 @@ object JvmOps {
     case MonoType.Region => JvmType.Object
 
     // Compound
-    case MonoType.Array(_) => JvmType.Object
+    case MonoType.ArrayMultiDim(_, _) => JvmType.Object
     case MonoType.Lazy(_) => JvmType.Object
     case MonoType.Ref(_) => getRefClassType(tpe)
     case MonoType.Tuple(_) => getTupleClassType(tpe.asInstanceOf[MonoType.Tuple])
@@ -209,8 +209,8 @@ object JvmOps {
     * NB: The given type `tpe` must be an enum type.
     */
   def getEnumInterfaceType(sym: Symbol.EnumSym)(implicit root: Root, flix: Flix): JvmType.Reference = {
-      // The enum resides in its namespace package.
-      JvmType.Reference(JvmName(sym.namespace, "I" + sym.name + Flix.Delimiter))
+    // The enum resides in its namespace package.
+    JvmType.Reference(JvmName(sym.namespace, "I" + sym.name + Flix.Delimiter))
   }
 
   /**
@@ -638,7 +638,7 @@ object JvmOps {
       case MonoType.Regex => Set(tpe)
       case MonoType.Region => Set(tpe)
 
-      case MonoType.Array(elm) => nestedTypesOf(elm) + tpe
+      case MonoType.ArrayMultiDim(elm, _) => nestedTypesOf(elm) + tpe
       case MonoType.Lazy(elm) => nestedTypesOf(elm) + tpe
       case MonoType.Ref(elm) => nestedTypesOf(elm) + tpe
       case MonoType.Tuple(elms) => elms.flatMap(nestedTypesOf).toSet + tpe


### PR DESCRIPTION
This PR changes `MonoType.Array` to `MonoType.ArrayMultiDim` (we should consider just adding `dim` to `MonoType.Array` instead of renaming the type, in my opinion), but does not yet change any behavior.

Related to https://github.com/flix/flix/issues/5917