### PR TITLE
fix: recurse in `filterItems` in HTML documentation

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -211,7 +211,7 @@ object HtmlDocumentor {
         sym,
         parent,
         uses,
-        submodules,
+        submodules.map(filterItems),
         classes.filter(c => c.modifiers.isPublic && !c.ann.isInternal).map(filterClass),
         enums.filter(e => e.mod.isPublic && !e.ann.isInternal),
         effects.filter(e => e.mod.isPublic && !e.ann.isInternal),


### PR DESCRIPTION
Fixes #6464