### PR TITLE
refactor: rename `ParOps` functions.

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -35,7 +35,7 @@ object Deriver {
   private implicit val DefaultLevel: Level = Level.Default
 
   def run(root: KindedAst.Root)(implicit flix: Flix): Validation[KindedAst.Root, DerivationError] = flix.phase("Deriver") {
-    val derivedInstances = ParOps.parMapSeq(root.enums.values)(getDerivedInstances(_, root))
+    val derivedInstances = ParOps.parTraverse(root.enums.values)(getDerivedInstances(_, root))
 
     mapN(derivedInstances) {
       instances =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -72,17 +72,17 @@ object Kinder {
     flatMapN(visitTypeAliases(root.taOrder, root)) {
       taenv =>
 
-        val enumsVal = ParOps.parMapValuesSeq(root.enums)(visitEnum(_, taenv, root))
+        val enumsVal = ParOps.parTraverseValues(root.enums)(visitEnum(_, taenv, root))
 
-        val restrictableEnumsVal = ParOps.parMapValuesSeq(root.restrictableEnums)(visitRestrictableEnum(_, taenv, root))
+        val restrictableEnumsVal = ParOps.parTraverseValues(root.restrictableEnums)(visitRestrictableEnum(_, taenv, root))
 
         val classesVal = visitClasses(root, taenv, oldRoot, changeSet)
 
         val defsVal = visitDefs(root, taenv, oldRoot, changeSet)
 
-        val instancesVal = ParOps.parMapValuesSeq(root.instances)(traverse(_)(i => visitInstance(i, taenv, root)))
+        val instancesVal = ParOps.parTraverseValues(root.instances)(traverse(_)(i => visitInstance(i, taenv, root)))
 
-        val effectsVal = ParOps.parMapValuesSeq(root.effects)(visitEffect(_, taenv, root))
+        val effectsVal = ParOps.parTraverseValues(root.effects)(visitEffect(_, taenv, root))
 
         mapN(enumsVal, restrictableEnumsVal, classesVal, defsVal, instancesVal, effectsVal) {
           case (enums, restrictableEnums, classes, defs, instances, effects) =>
@@ -208,7 +208,7 @@ object Kinder {
   private def visitClasses(root: ResolvedAst.Root, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Validation[Map[Symbol.ClassSym, KindedAst.Class], KindError] = {
     val (staleClasses, freshClasses) = changeSet.partition(root.classes, oldRoot.classes)
 
-    val result = ParOps.parMapValuesSeq(staleClasses)(visitClass(_, taenv, root))
+    val result = ParOps.parTraverseValues(staleClasses)(visitClass(_, taenv, root))
     result.map(freshClasses ++ _)
   }
 
@@ -275,7 +275,7 @@ object Kinder {
   private def visitDefs(root: ResolvedAst.Root, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Validation[Map[Symbol.DefnSym, KindedAst.Def], KindError] = {
     val (staleDefs, freshDefs) = changeSet.partition(root.defs, oldRoot.defs)
 
-    val result = ParOps.parMapValuesSeq(staleDefs)(visitDef(_, Nil, KindEnv.empty, taenv, root))
+    val result = ParOps.parTraverseValues(staleDefs)(visitDef(_, Nil, KindEnv.empty, taenv, root))
     result.map(freshDefs ++ _)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -40,7 +40,7 @@ object Namer {
       case (macc, root) => macc + (root.loc.source -> root.loc)
     }
 
-    val unitsVal = ParOps.parMapValuesSeq(program.units)(visitUnit)
+    val unitsVal = ParOps.parTraverseValues(program.units)(visitUnit)
 
     flatMapN(unitsVal) {
       case units =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -51,7 +51,7 @@ object Parser {
       val (stale, fresh) = changeSet.partition(root.sources, oldRoot.units)
 
       // Parse each stale source in parallel.
-      val result = ParOps.parMapSeq(stale.keys)(parseRoot)
+      val result = ParOps.parTraverse(stale.keys)(parseRoot)
 
       // Combine the ASTs into one abstract syntax tree.
       result.map {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -27,7 +27,7 @@ object Parser2 {
   def run(root: Map[Ast.Source, Array[Token]])(implicit flix: Flix): Validation[Map[Ast.Source, UnstructuredTree.Tree], CompilationMessage] =
     flix.phase("Parser2") {
       // Parse each source file in parallel.
-      ParOps.parMapValuesSeq(root)(parse)
+      ParOps.parTraverseValues(root)(parse)
     }
 
   private def parse(ts: Array[Token]): Validation[UnstructuredTree.Tree, CompilationMessage] = {

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -98,7 +98,7 @@ object Resolver {
     flatMapN(sequence(usesVal), resolveTypeAliases(defaultUses, root)) {
       case (uses, (taenv, taOrder)) =>
 
-        val unitsVal = ParOps.parMapSeq(root.units.values)(visitUnit(_, taenv, defaultUses, root))
+        val unitsVal = ParOps.parTraverse(root.units.values)(visitUnit(_, taenv, defaultUses, root))
         flatMapN(unitsVal) {
           case units =>
             val table = SymbolTable.traverse(units)(tableUnit)

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -50,9 +50,9 @@ object Stratifier {
     implicit val g: LabelledPrecedenceGraph = root.precedenceGraph
     implicit val r: Root = root
     // Compute the stratification at every datalog expression in the ast.
-    val newDefs = ParOps.parMapValuesSeq(root.defs)(visitDef(_))
-    val newInstances = ParOps.parMapValuesSeq(root.instances)(traverse(_)(visitInstance(_)))
-    val newClasses = ParOps.parMapValuesSeq(root.classes)(visitClass(_))
+    val newDefs = ParOps.parTraverseValues(root.defs)(visitDef(_))
+    val newInstances = ParOps.parTraverseValues(root.instances)(traverse(_)(visitInstance(_)))
+    val newClasses = ParOps.parTraverseValues(root.classes)(visitClass(_))
 
     mapN(newDefs, newInstances, newClasses) {
       case (ds, is, cs) => root.copy(defs = ds, instances = is, classes = cs)

--- a/main/src/ca/uwaterloo/flix/language/phase/TreeShaker1.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TreeShaker1.scala
@@ -47,7 +47,7 @@ object TreeShaker1 {
     val initReach = initReachable(root)
 
     // Compute the symbols that are transitively reachable.
-    val allReachable = ParOps.parReachable(initReach, visitSym(_, root))
+    val allReachable = ParOps.parReach(initReach, visitSym(_, root))
 
     // Filter the reachable definitions.
     val reachableDefs = root.defs.filter {

--- a/main/src/ca/uwaterloo/flix/language/phase/TreeShaker2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TreeShaker2.scala
@@ -41,7 +41,7 @@ object TreeShaker2 {
     val initReach = initReachable(root)
 
     // Compute the symbols that are transitively reachable.
-    val allReachable = ParOps.parReachable(initReach, visitSym(_, root))
+    val allReachable = ParOps.parReach(initReach, visitSym(_, root))
 
     // Filter the reachable definitions.
     val newDefs = root.defs.filter {

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeInference.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeInference.scala
@@ -98,7 +98,7 @@ object TypeInference {
     flix.subphase("Classes") {
       // Don't bother to infer the fresh classes
       val (staleClasses, freshClasses) = changeSet.partition(root.classes, oldRoot.classes)
-      val result = ParOps.parMapSeq(staleClasses.values)(visitClass(_, root, classEnv, eqEnv))
+      val result = ParOps.parTraverse(staleClasses.values)(visitClass(_, root, classEnv, eqEnv))
       result.map {
         case substs =>
           val (sigSubsts, defSubsts) = substs.unzip
@@ -136,7 +136,7 @@ object TypeInference {
         inst <- insts
       } yield inst
 
-      val result = ParOps.parMapSeq(instances)(visitInstance(_, root, classEnv, eqEnv))
+      val result = ParOps.parTraverse(instances)(visitInstance(_, root, classEnv, eqEnv))
 
       result.map {
         case substs => substs.fold(Map.empty)(_ ++ _)
@@ -199,7 +199,7 @@ object TypeInference {
       // only infer the stale defs
       val (staleDefs, freshDefs) = changeSet.partition(root.defs, oldRoot.defs)
 
-      ParOps.parMapValuesSeq(staleDefs)(visitDefn(_, Nil, root, classEnv, eqEnv))
+      ParOps.parTraverseValues(staleDefs)(visitDefn(_, Nil, root, classEnv, eqEnv))
     }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -65,7 +65,7 @@ object Weeder {
       // Compute the stale and fresh sources.
       val (stale, fresh) = changeSet.partition(root.units, oldRoot.units)
 
-      ParOps.parMapValuesSeq(stale)(visitCompilationUnit).map {
+      ParOps.parTraverseValues(stale)(visitCompilationUnit).map {
         result =>
           val m = fresh ++ result
           WeededAst.Root(m, root.entryPoint, root.names)

--- a/main/src/ca/uwaterloo/flix/util/ParOps.scala
+++ b/main/src/ca/uwaterloo/flix/util/ParOps.scala
@@ -31,7 +31,7 @@ object ParOps {
   private val SequentialThreshold: Int = 4
 
   /**
-    * Applies the function `f` to every element in `xs` in parallel.
+    * Applies the function `f` to every element of `xs` in parallel.
     */
   def parMap[A, B: ClassTag](xs: Iterable[A])(f: A => B)(implicit flix: Flix): Iterable[B] = {
     // Compute the size of the input and construct a new empty array to hold the result.
@@ -58,7 +58,7 @@ object ParOps {
   }
 
   /**
-    * Applies the function `f` to every value in the map `m` in parallel.
+    * Applies the function `f` to every value of the map `m` in parallel.
     */
   def parMapValues[K, A, B](m: Map[K, A])(f: A => B)(implicit flix: Flix): Map[K, B] =
     parMap(m) {
@@ -66,7 +66,7 @@ object ParOps {
     }.toMap
 
   /**
-    * Applies the function `f` to every element in `xs` in parallel. Aggregates the result using the applicative instance for Validation.
+    * Applies the function `f` to every element of `xs` in parallel. Aggregates the result using the applicative instance for [[Validation]].
     */
   def parTraverse[A, B, E](xs: Iterable[A])(f: A => Validation[B, E])(implicit flix: Flix): Validation[Iterable[B], E] = {
     val results = parMap(xs)(f)
@@ -74,7 +74,7 @@ object ParOps {
   }
 
   /**
-    * Applies the function `f` to every element in the map `m` in parallel. Aggregates the result using the applicative instance for Validation.
+    * Applies the function `f` to every element of the map `m` in parallel. Aggregates the result using the applicative instance for [[Validation]].
     */
   def parTraverseValues[K, A, B, E](m: Map[K, A])(f: A => Validation[B, E])(implicit flix: Flix): Validation[Map[K, B], E] = {
     parTraverse(m) {


### PR DESCRIPTION
Fixes #6613