### PR TITLE
refactor: swap out markdown parser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,9 @@ dependencies {
     implementation('org.ow2.asm:asm:9.6')
     implementation('org.parboiled:parboiled_2.13:2.4.1')
     implementation('org.scalactic:scalactic_2.13:3.2.15')
-    implementation('com.github.rjeschke:txtmark:0.13')
     implementation('com.github.scopt:scopt_2.13:4.1.0')
     implementation('com.google.guava:guava:31.1-jre')
+    implementation('org.jetbrains:markdown:0.6.1')
 
     // implementation("io.github.p-org.solvers:pjbdd:1.0.10-10-v5")
     implementation files('lib/pjbdd-v1.0.10-9-67-gf113b5a.jar')


### PR DESCRIPTION
Swapped out the markdown parser in an attempt to fix the escaping problems, which did not work.
Leaving this here if we ever decided to switch for other reasons.