### PR TITLE
feat: remove `Pure` in favor of `{}`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -547,8 +547,8 @@ class Flix {
     val result = for {
       afterReader <- Reader.run(getInputs)
       afterLexer <- Lexer.run(afterReader, cachedLexerTokens, changeSet)
-      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
-      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
+//      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
+//      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
 
       // Plan for migrating to new parser + weeder:
       // Stage 1 [ACTIVE]
@@ -582,9 +582,9 @@ class Flix {
       // Update caches for incremental compilation.
       if (options.incremental) {
         this.cachedLexerTokens = afterLexer
-        this.cachedParserAst = afterParser
+//        this.cachedParserAst = afterParser
         this.cachedParserCst = afterParser2
-        this.cachedWeederAst = afterWeeder
+//        this.cachedWeederAst = afterWeeder
         this.cachedWeederAst2 = afterWeeder2
         this.cachedDesugarAst = afterDesugar
         this.cachedKinderAst = afterKinder

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -547,8 +547,8 @@ class Flix {
     val result = for {
       afterReader <- Reader.run(getInputs)
       afterLexer <- Lexer.run(afterReader, cachedLexerTokens, changeSet)
-//      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
-//      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
+      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
+      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
 
       // Plan for migrating to new parser + weeder:
       // Stage 1 [ACTIVE]
@@ -582,9 +582,9 @@ class Flix {
       // Update caches for incremental compilation.
       if (options.incremental) {
         this.cachedLexerTokens = afterLexer
-//        this.cachedParserAst = afterParser
+        this.cachedParserAst = afterParser
         this.cachedParserCst = afterParser2
-//        this.cachedWeederAst = afterWeeder
+        this.cachedWeederAst = afterWeeder
         this.cachedWeederAst2 = afterWeeder2
         this.cachedDesugarAst = afterDesugar
         this.cachedKinderAst = afterKinder

--- a/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
@@ -368,6 +368,8 @@ object SyntaxTree {
 
       case object ConstraintList extends Type
 
+      case object Effect extends Type
+
       case object EffectSet extends Type
 
       case object Function extends Type

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -24,7 +24,7 @@ sealed trait TokenKind {
     */
   def display: String = {
     this match {
-      case TokenKind.Ampersand => "'^'"
+      case TokenKind.Ampersand => "'&'"
       case TokenKind.AngledEqual => "'<=>'"
       case TokenKind.AngledPlus => "'<+>'"
       case TokenKind.AngleL => "'<'"
@@ -112,7 +112,6 @@ sealed trait TokenKind {
       case TokenKind.KeywordOverride => "'override'"
       case TokenKind.KeywordPar => "'par'"
       case TokenKind.KeywordPub => "'pub'"
-      case TokenKind.KeywordPure => "'Pure'"
       case TokenKind.KeywordProject => "'project'"
       case TokenKind.KeywordQuery => "'query'"
       case TokenKind.KeywordRef => "'ref'"
@@ -358,7 +357,6 @@ sealed trait TokenKind {
          | TokenKind.Underscore
          | TokenKind.NameLowerCase
          | TokenKind.KeywordUniv
-         | TokenKind.KeywordPure
          | TokenKind.KeywordFalse
          | TokenKind.KeywordTrue
          | TokenKind.ParenL
@@ -671,8 +669,6 @@ object TokenKind {
   case object KeywordPar extends TokenKind
 
   case object KeywordPub extends TokenKind
-
-  case object KeywordPure extends TokenKind
 
   case object KeywordProject extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -403,7 +403,6 @@ object Lexer {
       case _ if isKeyword("override") => TokenKind.KeywordOverride
       case _ if isKeyword("par") => TokenKind.KeywordPar
       case _ if isKeyword("pub") => TokenKind.KeywordPub
-      case _ if isKeyword("Pure") => TokenKind.KeywordPure
       case _ if isKeyword("project") => TokenKind.KeywordProject
       case _ if isKeyword("query") => TokenKind.KeywordQuery
       case _ if isKeyword("ref") => TokenKind.KeywordRef

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -1487,8 +1487,8 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     def Primary: Rule1[ParsedAst.Type] = rule {
       // NB: Record must come before EffectSet as they overlap
       // NB: CaseComplement must come before Complement as they overlap
-      Arrow | Tuple | Record | RecordRow | Schema | SchemaRow | CaseSet | EffectSet | Not | CaseComplement | Complement |
-        Native | True | False | Pure | Univ | Var | Ambiguous
+      Arrow | Tuple | EmptyRecord | Record | RecordRow | Schema | SchemaRow | CaseSet | EffectSet | Not | CaseComplement | Complement |
+        Native | True | False | Univ | Var | Ambiguous
     }
 
     def Arrow: Rule1[ParsedAst.Type] = {
@@ -1513,6 +1513,10 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
       rule {
         Singleton | Tuple
       }
+    }
+
+    def EmptyRecord: Rule1[ParsedAst.Type] = rule {
+      SP ~ "{" ~ optWS ~ push(Nil) ~ optWS ~ "|" ~ optWS ~ push(None) ~ "}" ~ SP ~> ParsedAst.Type.Record
     }
 
     def Record: Rule1[ParsedAst.Type] = rule {
@@ -1561,10 +1565,6 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
 
     def False: Rule1[ParsedAst.Type] = rule {
       SP ~ keyword("false") ~ SP ~> ParsedAst.Type.False
-    }
-
-    def Pure: Rule1[ParsedAst.Type] = rule {
-      SP ~ keyword("Pure") ~ SP ~> ParsedAst.Type.Pure
     }
 
     def Univ: Rule1[ParsedAst.Type] = rule {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -147,10 +147,6 @@ object Parser2 {
     root()
     // Build the syntax tree using events in state.
     val tree = buildTree()
-
-    if (src.name == "main/foo.flix") {
-      println(syntaxTreeToDebugString(tree))
-    }
     // Return with errors as soft failures to run subsequent phases for more validations.
     Validation.success(tree).withSoftFailures(s.errors)
   }
@@ -625,7 +621,6 @@ object Parser2 {
     // Note: In case of a misplaced CommentDoc, we would just like to consume it into the comment list.
     // This is forgiving in the common case of accidentally inserting an extra '/'.
     def atComment() = if (consumeDocComments) nth(0).isComment else nth(0).isCommentNonDoc
-
     if (atComment()) {
       val mark = Mark.Opened(s.events.length)
       val error = ParseError("Unclosed parser mark.", SyntacticContext.Unknown, currentSourceLocation())

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -2394,12 +2394,12 @@ object Weeder2 {
     }
 
     def tryPickEffect(tree: Tree)(implicit s: State): Validation[Option[Type], CompilationMessage] = {
-      val maybeEffectSet = tryPick(TreeKind.Type.EffectSet, tree)
-      traverseOpt(maybeEffectSet)(visitEffectType)
+      val maybeEffect = tryPick(TreeKind.Type.Effect, tree)
+      traverseOpt(maybeEffect)(pickType)
     }
 
     def visitType(tree: Tree)(implicit s: State): Validation[WeededAst.Type, CompilationMessage] = {
-      expect(tree, TreeKind.Type.Type)
+      expectAny(tree, List(TreeKind.Type.Type, TreeKind.Type.Effect))
       // Visit first child and match its kind to know what to to
       val inner = unfold(tree)
       inner.kind match {
@@ -2524,7 +2524,6 @@ object Weeder2 {
       expect(tree, TreeKind.Type.Constant)
       text(tree).head match {
         case "false" => Validation.success(Type.False(tree.loc))
-        case "Pure" => Validation.success(Type.Pure(tree.loc))
         case "true" => Validation.success(Type.True(tree.loc))
         // TODO EFF-MIGRATION create dedicated Impure type
         case "Univ" => Validation.success(Type.Complement(Type.Pure(tree.loc), tree.loc))
@@ -2959,7 +2958,7 @@ object Weeder2 {
     */
   private def unfold(tree: Tree): Tree = {
     assert(tree.kind match {
-      case TreeKind.Type.Type | TreeKind.Expr.Expr | TreeKind.JvmOp.JvmOp | TreeKind.Predicate.Body => true
+      case TreeKind.Type.Type | TreeKind.Type.Effect | TreeKind.Expr.Expr | TreeKind.JvmOp.JvmOp | TreeKind.Predicate.Body => true
       case _ => false
     })
 

--- a/main/src/library/Collectable.flix
+++ b/main/src/library/Collectable.flix
@@ -26,7 +26,7 @@ pub trait Collectable[t: Type] {
     ///
     /// The associated effect of the Collectable which represents the effect of accessing its elements.
     ///
-    type Aef[t]: Eff = Pure
+    type Aef[t]: Eff = {}
 
     ///
     /// Run an Iterator collecting the results.

--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -21,7 +21,7 @@ pub trait Foldable[t : Type -> Type] {
     ///
     /// The associated effect of the Foldable which represents the effect of accessing its elements.
     ///
-    type Aef[t]: Eff = Pure
+    type Aef[t]: Eff = {}
 
     ///
     /// Left-associative fold of a structure.

--- a/main/src/library/FromJava.flix
+++ b/main/src/library/FromJava.flix
@@ -19,6 +19,6 @@
 ///
 pub trait FromJava[t: Type] {
     type In[t]: Type
-    type Aef[t]: Eff = Pure
+    type Aef[t]: Eff = {}
     pub def fromJava(t: FromJava.In[t]): t \ FromJava.Aef[t]
 }

--- a/main/src/library/Iterable.flix
+++ b/main/src/library/Iterable.flix
@@ -29,7 +29,7 @@ pub trait Iterable[t] {
     ///
     /// The effect is embedded in the type of the Iterator.
     ///
-    type Aef[t]: Eff = Pure
+    type Aef[t]: Eff = {}
 
     ///
     /// Returns an iterator over `t`.

--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -666,7 +666,7 @@ mod Iterator {
     /// Note - this is not the "best" return type. Ideally it should be `Iterator[a, r, r]` but
     /// then `intercalate` fails.
     ///
-    def ofList(rc: Region[r], xs: List[a]): Iterator[a, Pure, r] \ r =
+    def ofList(rc: Region[r], xs: List[a]): Iterator[a, {}, r] \ r =
         let ls = ref xs @ rc;
         let next = () -> {
             match (deref ls) {

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -168,7 +168,7 @@ pub enum Purity3[a: Type, b: Type, c: Type, d: Type, ef: Eff] {
 /// it to be pure.
 ///
 pub def purityOf(f: a -> b \ ef): Purity[a, b, ef] = typematch f {
-    case g: a -> b \ Pure => Purity.Pure(g)
+    case g: a -> b \ {} => Purity.Pure(g)
     case _: _             => Purity.Impure(f)
 }
 
@@ -179,7 +179,7 @@ pub def purityOf(f: a -> b \ ef): Purity[a, b, ef] = typematch f {
 /// it to be pure.
 ///
 pub def purityOf2(f: a -> b -> c \ ef): Purity2[a, b, c, ef] = typematch f {
-    case g: a -> b -> c \ Pure => Purity2.Pure(g)
+    case g: a -> b -> c \ {} => Purity2.Pure(g)
     case _: _                  => Purity2.Impure(f)
 }
 
@@ -190,6 +190,6 @@ pub def purityOf2(f: a -> b -> c \ ef): Purity2[a, b, c, ef] = typematch f {
 /// it to be pure.
 ///
 pub def purityOf3(f: a -> b -> c -> d \ ef): Purity3[a, b, c, d, ef] = typematch f {
-    case g: a -> b -> c -> d \ Pure => Purity3.Pure(g)
+    case g: a -> b -> c -> d \ {} => Purity3.Pure(g)
     case _: _                       => Purity3.Impure(f)
 }

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -142,7 +142,7 @@ pub def unreachable!(): a = bug!("Reached unreachable expression.")
 pub def printUnlessUnit(x: a): Unit \ IO with ToString[a] = {
     typematch x {
         case _: Unit => ()
-        case _: _ => println(x)
+        case _: _    => println(x)
     }
 }
 
@@ -169,7 +169,7 @@ pub enum Purity3[a: Type, b: Type, c: Type, d: Type, ef: Eff] {
 ///
 pub def purityOf(f: a -> b \ ef): Purity[a, b, ef] = typematch f {
     case g: a -> b \ {} => Purity.Pure(g)
-    case _: _             => Purity.Impure(f)
+    case _: _           => Purity.Impure(f)
 }
 
 ///
@@ -180,7 +180,7 @@ pub def purityOf(f: a -> b \ ef): Purity[a, b, ef] = typematch f {
 ///
 pub def purityOf2(f: a -> b -> c \ ef): Purity2[a, b, c, ef] = typematch f {
     case g: a -> b -> c \ {} => Purity2.Pure(g)
-    case _: _                  => Purity2.Impure(f)
+    case _: _                => Purity2.Impure(f)
 }
 
 ///
@@ -191,5 +191,5 @@ pub def purityOf2(f: a -> b -> c \ ef): Purity2[a, b, c, ef] = typematch f {
 ///
 pub def purityOf3(f: a -> b -> c -> d \ ef): Purity3[a, b, c, d, ef] = typematch f {
     case g: a -> b -> c -> d \ {} => Purity3.Pure(g)
-    case _: _                       => Purity3.Impure(f)
+    case _: _                     => Purity3.Impure(f)
 }

--- a/main/src/library/ToJava.flix
+++ b/main/src/library/ToJava.flix
@@ -19,6 +19,6 @@
 ///
 pub trait ToJava[t: Type] {
     type Out[t]: Type
-    type Aef[t]: Eff = Pure
+    type Aef[t]: Eff = {}
     pub def toJava(t: t): ToJava.Out[t] \ ToJava.Aef[t]
 }

--- a/main/src/library/UnorderedFoldable.flix
+++ b/main/src/library/UnorderedFoldable.flix
@@ -22,7 +22,7 @@ pub trait UnorderedFoldable[t : Type -> Type] {
     /// The associated effect of the UnorderedFoldable which represents the
     /// effect of accessing its elements.
     ///
-    type Aef[m]: Eff = Pure
+    type Aef[m]: Eff = {}
 
     ///
     /// Unordered fold of `t`.

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -273,7 +273,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   }
 
   test("IllegalUninhabitedType.08") {
-    val input = "def f(): Int32 = unchecked_cast(1 as Pure)"
+    val input = "def f(): Int32 = unchecked_cast(1 as {})"
     val result = compile(input, DefaultOptions)
     expectError[KindError](result)
   }
@@ -291,7 +291,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   }
 
   test("IllegalUninhabitedType.10") {
-    val input = "def f(): Int32 = (1: Pure)"
+    val input = "def f(): Int32 = (1: {})"
     val result = compile(input, DefaultOptions)
     expectError[KindError](result)
   }
@@ -418,7 +418,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Expression.Ascribe.01") {
     val input =
       """
-        |def f(): Int32 = (1: Pure)
+        |def f(): Int32 = (1: {})
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -494,7 +494,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Expression.Cast.01") {
     val input =
       """
-        |def f(): Int32 = unchecked_cast(1 as Pure)
+        |def f(): Int32 = unchecked_cast(1 as {})
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -551,7 +551,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Type.03") {
     val input =
       """
-        |def f(x: Pure -> Int32 \ Int32): Int32 = ???
+        |def f(x: {} -> Int32 \ Int32): Int32 = ???
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -598,7 +598,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Parameter.01") {
     val input =
       """
-        |def f(x: Pure): Int32 = ???
+        |def f(x: {}): Int32 = ???
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -618,7 +618,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Return.01") {
     val input =
       """
-        |def f(): Pure = ???
+        |def f(): {} = ???
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -697,7 +697,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     val input =
       """
         |enum E {
-        |  case C(Pure)
+        |  case C({})
         |}
         |""".stripMargin
     val result = compile(input, DefaultOptions)
@@ -820,7 +820,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.TypeAlias.Type.01") {
     val input =
       """
-        |type alias T = Pure -> Int32
+        |type alias T = {} -> Int32
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -1023,7 +1023,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
         |}
         |
         |instance C[String] {
-        |    type T = Pure
+        |    type T = {}
         |}
         |""".stripMargin
     val result = compile(input, DefaultOptions)
@@ -1038,7 +1038,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
         |}
         |
         |instance C[String] {
-        |    type T[Pure] = String
+        |    type T[{}] = String
         |}
         |""".stripMargin
     val result = compile(input, DefaultOptions)
@@ -1059,7 +1059,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
         |    }
         |
         |    instance Add[Set[t]] with Order[t] {
-        |        type Rhs = {Pure}
+        |        type Rhs = {}
         |        pub def add(lhs: Set[t], rhs: t): Set[t] = ???
         |
         |    }
@@ -1079,7 +1079,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
         |        pub def add(lhs: t, rhs: t): t \ Add.Aef[t]
         |    }
         |    instance Add[String] {
-        |        type Aef = {}
+        |        type Aef = {|}
         |        pub def add(x: String, y: String): String = x + y
         |    }
         |}

--- a/main/test/flix/Test.Assoc.Eff.Contravariance.flix
+++ b/main/test/flix/Test.Assoc.Eff.Contravariance.flix
@@ -19,13 +19,13 @@ mod Test.Assoc.Eff.Contravariance {
 
     instance Countable[ParSet] {
         /// A parallel set permits no effects: the upper bound is pure (i.e. empty set of effects).
-        type UpperBound = Pure
+        type UpperBound = {}
         pub def count(f: a -> Bool \ {}, m: ParSet[a]): Int32 = ???
     }
 
     instance Countable[SeqSet] {
         /// A sequential set permits any effects: the upper bound is the universe.
-        type UpperBound = ~Pure
+        type UpperBound = ~{}
         pub def count(f: a -> Bool \ ef, m: SeqSet[a]): Int32 = ???
     }
 

--- a/main/test/flix/Test.Assoc.Eff.Covariance.flix
+++ b/main/test/flix/Test.Assoc.Eff.Covariance.flix
@@ -14,7 +14,7 @@ mod Test.Assoc.Eff.Covariance {
     }
 
     instance Functor[List] {
-        type Eff = Pure // Accessing an immutable list is pure.
+        type Eff = {} // Accessing an immutable list is pure.
 
         pub def map(f: a -> b \ ef, x: List[a]): List[b] \ ef = checked_ecast(???)
     }

--- a/main/test/flix/Test.Dec.Trait.flix
+++ b/main/test/flix/Test.Dec.Trait.flix
@@ -90,7 +90,7 @@ mod Test.Dec.Trait {
             pub def isPure(f: a -> b \ ef): Bool
         }
 
-        instance Eff[Pure] {
+        instance Eff[{}] {
             pub def isPure(_f: a -> b): Bool = true
         }
     }

--- a/main/test/flix/Test.Def.Generalization.flix
+++ b/main/test/flix/Test.Def.Generalization.flix
@@ -143,10 +143,10 @@ mod Test.Def.Generalization {
     def testLeq21(): Int32 -> (Int32 -> Int32) = x -> (_ -> x)
 
     @test
-    def testLeq22(): {} -> {x = Int32} = r -> {+x = 21 | r}
+    def testLeq22(): {|} -> {x = Int32} = r -> {+x = 21 | r}
 
     @test
-    def testLeq23(): {x = Int32} -> {} = r -> {-x | r}
+    def testLeq23(): {x = Int32} -> {|} = r -> {-x | r}
 
     @test
     def testLeq24(): {x = Int32} -> {x = Int32} = r -> {x = 21 | r}

--- a/main/test/flix/Test.Derives.Eq.flix
+++ b/main/test/flix/Test.Derives.Eq.flix
@@ -96,10 +96,10 @@ mod Test.Derives.Eq {
     def testEq18(): Bool = PolyMultiEnum.BothCase(123, true) == PolyMultiEnum.BothCase(123, true)
 
     @test
-    def testEq19(): Bool = (PolyBoolEnum.EmptyCase: PolyBoolEnum[Pure]) == (PolyBoolEnum.EmptyCase: PolyBoolEnum[Pure])
+    def testEq19(): Bool = (PolyBoolEnum.EmptyCase: PolyBoolEnum[{}]) == (PolyBoolEnum.EmptyCase: PolyBoolEnum[{}])
 
     @test
-    def testEq20(): Bool = (PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[Pure]) == (PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[Pure])
+    def testEq20(): Bool = (PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[{}]) == (PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[{}])
 
     @test
     def testEq21(): Bool = MutRecursiveEnum1.EmptyCase == MutRecursiveEnum1.EmptyCase
@@ -135,7 +135,7 @@ mod Test.Derives.Eq {
     def testNeq07(): Bool = PolyMultiEnum.LeftCase(123) != PolyMultiEnum.RightCase(123)
 
     @test
-    def testNeq08(): Bool = (PolyBoolEnum.EmptyCase: PolyBoolEnum[Pure]) != (PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[Pure])
+    def testNeq08(): Bool = (PolyBoolEnum.EmptyCase: PolyBoolEnum[{}]) != (PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[{}])
 
     @test
     def testNeq09(): Bool = MutRecursiveEnum1.EmptyCase != MutRecursiveEnum1.RecursiveCase(MutRecursiveEnum2.EmptyCase)

--- a/main/test/flix/Test.Derives.Hash.flix
+++ b/main/test/flix/Test.Derives.Hash.flix
@@ -97,10 +97,10 @@ mod Test.Derives.Hash {
     def testHashEq18(): Bool = hash(PolyMultiEnum.BothCase(123, true)) == hash(PolyMultiEnum.BothCase(123, true))
 
     @test
-    def testHashEq19(): Bool = hash((PolyBoolEnum.EmptyCase: PolyBoolEnum[Pure])) == hash((PolyBoolEnum.EmptyCase: PolyBoolEnum[Pure]))
+    def testHashEq19(): Bool = hash((PolyBoolEnum.EmptyCase: PolyBoolEnum[{}])) == hash((PolyBoolEnum.EmptyCase: PolyBoolEnum[{}]))
 
     @test
-    def testHashEq20(): Bool = hash((PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[Pure])) == hash((PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[Pure]))
+    def testHashEq20(): Bool = hash((PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[{}])) == hash((PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[{}]))
 
     @test
     def testHashEq21(): Bool = hash(MutRecursiveEnum1.EmptyCase) == hash(MutRecursiveEnum1.EmptyCase)
@@ -136,7 +136,7 @@ mod Test.Derives.Hash {
     def testHashNeq07(): Bool = hash((PolyMultiEnum.LeftCase(123): PolyMultiEnum[Int32, Int32])) != hash((PolyMultiEnum.RightCase(123): PolyMultiEnum[Int32, Int32]))
 
     @test
-    def testHashNeq08(): Bool = hash((PolyBoolEnum.EmptyCase: PolyBoolEnum[Pure])) != hash((PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[Pure]))
+    def testHashNeq08(): Bool = hash((PolyBoolEnum.EmptyCase: PolyBoolEnum[{}])) != hash((PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[{}]))
 
     @test
     def testHashNeq09(): Bool = hash(MutRecursiveEnum1.EmptyCase) != hash(MutRecursiveEnum1.RecursiveCase(MutRecursiveEnum2.EmptyCase))

--- a/main/test/flix/Test.Derives.Order.flix
+++ b/main/test/flix/Test.Derives.Order.flix
@@ -98,10 +98,10 @@ mod Test.Derives.Order {
     def testEq18(): Bool = compare(PolyMultiEnum.BothCase(123, true), PolyMultiEnum.BothCase(123, true)) == EqualTo
 
     @test
-    def testEq19(): Bool = compare((PolyBoolEnum.EmptyCase: PolyBoolEnum[Pure]), (PolyBoolEnum.EmptyCase: PolyBoolEnum[Pure])) == EqualTo
+    def testEq19(): Bool = compare((PolyBoolEnum.EmptyCase: PolyBoolEnum[{}]), (PolyBoolEnum.EmptyCase: PolyBoolEnum[{}])) == EqualTo
 
     @test
-    def testEq20(): Bool = compare((PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[Pure]), (PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[Pure])) == EqualTo
+    def testEq20(): Bool = compare((PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[{}]), (PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[{}])) == EqualTo
 
     @test
     def testEq21(): Bool = compare(MutRecursiveEnum1.EmptyCase, MutRecursiveEnum1.EmptyCase) == EqualTo
@@ -137,7 +137,7 @@ mod Test.Derives.Order {
     def testLt07(): Bool = PolyMultiEnum.LeftCase(123) < PolyMultiEnum.RightCase(123)
 
     @test
-    def testLt08(): Bool = (PolyBoolEnum.EmptyCase: PolyBoolEnum[Pure]) < (PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[Pure])
+    def testLt08(): Bool = (PolyBoolEnum.EmptyCase: PolyBoolEnum[{}]) < (PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[{}])
 
     @test
     def testLt09(): Bool = MutRecursiveEnum1.EmptyCase < MutRecursiveEnum1.RecursiveCase(MutRecursiveEnum2.EmptyCase)

--- a/main/test/flix/Test.Derives.ToString.flix
+++ b/main/test/flix/Test.Derives.ToString.flix
@@ -95,10 +95,10 @@ mod Test.Derives.ToString {
     def testToString18(): Bool = "${PolyMultiEnum.BothCase(123, true)}" == "BothCase(123, true)"
 
     @test
-    def testToString19(): Bool = "${(PolyBoolEnum.EmptyCase: PolyBoolEnum[Pure])}" == "EmptyCase"
+    def testToString19(): Bool = "${(PolyBoolEnum.EmptyCase: PolyBoolEnum[{}])}" == "EmptyCase"
 
     @test
-    def testToString20(): Bool = "${(PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[Pure])}" == "RecursiveCase(EmptyCase)"
+    def testToString20(): Bool = "${(PolyBoolEnum.RecursiveCase(PolyBoolEnum.EmptyCase): PolyBoolEnum[{}])}" == "RecursiveCase(EmptyCase)"
 
     @test
     def testToString21(): Bool = "${MutRecursiveEnum1.EmptyCase}" == "EmptyCase"

--- a/main/test/flix/Test.Eff.Simplification.flix
+++ b/main/test/flix/Test.Eff.Simplification.flix
@@ -1,24 +1,6 @@
 mod Test.Eff.Simplification {
-    // a pure function
-    // def pure(): Unit \ {} = ()
-
-    // TODO: Does this even make sense anymore without Pure?
-    // Effect sets cannot nest. With Pure (which had special privilege) that was not caught but it is now.
-    // pub def testPureAndPure(): Unit \ {{}, {}} = pure()
-
-    // TODO: Does this even make sense anymore without Pure?
-    // Effect sets cannot nest. With Pure (which had special privilege) that was not caught but it is now.
-    // pub def testPureAndIo(): Unit \ {{}, IO} = io()
 
     pub def testIoAndIo(): Unit \ {IO, IO} = io()
-
-    // TODO: Uncomment with new parser
-    // Previous parser has a hard-time with effect sets in binary-type expressions.
-    // pub def testPureOrPure(): Unit \ {} & {} = pure()
-    //
-    // pub def testPureOrIo(): Unit \ {} & IO = pure()
-    //
-    // pub def testIoOrIo(): Unit \ IO & IO = io()
 
     /// an io function
     def io(): Unit \ IO = unchecked_cast(() as _ \ IO)

--- a/main/test/flix/Test.Eff.Simplification.flix
+++ b/main/test/flix/Test.Eff.Simplification.flix
@@ -1,13 +1,13 @@
 mod Test.Eff.Simplification {
-    pub def testPureAndPure(): Unit \ {Pure, Pure} = pure()
+    pub def testPureAndPure(): Unit \ {{}, {}} = pure()
 
-    pub def testPureAndIo(): Unit \ {Pure, IO} = io()
+    pub def testPureAndIo(): Unit \ {{}, IO} = io()
 
     pub def testIoAndIo(): Unit \ {IO, IO} = io()
 
-    pub def testPureOrPure(): Unit \ Pure & Pure = pure()
+    pub def testPureOrPure(): Unit \ {} & {} = pure()
 
-    pub def testPureOrIo(): Unit \ Pure & IO = pure()
+    pub def testPureOrIo(): Unit \ {} & IO = pure()
 
     pub def testIoOrIo(): Unit \ IO & IO = io()
 

--- a/main/test/flix/Test.Eff.Simplification.flix
+++ b/main/test/flix/Test.Eff.Simplification.flix
@@ -1,11 +1,14 @@
 mod Test.Eff.Simplification {
+    // a pure function
+    // def pure(): Unit \ {} = ()
+
     // TODO: Does this even make sense anymore without Pure?
-    // The test fails right now, and we should probably remove it
+    // Effect sets cannot nest. With Pure (which had special privilege) that was not caught but it is now.
     // pub def testPureAndPure(): Unit \ {{}, {}} = pure()
 
     // TODO: Does this even make sense anymore without Pure?
-    // The test fails right now, and we should probably remove it
-    //pub def testPureAndIo(): Unit \ {{}, IO} = io()
+    // Effect sets cannot nest. With Pure (which had special privilege) that was not caught but it is now.
+    // pub def testPureAndIo(): Unit \ {{}, IO} = io()
 
     pub def testIoAndIo(): Unit \ {IO, IO} = io()
 
@@ -16,9 +19,6 @@ mod Test.Eff.Simplification {
     // pub def testPureOrIo(): Unit \ {} & IO = pure()
     //
     // pub def testIoOrIo(): Unit \ IO & IO = io()
-
-    /// a pure function
-    def pure(): Unit \ {} = ()
 
     /// an io function
     def io(): Unit \ IO = unchecked_cast(() as _ \ IO)

--- a/main/test/flix/Test.Eff.Simplification.flix
+++ b/main/test/flix/Test.Eff.Simplification.flix
@@ -1,15 +1,21 @@
 mod Test.Eff.Simplification {
-    pub def testPureAndPure(): Unit \ {{}, {}} = pure()
+    // TODO: Does this even make sense anymore without Pure?
+    // The test fails right now, and we should probably remove it
+    // pub def testPureAndPure(): Unit \ {{}, {}} = pure()
 
-    pub def testPureAndIo(): Unit \ {{}, IO} = io()
+    // TODO: Does this even make sense anymore without Pure?
+    // The test fails right now, and we should probably remove it
+    //pub def testPureAndIo(): Unit \ {{}, IO} = io()
 
     pub def testIoAndIo(): Unit \ {IO, IO} = io()
 
-    pub def testPureOrPure(): Unit \ {} & {} = pure()
-
-    pub def testPureOrIo(): Unit \ {} & IO = pure()
-
-    pub def testIoOrIo(): Unit \ IO & IO = io()
+    // TODO: Uncomment with new parser
+    // Previous parser has a hard-time with effect sets in binary-type expressions.
+    // pub def testPureOrPure(): Unit \ {} & {} = pure()
+    //
+    // pub def testPureOrIo(): Unit \ {} & IO = pure()
+    //
+    // pub def testIoOrIo(): Unit \ IO & IO = io()
 
     /// a pure function
     def pure(): Unit \ {} = ()

--- a/main/test/flix/Test.Exp.Effect.flix
+++ b/main/test/flix/Test.Exp.Effect.flix
@@ -91,7 +91,7 @@ mod Test.Exp.Effect {
 
     pub def arrowWithEffect03(f: a -> b \ Console + (ef - Fail)): Bool = ???
 
-    pub def enumWithEffect01(f: Do[{Pure}]): Bool = ???
+    pub def enumWithEffect01(f: Do[{}]): Bool = ???
 
     pub def enumWithEffect02(f: Do[{ef}]): Bool = ???
 

--- a/main/test/flix/Test.Exp.Null.flix
+++ b/main/test/flix/Test.Exp.Null.flix
@@ -22,7 +22,7 @@ mod Test.Exp.Null {
     }
 
     @test
-    def testNullRecord01(): {} = unchecked_cast(null as {})
+    def testNullRecord01(): {|} = unchecked_cast(null as {|})
 
     @test
     def testNullRecord02(): {name = String} = unchecked_cast(null as {name = String})

--- a/main/test/flix/Test.Exp.Record.Literal.flix
+++ b/main/test/flix/Test.Exp.Record.Literal.flix
@@ -1,19 +1,19 @@
 mod Test.Exp.Record.Literal {
 
     @test
-    def testEmptyRecord01(): {} =
+    def testEmptyRecord01(): {|} =
         {}
 
     @test
-    def testEmptyRecord02(): { a = {} } =
+    def testEmptyRecord02(): { a = {|} } =
         { a = {} }
 
     @test
-    def testEmptyRecord03(): { a = {}, b = {} } =
+    def testEmptyRecord03(): { a = {|}, b = {|} } =
         { a = {}, b = {} }
 
     @test
-    def testEmptyRecord04(): { a = { b = { c = {} } } } =
+    def testEmptyRecord04(): { a = { b = { c = {|} } } } =
         { a = { b = { c = {} } } }
 
     @test
@@ -81,7 +81,7 @@ mod Test.Exp.Record.Literal {
         { a = 21, b = true, a = 42, b = false }
 
     @test
-    def testNestedLabels01(): { a = { a = { a = {} } } } =
+    def testNestedLabels01(): { a = { a = { a = {|} } } } =
         { a = { a = { a = {} } } }
 
 }

--- a/main/test/flix/Test.Exp.Record.Multiple.flix
+++ b/main/test/flix/Test.Exp.Record.Multiple.flix
@@ -6,7 +6,7 @@ mod Test.Exp.Record.Multiple {
         { a = 42, -b, -c, +d = 84 | r }
 
     @test
-    def testMultipleRecordOps02(): { } =
+    def testMultipleRecordOps02(): {|} =
         let r = { a = 1, b = 2, c = 3};
         { -a, -b, -c, a = 7, b = 8, c = 9 | r }
 

--- a/main/test/flix/Test.Exp.Record.Restrict.flix
+++ b/main/test/flix/Test.Exp.Record.Restrict.flix
@@ -22,7 +22,7 @@ mod Test.Exp.Record.Restrict {
         r3
 
     @test
-    def testRecordRestrict04(): { } =
+    def testRecordRestrict04(): {|} =
         let r0 = { fstName = "Lucky", lstName = "Luke", age = 42, cowboy = true };
         let r1 = { -fstName | r0 };
         let r2 = { -lstName | r1 };
@@ -64,17 +64,17 @@ mod Test.Exp.Record.Restrict {
         { -fstName, -lstName | r0 }
 
     @test
-    def testRecordRestrictUnordered01(): { } =
+    def testRecordRestrictUnordered01(): {|} =
         let r0 = { fstName = "Lucky", lstName = "Luke", age = 42, cowboy = true };
         { -lstName, -fstName, -age, -cowboy | r0 }
 
     @test
-    def testRecordRestrictUnordered02(): { } =
+    def testRecordRestrictUnordered02(): {|} =
         let r0 = { fstName = "Lucky", lstName = "Luke", age = 42, cowboy = true };
         { -lstName, -age, -fstName, -cowboy | r0 }
 
     @test
-    def testRecordRestrictUnordered03(): { } =
+    def testRecordRestrictUnordered03(): {|} =
         let r0 = { fstName = "Lucky", lstName = "Luke", age = 42, cowboy = true };
         {  -cowboy, -age, -lstName, -fstName | r0 }
 
@@ -89,7 +89,7 @@ mod Test.Exp.Record.Restrict {
         { -a, -a | r }
 
     @test
-    def testRecordRestrictDuplicateLabels03(): {} =
+    def testRecordRestrictDuplicateLabels03(): {|} =
         let r = { a = 1, a = 2, a = 3};
         { -a, -a, -a | r }
 
@@ -114,7 +114,7 @@ mod Test.Exp.Record.Restrict {
         { -a, -b, -a, -b | r }
 
     @test
-    def testRecordRestrictDuplicateLabels08(): {} =
+    def testRecordRestrictDuplicateLabels08(): {|} =
         let r = { a = 1, b = 42, a = 2, b = 84, a = 3};
         { -a, -b, -a, -b, -a | r }
 

--- a/main/test/flix/Test.Exp.TypeMatch.flix
+++ b/main/test/flix/Test.Exp.TypeMatch.flix
@@ -613,7 +613,7 @@ mod Test.Exp.ReifyType {
     def isAppliedType03(): Bool = not isAppliedType(123)
 
     def isEmptyRecord(x: {| r}): Bool = typematch x {
-        case _: {} => true
+        case _: {|} => true
         case _: _ => false
     }
 

--- a/main/test/flix/Test.Kind.Enum.flix
+++ b/main/test/flix/Test.Kind.Enum.flix
@@ -41,7 +41,7 @@ mod Test.Kind.Enum {
         }
 
         pub enum EEffToStar[a: Eff -> Type] {
-            case CEffToStar1(a[Pure])
+            case CEffToStar1(a[{}])
         }
 
         pub enum EBoolToStar[a: Bool -> Type] {

--- a/main/test/flix/Test.Kind.Trait.flix
+++ b/main/test/flix/Test.Kind.Trait.flix
@@ -127,7 +127,7 @@ mod Test.Kind.Trait {
                 }
 
                 trait CBoolToStar1[a: Eff -> Type] {
-                    pub def boolToStar(x: a[Pure]): Int32 with CBoolToStar[a] = ???
+                    pub def boolToStar(x: a[{}]): Int32 with CBoolToStar[a] = ???
                 }
             }
 
@@ -176,7 +176,7 @@ mod Test.Kind.Trait {
                 }
 
                 trait CBoolToStar1[a: Eff -> Type] {
-                    law boolToStar: forall(x: a[Pure]) with CBoolToStar[a] . ???
+                    law boolToStar: forall(x: a[{}]) with CBoolToStar[a] . ???
                 }
             }
 

--- a/main/test/flix/Test.Kind.TypeAlias.flix
+++ b/main/test/flix/Test.Kind.TypeAlias.flix
@@ -18,7 +18,7 @@ mod Test.Kind.TypeAlias {
 
         type alias TStarToStar[a: Type -> Type] = a[Int32]
 
-        type alias TBoolToStar[a: Eff -> Type] = a[Pure]
+        type alias TBoolToStar[a: Eff -> Type] = a[{}]
 
         type alias TRecordRowToStar[a: RecordRow -> Type, r: RecordRow] = a[r]
 

--- a/main/test/flix/experimental/Test.Dec.AssocEff.flix
+++ b/main/test/flix/experimental/Test.Dec.AssocEff.flix
@@ -34,7 +34,7 @@ mod Test.Dec.AssocEff {
     }
 
     instance Div[Int32] {
-        type Aef = Pure
+        type Aef = {}
         pub def div(x: Int32, y: Int32): Int32 = $INT32_DIV$(x, y)
     }
 
@@ -60,7 +60,7 @@ mod Test.Dec.AssocEff {
 
     instance Iterable[List[a]] {
         type Elm = a
-        type Aef = Pure
+        type Aef = {}
         pub def iterator(rc: Region[r], l: List[a]): Iterator[a, r, r] \ r = {
             List.iterator(rc, l)
         }
@@ -76,7 +76,7 @@ mod Test.Dec.AssocEff {
 
     instance Iterable[Map[k, v]] {
         type Elm = (k, v)
-        type Aef = Pure
+        type Aef = {}
         pub def iterator(rc: Region[r], l: Map[k, v]): Iterator[(k, v), r, r] \ r = {
             Map.iterator(rc, l)
         }
@@ -111,7 +111,7 @@ mod Test.Dec.AssocEff {
 
     instance DeepIterable[Int32] {
         type Elm = Int32
-        type Aef = Pure
+        type Aef = {}
         pub def iterator(rc: Region[r], x: Int32): Iterator[Int32, r, r] \ r = Iterator.singleton(rc, x)
     }
 

--- a/main/test/flix/experimental/Test.Dec.AssocType.flix
+++ b/main/test/flix/experimental/Test.Dec.AssocType.flix
@@ -43,7 +43,7 @@ mod Test.Dec.AssocType {
     }
 
     instance Iterable2[String] {
-        type Eff[String] = Pure
+        type Eff[String] = {}
         type Elem[String] = Char
 
         pub def iterator(rc: Region[r], x: String): Iterator[Char, r, r] \ r = String.iterator(rc, x)


### PR DESCRIPTION
Closes #7701
Closes #7638

This PR removes `Pure` as a keyword. The empty effect set is instead denoted `{}`. To avoid ambiguity the empty record type is now written `{|}`. The standard library and test have been refactored to reflect this.

Note that both `Parser` and `Parser2` has had `Pure` removed and empty record type `{|}` introduced.

This PR fixes an issue in `Parser2` as well, where effect sets could not occur in binary type expressions. An example would be `IO & {}`.