### PR TITLE
refactor: add associated element type and effect to Collectable (part of issue #7433)

### DIFF
--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -110,8 +110,9 @@ instance ToString[Chain[a]] with ToString[a] {
     }
 }
 
-instance Collectable[Chain] {
-    pub def collect(iter: Iterator[a, ef, r]): Chain[a] \ { ef, r } with Order[a] = Iterator.toChain(iter)
+instance Collectable[Chain[a]] {
+    type Elm = a
+    pub def collect(iter: Iterator[a, ef, r]): Chain[a] \ { ef, r } = Iterator.toChain(iter)
 }
 
 instance Iterable[Chain[a]] {

--- a/main/src/library/Collectable.flix
+++ b/main/src/library/Collectable.flix
@@ -17,11 +17,20 @@
 ///
 /// A trait representing collections that can be produced from an Iterator.
 ///
-pub trait Collectable[m: Type -> Type] {
+pub trait Collectable[m: Type] {
+    ///
+    /// The element type of the Collectable.
+    ///
+    type Elm[m]: Type
+
+    ///
+    /// The associated effect of the Collectable.
+    ///
+    type Aef[m]: Eff = Pure
 
     ///
     /// Run an Iterator collecting the results.
     ///
-    pub def collect(iter: Iterator[a, ef, r]): m[a] \ {ef, r} with Order[a]
+    pub def collect(iter: Iterator[Collectable.Elm[m], ef, r]): m \ (ef + Collectable.Aef[m] +  r)
 
 }

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -116,8 +116,9 @@ instance Monoid[List[a]] {
     pub def empty(): List[a] = Nil
 }
 
-instance Collectable[List] {
-    pub def collect(iter: Iterator[a, ef, r]): List[a] \ { r, ef } with Order[a] = Iterator.toList(iter)
+instance Collectable[List[a]] {
+    type Elm = a
+    pub def collect(iter: Iterator[a, ef, r]): List[a] \ { r, ef } = Iterator.toList(iter)
 }
 
 instance Iterable[List[a]] {

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -87,8 +87,9 @@ instance Monoid[Set[a]] with Order[a] {
 
 instance CommutativeMonoid[Set[a]] with Order[a]
 
-instance Collectable[Set] {
-    pub def collect(iter: Iterator[a, ef, r]): Set[a] \ { ef, r } with Order[a] = Iterator.toSet(iter)
+instance Collectable[Set[a]] with Order[a] {
+    type Elm = a
+    pub def collect(iter: Iterator[a, ef, r]): Set[a] \ { ef, r } = Iterator.toSet(iter)
 }
 
 instance Iterable[Set[a]] {

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -93,8 +93,9 @@ instance Monoid[Vector[a]] {
     pub def empty(): Vector[a] = Vector.empty()
 }
 
-instance Collectable[Vector] {
-    pub def collect(iter: Iterator[a, ef, r]): Vector[a] \ { r, ef } with Order[a] = Iterator.toVector(iter)
+instance Collectable[Vector[a]] {
+    type Elm = a
+    pub def collect(iter: Iterator[a, ef, r]): Vector[a] \ (ef + r) = Iterator.toVector(iter)
 }
 
 instance Iterable[Vector[a]] {

--- a/main/test/ca/uwaterloo/flix/library/TestCollectable.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestCollectable.flix
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024 Stephen Tetley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mod TestCollectable {
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Chain instance                                                          //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def collectChain01(): Bool = region rc {
+        let iter: Iterator[Int32, rc, rc] = Iterator.empty(rc);
+        (Collectable.collect(iter) : Chain[Int32]) == Chain.empty()
+    }
+
+    @test
+    def collectChain02(): Bool = region rc {
+        let iter = Iterator.singleton(rc, 1);
+        Collectable.collect(iter) == Chain.singleton(1)
+    }
+
+    @test
+    def collectChain03(): Bool = region rc {
+        let iter = List.iterator(rc, List#{1, 2, 3});
+        Collectable.collect(iter) == List.toChain(List#{1, 2, 3})
+    }
+
+    @test
+    def collectChain04(): Bool = region rc {
+        let iter = List.iterator(rc, List#{'C', 'B', 'A'});
+        Collectable.collect(iter) == List.toChain(List#{'C', 'B', 'A'})
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // List instance                                                           //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def collectList01(): Bool = region rc {
+        let iter: Iterator[Int32, rc, rc] = Iterator.empty(rc);
+        (Collectable.collect(iter) : List[Int32]) == Nil
+    }
+
+    @test
+    def collectList02(): Bool = region rc {
+        let iter = Iterator.singleton(rc, 1);
+        Collectable.collect(iter) == List#{1}
+    }
+
+    @test
+    def collectList03(): Bool = region rc {
+        let iter = List.iterator(rc, List#{1, 2, 3});
+        Collectable.collect(iter) == List#{1, 2, 3}
+    }
+
+    @test
+    def collectList04(): Bool = region rc {
+        let iter = List.iterator(rc, List#{'C', 'B', 'A'});
+        Collectable.collect(iter) == List#{'C', 'B', 'A'}
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Set instance                                                            //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def collectSet01(): Bool = region rc {
+        let iter: Iterator[Int32, rc, rc] = Iterator.empty(rc);
+        (Collectable.collect(iter) : Set[Int32]) == Set.empty()
+    }
+
+    @test
+    def collectSet02(): Bool = region rc {
+        let iter = Iterator.singleton(rc, 1);
+        Collectable.collect(iter) == Set#{1}
+    }
+
+    @test
+    def collectSet03(): Bool = region rc {
+        let iter = List.iterator(rc, List#{1, 2, 3});
+        Collectable.collect(iter) == Set#{1, 2, 3}
+    }
+
+    @test
+    def collectSet04(): Bool = region rc {
+        let iter = List.iterator(rc, List#{'C', 'B', 'A'});
+        Collectable.collect(iter) == Set#{'A', 'B', 'C'}
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Set instance                                                            //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def collectVector01(): Bool = region rc {
+        let iter: Iterator[Int32, rc, rc] = Iterator.empty(rc);
+        (Collectable.collect(iter) : Vector[Int32]) == Vector#{}
+    }
+
+    @test
+    def collectVector02(): Bool = region rc {
+        let iter = Iterator.singleton(rc, 1);
+        Collectable.collect(iter) == Vector#{1}
+    }
+
+    @test
+    def collectVector03(): Bool = region rc {
+        let iter = List.iterator(rc, List#{1, 2, 3});
+        Collectable.collect(iter) == Vector#{1, 2, 3}
+    }
+
+    @test
+    def collectVector04(): Bool = region rc {
+        let iter = List.iterator(rc, List#{'C', 'B', 'A'});
+        Collectable.collect(iter) == Vector#{'C', 'B', 'A'}
+    }
+
+}


### PR DESCRIPTION
This PR changes the kind of `Collectable` to Type and adds an associated element type and effect. It also removes the `Order` constraint on `collect` that I think was unnecessary (the `Set` instance uses an `Order` constraint but it isn't needed at the trait level).

I've added a handful of instance tests.