### PR TITLE
feat: rename `open` and `open_as`

### DIFF
--- a/examples/larger-examples/restrictable-variants/boolean-formulas.flix
+++ b/examples/larger-examples/restrictable-variants/boolean-formulas.flix
@@ -12,7 +12,7 @@ mod BooleanFormulas {
     pub def main(): Unit \ IO = {
         let subst = Map#{1 => true, 2 => false};
         // ~v1 and (v2 xor true)
-        let example = open Exp.And(open Exp.Not(open Exp.Var(1)), open Exp.Xor(open Exp.Var(2), open Exp.Cst(true)));
+        let example = open_variant Exp.And(open_variant Exp.Not(open_variant Exp.Var(1)), open_variant Exp.Xor(open_variant Exp.Var(2), open_variant Exp.Cst(true)));
         println("input is '${toString(example)}'");
         println("input size ${size(example)}");
         println("input evaluates to '${fastrun(subst, example)}'");
@@ -43,38 +43,38 @@ mod BooleanFormulas {
 
     pub def simplifyNaive(e: Exp[s]): Exp[~~<Exp.Xor>] =
         choose e {
-            case Exp.Var(x)     => open Exp.Var(x)
-            case Exp.Cst(b)     => open Exp.Cst(b)
-            case Exp.Not(x)     => open Exp.Not(simplifyNaive(x))
-            case Exp.Or(x, y)   => open Exp.Or(simplifyNaive(x), simplifyNaive(y))
-            case Exp.And(x, y)  => open Exp.And(simplifyNaive(x), simplifyNaive(y))
+            case Exp.Var(x)     => open_variant Exp.Var(x)
+            case Exp.Cst(b)     => open_variant Exp.Cst(b)
+            case Exp.Not(x)     => open_variant Exp.Not(simplifyNaive(x))
+            case Exp.Or(x, y)   => open_variant Exp.Or(simplifyNaive(x), simplifyNaive(y))
+            case Exp.And(x, y)  => open_variant Exp.And(simplifyNaive(x), simplifyNaive(y))
             case Exp.Xor(x, y)  =>
                 let x1 = simplifyNaive(x);
                 let y1 = simplifyNaive(y);
-                open Exp.Or(open Exp.And(x1, open Exp.Not(y1)), open Exp.And(open Exp.Not(x1), y1))
+                open_variant Exp.Or(open_variant Exp.And(x1, open_variant Exp.Not(y1)), open_variant Exp.And(open_variant Exp.Not(x1), y1))
         }
 
     pub def map(f: Int32 -> Int32, e: Exp[s]): Exp[s] =
         choose* e {
             case Exp.Var(x)     => Exp.Var(f(x))
             case Exp.Cst(b)     => Exp.Cst(b)
-            case Exp.Not(x)     => open Exp.Not(map(f, x))
-            case Exp.Or(x, y)   => open Exp.Or(map(f, x), map(f, y))
-            case Exp.And(x, y)  => open Exp.And(map(f, x), map(f, y))
-            case Exp.Xor(x, y)  => open Exp.Xor(map(f, x), map(f, y))
+            case Exp.Not(x)     => open_variant Exp.Not(map(f, x))
+            case Exp.Or(x, y)   => open_variant Exp.Or(map(f, x), map(f, y))
+            case Exp.And(x, y)  => open_variant Exp.And(map(f, x), map(f, y))
+            case Exp.Xor(x, y)  => open_variant Exp.Xor(map(f, x), map(f, y))
         }
 
     pub def simplify(e: Exp[s]): Exp[(s -- <Exp.Xor>) ++ <Exp.Or, Exp.And, Exp.Not>] =
         choose* e {
-            case Exp.Var(x)     => open Exp.Var(x)
-            case Exp.Cst(b)     => open Exp.Cst(b)
-            case Exp.Not(x)     => open Exp.Not(simplify(x))
-            case Exp.Or(x, y)   => open Exp.Or(simplify(x), simplify(y))
-            case Exp.And(x, y)  => open Exp.And(simplify(x), simplify(y))
+            case Exp.Var(x)     => open_variant Exp.Var(x)
+            case Exp.Cst(b)     => open_variant Exp.Cst(b)
+            case Exp.Not(x)     => open_variant Exp.Not(simplify(x))
+            case Exp.Or(x, y)   => open_variant Exp.Or(simplify(x), simplify(y))
+            case Exp.And(x, y)  => open_variant Exp.And(simplify(x), simplify(y))
             case Exp.Xor(x, y)  =>
                 let x1 = simplify(x);
                 let y1 = simplify(y);
-                open Exp.Or(open Exp.And(x1, open Exp.Not(y1)), open Exp.And(open Exp.Not(x1), y1))
+                open_variant Exp.Or(open_variant Exp.And(x1, open_variant Exp.Not(y1)), open_variant Exp.And(open_variant Exp.Not(x1), y1))
     }
 
     pub def run(e: Exp[s -- <Exp.Var>]): Bool =
@@ -85,10 +85,10 @@ mod BooleanFormulas {
         choose* e {
             case Exp.Var(x)     => Exp.Cst(Map.getWithDefault(x, false, m))
             case Exp.Cst(b)     => Exp.Cst(b)
-            case Exp.Not(x)     => open Exp.Not(subst(m, x))
-            case Exp.Or(x, y)   => open Exp.Or(subst(m, x), subst(m, y))
-            case Exp.And(x, y)  => open Exp.And(subst(m, x), subst(m, y))
-            case Exp.Xor(x, y)  => open Exp.Xor(subst(m, x), subst(m, y))
+            case Exp.Not(x)     => open_variant Exp.Not(subst(m, x))
+            case Exp.Or(x, y)   => open_variant Exp.Or(subst(m, x), subst(m, y))
+            case Exp.And(x, y)  => open_variant Exp.And(subst(m, x), subst(m, y))
+            case Exp.Xor(x, y)  => open_variant Exp.Xor(subst(m, x), subst(m, y))
         }
 
     pub def fasteval(e: Exp[s && <Exp.Cst, Exp.Not, Exp.And, Exp.Or>]): Bool =

--- a/examples/larger-examples/restrictable-variants/colors.flix
+++ b/examples/larger-examples/restrictable-variants/colors.flix
@@ -15,16 +15,16 @@ mod Colors {
         println("this is red: ${red}");
 
         // create the color green with an open type
-        let green = open Color.Green;
+        let green = open_variant Color.Green;
         println("this is green: ${green}");
 
         // for the non-general functions we need to open red again
-        println("Is red warm? ${isWarm(open_as Color red)}, ${isWarmAlternative(open_as Color red)}, and ${isWarmGeneral(red)}");
+        println("Is red warm? ${isWarm(open_variant_as Color red)}, ${isWarmAlternative(open_variant_as Color red)}, and ${isWarmGeneral(red)}");
 
         // to compare the two types, we need to open the type of red
         // (green is recreated to avoid propagating typing backwards but it
         // can be reused.)
-        println("Are these two colors equal? ${(open_as Color red) == (open Color.Green)}");
+        println("Are these two colors equal? ${(open_variant_as Color red) == (open_variant Color.Green)}");
 
         // lets look at the inferred type of isWarm
         let _isWarmLocal = c -> choose c {

--- a/examples/larger-examples/restrictable-variants/sequences.flix
+++ b/examples/larger-examples/restrictable-variants/sequences.flix
@@ -46,7 +46,7 @@ mod Seq {
         println("a: ${a}");
 
         // We can flatMap an Option to a List.
-        let b = option |> flatMap(x -> open Seq.Cons(x, Seq.Nil));
+        let b = option |> flatMap(x -> open_variant Seq.Cons(x, Seq.Nil));
         println("b: ${b}");
 
         // We can flatMap a NonEmptyList to a NonEmptyList
@@ -110,8 +110,8 @@ mod Seq {
     ///
     pub def append(l1: Seq[s1][a], l2: Seq[s2][a]): Seq[s2 ++ <Seq.Cons>][a] = choose* l1 {
         case Seq.Nil            => l2
-        case Seq.One(x)         => open Seq.Cons(x, l2)
-        case Seq.Cons(x, xs)    => open Seq.Cons(x, append(xs, l2))
+        case Seq.One(x)         => open_variant Seq.Cons(x, l2)
+        case Seq.Cons(x, xs)    => open_variant Seq.Cons(x, append(xs, l2))
     }
 
     ///
@@ -160,8 +160,8 @@ mod Seq {
     ///
     pub def indexOf(a: a, l: Seq[s][a]): SOption[Int32] with Eq[a] = choose* l {
         case Seq.Nil            => Seq.Nil
-        case Seq.One(x)         => if (x == a) open Seq.One(0) else open Seq.Nil
-        case Seq.Cons(x, xs)    => if (x == a) open Seq.One(0) else indexOf(a, xs) |> map(y -> y + 1)
+        case Seq.One(x)         => if (x == a) open_variant Seq.One(0) else open_variant Seq.Nil
+        case Seq.Cons(x, xs)    => if (x == a) open_variant Seq.One(0) else indexOf(a, xs) |> map(y -> y + 1)
     }
 
     ///
@@ -174,20 +174,20 @@ mod Seq {
     ///
     pub def findLeft(f: a -> Bool \ ef, l: Seq[s][a]): SOption[a] \ ef = choose* l {
         case Seq.Nil            => Seq.Nil
-        case Seq.One(x)         => if (f(x)) open Seq.One(x) else open Seq.Nil
-        case Seq.Cons(x, xs)    => if (f(x)) open Seq.One(x) else findLeft(f, xs)
+        case Seq.One(x)         => if (f(x)) open_variant Seq.One(x) else open_variant Seq.Nil
+        case Seq.Cons(x, xs)    => if (f(x)) open_variant Seq.One(x) else findLeft(f, xs)
     }
 
     ///
     /// Optionally returns the first element of `l` that satisfies the predicate `f` when searching from right to left.
     ///
     pub def findRight(f: a -> Bool \ ef, l: Seq[s][a]): SOption[a] \ ef =
-        findRightHelper(f, l, () -> open Seq.Nil)
+        findRightHelper(f, l, () -> open_variant Seq.Nil)
 
     def findRightHelper(f: a -> Bool \ ef1, l: Seq[s][a], k: Unit -> SOption[a] \ ef2): SOption[a] \ {ef1, ef2} = choose* l {
         case Seq.Nil            => k()
-        case Seq.One(x)         => if (f(x)) open Seq.One(x) else k()
-        case Seq.Cons(x, xs)    => findRightHelper(f, xs, () -> if (f(x)) open Seq.One(x) else k())
+        case Seq.One(x)         => if (f(x)) open_variant Seq.One(x) else k()
+        case Seq.Cons(x, xs)    => findRightHelper(f, xs, () -> if (f(x)) open_variant Seq.One(x) else k())
     }
 
     ///
@@ -197,9 +197,9 @@ mod Seq {
     ///
     pub def range(b: Int32, e: Int32): SList[Int32] =
         if (b > e) {
-            open Seq.Nil
+            open_variant Seq.Nil
         } else {
-            open Seq.Cons(b, range(b + 1, e))
+            open_variant Seq.Cons(b, range(b + 1, e))
         }
 
     ///
@@ -209,9 +209,9 @@ mod Seq {
     ///
     pub def repeat(n: Int32, a: a): SList[a] =
         if (n <= 0) {
-            open Seq.Nil
+            open_variant Seq.Nil
         } else {
-            open Seq.Cons(a, repeat(n - 1, a))
+            open_variant Seq.Cons(a, repeat(n - 1, a))
         }
 
     // ///
@@ -226,8 +226,8 @@ mod Seq {
     ///
     pub def scanLeft(f: (b, a) -> b \ ef, s: b, l: Seq[s][a]): SNel[b] \ ef = choose* l {
         case Seq.Nil            => Seq.One(s)
-        case Seq.One(x)         => open Seq.Cons(s, Seq.One(f(s, x)))
-        case Seq.Cons(x, xs)    => open Seq.Cons(s, scanLeft(f, f(s, x), xs))
+        case Seq.One(x)         => open_variant Seq.Cons(s, Seq.One(f(s, x)))
+        case Seq.Cons(x, xs)    => open_variant Seq.Cons(s, scanLeft(f, f(s, x), xs))
     }
 
     // ///
@@ -237,10 +237,10 @@ mod Seq {
     // ///
     pub def scanRight(f: (a, b) -> b \ ef, s: b, l: Seq[s][a]): SNel[b] \ ef = choose* l {
         case Seq.Nil            => Seq.One(s)
-        case Seq.One(x)         => open Seq.Cons(f(x, s), Seq.One(s))
+        case Seq.One(x)         => open_variant Seq.Cons(f(x, s), Seq.One(s))
         case Seq.Cons(x, xs)    =>
             let r = scanRight(f, s, xs);
-            open Seq.Cons(f(x, head(r)), r)
+            open_variant Seq.Cons(f(x, head(r)), r)
     }
 
     ///
@@ -251,7 +251,7 @@ mod Seq {
     pub def map(f: a -> b \ ef, l: Seq[s][a]): Seq[s][b] \ ef = choose* l {
         case Seq.Nil            => Seq.Nil
         case Seq.One(x)         => Seq.One(f(x))
-        case Seq.Cons(x, xs)    => open Seq.Cons(f(x), map(f, xs))
+        case Seq.Cons(x, xs)    => open_variant Seq.Cons(f(x), map(f, xs))
     }
 
     ///
@@ -288,8 +288,8 @@ mod Seq {
 
     def revAppend(l1: Seq[s1][a], l2: Seq[s2][a]): Seq[s2 ++ <Seq.Cons>][a] = choose* l1 {
         case Seq.Nil            => l2
-        case Seq.One(x)         => open Seq.Cons(x, l2)
-        case Seq.Cons(x, xs)    => revAppend(xs, open Seq.Cons(x, l2))
+        case Seq.One(x)         => open_variant Seq.Cons(x, l2)
+        case Seq.Cons(x, xs)    => revAppend(xs, open_variant Seq.Cons(x, l2))
     }
 
     ///
@@ -300,7 +300,7 @@ mod Seq {
     pub def update(i: Int32, a: a, l: Seq[s][a]): Seq[s][a] = choose* l {
         case Seq.Nil            => Seq.Nil
         case Seq.One(x)         => if (i == 0) Seq.One(a) else Seq.One(x)
-        case Seq.Cons(x, xs)    => if (i == 0) open Seq.Cons(a, xs) else open Seq.Cons(x, update(i - 1, a, xs))
+        case Seq.Cons(x, xs)    => if (i == 0) open_variant Seq.Cons(a, xs) else open_variant Seq.Cons(x, update(i - 1, a, xs))
     }
 
     ///
@@ -314,13 +314,13 @@ mod Seq {
     pub def intersperse(a: a, l: Seq[s][a]): Seq[s ++ <Seq.Cons>][a] = choose* l {
         case Seq.Nil            => Seq.Nil
         case Seq.One(x)         => Seq.One(x)
-        case Seq.Cons(x, xs)    => open Seq.Cons(x, presperse(a, xs))
+        case Seq.Cons(x, xs)    => open_variant Seq.Cons(x, presperse(a, xs))
     }
 
     def presperse(a: a, l: Seq[s][a]): Seq[s ++ <Seq.Cons>][a] = choose* l {
         case Seq.Nil            => Seq.Nil
-        case Seq.One(x)         => open Seq.Cons(a, Seq.One(x))
-        case Seq.Cons(x, xs)    => open Seq.Cons(a, open Seq.Cons(x, presperse(a, xs)))
+        case Seq.One(x)         => open_variant Seq.Cons(a, Seq.One(x))
+        case Seq.Cons(x, xs)    => open_variant Seq.Cons(a, open_variant Seq.Cons(x, presperse(a, xs)))
     }
 
     ///
@@ -483,8 +483,8 @@ mod Seq {
     ///
     pub def filter(f: a -> Bool \ ef, l: Seq[s][a]): Seq[s ++ <Seq.Nil>][a] \ ef = choose* l {
         case Seq.Nil            => Seq.Nil
-        case Seq.One(x)         => if (f(x)) open Seq.One(x) else open Seq.Nil
-        case Seq.Cons(x, xs)    => if (f(x)) open Seq.Cons(x, filter(f, xs)) else open_as Seq filter(f, xs)
+        case Seq.One(x)         => if (f(x)) open_variant Seq.One(x) else open_variant Seq.Nil
+        case Seq.Cons(x, xs)    => if (f(x)) open_variant Seq.Cons(x, filter(f, xs)) else open_variant_as Seq filter(f, xs)
     }
 
     ///
@@ -513,7 +513,7 @@ mod Seq {
     ///
     pub def drop(n: Int32, l: Seq[s][a]): Seq[s ++ <Seq.Nil>][a] = {
         if (n <= 0) {
-            open_as Seq l
+            open_variant_as Seq l
         } else {
             choose* l {
                 case Seq.Nil            => Seq.Nil
@@ -528,8 +528,8 @@ mod Seq {
     ///
     pub def dropWhile(f: a -> Bool \ ef, l: Seq[s][a]): Seq[s ++ <Seq.Nil>][a] \ ef = choose* l {
         case Seq.Nil            => Seq.Nil
-        case Seq.One(x)         => if (f(x)) open Seq.Nil else open Seq.One(x)
-        case Seq.Cons(x, xs)    => if (f(x)) open_as Seq dropWhile(f, xs) else open Seq.Cons(x, open_as Seq xs)
+        case Seq.One(x)         => if (f(x)) open_variant Seq.Nil else open_variant Seq.One(x)
+        case Seq.Cons(x, xs)    => if (f(x)) open_variant_as Seq dropWhile(f, xs) else open_variant Seq.Cons(x, open_variant_as Seq xs)
     }
 
     ///
@@ -540,12 +540,12 @@ mod Seq {
     ///
     pub def take(n: Int32, l: Seq[s][a]): Seq[s ++ <Seq.Nil>][a] = {
         if (n <= 0) {
-            open Seq.Nil
+            open_variant Seq.Nil
         } else {
             choose* l {
                 case Seq.Nil            => Seq.Nil
                 case Seq.One(x)         => Seq.One(x)
-                case Seq.Cons(x, xs)    => open Seq.Cons(x, take(n - 1, xs))
+                case Seq.Cons(x, xs)    => open_variant Seq.Cons(x, take(n - 1, xs))
             }
         }
     }
@@ -555,8 +555,8 @@ mod Seq {
     ///
     pub def takeWhile(f: a -> Bool \ ef, l: Seq[s][a]): Seq[s ++ <Seq.Nil>][a] \ ef = choose* l {
         case Seq.Nil            => Seq.Nil
-        case Seq.One(x)         => if (f(x)) open Seq.One(x) else open Seq.Nil
-        case Seq.Cons(x, xs)    => if (f(x)) open Seq.Cons(x, takeWhile(f, xs)) else open_as Seq takeWhile(f, xs)
+        case Seq.One(x)         => if (f(x)) open_variant Seq.One(x) else open_variant Seq.Nil
+        case Seq.Cons(x, xs)    => if (f(x)) open_variant Seq.Cons(x, takeWhile(f, xs)) else open_variant_as Seq takeWhile(f, xs)
     }
 
     ///
@@ -589,7 +589,7 @@ mod Seq {
             choose* l2 {
                 case Seq.Nil            => Seq.Nil
                 case Seq.One(y)         => Seq.One((x, y))
-                case Seq.Cons(y, ys)    => open Seq.Cons((x, y), zip(xs, ys))
+                case Seq.Cons(y, ys)    => open_variant Seq.Cons((x, y), zip(xs, ys))
             }
     }
 
@@ -612,7 +612,7 @@ mod Seq {
     def zipWithIndexHelper(i: Int32, l: Seq[s][a]): Seq[s][(Int32, a)] = choose* l {
         case Seq.Nil            => Seq.Nil
         case Seq.One(x)         => Seq.One((i, x))
-        case Seq.Cons(x, xs)    => open Seq.Cons((i, x), zipWithIndexHelper(i + 1, xs))
+        case Seq.Cons(x, xs)    => open_variant Seq.Cons((i, x), zipWithIndexHelper(i + 1, xs))
     }
 
     ///
@@ -813,9 +813,9 @@ mod Seq {
     }
 
     def insert(x: a, l: Seq[s][a]): Seq[s ++ <Seq.Cons>][a] with Order[a] = choose* l {
-        case Seq.Nil            => open Seq.Cons(x, Seq.Nil)
-        case Seq.One(y)         => if (x <= y) open Seq.Cons(x, Seq.One(y)) else open Seq.Cons(y, Seq.One(x))
-        case Seq.Cons(y, ys)    => if (x <= y) open Seq.Cons(x, open Seq.Cons(y, ys)) else open Seq.Cons(y, insert(x, ys))
+        case Seq.Nil            => open_variant Seq.Cons(x, Seq.Nil)
+        case Seq.One(y)         => if (x <= y) open_variant Seq.Cons(x, Seq.One(y)) else open_variant Seq.Cons(y, Seq.One(x))
+        case Seq.Cons(y, ys)    => if (x <= y) open_variant Seq.Cons(x, open_variant Seq.Cons(y, ys)) else open_variant Seq.Cons(y, insert(x, ys))
     }
 
     ///
@@ -834,11 +834,11 @@ mod Seq {
     /// Returns an iterator over `l`.
     ///
     pub def iterator(rc: Region[r], xs: Seq[s][a]): Iterator[a, r, r] \ r =
-        let ls = ref open_as Seq xs @ rc;
+        let ls = ref open_variant_as Seq xs @ rc;
         let next = () -> {
             choose (deref ls) {
                 case Seq.Nil            => None
-                case Seq.One(x)         => ls := open Seq.Nil; Some(x)
+                case Seq.One(x)         => ls := open_variant Seq.Nil; Some(x)
                 case Seq.Cons(x, rs)    => ls := rs; Some(x)
             }
         };

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1172,11 +1172,11 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def Open: Rule1[ParsedAst.Expression.Open] = rule {
-      SP ~ keyword("open") ~ optWS ~ Names.QName ~ SP ~> ParsedAst.Expression.Open
+      SP ~ keyword("open_variant") ~ optWS ~ Names.QName ~ SP ~> ParsedAst.Expression.Open
     }
 
     def OpenAs: Rule1[ParsedAst.Expression.OpenAs] = rule {
-      SP ~ keyword("open_as") ~ optWS ~ Names.QName ~ WS ~ Expression ~ SP ~> ParsedAst.Expression.OpenAs
+      SP ~ keyword("open_variant_as") ~ optWS ~ Names.QName ~ WS ~ Expression ~ SP ~> ParsedAst.Expression.OpenAs
     }
 
     def HolyName: Rule1[ParsedAst.Expression.HolyName] = rule {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -919,7 +919,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |     };
         |     let h = if (true) f else g;
         |
-        |     let cstOrNotOrVar = if (true) open Expr.Cst else if (true) open Expr.Not else open Expr.Var;
+        |     let cstOrNotOrVar = if (true) open_variant Expr.Cst else if (true) open_variant Expr.Not else open_variant Expr.Var;
         |
         |     h(cstOrNotOrVar)
         | }

--- a/main/test/flix/Test.Def.ChooseStar.Simple.flix
+++ b/main/test/flix/Test.Def.ChooseStar.Simple.flix
@@ -158,7 +158,7 @@ mod Test.Def.ChooseStar.Simple {
     }
 
     pub def testChooseStar10(): Bool = {
-        let cstOrVar = if (true) open Expr.Cst else open Expr.Var;
+        let cstOrVar = if (true) open_variant Expr.Cst else open_variant Expr.Var;
         let thing = helper10(cstOrVar);
         choose thing {case Expr.Cst => true}
     }
@@ -171,7 +171,7 @@ mod Test.Def.ChooseStar.Simple {
 //    }
 //
 //    pub def testChooseStar11(): Bool = {
-//        let cstOrVar = if (true) open Expr.Cst else open Expr.Var;
+//        let cstOrVar = if (true) open_variant Expr.Cst else open_variant Expr.Var;
 //        let thing = helper11(cstOrVar);
 //        choose thing {
 //            case Expr.Xor => true
@@ -214,7 +214,7 @@ mod Test.Def.ChooseStar.Simple {
 //
 //    pub def testChooseStar13(): Bool = {
 //        let h = if (true) helper13_1 else helper13_2;
-//        let cstOrNot = if (true) open Expr.Cst else open Expr.Not;
+//        let cstOrNot = if (true) open_variant Expr.Cst else open_variant Expr.Not;
 //        choose h(cstOrNot) {case Expr.Cst => true}
 //    }
 //

--- a/main/test/flix/Test.Exp.Choose.Polymorphic.flix
+++ b/main/test/flix/Test.Exp.Choose.Polymorphic.flix
@@ -23,7 +23,7 @@ mod Test.Exp.Choose.Polymorphic {
     }
 
     pub def testChoose03(): Bool = {
-        let cstOrVar = if (true) open Expr.Cst(123) else open Expr.Var("hi");
+        let cstOrVar = if (true) open_variant Expr.Cst(123) else open_variant Expr.Var("hi");
         choose cstOrVar {
             case Expr.Cst(_) => true
             case Expr.Var(_) => false
@@ -31,7 +31,7 @@ mod Test.Exp.Choose.Polymorphic {
     }
 
     pub def testChoose04(): Bool = {
-        let cstOrVar = if (true) open Expr.Cst(123) else open Expr.Var("hi");
+        let cstOrVar = if (true) open_variant Expr.Cst(123) else open_variant Expr.Var("hi");
         choose cstOrVar {
             case Expr.Xor(_) => false
             case Expr.Cst(_) => true
@@ -65,7 +65,7 @@ mod Test.Exp.Choose.Polymorphic {
         };
         let h = if (true) f else g;
 
-        let cstOrNot = if (true) open Expr.Cst("hello") else open Expr.Not(Some("hello"));
+        let cstOrNot = if (true) open_variant Expr.Cst("hello") else open_variant Expr.Not(Some("hello"));
         h(cstOrNot)
     }
 }

--- a/main/test/flix/Test.Exp.Choose.Recursive.flix
+++ b/main/test/flix/Test.Exp.Choose.Recursive.flix
@@ -22,7 +22,7 @@ mod Test.Exp.Choose.Recursive {
     }
 
     pub def testChoose03(): Bool = {
-        let cstOrVar = if (true) open Expr.Cst(true) else open Expr.Var(123);
+        let cstOrVar = if (true) open_variant Expr.Cst(true) else open_variant Expr.Var(123);
         choose cstOrVar {
             case Expr.Cst(_) => true
             case Expr.Var(_) => false
@@ -30,7 +30,7 @@ mod Test.Exp.Choose.Recursive {
     }
 
     pub def testChoose04(): Bool = {
-        let cstOrVar = if (true) open Expr.Cst(true) else open Expr.Var(123);
+        let cstOrVar = if (true) open_variant Expr.Cst(true) else open_variant Expr.Var(123);
         choose cstOrVar {
             case Expr.Xor(_) => false
             case Expr.Cst(_) => true
@@ -64,28 +64,28 @@ mod Test.Exp.Choose.Recursive {
         };
         let h = if (true) f else g;
 
-        let cstOrNot = if (true) open Expr.Cst(true) else open Expr.Not(open Expr.Cst(true));
+        let cstOrNot = if (true) open_variant Expr.Cst(true) else open_variant Expr.Not(open_variant Expr.Cst(true));
         h(cstOrNot)
     }
 
 // TODO RESTR-VARS
 //    pub def testChoose07(): Bool = {
 //        let id = x -> choose x {
-//            case Expr.Cst(y)    => open Expr.Cst(y)
-//            case Expr.Var(y)    => open Expr.Var(y)
-//            case Expr.Not(y)    => open Expr.Not(y)
+//            case Expr.Cst(y)    => open_variant Expr.Cst(y)
+//            case Expr.Var(y)    => open_variant Expr.Var(y)
+//            case Expr.Not(y)    => open_variant Expr.Not(y)
 //        };
-//        let _ = id(open Expr.Cst(true));
+//        let _ = id(open_variant Expr.Cst(true));
 //        true
 //    }
 //
 //    pub def testChoose08(): Bool = {
 //        let unNot = x -> choose x {
-//            case Expr.Cst(y)    => open Expr.Cst(y)
-//            case Expr.Var(y)    => open Expr.Var(y)
+//            case Expr.Cst(y)    => open_variant Expr.Cst(y)
+//            case Expr.Var(y)    => open_variant Expr.Var(y)
 //            case Expr.Not(y)    => y
 //        };
-//        let _ = unNot(open Expr.Cst(true));
+//        let _ = unNot(open_variant Expr.Cst(true));
 //        true
 //    }
 }

--- a/main/test/flix/Test.Exp.Choose.Simple.flix
+++ b/main/test/flix/Test.Exp.Choose.Simple.flix
@@ -17,7 +17,7 @@ mod Test.Exp.Choose.Simple {
     }
 
     pub def testChoose03(): Bool = {
-        let cstOrVar = if (true) open Expr.Cst else open Expr.Var;
+        let cstOrVar = if (true) open_variant Expr.Cst else open_variant Expr.Var;
         choose cstOrVar {
             case Expr.Cst => true
             case Expr.Var => false
@@ -25,7 +25,7 @@ mod Test.Exp.Choose.Simple {
     }
 
     pub def testChoose04(): Bool = {
-        let cstOrVar = if (true) open Expr.Cst else open Expr.Var;
+        let cstOrVar = if (true) open_variant Expr.Cst else open_variant Expr.Var;
         choose cstOrVar {
             case Expr.Xor => false
             case Expr.Cst => true
@@ -59,16 +59,16 @@ mod Test.Exp.Choose.Simple {
         };
         let h = if (true) f else g;
 
-        let cstOrNot = if (true) open Expr.Cst else open Expr.Not;
+        let cstOrNot = if (true) open_variant Expr.Cst else open_variant Expr.Not;
         h(cstOrNot)
     }
 
 //     pub def testChoose07(): Bool = {
 //         let id = x -> choose x {
-//             case Expr.And    => open Expr.And
-//             case Expr.Cst    => open Expr.Cst
-//             case Expr.Not    => open Expr.Not
-//             case Expr.Or     => open Expr.Or
+//             case Expr.And    => open_variant Expr.And
+//             case Expr.Cst    => open_variant Expr.Cst
+//             case Expr.Not    => open_variant Expr.Not
+//             case Expr.Or     => open_variant Expr.Or
 //         };
 //         let _ = id(Expr.Cst);
 //         true

--- a/main/test/flix/Test.Exp.Choose.SimpleTerms.flix
+++ b/main/test/flix/Test.Exp.Choose.SimpleTerms.flix
@@ -23,7 +23,7 @@ mod Test.Exp.Choose.SimpleTerms {
 
 // TODO RESTR-VARS
     pub def testChoose03(): Bool = {
-        let cstOrVar = if (true) open Expr.Cst('a') else open Expr.Var("lol");
+        let cstOrVar = if (true) open_variant Expr.Cst('a') else open_variant Expr.Var("lol");
         choose cstOrVar {
             case Expr.Cst(_) => true
             case Expr.Var(_) => false
@@ -31,7 +31,7 @@ mod Test.Exp.Choose.SimpleTerms {
     }
 
     pub def testChoose04(): Bool = {
-        let cstOrVar = if (true) open Expr.Cst('a') else open Expr.Var("lol");
+        let cstOrVar = if (true) open_variant Expr.Cst('a') else open_variant Expr.Var("lol");
         choose cstOrVar {
             case Expr.Xor(_) => false
             case Expr.Cst(_) => true
@@ -65,7 +65,7 @@ mod Test.Exp.Choose.SimpleTerms {
         };
         let h = if (true) f else g;
 
-        let cstOrNot = if (true) open Expr.Cst('a') else open Expr.Not((123, 123ii, 1e23ff));
+        let cstOrNot = if (true) open_variant Expr.Cst('a') else open_variant Expr.Not((123, 123ii, 1e23ff));
         h(cstOrNot)
     }
 }

--- a/main/test/flix/Test.Exp.ChooseStar.Polymorphic.flix
+++ b/main/test/flix/Test.Exp.ChooseStar.Polymorphic.flix
@@ -54,10 +54,10 @@ mod Test.Exp.ChooseStar.Simple {
 // TODO RESTR-VARS
 //    pub def testChooseStar4(): Bool = {
 //        // P2: check the lower bound by using result in a choose
-//        let star = choose* open Expr.Cst(32.1f32) {
-//            case Expr.Cst(_) => open Expr.Var("tmp")
-//            case Expr.Not(_) => open Expr.Var("tmp")
-//            case Expr.Xor(x, _) => open Expr.Not(Some(x))
+//        let star = choose* open_variant Expr.Cst(32.1f32) {
+//            case Expr.Cst(_) => open_variant Expr.Var("tmp")
+//            case Expr.Not(_) => open_variant Expr.Var("tmp")
+//            case Expr.Xor(x, _) => open_variant Expr.Not(Some(x))
 //        };
 //        choose star {
 //            case Expr.Var(_) => true
@@ -68,9 +68,9 @@ mod Test.Exp.ChooseStar.Simple {
 //
 //    pub def testChooseStar5(): Bool = {
 //        // P3: Check that not is not present
-//        let star = choose* open Expr.Cst(None) {
-//            case Expr.Not(opt) => open Expr.Not(opt)
-//            case Expr.Cst(opt) => open Expr.Var(match opt {
+//        let star = choose* open_variant Expr.Cst(None) {
+//            case Expr.Not(opt) => open_variant Expr.Not(opt)
+//            case Expr.Cst(opt) => open_variant Expr.Var(match opt {
 //                case None => "None"
 //                case Some(_) => "Some"
 //            })
@@ -82,9 +82,9 @@ mod Test.Exp.ChooseStar.Simple {
 //
 //    pub def testChooseStar6(): Bool = {
 //        // P3: Check that not is not present
-//        let star = choose* open Expr.Cst(12) {
-//            case Expr.Not(opt) => open Expr.Not(opt)
-//            case Expr.Cst(x) => open Expr.Cst(x)
+//        let star = choose* open_variant Expr.Cst(12) {
+//            case Expr.Not(opt) => open_variant Expr.Not(opt)
+//            case Expr.Cst(x) => open_variant Expr.Cst(x)
 //        };
 //        choose star {
 //            case Expr.Cst(_) => true
@@ -94,12 +94,12 @@ mod Test.Exp.ChooseStar.Simple {
 //    pub def testChooseStar7(): Bool = {
 //        // P3: Check that Not is not present
 //        let f = c -> choose* c {
-//            case Expr.Not(opt) => open Expr.Not(opt)
-//            case Expr.Cst(_) => open Expr.Var("tmp")
+//            case Expr.Not(opt) => open_variant Expr.Not(opt)
+//            case Expr.Cst(_) => open_variant Expr.Var("tmp")
 //        };
 //        let g = c -> choose* c {
-//            case Expr.Not(opt) => open Expr.Not(opt)
-//            case Expr.Xor(x, y) => open Expr.And(y, x)
+//            case Expr.Not(opt) => open_variant Expr.Not(opt)
+//            case Expr.Xor(x, y) => open_variant Expr.And(y, x)
 //        };
 //        let _ = if (true) f else g;
 //        true

--- a/main/test/flix/Test.Exp.ChooseStar.Simple.flix
+++ b/main/test/flix/Test.Exp.ChooseStar.Simple.flix
@@ -115,7 +115,7 @@ mod Test.Exp.ChooseStar.Simple {
 
     pub def testChoose10(): Bool = {
         // P1: Check that choose* upperbounds the input like choose
-        let cstOrVar = if (true) open Expr.Cst else open Expr.Var;
+        let cstOrVar = if (true) open_variant Expr.Cst else open_variant Expr.Var;
         let thing = choose* cstOrVar {
             case Expr.Cst => Expr.Cst
             case Expr.Var => Expr.Cst
@@ -125,7 +125,7 @@ mod Test.Exp.ChooseStar.Simple {
 
     pub def testChoose11(): Bool = {
         // P1: Check that choose* upperbounds the input like choose
-        let cstOrVar = if (true) open Expr.Cst else open Expr.Var;
+        let cstOrVar = if (true) open_variant Expr.Cst else open_variant Expr.Var;
         let thing = choose* cstOrVar {
             case Expr.Xor => Expr.Xor
             case Expr.Cst => Expr.Cst
@@ -169,7 +169,7 @@ mod Test.Exp.ChooseStar.Simple {
 //        };
 //        let h = if (true) f else g;
 //
-//        let cstOrNot = if (true) open Expr.Cst else open Expr.Not;
+//        let cstOrNot = if (true) open_variant Expr.Cst else open_variant Expr.Not;
 //        choose h(cstOrNot) {case Expr.Cst => true}
 //    }
 


### PR DESCRIPTION
Fixes #7222

* `open` -> `open_variant`
* `open_as` -> `open_variant_as`