### PR TITLE
feat: move more casts to `Eraser`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -100,7 +100,8 @@ object Eraser {
         case AtomicOp.PutStaticField(field) => aa
         case AtomicOp.Spawn => aa
         case AtomicOp.Lazy => aa
-        case AtomicOp.Force => aa
+        case AtomicOp.Force =>
+          castExp(aa, t, purity, loc)
         case AtomicOp.BoxBool => aa
         case AtomicOp.BoxInt8 => aa
         case AtomicOp.BoxInt16 => aa

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -76,7 +76,8 @@ object Eraser {
           castExp(aa, t, purity, loc)
         case AtomicOp.Tuple => aa
         case AtomicOp.RecordEmpty => aa
-        case AtomicOp.RecordSelect(label) => aa
+        case AtomicOp.RecordSelect(_) =>
+          castExp(aa, t, purity, loc)
         case AtomicOp.RecordExtend(label) => aa
         case AtomicOp.RecordRestrict(label) => aa
         case AtomicOp.ArrayLit => aa

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -72,7 +72,8 @@ object Eraser {
         case AtomicOp.Tag(_) => aa
         case AtomicOp.Untag(_) =>
           castExp(aa, t, purity, loc)
-        case AtomicOp.Index(idx) => aa
+        case AtomicOp.Index(_) =>
+          castExp(aa, t, purity, loc)
         case AtomicOp.Tuple => aa
         case AtomicOp.RecordEmpty => aa
         case AtomicOp.RecordSelect(label) => aa

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -13,8 +13,11 @@ import ca.uwaterloo.flix.util.ParOps
   * This means that expressions should cast their output but assume correct
   * input types.
   *
-  * - Enum tag values are erased (cast in untag)
-  * - Ref values are erased (cast in deref)
+  * - Enum tag unpacking
+  * - Ref unpacking
+  * - tuple unpacking
+  * - record unpacking
+  * - lazy unpacking
   */
 object Eraser {
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -1069,8 +1069,6 @@ object GenExpression {
         mv.visitFieldInsn(GETFIELD, internalClassType, "value", erasedType.toDescriptor)
 
         mv.visitLabel(end)
-        // The result of force is a generic object so a cast is needed.
-        AsmOps.castIfNotPrim(mv, JvmOps.getJvmType(tpe))
 
       case AtomicOp.BoxBool =>
         val List(exp) = exps

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -651,9 +651,6 @@ object GenExpression {
         // Retrieve the value field  (To get the proper value)
         mv.visitFieldInsn(GETFIELD, classType.name.toInternalName, backendRecordExtendType.ValueField.name, JvmOps.getErasedJvmType(tpe).toDescriptor)
 
-        // Cast the field value to the expected type.
-        AsmOps.castIfNotPrim(mv, JvmOps.getJvmType(tpe))
-
       case AtomicOp.RecordExtend(field) =>
         val List(exp1, exp2) = exps
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -1217,7 +1217,6 @@ object GenExpression {
           // Calling unwind and unboxing
           val erasedResult = BackendType.toErasedBackendType(closureResultType)
           BackendObjType.Result.unwindThunkToType(0 /* TODO */, ctx.newFrame, erasedResult)(new BytecodeInstructions.F(mv))
-          AsmOps.castIfNotPrim(mv, JvmOps.getJvmType(tpe))
       }
 
     case Expr.ApplyDef(sym, exps, ct, tpe, _, loc) => ct match {
@@ -1257,7 +1256,6 @@ object GenExpression {
         }
         // Calling unwind and unboxing
         BackendObjType.Result.unwindThunkToType(0 /* TODO */, ctx.newFrame, BackendType.toErasedBackendType(tpe))(new BytecodeInstructions.F(mv))
-        AsmOps.castIfNotPrim(mv, JvmOps.getJvmType(tpe))
     }
 
     case Expr.ApplySelfTail(sym, formals, exps, tpe, _, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -599,8 +599,6 @@ object GenExpression {
         compileExpr(exp)
         // Retrieving the field `field${offset}`
         mv.visitFieldInsn(GETFIELD, classType.name.toInternalName, s"field$idx", JvmOps.getErasedJvmType(tpe).toDescriptor)
-        // Cast the object to it's type if it's not a primitive
-        AsmOps.castIfNotPrim(mv, JvmOps.getJvmType(tpe))
 
       case AtomicOp.Tuple =>
         // We get the JvmType of the class for the tuple


### PR DESCRIPTION
- tuple unpacking
- Record unpacking
- lazy unpacking
- function call