### PR TITLE
fix: Emit error on faulty program

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -740,6 +740,8 @@ object Parser2 {
         case TokenKind.KeywordEnum | TokenKind.KeywordRestrictable => enumerationDecl(mark)
         case TokenKind.KeywordType => typeAliasDecl(mark)
         case TokenKind.KeywordEff => effectDecl(mark)
+        // Last thing was a comment
+        case TokenKind.Eof => close(mark, TreeKind.CommentList)
         case at =>
           val loc = currentSourceLocation()
           // Skip ahead until we hit another declaration.

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -144,6 +144,16 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
+  test("LeadOnCurlyR.01") {
+    val input =
+      """
+        |} def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
   test("BadTrait.01") {
     val input =
       """


### PR DESCRIPTION
Closes #7698 

Adds the example as a test-case. 

The fix was to delete some code that handled the case of a trailing doc-comment
```scala
mod Foo {
  def bar(): Int32 = 123
  /// Like this one
}
def main(): Unit = ()
/// Or this one
```

Turns out, that special handling was no longer needed due to other updates! 