### PR TITLE
style: rename `MonoType.Str` -> `MonoType.String`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
@@ -50,7 +50,7 @@ object MonoType {
 
   case object BigInt extends MonoType
 
-  case object Str extends MonoType
+  case object String extends MonoType
 
   case object Regex extends MonoType
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypePrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypePrinter.scala
@@ -36,7 +36,7 @@ object MonoTypePrinter {
     case MonoType.Int32 => Type.Int32
     case MonoType.Int64 => Type.Int64
     case MonoType.BigInt => Type.BigInt
-    case MonoType.Str => Type.Str
+    case MonoType.String => Type.Str
     case MonoType.Regex => Type.Regex
     case MonoType.Region => Type.Region
     case MonoType.Array(tpe) => Type.Array(print(tpe))

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -266,7 +266,7 @@ object Simplifier {
 
             case TypeConstructor.BigInt => MonoType.BigInt
 
-            case TypeConstructor.Str => MonoType.Str
+            case TypeConstructor.Str => MonoType.String
 
             case TypeConstructor.Regex => MonoType.Regex
 
@@ -396,7 +396,7 @@ object Simplifier {
           // Unit is always equal to itself.
           return SimplifiedAst.Expr.Cst(Ast.Constant.Bool(true), MonoType.Bool, loc)
 
-        case (MonoType.Str, _) =>
+        case (MonoType.String, _) =>
           val strClass = Class.forName("java.lang.String")
           val objClass = Class.forName("java.lang.Object")
           val method = strClass.getMethod("equals", objClass)

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -70,7 +70,7 @@ object Verifier {
       case Constant.Int32(_) => check(expected = MonoType.Int32)(actual = tpe, loc)
       case Constant.Int64(_) => check(expected = MonoType.Int64)(actual = tpe, loc)
       case Constant.BigInt(_) => check(expected = MonoType.BigInt)(actual = tpe, loc)
-      case Constant.Str(_) => check(expected = MonoType.Str)(actual = tpe, loc)
+      case Constant.Str(_) => check(expected = MonoType.String)(actual = tpe, loc)
       case Constant.Regex(_) => check(expected = MonoType.Regex)(actual = tpe, loc)
     }
 
@@ -214,7 +214,7 @@ object Verifier {
             case SemanticOp.Int64Op.Shl => (MonoType.Int64, MonoType.Int32, MonoType.Int64)
             case SemanticOp.Int64Op.Shr => (MonoType.Int64, MonoType.Int32, MonoType.Int64)
 
-            case SemanticOp.StringOp.Concat => (MonoType.Str, MonoType.Str, MonoType.Str)
+            case SemanticOp.StringOp.Concat => (MonoType.String, MonoType.String, MonoType.String)
 
             case _ => throw InternalCompilerException(s"Invalid binary operator: '$sop'", loc)
           }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -128,7 +128,7 @@ object BackendType {
     case MonoType.Int16 => Int16
     case MonoType.Int32 => Int32
     case MonoType.Int64 => Int64
-    case MonoType.Unit | MonoType.BigDecimal | MonoType.BigInt | MonoType.Str | MonoType.Regex |
+    case MonoType.Unit | MonoType.BigDecimal | MonoType.BigInt | MonoType.String | MonoType.Regex |
          MonoType.Array(_) | MonoType.Lazy(_) | MonoType.Ref(_) | MonoType.Tuple(_) |
          MonoType.Enum(_) | MonoType.Arrow(_, _) | MonoType.RecordEmpty | MonoType.RecordExtend(_, _, _) |
          MonoType.SchemaEmpty | MonoType.SchemaExtend(_, _, _) | MonoType.Native(_) |

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -56,7 +56,7 @@ object JvmOps {
     case MonoType.Int32 => JvmType.PrimInt
     case MonoType.Int64 => JvmType.PrimLong
     case MonoType.BigInt => JvmType.BigInteger
-    case MonoType.Str => JvmType.String
+    case MonoType.String => JvmType.String
     case MonoType.Regex => JvmType.Regex
     case MonoType.Region => JvmType.Object
 
@@ -634,7 +634,7 @@ object JvmOps {
       case MonoType.Int32 => Set(tpe)
       case MonoType.Int64 => Set(tpe)
       case MonoType.BigInt => Set(tpe)
-      case MonoType.Str => Set(tpe)
+      case MonoType.String => Set(tpe)
       case MonoType.Regex => Set(tpe)
       case MonoType.Region => Set(tpe)
 


### PR DESCRIPTION
Why does this type have a special name compared to everywhere else in the compiler?