### PR TITLE
fix: capture `main` after bad module

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -429,6 +429,13 @@ sealed trait TokenKind {
   def isRecoverDecl: Boolean = this.isFirstDecl
 
   /**
+    * Checks if kind is a TokenKind that warrants breaking a module parsing loop.
+    * This is used to skip tokens until the start of a declaration is found,
+    * in case no other error-recovery could be applied.
+    */
+  def isRecoverMod: Boolean = this == TokenKind.CurlyR || this.isFirstDecl
+
+  /**
     * Checks if kind is a TokenKind that warrants breaking an expression parsing loop.
     * For instance, if we find an 'trait' keyword in the middle of an expression,
     * we can assume that there is no more expression to parse.

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -756,12 +756,12 @@ object Parser2 {
   }
 
   private object Decl {
-    def declaration()(implicit s: State): Mark.Closed = {
+    def declaration(nestingLevel: Int = 0)(implicit s: State): Mark.Closed = {
       val mark = open(consumeDocComments = false)
       docComment()
       // Handle modules
       if (at(TokenKind.KeywordMod)) {
-        return moduleDecl(mark)
+        return moduleDecl(mark, nestingLevel)
       }
       // Handle declarations
       annotations()
@@ -774,27 +774,41 @@ object Parser2 {
         case TokenKind.KeywordEnum | TokenKind.KeywordRestrictable => enumerationDecl(mark)
         case TokenKind.KeywordType => typeAliasDecl(mark)
         case TokenKind.KeywordEff => effectDecl(mark)
-        // Last thing was a comment
-        case TokenKind.Eof => close(mark, TreeKind.CommentList)
         case at =>
           val loc = currentSourceLocation()
-          // Skip ahead until we hit another declaration.
-          while (!nth(0).isRecoverDecl && !eof()) {
-            advance()
-          }
           val error = ParseError(s"Expected <declaration> before ${at.display}", SyntacticContext.Decl.OtherDecl, loc)
+          if (nestingLevel == 0) {
+            // If we are at top-level (nestingLevel == 0) skip ahead until we hit another declaration.
+            // If we are in a module (nestingLevel > 0) we let the module rule handle recovery.
+            while (!nth(0).isRecoverDecl && !eof()) {
+              advance()
+            }
+          }
           closeWithError(mark, error)
       }
     }
 
-    private def moduleDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
+    private def moduleDecl(mark: Mark.Opened, nestingLevel: Int = 0)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordMod))
       expect(TokenKind.KeywordMod, SyntacticContext.Decl.OtherDecl)
       name(NAME_MODULE, allowQualified = true, context = SyntacticContext.Decl.OtherDecl)
       expect(TokenKind.CurlyL, SyntacticContext.Decl.OtherDecl)
       usesOrImports()
-      while (!at(TokenKind.CurlyR) && !eof()) {
-        declaration()
+      var continue = true
+      while (continue && !eof()) {
+        nth(0) match {
+          case t if t.isFirstDecl => declaration(nestingLevel + 1)
+          case TokenKind.CurlyR => continue = false
+          case at =>
+            val markErr = open()
+            val loc = currentSourceLocation()
+            val error = ParseError(s"Expected <declaration> before ${at.display}", SyntacticContext.Decl.OtherDecl, loc)
+            // Skip ahead until we find another declaration or a '}' signifying the end of the module.
+            while (!nth(0).isRecoverMod) {
+              advance()
+            }
+            closeWithError(markErr, error)
+        }
       }
       expect(TokenKind.CurlyR, SyntacticContext.Decl.OtherDecl)
       close(mark, TreeKind.Decl.Module)

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -774,6 +774,7 @@ object Parser2 {
         case TokenKind.KeywordEnum | TokenKind.KeywordRestrictable => enumerationDecl(mark)
         case TokenKind.KeywordType => typeAliasDecl(mark)
         case TokenKind.KeywordEff => effectDecl(mark)
+        case TokenKind.Eof => close(mark, TreeKind.CommentList) // Last tokens in the file were comments.
         case at =>
           val loc = currentSourceLocation()
           val error = ParseError(s"Expected <declaration> before ${at.display}", SyntacticContext.Decl.OtherDecl, loc)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -154,6 +154,47 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
+  test("DanglingDocComment.01") {
+    val input =
+      """
+        |def main(): Unit = ()
+        |/// This documents nothing
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
+  test("DanglingDocComment.02") {
+    val input =
+      """
+        |mod Foo {
+        |  /// This documents nothing
+        |}
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
+  test("MangledModule.02") {
+    val input =
+      """
+        |mod Bar {
+        |    legumes provide healthy access to proteins
+        |    pub def foo(): Int32 = 123
+        |    /// This is not quite finished
+        |    pub def
+        |}
+        |def main(): Int32 = Bar.foo()
+        |
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
   test("BadTrait.01") {
     val input =
       """


### PR DESCRIPTION
Closes #7708 

Example added as a test case, along with two similar examples.