### PR TITLE
feat: split Validation.toResult

### DIFF
--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -84,12 +84,24 @@ sealed trait Validation[+T, +E] {
 
   /**
     * Returns `this` as a [[Result]].
-    * Both [[Validation.Success]] and [[Validation.SoftFailure]] are treated as [[Result.Ok]].
+    * Returns [[Result.Ok]] if and only if there are no errors.
+    * Returns [[Result.Err]] otherwise.
     */
-  def toResult: Result[(T, List[E]), List[E]] = this match {
-    case Validation.Success(t) => Result.Ok((t, List.empty))
-    case Validation.SoftFailure(t, errors) => Result.Ok((t, errors.toList))
-    case Validation.HardFailure(errors) => Result.Err(errors.toList)
+  def toHardResult: Result[T, Chain[E]] = this match {
+    case Validation.Success(t) => Result.Ok(t)
+    case Validation.SoftFailure(_, errors) => Result.Err(errors)
+    case Validation.HardFailure(errors) => Result.Err(errors)
+  }
+
+  /**
+    * Returns `this` as a [[Result]].
+    * If any success value exists it will be returned as a [[Result.Ok]] along with a possibly non-empty list of errors.
+    * This is meant for when a success value is useful in the presence of errors.
+    */
+  def toSoftResult: Result[(T, Chain[E]), Chain[E]] = this match {
+    case Validation.Success(t) => Result.Ok((t, Chain.empty))
+    case Validation.SoftFailure(t, errors) => Result.Ok((t, errors))
+    case Validation.HardFailure(errors) => Result.Err(errors)
   }
 }
 

--- a/main/test/ca/uwaterloo/flix/util/TestValidation.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestValidation.scala
@@ -433,24 +433,44 @@ class TestValidation extends AnyFunSuite {
     assertResult(Validation.HardFailure(Chain(ex, ex)))(result)
   }
 
-  test("toResult01") {
+  test("toSoftResult01") {
     val t = Validation.success[String, DummyError]("abc")
-    val result = t.toResult
-    assertResult(Result.Ok(("abc", List.empty)))(result)
+    val result = t.toSoftResult
+    assertResult(Result.Ok(("abc", Chain.empty)))(result)
   }
 
-  test("toResult02") {
+  test("toSoftResult02") {
     val e = DummyRecoverable()
     val t = Validation.toSoftFailure("xyz", e)
-    val result = t.toResult
-    assertResult(Result.Ok(("xyz", List(e))))(result)
+    val result = t.toSoftResult
+    assertResult(Result.Ok(("xyz", Chain(e))))(result)
   }
 
-  test("toResult03") {
+  test("toSoftResult03") {
     val e = DummyUnrecoverable()
     val t = Validation.toHardFailure[String, DummyUnrecoverable](e)
-    val result = t.toResult
-    assertResult(Result.Err(List(e)))(result)
+    val result = t.toSoftResult
+    assertResult(Result.Err(Chain(e)))(result)
+  }
+
+  test("toHardResult01") {
+    val t = Validation.success[String, DummyError]("abc")
+    val result = t.toHardResult
+    assertResult(Result.Ok("abc"))(result)
+  }
+
+  test("toHardResult02") {
+    val e = DummyRecoverable()
+    val t = Validation.toSoftFailure("xyz", e)
+    val result = t.toHardResult
+    assertResult(Result.Err(Chain(e)))(result)
+  }
+
+  test("toHardResult03") {
+    val e = DummyUnrecoverable()
+    val t = Validation.toHardFailure[String, DummyUnrecoverable](e)
+    val result = t.toHardResult
+    assertResult(Result.Err(Chain(e)))(result)
   }
 
   trait DummyError


### PR DESCRIPTION
Introduces `toSoftResult` & `toHardResult`.

Related to https://github.com/flix/flix/pull/6912
Related to https://github.com/flix/flix/issues/6746 