### PR TITLE
fix: filler region value null instead of unit

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -528,9 +528,9 @@ object GenExpression {
         }
 
       case AtomicOp.Region =>
-        //!TODO: For now, just emit unit
-        val e = Expr.Cst(Ast.Constant.Unit, MonoType.Unit, loc)
-        compileExpr(e)
+        //!TODO: For now, just emit null
+        mv.visitInsn(ACONST_NULL)
+        mv.visitTypeInsn(CHECKCAST, BackendObjType.Region.jvmName.toInternalName)
 
       case AtomicOp.ScopeExit =>
         val List(exp1, exp2) = exps


### PR DESCRIPTION
unit is not type Region, which can sometimes lead to bugs (effect binders) so instead null is used which is actually of type Region