### PR TITLE
feat: lex `CommentDoc`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -81,6 +81,8 @@ object TokenKind {
 
   case object CommentLine extends TokenKind
 
+  case object CommentDoc extends TokenKind
+
   case object CurlyL extends TokenKind
 
   case object CurlyR extends TokenKind

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -331,7 +331,11 @@ object Lexer {
         TokenKind.Hash
       }
       case '/' => if (peek() == '/') {
-        acceptLineComment()
+        if (peekPeek().contains('/')) {
+          acceptDocComment()
+        } else {
+          acceptLineComment()
+        }
       } else if (peek() == '*') {
         acceptBlockComment()
       } else {
@@ -892,6 +896,20 @@ object Lexer {
       }
     }
     TokenKind.CommentLine
+  }
+
+  /**
+   * Moves current position past a doc-comment
+   */
+  private def acceptDocComment()(implicit s: State): TokenKind = {
+    while (!eof()) {
+      if (peek() == '\n') {
+        return TokenKind.CommentDoc
+      } else {
+        advance()
+      }
+    }
+    TokenKind.CommentDoc
   }
 
   /**


### PR DESCRIPTION
Add support for lexing doc comments. Any comment starting with `///` is considered a doc-comment.