### PR TITLE
feat: extend method resolution with `TypeError.AmbiguousMethod`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -102,7 +102,7 @@ object TypeError {
       s"""${line(kind, source.name)}
          |>> Java method '$methodName' from type '${red(formatType(tpe0, Some(renv)))}' with arguments types (${tpes.mkString(", ")}) is ambiguous.
          | Possible candidate methods:
-         |  ${methods.map(m => m.getName).mkString(", ")}
+         |  ${methods.map(m => s"${m.getName}(${m.getParameterTypes.map(t => t.getName).mkString(", ")})").mkString(", ")}
          |
          |${code(loc, s"java method '${methodName} ambiguous")}
          |""".stripMargin

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -24,6 +24,7 @@ import ca.uwaterloo.flix.language.ast._
 import ca.uwaterloo.flix.language.fmt.FormatEqualityConstraint.formatEqualityConstraint
 import ca.uwaterloo.flix.language.fmt.FormatType.formatType
 import ca.uwaterloo.flix.util.{Formatter, Grammar}
+import java.lang.reflect.Method;
 
 /**
   * A common super-type for type errors.
@@ -79,6 +80,31 @@ object TypeError {
          |>> Java method '$methodName' from type '${red(formatType(tpe0, Some(renv)))}' with arguments types (${tpes.mkString(", ")}) not found.
          |
          |${code(loc, s"java method '${methodName} not found")}
+         |""".stripMargin
+    }
+  }
+
+  /**
+   * Java ambiguous method type error.
+   *
+   * @param tpe0    the type of the receiver object.
+   * @param tpes    the types of the arguments.
+   * @param methods a list of possible candidate methods on the type of the receiver object.
+   * @param renv    the rigidity environment.
+   * @param loc     the location where the error occured.
+   */
+  case class AmbiguousMethod(methodName: String, tpe0: Type, tpes: List[Type], methods: List[Method], renv: RigidityEnv, loc: SourceLocation)(implicit flix: Flix) extends TypeError {
+    // TODO INTEROP better comment with candidate methods formatting
+    def summary: String = s"Ambiguous Java method '$methodName' in type '$tpe0' with arguments types (${tpes.mkString(", ")})."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s"""${line(kind, source.name)}
+         |>> Java method '$methodName' from type '${red(formatType(tpe0, Some(renv)))}' with arguments types (${tpes.mkString(", ")}) is ambiguous.
+         | Possible candidate methods:
+         |  ${methods.map(m => m.getName).mkString(", ")}
+         |
+         |${code(loc, s"java method '${methodName} ambiguous")}
          |""".stripMargin
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -99,12 +99,15 @@ object TypeError {
 
     def message(formatter: Formatter): String = {
       import formatter._
+      def methodToStr(m: Method) = {
+         s"${m.getName}(${m.getParameterTypes.map(t => t.getName).mkString(", ")})"
+      }
       s"""${line(kind, source.name)}
          |>> Java method '$methodName' from type '${red(formatType(tpe0, Some(renv)))}' with arguments types (${tpes.mkString(", ")}) is ambiguous.
          | Possible candidate methods:
-         |  ${methods.map(m => s"${m.getName}(${m.getParameterTypes.map(t => t.getName).mkString(", ")})").mkString(", ")}
+         |  ${methods.map(m => methodToStr(m)).mkString(", ")}
          |
-         |${code(loc, s"java method '${methodName} ambiguous")}
+         |${code(loc, s"Ambiguous Java method '${methodName}'")}
          |""".stripMargin
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver.scala
@@ -285,6 +285,7 @@ object ConstraintSolver {
           case JavaResolutionResult.Resolved(tpe) =>
             val subst = Substitution.singleton(mvar.sym, tpe)
             Result.Ok(ResolutionResult(subst @@ subst0, Nil, progress = true))
+          case JavaResolutionResult.AmbiguousMethod(methods) => Result.Err(TypeError.AmbiguousMethod(method.name, tpe, tpes, methods, renv, mvar.loc))
           case JavaResolutionResult.MethodNotFound => Result.Err(TypeError.MethodNotFound(method.name, tpe, tpes, List(), renv, mvar.loc)) // TODO INTEROP: fill in candidate methods
         }
       } else {

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
@@ -163,7 +163,7 @@ object TypeReduction {
       case 1 =>
         val tpe = Type.Cst(TypeConstructor.JvmMethod(candidateMethods.head), loc)
         JavaResolutionResult.Resolved(tpe)
-      case _ => JavaResolutionResult.AmbiguousMethod(candidateMethods.toList) // For now, method not found either if there is an ambiguity or no method found
+      case _ => JavaResolutionResult.AmbiguousMethod(candidateMethods.toList)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
@@ -157,7 +157,7 @@ object TypeReduction {
       case 1 =>
         val tpe = Type.Cst(TypeConstructor.JvmMethod(candidateMethods.head), loc)
         JavaResolutionResult.Resolved(tpe)
-      case 2 => JavaResolutionResult.AmbiguousMethod(candidateMethods.toList) // For now, method not found either if there is an ambiguity or no method found
+      case _ => JavaResolutionResult.AmbiguousMethod(candidateMethods.toList) // For now, method not found either if there is an ambiguity or no method found
     }
   }
 

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1461,4 +1461,33 @@ class TestTyper extends AnyFunSuite with TestUtils {
     val result = compile(input, Options.TestWithLibNix)
     expectError[TypeError.MissingTraitConstraint](result)
   }
+
+  test("TypeError.AmbiguousMethod.01") {
+    val input =
+      """
+        |def main(): Unit \ IO =
+        |    import java_new java.lang.StringBuilder(String): ##java.lang.StringBuilder \ IO as newSB;
+        |    let a = testInvokeMethod2_01(newSB(""));
+        |    println(a#toString())
+        |
+        |def testInvokeMethod2_01(sb: ##java.lang.StringBuilder): ##java.lang.StringBuilder \ IO =
+        |    sb#append(null)
+        |""".stripMargin
+    val result = compile(input, Options.Default)
+    expectError[TypeError.AmbiguousMethod](result)
+  }
+
+  test("TypeError.AmbiguousMethod.02") {
+    val input =
+      """
+        |def main(): Unit \ IO =
+        |    import java_new java.io.PrintStream(String): ##java.io.PrintStream \ IO as newPS;
+        |    testInvokeMethod2_01(newPS(""))
+        |
+        |def testInvokeMethod2_01(ps: ##java.io.PrintStream): Unit \ IO =
+        |    ps#println(null)
+        |""".stripMargin
+    val result = compile(input, Options.Default)
+    expectError[TypeError.AmbiguousMethod](result)
+  }
 }


### PR DESCRIPTION
Fixes one of #7769 tasks.
WIP:
- more tests should be done with an ambiguous method, e.g., with overloading.
- cleaning code
- finish subTyping

`valueOf` method of `String` doesn't work as it is a static method, which gives upon call:

` Exception in thread "main" java.lang.IncompatibleClassChangeError: Expecting non-static method 'java.lang.String java.lang.String.valueOf(int)'`