### PR TITLE
feat: recover in `trait`, `instance` and `eff`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -825,15 +825,16 @@ object Parser2 {
       }
       if (at(TokenKind.CurlyL)) {
         expect(TokenKind.CurlyL, SyntacticContext.Decl.Trait)
-        while (!at(TokenKind.CurlyR) && !eof()) {
-          val mark = open(consumeDocComments = false)
-          docComment()
+        var continue = true
+        while (continue && !eof()) {
+          val docMark = docComment()
           annotations()
           modifiers()
           nth(0) match {
-            case TokenKind.KeywordLaw => lawDecl(mark)
-            case TokenKind.KeywordDef => signatureDecl(mark)
-            case TokenKind.KeywordType => associatedTypeSigDecl(mark)
+            case TokenKind.CurlyR => continue = false
+            case TokenKind.KeywordLaw => lawDecl(openBefore(docMark))
+            case TokenKind.KeywordDef => signatureDecl(openBefore(docMark))
+            case TokenKind.KeywordType => associatedTypeSigDecl(openBefore(docMark))
             case at =>
               val loc = currentSourceLocation()
               // Skip ahead until we hit another declaration or any CurlyR.
@@ -866,14 +867,15 @@ object Parser2 {
       }
       if (at(TokenKind.CurlyL)) {
         expect(TokenKind.CurlyL, SyntacticContext.Decl.Instance)
-        while (!at(TokenKind.CurlyR) && !eof()) {
-          val mark = open(consumeDocComments = false)
-          docComment()
+        var continue = true
+        while (continue && !eof()) {
+          val docMark = docComment()
           annotations()
           modifiers()
           nth(0) match {
-            case TokenKind.KeywordDef => definitionDecl(mark)
-            case TokenKind.KeywordType => associatedTypeDefDecl(mark)
+            case TokenKind.CurlyR => continue = false
+            case TokenKind.KeywordDef => definitionDecl(openBefore(docMark))
+            case TokenKind.KeywordType => associatedTypeDefDecl(openBefore(docMark))
             case at =>
               val loc = currentSourceLocation()
               // Skip ahead until we hit another declaration or any CurlyR.
@@ -1102,13 +1104,14 @@ object Parser2 {
       }
 
       if (eat(TokenKind.CurlyL)) {
-        while (!at(TokenKind.CurlyR) && !eof()) {
-          val mark = open(consumeDocComments = false)
-          docComment()
+        var continue = true
+        while (continue && !eof()) {
+          val docMark = docComment()
           annotations()
           modifiers()
           nth(0) match {
-            case TokenKind.KeywordDef => operationDecl(mark)
+            case TokenKind.CurlyR => continue = false
+            case TokenKind.KeywordDef => operationDecl(openBefore(docMark))
             case at =>
               val loc = currentSourceLocation()
               // Skip ahead until we hit another declaration or any CurlyR.

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -178,6 +178,45 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
+  test("DanglingDocComment.03") {
+    val input =
+      """
+        |trait Foo[t] {
+        |  /// This documents nothing
+        |}
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
+  test("DanglingDocComment.04") {
+    val input =
+      """
+        |instance Foo[Int32] {
+        |  /// This documents nothing
+        |}
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
+  test("DanglingDocComment.05") {
+    val input =
+      """
+        |eff MyEff {
+        |  /// This documents nothing
+        |}
+        |def main(): Unit = ()
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
   test("MangledModule.02") {
     val input =
       """


### PR DESCRIPTION
Closes #7711.
Adds 3 test cases to cover the issues.