### PR TITLE
refactor: rename `ParOps.mapValues` to `ParOps.parMapValues`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -27,7 +27,7 @@ object Desugar {
     * Performs desugaring on `program`.
     */
   def run(program: WeededAst.Root)(implicit flix: Flix): DesugaredAst.Root = flix.phase("Desugar") {
-    val units = ParOps.mapValues(program.units)(visitUnit)
+    val units = ParOps.parMapValues(program.units)(visitUnit)
     DesugaredAst.Root(units, program.entryPoint, program.names)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -151,7 +151,7 @@ object TypeReconstruction {
   private def visitDefs(root: KindedAst.Root, substs: Map[Symbol.DefnSym, Substitution], oldRoot: TypedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Map[Symbol.DefnSym, TypedAst.Def] = {
     flix.subphase("Defs") {
       val (staleDefs, freshDefs) = changeSet.partition(root.defs, oldRoot.defs)
-      ParOps.mapValues(staleDefs) {
+      ParOps.parMapValues(staleDefs) {
         case defn => visitDef(defn, root, substs(defn.sym))
       } ++ freshDefs
     }
@@ -163,7 +163,7 @@ object TypeReconstruction {
   private def visitClasses(root: KindedAst.Root, defSubsts: Map[Symbol.DefnSym, Substitution], sigSubsts: Map[Symbol.SigSym, Substitution], oldRoot: TypedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Map[Symbol.ClassSym, TypedAst.Class] = {
     flix.subphase("Classes") {
       val (staleClasses, freshClasses) = changeSet.partition(root.classes, oldRoot.classes)
-      ParOps.mapValues(staleClasses)(visitClass(_, root, defSubsts, sigSubsts)) ++ freshClasses
+      ParOps.parMapValues(staleClasses)(visitClass(_, root, defSubsts, sigSubsts)) ++ freshClasses
     }
   }
 
@@ -172,7 +172,7 @@ object TypeReconstruction {
     */
   private def visitInstances(root: KindedAst.Root, defSubsts: Map[Symbol.DefnSym, Substitution])(implicit flix: Flix): Map[Symbol.ClassSym, List[TypedAst.Instance]] = {
     flix.subphase("Instances") {
-      ParOps.mapValues(root.instances) {
+      ParOps.parMapValues(root.instances) {
         case insts => insts.map(visitInstance(_, root, defSubsts))
       }
     }

--- a/main/src/ca/uwaterloo/flix/util/ParOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/ParOps.scala
@@ -47,7 +47,7 @@ object ParOps {
     * Apply the given function `f` to each value in the map `m` in parallel.
     */
   @inline
-  def mapValues[K, A, B](m: Map[K, A])(f: A => B)(implicit flix: Flix): Map[K, B] =
+  def parMapValues[K, A, B](m: Map[K, A])(f: A => B)(implicit flix: Flix): Map[K, B] =
     parMap(m) {
       case (k, v) => (k, f(v))
     }.toMap


### PR DESCRIPTION
For consistency