### PR TITLE
refactor: rename `CallType` -> `ExpPosition`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -344,20 +344,20 @@ object Ast {
   }
 
   /**
-    * A common super-type that represents a call type.
+    * A common super-type that represents an expression position (tail position or not).
     */
-  sealed trait CallType
+  sealed trait ExpPosition
 
-  object CallType {
+  object ExpPosition {
     /**
-      * Represents a call in tail position.
+      * Represents an expression in tail position.
       */
-    case object TailCall extends CallType
+    case object Tail extends ExpPosition
 
     /**
-      * Represents a call in non-tail position.
+      * Represents an expression in non-tail position.
       */
-    case object NonTailCall extends CallType
+    case object NonTail extends ExpPosition
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -72,9 +72,9 @@ object ReducedAst {
 
     case class ApplyAtomic(op: AtomicOp, exps: List[Expr], tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class ApplyClo(exp: Expr, exps: List[Expr], ct: Ast.CallType, tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyClo(exp: Expr, exps: List[Expr], ct: Ast.ExpPosition, tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class ApplyDef(sym: Symbol.DefnSym, exps: List[Expr], ct: Ast.CallType, tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyDef(sym: Symbol.DefnSym, exps: List[Expr], ct: Ast.ExpPosition, tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
 
     case class ApplySelfTail(sym: Symbol.DefnSym, actuals: List[Expr], tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -243,13 +243,13 @@ object DocAst {
     def Cst(cst: Ast.Constant): Expression =
       printer.ConstantPrinter.print(cst)
 
-    def ApplyClo(d: Expression, ds: List[Expression], ct: Option[Ast.CallType]): Expression =
+    def ApplyClo(d: Expression, ds: List[Expression], ct: Option[Ast.ExpPosition]): Expression =
       App(d, ds)
 
     def ApplySelfTail(sym: Symbol.DefnSym, ds: List[Expression]): Expression =
       App(AsIs(sym.toString), ds)
 
-    def ApplyDef(sym: Symbol.DefnSym, ds: List[Expression], ct: Option[Ast.CallType]): Expression =
+    def ApplyDef(sym: Symbol.DefnSym, ds: List[Expression], ct: Option[Ast.ExpPosition]): Expression =
       App(AsIs(sym.toString), ds)
 
     def Do(sym: Symbol.OpSym, ds: List[Expression]): Expression =

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.Ast.{BoundBy, CallType}
+import ca.uwaterloo.flix.language.ast.Ast.{BoundBy, ExpPosition}
 import ca.uwaterloo.flix.language.ast.Symbol.{DefnSym, VarSym}
 import ca.uwaterloo.flix.language.ast.{AtomicOp, Level, LiftedAst, Purity, ReducedAst, SemanticOp, SourceLocation, Symbol}
 import ca.uwaterloo.flix.language.phase.jvm.GenExpression
@@ -228,11 +228,11 @@ object EffectBinder {
     case LiftedAst.Expr.ApplyClo(exp, exps, tpe, purity, loc) =>
       val e = visitExprWithBinders(binders)(exp)
       val es = exps.map(visitExprWithBinders(binders))
-      ReducedAst.Expr.ApplyClo(e, es, CallType.NonTailCall, tpe, purity, loc)
+      ReducedAst.Expr.ApplyClo(e, es, ExpPosition.NonTail, tpe, purity, loc)
 
     case LiftedAst.Expr.ApplyDef(sym, exps, tpe, purity, loc) =>
       val es = exps.map(visitExprWithBinders(binders))
-      ReducedAst.Expr.ApplyDef(sym, es, CallType.NonTailCall, tpe, purity, loc)
+      ReducedAst.Expr.ApplyDef(sym, es, ExpPosition.NonTail, tpe, purity, loc)
 
     case LiftedAst.Expr.IfThenElse(exp1, exp2, exp3, tpe, purity, loc) =>
       val e1 = visitExprInnerWithBinders(binders)(exp1)

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -1,7 +1,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.Ast.CallType
+import ca.uwaterloo.flix.language.ast.Ast.ExpPosition
 import ca.uwaterloo.flix.language.ast.ReducedAst.Expr._
 import ca.uwaterloo.flix.language.ast.ReducedAst._
 import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoType, Purity, SourceLocation, Symbol}
@@ -130,11 +130,11 @@ object Eraser {
 
     case ApplyClo(exp, exps, ct, tpe, purity, loc) =>
       val ac = ApplyClo(visitExp(exp), exps.map(visitExp), ct, box(tpe), purity, loc)
-      if (ct == CallType.TailCall) ac
+      if (ct == ExpPosition.Tail) ac
       else castExp(unboxExp(ac, erase(tpe), purity, loc), visitType(tpe), purity, loc)
     case ApplyDef(sym, exps, ct, tpe, purity, loc) =>
       val ad = ApplyDef(sym, exps.map(visitExp), ct, box(tpe), purity, loc)
-      if (ct == CallType.TailCall) ad
+      if (ct == ExpPosition.Tail) ad
       else castExp(unboxExp(ad, erase(tpe), purity, loc), visitType(tpe), purity, loc)
     case ApplySelfTail(sym, actuals, tpe, purity, loc) =>
       ApplySelfTail(sym, actuals.map(visitExp), visitType(tpe), purity, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Inliner.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Inliner.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.CompilationMessage
-import ca.uwaterloo.flix.language.ast.Ast.CallType
+import ca.uwaterloo.flix.language.ast.Ast.ExpPosition
 import ca.uwaterloo.flix.language.ast.OccurrenceAst.Occur._
 import ca.uwaterloo.flix.language.ast.Purity.Pure
 import ca.uwaterloo.flix.language.ast.{Ast, AtomicOp, LiftedAst, MonoType, OccurrenceAst, Purity, SemanticOp, SourceLocation, Symbol}

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.Ast.CallType
+import ca.uwaterloo.flix.language.ast.Ast.ExpPosition
 import ca.uwaterloo.flix.language.ast.{MonoType, Purity}
 import ca.uwaterloo.flix.language.ast.ReducedAst._
 import ca.uwaterloo.flix.util.ParOps
@@ -84,13 +84,13 @@ object Reducer {
         Expr.ApplyAtomic(op, es, tpe, purity, loc)
 
       case Expr.ApplyClo(exp, exps, ct, tpe, purity, loc) =>
-        if (ct == CallType.NonTailCall && Purity.isControlImpure(purity)) lctx.pcPoints += 1
+        if (ct == ExpPosition.NonTail && Purity.isControlImpure(purity)) lctx.pcPoints += 1
         val e = visitExpr(exp)
         val es = exps.map(visitExpr)
         Expr.ApplyClo(e, es, ct, tpe, purity, loc)
 
       case Expr.ApplyDef(sym, exps, ct, tpe, purity, loc) =>
-        if (ct == CallType.NonTailCall && Purity.isControlImpure(purity)) lctx.pcPoints += 1
+        if (ct == ExpPosition.NonTail && Purity.isControlImpure(purity)) lctx.pcPoints += 1
         val es = exps.map(visitExpr)
         Expr.ApplyDef(sym, es, ct, tpe, purity, loc)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Tailrec.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Tailrec.scala
@@ -28,7 +28,7 @@ import ca.uwaterloo.flix.util.collection.MapOps
   * Specifically, it replaces [[Expr.ApplyDef]] AST nodes with [[Expr.ApplySelfTail]] AST nodes
   * when the [[Expr.ApplyDef]] node calls the enclosing function and occurs in tail position.
   *
-  * For correctness it is assumed that all calls in the given AST have [[Ast.CallType.NonTailCall]]
+  * For correctness it is assumed that all calls in the given AST have [[Ast.ExpPosition.NonTail]]
   * and there are no [[Expr.ApplySelfTail]] nodes present.
   */
 object Tailrec {
@@ -82,13 +82,13 @@ object Tailrec {
         Expr.Branch(e0, br, tpe, purity, loc)
 
       case Expr.ApplyClo(exp, exps, _, tpe, purity, loc) =>
-        Expr.ApplyClo(exp, exps, Ast.CallType.TailCall, tpe, purity, loc)
+        Expr.ApplyClo(exp, exps, Ast.ExpPosition.Tail, tpe, purity, loc)
 
       case Expr.ApplyDef(sym, exps, _, tpe, purity, loc) =>
         // Check whether this is a self recursive call.
         if (defn.sym != sym) {
           // Tail call.
-          Expr.ApplyDef(sym, exps, Ast.CallType.TailCall, tpe, purity, loc)
+          Expr.ApplyDef(sym, exps, Ast.ExpPosition.Tail, tpe, purity, loc)
         } else {
           // Self recursive tail call.
           Expr.ApplySelfTail(sym, exps, tpe, purity, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -18,7 +18,7 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.Ast.CallType
+import ca.uwaterloo.flix.language.ast.Ast.ExpPosition
 import ca.uwaterloo.flix.language.ast.ReducedAst._
 import ca.uwaterloo.flix.language.ast.SemanticOp._
 import ca.uwaterloo.flix.language.ast.{MonoType, _}
@@ -1078,7 +1078,7 @@ object GenExpression {
 
     case Expr.ApplyClo(exp, exps, ct, _, purity, loc) =>
       ct match {
-        case CallType.TailCall =>
+        case ExpPosition.Tail =>
           // Type of the function abstract class
           val functionInterface = JvmOps.getFunctionInterfaceType(exp.tpe)
           val closureAbstractClass = JvmOps.getClosureAbstractClassType(exp.tpe)
@@ -1100,7 +1100,7 @@ object GenExpression {
           // Return the closure
           mv.visitInsn(ARETURN)
 
-        case CallType.NonTailCall =>
+        case ExpPosition.NonTail =>
           // Type of the function abstract class
           val functionInterface = JvmOps.getFunctionInterfaceType(exp.tpe)
           val closureAbstractClass = JvmOps.getClosureAbstractClassType(exp.tpe)
@@ -1140,7 +1140,7 @@ object GenExpression {
       }
 
     case Expr.ApplyDef(sym, exps, ct, _, purity, loc) => ct match {
-      case CallType.TailCall =>
+      case ExpPosition.Tail =>
         // Type of the function abstract class
         val functionInterface = JvmOps.getFunctionInterfaceType(root.defs(sym).arrowType)
 
@@ -1158,7 +1158,7 @@ object GenExpression {
         // Return the def
         mv.visitInsn(ARETURN)
 
-      case CallType.NonTailCall =>
+      case ExpPosition.NonTail =>
         // JvmType of Def
         val defJvmType = JvmOps.getFunctionDefinitionClassType(sym)
 


### PR DESCRIPTION
Related to# 7183

Also reames
- `TailCall` -> `Tail`
- `NonTailCall` -> `NonTail`