### PR TITLE
refactor: remove schemas in backend

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
@@ -76,10 +76,6 @@ object MonoType {
 
   case class RecordExtend(label: String, value: MonoType, rest: MonoType) extends MonoType
 
-  case object SchemaEmpty extends MonoType
-
-  case class SchemaExtend(name: String, tpe: MonoType, rest: MonoType) extends MonoType
-
   case class Native(clazz: Class[_]) extends MonoType
 
   val Object: MonoType = Native(classOf[java.lang.Object])

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypePrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypePrinter.scala
@@ -47,8 +47,6 @@ object MonoTypePrinter {
     case MonoType.Arrow(args, result) => Type.Arrow(args.map(print), print(result))
     case MonoType.RecordEmpty => Type.RecordEmpty
     case MonoType.RecordExtend(label, value, rest) => Type.RecordExtend(label, print(value), print(rest))
-    case MonoType.SchemaEmpty => Type.SchemaEmpty
-    case MonoType.SchemaExtend(name, tpe, rest) => Type.SchemaExtend(name, print(tpe), print(rest))
     case MonoType.Native(clazz) => Type.Native(clazz)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -318,14 +318,13 @@ object Reducer {
         val taskList1 = tpe match {
           case Unit | Bool | Char | Float32 | Float64 | BigDecimal | Int8 | Int16 |
                Int32 | Int64 | BigInt | String | Regex | Region | Enum(_) |
-               RecordEmpty | SchemaEmpty | Native(_) => taskList
+               RecordEmpty | Native(_) => taskList
           case Array(elm) => taskList.enqueue(elm)
           case Lazy(elm) => taskList.enqueue(elm)
           case Ref(elm) => taskList.enqueue(elm)
           case Tuple(elms) => taskList.enqueueAll(elms)
           case Arrow(targs, tresult) => taskList.enqueueAll(targs).enqueue(tresult)
           case RecordExtend(_, value, rest) => taskList.enqueue(value).enqueue(rest)
-          case SchemaExtend(_, t, rest) => taskList.enqueue(t).enqueue(rest)
         }
         nestedTypesOf(acc + tpe, taskList1)
       case None => acc

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -174,8 +174,7 @@ object BackendType {
     case MonoType.Unit | MonoType.BigDecimal | MonoType.BigInt | MonoType.String | MonoType.Regex |
          MonoType.Array(_) | MonoType.Lazy(_) | MonoType.Ref(_) | MonoType.Tuple(_) |
          MonoType.Enum(_) | MonoType.Arrow(_, _) | MonoType.RecordEmpty | MonoType.RecordExtend(_, _, _) |
-         MonoType.SchemaEmpty | MonoType.SchemaExtend(_, _, _) | MonoType.Native(_) |
-         MonoType.Region => BackendObjType.JavaObject.toTpe
+         MonoType.Native(_) | MonoType.Region => BackendObjType.JavaObject.toTpe
   }
 
   /**
@@ -203,10 +202,10 @@ object BackendType {
       // TODO: Ugly hack.
       val fqn = clazz.getName.replace('.', '/')
       JvmName.mk(fqn).toTpe
-    case MonoType.Unit | MonoType.Lazy(_) | MonoType.Ref(_) |
-         MonoType.Tuple(_) | MonoType.Arrow(_, _) | MonoType.RecordEmpty |
-         MonoType.RecordExtend(_, _, _) | MonoType.Region | MonoType.Enum(_) |
-         MonoType.SchemaEmpty | MonoType.SchemaExtend(_, _, _) => BackendObjType.JavaObject.toTpe
+    case MonoType.Unit | MonoType.Lazy(_) | MonoType.Ref(_) | MonoType.Tuple(_) |
+         MonoType.Arrow(_, _) | MonoType.RecordEmpty |
+         MonoType.RecordExtend(_, _, _) | MonoType.Region | MonoType.Enum(_) =>
+      BackendObjType.JavaObject.toTpe
   }
 
   sealed trait PrimitiveType extends BackendType {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -97,8 +97,7 @@ object JvmOps {
       case Int64 => JvmType.PrimLong
       case Unit | BigDecimal | BigInt | String | Regex | Region | Array(_) |
            Lazy(_) | Ref(_) | Tuple(_) | Enum(_) | Arrow(_, _) | RecordEmpty |
-           RecordExtend(_, _, _) | SchemaEmpty | SchemaExtend(_, _, _) |
-           Native(_) => JvmType.Object
+           RecordExtend(_, _, _) | Native(_) => JvmType.Object
     }
   }
 


### PR DESCRIPTION
Fixes #6963.

Not removed from DocAst since it will be used by the frontend at some point