### PR TITLE
chore: rename TypedAst.Class to TypedAst.Trait (issue #6591)

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Entity.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Entity.scala
@@ -67,7 +67,7 @@ object Entity {
     def precision: Precision = Precision.High
   }
 
-  case class Class(e: TypedAst.Class) extends Entity {
+  case class Class(e: TypedAst.Trait) extends Entity {
     def loc: SourceLocation = e.sym.loc
     def precision: Precision = Precision.High
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
@@ -35,9 +35,9 @@ object Index {
   def all(indices: Index*): Index = indices.foldLeft(Index.empty)(_ ++ _)
 
   /**
-    * Returns an index for the given `class0`.
+    * Returns an index for the given `trait0`.
     */
-  def occurrenceOf(class0: TypedAst.Class): Index = empty + Entity.Class(class0)
+  def occurrenceOf(trait0: TypedAst.Trait): Index = empty + Entity.Class(trait0)
 
   /**
     * Returns an index for the given `case0`.

--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -29,7 +29,7 @@ object Indexer {
     Index.all(
       traverse(root.defs.values)(visitDef),
       traverse(root.enums.values)(visitEnum),
-      traverse(root.classes.values)(visitTrait),
+      traverse(root.traits.values)(visitTrait),
       traverse(root.instances.values) {
         instances => traverse(instances)(visitInstance)
       },
@@ -85,8 +85,8 @@ object Indexer {
       Index.all(
         Index.occurrenceOf(enum0),
         traverse(tparams)(visitTypeParam),
-        traverse(derives.classes) {
-          case Ast.Derivation(clazz, loc) => Index.useOf(clazz, loc)
+        traverse(derives.traits) {
+          case Ast.Derivation(trt, loc) => Index.useOf(trt, loc)
         },
         traverse(cases.values)(visitCase),
       )
@@ -103,8 +103,8 @@ object Indexer {
   /**
     * Returns a reverse index for the given trait `trait0`.
     */
-  private def visitTrait(trait0: TypedAst.Class): Index = trait0 match {
-    case Class(doc, ann, mod, sym, tparam, superTraits, assocs, signatures, laws, loc) =>
+  private def visitTrait(trait0: TypedAst.Trait): Index = trait0 match {
+    case Trait(doc, ann, mod, sym, tparam, superTraits, assocs, signatures, laws, loc) =>
       Index.all(
         Index.occurrenceOf(trait0),
         visitTypeParam(tparam),

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -124,7 +124,7 @@ object CodeActionProvider {
     * Returns a code action that proposes to `use` a trait.
     */
   private def mkUseTrait(ident: Name.Ident, uri: String)(implicit root: Root): List[CodeAction] = {
-    val syms = root.classes.map {
+    val syms = root.traits.map {
       case (sym, _) => sym
     }
     mkUseSym(ident, syms.map(_.name), syms, uri)
@@ -146,10 +146,10 @@ object CodeActionProvider {
   private def mkUseType(ident: Name.Ident, uri: String)(implicit root: Root): List[CodeAction] = {
     val names = root.enums.map { case (sym, _) => sym.name } ++
       root.restrictableEnums.map { case (sym, _) => sym.name } ++
-      root.classes.map { case (sym, _) => sym.name } ++
+      root.traits.map { case (sym, _) => sym.name } ++
       root.typeAliases.map { case (sym, _) => sym.name }
 
-    val syms = (root.enums ++ root.restrictableEnums ++ root.classes ++ root.typeAliases).map {
+    val syms = (root.enums ++ root.restrictableEnums ++ root.traits ++ root.typeAliases).map {
       case (sym, _) => sym
     }
 
@@ -419,7 +419,7 @@ object CodeActionProvider {
     * `None` otherwise.
     */
   private def mkDerive(e: TypedAst.Enum, trt: String, uri: String): Option[CodeAction] = {
-    val alreadyDerived = e.derives.classes.exists(d => d.trt.name == trt)
+    val alreadyDerived = e.derives.traits.exists(d => d.trt.name == trt)
     if (alreadyDerived) None
     else Some(
       CodeAction(
@@ -454,7 +454,7 @@ object CodeActionProvider {
     */
   private def addDerivation(e: TypedAst.Enum, trt: String, uri: String): WorkspaceEdit = {
     val text =
-      if (e.derives.classes.isEmpty)
+      if (e.derives.traits.isEmpty)
         s" with $trt"
       else
         s", $trt"

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/ImplementationProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/ImplementationProvider.scala
@@ -33,7 +33,7 @@ object ImplementationProvider {
     val links = for {
       traitSym <- traitAt(uri, position)
       inst <- root.instances.getOrElse(traitSym, Nil)
-    } yield LocationLink.fromInstanceTraitSymUse(inst.clazz, traitSym.loc)
+    } yield LocationLink.fromInstanceTraitSymUse(inst.trt, traitSym.loc)
 
     links.toList
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -43,7 +43,7 @@ object SemanticTokensProvider {
     //
     // Construct an iterator of the semantic tokens from traits.
     //
-    val traitTokens = root.classes.values.flatMap {
+    val traitTokens = root.traits.values.flatMap {
       case decl if include(uri, decl.sym.loc) => visitTrait(decl)
       case _ => Nil
     }
@@ -53,7 +53,7 @@ object SemanticTokensProvider {
     //
     val instanceTokens = root.instances.values.flatMap {
       case instances => instances.flatMap {
-        case instance if include(uri, instance.clazz.loc) => visitInstance(instance)
+        case instance if include(uri, instance.trt.loc) => visitInstance(instance)
         case _ => Nil
       }
     }
@@ -124,8 +124,8 @@ object SemanticTokensProvider {
   /**
     * Returns all semantic tokens in the given trait `traitDecl`.
     */
-  private def visitTrait(traitDecl: TypedAst.Class): Iterator[SemanticToken] = traitDecl match {
-    case TypedAst.Class(_, _, _, sym, tparam, superTraits, assocs, signatures, laws, _) =>
+  private def visitTrait(traitDecl: TypedAst.Trait): Iterator[SemanticToken] = traitDecl match {
+    case TypedAst.Trait(_, _, _, sym, tparam, superTraits, assocs, signatures, laws, _) =>
       val t = SemanticToken(SemanticTokenType.Interface, Nil, sym.loc)
       IteratorOps.all(
         Iterator(t),
@@ -164,7 +164,7 @@ object SemanticTokensProvider {
       IteratorOps.all(
         Iterator(t),
         visitTypeParams(tparams),
-        Iterator(derives.classes: _*).map {
+        Iterator(derives.traits: _*).map {
           case Ast.Derivation(_, loc) => SemanticToken(SemanticTokenType.Class, Nil, loc)
         },
         cases.foldLeft(Iterator.empty[SemanticToken]) {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
@@ -36,7 +36,7 @@ object SymbolProvider {
 
     val enums = root.enums.values.filter(_.sym.name.startsWith(query)).flatMap(mkEnumSymbolInformation)
     val defs = root.defs.values.collect { case d if d.sym.name.startsWith(query) => mkDefSymbolInformation(d) }
-    val traits = root.classes.values.collect { case t if t.sym.name.startsWith(query) => mkTraitSymbolInformation(t) }
+    val traits = root.traits.values.collect { case t if t.sym.name.startsWith(query) => mkTraitSymbolInformation(t) }
     val sigs = root.sigs.values.collect { case sig if sig.sym.name.startsWith(query) => mkSigSymbolInformation(sig) }
     val effs = root.effects.values.filter(_.sym.name.startsWith(query)).flatMap(mkEffectSymbolInformation)
     (traits ++ defs ++ enums ++ sigs ++ effs).toList
@@ -53,26 +53,26 @@ object SymbolProvider {
 
     val enums = root.enums.values.collect { case enum if enum.loc.source.name == uri => mkEnumDocumentSymbol(enum) }
     val defs = root.defs.values.collect { case d if d.sym.loc.source.name == uri => mkDefDocumentSymbol(d) }
-    val traits = root.classes.values.collect { case t if t.sym.loc.source.name == uri => mkTraitDocumentSymbol(t) }
+    val traits = root.traits.values.collect { case t if t.sym.loc.source.name == uri => mkTraitDocumentSymbol(t) }
     val effs = root.effects.values.collect { case e if e.sym.loc.source.name == uri => mkEffectDocumentSymbol(e) }
     (traits ++ defs ++ enums ++ effs).toList
   }
 
   /**
-    * Returns an Interface SymbolInformation from a Class node.
+    * Returns an Interface SymbolInformation from a Trait node.
     */
-  private def mkTraitSymbolInformation(t: TypedAst.Class) = t match {
-    case TypedAst.Class(_, _, _, sym, _, _, _, _, _, _) => SymbolInformation(
+  private def mkTraitSymbolInformation(t: TypedAst.Trait) = t match {
+    case TypedAst.Trait(_, _, _, sym, _, _, _, _, _, _) => SymbolInformation(
       sym.name, SymbolKind.Interface, Nil, deprecated = false, Location(sym.loc.source.name, Range.from(sym.loc)), None,
     )
   }
 
   /**
-    * Returns an Interface DocumentSymbol from a Class node.
+    * Returns an Interface DocumentSymbol from a Trait node.
     * It navigates the AST and adds Sig and TypeParam of t and as children DocumentSymbols.
     */
-  private def mkTraitDocumentSymbol(t: TypedAst.Class): DocumentSymbol = t match {
-    case TypedAst.Class(doc, _, _, sym, tparam, _, _, signatures, _, _) => DocumentSymbol( // TODO ASSOC-TYPES visit assocs
+  private def mkTraitDocumentSymbol(t: TypedAst.Trait): DocumentSymbol = t match {
+    case TypedAst.Trait(doc, _, _, sym, tparam, _, _, signatures, _, _) => DocumentSymbol( // TODO ASSOC-TYPES visit assocs
       sym.name,
       Some(doc.text),
       SymbolKind.Interface,

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -440,10 +440,10 @@ object Completion {
   /**
     * Represents an Instance completion (based on traits)
     *
-    * @param clazz      the clazz.
+    * @param trt        the trait.
     * @param completion the completion string (used as information for TextEdit).
     */
-  case class InstanceCompletion(clazz: TypedAst.Class, completion: String) extends Completion
+  case class InstanceCompletion(trt: TypedAst.Trait, completion: String) extends Completion
 
   /**
     * Represents an Use completion.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InstanceCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InstanceCompleter.scala
@@ -57,19 +57,19 @@ object InstanceCompleter extends Completer {
     /**
       * Formats the given type `tpe`.
       */
-    def fmtType(trt: TypedAst.Class, tpe: Type, hole: String)(implicit flix: Flix): String =
+    def fmtType(trt: TypedAst.Trait, tpe: Type, hole: String)(implicit flix: Flix): String =
       FormatType.formatType(replaceText(trt.tparam.sym, tpe, hole))
 
     /**
       * Formats the given formal parameters in `spec`.
       */
-    def fmtFormalParams(trt: TypedAst.Class, spec: TypedAst.Spec, hole: String)(implicit flix: Flix): String =
+    def fmtFormalParams(trt: TypedAst.Trait, spec: TypedAst.Spec, hole: String)(implicit flix: Flix): String =
       spec.fparams.map(fparam => s"${fparam.sym.text}: ${fmtType(trt, fparam.tpe, hole)}").mkString(", ")
 
     /**
       * Formats the given signature `sig`.
       */
-    def fmtSignature(trt: TypedAst.Class, sig: TypedAst.Sig, hole: String)(implicit flix: Flix): String = {
+    def fmtSignature(trt: TypedAst.Trait, sig: TypedAst.Sig, hole: String)(implicit flix: Flix): String = {
       val fparams = fmtFormalParams(trt, sig.spec, hole)
       val retTpe = fmtType(trt, sig.spec.retTpe, hole)
       val eff = sig.spec.eff match {
@@ -79,7 +79,7 @@ object InstanceCompleter extends Completer {
       s"    pub def ${sig.sym.name}($fparams): $retTpe$eff = ???"
     }
 
-    root.classes.map {
+    root.traits.map {
       case (_, trt) =>
         val hole = "${1:t}"
         val traitSym = trt.sym
@@ -94,7 +94,7 @@ object InstanceCompleter extends Completer {
   /**
     * Formats the given trait `trt`.
     */
-  def fmtTrait(trt: TypedAst.Class): String = {
+  def fmtTrait(trt: TypedAst.Trait): String = {
     s"trait ${trt.sym.name}[${trt.tparam.name.name}]"
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/WithCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/WithCompleter.scala
@@ -40,25 +40,25 @@ object WithCompleter extends Completer {
 
     if (enumPattern matches context.prefix) {
       for {
-        (_, clazz) <- root.classes
-        sym = clazz.sym
+        (_, trt) <- root.traits
+        sym = trt.sym
         if Resolver.DerivableSyms.contains(sym)
         name = sym.toString
         completion = if (currentWordIsWith) s"with $name" else name
       } yield {
         Completion.WithCompletion(completion, Priority.high(name), TextEdit(context.range, completion),
-          Some(clazz.doc.text), InsertTextFormat.PlainText)
+          Some(trt.doc.text), InsertTextFormat.PlainText)
       }
     } else if (withPattern.matches(context.prefix) || currentWordIsWith) {
-      root.classes.map {
-        case (_, clazz) =>
-          val name = clazz.sym.toString
+      root.traits.map {
+        case (_, trt) =>
+          val name = trt.sym.toString
           val hole = "${1:t}"
           val application = s"$name[$hole]"
           val completion = if (currentWordIsWith) s"with $application" else application
           val label = if (currentWordIsWith) s"with $name[...]" else s"$name[...]"
           Completion.WithCompletion(label, Priority.high(name), TextEdit(context.range, completion),
-            Some(clazz.doc.text), InsertTextFormat.Snippet)
+            Some(trt.doc.text), InsertTextFormat.Snippet)
       }
     } else {
       Nil

--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -699,7 +699,7 @@ object Ast {
     * if the enum is `enum Color {` then the source position would point
     * to the position right after `r` and have zero width.
     */
-  case class Derivations(classes: List[Derivation], loc: SourceLocation)
+  case class Derivations(traits: List[Derivation], loc: SourceLocation)
 
   /**
     * Represents the way a variable is bound.

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -27,7 +27,7 @@ object TypedAst {
   val empty: Root = Root(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, None, Set.empty, Map.empty, Map.empty, ListMap.empty, MultiMap.empty, LabelledPrecedenceGraph.empty)
 
   case class Root(modules: Map[Symbol.ModuleSym, List[Symbol]],
-                  classes: Map[Symbol.TraitSym, Class],
+                  traits: Map[Symbol.TraitSym, Trait],
                   instances: Map[Symbol.TraitSym, List[Instance]],
                   sigs: Map[Symbol.SigSym, Sig],
                   defs: Map[Symbol.DefnSym, Def],
@@ -39,14 +39,14 @@ object TypedAst {
                   entryPoint: Option[Symbol.DefnSym],
                   reachable: Set[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],
-                  classEnv: Map[Symbol.TraitSym, Ast.TraitContext],
+                  traitEnv: Map[Symbol.TraitSym, Ast.TraitContext],
                   eqEnv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef],
                   names: MultiMap[List[String], String],
                   precedenceGraph: LabelledPrecedenceGraph)
 
-  case class Class(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superClasses: List[Ast.TypeConstraint], assocs: List[AssocTypeSig], sigs: List[Sig], laws: List[Def], loc: SourceLocation)
+  case class Trait(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[Ast.TypeConstraint], assocs: List[AssocTypeSig], sigs: List[Sig], laws: List[Def], loc: SourceLocation)
 
-  case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, clazz: Ast.TraitSymUse, tpe: Type, tconstrs: List[Ast.TypeConstraint], assocs: List[AssocTypeDef], defs: List[Def], ns: Name.NName, loc: SourceLocation)
+  case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, trt: Ast.TraitSymUse, tpe: Type, tconstrs: List[Ast.TypeConstraint], assocs: List[AssocTypeDef], defs: List[Def], ns: Name.NName, loc: SourceLocation)
 
   case class Sig(sym: Symbol.SigSym, spec: Spec, exp: Option[Expr])
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -56,7 +56,7 @@ object Deriver {
       lazy val toStringSym = PredefinedTraits.lookupTraitSym("ToString", root)
       lazy val hashSym = PredefinedTraits.lookupTraitSym("Hash", root)
       lazy val sendableSym = PredefinedTraits.lookupTraitSym("Sendable", root)
-      val instanceVals = Validation.traverse(derives.classes) {
+      val instanceVals = Validation.traverse(derives.traits) {
         case Ast.Derivation(traitSym, loc) if cases.isEmpty => Validation.toSoftFailure(None, DerivationError.IllegalDerivationForEmptyEnum(enumSym, traitSym, loc))
         case Ast.Derivation(sym, loc) if sym == eqSym => mapN(mkEqInstance(enum0, loc, root))(Some(_))
         case Ast.Derivation(sym, loc) if sym == orderSym => mapN(mkOrderInstance(enum0, loc, root))(Some(_))

--- a/main/src/ca/uwaterloo/flix/language/phase/EntryPoint.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EntryPoint.scala
@@ -67,7 +67,7 @@ object EntryPoint {
     flatMapN(findOriginalEntryPoint(root)) {
       // Case 1: We have an entry point. Wrap it.
       case Some(entryPoint0) =>
-        mapN(visitEntryPoint(entryPoint0, root, root.classEnv)) {
+        mapN(visitEntryPoint(entryPoint0, root, root.traitEnv)) {
           entryPoint =>
             root.copy(
               defs = root.defs + (entryPoint.sym -> entryPoint),
@@ -188,7 +188,7 @@ object EntryPoint {
         Validation.success(())
       } else {
         // Delay ToString resolution if main has return type unit for testing with lib nix.
-        val toString = root.classes(new Symbol.TraitSym(Nil, "ToString", SourceLocation.Unknown)).sym
+        val toString = root.traits(new Symbol.TraitSym(Nil, "ToString", SourceLocation.Unknown)).sym
         if (TraitEnvironment.holds(Ast.TypeConstraint(Ast.TypeConstraint.Head(toString, SourceLocation.Unknown), resultTpe, SourceLocation.Unknown), traitEnv)) {
           // Case 2: XYZ -> a with ToString[a]
           Validation.success(())

--- a/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/HtmlDocumentor.scala
@@ -270,7 +270,7 @@ object HtmlDocumentor {
     * Extracts all relevant information about the given `TraitSym` from the root, into a `HtmlDocumentor.Trait`.
     */
   private def mkTrait(sym: Symbol.TraitSym, parent: Symbol.ModuleSym, companionMod: Option[Module], root: TypedAst.Root): Trait = {
-    val decl = root.classes(sym)
+    val decl = root.traits(sym)
 
     val (sigs, defs) = decl.sigs.partition(_.exp.isEmpty)
     val instances = root.instances.getOrElse(sym, Nil)
@@ -344,15 +344,15 @@ object HtmlDocumentor {
     * but with all items that shouldn't appear in the documentation removed.
     */
   private def filterTrait(trt: Trait): Trait = trt match {
-    case Trait(TypedAst.Class(doc, ann, mod, sym, tparam, superClasses, assocs, _, laws, loc), signatures, defs, instances, parent, companionMod) =>
+    case Trait(TypedAst.Trait(doc, ann, mod, sym, tparam, superTraits, assocs, _, laws, loc), signatures, defs, instances, parent, companionMod) =>
       Trait(
-        TypedAst.Class(
+        TypedAst.Trait(
           doc,
           ann,
           mod,
           sym,
           tparam,
-          superClasses,
+          superTraits,
           assocs,
           Nil,
           laws.filter(l => l.spec.mod.isPublic && !l.spec.ann.isInternal),
@@ -590,7 +590,7 @@ object HtmlDocumentor {
     sb.append("<span class='keyword'>trait</span> ")
     sb.append(s"<span class='name'>${esc(trt.name)}</span>")
     docTypeParams(List(trt.decl.tparam))
-    docTypeConstraints(trt.decl.superClasses)
+    docTypeConstraints(trt.decl.superTraits)
     sb.append("</code>")
     docActions(None, trt.decl.loc)
     sb.append("</div>")
@@ -1120,14 +1120,14 @@ object HtmlDocumentor {
     * If `derives` contains no elements, nothing will be generated.
     */
   private def docDerivations(derives: Ast.Derivations)(implicit flix: Flix, sb: StringBuilder): Unit = {
-    if (derives.classes.isEmpty) {
+    if (derives.traits.isEmpty) {
       return
     }
 
     sb.append("<span> <span class='keyword'>with</span> ")
-    docList(derives.classes.sortBy(_.loc)) { c =>
-      sb.append(s"<a class='tpe-constraint' href='${escUrl(traitFileName(c.trt))}' title='trait ${esc(traitName(c.trt))}'>")
-      sb.append(s"${esc(c.trt.name)}")
+    docList(derives.traits.sortBy(_.loc)) { t =>
+      sb.append(s"<a class='tpe-constraint' href='${escUrl(traitFileName(t.trt))}' title='trait ${esc(traitName(t.trt))}'>")
+      sb.append(s"${esc(t.trt.name)}")
       sb.append("</a>")
     }
     sb.append("</span>")
@@ -1455,7 +1455,7 @@ object HtmlDocumentor {
   /**
     * A representation of a trait that's easier to work with while generating documentation.
     */
-  private case class Trait(decl: TypedAst.Class,
+  private case class Trait(decl: TypedAst.Trait,
                            signatures: List[TypedAst.Sig],
                            defs: List[TypedAst.Sig],
                            instances: List[TypedAst.Instance],

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -38,16 +38,16 @@ object Instances {
     * Validates all instances in the given AST root.
     */
   private def visitTraits(root: TypedAst.Root)(implicit flix: Flix): List[InstanceError] = {
-    val results = ParOps.parMap(root.classes.values)(visitTrait)
+    val results = ParOps.parMap(root.traits.values)(visitTrait)
     results.flatten.toList
   }
 
   /**
     * Checks that all signatures in `trait0` are used in laws if `trait0` is marked `lawful`.
     */
-  private def checkLawApplication(trait0: TypedAst.Class): List[InstanceError] = trait0 match {
+  private def checkLawApplication(trait0: TypedAst.Trait): List[InstanceError] = trait0 match {
     // Case 1: lawful trait
-    case TypedAst.Class(_, _, mod, _, _, _, _, sigs, laws, _) if mod.isLawful =>
+    case TypedAst.Trait(_, _, mod, _, _, _, _, sigs, laws, _) if mod.isLawful =>
       val usedSigs = laws.foldLeft(Set.empty[Symbol.SigSym]) {
         case (acc, TypedAst.Def(_, _, exp)) => acc ++ TypedAstOps.sigSymsOf(exp)
       }
@@ -56,13 +56,13 @@ object Instances {
         sig => InstanceError.UnlawfulSignature(sig, sig.loc)
       }
     // Case 2: non-lawful trait
-    case TypedAst.Class(_, _, _, _, _, _, _, _, _, _) => Nil
+    case TypedAst.Trait(_, _, _, _, _, _, _, _, _, _) => Nil
   }
 
   /**
     * Performs validations on a single trait.
     */
-  private def visitTrait(trait0: TypedAst.Class): List[InstanceError] = {
+  private def visitTrait(trait0: TypedAst.Trait): List[InstanceError] = {
     checkLawApplication(trait0)
   }
 
@@ -142,25 +142,25 @@ object Instances {
         // Case 2: An instance matching this type exists. Error.
         case Some(inst2) =>
           List(
-            InstanceError.OverlappingInstances(inst1.clazz.sym, inst1.clazz.loc, inst2.clazz.loc),
-            InstanceError.OverlappingInstances(inst1.clazz.sym, inst2.clazz.loc, inst1.clazz.loc)
+            InstanceError.OverlappingInstances(inst1.trt.sym, inst1.trt.loc, inst2.trt.loc),
+            InstanceError.OverlappingInstances(inst1.trt.sym, inst2.trt.loc, inst1.trt.loc)
           )
       }
     }
   }
 
   /**
-    * Checks that every signature in `clazz` is implemented in `inst`, and that `inst` does not have any extraneous definitions.
+    * Checks that every signature in `trt` is implemented in `inst`, and that `inst` does not have any extraneous definitions.
     */
   private def checkSigMatch(inst: TypedAst.Instance, root: TypedAst.Root)(implicit flix: Flix): List[InstanceError] = {
-    val clazz = root.classes(inst.clazz.sym)
+    val clazz = root.traits(inst.trt.sym)
 
     // Step 1: check that each signature has an implementation.
     val sigMatchVal = clazz.sigs.flatMap {
       sig =>
         (inst.defs.find(_.sym.text == sig.sym.name), sig.exp) match {
           // Case 1: there is no definition with the same name, and no default implementation
-          case (None, None) => List(InstanceError.MissingImplementation(sig.sym, inst.clazz.loc))
+          case (None, None) => List(InstanceError.MissingImplementation(sig.sym, inst.trt.loc))
           // Case 2: there is no definition with the same name, but there is a default implementation
           case (None, Some(_)) => Nil
           // Case 3: there is an implementation marked override, but no default implementation
@@ -170,7 +170,7 @@ object Instances {
           // Case 5: there is an implementation with the right modifier
           case (Some(defn), _) =>
             val expectedScheme = Scheme.partiallyInstantiate(sig.spec.declaredScheme, clazz.tparam.sym, inst.tpe, defn.sym.loc)
-            if (Scheme.equal(expectedScheme, defn.spec.declaredScheme, root.classEnv, root.eqEnv)) {
+            if (Scheme.equal(expectedScheme, defn.spec.declaredScheme, root.traitEnv, root.eqEnv)) {
               // Case 5.1: the schemes match. Success!
               Nil
             } else {
@@ -183,7 +183,7 @@ object Instances {
     val extraDefVal = inst.defs.flatMap {
       defn =>
         clazz.sigs.find(_.sym.name == defn.sym.text) match {
-          case None => List(InstanceError.ExtraneousDef(defn.sym, inst.clazz.sym, defn.sym.loc))
+          case None => List(InstanceError.ExtraneousDef(defn.sym, inst.trt.sym, defn.sym.loc))
           case _ => Nil
         }
     }
@@ -195,7 +195,7 @@ object Instances {
     * Finds an instance of the trait for a given type.
     */
   def findInstanceForType(tpe: Type, clazz: Symbol.TraitSym, root: TypedAst.Root)(implicit flix: Flix): Option[(Ast.Instance, Substitution)] = {
-    val superInsts = root.classEnv.get(clazz).map(_.instances).getOrElse(Nil)
+    val superInsts = root.traitEnv.get(clazz).map(_.instances).getOrElse(Nil)
     // lazily find the instance whose type unifies and save the substitution
     ListOps.findMap(superInsts) {
       superInst =>
@@ -211,7 +211,7 @@ object Instances {
     */
   private def checkSuperInstances(inst: TypedAst.Instance, root: TypedAst.Root)(implicit flix: Flix): List[InstanceError] = inst match {
     case TypedAst.Instance(_, _, _, clazz, tpe, tconstrs, _, _, _, _) =>
-      val superTraits = root.classEnv(clazz.sym).superTraits
+      val superTraits = root.traitEnv(clazz.sym).superTraits
       superTraits flatMap {
         superTrait =>
           // Find the instance of the super trait matching the type of this instance.
@@ -220,7 +220,7 @@ object Instances {
               // Case 1: An instance matches. Check that its constraints are entailed by this instance.
               superInst.tconstrs flatMap {
                 tconstr =>
-                  TraitEnvironment.entail(tconstrs.map(subst.apply), subst(tconstr), root.classEnv).toHardResult match {
+                  TraitEnvironment.entail(tconstrs.map(subst.apply), subst(tconstr), root.traitEnv).toHardResult match {
                     case Result.Ok(_) => Nil
                     case Result.Err(errors) => errors.map {
                       case UnificationError.NoMatchingInstance(missingTconstr) => InstanceError.MissingTraitConstraint(missingTconstr, superTrait, clazz.loc)
@@ -239,7 +239,7 @@ object Instances {
     * Reassembles an instance
     */
   private def checkInstance(inst: TypedAst.Instance, root: TypedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): List[InstanceError] = {
-    val isTraitStable = inst.clazz.loc.source.stable
+    val isTraitStable = inst.trt.loc.source.stable
     val isInstanceStable = inst.loc.source.stable
     val isIncremental = changeSet.isInstanceOf[ChangeSet.Changes]
     if (isIncremental && isTraitStable && isInstanceStable) {
@@ -277,12 +277,12 @@ object Instances {
   /**
     * Retrieves the head of a simple instance.
     *
-    * The head of an instance `Clazz[T[a, b, c]]` is T
+    * The head of an instance `Trait[T[a, b, c]]` is T
     */
   private def unsafeGetHead(inst: TypedAst.Instance): TypeConstructor = {
     inst.tpe.typeConstructor match {
       case Some(tc) => tc
-      case None => throw InternalCompilerException("unexpected non-simple type",  inst.clazz.loc)
+      case None => throw InternalCompilerException("unexpected non-simple type",  inst.trt.loc)
     }
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -154,13 +154,13 @@ object Lowering {
 
     // TypedAst.Sigs are shared between the `sigs` field and the `classes` field.
     // Instead of visiting twice, we visit the `sigs` field and then look up the results when visiting traits.
-    val traits = ParOps.parMapValues(root.classes)(t => visitTrait(t, sigs))
+    val traits = ParOps.parMapValues(root.traits)(t => visitTrait(t, sigs))
 
     val newEnums = enums ++ restrictableEnums.map {
       case (_, v) => v.sym -> v
     }
 
-    LoweredAst.Root(traits, instances, sigs, defs, newEnums, effects, aliases, root.entryPoint, root.reachable, root.sources, root.classEnv, root.eqEnv)
+    LoweredAst.Root(traits, instances, sigs, defs, newEnums, effects, aliases, root.entryPoint, root.reachable, root.sources, root.traitEnv, root.eqEnv)
   }
 
   /**
@@ -295,8 +295,8 @@ object Lowering {
   /**
     * Lowers the given trait `trt0`, with the given lowered sigs `sigs`.
     */
-  private def visitTrait(trt0: TypedAst.Class, sigs: Map[Symbol.SigSym, LoweredAst.Sig])(implicit root: TypedAst.Root, flix: Flix): LoweredAst.Trait = trt0 match {
-    case TypedAst.Class(doc, ann, mod, sym, tparam0, superTraits0, assocs0, signatures0, laws0, loc) =>
+  private def visitTrait(trt0: TypedAst.Trait, sigs: Map[Symbol.SigSym, LoweredAst.Sig])(implicit root: TypedAst.Root, flix: Flix): LoweredAst.Trait = trt0 match {
+    case TypedAst.Trait(doc, ann, mod, sym, tparam0, superTraits0, assocs0, signatures0, laws0, loc) =>
       val tparam = visitTypeParam(tparam0)
       val superTraits = superTraits0.map(visitTypeConstraint)
       val assocs = assocs0.map {

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -111,7 +111,7 @@ object PatMatch {
     flix.phase("PatMatch") {
       implicit val r: TypedAst.Root = root
 
-      val classDefExprs = root.classes.values.flatMap(_.sigs).flatMap(_.exp)
+      val classDefExprs = root.traits.values.flatMap(_.sigs).flatMap(_.exp)
       val classDefErrs = ParOps.parMap(classDefExprs)(visitExp).flatten
 
       val defErrs = ParOps.parMap(root.defs.values)(defn => visitExp(defn.exp)).flatten

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -37,8 +37,8 @@ object PredDeps {
     // Compute an over-approximation of the dependency graph for all constraints in the program.
     val defExps = root.defs.values.map(_.exp)
     val instanceExps = root.instances.values.flatten.flatMap(_.defs).map(_.exp)
-    val classExps = root.classes.values.flatMap(c => c.laws.map(_.exp) ++ c.sigs.flatMap(_.exp))
-    val allExps = defExps ++ instanceExps ++ classExps
+    val traitExps = root.traits.values.flatMap(t => t.laws.map(_.exp) ++ t.sigs.flatMap(_.exp))
+    val allExps = defExps ++ instanceExps ++ traitExps
 
     val g = ParOps.parAgg(allExps, LabelledPrecedenceGraph.empty)({
       case (acc, d) => acc + visitExp(d)

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -149,7 +149,7 @@ object Redundancy {
     */
   private def checkRedundantTypeConstraints()(implicit root: Root, flix: Flix): List[RedundancyError] = {
     val defErrors = ParOps.parMap(root.defs.values)(defn => redundantTypeConstraints(defn.spec.declaredScheme.tconstrs))
-    val classErrors = ParOps.parMap(root.classes.values)(clazz => redundantTypeConstraints(clazz.superClasses))
+    val classErrors = ParOps.parMap(root.traits.values)(trt => redundantTypeConstraints(trt.superTraits))
     val instErrors = ParOps.parMap(root.instances.values.flatten)(inst => redundantTypeConstraints(inst.tconstrs))
     val sigErrors = ParOps.parMap(root.sigs.values)(sig => redundantTypeConstraints(sig.spec.declaredScheme.tconstrs))
 
@@ -164,7 +164,7 @@ object Redundancy {
       (tconstr1, i1) <- tconstrs.zipWithIndex
       (tconstr2, i2) <- tconstrs.zipWithIndex
       // don't compare a constraint against itself
-      if i1 != i2 && TraitEnvironment.entails(tconstr1, tconstr2, root.classEnv)
+      if i1 != i2 && TraitEnvironment.entails(tconstr1, tconstr2, root.traitEnv)
     } yield RedundancyError.RedundantTypeConstraint(tconstr1, tconstr2, tconstr2.loc)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -32,7 +32,7 @@ object Safety {
     //
     // Collect all errors.
     //
-    val classSigErrs = ParOps.parMap(root.classes.values.flatMap(_.sigs))(visitSig).flatten
+    val classSigErrs = ParOps.parMap(root.traits.values.flatMap(_.sigs))(visitSig).flatten
     val defErrs = ParOps.parMap(root.defs.values)(visitDef).flatten
     val instanceDefErrs = ParOps.parMap(TypedAstOps.instanceDefsOf(root))(visitDef).flatten
     val sigErrs = ParOps.parMap(root.sigs.values)(visitSig).flatten

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -52,17 +52,17 @@ object Stratifier {
     // Compute the stratification at every datalog expression in the ast.
     val newDefs = ParOps.parTraverseValues(root.defs)(visitDef(_))
     val newInstances = ParOps.parTraverseValues(root.instances)(traverse(_)(visitInstance(_)))
-    val newTraits = ParOps.parTraverseValues(root.classes)(visitTrait(_))
+    val newTraits = ParOps.parTraverseValues(root.traits)(visitTrait(_))
 
     mapN(newDefs, newInstances, newTraits) {
-      case (ds, is, ts) => root.copy(defs = ds, instances = is, classes = ts)
+      case (ds, is, ts) => root.copy(defs = ds, instances = is, traits = ts)
     }
   }
 
   /**
     * Performs Stratification of the given trait `t0`.
     */
-  private def visitTrait(t0: TypedAst.Class)(implicit root: Root, g: LabelledPrecedenceGraph, flix: Flix): Validation[TypedAst.Class, StratificationError] = {
+  private def visitTrait(t0: TypedAst.Trait)(implicit root: Root, g: LabelledPrecedenceGraph, flix: Flix): Validation[TypedAst.Trait, StratificationError] = {
     val newLaws = traverse(t0.laws)(visitDef(_))
     val newSigs = traverse(t0.sigs)(visitSig(_))
     mapN(newLaws, newSigs) {

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -29,7 +29,7 @@ object CodeHinter {
     * Returns a collection of code quality hints for the given AST `root`.
     */
   def run(root: TypedAst.Root, sources: Set[String])(implicit flix: Flix, index: Index): List[CodeHint] = {
-    val traitHints = root.classes.values.flatMap(visitTrait(_)(root, index)).toList
+    val traitHints = root.traits.values.flatMap(visitTrait(_)(root, index)).toList
     val defsHints = root.defs.values.flatMap(visitDef(_)(root, flix)).toList
     val enumsHints = root.enums.values.flatMap(visitEnum(_)(root, index)).toList
     (traitHints ++ defsHints ++ enumsHints).filter(include(_, sources))
@@ -58,7 +58,7 @@ object CodeHinter {
   /**
     * Computes code quality hints for the given trait `trt`.
     */
-  private def visitTrait(trt: TypedAst.Class)(implicit root: Root, index: Index): List[CodeHint] = {
+  private def visitTrait(trt: TypedAst.Trait)(implicit root: Root, index: Index): List[CodeHint] = {
     val uses = index.usesOf(trt.sym)
     val isDeprecated = trt.ann.isDeprecated
     val deprecated = if (isDeprecated) uses.map(CodeHint.Deprecated) else Nil

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -197,16 +197,16 @@ class Shell(bootstrap: Bootstrap, options: Options) {
     */
   private def execInfo(s: String)(implicit terminal: Terminal): Unit = {
     val w = terminal.writer()
-    val classSym = Symbol.mkTraitSym(s)
+    val traitSym = Symbol.mkTraitSym(s)
     val defnSym = Symbol.mkDefnSym(s)
     val enumSym = Symbol.mkEnumSym(s)
     val aliasSym = Symbol.mkTypeAliasSym(s)
 
     root match {
       case Some(r) =>
-        if (r.classes.contains(classSym)) {
-          val classDecl = r.classes(classSym)
-          w.println(FormatDoc.asMarkDown(classDecl.doc))
+        if (r.traits.contains(traitSym)) {
+          val traitDecl = r.traits(traitSym)
+          w.println(FormatDoc.asMarkDown(traitDecl.doc))
         } else if (r.defs.contains(defnSym)) {
           val defDecl = r.defs(defnSym)
           w.println(FormatSignature.asMarkDown(defDecl))

--- a/main/src/ca/uwaterloo/flix/tools/Summary.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Summary.scala
@@ -74,7 +74,7 @@ object Summary {
       for ((source, loc) <- root.sources.toList.sortBy(_._1.name)) {
         val module = source.name
         val defs = getFunctions(source, root) ++
-          getClassFunctions(source, root) ++
+          getTraitFunctions(source, root) ++
           getInstanceFunctions(source, root)
 
         val numberOfLines = loc.endLine
@@ -129,14 +129,14 @@ object Summary {
     }
 
   /**
-    * Returns the [[Spec]] of all class functions in the given `source`.
+    * Returns the [[Spec]] of all trait functions in the given `source`.
     *
     * Note: This means signatures that have an implementation (i.e. body expression).
     */
-  private def getClassFunctions(source: Ast.Source, root: Root): Iterable[Spec] =
-    root.classes.collect {
-      case (sym, clazz) if sym.loc.source == source =>
-        clazz.sigs.collect {
+  private def getTraitFunctions(source: Ast.Source, root: Root): Iterable[Spec] =
+    root.traits.collect {
+      case (sym, trt) if sym.loc.source == source =>
+        trt.sigs.collect {
           case sig if sig.exp.nonEmpty => sig.spec
         }
     }.flatten


### PR DESCRIPTION
This PR renames `TypedAst.Class` to `TypedAst.Trait` and renames field labels in `TypedAst.Root`.

It also renames field labels in `Completion.InstanceCompletion` and `Ast.Derivations`
