### PR TITLE
chore: rename lsp Entity.Class to Entity.Trait (issue #6591)

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Entity.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Entity.scala
@@ -67,7 +67,7 @@ object Entity {
     def precision: Precision = Precision.High
   }
 
-  case class Class(e: TypedAst.Trait) extends Entity {
+  case class Trait(e: TypedAst.Trait) extends Entity {
     def loc: SourceLocation = e.sym.loc
     def precision: Precision = Precision.High
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Index.scala
@@ -37,7 +37,7 @@ object Index {
   /**
     * Returns an index for the given `trait0`.
     */
-  def occurrenceOf(trait0: TypedAst.Trait): Index = empty + Entity.Class(trait0)
+  def occurrenceOf(trait0: TypedAst.Trait): Index = empty + Entity.Trait(trait0)
 
   /**
     * Returns an index for the given `case0`.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
@@ -31,7 +31,7 @@ object FindReferencesProvider {
 
         case Entity.Case(caze) => findCaseReferences(caze.sym)
 
-        case Entity.Class(trait0) => findTraitReferences(trait0.sym)
+        case Entity.Trait(trait0) => findTraitReferences(trait0.sym)
 
         case Entity.Def(defn) => findDefReferences(defn.sym)
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
@@ -72,7 +72,7 @@ object GotoProvider {
             ("status" -> ResponseStatus.Success) ~ ("result" -> LocationLink.fromOpSym(sym, loc).toJSON)
 
           case Entity.Case(_) => mkNotFound(uri, pos)
-          case Entity.Class(_) => mkNotFound(uri, pos)
+          case Entity.Trait(_) => mkNotFound(uri, pos)
           case Entity.Def(_) => mkNotFound(uri, pos)
           case Entity.Effect(_) => mkNotFound(uri, pos)
           case Entity.Enum(_) => mkNotFound(uri, pos)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
@@ -82,7 +82,7 @@ object HighlightProvider {
 
         case Entity.OpUse(sym, _, _) => highlightOp(sym)
 
-        case Entity.Class(_) => mkNotFound(uri, pos)
+        case Entity.Trait(_) => mkNotFound(uri, pos)
         case Entity.TypeVar(_) => mkNotFound(uri, pos)
       }
     }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HoverProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HoverProvider.scala
@@ -64,7 +64,7 @@ object HoverProvider {
 
     case Entity.OpUse(sym, loc, _) => hoverOp(sym, loc, current).getOrElse(mkNotFound(uri, pos))
 
-    case Entity.Class(_) => mkNotFound(uri, pos)
+    case Entity.Trait(_) => mkNotFound(uri, pos)
     case Entity.Def(_) => mkNotFound(uri, pos)
     case Entity.Effect(_) => mkNotFound(uri, pos)
     case Entity.Enum(_) => mkNotFound(uri, pos)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/RenameProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/RenameProvider.scala
@@ -70,7 +70,7 @@ object RenameProvider {
           case _ => mkNotFound(uri, pos)
         }
 
-        case Entity.Class(_) => mkNotFound(uri, pos)
+        case Entity.Trait(_) => mkNotFound(uri, pos)
         case Entity.AssocType(_) => mkNotFound(uri, pos)
         case Entity.Effect(_) => mkNotFound(uri, pos)
         case Entity.Enum(_) => mkNotFound(uri, pos)


### PR DESCRIPTION
This PR Renames `Entity.Class` to `Entity.Trait`.