### PR TITLE
fix: Avoid crash in bad effect declaration

### DIFF
--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -508,6 +508,20 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
+  test("BadEff.01") {
+    val input =
+      """
+        |pub eff Print {
+        |    /
+        |    pub def printIt(): Unit
+        |}
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
   test("Regression.#7646") {
     val input =
       """


### PR DESCRIPTION
Closes #7641 

Made a test with the example. A single error is now emitted:
```
-- Parse Error -------------------------------------------------- main/foo.flix

>> Parse Error: Expected 'def' before '/'

2 |     /
        ^
        Here
Syntactic Context: OtherDecl.
```