### PR TITLE
refactor: introduce `LocalContext` and `SharedContext` in `Redundancy`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/RedundancyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/RedundancyError.scala
@@ -401,36 +401,6 @@ object RedundancyError {
   }
 
   /**
-    * An error raised to indicate that the given variable symbol `sym` is only used once in a constraint.
-    *
-    * @param sym the variable only used once
-    * @param loc the location of the error
-    */
-  case class IllegalSingleVariable(sym: Symbol.VarSym, loc: SourceLocation) extends RedundancyError {
-    def summary: String = s"Single use of variable '$sym'."
-
-    def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> This variable is named, but only used once '${red(sym.text)}'. Use a wildcard instead?
-         |
-         |${code(loc, "the variable occurs here.")}
-         |""".stripMargin
-    }
-
-    def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         |Possible fixes:
-         |
-         |  (1)  Prefix the variable name with a wildcard.
-         |  (2)  Replace the variable name with a wildcard.
-         |  (3)  Check for any spelling mistakes.
-         |
-         |""".stripMargin
-    })
-  }
-
-  /**
     * An error raised to indicate that an expression is useless.
     *
     * @param tpe the type of the expression.

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -1198,7 +1198,10 @@ object Redundancy {
      * Marks all the given variable symbols `syms` as used.
      */
     def --(syms: Iterable[Symbol.VarSym]): Used =
-      if (syms.isEmpty) this else copy(varSyms = varSyms -- syms)
+      if (syms.isEmpty)
+        this
+      else
+        copy(varSyms = varSyms -- syms, occurrencesOf = occurrencesOf -- syms)
 
     /**
      * Returns `this` without any unused variable errors.

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -81,8 +81,6 @@ object Redundancy {
     usedRes.toValidation(root)
   }
 
-  class SharedContext(val defSyms: ConcurrentHashMap[Symbol.DefnSym, Unit])
-
   /**
     * Checks for unused symbols in the given signature and returns all used symbols.
     */
@@ -1307,4 +1305,12 @@ object Redundancy {
       */
     def ofSig(sig: Symbol.SigSym): RecursionContext = RecursionContext(defn = None, sig = Some(sig), vars = Set.empty)
   }
+
+  /**
+    * A global shared context. Must be thread-safe.
+    *
+    * @param defSyms the definition symbols used anywhere in the program.
+    */
+  class SharedContext(val defSyms: ConcurrentHashMap[Symbol.DefnSym, Unit])
+
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -103,9 +103,9 @@ object Redundancy {
       unusedFormalParams ++
       unusedTypeParams).copy(varSyms = Set.empty)
 
-    // Check if the expression contains holes or errors.
-    // If it does, we discard all unused local variable errors.
-    if (lctx.holeSyms.isEmpty && !usedAll.hasErrorNode)
+    // If the expression has no holes nor errors then we return usedAll.
+    // Otherwise, we discard all unused variable errors.
+    if (lctx.holeSyms.isEmpty && lctx.errorLocs.isEmpty)
       usedAll
     else
       usedAll.withoutUnusedVars
@@ -129,9 +129,9 @@ object Redundancy {
       unusedFormalParams ++
       unusedTypeParams).copy(varSyms = Set.empty)
 
-    // Check if the expression contains holes or errors.
-    // If it does, we discard all unused local variable errors.
-    if (lctx.holeSyms.isEmpty && !usedAll.hasErrorNode)
+    // If the expression has no holes nor errors then we return usedAll.
+    // Otherwise, we discard all unused variable errors.
+    if (lctx.holeSyms.isEmpty && lctx.errorLocs.isEmpty)
       usedAll
     else
       usedAll.withoutUnusedVars
@@ -763,7 +763,8 @@ object Redundancy {
       visitExp(exp, env0, rc)
 
     case Expr.Error(_, _, _) =>
-      Used.empty.withErrorNode
+      lctx.errorLocs += e0.loc
+      Used.empty
 
   }
 
@@ -1133,7 +1134,7 @@ object Redundancy {
     /**
       * Represents the empty set of used symbols.
       */
-    val empty: Used = Used(Set.empty, ListMap.empty, hasErrorNode = false, Set.empty)
+    val empty: Used = Used(Set.empty, ListMap.empty, Set.empty)
 
     /**
       * Returns an object where the given variable symbol `sym` is marked as used.
@@ -1156,7 +1157,6 @@ object Redundancy {
     */
   private case class Used(varSyms: Set[Symbol.VarSym],
                           occurrencesOf: ListMap[Symbol.VarSym, SourceLocation],
-                          hasErrorNode: Boolean,
                           errors: Set[RedundancyError]) {
 
     /**
@@ -1173,7 +1173,6 @@ object Redundancy {
         Used(
           this.varSyms ++ that.varSyms,
           this.occurrencesOf ++ that.occurrencesOf,
-          this.hasErrorNode || that.hasErrorNode,
           this.errors ++ that.errors
         )
       }
@@ -1213,11 +1212,6 @@ object Redundancy {
     })
 
     /**
-      * Returns `this` with an error node.
-      */
-    def withErrorNode: Used = copy(hasErrorNode = true)
-
-    /**
       * Returns Successful(a) unless `this` contains errors.
       */
     def toValidation[A](a: A): Validation[A, RedundancyError] = if (errors.isEmpty) Success(a) else SoftFailure(a, errors.to(LazyList))
@@ -1227,15 +1221,16 @@ object Redundancy {
     * Companion object for [[LocalContext]].
     */
   private object LocalContext {
-    def mk(): LocalContext = new LocalContext(mutable.Set.empty)
+    def mk(): LocalContext = new LocalContext(mutable.Set.empty, mutable.Set.empty)
   }
 
   /**
-    * A local non-shared context.
+    * A local non-shared context. Does not need to be thread-safe.
     *
-    * @param holeSyms the hole symbols in the def or sig.
+    * @param holeSyms  the hole symbols in the def or sig.
+    * @param errorLocs the source locations of the error expressions.
     */
-  private case class LocalContext(holeSyms: mutable.Set[Symbol.HoleSym])
+  private case class LocalContext(holeSyms: mutable.Set[Symbol.HoleSym], errorLocs: mutable.Set[SourceLocation])
 
   /**
     * Companion object for [[SharedContext]]

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -1081,7 +1081,7 @@ object Redundancy {
   private def deadEnum(enm: Enum, used: Used): Boolean =
     !enm.sym.name.startsWith("_") &&
       !enm.mod.isPublic &&
-      used.enumSyms(enm.sym).isEmpty
+      !used.enumSyms.contains(enm.sym)
 
   /**
     * Returns `true` if the given `tag` of the given `enm` is unused according to `used`.
@@ -1090,7 +1090,7 @@ object Redundancy {
     !enm.sym.name.startsWith("_") &&
       !enm.mod.isPublic &&
       !tag.name.startsWith("_") &&
-      !used.enumSyms(enm.sym).contains(tag)
+      !used.tagSyms.contains(tag)
 
   /**
     * Returns `true` if the given `tag` is unused according to the `usedTags`.
@@ -1162,12 +1162,12 @@ object Redundancy {
     /**
       * Represents the empty set of used symbols.
       */
-    val empty: Used = Used(MultiMap.empty, MultiMap.empty, Set.empty, Set.empty, Set.empty, ListMap.empty, hasErrorNode = false, Set.empty)
+    val empty: Used = Used(Set.empty, Set.empty, MultiMap.empty, Set.empty, Set.empty, Set.empty, ListMap.empty, hasErrorNode = false, Set.empty)
 
     /**
       * Returns an object where the given enum symbol `sym` and `tag` are marked as used.
       */
-    def of(sym: Symbol.EnumSym, caze: Symbol.CaseSym): Used = empty.copy(enumSyms = MultiMap.singleton(sym, caze))
+    def of(sym: Symbol.EnumSym, caze: Symbol.CaseSym): Used = empty.copy(enumSyms = Set(sym), tagSyms = Set(caze))
 
     /**
       * Returns an object where the given restrictable enum symbol `sym` and `tag` are marked as used.
@@ -1203,7 +1203,8 @@ object Redundancy {
   /**
     * A representation of used symbols.
     */
-  private case class Used(enumSyms: MultiMap[Symbol.EnumSym, Symbol.CaseSym],
+  private case class Used(enumSyms: Set[Symbol.EnumSym],
+                          tagSyms: Set[Symbol.CaseSym],
                           restrictableEnumSyms: MultiMap[Symbol.RestrictableEnumSym, Symbol.RestrictableCaseSym],
                           holeSyms: Set[Symbol.HoleSym],
                           varSyms: Set[Symbol.VarSym],
@@ -1225,6 +1226,7 @@ object Redundancy {
       } else {
         Used(
           this.enumSyms ++ that.enumSyms,
+          this.tagSyms ++ that.tagSyms,
           this.restrictableEnumSyms ++ that.restrictableEnumSyms,
           this.holeSyms ++ that.holeSyms,
           this.varSyms ++ that.varSyms,

--- a/main/src/ca/uwaterloo/flix/util/collection/ListMap.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/ListMap.scala
@@ -74,4 +74,14 @@ case class ListMap[K, V](m: Map[K, List[V]]) {
     }
   }
 
+  /**
+   * Returns `this` list map without the mapping for `k`.
+   */
+  def -(k: K): ListMap[K, V] = ListMap(m - k)
+
+  /**
+   * Returns ´this´ list map without the mappings for ´ks´.
+   */
+  def --(ks: Iterable[K]): ListMap[K, V] = ListMap(m -- ks)
+
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -1625,20 +1625,6 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     expectError[RedundancyError.UnusedFormalParam](result)
   }
 
-  test("IllegalSingleVariable.Predicate.01") {
-    val input =
-      s"""
-         |mod N {
-         |    def f(): #{ A(Int32), B(Int32), C(Int32) } =
-         |        #{
-         |            A(x) :- B(x), C(y).
-         |        }
-         |}
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibMin)
-    expectError[RedundancyError.IllegalSingleVariable](result)
-  }
-
   test("UnusedDefSym.01") {
     val input =
       """


### PR DESCRIPTION
- Introduce `LocalContext`
- Introduce `SharedContex`
- Drop `IllegalSingleVariable` (but see #6724)
- Drop support for restrictable variants.