### PR TITLE
refactor: add MonoAst

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -101,8 +101,8 @@ class Flix {
     */
   private var cachedLoweringAst: LoweredAst.Root = LoweredAst.empty
   private var cachedTreeShaker1Ast: LoweredAst.Root = LoweredAst.empty
-  private var cachedMonoDefsAst: LoweredAst.Root = LoweredAst.empty
-  private var cachedMonoTypesAst: LoweredAst.Root = LoweredAst.empty
+  private var cachedMonoDefsAst: MonoAst.Root = MonoAst.empty
+  private var cachedMonoTypesAst: MonoAst.Root = MonoAst.empty
   private var cachedSimplifierAst: SimplifiedAst.Root = SimplifiedAst.empty
   private var cachedClosureConvAst: SimplifiedAst.Root = SimplifiedAst.empty
   private var cachedLambdaLiftAst: LiftedAst.Root = LiftedAst.empty
@@ -118,9 +118,9 @@ class Flix {
 
   def getTreeShaker1Ast: LoweredAst.Root = cachedTreeShaker1Ast
 
-  def getMonoDefsAst: LoweredAst.Root = cachedMonoDefsAst
+  def getMonoDefsAst: MonoAst.Root = cachedMonoDefsAst
 
-  def getMonoTypesAst: LoweredAst.Root = cachedMonoTypesAst
+  def getMonoTypesAst: MonoAst.Root = cachedMonoTypesAst
 
   def getSimplifierAst: SimplifiedAst.Root = cachedSimplifierAst
 

--- a/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
@@ -1,0 +1,213 @@
+/*
+  * Copyright 2024 Jonathan Lindegaard Starup
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *   http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package ca.uwaterloo.flix.language.ast
+
+import ca.uwaterloo.flix.language.ast.Ast.{Denotation, EliminatedBy, Source}
+import ca.uwaterloo.flix.language.phase.MonoDefs
+
+object MonoAst {
+
+  val empty: Root = Root(Map.empty, Map.empty, None, Set.empty, Map.empty)
+
+  case class Root(defs: Map[Symbol.DefnSym, Def],
+                  effects: Map[Symbol.EffectSym, Effect],
+                  entryPoint: Option[Symbol.DefnSym],
+                  reachable: Set[Symbol.DefnSym],
+                  sources: Map[Source, SourceLocation])
+
+  case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Expr)
+
+  case class Spec(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, fparams: List[FormalParam], functionType: Type, retTpe: Type, eff: Type, loc: SourceLocation)
+
+  case class Effect(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EffectSym, ops: List[Op], loc: SourceLocation)
+
+  case class Op(sym: Symbol.OpSym, spec: Spec)
+
+  sealed trait Expr extends Product {
+    def tpe: Type
+
+    def eff: Type
+
+    def loc: SourceLocation
+  }
+
+  object Expr {
+
+    case class Cst(cst: Ast.Constant, tpe: Type, loc: SourceLocation) extends Expr {
+      def eff: Type = Type.Pure
+    }
+
+    case class Var(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends Expr {
+      def eff: Type = Type.Pure
+    }
+
+    case class Def(sym: Symbol.DefnSym, tpe: Type, loc: SourceLocation) extends Expr {
+      def eff: Type = Type.Pure
+    }
+
+    @EliminatedBy(MonoDefs.getClass)
+    case class Sig(sym: Symbol.SigSym, tpe: Type, loc: SourceLocation) extends Expr {
+      def eff: Type = Type.Pure
+    }
+
+    case class Lambda(fparam: FormalParam, exp: Expr, tpe: Type, loc: SourceLocation) extends Expr {
+      def eff: Type = Type.Pure
+    }
+
+    case class Apply(exp: Expr, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class ApplyAtomic(op: AtomicOp, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class Let(sym: Symbol.VarSym, mod: Ast.Modifiers, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class LetRec(sym: Symbol.VarSym, mod: Ast.Modifiers, exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class Scope(sym: Symbol.VarSym, regionVar: Type.Var, exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class Stm(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class Discard(exp: Expr, eff: Type, loc: SourceLocation) extends Expr {
+      def tpe: Type = Type.mkUnit(loc)
+    }
+
+    case class Match(exp: Expr, rules: List[MatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class TypeMatch(exp: Expr, rules: List[TypeMatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class VectorLit(exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class VectorLoad(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class VectorLength(exp: Expr, loc: SourceLocation) extends Expr {
+      def eff: Type = exp.eff
+
+      def tpe: Type = Type.Int32
+    }
+
+    case class Ascribe(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class Cast(exp: Expr, declaredType: Option[Type], declaredEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class TryWith(exp: Expr, effUse: Ast.EffectSymUse, rules: List[HandlerRule], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class Do(op: Ast.OpSymUse, exps: List[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+
+    case class NewObject(name: String, clazz: java.lang.Class[_], tpe: Type, eff: Type, methods: List[JvmMethod], loc: SourceLocation) extends Expr
+
+  }
+
+  sealed trait Pattern {
+    def tpe: Type
+
+    def loc: SourceLocation
+  }
+
+  object Pattern {
+
+    case class Wild(tpe: Type, loc: SourceLocation) extends Pattern
+
+    case class Var(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends Pattern
+
+    case class Cst(cst: Ast.Constant, tpe: Type, loc: SourceLocation) extends Pattern
+
+    case class Tag(sym: Ast.CaseSymUse, pat: Pattern, tpe: Type, loc: SourceLocation) extends Pattern
+
+    case class Tuple(elms: List[Pattern], tpe: Type, loc: SourceLocation) extends Pattern
+
+    case class Record(pats: List[Pattern.Record.RecordLabelPattern], pat: Pattern, tpe: Type, loc: SourceLocation) extends Pattern
+
+    case class RecordEmpty(tpe: Type, loc: SourceLocation) extends Pattern
+
+    object Record {
+      case class RecordLabelPattern(label: Name.Label, tpe: Type, pat: Pattern, loc: SourceLocation)
+    }
+  }
+
+  sealed trait Predicate {
+    def loc: SourceLocation
+  }
+
+  object Predicate {
+
+    sealed trait Head extends Predicate
+
+    object Head {
+
+      case class Atom(pred: Name.Pred, den: Denotation, terms: List[Expr], tpe: Type, loc: SourceLocation) extends Predicate.Head
+
+    }
+
+    sealed trait Body extends Predicate
+
+    object Body {
+
+      case class Atom(pred: Name.Pred, den: Denotation, polarity: Ast.Polarity, fixity: Ast.Fixity, terms: List[Pattern], tpe: Type, loc: SourceLocation) extends Predicate.Body
+
+      case class Functional(outVars: List[Symbol.VarSym], exp: Expr, loc: SourceLocation) extends Predicate.Body
+
+      case class Guard(exp: Expr, loc: SourceLocation) extends Predicate.Body
+
+    }
+
+  }
+
+  case class Attribute(name: String, tpe: Type, loc: SourceLocation)
+
+  case class Case(sym: Symbol.CaseSym, tpe: Type, sc: Scheme, loc: SourceLocation)
+
+  case class Constraint(cparams: List[ConstraintParam], head: Predicate.Head, body: List[Predicate.Body], loc: SourceLocation)
+
+  sealed trait ConstraintParam {
+    def sym: Symbol.VarSym
+
+    def tpe: Type
+
+    def loc: SourceLocation
+  }
+
+  object ConstraintParam {
+
+    case class HeadParam(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends ConstraintParam
+
+    case class RuleParam(sym: Symbol.VarSym, tpe: Type, loc: SourceLocation) extends ConstraintParam
+
+  }
+
+  case class FormalParam(sym: Symbol.VarSym, mod: Ast.Modifiers, tpe: Type, src: Ast.TypeSource, loc: SourceLocation)
+
+  case class PredicateParam(pred: Name.Pred, tpe: Type, loc: SourceLocation)
+
+  case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Expr, retTpe: Type, eff: Type, loc: SourceLocation)
+
+  case class CatchRule(sym: Symbol.VarSym, clazz: java.lang.Class[_], exp: Expr)
+
+  case class HandlerRule(op: Ast.OpSymUse, fparams: List[FormalParam], exp: Expr)
+
+  case class MatchRule(pat: Pattern, guard: Option[Expr], exp: Expr)
+
+  case class TypeMatchRule(sym: Symbol.VarSym, tpe: Type, exp: Expr)
+
+  case class SelectChannelRule(sym: Symbol.VarSym, chan: Expr, exp: Expr)
+
+  case class ParYieldFragment(pat: Pattern, exp: Expr, loc: SourceLocation)
+
+
+}

--- a/main/src/ca/uwaterloo/flix/language/dbg/AstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/AstPrinter.scala
@@ -81,8 +81,8 @@ object AstPrinter {
     val backend = List(
       Some(("Lowering", () => formatLoweredAst(flix.getLoweringAst))),
       Some(("TreeShaker1", () => formatLoweredAst(flix.getTreeShaker1Ast))),
-      Some(("MonoDefs", () => formatLoweredAst(flix.getMonoDefsAst))),
-      Some(("MonoTypes", () => formatLoweredAst(flix.getMonoTypesAst))),
+      wipPhase("MonoDefs"),
+      wipPhase("MonoTypes"),
       Some(("Simplifier", () => formatSimplifiedAst(flix.getSimplifierAst))),
       Some(("ClosureConv", () => formatSimplifiedAst(flix.getClosureConvAst))),
       Some(("LambdaLift", () => formatLiftedAst(flix.getLambdaLiftAst))),

--- a/main/src/ca/uwaterloo/flix/language/phase/MonoDefs.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/MonoDefs.scala
@@ -294,8 +294,8 @@ object MonoDefs {
   }
 
   /**
-    * converts the given effect op spec. Assumes that the spec has no variables,
-    * so the subst can be empty.
+    * Converts the given effect op spec. Effect operations are monomorphic -
+    * they have no variables - so the substitution can be empty.
     */
   private def visitEffectOpSpec(spec: LoweredAst.Spec, subst: StrictSubstitution): MonoAst.Spec = spec match {
     case LoweredAst.Spec(doc, ann, mod, _, fparams0, declaredScheme, retTpe, eff, _, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/MonoDefs.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/MonoDefs.scala
@@ -256,6 +256,8 @@ object MonoDefs {
     ParOps.parMap(nonParametricDefns) {
       case (sym, defn) =>
         // We use an empty substitution because the defs are non-parametric.
+        // its important that non-parametric functions keep their symbol to not
+        // invalidate the set of reachable functions.
         mkFreshDefn(sym, defn, empty)
     }
 
@@ -286,7 +288,7 @@ object MonoDefs {
       ctx.toMap,
       effects,
       root.entryPoint,
-      root.reachable, // does this make sense?
+      root.reachable,
       root.sources
     )
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/MonoDefs.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/MonoDefs.scala
@@ -301,7 +301,7 @@ object MonoDefs {
         case LoweredAst.FormalParam(sym, mod, tpe, src, loc) =>
           MonoAst.FormalParam(sym, mod, subst(tpe), src, loc)
       }
-      MonoAst.Spec(doc, ann, mod, fparams, declaredScheme.base, retTpe, eff, loc)
+      MonoAst.Spec(doc, ann, mod, fparams, declaredScheme.base, subst(retTpe), subst(eff), loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/MonoDefs.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/MonoDefs.scala
@@ -18,8 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.Modifiers
-import ca.uwaterloo.flix.language.ast.LoweredAst._
-import ca.uwaterloo.flix.language.ast.{Ast, Kind, LoweredAst, RigidityEnv, Scheme, SourceLocation, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.{Ast, Kind, LoweredAst, MonoAst, RigidityEnv, Scheme, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.phase.unification.{EqualityEnvironment, Substitution, Unification}
 import ca.uwaterloo.flix.util.Result.{Err, Ok}
 import ca.uwaterloo.flix.util.collection.ListMap
@@ -153,7 +152,7 @@ object MonoDefs {
       *
       * Note: We use a concurrent linked queue (which is non-blocking) so threads can enqueue items without contention.
       */
-    private val defQueue: ConcurrentLinkedQueue[(Symbol.DefnSym, Def, StrictSubstitution)] = new ConcurrentLinkedQueue
+    private val defQueue: ConcurrentLinkedQueue[(Symbol.DefnSym, LoweredAst.Def, StrictSubstitution)] = new ConcurrentLinkedQueue
 
     /**
       * Returns `true` if the queue is non-empty.
@@ -169,7 +168,7 @@ object MonoDefs {
       *
       * Note: This is not synchronized.
       */
-    def enqueue(sym: Symbol.DefnSym, defn: Def, subst: StrictSubstitution): Unit = {
+    def enqueue(sym: Symbol.DefnSym, defn: LoweredAst.Def, subst: StrictSubstitution): Unit = {
       defQueue.add((sym, defn, subst))
     }
 
@@ -178,8 +177,8 @@ object MonoDefs {
       *
       * Note: This is not synchronized.
       */
-    def dequeueAll: Array[(Symbol.DefnSym, Def, StrictSubstitution)] = {
-      val r = defQueue.toArray(Array.empty[(Symbol.DefnSym, Def, StrictSubstitution)])
+    def dequeueAll: Array[(Symbol.DefnSym, LoweredAst.Def, StrictSubstitution)] = {
+      val r = defQueue.toArray(Array.empty[(Symbol.DefnSym, LoweredAst.Def, StrictSubstitution)])
       defQueue.clear()
       r
     }
@@ -214,19 +213,19 @@ object MonoDefs {
     /**
       * A map used to collect specialized definitions, etc.
       */
-    private val specializedDefns: mutable.Map[Symbol.DefnSym, LoweredAst.Def] = mutable.Map.empty
+    private val specializedDefns: mutable.Map[Symbol.DefnSym, MonoAst.Def] = mutable.Map.empty
 
     /**
       * Adds a new specialized definition for the given def symbol `sym`.
       */
-    def putSpecializedDef(sym: Symbol.DefnSym, defn: LoweredAst.Def): Unit = synchronized {
+    def putSpecializedDef(sym: Symbol.DefnSym, defn: MonoAst.Def): Unit = synchronized {
       specializedDefns.put(sym, defn)
     }
 
     /**
       * Returns the specialized definitions as an immutable map.
       */
-    def toMap: Map[Symbol.DefnSym, LoweredAst.Def] = synchronized {
+    def toMap: Map[Symbol.DefnSym, MonoAst.Def] = synchronized {
       specializedDefns.toMap
     }
   }
@@ -234,9 +233,9 @@ object MonoDefs {
   /**
     * Performs monomorphization of the given AST `root`.
     */
-  def run(root: Root)(implicit flix: Flix): Root = flix.phase("MonoDefs") {
+  def run(root: LoweredAst.Root)(implicit flix: Flix): MonoAst.Root = flix.phase("MonoDefs") {
 
-    implicit val r: Root = root
+    implicit val r: LoweredAst.Root = root
     implicit val ctx: Context = new Context()
     val empty = StrictSubstitution(Substitution.empty, root.eqEnv)
 
@@ -273,19 +272,42 @@ object MonoDefs {
       }
     }
 
+    val effects = ParOps.parMapValues(root.effects){
+      case LoweredAst.Effect(doc, ann, mod, sym, ops0, loc) =>
+        val ops = ops0.map{
+          case LoweredAst.Op(sym, spec) =>
+            MonoAst.Op(sym, visitEffectOpSpec(spec, empty))
+        }
+        MonoAst.Effect(doc, ann, mod, sym, ops, loc)
+    }
+
     // Reassemble the AST.
-    root.copy(
-      defs = ctx.toMap,
-      classes = Map.empty,
-      instances = Map.empty,
-      sigs = Map.empty
+    MonoAst.Root(
+      ctx.toMap,
+      effects,
+      root.entryPoint,
+      root.reachable, // does this make sense?
+      root.sources
     )
+  }
+
+  /**
+    * converts the given effect op spec. Assumes that the spec has no variables,
+    * so the subst can be empty.
+    */
+  private def visitEffectOpSpec(spec: LoweredAst.Spec, subst: StrictSubstitution): MonoAst.Spec = spec match {
+    case LoweredAst.Spec(doc, ann, mod, _, fparams0, declaredScheme, retTpe, eff, _, loc) =>
+      val fparams = fparams0.map{
+        case LoweredAst.FormalParam(sym, mod, tpe, src, loc) =>
+          MonoAst.FormalParam(sym, mod, subst(tpe), src, loc)
+      }
+      MonoAst.Spec(doc, ann, mod, fparams, declaredScheme.base, retTpe, eff, loc)
   }
 
   /**
     * Adds a specialized def for the given symbol `freshSym` and def `defn` with the given substitution `subst`.
     */
-  private def mkFreshDefn(freshSym: Symbol.DefnSym, defn: Def, subst: StrictSubstitution)(implicit ctx: Context, root: Root, flix: Flix): Unit = {
+  private def mkFreshDefn(freshSym: Symbol.DefnSym, defn: LoweredAst.Def, subst: StrictSubstitution)(implicit ctx: Context, root: LoweredAst.Root, flix: Flix): Unit = {
     // Specialize the formal parameters and introduce fresh local variable symbols.
     val (fparams, env0) = specializeFormalParams(defn.spec.fparams, subst)
 
@@ -295,19 +317,17 @@ object MonoDefs {
     // Reassemble the definition.
     // NB: Removes the type parameters as the function is now monomorphic.
     val spec0 = defn.spec
-    val spec = Spec(
+    val spec = MonoAst.Spec(
       spec0.doc,
       spec0.ann,
       spec0.mod,
-      Nil,
       fparams,
-      Scheme(Nil, Nil, Nil, subst(defn.spec.declaredScheme.base)),
+      subst(defn.spec.declaredScheme.base),
       subst(spec0.retTpe),
       subst(spec0.eff),
-      spec0.tconstrs,
       spec0.loc
     )
-    val specializedDefn = defn.copy(sym = freshSym, spec = spec, exp = specializedExp)
+    val specializedDefn = MonoAst.Def(freshSym, spec, specializedExp)
 
     // Save the specialized function.
     ctx.putSpecializedDef(freshSym, specializedDefn)
@@ -323,85 +343,85 @@ object MonoDefs {
     * If a specialized version of a function does not yet exists, a fresh symbol is created for it, and the
     * definition and substitution is enqueued.
     */
-  private def visitExp(exp0: Expr, env0: Map[Symbol.VarSym, Symbol.VarSym], subst: StrictSubstitution)(implicit ctx: Context, root: Root, flix: Flix): Expr = exp0 match {
-    case Expr.Var(sym, tpe, loc) =>
-      Expr.Var(env0(sym), subst(tpe), loc)
+  private def visitExp(exp0: LoweredAst.Expr, env0: Map[Symbol.VarSym, Symbol.VarSym], subst: StrictSubstitution)(implicit ctx: Context, root: LoweredAst.Root, flix: Flix): MonoAst.Expr = exp0 match {
+    case LoweredAst.Expr.Var(sym, tpe, loc) =>
+      MonoAst.Expr.Var(env0(sym), subst(tpe), loc)
 
-    case Expr.Def(sym, tpe, loc) =>
+    case LoweredAst.Expr.Def(sym, tpe, loc) =>
       /*
        * !! This is where all the magic happens !!
        */
       val newSym = specializeDefSym(sym, subst(tpe))
-      Expr.Def(newSym, subst(tpe), loc)
+      MonoAst.Expr.Def(newSym, subst(tpe), loc)
 
-    case Expr.Sig(sym, tpe, loc) =>
+    case LoweredAst.Expr.Sig(sym, tpe, loc) =>
       val newSym = specializeSigSym(sym, subst(tpe))
-      Expr.Def(newSym, subst(tpe), loc)
+      MonoAst.Expr.Def(newSym, subst(tpe), loc)
 
-    case Expr.Cst(cst, tpe, loc) =>
-      Expr.Cst(cst, subst(tpe), loc)
+    case LoweredAst.Expr.Cst(cst, tpe, loc) =>
+      MonoAst.Expr.Cst(cst, subst(tpe), loc)
 
-    case Expr.Lambda(fparam, exp, tpe, loc) =>
+    case LoweredAst.Expr.Lambda(fparam, exp, tpe, loc) =>
       val (p, env1) = specializeFormalParam(fparam, subst)
       val e = visitExp(exp, env0 ++ env1, subst)
-      Expr.Lambda(p, e, subst(tpe), loc)
+      MonoAst.Expr.Lambda(p, e, subst(tpe), loc)
 
-    case Expr.Apply(exp, exps, tpe, eff, loc) =>
+    case LoweredAst.Expr.Apply(exp, exps, tpe, eff, loc) =>
       val e = visitExp(exp, env0, subst)
       val es = exps.map(visitExp(_, env0, subst))
-      Expr.Apply(e, es, subst(tpe), subst(eff), loc)
+      MonoAst.Expr.Apply(e, es, subst(tpe), subst(eff), loc)
 
-    case Expr.ApplyAtomic(op, exps, tpe, eff, loc) =>
+    case LoweredAst.Expr.ApplyAtomic(op, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp(_, env0, subst))
-      Expr.ApplyAtomic(op, es, subst(tpe), subst(eff), loc)
+      MonoAst.Expr.ApplyAtomic(op, es, subst(tpe), subst(eff), loc)
 
-    case Expr.Let(sym, mod, exp1, exp2, tpe, eff, loc) =>
+    case LoweredAst.Expr.Let(sym, mod, exp1, exp2, tpe, eff, loc) =>
       // Generate a fresh symbol for the let-bound variable.
       val freshSym = Symbol.freshVarSym(sym)
       val env1 = env0 + (sym -> freshSym)
-      Expr.Let(freshSym, mod, visitExp(exp1, env0, subst), visitExp(exp2, env1, subst), subst(tpe), subst(eff), loc)
+      MonoAst.Expr.Let(freshSym, mod, visitExp(exp1, env0, subst), visitExp(exp2, env1, subst), subst(tpe), subst(eff), loc)
 
-    case Expr.LetRec(sym, mod, exp1, exp2, tpe, eff, loc) =>
+    case LoweredAst.Expr.LetRec(sym, mod, exp1, exp2, tpe, eff, loc) =>
       // Generate a fresh symbol for the let-bound variable.
       val freshSym = Symbol.freshVarSym(sym)
       val env1 = env0 + (sym -> freshSym)
-      Expr.LetRec(freshSym, mod, visitExp(exp1, env1, subst), visitExp(exp2, env1, subst), subst(tpe), subst(eff), loc)
+      MonoAst.Expr.LetRec(freshSym, mod, visitExp(exp1, env1, subst), visitExp(exp2, env1, subst), subst(tpe), subst(eff), loc)
 
-    case Expr.Scope(sym, regionVar, exp, tpe, eff, loc) =>
+    case LoweredAst.Expr.Scope(sym, regionVar, exp, tpe, eff, loc) =>
       val freshSym = Symbol.freshVarSym(sym)
       val env1 = env0 + (sym -> freshSym)
       // forcedly mark the region variable as IO inside the region
       val subst1 = StrictSubstitution(subst.s.unbind(regionVar.sym), subst.eqEnv)
       val subst2 = subst1 + (regionVar.sym -> Type.IO)
-      Expr.Scope(freshSym, regionVar, visitExp(exp, env1, subst2), subst(tpe), subst(eff), loc)
+      MonoAst.Expr.Scope(freshSym, regionVar, visitExp(exp, env1, subst2), subst(tpe), subst(eff), loc)
 
-    case Expr.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
+    case LoweredAst.Expr.IfThenElse(exp1, exp2, exp3, tpe, eff, loc) =>
       val e1 = visitExp(exp1, env0, subst)
       val e2 = visitExp(exp2, env0, subst)
       val e3 = visitExp(exp3, env0, subst)
-      Expr.IfThenElse(e1, e2, e3, subst(tpe), subst(eff), loc)
+      MonoAst.Expr.IfThenElse(e1, e2, e3, subst(tpe), subst(eff), loc)
 
-    case Expr.Stm(exp1, exp2, tpe, eff, loc) =>
+    case LoweredAst.Expr.Stm(exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1, env0, subst)
       val e2 = visitExp(exp2, env0, subst)
-      Expr.Stm(e1, e2, subst(tpe), subst(eff), loc)
+      MonoAst.Expr.Stm(e1, e2, subst(tpe), subst(eff), loc)
 
-    case Expr.Discard(exp, eff, loc) =>
+    case LoweredAst.Expr.Discard(exp, eff, loc) =>
       val e = visitExp(exp, env0, subst)
-      Expr.Discard(e, subst(eff), loc)
+      MonoAst.Expr.Discard(e, subst(eff), loc)
 
-    case Expr.Match(exp, rules, tpe, eff, loc) =>
+    case LoweredAst.Expr.Match(exp, rules, tpe, eff, loc) =>
       val rs = rules map {
-        case MatchRule(pat, guard, body) =>
+        case LoweredAst.MatchRule(pat, guard, body) =>
           val (p, env1) = visitPat(pat, subst)
           val extendedEnv = env0 ++ env1
           val g = guard.map(visitExp(_, extendedEnv, subst))
           val b = visitExp(body, extendedEnv, subst)
-          MatchRule(p, g, b)
+          MonoAst.MatchRule(p, g, b)
       }
-      Expr.Match(visitExp(exp, env0, subst), rs, subst(tpe), subst(eff), loc)
+      MonoAst.Expr.Match(visitExp(exp, env0, subst), rs, subst(tpe), subst(eff), loc)
 
-    case Expr.TypeMatch(exp, rules, tpe, _, loc) =>
+    case LoweredAst.Expr.TypeMatch(exp, rules, tpe, _, loc) =>
       // use the non-strict substitution
       // to allow free type variables to match with anything
       val expTpe = subst.nonStrict(exp.tpe)
@@ -411,7 +431,7 @@ object MonoDefs {
         case (acc, Type.Var(sym, _)) => acc.markRigid(sym)
       }
       rules.iterator.flatMap {
-        case TypeMatchRule(sym, t, body0) =>
+        case LoweredAst.TypeMatchRule(sym, t, body0) =>
           // try to unify
           Unification.unifyTypes(expTpe, subst.nonStrict(t), renv) match {
             // Case 1: types don't unify; just continue
@@ -427,62 +447,62 @@ object MonoDefs {
               // visit the body under the extended environment
               val body = visitExp(body0, env1, StrictSubstitution(subst1, root.eqEnv))
               val eff = Type.mkUnion(e.eff, body.eff, loc.asSynthetic)
-              Some(Expr.Let(freshSym, Modifiers.Empty, e, body, StrictSubstitution(subst1, root.eqEnv).apply(tpe), subst1(eff), loc))
+              Some(MonoAst.Expr.Let(freshSym, Modifiers.Empty, e, body, StrictSubstitution(subst1, root.eqEnv).apply(tpe), subst1(eff), loc))
           }
       }.next() // We are safe to get next() because the last case will always match
 
-    case Expr.VectorLit(exps, tpe, eff, loc) =>
+    case LoweredAst.Expr.VectorLit(exps, tpe, eff, loc) =>
       val es = exps.map(visitExp(_, env0, subst))
-      Expr.VectorLit(es, subst(tpe), subst(eff), loc)
+      MonoAst.Expr.VectorLit(es, subst(tpe), subst(eff), loc)
 
-    case Expr.VectorLoad(exp1, exp2, tpe, eff, loc) =>
+    case LoweredAst.Expr.VectorLoad(exp1, exp2, tpe, eff, loc) =>
       val e1 = visitExp(exp1, env0, subst)
       val e2 = visitExp(exp2, env0, subst)
-      Expr.VectorLoad(e1, e2, subst(tpe), subst(eff), loc)
+      MonoAst.Expr.VectorLoad(e1, e2, subst(tpe), subst(eff), loc)
 
-    case Expr.VectorLength(exp, loc) =>
+    case LoweredAst.Expr.VectorLength(exp, loc) =>
       val e = visitExp(exp, env0, subst)
-      Expr.VectorLength(e, loc)
+      MonoAst.Expr.VectorLength(e, loc)
 
-    case Expr.Ascribe(exp, tpe, eff, loc) =>
+    case LoweredAst.Expr.Ascribe(exp, tpe, eff, loc) =>
       val e = visitExp(exp, env0, subst)
-      Expr.Ascribe(e, subst(tpe), subst(eff), loc)
+      MonoAst.Expr.Ascribe(e, subst(tpe), subst(eff), loc)
 
-    case Expr.Cast(exp, _, _, tpe, eff, loc) =>
+    case LoweredAst.Expr.Cast(exp, _, _, tpe, eff, loc) =>
       // We drop the declaredType and declaredEff here.
       val e = visitExp(exp, env0, subst)
-      Expr.Cast(e, None, None, subst(tpe), subst(eff), loc)
+      MonoAst.Expr.Cast(e, None, None, subst(tpe), subst(eff), loc)
 
-    case Expr.TryCatch(exp, rules, tpe, eff, loc) =>
+    case LoweredAst.Expr.TryCatch(exp, rules, tpe, eff, loc) =>
       val e = visitExp(exp, env0, subst)
       val rs = rules map {
-        case CatchRule(sym, clazz, body) =>
+        case LoweredAst.CatchRule(sym, clazz, body) =>
           // Generate a fresh symbol.
           val freshSym = Symbol.freshVarSym(sym)
           val env1 = env0 + (sym -> freshSym)
           val b = visitExp(body, env1, subst)
-          CatchRule(freshSym, clazz, b)
+          MonoAst.CatchRule(freshSym, clazz, b)
       }
-      Expr.TryCatch(e, rs, subst(tpe), subst(eff), loc)
+      MonoAst.Expr.TryCatch(e, rs, subst(tpe), subst(eff), loc)
 
-    case Expr.TryWith(exp, effect, rules, tpe, eff, loc) =>
+    case LoweredAst.Expr.TryWith(exp, effect, rules, tpe, eff, loc) =>
       val e = visitExp(exp, env0, subst)
       val rs = rules map {
-        case HandlerRule(op, fparams0, body0) =>
+        case LoweredAst.HandlerRule(op, fparams0, body0) =>
           val (fparams, fparamEnv) = specializeFormalParams(fparams0, subst)
           val env1 = env0 ++ fparamEnv
           val body = visitExp(body0, env1, subst)
-          HandlerRule(op, fparams, body)
+          MonoAst.HandlerRule(op, fparams, body)
       }
-      Expr.TryWith(e, effect, rs, subst(tpe), subst(eff), loc)
+      MonoAst.Expr.TryWith(e, effect, rs, subst(tpe), subst(eff), loc)
 
-    case Expr.Do(op, exps, tpe, eff, loc) =>
+    case LoweredAst.Expr.Do(op, exps, tpe, eff, loc) =>
       val es = exps.map(visitExp(_, env0, subst))
-      Expr.Do(op, es, subst(tpe), subst(eff), loc)
+      MonoAst.Expr.Do(op, es, subst(tpe), subst(eff), loc)
 
-    case Expr.NewObject(name, clazz, tpe, eff, methods0, loc) =>
+    case LoweredAst.Expr.NewObject(name, clazz, tpe, eff, methods0, loc) =>
       val methods = methods0.map(visitJvmMethod(_, env0, subst))
-      Expr.NewObject(name, clazz, subst(tpe), subst(eff), methods, loc)
+      MonoAst.Expr.NewObject(name, clazz, subst(tpe), subst(eff), methods, loc)
 
   }
 
@@ -491,29 +511,29 @@ object MonoDefs {
     *
     * Returns the new pattern and a mapping from variable symbols to fresh variable symbols.
     */
-  private def visitPat(p0: Pattern, subst: StrictSubstitution)(implicit flix: Flix): (Pattern, Map[Symbol.VarSym, Symbol.VarSym]) = p0 match {
-    case Pattern.Wild(tpe, loc) => (Pattern.Wild(subst(tpe), loc), Map.empty)
-    case Pattern.Var(sym, tpe, loc) =>
+  private def visitPat(p0: LoweredAst.Pattern, subst: StrictSubstitution)(implicit flix: Flix): (MonoAst.Pattern, Map[Symbol.VarSym, Symbol.VarSym]) = p0 match {
+    case LoweredAst.Pattern.Wild(tpe, loc) => (MonoAst.Pattern.Wild(subst(tpe), loc), Map.empty)
+    case LoweredAst.Pattern.Var(sym, tpe, loc) =>
       // Generate a fresh variable symbol for the pattern-bound variable.
       val freshSym = Symbol.freshVarSym(sym)
-      (Pattern.Var(freshSym, subst(tpe), loc), Map(sym -> freshSym))
-    case Pattern.Cst(cst, tpe, loc) => (Pattern.Cst(cst, subst(tpe), loc), Map.empty)
-    case Pattern.Tag(sym, pat, tpe, loc) =>
+      (MonoAst.Pattern.Var(freshSym, subst(tpe), loc), Map(sym -> freshSym))
+    case LoweredAst.Pattern.Cst(cst, tpe, loc) => (MonoAst.Pattern.Cst(cst, subst(tpe), loc), Map.empty)
+    case LoweredAst.Pattern.Tag(sym, pat, tpe, loc) =>
       val (p, env1) = visitPat(pat, subst)
-      (Pattern.Tag(sym, p, subst(tpe), loc), env1)
-    case Pattern.Tuple(elms, tpe, loc) =>
+      (MonoAst.Pattern.Tag(sym, p, subst(tpe), loc), env1)
+    case LoweredAst.Pattern.Tuple(elms, tpe, loc) =>
       val (ps, envs) = elms.map(visitPat(_, subst)).unzip
-      (Pattern.Tuple(ps, subst(tpe), loc), envs.reduce(_ ++ _))
-    case Pattern.Record(pats, pat, tpe, loc) =>
+      (MonoAst.Pattern.Tuple(ps, subst(tpe), loc), envs.reduce(_ ++ _))
+    case LoweredAst.Pattern.Record(pats, pat, tpe, loc) =>
       val (ps, envs) = pats.map {
-        case Pattern.Record.RecordLabelPattern(label, tpe1, pat1, loc1) =>
+        case LoweredAst.Pattern.Record.RecordLabelPattern(label, tpe1, pat1, loc1) =>
           val (p1, env1) = visitPat(pat1, subst)
-          (Pattern.Record.RecordLabelPattern(label, subst(tpe1), p1, loc1), env1)
+          (MonoAst.Pattern.Record.RecordLabelPattern(label, subst(tpe1), p1, loc1), env1)
       }.unzip
       val (p, env1) = visitPat(pat, subst)
       val finalEnv = env1 :: envs
-      (Pattern.Record(ps, p, subst(tpe), loc), finalEnv.reduce(_ ++ _))
-    case Pattern.RecordEmpty(tpe, loc) => (Pattern.RecordEmpty(subst(tpe), loc), Map.empty)
+      (MonoAst.Pattern.Record(ps, p, subst(tpe), loc), finalEnv.reduce(_ ++ _))
+    case LoweredAst.Pattern.RecordEmpty(tpe, loc) => (MonoAst.Pattern.RecordEmpty(subst(tpe), loc), Map.empty)
   }
 
   /**
@@ -521,17 +541,17 @@ object MonoDefs {
     *
     * Returns the new method.
     */
-  private def visitJvmMethod(method: JvmMethod, env0: Map[Symbol.VarSym, Symbol.VarSym], subst: StrictSubstitution)(implicit ctx: Context, root: Root, flix: Flix): JvmMethod = method match {
-    case JvmMethod(ident, fparams0, exp0, tpe, eff, loc) =>
+  private def visitJvmMethod(method: LoweredAst.JvmMethod, env0: Map[Symbol.VarSym, Symbol.VarSym], subst: StrictSubstitution)(implicit ctx: Context, root: LoweredAst.Root, flix: Flix): MonoAst.JvmMethod = method match {
+    case LoweredAst.JvmMethod(ident, fparams0, exp0, tpe, eff, loc) =>
       val (fparams, env1) = specializeFormalParams(fparams0, subst)
       val exp = visitExp(exp0, env0 ++ env1, subst)
-      JvmMethod(ident, fparams, exp, subst(tpe), subst(eff), loc)
+      MonoAst.JvmMethod(ident, fparams, exp, subst(tpe), subst(eff), loc)
   }
 
   /**
     * Returns the def symbol corresponding to the specialized symbol `sym` w.r.t. to the type `tpe`.
     */
-  private def specializeDefSym(sym: Symbol.DefnSym, tpe: Type)(implicit ctx: Context, root: Root, flix: Flix): Symbol.DefnSym = {
+  private def specializeDefSym(sym: Symbol.DefnSym, tpe: Type)(implicit ctx: Context, root: LoweredAst.Root, flix: Flix): Symbol.DefnSym = {
     // Lookup the definition and its declared type.
     val defn = root.defs(sym)
 
@@ -549,7 +569,7 @@ object MonoDefs {
   /**
     * Returns the def symbol corresponding to the specialized symbol `sym` w.r.t. to the type `tpe`.
     */
-  private def specializeSigSym(sym: Symbol.SigSym, tpe0: Type)(implicit ctx: Context, root: Root, flix: Flix): Symbol.DefnSym = {
+  private def specializeSigSym(sym: Symbol.SigSym, tpe0: Type)(implicit ctx: Context, root: LoweredAst.Root, flix: Flix): Symbol.DefnSym = {
     // Perform erasure on the type
     val tpe = eraseType(tpe0)
 
@@ -596,7 +616,7 @@ object MonoDefs {
   /**
     * Returns the def symbol corresponding to the specialized def `defn` w.r.t. to the type `tpe`.
     */
-  private def specializeDef(defn: LoweredAst.Def, tpe: Type)(implicit ctx: Context, root: Root, flix: Flix): Symbol.DefnSym = {
+  private def specializeDef(defn: LoweredAst.Def, tpe: Type)(implicit ctx: Context, root: LoweredAst.Root, flix: Flix): Symbol.DefnSym = {
     // Unify the declared and actual type to obtain the substitution map.
     val subst = infallibleUnify(defn.spec.declaredScheme.base, tpe)
 
@@ -628,7 +648,7 @@ object MonoDefs {
     *
     * Returns the new formal parameters and an environment mapping the variable symbol for each parameter to a fresh symbol.
     */
-  private def specializeFormalParams(fparams0: List[FormalParam], subst0: StrictSubstitution)(implicit flix: Flix): (List[FormalParam], Map[Symbol.VarSym, Symbol.VarSym]) = {
+  private def specializeFormalParams(fparams0: List[LoweredAst.FormalParam], subst0: StrictSubstitution)(implicit flix: Flix): (List[MonoAst.FormalParam], Map[Symbol.VarSym, Symbol.VarSym]) = {
     // Return early if there are no formal parameters.
     if (fparams0.isEmpty)
       return (Nil, Map.empty)
@@ -643,16 +663,16 @@ object MonoDefs {
     *
     * Returns the new formal parameter and an environment mapping the variable symbol to a fresh variable symbol.
     */
-  private def specializeFormalParam(fparam0: FormalParam, subst0: StrictSubstitution)(implicit flix: Flix): (FormalParam, Map[Symbol.VarSym, Symbol.VarSym]) = {
-    val FormalParam(sym, mod, tpe, src, loc) = fparam0
+  private def specializeFormalParam(fparam0: LoweredAst.FormalParam, subst0: StrictSubstitution)(implicit flix: Flix): (MonoAst.FormalParam, Map[Symbol.VarSym, Symbol.VarSym]) = {
+    val LoweredAst.FormalParam(sym, mod, tpe, src, loc) = fparam0
     val freshSym = Symbol.freshVarSym(sym)
-    (FormalParam(freshSym, mod, subst0(tpe), src, loc), Map(sym -> freshSym))
+    (MonoAst.FormalParam(freshSym, mod, subst0(tpe), src, loc), Map(sym -> freshSym))
   }
 
   /**
     * Unifies `tpe1` and `tpe2` which must be unifiable.
     */
-  private def infallibleUnify(tpe1: Type, tpe2: Type)(implicit root: Root, flix: Flix): StrictSubstitution = {
+  private def infallibleUnify(tpe1: Type, tpe2: Type)(implicit root: LoweredAst.Root, flix: Flix): StrictSubstitution = {
     Unification.unifyTypes(tpe1, tpe2, RigidityEnv.empty) match {
       case Result.Ok((subst, econstrs)) => // TODO ASSOC-TYPES consider econstrs
         StrictSubstitution(subst, root.eqEnv)
@@ -666,7 +686,7 @@ object MonoDefs {
     *
     * Flix does not erase normal types, but it does erase Boolean and caseset formulas.
     */
-  private def eraseType(tpe: Type)(implicit root: Root, flix: Flix): Type = tpe match {
+  private def eraseType(tpe: Type)(implicit root: LoweredAst.Root, flix: Flix): Type = tpe match {
     case Type.Var(sym, loc) =>
       sym.kind match {
         case Kind.CaseSet(enumSym) =>


### PR DESCRIPTION
Fixes  #7167

This PR is pure refactoring

* MonoDefs was `Lowered -> Lowered` and is now `Lowered -> MonoAst`
* MonoTypes was `Lowered -> Lowered` and is now `MonoAst -> MonoAst`
* Simplifier was `Lowered -> Simplified` and is now `MonoAst -> Simplified`
* MonoAst is copied from LoweredAst but I've removed things that MonoDefs set to empty (like instances fx)
* The only extra work is that MonoDefs traverses effects now, which was arguably a bug it didn't before

The idea is that in a followup PR, monotypes and monodefs can be merged and monoAst will then contain monotypes

a followup PR is also needed to prettyprint MonoAst