### PR TITLE
feat: add `TokenKind.display` for better errors

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -546,8 +546,8 @@ class Flix {
     val result = for {
       afterReader <- Reader.run(getInputs)
       afterLexer <- Lexer.run(afterReader, cachedLexerTokens, changeSet)
-//      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
-//      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
+      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
+      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
 
       // Plan for migrating to new parser + weeder:
       // Stage 1 [ACTIVE]
@@ -581,9 +581,9 @@ class Flix {
       // Update caches for incremental compilation.
       if (options.incremental) {
         this.cachedLexerTokens = afterLexer
-//        this.cachedParserAst = afterParser
+        this.cachedParserAst = afterParser
         this.cachedParserCst = afterParser2
-//        this.cachedWeederAst = afterWeeder
+        this.cachedWeederAst = afterWeeder
         this.cachedWeederAst2 = afterWeeder2
         this.cachedDesugarAst = afterDesugar
         this.cachedKinderAst = afterKinder

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -546,8 +546,8 @@ class Flix {
     val result = for {
       afterReader <- Reader.run(getInputs)
       afterLexer <- Lexer.run(afterReader, cachedLexerTokens, changeSet)
-      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
-      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
+//      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
+//      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
 
       // Plan for migrating to new parser + weeder:
       // Stage 1 [ACTIVE]
@@ -581,9 +581,9 @@ class Flix {
       // Update caches for incremental compilation.
       if (options.incremental) {
         this.cachedLexerTokens = afterLexer
-        this.cachedParserAst = afterParser
+//        this.cachedParserAst = afterParser
         this.cachedParserCst = afterParser2
-        this.cachedWeederAst = afterWeeder
+//        this.cachedWeederAst = afterWeeder
         this.cachedWeederAst2 = afterWeeder2
         this.cachedDesugarAst = afterDesugar
         this.cachedKinderAst = afterKinder

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -1,19 +1,15 @@
 /*
  * Copyright 2023 Herluf Baggesen
  *
- * Licensed under the Apache License
-case TokenKind. Version 2.0 (the "License");
+ * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing
-case TokenKind. software
+ * Unless required by applicable law or agreed to in writing software
  * distributed under the License is distributed on an "AS IS" BASIS
-case TokenKind.
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND
-case TokenKind. either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -1,15 +1,19 @@
 /*
  * Copyright 2023 Herluf Baggesen
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License
+case TokenKind. Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * Unless required by applicable law or agreed to in writing
+case TokenKind. software
+ * distributed under the License is distributed on an "AS IS" BASIS
+case TokenKind.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND
+case TokenKind. either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
@@ -17,7 +21,185 @@ package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.language.errors.LexerError
 
-sealed trait TokenKind
+sealed trait TokenKind {
+  /**
+    * A string representation of the [[TokenKind]] suitable for printing.
+    * For instance TokenKind.Ampersand.display gives "'&'".
+    */
+  def display: String = {
+    this match {
+      case TokenKind.Ampersand => "'^'"
+      case TokenKind.AngledEqual => "'<=>'"
+      case TokenKind.AngledPlus => "'<+>'"
+      case TokenKind.AngleL => "'<'"
+      case TokenKind.AngleLEqual => "'<='"
+      case TokenKind.AngleR => "'>'"
+      case TokenKind.AngleREqual => "'>='"
+      case TokenKind.ArrayHash => "'Array#'"
+      case TokenKind.ArrowThickR => "'=>'"
+      case TokenKind.ArrowThinL => "'<-'"
+      case TokenKind.ArrowThinR => "'->'"
+      case TokenKind.At => "'@'"
+      case TokenKind.Backslash => "'\\'"
+      case TokenKind.Bang => "'!'"
+      case TokenKind.BangEqual => "'!='"
+      case TokenKind.Bar => "'|'"
+      case TokenKind.BracketL => "'['"
+      case TokenKind.BracketR => "']'"
+      case TokenKind.Caret => "'^'"
+      case TokenKind.Colon => "':'"
+      case TokenKind.ColonColon => "'::'"
+      case TokenKind.ColonEqual => "':='"
+      case TokenKind.ColonMinus => "':-'"
+      case TokenKind.Comma => "','"
+      case TokenKind.CurlyL => "'{'"
+      case TokenKind.CurlyR => "'}'"
+      case TokenKind.Dollar => "'$'"
+      case TokenKind.Dot => "'.'"
+      case TokenKind.DotCurlyL => "'.{'"
+      case TokenKind.Equal => "'='"
+      case TokenKind.EqualEqual => "'=='"
+      case TokenKind.Hash => "'#'"
+      case TokenKind.HashCurlyL => "'#{'"
+      case TokenKind.HashParenL => "'#('"
+      case TokenKind.HoleAnonymous => "'???'"
+      case TokenKind.KeywordAlias => "'alias'"
+      case TokenKind.KeywordAnd => "'and'"
+      case TokenKind.KeywordAs => "'as'"
+      case TokenKind.KeywordCase => "'case'"
+      case TokenKind.KeywordCatch => "'catch'"
+      case TokenKind.KeywordCheckedCast => "'checked_cast'"
+      case TokenKind.KeywordCheckedECast => "'checked_ecast'"
+      case TokenKind.KeywordChoose => "'choose'"
+      case TokenKind.KeywordChooseStar => "'choose*'"
+      case TokenKind.KeywordDebug => "'debug'"
+      case TokenKind.KeywordDebugBang => "'debug!'"
+      case TokenKind.KeywordDebugBangBang => "'debug!'"
+      case TokenKind.KeywordDef => "'def'"
+      case TokenKind.KeywordDeref => "'deref'"
+      case TokenKind.KeywordDiscard => "'discard'"
+      case TokenKind.KeywordDo => "'do'"
+      case TokenKind.KeywordEff => "'eff'"
+      case TokenKind.KeywordElse => "'else'"
+      case TokenKind.KeywordEnum => "'enum'"
+      case TokenKind.KeywordFalse => "'false'"
+      case TokenKind.KeywordFix => "'fix'"
+      case TokenKind.KeywordForA => "'forA'"
+      case TokenKind.KeywordForall => "'forall'"
+      case TokenKind.KeywordForce => "'force'"
+      case TokenKind.KeywordForeach => "'foreach'"
+      case TokenKind.KeywordForM => "'forM'"
+      case TokenKind.KeywordFrom => "'from'"
+      case TokenKind.KeywordIf => "'if'"
+      case TokenKind.KeywordImport => "'import'"
+      case TokenKind.KeywordInject => "'inject'"
+      case TokenKind.KeywordInline => "'inline'"
+      case TokenKind.KeywordInstance => "'instance'"
+      case TokenKind.KeywordInstanceOf => "'instanceof'"
+      case TokenKind.KeywordInto => "'into'"
+      case TokenKind.KeywordJavaGetField => "'java_get_field'"
+      case TokenKind.KeywordJavaNew => "'java_new'"
+      case TokenKind.KeywordJavaSetField => "'java_set_field'"
+      case TokenKind.KeywordLaw => "'law'"
+      case TokenKind.KeywordLawful => "'lawful'"
+      case TokenKind.KeywordLazy => "'lazy'"
+      case TokenKind.KeywordLet => "'let'"
+      case TokenKind.KeywordMaskedCast => "'masked_cast'"
+      case TokenKind.KeywordMatch => "'match'"
+      case TokenKind.KeywordMod => "'mod'"
+      case TokenKind.KeywordNew => "'new'"
+      case TokenKind.KeywordNot => "'not'"
+      case TokenKind.KeywordNull => "'null'"
+      case TokenKind.KeywordOpenVariant => "'open_variant'"
+      case TokenKind.KeywordOpenVariantAs => "'open_variant_as'"
+      case TokenKind.KeywordOr => "'or'"
+      case TokenKind.KeywordOverride => "'override'"
+      case TokenKind.KeywordPar => "'par'"
+      case TokenKind.KeywordPub => "'pub'"
+      case TokenKind.KeywordPure => "'Pure'"
+      case TokenKind.KeywordProject => "'project'"
+      case TokenKind.KeywordQuery => "'query'"
+      case TokenKind.KeywordRef => "'ref'"
+      case TokenKind.KeywordRegion => "'region'"
+      case TokenKind.KeywordRestrictable => "'restrictable'"
+      case TokenKind.KeywordRvadd => "'rvadd'"
+      case TokenKind.KeywordRvand => "'rvand'"
+      case TokenKind.KeywordRvnot => "'rvnot'"
+      case TokenKind.KeywordRvsub => "'rvsub'"
+      case TokenKind.KeywordSealed => "'sealed'"
+      case TokenKind.KeywordSelect => "'select'"
+      case TokenKind.KeywordSolve => "'solve'"
+      case TokenKind.KeywordSpawn => "'spawn'"
+      case TokenKind.KeywordStatic => "'static'"
+      case TokenKind.KeywordStaticUppercase => "'Static'"
+      case TokenKind.KeywordTrait => "'trait'"
+      case TokenKind.KeywordTrue => "'true'"
+      case TokenKind.KeywordTry => "'try'"
+      case TokenKind.KeywordType => "'type'"
+      case TokenKind.KeywordTypeMatch => "'typematch'"
+      case TokenKind.KeywordUncheckedCast => "'unchecked_cast'"
+      case TokenKind.KeywordUniv => "'univ'"
+      case TokenKind.KeywordUse => "'use'"
+      case TokenKind.KeywordWhere => "'where'"
+      case TokenKind.KeywordWith => "'with'"
+      case TokenKind.KeywordWithout => "'without'"
+      case TokenKind.KeywordYield => "'yield'"
+      case TokenKind.KeywordXor => "'xor'"
+      case TokenKind.ListHash => "'List#'"
+      case TokenKind.MapHash => "'Map#'"
+      case TokenKind.Minus => "'-'"
+      case TokenKind.ParenL => "'('"
+      case TokenKind.ParenR => "')'"
+      case TokenKind.Plus => "'+'"
+      case TokenKind.Semi => "';'"
+      case TokenKind.SetHash => "'Set#'"
+      case TokenKind.Slash => "'/'"
+      case TokenKind.Star => "'*'"
+      case TokenKind.StarStar => "'**'"
+      case TokenKind.Tilde => "'~'"
+      case TokenKind.TripleAmpersand => "'&&&'"
+      case TokenKind.TripleAngleL => "'<<<'"
+      case TokenKind.TripleAngleR => "'>>>'"
+      case TokenKind.TripleBar => "'|||'"
+      case TokenKind.TripleCaret => "'^^^'"
+      case TokenKind.TripleColon => "':::'"
+      case TokenKind.TripleTilde => "'~~~'"
+      case TokenKind.Underscore => "'_'"
+      case TokenKind.VectorHash => "'Vector#'"
+      case TokenKind.Eof => "<end-of-file>"
+      case TokenKind.NameLowerCase => "<name>"
+      case TokenKind.NameUpperCase => "<Name>"
+      case TokenKind.NameMath => "<math name>"
+      case TokenKind.NameGreek => "<greek name>"
+      case TokenKind.NameJava => "<java name>"
+      case TokenKind.UserDefinedOperator => "<user-defined operator>"
+      case TokenKind.Annotation => "<annotation>"
+      case TokenKind.BuiltIn => "<built in>"
+      case TokenKind.CommentBlock => "<block comment>"
+      case TokenKind.CommentDoc => "<doc comment>"
+      case TokenKind.CommentLine => "<comment>"
+      case TokenKind.HoleNamed => "<named hole>"
+      case TokenKind.HoleVariable => "<variable hole>"
+      case TokenKind.InfixFunction => "<infix function>"
+      case TokenKind.LiteralBigDecimal => "'<digits>ff'"
+      case TokenKind.LiteralBigInt => "'<digits>ii'"
+      case TokenKind.LiteralDebugStringL => "'%{'"
+      case TokenKind.LiteralDebugStringR => "'}'"
+      case TokenKind.LiteralFloat32 => "'<digits>f32'"
+      case TokenKind.LiteralFloat64 => "'<digits>f64'"
+      case TokenKind.LiteralInt8 => "'<digits>i8'"
+      case TokenKind.LiteralInt16 => "'<digits>i16'"
+      case TokenKind.LiteralInt32 => "'<digits>i32'"
+      case TokenKind.LiteralInt64 => "'<digits>i64'"
+      case TokenKind.LiteralRegex => "<regex>"
+      case TokenKind.LiteralString => "<string>"
+      case TokenKind.LiteralChar => "<char>"
+      case TokenKind.LiteralStringInterpolationL => "'${'"
+      case TokenKind.LiteralStringInterpolationR => "'}'"
+      case TokenKind.Err(_) => "<error>"
+    }
+  }
+}
 
 /**
   * Tokens are named for 'what they are' rather than 'what they represent'.
@@ -170,8 +352,6 @@ object TokenKind {
   case object KeywordIf extends TokenKind
 
   case object KeywordImport extends TokenKind
-
-  case object KeywordImpure extends TokenKind
 
   case object KeywordInject extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -1,14 +1,14 @@
 /*
  * Copyright 2023 Herluf Baggesen
  *
- * Licensed under the Apache License Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing software
- * distributed under the License is distributed on an "AS IS" BASIS
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -7,9 +7,9 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -24,7 +24,6 @@ import ca.uwaterloo.flix.language.errors.{ParseError, WeederError}
 import ca.uwaterloo.flix.util.Validation._
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps, Validation}
 import org.parboiled2.ParserInput
-
 import scala.collection.mutable.ArrayBuffer
 
 /**
@@ -147,9 +146,6 @@ object Parser2 {
     root()
     // Build the syntax tree using events in state.
     val tree = buildTree()
-    if (src.name == "main/foo.flix") {
-      println(syntaxTreeToDebugString(tree))
-    }
     // Return with errors as soft failures to run subsequent phases for more validations.
     Validation.success(tree).withSoftFailures(s.errors)
   }


### PR DESCRIPTION
This PR add a way to get a display string for a `TokenKind`.

This allows `Parser2` to emit more easily read errors like these:
```scala
eff
def main(): Int32 = 123
```
```text
>> Parse Error: Expected <Name> before 'def'

1 | eff
    ^^^
    Here
Syntactic Context: Unknown.
```
or here:
```scala
def foo(): Int32 = 123;
enum Legumes { case BlackBeans }
```
```text
>> Parse Error: Expected <expression> before 'enum'

1 | def foo(): Int32 = 123;
                          ^
                          Here
Syntactic Context: OtherExpr.
```

This PR also aligns all errors that `Parser2` produces to these principles:
- A concrete TokenKind is displayed with ticks, ie. `'and'`
- A runtime specific TokenKind is displayed with angles, ie. `<name>`
- A large group of token kinds with a sensible name is also displayed with angles, ie. `<expression>` or `<pattern>`
- Use phrasing "Expected xyz before wqk" where possible.