### PR TITLE
refactor: add assoc type and effect to Iterable (part of issue #7433)

### DIFF
--- a/examples/larger-examples/Reachable.flix
+++ b/examples/larger-examples/Reachable.flix
@@ -15,7 +15,7 @@
  */
 
 mod Reachable.Imperative {
-    pub def reachable(origin: n, edges: f[(n, n)]): Set[n] with Iterable[f], Order[n] =
+    pub def reachable(origin: n, edges: es): Set[n] \ Iterable.Aef[es] with Iterable[es], Order[n] where Iterable.Elm[es] ~ (n, n) =
         region rc {
             // collect edge lists
             let edgeMap = MutMap.empty(rc);

--- a/examples/larger-examples/restrictable-variants/sequences.flix
+++ b/examples/larger-examples/restrictable-variants/sequences.flix
@@ -905,6 +905,8 @@ instance Foldable[Seq.Seq[s]] {
     pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, s: b, l: Seq.Seq[s][a]): b \ ef = Seq.foldRightWithCont(f, s, l)
 }
 
-instance Iterable[Seq.Seq[s]] {
+instance Iterable[Seq.Seq[s][a]] {
+    type Elm[Seq.Seq[s][a]] = a
+    type Aef[Seq.Seq[s][a]] = Pure
     pub def iterator(rc: Region[r], l: Seq.Seq[s][a]): Iterator[a, r, r] \ r = Seq.iterator(rc, l)
 }

--- a/examples/larger-examples/restrictable-variants/sequences.flix
+++ b/examples/larger-examples/restrictable-variants/sequences.flix
@@ -906,7 +906,6 @@ instance Foldable[Seq.Seq[s]] {
 }
 
 instance Iterable[Seq.Seq[s][a]] {
-    type Elm[Seq.Seq[s][a]] = a
-    type Aef[Seq.Seq[s][a]] = Pure
+    type Elm = a
     pub def iterator(rc: Region[r], l: Seq.Seq[s][a]): Iterator[a, r, r] \ r = Seq.iterator(rc, l)
 }

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -116,7 +116,6 @@ instance Collectable[Chain] {
 
 instance Iterable[Chain[a]] {
     type Elm[Chain[a]] = a
-    type Aef[Chain[a]] = Pure
     pub def iterator(rc: Region[r], c: Chain[a]): Iterator[a, r, r] \ r = Chain.iterator(rc, c)
 }
 

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -116,6 +116,7 @@ instance Collectable[Chain] {
 
 instance Iterable[Chain[a]] {
     type Elm[Chain[a]] = a
+    type Aef[Chain[a]] = Pure
     pub def iterator(rc: Region[r], c: Chain[a]): Iterator[a, r, r] \ r = Chain.iterator(rc, c)
 }
 

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -115,7 +115,7 @@ instance Collectable[Chain] {
 }
 
 instance Iterable[Chain[a]] {
-    type Elm[Chain[a]] = a
+    type Elm = a
     pub def iterator(rc: Region[r], c: Chain[a]): Iterator[a, r, r] \ r = Chain.iterator(rc, c)
 }
 

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -114,7 +114,8 @@ instance Collectable[Chain] {
     pub def collect(iter: Iterator[a, ef, r]): Chain[a] \ { ef, r } with Order[a] = Iterator.toChain(iter)
 }
 
-instance Iterable[Chain] {
+instance Iterable[Chain[a]] {
+    type Elm[Chain[a]] = a
     pub def iterator(rc: Region[r], c: Chain[a]): Iterator[a, r, r] \ r = Chain.iterator(rc, c)
 }
 

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -119,7 +119,8 @@ instance Monoid[DelayList[a]] {
     pub def empty(): DelayList[a] = DelayList.ENil
 }
 
-instance Iterable[DelayList] {
+instance Iterable[DelayList[a]] {
+    type Elm[DelayList[a]] = a
     pub def iterator(rc: Region[r], l: DelayList[a]): Iterator[a, r, r] \ r = DelayList.iterator(rc, l)
 }
 

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -121,6 +121,7 @@ instance Monoid[DelayList[a]] {
 
 instance Iterable[DelayList[a]] {
     type Elm[DelayList[a]] = a
+    type Aef[DelayList[a]] = Pure
     pub def iterator(rc: Region[r], l: DelayList[a]): Iterator[a, r, r] \ r = DelayList.iterator(rc, l)
 }
 

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -121,7 +121,6 @@ instance Monoid[DelayList[a]] {
 
 instance Iterable[DelayList[a]] {
     type Elm[DelayList[a]] = a
-    type Aef[DelayList[a]] = Pure
     pub def iterator(rc: Region[r], l: DelayList[a]): Iterator[a, r, r] \ r = DelayList.iterator(rc, l)
 }
 

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -120,7 +120,7 @@ instance Monoid[DelayList[a]] {
 }
 
 instance Iterable[DelayList[a]] {
-    type Elm[DelayList[a]] = a
+    type Elm = a
     pub def iterator(rc: Region[r], l: DelayList[a]): Iterator[a, r, r] \ r = DelayList.iterator(rc, l)
 }
 

--- a/main/src/library/DelayMap.flix
+++ b/main/src/library/DelayMap.flix
@@ -45,7 +45,6 @@ instance Foldable[DelayMap[k]] {
 
 instance Iterable[DelayMap[k, v]] {
     type Elm[DelayMap[k, v]] = v
-    type Aef[DelayMap[k, v]] = Pure
     pub def iterator(rc: Region[r], m: DelayMap[k, v]): Iterator[v, r, r] \ r =
         DelayMap.iterator(rc, m) |> Iterator.map(snd)
 }

--- a/main/src/library/DelayMap.flix
+++ b/main/src/library/DelayMap.flix
@@ -45,6 +45,7 @@ instance Foldable[DelayMap[k]] {
 
 instance Iterable[DelayMap[k, v]] {
     type Elm[DelayMap[k, v]] = v
+    type Aef[DelayMap[k, v]] = Pure
     pub def iterator(rc: Region[r], m: DelayMap[k, v]): Iterator[v, r, r] \ r =
         DelayMap.iterator(rc, m) |> Iterator.map(snd)
 }

--- a/main/src/library/DelayMap.flix
+++ b/main/src/library/DelayMap.flix
@@ -43,7 +43,8 @@ instance Foldable[DelayMap[k]] {
 
 }
 
-instance Iterable[DelayMap[k]] {
+instance Iterable[DelayMap[k, v]] {
+    type Elm[DelayMap[k, v]] = v
     pub def iterator(rc: Region[r], m: DelayMap[k, v]): Iterator[v, r, r] \ r =
         DelayMap.iterator(rc, m) |> Iterator.map(snd)
 }

--- a/main/src/library/DelayMap.flix
+++ b/main/src/library/DelayMap.flix
@@ -44,7 +44,7 @@ instance Foldable[DelayMap[k]] {
 }
 
 instance Iterable[DelayMap[k, v]] {
-    type Elm[DelayMap[k, v]] = v
+    type Elm = v
     pub def iterator(rc: Region[r], m: DelayMap[k, v]): Iterator[v, r, r] \ r =
         DelayMap.iterator(rc, m) |> Iterator.map(snd)
 }

--- a/main/src/library/Iterable.flix
+++ b/main/src/library/Iterable.flix
@@ -19,19 +19,24 @@
 ///
 pub trait Iterable[t] {
     ///
-    /// The element type of the iterable.
+    /// The element type of the Iterable.
     ///
     type Elm[t]: Type
 
     ///
+    /// The associated effect of the Iterable.
+    ///
+    type Aef[t]: Eff
+
+    ///
     /// Returns an iterator over `t`.
     ///
-    pub def iterator(rc: Region[r], t: t): Iterator[Iterable.Elm[t], r, r] \ r
+    pub def iterator(rc: Region[r], t: t): Iterator[Iterable.Elm[t], Iterable.Aef[t] + r, r] \ Iterable.Aef[t] + r
 
     ///
     /// Returns an iterator over `t` zipped with the indices of the elements.
     ///
-    pub def enumerator(rc: Region[r], t: t): Iterator[(Int32, Iterable.Elm[t]), r, r] \ r =
+    pub def enumerator(rc: Region[r], t: t): Iterator[(Int32, Iterable.Elm[t]), Iterable.Aef[t] + r, r] \ Iterable.Aef[t] + r =
         Iterable.iterator(rc, t) |> Iterator.zipWithIndex
 
 }

--- a/main/src/library/Iterable.flix
+++ b/main/src/library/Iterable.flix
@@ -26,7 +26,7 @@ pub trait Iterable[t] {
     ///
     /// The associated effect of the Iterable.
     ///
-    type Aef[t]: Eff
+    type Aef[t]: Eff = Pure
 
     ///
     /// Returns an iterator over `t`.

--- a/main/src/library/Iterable.flix
+++ b/main/src/library/Iterable.flix
@@ -17,17 +17,21 @@
 ///
 /// A trait for immutable data structures that can be iterated.
 ///
-pub trait Iterable[t: Type -> Type] {
+pub trait Iterable[t] {
+    ///
+    /// The element type of the iterable.
+    ///
+    type Elm[t]: Type
 
     ///
     /// Returns an iterator over `t`.
     ///
-    pub def iterator(rc: Region[r], t: t[a]): Iterator[a, r, r] \ r
+    pub def iterator(rc: Region[r], t: t): Iterator[Iterable.Elm[t], r, r] \ r
 
     ///
     /// Returns an iterator over `t` zipped with the indices of the elements.
     ///
-    pub def enumerator(rc: Region[r], t: t[a]): Iterator[(Int32, a), r, r] \ r =
+    pub def enumerator(rc: Region[r], t: t): Iterator[(Int32, Iterable.Elm[t]), r, r] \ r =
         Iterable.iterator(rc, t) |> Iterator.zipWithIndex
 
 }

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -122,7 +122,6 @@ instance Collectable[List] {
 
 instance Iterable[List[a]] {
     type Elm[List[a]] = a
-    type Aef[List[a]] = Pure
     pub def iterator(rc: Region[r], l: List[a]): Iterator[a, r, r] \ r = List.iterator(rc, l)
 }
 

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -122,6 +122,7 @@ instance Collectable[List] {
 
 instance Iterable[List[a]] {
     type Elm[List[a]] = a
+    type Aef[List[a]] = Pure
     pub def iterator(rc: Region[r], l: List[a]): Iterator[a, r, r] \ r = List.iterator(rc, l)
 }
 

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -121,7 +121,7 @@ instance Collectable[List] {
 }
 
 instance Iterable[List[a]] {
-    type Elm[List[a]] = a
+    type Elm = a
     pub def iterator(rc: Region[r], l: List[a]): Iterator[a, r, r] \ r = List.iterator(rc, l)
 }
 

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -120,7 +120,8 @@ instance Collectable[List] {
     pub def collect(iter: Iterator[a, ef, r]): List[a] \ { r, ef } with Order[a] = Iterator.toList(iter)
 }
 
-instance Iterable[List] {
+instance Iterable[List[a]] {
+    type Elm[List[a]] = a
     pub def iterator(rc: Region[r], l: List[a]): Iterator[a, r, r] \ r = List.iterator(rc, l)
 }
 

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -103,6 +103,7 @@ instance MeetLattice[Map[k, v]] with Order[k], Eq[v], MeetLattice[v] {
 
 instance Iterable[Map[k, v]] {
     type Elm[Map[k, v]] = v
+    type Aef[Map[k, v]] = Pure
     pub def iterator(rc: Region[r], m: Map[k, v]): Iterator[v, r, r] \ r = Map.iteratorValues(rc, m)
 }
 

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -102,7 +102,7 @@ instance MeetLattice[Map[k, v]] with Order[k], Eq[v], MeetLattice[v] {
 }
 
 instance Iterable[Map[k, v]] {
-    type Elm[Map[k, v]] = v
+    type Elm = v
     pub def iterator(rc: Region[r], m: Map[k, v]): Iterator[v, r, r] \ r = Map.iteratorValues(rc, m)
 }
 

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -101,7 +101,8 @@ instance MeetLattice[Map[k, v]] with Order[k], Eq[v], MeetLattice[v] {
         Map.intersectionWith(MeetLattice.greatestLowerBound, m1, m2)
 }
 
-instance Iterable[Map[k]] {
+instance Iterable[Map[k, v]] {
+    type Elm[Map[k, v]] = v
     pub def iterator(rc: Region[r], m: Map[k, v]): Iterator[v, r, r] \ r = Map.iteratorValues(rc, m)
 }
 

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -103,7 +103,6 @@ instance MeetLattice[Map[k, v]] with Order[k], Eq[v], MeetLattice[v] {
 
 instance Iterable[Map[k, v]] {
     type Elm[Map[k, v]] = v
-    type Aef[Map[k, v]] = Pure
     pub def iterator(rc: Region[r], m: Map[k, v]): Iterator[v, r, r] \ r = Map.iteratorValues(rc, m)
 }
 

--- a/main/src/library/MutDisjointSets.flix
+++ b/main/src/library/MutDisjointSets.flix
@@ -61,8 +61,6 @@ mod MutDisjointSets {
     ///
     /// Updates `s` with the elements of the iterable `m`.
     ///
-    /// TODO: with Order[Iterable.Elm[m]] missing
-    ///
     pub def makeSets(m: m, s: MutDisjointSets[elt, r]): Unit \ (r + Iterable.Aef[m]) with Iterable[m], Order[elt] where Iterable.Elm[m] ~ elt = region rc {
         Iterable.iterator(rc, m) |> Iterator.forEach(x -> makeSet(x, s))
     }

--- a/main/src/library/MutDisjointSets.flix
+++ b/main/src/library/MutDisjointSets.flix
@@ -63,7 +63,7 @@ mod MutDisjointSets {
     ///
     /// TODO: with Order[Iterable.Elm[m]] missing
     ///
-    pub def makeSets(m: m, s: MutDisjointSets[Iterable.Elm[m], r]): Unit \ r with Iterable[m] = region rc {
+    pub def makeSets(m: m, s: MutDisjointSets[elt, r]): Unit \ (r + Iterable.Aef[m]) with Iterable[m], Order[elt] where Iterable.Elm[m] ~ elt = region rc {
         Iterable.iterator(rc, m) |> Iterator.forEach(x -> makeSet(x, s))
     }
 

--- a/main/src/library/MutDisjointSets.flix
+++ b/main/src/library/MutDisjointSets.flix
@@ -61,7 +61,9 @@ mod MutDisjointSets {
     ///
     /// Updates `s` with the elements of the iterable `m`.
     ///
-    pub def makeSets(m: m[t], s: MutDisjointSets[t, r]): Unit \ r with Iterable[m], Order[t] = region rc {
+    /// TODO: with Order[Iterable.Elm[m]] missing
+    ///
+    pub def makeSets(m: m, s: MutDisjointSets[Iterable.Elm[m], r]): Unit \ r with Iterable[m] = region rc {
         Iterable.iterator(rc, m) |> Iterator.forEach(x -> makeSet(x, s))
     }
 

--- a/main/src/library/MutQueue.flix
+++ b/main/src/library/MutQueue.flix
@@ -108,7 +108,9 @@ mod MutQueue {
     ///
     /// Enqueues each element in `l` into `mq`.
     ///
-    pub def enqueueAll(mq: MutQueue[a, r], m: m[a]): Unit \ r with Order[a], Iterable[m] =
+    /// TODO: with Order[Iterable.Elm[m]] missing
+    ///
+    pub def enqueueAll(mq: MutQueue[Iterable.Elm[m], r], m: m): Unit \ r with Iterable[m], Order[Iterable.Elm[m]] =
         foreach(x <- m) {
             enqueue(mq, x)
         }

--- a/main/src/library/MutQueue.flix
+++ b/main/src/library/MutQueue.flix
@@ -106,11 +106,9 @@ mod MutQueue {
         else None
 
     ///
-    /// Enqueues each element in `l` into `mq`.
+    /// Enqueues each element in `m` into `mq`.
     ///
-    /// TODO: with Order[Iterable.Elm[m]] missing
-    ///
-    pub def enqueueAll(mq: MutQueue[Iterable.Elm[m], r], m: m): Unit \ r with Iterable[m], Order[Iterable.Elm[m]] =
+    pub def enqueueAll(mq: MutQueue[elt, r], m: m): Unit \ (r + Iterable.Aef[m]) with Iterable[m], Order[elt] where Iterable.Elm[m] ~ elt =
         foreach(x <- m) {
             enqueue(mq, x)
         }

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -137,7 +137,7 @@ instance ToString[Nec[a]] with ToString[a] {
 }
 
 instance Iterable[Nec[a]] {
-    type Elm[Nec[a]] = a
+    type Elm = a
     pub def iterator(rc: Region[r], l: Nec[a]): Iterator[a, r, r] \ r = Nec.iterator(rc, l)
 }
 

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -136,7 +136,8 @@ instance ToString[Nec[a]] with ToString[a] {
     }
 }
 
-instance Iterable[Nec] {
+instance Iterable[Nec[a]] {
+    type Elm[Nec[a]] = a
     pub def iterator(rc: Region[r], l: Nec[a]): Iterator[a, r, r] \ r = Nec.iterator(rc, l)
 }
 

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -138,7 +138,6 @@ instance ToString[Nec[a]] with ToString[a] {
 
 instance Iterable[Nec[a]] {
     type Elm[Nec[a]] = a
-    type Aef[Nec[a]] = Pure
     pub def iterator(rc: Region[r], l: Nec[a]): Iterator[a, r, r] \ r = Nec.iterator(rc, l)
 }
 

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -138,6 +138,7 @@ instance ToString[Nec[a]] with ToString[a] {
 
 instance Iterable[Nec[a]] {
     type Elm[Nec[a]] = a
+    type Aef[Nec[a]] = Pure
     pub def iterator(rc: Region[r], l: Nec[a]): Iterator[a, r, r] \ r = Nec.iterator(rc, l)
 }
 

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -112,7 +112,7 @@ instance SemiGroup[Nel[a]] {
 }
 
 instance Iterable[Nel[a]] {
-    type Elm[Nel[a]] = a
+    type Elm = a
     pub def iterator(rc: Region[r], l: Nel[a]): Iterator[a, r, r] \ r = Nel.iterator(rc, l)
 }
 

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -113,6 +113,7 @@ instance SemiGroup[Nel[a]] {
 
 instance Iterable[Nel[a]] {
     type Elm[Nel[a]] = a
+    type Aef[Nel[a]] = Pure
     pub def iterator(rc: Region[r], l: Nel[a]): Iterator[a, r, r] \ r = Nel.iterator(rc, l)
 }
 

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -113,7 +113,6 @@ instance SemiGroup[Nel[a]] {
 
 instance Iterable[Nel[a]] {
     type Elm[Nel[a]] = a
-    type Aef[Nel[a]] = Pure
     pub def iterator(rc: Region[r], l: Nel[a]): Iterator[a, r, r] \ r = Nel.iterator(rc, l)
 }
 

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -111,7 +111,8 @@ instance SemiGroup[Nel[a]] {
     pub def combine(x: Nel[a], y: Nel[a]): Nel[a] = Nel.append(x, y)
 }
 
-instance Iterable[Nel] {
+instance Iterable[Nel[a]] {
+    type Elm[Nel[a]] = a
     pub def iterator(rc: Region[r], l: Nel[a]): Iterator[a, r, r] \ r = Nel.iterator(rc, l)
 }
 

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -151,6 +151,7 @@ instance CommutativeMonoid[Option[a]] with CommutativeMonoid[a]
 
 instance Iterable[Option[a]] {
     type Elm[Option[a]] = a
+    type Aef[Option[a]] = Pure
     pub def iterator(rc: Region[r], o: Option[a]): Iterator[a, r, r] \ r = Option.iterator(rc, o)
 }
 

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -150,7 +150,7 @@ instance Monoid[Option[a]] with Monoid[a] {
 instance CommutativeMonoid[Option[a]] with CommutativeMonoid[a]
 
 instance Iterable[Option[a]] {
-    type Elm[Option[a]] = a
+    type Elm = a
     pub def iterator(rc: Region[r], o: Option[a]): Iterator[a, r, r] \ r = Option.iterator(rc, o)
 }
 

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -151,7 +151,6 @@ instance CommutativeMonoid[Option[a]] with CommutativeMonoid[a]
 
 instance Iterable[Option[a]] {
     type Elm[Option[a]] = a
-    type Aef[Option[a]] = Pure
     pub def iterator(rc: Region[r], o: Option[a]): Iterator[a, r, r] \ r = Option.iterator(rc, o)
 }
 

--- a/main/src/library/Option.flix
+++ b/main/src/library/Option.flix
@@ -149,7 +149,8 @@ instance Monoid[Option[a]] with Monoid[a] {
 
 instance CommutativeMonoid[Option[a]] with CommutativeMonoid[a]
 
-instance Iterable[Option] {
+instance Iterable[Option[a]] {
+    type Elm[Option[a]] = a
     pub def iterator(rc: Region[r], o: Option[a]): Iterator[a, r, r] \ r = Option.iterator(rc, o)
 }
 

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -86,7 +86,8 @@ instance Filterable[RedBlackTree[k]] with Order[k] {
 
 instance Witherable[RedBlackTree[k]] with Order[k]
 
-instance Iterable[RedBlackTree[k]] {
+instance Iterable[RedBlackTree[k, v]] {
+    type Elm[RedBlackTree[k, v]] = v
     pub def iterator(rc: Region[r], t: RedBlackTree[k, v]): Iterator[v, r, r] \ r =
             RedBlackTree.iterator(rc, t) |> Iterator.map(snd)
 }

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -88,6 +88,7 @@ instance Witherable[RedBlackTree[k]] with Order[k]
 
 instance Iterable[RedBlackTree[k, v]] {
     type Elm[RedBlackTree[k, v]] = v
+    type Aef[RedBlackTree[k, v]] = Pure
     pub def iterator(rc: Region[r], t: RedBlackTree[k, v]): Iterator[v, r, r] \ r =
             RedBlackTree.iterator(rc, t) |> Iterator.map(snd)
 }

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -88,7 +88,6 @@ instance Witherable[RedBlackTree[k]] with Order[k]
 
 instance Iterable[RedBlackTree[k, v]] {
     type Elm[RedBlackTree[k, v]] = v
-    type Aef[RedBlackTree[k, v]] = Pure
     pub def iterator(rc: Region[r], t: RedBlackTree[k, v]): Iterator[v, r, r] \ r =
             RedBlackTree.iterator(rc, t) |> Iterator.map(snd)
 }

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -87,7 +87,7 @@ instance Filterable[RedBlackTree[k]] with Order[k] {
 instance Witherable[RedBlackTree[k]] with Order[k]
 
 instance Iterable[RedBlackTree[k, v]] {
-    type Elm[RedBlackTree[k, v]] = v
+    type Elm = v
     pub def iterator(rc: Region[r], t: RedBlackTree[k, v]): Iterator[v, r, r] \ r =
             RedBlackTree.iterator(rc, t) |> Iterator.map(snd)
 }

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -93,7 +93,6 @@ instance Collectable[Set] {
 
 instance Iterable[Set[a]] {
     type Elm[Set[a]] = a
-    type Aef[Set[a]] = Pure
     pub def iterator(rc: Region[r], s: Set[a]): Iterator[a, r, r] \ r = Set.iterator(rc, s)
 }
 

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -93,6 +93,7 @@ instance Collectable[Set] {
 
 instance Iterable[Set[a]] {
     type Elm[Set[a]] = a
+    type Aef[Set[a]] = Pure
     pub def iterator(rc: Region[r], s: Set[a]): Iterator[a, r, r] \ r = Set.iterator(rc, s)
 }
 

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -91,7 +91,8 @@ instance Collectable[Set] {
     pub def collect(iter: Iterator[a, ef, r]): Set[a] \ { ef, r } with Order[a] = Iterator.toSet(iter)
 }
 
-instance Iterable[Set] {
+instance Iterable[Set[a]] {
+    type Elm[Set[a]] = a
     pub def iterator(rc: Region[r], s: Set[a]): Iterator[a, r, r] \ r = Set.iterator(rc, s)
 }
 

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -92,7 +92,7 @@ instance Collectable[Set] {
 }
 
 instance Iterable[Set[a]] {
-    type Elm[Set[a]] = a
+    type Elm = a
     pub def iterator(rc: Region[r], s: Set[a]): Iterator[a, r, r] \ r = Set.iterator(rc, s)
 }
 

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -99,6 +99,7 @@ instance Collectable[Vector] {
 
 instance Iterable[Vector[a]] {
     type Elm[Vector[a]] = a
+    type Aef[Vector[a]] = Pure
     pub def iterator(rc: Region[r], v: Vector[a]): Iterator[a, r, r] \ r = Vector.iterator(rc, v)
 }
 

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -97,7 +97,8 @@ instance Collectable[Vector] {
     pub def collect(iter: Iterator[a, ef, r]): Vector[a] \ { r, ef } with Order[a] = Iterator.toVector(iter)
 }
 
-instance Iterable[Vector] {
+instance Iterable[Vector[a]] {
+    type Elm[Vector[a]] = a
     pub def iterator(rc: Region[r], v: Vector[a]): Iterator[a, r, r] \ r = Vector.iterator(rc, v)
 }
 

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -99,7 +99,6 @@ instance Collectable[Vector] {
 
 instance Iterable[Vector[a]] {
     type Elm[Vector[a]] = a
-    type Aef[Vector[a]] = Pure
     pub def iterator(rc: Region[r], v: Vector[a]): Iterator[a, r, r] \ r = Vector.iterator(rc, v)
 }
 

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -98,7 +98,7 @@ instance Collectable[Vector] {
 }
 
 instance Iterable[Vector[a]] {
-    type Elm[Vector[a]] = a
+    type Elm = a
     pub def iterator(rc: Region[r], v: Vector[a]): Iterator[a, r, r] \ r = Vector.iterator(rc, v)
 }
 


### PR DESCRIPTION
This PR adds an associated type and effect to `Iterable` and makes `Iterable`'s kind `Type` rather than `Type -> Type`.

The collections that already had `Iterable` instances have been updated along with two examples.