### PR TITLE
fix: tests always pass

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -34,7 +34,7 @@ object ReducedAst {
                   reachable: Set[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation])
 
-  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], lparams: List[LocalParam], pcPoints: Int, expr: Expr, tpe: MonoType, purity: Purity, loc: SourceLocation) {
+  case class Def(ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.DefnSym, cparams: List[FormalParam], fparams: List[FormalParam], lparams: List[LocalParam], pcPoints: Int, expr: Expr, tpe: MonoType, originalTpe: MonoType, purity: Purity, loc: SourceLocation) {
     var method: Method = _
     val arrowType: MonoType.Arrow = MonoType.Arrow(fparams.map(_.tpe), tpe)
   }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
@@ -36,7 +36,7 @@ object ReducedAstPrinter {
         DocAst.Enum(ann, mod, sym, Nil, cases)
     }.toList
     val defs = root.defs.values.map {
-      case ReducedAst.Def(ann, mod, sym, cparams, fparams, _, _, stmt, tpe, purity, _) =>
+      case ReducedAst.Def(ann, mod, sym, cparams, fparams, _, _, stmt, tpe, _, purity, _) =>
         DocAst.Def(
           ann,
           mod,

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -86,7 +86,7 @@ object EffectBinder {
       val exp = visitExpr(exp0)
       // OBS lctx.pcPoints is mutated by visitExpr
       val pcPoints = lctx.pcPoints
-      ReducedAst.Def(ann, mod, sym, cparams, fparams, lparams, pcPoints, exp, tpe, purity, loc)
+      ReducedAst.Def(ann, mod, sym, cparams, fparams, lparams, pcPoints, exp, tpe, tpe, purity, loc)
   }
 
   private def visitEnum(e: LiftedAst.Enum): ReducedAst.Enum = e match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -49,12 +49,12 @@ object Reducer {
   }
 
   private def visitDef(d: Def)(implicit ctx: SharedContext): Def = d match {
-    case Def(ann, mod, sym, cparams, fparams, lparams, pcPoints, exp, tpe, purity, loc) =>
+    case Def(ann, mod, sym, cparams, fparams, lparams, pcPoints, exp, tpe, originalTpe, purity, loc) =>
       implicit val lctx: LocalContext = LocalContext.mk()
       assert(lparams.isEmpty, s"Unexpected def local params before Reducer: $lparams")
       val e = visitExpr(exp)
       val ls = lctx.lparams.toList
-      Def(ann, mod, sym, cparams, fparams, ls, pcPoints, e, tpe, purity, loc)
+      Def(ann, mod, sym, cparams, fparams, ls, pcPoints, e, tpe, originalTpe, purity, loc)
   }
 
   private def visitExpr(exp0: Expr)(implicit lctx: LocalContext, ctx: SharedContext): Expr = exp0 match {
@@ -191,7 +191,7 @@ object Reducer {
       // `defn.fparams` and `defn.tpe` are both included in `defn.arrowType`
 
       // Return the types in the defn.
-      cParamTypes ++ expressionTypes + defn.arrowType
+      cParamTypes ++ expressionTypes + defn.arrowType + defn.originalTpe
     }
 
     def visitExp(exp0: Expr): Set[MonoType] = (exp0 match {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenNamespaceClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenNamespaceClasses.scala
@@ -69,13 +69,12 @@ object GenNamespaceClasses {
     * Adding a shim for the function `defn` on namespace `ns`
     */
   private def compileShimMethod(visitor: ClassWriter, defn: Def): Unit = {
-    // TODO: This can probably be removed (used in GenMain and other places)
     // Name of the shim
     val name = JvmOps.getDefMethodNameInNamespaceClass(defn.sym)
 
     // Erased argument and result type.
-    val erasedArgs = defn.arrowType.args.map(JvmOps.getErasedJvmType)
-    val erasedResult = JvmOps.getErasedJvmType(defn.tpe)
+    val erasedArgs = defn.fparams.map(_.tpe).map(JvmOps.getErasedJvmType)
+    val erasedResult = JvmOps.getErasedJvmType(defn.originalTpe)
 
     // Method header
     val method = visitor.visitMethod(ACC_PUBLIC + ACC_FINAL + ACC_STATIC, name, AsmOps.getMethodDescriptor(erasedArgs, erasedResult), null, null)
@@ -102,7 +101,7 @@ object GenNamespaceClasses {
       // Incrementing the offset
       offset += AsmOps.getStackSize(arg)
     }
-    BackendObjType.Result.unwindSuspensionFreeThunkToType(BackendType.toErasedBackendType(defn.tpe))(new BytecodeInstructions.F(method))
+    BackendObjType.Result.unwindSuspensionFreeThunkToType(BackendType.toErasedBackendType(defn.originalTpe))(new BytecodeInstructions.F(method))
     // no erasure here because the ns function works on erased values
 
     // Return


### PR DESCRIPTION
Fixes #7086

This is not a pretty fix. Maybe the proper solution is to actually add these functions pre-eraser and just generate in the backend. Something like `Root.Api` which is the list of functions that GenNamespaceClasses currently just makes up. These functions would call their corresponding def and unwrap the Value