### PR TITLE
refactor: disable safe mode in documentation parsing

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -1183,7 +1183,6 @@ object HtmlDocumentor {
     // Panic mode will escape all < and > characters
     val config =
       txtmark.Configuration.builder()
-        .enableSafeMode()
         .enablePanicMode()
         .build()
     val parsed = txtmark.Processor.process(doc.text, config)


### PR DESCRIPTION
Should be redundant when using panic mode