### PR TITLE
fix: differentiate uses of item's name and qualified name in HTML documentation

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -77,7 +77,7 @@ object HtmlDocumentor {
 
     def visitMod(mod: Module): Unit = {
       val out = documentModule(mod)
-      writeDocFile(mod.fileName(), out)
+      writeDocFile(mod.fileName, out)
 
       mod.submodules.foreach(visitMod)
       mod.classes.foreach(visitClass)
@@ -87,7 +87,7 @@ object HtmlDocumentor {
 
     def visitClass(clazz: Class): Unit = {
       val out = documentClass(clazz)
-      writeDocFile(clazz.fileName(), out)
+      writeDocFile(clazz.fileName, out)
 
       clazz.companionMod.foreach { mod =>
         mod.submodules.foreach(visitMod)
@@ -99,7 +99,7 @@ object HtmlDocumentor {
 
     def visitEffect(eff: Effect): Unit = {
       val out = documentEffect(eff)
-      writeDocFile(eff.fileName(), out)
+      writeDocFile(eff.fileName, out)
 
       eff.companionMod.foreach { mod =>
         mod.submodules.foreach(visitMod)
@@ -111,7 +111,7 @@ object HtmlDocumentor {
 
     def visitEnum(enm: Enum): Unit = {
       val out = documentEnum(enm)
-      writeDocFile(enm.fileName(), out)
+      writeDocFile(enm.fileName, out)
 
       enm.companionMod.foreach { mod =>
         mod.submodules.foreach(visitMod)
@@ -126,50 +126,62 @@ object HtmlDocumentor {
   }
 
   /**
-    * Get the display name of the module.
-    *
-    * See also `moduleFileName` for the file name of the module.
+    * Get the shortest name of the module symbol, e.g. 'StdOut'.
     */
-  private def moduleName(sym: Symbol.ModuleSym): String = if (sym.isRoot) RootNS else sym.toString
+  private def moduleName(sym: Symbol.ModuleSym): String = sym.ns.lastOption.getOrElse(RootNS)
 
   /**
-    * Get the file name of the module.
+    * Get the fully qualified name of the module symbol, e.g. 'System.StdOut'.
+    */
+  private def moduleQualifiedName(sym: Symbol.ModuleSym): String = if (sym.isRoot) RootNS else sym.toString
+
+  /**
+    * Get the file name of the module symbol, e.g. 'System.StdOut.html'.
     */
   private def moduleFileName(sym: Symbol.ModuleSym): String = s"${if (sym.isRoot) RootFileName else sym.toString}.html"
 
   /**
-    * Get the display name of the class.
-    *
-    * See also `classFileName` for the file name of the class.
+    * Get the shortest name of the class symbol, e.g. 'StdOut'.
     */
-  private def className(sym: Symbol.ClassSym): String = sym.toString
+  private def className(sym: Symbol.ClassSym): String = sym.name
 
   /**
-    * Get the file name of the class.
+    * Get the fully qualified name of the class symbol, e.g. 'System.StdOut'.
+    */
+  private def classQualifiedName(sym: Symbol.ClassSym): String = sym.toString
+
+  /**
+    * Get the file name of the class symbol, e.g. 'System.StdOut.html'.
     */
   private def classFileName(sym: Symbol.ClassSym): String = s"${sym.toString}.html"
 
   /**
-    * Get the display name of the effect.
-    *
-    * See also `effectFileName` for the file name of the effect.
+    * Get the shortest name of the effect symbol, e.g. 'StdOut'.
     */
-  private def effectName(sym: Symbol.EffectSym): String = sym.toString
+  private def effectName(sym: Symbol.EffectSym): String = sym.name
 
   /**
-    * Get the file name of the effect.
+    * Get the fully qualified name of the effect symbol, e.g. 'System.StdOut'.
+    */
+  private def effectQualifiedName(sym: Symbol.EffectSym): String = sym.toString
+
+  /**
+    * Get the file name of the class symbol, e.g. 'System.StdOut.html'.
     */
   private def effectFileName(sym: Symbol.EffectSym): String = s"${sym.toString}.html"
 
   /**
-    * Get the display name of the enum.
-    *
-    * See also `enumFileName` for the file name of the enum.
+    * Get the shortest name of the enum symbol, e.g. 'StdOut'.
     */
-  private def enumName(sym: Symbol.EnumSym): String = sym.toString
+  private def enumName(sym: Symbol.EnumSym): String = sym.name
 
   /**
-    * Get the file name of the enum.
+    * Get the fully qualified name of the enum symbol, e.g. 'System.StdOut'.
+    */
+  private def enumQualifiedName(sym: Symbol.EnumSym): String = sym.toString
+
+  /**
+    * Get the file name of the enum symbol, e.g. 'System.StdOut.html'.
     */
   private def enumFileName(sym: Symbol.EnumSym): String = s"${sym.toString}.html"
 
@@ -396,13 +408,13 @@ object HtmlDocumentor {
   private def documentModule(mod: Module)(implicit flix: Flix): String = {
     implicit val sb: StringBuilder = new StringBuilder()
 
-    val sortedClasses = mod.classes.sortBy(_.name())
-    val sortedEnums = mod.enums.sortBy(_.name())
-    val sortedEffs = mod.effects.sortBy(_.name())
+    val sortedClasses = mod.classes.sortBy(_.name)
+    val sortedEnums = mod.enums.sortBy(_.name)
+    val sortedEffs = mod.effects.sortBy(_.name)
     val sortedTypeAliases = mod.typeAliases.sortBy(_.sym.name)
     val sortedDefs = mod.defs.sortBy(_.sym.name)
 
-    sb.append(mkHead(mod.name()))
+    sb.append(mkHead(mod.qualifiedName))
     sb.append("<body class='no-script'>")
 
     docThemeToggle()
@@ -415,17 +427,17 @@ object HtmlDocumentor {
       docSideBarSection(
         "Classes",
         sortedClasses,
-        (c: Class) => sb.append(s"<a href='${escUrl(c.fileName())}'>${esc(c.name())}</a>"),
+        (c: Class) => sb.append(s"<a href='${escUrl(c.fileName)}'>${esc(c.name)}</a>"),
       )
       docSideBarSection(
         "Effects",
         sortedEffs,
-        (e: Effect) => sb.append(s"<a href='${escUrl(e.fileName())}'>${esc(e.name())}</a>"),
+        (e: Effect) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
         "Enums",
         sortedEnums,
-        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName())}'>${esc(e.name())}</a>"),
+        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
         "Type Aliases",
@@ -440,7 +452,7 @@ object HtmlDocumentor {
     }
 
     sb.append("<main>")
-    sb.append(s"<h1>${esc(mod.name())}</h1>")
+    sb.append(s"<h1>${esc(mod.qualifiedName)}</h1>")
     docSection("Type Aliases", sortedTypeAliases, docTypeAlias)
     docSection("Definitions", sortedDefs, docDef)
     sb.append("</main>")
@@ -462,13 +474,13 @@ object HtmlDocumentor {
     val sortedClassDefs = clazz.defs.sortBy(_.sym.name)
 
     val mod = clazz.companionMod
-    val sortedClasses = mod.map(_.classes).getOrElse(Nil).sortBy(_.name())
-    val sortedEnums = mod.map(_.enums).getOrElse(Nil).sortBy(_.name())
-    val sortedEffs = mod.map(_.effects).getOrElse(Nil).sortBy(_.name())
+    val sortedClasses = mod.map(_.classes).getOrElse(Nil).sortBy(_.name)
+    val sortedEnums = mod.map(_.enums).getOrElse(Nil).sortBy(_.name)
+    val sortedEffs = mod.map(_.effects).getOrElse(Nil).sortBy(_.name)
     val sortedTypeAliases = mod.map(_.typeAliases).getOrElse(Nil).sortBy(_.sym.name)
     val sortedModuleDefs = mod.map(_.defs).getOrElse(Nil).sortBy(_.sym.name)
 
-    sb.append(mkHead(clazz.name()))
+    sb.append(mkHead(clazz.qualifiedName))
     sb.append("<body class='no-script'>")
 
     docThemeToggle()
@@ -489,17 +501,17 @@ object HtmlDocumentor {
       docSideBarSection(
         "Classes",
         sortedClasses,
-        (c: Class) => sb.append(s"<a href='${escUrl(c.fileName())}'>${esc(c.name())}</a>"),
+        (c: Class) => sb.append(s"<a href='${escUrl(c.fileName)}'>${esc(c.name)}</a>"),
       )
       docSideBarSection(
         "Effects",
         sortedEffs,
-        (e: Effect) => sb.append(s"<a href='${escUrl(e.fileName())}'>${esc(e.name())}</a>"),
+        (e: Effect) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
         "Enums",
         sortedEnums,
-        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName())}'>${esc(e.name())}</a>"),
+        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
         "Type Aliases",
@@ -514,14 +526,14 @@ object HtmlDocumentor {
     }
 
     sb.append("<main>")
-    sb.append(s"<h1>${esc(clazz.name())}</h1>")
+    sb.append(s"<h1>${esc(clazz.qualifiedName)}</h1>")
 
     sb.append(s"<div class='box'>")
     docAnnotations(clazz.decl.ann)
     sb.append("<div class='decl'>")
     sb.append("<code>")
     sb.append("<span class='keyword'>class</span> ")
-    sb.append(s"<span class='name'>${esc(clazz.name())}</span>")
+    sb.append(s"<span class='name'>${esc(clazz.name)}</span>")
     docTypeParams(List(clazz.decl.tparam))
     docTypeConstraints(clazz.decl.superClasses)
     sb.append("</code>")
@@ -554,13 +566,13 @@ object HtmlDocumentor {
     val sortedOps = eff.decl.ops.sortBy(_.sym.name)
 
     val mod = eff.companionMod
-    val sortedClasses = mod.map(_.classes).getOrElse(Nil).sortBy(_.name())
-    val sortedEnums = mod.map(_.enums).getOrElse(Nil).sortBy(_.name())
-    val sortedEffs = mod.map(_.effects).getOrElse(Nil).sortBy(_.name())
+    val sortedClasses = mod.map(_.classes).getOrElse(Nil).sortBy(_.name)
+    val sortedEnums = mod.map(_.enums).getOrElse(Nil).sortBy(_.name)
+    val sortedEffs = mod.map(_.effects).getOrElse(Nil).sortBy(_.name)
     val sortedTypeAliases = mod.map(_.typeAliases).getOrElse(Nil).sortBy(_.sym.name)
     val sortedModuleDefs = mod.map(_.defs).getOrElse(Nil).sortBy(_.sym.name)
 
-    sb.append(mkHead(eff.name()))
+    sb.append(mkHead(eff.qualifiedName))
     sb.append("<body class='no-script'>")
 
     docThemeToggle()
@@ -575,17 +587,17 @@ object HtmlDocumentor {
       docSideBarSection(
         "Classes",
         sortedClasses,
-        (c: Class) => sb.append(s"<a href='${escUrl(c.fileName())}'>${esc(c.name())}</a>"),
+        (c: Class) => sb.append(s"<a href='${escUrl(c.fileName)}'>${esc(c.name)}</a>"),
       )
       docSideBarSection(
         "Effects",
         sortedEffs,
-        (e: Effect) => sb.append(s"<a href='${escUrl(e.fileName())}'>${esc(e.name())}</a>"),
+        (e: Effect) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
         "Enums",
         sortedEnums,
-        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName())}'>${esc(e.name())}</a>"),
+        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
         "Type Aliases",
@@ -600,14 +612,14 @@ object HtmlDocumentor {
     }
 
     sb.append("<main>")
-    sb.append(s"<h1>${esc(eff.name())}</h1>")
+    sb.append(s"<h1>${esc(eff.qualifiedName)}</h1>")
 
-    sb.append(s"<div class='box' id='eff-${esc(eff.name())}'>")
+    sb.append(s"<div class='box' id='eff-${esc(eff.name)}'>")
     docAnnotations(eff.decl.ann)
     sb.append("<div class='decl'>")
     sb.append("<code>")
     sb.append("<span class='keyword'>eff</span> ")
-    sb.append(s"<span class='name'>${esc(eff.name())}</span>")
+    sb.append(s"<span class='name'>${esc(eff.name)}</span>")
     sb.append("</code>")
     docActions(None, eff.decl.loc)
     sb.append("</div>")
@@ -633,13 +645,13 @@ object HtmlDocumentor {
     implicit val sb: StringBuilder = new StringBuilder()
 
     val mod = enm.companionMod
-    val sortedClasses = mod.map(_.classes).getOrElse(Nil).sortBy(_.name())
-    val sortedEnums = mod.map(_.enums).getOrElse(Nil).sortBy(_.name())
-    val sortedEffs = mod.map(_.effects).getOrElse(Nil).sortBy(_.name())
+    val sortedClasses = mod.map(_.classes).getOrElse(Nil).sortBy(_.name)
+    val sortedEnums = mod.map(_.enums).getOrElse(Nil).sortBy(_.name)
+    val sortedEffs = mod.map(_.effects).getOrElse(Nil).sortBy(_.name)
     val sortedTypeAliases = mod.map(_.typeAliases).getOrElse(Nil).sortBy(_.sym.name)
     val sortedModuleDefs = mod.map(_.defs).getOrElse(Nil).sortBy(_.sym.name)
 
-    sb.append(mkHead(enm.name()))
+    sb.append(mkHead(enm.qualifiedName))
     sb.append("<body class='no-script'>")
 
     docThemeToggle()
@@ -650,17 +662,17 @@ object HtmlDocumentor {
       docSideBarSection(
         "Classes",
         sortedClasses,
-        (c: Class) => sb.append(s"<a href='${escUrl(c.fileName())}'>${esc(c.name())}</a>"),
+        (c: Class) => sb.append(s"<a href='${escUrl(c.fileName)}'>${esc(c.name)}</a>"),
       )
       docSideBarSection(
         "Effects",
         sortedEffs,
-        (e: Effect) => sb.append(s"<a href='${escUrl(e.fileName())}'>${esc(e.name())}</a>"),
+        (e: Effect) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
         "Enums",
         sortedEnums,
-        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName())}'>${esc(e.name())}</a>"),
+        (e: Enum) => sb.append(s"<a href='${escUrl(e.fileName)}'>${esc(e.name)}</a>"),
       )
       docSideBarSection(
         "Type Aliases",
@@ -675,14 +687,14 @@ object HtmlDocumentor {
     }
 
     sb.append("<main>")
-    sb.append(s"<h1>${esc(enm.name())}</h1>")
+    sb.append(s"<h1>${esc(enm.qualifiedName)}</h1>")
 
-    sb.append(s"<div class='box' id='enum-${esc(enm.name())}'>")
+    sb.append(s"<div class='box' id='enum-${esc(enm.name)}'>")
     docAnnotations(enm.decl.ann)
     sb.append("<div class='decl'>")
     sb.append("<code>")
     sb.append("<span class='keyword'>enum</span> ")
-    sb.append(s"<span class='name'>${esc(enm.name())}</span>")
+    sb.append(s"<span class='name'>${esc(enm.name)}</span>")
     docTypeParams(enm.decl.tparams)
     docDerivations(enm.decl.derives)
     sb.append("</code>")
@@ -789,7 +801,7 @@ object HtmlDocumentor {
         parentMod.effects ++
         parentMod.enums
 
-    val sortedItems = subItems.sortBy(_.name())
+    val sortedItems = subItems.sortBy(_.name)
 
     if (sortedItems.isEmpty) {
       return
@@ -799,7 +811,7 @@ object HtmlDocumentor {
     sb.append("<ul class='Modules'>")
     for (m <- sortedItems) {
       sb.append("<li>")
-      sb.append(s"<a href='${escUrl(m.fileName())}'>${esc(m.name())}</a>")
+      sb.append(s"<a href='${escUrl(m.fileName)}'>${esc(m.name)}</a>")
       sb.append("</li>")
     }
     sb.append("</ul>")
@@ -1314,9 +1326,14 @@ object HtmlDocumentor {
     * An item is a unit that is typically output to its own HTML file.
     */
   private sealed trait Item {
-    def name(): String
+    /** The shortest name of the item, e.g. 'StdOut' */
+    def name: String
 
-    def fileName(): String
+    /** The fully qualified name of the item, e.g. 'System.StdOut' */
+    def qualifiedName: String
+
+    /** The file name of the item, e.g. 'System.StdOut.html' */
+    def fileName: String
   }
   /**
     * A represention of a module that's easier to work with while generating documention.
@@ -1330,9 +1347,11 @@ object HtmlDocumentor {
                             enums: List[Enum],
                             typeAliases: List[TypedAst.TypeAlias],
                             defs: List[TypedAst.Def]) extends Item {
-    override def name(): String = moduleName(this.sym)
+    override def name: String = moduleName(this.sym)
 
-    override def fileName(): String = moduleFileName(this.sym)
+    override def qualifiedName: String = moduleQualifiedName(this.sym)
+
+    override def fileName: String = moduleFileName(this.sym)
   }
 
   /**
@@ -1344,9 +1363,11 @@ object HtmlDocumentor {
                            instances: List[TypedAst.Instance],
                            parent: Symbol.ModuleSym,
                            companionMod: Option[Module]) extends Item {
-    override def name(): String = className(this.decl.sym)
+    override def name: String = className(this.decl.sym)
 
-    override def fileName(): String = classFileName(this.decl.sym)
+    override def qualifiedName: String = classQualifiedName(this.decl.sym)
+
+    override def fileName: String = classFileName(this.decl.sym)
   }
 
   /**
@@ -1355,9 +1376,11 @@ object HtmlDocumentor {
   private case class Effect(decl: TypedAst.Effect,
                             parent: Symbol.ModuleSym,
                             companionMod: Option[Module]) extends Item {
-    override def name(): String = effectName(this.decl.sym)
+    override def name: String = effectName(this.decl.sym)
 
-    override def fileName(): String = effectFileName(this.decl.sym)
+    override def qualifiedName: String = effectQualifiedName(this.decl.sym)
+
+    override def fileName: String = effectFileName(this.decl.sym)
   }
 
   /**
@@ -1366,8 +1389,10 @@ object HtmlDocumentor {
   private case class Enum(decl: TypedAst.Enum,
                           parent: Symbol.ModuleSym,
                           companionMod: Option[Module]) extends Item {
-    override def name(): String = enumName(this.decl.sym)
+    override def name: String = enumName(this.decl.sym)
 
-    override def fileName(): String = enumFileName(this.decl.sym)
+    override def qualifiedName: String = enumQualifiedName(this.decl.sym)
+
+    override def fileName: String = enumFileName(this.decl.sym)
   }
 }


### PR DESCRIPTION
Fixes #6484