### PR TITLE
ci: run tests from community build

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -70,3 +70,5 @@ jobs:
         run: |
           # Build the project.
           java -jar flix.jar build --github-key ${{ github.token }}
+          # Run tests
+          java -jar flix.jar test


### PR DESCRIPTION
Fixes #6814 