### PR TITLE
refactor: Move EffectBinder before Reducer

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -110,8 +110,8 @@ class Flix {
   private var cachedOptimizerAst: LiftedAst.Root = LiftedAst.empty
   private var cachedTreeShaker2Ast: LiftedAst.Root = LiftedAst.empty
   private var cachedEraserAst: LiftedAst.Root = LiftedAst.empty
+  private var cachedEffectBinderAst: LiftedAst.Root = LiftedAst.empty
   private var cachedReducerAst: ReducedAst.Root = ReducedAst.empty
-  private var cachedEffectBinderAst: ReducedAst.Root = ReducedAst.empty
   private var cachedVarOffsetsAst: ReducedAst.Root = ReducedAst.empty
 
   def getLoweringAst: LoweredAst.Root = cachedLoweringAst
@@ -136,9 +136,9 @@ class Flix {
 
   def getEraserAst: LiftedAst.Root = cachedEraserAst
 
-  def getReducerAst: ReducedAst.Root = cachedReducerAst
+  def getEffectBinderAst: LiftedAst.Root = cachedEffectBinderAst
 
-  def getEffectBinderAst: ReducedAst.Root = cachedEffectBinderAst
+  def getReducerAst: ReducedAst.Root = cachedReducerAst
 
   def getVarOffsetsAst: ReducedAst.Root = cachedVarOffsetsAst
 
@@ -613,9 +613,9 @@ class Flix {
     cachedOptimizerAst = Optimizer.run(cachedTailrecAst)
     cachedTreeShaker2Ast = TreeShaker2.run(cachedOptimizerAst)
     cachedEraserAst = Eraser.run(cachedTreeShaker2Ast)
-    cachedReducerAst = Reducer.run(cachedEraserAst)
-    cachedEffectBinderAst = EffectBinder.run(cachedReducerAst)
-    cachedVarOffsetsAst = VarOffsets.run(cachedEffectBinderAst)
+    cachedEffectBinderAst = EffectBinder.run(cachedEraserAst)
+    cachedReducerAst = Reducer.run(cachedEffectBinderAst)
+    cachedVarOffsetsAst = VarOffsets.run(cachedReducerAst)
     val result = JvmBackend.run(cachedVarOffsetsAst)
 
     // Write formatted asts to disk based on options.

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -109,8 +109,8 @@ class Flix {
   private var cachedTailrecAst: LiftedAst.Root = LiftedAst.empty
   private var cachedOptimizerAst: LiftedAst.Root = LiftedAst.empty
   private var cachedTreeShaker2Ast: LiftedAst.Root = LiftedAst.empty
-  private var cachedEraserAst: LiftedAst.Root = LiftedAst.empty
   private var cachedEffectBinderAst: LiftedAst.Root = LiftedAst.empty
+  private var cachedEraserAst: LiftedAst.Root = LiftedAst.empty
   private var cachedReducerAst: ReducedAst.Root = ReducedAst.empty
   private var cachedVarOffsetsAst: ReducedAst.Root = ReducedAst.empty
 
@@ -134,9 +134,9 @@ class Flix {
 
   def getTreeShaker2Ast: LiftedAst.Root = cachedTreeShaker2Ast
 
-  def getEraserAst: LiftedAst.Root = cachedEraserAst
-
   def getEffectBinderAst: LiftedAst.Root = cachedEffectBinderAst
+
+  def getEraserAst: LiftedAst.Root = cachedEraserAst
 
   def getReducerAst: ReducedAst.Root = cachedReducerAst
 
@@ -612,9 +612,9 @@ class Flix {
     cachedTailrecAst = Tailrec.run(cachedLambdaLiftAst)
     cachedOptimizerAst = Optimizer.run(cachedTailrecAst)
     cachedTreeShaker2Ast = TreeShaker2.run(cachedOptimizerAst)
-    cachedEraserAst = Eraser.run(cachedTreeShaker2Ast)
-    cachedEffectBinderAst = EffectBinder.run(cachedEraserAst)
-    cachedReducerAst = Reducer.run(cachedEffectBinderAst)
+    cachedEffectBinderAst = EffectBinder.run(cachedTreeShaker2Ast)
+    cachedEraserAst = Eraser.run(cachedEffectBinderAst)
+    cachedReducerAst = Reducer.run(cachedEraserAst)
     cachedVarOffsetsAst = VarOffsets.run(cachedReducerAst)
     val result = JvmBackend.run(cachedVarOffsetsAst)
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
@@ -42,7 +42,7 @@ object ShowAstProvider {
       val phases = List("Parser", "Weeder", "Kinder", "Resolver", "TypedAst",
         "Documentor", "Lowering", "TreeShaker1", "MonoDefs",
         "MonoTypes", "Simplifier", "ClosureConv", "LambdaLift", "Tailrec",
-        "Optimizer", "TreeShaker2", "Eraser", "Reducer", "EffectBinder", "VarOffsets")
+        "Optimizer", "TreeShaker2", "Eraser", "EffectBinder", "Reducer", "VarOffsets")
 
       phase match {
         case "Parser" => astObject(phase, "Work In Progress")
@@ -62,8 +62,8 @@ object ShowAstProvider {
         case "Optimizer" => astObject(phase, AstPrinter.formatLiftedAst(flix.getOptimizerAst))
         case "TreeShaker2" => astObject(phase, AstPrinter.formatLiftedAst(flix.getTreeShaker2Ast))
         case "Eraser" => astObject(phase, AstPrinter.formatLiftedAst(flix.getEraserAst))
+        case "EffectBinder" => astObject(phase, AstPrinter.formatLiftedAst(flix.getEffectBinderAst))
         case "Reducer" => astObject(phase, AstPrinter.formatReducedAst(flix.getReducerAst))
-        case "EffectBinder" => astObject(phase, AstPrinter.formatReducedAst(flix.getEffectBinderAst))
         case "VarOffsets" => astObject(phase, AstPrinter.formatReducedAst(flix.getVarOffsetsAst))
         case _ =>
           astObject(phase, s"Unknown phase: '$phase'. Try one of these ${phases.map(s => s"'$s'").mkString(", ")}")

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
@@ -42,7 +42,7 @@ object ShowAstProvider {
       val phases = List("Parser", "Weeder", "Kinder", "Resolver", "TypedAst",
         "Documentor", "Lowering", "TreeShaker1", "MonoDefs",
         "MonoTypes", "Simplifier", "ClosureConv", "LambdaLift", "Tailrec",
-        "Optimizer", "TreeShaker2", "Eraser", "EffectBinder", "Reducer", "VarOffsets")
+        "Optimizer", "TreeShaker2", "EffectBinder", "Eraser", "Reducer", "VarOffsets")
 
       phase match {
         case "Parser" => astObject(phase, "Work In Progress")
@@ -61,8 +61,8 @@ object ShowAstProvider {
         case "Tailrec" => astObject(phase, AstPrinter.formatLiftedAst(flix.getTailrecAst))
         case "Optimizer" => astObject(phase, AstPrinter.formatLiftedAst(flix.getOptimizerAst))
         case "TreeShaker2" => astObject(phase, AstPrinter.formatLiftedAst(flix.getTreeShaker2Ast))
-        case "Eraser" => astObject(phase, AstPrinter.formatLiftedAst(flix.getEraserAst))
         case "EffectBinder" => astObject(phase, AstPrinter.formatLiftedAst(flix.getEffectBinderAst))
+        case "Eraser" => astObject(phase, AstPrinter.formatLiftedAst(flix.getEraserAst))
         case "Reducer" => astObject(phase, AstPrinter.formatReducedAst(flix.getReducerAst))
         case "VarOffsets" => astObject(phase, AstPrinter.formatReducedAst(flix.getVarOffsetsAst))
         case _ =>

--- a/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
@@ -30,7 +30,8 @@ object LiftedAst {
                   reachable: Set[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
-  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], exp: Expr, tpe: MonoType, purity: Purity, loc: SourceLocation)
+  /** pcPoints are initialized in [[ca.uwaterloo.flix.language.phase.EffectBinder]] */
+  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], pcPoints: Int, exp: Expr, tpe: MonoType, purity: Purity, loc: SourceLocation)
 
   case class Enum(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, cases: Map[Symbol.CaseSym, Case], tpe: MonoType, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/AstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/AstPrinter.scala
@@ -66,8 +66,8 @@ object AstPrinter {
       if (asts.contains("Tailrec")) writeToDisk("Tailrec", formatLiftedAst(flix.getTailrecAst))
       if (asts.contains("Optimizer")) writeToDisk("Optimizer", formatLiftedAst(flix.getOptimizerAst))
       if (asts.contains("TreeShaker2")) writeToDisk("TreeShaker2", formatLiftedAst(flix.getTreeShaker2Ast))
-      if (asts.contains("Eraser")) writeToDisk("Eraser", formatLiftedAst(flix.getEraserAst))
       if (asts.contains("EffectBinder")) writeToDisk("EffectBinder", formatLiftedAst(flix.getEffectBinderAst))
+      if (asts.contains("Eraser")) writeToDisk("Eraser", formatLiftedAst(flix.getEraserAst))
       if (asts.contains("Reducer")) writeToDisk("Reducer", formatReducedAst(flix.getReducerAst))
       if (asts.contains("VarOffsets")) writeToDisk("VarOffsets", formatReducedAst(flix.getVarOffsetsAst))
       if (asts.contains("JvmBackend")) () // wip
@@ -111,8 +111,8 @@ object AstPrinter {
     writeToDisk("Tailrec", formatLiftedAst(flix.getTailrecAst))
     writeToDisk("Optimizer", formatLiftedAst(flix.getOptimizerAst))
     writeToDisk("TreeShaker2", formatLiftedAst(flix.getTreeShaker2Ast))
-    writeToDisk("Eraser", formatLiftedAst(flix.getEraserAst))
     writeToDisk("EffectBinder", formatLiftedAst(flix.getEffectBinderAst))
+    writeToDisk("Eraser", formatLiftedAst(flix.getEraserAst))
     writeToDisk("Reducer", formatReducedAst(flix.getReducerAst))
     writeToDisk("VarOffsets", formatReducedAst(flix.getVarOffsetsAst))
   }

--- a/main/src/ca/uwaterloo/flix/language/dbg/AstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/AstPrinter.scala
@@ -67,8 +67,8 @@ object AstPrinter {
       if (asts.contains("Optimizer")) writeToDisk("Optimizer", formatLiftedAst(flix.getOptimizerAst))
       if (asts.contains("TreeShaker2")) writeToDisk("TreeShaker2", formatLiftedAst(flix.getTreeShaker2Ast))
       if (asts.contains("Eraser")) writeToDisk("Eraser", formatLiftedAst(flix.getEraserAst))
+      if (asts.contains("EffectBinder")) writeToDisk("EffectBinder", formatLiftedAst(flix.getEffectBinderAst))
       if (asts.contains("Reducer")) writeToDisk("Reducer", formatReducedAst(flix.getReducerAst))
-      if (asts.contains("EffectBinder")) writeToDisk("EffectBinder", formatReducedAst(flix.getEffectBinderAst))
       if (asts.contains("VarOffsets")) writeToDisk("VarOffsets", formatReducedAst(flix.getVarOffsetsAst))
       if (asts.contains("JvmBackend")) () // wip
     }
@@ -112,8 +112,8 @@ object AstPrinter {
     writeToDisk("Optimizer", formatLiftedAst(flix.getOptimizerAst))
     writeToDisk("TreeShaker2", formatLiftedAst(flix.getTreeShaker2Ast))
     writeToDisk("Eraser", formatLiftedAst(flix.getEraserAst))
+    writeToDisk("EffectBinder", formatLiftedAst(flix.getEffectBinderAst))
     writeToDisk("Reducer", formatReducedAst(flix.getReducerAst))
-    writeToDisk("EffectBinder", formatReducedAst(flix.getEffectBinderAst))
     writeToDisk("VarOffsets", formatReducedAst(flix.getVarOffsetsAst))
   }
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
@@ -36,7 +36,7 @@ object LiftedAstPrinter {
         DocAst.Enum(ann, mod, sym, Nil, cases)
     }.toList
     val defs = root.defs.values.map {
-      case LiftedAst.Def(ann, mod, sym, cparams, fparams, exp, tpe, purity, _) =>
+      case LiftedAst.Def(ann, mod, sym, cparams, fparams, _, exp, tpe, purity, _) =>
         DocAst.Def(
           ann,
           mod,

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.{BoundBy, CallType}
-import ca.uwaterloo.flix.language.ast.ReducedAst._
+import ca.uwaterloo.flix.language.ast.LiftedAst._
 import ca.uwaterloo.flix.language.ast.Symbol.{DefnSym, VarSym}
 import ca.uwaterloo.flix.language.ast.{AtomicOp, Level, Purity, SemanticOp, SourceLocation, Symbol}
 import ca.uwaterloo.flix.language.phase.jvm.GenExpression
@@ -29,9 +29,7 @@ import scala.collection.mutable
 
 /**
   * This phase transforms the AST such that all effect operations will happen on
-  * an empty operand stack in [[GenExpression]]. This means that additional
-  * let-bindings are introduced which means that [[Def.lparams]] must be updated
-  * accordingly.
+  * an empty operand stack in [[GenExpression]].
   *
   * The number of "pc points" must be counted, which is the number of points
   * where a continuation will be used. This includes do operations, all calls
@@ -58,13 +56,13 @@ object EffectBinder {
   /**
     * A local non-shared context. Does not need to be thread-safe.
     */
-  private case class LocalContext(lparams: mutable.ArrayBuffer[LocalParam], var pcPoints: Int)
+  private case class LocalContext(var pcPoints: Int)
 
   /**
     * Companion object for [[LocalContext]].
     */
   private object LocalContext {
-    def mk(): LocalContext = LocalContext(mutable.ArrayBuffer.empty, 0)
+    def mk(): LocalContext = LocalContext(0)
   }
 
   private sealed trait Binder
@@ -79,16 +77,15 @@ object EffectBinder {
     */
   private def visitDef(defn: Def)(implicit flix: Flix): Def = {
     implicit val lctx: LocalContext = LocalContext.mk()
-    val stmt = visitStmt(defn.stmt)
-    defn.copy(stmt = stmt, lparams = defn.lparams ++ lctx.lparams.toList, pcPoints = lctx.pcPoints)
+    val exp = visitExpr(defn.exp)
+    defn.copy(exp = exp, pcPoints = lctx.pcPoints)
   }
 
-  /**
-    * Transforms the [[Stmt]] such that effect operations will be run without an
-    * operand stack.
-    */
-  private def visitStmt(stmt: Stmt)(implicit lctx: LocalContext, flix: Flix): Stmt = stmt match {
-    case Stmt.Ret(expr, tpe, loc) => Stmt.Ret(visitExpr(expr), tpe, loc)
+  private def visitJvmMethod(method: JvmMethod)(implicit lctx: LocalContext, flix: Flix): JvmMethod = method match {
+    case JvmMethod(ident, fparams, clo, retTpe, purity, loc) =>
+      // JvmMethods are generated as their own functions so let-binding do not
+      // span across
+      JvmMethod(ident, fparams, visitExpr(clo), retTpe, purity, loc)
   }
 
   /**
@@ -183,7 +180,7 @@ object EffectBinder {
       val e = visitExprInnerWithBinders(binders)(exp)
       bindBinders(binders, e)
 
-    case Expr.NewObject(_, _, _, _, _, _, _) =>
+    case Expr.NewObject(_, _, _, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp)
       bindBinders(binders, e)
@@ -279,9 +276,9 @@ object EffectBinder {
       val es = exps.map(visitExprWithBinders(binders))
       Expr.Do(op, es, tpe, purity, loc)
 
-    case Expr.NewObject(name, clazz, tpe, purity, methods, exps, loc) =>
-      val es = exps.map(visitExprInnerWithBinders(binders))
-      Expr.NewObject(name, clazz, tpe, purity, methods, es, loc)
+    case Expr.NewObject(name, clazz, tpe, purity, methods, loc) =>
+      val ms = methods.map(visitJvmMethod)
+      Expr.NewObject(name, clazz, tpe, purity, ms, loc)
   }
 
   /**
@@ -320,7 +317,7 @@ object EffectBinder {
       case Expr.TryCatch(_, _, _, _, _) => letBindExpr(binders)(e)
       case Expr.TryWith(_, _, _, _, _, _) => letBindExpr(binders)(e)
       case Expr.Do(_, _, _, _, _) => letBindExpr(binders)(e)
-      case Expr.NewObject(_, _, _, _, _, _, _) => letBindExpr(binders)(e)
+      case Expr.NewObject(_, _, _, _, _, _) => letBindExpr(binders)(e)
     }
 
     bind(visitExprInnerWithBinders(binders)(exp))
@@ -333,7 +330,6 @@ object EffectBinder {
   private def letBindExpr(binders: mutable.ArrayBuffer[Binder])(e: Expr)(implicit lctx: LocalContext, flix: Flix): Expr.Var = {
     val loc = e.loc.asSynthetic
     val sym = Symbol.freshVarSym("anf", BoundBy.Let, loc)(Level.Default, flix)
-    lctx.lparams.addOne(LocalParam(sym, e.tpe))
     binders.addOne(LetBinder(sym, e, loc))
     Expr.Var(sym, e.tpe, loc)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -43,10 +43,10 @@ object Eraser {
   }
 
   private def visitDef(defn: Def): Def = defn match {
-    case Def(ann, mod, sym, cparams, fparams, exp, tpe, purity, loc) =>
+    case Def(ann, mod, sym, cparams, fparams, pcPoints, exp, tpe, purity, loc) =>
       val eNew = visitExp(exp)
       val e = Expr.ApplyAtomic(AtomicOp.Box, List(eNew), box(tpe), purity, loc)
-      Def(ann, mod, sym, cparams.map(visitParam), fparams.map(visitParam), e, box(tpe), purity, loc)
+      Def(ann, mod, sym, cparams.map(visitParam), fparams.map(visitParam), pcPoints, e, box(tpe), purity, loc)
   }
 
   private def visitParam(fp: FormalParam): FormalParam = fp match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Inliner.scala
@@ -83,7 +83,7 @@ object Inliner {
     val fparams = def0.fparams.map {
       case OccurrenceAst.FormalParam(sym, mod, tpe, loc) => LiftedAst.FormalParam(sym, mod, tpe, loc)
     }
-    LiftedAst.Def(def0.ann, def0.mod, def0.sym, cparams, fparams, convertedExp, def0.tpe, convertedExp.purity, def0.loc)
+    LiftedAst.Def(def0.ann, def0.mod, def0.sym, cparams, fparams, -1, convertedExp, def0.tpe, convertedExp.purity, def0.loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
@@ -51,7 +51,7 @@ object LambdaLift {
     case SimplifiedAst.Def(ann, mod, sym, fparams, exp, tpe, purity, loc) =>
       val fs = fparams.map(visitFormalParam)
       val e = visitExp(exp)(sym, ctx, flix)
-      LiftedAst.Def(ann, mod, sym, Nil, fs, e, tpe, purity, loc)
+      LiftedAst.Def(ann, mod, sym, Nil, fs, -1, e, tpe, purity, loc)
   }
 
   private def visitEnum(enum0: SimplifiedAst.Enum): LiftedAst.Enum = enum0 match {
@@ -105,7 +105,7 @@ object LambdaLift {
 
       // Construct a new definition.
       val defTpe = arrowTpe.result
-      val defn = LiftedAst.Def(ann, mod, freshSymbol, cs, fs, liftedExp, defTpe, liftedExp.purity, loc)
+      val defn = LiftedAst.Def(ann, mod, freshSymbol, cs, fs, -1, liftedExp, defTpe, liftedExp.purity, loc)
 
       // Add the new definition to the map of lifted definitions.
       ctx.liftedDefs.add(freshSymbol -> defn)

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -40,14 +40,14 @@ object Reducer {
   }
 
   private def visitDef(d: LiftedAst.Def)(implicit ctx: SharedContext): ReducedAst.Def = d match {
-    case LiftedAst.Def(ann, mod, sym, cparams, fparams, exp, tpe, purity, loc) =>
+    case LiftedAst.Def(ann, mod, sym, cparams, fparams, pcPoints, exp, tpe, purity, loc) =>
       implicit val lctx: LocalContext = LocalContext.mk()
       val cs = cparams.map(visitFormalParam)
       val fs = fparams.map(visitFormalParam)
       val e = visitExpr(exp)
       val ls = lctx.lparams.toList
       val stmt = ReducedAst.Stmt.Ret(e, e.tpe, e.loc)
-      ReducedAst.Def(ann, mod, sym, cs, fs, ls, 0, stmt, tpe, purity, loc)
+      ReducedAst.Def(ann, mod, sym, cs, fs, ls, pcPoints, stmt, tpe, purity, loc)
   }
 
   private def visitEnum(d: LiftedAst.Enum): ReducedAst.Enum = d match {


### PR DESCRIPTION
Related to #7011

This avoids the maintenance of the local parameters and moves it before the eraser

The pcPoints will be removed form Lifted again in the next PR where EffectBinder will introduce ReducedAst instead of Reducer