### PR TITLE
fix: Simplifier on record patterns

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -737,7 +737,7 @@ object Simplifier {
     @tailrec
     def visit(t: MonoType, cont: MonoType => MonoType): MonoType = t match {
       case MonoType.RecordExtend(f, _, tail) if label.name == f => cont(tail)
-      case MonoType.RecordExtend(f, tp, tail) => visit(tail, ty => MonoType.RecordExtend(f, tp, ty))
+      case MonoType.RecordExtend(f, tp, tail) => visit(tail, ty => cont(MonoType.RecordExtend(f, tp, ty)))
       case ty => cont(ty)
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -607,10 +607,10 @@ object Simplifier {
         val zero = patternMatchList(labelPats ::: ps, freshVars ::: vs, guard, succ, fail)
         // Note that we reverse pats and freshVars because we still want to fold right
         // but we want to restrict the record / matchVar from left to right
-        val (one, restrictedMatchVar) = pats.reverse.zip(freshVars.reverse).foldRight((zero, varExp): (SimplifiedAst.Expr, SimplifiedAst.Expr)) {
-          case ((MonoAst.Pattern.Record.RecordLabelPattern(label, _, pat, loc1), name), (exp, matchVarExp)) =>
+        val (one, restrictedMatchVar) = pats.zip(freshVars.reverse).foldLeft((zero, varExp): (SimplifiedAst.Expr, SimplifiedAst.Expr)) {
+          case ((exp, matchVarExp), (MonoAst.Pattern.Record.RecordLabelPattern(label, _, pat, loc1), name)) =>
             val recordSelectExp = SimplifiedAst.Expr.ApplyAtomic(AtomicOp.RecordSelect(label), List(matchVarExp), visitType(pat.tpe), Purity.Pure, loc1)
-            val restrictedMatchVarExp = SimplifiedAst.Expr.ApplyAtomic(AtomicOp.RecordRestrict(label), List(matchVarExp), mkRecordRestrict(label, varExp.tpe), matchVarExp.purity, loc1)
+            val restrictedMatchVarExp = SimplifiedAst.Expr.ApplyAtomic(AtomicOp.RecordRestrict(label), List(matchVarExp), mkRecordRestrict(label, matchVarExp.tpe), matchVarExp.purity, loc1)
             val labelLetBinding = SimplifiedAst.Expr.Let(name, recordSelectExp, exp, succ.tpe, exp.purity, loc1)
             (labelLetBinding, restrictedMatchVarExp)
         }

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -607,7 +607,7 @@ object Simplifier {
         val zero = patternMatchList(labelPats ::: ps, freshVars ::: vs, guard, succ, fail)
         // Note that we reverse pats and freshVars because we still want to fold right
         // but we want to restrict the record / matchVar from left to right
-        val (one, restrictedMatchVar) = pats.zip(freshVars.reverse).foldLeft((zero, varExp): (SimplifiedAst.Expr, SimplifiedAst.Expr)) {
+        val (one, restrictedMatchVar) = pats.zip(freshVars).foldLeft((zero, varExp): (SimplifiedAst.Expr, SimplifiedAst.Expr)) {
           case ((exp, matchVarExp), (MonoAst.Pattern.Record.RecordLabelPattern(label, _, pat, loc1), name)) =>
             val recordSelectExp = SimplifiedAst.Expr.ApplyAtomic(AtomicOp.RecordSelect(label), List(matchVarExp), visitType(pat.tpe), Purity.Pure, loc1)
             val restrictedMatchVarExp = SimplifiedAst.Expr.ApplyAtomic(AtomicOp.RecordRestrict(label), List(matchVarExp), mkRecordRestrict(label, matchVarExp.tpe), matchVarExp.purity, loc1)

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -605,8 +605,7 @@ object Simplifier {
         val labelPats = pats.map(_.pat)
         val varExp = SimplifiedAst.Expr.Var(v, visitType(tpe), loc)
         val zero = patternMatchList(labelPats ::: ps, freshVars ::: vs, guard, succ, fail)
-        // Note that we reverse pats and freshVars because we still want to fold right
-        // but we want to restrict the record / matchVar from left to right
+        // Let-binders are built in reverse, but it does not matter since binders are independent and pure
         val (one, restrictedMatchVar) = pats.zip(freshVars).foldLeft((zero, varExp): (SimplifiedAst.Expr, SimplifiedAst.Expr)) {
           case ((exp, matchVarExp), (MonoAst.Pattern.Record.RecordLabelPattern(label, _, pat, loc1), name)) =>
             val recordSelectExp = SimplifiedAst.Expr.ApplyAtomic(AtomicOp.RecordSelect(label), List(matchVarExp), visitType(pat.tpe), Purity.Pure, loc1)

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -312,6 +312,49 @@ object Verifier {
           checkEq(decl, actual, loc)
           tpe
 
+        case AtomicOp.Assign =>
+          val List(t1, t2) = ts
+          t1 match {
+            case MonoType.Ref(elm) =>
+              checkEq(t2, elm, loc)
+              check(expected = MonoType.Unit)(actual = tpe, loc)
+            case _ => failMismatchedShape(t1, "Ref", loc)
+          }
+
+        // Match- and Hole-errors match with any type
+        case AtomicOp.HoleError(_) | AtomicOp.MatchError => tpe
+
+        case AtomicOp.RecordEmpty => check(expected = MonoType.RecordEmpty)(actual = tpe, loc)
+        case AtomicOp.RecordExtend(label) =>
+          val List(t1, t2) = ts
+          removeFromRecordType(tpe, label.name, loc) match {
+            case (rec, Some(valtype)) =>
+              checkEq(rec, t2, loc)
+              checkEq(valtype, t1, loc)
+              tpe
+            case (_, None) => failMismatchedShape(tpe, s"Record with ${label.name}", loc)
+          }
+
+        case AtomicOp.RecordRestrict(label) =>
+          val List(t1) = ts
+          removeFromRecordType(t1, label.name, loc) match {
+            case (rec, Some(_)) =>
+              // TODO: VERIFIER: this fails when a is removed from { a = Bool | { a = Int32 | { b = Int32 | {}}}}
+              //  which results in { a = Bool | { a = Int32 | { b = Int32 | {}}}}
+              checkEq(tpe, rec, loc)
+            case (_, None) => failMismatchedShape(t1, s"Record with ${label.name}", loc)
+          }
+
+        case AtomicOp.RecordSelect(label) =>
+          val List(t1) = ts
+          selectFromRecordType(t1, label.name, loc) match {
+            case Some(elmt) =>
+              // TODO: VERIFIER: this fails e.g. when a is selected from { a = Bool | { a = Int32 | { a = Int32 | {}}}}
+              //  which results in Int32. (Test.Exp.Match.Record.flix:262:60)
+              checkEq(tpe, elmt, loc)
+            case None => failMismatchedShape(t1, s"Record with '${label.name}'", loc)
+          }
+
         case _ => tpe // TODO: VERIFIER: Add rest
       }
 
@@ -414,6 +457,28 @@ object Verifier {
     if (tpe1 == tpe2)
       tpe1
     else failMismatchedTypes(tpe1, tpe2, loc)
+  }
+
+
+  private def removeFromRecordType(rec: MonoType, label: String, loc: SourceLocation): (MonoType, Option[MonoType]) = rec match {
+    case MonoType.RecordEmpty => (rec, None)
+    case MonoType.RecordExtend(lbl, valtype, rest) =>
+      if (label == lbl) (rest, Some(valtype))
+      else {
+        val (rec, opt) = removeFromRecordType(rest, label, loc)
+        (MonoType.RecordExtend(lbl, valtype, rec), opt)
+      }
+    case _ => failMismatchedShape(rec, "Record", loc)
+  }
+
+  private def selectFromRecordType(rec: MonoType, label: String, loc: SourceLocation): Option[MonoType] = rec match {
+    case MonoType.RecordExtend(lbl, valtype, rest) =>
+      if (lbl == label)
+        Some(valtype)
+      else
+        selectFromRecordType(rest, label, loc)
+    case MonoType.RecordEmpty => None
+    case _ => failMismatchedShape(rec, "Record", loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -312,49 +312,6 @@ object Verifier {
           checkEq(decl, actual, loc)
           tpe
 
-        case AtomicOp.Assign =>
-          val List(t1, t2) = ts
-          t1 match {
-            case MonoType.Ref(elm) =>
-              checkEq(t2, elm, loc)
-              check(expected = MonoType.Unit)(actual = tpe, loc)
-            case _ => failMismatchedShape(t1, "Ref", loc)
-          }
-
-        // Match- and Hole-errors match with any type
-        case AtomicOp.HoleError(_) | AtomicOp.MatchError => tpe
-
-        case AtomicOp.RecordEmpty => check(expected = MonoType.RecordEmpty)(actual = tpe, loc)
-        case AtomicOp.RecordExtend(label) =>
-          val List(t1, t2) = ts
-          removeFromRecordType(tpe, label.name, loc) match {
-            case (rec, Some(valtype)) =>
-              checkEq(rec, t2, loc)
-              checkEq(valtype, t1, loc)
-              tpe
-            case (_, None) => failMismatchedShape(tpe, s"Record with ${label.name}", loc)
-          }
-
-        case AtomicOp.RecordRestrict(label) =>
-          val List(t1) = ts
-          removeFromRecordType(t1, label.name, loc) match {
-            case (rec, Some(_)) =>
-              // TODO: VERIFIER: this fails when a is removed from { a = Bool | { a = Int32 | { b = Int32 | {}}}}
-              //  which results in { a = Bool | { a = Int32 | { b = Int32 | {}}}}
-              checkEq(tpe, rec, loc)
-            case (_, None) => failMismatchedShape(t1, s"Record with ${label.name}", loc)
-          }
-
-        case AtomicOp.RecordSelect(label) =>
-          val List(t1) = ts
-          selectFromRecordType(t1, label.name, loc) match {
-            case Some(elmt) =>
-              // TODO: VERIFIER: this fails e.g. when a is selected from { a = Bool | { a = Int32 | { a = Int32 | {}}}}
-              //  which results in Int32. (Test.Exp.Match.Record.flix:262:60)
-              checkEq(tpe, elmt, loc)
-            case None => failMismatchedShape(t1, s"Record with '${label.name}'", loc)
-          }
-
         case _ => tpe // TODO: VERIFIER: Add rest
       }
 
@@ -457,28 +414,6 @@ object Verifier {
     if (tpe1 == tpe2)
       tpe1
     else failMismatchedTypes(tpe1, tpe2, loc)
-  }
-
-
-  private def removeFromRecordType(rec: MonoType, label: String, loc: SourceLocation): (MonoType, Option[MonoType]) = rec match {
-    case MonoType.RecordEmpty => (rec, None)
-    case MonoType.RecordExtend(lbl, valtype, rest) =>
-      if (label == lbl) (rest, Some(valtype))
-      else {
-        val (rec, opt) = removeFromRecordType(rest, label, loc)
-        (MonoType.RecordExtend(lbl, valtype, rec), opt)
-      }
-    case _ => failMismatchedShape(rec, "Record", loc)
-  }
-
-  private def selectFromRecordType(rec: MonoType, label: String, loc: SourceLocation): Option[MonoType] = rec match {
-    case MonoType.RecordExtend(lbl, valtype, rest) =>
-      if (lbl == label)
-        Some(valtype)
-      else
-        selectFromRecordType(rest, label, loc)
-    case MonoType.RecordEmpty => None
-    case _ => failMismatchedShape(rec, "Record", loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.Constant
 import ca.uwaterloo.flix.language.ast.ReducedAst._
-import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoType, SemanticOp, SourceLocation, Symbol}
+import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoType, Name, SemanticOp, SourceLocation, Symbol}
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
 /**
@@ -312,6 +312,49 @@ object Verifier {
           checkEq(decl, actual, loc)
           tpe
 
+        case AtomicOp.Assign =>
+          val List(t1, t2) = ts
+          t1 match {
+            case MonoType.Ref(elm) =>
+              checkEq(t2, elm, loc)
+              check(expected = MonoType.Unit)(actual = tpe, loc)
+            case _ => failMismatchedShape(t1, "Ref", loc)
+          }
+
+        // Match- and Hole-errors match with any type
+        case AtomicOp.HoleError(_) | AtomicOp.MatchError => tpe
+
+        case AtomicOp.RecordEmpty => check(expected = MonoType.RecordEmpty)(actual = tpe, loc)
+        case AtomicOp.RecordExtend(label) =>
+          val List(t1, t2) = ts
+          removeFromRecordType(tpe, label.name, loc) match {
+            case (rec, Some(valtype)) =>
+              checkEq(rec, t2, loc)
+              checkEq(valtype, t1, loc)
+              tpe
+            case (_, None) => failMismatchedShape(tpe, s"Record with ${label.name}", loc)
+          }
+
+        case AtomicOp.RecordRestrict(label) =>
+          val List(t1) = ts
+          removeFromRecordType(t1, label.name, loc) match {
+            case (rec, Some(_)) =>
+              // TODO: VERIFIER: this fails when a is removed from { a = Bool | { a = Int32 | { b = Int32 | {}}}}
+              //  which results in { a = Bool | { a = Int32 | { b = Int32 | {}}}}
+              checkEq(tpe, rec, loc)
+            case (_, None) => failMismatchedShape(t1, s"Record with ${label.name}", loc)
+          }
+
+        case AtomicOp.RecordSelect(label) =>
+          val List(t1) = ts
+          selectFromRecordType(t1, label.name, loc) match {
+            case Some(elmt) =>
+              // TODO: VERIFIER: this fails e.g. when a is selected from { a = Bool | { a = Int32 | { a = Int32 | {}}}}
+              //  which results in Int32. (Test.Exp.Match.Record.flix:262:60)
+              checkEq(tpe, elmt, loc)
+            case None => failMismatchedShape(t1, s"Record with '${label.name}'", loc)
+          }
+
         case _ => tpe // TODO: VERIFIER: Add rest
       }
 
@@ -396,6 +439,27 @@ object Verifier {
       // TODO: VERIFIER: Add support for NewObject.
       tpe
 
+  }
+
+  private def removeFromRecordType(rec: MonoType, label: String, loc: SourceLocation): (MonoType, Option[MonoType]) = rec match {
+    case MonoType.RecordEmpty => (rec, None)
+    case MonoType.RecordExtend(lbl, valtype, rest) =>
+      if (label == lbl) (rest, Some(valtype))
+      else {
+        val (rec, opt) = removeFromRecordType(rest, label, loc)
+        (MonoType.RecordExtend(lbl, valtype, rec), opt)
+      }
+    case _ => failMismatchedShape(rec, "Record", loc)
+  }
+
+  private def selectFromRecordType(rec: MonoType, label: String, loc: SourceLocation): Option[MonoType] = rec match {
+    case MonoType.RecordExtend(lbl, valtype, rest) =>
+      if (lbl == label)
+        Some(valtype)
+      else
+        selectFromRecordType(rest, label, loc)
+    case MonoType.RecordEmpty => None
+    case _ => failMismatchedShape(rec, "Record", loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.Constant
 import ca.uwaterloo.flix.language.ast.ReducedAst._
-import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoType, Name, SemanticOp, SourceLocation, Symbol}
+import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoType, SemanticOp, SourceLocation, Symbol}
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
 /**
@@ -312,49 +312,6 @@ object Verifier {
           checkEq(decl, actual, loc)
           tpe
 
-        case AtomicOp.Assign =>
-          val List(t1, t2) = ts
-          t1 match {
-            case MonoType.Ref(elm) =>
-              checkEq(t2, elm, loc)
-              check(expected = MonoType.Unit)(actual = tpe, loc)
-            case _ => failMismatchedShape(t1, "Ref", loc)
-          }
-
-        // Match- and Hole-errors match with any type
-        case AtomicOp.HoleError(_) | AtomicOp.MatchError => tpe
-
-        case AtomicOp.RecordEmpty => check(expected = MonoType.RecordEmpty)(actual = tpe, loc)
-        case AtomicOp.RecordExtend(label) =>
-          val List(t1, t2) = ts
-          removeFromRecordType(tpe, label.name, loc) match {
-            case (rec, Some(valtype)) =>
-              checkEq(rec, t2, loc)
-              checkEq(valtype, t1, loc)
-              tpe
-            case (_, None) => failMismatchedShape(tpe, s"Record with ${label.name}", loc)
-          }
-
-        case AtomicOp.RecordRestrict(label) =>
-          val List(t1) = ts
-          removeFromRecordType(t1, label.name, loc) match {
-            case (rec, Some(_)) =>
-              // TODO: VERIFIER: this fails when a is removed from { a = Bool | { a = Int32 | { b = Int32 | {}}}}
-              //  which results in { a = Bool | { a = Int32 | { b = Int32 | {}}}}
-              checkEq(tpe, rec, loc)
-            case (_, None) => failMismatchedShape(t1, s"Record with ${label.name}", loc)
-          }
-
-        case AtomicOp.RecordSelect(label) =>
-          val List(t1) = ts
-          selectFromRecordType(t1, label.name, loc) match {
-            case Some(elmt) =>
-              // TODO: VERIFIER: this fails e.g. when a is selected from { a = Bool | { a = Int32 | { a = Int32 | {}}}}
-              //  which results in Int32. (Test.Exp.Match.Record.flix:262:60)
-              checkEq(tpe, elmt, loc)
-            case None => failMismatchedShape(t1, s"Record with '${label.name}'", loc)
-          }
-
         case _ => tpe // TODO: VERIFIER: Add rest
       }
 
@@ -439,27 +396,6 @@ object Verifier {
       // TODO: VERIFIER: Add support for NewObject.
       tpe
 
-  }
-
-  private def removeFromRecordType(rec: MonoType, label: String, loc: SourceLocation): (MonoType, Option[MonoType]) = rec match {
-    case MonoType.RecordEmpty => (rec, None)
-    case MonoType.RecordExtend(lbl, valtype, rest) =>
-      if (label == lbl) (rest, Some(valtype))
-      else {
-        val (rec, opt) = removeFromRecordType(rest, label, loc)
-        (MonoType.RecordExtend(lbl, valtype, rec), opt)
-      }
-    case _ => failMismatchedShape(rec, "Record", loc)
-  }
-
-  private def selectFromRecordType(rec: MonoType, label: String, loc: SourceLocation): Option[MonoType] = rec match {
-    case MonoType.RecordExtend(lbl, valtype, rest) =>
-      if (lbl == label)
-        Some(valtype)
-      else
-        selectFromRecordType(rest, label, loc)
-    case MonoType.RecordEmpty => None
-    case _ => failMismatchedShape(rec, "Record", loc)
   }
 
   /**


### PR DESCRIPTION
- fixed typo where accumulated exp was not used
- fixed `l.reverse.foldRight` -> `l.foldLeft`
- fixed calling the continuation in `mkRecordRestrict`