### PR TITLE
fix: handle empty singleton enum

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1014,7 +1014,17 @@ object Parser2 {
       val isShorthand = at(TokenKind.ParenL)
       if (isShorthand) {
         val markType = open()
-        Type.tuple()
+        val mark = open()
+        oneOrMore(
+          namedTokenSet = NamedTokenSet.Type,
+          getItem = () => Type.ttype(),
+          checkForItem = _.isFirstType,
+          breakWhen = _.isRecoverType,
+          context = SyntacticContext.Type.OtherType
+        ) match {
+          case Some(error) => closeWithError(mark, error)
+          case None => close(mark, TreeKind.Type.Tuple)
+        }
         close(markType, TreeKind.Type.Type)
       }
       // derivations

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -344,6 +344,10 @@ object Weeder2 {
             case (Some(_), _ :: _) => Validation.toHardFailure(IllegalEnum(ident.loc))
             // Empty enum
             case (None, Nil) => Validation.success(List.empty)
+            // Empty singleton enum
+            case (Some(Type.Error(_)), Nil) =>
+              // Fall back on no cases, parser has already reported an error
+              Validation.success(List.empty)
             // Singleton enum
             case (Some(t), Nil) =>
               Validation.success(List(WeededAst.Case(ident, flattenEnumCaseType(t), ident.loc)))


### PR DESCRIPTION
Closes #7804 

With this example
```scala
enum Foo()
```
We now get error:
```
-- Parse Error (OtherType) -------------------------------------------------- main/foo.flix

>> Expected at least one <type>.

13 | enum Foo()
             ^
             Here
```

And crucially no cases are passed on in the resulting `WeededAst.Enum` meaning that we no longer spawn an invalid empty tuple type.