### PR TITLE
fix: PredicateCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -3177,15 +3177,23 @@ object Parser2 {
     def head()(implicit s: State): Mark.Closed = {
       val mark = open()
       name(NAME_PREDICATE, context = SyntacticContext.Expr.Constraint)
-      if (at(TokenKind.ParenL)) {
-        termList()
-      }
+      termList()
       close(mark, TreeKind.Predicate.Head)
     }
 
     private def termList()(implicit s: State): Mark.Closed = {
-      assert(at(TokenKind.ParenL))
       val mark = open()
+      // Check for missing term list
+      if (!at(TokenKind.ParenL)) {
+        closeWithError(open(), UnexpectedToken(
+          expected = NamedTokenSet.FromKinds(Set(TokenKind.ParenL)),
+          actual = Some(nth(0)),
+          sctx = SyntacticContext.Expr.Constraint,
+          hint = Some("provide a list of terms."),
+          loc = previousSourceLocation())
+        )
+      }
+
       zeroOrMore(
         namedTokenSet = NamedTokenSet.Expression,
         getItem = () => Expr.expression(),


### PR DESCRIPTION
The following example now invokes `PredicateCompleter`:
```scala
﻿def isConnected(s: Set[(Int32, Int32)], src: Int32, dst: Int32): Bool =
    let rules = #{
        Path(x, y) :- Edge(x, y).
        Path(x, z) :- Path(x, y), Edge(y, z).
        P // <- Suggests Path/2
    };
    let edges = inject s into Edge;
    let paths = query edges, rules select true from Path(src, dst);
    not (paths |> Vector.isEmpty)
```