### PR TITLE
refactor: remove `Iterable` dependency in `Chain`

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/SocketServer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/SocketServer.scala
@@ -193,7 +193,7 @@ class SocketServer(port: Int) extends WebSocketServer(new InetSocketAddress(port
 
         case failure =>
           // Compilation failed. Retrieve and format the first error message.
-          Err(failure.errors.head.message(flix.getFormatter))
+          Err(failure.errors.head.get.message(flix.getFormatter))
       }
     } catch {
       case ex: RuntimeException => Err(ex.getMessage)

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -73,8 +73,8 @@ sealed trait Validation[+T, +E] {
     * Transform exactly one hard error into a soft error using the given function `f`.
     */
   def recoverOne[U >: T](f: PartialFunction[E, U]): Validation[U, E] = this match {
-    case Validation.HardFailure(errors) if errors.length == 1 =>
-      val one = errors.head
+    case Validation.HardFailure(errors) if errors.head.isDefined =>
+      val one = errors.head.get
       if (f.isDefinedAt(one))
         Validation.SoftFailure(f(one), Chain(one))
       else

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -73,7 +73,7 @@ sealed trait Validation[+T, +E] {
     * Transform exactly one hard error into a soft error using the given function `f`.
     */
   def recoverOne[U >: T](f: PartialFunction[E, U]): Validation[U, E] = this match {
-    case Validation.HardFailure(errors) if errors.head.isDefined =>
+    case Validation.HardFailure(errors) if errors.length == 1 =>
       val one = errors.head.get
       if (f.isDefinedAt(one))
         Validation.SoftFailure(f(one), Chain(one))

--- a/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
@@ -127,6 +127,15 @@ sealed trait Chain[+A] {
     case c: Chain.Proxy[A] => c.xs.toList
   }
 
+  /**
+    * Displays all elements of this collection in a string using a separator string.
+    */
+  final def mkString(sep: String): String = this match {
+    case Chain.Empty => ""
+    case Chain.Link(l, r) => l.mkString(sep) ++ sep ++ r.mkString(sep)
+    case Chain.Proxy(xs) => xs.mkString(sep)
+  }
+
   final override def hashCode(): Int = this.toList.hashCode()
 
   final override def equals(obj: Any): Boolean = obj match {

--- a/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
@@ -97,6 +97,15 @@ sealed trait Chain[+A] {
   }
 
   /**
+    * Returns `this` as a [[Seq]].
+    */
+  final def toSeq: Seq[A] = this match {
+    case Chain.Empty => Seq.empty
+    case Chain.Link(l, r) => l.toSeq ++ r.toSeq
+    case Chain.Proxy(xs) => xs
+  }
+
+  /**
     * Returns `this` as a [[List]].
     */
   final def toList: List[A] = this match {

--- a/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
@@ -46,6 +46,21 @@ sealed trait Chain[+A] extends Iterable[A] {
   }
 
   /**
+    * The empty chain.
+    */
+  override val empty: Chain[A] = Chain.Empty
+
+  /**
+    * Returns the amount of elements in the chain.
+    */
+  final def length: Int = this match {
+    case Chain.Empty => 0
+    case Chain.Link(l, r) => l.length + r.length
+    case Chain.Many(cs) => cs.map(_.length).sum
+    case Chain.Proxy(xs) => xs.length
+  }
+
+  /**
     * Returns `this` as a [[List]].
     */
   override def toList: List[A] = this match {
@@ -60,21 +75,6 @@ sealed trait Chain[+A] extends Iterable[A] {
       c.cs.foreach(c => buf.addAll(c.iterator))
       buf.toList
     case c: Chain.Proxy[A] => c.xs.toList
-  }
-
-  /**
-    * The empty chain.
-    */
-  override val empty: Chain[A] = Chain.Empty
-
-  /**
-    * Returns the amount of elements in the chain.
-    */
-  final def length: Int = this match {
-    case Chain.Empty => 0
-    case Chain.Link(l, r) => l.length + r.length
-    case Chain.Many(cs) => cs.map(_.length).sum
-    case Chain.Proxy(xs) => xs.length
   }
 
   final override def hashCode(): Int = this.toList.hashCode()

--- a/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
@@ -15,8 +15,6 @@
  */
 package ca.uwaterloo.flix.util.collection
 
-import scala.collection.mutable.ListBuffer
-
 /**
   * A linear data structure that allows fast concatenation.
   */
@@ -28,7 +26,6 @@ sealed trait Chain[+A] extends Iterable[A] {
   final def iterator: Iterator[A] = this match {
     case Chain.Empty => Iterator.empty
     case Chain.Link(l, r) => l.iterator ++ r.iterator
-    case Chain.Many(cs) => cs.flatMap(_.iterator).iterator
     case Chain.Proxy(xs) => xs.iterator
   }
 
@@ -56,7 +53,6 @@ sealed trait Chain[+A] extends Iterable[A] {
   final def length: Int = this match {
     case Chain.Empty => 0
     case Chain.Link(l, r) => l.length + r.length
-    case Chain.Many(cs) => cs.map(_.length).sum
     case Chain.Proxy(xs) => xs.length
   }
 
@@ -70,10 +66,6 @@ sealed trait Chain[+A] extends Iterable[A] {
     // depends on toList.
     case _: Chain.Empty.type => List.empty
     case c: Chain.Link[A] => c.l.toList ++ c.r.toList
-    case c: Chain.Many[A] =>
-      val buf = ListBuffer.empty[A]
-      c.cs.foreach(c => buf.addAll(c.iterator))
-      buf.toList
     case c: Chain.Proxy[A] => c.xs.toList
   }
 
@@ -98,14 +90,14 @@ object Chain {
   private case class Link[A](l: Chain[A], r: Chain[A]) extends Chain[A]
 
   /**
-    * A concatenation of many chains.
-    */
-  private case class Many[A](cs: Seq[Chain[A]]) extends Chain[A]
-
-  /**
     * A chain wrapping a sequence.
     */
   private case class Proxy[A](xs: Seq[A]) extends Chain[A]
+
+  /**
+    * The empty chain.
+    */
+  val empty: Chain[Nothing] = Chain.Empty
 
   /**
     * Returns a chain containing the given elements.
@@ -126,15 +118,5 @@ object Chain {
     * Returns a chain containing the given elements.
     */
   def from[A](xs: Iterable[A]): Chain[A] = if (xs.isEmpty) Chain.empty else Chain.Proxy(xs.toSeq)
-
-  /**
-    * The empty chain.
-    */
-  val empty: Chain[Nothing] = Chain.Empty
-
-  /**
-    * Concatenates the given sequence of chains, in order.
-    */
-  def concat[A](cs: Seq[Chain[A]]): Chain[A] = Chain.Many(cs)
 
 }

--- a/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
@@ -20,7 +20,7 @@ import scala.annotation.tailrec
 /**
   * A linear data structure that allows fast concatenation.
   */
-sealed trait Chain[+A] {
+sealed trait Chain[+A] extends Iterable[A] {
 
   /**
     * Returns an iterator over the chain, from left to right.
@@ -47,12 +47,12 @@ sealed trait Chain[+A] {
   /**
     * The empty chain.
     */
-  final val empty: Chain[A] = Chain.Empty
+  override val empty: Chain[A] = Chain.Empty
 
   /**
     * Returns `true` if and only if `this` contains no elements.
     */
-  final def isEmpty: Boolean = this match {
+  override def isEmpty: Boolean = this match {
     case Chain.Empty => true
     case Chain.Link(l, r) => l.isEmpty && r.isEmpty
     case Chain.Proxy(xs) => xs.isEmpty
@@ -62,10 +62,10 @@ sealed trait Chain[+A] {
     * Returns the leftmost element if any exists.
     */
   @tailrec
-  final def head: Option[A] = this match {
+  override def headOption: Option[A] = this match {
     case Chain.Empty => None
-    case Chain.Link(Chain.empty, r) => r.head
-    case Chain.Link(l, _) => l.head
+    case Chain.Link(Chain.empty, r) => r.headOption
+    case Chain.Link(l, _) => l.headOption
     case Chain.Proxy(xs) => xs.headOption
   }
 
@@ -81,7 +81,7 @@ sealed trait Chain[+A] {
   /**
     * Returns `this` as a [[List]].
     */
-  final def toList: List[A] = this match {
+  override def toList: List[A] = this match {
     // N.B.: We have to use reflection to avoid
     // infinite recursion when pattern matching
     // since it calls the equals method which

--- a/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
@@ -15,10 +15,12 @@
  */
 package ca.uwaterloo.flix.util.collection
 
+import scala.annotation.tailrec
+
 /**
   * A linear data structure that allows fast concatenation.
   */
-sealed trait Chain[+A] extends Iterable[A] {
+sealed trait Chain[+A] {
 
   /**
     * Returns an iterator over the chain, from left to right.
@@ -45,7 +47,27 @@ sealed trait Chain[+A] extends Iterable[A] {
   /**
     * The empty chain.
     */
-  override val empty: Chain[A] = Chain.Empty
+  final val empty: Chain[A] = Chain.Empty
+
+  /**
+    * Returns `true` if and only if `this` contains no elements.
+    */
+  final def isEmpty: Boolean = this match {
+    case Chain.Empty => true
+    case Chain.Link(l, r) => l.isEmpty && r.isEmpty
+    case Chain.Proxy(xs) => xs.isEmpty
+  }
+
+  /**
+    * Returns the leftmost element if any exists.
+    */
+  @tailrec
+  final def head: Option[A] = this match {
+    case Chain.Empty => None
+    case Chain.Link(Chain.empty, r) => r.head
+    case Chain.Link(l, _) => l.head
+    case Chain.Proxy(xs) => xs.headOption
+  }
 
   /**
     * Returns the amount of elements in the chain.
@@ -59,7 +81,7 @@ sealed trait Chain[+A] extends Iterable[A] {
   /**
     * Returns `this` as a [[List]].
     */
-  override def toList: List[A] = this match {
+  final def toList: List[A] = this match {
     // N.B.: We have to use reflection to avoid
     // infinite recursion when pattern matching
     // since it calls the equals method which

--- a/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
@@ -88,6 +88,15 @@ sealed trait Chain[+A] {
   }
 
   /**
+    * Applies `f` this every element in `this`.
+    */
+  final def foreach(f: A => Unit): Unit = this match {
+    case Chain.Empty => ()
+    case Chain.Link(l, r) => l.foreach(f); r.foreach(f)
+    case Chain.Proxy(xs) => xs.foreach(f)
+  }
+
+  /**
     * Returns `this` as a [[List]].
     */
   final def toList: List[A] = this match {

--- a/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
@@ -79,6 +79,15 @@ sealed trait Chain[+A] {
   }
 
   /**
+    * Returns `true` if and only if an element in `this` satisfies the predicate `f`.
+    */
+  final def exists(f: A => Boolean): Boolean = this match {
+    case Chain.Empty => false
+    case Chain.Link(l, r) => l.exists(f) || r.exists(f)
+    case Chain.Proxy(xs) => xs.exists(f)
+  }
+
+  /**
     * Returns a new [[Chain]] with `f` applied to every element in `this`.
     */
   final def map[B](f: A => B): Chain[B] = this match {

--- a/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
@@ -15,10 +15,12 @@
  */
 package ca.uwaterloo.flix.util.collection
 
+import scala.annotation.tailrec
+
 /**
   * A linear data structure that allows fast concatenation.
   */
-sealed trait Chain[+A] extends Iterable[A] {
+sealed trait Chain[+A] {
 
   /**
     * Returns an iterator over the chain, from left to right.
@@ -45,12 +47,12 @@ sealed trait Chain[+A] extends Iterable[A] {
   /**
     * The empty chain.
     */
-  override val empty: Chain[A] = Chain.Empty
+  final val empty: Chain[A] = Chain.Empty
 
   /**
     * Returns `true` if and only if `this` contains no elements.
     */
-  override def isEmpty: Boolean = this match {
+  final def isEmpty: Boolean = this match {
     case Chain.Empty => true
     case Chain.Link(l, r) => l.isEmpty && r.isEmpty
     case Chain.Proxy(xs) => xs.isEmpty
@@ -59,10 +61,11 @@ sealed trait Chain[+A] extends Iterable[A] {
   /**
     * Returns the leftmost element if any exists.
     */
-  override def headOption: Option[A] = this match {
+  @tailrec
+  final def head: Option[A] = this match {
     case Chain.Empty => None
-    case Chain.Link(Chain.empty, r) => r.headOption
-    case Chain.Link(l, _) => l.headOption
+    case Chain.Link(Chain.empty, r) => r.head
+    case Chain.Link(l, _) => l.head
     case Chain.Proxy(xs) => xs.headOption
   }
 
@@ -76,9 +79,18 @@ sealed trait Chain[+A] extends Iterable[A] {
   }
 
   /**
+    * Returns a new [[Chain]] with `f` applied to every element in `this`.
+    */
+  final def map[B](f: A => B): Chain[B] = this match {
+    case Chain.Empty => Chain.empty
+    case Chain.Link(l, r) => Chain.Link(l.map(f), r.map(f))
+    case Chain.Proxy(xs) => Chain.Proxy(xs.map(f))
+  }
+
+  /**
     * Returns `this` as a [[List]].
     */
-  override def toList: List[A] = this match {
+  final def toList: List[A] = this match {
     // N.B.: We have to use reflection to avoid
     // infinite recursion when pattern matching
     // since it calls the equals method which

--- a/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
+++ b/main/src/ca/uwaterloo/flix/util/collection/Chain.scala
@@ -15,8 +15,6 @@
  */
 package ca.uwaterloo.flix.util.collection
 
-import scala.annotation.tailrec
-
 /**
   * A linear data structure that allows fast concatenation.
   */
@@ -61,7 +59,6 @@ sealed trait Chain[+A] extends Iterable[A] {
   /**
     * Returns the leftmost element if any exists.
     */
-  @tailrec
   override def headOption: Option[A] = this match {
     case Chain.Empty => None
     case Chain.Link(Chain.empty, r) => r.headOption

--- a/main/test/ca/uwaterloo/flix/util/TestChain.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestChain.scala
@@ -113,19 +113,19 @@ class TestChain extends AnyFunSuite {
   }
 
   test("TestHead.01") {
-    assertResult(Chain.empty.head)(None)
+    assertResult(Chain.empty.headOption)(None)
   }
 
   test("TestHead.02") {
-    assertResult(Chain(1).head)(Some(1))
+    assertResult(Chain(1).headOption)(Some(1))
   }
 
   test("TestHead.03") {
-    assertResult(Chain(2, 1).head)(Some(2))
+    assertResult(Chain(2, 1).headOption)(Some(2))
   }
 
   test("TestHead.04") {
-    assertResult(Chain(3, 2, 1).head)(Some(3))
+    assertResult(Chain(3, 2, 1).headOption)(Some(3))
   }
 
 }

--- a/main/test/ca/uwaterloo/flix/util/TestChain.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestChain.scala
@@ -115,11 +115,11 @@ class TestChain extends AnyFunSuite {
   }
 
   test("TestIsEmpty.02") {
-    assert(Chain(1).isEmpty)
+    assert(!Chain(1).isEmpty)
   }
 
   test("TestIsEmpty.03") {
-    assert(Chain(1, 2).isEmpty)
+    assert(!Chain(1, 2).isEmpty)
   }
 
   test("TestHead.01") {

--- a/main/test/ca/uwaterloo/flix/util/TestChain.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestChain.scala
@@ -113,19 +113,36 @@ class TestChain extends AnyFunSuite {
   }
 
   test("TestHead.01") {
-    assertResult(Chain.empty.headOption)(None)
+    assertResult(Chain.empty.head)(None)
   }
 
   test("TestHead.02") {
-    assertResult(Chain(1).headOption)(Some(1))
+    assertResult(Chain(1).head)(Some(1))
   }
 
   test("TestHead.03") {
-    assertResult(Chain(2, 1).headOption)(Some(2))
+    assertResult(Chain(2, 1).head)(Some(2))
   }
 
   test("TestHead.04") {
-    assertResult(Chain(3, 2, 1).headOption)(Some(3))
+    assertResult(Chain(3, 2, 1).head)(Some(3))
   }
+
+  test("TestLength.01") {
+    assertResult(Chain.empty.length)(0)
+  }
+
+  test("TestLength.02") {
+    assertResult(Chain(1).length)(1)
+  }
+
+  test("TestLength.03") {
+    assertResult(Chain(1, 2).length)(2)
+  }
+
+  test("TestLength.04") {
+    assertResult(Chain(1, 2, 3).length)(3)
+  }
+
 
 }

--- a/main/test/ca/uwaterloo/flix/util/TestChain.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestChain.scala
@@ -251,4 +251,16 @@ class TestChain extends AnyFunSuite {
     assertResult(Chain(1, 9, 3).exists(i => i > 3))(true)
   }
 
+  test("TestMkString.01") {
+    assertResult(Chain.empty.mkString("+"))("")
+  }
+
+  test("TestMkString.02") {
+    assertResult(Chain(1, 2, 3).mkString("+"))("1+2+3")
+  }
+
+  test("TestMkString.02") {
+    val chain = Chain(1) ++ Chain(2) ++ Chain(3) ++ Chain(4) ++ Chain(5)
+    assertResult(chain.mkString("-"))("1-2-3-4-5")
+  }
 }

--- a/main/test/ca/uwaterloo/flix/util/TestChain.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestChain.scala
@@ -213,4 +213,42 @@ class TestChain extends AnyFunSuite {
   test("TestToSeq.05") {
     assertResult((Chain(1, 2, 3, 4) ++ Chain.empty).toSeq)(Seq(1, 2, 3, 4))
   }
+
+
+  test("TestExists.01") {
+    assertResult(Chain.empty.exists((i: Int) => i > 3))(false)
+  }
+
+  test("TestExists.02") {
+    assertResult(Chain(1).exists(i => i > 3))(false)
+  }
+
+  test("TestExists.03") {
+    assertResult(Chain(5).exists(i => i > 3))(true)
+  }
+
+  test("TestExists.04") {
+    assertResult(Chain(1, 2).exists(i => i > 3))(false)
+  }
+
+  test("TestExists.05") {
+    assertResult(Chain(1, 6).exists(i => i > 3))(true)
+  }
+
+  test("TestExists.06") {
+    assertResult(Chain(6, 1).exists(i => i > 3))(true)
+  }
+
+  test("TestExists.07") {
+    assertResult(Chain(16, 6).exists(i => i > 3))(true)
+  }
+
+  test("TestExists.08") {
+    assertResult(Chain(1, -9, 3).exists(i => i > 3))(false)
+  }
+
+  test("TestExists.09") {
+    assertResult(Chain(1, 9, 3).exists(i => i > 3))(true)
+  }
+
 }

--- a/main/test/ca/uwaterloo/flix/util/TestChain.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestChain.scala
@@ -20,11 +20,6 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class TestChain extends AnyFunSuite {
 
-  test("TestChain.01") {
-    val chain = Chain.empty
-    assert(chain.isEmpty)
-  }
-
   test("TestChain.02") {
     val chain = Chain(1, 2, 3, 4)
     assert(chain.toList == List(1, 2, 3, 4))
@@ -110,6 +105,18 @@ class TestChain extends AnyFunSuite {
     val c1 = Chain(1) ++ Chain(2) ++ Chain(3) ++ Chain(4) ++ Chain(5)
     val c2 = Chain(2, 2, 3, 4, 6)
     assert(c1 != c2)
+  }
+
+  test("TestIsEmpty.01") {
+    assert(Chain.empty.isEmpty)
+  }
+
+  test("TestIsEmpty.02") {
+    assert(Chain(1).isEmpty)
+  }
+
+  test("TestIsEmpty.03") {
+    assert(Chain(1, 2).isEmpty)
   }
 
   test("TestHead.01") {

--- a/main/test/ca/uwaterloo/flix/util/TestChain.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestChain.scala
@@ -20,34 +20,37 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class TestChain extends AnyFunSuite {
 
-  test("TestChain.02") {
-    val chain = Chain(1, 2, 3, 4)
-    assert(chain.toList == List(1, 2, 3, 4))
+  test("TestToList.01") {
+    assertResult(Chain.empty.toList)(List.empty)
   }
 
-  test("TestChain.03") {
+  test("TestToList.02") {
+    assertResult(Chain(1, 2, 3, 4).toList)(List(1, 2, 3, 4))
+  }
+
+  test("TestToList.03") {
     val chain = Chain(1, 2) ++ Chain(3, 4)
-    assert(chain.toList == List(1, 2, 3, 4))
+    assertResult(chain.toList)(List(1, 2, 3, 4))
   }
 
-  test("TestChain.04") {
+  test("TestToList.04") {
     val chain = Chain.empty ++ Chain(1, 2, 3, 4)
-    assert(chain.toList == List(1, 2, 3, 4))
+    assertResult(chain.toList)(List(1, 2, 3, 4))
   }
 
-  test("TestChain.05") {
+  test("TestToList.05") {
     val chain = Chain(1, 2, 3, 4) ++ Chain.empty
-    assert(chain.toList == List(1, 2, 3, 4))
+    assertResult(chain.toList)(List(1, 2, 3, 4))
   }
 
-  test("TestChain.06") {
+  test("TestToList.06") {
     val chains = List(
       Chain.empty,
       Chain(1, 2),
       Chain.empty ++ Chain(3, 4)
     )
     val chain = chains.fold(Chain.empty)(_ ++ _)
-    assert(chain.toList == List(1, 2, 3, 4))
+    assertResult(chain.toList)(List(1, 2, 3, 4))
   }
 
   test("TestEq.01") {

--- a/main/test/ca/uwaterloo/flix/util/TestChain.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestChain.scala
@@ -259,7 +259,7 @@ class TestChain extends AnyFunSuite {
     assertResult(Chain(1, 2, 3).mkString("+"))("1+2+3")
   }
 
-  test("TestMkString.02") {
+  test("TestMkString.03") {
     val chain = Chain(1) ++ Chain(2) ++ Chain(3) ++ Chain(4) ++ Chain(5)
     assertResult(chain.mkString("-"))("1-2-3-4-5")
   }

--- a/main/test/ca/uwaterloo/flix/util/TestChain.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestChain.scala
@@ -179,4 +179,15 @@ class TestChain extends AnyFunSuite {
     assertResult(Chain(7, 8).map(i => i > 2))(Chain(true, true))
   }
 
+  test("TestForeach.01") {
+    var r = 21
+    Chain.empty.foreach(x => r = x)
+    assertResult(r)(21)
+  }
+
+  test("TestForeach.02") {
+    var r = 21
+    Chain(1, 2, 3).foreach(x => r = x)
+    assertResult(r)(3)
+  }
 }

--- a/main/test/ca/uwaterloo/flix/util/TestChain.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestChain.scala
@@ -111,4 +111,21 @@ class TestChain extends AnyFunSuite {
     val c2 = Chain(2, 2, 3, 4, 6)
     assert(c1 != c2)
   }
+
+  test("TestHead.01") {
+    assertResult(Chain.empty.head)(None)
+  }
+
+  test("TestHead.02") {
+    assertResult(Chain(1).head)(Some(1))
+  }
+
+  test("TestHead.03") {
+    assertResult(Chain(2, 1).head)(Some(2))
+  }
+
+  test("TestHead.04") {
+    assertResult(Chain(3, 2, 1).head)(Some(3))
+  }
+
 }

--- a/main/test/ca/uwaterloo/flix/util/TestChain.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestChain.scala
@@ -151,5 +151,32 @@ class TestChain extends AnyFunSuite {
     assertResult(Chain(1, 2, 3).length)(3)
   }
 
+  test("TestMap.01") {
+    assertResult(Chain.empty.map((i: Int) => i > 2))(Chain.empty)
+  }
+
+  test("TestMap.02") {
+    assertResult(Chain(1).map(i => i > 2))(Chain(false))
+  }
+
+  test("TestMap.03") {
+    assertResult(Chain(3).map(i => i > 2))(Chain(true))
+  }
+
+  test("TestMap.04") {
+    assertResult(Chain(1, 2).map(i => i > 2))(Chain(false, false))
+  }
+
+  test("TestMap.05") {
+    assertResult(Chain(1, 8).map(i => i > 2))(Chain(false, true))
+  }
+
+  test("TestMap.06") {
+    assertResult(Chain(8, 1).map(i => i > 2))(Chain(true, false))
+  }
+
+  test("TestMap.07") {
+    assertResult(Chain(7, 8).map(i => i > 2))(Chain(true, true))
+  }
 
 }

--- a/main/test/ca/uwaterloo/flix/util/TestChain.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestChain.scala
@@ -51,7 +51,7 @@ class TestChain extends AnyFunSuite {
       Chain(1, 2),
       Chain.empty ++ Chain(3, 4)
     )
-    val chain = Chain.concat(chains)
+    val chain = chains.fold(Chain.empty)(_ ++ _)
     assert(chain.toList == List(1, 2, 3, 4))
   }
 
@@ -77,7 +77,7 @@ class TestChain extends AnyFunSuite {
   }
 
   test("TestEq.05") {
-    val c1 = Chain.concat(Seq(Chain(1), Chain(2), Chain(3), Chain(4), Chain(5)))
+    val c1 = Seq(Chain(1), Chain(2), Chain(3), Chain(4), Chain(5)).fold(Chain.empty)(_ ++ _)
     val c2 = Chain(1, 2, 3, 4, 5)
     assertResult(c1)(c2)
   }
@@ -95,7 +95,7 @@ class TestChain extends AnyFunSuite {
   }
 
   test("TestEq.08") {
-    val c1 = Chain.concat(Seq(Chain(1), Chain(2), Chain(3), Chain(4), Chain(5)))
+    val c1 = Seq(Chain(1), Chain(2), Chain(3), Chain(4), Chain(5)).fold(Chain.empty)(_ ++ _)
     val c2 = Chain(1, 2, 3, 4, 6)
     assert(c1 != c2)
   }

--- a/main/test/ca/uwaterloo/flix/util/TestChain.scala
+++ b/main/test/ca/uwaterloo/flix/util/TestChain.scala
@@ -190,4 +190,24 @@ class TestChain extends AnyFunSuite {
     Chain(1, 2, 3).foreach(x => r = x)
     assertResult(r)(3)
   }
+
+  test("TestToSeq.01") {
+    assertResult(Chain.empty.toSeq)(Seq.empty)
+  }
+
+  test("TestToSeq.02") {
+    assertResult(Chain(1, 2, 3, 4).toSeq)(Seq(1, 2, 3, 4))
+  }
+
+  test("TestToSeq.03") {
+    assertResult((Chain(1, 2) ++ Chain(3, 4)).toSeq)(Seq(1, 2, 3, 4))
+  }
+
+  test("TestToSeq.04") {
+    assertResult((Chain.empty ++ Chain(10, 20, 30, 50)).toSeq)(Seq(10, 20, 30, 50))
+  }
+
+  test("TestToSeq.05") {
+    assertResult((Chain(1, 2, 3, 4) ++ Chain.empty).toSeq)(Seq(1, 2, 3, 4))
+  }
 }


### PR DESCRIPTION
- [x] `isEmpty`
- [x] `head`
- [x] `map`
- [ ] `filter`
- [ ] `flatMap`
- [x] `exists`
- [ ] `forall`
- [x] `foreach`
- [x] `toSeq`
- [x] `mkString`

Depends on https://github.com/flix/flix/pull/7008
Related to https://github.com/flix/flix/issues/6989