### PR TITLE
docs: fix ambiguity in `Map.empty`

### DIFF
--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -156,7 +156,7 @@ mod Map {
     ///
     /// Returns the empty map.
     ///
-    /// `Map#{}` is syntactic sugar for `empty` (`Map#{} = empty()`).
+    /// `Map#{}` is syntactic sugar for `empty` (`Map#{} == empty()`).
     ///
     pub def empty(): Map[k, v] = Map(RedBlackTree.empty())
 


### PR DESCRIPTION
I found this quite confusing when reading the docs, since the equality character is meant as a comparison and not an assignment / binding. So I think when reading code docs, it's better to have consistency between the syntax of the language and the meaning of the docs.