### PR TITLE
refactor: rename `TypeContext` methods

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/ConstraintGeneration.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/ConstraintGeneration.scala
@@ -53,9 +53,9 @@ object ConstraintGeneration {
       case Expr.Def(sym, tvar, loc) =>
         val defn = root.defs(sym)
         val (tconstrs, econstrs, defTpe) = Scheme.instantiate(defn.spec.sc, loc.asSynthetic)
-        c.unifyTypeM(tvar, defTpe, loc)
-        c.addClassConstraintsM(tconstrs, loc)
-        econstrs.foreach { econstr => c.unifyTypeM(econstr.tpe1, econstr.tpe2, loc) }
+        c.unifyType(tvar, defTpe, loc)
+        c.addClassConstraints(tconstrs, loc)
+        econstrs.foreach { econstr => c.unifyType(econstr.tpe1, econstr.tpe2, loc) }
         val resTpe = defTpe
         val resEff = Type.Pure
         (resTpe, resEff)
@@ -63,9 +63,9 @@ object ConstraintGeneration {
       case Expr.Sig(sym, tvar, loc) =>
         val sig = root.classes(sym.clazz).sigs(sym)
         val (tconstrs, econstrs, sigTpe) = Scheme.instantiate(sig.spec.sc, loc.asSynthetic)
-        c.unifyTypeM(tvar, sigTpe, loc)
-        c.addClassConstraintsM(tconstrs, loc)
-        econstrs.foreach { econstr => c.unifyTypeM(econstr.tpe1, econstr.tpe2, loc) }
+        c.unifyType(tvar, sigTpe, loc)
+        c.addClassConstraints(tconstrs, loc)
+        econstrs.foreach { econstr => c.unifyType(econstr.tpe1, econstr.tpe2, loc) }
         val resTpe = sigTpe
         val resEff = Type.Pure
         (resTpe, resEff)
@@ -80,7 +80,7 @@ object ConstraintGeneration {
         // We allow the effect to be any superset of exp's effect.
         val (_, eff) = visitExp(exp)
         val atLeastEff = Type.mkUnion(eff, Type.freshVar(Kind.Eff, loc.asSynthetic), loc.asSynthetic)
-        c.unifyTypeM(atLeastEff, evar, loc)
+        c.unifyType(atLeastEff, evar, loc)
         val resTpe = tvar
         val resEff = atLeastEff
         (resTpe, resEff)
@@ -133,11 +133,11 @@ object ConstraintGeneration {
 
             val (tpes, effs) = exps.map(visitExp).unzip
             c.expectTypeArguments(sym, declaredArgumentTypes, tpes, exps.map(_.loc), loc)
-            c.addClassConstraintsM(constrs1, loc)
-            econstrs1.foreach { econstr => c.unifyTypeM(econstr.tpe1, econstr.tpe2, loc) }
-            c.unifyTypeM(tvar2, declaredType, loc)
-            c.unifyTypeM(tvar, declaredResultType, loc)
-            c.unifyTypeM(evar, Type.mkUnion(declaredEff :: effs, loc), loc)
+            c.addClassConstraints(constrs1, loc)
+            econstrs1.foreach { econstr => c.unifyType(econstr.tpe1, econstr.tpe2, loc) }
+            c.unifyType(tvar2, declaredType, loc)
+            c.unifyType(tvar, declaredResultType, loc)
+            c.unifyType(evar, Type.mkUnion(declaredEff :: effs, loc), loc)
             val resTpe = tvar
             val resEff = evar
             (resTpe, resEff)
@@ -150,16 +150,16 @@ object ConstraintGeneration {
             val lambdaBodyEff = Type.freshVar(Kind.Eff, loc)
             val (tpe, eff) = visitExp(exp)
             val (tpes, effs) = exps.map(visitExp).unzip
-            c.expectTypeM(tpe, Type.mkUncurriedArrowWithEffect(tpes, lambdaBodyEff, lambdaBodyType, loc), loc)
-            c.unifyTypeM(tvar, lambdaBodyType, loc)
-            c.unifyTypeM(evar, Type.mkUnion(lambdaBodyEff :: eff :: effs, loc), loc)
+            c.expectType(tpe, Type.mkUncurriedArrowWithEffect(tpes, lambdaBodyEff, lambdaBodyType, loc), loc)
+            c.unifyType(tvar, lambdaBodyType, loc)
+            c.unifyType(evar, Type.mkUnion(lambdaBodyEff :: eff :: effs, loc), loc)
             val resTpe = tvar
             val resEff = evar
             (resTpe, resEff)
         }
 
       case Expr.Lambda(fparam, exp, loc) =>
-        c.unifyTypeM(fparam.sym.tvar, fparam.tpe, loc)
+        c.unifyType(fparam.sym.tvar, fparam.tpe, loc)
         val (tpe, eff) = visitExp(exp)
         val resTpe = Type.mkArrowWithEffect(fparam.tpe, eff, tpe, loc)
         val resEff = Type.Pure
@@ -168,56 +168,56 @@ object ConstraintGeneration {
       case KindedAst.Expr.Unary(sop, exp, tvar, loc) => sop match {
         case SemanticOp.BoolOp.Not =>
           val (tpe, eff) = visitExp(exp)
-          c.expectTypeM(expected = Type.Bool, actual = tpe, exp.loc)
-          c.unifyTypeM(Type.Bool, tvar, exp.loc)
+          c.expectType(expected = Type.Bool, actual = tpe, exp.loc)
+          c.unifyType(Type.Bool, tvar, exp.loc)
           val resTpe = tvar
           val resEff = eff
           (resTpe, resEff)
 
         case SemanticOp.Float32Op.Neg =>
           val (tpe, eff) = visitExp(exp)
-          c.expectTypeM(expected = Type.Float32, actual = tpe, exp.loc)
-          c.unifyTypeM(Type.Float32, tvar, exp.loc)
+          c.expectType(expected = Type.Float32, actual = tpe, exp.loc)
+          c.unifyType(Type.Float32, tvar, exp.loc)
           val resTpe = tvar
           val resEff = eff
           (resTpe, resEff)
 
         case SemanticOp.Float64Op.Neg =>
           val (tpe, eff) = visitExp(exp)
-          c.expectTypeM(expected = Type.Float64, actual = tpe, exp.loc)
-          c.unifyTypeM(Type.Float64, tvar, exp.loc)
+          c.expectType(expected = Type.Float64, actual = tpe, exp.loc)
+          c.unifyType(Type.Float64, tvar, exp.loc)
           val resTpe = tvar
           val resEff = eff
           (resTpe, resEff)
 
         case SemanticOp.Int8Op.Neg | SemanticOp.Int8Op.Not =>
           val (tpe, eff) = visitExp(exp)
-          c.expectTypeM(expected = Type.Int8, actual = tpe, exp.loc)
-          c.unifyTypeM(Type.Int8, tvar, exp.loc)
+          c.expectType(expected = Type.Int8, actual = tpe, exp.loc)
+          c.unifyType(Type.Int8, tvar, exp.loc)
           val resTpe = tvar
           val resEff = eff
           (resTpe, resEff)
 
         case SemanticOp.Int16Op.Neg | SemanticOp.Int16Op.Not =>
           val (tpe, eff) = visitExp(exp)
-          c.expectTypeM(expected = Type.Int16, actual = tpe, exp.loc)
-          c.unifyTypeM(Type.Int16, tvar, exp.loc)
+          c.expectType(expected = Type.Int16, actual = tpe, exp.loc)
+          c.unifyType(Type.Int16, tvar, exp.loc)
           val resTpe = tvar
           val resEff = eff
           (resTpe, resEff)
 
         case SemanticOp.Int32Op.Neg | SemanticOp.Int32Op.Not =>
           val (tpe, eff) = visitExp(exp)
-          c.expectTypeM(expected = Type.Int32, actual = tpe, exp.loc)
-          c.unifyTypeM(Type.Int32, tvar, exp.loc)
+          c.expectType(expected = Type.Int32, actual = tpe, exp.loc)
+          c.unifyType(Type.Int32, tvar, exp.loc)
           val resTpe = tvar
           val resEff = eff
           (resTpe, resEff)
 
         case SemanticOp.Int64Op.Neg | SemanticOp.Int64Op.Not =>
           val (tpe, eff) = visitExp(exp)
-          c.expectTypeM(expected = Type.Int64, actual = tpe, exp.loc)
-          c.unifyTypeM(Type.Int64, tvar, exp.loc)
+          c.expectType(expected = Type.Int64, actual = tpe, exp.loc)
+          c.unifyType(Type.Int64, tvar, exp.loc)
           val resTpe = tvar
           val resEff = eff
           (resTpe, resEff)
@@ -228,9 +228,9 @@ object ConstraintGeneration {
         case SemanticOp.BoolOp.And | SemanticOp.BoolOp.Or =>
           val (tpe1, eff1) = visitExp(exp1)
           val (tpe2, eff2) = visitExp(exp2)
-          c.expectTypeM(expected = Type.Bool, actual = tpe1, exp1.loc)
-          c.expectTypeM(expected = Type.Bool, actual = tpe2, exp2.loc)
-          c.unifyTypeM(tvar, Type.Bool, loc)
+          c.expectType(expected = Type.Bool, actual = tpe1, exp1.loc)
+          c.expectType(expected = Type.Bool, actual = tpe2, exp2.loc)
+          c.unifyType(tvar, Type.Bool, loc)
           val resTpe = tvar
           val resEff = Type.mkUnion(eff1, eff2, loc)
           (resTpe, resEff)
@@ -239,9 +239,9 @@ object ConstraintGeneration {
              | SemanticOp.Float32Op.Exp =>
           val (tpe1, eff1) = visitExp(exp1)
           val (tpe2, eff2) = visitExp(exp2)
-          c.expectTypeM(expected = Type.Float32, actual = tpe1, exp1.loc)
-          c.expectTypeM(expected = Type.Float32, actual = tpe2, exp2.loc)
-          c.unifyTypeM(tvar, Type.Float32, loc)
+          c.expectType(expected = Type.Float32, actual = tpe1, exp1.loc)
+          c.expectType(expected = Type.Float32, actual = tpe2, exp2.loc)
+          c.unifyType(tvar, Type.Float32, loc)
           val resTpe = tvar
           val resEff = Type.mkUnion(eff1, eff2, loc)
           (resTpe, resEff)
@@ -250,9 +250,9 @@ object ConstraintGeneration {
              | SemanticOp.Float64Op.Exp =>
           val (tpe1, eff1) = visitExp(exp1)
           val (tpe2, eff2) = visitExp(exp2)
-          c.expectTypeM(expected = Type.Float64, actual = tpe1, exp1.loc)
-          c.expectTypeM(expected = Type.Float64, actual = tpe2, exp2.loc)
-          c.unifyTypeM(tvar, Type.Float64, loc)
+          c.expectType(expected = Type.Float64, actual = tpe1, exp1.loc)
+          c.expectType(expected = Type.Float64, actual = tpe2, exp2.loc)
+          c.unifyType(tvar, Type.Float64, loc)
           val resTpe = tvar
           val resEff = Type.mkUnion(eff1, eff2, loc)
           (resTpe, resEff)
@@ -262,9 +262,9 @@ object ConstraintGeneration {
              | SemanticOp.Int8Op.And | SemanticOp.Int8Op.Or | SemanticOp.Int8Op.Xor =>
           val (tpe1, eff1) = visitExp(exp1)
           val (tpe2, eff2) = visitExp(exp2)
-          c.expectTypeM(expected = Type.Int8, actual = tpe1, exp1.loc)
-          c.expectTypeM(expected = Type.Int8, actual = tpe2, exp2.loc)
-          c.unifyTypeM(tvar, Type.Int8, loc)
+          c.expectType(expected = Type.Int8, actual = tpe1, exp1.loc)
+          c.expectType(expected = Type.Int8, actual = tpe2, exp2.loc)
+          c.unifyType(tvar, Type.Int8, loc)
           val resTpe = tvar
           val resEff = Type.mkUnion(eff1, eff2, loc)
           (resTpe, resEff)
@@ -274,9 +274,9 @@ object ConstraintGeneration {
              | SemanticOp.Int16Op.And | SemanticOp.Int16Op.Or | SemanticOp.Int16Op.Xor =>
           val (tpe1, eff1) = visitExp(exp1)
           val (tpe2, eff2) = visitExp(exp2)
-          c.expectTypeM(expected = Type.Int16, actual = tpe1, exp1.loc)
-          c.expectTypeM(expected = Type.Int16, actual = tpe2, exp2.loc)
-          c.unifyTypeM(tvar, Type.Int16, loc)
+          c.expectType(expected = Type.Int16, actual = tpe1, exp1.loc)
+          c.expectType(expected = Type.Int16, actual = tpe2, exp2.loc)
+          c.unifyType(tvar, Type.Int16, loc)
           val resTpe = tvar
           val resEff = Type.mkUnion(eff1, eff2, loc)
           (resTpe, resEff)
@@ -286,9 +286,9 @@ object ConstraintGeneration {
              | SemanticOp.Int32Op.And | SemanticOp.Int32Op.Or | SemanticOp.Int32Op.Xor =>
           val (tpe1, eff1) = visitExp(exp1)
           val (tpe2, eff2) = visitExp(exp2)
-          c.expectTypeM(expected = Type.Int32, actual = tpe1, exp1.loc)
-          c.expectTypeM(expected = Type.Int32, actual = tpe2, exp2.loc)
-          c.unifyTypeM(tvar, Type.Int32, loc)
+          c.expectType(expected = Type.Int32, actual = tpe1, exp1.loc)
+          c.expectType(expected = Type.Int32, actual = tpe2, exp2.loc)
+          c.unifyType(tvar, Type.Int32, loc)
           val resTpe = tvar
           val resEff = Type.mkUnion(eff1, eff2, loc)
           (resTpe, resEff)
@@ -298,9 +298,9 @@ object ConstraintGeneration {
              | SemanticOp.Int64Op.And | SemanticOp.Int64Op.Or | SemanticOp.Int64Op.Xor =>
           val (tpe1, eff1) = visitExp(exp1)
           val (tpe2, eff2) = visitExp(exp2)
-          c.expectTypeM(expected = Type.Int64, actual = tpe1, exp1.loc)
-          c.expectTypeM(expected = Type.Int64, actual = tpe2, exp2.loc)
-          c.unifyTypeM(tvar, Type.Int64, loc)
+          c.expectType(expected = Type.Int64, actual = tpe1, exp1.loc)
+          c.expectType(expected = Type.Int64, actual = tpe2, exp2.loc)
+          c.unifyType(tvar, Type.Int64, loc)
           val resTpe = tvar
           val resEff = Type.mkUnion(eff1, eff2, loc)
           (resTpe, resEff)
@@ -311,8 +311,8 @@ object ConstraintGeneration {
              | SemanticOp.Int64Op.Shl | SemanticOp.Int64Op.Shr =>
           val (tpe1, eff1) = visitExp(exp1)
           val (tpe2, eff2) = visitExp(exp2)
-          c.unifyTypeM(tvar, tpe1, loc)
-          c.expectTypeM(expected = Type.Int32, actual = tpe2, exp2.loc)
+          c.unifyType(tvar, tpe1, loc)
+          c.expectType(expected = Type.Int32, actual = tpe2, exp2.loc)
           val resTpe = tvar
           val resEff = Type.mkUnion(eff1, eff2, loc)
           (resTpe, resEff)
@@ -327,8 +327,8 @@ object ConstraintGeneration {
              | SemanticOp.Int64Op.Eq | SemanticOp.Int64Op.Neq =>
           val (tpe1, eff1) = visitExp(exp1)
           val (tpe2, eff2) = visitExp(exp2)
-          c.unifyTypeM(tpe1, tpe2, loc)
-          c.unifyTypeM(tvar, Type.Bool, loc)
+          c.unifyType(tpe1, tpe2, loc)
+          c.unifyType(tvar, Type.Bool, loc)
           val resTpe = tvar
           val resEff = Type.mkUnion(eff1, eff2, loc)
           (resTpe, resEff)
@@ -342,8 +342,8 @@ object ConstraintGeneration {
              | SemanticOp.Int64Op.Lt | SemanticOp.Int64Op.Le | SemanticOp.Int64Op.Gt | SemanticOp.Int64Op.Ge =>
           val (tpe1, eff1) = visitExp(exp1)
           val (tpe2, eff2) = visitExp(exp2)
-          c.unifyTypeM(tpe1, tpe2, loc)
-          c.unifyTypeM(tvar, Type.Bool, loc)
+          c.unifyType(tpe1, tpe2, loc)
+          c.unifyType(tvar, Type.Bool, loc)
           val resTpe = tvar
           val resEff = Type.mkUnion(eff1, eff2, loc)
           (resTpe, resEff)
@@ -351,9 +351,9 @@ object ConstraintGeneration {
         case SemanticOp.StringOp.Concat =>
           val (tpe1, eff1) = visitExp(exp1)
           val (tpe2, eff2) = visitExp(exp2)
-          c.expectTypeM(expected = Type.Str, actual = tpe1, exp1.loc)
-          c.expectTypeM(expected = Type.Str, actual = tpe2, exp2.loc)
-          c.unifyTypeM(tvar, Type.Str, loc)
+          c.expectType(expected = Type.Str, actual = tpe1, exp1.loc)
+          c.expectType(expected = Type.Str, actual = tpe2, exp2.loc)
+          c.unifyType(tvar, Type.Str, loc)
           val resTpe = tvar
           val resEff = Type.mkUnion(eff1, eff2, loc)
           (resTpe, resEff)
@@ -363,8 +363,8 @@ object ConstraintGeneration {
         val (tpe1, eff1) = visitExp(exp1)
         val (tpe2, eff2) = visitExp(exp2)
         val (tpe3, eff3) = visitExp(exp3)
-        c.expectTypeM(expected = Type.Bool, actual = tpe1, exp1.loc)
-        c.unifyTypeM(tpe2, tpe3, loc)
+        c.expectType(expected = Type.Bool, actual = tpe1, exp1.loc)
+        c.unifyType(tpe2, tpe3, loc)
         val resTpe = tpe3
         val resEff = Type.mkUnion(eff1, eff2, eff3, loc)
         (resTpe, resEff)
@@ -384,7 +384,7 @@ object ConstraintGeneration {
 
       case Expr.Let(sym, _, exp1, exp2, loc) =>
         val (tpe1, eff1) = visitExp(exp1)
-        c.unifyTypeM(sym.tvar, tpe1, exp1.loc)
+        c.unifyType(sym.tvar, tpe1, exp1.loc)
         val (tpe2, eff2) = visitExp(exp2)
         val resTpe = tpe2
         val resEff = Type.mkUnion(eff1, eff2, loc)
@@ -393,7 +393,7 @@ object ConstraintGeneration {
       case Expr.LetRec(sym, _, _, exp1, exp2, loc) =>
         // exp1 is known to be a lambda syntactically
         val (tpe1, eff1) = visitExp(exp1)
-        c.unifyTypeM(sym.tvar, tpe1, exp1.loc)
+        c.unifyType(sym.tvar, tpe1, exp1.loc)
         val (tpe2, eff2) = visitExp(exp2)
         val resTpe = tpe2
         val resEff = Type.mkUnion(eff1, eff2, loc)
@@ -413,10 +413,10 @@ object ConstraintGeneration {
         // We must unify sym.tvar and the region var INSIDE the region
         // because we need to ensure that reference to the region are
         // resolved BEFORE purifying the region as we exit
-        c.enterRegionM(regionVar.sym)
-        c.unifyTypeM(sym.tvar, Type.mkRegion(regionVar, loc), loc)
+        c.enterRegion(regionVar.sym)
+        c.unifyType(sym.tvar, Type.mkRegion(regionVar, loc), loc)
         val (tpe, eff) = visitExp(exp)
-        c.exitRegionM(evar, eff, loc)
+        c.exitRegion(evar, eff, loc)
         val resTpe = tpe
         val resEff = evar
         (resTpe, resEff)
@@ -424,15 +424,15 @@ object ConstraintGeneration {
       case Expr.Match(exp, rules, loc) =>
         val (tpe, eff) = visitExp(exp)
         val (patTpes, tpes, effs) = rules.map(visitMatchRule).unzip3
-        c.unifyAllTypesM(tpe :: patTpes, Kind.Star, loc)
-        val resTpe = c.unifyAllTypesM(tpes, Kind.Star, loc)
+        c.unifyAllTypes(tpe :: patTpes, Kind.Star, loc)
+        val resTpe = c.unifyAllTypes(tpes, Kind.Star, loc)
         val resEff = Type.mkUnion(eff :: effs, loc)
         (resTpe, resEff)
 
       case Expr.TypeMatch(exp, rules, loc) =>
         val (_, eff) = visitExp(exp)
         val (tpes, effs) = rules.map(visitTypeMatchRule).unzip
-        val resTpe = c.unifyAllTypesM(tpes, Kind.Star, loc)
+        val resTpe = c.unifyAllTypes(tpes, Kind.Star, loc)
         val resEff = Type.mkUnion(eff :: effs, loc)
         (resTpe, resEff)
 
@@ -446,7 +446,7 @@ object ConstraintGeneration {
 
         // The tag type is a function from the type of variant to the type of the enum.
         val (tpe, eff) = visitExp(exp)
-        c.unifyTypeM(tagType, Type.mkPureArrow(tpe, tvar, loc), loc)
+        c.unifyType(tagType, Type.mkPureArrow(tpe, tvar, loc), loc)
         val resTpe = tvar
         val resEff = eff
         (resTpe, resEff)
@@ -474,7 +474,7 @@ object ConstraintGeneration {
         val expectedRowType = Type.mkRecordRowExtend(label, tvar, freshRowVar, loc)
         val expectedRecordType = Type.mkRecord(expectedRowType, loc)
         val (tpe, eff) = visitExp(exp)
-        c.unifyTypeM(tpe, expectedRecordType, loc)
+        c.unifyType(tpe, expectedRecordType, loc)
         val resTpe = tvar
         val resEff = eff
         (resTpe, resEff)
@@ -488,8 +488,8 @@ object ConstraintGeneration {
         val freshRowVar = Type.freshVar(Kind.RecordRow, loc)
         val (tpe1, eff1) = visitExp(exp1)
         val (tpe2, eff2) = visitExp(exp2)
-        c.unifyTypeM(tpe2, Type.mkRecord(freshRowVar, loc), loc)
-        c.unifyTypeM(tvar, Type.mkRecord(Type.mkRecordRowExtend(label, tpe1, freshRowVar, loc), loc), loc)
+        c.unifyType(tpe2, Type.mkRecord(freshRowVar, loc), loc)
+        c.unifyType(tvar, Type.mkRecord(Type.mkRecordRowExtend(label, tpe1, freshRowVar, loc), loc), loc)
         val resTpe = tvar
         val resEff = Type.mkUnion(eff1, eff2, loc)
         (resTpe, resEff)
@@ -503,8 +503,8 @@ object ConstraintGeneration {
         val freshLabelType = Type.freshVar(Kind.Star, loc)
         val freshRowVar = Type.freshVar(Kind.RecordRow, loc)
         val (tpe, eff) = visitExp(exp)
-        c.unifyTypeM(tpe, Type.mkRecord(Type.mkRecordRowExtend(label, freshLabelType, freshRowVar, loc), loc), loc)
-        c.unifyTypeM(tvar, Type.mkRecord(freshRowVar, loc), loc)
+        c.unifyType(tpe, Type.mkRecord(Type.mkRecordRowExtend(label, freshLabelType, freshRowVar, loc), loc), loc)
+        c.unifyType(tvar, Type.mkRecord(freshRowVar, loc), loc)
         val resTpe = tvar
         val resEff = eff
         (resTpe, resEff)
@@ -514,10 +514,10 @@ object ConstraintGeneration {
         val regionType = Type.mkRegion(regionVar, loc)
         val (tpes, effs) = exps.map(visitExp).unzip
         val (tpe, eff) = visitExp(exp)
-        c.expectTypeM(expected = regionType, actual = tpe, exp.loc)
-        val elmTpe = c.unifyAllTypesM(tpes, Kind.Star, loc)
-        c.unifyTypeM(tvar, Type.mkArray(elmTpe, regionVar, loc), loc)
-        c.unifyTypeM(evar, Type.mkUnion(Type.mkUnion(effs, loc), eff, regionVar, loc), loc)
+        c.expectType(expected = regionType, actual = tpe, exp.loc)
+        val elmTpe = c.unifyAllTypes(tpes, Kind.Star, loc)
+        c.unifyType(tvar, Type.mkArray(elmTpe, regionVar, loc), loc)
+        c.unifyType(evar, Type.mkUnion(Type.mkUnion(effs, loc), eff, regionVar, loc), loc)
         val resTpe = tvar
         val resEff = evar
         (resTpe, resEff)
@@ -528,10 +528,10 @@ object ConstraintGeneration {
         val (tpe1, eff1) = visitExp(exp1)
         val (tpe2, eff2) = visitExp(exp2)
         val (tpe3, eff3) = visitExp(exp3)
-        c.expectTypeM(expected = regionType, actual = tpe1, loc)
-        c.expectTypeM(expected = Type.Int32, actual = tpe3, exp3.loc)
-        c.unifyTypeM(tvar, Type.mkArray(tpe2, regionVar, loc), loc)
-        c.unifyTypeM(evar, Type.mkUnion(eff1, eff2, eff3, regionVar, loc), loc)
+        c.expectType(expected = regionType, actual = tpe1, loc)
+        c.expectType(expected = Type.Int32, actual = tpe3, exp3.loc)
+        c.unifyType(tvar, Type.mkArray(tpe2, regionVar, loc), loc)
+        c.unifyType(evar, Type.mkUnion(eff1, eff2, eff3, regionVar, loc), loc)
         val resTpe = tvar
         val resEff = evar
         (resTpe, resEff)
@@ -540,9 +540,9 @@ object ConstraintGeneration {
         val regionVar = Type.freshVar(Kind.Eff, loc)
         val (tpe1, eff1) = visitExp(exp1)
         val (tpe2, eff2) = visitExp(exp2)
-        c.expectTypeM(expected = Type.mkArray(tvar, regionVar, loc), actual = tpe1, exp1.loc)
-        c.expectTypeM(expected = Type.Int32, actual = tpe2, exp2.loc)
-        c.unifyTypeM(evar, Type.mkUnion(regionVar, eff1, eff2, loc), loc)
+        c.expectType(expected = Type.mkArray(tvar, regionVar, loc), actual = tpe1, exp1.loc)
+        c.expectType(expected = Type.Int32, actual = tpe2, exp2.loc)
+        c.unifyType(evar, Type.mkUnion(regionVar, eff1, eff2, loc), loc)
         val resTpe = tvar
         val resEff = evar
         (resTpe, resEff)
@@ -554,10 +554,10 @@ object ConstraintGeneration {
         val (tpe1, eff1) = visitExp(exp1)
         val (tpe2, eff2) = visitExp(exp2)
         val (tpe3, eff3) = visitExp(exp3)
-        c.expectTypeM(expected = arrayType, actual = tpe1, exp1.loc)
-        c.expectTypeM(expected = Type.Int32, actual = tpe2, exp2.loc)
-        c.expectTypeM(expected = elmVar, actual = tpe3, exp3.loc)
-        c.unifyTypeM(evar, Type.mkUnion(List(regionVar, eff1, eff2, eff3), loc), loc)
+        c.expectType(expected = arrayType, actual = tpe1, exp1.loc)
+        c.expectType(expected = Type.Int32, actual = tpe2, exp2.loc)
+        c.expectType(expected = elmVar, actual = tpe3, exp3.loc)
+        c.unifyType(evar, Type.mkUnion(List(regionVar, eff1, eff2, eff3), loc), loc)
         val resTpe = Type.Unit
         val resEff = evar
         (resTpe, resEff)
@@ -566,16 +566,16 @@ object ConstraintGeneration {
         val elmVar = Type.freshVar(Kind.Star, loc)
         val regionVar = Type.freshVar(Kind.Eff, loc)
         val (tpe, eff) = visitExp(exp)
-        c.expectTypeM(Type.mkArray(elmVar, regionVar, loc), tpe, exp.loc)
+        c.expectType(Type.mkArray(elmVar, regionVar, loc), tpe, exp.loc)
         val resTpe = Type.Int32
         val resEff = eff
         (resTpe, resEff)
 
       case Expr.VectorLit(exps, tvar, evar, loc) =>
         val (tpes, effs) = exps.map(visitExp).unzip
-        val tpe = c.unifyAllTypesM(tpes, Kind.Star, loc)
-        c.unifyTypeM(tvar, Type.mkVector(tpe, loc), loc)
-        c.unifyTypeM(evar, Type.mkUnion(effs, loc), loc)
+        val tpe = c.unifyAllTypes(tpes, Kind.Star, loc)
+        c.unifyType(tvar, Type.mkVector(tpe, loc), loc)
+        c.unifyType(evar, Type.mkUnion(effs, loc), loc)
         val resTpe = tvar
         val resEff = evar
         (resTpe, resEff)
@@ -583,9 +583,9 @@ object ConstraintGeneration {
       case Expr.VectorLoad(exp1, exp2, tvar, evar, loc) =>
         val (tpe1, eff1) = visitExp(exp1)
         val (tpe2, eff2) = visitExp(exp2)
-        c.expectTypeM(expected = Type.mkVector(tvar, loc), actual = tpe1, exp1.loc)
-        c.expectTypeM(expected = Type.Int32, actual = tpe2, exp2.loc)
-        c.unifyTypeM(evar, Type.mkUnion(eff1, eff2, loc), loc)
+        c.expectType(expected = Type.mkVector(tvar, loc), actual = tpe1, exp1.loc)
+        c.expectType(expected = Type.Int32, actual = tpe2, exp2.loc)
+        c.unifyType(evar, Type.mkUnion(eff1, eff2, loc), loc)
         val resTpe = tvar
         val resEff = evar
         (resTpe, resEff)
@@ -593,7 +593,7 @@ object ConstraintGeneration {
       case Expr.VectorLength(exp, loc) =>
         val elmVar = Type.freshVar(Kind.Star, loc)
         val (tpe, eff) = visitExp(exp)
-        c.expectTypeM(Type.mkVector(elmVar, loc), tpe, exp.loc)
+        c.expectType(Type.mkVector(elmVar, loc), tpe, exp.loc)
         val resTpe = Type.Int32
         val resEff = eff
         (resTpe, resEff)
@@ -603,9 +603,9 @@ object ConstraintGeneration {
         val regionType = Type.mkRegion(regionVar, loc)
         val (tpe1, eff1) = visitExp(exp1)
         val (tpe2, eff2) = visitExp(exp2)
-        c.expectTypeM(tpe2, regionType, exp2.loc)
-        c.unifyTypeM(tvar, Type.mkRef(tpe1, regionVar, loc), loc)
-        c.unifyTypeM(evar, Type.mkUnion(eff1, eff2, regionVar, loc), loc)
+        c.expectType(tpe2, regionType, exp2.loc)
+        c.unifyType(tvar, Type.mkRef(tpe1, regionVar, loc), loc)
+        c.unifyType(evar, Type.mkUnion(eff1, eff2, regionVar, loc), loc)
         val resTpe = tvar
         val resEff = evar
         (resTpe, resEff)
@@ -615,9 +615,9 @@ object ConstraintGeneration {
         val regionVar = Type.freshVar(Kind.Eff, loc)
         val refType = Type.mkRef(elmVar, regionVar, loc)
         val (tpe, eff) = visitExp(exp)
-        c.expectTypeM(expected = refType, actual = tpe, exp.loc)
-        c.unifyTypeM(tvar, elmVar, loc)
-        c.unifyTypeM(evar, Type.mkUnion(eff, regionVar, loc), loc)
+        c.expectType(expected = refType, actual = tpe, exp.loc)
+        c.unifyType(tvar, elmVar, loc)
+        c.unifyType(evar, Type.mkUnion(eff, regionVar, loc), loc)
         val resTpe = tvar
         val resEff = evar
         (resTpe, resEff)
@@ -628,9 +628,9 @@ object ConstraintGeneration {
         val refType = Type.mkRef(elmVar, regionVar, loc)
         val (tpe1, eff1) = visitExp(exp1)
         val (tpe2, eff2) = visitExp(exp2)
-        c.expectTypeM(expected = refType, actual = tpe1, exp1.loc)
-        c.unifyTypeM(elmVar, tpe2, exp2.loc)
-        c.unifyTypeM(evar, Type.mkUnion(eff1, eff2, regionVar, loc), loc)
+        c.expectType(expected = refType, actual = tpe1, exp1.loc)
+        c.unifyType(elmVar, tpe2, exp2.loc)
+        c.unifyType(evar, Type.mkUnion(eff1, eff2, regionVar, loc), loc)
         val resTpe = Type.Unit
         val resEff = evar
         (resTpe, resEff)
@@ -638,9 +638,9 @@ object ConstraintGeneration {
       case Expr.Ascribe(exp, expectedTpe, expectedEff, tvar, loc) =>
         // An ascribe expression is sound; the type system checks that the declared type matches the inferred type.
         val (actualTpe, actualEff) = visitExp(exp)
-        expectedTpe.foreach { tpe => c.expectTypeM(expected = tpe, actual = actualTpe, loc) }
-        c.unifyTypeM(actualTpe, tvar, loc)
-        expectedEff.foreach { eff => c.expectTypeM(expected = eff, actual = actualEff, loc) }
+        expectedTpe.foreach { tpe => c.expectType(expected = tpe, actual = actualTpe, loc) }
+        c.unifyType(actualTpe, tvar, loc)
+        expectedEff.foreach { eff => c.expectType(expected = eff, actual = actualEff, loc) }
         val resTpe = tvar
         val resEff = actualEff
         (resTpe, resEff)
@@ -658,7 +658,7 @@ object ConstraintGeneration {
             // We replace the type with a fresh variable to allow any type.
             // The validity of this cast is checked in the Safety phase.
             val (_, eff) = visitExp(exp)
-            c.unifyTypeM(evar, eff, loc)
+            c.unifyType(evar, eff, loc)
             val resTpe = tvar
             val resEff = evar
             (resTpe, resEff)
@@ -666,7 +666,7 @@ object ConstraintGeneration {
           case Ast.CheckedCastType.EffectCast =>
             // We union the effect with a fresh variable to allow unifying with a "larger" effect.
             val (tpe, eff) = visitExp(exp)
-            c.unifyTypeM(tvar, tpe, loc)
+            c.unifyType(tvar, tpe, loc)
             val resTpe = tvar
             val resEff = Type.mkUnion(eff, evar, loc)
             (resTpe, resEff)
@@ -675,7 +675,7 @@ object ConstraintGeneration {
       case Expr.UncheckedCast(exp, declaredTpe, declaredEff, tvar, loc) =>
         // An unchecked cast expression is unsound; the type system assumes the declared type and effect are correct.
         val (actualTyp, actualEff) = visitExp(exp)
-        c.unifyTypeM(tvar, declaredTpe.getOrElse(actualTyp), loc)
+        c.unifyType(tvar, declaredTpe.getOrElse(actualTyp), loc)
         val resTpe = tvar
         val resEff = declaredEff.getOrElse(actualEff)
         (resTpe, resEff)
@@ -699,8 +699,8 @@ object ConstraintGeneration {
       case Expr.TryCatch(exp, rules, loc) =>
         val (tpe, eff) = visitExp(exp)
         val (tpes, effs) = rules.map(visitCatchRule).unzip
-        val ruleTpe = c.unifyAllTypesM(tpes, Kind.Star, loc)
-        c.unifyTypeM(tpe, ruleTpe, loc)
+        val ruleTpe = c.unifyAllTypes(tpes, Kind.Star, loc)
+        c.unifyType(tpe, ruleTpe, loc)
         val resTpe = tpe
         val resEff = Type.mkUnion(eff :: effs, loc)
         (resTpe, resEff)
@@ -709,7 +709,7 @@ object ConstraintGeneration {
         val (tpe, eff) = visitExp(exp)
         val continuationEffect = Type.freshVar(Kind.Eff, loc)
         val (tpes, effs) = rules.map(visitHandlerRule(_, tpe, continuationEffect, loc)).unzip
-        c.unifyAllTypesM(tpe :: tvar :: tpes, Kind.Star, loc)
+        c.unifyAllTypes(tpe :: tvar :: tpes, Kind.Star, loc)
 
 
         // TODO ASSOC-TYPES The types used here are not correct.
@@ -719,7 +719,7 @@ object ConstraintGeneration {
         val correctedBodyEff = c.purifyEff(effUse.sym, eff)
 
         // The continuation effect is the effect of all the rule bodies, plus the effect of the try-body
-        c.unifyTypeM(continuationEffect, Type.mkUnion(correctedBodyEff :: effs, loc), loc)
+        c.unifyType(continuationEffect, Type.mkUnion(correctedBodyEff :: effs, loc), loc)
         val resultTpe = tpe
 
         // TODO ASSOC-TYPES should be continuationEffect
@@ -736,7 +736,7 @@ object ConstraintGeneration {
         // specialize the return type of the op if needed
         val opTpe = getDoType(op)
 
-        c.unifyTypeM(opTpe, tvar, loc)
+        c.unifyType(opTpe, tvar, loc)
         val resTpe = tvar
         val resEff = Type.mkUnion(effTpe :: op.spec.eff :: effs, loc)
 
@@ -752,7 +752,7 @@ object ConstraintGeneration {
       case Expr.InvokeMethod(method, clazz, exp, exps, loc) =>
         val classTpe = Type.getFlixType(clazz)
         val (thisTpe, _) = visitExp(exp)
-        c.unifyTypeM(thisTpe, classTpe, loc)
+        c.unifyType(thisTpe, classTpe, loc)
         val (_, _) = exps.map(visitExp).unzip
         val resTpe = Type.getFlixType(method.getReturnType)
         val resEff = Type.IO
@@ -768,7 +768,7 @@ object ConstraintGeneration {
         val classType = Type.getFlixType(clazz)
         val fieldType = Type.getFlixType(field.getType)
         val (tpe, _) = visitExp(exp)
-        c.expectTypeM(expected = classType, actual = tpe, exp.loc)
+        c.expectType(expected = classType, actual = tpe, exp.loc)
         val resTpe = fieldType
         val resEff = Type.IO
         (resTpe, resEff)
@@ -778,8 +778,8 @@ object ConstraintGeneration {
         val classType = Type.getFlixType(clazz)
         val (tpe1, _) = visitExp(exp1)
         val (tpe2, _) = visitExp(exp2)
-        c.expectTypeM(expected = classType, actual = tpe1, exp1.loc)
-        c.expectTypeM(expected = fieldType, actual = tpe2, exp2.loc)
+        c.expectType(expected = classType, actual = tpe1, exp1.loc)
+        c.expectType(expected = fieldType, actual = tpe2, exp2.loc)
         val resTpe = Type.Unit
         val resEff = Type.IO
         (resTpe, resEff)
@@ -792,7 +792,7 @@ object ConstraintGeneration {
 
       case Expr.PutStaticField(field, exp, _) =>
         val (valueTyp, _) = visitExp(exp)
-        c.expectTypeM(expected = Type.getFlixType(field.getType), actual = valueTyp, exp.loc)
+        c.expectType(expected = Type.getFlixType(field.getType), actual = valueTyp, exp.loc)
         val resTpe = Type.Unit
         val resEff = Type.IO
         (resTpe, resEff)
@@ -808,8 +808,8 @@ object ConstraintGeneration {
         val regionType = Type.mkRegion(regionVar, loc)
         val (tpe1, eff1) = visitExp(exp1)
         val (tpe2, eff2) = visitExp(exp2)
-        c.expectTypeM(expected = regionType, actual = tpe1, exp1.loc)
-        c.expectTypeM(expected = Type.Int32, actual = tpe2, exp2.loc)
+        c.expectType(expected = regionType, actual = tpe1, exp1.loc)
+        c.expectType(expected = Type.Int32, actual = tpe2, exp2.loc)
         val resTpe = tvar
         val resEff = Type.mkUnion(eff1, eff2, regionVar, loc)
         (resTpe, resEff)
@@ -819,8 +819,8 @@ object ConstraintGeneration {
         val elmTpe = Type.freshVar(Kind.Star, loc)
         val receiverTpe = Type.mkReceiver(elmTpe, regionVar, loc)
         val (tpe, eff) = visitExp(exp)
-        c.expectTypeM(expected = receiverTpe, actual = tpe, exp.loc)
-        c.unifyTypeM(tvar, elmTpe, loc)
+        c.expectType(expected = receiverTpe, actual = tpe, exp.loc)
+        c.unifyType(tvar, elmTpe, loc)
         val resTpe = tvar
         val resEff = Type.mkUnion(eff, regionVar, loc)
         (resTpe, resEff)
@@ -831,8 +831,8 @@ object ConstraintGeneration {
         val senderTpe = Type.mkSender(elmTpe, regionVar, loc)
         val (tpe1, eff1) = visitExp(exp1)
         val (tpe2, eff2) = visitExp(exp2)
-        c.expectTypeM(expected = senderTpe, actual = tpe1, exp1.loc)
-        c.expectTypeM(expected = elmTpe, actual = tpe2, exp2.loc)
+        c.expectType(expected = senderTpe, actual = tpe1, exp1.loc)
+        c.expectType(expected = elmTpe, actual = tpe2, exp2.loc)
         val resTpe = Type.mkUnit(loc)
         val resEff = Type.mkUnion(eff1, eff2, regionVar, loc)
         (resTpe, resEff)
@@ -841,7 +841,7 @@ object ConstraintGeneration {
         val regionVar = Type.freshVar(Kind.Eff, loc)
         val (ruleTypes, ruleEffs) = rules.map(visitSelectRule(_, regionVar)).unzip
         val (defaultType, eff2) = visitDefaultRule(default, loc)
-        c.unifyAllTypesM(tvar :: defaultType :: ruleTypes, Kind.Star, loc)
+        c.unifyAllTypes(tvar :: defaultType :: ruleTypes, Kind.Star, loc)
         val resTpe = tvar
         val resEff = Type.mkUnion(regionVar :: eff2 :: ruleEffs, loc)
         (resTpe, resEff)
@@ -852,7 +852,7 @@ object ConstraintGeneration {
         val regionType = Type.mkRegion(regionVar, loc)
         val (_, _) = visitExp(exp1)
         val (tpe2, _) = visitExp(exp2)
-        c.expectTypeM(expected = regionType, actual = tpe2, exp2.loc)
+        c.expectType(expected = regionType, actual = tpe2, exp2.loc)
         val resTpe = Type.Unit
         val resEff = Type.mkUnion(Type.IO, regionVar, loc)
         (resTpe, resEff)
@@ -871,14 +871,14 @@ object ConstraintGeneration {
 
       case Expr.Lazy(exp, loc) =>
         val (tpe, eff) = visitExp(exp)
-        c.expectTypeM(expected = Type.Pure, actual = eff, exp.loc)
+        c.expectType(expected = Type.Pure, actual = eff, exp.loc)
         val resTpe = Type.mkLazy(tpe, loc)
         val resEff = Type.Pure
         (resTpe, resEff)
 
       case Expr.Force(exp, tvar, loc) =>
         val (tpe, eff) = visitExp(exp)
-        c.expectTypeM(expected = Type.mkLazy(tvar, loc), actual = tpe, exp.loc)
+        c.expectType(expected = Type.mkLazy(tvar, loc), actual = tpe, exp.loc)
         val resTpe = tvar
         val resEff = eff
         (resTpe, resEff)
@@ -913,7 +913,7 @@ object ConstraintGeneration {
       case KindedAst.Pattern.Wild(tvar, _) => tvar
 
       case KindedAst.Pattern.Var(sym, tvar, loc) =>
-        c.unifyTypeM(sym.tvar, tvar, loc)
+        c.unifyType(sym.tvar, tvar, loc)
         tvar
 
       case KindedAst.Pattern.Cst(cst, _) => Type.constantType(cst)
@@ -926,7 +926,7 @@ object ConstraintGeneration {
 
         // The tag type is a function from the type of variant to the type of the enum.
         val tpe = visitPattern(pat)
-        c.unifyTypeM(tagType, Type.mkPureArrow(tpe, tvar, loc), loc)
+        c.unifyType(tagType, Type.mkPureArrow(tpe, tvar, loc), loc)
         tvar
 
 
@@ -939,10 +939,10 @@ object ConstraintGeneration {
         val freshRecord = Type.mkRecord(freshRowVar, loc.asSynthetic)
 
         val tailTpe = visitPattern(pat)
-        c.unifyTypeM(freshRecord, tailTpe, loc.asSynthetic)
+        c.unifyType(freshRecord, tailTpe, loc.asSynthetic)
         val patTpes = pats.map(visitRecordLabelPattern)
         val resTpe = mkRecordType(patTpes, freshRowVar, loc)
-        c.unifyTypeM(resTpe, tvar, loc)
+        c.unifyType(resTpe, tvar, loc)
         resTpe
 
       case KindedAst.Pattern.RecordEmpty(loc) => Type.mkRecord(Type.RecordRowEmpty, loc)
@@ -961,7 +961,7 @@ object ConstraintGeneration {
     case KindedAst.Pattern.Record.RecordLabelPattern(label, tvar, p, loc) =>
       // { Label = Pattern ... }
       val tpe = visitPattern(p)
-      c.unifyTypeM(tpe, tvar, loc)
+      c.unifyType(tpe, tvar, loc)
       (label, tpe, loc)
   }
 
@@ -976,8 +976,8 @@ object ConstraintGeneration {
       guard.foreach {
         g =>
           val (guardTpe, guardEff) = visitExp(g)
-          c.expectTypeM(expected = Type.Bool, actual = guardTpe, g.loc)
-          c.expectTypeM(expected = Type.Pure, actual = guardEff, g.loc)
+          c.expectType(expected = Type.Bool, actual = guardTpe, g.loc)
+          c.expectType(expected = Type.Pure, actual = guardEff, g.loc)
       }
       val (tpe, eff) = visitExp(exp)
       (patTpe, tpe, eff)
@@ -995,10 +995,10 @@ object ConstraintGeneration {
       // This marking only really affects wildcards,
       // as non-wildcard variables must come from the function signature
       // and are therefore already rigid.
-      declTpe.typeVars.map(_.sym).foreach(c.rigidifyM)
+      declTpe.typeVars.map(_.sym).foreach(c.rigidify)
 
       // Unify the variable's type with the declared type
-      c.unifyTypeM(sym.tvar, declTpe, sym.loc)
+      c.unifyType(sym.tvar, declTpe, sym.loc)
 
       visitExp(exp)
   }
@@ -1010,7 +1010,7 @@ object ConstraintGeneration {
     */
   private def visitCatchRule(rule: KindedAst.CatchRule)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = rule match {
     case KindedAst.CatchRule(sym, clazz, exp) =>
-      c.expectTypeM(expected = Type.mkNative(clazz, sym.loc), sym.tvar, sym.loc)
+      c.expectType(expected = Type.mkNative(clazz, sym.loc), sym.tvar, sym.loc)
       visitExp(exp)
   }
 
@@ -1044,11 +1044,11 @@ object ConstraintGeneration {
           val resumptionEff = continuationEffect
           val expectedResumptionType = Type.mkArrowWithEffect(resumptionArgType, resumptionEff, resumptionResType, loc.asSynthetic)
           unifyFormalParams(op.sym, expected = expectedFparams, actual = actualFparams, op.loc)
-          c.expectTypeM(expected = expectedResumptionType, actual = resumptionFparam.tpe, resumptionFparam.loc)
+          c.expectType(expected = expectedResumptionType, actual = resumptionFparam.tpe, resumptionFparam.loc)
           val (actualTpe, actualEff) = visitExp(body)
 
           // unify the operation return type with its tvar
-          c.unifyTypeM(actualTpe, opTvar, body.loc)
+          c.unifyType(actualTpe, opTvar, body.loc)
 
           (actualTpe, actualEff)
       }
@@ -1065,13 +1065,13 @@ object ConstraintGeneration {
         */
       def visitFormalParam(fparam: KindedAst.FormalParam): Unit = fparam match {
         case KindedAst.FormalParam(sym, _, tpe, _, loc) =>
-          c.unifyTypeM(sym.tvar, tpe, loc)
+          c.unifyType(sym.tvar, tpe, loc)
       }
 
       fparams.foreach(visitFormalParam)
       val (bodyTpe, bodyEff) = visitExp(exp)
-      c.expectTypeM(expected = returnTpe, actual = bodyTpe, exp.loc)
-      c.expectTypeM(expected = eff, actual = bodyEff, exp.loc)
+      c.expectType(expected = returnTpe, actual = bodyTpe, exp.loc)
+      c.expectType(expected = eff, actual = bodyEff, exp.loc)
   }
 
   /**
@@ -1084,7 +1084,7 @@ object ConstraintGeneration {
       case KindedAst.SelectChannelRule(sym, chan, body) =>
         val (chanType, eff1) = visitExp(chan)
         val (bodyType, eff2) = visitExp(body)
-        c.unifyTypeM(chanType, Type.mkReceiver(sym.tvar, regionVar, sym.loc), sym.loc)
+        c.unifyType(chanType, Type.mkReceiver(sym.tvar, regionVar, sym.loc), sym.loc)
         val resTpe = bodyType
         val resEff = Type.mkUnion(eff1, eff2, regionVar, body.loc)
         (resTpe, resEff)
@@ -1121,7 +1121,7 @@ object ConstraintGeneration {
     */
   private def visitOpArg(arg: KindedAst.Expr, fparam: KindedAst.FormalParam)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): Type = {
     val (tpe, eff) = visitExp(arg)
-    c.expectTypeM(expected = fparam.tpe, actual = tpe, arg.loc)
+    c.expectType(expected = fparam.tpe, actual = tpe, arg.loc)
     eff
   }
 
@@ -1132,8 +1132,8 @@ object ConstraintGeneration {
     case KindedAst.ParYieldFragment(pat, exp, loc) =>
       val patTpe = visitPattern(pat)
       val (tpe, eff) = visitExp(exp)
-      c.unifyTypeM(patTpe, tpe, loc)
-      c.expectTypeM(expected = Type.Pure, actual = eff, exp.loc)
+      c.unifyType(patTpe, tpe, loc)
+      c.expectType(expected = Type.Pure, actual = eff, exp.loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/constraintgeneration/TypeContext.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/constraintgeneration/TypeContext.scala
@@ -32,9 +32,11 @@ class TypeContext {
 
   private object ScopeConstraints {
     /**
-      * The empty ScopeConstraints with no associated region.
+      * Creates an empty ScopeConstraints with no associated region.
+      *
+      * Note: The function must return a _NEW_ object because each object has mutable state.
       */
-    val empty: ScopeConstraints = new ScopeConstraints(None)
+    def empty: ScopeConstraints = new ScopeConstraints(None)
 
     /**
       * Creates an empty ScopeConstraints associated with the given region.

--- a/main/src/ca/uwaterloo/flix/language/phase/constraintgeneration/TypeContext.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/constraintgeneration/TypeContext.scala
@@ -31,11 +31,10 @@ import scala.collection.mutable
 class TypeContext {
 
   private object ScopeConstraints {
-
     /**
-      * Creates an empty ScopeConstraints with no associated region.
+      * The empty ScopeConstraints with no associated region.
       */
-    def empty: ScopeConstraints = new ScopeConstraints(None)
+    val empty: ScopeConstraints = new ScopeConstraints(None)
 
     /**
       * Creates an empty ScopeConstraints associated with the given region.
@@ -118,7 +117,7 @@ class TypeContext {
     *   tpe1 ~ tpe2
     * }}}
     */
-  def unifyTypeM(tpe1: Type, tpe2: Type, loc: SourceLocation): Unit = {
+  def unifyType(tpe1: Type, tpe2: Type, loc: SourceLocation): Unit = {
     val constr = TypingConstraint.Equality(tpe1, tpe2, Provenance.Match(tpe1, tpe2, loc))
     currentScopeConstraints.add(constr)
   }
@@ -131,9 +130,9 @@ class TypeContext {
     *   tpe1 ~ tpe3
     * }}}
     */
-  def unifyType3M(tpe1: Type, tpe2: Type, tpe3: Type, loc: SourceLocation): Unit = {
-    unifyTypeM(tpe1, tpe2, loc)
-    unifyTypeM(tpe1, tpe3, loc)
+  def unifyType3(tpe1: Type, tpe2: Type, tpe3: Type, loc: SourceLocation): Unit = {
+    unifyType(tpe1, tpe2, loc)
+    unifyType(tpe1, tpe3, loc)
   }
 
   /**
@@ -148,16 +147,28 @@ class TypeContext {
     *   tpe1 ~ tpeN
     * }}}
     */
-  def unifyAllTypesM(tpes: List[Type], kind: Kind, loc: SourceLocation)(implicit level: Level, flix: Flix): Type = {
+  def unifyAllTypes(tpes: List[Type], kind: Kind, loc: SourceLocation)(implicit level: Level, flix: Flix): Type = {
     // For performance, avoid creating a fresh type var if the list is non-empty
     tpes match {
       // Case 1: Nonempty list. Unify everything with the first type.
       case tpe1 :: rest =>
-        rest.foreach(unifyTypeM(tpe1, _, loc))
+        rest.foreach(unifyType(tpe1, _, loc))
         tpe1
       // Case 2: Empty list. Return a fresh type var.
       case Nil => Type.freshVar(kind, loc.asSynthetic)
     }
+  }
+
+  /**
+    * Generates constraints expecting the given types to unify.
+    *
+    * {{{
+    *   expected ~ actual
+    * }}}
+    */
+  def expectType(expected: Type, actual: Type, loc: SourceLocation): Unit = {
+    val constr = TypingConstraint.Equality(expected, actual, Provenance.ExpectType(expected, actual, loc))
+    currentScopeConstraints.add(constr)
   }
 
   /**
@@ -183,21 +194,9 @@ class TypeContext {
   }
 
   /**
-    * Generates constraints expecting the given types to unify.
-    *
-    * {{{
-    *   expected ~ actual
-    * }}}
-    */
-  def expectTypeM(expected: Type, actual: Type, loc: SourceLocation): Unit = {
-    val constr = TypingConstraint.Equality(expected, actual, Provenance.ExpectType(expected, actual, loc))
-    currentScopeConstraints.add(constr)
-  }
-
-  /**
     * Adds the given class constraints to the context.
     */
-  def addClassConstraintsM(tconstrs0: List[Ast.TypeConstraint], loc: SourceLocation): Unit = {
+  def addClassConstraints(tconstrs0: List[Ast.TypeConstraint], loc: SourceLocation): Unit = {
     // convert all the syntax-level constraints to semantic constraints
     val tconstrs = tconstrs0.map {
       case Ast.TypeConstraint(head, arg, _) => TypingConstraint.Class(head.sym, arg, loc)
@@ -208,7 +207,7 @@ class TypeContext {
   /**
     * Marks the given type variable as rigid in the context.
     */
-  def rigidifyM(sym: Symbol.KindedTypeVarSym): Unit = {
+  def rigidify(sym: Symbol.KindedTypeVarSym): Unit = {
     renv = renv.markRigid(sym)
   }
 
@@ -242,7 +241,7 @@ class TypeContext {
     * the level is incremented,
     * and we get a fresh empty set of constraints for the new scope.
     */
-  def enterRegionM(sym: Symbol.KindedTypeVarSym): Unit = {
+  def enterRegion(sym: Symbol.KindedTypeVarSym): Unit = {
     // save the info from the parent region
     constraintStack.push(currentScopeConstraints)
     renv = renv.markRigid(sym)
@@ -267,7 +266,7 @@ class TypeContext {
     * We add the new purification constraints to the current constraints.
     * Finally, we decrement the level.
     */
-  def exitRegionM(externalEff1: Type, internalEff2: Type, loc: SourceLocation): Unit = {
+  def exitRegion(externalEff1: Type, internalEff2: Type, loc: SourceLocation): Unit = {
     val constr = currentScopeConstraints.region match {
       case None => throw InternalCompilerException("unexpected missing region", loc)
       case Some(r) =>
@@ -280,4 +279,5 @@ class TypeContext {
     currentScopeConstraints.add(constr)
     level = level.decr
   }
+
 }


### PR DESCRIPTION
I only changed `TypeContext`.
related to #7286 