### PR TITLE
chore: rename `PatternExhaustiveness` to `PatMatch`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -542,7 +542,7 @@ class Flix {
       afterEntryPoint <- EntryPoint.run(afterTyper)
       _ <- Instances.run(afterEntryPoint, cachedTyperAst, changeSet)
       afterStratifier <- Stratifier.run(afterEntryPoint)
-      afterPatMatch <- PatternExhaustiveness.run(afterStratifier)
+      afterPatMatch <- PatMatch.run(afterStratifier)
       afterRedundancy <- Redundancy.run(afterPatMatch)
       afterSafety <- Safety.run(afterRedundancy)
     } yield {

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -38,7 +38,7 @@ import ca.uwaterloo.flix.util.{InternalCompilerException, Validation}
   * pattern match and returns the result.
   *
   */
-object PatternExhaustiveness {
+object PatMatch {
 
   /**
     * An ADT to make matching Type Constructors easier. We need to

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -108,7 +108,7 @@ object PatMatch {
     * Returns an error message if a pattern match is not exhaustive
     */
   def run(root: TypedAst.Root)(implicit flix: Flix): Validation[Root, NonExhaustiveMatchError] =
-    flix.phase("PatternExhaustiveness") {
+    flix.phase("PatMatch") {
       val defErrs = root.defs.values.flatMap(defn => visitExp(defn.exp, root))
       val instanceDefErrs = TypedAstOps.instanceDefsOf(root).flatMap(defn => visitExp(defn.exp, root))
       // Only need to check sigs with implementations


### PR DESCRIPTION
(This will make it easier to print graphs with phase names).