### PR TITLE
feat: add ToJava and FromJava instances for builtin types String, Char and the number types

### DIFF
--- a/main/src/library/FromJava.flix
+++ b/main/src/library/FromJava.flix
@@ -15,10 +15,60 @@
  */
 
 ///
-/// A trait for marshaling values from Java.
+/// A trait for marshaling values from Java objects.
 ///
 pub trait FromJava[t: Type] {
     type In[t]: Type
     type Aef[t]: Eff = Pure
     pub def fromJava(t: FromJava.In[t]): t \ FromJava.Aef[t]
+}
+
+instance FromJava[Int8] {
+    type In = ##java.lang.Byte
+    pub def fromJava(i: ##java.lang.Byte): Int8 = Int8.byteValue(i)
+}
+
+instance FromJava[Int16] {
+    type In = ##java.lang.Short
+    pub def fromJava(i: ##java.lang.Short): Int16 = Int16.shortValue(i)
+}
+
+instance FromJava[Int32] {
+    type In = ##java.lang.Integer
+    pub def fromJava(i: ##java.lang.Integer): Int32 = Int32.intValue(i)
+}
+
+instance FromJava[Int64] {
+    type In = ##java.lang.Long
+    pub def fromJava(i: ##java.lang.Long): Int64 = Int64.longValue(i)
+}
+
+instance FromJava[Float32] {
+    type In = ##java.lang.Float
+    pub def fromJava(d: ##java.lang.Float): Float32 = Float32.floatValue(d)
+}
+
+instance FromJava[Float64] {
+    type In = ##java.lang.Double
+    pub def fromJava(d: ##java.lang.Double): Float64 = Float64.doubleValue(d)
+}
+
+instance FromJava[BigInt] {
+    type In = ##java.math.BigInteger
+    pub def fromJava(i: ##java.math.BigInteger): BigInt = i
+}
+
+instance FromJava[BigDecimal] {
+    type In = ##java.math.BigDecimal
+    pub def fromJava(d: ##java.math.BigDecimal): BigDecimal = d
+}
+
+instance FromJava[Char] {
+    type In = ##java.lang.Character
+    pub def fromJava(c: ##java.lang.Character): Char = Char.charValue(c)
+}
+
+instance FromJava[String] {
+    type In = ##java.lang.String
+    pub def fromJava(s: ##java.lang.String): String = s
 }

--- a/main/src/library/ToJava.flix
+++ b/main/src/library/ToJava.flix
@@ -15,10 +15,71 @@
  */
 
 ///
-/// A trait for marshaling values to Java.
+/// A trait for marshaling values to Java objects.
 ///
 pub trait ToJava[t: Type] {
     type Out[t]: Type
     type Aef[t]: Eff = Pure
     pub def toJava(t: t): ToJava.Out[t] \ ToJava.Aef[t]
+}
+
+mod ToJava {
+
+    ///
+    /// Marshal a type that supports `ToJava` to its respective to `ToJava.Out` type
+    /// and upcast it to a `java.lang.Object`
+    ///
+    pub def toJavaObject(t: t): ##java.lang.Object \ ToJava.Aef[t] with ToJava[t] =
+        unchecked_cast(ToJava.toJava(t) as ##java.lang.Object)
+
+}
+
+instance ToJava[Int8] {
+    type Out = ##java.lang.Byte
+    pub def toJava(i: Int8): ##java.lang.Byte = Int8.valueOf(i)
+}
+
+instance ToJava[Int16] {
+    type Out = ##java.lang.Short
+    pub def toJava(i: Int16): ##java.lang.Short = Int16.valueOf(i)
+}
+
+instance ToJava[Int32] {
+    type Out = ##java.lang.Integer
+    pub def toJava(i: Int32): ##java.lang.Integer = Int32.valueOf(i)
+}
+
+instance ToJava[Int64] {
+    type Out = ##java.lang.Long
+    pub def toJava(i: Int64): ##java.lang.Long = Int64.valueOf(i)
+}
+
+instance ToJava[Float32] {
+    type Out = ##java.lang.Float
+    pub def toJava(d: Float32): ##java.lang.Float = Float32.valueOf(d)
+}
+
+instance ToJava[Float64] {
+    type Out = ##java.lang.Double
+    pub def toJava(d: Float64): ##java.lang.Double = Float64.valueOf(d)
+}
+
+instance ToJava[BigInt] {
+    type Out = ##java.math.BigInteger
+    pub def toJava(i: BigInt): ##java.math.BigInteger = i
+}
+
+instance ToJava[BigDecimal] {
+    type Out = ##java.math.BigDecimal
+    pub def toJava(d: BigDecimal): ##java.math.BigDecimal = d
+}
+
+instance ToJava[Char] {
+    type Out = ##java.lang.Character
+    pub def toJava(c: Char): ##java.lang.Character = Char.valueOf(c)
+}
+
+instance ToJava[String] {
+    type Out = ##java.lang.String
+    pub def toJava(s: String): ##java.lang.String = s
 }

--- a/main/test/ca/uwaterloo/flix/library/TestFromJava.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFromJava.flix
@@ -17,6 +17,152 @@
 mod TestFromJava {
 
     /////////////////////////////////////////////////////////////////////////////
+    // Int8                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def int8FromJava01(): Bool =
+        let i = Int8.valueOf(0i8);
+        FromJava.fromJava(i) == 0i8
+
+    @test
+    def int8FromJava02(): Bool =
+        let i = Int8.valueOf(100i8);
+        FromJava.fromJava(i) == 100i8
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int16                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def int16FromJava01(): Bool =
+        let i = Int16.valueOf(0i16);
+        FromJava.fromJava(i) == 0i16
+
+    @test
+    def int16FromJava02(): Bool =
+        let i = Int16.valueOf(100i16);
+        FromJava.fromJava(i) == 100i16
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int32                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def int32FromJava01(): Bool =
+        let i = Int32.valueOf(0);
+        FromJava.fromJava(i) == 0
+
+    @test
+    def int32FromJava02(): Bool =
+        let i = Int32.valueOf(100);
+        FromJava.fromJava(i) == 100
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int64                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def int64FromJava01(): Bool =
+        let i = Int64.valueOf(0i64);
+        FromJava.fromJava(i) == 0i64
+
+    @test
+    def int64FromJava02(): Bool =
+        let i = Int64.valueOf(100i64);
+        FromJava.fromJava(i) == 100i64
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Float32                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def float32FromJava01(): Bool =
+        let d = Float32.valueOf(0.0f32);
+        FromJava.fromJava(d) == 0.0f32
+
+    @test
+    def float32FromJava02(): Bool =
+        let d = Float32.valueOf(100.0f32);
+        FromJava.fromJava(d) == 100.0f32
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Float64                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def float64FromJava01(): Bool =
+        let d = Float64.valueOf(0.0f64);
+        FromJava.fromJava(d) == 0.0f64
+
+    @test
+    def float64FromJava02(): Bool =
+        let d = Float64.valueOf(100.0f64);
+        FromJava.fromJava(d) == 100.0f64
+
+    /////////////////////////////////////////////////////////////////////////////
+    // BigInt                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def bigIntFromJava01(): Bool =
+        import static java.math.BigInteger.valueOf(Int64): ##java.math.BigInteger \ {};
+        let i = valueOf(0i64);
+        FromJava.fromJava(i) == 0ii
+
+    @test
+    def bigIntFromJava02(): Bool =
+        import static java.math.BigInteger.valueOf(Int64): ##java.math.BigInteger \ {};
+        let i = valueOf(100i64);
+        FromJava.fromJava(i) == 100ii
+
+    /////////////////////////////////////////////////////////////////////////////
+    // BigDecimal                                                              //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def bigDecimalFromJava01(): Bool =
+        import static java.math.BigDecimal.valueOf(Int64): ##java.math.BigDecimal \ {};
+        let d = valueOf(0i64);
+        FromJava.fromJava(d) == 0.0ff
+
+    @test
+    def bigDecimalFromJava02(): Bool =
+        import static java.math.BigDecimal.valueOf(Int64): ##java.math.BigDecimal \ {};
+        let d = valueOf(100i64);
+        FromJava.fromJava(d) == 100.0ff
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Char                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def charFromJava01(): Bool =
+        let c = Char.valueOf('0');
+        FromJava.fromJava(c) == '0'
+
+    @test
+    def charFromJava02(): Bool =
+        let c = Char.valueOf('a');
+        FromJava.fromJava(c) == 'a'
+
+    /////////////////////////////////////////////////////////////////////////////
+    // String                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def stringFromJava01(): Bool =
+        import static java.lang.String.valueOf(Bool): ##java.lang.String \ {};
+        let s = valueOf(true);
+        FromJava.fromJava(s) == "true"
+
+    @test
+    def stringFromJava02(): Bool =
+        import static java.lang.String.valueOf(Bool): ##java.lang.String \ {};
+        let s = valueOf(false);
+        FromJava.fromJava(s) == "false"
+
+    /////////////////////////////////////////////////////////////////////////////
     // Chain                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 

--- a/main/test/ca/uwaterloo/flix/library/TestToJava.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestToJava.flix
@@ -17,6 +17,166 @@
 mod TestToJava {
 
     /////////////////////////////////////////////////////////////////////////////
+    // toJavaObject                                                            //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def toJavaObject01(): Bool =
+        let x = ToJava.toJavaObject(0);
+        typematch x {
+            case _: ##java.lang.Object => true
+            case _: _ => false
+        }
+
+    @test
+    def toJavaObject02(): Bool =
+        let x = ToJava.toJavaObject("hello world!");
+        typematch x {
+            case _: ##java.lang.Object => true
+            case _: _ => false
+        }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int8                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def int8ToJava01(): Bool =
+        let i = ToJava.toJava(0i8);
+        Int8.byteValue(i) == 0i8
+
+    @test
+    def int8ToJava02(): Bool =
+        let i = ToJava.toJava(100i8);
+        Int8.byteValue(i) == 100i8
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int16                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def int16ToJava01(): Bool =
+        let i = ToJava.toJava(0i16);
+        Int16.shortValue(i) == 0i16
+
+    @test
+    def int16ToJava02(): Bool =
+        let i = ToJava.toJava(100i16);
+        Int16.shortValue(i) == 100i16
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int32                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def int32ToJava01(): Bool =
+        let i = ToJava.toJava(0);
+        Int32.intValue(i) == 0
+
+    @test
+    def int32ToJava02(): Bool =
+        let i = ToJava.toJava(100);
+        Int32.intValue(i) == 100
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Int64                                                                   //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def int64ToJava01(): Bool =
+        let i = ToJava.toJava(0i64);
+        Int64.longValue(i) == 0i64
+
+    @test
+    def int64ToJava02(): Bool =
+        let i = ToJava.toJava(100i64);
+        Int64.longValue(i) == 100i64
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Float32                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def float32ToJava01(): Bool =
+        let d = ToJava.toJava(0.0f32);
+        Float32.floatValue(d) == 0.0f32
+
+    @test
+    def float32ToJava02(): Bool =
+        let d = ToJava.toJava(100.0f32);
+        Float32.floatValue(d) == 100.0f32
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Float64                                                                 //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def float64ToJava01(): Bool =
+        let d = ToJava.toJava(0.0f64);
+        Float64.doubleValue(d) == 0.0f64
+
+    @test
+    def float64ToJava02(): Bool =
+        let d = ToJava.toJava(100.0f64);
+        Float64.doubleValue(d) == 100.0f64
+
+    /////////////////////////////////////////////////////////////////////////////
+    // BigInt                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def bigIntToJava01(): Bool =
+        let i = ToJava.toJava(0ii);
+        i == 0ii
+
+    @test
+    def bigIntToJava02(): Bool =
+        let i = ToJava.toJava(100ii);
+        i == 100ii
+
+    /////////////////////////////////////////////////////////////////////////////
+    // BigDecimal                                                              //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def bigDecimalToJava01(): Bool =
+        let d = ToJava.toJava(0.0ff);
+        d == 0.0ff
+
+    @test
+    def bigDecimalToJava02(): Bool =
+        let d = ToJava.toJava(100.0ff);
+        d == 100.0ff
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Char                                                                    //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def charToJava01(): Bool =
+        let c = ToJava.toJava('0');
+        Char.charValue(c) == '0'
+
+    @test
+    def charToJava02(): Bool =
+        let c = ToJava.toJava('a');
+        Char.charValue(c) == 'a'
+
+    /////////////////////////////////////////////////////////////////////////////
+    // String                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def stringToJava01(): Bool =
+        let s = ToJava.toJava("");
+        s == ""
+
+    @test
+    def stringToJava02(): Bool =
+        let s = ToJava.toJava("hello world!");
+        s == "hello world!"
+
+    /////////////////////////////////////////////////////////////////////////////
     // Chain                                                                   //
     /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This PR added `ToJava` and `FromJava` instances for the builtin types `String`, `Char` and the number types `Int32` etc.

For Flix types that are primitive types in Java, the conversion is to the respective Java object rather than the primitive type (the Flix type is already the primitive) type. ie. Flix `Char` goes to Java's `java.lang.Character`. `String`, `BigInt` and `BigDecimal` are just identity. Converting to the Java object means they can be stored in Java collections.

The PR also adds `toJavaObject(a: t): ##java.lang.Object with ToJava[t]` to convert safely to the Java representation and upcast to `java.lang.Object`.
