### PR TITLE
feat: add `toVector` to Set and others (issue #7430)

### DIFF
--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -780,6 +780,26 @@ mod Map {
         foldRightWithKey((k, v, acc) -> (k, v) :: acc, Nil, m)
 
     ///
+    /// Returns the map `m` as an array.
+    ///
+    pub def toArray(rc: Region[r], m: Map[k, v]): Array[(k, v), r] \ r = match size(m) {
+        case 0  => Array#{} @ rc
+        case sz =>
+            let a = Array.empty(rc, sz);
+            forEachWithIndex((i, k, v) -> Array.put((k, v), i, a), m);
+            a
+        }
+
+    ///
+    /// Returns the map `m` as a vector.
+    ///
+    pub def toVector(m: Map[k, v]): Vector[(k, v)] = region rc {
+        let arr = Array.empty(rc, size(m));
+        forEachWithIndex((i, k, v) -> Array.put((k, v), i, arr), m);
+        Array.toVector(arr)
+    }
+
+    ///
     /// Returns the map `m` as a set of key-value pairs.
     ///
     pub def toSet(m: Map[k, v]): Set[(k, v)] with Order[k], Order[v] =

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -547,6 +547,20 @@ mod MutMap {
         Map.toList(deref mm)
 
     ///
+    /// Returns the mutable map `m` as a vector of key-value pairs.
+    ///
+    pub def toVector(m: MutMap[k, v, r]): Vector[(k, v)] \ r =
+        let MutMap(_, mm) = m;
+        Map.toVector(deref mm)
+
+    ///
+    /// Returns the mutable map `m` as an array of key-value pairs.
+    ///
+    pub def toArray(rc1: Region[r1], m: MutMap[k, v, r]): Array[(k, v), r1] \ {r, r1} =
+        let MutMap(_, mm) = m;
+        Map.toArray(rc1, deref mm)
+
+    ///
     /// Returns the mutable map `m` as a set of key-value pairs.
     ///
     pub def toSet(m: MutMap[k, v, r]): Set[(k, v)] \ r with Order[k], Order[v] =

--- a/main/src/library/MutQueue.flix
+++ b/main/src/library/MutQueue.flix
@@ -148,6 +148,15 @@ mod MutQueue {
         Array.takeLeft(rc, deref s, deref arr)
 
     ///
+    /// Returns an Vector representation of `mq`.
+    ///
+    /// Note that a MutQueue's element order depends on the order in which the elements were enqueued.
+    ///
+    pub def toVector(mq: MutQueue[a, r]): Vector[a] \ r = region rc {
+        toArray(rc, mq) |> Array.toVector
+    }
+
+    ///
     /// Reinforces the max heap invariant from `idx` after an element is added to `mq`.
     ///
     def heapifyUp(idx: Int32, mq: MutQueue[a, r]): Unit \ r with Order[a] =

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -508,6 +508,26 @@ mod Set {
         foldRight((x, acc) -> x :: acc, Nil, s)
 
     ///
+    /// Returns the set `s` as an array.
+    ///
+    pub def toArray(rc: Region[r], s: Set[a]): Array[a, r] \ r = match size(s) {
+        case 0  => Array#{} @ rc
+        case sz =>
+            let a = Array.empty(rc, sz);
+            Iterator.forEachWithIndex((i, b) -> Array.put(b, i, a), iterator(rc, s));
+            a
+        }
+
+    ///
+    /// Returns the set `s` as a vector.
+    ///
+    pub def toVector(s: Set[a]): Vector[a] = region rc {
+        let arr = Array.empty(rc, size(s));
+        Iterator.forEachWithIndex((i, x) -> Array.put(x, i, arr), iterator(rc, s));
+        Array.toVector(arr)
+    }
+
+    ///
     /// Returns the set `s` as a chain.
     ///
     pub def toChain(s: Set[a]): Chain[a] =

--- a/main/test/ca/uwaterloo/flix/library/TestMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMap.flix
@@ -1701,6 +1701,44 @@ def toList03(): Bool = Map.toList(Map#{1 => 2, 3 => 4}) == (1, 2) :: (3, 4) :: N
 def toList04(): Bool = Map.toList(Map#{1 => 2, 2 => 2, 3 => 4}) == (1, 2) :: (2, 2) :: (3, 4) :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
+// toArray                                                                 //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def toArray01(): Bool = region rc {
+    Array.sameElements(Map.toArray(rc, (Map#{}: Map[Unit, Unit])), Array#{} @ rc)
+}
+
+@test
+def toArray02(): Bool = region rc {
+    Array.sameElements(Map.toArray(rc, Map#{1 => 2}), Array#{(1, 2)} @ rc)
+}
+
+@test
+def toArray03(): Bool =  region rc {
+    Array.sameElements(Map.toArray(rc, Map#{1 => 2, 3 => 4}), Array#{(1, 2), (3, 4)} @ rc)
+}
+
+@test
+def toArray04(): Bool = region rc {
+    Array.sameElements(Map.toArray(rc, Map#{1 => 2, 2 => 2, 3 => 4}), Array#{(1, 2), (2, 2), (3, 4)} @ rc)
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// toVector                                                                //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def toVector01(): Bool = Map.toVector((Map#{}: Map[Unit, Unit])) == (Vector#{} : Vector[(Unit, Unit)])
+
+@test
+def toVector02(): Bool = Map.toVector(Map#{1 => 2}) == Vector#{(1, 2)}
+
+@test
+def toVector03(): Bool = Map.toVector(Map#{1 => 2, 3 => 4}) == Vector#{(1, 2), (3, 4)}
+
+@test
+def toVector04(): Bool = Map.toVector(Map#{1 => 2, 2 => 2, 3 => 4}) == Vector#{(1, 2), (2, 2), (3, 4)}
+
+/////////////////////////////////////////////////////////////////////////////
 // toMutDeque                                                              //
 /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestMutMap.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutMap.flix
@@ -338,7 +338,6 @@ mod TestMutMap {
             MutMap.joinWith((k, v) -> "${k} => ${v}", ", ") == "0 => 1, 1 => 2, 2 => 2"
     }
 
-
     /////////////////////////////////////////////////////////////////////////////
     // toMutDeque                                                              //
     /////////////////////////////////////////////////////////////////////////////
@@ -388,6 +387,119 @@ mod TestMutMap {
         MutDeque.pushFront((1, 'a'), d2);
 
         d1 `MutDeque.sameElements` d2
+    }
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toList                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toList01(): Bool = region rc {
+        let m: MutMap[Int32, Int32, _] = MutMap.empty(rc);
+        MutMap.toList(m) == (List#{} : List[(Int32, Int32)])
+    }
+
+    @test
+    def toList02(): Bool = region rc {
+        let m = Map.toMutMap(rc, Map#{1 => 2});
+        MutMap.toList(m) == List#{(1, 2)}
+    }
+
+    @test
+    def toList03(): Bool = region rc {
+        let m = Map.toMutMap(rc, Map#{1 => 2, 3 => 4, 5 => 6});
+        MutMap.toList(m) == List#{(1, 2), (3, 4), (5, 6)}
+    }
+
+    @test
+    def toList04(): Bool = region rc {
+        let m = Map.toMutMap(rc, Map#{1 => 'a', 2 => 'b', 3 => 'c'});
+        MutMap.toList(m) == List#{(1, 'a'), (2, 'b'), (3, 'c')}
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toVector                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toVector01(): Bool = region rc {
+        let m: MutMap[Int32, Int32, _] = MutMap.empty(rc);
+        MutMap.toVector(m) == (Vector#{} : Vector[(Int32, Int32)])
+    }
+
+    @test
+    def toVector02(): Bool = region rc {
+        let m = Map.toMutMap(rc, Map#{1 => 2});
+        MutMap.toVector(m) == Vector#{(1, 2)}
+    }
+
+    @test
+    def toVector03(): Bool = region rc {
+        let m = Map.toMutMap(rc, Map#{1 => 2, 3 => 4, 5 => 6});
+        MutMap.toVector(m) == Vector#{(1, 2), (3, 4), (5, 6)}
+    }
+
+    @test
+    def toVector04(): Bool = region rc {
+        let m = Map.toMutMap(rc, Map#{1 => 'a', 2 => 'b', 3 => 'c'});
+        MutMap.toVector(m) == Vector#{(1, 'a'), (2, 'b'), (3, 'c')}
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toArray                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toArray01(): Bool = region rc {
+        let m: MutMap[Int32, Int32, _] = MutMap.empty(rc);
+        Array.sameElements(MutMap.toArray(rc, m), Array#{} @ rc)
+    }
+
+    @test
+    def toArray02(): Bool = region rc {
+        let m = Map.toMutMap(rc, Map#{1 => 2});
+        Array.sameElements(MutMap.toArray(rc, m), Array#{(1, 2)} @ rc)
+    }
+
+    @test
+    def toArray03(): Bool = region rc {
+        let m = Map.toMutMap(rc, Map#{1 => 2, 3 => 4, 5 => 6});
+        Array.sameElements(MutMap.toArray(rc, m), Array#{(1, 2), (3, 4), (5, 6)} @ rc)
+    }
+
+    @test
+    def toArray04(): Bool = region rc {
+        let m = Map.toMutMap(rc, Map#{1 => 'a', 2 => 'b', 3 => 'c'});
+        Array.sameElements(MutMap.toArray(rc, m), Array#{(1, 'a'), (2, 'b'), (3, 'c')} @ rc)
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toSet                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toSet01(): Bool = region rc {
+        let m: MutMap[Int32, Int32, _] = MutMap.empty(rc);
+        MutMap.toSet(m) == (Set#{} : Set[(Int32, Int32)])
+    }
+
+    @test
+    def toSet02(): Bool = region rc {
+        let m = Map.toMutMap(rc, Map#{1 => 2});
+        MutMap.toSet(m) == Set#{(1, 2)}
+    }
+
+    @test
+    def toSet03(): Bool = region rc {
+        let m = Map.toMutMap(rc, Map#{1 => 2, 3 => 4, 5 => 6});
+        MutMap.toSet(m) == Set#{(1, 2), (3, 4), (5, 6)}
+    }
+
+    @test
+    def toSet04(): Bool = region rc {
+        let m = Map.toMutMap(rc, Map#{1 => 'a', 2 => 'b', 3 => 'c'});
+        MutMap.toSet(m) == Set#{(1, 'a'), (2, 'b'), (3, 'c')}
     }
 
     /////////////////////////////////////////////////////////////////////////////

--- a/main/test/ca/uwaterloo/flix/library/TestMutQueue.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutQueue.flix
@@ -449,46 +449,93 @@ mod TestMutQueue {
     /////////////////////////////////////////////////////////////////////////////
 
     @Test
-    def testArray01(): Bool = region rc {
+    def testToArray01(): Bool = region rc {
         let mq = (MutQueue.empty(rc) : MutQueue[Int32, rc]);
         Array.toString(MutQueue.toArray(rc, mq)) == "Array#{}"
     }
 
     @Test
-    def testArray02(): Bool = region rc {
+    def testToArray02(): Bool = region rc {
         let mq = (MutQueue.empty(rc) : MutQueue[Int32, rc]);
         MutQueue.enqueue(mq, 1);
         Array.toString(MutQueue.toArray(rc, mq)) == "Array#{1}"
     }
 
     @Test
-    def testArray03(): Bool = region rc {
+    def testToArray03(): Bool = region rc {
         let mq = (MutQueue.empty(rc) : MutQueue[Int32, rc]);
         MutQueue.enqueueAll(mq, 1 :: 2 :: Nil);
         Array.toString(MutQueue.toArray(rc, mq)) == "Array#{2, 1}"
     }
 
     @Test
-    def testArray04(): Bool = region rc {
+    def testToArray04(): Bool = region rc {
         let mq = (MutQueue.empty(rc) : MutQueue[Int32, rc]);
         MutQueue.enqueueAll(mq, 2 :: 1 :: Nil);
         Array.toString(MutQueue.toArray(rc, mq)) == "Array#{2, 1}"
     }
 
     @Test
-    def testArray05(): Bool = region rc {
+    def testToArray05(): Bool = region rc {
         let mq = (MutQueue.empty(rc) : MutQueue[Int32, rc]);
         MutQueue.enqueueAll(mq, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: Nil);
         Array.toString(MutQueue.toArray(rc, mq)) == "Array#{8, 7, 6, 4, 3, 2, 5, 1}"
     }
 
     @Test
-    def testArray06(): Bool = region rc {
+    def testToArray06(): Bool = region rc {
         let mq = (MutQueue.empty(rc) : MutQueue[Int32, rc]);
         MutQueue.enqueueAll(mq, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: Nil);
         MutQueue.dequeue(mq);
         MutQueue.dequeue(mq);
         Array.toString(MutQueue.toArray(rc, mq)) == "Array#{6, 4, 5, 1, 3, 2}"
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // toVector                                                                //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    def testToVector01(): Bool = region rc {
+        let mq = (MutQueue.empty(rc) : MutQueue[Int32, rc]);
+        MutQueue.toVector(mq) == (Vector#{} : Vector[Int32])
+    }
+
+    @Test
+    def testToVector02(): Bool = region rc {
+        let mq = (MutQueue.empty(rc) : MutQueue[Int32, rc]);
+        MutQueue.enqueue(mq, 1);
+        MutQueue.toVector(mq) == Vector#{1}
+    }
+
+    @Test
+    def testToVector03(): Bool = region rc {
+        let mq = (MutQueue.empty(rc) : MutQueue[Int32, rc]);
+        MutQueue.enqueueAll(mq, 1 :: 2 :: Nil);
+        MutQueue.toVector(mq) == Vector#{2, 1}
+    }
+
+    @Test
+    def testToVector04(): Bool = region rc {
+        let mq = (MutQueue.empty(rc) : MutQueue[Int32, rc]);
+        MutQueue.enqueueAll(mq, 2 :: 1 :: Nil);
+        MutQueue.toVector(mq) == Vector#{2, 1}
+    }
+
+    @Test
+    def testToVector05(): Bool = region rc {
+        let mq = (MutQueue.empty(rc) : MutQueue[Int32, rc]);
+        MutQueue.enqueueAll(mq, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: Nil);
+        MutQueue.toVector(mq) == Vector#{8, 7, 6, 4, 3, 2, 5, 1}
+    }
+
+    @Test
+    def testToVector06(): Bool = region rc {
+        let mq = (MutQueue.empty(rc) : MutQueue[Int32, rc]);
+        MutQueue.enqueueAll(mq, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: Nil);
+        MutQueue.dequeue(mq);
+        MutQueue.dequeue(mq);
+        MutQueue.toVector(mq) == Vector#{6, 4, 5, 1, 3, 2}
     }
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestSet.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestSet.flix
@@ -1117,6 +1117,52 @@ def toList03(): Bool = Set.toList(Set#{1, 2}) == 1 :: 2 :: Nil
 def toList04(): Bool = Set.toList(Set#{1, 2, 3}) == 1 :: 2 :: 3 :: Nil
 
 /////////////////////////////////////////////////////////////////////////////
+// toArray                                                                 //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def toArray01(): Bool = region rc {
+    Array.sameElements(Set.toArray(rc, (Set#{}: Set[Unit])), (Array#{} @ rc))
+}
+
+@test
+def toArray02(): Bool = region rc {
+    Array.sameElements(Set.toArray(rc, Set#{1}), Array#{1} @ rc)
+}
+
+@test
+def toArray03(): Bool = region rc {
+    Array.sameElements(Set.toArray(rc, Set#{1, 2}), Array#{1, 2} @ rc)
+}
+
+@test
+def toArray04(): Bool = region rc {
+    Array.sameElements(Set.toArray(rc, Set#{1, 2, 3}), Array#{1, 2, 3} @ rc)
+}
+
+@test
+def toArray05(): Bool = region rc {
+    Array.sameElements(Set.toArray(rc, Set#{3, 2, 1}), Array#{1, 2, 3} @ rc)
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// toVector                                                                //
+/////////////////////////////////////////////////////////////////////////////
+@test
+def toVector01(): Bool = Set.toVector((Set#{}: Set[Unit])) == Vector.empty()
+
+@test
+def toVector02(): Bool = Set.toVector(Set#{1}) == Vector#{1}
+
+@test
+def toVector03(): Bool = Set.toVector(Set#{1, 2}) == Vector#{1, 2}
+
+@test
+def toVector04(): Bool = Set.toVector(Set#{1, 2, 3}) == Vector#{1, 2, 3}
+
+@test
+def toVector05(): Bool = Set.toVector(Set#{3, 2, 1}) == Vector#{1, 2, 3}
+
+/////////////////////////////////////////////////////////////////////////////
 // toChain                                                                 //
 /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This PR `Set.toVector` and other related conversions:

~~~

Map.toVector
Map.toArray
MutMap.toVector
MutMap.toArray
MutQueue.toVector
Set.toVector
Set.toArray

~~~
