### PR TITLE
feat: Systematic names

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.phase.jvm.BackendObjType.mkName
+import ca.uwaterloo.flix.language.phase.jvm.BackendObjType.mkClassName
 import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions.Branch._
 import ca.uwaterloo.flix.language.phase.jvm.BytecodeInstructions._
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Final.{IsFinal, NotFinal}
@@ -36,26 +36,26 @@ sealed trait BackendObjType {
     * The `JvmName` that represents the type `Ref(Int)` refers to `"Ref$Int"`.
     */
   val jvmName: JvmName = this match {
-    case BackendObjType.Unit => JvmName(DevFlixRuntime, "Unit")
+    case BackendObjType.Unit => JvmName(DevFlixRuntime, mkClassName("Unit"))
+    case BackendObjType.Lazy(tpe) => JvmName(RootPackage, mkClassName("Lazy", tpe))
+    case BackendObjType.Ref(tpe) => JvmName(RootPackage, mkClassName("Ref", tpe))
+    case BackendObjType.Tuple(elms) => JvmName(RootPackage, mkClassName("Tuple", elms))
+    case BackendObjType.Arrow(args, result) => JvmName(RootPackage, mkClassName(s"Fn${args.length}", args :+ result))
+    case BackendObjType.RecordEmpty => JvmName(RootPackage, mkClassName(s"RecordEmpty"))
+    case BackendObjType.RecordExtend(_, value, _) => JvmName(RootPackage, mkClassName("RecordExtend", value))
+    case BackendObjType.Record => JvmName(RootPackage, mkClassName("Record"))
+    case BackendObjType.Native(className) => className
+    case BackendObjType.ReifiedSourceLocation => JvmName(DevFlixRuntime, mkClassName("ReifiedSourceLocation"))
+    case BackendObjType.Global => JvmName(DevFlixRuntime, mkClassName("Global"))
+    case BackendObjType.Regex => JvmName(List("java", "util", "regex"), mkClassName("Pattern"))
+    case BackendObjType.FlixError => JvmName(DevFlixRuntime, mkClassName("FlixError"))
+    case BackendObjType.HoleError => JvmName(DevFlixRuntime, mkClassName("HoleError"))
+    case BackendObjType.MatchError => JvmName(DevFlixRuntime, mkClassName("MatchError"))
+    case BackendObjType.Region => JvmName(DevFlixRuntime, mkClassName("Region"))
+    case BackendObjType.UncaughtExceptionHandler => JvmName(DevFlixRuntime, mkClassName("UncaughtExceptionHandler"))
+    // Java classes
     case BackendObjType.BigDecimal => JvmName(List("java", "math"), "BigDecimal")
     case BackendObjType.BigInt => JvmName(List("java", "math"), "BigInteger")
-    case BackendObjType.Lazy(tpe) => JvmName(RootPackage, mkName("Lazy", tpe))
-    case BackendObjType.Ref(tpe) => JvmName(RootPackage, mkName("Ref", tpe))
-    case BackendObjType.Tuple(elms) => JvmName(RootPackage, mkName("Tuple", elms))
-    case BackendObjType.Arrow(args, result) => JvmName(RootPackage, mkName(s"Fn${args.length}", args :+ result))
-    case BackendObjType.RecordEmpty => JvmName(RootPackage, mkName(s"RecordEmpty"))
-    case BackendObjType.RecordExtend(_, value, _) => JvmName(RootPackage, mkName("RecordExtend", value))
-    case BackendObjType.Record => JvmName(RootPackage, s"IRecord${Flix.Delimiter}")
-    case BackendObjType.Native(className) => className
-    case BackendObjType.ReifiedSourceLocation => JvmName(DevFlixRuntime, "ReifiedSourceLocation")
-    case BackendObjType.Global => JvmName(DevFlixRuntime, "Global")
-    case BackendObjType.Regex => JvmName(List("java", "util", "regex"), "Pattern")
-    case BackendObjType.FlixError => JvmName(DevFlixRuntime, "FlixError")
-    case BackendObjType.HoleError => JvmName(DevFlixRuntime, "HoleError")
-    case BackendObjType.MatchError => JvmName(DevFlixRuntime, "MatchError")
-    case BackendObjType.Region => JvmName(DevFlixRuntime, "Region")
-    case BackendObjType.UncaughtExceptionHandler => JvmName(DevFlixRuntime, "UncaughtExceptionHandler")
-    // Java classes
     case BackendObjType.JavaObject => JvmName(JavaLang, "Object")
     case BackendObjType.String => JvmName(JavaLang, "String")
     case BackendObjType.Arrays => JvmName(JavaUtil, "Arrays")
@@ -69,21 +69,21 @@ sealed trait BackendObjType {
     case BackendObjType.Thread => JvmName(JavaLang, "Thread")
     case BackendObjType.ThreadBuilderOfVirtual => JvmName(JavaLang, "Thread$Builder$OfVirtual")
     case BackendObjType.ThreadUncaughtExceptionHandler => JvmName(JavaLang, "Thread$UncaughtExceptionHandler")
-    case BackendObjType.Result => JvmName(DevFlixRuntime, "Result")
     // Effects Runtime
-    case BackendObjType.Value => JvmName(DevFlixRuntime, "Value")
-    case BackendObjType.Frame => JvmName(DevFlixRuntime, "Frame")
-    case BackendObjType.Thunk => JvmName(DevFlixRuntime, "Thunk")
-    case BackendObjType.Suspension => JvmName(DevFlixRuntime, "Suspension")
-    case BackendObjType.Frames => JvmName(DevFlixRuntime, "Frames")
-    case BackendObjType.FramesCons => JvmName(DevFlixRuntime, "FramesCons")
-    case BackendObjType.FramesNil => JvmName(DevFlixRuntime, "FramesNil")
-    case BackendObjType.Resumption => JvmName(DevFlixRuntime, "Resumption")
-    case BackendObjType.ResumptionCons => JvmName(DevFlixRuntime, "ResumptionCons")
-    case BackendObjType.ResumptionNil => JvmName(DevFlixRuntime, "ResumptionNil")
-    case BackendObjType.Handler => JvmName(DevFlixRuntime, "Handler")
-    case BackendObjType.EffectCall => JvmName(DevFlixRuntime, "EffectCall")
-    case BackendObjType.ResumptionWrapper => JvmName(DevFlixRuntime, "ResumptionWrapper")
+    case BackendObjType.Result => JvmName(DevFlixRuntime, mkClassName("Result"))
+    case BackendObjType.Value => JvmName(DevFlixRuntime, mkClassName("Value"))
+    case BackendObjType.Frame => JvmName(DevFlixRuntime, mkClassName("Frame"))
+    case BackendObjType.Thunk => JvmName(DevFlixRuntime, mkClassName("Thunk"))
+    case BackendObjType.Suspension => JvmName(DevFlixRuntime, mkClassName("Suspension"))
+    case BackendObjType.Frames => JvmName(DevFlixRuntime, mkClassName("Frames"))
+    case BackendObjType.FramesCons => JvmName(DevFlixRuntime, mkClassName("FramesCons"))
+    case BackendObjType.FramesNil => JvmName(DevFlixRuntime, mkClassName("FramesNil"))
+    case BackendObjType.Resumption => JvmName(DevFlixRuntime, mkClassName("Resumption"))
+    case BackendObjType.ResumptionCons => JvmName(DevFlixRuntime, mkClassName("ResumptionCons"))
+    case BackendObjType.ResumptionNil => JvmName(DevFlixRuntime, mkClassName("ResumptionNil"))
+    case BackendObjType.Handler => JvmName(DevFlixRuntime, mkClassName("Handler"))
+    case BackendObjType.EffectCall => JvmName(DevFlixRuntime, mkClassName("EffectCall"))
+    case BackendObjType.ResumptionWrapper => JvmName(DevFlixRuntime, mkClassName("ResumptionWrapper"))
   }
 
   /**
@@ -112,22 +112,18 @@ sealed trait BackendObjType {
 }
 
 object BackendObjType {
-  /**
-    * Constructs a concatenated string using `JvmName.Delimiter`. The call
-    * `mkName("Tuple2", List(Object, Int, String))` would
-    * result in the string `"Tuple2$Obj$Int32$Obj"`.
-    */
-  private def mkName(prefix: String, args: List[BackendType]): String = {
-    // TODO: Should delimiter always be included?
-    if (args.isEmpty) prefix
-    else s"$prefix${Flix.Delimiter}${args.map(e => e.toErased.toErasedString).mkString(Flix.Delimiter)}"
+
+  private def mkClassName(prefix: String, tpe: BackendType): String = {
+    JvmName.mkClassName(prefix, tpe.toErasedString)
   }
 
-  private def mkName(prefix: String, arg: BackendType): String =
-    mkName(prefix, List(arg))
+  private def mkClassName(prefix: String, tpes: List[BackendType]): String = {
+    JvmName.mkClassName(prefix, tpes.map(_.toErasedString))
+  }
 
-  private def mkName(prefix: String): String =
-    mkName(prefix, Nil)
+  private def mkClassName(prefix: String): String = {
+    JvmName.mkClassName(prefix)
+  }
 
   case object Unit extends BackendObjType with Generatable {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -17,6 +17,7 @@
 
 package ca.uwaterloo.flix.language.phase.jvm
 
+import ca.uwaterloo.flix.api.Flix
 import org.objectweb.asm
 
 import java.nio.file.{Path, Paths}
@@ -71,6 +72,47 @@ object JvmName {
   }
 
   val RootPackage: List[String] = Nil
+
+  /**
+    * Constructs a concatenated string using `JvmName.Delimiter`. The call
+    * `mkClassName("Tuple2", List(Object, Int, String))` would
+    * result in the string `"Tuple2$Obj$Int32$Obj"`.
+    */
+  def mkClassName(prefix: String, args: List[String]): String = {
+    // TODO: Should delimiter always be included?
+    val cPrefix = mangle(prefix)
+    if (args.isEmpty) s"$cPrefix${Flix.Delimiter}"
+    else s"$cPrefix${Flix.Delimiter}${args.map(mangle).mkString(Flix.Delimiter)}"
+  }
+
+  def mkClassName(prefix: String, arg: String): String =
+    mkClassName(prefix, List(arg))
+
+  def mkClassName(prefix: String): String =
+    mkClassName(prefix, Nil)
+
+  /**
+    * Performs name mangling on the given string `s` to avoid issues with special characters.
+    */
+  // TODO: Magnus: Use this in appropriate places.
+  def mangle(s: String): String = s.
+    replace("+", Flix.Delimiter + "plus").
+    replace("-", Flix.Delimiter + "minus").
+    replace("*", Flix.Delimiter + "asterisk").
+    replace("/", Flix.Delimiter + "fslash").
+    replace("\\", Flix.Delimiter + "bslash").
+    replace("<", Flix.Delimiter + "less").
+    replace(">", Flix.Delimiter + "greater").
+    replace("=", Flix.Delimiter + "eq").
+    replace("&", Flix.Delimiter + "ampersand").
+    replace("|", Flix.Delimiter + "bar").
+    replace("^", Flix.Delimiter + "caret").
+    replace("~", Flix.Delimiter + "tilde").
+    replace("!", Flix.Delimiter + "exclamation").
+    replace("#", Flix.Delimiter + "hashtag").
+    replace(":", Flix.Delimiter + "colon").
+    replace("?", Flix.Delimiter + "question").
+    replace("@", Flix.Delimiter + "at")
 
   //
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Java Names ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -20,6 +20,7 @@ package ca.uwaterloo.flix.language.phase.jvm
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.ReducedAst._
 import ca.uwaterloo.flix.language.ast.{MonoType, SourceLocation, Symbol}
+import ca.uwaterloo.flix.language.phase.jvm.JvmName.mangle
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
 import java.nio.file.{Files, LinkOption, Path}
@@ -135,7 +136,7 @@ object JvmOps {
   private def getFunctionInterfaceType(argTypes: List[String], resType: String): JvmType.Reference = {
     val arity = argTypes.length
     val typeStrings = argTypes :+ resType
-    val name = "Fn" + arity + Flix.Delimiter + typeStrings.mkString(Flix.Delimiter)
+    val name = JvmName.mkClassName(s"Fn$arity", typeStrings)
     JvmType.Reference(JvmName(RootPackage, name))
   }
 
@@ -159,7 +160,7 @@ object JvmOps {
       val args = (targs ::: tresult :: Nil).map(tpe => stringify(getErasedJvmType(tpe)))
 
       // The JVM name is of the form FnArity$Arg0$Arg1$Arg2
-      val name = "Clo" + arity + Flix.Delimiter + args.mkString(Flix.Delimiter)
+      val name = JvmName.mkClassName(s"Clo$arity", args)
 
       // The type resides in the root package.
       JvmType.Reference(JvmName(RootPackage, name))
@@ -176,7 +177,7 @@ object JvmOps {
     */
   def getClosureClassType(sym: Symbol.DefnSym)(implicit root: Root, flix: Flix): JvmType.Reference = {
     // The JVM name is of the form Clo$sym.name
-    val name = s"Clo${Flix.Delimiter}${mangle(sym.name)}"
+    val name = JvmName.mkClassName(s"Clo", sym.name)
 
     // The JVM package is the namespace of the symbol.
     val pkg = sym.namespace
@@ -196,7 +197,8 @@ object JvmOps {
     */
   def getEnumInterfaceType(sym: Symbol.EnumSym)(implicit root: Root, flix: Flix): JvmType.Reference = {
       // The enum resides in its namespace package.
-      JvmType.Reference(JvmName(sym.namespace, "I" + sym.name + Flix.Delimiter))
+      val name = JvmName.mkClassName("I", sym.name)
+      JvmType.Reference(JvmName(sym.namespace, name))
   }
 
   /**
@@ -210,7 +212,7 @@ object JvmOps {
     */
   def getTagClassType(sym: Symbol.CaseSym)(implicit root: Root, flix: Flix): JvmType.Reference = {
     // TODO: Magnus: Can we improve the representation w.r.t. unused type variables?
-    val name = sym.enumSym.name + Flix.Delimiter + sym.name
+    val name = JvmName.mkClassName(sym.enumSym.name, sym.name)
     // The tag class resides in its namespace package.
     JvmType.Reference(JvmName(sym.namespace, name))
   }
@@ -237,7 +239,7 @@ object JvmOps {
       val args = elms.map(tpe => stringify(getErasedJvmType(tpe)))
 
       // The JVM name is of the form TupleArity$Arg0$Arg1$Arg2
-      val name = "Tuple" + arity + Flix.Delimiter + args.mkString(Flix.Delimiter)
+      val name = JvmName.mkClassName(s"Tuple$arity", args)
 
       // The type resides in the root package.
       JvmType.Reference(JvmName(RootPackage, name))
@@ -246,23 +248,23 @@ object JvmOps {
   def getLazyClassType(tpe: MonoType.Lazy)(implicit root: Root, flix: Flix): JvmType.Reference = tpe match {
     case MonoType.Lazy(tpe) =>
       val arg = stringify(getErasedJvmType(tpe))
-      val name = "Lazy" + Flix.Delimiter + arg
+      val name = JvmName.mkClassName("Lazy", arg)
       JvmType.Reference(JvmName(RootPackage, name))
   }
 
   /**
-    * Returns the record interface type `IRecord`.
+    * Returns the record interface type `Record`.
     *
     * For example,
     *
-    * {}                    =>  IRecord
-    * {x :: Int}            =>  IRecord
-    * {x :: Str, y :: Int}  =>  IRecord
+    * {}                    =>  Record
+    * {x :: Int}            =>  Record
+    * {x :: Str, y :: Int}  =>  Record
     */
   def getRecordInterfaceType()(implicit root: Root, flix: Flix): JvmType.Reference = {
 
-    // The JVM name is of the form IRecord
-    val name = s"IRecord${Flix.Delimiter}"
+    // The JVM name is of the form Record
+    val name = JvmName.mkClassName("Record")
 
     // The type resides in the root package.
     JvmType.Reference(JvmName(RootPackage, name))
@@ -279,7 +281,7 @@ object JvmOps {
   def getRecordEmptyClassType()(implicit root: Root, flix: Flix): JvmType.Reference = {
 
     // The JVM name is of the form RecordEmpty
-    val name = "RecordEmpty"
+    val name = JvmName.mkClassName("RecordEmpty")
 
     // The type resides in the root package.
     JvmType.Reference(JvmName(RootPackage, name))
@@ -304,7 +306,7 @@ object JvmOps {
       val valueType = stringify(getErasedJvmType(value))
 
       // The JVM name is of the form RecordExtend
-      val name = "RecordExtend" + Flix.Delimiter + valueType
+      val name = JvmName.mkClassName("RecordExtend", valueType)
 
       // The type resides in the root package.
       JvmType.Reference(JvmName(RootPackage, name))
@@ -328,7 +330,7 @@ object JvmOps {
     val valueType = JvmOps.stringify(JvmOps.getErasedJvmType(tpe))
 
     // The JVM name is of the form RecordExtend
-    val name = "RecordExtend" + Flix.Delimiter + valueType
+    val name = JvmName.mkClassName("RecordExtend", valueType)
 
     // The type resides in the root package.
     JvmType.Reference(JvmName(JvmOps.RootPackage, name))
@@ -360,7 +362,7 @@ object JvmOps {
       val arg = stringify(getErasedJvmType(elmType))
 
       // The JVM name is of the form TArity$Arg0$Arg1$Arg2
-      val name = "Ref" + Flix.Delimiter + arg
+      val name = JvmName.mkClassName("Ref", arg)
 
       // The type resides in the ca.uwaterloo.flix.api.cell package.
       JvmType.Reference(JvmName(Nil, name))
@@ -377,7 +379,7 @@ object JvmOps {
     */
   def getFunctionDefinitionClassType(sym: Symbol.DefnSym)(implicit root: Root, flix: Flix): JvmType.Reference = {
     val pkg = sym.namespace
-    val name = "Def" + Flix.Delimiter + mangle(sym.name)
+    val name = JvmName.mkClassName("Def", sym.name)
     JvmType.Reference(JvmName(pkg, name))
   }
 
@@ -391,7 +393,7 @@ object JvmOps {
     */
   def getEffectDefinitionClassType(sym: Symbol.EffectSym)(implicit root: Root, flix: Flix): JvmType.Reference = {
     val pkg = sym.namespace
-    val name = "Eff" + Flix.Delimiter + mangle(sym.name)
+    val name = JvmName.mkClassName("Eff", sym.name)
     JvmType.Reference(JvmName(pkg, name))
   }
 
@@ -414,7 +416,7 @@ object JvmOps {
     */
   def getNamespaceClassType(ns: NamespaceInfo)(implicit root: Root, flix: Flix): JvmType.Reference = {
     val pkg = ns.ns
-    val name = "Ns"
+    val name = JvmName.mkClassName("Ns")
     JvmType.Reference(JvmName(pkg, name))
   }
 
@@ -427,29 +429,6 @@ object JvmOps {
     * length    =>  m_length
     */
   def getDefMethodNameInNamespaceClass(sym: Symbol.DefnSym): String = "m_" + mangle(sym.name)
-
-  /**
-    * Performs name mangling on the given string `s` to avoid issues with special characters.
-    */
-  // TODO: Magnus: Use this in appropriate places.
-  def mangle(s: String): String = s.
-    replace("+", Flix.Delimiter + "plus").
-    replace("-", Flix.Delimiter + "minus").
-    replace("*", Flix.Delimiter + "asterisk").
-    replace("/", Flix.Delimiter + "fslash").
-    replace("\\", Flix.Delimiter + "bslash").
-    replace("<", Flix.Delimiter + "less").
-    replace(">", Flix.Delimiter + "greater").
-    replace("=", Flix.Delimiter + "eq").
-    replace("&", Flix.Delimiter + "ampersand").
-    replace("|", Flix.Delimiter + "bar").
-    replace("^", Flix.Delimiter + "caret").
-    replace("~", Flix.Delimiter + "tilde").
-    replace("!", Flix.Delimiter + "exclamation").
-    replace("#", Flix.Delimiter + "hashtag").
-    replace(":", Flix.Delimiter + "colon").
-    replace("?", Flix.Delimiter + "question").
-    replace("@", Flix.Delimiter + "at")
 
   /**
     * Returns stringified name of the given JvmType `tpe`.


### PR DESCRIPTION
Consistently create generated class names via `JvmName.mkClassName` in order to 1) mangle illegal characters and 2) consistently add at least one `$` to all generated names and 3) keep the logic in one place