### PR TITLE
refactor: use `SourcePosition` in `Token`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/SourcePosition.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SourcePosition.scala
@@ -12,15 +12,12 @@ object SourcePosition {
 /**
   * A class that represent a physical source position inside a source input.
   *
+  * A [[SourcePosition]] must always be one-indexed.
+  *
   * @param line  the line number.
   * @param col   the column number.
   */
 case class SourcePosition(source: Source, line: Int, col: Short) {
-
-  /**
-    * Returns the hashCode of `this` source position.
-    */
-  override def hashCode(): Int = source.hashCode() + line + col
 
   /**
     * Returns `true` if `this` and `o` represent the same source position.
@@ -32,4 +29,10 @@ case class SourcePosition(source: Source, line: Int, col: Short) {
         this.col == that.col
     case _ => false
   }
+
+  /**
+    * Returns the hashCode of `this` source position.
+    */
+  override def hashCode(): Int = source.hashCode() + line + col
+
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/SourcePosition.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SourcePosition.scala
@@ -14,8 +14,8 @@ object SourcePosition {
   *
   * A [[SourcePosition]] must always be one-indexed.
   *
-  * @param line  the line number.
-  * @param col   the column number.
+  * @param line the line number. Must be one-indexed.
+  * @param col  the column number. Must be one-indexed.
   */
 case class SourcePosition(source: Source, line: Int, col: Short) {
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Token.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Token.scala
@@ -25,20 +25,14 @@ package ca.uwaterloo.flix.language.ast
   *
   * We do so because [[Token]]s are very common objects.
   *
-  * Specifically, we:
-  *
-  * - Use `Short`s instead of `Int`s to represent column offsets (i.e. `beginCol` and `endCol`).
-  *
-  * @param kind      The kind of token this instance represents.
-  * @param src       A pointer to the source that this lexeme stems from.
-  * @param start     The absolute character offset into `src` of the beginning of the lexeme.
-  * @param end       The absolute character offset into `src` of the end of the lexeme.
-  * @param beginLine The line that the lexeme __starts__ on.
-  * @param beginCol  The column that the lexeme __starts__ on.
-  * @param endLine   The line that the lexeme __ends__ on.
-  * @param endCol    The column that the lexeme __ends__ on.
+  * @param kind  The kind of token this instance represents.
+  * @param src   A pointer to the source that this lexeme stems from.
+  * @param start The absolute character offset into `src` of the beginning of the lexeme. Indexed from zero.
+  * @param end   The absolute character offset into `src` of the end of the lexeme. Indexed from zero.
+  * @param sp1   The source position that the lexeme __starts__ on. Indexed starting from one.
+  * @param sp2   The source position that the lexeme __ends__ on. Indexed starting from one.
   */
-case class Token(kind: TokenKind, src: Ast.Source, start: Int, end: Int, beginLine: Int, beginCol: Short, endLine: Int, endCol: Short) extends SyntaxTree.Child {
+case class Token(kind: TokenKind, src: Ast.Source, start: Int, end: Int, sp1: SourcePosition, sp2: SourcePosition) extends SyntaxTree.Child {
   /**
     * Computes the lexeme that the token refers to by slicing it from `src`.
     *
@@ -47,28 +41,15 @@ case class Token(kind: TokenKind, src: Ast.Source, start: Int, end: Int, beginLi
   def text: String = src.data.slice(start, end).mkString("")
 
   /**
-    * Returns a string representation of this token. Should only be used for debugging.
-    */
-  override def toString: String = s"Token($kind, $text, $beginLine, $beginCol, $endLine, $endCol)"
-
-  /**
-    * Makes a [[SourcePosition]] pointing at the start of this token.
-    * NB: Tokens are zero-indexed while SourcePositions are one-indexed
-    */
-  def mkSourcePosition: SourcePosition = SourcePosition(src, beginLine + 1, (beginCol + 1).toShort)
-
-  /**
-    * Makes a [[SourcePosition]] pointing at the _end_ of this token.
-    * NB: Tokens are zero-indexed while SourcePositions are one-indexed
-    */
-  def mkSourcePositionEnd: SourcePosition = SourcePosition(src, endLine + 1, (endCol + 1).toShort)
-
-  /**
     * Makes a [[SourceLocation]] spanning this token.
     * NB: Tokens are zero-indexed while SourceLocations are one-indexed
     */
   def mkSourceLocation(isReal: Boolean = true): SourceLocation = {
-    SourceLocation(src, isReal, beginLine + 1, (beginCol + 1).toShort, endLine + 1, (endCol + 1).toShort)
+    SourceLocation(src, isReal, sp1.line, sp1.col, sp2.line, sp2.col)
   }
-}
 
+  /**
+    * Returns a string representation of this token. Must only be used for debugging.
+    */
+  override def toString: String = s"Token($kind, $text, ${sp1.line}, ${sp1.col}, ${sp2.line}, ${sp2.col})"
+}

--- a/main/src/ca/uwaterloo/flix/language/ast/Token.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Token.scala
@@ -27,10 +27,10 @@ package ca.uwaterloo.flix.language.ast
   *
   * @param kind  The kind of token this instance represents.
   * @param src   A pointer to the source that this lexeme stems from.
-  * @param start The absolute character offset into `src` of the beginning of the lexeme. Indexed from zero.
-  * @param end   The absolute character offset into `src` of the end of the lexeme. Indexed from zero.
-  * @param sp1   The source position that the lexeme __starts__ on. Indexed starting from one.
-  * @param sp2   The source position that the lexeme __ends__ on. Indexed starting from one.
+  * @param start The absolute character offset into `src` of the beginning of the lexeme. Must be zero-indexed.
+  * @param end   The absolute character offset into `src` of the end of the lexeme. Must be zero-indexed.
+  * @param sp1   The source position that the lexeme __starts__ on. Must be one-indexed.
+  * @param sp2   The source position that the lexeme __ends__ on. Must be one-indexed.
   */
 case class Token(kind: TokenKind, src: Ast.Source, start: Int, end: Int, sp1: SourcePosition, sp2: SourcePosition) extends SyntaxTree.Child {
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.CompilationMessage
-import ca.uwaterloo.flix.language.ast.{Ast, ChangeSet, ReadAst, SourceLocation, Token, TokenKind}
+import ca.uwaterloo.flix.language.ast.{Ast, ChangeSet, ReadAst, SourceLocation, SourcePosition, Token, TokenKind}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.{DebugNoOp, DebugValidation}
 import ca.uwaterloo.flix.language.errors.LexerError
 import ca.uwaterloo.flix.util.{ParOps, Validation}
@@ -131,7 +131,7 @@ object Lexer {
     addToken(TokenKind.Eof)
 
     val errors = s.tokens.collect {
-      case Token(TokenKind.Err(err), _, _, _, _, _, _, _) => err
+      case Token(TokenKind.Err(err), _, _, _, _, _) => err
     }
 
     Validation.toSuccessOrSoftFailure(s.tokens.toArray, errors)
@@ -279,7 +279,9 @@ object Lexer {
    * Afterwards `s.start` is reset to the next position after the previous token.
    */
   private def addToken(kind: TokenKind)(implicit s: State): Unit = {
-    s.tokens += Token(kind, s.src, s.start.offset, s.current.offset, s.start.line, s.start.column.toShort, s.end.line, s.end.column.toShort)
+    val b = SourcePosition(s.src, s.start.line + 1, (s.start.column + 1).toShort)
+    val e = SourcePosition(s.src, s.end.line + 1, (s.end.column + 1).toShort)
+    s.tokens += Token(kind, s.src, s.start.offset, s.current.offset, b, e)
     s.start = new Position(s.current.line, s.current.column, s.current.offset)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -166,7 +166,9 @@ object Parser2 {
     })
 
     // Make a synthetic token to begin with, to make the SourceLocations generated below be correct.
-    var lastAdvance = Token(TokenKind.Eof, s.src, 0, 0, 0, 0, 0, 0)
+    val b = SourcePosition(s.src, 0, 0)
+    val e = SourcePosition(s.src, 0, 0)
+    var lastAdvance = Token(TokenKind.Eof, s.src, 0, 0, b, e)
     for (event <- s.events) {
       event match {
         case Event.Open(kind) =>
@@ -179,14 +181,14 @@ object Parser2 {
           stack.head.loc = if (stack.head.children.length == 0)
             // If the subtree has no children, give it a zero length position just after the last token
             SourceLocation.mk(
-              lastAdvance.mkSourcePositionEnd,
-              lastAdvance.mkSourcePositionEnd
+              lastAdvance.sp2,
+              lastAdvance.sp2
             )
           else
             // Otherwise the source location can span from the first to the last token in the sub tree
             SourceLocation.mk(
-              openToken.mkSourcePosition,
-              lastAdvance.mkSourcePositionEnd
+              openToken.sp1,
+              lastAdvance.sp2
             )
           locationStack = locationStack.tail
           stack = stack.tail
@@ -202,8 +204,8 @@ object Parser2 {
     // Set source location of the root
     val openToken = locationStack.last
     stack.last.loc = SourceLocation.mk(
-      openToken.mkSourcePosition,
-      tokens.head.mkSourcePositionEnd
+      openToken.sp1,
+      tokens.head.sp2
     )
 
     // The stack should now contain a single Source tree,
@@ -220,10 +222,10 @@ object Parser2 {
   private def previousSourceLocation()(implicit s: State): SourceLocation = {
     // state is zero-indexed while SourceLocation works as one-indexed.
     val token = s.tokens((s.position - 1).max(0))
-    val beginLine = token.beginLine + 1
-    val beginCol = (token.beginCol + 1).toShort
-    val endLine = token.endLine + 1
-    val endCol = (token.endCol + 1).toShort
+    val beginLine = token.sp1.line
+    val beginCol = token.sp1.col
+    val endLine = token.sp2.line
+    val endCol = token.sp2.col
     SourceLocation(s.src, isReal = true, beginLine, beginCol, endLine, endCol)
   }
 
@@ -233,10 +235,10 @@ object Parser2 {
   private def currentSourceLocation()(implicit s: State): SourceLocation = {
     // state is zero-indexed while SourceLocation works as one-indexed.
     val token = s.tokens(s.position)
-    val beginLine = token.beginLine + 1
-    val beginCol = (token.beginCol + 1).toShort
-    val endLine = token.endLine + 1
-    val endCol = (token.endCol + 1).toShort
+    val beginLine = token.sp1.line
+    val beginCol = token.sp1.col
+    val endLine = token.sp2.line
+    val endCol = token.sp2.col
     SourceLocation(s.src, isReal = true, beginLine, beginCol, endLine, endCol)
   }
 
@@ -3488,7 +3490,7 @@ object Parser2 {
   def syntaxTreeToDebugString(tree: SyntaxTree.Tree, nesting: Int = 1): String = {
     s"${tree.kind}${
       tree.children.map {
-        case token@Token(_, _, _, _, _, _, _, _) => s"\n${"  " * nesting}'${token.text}'"
+        case token@Token(_, _, _, _, _, _) => s"\n${"  " * nesting}'${token.text}'"
         case tree@SyntaxTree.Tree(_, _, _) => s"\n${"  " * nesting}${syntaxTreeToDebugString(tree, nesting + 1)}"
       }.mkString("")
     }"

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -865,7 +865,7 @@ object Weeder2 {
 
       Validation.fold(tree.children, init: WeededAst.Expr) {
         // A string part: Concat it onto the result
-        case (acc, token@Token(_, _, _, _, _, _, _, _)) =>
+        case (acc, token@Token(_, _, _, _, _, _)) =>
           isDebug = token.kind == TokenKind.LiteralDebugStringL
           val loc = token.mkSourceLocation()
           val lit0 = token.text.stripPrefix("\"").stripSuffix("\"").stripPrefix("}")
@@ -936,7 +936,7 @@ object Weeder2 {
       // Note: This visitor is used by both expression literals and pattern literals.
       expectAny(tree, List(TreeKind.Expr.Literal, TreeKind.Pattern.Literal))
       tree.children(0) match {
-        case token@Token(_, _, _, _, _, _ ,_ ,_) => token.kind match {
+        case token@Token(_, _, _, _, _, _ ) => token.kind match {
           case TokenKind.KeywordNull => Validation.success(Expr.Cst(Ast.Constant.Null, token.mkSourceLocation()))
           case TokenKind.KeywordTrue => Validation.success(Expr.Cst(Ast.Constant.Bool(true), token.mkSourceLocation()))
           case TokenKind.KeywordFalse => Validation.success(Expr.Cst(Ast.Constant.Bool(false), token.mkSourceLocation()))
@@ -1035,7 +1035,7 @@ object Weeder2 {
       flatMapN(pick(TreeKind.Operator, tree), pick(TreeKind.Expr.Expr, tree))(
         (opTree, exprTree) => {
           opTree.children.headOption match {
-            case Some(opToken@Token(_, _, _, _, _, _, _, _)) =>
+            case Some(opToken@Token(_, _, _, _, _, _)) =>
               val sp1 = tree.loc.sp1
               val sp2 = tree.loc.sp2
               val literalToken = tryPickNumberLiteralToken(exprTree)
@@ -1043,7 +1043,7 @@ object Weeder2 {
                 // fold unary minus into a constant
                 case Some(lit) if opToken.text == "-" =>
                   // Construct a synthetic literal tree with the unary minus and visit that like any other literal expression
-                  val syntheticToken = Token(lit.kind, lit.src, opToken.start, lit.end, lit.beginLine, lit.beginCol, lit.endLine, lit.endCol)
+                  val syntheticToken = Token(lit.kind, lit.src, opToken.start, lit.end, lit.sp1, lit.sp2)
                   val syntheticLiteral = Tree(TreeKind.Expr.Literal, Array(syntheticToken), exprTree.loc.asSynthetic)
                   visitLiteralExpr(syntheticLiteral)
                 case _ => mapN(visitExpr(exprTree))(expr => {
@@ -1070,7 +1070,7 @@ object Weeder2 {
       val NumberLiteralKinds = List(TokenKind.LiteralInt8, TokenKind.LiteralInt16, TokenKind.LiteralInt32, TokenKind.LiteralInt64, TokenKind.LiteralBigInt, TokenKind.LiteralFloat32, TokenKind.LiteralFloat64, TokenKind.LiteralBigDecimal)
       val maybeTree = tryPick(TreeKind.Expr.Literal, tree)
       maybeTree.flatMap(_.children(0) match {
-        case t@Token(_, _, _, _, _, _, _, _) if NumberLiteralKinds.contains(t.kind) => Some(t)
+        case t@Token(_, _, _, _, _, _) if NumberLiteralKinds.contains(t.kind) => Some(t)
         case _ => None
       })
     }
@@ -1082,7 +1082,7 @@ object Weeder2 {
       flatMapN(op, traverse(exprs)(visitExpr)) {
         case (op, e1 :: e2 :: Nil) =>
           val isInfix = op.children.head match {
-            case Token(kind, _, _, _, _, _, _, _) => kind == TokenKind.InfixFunction
+            case Token(kind, _, _, _, _, _) => kind == TokenKind.InfixFunction
             case _ => false
           }
 
@@ -1812,9 +1812,9 @@ object Weeder2 {
 
     private def pickDebugKind(tree: Tree): Validation[DebugKind, CompilationMessage] = {
       tree.children.headOption match {
-        case Some(Token(kind, _, _, _, _, _, _, _)) if kind == TokenKind.KeywordDebug => Validation.success(DebugKind.Debug)
-        case Some(Token(kind, _, _, _, _, _, _, _)) if kind == TokenKind.KeywordDebugBang => Validation.success(DebugKind.DebugWithLoc)
-        case Some(Token(kind, _, _, _, _, _, _, _)) if kind == TokenKind.KeywordDebugBangBang => Validation.success(DebugKind.DebugWithLocAndSrc)
+        case Some(Token(kind, _, _, _, _, _)) if kind == TokenKind.KeywordDebug => Validation.success(DebugKind.Debug)
+        case Some(Token(kind, _, _, _, _, _)) if kind == TokenKind.KeywordDebugBang => Validation.success(DebugKind.DebugWithLoc)
+        case Some(Token(kind, _, _, _, _, _)) if kind == TokenKind.KeywordDebugBangBang => Validation.success(DebugKind.DebugWithLocAndSrc)
         case _ => throw InternalCompilerException(s"Malformed debug expression, could not find debug kind", tree.loc)
       }
     }
@@ -2079,16 +2079,16 @@ object Weeder2 {
       expect(tree, TreeKind.Pattern.Unary)
       val NumberLiteralKinds = List(TokenKind.LiteralInt8, TokenKind.LiteralInt16, TokenKind.LiteralInt32, TokenKind.LiteralInt64, TokenKind.LiteralBigInt, TokenKind.LiteralFloat32, TokenKind.LiteralFloat64, TokenKind.LiteralBigDecimal)
       val literalToken = tree.children(1) match {
-        case t@Token(_, _, _, _, _, _, _, _) if NumberLiteralKinds.contains(t.kind) => Some(t)
+        case t@Token(_, _, _, _, _, _) if NumberLiteralKinds.contains(t.kind) => Some(t)
         case _ => None
       }
       flatMapN(pick(TreeKind.Operator, tree))(_.children(0) match {
-        case opToken@Token(_, _, _, _, _, _, _, _) =>
+        case opToken@Token(_, _, _, _, _, _) =>
           literalToken match {
             // fold unary minus into a constant, and visit it like any other constant
             case Some(lit) if opToken.text == "-" =>
               // Construct a synthetic literal tree with the unary minus and visit that like any other literal expression
-              val syntheticToken = Token(lit.kind, lit.src, opToken.start, lit.end, lit.beginLine, lit.beginCol, lit.endLine, lit.endCol)
+              val syntheticToken = Token(lit.kind, lit.src, opToken.start, lit.end, lit.sp1, lit.sp2)
               val syntheticLiteral = Tree(TreeKind.Pattern.Literal, Array(syntheticToken), tree.loc.asSynthetic)
               visitLiteralPat(syntheticLiteral)
             case _ => throw InternalCompilerException(s"No number literal found for unary '-'", tree.loc)
@@ -2928,11 +2928,11 @@ object Weeder2 {
     */
   private def tokenToIdent(tree: Tree): Validation[Name.Ident, CompilationMessage] = {
     tree.children.headOption match {
-      case Some(token@Token(_, _, _, _, _, _, _, _)) =>
+      case Some(token@Token(_, _, _, _, _, _)) =>
         Validation.success(Name.Ident(
-          token.mkSourcePosition,
+          token.sp1,
           token.text,
-          token.mkSourcePositionEnd
+          token.sp2
         ))
       // If child is an ErrorTree, that means the parse already reported and error.
       // We can avoid double reporting by returning a success here.
@@ -2990,7 +2990,7 @@ object Weeder2 {
     */
   private def hasToken(kind: TokenKind, tree: Tree): Boolean = {
     tree.children.exists {
-      case Token(k, _, _, _, _, _, _, _) => k == kind
+      case Token(k, _, _, _, _, _) => k == kind
       case _ => false
     }
   }
@@ -3008,7 +3008,7 @@ object Weeder2 {
     * Collects all immediate child tokens from a tree.
     */
   private def pickAllTokens(tree: Tree): Array[Token] = {
-    tree.children.collect { case token@Token(_, _, _, _, _, _, _, _) => token }
+    tree.children.collect { case token@Token(_, _, _, _, _, _) => token }
   }
 
   /**
@@ -3016,7 +3016,7 @@ object Weeder2 {
     */
   private def text(tree: Tree): List[String] = {
     tree.children.foldLeft[List[String]](List.empty)((acc, c) => c match {
-      case token@Token(_, _, _, _, _, _, _, _) => acc :+ token.text
+      case token@Token(_, _, _, _, _, _) => acc :+ token.text
       case _ => acc
     })
   }


### PR DESCRIPTION
The idea is to store store source positions in Token.

Note: We require that source positions are one-indexed.