### PR TITLE
docs: update documentation for `GenExpression.addSourceLine`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -1590,8 +1590,8 @@ object GenExpression {
     case _ => mv.visitLdcInsn(i)
   }
 
-  /*
-   * Adding the source of the line for debugging
+  /**
+   * Adds the source of the line for debugging
    */
   private def addSourceLine(visitor: MethodVisitor, loc: SourceLocation): Unit = {
     val label = new Label()


### PR DESCRIPTION
It was marked as a comment instead of a doc comment.