### PR TITLE
refactor: replace `scala-parallel-collections` with native Java threads

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     implementation('org.ow2.asm:asm:9.6')
     implementation('org.parboiled:parboiled_2.13:2.4.1')
     implementation('org.scalactic:scalactic_2.13:3.2.15')
-    implementation("org.scala-lang.modules:scala-parallel-collections_2.13:0.2.0")
     implementation('com.github.rjeschke:txtmark:0.13')
     implementation('com.github.scopt:scopt_2.13:4.1.0')
     implementation('com.google.guava:guava:31.1-jre')

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -326,16 +326,6 @@ class Flix {
   var options: Options = Options.Default
 
   /**
-    * The fork join pool for `this` Flix instance.
-    */
-  private var forkJoinPool: java.util.concurrent.ForkJoinPool = _
-
-  /**
-    * The fork join task support for `this` Flix instance.
-    */
-  var forkJoinTaskSupport: scala.collection.parallel.ForkJoinTaskSupport = _
-
-  /**
     * The thread pool executor service for `this` Flix instance.
     */
   var threadPool: ExecutorService = _
@@ -522,9 +512,6 @@ class Flix {
     // Mark this object as implicit.
     implicit val flix: Flix = this
 
-    // Initialize fork join pool.
-    initForkJoin()
-
     // Initialize the thread pool.
     initThreadPool()
 
@@ -569,9 +556,6 @@ class Flix {
     // (Possible duplicate files in codeGen will just be empty and overwritten there)
     AstPrinter.printAsts()
 
-    // Shutdown fork join pool.
-    shutdownForkJoin()
-
     // Shutdown thread pool.
     shutdownThreadPool()
 
@@ -598,9 +582,6 @@ class Flix {
     // Mark this object as implicit.
     implicit val flix: Flix = this
 
-    // Initialize fork join pool.
-    initForkJoin()
-
     // Initialize thread pool.
     initThreadPool()
 
@@ -620,9 +601,6 @@ class Flix {
 
     // Write formatted asts to disk based on options.
     AstPrinter.printAsts()
-
-    // Shutdown fork join pool.
-    shutdownForkJoin()
 
     // Shutdown thread pool.
     shutdownThreadPool()
@@ -728,25 +706,10 @@ class Flix {
   }
 
   /**
-    * Initializes the fork join pools.
-    */
-  private def initForkJoin(): Unit = {
-    forkJoinPool = new java.util.concurrent.ForkJoinPool(options.threads)
-    forkJoinTaskSupport = new scala.collection.parallel.ForkJoinTaskSupport(forkJoinPool)
-  }
-
-  /**
     * Initializes the thread pool.
     */
   private def initThreadPool(): Unit = {
     threadPool = Executors.newFixedThreadPool(options.threads)
-  }
-
-  /**
-    * Shuts down the fork join pools.
-    */
-  private def shutdownForkJoin(): Unit = {
-    forkJoinPool.shutdown()
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/util/ParOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/ParOps.scala
@@ -31,11 +31,10 @@ object ParOps {
     */
   @inline
   def parMap[A, B](xs: Iterable[A])(f: A => B)(implicit flix: Flix): Iterable[B] = {
-    val in = xs.toVector
-    val out = ArrayBuffer.fill(in.size)(null.asInstanceOf[B])
+    val out = ArrayBuffer.fill(xs.size)(null.asInstanceOf[B])
 
     val futuresBuilder = ArrayBuffer.newBuilder[Future[?]]
-    futuresBuilder.sizeHint(in.size)
+    futuresBuilder.sizeHint(xs.size)
     val futures = futuresBuilder.result()
 
     val threadPool = flix.threadPool
@@ -98,6 +97,7 @@ object ParOps {
       override def call(): Set[T] = next(t)
     }
 
+    // Use global thread pool.
     val threadPool = flix.threadPool
 
     // A mutable variable that holds the currently reachable Ts.

--- a/main/src/ca/uwaterloo/flix/util/ParOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/ParOps.scala
@@ -34,10 +34,10 @@ object ParOps {
     val in = xs.toVector
     val out = ArrayBuffer.fill(in.size)(null.asInstanceOf[B])
 
-    val executorService: ExecutorService = Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors())
+    val threadPool = flix.threadPool
     val futures = ArrayBuffer.empty[Future[?]]
     for ((elm, idx) <- xs.zipWithIndex) {
-      futures += executorService.submit(new Runnable {
+      futures += threadPool.submit(new Runnable {
         override def run(): Unit = {
           out(idx) = f(elm)
         }

--- a/main/src/ca/uwaterloo/flix/util/ParOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/ParOps.scala
@@ -22,7 +22,6 @@ import scala.jdk.CollectionConverters._
 import ca.uwaterloo.flix.api.Flix
 
 import scala.collection.mutable.ArrayBuffer
-import scala.reflect.ClassTag
 
 object ParOps {
 

--- a/main/src/ca/uwaterloo/flix/util/ParOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/ParOps.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.util
 
 import java.util
-import java.util.concurrent.{Callable, ExecutorService, Executors, Future}
+import java.util.concurrent.{Callable, Future}
 import scala.jdk.CollectionConverters._
 import scala.collection.parallel._
 import ca.uwaterloo.flix.api.Flix
@@ -98,8 +98,7 @@ object ParOps {
       override def call(): Set[T] = next(t)
     }
 
-    // Initialize a new executor service.
-    val executorService = Executors.newFixedThreadPool(flix.options.threads)
+    val threadPool = flix.threadPool
 
     // A mutable variable that holds the currently reachable Ts.
     var reach = init
@@ -117,7 +116,7 @@ object ParOps {
       }
 
       // Invoke all callables in parallel.
-      val futures = executorService.invokeAll(callables)
+      val futures = threadPool.invokeAll(callables)
 
       // Compute the set of all inferred Ts in this iteration.
       // May include Ts discovered in previous iterations.
@@ -129,9 +128,6 @@ object ParOps {
       delta = newReach -- reach
       reach = reach ++ delta
     }
-
-    // Shutdown the executor service.
-    executorService.shutdown()
 
     // Return the set of reachable Ts.
     reach

--- a/main/src/ca/uwaterloo/flix/util/ParOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/ParOps.scala
@@ -22,6 +22,7 @@ import scala.jdk.CollectionConverters._
 import ca.uwaterloo.flix.api.Flix
 
 import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
 
 object ParOps {
 
@@ -83,7 +84,7 @@ object ParOps {
     val threadPool = flix.threadPool
 
     // Distribute elements about equally between the threads
-    val threadElms = ArrayBuffer.fill(threads) {
+    val threadElms = Array.fill(threads) {
       val elmsBuilder = ArrayBuffer.newBuilder[A]
       elmsBuilder.sizeHint(size / threads)
       elmsBuilder.result()

--- a/main/src/ca/uwaterloo/flix/util/ParOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/ParOps.scala
@@ -87,7 +87,7 @@ object ParOps {
       elmsBuilder.result()
     }
     val iterator = xs.iterator
-    val (l1, l2) = threadElms.splitAt(xs.size % threads)
+    val (l1, l2) = threadElms.splitAt(threads - (xs.size % threads))
     l1.foreach {
       l => l.appendAll(iterator.take(xs.size / threads))
     }

--- a/main/src/ca/uwaterloo/flix/util/ParOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/ParOps.scala
@@ -31,8 +31,8 @@ object ParOps {
     */
   @inline
   def parMap[A, B](xs: Iterable[A])(f: A => B)(implicit flix: Flix): Iterable[B] = {
-    val in: Vector[A] = xs.toVector
-    val out: ArrayBuffer[B] = ArrayBuffer.fill(in.size)(null.asInstanceOf[B])
+    val in = xs.toVector
+    val out = ArrayBuffer.fill(in.size)(null.asInstanceOf[B])
 
     val executorService: ExecutorService = Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors())
     val futures = ArrayBuffer.empty[Future[?]]

--- a/main/src/ca/uwaterloo/flix/util/ParOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/ParOps.scala
@@ -34,8 +34,11 @@ object ParOps {
     val in = xs.toVector
     val out = ArrayBuffer.fill(in.size)(null.asInstanceOf[B])
 
+    val futuresBuilder = ArrayBuffer.newBuilder[Future[?]]
+    futuresBuilder.sizeHint(in.size)
+    val futures = futuresBuilder.result()
+
     val threadPool = flix.threadPool
-    val futures = ArrayBuffer.empty[Future[?]]
     for ((elm, idx) <- xs.zipWithIndex) {
       futures += threadPool.submit(new Runnable {
         override def run(): Unit = {
@@ -43,9 +46,9 @@ object ParOps {
         }
       })
     }
-    for (future <- futures) {
-      future.get()
-    }
+
+    // Await all
+    futures.foreach(_.get())
 
     out
   }

--- a/main/test/ca/uwaterloo/flix/util/TestParOps.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestParOps.scala
@@ -16,12 +16,14 @@
 package ca.uwaterloo.flix.util
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.util.ParOps
 import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.concurrent.Executors
 
 class TestParOps extends AnyFunSuite {
 
   implicit var flix: Flix = new Flix()
+  flix.threadPool = Executors.newFixedThreadPool(8)
 
   test("parMap01") {
     val list = List(1, 2, 3, 4)

--- a/main/test/ca/uwaterloo/flix/util/TestParOps.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestParOps.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Holger Dal Mogensen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.util
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.util.ParOps
+import org.scalatest.funsuite.AnyFunSuite
+
+class TestParOps extends AnyFunSuite {
+
+  implicit var flix: Flix = new Flix()
+
+  test("parMap01") {
+    val list = List(1, 2, 3, 4)
+    val result = ParOps.parMap(list)(x => x * 2)
+    assert(result.toList == List(2, 4, 6, 8))
+  }
+
+  test("parMap02") {
+    val list = List(List(1, 2), List(3, 4))
+    val result = ParOps.parMap(list) {
+      subList => ParOps.parMap(subList)(x => x * 2)
+    }
+    assert(result.toList == List(List(2, 4), List(6, 8)))
+  }
+}

--- a/main/test/ca/uwaterloo/flix/util/TestParOps.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestParOps.scala
@@ -38,4 +38,23 @@ class TestParOps extends AnyFunSuite {
     }
     assert(result.toList == List(List(2, 4), List(6, 8)))
   }
+
+  test("parAgg01") {
+    val list = List(1, 2, 3, 4)
+    val result = ParOps.parAgg(list, List.empty[Int])(
+      (acc, x) => acc :+ x * 2,
+      (l1, l2) => l1 ++ l2,
+    )
+    assert(result == List(2, 4, 6, 8))
+  }
+
+  test("parAgg02") {
+    val range = 1 to 100
+    val result = ParOps.parAgg(range, List.empty[Int])(
+      (acc, x) => acc :+ x * 2,
+      (l1, l2) => l1 ++ l2,
+    )
+    val doubledRange = range.map(_ * 2)
+    assert(result == doubledRange)
+  }
 }

--- a/main/test/ca/uwaterloo/flix/util/UtilSuite.scala
+++ b/main/test/ca/uwaterloo/flix/util/UtilSuite.scala
@@ -20,6 +20,7 @@ import org.scalatest.Suites
 
 class UtilSuite extends Suites(
   new TestGraph,
+  new TestParOps,
   new TestResult,
   new TestValidation
 )


### PR DESCRIPTION
Fixes #6583