### PR TITLE
feat: Add missing `TokenKind`s

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -257,6 +257,8 @@ object TokenKind {
 
   case object KeywordUncheckedCast extends TokenKind
 
+  case object KeywordUniv extends TokenKind
+
   case object KeywordUse extends TokenKind
 
   case object KeywordWhere extends TokenKind

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -29,6 +29,8 @@ sealed trait TokenKind
 object TokenKind {
   case object Ampersand extends TokenKind
 
+  case object AmpersandAmpersand extends TokenKind
+
   case object AngledEqual extends TokenKind
 
   case object AngledPlus extends TokenKind
@@ -75,6 +77,8 @@ object TokenKind {
 
   case object ColonEqual extends TokenKind
 
+  case object ColonMinus extends TokenKind
+
   case object Comma extends TokenKind
 
   case object CommentBlock extends TokenKind
@@ -91,11 +95,17 @@ object TokenKind {
 
   case object Dot extends TokenKind
 
+  case object DotCurlyL extends TokenKind
+
   case object Equal extends TokenKind
 
   case object EqualEqual extends TokenKind
 
   case object Hash extends TokenKind
+
+  case object HashCurlyL extends TokenKind
+
+  case object HashParenL extends TokenKind
 
   case object HoleAnonymous extends TokenKind
 
@@ -163,11 +173,15 @@ object TokenKind {
 
   case object KeywordImport extends TokenKind
 
+  case object KeywordImpure extends TokenKind
+
   case object KeywordInject extends TokenKind
 
   case object KeywordInline extends TokenKind
 
   case object KeywordInstance extends TokenKind
+
+  case object KeywordInstanceOf extends TokenKind
 
   case object KeywordInto extends TokenKind
 
@@ -215,15 +229,23 @@ object TokenKind {
 
   case object KeywordRestrictable extends TokenKind
 
+  case object KeywordResume extends TokenKind
+
   case object KeywordSealed extends TokenKind
 
   case object KeywordSelect extends TokenKind
+
+  case object KeywordSet extends TokenKind
 
   case object KeywordSolve extends TokenKind
 
   case object KeywordSpawn extends TokenKind
 
   case object KeywordStatic extends TokenKind
+
+  case object KeywordStaticUppercase extends TokenKind
+
+  case object KeywordTrait extends TokenKind
 
   case object KeywordTrue extends TokenKind
 
@@ -235,8 +257,6 @@ object TokenKind {
 
   case object KeywordUncheckedCast extends TokenKind
 
-  case object KeywordUniv extends TokenKind
-
   case object KeywordUse extends TokenKind
 
   case object KeywordWhere extends TokenKind
@@ -247,6 +267,8 @@ object TokenKind {
 
   case object KeywordYield extends TokenKind
 
+  case object KeywordXor extends TokenKind
+
   case object ListHash extends TokenKind
 
   case object LiteralBigDecimal extends TokenKind
@@ -254,6 +276,10 @@ object TokenKind {
   case object LiteralBigInt extends TokenKind
 
   case object LiteralChar extends TokenKind
+
+  case object LiteralDebugStringL extends TokenKind
+
+  case object LiteralDebugStringR extends TokenKind
 
   case object LiteralFloat32 extends TokenKind
 
@@ -279,6 +305,8 @@ object TokenKind {
 
   case object Minus extends TokenKind
 
+  case object MinusMinus extends TokenKind
+
   case object NameGreek extends TokenKind
 
   case object NameJava extends TokenKind
@@ -295,6 +323,8 @@ object TokenKind {
 
   case object Plus extends TokenKind
 
+  case object PlusPlus extends TokenKind
+
   case object Semi extends TokenKind
 
   case object SetHash extends TokenKind
@@ -307,6 +337,8 @@ object TokenKind {
 
   case object Tilde extends TokenKind
 
+  case object TildeTilde extends TokenKind
+
   case object TripleAmpersand extends TokenKind
 
   case object TripleAngleL extends TokenKind
@@ -316,6 +348,8 @@ object TokenKind {
   case object TripleBar extends TokenKind
 
   case object TripleCaret extends TokenKind
+
+  case object TripleColon extends TokenKind
 
   case object TripleTilde extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -131,8 +131,6 @@ object TokenKind {
 
   case object KeywordChoose extends TokenKind
 
-  case object KeywordClass extends TokenKind
-
   case object KeywordDebug extends TokenKind
 
   case object KeywordDef extends TokenKind
@@ -215,8 +213,6 @@ object TokenKind {
 
   case object KeywordPar extends TokenKind
 
-  case object KeywordProject extends TokenKind
-
   case object KeywordPub extends TokenKind
 
   case object KeywordPure extends TokenKind
@@ -228,8 +224,6 @@ object TokenKind {
   case object KeywordRegion extends TokenKind
 
   case object KeywordRestrictable extends TokenKind
-
-  case object KeywordResume extends TokenKind
 
   case object KeywordSealed extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -151,8 +151,6 @@ object TokenKind {
 
   case object KeywordFix extends TokenKind
 
-  case object KeywordFor extends TokenKind
-
   case object KeywordForA extends TokenKind
 
   case object KeywordForall extends TokenKind

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -47,13 +47,13 @@ object TokenKind {
 
   case object ArrayHash extends TokenKind
 
-  case object Arrow extends TokenKind
+  case object ArrowThickR extends TokenKind
 
-  case object ArrowThin extends TokenKind
+  case object ArrowThinL extends TokenKind
+
+  case object ArrowThinR extends TokenKind
 
   case object At extends TokenKind
-
-  case object BackArrowThin extends TokenKind
 
   case object Backslash extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -397,7 +397,6 @@ object Lexer {
       case _ if isKeyword("enum") => TokenKind.KeywordEnum
       case _ if isKeyword("false") => TokenKind.KeywordFalse
       case _ if isKeyword("fix") => TokenKind.KeywordFix
-      case _ if isKeyword("for") => TokenKind.KeywordFor
       case _ if isKeyword("forA") => TokenKind.KeywordForA
       case _ if isKeyword("forall") => TokenKind.KeywordForall
       case _ if isKeyword("force") => TokenKind.KeywordForce

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -364,9 +364,9 @@ object Lexer {
       case _ if isKeyword("???") => TokenKind.HoleAnonymous
       case '?' if peek().isLetter => acceptNamedHole()
       case _ if isKeyword("**") => TokenKind.StarStar
-      case _ if isKeyword("<-") => TokenKind.BackArrowThin
-      case _ if isKeyword("=>") => TokenKind.Arrow
-      case _ if isKeyword("->") => TokenKind.ArrowThin
+      case _ if isKeyword("<-") => TokenKind.ArrowThinL
+      case _ if isKeyword("->") => TokenKind.ArrowThinR
+      case _ if isKeyword("=>") => TokenKind.ArrowThickR
       case _ if isKeyword("<=") => TokenKind.AngleLEqual
       case _ if isKeyword(">=") => TokenKind.AngleREqual
       case _ if isKeyword("==") => TokenKind.EqualEqual

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -387,7 +387,6 @@ object Lexer {
       case _ if isKeyword("checked_cast") => TokenKind.KeywordCheckedCast
       case _ if isKeyword("checked_ecast") => TokenKind.KeywordCheckedECast
       case _ if isKeyword("choose") => TokenKind.KeywordChoose
-      case _ if isKeyword("class") => TokenKind.KeywordClass
       case _ if isKeyword("debug") => TokenKind.KeywordDebug
       case _ if isKeyword("def") => TokenKind.KeywordDef
       case _ if isKeyword("deref") => TokenKind.KeywordDeref
@@ -427,7 +426,6 @@ object Lexer {
       case _ if isKeyword("or") => TokenKind.KeywordOr
       case _ if isKeyword("override") => TokenKind.KeywordOverride
       case _ if isKeyword("par") => TokenKind.KeywordPar
-      case _ if isKeyword("project") => TokenKind.KeywordProject
       case _ if isKeyword("pub") => TokenKind.KeywordPub
       case _ if isKeyword("pure") => TokenKind.KeywordPure
       case _ if isKeyword("query") => TokenKind.KeywordQuery


### PR DESCRIPTION
When parsing the standard library a number of missing `TokenKind` s where discovered.