### PR TITLE
fix: handle malformed for-fragments

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1869,21 +1869,22 @@ object Parser2 {
 
     private def forFragments()(implicit s: State): Unit = {
       assert(at(TokenKind.ParenL))
-      expect(TokenKind.ParenL, SyntacticContext.Expr.OtherExpr)
-      while (!at(TokenKind.ParenR) && !eof()) {
-        if (at(TokenKind.KeywordIf)) {
-          guardFragment()
-        } else {
-          generatorOrLetFragment()
-        }
-        if (!at(TokenKind.ParenR)) {
-          expect(TokenKind.Semi, SyntacticContext.Expr.OtherExpr)
-        }
-      }
-      expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
+      oneOrMore(
+        displayName = "for-fragment",
+        checkForItem = t =>t.isFirstPattern || t == TokenKind.KeywordIf,
+        getItem = () =>
+          if (at(TokenKind.KeywordIf)) {
+            guardFragment()
+          } else {
+            generatorOrLetFragment()
+          },
+        breakWhen = t => t == TokenKind.KeywordYield || t.isRecoverExpr,
+        separator = TokenKind.Semi,
+        context = SyntacticContext.Expr.OtherExpr
+      )
     }
 
-    private def guardFragment()(implicit s: State): Unit = {
+    private def guardFragment()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordIf))
       val mark = open()
       expect(TokenKind.KeywordIf, SyntacticContext.Expr.OtherExpr)
@@ -1891,7 +1892,7 @@ object Parser2 {
       close(mark, TreeKind.Expr.ForFragmentGuard)
     }
 
-    private def generatorOrLetFragment()(implicit s: State): Unit = {
+    private def generatorOrLetFragment()(implicit s: State): Mark.Closed = {
       val mark = open()
       Pattern.pattern()
       val isGenerator = eat(TokenKind.ArrowThinL)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -391,6 +391,18 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
+  test("BadForFragments.03") {
+    val input =
+      """
+        |def foo(): Int32 =
+        |    forA ( x <- bar(), y <- baz() yield ???
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
   test("BadIfThenElse.01") {
     val input =
       """

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -367,6 +367,30 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
+  test("BadForFragments.01") {
+    val input =
+      """
+        |def foo(): Int32 =
+        |    forA ( x <- bar(); y <- baz() yield ???
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
+  test("BadForFragments.02") {
+    val input =
+      """
+        |def foo(): Int32 =
+        |    forA ( x <- bar(); y <- baz(); yield ???
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
   test("BadIfThenElse.01") {
     val input =
       """


### PR DESCRIPTION
Closes #7679
Closes #7681 

Test cases added to cover both issues

With the example:
```scala
def foo(): Int32 =
    forA ( x <- bar(); y <- baz() yield ???
def main(): Unit = ()
```
We now get errors rather than a crash.
```
-- Parse Error -------------------------------------------------- main/foo.flix

>> Parse Error: Expected ';' before 'yield'

2 |     forA ( x <- bar(); y <- baz() yield ???
                                    ^
                                    Here
Syntactic Context: OtherExpr.

-- Parse Error -------------------------------------------------- main/foo.flix

>> Parse Error: Expected ')' before 'yield'

2 |     forA ( x <- bar(); y <- baz() yield ???
                                    ^
                                    Here
Syntactic Context: OtherExpr.
```