### PR TITLE
experiment: use `VirtualThread`s for `parMap`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.scala-lang:scala-library:2.13.11!!'
-    implementation 'org.scala-lang:scala-reflect:2.13.11!!'
+    implementation 'org.scala-lang:scala-library:2.13.12!!'
+    implementation 'org.scala-lang:scala-reflect:2.13.12!!'
 
     implementation('org.java-websocket:Java-WebSocket:1.5.3')
     implementation('org.jline:jline:3.22.0')
@@ -46,10 +46,10 @@ tasks.withType(ScalaCompile) {
             "-language:postfixOps",
             "-Xfatal-warnings",
             "-Ypatmat-exhaust-depth", "400",
-            "-release", "11"
+            "-release", "21"
     ]
-    compileScala.sourceCompatibility = 11
-    compileScala.targetCompatibility = 11
+    compileScala.sourceCompatibility = 21
+    compileScala.targetCompatibility = 21
 }
 
 sourceSets {


### PR DESCRIPTION
Performance before:

```
====================== Flix Compiler Throughput ======================

Throughput (best): 33.902 lines/sec (with 24 threads.)

  min:  7.255, max: 33.902, avg: 28.358, median: 31.888

  The highest throughput was in iteration: 8 (out of 10).
  The ratio between the best and worst iteration was: 4,7x.

Finished 10 iterations on 65.953 lines of code in 28 seconds.
```

Performance after:

```
====================== Flix Compiler Throughput ======================

Throughput (best): 35.641 lines/sec (with 24 threads.)

  min:  7.418, max: 35.641, avg: 29.879, median: 34.401

  The highest throughput was in iteration: 9 (out of 10).
  The ratio between the best and worst iteration was: 4,8x.

Finished 10 iterations on 65.953 lines of code in 27 seconds.
```