### PR TITLE
feat: Lex regex literals

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -263,6 +263,8 @@ object TokenKind {
 
   case object LiteralInt64 extends TokenKind
 
+  case object LiteralRegex extends TokenKind
+
   case object LiteralString extends TokenKind
 
   case object LiteralStringInterpolationL extends TokenKind

--- a/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
@@ -153,6 +153,27 @@ object LexerError {
   }
 
   /**
+   * An error raised when an unterminated regex is encountered.
+   *
+   * @param loc The location of the opening `"`.
+   */
+  case class UnterminatedRegex(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Unterminated regex."
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Missing `"` in regex.
+         |
+         |${code(loc, "Regex starts here")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
    * An error raised when an unterminated infix function is encountered.
    *
    * @param loc The location of the opening '&#96;'.

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -444,6 +444,7 @@ object Lexer {
       case _ if isKeyword("Map#") => TokenKind.MapHash
       case _ if isKeyword("List#") => TokenKind.ListHash
       case _ if isKeyword("Vector#") => TokenKind.VectorHash
+      case _ if isKeyword("regex\"") => acceptRegex()
       case _ if isMathNameChar(c) => acceptMathName()
       case _ if isGreekNameChar(c) => acceptGreekName()
       // User defined operators.
@@ -796,6 +797,23 @@ object Lexer {
     }
 
     TokenKind.Err(LexerError.UnterminatedChar(sourceLocationAtStart()))
+  }
+
+  /**
+   * Moves current position past a regex literal.
+   * If the regex  is unterminated a `TokenKind.Err` is returned.
+   */
+  private def acceptRegex()(implicit s: State): TokenKind = {
+    while (!eof()) {
+      val p = escapedPeek()
+      if (p.contains('"')) {
+        advance()
+        return TokenKind.LiteralRegex
+      }
+      advance()
+    }
+
+    TokenKind.Err(LexerError.UnterminatedRegex(sourceLocationAtStart()))
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
@@ -139,10 +139,16 @@ class TestLexer extends AnyFunSuite with TestUtils {
     expectError[LexerError.UnterminatedChar](result)
   }
 
-  test("LexerError.UnterminatedChar.05") {
-    val input = "'a"
+  test("LexerError.UnterminatedRegex.01") {
+    val input = """ regex" """
     val result = compile(input, Options.TestWithLibNix)
-    expectError[LexerError.UnterminatedChar](result)
+    expectError[LexerError.UnterminatedRegex](result)
+  }
+
+  test("LexerError.UnterminatedRegex.02") {
+    val input = """ regex"\" """
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.UnterminatedRegex](result)
   }
 
   test("LexerError.UnterminatedInfixFunction.01") {


### PR DESCRIPTION
Lex regex literals such as `regex"{Alpha}"`