### PR TITLE
feat: add resumption argument to effect handlers

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/TypeInference.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeInference.scala
@@ -1067,14 +1067,20 @@ object TypeInference {
           }
         }
 
-        def visitHandlerRule(rule: KindedAst.HandlerRule): InferMonad[(List[Ast.TypeConstraint], Type, Type)] = rule match {
-          case KindedAst.HandlerRule(op, actualFparams, body, opTvar) =>
+        def visitHandlerRule(rule: KindedAst.HandlerRule, tryBlockTpe: Type, tryBlockEff: Type): InferMonad[(List[Ast.TypeConstraint], Type, Type)] = rule match {
+          case KindedAst.HandlerRule(op, actualFparams0, body, opTvar) =>
             // Don't need to generalize since ops are monomorphic
             // Don't need to handle unknown op because resolver would have caught this
+            val (actualFparams, List(resumptionFparam)) = actualFparams0.splitAt(actualFparams0.length - 1)
             ops(op.sym) match {
-              case KindedAst.Op(_, KindedAst.Spec(_, _, _, _, expectedFparams, _, opTpe, expectedPur, _, _, _)) =>
+              case KindedAst.Op(_, KindedAst.Spec(_, _, _, _, expectedFparams, _, opTpe, _, _, _, _)) =>
+                val resumptionArgType = opTpe
+                val resumptionResType = tryBlockTpe
+                val resumptionEff = tryBlockEff
+                val expectedResumptionType = Type.mkArrowWithEffect(resumptionArgType, resumptionEff, resumptionResType, loc.asSynthetic)
                 for {
                   _ <- unifyFormalParams(op.sym, expected = expectedFparams, actual = actualFparams)
+                  _ <- expectTypeM(expected = expectedResumptionType, actual = resumptionFparam.tpe, resumptionFparam.loc)
                   (actualTconstrs, actualTpe, actualEff) <- visitExp(body)
 
                   // unify the operation return type with its tvar
@@ -1082,18 +1088,18 @@ object TypeInference {
 
                   // unify the handler result type with the whole block's tvar
                   resultTpe <- expectTypeM(expected = tvar, actual = actualTpe, body.loc)
-                  resultEff <- expectTypeM(expected = expectedPur, actual = actualEff, body.loc) // MATT improve error message for this
-                } yield (actualTconstrs, resultTpe, resultEff)
+                } yield (actualTconstrs, resultTpe, actualEff)
             }
         }
 
         val effType = Type.Cst(TypeConstructor.Effect(effUse.sym), effUse.loc)
         for {
-          (tconstrs, tpe, eff) <- visitExp(exp)
-          (tconstrss, _, effs) <- traverseM(rules)(visitHandlerRule).map(_.unzip3)
+          (tconstrs, tpe, bodyEff) <- visitExp(exp)
+          (tconstrss, _, effs) <- traverseM(rules)(visitHandlerRule(_, tpe, bodyEff)).map(_.unzip3)
           resultTconstrs = (tconstrs :: tconstrss).flatten
           resultTpe <- unifyTypeM(tvar, tpe, loc)
-          resultEff = Type.mkUnion(Type.mkDifference(eff, effType, loc) :: effs, loc)
+          compositeEff = Type.mkUnion(bodyEff :: effs, bodyEff.loc.asSynthetic)
+          resultEff = Type.mkDifference(compositeEff, effType, loc)
         } yield (resultTconstrs, resultTpe, resultEff)
 
       case KindedAst.Expr.Do(op, args, tvar, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -1602,10 +1602,16 @@ object Weeder {
       val expVal = visitExp(exp0, senv)
       val rulesVal = traverse(rules0.getOrElse(Seq.empty)) {
         case ParsedAst.HandlerRule(op, fparams0, body0) =>
-          val fparamsVal = visitFormalParams(fparams0, Presence.Forbidden)
+          // In this case, we want an extra resumption argument
+          // so both an empty list and a singleton list should be padded with unit
+          // [] --> [_unit]
+          // [x] --> [_unit, x]
+          // [x, ...] --> [x, ...]
+          val fparamsValPrefix = if (fparams0.sizeIs == 1) visitFormalParams(Seq.empty, Presence.Forbidden) else Nil.toSuccess
+          val fparamsValSuffix = visitFormalParams(fparams0, Presence.Forbidden)
           val bodyVal = visitExp(body0, SyntacticEnv.Handler)
-          mapN(fparamsVal, bodyVal) {
-            case (fparams, body) => WeededAst.HandlerRule(op, fparams, body)
+          mapN(fparamsValPrefix, fparamsValSuffix, bodyVal) {
+            case (fparamsPrefix, fparamsSuffix, body) => WeededAst.HandlerRule(op, fparamsPrefix ++ fparamsSuffix, body)
           }
       }
       val loc = mkSL(sp1, sp2)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -654,7 +654,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |
         |def foo(): Unit = {
         |    try () with E {
-        |        def op(x, y) = ()
+        |        def op(x, y, cont) = ()
         |    }
         |}
         |""".stripMargin

--- a/main/test/flix/Test.Exp.Effect.flix
+++ b/main/test/flix/Test.Exp.Effect.flix
@@ -5,14 +5,14 @@ mod Test.Exp.Effect {
     // @test
     pub def handleEff01(): Bool = {
         try true with Fail {
-            def fail(_) = false
+            def fail(_, _cont) = false
         }
     }
 
     // @test
     pub def handleEff02(): Unit = {
         try () with Fail {
-            def fail(_) = resume()
+            def fail(_, cont) = cont()
         }
     }
 
@@ -33,14 +33,14 @@ mod Test.Exp.Effect {
             do Test.Exp.Effect.Console.println("bye");
             true
         } with Console {
-            def println(_) = resume()
+            def println(_, cont) = cont()
         }
     }
 
     // @test
     pub def handlePerform01(): Unit = {
         try do Test.Exp.Effect.Fail.fail("rats") with Fail {
-            def fail(_) = ()
+            def fail(_, _cont) = ()
         }
     }
 
@@ -50,7 +50,7 @@ mod Test.Exp.Effect {
             let _ = do Test.Exp.Effect.Console.println("It was the best of times");
             true
         } with Console {
-            def println(_) = resume()
+            def println(_, cont) = cont()
         }
     }
 

--- a/main/test/flix/Test.Exp.TryWith.flix
+++ b/main/test/flix/Test.Exp.TryWith.flix
@@ -20,7 +20,7 @@ mod Test.Exp.TryWith {
         try {
             do Test.Exp.TryWith.Print.doIt()
         } with Print {
-            def doIt() = ()
+            def doIt(_cont) = ()
         }
     }
 
@@ -29,11 +29,11 @@ mod Test.Exp.TryWith {
         try {
             do Test.Exp.TryWith.Print.doIt()
         } with Print {
-            def doIt() = {
+            def doIt(_cont) = {
                 try {
                     do Test.Exp.TryWith.Print2.doIt2()
                 } with Print2 {
-                    def doIt2() = ()
+                    def doIt2(_cont) = ()
                 }
             }
         }
@@ -45,7 +45,7 @@ mod Test.Exp.TryWith {
         try {
             letsDoIt()
         } with Print {
-            def doIt() = ()
+            def doIt(_cont) = ()
         }
     }
 
@@ -54,7 +54,7 @@ mod Test.Exp.TryWith {
         try {
             do Test.Exp.TryWith.Greet.greet("Alice")
         } with Greet {
-            def greet(_) = ()
+            def greet(_, _cont) = ()
         }
     }
 
@@ -63,11 +63,11 @@ mod Test.Exp.TryWith {
         try {
             do Test.Exp.TryWith.Greet.greet("Duchess")
         } with Greet {
-            def greet(name) = {
+            def greet(name, _cont) = {
                 try {
                     do Test.Exp.TryWith.Greet2.greet2(name)
                 } with Greet2 {
-                    def greet2(_) = ()
+                    def greet2(_, _cont) = ()
                 }
             }
         }
@@ -86,7 +86,7 @@ mod Test.Exp.TryWith {
         try {
             greetAll("Cheshire Cat" :: "Queen of Hearts" :: "White Rabbit" :: "Dormouse" :: Nil)
         } with Greet {
-            def greet(_) = ()
+            def greet(_, _cont) = ()
         }
     }
 
@@ -97,10 +97,10 @@ mod Test.Exp.TryWith {
                 do Test.Exp.TryWith.Print.doIt();
                 do Test.Exp.TryWith.Print2.doIt2()
             } with Print {
-                def doIt() = ()
+                def doIt(_cont) = ()
             }
         } with Print2 {
-            def doIt2() = ()
+            def doIt2(_cont) = ()
         }
     }
 
@@ -110,11 +110,11 @@ mod Test.Exp.TryWith {
             try {
                 do Test.Exp.TryWith.Print.doIt()
             } with Print {
-                def doIt() = ()
+                def doIt(_cont) = ()
             };
             do Test.Exp.TryWith.Print2.doIt2()
         } with Print2 {
-            def doIt2() = ()
+            def doIt2(_cont) = ()
         }
     }
 }


### PR DESCRIPTION
Fixes #6642
```
eff MyEffect {
    pub def yield(x: Int32): Unit
}

def main(): Int32 = {
    try {
        let x = 42;
        do MyEffect.yield(1);
        let y = 13;
        do MyEffect.yield(1);
        x + y
    } with MyEffect {
        def yield(x, rr) = rr() + x
    }
}
```

- `resume` still exists as a keyword and ast node
- usability is bad, if you just write `yield(rr)` in the handler above, you get a type error with unknown location