### PR TITLE
fix: Count HashCurlyL as opener

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1367,7 +1367,7 @@ object Parser2 {
               nth(lookAhead) match {
                 case TokenKind.ParenL => level += 1
                 case TokenKind.ParenR => level -= 1
-                case TokenKind.CurlyL => curlyLevel += 1
+                case TokenKind.CurlyL | TokenKind.HashCurlyL => curlyLevel += 1
                 case TokenKind.CurlyR if level == 1 =>
                   if (curlyLevel == 0) {
                     // Hitting '}' on top-level is a clear indicator that something is wrong. Most likely the terminating ')' was forgotten.
@@ -1777,7 +1777,7 @@ object Parser2 {
                 case TokenKind.Bar if nestingLevel == 0 =>
                   isRecordOp = true
                   continue = false
-                case TokenKind.CurlyL =>
+                case TokenKind.CurlyL | TokenKind.HashCurlyL =>
                   nestingLevel += 1
                   lookahead += 1
                 case TokenKind.CurlyR =>


### PR DESCRIPTION
This fixes a bug in the spots where we need to count nesting levels of curly braces.
The issue was that `#{` and `}` pairs were ignored.