### PR TITLE
feat: add conversion functions for Char and the number types to/from their Java object versions (issue #6426)

### DIFF
--- a/main/src/library/Char.flix
+++ b/main/src/library/Char.flix
@@ -240,4 +240,24 @@ mod Char {
             case c                  => Some(c)
         }
 
+    ///
+    /// Get the primitive Char value from its object representation (i.e. ##java.lang.Character).
+    ///
+    /// This function is expected to be used when marshaling Chars from Java. Generally in Flix
+    /// code you should not need to use `##java.lang.Character`.
+    ///
+    pub def charValue(c: ##java.lang.Character): Char =
+        import java.lang.Character.charValue(): Char \ {};
+        charValue(c)
+
+    ///
+    /// Convert an Char value to its its object representation (i.e. ##java.lang.Character).
+    ///
+    /// This function is expected to be used when marshaling Chars to Java. Generally in Flix
+    /// code you should not need to use `##java.lang.Character`.
+    ///
+    pub def valueOf(c: Char): ##java.lang.Character =
+        import static java.lang.Character.valueOf(Char): ##java.lang.Character \ {};
+        valueOf(c)
+
 }

--- a/main/src/library/Float32.flix
+++ b/main/src/library/Float32.flix
@@ -349,4 +349,24 @@ mod Float32 {
     ///
     pub def pow(b: Float32, n: Float32): Float32 = $FLOAT32_EXP$(b, n)
 
+    ///
+    /// Get the primitive Float32 value from its object representation (i.e. ##java.lang.Float).
+    ///
+    /// This function is expected to be used when marshaling Float32s from Java. Generally in Flix
+    /// code you should not need to use `##java.lang.Float`.
+    ///
+    pub def floatValue(d: ##java.lang.Float): Float32 =
+        import java.lang.Float.floatValue(): Float32 \ {};
+        floatValue(d)
+
+    ///
+    /// Convert an Float32 value to its object representation (i.e. ##java.lang.Float).
+    ///
+    /// This function is expected to be used when marshaling Float32s to Java. Generally in Flix
+    /// code you should not need to use `##java.lang.Float`.
+    ///
+    pub def valueOf(d: Float32): ##java.lang.Float =
+        import static java.lang.Float.valueOf(Float32): ##java.lang.Float \ {};
+        valueOf(d)
+
 }

--- a/main/src/library/Float64.flix
+++ b/main/src/library/Float64.flix
@@ -377,4 +377,24 @@ mod Float64 {
         import static java.lang.Math.exp(Float64): Float64 \ {};
         exp(x)
 
+    ///
+    /// Get the primitive Float64 value from its object representation (i.e. ##java.lang.Double).
+    ///
+    /// This function is expected to be used when marshaling Float64s from Java. Generally in Flix
+    /// code you should not need to use `##java.lang.Double`.
+    ///
+    pub def doubleValue(i: ##java.lang.Double): Float64 =
+        import java.lang.Double.doubleValue(): Float64 \ {};
+        doubleValue(i)
+
+    ///
+    /// Convert an Float64 value to its object representation (i.e. ##java.lang.Double).
+    ///
+    /// This function is expected to be used when marshaling Float64s to Java. Generally in Flix
+    /// code you should not need to use `##java.lang.Double`.
+    ///
+    pub def valueOf(i: Float64): ##java.lang.Double =
+        import static java.lang.Double.valueOf(Float64): ##java.lang.Double \ {};
+        valueOf(i)
+
 }

--- a/main/src/library/Int16.flix
+++ b/main/src/library/Int16.flix
@@ -438,4 +438,24 @@ mod Int16 {
         let maxi16 = Int8.toInt16(max.max);
         (valueOf(clamp(min = mini16, max = maxi16, x)) |> byteValue)
 
+    ///
+    /// Get the primitive Int16 value from its object representation (i.e. ##java.lang.Short).
+    ///
+    /// This function is expected to be used when marshaling Int16s from Java. Generally in Flix
+    /// code you should not need to use `##java.lang.Short`.
+    ///
+    pub def shortValue(i: ##java.lang.Short): Int16 =
+        import java.lang.Short.shortValue(): Int16 \ {};
+        shortValue(i)
+
+    ///
+    /// Convert an Int16 value to its object representation (i.e. ##java.lang.Short).
+    ///
+    /// This function is expected to be used when marshaling Int16s to Java. Generally in Flix
+    /// code you should not need to use `##java.lang.Short`.
+    ///
+    pub def valueOf(i: Int16): ##java.lang.Short =
+        import static java.lang.Short.valueOf(Int16): ##java.lang.Short \ {};
+        valueOf(i)
+
 }

--- a/main/src/library/Int32.flix
+++ b/main/src/library/Int32.flix
@@ -476,4 +476,24 @@ mod Int32 {
         let maxi32 = Int16.toInt32(max.max);
         (valueOf(clamp(min = mini32, max = maxi32, x)) |> shortValue)
 
+    ///
+    /// Get the primitive Int32 value from its object representation (i.e. ##java.lang.Integer).
+    ///
+    /// This function is expected to be used when marshaling Int32s from Java. Generally in Flix
+    /// code you should not need to use `##java.lang.Integer`.
+    ///
+    pub def intValue(i: ##java.lang.Integer): Int32 =
+        import java.lang.Integer.intValue(): Int32 \ {};
+        intValue(i)
+
+    ///
+    /// Convert an Int32 value to its object representation (i.e. ##java.lang.Integer).
+    ///
+    /// This function is expected to be used when marshaling Int32s to Java. Generally in Flix
+    /// code you should not need to use `##java.lang.Integer`.
+    ///
+    pub def valueOf(i: Int32): ##java.lang.Integer =
+        import static java.lang.Integer.valueOf(Int32): ##java.lang.Integer \ {};
+        valueOf(i)
+
 }

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -492,4 +492,24 @@ mod Int64 {
         let maxi64 = Int32.toInt64(max.max);
         (valueOf(clamp(min = mini64, max = maxi64, x)) |> intValue)
 
+    ///
+    /// Get the primitive Int64 value from its object representation (i.e. ##java.lang.Long).
+    ///
+    /// This function is expected to be used when marshaling Int64s from Java. Generally in Flix
+    /// code you should not need to use `##java.lang.Long`.
+    ///
+    pub def longValue(i: ##java.lang.Long): Int64 =
+        import java.lang.Long.longValue(): Int64 \ {};
+        longValue(i)
+
+    ///
+    /// Convert an Int64 value to its object representation (i.e. ##java.lang.Long).
+    ///
+    /// This function is expected to be used when marshaling Int64s to Java. Generally in Flix
+    /// code you should not need to use `##java.lang.Long`.
+    ///
+    pub def valueOf(i: Int64): ##java.lang.Long =
+        import static java.lang.Long.valueOf(Int64): ##java.lang.Long \ {};
+        valueOf(i)
+
 }

--- a/main/src/library/Int8.flix
+++ b/main/src/library/Int8.flix
@@ -408,4 +408,25 @@ mod Int8 {
     pub def toBigDecimal(x: Int8): BigDecimal =
         import new java.math.BigDecimal(Int32): BigDecimal \ {} as fromInt32;
         Int8.toInt32(x) |> fromInt32
+
+    ///
+    /// Get the primitive Int8 value from its object representation (i.e. ##java.lang.Byte).
+    ///
+    /// This function is expected to be used when marshaling Int8s from Java. Generally in Flix
+    /// code you should not need to use `##java.lang.Byte`.
+    ///
+    pub def byteValue(i: ##java.lang.Byte): Int8 =
+        import java.lang.Byte.byteValue(): Int8 \ {};
+        byteValue(i)
+
+    ///
+    /// Convert an Int8 value to its object representation (i.e. ##java.lang.Byte).
+    ///
+    /// This function is expected to be used when marshaling Int8s to Java. Generally in Flix
+    /// code you should not need to use `##java.lang.Byte`.
+    ///
+    pub def valueOf(i: Int8): ##java.lang.Byte =
+        import static java.lang.Byte.valueOf(Int8): ##java.lang.Byte \ {};
+        valueOf(i)
+
 }

--- a/main/test/ca/uwaterloo/flix/library/TestChar.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestChar.flix
@@ -817,4 +817,45 @@ def forDigit10(): Bool = Char.forDigit(radix = 16, 10) == Some('a')
 @test
 def forDigit11(): Bool = Char.forDigit(radix = 16, 15) == Some('f')
 
+/////////////////////////////////////////////////////////////////////////////
+// charValue                                                               //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def charValue01(): Bool =
+    let c = Char.valueOf('0');
+    Char.charValue(c) == '0'
+
+@test
+def charValue02(): Bool =
+    let c = Char.valueOf('A');
+    Char.charValue(c) == 'A'
+
+@test
+def charValue03(): Bool =
+    let c = Char.valueOf('+');
+    Char.charValue(c) == '+'
+
+/////////////////////////////////////////////////////////////////////////////
+// valueOf                                                                 //
+/////////////////////////////////////////////////////////////////////////////
+
+@test
+def valueOf01(): Bool =
+    import java.lang.Character.equals(##java.lang.Object): Bool \ {};
+    let c = Char.valueOf('0');
+    equals(c, checked_cast(Char.valueOf('0')))
+
+@test
+def valueOf02(): Bool =
+    import java.lang.Character.equals(##java.lang.Object): Bool \ {};
+    let c = Char.valueOf('A');
+    equals(c, checked_cast(Char.valueOf('A')))
+
+@test
+def valueOf03(): Bool =
+    import java.lang.Character.equals(##java.lang.Object): Bool \ {};
+    let c = Char.valueOf('+');
+    equals(c, checked_cast(Char.valueOf('+')))
+
 }

--- a/main/test/ca/uwaterloo/flix/library/TestFloat32.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFloat32.flix
@@ -734,4 +734,45 @@ mod TestFloat32 {
     @test
     def pow05(): Bool = equalsEps(Float32.pow(5.0f32, 2.0f32), 25.0f32, 0.001f32)
 
+    /////////////////////////////////////////////////////////////////////////////
+    // floatValue                                                              //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def floatValue01(): Bool =
+        let d = Float32.valueOf(0.0f32);
+        Float32.floatValue(d) == 0.0f32
+
+    @test
+    def floatValue02(): Bool =
+        let d = Float32.valueOf(1.0f32);
+        Float32.floatValue(d) == 1.0f32
+
+    @test
+    def floatValue03(): Bool =
+        let d = Float32.valueOf(-1.0f32);
+        Float32.floatValue(d) == -1.0f32
+
+    /////////////////////////////////////////////////////////////////////////////
+    // valueOf                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def valueOf01(): Bool =
+        import java.lang.Float.equals(##java.lang.Object): Bool \ {};
+        let d = Float32.valueOf(0.0f32);
+        equals(d, checked_cast(Float32.valueOf(0.0f32)))
+
+    @test
+    def valueOf02(): Bool =
+        import java.lang.Float.equals(##java.lang.Object): Bool \ {};
+        let d = Float32.valueOf(1.0f32);
+        equals(d, checked_cast(Float32.valueOf(1.0f32)))
+
+    @test
+    def valueOf03(): Bool =
+        import java.lang.Float.equals(##java.lang.Object): Bool \ {};
+        let d = Float32.valueOf(-1.0f32);
+        equals(d, checked_cast(Float32.valueOf(-1.0f32)))
+
 }

--- a/main/test/ca/uwaterloo/flix/library/TestFloat64.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFloat64.flix
@@ -775,5 +775,45 @@ mod TestFloat64 {
 
     @test
     def exp03(): Bool = equalsEps(Float64.exp(5.0f64), 148.413159f64, 0.001f64)
+    /////////////////////////////////////////////////////////////////////////////
+    // doubleValue                                                             //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def doubleValue01(): Bool =
+        let d = Float64.valueOf(0.0f64);
+        Float64.doubleValue(d) == 0.0f64
+
+    @test
+    def doubleValue02(): Bool =
+        let d = Float64.valueOf(1.0f64);
+        Float64.doubleValue(d) == 1.0f64
+
+    @test
+    def doubleValue03(): Bool =
+        let d = Float64.valueOf(-1.0f64);
+        Float64.doubleValue(d) == -1.0f64
+
+    /////////////////////////////////////////////////////////////////////////////
+    // valueOf                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def valueOf01(): Bool =
+        import java.lang.Double.equals(##java.lang.Object): Bool \ {};
+        let d = Float64.valueOf(0.0f64);
+        equals(d, checked_cast(Float64.valueOf(0.0f64)))
+
+    @test
+    def valueOf02(): Bool =
+        import java.lang.Double.equals(##java.lang.Object): Bool \ {};
+        let d = Float64.valueOf(1.0f64);
+        equals(d, checked_cast(Float64.valueOf(1.0f64)))
+
+    @test
+    def valueOf03(): Bool =
+        import java.lang.Double.equals(##java.lang.Object): Bool \ {};
+        let d = Float64.valueOf(-1.0f64);
+        equals(d, checked_cast(Float64.valueOf(-1.0f64)))
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestInt16.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt16.flix
@@ -1124,4 +1124,45 @@ mod TestInt16 {
     @test
     def clampToInt808(): Bool = Int16.clampToInt8(min = 10i8, max = 0i8, 5i16) == 10i8      // Bad range
 
+    /////////////////////////////////////////////////////////////////////////////
+    // shortValue                                                              //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def shortValue01(): Bool =
+        let i = Int16.valueOf(0i16);
+        Int16.shortValue(i) == 0i16
+
+    @test
+    def shortValue02(): Bool =
+        let i = Int16.valueOf(1i16);
+        Int16.shortValue(i) == 1i16
+
+    @test
+    def shortValue03(): Bool =
+        let i = Int16.valueOf(-1i16);
+        Int16.shortValue(i) == -1i16
+
+    /////////////////////////////////////////////////////////////////////////////
+    // valueOf                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def valueOf01(): Bool =
+        import java.lang.Short.equals(##java.lang.Object): Bool \ {};
+        let i = Int16.valueOf(0i16);
+        equals(i, checked_cast(Int16.valueOf(0i16)))
+
+    @test
+    def valueOf02(): Bool =
+        import java.lang.Short.equals(##java.lang.Object): Bool \ {};
+        let i = Int16.valueOf(1i16);
+        equals(i, checked_cast(Int16.valueOf(1i16)))
+
+    @test
+    def valueOf03(): Bool =
+        import java.lang.Short.equals(##java.lang.Object): Bool \ {};
+        let i = Int16.valueOf(-1i16);
+        equals(i, checked_cast(Int16.valueOf(-1i16)))
+
 }

--- a/main/test/ca/uwaterloo/flix/library/TestInt32.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt32.flix
@@ -1169,4 +1169,45 @@ mod TestInt32 {
     @test
     def clampToInt1607(): Bool = Int32.clampToInt16(min = -100i16, max = 100i16, Int32.minValue()) == -100i16
 
+    /////////////////////////////////////////////////////////////////////////////
+    // intValue                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def intValue01(): Bool =
+        let i = Int32.valueOf(0);
+        Int32.intValue(i) == 0
+
+    @test
+    def intValue02(): Bool =
+        let i = Int32.valueOf(1);
+        Int32.intValue(i) == 1
+
+    @test
+    def intValue03(): Bool =
+        let i = Int32.valueOf(-1);
+        Int32.intValue(i) == -1
+
+    /////////////////////////////////////////////////////////////////////////////
+    // valueOf                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def valueOf01(): Bool =
+        import java.lang.Integer.equals(##java.lang.Object): Bool \ {};
+        let i = Int32.valueOf(0);
+        equals(i, checked_cast(Int32.valueOf(0)))
+
+    @test
+    def valueOf02(): Bool =
+        import java.lang.Integer.equals(##java.lang.Object): Bool \ {};
+        let i = Int32.valueOf(1);
+        equals(i, checked_cast(Int32.valueOf(1)))
+
+    @test
+    def valueOf03(): Bool =
+        import java.lang.Integer.equals(##java.lang.Object): Bool \ {};
+        let i = Int32.valueOf(-1);
+        equals(i, checked_cast(Int32.valueOf(-1)))
+
 }

--- a/main/test/ca/uwaterloo/flix/library/TestInt64.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt64.flix
@@ -1178,4 +1178,45 @@ mod TestInt64 {
     @test
     def clampToInt3207(): Bool = Int64.clampToInt32(min = -100, max = 100, Int64.minValue()) == -100
 
+    /////////////////////////////////////////////////////////////////////////////
+    // longValue                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def longValue01(): Bool =
+        let i = Int64.valueOf(0i64);
+        Int64.longValue(i) == 0i64
+
+    @test
+    def longValue02(): Bool =
+        let i = Int64.valueOf(1i64);
+        Int64.longValue(i) == 1i64
+
+    @test
+    def shortValue03(): Bool =
+        let i = Int64.valueOf(-1i64);
+        Int64.longValue(i) == -1i64
+
+    /////////////////////////////////////////////////////////////////////////////
+    // valueOf                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def valueOf01(): Bool =
+        import java.lang.Long.equals(##java.lang.Object): Bool \ {};
+        let i = Int64.valueOf(0i64);
+        equals(i, checked_cast(Int64.valueOf(0i64)))
+
+    @test
+    def valueOf02(): Bool =
+        import java.lang.Long.equals(##java.lang.Object): Bool \ {};
+        let i = Int64.valueOf(1i64);
+        equals(i, checked_cast(Int64.valueOf(1i64)))
+
+    @test
+    def valueOf03(): Bool =
+        import java.lang.Long.equals(##java.lang.Object): Bool \ {};
+        let i = Int64.valueOf(-1i64);
+        equals(i, checked_cast(Int64.valueOf(-1i64)))
+
 }

--- a/main/test/ca/uwaterloo/flix/library/TestInt8.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt8.flix
@@ -1081,4 +1081,45 @@ mod TestInt8 {
     @test
     def toBigDecimal05(): Bool = Int8.toBigDecimal(-128i8) == -128.0ff
 
+    /////////////////////////////////////////////////////////////////////////////
+    // byteValue                                                               //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def byteValue01(): Bool =
+        let i = Int8.valueOf(0i8);
+        Int8.byteValue(i) == 0i8
+
+    @test
+    def byteValue02(): Bool =
+        let i = Int8.valueOf(1i8);
+        Int8.byteValue(i) == 1i8
+
+    @test
+    def byteValue03(): Bool =
+        let i = Int8.valueOf(-1i8);
+        Int8.byteValue(i) == -1i8
+
+    /////////////////////////////////////////////////////////////////////////////
+    // valueOf                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def valueOf01(): Bool =
+        import java.lang.Byte.equals(##java.lang.Object): Bool \ {};
+        let i = Int8.valueOf(0i8);
+        equals(i, checked_cast(Int8.valueOf(0i8)))
+
+    @test
+    def valueOf02(): Bool =
+        import java.lang.Byte.equals(##java.lang.Object): Bool \ {};
+        let i = Int8.valueOf(1i8);
+        equals(i, checked_cast(Int8.valueOf(1i8)))
+
+    @test
+    def valueOf03(): Bool =
+        import java.lang.Byte.equals(##java.lang.Object): Bool \ {};
+        let i = Int8.valueOf(-1i8);
+        equals(i, checked_cast(Int8.valueOf(-1i8)))
+
 }


### PR DESCRIPTION
See issue #6426 

This PR add conversion functions to Char and the primitive number types to convert them to and from their Java corresponding Java objects. Converting to Java objects is necessary to store them in generic collections from `java.util` that can only store objects and not primitive types. 

`BigInt` and `BigDecimal` are not primitive types so don't need these conversion functions.

Possible design issues: 
1. Maybe these functions should go in `Adaptor`, though they would need name changes to distinguish the types.
2. If they stay in the current modules, maybe they should diverge from the Java naming for for `charValue`, `byteValue` etc.


Potential work todo - I haven't used the new `valueOf` functions at other places in their respective modules that are already importing and using Java's `valueOf`. Unless it's likely to be a performance hit, it would be nicer to use the new function rather than import the Java one. 
