### PR TITLE
feat: add `MonoType.Void`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
@@ -28,6 +28,11 @@ object MonoType {
   /// Primitive Types.
   ///
 
+  /**
+    * Represents an uninhabited type, not an absent value like in Java.
+    */
+  case object Void extends MonoType
+
   case object AnyType extends MonoType
 
   case object Unit extends MonoType

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -327,6 +327,8 @@ object DocAst {
     /** inserted string printed as-is (assumed not to require parenthesis) */
     case class Meta(s: String) extends Atom
 
+    val Void: Type = AsIs("Void")
+
     val AnyType: Type = AsIs("AnyType")
 
     val Unknown: Type = Meta("unknown type")

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypePrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoTypePrinter.scala
@@ -25,6 +25,7 @@ object MonoTypePrinter {
     * Returns the [[Type]] representation of `tpe`.
     */
   def print(tpe: MonoType): Type = tpe match {
+    case MonoType.Void => Type.Void
     case MonoType.AnyType => Type.AnyType
     case MonoType.Unit => Type.Unit
     case MonoType.Bool => Type.Bool

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -185,6 +185,7 @@ object Eraser {
   private def visitType(tpe: MonoType): MonoType = {
     import MonoType._
     tpe match {
+      case Void => Void
       case AnyType => AnyType
       case Unit => Unit
       case Bool => Bool
@@ -223,8 +224,8 @@ object Eraser {
       case Int16 => Int16
       case Int32 => Int32
       case Int64 => Int64
-      case AnyType | Unit | BigDecimal | BigInt | String | Regex | Region |
-           Array(_) | Lazy(_) | Ref(_) | Tuple(_) | MonoType.Enum(_) |
+      case Void |AnyType | Unit | BigDecimal | BigInt | String | Regex |
+           Region | Array(_) | Lazy(_) | Ref(_) | Tuple(_) | MonoType.Enum(_) |
            Arrow(_, _) | RecordEmpty | RecordExtend(_, _, _) | Native(_) =>
         MonoType.Object
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -220,9 +220,9 @@ object Reducer {
     types.dequeueOption match {
       case Some((tpe, taskList)) =>
         val taskList1 = tpe match {
-          case AnyType | Unit | Bool | Char | Float32 | Float64 | BigDecimal | Int8 |
-               Int16 | Int32 | Int64 | BigInt | String | Regex | Region | Enum(_) |
-               RecordEmpty | Native(_) => taskList
+          case Void | AnyType | Unit | Bool | Char | Float32 | Float64 | BigDecimal | Int8 | Int16 |
+               Int32 | Int64 | BigInt | String | Regex | Region | Enum(_) | RecordEmpty |
+               Native(_) => taskList
           case Array(elm) => taskList.enqueue(elm)
           case Lazy(elm) => taskList.enqueue(elm)
           case Ref(elm) => taskList.enqueue(elm)

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -232,9 +232,7 @@ object Simplifier {
 
       case Some(tc) =>
         tc match {
-          case TypeConstructor.Void =>
-            // Java does not have a bottom type, so we map `Void` to `Object`.
-            MonoType.Object
+          case TypeConstructor.Void => MonoType.Void
 
           case TypeConstructor.AnyType => MonoType.AnyType
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendType.scala
@@ -162,6 +162,7 @@ object BackendType {
     */
   def toBackendType(tpe0: MonoType): BackendType = {
     tpe0 match {
+      case MonoType.Void => BackendObjType.JavaObject.toTpe
       case MonoType.AnyType => BackendObjType.JavaObject.toTpe
       case MonoType.Unit => BackendObjType.Unit.toTpe
       case MonoType.Bool => BackendType.Bool
@@ -216,10 +217,11 @@ object BackendType {
     case MonoType.Int64 => BackendType.Int64
     case MonoType.Float32 => BackendType.Float32
     case MonoType.Float64 => BackendType.Float64
-    case MonoType.AnyType | MonoType.Unit | MonoType.BigDecimal | MonoType.BigInt | MonoType.String |
-         MonoType.Regex | MonoType.Array(_) | MonoType.Lazy(_) | MonoType.Ref(_) | MonoType.Tuple(_) |
-         MonoType.Enum(_) | MonoType.Arrow(_, _) | MonoType.RecordEmpty | MonoType.RecordExtend(_, _, _) |
-         MonoType.Native(_) | MonoType.Region => BackendObjType.JavaObject.toTpe
+    case MonoType.Void | MonoType.AnyType | MonoType.Unit | MonoType.BigDecimal | MonoType.BigInt |
+         MonoType.String | MonoType.Regex | MonoType.Array(_) | MonoType.Lazy(_) | MonoType.Ref(_) |
+         MonoType.Tuple(_) | MonoType.Enum(_) | MonoType.Arrow(_, _) | MonoType.RecordEmpty |
+         MonoType.RecordExtend(_, _, _) | MonoType.Native(_) | MonoType.Region =>
+      BackendObjType.JavaObject.toTpe
   }
 
   def asErasedBackendType(tpe: MonoType): BackendType = tpe match {
@@ -232,10 +234,11 @@ object BackendType {
     case MonoType.Float32 => BackendType.Float32
     case MonoType.Float64 => BackendType.Float64
     case MonoType.Native(clazz) if clazz == classOf[Object] => BackendObjType.JavaObject.toTpe
-    case MonoType.AnyType | MonoType.Unit | MonoType.BigDecimal | MonoType.BigInt | MonoType.String |
-         MonoType.Regex | MonoType.Array(_) | MonoType.Lazy(_) | MonoType.Ref(_) | MonoType.Tuple(_) |
-         MonoType.Enum(_) | MonoType.Arrow(_, _) | MonoType.RecordEmpty | MonoType.RecordExtend(_, _, _) |
-         MonoType.Native(_) | MonoType.Region => throw InternalCompilerException(s"Unexpected type $tpe", SourceLocation.Unknown)
+    case MonoType.Void | MonoType.AnyType | MonoType.Unit | MonoType.BigDecimal | MonoType.BigInt |
+         MonoType.String | MonoType.Regex | MonoType.Array(_) | MonoType.Lazy(_) | MonoType.Ref(_) |
+         MonoType.Tuple(_) | MonoType.Enum(_) | MonoType.Arrow(_, _) | MonoType.RecordEmpty |
+         MonoType.RecordExtend(_, _, _) | MonoType.Native(_) | MonoType.Region =>
+      throw InternalCompilerException(s"Unexpected type $tpe", SourceLocation.Unknown)
   }
 
   /**
@@ -259,7 +262,7 @@ object BackendType {
     case MonoType.String => BackendObjType.String.toTpe
     case MonoType.Regex => BackendObjType.Regex.toTpe
     case MonoType.Native(clazz) => JvmName.ofClass(clazz).toTpe
-    case MonoType.AnyType | MonoType.Unit | MonoType.Lazy(_) | MonoType.Ref(_) |
+    case MonoType.Void | MonoType.AnyType | MonoType.Unit | MonoType.Lazy(_) | MonoType.Ref(_) |
          MonoType.Tuple(_) | MonoType.Arrow(_, _) | MonoType.RecordEmpty |
          MonoType.RecordExtend(_, _, _) | MonoType.Region | MonoType.Enum(_) =>
       BackendObjType.JavaObject.toTpe

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -45,6 +45,7 @@ object JvmOps {
     */
   def getJvmType(tpe: MonoType): JvmType = tpe match {
     // Primitives
+    case MonoType.Void => JvmType.Object
     case MonoType.AnyType => JvmType.Object
     case MonoType.Unit => JvmType.Unit
     case MonoType.Bool => JvmType.PrimBool
@@ -89,9 +90,10 @@ object JvmOps {
       case Int16 => JvmType.PrimShort
       case Int32 => JvmType.PrimInt
       case Int64 => JvmType.PrimLong
-      case AnyType | Unit | BigDecimal | BigInt | String | Regex | Region |
-           Array(_) |Lazy(_) | Ref(_) | Tuple(_) | Enum(_) | Arrow(_, _) |
-           RecordEmpty |RecordExtend(_, _, _) | Native(_) => JvmType.Object
+      case Void | AnyType | Unit | BigDecimal | BigInt | String | Regex |
+           Region | Array(_) |Lazy(_) | Ref(_) | Tuple(_) | Enum(_) |
+           Arrow(_, _) | RecordEmpty |RecordExtend(_, _, _) | Native(_) =>
+        JvmType.Object
     }
   }
 
@@ -112,9 +114,9 @@ object JvmOps {
       case Int32 => JvmType.PrimInt
       case Int64 => JvmType.PrimLong
       case Native(clazz) if clazz == classOf[Object] => JvmType.Object
-      case AnyType | Unit | BigDecimal | BigInt | String | Regex | Region |
-           Array(_) | Lazy(_) | Ref(_) | Tuple(_) | Enum(_) | Arrow(_, _) |
-           RecordEmpty | RecordExtend(_, _, _) | Native(_) =>
+      case Void | AnyType | Unit | BigDecimal | BigInt | String | Regex |
+           Region | Array(_) | Lazy(_) | Ref(_) | Tuple(_) | Enum(_) |
+           Arrow(_, _) | RecordEmpty | RecordExtend(_, _, _) | Native(_) =>
         throw InternalCompilerException(s"Unexpected type $tpe", SourceLocation.Unknown)
     }
   }


### PR DESCRIPTION
Matches `Type.Void`, used for effect operations primarily.

previously this was represented by `MonoType.Object` which loses information

Fixes #7554