### PR TITLE
fix: add missing source lines to errors

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -598,7 +598,7 @@ object TypeError {
 
     def message(formatter: Formatter): String = {
       import formatter._
-      s"""
+      s"""${line(kind, source.name)}
          |>> Expected effect: '${red(formatType(expected, Some(renv)))}' but found effect: '${red(formatType(inferred, Some(renv)))}'.
          |
          |${code(loc, "expression has unexpected effect.")}
@@ -632,7 +632,7 @@ object TypeError {
 
     def message(formatter: Formatter): String = {
       import formatter._
-      s"""
+      s"""${line(kind, source.name)}
          |>> Expected type: '${red(formatType(expected, Some(renv)))}' but found type: '${red(formatType(inferred, Some(renv)))}'.
          |
          |${code(loc, "expression has unexpected type.")}


### PR DESCRIPTION
Maybe we should abbreviate parts of the expression to avoid this issue