### PR TITLE
feat: make effects stack-less

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
@@ -42,7 +42,7 @@ object ShowAstProvider {
       val phases = List("Parser", "Weeder", "Kinder", "Resolver", "TypedAst",
         "Documentor", "Lowering", "TreeShaker1", "MonoDefs",
         "MonoTypes", "Simplifier", "ClosureConv", "LambdaLift", "Tailrec",
-        "Optimizer", "TreeShaker2", "Reducer", "VarOffsets", "Eraser")
+        "Optimizer", "TreeShaker2", "Reducer", "EffectBinder", "VarOffsets", "Eraser")
 
       phase match {
         case "Parser" => astObject(phase, "Work In Progress")
@@ -62,6 +62,7 @@ object ShowAstProvider {
         case "Optimizer" => astObject(phase, AstPrinter.formatLiftedAst(flix.getOptimizerAst))
         case "TreeShaker2" => astObject(phase, AstPrinter.formatLiftedAst(flix.getTreeShaker2Ast))
         case "Reducer" => astObject(phase, AstPrinter.formatReducedAst(flix.getReducerAst))
+        case "EffectBinder" => astObject(phase, AstPrinter.formatReducedAst(flix.getEffectBinderAst))
         case "VarOffsets" => astObject(phase, AstPrinter.formatReducedAst(flix.getVarOffsetsAst))
         case "Eraser" => astObject(phase, "Work In Progress")
         case _ =>

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -275,8 +275,6 @@ object EffectBinder {
     * outermost one. Only [[Expr.Let]] and [[Expr.LetRec]] are added.
     */
   private def visitExprWithBinders(binders: mutable.ArrayBuffer[Expr])(exp: Expr)(implicit lctx: LocalContext, flix: Flix): Expr = {
-    val expTransformed = visitExprInnerWithBinders(binders)(exp)
-
     /**
       * Let-binds the given expression, unless its a variable or constant.
       * If the given argument is a binder, then the structure is flattened.
@@ -307,8 +305,7 @@ object EffectBinder {
       case Expr.Resume(_, _, _) => letBindExpr(binders)(e)
       case Expr.NewObject(_, _, _, _, _, _, _) => letBindExpr(binders)(e)
     }
-
-    bind(expTransformed)
+    bind(visitExprInnerWithBinders(binders)(exp))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -20,18 +20,33 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.BoundBy
 import ca.uwaterloo.flix.language.ast.ReducedAst._
 import ca.uwaterloo.flix.language.ast.{Level, Purity, Symbol}
+import ca.uwaterloo.flix.language.phase.jvm.GenExpression
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 
-
+/**
+  * This phase transforms the AST such that all effect operations will happen on
+  * an empty operand stack in [[GenExpression]]. This means that additional
+  * let-bindings are introduced which means that [[Def.lparams]] must be updated
+  * accordingly.
+  *
+  * An effect operation is either a Do or an application with a control effect,
+  * i.e. an effect that's not just a region or IO. For now all calls are
+  * considered to have an effect.
+  *
+  * Currently, this phase let-binds everything maximally, simplifying the
+  * algorithm.
+  */
 object EffectBinder {
 
   /**
-    * Identity Function.
+    * Transforms the AST such that effect operations will be run without an
+    * operand stack.
     */
   def run(root: Root)(implicit flix: Flix): Root = flix.phase("EffectBinder") {
-    val newDefs = ParOps.parMapValues(root.defs)(letBindEffectsDef)
+    val newDefs = ParOps.parMapValues(root.defs)(visitDef)
     root.copy(defs = newDefs)
   }
 
@@ -48,124 +63,132 @@ object EffectBinder {
   }
 
   /**
-    * Identity Function.
+    * Transforms the [[Def]] such that effect operations will be run without an
+    * operand stack.
     */
-  private def letBindEffectsDef(defn: Def)(implicit flix: Flix): Def = {
+  private def visitDef(defn: Def)(implicit flix: Flix): Def = {
     implicit val lctx: LocalContext = LocalContext.mk()
-    val stmt = letBindEffectsStmt(defn.stmt)
+    val stmt = visitStmt(defn.stmt)
     defn.copy(stmt = stmt, lparams = defn.lparams ++ lctx.lparams.toList)
   }
 
   /**
-    * Identity Function.
+    * Transforms the [[Stmt]] such that effect operations will be run without an
+    * operand stack.
     */
-  private def letBindEffectsStmt(stmt: Stmt)(implicit lctx: LocalContext, flix: Flix): Stmt = stmt match {
-    case Stmt.Ret(expr, tpe, loc) => Stmt.Ret(letBindEffectsTopLevel(expr), tpe, loc)
+  private def visitStmt(stmt: Stmt)(implicit lctx: LocalContext, flix: Flix): Stmt = stmt match {
+    case Stmt.Ret(expr, tpe, loc) => Stmt.Ret(visitExpr(expr), tpe, loc)
   }
 
   /**
-    * Let-binds sub-expressions inside the returned expression.
+    * Transforms the [[Expr]] such that effect operations will be run without an
+    * operand stack - binding necessary expressions in the returned [[Expr]].
     */
-  private def letBindEffectsTopLevel(exp: Expr)(implicit lctx: LocalContext, flix: Flix): Expr = exp match {
+  private def visitExpr(exp: Expr)(implicit lctx: LocalContext, flix: Flix): Expr = exp match {
     case Expr.Cst(_, _, _) =>
-      bindBinders(letBindEffectsTopLevelAux(exp))
+      val binders = mutable.ArrayBuffer.empty[Expr]
+      val e = visitExprInnerWithBinders(binders)(exp)
+      bindBinders(binders, e)
 
     case Expr.Var(_, _, _) =>
-      bindBinders(letBindEffectsTopLevelAux(exp))
+      val binders = mutable.ArrayBuffer.empty[Expr]
+      val e = visitExprInnerWithBinders(binders)(exp)
+      bindBinders(binders, e)
 
     case Expr.ApplyAtomic(_, _, _, _, _) =>
-      bindBinders(letBindEffectsTopLevelAux(exp))
+      val binders = mutable.ArrayBuffer.empty[Expr]
+      val e = visitExprInnerWithBinders(binders)(exp)
+      bindBinders(binders, e)
 
     case Expr.ApplyClo(_, _, _, _, _, _) =>
-      bindBinders(letBindEffectsTopLevelAux(exp))
+      val binders = mutable.ArrayBuffer.empty[Expr]
+      val e = visitExprInnerWithBinders(binders)(exp)
+      bindBinders(binders, e)
 
     case Expr.ApplyDef(_, _, _, _, _, _) =>
-      bindBinders(letBindEffectsTopLevelAux(exp))
+      val binders = mutable.ArrayBuffer.empty[Expr]
+      val e = visitExprInnerWithBinders(binders)(exp)
+      bindBinders(binders, e)
 
     case Expr.ApplySelfTail(_, _, _, _, _, _) =>
-      bindBinders(letBindEffectsTopLevelAux(exp))
+      val binders = mutable.ArrayBuffer.empty[Expr]
+      val e = visitExprInnerWithBinders(binders)(exp)
+      bindBinders(binders, e)
 
     case Expr.IfThenElse(_, _, _, _, _, _) =>
-      bindBinders(letBindEffectsTopLevelAux(exp))
+      val binders = mutable.ArrayBuffer.empty[Expr]
+      val e = visitExprInnerWithBinders(binders)(exp)
+      bindBinders(binders, e)
 
     case Expr.Branch(exp, branches, tpe, purity, loc) =>
-      val e = letBindEffectsTopLevel(exp)
+      val e = visitExpr(exp)
       val branches1 = branches.map {
-        case (sym, branchExp) => (sym, letBindEffectsTopLevel(branchExp))
+        case (sym, branchExp) => (sym, visitExpr(branchExp))
       }
       Expr.Branch(e, branches1, tpe, purity, loc)
 
     case Expr.JumpTo(_, _, _, _) =>
-      bindBinders(letBindEffectsTopLevelAux(exp))
+      val binders = mutable.ArrayBuffer.empty[Expr]
+      val e = visitExprInnerWithBinders(binders)(exp)
+      bindBinders(binders, e)
 
     case Expr.Let(sym, exp1, exp2, tpe, purity, loc) =>
-      val (binders, e1) = letBindEffectsTopLevelAux(exp1)
-      val e2 = letBindEffectsTopLevel(exp2)
+      val binders = mutable.ArrayBuffer.empty[Expr]
+      val e1 = visitExprInnerWithBinders(binders)(exp1)
+      val e2 = visitExpr(exp2)
       val e = Expr.Let(sym, e1, e2, tpe, purity, loc)
       bindBinders(binders, e)
 
     case Expr.LetRec(varSym, index, defSym, exp1, exp2, tpe, purity, loc) =>
-      val (binders, e1) = letBindEffectsTopLevelAux(exp1)
-      val e2 = letBindEffectsTopLevel(exp2)
+      val binders = mutable.ArrayBuffer.empty[Expr]
+      val e1 = visitExprInnerWithBinders(binders)(exp1)
+      val e2 = visitExpr(exp2)
       val e = Expr.LetRec(varSym, index, defSym, e1, e2, tpe, purity, loc)
       bindBinders(binders, e)
 
     case Expr.Scope(sym, exp, tpe, purity, loc) =>
-      val e = letBindEffectsTopLevel(exp)
+      val e = visitExpr(exp)
       Expr.Scope(sym, e, tpe, purity, loc)
 
     case Expr.TryCatch(exp, rules, tpe, purity, loc) =>
-      val e = letBindEffectsTopLevel(exp)
+      val e = visitExpr(exp)
       val rules1 = rules.map {
-        case cr => CatchRule(cr.sym, cr.clazz, letBindEffectsTopLevel(cr.exp))
+        case cr => CatchRule(cr.sym, cr.clazz, visitExpr(cr.exp))
       }
       Expr.TryCatch(e, rules1, tpe, purity, loc)
 
     case Expr.TryWith(exp, effUse, rules, tpe, purity, loc) =>
-      val e = letBindEffectsTopLevel(exp)
+      val e = visitExpr(exp)
       val rules1 = rules.map {
-        case hr => hr.copy(exp = letBindEffectsTopLevel(hr.exp))
+        case hr => hr.copy(exp = visitExpr(hr.exp))
       }
       Expr.TryWith(e, effUse, rules1, tpe, purity, loc)
 
-    case Expr.Do(op, exps, tpe, purity, loc) =>
-      bindBinders(letBindEffectsTopLevelAux(Expr.Do(op, exps, tpe, purity, loc)))
+    case Expr.Do(_, _, _, _, _) =>
+      val binders = mutable.ArrayBuffer.empty[Expr]
+      val e = visitExprInnerWithBinders(binders)(exp)
+      bindBinders(binders, e)
 
-    case Expr.Resume(exp, tpe, loc) =>
-      bindBinders(letBindEffectsTopLevelAux(Expr.Resume(exp, tpe, loc)))
+    case Expr.Resume(_, _, _) =>
+      val binders = mutable.ArrayBuffer.empty[Expr]
+      val e = visitExprInnerWithBinders(binders)(exp)
+      bindBinders(binders, e)
 
-    case Expr.NewObject(name, clazz, tpe, purity, methods, exps, loc) =>
-      bindBinders(letBindEffectsTopLevelAux(Expr.NewObject(name, clazz, tpe, purity, methods, exps, loc)))
-  }
-
-  private def letBindEffectsTopLevelAux(exp: Expr)(implicit lctx: LocalContext, flix: Flix): (mutable.ArrayBuffer[Expr], Expr) = {
-    val binders = mutable.ArrayBuffer.empty[Expr]
-    val e = letBindInnerEffects(binders)(exp)
-    (binders, e)
-  }
-
-  private def bindBinders(t: (mutable.ArrayBuffer[Expr], Expr)): Expr=  {
-    // the right-most binder is the closest one, so we fold from the right
-    val (binders, e) = t
-    binders.foldRight(e) {
-      case (Expr.Let(sym, exp1, _, _, _, loc), acc) =>
-        Expr.Let(sym, exp1, acc, acc.tpe, combine(acc.purity, exp1.purity), loc)
-      case (Expr.LetRec(varSym, index, defSym, exp1, _, _, _, loc), acc) =>
-        Expr.LetRec(varSym, index, defSym, exp1, acc, acc.tpe, combine(acc.purity, exp1.purity), loc)
-      case (other, _) => throw InternalCompilerException(s"Unexpected binder $other", other.loc)
-    }
-  }
-
-  private def combine(p1: Purity, p2: Purity): Purity = (p1, p2) match {
-    case (Purity.Pure, Purity.Pure) => Purity.Pure
-    case _ => Purity.Impure
+    case Expr.NewObject(_, _, _, _, _, _, _) =>
+      val binders = mutable.ArrayBuffer.empty[Expr]
+      val e = visitExprInnerWithBinders(binders)(exp)
+      bindBinders(binders, e)
   }
 
   /**
-    * Let-binds all inner expressions, but not the top-most one.
-    * Binders are added to the [[LocalContext]].
+    * Transforms the [[Expr]] such that effect operations will be run without an
+    * operand stack. The outer-most expression IS NOT let-bound but all
+    * sub-expressions will be. `do E(x, y, z)` might be returned.
+    *
+    * Necessary bindings are added to binders, where the first binder is the
+    * outermost one. Only [[Expr.Let]] and [[Expr.LetRec]] are added.
     */
-  private def letBindInnerEffects(binders: mutable.ArrayBuffer[Expr])(exp: Expr)(implicit lctx: LocalContext, flix: Flix): Expr = exp match {
+  private def visitExprInnerWithBinders(binders: mutable.ArrayBuffer[Expr])(exp: Expr)(implicit lctx: LocalContext, flix: Flix): Expr = exp match {
     case Expr.Cst(cst, tpe, loc) =>
       Expr.Cst(cst, tpe, loc)
 
@@ -173,32 +196,32 @@ object EffectBinder {
       Expr.Var(sym, tpe, loc)
 
     case Expr.ApplyAtomic(op, exps, tpe, purity, loc) =>
-      val es = exps.map(letBindEffects(binders))
+      val es = exps.map(visitExprWithBinders(binders))
       Expr.ApplyAtomic(op, es, tpe, purity, loc)
 
     case Expr.ApplyClo(exp, exps, ct, tpe, purity, loc) =>
-      val e = letBindEffects(binders)(exp)
-      val es = exps.map(letBindEffects(binders))
+      val e = visitExprWithBinders(binders)(exp)
+      val es = exps.map(visitExprWithBinders(binders))
       Expr.ApplyClo(e, es, ct, tpe, purity, loc)
 
     case Expr.ApplyDef(sym, exps, ct, tpe, purity, loc) =>
-      val es = exps.map(letBindEffects(binders))
+      val es = exps.map(visitExprWithBinders(binders))
       Expr.ApplyDef(sym, es, ct, tpe, purity, loc)
 
     case Expr.ApplySelfTail(sym, formals, actuals, tpe, purity, loc) =>
-      val as = actuals.map(letBindEffects(binders))
+      val as = actuals.map(visitExprWithBinders(binders))
       Expr.ApplySelfTail(sym, formals, as, tpe, purity, loc)
 
     case Expr.IfThenElse(exp1, exp2, exp3, tpe, purity, loc) =>
-      val e1 = letBindInnerEffects(binders)(exp1)
-      val e2 = letBindEffectsTopLevel(exp2)
-      val e3 = letBindEffectsTopLevel(exp3)
+      val e1 = visitExprInnerWithBinders(binders)(exp1)
+      val e2 = visitExpr(exp2)
+      val e3 = visitExpr(exp3)
       Expr.IfThenElse(e1, e2, e3, tpe, purity, loc)
 
     case Expr.Branch(exp, branches, tpe, purity, loc) =>
-      val e = letBindEffectsTopLevel(exp)
+      val e = visitExpr(exp)
       val bs = branches.map {
-        case (sym, branchExp) => (sym, letBindEffectsTopLevel(branchExp))
+        case (sym, branchExp) => (sym, visitExpr(branchExp))
       }
       Expr.Branch(e, bs, tpe, purity, loc)
 
@@ -206,49 +229,59 @@ object EffectBinder {
       Expr.JumpTo(sym, tpe, purity, loc)
 
     case Expr.Let(sym, exp1, exp2, _, _, loc) =>
-      val e1 = letBindInnerEffects(binders)(exp1)
+      val e1 = visitExprInnerWithBinders(binders)(exp1)
       binders.addOne(Expr.Let(sym, e1, null, null, null, loc))
-      letBindInnerEffects(binders)(exp2)
+      visitExprInnerWithBinders(binders)(exp2)
 
     case Expr.LetRec(varSym, index, defSym, exp1, exp2, _, _, loc) =>
-      val e1 = letBindInnerEffects(binders)(exp1)
+      val e1 = visitExprInnerWithBinders(binders)(exp1)
       binders.addOne(Expr.LetRec(varSym, index, defSym, e1, null, null, null, loc))
-      letBindInnerEffects(binders)(exp2)
+      visitExprInnerWithBinders(binders)(exp2)
 
     case Expr.Scope(sym, exp, tpe, purity, loc) =>
-      val e = letBindEffectsTopLevel(exp)
+      val e = visitExpr(exp)
       Expr.Scope(sym, e, tpe, purity, loc)
 
     case Expr.TryCatch(exp, rules, tpe, purity, loc) =>
-      val e = letBindEffectsTopLevel(exp)
+      val e = visitExpr(exp)
       Expr.TryCatch(e, rules, tpe, purity, loc)
 
     case Expr.TryWith(exp, effUse, rules, tpe, purity, loc) =>
-      val e = letBindEffectsTopLevel(exp)
+      val e = visitExpr(exp)
       val rs = rules.map {
-        case HandlerRule(op, fparams, handlerExp) => HandlerRule(op, fparams, letBindEffectsTopLevel(handlerExp))
+        case HandlerRule(op, fparams, handlerExp) => HandlerRule(op, fparams, visitExpr(handlerExp))
       }
       Expr.TryWith(e, effUse, rs, tpe, purity, loc)
 
     case Expr.Do(op, exps, tpe, purity, loc) =>
-      val es = exps.map(letBindEffects(binders))
+      val es = exps.map(visitExprWithBinders(binders))
       Expr.Do(op, es, tpe, purity, loc)
 
     case Expr.NewObject(name, clazz, tpe, purity, methods, exps, loc) =>
-      val es = exps.map(letBindInnerEffects(binders))
+      val es = exps.map(visitExprInnerWithBinders(binders))
       Expr.NewObject(name, clazz, tpe, purity, methods, es, loc)
 
     case Expr.Resume(exp, tpe, loc) =>
-      val e = letBindEffects(binders)(exp)
+      val e = visitExprWithBinders(binders)(exp)
       Expr.Resume(e, tpe, loc)
   }
 
   /**
-    * Let-binds all sub-expressions including the top-most one.
-    * Always returns a variable or a constant.
+    * Transforms the [[Expr]] such that effect operations will be run without an
+    * operand stack. The outer-most expression IS let-bound along with all
+    * sub-expressions. A variable or a constant is always returned.
+    *
+    * Necessary bindings are added to binders, where the first binder is the
+    * outermost one. Only [[Expr.Let]] and [[Expr.LetRec]] are added.
     */
-  private def letBindEffects(binders: mutable.ArrayBuffer[Expr])(exp: Expr)(implicit lctx: LocalContext, flix: Flix): Expr = {
-    val expTransformed = letBindInnerEffects(binders)(exp)
+  private def visitExprWithBinders(binders: mutable.ArrayBuffer[Expr])(exp: Expr)(implicit lctx: LocalContext, flix: Flix): Expr = {
+    val expTransformed = visitExprInnerWithBinders(binders)(exp)
+
+    /**
+      * Let-binds the given expression, unless its a variable or constant.
+      * If the given argument is a binder, then the structure is flattened.
+      */
+    @tailrec
     def bind(e: Expr): Expr = e match {
       // trivial expressions
       case Expr.Cst(_, _, _) => e
@@ -274,15 +307,45 @@ object EffectBinder {
       case Expr.Resume(_, _, _) => letBindExpr(binders)(e)
       case Expr.NewObject(_, _, _, _, _, _, _) => letBindExpr(binders)(e)
     }
+
     bind(expTransformed)
   }
 
+  /**
+    * Simply let-binds the given expression, adding a [[Expr.Let]] to binders.
+    * The local params of [[LocalContext]] is updated with this new binder.
+    */
   private def letBindExpr(binders: mutable.ArrayBuffer[Expr])(e: Expr)(implicit lctx: LocalContext, flix: Flix): Expr.Var = {
     val loc = e.loc.asSynthetic
     val sym = Symbol.freshVarSym("anf", BoundBy.Let, loc)(Level.Default, flix)
     lctx.lparams.addOne(LocalParam(sym, e.tpe))
     binders.addOne(Expr.Let(sym, e, null, null, null, loc))
     Expr.Var(sym, e.tpe, loc)
+  }
+
+  /**
+    * Returns an [[Expr]] where the given binders is a chained [[Expr.Let]]
+    * expression. The first binder will be the outer-most one.
+    *
+    * The binders are expected to be either [[Expr.Let]] or [[Expr.LetRec]]
+    * where the body of the binder is ignored.
+    */
+  private def bindBinders(binders: mutable.ArrayBuffer[Expr], exp: Expr): Expr = {
+    binders.foldRight(exp) {
+      case (Expr.Let(sym, exp1, _, _, _, loc), acc) =>
+        Expr.Let(sym, exp1, acc, acc.tpe, combine(acc.purity, exp1.purity), loc)
+      case (Expr.LetRec(varSym, index, defSym, exp1, _, _, _, loc), acc) =>
+        Expr.LetRec(varSym, index, defSym, exp1, acc, acc.tpe, combine(acc.purity, exp1.purity), loc)
+      case (other, _) => throw InternalCompilerException(s"Unexpected binder $other", other.loc)
+    }
+  }
+
+  /**
+    * Returns [[Purity.Pure]] if and only if both arguments are [[Purity.Pure]].
+    */
+  private def combine(p1: Purity, p2: Purity): Purity = (p1, p2) match {
+    case (Purity.Pure, Purity.Pure) => Purity.Pure
+    case _ => Purity.Impure
   }
 
 }


### PR DESCRIPTION
A compromise between a simple let-binder and a clever solution. We let bind everything, but complexity is added since, when looking at the body of a top-level let-binding (`let x = e1; e2`) we don't want to let-bind the outermost structure of `e1`.

This last small optimization is about a 2x decrease in let-binders and avoid the type issues with regions and the bug with if-statements generated from pattern matches.