### PR TITLE
fix: handle nested block-comments termniation within strings in `Lexer` 

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -872,6 +872,9 @@ object Lexer {
    * If this level is reached a `TokenKind.Err` is returned.
    * A block-comment might also be unterminated if there is less terminations than levels of nesting.
    * In this case a `TokenKind.Err` is returned as well.
+   * Also note cases like '/* def f(): String = "* /" */'.
+   * Since a string containing either "/ *" or "* /"is treated as a regular string,
+   * acceptBlockComment must keep track of whether it is within a string to ignore nesting or termination.
    */
   private def acceptBlockComment()(implicit s: State): TokenKind = {
     var level = 1

--- a/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
@@ -218,4 +218,16 @@ class TestLexer extends AnyFunSuite with TestUtils {
     val result = compile(input, Options.TestWithLibNix)
     expectError[LexerError.StringInterpolationTooDeep](result)
   }
+
+  test("Lexer.BlockCommentTerminationInString.01") {
+    val input = """ /* def example(): String = "*//" */ """
+    val result = compile(input, Options.TestWithLibNix)
+    rejectError[LexerError](result)
+  }
+
+  test("Lexer.BlockCommentOpeningInString.01") {
+    val input = """ /* def example(): String = "//*" */ """
+    val result = compile(input, Options.TestWithLibNix)
+    expectSuccess(result)
+  }
 }

--- a/main/test/ca/uwaterloo/flix/library/testdata/outfile01.bin
+++ b/main/test/ca/uwaterloo/flix/library/testdata/outfile01.bin
@@ -1,0 +1,1 @@
+Hello World!


### PR DESCRIPTION
From the discussion here https://github.com/flix/flix/discussions/6531 some tricky cases were found:
```
/* def example(): String = "*//" */
/* def example(): String = "//*" */
```
These should both lex to block comments.

This PR makes sure this is the case.