### PR TITLE
chore: rename class to trait (ClassSym => TraitSym) (issue #6591)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
@@ -152,7 +152,7 @@ object Scheme {
 
     // Check that the constraints from sc1 hold
     // And that the bases unify
-    val cconstrs = sc1.tconstrs.map { case Ast.TypeConstraint(head, arg, loc) => TypeConstraint.Class(head.sym, arg, loc) }
+    val cconstrs = sc1.tconstrs.map { case Ast.TypeConstraint(head, arg, loc) => TypeConstraint.Trait(head.sym, arg, loc) }
     val econstrs = sc1.econstrs.map { case Ast.BroadEqualityConstraint(t1, t2) => TypeConstraint.Equality(t1, t2, Provenance.Match(t1, t2, SourceLocation.Unknown)) }
     val baseConstr = TypeConstraint.Equality(sc1.base, tpe2, Provenance.Match(sc1.base, tpe2, SourceLocation.Unknown))
     ConstraintSolver.resolve(baseConstr :: cconstrs ::: econstrs, subst, renv)(cenv, eenv, flix) match {

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -170,16 +170,16 @@ object Symbol {
   def mkModuleSym(fqn: List[String]): ModuleSym = new ModuleSym(fqn)
 
   /**
-    * Returns the class symbol for the given name `ident` in the given namespace `ns`.
+    * Returns the trait symbol for the given name `ident` in the given namespace `ns`.
     */
-  def mkClassSym(ns: NName, ident: Ident): TraitSym = {
+  def mkTraitSym(ns: NName, ident: Ident): TraitSym = {
     new TraitSym(ns.parts, ident.name, ident.loc)
   }
 
   /**
-    * Returns the class symbol for the given fully qualified name
+    * Returns the trait symbol for the given fully qualified name
     */
-  def mkClassSym(fqn: String): TraitSym = split(fqn) match {
+  def mkTraitSym(fqn: String): TraitSym = split(fqn) match {
     case None => new TraitSym(Nil, fqn, SourceLocation.Unknown)
     case Some((ns, name)) => new TraitSym(ns, name, SourceLocation.Unknown)
   }
@@ -200,10 +200,10 @@ object Symbol {
   }
 
   /**
-    * Returns the signature symbol for the given name `ident` in the class associated with the given class symbol `classSym`.
+    * Returns the signature symbol for the given name `ident` in the trait associated with the given trait symbol `traitSym`.
     */
-  def mkSigSym(classSym: TraitSym, ident: Name.Ident): SigSym = {
-    new SigSym(classSym, ident.name, ident.loc)
+  def mkSigSym(traitSym: TraitSym, ident: Name.Ident): SigSym = {
+    new SigSym(traitSym, ident.name, ident.loc)
   }
 
   /**
@@ -214,10 +214,10 @@ object Symbol {
   }
 
   /**
-    * Returns the associated type symbol for the given name `ident` in the class associated with the given class symbol `classSym`.
+    * Returns the associated type symbol for the given name `ident` in the trait associated with the given trait symbol `traitSym`.
     */
-  def mkAssocTypeSym(classSym: TraitSym, ident: Name.Ident): AssocTypeSym = {
-    new AssocTypeSym(classSym, ident.name, ident.loc)
+  def mkAssocTypeSym(traitSym: TraitSym, ident: Name.Ident): AssocTypeSym = {
+    new AssocTypeSym(traitSym, ident.name, ident.loc)
   }
 
   /**
@@ -546,7 +546,7 @@ object Symbol {
   }
 
   /**
-    * Class Symbol.
+    * Trait Symbol.
     */
   final class TraitSym(val namespace: List[String], val name: String, val loc: SourceLocation) extends Sourceable with Symbol {
     /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -427,7 +427,7 @@ object Namer {
     */
   private def visitTrait(trt: DesugaredAst.Declaration.Class, ns0: Name.NName)(implicit flix: Flix): Validation[NamedAst.Declaration.Trait, NameError] = trt match {
     case DesugaredAst.Declaration.Class(doc, ann, mod0, ident, tparams0, superTraits0, assocs0, signatures, laws0, loc) =>
-      val sym = Symbol.mkClassSym(ns0, ident)
+      val sym = Symbol.mkTraitSym(ns0, ident)
       val mod = visitModifiers(mod0, ns0)
       val tparam = getTypeParam(tparams0)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/TreeShaker1.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TreeShaker1.scala
@@ -32,7 +32,7 @@ import ca.uwaterloo.flix.util.ParOps
   *
   * (c) Appears in a function which itself is reachable.
   *
-  * (d) Is an instance of a class whose signature(s) appear in a reachable function.
+  * (d) Is an instance of a trait whose signature(s) appear in a reachable function.
   * Monomorph will erase unused instances so this phase must check all instances
   * for the monomorph to work.
   *
@@ -72,9 +72,9 @@ object TreeShaker1 {
     *
     * (a) The function or signature symbols in the implementation / body expression of a reachable function symbol
     *
-    * (b) The class symbol of a reachable sig symbol.
+    * (b) The trait symbol of a reachable sig symbol.
     *
-    * (c) Every expression in a class instance of a reachable class symbol is reachable.
+    * (c) Every expression in a trait instance of a reachable trait symbol is reachable.
     *
     */
   private def visitSym(sym: ReachableSym, root: Root): Set[ReachableSym] = sym match {
@@ -83,11 +83,11 @@ object TreeShaker1 {
 
     case ReachableSym.SigSym(sigSym) =>
       val sig = root.sigs(sigSym)
-      Set(ReachableSym.ClassSym(sig.sym.trt)) ++
+      Set(ReachableSym.TraitSym(sig.sym.trt)) ++
         sig.exp.map(visitExp).getOrElse(Set.empty)
 
-    case ReachableSym.ClassSym(classSym) =>
-      root.instances(classSym).foldLeft(Set.empty[ReachableSym]) {
+    case ReachableSym.TraitSym(traitSym) =>
+      root.instances(traitSym).foldLeft(Set.empty[ReachableSym]) {
         case (acc, s) => visitExps(s.defs.map(_.exp)) ++ acc
       }
   }
@@ -176,7 +176,7 @@ object TreeShaker1 {
 
 
   /**
-    * A common super-type for reachable symbols (defs, classes, sigs)
+    * A common super-type for reachable symbols (defs, traits, sigs)
     */
   sealed trait ReachableSym
 
@@ -184,7 +184,7 @@ object TreeShaker1 {
 
     case class DefnSym(sym: Symbol.DefnSym) extends ReachableSym
 
-    case class ClassSym(sym: Symbol.TraitSym) extends ReachableSym
+    case class TraitSym(sym: Symbol.TraitSym) extends ReachableSym
 
     case class SigSym(sym: Symbol.SigSym) extends ReachableSym
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/Debug.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/Debug.scala
@@ -136,7 +136,7 @@ object Debug {
     */
   private def toSubDot(constr: TypeConstraint): String = constr match {
     case TypeConstraint.Equality(tpe1, tpe2, _) => s"""${dotId(constr)} [label = "$tpe1 ~ $tpe2"];"""
-    case TypeConstraint.Class(sym, tpe, _) => s"""${dotId(constr)} [label = "$sym[$tpe]"];"""
+    case TypeConstraint.Trait(sym, tpe, _) => s"""${dotId(constr)} [label = "$sym[$tpe]"];"""
     case TypeConstraint.Purification(sym, eff1, eff2, _, nested) =>
       val header = s"""${dotId(constr)} [label = "$eff1 ~ ($eff2)[$sym ↦ Pure]"];"""
       val children = nested.map(toSubDot)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
@@ -36,12 +36,12 @@ sealed trait TypeConstraint {
       val tvars = tpe1.typeVars ++ tpe2.typeVars
       val effTvars = tvars.filter(_.kind == Kind.Eff)
       (1, effTvars.size, tvars.size)
-    case TypeConstraint.Class(_, _, _) => (2, 0, 0)
+    case TypeConstraint.Trait(_, _, _) => (2, 0, 0)
   }
 
   override def toString: String = this match {
     case TypeConstraint.Equality(tpe1, tpe2, _) => s"$tpe1 ~ $tpe2"
-    case TypeConstraint.Class(sym, tpe, _) => s"$sym[$tpe]"
+    case TypeConstraint.Trait(sym, tpe, _) => s"$sym[$tpe]"
     case TypeConstraint.Purification(sym, eff1, eff2, _, nested) => s"$eff1 ~ ($eff2)[$sym ↦ Pure] ∧ $nested"
   }
 
@@ -50,7 +50,7 @@ sealed trait TypeConstraint {
     */
   def numVars: Int = this match {
     case TypeConstraint.Equality(tpe1, tpe2, _) => tpe1.typeVars.size + tpe2.typeVars.size
-    case TypeConstraint.Class(_, tpe, _) => tpe.typeVars.size
+    case TypeConstraint.Trait(_, tpe, _) => tpe.typeVars.size
     case TypeConstraint.Purification(_, eff1, eff2, _, _) => eff1.typeVars.size + eff2.typeVars.size
   }
 
@@ -70,12 +70,12 @@ object TypeConstraint {
   }
 
   /**
-    * A constraint indicating that the given type is a member of the given class.
+    * A constraint indicating that the given type is a member of the given trait.
     * {{{
     *   sym[tpe]
     * }}}
     */
-  case class Class(sym: Symbol.TraitSym, tpe: Type, loc: SourceLocation) extends TypeConstraint
+  case class Trait(sym: Symbol.TraitSym, tpe: Type, loc: SourceLocation) extends TypeConstraint
 
   /**
     * A constraint indicating that:

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeContext.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeContext.scala
@@ -188,12 +188,12 @@ class TypeContext {
   }
 
   /**
-    * Adds the given class constraints to the context.
+    * Adds the given trait constraints to the context.
     */
   def addClassConstraints(tconstrs0: List[Ast.TypeConstraint], loc: SourceLocation): Unit = {
     // convert all the syntax-level constraints to semantic constraints
     val tconstrs = tconstrs0.map {
-      case Ast.TypeConstraint(head, arg, _) => TypeConstraint.Class(head.sym, arg, loc)
+      case Ast.TypeConstraint(head, arg, _) => TypeConstraint.Trait(head.sym, arg, loc)
     }
     currentScopeConstraints.addAll(tconstrs)
   }

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -197,7 +197,7 @@ class Shell(bootstrap: Bootstrap, options: Options) {
     */
   private def execInfo(s: String)(implicit terminal: Terminal): Unit = {
     val w = terminal.writer()
-    val classSym = Symbol.mkClassSym(s)
+    val classSym = Symbol.mkTraitSym(s)
     val defnSym = Symbol.mkDefnSym(s)
     val enumSym = Symbol.mkEnumSym(s)
     val aliasSym = Symbol.mkTypeAliasSym(s)

--- a/main/test/ca/uwaterloo/flix/language/phase/unification/TestAssocTypeUnification.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/unification/TestAssocTypeUnification.scala
@@ -27,7 +27,7 @@ class TestAssocTypeUnification extends AnyFunSuite with TestUtils {
 
   private implicit val flix: Flix = new Flix()
   private val loc: SourceLocation = SourceLocation.Unknown
-  private val CollSym: Symbol.TraitSym = Symbol.mkClassSym("Coll")
+  private val CollSym: Symbol.TraitSym = Symbol.mkTraitSym("Coll")
   private val ElemSym: Symbol.AssocTypeSym = Symbol.mkAssocTypeSym(CollSym, Name.Ident(SourcePosition.Unknown, "Elem", SourcePosition.Unknown))
   private val ElemCst: Ast.AssocTypeConstructor = Ast.AssocTypeConstructor(ElemSym, loc)
 


### PR DESCRIPTION
This PR renames the case classes `Symbol.ClassSym` to `Symbol.TraitSym` and `TreeShaker1.ClassSym` to `TreeShaker1.TraitSym`. 

It also changes `TypeContraint.Class` to `TypeConstraint.Trait`.