### PR TITLE
fix: OpCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -502,8 +502,8 @@ class Flix {
     val result = for {
       afterReader <- Reader.run(getInputs)
       afterLexer <- Lexer.run(afterReader, cachedLexerTokens, changeSet)
-      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
-      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
+//      afterParser <- Parser.run(afterReader, entryPoint, cachedParserAst, changeSet)
+//      afterWeeder <- Weeder.run(afterParser, cachedWeederAst, changeSet)
 
       // Plan for migrating to new parser + weeder:
       // Stage 1 [ACTIVE]
@@ -538,9 +538,9 @@ class Flix {
       // Update caches for incremental compilation.
       if (options.incremental) {
         this.cachedLexerTokens = afterLexer
-        this.cachedParserAst = afterParser
+//        this.cachedParserAst = afterParser
         this.cachedParserCst = afterParser2
-        this.cachedWeederAst = afterWeeder
+//        this.cachedWeederAst = afterWeeder
         this.cachedWeederAst2 = afterWeeder2
         this.cachedDesugarAst = afterDesugar
         this.cachedKinderAst = afterKinder

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -286,6 +286,7 @@ object CompletionProvider {
       case ResolutionError.UndefinedJvmClass(_, _, _) => (1, SyntacticContext.Import)
       case ResolutionError.UndefinedName(_, _, _, isUse, _) => if (isUse) (1, SyntacticContext.Use) else (2, SyntacticContext.Expr.OtherExpr)
       case ResolutionError.UndefinedType(_, _, _) => (1, SyntacticContext.Type.OtherType)
+      case ResolutionError.UndefinedOp(_, _) => (1, SyntacticContext.Expr.Do)
       case WeederError.MalformedIdentifier(_, _) => (2, SyntacticContext.Import)
       case WeederError.UnappliedIntrinsic(_, _) => (5, SyntacticContext.Expr.OtherExpr)
       case err: ParseError => (5, err.sctx)


### PR DESCRIPTION
The following example will now invoke `OpCompleter`

```scala
eff MyPrint {
    pub def printIt(): Unit
}

def f(): Unit \ IO = 
    do M // <- suggests MyPrint.printlt
```