### PR TITLE
chore: bump actions upload artifact

### DIFF
--- a/.github/workflows/jar-on-demand.yaml
+++ b/.github/workflows/jar-on-demand.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Build
         run: ./gradlew jar
       - name: Upload feature phases results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: JAR
           path: build/libs/flix.jar


### PR DESCRIPTION
I forgot to update `actions/upload-artifact` in `jar-on-demand`

Related to https://github.com/flix/flix/pull/7474
Related to https://github.com/flix/flix/issues/7467