### PR TITLE
fix: Make type parameter required on instances

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -803,7 +803,11 @@ object Parser2 {
       assert(at(TokenKind.KeywordInstance))
       expect(TokenKind.KeywordInstance, SyntacticContext.Decl.Instance)
       name(NAME_DEFINITION, allowQualified = true, context = SyntacticContext.Decl.Instance)
-      if (eat(TokenKind.BracketL)) {
+      if (!eat(TokenKind.BracketL)) {
+        // Produce an error for missing type parameter.
+        // TODO: Error hint: Instances must have a type parameter.
+        expect(TokenKind.BracketL, SyntacticContext.Decl.Instance)
+      } else {
         Type.ttype()
         expect(TokenKind.BracketR, SyntacticContext.Decl.Instance)
       }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -479,6 +479,17 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
+  test("BadInstance.01") {
+    val input =
+      """
+        |instance Order { }
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
   test("Regression.#7646") {
     val input =
       """


### PR DESCRIPTION
Closes #7649

Example added as a test case. The error emitted is:
```
-- Parse Error -------------------------------------------------- main/foo.flix

>> Parse Error: Expected '[' before '{'

1 | instance Order { }
             ^^^^^
             Here
Syntactic Context: Instance.
```