### PR TITLE
fix: count unused type parameters in redundancy checks

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -236,10 +236,13 @@ object Redundancy {
   /**
     * Finds unused type parameters.
     */
-  private def findUnusedTypeParameters(spec: Spec): List[UnusedTypeParam] = {
-    spec.tparams.collect {
-      case tparam if deadTypeVar(tparam.sym, spec.declaredScheme.base.typeVars.map(_.sym)) => UnusedTypeParam(tparam.name)
-    }
+  private def findUnusedTypeParameters(spec: Spec): List[UnusedTypeParam] = spec match {
+    case Spec(_, _, _, tparams, fparams, _, tpe, eff, tconstrs, econstrs, _) =>
+      val tpes = fparams.map(_.tpe) ::: tpe :: eff :: tconstrs.map(_.arg) ::: econstrs.map(_.tpe1) ::: econstrs.map(_.tpe2)
+      val used = tpes.flatMap { t => t.typeVars.map(_.sym) }.toSet
+      tparams.collect {
+        case tparam if deadTypeVar(tparam.sym, used) => UnusedTypeParam(tparam.name)
+      }
   }
 
 


### PR DESCRIPTION
related to #7660