### PR TITLE
refactor: local offset argumet

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -269,11 +269,14 @@ object Symbol {
     /**
       * Returns the stack offset of `this` variable symbol.
       *
+      * The local offset should be the number of jvm arguments for static
+      * methods and one higher than that for instance methods.
+      *
       * Throws [[InternalCompilerException]] if the stack offset has not been set.
       */
-    def getStackOffset: Int = stackOffset match {
+    def getStackOffset(localOffset: Int): Int = stackOffset match {
       case None => throw InternalCompilerException(s"Unknown offset for variable symbol $toString.", loc)
-      case Some(offset) => offset
+      case Some(offset) => offset + localOffset
     }
 
     /**

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -132,7 +132,7 @@ object DocAst {
 
     /** e.g. `x_2` */
     def VarWithOffset(sym: Symbol.VarSym): Expression =
-      AsIs(sym.toString + "_" + sym.getStackOffset.toString)
+      AsIs(sym.toString + "_" + sym.getStackOffset(0).toString)
 
     def Hole(sym: Symbol.HoleSym): Expression =
       AsIs("?" + sym.toString)


### PR DESCRIPTION
Instead of magic `+1`s all around, its a number stored in the method argument and is required in `var.getStackOffset(localOffset)`

This means that genexpression is not hardcoded to a specific context (an instance method without actual jvm arguments)

This PR also changes the `+1` to `+2` since the value argument added for arguments were not accounted for.