### PR TITLE
fix: join implementation in IDE example

### DIFF
--- a/examples/larger-examples/program-analysis/IDE.flix
+++ b/examples/larger-examples/program-analysis/IDE.flix
@@ -269,17 +269,12 @@ mod ConstantProp {
                 case (MicroFunction.NonBot(a1, b1, c1), MicroFunction.NonBot(a2, b2, c2)) =>
                     if (a1 == a2 and b1 == b2)
                         MicroFunction.NonBot(a1, b1, lub(c1, c2))
-                    else if (c1 == c2)
-                        if((a2-a1) != 0 and 0 == (b1 - b2) `Int32.rem` (a2 - a1)) {
-                            // Divisible.
-                            MicroFunction.NonBot(a1, b2, lub(Const.Cst(a1 * (b1 - b2) / (a2 - a1) + b1), lub(c1, c2)))
-                        } else {
-                            // Indivisible.
-                            MicroFunction.NonBot(1, 0, Const.Top)
-                        }
-                    else {
-                        ?unreachable
-                    }
+                    else if((a2-a1) != 0 and 0 == (b1 - b2) `Int32.rem` (a2 - a1))
+                        // Divisible.
+                        MicroFunction.NonBot(a1, b2, lub(Const.Cst(a1 * (b1 - b2) / (a2 - a1) + b1), lub(c1, c2)))
+                    else
+                        // Indivisible.
+                        MicroFunction.NonBot(1, 0, Const.Top)
             }
     }
 


### PR DESCRIPTION
Looking through historical code, it seems this stems from a typo in an early Flix implementation of this example. An old implementation had this:

        (case <(NonBotTrans <a1 b1 c2>) (NonBotTrans <a2 b2 c2>)>
            (if (== 0 (% (- b1 b2) (- a2 a1)))
                // is divisible
                (NonBotTrans <a1 b2 (lub (Cst (+ (* a1 (/ (- b1 b2) (- a2 a1))) b1)) (lub c1 c2))>)
                // is not divisible
                (NonBotTrans <1 0 Top>)
            )
        )

Notice that this should not have even compiled back then, since it references variable c1, which is not even bound. The typo there was that NonBotTrans <a1 b1 c2> should have been NonBotTrans <a1 b1 c1>. The spurious requirement that c1 == c2 was probably added during the translation of that code with the typo to modern Flix.