### PR TITLE
refactor: clean up `getFunctionInterfaceType`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -564,21 +564,12 @@ object BackendObjType {
       mkDescriptor(StringBuilder.toTpe)(String.toTpe))
   }
 
-  // case object SchemaEmpty extends BackendObjType
-
-  //  case class SchemaExtend(name: String, tpe: BackendType, rest: BackendType) extends BackendObjType
-
-  //  case class Relation(tpes: List[BackendType]) extends BackendObjType
-
-  //  case class Lattice(tpes: List[BackendType]) extends BackendObjType
-
   /**
     * Represents a JVM type not represented in BackendObjType.
     * This should not be used for `java.lang.String` for example since `BackendObjType.String`
     * represents this type.
     */
   case class Native(className: JvmName) extends BackendObjType
-
 
   case object ReifiedSourceLocation extends BackendObjType with Generatable {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenAnonymousClasses.scala
@@ -118,10 +118,11 @@ object GenAnonymousClasses {
     */
   private def compileMethod(currentClass: JvmType.Reference, method: JvmMethod, cloName: String, classVisitor: ClassWriter): Unit = method match {
     case JvmMethod(ident, fparams, tpe, _, _) =>
-      val erasedArgs = fparams.map(_.tpe).map(JvmOps.getErasedJvmType)
-      val boxedResult = JvmType.Object
-      val closureAbstractClass = JvmOps.getClosureAbstractClassType(erasedArgs, boxedResult)
-      val functionInterface = JvmOps.getFunctionInterfaceType(erasedArgs, boxedResult)
+      val args = fparams.map(_.tpe)
+      val boxedResult = MonoType.Object
+      val arrowType = MonoType.Arrow(args, boxedResult)
+      val closureAbstractClass = JvmOps.getClosureAbstractClassType(arrowType)
+      val functionInterface = JvmOps.getFunctionInterfaceType(arrowType)
 
       // Create the field that will store the closure implementing the body of the method
       AsmOps.compileField(classVisitor, cloName, closureAbstractClass, isStatic = false, isPrivate = false, isVolatile = false)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -136,31 +136,10 @@ object JvmOps {
     */
   def getFunctionInterfaceType(tpe: MonoType): JvmType.Reference = tpe match {
     case MonoType.Arrow(targs, tresult) =>
-      getFunctionInterfaceType(targs.map(getErasedJvmType), asErasedJvmType(tresult))
+      val arrowType = BackendObjType.Arrow(targs.map(BackendType.toErasedBackendType), BackendType.asErasedBackendType(tresult))
+      JvmType.Reference(arrowType.jvmName)
     case _ =>
       throw InternalCompilerException(s"Unexpected type: '$tpe'.", SourceLocation.Unknown)
-  }
-
-  /**
-    * Returns the function abstract class type `FnX$Y$Z` for the given types.
-    *
-    * For example:
-    *
-    * (Int)(Int)          =>  Fn2$Int$Int
-    * (Int, String)(Int)   =>  Fn3$Int$Obj$Int
-    */
-  def getFunctionInterfaceType(args: List[JvmType], res: JvmType): JvmType.Reference = {
-    getFunctionInterfaceType(args.map(_.toErased).map(stringify), stringify(res.toErased))
-  }
-
-  /**
-    * The JVM name is of the form `FnArity$argTypes0$argTypes1$..$resType`
-    */
-  private def getFunctionInterfaceType(argTypes: List[String], resType: String): JvmType.Reference = {
-    val arity = argTypes.length
-    val typeStrings = argTypes :+ resType
-    val name = JvmName.mkClassName(s"Fn$arity", typeStrings)
-    JvmType.Reference(JvmName(RootPackage, name))
   }
 
   /**


### PR DESCRIPTION
The logic is duplicated in JvmOps and BackendObjectType so now its not