### PR TITLE
feat: nice error when keyword is used as name.

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -209,6 +209,93 @@ sealed trait TokenKind {
   def isComment: Boolean = this == TokenKind.CommentDoc || this.isCommentNonDoc
 
   /**
+    * Checks if this token is a keyword.
+    */
+  def isKeyword: Boolean = this match {
+    case TokenKind.KeywordAlias => true
+    case TokenKind.KeywordAnd => true
+    case TokenKind.KeywordAs => true
+    case TokenKind.KeywordCase => true
+    case TokenKind.KeywordCatch => true
+    case TokenKind.KeywordCheckedCast => true
+    case TokenKind.KeywordCheckedECast => true
+    case TokenKind.KeywordChoose => true
+    case TokenKind.KeywordChooseStar => true
+    case TokenKind.KeywordDebug => true
+    case TokenKind.KeywordDebugBang => true
+    case TokenKind.KeywordDebugBangBang => true
+    case TokenKind.KeywordDef => true
+    case TokenKind.KeywordDeref => true
+    case TokenKind.KeywordDiscard => true
+    case TokenKind.KeywordDo => true
+    case TokenKind.KeywordEff => true
+    case TokenKind.KeywordElse => true
+    case TokenKind.KeywordEnum => true
+    case TokenKind.KeywordFalse => true
+    case TokenKind.KeywordFix => true
+    case TokenKind.KeywordForA => true
+    case TokenKind.KeywordForall => true
+    case TokenKind.KeywordForce => true
+    case TokenKind.KeywordForeach => true
+    case TokenKind.KeywordForM => true
+    case TokenKind.KeywordFrom => true
+    case TokenKind.KeywordIf => true
+    case TokenKind.KeywordImport => true
+    case TokenKind.KeywordInject => true
+    case TokenKind.KeywordInline => true
+    case TokenKind.KeywordInstance => true
+    case TokenKind.KeywordInstanceOf => true
+    case TokenKind.KeywordInto => true
+    case TokenKind.KeywordJavaGetField => true
+    case TokenKind.KeywordJavaNew => true
+    case TokenKind.KeywordJavaSetField => true
+    case TokenKind.KeywordLaw => true
+    case TokenKind.KeywordLawful => true
+    case TokenKind.KeywordLazy => true
+    case TokenKind.KeywordLet => true
+    case TokenKind.KeywordMaskedCast => true
+    case TokenKind.KeywordMatch => true
+    case TokenKind.KeywordMod => true
+    case TokenKind.KeywordNew => true
+    case TokenKind.KeywordNot => true
+    case TokenKind.KeywordNull => true
+    case TokenKind.KeywordOpenVariant => true
+    case TokenKind.KeywordOpenVariantAs => true
+    case TokenKind.KeywordOr => true
+    case TokenKind.KeywordOverride => true
+    case TokenKind.KeywordPar => true
+    case TokenKind.KeywordPub => true
+    case TokenKind.KeywordProject => true
+    case TokenKind.KeywordQuery => true
+    case TokenKind.KeywordRef => true
+    case TokenKind.KeywordRegion => true
+    case TokenKind.KeywordRestrictable => true
+    case TokenKind.KeywordRvadd => true
+    case TokenKind.KeywordRvand => true
+    case TokenKind.KeywordRvnot => true
+    case TokenKind.KeywordRvsub => true
+    case TokenKind.KeywordSealed => true
+    case TokenKind.KeywordSelect => true
+    case TokenKind.KeywordSolve => true
+    case TokenKind.KeywordSpawn => true
+    case TokenKind.KeywordStatic => true
+    case TokenKind.KeywordTrait => true
+    case TokenKind.KeywordTrue => true
+    case TokenKind.KeywordTry => true
+    case TokenKind.KeywordType => true
+    case TokenKind.KeywordTypeMatch => true
+    case TokenKind.KeywordUncheckedCast => true
+    case TokenKind.KeywordUniv => true
+    case TokenKind.KeywordUse => true
+    case TokenKind.KeywordWhere => true
+    case TokenKind.KeywordWith => true
+    case TokenKind.KeywordWithout => true
+    case TokenKind.KeywordYield => true
+    case TokenKind.KeywordXor => true
+    case _ => false
+  }
+
+  /**
     * Checks if this token is a modifier.
     */
   def isModifier: Boolean = this match {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -614,6 +614,20 @@ object Parser2 {
     */
   private def name(kinds: Set[TokenKind], allowQualified: Boolean = false, context: SyntacticContext)(implicit s: State): Mark.Closed = {
     val mark = open(consumeDocComments = false)
+
+    // Check if we are at a keyword and emit nice error if so.
+    val current = nth(0)
+    if (nth(0).isKeyword) {
+      advance()
+      return closeWithError(mark, UnexpectedToken(
+        NamedTokenSet.FromKinds(kinds),
+        actual = Some(current),
+        sctx = context,
+        hint = Some(s"${current.display} is a keyword."),
+        loc = previousSourceLocation()
+      ))
+    }
+
     expectAny(kinds, context)
     val first = close(mark, TreeKind.Ident)
     if (!allowQualified) {
@@ -1767,7 +1781,7 @@ object Parser2 {
             case TokenKind.ParenR => parenNestingLevel -= 1; lookAhead += 1
             case TokenKind.Eof =>
               val error = UnexpectedToken(expected = NamedTokenSet.Expression, actual = None, SyntacticContext.Expr.OtherExpr, loc = currentSourceLocation())
-              return closeWithError(mark,error )
+              return closeWithError(mark, error)
             case t if t.isFirstDecl =>
               // Advance past the erroneous region to the next stable token (the start of the declaration)
               for (_ <- 0 until lookAhead) {


### PR DESCRIPTION
For instance:
```scala
def new(): Int32 = 123
```
gives 
```
>> Expected <Name>, <greek name>, <name>, <user-defined operator> or <math name> before 'new'.

1 | def new(): Int32 = 123
        ^^^
        Here
Hint: 'new' is a keyword.
```
