### PR TITLE
fix: Make sure equality contraint loop terminates

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -840,7 +840,7 @@ object Parser2 {
         Type.constraints()
       }
       if (at(TokenKind.KeywordWhere)) {
-        equalityConstraints(TokenKind.Equal)
+        equalityConstraints()
       }
       if (eat(TokenKind.Equal)) {
         Expr.statement()
@@ -862,7 +862,7 @@ object Parser2 {
         Type.constraints()
       }
       if (at(TokenKind.KeywordWhere)) {
-        equalityConstraints(TokenKind.Equal)
+        equalityConstraints()
       }
 
       // We want to only parse an expression if we see an equal sign to avoid consuming following definitions as LetRecDefs.
@@ -1126,11 +1126,11 @@ object Parser2 {
       close(mark, TreeKind.Parameter)
     }
 
-    private def equalityConstraints(terminator: TokenKind)(implicit s: State): Mark.Closed = {
+    private def equalityConstraints()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordWhere))
       val mark = open()
       expect(TokenKind.KeywordWhere, SyntacticContext.Decl.OtherDecl)
-      while (!at(terminator) && !eof()) {
+      while (nth(0).isFirstType && !eof()) {
         val markConstraint = open()
         Type.ttype()
         expect(TokenKind.Tilde, SyntacticContext.Decl.OtherDecl)


### PR DESCRIPTION
Fixes issue found in #7660 where equality constraints in signatures would loop endlessly.