### PR TITLE
feat: optimize monoTypes

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/MonoTypes.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/MonoTypes.scala
@@ -69,6 +69,10 @@ object MonoTypes {
       */
     private val specializedEnums: mutable.Map[Symbol.EnumSym, LoweredAst.Enum] = mutable.Map.empty
 
+    def get(sym: Symbol.EnumSym, tpe: Type): Option[Symbol.EnumSym] = {
+      enum2enum.get((sym, tpe)).map(_._1)
+    }
+
     /**
       * Lookup `sym` specialized to `tpe`.
       *
@@ -486,7 +490,10 @@ object MonoTypes {
     val tpe = Type.mkEnum(sym, args, loc)
 
     // reuse specialization if possible
-    ctx.getOrPut(sym, args, tpe, args.isEmpty)
+    ctx.get(sym, tpe) match {
+      case None => ctx.getOrPut(sym, args, tpe, args.isEmpty)
+      case Some(s) => s
+    }
   }
 
   /**


### PR DESCRIPTION
* before
  * discover enums in defs, when a new enum is found, immediately specialize
* Trick 1
  * first discover enums in defs in parallel, then recursively specialized enums with frontier synchronization.
  * Performance gain: 1.2x (1 vs 8 cores)
* Trick 2
  *  don't synchronize `get`, only put
  * (I don't know if this is actually safe in the scala hashmap)
  * Performance gain (with trick 1) 2.6x (1 vs 8 cores)