### PR TITLE
refactor: rename `--github-key` to `--github-token`

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -69,4 +69,4 @@ jobs:
         timeout-minutes: 10
         run: |
           # Build the project.
-          java -jar flix.jar build --github-key ${{ github.token }}
+          java -jar flix.jar build --github-token ${{ github.token }}

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -64,3 +64,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Ziyao Wei](https://github.com/ZiyaoWei)
 - [Xavier deSouza](https://github.com/xdesou01)
 - [Herluf Baggesen](https://github.com/herluf-ba)
+- [Yukang Xie](https://github.com/bathtub-01)

--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -74,7 +74,7 @@ object Main {
       lib = cmdOpts.xlib,
       entryPoint = entryPoint,
       explain = cmdOpts.explain,
-      githubKey = cmdOpts.githubKey,
+      githubToken = cmdOpts.githubToken,
       incremental = Options.Default.incremental,
       json = cmdOpts.json,
       progress = true,
@@ -134,7 +134,7 @@ object Main {
           }
 
         case Command.Check =>
-          flatMapN(Bootstrap.bootstrap(cwd, options.githubKey)(System.err)) {
+          flatMapN(Bootstrap.bootstrap(cwd, options.githubToken)(System.err)) {
             bootstrap =>
               val flix = new Flix().setFormatter(formatter)
               flix.setOptions(options)
@@ -147,7 +147,7 @@ object Main {
           }
 
         case Command.Build =>
-          flatMapN(Bootstrap.bootstrap(cwd, options.githubKey)(System.err)) {
+          flatMapN(Bootstrap.bootstrap(cwd, options.githubToken)(System.err)) {
             bootstrap =>
               val flix = new Flix().setFormatter(formatter)
               flix.setOptions(options.copy(loadClassFiles = false))
@@ -160,7 +160,7 @@ object Main {
           }
 
         case Command.BuildJar =>
-          flatMapN(Bootstrap.bootstrap(cwd, options.githubKey)(System.err)) {
+          flatMapN(Bootstrap.bootstrap(cwd, options.githubToken)(System.err)) {
             bootstrap => bootstrap.buildJar()
           } match {
             case Validation.Success(_) =>
@@ -171,7 +171,7 @@ object Main {
           }
 
         case Command.BuildPkg =>
-          flatMapN(Bootstrap.bootstrap(cwd, options.githubKey)(System.err)) {
+          flatMapN(Bootstrap.bootstrap(cwd, options.githubToken)(System.err)) {
             bootstrap => bootstrap.buildPkg()
           } match {
             case Validation.Success(_) =>
@@ -182,7 +182,7 @@ object Main {
           }
 
         case Command.Doc =>
-          flatMapN(Bootstrap.bootstrap(cwd, options.githubKey)(System.err)) {
+          flatMapN(Bootstrap.bootstrap(cwd, options.githubToken)(System.err)) {
             bootstrap =>
               val flix = new Flix().setFormatter(formatter)
               flix.setOptions(options)
@@ -196,7 +196,7 @@ object Main {
           }
 
         case Command.Run =>
-          flatMapN(Bootstrap.bootstrap(cwd, options.githubKey)(System.err)) {
+          flatMapN(Bootstrap.bootstrap(cwd, options.githubToken)(System.err)) {
             bootstrap =>
               val flix = new Flix().setFormatter(formatter)
               flix.setOptions(options)
@@ -214,7 +214,7 @@ object Main {
           }
 
         case Command.Benchmark =>
-          flatMapN(Bootstrap.bootstrap(cwd, options.githubKey)(System.err)) {
+          flatMapN(Bootstrap.bootstrap(cwd, options.githubToken)(System.err)) {
             bootstrap =>
               val flix = new Flix().setFormatter(formatter)
               flix.setOptions(options.copy(progress = false))
@@ -228,7 +228,7 @@ object Main {
           }
 
         case Command.Test =>
-          flatMapN(Bootstrap.bootstrap(cwd, options.githubKey)(System.err)) {
+          flatMapN(Bootstrap.bootstrap(cwd, options.githubToken)(System.err)) {
             bootstrap =>
               val flix = new Flix().setFormatter(formatter)
               flix.setOptions(options.copy(progress = false))
@@ -246,7 +246,7 @@ object Main {
             println("The 'repl' command cannot be used with a list of files.")
             System.exit(1)
           }
-          Bootstrap.bootstrap(cwd, options.githubKey)(System.err) match {
+          Bootstrap.bootstrap(cwd, options.githubToken)(System.err) match {
             case Validation.Success(bootstrap) =>
               val shell = new Shell(bootstrap, options)
               shell.loop()
@@ -268,7 +268,7 @@ object Main {
           System.exit(0)
 
         case Command.Release =>
-          flatMapN(Bootstrap.bootstrap(cwd, options.githubKey)(System.err)) {
+          flatMapN(Bootstrap.bootstrap(cwd, options.githubToken)(System.err)) {
             bootstrap =>
               val flix = new Flix().setFormatter(formatter)
               flix.setOptions(options.copy(progress = false))
@@ -303,7 +303,7 @@ object Main {
                      entryPoint: Option[String] = None,
                      explain: Boolean = false,
                      installDeps: Boolean = true,
-                     githubKey: Option[String] = None,
+                     githubToken: Option[String] = None,
                      json: Boolean = false,
                      listen: Option[Int] = None,
                      threads: Option[Int] = None,
@@ -433,7 +433,7 @@ object Main {
       opt[Unit]("explain").action((_, c) => c.copy(explain = true)).
         text("provides suggestions on how to solve a problem.")
 
-      opt[String]("github-key").action((s, c) => c.copy(githubKey = Some(s))).
+      opt[String]("github-token").action((s, c) => c.copy(githubToken = Some(s))).
         text("API key to use for GitHub dependency resolution.")
 
       help("help").text("prints this usage information.")

--- a/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
+++ b/main/src/ca/uwaterloo/flix/api/Bootstrap.scala
@@ -646,8 +646,8 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
       case None => return Validation.toHardFailure(BootstrapError.ReleaseError(ReleaseError.MissingRepository))
     }
 
-    // Check if `--github-key` option is present
-    val githubKey = flix.options.githubKey match {
+    // Check if `--github-token` option is present
+    val githubToken = flix.options.githubToken match {
       case Some(k) => k
       case None => return Validation.toHardFailure(BootstrapError.ReleaseError(ReleaseError.MissingApiKey))
     }
@@ -675,7 +675,7 @@ class Bootstrap(val projectPath: Path, apiKey: Option[String]) {
     // Publish to GitHub
     println("Publishing a new release...")
     val artifacts = List(getPkgFile(projectPath), getManifestFile(projectPath))
-    val publishResult = GitHub.publishRelease(githubRepo, manifest.version, artifacts, githubKey)
+    val publishResult = GitHub.publishRelease(githubRepo, manifest.version, artifacts, githubToken)
     publishResult match {
       case Ok(()) => // Continue
       case Err(e) => return Validation.toHardFailure(BootstrapError.ReleaseError(e))

--- a/main/src/ca/uwaterloo/flix/tools/SimpleRunner.scala
+++ b/main/src/ca/uwaterloo/flix/tools/SimpleRunner.scala
@@ -62,7 +62,7 @@ object SimpleRunner {
 
     // check if we should start a REPL
     if (cmdOpts.command == Command.None && cmdOpts.files.isEmpty) {
-      Bootstrap.bootstrap(cwd, options.githubKey)(System.out) match {
+      Bootstrap.bootstrap(cwd, options.githubToken)(System.out) match {
         case Validation.Success(bootstrap) =>
           val shell = new Shell(bootstrap, options)
           shell.loop()

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ReleaseError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ReleaseError.scala
@@ -43,7 +43,7 @@ object ReleaseError {
   case object MissingApiKey extends ReleaseError {
     override def message(f: Formatter): String =
       s"""
-         | Cannot create a release without the `--github-key` option.
+         | Cannot create a release without the `--github-token` option.
          |""".stripMargin
   }
 

--- a/main/src/ca/uwaterloo/flix/util/Options.scala
+++ b/main/src/ca/uwaterloo/flix/util/Options.scala
@@ -28,7 +28,7 @@ object Options {
     lib = LibLevel.All,
     entryPoint = None,
     explain = false,
-    githubKey = None,
+    githubToken = None,
     installDeps = false,
     incremental = true,
     json = false,
@@ -80,7 +80,7 @@ object Options {
   * @param lib                 selects the level of libraries to include.
   * @param entryPoint          specifies the main entry point.
   * @param explain             enables additional explanations.
-  * @param githubKey           the API key to use for GitHub dependency resolution.
+  * @param githubToken           the API key to use for GitHub dependency resolution.
   * @param incremental         enables incremental compilation.
   * @param installDeps         enables automatic installation of dependencies.
   * @param json                enable json output.
@@ -103,7 +103,7 @@ object Options {
 case class Options(lib: LibLevel,
                    entryPoint: Option[Symbol.DefnSym],
                    explain: Boolean,
-                   githubKey: Option[String],
+                   githubToken: Option[String],
                    incremental: Boolean,
                    installDeps: Boolean,
                    json: Boolean,


### PR DESCRIPTION
Resolves #6973

- renamed the command line option from `--github-key` to `--github-token`
- renamed the field `githubKey` to `githubToken` in `Options` and `CmdOpts` classes