### PR TITLE
chore: rename ClassEnvironment to TraitEnvironment and Ast.ClassContext to Ast.TraitContext (issue #6591)

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -419,7 +419,7 @@ object CodeActionProvider {
     * `None` otherwise.
     */
   private def mkDerive(e: TypedAst.Enum, trt: String, uri: String): Option[CodeAction] = {
-    val alreadyDerived = e.derives.classes.exists(d => d.clazz.name == trt)
+    val alreadyDerived = e.derives.classes.exists(d => d.trt.name == trt)
     if (alreadyDerived) None
     else Some(
       CodeAction(

--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -673,9 +673,9 @@ object Ast {
   case class Instance(tpe: Type, tconstrs: List[Ast.TypeConstraint])
 
   /**
-    * Represents the super classes and instances available for a particular class.
+    * Represents the super traits and instances available for a particular traits.
     */
-  case class ClassContext(superClasses: List[Symbol.TraitSym], instances: List[Ast.Instance])
+  case class TraitContext(superTraits: List[Symbol.TraitSym], instances: List[Ast.Instance])
 
   /**
     * Represents the definition of an associated type.
@@ -687,7 +687,7 @@ object Ast {
   /**
     * Represents a derivation on an enum (e.g. `enum E with Eq`).
     */
-  case class Derivation(clazz: Symbol.TraitSym, loc: SourceLocation)
+  case class Derivation(trt: Symbol.TraitSym, loc: SourceLocation)
 
   /**
     * Represents a list of derivations with a source location.

--- a/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
@@ -34,7 +34,7 @@ object LoweredAst {
                   entryPoint: Option[Symbol.DefnSym],
                   reachable: Set[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],
-                  classEnv: Map[Symbol.TraitSym, Ast.ClassContext],
+                  classEnv: Map[Symbol.TraitSym, Ast.TraitContext],
                   eqEnv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef])
 
   case class Class(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superClasses: List[Ast.TypeConstraint], assocs: List[AssocTypeSig], signatures: List[Sig], laws: List[Def], loc: SourceLocation)

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -39,7 +39,7 @@ object TypedAst {
                   entryPoint: Option[Symbol.DefnSym],
                   reachable: Set[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],
-                  classEnv: Map[Symbol.TraitSym, Ast.ClassContext],
+                  classEnv: Map[Symbol.TraitSym, Ast.TraitContext],
                   eqEnv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef],
                   names: MultiMap[List[String], String],
                   precedenceGraph: LabelledPrecedenceGraph)

--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -1126,8 +1126,8 @@ object HtmlDocumentor {
 
     sb.append("<span> <span class='keyword'>with</span> ")
     docList(derives.classes.sortBy(_.loc)) { c =>
-      sb.append(s"<a class='tpe-constraint' href='${escUrl(traitFileName(c.clazz))}' title='trait ${esc(traitName(c.clazz))}'>")
-      sb.append(s"${esc(c.clazz.name)}")
+      sb.append(s"<a class='tpe-constraint' href='${escUrl(traitFileName(c.trt))}' title='trait ${esc(traitName(c.trt))}'>")
+      sb.append(s"${esc(c.trt.name)}")
       sb.append("</a>")
     }
     sb.append("</span>")

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -23,7 +23,7 @@ import ca.uwaterloo.flix.language.ast.ops.TypedAstOps
 import ca.uwaterloo.flix.language.ast.{Ast, Name, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.errors.RedundancyError
 import ca.uwaterloo.flix.language.errors.RedundancyError._
-import ca.uwaterloo.flix.language.phase.unification.ClassEnvironment
+import ca.uwaterloo.flix.language.phase.unification.TraitEnvironment
 import ca.uwaterloo.flix.util.{ParOps, Validation}
 
 import java.util.concurrent.ConcurrentHashMap
@@ -164,7 +164,7 @@ object Redundancy {
       (tconstr1, i1) <- tconstrs.zipWithIndex
       (tconstr2, i2) <- tconstrs.zipWithIndex
       // don't compare a constraint against itself
-      if i1 != i2 && ClassEnvironment.entails(tconstr1, tconstr2, root.classEnv)
+      if i1 != i2 && TraitEnvironment.entails(tconstr1, tconstr2, root.classEnv)
     } yield RedundancyError.RedundantTypeConstraint(tconstr1, tconstr2, tconstr2.loc)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver.scala
@@ -48,30 +48,30 @@ object ConstraintSolver {
   /**
     * Resolves constraints in the given definition using the given inference result.
     */
-  def visitDef(defn: KindedAst.Def, infResult: InfResult, renv0: RigidityEnv, tconstrs0: List[Ast.TypeConstraint], cenv0: Map[Symbol.TraitSym, Ast.ClassContext], eqEnv0: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], root: KindedAst.Root)(implicit flix: Flix): Validation[Substitution, TypeError] = defn match {
+  def visitDef(defn: KindedAst.Def, infResult: InfResult, renv0: RigidityEnv, tconstrs0: List[Ast.TypeConstraint], tenv0: Map[Symbol.TraitSym, Ast.TraitContext], eqEnv0: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], root: KindedAst.Root)(implicit flix: Flix): Validation[Substitution, TypeError] = defn match {
     case KindedAst.Def(sym, spec, _) =>
       if (flix.options.xprinttyper.contains(sym.toString)) {
         Debug.startRecording()
       }
-      visitSpec(spec, infResult, renv0, tconstrs0, cenv0, eqEnv0, root)
+      visitSpec(spec, infResult, renv0, tconstrs0, tenv0, eqEnv0, root)
   }
 
   /**
     * Resolves constraints in the given signature using the given inference result.
     */
-  def visitSig(sig: KindedAst.Sig, infResult: InfResult, renv0: RigidityEnv, tconstrs0: List[Ast.TypeConstraint], cenv0: Map[Symbol.TraitSym, Ast.ClassContext], eqEnv0: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], root: KindedAst.Root)(implicit flix: Flix): Validation[Substitution, TypeError] = sig match {
+  def visitSig(sig: KindedAst.Sig, infResult: InfResult, renv0: RigidityEnv, tconstrs0: List[Ast.TypeConstraint], tenv0: Map[Symbol.TraitSym, Ast.TraitContext], eqEnv0: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], root: KindedAst.Root)(implicit flix: Flix): Validation[Substitution, TypeError] = sig match {
     case KindedAst.Sig(_, _, None) => Validation.success(Substitution.empty)
     case KindedAst.Sig(sym, spec, Some(_)) =>
       if (flix.options.xprinttyper.contains(sym.toString)) {
         Debug.startRecording()
       }
-      visitSpec(spec, infResult, renv0, tconstrs0, cenv0, eqEnv0, root)
+      visitSpec(spec, infResult, renv0, tconstrs0, tenv0, eqEnv0, root)
   }
 
   /**
     * Resolves constraints in the given spec using the given inference result.
     */
-  def visitSpec(spec: KindedAst.Spec, infResult: InfResult, renv0: RigidityEnv, tconstrs0: List[Ast.TypeConstraint], cenv0: Map[Symbol.TraitSym, Ast.ClassContext], eqEnv0: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], root: KindedAst.Root)(implicit flix: Flix): Validation[Substitution, TypeError] = spec match {
+  def visitSpec(spec: KindedAst.Spec, infResult: InfResult, renv0: RigidityEnv, tconstrs0: List[Ast.TypeConstraint], tenv0: Map[Symbol.TraitSym, Ast.TraitContext], eqEnv0: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], root: KindedAst.Root)(implicit flix: Flix): Validation[Substitution, TypeError] = spec match {
     case KindedAst.Spec(_, _, _, _, fparams, _, tpe, eff, tconstrs, econstrs, loc) =>
 
       val InfResult(infConstrs, infTpe, infEff, infRenv) = infResult
@@ -95,7 +95,7 @@ object ConstraintSolver {
       // The trait and equality environments are made up of:
       // 1. constraints from the context (e.g. constraints on instances and traits, plus global constraints)
       // 2. constraints from the function signature
-      val cenv = expandClassEnv(cenv0, tconstrs ++ tconstrs0)
+      val cenv = expandTraitEnv(tenv0, tconstrs ++ tconstrs0)
       val eenv = expandEqualityEnv(eqEnv0, econstrs) // TODO ASSOC-TYPES allow econstrs on instances
 
       // We add extra constraints for the declared type and effect
@@ -147,12 +147,12 @@ object ConstraintSolver {
     *   instance Order[b]
     * }}}
     */
-  def expandClassEnv(cenv: Map[Symbol.TraitSym, Ast.ClassContext], tconstrs: List[Ast.TypeConstraint]): Map[Symbol.TraitSym, Ast.ClassContext] = {
-    tconstrs.flatMap(withSupers(_, cenv)).foldLeft(cenv) {
+  def expandTraitEnv(tenv: Map[Symbol.TraitSym, Ast.TraitContext], tconstrs: List[Ast.TypeConstraint]): Map[Symbol.TraitSym, Ast.TraitContext] = {
+    tconstrs.flatMap(withSupers(_, tenv)).foldLeft(tenv) {
       case (acc, Ast.TypeConstraint(Ast.TypeConstraint.Head(sym, _), arg, loc)) =>
         val inst = Ast.Instance(arg, Nil)
         val context = acc.get(sym) match {
-          case Some(Ast.ClassContext(supers, insts)) => Ast.ClassContext(supers, inst :: insts)
+          case Some(Ast.TraitContext(supers, insts)) => Ast.TraitContext(supers, inst :: insts)
           case None => throw InternalCompilerException(s"unexpected unknown trait sym: $sym", loc)
         }
         acc + (sym -> context)
@@ -196,7 +196,7 @@ object ConstraintSolver {
     * - a substitution and leftover constraints, or
     * - an error if resolution failed
     */
-  def resolve(constrs: List[TypeConstraint], subst0: Substitution, renv: RigidityEnv)(implicit cenv: Map[Symbol.TraitSym, Ast.ClassContext], eenv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], flix: Flix): Result[ResolutionResult, TypeError] = {
+  def resolve(constrs: List[TypeConstraint], subst0: Substitution, renv: RigidityEnv)(implicit tenv: Map[Symbol.TraitSym, Ast.TraitContext], eenv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], flix: Flix): Result[ResolutionResult, TypeError] = {
 
     // We track changes to the resolution state through mutable variables.
 
@@ -244,7 +244,7 @@ object ConstraintSolver {
     *
     * Applies the initial substitution `subst0` before attempting to resolve.
     */
-  private def resolveOneOf(constrs: List[TypeConstraint], subst0: Substitution, renv: RigidityEnv)(implicit cenv: Map[Symbol.TraitSym, Ast.ClassContext], eenv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], flix: Flix): Result[ResolutionResult, TypeError] = {
+  private def resolveOneOf(constrs: List[TypeConstraint], subst0: Substitution, renv: RigidityEnv)(implicit tenv: Map[Symbol.TraitSym, Ast.TraitContext], eenv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], flix: Flix): Result[ResolutionResult, TypeError] = {
     def tryResolve(cs: List[TypeConstraint]): Result[ResolutionResult, TypeError] = cs match {
       case Nil => Result.Ok(ResolutionResult(subst0, cs, progress = false))
       case hd :: tl => resolveOne(hd, renv, subst0).flatMap {
@@ -263,7 +263,7 @@ object ConstraintSolver {
   /**
     * Tries to resolve the given constraint.
     */
-  private def resolveOne(constr0: TypeConstraint, renv: RigidityEnv, subst0: Substitution)(implicit cenv: Map[Symbol.TraitSym, Ast.ClassContext], eenv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], flix: Flix): Result[ResolutionResult, TypeError] = constr0 match {
+  private def resolveOne(constr0: TypeConstraint, renv: RigidityEnv, subst0: Substitution)(implicit tenv: Map[Symbol.TraitSym, Ast.TraitContext], eenv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], flix: Flix): Result[ResolutionResult, TypeError] = constr0 match {
     case TypeConstraint.Equality(tpe1, tpe2, prov0) =>
       val t1 = TypeMinimization.minimizeType(subst0(tpe1))
       val t2 = TypeMinimization.minimizeType(subst0(tpe2))
@@ -272,7 +272,7 @@ object ConstraintSolver {
         case ResolutionResult(subst, constrs, p) => ResolutionResult(subst @@ subst0, constrs, progress = p)
       }
     case TypeConstraint.Trait(sym, tpe, loc) =>
-      resolveClassConstraint(sym, subst0(tpe), renv, loc).map {
+      resolveTraitConstraint(sym, subst0(tpe), renv, loc).map {
         case (constrs, progress) => ResolutionResult(subst0, constrs, progress)
       }
     case TypeConstraint.Purification(sym, eff1, eff2, prov, nested0) =>
@@ -443,7 +443,7 @@ object ConstraintSolver {
     *   ToString[a -> b \ ef] ~> <ERROR>
     * }}}
     */
-  private def resolveClassConstraint(trt: Symbol.TraitSym, tpe0: Type, renv0: RigidityEnv, loc: SourceLocation)(implicit cenv: Map[Symbol.TraitSym, Ast.ClassContext], eenv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], flix: Flix): Result[(List[TypeConstraint], Boolean), TypeError] = {
+  private def resolveTraitConstraint(trt: Symbol.TraitSym, tpe0: Type, renv0: RigidityEnv, loc: SourceLocation)(implicit tenv: Map[Symbol.TraitSym, Ast.TraitContext], eenv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], flix: Flix): Result[(List[TypeConstraint], Boolean), TypeError] = {
     // redE
     simplifyType(tpe0, renv0, loc).flatMap {
       case (t, progress) =>
@@ -459,7 +459,7 @@ object ConstraintSolver {
           case _ =>
             // we mark t's tvars as rigid so we get the substitution in the right direction
             val renv = t.typeVars.map(_.sym).foldLeft(renv0)(_.markRigid(_))
-            val insts = cenv(trt).instances
+            val insts = tenv(trt).instances
             // find the first (and only) instance that matches
             val tconstrsOpt = ListOps.findMap(insts) {
               inst =>
@@ -483,7 +483,7 @@ object ConstraintSolver {
                 // simplify all the implied constraints
                 Result.traverse(tconstrs) {
                   case Ast.TypeConstraint(Ast.TypeConstraint.Head(c, _), arg, _) =>
-                    resolveClassConstraint(c, arg, renv0, loc)
+                    resolveTraitConstraint(c, arg, renv0, loc)
                 } map {
                   case res =>
                     val cs = res.flatMap { case (c, _) => c }
@@ -580,12 +580,12 @@ object ConstraintSolver {
     *
     * For example, `Order[a]` implies `Order[a]` and `Eq[a]`
     */
-  private def withSupers(tconstr: Ast.TypeConstraint, cenv: Map[Symbol.TraitSym, Ast.ClassContext]): List[Ast.TypeConstraint] = {
-    val superSyms = cenv(tconstr.head.sym).superClasses
+  private def withSupers(tconstr: Ast.TypeConstraint, tenv: Map[Symbol.TraitSym, Ast.TraitContext]): List[Ast.TypeConstraint] = {
+    val superSyms = tenv(tconstr.head.sym).superTraits
     val directSupers = superSyms.map {
       case sym => Ast.TypeConstraint(Ast.TypeConstraint.Head(sym, SourceLocation.Unknown), tconstr.arg, tconstr.loc)
     }
-    val allSupers = directSupers.flatMap(withSupers(_, cenv))
+    val allSupers = directSupers.flatMap(withSupers(_, tenv))
     tconstr :: allSupers
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/TraitEnvironment.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/TraitEnvironment.scala
@@ -17,48 +17,48 @@
 package ca.uwaterloo.flix.language.phase.unification
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.Ast.ClassContext
+import ca.uwaterloo.flix.language.ast.Ast.TraitContext
 import ca.uwaterloo.flix.language.ast.{Ast, RigidityEnv, Symbol, Type}
 import ca.uwaterloo.flix.util.{Result, Validation}
 
 import scala.annotation.tailrec
 
-object ClassEnvironment {
+object TraitEnvironment {
 
 
   /**
-    * Returns success iff type constraints `tconstrs0` entail type constraint `tconstr`, under class environment `instances`.
+    * Returns success iff type constraints `tconstrs0` entail type constraint `tconstr`, under trait environment `instances`.
     * That is, `tconstr` is true if all of `tconstrs0` are true.
     */
   // MATT THIH says that toncstrs0 should always be in HNF so checking for byInst is a waste.
-  def entail(tconstrs0: List[Ast.TypeConstraint], tconstr: Ast.TypeConstraint, classEnv: Map[Symbol.TraitSym, Ast.ClassContext])(implicit flix: Flix): Validation[Unit, UnificationError] = {
+  def entail(tconstrs0: List[Ast.TypeConstraint], tconstr: Ast.TypeConstraint, traitEnv: Map[Symbol.TraitSym, Ast.TraitContext])(implicit flix: Flix): Validation[Unit, UnificationError] = {
 
-    val superClasses = tconstrs0.flatMap(bySuper(_, classEnv))
+    val superTraits = tconstrs0.flatMap(bySuper(_, traitEnv))
 
-    // Case 1: tconstrs0 entail tconstr if tconstr is a super class of any member of tconstrs0
-    if (superClasses.contains(tconstr)) {
+    // Case 1: tconstrs0 entail tconstr if tconstr is a super trait of any member of tconstrs0
+    if (superTraits.contains(tconstr)) {
       Validation.success(())
     } else {
       // Case 2: there is an instance matching tconstr and all of the instance's constraints are entailed by tconstrs0
-      Validation.flatMapN(byInst(tconstr, classEnv)) {
-        case tconstrs => Validation.sequenceX(tconstrs.map(entail(tconstrs0, _, classEnv)))
+      Validation.flatMapN(byInst(tconstr, traitEnv)) {
+        case tconstrs => Validation.sequenceX(tconstrs.map(entail(tconstrs0, _, traitEnv)))
       }
     }
   }
 
   /**
-    * Returns true iff type constraint `tconstr1` entails tconstr2 under class environment `classEnv`.
+    * Returns true iff type constraint `tconstr1` entails tconstr2 under trait environment `traitEnv`.
     */
-  def entails(tconstr1: Ast.TypeConstraint, tconstr2: Ast.TypeConstraint, classEnv: Map[Symbol.TraitSym, Ast.ClassContext]): Boolean = {
-    val superClasses = bySuper(tconstr1, classEnv)
-    superClasses.contains(tconstr2)
+  def entails(tconstr1: Ast.TypeConstraint, tconstr2: Ast.TypeConstraint, traitEnv: Map[Symbol.TraitSym, Ast.TraitContext]): Boolean = {
+    val superTraits = bySuper(tconstr1, traitEnv)
+    superTraits.contains(tconstr2)
   }
 
   /**
-    * Returns true iff the given type constraint holds under the given class environment.
+    * Returns true iff the given type constraint holds under the given trait environment.
     */
-  def holds(tconstr: Ast.TypeConstraint, classEnv: Map[Symbol.TraitSym, Ast.ClassContext])(implicit flix: Flix): Boolean = {
-    byInst(tconstr, classEnv).toHardResult match {
+  def holds(tconstr: Ast.TypeConstraint, traitEnv: Map[Symbol.TraitSym, Ast.TraitContext])(implicit flix: Flix): Boolean = {
+    byInst(tconstr, traitEnv).toHardResult match {
       case Result.Ok(_) => true
       case Result.Err(_) => false
     }
@@ -67,13 +67,13 @@ object ClassEnvironment {
   /**
     * Removes the type constraints which are entailed by the others in the list.
     */
-  private def simplify(tconstrs0: List[Ast.TypeConstraint], classEnv: Map[Symbol.TraitSym, Ast.ClassContext])(implicit flix: Flix): List[Ast.TypeConstraint] = {
+  private def simplify(tconstrs0: List[Ast.TypeConstraint], traitEnv: Map[Symbol.TraitSym, Ast.TraitContext])(implicit flix: Flix): List[Ast.TypeConstraint] = {
 
     @tailrec
     def loop(tconstrs0: List[Ast.TypeConstraint], acc: List[Ast.TypeConstraint]): List[Ast.TypeConstraint] = tconstrs0 match {
       // Case 0: no tconstrs left to process, we're done
       case Nil => acc
-      case head :: tail => entail(acc ++ tail, head, classEnv).toHardResult match {
+      case head :: tail => entail(acc ++ tail, head, traitEnv).toHardResult match {
         // Case 1: `head` is entailed by the other type constraints, skip it
         case Result.Ok(_) => loop(tail, acc)
         // Case 2: `head` is not entailed, add it to the list
@@ -87,31 +87,31 @@ object ClassEnvironment {
   /**
     * Normalizes a list of type constraints, converting to head-normal form and removing semantic duplicates.
     */
-  def reduce(tconstrs0: List[Ast.TypeConstraint], classEnv: Map[Symbol.TraitSym, Ast.ClassContext])(implicit flix: Flix): Validation[List[Ast.TypeConstraint], UnificationError] = {
+  def reduce(tconstrs0: List[Ast.TypeConstraint], traitEnv: Map[Symbol.TraitSym, Ast.TraitContext])(implicit flix: Flix): Validation[List[Ast.TypeConstraint], UnificationError] = {
     val tconstrs1 = tconstrs0.map {
       case Ast.TypeConstraint(head, tpe, loc) => Ast.TypeConstraint(head, Type.eraseAliases(tpe), loc)
     }
-    val normalization = Validation.sequence(tconstrs1.map(toHeadNormalForm(_, classEnv)))
-    Validation.mapN(normalization)(tconstrs => simplify(tconstrs.flatten, classEnv))
+    val normalization = Validation.sequence(tconstrs1.map(toHeadNormalForm(_, traitEnv)))
+    Validation.mapN(normalization)(tconstrs => simplify(tconstrs.flatten, traitEnv))
   }
 
   /**
     * Converts the type constraint to head-normal form, i.e. `a[X1, Xn]`, where `a` is a variable and `n >= 0`.
     */
-  private def toHeadNormalForm(tconstr: Ast.TypeConstraint, classEnv: Map[Symbol.TraitSym, ClassContext])(implicit flix: Flix): Validation[List[Ast.TypeConstraint], UnificationError] = {
+  private def toHeadNormalForm(tconstr: Ast.TypeConstraint, traitEnv: Map[Symbol.TraitSym, TraitContext])(implicit flix: Flix): Validation[List[Ast.TypeConstraint], UnificationError] = {
     if (isHeadNormalForm(tconstr.arg)) {
       Validation.success(List(tconstr))
     } else {
-      byInst(tconstr, classEnv)
+      byInst(tconstr, traitEnv)
     }
   }
 
   /**
     * Returns the list of constraints that hold if the given constraint `tconstr` holds, using the constraints on available instances.
     */
-  private def byInst(tconstr: Ast.TypeConstraint, classEnv: Map[Symbol.TraitSym, Ast.ClassContext])(implicit flix: Flix): Validation[List[Ast.TypeConstraint], UnificationError] = tconstr match {
+  private def byInst(tconstr: Ast.TypeConstraint, traitEnv: Map[Symbol.TraitSym, Ast.TraitContext])(implicit flix: Flix): Validation[List[Ast.TypeConstraint], UnificationError] = tconstr match {
     case Ast.TypeConstraint(head, arg, loc) =>
-      val matchingInstances = classEnv.get(head.sym).map(_.instances).getOrElse(Nil)
+      val matchingInstances = traitEnv.get(head.sym).map(_.instances).getOrElse(Nil)
 
       val renv = RigidityEnv.ofRigidVars(arg.typeVars.map(_.sym))
 
@@ -142,27 +142,27 @@ object ClassEnvironment {
   }
 
   /**
-    * Returns the list of constraints that hold if the given constraint `tconstr` holds, using the super classes of the constraint.
+    * Returns the list of constraints that hold if the given constraint `tconstr` holds, using the super traits of the constraint.
     *
-    * E.g. if we have 3 classes: `A`, `B`, `C` where
+    * E.g. if we have 3 traits: `A`, `B`, `C` where
     * - `A` extends `B`
     * - `B` extends `C`
     * Then for the constraint `t : A`, we return:
     * - `t : A` (given)
-    * - `t : B` (because `B` is a super class of `A`)
-    * - `t : C` (because `C` is a super class of `B`, and transitively a super class of `A`)
+    * - `t : B` (because `B` is a super trait of `A`)
+    * - `t : C` (because `C` is a super trait of `B`, and transitively a super trait of `A`)
     *
     */
-  private def bySuper(tconstr: Ast.TypeConstraint, classEnv: Map[Symbol.TraitSym, Ast.ClassContext]): List[Ast.TypeConstraint] = {
+  private def bySuper(tconstr: Ast.TypeConstraint, traitEnv: Map[Symbol.TraitSym, Ast.TraitContext]): List[Ast.TypeConstraint] = {
 
-    // Get the classes that are directly superclasses of the class in `tconstr`
-    val directSupers = classEnv.get(tconstr.head.sym).map(_.superClasses).getOrElse(Nil)
+    // Get the traits that are directly super traits of the trait in `tconstr`
+    val directSupers = traitEnv.get(tconstr.head.sym).map(_.superTraits).getOrElse(Nil)
 
-    // Walk the super class tree.
-    // There may be duplicates, but this will terminate since super classes must be acyclic.
+    // Walk the super trait tree.
+    // There may be duplicates, but this will terminate since super traits must be acyclic.
     tconstr :: directSupers.flatMap {
-      // recurse on the superclasses of each direct superclass
-      superClass => bySuper(Ast.TypeConstraint(Ast.TypeConstraint.Head(superClass, tconstr.loc), tconstr.arg, tconstr.loc), classEnv)
+      // recurse on the super traits of each direct super trait
+      superTrait => bySuper(Ast.TypeConstraint(Ast.TypeConstraint.Head(superTrait, tconstr.loc), tconstr.arg, tconstr.loc), traitEnv)
     }
   }
 


### PR DESCRIPTION
This PR renames the case class `Ast.ClassContext` to `Ast.TraitContext`.

It also renames module / object `ca.uwaterloo.flix.language.phase.unification.ClassEnvironment` to `ca.uwaterloo.flix.language.phase.unification.TraitEnvironment`
