### PR TITLE
fix: `SourceLocation`s on declarations

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -1023,8 +1023,6 @@ object Lexer {
    * Moves current position past a line- or doc-comment
    */
   private def acceptLineOrDocComment()(implicit s: State): TokenKind = {
-//    advance() // Eat one slash.
-
     // Check for doc-comment. A doc-comments leads with exactly 3 slashes.
     // For instance '//// this is not a doc-comment'.
     val kind = (peek(), peekPeek()) match {


### PR DESCRIPTION
Closes #7783 

The issue was that a doc-comment with no text was read as a line-comment. That seems innocent but we have the habit of writing:
```scala
///
/// The comment about gets read as a line-comment.
///
pub type alias Static = IO
```