### PR TITLE
refactor: get rid of indexed indices in Indexer

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
@@ -30,6 +30,11 @@ object Index {
     MultiMap.empty, MultiMap.empty, MultiMap.empty, MultiMap.empty)
 
   /**
+    * Merges all the given indices.
+    */
+  def all(indices: Index*): Index = indices.foldLeft(Index.empty)(_ ++ _)
+
+  /**
     * Returns an index for the given `class0`.
     */
   def occurrenceOf(class0: TypedAst.Class): Index = empty + Entity.Class(class0)


### PR DESCRIPTION
The existing pattern in Indexer:

```
idx1 = ...
idx2 = ...
idx1 ++ idx2 ++ ...
```

is clunky and error-prone.
It is easy to forget to `++` something at the end, and any time we add or remove a field, we have to change the indices.
This new system solves both of those.

If this is deemed reasonable, then I'd like to do the same thing in SemanticTokensProvider.