### PR TITLE
feat: fix crashes found by fuzzing

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -126,7 +126,7 @@ object Parser2 {
     try {
       run(tokens, oldRoot, changeSet).toHardResult match {
         case Result.Ok(t) => Validation.success(t)
-        case Result.Err(e) =>
+        case Result.Err(_) =>
           // Note: We don't know if the Parser failed or the input was actually incorrect.
           // We assume the worst, i.e. that the Parser failed, and we return success.
           Validation.success(SyntaxTree.empty)
@@ -334,16 +334,18 @@ object Parser2 {
   /**
     * Look-ahead `lookahead` tokens.
     * Consumes one fuel and throws [[InternalCompilerException]] if the parser is out of fuel.
+    * Does not consume fuel if parser has hit end-of-file.
+    * This lets the parser return what ever errors were produced from a deep call-stack without running out of fuel.
     */
   private def nth(lookahead: Int)(implicit s: State): TokenKind = {
     if (s.fuel == 0) {
       throw InternalCompilerException(s"[${currentSourceLocation()}] Parser is stuck", currentSourceLocation())
     }
 
-    s.fuel -= 1
-    if (s.position + lookahead >= s.tokens.length) {
+    if (s.position + lookahead >= s.tokens.length - 1) {
       TokenKind.Eof
     } else {
+      s.fuel -= 1
       s.tokens(s.position + lookahead).kind
     }
   }
@@ -469,7 +471,7 @@ object Parser2 {
     }
 
     private def run()(implicit s: State): Int = {
-      def isAtEnd(): Boolean = at(rightDelim) || optionallyWith.exists { case (indicator, _) => at(indicator) }
+      def isAtEnd: Boolean = at(rightDelim) || optionallyWith.exists { case (indicator, _) => at(indicator) }
 
       if (!at(leftDelim)) {
         return 0
@@ -477,12 +479,12 @@ object Parser2 {
       expect(leftDelim)
       var continue = true
       var numItems = 0
-      while (continue && !isAtEnd() && !eof()) {
+      while (continue && !isAtEnd && !eof()) {
         comments()
         if (checkForItem()) {
           getItem()
           numItems += 1
-          if (!isAtEnd()) {
+          if (!isAtEnd) {
             if (optionalSeparator) eat(separator) else expect(separator)
           }
         } else {
@@ -550,7 +552,7 @@ object Parser2 {
     * Consumes a token if kind is in `kinds`. If `allowQualified` is passed also consume subsequent dot-separated tokens with kind in `kinds`.
     */
   private def name(kinds: List[TokenKind], allowQualified: Boolean = false)(implicit s: State): Mark.Closed = {
-    val mark = open()
+    val mark = open(consumeDocComments = false)
     expectAny(kinds)
     val first = close(mark, TreeKind.Ident)
     if (!allowQualified) {
@@ -1358,12 +1360,21 @@ object Parser2 {
           // Detect lambda function declaration
           val isLambda = {
             var level = 1
+            var curlyLevel = 0
             var lookAhead = 0
             while (level > 0 && !eof()) {
               lookAhead += 1
               nth(lookAhead) match {
                 case TokenKind.ParenL => level += 1
                 case TokenKind.ParenR => level -= 1
+                case TokenKind.CurlyL => curlyLevel += 1
+                case TokenKind.CurlyR if level == 1 =>
+                  if (curlyLevel == 0) {
+                    // Hitting '}' on top-level is a clear indicator that something is wrong. Most likely the terminating ')' was forgotten.
+                    return advanceWithError(ParseError("Malformed tuple.", SyntacticContext.Unknown, currentSourceLocation()))
+                  } else {
+                    curlyLevel -= 1
+                  }
                 case TokenKind.Eof => return advanceWithError(ParseError("Malformed tuple.", SyntacticContext.Unknown, currentSourceLocation()))
                 case _ =>
               }
@@ -1968,7 +1979,6 @@ object Parser2 {
     }
 
     private def catchRule()(implicit s: State): Mark.Closed = {
-      assert(at(TokenKind.KeywordCase))
       val mark = open()
       expect(TokenKind.KeywordCase)
       name(NAME_VARIABLE)
@@ -2198,8 +2208,12 @@ object Parser2 {
       while (eat(TokenKind.Comma) && !eof()) {
         expression()
       }
-      fixpointQuerySelect()
-      fixpointQueryFrom()
+      if (at(TokenKind.KeywordSelect)) {
+        fixpointQuerySelect()
+      }
+      if (at(TokenKind.KeywordFrom)) {
+        fixpointQueryFrom()
+      }
       if (at(TokenKind.KeywordWhere)) {
         fixpointQueryWhere()
       }
@@ -2253,19 +2267,19 @@ object Parser2 {
         case _ => false
       }
 
-      def getOpener(): Option[TokenKind] = nth(0) match {
+      def getOpener: Option[TokenKind] = nth(0) match {
         case TokenKind.LiteralStringInterpolationL => advance(); Some(TokenKind.LiteralStringInterpolationL)
         case TokenKind.LiteralDebugStringL => advance(); Some(TokenKind.LiteralDebugStringR)
         case _ => None
       }
 
-      var lastOpener = getOpener()
+      var lastOpener = getOpener
       while (lastOpener.isDefined && !eof()) {
         if (atTerminator(lastOpener)) {
           lastOpener = None // Terminate the loop
         } else {
           expression()
-          lastOpener = getOpener() // Try to get nested interpolation
+          lastOpener = getOpener // Try to get nested interpolation
         }
       }
       expectAny(List(TokenKind.LiteralStringInterpolationR, TokenKind.LiteralDebugStringR))
@@ -2935,7 +2949,7 @@ object Parser2 {
       close(mark, TreeKind.JvmOp.StaticMethod)
     }
 
-    private def getBody()(implicit s: State): Unit = {
+    private def fieldGetBody()(implicit s: State): Unit = {
       expect(TokenKind.KeywordJavaGetField)
       name(NAME_JAVA, allowQualified = true)
       ascription()
@@ -2953,7 +2967,7 @@ object Parser2 {
 
     def getField()(implicit s: State): Mark.Closed = {
       val mark = open()
-      getBody()
+      fieldGetBody()
       close(mark, TreeKind.JvmOp.GetField)
     }
 
@@ -2961,7 +2975,7 @@ object Parser2 {
       assert(at(TokenKind.KeywordStatic))
       val mark = open()
       expect(TokenKind.KeywordStatic)
-      getBody()
+      fieldGetBody()
       close(mark, TreeKind.JvmOp.StaticGetField)
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.Ast.{Constant, Denotation, Fixity, Polarity, SyntacticContext}
-import ca.uwaterloo.flix.language.ast.SyntaxTree.{Child, Root, Tree, TreeKind}
+import ca.uwaterloo.flix.language.ast.SyntaxTree.{Child, Tree, TreeKind}
 import ca.uwaterloo.flix.language.ast.{Ast, ChangeSet, Name, ReadAst, SemanticOp, SourceLocation, SourcePosition, Symbol, SyntaxTree, Token, TokenKind, WeededAst}
 import ca.uwaterloo.flix.language.errors.ParseError
 import ca.uwaterloo.flix.language.errors.WeederError._
@@ -160,7 +160,9 @@ object Weeder2 {
     flatMapN(JvmOp.pickJavaName(tree))(jname => {
       mapN(traverseOpt(maybeImportMany)(tree => visitImportMany(tree, jname.fqn))) {
         // case: import one, use the java name
-        case None | Some(Nil) => List(UseOrImport.Import(jname, Name.Ident(jname.sp1, jname.fqn.last, jname.sp2), tree.loc))
+        case None | Some(Nil) =>
+          val ident = Name.Ident(jname.sp1, jname.fqn.lastOption.getOrElse(""), jname.sp2)
+          List(UseOrImport.Import(jname, ident, tree.loc))
         // case: import many
         case Some(imports) => imports
       }
@@ -796,8 +798,15 @@ object Weeder2 {
         case TreeKind.Expr.FixpointSolveWithProject => visitFixpointSolveExpr(tree)
         case TreeKind.Expr.FixpointQuery => visitFixpointQueryExpr(tree)
         case TreeKind.Expr.Debug => visitDebugExpr(tree)
+        case TreeKind.Expr.Intrinsic =>
+          // Intrinsics must be applied to check that they have the right amount of arguments.
+          // This means that intrinsics are not "first-class" like other functions.
+          // Something like "let assign = $VECTOR_ASSIGN$" hits this case.
+          val error = ParseError("Intrinsics must be applied.", SyntacticContext.Expr.OtherExpr, tree.loc)
+          Validation.toSoftFailure(Expr.Error(error), error)
         case TreeKind.ErrorTree(err) => Validation.success(Expr.Error(err))
-        case _ => throw InternalCompilerException("Expected expression.", tree.loc)
+        case _ =>
+          throw InternalCompilerException(s"Expected expression.", tree.loc)
       }
     }
 
@@ -806,6 +815,7 @@ object Weeder2 {
       val idents = pickAll(TreeKind.Ident, tree)
       flatMapN(traverse(idents)(tokenToIdent)) {
         idents =>
+          assert(idents.nonEmpty) // Require at least one ident
           val first = idents.head
           val ident = idents.last
           val nnameIdents = idents.dropRight(1)
@@ -1081,7 +1091,8 @@ object Weeder2 {
           if (isInfix) {
             val infixName = text(op).head.stripPrefix("`").stripSuffix("`")
             val infixNameParts = infixName.split('.').toList
-            val qname = Name.mkQName(infixNameParts.init, infixNameParts.last, op.loc.sp1, op.loc.sp2)
+            val lastName = infixNameParts.lastOption.getOrElse("")
+            val qname = Name.mkQName(infixNameParts.init, lastName, op.loc.sp1, op.loc.sp2)
             val opExpr = Expr.Ambiguous(qname, op.loc)
             return Validation.success(Expr.Infix(e1, opExpr, e2, tree.loc))
           }
@@ -1798,6 +1809,7 @@ object Weeder2 {
     }
 
     private def visitIntrinsic(tree: Tree, args: List[Expr]): Validation[Expr, CompilationMessage] = {
+      expect(tree, TreeKind.Expr.Intrinsic)
       val intrinsic = text(tree).head.stripPrefix("$").stripSuffix("$")
       val loc = tree.loc
       (intrinsic, args) match {
@@ -2855,6 +2867,7 @@ object Weeder2 {
     val idents = pickAll(TreeKind.Ident, tree)
     mapN(traverse(idents)(tokenToIdent)) {
       idents =>
+        assert(idents.nonEmpty) // We require atleast one element to construct a qname
         val first = idents.head
         val ident = idents.last
         val nnameIdents = idents.dropRight(1)


### PR DESCRIPTION
Fixes crashes found by fuzzing the standard library. 

There are still a couple left to fix, but those are way easier to handle after we have recover sets, so I have just noted them.