### PR TITLE
feat: demote `Pure` from being a keyword

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -547,8 +547,8 @@ class Flix {
     val result = for {
       afterReader <- Reader.run(getInputs)
       afterLexer <- Lexer.run(afterReader, cachedLexerTokens, changeSet)
-      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
-      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
+//      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
+//      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
 
       // Plan for migrating to new parser + weeder:
       // Stage 1 [ACTIVE]
@@ -582,9 +582,9 @@ class Flix {
       // Update caches for incremental compilation.
       if (options.incremental) {
         this.cachedLexerTokens = afterLexer
-        this.cachedParserAst = afterParser
+//        this.cachedParserAst = afterParser
         this.cachedParserCst = afterParser2
-        this.cachedWeederAst = afterWeeder
+//        this.cachedWeederAst = afterWeeder
         this.cachedWeederAst2 = afterWeeder2
         this.cachedDesugarAst = afterDesugar
         this.cachedKinderAst = afterKinder

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -547,8 +547,8 @@ class Flix {
     val result = for {
       afterReader <- Reader.run(getInputs)
       afterLexer <- Lexer.run(afterReader, cachedLexerTokens, changeSet)
-//      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
-//      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
+      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
+      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
 
       // Plan for migrating to new parser + weeder:
       // Stage 1 [ACTIVE]
@@ -582,9 +582,9 @@ class Flix {
       // Update caches for incremental compilation.
       if (options.incremental) {
         this.cachedLexerTokens = afterLexer
-//        this.cachedParserAst = afterParser
+        this.cachedParserAst = afterParser
         this.cachedParserCst = afterParser2
-//        this.cachedWeederAst = afterWeeder
+        this.cachedWeederAst = afterWeeder
         this.cachedWeederAst2 = afterWeeder2
         this.cachedDesugarAst = afterDesugar
         this.cachedKinderAst = afterKinder

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -112,7 +112,6 @@ sealed trait TokenKind {
       case TokenKind.KeywordOverride => "'override'"
       case TokenKind.KeywordPar => "'par'"
       case TokenKind.KeywordPub => "'pub'"
-      case TokenKind.KeywordPure => "'Pure'"
       case TokenKind.KeywordProject => "'project'"
       case TokenKind.KeywordQuery => "'query'"
       case TokenKind.KeywordRef => "'ref'"
@@ -358,7 +357,6 @@ sealed trait TokenKind {
          | TokenKind.Underscore
          | TokenKind.NameLowerCase
          | TokenKind.KeywordUniv
-         | TokenKind.KeywordPure
          | TokenKind.KeywordFalse
          | TokenKind.KeywordTrue
          | TokenKind.ParenL
@@ -370,6 +368,7 @@ sealed trait TokenKind {
          | TokenKind.KeywordNot
          | TokenKind.Tilde
          | TokenKind.KeywordRvnot
+         | TokenKind.Slash
          | TokenKind.KeywordStaticUppercase => true
     case _ => false
   }
@@ -671,8 +670,6 @@ object TokenKind {
   case object KeywordPar extends TokenKind
 
   case object KeywordPub extends TokenKind
-
-  case object KeywordPure extends TokenKind
 
   case object KeywordProject extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -368,7 +368,7 @@ sealed trait TokenKind {
          | TokenKind.KeywordNot
          | TokenKind.Tilde
          | TokenKind.KeywordRvnot
-         | TokenKind.Slash
+         | TokenKind.Backslash
          | TokenKind.KeywordStaticUppercase => true
     case _ => false
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -403,7 +403,6 @@ object Lexer {
       case _ if isKeyword("override") => TokenKind.KeywordOverride
       case _ if isKeyword("par") => TokenKind.KeywordPar
       case _ if isKeyword("pub") => TokenKind.KeywordPub
-      case _ if isKeyword("Pure") => TokenKind.KeywordPure
       case _ if isKeyword("project") => TokenKind.KeywordProject
       case _ if isKeyword("query") => TokenKind.KeywordQuery
       case _ if isKeyword("ref") => TokenKind.KeywordRef

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1487,7 +1487,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     def Primary: Rule1[ParsedAst.Type] = rule {
       // NB: Record must come before EffectSet as they overlap
       // NB: CaseComplement must come before Complement as they overlap
-      Arrow | Tuple | Record | RecordRow | Schema | SchemaRow | CaseSet | EffectSet | Not | CaseComplement | Complement |
+      Arrow | Tuple | Record | RecordRow | Schema | SchemaRow | CaseSet | EmptyEffectSet | EffectSet | Not | CaseComplement | Complement |
         Native | True | False | Pure | Univ | Var | Ambiguous
     }
 
@@ -1533,6 +1533,10 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     def SchemaRow: Rule1[ParsedAst.Type] = rule {
       SP ~ atomic("#(") ~ optWS ~ zeroOrMore(RelPredicateWithTypes | LatPredicateWithTypes | PredicateWithAlias).separatedBy(optWS ~ "," ~ optWS) ~ optional(optWS ~ "|" ~ optWS ~ Names.Variable) ~ optWS ~ ")" ~ SP ~> ParsedAst.Type.SchemaRow
+    }
+
+    def EmptyEffectSet: Rule1[ParsedAst.Type] = rule {
+      SP ~ "/" ~ optWS ~ "{" ~ optWS ~ push(Nil) ~ "}" ~ SP ~> ParsedAst.Type.EffectSet
     }
 
     def EffectSet: Rule1[ParsedAst.Type] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1536,7 +1536,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def EmptyEffectSet: Rule1[ParsedAst.Type] = rule {
-      SP ~ "/" ~ optWS ~ "{" ~ optWS ~ push(Nil) ~ "}" ~ SP ~> ParsedAst.Type.EffectSet
+      SP ~ "\\" ~ optWS ~ "{" ~ optWS ~ push(Nil) ~ "}" ~ SP ~> ParsedAst.Type.EffectSet
     }
 
     def EffectSet: Rule1[ParsedAst.Type] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -582,8 +582,7 @@ object Parser2 {
   private val NAME_KIND: Set[TokenKind] = Set(TokenKind.NameUpperCase)
   private val NAME_EFFECT: Set[TokenKind] = Set(TokenKind.NameUpperCase)
   private val NAME_MODULE: Set[TokenKind] = Set(TokenKind.NameUpperCase)
-  // TODO: Pure is used in enums as tags in Prelude.flix. Should we allow this?
-  private val NAME_TAG: Set[TokenKind] = Set(TokenKind.NameUpperCase, TokenKind.KeywordPure)
+  private val NAME_TAG: Set[TokenKind] = Set(TokenKind.NameUpperCase)
   private val NAME_PREDICATE: Set[TokenKind] = Set(TokenKind.NameUpperCase)
 
   /**
@@ -2841,7 +2840,6 @@ object Parser2 {
              | TokenKind.Underscore => name(NAME_VARIABLE, context = SyntacticContext.Type.OtherType)
         case TokenKind.NameLowerCase => variableType()
         case TokenKind.KeywordUniv
-             | TokenKind.KeywordPure
              | TokenKind.KeywordFalse
              | TokenKind.KeywordTrue => constantType()
         case TokenKind.ParenL => tupleOrRecordRowType()
@@ -2850,6 +2848,7 @@ object Parser2 {
         case TokenKind.HashParenL => schemaRowType()
         case TokenKind.NameJava => nativeType()
         case TokenKind.AngleL => caseSetType()
+        case TokenKind.Slash => emptyEffectSet()
         case TokenKind.KeywordNot
              | TokenKind.Tilde
              | TokenKind.KeywordRvnot => unaryType()
@@ -2872,7 +2871,7 @@ object Parser2 {
       close(mark, TreeKind.Type.Variable)
     }
 
-    private val TYPE_CONSTANT: Set[TokenKind] = Set(TokenKind.KeywordUniv, TokenKind.KeywordPure, TokenKind.KeywordFalse, TokenKind.KeywordTrue)
+    private val TYPE_CONSTANT: Set[TokenKind] = Set(TokenKind.KeywordUniv, TokenKind.KeywordFalse, TokenKind.KeywordTrue)
 
     private def constantType()(implicit s: State): Mark.Closed = {
       val mark = open()
@@ -3060,6 +3059,15 @@ object Parser2 {
         context = SyntacticContext.Type.OtherType
       )
       close(mark, TreeKind.Type.CaseSet)
+    }
+
+    private def emptyEffectSet()(implicit s: State): Mark.Closed = {
+      assert(at(TokenKind.Slash))
+      val mark = open()
+      expect(TokenKind.Slash, SyntacticContext.Type.Eff)
+       expect(TokenKind.CurlyL, SyntacticContext.Type.Eff)
+      expect(TokenKind.CurlyR, SyntacticContext.Type.Eff)
+      close(mark, TreeKind.Type.EffectSet)
     }
 
     private val FIRST_TYPE_UNARY: Set[TokenKind] = Set(TokenKind.Tilde, TokenKind.KeywordNot, TokenKind.KeywordRvnot)

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2848,7 +2848,7 @@ object Parser2 {
         case TokenKind.HashParenL => schemaRowType()
         case TokenKind.NameJava => nativeType()
         case TokenKind.AngleL => caseSetType()
-        case TokenKind.Slash => emptyEffectSet()
+        case TokenKind.Backslash => emptyEffectSet()
         case TokenKind.KeywordNot
              | TokenKind.Tilde
              | TokenKind.KeywordRvnot => unaryType()
@@ -3062,9 +3062,9 @@ object Parser2 {
     }
 
     private def emptyEffectSet()(implicit s: State): Mark.Closed = {
-      assert(at(TokenKind.Slash))
+      assert(at(TokenKind.Backslash))
       val mark = open()
-      expect(TokenKind.Slash, SyntacticContext.Type.Eff)
+      expect(TokenKind.Backslash, SyntacticContext.Type.Eff)
        expect(TokenKind.CurlyL, SyntacticContext.Type.Eff)
       expect(TokenKind.CurlyR, SyntacticContext.Type.Eff)
       close(mark, TreeKind.Type.EffectSet)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -2524,7 +2524,6 @@ object Weeder2 {
       expect(tree, TreeKind.Type.Constant)
       text(tree).head match {
         case "false" => Validation.success(Type.False(tree.loc))
-        case "Pure" => Validation.success(Type.Pure(tree.loc))
         case "true" => Validation.success(Type.True(tree.loc))
         // TODO EFF-MIGRATION create dedicated Impure type
         case "Univ" => Validation.success(Type.Complement(Type.Pure(tree.loc), tree.loc))

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -4,6 +4,11 @@
 pub type alias Static = IO
 
 ///
+/// Pure denotes the empty effect set.
+///
+pub type alias Pure = / { }
+
+///
 /// An enum that holds type information where a witness is not available.
 ///
 pub enum Proxy[_] {

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -6,7 +6,7 @@ pub type alias Static = IO
 ///
 /// Pure denotes the empty effect set.
 ///
-pub type alias Pure = / { }
+pub type alias Pure = \ { }
 
 ///
 /// An enum that holds type information where a witness is not available.

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -273,7 +273,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   }
 
   test("IllegalUninhabitedType.08") {
-    val input = "def f(): Int32 = unchecked_cast(1 as Pure)"
+    val input = "def f(): Int32 = unchecked_cast(1 as \\ {})"
     val result = compile(input, DefaultOptions)
     expectError[KindError](result)
   }
@@ -291,7 +291,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   }
 
   test("IllegalUninhabitedType.10") {
-    val input = "def f(): Int32 = (1: Pure)"
+    val input = "def f(): Int32 = (1: \\ { })"
     val result = compile(input, DefaultOptions)
     expectError[KindError](result)
   }
@@ -418,7 +418,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Expression.Ascribe.01") {
     val input =
       """
-        |def f(): Int32 = (1: Pure)
+        |def f(): Int32 = (1: \ { })
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -494,7 +494,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Expression.Cast.01") {
     val input =
       """
-        |def f(): Int32 = unchecked_cast(1 as Pure)
+        |def f(): Int32 = unchecked_cast(1 as \ {})
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -598,7 +598,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Parameter.01") {
     val input =
       """
-        |def f(x: Pure): Int32 = ???
+        |def f(x: \ {}): Int32 = ???
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -618,7 +618,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Return.01") {
     val input =
       """
-        |def f(): Pure = ???
+        |def f(): \ { } = ???
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -697,7 +697,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     val input =
       """
         |enum E {
-        |  case C(Pure)
+        |  case C(\ { })
         |}
         |""".stripMargin
     val result = compile(input, DefaultOptions)
@@ -820,7 +820,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.TypeAlias.Type.01") {
     val input =
       """
-        |type alias T = Pure -> Int32
+        |type alias T = \ { } -> Int32
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -1038,7 +1038,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
         |}
         |
         |instance C[String] {
-        |    type T[Pure] = String
+        |    type T[\ { }] = String
         |}
         |""".stripMargin
     val result = compile(input, DefaultOptions)
@@ -1059,7 +1059,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
         |    }
         |
         |    instance Add[Set[t]] with Order[t] {
-        |        type Rhs = {Pure}
+        |        type Rhs = \ { }
         |        pub def add(lhs: Set[t], rhs: t): Set[t] = ???
         |
         |    }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -1023,7 +1023,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
         |}
         |
         |instance C[String] {
-        |    type T = Pure
+        |    type T = \ { }
         |}
         |""".stripMargin
     val result = compile(input, DefaultOptions)

--- a/main/test/flix/Test.Dec.Trait.flix
+++ b/main/test/flix/Test.Dec.Trait.flix
@@ -90,7 +90,9 @@ mod Test.Dec.Trait {
             pub def isPure(f: a -> b \ ef): Bool
         }
 
-        instance Eff[Pure] {
+        // Note: 'Pure' is a type alias from Prelude, but we can't use type aliases in instances.
+        // So use the Pure effect literal instead.
+        instance Eff[/ { }] {
             pub def isPure(_f: a -> b): Bool = true
         }
     }

--- a/main/test/flix/Test.Dec.Trait.flix
+++ b/main/test/flix/Test.Dec.Trait.flix
@@ -92,7 +92,7 @@ mod Test.Dec.Trait {
 
         // Note: 'Pure' is a type alias from Prelude, but we can't use type aliases in instances.
         // So use the Pure effect literal instead.
-        instance Eff[/ { }] {
+        instance Eff[\ { }] {
             pub def isPure(_f: a -> b): Bool = true
         }
     }


### PR DESCRIPTION
Closes #7638

This PR demotes `Pure` from being a keyword to just a regular `UppercaseName`.
Instead `Pure` is now declared as a type-alias in `Prelude.flix` like so:
```scala
///
/// Pure denotes the empty effect set.
///
pub type alias Pure = \ { }
```
Notice we are using `\ { }` rather than just `{}`. This notion of an _empty effect set literal_ is also implemented in this PR. It is needed to disambiguate between the empty record type `{}` and the empty effect set `{}`. Otherwise the type-alias would be read as an empty record type.

## Considerations of the empty effect set literal
- `\ { }` effectively replaces `Pure`. This means that we don't need special handling when `Pure` us mentioned in a type, simplifying error messages and the parser/weeder implementation.
-`\ { }` leads with a `\` which is syntactically consistent with other uses of effects like `\ IO`.
- Refactoring existing code that uses `Pure` is *rarely* needed because of the type-alias in `Prelude.flix`. The exception is instances, because they may not refer to type-aliases. In these cases `Pure` can be replaced with `\ { }` directly. 
- `\ { }` disambiguates effect sets from record types completely. The empty record type is now `{}` free of context.