### PR TITLE
fix: single argument enum tag display bug in LSP completion

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -257,7 +257,7 @@ sealed trait Completion {
       val args = (1 until arity + 1).map(i => s"?elem$i").mkString(", ")
       val snippet = if (args.isEmpty) name else s"$name($args)"
       CompletionItem(
-        label = CompletionUtils.getLabelForEnumTags(name, cas),
+        label = CompletionUtils.getLabelForEnumTags(name, cas, arity),
         sortText = Priority.normal(name),
         textEdit = TextEdit(context.range, snippet),
         detail = Some(enumSym.name),

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -52,11 +52,11 @@ object CompletionUtils {
 
   private def isUnitFunction(fparams: List[TypedAst.FormalParam]): Boolean = fparams.length == 1 && isUnitType(fparams(0).tpe)
 
-  def getLabelForEnumTags(name: String, cas: TypedAst.Case)(implicit flix: Flix): String = {
-    cas.tpe match {
-      case Type.Unit => name
-      case tpe: Type.Cst => s"$name(${FormatType.formatType(tpe)})"
-      case _ =>  s"$name${FormatType.formatType(cas.tpe)}"
+  def getLabelForEnumTags(name: String, cas: TypedAst.Case, arity: Int)(implicit flix: Flix): String = {
+    arity match {
+      case 0 => name
+      case 1 => s"$name(${FormatType.formatType(cas.tpe)})"
+      case _ => s"$name${FormatType.formatType(cas.tpe)}"
     }
   }
 


### PR DESCRIPTION
Fixes #6025 

...which is caused by incorrectly adding surrounding parentheses for Enum tags. From the commit history it seems that the intended logic correct but the implementation isn't ([comment](https://github.com/flix/flix/pull/5977/commits/dfe95cdfc76a5e1c0aa92f91e7d4ded1a429a397#r1197611912)).

This changes the logic so that instead of looking at the type of the arguments, we just look at the arity and would only add parentheses when arity is 1.

Screenshot -
<img width="414" alt="image" src="https://github.com/flix/flix/assets/940823/34521dcb-4224-4344-8ab7-a5b6b8e7f027">
