### PR TITLE
refactor: cleanup `SafetyError`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -17,28 +17,6 @@ sealed trait SafetyError extends CompilationMessage {
 object SafetyError {
 
   /**
-   * An error raised to indicate that an object derivation includes a method that doesn't exist in the superclass being implemented.
-   *
-   * @param clazz The type of superclass
-   * @param name  The name of the extra method.
-   * @param loc   The source location of the method.
-   */
-  case class ExtraMethod(clazz: java.lang.Class[_], name: String, loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Method '$name' not found in superclass '${clazz.getName}'"
-
-    def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Method '${red(name)}' not found in superclass '${red(clazz.getName)}'
-         |
-         |${code(loc, "the method occurs here.")}
-         |""".stripMargin
-    }
-
-    def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
    * An error raised to indicate a cast from a non-Java type to a Java type.
    *
    * @param from the source type.
@@ -341,35 +319,6 @@ object SafetyError {
   }
 
   /**
-    * An error raised to indicate an invalid `this` parameter for a method.
-    *
-    * @param clazz           The expected `this` type.
-    * @param illegalThisType The incorrect `this` type.
-    * @param name            The name of the method with the invalid `this` parameter.
-    * @param loc             The source location of the method.
-    */
-  case class IllegalThisType(clazz: java.lang.Class[_], illegalThisType: Type, name: String, loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Invalid `this` parameter for method '$name'."
-
-    def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Invalid 'this' parameter for method '${red(name)}''.
-         |
-         |Expected 'this' type is ${cyan(s"##${clazz.getName}")}, but the first argument is declared as type ${cyan(illegalThisType.toString)}
-         |
-         |${code(loc, "the method occurs here.")}
-         |""".stripMargin
-    }
-
-    def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         | The first argument to any method must be 'this', and must have the same type as the superclass.
-         |""".stripMargin
-    })
-  }
-
-  /**
    * An error raised to indicate an impossible cast.
    *
    * @param from the type of the expression being cast.
@@ -425,12 +374,41 @@ object SafetyError {
   }
 
   /**
+   * An error raised to indicate an invalid `this` parameter for a method.
+   *
+   * @param clazz           The expected `this` type.
+   * @param illegalThisType The incorrect `this` type.
+   * @param name            The name of the method with the invalid `this` parameter.
+   * @param loc             The source location of the method.
+   */
+  case class NewObjectIllegalThisType(clazz: java.lang.Class[_], illegalThisType: Type, name: String, loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Invalid `this` parameter for method '$name'."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Invalid 'this' parameter for method '${red(name)}''.
+         |
+         |Expected 'this' type is ${cyan(s"##${clazz.getName}")}, but the first argument is declared as type ${cyan(illegalThisType.toString)}
+         |
+         |${code(loc, "the method occurs here.")}
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = Some({
+      s"""
+         | The first argument to any method must be 'this', and must have the same type as the superclass.
+         |""".stripMargin
+    })
+  }
+
+  /**
     * An error raised to indicate that a class lacks a public zero argument constructor.
     *
     * @param clazz the class.
     * @param loc   the source location of the new object expression.
     */
-  case class MissingPublicZeroArgConstructor(clazz: java.lang.Class[_], loc: SourceLocation) extends SafetyError {
+  case class NewObjectMissingPublicZeroArgConstructor(clazz: java.lang.Class[_], loc: SourceLocation) extends SafetyError {
     def summary: String = s"Class '${clazz.getName}' lacks a public zero argument constructor."
 
     def message(formatter: Formatter): String = {
@@ -446,13 +424,43 @@ object SafetyError {
   }
 
   /**
+   * An error raised to indicate an unimplemented superclass method
+   *
+   * @param clazz  The type of the superclass.
+   * @param method The unimplemented method.
+   * @param loc    The source location of the object derivation.
+   */
+  case class NewObjectMissingMethod(clazz: java.lang.Class[_], method: java.lang.reflect.Method, loc: SourceLocation) extends SafetyError {
+    def summary: String = s"No implementation found for method '${method.getName}' of superclass '${clazz.getName}'."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> No implementation found for method '${red(method.getName)}' of superclass '${red(clazz.getName)}'.
+         |
+         |${code(loc, "the object occurs here.")}
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = Some({
+      val parameterTypes = (clazz +: method.getParameterTypes).map(formatJavaType)
+      val returnType = formatJavaType(method.getReturnType)
+      s"""
+         | Try adding a method with the following signature:
+         |
+         | def ${method.getName}(${parameterTypes.mkString(", ")}): $returnType
+         |""".stripMargin
+    })
+  }
+
+  /**
    * An error raised to indicate a missing `this` parameter for a method.
    *
    * @param clazz The expected `this` type.
    * @param name  The name of the method with the invalid `this` parameter.
    * @param loc   The source location of the method.
    */
-  case class MissingThisArg(clazz: java.lang.Class[_], name: String, loc: SourceLocation) extends SafetyError {
+  case class NewObjectMissingThisArg(clazz: java.lang.Class[_], name: String, loc: SourceLocation) extends SafetyError {
     def summary: String = s"Missing `this` parameter for method '$name'."
 
     def message(formatter: Formatter): String = {
@@ -479,7 +487,7 @@ object SafetyError {
    * @param clazz the class.
    * @param loc   the source location of the new object expression.
    */
-  case class NonPublicClass(clazz: java.lang.Class[_], loc: SourceLocation) extends SafetyError {
+  case class NewObjectNonPublicCLass(clazz: java.lang.Class[_], loc: SourceLocation) extends SafetyError {
     def summary: String = s"Class '${clazz.getName}' is not public"
 
     def message(formatter: Formatter): String = {
@@ -488,6 +496,28 @@ object SafetyError {
          |>> Class '${red(clazz.getName)}' is not public.
          |
          |${code(loc, "non-public class.")}
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised to indicate that an object derivation includes a method that doesn't exist in the superclass being implemented.
+   *
+   * @param clazz The type of superclass
+   * @param name  The name of the extra method.
+   * @param loc   The source location of the method.
+   */
+  case class NewObjectUnreachableMethod(clazz: java.lang.Class[_], name: String, loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Method '$name' not found in superclass '${clazz.getName}'"
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Method '${red(name)}' not found in superclass '${red(clazz.getName)}'
+         |
+         |${code(loc, "the method occurs here.")}
          |""".stripMargin
     }
 
@@ -512,36 +542,6 @@ object SafetyError {
     }
 
     def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-   * An error raised to indicate an unimplemented superclass method
-   *
-   * @param clazz  The type of the superclass.
-   * @param method The unimplemented method.
-   * @param loc    The source location of the object derivation.
-   */
-  case class UnimplementedMethod(clazz: java.lang.Class[_], method: java.lang.reflect.Method, loc: SourceLocation) extends SafetyError {
-    def summary: String = s"No implementation found for method '${method.getName}' of superclass '${clazz.getName}'."
-
-    def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> No implementation found for method '${red(method.getName)}' of superclass '${red(clazz.getName)}'.
-         |
-         |${code(loc, "the object occurs here.")}
-         |""".stripMargin
-    }
-
-    def explain(formatter: Formatter): Option[String] = Some({
-      val parameterTypes = (clazz +: method.getParameterTypes).map(formatJavaType)
-      val returnType = formatJavaType(method.getReturnType)
-      s"""
-         | Try adding a method with the following signature:
-         |
-         | def ${method.getName}(${parameterTypes.mkString(", ")}): $returnType
-         |""".stripMargin
-    })
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -16,13 +16,38 @@ sealed trait SafetyError extends CompilationMessage {
 object SafetyError {
 
   /**
+   * An error raised to indicate an illegal checked type cast.
+   *
+   * @param from the source type.
+   * @param to   the destination type.
+   * @param loc  the source location of the cast.
+   */
+  case class IllegalCheckedCast(from: Type, to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
+    override def summary: String = "Illegal checked cast"
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Illegal checked cast.
+         |
+         |${code(loc, "illegal cast.")}
+         |
+         |From: ${FormatType.formatType(from, None)}
+         |To  : ${FormatType.formatType(to, None)}
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
    * An error raised to indicate a cast from a non-Java type to a Java type.
    *
    * @param from the source type.
    * @param to   the destination type.
    * @param loc  the source location of the cast.
    */
-  case class IllegalCastFromNonJava(from: Type, to: java.lang.Class[_], loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
+  case class IllegalCheckedCastFromNonJava(from: Type, to: java.lang.Class[_], loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
     override def summary: String = "Illegal checked cast: Attempt to cast a non-Java type to a Java type."
 
     override def message(formatter: Formatter): String = {
@@ -47,7 +72,7 @@ object SafetyError {
    * @param to   the destination type.
    * @param loc  the source location of the cast.
    */
-  case class IllegalCastFromVar(from: Type.Var, to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
+  case class IllegalCheckedCastFromVar(from: Type.Var, to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
     override def summary: String = "Illegal checked cast: Attempt to cast a type variable to a type."
 
     override def message(formatter: Formatter): String = {
@@ -72,7 +97,7 @@ object SafetyError {
    * @param to   the destination type.
    * @param loc  the source location of the cast.
    */
-  case class IllegalCastToNonJava(from: java.lang.Class[_], to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
+  case class IllegalCheckedCastToNonJava(from: java.lang.Class[_], to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
     override def summary: String = "Illegal checked cast: Attempt to cast a Java type to a non-Java type."
 
     override def message(formatter: Formatter): String = {
@@ -97,7 +122,7 @@ object SafetyError {
    * @param to   the destination type (the variable).
    * @param loc  the source location of the cast.
    */
-  case class IllegalCastToVar(from: Type, to: Type.Var, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
+  case class IllegalCheckedCastToVar(from: Type, to: Type.Var, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
     override def summary: String = "Illegal checked cast: Attempt to cast a type to a type variable."
 
     override def message(formatter: Formatter): String = {
@@ -106,31 +131,6 @@ object SafetyError {
          |>> Illegal checked cast: Attempt to cast a type to a type variable.
          |
          |${code(loc, "illegal checked cast.")}
-         |
-         |From: ${FormatType.formatType(from, None)}
-         |To  : ${FormatType.formatType(to, None)}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-   * An error raised to indicate an illegal checked type cast.
-   *
-   * @param from the source type.
-   * @param to   the destination type.
-   * @param loc  the source location of the cast.
-   */
-  case class IllegalCheckedTypeCast(from: Type, to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
-    override def summary: String = "Illegal checked cast"
-
-    override def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Illegal checked cast.
-         |
-         |${code(loc, "illegal cast.")}
          |
          |From: ${FormatType.formatType(from, None)}
          |To  : ${FormatType.formatType(to, None)}

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -162,8 +162,7 @@ object SafetyError {
      * Returns a formatted string with helpful suggestions.
      */
     def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         |A lattice variable cannot be used as relational variable unless the atom
+      s"""A lattice variable cannot be used as relational variable unless the atom
          |from which it originates is marked with `fix`.
          |""".stripMargin
     })
@@ -235,9 +234,7 @@ object SafetyError {
     def explain(formatter: Formatter): Option[String] = Some({
       import formatter._
       if (!sym.isWild)
-        s"""
-           |${underline("Tip:")} Ensure that the variable occurs in at least one positive atom.
-           |""".stripMargin
+        s"""${underline("Tip:")} Ensure that the variable occurs in at least one positive atom.""".stripMargin
       else
         ""
     })
@@ -338,13 +335,13 @@ object SafetyError {
   }
 
   /**
-   * An error raised to indicate an impossible cast.
+   * An error raised to indicate an impossible unchecked cast.
    *
-   * @param from the type of the expression being cast.
-   * @param to   the type being cast to, i.e. the declared type or effect of the cast.
+   * @param from the source type.
+   * @param to   the destination type.
    * @param loc  the source location of the cast.
    */
-  case class ImpossibleCast(from: Type, to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
+  case class ImpossibleUncheckedCast(from: Type, to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
     override def summary: String = "Impossible cast."
 
     override def message(formatter: Formatter): String = {

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -245,6 +245,26 @@ object SafetyError {
   }
 
   /**
+   * An error raised to indicate an unexpected pattern bound in a body atom.
+   *
+   * @param loc the position of the body atom containing the unexpected pattern.
+   */
+  case class IllegalPatternInBodyAtom(loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Unexpected pattern in body atom."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Unexpected pattern in body atom.
+         |
+         |${code(loc, "pattern occurs in this body atom.")}
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
    * Unable to derive Sendable error
    *
    * @param tpe the type that is not sendable.
@@ -518,26 +538,6 @@ object SafetyError {
          |>> Method '${red(name)}' not found in superclass '${red(clazz.getName)}'
          |
          |${code(loc, "the method occurs here.")}
-         |""".stripMargin
-    }
-
-    def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-   * An error raised to indicate an unexpected pattern bound in a body atom.
-   *
-   * @param loc the position of the body atom containing the unexpected pattern.
-   */
-  case class UnexpectedPatternInBodyAtom(loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Unexpected pattern in body atom."
-
-    def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Unexpected pattern in body atom.
-         |
-         |${code(loc, "pattern occurs in this body atom.")}
          |""".stripMargin
     }
 

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -17,19 +17,21 @@ sealed trait SafetyError extends CompilationMessage {
 object SafetyError {
 
   /**
-    * An error raised to indicate an unexpected pattern bound in a body atom.
-    *
-    * @param loc the position of the body atom containing the unexpected pattern.
-    */
-  case class UnexpectedPatternInBodyAtom(loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Unexpected pattern in body atom."
+   * An error raised to indicate that an object derivation includes a method that doesn't exist in the superclass being implemented.
+   *
+   * @param clazz The type of superclass
+   * @param name  The name of the extra method.
+   * @param loc   The source location of the method.
+   */
+  case class ExtraMethod(clazz: java.lang.Class[_], name: String, loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Method '$name' not found in superclass '${clazz.getName}'"
 
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
-         |>> Unexpected pattern in body atom.
+         |>> Method '${red(name)}' not found in superclass '${red(clazz.getName)}'
          |
-         |${code(loc, "pattern occurs in this body atom.")}
+         |${code(loc, "the method occurs here.")}
          |""".stripMargin
     }
 
@@ -37,31 +39,180 @@ object SafetyError {
   }
 
   /**
-    * An error raised to indicate an illegal use of a non-positively bound variable in a negative atom.
-    *
-    * @param loc the position of the body atom containing the illegal variable.
-    */
-  case class IllegalNonPositivelyBoundVariable(sym: Symbol.VarSym, loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Illegal non-positively bound variable '$sym'."
+   * An error raised to indicate a cast from a non-Java type to a Java type.
+   *
+   * @param from the source type.
+   * @param to   the destination type.
+   * @param loc  the source location of the cast.
+   */
+  case class IllegalCastFromNonJava(from: Type, to: java.lang.Class[_], loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
+    override def summary: String = "Illegal checked cast: Attempt to cast a non-Java type to a Java type."
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Illegal checked cast: Attempt to cast a non-Java type to a Java type.
+         |
+         |${code(loc, "illegal cast")}
+         |
+         |From: ${FormatType.formatType(from, None)}
+         |To  : ${formatJavaType(to)}
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised to indicate a cast from a type variable to a type.
+   *
+   * @param from the source type (the variable).
+   * @param to   the destination type.
+   * @param loc  the source location of the cast.
+   */
+  case class IllegalCastFromVar(from: Type.Var, to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
+    override def summary: String = "Illegal checked cast: Attempt to cast a type variable to a type."
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Illegal checked cast: Attempt to cast a type variable to a type.
+         |
+         |${code(loc, "illegal cast")}
+         |
+         |From: ${FormatType.formatType(from, None)}
+         |To  : ${FormatType.formatType(to, None)}
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised to indicate a cast from a Java type to a non-Java type.
+   *
+   * @param from the source type.
+   * @param to   the destination type.
+   * @param loc  the source location of the cast.
+   */
+  case class IllegalCastToNonJava(from: java.lang.Class[_], to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
+    override def summary: String = "Illegal checked cast: Attempt to cast a Java type to a non-Java type."
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Illegal checked cast: Attempt to cast a Java type to a non-Java type.
+         |
+         |${code(loc, "illegal cast")}
+         |
+         |From: ${formatJavaType(from)}
+         |To  : ${FormatType.formatType(to, None)}
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised to indicate a cast from a type to a type variable.
+   *
+   * @param from the source type.
+   * @param to   the destination type (the variable).
+   * @param loc  the source location of the cast.
+   */
+  case class IllegalCastToVar(from: Type, to: Type.Var, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
+    override def summary: String = "Illegal checked cast: Attempt to cast a type to a type variable."
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Illegal checked cast: Attempt to cast a type to a type variable.
+         |
+         |${code(loc, "illegal checked cast.")}
+         |
+         |From: ${FormatType.formatType(from, None)}
+         |To  : ${FormatType.formatType(to, None)}
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised to indicate an illegal checked type cast.
+   *
+   * @param from the source type.
+   * @param to   the destination type.
+   * @param loc  the source location of the cast.
+   */
+  case class IllegalCheckedTypeCast(from: Type, to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
+    override def summary: String = "Illegal checked cast"
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Illegal checked cast.
+         |
+         |${code(loc, "illegal cast.")}
+         |
+         |From: ${FormatType.formatType(from, None)}
+         |To  : ${FormatType.formatType(to, None)}
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised to indicate an illegal relational use of the lattice variable `sym`.
+   *
+   * @param sym the variable symbol.
+   * @param loc the source location of the atom where the illegal use occurs.
+   */
+  case class IllegalRelationalUseOfLatticeVariable(sym: Symbol.VarSym, loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Illegal relational use of the lattice variable '$sym'."
 
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
-         |>> Illegal non-positively bound variable '${red(sym.text)}'.
+         |>> Illegal relational use of the lattice variable '${red(sym.text)}'. Use `fix`?
          |
-         |${code(loc, "the variable occurs in this negated atom.")}
+         |${code(loc, "the illegal use occurs here.")}
          |""".stripMargin
     }
 
+    /**
+     * Returns a formatted string with helpful suggestions.
+     */
     def explain(formatter: Formatter): Option[String] = Some({
-      import formatter._
-      if (!sym.isWild)
-        s"""
-           |${underline("Tip:")} Ensure that the variable occurs in at least one positive atom.
-           |""".stripMargin
-      else
-        ""
+      s"""
+         |A lattice variable cannot be used as relational variable unless the atom
+         |from which it originates is marked with `fix`.
+         |""".stripMargin
     })
+  }
+
+  /**
+   * An error raised to indicate an illegal use of a wildcard in a negative atom.
+   *
+   * @param loc the position of the body atom containing the illegal wildcard.
+   */
+  case class IllegalNegativelyBoundWildcard(loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Illegal negatively bound wildcard '_'."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Illegal negatively bound wildcard '${red("_")}'.
+         |
+         |${code(loc, "the wildcard occurs in this negated atom.")}
+         |""".stripMargin
+    }
+
+    /**
+     * Returns a formatted string with helpful suggestions.
+     */
+    def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -88,449 +239,40 @@ object SafetyError {
   }
 
   /**
-    * An error raised to indicate an illegal use of a wildcard in a negative atom.
-    *
-    * @param loc the position of the body atom containing the illegal wildcard.
-    */
-  case class IllegalNegativelyBoundWildcard(loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Illegal negatively bound wildcard '_'."
+   * An error raised to indicate an illegal use of a non-positively bound variable in a negative atom.
+   *
+   * @param loc the position of the body atom containing the illegal variable.
+   */
+  case class IllegalNonPositivelyBoundVariable(sym: Symbol.VarSym, loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Illegal non-positively bound variable '$sym'."
 
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
-         |>> Illegal negatively bound wildcard '${red("_")}'.
+         |>> Illegal non-positively bound variable '${red(sym.text)}'.
          |
-         |${code(loc, "the wildcard occurs in this negated atom.")}
-         |""".stripMargin
-    }
-
-    /**
-      * Returns a formatted string with helpful suggestions.
-      */
-    def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-    * An error raised to indicate an illegal relational use of the lattice variable `sym`.
-    *
-    * @param sym the variable symbol.
-    * @param loc the source location of the atom where the illegal use occurs.
-    */
-  case class IllegalRelationalUseOfLatticeVariable(sym: Symbol.VarSym, loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Illegal relational use of the lattice variable '$sym'."
-
-    def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Illegal relational use of the lattice variable '${red(sym.text)}'. Use `fix`?
-         |
-         |${code(loc, "the illegal use occurs here.")}
-         |""".stripMargin
-    }
-
-    /**
-      * Returns a formatted string with helpful suggestions.
-      */
-    def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         |A lattice variable cannot be used as relational variable unless the atom
-         |from which it originates is marked with `fix`.
-         |""".stripMargin
-    })
-  }
-
-  /**
-    * An error raised to indicate an impossible cast.
-    *
-    * @param from the type of the expression being cast.
-    * @param to   the type being cast to, i.e. the declared type or effect of the cast.
-    * @param loc  the source location of the cast.
-    */
-  case class ImpossibleCast(from: Type, to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
-    override def summary: String = "Impossible cast."
-
-    override def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> The following cast is impossible and will never succeed.
-         |
-         |${code(loc, "the cast occurs here.")}
-         |
-         |From: ${FormatType.formatType(from, None)}
-         |To  : ${FormatType.formatType(to, None)}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-    * An error raised to indicate an illegal checked type cast.
-    *
-    * @param from the source type.
-    * @param to   the destination type.
-    * @param loc  the source location of the cast.
-    */
-  case class IllegalCheckedTypeCast(from: Type, to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
-    override def summary: String = "Illegal checked cast"
-
-    override def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Illegal checked cast.
-         |
-         |${code(loc, "illegal cast.")}
-         |
-         |From: ${FormatType.formatType(from, None)}
-         |To  : ${FormatType.formatType(to, None)}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-    * An error raised to indicate a cast from a non-Java type to a Java type.
-    *
-    * @param from the source type.
-    * @param to   the destination type.
-    * @param loc  the source location of the cast.
-    */
-  case class IllegalCastFromNonJava(from: Type, to: java.lang.Class[_], loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
-    override def summary: String = "Illegal checked cast: Attempt to cast a non-Java type to a Java type."
-
-    override def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Illegal checked cast: Attempt to cast a non-Java type to a Java type.
-         |
-         |${code(loc, "illegal cast")}
-         |
-         |From: ${FormatType.formatType(from, None)}
-         |To  : ${formatJavaType(to)}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-    * An error raised to indicate a cast from a Java type to a non-Java type.
-    *
-    * @param from the source type.
-    * @param to   the destination type.
-    * @param loc  the source location of the cast.
-    */
-  case class IllegalCastToNonJava(from: java.lang.Class[_], to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
-    override def summary: String = "Illegal checked cast: Attempt to cast a Java type to a non-Java type."
-
-    override def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Illegal checked cast: Attempt to cast a Java type to a non-Java type.
-         |
-         |${code(loc, "illegal cast")}
-         |
-         |From: ${formatJavaType(from)}
-         |To  : ${FormatType.formatType(to, None)}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-    * An error raised to indicate a cast from a type variable to a type.
-    *
-    * @param from the source type (the variable).
-    * @param to   the destination type.
-    * @param loc  the source location of the cast.
-    */
-  case class IllegalCastFromVar(from: Type.Var, to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
-    override def summary: String = "Illegal checked cast: Attempt to cast a type variable to a type."
-
-    override def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Illegal checked cast: Attempt to cast a type variable to a type.
-         |
-         |${code(loc, "illegal cast")}
-         |
-         |From: ${FormatType.formatType(from, None)}
-         |To  : ${FormatType.formatType(to, None)}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-    * An error raised to indicate a cast from a type to a type variable.
-    *
-    * @param from the source type.
-    * @param to   the destination type (the variable).
-    * @param loc  the source location of the cast.
-    */
-  case class IllegalCastToVar(from: Type, to: Type.Var, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
-    override def summary: String = "Illegal checked cast: Attempt to cast a type to a type variable."
-
-    override def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Illegal checked cast: Attempt to cast a type to a type variable.
-         |
-         |${code(loc, "illegal checked cast.")}
-         |
-         |From: ${FormatType.formatType(from, None)}
-         |To  : ${FormatType.formatType(to, None)}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-    * An error raised to indicate an illegal object derivation. Objects can only be derived from Java interfaces.
-    *
-    * @param clazz The (illegal) superclass.
-    * @param loc   The source location of the object derivation.
-    */
-  case class IllegalObjectDerivation(clazz: java.lang.Class[_], loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Illegal object derivation from '$clazz'."
-
-    def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> '${red(clazz.toString)}' is not a Java interface.
-         |
-         |${code(loc, "the illegal derivation occurs here.")}
-         |""".stripMargin
-    }
-
-    def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-    * An error raised to indicate a missing `this` parameter for a method.
-    *
-    * @param clazz The expected `this` type.
-    * @param name  The name of the method with the invalid `this` parameter.
-    * @param loc   The source location of the method.
-    */
-  case class MissingThis(clazz: java.lang.Class[_], name: String, loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Missing `this` parameter for method '$name'."
-
-    def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Missing 'this' parameter for method '${red(name)}''.
-         |
-         |The 'this' parameter should have type ${cyan(s"##${clazz.getName}")}
-         |
-         |${code(loc, "the method occurs here.")}
+         |${code(loc, "the variable occurs in this negated atom.")}
          |""".stripMargin
     }
 
     def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         | The first argument to any method must be 'this', and must have the same type as the superclass.
-         |""".stripMargin
+      import formatter._
+      if (!sym.isWild)
+        s"""
+           |${underline("Tip:")} Ensure that the variable occurs in at least one positive atom.
+           |""".stripMargin
+      else
+        ""
     })
   }
 
   /**
-    * An error raised to indicate an invalid `this` parameter for a method.
-    *
-    * @param clazz           The expected `this` type.
-    * @param illegalThisType The incorrect `this` type.
-    * @param name            The name of the method with the invalid `this` parameter.
-    * @param loc             The source location of the method.
-    */
-  case class IllegalThisType(clazz: java.lang.Class[_], illegalThisType: Type, name: String, loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Invalid `this` parameter for method '$name'."
-
-    def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Invalid 'this' parameter for method '${red(name)}''.
-         |
-         |Expected 'this' type is ${cyan(s"##${clazz.getName}")}, but the first argument is declared as type ${cyan(illegalThisType.toString)}
-         |
-         |${code(loc, "the method occurs here.")}
-         |""".stripMargin
-    }
-
-    def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         | The first argument to any method must be 'this', and must have the same type as the superclass.
-         |""".stripMargin
-    })
-  }
-
-  /**
-    * Format a Java type suitable for method implementation.
-    */
-  private def formatJavaType(t: java.lang.Class[_]): String = {
-    if (t.isPrimitive || t.isArray)
-      Type.getFlixType(t).toString
-    else
-      s"##${t.getName}"
-  }
-
-  /**
-    * An error raised to indicate an unimplemented superclass method
-    *
-    * @param clazz  The type of the superclass.
-    * @param method The unimplemented method.
-    * @param loc    The source location of the object derivation.
-    */
-  case class UnimplementedMethod(clazz: java.lang.Class[_], method: java.lang.reflect.Method, loc: SourceLocation) extends SafetyError {
-    def summary: String = s"No implementation found for method '${method.getName}' of superclass '${clazz.getName}'."
-
-    def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> No implementation found for method '${red(method.getName)}' of superclass '${red(clazz.getName)}'.
-         |
-         |${code(loc, "the object occurs here.")}
-         |""".stripMargin
-    }
-
-    def explain(formatter: Formatter): Option[String] = Some({
-      val parameterTypes = (clazz +: method.getParameterTypes).map(formatJavaType)
-      val returnType = formatJavaType(method.getReturnType)
-      s"""
-         | Try adding a method with the following signature:
-         |
-         | def ${method.getName}(${parameterTypes.mkString(", ")}): $returnType
-         |""".stripMargin
-    })
-  }
-
-  /**
-    * An error raised to indicate that an object derivation includes a method that doesn't exist
-    * in the superclass being implemented.
-    *
-    * @param clazz The type of superclass
-    * @param name  The name of the extra method.
-    * @param loc   The source location of the method.
-    */
-  case class ExtraMethod(clazz: java.lang.Class[_], name: String, loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Method '$name' not found in superclass '${clazz.getName}'"
-
-    def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Method '${red(name)}' not found in superclass '${red(clazz.getName)}'
-         |
-         |${code(loc, "the method occurs here.")}
-         |""".stripMargin
-    }
-
-    def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-    * An error raised to indicate that a class lacks a public zero argument constructor.
-    *
-    * @param clazz the class.
-    * @param loc   the source location of the new object expression.
-    */
-  case class MissingPublicZeroArgConstructor(clazz: java.lang.Class[_], loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Class '${clazz.getName}' lacks a public zero argument constructor."
-
-    def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Class '${red(clazz.getName)}' lacks a public zero argument constructor.
-         |
-         |${code(loc, "missing constructor.")}
-         |""".stripMargin
-    }
-
-    def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-    * An error raised to indicate that a class is non-public.
-    *
-    * @param clazz the class.
-    * @param loc   the source location of the new object expression.
-    */
-  case class NonPublicClass(clazz: java.lang.Class[_], loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Class '${clazz.getName}' is not public"
-
-    def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Class '${red(clazz.getName)}' is not public.
-         |
-         |${code(loc, "non-public class.")}
-         |""".stripMargin
-    }
-
-    def explain(formatter: Formatter): Option[String] = None
-  }
-
-  /**
-    * An error raised to indicate that a `par expression` is not supported.
-    *
-    * @param exp the par expression.
-    * @param loc the source location of the expression.
-    */
-  case class IllegalParExpression(exp: Expr, loc: SourceLocation) extends SafetyError {
-    override def summary: String = s"Unable to parallelize $exp"
-
-    override def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Unable to parallelize expression.
-         |
-         |${code(loc, "illegal par expression")}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] =
-      Some("Only tuples and function applications can be parallelized with par.")
-  }
-
-  /**
-    * An error raised to indicate that a TypeMatch expression is missing a default case.
-    *
-    * @param loc the location where the error occurred.
-    */
-  case class MissingDefaultTypeMatchCase(loc: SourceLocation) extends SafetyError {
-    override def summary: String = s"Missing default case."
-
-    override def message(formatter: Formatter): String = {
-      import formatter._
-      s"""${line(kind, source.name)}
-         |>> Missing default case.
-         |
-         |${code(loc, "missing default case.")}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         | A typematch expression must have a default case. For example:
-         |
-         | typematch x {
-         |     case y: Int32 => ...
-         |     case _: _ => ... // default case
-         | }
-         |
-         |""".stripMargin
-    })
-  }
-
-  /**
-    * Unable to derive Sendable error
-    *
-    * @param tpe the type that is not sendable.
-    * @param loc the location where the error occurred.
-    */
-  case class SendableError(tpe: Type, loc: SourceLocation) extends SafetyError {
+   * Unable to derive Sendable error
+   *
+   * @param tpe the type that is not sendable.
+   * @param loc the location where the error occurred.
+   */
+  case class IllegalSendableInstance(tpe: Type, loc: SourceLocation) extends SafetyError {
     def summary: String = s"Cannot derive Sendable for $tpe"
 
     def message(formatter: Formatter): String = {
@@ -555,11 +297,11 @@ object SafetyError {
   }
 
   /**
-    * An error raised to indicate that a function marked with the `@test` annotation
-    * has at least one non-unit parameter.
-    *
-    * @param loc the source location of the parameter.
-    */
+   * An error raised to indicate that a function marked with the `@test` annotation
+   * has at least one non-unit parameter.
+   *
+   * @param loc the source location of the parameter.
+   */
   case class IllegalTestParameters(loc: SourceLocation) extends SafetyError {
     def summary: String = s"Test entry point must not have parameters."
 
@@ -596,5 +338,219 @@ object SafetyError {
          |
          |""".stripMargin
     )
+  }
+
+  /**
+    * An error raised to indicate an invalid `this` parameter for a method.
+    *
+    * @param clazz           The expected `this` type.
+    * @param illegalThisType The incorrect `this` type.
+    * @param name            The name of the method with the invalid `this` parameter.
+    * @param loc             The source location of the method.
+    */
+  case class IllegalThisType(clazz: java.lang.Class[_], illegalThisType: Type, name: String, loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Invalid `this` parameter for method '$name'."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Invalid 'this' parameter for method '${red(name)}''.
+         |
+         |Expected 'this' type is ${cyan(s"##${clazz.getName}")}, but the first argument is declared as type ${cyan(illegalThisType.toString)}
+         |
+         |${code(loc, "the method occurs here.")}
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = Some({
+      s"""
+         | The first argument to any method must be 'this', and must have the same type as the superclass.
+         |""".stripMargin
+    })
+  }
+
+  /**
+   * An error raised to indicate an impossible cast.
+   *
+   * @param from the type of the expression being cast.
+   * @param to   the type being cast to, i.e. the declared type or effect of the cast.
+   * @param loc  the source location of the cast.
+   */
+  case class ImpossibleCast(from: Type, to: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
+    override def summary: String = "Impossible cast."
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> The following cast is impossible and will never succeed.
+         |
+         |${code(loc, "the cast occurs here.")}
+         |
+         |From: ${FormatType.formatType(from, None)}
+         |To  : ${FormatType.formatType(to, None)}
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised to indicate that a TypeMatch expression is missing a default case.
+   *
+   * @param loc the location where the error occurred.
+   */
+  case class MissingDefaultTypeMatchCase(loc: SourceLocation) extends SafetyError {
+    override def summary: String = s"Missing default case."
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Missing default case.
+         |
+         |${code(loc, "missing default case.")}
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = Some({
+      s"""
+         | A typematch expression must have a default case. For example:
+         |
+         | typematch x {
+         |     case y: Int32 => ...
+         |     case _: _ => ... // default case
+         | }
+         |
+         |""".stripMargin
+    })
+  }
+
+  /**
+    * An error raised to indicate that a class lacks a public zero argument constructor.
+    *
+    * @param clazz the class.
+    * @param loc   the source location of the new object expression.
+    */
+  case class MissingPublicZeroArgConstructor(clazz: java.lang.Class[_], loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Class '${clazz.getName}' lacks a public zero argument constructor."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Class '${red(clazz.getName)}' lacks a public zero argument constructor.
+         |
+         |${code(loc, "missing constructor.")}
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised to indicate a missing `this` parameter for a method.
+   *
+   * @param clazz The expected `this` type.
+   * @param name  The name of the method with the invalid `this` parameter.
+   * @param loc   The source location of the method.
+   */
+  case class MissingThisArg(clazz: java.lang.Class[_], name: String, loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Missing `this` parameter for method '$name'."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Missing 'this' parameter for method '${red(name)}''.
+         |
+         |The 'this' parameter should have type ${cyan(s"##${clazz.getName}")}
+         |
+         |${code(loc, "the method occurs here.")}
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = Some({
+      s"""
+         | The first argument to any method must be 'this', and must have the same type as the superclass.
+         |""".stripMargin
+    })
+  }
+
+  /**
+   * An error raised to indicate that a class is non-public.
+   *
+   * @param clazz the class.
+   * @param loc   the source location of the new object expression.
+   */
+  case class NonPublicClass(clazz: java.lang.Class[_], loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Class '${clazz.getName}' is not public"
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Class '${red(clazz.getName)}' is not public.
+         |
+         |${code(loc, "non-public class.")}
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised to indicate an unexpected pattern bound in a body atom.
+   *
+   * @param loc the position of the body atom containing the unexpected pattern.
+   */
+  case class UnexpectedPatternInBodyAtom(loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Unexpected pattern in body atom."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Unexpected pattern in body atom.
+         |
+         |${code(loc, "pattern occurs in this body atom.")}
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
+   * An error raised to indicate an unimplemented superclass method
+   *
+   * @param clazz  The type of the superclass.
+   * @param method The unimplemented method.
+   * @param loc    The source location of the object derivation.
+   */
+  case class UnimplementedMethod(clazz: java.lang.Class[_], method: java.lang.reflect.Method, loc: SourceLocation) extends SafetyError {
+    def summary: String = s"No implementation found for method '${method.getName}' of superclass '${clazz.getName}'."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> No implementation found for method '${red(method.getName)}' of superclass '${red(clazz.getName)}'.
+         |
+         |${code(loc, "the object occurs here.")}
+         |""".stripMargin
+    }
+
+    def explain(formatter: Formatter): Option[String] = Some({
+      val parameterTypes = (clazz +: method.getParameterTypes).map(formatJavaType)
+      val returnType = formatJavaType(method.getReturnType)
+      s"""
+         | Try adding a method with the following signature:
+         |
+         | def ${method.getName}(${parameterTypes.mkString(", ")}): $returnType
+         |""".stripMargin
+    })
+  }
+
+  /**
+   * Format a Java type suitable for method implementation.
+   */
+  private def formatJavaType(t: java.lang.Class[_]): String = {
+    if (t.isPrimitive || t.isArray)
+      Type.getFlixType(t).toString
+    else
+      s"##${t.getName}"
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -2,14 +2,13 @@ package ca.uwaterloo.flix.language.errors
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.CompilationMessage
-import ca.uwaterloo.flix.language.ast.TypedAst.Expr
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol, Type}
 import ca.uwaterloo.flix.language.fmt.FormatType
 import ca.uwaterloo.flix.util.Formatter
 
 /**
-  * A common super-type for safety errors.
-  */
+ * A common super-type for safety errors.
+ */
 sealed trait SafetyError extends CompilationMessage {
   val kind: String = "Safety Error"
 }
@@ -147,7 +146,7 @@ object SafetyError {
    * @param sym the variable symbol.
    * @param loc the source location of the atom where the illegal use occurs.
    */
-  case class IllegalRelationalUseOfLatticeVariable(sym: Symbol.VarSym, loc: SourceLocation) extends SafetyError {
+  case class IllegalRelationalUseOfLatticeVar(sym: Symbol.VarSym, loc: SourceLocation) extends SafetyError {
     def summary: String = s"Illegal relational use of the lattice variable '$sym'."
 
     def message(formatter: Formatter): String = {
@@ -175,7 +174,7 @@ object SafetyError {
    *
    * @param loc the position of the body atom containing the illegal wildcard.
    */
-  case class IllegalNegativelyBoundWildcard(loc: SourceLocation) extends SafetyError {
+  case class IllegalNegativelyBoundWildCard(loc: SourceLocation) extends SafetyError {
     def summary: String = s"Illegal negatively bound wildcard '_'."
 
     def message(formatter: Formatter): String = {
@@ -194,11 +193,11 @@ object SafetyError {
   }
 
   /**
-    * An error raised to indicate an illegal use of a wild variable in a negative atom.
-    *
-    * @param loc the position of the body atom containing the illegal variable.
-    */
-  case class IllegalNegativelyBoundWildVariable(sym: Symbol.VarSym, loc: SourceLocation) extends SafetyError {
+   * An error raised to indicate an illegal use of a wild variable in a negative atom.
+   *
+   * @param loc the position of the body atom containing the illegal variable.
+   */
+  case class IllegalNegativelyBoundWildVar(sym: Symbol.VarSym, loc: SourceLocation) extends SafetyError {
     def summary: String = s"Illegal negatively bound variable '$sym'."
 
     def message(formatter: Formatter): String = {
@@ -211,8 +210,8 @@ object SafetyError {
     }
 
     /**
-      * Returns a formatted string with helpful suggestions.
-      */
+     * Returns a formatted string with helpful suggestions.
+     */
     def explain(formatter: Formatter): Option[String] = None
   }
 
@@ -221,7 +220,7 @@ object SafetyError {
    *
    * @param loc the position of the body atom containing the illegal variable.
    */
-  case class IllegalNonPositivelyBoundVariable(sym: Symbol.VarSym, loc: SourceLocation) extends SafetyError {
+  case class IllegalNonPositivelyBoundVar(sym: Symbol.VarSym, loc: SourceLocation) extends SafetyError {
     def summary: String = s"Illegal non-positively bound variable '$sym'."
 
     def message(formatter: Formatter): String = {
@@ -423,11 +422,11 @@ object SafetyError {
   }
 
   /**
-    * An error raised to indicate that a class lacks a public zero argument constructor.
-    *
-    * @param clazz the class.
-    * @param loc   the source location of the new object expression.
-    */
+   * An error raised to indicate that a class lacks a public zero argument constructor.
+   *
+   * @param clazz the class.
+   * @param loc   the source location of the new object expression.
+   */
   case class NewObjectMissingPublicZeroArgConstructor(clazz: java.lang.Class[_], loc: SourceLocation) extends SafetyError {
     def summary: String = s"Class '${clazz.getName}' lacks a public zero argument constructor."
 
@@ -507,7 +506,7 @@ object SafetyError {
    * @param clazz the class.
    * @param loc   the source location of the new object expression.
    */
-  case class NewObjectNonPublicCLass(clazz: java.lang.Class[_], loc: SourceLocation) extends SafetyError {
+  case class NewObjectNonPublicClass(clazz: java.lang.Class[_], loc: SourceLocation) extends SafetyError {
     def summary: String = s"Class '${clazz.getName}' is not public"
 
     def message(formatter: Formatter): String = {
@@ -553,4 +552,5 @@ object SafetyError {
     else
       s"##${t.getName}"
   }
+
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -723,14 +723,14 @@ object Safety {
       if (hasNonPrivateZeroArgConstructor(clazz))
         List.empty
       else
-        List(MissingPublicZeroArgConstructor(clazz, loc))
+        List(NewObjectMissingPublicZeroArgConstructor(clazz, loc))
     }
 
     //
     // Check that `clazz` is public
     //
     val visibilityErrors = if (!isPublicClass(clazz))
-      List(NonPublicClass(clazz, loc))
+      List(NewObjectNonPublicCLass(clazz, loc))
     else
       List.empty
 
@@ -744,8 +744,8 @@ object Safety {
         val thisType = Type.eraseAliases(fparam.tpe)
         thisType match {
           case `tpe` => None
-          case Type.Unit => Some(MissingThisArg(clazz, ident.name, methodLoc))
-          case _ => Some(IllegalThisType(clazz, fparam.tpe, ident.name, methodLoc))
+          case Type.Unit => Some(NewObjectMissingThisArg(clazz, ident.name, methodLoc))
+          case _ => Some(NewObjectIllegalThisType(clazz, fparam.tpe, ident.name, methodLoc))
         }
     }
 
@@ -761,13 +761,13 @@ object Safety {
     // Check that there are no unimplemented methods.
     //
     val unimplemented = mustImplement diff implemented
-    val unimplementedErrors = unimplemented.map(m => UnimplementedMethod(clazz, javaMethods(m), loc))
+    val unimplementedErrors = unimplemented.map(m => NewObjectMissingMethod(clazz, javaMethods(m), loc))
 
     //
     // Check that there are no methods that aren't in the interface
     //
     val extra = implemented diff canImplement
-    val extraErrors = extra.map(m => ExtraMethod(clazz, m.name, flixMethods(m).loc))
+    val extraErrors = extra.map(m => NewObjectUnreachableMethod(clazz, m.name, flixMethods(m).loc))
 
     constructorErrors ++ visibilityErrors ++ thisErrors ++ unimplementedErrors ++ extraErrors
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -55,7 +55,7 @@ object Safety {
     root.instances.getOrElse(sendableClass, Nil) flatMap {
       case Instance(_, _, _, _, tpe, _, _, _, _, loc) =>
         if (tpe.typeArguments.exists(_.kind == Kind.Eff))
-          List(SafetyError.SendableError(tpe, loc))
+          List(SafetyError.IllegalSendableInstance(tpe, loc))
         else
           Nil
     }
@@ -744,7 +744,7 @@ object Safety {
         val thisType = Type.eraseAliases(fparam.tpe)
         thisType match {
           case `tpe` => None
-          case Type.Unit => Some(MissingThis(clazz, ident.name, methodLoc))
+          case Type.Unit => Some(MissingThisArg(clazz, ident.name, methodLoc))
           case _ => Some(IllegalThisType(clazz, fparam.tpe, ident.name, methodLoc))
         }
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -377,46 +377,46 @@ object Safety {
 
       // Allow casting one Java type to another if there is a sub-type relationship.
       case (Type.Cst(TypeConstructor.Native(left), _), Type.Cst(TypeConstructor.Native(right), _)) =>
-        if (right.isAssignableFrom(left)) Nil else IllegalCheckedTypeCast(from, to, loc) :: Nil
+        if (right.isAssignableFrom(left)) Nil else IllegalCheckedCast(from, to, loc) :: Nil
 
       // Similar, but for String.
       case (Type.Cst(TypeConstructor.Str, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-        if (right.isAssignableFrom(classOf[String])) Nil else IllegalCheckedTypeCast(from, to, loc) :: Nil
+        if (right.isAssignableFrom(classOf[String])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
 
       // Similar, but for Regex.
       case (Type.Cst(TypeConstructor.Regex, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-        if (right.isAssignableFrom(classOf[java.util.regex.Pattern])) Nil else IllegalCheckedTypeCast(from, to, loc) :: Nil
+        if (right.isAssignableFrom(classOf[java.util.regex.Pattern])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
 
       // Similar, but for BigInt.
       case (Type.Cst(TypeConstructor.BigInt, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-        if (right.isAssignableFrom(classOf[BigInteger])) Nil else IllegalCheckedTypeCast(from, to, loc) :: Nil
+        if (right.isAssignableFrom(classOf[BigInteger])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
 
       // Similar, but for BigDecimal.
       case (Type.Cst(TypeConstructor.BigDecimal, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-        if (right.isAssignableFrom(classOf[java.math.BigDecimal])) Nil else IllegalCheckedTypeCast(from, to, loc) :: Nil
+        if (right.isAssignableFrom(classOf[java.math.BigDecimal])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
 
       // Similar, but for Arrays.
       case (Type.Cst(TypeConstructor.Array, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-        if (right.isAssignableFrom(classOf[Array[Object]])) Nil else IllegalCheckedTypeCast(from, to, loc) :: Nil
+        if (right.isAssignableFrom(classOf[Array[Object]])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
 
       // Disallow casting a type variable.
       case (src@Type.Var(_, _), _) =>
-        IllegalCastFromVar(src, to, loc) :: Nil
+        IllegalCheckedCastFromVar(src, to, loc) :: Nil
 
       // Disallow casting a type variable (symmetric case)
       case (_, dst@Type.Var(_, _)) =>
-        IllegalCastToVar(from, dst, loc) :: Nil
+        IllegalCheckedCastToVar(from, dst, loc) :: Nil
 
       // Disallow casting a Java type to any other type.
       case (Type.Cst(TypeConstructor.Native(clazz), _), _) =>
-        IllegalCastToNonJava(clazz, to, loc) :: Nil
+        IllegalCheckedCastToNonJava(clazz, to, loc) :: Nil
 
       // Disallow casting a Java type to any other type (symmetric case).
       case (_, Type.Cst(TypeConstructor.Native(clazz), _)) =>
-        IllegalCastFromNonJava(from, clazz, loc) :: Nil
+        IllegalCheckedCastFromNonJava(from, clazz, loc) :: Nil
 
       // Disallow all other casts.
-      case _ => IllegalCheckedTypeCast(from, to, loc) :: Nil
+      case _ => IllegalCheckedCast(from, to, loc) :: Nil
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -564,7 +564,7 @@ object Safety {
         case Denotation.Latticenal => terms.dropRight(1)
       }
       val err2 = relTerms.flatMap(freeVarsOf).filter(latVars.contains).map(
-        s => IllegalRelationalUseOfLatticeVariable(s, loc)
+        s => IllegalRelationalUseOfLatticeVar(s, loc)
       )
 
       // Combine the messages
@@ -587,7 +587,7 @@ object Safety {
     * @param loc the location of the atom containing the terms.
     */
   private def makeIllegalNonPositivelyBoundVariableError(sym: Symbol.VarSym, loc: SourceLocation): SafetyError =
-    if (sym.isWild) IllegalNegativelyBoundWildVariable(sym, loc) else IllegalNonPositivelyBoundVariable(sym, loc)
+    if (sym.isWild) IllegalNegativelyBoundWildVar(sym, loc) else IllegalNonPositivelyBoundVar(sym, loc)
 
   /**
     * Returns all the positively defined variable symbols in the given constraint `c0`.
@@ -673,7 +673,7 @@ object Safety {
     })
 
     // Compute the lattice variables that are illegally used in the terms.
-    allVars.intersect(latVars).toList.map(sym => IllegalRelationalUseOfLatticeVariable(sym, loc))
+    allVars.intersect(latVars).toList.map(sym => IllegalRelationalUseOfLatticeVar(sym, loc))
   }
 
   /**
@@ -692,7 +692,7 @@ object Safety {
     */
   @tailrec
   private def visitPat(term: Pattern, loc: SourceLocation): List[CompilationMessage] = term match {
-    case Pattern.Wild(_, _) => List(IllegalNegativelyBoundWildcard(loc))
+    case Pattern.Wild(_, _) => List(IllegalNegativelyBoundWildCard(loc))
     case Pattern.Var(_, _, _) => Nil
     case Pattern.Cst(_, _, _) => Nil
     case Pattern.Tag(_, pat, _, _) => visitPat(pat, loc)
@@ -730,7 +730,7 @@ object Safety {
     // Check that `clazz` is public
     //
     val visibilityErrors = if (!isPublicClass(clazz))
-      List(NewObjectNonPublicCLass(clazz, loc))
+      List(NewObjectNonPublicClass(clazz, loc))
     else
       List.empty
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -434,7 +434,7 @@ object Safety {
     * - No primitive type can be cast to a reference type and vice-versa.
     * - No Bool type can be cast to a non-Bool type  and vice-versa.
     */
-  private def verifyUncheckedCast(cast: Expr.UncheckedCast)(implicit flix: Flix): List[SafetyError.ImpossibleCast] = {
+  private def verifyUncheckedCast(cast: Expr.UncheckedCast)(implicit flix: Flix): List[SafetyError.ImpossibleUncheckedCast] = {
     val tpe1 = Type.eraseAliases(cast.exp.tpe).baseType
     val tpe2 = cast.declaredType.map(Type.eraseAliases).map(_.baseType)
 
@@ -456,19 +456,19 @@ object Safety {
 
       // Disallow casting a Boolean to another primitive type.
       case (Type.Bool, Some(t2)) if primitives.filter(_ != Type.Bool).contains(t2) =>
-        ImpossibleCast(cast.exp.tpe, cast.declaredType.get, cast.loc) :: Nil
+        ImpossibleUncheckedCast(cast.exp.tpe, cast.declaredType.get, cast.loc) :: Nil
 
       // Disallow casting a Boolean to another primitive type (symmetric case).
       case (t1, Some(Type.Bool)) if primitives.filter(_ != Type.Bool).contains(t1) =>
-        ImpossibleCast(cast.exp.tpe, cast.declaredType.get, cast.loc) :: Nil
+        ImpossibleUncheckedCast(cast.exp.tpe, cast.declaredType.get, cast.loc) :: Nil
 
       // Disallowing casting a non-primitive type to a primitive type.
       case (t1, Some(t2)) if primitives.contains(t1) && !primitives.contains(t2) =>
-        ImpossibleCast(cast.exp.tpe, cast.declaredType.get, cast.loc) :: Nil
+        ImpossibleUncheckedCast(cast.exp.tpe, cast.declaredType.get, cast.loc) :: Nil
 
       // Disallowing casting a non-primitive type to a primitive type (symmetric case).
       case (t1, Some(t2)) if primitives.contains(t2) && !primitives.contains(t1) =>
-        ImpossibleCast(cast.exp.tpe, cast.declaredType.get, cast.loc) :: Nil
+        ImpossibleUncheckedCast(cast.exp.tpe, cast.declaredType.get, cast.loc) :: Nil
 
       case _ => Nil
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -533,7 +533,7 @@ object Safety {
         case Pattern.Var(_, _, _) => acc
         case Pattern.Wild(_, _) => acc
         case Pattern.Cst(_, _, _) => acc
-        case _ => UnexpectedPatternInBodyAtom(loc) :: acc
+        case _ => IllegalPatternInBodyAtom(loc) :: acc
       })
     case _ => Nil
   }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -358,7 +358,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |def f(): Bool = unchecked_cast("true" as Bool)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.ImpossibleCast](result)
+    expectError[SafetyError.ImpossibleUncheckedCast](result)
   }
 
   test("ImpossibleCast.02") {
@@ -367,7 +367,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |def f(): String = unchecked_cast(true as String)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.ImpossibleCast](result)
+    expectError[SafetyError.ImpossibleUncheckedCast](result)
   }
 
   test("ImpossibleCast.03") {
@@ -377,7 +377,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |def f(): A = unchecked_cast(true as A)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.ImpossibleCast](result)
+    expectError[SafetyError.ImpossibleUncheckedCast](result)
   }
 
   test("ImpossibleCast.04") {
@@ -387,7 +387,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |def f(): Bool = unchecked_cast(A.A(false) as Bool)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.ImpossibleCast](result)
+    expectError[SafetyError.ImpossibleUncheckedCast](result)
   }
 
   test("ImpossibleCast.05") {
@@ -397,7 +397,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |def f(): A = unchecked_cast(1 as A)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.ImpossibleCast](result)
+    expectError[SafetyError.ImpossibleUncheckedCast](result)
   }
 
   test("ImpossibleCast.06") {
@@ -407,7 +407,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |def f(): Int32 = unchecked_cast(A.A(1) as Int32)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.ImpossibleCast](result)
+    expectError[SafetyError.ImpossibleUncheckedCast](result)
   }
 
   test("ImpossibleCast.07") {
@@ -417,7 +417,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |def f(): A = unchecked_cast("a" as A)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.ImpossibleCast](result)
+    expectError[SafetyError.ImpossibleUncheckedCast](result)
   }
 
   test("ImpossibleCast.08") {
@@ -427,7 +427,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |def f(): String = unchecked_cast(A.A("a") as String)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.ImpossibleCast](result)
+    expectError[SafetyError.ImpossibleUncheckedCast](result)
   }
 
   test("ImpossibleCast.09") {
@@ -437,7 +437,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    unchecked_cast(('a', 'b', false) as ##java.lang.String)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.ImpossibleCast](result)
+    expectError[SafetyError.ImpossibleUncheckedCast](result)
   }
 
   test("IllegalCheckedTypeCast.01") {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -448,7 +448,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(mkObj())
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.IllegalCheckedTypeCast](result)
+    expectError[SafetyError.IllegalCheckedCast](result)
   }
 
   test("IllegalCheckedTypeCast.02") {
@@ -459,7 +459,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(mkObj())
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.IllegalCheckedTypeCast](result)
+    expectError[SafetyError.IllegalCheckedCast](result)
   }
 
   test("IllegalCheckedTypeCast.03") {
@@ -470,7 +470,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(valueOf(true))
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.IllegalCheckedTypeCast](result)
+    expectError[SafetyError.IllegalCheckedCast](result)
   }
 
   test("IllegalCheckedTypeCast.04") {
@@ -481,7 +481,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(valueOf)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.IllegalCheckedTypeCast](result)
+    expectError[SafetyError.IllegalCheckedCast](result)
   }
 
   test("IllegalCheckedTypeCast.05") {
@@ -491,7 +491,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(x -> x)
     """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.IllegalCheckedTypeCast](result)
+    expectError[SafetyError.IllegalCheckedCast](result)
   }
 
   test("IllegalCastFromNonJava.01") {
@@ -501,7 +501,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(10i64)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.IllegalCastFromNonJava](result)
+    expectError[SafetyError.IllegalCheckedCastFromNonJava](result)
   }
 
   test("IllegalCastFromNonJava.02") {
@@ -511,7 +511,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(true)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.IllegalCastFromNonJava](result)
+    expectError[SafetyError.IllegalCheckedCastFromNonJava](result)
   }
 
   test("IllegalCastFromNonJava.03") {
@@ -521,7 +521,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(false)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.IllegalCastFromNonJava](result)
+    expectError[SafetyError.IllegalCheckedCastFromNonJava](result)
   }
 
   test("IllegalCastFromNonJava.04") {
@@ -532,7 +532,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(Boolean.Boolean(true))
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.IllegalCastFromNonJava](result)
+    expectError[SafetyError.IllegalCheckedCastFromNonJava](result)
   }
 
   test("IllegalCastToNonJava.01") {
@@ -544,7 +544,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(mkObj())
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.IllegalCastToNonJava](result)
+    expectError[SafetyError.IllegalCheckedCastToNonJava](result)
   }
 
   test("IllegalCastToNonJava.02") {
@@ -555,7 +555,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(mkObj())
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.IllegalCastToNonJava](result)
+    expectError[SafetyError.IllegalCheckedCastToNonJava](result)
   }
 
   test("IllegalCastToNonJava.03") {
@@ -566,7 +566,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(valueOf(true))
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.IllegalCastToNonJava](result)
+    expectError[SafetyError.IllegalCheckedCastToNonJava](result)
   }
 
   test("IllegalCastToNonJava.04") {
@@ -577,7 +577,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(newSb())
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.IllegalCastToNonJava](result)
+    expectError[SafetyError.IllegalCheckedCastToNonJava](result)
   }
 
   test("IllegalCastToNonJava.05") {
@@ -589,7 +589,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(newSb())
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.IllegalCastToNonJava](result)
+    expectError[SafetyError.IllegalCheckedCastToNonJava](result)
   }
 
   test("IllegalCastToNonJava.06") {
@@ -601,7 +601,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    Boolean.Boolean(checked_cast(valueOf(true)))
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.IllegalCastToNonJava](result)
+    expectError[SafetyError.IllegalCheckedCastToNonJava](result)
   }
 
   test("IllegalCastToNonJava.07") {
@@ -612,7 +612,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(newSb())
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.IllegalCastToNonJava](result)
+    expectError[SafetyError.IllegalCheckedCastToNonJava](result)
   }
 
   test("IllegalCastFromVar.01") {
@@ -624,7 +624,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |def g(x: a): a = checked_cast(x)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.IllegalCastFromVar](result)
+    expectError[SafetyError.IllegalCheckedCastFromVar](result)
   }
 
   test("IllegalCastFromVar.02") {
@@ -634,7 +634,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(x)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.IllegalCastFromVar](result)
+    expectError[SafetyError.IllegalCheckedCastFromVar](result)
   }
 
   test("IllegalCastToVar.01") {
@@ -646,7 +646,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |def g(x: String): a = checked_cast(x)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.IllegalCastToVar](result)
+    expectError[SafetyError.IllegalCheckedCastToVar](result)
   }
 
   test("IllegalCastToVar.02") {
@@ -656,7 +656,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    checked_cast(x)
       """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.IllegalCastToVar](result)
+    expectError[SafetyError.IllegalCheckedCastToVar](result)
   }
 
   test("IllegalCastToVar.03") {
@@ -671,7 +671,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    ()
     """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[SafetyError.IllegalCastToVar](result)
+    expectError[SafetyError.IllegalCheckedCastToVar](result)
   }
 
   test("IllegalParametersToTestEntryPoint.01") {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -253,7 +253,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |  }
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.MissingThis](result)
+    expectError[SafetyError.MissingThisArg](result)
   }
 
   test("TestInvalidThis.02") {
@@ -340,7 +340,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |enum Enum1[r: Region](Array[Int32, r]) with Sendable
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.SendableError](result)
+    expectError[SafetyError.IllegalSendableInstance](result)
   }
 
   test("UnableToDeriveSendable.02") {
@@ -349,7 +349,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |instance Sendable[Array[a, r]]
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.SendableError](result)
+    expectError[SafetyError.IllegalSendableInstance](result)
   }
 
   test("ImpossibleCast.01") {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.SafetyError
-import ca.uwaterloo.flix.language.errors.SafetyError.{IllegalNegativelyBoundWildcard, IllegalNonPositivelyBoundVariable, IllegalRelationalUseOfLatticeVariable, UnexpectedPatternInBodyAtom}
+import ca.uwaterloo.flix.language.errors.SafetyError.{IllegalNegativelyBoundWildcard, IllegalNonPositivelyBoundVariable, IllegalRelationalUseOfLatticeVariable, IllegalPatternInBodyAtom}
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -34,7 +34,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
-    expectError[UnexpectedPatternInBodyAtom](result)
+    expectError[IllegalPatternInBodyAtom](result)
   }
 
   test("UnexpectedBodyAtomPattern.02") {
@@ -45,7 +45,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
-    expectError[UnexpectedPatternInBodyAtom](result)
+    expectError[IllegalPatternInBodyAtom](result)
   }
 
   test("UnexpectedBodyAtomPattern.03") {
@@ -56,7 +56,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
-    expectError[UnexpectedPatternInBodyAtom](result)
+    expectError[IllegalPatternInBodyAtom](result)
   }
 
   test("UnexpectedBodyAtomPattern.04") {
@@ -67,7 +67,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
     """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
-    expectError[UnexpectedPatternInBodyAtom](result)
+    expectError[IllegalPatternInBodyAtom](result)
   }
 
   test("NonPositivelyBoundVariable.01") {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -253,7 +253,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |  }
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.MissingThisArg](result)
+    expectError[SafetyError.NewObjectMissingThisArg](result)
   }
 
   test("TestInvalidThis.02") {
@@ -265,7 +265,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |  }
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.IllegalThisType](result)
+    expectError[SafetyError.NewObjectIllegalThisType](result)
   }
 
   test("TestUnimplementedMethod.01") {
@@ -274,7 +274,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |def f(): ##java.lang.Runnable \ IO = new ##java.lang.Runnable {}
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.UnimplementedMethod](result)
+    expectError[SafetyError.NewObjectMissingMethod](result)
   }
 
   test("TestExtraMethod.01") {
@@ -287,7 +287,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |  }
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.ExtraMethod](result)
+    expectError[SafetyError.NewObjectUnreachableMethod](result)
   }
 
   test("TestNonDefaultConstructor.01") {
@@ -298,7 +298,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |  }
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.MissingPublicZeroArgConstructor](result)
+    expectError[SafetyError.NewObjectMissingPublicZeroArgConstructor](result)
   }
 
   test("TestNonPublicInterface.01") {
@@ -309,7 +309,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |  }
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.NonPublicClass](result)
+    expectError[SafetyError.NewObjectNonPublicCLass](result)
   }
 
   test("TestMissingDefaultTypeMatchCase.01") {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.SafetyError
-import ca.uwaterloo.flix.language.errors.SafetyError.{IllegalNegativelyBoundWildcard, IllegalNonPositivelyBoundVariable, IllegalRelationalUseOfLatticeVariable, IllegalPatternInBodyAtom}
+import ca.uwaterloo.flix.language.errors.SafetyError.{IllegalNegativelyBoundWildCard, IllegalNonPositivelyBoundVar, IllegalRelationalUseOfLatticeVar, IllegalPatternInBodyAtom}
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -78,7 +78,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
       """.stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[IllegalNonPositivelyBoundVariable](result)
+    expectError[IllegalNonPositivelyBoundVar](result)
   }
 
   test("NonPositivelyBoundVariable.02") {
@@ -89,7 +89,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
     """.stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[IllegalNonPositivelyBoundVariable](result)
+    expectError[IllegalNonPositivelyBoundVar](result)
   }
 
   test("NonPositivelyBoundVariable.03") {
@@ -100,7 +100,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
     """.stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[IllegalNonPositivelyBoundVariable](result)
+    expectError[IllegalNonPositivelyBoundVar](result)
   }
 
   test("NonPositivelyBoundVariable.04") {
@@ -116,7 +116,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |    ()
     """.stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[IllegalNonPositivelyBoundVariable](result)
+    expectError[IllegalNonPositivelyBoundVar](result)
   }
 
   // TODO NS-REFACTOR find out if wildcard and wild variable are different
@@ -128,7 +128,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
       """.stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[IllegalNegativelyBoundWildcard](result)
+    expectError[IllegalNegativelyBoundWildCard](result)
   }
 
 
@@ -141,7 +141,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
       """.stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[IllegalNegativelyBoundWildcard](result)
+    expectError[IllegalNegativelyBoundWildCard](result)
   }
 
   // TODO NS-REFACTOR find out if wildcard and wild variable are different
@@ -153,7 +153,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
       """.stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[IllegalNegativelyBoundWildcard](result)
+    expectError[IllegalNegativelyBoundWildCard](result)
   }
 
   test("NegativelyBoundWildcard.01") {
@@ -164,7 +164,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
       """.stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[IllegalNegativelyBoundWildcard](result)
+    expectError[IllegalNegativelyBoundWildCard](result)
   }
 
   test("NegativelyBoundWildcard.02") {
@@ -175,7 +175,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
       """.stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[IllegalNegativelyBoundWildcard](result)
+    expectError[IllegalNegativelyBoundWildCard](result)
   }
 
   test("NegativelyBoundWildcard.03") {
@@ -186,7 +186,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
       """.stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[IllegalNegativelyBoundWildcard](result)
+    expectError[IllegalNegativelyBoundWildCard](result)
   }
 
   test("UseOfLatticeVariable.01") {
@@ -197,7 +197,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
       """.stripMargin
     val result = compile(input, Options.TestWithLibAll)
-    expectError[IllegalRelationalUseOfLatticeVariable](result)
+    expectError[IllegalRelationalUseOfLatticeVar](result)
   }
 
   test("UseOfLatticeVariable.02") {
@@ -208,7 +208,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
         |""".stripMargin
     val result = compile(input, Options.TestWithLibAll)
-    expectError[IllegalRelationalUseOfLatticeVariable](result)
+    expectError[IllegalRelationalUseOfLatticeVar](result)
   }
 
   test("UseOfLatticeVariable.03") {
@@ -219,7 +219,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
         |""".stripMargin
     val result = compile(input, Options.TestWithLibAll)
-    expectError[IllegalRelationalUseOfLatticeVariable](result)
+    expectError[IllegalRelationalUseOfLatticeVar](result)
   }
 
   test("UseOfLatticeVariable.04") {
@@ -230,7 +230,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
         |""".stripMargin
     val result = compile(input, Options.TestWithLibAll)
-    expectError[IllegalRelationalUseOfLatticeVariable](result)
+    expectError[IllegalRelationalUseOfLatticeVar](result)
   }
 
   test("UseOfLatticeVariable.05") {
@@ -241,7 +241,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |}
         |""".stripMargin
     val result = compile(input, Options.TestWithLibAll)
-    expectError[IllegalRelationalUseOfLatticeVariable](result)
+    expectError[IllegalRelationalUseOfLatticeVar](result)
   }
 
   test("TestInvalidThis.01") {
@@ -309,7 +309,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |  }
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.NewObjectNonPublicCLass](result)
+    expectError[SafetyError.NewObjectNonPublicClass](result)
   }
 
   test("TestMissingDefaultTypeMatchCase.01") {


### PR DESCRIPTION
- Eliminate unused errors.
- Rename errors to be more precise.
- Update documentation.
- Re-order to be alphabetical.