### PR TITLE
chore: rename Class to Trait in the Parsers and NamedAst (issue #6591)

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -38,9 +38,9 @@ object NamedAst {
 
     case class Namespace(sym: Symbol.ModuleSym, usesAndImports: List[UseOrImport], decls: List[Declaration], loc: SourceLocation) extends Declaration
 
-    case class Trait(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superClasses: List[TypeConstraint], assocs: List[Declaration.AssocTypeSig], sigs: List[Declaration.Sig], laws: List[Declaration.Def], loc: SourceLocation) extends Declaration
+    case class Trait(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TypeConstraint], assocs: List[Declaration.AssocTypeSig], sigs: List[Declaration.Sig], laws: List[Declaration.Def], loc: SourceLocation) extends Declaration
 
-    case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, clazz: Name.QName, tparams: TypeParams, tpe: Type, tconstrs: List[TypeConstraint], assocs: List[Declaration.AssocTypeDef], defs: List[Declaration.Def], ns: List[String], loc: SourceLocation) extends Declaration
+    case class Instance(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, trt: Name.QName, tparams: TypeParams, tpe: Type, tconstrs: List[TypeConstraint], assocs: List[Declaration.AssocTypeDef], defs: List[Declaration.Def], ns: List[String], loc: SourceLocation) extends Declaration
 
     case class Sig(sym: Symbol.SigSym, spec: Spec, exp: Option[Expr]) extends Declaration
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -32,10 +32,10 @@ import scala.annotation.tailrec
   *
   * ---
   *
-  * INVARIANT: No rule should comsume trailing whitespace
+  * INVARIANT: No rule should consume trailing whitespace
   *
   * REASON: Consuming trailing whitespace might consume the documentation of the
-  * next def/class/etc.
+  * next def/trait/etc.
   *
   * EXAMPLE: Do not write `... ~ optWS ~ optional(":" ~ optWS ~ Type)`,
   * instead write `... ~ optional(optWS ~ ":" ~ optWS ~ Type)`.
@@ -137,7 +137,7 @@ object Parser {
       case "Constraint" => SyntacticContext.Expr.Constraint
       case "Do" => SyntacticContext.Expr.Do
 
-      case "Class" => SyntacticContext.Decl.Trait
+      case "Trait" => SyntacticContext.Decl.Trait
       case "Enum" => SyntacticContext.Decl.Enum
       case "Instance" => SyntacticContext.Decl.Instance
       case "Decls" => SyntacticContext.Decl.OtherDecl
@@ -231,7 +231,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       Declarations.Enum |
       Declarations.RestrictableEnum |
       Declarations.TypeAlias |
-      Declarations.Class |
+      Declarations.Trait |
       Declarations.Instance |
       Declarations.Effect
   }
@@ -336,16 +336,16 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       Documentation ~ Modifiers ~ SP ~ keyword("type") ~ WS ~ Names.Type ~ optWS ~ optional("[" ~ oneOrMore(Type).separatedBy(optWS ~ "," ~ optWS) ~ "]") ~ optWS ~ "=" ~ optWS ~ Type ~ SP ~> ParsedAst.Declaration.AssocTypeDef
     }
 
-    def Class: Rule1[ParsedAst.Declaration] = {
+    def Trait: Rule1[ParsedAst.Declaration] = {
       def Head = rule {
-        Documentation ~ Annotations ~ Modifiers ~ SP ~ (keyword("trait") | keyword("class")) ~ WS ~ Names.Class ~ optWS ~ "[" ~ optWS ~ TypeParam ~ optWS ~ "]" ~ WithClause
+        Documentation ~ Annotations ~ Modifiers ~ SP ~ (keyword("trait") | keyword("class")) ~ WS ~ Names.Trait ~ optWS ~ "[" ~ optWS ~ TypeParam ~ optWS ~ "]" ~ WithClause
       }
 
-      def EmptyBody = namedRule("ClassBody") {
+      def EmptyBody = namedRule("TraitBody") {
         push(Nil) ~ push(Nil) ~ SP
       }
 
-      def NonEmptyBody = namedRule("ClassBody") {
+      def NonEmptyBody = namedRule("TraitBody") {
         optWS ~ "{" ~ zeroOrMore(Declarations.AssocTypeSig) ~ zeroOrMore(Declarations.Law | Declarations.Sig) ~ optWS ~ "}" ~ SP
       }
 
@@ -355,7 +355,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def TypeConstraint: Rule1[ParsedAst.TypeConstraint] = rule {
-      SP ~ Names.QualifiedClass ~ optWS ~ "[" ~ optWS ~ Type ~ optWS ~ "]" ~ SP ~> ParsedAst.TypeConstraint
+      SP ~ Names.QualifiedTrait ~ optWS ~ "[" ~ optWS ~ Type ~ optWS ~ "]" ~ SP ~> ParsedAst.TypeConstraint
     }
 
     def WithClause: Rule1[Seq[ParsedAst.TypeConstraint]] = rule {
@@ -372,7 +372,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     def Instance: Rule1[ParsedAst.Declaration] = {
       def Head = rule {
-        Documentation ~ Annotations ~ Modifiers ~ SP ~ keyword("instance") ~ WS ~ Names.QualifiedClass ~ optWS ~ "[" ~ optWS ~ Type ~ optWS ~ "]" ~ WithClause
+        Documentation ~ Annotations ~ Modifiers ~ SP ~ keyword("instance") ~ WS ~ Names.QualifiedTrait ~ optWS ~ "[" ~ optWS ~ Type ~ optWS ~ "]" ~ WithClause
       }
 
       def EmptyBody = namedRule("InstanceBody") {
@@ -421,7 +421,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     def Derivations: Rule1[ParsedAst.Derivations] = {
       def WithClause: Rule1[Seq[Name.QName]] = rule {
-        keyword("with") ~ WS ~ oneOrMore(Names.QualifiedClass).separatedBy(optWS ~ "," ~ optWS)
+        keyword("with") ~ WS ~ oneOrMore(Names.QualifiedTrait).separatedBy(optWS ~ "," ~ optWS)
       }
 
       rule {
@@ -1791,9 +1791,9 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     def Attribute: Rule1[Name.Ident] = LowerCaseName
 
-    def Class: Rule1[Name.Ident] = UpperCaseName
+    def Trait: Rule1[Name.Ident] = UpperCaseName
 
-    def QualifiedClass: Rule1[Name.QName] = QName
+    def QualifiedTrait: Rule1[Name.QName] = QName
 
     def Definition: Rule1[Name.Ident] = rule {
       LowerCaseName | GreekName | MathName | OperatorName

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -682,7 +682,7 @@ object Parser2 {
       annotations()
       modifiers()
       nth(0) match {
-        case TokenKind.KeywordTrait => typeClassDecl(mark)
+        case TokenKind.KeywordTrait => traitDecl(mark)
         case TokenKind.KeywordInstance => instanceDecl(mark)
         case TokenKind.KeywordDef => definitionDecl(mark)
         case TokenKind.KeywordEnum | TokenKind.KeywordRestrictable => enumerationDecl(mark)
@@ -709,7 +709,7 @@ object Parser2 {
       close(mark, TreeKind.Decl.Module)
     }
 
-    private def typeClassDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
+    private def traitDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       expect(TokenKind.KeywordTrait)
       name(NAME_DEFINITION)
       if (at(TokenKind.BracketL)) {


### PR DESCRIPTION
This PR Renames `Class` to `Trait` in the parsers and `NamedAst`.