### PR TITLE
feat: new type rule for `try-with`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/TypeInference.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeInference.scala
@@ -923,7 +923,6 @@ object TypeInference {
       case KindedAst.Expr.TryWith(exp, effUse, rules, tvar, loc) =>
         val effect = root.effects(effUse.sym)
         val ops = effect.ops.map(op => op.sym -> op).toMap
-        val effType = Type.Cst(TypeConstructor.Effect(effUse.sym), effUse.loc)
         val continuationEffect = Type.freshVar(Kind.Eff, loc)
 
         def unifyFormalParams(op: Symbol.OpSym, expected: List[KindedAst.FormalParam], actual: List[KindedAst.FormalParam]): InferMonad[Unit] = {

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeInference.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeInference.scala
@@ -966,8 +966,7 @@ object TypeInference {
 
         for {
           (tconstrs, tpe, bodyEff) <- visitExp(exp)
-          _ <- expectTypeM(expected = effType, actual = bodyEff, exp.loc) // TODO temp simplification
-          correctedBodyEff = Type.Pure // Type.mkDifference(bodyEff, effType, loc) // TODO temp simplification
+          correctedBodyEff <- purifyEff(effUse.sym, bodyEff) // Note: Does not work for polymorphic effects.
           (tconstrss, _, effs) <- traverseM(rules)(visitHandlerRule(_, tpe)).map(_.unzip3)
           _ <- unifyTypeM(continuationEffect, Type.mkUnion(correctedBodyEff :: effs, loc), loc)
           resultTconstrs = (tconstrs :: tconstrss).flatten

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -525,7 +525,7 @@ object Unification {
         case _ => t
       }
       case Type.Apply(tpe1, tpe2, loc) => Type.Apply(visit(tpe1), visit(tpe2), loc)
-      case Type.Alias(cst, args, tpe, loc) => Type.Alias(cst, args.map(visit), visit(tpe), loc)
+      case Type.Alias(cst, _, tpe, _) => visit(tpe)
       case Type.AssocType(cst, arg, kind, loc) => Type.AssocType(cst, visit(arg), kind, loc)
     }
 

--- a/main/test/flix/Test.Exp.Effect.flix
+++ b/main/test/flix/Test.Exp.Effect.flix
@@ -4,21 +4,21 @@ mod Test.Exp.Effect {
     // just making it public for redundancy purposes
     // @test
     pub def handleEff01(): Bool = {
-        try checked_ecast (true) with Fail {
+        try true with Fail {
             def fail(_, _cont) = false
         }
     }
 
     // @test
     pub def handleEff02(): Unit = {
-        try checked_ecast (()) with Fail {
+        try () with Fail {
             def fail(_, cont) = cont()
         }
     }
 
     // @test
     pub def handleEff03(): Bool = {
-        try checked_ecast (true) with Empty
+        try true with Empty
     }
 
     // @test


### PR DESCRIPTION
The new type rule permits multiple effects:

```scala
eff Gen {
    pub def gen(x: Int32): Unit
}

eff Print {
    pub def print(x: String): Unit
}

def generator(x: Int32): Unit \ Gen + Print =
    do Gen.gen(x); do Print.print("abc"); generator(x + 1)

def sample(limit: Int32): List[Int32] \ Print =
    try {
        generator(0); Nil
    } with Gen {
        def gen(x, k) = if (x == limit) Nil else x :: k()
    }

def main(): Unit \ IO =
    try {
        println(sample(4))
    } with Print {
        def print(x, k) = { println(x); k() }
    }
```

I know its incomplete (i.e. it rejects programs with polymorphic handlers), but I am not sure if it is unsound. 
Possibly it could be sound still.

In any case, this is just a temporary measure while we wait for sets :)