### PR TITLE
fix: capture doc comments again

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -638,7 +638,7 @@ object Parser2 {
   /// GRAMMAR                                                                             //
   //////////////////////////////////////////////////////////////////////////////////////////
   private def root()(implicit s: State): Unit = {
-    val mark = open()
+    val mark = open(consumeDocComments = false)
     usesOrImports()
     while (!eof()) {
       Decl.declaration()
@@ -647,7 +647,7 @@ object Parser2 {
   }
 
   private def usesOrImports()(implicit s: State): Mark.Closed = {
-    val mark = open()
+    val mark = open(consumeDocComments = false)
     var continue = true
     while (continue && !eof()) {
       nth(0) match {


### PR DESCRIPTION
Closes #7608 

The issue was that `CommentList` was introduced to group sequential comments into a single syntax node, but the weeder was not updated to select into `CommentList`s and capture text. `pickDocumentation` was updated to remedy that.

Another related issue was that the very first doc comment in a file would be placed under the root node rather than the first declaration. That was also fixed.