### PR TITLE
fix: add termination to module recover loop

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -840,7 +840,7 @@ object Parser2 {
             val loc = currentSourceLocation()
             val error = UnexpectedToken(expected = NamedTokenSet.Declaration, actual = Some(at), SyntacticContext.Decl.OtherDecl, loc = loc)
             // Skip ahead until we find another declaration or a '}' signifying the end of the module.
-            while (!nth(0).isRecoverMod) {
+            while (!nth(0).isRecoverMod && !eof()) {
               advance()
             }
             closeWithError(markErr, error)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -1023,8 +1023,18 @@ class TestParserHappy extends AnyFunSuite with TestUtils {
     expectSuccess(result)
   }
 
-  // TODO: unignore with Parser2
-  ignore("IllegalModuleName.01") {
+  test("IllegalModule.01") {
+    val input =
+      """
+        |mod DelayMap {
+        |    @Experimental
+        |    pub de
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ParseError](result)
+  }
+
+  test("IllegalModuleName.01") {
     val input =
       """
         |mod mymod {
@@ -1034,8 +1044,7 @@ class TestParserHappy extends AnyFunSuite with TestUtils {
     expectError[ParseError](result)
   }
 
-  // TODO: unignore with Parser2
-  ignore("IllegalModuleName.02") {
+  test("IllegalModuleName.02") {
     val input =
       """
         |mod Mymod.othermod {
@@ -1045,8 +1054,7 @@ class TestParserHappy extends AnyFunSuite with TestUtils {
     expectError[ParseError](result)
   }
 
-  // TODO: unignore with Parser2
-  ignore("IllegalModuleName.03") {
+  test("IllegalModuleName.03") {
     val input =
       """
         |mod Mymod {


### PR DESCRIPTION
This fixes a bug I caught while fuzzing the parser.

Here's a minimal example the produces the issue:
```scala
mod DelayMap {
    @Experimental
    pub de
```
This example has been added as a test case. 
3 tests were unignored as well, since they all pass.