### PR TITLE
refactor: deleted unused code from LoweredAst

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
@@ -26,15 +26,15 @@ object LoweredAstPrinter {
     */
   def print(root: LoweredAst.Root): DocAst.Program = {
     val enums = root.enums.values.map {
-      case LoweredAst.Enum(_, ann, mod, sym, tparams, _, cases0, _, _) =>
+      case LoweredAst.Enum(ann, mod, sym, tparams, cases0, _, _) =>
         val cases = cases0.values.map {
-          case LoweredAst.Case(sym, tpe, _, _) =>
+          case LoweredAst.Case(sym, tpe, _) =>
             DocAst.Case(sym, TypePrinter.print(tpe))
         }.toList
         DocAst.Enum(ann, mod, sym, tparams.map(printTypeParam), cases)
     }.toList
     val defs = root.defs.values.map {
-      case LoweredAst.Def(sym, LoweredAst.Spec(_, ann, mod, _, fparams, _, retTpe, eff, _, _), exp) =>
+      case LoweredAst.Def(sym, LoweredAst.Spec(ann, mod, _, fparams, _, retTpe, eff, _), exp) =>
         DocAst.Def(
           ann,
           mod,
@@ -141,7 +141,7 @@ object LoweredAstPrinter {
     * Returns the [[DocAst.Expression.Ascription]] representation of `fp`.
     */
   private def printFormalParam(fp: LoweredAst.FormalParam): DocAst.Expression.Ascription = {
-    val LoweredAst.FormalParam(sym, _, tpe, _, _) = fp
+    val LoweredAst.FormalParam(sym, _, tpe, _) = fp
     DocAst.Expression.Ascription(DocAst.Expression.Var(sym), TypePrinter.print(tpe))
   }
 
@@ -149,7 +149,7 @@ object LoweredAstPrinter {
     * Returns the [[DocAst.TypeParam]] representation of `tp`.
     */
   private def printTypeParam(tp: LoweredAst.TypeParam): DocAst.TypeParam = tp match {
-    case LoweredAst.TypeParam(_, sym, _) =>
+    case LoweredAst.TypeParam(_, sym) =>
       DocAst.TypeParam(sym)
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/MonoDefs.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/MonoDefs.scala
@@ -291,7 +291,6 @@ object MonoDefs {
       // Reassemble the AST.
       root.copy(
         defs = ctx.toMap,
-        classes = Map.empty,
         instances = Map.empty,
         sigs = Map.empty
       )
@@ -314,7 +313,6 @@ object MonoDefs {
     // NB: Removes the type parameters as the function is now monomorphic.
     val spec0 = defn.spec
     val spec = Spec(
-      spec0.doc,
       spec0.ann,
       spec0.mod,
       Nil,
@@ -322,7 +320,6 @@ object MonoDefs {
       Scheme(Nil, Nil, Nil, subst(defn.spec.declaredScheme.base)),
       subst(spec0.retTpe),
       subst(spec0.eff),
-      spec0.tconstrs,
       spec0.loc
     )
     val specializedDefn = defn.copy(sym = freshSym, spec = spec, exp = specializedExp)
@@ -662,9 +659,9 @@ object MonoDefs {
    * Returns the new formal parameter and an environment mapping the variable symbol to a fresh variable symbol.
    */
   private def specializeFormalParam(fparam0: FormalParam, subst0: StrictSubstitution)(implicit flix: Flix): (FormalParam, Map[Symbol.VarSym, Symbol.VarSym]) = {
-    val FormalParam(sym, mod, tpe, src, loc) = fparam0
+    val FormalParam(sym, mod, tpe, loc) = fparam0
     val freshSym = Symbol.freshVarSym(sym)
-    (FormalParam(freshSym, mod, subst0(tpe), src, loc), Map(sym -> freshSym))
+    (FormalParam(freshSym, mod, subst0(tpe), loc), Map(sym -> freshSym))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/MonoTypes.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/MonoTypes.scala
@@ -140,12 +140,12 @@ object MonoTypes {
     * Returns a [[LoweredAst.Spec]] with specialized enums and without aliases in its types.
     */
   private def visitSpec(spec: LoweredAst.Spec)(implicit ctx: SharedContext, root: LoweredAst.Root, flix: Flix): LoweredAst.Spec = spec match {
-    case LoweredAst.Spec(doc, ann, mod, tparams, fparams, declaredScheme, retTpe, eff, tconstrs, loc) =>
+    case LoweredAst.Spec(ann, mod, tparams, fparams, declaredScheme, retTpe, eff, loc) =>
       val fs = fparams.map(visitFormalParam)
       val ds = visitScheme(declaredScheme)
       val rt = visitType(retTpe)
       val p = visitType(eff)
-      LoweredAst.Spec(doc, ann, mod, tparams, fs, ds, rt, p, tconstrs, loc)
+      LoweredAst.Spec(ann, mod, tparams, fs, ds, rt, p, loc)
   }
 
   /**
@@ -410,9 +410,9 @@ object MonoTypes {
     * Returns a formal param with specialized enums in its type and no aliases.
     */
   private def visitFormalParam(p: LoweredAst.FormalParam)(implicit ctx: SharedContext, root: LoweredAst.Root, flix: Flix): LoweredAst.FormalParam = p match {
-    case LoweredAst.FormalParam(sym, mod, tpe, src, loc) =>
+    case LoweredAst.FormalParam(sym, mod, tpe, loc) =>
       val t = visitType(tpe)
-      LoweredAst.FormalParam(sym, mod, t, src, loc)
+      LoweredAst.FormalParam(sym, mod, t, loc)
   }
 
   /**
@@ -460,10 +460,9 @@ object MonoTypes {
     * Specialize the given case `caze` belonging to the given enum `enumSym`.
     */
   private def specializeCase(enumSym: Symbol.EnumSym, caze: LoweredAst.Case, subst: Substitution)(implicit ctx: SharedContext, root: LoweredAst.Root, flix: Flix): (Symbol.CaseSym, LoweredAst.Case) = caze match {
-    case LoweredAst.Case(caseSym, caseTpe, caseSc, caseLoc) =>
+    case LoweredAst.Case(caseSym, caseTpe, caseLoc) =>
       val freshCaseSym = new Symbol.CaseSym(enumSym, caseSym.name, caseSym.loc)
-      val newCaseSc = Scheme(caseSc.quantifiers, caseSc.tconstrs, caseSc.econstrs, subst(caseSc.base))
-      val caze = LoweredAst.Case(freshCaseSym, visitType(subst(caseTpe)), visitScheme(newCaseSc), caseLoc)
+      val caze = LoweredAst.Case(freshCaseSym, visitType(subst(caseTpe)), caseLoc)
       (freshCaseSym, caze)
   }
 


### PR DESCRIPTION
Fixes #7077

It's surprising how much code is unused.

Questions before merging: 
- some things like `loc` could maybe be kept for each class just for consistency?
- Instances could keep their names and type for sanity even though its not used?
- Should the "transitive" unused values also be removed (deleted in Lowered, Simplified, Lifted, Reduced)