### PR TITLE
refactor: remove redundant casts

### DIFF
--- a/main/src/library/Adaptor.flix
+++ b/main/src/library/Adaptor.flix
@@ -134,7 +134,7 @@ mod Adaptor {
                 case false => None
             }
         };
-        let iterF = () -> checked_ecast(step());
+        let iterF = () -> (step());
         Iterator.iterate(rc, iterF)
 
     ///
@@ -176,7 +176,7 @@ mod Adaptor {
     /// Alias for `toArrayList`.
     ///
     pub def toList(ma: m[a]): ##java.util.List \ (IO + Foldable.Aef[m]) with Foldable[m] =
-        checked_ecast(checked_cast(toArrayList(ma)))
+        checked_cast(toArrayList(ma))
 
     ///
     /// Returns the elements of the given foldable `ma` as a new Java `ArrayList`.

--- a/main/src/library/Files.flix
+++ b/main/src/library/Files.flix
@@ -374,7 +374,7 @@ mod Files {
             let javaPath = toPath(javaFile);
             let reader = newBufferedReader(javaPath);
             let line = ref readLine(reader) @ rc;
-            let next = () -> checked_ecast({
+            let next = () -> ({
                 if (not Object.isNull(deref line)) {
                     try {
                         let l = deref line;
@@ -415,7 +415,7 @@ mod Files {
             let javaPath = toPath(javaFile);
             let reader = newBufferedReader(javaPath, forName(opts.charSet));
             let line = ref readLine(reader) @ rc;
-            let next = () -> checked_ecast({
+            let next = () -> ({
                 if (not Object.isNull(deref line)) {
                     try {
                         let l = deref line;
@@ -521,7 +521,7 @@ mod Files {
                 let stream = newInputStream(javaFile);
                 let bytes = ref Array.empty(rc, chunkSize) @ rc;
                 let numberRead = ref read(stream, deref bytes) @ rc;
-                let next = () -> checked_ecast({
+                let next = () -> ({
                     if (deref numberRead >= 0) {
                         try {
                             let chunk = deref bytes;


### PR DESCRIPTION
I'm not sure why these are not caught by the redundancy checking