### PR TITLE
feat: add `TryWith` and `Do` to `Verifier`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -455,24 +455,24 @@ object Verifier {
 
       checkEq(tpe, exptype, loc)
 
-    case Expr.Do(op, exps, tpe, purity, loc) =>
+    case Expr.Do(opUse, exps, tpe, purity, loc) =>
       val ts = exps.map(visitExpr)
-      val eff = root.effects.getOrElse(op.sym.eff,
-        throw InternalCompilerException(s"Unknown effect sym: '${op.sym.eff}'", loc))
-      val opp = eff.ops.find(_.sym == op.sym)
-        .getOrElse(throw InternalCompilerException(s"Unknown operation sym: '${op.sym}'", loc))
+      val eff = root.effects.getOrElse(opUse.sym.eff,
+        throw InternalCompilerException(s"Unknown effect sym: '${opUse.sym.eff}'", loc))
+      val op = eff.ops.find(_.sym == opUse.sym)
+        .getOrElse(throw InternalCompilerException(s"Unknown operation sym: '${opUse.sym}'", loc))
 
       // TODO: VERIFIER: fix this weird special case if Void is return type of operation
       // fails in 'main/test/flix/Test.Type.Void.flix:16:13' (cases on lines 16, 24, 40)
       // see https://github.com/flix/flix/blob/7136d0b7363b2a70d59e5be8608298eeebd0caac/main/src/ca/uwaterloo/flix/language/phase/TypeInference.scala#L969
-      val oprestype = opp.tpe match {
+      val oprestype = op.tpe match {
         case MonoType.Native(_) => tpe // just assume `tpe` is correct for now
         case t => t
       }
 
       val sig = MonoType.Arrow(ts, tpe)
       val opsig = MonoType.Arrow(
-        opp.fparams.map(_.tpe), oprestype
+        op.fparams.map(_.tpe), oprestype
       )
 
       checkEq(sig, opsig, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -20,6 +20,7 @@ import ca.uwaterloo.flix.language.ast.Ast.Constant
 import ca.uwaterloo.flix.language.ast.ReducedAst._
 import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoType, Name, SemanticOp, SourceLocation, Symbol}
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
+import scala.annotation.tailrec
 
 /**
   * Verify the AST before bytecode generation.
@@ -503,7 +504,7 @@ object Verifier {
   private def check(expected: MonoType)(actual: MonoType, loc: SourceLocation): MonoType = {
     if (expected == actual)
       expected
-    else failUnexpectedType(expected, actual, loc)
+    else failUnexpectedType(actual, expected, loc)
   }
 
   /**
@@ -534,6 +535,7 @@ object Verifier {
     * Get the type associated with `label` in the given record type `rec`.
     * If `rec` is not a record, return `None`
     */
+  @tailrec
   private def selectFromRecordType(rec: MonoType, label: String, loc: SourceLocation): Option[MonoType] = rec match {
     case MonoType.RecordExtend(lbl, valtype, rest) =>
       if (lbl == label)

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -474,11 +474,8 @@ object Verifier {
       val op = eff.ops.find(_.sym == opUse.sym)
         .getOrElse(throw InternalCompilerException(s"Unknown operation sym: '${opUse.sym}'", loc))
 
-      // TODO: VERIFIER: fix this weird special case if Void is return type of operation
-      // fails in 'main/test/flix/Test.Type.Void.flix:16:13' (cases on lines 16, 24, 40)
-      // see https://github.com/flix/flix/blob/7136d0b7363b2a70d59e5be8608298eeebd0caac/main/src/ca/uwaterloo/flix/language/phase/TypeInference.scala#L969
       val oprestype = op.tpe match {
-        case MonoType.Native(_) => tpe // just assume `tpe` is correct for now
+        case MonoType.Void => tpe // should match any return type
         case t => t
       }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -445,10 +445,8 @@ object Verifier {
 
     case Expr.TryWith(exp, effUse, rules, ct, tpe, purity, loc) =>
       val exptype = visitExpr(exp) match {
-        case MonoType.Arrow(List(u), t) =>
-          check(expected = MonoType.Unit)(actual = u, loc)
-          t
-        case e => failMismatchedShape(e, "Arrow with one parameter", loc)
+        case MonoType.Arrow(List(MonoType.Unit), t) => t
+        case e => failMismatchedShape(e, "Arrow(List(Unit), _)", loc)
       }
 
       val effect = root.effects.getOrElse(effUse.sym,


### PR DESCRIPTION
In the case where the return type of an effects operation is `Void`, `op.tpe` has type `MonoType.Native(java.lang.Object)`. However, this doesn't match with the associated type of `Do.Expr` expressions reffering to such operations. 
Is this expected? Looks like it has something to do with the way void is handled during the TypeInference-phase (now removed...). More details in TODO comment.