### PR TITLE
feat: add effect defs and operations to backend

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordOtherCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordOtherCompleter.scala
@@ -44,6 +44,7 @@ object KeywordOtherCompleter extends Completer {
       "Record",
       "Schema",
       "sealed",
+      "trait",
       "type",
       "where",
       "with",

--- a/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
@@ -21,16 +21,21 @@ import ca.uwaterloo.flix.language.ast.Purity.Pure
 
 object LiftedAst {
 
-  val empty: Root = Root(Map.empty, Map.empty, None, Map.empty)
+  val empty: Root = Root(Map.empty, Map.empty, Map.empty, None, Map.empty)
 
   case class Root(defs: Map[Symbol.DefnSym, Def],
                   enums: Map[Symbol.EnumSym, Enum],
+                  effects: Map[Symbol.EffectSym, Effect],
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
   case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], exp: Expr, tpe: MonoType, purity: Purity, loc: SourceLocation)
 
   case class Enum(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, cases: Map[Symbol.CaseSym, Case], tpe: MonoType, loc: SourceLocation)
+
+  case class Effect(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[Op], loc: SourceLocation)
+
+  case class Op(sym: Symbol.OpSym, ann: Ast.Annotations, mod: Ast.Modifiers, fparams: List[FormalParam], tpe: MonoType, purity: Purity, loc: SourceLocation)
 
   sealed trait Expr {
     def tpe: MonoType

--- a/main/src/ca/uwaterloo/flix/language/ast/OccurrenceAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/OccurrenceAst.scala
@@ -23,12 +23,17 @@ object OccurrenceAst {
 
   case class Root(defs: Map[Symbol.DefnSym, OccurrenceAst.Def],
                   enums: Map[Symbol.EnumSym, OccurrenceAst.Enum],
+                  effects: Map[Symbol.EffectSym, OccurrenceAst.Effect],
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
   case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[OccurrenceAst.FormalParam], fparams: List[OccurrenceAst.FormalParam], exp: OccurrenceAst.Expression, context: DefContext, tpe: MonoType, purity: Purity, loc: SourceLocation)
 
   case class Enum(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, cases: Map[Symbol.CaseSym, OccurrenceAst.Case], tpe: MonoType, loc: SourceLocation)
+
+  case class Effect(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[Op], loc: SourceLocation)
+
+  case class Op(sym: Symbol.OpSym, ann: Ast.Annotations, mod: Ast.Modifiers, fparams: List[FormalParam], tpe: MonoType, purity: Purity, loc: SourceLocation)
 
   sealed trait Expression {
     def tpe: MonoType

--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -23,10 +23,11 @@ import java.lang.reflect.Method
 
 object ReducedAst {
 
-  val empty: Root = Root(Map.empty, Map.empty, List.empty, None, Map.empty)
+  val empty: Root = Root(Map.empty, Map.empty, Map.empty, List.empty, None, Map.empty)
 
   case class Root(defs: Map[Symbol.DefnSym, Def],
                   enums: Map[Symbol.EnumSym, Enum],
+                  effects: Map[Symbol.EffectSym, Effect],
                   anonClasses: List[AnonClass],
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
@@ -37,6 +38,10 @@ object ReducedAst {
   }
 
   case class Enum(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, cases: Map[Symbol.CaseSym, Case], tpe: MonoType, loc: SourceLocation)
+
+  case class Effect(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[Op], loc: SourceLocation)
+
+  case class Op(sym: Symbol.OpSym, ann: Ast.Annotations, mod: Ast.Modifiers, fparams: List[FormalParam], tpe: MonoType, purity: Purity, loc: SourceLocation)
 
   sealed trait Expr {
     def tpe: MonoType

--- a/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
@@ -22,16 +22,21 @@ import ca.uwaterloo.flix.language.phase.ClosureConv
 
 object SimplifiedAst {
 
-  val empty: Root = Root(Map.empty, Map.empty, None, Map.empty)
+  val empty: Root = Root(Map.empty, Map.empty, Map.empty, None, Map.empty)
 
   case class Root(defs: Map[Symbol.DefnSym, Def],
                   enums: Map[Symbol.EnumSym, Enum],
+                  effects: Map[Symbol.EffectSym, Effect],
                   entryPoint: Option[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
   case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, fparams: List[FormalParam], exp: Expr, tpe: MonoType, purity: Purity, loc: SourceLocation)
 
   case class Enum(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, cases: Map[Symbol.CaseSym, Case], tpe: MonoType, loc: SourceLocation)
+
+  case class Effect(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[Op], loc: SourceLocation)
+
+  case class Op(sym: Symbol.OpSym, ann: Ast.Annotations, mod: Ast.Modifiers, fparams: List[FormalParam], tpe: MonoType, purity: Purity, loc: SourceLocation)
 
   sealed trait Expr {
     def tpe: MonoType

--- a/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
@@ -48,9 +48,14 @@ object LambdaLift {
       case (sym, enum0) => sym -> visitEnum(enum0)
     }
 
+    val newEffects = root.effects.map {
+      case (sym, effect0) => sym -> visitEffect(effect0)
+    }
+
     LiftedAst.Root(
       newDefs ++ m,
       newEnums,
+      newEffects,
       root.entryPoint,
       root.sources
     )
@@ -75,6 +80,18 @@ object LambdaLift {
         case (tag, SimplifiedAst.Case(caseSym, caseTpe, loc)) => tag -> LiftedAst.Case(caseSym, caseTpe, loc)
       }
       LiftedAst.Enum(ann, mod, sym, cs, tpe, loc)
+  }
+
+  private def visitEffect(effect: SimplifiedAst.Effect): LiftedAst.Effect = effect match {
+    case SimplifiedAst.Effect(ann, mod, sym, ops0, loc) =>
+      val ops = ops0.map(visitEffectOp)
+      LiftedAst.Effect(ann, mod, sym, ops, loc)
+  }
+
+  private def visitEffectOp(op: SimplifiedAst.Op): LiftedAst.Op = op match {
+    case SimplifiedAst.Op(sym, ann, mod, fparams0, tpe, purity, loc) =>
+      val fparams = fparams0.map(visitFormalParam)
+      LiftedAst.Op(sym, ann, mod, fparams, tpe, purity, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/OccurrenceAnalyzer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/OccurrenceAnalyzer.scala
@@ -62,14 +62,12 @@ object OccurrenceAnalyzer {
     */
   def run(root: LiftedAst.Root)(implicit flix: Flix): Validation[OccurrenceAst.Root, CompilationMessage] = flix.subphase("OccurrenceAnalyzer") {
 
-    // Visit every definition in the program in parallel and transform to type 'OccurrenceAst.Def'
     val defs = visitDefs(root.defs)
-
-    // Visit every enum in the program and transform to type 'OccurrenceAst.Enum'
     val enums = root.enums.map { case (k, v) => k -> visitEnum(v) }
+    val effects = root.effects.map { case (k, v) => k -> visitEffect(v) }
 
     // Reassemble the ast root.
-    val result = OccurrenceAst.Root(defs, enums, root.entryPoint, root.sources)
+    val result = OccurrenceAst.Root(defs, enums, effects, root.entryPoint, root.sources)
 
     result.toSuccess
   }
@@ -90,6 +88,18 @@ object OccurrenceAnalyzer {
     */
   private def visitCase(case0: LiftedAst.Case): OccurrenceAst.Case = {
     OccurrenceAst.Case(case0.sym, case0.tpe, case0.loc)
+  }
+
+  private def visitEffect(effect: LiftedAst.Effect): OccurrenceAst.Effect = effect match {
+    case LiftedAst.Effect(ann, mod, sym, ops0, loc) =>
+      val ops = ops0.map(visitEffectOp)
+      OccurrenceAst.Effect(ann, mod, sym, ops, loc)
+  }
+
+  private def visitEffectOp(op: LiftedAst.Op): OccurrenceAst.Op = op match {
+    case LiftedAst.Op(sym, ann, mod, fparams0, tpe, purity, loc) =>
+      val fparams = fparams0.map(visitFormalParam)
+      OccurrenceAst.Op(sym, ann, mod, fparams, tpe, purity, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -32,8 +32,11 @@ object Reducer {
     val newEnums = root.enums.map {
       case (sym, d) => sym -> visitEnum(d)
     }
+    val newEffects = root.effects.map {
+      case (sym, effect) => sym -> visitEffect(effect)
+    }
 
-    ReducedAst.Root(newDefs, newEnums, ctx.anonClasses.toList, root.entryPoint, root.sources)
+    ReducedAst.Root(newDefs, newEnums, newEffects, ctx.anonClasses.toList, root.entryPoint, root.sources)
   }
 
   private def visitDef(d: LiftedAst.Def)(implicit ctx: Context): ReducedAst.Def = d match {
@@ -52,6 +55,18 @@ object Reducer {
       }
       val t = tpe
       ReducedAst.Enum(ann, mod, sym, cases, tpe, loc)
+  }
+
+  private def visitEffect(effect: LiftedAst.Effect): ReducedAst.Effect = effect match {
+    case LiftedAst.Effect(ann, mod, sym, ops0, loc) =>
+      val ops = ops0.map(visitEffectOp)
+      ReducedAst.Effect(ann, mod, sym, ops, loc)
+  }
+
+  private def visitEffectOp(op: LiftedAst.Op): ReducedAst.Op = op match {
+    case LiftedAst.Op(sym, ann, mod, fparams0, tpe, purity, loc) =>
+      val fparams = fparams0.map(visitFormalParam)
+      ReducedAst.Op(sym, ann, mod, fparams, tpe, purity, loc)
   }
 
   private def visitExpr(exp0: LiftedAst.Expr)(implicit ctx: Context): ReducedAst.Expr = exp0 match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -48,7 +48,7 @@ object Weeder {
     "class", "def", "deref", "else", "enum", "false", "fix", "force",
     "if", "import", "inline", "instance", "instanceof", "into", "law", "lawful", "lazy", "let", "let*", "match",
     "null", "override", "pub", "ref", "region",
-    "sealed", "set", "spawn", "Static", "true",
+    "sealed", "set", "spawn", "Static", "trait", "true",
     "type", "use", "where", "with", "discard", "object"
   )
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -1459,19 +1459,17 @@ object GenExpression {
       mv.visitLabel(afterTryAndCatch)
 
     case Expr.TryWith(exp, effUse, rules, tpe, purity, loc) =>
-      // TODO (temp unit value)
-      mv.visitInsn(Opcodes.ACONST_NULL)
-      mv.visitInsn(Opcodes.ATHROW)
+      // TODO (temp unhandled code)
+      compileExpr(exp)
 
 
     case Expr.Do(op, exps, tpe, purity, loc) =>
       // TODO (temp unit value)
-      mv.visitInsn(Opcodes.ACONST_NULL)
-      mv.visitInsn(Opcodes.ATHROW)
+      mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
 
 
     case Expr.Resume(exp, tpe, loc) =>
-      // TODO (temp unit value)
+      // TODO (temp throw null)
       mv.visitInsn(Opcodes.ACONST_NULL)
       mv.visitInsn(Opcodes.ATHROW)
 


### PR DESCRIPTION
- `try a with b` generates code `a`
- `resume(...)` generates code `throw null`
- `do ...` generates code `()`
- I've copied the analyser/inliner code from `tryCatch` so `tryWith` should also work, given that the previous code works?