### PR TITLE
feat: backend effect functions

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -291,7 +291,20 @@ object Reducer {
         sacc + eType ++ caseTypes
     }
 
-    val result = defTypes ++ enumTypes
+    val effectTypes = root.effects.foldLeft(Set.empty[MonoType]) {
+      case (sacc, (_, e)) =>
+        val opTypes = e.ops.map{
+          case op =>
+            val paramTypes = op.fparams.map(_.tpe)
+            val resType = op.tpe
+            val continuationType = MonoType.Object
+            val correctedFunctionType = MonoType.Arrow(paramTypes :+ continuationType, resType)
+            paramTypes.toSet + resType + continuationType + correctedFunctionType
+        }.foldLeft(Set.empty[MonoType]){case (acc, cur) => acc.union(cur)}
+        sacc ++ opTypes
+    }
+
+    val result = defTypes ++ enumTypes ++ effectTypes
 
     nestedTypesOf(Set.empty, Queue.from(result))
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -298,8 +298,8 @@ object Reducer {
             val paramTypes = op.fparams.map(_.tpe)
             val resType = op.tpe
             val continuationType = MonoType.Object
-            val correctedFunctionType = MonoType.Arrow(paramTypes :+ continuationType, resType)
-            paramTypes.toSet + resType + continuationType + correctedFunctionType
+            val correctedFunctionType: MonoType = MonoType.Arrow(paramTypes :+ continuationType, resType)
+            Set(correctedFunctionType)
         }.foldLeft(Set.empty[MonoType]){case (acc, cur) => acc.union(cur)}
         sacc ++ opTypes
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
@@ -1,8 +1,7 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.ReducedAst.{Effect, FormalParam, Op, Root}
-import ca.uwaterloo.flix.language.ast.{MonoType, Symbol}
+import ca.uwaterloo.flix.language.ast.ReducedAst.{Effect, Op, Root}
 import ca.uwaterloo.flix.util.ParOps
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes._
@@ -14,18 +13,33 @@ import org.objectweb.asm.Opcodes._
 ///     pub def add(x: Int32, y: Int32): Int32
 /// }
 /// ```
-/// Is conceptually understood as (`Resumption` is a backend interface):
+/// Is conceptually understood as (the input types of `cont` are actually boxed in `Value`):
 /// ```
 /// eff SomeEffect {
-///     pub def flip(unit: Unit, cont: Resumption): Value
-///     pub def add(x: Int32, y: Int32, cont: Resumption): Value
+///     pub def flip(unit: Unit, cont: Bool -> Result): Value
+///     pub def add(x: Int32, y: Int32, cont: Int32 -> Result): Value
 /// }
 /// ```
 /// and is generated like so:
 /// ```
 /// public final class Eff$SomeEffect implements Handler {
-///     public Fn2$Obj$Obj flip
-///     public Fn3$Int32$Int32&Obj add
+///     public Fn2$Obj$Obj$Obj flip
+///     public Fn3$Int32$Int32&Obj$Obj add
+///
+///     public static EffectCall flip(Object var0, Handler h, Resumption r) {
+///         Fn2$Obj$Obj$Obj f = ((Eff$SomeEffect) h).flip;
+///         f.arg0 = var0;
+///         f.arg1 = new ResumptionWrapper(r);
+///         return f.invoke();
+///     }
+///
+///     public static EffectCall add(Int var0, Int var1, Handler h, Resumption r) {
+///         Fn2$Obj$Obj$Obj f = ((Eff$SomeEffect) h).flip;
+///         f.arg0 = var0;
+///         f.arg1 = var1;
+///         f.arg2 = new ResumptionWrapper(r);
+///         return f.invoke();
+///     }
 /// }
 /// ```
 object GenEffectClasses {
@@ -48,21 +62,64 @@ object GenEffectClasses {
     visitor.visit(AsmOps.JavaVersion, ACC_PUBLIC + ACC_FINAL, effectType.name.toInternalName,
       null, superClass, interfaces)
 
-    genFields(visitor, effect)
+    for (op <- effect.ops) genFieldAndMethod(visitor, effectType, op)
 
     visitor.visitEnd()
     visitor.toByteArray
   }
 
-  private def genFields(visitor: ClassWriter, effect: Effect): Unit = {
-    for (Op(sym, _, _, fparams, _, _, _) <- effect.ops) {
-      val erasedFparams = fparams.map(_.tpe).map(JvmOps.getErasedJvmType)
-      val resumptionType = JvmType.Object // actually a function
-      val res = JvmType.Object // actually a Value
-      val args = erasedFparams :+ resumptionType
-      val functionType = JvmOps.getFunctionInterfaceType(args, res)
-      visitor.visitField(ACC_PUBLIC, JvmOps.getEffectOpName(sym), functionType.toDescriptor, null, null)
+  private def genFieldAndMethod(visitor: ClassWriter, effectType: JvmType.Reference, op: Op): Unit = {
+    // Field
+    val writtenOpArgs = op.fparams.map(_.tpe).map(JvmOps.getErasedJvmType)
+    val resumption = JvmType.Reference(BackendObjType.Resumption.jvmName)
+    val opResult = JvmType.Object // actually a Value
+    val modifiedArgs = writtenOpArgs :+ resumption
+    val opName = JvmOps.getEffectOpName(op.sym)
+    val opFunctionType = JvmOps.getFunctionInterfaceType(modifiedArgs, opResult)
+    visitor.visitField(ACC_PUBLIC, opName, opFunctionType.toDescriptor, null, null)
+    // Method
+    // 1. Cast the given generic handler to the current effect
+    // 2. Convert the given resumption into a callable Fn1$Obj (Value -> Result) via ResumptionWrapper
+    // 3. call invoke on the op
+    val (writtenOpArgsOffsetRev, handlerOffset) = writtenOpArgs.foldLeft((Nil: List[(JvmType, Int)], 0)) {
+      case ((acc, prev), arg) => ((arg, prev) :: acc, prev + AsmOps.getStackSize(arg))
     }
+    val writtenOpArgsOffset = writtenOpArgsOffsetRev.reverse
+    val handlerType = JvmType.Reference(BackendObjType.Handler.jvmName)
+    val methodArgs = writtenOpArgs ++ List(handlerType, resumption)
+    val methodResult = JvmType.Reference(BackendObjType.Result.jvmName)
+    val effectName = effectType.name.toInternalName
+    val mv = visitor.visitMethod(ACC_PUBLIC + ACC_STATIC, opName, AsmOps.getMethodDescriptor(methodArgs, methodResult), null, null)
+    mv.visitCode()
+
+    mv.visitVarInsn(ALOAD, handlerOffset)
+    mv.visitTypeInsn(CHECKCAST, effectName)
+    mv.visitFieldInsn(GETFIELD, effectName, opName, opFunctionType.toDescriptor)
+    // bind all regular arguments
+    for (((t, localOffset), i) <- writtenOpArgsOffset.zipWithIndex) {
+      val xLoad = AsmOps.getLoadInstruction(t)
+      mv.visitInsn(DUP)
+      mv.visitVarInsn(xLoad, localOffset)
+      mv.visitFieldInsn(PUTFIELD, opFunctionType.name.toInternalName, s"arg$i", t.toDescriptor)
+    }
+    // convert the resumption to a function
+    mv.visitInsn(DUP)
+
+    val wrapperType = BackendObjType.ResumptionWrapper
+    val wrapperName = wrapperType.jvmName.toInternalName
+    mv.visitTypeInsn(NEW, wrapperName)
+    mv.visitInsn(DUP)
+    mv.visitVarInsn(ALOAD, handlerOffset + 1) // the resumption is the stack offset after handler
+    mv.visitMethodInsn(INVOKESPECIAL, wrapperName, JvmName.ConstructorMethod, wrapperType.Constructor.d.toDescriptor, false)
+
+    mv.visitFieldInsn(PUTFIELD, opFunctionType.name.toInternalName, s"arg${modifiedArgs.size - 1}", resumption.toErased.toDescriptor)
+    // call invoke
+    val invokeMethod = BackendObjType.Thunk.InvokeMethod
+    mv.visitMethodInsn(INVOKEVIRTUAL, opFunctionType.name.toInternalName, invokeMethod.name, invokeMethod.d.toDescriptor, false)
+    mv.visitInsn(ARETURN)
+
+    mv.visitMaxs(999, 999)
+    mv.visitEnd()
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
@@ -23,8 +23,8 @@ import org.objectweb.asm.Opcodes._
 /// and is generated like so:
 /// ```
 /// public final class Eff$SomeEffect implements Handler {
-///     public Fn2$Obj$Obj$Obj flip
-///     public Fn3$Int32$Int32&Obj$Obj add
+///     public Fn2$Obj$Obj$Obj flip;
+///     public Fn3$Int32$Int32&Obj$Obj add;
 ///
 ///     public static EffectCall flip(Object var0, Handler h, Resumption r) {
 ///         Fn2$Obj$Obj$Obj f = ((Eff$SomeEffect) h).flip;

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.ReducedAst._
-import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
+import ca.uwaterloo.flix.language.ast.{MonoType, SourceLocation, Symbol}
 import ca.uwaterloo.flix.runtime.CompilationResult
 import ca.uwaterloo.flix.util.InternalCompilerException
 
@@ -45,8 +45,10 @@ object JvmBackend {
       // Compute the set of namespaces in the program.
       val namespaces = JvmOps.namespacesOf(root)
 
+      val objectToObject = MonoType.Arrow(List(MonoType.Object), MonoType.Object) // by resumptionWrapper
       // Retrieve all the types in the program.
-      val types = root.types
+      val requiredTypes = Set(objectToObject) // note that required types need to be present deeply (if you add `List[Int32]` also add `Int32`)
+      val types = root.types ++ requiredTypes
 
       // Filter the program types into different sets
       val erasedRefTypes = JvmOps.getErasedRefsOf(types)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -112,6 +112,7 @@ object JvmBackend {
       val handlerInterface = Map(genClass(BackendObjType.Handler))
       val effectCallClass = Map(genClass(BackendObjType.EffectCall))
       val effectClasses = GenEffectClasses.gen(root.effects.values)
+      val resumptionWrapper = Map(genClass(BackendObjType.ResumptionWrapper))
 
       // Collect all the classes and interfaces together.
       List(
@@ -150,7 +151,8 @@ object JvmBackend {
         resumptionNilClass,
         handlerInterface,
         effectCallClass,
-        effectClasses
+        effectClasses,
+        resumptionWrapper
       ).reduce(_ ++ _)
     }
 


### PR DESCRIPTION
* `ResumptionWrapper` is a helper calls to make a `Resumption` a callable function in flix protocol
* `Effect.op` functions are unused, but will be used to generate code in try-with
* Reducer now also looks for types in effects (this is needed now since the above functions assume the existence of some function interfaces)


From the docs:
```java
eff SomeEffect {
    pub def flip(unit: Unit, cont: Bool -> Result): Value
    pub def add(x: Int32, y: Int32, cont: Int32 -> Result): Value
}
```
is generated like so:
```java
public final class Eff$SomeEffect implements Handler {
    public Fn2$Obj$Obj$Obj flip;
    public Fn3$Int32$Int32&Obj$Obj add;
    public static EffectCall flip(Object var0, Handler h, Resumption r) {
        Fn2$Obj$Obj$Obj f = ((Eff$SomeEffect) h).flip;
        f.arg0 = var0;
        f.arg1 = new ResumptionWrapper(r);
        return f.invoke();
    }
    public static EffectCall add(Int var0, Int var1, Handler h, Resumption r) {
        Fn2$Obj$Obj$Obj f = ((Eff$SomeEffect) h).flip;
        f.arg0 = var0;
        f.arg1 = var1;
        f.arg2 = new ResumptionWrapper(r);
        return f.invoke();
    }
}
```