### PR TITLE
feat: Add `TokenKind.BangEqual` and `TokenKind.ArrowThin` 

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -47,13 +47,17 @@ object TokenKind {
 
   case object Arrow extends TokenKind
 
+  case object ArrowThin extends TokenKind
+
   case object At extends TokenKind
 
-  case object BackArrow extends TokenKind
+  case object BackArrowThin extends TokenKind
 
   case object Backslash extends TokenKind
 
   case object Bang extends TokenKind
+
+  case object BangEqual extends TokenKind
 
   case object Bar extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -354,11 +354,13 @@ object Lexer {
       case _ if isKeyword("???") => TokenKind.HoleAnonymous
       case '?' if peek().isLetter => acceptNamedHole()
       case _ if isKeyword("**") => TokenKind.StarStar
-      case _ if isKeyword("<-") => TokenKind.BackArrow
+      case _ if isKeyword("<-") => TokenKind.BackArrowThin
       case _ if isKeyword("=>") => TokenKind.Arrow
+      case _ if isKeyword("->") => TokenKind.ArrowThin
       case _ if isKeyword("<=") => TokenKind.AngleLEqual
       case _ if isKeyword(">=") => TokenKind.AngleREqual
       case _ if isKeyword("==") => TokenKind.EqualEqual
+      case _ if isKeyword("!=") => TokenKind.BangEqual
       case _ if isKeyword("&&&") => TokenKind.TripleAmpersand
       case _ if isKeyword("<<<") => TokenKind.TripleAngleL
       case _ if isKeyword(">>>") => TokenKind.TripleAngleR


### PR DESCRIPTION
Amazingly I forgot these tokens in the initial push for the lexer.