### PR TITLE
style: rename `from` to `src` and `to` to `dst`

### DIFF
--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -549,16 +549,16 @@ mod Array {
         init(rc1, f, len)
 
     ///
-    /// Returns a copy of `a` with every occurrence of `from` replaced by `to`.
+    /// Returns a copy of `a` with every occurrence of `src` replaced by `dst`.
     ///
-    pub def replace(rc1: Region[r1], from: {from = a}, to: {to = a}, a: Array[a, r]): Array[a, r1] \ { r, r1 } with Eq[a] =
-        map(rc1, e -> if (e == from.from) to.to else e, a)
+    pub def replace(rc1: Region[r1], src: {src = a}, dst: {dst = a}, a: Array[a, r]): Array[a, r1] \ { r, r1 } with Eq[a] =
+        map(rc1, e -> if (e == src.src) dst.dst else e, a)
 
     ///
-    /// Replace every occurrence of `from` by `to` in the array `a`, mutating it in place.
+    /// Replace every occurrence of `src` by `dst` in the array `a`, mutating it in place.
     ///
-    pub def replace!(from: {from = a}, to: {to = a}, a: Array[a, r]): Unit \ r with Eq[a] =
-        transform!(e -> if (e == from.from) to.to else e, a)
+    pub def replace!(src: {src = a}, dst: {dst = a}, a: Array[a, r]): Unit \ r with Eq[a] =
+        transform!(e -> if (e == src.src) dst.dst else e, a)
 
     ///
     /// Returns `b` with the `n` elements starting at index `i` replaced with the elements of `a`.

--- a/main/src/library/GetOpt.flix
+++ b/main/src/library/GetOpt.flix
@@ -416,6 +416,6 @@ mod GetOpt {
     /// Remove all quote marks from the list of tokens.
     ///
     def removeQuoteMarks(quoteOpen: String, quoteClose: String, args: List[String]): List[String] =
-        args |> List.map(String.replace({from = quoteOpen}, {to = ""}) >> String.replace({from = quoteClose}, {to = ""}))
+        args |> List.map(String.replace({src = quoteOpen}, {dst = ""}) >> String.replace({src = quoteClose}, {dst = ""}))
 
 }

--- a/main/src/library/Graph.flix
+++ b/main/src/library/Graph.flix
@@ -508,7 +508,7 @@ mod Graph {
     /// with backslash.
     ///
     def graphvizId(id: t): String with ToString[t] = {
-        "\"${String.replace(from = "\"", to = "\\\"", "${id}")}\""
+        "\"${String.replace(src = "\"", dst = "\\\"", "${id}")}\""
     }
 
     ///

--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -287,12 +287,12 @@ mod Iterator {
         Iterator(rc, iterF1)
 
     ///
-    /// Returns an iterator with every occurrence of `from` replaced by `to` in `iter`.
+    /// Returns an iterator with every occurrence of `src` replaced by `dst` in `iter`.
     ///
     /// Does *not* consume any elements from the iterator.
     ///
-    pub def replace(from: {from = a}, to: {to = a}, iter: Iterator[a, ef, r]): Iterator[a, ef, r] with Eq[a] =
-        map(a -> if (a == from.from) to.to else a, iter)
+    pub def replace(src: {src = a}, dst: {dst = a}, iter: Iterator[a, ef, r]): Iterator[a, ef, r] with Eq[a] =
+        map(a -> if (a == src.src) dst.dst else a, iter)
 
     ///
     /// Returns `iterB` appended to (the end of) `iterA`.

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -649,10 +649,10 @@ mod MutList {
         l1 := deref l2
 
     ///
-    /// Replaces all occurrences of the `from` with `to` in the given mutable list `v`.
+    /// Replaces all occurrences of the `src` with `dst` in the given mutable list `v`.
     ///
-    pub def replace!(from: {from = a}, to: {to = a}, v: MutList[a, r]): Unit \ r with Eq[a] =
-        transform!(e -> if (e == from.from) to.to else e, v)
+    pub def replace!(src: {src = a}, dst: {dst = a}, v: MutList[a, r]): Unit \ r with Eq[a] =
+        transform!(e -> if (e == src.src) dst.dst else e, v)
 
     ///
     /// Reverses the order of the elements in the given mutable list `v`.

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -104,13 +104,13 @@ mod MutSet {
         ms := Set.filter(f, deref ms)
 
     ///
-    /// Replaces the element `from` with the element `to` if `from` is in the mutable set `s`.
+    /// Replaces the element `src` with the element `dst` if `from` is in the mutable set `s`.
     ///
     /// The mutable set `s` is unchanged if the element `from` is not in it.
     ///
-    pub def replace!(from: {from = a}, to: {to = a}, s: MutSet[a, r]): Unit \ r with Order[a] =
+    pub def replace!(src: {src = a}, dst: {dst = a}, s: MutSet[a, r]): Unit \ r with Order[a] =
         let MutSet(_, ms) = s;
-        ms := Set.replace(from = from.from, to = to.to, deref ms)
+        ms := Set.replace(src = src.src, dst = dst.dst, deref ms)
 
     ///
     /// Applies the function `f` to every element in the mutable set `s`.

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -424,10 +424,10 @@ mod Nec {
         }
 
     ///
-    /// Returns `l` with every occurrence of `from` replaced by `to`.
+    /// Returns `l` with every occurrence of `src` replaced by `dst`.
     ///
-    pub def replace(from: {from = a}, to: {to = a}, l: Nec[a]): Nec[a] with Eq[a] =
-        map(e -> if (e == from.from) to.to else e, l)
+    pub def replace(src: {src = a}, dst: {dst = a}, l: Nec[a]): Nec[a] with Eq[a] =
+        map(e -> if (e == src.src) dst.dst else e, l)
 
     ///
     /// Returns all permutations of `c` in lexicographical order by element indices in `c`.

--- a/main/src/library/Regex.flix
+++ b/main/src/library/Regex.flix
@@ -202,21 +202,21 @@ mod Regex {
 
 
     ///
-    /// Returns string `s` with every match of the Regex `from` replaced by the string `to`.
+    /// Returns string `s` with every match of the Regex `src` replaced by the string `dst`.
     ///
-    pub def replace(from: {from = Regex}, to: {to = String}, s: String): String = region rc {
+    pub def replace(src: {src = Regex}, dst: {dst = String}, s: String): String = region rc {
         import java.util.regex.Matcher.replaceAll(String): String \ rc;
-        let Matcher(m1) = newMatcher(rc, from.from, s);
-        replaceAll(m1, to.to)
+        let Matcher(m1) = newMatcher(rc, src.src, s);
+        replaceAll(m1, dst.dst)
     }
 
     ///
-    /// Returns string `s` with the first match of the regular expression `from` replaced by the string `to`.
+    /// Returns string `s` with the first match of the regular expression `src` replaced by the string `dst`.
     ///
-    pub def replaceFirst(from: {from = Regex}, to: {to = String}, s: String): String = region rc {
+    pub def replaceFirst(src: {src = Regex}, dst: {dst = String}, s: String): String = region rc {
         import java.util.regex.Matcher.replaceFirst(String): String \ rc;
-        let Matcher(m1) = newMatcher(rc, from.from, s);
-        replaceFirst(m1, to.to)
+        let Matcher(m1) = newMatcher(rc, src.src, s);
+        replaceFirst(m1, dst.dst)
     }
 
     ///

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -82,10 +82,10 @@ mod Result {
     }
 
     ///
-    /// Returns `Ok(to)` if `r` is `Ok(from)`. Otherwise returns `r`.
+    /// Returns `Ok(dst)` if `r` is `Ok(src)`. Otherwise returns `r`.
     ///
-    pub def replace(from: {from = t}, to: {to = t}, r: Result[e, t]): Result[e, t] with Eq[t] = match r {
-        case Ok(v)  => Ok(if (v == from.from) to.to else v)
+    pub def replace(src: {src = t}, dst: {dst = t}, r: Result[e, t]): Result[e, t] with Eq[t] = match r {
+        case Ok(v)  => Ok(if (v == src.src) dst.dst else v)
         case Err(_) => r
     }
 

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -474,12 +474,12 @@ mod Set {
         foldLeft(step, empty(), s)
 
     ///
-    /// Replaces the element `from` with `to` if `from` is in `s`. Otherwise, returns `s`.
+    /// Replaces the element `src` with `dst` if `src` is in `s`. Otherwise, returns `s`.
     ///
     /// Note: The returned set may be smaller than `s`.
     ///
-    pub def replace(from: {from = a}, to: {to = a}, s: Set[a]): Set[a] with Order[a] =
-        if (memberOf(from.from, s)) insert(to.to, remove(from.from, s)) else s
+    pub def replace(src: {src = a}, dst: {dst = a}, s: Set[a]): Set[a] with Order[a] =
+        if (memberOf(src.src, s)) insert(dst.dst, remove(src.src, s)) else s
 
     ///
     /// Returns a pair of sets `(s1, s2)`.

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -818,18 +818,18 @@ mod String {
     }
 
     ///
-    /// Returns `s` with every match of the substring `from` replaced by the string `to`.
+    /// Returns `s` with every match of the substring `src` replaced by the string `dst`.
     ///
-    pub def replace(from: {from = String}, to: {to = String}, s: String): String =
+    pub def replace(src: {src = String}, dst: {dst = String}, s: String): String =
         import java.lang.String.replace(##java.lang.CharSequence, ##java.lang.CharSequence): String \ {};
-        replace(s, checked_cast(from.from), checked_cast(to.to))
+        replace(s, checked_cast(src.src), checked_cast(dst.dst))
 
     ///
-    /// Returns `s` with every match of the character `target` replaced by the character `rep`.
+    /// Returns `s` with every match of the character `src` replaced by the character `dst`.
     ///
-    pub def replaceChar(from: {from = Char}, to: {to = Char}, s: String): String =
+    pub def replaceChar(src: {src = Char}, dst: {dst = Char}, s: String): String =
         import java.lang.String.replace(Char, Char): String \ {};
-        replace(s, from.from, to.to)
+        replace(s, src.src, dst.dst)
 
     ///
     /// Returns `s` with every match of the regular expression `regex` replaced by the string `to`.
@@ -1380,7 +1380,7 @@ mod String {
     /// Unwrap the string, replacing every newline with a space
     ///
     pub def unwrap(s: String): String =
-        Regex.replace({from = regex"[\r\n]+"}, {to = " "}, s)
+        Regex.replace({src = regex"[\r\n]+"}, {dst = " "}, s)
 
     ///
     /// Returns an iterator over `s`.

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -716,10 +716,10 @@ mod Vector {
         exists(x -> length(x) != l, vs)
 
     ///
-    /// Returns a copy of `v` with every occurrence of `from` replaced by `to`.
+    /// Returns a copy of `v` with every occurrence of `src` replaced by `dst`.
     ///
-    pub def replace(from: {from = a}, to: {to = a}, v: Vector[a]): Vector[a] with Eq[a] =
-        map(e -> if (e == from.from) to.to else e, v)
+    pub def replace(src: {src = a}, dst: {dst = a}, v: Vector[a]): Vector[a] with Eq[a] =
+        map(e -> if (e == src.src) dst.dst else e, v)
 
     ///
     /// Returns `true` if and only if `a` is a prefix of `b`.

--- a/main/src/resources/benchmark/BenchmarkSet.flix
+++ b/main/src/resources/benchmark/BenchmarkSet.flix
@@ -173,21 +173,21 @@ mod BenchmarkSet {
     ///
     @benchmark
     pub def benchmark25(): Bool =
-        Set.memberOf(24, Set.replace(from = 0, to = 24, Set.range(0, 24)))
+        Set.memberOf(24, Set.replace(src = 0, dst = 24, Set.range(0, 24)))
 
     ///
     /// create a set of `Int32` and replace a mid-valued element with a high-valued element.
     ///
     @benchmark
     pub def benchmark26(): Bool =
-        Set.memberOf(24, Set.replace(from = 12, to = 24, Set.range(0, 24)))
+        Set.memberOf(24, Set.replace(src = 12, dst = 24, Set.range(0, 24)))
 
     ///`
     /// create a set of `Int32` and replace a high-valued element with a low valued-element.
     ///
     @benchmark
     pub def benchmark27(): Bool =
-        Set.memberOf(-1, Set.replace(from = 23, to = -1, Set.range(0, 24)))
+        Set.memberOf(-1, Set.replace(src = 23, dst = -1, Set.range(0, 24)))
 
     ///
     /// create a set of 4 `Int32` and compute the size of its subsets.

--- a/main/test/ca/uwaterloo/flix/library/TestArray.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestArray.flix
@@ -1427,49 +1427,49 @@ mod TestArray {
 
     @test
     def replace01(): Bool = region rc {
-        let a = Array.replace(rc, from = 3, to = 4, Array#{} @ rc);
+        let a = Array.replace(rc, src = 3, dst =  4, Array#{} @ rc);
         Array.sameElements(a, ((Array#{} @ rc): Array[Int32, _]))
     }
 
     @test
     def replace02(): Bool = region rc {
-        let a = Array.replace(rc, from = 3, to = 4, Array#{1} @ rc);
+        let a = Array.replace(rc, src = 3, dst =  4, Array#{1} @ rc);
         Array.sameElements(a, Array#{1} @ rc)
     }
 
     @test
     def replace03(): Bool = region rc {
-        let a = Array.replace(rc, from = 3, to = 4, Array#{3} @ rc);
+        let a = Array.replace(rc, src = 3, dst =  4, Array#{3} @ rc);
         Array.sameElements(a, Array#{4} @ rc)
     }
 
     @test
     def replace04(): Bool = region rc {
-        let a = Array.replace(rc, from = 3, to = 4, Array#{4} @ rc);
+        let a = Array.replace(rc, src = 3, dst =  4, Array#{4} @ rc);
         Array.sameElements(a, Array#{4} @ rc)
     }
 
     @test
     def replace05(): Bool = region rc {
-        let a = Array.replace(rc, from = 3, to = 4, Array#{1, 2} @ rc);
+        let a = Array.replace(rc, src = 3, dst =  4, Array#{1, 2} @ rc);
         Array.sameElements(a, Array#{1,2} @ rc)
     }
 
     @test
     def replace06(): Bool = region rc {
-        let a = Array.replace(rc, from = 3, to = 4, Array#{1,3} @ rc);
+        let a = Array.replace(rc, src = 3, dst =  4, Array#{1,3} @ rc);
         Array.sameElements(a, Array#{1,4} @ rc)
     }
 
     @test
     def replace07(): Bool = region rc {
-        let a = Array.replace(rc, from = 3, to = 4, Array#{3,4} @ rc);
+        let a = Array.replace(rc, src = 3, dst =  4, Array#{3,4} @ rc);
         Array.sameElements(a, Array#{4,4} @ rc)
     }
 
     @test
     def replace08(): Bool = region rc {
-        let a = Array.replace(rc, from = 3, to = 4, Array#{3,3} @ rc);
+        let a = Array.replace(rc, src = 3, dst =  4, Array#{3,3} @ rc);
         Array.sameElements(a, Array#{4,4} @ rc)
     }
 
@@ -1480,56 +1480,56 @@ mod TestArray {
     @test
     def replace01!(): Bool = region rc {
         let a: Array[Int32, _] = Array#{} @ rc;
-        Array.replace!(from = 3, to = 4, a);
+        Array.replace!(src = 3, dst =  4, a);
         Array.sameElements(a, ((Array#{} @ rc): Array[Int32, _]))
     }
 
     @test
     def replace02!(): Bool = region rc {
         let a = Array#{1} @ rc;
-        Array.replace!(from = 3, to = 4, a);
+        Array.replace!(src = 3, dst =  4, a);
         Array.sameElements(a, Array#{1} @ rc)
     }
 
     @test
     def replace03!(): Bool = region rc {
         let a = Array#{3} @ rc;
-        Array.replace!(from = 3, to = 4, a);
+        Array.replace!(src = 3, dst =  4, a);
         Array.sameElements(a, Array#{4} @ rc)
     }
 
     @test
     def replace04!(): Bool = region rc {
         let a = Array#{4} @ rc;
-        Array.replace!(from = 3, to = 4, a);
+        Array.replace!(src = 3, dst =  4, a);
         Array.sameElements(a, Array#{4} @ rc)
     }
 
     @test
     def replace05!(): Bool = region rc {
         let a = Array#{1, 2} @ rc;
-        Array.replace!(from = 3, to = 4, a);
+        Array.replace!(src = 3, dst =  4, a);
         Array.sameElements(a, Array#{1,2} @ rc)
     }
 
     @test
     def replace06!(): Bool = region rc {
         let a = Array#{1,3} @ rc;
-        Array.replace!(from = 3, to = 4, a);
+        Array.replace!(src = 3, dst =  4, a);
         Array.sameElements(a, Array#{1,4} @ rc)
     }
 
     @test
     def replace07!(): Bool = region rc {
         let a = Array#{3,4} @ rc;
-        Array.replace!(from = 3, to = 4, a);
+        Array.replace!(src = 3, dst =  4, a);
         Array.sameElements(a, Array#{4,4} @ rc)
     }
 
     @test
     def replace08!(): Bool = region rc {
         let a = Array#{3,3} @ rc;
-        Array.replace!(from = 3, to = 4, a);
+        Array.replace!(src = 3, dst =  4, a);
         Array.sameElements(a, Array#{4,4} @ rc)
     }
 

--- a/main/test/ca/uwaterloo/flix/library/TestIterator.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterator.flix
@@ -588,49 +588,49 @@ mod TestIterator {
     @test
     def replace01(): Bool = region rc {
         List.iterator(rc, Nil) |>
-            Iterator.replace(from = 3, to = 4) |> Iterator.toList == Nil
+            Iterator.replace(src =  3, dst =  4) |> Iterator.toList == Nil
     }
 
     @test
     def replace02(): Bool = region rc {
         List.iterator(rc, 1 :: Nil) |>
-            Iterator.replace(from = 3, to = 4) |> Iterator.toList == 1 :: Nil
+            Iterator.replace(src =  3, dst =  4) |> Iterator.toList == 1 :: Nil
     }
 
     @test
     def replace03(): Bool = region rc {
         List.iterator(rc, 3 :: Nil) |>
-            Iterator.replace(from = 3, to = 4) |> Iterator.toList == 4 :: Nil
+            Iterator.replace(src =  3, dst =  4) |> Iterator.toList == 4 :: Nil
     }
 
     @test
     def replace04(): Bool = region rc {
         List.iterator(rc, 4 :: Nil) |>
-            Iterator.replace(from = 3, to = 4) |> Iterator.toList == 4 :: Nil
+            Iterator.replace(src =  3, dst =  4) |> Iterator.toList == 4 :: Nil
     }
 
     @test
     def replace05(): Bool = region rc {
         List.iterator(rc, 1 :: 2 :: Nil) |>
-            Iterator.replace(from = 3, to = 4) |> Iterator.toList == 1 :: 2 :: Nil
+            Iterator.replace(src =  3, dst =  4) |> Iterator.toList == 1 :: 2 :: Nil
     }
 
     @test
     def replace06(): Bool = region rc {
         List.iterator(rc, 1 :: 3 :: Nil) |>
-            Iterator.replace(from = 3, to = 4) |> Iterator.toList == 1 :: 4 :: Nil
+            Iterator.replace(src =  3, dst =  4) |> Iterator.toList == 1 :: 4 :: Nil
     }
 
     @test
     def replace07(): Bool = region rc {
         List.iterator(rc, 3 :: 4 :: Nil) |>
-            Iterator.replace(from = 3, to = 4) |> Iterator.toList == 4 :: 4 :: Nil
+            Iterator.replace(src =  3, dst =  4) |> Iterator.toList == 4 :: 4 :: Nil
     }
 
     @test
     def replace08(): Bool = region rc {
         List.iterator(rc, 3 :: 3 :: Nil) |>
-            Iterator.replace(from = 3, to = 4) |> Iterator.toList == 4 :: 4 :: Nil
+            Iterator.replace(src =  3, dst =  4) |> Iterator.toList == 4 :: 4 :: Nil
     }
 
     /////////////////////////////////////////////////////////////////////////////

--- a/main/test/ca/uwaterloo/flix/library/TestMutList.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutList.flix
@@ -1288,7 +1288,7 @@ mod TestMutList {
         MutList.push!(2, l1);
         MutList.push!(1, l1);
         MutList.push!(1, l1);
-        MutList.replace!(from = 1, to = 42, l1);
+        MutList.replace!(src = 1, dst = 42, l1);
         let l2 = MutList.empty(rc);
         let xs = 42 :: 2 :: 2 :: 42 :: 42 :: Nil;
         List.forEach(x -> MutList.push!(x, l2), xs);
@@ -1298,7 +1298,7 @@ mod TestMutList {
     @test
     def replace!02(): Bool = region rc {
         let l1 = MutList.range(rc, 4, 7);
-        MutList.replace!(from = 4, to = 0, l1);
+        MutList.replace!(src = 4, dst = 0, l1);
         let l2 = MutList.empty(rc);
         let xs = 0 :: 5 :: 6 :: Nil;
         List.forEach(x -> MutList.push!(x, l2), xs);
@@ -1308,7 +1308,7 @@ mod TestMutList {
     @test
     def replace!03(): Bool = region rc {
         let l1 = MutList.range(rc, 4, 7);
-        MutList.replace!(from = 5, to = 0, l1);
+        MutList.replace!(src = 5, dst = 0, l1);
         let l2 = MutList.empty(rc);
         let xs = 4 :: 0 :: 6 :: Nil;
         List.forEach(x -> MutList.push!(x, l2), xs);
@@ -1318,7 +1318,7 @@ mod TestMutList {
     @test
     def replace!04(): Bool = region rc {
         let l1 = MutList.range(rc, 4, 7);
-        MutList.replace!(from = 6, to = 0, l1);
+        MutList.replace!(src = 6, dst = 0, l1);
         let l2 = MutList.empty(rc);
         let xs = 4 :: 5 :: 0 :: Nil;
         List.forEach(x -> MutList.push!(x, l2), xs);
@@ -1330,7 +1330,7 @@ mod TestMutList {
         let l1 = MutList.empty(rc);
         let xs1 = List.repeat(97, 'a');
         List.forEach(x -> MutList.push!(x, l1), xs1);
-        MutList.replace!(from = 'a', to = 'z', l1);
+        MutList.replace!(src = 'a', dst = 'z', l1);
         let l2 = MutList.empty(rc);
         let xs2 = List.repeat(97, 'z');
         List.forEach(x -> MutList.push!(x, l2), xs2);

--- a/main/test/ca/uwaterloo/flix/library/TestNec.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestNec.flix
@@ -553,16 +553,16 @@ mod TestNec {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def replace01(): Bool = Nec.replace(from = 1, to = 42, singleton(1)) == singleton(42)
+    def replace01(): Bool = Nec.replace(src =  1, dst =  42, singleton(1)) == singleton(42)
 
     @test
-    def replace02(): Bool = Nec.replace(from = 7, to = 42, singleton(1)) == singleton(1)
+    def replace02(): Bool = Nec.replace(src =  7, dst =  42, singleton(1)) == singleton(1)
 
     @test
-    def replace03(): Bool = Nec.replace(from = 2, to = 42, necOf2(1, 2)) == necOf2(1, 42)
+    def replace03(): Bool = Nec.replace(src =  2, dst =  42, necOf2(1, 2)) == necOf2(1, 42)
 
     @test
-    def replace04(): Bool = Nec.replace(from = 7, to = 42, necOf2(1, 2)) == necOf2(1, 2)
+    def replace04(): Bool = Nec.replace(src =  7, dst =  42, necOf2(1, 2)) == necOf2(1, 2)
 
     /////////////////////////////////////////////////////////////////////////////
     // permutations                                                            //

--- a/main/test/ca/uwaterloo/flix/library/TestRegex.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestRegex.flix
@@ -332,27 +332,27 @@ mod TestRegex {
 
     @test
     def replace01(): Bool =
-        Regex.replace(from = regex"\\p{Blank}+", to = "_", "") == ""
+        Regex.replace(src = regex"\\p{Blank}+", dst = "_", "") == ""
 
     @test
     def replace02(): Bool =
-        Regex.replace(from = regex"\\p{Blank}+", to = "_", "A B C") == "A_B_C"
+        Regex.replace(src = regex"\\p{Blank}+", dst = "_", "A B C") == "A_B_C"
 
     @test
     def replace03(): Bool =
-        Regex.replace(from = regex"\\p{Blank}+", to = "_", "A  B   C") == "A_B_C"
+        Regex.replace(src = regex"\\p{Blank}+", dst = "_", "A  B   C") == "A_B_C"
 
     @test
     def replace04(): Bool =
-        Regex.replace(from = regex"\\p{Blank}+", to = "_", "ABC") == "ABC"
+        Regex.replace(src = regex"\\p{Blank}+", dst = "_", "ABC") == "ABC"
 
     @test
     def replace05(): Bool =
-        Regex.replace(from = regex"\\p{Blank}+", to = "__", "A B  C") == "A__B__C"
+        Regex.replace(src = regex"\\p{Blank}+", dst = "__", "A B  C") == "A__B__C"
 
     @test
     def replace06(): Bool =
-        Regex.replace(from = regex"\\p{Blank}+", to = "__", " A B  C  ") == "__A__B__C__"
+        Regex.replace(src = regex"\\p{Blank}+", dst = "__", " A B  C  ") == "__A__B__C__"
 
     /////////////////////////////////////////////////////////////////////////////
     // replaceFirst                                                            //
@@ -360,27 +360,27 @@ mod TestRegex {
 
     @test
     def replaceFirst01(): Bool =
-        Regex.replaceFirst(from = regex"\\p{Blank}+", to = "_", "") == ""
+        Regex.replaceFirst(src = regex"\\p{Blank}+", dst = "_", "") == ""
 
     @test
     def replaceFirst02(): Bool =
-        Regex.replaceFirst(from = regex"\\p{Blank}+", to = "_", "A B C") == "A_B C"
+        Regex.replaceFirst(src = regex"\\p{Blank}+", dst = "_", "A B C") == "A_B C"
 
     @test
     def replaceFirst03(): Bool =
-        Regex.replaceFirst(from = regex"\\p{Blank}+", to = "_", "A  B   C") == "A_B   C"
+        Regex.replaceFirst(src = regex"\\p{Blank}+", dst = "_", "A  B   C") == "A_B   C"
 
     @test
     def replaceFirst04(): Bool =
-        Regex.replaceFirst(from = regex"\\p{Blank}+", to = "_", "ABC")  == "ABC"
+        Regex.replaceFirst(src = regex"\\p{Blank}+", dst = "_", "ABC")  == "ABC"
 
     @test
     def replaceFirst05(): Bool =
-        Regex.replaceFirst(from = regex"\\p{Blank}+", to = "__", "A B  C") == "A__B  C"
+        Regex.replaceFirst(src = regex"\\p{Blank}+", dst = "__", "A B  C") == "A__B  C"
 
     @test
     def replaceFirst06(): Bool =
-        Regex.replaceFirst(from = regex"\\p{Blank}+", to = "__", " A B  C  ") == "__A B  C  "
+        Regex.replaceFirst(src = regex"\\p{Blank}+", dst = "__", " A B  C  ") == "__A B  C  "
 
     /////////////////////////////////////////////////////////////////////////////
     // startsWith                                                              //

--- a/main/test/ca/uwaterloo/flix/library/TestResult.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestResult.flix
@@ -105,16 +105,16 @@ mod TestResult {
     // replace                                                                 //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def replace01(): Bool = Result.replace(from = 3, to = 4, Err(false)) == Err(false)
+    def replace01(): Bool = Result.replace(src =  3, dst =  4, Err(false)) == Err(false)
 
     @test
-    def replace02(): Bool = (Result.replace(from = 3, to = 4, (Ok(2): Result[Unit, Int32]))) == Ok(2)
+    def replace02(): Bool = (Result.replace(src =  3, dst =  4, (Ok(2): Result[Unit, Int32]))) == Ok(2)
 
     @test
-    def replace03(): Bool = (Result.replace(from = 3, to = 4, (Ok(3): Result[Unit, Int32]))) == Ok(4)
+    def replace03(): Bool = (Result.replace(src =  3, dst =  4, (Ok(3): Result[Unit, Int32]))) == Ok(4)
 
     @test
-    def replace04(): Bool = (Result.replace(from = 3, to = 4, (Ok(4): Result[Unit, Int32]))) == Ok(4)
+    def replace04(): Bool = (Result.replace(src =  3, dst =  4, (Ok(4): Result[Unit, Int32]))) == Ok(4)
 
     /////////////////////////////////////////////////////////////////////////////
     // exists                                                                  //

--- a/main/test/ca/uwaterloo/flix/library/TestSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSet.flix
@@ -1027,28 +1027,28 @@ def filterMap08(): Bool =
 // replace                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 @test
-def replace01(): Bool = Set.replace(from = 3, to = 4, Set#{}) == Set#{}
+def replace01(): Bool = Set.replace(src = 3, dst = 4, Set#{}) == Set#{}
 
 @test
-def replace02(): Bool = Set.replace(from = 3, to = 4, Set#{1}) == Set#{1}
+def replace02(): Bool = Set.replace(src = 3, dst = 4, Set#{1}) == Set#{1}
 
 @test
-def replace03(): Bool = Set.replace(from = 3, to = 4, Set#{3}) == Set#{4}
+def replace03(): Bool = Set.replace(src = 3, dst = 4, Set#{3}) == Set#{4}
 
 @test
-def replace04(): Bool = Set.replace(from = 3, to = 4, Set#{4}) == Set#{4}
+def replace04(): Bool = Set.replace(src = 3, dst = 4, Set#{4}) == Set#{4}
 
 @test
-def replace05(): Bool = Set.replace(from = 3, to = 4, Set#{1, 2}) == Set#{1, 2}
+def replace05(): Bool = Set.replace(src = 3, dst = 4, Set#{1, 2}) == Set#{1, 2}
 
 @test
-def replace06(): Bool = Set.replace(from = 3, to = 4, Set#{1, 3}) == Set#{1, 4}
+def replace06(): Bool = Set.replace(src = 3, dst = 4, Set#{1, 3}) == Set#{1, 4}
 
 @test
-def replace07(): Bool = Set.replace(from = 3, to = 4, Set#{3, 2}) == Set#{4, 2}
+def replace07(): Bool = Set.replace(src = 3, dst = 4, Set#{3, 2}) == Set#{4, 2}
 
 @test
-def replace08(): Bool = Set.replace(from = 3, to = 4, Set#{3, 4}) == Set#{4}
+def replace08(): Bool = Set.replace(src = 3, dst = 4, Set#{3, 4}) == Set#{4}
 
 /////////////////////////////////////////////////////////////////////////////
 // partition                                                               //

--- a/main/test/ca/uwaterloo/flix/library/TestString.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestString.flix
@@ -2272,56 +2272,56 @@ def center17(): Bool = String.center(8, '_', "abc") == "__abc___"
 /////////////////////////////////////////////////////////////////////////////
 
 @test
-def replace01(): Bool = String.replace({from = "c"}, {to = "d"}, "") == ""
+def replace01(): Bool = String.replace({src = "c"}, {dst = "d"}, "") == ""
 
 @test
-def replace02(): Bool = String.replace({from = "c"}, {to = "d"}, "a") == "a"
+def replace02(): Bool = String.replace({src = "c"}, {dst = "d"}, "a") == "a"
 
 @test
-def replace03(): Bool = String.replace({from = "c"}, {to = "d"}, "c") == "d"
+def replace03(): Bool = String.replace({src = "c"}, {dst = "d"}, "c") == "d"
 
 @test
-def replace04(): Bool = String.replace({from = "c"}, {to = "d"}, "d") == "d"
+def replace04(): Bool = String.replace({src = "c"}, {dst = "d"}, "d") == "d"
 
 @test
-def replace05(): Bool = String.replace({from = "c"}, {to = "d"}, "ab") == "ab"
+def replace05(): Bool = String.replace({src = "c"}, {dst = "d"}, "ab") == "ab"
 
 @test
-def replace06(): Bool = String.replace({from = "c"}, {to = "d"}, "abc") == "abd"
+def replace06(): Bool = String.replace({src = "c"}, {dst = "d"}, "abc") == "abd"
 
 @test
-def replace07(): Bool = String.replace({from = "c"}, {to = "d"}, "cd") == "dd"
+def replace07(): Bool = String.replace({src = "c"}, {dst = "d"}, "cd") == "dd"
 
 @test
-def replace08(): Bool = String.replace({from = "c"}, {to = "d"}, "cc") == "dd"
+def replace08(): Bool = String.replace({src = "c"}, {dst = "d"}, "cc") == "dd"
 
 /////////////////////////////////////////////////////////////////////////////
 // replaceChar                                                             //
 /////////////////////////////////////////////////////////////////////////////
 
 @test
-def replaceChar01(): Bool = String.replaceChar({from = 'c'}, {to = 'd'}, "") == ""
+def replaceChar01(): Bool = String.replaceChar({src = 'c'}, {dst = 'd'}, "") == ""
 
 @test
-def replaceChar02(): Bool = String.replaceChar({from = 'c'}, {to = 'd'}, "a") == "a"
+def replaceChar02(): Bool = String.replaceChar({src = 'c'}, {dst = 'd'}, "a") == "a"
 
 @test
-def replaceChar03(): Bool = String.replaceChar({from = 'c'}, {to = 'd'}, "c") == "d"
+def replaceChar03(): Bool = String.replaceChar({src = 'c'}, {dst = 'd'}, "c") == "d"
 
 @test
-def replaceChar04(): Bool = String.replaceChar({from = 'c'}, {to = 'd'}, "d") == "d"
+def replaceChar04(): Bool = String.replaceChar({src = 'c'}, {dst = 'd'}, "d") == "d"
 
 @test
-def replaceChar05(): Bool = String.replaceChar({from = 'c'}, {to = 'd'}, "ab") == "ab"
+def replaceChar05(): Bool = String.replaceChar({src = 'c'}, {dst = 'd'}, "ab") == "ab"
 
 @test
-def replaceChar06(): Bool = String.replaceChar({from = 'c'}, {to = 'd'}, "abc") == "abd"
+def replaceChar06(): Bool = String.replaceChar({src = 'c'}, {dst = 'd'}, "abc") == "abd"
 
 @test
-def replaceChar07(): Bool = String.replaceChar({from = 'c'}, {to = 'd'}, "cd") == "dd"
+def replaceChar07(): Bool = String.replaceChar({src = 'c'}, {dst = 'd'}, "cd") == "dd"
 
 @test
-def replaceChar08(): Bool = String.replaceChar({from = 'c'}, {to = 'd'}, "cc") == "dd"
+def replaceChar08(): Bool = String.replaceChar({src = 'c'}, {dst = 'd'}, "cc") == "dd"
 
 /////////////////////////////////////////////////////////////////////////////
 // replaceMatches                                                          //

--- a/main/test/ca/uwaterloo/flix/library/TestVector.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestVector.flix
@@ -1246,42 +1246,42 @@ mod TestVector {
 
     @test
     def replace01(): Bool =
-        let v = Vector.replace(from = 3, to = 4, (Vector#{}: Vector[Int32]));
+        let v = Vector.replace(src = 3, dst = 4, (Vector#{}: Vector[Int32]));
         v == Vector#{}
 
     @test
     def replace02(): Bool =
-        let v = Vector.replace(from = 3, to = 4, Vector#{1});
+        let v = Vector.replace(src = 3, dst = 4, Vector#{1});
         v == Vector#{1}
 
     @test
     def replace03(): Bool =
-        let v = Vector.replace(from = 3, to = 4, Vector#{3});
+        let v = Vector.replace(src = 3, dst = 4, Vector#{3});
         v == Vector#{4}
 
     @test
     def replace04(): Bool =
-        let v = Vector.replace(from = 3, to = 4, Vector#{4});
+        let v = Vector.replace(src = 3, dst = 4, Vector#{4});
         v == Vector#{4}
 
     @test
     def replace05(): Bool =
-        let v = Vector.replace(from = 3, to = 4, Vector#{1, 2});
+        let v = Vector.replace(src = 3, dst = 4, Vector#{1, 2});
         v == Vector#{1, 2}
 
     @test
     def replace06(): Bool =
-        let v = Vector.replace(from = 3, to = 4, Vector#{1, 3});
+        let v = Vector.replace(src = 3, dst = 4, Vector#{1, 3});
         v == Vector#{1, 4}
 
     @test
     def replace07(): Bool =
-        let v = Vector.replace(from = 3, to = 4, Vector#{3, 4});
+        let v = Vector.replace(src = 3, dst = 4, Vector#{3, 4});
         v == Vector#{4, 4}
 
     @test
     def replace08(): Bool =
-        let v = Vector.replace(from = 3, to = 4, Vector#{3, 3});
+        let v = Vector.replace(src = 3, dst = 4, Vector#{3, 3});
         v == Vector#{4, 4}
 
     /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Some missing renaming in the standard library and its tests.