### PR TITLE
fix: Handle bad enum case crash.

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -430,7 +430,7 @@ object Parser2 {
       case TokenKind.CommentDoc => ParseError(s"Doc-comments can only decorate declarations.", context, previousSourceLocation())
       case at =>
         val kindsDisplayed = prettyJoin(kinds.toList.map(k => s"${k.display}"))
-        ParseError(s"Expected $kindsDisplayed before ${at.display}", SyntacticContext.Unknown, previousSourceLocation())
+        ParseError(s"Expected $kindsDisplayed before ${at.display}", context, previousSourceLocation())
     }
     closeWithError(mark, error)
   }
@@ -960,9 +960,7 @@ object Parser2 {
       while (!eof() && atAny(FIRST_ENUM_CASE)) {
         val mark = open(consumeDocComments = false)
         docComment()
-        if (at(TokenKind.KeywordCase)) {
-          expect(TokenKind.KeywordCase, SyntacticContext.Decl.Enum)
-        } else {
+        if (!eat(TokenKind.KeywordCase)) {
           expect(TokenKind.Comma, SyntacticContext.Decl.Enum)
           // Handle comma followed by case keyword
           docComment()

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -2919,6 +2919,11 @@ object Weeder2 {
       case Some(t: Tree) if t.kind.isInstanceOf[TreeKind.ErrorTree] =>
         val name = text(tree).mkString("")
         Validation.success(Name.Ident(tree.loc.sp1, name, tree.loc.sp2))
+      case Some(t: Tree) if t.kind == TreeKind.CommentList =>
+        // We hit a misplaced comment.
+        val name = text(tree).mkString("")
+        val error = ParseError(if (t.children.length > 1) "Misplaced comments" else "Misplaced comment", SyntacticContext.Unknown, t.loc)
+        Validation.toSoftFailure(Name.Ident(tree.loc.sp1, name, tree.loc.sp2), error)
       case _ => throw InternalCompilerException(s"Parse failure: expected first child of '${tree.kind}' to be Child.Token", tree.loc)
     }
   }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -190,6 +190,24 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
+  test("BadEnum.04") {
+    val input =
+      """
+        |// A Suit type deriving an Eq and ToString instance
+        |enum Suit with Eq, ToString {
+        |    case
+        |    //case Clubs
+        |    //case Hearts
+        |    //case Spades
+        |    //case Diamonds
+        |}
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
   test("TypeAlias.01") {
     val input =
       """


### PR DESCRIPTION
Closes #7645 

Added a test case with the example. Two error messages are produced instead of a crash now: 
```
-- Parse Error -------------------------------------------------- main/foo.flix

>> Parse Error: Misplaced comments

4 |>     //case Clubs
5 |>     //case Hearts
6 |>     //case Spades
7 |>     //case Diamonds

Here
Syntactic Context: Unknown.

-- Parse Error -------------------------------------------------- main/foo.flix

>> Parse Error: Expected <Name> or 'Pure' before '}'

7 |     //case Diamonds
        ^^^^^^^^^^^^^^^
        Here
Syntactic Context: Enum.
```

**Reasoning**: 

The enum case rule sees `case` and expects a name next. To the parser, comments are invisible, which is achieved by consuming them immediately when opening a new tree node. So when the parser looks for a tag-name it sees the `}` next and produces the bottom-most error. 

The first error is produced by the weeder. It looks for a tree node of kind Ident which should contain the tag-name of the enum-case. Within the ident however is only a CommentList. This represents a general case of disallowed comment placement, ala `let /* why even would we want this ?*/ x = ???` so the weeder makes an error out of it.