### PR TITLE
fix: use `oneOrMore` on uses and imports

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -150,6 +150,9 @@ object Parser2 {
     root()
     // Build the syntax tree using events in state.
     val tree = buildTree()
+    if (src.name == "main/foo.flix") {
+      syntaxTreeToDebugString(tree)
+    }
     // Return with errors as soft failures to run subsequent phases for more validations.
     Validation.success(tree).withSoftFailures(s.errors)
   }
@@ -706,7 +709,7 @@ object Parser2 {
     // handle use many case
     if (at(TokenKind.DotCurlyL)) {
       val mark = open()
-      zeroOrMore(
+      oneOrMore(
         namedTokenSet = NamedTokenSet.Name,
         getItem = () => aliasedName(NAME_USE, SyntacticContext.Use),
         checkForItem = NAME_USE.contains,
@@ -714,7 +717,10 @@ object Parser2 {
         delimiterL = TokenKind.DotCurlyL,
         delimiterR = TokenKind.CurlyR,
         context = SyntacticContext.Use
-      )
+      ) match {
+        case Some(err) => closeWithError(open(), err)
+        case None =>
+      }
       close(mark, TreeKind.UsesOrImports.UseMany)
     }
     close(mark, TreeKind.UsesOrImports.Use)
@@ -728,7 +734,7 @@ object Parser2 {
     // handle import many case
     if (at(TokenKind.DotCurlyL)) {
       val mark = open()
-      zeroOrMore(
+      oneOrMore(
         namedTokenSet = NamedTokenSet.Name,
         getItem = () => aliasedName(NAME_JAVA, SyntacticContext.Import),
         checkForItem = NAME_JAVA.contains,
@@ -736,7 +742,10 @@ object Parser2 {
         delimiterL = TokenKind.DotCurlyL,
         delimiterR = TokenKind.CurlyR,
         context = SyntacticContext.Import
-      )
+      ) match {
+        case Some(err) => closeWithError(open(), err)
+        case None =>
+      }
       close(mark, TreeKind.UsesOrImports.ImportMany)
     }
     close(mark, TreeKind.UsesOrImports.Import)

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -150,9 +150,6 @@ object Parser2 {
     root()
     // Build the syntax tree using events in state.
     val tree = buildTree()
-    if (src.name == "main/foo.flix") {
-      syntaxTreeToDebugString(tree)
-    }
     // Return with errors as soft failures to run subsequent phases for more validations.
     Validation.success(tree).withSoftFailures(s.errors)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -100,8 +100,10 @@ object Weeder2 {
       }
       val nname = Name.NName(qname.sp1, qname.namespace.idents :+ qname.ident, qname.sp2)
       mapN(traverseOpt(maybeUseMany)(tree => visitUseMany(tree, nname))) {
+        // case: empty use many. Fallback on empty list. Parser has reported an error here.
+        case Some(Nil) => List.empty
         // case: use one, use the qname
-        case None | Some(Nil) => List(UseOrImport.Use(qname, qname.ident, qname.loc))
+        case None => List(UseOrImport.Use(qname, qname.ident, qname.loc))
         // case: use many
         case Some(uses) => uses
       }
@@ -146,8 +148,10 @@ object Weeder2 {
     val maybeImportMany = tryPick(TreeKind.UsesOrImports.ImportMany, tree)
     flatMapN(JvmOp.pickJavaName(tree))(jname => {
       mapN(traverseOpt(maybeImportMany)(tree => visitImportMany(tree, jname.fqn))) {
+        // case: empty import many. Fallback on empty list. Parser has reported an error here.
+        case Some(Nil) => List.empty
         // case: import one, use the java name
-        case None | Some(Nil) =>
+        case None =>
           val ident = Name.Ident(jname.sp1, jname.fqn.lastOption.getOrElse(""), jname.sp2)
           List(UseOrImport.Import(jname, ident, tree.loc))
         // case: import many


### PR DESCRIPTION
Closes #7743 by using `oneOrMore` in parser to emit errors on empty use many or import many.
For instance this example
```scala
import List.{}
def main(): Unit \ IO =
    use SemiGroup.{};
    println("Hello World!")
```
now outputs:
```
-- Parse Error (Import) -------------------------------------------------- main/foo.flix

>> Expected at least one <name>.

1 | import List.{}
               ^^
               Here

-- Parse Error (Use) -------------------------------------------------- main/foo.flix

>> Expected at least one <name>.

3 |     use SemiGroup.{};
                     ^^
                     Here


Compilation failed with 2 error(s).
```