### PR TITLE
chore: bump github actions versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Check out master
         uses: actions/checkout@v4
       - name: Install JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -18,14 +18,14 @@ jobs:
       - name: Check out branch
         uses: actions/checkout@v4
       - name: Install JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
       - name: Build Flix JAR
         run: ./gradlew jar
       - name: Upload Flix JAR
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: flix-jar
           path: build/libs/flix.jar
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -62,7 +62,7 @@ jobs:
         with:
           repository: ${{ matrix.repo }}
       - name: Download Flix JAR
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: flix-jar
       - name: Build community project

--- a/.github/workflows/jar-on-demand.yaml
+++ b/.github/workflows/jar-on-demand.yaml
@@ -21,7 +21,7 @@ jobs:
                 body: 'Building JAR...'
               })
       - name: Install JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'


### PR DESCRIPTION
Bumps major version of GitHub Actions to non-deprecated version.

- `actions/upload-artifact` to `v4`
- `actions/download-artifact` to `v4`
- `actions/setup-java` to `v4`

Currently we get the following warnings:

Build workflow:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-java@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

Community build workflow:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-java@v3, actions/download-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```