### PR TITLE
fix: rhs-expression required on LetMatch and LetRecDef

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1165,12 +1165,21 @@ object Parser2 {
   }
 
   private object Expr {
-    def statement()(implicit s: State): Mark.Closed = {
+    /**
+      * Parse a statement, which is an expression optionally followed by a semi-colon and another expression.
+      * If mustHaveRhs is true, the right-hand-side expression is not treated as optional
+      */
+    def statement(rhsIsOptional: Boolean = true)(implicit s: State): Mark.Closed = {
       var lhs = expression()
       if (eat(TokenKind.Semi)) {
         statement()
         lhs = close(openBefore(lhs), TreeKind.Expr.Statement)
         lhs = close(openBefore(lhs), TreeKind.Expr.Expr)
+      } else if (!rhsIsOptional) {
+        // If no semi is found and it was required, produce an error.
+        // TODO: We can add a parse error hint as an argument to statement ala:
+        // "Add an expression after the let-binding like so: 'let x = <expr1>; <expr2>'"
+        expect(TokenKind.Semi, SyntacticContext.Expr.OtherExpr)
       }
       lhs
     }
@@ -1613,7 +1622,7 @@ object Parser2 {
         Type.ttype()
       }
       expect(TokenKind.Equal, SyntacticContext.Expr.OtherExpr)
-      statement()
+      statement(rhsIsOptional = false)
       close(mark, TreeKind.Expr.LetMatch)
     }
 
@@ -1629,7 +1638,7 @@ object Parser2 {
         Type.typeAndEffect()
       }
       expect(TokenKind.Equal, SyntacticContext.Expr.OtherExpr)
-      statement()
+      statement(rhsIsOptional = false)
       close(mark, TreeKind.Expr.LetRecDef)
     }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -522,6 +522,32 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
+  test("LetMatchNoStatement.01") {
+    val input =
+      """
+        |def foo(): Unit \ IO =
+        |    let x =
+        |    println("Hello World!")
+        |
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
+  test("LetRecDefNoStatement.01") {
+    val input =
+      """
+        |def foo(): Unit \ IO =
+        |    def bar(): Int32 = 123
+        |def main(): Int32 = 456
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
   test("Regression.#7646") {
     val input =
       """


### PR DESCRIPTION
Closes #7636 

This PR makes it a parse error to have either a LetMatch or a LetRecDef without a following right-hand side expression. A test for each of these cases has been added. An example would be this program:
```scala
def foo(): Unit \ IO =
    def bar(): Int32 = 123

def main(): Int32 = 123
```
Which gives a single parse error:
```
-- Parse Error -------------------------------------------------- main/foo.flix

>> Parse Error: Expected ';' before 'def'

2 |     def bar(): Int32 = 123
                           ^^^
                           Here
Syntactic Context: OtherExpr.
```