### PR TITLE
test: disable test parallelism

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,13 @@ jar {
 
 task testAll(dependsOn: ['testClasses'], type: JavaExec) {
     mainClass = 'org.scalatest.tools.Runner'
-    args = ['-P', '-s', 'ca.uwaterloo.flix.TestAll', '-o']
+    // Note: We do not use the -P (parallelism) flag for two reasons:
+    // (A) It may use excessive amounts of memory (running many instances of the compiler).
+    // (B) It may garble the order of the output (when an error occurs).
+    // Of course we still benefit from parallelism inside Flix itself.
+    args = ['-s', 'ca.uwaterloo.flix.TestAll', '-o']
+    // We also enforce that all tests can complete with 4GB of memory:
+    jvmArgs = ['-Xmx4g']
     classpath = sourceSets.test.runtimeClasspath
     standardInput = System.in
 }


### PR DESCRIPTION
See diff for rationale.

Yes, this makes CI slower, but it also makes everything more robust.