### PR TITLE
refactor: clean up jvm code

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/AsmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/AsmOps.scala
@@ -17,14 +17,11 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.ReducedAst.Root
 import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
 import ca.uwaterloo.flix.util.{InternalCompilerException, JvmTarget}
 import org.objectweb.asm.Opcodes._
 import org.objectweb.asm.{ClassWriter, MethodVisitor}
-
-import scala.annotation.tailrec
 
 object AsmOps {
 
@@ -260,7 +257,7 @@ object AsmOps {
     * return this.value;
     * }
     */
-  def compileGetBoxedTagValueMethod(visitor: ClassWriter, classType: JvmType.Reference, valueType: JvmType)(implicit root: Root, flix: Flix): Unit = {
+  def compileGetBoxedTagValueMethod(visitor: ClassWriter, classType: JvmType.Reference, valueType: JvmType): Unit = {
     val method = visitor.visitMethod(ACC_PUBLIC + ACC_FINAL, "getBoxedTagValue", AsmOps.getMethodDescriptor(Nil, JvmType.Object), null, null)
 
     method.visitCode()
@@ -270,33 +267,6 @@ object AsmOps {
     method.visitInsn(ARETURN)
     method.visitMaxs(1, 1)
     method.visitEnd()
-  }
-
-  /**
-    * Generates code to throw a MatchError.
-    */
-  def compileThrowFlixError(mv: MethodVisitor, className: JvmName, loc: SourceLocation): Unit = {
-    compileReifiedSourceLocation(mv, loc)
-    mv.visitTypeInsn(NEW, className.toInternalName)
-    mv.visitInsn(DUP2)
-    mv.visitInsn(SWAP)
-    mv.visitMethodInsn(INVOKESPECIAL, className.toInternalName, "<init>", s"(${BackendObjType.ReifiedSourceLocation.toDescriptor})${JvmType.Void.toDescriptor}", false)
-    mv.visitInsn(ATHROW)
-  }
-
-  /**
-    * Generates code to throw a MatchError.
-    */
-  def compileThrowHoleError(mv: MethodVisitor, hole: String, loc: SourceLocation): Unit = {
-    compileReifiedSourceLocation(mv, loc)
-    val className = BackendObjType.HoleError.jvmName
-    mv.visitTypeInsn(NEW, className.toInternalName)
-    mv.visitInsn(DUP2)
-    mv.visitInsn(SWAP)
-    mv.visitLdcInsn(hole)
-    mv.visitInsn(SWAP)
-    mv.visitMethodInsn(INVOKESPECIAL, className.toInternalName, "<init>", s"(${BackendObjType.String.toDescriptor}${BackendObjType.ReifiedSourceLocation.toDescriptor})${JvmType.Void.toDescriptor}", false)
-    mv.visitInsn(ATHROW)
   }
 
   /**
@@ -344,7 +314,7 @@ object AsmOps {
   /**
     * Emits code that puts the function object of the def symbol `def` on top of the stack.
     */
-  def compileDefSymbol(sym: Symbol.DefnSym, mv: MethodVisitor)(implicit root: Root, flix: Flix): Unit = {
+  def compileDefSymbol(sym: Symbol.DefnSym, mv: MethodVisitor): Unit = {
     // JvmType of Def
     val defJvmType = JvmOps.getFunctionDefinitionClassType(sym)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeLoader.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BytecodeLoader.scala
@@ -17,7 +17,6 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.ReducedAst.Root
 
 /**
   * Loads generated JVM bytecode classes using a custom class loader.
@@ -27,7 +26,7 @@ object BytecodeLoader {
   /**
     * Loads the given JVM `classes` using a custom class loader.
     */
-  def loadAll(classes: Map[JvmName, JvmClass])(implicit flix: Flix, root: Root): Map[JvmName, Class[_]] = flix.subphase("LoadClasses") {
+  def loadAll(classes: Map[JvmName, JvmClass])(implicit flix: Flix): Map[JvmName, Class[_]] = flix.subphase("LoadClasses") {
     //
     // Compute a map from binary names (strings) to JvmClasses.
     //

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/ClassMaker.scala
@@ -33,7 +33,7 @@ import org.objectweb.asm.{ClassWriter, Opcodes}
 
 // TODO: There are further things you can constrain and assert, e.g. final classes have implicitly final methods.
 sealed trait ClassMaker {
-  def mkStaticConstructor(c: StaticConstructorMethod)(implicit flix: Flix): Unit = {
+  def mkStaticConstructor(c: StaticConstructorMethod): Unit = {
     makeMethod(Some(extractIns(c.ins)), c.name, c.d, c.v, c.f, IsStatic, NotAbstract)
   }
 
@@ -48,18 +48,18 @@ sealed trait ClassMaker {
 
   protected val visitor: ClassWriter
 
-  protected def makeField(fieldName: String, fieldType: BackendType, v: Visibility, f: Final, vol: Volatility, s: Static)(implicit flix: Flix): Unit = {
+  protected def makeField(fieldName: String, fieldType: BackendType, v: Visibility, f: Final, vol: Volatility, s: Static): Unit = {
     val m = v.toInt + f.toInt + s.toInt + vol.toInt
     val field = visitor.visitField(m, fieldName, fieldType.toDescriptor, null, null)
     field.visitEnd()
   }
 
-  def mkField(f: Field)(implicit flix: Flix): Unit = f match {
+  def mkField(f: Field): Unit = f match {
     case InstanceField(_, v, f, vol, name, tpe) => makeField(name, tpe, v, f, vol, NotStatic)
     case StaticField(_, v, f, vol, name, tpe) => makeField(name, tpe, v, f, vol, IsStatic)
   }
 
-  protected def makeMethod(i: Option[InstructionSet], methodName: String, d: MethodDescriptor, v: Visibility, f: Final, s: Static, a: Abstract)(implicit flix: Flix): Unit = {
+  protected def makeMethod(i: Option[InstructionSet], methodName: String, d: MethodDescriptor, v: Visibility, f: Final, s: Static, a: Abstract): Unit = {
     val m = v.toInt + f.toInt + s.toInt + a.toInt
     val mv = visitor.visitMethod(m, methodName, d.toDescriptor, null, null)
     i match {
@@ -72,7 +72,7 @@ sealed trait ClassMaker {
     mv.visitEnd()
   }
 
-  protected def makeAbstractMethod(methodName: String, d: MethodDescriptor)(implicit flix: Flix): Unit = {
+  protected def makeAbstractMethod(methodName: String, d: MethodDescriptor): Unit = {
     makeMethod(None, methodName, d, IsPublic, NotFinal, NotStatic, IsAbstract)
   }
 }
@@ -87,19 +87,19 @@ object ClassMaker {
   class InstanceClassMaker(cw: ClassWriter) extends ClassMaker {
     protected val visitor: ClassWriter = cw
 
-    def mkConstructor(ins: InstructionSet, d: MethodDescriptor, v: Visibility)(implicit flix: Flix): Unit = {
+    def mkConstructor(ins: InstructionSet, d: MethodDescriptor, v: Visibility): Unit = {
       makeMethod(Some(ins), JvmName.ConstructorMethod, d, v, NotFinal, NotStatic, NotAbstract)
     }
 
-    def mkStaticMethod(m: StaticMethod)(implicit flix: Flix): Unit = {
+    def mkStaticMethod(m: StaticMethod): Unit = {
       makeMethod(Some(extractIns(m.ins)), m.name, m.d, m.v, m.f, IsStatic, NotAbstract)
     }
 
-    def mkConstructor(c: ConstructorMethod)(implicit flix: Flix): Unit = {
+    def mkConstructor(c: ConstructorMethod): Unit = {
       makeMethod(Some(extractIns(c.ins)), JvmName.ConstructorMethod, c.d, c.v, c.f, NotStatic, NotAbstract)
     }
 
-    def mkMethod(m: InstanceMethod)(implicit flix: Flix): Unit = {
+    def mkMethod(m: InstanceMethod): Unit = {
       makeMethod(Some(extractIns(m.ins)), m.name, m.d, m.v, m.f, NotStatic, NotAbstract)
     }
   }
@@ -107,19 +107,19 @@ object ClassMaker {
   class AbstractClassMaker(cw: ClassWriter) extends ClassMaker {
     protected val visitor: ClassWriter = cw
 
-    def mkConstructor(c: ConstructorMethod)(implicit flix: Flix): Unit = {
+    def mkConstructor(c: ConstructorMethod): Unit = {
       makeMethod(Some(extractIns(c.ins)), c.name, c.d, c.v, c.f, NotStatic, NotAbstract)
     }
 
-    def mkStaticMethod(m: StaticMethod)(implicit flix: Flix): Unit = {
+    def mkStaticMethod(m: StaticMethod): Unit = {
       makeMethod(Some(extractIns(m.ins)), m.name, m.d, m.v, m.f, IsStatic, NotAbstract)
     }
 
-    def mkMethod(m: InstanceMethod)(implicit flix: Flix): Unit = {
+    def mkMethod(m: InstanceMethod): Unit = {
       makeMethod(Some(extractIns(m.ins)), m.name, m.d, m.v, m.f, NotStatic, NotAbstract)
     }
 
-    def mkAbstractMethod(m: AbstractMethod)(implicit flix: Flix): Unit = {
+    def mkAbstractMethod(m: AbstractMethod): Unit = {
       makeAbstractMethod(m.name, m.d)
     }
   }
@@ -127,15 +127,15 @@ object ClassMaker {
   class InterfaceMaker(cw: ClassWriter) extends ClassMaker {
     protected val visitor: ClassWriter = cw
 
-    def mkInterfaceMethod(m: InterfaceMethod)(implicit flix: Flix): Unit = {
+    def mkInterfaceMethod(m: InterfaceMethod): Unit = {
       makeAbstractMethod(m.name, m.d)
     }
 
-    def mkStaticInterfaceMethod(m: StaticInterfaceMethod)(implicit flix: Flix): Unit = {
+    def mkStaticInterfaceMethod(m: StaticInterfaceMethod): Unit = {
       makeMethod(Some(extractIns(m.ins)), m.name, m.d, m.v, m.f, IsStatic, NotAbstract)
     }
 
-    def mkDefaultMethod(m: DefaultMethod)(implicit flix: Flix): Unit = {
+    def mkDefaultMethod(m: DefaultMethod): Unit = {
       makeMethod(Some(extractIns(m.ins)), m.name, m.d, m.v, m.f, NotStatic, NotAbstract)
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/FlixClassLoader.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/FlixClassLoader.scala
@@ -28,7 +28,7 @@ import scala.collection.mutable
   * We pass the platform class loader as the parent to avoid it delegating to the system classloader
   * (otherwise compiled Flix code has access to all classes within the compiler)
   */
-class FlixClassLoader(classes: Map[String, JvmClass])(implicit flix: Flix) extends ClassLoader(ClassLoader.getPlatformClassLoader()) {
+class FlixClassLoader(classes: Map[String, JvmClass])(implicit flix: Flix) extends ClassLoader(ClassLoader.getPlatformClassLoader) {
 
   /**
     * An internal cache of already loaded classes.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenClosureAbstractClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenClosureAbstractClasses.scala
@@ -17,7 +17,6 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.ReducedAst.Root
 import ca.uwaterloo.flix.language.ast.MonoType
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
 import org.objectweb.asm.ClassWriter
@@ -31,7 +30,7 @@ object GenClosureAbstractClasses {
   /**
     * Returns the set of function abstract classes for the given set of types `ts`.
     */
-  def gen(ts: Set[MonoType])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
+  def gen(ts: Set[MonoType])(implicit flix: Flix): Map[JvmName, JvmClass] = {
     ts.foldLeft(Map.empty[JvmName, JvmClass]) {
       case (macc, tpe: MonoType.Arrow) =>
         // Case 1: The type constructor is an arrow type.
@@ -45,7 +44,7 @@ object GenClosureAbstractClasses {
     }
   }
 
-  private def genClosureAbstractClass(tpe: MonoType.Arrow)(implicit root: Root, flix: Flix): JvmClass = {
+  private def genClosureAbstractClass(tpe: MonoType.Arrow)(implicit flix: Flix): JvmClass = {
     // (Int, String) -> Bool example:
     // public abstract class Clo2$Int$Obj$Bool extends Fn2$Int$Obj$Bool {
     //   public Clo2$Int$Obj$Bool() { ... }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
@@ -1,7 +1,7 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.ReducedAst.{Effect, Op, Root}
+import ca.uwaterloo.flix.language.ast.ReducedAst.{Effect, Op}
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor
 import ca.uwaterloo.flix.util.ParOps
 import org.objectweb.asm.ClassWriter
@@ -45,7 +45,7 @@ import org.objectweb.asm.Opcodes._
 /// ```
 object GenEffectClasses {
 
-  def gen(effects: Iterable[Effect])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
+  def gen(effects: Iterable[Effect])(implicit flix: Flix): Map[JvmName, JvmClass] = {
     ParOps.parAgg(effects, Map.empty[JvmName, JvmClass])({
       case (macc, effect) =>
         val classType = JvmOps.getEffectDefinitionClassType(effect.sym)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEnumInterfaces.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEnumInterfaces.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.ReducedAst.{Enum, Root}
+import ca.uwaterloo.flix.language.ast.ReducedAst.Enum
 import org.objectweb.asm.Opcodes._
 
 /**
@@ -28,7 +28,7 @@ object GenEnumInterfaces {
   /**
     * Returns the set of enum interfaces for the given enums.
     */
-  def gen(enums: Iterable[Enum])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
+  def gen(enums: Iterable[Enum])(implicit flix: Flix): Map[JvmName, JvmClass] = {
     enums.foldLeft(Map.empty[JvmName, JvmClass]) {
       case (macc, e) =>
         // Construct enum interface.
@@ -42,7 +42,7 @@ object GenEnumInterfaces {
   /**
     * Generates an interface for the given type.
     */
-  private def genByteCode(interfaceType: JvmType.Reference)(implicit root: Root, flix: Flix): Array[Byte] = {
+  private def genByteCode(interfaceType: JvmType.Reference)(implicit flix: Flix): Array[Byte] = {
     // Create a new class writer.
     val visitor = AsmOps.mkClassWriter()
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -873,7 +873,7 @@ object GenExpression {
         val List(exp) = exps
         val className = asm.Type.getInternalName(clazz)
         compileExpr(exp)
-        mv.visitTypeInsn(INSTANCEOF, className.toString)
+        mv.visitTypeInsn(INSTANCEOF, className)
 
       case AtomicOp.Cast =>
         val List(exp) = exps
@@ -992,7 +992,7 @@ object GenExpression {
 
         exp2 match {
           // The expression represents the `Static` region, just start a thread directly
-          case Expr.ApplyAtomic(AtomicOp.Region, _, tpe, _, loc) =>
+          case Expr.ApplyAtomic(AtomicOp.Region, _, _, _, _) =>
 
             // Compile the expression, putting a function implementing the Runnable interface on the stack
             compileExpr(exp1)
@@ -1072,15 +1072,29 @@ object GenExpression {
       case AtomicOp.HoleError(sym) =>
         // Add source line number for debugging (failable by design)
         addSourceLine(mv, loc)
-        AsmOps.compileThrowHoleError(mv, sym.toString, loc)
+        AsmOps.compileReifiedSourceLocation(mv, loc)
+        val className = BackendObjType.HoleError.jvmName
+        mv.visitTypeInsn(NEW, className.toInternalName)
+        mv.visitInsn(DUP2)
+        mv.visitInsn(SWAP)
+        mv.visitLdcInsn(sym.toString)
+        mv.visitInsn(SWAP)
+        mv.visitMethodInsn(INVOKESPECIAL, className.toInternalName, "<init>", s"(${BackendObjType.String.toDescriptor}${BackendObjType.ReifiedSourceLocation.toDescriptor})${JvmType.Void.toDescriptor}", false)
+        mv.visitInsn(ATHROW)
 
       case AtomicOp.MatchError =>
         // Add source line number for debugging (failable by design)
         addSourceLine(mv, loc)
-        AsmOps.compileThrowFlixError(mv, BackendObjType.MatchError.jvmName, loc)
+        val className = BackendObjType.MatchError.jvmName
+        AsmOps.compileReifiedSourceLocation(mv, loc)
+        mv.visitTypeInsn(NEW, className.toInternalName)
+        mv.visitInsn(DUP2)
+        mv.visitInsn(SWAP)
+        mv.visitMethodInsn(INVOKESPECIAL, className.toInternalName, "<init>", s"(${BackendObjType.ReifiedSourceLocation.toDescriptor})${JvmType.Void.toDescriptor}", false)
+        mv.visitInsn(ATHROW)
     }
 
-    case Expr.ApplyClo(exp, exps, ct, tpe, _, loc) =>
+    case Expr.ApplyClo(exp, exps, ct, _, _, _) =>
       ct match {
         case CallType.TailCall =>
           // Type of the function abstract class
@@ -1130,7 +1144,7 @@ object GenExpression {
           BackendObjType.Result.unwindThunkToType(0 /* TODO */, ctx.newFrame, erasedResult)(new BytecodeInstructions.F(mv))
       }
 
-    case Expr.ApplyDef(sym, exps, ct, tpe, _, loc) => ct match {
+    case Expr.ApplyDef(sym, exps, ct, tpe, _, _) => ct match {
       case CallType.TailCall =>
         // Type of the function abstract class
         val functionInterface = JvmOps.getFunctionInterfaceType(root.defs(sym).arrowType)
@@ -1169,7 +1183,7 @@ object GenExpression {
         BackendObjType.Result.unwindThunkToType(0 /* TODO */, ctx.newFrame, BackendType.toErasedBackendType(tpe))(new BytecodeInstructions.F(mv))
     }
 
-    case Expr.ApplySelfTail(sym, formals, exps, tpe, _, loc) =>
+    case Expr.ApplySelfTail(sym, _, exps, _, _, _) =>
       // The function abstract class name
       val functionInterface = JvmOps.getFunctionInterfaceType(root.defs(sym).arrowType)
       // Evaluate each argument and put the result on the Fn class.
@@ -1183,7 +1197,7 @@ object GenExpression {
       // Jump to the entry point of the method.
       mv.visitJumpInsn(GOTO, ctx.entryPoint)
 
-    case Expr.IfThenElse(exp1, exp2, exp3, _, _, loc) =>
+    case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) =>
       val ifElse = new Label()
       val ifEnd = new Label()
       compileExpr(exp1)
@@ -1194,7 +1208,7 @@ object GenExpression {
       compileExpr(exp3)
       mv.visitLabel(ifEnd)
 
-    case Expr.Branch(exp, branches, _, _, loc) =>
+    case Expr.Branch(exp, branches, _, _, _) =>
       // Calculating the updated jumpLabels map
       val updatedJumpLabels = branches.foldLeft(ctx.lenv)((map, branch) => map + (branch._1 -> new Label()))
       val ctx1 = ctx.copy(lenv = updatedJumpLabels)
@@ -1216,11 +1230,11 @@ object GenExpression {
       // label for the end of branches
       mv.visitLabel(endLabel)
 
-    case Expr.JumpTo(sym, _, _, loc) =>
+    case Expr.JumpTo(sym, _, _, _) =>
       // Jumping to the label
       mv.visitJumpInsn(GOTO, ctx.lenv(sym))
 
-    case Expr.Let(sym, exp1, exp2, _, _, loc) =>
+    case Expr.Let(sym, exp1, exp2, _, _, _) =>
       compileExpr(exp1)
       // Jvm Type of the `exp1`
       val jvmType = JvmOps.getJvmType(exp1.tpe)
@@ -1230,7 +1244,7 @@ object GenExpression {
       mv.visitVarInsn(iStore, sym.getStackOffset(ctx.localOffset))
       compileExpr(exp2)
 
-    case Expr.LetRec(varSym, index, defSym, exp1, exp2, _, _, loc) =>
+    case Expr.LetRec(varSym, index, defSym, exp1, exp2, _, _, _) =>
       // Jvm Type of the `exp1`
       val jvmType = JvmOps.getJvmType(exp1.tpe)
       // Store instruction for `jvmType`
@@ -1353,17 +1367,17 @@ object GenExpression {
       // Add the label after both the try and catch rules.
       mv.visitLabel(afterTryAndCatch)
 
-    case Expr.TryWith(exp, effUse, rules, tpe, purity, loc) =>
+    case Expr.TryWith(exp, _, _, _, _, _) =>
       // TODO (temp unhandled code)
       compileExpr(exp)
 
 
-    case Expr.Do(op, exps, tpe, purity, loc) =>
+    case Expr.Do(_, _, _, _, _) =>
       // TODO (temp unit value)
       mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
 
 
-    case Expr.NewObject(name, _, tpe, _, _, exps, loc) =>
+    case Expr.NewObject(name, _, _, _, _, exps, _) =>
       val className = JvmName(ca.uwaterloo.flix.language.phase.jvm.JvmName.RootPackage, name).toInternalName
       mv.visitTypeInsn(NEW, className)
       mv.visitInsn(DUP)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -229,7 +229,7 @@ object GenFunAndClosureClasses {
     m.visitEnd()
   }
 
-  private def loadFromField(m: MethodVisitor, classType: JvmType.Reference, name: String, localIndex: Int, tpe: MonoType)(implicit root: Root, flix: Flix): Unit = {
+  private def loadFromField(m: MethodVisitor, classType: JvmType.Reference, name: String, localIndex: Int, tpe: MonoType): Unit = {
     // retrieve the erased field
     val erasedVarType = JvmOps.getErasedJvmType(tpe)
     m.visitVarInsn(ALOAD, 0)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenMainClass.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenMainClass.scala
@@ -17,8 +17,8 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.ReducedAst.{Def, Root, FormalParam}
-import ca.uwaterloo.flix.language.ast.{MonoType, ReducedAst, Symbol}
+import ca.uwaterloo.flix.language.ast.ReducedAst.{Def, FormalParam, Root}
+import ca.uwaterloo.flix.language.ast.{MonoType, Symbol}
 import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes._
@@ -49,7 +49,7 @@ object GenMainClass {
     */
   private def checkMainType(defn: Def): Unit = (defn.cparams, defn.fparams, defn.tpe) match {
     case (Nil, List(FormalParam(_, _, MonoType.Unit, _)), MonoType.Unit) => ()
-    case (cs @ _ :: _, _, _) =>
+    case (cs@_ :: _, _, _) =>
       val tupleType = MonoType.Tuple(cs.map(_.tpe))
       throw InternalCompilerException(s"Entrypoint function has unexpected captured parameters '$tupleType'", defn.loc)
     case (Nil, _, _) =>
@@ -66,7 +66,7 @@ object GenMainClass {
     }
   }
 
-  private def genByteCode(sym: Symbol.DefnSym, jvmType: JvmType.Reference)(implicit root: Root, flix: Flix): Array[Byte] = {
+  private def genByteCode(sym: Symbol.DefnSym, jvmType: JvmType.Reference)(implicit flix: Flix): Array[Byte] = {
     // class writer
     val visitor = AsmOps.mkClassWriter()
 
@@ -105,7 +105,7 @@ object GenMainClass {
     *
     * `}`
     */
-  private def compileMainMethod(sym: Symbol.DefnSym, visitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = {
+  private def compileMainMethod(sym: Symbol.DefnSym, visitor: ClassWriter): Unit = {
     // The required java main signature `Array[String] -> Void`.
     val javaMainDescriptor = s"(${AsmOps.getArrayType(JvmType.String)})${JvmType.Void.toDescriptor}"
     // `public static void main(String[] args)`.

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenNamespaceClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenNamespaceClasses.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.ReducedAst.{Def, Root}
+import ca.uwaterloo.flix.language.ast.ReducedAst.Def
 import ca.uwaterloo.flix.util.ParOps
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes._
@@ -30,7 +30,7 @@ object GenNamespaceClasses {
   /**
     * Returns the set of namespaces classes for the given set of namespaces.
     */
-  def gen(namespaces: Set[NamespaceInfo])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
+  def gen(namespaces: Set[NamespaceInfo])(implicit flix: Flix): Map[JvmName, JvmClass] = {
     //
     // Generate a namespace class for each namespace and collect the results in a map.
     //
@@ -46,7 +46,7 @@ object GenNamespaceClasses {
   /**
     * Returns the namespace class for the given namespace `ns`.
     */
-  private def genBytecode(ns: NamespaceInfo)(implicit root: Root, flix: Flix): Array[Byte] = {
+  private def genBytecode(ns: NamespaceInfo)(implicit flix: Flix): Array[Byte] = {
     // JvmType for namespace
     val namespaceClassType = JvmOps.getNamespaceClassType(ns)
 
@@ -73,7 +73,7 @@ object GenNamespaceClasses {
   /**
     * Adding a shim for the function `defn` on namespace `ns`
     */
-  private def compileShimMethod(visitor: ClassWriter, defn: Def)(implicit root: Root, flix: Flix): Unit = {
+  private def compileShimMethod(visitor: ClassWriter, defn: Def): Unit = {
     // TODO: This can probably be removed (used in GenMain and other places)
     // Name of the shim
     val name = JvmOps.getDefMethodNameInNamespaceClass(defn.sym)
@@ -121,7 +121,7 @@ object GenNamespaceClasses {
   /**
     * Add the constructor for the class which initializes each field
     */
-  private def compileNamespaceConstructor(visitor: ClassWriter)(implicit root: Root, flix: Flix): Unit = {
+  private def compileNamespaceConstructor(visitor: ClassWriter): Unit = {
     // Method header
     val constructor = visitor.visitMethod(ACC_PUBLIC, "<init>", AsmOps.getMethodDescriptor(Nil, JvmType.Void), null, null)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenTagClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenTagClasses.scala
@@ -17,8 +17,8 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.ReducedAst.{Case, Root}
-import ca.uwaterloo.flix.language.ast.{MonoType, ReducedAst}
+import ca.uwaterloo.flix.language.ast.MonoType
+import ca.uwaterloo.flix.language.ast.ReducedAst.Case
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes._
 
@@ -30,7 +30,7 @@ object GenTagClasses {
   /**
     * Returns the set of tuple interfaces for the given cases (also called tags).
     */
-  def gen(tags: Iterable[Case])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
+  def gen(tags: Iterable[Case])(implicit flix: Flix): Map[JvmName, JvmClass] = {
     tags.foldLeft(Map.empty[JvmName, JvmClass]) {
       case (macc, tag) =>
         val jvmType = JvmOps.getTagClassType(tag.sym)
@@ -91,7 +91,7 @@ object GenTagClasses {
     * throw new Exception("equals method shouldn't be called");
     * }
     */
-  private def genByteCode(tag: Case)(implicit root: Root, flix: Flix): Array[Byte] = {
+  private def genByteCode(tag: Case)(implicit flix: Flix): Array[Byte] = {
     // The JvmType of the interface for enum of `tag`.
     val superType = JvmOps.getEnumInterfaceType(tag.sym.enumSym)
 
@@ -165,7 +165,7 @@ object GenTagClasses {
     * @param valueType   type of the `value` field
     * @param isSingleton if the class is a singleton this flag is set
     */
-  private def compileEnumConstructor(visitor: ClassWriter, classType: JvmType.Reference, valueType: JvmType, isSingleton: Boolean)(implicit root: Root, flix: Flix): Unit = {
+  private def compileEnumConstructor(visitor: ClassWriter, classType: JvmType.Reference, valueType: JvmType, isSingleton: Boolean): Unit = {
     // If this is a singleton then we should make the constructor private
     val specifier =
       ACC_PUBLIC
@@ -194,7 +194,7 @@ object GenTagClasses {
     constructor.visitEnd()
   }
 
-  def compileToStringMethod(visitor: ClassWriter, classType: JvmType.Reference, tag: Case)(implicit root: Root, flix: Flix): Unit = {
+  def compileToStringMethod(visitor: ClassWriter, classType: JvmType.Reference, tag: Case): Unit = {
     val method = visitor.visitMethod(ACC_PUBLIC + ACC_FINAL, "toString", AsmOps.getMethodDescriptor(Nil, JvmType.String), null, null)
     tag.tpe match {
       case MonoType.Unit => // "$Tag"
@@ -238,7 +238,7 @@ object GenTagClasses {
     * @param visitor   class visitor
     * @param classType JvmType.Reference of the class
     */
-  private def compileUnitInstance(visitor: ClassWriter, classType: JvmType.Reference)(implicit root: Root, flix: Flix): Unit = {
+  private def compileUnitInstance(visitor: ClassWriter, classType: JvmType.Reference): Unit = {
     val method = visitor.visitMethod(ACC_STATIC, "<clinit>", "()V", null, null)
     method.visitCode()
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenTupleClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenTupleClasses.scala
@@ -18,7 +18,6 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.ReducedAst.Root
 import ca.uwaterloo.flix.language.ast.MonoType
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes._
@@ -31,7 +30,7 @@ object GenTupleClasses {
   /**
     * Returns the set of tuple classes for the given set of types `ts`.
     */
-  def gen(ts: Set[MonoType])(implicit root: Root, flix: Flix): Map[JvmName, JvmClass] = {
+  def gen(ts: Set[MonoType])(implicit flix: Flix): Map[JvmName, JvmClass] = {
     ts.foldLeft(Map.empty[JvmName, JvmClass]) {
       case (macc, tpe@MonoType.Tuple(elms)) =>
         // Case 1: The type constructor is a tuple.
@@ -96,7 +95,7 @@ object GenTupleClasses {
     * }
     *
     */
-  private def genByteCode(classType: JvmType.Reference, monoTargs: List[MonoType])(implicit root: Root, flix: Flix): Array[Byte] = {
+  private def genByteCode(classType: JvmType.Reference, monoTargs: List[MonoType])(implicit flix: Flix): Array[Byte] = {
     // class writer
     val visitor = AsmOps.mkClassWriter()
 
@@ -146,7 +145,7 @@ object GenTupleClasses {
     * elements of the tuple in the same order that they appear on the tuple but if the element is a primitive then it will
     * box the value.
     */
-  private def compileGetBoxedValueMethod(visitor: ClassWriter, classType: JvmType.Reference, fields: List[JvmType])(implicit root: Root, flix: Flix): Unit = {
+  private def compileGetBoxedValueMethod(visitor: ClassWriter, classType: JvmType.Reference, fields: List[JvmType]): Unit = {
     // header of the method
     val method = visitor.visitMethod(ACC_PUBLIC + ACC_FINAL, "getBoxedValue", s"()[Ljava/lang/Object;", null, null)
 
@@ -189,7 +188,7 @@ object GenTupleClasses {
     * this.field1 = var2;
     * }
     */
-  def compileTupleConstructor(visitor: ClassWriter, classType: JvmType.Reference, fields: List[JvmType])(implicit root: Root, flix: Flix): Unit = {
+  private def compileTupleConstructor(visitor: ClassWriter, classType: JvmType.Reference, fields: List[JvmType]): Unit = {
 
     val constructor = visitor.visitMethod(ACC_PUBLIC, "<init>", AsmOps.getMethodDescriptor(fields, JvmType.Void), null, null)
 
@@ -221,7 +220,7 @@ object GenTupleClasses {
     constructor.visitEnd()
   }
 
-  def compileToStringMethod(visitor: ClassWriter, classType: JvmType.Reference, fields: List[MonoType])(implicit root: Root, flix: Flix): Unit = {
+  def compileToStringMethod(visitor: ClassWriter, classType: JvmType.Reference, fields: List[MonoType]): Unit = {
     val method = visitor.visitMethod(ACC_PUBLIC + ACC_FINAL, "toString", AsmOps.getMethodDescriptor(Nil, JvmType.String), null, null)
     // this is for the new bytecode framework
     val methodF = new BytecodeInstructions.F(method)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmBackend.scala
@@ -204,7 +204,7 @@ object JvmBackend {
   /**
     * Returns a map from non-closure definition symbols to executable functions (backed by JVM backend).
     */
-  private def getCompiledDefs(root: Root)(implicit flix: Flix): Map[Symbol.DefnSym, () => AnyRef] =
+  private def getCompiledDefs(root: Root): Map[Symbol.DefnSym, () => AnyRef] =
     root.defs.foldLeft(Map.empty[Symbol.DefnSym, () => AnyRef]) {
       case (macc, (_, defn)) if defn.cparams.nonEmpty =>
         macc
@@ -216,7 +216,7 @@ object JvmBackend {
   /**
     * Returns a function object for the given definition symbol `sym`.
     */
-  private def link(sym: Symbol.DefnSym, root: Root)(implicit flix: Flix): java.util.function.Function[Array[AnyRef], AnyRef] = {
+  private def link(sym: Symbol.DefnSym, root: Root): java.util.function.Function[Array[AnyRef], AnyRef] = {
     // Retrieve the definition and its type.
     val defn = root.defs.getOrElse(sym, throw InternalCompilerException(s"Linking error: '$sym' cannot be found in root defs", SourceLocation.Unknown))
     // Check that the method is initialized.


### PR DESCRIPTION
- remove unused implicits 
- removed unused parameters
- removed unused pattern match variables
- remove unused imports
- inline simple methods with one occurance