### PR TITLE
refactor: rename Class to Trait (issue #6591)

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -78,7 +78,7 @@ object CodeActionProvider {
       mkDeriveMissingOrder(tpe, uri)
     case TypeError.MissingInstanceToString(tpe, _, loc) if onSameLine(range, loc) =>
       mkDeriveMissingToString(tpe, uri)
-    case InstanceError.MissingSuperClassInstance(tpe, sub, sup, loc) if onSameLine(range, loc) =>
+    case InstanceError.MissingSuperTraitInstance(tpe, sub, sup, loc) if onSameLine(range, loc) =>
       mkDeriveMissingSuperClass(tpe, sup, uri)
     case _ => Nil
   }

--- a/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/InstanceError.scala
@@ -37,7 +37,7 @@ object InstanceError {
     * Error indicating a complex instance type.
     *
     * @param tpe the complex type.
-    * @param sym the class symbol.
+    * @param sym the trait symbol.
     * @param loc the location where the error occurred.
     */
   case class ComplexInstance(tpe: Type, sym: Symbol.TraitSym, loc: SourceLocation)(implicit flix: Flix) extends InstanceError with Recoverable {
@@ -60,7 +60,7 @@ object InstanceError {
     * Error indicating the duplicate use of a type variable in an instance type.
     *
     * @param tvar the duplicated type variable.
-    * @param sym  the class symbol.
+    * @param sym  the trait symbol.
     * @param loc  the location where the error occurred.
     */
   case class DuplicateTypeVar(tvar: Type.Var, sym: Symbol.TraitSym, loc: SourceLocation)(implicit flix: Flix) extends InstanceError with Recoverable {
@@ -84,20 +84,20 @@ object InstanceError {
   }
 
   /**
-    * Error indicating the instance has a definition not present in the implemented class.
+    * Error indicating the instance has a definition not present in the implemented trait.
     *
     * @param defnSym  the defn symbol.
-    * @param classSym the class symbol.
+    * @param traitSym the trait symbol.
     * @param loc      the location of the definition.
     */
-  case class ExtraneousDef(defnSym: Symbol.DefnSym, classSym: Symbol.TraitSym, loc: SourceLocation) extends InstanceError with Recoverable {
+  case class ExtraneousDef(defnSym: Symbol.DefnSym, traitSym: Symbol.TraitSym, loc: SourceLocation) extends InstanceError with Recoverable {
     def summary: String = "Extraneous implementation."
 
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
          |
-         |>> The signature '${red(defnSym.name)}' is not present in the '${magenta(classSym.name)}' trait.
+         |>> The signature '${red(defnSym.name)}' is not present in the '${magenta(traitSym.name)}' trait.
          |
          |${code(loc, s"extraneous def")}
          |""".stripMargin
@@ -112,22 +112,22 @@ object InstanceError {
   /**
     * Error indicating an associated type in an instance type.
     *
-    * @param assoc the type alias.
-    * @param clazz the class symbol.
-    * @param loc   the location where the error occurred.
+    * @param assoc  the type alias.
+    * @param trtSym the trait symbol.
+    * @param loc    the location where the error occurred.
     */
-  case class IllegalAssocTypeInstance(assoc: Symbol.AssocTypeSym, clazz: Symbol.TraitSym, loc: SourceLocation) extends InstanceError with Recoverable {
+  case class IllegalAssocTypeInstance(assoc: Symbol.AssocTypeSym, trtSym: Symbol.TraitSym, loc: SourceLocation) extends InstanceError with Recoverable {
     override def summary: String = "Associated type in instance type."
 
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
          |
-         |>> Illegal use of associated type '${red(assoc.name)}' in instance declaration for '${magenta(clazz.name)}'.
+         |>> Illegal use of associated type '${red(assoc.name)}' in instance declaration for '${magenta(trtSym.name)}'.
          |
          |${code(loc, s"illegal use of associated type")}
          |
-         |A type class instance cannot use an associated type. Use the full type.
+         |A trait instance cannot use an associated type. Use the full type.
          |""".stripMargin
     }
   }
@@ -158,22 +158,22 @@ object InstanceError {
   /**
     * Error indicating a type alias in an instance type.
     *
-    * @param alias the type alias.
-    * @param clazz the class symbol.
-    * @param loc   the location where the error occurred.
+    * @param alias  the type alias.
+    * @param trtSym the trait symbol.
+    * @param loc    the location where the error occurred.
     */
-  case class IllegalTypeAliasInstance(alias: Symbol.TypeAliasSym, clazz: Symbol.TraitSym, loc: SourceLocation) extends InstanceError with Recoverable {
+  case class IllegalTypeAliasInstance(alias: Symbol.TypeAliasSym, trtSym: Symbol.TraitSym, loc: SourceLocation) extends InstanceError with Recoverable {
     override def summary: String = "Type alias in instance type."
 
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
          |
-         |>> Illegal use of type alias '${red(alias.name)}' in instance declaration for '${magenta(clazz.name)}'.
+         |>> Illegal use of type alias '${red(alias.name)}' in instance declaration for '${magenta(trtSym.name)}'.
          |
          |${code(loc, s"illegal use of type alias")}
          |
-         |A type class instance cannot use a type alias. Use the full type.
+         |A trait instance cannot use a type alias. Use the full type.
          |""".stripMargin
     }
   }
@@ -234,33 +234,33 @@ object InstanceError {
   }
 
   /**
-    * Error indicating a missing super class instance.
+    * Error indicating a missing super trait instance.
     *
-    * @param tpe        the type for which the super class instance is missing.
-    * @param subClass   the symbol of the sub class.
-    * @param superClass the symbol of the super class.
+    * @param tpe        the type for which the super trait instance is missing.
+    * @param Trait      the symbol of the sub trait.
+    * @param superTrait the symbol of the super trait.
     * @param loc        the location where the error occurred.
     */
-  case class MissingSuperClassInstance(tpe: Type, subClass: Symbol.TraitSym, superClass: Symbol.TraitSym, loc: SourceLocation)(implicit flix: Flix) extends InstanceError with Recoverable {
-    override def summary: String = s"Missing super class instance '$superClass'."
+  case class MissingSuperTraitInstance(tpe: Type, subTrait: Symbol.TraitSym, superTrait: Symbol.TraitSym, loc: SourceLocation)(implicit flix: Flix) extends InstanceError with Recoverable {
+    override def summary: String = s"Missing super trait instance '$superTrait'."
 
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
          |
-         |>> Missing super class instance '${red(superClass.name)}' for type '${red(FormatType.formatType(tpe))}'.
+         |>> Missing super trait instance '${red(superTrait.name)}' for type '${red(FormatType.formatType(tpe))}'.
          |
-         |${code(loc, s"missing super class instance")}
+         |${code(loc, s"missing super trait instance")}
          |
-         |The class '${red(subClass.name)}' extends the class '${red(superClass.name)}'.
+         |The trait '${red(subTrait.name)}' extends the trait '${red(superTrait.name)}'.
          |
-         |If you provide an instance for '${red(subClass.name)}' you must also provide an instance for '${red(superClass.name)}'.
+         |If you provide an instance for '${red(subTrait.name)}' you must also provide an instance for '${red(superTrait.name)}'.
          |""".stripMargin
     }
 
     override def explain(formatter: Formatter): Option[String] = Some({
       import formatter._
-      s"${underline("Tip:")} Add an instance of '${superClass.name}' for '${FormatType.formatType(tpe)}'."
+      s"${underline("Tip:")} Add an instance of '${superTrait.name}' for '${FormatType.formatType(tpe)}'."
     })
   }
 
@@ -268,10 +268,10 @@ object InstanceError {
     * An error indicating that a required constraint is missing from an instance declaration.
     *
     * @param tconstr    the missing constraint.
-    * @param superClass the superclass that is the source of the constraint.
+    * @param superTrait the supertrait that is the source of the constraint.
     * @param loc        the location where the error occurred.
     */
-  case class MissingTypeClassConstraint(tconstr: Ast.TypeConstraint, superClass: Symbol.TraitSym, loc: SourceLocation)(implicit flix: Flix) extends InstanceError with Recoverable {
+  case class MissingTraitConstraint(tconstr: Ast.TypeConstraint, superTrait: Symbol.TraitSym, loc: SourceLocation)(implicit flix: Flix) extends InstanceError with Recoverable {
     override def summary: String = s"Missing type constraint: ${FormatTypeConstraint.formatTypeConstraint(tconstr)}"
 
     override def message(formatter: Formatter): String = {
@@ -280,7 +280,7 @@ object InstanceError {
          |
          |>> Missing type constraint: ${FormatTypeConstraint.formatTypeConstraint(tconstr)}
          |
-         |The constraint ${FormatTypeConstraint.formatTypeConstraint(tconstr)} is required because it is a constraint on super class ${superClass.name}.
+         |The constraint ${FormatTypeConstraint.formatTypeConstraint(tconstr)} is required because it is a constraint on super trait ${superTrait.name}.
          |
          |${code(loc, s"missing type constraint")}
       """.stripMargin
@@ -295,7 +295,7 @@ object InstanceError {
   /**
     * Error indicating an orphan instance.
     *
-    * @param sym the class symbol.
+    * @param sym the trait symbol.
     * @param tpe the instance type.
     * @param loc the location where the error occurred.
     */
@@ -310,7 +310,7 @@ object InstanceError {
          |
          |${code(loc, s"orphan instance")}
          |
-         |An instance must be declared in the class's namespace or in the type's namespace.
+         |An instance must be declared in the trait's namespace or in the type's namespace.
          |""".stripMargin
     }
   }
@@ -318,7 +318,7 @@ object InstanceError {
   /**
     * Error indicating that the types of two instances overlap.
     *
-    * @param sym  the class symbol.
+    * @param sym  the trait symbol.
     * @param loc1 the location of the first instance.
     * @param loc2 the location of the second instance.
     */
@@ -346,7 +346,7 @@ object InstanceError {
   }
 
   /**
-    * Error indicating an unlawful signature in a lawful class.
+    * Error indicating an unlawful signature in a lawful trait.
     *
     * @param sym the symbol of the unlawful signature.
     * @param loc the location where the error occurred.
@@ -360,7 +360,7 @@ object InstanceError {
          |
          |>> Unlawful signature '${red(sym.name)}'.
          |
-         |>> Each signature of a lawful class must appear in at least one law.
+         |>> Each signature of a lawful trait must appear in at least one law.
          |
          |${code(loc, s"unlawful signature")}
          |

--- a/main/src/ca/uwaterloo/flix/language/errors/KindError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/KindError.scala
@@ -55,20 +55,20 @@ object KindError {
   }
 
   /**
-   * Missing type class constraint.
+   * Missing trait constraint.
    *
-   * @param clazz the class of the constraint.
+   * @param trt   the trait of the constraint.
    * @param tpe   the type of the constraint.
    * @param renv  the rigidity environment.
    * @param loc   the location where the error occurred.
    */
-  case class MissingTypeClassConstraint(clazz: Symbol.TraitSym, tpe: Type, renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix) extends KindError with Unrecoverable {
-    def summary: String = s"No constraint of the '$clazz' class for the type '${formatType(tpe, Some(renv))}'"
+  case class MissingTraitConstraint(trt: Symbol.TraitSym, tpe: Type, renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix) extends KindError with Unrecoverable {
+    def summary: String = s"No constraint of the '$trt' trait for the type '${formatType(tpe, Some(renv))}'"
 
     def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
-         |>> No constraint of the '${cyan(clazz.toString)}' class for the type '${red(formatType(tpe, Some(renv)))}'.
+         |>> No constraint of the '${cyan(trt.toString)}' trait for the type '${red(formatType(tpe, Some(renv)))}'.
          |
          |${code(loc, s"missing constraint")}
          |

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -223,14 +223,14 @@ object Instances {
                   ClassEnvironment.entail(tconstrs.map(subst.apply), subst(tconstr), root.classEnv).toHardResult match {
                     case Result.Ok(_) => Nil
                     case Result.Err(errors) => errors.map {
-                      case UnificationError.NoMatchingInstance(missingTconstr) => InstanceError.MissingTypeClassConstraint(missingTconstr, superClass, clazz.loc)
+                      case UnificationError.NoMatchingInstance(missingTconstr) => InstanceError.MissingTraitConstraint(missingTconstr, superClass, clazz.loc)
                       case _ => throw InternalCompilerException("Unexpected unification error", inst.loc)
                     }.toList
                   }
               }
             case None =>
               // Case 2: No instance matches. Error.
-              List(InstanceError.MissingSuperClassInstance(tpe, clazz.sym, superClass, clazz.loc))
+              List(InstanceError.MissingSuperTraitInstance(tpe, clazz.sym, superClass, clazz.loc))
           }
       }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -380,7 +380,7 @@ object Kinder {
               Validation.success(())
             } else {
               val renv = tparams.map(_.sym).foldLeft(RigidityEnv.empty)(_.markRigid(_))
-              Validation.toHardFailure(KindError.MissingTypeClassConstraint(clazzSym, arg, renv, loc))
+              Validation.toHardFailure(KindError.MissingTraitConstraint(clazzSym, arg, renv, loc))
             }
           case t => throw InternalCompilerException(s"illegal type: $t", t.loc)
         }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
@@ -443,7 +443,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
     expectError[InstanceError.OrphanInstance](result)
   }
 
-  test("Test.MissingSuperClassInstance.01") {
+  test("Test.MissingSuperTraitInstance.01") {
     val input =
       """
         |trait A[a] with B[a]
@@ -452,10 +452,10 @@ class TestInstances extends AnyFunSuite with TestUtils {
         |instance A[Int32]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[InstanceError.MissingSuperClassInstance](result)
+    expectError[InstanceError.MissingSuperTraitInstance](result)
   }
 
-  test("Test.MissingSuperClassInstance.02") {
+  test("Test.MissingSuperTraitInstance.02") {
     val input =
       """
         |trait A[a] with B[a], C[a]
@@ -466,10 +466,10 @@ class TestInstances extends AnyFunSuite with TestUtils {
         |instance B[Int32]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[InstanceError.MissingSuperClassInstance](result)
+    expectError[InstanceError.MissingSuperTraitInstance](result)
   }
 
-  test("Test.MissingSuperClassInstance.03") {
+  test("Test.MissingSuperTraitInstance.03") {
     val input =
       """
         |trait A[a] with B[a]
@@ -479,7 +479,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
         |instance B[Bool]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[InstanceError.MissingSuperClassInstance](result)
+    expectError[InstanceError.MissingSuperTraitInstance](result)
   }
 
   test("Test.UnlawfulSignature.01") {
@@ -625,7 +625,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
         |instance D[(a, b)]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[InstanceError.MissingTypeClassConstraint](result)
+    expectError[InstanceError.MissingTraitConstraint](result)
   }
 
   test("Test.MissingConstraint.02") {
@@ -642,7 +642,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
         |instance E[(a, b)] with C[a], C[b]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    expectError[InstanceError.MissingTypeClassConstraint](result)
+    expectError[InstanceError.MissingTraitConstraint](result)
   }
 
   test("Test.MissingConstraint.03") {
@@ -655,6 +655,6 @@ class TestInstances extends AnyFunSuite with TestUtils {
         |instance D[(a, b)] with D[a], D[b]
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)
-    rejectError[InstanceError.MissingTypeClassConstraint](result)
+    rejectError[InstanceError.MissingTraitConstraint](result)
   }
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -841,7 +841,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
-  test("KindError.Class.Law.01") {
+  test("KindError.Trait.Law.01") {
     val input =
       """
         |trait C[a: Type -> Type] {
@@ -852,7 +852,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
-  test("KindError.Class.Sig.01") {
+  test("KindError.Trait.Sig.01") {
     val input =
       """
         |trait C[a: Type -> Type] {
@@ -863,7 +863,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
-  test("KindError.Class.Sig.02") {
+  test("KindError.Trait.Sig.02") {
     val input =
       """
         |trait C[a] {
@@ -874,7 +874,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
-  test("KindError.Class.TypeConstraint.01") {
+  test("KindError.Trait.TypeConstraint.01") {
     val input =
       """
         |trait C[a]
@@ -1025,7 +1025,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
         |def foo(): C.T[a] = ???
         |""".stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[KindError.MissingTypeClassConstraint](result)
+    expectError[KindError.MissingTraitConstraint](result)
   }
 
   test("KindError.AssocType.01") {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestPatExhaustiveness.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestPatExhaustiveness.scala
@@ -320,7 +320,7 @@ class TestPatExhaustiveness extends AnyFunSuite with TestUtils {
     expectError[NonExhaustiveMatchError](result)
   }
 
-  test("Pattern.Class.01") {
+  test("Pattern.Trait.01") {
     val input =
       """
         |enum E {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -1506,7 +1506,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     expectError[RedundancyError.RedundantUncheckedEffectCast](result)
   }
 
-  test("RedundantTypeConstraint.Class.01") {
+  test("RedundantTypeConstraint.Trait.01") {
     val input =
       """
         |trait C[a]
@@ -1517,7 +1517,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     expectError[RedundancyError.RedundantTypeConstraint](result)
   }
 
-  test("RedundantTypeConstraint.Class.02") {
+  test("RedundantTypeConstraint.Trait.02") {
     val input =
       """
         |trait C[a]

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -828,13 +828,13 @@ class TestResolver extends AnyFunSuite with TestUtils {
   }
 
 
-  test("CyclicClassHierarchy.01") {
+  test("CyclicTraitHierarchy.01") {
     val input = "trait A[a] with A[a]"
     val result = compile(input, Options.TestWithLibNix)
     expectError[ResolutionError.CyclicTraitHierarchy](result)
   }
 
-  test("CyclicClassHierarchy.02") {
+  test("CyclicTraitHierarchy.02") {
     val input =
       """
         |trait A[a] with B[a]
@@ -844,7 +844,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.CyclicTraitHierarchy](result)
   }
 
-  test("CyclicClassHierarchy.03") {
+  test("CyclicTraitHierarchy.03") {
     val input =
       """
         |trait A[a] with B[a]
@@ -855,7 +855,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.CyclicTraitHierarchy](result)
   }
 
-  test("CyclicClassHierarchy.04") {
+  test("CyclicTraitHierarchy.04") {
     val input =
       """
         |trait A[a] with A[a], B[a]
@@ -865,7 +865,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.CyclicTraitHierarchy](result)
   }
 
-  test("CyclicClassHierarchy.05") {
+  test("CyclicTraitHierarchy.05") {
     val input =
       """
         |trait A[a] with B[a]
@@ -1167,7 +1167,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.UndefinedTypeVar](result)
   }
 
-  test("UndefinedTypeVar.Class.01") {
+  test("UndefinedTypeVar.Trait.01") {
     val input =
       """
         |trait A[a]
@@ -1177,7 +1177,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.UndefinedTypeVar](result)
   }
 
-  test("UndefinedTypeVar.Class.02") {
+  test("UndefinedTypeVar.Trait.02") {
     val input =
       """
         |trait A[a]


### PR DESCRIPTION
This PR changes error names that had "Class" in them:

InstanceError.MissingSuperClassInstance 
InstanceError.MissingTypeClassConstraint
KindError.MissingTypeClassConstraint

It also changes class to trait in comments, variable names and test display names.

Is there a way to run `TestAll` outside off IntelliJ? On my PC it goes off into spinner mode after about 1400 of the tests. I've tried both under Linux and Windows and increasing Intellij's memory setting without success. Separately running the test file that it apparently got stuck on is fine - so it doesn't appear to a problem with any particular file.