### PR TITLE
fix: Capture doc-comments on top-level traits.

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -253,7 +253,7 @@ object Parser2 {
     val error = ParseError("Unclosed parser mark", SyntacticContext.Unknown, currentSourceLocation())
     s.events.append(Event.Open(TreeKind.ErrorTree(error)))
     // Consume any comments just before opening a new mark
-    comments(canStartOnDoc = consumeDocComments)
+    comments(consumeDocComments = consumeDocComments)
     mark
   }
 
@@ -617,17 +617,16 @@ object Parser2 {
     * In cases where doc-comments cannot occur (above expressions for instance), we would like to treat them as regular comments.
     * This is achieved by passing `canStartOnDoc = true`.
     */
-  private def comments(canStartOnDoc: Boolean = false)(implicit s: State): Unit = {
+  private def comments(consumeDocComments: Boolean = false)(implicit s: State): Unit = {
     // Note: In case of a misplaced CommentDoc, we would just like to consume it into the comment list.
     // This is forgiving in the common case of accidentally inserting an extra '/'.
-    val k = nth(0)
-    val atStart = if (canStartOnDoc) k.isComment else k.isCommentNonDoc
-    if (atStart) {
+    def atComment() = if (consumeDocComments) nth(0).isComment else nth(0).isCommentNonDoc
+    if (atComment()) {
       val mark = Mark.Opened(s.events.length)
       val error = ParseError("Unclosed parser mark.", SyntacticContext.Unknown, currentSourceLocation())
       s.events.append(Event.Open(TreeKind.ErrorTree(error)))
       // Note: This loop will also consume doc-comments that are preceded or surrounded by either line or block comments.
-      while (nth(0).isComment && !eof()) {
+      while (atComment() && !eof()) {
         advance()
       }
       close(mark, TreeKind.CommentList)

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -638,7 +638,7 @@ object Parser2 {
   /// GRAMMAR                                                                             //
   //////////////////////////////////////////////////////////////////////////////////////////
   private def root()(implicit s: State): Unit = {
-    val mark = open()
+    val mark = open(consumeDocComments = false)
     usesOrImports()
     while (!eof()) {
       Decl.declaration()
@@ -647,7 +647,7 @@ object Parser2 {
   }
 
   private def usesOrImports()(implicit s: State): Mark.Closed = {
-    val mark = open()
+    val mark = open(consumeDocComments = false)
     var continue = true
     while (continue && !eof()) {
       nth(0) match {

--- a/main/test/flix/Test.Def.ChooseStar.Simple.flix
+++ b/main/test/flix/Test.Def.ChooseStar.Simple.flix
@@ -193,11 +193,11 @@ mod Test.Def.ChooseStar.Simple {
 //        let h = if (true) helper12_1 else helper12_2;
 //        let thing = h(Expr.Cst);
 //        ???
-////        choose h(Expr.Cst) {
-////            case Expr.Cst => true
-////            case Expr.Var => true
-////            case Expr.Xor => true
-////        }
+//          choose h(Expr.Cst) {
+//              case Expr.Cst => true
+//              case Expr.Var => true
+//              case Expr.Xor => true
+//          }
 //    }
 //
 //    def helper13_1(e: Expr[s rvand <Expr.Cst, Expr.Var, Expr.Not>]): Expr[<Expr.Cst>] = choose* e {


### PR DESCRIPTION
Closes #7608 

Fixes issue where a doc-comment immediately after the license block-comment would get misplaced into the wrong CommentList.