### PR TITLE
feat: add Iterable instances for mutable data structures (issue #7639)

### DIFF
--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+instance Iterable[Array[a, r]] {
+    type Elm = a
+    type Aef = r
+    pub def iterator(rc: Region[r1], a: Array[a, r]): Iterator[a, r + r1, r1] \ (r + r1) =
+        checked_ecast(Array.iterator(rc, a))
+}
+
 mod Array {
 
     ///

--- a/main/src/library/Iterable.flix
+++ b/main/src/library/Iterable.flix
@@ -24,19 +24,22 @@ pub trait Iterable[t] {
     type Elm[t]: Type
 
     ///
-    /// The associated effect of the Iterable.
+    /// The associated effect of creating the Iterable and accessing the elements
+    /// in the underlying data structure or generator.
+    ///
+    /// The effect is embedded in the type of the Iterator.
     ///
     type Aef[t]: Eff = Pure
 
     ///
     /// Returns an iterator over `t`.
     ///
-    pub def iterator(rc: Region[r], t: t): Iterator[Iterable.Elm[t], Iterable.Aef[t] + r, r] \ Iterable.Aef[t] + r
+    pub def iterator(rc: Region[r], t: t): Iterator[Iterable.Elm[t], r + aef, r] \ (r + aef) where Iterable.Aef[t] ~ aef
 
     ///
     /// Returns an iterator over `t` zipped with the indices of the elements.
     ///
-    pub def enumerator(rc: Region[r], t: t): Iterator[(Int32, Iterable.Elm[t]), Iterable.Aef[t] + r, r] \ Iterable.Aef[t] + r =
+    pub def enumerator(rc: Region[r], t: t): Iterator[(Int32, Iterable.Elm[t]), r + aef, r] \ (r + aef) where Iterable.Aef[t] ~ aef =
         Iterable.iterator(rc, t) |> Iterator.zipWithIndex
 
 }

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -31,6 +31,12 @@ pub enum MutDeque[a: Type, r: Region] {
     case MutDeque(Region[r], Ref[Array[a, r], r], Ref[Int32, r], Ref[Int32, r])
 }
 
+instance Iterable[MutDeque[a, r]] {
+    type Elm = a
+    type Aef = r
+    pub def iterator(rc: Region[r1], md: MutDeque[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutDeque.iterator(rc, md)
+}
+
 mod MutDeque {
 
     ///

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -25,6 +25,12 @@ pub enum MutList[a: Type, r: Region] {
     case MutList(Region[r], Ref[Array[a, r], r], Ref[Int32, r])
 }
 
+instance Iterable[MutList[a, r]] {
+    type Elm = a
+    type Aef = r
+    pub def iterator(rc: Region[r1], l: MutList[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutList.iterator(rc, l)
+}
+
 mod MutList {
 
     ///

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -21,6 +21,13 @@ pub enum MutMap[k: Type, v: Type, r: Region] {
     case MutMap(Region[r], Ref[Map[k, v], r])
 }
 
+instance Iterable[MutMap[k, v, r]] {
+    type Elm = (k, v)
+    type Aef = r
+    pub def iterator(rc: Region[r1], m: MutMap[k, v, r]): Iterator[(k, v), r + r1, r1] \ (r + r1) =
+        MutMap.iterator(rc, m)
+}
+
 mod MutMap {
 
     ///

--- a/main/src/library/MutQueue.flix
+++ b/main/src/library/MutQueue.flix
@@ -27,6 +27,12 @@ pub enum MutQueue[a: Type, r: Region] {
     case MutQueue(Region[r], Ref[Array[a, r], r], Ref[Int32, r])
 }
 
+instance Iterable[MutQueue[a, r]] {
+    type Elm = a
+    type Aef = r
+    pub def iterator(rc: Region[r1], q: MutQueue[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutQueue.iterator(rc, q)
+}
+
 mod MutQueue {
 
     ///

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -21,6 +21,12 @@ pub enum MutSet[t: Type, r: Region] {
     case MutSet(Region[r], Ref[Set[t], r])
 }
 
+instance Iterable[MutSet[a, r]] {
+    type Elm = a
+    type Aef = r
+    pub def iterator(rc: Region[r1], s: MutSet[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutSet.iterator(rc, s)
+}
+
 mod MutSet {
 
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestIterable.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterable.flix
@@ -209,6 +209,34 @@ mod TestIterable {
     }
 
     /////////////////////////////////////////////////////////////////////////////
+    // MutSet instance                                                         //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def iterableMutSet01(): Bool = region rc {
+        let s : MutSet[Int32, rc] = MutSet.empty(rc);
+        Iterable.iterator(rc, s) |> Iterator.toSet == Set.empty()
+    }
+
+    @test
+    def iterableMutSet02(): Bool = region rc {
+        let s = Set#{2, 5, 11, 8} |> Set.toMutSet(rc);
+        Iterable.iterator(rc, s) |> Iterator.toSet == Set#{2, 5, 8, 11}
+    }
+
+    @test
+    def iterableMutSet03(): Bool = region rc {
+        let s = Set#{'A', 'B', 'D', 'C'} |> Set.toMutSet(rc);
+        Iterable.iterator(rc, s) |> Iterator.toSet == Set#{'A', 'B', 'C', 'D'}
+    }
+
+    @test
+    def iterableMutSet04(): Bool = region rc {
+        let s = Set#{(2, 'A'), (5, 'B'), (11, 'D'), (8, 'C')} |> Set.toMutSet(rc);
+        Iterable.iterator(rc, s) |> Iterator.toSet == Set#{(2, 'A'), (5, 'B'), (8, 'C'), (11, 'D')}
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
     // RedBlackTree instance                                                   //
     /////////////////////////////////////////////////////////////////////////////
 
@@ -222,6 +250,34 @@ mod TestIterable {
     def iterableRedBlackTree02(): Bool = region rc {
         let Map.Map(t) = Map#{2 => 'A', 5 => 'B', 11 => 'D', 8 => 'C'};
         Iterable.iterator(rc, t) |> Iterator.toList == List#{(2, 'A'), (5, 'B'), (8, 'C'), (11, 'D')}
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Set instance                                                            //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def iterableSet01(): Bool = region rc {
+        let s : Set[Int32] = Set.empty();
+        Iterable.iterator(rc, s) |> Iterator.toSet == Set.empty()
+    }
+
+    @test
+    def iterableSet02(): Bool = region rc {
+        let s = Set#{2, 5, 11, 8};
+        Iterable.iterator(rc, s) |> Iterator.toSet == Set#{2, 5, 8, 11}
+    }
+
+    @test
+    def iterableSet03(): Bool = region rc {
+        let s = Set#{'A', 'B', 'D', 'C'};
+        Iterable.iterator(rc, s) |> Iterator.toSet == Set#{'A', 'B', 'C', 'D'}
+    }
+
+    @test
+    def iterableSet04(): Bool = region rc {
+        let s = Set#{(2, 'A'), (5, 'B'), (11, 'D'), (8, 'C')};
+        Iterable.iterator(rc, s) |> Iterator.toSet == Set#{(2, 'A'), (5, 'B'), (8, 'C'), (11, 'D')}
     }
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestIterable.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestIterable.flix
@@ -17,6 +17,50 @@
 mod TestIterable {
 
     /////////////////////////////////////////////////////////////////////////////
+    // Array instance                                                          //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def iterableArray01(): Bool = region rc {
+        let a : Array[Int32, rc] = Array#{} @ rc;
+        Iterable.iterator(rc, a) |> Iterator.toList == Nil
+    }
+
+    @test
+    def iterableArray02(): Bool = region rc {
+        let a = Array#{2, 5, 11, 8} @ rc;
+        Iterable.iterator(rc, a) |> Iterator.toList == List#{2, 5, 11, 8}
+    }
+
+    @test
+    def iterableArray03(): Bool = region rc {
+        let a = Array#{'A', 'B', 'D', 'C'} @ rc;
+        Iterable.iterator(rc, a) |> Iterator.toList == List#{'A', 'B', 'D', 'C'}
+    }
+
+    @test
+    def iterableArray04(): Bool = region rc {
+        let a = Array#{(2, 'A'), (5, 'B'), (11, 'D'), (8, 'C')} @ rc;
+        Iterable.iterator(rc, a) |> Iterator.toList == List#{(2, 'A'), (5, 'B'), (11, 'D'), (8, 'C')}
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // DelayMap instance                                                       //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def iterableDelayMap01(): Bool = region rc {
+        let m : DelayMap[Int32, Char] = DelayMap.empty();
+        Iterable.iterator(rc, m) |> Iterator.toList == Nil
+    }
+
+    @test
+    def iterableDelayMap02(): Bool = region rc {
+        let m = Map#{2 => 'A', 5 => 'B', 11 => 'D', 8 => 'C'} |> Map.toDelayMap;
+        Iterable.iterator(rc, m) |> Iterator.toList == List#{(2, 'A'), (5, 'B'), (8, 'C'), (11, 'D')}
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
     // List instance                                                           //
     /////////////////////////////////////////////////////////////////////////////
 
@@ -45,22 +89,6 @@ mod TestIterable {
     }
 
     /////////////////////////////////////////////////////////////////////////////
-    // RedBlackTree instance                                                   //
-    /////////////////////////////////////////////////////////////////////////////
-
-    @test
-    def iterableRedBlackTree01(): Bool = region rc {
-        let t : RedBlackTree[Int32, Char] = RedBlackTree.empty();
-        Iterable.iterator(rc, t) |> Iterator.toList == Nil
-    }
-
-    @test
-    def iterableRedBlackTree02(): Bool = region rc {
-        let Map.Map(t) = Map#{2 => 'A', 5 => 'B', 11 => 'D', 8 => 'C'};
-        Iterable.iterator(rc, t) |> Iterator.toList == List#{(2, 'A'), (5, 'B'), (8, 'C'), (11, 'D')}
-    }
-
-    /////////////////////////////////////////////////////////////////////////////
     // Map instance                                                            //
     /////////////////////////////////////////////////////////////////////////////
 
@@ -77,19 +105,123 @@ mod TestIterable {
     }
 
     /////////////////////////////////////////////////////////////////////////////
-    // DelayMap instance                                                       //
+    // MutDeque instance                                                       //
     /////////////////////////////////////////////////////////////////////////////
 
     @test
-    def iterableDelayMap01(): Bool = region rc {
-        let m : DelayMap[Int32, Char] = DelayMap.empty();
+    def iterableMutDeque01(): Bool = region rc {
+        let d : MutDeque[Int32, rc] = MutDeque.empty(rc);
+        Iterable.iterator(rc, d) |> Iterator.toList == Nil
+    }
+
+    @test
+    def iterableMutDeque02(): Bool = region rc {
+        let d = List#{2, 5, 11, 8} |> List.toMutDeque(rc);
+        Iterable.iterator(rc, d) |> Iterator.toList == List#{2, 5, 11, 8}
+    }
+
+    @test
+    def iterableMutDeque03(): Bool = region rc {
+        let d = List#{'A', 'B', 'D', 'C'} |> List.toMutDeque(rc);
+        Iterable.iterator(rc, d) |> Iterator.toList == List#{'A', 'B', 'D', 'C'}
+    }
+
+    @test
+    def iterableMutDeque04(): Bool = region rc {
+        let d = List#{(2, 'A'), (5, 'B'), (11, 'D'), (8, 'C')} |> List.toMutDeque(rc);
+        Iterable.iterator(rc, d) |> Iterator.toList == List#{(2, 'A'), (5, 'B'), (11, 'D'), (8, 'C')}
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // MutList instance                                                        //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def iterableMutList01(): Bool = region rc {
+        let l : MutList[Int32, rc] = MutList.empty(rc);
+        Iterable.iterator(rc, l) |> Iterator.toList == Nil
+    }
+
+    @test
+    def iterableMutList02(): Bool = region rc {
+        let l = List#{2, 5, 11, 8} |> List.toMutList(rc);
+        Iterable.iterator(rc, l) |> Iterator.toList == List#{2, 5, 11, 8}
+    }
+
+    @test
+    def iterableMutList03(): Bool = region rc {
+        let l = List#{'A', 'B', 'D', 'C'} |> List.toMutList(rc);
+        Iterable.iterator(rc, l) |> Iterator.toList == List#{'A', 'B', 'D', 'C'}
+    }
+
+    @test
+    def iterableMutList04(): Bool = region rc {
+        let l = List#{(2, 'A'), (5, 'B'), (11, 'D'), (8, 'C')} |> List.toMutList(rc);
+        Iterable.iterator(rc, l) |> Iterator.toList == List#{(2, 'A'), (5, 'B'), (11, 'D'), (8, 'C')}
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // MutMap instance                                                         //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def iterableMutMap01(): Bool = region rc {
+        let m : MutMap[Int32, Char, rc] = MutMap.empty(rc);
         Iterable.iterator(rc, m) |> Iterator.toList == Nil
     }
 
     @test
-    def iterableDelayMap02(): Bool = region rc {
-        let m = Map#{2 => 'A', 5 => 'B', 11 => 'D', 8 => 'C'} |> Map.toDelayMap;
+    def iterableMutMap02(): Bool = region rc {
+        let m = Map#{2 => 'A', 5 => 'B', 11 => 'D', 8 => 'C'} |> Map.toMutMap(rc);
         Iterable.iterator(rc, m) |> Iterator.toList == List#{(2, 'A'), (5, 'B'), (8, 'C'), (11, 'D')}
+    }
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // MutQueue instance                                                       //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def iterableMutQueue01(): Bool = region rc {
+        let mq : MutQueue[Int32, rc] = MutQueue.empty(rc);
+        Iterable.iterator(rc, mq) |> Iterator.toList == Nil
+    }
+
+    @test
+    def iterableMutQueue02(): Bool = region rc {
+        let mq = MutQueue.empty(rc);
+        MutQueue.enqueueAll(mq, List#{2, 5, 11, 8});
+        Iterable.iterator(rc, mq) |> Iterator.toList == List#{11, 8, 5, 2}
+    }
+
+    @test
+    def iterableMutQueue03(): Bool = region rc {
+        let mq = MutQueue.empty(rc);
+        MutQueue.enqueueAll(mq, List#{'A', 'B', 'D', 'C'});
+        Iterable.iterator(rc, mq) |> Iterator.toList == List#{'D', 'C', 'B', 'A'}
+    }
+
+    @test
+    def iterableMutQueue04(): Bool = region rc {
+        let mq = MutQueue.empty(rc);
+        MutQueue.enqueueAll(mq, List#{(2, 'A'), (5, 'B'), (11, 'D'), (8, 'C')});
+        Iterable.iterator(rc, mq) |> Iterator.toList == List#{(11, 'D'), (8, 'C'), (5, 'B'), (2, 'A')}
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // RedBlackTree instance                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def iterableRedBlackTree01(): Bool = region rc {
+        let t : RedBlackTree[Int32, Char] = RedBlackTree.empty();
+        Iterable.iterator(rc, t) |> Iterator.toList == Nil
+    }
+
+    @test
+    def iterableRedBlackTree02(): Bool = region rc {
+        let Map.Map(t) = Map#{2 => 'A', 5 => 'B', 11 => 'D', 8 => 'C'};
+        Iterable.iterator(rc, t) |> Iterator.toList == List#{(2, 'A'), (5, 'B'), (8, 'C'), (11, 'D')}
     }
 
 }


### PR DESCRIPTION
This PR adds `Iterable` instances for mutable data structures and improves the documentation of `Iterable.Aef`.

See issue #7639