### PR TITLE
fix: source location on built-in binary ops

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1096,7 +1096,7 @@ object Weeder2 {
           }
 
           def mkApply(name: String): Expr.Apply = Expr.Apply(
-            Expr.Ambiguous(Name.mkQName(name, tree.loc.sp1, tree.loc.sp2), tree.loc), List(e1, e2),
+            Expr.Ambiguous(Name.mkQName(name, op.loc.sp1, op.loc.sp2), op.loc), List(e1, e2),
             tree.loc
           )
 


### PR DESCRIPTION
Closes #7637 


The example from the issue now has proper highlighting. The issue was a wrong source location on buitin operators.

<img width="258" alt="Screenshot 2024-05-27 at 09 18 53" src="https://github.com/flix/flix/assets/15815457/74394d83-ea57-4c0c-9a07-084feb21ca89">
