### PR TITLE
feat: Normalize records in monomorpher

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -27,7 +27,7 @@ import ca.uwaterloo.flix.util.InternalCompilerException
 object Verifier {
 
   def run(root: Root)(implicit flix: Flix): Root = flix.phase("Verifier") {
-    if (flix.options.xverify) {
+    if (true) {
       root.defs.values.foreach(d => visitDef(d)(root))
     }
     root

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -27,7 +27,7 @@ import ca.uwaterloo.flix.util.InternalCompilerException
 object Verifier {
 
   def run(root: Root)(implicit flix: Flix): Root = flix.phase("Verifier") {
-    if (true) {
+    if (flix.options.xverify) {
       root.defs.values.foreach(d => visitDef(d)(root))
     }
     root


### PR DESCRIPTION
Alternative to #7421

This keeps  `apply` simpler but has n^2 time complexity on the length of records