### PR TITLE
fix: Parse error when last token of module is a DocComment

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -653,8 +653,8 @@ object Parser2 {
     def declaration()(implicit s: State): Mark.Closed = {
       val mark = open(consumeDocComments = false)
       docComment()
-      // Handle case where the last thing in a file is a doc-comment
-      if (eof()) {
+      // Handle case where the last thing in a file or module is a doc-comment
+      if (eof() || at(TokenKind.CurlyR)) {
         return close(mark, TreeKind.CommentList)
       }
       // Handle modules

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -870,6 +870,7 @@ object Parser2 {
       docComment()
       // Handle case where the last thing in a file or module is a doc-comment
       if (eof() || at(TokenKind.CurlyR)) {
+        println(currentSourceLocation(), nth(0))
         return close(mark, TreeKind.CommentList)
       }
       // Handle modules
@@ -1485,8 +1486,7 @@ object Parser2 {
              | TokenKind.KeywordDeref => unaryExpr()
         case TokenKind.KeywordIf => ifThenElseExpr()
         case TokenKind.KeywordLet => letMatchExpr()
-        case TokenKind.Annotation if nth(1) == TokenKind.KeywordDef => letRecDefExpr()
-        case TokenKind.KeywordDef => letRecDefExpr()
+        case TokenKind.Annotation | TokenKind.KeywordDef => letRecDefExpr()
         case TokenKind.KeywordImport => letImportExpr()
         case TokenKind.KeywordRegion => scopeExpr()
         case TokenKind.KeywordMatch => matchOrMatchLambdaExpr()


### PR DESCRIPTION
Closes #7604

This issue was this program:
```scala
mod A {

    eff _B {}

    ///

}
```
Which gave a parser error. The reason was that the doc-comment indicates that a declaration is about to follow, but it does not. The fix is to treat the doc-comment as a regular comment, which will behave nicely in an IDE setting, and be harmless otherwise.