### PR TITLE
refactor: update KeywordOtherCompleter and Weeder to recognize `trait` keyword

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordOtherCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordOtherCompleter.scala
@@ -44,6 +44,7 @@ object KeywordOtherCompleter extends Completer {
       "Record",
       "Schema",
       "sealed",
+      "trait",
       "type",
       "where",
       "with",

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -48,7 +48,7 @@ object Weeder {
     "class", "def", "deref", "else", "enum", "false", "fix", "force",
     "if", "import", "inline", "instance", "instanceof", "into", "law", "lawful", "lazy", "let", "let*", "match",
     "null", "override", "pub", "ref", "region",
-    "sealed", "set", "spawn", "Static", "true",
+    "sealed", "set", "spawn", "Static", "trait", "true",
     "type", "use", "where", "with", "discard", "object"
   )
 


### PR DESCRIPTION
This PR updates the completions in `KeywordOtherCompleter` and the set of reserved words in `Weeder` to recognize the new `trait` keyword.

Part of the work on rename `class` to `trait` issue #6591 .