### PR TITLE
refactor: Align Lifted and Reduced Ast

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -16,7 +16,6 @@
 
 package ca.uwaterloo.flix.language.ast
 
-import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.Source
 import ca.uwaterloo.flix.language.ast.Purity.Pure
 
@@ -35,7 +34,7 @@ object ReducedAst {
                   reachable: Set[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
-  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], lparams: List[LocalParam], pcPoints: Int, stmt: Stmt, tpe: MonoType, purity: Purity, loc: SourceLocation) {
+  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], lparams: List[LocalParam], pcPoints: Int, expr: Expr, tpe: MonoType, purity: Purity, loc: SourceLocation) {
     var method: Method = _
     val arrowType: MonoType.Arrow = MonoType.Arrow(fparams.map(_.tpe), tpe)
   }
@@ -90,19 +89,7 @@ object ReducedAst {
 
     case class Do(op: Ast.OpSymUse, exps: List[Expr], tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class NewObject(name: String, clazz: java.lang.Class[_], tpe: MonoType, purity: Purity, methods: List[JvmMethod], exps: List[Expr], loc: SourceLocation) extends Expr
-
-  }
-
-  sealed trait Stmt {
-    def tpe: MonoType
-
-    def loc: SourceLocation
-  }
-
-  object Stmt {
-
-    case class Ret(expr: Expr, tpe: MonoType, loc: SourceLocation) extends Stmt
+    case class NewObject(name: String, clazz: java.lang.Class[_], tpe: MonoType, purity: Purity, methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
   }
 
@@ -110,7 +97,7 @@ object ReducedAst {
 
   case class Case(sym: Symbol.CaseSym, tpe: MonoType, loc: SourceLocation)
 
-  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], tpe: MonoType, purity: Purity, loc: SourceLocation)
+  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: MonoType, purity: Purity, loc: SourceLocation)
 
   case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[_], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
@@ -16,7 +16,7 @@
 
 package ca.uwaterloo.flix.language.dbg.printer
 
-import ca.uwaterloo.flix.language.ast.ReducedAst.{Expr, Stmt}
+import ca.uwaterloo.flix.language.ast.ReducedAst.Expr
 import ca.uwaterloo.flix.language.ast.{ReducedAst, Symbol}
 import ca.uwaterloo.flix.language.dbg.DocAst
 import ca.uwaterloo.flix.util.collection.MapOps
@@ -69,19 +69,12 @@ object ReducedAstPrinter {
     case Expr.TryCatch(exp, rules, _, _, _) => DocAst.Expression.TryCatch(print(exp), rules.map {
       case ReducedAst.CatchRule(sym, clazz, exp) => (sym, clazz, print(exp))
     })
-    case Expr.TryWith(exp, effUse, rules, _, _, _) => DocAst.Expression.TryWith(print(exp), effUse.sym, rules.map{
+    case Expr.TryWith(exp, effUse, rules, _, _, _) => DocAst.Expression.TryWith(print(exp), effUse.sym, rules.map {
       case ReducedAst.HandlerRule(op, fparams, exp) =>
         (op.sym, fparams.map(printFormalParam), print(exp))
     })
     case Expr.Do(op, exps, _, _, _) => DocAst.Expression.Do(op.sym, exps.map(print))
-    case Expr.NewObject(name, clazz, tpe, _, methods, exps, _) => DocAst.Expression.NewObject(name, clazz, MonoTypePrinter.print(tpe), methods.zip(exps).map(printJvmMethod))
-  }
-
-  /**
-    * Returns the [[DocAst.Expression]] representation of `stmt`.
-    */
-  def print(stmt: ReducedAst.Stmt): DocAst.Expression = stmt match {
-    case Stmt.Ret(expr, _, _) => DocAst.Expression.Ret(print(expr))
+    case Expr.NewObject(name, clazz, tpe, _, methods, _) => DocAst.Expression.NewObject(name, clazz, MonoTypePrinter.print(tpe), methods.map(printJvmMethod))
   }
 
   /**
@@ -101,7 +94,8 @@ object ReducedAstPrinter {
   /**
     * Returns the [[DocAst.JvmMethod]] representation of `method`.
     */
-  private def printJvmMethod(method: (ReducedAst.JvmMethod, ReducedAst.Expr)): DocAst.JvmMethod = method match {
-    case (m, clo) => DocAst.JvmMethod(m.ident, m.fparams map printFormalParam, print(clo), MonoTypePrinter.print(m.tpe))
+  private def printJvmMethod(method: ReducedAst.JvmMethod): DocAst.JvmMethod = method match {
+    case ReducedAst.JvmMethod(ident, fparams, exp, tpe, _, _) =>
+      DocAst.JvmMethod(ident, fparams map printFormalParam, print(exp), MonoTypePrinter.print(tpe))
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -46,8 +46,7 @@ object Reducer {
       val fs = fparams.map(visitFormalParam)
       val e = visitExpr(exp)
       val ls = lctx.lparams.toList
-      val stmt = ReducedAst.Stmt.Ret(e, e.tpe, e.loc)
-      ReducedAst.Def(ann, mod, sym, cs, fs, ls, 0, stmt, tpe, purity, loc)
+      ReducedAst.Def(ann, mod, sym, cs, fs, ls, 0, e, tpe, purity, loc)
   }
 
   private def visitEnum(d: LiftedAst.Enum): ReducedAst.Enum = d match {
@@ -154,15 +153,15 @@ object Reducer {
       ReducedAst.Expr.Do(op, es, tpe, purity, loc)
 
     case LiftedAst.Expr.NewObject(name, clazz, tpe, purity, methods, loc) =>
-      val es = methods.map(m => visitExpr(m.clo))
       val specs = methods.map {
-        case LiftedAst.JvmMethod(ident, fparams, _, retTpe, purity, loc) =>
+        case LiftedAst.JvmMethod(ident, fparams, clo, retTpe, purity, loc) =>
           val f = fparams.map(visitFormalParam)
-          ReducedAst.JvmMethod(ident, f, retTpe, purity, loc)
+          val c = visitExpr(clo)
+          ReducedAst.JvmMethod(ident, f, c, retTpe, purity, loc)
       }
       ctx.anonClasses.add(ReducedAst.AnonClass(name, clazz, tpe, specs, loc))
 
-      ReducedAst.Expr.NewObject(name, clazz, tpe, purity, specs, es, loc)
+      ReducedAst.Expr.NewObject(name, clazz, tpe, purity, specs, loc)
 
   }
 
@@ -213,7 +212,7 @@ object Reducer {
       }
 
       // Compute the types in the expression.
-      val expressionTypes = visitStmt(defn.stmt)
+      val expressionTypes = visitExp(defn.expr)
 
       // `defn.fparams` and `defn.tpe` are both included in `defn.arrowType`
 
@@ -254,8 +253,7 @@ object Reducer {
 
       case ReducedAst.Expr.Do(_, exps, tpe, _, _) => visitExps(exps) ++ Set(tpe)
 
-      case ReducedAst.Expr.NewObject(_, _, _, _, _, exps, _) =>
-        visitExps(exps)
+      case ReducedAst.Expr.NewObject(_, _, _, _, methods, _) => visitExps(methods.map(_.exp))
 
       case ReducedAst.Expr.ApplyAtomic(_, exps, tpe, _, _) => visitExps(exps) + tpe
 
@@ -265,10 +263,6 @@ object Reducer {
       exps.foldLeft(Set.empty[MonoType]) {
         case (sacc, e) => sacc ++ visitExp(e)
       }
-    }
-
-    def visitStmt(s: ReducedAst.Stmt): Set[MonoType] = s match {
-      case ReducedAst.Stmt.Ret(e, tpe, loc) => visitExp(e)
     }
 
     // Visit every definition.

--- a/main/src/ca/uwaterloo/flix/language/phase/VarOffsets.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/VarOffsets.scala
@@ -55,11 +55,7 @@ object VarOffsets {
     }
 
     // Compute stack offset for the body.
-    visitStm(defn.stmt, offset)
-  }
-
-  private def visitStm(stmt: Stmt, i0: Int): Int = stmt match {
-    case Stmt.Ret(e, _, _) => visitExp(e, i0)
+    visitExp(defn.expr, offset)
   }
 
   private def visitExp(e0: Expr, i0: Int): Int = e0 match {
@@ -123,7 +119,7 @@ object VarOffsets {
     case Expr.Do(_, exps, _, _, _) =>
       visitExps(exps, i0)
 
-    case Expr.NewObject(_, _, _, _, _, _, _) =>
+    case Expr.NewObject(_, _, _, _, _, _) =>
       // The expressions in NewObject are not executed here (concretely they're
       // always closures) and should not have var offsets here.
       // They don't contain binders so visiting them does nothing.

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -36,7 +36,7 @@ object Verifier {
       case (macc, fparam) => macc + (fparam.sym -> fparam.tpe)
     }
     try {
-      visitStmt(decl.stmt)(root, env, Map.empty)
+      visitExpr(decl.expr)(root, env, Map.empty)
     } catch {
       case UnexpectedType(expected, found, loc) =>
         println(s"Unexpected type near ${loc.format}")
@@ -321,15 +321,10 @@ object Verifier {
       // TODO: VERIFIER: Add support for Do.
       tpe
 
-    case Expr.NewObject(name, clazz, tpe, methods, _, _, loc) =>
+    case Expr.NewObject(name, clazz, tpe, methods, _, loc) =>
       // TODO: VERIFIER: Add support for NewObject.
       tpe
 
-  }
-
-  private def visitStmt(stmt: ReducedAst.Stmt)(implicit root: Root, env: Map[Symbol.VarSym, MonoType], lenv: Map[Symbol.LabelSym, MonoType]): MonoType = stmt match {
-    case Stmt.Ret(expr, tpe, loc) =>
-      visitExpr(expr)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -117,7 +117,7 @@ object GenAnonymousClasses {
     * Method
     */
   private def compileMethod(currentClass: JvmType.Reference, method: JvmMethod, cloName: String, classVisitor: ClassWriter): Unit = method match {
-    case JvmMethod(ident, fparams, tpe, _, _) =>
+    case JvmMethod(ident, fparams, _, tpe, _, _) =>
       val erasedArgs = fparams.map(_.tpe).map(JvmOps.getErasedJvmType)
       val boxedResult = JvmType.Object
       val closureAbstractClass = JvmOps.getClosureAbstractClassType(erasedArgs, boxedResult)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -1519,7 +1519,8 @@ object GenExpression {
       mv.visitLabel(afterUnboxing)
       AsmOps.castIfNotPrim(mv, JvmOps.getJvmType(tpe))
 
-    case Expr.NewObject(name, _, _, _, _, exps, _) =>
+    case Expr.NewObject(name, _, _, _, methods, _) =>
+      val exps = methods.map(_.exp)
       val className = JvmName(ca.uwaterloo.flix.language.phase.jvm.JvmName.RootPackage, name).toInternalName
       mv.visitTypeInsn(NEW, className)
       mv.visitInsn(DUP)
@@ -1560,13 +1561,6 @@ object GenExpression {
       case BackendType.Float32 => mv.visitIntInsn(NEWARRAY, T_FLOAT)
       case BackendType.Float64 => mv.visitIntInsn(NEWARRAY, T_DOUBLE)
     }
-  }
-
-  /**
-    * Emits code for the given statement `stmt0` to the given method `visitor` in the `currentClass`.
-    */
-  def compileStmt(stmt0: Stmt)(implicit mv: MethodVisitor, ctx: MethodContext, root: Root, flix: Flix): Unit = stmt0 match {
-    case Stmt.Ret(e, _, _) => compileExpr(e)
   }
 
   private def visitComparisonPrologue(exp1: Expr, exp2: Expr)(implicit mv: MethodVisitor, ctx: MethodContext, root: Root, flix: Flix): (Label, Label) = {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -243,7 +243,7 @@ object GenFunAndClosureClasses {
         POP()
     }
     val ctx = GenExpression.MethodContext(classType, enterLabel, Map(), newFrame, setPc, localOffset, pcLabels.prepended(null), Array(0))
-    GenExpression.compileStmt(defn.stmt)(m, ctx, root, flix)
+    GenExpression.compileExpr(defn.expr)(m, ctx, root, flix)
     assert(ctx.pcCounter(0) == pcLabels.size, s"${(classType.name, ctx.pcCounter(0), pcLabels.size)}")
 
     val returnValue = BytecodeInstructions.xReturn(BackendObjType.Result.toTpe)


### PR DESCRIPTION
Related to #7011
Stmt is removed from ReducedAst and expressions are handled consistently in JvmMethod