### PR TITLE
refactor: allow `trait` and `class` as keywords. Update stdlib, examples and main.test.flix tests to use `trait`.

### DIFF
--- a/examples/deriving-traits.flix
+++ b/examples/deriving-traits.flix
@@ -1,4 +1,4 @@
-/// We derive the type classes Eq, Order, and ToString for the enum Month
+/// We derive the traits Eq, Order, and ToString for the enum Month
 enum Month with Eq, Order, ToString {
     case January
     case February
@@ -17,7 +17,7 @@ enum Month with Eq, Order, ToString {
 type alias Year = Int32
 type alias Day = Int32
 
-/// The Date type derives the type classes Eq and Order
+/// The Date type derives the traits Eq and Order
 enum Date(Year, Month, Day) with Eq, Order
 
 /// We implement our own instance of ToString for Date
@@ -28,10 +28,10 @@ instance ToString[Date] {
         "${d} ${m}, ${y}"
 }
 
-/// Thanks to the Eq and Order type classes, we can easily compare dates.
+/// Thanks to the Eq and Order traits, we can easily compare dates.
 def earlierDate(d1: Date, d2: Date): Date = Order.min(d1, d2)
 
-/// Thanks to the ToString type class, we can easily convert dates to strings.
+/// Thanks to the ToString trait, we can easily convert dates to strings.
 def printDate(d: Date): Unit \ IO =
     let message = "The date is ${d}!";
     println(message)

--- a/examples/larger-examples/restrictable-variants/colors.flix
+++ b/examples/larger-examples/restrictable-variants/colors.flix
@@ -8,7 +8,7 @@ mod Colors {
 
     // To run this function press the floating "Run" button right below these
     // three lines. This can be done for any function that is `pub` and does not
-    // take arguments. (It doesnt not appear until the code is sucessfully compiled)
+    // take arguments. (It doesnt not appear until the code is successfully compiled)
     pub def main(): Unit \ IO = {
         // create the color red
         let red = Color.Red;
@@ -93,7 +93,7 @@ mod Colors {
 
 }
 
-// Type Class Instances
+// Trait Instances
 
 instance ToString[Colors.Color[i]] {
     pub def toString(x: Colors.Color[i]): String = choose x {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -335,7 +335,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     def Class: Rule1[ParsedAst.Declaration] = {
       def Head = rule {
-        Documentation ~ Annotations ~ Modifiers ~ SP ~ keyword("class") ~ WS ~ Names.Class ~ optWS ~ "[" ~ optWS ~ TypeParam ~ optWS ~ "]" ~ WithClause
+        Documentation ~ Annotations ~ Modifiers ~ SP ~ (keyword("trait") | keyword("class")) ~ WS ~ Names.Class ~ optWS ~ "[" ~ optWS ~ TypeParam ~ optWS ~ "]" ~ WithClause
       }
 
       def EmptyBody = namedRule("ClassBody") {

--- a/main/src/library/Add.flix
+++ b/main/src/library/Add.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for addition.
+/// A trait for addition.
 ///
-pub class Add[a] {
+pub trait Add[a] {
     ///
     /// Returns the sum of `x` and `y`.
     ///

--- a/main/src/library/Applicative.flix
+++ b/main/src/library/Applicative.flix
@@ -15,7 +15,7 @@
  */
 
 ///
-/// A type class for functors that support application, i.e. allow to:
+/// A trait for functors that support application, i.e. allow to:
 ///
 /// - Make an applicative value out of a normal value (embed it into a default context), e.g. embed `5` into `Some(5)`.
 /// - Apply a function-type applicative to a matching argument-type applicative, resulting in an applicative of
@@ -34,7 +34,7 @@
 ///     `ap(f: m[a -> b \ e], x: m[a]): m[b] \ ef = map2(identity, f, x)`
 ///     `map2(f: a -> b -> c \ e, x: m[a], y: m[b]): m[c] \ ef = ap(Functor.map(f, x), y)`
 ///
-pub lawful class Applicative[m : Type -> Type] with Functor[m] {
+pub lawful trait Applicative[m : Type -> Type] with Functor[m] {
     ///
     /// Puts `x` into a default context.
     ///

--- a/main/src/library/BigDecimal.flix
+++ b/main/src/library/BigDecimal.flix
@@ -17,7 +17,7 @@
 
 /// Represents arbitrary-precision signed decimal numbers.
 /// The representation consists of both a "value" and a "scale". Standard
-/// equality (`==` and the `Eq` typeclass) consider both value and scale,
+/// equality (`==` and the `Eq` trait) consider both value and scale,
 /// numerical equality (are the values the same after the scales have been
 /// normalized) is provided by the function `numericEquals`.
 mod BigDecimal {

--- a/main/src/library/Closeable.flix
+++ b/main/src/library/Closeable.flix
@@ -15,8 +15,8 @@
  */
 
 ///
-/// A type class for types that can be closed.
+/// A trait for types that can be closed.
 ///
-pub class Closeable[a] {
+pub trait Closeable[a] {
     pub def close(x: a): Unit \ IO
 }

--- a/main/src/library/Collectable.flix
+++ b/main/src/library/Collectable.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A class representing collections that can be produced from an Iterator.
+/// A trait representing collections that can be produced from an Iterator.
 ///
-pub class Collectable[m: Type -> Type] {
+pub trait Collectable[m: Type -> Type] {
 
     ///
     /// Run an Iterator collecting the results.

--- a/main/src/library/CommutativeGroup.flix
+++ b/main/src/library/CommutativeGroup.flix
@@ -15,12 +15,12 @@
  */
 
 ///
-/// A type class for types that form a commutative group (abelian group)
+/// A trait for types that form a commutative group (abelian group)
 /// i.e. groups where the `combine` function is commutative.
 ///
 /// The default instances for number define the additive inverse in the real numbers.
 ///
-pub lawful class CommutativeGroup[a] with Group[a], CommutativeMonoid[a] {}
+pub lawful trait CommutativeGroup[a] with Group[a], CommutativeMonoid[a] {}
 
 instance CommutativeGroup[Unit]
 

--- a/main/src/library/CommutativeMonoid.flix
+++ b/main/src/library/CommutativeMonoid.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for types that form a commutative monoid.
+/// A trait for types that form a commutative monoid.
 ///
-pub lawful class CommutativeMonoid[a] with Monoid[a] {
+pub lawful trait CommutativeMonoid[a] with Monoid[a] {
 
     ///
     /// Returns a neutral element.

--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for types that form a commutative semigroup.
+/// A trait for types that form a commutative semigroup.
 ///
-pub lawful class CommutativeSemiGroup[a] with SemiGroup[a] {
+pub lawful trait CommutativeSemiGroup[a] with SemiGroup[a] {
 
     ///
     /// An associative & commutative binary operation on `a`.

--- a/main/src/library/Div.flix
+++ b/main/src/library/Div.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for division.
+/// A trait for division.
 ///
-pub class Div[a] {
+pub trait Div[a] {
     ///
     /// Returns `x` divided by `y`.
     ///

--- a/main/src/library/Eq.flix
+++ b/main/src/library/Eq.flix
@@ -17,9 +17,9 @@
 use Bool.{==>, <==>}
 
 ///
-/// A type class for equality and inequality.
+/// A trait for equality and inequality.
 ///
-pub lawful class Eq[a] {
+pub lawful trait Eq[a] {
 
     ///
     /// Returns `true` if and only if `x` is equal to `y`.

--- a/main/src/library/Filterable.flix
+++ b/main/src/library/Filterable.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for filtering container functors.
+/// A trait for filtering container functors.
 ///
-pub class Filterable[m : Type -> Type] with Functor[m] {
+pub trait Filterable[m : Type -> Type] with Functor[m] {
 
     ///
     /// Applies the partial function `f` to every element in `x` collecting the results.

--- a/main/src/library/Fixpoint/PredSymsOf.flix
+++ b/main/src/library/Fixpoint/PredSymsOf.flix
@@ -19,9 +19,9 @@ mod Fixpoint {
     use Fixpoint.Shared.PredSym
 
     ///
-    /// A type class for types that contain predicate symbols.
+    /// A trait for types that contain predicate symbols.
     ///
-    pub class PredSymsOf[t] {
+    pub trait PredSymsOf[t] {
         pub def predSymsOf(x: t): Set[PredSym]
     }
 }

--- a/main/src/library/Fixpoint/SubstitutePredSym.flix
+++ b/main/src/library/Fixpoint/SubstitutePredSym.flix
@@ -19,9 +19,9 @@ mod Fixpoint {
     use Fixpoint.Shared.PredSym
 
     ///
-    /// A type class for types with predicate symbols that can be substituted.
+    /// A trait for types with predicate symbols that can be substituted.
     ///
-    pub class SubstitutePredSym[t] {
+    pub trait SubstitutePredSym[t] {
         pub def substitute(x: t, s: Map[PredSym, PredSym]): t
     }
 

--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for data structures that can be folded.
+/// A trait for data structures that can be folded.
 ///
-pub class Foldable[t : Type -> Type] {
+pub trait Foldable[t : Type -> Type] {
 
     ///
     /// Left-associative fold of a structure.

--- a/main/src/library/FromString.flix
+++ b/main/src/library/FromString.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for types that can be constructed from strings.
+/// A trait for types that can be constructed from strings.
 ///
-pub class FromString[a] {
+pub trait FromString[a] {
     ///
     /// Optionally returns the value associated with the given string `s`.
     ///

--- a/main/src/library/Functor.flix
+++ b/main/src/library/Functor.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for types that can be mapped over.
+/// A trait for types that can be mapped over.
 ///
-pub lawful class Functor[m : Type -> Type] {
+pub lawful trait Functor[m : Type -> Type] {
     ///
     /// Applies the function `f` to `x` preserving its structure.
     ///

--- a/main/src/library/Group.flix
+++ b/main/src/library/Group.flix
@@ -15,11 +15,11 @@
  */
 
 ///
-/// A type class for types that form a group.
+/// A trait for types that form a group.
 ///
 /// The default instances for numbers define the additive inverse in the real numbers.
 ///
-pub class Group[a] with Monoid[a] {
+pub trait Group[a] with Monoid[a] {
 
     ///
     /// Returns the neutral element.

--- a/main/src/library/Hash.flix
+++ b/main/src/library/Hash.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for types that can be hashed.
+/// A trait for types that can be hashed.
 ///
-pub class Hash[a] {
+pub trait Hash[a] {
     ///
     /// Returns a hash value for the given x.
     ///

--- a/main/src/library/Iterable.flix
+++ b/main/src/library/Iterable.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for immutable data structures that can be iterated.
+/// A trait for immutable data structures that can be iterated.
 ///
-pub class Iterable[t: Type -> Type] {
+pub trait Iterable[t: Type -> Type] {
 
     ///
     /// Returns an iterator over `t`.

--- a/main/src/library/JoinLattice.flix
+++ b/main/src/library/JoinLattice.flix
@@ -18,9 +18,9 @@
 use Bool.{==>}
 
 ///
-/// A type class for join semi lattices.
+/// A trait for join semi lattices.
 ///
-pub lawful class JoinLattice[a] with PartialOrder[a] {
+pub lawful trait JoinLattice[a] with PartialOrder[a] {
 
     ///
     /// Returns the least upper bound of `x` and `y`.

--- a/main/src/library/LowerBound.flix
+++ b/main/src/library/LowerBound.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for partially ordered types that have a lower bound.
+/// A trait for partially ordered types that have a lower bound.
 ///
-pub class LowerBound[a] {
+pub trait LowerBound[a] {
     ///
     /// Returns the smallest value of `a`.
     ///

--- a/main/src/library/MeetLattice.flix
+++ b/main/src/library/MeetLattice.flix
@@ -17,11 +17,11 @@
 use Bool.{==>}
 
 ///
-/// A type class for meet semi lattices.
+/// A trait for meet semi lattices.
 /// A Meet Lattice is pair of functions (⊑, ⊓) where ⊑ is a partial order and ⊓ satisfy two properties:
 /// lower-bound and greatest-lower-bound.
 ///
-pub lawful class MeetLattice[a] with PartialOrder[a] {
+pub lawful trait MeetLattice[a] with PartialOrder[a] {
 
     ///
     /// Returns the greatest lower bound of `x` and `y`.

--- a/main/src/library/Monad.flix
+++ b/main/src/library/Monad.flix
@@ -15,12 +15,12 @@
  */
 
 ///
-/// A type class for applicatives that support monadic bind (`flatMap`), i.e., allow to apply a function
+/// A trait for applicatives that support monadic bind (`flatMap`), i.e., allow to apply a function
 /// that takes a normal value and produces a monadic value to a monadic value. That is, the bind mechanism
 /// supports extraction of monadic values, or, viewed differently, allows to combine (flatten) nested
 /// monadic values (`flapMap` can be understood as a `Functor.map` followed by a `flatten`).
 ///
-pub lawful class Monad[m : Type -> Type] with Applicative[m] {
+pub lawful trait Monad[m : Type -> Type] with Applicative[m] {
 
     ///
     /// Apply function `f` to the monadic value `x`, resulting in a combined monadic value.

--- a/main/src/library/MonadZero.flix
+++ b/main/src/library/MonadZero.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for Monads that have a zero element.
+/// A trait for Monads that have a zero element.
 ///
-class MonadZero[m: Type -> Type] with Monad[m] {
+trait MonadZero[m: Type -> Type] with Monad[m] {
 
     ///
     /// Returns the zero element of the monad.

--- a/main/src/library/MonadZip.flix
+++ b/main/src/library/MonadZip.flix
@@ -15,11 +15,11 @@
  */
 
 ///
-/// A type class for zipping Monads, typically container monads like `List`.
+/// A trait for zipping Monads, typically container monads like `List`.
 ///
 /// A minimal implementation must define `zipWith` and `zipWithA`.
 ///
-class MonadZip[m: Type -> Type] with Monad[m] {
+trait MonadZip[m: Type -> Type] with Monad[m] {
 
     ///
     /// Returns single monad where the element (or elements) of `ma` and `mb` are combined

--- a/main/src/library/Monoid.flix
+++ b/main/src/library/Monoid.flix
@@ -15,10 +15,10 @@
  */
 
 ///
-/// A type class for Monoids, objects that support an associative binary
+/// A trait for Monoids, objects that support an associative binary
 /// operation `combine` and neutral element `empty`.
 ///
-pub lawful class Monoid[a] with SemiGroup[a] {
+pub lawful trait Monoid[a] with SemiGroup[a] {
     ///
     /// Returns a neutral element.
     ///

--- a/main/src/library/Mul.flix
+++ b/main/src/library/Mul.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for multiplication.
+/// A trait for multiplication.
 ///
-pub class Mul[a] {
+pub trait Mul[a] {
     ///
     /// Returns `x` multiplied by `y`.
     ///

--- a/main/src/library/MultiMap.flix
+++ b/main/src/library/MultiMap.flix
@@ -21,7 +21,7 @@
 /// A MultiMap is a Map that allows multiple values for a key.
 /// Multiple values are stored in a Set so duplicates are not allowed.
 ///
-/// The key and value types must implement the Eq and Order type classes.
+/// The key and value types must implement the Eq and Order traits.
 ///
 pub enum MultiMap[k, v] with Sendable {
     case MultiMap(Map[k, Set[v]])
@@ -526,7 +526,7 @@ mod MultiMap {
         let MultiMap(m1) = m;
         Map.toMutDeque(rc, m1)
 
-    // No traversable functions due to Order constraint that's outside the `Traversable` class.
+    // No traversable functions due to Order constraint that is outside the `Traversable` trait.
 
     ///
     /// Applies `f` to every `(key, value)` of MultiMap `m`.

--- a/main/src/library/Neg.flix
+++ b/main/src/library/Neg.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for negation.
+/// A trait for negation.
 ///
-pub class Neg[a] {
+pub trait Neg[a] {
     ///
     /// Returns -`x`.
     ///

--- a/main/src/library/Order.flix
+++ b/main/src/library/Order.flix
@@ -17,9 +17,9 @@
 use Bool.{==>, <==>}
 
 ///
-/// A type class for types with a total order.
+/// A trait for types with a total order.
 ///
-pub lawful class Order[a] with Eq[a] {
+pub lawful trait Order[a] with Eq[a] {
 
     ///
     /// Returns `Comparison.LessThan` if `x` < `y`, `Equal` if `x` == `y` or `Comparison.GreaterThan` `if `x` > `y`.

--- a/main/src/library/PartialOrder.flix
+++ b/main/src/library/PartialOrder.flix
@@ -19,7 +19,7 @@ use Bool.{==>}
 ///
 /// A Partial Order is a function ⊑ which satisfies three properties: reflexivity, anti-symmetry, and transitivity.
 ///
-pub lawful class PartialOrder[a] {
+pub lawful trait PartialOrder[a] {
 
     ///
     /// Returns `true` if `x` is smaller or equal to `y`.

--- a/main/src/library/Reader.flix
+++ b/main/src/library/Reader.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for types which are resources that can be accessed as bytes.
+/// A trait for types which are resources that can be accessed as bytes.
 ///
-class Reader[t] {
+trait Reader[t] {
     ///
     /// Reads `k` bytes from the underlying resource and writes them into `b`.
     ///

--- a/main/src/library/Reducible.flix
+++ b/main/src/library/Reducible.flix
@@ -15,11 +15,11 @@
  */
 
 ///
-/// A type class for types that can be reduced to a summary value.
+/// A trait for types that can be reduced to a summary value.
 ///
 /// `Reducible` is like a non-empty `Foldable` and may only be implemented on non-empty data structures.
 ///
-pub class Reducible[t: Type -> Type] {
+pub trait Reducible[t: Type -> Type] {
 
     ///
     /// Left-associative reduction of a structure.

--- a/main/src/library/SemiGroup.flix
+++ b/main/src/library/SemiGroup.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for types that form a semigroup.
+/// A trait for types that form a semigroup.
 ///
-pub class SemiGroup[a] {
+pub trait SemiGroup[a] {
     ///
     /// An associative binary operation on `a`.
     ///

--- a/main/src/library/Sendable.flix
+++ b/main/src/library/Sendable.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for types that can be passed to `Channel.send`.
+/// A trait for types that can be passed to `Channel.send`.
 ///
-pub class Sendable[a]
+pub trait Sendable[a]
 
 instance Sendable[Unit]
 

--- a/main/src/library/Sub.flix
+++ b/main/src/library/Sub.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for subtraction.
+/// A trait for subtraction.
 ///
-pub class Sub[a] {
+pub trait Sub[a] {
     ///
     /// Returns the difference of `x` and `y`.
     ///

--- a/main/src/library/ToJava.flix
+++ b/main/src/library/ToJava.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for marshaling values to Java.
+/// A trait for marshaling values to Java.
 ///
-pub class ToJava[t: Type] {
+pub trait ToJava[t: Type] {
     type O
     pub def toJava(t: t): ToJava.O[t] \ IO
 }

--- a/main/src/library/ToString.flix
+++ b/main/src/library/ToString.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for types that can be converted to strings.
+/// A trait for types that can be converted to strings.
 ///
-pub class ToString[a] {
+pub trait ToString[a] {
     ///
     /// Returns a string representation of the given x.
     ///

--- a/main/src/library/Traversable.flix
+++ b/main/src/library/Traversable.flix
@@ -15,10 +15,10 @@
  */
 
 ///
-/// A type class for data structures that can be traversed in left-to-right
+/// A trait for data structures that can be traversed in left-to-right
 /// order with an applicative functor.
 ///
-pub class Traversable[t : Type -> Type] with Functor[t], Foldable[t] {
+pub trait Traversable[t : Type -> Type] with Functor[t], Foldable[t] {
 
     ///
     /// Returns the result of applying the applicative mapping function `f` to all the elements of the

--- a/main/src/library/UnorderedFoldable.flix
+++ b/main/src/library/UnorderedFoldable.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for unordered data structures that can be folded.
+/// A trait for unordered data structures that can be folded.
 ///
-pub class UnorderedFoldable[t : Type -> Type] {
+pub trait UnorderedFoldable[t : Type -> Type] {
 
     ///
     /// Unordered fold of `t`.

--- a/main/src/library/UpperBound.flix
+++ b/main/src/library/UpperBound.flix
@@ -15,9 +15,9 @@
  */
 
 ///
-/// A type class for partially ordered types that have an upper bound.
+/// A trait for partially ordered types that have an upper bound.
 ///
-pub class UpperBound[a] {
+pub trait UpperBound[a] {
     ///
     /// Returns the largest value of `a`.
     ///

--- a/main/src/library/Witherable.flix
+++ b/main/src/library/Witherable.flix
@@ -15,10 +15,10 @@
  */
 
 ///
-/// A type class for data structures that can be traversed in left-to-right
+/// A trait for data structures that can be traversed in left-to-right
 /// order with an applicative partial functor.
 ///
-pub class Witherable[t : Type -> Type] with Traversable[t], Filterable[t] {
+pub trait Witherable[t : Type -> Type] with Traversable[t], Filterable[t] {
 
     ///
     /// Returns the result of applying the applicative partial mapping function `f` to all the elements of the

--- a/main/test/ca/uwaterloo/flix/library/TestMonadZip.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMonadZip.flix
@@ -16,9 +16,9 @@
 
 mod TestMonadZip {
 
-    // Generally the functions from the `MonadZip` class will be tested without
+    // Generally the functions from the `MonadZip` trait will be tested without
     // overloading in their respective modules. The tests here are basically
-    // to test the type class instances can be invoked as expected.
+    // to test the trait instances can be invoked as expected.
 
     // Helper
     def necOf2(x: a, y: a) : Nec[a] = Nec.cons(x, Nec.singleton(y))

--- a/main/test/flix/Test.Assoc.Eff.Contravariance.flix
+++ b/main/test/flix/Test.Assoc.Eff.Contravariance.flix
@@ -7,9 +7,9 @@ mod Test.Assoc.Eff.Contravariance {
     pub eff Network
 
     ///
-    /// A type class for container types which can have their elements counted.
+    /// A trait for container types which can have their elements counted.
     ///
-    class Countable[m: Type -> Type] {
+    trait Countable[m: Type -> Type] {
         /// An associated effect which specifies an *upperbound* on the permitted effects.
         type UpperBound: Eff
 

--- a/main/test/flix/Test.Assoc.Eff.Covariance.flix
+++ b/main/test/flix/Test.Assoc.Eff.Covariance.flix
@@ -4,9 +4,9 @@ mod Test.Assoc.Eff.Covariance {
     pub enum MutList[_r: Region, _t: Type]  // A mutable data type with a region.
 
     ///
-    /// A type class for container types that can have their elements mapped.
+    /// A trait for container types that can have their elements mapped.
     ///
-    class Functor[m: Type -> Type] {
+    trait Functor[m: Type -> Type] {
         // An associated effect which represents the effect of accessing the data structure.
         type Eff: Eff
 

--- a/main/test/flix/Test.Assoc.Type.flix
+++ b/main/test/flix/Test.Assoc.Type.flix
@@ -1,6 +1,6 @@
 mod Test.Assoc.Type {
 
-    class Collection[t] {
+    trait Collection[t] {
         type Elm[t]: Type
 
         pub def isEmpty(x: t): Bool
@@ -16,7 +16,7 @@ mod Test.Assoc.Type {
         pub def head(x: String): Option[Char] = if (String.isEmpty(x)) None else Some(String.charAt(0, x))
     }
 
-    class Collection2[t] {
+    trait Collection2[t] {
         type Elm: Type
 
         pub def isEmpty(x: t): Bool
@@ -32,7 +32,7 @@ mod Test.Assoc.Type {
         pub def head(x: String): Option[Char] = if (String.isEmpty(x)) None else Some(String.charAt(0, x))
     }
 
-    class Collection3[t] {
+    trait Collection3[t] {
         type Elm
 
         pub def isEmpty(x: t): Bool

--- a/main/test/flix/Test.Dec.TopLevel.flix
+++ b/main/test/flix/Test.Dec.TopLevel.flix
@@ -14,4 +14,4 @@ enum Ot(Bool)
 
 type alias Ta = Bool
 
-class C0[a]
+trait T0[a]

--- a/main/test/flix/Test.Dec.Trait.flix
+++ b/main/test/flix/Test.Dec.Trait.flix
@@ -1,21 +1,19 @@
-// TODO this module is replicated by `Test.Dec.Trait.flix` for the `trait` keyword.
-// Remove this module at the end of the transition period from `class` to `trait`.
-mod Test.Dec.Class {
+mod Test.Dec.Trait {
     mod Test01 {
 
-        class X[a]
+        trait X[a]
     }
 
     mod Test02 {
 
-        class X[a] {
+        trait X[a] {
             pub def f(x: a): Bool
         }
 
     }
 
     mod Test03 {
-        class X[a] {
+        trait X[a] {
             pub def f(x: a): Bool
         }
 
@@ -23,31 +21,31 @@ mod Test.Dec.Class {
             pub def f(x: Int32): Bool = x == 0
         }
 
-        pub def g(x: Int32): Bool = Test.Dec.Class.Test03.X.f(x)
+        pub def g(x: Int32): Bool = Test.Dec.Trait.Test03.X.f(x)
     }
 
     mod Test04 {
-        class C[a] {
+        trait C[a] {
             pub def f(x: a): Bool
         }
 
-        class D[a] {
+        trait D[a] {
             pub def g(x: a): Bool
         }
 
-        pub def h(x: a): Bool with C[a], D[a] = Test.Dec.Class.Test04.C.f(x) and Test.Dec.Class.Test04.D.g(x)
+        pub def h(x: a): Bool with C[a], D[a] = Test.Dec.Trait.Test04.C.f(x) and Test.Dec.Trait.Test04.D.g(x)
     }
 
     mod Test05 {
 
-        class C[a]
+        trait C[a]
 
         instance C[List[a]] with C[a]
     }
 
     mod Test06 {
 
-        pub class C[a] {
+        pub trait C[a] {
             pub def f(x: a): Bool
         }
 
@@ -64,18 +62,18 @@ mod Test.Dec.Class {
             }
         }
 
-        pub def g(x: List[Int32]): Bool = Test.Dec.Class.Test06.C.f(x)
+        pub def g(x: List[Int32]): Bool = Test.Dec.Trait.Test06.C.f(x)
     }
 
     mod Test07 {
-        use Test.Dec.Class.Test06.C
+        use Test.Dec.Trait.Test06.C
 
         pub def g(x: a): a with C[a] = x
     }
 
     mod Test08 {
 
-        class F[m : Type -> Type] {
+        trait F[m : Type -> Type] {
             pub def map(f: a -> b, x: m[a]): m[b]
         }
 
@@ -88,7 +86,7 @@ mod Test.Dec.Class {
     }
 
     mod Test09 {
-        class Eff[ef : Eff] {
+        trait Eff[ef : Eff] {
             pub def isPure(f: a -> b \ ef): Bool
         }
 
@@ -98,13 +96,13 @@ mod Test.Dec.Class {
     }
 
     mod Test10 {
-        class C[a] {
+        trait C[a] {
             pub def f(x: a): Bool
         }
 
-        class D[a] with C[a]
+        trait D[a] with C[a]
 
-        class E[a] with D[a]
+        trait E[a] with D[a]
 
         instance C[Int32] {
             pub def f(_x: Int32): Bool = true
@@ -114,17 +112,17 @@ mod Test.Dec.Class {
 
         instance E[Int32]
 
-        pub def g(x: a): Bool with D[a] = Test.Dec.Class.Test10.C.f(x)
+        pub def g(x: a): Bool with D[a] = Test.Dec.Trait.Test10.C.f(x)
 
-        pub def h(x: a): Bool with E[a] = Test.Dec.Class.Test10.C.f(x)
+        pub def h(x: a): Bool with E[a] = Test.Dec.Trait.Test10.C.f(x)
     }
 
     mod Test11 {
-        lawful class C[a] {
+        lawful trait C[a] {
             pub def f(x: a, y: a): Bool
 
             // TODO handle mods better
-            law reflexivity: forall (x: a, y: a) . Test.Dec.Class.Test11.C.f(x, y) == Test.Dec.Class.Test11.C.f(y, x)
+            law reflexivity: forall (x: a, y: a) . Test.Dec.Trait.Test11.C.f(x, y) == Test.Dec.Trait.Test11.C.f(y, x)
         }
 
         instance C[Int32] {
@@ -133,7 +131,7 @@ mod Test.Dec.Class {
     }
 
     mod Test12 {
-        class C[a] {
+        trait C[a] {
             pub def f(): a
 
             law l: forall (_x: a) . true
@@ -145,12 +143,12 @@ mod Test.Dec.Class {
     }
 
     mod Test13 {
-        class C[a] {
+        trait C[a] {
             pub def f(): a
 
-            pub def g(): a = Test.Dec.Class.Test13.C.f()
+            pub def g(): a = Test.Dec.Trait.Test13.C.f()
 
-            pub def h(): a = Test.Dec.Class.Test13.C.g()
+            pub def h(): a = Test.Dec.Trait.Test13.C.g()
         }
 
         instance C[Int32] {
@@ -160,52 +158,52 @@ mod Test.Dec.Class {
         }
 
         @test
-        def testSigOverride01(): Bool = Test.Dec.Class.Test13.C.f() == 0
+        def testSigOverride01(): Bool = Test.Dec.Trait.Test13.C.f() == 0
 
         @test
-        def testSigOverride02(): Bool = Test.Dec.Class.Test13.C.g() == 0
+        def testSigOverride02(): Bool = Test.Dec.Trait.Test13.C.g() == 0
 
         @test
-        def testSigOverride03(): Bool = Test.Dec.Class.Test13.C.h() == 1
+        def testSigOverride03(): Bool = Test.Dec.Trait.Test13.C.h() == 1
     }
 
     mod Test14 {
-        class C[a] {
+        trait C[a] {
             pub def c(x: a): Int32
         }
 
-        class D[a] with C[a] {
+        trait D[a] with C[a] {
             pub def d(x: a): Int32
         }
 
-        pub def f(x: a): Int32 with D[a] = Test.Dec.Class.Test14.C.c(x) + Test.Dec.Class.Test14.D.d(x)
+        pub def f(x: a): Int32 with D[a] = Test.Dec.Trait.Test14.C.c(x) + Test.Dec.Trait.Test14.D.d(x)
     }
 
     mod Test15 {
-        class C[a]
+        trait C[a]
 
-        class D[a]
+        trait D[a]
 
         pub def f(x: a, y: b): Bool with C[a], D[b] = ???
     }
 
     mod Test16 {
-        class D[a] {
+        trait D[a] {
             pub def f(x: a, y: a): Bool
         }
 
-        class C[a] {
-            law l: forall (x: a, y: a) with D[a] . Test.Dec.Class.Test16.D.f(x, y)
+        trait C[a] {
+            law l: forall (x: a, y: a) with D[a] . Test.Dec.Trait.Test16.D.f(x, y)
         }
     }
 
     mod Test17 {
-        class D[a] {
+        trait D[a] {
             pub def f(x: a): Bool
         }
 
-        class E[a: Type -> Type] {
-            law l: forall (x: a[b]) with D[a[b]] . Test.Dec.Class.Test17.D.f(x)
+        trait E[a: Type -> Type] {
+            law l: forall (x: a[b]) with D[a[b]] . Test.Dec.Trait.Test17.D.f(x)
         }
     }
 

--- a/main/test/flix/Test.Exp.Infix.flix
+++ b/main/test/flix/Test.Exp.Infix.flix
@@ -25,7 +25,7 @@ mod Test.Exp.Infix {
         pub def mul(x: Int32, y: Int32): Int32 = x * y
     }
 
-    class Divisible[a] {
+    trait Divisible[a] {
         pub def div(x: a, y: a): a
     }
 

--- a/main/test/flix/Test.Exp.Interpolation.flix
+++ b/main/test/flix/Test.Exp.Interpolation.flix
@@ -221,7 +221,7 @@ mod Test.Exp.Interpolation {
 
 }
 
-///pub class ToString[a] {
+///pub trait ToString[a] {
 ///    pub def toString(x: a): String
 ///}
 ///

--- a/main/test/flix/Test.Integ.Trait.Schema.flix
+++ b/main/test/flix/Test.Integ.Trait.Schema.flix
@@ -1,13 +1,11 @@
-// TODO this module is replicated by `Test.Integ.Trait.Schema.flix` for the `trait` keyword.
-// Remove this module at the end of the transition period from `class` to `trait`.
-mod Test.Integ.Class.Schema {
-    class C[a] {
+mod Test.Integ.Trait.Schema {
+    trait C[a] {
         pub def f(_x: a): #{ R(Int32, Bool) } = #{
             R(1, true).
         }
     }
 
-    class D[a] {
+    trait D[a] {
         pub def f(x: a): #{ R(Int32, Bool) }
     }
 
@@ -21,13 +19,13 @@ mod Test.Integ.Class.Schema {
 
     @test
     def testSchemaInSig01(): Bool = {
-        let _ = Test.Integ.Class.Schema.C.f(5);
+        let _ = Test.Integ.Trait.Schema.C.f(5);
         true
     }
 
     @test
     def testSchemaInSig02(): Bool = {
-        let _ = Test.Integ.Class.Schema.D.f(5);
+        let _ = Test.Integ.Trait.Schema.D.f(5);
         true
     }
 }

--- a/main/test/flix/Test.Kind.Def.flix
+++ b/main/test/flix/Test.Kind.Def.flix
@@ -19,8 +19,8 @@ mod Test.Kind.Def {
         }
 
         mod TypeConstraint {
-            class CStar[a: Type]
-            class CStarToStar[a: Type -> Type]
+            trait CStar[a: Type]
+            trait CStarToStar[a: Type -> Type]
 
             pub def star(x: a): Int32 with CStar[a] = ???
 
@@ -78,9 +78,9 @@ mod Test.Kind.Def {
         }
 
         mod TypeConstraint {
-            class CStar[a: Type]
-            class CStarToStar[a: Type -> Type]
-            class CBoolToStar[a: Eff -> Type]
+            trait CStar[a: Type]
+            trait CStarToStar[a: Type -> Type]
+            trait CBoolToStar[a: Eff -> Type]
 
             pub def star[a: Type](x: a): Int32 with CStar[a] = ???
 
@@ -135,7 +135,7 @@ mod Test.Kind.Def {
 
             pub enum PredSym
             pub enum Datalog[_a]
-            pub class Foldable[a: Type -> Type]
+            pub trait Foldable[a: Type -> Type]
         }
     }
 

--- a/main/test/flix/Test.Kind.Instance.flix
+++ b/main/test/flix/Test.Kind.Instance.flix
@@ -3,10 +3,10 @@ mod Test.Kind.Instance {
     mod TypeConstraint {
         pub enum EStar[_a: Type]
         pub enum EStarToStar[_a: Type -> Type]
-        class CStar[a: Type]
-        class CStar1[a: Type]
-        class CStarToStar[a: Type -> Type]
-        class CStarToStar2[a: Type -> Type]
+        trait CStar[a: Type]
+        trait CStar1[a: Type]
+        trait CStarToStar[a: Type -> Type]
+        trait CStarToStar2[a: Type -> Type]
 
         instance CStar1[EStar[a]] with CStar[a]
 

--- a/main/test/flix/Test.Kind.Trait.flix
+++ b/main/test/flix/Test.Kind.Trait.flix
@@ -1,32 +1,30 @@
-// TODO this module is replicated by `Test.Kind.Trait.flix` for the `trait` keyword.
-// Remove this module at the end of the transition period from `class` to `trait`.
-mod Test.Kind.Class {
+mod Test.Kind.Trait {
 
     mod Implicit {
 
         mod TypeConstraint {
-            class CStar[a: Type]
+            trait CStar[a: Type]
 
-            class CStar1[a] with CStar[a]
+            trait CStar1[a] with CStar[a]
         }
 
         mod Sig {
             mod FormalParams {
-                class CStar1[a] {
+                trait CStar1[a] {
                     pub def star(x: a): Int32 = ???
                 }
             }
 
             mod Return {
-                class CStar1[a] {
+                trait CStar1[a] {
                     pub def star(): a = ???
                 }
             }
 
             mod TypeConstraint {
-                class CStar[a: Type]
+                trait CStar[a: Type]
 
-                class CStar1[a] {
+                trait CStar1[a] {
                     pub def star(x: a): Int32 with CStar[a] = ???
                 }
             }
@@ -34,20 +32,20 @@ mod Test.Kind.Class {
             mod Enum {
                 pub enum EStar[_a: Type]
 
-                class CStar1[a] {
+                trait CStar1[a] {
                     pub def star(x: EStar[a]): Int32 = ???
                 }
             }
 
             mod Exp {
-                class CStar1[a] {
+                trait CStar1[a] {
                     pub def star(x: a): Int32 = let _: a = ???; ???
                 }
             }
 
             mod Mix {
                 // ensure we use `m`'s annotation
-                class CTypeBoolType[m: Type -> Eff -> Type] {
+                trait CTypeBoolType[m: Type -> Eff -> Type] {
                     pub def fAndM(f: a -> b \ ef1, x: m[a, ef2]): m[b, ef1 + ef2]
                 }
             }
@@ -55,15 +53,15 @@ mod Test.Kind.Class {
 
         mod Law {
             mod FormalParams {
-                class CStar1[a] {
+                trait CStar1[a] {
                     law star: forall(x: a) . ???
                 }
             }
 
             mod TypeConstraint {
-                class CStar[a: Type]
+                trait CStar[a: Type]
 
-                class CStar1[a] {
+                trait CStar1[a] {
                     law star: forall(x: a) with CStar[a] . ???
                 }
             }
@@ -71,13 +69,13 @@ mod Test.Kind.Class {
             mod Enum {
                 pub enum EStar[_a: Type]
 
-                class CStar1[a] {
+                trait CStar1[a] {
                     law star: forall(x: EStar[a]) . ???
                 }
             }
 
             mod Exp {
-                class CStar1[a] {
+                trait CStar1[a] {
                     law star: forall(x: a) . { ???: a; ??? }
                 }
             }
@@ -86,49 +84,49 @@ mod Test.Kind.Class {
 
     mod Explicit {
         mod TypeConstraint {
-            class CStar[a: Type]
-            class CStarToStar[a: Type -> Type]
+            trait CStar[a: Type]
+            trait CStarToStar[a: Type -> Type]
 
-            class CStar1[a: Type] with CStar[a]
+            trait CStar1[a: Type] with CStar[a]
 
-            class CStarToStar1[a: Type -> Type] with CStarToStar[a]
+            trait CStarToStar1[a: Type -> Type] with CStarToStar[a]
         }
 
         mod Sig {
             mod FormalParams {
-                class CStar1[a: Type] {
+                trait CStar1[a: Type] {
                     pub def star(x: a): Int32 = ???
                 }
 
-                class CStarToStar1[a: Type -> Type] {
+                trait CStarToStar1[a: Type -> Type] {
                     pub def starToStar(x: a[Int32]): Int32 = ???
                 }
             }
 
             mod Return {
-                class CStar1[a: Type] {
+                trait CStar1[a: Type] {
                     pub def star(): a = ???
                 }
 
-                class CStarToStar1[a: Type -> Type] {
+                trait CStarToStar1[a: Type -> Type] {
                     pub def starToStar(): a[Int32] = ???
                 }
             }
 
             mod TypeConstraint {
-                class CStar[a: Type]
-                class CStarToStar[a: Type -> Type]
-                class CBoolToStar[a: Eff -> Type]
+                trait CStar[a: Type]
+                trait CStarToStar[a: Type -> Type]
+                trait CBoolToStar[a: Eff -> Type]
 
-                class CStar1[a: Type] {
+                trait CStar1[a: Type] {
                     pub def star(x: a): Int32 with CStar[a] = ???
                 }
 
-                class CStarToStar1[a: Type -> Type] {
+                trait CStarToStar1[a: Type -> Type] {
                     pub def starToStar(x: a[Int32]): Int32 with CStarToStar[a] = ???
                 }
 
-                class CBoolToStar1[a: Eff -> Type] {
+                trait CBoolToStar1[a: Eff -> Type] {
                     pub def boolToStar(x: a[Pure]): Int32 with CBoolToStar[a] = ???
                 }
             }
@@ -137,17 +135,17 @@ mod Test.Kind.Class {
                 pub enum EStar[_a: Type]
                 pub enum EStarToStar[_a: Type -> Type]
 
-                class CStar1[a: Type] {
+                trait CStar1[a: Type] {
                     pub def star(x: EStar[a]): Int32 = ???
                 }
 
-                class CStarToStar1[a: Type -> Type] {
+                trait CStarToStar1[a: Type -> Type] {
                     pub def starToStar(x: EStarToStar[a]): Int32 = ???
                 }
             }
 
             mod Exp {
-                class CStar1[a: Type] {
+                trait CStar1[a: Type] {
                     pub def star(x: a): Int32 = let _: a = ???; ???
                 }
             }
@@ -155,29 +153,29 @@ mod Test.Kind.Class {
 
         mod Law {
             mod FormalParams {
-                class CStar1[a: Type] {
+                trait CStar1[a: Type] {
                     law star: forall(x: a) . ???
                 }
 
-                class CStarToStar1[a: Type -> Type] {
+                trait CStarToStar1[a: Type -> Type] {
                     law starToStar: forall(x: a[Int32]) . ???
                 }
             }
 
             mod TypeConstraint {
-                class CStar[a: Type]
-                class CStarToStar[a: Type -> Type]
-                class CBoolToStar[a: Eff -> Type]
+                trait CStar[a: Type]
+                trait CStarToStar[a: Type -> Type]
+                trait CBoolToStar[a: Eff -> Type]
 
-                class CStar1[a: Type] {
+                trait CStar1[a: Type] {
                     law star: forall(x: a) with CStar[a] . ???
                 }
 
-                class CStarToStar1[a: Type -> Type] {
+                trait CStarToStar1[a: Type -> Type] {
                     law starToStar: forall(x: a[Int32]) with CStarToStar[a] . ???
                 }
 
-                class CBoolToStar1[a: Eff -> Type] {
+                trait CBoolToStar1[a: Eff -> Type] {
                     law boolToStar: forall(x: a[Pure]) with CBoolToStar[a] . ???
                 }
             }
@@ -186,17 +184,17 @@ mod Test.Kind.Class {
                 pub enum EStar[_a: Type]
                 pub enum EStarToStar[_a: Type -> Type]
 
-                class CStar1[a: Type] {
+                trait CStar1[a: Type] {
                     law star: forall(x: EStar[a]) . ???
                 }
 
-                class CStarToStar1[a: Type -> Type] {
+                trait CStarToStar1[a: Type -> Type] {
                     law starToStar: forall(x: EStarToStar[a]) . ???
                 }
             }
 
             mod Exp {
-                class CStar1[a: Type] {
+                trait CStar1[a: Type] {
                     law star: forall(x: a) . { ???: a; ??? }
                 }
             }

--- a/main/test/flix/Test.Use.Sig.flix
+++ b/main/test/flix/Test.Use.Sig.flix
@@ -1,76 +1,76 @@
 mod A {
-    pub class FClass[a] {
+    pub trait FTrait[a] {
         pub def f(): a
     }
 
-    instance FClass[Int32] {
+    instance FTrait[Int32] {
         pub def f(): Int32 = 1
     }
 
     @test
     def testMod01(): Bool =
-        use A.FClass.f;
+        use A.FTrait.f;
         f() == 1
 
     @test
     def testMod02(): Bool =
-        use B.FClass.f;
+        use B.FTrait.f;
         f() == 2
 
     @test
     def testMod03(): Bool =
-        use C.FClass.f;
+        use C.FTrait.f;
         f() == 3
 }
 
 mod B {
-    pub class FClass[a] {
+    pub trait FTrait[a] {
         pub def f(): a
     }
 
-    instance FClass[Int32] {
+    instance FTrait[Int32] {
         pub def f(): Int32 = 2
     }
 
     @test
     def testMod04(): Bool =
-        use A.FClass.{f => fa};
+        use A.FTrait.{f => fa};
         fa() == 1
 
     @test
     def testMod05(): Bool =
-        use B.FClass.{f => fb};
+        use B.FTrait.{f => fb};
         fb() == 2
 
     @test
     def testMod06(): Bool =
-        use C.FClass.{f => fc};
+        use C.FTrait.{f => fc};
         fc() == 3
 
 }
 
 mod C {
-    pub class FClass[a] {
+    pub trait FTrait[a] {
         pub def f(): a
     }
 
-    instance FClass[Int32] {
+    instance FTrait[Int32] {
         pub def f(): Int32 = 3
     }
 
     @test
     def testMod07(): Bool =
-        use A.FClass.{f => fa};
-        use B.FClass.{f => fb};
-        use C.FClass.{f => fc};
+        use A.FTrait.{f => fa};
+        use B.FTrait.{f => fb};
+        use C.FTrait.{f => fc};
         (fa() + fb() + fc()) == 6
 }
 
 mod D {
-    use A.FClass.f
-    use B.FClass.{f => fb}
-    use X.Y.GClass.g
-    use X.Y.Z.GClass.{g => gz}
+    use A.FTrait.f
+    use B.FTrait.{f => fb}
+    use X.Y.GTrait.g
+    use X.Y.Z.GTrait.{g => gz}
 
     @test
     def testMod08(): Bool = f() == 1
@@ -85,38 +85,38 @@ mod D {
     def testMod11(): Bool = gz() == 7
 }
 
-pub class GClass[a] {
+pub trait GTrait[a] {
     pub def g(): a
 }
 
-instance GClass[Int32] {
+instance GTrait[Int32] {
     pub def g(): Int32 = 4
 }
 
 mod X {
-    pub class GClass[a] {
+    pub trait GTrait[a] {
         pub def g(): a
     }
 
-    instance GClass[Int32] {
+    instance GTrait[Int32] {
         pub def g(): Int32 = 5
     }
 
     mod Y {
-        pub class GClass[a] {
+        pub trait GTrait[a] {
             pub def g(): a
         }
 
-        instance GClass[Int32] {
+        instance GTrait[Int32] {
             pub def g(): Int32 = 6
         }
 
         mod Z {
-            pub class GClass[a] {
+            pub trait GTrait[a] {
                 pub def g(): a
             }
 
-            instance GClass[Int32] {
+            instance GTrait[Int32] {
                 pub def g(): Int32 = 7
             }
         }
@@ -127,24 +127,24 @@ mod Test.Use.Sig {
 
     @test
     def testMod12(): Bool =
-        use X.GClass.g;
+        use X.GTrait.g;
         g() == 5
 
     @test
     def testMod13(): Bool =
-        use X.Y.GClass.g;
+        use X.Y.GTrait.g;
         g() == 6
 
     @test
     def testMod14(): Bool =
-        use X.Y.Z.GClass.g;
+        use X.Y.Z.GTrait.g;
         g() == 7
 
     @test
     def testMod15(): Bool =
-        use X.GClass.{g => gx};
-        use X.Y.GClass.{g => gxy};
-        use X.Y.Z.GClass.{g => gxyz};
+        use X.GTrait.{g => gx};
+        use X.Y.GTrait.{g => gxy};
+        use X.Y.Z.GTrait.{g => gxyz};
         (gx() + gxy() + gxyz()) == 18
 
 }

--- a/main/test/flix/experimental/Test.Dec.AssocType.flix
+++ b/main/test/flix/experimental/Test.Dec.AssocType.flix
@@ -1,6 +1,6 @@
 mod Test.Dec.AssocType {
 
-    class Coll[a] {
+    trait Coll[a] {
         type Elem[a]: Type
 
         pub def contains(x: Coll.Elem[a], c: a): Bool
@@ -35,7 +35,7 @@ mod Test.Dec.AssocType {
     @test
     def testHead01(): Bool = Coll.head("ABC") == Some('A')
 
-    class Iterable2[a] {
+    trait Iterable2[a] {
         type Eff[a]: Eff
         type Elem[a]: Type
 
@@ -56,7 +56,7 @@ mod Test.Dec.AssocType {
         pub def iterator(rc: Region[r2], x: MutList[a, r]): Iterator[a, r + r2, r2] \ r + r2 = MutList.iterator(rc, x)
     }
 
-    class C[a] {
+    trait C[a] {
         type T[a]: Type
         pub def f(x: a): C.T[a]
     }


### PR DESCRIPTION
This PR is the first part of renaming `class` to `trait` (issue #6591), it adds `trait` as a keyword in the parser, `class` remains a keyword as well.

I've changed the stdlib and the examples to use `trait` rather than `class`. Because "real code" is now using `trait` I've changed the `main.test.flix` tests to use `trait` as well. In cases where there were specific test files to test type classes (Test.Dec.Class.flix, Test.Integ.Class.Schema.flix, Test.Kind.Class.flix) I have duplicated the files to test them using `trait`. At the end of the transition period from `class` to `trait` the Class versions should be removed.

Hopefully these changes to the `main.test.flix` tests will not be particularly onerous for Matthew when he merges in the new type checker. I have left the `LanguageSuite` tests as-is as they are likely to more conflicting and not as easy to resolve given they use embedded Flix code inside Scala code.