### PR TITLE
feat: check type of value caught in try-catch (#7414)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -165,6 +165,24 @@ object SafetyError {
   }
 
   /**
+   * An error raised to indicate that the Java class in a catch clause is not a Throwable.
+   *
+   * @param loc the location of the catch parameter.
+   */
+  case class IllegalCatchType(loc: SourceLocation) extends SafetyError with Recoverable {
+    def summary: String = s"Exception type is not a subclass of Throwable."
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> $summary
+         |
+         |${code(loc, "Type should be java.lang.Throwable or a subclass.")}
+         |""".stripMargin
+    }
+  }
+
+  /**
     * An error raised to indicate an illegal use of a wildcard in a negative atom.
     *
     * @param loc the position of the body atom containing the illegal wildcard.

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -18,13 +18,42 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.SafetyError
-import ca.uwaterloo.flix.language.errors.SafetyError.{IllegalNegativelyBoundWildCard, IllegalNonPositivelyBoundVar, IllegalRelationalUseOfLatticeVar, IllegalPatternInBodyAtom}
+import ca.uwaterloo.flix.language.errors.SafetyError.{IllegalCatchType, IllegalNegativelyBoundWildCard, IllegalNonPositivelyBoundVar, IllegalPatternInBodyAtom, IllegalRelationalUseOfLatticeVar}
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.funsuite.AnyFunSuite
 
 class TestSafety extends AnyFunSuite with TestUtils {
 
   val DefaultOptions: Options = Options.TestWithLibMin
+
+  test("IllegalCatchType.01") {
+    val input =
+      """
+        |pub def f(): String =
+        |    try {
+        |        "abc"
+        |    } catch {
+        |        case _s: ##java.lang.Object => "fail"
+        |    }
+      """.stripMargin
+    val result = compile(input, Options.DefaultTest)
+    expectError[IllegalCatchType](result)
+  }
+
+  test("IllegalCatchType.02") {
+    val input =
+      """
+        |pub def f(): String =
+        |    try {
+        |        "abc"
+        |    } catch {
+        |        case _e1: ##java.lang.Exception => "ok"
+        |        case _e2: ##java.lang.String => "not ok"
+        |    }
+      """.stripMargin
+    val result = compile(input, Options.DefaultTest)
+    expectError[IllegalCatchType](result)
+  }
 
   test("UnexpectedBodyAtomPattern.01") {
     val input =


### PR DESCRIPTION
The error below might be improved I think: the highlighting could be better on ##java.lang.String rather than _s

But I didn't find any SourceLocation in the parsed expression for the ## bit.

```
>> Catch type is not a subclass of Throwable.

5 |         case _s: ##java.lang.String => "x"
                 ^^
                 Type should be java.lang.Throwable or a subclass.
```