### PR TITLE
fix: Don't consume fuel when checking for comments

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -673,9 +673,17 @@ object Parser2 {
     * This is achieved by passing `canStartOnDoc = true`.
     */
   private def comments(consumeDocComments: Boolean = false)(implicit s: State): Unit = {
-    // Note: In case of a misplaced CommentDoc, we would just like to consume it into the comment list.
-    // This is forgiving in the common case of accidentally inserting an extra '/'.
-    def atComment() = if (consumeDocComments) nth(0).isComment else nth(0).isCommentNonDoc
+    // Note: This function does not use nth on purpose.
+    // Calls to comments are so frequent, from open and close for instance,
+    // that nth would needlessly consume all the parses fuel.
+    def atComment(): Boolean = {
+      val current = if (s.position >= s.tokens.length - 1) {
+        TokenKind.Eof
+      } else {
+        s.tokens(s.position).kind
+      }
+      if (consumeDocComments) current.isComment else current.isCommentNonDoc
+    }
 
     if (atComment()) {
       val mark = Mark.Opened(s.events.length)

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -673,9 +673,9 @@ object Parser2 {
     * This is achieved by passing `canStartOnDoc = true`.
     */
   private def comments(consumeDocComments: Boolean = false)(implicit s: State): Unit = {
-    // Note: This function does not use nth on purpose.
-    // Calls to comments are so frequent, from open and close for instance,
-    // that nth would needlessly consume all the parses fuel.
+    // Note: This function does not use nth on purpose, to avoid consuming fuel.
+    // both open and close use comments, and so comments is called so ofter
+    // that nth would needlessly consume all the parsers fuel.
     def atComment(): Boolean = {
       val current = if (s.position >= s.tokens.length - 1) {
         TokenKind.Eof


### PR DESCRIPTION
Closes #7820 
The issue was that `close` calls into `comments` which then does a bunch of calls to `nth` consuming parser fuel.
That's fine in most cases but in the case of a long series of statements, there's a long string of calls to `close` when recursion bottoms out. Many calls to close with no advances makes it look like the parser is stuck, but really everything is fine. We just have deep nesting.

The fix was to allow `comments` to look up the current token without consuming fuel. This is fine, since the behavior is enclosed in `comments` and wont affect fuel elsewhere.