### PR TITLE
fix: use options in all commands

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -166,6 +166,7 @@ object Main {
           flatMapN(Bootstrap.bootstrap(cwd, options.githubKey)(System.err)) {
             bootstrap =>
               implicit val flix: Flix = new Flix().setFormatter(formatter)
+              flix.setOptions(options)
               bootstrap.build(loadClasses = false)
           } match {
             case Validation.Success(_) => System.exit(0)

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -617,6 +617,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     */
   def run(o: Options, args: Array[String]): Validation[Unit, BootstrapError] = {
     implicit val flix: Flix = new Flix().setFormatter(Formatter.getDefault)
+    flix.setOptions(o)
     build().map(_.getMain).map {
       case Some(main) => main(args)
       case None => ()
@@ -628,6 +629,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     */
   def test(o: Options): Validation[Unit, BootstrapError] = {
     implicit val flix: Flix = new Flix().setFormatter(Formatter.getDefault)
+    flix.setOptions(o)
     flatMapN(build()) {
       compilationResult =>
         Tester.run(Nil, compilationResult) match {


### PR DESCRIPTION
`Build` `Run` and `Test` did not respect the given options. Just using default options.

This means that they forget the github key, and just breaks with `--entrypoint Company.run`