### PR TITLE
fix: allow whitespace in `unchecked_cast`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -838,7 +838,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def UncheckedCast: Rule1[ParsedAst.Expression] = rule {
-      SP ~ keyword("unchecked_cast") ~ optWS ~ "(" ~ Expression ~ WS ~ "as" ~ optWS ~ TypeAndEffect ~ optWS ~ ")" ~ SP ~> ParsedAst.Expression.UncheckedCast
+      SP ~ keyword("unchecked_cast") ~ optWS ~ "(" ~ optWS ~ Expression ~ WS ~ "as" ~ optWS ~ TypeAndEffect ~ optWS ~ ")" ~ SP ~> ParsedAst.Expression.UncheckedCast
     }
 
     def UncheckedMaskingCast: Rule1[ParsedAst.Expression.UncheckedMaskingCast] = rule {


### PR DESCRIPTION
White space is not allowed in `unchecked_cast` between the opening parenthesis and the inner expression. This PR fixes that bug.

```scala
unchecked_cast(    { ... } as _ \ {}) // notice the white space
```
is now allowed.