### PR TITLE
fix: correct bool-op shortcircuit handling

### DIFF
--- a/main/test/flix/Test.Exp.Binary.Logic.flix
+++ b/main/test/flix/Test.Exp.Binary.Logic.flix
@@ -91,6 +91,9 @@ mod Test.Exp.Binary.Logic {
     def testBinaryLogicalAnd05b(): Bool = (false and ???) == false
 
     @test
+    def testBinaryLogicalAnd05c(): Bool = (false and {let crash = ???; false}) == false
+
+    @test
     def testBinaryLogicalAnd06a(): Bool = (true and true and true) == true
 
     @test
@@ -129,6 +132,9 @@ mod Test.Exp.Binary.Logic {
 
     @test
     def binaryLogicalOrTest05b(): Bool = (true or ???) == true
+
+    @test
+    def binaryLogicalOrTest05c(): Bool = (true or {let crash = ???; true}) == true
 
     @test
     def binaryLogicalOrTest06a(): Bool = (true or true or true) == true


### PR DESCRIPTION
fixes  #6813

And and Or use shortcircuiting which was not represented in the translation. luckily, in the code gen for these operations, the right operand is not on the stack when the left operand is evaluated, so translation is like an if-statement.

I've verified that no tests crash, but some still fail, probably due to https://github.com/mlutze/flix-json/issues/75