### PR TITLE
feat: add `Box`, `Unbox`, `Cast` to `Verifier`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -42,6 +42,7 @@ object Verifier {
     visitExpr(decl.expr)(root, env, Map.empty)
   }
 
+  private val boxtype = MonoType.Native(new java.lang.Object().getClass)
 
   private def visitExpr(expr: Expr)(implicit root: Root, env: Map[Symbol.VarSym, MonoType], lenv: Map[Symbol.LabelSym, MonoType]): MonoType = expr match {
 
@@ -355,6 +356,18 @@ object Verifier {
           val actual = MonoType.Arrow(ts, tpe)
 
           checkEq(decl, actual, loc)
+          tpe
+
+        case AtomicOp.Box =>
+          check(expected = boxtype)(actual = tpe, loc)
+
+        case AtomicOp.Unbox =>
+          val List(t1) = ts
+          check(expected = boxtype)(actual = t1, loc)
+          tpe
+
+        // cast may result in any type
+        case AtomicOp.Cast =>
           tpe
 
         case _ => tpe // TODO: VERIFIER: Add rest

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -42,6 +42,7 @@ object Verifier {
     visitExpr(decl.expr)(root, env, Map.empty)
   }
 
+
   private def visitExpr(expr: Expr)(implicit root: Root, env: Map[Symbol.VarSym, MonoType], lenv: Map[Symbol.LabelSym, MonoType]): MonoType = expr match {
 
     case Expr.Cst(cst, tpe, loc) => cst match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -42,8 +42,6 @@ object Verifier {
     visitExpr(decl.expr)(root, env, Map.empty)
   }
 
-  private val boxtype = MonoType.Native(new java.lang.Object().getClass)
-
   private def visitExpr(expr: Expr)(implicit root: Root, env: Map[Symbol.VarSym, MonoType], lenv: Map[Symbol.LabelSym, MonoType]): MonoType = expr match {
 
     case Expr.Cst(cst, tpe, loc) => cst match {
@@ -359,11 +357,11 @@ object Verifier {
           tpe
 
         case AtomicOp.Box =>
-          check(expected = boxtype)(actual = tpe, loc)
+          check(expected = MonoType.Object)(actual = tpe, loc)
 
         case AtomicOp.Unbox =>
           val List(t1) = ts
-          check(expected = boxtype)(actual = t1, loc)
+          check(expected = MonoType.Object)(actual = t1, loc)
           tpe
 
         // cast may result in any type


### PR DESCRIPTION
In its current state, this PR doesn't change anything, since the verifier never encounters `Box`/`Unbox`. Before the `TailPos` phase is completed, there are no `MonoType.Box`/`Unbox` occurances within the Ast. However, moving the verifier below `Eraser` introduces test-failures in other cases (with e.g. `IfThenElse` and `Let`).