### PR TITLE
refactor: add assoc effect to ToJava (part of issue #7433)

### DIFF
--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -121,6 +121,7 @@ instance Iterable[Chain[a]] {
 
 instance ToJava[Chain[a]] {
     type O = ##java.util.List
+    type Aef = IO
     pub def toJava(c: Chain[a]): ##java.util.List \ IO = Adaptor.toList(c)
 }
 

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -127,6 +127,7 @@ instance Iterable[List[a]] {
 
 instance ToJava[List[a]] {
     type O = ##java.util.List
+    type Aef = IO
     pub def toJava(l: List[a]): ##java.util.List \ IO = Adaptor.toList(l)
 }
 

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -108,6 +108,7 @@ instance Iterable[Map[k, v]] {
 
 instance ToJava[Map[k, v]] with Order[k] {
     type O = ##java.util.Map
+    type Aef = IO
     pub def toJava(m: Map[k, v]): ##java.util.Map \ IO = Adaptor.toMap(m)
 }
 

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -143,6 +143,7 @@ instance Iterable[Nec[a]] {
 
 instance ToJava[Nec[a]] {
     type O = ##java.util.List
+    type Aef = IO
     pub def toJava(l: Nec[a]): ##java.util.List \ IO = Adaptor.toList(l)
 }
 

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -118,6 +118,7 @@ instance Iterable[Nel[a]] {
 
 instance ToJava[Nel[a]] {
     type O = ##java.util.List
+    type Aef = IO
     pub def toJava(l: Nel[a]): ##java.util.List \ IO = Adaptor.toList(l)
 }
 

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -98,6 +98,7 @@ instance Iterable[Set[a]] {
 
 instance ToJava[Set[a]] with Order[a] {
     type O = ##java.util.Set
+    type Aef = IO
     pub def toJava(s: Set[a]): ##java.util.Set \ IO = Adaptor.toSet(s)
 }
 

--- a/main/src/library/ToJava.flix
+++ b/main/src/library/ToJava.flix
@@ -18,6 +18,7 @@
 /// A trait for marshaling values to Java.
 ///
 pub trait ToJava[t: Type] {
-    type O
-    pub def toJava(t: t): ToJava.O[t] \ IO
+    type O[t]: Type
+    type Aef[t]: Eff = Pure
+    pub def toJava(t: t): ToJava.O[t] \ ToJava.Aef[t]
 }

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -104,6 +104,7 @@ instance Iterable[Vector[a]] {
 
 instance ToJava[Vector[a]] {
     type O = ##java.util.List
+    type Aef = IO
     pub def toJava(v: Vector[a]): ##java.util.List \ IO = Adaptor.toList(v)
 }
 


### PR DESCRIPTION
This PR adds an associated effect to `ToJava`.

Adding a `FromJava` class will follow in another PR.