### PR TITLE
feat: prepare `TestParser` and `TestWeeder` for new parser

### DIFF
--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -1,373 +1,15 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
-import ca.uwaterloo.flix.language.errors.ParseError
+import ca.uwaterloo.flix.language.errors.{LexerError, ParseError, WeederError}
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.funsuite.AnyFunSuite
 
+/**
+ * Note that CompilerSuite and LibrarySuite covers the positive testing of the parser well.
+ * We would like more negative tests in here though.
+ */
 class TestParser extends AnyFunSuite with TestUtils {
-
-  test("ParseError.Int.01") {
-    val input =
-      s"""
-         |def f(): Int = 1_
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int.02") {
-    val input =
-      s"""
-         |def f(): Int = 1_000_
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int.03") {
-    val input =
-      s"""
-         |def f(): Int = 0x_1
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int.04") {
-    val input =
-      s"""
-         |def f(): Int = 0x1_
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int8.01") {
-    val input =
-      s"""
-         |def f(): Int8 = 1_i8
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int8.02") {
-    val input =
-      s"""
-         |def f(): Int8 = 1_000_i8
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int8.03") {
-    val input =
-      s"""
-         |def f(): Int8 = 0x_1i8
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int8.04") {
-    val input =
-      s"""
-         |def f(): Int8 = 0x1_i8
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int16.01") {
-    val input =
-      s"""
-         |def f(): Int16 = 1_i16
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int16.02") {
-    val input =
-      s"""
-         |def f(): Int16 = 1_000_i16
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int16.03") {
-    val input =
-      s"""
-         |def f(): Int16 = 0x_1i16
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int16.04") {
-    val input =
-      s"""
-         |def f(): Int16 = 0x1_i16
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int32.01") {
-    val input =
-      s"""
-         |def f(): Int32 = 1_i32
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int32.02") {
-    val input =
-      s"""
-         |def f(): Int32 = 1_000_i32
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int32.03") {
-    val input =
-      s"""
-         |def f(): Int32 = 0x_1i32
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int32.04") {
-    val input =
-      s"""
-         |def f(): Int32 = 0x1_i32
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int64.01") {
-    val input =
-      s"""
-         |def f(): Int64 = 1_i64
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int64.02") {
-    val input =
-      s"""
-         |def f(): Int64 = 1_000_i64
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int64.03") {
-    val input =
-      s"""
-         |def f(): Int64 = 0x_1i64
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Int64.04") {
-    val input =
-      s"""
-         |def f(): Int64 = 0x1_i64
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.BigInt.01") {
-    val input =
-      s"""
-         |def f(): BigInt = 1_ii
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.BigInt.02") {
-    val input =
-      s"""
-         |def f(): BigInt = 1_000_ii
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.BigInt.03") {
-    val input =
-      s"""
-         |def f(): BigInt = 0x_1ii
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.BigInt.04") {
-    val input =
-      s"""
-         |def f(): BigInt = 0x1_ii
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Float.01") {
-    val input =
-      s"""
-         |def f(): Float = 1_.0
-       """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Float.02") {
-    val input =
-      s"""
-         |def f(): Float = 1_000_.0
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Float.03") {
-    val input =
-      s"""
-         |def f(): Float = 1.0_
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Float32.01") {
-    val input =
-      s"""
-         |def f(): Float32 = 1_.0f32
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Float32.02") {
-    val input =
-      s"""
-         |def f(): Float32 = 1_000_.0f32
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Float32.03") {
-    val input =
-      s"""
-         |def f(): Float32 = 1.0_f32
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Float64.01") {
-    val input =
-      s"""
-         |def f(): Float64 = 1_.0f64
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Float64.02") {
-    val input =
-      s"""
-         |def f(): Float64 = 1_000_.0f64
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Float64.03") {
-    val input =
-      s"""
-         |def f(): Float64 = 1.0_f64
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.BigDecimal.01") {
-    val input =
-      s"""
-         |def f(): BigDecimal = 1_.0ff
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.BigDecimal.02") {
-    val input =
-      s"""
-         |def f(): BigDecimal = 1_000_.0ff
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.BigDecimal.03") {
-    val input =
-      s"""
-         |def f(): Float64 = 1.0_ff
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.Regression.01") {
-    val input =
-      s"""
-         |def foo(): String = "abc"
-         |def bar(): String = foo()
-         |d
-         """.stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.EOI.01") {
-    val input = """def foo(): String = """"
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.EOI.02") {
-    val input =
-      """def foo(): Char = '"""
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.EOI.03") {
-    val input =
-      """def foo (): String = "\"""
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
-  test("ParseError.EOI.04") {
-    val input = """def foo (): Char = "\"""
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
   test("ParseError.Interpolation.01") {
     val input = s"""pub def foo(): String = "$${""""
     val result = compile(input, Options.TestWithLibNix)
@@ -381,9 +23,9 @@ class TestParser extends AnyFunSuite with TestUtils {
   }
 
   test("ParseError.Interpolation.03") {
-    val input = s"""pub def foo(): String = "$${1 + {2}""""
+    val input = s"""pub def foo(): String = "$${1 {}""""
     val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
+    expectError[LexerError](result)
   }
 
   test("ParseError.EnumCase.01") {
@@ -439,6 +81,137 @@ class TestParser extends AnyFunSuite with TestUtils {
       """
         |def foo(): Bool =
         |    1000ii instanceof BigInt
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ParseError](result)
+  }
+
+  test("IllegalEffectTypeParams.01") {
+    val input =
+      """
+        |eff MyEffect[a]
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalEffectTypeParams](result)
+  }
+
+  test("IllegalEffectTypeParams.02") {
+    val input =
+      """
+        |eff MyEffect {
+        |    def op[a](x: a): Unit
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalEffectTypeParams](result)
+  }
+
+  test("IllegalEffectTypeParams.03") {
+    val input =
+      """
+        |eff MyEffect[a] {
+        |    def op[b](x: a, y: b): Unit
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalEffectTypeParams](result)
+  }
+
+  test("IllegalEffectfulOperation.01") {
+    val input =
+      """
+        |eff E {
+        |    def op(): Unit \ IO
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibMin)
+    expectError[WeederError.IllegalEffectfulOperation](result)
+  }
+
+  test("IllegalEffectfulOperation.02") {
+    val input =
+      """
+        |eff E {
+        |    def op(): Unit \ E
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalEffectfulOperation](result)
+  }
+
+  test("IllegalEffectfulOperation.03") {
+    val input =
+      """
+        |eff E {
+        |    def op(): Unit \ ef
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalEffectfulOperation](result)
+  }
+
+  test("IllegalEffectfulOperation.04") {
+    val input =
+      """
+        |eff A {
+        |    pub def op(): Unit
+        |}
+        |eff E {
+        |    def op(): Unit \ A
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalEffectfulOperation](result)
+  }
+
+  test("IllegalEnum.01") {
+    val input =
+      """
+        |enum E(Int32) { }
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalEnum](result)
+  }
+
+  test("IllegalEnum.02") {
+    val input =
+      """
+        |enum E(a) { }
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalEnum](result)
+  }
+
+  // TODO: unignore with Parser2
+  ignore("IllegalModuleName.01") {
+    val input =
+      """
+        |mod mymod {
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ParseError](result)
+  }
+
+  // TODO: unignore with Parser2
+  ignore("IllegalModuleName.02") {
+    val input =
+      """
+        |mod Mymod.othermod {
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ParseError](result)
+  }
+
+  // TODO: unignore with Parser2
+  ignore("IllegalModuleName.03") {
+    val input =
+      """
+        |mod Mymod {
+        |    mod othermod {
+        |    }
+        |}
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[ParseError](result)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -21,6 +21,8 @@ import ca.uwaterloo.flix.language.errors.WeederError
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.funsuite.AnyFunSuite
 
+// NOTE: Weeder2 already passes many of these. All tests that don't have a 'TODO' pass.
+
 class TestWeeder extends AnyFunSuite with TestUtils {
 
   test("DuplicateAnnotation.01") {
@@ -173,15 +175,6 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.EmptyForFragment](result)
   }
 
-  test("EmptyForFragment.05") {
-    val input =
-      """
-        |def f(): Chain[String] = for () yield "a"
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.EmptyForFragment](result)
-  }
-
   test("EmptyInterpolatedExpression.01") {
     val input = "def f(): String = \"${}\""
     val result = compile(input, Options.TestWithLibNix)
@@ -212,7 +205,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.EmptyInterpolatedExpression](result)
   }
 
-  ignore("EmptyInterpolatedExpression.06") {
+  test("EmptyInterpolatedExpression.06") {
     val input = """def f(): String = "${"${}"}" """
     val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.EmptyInterpolatedExpression](result)
@@ -290,84 +283,6 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.IllegalAnnotation](result)
   }
 
-  test("IllegalEffectTypeParams.01") {
-    val input =
-      """
-        |eff MyEffect[a]
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalEffectTypeParams](result)
-  }
-
-  test("IllegalEffectTypeParams.02") {
-    val input =
-      """
-        |eff MyEffect {
-        |    def op[a](x: a): Unit
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalEffectTypeParams](result)
-  }
-
-  test("IllegalEffectTypeParams.03") {
-    val input =
-      """
-        |eff MyEffect[a] {
-        |    def op[b](x: a, y: b): Unit
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalEffectTypeParams](result)
-  }
-
-  test("IllegalEffectfulOperation.01") {
-    val input =
-      """
-        |eff E {
-        |    def op(): Unit \ IO
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibMin)
-    expectError[WeederError.IllegalEffectfulOperation](result)
-  }
-
-  test("IllegalEffectfulOperation.02") {
-    val input =
-      """
-        |eff E {
-        |    def op(): Unit \ E
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalEffectfulOperation](result)
-  }
-
-  test("IllegalEffectfulOperation.03") {
-    val input =
-      """
-        |eff E {
-        |    def op(): Unit \ ef
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalEffectfulOperation](result)
-  }
-
-  test("IllegalEffectfulOperation.04") {
-    val input =
-      """
-        |eff A {
-        |    pub def op(): Unit
-        |}
-        |eff E {
-        |    def op(): Unit \ A
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalEffectfulOperation](result)
-  }
-
   test("IllegalEnum.01") {
     val input =
       """
@@ -379,23 +294,6 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.IllegalEnum](result)
   }
 
-  test("IllegalEnum.02") {
-    val input =
-      """
-        |enum E(Int32) { }
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalEnum](result)
-  }
-
-  test("IllegalEnum.03") {
-    val input =
-      """
-        |enum E(a) { }
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalEnum](result)
-  }
 
   test("IllegalEqualityConstraint.01") {
     val input =
@@ -424,12 +322,6 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.IllegalEqualityConstraint](result)
   }
 
-  test("IllegalEscapeSequence.01") {
-    val input = s"""pub def foo(): String = "\\$$ {""""
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalEscapeSequence](result)
-  }
-
   test("IllegalEscapeSequence.Char.01") {
     val input =
       """
@@ -442,13 +334,13 @@ class TestWeeder extends AnyFunSuite with TestUtils {
   test("IllegalEscapeSequence.Interpolation.01") {
     val input =
       """
-        |def f(): String = '${25}\Q'
+        |def f(): String = "${25}\Q"
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.IllegalEscapeSequence](result)
   }
 
-  test("IllegalEscapeSequence.Patten.Char.01") {
+  test("IllegalEscapeSequence.Pattern.Char.01") {
     val input =
       """
         |def f(x: Char): Bool = match x {
@@ -460,7 +352,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.IllegalEscapeSequence](result)
   }
 
-  test("IllegalEscapeSequence.Patten.String.01") {
+  test("IllegalEscapeSequence.Pattern.String.01") {
     val input =
       """
         |def f(x: String): Bool = match x {
@@ -734,224 +626,6 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.IllegalModifier](result)
   }
 
-  test("IllegalModuleName.01") {
-    val input =
-      """
-        |mod mymod {
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.02") {
-    val input =
-      """
-        |mod myMod {
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.03") {
-    val input =
-      """
-        |mod mymod.othermod {
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.04") {
-    val input =
-      """
-        |mod mymod.Othermod {
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.05") {
-    val input =
-      """
-        |mod Mymod.othermod {
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.06") {
-    val input =
-      """
-        |mod Mymod {
-        |    mod othermod {
-        |    }
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.07") {
-    val input =
-      """
-        |mod mymod {
-        |    mod othermod {
-        |    }
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.08") {
-    val input =
-      """
-        |mod mymod {
-        |    mod Othermod {
-        |    }
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.09") {
-    val input =
-      """
-        |mod mymod {
-        |    mod Othermod.Thirdmod {
-        |    }
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.10") {
-    val input =
-      """
-        |mod mymod {
-        |    mod Othermod.thirdMod {
-        |    }
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.11") {
-    val input =
-      """
-        |mod Mymod {
-        |    mod othermod.thirdMod {
-        |    }
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.12") {
-    val input =
-      """
-        |mod Mymod {
-        |    mod Othermod.thirdMod {
-        |    }
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.13") {
-    val input =
-      """
-        |mod Mymod.Othermod {
-        |    mod thirdMod {
-        |    }
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.14") {
-    val input =
-      """
-        |mod Mymod.othermod {
-        |    mod thirdMod {
-        |    }
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.15") {
-    val input =
-      """
-        |mod Mymod.othermod {
-        |    mod ThirdMod {
-        |    }
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.16") {
-    val input =
-      """
-        |mod mymod.othermod {
-        |    mod ThirdMod {
-        |    }
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.17") {
-    val input =
-      """
-        |mod mymod.othermod {
-        |    mod thirdMod {
-        |    }
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.18") {
-    val input =
-      """
-        |mod mymod.Othermod {
-        |    mod thirdMod {
-        |    }
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
-  test("IllegalModuleName.19") {
-    val input =
-      """
-        |mod mymod.Othermod {
-        |    mod ThirdMod {
-        |    }
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalModuleName](result)
-  }
-
   test("IllegalNullPattern.01") {
     val input =
       s"""
@@ -1114,120 +788,25 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.IllegalTypeConstraintParameter](result)
   }
 
-  test("IllegalUse.Alias.01") {
-    val input =
-      """
-        |mod M {
-        |    def foo(): Int32 = ???
-        |}
-        |
-        |mod N {
-        |    use M.{foo => Foo}
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalUse](result)
-  }
-
-  test("IllegalUse.Alias.02") {
-    val input =
-      """
-        |mod M {
-        |    enum Enum1
-        |    def foo(): Int32 = ???
-        |}
-        |
-        |mod N {
-        |    use M.{Enum1 => enum1}
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalUse](result)
-  }
-
-  test("IllegalUse.Alias.03") {
-    val input =
-      """
-        |mod N {
-        |    use M.{E => e}
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalUse](result)
-  }
-
-  test("IllegalUse.Alias.04") {
-    val input =
-      """
-        |mod B {
-        |    use M.{e => A}
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.IllegalUse](result)
-  }
-
-  test("MalformedChar.Char.01") {
-    val input =
-      """
-        |def f(): Char = 'ab'
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedChar](result)
-  }
-
-  test("MalformedChar.Char.02") {
-    val input =
-      """
-        |def f(): Char = ''
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedChar](result)
-  }
-
-  test("MalformedChar.Patten.Char.01") {
-    val input =
-      """
-        |def f(x: Char): Bool = match x {
-        |  case 'ab' => true
-        |  case _ => false
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedChar](result)
-  }
-
-  ignore("MalformedFloat32.01") {
-    val input = "def f(): Float32 = 3402823700000000000000000000000000000000.0f32"
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedFloat](result)
-  }
-
-  ignore("MalformedFloat32.02") {
-    val input = "def f(): Float32 = -117549400000000000000000000000000000000.0f32"
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedFloat](result)
-  }
-
-  ignore("MalformedFloat32.03") {
-    val input = "def f(): Float32 = -3402823700000000000000000000000000000000.0f32"
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedFloat](result)
-  }
-
+  // TODO: unignore with Parser2
   ignore("MalformedFloat64.01") {
     val input = "def f(): Float64 = 1.7976931348623158e+308"
     val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.MalformedFloat](result)
   }
 
+  // TODO: unignore with Parser2
   ignore("MalformedFloat64.02") {
     val input = "def f(): Float64 = -1.7976931348623158e+308"
     val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.MalformedFloat](result)
   }
 
-  test("MalformedIdentifier.01") {
+  // This is supposed to check that the identifier does not include '$'.
+  // But since a user defined operation like '<$>' is perfectly valid,
+  // checking the identifier becomes tricky,
+  // which is why the next 3 tests are ignored.
+  ignore("MalformedIdentifier.01") {
     val input =
       """
         |import java.util.Locale$Builder
@@ -1336,111 +915,6 @@ class TestWeeder extends AnyFunSuite with TestUtils {
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.MalformedRegex](result)
-  }
-
-  test("MalformedUnicodeEscapeSequence.Char.01") {
-    val input =
-      """
-        |def f(): Char = 'BSuINVALID'
-        |""".stripMargin.replace("BS", "\\")
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
-  }
-
-  test("MalformedUnicodeEscapeSequence.Char.02") {
-    val input =
-      """
-        |def f(): Char = 'BSu000'
-        |""".stripMargin.replace("BS", "\\")
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
-  }
-
-  test("MalformedUnicodeEscapeSequence.Interpolation.01") {
-    val input =
-      """
-        |def f(): String = '${25}BSuINVALID'
-        |""".stripMargin.replace("BS", "\\")
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
-  }
-
-  test("MalformedUnicodeEscapeSequence.Interpolation.02") {
-    val input =
-      """
-        |def f(): String = '${25}BSu000'
-        |""".stripMargin.replace("BS", "\\")
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
-  }
-
-  test("MalformedUnicodeEscapeSequence.Patten.Char.01") {
-    val input =
-      """
-        |def f(x: Char): Bool = match x {
-        |  case 'BSuINVALID' => true
-        |  case _ => false
-        |}
-        |""".stripMargin.replace("BS", "\\")
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
-  }
-
-  test("MalformedUnicodeEscapeSequence.Patten.Char.02") {
-    val input =
-      """
-        |def f(x: Char): Bool = match x {
-        |  case 'BSu000' => true
-        |  case _ => false
-        |}
-        |""".stripMargin.replace("BS", "\\")
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
-  }
-
-  test("MalformedUnicodeEscapeSequence.Patten.String.01") {
-    val input =
-      """
-        |def f(x: String): Bool = match x {
-        |  case "BSuINVALID" => true
-        |  case _ => false
-        |}
-        |""".stripMargin.replace("BS", "\\")
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
-  }
-
-  test("MalformedUnicodeEscapeSequence.Patten.String.02") {
-    val input =
-      """
-        |def f(x: String): Bool = match x {
-        |  case "BSu000" => true
-        |  case _ => false
-        |}
-        |""".stripMargin.replace("BS", "\\")
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
-  }
-
-  test("MalformedUnicodeEscapeSequence.String.01") {
-    // In scala, unicode escapes are preprocessed,
-    // and other escapes are not processed in triple-quoted strings.
-    // So we use BS in the input and replace it with a real backslash afterward.
-    val input =
-      """
-        |def f(): String = "BSuINVALID"
-        |""".stripMargin.replace("BS", "\\")
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
-  }
-
-  test("MalformedUnicodeEscapeSequence.String.02") {
-    val input =
-      """
-        |def f(): String = "BSu000"
-        |""".stripMargin.replace("BS", "\\")
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
   }
 
   test("MismatchedTypeParameters.01") {
@@ -1655,77 +1129,6 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.NonUnaryAssocType](result)
   }
 
-  test("ReservedName.Def.01") {
-    val input =
-      """
-        |pub def **(x: a, y: a): a = ???
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.ReservedName](result)
-  }
-
-  test("ReservedName.Def.02") {
-    val input =
-      """
-        |pub def def(x: a, y: a): a = ???
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.ReservedName](result)
-  }
-
-  test("ReservedName.Effect.01") {
-    val input =
-      """
-        |eff Pure
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.ReservedName](result)
-  }
-
-  test("ReservedName.Law.01") {
-    val input =
-      """
-        |trait C[a] {
-        |    law **: forall (x: a) . true
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.ReservedName](result)
-  }
-
-  test("ReservedName.Law.02") {
-    val input =
-      """
-        |trait C[a] {
-        |    law law: forall (x: a) . true
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.ReservedName](result)
-  }
-
-  test("ReservedName.Sig.01") {
-    val input =
-      """
-        |trait C[a] {
-        |    pub def <+>(x: a): a
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.ReservedName](result)
-  }
-
-  test("ReservedName.Sig.02") {
-    val input =
-      """
-        |trait C[a] {
-        |    pub def pub(x: a): a
-        |}
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[WeederError.ReservedName](result)
-  }
-
   test("UndefinedAnnotation.01") {
     val input =
       """@abc
@@ -1780,6 +1183,60 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.UndefinedIntrinsic](result)
   }
 
+  // Testing that the casing of 'foo' and 'Foo' should match
+  test("IllegalUse.Alias.01") {
+    val input =
+      """
+        |mod M {
+        |    def foo(): Int32 = ???
+        |}
+        |
+        |mod N {
+        |    use M.{foo => Foo}
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalUse](result)
+  }
+
+  test("IllegalUse.Alias.02") {
+    val input =
+      """
+        |mod M {
+        |    enum Enum1
+        |    def foo(): Int32 = ???
+        |}
+        |
+        |mod N {
+        |    use M.{Enum1 => enum1}
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalUse](result)
+  }
+
+  test("IllegalUse.Alias.03") {
+    val input =
+      """
+        |mod N {
+        |    use M.{E => e}
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalUse](result)
+  }
+
+  test("IllegalUse.Alias.04") {
+    val input =
+      """
+        |mod B {
+        |    use M.{e => A}
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.IllegalUse](result)
+  }
+
   test("UnqualifiedUse.01") {
     val input =
       """
@@ -1816,5 +1273,140 @@ class TestWeeder extends AnyFunSuite with TestUtils {
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
     expectError[WeederError.UnqualifiedUse](result)
+  }
+
+  test("MalformedChar.Char.01") {
+    val input =
+      """
+        |def f(): Char = 'ab'
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.MalformedChar](result)
+  }
+
+  test("MalformedChar.Char.02") {
+    val input =
+      """
+        |def f(): Char = ''
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.MalformedChar](result)
+  }
+
+  test("MalformedChar.Pattern.Char.01") {
+    val input =
+      """
+        |def f(x: Char): Bool = match x {
+        |  case 'ab' => true
+        |  case _ => false
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.MalformedChar](result)
+  }
+
+  test("MalformedUnicodeEscapeSequence.Char.01") {
+    val input =
+      """
+        |def f(): Char = 'BSuINVALID'
+        |""".stripMargin.replace("BS", "\\")
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
+  }
+
+  test("MalformedUnicodeEscapeSequence.Char.02") {
+    val input =
+      """
+        |def f(): Char = 'BSu000'
+        |""".stripMargin.replace("BS", "\\")
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
+  }
+
+  test("MalformedUnicodeEscapeSequence.Interpolation.01") {
+    val input =
+      """
+        |def f(): String = "${25}BSuINVALID"
+        |""".stripMargin.replace("BS", "\\")
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
+  }
+
+  test("MalformedUnicodeEscapeSequence.Interpolation.02") {
+    val input =
+      """
+        |def f(): String = "${25}BSu000"
+        |""".stripMargin.replace("BS", "\\")
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
+  }
+
+  test("MalformedUnicodeEscapeSequence.Pattern.Char.01") {
+    val input =
+      """
+        |def f(x: Char): Bool = match x {
+        |  case 'BSuINVALID' => true
+        |  case _ => false
+        |}
+        |""".stripMargin.replace("BS", "\\")
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
+  }
+
+  test("MalformedUnicodeEscapeSequence.Pattern.Char.02") {
+    val input =
+      """
+        |def f(x: Char): Bool = match x {
+        |  case 'BSu000' => true
+        |  case _ => false
+        |}
+        |""".stripMargin.replace("BS", "\\")
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
+  }
+
+  test("MalformedUnicodeEscapeSequence.Pattern.String.01") {
+    val input =
+      """
+        |def f(x: String): Bool = match x {
+        |  case "BSuINVALID" => true
+        |  case _ => false
+        |}
+        |""".stripMargin.replace("BS", "\\")
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
+  }
+
+  test("MalformedUnicodeEscapeSequence.Pattern.String.02") {
+    val input =
+      """
+        |def f(x: String): Bool = match x {
+        |  case "BSu000" => true
+        |  case _ => false
+        |}
+        |""".stripMargin.replace("BS", "\\")
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
+  }
+
+  test("MalformedUnicodeEscapeSequence.String.01") {
+    // In scala, unicode escapes are preprocessed,
+    // and other escapes are not processed in triple-quoted strings.
+    // So we use BS in the input and replace it with a real backslash afterward.
+    val input =
+      """
+        |def f(): String = "BSuINVALID"
+        |""".stripMargin.replace("BS", "\\")
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
+  }
+
+  test("MalformedUnicodeEscapeSequence.String.02") {
+    val input =
+      """
+        |def f(): String = "BSu000"
+        |""".stripMargin.replace("BS", "\\")
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.MalformedUnicodeEscapeSequence](result)
   }
 }


### PR DESCRIPTION
Most of the deleted tests are moved to `TestLexer` which live in this PR #7461. 

5 tests have been ignored since the old pipeline does not produce the same error as the new one will. These are:
```
TestWeeder.MalformedFloat64.01
TestWeeder.MalformedFloat64.02
TestParser.IllegalModuleName.01
TestParser.IllegalModuleName.02
TestParser.IllegalModuleName.03
```
They are marked with a TODO and should be reactivated when the new parser is taken into use.