### PR TITLE
chore: `class` -> `trait` in language phase tests

### DIFF
--- a/main/test/ca/uwaterloo/flix/language/phase/TestDeriver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestDeriver.scala
@@ -46,7 +46,7 @@ class TestDeriver extends AnyFunSuite with TestUtils {
   test("IllegalDerivation.01") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |enum E with C {
         |    case E

--- a/main/test/ca/uwaterloo/flix/language/phase/TestEntryPoint.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestEntryPoint.scala
@@ -44,7 +44,7 @@ class TestEntryPoint extends AnyFunSuite with TestUtils {
   test("Test.IllegalEntryPointArg.Main.03") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |def main(blah: Array[a, _]): Unit \ IO with C[a] = checked_ecast(())
         |""".stripMargin

--- a/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
@@ -27,7 +27,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.OverlappingInstance.01") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |instance C[Int32]
         |
@@ -40,7 +40,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.OverlappingInstance.02") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |instance C[(a, b)]
         |
@@ -53,7 +53,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.OverlappingInstance.03") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |instance C[a -> b \ ef1]
         |
@@ -70,7 +70,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
         |    case Box(a)
         |}
         |
-        |class C[a]
+        |trait C[a]
         |
         |instance C[Box[a]]
         |
@@ -83,7 +83,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.OverlappingInstances.05") {
     val input =
       """
-        | class C[a] {
+        | trait C[a] {
         |  pub def f(x: a, y: a): Bool
         |}
         |
@@ -104,7 +104,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.ComplexInstanceType.01") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |instance C[(a, Int32)]
         |""".stripMargin
@@ -115,7 +115,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.ComplexInstanceType.02") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |instance C[Unit -> a]
         |""".stripMargin
@@ -130,7 +130,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
         |    case Box(a)
         |}
         |
-        |class C[a]
+        |trait C[a]
         |
         |instance C[Box[Int32]]
         |""".stripMargin
@@ -141,7 +141,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.ComplexInstanceType.05") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |instance C[Int32 -> b \ e]
         |""".stripMargin
@@ -156,7 +156,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
         |    case Box(a)
         |}
         |
-        |class C[a]
+        |trait C[a]
         |
         |instance C[Box[a] -> b \ e]
         |""".stripMargin
@@ -167,7 +167,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.ComplexInstanceType.07") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |instance C[a]
         |""".stripMargin
@@ -178,7 +178,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.ComplexInstanceType.08") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |instance C[m[a]]
         |""".stripMargin
@@ -189,7 +189,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.DuplicateTypeParameter.01") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |instance C[(a, a)]
         |""".stripMargin
@@ -200,7 +200,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.DuplicateTypeParameter.02") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |instance C[a -> a \ ef]
         |""".stripMargin
@@ -215,7 +215,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
         |    case DoubleBox(a, b)
         |}
         |
-        |class C[a]
+        |trait C[a]
         |
         |instance C[DoubleBox[a, a]]
         |""".stripMargin
@@ -226,7 +226,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.MissingImplementation.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def get(): a
         |}
         |
@@ -240,7 +240,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.MismatchedSignatures.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def get(): a
         |}
         |
@@ -255,7 +255,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.MismatchedSignatures.02") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def f(x: a): Bool
         |}
         |
@@ -274,7 +274,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.MismatchSignatures.03") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def f(x: a): String
         |}
         |
@@ -299,11 +299,11 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.MismatchedSignatures.04") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def f(x: b): a with D[b]
         |}
         |
-        |class D[a]
+        |trait D[a]
         |
         |instance C[Bool] {
         |    pub def f(x: b): Bool = false
@@ -316,7 +316,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.MismatchedSignatures.05") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def f(x: a, y: Int32): Int32
         |}
         |
@@ -331,7 +331,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.MismatchedSignatures.06") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def f(x: a, y: Int32): Int32 \ e
         |}
         |
@@ -346,7 +346,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.ExtraneousDefinition.01") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |instance C[Bool] {
         |    pub def get(): Bool = false
@@ -359,7 +359,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.OrphanInstance.01") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |mod C {
         |    instance C[Int32]
@@ -373,7 +373,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
     val input =
       """
         |mod N {
-        |    pub class C[a]
+        |    pub trait C[a]
         |}
         |
         |instance N.C[Int32]
@@ -386,7 +386,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
     val input =
       """
         |mod N {
-        |    class C[a]
+        |    trait C[a]
         |
         |    mod C {
         |        instance N.C[Int32]
@@ -401,7 +401,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
     val input =
       """
         |mod N {
-        |    class C[a]
+        |    trait C[a]
         |
         |    mod O {
         |        instance N.C[Int32]
@@ -415,8 +415,8 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.MissingSuperClassInstance.01") {
     val input =
       """
-        |class A[a] with B[a]
-        |class B[a]
+        |trait A[a] with B[a]
+        |trait B[a]
         |
         |instance A[Int32]
         |""".stripMargin
@@ -427,9 +427,9 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.MissingSuperClassInstance.02") {
     val input =
       """
-        |class A[a] with B[a], C[a]
-        |class B[a]
-        |class C[a]
+        |trait A[a] with B[a], C[a]
+        |trait B[a]
+        |trait C[a]
         |
         |instance A[Int32]
         |instance B[Int32]
@@ -441,8 +441,8 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.MissingSuperClassInstance.03") {
     val input =
       """
-        |class A[a] with B[a]
-        |class B[a]
+        |trait A[a] with B[a]
+        |trait B[a]
         |
         |instance A[Int32]
         |instance B[Bool]
@@ -484,7 +484,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.MultipleErrors.01") {
     val input =
       """
-        |class Foo[a] {
+        |trait Foo[a] {
         |    pub def bar(): a
         |}
         |
@@ -500,7 +500,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.IllegalOverride.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |  pub def f(x: a): Bool
         |}
         |
@@ -515,7 +515,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.UnmarkedOverride.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |  pub def f(x: a): Bool = true
         |}
         |
@@ -530,7 +530,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.ComplexErrorSuppressesOtherErrors.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |  pub def f(x: a): Bool
         |}
         |
@@ -550,7 +550,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.TypeAliasInstance.01") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |type alias T = Int32
         |instance C[T]
         |""".stripMargin
@@ -561,7 +561,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.TypeAliasInstance.02") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |type alias T[a] = Int32
         |instance C[T[a]]
         |""".stripMargin
@@ -572,11 +572,11 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.AssocTypeInstance.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    type T[a]: Type
         |}
         |
-        |class D[a]
+        |trait D[a]
         |
         |instance D[C.T[a]]
         |""".stripMargin
@@ -587,8 +587,8 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.MissingConstraint.01") {
     val input =
       """
-        |class C[a]
-        |class D[a] with C[a]
+        |trait C[a]
+        |trait D[a] with C[a]
         |
         |instance C[(a, b)] with C[a], C[b]
         |instance D[(a, b)]
@@ -600,11 +600,11 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.MissingConstraint.02") {
     val input =
       """
-        |class C[a]
-        |class D[a] with C[a]
-        |class E[a] with D[a]
+        |trait C[a]
+        |trait D[a] with C[a]
+        |trait E[a] with D[a]
         |
-        |class F[a]
+        |trait F[a]
         |
         |instance C[(a, b)] with C[a], C[b]
         |instance D[(a, b)] with C[a], C[b], F[a], F[b]
@@ -617,8 +617,8 @@ class TestInstances extends AnyFunSuite with TestUtils {
   test("Test.MissingConstraint.03") {
     val input =
       """
-        |class C[a]
-        |class D[a] with C[a]
+        |trait C[a]
+        |trait D[a] with C[a]
         |
         |instance C[(a, b)] with C[a], C[b]
         |instance D[(a, b)] with D[a], D[b]

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -656,7 +656,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.TypeConstraint.01") {
     val input =
       """
-        |class C[a: Type -> Type]
+        |trait C[a: Type -> Type]
 
         |def f[a: Type](): a with C[a] = ???
         |""".stripMargin
@@ -676,7 +676,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Mismatch.02") {
     val input =
       """
-        |class C[a: Type -> Type]
+        |trait C[a: Type -> Type]
         |
         |def f(x: a): Int32 with C[a] = ???
         |""".stripMargin
@@ -775,7 +775,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Instance.Def.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |  pub def f(x: a): a
         |}
         |
@@ -792,9 +792,9 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Instance.TypeConstraint.01") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
-        |class D[a: Type -> Type]
+        |trait D[a: Type -> Type]
         |
         |enum E[a]
         |
@@ -807,7 +807,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Instance.TypeParameter.01") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |enum E[a]
         |
@@ -844,7 +844,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Class.Law.01") {
     val input =
       """
-        |class C[a: Type -> Type] {
+        |trait C[a: Type -> Type] {
         |  law l: forall (x: a) . ???
         |}
         |""".stripMargin
@@ -855,7 +855,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Class.Sig.01") {
     val input =
       """
-        |class C[a: Type -> Type] {
+        |trait C[a: Type -> Type] {
         |  pub def f(x: a): Int32 = ???
         |}
         |""".stripMargin
@@ -866,7 +866,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Class.Sig.02") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |  pub def f(x: {l =  Int32 | a}): Int32 = ???
         |}
         |""".stripMargin
@@ -877,9 +877,9 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Class.TypeConstraint.01") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
-        |class D[a: Type -> Type] with C[a]
+        |trait D[a: Type -> Type] with C[a]
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -1018,7 +1018,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.MissingConstraint.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    type T
         |}
         |

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -103,7 +103,7 @@ class TestNamer extends AnyFunSuite with TestUtils {
   test("DuplicateLowerName.07") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def f(x: a): Int
         |    pub def f(x: a): Bool
         |}
@@ -115,7 +115,7 @@ class TestNamer extends AnyFunSuite with TestUtils {
   test("DuplicateLowerName.08") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def f(x: a): Int
         |    pub def f(x: a): Bool
         |    pub def f(x: Int): a
@@ -128,7 +128,7 @@ class TestNamer extends AnyFunSuite with TestUtils {
   test("DuplicateLowerName.09") {
     val input =
       s"""
-         |class A[a] {
+         |trait A[a] {
          |  pub def f(x: a): Int
          |}
          |
@@ -149,7 +149,7 @@ class TestNamer extends AnyFunSuite with TestUtils {
          |
          |mod A {
          |  mod B {
-         |    class C[a] {
+         |    trait C[a] {
          |      pub def f(x: a): Int
          |    }
          |  }
@@ -167,7 +167,7 @@ class TestNamer extends AnyFunSuite with TestUtils {
          |}
          |
          |mod A {
-         |  class C[a] {
+         |  trait C[a] {
          |    pub def f(x: a): Int
          |  }
          |}
@@ -335,7 +335,7 @@ class TestNamer extends AnyFunSuite with TestUtils {
     val input =
       s"""
          |type alias USD = Int
-         |class USD[a]
+         |trait USD[a]
        """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[NameError.DuplicateUpperName](result)
@@ -346,7 +346,7 @@ class TestNamer extends AnyFunSuite with TestUtils {
       s"""
          |type alias USD = Int
          |type alias USD = Int
-         |class USD[a]
+         |trait USD[a]
        """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[NameError.DuplicateUpperName](result)
@@ -360,7 +360,7 @@ class TestNamer extends AnyFunSuite with TestUtils {
          |}
          |
          |mod A {
-         |  class USD[a]
+         |  trait USD[a]
          |}
        """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
@@ -373,7 +373,7 @@ class TestNamer extends AnyFunSuite with TestUtils {
          |enum USD {
          |  case A
          |}
-         |class USD[a]
+         |trait USD[a]
        """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[NameError.DuplicateUpperName](result)
@@ -388,7 +388,7 @@ class TestNamer extends AnyFunSuite with TestUtils {
          |enum USD {
          |  case B
          |}
-         |class USD[a]
+         |trait USD[a]
        """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[NameError.DuplicateUpperName](result)
@@ -404,7 +404,7 @@ class TestNamer extends AnyFunSuite with TestUtils {
          |}
          |
          |mod A {
-         |  class USD[a]
+         |  trait USD[a]
          |}
        """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
@@ -414,8 +414,8 @@ class TestNamer extends AnyFunSuite with TestUtils {
   test("DuplicateUpperName.16") {
     val input =
       s"""
-         |class USD[a]
-         |class USD[a]
+         |trait USD[a]
+         |trait USD[a]
        """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[NameError.DuplicateUpperName](result)
@@ -424,9 +424,9 @@ class TestNamer extends AnyFunSuite with TestUtils {
   test("DuplicateUpperName.17") {
     val input =
       s"""
-         |class USD[a]
-         |class USD[a]
-         |class USD[a]
+         |trait USD[a]
+         |trait USD[a]
+         |trait USD[a]
          """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[NameError.DuplicateUpperName](result)
@@ -436,11 +436,11 @@ class TestNamer extends AnyFunSuite with TestUtils {
     val input =
       s"""
          |mod A {
-         |  class USD[a]
+         |  trait USD[a]
          |}
          |
          |mod A {
-         |  class USD[a]
+         |  trait USD[a]
          |}
        """.stripMargin
     val result = compile(input, Options.TestWithLibNix)
@@ -460,7 +460,7 @@ class TestNamer extends AnyFunSuite with TestUtils {
   test("DuplicateUpperName.20") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |eff C
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestPatExhaustiveness.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestPatExhaustiveness.scala
@@ -306,7 +306,7 @@ class TestPatExhaustiveness extends AnyFunSuite with TestUtils {
         |    case E2
         |}
         |
-        |class C[a] {
+        |trait C[a] {
         |    pub def f(x: a): Int32
         |}
         |
@@ -328,7 +328,7 @@ class TestPatExhaustiveness extends AnyFunSuite with TestUtils {
         |    case E2
         |}
         |
-        |class C[a] {
+        |trait C[a] {
         |    pub def f(_x: a): Int32 = match E.E1 {
         |        case E.E1 => 1
         |    }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -1462,7 +1462,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
   test("UnusedFormalParam.Instance.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def f(x: a): a
         |}
         |
@@ -1509,9 +1509,9 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
   test("RedundantTypeConstraint.Class.01") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
-        |class D[a] with C[a], C[a]
+        |trait D[a] with C[a], C[a]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[RedundancyError.RedundantTypeConstraint](result)
@@ -1520,11 +1520,11 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
   test("RedundantTypeConstraint.Class.02") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
-        |class D[a] with C[a]
+        |trait D[a] with C[a]
         |
-        |class E[a] with C[a], D[a]
+        |trait E[a] with C[a], D[a]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[RedundancyError.RedundantTypeConstraint](result)
@@ -1533,7 +1533,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
   test("RedundantTypeConstraint.Def.01") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |pub def f(x: a): Bool with C[a], C[a] = ???
         |""".stripMargin
@@ -1544,9 +1544,9 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
   test("RedundantTypeConstraint.Def.02") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
-        |class D[a] with C[a]
+        |trait D[a] with C[a]
         |
         |pub def f(x: a): Bool with C[a], D[a] = ???
         |""".stripMargin
@@ -1557,9 +1557,9 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
   test("RedundantTypeConstraint.Sig.01") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
-        |class D[a] {
+        |trait D[a] {
         |  pub def f(x: a): Bool with C[a], C[a]
         |}
         |""".stripMargin
@@ -1570,11 +1570,11 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
   test("RedundantTypeConstraint.Sig.02") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
-        |class D[a] with C[a]
+        |trait D[a] with C[a]
         |
-        |class E[a] {
+        |trait E[a] {
         |  pub def f(x: a): Bool with C[a], D[a]
         |}
         |""".stripMargin
@@ -1587,9 +1587,9 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
       """
         |enum Box[a](a)
         |
-        |class C[a]
+        |trait C[a]
         |
-        |class D[a]
+        |trait D[a]
         |
         |instance D[Box[a]] with C[a], C[a]
         |""".stripMargin
@@ -1602,11 +1602,11 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
       """
         |enum Box[a](a)
         |
-        |class C[a]
+        |trait C[a]
         |
-        |class D[a] with C[a]
+        |trait D[a] with C[a]
         |
-        |class E[a]
+        |trait E[a]
         |
         |instance E[Box[a]] with C[a], C[a]
         |""".stripMargin

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -159,7 +159,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     val input =
       s"""
          |mod A {
-         |  class Show[a] {
+         |  trait Show[a] {
          |    pub def show(x: a): String
          |  }
          |}
@@ -179,7 +179,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
          |  def f(x: a): Int32 with A.B.C.Show[a] = ???
          |
          |  mod B.C {
-         |    class Show[a] {
+         |    trait Show[a] {
          |      pub def show(x: a): String
          |    }
          |  }
@@ -193,7 +193,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     val input =
       """
         |mod N {
-        |    class C[a]
+        |    trait C[a]
         |}
         |
         |mod O {
@@ -208,11 +208,11 @@ class TestResolver extends AnyFunSuite with TestUtils {
     val input =
       """
         |mod N {
-        |    class C[a]
+        |    trait C[a]
         |}
         |
         |mod O {
-        |    class D[a] with N.C[a]
+        |    trait D[a] with N.C[a]
         |}
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
@@ -223,7 +223,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     val input =
       """
         |mod N {
-        |    pub sealed class C[a]
+        |    pub sealed trait C[a]
         |}
         |
         |mod O {
@@ -238,7 +238,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     val input =
       """
         |mod N {
-        |    sealed class C[a]
+        |    sealed trait C[a]
         |
         |    mod O {
         |        instance N.C[Int32]
@@ -253,10 +253,10 @@ class TestResolver extends AnyFunSuite with TestUtils {
     val input =
       """
         |mod N {
-        |    sealed class C[a]
+        |    sealed trait C[a]
         |
         |    mod O {
-        |        class D[a] with N.C[a]
+        |        trait D[a] with N.C[a]
         |    }
         |}
         |""".stripMargin
@@ -368,7 +368,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     val input =
       s"""
          |mod A {
-         |    class C[a] {
+         |    trait C[a] {
          |        pub def f(x: a): a
          |    }
          |}
@@ -447,7 +447,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("UndefinedClass.03") {
     val input =
       """
-        |class K[a]
+        |trait K[a]
         |
         |def f(x: a): a with K[a], U[a] = x
         |""".stripMargin
@@ -458,7 +458,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("UndefinedClass.04") {
     val input =
       """
-        |class K[a]
+        |trait K[a]
         |
         |instance K[a] with U[a]
         |""".stripMargin
@@ -838,7 +838,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
 
 
   test("CyclicClassHierarchy.01") {
-    val input = "class A[a] with A[a]"
+    val input = "trait A[a] with A[a]"
     val result = compile(input, Options.TestWithLibNix)
     expectError[ResolutionError.CyclicClassHierarchy](result)
   }
@@ -846,8 +846,8 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("CyclicClassHierarchy.02") {
     val input =
       """
-        |class A[a] with B[a]
-        |class B[a] with A[a]
+        |trait A[a] with B[a]
+        |trait B[a] with A[a]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[ResolutionError.CyclicClassHierarchy](result)
@@ -856,9 +856,9 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("CyclicClassHierarchy.03") {
     val input =
       """
-        |class A[a] with B[a]
-        |class B[a] with C[a]
-        |class C[a] with A[a]
+        |trait A[a] with B[a]
+        |trait B[a] with C[a]
+        |trait C[a] with A[a]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[ResolutionError.CyclicClassHierarchy](result)
@@ -867,8 +867,8 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("CyclicClassHierarchy.04") {
     val input =
       """
-        |class A[a] with A[a], B[a]
-        |class B[a]
+        |trait A[a] with A[a], B[a]
+        |trait B[a]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[ResolutionError.CyclicClassHierarchy](result)
@@ -877,9 +877,9 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("CyclicClassHierarchy.05") {
     val input =
       """
-        |class A[a] with B[a]
-        |class B[a] with A[a], C[a]
-        |class C[a]
+        |trait A[a] with B[a]
+        |trait B[a] with A[a], C[a]
+        |trait C[a]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[ResolutionError.CyclicClassHierarchy](result)
@@ -949,7 +949,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("UnderAppliedAssocType.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    type T[a]: Type
         |}
         |
@@ -962,7 +962,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("UndefinedAssocType.01") {
     val input =
       """
-        |class C[a]
+        |trait C[a]
         |
         |instance C[String] {
         |    type T[String] = Int32
@@ -1179,8 +1179,8 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("UndefinedTypeVar.Class.01") {
     val input =
       """
-        |class A[a]
-        |class B[a] with A[b]
+        |trait A[a]
+        |trait B[a] with A[b]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[ResolutionError.UndefinedTypeVar](result)
@@ -1189,9 +1189,9 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("UndefinedTypeVar.Class.02") {
     val input =
       """
-        |class A[a]
-        |class B[a]
-        |class C[a] with A[a], B[b]
+        |trait A[a]
+        |trait B[a]
+        |trait C[a] with A[a], B[b]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[ResolutionError.UndefinedTypeVar](result)
@@ -1213,7 +1213,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     // The type variable `a` does not appear in the signature of `f`
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def f(): Bool
         |}
         |""".stripMargin
@@ -1224,7 +1224,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("IllegalSignature.02") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def f(): a
         |
         |    pub def g(): Bool
@@ -1237,7 +1237,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("IllegalSignature.03") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def f(x: {y = a}): {y = Bool}
         |
         |    pub def g(x: {y = Bool}): Bool
@@ -1250,7 +1250,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("IllegalSignature.04") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def f(): a
         |
         |    pub def g(): Bool
@@ -1265,7 +1265,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("IllegalSignature.05") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def f(): Int
         |
         |    pub def g(): String
@@ -1280,7 +1280,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("IllegalSignature.06") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    type T[a]: Type
         |
         |    pub def f(x: C.T[a]): String
@@ -1389,7 +1389,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("UndefinedKind.01") {
     val input =
       """
-        |class C[a: Blah]
+        |trait C[a: Blah]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[ResolutionError.UndefinedKind](result)
@@ -1426,7 +1426,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("DuplicateAssocTypeDef.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    type T: Type
         |}
         |
@@ -1442,7 +1442,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("MissingAssocTypeDef.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    type T: Type
         |}
         |
@@ -1456,7 +1456,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("IllegalAssocTypeApplication.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    type T
         |}
         |
@@ -1469,7 +1469,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("IllegalAssocTypeApplication.02") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    type T[a]: Type
         |}
         |

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -209,7 +209,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
   test("NoMatchingInstance.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |  pub def foo(x: a): String
         |}
         |def foo(x: a): String = C.foo(x)
@@ -221,7 +221,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
   test("NoMatchingInstance.02") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |  pub def foo(x: a): String
         |}
         |def foo(x: Int32): String = C.foo(x)
@@ -237,7 +237,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    case Box(a)
         |}
         |
-        |class C[a] {
+        |trait C[a] {
         |    pub def foo(x: a): String
         |}
         |
@@ -264,7 +264,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    case Box(a)
         |}
         |
-        |class C[a] {
+        |trait C[a] {
         |    pub def foo(x: a): String
         |}
         |
@@ -287,7 +287,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
   test("NoMatchingInstance.05") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def foo(x: a): Int32
         |}
         |
@@ -305,7 +305,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
     // missing constraint on C[b]
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def foo(x: a): Int32
         |}
         |
@@ -318,7 +318,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
   test("NoMatchingInstance.07") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def foo(x: a): Int32
         |}
         |
@@ -1139,7 +1139,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
   test("TestAssocType.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    type T: Type
         |    pub def f(x: a): C.T[a]
         |}
@@ -1153,7 +1153,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
   test("TestAssocType.02") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    type T: Type
         |    pub def f(x: a): C.T[a]
         |}

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -1001,7 +1001,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("IllegalPrivateDeclaration.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    def f(): a
         |}
         |""".stripMargin
@@ -1090,7 +1090,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("IllegalTypeConstraintParameter.01") {
     val input =
       """
-        |class C[a] with D[Int32]
+        |trait C[a] with D[Int32]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.IllegalTypeConstraintParameter](result)
@@ -1513,7 +1513,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("MissingTypeParamKind.02") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    def f[b](x: b): a = ???
         |}
         |""".stripMargin
@@ -1524,7 +1524,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("MissingTypeParamKind.03") {
     val input =
       """
-        |class A[a: Type] {
+        |trait A[a: Type] {
         |    pub def f[a](x: a): Int32 = ???
         |}
         |""".stripMargin
@@ -1625,7 +1625,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("NonUnaryAssocType.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    type T[a, b]: Type
         |}
         |""".stripMargin
@@ -1685,7 +1685,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("ReservedName.Law.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    law **: forall (x: a) . true
         |}
         |""".stripMargin
@@ -1696,7 +1696,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("ReservedName.Law.02") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    law law: forall (x: a) . true
         |}
         |""".stripMargin
@@ -1707,7 +1707,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("ReservedName.Sig.01") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def <+>(x: a): a
         |}
         |""".stripMargin
@@ -1718,7 +1718,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("ReservedName.Sig.02") {
     val input =
       """
-        |class C[a] {
+        |trait C[a] {
         |    pub def pub(x: a): a
         |}
         |""".stripMargin


### PR DESCRIPTION
`class` has been removed in the new parser in favor of `trait`. This PR refactors phase tests to reflect that.