### PR TITLE
chore: rename class to trait in Deriver and rename PredefinedClasses (issue #6591)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -19,7 +19,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.BoundBy
 import ca.uwaterloo.flix.language.ast.{Ast, Kind, KindedAst, Name, Scheme, SemanticOp, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.errors.DerivationError
-import ca.uwaterloo.flix.language.phase.util.PredefinedClasses
+import ca.uwaterloo.flix.language.phase.util.PredefinedTraits
 import ca.uwaterloo.flix.util.Validation.mapN
 import ca.uwaterloo.flix.util.{ParOps, Validation}
 
@@ -51,13 +51,13 @@ object Deriver {
   private def getDerivedInstances(enum0: KindedAst.Enum, root: KindedAst.Root)(implicit flix: Flix): Validation[List[KindedAst.Instance], DerivationError] = enum0 match {
     case KindedAst.Enum(_, _, _, enumSym, _, derives, cases, _, _) =>
       // lazy so that in we don't try a lookup if there are no derivations (important for Nix Lib)
-      lazy val eqSym = PredefinedClasses.lookupClassSym("Eq", root)
-      lazy val orderSym = PredefinedClasses.lookupClassSym("Order", root)
-      lazy val toStringSym = PredefinedClasses.lookupClassSym("ToString", root)
-      lazy val hashSym = PredefinedClasses.lookupClassSym("Hash", root)
-      lazy val sendableSym = PredefinedClasses.lookupClassSym("Sendable", root)
+      lazy val eqSym = PredefinedTraits.lookupTraitSym("Eq", root)
+      lazy val orderSym = PredefinedTraits.lookupTraitSym("Order", root)
+      lazy val toStringSym = PredefinedTraits.lookupTraitSym("ToString", root)
+      lazy val hashSym = PredefinedTraits.lookupTraitSym("Hash", root)
+      lazy val sendableSym = PredefinedTraits.lookupTraitSym("Sendable", root)
       val instanceVals = Validation.traverse(derives.classes) {
-        case Ast.Derivation(classSym, loc) if cases.isEmpty => Validation.toSoftFailure(None, DerivationError.IllegalDerivationForEmptyEnum(enumSym, classSym, loc))
+        case Ast.Derivation(traitSym, loc) if cases.isEmpty => Validation.toSoftFailure(None, DerivationError.IllegalDerivationForEmptyEnum(enumSym, traitSym, loc))
         case Ast.Derivation(sym, loc) if sym == eqSym => mapN(mkEqInstance(enum0, loc, root))(Some(_))
         case Ast.Derivation(sym, loc) if sym == orderSym => mapN(mkOrderInstance(enum0, loc, root))(Some(_))
         case Ast.Derivation(sym, loc) if sym == toStringSym => mapN(mkToStringInstance(enum0, loc, root))(Some(_))
@@ -94,7 +94,7 @@ object Deriver {
     */
   private def mkEqInstance(enum0: KindedAst.Enum, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): Validation[KindedAst.Instance, DerivationError] = enum0 match {
     case KindedAst.Enum(_, _, _, _, tparams, _, _, tpe, _) =>
-      val eqClassSym = PredefinedClasses.lookupClassSym("Eq", root)
+      val eqTraitSym = PredefinedTraits.lookupTraitSym("Eq", root)
       val eqDefSym = Symbol.mkDefnSym("Eq.eq", Some(flix.genSym.freshId()))
 
       val param1 = Symbol.freshVarSym("x", BoundBy.FormalParam, loc)
@@ -104,13 +104,13 @@ object Deriver {
 
       val defn = KindedAst.Def(eqDefSym, spec, exp)
 
-      val tconstrs = getTypeConstraintsForTypeParams(tparams, eqClassSym, loc)
+      val tconstrs = getTypeConstraintsForTypeParams(tparams, eqTraitSym, loc)
 
       Validation.success(KindedAst.Instance(
         doc = Ast.Doc(Nil, loc),
         ann = Ast.Annotations.Empty,
         mod = Ast.Modifiers.Empty,
-        clazz = Ast.TraitSymUse(eqClassSym, loc),
+        clazz = Ast.TraitSymUse(eqTraitSym, loc),
         tpe = tpe,
         tconstrs = tconstrs,
         assocs = Nil,
@@ -145,7 +145,7 @@ object Deriver {
     */
   private def mkEqSpec(enum0: KindedAst.Enum, param1: Symbol.VarSym, param2: Symbol.VarSym, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): KindedAst.Spec = enum0 match {
     case KindedAst.Enum(_, _, _, _, tparams, _, _, tpe, _) =>
-      val eqClassSym = PredefinedClasses.lookupClassSym("Eq", root)
+      val eqTraitSym = PredefinedTraits.lookupTraitSym("Eq", root)
       KindedAst.Spec(
         doc = Ast.Doc(Nil, loc),
         ann = Ast.Annotations.Empty,
@@ -157,13 +157,13 @@ object Deriver {
         ),
         sc = Scheme(
           tparams.map(_.sym),
-          List(Ast.TypeConstraint(Ast.TypeConstraint.Head(eqClassSym, loc), tpe, loc)),
+          List(Ast.TypeConstraint(Ast.TypeConstraint.Head(eqTraitSym, loc), tpe, loc)),
           Nil,
           Type.mkPureUncurriedArrow(List(tpe, tpe), Type.mkBool(loc), loc)
         ),
         tpe = Type.mkBool(loc),
         eff = Type.Cst(TypeConstructor.Pure, loc),
-        tconstrs = List(Ast.TypeConstraint(Ast.TypeConstraint.Head(eqClassSym, loc), tpe, loc)),
+        tconstrs = List(Ast.TypeConstraint(Ast.TypeConstraint.Head(eqTraitSym, loc), tpe, loc)),
         econstrs = Nil,
         loc = loc
       )
@@ -174,7 +174,7 @@ object Deriver {
     */
   private def mkEqMatchRule(caze: KindedAst.Case, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): KindedAst.MatchRule = caze match {
     case KindedAst.Case(sym, tpe, _, _) =>
-      val eqSym = PredefinedClasses.lookupSigSym("Eq", "eq", root)
+      val eqSym = PredefinedTraits.lookupSigSym("Eq", "eq", root)
 
       // get a pattern corresponding to this case, e.g.
       // `case C2(x0, x1)`
@@ -245,7 +245,7 @@ object Deriver {
     */
   private def mkOrderInstance(enum0: KindedAst.Enum, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): Validation[KindedAst.Instance, DerivationError] = enum0 match {
     case KindedAst.Enum(_, _, _, _, tparams, _, _, tpe, _) =>
-      val orderClassSym = PredefinedClasses.lookupClassSym("Order", root)
+      val orderTraitSym = PredefinedTraits.lookupTraitSym("Order", root)
       val compareDefSym = Symbol.mkDefnSym("Order.compare", Some(flix.genSym.freshId()))
 
       val param1 = Symbol.freshVarSym("x", BoundBy.FormalParam, loc)
@@ -255,12 +255,12 @@ object Deriver {
 
       val defn = KindedAst.Def(compareDefSym, spec, exp)
 
-      val tconstrs = getTypeConstraintsForTypeParams(tparams, orderClassSym, loc)
+      val tconstrs = getTypeConstraintsForTypeParams(tparams, orderTraitSym, loc)
       Validation.success(KindedAst.Instance(
         doc = Ast.Doc(Nil, loc),
         ann = Ast.Annotations.Empty,
         mod = Ast.Modifiers.Empty,
-        clazz = Ast.TraitSymUse(orderClassSym, loc),
+        clazz = Ast.TraitSymUse(orderTraitSym, loc),
         tpe = tpe,
         tconstrs = tconstrs,
         assocs = Nil,
@@ -275,7 +275,7 @@ object Deriver {
     */
   private def mkCompareImpl(enum0: KindedAst.Enum, param1: Symbol.VarSym, param2: Symbol.VarSym, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): KindedAst.Expr = enum0 match {
     case KindedAst.Enum(_, _, _, _, _, _, cases, _, _) =>
-      val compareSigSym = PredefinedClasses.lookupSigSym("Order", "compare", root)
+      val compareSigSym = PredefinedTraits.lookupSigSym("Order", "compare", root)
 
       val lambdaVarSym = Symbol.freshVarSym("indexOf", BoundBy.Let, loc)
 
@@ -336,8 +336,8 @@ object Deriver {
     */
   private def mkCompareSpec(enum0: KindedAst.Enum, param1: Symbol.VarSym, param2: Symbol.VarSym, loc: SourceLocation, root: KindedAst.Root): KindedAst.Spec = enum0 match {
     case KindedAst.Enum(_, _, _, _, tparams, _, _, tpe, _) =>
-      val orderClassSym = PredefinedClasses.lookupClassSym("Order", root)
-      val comparisonEnumSym = PredefinedClasses.lookupEnumSym("Comparison", root)
+      val orderTraitSym = PredefinedTraits.lookupTraitSym("Order", root)
+      val comparisonEnumSym = PredefinedTraits.lookupEnumSym("Comparison", root)
 
       KindedAst.Spec(
         doc = Ast.Doc(Nil, loc),
@@ -350,13 +350,13 @@ object Deriver {
         ),
         sc = Scheme(
           tparams.map(_.sym),
-          List(Ast.TypeConstraint(Ast.TypeConstraint.Head(orderClassSym, loc), tpe, loc)),
+          List(Ast.TypeConstraint(Ast.TypeConstraint.Head(orderTraitSym, loc), tpe, loc)),
           Nil,
           Type.mkPureUncurriedArrow(List(tpe, tpe), Type.mkEnum(comparisonEnumSym, Kind.Star, loc), loc)
         ),
         tpe = Type.mkEnum(comparisonEnumSym, Kind.Star, loc),
         eff = Type.Cst(TypeConstructor.Pure, loc),
-        tconstrs = List(Ast.TypeConstraint(Ast.TypeConstraint.Head(orderClassSym, loc), tpe, loc)),
+        tconstrs = List(Ast.TypeConstraint(Ast.TypeConstraint.Head(orderTraitSym, loc), tpe, loc)),
         econstrs = Nil,
         loc = loc
       )
@@ -379,9 +379,9 @@ object Deriver {
     */
   private def mkComparePairMatchRule(caze: KindedAst.Case, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): KindedAst.MatchRule = caze match {
     case KindedAst.Case(sym, tpe, _, _) =>
-      val equalToSym = PredefinedClasses.lookupCaseSym("Comparison", "EqualTo", root)
-      val compareSigSym = PredefinedClasses.lookupSigSym("Order", "compare", root)
-      val thenCompareDefSym = PredefinedClasses.lookupDefSym(List("Order"), "thenCompare", root)
+      val equalToSym = PredefinedTraits.lookupCaseSym("Comparison", "EqualTo", root)
+      val compareSigSym = PredefinedTraits.lookupSigSym("Order", "compare", root)
+      val thenCompareDefSym = PredefinedTraits.lookupDefSym(List("Order"), "thenCompare", root)
 
       // Match on the tuple
       // `case (C2(x0, x1), C2(y0, y1))
@@ -459,7 +459,7 @@ object Deriver {
     */
   private def mkToStringInstance(enum0: KindedAst.Enum, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): Validation[KindedAst.Instance, DerivationError] = enum0 match {
     case KindedAst.Enum(_, _, _, _, tparams, _, _, tpe, _) =>
-      val toStringClassSym = PredefinedClasses.lookupClassSym("ToString", root)
+      val toStringTraitSym = PredefinedTraits.lookupTraitSym("ToString", root)
       val toStringDefSym = Symbol.mkDefnSym("ToString.toString", Some(flix.genSym.freshId()))
 
       val param = Symbol.freshVarSym("x", BoundBy.FormalParam, loc)
@@ -468,13 +468,13 @@ object Deriver {
 
       val defn = KindedAst.Def(toStringDefSym, spec, exp)
 
-      val tconstrs = getTypeConstraintsForTypeParams(tparams, toStringClassSym, loc)
+      val tconstrs = getTypeConstraintsForTypeParams(tparams, toStringTraitSym, loc)
 
       Validation.success(KindedAst.Instance(
         doc = Ast.Doc(Nil, loc),
         ann = Ast.Annotations.Empty,
         mod = Ast.Modifiers.Empty,
-        clazz = Ast.TraitSymUse(toStringClassSym, loc),
+        clazz = Ast.TraitSymUse(toStringTraitSym, loc),
         tpe = tpe,
         tconstrs = tconstrs,
         assocs = Nil,
@@ -505,7 +505,7 @@ object Deriver {
     */
   private def mkToStringSpec(enum0: KindedAst.Enum, param: Symbol.VarSym, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): KindedAst.Spec = enum0 match {
     case KindedAst.Enum(_, _, _, _, tparams, _, _, tpe, _) =>
-      val toStringClassSym = PredefinedClasses.lookupClassSym("ToString", root)
+      val toStringTraitSym = PredefinedTraits.lookupTraitSym("ToString", root)
       KindedAst.Spec(
         doc = Ast.Doc(Nil, loc),
         ann = Ast.Annotations.Empty,
@@ -514,13 +514,13 @@ object Deriver {
         fparams = List(KindedAst.FormalParam(param, Ast.Modifiers.Empty, tpe, Ast.TypeSource.Ascribed, loc)),
         sc = Scheme(
           tparams.map(_.sym),
-          List(Ast.TypeConstraint(Ast.TypeConstraint.Head(toStringClassSym, loc), tpe, loc)),
+          List(Ast.TypeConstraint(Ast.TypeConstraint.Head(toStringTraitSym, loc), tpe, loc)),
           Nil,
           Type.mkPureArrow(tpe, Type.mkString(loc), loc)
         ),
         tpe = Type.mkString(loc),
         eff = Type.Cst(TypeConstructor.Pure, loc),
-        tconstrs = List(Ast.TypeConstraint(Ast.TypeConstraint.Head(toStringClassSym, loc), tpe, loc)),
+        tconstrs = List(Ast.TypeConstraint(Ast.TypeConstraint.Head(toStringTraitSym, loc), tpe, loc)),
         econstrs = Nil,
         loc = loc
       )
@@ -531,7 +531,7 @@ object Deriver {
     */
   private def mkToStringMatchRule(caze: KindedAst.Case, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): KindedAst.MatchRule = caze match {
     case KindedAst.Case(sym, tpe, _, _) =>
-      val toStringSym = PredefinedClasses.lookupSigSym("ToString", "toString", root)
+      val toStringSym = PredefinedTraits.lookupSigSym("ToString", "toString", root)
 
       // get a pattern corresponding to this case, e.g.
       // `case C2(x0, x1)`
@@ -595,7 +595,7 @@ object Deriver {
     */
   private def mkHashInstance(enum0: KindedAst.Enum, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): Validation[KindedAst.Instance, DerivationError] = enum0 match {
     case KindedAst.Enum(_, _, _, _, tparams, _, _, tpe, _) =>
-      val hashClassSym = PredefinedClasses.lookupClassSym("Hash", root)
+      val hashTraitSym = PredefinedTraits.lookupTraitSym("Hash", root)
       val hashDefSym = Symbol.mkDefnSym("Hash.hash", Some(flix.genSym.freshId()))
 
       val param = Symbol.freshVarSym("x", BoundBy.FormalParam, loc)
@@ -604,12 +604,12 @@ object Deriver {
 
       val defn = KindedAst.Def(hashDefSym, spec, exp)
 
-      val tconstrs = getTypeConstraintsForTypeParams(tparams, hashClassSym, loc)
+      val tconstrs = getTypeConstraintsForTypeParams(tparams, hashTraitSym, loc)
       Validation.success(KindedAst.Instance(
         doc = Ast.Doc(Nil, loc),
         ann = Ast.Annotations.Empty,
         mod = Ast.Modifiers.Empty,
-        clazz = Ast.TraitSymUse(hashClassSym, loc),
+        clazz = Ast.TraitSymUse(hashTraitSym, loc),
         tpe = tpe,
         tconstrs = tconstrs,
         defs = List(defn),
@@ -642,7 +642,7 @@ object Deriver {
     */
   private def mkHashSpec(enum0: KindedAst.Enum, param: Symbol.VarSym, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): KindedAst.Spec = enum0 match {
     case KindedAst.Enum(_, _, _, _, tparams, _, _, tpe, _) =>
-      val hashClassSym = PredefinedClasses.lookupClassSym("Hash", root)
+      val hashTraitSym = PredefinedTraits.lookupTraitSym("Hash", root)
       KindedAst.Spec(
         doc = Ast.Doc(Nil, loc),
         ann = Ast.Annotations.Empty,
@@ -651,13 +651,13 @@ object Deriver {
         fparams = List(KindedAst.FormalParam(param, Ast.Modifiers.Empty, tpe, Ast.TypeSource.Ascribed, loc)),
         sc = Scheme(
           tparams.map(_.sym),
-          List(Ast.TypeConstraint(Ast.TypeConstraint.Head(hashClassSym, loc), tpe, loc)),
+          List(Ast.TypeConstraint(Ast.TypeConstraint.Head(hashTraitSym, loc), tpe, loc)),
           Nil,
           Type.mkPureArrow(tpe, Type.mkInt32(loc), loc)
         ),
         tpe = Type.mkInt32(loc),
         eff = Type.Cst(TypeConstructor.Pure, loc),
-        tconstrs = List(Ast.TypeConstraint(Ast.TypeConstraint.Head(hashClassSym, loc), tpe, loc)),
+        tconstrs = List(Ast.TypeConstraint(Ast.TypeConstraint.Head(hashTraitSym, loc), tpe, loc)),
         econstrs = Nil,
         loc = loc
       )
@@ -668,8 +668,8 @@ object Deriver {
     */
   private def mkHashMatchRule(caze: KindedAst.Case, index: Int, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): KindedAst.MatchRule = caze match {
     case KindedAst.Case(sym, tpe, _, _) =>
-      val hashSigSym = PredefinedClasses.lookupSigSym("Hash", "hash", root)
-      val combineDefSym = PredefinedClasses.lookupDefSym(List("Hash"), "combine", root)
+      val hashSigSym = PredefinedTraits.lookupSigSym("Hash", "hash", root)
+      val combineDefSym = PredefinedTraits.lookupDefSym(List("Hash"), "combine", root)
 
       // get a pattern corresponding to this case, e.g.
       // `case C2(x0, x1)`
@@ -723,15 +723,15 @@ object Deriver {
     */
   private def mkSendableInstance(enum0: KindedAst.Enum, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): Validation[KindedAst.Instance, DerivationError] = enum0 match {
     case KindedAst.Enum(_, _, _, _, tparams, _, _, tpe, _) =>
-      val sendableClassSym = PredefinedClasses.lookupClassSym("Sendable", root)
+      val sendableTraitSym = PredefinedTraits.lookupTraitSym("Sendable", root)
 
-      val tconstrs = getTypeConstraintsForTypeParams(tparams, sendableClassSym, loc)
+      val tconstrs = getTypeConstraintsForTypeParams(tparams, sendableTraitSym, loc)
 
       Validation.success(KindedAst.Instance(
         doc = Ast.Doc(Nil, loc),
         ann = Ast.Annotations.Empty,
         mod = Ast.Modifiers.Empty,
-        clazz = Ast.TraitSymUse(sendableClassSym, loc),
+        clazz = Ast.TraitSymUse(sendableTraitSym, loc),
         tpe = tpe,
         tconstrs = tconstrs,
         defs = Nil,
@@ -752,9 +752,9 @@ object Deriver {
     * Creates type constraints for the given type parameters.
     * Filters out non-star type parameters and wild type parameters.
     */
-  private def getTypeConstraintsForTypeParams(tparams: List[KindedAst.TypeParam], clazz: Symbol.TraitSym, loc: SourceLocation): List[Ast.TypeConstraint] = tparams.collect {
+  private def getTypeConstraintsForTypeParams(tparams: List[KindedAst.TypeParam], trt: Symbol.TraitSym, loc: SourceLocation): List[Ast.TypeConstraint] = tparams.collect {
     case tparam if tparam.sym.kind == Kind.Star && !tparam.name.isWild =>
-      Ast.TypeConstraint(Ast.TypeConstraint.Head(clazz, loc), Type.Var(tparam.sym, loc), loc)
+      Ast.TypeConstraint(Ast.TypeConstraint.Head(trt, loc), Type.Var(tparam.sym, loc), loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintGen.scala
@@ -19,7 +19,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.Denotation
 import ca.uwaterloo.flix.language.ast._
 import ConstraintGen.{visitExp, visitPattern}
-import ca.uwaterloo.flix.language.phase.util.PredefinedClasses
+import ca.uwaterloo.flix.language.phase.util.PredefinedTraits
 
 object SchemaConstraintGen {
 
@@ -126,8 +126,8 @@ object SchemaConstraintGen {
         val freshRestSchemaTypeVar = Type.freshVar(Kind.SchemaRow, loc)
 
         // Require Order and Foldable instances.
-        val orderSym = PredefinedClasses.lookupClassSym("Order", root)
-        val foldableSym = PredefinedClasses.lookupClassSym("Foldable", root)
+        val orderSym = PredefinedTraits.lookupTraitSym("Order", root)
+        val foldableSym = PredefinedTraits.lookupTraitSym("Foldable", root)
         val order = Ast.TypeConstraint(Ast.TypeConstraint.Head(orderSym, loc), freshElmTypeVar, loc)
         val foldable = Ast.TypeConstraint(Ast.TypeConstraint.Head(foldableSym, loc), freshTypeConstructorVar, loc)
 
@@ -194,7 +194,7 @@ object SchemaConstraintGen {
         val (termTypes, termEffs) = terms.map(visitExp(_)).unzip
         c.unifyType(Type.Pure, Type.mkUnion(termEffs, loc), loc)
         c.unifyType(tvar, mkRelationOrLatticeType(pred.name, den, termTypes, root, loc), loc)
-        val tconstrs = getTermTypeClassConstraints(den, termTypes, root, loc)
+        val tconstrs = getTermTraitConstraints(den, termTypes, root, loc)
         c.addClassConstraints(tconstrs, loc)
         val resTpe = Type.mkSchemaRowExtend(pred, tvar, restRow, loc)
         resTpe
@@ -210,7 +210,7 @@ object SchemaConstraintGen {
         val restRow = Type.freshVar(Kind.SchemaRow, loc)
         val termTypes = terms.map(visitPattern)
         c.unifyType(tvar, mkRelationOrLatticeType(pred.name, den, termTypes, root, loc), loc)
-        val tconstrs = getTermTypeClassConstraints(den, termTypes, root, loc)
+        val tconstrs = getTermTraitConstraints(den, termTypes, root, loc)
         c.addClassConstraints(tconstrs, loc)
         val resTpe = Type.mkSchemaRowExtend(pred, tvar, restRow, loc)
         resTpe
@@ -242,39 +242,39 @@ object SchemaConstraintGen {
   }
 
   /**
-    * Returns the type class constraints for the given term types `ts` with the given denotation `den`.
+    * Returns the trait constraints for the given term types `ts` with the given denotation `den`.
     */
-  private def getTermTypeClassConstraints(den: Ast.Denotation, ts: List[Type], root: KindedAst.Root, loc: SourceLocation): List[Ast.TypeConstraint] = den match {
+  private def getTermTraitConstraints(den: Ast.Denotation, ts: List[Type], root: KindedAst.Root, loc: SourceLocation): List[Ast.TypeConstraint] = den match {
     case Denotation.Relational =>
-      ts.flatMap(mkTypeClassConstraintsForRelationalTerm(_, root, loc))
+      ts.flatMap(mkTraitConstraintsForRelationalTerm(_, root, loc))
     case Denotation.Latticenal =>
-      ts.init.flatMap(mkTypeClassConstraintsForRelationalTerm(_, root, loc)) ::: mkTypeClassConstraintsForLatticeTerm(ts.last, root, loc)
+      ts.init.flatMap(mkTraitConstraintsForRelationalTerm(_, root, loc)) ::: mkTraitConstraintsForLatticeTerm(ts.last, root, loc)
   }
 
   /**
-    * Constructs the type class constraints for the given relational term type `tpe`.
+    * Constructs the trait constraints for the given relational term type `tpe`.
     */
-  private def mkTypeClassConstraintsForRelationalTerm(tpe: Type, root: KindedAst.Root, loc: SourceLocation): List[Ast.TypeConstraint] = {
-    val classes = List(
-      PredefinedClasses.lookupClassSym("Eq", root),
-      PredefinedClasses.lookupClassSym("Order", root),
+  private def mkTraitConstraintsForRelationalTerm(tpe: Type, root: KindedAst.Root, loc: SourceLocation): List[Ast.TypeConstraint] = {
+    val traits = List(
+      PredefinedTraits.lookupTraitSym("Eq", root),
+      PredefinedTraits.lookupTraitSym("Order", root),
     )
-    classes.map(clazz => Ast.TypeConstraint(Ast.TypeConstraint.Head(clazz, loc), tpe, loc))
+    traits.map(trt => Ast.TypeConstraint(Ast.TypeConstraint.Head(trt, loc), tpe, loc))
   }
 
   /**
-    * Constructs the type class constraints for the given lattice term type `tpe`.
+    * Constructs the trait constraints for the given lattice term type `tpe`.
     */
-  private def mkTypeClassConstraintsForLatticeTerm(tpe: Type, root: KindedAst.Root, loc: SourceLocation): List[Ast.TypeConstraint] = {
-    val classes = List(
-      PredefinedClasses.lookupClassSym("Eq", root),
-      PredefinedClasses.lookupClassSym("Order", root),
-      PredefinedClasses.lookupClassSym("PartialOrder", root),
-      PredefinedClasses.lookupClassSym("LowerBound", root),
-      PredefinedClasses.lookupClassSym("JoinLattice", root),
-      PredefinedClasses.lookupClassSym("MeetLattice", root),
+  private def mkTraitConstraintsForLatticeTerm(tpe: Type, root: KindedAst.Root, loc: SourceLocation): List[Ast.TypeConstraint] = {
+    val traits = List(
+      PredefinedTraits.lookupTraitSym("Eq", root),
+      PredefinedTraits.lookupTraitSym("Order", root),
+      PredefinedTraits.lookupTraitSym("PartialOrder", root),
+      PredefinedTraits.lookupTraitSym("LowerBound", root),
+      PredefinedTraits.lookupTraitSym("JoinLattice", root),
+      PredefinedTraits.lookupTraitSym("MeetLattice", root),
     )
-    classes.map(clazz => Ast.TypeConstraint(Ast.TypeConstraint.Head(clazz, loc), tpe, loc))
+    traits.map(trt => Ast.TypeConstraint(Ast.TypeConstraint.Head(trt, loc), tpe, loc))
   }
 
 

--- a/main/src/ca/uwaterloo/flix/language/phase/util/PredefinedTraits.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/util/PredefinedTraits.scala
@@ -20,27 +20,27 @@ import ca.uwaterloo.flix.util.InternalCompilerException
 
 
 /**
-  * The following classes are assumed to always exist.
+  * The following traits are assumed to always exist.
   *
   * Anything added here must be mentioned in `CoreLibrary` in the Flix class.
   */
-object PredefinedClasses {
+object PredefinedTraits {
 
   /**
-    * Returns the class symbol with the given `name`.
+    * Returns the trait symbol with the given `name`.
     */
-  def lookupClassSym(name: String, root: KindedAst.Root): Symbol.TraitSym = {
+  def lookupTraitSym(name: String, root: KindedAst.Root): Symbol.TraitSym = {
     val key = new Symbol.TraitSym(Nil, name, SourceLocation.Unknown)
-    root.classes.getOrElse(key, throw InternalCompilerException(s"The type class: '$key' is not defined.", SourceLocation.Unknown)).sym
+    root.classes.getOrElse(key, throw InternalCompilerException(s"The trait: '$key' is not defined.", SourceLocation.Unknown)).sym
   }
 
   /**
     * Returns the sig symbol with the given `clazz` and name `sig`.
     */
   def lookupSigSym(clazz: String, sig: String, root: KindedAst.Root): Symbol.SigSym = {
-    val clazzKey = new Symbol.TraitSym(Nil, clazz, SourceLocation.Unknown)
-    val sigKey = new Symbol.SigSym(clazzKey, sig, SourceLocation.Unknown)
-    root.classes.getOrElse(clazzKey, throw InternalCompilerException(s"The type class: '$clazzKey' is not defined.", SourceLocation.Unknown))
+    val trtKey = new Symbol.TraitSym(Nil, clazz, SourceLocation.Unknown)
+    val sigKey = new Symbol.SigSym(trtKey, sig, SourceLocation.Unknown)
+    root.classes.getOrElse(trtKey, throw InternalCompilerException(s"The trait: '$trtKey' is not defined.", SourceLocation.Unknown))
       .sigs.getOrElse(sigKey, throw InternalCompilerException(s"The signature '$sigKey' is not defined.", SourceLocation.Unknown))
       .sym
   }


### PR DESCRIPTION
This PR renames class to trait within `Deriver` and renames the module / object `PredefinedClasses` to `PredefinedTraits`.

`SchemaConstraintGen` is also updated.