### PR TITLE
feat: Emit `LexerError` on multiline strings

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -781,6 +781,11 @@ object Lexer {
       if (p.isEmpty) {
         return TokenKind.Err(LexerError.UnterminatedString(sourceLocationAtStart()))
       }
+      // Check for multi-line string
+      if (p.contains('\n')) {
+        return TokenKind.Err(LexerError.UnterminatedString(sourceLocationAtStart()))
+      }
+      // All is good, eat one char and continue.
       advance()
     }
     TokenKind.Err(LexerError.UnterminatedString(sourceLocationAtStart()))

--- a/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
@@ -272,6 +272,15 @@ class TestLexer extends AnyFunSuite with TestUtils {
     expectError[LexerError.UnterminatedString](result)
   }
 
+  test("LexerError.MultilineString.01") {
+    val input = s"""
+         |def f(): String = "This is a
+         |multi-line string"
+         |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.UnterminatedString](result)
+  }
+
   test("LexerError.UnterminatedStringInterpolation.01") {
     val input = """ "Hi ${name!" """
     val result = compile(input, Options.TestWithLibNix)


### PR DESCRIPTION
Closes #7728 

This example
```scala
def main(): String = "This is a
 multi-line string"
```
Gives:
```
-- Lexer Error -------------------------------------------------- main/foo.flix

>> missing '"' in string.

1 | def main(): String = "This is a
                         ^
                         String starts here.

-- Lexer Error -------------------------------------------------- main/foo.flix

>> missing '"' in string.

2 |  multi-line string"
                      ^
                      String starts here.
```
Note that there are **two** errors. That's because once we see the new-line in the string, we can't assume there will be a closing `"` later in the file, so we stop consuming characters at that point. Then if there actually is a `"` later, that starts a new string, which is also unterminated.
This is the most conservative behaviour, although we could do better if we checked if the amount of `"`s in the file is even.
I think this is future work.

In an IDE this sort of error gets understood quickly from semantic highlighting. The entire file changes color and it's usually clear to the programmer that the string is malformed.