### PR TITLE
fix: fix datalog crash

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -240,6 +240,31 @@ sealed trait TokenKind {
   })
 
   /**
+    * Checks if this token is one of the [[TokenKind]]s that can validly appear as the first token in a declaration within an instance.
+    * Note that a CommentDoc, a Modifier and/or an annotation may lead such a declaration.
+    */
+  def isFirstInstance: Boolean = this.isModifier || (this match {
+    case TokenKind.CommentDoc
+         | TokenKind.Annotation
+         | TokenKind.KeywordDef
+         | TokenKind.KeywordType => true
+    case _ => false
+  })
+
+  /**
+    * Checks if this token is one of the [[TokenKind]]s that can validly appear as the first token in a declaration within a trait.
+    * Note that a CommentDoc, a Modifier and/or an annotation may lead such a declaration.
+    */
+  def isFirstTrait: Boolean = this.isModifier || (this match {
+    case TokenKind.CommentDoc
+         | TokenKind.Annotation
+         | TokenKind.KeywordDef
+         | TokenKind.KeywordLaw
+         | TokenKind.KeywordType => true
+    case _ => false
+  })
+
+  /**
     * Checks if kind is one of the [[TokenKind]]s that can validly appear as the first token of any expression.
     */
   def isFirstExpr: Boolean = this match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -787,7 +787,7 @@ object Parser2 {
             case at =>
               val loc = currentSourceLocation()
               // Skip ahead until we hit another declaration or any CurlyR.
-              while (!nth(0).isFirstDecl && !eat(TokenKind.CurlyR) && !eof()) {
+              while (!nth(0).isFirstTrait && !eat(TokenKind.CurlyR) && !eof()) {
                 advance()
               }
               val error = ParseError(s"Expected ${TokenKind.KeywordType.display}, ${TokenKind.KeywordDef.display} or ${TokenKind.KeywordLaw.display} before ${at.display}", SyntacticContext.Decl.Trait, loc)
@@ -827,7 +827,7 @@ object Parser2 {
             case at =>
               val loc = currentSourceLocation()
               // Skip ahead until we hit another declaration or any CurlyR.
-              while (!nth(0).isFirstDecl && !eat(TokenKind.CurlyR) && !eof()) {
+              while (!nth(0).isFirstInstance && !eat(TokenKind.CurlyR) && !eof()) {
                 advance()
               }
               val error = ParseError(s"Expected ${TokenKind.KeywordType.display} or ${TokenKind.KeywordDef.display} before ${at.display}", SyntacticContext.Decl.Instance, loc)
@@ -1484,7 +1484,8 @@ object Parser2 {
             var level = 1
             var curlyLevel = 0
             var lookAhead = 0
-            while (level > 0 && !eof()) {
+            val tokensLeft = s.tokens.length - s.position
+            while (level > 0 && lookAhead < tokensLeft && !eof()) {
               lookAhead += 1
               nth(lookAhead) match {
                 case TokenKind.ParenL => level += 1
@@ -1722,6 +1723,12 @@ object Parser2 {
             case TokenKind.ParenL => parenNestingLevel += 1; lookAhead += 1
             case TokenKind.ParenR => parenNestingLevel -= 1; lookAhead += 1
             case TokenKind.Eof => return closeWithError(mark, ParseError("Malformed match expression.", SyntacticContext.Expr.OtherExpr, currentSourceLocation()))
+            case t if t.isFirstDecl =>
+              // Advance past the erroneous region to the next stable token (the start of the declaration)
+                for (_ <- 0 until lookAhead) {
+                  advance()
+                }
+              return closeWithError(mark, ParseError(s"Expected match expression before ${t.display}", SyntacticContext.Expr.OtherExpr, previousSourceLocation()))
             case _ => lookAhead += 1
           }
         }
@@ -3124,14 +3131,19 @@ object Parser2 {
     def body()(implicit s: State): Mark.Closed = {
       val mark = open()
       nth(0) match {
-        case TokenKind.KeywordIf => guard()
-        case TokenKind.KeywordLet => functional()
-        case TokenKind.KeywordNot | TokenKind.KeywordFix | TokenKind.NameUpperCase => atom()
+        case TokenKind.KeywordIf =>
+          guard()
+          close(mark, TreeKind.Predicate.Body)
+        case TokenKind.KeywordLet =>
+          functional()
+          close(mark, TreeKind.Predicate.Body)
+        case TokenKind.KeywordNot | TokenKind.KeywordFix | TokenKind.NameUpperCase =>
+          atom()
+          close(mark, TreeKind.Predicate.Body)
         case at =>
-          val error = ParseError(s"Expected ${TokenKind.KeywordIf.display}, ${TokenKind.KeywordLet.display}, ${TokenKind.KeywordNot.display}, ${TokenKind.KeywordFix} or ${TokenKind.NameUpperCase.display} before ${at.display}", SyntacticContext.Unknown, currentSourceLocation())
-          advanceWithError(error)
+          val error = ParseError(s"Expected ${TokenKind.KeywordIf.display}, ${TokenKind.KeywordLet.display}, ${TokenKind.KeywordNot.display}, ${TokenKind.KeywordFix.display} or ${TokenKind.NameUpperCase.display} before ${at.display}", SyntacticContext.Expr.Constraint, currentSourceLocation())
+          closeWithError(mark, error)
       }
-      close(mark, TreeKind.Predicate.Body)
     }
 
     private def guard()(implicit s: State): Mark.Closed = {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1206,8 +1206,13 @@ object Weeder2 {
     private def visitMatchExpr(tree: Tree)(implicit s: State): Validation[Expr, CompilationMessage] = {
       expect(tree, TreeKind.Expr.Match)
       val rules = pickAll(TreeKind.Expr.MatchRuleFragment, tree)
-      mapN(pickExpr(tree), traverse(rules)(visitMatchRule)) {
-        (expr, rules) => Expr.Match(expr, rules, tree.loc)
+      flatMapN(pickExpr(tree), traverse(rules)(visitMatchRule)) {
+        // Case: no valid match rule found in match expr
+        case (expr, Nil) =>
+          val error = ParseError("Expected at least one match-case", SyntacticContext.Expr.OtherExpr, expr.loc)
+          // Fall back on Expr.Error. Parser has reported an error here.
+          Validation.success(Expr.Error(error))
+        case (expr, rules) => Validation.success(Expr.Match(expr, rules, tree.loc))
       }
     }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -522,6 +522,20 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
+  test("BadConstraintSet.01") {
+    val input =
+      """
+        |def baz(): #{ Path(Int32, Int32) } = #{
+        |    Edge(1, 2).
+        |    Path(x, y) :-
+        |}
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
   test("Regression.#7646") {
     val input =
       """

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -453,6 +453,17 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
+  test("BadMatch.02") {
+    val input =
+      """
+        |def map(t: Int32): Int32 = match t
+        |def main(): Int32 = 123
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
   test("BadType.01") {
     val input =
       """

--- a/main/test/flix/fuzzers/FuzzDeleteLines.scala
+++ b/main/test/flix/fuzzers/FuzzDeleteLines.scala
@@ -46,6 +46,12 @@ class FuzzDeleteLines extends AnyFunSuite with TestUtils {
     compileAllLinesExceptOne(filepath.getFileName.toString, lines)
   }
 
+  test("ford-fulkerson") {
+    val filepath = Paths.get("examples/larger-examples/datalog/ford-fulkerson.flix")
+    val lines = Files.lines(filepath)
+    compileAllLinesExceptOne(filepath.getFileName.toString, lines)
+  }
+
   /**
     * We compile N variants of the given program where we omit a single line.
     * For example, in a file with 100 lines and N = 10 we make variants without line 1, 10, 20, and so on.

--- a/main/test/flix/fuzzers/FuzzDuplicateLines.scala
+++ b/main/test/flix/fuzzers/FuzzDuplicateLines.scala
@@ -47,6 +47,12 @@ class FuzzDuplicateLines extends AnyFunSuite with TestUtils {
     compileWithDuplicateLine(filepath.getFileName.toString, lines)
   }
 
+  test("ford-fulkerson") {
+    val filepath = Paths.get("examples/larger-examples/datalog/ford-fulkerson.flix")
+    val lines = Files.lines(filepath)
+    compileWithDuplicateLine(filepath.getFileName.toString, lines)
+  }
+
   /**
     * Compile N variants of the given program with a single line duplicated.
     * The program may not be valid: We just care that it does not crash the compiler.

--- a/main/test/flix/fuzzers/FuzzPrefixes.scala
+++ b/main/test/flix/fuzzers/FuzzPrefixes.scala
@@ -46,6 +46,12 @@ class FuzzPrefixes extends AnyFunSuite with TestUtils {
     compilePrefixes(filepath.getFileName.toString, input)
   }
 
+  test("ford-fulkerson") {
+    val filepath = Paths.get("examples/larger-examples/datalog/ford-fulkerson.flix")
+    val input = Files.readString(filepath)
+    compilePrefixes(filepath.getFileName.toString, input)
+  }
+
   /**
     * We break the given string `input` down into N prefixes and compile each of them.
     * For example, if N is 100 and the input has length 300 then we create prefixes of length 3, 6, 9, ...

--- a/main/test/flix/fuzzers/FuzzSwapLines.scala
+++ b/main/test/flix/fuzzers/FuzzSwapLines.scala
@@ -50,6 +50,12 @@ class FuzzSwapLines extends AnyFunSuite with TestUtils {
     compileWithSwappedLines(filepath.getFileName.toString, lines)
   }
 
+  test("ford-fulkerson") {
+    val filepath = Paths.get("examples/larger-examples/datalog/ford-fulkerson.flix")
+    val lines = Files.lines(filepath)
+    compileWithSwappedLines(filepath.getFileName.toString, lines)
+  }
+
   /**
     * We compile variants of the given program where we swap [[numSwapLines]] lines.
     * For example, in a file with 100 lines and numSwapLines = 10, we try all swaps with 10 of the lines.


### PR DESCRIPTION
Closes #7640 

Fixes a crash on malformed datalog program and adds the program to parser test suite. 
Also adds a datalog example (`ford-fulkerson.flix`) to the fuzzer suite and fixes 3 more crashes found by doing that.