### PR TITLE
chore: rename class to trait in various LSP modules (issue #6591)

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -29,7 +29,7 @@ object Indexer {
     Index.all(
       traverse(root.defs.values)(visitDef),
       traverse(root.enums.values)(visitEnum),
-      traverse(root.classes.values)(visitClass),
+      traverse(root.classes.values)(visitTrait),
       traverse(root.instances.values) {
         instances => traverse(instances)(visitInstance)
       },
@@ -101,14 +101,14 @@ object Indexer {
   }
 
   /**
-    * Returns a reverse index for the given class `class0`.
+    * Returns a reverse index for the given trait `trait0`.
     */
-  private def visitClass(class0: TypedAst.Class): Index = class0 match {
-    case Class(doc, ann, mod, sym, tparam, superClasses, assocs, signatures, laws, loc) =>
+  private def visitTrait(trait0: TypedAst.Class): Index = trait0 match {
+    case Class(doc, ann, mod, sym, tparam, superTraits, assocs, signatures, laws, loc) =>
       Index.all(
-        Index.occurrenceOf(class0),
+        Index.occurrenceOf(trait0),
         visitTypeParam(tparam),
-        traverse(superClasses)(visitTypeConstraint),
+        traverse(superTraits)(visitTypeConstraint),
         traverse(assocs)(visitAssocTypeSig),
         traverse(signatures)(visitSig),
         //        laws.map(visitDef) // TODO visit laws?

--- a/main/src/ca/uwaterloo/flix/api/lsp/LocationLink.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LocationLink.scala
@@ -99,7 +99,7 @@ object LocationLink {
   /**
     * Returns a reference to the instance node `instance`.
     */
-  def fromInstanceClassSymUse(clazz: Ast.TraitSymUse, originLoc: SourceLocation): LocationLink = {
+  def fromInstanceTraitSymUse(clazz: Ast.TraitSymUse, originLoc: SourceLocation): LocationLink = {
     val originSelectionRange = Range.from(originLoc)
     val targetUri = clazz.loc.source.name
     val targetRange = Range.from(clazz.loc)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -41,7 +41,7 @@ object CodeActionProvider {
         Nil
     case ResolutionError.UndefinedTrait(qn, _, loc) if onSameLine(range, loc) =>
       if (qn.namespace.isRoot)
-        mkUseClass(qn.ident, uri)
+        mkUseTrait(qn.ident, uri)
       else
         Nil
     case ResolutionError.UndefinedEffect(qn, _, loc) if onSameLine(range, loc) =>
@@ -79,7 +79,7 @@ object CodeActionProvider {
     case TypeError.MissingInstanceToString(tpe, _, loc) if onSameLine(range, loc) =>
       mkDeriveMissingToString(tpe, uri)
     case InstanceError.MissingSuperTraitInstance(tpe, sub, sup, loc) if onSameLine(range, loc) =>
-      mkDeriveMissingSuperClass(tpe, sup, uri)
+      mkDeriveMissingSuperTrait(tpe, sup, uri)
     case _ => Nil
   }
 
@@ -121,9 +121,9 @@ object CodeActionProvider {
   }
 
   /**
-    * Returns a code action that proposes to `use` a class.
+    * Returns a code action that proposes to `use` a trait.
     */
-  private def mkUseClass(ident: Name.Ident, uri: String)(implicit root: Root): List[CodeAction] = {
+  private def mkUseTrait(ident: Name.Ident, uri: String)(implicit root: Root): List[CodeAction] = {
     val syms = root.classes.map {
       case (sym, _) => sym
     }
@@ -354,91 +354,91 @@ object CodeActionProvider {
     )
 
   /**
-    * Returns a quickfix code action to derive the `Eq` type class for the given type `tpe` if it is an enum.
+    * Returns a quickfix code action to derive the `Eq` trait for the given type `tpe` if it is an enum.
     */
   private def mkDeriveMissingEq(tpe: Type, uri: String)(implicit root: Root): Option[CodeAction] =
     mkDeriveMissing(tpe, "Eq", uri)
 
   /**
-    * Returns a quickfix code action to derive the `Order` type class for the given type `tpe` if it is an enum.
+    * Returns a quickfix code action to derive the `Order` trait for the given type `tpe` if it is an enum.
     */
   private def mkDeriveMissingOrder(tpe: Type, uri: String)(implicit root: Root): Option[CodeAction] =
     mkDeriveMissing(tpe, "Order", uri)
 
   /**
-    * Returns a quickfix code action to derive the `ToString` type class for the given type `tpe` if it is an enum.
+    * Returns a quickfix code action to derive the `ToString` trait for the given type `tpe` if it is an enum.
     */
   private def mkDeriveMissingToString(tpe: Type, uri: String)(implicit root: Root): Option[CodeAction] =
     mkDeriveMissing(tpe, "ToString", uri)
 
   /**
-   * Returns a quickfix code action to derive the missing superclass for the given subclass.
+   * Returns a quickfix code action to derive the missing supertrait for the given subtrait.
    */
-  private def mkDeriveMissingSuperClass(tpe: Type, superClass: Symbol.TraitSym, uri: String)(implicit root: Root): Option[CodeAction] =
-    mkDeriveMissing(tpe, superClass.name, uri)
+  private def mkDeriveMissingSuperTrait(tpe: Type, superTrait: Symbol.TraitSym, uri: String)(implicit root: Root): Option[CodeAction] =
+    mkDeriveMissing(tpe, superTrait.name, uri)
 
   /**
     * Internal helper function for all `mkDeriveMissingX`.
-    * Returns a quickfix code action to derive the given type class `clazz`
+    * Returns a quickfix code action to derive the given trait `trt`
     * for the given type `tpe` if it is an enum in the root.
     */
-  private def mkDeriveMissing(tpe: Type, clazz: String, uri: String)(implicit root: Root): Option[CodeAction] = tpe.typeConstructor match {
+  private def mkDeriveMissing(tpe: Type, trt: String, uri: String)(implicit root: Root): Option[CodeAction] = tpe.typeConstructor match {
     case Some(TypeConstructor.Enum(sym, _)) =>
       root.enums.get(sym).map { e =>
         CodeAction(
-          title = s"Derive $clazz",
+          title = s"Derive $trt",
           kind = CodeActionKind.QuickFix,
-          edit = Some(addDerivation(e, clazz, uri)),
+          edit = Some(addDerivation(e, trt, uri)),
           command = None
         )
       }
     case _ => None
   }
 
-  // TODO: We should only offer to derive type classes which have not already been derived.
+  // TODO: We should only offer to derive traits which have not already been derived.
 
   /**
-    * Returns a code action to derive the `Eq` type class.
+    * Returns a code action to derive the `Eq` trait.
     */
   private def mkDeriveEq(e: TypedAst.Enum, uri: String): Option[CodeAction] = mkDerive(e, "Eq", uri)
 
   /**
-    * Returns a code action to derive the `Order` type class.
+    * Returns a code action to derive the `Order` trait.
     */
   private def mkDeriveOrder(e: TypedAst.Enum, uri: String): Option[CodeAction] = mkDerive(e, "Order", uri)
 
   /**
-    * Returns a code action to derive the `ToString` type class.
+    * Returns a code action to derive the `ToString` trait.
     */
   private def mkDeriveToString(e: TypedAst.Enum, uri: String): Option[CodeAction] = mkDerive(e, "ToString", uri)
 
-  // TODO: Add derivation for the Hash and Sendable type classes.
+  // TODO: Add derivation for the Hash and Sendable traits.
 
   /**
-    * Returns a code action to derive the given type class `clazz` for the given enum `e` if it isn't already.
+    * Returns a code action to derive the given trait `trt` for the given enum `e` if it isn't already.
     * `None` otherwise.
     */
-  private def mkDerive(e: TypedAst.Enum, clazz: String, uri: String): Option[CodeAction] = {
-    val alreadyDerived = e.derives.classes.exists(d => d.clazz.name == clazz)
+  private def mkDerive(e: TypedAst.Enum, trt: String, uri: String): Option[CodeAction] = {
+    val alreadyDerived = e.derives.classes.exists(d => d.clazz.name == trt)
     if (alreadyDerived) None
     else Some(
       CodeAction(
-        title = s"Derive $clazz",
+        title = s"Derive $trt",
         kind = CodeActionKind.Refactor,
-        edit = Some(addDerivation(e, clazz, uri)),
+        edit = Some(addDerivation(e, trt, uri)),
         command = None
       )
     )
   }
 
   /**
-    * Returns a workspace edit that properly derives the given type class, `clazz`, for the enum, `e`.
+    * Returns a workspace edit that properly derives the given trait, `trt`, for the enum, `e`.
     *
     * For example, if we have:
     * {{{
     *   enum Abc {}
     * }}}
-    * we could derive the type class 'Eq' like so:
+    * we could derive the trait 'Eq' like so:
     * {{{
     *   enum Abc with Eq { }
     * }}}
@@ -452,12 +452,12 @@ object CodeActionProvider {
     *   enum Abc with ToString, Eq { }
     * }}}
     */
-  private def addDerivation(e: TypedAst.Enum, clazz: String, uri: String): WorkspaceEdit = {
+  private def addDerivation(e: TypedAst.Enum, trt: String, uri: String): WorkspaceEdit = {
     val text =
       if (e.derives.classes.isEmpty)
-        s" with $clazz"
+        s" with $trt"
       else
-        s", $clazz"
+        s", $trt"
 
     val end = Position.fromEnd(e.derives.loc)
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
@@ -31,7 +31,7 @@ object FindReferencesProvider {
 
         case Entity.Case(caze) => findCaseReferences(caze.sym)
 
-        case Entity.Class(class0) => findClassReferences(class0.sym)
+        case Entity.Class(trait0) => findTraitReferences(trait0.sym)
 
         case Entity.Def(defn) => findDefReferences(defn.sym)
 
@@ -91,7 +91,7 @@ object FindReferencesProvider {
     }
   }
 
-  private def findClassReferences(sym: Symbol.TraitSym)(implicit index: Index, root: Root): JObject = {
+  private def findTraitReferences(sym: Symbol.TraitSym)(implicit index: Index, root: Root): JObject = {
     val defSite = Location.from(sym.loc)
     val useSites = index.usesOf(sym)
     val locs = defSite :: useSites.toList.map(Location.from)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/ImplementationProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/ImplementationProvider.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.Symbol
 object ImplementationProvider {
 
   /**
-    * Returns implementations LocationLink for a given class.
+    * Returns implementations LocationLink for a given trait.
     */
   def processImplementation(uri: String, position: Position)(implicit root: Root): List[LocationLink] = {
     if (root == null) {
@@ -31,22 +31,22 @@ object ImplementationProvider {
     }
 
     val links = for {
-      classSym <- classAt(uri, position)
-      inst <- root.instances.getOrElse(classSym, Nil)
-    } yield LocationLink.fromInstanceClassSymUse(inst.clazz, classSym.loc)
+      traitSym <- traitAt(uri, position)
+      inst <- root.instances.getOrElse(traitSym, Nil)
+    } yield LocationLink.fromInstanceTraitSymUse(inst.clazz, traitSym.loc)
 
     links.toList
   }
 
   /**
-    * Returns the class symbol located at the given position as a singleton iterable.
-    * Returns an empty iterable if there is no such class symbol.
+    * Returns the trait symbol located at the given position as a singleton iterable.
+    * Returns an empty iterable if there is no such trait symbol.
     */
-  private def classAt(uri: String, p: Position)(implicit root: Root): Iterable[Symbol.TraitSym] = {
-    root.instances.keys.filter(classSym => classSym.loc.source.name == uri
-      && (classSym.loc.beginLine < p.line
-      || (classSym.loc.beginLine == p.line && classSym.loc.beginCol <= p.character))
-      && (classSym.loc.endLine > p.line
-      || (classSym.loc.endLine == p.line && classSym.loc.endCol >= p.character)))
+  private def traitAt(uri: String, p: Position)(implicit root: Root): Iterable[Symbol.TraitSym] = {
+    root.instances.keys.filter(traitSym => traitSym.loc.source.name == uri
+      && (traitSym.loc.beginLine < p.line
+      || (traitSym.loc.beginLine == p.line && traitSym.loc.beginCol <= p.character))
+      && (traitSym.loc.endLine > p.line
+      || (traitSym.loc.endLine == p.line && traitSym.loc.endCol >= p.character)))
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -41,10 +41,10 @@ object SemanticTokensProvider {
     //
 
     //
-    // Construct an iterator of the semantic tokens from classes.
+    // Construct an iterator of the semantic tokens from traits.
     //
-    val classTokens = root.classes.values.flatMap {
-      case decl if include(uri, decl.sym.loc) => visitClass(decl)
+    val traitTokens = root.classes.values.flatMap {
+      case decl if include(uri, decl.sym.loc) => visitTrait(decl)
       case _ => Nil
     }
 
@@ -93,7 +93,7 @@ object SemanticTokensProvider {
     //
     // Collect all tokens into one list.
     //
-    val allTokens = (classTokens ++ instanceTokens ++ defnTokens ++ enumTokens ++ typeAliasTokens ++ effectTokens).toList
+    val allTokens = (traitTokens ++ instanceTokens ++ defnTokens ++ enumTokens ++ typeAliasTokens ++ effectTokens).toList
 
     //
     // We keep all tokens that are: (i) single-line tokens, (ii) have the same source as `uri`, and (iii) come from real source locations.
@@ -122,14 +122,14 @@ object SemanticTokensProvider {
   private def include(uri: String, loc: SourceLocation): Boolean = loc.source.name == uri
 
   /**
-    * Returns all semantic tokens in the given class `classDecl`.
+    * Returns all semantic tokens in the given trait `traitDecl`.
     */
-  private def visitClass(classDecl: TypedAst.Class): Iterator[SemanticToken] = classDecl match {
-    case TypedAst.Class(_, _, _, sym, tparam, superClasses, assocs, signatures, laws, _) =>
+  private def visitTrait(traitDecl: TypedAst.Class): Iterator[SemanticToken] = traitDecl match {
+    case TypedAst.Class(_, _, _, sym, tparam, superTraits, assocs, signatures, laws, _) =>
       val t = SemanticToken(SemanticTokenType.Interface, Nil, sym.loc)
       IteratorOps.all(
         Iterator(t),
-        superClasses.flatMap(visitTypeConstraint),
+        superTraits.flatMap(visitTypeConstraint),
         assocs.flatMap(visitAssocTypeSig),
         visitTypeParam(tparam),
         signatures.flatMap(visitSig),

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
@@ -36,10 +36,10 @@ object SymbolProvider {
 
     val enums = root.enums.values.filter(_.sym.name.startsWith(query)).flatMap(mkEnumSymbolInformation)
     val defs = root.defs.values.collect { case d if d.sym.name.startsWith(query) => mkDefSymbolInformation(d) }
-    val classes = root.classes.values.collect { case c if c.sym.name.startsWith(query) => mkClassSymbolInformation(c) }
+    val traits = root.classes.values.collect { case t if t.sym.name.startsWith(query) => mkTraitSymbolInformation(t) }
     val sigs = root.sigs.values.collect { case sig if sig.sym.name.startsWith(query) => mkSigSymbolInformation(sig) }
     val effs = root.effects.values.filter(_.sym.name.startsWith(query)).flatMap(mkEffectSymbolInformation)
-    (classes ++ defs ++ enums ++ sigs ++ effs).toList
+    (traits ++ defs ++ enums ++ sigs ++ effs).toList
   }
 
   /**
@@ -53,15 +53,15 @@ object SymbolProvider {
 
     val enums = root.enums.values.collect { case enum if enum.loc.source.name == uri => mkEnumDocumentSymbol(enum) }
     val defs = root.defs.values.collect { case d if d.sym.loc.source.name == uri => mkDefDocumentSymbol(d) }
-    val classes = root.classes.values.collect { case c if c.sym.loc.source.name == uri => mkClassDocumentSymbol(c) }
+    val traits = root.classes.values.collect { case t if t.sym.loc.source.name == uri => mkTraitDocumentSymbol(t) }
     val effs = root.effects.values.collect { case e if e.sym.loc.source.name == uri => mkEffectDocumentSymbol(e) }
-    (classes ++ defs ++ enums ++ effs).toList
+    (traits ++ defs ++ enums ++ effs).toList
   }
 
   /**
     * Returns an Interface SymbolInformation from a Class node.
     */
-  private def mkClassSymbolInformation(c: TypedAst.Class) = c match {
+  private def mkTraitSymbolInformation(t: TypedAst.Class) = t match {
     case TypedAst.Class(_, _, _, sym, _, _, _, _, _, _) => SymbolInformation(
       sym.name, SymbolKind.Interface, Nil, deprecated = false, Location(sym.loc.source.name, Range.from(sym.loc)), None,
     )
@@ -69,9 +69,9 @@ object SymbolProvider {
 
   /**
     * Returns an Interface DocumentSymbol from a Class node.
-    * It navigates the AST and adds Sig and TypeParam of c and as children DocumentSymbols.
+    * It navigates the AST and adds Sig and TypeParam of t and as children DocumentSymbols.
     */
-  private def mkClassDocumentSymbol(c: TypedAst.Class): DocumentSymbol = c match {
+  private def mkTraitDocumentSymbol(t: TypedAst.Class): DocumentSymbol = t match {
     case TypedAst.Class(doc, _, _, sym, tparam, _, _, signatures, _, _) => DocumentSymbol( // TODO ASSOC-TYPES visit assocs
       sym.name,
       Some(doc.text),

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -182,13 +182,13 @@ sealed trait Completion {
         documentation = None,
         insertTextFormat = InsertTextFormat.Snippet,
         kind = CompletionItemKind.Snippet)
-    case Completion.InstanceCompletion(clazz, completion) =>
-      val classSym = clazz.sym
-      CompletionItem(label = s"$classSym[...]",
-        sortText = Priority.high(classSym.toString),
+    case Completion.InstanceCompletion(trt, completion) =>
+      val traitSym = trt.sym
+      CompletionItem(label = s"$traitSym[...]",
+        sortText = Priority.high(traitSym.toString),
         textEdit = TextEdit(context.range, completion),
-        detail = Some(InstanceCompleter.fmtClass(clazz)),
-        documentation = Some(clazz.doc.text),
+        detail = Some(InstanceCompleter.fmtTrait(trt)),
+        documentation = Some(trt.doc.text),
         insertTextFormat = InsertTextFormat.Snippet,
         kind = CompletionItemKind.Snippet)
     case Completion.UseCompletion(name, kind) =>
@@ -438,7 +438,7 @@ object Completion {
   case class MatchCompletion(enm: TypedAst.Enum, completion: String) extends Completion
 
   /**
-    * Represents an Instance completion (based on type classes)
+    * Represents an Instance completion (based on traits)
     *
     * @param clazz      the clazz.
     * @param completion the completion string (used as information for TextEdit).

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InstanceCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InstanceCompleter.scala
@@ -23,7 +23,7 @@ import ca.uwaterloo.flix.language.fmt.FormatType
 
 object InstanceCompleter extends Completer {
   /**
-    * Returns a List of Completion based on type classes.
+    * Returns a List of Completion based on traits.
     */
   override def getCompletions(context: CompletionContext)(implicit flix: Flix, index: Index, root: TypedAst.Root, delta: DeltaContext): Iterable[InstanceCompletion] = {
     if (context.previousWord != "instance") {
@@ -57,21 +57,21 @@ object InstanceCompleter extends Completer {
     /**
       * Formats the given type `tpe`.
       */
-    def fmtType(clazz: TypedAst.Class, tpe: Type, hole: String)(implicit flix: Flix): String =
-      FormatType.formatType(replaceText(clazz.tparam.sym, tpe, hole))
+    def fmtType(trt: TypedAst.Class, tpe: Type, hole: String)(implicit flix: Flix): String =
+      FormatType.formatType(replaceText(trt.tparam.sym, tpe, hole))
 
     /**
       * Formats the given formal parameters in `spec`.
       */
-    def fmtFormalParams(clazz: TypedAst.Class, spec: TypedAst.Spec, hole: String)(implicit flix: Flix): String =
-      spec.fparams.map(fparam => s"${fparam.sym.text}: ${fmtType(clazz, fparam.tpe, hole)}").mkString(", ")
+    def fmtFormalParams(trt: TypedAst.Class, spec: TypedAst.Spec, hole: String)(implicit flix: Flix): String =
+      spec.fparams.map(fparam => s"${fparam.sym.text}: ${fmtType(trt, fparam.tpe, hole)}").mkString(", ")
 
     /**
       * Formats the given signature `sig`.
       */
-    def fmtSignature(clazz: TypedAst.Class, sig: TypedAst.Sig, hole: String)(implicit flix: Flix): String = {
-      val fparams = fmtFormalParams(clazz, sig.spec, hole)
-      val retTpe = fmtType(clazz, sig.spec.retTpe, hole)
+    def fmtSignature(trt: TypedAst.Class, sig: TypedAst.Sig, hole: String)(implicit flix: Flix): String = {
+      val fparams = fmtFormalParams(trt, sig.spec, hole)
+      val retTpe = fmtType(trt, sig.spec.retTpe, hole)
       val eff = sig.spec.eff match {
         case Type.Cst(TypeConstructor.Pure, _) => ""
         case e => raw" \ " + FormatType.formatType(e)
@@ -80,21 +80,21 @@ object InstanceCompleter extends Completer {
     }
 
     root.classes.map {
-      case (_, clazz) =>
+      case (_, trt) =>
         val hole = "${1:t}"
-        val classSym = clazz.sym
-        val signatures = clazz.sigs.filter(_.exp.isEmpty)
-        val body = signatures.map(s => fmtSignature(clazz, s, hole)).mkString("\n\n")
-        val completion = s"$classSym[$hole] {\n\n$body\n\n}\n"
+        val traitSym = trt.sym
+        val signatures = trt.sigs.filter(_.exp.isEmpty)
+        val body = signatures.map(s => fmtSignature(trt, s, hole)).mkString("\n\n")
+        val completion = s"$traitSym[$hole] {\n\n$body\n\n}\n"
 
-        InstanceCompletion(clazz, completion)
+        InstanceCompletion(trt, completion)
     }.toList
   }
 
   /**
-    * Formats the given class `clazz`.
+    * Formats the given trait `trt`.
     */
-  def fmtClass(clazz: TypedAst.Class): String = {
-    s"class ${clazz.sym.name}[${clazz.tparam.name.name}]"
+  def fmtTrait(trt: TypedAst.Class): String = {
+    s"trait ${trt.sym.name}[${trt.tparam.name.name}]"
   }
 }


### PR DESCRIPTION
This PR renames class to trait in Indexer and various other LSP modules. I think all the changes are internal and don't involve the LSPs API (I don't really know how it works).

I'm back at work tomorrow, so the rate of PRs will slow down. 