### PR TITLE
feat: add `SyntacticContext` to `expect`, `expectAny` and `name`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -24,6 +24,7 @@ import ca.uwaterloo.flix.language.errors.{ParseError, WeederError}
 import ca.uwaterloo.flix.util.Validation._
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps, Validation}
 import org.parboiled2.ParserInput
+
 import scala.collection.mutable.ArrayBuffer
 
 /**
@@ -353,8 +354,6 @@ object Parser2 {
 
   /**
     * Checks if the parser is at a token of kind in `kinds`.
-    * TODO: We can get a little performance from using BitSets here.
-    * It complicates the implementation though, since each TokenKind must then have an Int representation.
     */
   private def atAny(kinds: Set[TokenKind])(implicit s: State): Boolean = {
     kinds.contains(nth(0))
@@ -392,17 +391,17 @@ object Parser2 {
     * expect(TokenKind.ParenL)
     * Means "if (" with no comment in-between "if" and "(".
     */
-  private def expect(kind: TokenKind)(implicit s: State): Unit = {
+  private def expect(kind: TokenKind, context: SyntacticContext)(implicit s: State): Unit = {
     if (eat(kind)) {
       return
     }
 
     val mark = open()
     val error = nth(0) match {
-      case TokenKind.CommentLine => ParseError(s"Invalid comment", SyntacticContext.Unknown, previousSourceLocation())
-      case TokenKind.CommentBlock => ParseError(s"Invalid comment", SyntacticContext.Unknown, previousSourceLocation())
-      case TokenKind.CommentDoc => ParseError(s"Doc-comments can only decorate declarations.", SyntacticContext.Unknown, previousSourceLocation())
-      case at => ParseError(s"Expected ${kind.display} before ${at.display}", SyntacticContext.Unknown, previousSourceLocation())
+      case TokenKind.CommentLine => ParseError(s"Invalid comment", context, previousSourceLocation())
+      case TokenKind.CommentBlock => ParseError(s"Invalid comment", context, previousSourceLocation())
+      case TokenKind.CommentDoc => ParseError(s"Doc-comments can only decorate declarations.", context, previousSourceLocation())
+      case at => ParseError(s"Expected ${kind.display} before ${at.display}", context, previousSourceLocation())
     }
     closeWithError(mark, error)
   }
@@ -420,15 +419,15 @@ object Parser2 {
   /**
     * Advance past current token if it is of kind in `kinds`. Otherwise wrap it in an error.
     */
-  private def expectAny(kinds: Set[TokenKind])(implicit s: State): Unit = {
+  private def expectAny(kinds: Set[TokenKind], context: SyntacticContext)(implicit s: State): Unit = {
     if (eatAny(kinds)) {
       return
     }
     val mark = open()
     val error = nth(0) match {
-      case TokenKind.CommentLine => ParseError(s"Invalid comment", SyntacticContext.Unknown, previousSourceLocation())
-      case TokenKind.CommentBlock => ParseError(s"Invalid comment", SyntacticContext.Unknown, previousSourceLocation())
-      case TokenKind.CommentDoc => ParseError(s"Doc-comments can only decorate declarations.", SyntacticContext.Unknown, previousSourceLocation())
+      case TokenKind.CommentLine => ParseError(s"Invalid comment", context, previousSourceLocation())
+      case TokenKind.CommentBlock => ParseError(s"Invalid comment", context, previousSourceLocation())
+      case TokenKind.CommentDoc => ParseError(s"Doc-comments can only decorate declarations.", context, previousSourceLocation())
       case at =>
         val kindsDisplayed = prettyJoin(kinds.toList.map(k => s"${k.display}"))
         ParseError(s"Expected $kindsDisplayed before ${at.display}", SyntacticContext.Unknown, previousSourceLocation())
@@ -486,13 +485,14 @@ object Parser2 {
                           delimiterR: TokenKind = TokenKind.ParenR,
                           optionalSeparator: Boolean = false,
                           optionallyWith: Option[(TokenKind, () => Unit)] = None,
+                          context: SyntacticContext
                         )(implicit s: State): Int = {
     def atEnd(): Boolean = at(delimiterR) || optionallyWith.exists { case (indicator, _) => at(indicator) }
 
     if (!at(delimiterL)) {
       return 0
     }
-    expect(delimiterL)
+    expect(delimiterL, context)
     var continue = true
     var numItems = 0
     while (continue && !atEnd() && !eof()) {
@@ -501,7 +501,7 @@ object Parser2 {
         getItem()
         numItems += 1
         if (!atEnd()) {
-          if (optionalSeparator) eat(separator) else expect(separator)
+          if (optionalSeparator) eat(separator) else expect(separator, context)
           if (atEnd()) {
             closeWithError(open(), ParseError(s"Trailing ${separator.display}", SyntacticContext.Unknown, previousSourceLocation()))
           }
@@ -524,7 +524,7 @@ object Parser2 {
       }
       case None =>
     }
-    expect(delimiterR)
+    expect(delimiterR, context)
     numItems
   }
 
@@ -546,9 +546,10 @@ object Parser2 {
                  delimiterR: TokenKind = TokenKind.ParenR,
                  optionalSeparator: Boolean = false,
                  optionallyWith: Option[(TokenKind, () => Unit)] = None,
+                 context: SyntacticContext
                )(implicit s: State): Option[ParseError] = {
     val locBefore = previousSourceLocation()
-    val itemCount = zeroOrMore(displayName, getItem, checkForItem, recoverOn, separator, delimiterL, delimiterR, optionalSeparator, optionallyWith)
+    val itemCount = zeroOrMore(displayName, getItem, checkForItem, recoverOn, separator, delimiterL, delimiterR, optionalSeparator, optionallyWith, context)
     val locAfter = currentSourceLocation()
     if (itemCount < 1) {
       val loc = SourceLocation.mk(locBefore.sp1, locAfter.sp1)
@@ -750,9 +751,9 @@ object Parser2 {
   /**
     * Consumes a token if kind is in `kinds`. If `allowQualified` is passed also consume subsequent dot-separated tokens with kind in `kinds`.
     */
-  private def name(kinds: Set[TokenKind], allowQualified: Boolean = false)(implicit s: State): Mark.Closed = {
+  private def name(kinds: Set[TokenKind], allowQualified: Boolean = false, context: SyntacticContext)(implicit s: State): Mark.Closed = {
     val mark = open(consumeDocComments = false)
-    expectAny(kinds)
+    expectAny(kinds, context)
     val first = close(mark, TreeKind.Ident)
     if (!allowQualified) {
       return first
@@ -760,7 +761,7 @@ object Parser2 {
     while (at(TokenKind.Dot) && kinds.contains(nth(1)) && !eof()) {
       eat(TokenKind.Dot)
       val mark = open()
-      expectAny(kinds)
+      expectAny(kinds, context)
       close(mark, TreeKind.Ident)
     }
     if (allowQualified) {
@@ -828,18 +829,19 @@ object Parser2 {
   private def use()(implicit s: State): Mark.Closed = {
     assert(at(TokenKind.KeywordUse))
     val mark = open()
-    expect(TokenKind.KeywordUse)
-    name(NAME_USE, allowQualified = true)
+    expect(TokenKind.KeywordUse, SyntacticContext.Use)
+    name(NAME_USE, allowQualified = true, context = SyntacticContext.Use)
     // handle use many case
     if (at(TokenKind.DotCurlyL)) {
       val mark = open()
       zeroOrMore(
         displayName = "name",
-        getItem = () => aliasedName(NAME_USE),
+        getItem = () => aliasedName(NAME_USE, SyntacticContext.Use),
         checkForItem = () => atAny(NAME_USE),
         recoverOn = () => atAny(RECOVER_TOP_LEVEL_USE),
         delimiterL = TokenKind.DotCurlyL,
-        delimiterR = TokenKind.CurlyR
+        delimiterR = TokenKind.CurlyR,
+        context = SyntacticContext.Use
       )
       close(mark, TreeKind.UsesOrImports.UseMany)
     }
@@ -849,28 +851,29 @@ object Parser2 {
   private def iimport()(implicit s: State): Mark.Closed = {
     assert(at(TokenKind.KeywordImport))
     val mark = open()
-    expect(TokenKind.KeywordImport)
-    name(NAME_JAVA, allowQualified = true)
+    expect(TokenKind.KeywordImport, SyntacticContext.Import)
+    name(NAME_JAVA, allowQualified = true, context = SyntacticContext.Import)
     // handle import many case
     if (at(TokenKind.DotCurlyL)) {
       val mark = open()
       zeroOrMore(
         displayName = "name",
-        getItem = () => aliasedName(NAME_JAVA),
+        getItem = () => aliasedName(NAME_JAVA, SyntacticContext.Import),
         checkForItem = () => atAny(NAME_JAVA),
         recoverOn = () => atAny(RECOVER_TOP_LEVEL_USE),
         delimiterL = TokenKind.DotCurlyL,
-        delimiterR = TokenKind.CurlyR
+        delimiterR = TokenKind.CurlyR,
+        context = SyntacticContext.Import
       )
       close(mark, TreeKind.UsesOrImports.ImportMany)
     }
     close(mark, TreeKind.UsesOrImports.Import)
   }
 
-  private def aliasedName(names: Set[TokenKind])(implicit s: State): Mark.Closed = {
-    var lhs = name(names)
+  private def aliasedName(names: Set[TokenKind], context: SyntacticContext)(implicit s: State): Mark.Closed = {
+    var lhs = name(names, context = context)
     if (eat(TokenKind.ArrowThickR)) {
-      name(names)
+      name(names, context = context)
       lhs = close(openBefore(lhs), TreeKind.UsesOrImports.Alias)
     }
     lhs
@@ -882,7 +885,6 @@ object Parser2 {
       docComment()
       // Handle case where the last thing in a file or module is a doc-comment
       if (eof() || at(TokenKind.CurlyR)) {
-        println(currentSourceLocation(), nth(0))
         return close(mark, TreeKind.CommentList)
       }
       // Handle modules
@@ -913,28 +915,29 @@ object Parser2 {
 
     private def moduleDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordMod))
-      expect(TokenKind.KeywordMod)
-      name(NAME_MODULE, allowQualified = true)
+      expect(TokenKind.KeywordMod, SyntacticContext.Decl.OtherDecl)
+      name(NAME_MODULE, allowQualified = true, context = SyntacticContext.Decl.OtherDecl)
       if (at(TokenKind.CurlyL)) {
-        expect(TokenKind.CurlyL)
+        expect(TokenKind.CurlyL, SyntacticContext.Decl.OtherDecl)
         usesOrImports()
         while (!at(TokenKind.CurlyR) && !eof()) {
           declaration()
         }
-        expect(TokenKind.CurlyR)
+        expect(TokenKind.CurlyR, SyntacticContext.Decl.OtherDecl)
       }
       close(mark, TreeKind.Decl.Module)
     }
 
     private def traitDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
-      expect(TokenKind.KeywordTrait)
-      name(NAME_DEFINITION)
+      assert(at(TokenKind.KeywordTrait))
+      expect(TokenKind.KeywordTrait, SyntacticContext.Decl.Trait)
+      name(NAME_DEFINITION, context = SyntacticContext.Decl.Trait)
       Type.parameters()
       if (at(TokenKind.KeywordWith)) {
         Type.constraints()
       }
       if (at(TokenKind.CurlyL)) {
-        expect(TokenKind.CurlyL)
+        expect(TokenKind.CurlyL, SyntacticContext.Decl.Trait)
         while (!at(TokenKind.CurlyR) && !eof()) {
           val mark = open(consumeDocComments = false)
           docComment()
@@ -949,23 +952,24 @@ object Parser2 {
               advanceWithError(error, Some(mark))
           }
         }
-        expect(TokenKind.CurlyR)
+        expect(TokenKind.CurlyR, SyntacticContext.Decl.Trait)
       }
       close(mark, TreeKind.Decl.Trait)
     }
 
     private def instanceDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
-      expect(TokenKind.KeywordInstance)
-      name(NAME_DEFINITION, allowQualified = true)
+      assert(at(TokenKind.KeywordInstance))
+      expect(TokenKind.KeywordInstance, SyntacticContext.Decl.Instance)
+      name(NAME_DEFINITION, allowQualified = true, context = SyntacticContext.Decl.Instance)
       if (eat(TokenKind.BracketL)) {
         Type.ttype()
-        expect(TokenKind.BracketR)
+        expect(TokenKind.BracketR, SyntacticContext.Decl.Instance)
       }
       if (at(TokenKind.KeywordWith)) {
         Type.constraints()
       }
       if (at(TokenKind.CurlyL)) {
-        expect(TokenKind.CurlyL)
+        expect(TokenKind.CurlyL, SyntacticContext.Decl.Instance)
         while (!at(TokenKind.CurlyR) && !eof()) {
           val mark = open(consumeDocComments = false)
           docComment()
@@ -979,19 +983,20 @@ object Parser2 {
               advanceWithError(error, Some(mark))
           }
         }
-        expect(TokenKind.CurlyR)
+        expect(TokenKind.CurlyR, SyntacticContext.Decl.Instance)
       }
       close(mark, TreeKind.Decl.Instance)
     }
 
     private def signatureDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
-      expect(TokenKind.KeywordDef)
-      name(NAME_DEFINITION)
+      assert(at(TokenKind.KeywordDef))
+      expect(TokenKind.KeywordDef, SyntacticContext.Decl.OtherDecl)
+      name(NAME_DEFINITION, context = SyntacticContext.Decl.OtherDecl)
       if (at(TokenKind.BracketL)) {
         Type.parameters()
       }
-      parameters()
-      expect(TokenKind.Colon)
+      parameters(SyntacticContext.Decl.OtherDecl)
+      expect(TokenKind.Colon, SyntacticContext.Decl.OtherDecl)
       Type.typeAndEffect()
 
       if (at(TokenKind.KeywordWith)) {
@@ -1007,13 +1012,14 @@ object Parser2 {
     }
 
     private def definitionDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
-      expect(TokenKind.KeywordDef)
-      name(NAME_DEFINITION)
+      assert(at(TokenKind.KeywordDef))
+      expect(TokenKind.KeywordDef, SyntacticContext.Decl.OtherDecl)
+      name(NAME_DEFINITION, context = SyntacticContext.Decl.OtherDecl)
       if (at(TokenKind.BracketL)) {
         Type.parameters()
       }
-      parameters()
-      expect(TokenKind.Colon)
+      parameters(SyntacticContext.Decl.OtherDecl)
+      expect(TokenKind.Colon, SyntacticContext.Decl.OtherDecl)
       Type.typeAndEffect()
       if (at(TokenKind.KeywordWith)) {
         Type.constraints()
@@ -1029,7 +1035,7 @@ object Parser2 {
       if (eat(TokenKind.Equal)) {
         Expr.statement()
       } else {
-        expect(TokenKind.Equal) // Produce an error for missing '='
+        expect(TokenKind.Equal, SyntacticContext.Decl.OtherDecl) // Produce an error for missing '='
       }
 
       close(mark, TreeKind.Decl.Def)
@@ -1037,20 +1043,20 @@ object Parser2 {
 
     private def lawDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordLaw))
-      expect(TokenKind.KeywordLaw)
-      name(NAME_DEFINITION)
-      expect(TokenKind.Colon)
-      expect(TokenKind.KeywordForall)
+      expect(TokenKind.KeywordLaw, SyntacticContext.Decl.OtherDecl)
+      name(NAME_DEFINITION, context = SyntacticContext.Decl.OtherDecl)
+      expect(TokenKind.Colon, SyntacticContext.Decl.OtherDecl)
+      expect(TokenKind.KeywordForall, SyntacticContext.Decl.OtherDecl)
       if (at(TokenKind.BracketL)) {
         Type.parameters()
       }
       if (at(TokenKind.ParenL)) {
-        parameters()
+        parameters(SyntacticContext.Decl.OtherDecl)
       }
       if (at(TokenKind.KeywordWith)) {
         Type.constraints()
       }
-      expect(TokenKind.Dot)
+      expect(TokenKind.Dot, SyntacticContext.Decl.OtherDecl)
       Expr.expression()
       close(mark, TreeKind.Decl.Law)
     }
@@ -1058,15 +1064,15 @@ object Parser2 {
     private def enumerationDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(atAny(Set(TokenKind.KeywordRestrictable, TokenKind.KeywordEnum)))
       val isRestrictable = eat(TokenKind.KeywordRestrictable)
-      expect(TokenKind.KeywordEnum)
+      expect(TokenKind.KeywordEnum, SyntacticContext.Decl.Enum)
       val nameLoc = currentSourceLocation()
-      name(NAME_TYPE)
+      name(NAME_TYPE, context = SyntacticContext.Decl.Enum)
       if (isRestrictable) {
-        expect(TokenKind.BracketL)
+        expect(TokenKind.BracketL, SyntacticContext.Decl.Enum)
         val markParam = open()
-        name(NAME_VARIABLE)
+        name(NAME_VARIABLE, context = SyntacticContext.Decl.Enum)
         close(markParam, TreeKind.Parameter)
-        expect(TokenKind.BracketR)
+        expect(TokenKind.BracketR, SyntacticContext.Decl.Enum)
       }
       if (at(TokenKind.BracketL)) {
         Type.parameters()
@@ -1087,14 +1093,14 @@ object Parser2 {
       if (isShorthand && eat(TokenKind.CurlyL)) {
         val mark = open()
         enumCases()
-        expect(TokenKind.CurlyR)
+        expect(TokenKind.CurlyR, SyntacticContext.Decl.Enum)
         closeWithError(mark, WeederError.IllegalEnum(nameLoc))
       }
 
       // enum body
       if (eat(TokenKind.CurlyL)) {
         enumCases()
-        expect(TokenKind.CurlyR)
+        expect(TokenKind.CurlyR, SyntacticContext.Decl.Enum)
       }
       close(mark, if (isRestrictable) TreeKind.Decl.RestrictableEnum else TreeKind.Decl.Enum)
     }
@@ -1108,14 +1114,14 @@ object Parser2 {
         val mark = open(consumeDocComments = false)
         docComment()
         if (at(TokenKind.KeywordCase)) {
-          expect(TokenKind.KeywordCase)
+          expect(TokenKind.KeywordCase, SyntacticContext.Decl.Enum)
         } else {
-          expect(TokenKind.Comma)
+          expect(TokenKind.Comma, SyntacticContext.Decl.Enum)
           // Handle comma followed by case keyword
           docComment()
           eat(TokenKind.KeywordCase)
         }
-        name(NAME_TAG)
+        name(NAME_TAG, context = SyntacticContext.Decl.Enum)
         if (at(TokenKind.ParenL)) {
           val mark = open()
           val markTuple = open()
@@ -1123,7 +1129,8 @@ object Parser2 {
             displayName = "type",
             getItem = () => Type.ttype(),
             checkForItem = () => atAny(FIRST_TYPE),
-            recoverOn = () => atAny(RECOVER_DECL)
+            recoverOn = () => atAny(RECOVER_DECL),
+            context = SyntacticContext.Decl.Enum
           ) match {
             case Some(error) =>
               close(markTuple, TreeKind.Type.Tuple)
@@ -1139,9 +1146,9 @@ object Parser2 {
 
     private def typeAliasDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordType))
-      expect(TokenKind.KeywordType)
-      expect(TokenKind.KeywordAlias)
-      name(NAME_TYPE)
+      expect(TokenKind.KeywordType, SyntacticContext.Decl.OtherDecl)
+      expect(TokenKind.KeywordAlias, SyntacticContext.Decl.OtherDecl)
+      name(NAME_TYPE, context = SyntacticContext.Decl.OtherDecl)
       if (at(TokenKind.BracketL)) {
         Type.parameters()
       }
@@ -1153,25 +1160,23 @@ object Parser2 {
 
     private def associatedTypeSigDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordType))
-      expect(TokenKind.KeywordType)
-      name(NAME_TYPE)
+      expect(TokenKind.KeywordType, SyntacticContext.Decl.OtherDecl)
+      name(NAME_TYPE, context = SyntacticContext.Decl.OtherDecl)
       if (at(TokenKind.BracketL)) {
         Type.parameters()
       }
-      if (at(TokenKind.Colon)) {
-        expect(TokenKind.Colon)
+      if (eat(TokenKind.Colon)) {
         Type.kind()
       }
-      if (at(TokenKind.Equal)) {
-        expect(TokenKind.Equal)
+      if (eat(TokenKind.Equal)) {
         Type.ttype()
       }
       close(mark, TreeKind.Decl.AssociatedTypeSig)
     }
 
     private def associatedTypeDefDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
-      expect(TokenKind.KeywordType)
-      name(NAME_TYPE)
+      expect(TokenKind.KeywordType, SyntacticContext.Decl.OtherDecl)
+      name(NAME_TYPE, context = SyntacticContext.Decl.OtherDecl)
       if (at(TokenKind.BracketL)) {
         Type.arguments()
       }
@@ -1183,8 +1188,8 @@ object Parser2 {
 
     private def effectDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordEff))
-      expect(TokenKind.KeywordEff)
-      name(NAME_EFFECT)
+      expect(TokenKind.KeywordEff, SyntacticContext.Decl.OtherDecl)
+      name(NAME_EFFECT, context = SyntacticContext.Decl.OtherDecl)
 
       // Check for illegal type parameters.
       if (at(TokenKind.BracketL)) {
@@ -1198,7 +1203,7 @@ object Parser2 {
         while (!at(TokenKind.CurlyR) && !eof()) {
           operationDecl()
         }
-        expect(TokenKind.CurlyR)
+        expect(TokenKind.CurlyR, SyntacticContext.Decl.OtherDecl)
       }
       close(mark, TreeKind.Decl.Effect)
     }
@@ -1208,8 +1213,8 @@ object Parser2 {
       docComment()
       annotations()
       modifiers()
-      expect(TokenKind.KeywordDef)
-      name(NAME_DEFINITION)
+      expect(TokenKind.KeywordDef, SyntacticContext.Decl.OtherDecl)
+      name(NAME_DEFINITION, context = SyntacticContext.Decl.OtherDecl)
 
       // Check for illegal type parameters.
       if (at(TokenKind.BracketL)) {
@@ -1220,7 +1225,7 @@ object Parser2 {
       }
 
       if (at(TokenKind.ParenL)) {
-        parameters()
+        parameters(SyntacticContext.Decl.OtherDecl)
       }
       if (eat(TokenKind.Colon)) {
         val typeLoc = currentSourceLocation()
@@ -1263,20 +1268,21 @@ object Parser2 {
       close(mark, TreeKind.Doc)
     }
 
-    def parameters()(implicit s: State): Mark.Closed = {
+    def parameters(context: SyntacticContext)(implicit s: State): Mark.Closed = {
       val mark = open()
       zeroOrMore(
         displayName = "parameter",
-        getItem = parameter,
+        getItem = () => parameter(context),
         checkForItem = () => atAny(NAME_PARAMETER),
-        recoverOn = () => atAny(RECOVER_PARAMETERS)
+        recoverOn = () => atAny(RECOVER_PARAMETERS),
+        context = context
       )
       close(mark, TreeKind.ParameterList)
     }
 
-    private def parameter()(implicit s: State): Mark.Closed = {
+    private def parameter(context: SyntacticContext)(implicit s: State): Mark.Closed = {
       val mark = open()
-      name(NAME_PARAMETER)
+      name(NAME_PARAMETER, context = context)
       if (eat(TokenKind.Colon)) {
         Type.ttype()
       }
@@ -1286,11 +1292,11 @@ object Parser2 {
     private def equalityConstraints(terminator: TokenKind)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordWhere))
       val mark = open()
-      expect(TokenKind.KeywordWhere)
+      expect(TokenKind.KeywordWhere, SyntacticContext.Decl.OtherDecl)
       while (!at(terminator) && !eof()) {
         val markConstraint = open()
         Type.ttype()
-        expect(TokenKind.Tilde)
+        expect(TokenKind.Tilde, SyntacticContext.Decl.OtherDecl)
         Type.ttype()
         eat(TokenKind.Comma)
         close(markConstraint, TreeKind.Decl.EqualityConstraintFragment)
@@ -1323,9 +1329,9 @@ object Parser2 {
       if (at(TokenKind.Dot) && nth(1) == TokenKind.NameLowerCase) {
         val mark = openBefore(lhs)
         eat(TokenKind.Dot)
-        name(NAME_FIELD)
+        name(NAME_FIELD, context = SyntacticContext.Expr.OtherExpr)
         while (eat(TokenKind.Dot)) {
-          name(NAME_FIELD)
+          name(NAME_FIELD, context = SyntacticContext.Expr.OtherExpr)
         }
         lhs = close(mark, TreeKind.Expr.RecordSelect)
         lhs = close(openBefore(lhs), TreeKind.Expr.Expr)
@@ -1352,18 +1358,19 @@ object Parser2 {
           val mark = open()
           oneOrMore(
             displayName = "effect",
-            getItem = () => name(NAME_EFFECT, allowQualified = true),
+            getItem = () => name(NAME_EFFECT, allowQualified = true, SyntacticContext.Type.Eff),
             checkForItem = () => atAny(NAME_EFFECT),
             recoverOn = () => atAny(RECOVER_EXPR),
             delimiterL = TokenKind.CurlyL,
-            delimiterR = TokenKind.CurlyR
+            delimiterR = TokenKind.CurlyR,
+            context = SyntacticContext.Expr.OtherExpr
           ) match {
             case Some(error) => closeWithError(mark, error)
             case None => close(mark, TreeKind.Type.EffectSet)
           }
         } else {
           val mark = open()
-          name(NAME_EFFECT, allowQualified = true)
+          name(NAME_EFFECT, allowQualified = true, context = SyntacticContext.Expr.OtherExpr)
           close(mark, TreeKind.Type.EffectSet)
         }
         lhs = close(openBefore(lhs), TreeKind.Expr.Without)
@@ -1442,7 +1449,8 @@ object Parser2 {
         displayName = "argument",
         getItem = argument,
         checkForItem = () => atAny(FIRST_EXPR_NO_KEYWORD_DEF),
-        recoverOn = () => atAny(RECOVER_EXPR)
+        recoverOn = () => atAny(RECOVER_EXPR),
+        context = SyntacticContext.Expr.OtherExpr
       )
       close(mark, TreeKind.ArgumentList)
     }
@@ -1483,11 +1491,11 @@ object Parser2 {
              | TokenKind.KeywordNull
              | TokenKind.LiteralRegex => literalExpr()
         case TokenKind.ParenL => parenOrTupleOrLambdaExpr()
-        case TokenKind.Underscore => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else name(NAME_VARIABLE)
-        case TokenKind.NameLowerCase => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else name(NAME_FIELD, allowQualified = true)
+        case TokenKind.Underscore => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else name(NAME_VARIABLE, context = SyntacticContext.Expr.OtherExpr)
+        case TokenKind.NameLowerCase => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else name(NAME_FIELD, allowQualified = true, context = SyntacticContext.Expr.OtherExpr)
         case TokenKind.NameUpperCase
              | TokenKind.NameMath
-             | TokenKind.NameGreek => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else name(NAME_DEFINITION, allowQualified = true)
+             | TokenKind.NameGreek => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else name(NAME_DEFINITION, allowQualified = true, context = SyntacticContext.Expr.OtherExpr)
         case TokenKind.Minus
              | TokenKind.KeywordNot
              | TokenKind.Plus
@@ -1537,7 +1545,7 @@ object Parser2 {
         case TokenKind.KeywordDebug
              | TokenKind.KeywordDebugBang
              | TokenKind.KeywordDebugBangBang => debugExpr()
-        case TokenKind.NameJava => name(NAME_JAVA, allowQualified = true)
+        case TokenKind.NameJava => name(NAME_JAVA, allowQualified = true, SyntacticContext.Expr.OtherExpr)
         case t =>
           val mark = open()
           val error = ParseError(s"Expected <expression> before ${t.display}", SyntacticContext.Expr.OtherExpr, previousSourceLocation())
@@ -1549,16 +1557,16 @@ object Parser2 {
     private def openVariantExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordOpenVariant))
       val mark = open()
-      expect(TokenKind.KeywordOpenVariant)
-      name(NAME_QNAME, allowQualified = true)
+      expect(TokenKind.KeywordOpenVariant, SyntacticContext.Expr.OtherExpr)
+      name(NAME_QNAME, allowQualified = true, context = SyntacticContext.Expr.OtherExpr)
       close(mark, TreeKind.Expr.OpenVariant)
     }
 
     private def openVariantAsExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordOpenVariantAs))
       val mark = open()
-      expect(TokenKind.KeywordOpenVariantAs)
-      name(NAME_QNAME, allowQualified = true)
+      expect(TokenKind.KeywordOpenVariantAs, SyntacticContext.Expr.OtherExpr)
+      name(NAME_QNAME, allowQualified = true, context = SyntacticContext.Expr.OtherExpr)
       expression()
       close(mark, TreeKind.Expr.OpenVariantAs)
     }
@@ -1567,8 +1575,12 @@ object Parser2 {
       assert(atAny(Set(TokenKind.HoleNamed, TokenKind.HoleAnonymous)))
       val mark = open()
       nth(0) match {
-        case TokenKind.HoleAnonymous => advance(); close(mark, TreeKind.Expr.Hole)
-        case TokenKind.HoleNamed => name(Set(TokenKind.HoleNamed)); close(mark, TreeKind.Expr.Hole)
+        case TokenKind.HoleAnonymous =>
+          advance()
+          close(mark, TreeKind.Expr.Hole)
+        case TokenKind.HoleNamed =>
+          name(Set(TokenKind.HoleNamed), context = SyntacticContext.Expr.OtherExpr)
+          close(mark, TreeKind.Expr.Hole)
         case _ => throw InternalCompilerException("Parser assert missed case", currentSourceLocation())
       }
     }
@@ -1576,14 +1588,14 @@ object Parser2 {
     private def holeVariableExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.HoleVariable))
       val mark = open()
-      name(Set(TokenKind.HoleVariable))
+      name(Set(TokenKind.HoleVariable), context = SyntacticContext.Expr.OtherExpr)
       close(mark, TreeKind.Expr.HoleVariable)
     }
 
     private def useExpr()(implicit s: State): Mark.Closed = {
       val mark = open()
       use()
-      expect(TokenKind.Semi)
+      expect(TokenKind.Semi, SyntacticContext.Expr.OtherExpr)
       statement()
       close(mark, TreeKind.Expr.Use)
     }
@@ -1649,23 +1661,23 @@ object Parser2 {
 
     private def lambda()(implicit s: State): Mark.Closed = {
       val mark = open()
-      Decl.parameters()
-      expect(TokenKind.ArrowThinR)
+      Decl.parameters(SyntacticContext.Expr.OtherExpr)
+      expect(TokenKind.ArrowThinR, SyntacticContext.Expr.OtherExpr)
       expression()
       close(mark, TreeKind.Expr.Lambda)
     }
 
     private def parenOrTupleOrAscribe()(implicit s: State): Mark.Closed = {
       val mark = open()
-      expect(TokenKind.ParenL)
+      expect(TokenKind.ParenL, SyntacticContext.Expr.OtherExpr)
       val markExpr = expression()
       // Distinguish between expression in parenthesis, type ascriptions and tuples
       nth(0) match {
         // Type ascription
         case TokenKind.Colon =>
-          expect(TokenKind.Colon)
+          expect(TokenKind.Colon, SyntacticContext.Expr.OtherExpr)
           Type.typeAndEffect()
-          expect(TokenKind.ParenR)
+          expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
           close(mark, TreeKind.Expr.Ascribe)
         // Tuple
         case TokenKind.Equal | TokenKind.Comma =>
@@ -1679,11 +1691,11 @@ object Parser2 {
             eat(TokenKind.Comma)
             argument()
           }
-          expect(TokenKind.ParenR)
+          expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
           close(mark, TreeKind.Expr.Tuple)
         // Paren
         case _ =>
-          expect(TokenKind.ParenR)
+          expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
           close(mark, TreeKind.Expr.Paren)
       }
     }
@@ -1692,10 +1704,10 @@ object Parser2 {
       val mark = open()
       val markParams = open()
       val markParam = open()
-      name(NAME_PARAMETER)
+      name(NAME_PARAMETER, context = SyntacticContext.Expr.OtherExpr)
       close(markParam, TreeKind.Parameter)
       close(markParams, TreeKind.ParameterList)
-      expect(TokenKind.ArrowThinR)
+      expect(TokenKind.ArrowThinR, SyntacticContext.Expr.OtherExpr)
       expression()
       close(mark, TreeKind.Expr.Lambda)
     }
@@ -1714,7 +1726,7 @@ object Parser2 {
       val mark = open()
       val op = nth(0)
       val markOp = open()
-      expectAny(FIRST_EXPR_UNARY)
+      expectAny(FIRST_EXPR_UNARY, context = SyntacticContext.Expr.OtherExpr)
       close(markOp, TreeKind.Operator)
       expression(left = op, leftIsUnary = true)
       close(mark, TreeKind.Expr.Unary)
@@ -1723,10 +1735,10 @@ object Parser2 {
     private def ifThenElseExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordIf))
       val mark = open()
-      expect(TokenKind.KeywordIf)
+      expect(TokenKind.KeywordIf, SyntacticContext.Expr.OtherExpr)
       if (eat(TokenKind.ParenL)) {
         expression()
-        expect(TokenKind.ParenR)
+        expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
       }
       expression()
       if (eat(TokenKind.KeywordElse)) {
@@ -1738,12 +1750,12 @@ object Parser2 {
     private def letMatchExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordLet))
       val mark = open()
-      expect(TokenKind.KeywordLet)
+      expect(TokenKind.KeywordLet, SyntacticContext.Expr.OtherExpr)
       Pattern.pattern()
       if (eat(TokenKind.Colon)) {
         Type.ttype()
       }
-      expect(TokenKind.Equal)
+      expect(TokenKind.Equal, SyntacticContext.Expr.OtherExpr)
       statement()
       close(mark, TreeKind.Expr.LetMatch)
     }
@@ -1753,13 +1765,13 @@ object Parser2 {
       val mark = open(consumeDocComments = false)
       Decl.docComment()
       Decl.annotations()
-      expect(TokenKind.KeywordDef)
-      name(NAME_DEFINITION)
-      Decl.parameters()
+      expect(TokenKind.KeywordDef, SyntacticContext.Expr.OtherExpr)
+      name(NAME_DEFINITION, context = SyntacticContext.Expr.OtherExpr)
+      Decl.parameters(SyntacticContext.Expr.OtherExpr)
       if (eat(TokenKind.Colon)) {
         Type.typeAndEffect()
       }
-      expect(TokenKind.Equal)
+      expect(TokenKind.Equal, SyntacticContext.Expr.OtherExpr)
       statement()
       close(mark, TreeKind.Expr.LetRecDef)
     }
@@ -1767,7 +1779,7 @@ object Parser2 {
     private def letImportExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordImport))
       val mark = open()
-      expect(TokenKind.KeywordImport)
+      expect(TokenKind.KeywordImport, SyntacticContext.Expr.OtherExpr)
       val markJvmOp = open()
       nth(0) match {
         case TokenKind.KeywordJavaNew => JvmOp.constructor()
@@ -1787,7 +1799,7 @@ object Parser2 {
           advanceWithError(error)
       }
       close(markJvmOp, TreeKind.JvmOp.JvmOp)
-      expect(TokenKind.Semi)
+      expect(TokenKind.Semi, SyntacticContext.Expr.OtherExpr)
       statement()
       close(mark, TreeKind.Expr.LetImport)
     }
@@ -1795,8 +1807,8 @@ object Parser2 {
     private def scopeExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordRegion))
       val mark = open()
-      expect(TokenKind.KeywordRegion)
-      name(NAME_VARIABLE)
+      expect(TokenKind.KeywordRegion, SyntacticContext.Expr.OtherExpr)
+      name(NAME_VARIABLE, context = SyntacticContext.Expr.OtherExpr)
       if (at(TokenKind.CurlyL)) {
         block()
       }
@@ -1806,12 +1818,12 @@ object Parser2 {
     private def block()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.CurlyL))
       val mark = open()
-      expect(TokenKind.CurlyL)
+      expect(TokenKind.CurlyL, SyntacticContext.Expr.OtherExpr)
       if (eat(TokenKind.CurlyR)) { // Handle empty block
         return close(mark, TreeKind.Expr.LiteralRecord)
       }
       statement()
-      expect(TokenKind.CurlyR)
+      expect(TokenKind.CurlyR, SyntacticContext.Expr.OtherExpr)
       close(mark, TreeKind.Expr.Block)
     }
 
@@ -1824,17 +1836,17 @@ object Parser2 {
     private def debugExpr()(implicit s: State): Mark.Closed = {
       assert(atAny(FIRST_EXPR_DEBUG))
       val mark = open()
-      expectAny(FIRST_EXPR_DEBUG)
-      expect(TokenKind.ParenL)
+      expectAny(FIRST_EXPR_DEBUG, SyntacticContext.Expr.OtherExpr)
+      expect(TokenKind.ParenL, SyntacticContext.Expr.OtherExpr)
       expression()
-      expect(TokenKind.ParenR)
+      expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
       close(mark, TreeKind.Expr.Debug)
     }
 
     private def matchOrMatchLambdaExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordMatch))
       val mark = open()
-      expect(TokenKind.KeywordMatch)
+      expect(TokenKind.KeywordMatch, SyntacticContext.Expr.OtherExpr)
       // Detect match lambda
       val isLambda = {
         var lookAhead = 0
@@ -1861,7 +1873,7 @@ object Parser2 {
 
       if (isLambda) {
         Pattern.pattern()
-        expect(TokenKind.ArrowThinR)
+        expect(TokenKind.ArrowThinR, SyntacticContext.Expr.OtherExpr)
         expression()
         close(mark, TreeKind.Expr.LambdaMatch)
       } else {
@@ -1872,7 +1884,7 @@ object Parser2 {
             matchRule()
             eat(TokenKind.Comma)
           }
-          expect(TokenKind.CurlyR)
+          expect(TokenKind.CurlyR, SyntacticContext.Expr.OtherExpr)
         }
         close(mark, TreeKind.Expr.Match)
       }
@@ -1881,7 +1893,7 @@ object Parser2 {
     private def matchRule()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordCase))
       val mark = open()
-      expect(TokenKind.KeywordCase)
+      expect(TokenKind.KeywordCase, SyntacticContext.Expr.OtherExpr)
       Pattern.pattern()
       if (eat(TokenKind.KeywordIf)) {
         expression()
@@ -1896,14 +1908,14 @@ object Parser2 {
     private def typematchExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordTypeMatch))
       val mark = open()
-      expect(TokenKind.KeywordTypeMatch)
+      expect(TokenKind.KeywordTypeMatch, SyntacticContext.Expr.OtherExpr)
       expression()
       if (eat(TokenKind.CurlyL)) {
         comments()
         while (at(TokenKind.KeywordCase) && !eof()) {
           typematchRule()
         }
-        expect(TokenKind.CurlyR)
+        expect(TokenKind.CurlyR, SyntacticContext.Expr.OtherExpr)
       }
       close(mark, TreeKind.Expr.TypeMatch)
     }
@@ -1911,8 +1923,8 @@ object Parser2 {
     private def typematchRule()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordCase))
       val mark = open()
-      expect(TokenKind.KeywordCase)
-      name(NAME_VARIABLE)
+      expect(TokenKind.KeywordCase, SyntacticContext.Expr.OtherExpr)
+      name(NAME_VARIABLE, context = SyntacticContext.Expr.OtherExpr)
       if (eat(TokenKind.Colon)) {
         Type.ttype()
       }
@@ -1930,27 +1942,27 @@ object Parser2 {
       val mark = open()
       val isStar = eat(TokenKind.KeywordChooseStar)
       if (!isStar) {
-        expect(TokenKind.KeywordChoose)
+        expect(TokenKind.KeywordChoose, SyntacticContext.Expr.OtherExpr)
       }
       expression()
-      expect(TokenKind.CurlyL)
+      expect(TokenKind.CurlyL, SyntacticContext.Expr.OtherExpr)
       comments()
       while (at(TokenKind.KeywordCase) && !eof()) {
         matchRule()
       }
-      expect(TokenKind.CurlyR)
+      expect(TokenKind.CurlyR, SyntacticContext.Expr.OtherExpr)
       close(mark, if (isStar) TreeKind.Expr.RestrictableChooseStar else TreeKind.Expr.RestrictableChoose)
     }
 
     private def forApplicativeExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordForA))
       val mark = open()
-      expect(TokenKind.KeywordForA)
+      expect(TokenKind.KeywordForA, SyntacticContext.Expr.OtherExpr)
       if (at(TokenKind.ParenL)) {
         // Note: Only generator patterns are allowed here. Weeder verifies this.
         forFragments()
       }
-      expect(TokenKind.KeywordYield)
+      expect(TokenKind.KeywordYield, SyntacticContext.Expr.OtherExpr)
       expression()
       close(mark, TreeKind.Expr.ForApplicative)
     }
@@ -1959,7 +1971,7 @@ object Parser2 {
       assert(at(TokenKind.KeywordForeach))
       val mark = open()
       var kind: TreeKind = TreeKind.Expr.Foreach
-      expect(TokenKind.KeywordForeach)
+      expect(TokenKind.KeywordForeach, SyntacticContext.Expr.OtherExpr)
       if (at(TokenKind.ParenL)) {
         forFragments()
       }
@@ -1973,7 +1985,7 @@ object Parser2 {
     private def forMonadicExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordForM))
       val mark = open()
-      expect(TokenKind.KeywordForM)
+      expect(TokenKind.KeywordForM, SyntacticContext.Expr.OtherExpr)
       if (at(TokenKind.ParenL)) {
         forFragments()
       }
@@ -1985,7 +1997,7 @@ object Parser2 {
 
     private def forFragments()(implicit s: State): Unit = {
       assert(at(TokenKind.ParenL))
-      expect(TokenKind.ParenL)
+      expect(TokenKind.ParenL, SyntacticContext.Expr.OtherExpr)
       while (!at(TokenKind.ParenR) && !eof()) {
         if (at(TokenKind.KeywordIf)) {
           guardFragment()
@@ -1993,16 +2005,16 @@ object Parser2 {
           generatorOrLetFragment()
         }
         if (!at(TokenKind.ParenR)) {
-          expect(TokenKind.Semi)
+          expect(TokenKind.Semi, SyntacticContext.Expr.OtherExpr)
         }
       }
-      expect(TokenKind.ParenR)
+      expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
     }
 
     private def guardFragment()(implicit s: State): Unit = {
       assert(at(TokenKind.KeywordIf))
       val mark = open()
-      expect(TokenKind.KeywordIf)
+      expect(TokenKind.KeywordIf, SyntacticContext.Expr.OtherExpr)
       expression()
       close(mark, TreeKind.Expr.ForFragmentGuard)
     }
@@ -2012,7 +2024,7 @@ object Parser2 {
       Pattern.pattern()
       val isGenerator = eat(TokenKind.ArrowThinL)
       if (!isGenerator) {
-        expect(TokenKind.Equal)
+        expect(TokenKind.Equal, SyntacticContext.Expr.OtherExpr)
       }
       expression()
       close(mark, if (isGenerator) {
@@ -2077,15 +2089,16 @@ object Parser2 {
         checkForItem = () => atAny(NAME_FIELD),
         recoverOn = () => atAny(RECOVER_EXPR),
         delimiterL = TokenKind.CurlyL,
-        delimiterR = TokenKind.CurlyR
+        delimiterR = TokenKind.CurlyR,
+        context = SyntacticContext.Expr.OtherExpr
       )
       close(mark, TreeKind.Expr.LiteralRecord)
     }
 
     private def recordLiteralField()(implicit s: State): Mark.Closed = {
       val mark = open()
-      name(NAME_FIELD)
-      expect(TokenKind.Equal)
+      name(NAME_FIELD, context = SyntacticContext.Expr.OtherExpr)
+      expect(TokenKind.Equal, SyntacticContext.Expr.OtherExpr)
       expression()
       close(mark, TreeKind.Expr.LiteralRecordFieldFragment)
     }
@@ -2102,7 +2115,8 @@ object Parser2 {
         recoverOn = () => atAny(RECOVER_EXPR),
         delimiterL = TokenKind.CurlyL,
         delimiterR = TokenKind.CurlyR,
-        optionallyWith = Some((TokenKind.Bar, () => expression()))
+        optionallyWith = Some((TokenKind.Bar, () => expression())),
+        context = SyntacticContext.Expr.OtherExpr
       ) match {
         case Some(error) => closeWithError(mark, error)
         case None => close(mark, TreeKind.Expr.RecordOperation)
@@ -2114,17 +2128,17 @@ object Parser2 {
       nth(0) match {
         case TokenKind.Plus =>
           advance()
-          name(NAME_FIELD)
-          expect(TokenKind.Equal)
+          name(NAME_FIELD, context = SyntacticContext.Expr.OtherExpr)
+          expect(TokenKind.Equal, SyntacticContext.Expr.OtherExpr)
           expression()
           close(mark, TreeKind.Expr.RecordOpExtend)
         case TokenKind.Minus =>
           advance()
-          name(NAME_FIELD)
+          name(NAME_FIELD, context = SyntacticContext.Expr.OtherExpr)
           close(mark, TreeKind.Expr.RecordOpRestrict)
         case TokenKind.NameLowerCase =>
-          name(NAME_FIELD)
-          expect(TokenKind.Equal)
+          name(NAME_FIELD, context = SyntacticContext.Expr.OtherExpr)
+          expect(TokenKind.Equal, SyntacticContext.Expr.OtherExpr)
           expression()
           close(mark, TreeKind.Expr.RecordOpUpdate)
         case at =>
@@ -2136,14 +2150,15 @@ object Parser2 {
     private def arrayLiteralExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.ArrayHash))
       val mark = open()
-      expect(TokenKind.ArrayHash)
+      expect(TokenKind.ArrayHash, context = SyntacticContext.Expr.OtherExpr)
       zeroOrMore(
         displayName = "expression",
         getItem = () => expression(),
         checkForItem = () => atAny(FIRST_EXPR),
         recoverOn = () => atAny(RECOVER_EXPR),
         delimiterL = TokenKind.CurlyL,
-        delimiterR = TokenKind.CurlyR
+        delimiterR = TokenKind.CurlyR,
+        context = SyntacticContext.Expr.OtherExpr
       )
       if (at(TokenKind.At)) {
         scopeName()
@@ -2154,7 +2169,7 @@ object Parser2 {
     private def scopeName()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.At))
       val mark = open()
-      expect(TokenKind.At)
+      expect(TokenKind.At, SyntacticContext.Expr.OtherExpr)
       expression()
       close(mark, TreeKind.Expr.ScopeName)
     }
@@ -2162,14 +2177,15 @@ object Parser2 {
     private def vectorLiteralExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.VectorHash))
       val mark = open()
-      expect(TokenKind.VectorHash)
+      expect(TokenKind.VectorHash, SyntacticContext.Expr.OtherExpr)
       zeroOrMore(
         displayName = "expression",
         getItem = () => expression(),
         checkForItem = () => atAny(FIRST_EXPR),
         recoverOn = () => atAny(RECOVER_EXPR),
         delimiterL = TokenKind.CurlyL,
-        delimiterR = TokenKind.CurlyR
+        delimiterR = TokenKind.CurlyR,
+        context = SyntacticContext.Expr.OtherExpr
       )
       close(mark, TreeKind.Expr.LiteralVector)
     }
@@ -2177,14 +2193,15 @@ object Parser2 {
     private def listLiteralExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.ListHash))
       val mark = open()
-      expect(TokenKind.ListHash)
+      expect(TokenKind.ListHash, SyntacticContext.Expr.OtherExpr)
       zeroOrMore(
         displayName = "expression",
         getItem = () => expression(),
         checkForItem = () => atAny(FIRST_EXPR),
         recoverOn = () => atAny(RECOVER_EXPR),
         delimiterL = TokenKind.CurlyL,
-        delimiterR = TokenKind.CurlyR
+        delimiterR = TokenKind.CurlyR,
+        context = SyntacticContext.Expr.OtherExpr
       )
       close(mark, TreeKind.Expr.LiteralList)
     }
@@ -2192,14 +2209,15 @@ object Parser2 {
     private def setLiteralExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.SetHash))
       val mark = open()
-      expect(TokenKind.SetHash)
+      expect(TokenKind.SetHash, SyntacticContext.Expr.OtherExpr)
       zeroOrMore(
         displayName = "expression",
         getItem = () => expression(),
         checkForItem = () => atAny(FIRST_EXPR),
         recoverOn = () => atAny(RECOVER_EXPR),
         delimiterL = TokenKind.CurlyL,
-        delimiterR = TokenKind.CurlyR
+        delimiterR = TokenKind.CurlyR,
+        context = SyntacticContext.Expr.OtherExpr
       )
       close(mark, TreeKind.Expr.LiteralSet)
     }
@@ -2207,14 +2225,15 @@ object Parser2 {
     private def mapLiteralExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.MapHash))
       val mark = open()
-      expect(TokenKind.MapHash)
+      expect(TokenKind.MapHash, SyntacticContext.Expr.OtherExpr)
       zeroOrMore(
         displayName = "map literal",
         getItem = mapLiteralValue,
         checkForItem = () => atAny(FIRST_EXPR),
         recoverOn = () => atAny(RECOVER_EXPR),
         delimiterL = TokenKind.CurlyL,
-        delimiterR = TokenKind.CurlyR
+        delimiterR = TokenKind.CurlyR,
+        context = SyntacticContext.Expr.OtherExpr
       )
       close(mark, TreeKind.Expr.LiteralMap)
     }
@@ -2231,7 +2250,7 @@ object Parser2 {
     private def refExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordRef))
       val mark = open()
-      expect(TokenKind.KeywordRef)
+      expect(TokenKind.KeywordRef, SyntacticContext.Expr.OtherExpr)
       expression()
       if (at(TokenKind.At)) {
         scopeName()
@@ -2242,10 +2261,10 @@ object Parser2 {
     private def checkedTypeCastExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordCheckedCast))
       val mark = open()
-      expect(TokenKind.KeywordCheckedCast)
+      expect(TokenKind.KeywordCheckedCast, SyntacticContext.Expr.OtherExpr)
       if (eat(TokenKind.ParenL)) {
         expression()
-        expect(TokenKind.ParenR)
+        expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
       }
       close(mark, TreeKind.Expr.CheckedTypeCast)
     }
@@ -2253,10 +2272,10 @@ object Parser2 {
     private def checkedEffectCastExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordCheckedECast))
       val mark = open()
-      expect(TokenKind.KeywordCheckedECast)
+      expect(TokenKind.KeywordCheckedECast, SyntacticContext.Expr.OtherExpr)
       if (eat(TokenKind.ParenL)) {
         expression()
-        expect(TokenKind.ParenR)
+        expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
       }
       close(mark, TreeKind.Expr.CheckedEffectCast)
     }
@@ -2264,13 +2283,13 @@ object Parser2 {
     private def uncheckedCastExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordUncheckedCast))
       val mark = open()
-      expect(TokenKind.KeywordUncheckedCast)
+      expect(TokenKind.KeywordUncheckedCast, SyntacticContext.Expr.OtherExpr)
       if (eat(TokenKind.ParenL)) {
         expression()
         if (eat(TokenKind.KeywordAs)) {
           Type.typeAndEffect()
         }
-        expect(TokenKind.ParenR)
+        expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
       }
       close(mark, TreeKind.Expr.UncheckedCast)
     }
@@ -2278,10 +2297,10 @@ object Parser2 {
     private def uncheckedMaskingCastExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordMaskedCast))
       val mark = open()
-      expect(TokenKind.KeywordMaskedCast)
+      expect(TokenKind.KeywordMaskedCast, SyntacticContext.Expr.OtherExpr)
       if (eat(TokenKind.ParenL)) {
         expression()
-        expect(TokenKind.ParenR)
+        expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
       }
       close(mark, TreeKind.Expr.UncheckedMaskingCast)
     }
@@ -2289,7 +2308,7 @@ object Parser2 {
     private def tryExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordTry))
       val mark = open()
-      expect(TokenKind.KeywordTry)
+      expect(TokenKind.KeywordTry, SyntacticContext.Expr.OtherExpr)
       expression()
       if (at(TokenKind.KeywordCatch)) {
         while (at(TokenKind.KeywordCatch)) {
@@ -2307,7 +2326,7 @@ object Parser2 {
     private def catchBody()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordCatch))
       val mark = open()
-      expect(TokenKind.KeywordCatch)
+      expect(TokenKind.KeywordCatch, SyntacticContext.Expr.OtherExpr)
       oneOrMore(
         displayName = "catch rule",
         getItem = catchRule,
@@ -2315,7 +2334,8 @@ object Parser2 {
         recoverOn = () => atAny(RECOVER_EXPR),
         optionalSeparator = true,
         delimiterL = TokenKind.CurlyL,
-        delimiterR = TokenKind.CurlyR
+        delimiterR = TokenKind.CurlyR,
+        context = SyntacticContext.Expr.OtherExpr
       ) match {
         case Some(error) => closeWithError(mark, error)
         case None => close(mark, TreeKind.Expr.TryCatchBodyFragment)
@@ -2324,10 +2344,10 @@ object Parser2 {
 
     private def catchRule()(implicit s: State): Mark.Closed = {
       val mark = open()
-      expect(TokenKind.KeywordCase)
-      name(NAME_VARIABLE)
+      expect(TokenKind.KeywordCase, SyntacticContext.Expr.OtherExpr)
+      name(NAME_VARIABLE, context = SyntacticContext.Expr.OtherExpr)
       if (eat(TokenKind.Colon)) {
-        name(NAME_JAVA, allowQualified = true)
+        name(NAME_JAVA, allowQualified = true, context = SyntacticContext.Expr.OtherExpr)
       }
       if (eat(TokenKind.ArrowThickR)) {
         expression()
@@ -2338,8 +2358,8 @@ object Parser2 {
     private def withBody()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordWith))
       val mark = open()
-      expect(TokenKind.KeywordWith)
-      name(NAME_EFFECT, allowQualified = true)
+      expect(TokenKind.KeywordWith, SyntacticContext.Expr.OtherExpr)
+      name(NAME_EFFECT, allowQualified = true, context = SyntacticContext.Expr.OtherExpr)
       oneOrMore(
         displayName = "with rule",
         getItem = withRule,
@@ -2347,7 +2367,8 @@ object Parser2 {
         recoverOn = () => atAny(RECOVER_EXPR),
         optionalSeparator = true,
         delimiterL = TokenKind.CurlyL,
-        delimiterR = TokenKind.CurlyR
+        delimiterR = TokenKind.CurlyR,
+        context = SyntacticContext.Expr.OtherExpr
       ) match {
         case Some(error) => closeWithError(mark, error)
         case None => close(mark, TreeKind.Expr.TryWithBodyFragment)
@@ -2357,9 +2378,9 @@ object Parser2 {
     private def withRule()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordDef))
       val mark = open()
-      expect(TokenKind.KeywordDef)
-      name(Set(TokenKind.NameLowerCase))
-      Decl.parameters()
+      expect(TokenKind.KeywordDef, SyntacticContext.Expr.OtherExpr)
+      name(Set(TokenKind.NameLowerCase), context = SyntacticContext.Expr.OtherExpr)
+      Decl.parameters(SyntacticContext.Expr.OtherExpr)
       if (eat(TokenKind.Equal)) {
         expression()
       }
@@ -2369,8 +2390,8 @@ object Parser2 {
     private def doExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordDo))
       val mark = open()
-      expect(TokenKind.KeywordDo)
-      name(NAME_QNAME, allowQualified = true)
+      expect(TokenKind.KeywordDo, SyntacticContext.Expr.Do)
+      name(NAME_QNAME, allowQualified = true, context = SyntacticContext.Expr.Do)
       arguments()
       close(mark, TreeKind.Expr.Do)
     }
@@ -2378,22 +2399,22 @@ object Parser2 {
     private def newObjectExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordNew))
       val mark = open()
-      expect(TokenKind.KeywordNew)
+      expect(TokenKind.KeywordNew, SyntacticContext.Expr.OtherExpr)
       Type.ttype()
-      expect(TokenKind.CurlyL)
+      expect(TokenKind.CurlyL, SyntacticContext.Expr.OtherExpr)
       while (at(TokenKind.KeywordDef) && !eof()) {
         jvmMethod()
       }
-      expect(TokenKind.CurlyR)
+      expect(TokenKind.CurlyR, SyntacticContext.Expr.OtherExpr)
       close(mark, TreeKind.Expr.NewObject)
     }
 
     private def jvmMethod()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordDef))
       val mark = open()
-      expect(TokenKind.KeywordDef)
-      name(NAME_JAVA)
-      Decl.parameters()
+      expect(TokenKind.KeywordDef, SyntacticContext.Expr.OtherExpr)
+      name(NAME_JAVA, context = SyntacticContext.Expr.OtherExpr)
+      Decl.parameters(SyntacticContext.Expr.OtherExpr)
       if (eat(TokenKind.Colon)) {
         Type.typeAndEffect()
       }
@@ -2406,45 +2427,44 @@ object Parser2 {
     private def staticExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordStaticUppercase))
       val mark = open()
-      expect(TokenKind.KeywordStaticUppercase)
+      expect(TokenKind.KeywordStaticUppercase, SyntacticContext.Expr.OtherExpr)
       close(mark, TreeKind.Expr.Static)
     }
 
     private def selectExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordSelect))
       val mark = open()
-      expect(TokenKind.KeywordSelect)
-
-      expect(TokenKind.CurlyL)
+      expect(TokenKind.KeywordSelect, SyntacticContext.Expr.OtherExpr)
+      expect(TokenKind.CurlyL, SyntacticContext.Expr.OtherExpr)
       comments()
       var continue = true
       while (continue && at(TokenKind.KeywordCase) && !eof()) {
         val ruleMark = open()
-        expect(TokenKind.KeywordCase)
+        expect(TokenKind.KeywordCase, SyntacticContext.Expr.OtherExpr)
         val isDefault = findBefore(TokenKind.ArrowThickR, Array(TokenKind.ArrowThinL))
         if (isDefault) {
           // Only the last rule can be a wildcard rule so stop after this one
           continue = false
-          expect(TokenKind.Underscore)
-          expect(TokenKind.ArrowThickR)
+          expect(TokenKind.Underscore, SyntacticContext.Expr.OtherExpr)
+          expect(TokenKind.ArrowThickR, SyntacticContext.Expr.OtherExpr)
           statement()
           close(ruleMark, TreeKind.Expr.SelectRuleDefaultFragment)
         } else {
-          name(NAME_VARIABLE)
-          expect(TokenKind.ArrowThinL)
+          name(NAME_VARIABLE, context = SyntacticContext.Expr.OtherExpr)
+          expect(TokenKind.ArrowThinL, SyntacticContext.Expr.OtherExpr)
           // Note that only "Channel.recv" and "recv" are allowed for this name.
           // We don't want to reserve "Channel" and "recv" as keywords,
           // so parsing it as a qname seems fine for now.
-          name(NAME_QNAME, allowQualified = true)
-          expect(TokenKind.ParenL)
+          name(NAME_QNAME, allowQualified = true, context = SyntacticContext.Expr.OtherExpr)
+          expect(TokenKind.ParenL, SyntacticContext.Expr.OtherExpr)
           expression()
-          expect(TokenKind.ParenR)
-          expect(TokenKind.ArrowThickR)
+          expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
+          expect(TokenKind.ArrowThickR, SyntacticContext.Expr.OtherExpr)
           statement()
           close(ruleMark, TreeKind.Expr.SelectRuleFragment)
         }
       }
-      expect(TokenKind.CurlyR)
+      expect(TokenKind.CurlyR, SyntacticContext.Expr.OtherExpr)
 
       close(mark, TreeKind.Expr.Select)
     }
@@ -2452,7 +2472,7 @@ object Parser2 {
     private def spawnExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordSpawn))
       val mark = open()
-      expect(TokenKind.KeywordSpawn)
+      expect(TokenKind.KeywordSpawn, SyntacticContext.Expr.OtherExpr)
       expression()
       if (at(TokenKind.At)) {
         scopeName()
@@ -2465,20 +2485,21 @@ object Parser2 {
     private def parYieldExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordPar))
       val mark = open()
-      expect(TokenKind.KeywordPar)
+      expect(TokenKind.KeywordPar, SyntacticContext.Expr.OtherExpr)
       if (at(TokenKind.ParenL)) {
         oneOrMore(
           displayName = "'pattern <- expression'",
           getItem = parYieldFragment,
           checkForItem = () => atAny(FIRST_PATTERN),
           separator = TokenKind.Semi,
-          recoverOn = () => atAny(RECOVER_EXPR_PAR_YIELD_FRAG)
+          recoverOn = () => atAny(RECOVER_EXPR_PAR_YIELD_FRAG),
+          context = SyntacticContext.Expr.OtherExpr
         ) match {
           case Some(error) => closeWithError(open(), error)
           case None =>
         }
       }
-      expect(TokenKind.KeywordYield)
+      expect(TokenKind.KeywordYield, SyntacticContext.Expr.OtherExpr)
       expression()
       close(mark, TreeKind.Expr.ParYield)
     }
@@ -2486,7 +2507,7 @@ object Parser2 {
     private def parYieldFragment()(implicit s: State): Mark.Closed = {
       val mark = open()
       Pattern.pattern()
-      expect(TokenKind.ArrowThinL)
+      expect(TokenKind.ArrowThinL, SyntacticContext.Expr.OtherExpr)
       expression()
       close(mark, TreeKind.Expr.ParYieldFragment)
     }
@@ -2494,11 +2515,11 @@ object Parser2 {
     private def fixpointConstraintSetExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.HashCurlyL))
       val mark = open()
-      expect(TokenKind.HashCurlyL)
+      expect(TokenKind.HashCurlyL, SyntacticContext.Expr.Constraint)
       while (!at(TokenKind.CurlyR) && !eof()) {
         fixpointConstraint()
       }
-      expect(TokenKind.CurlyR)
+      expect(TokenKind.CurlyR, SyntacticContext.Expr.Constraint)
       close(mark, TreeKind.Expr.FixpointConstraintSet)
     }
 
@@ -2511,7 +2532,7 @@ object Parser2 {
           Predicate.body()
         }
       }
-      expect(TokenKind.Dot)
+      expect(TokenKind.Dot, SyntacticContext.Expr.Constraint)
       close(mark, TreeKind.Expr.FixpointConstraint)
     }
 
@@ -2519,7 +2540,7 @@ object Parser2 {
       assert(at(TokenKind.HashParenL))
       val mark = open()
       Predicate.params()
-      expect(TokenKind.ArrowThinR)
+      expect(TokenKind.ArrowThinR, SyntacticContext.Expr.OtherExpr)
       expression()
       close(mark, TreeKind.Expr.FixpointLambda)
     }
@@ -2527,16 +2548,16 @@ object Parser2 {
     private def fixpointSolveExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordSolve))
       val mark = open()
-      expect(TokenKind.KeywordSolve)
+      expect(TokenKind.KeywordSolve, SyntacticContext.Expr.OtherExpr)
       expression()
       while (eat(TokenKind.Comma) && !eof()) {
         expression()
       }
 
       if (eat(TokenKind.KeywordProject)) {
-        name(NAME_PREDICATE)
+        name(NAME_PREDICATE, context = SyntacticContext.Expr.OtherExpr)
         while (eat(TokenKind.Comma) && !eof()) {
-          name(NAME_PREDICATE)
+          name(NAME_PREDICATE, context = SyntacticContext.Expr.OtherExpr)
         }
       }
       close(mark, TreeKind.Expr.FixpointSolveWithProject)
@@ -2545,15 +2566,15 @@ object Parser2 {
     private def fixpointInjectExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordInject))
       val mark = open()
-      expect(TokenKind.KeywordInject)
+      expect(TokenKind.KeywordInject, SyntacticContext.Expr.OtherExpr)
       expression()
       while (eat(TokenKind.Comma) && !eof()) {
         expression()
       }
-      expect(TokenKind.KeywordInto)
-      name(NAME_PREDICATE)
+      expect(TokenKind.KeywordInto, SyntacticContext.Expr.OtherExpr)
+      name(NAME_PREDICATE, context = SyntacticContext.Expr.OtherExpr)
       while (eat(TokenKind.Comma) && !eof()) {
-        name(NAME_PREDICATE)
+        name(NAME_PREDICATE, context = SyntacticContext.Expr.OtherExpr)
       }
       close(mark, TreeKind.Expr.FixpointInject)
     }
@@ -2561,7 +2582,7 @@ object Parser2 {
     private def fixpointQueryExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordQuery))
       val mark = open()
-      expect(TokenKind.KeywordQuery)
+      expect(TokenKind.KeywordQuery, SyntacticContext.Expr.OtherExpr)
       expression()
       while (eat(TokenKind.Comma) && !eof()) {
         expression()
@@ -2581,7 +2602,7 @@ object Parser2 {
     private def fixpointQuerySelect()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordSelect))
       val mark = open()
-      expect(TokenKind.KeywordSelect)
+      expect(TokenKind.KeywordSelect, SyntacticContext.Expr.OtherExpr)
       (nth(0), nth(1)) match {
         case (TokenKind.ParenL, TokenKind.ParenR) => expression()
         case (TokenKind.ParenL, _) => zeroOrMore(
@@ -2589,6 +2610,7 @@ object Parser2 {
           getItem = () => expression(),
           checkForItem = () => atAny(FIRST_EXPR),
           recoverOn = () => atAny(RECOVER_EXPR),
+          context = SyntacticContext.Expr.OtherExpr
         )
         case _ => expression()
       }
@@ -2598,7 +2620,7 @@ object Parser2 {
     private def fixpointQueryFrom()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordFrom))
       val mark = open()
-      expect(TokenKind.KeywordFrom)
+      expect(TokenKind.KeywordFrom, SyntacticContext.Expr.OtherExpr)
       Predicate.atom()
       while (eat(TokenKind.Comma) && !eof()) {
         Predicate.atom()
@@ -2609,7 +2631,7 @@ object Parser2 {
     private def fixpointQueryWhere()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordWhere))
       val mark = open()
-      expect(TokenKind.KeywordWhere)
+      expect(TokenKind.KeywordWhere, SyntacticContext.Expr.OtherExpr)
       expression()
       close(mark, TreeKind.Expr.FixpointWhere)
     }
@@ -2647,7 +2669,7 @@ object Parser2 {
           lastOpener = getOpener // Try to get nested interpolation
         }
       }
-      expectAny(Set(TokenKind.LiteralStringInterpolationR, TokenKind.LiteralDebugStringR))
+      expectAny(Set(TokenKind.LiteralStringInterpolationR, TokenKind.LiteralDebugStringR), SyntacticContext.Expr.OtherExpr)
       close(mark, TreeKind.Expr.StringInterpolation)
     }
   }
@@ -2696,7 +2718,7 @@ object Parser2 {
 
     private def variablePat()(implicit s: State): Mark.Closed = {
       val mark = open()
-      name(NAME_VARIABLE)
+      name(NAME_VARIABLE, context = SyntacticContext.Pat.OtherPat)
       close(mark, TreeKind.Pattern.Variable)
     }
 
@@ -2708,7 +2730,7 @@ object Parser2 {
 
     private def tagPat()(implicit s: State): Mark.Closed = {
       val mark = open()
-      name(NAME_TAG, allowQualified = true)
+      name(NAME_TAG, allowQualified = true, context = SyntacticContext.Pat.OtherPat)
       if (at(TokenKind.ParenL)) {
         tuplePat()
       }
@@ -2722,7 +2744,8 @@ object Parser2 {
         displayName = "pattern",
         getItem = pattern,
         checkForItem = () => atAny(FIRST_PATTERN),
-        recoverOn = () => atAny(RECOVER_EXPR)
+        recoverOn = () => atAny(RECOVER_EXPR),
+        context = SyntacticContext.Pat.OtherPat
       )
       close(mark, TreeKind.Pattern.Tuple)
     }
@@ -2737,14 +2760,15 @@ object Parser2 {
         delimiterL = TokenKind.CurlyL,
         delimiterR = TokenKind.CurlyR,
         optionallyWith = Some((TokenKind.Bar, () => pattern())),
-        recoverOn = () => atAny(RECOVER_EXPR)
+        recoverOn = () => atAny(RECOVER_EXPR),
+        context = SyntacticContext.Pat.OtherPat
       )
       close(mark, TreeKind.Pattern.Record)
     }
 
     private def recordField()(implicit s: State): Mark.Closed = {
       val mark = open()
-      name(NAME_FIELD)
+      name(NAME_FIELD, context = SyntacticContext.Pat.OtherPat)
       if (eat(TokenKind.Equal)) {
         pattern()
       }
@@ -2848,7 +2872,8 @@ object Parser2 {
         checkForItem = () => atAny(FIRST_TYPE),
         delimiterL = TokenKind.BracketL,
         delimiterR = TokenKind.BracketR,
-        recoverOn = () => atAny(RECOVER_TYPE)
+        recoverOn = () => atAny(RECOVER_TYPE),
+        context = SyntacticContext.Type.OtherType
       )
       close(mark, TreeKind.Type.ArgumentList)
     }
@@ -2867,7 +2892,8 @@ object Parser2 {
         checkForItem = () => atAny(NAME_VARIABLE ++ NAME_TYPE),
         delimiterL = TokenKind.BracketL,
         delimiterR = TokenKind.BracketR,
-        recoverOn = () => atAny(RECOVER_TYPE)
+        recoverOn = () => atAny(RECOVER_TYPE),
+        context = SyntacticContext.Type.OtherType
       ) match {
         case Some(error) => closeWithError(mark, error)
         case None => close(mark, TreeKind.TypeParameterList)
@@ -2876,9 +2902,9 @@ object Parser2 {
 
     private def parameter()(implicit s: State): Mark.Closed = {
       val mark = open()
-      name(NAME_VARIABLE ++ NAME_TYPE)
+      name(NAME_VARIABLE ++ NAME_TYPE, context = SyntacticContext.Type.OtherType)
       if (at(TokenKind.Colon)) {
-        expect(TokenKind.Colon)
+        expect(TokenKind.Colon, SyntacticContext.Type.OtherType)
         Type.kind()
       }
       close(mark, TreeKind.Parameter)
@@ -2887,7 +2913,7 @@ object Parser2 {
     def constraints()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordWith))
       val mark = open()
-      expect(TokenKind.KeywordWith)
+      expect(TokenKind.KeywordWith, SyntacticContext.WithClause)
       // Note, Can't use zeroOrMore here since there's are no delimiterR.
       var continue = true
       while (continue && !eof()) {
@@ -2907,22 +2933,22 @@ object Parser2 {
 
     private def constraint()(implicit s: State): Mark.Closed = {
       val mark = open()
-      name(NAME_DEFINITION, allowQualified = true)
-      expect(TokenKind.BracketL)
+      name(NAME_DEFINITION, allowQualified = true, SyntacticContext.WithClause)
+      expect(TokenKind.BracketL, SyntacticContext.WithClause)
       Type.ttype()
-      expect(TokenKind.BracketR)
+      expect(TokenKind.BracketR, SyntacticContext.WithClause)
       close(mark, TreeKind.Type.Constraint)
     }
 
     def derivations()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordWith))
       val mark = open()
-      expect(TokenKind.KeywordWith)
+      expect(TokenKind.KeywordWith, SyntacticContext.WithClause)
       // Note, Can't use zeroOrMore here since there's are no delimiterR.
       var continue = true
       while (continue && !eof()) {
         if (atAny(NAME_QNAME)) {
-          name(NAME_QNAME, allowQualified = true)
+          name(NAME_QNAME, allowQualified = true, context = SyntacticContext.WithClause)
         } else {
           val error = ParseError("Expected type derivation", SyntacticContext.WithClause, currentSourceLocation())
           closeWithError(open(), error)
@@ -2939,10 +2965,10 @@ object Parser2 {
       // If a new type is added here, remember to add it to TYPE_FIRST too.
       val mark = open()
       nth(0) match {
-        case TokenKind.NameUpperCase => name(NAME_TYPE, allowQualified = true)
+        case TokenKind.NameUpperCase => name(NAME_TYPE, allowQualified = true, context = SyntacticContext.Type.OtherType)
         case TokenKind.NameMath
              | TokenKind.NameGreek
-             | TokenKind.Underscore => name(NAME_VARIABLE)
+             | TokenKind.Underscore => name(NAME_VARIABLE, context = SyntacticContext.Type.OtherType)
         case TokenKind.NameLowerCase => variableType()
         case TokenKind.KeywordUniv
              | TokenKind.KeywordPure
@@ -2959,7 +2985,7 @@ object Parser2 {
              | TokenKind.KeywordRvnot => unaryType()
         // TODO: Static is used as a type name in Prelude.flix. That requires special handling here.
         // If we remove this rule, remove KeywordStaticUppercase from FIRST_TYPE too.
-        case TokenKind.KeywordStaticUppercase => name(Set(TokenKind.KeywordStaticUppercase))
+        case TokenKind.KeywordStaticUppercase => name(Set(TokenKind.KeywordStaticUppercase), context = SyntacticContext.Type.OtherType)
         case t =>
           val mark = open()
           val error = ParseError(s"Expected <type> before ${t.display}.", SyntacticContext.Type.OtherType, previousSourceLocation())
@@ -2972,7 +2998,7 @@ object Parser2 {
 
     private def variableType()(implicit s: State): Mark.Closed = {
       val mark = open()
-      expectAny(TYPE_VAR)
+      expectAny(TYPE_VAR, SyntacticContext.Type.OtherType)
       close(mark, TreeKind.Type.Variable)
     }
 
@@ -2980,7 +3006,7 @@ object Parser2 {
 
     private def constantType()(implicit s: State): Mark.Closed = {
       val mark = open()
-      expectAny(TYPE_CONSTANT)
+      expectAny(TYPE_CONSTANT, SyntacticContext.Type.OtherType)
       close(mark, TreeKind.Type.Constant)
     }
 
@@ -3006,7 +3032,8 @@ object Parser2 {
         getItem = recordField,
         checkForItem = () => atAny(NAME_FIELD),
         recoverOn = () => atAny(RECOVER_TYPE),
-        optionallyWith = Some((TokenKind.Bar, variableType))
+        optionallyWith = Some((TokenKind.Bar, variableType)),
+        context = SyntacticContext.Type.OtherType
       )
       close(mark, TreeKind.Type.RecordRow)
     }
@@ -3018,7 +3045,8 @@ object Parser2 {
         displayName = "type",
         getItem = () => ttype(),
         checkForItem = () => atAny(FIRST_TYPE),
-        recoverOn = () => atAny(RECOVER_TYPE)
+        recoverOn = () => atAny(RECOVER_TYPE),
+        context = SyntacticContext.Type.OtherType
       )
       close(mark, TreeKind.Type.Tuple)
     }
@@ -3045,15 +3073,16 @@ object Parser2 {
         recoverOn = () => atAny(RECOVER_TYPE),
         delimiterL = TokenKind.CurlyL,
         delimiterR = TokenKind.CurlyR,
-        optionallyWith = Some((TokenKind.Bar, variableType))
+        optionallyWith = Some((TokenKind.Bar, variableType)),
+        context = SyntacticContext.Type.OtherType
       )
       close(mark, TreeKind.Type.Record)
     }
 
     private def recordField()(implicit s: State): Mark.Closed = {
       val mark = open()
-      name(NAME_FIELD)
-      expect(TokenKind.Equal)
+      name(NAME_FIELD, context = SyntacticContext.Type.OtherType)
+      expect(TokenKind.Equal, SyntacticContext.Type.OtherType)
       ttype()
       close(mark, TreeKind.Type.RecordFieldFragment)
     }
@@ -3067,7 +3096,8 @@ object Parser2 {
           checkForItem = () => atAny(FIRST_TYPE),
           recoverOn = () => atAny(RECOVER_TYPE),
           delimiterL = TokenKind.CurlyL,
-          delimiterR = TokenKind.CurlyR
+          delimiterR = TokenKind.CurlyR,
+          context = SyntacticContext.Type.Eff
         )
         close(mark, TreeKind.Type.EffectSet)
       } else {
@@ -3087,7 +3117,8 @@ object Parser2 {
         delimiterL = TokenKind.HashCurlyL,
         delimiterR = TokenKind.CurlyR,
         recoverOn = () => atAny(RECOVER_TYPE),
-        optionallyWith = Some(TokenKind.Bar, () => name(NAME_VARIABLE))
+        optionallyWith = Some(TokenKind.Bar, () => name(NAME_VARIABLE, context = SyntacticContext.Type.OtherType)),
+        context = SyntacticContext.Type.OtherType
       )
       close(mark, TreeKind.Type.Schema)
     }
@@ -3101,14 +3132,15 @@ object Parser2 {
         checkForItem = () => atAny(NAME_PREDICATE),
         delimiterL = TokenKind.HashParenL,
         recoverOn = () => atAny(RECOVER_TYPE),
-        optionallyWith = Some(TokenKind.Bar, () => name(NAME_VARIABLE))
+        optionallyWith = Some(TokenKind.Bar, () => name(NAME_VARIABLE, context = SyntacticContext.Type.OtherType)),
+        context = SyntacticContext.Type.OtherType
       )
       close(mark, TreeKind.Type.SchemaRow)
     }
 
     private def schemaTerm()(implicit s: State): Mark.Closed = {
       val mark = open()
-      name(NAME_PREDICATE, allowQualified = true)
+      name(NAME_PREDICATE, allowQualified = true, context = SyntacticContext.Type.OtherType)
       if (at(TokenKind.BracketL)) {
         arguments()
         close(mark, TreeKind.Type.PredicateWithAlias)
@@ -3118,6 +3150,7 @@ object Parser2 {
           getItem = () => ttype(),
           checkForItem = () => atAny(FIRST_TYPE),
           recoverOn = () => atAny(RECOVER_TYPE),
+          context = SyntacticContext.Type.OtherType,
           optionallyWith = Some(TokenKind.Semi, () => {
             val mark = open()
             ttype()
@@ -3149,11 +3182,12 @@ object Parser2 {
       val mark = open()
       zeroOrMore(
         displayName = "definition name",
-        getItem = () => name(NAME_DEFINITION, allowQualified = true),
+        getItem = () => name(NAME_DEFINITION, allowQualified = true, context = SyntacticContext.Type.OtherType),
         checkForItem = () => atAny(NAME_DEFINITION),
         recoverOn = () => atAny(RECOVER_TYPE),
         delimiterL = TokenKind.AngleL,
-        delimiterR = TokenKind.AngleR
+        delimiterR = TokenKind.AngleR,
+        context = SyntacticContext.Type.OtherType
       )
       close(mark, TreeKind.Type.CaseSet)
     }
@@ -3164,7 +3198,7 @@ object Parser2 {
       val mark = open()
       val op = nth(0)
       val markOp = open()
-      expectAny(FIRST_TYPE_UNARY)
+      expectAny(FIRST_TYPE_UNARY, SyntacticContext.Type.OtherType)
       close(markOp, TreeKind.Operator)
       ttype(left = op)
       close(mark, TreeKind.Type.Unary)
@@ -3173,14 +3207,14 @@ object Parser2 {
     def kind()(implicit s: State): Mark.Closed = {
       def kindFragment(): Unit = {
         val inParens = eat(TokenKind.ParenL)
-        name(NAME_KIND)
+        name(NAME_KIND, context = SyntacticContext.Type.OtherType)
         // Check for arrow kind
         if (eat(TokenKind.ArrowThinR)) {
           kind()
         }
         // consume ')' is necessary
         if (inParens) {
-          expect(TokenKind.ParenR)
+          expect(TokenKind.ParenR, SyntacticContext.Type.OtherType)
         }
       }
 
@@ -3193,7 +3227,7 @@ object Parser2 {
   private object Predicate {
     def head()(implicit s: State): Mark.Closed = {
       val mark = open()
-      name(NAME_PREDICATE)
+      name(NAME_PREDICATE, context = SyntacticContext.Expr.Constraint)
       if (at(TokenKind.ParenL)) {
         termList()
       }
@@ -3208,6 +3242,7 @@ object Parser2 {
         getItem = () => Expr.expression(),
         checkForItem = () => atAny(FIRST_EXPR),
         recoverOn = () => atAny(RECOVER_EXPR),
+        context = SyntacticContext.Expr.Constraint,
         optionallyWith = Some(TokenKind.Semi, () => {
           val mark = open()
           Expr.expression()
@@ -3224,6 +3259,7 @@ object Parser2 {
         getItem = Pattern.pattern,
         checkForItem = () => atAny(FIRST_PATTERN),
         recoverOn = () => atAny(RECOVER_PATTERN),
+        context = SyntacticContext.Expr.Constraint,
         optionallyWith = Some(TokenKind.Semi, () => {
           val mark = open()
           Pattern.pattern()
@@ -3249,7 +3285,7 @@ object Parser2 {
     private def guard()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordIf))
       val mark = open()
-      expect(TokenKind.KeywordIf)
+      expect(TokenKind.KeywordIf, SyntacticContext.Expr.Constraint)
       Expr.expression()
       close(mark, TreeKind.Predicate.Guard)
     }
@@ -3257,23 +3293,24 @@ object Parser2 {
     private def functional()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordLet))
       val mark = open()
-      expect(TokenKind.KeywordLet)
+      expect(TokenKind.KeywordLet, SyntacticContext.Expr.Constraint)
       nth(0) match {
         case TokenKind.ParenL => zeroOrMore(
           displayName = "variable name",
-          getItem = () => name(NAME_VARIABLE),
+          getItem = () => name(NAME_VARIABLE, context = SyntacticContext.Expr.OtherExpr),
           checkForItem = () => atAny(NAME_VARIABLE),
-          recoverOn = () => atAny(FIRST_EXPR + TokenKind.Equal)
+          recoverOn = () => atAny(FIRST_EXPR + TokenKind.Equal),
+          context = SyntacticContext.Expr.Constraint
         )
         case TokenKind.NameLowerCase
              | TokenKind.NameMath
              | TokenKind.NameGreek
-             | TokenKind.Underscore => name(NAME_VARIABLE)
+             | TokenKind.Underscore => name(NAME_VARIABLE, context = SyntacticContext.Expr.Constraint)
         case at =>
           val error = ParseError(s"Expected ${TokenKind.ParenL.display} or name before ${at.display}", SyntacticContext.Unknown, currentSourceLocation())
           advanceWithError(error)
       }
-      expect(TokenKind.Equal)
+      expect(TokenKind.Equal, SyntacticContext.Expr.Constraint)
       Expr.expression()
       close(mark, TreeKind.Predicate.Functional)
     }
@@ -3282,7 +3319,7 @@ object Parser2 {
       val mark = open()
       eat(TokenKind.KeywordNot)
       eat(TokenKind.KeywordFix)
-      name(NAME_PREDICATE)
+      name(NAME_PREDICATE,context = SyntacticContext.Expr.Constraint)
       patternList()
       close(mark, TreeKind.Predicate.Atom)
     }
@@ -3294,7 +3331,8 @@ object Parser2 {
         getItem = Predicate.param,
         checkForItem = () => atAny(NAME_PREDICATE),
         delimiterL = TokenKind.HashParenL,
-        recoverOn = () => atAny(FIRST_EXPR + TokenKind.ArrowThinR)
+        recoverOn = () => atAny(FIRST_EXPR + TokenKind.ArrowThinR),
+        context = SyntacticContext.Expr.Constraint
       )
       close(mark, TreeKind.Predicate.ParamList)
     }
@@ -3302,13 +3340,14 @@ object Parser2 {
     private def param()(implicit s: State): Mark.Closed = {
       var kind: TreeKind = TreeKind.Predicate.ParamUntyped
       val mark = open()
-      name(NAME_PREDICATE)
+      name(NAME_PREDICATE, context = SyntacticContext.Expr.Constraint)
       kind = TreeKind.Predicate.Param
       zeroOrMore(
         displayName = "type",
         getItem = () => Type.ttype(),
         checkForItem = () => atAny(FIRST_TYPE),
         recoverOn = () => atAny(RECOVER_TYPE),
+        context = SyntacticContext.Expr.Constraint,
         optionallyWith = Some(TokenKind.Semi, () => {
           val mark = open()
           Type.ttype()
@@ -3317,7 +3356,6 @@ object Parser2 {
       )
       close(mark, kind)
     }
-
   }
 
   private object JvmOp {
@@ -3327,14 +3365,15 @@ object Parser2 {
         displayName = "type",
         getItem = () => Type.ttype(),
         checkForItem = () => atAny(FIRST_TYPE),
-        recoverOn = () => atAny(RECOVER_TYPE)
+        recoverOn = () => atAny(RECOVER_TYPE),
+        context = SyntacticContext.Type.OtherType
       )
       close(mark, TreeKind.JvmOp.Sig)
     }
 
     private def ascription()(implicit s: State): Mark.Closed = {
       val mark = open()
-      expect(TokenKind.Colon)
+      expect(TokenKind.Colon, SyntacticContext.Expr.OtherExpr)
       Type.typeAndEffect()
       close(mark, TreeKind.JvmOp.Ascription)
     }
@@ -3342,21 +3381,21 @@ object Parser2 {
     def constructor()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordJavaNew))
       val mark = open()
-      expect(TokenKind.KeywordJavaNew)
-      name(NAME_JAVA, allowQualified = true)
+      expect(TokenKind.KeywordJavaNew, SyntacticContext.Expr.OtherExpr)
+      name(NAME_JAVA, allowQualified = true, context = SyntacticContext.Expr.OtherExpr)
       signature()
       ascription()
-      expect(TokenKind.KeywordAs)
-      name(NAME_VARIABLE)
+      expect(TokenKind.KeywordAs, SyntacticContext.Expr.OtherExpr)
+      name(NAME_VARIABLE, context = SyntacticContext.Expr.OtherExpr)
       close(mark, TreeKind.JvmOp.Constructor)
     }
 
     private def methodBody()(implicit s: State): Unit = {
-      name(NAME_JAVA, allowQualified = true)
+      name(NAME_JAVA, allowQualified = true, context = SyntacticContext.Expr.OtherExpr)
       signature()
       ascription()
       if (eat(TokenKind.KeywordAs)) {
-        name(NAME_VARIABLE)
+        name(NAME_VARIABLE, context = SyntacticContext.Expr.OtherExpr)
       }
     }
 
@@ -3369,25 +3408,25 @@ object Parser2 {
     def staticMethod()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordStatic))
       val mark = open()
-      expect(TokenKind.KeywordStatic)
+      expect(TokenKind.KeywordStatic, SyntacticContext.Expr.OtherExpr)
       methodBody()
       close(mark, TreeKind.JvmOp.StaticMethod)
     }
 
     private def fieldGetBody()(implicit s: State): Unit = {
-      expect(TokenKind.KeywordJavaGetField)
-      name(NAME_JAVA, allowQualified = true)
+      expect(TokenKind.KeywordJavaGetField, SyntacticContext.Expr.OtherExpr)
+      name(NAME_JAVA, allowQualified = true, context = SyntacticContext.Expr.OtherExpr)
       ascription()
-      expect(TokenKind.KeywordAs)
-      name(NAME_VARIABLE)
+      expect(TokenKind.KeywordAs, SyntacticContext.Expr.OtherExpr)
+      name(NAME_VARIABLE, context = SyntacticContext.Expr.OtherExpr)
     }
 
     private def putBody()(implicit s: State): Unit = {
-      expect(TokenKind.KeywordJavaSetField)
-      name(NAME_JAVA, allowQualified = true)
+      expect(TokenKind.KeywordJavaSetField, SyntacticContext.Expr.OtherExpr)
+      name(NAME_JAVA, allowQualified = true, context = SyntacticContext.Expr.OtherExpr)
       ascription()
-      expect(TokenKind.KeywordAs)
-      name(NAME_VARIABLE)
+      expect(TokenKind.KeywordAs, SyntacticContext.Expr.OtherExpr)
+      name(NAME_VARIABLE, context = SyntacticContext.Expr.OtherExpr)
     }
 
     def getField()(implicit s: State): Mark.Closed = {
@@ -3399,7 +3438,7 @@ object Parser2 {
     def staticGetField()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordStatic))
       val mark = open()
-      expect(TokenKind.KeywordStatic)
+      expect(TokenKind.KeywordStatic, SyntacticContext.Expr.OtherExpr)
       fieldGetBody()
       close(mark, TreeKind.JvmOp.StaticGetField)
     }
@@ -3413,7 +3452,7 @@ object Parser2 {
     def staticPutField()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordStatic))
       val mark = open()
-      expect(TokenKind.KeywordStatic)
+      expect(TokenKind.KeywordStatic, SyntacticContext.Expr.OtherExpr)
       putBody()
       close(mark, TreeKind.JvmOp.StaticPutField)
     }


### PR DESCRIPTION
This PR add syntactic context to all calls to expect, expectAny and name to enable IDE completions. 

Closes #7630