### PR TITLE
feat: check loop fragments do no start with `if`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -912,6 +912,9 @@ object Weeder {
         case _ if frags.isEmpty =>
           val err = WeederError.IllegalEmptyForFragment(loc)
           WeededAst.Expr.Error(err).toSoftFailure(err)
+        case (WeededAst.ForFragment.Guard(_, loc1) :: _, _) =>
+          val err = WeederError.IllegalForFragment(loc1)
+          WeededAst.Expr.Error(err).toSoftFailure(err)
         case (fs1, e1) => WeededAst.Expr.MonadicFor(fs1, e1, loc).toSuccess
       }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -815,6 +815,24 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.IllegalForFragment](result)
   }
 
+  test("IllegalForFragment.03") {
+    val input =
+      """
+        |def f(x: Int32, ys: List[Int32]): List[Int32] = foreach (if x > 0) println(x)
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalForFragment](result)
+  }
+
+  test("IllegalForFragment.04") {
+    val input =
+      """
+        |def f(x: Int32, ys: List[Int32]): List[Int32] = foreach (if x > 0; y <- ys) println(x + y)
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalForFragment](result)
+  }
+
   test("IllegalEmptyForFragment.01") {
     val input =
       """

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -800,7 +800,9 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("IllegalForFragment.01") {
     val input =
       """
-        |def f(x: Int32): List[Int32] = foreach (if x > 0) yield 1
+        |def f(x: Int32): List[Int32] =
+        | foreach (if x > 0) yield 1
+        |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.IllegalForFragment](result)
@@ -809,7 +811,9 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("IllegalForFragment.02") {
     val input =
       """
-        |def f(x: Int32, ys: List[Int32]): List[Int32] = foreach (if x > 0; y <- ys) yield y
+        |def f(x: Int32, ys: List[Int32]): List[Int32] =
+        | foreach (if x > 0; y <- ys) yield y
+        |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.IllegalForFragment](result)
@@ -818,7 +822,9 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("IllegalForFragment.03") {
     val input =
       """
-        |def f(x: Int32, ys: List[Int32]): List[Int32] = foreach (if x > 0) println(x)
+        |def f(x: Int32): List[Int32] =
+        | foreach (if x > 0) println(x)
+        |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.IllegalForFragment](result)
@@ -827,7 +833,33 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("IllegalForFragment.04") {
     val input =
       """
-        |def f(x: Int32, ys: List[Int32]): List[Int32] = foreach (if x > 0; y <- ys) println(x + y)
+        |def g(_: Int32): Unit \ IO = checked_ecast(())
+        |
+        |def f(x: Int32, ys: List[Int32]): List[Int32] =
+        | foreach (if x > 0; y <- ys) println(y)
+        |
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalForFragment](result)
+  }
+
+  test("IllegalForFragment.05") {
+    val input =
+      """
+        |def f(x: Int32): List[Int32] =
+        | forM (if x > 0) yield x
+        |
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalForFragment](result)
+  }
+
+  test("IllegalForFragment.06") {
+    val input =
+      """
+        |def f(x: Int32, ys: List[Int32]): List[Int32] =
+        | forM (if x > 0; y <- ys) yield y
+        |
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.IllegalForFragment](result)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -1260,11 +1260,11 @@ class TestWeeder extends AnyFunSuite with TestUtils {
       """
         |def f(): Int32 = {
         | @Test
-        | def g(i) = if (i <= 0) 0 else 1 + g(i - 1);
+        | def g(i) = if (i <= 0) 0 else g(i - 1);
         | g(10)
         |}
         |""".stripMargin
-    val result = compile(input, Options.TestWithLibMin)
+    val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.IllegalInnerFunctionAnnotation](result)
   }
 
@@ -1273,11 +1273,11 @@ class TestWeeder extends AnyFunSuite with TestUtils {
       """
         |def f(): Int32 = {
         | @benchmark @Tailrec
-        | def g(i) = if (i <= 0) 0 else 1 + g(i - 1);
+        | def g(i) = if (i <= 0) 0 else g(i - 1);
         | g(10)
         |}
         |""".stripMargin
-    val result = compile(input, Options.TestWithLibMin)
+    val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.IllegalInnerFunctionAnnotation](result)
   }
 
@@ -1286,11 +1286,11 @@ class TestWeeder extends AnyFunSuite with TestUtils {
       """
         |def f(): Int32 = {
         | @Tailrec @Tailrec
-        | def g(i) = if (i <= 0) 0 else 1 + g(i - 1);
+        | def g(i) = if (i <= 0) 0 else g(i - 1);
         | g(10)
         |}
         |""".stripMargin
-    val result = compile(input, Options.TestWithLibMin)
+    val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.DuplicateAnnotation](result)
   }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -833,8 +833,6 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("IllegalForFragment.04") {
     val input =
       """
-        |def g(_: Int32): Unit \ IO = checked_ecast(())
-        |
         |def f(x: Int32, ys: List[Int32]): List[Int32] =
         | foreach (if x > 0; y <- ys) println(y)
         |


### PR DESCRIPTION
This PR adds two things:
1. Checks sub expressions of for loops before throwing potential errors
2. Checks that for loops do not begin with `if`