### PR TITLE
test: add test for identity type alias

### DIFF
--- a/main/test/flix/Test.Dec.TypeAlias.flix
+++ b/main/test/flix/Test.Dec.TypeAlias.flix
@@ -168,4 +168,14 @@ mod Test.Dec.TypeAlias {
 
     @test
     def testTypeAlias28(): P[If[true, true, false]] = ("xyz": P[true])
+
+    ///
+    /// Identity type alias
+    ///
+    type alias Id[a] = a
+
+    def testTypeAlias29Helper(x: a): Id[a] = x
+
+    @test
+    def testTypeAlias29(): Bool = testTypeAlias29Helper(123) == 123
 }


### PR DESCRIPTION
closes #5729 (fixed by rework; this just adds a test)