### PR TITLE
feat: Fix parser crash on bad match case

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -547,8 +547,8 @@ class Flix {
     val result = for {
       afterReader <- Reader.run(getInputs)
       afterLexer <- Lexer.run(afterReader, cachedLexerTokens, changeSet)
-      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
-      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
+//      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
+//      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
 
       // Plan for migrating to new parser + weeder:
       // Stage 1 [ACTIVE]
@@ -582,9 +582,9 @@ class Flix {
       // Update caches for incremental compilation.
       if (options.incremental) {
         this.cachedLexerTokens = afterLexer
-        this.cachedParserAst = afterParser
+//        this.cachedParserAst = afterParser
         this.cachedParserCst = afterParser2
-        this.cachedWeederAst = afterWeeder
+//        this.cachedWeederAst = afterWeeder
         this.cachedWeederAst2 = afterWeeder2
         this.cachedDesugarAst = afterDesugar
         this.cachedKinderAst = afterKinder

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -547,8 +547,8 @@ class Flix {
     val result = for {
       afterReader <- Reader.run(getInputs)
       afterLexer <- Lexer.run(afterReader, cachedLexerTokens, changeSet)
-//      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
-//      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
+      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
+      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
 
       // Plan for migrating to new parser + weeder:
       // Stage 1 [ACTIVE]
@@ -582,9 +582,9 @@ class Flix {
       // Update caches for incremental compilation.
       if (options.incremental) {
         this.cachedLexerTokens = afterLexer
-//        this.cachedParserAst = afterParser
+        this.cachedParserAst = afterParser
         this.cachedParserCst = afterParser2
-//        this.cachedWeederAst = afterWeeder
+        this.cachedWeederAst = afterWeeder
         this.cachedWeederAst2 = afterWeeder2
         this.cachedDesugarAst = afterDesugar
         this.cachedKinderAst = afterKinder

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -191,7 +191,7 @@ sealed trait TokenKind {
       case TokenKind.LiteralString => "<string>"
       case TokenKind.LiteralChar => "<char>"
       case TokenKind.LiteralStringInterpolationL => "'${'"
-      case TokenKind.LiteralStringInterpolationR => "'}'"
+      case TokenKind.LiteralStringInterpolationR => "'}\"'"
       case TokenKind.Err(_) => "<error>"
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1889,11 +1889,12 @@ object Parser2 {
           // Now check for record operation or record literal,
           // by looking for a '|' before the closing '}'
           val isRecordOp = {
+            val tokensLeft = s.tokens.length - s.position
             var lookahead = 1
             var nestingLevel = 0
             var isRecordOp = false
             var continue = true
-            while (continue && !eof()) {
+            while (continue && lookahead < tokensLeft) {
               nth(lookahead) match {
                 // Found closing '}' so stop seeking.
                 case TokenKind.CurlyR if nestingLevel == 0 => continue = false

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -721,7 +721,7 @@ object Parser2 {
       val mark = open(consumeDocComments = false)
       docComment()
       // Handle case where the last thing in a file or module is a doc-comment
-      if (eof() || at(TokenKind.CurlyR)) {
+      if (eof() || eat(TokenKind.CurlyR)) {
         return close(mark, TreeKind.CommentList)
       }
       // Handle modules
@@ -785,8 +785,13 @@ object Parser2 {
             case TokenKind.KeywordDef => signatureDecl(mark)
             case TokenKind.KeywordType => associatedTypeSigDecl(mark)
             case at =>
-              val error = ParseError(s"Expected ${TokenKind.KeywordType.display}, ${TokenKind.KeywordDef.display} or ${TokenKind.KeywordLaw.display} before ${at.display}", SyntacticContext.Decl.Trait, currentSourceLocation())
-              advanceWithError(error, Some(mark))
+              val loc = currentSourceLocation()
+              // Skip ahead until we hit another declaration or any CurlyR.
+              while (!nth(0).isFirstDecl && !eat(TokenKind.CurlyR) && !eof()) {
+                advance()
+              }
+              val error = ParseError(s"Expected ${TokenKind.KeywordType.display}, ${TokenKind.KeywordDef.display} or ${TokenKind.KeywordLaw.display} before ${at.display}", SyntacticContext.Decl.Trait, loc)
+              closeWithError(mark, error)
           }
         }
         expect(TokenKind.CurlyR, SyntacticContext.Decl.Trait)
@@ -816,8 +821,13 @@ object Parser2 {
             case TokenKind.KeywordDef => definitionDecl(mark)
             case TokenKind.KeywordType => associatedTypeDefDecl(mark)
             case at =>
-              val error = ParseError(s"Expected ${TokenKind.KeywordType.display} or ${TokenKind.KeywordDef.display}, found ${at.display}", SyntacticContext.Decl.Instance, currentSourceLocation())
-              advanceWithError(error, Some(mark))
+              val loc = currentSourceLocation()
+              // Skip ahead until we hit another declaration or any CurlyR.
+              while (!nth(0).isFirstDecl && !eat(TokenKind.CurlyR) && !eof()) {
+                advance()
+              }
+              val error = ParseError(s"Expected ${TokenKind.KeywordType.display} or ${TokenKind.KeywordDef.display} before ${at.display}", SyntacticContext.Decl.Instance, loc)
+              closeWithError(mark, error)
           }
         }
         expect(TokenKind.CurlyR, SyntacticContext.Decl.Instance)
@@ -1734,9 +1744,8 @@ object Parser2 {
         expression()
       }
       // TODO: It's common to type '=' instead of '=>' here. Should we make a specific error?
-      if (eat(TokenKind.ArrowThickR)) {
-        statement()
-      }
+      expect(TokenKind.ArrowThickR, SyntacticContext.Expr.OtherExpr)
+      statement()
       close(mark, TreeKind.Expr.MatchRuleFragment)
     }
 
@@ -3149,7 +3158,7 @@ object Parser2 {
       val mark = open()
       eat(TokenKind.KeywordNot)
       eat(TokenKind.KeywordFix)
-      name(NAME_PREDICATE,context = SyntacticContext.Expr.Constraint)
+      name(NAME_PREDICATE, context = SyntacticContext.Expr.Constraint)
       patternList()
       close(mark, TreeKind.Predicate.Atom)
     }
@@ -3295,7 +3304,7 @@ object Parser2 {
   def syntaxTreeToDebugString(tree: SyntaxTree.Tree, nesting: Int = 1): String = {
     s"${tree.kind}${
       tree.children.map {
-        case token@Token(_, _, _, _, _, _,_,_) => s"\n${"  " * nesting}'${token.text}'"
+        case token@Token(_, _, _, _, _, _, _, _) => s"\n${"  " * nesting}'${token.text}'"
         case tree@SyntaxTree.Tree(_, _, _) => s"\n${"  " * nesting}${syntaxTreeToDebugString(tree, nesting + 1)}"
       }.mkString("")
     }"

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -478,6 +478,21 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectErrorOnCheck[ParseError](result)
     expectMain(result)
   }
+
+  test("Regression.#7646") {
+    val input =
+      """
+        |instance ToString[Card] {
+        |    pub def toString(x: Card): String = match x {
+        |        case Card.Card(r, s) _ => "${r} of ${s}"
+        |    }
+        |}
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #7646 

The example now gives 3 parser errors:
```
-- Parse Error -------------------------------------------------- main/foo.flix

>> Parse Error: Expected '=>' before '_'

3 |         case Card.Card(r, s) _ => "${r} of ${s}"
                               ^
                               Here
Syntactic Context: OtherExpr.

-- Parse Error -------------------------------------------------- main/foo.flix

>> Parse Error: Expected '}' before '=>'

3 |         case Card.Card(r, s) _ => "${r} of ${s}"
                                 ^
                                 Here
Syntactic Context: OtherExpr.

-- Parse Error -------------------------------------------------- main/foo.flix

>> Parse Error: Expected 'type' or 'def' before '=>'

3 |         case Card.Card(r, s) _ => "${r} of ${s}"
                                   ^^
                                   Here
Syntactic Context: Instance.
```
**Reasoning**: 

First error is because parser expects '=>' but finds '_'. This stops parsing of a match-case and returns into the match-expression rule. 

Next error is because the match-expression rule, seeing that it is not at the start of a new match-case, expects a closing '}'. Then control is returned to the instance-body loop. 

The final error is because the instance-body sees something that does not look like a type def or a new definition, namely "=>".  It then skips ahead until a stable spot is found, which ends up being EOF.