### PR TITLE
refactor: change Iterable to iterate over (k, v) for maps (issue #7617)

### DIFF
--- a/main/src/library/DelayMap.flix
+++ b/main/src/library/DelayMap.flix
@@ -44,9 +44,9 @@ instance Foldable[DelayMap[k]] {
 }
 
 instance Iterable[DelayMap[k, v]] {
-    type Elm = v
-    pub def iterator(rc: Region[r], m: DelayMap[k, v]): Iterator[v, r, r] \ r =
-        DelayMap.iterator(rc, m) |> Iterator.map(snd)
+    type Elm = (k, v)
+    pub def iterator(rc: Region[r], m: DelayMap[k, v]): Iterator[(k, v), r, r] \ r =
+        DelayMap.iterator(rc, m)
 }
 
 mod DelayMap {

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -102,8 +102,8 @@ instance MeetLattice[Map[k, v]] with Order[k], Eq[v], MeetLattice[v] {
 }
 
 instance Iterable[Map[k, v]] {
-    type Elm = v
-    pub def iterator(rc: Region[r], m: Map[k, v]): Iterator[v, r, r] \ r = Map.iteratorValues(rc, m)
+    type Elm = (k, v)
+    pub def iterator(rc: Region[r], m: Map[k, v]): Iterator[(k, v), r, r] \ r = Map.iterator(rc, m)
 }
 
 instance ToJava[Map[k, v]] with Order[k] {

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -87,9 +87,9 @@ instance Filterable[RedBlackTree[k]] with Order[k] {
 instance Witherable[RedBlackTree[k]] with Order[k]
 
 instance Iterable[RedBlackTree[k, v]] {
-    type Elm = v
-    pub def iterator(rc: Region[r], t: RedBlackTree[k, v]): Iterator[v, r, r] \ r =
-            RedBlackTree.iterator(rc, t) |> Iterator.map(snd)
+    type Elm = (k, v)
+    pub def iterator(rc: Region[r], t: RedBlackTree[k, v]): Iterator[(k, v), r, r] \ r =
+            RedBlackTree.iterator(rc, t)
 }
 
 mod RedBlackTree {

--- a/main/test/ca/uwaterloo/flix/library/TestIterable.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterable.flix
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Stephen Tetley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mod TestIterable {
+
+    /////////////////////////////////////////////////////////////////////////////
+    // List instance                                                           //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def iterableList01(): Bool = region rc {
+        let l : List[Int32] = Nil;
+        Iterable.iterator(rc, l) |> Iterator.toList == Nil
+    }
+
+    @test
+    def iterableList02(): Bool = region rc {
+        let l = List#{2, 5, 11, 8};
+        Iterable.iterator(rc, l) |> Iterator.toList == List#{2, 5, 11, 8}
+    }
+
+    @test
+    def iterableList03(): Bool = region rc {
+        let l = List#{'A', 'B', 'D', 'C'};
+        Iterable.iterator(rc, l) |> Iterator.toList == List#{'A', 'B', 'D', 'C'}
+    }
+
+    @test
+    def iterableList04(): Bool = region rc {
+        let l = List#{(2, 'A'), (5, 'B'), (11, 'D'), (8, 'C')};
+        Iterable.iterator(rc, l) |> Iterator.toList == List#{(2, 'A'), (5, 'B'), (11, 'D'), (8, 'C')}
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // RedBlackTree instance                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def iterableRedBlackTree01(): Bool = region rc {
+        let t : RedBlackTree[Int32, Char] = RedBlackTree.empty();
+        Iterable.iterator(rc, t) |> Iterator.toList == Nil
+    }
+
+    @test
+    def iterableRedBlackTree02(): Bool = region rc {
+        let Map.Map(t) = Map#{2 => 'A', 5 => 'B', 11 => 'D', 8 => 'C'};
+        Iterable.iterator(rc, t) |> Iterator.toList == List#{(2, 'A'), (5, 'B'), (8, 'C'), (11, 'D')}
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Map instance                                                            //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def iterableMap01(): Bool = region rc {
+        let m : Map[Int32, Char] = Map.empty();
+        Iterable.iterator(rc, m) |> Iterator.toList == Nil
+    }
+
+    @test
+    def iterableMap02(): Bool = region rc {
+        let m = Map#{2 => 'A', 5 => 'B', 11 => 'D', 8 => 'C'};
+        Iterable.iterator(rc, m) |> Iterator.toList == List#{(2, 'A'), (5, 'B'), (8, 'C'), (11, 'D')}
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // DelayMap instance                                                       //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def iterableDelayMap01(): Bool = region rc {
+        let m : DelayMap[Int32, Char] = DelayMap.empty();
+        Iterable.iterator(rc, m) |> Iterator.toList == Nil
+    }
+
+    @test
+    def iterableDelayMap02(): Bool = region rc {
+        let m = Map#{2 => 'A', 5 => 'B', 11 => 'D', 8 => 'C'} |> Map.toDelayMap;
+        Iterable.iterator(rc, m) |> Iterator.toList == List#{(2, 'A'), (5, 'B'), (8, 'C'), (11, 'D')}
+    }
+
+}

--- a/main/test/flix/Test.Exp.ForEachYield.flix
+++ b/main/test/flix/Test.Exp.ForEachYield.flix
@@ -215,87 +215,87 @@ mod Test.Exp.ForEachYield {
             yield (x, y, z)
 
     @test
-    def testForEachYieldMix15(): List[(Int32, Int32, Bool)] =
+    def testForEachYieldMix15(): List[(Int32, Int32, String, Bool)] =
         let a = List.toSet((1, 2) :: (3, 4) :: Nil);
         let b = Map#{"1" => true, "2" => true, "3" => true};
-        foreach ((x, y) <- a; z <- b)
-            yield (x, y, z)
+        foreach ((x, y) <- a; (k, v) <- b)
+            yield (x, y, k, v)
 
     @test
-    def testForEachYieldMix16(): Set[(Int32, Int32, Bool)] =
+    def testForEachYieldMix16(): Set[(Int32, Int32, String, Bool)] =
         let a = List.toSet((1, 2) :: (3, 4) :: Nil);
         let b = Map#{"1" => true, "2" => true, "3" => true};
-        foreach ((x, y) <- a; z <- b)
-            yield (x, y, z)
+        foreach ((x, y) <- a; (k, v) <- b)
+            yield (x, y, k, v)
 
     @test
-    def testForEachYieldMix17(): Chain[(Int32, Int32, Bool)] =
+    def testForEachYieldMix17(): Chain[(Int32, Int32, String, Bool)] =
         let a = List.toSet((1, 2) :: (3, 4) :: Nil);
         let b = Map#{"1" => true, "2" => true, "3" => true};
-        foreach ((x, y) <- a; z <- b)
-            yield (x, y, z)
+        foreach ((x, y) <- a; (k, v) <- b)
+            yield (x, y, k, v)
 
     // N.B. There is no instance of `Order` on `Chain` so we cannot have `m[Chain[a]] with Collectable[m]`
 
     @test
-    def testForEachYieldMix18(): List[List[(Int32, String, Bool, Int32)]] =
+    def testForEachYieldMix18(): List[List[(Int32, String, String, Bool, Int32)]] =
         let a = List.toSet((1, 2) :: (3, 4) :: Nil);
         let b = Map#{"1" => true, "2" => true, "3" => true};
         let c = Set#{"5", "6", "7"};
-        foreach ((x, y) <- a; z <- b)
+        foreach ((x, y) <- a; (k, v) <- b)
             yield
                 foreach (q <- c)
-                    yield (x, q, z, y)
+                    yield (x, q, k, v, y)
 
     @test
-    def testForEachYieldMix19(): List[Set[(Int32, String, Bool, Int32)]] =
+    def testForEachYieldMix19(): List[Set[(Int32, String, String, Bool, Int32)]] =
         let a = List.toSet((1, 2) :: (3, 4) :: Nil);
         let b = Map#{"1" => true, "2" => true, "3" => true};
         let c = Set#{"5", "6", "7"};
-        foreach ((x, y) <- a; z <- b)
+        foreach ((x, y) <- a; (k, v) <- b)
             yield
                 foreach (q <- c)
-                    yield (x, q, z, y)
+                    yield (x, q, k, v, y)
 
     @test
-    def testForEachYieldMix20(): Set[List[(Int32, String, Bool, Int32)]] =
+    def testForEachYieldMix20(): Set[List[(Int32, String, String, Bool, Int32)]] =
         let a = List.toSet((1, 2) :: (3, 4) :: Nil);
         let b = Map#{"1" => true, "2" => true, "3" => true};
         let c = Set#{"5", "6", "7"};
-        foreach ((x, y) <- a; z <- b)
+        foreach ((x, y) <- a; (k, v) <- b)
             yield
                 foreach (q <- c)
-                    yield (x, q, z, y)
+                    yield (x, q, k, v, y)
 
     @test
-    def testForEachYieldMix21(): Set[Set[(Int32, String, Bool, Int32)]] =
+    def testForEachYieldMix21(): Set[Set[(Int32, String, String, Bool, Int32)]] =
         let a = List.toSet((1, 2) :: (3, 4) :: Nil);
         let b = Map#{"1" => true, "2" => true, "3" => true};
         let c = Set#{"5", "6", "7"};
-        foreach ((x, y) <- a; z <- b)
+        foreach ((x, y) <- a; (k, v) <- b)
             yield
                 foreach (q <- c)
-                    yield (x, q, z, y)
+                    yield (x, q, k, v, y)
 
     @test
-    def testForEachYieldMix22(): Chain[List[(Int32, String, Bool, Int32)]] =
+    def testForEachYieldMix22(): Chain[List[(Int32, String, String, Bool, Int32)]] =
         let a = List.toSet((1, 2) :: (3, 4) :: Nil);
         let b = Map#{"1" => true, "2" => true, "3" => true};
         let c = Set#{"5", "6", "7"};
-        foreach ((x, y) <- a; z <- b)
+        foreach ((x, y) <- a; (k, v) <- b)
             yield
                 foreach (q <- c)
-                    yield (x, q, z, y)
+                    yield (x, q, k, v, y)
 
     @test
-    def testForEachYieldMix23(): Chain[Set[(Int32, String, Bool, Int32)]] =
+    def testForEachYieldMix23(): Chain[Set[(Int32, String, String, Bool, Int32)]] =
         let a = List.toSet((1, 2) :: (3, 4) :: Nil);
         let b = Map#{"1" => true, "2" => true, "3" => true};
         let c = Set#{"5", "6", "7"};
-        foreach ((x, y) <- a; z <- b)
+        foreach ((x, y) <- a; (k, v) <- b)
             yield
                 foreach (q <- c)
-                    yield (x, q, z, y)
+                    yield (x, q, k, v, y)
 
     @test
     def testForEachYieldLet01(): List[(Int32, Int32)] =


### PR DESCRIPTION
This PR changes `Iterable` to iterate over key-value pairs on `Map`, `DelayMap` and `RedBlackTree`.