### PR TITLE
fix: better region types in parYield lowering

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -1661,7 +1661,7 @@ object Lowering {
         val loc = e.loc.asSynthetic
         val e1 = mkChannelExp(sym, e.tpe, loc) // The channel `ch`
         val e2 = mkPutChannel(e1, e, Type.IO, loc) // The put exp: `ch <- exp0`.
-        val e3 = LoweredAst.Expr.ApplyAtomic(AtomicOp.Region, List.empty, Type.Unit, Type.Pure, loc)
+        val e3 = LoweredAst.Expr.ApplyAtomic(AtomicOp.Region, List.empty, Type.mkRegion(Type.IO, loc), Type.Pure, loc)
         val e4 = LoweredAst.Expr.ApplyAtomic(AtomicOp.Spawn, List(e2, e3), Type.Unit, Type.IO, loc) // Spawn the put expression from above i.e. `spawn ch <- exp0`.
         LoweredAst.Expr.Stm(e4, acc, acc.tpe, Type.mkUnion(e4.eff, acc.eff, loc), loc) // Return a statement expression containing the other spawn expressions along with this one.
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -370,19 +370,6 @@ object Verifier {
         case AtomicOp.Cast =>
           tpe
 
-        case AtomicOp.Region =>
-          check(expected = MonoType.Region)(actual = tpe, loc)
-
-        case AtomicOp.Spawn =>
-          val List(t1, t2) = ts
-          t1 match {
-            case MonoType.Arrow(List(MonoType.Unit), _) => ()
-            case _ => failMismatchedShape(t1, "Arrow(List(Unit), _)", loc)
-          }
-
-          check(expected = MonoType.Region)(actual = t2, loc)
-          check(expected = MonoType.Unit)(actual = tpe, loc)
-
         case _ => tpe // TODO: VERIFIER: Add rest
       }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -370,6 +370,19 @@ object Verifier {
         case AtomicOp.Cast =>
           tpe
 
+        case AtomicOp.Region =>
+          check(expected = MonoType.Region)(actual = tpe, loc)
+
+        case AtomicOp.Spawn =>
+          val List(t1, t2) = ts
+          t1 match {
+            case MonoType.Arrow(List(MonoType.Unit), _) => ()
+            case _ => failMismatchedShape(t1, "Arrow(List(Unit), _)", loc)
+          }
+
+          check(expected = MonoType.Region)(actual = t2, loc)
+          check(expected = MonoType.Unit)(actual = tpe, loc)
+
         case _ => tpe // TODO: VERIFIER: Add rest
       }
 


### PR DESCRIPTION
`Region: Unit` is now `Region: Region[IO]` (which also doesn't make much sense, but that is how it is done in desugaring fx).