### PR TITLE
chore: update GitHub actions to the latest major release for security

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,9 +15,9 @@ jobs:
 
     steps:
       - name: Check out master
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -53,12 +53,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '21'
       - name: Check out project head
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ matrix.repo }}
       - name: Download Flix JAR

--- a/.github/workflows/jar-on-demand.yaml
+++ b/.github/workflows/jar-on-demand.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: >
-              github.issues.createComment({
+              github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -30,7 +30,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: >
-            var pull_promise = github.pulls.get({
+            var pull_promise = github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number
@@ -58,7 +58,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: >
-              github.issues.createComment({
+              github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/jar-on-demand.yaml
+++ b/.github/workflows/jar-on-demand.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Acknowledge request
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: >
@@ -21,12 +21,12 @@ jobs:
                 body: 'Building JAR...'
               })
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '21'
       - name: Lookup branches
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: >
@@ -42,7 +42,7 @@ jobs:
               core.exportVariable("master_ref", pull.data.base.ref);
             });
       - name: Check out feature branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ env.feature_repo }}
           ref: ${{ env.feature_ref }}
@@ -54,7 +54,7 @@ jobs:
           name: JAR
           path: build/libs/flix.jar
       - name: Comment phase report
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: >

--- a/.github/workflows/semantic-commit.yaml
+++ b/.github/workflows/semantic-commit.yaml
@@ -6,11 +6,13 @@ on:
 jobs:
   check-title:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     env:
       regex: "^(chore|ci|docs|feat|fix|refactor|style|test): "
     steps:
       - name: Check title
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: >
@@ -18,5 +20,3 @@ jobs:
             if (title.match(process.env.regex) === null) {
               throw new Error("Invalid commit message '" + title + "'.")
             }
-            
-      


### PR DESCRIPTION
I found several actions still depend on old major releases, so I suggest updating them in batch.

I've confirmed that all workflows work fine with these fixes:

- [Compiler Tests](https://github.com/KengoTODA/flix/actions/runs/6705975929)
- [Community Build](https://github.com/KengoTODA/flix/actions/runs/6705975928)
- [Semantic Commit Message](https://github.com/KengoTODA/flix/actions/runs/6705975941)
- [JAR on Demand](https://github.com/KengoTODA/flix/actions/runs/6706049488)