### PR TITLE
feat: convert `Token` to `SourcePosition` and `SourceLocation`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Token.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Token.scala
@@ -23,16 +23,16 @@ import org.parboiled2.ParserInput
  * Token does not hold its lexeme directly to avoid duplication of common keywords like "def".
  * Instead it holds a pointer to its source along with start and end offsets.
  *
- * @param kind     The kind of token this instance represents.
- * @param src      A pointer to the source that this lexeme stems from.
- * @param start    The absolute character offset into `src` of the beginning of the lexeme.
- * @param end      The absolute character offset into `src` of the end of the lexeme.
- * @param line     The line that the lexeme __starts__ on.
- * @param col      The column that the lexeme __starts__ on.
- * @param lineEnd  The line that the lexeme __ends__ on.
- * @param colEnd   The column that the lexeme __ends__ on.
+ * @param kind      The kind of token this instance represents.
+ * @param src       A pointer to the source that this lexeme stems from.
+ * @param start     The absolute character offset into `src` of the beginning of the lexeme.
+ * @param end       The absolute character offset into `src` of the end of the lexeme.
+ * @param beginLine The line that the lexeme __starts__ on.
+ * @param beginCol  The column that the lexeme __starts__ on.
+ * @param endLine   The line that the lexeme __ends__ on.
+ * @param endCol    The column that the lexeme __ends__ on.
  */
-case class Token(kind: TokenKind, src: Array[Char], start: Int, end: Int, line: Int, col: Int, lineEnd: Int, colEnd: Int) {
+case class Token(kind: TokenKind, src: Array[Char], start: Int, end: Int, beginLine: Int, beginCol: Int, endLine: Int, endCol: Int) {
   /**
    * Computes the lexeme that the token refers to by slicing it from `src`.
    * Note: This is explicitly lazy since we do not want to compute strings that are never used,
@@ -43,14 +43,14 @@ case class Token(kind: TokenKind, src: Array[Char], start: Int, end: Int, line: 
   /**
    * Returns a string representation of this token. Should only be used for debugging.
    */
-  override def toString: String = s"Token($kind, $text, $line, $col, $lineEnd, $colEnd)"
+  override def toString: String = s"Token($kind, $text, $beginLine, $beginCol, $endLine, $endCol)"
 
   /**
    * Makes a [[SourcePosition]] pointing at the start of this token.
    * NB: Tokens are zero-indexed while SourcePositions are one-indexed
    */
   def mkSourcePosition(src: Ast.Source, parserInput: Option[ParserInput]):SourcePosition = {
-    SourcePosition(src, line + 1, col + 1, parserInput)
+    SourcePosition(src, beginLine + 1, beginCol + 1, parserInput)
   }
 
   /**
@@ -58,7 +58,7 @@ case class Token(kind: TokenKind, src: Array[Char], start: Int, end: Int, line: 
    * NB: Tokens are zero-indexed while SourcePositions are one-indexed
    */
   def mkSourcePositionEnd(src: Ast.Source, parserInput: Option[ParserInput]): SourcePosition = {
-    SourcePosition(src, lineEnd + 1, colEnd + 1, parserInput)
+    SourcePosition(src, endLine + 1, endCol + 1, parserInput)
   }
 
   /**
@@ -66,7 +66,7 @@ case class Token(kind: TokenKind, src: Array[Char], start: Int, end: Int, line: 
    * NB: Tokens are zero-indexed while SourceLocations are one-indexed
    */
   def mkSourceLocation(src: Ast.Source, parserInput: Option[ParserInput], locationKind: SourceKind = SourceKind.Real): SourceLocation = {
-    SourceLocation(parserInput, src, locationKind, line + 1, col + 1, lineEnd + 1, colEnd + 1)
+    SourceLocation(parserInput, src, locationKind, beginLine + 1, beginCol + 1, endLine + 1, endCol + 1)
   }
 }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Token.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Token.scala
@@ -15,20 +15,24 @@
  */
 package ca.uwaterloo.flix.language.ast
 
+import org.parboiled2.ParserInput
+
 /**
  * A Token holding a kind, line and column.
  *
  * Token does not hold its lexeme directly to avoid duplication of common keywords like "def".
  * Instead it holds a pointer to its source along with start and end offsets.
  *
- * @param kind  The kind of token this instance represents.
- * @param src   A pointer to the source that this lexeme stems from.
- * @param start The absolute character offset into `src` of the beginning of the lexeme.
- * @param end   The absolute character offset into `src` of the end of the lexeme.
- * @param line  The line that the lexeme __starts__ on.
- * @param col   The column that the lexeme __starts__ on.
+ * @param kind     The kind of token this instance represents.
+ * @param src      A pointer to the source that this lexeme stems from.
+ * @param start    The absolute character offset into `src` of the beginning of the lexeme.
+ * @param end      The absolute character offset into `src` of the end of the lexeme.
+ * @param line     The line that the lexeme __starts__ on.
+ * @param col      The column that the lexeme __starts__ on.
+ * @param lineEnd  The line that the lexeme __ends__ on.
+ * @param colEnd   The column that the lexeme __ends__ on.
  */
-case class Token(kind: TokenKind, src: Array[Char], start: Int, end: Int, line: Int, col: Int) {
+case class Token(kind: TokenKind, src: Array[Char], start: Int, end: Int, line: Int, col: Int, lineEnd: Int, colEnd: Int) {
   /**
    * Computes the lexeme that the token refers to by slicing it from `src`.
    * Note: This is explicitly lazy since we do not want to compute strings that are never used,
@@ -40,4 +44,29 @@ case class Token(kind: TokenKind, src: Array[Char], start: Int, end: Int, line: 
    * Returns a string representation of this token. Should only be used for debugging.
    */
   override def toString: String = s"Token($kind, $text, $line, $col)"
+
+  /**
+   * Makes a [[SourcePosition]] pointing at the start of this token.
+   * NB: Tokens are zero-indexed while SourcePositions are one-indexed
+   */
+  def mkSourcePosition(src: Ast.Source, parserInput: Option[ParserInput]):SourcePosition = {
+    SourcePosition(src, line + 1, col + 1, parserInput)
+  }
+
+  /**
+   * Makes a [[SourcePosition]] pointing at the _end_ of this token.
+   * NB: Tokens are zero-indexed while SourcePositions are one-indexed
+   */
+  def mkSourcePositionEnd(src: Ast.Source, parserInput: Option[ParserInput]): SourcePosition = {
+    SourcePosition(src, lineEnd + 1, colEnd + 1, parserInput)
+  }
+
+  /**
+   * Makes a [[SourceLocation]] spanning this token.
+   * NB: Tokens are zero-indexed while SourceLocations are one-indexed
+   */
+  def mkSourceLocation(src: Ast.Source, parserInput: Option[ParserInput], locationKind: SourceKind = SourceKind.Real): SourceLocation = {
+    SourceLocation(parserInput, src, locationKind, line + 1, col + 1, lineEnd + 1, colEnd + 1)
+  }
 }
+

--- a/main/src/ca/uwaterloo/flix/language/ast/Token.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Token.scala
@@ -43,7 +43,7 @@ case class Token(kind: TokenKind, src: Array[Char], start: Int, end: Int, line: 
   /**
    * Returns a string representation of this token. Should only be used for debugging.
    */
-  override def toString: String = s"Token($kind, $text, $line, $col)"
+  override def toString: String = s"Token($kind, $text, $line, $col, $lineEnd, $colEnd)"
 
   /**
    * Makes a [[SourcePosition]] pointing at the start of this token.

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -292,7 +292,6 @@ object Lexer {
    * Afterwards `s.start` is reset to the next position after the previous token.
    */
   private def addToken(kind: TokenKind)(implicit s: State): Unit = {
-    // At this point, current will be sitting on the char _after_ the last one.
     s.tokens += Token(kind, s.src.data, s.start.offset, s.current.offset, s.start.line, s.start.column, s.end.line, s.end.column)
     s.start = new Position(s.current.line, s.current.column, s.current.offset)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -293,7 +293,6 @@ object Lexer {
    */
   private def addToken(kind: TokenKind)(implicit s: State): Unit = {
     // At this point, current will be sitting on the char _after_ the last one.
-    println(kind, s.end.line, s.end.column)
     s.tokens += Token(kind, s.src.data, s.start.offset, s.current.offset, s.start.line, s.start.column, s.end.line, s.end.column)
     s.start = new Position(s.current.line, s.current.column, s.current.offset)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -62,7 +62,8 @@ object Lexer {
 
   /**
    * The internal state of the lexer as it tokenizes a single source.
-   * At any point execution `start` represents the start of the token currently being considered,
+   * At any point execution `start` represents the start of the token currently being considered.
+   * Likewise `end` represents the end of the token currently being considered,
    * while `current` is the current read head of the lexer.
    * Note that both start and current are `Position`s since they are not necessarily on the same line.
    * `current` will always be on the same character as or past `start`.
@@ -72,9 +73,6 @@ object Lexer {
     var start: Position = new Position(0, 0, 0)
     val current: Position = new Position(0, 0, 0)
     var end: Position = new Position(0, 0, 0)
-    // The last column index of the line before the current one.
-    // This is specifically used on [[addToken]] so make endCol correct,
-    // when the lexer is sitting on a newline.
     val tokens: mutable.ListBuffer[Token] = mutable.ListBuffer.empty
     var interpolationNestingLevel: Int = 0
     // Compute a `ParserInput` when initializing a state for lexing a source.

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -139,7 +139,7 @@ object Lexer {
     addToken(TokenKind.Eof)
 
     val errors = s.tokens.collect {
-      case Token(TokenKind.Err(err), _, _, _, _, _) => err
+      case Token(TokenKind.Err(err), _, _, _, _, _, _, _) => err
     }
     if (errors.isEmpty) {
       s.tokens.toArray.toSuccess
@@ -287,7 +287,7 @@ object Lexer {
    * Afterwards `s.start` is reset to the next position after the previous token.
    */
   private def addToken(kind: TokenKind)(implicit s: State): Unit = {
-    s.tokens += Token(kind, s.src.data, s.start.offset, s.current.offset, s.start.line, s.start.column)
+    s.tokens += Token(kind, s.src.data, s.start.offset, s.current.offset, s.start.line, s.start.column, s.current.line, s.current.column)
     s.start = new Position(s.current.line, s.current.column, s.current.offset)
   }
 


### PR DESCRIPTION
This PR adds convenient conversions from a `Token` to `SourcePosition`, both at the start and end of the token, as well as a conversion into `SouceLocation`