### PR TITLE
refactor: move ReducedAst up two phases

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -109,8 +109,8 @@ class Flix {
   private var cachedTailrecAst: LiftedAst.Root = LiftedAst.empty
   private var cachedOptimizerAst: LiftedAst.Root = LiftedAst.empty
   private var cachedTreeShaker2Ast: LiftedAst.Root = LiftedAst.empty
-  private var cachedEffectBinderAst: LiftedAst.Root = LiftedAst.empty
-  private var cachedEraserAst: LiftedAst.Root = LiftedAst.empty
+  private var cachedEffectBinderAst: ReducedAst.Root = ReducedAst.empty
+  private var cachedEraserAst: ReducedAst.Root = ReducedAst.empty
   private var cachedReducerAst: ReducedAst.Root = ReducedAst.empty
   private var cachedVarOffsetsAst: ReducedAst.Root = ReducedAst.empty
 
@@ -134,9 +134,9 @@ class Flix {
 
   def getTreeShaker2Ast: LiftedAst.Root = cachedTreeShaker2Ast
 
-  def getEffectBinderAst: LiftedAst.Root = cachedEffectBinderAst
+  def getEffectBinderAst: ReducedAst.Root = cachedEffectBinderAst
 
-  def getEraserAst: LiftedAst.Root = cachedEraserAst
+  def getEraserAst: ReducedAst.Root = cachedEraserAst
 
   def getReducerAst: ReducedAst.Root = cachedReducerAst
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
@@ -61,8 +61,8 @@ object ShowAstProvider {
         case "Tailrec" => astObject(phase, AstPrinter.formatLiftedAst(flix.getTailrecAst))
         case "Optimizer" => astObject(phase, AstPrinter.formatLiftedAst(flix.getOptimizerAst))
         case "TreeShaker2" => astObject(phase, AstPrinter.formatLiftedAst(flix.getTreeShaker2Ast))
-        case "EffectBinder" => astObject(phase, AstPrinter.formatLiftedAst(flix.getEffectBinderAst))
-        case "Eraser" => astObject(phase, AstPrinter.formatLiftedAst(flix.getEraserAst))
+        case "EffectBinder" => astObject(phase, AstPrinter.formatReducedAst(flix.getEffectBinderAst))
+        case "Eraser" => astObject(phase, AstPrinter.formatReducedAst(flix.getEraserAst))
         case "Reducer" => astObject(phase, AstPrinter.formatReducedAst(flix.getReducerAst))
         case "VarOffsets" => astObject(phase, AstPrinter.formatReducedAst(flix.getVarOffsetsAst))
         case _ =>

--- a/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
@@ -31,7 +31,7 @@ object LiftedAst {
                   sources: Map[Source, SourceLocation])
 
   /** pcPoints are initialized in [[ca.uwaterloo.flix.language.phase.EffectBinder]] */
-  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], pcPoints: Int, exp: Expr, tpe: MonoType, purity: Purity, loc: SourceLocation)
+  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], exp: Expr, tpe: MonoType, purity: Purity, loc: SourceLocation)
 
   case class Enum(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, cases: Map[Symbol.CaseSym, Case], tpe: MonoType, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/AstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/AstPrinter.scala
@@ -66,8 +66,8 @@ object AstPrinter {
       if (asts.contains("Tailrec")) writeToDisk("Tailrec", formatLiftedAst(flix.getTailrecAst))
       if (asts.contains("Optimizer")) writeToDisk("Optimizer", formatLiftedAst(flix.getOptimizerAst))
       if (asts.contains("TreeShaker2")) writeToDisk("TreeShaker2", formatLiftedAst(flix.getTreeShaker2Ast))
-      if (asts.contains("EffectBinder")) writeToDisk("EffectBinder", formatLiftedAst(flix.getEffectBinderAst))
-      if (asts.contains("Eraser")) writeToDisk("Eraser", formatLiftedAst(flix.getEraserAst))
+      if (asts.contains("EffectBinder")) writeToDisk("EffectBinder", formatReducedAst(flix.getEffectBinderAst))
+      if (asts.contains("Eraser")) writeToDisk("Eraser", formatReducedAst(flix.getEraserAst))
       if (asts.contains("Reducer")) writeToDisk("Reducer", formatReducedAst(flix.getReducerAst))
       if (asts.contains("VarOffsets")) writeToDisk("VarOffsets", formatReducedAst(flix.getVarOffsetsAst))
       if (asts.contains("JvmBackend")) () // wip
@@ -111,8 +111,8 @@ object AstPrinter {
     writeToDisk("Tailrec", formatLiftedAst(flix.getTailrecAst))
     writeToDisk("Optimizer", formatLiftedAst(flix.getOptimizerAst))
     writeToDisk("TreeShaker2", formatLiftedAst(flix.getTreeShaker2Ast))
-    writeToDisk("EffectBinder", formatLiftedAst(flix.getEffectBinderAst))
-    writeToDisk("Eraser", formatLiftedAst(flix.getEraserAst))
+    writeToDisk("EffectBinder", formatReducedAst(flix.getEffectBinderAst))
+    writeToDisk("Eraser", formatReducedAst(flix.getEraserAst))
     writeToDisk("Reducer", formatReducedAst(flix.getReducerAst))
     writeToDisk("VarOffsets", formatReducedAst(flix.getVarOffsetsAst))
   }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
@@ -36,7 +36,7 @@ object LiftedAstPrinter {
         DocAst.Enum(ann, mod, sym, Nil, cases)
     }.toList
     val defs = root.defs.values.map {
-      case LiftedAst.Def(ann, mod, sym, cparams, fparams, _, exp, tpe, purity, _) =>
+      case LiftedAst.Def(ann, mod, sym, cparams, fparams, exp, tpe, purity, _) =>
         DocAst.Def(
           ann,
           mod,

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -18,11 +18,11 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.{BoundBy, CallType}
-import ca.uwaterloo.flix.language.ast.LiftedAst._
 import ca.uwaterloo.flix.language.ast.Symbol.{DefnSym, VarSym}
-import ca.uwaterloo.flix.language.ast.{AtomicOp, Level, Purity, SemanticOp, SourceLocation, Symbol}
+import ca.uwaterloo.flix.language.ast.{AtomicOp, Level, LiftedAst, Purity, ReducedAst, SemanticOp, SourceLocation, Symbol}
 import ca.uwaterloo.flix.language.phase.jvm.GenExpression
 import ca.uwaterloo.flix.util.ParOps
+import ca.uwaterloo.flix.util.collection.MapOps
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -48,9 +48,11 @@ object EffectBinder {
     * Transforms the AST such that effect operations will be run without an
     * operand stack.
     */
-  def run(root: Root)(implicit flix: Flix): Root = flix.phase("EffectBinder") {
+  def run(root: LiftedAst.Root)(implicit flix: Flix): ReducedAst.Root = flix.phase("EffectBinder") {
     val newDefs = ParOps.parMapValues(root.defs)(visitDef)
-    root.copy(defs = newDefs)
+    val newEnums = ParOps.parMapValues(root.enums)(visitEnum)
+    val newEffects = ParOps.parMapValues(root.effects)(visitEffect)
+    ReducedAst.Root(newDefs, newEnums, newEffects, Set.empty, Nil, root.entryPoint, root.reachable, root.sources)
   }
 
   /**
@@ -67,127 +69,164 @@ object EffectBinder {
 
   private sealed trait Binder
 
-  private case class LetBinder(sym: VarSym, exp: Expr, loc: SourceLocation) extends Binder
+  private case class LetBinder(sym: VarSym, exp: ReducedAst.Expr, loc: SourceLocation) extends Binder
 
-  private case class LetRecBinder(varSym: VarSym, index: Int, defSym: DefnSym, exp: Expr, loc: SourceLocation) extends Binder
+  private case class LetRecBinder(varSym: VarSym, index: Int, defSym: DefnSym, exp: ReducedAst.Expr, loc: SourceLocation) extends Binder
 
   /**
-    * Transforms the [[Def]] such that effect operations will be run without an
+    * Transforms the [[LiftedAst.Def]] such that effect operations will be run without an
     * operand stack.
     */
-  private def visitDef(defn: Def)(implicit flix: Flix): Def = {
-    implicit val lctx: LocalContext = LocalContext.mk()
-    val exp = visitExpr(defn.exp)
-    defn.copy(exp = exp, pcPoints = lctx.pcPoints)
+  private def visitDef(defn: LiftedAst.Def)(implicit flix: Flix): ReducedAst.Def = defn match {
+    case LiftedAst.Def(ann, mod, sym, cparams0, fparams0, exp0, tpe, purity, loc) =>
+      implicit val lctx: LocalContext = LocalContext.mk()
+      val cparams = cparams0.map(visitParam)
+      val fparams = fparams0.map(visitParam)
+      val lparams = Nil
+      val exp = visitExpr(exp0)
+      // OBS lctx.pcPoints is mutated by visitExpr
+      val pcPoints = lctx.pcPoints
+      ReducedAst.Def(ann, mod, sym, cparams, fparams, lparams, pcPoints, exp, tpe, purity, loc)
   }
 
-  private def visitJvmMethod(method: JvmMethod)(implicit lctx: LocalContext, flix: Flix): JvmMethod = method match {
-    case JvmMethod(ident, fparams, clo, retTpe, purity, loc) =>
+  private def visitEnum(e: LiftedAst.Enum): ReducedAst.Enum = e match {
+    case LiftedAst.Enum(ann, mod, sym, cases0, tpe, loc) =>
+      val cases = MapOps.mapValues(cases0)(visitCase)
+      ReducedAst.Enum(ann, mod, sym, cases, tpe, loc)
+  }
+
+  private def visitCase(c: LiftedAst.Case): ReducedAst.Case = c match {
+    case LiftedAst.Case(sym, tpe, loc) =>
+      ReducedAst.Case(sym, tpe, loc)
+  }
+
+  private def visitEffect(e: LiftedAst.Effect): ReducedAst.Effect = e match {
+    case LiftedAst.Effect(ann, mod, sym, ops0, loc) =>
+      val ops = ops0.map(visitOp)
+      ReducedAst.Effect(ann, mod, sym, ops, loc)
+  }
+
+  private def visitOp(op: LiftedAst.Op): ReducedAst.Op = op match {
+    case LiftedAst.Op(sym, ann, mod, fparams0, tpe, purity, loc) =>
+      val fparams = fparams0.map(visitParam)
+      ReducedAst.Op(sym, ann, mod, fparams, tpe, purity, loc)
+  }
+
+  private def visitParam(p: LiftedAst.FormalParam): ReducedAst.FormalParam = p match {
+    case LiftedAst.FormalParam(sym, mod, tpe, loc) =>
+      ReducedAst.FormalParam(sym, mod, tpe, loc)
+  }
+
+  private def visitJvmMethod(method: LiftedAst.JvmMethod)(implicit lctx: LocalContext, flix: Flix): ReducedAst.JvmMethod = method match {
+    case LiftedAst.JvmMethod(ident, fparams0, clo0, retTpe, purity, loc) =>
       // JvmMethods are generated as their own functions so let-binding do not
       // span across
-      JvmMethod(ident, fparams, visitExpr(clo), retTpe, purity, loc)
+      val fparams = fparams0.map(visitParam)
+      val clo = visitExpr(clo0)
+      ReducedAst.JvmMethod(ident, fparams, clo, retTpe, purity, loc)
   }
 
   /**
-    * Transforms the [[Expr]] such that effect operations will be run without an
-    * operand stack - binding necessary expressions in the returned [[Expr]].
+    * Transforms the [[LiftedAst.Expr]] such that effect operations will be run without an
+    * operand stack - binding necessary expressions in the returned [[ReducedA.Expr]].
     *
     * Updates [[LocalContext.pcPoints]] only for expressions not given to [[visitExprInnerWithBinders]].
     */
-  private def visitExpr(exp: Expr)(implicit lctx: LocalContext, flix: Flix): Expr = exp match {
-    case Expr.Cst(_, _, _) =>
+  private def visitExpr(exp: LiftedAst.Expr)(implicit lctx: LocalContext, flix: Flix): ReducedAst.Expr = exp match {
+    case LiftedAst.Expr.Cst(_, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp)
       bindBinders(binders, e)
 
-    case Expr.Var(_, _, _) =>
+    case LiftedAst.Expr.Var(_, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp)
       bindBinders(binders, e)
 
-    case Expr.ApplyAtomic(_, _, _, _, _) =>
+    case LiftedAst.Expr.ApplyAtomic(_, _, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp)
       bindBinders(binders, e)
 
-    case Expr.ApplyClo(_, _, _, _, _, _) =>
+    case LiftedAst.Expr.ApplyClo(_, _, _, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp)
       bindBinders(binders, e)
 
-    case Expr.ApplyDef(_, _, _, _, _, _) =>
+    case LiftedAst.Expr.ApplyDef(_, _, _, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp)
       bindBinders(binders, e)
 
-    case Expr.ApplySelfTail(_, _, _, _, _, _) =>
+    case LiftedAst.Expr.ApplySelfTail(_, _, _, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp)
       bindBinders(binders, e)
 
-    case Expr.IfThenElse(_, _, _, _, _, _) =>
+    case LiftedAst.Expr.IfThenElse(_, _, _, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp)
       bindBinders(binders, e)
 
-    case Expr.Branch(exp, branches, tpe, purity, loc) =>
-      val e = visitExpr(exp)
-      val branches1 = branches.map {
-        case (sym, branchExp) => (sym, visitExpr(branchExp))
-      }
-      Expr.Branch(e, branches1, tpe, purity, loc)
+    case LiftedAst.Expr.Branch(exp0, branches0, tpe, purity, loc) =>
+      val exp = visitExpr(exp0)
+      val branches = MapOps.mapValues(branches0)(visitExpr)
+      ReducedAst.Expr.Branch(exp, branches, tpe, purity, loc)
 
-    case Expr.JumpTo(_, _, _, _) =>
+    case LiftedAst.Expr.JumpTo(_, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp)
       bindBinders(binders, e)
 
-    case Expr.Let(sym, exp1, exp2, tpe, purity, loc) =>
+    case LiftedAst.Expr.Let(sym, exp1, exp2, tpe, purity, loc) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e1 = visitExprInnerWithBinders(binders)(exp1)
       val e2 = visitExpr(exp2)
-      val e = Expr.Let(sym, e1, e2, tpe, purity, loc)
+      val e = ReducedAst.Expr.Let(sym, e1, e2, tpe, purity, loc)
       bindBinders(binders, e)
 
-    case Expr.LetRec(varSym, index, defSym, exp1, exp2, tpe, purity, loc) =>
+    case LiftedAst.Expr.LetRec(varSym, index, defSym, exp1, exp2, tpe, purity, loc) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e1 = visitExprInnerWithBinders(binders)(exp1)
       val e2 = visitExpr(exp2)
-      val e = Expr.LetRec(varSym, index, defSym, e1, e2, tpe, purity, loc)
+      val e = ReducedAst.Expr.LetRec(varSym, index, defSym, e1, e2, tpe, purity, loc)
       bindBinders(binders, e)
 
-    case Expr.Scope(sym, exp, tpe, purity, loc) =>
-      val e = visitExpr(exp)
-      Expr.Scope(sym, e, tpe, purity, loc)
+    case LiftedAst.Expr.Scope(sym, exp0, tpe, purity, loc) =>
+      val exp = visitExpr(exp0)
+      ReducedAst.Expr.Scope(sym, exp, tpe, purity, loc)
 
-    case Expr.TryCatch(exp, rules, tpe, purity, loc) =>
+    case LiftedAst.Expr.TryCatch(exp, rules, tpe, purity, loc) =>
       val e = visitExpr(exp)
       val rules1 = rules.map {
-        case cr => CatchRule(cr.sym, cr.clazz, visitExpr(cr.exp))
+        case cr => ReducedAst.CatchRule(cr.sym, cr.clazz, visitExpr(cr.exp))
       }
-      Expr.TryCatch(e, rules1, tpe, purity, loc)
+      ReducedAst.Expr.TryCatch(e, rules1, tpe, purity, loc)
 
-    case Expr.TryWith(exp, effUse, rules, tpe, purity, loc) =>
+    case LiftedAst.Expr.TryWith(exp, effUse, rules, tpe, purity, loc) =>
       lctx.pcPoints += 1 // added here since visitInner will not see this try-with
       val e = visitExpr(exp)
       val rules1 = rules.map {
-        case hr => hr.copy(exp = visitExpr(hr.exp))
+        case LiftedAst.HandlerRule(op, fparams0, exp0) =>
+          val fparams = fparams0.map(visitParam)
+          val exp = visitExpr(exp0)
+          ReducedAst.HandlerRule(op, fparams, exp)
       }
-      Expr.TryWith(e, effUse, rules1, tpe, purity, loc)
+      ReducedAst.Expr.TryWith(e, effUse, rules1, tpe, purity, loc)
 
-    case Expr.Do(_, _, _, _, _) =>
+    case LiftedAst.Expr.Do(_, _, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp)
       bindBinders(binders, e)
 
-    case Expr.NewObject(_, _, _, _, _, _) =>
+    case LiftedAst.Expr.NewObject(_, _, _, _, _, _) =>
       val binders = mutable.ArrayBuffer.empty[Binder]
       val e = visitExprInnerWithBinders(binders)(exp)
       bindBinders(binders, e)
   }
 
   /**
-    * Transforms the [[Expr]] such that effect operations will be run without an
+    * Transforms the [[LiftedAst.Expr]] such that effect operations will be run without an
     * operand stack. The outer-most expression IS NOT let-bound but all
     * sub-expressions will be. `do E(x, y, z)` might be returned.
     *
@@ -196,154 +235,164 @@ object EffectBinder {
     *
     * Updates [[LocalContext.pcPoints]] as required.
     */
-  private def visitExprInnerWithBinders(binders: mutable.ArrayBuffer[Binder])(exp: Expr)(implicit lctx: LocalContext, flix: Flix): Expr = exp match {
-    case Expr.Cst(cst, tpe, loc) =>
-      Expr.Cst(cst, tpe, loc)
+  private def visitExprInnerWithBinders(binders: mutable.ArrayBuffer[Binder])(exp: LiftedAst.Expr)(implicit lctx: LocalContext, flix: Flix): ReducedAst.Expr = exp match {
+    case LiftedAst.Expr.Cst(cst, tpe, loc) =>
+      ReducedAst.Expr.Cst(cst, tpe, loc)
 
-    case Expr.Var(sym, tpe, loc) =>
-      Expr.Var(sym, tpe, loc)
+    case LiftedAst.Expr.Var(sym, tpe, loc) =>
+      ReducedAst.Expr.Var(sym, tpe, loc)
 
-    case Expr.ApplyAtomic(op@AtomicOp.Binary(SemanticOp.BoolOp.And | SemanticOp.BoolOp.Or), exps, tpe, purity, loc) =>
+    case LiftedAst.Expr.ApplyAtomic(op@AtomicOp.Binary(SemanticOp.BoolOp.And | SemanticOp.BoolOp.Or), exps, tpe, purity, loc) =>
       // And and Or does not leave the first argument on the stack in genExpression.
       val List(exp1, exp2) = exps
       val e1 = visitExprWithBinders(binders)(exp1)
       val e2 = visitExpr(exp2)
-      Expr.ApplyAtomic(op, List(e1, e2), tpe, purity, loc)
+      ReducedAst.Expr.ApplyAtomic(op, List(e1, e2), tpe, purity, loc)
 
-    case Expr.ApplyAtomic(op, exps, tpe, purity, loc) =>
+    case LiftedAst.Expr.ApplyAtomic(op, exps, tpe, purity, loc) =>
       val es = exps.map(visitExprWithBinders(binders))
-      Expr.ApplyAtomic(op, es, tpe, purity, loc)
+      ReducedAst.Expr.ApplyAtomic(op, es, tpe, purity, loc)
 
-    case Expr.ApplyClo(exp, exps, ct, tpe, purity, loc) =>
+    case LiftedAst.Expr.ApplyClo(exp, exps, ct, tpe, purity, loc) =>
       if (ct == CallType.NonTailCall && purity != Purity.Pure) lctx.pcPoints += 1
       val e = visitExprWithBinders(binders)(exp)
       val es = exps.map(visitExprWithBinders(binders))
-      Expr.ApplyClo(e, es, ct, tpe, purity, loc)
+      ReducedAst.Expr.ApplyClo(e, es, ct, tpe, purity, loc)
 
-    case Expr.ApplyDef(sym, exps, ct, tpe, purity, loc) =>
+    case LiftedAst.Expr.ApplyDef(sym, exps, ct, tpe, purity, loc) =>
       if (ct == CallType.NonTailCall && purity != Purity.Pure) lctx.pcPoints += 1
       val es = exps.map(visitExprWithBinders(binders))
-      Expr.ApplyDef(sym, es, ct, tpe, purity, loc)
+      ReducedAst.Expr.ApplyDef(sym, es, ct, tpe, purity, loc)
 
-    case Expr.ApplySelfTail(sym, formals, actuals, tpe, purity, loc) =>
-      val as = actuals.map(visitExprWithBinders(binders))
-      Expr.ApplySelfTail(sym, formals, as, tpe, purity, loc)
+    case LiftedAst.Expr.ApplySelfTail(sym, formals0, actuals0, tpe, purity, loc) =>
+      val formals = formals0.map(visitParam)
+      val actuals = actuals0.map(visitExprWithBinders(binders))
+      ReducedAst.Expr.ApplySelfTail(sym, formals, actuals, tpe, purity, loc)
 
-    case Expr.IfThenElse(exp1, exp2, exp3, tpe, purity, loc) =>
+    case LiftedAst.Expr.IfThenElse(exp1, exp2, exp3, tpe, purity, loc) =>
       val e1 = visitExprInnerWithBinders(binders)(exp1)
       val e2 = visitExpr(exp2)
       val e3 = visitExpr(exp3)
-      Expr.IfThenElse(e1, e2, e3, tpe, purity, loc)
+      ReducedAst.Expr.IfThenElse(e1, e2, e3, tpe, purity, loc)
 
-    case Expr.Branch(exp, branches, tpe, purity, loc) =>
+    case LiftedAst.Expr.Branch(exp, branches, tpe, purity, loc) =>
       val e = visitExpr(exp)
       val bs = branches.map {
         case (sym, branchExp) => (sym, visitExpr(branchExp))
       }
-      Expr.Branch(e, bs, tpe, purity, loc)
+      ReducedAst.Expr.Branch(e, bs, tpe, purity, loc)
 
-    case Expr.JumpTo(sym, tpe, purity, loc) =>
-      Expr.JumpTo(sym, tpe, purity, loc)
+    case LiftedAst.Expr.JumpTo(sym, tpe, purity, loc) =>
+      ReducedAst.Expr.JumpTo(sym, tpe, purity, loc)
 
-    case Expr.Let(sym, exp1, exp2, _, _, loc) =>
+    case LiftedAst.Expr.Let(sym, exp1, exp2, _, _, loc) =>
       val e1 = visitExprInnerWithBinders(binders)(exp1)
       binders.addOne(LetBinder(sym, e1, loc))
       visitExprInnerWithBinders(binders)(exp2)
 
-    case Expr.LetRec(varSym, index, defSym, exp1, exp2, _, _, loc) =>
+    case LiftedAst.Expr.LetRec(varSym, index, defSym, exp1, exp2, _, _, loc) =>
       val e1 = visitExprInnerWithBinders(binders)(exp1)
       binders.addOne(LetRecBinder(varSym, index, defSym, e1, loc))
       visitExprInnerWithBinders(binders)(exp2)
 
-    case Expr.Scope(sym, exp, tpe, purity, loc) =>
+    case LiftedAst.Expr.Scope(sym, exp, tpe, purity, loc) =>
       val e = visitExpr(exp)
-      Expr.Scope(sym, e, tpe, purity, loc)
+      ReducedAst.Expr.Scope(sym, e, tpe, purity, loc)
 
-    case Expr.TryCatch(exp, rules, tpe, purity, loc) =>
+    case LiftedAst.Expr.TryCatch(exp, rules0, tpe, purity, loc) =>
       val e = visitExpr(exp)
-      Expr.TryCatch(e, rules, tpe, purity, loc)
+      val rules = rules0.map {
+        case LiftedAst.CatchRule(sym, clazz, exp0) =>
+          // assumes that catch rule is control pure
+          val exp = visitExpr(exp0)
+          ReducedAst.CatchRule(sym, clazz, exp)
+      }
+      ReducedAst.Expr.TryCatch(e, rules, tpe, purity, loc)
 
-    case Expr.TryWith(exp, effUse, rules, tpe, purity, loc) =>
+    case LiftedAst.Expr.TryWith(exp, effUse, rules, tpe, purity, loc) =>
       lctx.pcPoints += 1
       val e = visitExpr(exp)
       val rs = rules.map {
-        case HandlerRule(op, fparams, handlerExp) => HandlerRule(op, fparams, visitExpr(handlerExp))
+        case LiftedAst.HandlerRule(op, fparams0, exp0) =>
+          val fparams = fparams0.map(visitParam)
+          val exp = visitExpr(exp0)
+          ReducedAst.HandlerRule(op, fparams, exp)
       }
-      Expr.TryWith(e, effUse, rs, tpe, purity, loc)
+      ReducedAst.Expr.TryWith(e, effUse, rs, tpe, purity, loc)
 
-    case Expr.Do(op, exps, tpe, purity, loc) =>
+    case LiftedAst.Expr.Do(op, exps, tpe, purity, loc) =>
       lctx.pcPoints += 1
       val es = exps.map(visitExprWithBinders(binders))
-      Expr.Do(op, es, tpe, purity, loc)
+      ReducedAst.Expr.Do(op, es, tpe, purity, loc)
 
-    case Expr.NewObject(name, clazz, tpe, purity, methods, loc) =>
+    case LiftedAst.Expr.NewObject(name, clazz, tpe, purity, methods, loc) =>
       val ms = methods.map(visitJvmMethod)
-      Expr.NewObject(name, clazz, tpe, purity, ms, loc)
+      ReducedAst.Expr.NewObject(name, clazz, tpe, purity, ms, loc)
   }
 
   /**
-    * Transforms the [[Expr]] such that effect operations will be run without an
+    * Transforms the [[LiftedAst.Expr]] such that effect operations will be run without an
     * operand stack. The outer-most expression IS let-bound along with all
     * sub-expressions. A variable or a constant is always returned.
     *
     * Necessary bindings are added to binders, where the first binder is the
     * outermost one.
     */
-  private def visitExprWithBinders(binders: mutable.ArrayBuffer[Binder])(exp: Expr)(implicit lctx: LocalContext, flix: Flix): Expr = {
+  private def visitExprWithBinders(binders: mutable.ArrayBuffer[Binder])(exp: LiftedAst.Expr)(implicit lctx: LocalContext, flix: Flix): ReducedAst.Expr = {
     /**
       * Let-binds the given expression, unless its a variable or constant.
       * If the given argument is a binder, then the structure is flattened.
       */
     @tailrec
-    def bind(e: Expr): Expr = e match {
+    def bind(e: ReducedAst.Expr): ReducedAst.Expr = e match {
       // trivial expressions
-      case Expr.Cst(_, _, _) => e
-      case Expr.Var(_, _, _) => e
-      case Expr.JumpTo(_, _, _, _) => e
-      case Expr.ApplyAtomic(_, _, _, _, _) => e
+      case ReducedAst.Expr.Cst(_, _, _) => e
+      case ReducedAst.Expr.Var(_, _, _) => e
+      case ReducedAst.Expr.JumpTo(_, _, _, _) => e
+      case ReducedAst.Expr.ApplyAtomic(_, _, _, _, _) => e
       // non-trivial expressions
-      case Expr.ApplyClo(_, _, _, _, _, _) => letBindExpr(binders)(e)
-      case Expr.ApplyDef(_, _, _, _, _, _) => letBindExpr(binders)(e)
-      case Expr.ApplySelfTail(_, _, _, _, _, _) => letBindExpr(binders)(e)
-      case Expr.IfThenElse(_, _, _, _, _, _) => letBindExpr(binders)(e)
-      case Expr.Branch(_, _, _, _, _) => letBindExpr(binders)(e)
-      case Expr.Let(sym, exp1, exp2, _, _, loc) =>
+      case ReducedAst.Expr.ApplyClo(_, _, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Expr.ApplyDef(_, _, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Expr.ApplySelfTail(_, _, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Expr.IfThenElse(_, _, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Expr.Branch(_, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Expr.Let(sym, exp1, exp2, _, _, loc) =>
         binders.addOne(LetBinder(sym, exp1, loc))
         bind(exp2)
-      case Expr.LetRec(varSym, index, defSym, exp1, exp2, _, _, loc) =>
+      case ReducedAst.Expr.LetRec(varSym, index, defSym, exp1, exp2, _, _, loc) =>
         binders.addOne(LetRecBinder(varSym, index, defSym, exp1, loc))
         bind(exp2)
-      case Expr.Scope(_, _, _, _, _) => letBindExpr(binders)(e)
-      case Expr.TryCatch(_, _, _, _, _) => letBindExpr(binders)(e)
-      case Expr.TryWith(_, _, _, _, _, _) => letBindExpr(binders)(e)
-      case Expr.Do(_, _, _, _, _) => letBindExpr(binders)(e)
-      case Expr.NewObject(_, _, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Expr.Scope(_, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Expr.TryCatch(_, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Expr.TryWith(_, _, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Expr.Do(_, _, _, _, _) => letBindExpr(binders)(e)
+      case ReducedAst.Expr.NewObject(_, _, _, _, _, _) => letBindExpr(binders)(e)
     }
 
     bind(visitExprInnerWithBinders(binders)(exp))
   }
 
   /**
-    * Simply let-binds the given expression, adding a [[Expr.Let]] to binders.
+    * Simply let-binds the given expression, adding a [[ReducedAst.Expr.Let]] to binders.
     * The local params of [[LocalContext]] is updated with this new binder.
     */
-  private def letBindExpr(binders: mutable.ArrayBuffer[Binder])(e: Expr)(implicit lctx: LocalContext, flix: Flix): Expr.Var = {
+  private def letBindExpr(binders: mutable.ArrayBuffer[Binder])(e: ReducedAst.Expr)(implicit flix: Flix): ReducedAst.Expr.Var = {
     val loc = e.loc.asSynthetic
     val sym = Symbol.freshVarSym("anf", BoundBy.Let, loc)(Level.Default, flix)
     binders.addOne(LetBinder(sym, e, loc))
-    Expr.Var(sym, e.tpe, loc)
+    ReducedAst.Expr.Var(sym, e.tpe, loc)
   }
 
   /**
-    * Returns an [[Expr]] where the given binders is a chained [[Expr.Let]]
+    * Returns an [[ReducedAst.Expr]] where the given binders is a chained [[ReducedAst.Expr.Let]]
     * expression. The first binder will be the outer-most one.
     */
-  private def bindBinders(binders: mutable.ArrayBuffer[Binder], exp: Expr): Expr = {
+  private def bindBinders(binders: mutable.ArrayBuffer[Binder], exp: ReducedAst.Expr): ReducedAst.Expr = {
     binders.foldRight(exp) {
       case (LetBinder(sym, exp1, loc), acc) =>
-        Expr.Let(sym, exp1, acc, acc.tpe, combine(acc.purity, exp1.purity), loc)
+        ReducedAst.Expr.Let(sym, exp1, acc, acc.tpe, combine(acc.purity, exp1.purity), loc)
       case (LetRecBinder(varSym, index, defSym, exp1, loc), acc) =>
-        Expr.LetRec(varSym, index, defSym, exp1, acc, acc.tpe, combine(acc.purity, exp1.purity), loc)
+        ReducedAst.Expr.LetRec(varSym, index, defSym, exp1, acc, acc.tpe, combine(acc.purity, exp1.purity), loc)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Inliner.scala
@@ -83,7 +83,7 @@ object Inliner {
     val fparams = def0.fparams.map {
       case OccurrenceAst.FormalParam(sym, mod, tpe, loc) => LiftedAst.FormalParam(sym, mod, tpe, loc)
     }
-    LiftedAst.Def(def0.ann, def0.mod, def0.sym, cparams, fparams, -1, convertedExp, def0.tpe, convertedExp.purity, def0.loc)
+    LiftedAst.Def(def0.ann, def0.mod, def0.sym, cparams, fparams, convertedExp, def0.tpe, convertedExp.purity, def0.loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/LambdaLift.scala
@@ -51,7 +51,7 @@ object LambdaLift {
     case SimplifiedAst.Def(ann, mod, sym, fparams, exp, tpe, purity, loc) =>
       val fs = fparams.map(visitFormalParam)
       val e = visitExp(exp)(sym, ctx, flix)
-      LiftedAst.Def(ann, mod, sym, Nil, fs, -1, e, tpe, purity, loc)
+      LiftedAst.Def(ann, mod, sym, Nil, fs, e, tpe, purity, loc)
   }
 
   private def visitEnum(enum0: SimplifiedAst.Enum): LiftedAst.Enum = enum0 match {
@@ -105,7 +105,7 @@ object LambdaLift {
 
       // Construct a new definition.
       val defTpe = arrowTpe.result
-      val defn = LiftedAst.Def(ann, mod, freshSymbol, cs, fs, -1, liftedExp, defTpe, liftedExp.purity, loc)
+      val defn = LiftedAst.Def(ann, mod, freshSymbol, cs, fs, liftedExp, defTpe, liftedExp.purity, loc)
 
       // Add the new definition to the map of lifted definitions.
       ctx.liftedDefs.add(freshSymbol -> defn)


### PR DESCRIPTION
What does this achieve? good question

- Effect Binder introduces pcPoints to defs, which means that LiftedAst now doesn't have to know about that
- Reducer still introduces lparams, root.types, and root.anonclasses. So an argument can be made that reducedAst should be split into two

Could be really cool to have polymorphic records here