### PR TITLE
chore: rename class to trait in Desugar and others (issue #6591)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -66,7 +66,7 @@ object Desugar {
       val decls = decls0.map(visitDecl)
       DesugaredAst.Declaration.Namespace(ident, usesAndImports, decls, loc)
 
-    case d: WeededAst.Declaration.Class => visitClass(d)
+    case d: WeededAst.Declaration.Class => visitTrait(d)
     case d: WeededAst.Declaration.Instance => visitInstance(d)
     case d: WeededAst.Declaration.Def => visitDef(d)
     case d: WeededAst.Declaration.Law => visitLaw(d)
@@ -77,16 +77,16 @@ object Desugar {
   }
 
   /**
-    * Desugars the given [[WeededAst.Declaration.Class]] `class0`.
+    * Desugars the given [[WeededAst.Declaration.Class]] `trait0`.
     */
-  private def visitClass(class0: WeededAst.Declaration.Class)(implicit flix: Flix): DesugaredAst.Declaration.Class = class0 match {
-    case WeededAst.Declaration.Class(doc, ann, mod, ident, tparam0, superClasses0, assocs0, sigs0, laws0, loc) =>
+  private def visitTrait(trait0: WeededAst.Declaration.Class)(implicit flix: Flix): DesugaredAst.Declaration.Class = trait0 match {
+    case WeededAst.Declaration.Class(doc, ann, mod, ident, tparam0, superTraits0, assocs0, sigs0, laws0, loc) =>
       val tparam = visitTypeParam(tparam0)
-      val superClasses = superClasses0.map(visitTypeConstraint)
+      val superTraits = superTraits0.map(visitTypeConstraint)
       val assocs = assocs0.map(visitAssocTypeSig)
       val sigs = sigs0.map(visitSig)
       val laws = laws0.map(visitDef)
-      DesugaredAst.Declaration.Class(doc, ann, mod, ident, tparam, superClasses, assocs, sigs, laws, loc)
+      DesugaredAst.Declaration.Class(doc, ann, mod, ident, tparam, superTraits, assocs, sigs, laws, loc)
   }
 
   /**
@@ -405,8 +405,8 @@ object Desugar {
     * Desugars the given [[WeededAst.Derivations]] `derives0`.
     */
   private def visitDerivations(derives0: WeededAst.Derivations): DesugaredAst.Derivations = derives0 match {
-    case WeededAst.Derivations(classes, loc) =>
-      DesugaredAst.Derivations(classes, loc)
+    case WeededAst.Derivations(traits, loc) =>
+      DesugaredAst.Derivations(traits, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -31,7 +31,7 @@ import scala.collection.immutable.SortedSet
 /**
   * Attributes kinds to the types in the AST.
   *
-  * For enums, classes, instances, and type aliases:
+  * For enums, traits, instances, and type aliases:
   * Either:
   *   - type parameters are not annotated and are then assumed all to be Star, or
   *   - type parameters are all annotated with their kinds.
@@ -45,7 +45,7 @@ import scala.collection.immutable.SortedSet
   *       - If the type variable is the type of a formal parameter, it is ascribed kind Star.
   *       - If the type variable is the return type of the function, it is ascribed kind Star.
   *       - If the type variable is the purity type of the function, it is ascribed kind Eff.
-  *       - If the type variable is an argument to a type constraint, it is ascribed the class's parameter kind
+  *       - If the type variable is an argument to a type constraint, it is ascribed the trait's parameter kind
   *       - If the type variable is an argument to a type constructor, it is ascribed the type constructor's parameter kind.
   *       - If the type variable is used as an type constructor, it is ascribed the kind Star -> Star ... -> Star -> X,
   *         where X is the kind inferred from enacting these rules in the place of the fully-applied type.
@@ -66,7 +66,7 @@ object Kinder {
 
         val restrictableEnumsVal = ParOps.parTraverseValues(root.restrictableEnums)(visitRestrictableEnum(_, taenv, root))
 
-        val classesVal = visitClasses(root, taenv, oldRoot, changeSet)
+        val traitsVal = visitTraits(root, taenv, oldRoot, changeSet)
 
         val defsVal = visitDefs(root, taenv, oldRoot, changeSet)
 
@@ -74,9 +74,9 @@ object Kinder {
 
         val effectsVal = ParOps.parTraverseValues(root.effects)(visitEffect(_, taenv, root))
 
-        mapN(enumsVal, restrictableEnumsVal, classesVal, defsVal, instancesVal, effectsVal) {
-          case (enums, restrictableEnums, classes, defs, instances, effects) =>
-            KindedAst.Root(classes, instances, defs, enums, restrictableEnums, effects, taenv, root.uses, root.entryPoint, root.sources, root.names)
+        mapN(enumsVal, restrictableEnumsVal, traitsVal, defsVal, instancesVal, effectsVal) {
+          case (enums, restrictableEnums, traits, defs, instances, effects) =>
+            KindedAst.Root(traits, instances, defs, enums, restrictableEnums, effects, taenv, root.uses, root.entryPoint, root.sources, root.names)
         }
     }
 
@@ -193,33 +193,33 @@ object Kinder {
   }
 
   /**
-    * Performs kinding on the all the classes in the given root.
+    * Performs kinding on the all the traits in the given root.
     */
-  private def visitClasses(root: ResolvedAst.Root, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Validation[Map[Symbol.TraitSym, KindedAst.Class], KindError] = {
-    val (staleClasses, freshClasses) = changeSet.partition(root.classes, oldRoot.classes)
+  private def visitTraits(root: ResolvedAst.Root, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): Validation[Map[Symbol.TraitSym, KindedAst.Class], KindError] = {
+    val (staleTraits, freshTraits) = changeSet.partition(root.classes, oldRoot.classes)
 
-    val result = ParOps.parTraverseValues(staleClasses)(visitClass(_, taenv, root))
-    mapN(result)(freshClasses ++ _)
+    val result = ParOps.parTraverseValues(staleTraits)(visitTrait(_, taenv, root))
+    mapN(result)(freshTraits ++ _)
   }
 
   /**
-    * Performs kinding on the given type class.
+    * Performs kinding on the given trait.
     */
-  private def visitClass(clazz: ResolvedAst.Declaration.Trait, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Class, KindError] = clazz match {
-    case ResolvedAst.Declaration.Trait(doc, ann, mod, sym, tparam0, superClasses0, assocs0, sigs0, laws0, loc) =>
+  private def visitTrait(trt: ResolvedAst.Declaration.Trait, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Class, KindError] = trt match {
+    case ResolvedAst.Declaration.Trait(doc, ann, mod, sym, tparam0, superTraits0, assocs0, sigs0, laws0, loc) =>
       val kenv = getKindEnvFromTypeParamDefaultStar(tparam0)
 
       val tparamsVal = visitTypeParam(tparam0, kenv)
-      val superClassesVal = traverse(superClasses0)(visitTypeConstraint(_, kenv, taenv, root))
+      val superTraitsVal = traverse(superTraits0)(visitTypeConstraint(_, kenv, taenv, root))
       val assocsVal = traverse(assocs0)(visitAssocTypeSig(_, kenv, taenv, root))
-      flatMapN(tparamsVal, superClassesVal, assocsVal) {
-        case (tparam, superClasses, assocs) =>
+      flatMapN(tparamsVal, superTraitsVal, assocsVal) {
+        case (tparam, superTraits, assocs) =>
           val sigsVal = traverse(sigs0) {
-            case (sigSym, sig0) => mapN(visitSig(sig0, tparam, superClasses, kenv, taenv, root))(sig => sigSym -> sig)
+            case (sigSym, sig0) => mapN(visitSig(sig0, tparam, superTraits, kenv, taenv, root))(sig => sigSym -> sig)
           }
-          val lawsVal = traverse(laws0)(visitDef(_, Nil, kenv, taenv, root)) // TODO ASSOC-TYPES need to include super classes?
+          val lawsVal = traverse(laws0)(visitDef(_, Nil, kenv, taenv, root)) // TODO ASSOC-TYPES need to include super traits?
           mapN(sigsVal, lawsVal) {
-            case (sigs, laws) => KindedAst.Class(doc, ann, mod, sym, tparam, superClasses, assocs, sigs.toMap, laws, loc)
+            case (sigs, laws) => KindedAst.Class(doc, ann, mod, sym, tparam, superTraits, assocs, sigs.toMap, laws, loc)
           }
 
       }
@@ -229,8 +229,8 @@ object Kinder {
     * Performs kinding on the given instance.
     */
   private def visitInstance(inst: ResolvedAst.Declaration.Instance, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Instance, KindError] = inst match {
-    case ResolvedAst.Declaration.Instance(doc, ann, mod, clazz, tpe0, tconstrs0, assocs0, defs0, ns, loc) =>
-      val kind = getClassKind(root.classes(clazz.sym))
+    case ResolvedAst.Declaration.Instance(doc, ann, mod, trt, tpe0, tconstrs0, assocs0, defs0, ns, loc) =>
+      val kind = getTraitKind(root.classes(trt.sym))
 
       val kenvVal = inferType(tpe0, kind, KindEnv.empty, taenv, root)
       flatMapN(kenvVal) {
@@ -242,7 +242,7 @@ object Kinder {
             case (tpe, tconstrs, assocs) =>
               val defsVal = traverse(defs0)(visitDef(_, tconstrs, kenv, taenv, root))
               mapN(defsVal) {
-                case defs => KindedAst.Instance(doc, ann, mod, clazz, tpe, tconstrs, assocs, defs, ns, loc)
+                case defs => KindedAst.Instance(doc, ann, mod, trt, tpe, tconstrs, assocs, defs, ns, loc)
               }
           }
       }
@@ -291,13 +291,13 @@ object Kinder {
   /**
     * Performs kinding on the given sig under the given kind environment.
     */
-  private def visitSig(sig0: ResolvedAst.Declaration.Sig, classTparam: KindedAst.TypeParam, classConstraints: List[Ast.TypeConstraint], kenv0: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Sig, KindError] = sig0 match {
+  private def visitSig(sig0: ResolvedAst.Declaration.Sig, traitTparam: KindedAst.TypeParam, traitConstraints: List[Ast.TypeConstraint], kenv0: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Sig, KindError] = sig0 match {
     case ResolvedAst.Declaration.Sig(sym, spec0, exp0) =>
       val kenvVal = getKindEnvFromSpec(spec0, kenv0, taenv, root)
       flatMapN(kenvVal) {
         kenv =>
           val henv = None
-          val specVal = visitSpec(spec0, List(classTparam.sym), classConstraints, kenv, taenv, root)
+          val specVal = visitSpec(spec0, List(traitTparam.sym), traitConstraints, kenv, taenv, root)
           val expVal = traverseOpt(exp0)(visitExp(_, kenv, taenv, henv, root))
           mapN(specVal, expVal) {
             case (spec, exp) => KindedAst.Sig(sym, spec, exp)
@@ -370,17 +370,17 @@ object Kinder {
         // check that they are all covered by the type constraints
         Validation.traverseX(tpes.flatMap(getAssocTypes)) {
           case Type.AssocType(Ast.AssocTypeConstructor(assocSym, _), arg@Type.Var(tvarSym1, _), _, loc) =>
-            val clazzSym = assocSym.clazz
+            val trtSym = assocSym.clazz
             val matches = (extraTconstrs ::: tconstrs).exists {
               case Ast.TypeConstraint(Ast.TypeConstraint.Head(tconstrSym, _), Type.Var(tvarSym2, _), _) =>
-                clazzSym == tconstrSym && tvarSym1 == tvarSym2
+                trtSym == tconstrSym && tvarSym1 == tvarSym2
               case _ => false
             }
             if (matches) {
               Validation.success(())
             } else {
               val renv = tparams.map(_.sym).foldLeft(RigidityEnv.empty)(_.markRigid(_))
-              Validation.toHardFailure(KindError.MissingTraitConstraint(clazzSym, arg, renv, loc))
+              Validation.toHardFailure(KindError.MissingTraitConstraint(trtSym, arg, renv, loc))
             }
           case t => throw InternalCompilerException(s"illegal type: $t", t.loc)
         }
@@ -403,12 +403,12 @@ object Kinder {
   /**
     * Performs kinding on the given associated type definition under the given kind environment.
     */
-  private def visitAssocTypeDef(d0: ResolvedAst.Declaration.AssocTypeDef, clazzKind: Kind, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.AssocTypeDef, KindError] = d0 match {
+  private def visitAssocTypeDef(d0: ResolvedAst.Declaration.AssocTypeDef, trtKind: Kind, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.AssocTypeDef, KindError] = d0 match {
     case ResolvedAst.Declaration.AssocTypeDef(doc, mod, symUse, arg0, tpe0, loc) =>
-      val clazz = root.classes(symUse.sym.clazz)
-      val assocSig = clazz.assocs.find(assoc => assoc.sym == symUse.sym).get
+      val trt = root.classes(symUse.sym.clazz)
+      val assocSig = trt.assocs.find(assoc => assoc.sym == symUse.sym).get
       val tpeKind = assocSig.kind
-      val argVal = visitType(arg0, clazzKind, kenv, taenv, root)
+      val argVal = visitType(arg0, trtKind, kenv, taenv, root)
       val tpeVal = visitType(tpe0, tpeKind, kenv, taenv, root)
 
       mapN(argVal, tpeVal) {
@@ -1208,15 +1208,15 @@ object Kinder {
       }
 
     case UnkindedType.AssocType(cst, arg0, loc) =>
-      val clazz = root.classes(cst.sym.clazz)
+      val trt = root.classes(cst.sym.clazz)
       // TODO ASSOC-TYPES maybe have dedicated field in root for assoc types
-      clazz.assocs.find(_.sym == cst.sym).get match {
+      trt.assocs.find(_.sym == cst.sym).get match {
         case ResolvedAst.Declaration.AssocTypeSig(_, _, _, _, k0, _, _) =>
           // TODO ASSOC-TYPES for now assuming just one type parameter
           // check that the assoc type kind matches the expected
           unify(k0, expectedKind) match {
             case Some(kind) =>
-              val innerExpectedKind = getClassKind(clazz)
+              val innerExpectedKind = getTraitKind(trt)
               val argVal = visitType(arg0, innerExpectedKind, kenv, taenv, root)
               mapN(argVal) {
                 case arg => Type.AssocType(cst, arg, kind, loc)
@@ -1360,8 +1360,8 @@ object Kinder {
     */
   private def visitTypeConstraint(tconstr: ResolvedAst.TypeConstraint, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[Ast.TypeConstraint, KindError] = tconstr match {
     case ResolvedAst.TypeConstraint(head, tpe0, loc) =>
-      val classKind = getClassKind(root.classes(head.sym))
-      mapN(visitType(tpe0, classKind, kenv, taenv, root)) {
+      val traitKind = getTraitKind(root.classes(head.sym))
+      mapN(visitType(tpe0, traitKind, kenv, taenv, root)) {
         tpe => Ast.TypeConstraint(head, tpe, loc)
       }
   }
@@ -1459,7 +1459,7 @@ object Kinder {
   /**
     * Infers a kind environment from the given spec.
     * A KindEnvironment is provided in case some subset of of kinds have been declared (and therefore should not be inferred),
-    * as in the case of a class type parameter used in a sig or law.
+    * as in the case of a trait type parameter used in a sig or law.
     */
   private def inferSpec(spec0: ResolvedAst.Spec, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindEnv, KindError] = spec0 match {
     case ResolvedAst.Spec(_, _, _, _, fparams, tpe, eff0, tconstrs, _, _) => // TODO ASSOC-TYPES use econstrs for inference?
@@ -1490,7 +1490,7 @@ object Kinder {
     */
   private def inferTypeConstraint(tconstr: ResolvedAst.TypeConstraint, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindEnv, KindError] = tconstr match {
     case ResolvedAst.TypeConstraint(head, tpe, _) =>
-      val kind = getClassKind(root.classes(head.sym))
+      val kind = getTraitKind(root.classes(head.sym))
       inferType(tpe, kind, kenv: KindEnv, taenv, root)
   }
 
@@ -1543,8 +1543,8 @@ object Kinder {
       }
 
     case UnkindedType.AssocType(cst, arg, _) =>
-      val clazz = root.classes(cst.sym.clazz)
-      val kind = getClassKind(clazz)
+      val trt = root.classes(cst.sym.clazz)
+      val kind = getTraitKind(trt)
       inferType(arg, kind, kenv0, taenv, root)
 
     case UnkindedType.Arrow(eff, _, _) =>
@@ -1715,9 +1715,9 @@ object Kinder {
   }
 
   /**
-    * Gets the kind of the class.
+    * Gets the kind of the trait.
     */
-  private def getClassKind(clazz: ResolvedAst.Declaration.Trait): Kind = clazz.tparam match {
+  private def getTraitKind(trt: ResolvedAst.Declaration.Trait): Kind = trt.tparam match {
     case ResolvedAst.TypeParam.Kinded(_, _, kind, _) => kind
     case _: ResolvedAst.TypeParam.Unkinded => Kind.Star
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -153,14 +153,14 @@ object Lowering {
     val aliases = ParOps.parMapValues(root.typeAliases)(visitTypeAlias)
 
     // TypedAst.Sigs are shared between the `sigs` field and the `classes` field.
-    // Instead of visiting twice, we visit the `sigs` field and then look up the results when visiting classes.
-    val classes = ParOps.parMapValues(root.classes)(c => visitClass(c, sigs))
+    // Instead of visiting twice, we visit the `sigs` field and then look up the results when visiting traits.
+    val traits = ParOps.parMapValues(root.classes)(t => visitTrait(t, sigs))
 
     val newEnums = enums ++ restrictableEnums.map {
       case (_, v) => v.sym -> v
     }
 
-    LoweredAst.Root(classes, instances, sigs, defs, newEnums, effects, aliases, root.entryPoint, root.reachable, root.sources, root.classEnv, root.eqEnv)
+    LoweredAst.Root(traits, instances, sigs, defs, newEnums, effects, aliases, root.entryPoint, root.reachable, root.sources, root.classEnv, root.eqEnv)
   }
 
   /**
@@ -293,18 +293,18 @@ object Lowering {
   }
 
   /**
-    * Lowers the given class `clazz0`, with the given lowered sigs `sigs`.
+    * Lowers the given trait `trt0`, with the given lowered sigs `sigs`.
     */
-  private def visitClass(clazz0: TypedAst.Class, sigs: Map[Symbol.SigSym, LoweredAst.Sig])(implicit root: TypedAst.Root, flix: Flix): LoweredAst.Class = clazz0 match {
-    case TypedAst.Class(doc, ann, mod, sym, tparam0, superClasses0, assocs0, signatures0, laws0, loc) =>
+  private def visitTrait(trt0: TypedAst.Class, sigs: Map[Symbol.SigSym, LoweredAst.Sig])(implicit root: TypedAst.Root, flix: Flix): LoweredAst.Class = trt0 match {
+    case TypedAst.Class(doc, ann, mod, sym, tparam0, superTraits0, assocs0, signatures0, laws0, loc) =>
       val tparam = visitTypeParam(tparam0)
-      val superClasses = superClasses0.map(visitTypeConstraint)
+      val superTraits = superTraits0.map(visitTypeConstraint)
       val assocs = assocs0.map {
         case TypedAst.AssocTypeSig(doc, mod, sym, tparam, kind, tpe, loc) => LoweredAst.AssocTypeSig(doc, mod, sym, tparam, kind, loc)
       }
       val signatures = signatures0.map(sig => sigs(sig.sym))
       val laws = laws0.map(visitDef)
-      LoweredAst.Class(doc, ann, mod, sym, tparam, superClasses, assocs, signatures, laws, loc)
+      LoweredAst.Class(doc, ann, mod, sym, tparam, superTraits, assocs, signatures, laws, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -82,7 +82,7 @@ object Namer {
     */
   private def visitDecl(decl0: DesugaredAst.Declaration, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration, NameError] = decl0 match {
     case decl: DesugaredAst.Declaration.Namespace => visitNamespace(decl, ns0)
-    case decl: DesugaredAst.Declaration.Class => visitClass(decl, ns0)
+    case decl: DesugaredAst.Declaration.Class => visitTrait(decl, ns0)
     case decl: DesugaredAst.Declaration.Instance => visitInstance(decl, ns0)
     case decl: DesugaredAst.Declaration.Def => visitDef(decl, ns0, DefKind.NonMember)
     case decl: DesugaredAst.Declaration.Enum => visitEnum(decl, ns0)
@@ -125,7 +125,7 @@ object Namer {
       }
       mapN(table2Val)(addUsesToTable(_, sym.ns, usesAndImports))
 
-    case NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam, superClasses, assocs, sigs, laws, loc) =>
+    case NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam, superTraits, assocs, sigs, laws, loc) =>
       val table1Val = tryAddToTable(table0, sym.namespace, sym.name, decl)
       flatMapN(table1Val) {
         case table1 => fold(assocs ++ sigs, table1) {
@@ -253,7 +253,7 @@ object Namer {
   }
 
   /**
-    * The result of looking up a type or class name in an ast root.
+    * The result of looking up a type or trait name in an ast root.
     */
   private sealed trait NameLookupResult
 
@@ -423,22 +423,22 @@ object Namer {
   }
 
   /**
-    * Performs naming on the given class `clazz`.
+    * Performs naming on the given trait `trt`.
     */
-  private def visitClass(clazz: DesugaredAst.Declaration.Class, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Trait, NameError] = clazz match {
-    case DesugaredAst.Declaration.Class(doc, ann, mod0, ident, tparams0, superClasses0, assocs0, signatures, laws0, loc) =>
+  private def visitTrait(trt: DesugaredAst.Declaration.Class, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Trait, NameError] = trt match {
+    case DesugaredAst.Declaration.Class(doc, ann, mod0, ident, tparams0, superTraits0, assocs0, signatures, laws0, loc) =>
       val sym = Symbol.mkClassSym(ns0, ident)
       val mod = visitModifiers(mod0, ns0)
       val tparam = getTypeParam(tparams0)
 
-      val superClassesVal = traverse(superClasses0)(visitTypeConstraint(_, ns0))
+      val superTraitsVal = traverse(superTraits0)(visitTypeConstraint(_, ns0))
       val assocsVal = traverse(assocs0)(visitAssocTypeSig(_, sym, ns0)) // TODO switch param order to match visitSig
       val sigsVal = traverse(signatures)(visitSig(_, ns0, sym))
       val lawsVal = traverse(laws0)(visitDef(_, ns0, DefKind.Member))
 
-      mapN(superClassesVal, assocsVal, sigsVal, lawsVal) {
-        case (superClasses, assocs, sigs, laws) =>
-          NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam, superClasses, assocs, sigs, laws, loc)
+      mapN(superTraitsVal, assocsVal, sigsVal, lawsVal) {
+        case (superTraits, assocs, sigs, laws) =>
+          NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam, superTraits, assocs, sigs, laws, loc)
       }
   }
 
@@ -487,7 +487,7 @@ object Namer {
   /**
     * Performs naming on the given signature declaration `sig`.
     */
-  private def visitSig(sig: DesugaredAst.Declaration.Sig, ns0: Name.NName, classSym: Symbol.TraitSym)(implicit flix: Flix): Validation[NamedAst.Declaration.Sig, NameError] = sig match {
+  private def visitSig(sig: DesugaredAst.Declaration.Sig, ns0: Name.NName, traitSym: Symbol.TraitSym)(implicit flix: Flix): Validation[NamedAst.Declaration.Sig, NameError] = sig match {
     case DesugaredAst.Declaration.Sig(doc, ann, mod0, ident, tparams0, fparams0, exp0, tpe0, eff0, tconstrs0, econstrs0, loc) =>
       val tparams = getTypeParamsFromFormalParams(tparams0, fparams0, tpe0, eff0, econstrs0)
 
@@ -508,7 +508,7 @@ object Namer {
           mapN(expVal) {
             case exp =>
 
-              val sym = Symbol.mkSigSym(classSym, ident)
+              val sym = Symbol.mkSigSym(traitSym, ident)
               val spec = NamedAst.Spec(doc, ann, mod, tparams, fparams, tpe, eff, tconstrs, econstrs, loc)
               NamedAst.Declaration.Sig(sym, spec, exp)
           }
@@ -1558,7 +1558,7 @@ object Namer {
     * Gets the location of the symbol of the declaration.
     */
   private def getSymLocation(f: NamedAst.Declaration): SourceLocation = f match {
-    case NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam, superClasses, assocs, sigs, laws, loc) => sym.loc
+    case NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam, superTraits, assocs, sigs, laws, loc) => sym.loc
     case NamedAst.Declaration.Sig(sym, spec, exp) => sym.loc
     case NamedAst.Declaration.Def(sym, spec, exp) => sym.loc
     case NamedAst.Declaration.Enum(doc, ann, mod, sym, tparams, derives, cases, loc) => sym.loc
@@ -1601,12 +1601,12 @@ object Namer {
 
   private object DefKind {
     /**
-      * A def that is a member of an instance or class.
+      * A def that is a member of an instance or trait.
       */
     case object Member extends DefKind
 
     /**
-      * A def that is not a member of an instance or class.
+      * A def that is not a member of an instance or trait.
       */
     case object NonMember extends DefKind
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -52,21 +52,21 @@ object Stratifier {
     // Compute the stratification at every datalog expression in the ast.
     val newDefs = ParOps.parTraverseValues(root.defs)(visitDef(_))
     val newInstances = ParOps.parTraverseValues(root.instances)(traverse(_)(visitInstance(_)))
-    val newClasses = ParOps.parTraverseValues(root.classes)(visitClass(_))
+    val newTraits = ParOps.parTraverseValues(root.classes)(visitTrait(_))
 
-    mapN(newDefs, newInstances, newClasses) {
-      case (ds, is, cs) => root.copy(defs = ds, instances = is, classes = cs)
+    mapN(newDefs, newInstances, newTraits) {
+      case (ds, is, ts) => root.copy(defs = ds, instances = is, classes = ts)
     }
   }
 
   /**
-    * Performs Stratification of the given class `c0`.
+    * Performs Stratification of the given trait `t0`.
     */
-  private def visitClass(c0: TypedAst.Class)(implicit root: Root, g: LabelledPrecedenceGraph, flix: Flix): Validation[TypedAst.Class, StratificationError] = {
-    val newLaws = traverse(c0.laws)(visitDef(_))
-    val newSigs = traverse(c0.sigs)(visitSig(_))
+  private def visitTrait(t0: TypedAst.Class)(implicit root: Root, g: LabelledPrecedenceGraph, flix: Flix): Validation[TypedAst.Class, StratificationError] = {
+    val newLaws = traverse(t0.laws)(visitDef(_))
+    val newSigs = traverse(t0.sigs)(visitSig(_))
     mapN(newLaws, newSigs) {
-      case (nl, ns) => c0.copy(laws = nl, sigs = ns)
+      case (nl, ns) => t0.copy(laws = nl, sigs = ns)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder.scala
@@ -139,7 +139,7 @@ object Weeder {
 
     case d: ParsedAst.Declaration.TypeAlias => visitTypeAlias(d)
 
-    case d: ParsedAst.Declaration.Class => visitClass(d)
+    case d: ParsedAst.Declaration.Class => visitTrait(d)
 
     case d: ParsedAst.Declaration.Instance => visitInstance(d)
 
@@ -147,10 +147,10 @@ object Weeder {
   }
 
   /**
-    * Performs weeding on the given class declaration `c0`.
+    * Performs weeding on the given trait declaration `c0`.
     */
-  private def visitClass(c0: ParsedAst.Declaration.Class)(implicit flix: Flix): Validation[List[WeededAst.Declaration.Class], WeederError] = c0 match {
-    case ParsedAst.Declaration.Class(doc0, ann0, mods0, sp1, ident, tparam0, superClasses0, assocs0, lawsAndSigs, sp2) =>
+  private def visitTrait(t0: ParsedAst.Declaration.Class)(implicit flix: Flix): Validation[List[WeededAst.Declaration.Class], WeederError] = t0 match {
+    case ParsedAst.Declaration.Class(doc0, ann0, mods0, sp1, ident, tparam0, superTraits0, assocs0, lawsAndSigs, sp2) =>
       val loc = mkSL(sp1, sp2)
       val doc = visitDoc(doc0)
       val laws0 = lawsAndSigs.collect { case law: ParsedAst.Declaration.Law => law }
@@ -159,14 +159,14 @@ object Weeder {
       val annVal = visitAnnotations(ann0)
       val modsVal = visitModifiers(mods0, legalModifiers = Set(Ast.Modifier.Lawful, Ast.Modifier.Public, Ast.Modifier.Sealed))
       val tparam = visitTypeParam(tparam0)
-      val superClassesVal = traverse(superClasses0)(visitTypeConstraint)
+      val superTraitsVal = traverse(superTraits0)(visitTypeConstraint)
       val assocsVal = traverse(assocs0)(visitAssocTypeSig(_, tparam))
       val sigsVal = traverse(sigs0)(visitSig)
       val lawsVal = traverse(laws0)(visitLaw)
 
-      mapN(annVal, modsVal, superClassesVal, assocsVal, sigsVal, lawsVal) {
-        case (ann, mods, superClasses, assocs, sigs, laws) =>
-          List(WeededAst.Declaration.Class(doc, ann, mods, ident, tparam, superClasses, assocs.flatten, sigs.flatten, laws.flatten, loc))
+      mapN(annVal, modsVal, superTraitsVal, assocsVal, sigsVal, lawsVal) {
+        case (ann, mods, superTraits, assocs, sigs, laws) =>
+          List(WeededAst.Declaration.Class(doc, ann, mods, ident, tparam, superTraits, assocs.flatten, sigs.flatten, laws.flatten, loc))
       }
   }
 
@@ -438,8 +438,8 @@ object Weeder {
     * Performs weeding on the given enum derivations `derives0`.
     */
   private def visitDerivations(derives0: ParsedAst.Derivations): WeededAst.Derivations = derives0 match {
-    case ParsedAst.Derivations(sp1, classes, sp2) =>
-      WeededAst.Derivations(classes.toList, mkSL(sp1, sp2))
+    case ParsedAst.Derivations(sp1, traits, sp2) =>
+      WeededAst.Derivations(traits.toList, mkSL(sp1, sp2))
   }
 
   /**
@@ -488,7 +488,7 @@ object Weeder {
   /**
     * Performs weeding on the given associated type signature `d0`.
     */
-  private def visitAssocTypeSig(d0: ParsedAst.Declaration.AssocTypeSig, clazzTparam: WeededAst.TypeParam): Validation[List[WeededAst.Declaration.AssocTypeSig], WeederError] = d0 match {
+  private def visitAssocTypeSig(d0: ParsedAst.Declaration.AssocTypeSig, trtTparam: WeededAst.TypeParam): Validation[List[WeededAst.Declaration.AssocTypeSig], WeederError] = d0 match {
     case ParsedAst.Declaration.AssocTypeSig(doc0, mod0, sp1, ident, tparams0, kind0, tpe0, sp2) =>
 
       val doc = visitDoc(doc0)
@@ -504,8 +504,8 @@ object Weeder {
       flatMapN(modVal, tparamsVal, tpeVal) {
         case (mod, tparams, tpe) =>
           val tparamVal = tparams match {
-            // Case 1: Elided. Use the class tparam.
-            case WeededAst.TypeParams.Elided => Validation.success(clazzTparam)
+            // Case 1: Elided. Use the trait tparam.
+            case WeededAst.TypeParams.Elided => Validation.success(trtTparam)
 
             // Case 2: Singleton parameter.
             case WeededAst.TypeParams.Kinded(hd :: Nil) => Validation.success(hd)
@@ -1291,11 +1291,11 @@ object Weeder {
         case (e, t, f) => WeededAst.Expr.Ascribe(e, t, f, mkSL(leftMostSourcePosition(exp), sp2))
       }
 
-    case ParsedAst.Expression.InstanceOf(exp, className, sp2) =>
+    case ParsedAst.Expression.InstanceOf(exp, traitName, sp2) =>
       val sp1 = leftMostSourcePosition(exp)
       val loc = mkSL(sp1, sp2)
       mapN(visitExp(exp)) {
-        case e => WeededAst.Expr.InstanceOf(e, className.toString, loc)
+        case e => WeededAst.Expr.InstanceOf(e, traitName.toString, loc)
       }
 
     case ParsedAst.Expression.CheckedTypeCast(sp1, exp, sp2) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -29,10 +29,10 @@ object CodeHinter {
     * Returns a collection of code quality hints for the given AST `root`.
     */
   def run(root: TypedAst.Root, sources: Set[String])(implicit flix: Flix, index: Index): List[CodeHint] = {
-    val classHints = root.classes.values.flatMap(visitClass(_)(root, index)).toList
+    val traitHints = root.classes.values.flatMap(visitTrait(_)(root, index)).toList
     val defsHints = root.defs.values.flatMap(visitDef(_)(root, flix)).toList
     val enumsHints = root.enums.values.flatMap(visitEnum(_)(root, index)).toList
-    (classHints ++ defsHints ++ enumsHints).filter(include(_, sources))
+    (traitHints ++ defsHints ++ enumsHints).filter(include(_, sources))
   }
 
   /**
@@ -56,13 +56,13 @@ object CodeHinter {
   }
 
   /**
-    * Computes code quality hints for the given class `typeclass`.
+    * Computes code quality hints for the given trait `trt`.
     */
-  private def visitClass(typeclass: TypedAst.Class)(implicit root: Root, index: Index): List[CodeHint] = {
-    val uses = index.usesOf(typeclass.sym)
-    val isDeprecated = typeclass.ann.isDeprecated
+  private def visitTrait(trt: TypedAst.Class)(implicit root: Root, index: Index): List[CodeHint] = {
+    val uses = index.usesOf(trt.sym)
+    val isDeprecated = trt.ann.isDeprecated
     val deprecated = if (isDeprecated) uses.map(CodeHint.Deprecated) else Nil
-    val isExperimental = typeclass.ann.isExperimental
+    val isExperimental = trt.ann.isExperimental
     val experimental = if (isExperimental) uses.map(CodeHint.Experimental) else Nil
     (deprecated ++ experimental).toList
   }


### PR DESCRIPTION
This PR renames class to trait within Desugar and other modules in `phase` (these modules used "class" enough to have `visitClass` functions). 

Some constructor and field names continue to use "class" at the moment as they are types defined outside these modules. Sometimes the used class in regard to Java classes which have been left unchanged.