### PR TITLE
feat: add `TokenKind` for new lexer

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -17,22 +17,31 @@ package ca.uwaterloo.flix.language.ast
 
 sealed trait TokenKind
 
-// NOTE: Tokens are named for 'what they are' rather than 'what they represent'.
-// So '::' is not named 'Cons' but instead 'ColonColon' as the lexer should be oblivious to the concept of cons
-
-// NOTE: Builtin type keywords like 'Float32' are lexed into 'Float32Keyword' whereas Float32 *literals* are lexed to 'Float32'
-// This aligns naming of literals with other types such as 'String' and 'Bool'
+/* Tokens are named for 'what they are' rather than 'what they represent'.
+ * So '::' is not named 'Cons' but instead 'ColonColon' as the lexer should be oblivious to the concept of cons
+ *
+ * Tokens belonging to some conceptual group should have the group name as prefix.
+ * So 'LiteralInt32' is preferred over 'Int32Literal'
+ */
 
 object TokenKind {
   case object Ampersand extends TokenKind
 
   case object AngledEqual extends TokenKind
 
-  case object AngledEqualEqual extends TokenKind
-
   case object AngledPlus extends TokenKind
 
+  case object AngleL extends TokenKind
+
+  case object AngleLEqual extends TokenKind
+
+  case object AngleR extends TokenKind
+
+  case object AngleREqual extends TokenKind
+
   case object Annotation extends TokenKind
+
+  case object ArrayHash extends TokenKind
 
   case object Arrow extends TokenKind
 
@@ -46,15 +55,13 @@ object TokenKind {
 
   case object Bar extends TokenKind
 
-  case object BigDecimal extends TokenKind
+  case object BracketL extends TokenKind
 
-  case object BigInt extends TokenKind
+  case object BracketR extends TokenKind
 
   case object BuiltIn extends TokenKind
 
   case object Caret extends TokenKind
-
-  case object Char extends TokenKind
 
   case object Colon extends TokenKind
 
@@ -68,19 +75,15 @@ object TokenKind {
 
   case object CommentLine extends TokenKind
 
-  case object Dollar extends TokenKind
+  case object CurlyL extends TokenKind
+
+  case object CurlyR extends TokenKind
 
   case object Dot extends TokenKind
-
-  case object DotDot extends TokenKind
 
   case object Equal extends TokenKind
 
   case object EqualEqual extends TokenKind
-
-  case object Float32 extends TokenKind
-
-  case object Float64 extends TokenKind
 
   case object Hash extends TokenKind
 
@@ -92,14 +95,6 @@ object TokenKind {
 
   case object InfixFunction extends TokenKind
 
-  case object Int16 extends TokenKind
-
-  case object Int32 extends TokenKind
-
-  case object Int64 extends TokenKind
-
-  case object Int8 extends TokenKind
-
   case object KeywordAbsent extends TokenKind
 
   case object KeywordAlias extends TokenKind
@@ -108,27 +103,29 @@ object TokenKind {
 
   case object KeywordAs extends TokenKind
 
-  case object KeywordBigDecimal extends TokenKind
-
-  case object KeywordBigInt extends TokenKind
-
-  case object KeywordBool extends TokenKind
-
   case object KeywordCase extends TokenKind
 
   case object KeywordCatch extends TokenKind
 
-  case object KeywordChan extends TokenKind
+  case object KeywordCheckedCast extends TokenKind
 
-  case object KeywordChar extends TokenKind
+  case object KeywordCheckedECast extends TokenKind
+
+  case object KeywordChoose extends TokenKind
 
   case object KeywordClass extends TokenKind
+
+  case object KeywordDebug extends TokenKind
 
   case object KeywordDef extends TokenKind
 
   case object KeywordDeref extends TokenKind
 
   case object KeywordDiscard extends TokenKind
+
+  case object KeywordDo extends TokenKind
+
+  case object KeywordEff extends TokenKind
 
   case object KeywordElse extends TokenKind
 
@@ -138,11 +135,11 @@ object TokenKind {
 
   case object KeywordFix extends TokenKind
 
-  case object KeywordFloat32 extends TokenKind
-
-  case object KeywordFloat64 extends TokenKind
+  case object KeywordFor extends TokenKind
 
   case object KeywordForA extends TokenKind
+
+  case object KeywordForall extends TokenKind
 
   case object KeywordForce extends TokenKind
 
@@ -150,27 +147,23 @@ object TokenKind {
 
   case object KeywordForM extends TokenKind
 
+  case object KeywordFrom extends TokenKind
+
+  case object KeywordGet extends TokenKind
+
   case object KeywordIf extends TokenKind
 
   case object KeywordImport extends TokenKind
 
   case object KeywordImpure extends TokenKind
 
+  case object KeywordInject extends TokenKind
+
   case object KeywordInline extends TokenKind
 
   case object KeywordInstance extends TokenKind
 
-  case object KeywordInt16 extends TokenKind
-
-  case object KeywordInt32 extends TokenKind
-
-  case object KeywordInt64 extends TokenKind
-
-  case object KeywordInt8 extends TokenKind
-
   case object KeywordInto extends TokenKind
-
-  case object KeywordLat extends TokenKind
 
   case object KeywordLaw extends TokenKind
 
@@ -180,21 +173,21 @@ object TokenKind {
 
   case object KeywordLet extends TokenKind
 
+  case object KeywordMasked_cast extends TokenKind
+
   case object KeywordMatch extends TokenKind
 
   case object KeywordMod extends TokenKind
 
-  case object KeywordNamespace extends TokenKind
-
-  case object KeywordNil extends TokenKind
+  case object KeywordNew extends TokenKind
 
   case object KeywordNot extends TokenKind
 
   case object KeywordNull extends TokenKind
 
-  case object KeywordObject extends TokenKind
+  case object KeywordOpen extends TokenKind
 
-  case object KeywordOpaque extends TokenKind
+  case object KeywordOpen_as extends TokenKind
 
   case object KeywordOr extends TokenKind
 
@@ -202,57 +195,45 @@ object TokenKind {
 
   case object KeywordPar extends TokenKind
 
-  case object KeywordPredicate extends TokenKind
-
   case object KeywordPresent extends TokenKind
+
+  case object KeywordProject extends TokenKind
 
   case object KeywordPub extends TokenKind
 
   case object KeywordPure extends TokenKind
 
-  case object KeywordRead extends TokenKind
-
-  case object KeywordRecordRow extends TokenKind
+  case object KeywordQuery extends TokenKind
 
   case object KeywordRef extends TokenKind
 
   case object KeywordRegion extends TokenKind
 
-  case object KeywordReify extends TokenKind
+  case object KeywordRelational_choose extends TokenKind
 
-  case object KeywordReifyBool extends TokenKind
+  case object KeywordRestrictable extends TokenKind
 
-  case object KeywordReifyEff extends TokenKind
-
-  case object KeywordReifyType extends TokenKind
-
-  case object KeywordRel extends TokenKind
-
-  case object KeywordRem extends TokenKind
-
-  case object KeywordSchemaRow extends TokenKind
+  case object KeywordResume extends TokenKind
 
   case object KeywordSealed extends TokenKind
 
-  case object KeywordSet extends TokenKind
+  case object KeywordSelect extends TokenKind
+
+  case object KeywordSolve extends TokenKind
 
   case object KeywordSpawn extends TokenKind
 
   case object KeywordStatic extends TokenKind
 
-  case object KeywordString extends TokenKind
-
   case object KeywordTrue extends TokenKind
+
+  case object KeywordTry extends TokenKind
 
   case object KeywordType extends TokenKind
 
   case object KeywordTypeMatch extends TokenKind
 
-  case object KeywordUnit extends TokenKind
-
-  case object KeywordUppercaseRegion extends TokenKind
-
-  case object KeywordUppercaseType extends TokenKind
+  case object KeywordUnchecked_cast extends TokenKind
 
   case object KeywordUse extends TokenKind
 
@@ -260,19 +241,29 @@ object TokenKind {
 
   case object KeywordWith extends TokenKind
 
-  case object KeywordWrite extends TokenKind
+  case object KeywordWithout extends TokenKind
 
   case object KeywordYield extends TokenKind
 
-  case object LAngle extends TokenKind
+  case object ListHash extends TokenKind
 
-  case object LAngleEqual extends TokenKind
+  case object LiteralBigDecimal extends TokenKind
 
-  case object LBracket extends TokenKind
+  case object LiteralBigInt extends TokenKind
 
-  case object LCurly extends TokenKind
+  case object LiteralChar extends TokenKind
 
-  case object LParen extends TokenKind
+  case object LiteralFloat32 extends TokenKind
+
+  case object LiteralFloat64 extends TokenKind
+
+  case object LiteralInt64 extends TokenKind
+
+  case object LiteralInt8 extends TokenKind
+
+  case object LiteralString extends TokenKind
+
+  case object MapHash extends TokenKind
 
   case object Minus extends TokenKind
 
@@ -280,25 +271,21 @@ object TokenKind {
 
   case object NameJava extends TokenKind
 
-  case object NameLowercase extends TokenKind
+  case object NameLowerCase extends TokenKind
 
   case object NameMath extends TokenKind
 
-  case object NameUppercase extends TokenKind
+  case object NameUpperCase extends TokenKind
+
+  case object ParenL extends TokenKind
+
+  case object ParenR extends TokenKind
 
   case object Plus extends TokenKind
 
-  case object RAngle extends TokenKind
-
-  case object RAngleEqual extends TokenKind
-
-  case object RBracket extends TokenKind
-
-  case object RCurly extends TokenKind
-
-  case object RParen extends TokenKind
-
   case object Semi extends TokenKind
+
+  case object SetHash extends TokenKind
 
   case object Slash extends TokenKind
 
@@ -306,19 +293,17 @@ object TokenKind {
 
   case object StarStar extends TokenKind
 
-  case object String extends TokenKind
-
   case object TripleAmpersand extends TokenKind
+
+  case object TripleAngleL extends TokenKind
+
+  case object TripleAngleR extends TokenKind
 
   case object TripleBar extends TokenKind
 
   case object TripleCaret extends TokenKind
 
-  case object TripleLAngle extends TokenKind
-
   case object TripleQuestionMark extends TokenKind
-
-  case object TripleRAngle extends TokenKind
 
   case object TripleTilde extends TokenKind
 
@@ -326,14 +311,14 @@ object TokenKind {
 
   case object UserDefinedOperator extends TokenKind
 
-  /**
-   * A special token emitted instead of halting the lexer when an error is encountered.
+  case object VectorHash extends TokenKind
+
+  /** A special token emitted instead of halting the lexer when an error is encountered.
    * @param kind the kind of error found.
    */
   case class Err(kind: TokenErrorKind) extends TokenKind
 
-  /**
-   * A virtual token signalling END-OF-FILE.
+  /** A virtual token signalling END-OF-FILE.
    */
   case object Eof extends TokenKind
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Magnus Madsen
+ * Copyright 2023 Herluf Baggesen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,340 @@ package ca.uwaterloo.flix.language.ast
 
 sealed trait TokenKind
 
-object TokenKind {
+// NOTE: Tokens are named for 'what they are' rather than 'what they represent'.
+// So '::' is not named 'Cons' but instead 'ColonColon' as the lexer should be oblivious to the concept of cons
 
+// NOTE: Builtin type keywords like 'Float32' are lexed into 'Float32Keyword' whereas Float32 *literals* are lexed to 'Float32'
+// This aligns naming of literals with other types such as 'String' and 'Bool'
+
+object TokenKind {
   case object LParen extends TokenKind
 
   case object RParen extends TokenKind
 
-  // TODO: LEXER
+  case object LCurly extends TokenKind
+
+  case object RCurly extends TokenKind
+
+  case object LBracket extends TokenKind
+
+  case object RBracket extends TokenKind
+
+  case object Bang extends TokenKind
+
+  case object Semi extends TokenKind
+
+  case object Dot extends TokenKind
+
+  case object DotDot extends TokenKind
+
+  case object Comma extends TokenKind
+
+  case object Colon extends TokenKind
+
+  case object ColonColon extends TokenKind
+
+  case object ColonEqual extends TokenKind
+
+  case object Arrow extends TokenKind
+
+  case object Plus extends TokenKind
+
+  case object Minus extends TokenKind
+
+  case object Hash extends TokenKind
+
+  case object Dollar extends TokenKind
+
+  case object Bar extends TokenKind
+
+  case object Caret extends TokenKind
+
+  case object Ampersand extends TokenKind
+
+  case object TripleAmpersand extends TokenKind
+
+  case object TripleLAngle extends TokenKind
+
+  case object TripleRAngle extends TokenKind
+
+  case object TripleQuestionMark extends TokenKind
+
+  case object TripleCaret extends TokenKind
+
+  case object TripleBar extends TokenKind
+
+  case object TripleTilde extends TokenKind
+
+  case object AngledEqual extends TokenKind
+
+  case object AngledEqualEqual extends TokenKind
+
+  case object AngledPlus extends TokenKind
+
+  case object Star extends TokenKind
+
+  case object StarStar extends TokenKind
+
+  case object Slash extends TokenKind
+
+  case object Backslash extends TokenKind
+
+  case object Underscore extends TokenKind
+
+  case object LAngle extends TokenKind
+
+  case object RAngle extends TokenKind
+
+  case object LAngleEqual extends TokenKind
+
+  case object RAngleEqual extends TokenKind
+
+  case object Equal extends TokenKind
+
+  case object EqualEqual extends TokenKind
+
+  case object UserDefinedOperator extends TokenKind
+
+  case object At extends TokenKind
+
+  case object InfixFunction extends TokenKind
+
+  case object BackArrow extends TokenKind
+
+  case object AndKeyword extends TokenKind
+
+  case object OrKeyword extends TokenKind
+
+  case object ModKeyword extends TokenKind
+
+  case object ForeachKeyword extends TokenKind
+
+  case object ForMKeyword extends TokenKind
+
+  case object ForAKeyword extends TokenKind
+
+  case object NotKeyword extends TokenKind
+
+  case object RemKeyword extends TokenKind
+
+  case object AbsentKeyword extends TokenKind
+
+  case object BoolKeyword extends TokenKind
+
+  case object UnitKeyword extends TokenKind
+
+  case object CharKeyword extends TokenKind
+
+  case object Float32Keyword extends TokenKind
+
+  case object Float64Keyword extends TokenKind
+
+  case object Int8Keyword extends TokenKind
+
+  case object Int16Keyword extends TokenKind
+
+  case object Int32Keyword extends TokenKind
+
+  case object Int64Keyword extends TokenKind
+
+  case object StringKeyword extends TokenKind
+
+  case object BigIntKeyword extends TokenKind
+
+  case object BigDecimalKeyword extends TokenKind
+
+  case object ImpureKeyword extends TokenKind
+
+  case object NilKeyword extends TokenKind
+
+  case object PredicateKeyword extends TokenKind
+
+  case object PresentKeyword extends TokenKind
+
+  case object PureKeyword extends TokenKind
+
+  case object ReadKeyword extends TokenKind
+
+  case object RecordRowKeyword extends TokenKind
+
+  case object UppercaseRegionKeyword extends TokenKind
+
+  case object SchemaRowKeyword extends TokenKind
+
+  case object UppercaseTypeKeyword extends TokenKind
+
+  case object WriteKeyword extends TokenKind
+
+  case object AliasKeyword extends TokenKind
+
+  case object CaseKeyword extends TokenKind
+
+  case object CatchKeyword extends TokenKind
+
+  case object ChanKeyword extends TokenKind
+
+  case object ClassKeyword extends TokenKind
+
+  case object DefKeyword extends TokenKind
+
+  case object DerefKeyword extends TokenKind
+
+  case object ElseKeyword extends TokenKind
+
+  case object EnumKeyword extends TokenKind
+
+  case object FalseKeyword extends TokenKind
+
+  case object FixKeyword extends TokenKind
+
+  case object ForceKeyword extends TokenKind
+
+  case object IfKeyword extends TokenKind
+
+  case object ImportKeyword extends TokenKind
+
+  case object InlineKeyword extends TokenKind
+
+  case object InstanceKeyword extends TokenKind
+
+  case object IntoKeyword extends TokenKind
+
+  case object LatKeyword extends TokenKind
+
+  case object LawKeyword extends TokenKind
+
+  case object LawfulKeyword extends TokenKind
+
+  case object LazyKeyword extends TokenKind
+
+  case object LetKeyword extends TokenKind
+
+  case object MatchKeyword extends TokenKind
+
+  case object TypeMatchKeyword extends TokenKind
+
+  case object NamespaceKeyword extends TokenKind
+
+  case object NullKeyword extends TokenKind
+
+  case object OpaqueKeyword extends TokenKind
+
+  case object OverrideKeyword extends TokenKind
+
+  case object ParKeyword extends TokenKind
+
+  case object YieldKeyword extends TokenKind
+
+  case object PubKeyword extends TokenKind
+
+  case object AsKeyword extends TokenKind
+
+  case object RefKeyword extends TokenKind
+
+  case object RegionKeyword extends TokenKind
+
+  case object ReifyKeyword extends TokenKind
+
+  case object ReifyBoolKeyword extends TokenKind
+
+  case object ReifyEffKeyword extends TokenKind
+
+  case object ReifyTypeKeyword extends TokenKind
+
+  case object RelKeyword extends TokenKind
+
+  case object SealedKeyword extends TokenKind
+
+  case object SetKeyword extends TokenKind
+
+  case object SpawnKeyword extends TokenKind
+
+  case object StaticKeyword extends TokenKind
+
+  case object TrueKeyword extends TokenKind
+
+  case object TypeKeyword extends TokenKind
+
+  case object UseKeyword extends TokenKind
+
+  case object WhereKeyword extends TokenKind
+
+  case object WithKeyword extends TokenKind
+
+  case object DiscardKeyword extends TokenKind
+
+  case object ObjectKeyword extends TokenKind
+
+  case object UppercaseName extends TokenKind
+
+  case object LowercaseName extends TokenKind
+
+  case object MathName extends TokenKind
+
+  case object GreekName extends TokenKind
+
+  case object Float32 extends TokenKind
+
+  case object Float64 extends TokenKind
+
+  case object Int8 extends TokenKind
+
+  case object Int16 extends TokenKind
+
+  case object Int32 extends TokenKind
+
+  case object Int64 extends TokenKind
+
+  case object BigInt extends TokenKind
+
+  case object BigDecimal extends TokenKind
+
+  case object String extends TokenKind
+
+  case object Char extends TokenKind
+
+  case object Annotation extends TokenKind
+
+  case object AnonymousHole extends TokenKind
+
+  case object JavaName extends TokenKind
+
+  case object BuiltIn extends TokenKind
+
+  case object NamedHole extends TokenKind
+
+  case object VariableHole extends TokenKind
+
+  case object LineComment extends TokenKind
+
+  case object BlockComment extends TokenKind
+
+  case class Err(kind: LexerErr) extends TokenKind
 
   case object Eof extends TokenKind
 
-  case object Err extends TokenKind
+}
 
+sealed trait LexerErr
+
+object LexerErr {
+
+  case object UnexpectedChar extends LexerErr
+
+  case object UnterminatedString extends LexerErr
+
+  case object UnterminatedChar extends LexerErr
+
+  case object UnterminatedInfixFunction extends LexerErr
+
+  case object DoubleDottedNumber extends LexerErr
+
+  case object MalformedNumber extends LexerErr
+
+  case object BlockCommentTooDeep extends LexerErr
+
+  case object UnterminatedBlockComment extends LexerErr
+
+  case object UnterminatedBuiltIn extends LexerErr
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -15,6 +15,8 @@
  */
 package ca.uwaterloo.flix.language.ast
 
+import ca.uwaterloo.flix.language.errors.LexerError
+
 sealed trait TokenKind
 
 // NOTE: Tokens are named for 'what they are' rather than 'what they represent'.
@@ -330,7 +332,7 @@ object TokenKind {
    * A special token emitted instead of halting the lexer when an error is encountered.
    * @param kind the kind of error found.
    */
-  case class Err(kind: LexerErr) extends TokenKind
+  case class Err(kind: LexerError) extends TokenKind
 
   /**
    * A virtual token signalling END-OF-FILE.

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -15,8 +15,6 @@
  */
 package ca.uwaterloo.flix.language.ast
 
-import ca.uwaterloo.flix.language.errors.LexerError
-
 sealed trait TokenKind
 
 // NOTE: Tokens are named for 'what they are' rather than 'what they represent'.
@@ -332,7 +330,7 @@ object TokenKind {
    * A special token emitted instead of halting the lexer when an error is encountered.
    * @param kind the kind of error found.
    */
-  case class Err(kind: LexerError) extends TokenKind
+  case class Err(kind: TokenErrorKind) extends TokenKind
 
   /**
    * A virtual token signalling END-OF-FILE.


### PR DESCRIPTION
Some token names were changed to make sure similar tokens are colocated when sorting alphabetically. These are:
- `*Keyword` becomes `Keyword*`. ie. `KeywordIf`
- `*Comment` becomes `Comment*`. 
- `*Name` becomes `Name*`. 
- `*Hole` becomes `Hole*`. 

A nice side-effect is that now editor suggestions work neatly. For instance `Name` suggests the different kinds of names available, making it easy to browse and select.