### PR TITLE
feat: add FromJava trait (part of issue #7433)

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -317,6 +317,7 @@ class Flix {
     "Regex.flix" -> LocalResource.get("/src/library/Regex.flix"),
     "Adaptor.flix" -> LocalResource.get("/src/library/Adaptor.flix"),
     "ToJava.flix" -> LocalResource.get("/src/library/ToJava.flix"),
+    "FromJava.flix" -> LocalResource.get("/src/library/FromJava.flix"),
   )
 
   /**

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -120,9 +120,17 @@ instance Iterable[Chain[a]] {
 }
 
 instance ToJava[Chain[a]] {
-    type O = ##java.util.List
+    type Out = ##java.util.List
     type Aef = IO
     pub def toJava(c: Chain[a]): ##java.util.List \ IO = Adaptor.toList(c)
+}
+
+instance FromJava[Chain[a]] {
+    type In = ##java.util.List
+    pub def fromJava(l: ##java.util.List): Chain[a] = region rc {
+        import java.util.List.iterator(): ##java.util.Iterator \ rc;
+        iterator(l) |> Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[a])) |> Iterator.toChain
+    }
 }
 
 mod Chain {

--- a/main/src/library/FromJava.flix
+++ b/main/src/library/FromJava.flix
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2023 Stephen Tetley
+ *  Copyright 2024 Stephen Tetley
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 
 ///
-/// A trait for marshaling values to Java.
+/// A trait for marshaling values from Java.
 ///
-pub trait ToJava[t: Type] {
-    type Out[t]: Type
+pub trait FromJava[t: Type] {
+    type In[t]: Type
     type Aef[t]: Eff = Pure
-    pub def toJava(t: t): ToJava.Out[t] \ ToJava.Aef[t]
+    pub def fromJava(t: FromJava.In[t]): t \ FromJava.Aef[t]
 }

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -126,9 +126,14 @@ instance Iterable[List[a]] {
 }
 
 instance ToJava[List[a]] {
-    type O = ##java.util.List
+    type Out = ##java.util.List
     type Aef = IO
     pub def toJava(l: List[a]): ##java.util.List \ IO = Adaptor.toList(l)
+}
+
+instance FromJava[List[a]] {
+    type In = ##java.util.List
+    pub def fromJava(l: ##java.util.List): List[a]  = Adaptor.fromList(l)
 }
 
 mod List {

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -107,9 +107,14 @@ instance Iterable[Map[k, v]] {
 }
 
 instance ToJava[Map[k, v]] with Order[k] {
-    type O = ##java.util.Map
+    type Out = ##java.util.Map
     type Aef = IO
     pub def toJava(m: Map[k, v]): ##java.util.Map \ IO = Adaptor.toMap(m)
+}
+
+instance FromJava[Map[k, v]] with Order[k] {
+    type In = ##java.util.Map
+    pub def fromJava(m: ##java.util.Map): Map[k, v] = Adaptor.fromMap(m)
 }
 
 mod Map {

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -142,7 +142,7 @@ instance Iterable[Nec[a]] {
 }
 
 instance ToJava[Nec[a]] {
-    type O = ##java.util.List
+    type Out = ##java.util.List
     type Aef = IO
     pub def toJava(l: Nec[a]): ##java.util.List \ IO = Adaptor.toList(l)
 }

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -117,7 +117,7 @@ instance Iterable[Nel[a]] {
 }
 
 instance ToJava[Nel[a]] {
-    type O = ##java.util.List
+    type Out = ##java.util.List
     type Aef = IO
     pub def toJava(l: Nel[a]): ##java.util.List \ IO = Adaptor.toList(l)
 }

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -97,9 +97,14 @@ instance Iterable[Set[a]] {
 }
 
 instance ToJava[Set[a]] with Order[a] {
-    type O = ##java.util.Set
+    type Out = ##java.util.Set
     type Aef = IO
     pub def toJava(s: Set[a]): ##java.util.Set \ IO = Adaptor.toSet(s)
+}
+
+instance FromJava[Set[a]] with Order[a] {
+    type In = ##java.util.Set
+    pub def fromJava(s: ##java.util.Set): Set[a] = Adaptor.fromSet(s)
 }
 
 mod Set {

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -108,6 +108,15 @@ instance ToJava[Vector[a]] {
     pub def toJava(v: Vector[a]): ##java.util.List \ IO = Adaptor.toList(v)
 }
 
+
+instance FromJava[Vector[a]] {
+    type In = ##java.util.List
+    pub def fromJava(l: ##java.util.List): Vector[a] = region rc {
+        import java.util.List.iterator(): ##java.util.Iterator \ rc;
+        iterator(l) |> Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[a])) |> Iterator.toVector
+    }
+}
+
 mod Vector {
 
     ///

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -103,7 +103,7 @@ instance Iterable[Vector[a]] {
 }
 
 instance ToJava[Vector[a]] {
-    type O = ##java.util.List
+    type Out = ##java.util.List
     type Aef = IO
     pub def toJava(v: Vector[a]): ##java.util.List \ IO = Adaptor.toList(v)
 }

--- a/main/test/ca/uwaterloo/flix/library/TestFromJava.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFromJava.flix
@@ -1,0 +1,129 @@
+/*
+ *  Copyright 2024 Stephen Tetley
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+mod TestFromJava {
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Chain                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def chainFromJava01(): Bool =
+        import static java.util.List.of(): ##java.util.List \ {};
+        let l = of();
+        (FromJava.fromJava(l): Chain[String]) == (Chain.empty(): Chain[String])
+
+    @test
+    def chainFromJava02(): Bool =
+        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
+        let l = of(checked_cast("one"));
+        (FromJava.fromJava(l): Chain[String]) == Chain.singleton("one")
+
+    @test
+    def chainFromJava03(): Bool =
+        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
+        let l = of(checked_cast("one"), checked_cast("two"));
+        (FromJava.fromJava(l): Chain[String]) == List.toChain(List#{"one", "two"})
+
+    /////////////////////////////////////////////////////////////////////////////
+    // List                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def listFromJava01(): Bool =
+        import static java.util.List.of(): ##java.util.List \ {};
+        let l = of();
+        (FromJava.fromJava(l): List[String]) == (Nil: List[String])
+
+    @test
+    def listFromJava02(): Bool =
+        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
+        let l = of(checked_cast("one"));
+        (FromJava.fromJava(l): List[String]) == List#{"one"}
+
+    @test
+    def listFromJava03(): Bool =
+        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
+        let l = of(checked_cast("one"), checked_cast("two"));
+        (FromJava.fromJava(l): List[String]) == List#{"one", "two"}
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Map                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def mapFromJava01(): Bool =
+        import static java.util.Map.of(): ##java.util.Map \ {};
+        let m = of();
+        (FromJava.fromJava(m): Map[String, String]) == Map#{}
+
+    @test
+    def mapFromJava02(): Bool =
+        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
+        let m = of(checked_cast("a"), checked_cast("one"));
+        (FromJava.fromJava(m): Map[String, String]) == Map#{"a" => "one"}
+
+    @test
+    def mapFromJava03(): Bool =
+        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object, ##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
+        let m = of(checked_cast("a"), checked_cast("one"), checked_cast("b"), checked_cast("two"));
+        (FromJava.fromJava(m): Map[String, String]) == Map#{"a" => "one", "b" => "two"}
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Set                                                                     //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def setFromJava01(): Bool=
+        import static java.util.Set.of(): ##java.util.Set \ {};
+        let s = of();
+        (FromJava.fromJava(s): Set[String]) == Set#{}
+
+    @test
+    def setFromJava02(): Bool =
+        import static java.util.Set.of(##java.lang.Object): ##java.util.Set \ {};
+        let s = of(checked_cast("one"));
+        (FromJava.fromJava(s): Set[String]) == Set#{"one"}
+
+    @test
+    def setFromJava03(): Bool =
+        import static java.util.Set.of(##java.lang.Object, ##java.lang.Object): ##java.util.Set \ {};
+        let s = of(checked_cast("one"), checked_cast("two"));
+        (FromJava.fromJava(s): Set[String]) == Set#{"one", "two"}
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Vector                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def vectorFromJava01(): Bool =
+        import static java.util.List.of(): ##java.util.List \ {};
+        let v = of();
+        (FromJava.fromJava(v): Vector[String]) == Vector#{}
+
+    @test
+    def vectorFromJava02(): Bool =
+        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
+        let v = of(checked_cast("one"));
+        (FromJava.fromJava(v): Vector[String]) == Vector#{"one"}
+
+    @test
+    def vectorFromJava03(): Bool =
+        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
+        let v = of(checked_cast("one"), checked_cast("two"));
+        (FromJava.fromJava(v): Vector[String]) == Vector#{"one", "two"}
+
+}

--- a/main/test/ca/uwaterloo/flix/library/TestToJava.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestToJava.flix
@@ -132,21 +132,21 @@ mod TestToJava {
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def toSet01(): Bool \ IO =
+    def setToJava01(): Bool \ IO =
         import static java.util.Set.of(): ##java.util.Set \ {};
         import java.util.Set.equals(##java.lang.Object): Bool \ {};
         let s: ##java.util.Set = ToJava.toJava((Set#{} : Set[String]));
         equals(of(), checked_cast(s))
 
     @test
-    def toSet02(): Bool \ IO =
+    def setToJava02(): Bool \ IO =
         import static java.util.Set.of(##java.lang.Object): ##java.util.Set \ {};
         import java.util.Set.equals(##java.lang.Object): Bool \ {};
         let s: ##java.util.Set = ToJava.toJava(Set#{"one"});
         equals(of(checked_cast("one")), checked_cast(s))
 
     @test
-    def toSet03(): Bool \ IO =
+    def setToJava03(): Bool \ IO =
         import static java.util.Set.of(##java.lang.Object, ##java.lang.Object): ##java.util.Set \ {};
         import java.util.Set.equals(##java.lang.Object): Bool \ {};
         let s: ##java.util.Set = ToJava.toJava(Set#{"one", "two"});


### PR DESCRIPTION
This PR adds the trait `FromJava` and instances for types that have `ToJava` except `Nec` and `Nel` as we cannot assert the input to them is non-empty.
        
The tests were derived from `TestToJava.flix` and I spotted some inconsistent names that I corrected.
