### PR TITLE
refactor: rename stdlib module File to Files

### DIFF
--- a/examples/file-information.flix
+++ b/examples/file-information.flix
@@ -3,7 +3,7 @@ def main(): Unit \ IO =
   let f = "README.md";
 
   // Check if the file 'README.md' exists.
-  match File.exists(f) {
+  match Files.exists(f) {
     case Ok(exist) => {
       println("The file ${f} exists: ${exist}.")
     }
@@ -11,7 +11,7 @@ def main(): Unit \ IO =
   };
 
   // Get statistics of the file 'README.md'.
-  match File.stat(f) {
+  match Files.stat(f) {
     case Ok(stats) => {
       println("${f} is of type: ${stats.fileType}");
       println("The size of ${f} is: ${stats.size}.");

--- a/examples/working-with-files-and-directories.flix
+++ b/examples/working-with-files-and-directories.flix
@@ -4,14 +4,14 @@ def main(): Unit \ IO =
   let dir = "src";
 
   // Read the file `README.md`.
-  match File.readLines(f) {
+  match Files.readLines(f) {
     case Ok(x :: _) => println("The first line of ${f} is: '${x}'.")
     case Ok(Nil)    => println("the file ${f} is empty.")
     case Err(msg)   => println("An error occurred with message: ${msg}")
   };
 
   // List the files in `src`.
-  match File.list(dir) {
+  match Files.list(dir) {
     case Ok(subpaths) => {
       println("All files or directories in ${dir} is: '${subpaths}'.")
     }

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -215,7 +215,7 @@ class Flix {
     "MutSet.flix" -> LocalResource.get("/src/library/MutSet.flix"),
     "MutMap.flix" -> LocalResource.get("/src/library/MutMap.flix"),
 
-    "File.flix" -> LocalResource.get("/src/library/File.flix"),
+    "Files.flix" -> LocalResource.get("/src/library/Files.flix"),
     "IOError.flix" -> LocalResource.get("/src/library/IOError.flix"),
     "Reader.flix" -> LocalResource.get("/src/library/Reader.flix"),
 

--- a/main/src/library/Files.flix
+++ b/main/src/library/Files.flix
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-mod File {
+mod Files {
 
     ///
     /// File types.
@@ -123,9 +123,9 @@ mod File {
     ///
     pub def fileType(f: String): Result[String, FileType] \ IO =
         forM (
-            isFile <- File.isRegularFile(f);
-            isDirec <- File.isDirectory(f);
-            isSymLink <- File.isSymbolicLink(f)
+            isFile <- Files.isRegularFile(f);
+            isDirec <- Files.isDirectory(f);
+            isSymLink <- Files.isSymbolicLink(f)
         ) yield {
             if (isFile)         FileType.File
             else if (isDirec)   FileType.Directory
@@ -612,7 +612,7 @@ mod File {
             import java.io.PrintWriter.close(): Unit \ IO;
             import java.io.PrintWriter.checkError(): Bool \ IO;
 
-            let alreadyExists = File.exists(f);
+            let alreadyExists = Files.exists(f);
 
             let javaFile = newFile(f);
             let w = newPrintWriter(javaFile);
@@ -647,7 +647,7 @@ mod File {
             import java.io.PrintWriter.close(): Unit \ IO;
             import java.io.PrintWriter.checkError(): Bool \ IO;
 
-            let alreadyExists = File.exists(f);
+            let alreadyExists = Files.exists(f);
 
             let javaFile = newFile(f);
             let w = newPrintWriter(javaFile);
@@ -681,7 +681,7 @@ mod File {
             import java.io.PrintWriter.close(): Unit \ IO;
             import java.io.PrintWriter.checkError(): Bool \ IO;
 
-            let alreadyExists = File.exists(f);
+            let alreadyExists = Files.exists(f);
 
             let javaFile = newFile(f);
             // 2nd parameter `true` is for append.
@@ -717,7 +717,7 @@ mod File {
             import java.io.PrintWriter.close(): Unit \ IO;
             import java.io.PrintWriter.checkError(): Bool \ IO;
 
-            let alreadyExists = File.exists(f);
+            let alreadyExists = Files.exists(f);
 
             let javaFile = newFile(f);
             // 2nd parameter `true` is for append.
@@ -755,7 +755,7 @@ mod File {
             import java.io.PrintWriter.close(): Unit \ IO;
             import java.io.PrintWriter.checkError(): Bool \ IO;
 
-            let alreadyExists = File.exists(f);
+            let alreadyExists = Files.exists(f);
 
             let javaFile = newFile(f);
             let fileStream = newFileStream(javaFile);
@@ -792,7 +792,7 @@ mod File {
             import java.io.PrintWriter.close(): Unit \ IO;
             import java.io.PrintWriter.checkError(): Bool \ IO;
 
-            let alreadyExists = File.exists(f);
+            let alreadyExists = Files.exists(f);
 
             let javaFile = newFile(f);
             // 2nd parameter `true` is for append.
@@ -827,7 +827,7 @@ mod File {
             import java.io.PrintWriter.close(): Unit \ IO;
             import java.io.PrintWriter.checkError(): Bool \ IO;
 
-            let alreadyExists = File.exists(f);
+            let alreadyExists = Files.exists(f);
 
             let javaFile = newFile(f);
             let printWriter = newPrintWriter(javaFile);
@@ -1023,7 +1023,7 @@ mod File {
     ///
     pub def moveInto(src: {src = String} , dst: String): Result[String, Unit] \ IO =
         try {
-            match File.isDirectory(dst) {
+            match isDirectory(dst) {
                 case Ok(true)  => {
                     import new java.io.File(String): ##java.io.File \ IO as newFile;
                     import java.io.File.toPath(): ##java.nio.file.Path \ IO;
@@ -1114,7 +1114,7 @@ mod File {
     ///
     pub def copyInto(src: {src = String} , dst: String): Result[String, Unit] \ IO =
         try {
-            match File.isDirectory(dst) {
+            match isDirectory(dst) {
                 case Ok(true)  => {
                     import new java.io.File(String): ##java.io.File \ IO as newFile;
                     import java.io.File.toPath(): ##java.nio.file.Path \ IO;

--- a/main/test/ca/uwaterloo/flix/library/TestFiles.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFiles.flix
@@ -16,7 +16,7 @@
 
 mod TestFile {
 
-    use File.{exists, isDirectory, isRegularFile, isReadable, isSymbolicLink,
+    use Files.{exists, isDirectory, isRegularFile, isReadable, isSymbolicLink,
         isWritable, isExecutable, readLines, readLinesWith, read, readWith,
         readLinesIter, readLinesIterWith, readBytes, readBytesWith, readChunks,
         stat, accessTime, creationTime, modificationTime, size}
@@ -64,7 +64,7 @@ mod TestFile {
     @test
     def testStat02(): Bool \ IO =
         match stat("README.md") {
-            case Ok(v) => v.fileType == File.FileType.File
+            case Ok(v) => v.fileType == Files.FileType.File
             case _ => false
         }
 


### PR DESCRIPTION
This PR renames `File` to `Files`. It is a prelude to adding a new `File` module.

This PR breaks some of the community-builds.