### PR TITLE
feat: LexerError for free dots

### DIFF
--- a/examples/larger-examples/datalog/sequence.flix
+++ b/examples/larger-examples/datalog/sequence.flix
@@ -2,7 +2,7 @@
 
 def main(): Unit \ IO =
 
-    let numLetters = #{NumLetters(20).};
+    let numLetters = #{ NumLetters(20). };
 
     let lp = #{
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -52,6 +52,7 @@ sealed trait TokenKind {
       case TokenKind.CurlyR => "'}'"
       case TokenKind.Dollar => "'$'"
       case TokenKind.Dot => "'.'"
+      case TokenKind.DotWhiteSpace => "'. '"
       case TokenKind.DotCurlyL => "'.{'"
       case TokenKind.Equal => "'='"
       case TokenKind.EqualEqual => "'=='"
@@ -637,6 +638,8 @@ object TokenKind {
   case object Dollar extends TokenKind
 
   case object Dot extends TokenKind
+
+  case object DotWhiteSpace extends TokenKind
 
   case object DotCurlyL extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
@@ -111,18 +111,18 @@ object LexerError {
   }
 
   /**
-    * An error raised when a period is surrounded by whitespace on both sides.
-    * This is problematic because we want to disallow tokens like: "Rectangle   .   Shape".
+    * An error raised when a period has whitespace before it.
+    * This is problematic because we want to disallow tokens like: "Rectangle   .Shape".
     *
     * @param loc The location of the '.'.
     */
   case class FreeDot(loc: SourceLocation) extends LexerError with Recoverable {
-    override def summary: String = s"'.' has whitespace on both sides."
+    override def summary: String = s"'.' has leading whitespace."
 
     override def message(formatter: Formatter): String = {
       import formatter._
       s"""${line(kind, source.name)}
-         |>> '.' has whitespace on both sides.
+         |>> '.' has leading whitespace.
          |
          |${code(loc, "here")}
          |

--- a/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
@@ -111,6 +111,27 @@ object LexerError {
   }
 
   /**
+    * An error raised when a period is surrounded by whitespace on both sides.
+    * This is problematic because we want to disallow tokens like: "Rectangle   .   Shape".
+    *
+    * @param loc The location of the '.'.
+    */
+  case class FreeDot(loc: SourceLocation) extends LexerError with Recoverable {
+    override def summary: String = s"'.' has whitespace on both sides."
+
+    override def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> '.' has whitespace on both sides.
+         |
+         |${code(loc, "here")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+  /**
    * An error raised when a number ends on an underscore.
    *
    * @param loc The location of the number literal.

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -314,12 +314,14 @@ object Lexer {
       case _ if isMatch(".{") => TokenKind.DotCurlyL
       case '.' =>
         // Check for whitespace around dot.
-        // We disallow whitespace on both sides; This captures cases like "Shape   .   Rectangle".
-        // But note that there can be whitespace after the dot in laws and fixpoint constraints:
-        //   law reflexivity: forall(x: a). x == x
-        //                                ^ Like this
-        if (previousPrevious().exists(_.isWhitespace) && peek().isWhitespace) {
+        if (previousPrevious().exists(_.isWhitespace)) {
+          // If the dot is prefixed with whitespace we treat that as an error.
           TokenKind.Err(LexerError.FreeDot(sourceLocationAtStart()))
+        } else if (peek().isWhitespace) {
+          // A dot with trailing whitespace is it's own TokenKind.
+          // That way we can use that as a terminator for fixpoint constraints,
+          // without clashing with qualified names. IE. This is not allowed "Shape.    Rectangle"
+          TokenKind.DotWhiteSpace
         } else {
           TokenKind.Dot
         }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser.scala
@@ -264,7 +264,7 @@ class Parser(val source: Source) extends org.parboiled2.Parser {
     }
 
     def Law: Rule1[ParsedAst.Declaration.Law] = rule {
-      Documentation ~ Annotations ~ Modifiers ~ SP ~ keyword("law") ~ WS ~ Names.Definition ~ optWS ~ ":" ~ optWS ~ keyword("forall") ~ optWS ~ TypeParams ~ optWS ~ FormalParamList ~ WithClause ~ optWS ~ OptEqualityConstraintList ~ optWS ~ "." ~ optWS ~ Expression ~ SP ~> ParsedAst.Declaration.Law
+      Documentation ~ Annotations ~ Modifiers ~ SP ~ keyword("law") ~ WS ~ Names.Definition ~ optWS ~ ":" ~ optWS ~ keyword("forall") ~ optWS ~ TypeParams ~ optWS ~ FormalParamList ~ WithClause ~ optWS ~ OptEqualityConstraintList ~ optWS ~ Expression ~ SP ~> ParsedAst.Declaration.Law
     }
 
     def Op: Rule1[ParsedAst.Declaration.Op] = rule {

--- a/main/src/library/Applicative.flix
+++ b/main/src/library/Applicative.flix
@@ -76,50 +76,50 @@ pub lawful trait Applicative[m : Type -> Type] with Functor[m] {
     ///
     /// Applying the identity function wrapped into an applicative preserves every applicative value.
     ///
-    law identity: forall(x: m[a]) with Eq[m[a]]. Applicative.ap(Applicative.point(identity), x) == x
+    law identity: forall(x: m[a]) with Eq[m[a]] Applicative.ap(Applicative.point(identity), x) == x
 
     ///
     /// Applicatively composing two functions and then applicatively applying the resulting function is the same
     /// as applicatively applying the functions one by one.
     ///
-    law composition: forall(f: m[b -> c], g: m[a -> b], v: m[a]) with Eq[m[c]]. Applicative.ap(Applicative.ap(Applicative.ap(Applicative.point((f, g) -> g >> f), f), g), v) == Applicative.ap(f, Applicative.ap(g, v))
+    law composition: forall(f: m[b -> c], g: m[a -> b], v: m[a]) with Eq[m[c]] Applicative.ap(Applicative.ap(Applicative.ap(Applicative.point((f, g) -> g >> f), f), g), v) == Applicative.ap(f, Applicative.ap(g, v))
 
     ///
     /// `point` is a homomorphism from normal to applicative values regarding application (normal vs. applicative).
     ///
     // TODO error in type checker does not allow to compile this, see #2099
-    // law homomorphism: forall(f: a -> b, x: a) with Eq[m[b]]. Applicative.ap(Applicative.point(f), Applicative.point(x)) == Applicative.point(f(x))
+    // law homomorphism: forall(f: a -> b, x: a) with Eq[m[b]] Applicative.ap(Applicative.point(f), Applicative.point(x)) == Applicative.point(f(x))
 
     ///
     /// Directly applicatively applying a function `f` to an argument `x` put into a default context is the same as putting the function that takes a function and applies it to `x` into a default context and applicatively applying it to `f`.
     ///
-    law interchange: forall(f: m[a -> b], x: a) with Eq[m[b]]. Applicative.ap(f, Applicative.point(x)) == Applicative.ap(Applicative.point(f -> f(x)), f)
+    law interchange: forall(f: m[a -> b], x: a) with Eq[m[b]] Applicative.ap(f, Applicative.point(x)) == Applicative.ap(Applicative.point(f -> f(x)), f)
 
     ///
     /// `map2` is equivalent to its default implementation.
     ///
-    law map2Correspondence: forall(f: t1 -> t2 -> r, x1: m[t1], x2: m[t2]) with Eq[m[r]]. Applicative.map2(f, x1, x2) == Applicative.ap(Functor.map(f, x1), x2)
+    law map2Correspondence: forall(f: t1 -> t2 -> r, x1: m[t1], x2: m[t2]) with Eq[m[r]] Applicative.map2(f, x1, x2) == Applicative.ap(Functor.map(f, x1), x2)
 
     ///
     /// `map3` is equivalent to its default implementation.
     ///
-    law map3Correspondence: forall(f: t1 -> t2 -> t3 -> r, x1: m[t1], x2: m[t2], x3: m[t3]) with Eq[m[r]]. Applicative.map3(f, x1, x2, x3) == Applicative.ap(Applicative.map2(f, x1, x2), x3)
+    law map3Correspondence: forall(f: t1 -> t2 -> t3 -> r, x1: m[t1], x2: m[t2], x3: m[t3]) with Eq[m[r]] Applicative.map3(f, x1, x2, x3) == Applicative.ap(Applicative.map2(f, x1, x2), x3)
 
     ///
     /// `map4` is equivalent to its default implementation.
     ///
-    law map4Correspondence: forall(f: t1 -> t2 -> t3 -> t4 -> r, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4]) with Eq[m[r]]. Applicative.map4(f, x1, x2, x3, x4) == Applicative.ap(Applicative.map3(f, x1, x2, x3), x4)
+    law map4Correspondence: forall(f: t1 -> t2 -> t3 -> t4 -> r, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4]) with Eq[m[r]] Applicative.map4(f, x1, x2, x3, x4) == Applicative.ap(Applicative.map3(f, x1, x2, x3), x4)
 
     ///
     /// `map5` is equivalent to its default implementation.
     ///
-    law map5Correspondence: forall(f: t1 -> t2 -> t3 -> t4 -> t5 -> r, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4], x5: m[t5]) with Eq[m[r]]. Applicative.map5(f, x1, x2, x3, x4, x5) == Applicative.ap(Applicative.map4(f, x1, x2, x3, x4), x5)
+    law map5Correspondence: forall(f: t1 -> t2 -> t3 -> t4 -> t5 -> r, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4], x5: m[t5]) with Eq[m[r]] Applicative.map5(f, x1, x2, x3, x4, x5) == Applicative.ap(Applicative.map4(f, x1, x2, x3, x4), x5)
 
     ///
     /// Mapping a function over an applicative (with `Functor.map`) is the same as putting the function
     /// into a default context and applying it to the applicative.
     ///
-    law mapCorrespondence: forall(f: a -> b, x: m[a]) with Eq[m[b]]. Functor.map(f, x) == Applicative.ap(Applicative.point(f), x)
+    law mapCorrespondence: forall(f: a -> b, x: m[a]) with Eq[m[b]] Functor.map(f, x) == Applicative.ap(Applicative.point(f), x)
 }
 
 mod Applicative {

--- a/main/src/library/Applicative.flix
+++ b/main/src/library/Applicative.flix
@@ -76,50 +76,50 @@ pub lawful trait Applicative[m : Type -> Type] with Functor[m] {
     ///
     /// Applying the identity function wrapped into an applicative preserves every applicative value.
     ///
-    law identity: forall(x: m[a]) with Eq[m[a]] . Applicative.ap(Applicative.point(identity), x) == x
+    law identity: forall(x: m[a]) with Eq[m[a]]. Applicative.ap(Applicative.point(identity), x) == x
 
     ///
     /// Applicatively composing two functions and then applicatively applying the resulting function is the same
     /// as applicatively applying the functions one by one.
     ///
-    law composition: forall(f: m[b -> c], g: m[a -> b], v: m[a]) with Eq[m[c]] . Applicative.ap(Applicative.ap(Applicative.ap(Applicative.point((f, g) -> g >> f), f), g), v) == Applicative.ap(f, Applicative.ap(g, v))
+    law composition: forall(f: m[b -> c], g: m[a -> b], v: m[a]) with Eq[m[c]]. Applicative.ap(Applicative.ap(Applicative.ap(Applicative.point((f, g) -> g >> f), f), g), v) == Applicative.ap(f, Applicative.ap(g, v))
 
     ///
     /// `point` is a homomorphism from normal to applicative values regarding application (normal vs. applicative).
     ///
     // TODO error in type checker does not allow to compile this, see #2099
-    // law homomorphism: forall(f: a -> b, x: a) with Eq[m[b]] . Applicative.ap(Applicative.point(f), Applicative.point(x)) == Applicative.point(f(x))
+    // law homomorphism: forall(f: a -> b, x: a) with Eq[m[b]]. Applicative.ap(Applicative.point(f), Applicative.point(x)) == Applicative.point(f(x))
 
     ///
     /// Directly applicatively applying a function `f` to an argument `x` put into a default context is the same as putting the function that takes a function and applies it to `x` into a default context and applicatively applying it to `f`.
     ///
-    law interchange: forall(f: m[a -> b], x: a) with Eq[m[b]] . Applicative.ap(f, Applicative.point(x)) == Applicative.ap(Applicative.point(f -> f(x)), f)
+    law interchange: forall(f: m[a -> b], x: a) with Eq[m[b]]. Applicative.ap(f, Applicative.point(x)) == Applicative.ap(Applicative.point(f -> f(x)), f)
 
     ///
     /// `map2` is equivalent to its default implementation.
     ///
-    law map2Correspondence: forall(f: t1 -> t2 -> r, x1: m[t1], x2: m[t2]) with Eq[m[r]] . Applicative.map2(f, x1, x2) == Applicative.ap(Functor.map(f, x1), x2)
+    law map2Correspondence: forall(f: t1 -> t2 -> r, x1: m[t1], x2: m[t2]) with Eq[m[r]]. Applicative.map2(f, x1, x2) == Applicative.ap(Functor.map(f, x1), x2)
 
     ///
     /// `map3` is equivalent to its default implementation.
     ///
-    law map3Correspondence: forall(f: t1 -> t2 -> t3 -> r, x1: m[t1], x2: m[t2], x3: m[t3]) with Eq[m[r]] . Applicative.map3(f, x1, x2, x3) == Applicative.ap(Applicative.map2(f, x1, x2), x3)
+    law map3Correspondence: forall(f: t1 -> t2 -> t3 -> r, x1: m[t1], x2: m[t2], x3: m[t3]) with Eq[m[r]]. Applicative.map3(f, x1, x2, x3) == Applicative.ap(Applicative.map2(f, x1, x2), x3)
 
     ///
     /// `map4` is equivalent to its default implementation.
     ///
-    law map4Correspondence: forall(f: t1 -> t2 -> t3 -> t4 -> r, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4]) with Eq[m[r]] . Applicative.map4(f, x1, x2, x3, x4) == Applicative.ap(Applicative.map3(f, x1, x2, x3), x4)
+    law map4Correspondence: forall(f: t1 -> t2 -> t3 -> t4 -> r, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4]) with Eq[m[r]]. Applicative.map4(f, x1, x2, x3, x4) == Applicative.ap(Applicative.map3(f, x1, x2, x3), x4)
 
     ///
     /// `map5` is equivalent to its default implementation.
     ///
-    law map5Correspondence: forall(f: t1 -> t2 -> t3 -> t4 -> t5 -> r, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4], x5: m[t5]) with Eq[m[r]] . Applicative.map5(f, x1, x2, x3, x4, x5) == Applicative.ap(Applicative.map4(f, x1, x2, x3, x4), x5)
+    law map5Correspondence: forall(f: t1 -> t2 -> t3 -> t4 -> t5 -> r, x1: m[t1], x2: m[t2], x3: m[t3], x4: m[t4], x5: m[t5]) with Eq[m[r]]. Applicative.map5(f, x1, x2, x3, x4, x5) == Applicative.ap(Applicative.map4(f, x1, x2, x3, x4), x5)
 
     ///
     /// Mapping a function over an applicative (with `Functor.map`) is the same as putting the function
     /// into a default context and applying it to the applicative.
     ///
-    law mapCorrespondence: forall(f: a -> b, x: m[a]) with Eq[m[b]] . Functor.map(f, x) == Applicative.ap(Applicative.point(f), x)
+    law mapCorrespondence: forall(f: a -> b, x: m[a]) with Eq[m[b]]. Functor.map(f, x) == Applicative.ap(Applicative.point(f), x)
 }
 
 mod Applicative {

--- a/main/src/library/CommutativeMonoid.flix
+++ b/main/src/library/CommutativeMonoid.flix
@@ -30,13 +30,13 @@ pub lawful trait CommutativeMonoid[a] with Monoid[a] {
     pub def combine(x: a, y: a): a =
         Monoid.combine(x, y)
 
-    law leftIdentity: forall(x: a) with Eq[a]. CommutativeMonoid.combine(CommutativeMonoid.empty(), x) == x
+    law leftIdentity: forall(x: a) with Eq[a] CommutativeMonoid.combine(CommutativeMonoid.empty(), x) == x
 
-    law rightIdentity: forall(x: a) with Eq[a]. CommutativeMonoid.combine(x, CommutativeMonoid.empty()) == x
+    law rightIdentity: forall(x: a) with Eq[a] CommutativeMonoid.combine(x, CommutativeMonoid.empty()) == x
 
-    law associative: forall(x: a, y: a, z: a) with Eq[a]. CommutativeMonoid.combine(CommutativeMonoid.combine(x, y), z) == CommutativeMonoid.combine(x, CommutativeMonoid.combine(y, z))
+    law associative: forall(x: a, y: a, z: a) with Eq[a] CommutativeMonoid.combine(CommutativeMonoid.combine(x, y), z) == CommutativeMonoid.combine(x, CommutativeMonoid.combine(y, z))
 
-    law commutative: forall(x: a, y: a) with Eq[a]. CommutativeMonoid.combine(x, y) == CommutativeMonoid.combine(y, x)
+    law commutative: forall(x: a, y: a) with Eq[a] CommutativeMonoid.combine(x, y) == CommutativeMonoid.combine(y, x)
 
 }
 instance CommutativeMonoid[Unit]

--- a/main/src/library/CommutativeMonoid.flix
+++ b/main/src/library/CommutativeMonoid.flix
@@ -30,13 +30,13 @@ pub lawful trait CommutativeMonoid[a] with Monoid[a] {
     pub def combine(x: a, y: a): a =
         Monoid.combine(x, y)
 
-    law leftIdentity: forall(x: a) with Eq[a] . CommutativeMonoid.combine(CommutativeMonoid.empty(), x) == x
+    law leftIdentity: forall(x: a) with Eq[a]. CommutativeMonoid.combine(CommutativeMonoid.empty(), x) == x
 
-    law rightIdentity: forall(x: a) with Eq[a] . CommutativeMonoid.combine(x, CommutativeMonoid.empty()) == x
+    law rightIdentity: forall(x: a) with Eq[a]. CommutativeMonoid.combine(x, CommutativeMonoid.empty()) == x
 
-    law associative: forall(x: a, y: a, z: a) with Eq[a] . CommutativeMonoid.combine(CommutativeMonoid.combine(x, y), z) == CommutativeMonoid.combine(x, CommutativeMonoid.combine(y, z))
+    law associative: forall(x: a, y: a, z: a) with Eq[a]. CommutativeMonoid.combine(CommutativeMonoid.combine(x, y), z) == CommutativeMonoid.combine(x, CommutativeMonoid.combine(y, z))
 
-    law commutative: forall(x: a, y: a) with Eq[a] . CommutativeMonoid.combine(x, y) == CommutativeMonoid.combine(y, x)
+    law commutative: forall(x: a, y: a) with Eq[a]. CommutativeMonoid.combine(x, y) == CommutativeMonoid.combine(y, x)
 
 }
 instance CommutativeMonoid[Unit]

--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -24,9 +24,9 @@ pub lawful trait CommutativeSemiGroup[a] with SemiGroup[a] {
     ///
     pub def combine(x: a, y: a): a = SemiGroup.combine(x, y)
 
-    law associative: forall(x: a, y: a, z: a) with Eq[a] . CommutativeSemiGroup.combine(CommutativeSemiGroup.combine(x, y), z) == CommutativeSemiGroup.combine(x, CommutativeSemiGroup.combine(y, z))
+    law associative: forall(x: a, y: a, z: a) with Eq[a]. CommutativeSemiGroup.combine(CommutativeSemiGroup.combine(x, y), z) == CommutativeSemiGroup.combine(x, CommutativeSemiGroup.combine(y, z))
 
-    law commutative: forall(x: a, y: a) with Eq[a] . CommutativeSemiGroup.combine(x, y) == CommutativeSemiGroup.combine(y, x)
+    law commutative: forall(x: a, y: a) with Eq[a]. CommutativeSemiGroup.combine(x, y) == CommutativeSemiGroup.combine(y, x)
 
 }
 

--- a/main/src/library/CommutativeSemiGroup.flix
+++ b/main/src/library/CommutativeSemiGroup.flix
@@ -24,9 +24,9 @@ pub lawful trait CommutativeSemiGroup[a] with SemiGroup[a] {
     ///
     pub def combine(x: a, y: a): a = SemiGroup.combine(x, y)
 
-    law associative: forall(x: a, y: a, z: a) with Eq[a]. CommutativeSemiGroup.combine(CommutativeSemiGroup.combine(x, y), z) == CommutativeSemiGroup.combine(x, CommutativeSemiGroup.combine(y, z))
+    law associative: forall(x: a, y: a, z: a) with Eq[a] CommutativeSemiGroup.combine(CommutativeSemiGroup.combine(x, y), z) == CommutativeSemiGroup.combine(x, CommutativeSemiGroup.combine(y, z))
 
-    law commutative: forall(x: a, y: a) with Eq[a]. CommutativeSemiGroup.combine(x, y) == CommutativeSemiGroup.combine(y, x)
+    law commutative: forall(x: a, y: a) with Eq[a] CommutativeSemiGroup.combine(x, y) == CommutativeSemiGroup.combine(y, x)
 
 }
 

--- a/main/src/library/Eq.flix
+++ b/main/src/library/Eq.flix
@@ -34,22 +34,22 @@ pub lawful trait Eq[a] {
     ///
     /// Reflexivity: An element `x` is equal to itself.
     ///
-    law reflexivity: forall(x: a). x == x
+    law reflexivity: forall(x: a) x == x
 
     ///
     /// Symmetry: If `x` is equal to `y` then `y` must also be equal to `x`.
     ///
-    law symmetry: forall(x: a, y: a). (x == y) ==> (y == x)
+    law symmetry: forall(x: a, y: a) (x == y) ==> (y == x)
 
     ///
     /// Transitivity: If `x` is equal to `y` and `y` is equal to `z` then `x` must be equal to `z`.
     ///
-    law transitivity: forall(x: a, y: a, z: a). ((x == y) and (y == z)) ==> (x == z)
+    law transitivity: forall(x: a, y: a, z: a) ((x == y) and (y == z)) ==> (x == z)
 
     ///
     /// x != y is logically equivalent to not (x == y).
     ///
-    law inverseNeq: forall(x: a, y: a). (x != y) <==> (not (x == y))
+    law inverseNeq: forall(x: a, y: a) (x != y) <==> (not (x == y))
 }
 
 instance Eq[Unit] {

--- a/main/src/library/Functor.flix
+++ b/main/src/library/Functor.flix
@@ -26,13 +26,13 @@ pub lawful trait Functor[m : Type -> Type] {
     ///
     /// Mapping the identity function over a functor preserves the functor.
     ///
-    law identity: forall(x: m[a]) with Eq[m[a]]. Functor.map(identity, x) == x
+    law identity: forall(x: m[a]) with Eq[m[a]] Functor.map(identity, x) == x
 
     ///
     /// Composing two functions and mapping the resulting function over a functor is the same as
     /// mapping the functions one after the other over the functor.
     ///
-    law composition: forall(f: b -> c, g: a -> b, v: m[a]) with Eq[m[c]]. Functor.map(g >> f, v) == Functor.map(f, Functor.map(g, v))
+    law composition: forall(f: b -> c, g: a -> b, v: m[a]) with Eq[m[c]] Functor.map(g >> f, v) == Functor.map(f, Functor.map(g, v))
 }
 
 mod Functor {

--- a/main/src/library/Functor.flix
+++ b/main/src/library/Functor.flix
@@ -26,13 +26,13 @@ pub lawful trait Functor[m : Type -> Type] {
     ///
     /// Mapping the identity function over a functor preserves the functor.
     ///
-    law identity: forall(x: m[a]) with Eq[m[a]] . Functor.map(identity, x) == x
+    law identity: forall(x: m[a]) with Eq[m[a]]. Functor.map(identity, x) == x
 
     ///
     /// Composing two functions and mapping the resulting function over a functor is the same as
     /// mapping the functions one after the other over the functor.
     ///
-    law composition: forall(f: b -> c, g: a -> b, v: m[a]) with Eq[m[c]] . Functor.map(g >> f, v) == Functor.map(f, Functor.map(g, v))
+    law composition: forall(f: b -> c, g: a -> b, v: m[a]) with Eq[m[c]]. Functor.map(g >> f, v) == Functor.map(f, Functor.map(g, v))
 }
 
 mod Functor {

--- a/main/src/library/Group.flix
+++ b/main/src/library/Group.flix
@@ -53,7 +53,7 @@ pub trait Group[a] with Monoid[a] {
     /// identity (neutral element) then
     /// `combine(x, y) == combine(y, x) == e`
     ///
-    law leftInvertible: forall(x: a) with Eq[a]. Group.combine(Group.inverse(x), x) == Group.empty()
+    law leftInvertible: forall(x: a) with Eq[a] Group.combine(Group.inverse(x), x) == Group.empty()
 
     ///
     /// Combining the inverse of `x` with `x` yields the neutral element in the group.
@@ -62,7 +62,7 @@ pub trait Group[a] with Monoid[a] {
     /// identity (neutral element) then
     /// `combine(x, y) == combine(y, x) == e`
     ///
-    law rightInvertible: forall(x: a) with Eq[a]. Group.combine(x, Group.inverse(x)) == Group.empty()
+    law rightInvertible: forall(x: a) with Eq[a] Group.combine(x, Group.inverse(x)) == Group.empty()
 
 }
 

--- a/main/src/library/Group.flix
+++ b/main/src/library/Group.flix
@@ -53,7 +53,7 @@ pub trait Group[a] with Monoid[a] {
     /// identity (neutral element) then
     /// `combine(x, y) == combine(y, x) == e`
     ///
-    law leftInvertible: forall(x: a) with Eq[a] . Group.combine(Group.inverse(x), x) == Group.empty()
+    law leftInvertible: forall(x: a) with Eq[a]. Group.combine(Group.inverse(x), x) == Group.empty()
 
     ///
     /// Combining the inverse of `x` with `x` yields the neutral element in the group.
@@ -62,7 +62,7 @@ pub trait Group[a] with Monoid[a] {
     /// identity (neutral element) then
     /// `combine(x, y) == combine(y, x) == e`
     ///
-    law rightInvertible: forall(x: a) with Eq[a] . Group.combine(x, Group.inverse(x)) == Group.empty()
+    law rightInvertible: forall(x: a) with Eq[a]. Group.combine(x, Group.inverse(x)) == Group.empty()
 
 }
 

--- a/main/src/library/JoinLattice.flix
+++ b/main/src/library/JoinLattice.flix
@@ -31,7 +31,7 @@ pub lawful trait JoinLattice[a] with PartialOrder[a] {
     /// The law asserts that the least upper bound operator returns
     /// an element that is greater than or equal to each of its arguments.
     ///
-    law leastUpperBound1: forall(x: a, y: a).
+    law leastUpperBound1: forall(x: a, y: a)
         PartialOrder.lessEqual(x, JoinLattice.leastUpperBound(x, y)) and
         PartialOrder.lessEqual(y, JoinLattice.leastUpperBound(x, y))
 
@@ -39,7 +39,7 @@ pub lawful trait JoinLattice[a] with PartialOrder[a] {
     /// The law asserts that the least upper bound operator returns
     /// the smallest element that is larger than its two arguments.
     ///
-    law leastUpperBound2: forall(x: a, y: a, z: a).
+    law leastUpperBound2: forall(x: a, y: a, z: a)
         (PartialOrder.lessEqual(x, z) and PartialOrder.lessEqual(y, z)) ==>
         PartialOrder.lessEqual(JoinLattice.leastUpperBound(x, y), z)
 

--- a/main/src/library/MeetLattice.flix
+++ b/main/src/library/MeetLattice.flix
@@ -32,7 +32,7 @@ pub lawful trait MeetLattice[a] with PartialOrder[a] {
     /// The lower bound law asserts that the greatest lower bound operator returns an element that
     /// is less than or equal to each of its arguments.
     ///
-    law greatestLowerBound1: forall(x: a, y: a).
+    law greatestLowerBound1: forall(x: a, y: a)
         PartialOrder.lessEqual(MeetLattice.greatestLowerBound(x, y), x) and
         PartialOrder.lessEqual(MeetLattice.greatestLowerBound(x, y), y)
 
@@ -40,7 +40,7 @@ pub lawful trait MeetLattice[a] with PartialOrder[a] {
     /// The greatest lower bound law asserts that the greatest lower bound operator returns the
     /// largest element that is smaller than its two arguments.
     ///
-    law greatestLowerBound2: forall(x: a, y: a, z: a).
+    law greatestLowerBound2: forall(x: a, y: a, z: a)
         (PartialOrder.lessEqual(z, x) and PartialOrder.lessEqual(z, y)) ==>
         PartialOrder.lessEqual(z, MeetLattice.greatestLowerBound(x, y))
 

--- a/main/src/library/Monad.flix
+++ b/main/src/library/Monad.flix
@@ -30,25 +30,25 @@ pub lawful trait Monad[m : Type -> Type] with Applicative[m] {
     ///
     /// Applying `flatMap` to the `point` function is the identity function.
     ///
-    law leftIdentity: forall(f: a -> m[b], x: m[a]) with Eq[m[a]]. Monad.flatMap(Applicative.point, x) == x
+    law leftIdentity: forall(f: a -> m[b], x: m[a]) with Eq[m[a]] Monad.flatMap(Applicative.point, x) == x
 
     ///
     /// Applying `flatMap` to a function and to a non-monadic argument after applying `point` to it is the same
     /// as applying the function directly to that argument.
     ///
-    law rightIdentity: forall(f: a -> m[b], x: a) with Eq[m[b]]. Monad.flatMap(f, Applicative.point(x)) == f(x)
+    law rightIdentity: forall(f: a -> m[b], x: a) with Eq[m[b]] Monad.flatMap(f, Applicative.point(x)) == f(x)
 
     ///
     /// Subsequent `flatMap` calls (nested in the monadic argument) can be moved to the outside by
     /// providing a lambda as first argument which then calls `flatMap`.
     ///
-    law associativity: forall(x: m[a], f: a -> m[b], g: b -> m[c]) with Eq[m[c]]. Monad.flatMap(g, Monad.flatMap(f, x)) == Monad.flatMap(y -> Monad.flatMap(g, f(y)), x)
+    law associativity: forall(x: m[a], f: a -> m[b], g: b -> m[c]) with Eq[m[c]] Monad.flatMap(g, Monad.flatMap(f, x)) == Monad.flatMap(y -> Monad.flatMap(g, f(y)), x)
 
     ///
     /// Applicatively applying a monadic function to a monadic argument is the same as using `flatMap`
     /// to extract function and argument, applying them normally and then applying `point` to the result.
     ///
-    law apCorrespondence: forall(f: m[a -> b], x: m[a]) with Eq[m[b]]. Applicative.ap(f, x) == Monad.flatMap(g -> Monad.flatMap(y -> Applicative.point(g(y)), x), f)
+    law apCorrespondence: forall(f: m[a -> b], x: m[a]) with Eq[m[b]] Applicative.ap(f, x) == Monad.flatMap(g -> Monad.flatMap(y -> Applicative.point(g(y)), x), f)
 }
 
 

--- a/main/src/library/Monad.flix
+++ b/main/src/library/Monad.flix
@@ -30,25 +30,25 @@ pub lawful trait Monad[m : Type -> Type] with Applicative[m] {
     ///
     /// Applying `flatMap` to the `point` function is the identity function.
     ///
-    law leftIdentity: forall(f: a -> m[b], x: m[a]) with Eq[m[a]] . Monad.flatMap(Applicative.point, x) == x
+    law leftIdentity: forall(f: a -> m[b], x: m[a]) with Eq[m[a]]. Monad.flatMap(Applicative.point, x) == x
 
     ///
     /// Applying `flatMap` to a function and to a non-monadic argument after applying `point` to it is the same
     /// as applying the function directly to that argument.
     ///
-    law rightIdentity: forall(f: a -> m[b], x: a) with Eq[m[b]] . Monad.flatMap(f, Applicative.point(x)) == f(x)
+    law rightIdentity: forall(f: a -> m[b], x: a) with Eq[m[b]]. Monad.flatMap(f, Applicative.point(x)) == f(x)
 
     ///
     /// Subsequent `flatMap` calls (nested in the monadic argument) can be moved to the outside by
     /// providing a lambda as first argument which then calls `flatMap`.
     ///
-    law associativity: forall(x: m[a], f: a -> m[b], g: b -> m[c]) with Eq[m[c]] . Monad.flatMap(g, Monad.flatMap(f, x)) == Monad.flatMap(y -> Monad.flatMap(g, f(y)), x)
+    law associativity: forall(x: m[a], f: a -> m[b], g: b -> m[c]) with Eq[m[c]]. Monad.flatMap(g, Monad.flatMap(f, x)) == Monad.flatMap(y -> Monad.flatMap(g, f(y)), x)
 
     ///
     /// Applicatively applying a monadic function to a monadic argument is the same as using `flatMap`
     /// to extract function and argument, applying them normally and then applying `point` to the result.
     ///
-    law apCorrespondence: forall(f: m[a -> b], x: m[a]) with Eq[m[b]] . Applicative.ap(f, x) == Monad.flatMap(g -> Monad.flatMap(y -> Applicative.point(g(y)), x), f)
+    law apCorrespondence: forall(f: m[a -> b], x: m[a]) with Eq[m[b]]. Applicative.ap(f, x) == Monad.flatMap(g -> Monad.flatMap(y -> Applicative.point(g(y)), x), f)
 }
 
 

--- a/main/src/library/Monoid.flix
+++ b/main/src/library/Monoid.flix
@@ -30,11 +30,11 @@ pub lawful trait Monoid[a] with SemiGroup[a] {
     pub def combine(x: a, y: a): a =
         SemiGroup.combine(x, y)
 
-    law leftIdentity: forall(x: a) with Eq[a]. Monoid.combine(Monoid.empty(), x) == x
+    law leftIdentity: forall(x: a) with Eq[a] Monoid.combine(Monoid.empty(), x) == x
 
-    law rightIdentity: forall(x: a) with Eq[a]. Monoid.combine(x, Monoid.empty()) == x
+    law rightIdentity: forall(x: a) with Eq[a] Monoid.combine(x, Monoid.empty()) == x
 
-    law associative: forall(x: a, y: a, z: a) with Eq[a]. Monoid.combine(Monoid.combine(x, y), z) == Monoid.combine(x, Monoid.combine(y, z))
+    law associative: forall(x: a, y: a, z: a) with Eq[a] Monoid.combine(Monoid.combine(x, y), z) == Monoid.combine(x, Monoid.combine(y, z))
 
 }
 

--- a/main/src/library/Monoid.flix
+++ b/main/src/library/Monoid.flix
@@ -30,11 +30,11 @@ pub lawful trait Monoid[a] with SemiGroup[a] {
     pub def combine(x: a, y: a): a =
         SemiGroup.combine(x, y)
 
-    law leftIdentity: forall(x: a) with Eq[a] . Monoid.combine(Monoid.empty(), x) == x
+    law leftIdentity: forall(x: a) with Eq[a]. Monoid.combine(Monoid.empty(), x) == x
 
-    law rightIdentity: forall(x: a) with Eq[a] . Monoid.combine(x, Monoid.empty()) == x
+    law rightIdentity: forall(x: a) with Eq[a]. Monoid.combine(x, Monoid.empty()) == x
 
-    law associative: forall(x: a, y: a, z: a) with Eq[a] . Monoid.combine(Monoid.combine(x, y), z) == Monoid.combine(x, Monoid.combine(y, z))
+    law associative: forall(x: a, y: a, z: a) with Eq[a]. Monoid.combine(Monoid.combine(x, y), z) == Monoid.combine(x, Monoid.combine(y, z))
 
 }
 

--- a/main/src/library/Order.flix
+++ b/main/src/library/Order.flix
@@ -79,53 +79,53 @@ pub lawful trait Order[a] with Eq[a] {
     ///
     /// Reflexivity: An element `x` is lower or equal to itself.
     ///
-    law reflexivity: forall(x: a). x <= x
+    law reflexivity: forall(x: a) x <= x
 
     ///
     /// Antisymmetry: If `x` is lower or equal to `y` and `y` is lower or equal to `x` then `x` must be equal to `y`.
     ///
-    law symmetry: forall(x: a, y: a). ((x <= y) and (y <= x)) ==> (x == y)
+    law symmetry: forall(x: a, y: a) ((x <= y) and (y <= x)) ==> (x == y)
 
     ///
     /// Transitivity: If `x` is lower or equal to `y` and `y` is lower equal to `z` then `x` must be lower or equal to `z`.
     ///
-    law transitivity: forall(x: a, y: a, z: a). ((x <= y) and (y <= z)) ==> (x <= z)
+    law transitivity: forall(x: a, y: a, z: a) ((x <= y) and (y <= z)) ==> (x <= z)
 
     ///
     /// Totality: For each two elements `x` and `y` either `x` is lower or equal to `y` or the other way round.
     ///
-    law totality: forall(x: a, y: a). ((x <= y) or (y <= x))
+    law totality: forall(x: a, y: a) ((x <= y) or (y <= x))
 
     ///
     /// Definition of the minimum function.
     ///
-    law min: forall(x: a, y: a). ((x <= y) ==> (Order.min(x, y) == x)) and ((y <= x) ==> (Order.min(x, y) == y))
+    law min: forall(x: a, y: a) ((x <= y) ==> (Order.min(x, y) == x)) and ((y <= x) ==> (Order.min(x, y) == y))
 
     ///
     /// Definition of the maximum function.
     ///
-    law max: forall(x: a, y: a). ((y <= x) ==> (Order.max(x, y) == x)) and ((x <= y) ==> (Order.max(x, y) == y))
+    law max: forall(x: a, y: a) ((y <= x) ==> (Order.max(x, y) == x)) and ((x <= y) ==> (Order.max(x, y) == y))
 
     ///
     /// x < y is logically equivalent to not (y <= x).
     /// This law defines the associated strict total order "<" associated with "<=".
     ///
-    law strictTotalOrder: forall(x: a, y: a). (x < y) <==> (not (y <= x))
+    law strictTotalOrder: forall(x: a, y: a) (x < y) <==> (not (y <= x))
 
     ///
     /// This law defines ">" based on "<".
     ///
-    law inverseOrder1: forall(x: a, y: a). (x > y) <==> (y < x)
+    law inverseOrder1: forall(x: a, y: a) (x > y) <==> (y < x)
 
     ///
     /// This law defines ">=" based on "<=".
     ///
-    law inverseOrder2: forall(x: a, y: a). (x >= y) <==> (y <= x)
+    law inverseOrder2: forall(x: a, y: a) (x >= y) <==> (y <= x)
 
     ///
     /// Definition of `compare` based on the defined total order.
     ///
-    law compare: forall(x: a, y: a). ((x < y) ==> (Order.compare(x, y) == Comparison.LessThan)) and ((x == y) ==> (Order.compare(x, y) == Comparison.EqualTo)) and ((x > y) ==> (Order.compare(x, y) == Comparison.GreaterThan))
+    law compare: forall(x: a, y: a) ((x < y) ==> (Order.compare(x, y) == Comparison.LessThan)) and ((x == y) ==> (Order.compare(x, y) == Comparison.EqualTo)) and ((x > y) ==> (Order.compare(x, y) == Comparison.GreaterThan))
 }
 
 mod Order {

--- a/main/src/library/PartialOrder.flix
+++ b/main/src/library/PartialOrder.flix
@@ -30,12 +30,12 @@ pub lawful trait PartialOrder[a] {
     ///
     /// Reflexivity: An element `x` is lower or equal to itself.
     ///
-    law reflexivity: forall(x: a). PartialOrder.lessEqual(x, x)
+    law reflexivity: forall(x: a) PartialOrder.lessEqual(x, x)
 
     ///
     /// Transitivity: If `x` is lower or equal to `y` and `y` is lower equal to `z` then `x` must be lower or equal to `z`.
     ///
-    law transitivity: forall(x: a, y: a, z: a). (PartialOrder.lessEqual(x, y) and PartialOrder.lessEqual(y, z)) ==> PartialOrder.lessEqual(x, z)
+    law transitivity: forall(x: a, y: a, z: a) (PartialOrder.lessEqual(x, y) and PartialOrder.lessEqual(y, z)) ==> PartialOrder.lessEqual(x, z)
 }
 
 instance PartialOrder[Int8] {

--- a/main/src/library/SemiGroup.flix
+++ b/main/src/library/SemiGroup.flix
@@ -30,7 +30,7 @@ pub trait SemiGroup[a] {
         if (n <= 1) x
         else SemiGroup.combine(x, SemiGroup.combineN(x, n - 1))
 
-    law associative: forall(x: a, y: a, z: a) with Eq[a] . SemiGroup.combine(SemiGroup.combine(x, y), z) == SemiGroup.combine(x, SemiGroup.combine(y, z))
+    law associative: forall(x: a, y: a, z: a) with Eq[a]. SemiGroup.combine(SemiGroup.combine(x, y), z) == SemiGroup.combine(x, SemiGroup.combine(y, z))
 
 }
 

--- a/main/src/library/SemiGroup.flix
+++ b/main/src/library/SemiGroup.flix
@@ -30,7 +30,7 @@ pub trait SemiGroup[a] {
         if (n <= 1) x
         else SemiGroup.combine(x, SemiGroup.combineN(x, n - 1))
 
-    law associative: forall(x: a, y: a, z: a) with Eq[a]. SemiGroup.combine(SemiGroup.combine(x, y), z) == SemiGroup.combine(x, SemiGroup.combine(y, z))
+    law associative: forall(x: a, y: a, z: a) with Eq[a] SemiGroup.combine(SemiGroup.combine(x, y), z) == SemiGroup.combine(x, SemiGroup.combine(y, z))
 
 }
 

--- a/main/src/library/Traversable.flix
+++ b/main/src/library/Traversable.flix
@@ -36,12 +36,12 @@ pub trait Traversable[t : Type -> Type] with Functor[t], Foldable[t] {
     /// Traversing with the identity function wrapped into an applicative preserves the container `t`
     /// where accessing elements within `t` is pure.
     ///
-    law identity: forall(t: t[a], f: a -> m[a]) with Eq[m[t[a]]], Applicative[m] where Foldable.Aef[t] ~ {} . Traversable.traverse(f, t) == Applicative.point(t)
+    law identity: forall(t: t[a], f: a -> m[a]) with Eq[m[t[a]]], Applicative[m] where Foldable.Aef[t] ~ {}. Traversable.traverse(f, t) == Applicative.point(t)
 
     ///
     /// sequence identity.
     ///
-    law identity: forall(t: t[a], f: a -> m[a]) with Eq[m[t[a]]], Applicative[m] where Foldable.Aef[t] ~ {} . Traversable.sequence(Functor.map(f, t)) == Applicative.point(t)
+    law identity: forall(t: t[a], f: a -> m[a]) with Eq[m[t[a]]], Applicative[m] where Foldable.Aef[t] ~ {}. Traversable.sequence(Functor.map(f, t)) == Applicative.point(t)
 
     // Missing laws: naturality and composition.
 

--- a/main/src/library/Traversable.flix
+++ b/main/src/library/Traversable.flix
@@ -36,12 +36,12 @@ pub trait Traversable[t : Type -> Type] with Functor[t], Foldable[t] {
     /// Traversing with the identity function wrapped into an applicative preserves the container `t`
     /// where accessing elements within `t` is pure.
     ///
-    law identity: forall(t: t[a], f: a -> m[a]) with Eq[m[t[a]]], Applicative[m] where Foldable.Aef[t] ~ {}. Traversable.traverse(f, t) == Applicative.point(t)
+    law identity: forall(t: t[a], f: a -> m[a]) with Eq[m[t[a]]], Applicative[m] where Foldable.Aef[t] ~ {} Traversable.traverse(f, t) == Applicative.point(t)
 
     ///
     /// sequence identity.
     ///
-    law identity: forall(t: t[a], f: a -> m[a]) with Eq[m[t[a]]], Applicative[m] where Foldable.Aef[t] ~ {}. Traversable.sequence(Functor.map(f, t)) == Applicative.point(t)
+    law identity: forall(t: t[a], f: a -> m[a]) with Eq[m[t[a]]], Applicative[m] where Foldable.Aef[t] ~ {} Traversable.sequence(Functor.map(f, t)) == Applicative.point(t)
 
     // Missing laws: naturality and composition.
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
@@ -505,7 +505,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
         |  pub def f(x: a): Bool
         |  pub def g(x: a): Bool
         |
-        |  law l: forall (x: a) . C.f(x)
+        |  law l: forall (x: a) C.f(x)
         |}
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -845,7 +845,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     val input =
       """
         |trait C[a: Type -> Type] {
-        |  law l: forall (x: a) . ???
+        |  law l: forall (x: a) ???
         |}
         |""".stripMargin
     val result = compile(input, DefaultOptions)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -836,7 +836,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
       """
         |trait A[a] {
         |    pub def f(x: Bool, y: a): Bool
-        |    law l: forall (x: Int32, y: Bool) . A.f(x, y)
+        |    law l: forall (x: Int32, y: Bool) A.f(x, y)
         |}
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)

--- a/main/test/flix/Test.Dec.Trait.flix
+++ b/main/test/flix/Test.Dec.Trait.flix
@@ -122,7 +122,7 @@ mod Test.Dec.Trait {
             pub def f(x: a, y: a): Bool
 
             // TODO handle mods better
-            law reflexivity: forall (x: a, y: a) . Test.Dec.Trait.Test11.C.f(x, y) == Test.Dec.Trait.Test11.C.f(y, x)
+            law reflexivity: forall (x: a, y: a) Test.Dec.Trait.Test11.C.f(x, y) == Test.Dec.Trait.Test11.C.f(y, x)
         }
 
         instance C[Int32] {
@@ -134,11 +134,11 @@ mod Test.Dec.Trait {
         trait C[a] {
             pub def f(): a
 
-            law l: forall (_x: a) . true
+            law l: forall (_x: a) true
 
             pub def g(): a
 
-            law m: forall[a: Type](_x: a) . true
+            law m: forall[a: Type](_x: a) true
         }
     }
 
@@ -193,7 +193,7 @@ mod Test.Dec.Trait {
         }
 
         trait C[a] {
-            law l: forall (x: a, y: a) with D[a] . Test.Dec.Trait.Test16.D.f(x, y)
+            law l: forall (x: a, y: a) with D[a] Test.Dec.Trait.Test16.D.f(x, y)
         }
     }
 
@@ -203,7 +203,7 @@ mod Test.Dec.Trait {
         }
 
         trait E[a: Type -> Type] {
-            law l: forall (x: a[b]) with D[a[b]] . Test.Dec.Trait.Test17.D.f(x)
+            law l: forall (x: a[b]) with D[a[b]] Test.Dec.Trait.Test17.D.f(x)
         }
     }
 

--- a/main/test/flix/Test.Def.Generalization.flix
+++ b/main/test/flix/Test.Def.Generalization.flix
@@ -61,19 +61,19 @@ mod Test.Def.Generalization {
     def testGen20(): #{A(Int32)} = #{}
 
     @test
-    def testGen21(): #{A(Int32), B(Int32)} = #{A(21).}
+    def testGen21(): #{ A(Int32), B(Int32)} = #{A(21). }
 
     @test
-    def testGen22(): #{A(Int32), B(Int32), C(Int32)} = #{A(21). B(42).}
+    def testGen22(): #{ A(Int32), B(Int32), C(Int32)} = #{A(21). B(42). }
 
     @test
     def testGen23(): #{A(Int32) | r} = #{}
 
     @test
-    def testGen24(): #{A(Int32), B(Int32) | r} = #{A(21).}
+    def testGen24(): #{ A(Int32), B(Int32) | r} = #{A(21). }
 
     @test
-    def testGen25(): #{A(Int32), B(Int32), C(Int32) | r} = #{A(21). B(42).}
+    def testGen25(): #{ A(Int32), B(Int32), C(Int32) | r} = #{A(21). B(42). }
 
     // TODO: Broken
     //@test

--- a/main/test/flix/Test.Exp.Fixpoint.Compose.flix
+++ b/main/test/flix/Test.Exp.Fixpoint.Compose.flix
@@ -88,12 +88,12 @@ mod Test.Exp.Fixpoint.Compose {
 
     @test
     def testFixpointCompose13(): Bool = {
-        let ans = query coolioQuack(#{Coolio("quack!").}) select s from Duck(s);
+        let ans = query coolioQuack(#{ Coolio("quack!"). }) select s from Duck(s);
         ans == Vector#{"quack!"}
     }
 
     def coolioQuack(p: #{Coolio(String)}): #{Coolio(String), Duck(String) | r} = {
-        p <+> #{Duck(s) :- Coolio(s).}
+        p <+> #{ Duck(s) :- Coolio(s). }
     }
 
     @test
@@ -103,22 +103,22 @@ mod Test.Exp.Fixpoint.Compose {
     }
 
     def duckOutOfNothing(p: #{}): #{Duck(String) | r} = {
-        p <+> #{Duck("quack!").}
+        p <+> #{ Duck("quack!"). }
     }
 
     @test
     def testFixpointCompose15(): Bool = {
-        let ans = query duckVille(#{Rip(1). Rap(2). Rup(3).}) select s from Duck(s);
+        let ans = query duckVille(#{ Rip(1). Rap(2). Rup(3). }) select s from Duck(s);
         ans == Vector#{"quack!"}
     }
 
     def duckVille(p: #{Rip(Int32), Rap(Int32), Rup(Int32)}): #{Rip(Int32), Rap(Int32), Rup(Int32), Duck(String) | r} = {
-        p <+> #{Duck("quack!").}
+        p <+> #{ Duck("quack!"). }
     }
 
     @test
     def testFixpointCompose16(): Bool = {
-        let ans = query noComparison(#{Apples(()).}, #{Oranges(()).}) select s from Apples(s);
+        let ans = query noComparison(#{ Apples(()). }, #{ Oranges(()). }) select s from Apples(s);
         ans == Vector#{()}
     }
 

--- a/main/test/flix/Test.Kind.Trait.flix
+++ b/main/test/flix/Test.Kind.Trait.flix
@@ -54,7 +54,7 @@ mod Test.Kind.Trait {
         mod Law {
             mod FormalParams {
                 trait CStar1[a] {
-                    law star: forall(x: a) . ???
+                    law star: forall(x: a) ???
                 }
             }
 
@@ -62,7 +62,7 @@ mod Test.Kind.Trait {
                 trait CStar[a: Type]
 
                 trait CStar1[a] {
-                    law star: forall(x: a) with CStar[a] . ???
+                    law star: forall(x: a) with CStar[a] ???
                 }
             }
 
@@ -70,13 +70,13 @@ mod Test.Kind.Trait {
                 pub enum EStar[_a: Type]
 
                 trait CStar1[a] {
-                    law star: forall(x: EStar[a]) . ???
+                    law star: forall(x: EStar[a]) ???
                 }
             }
 
             mod Exp {
                 trait CStar1[a] {
-                    law star: forall(x: a) . { (???: a); ??? }
+                    law star: forall(x: a) { (???: a); ??? }
                 }
             }
         }
@@ -154,11 +154,11 @@ mod Test.Kind.Trait {
         mod Law {
             mod FormalParams {
                 trait CStar1[a: Type] {
-                    law star: forall(x: a) . ???
+                    law star: forall(x: a) ???
                 }
 
                 trait CStarToStar1[a: Type -> Type] {
-                    law starToStar: forall(x: a[Int32]) . ???
+                    law starToStar: forall(x: a[Int32]) ???
                 }
             }
 
@@ -168,15 +168,15 @@ mod Test.Kind.Trait {
                 trait CBoolToStar[a: Eff -> Type]
 
                 trait CStar1[a: Type] {
-                    law star: forall(x: a) with CStar[a] . ???
+                    law star: forall(x: a) with CStar[a] ???
                 }
 
                 trait CStarToStar1[a: Type -> Type] {
-                    law starToStar: forall(x: a[Int32]) with CStarToStar[a] . ???
+                    law starToStar: forall(x: a[Int32]) with CStarToStar[a] ???
                 }
 
                 trait CBoolToStar1[a: Eff -> Type] {
-                    law boolToStar: forall(x: a[{}]) with CBoolToStar[a] . ???
+                    law boolToStar: forall(x: a[{}]) with CBoolToStar[a] ???
                 }
             }
 
@@ -185,17 +185,17 @@ mod Test.Kind.Trait {
                 pub enum EStarToStar[_a: Type -> Type]
 
                 trait CStar1[a: Type] {
-                    law star: forall(x: EStar[a]) . ???
+                    law star: forall(x: EStar[a]) ???
                 }
 
                 trait CStarToStar1[a: Type -> Type] {
-                    law starToStar: forall(x: EStarToStar[a]) . ???
+                    law starToStar: forall(x: EStarToStar[a]) ???
                 }
             }
 
             mod Exp {
                 trait CStar1[a: Type] {
-                    law star: forall(x: a) . { (???: a); ??? }
+                    law star: forall(x: a) { (???: a); ??? }
                 }
             }
         }


### PR DESCRIPTION
Closes #7727 

With the example from the issue we now get error:
```
-- Lexer Error -------------------------------------------------- main/foo.flix

>> '.' has whitespace on both sides.

18 |     area(Shape    .    Rectangle(2, 4)) |> println
                       ^
                       here
```
Note that the rule is that no `.` can have whitespace _on both sides_. That's because we need to be able to parse laws and fixpoint constraints:
```scala
law reflexivity: forall(x: a). x == x
//                           ^ Like this

// But this means that this is also fine:
println(area(Shape.    Rectangle(2, 4)))
```
All whitespace information is lost after the lexer, so the check needs to be in this phase. We can't do special handling of laws and fixpoint constraints in the lexer though, because it's context-free. Hence this compromise.