### PR TITLE
feat: remove underlying collection effect form imediate iterator effect

### DIFF
--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -17,8 +17,8 @@
 instance Iterable[Array[a, r]] {
     type Elm = a
     type Aef = r
-    pub def iterator(rc: Region[r1], a: Array[a, r]): Iterator[a, r + r1, r1] \ (r + r1) =
-        checked_ecast(Array.iterator(rc, a))
+    pub def iterator(rc: Region[r1], a: Array[a, r]): Iterator[a, r + r1, r1] \ r1 =
+        Array.iterator(rc, a)
 }
 
 mod Array {

--- a/main/src/library/Iterable.flix
+++ b/main/src/library/Iterable.flix
@@ -34,12 +34,12 @@ pub trait Iterable[t] {
     ///
     /// Returns an iterator over `t`.
     ///
-    pub def iterator(rc: Region[r], t: t): Iterator[Iterable.Elm[t], r + aef, r] \ (r + aef) where Iterable.Aef[t] ~ aef
+    pub def iterator(rc: Region[r], t: t): Iterator[Iterable.Elm[t], r + aef, r] \ r where Iterable.Aef[t] ~ aef
 
     ///
     /// Returns an iterator over `t` zipped with the indices of the elements.
     ///
-    pub def enumerator(rc: Region[r], t: t): Iterator[(Int32, Iterable.Elm[t]), r + aef, r] \ (r + aef) where Iterable.Aef[t] ~ aef =
+    pub def enumerator(rc: Region[r], t: t): Iterator[(Int32, Iterable.Elm[t]), r + aef, r] \ r where Iterable.Aef[t] ~ aef =
         Iterable.iterator(rc, t) |> Iterator.zipWithIndex
 
 }

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -34,7 +34,7 @@ pub enum MutDeque[a: Type, r: Region] {
 instance Iterable[MutDeque[a, r]] {
     type Elm = a
     type Aef = r
-    pub def iterator(rc: Region[r1], md: MutDeque[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutDeque.iterator(rc, md)
+    pub def iterator(rc: Region[r1], md: MutDeque[a, r]): Iterator[a, r + r1, r1] \ r1 = MutDeque.iterator(rc, md)
 }
 
 mod MutDeque {
@@ -423,10 +423,11 @@ mod MutDeque {
     ///
     /// Modifying `d` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(rc: Region[r1], d: MutDeque[a, r2]): Iterator[a, r1 + r2, r1] \ { r1, r2 } =
+    pub def iterator(rc: Region[r1], d: MutDeque[a, r2]): Iterator[a, r1 + r2, r1] \ r1 =
         let MutDeque(_, a, f, b) = d;
-        let i = ref (deref f) @ rc;
+        let i = ref -1 @ rc;
         let next = () -> {
+            if (deref i == -1) Ref.put(deref f, i) else ();
             if (deref i < deref b) {
                 let x = Array.get(deref i, deref a);
                 Ref.put(deref i + Int32.bitwiseAnd(1, capacity(d) - 1), i);

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -28,7 +28,7 @@ pub enum MutList[a: Type, r: Region] {
 instance Iterable[MutList[a, r]] {
     type Elm = a
     type Aef = r
-    pub def iterator(rc: Region[r1], l: MutList[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutList.iterator(rc, l)
+    pub def iterator(rc: Region[r1], l: MutList[a, r]): Iterator[a, r + r1, r1] \ r1 = MutList.iterator(rc, l)
 }
 
 mod MutList {
@@ -826,13 +826,12 @@ mod MutList {
     ///
     /// Modifying `l` while using an iterator has undefined behavior and is dangerous.
     ///
-    pub def iterator(rc: Region[r1], l: MutList[a, r2]): Iterator[a, r1 + r2, r1] \ { r1, r2 } =
+    pub def iterator(rc: Region[r1], l: MutList[a, r2]): Iterator[a, r1 + r2, r1] \ r1 =
         let MutList(_, a, len) = l;
-        let len1 = deref len;
         let ix = ref 0 @ rc;
         let next = () -> {
             let i = deref ix;
-            if (i < len1) {
+            if (i < deref len) {
                 let x = Array.get(i, deref a);
                 Ref.put(i + 1, ix);
                 Some(x)

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -24,7 +24,7 @@ pub enum MutMap[k: Type, v: Type, r: Region] {
 instance Iterable[MutMap[k, v, r]] {
     type Elm = (k, v)
     type Aef = r
-    pub def iterator(rc: Region[r1], m: MutMap[k, v, r]): Iterator[(k, v), r + r1, r1] \ (r + r1) =
+    pub def iterator(rc: Region[r1], m: MutMap[k, v, r]): Iterator[(k, v), r + r1, r1] \ r1 =
         MutMap.iterator(rc, m)
 }
 
@@ -593,23 +593,59 @@ mod MutMap {
     ///
     /// Returns an iterator over all key-value pairs in `m`.
     ///
-    pub def iterator(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[(k, v), r1 + r2, r1] \ { r1, r2 } =
+    pub def iterator(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[(k, v), r1 + r2, r1] \ r1 = {
         let MutMap(_, mm) = m;
-        Map.iterator(rc, deref mm) |> Iterator.map(x -> { discard deref mm; x })
+        let itRef = ref None @ rc;
+        let next = () -> {
+            let it = match deref itRef {
+                case None =>
+                    let underlying = Map.iterator(rc, deref mm);
+                    itRef |> Ref.put(Some(underlying));
+                    underlying
+                case Some(v) => v
+            };
+            Iterator.next(it)
+        };
+        Iterator.iterate(rc, next)
+    }
 
     ///
     /// Returns an iterator over keys in `m`.
     ///
-    pub def iteratorKeys(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[k, r1 + r2, r1] \ { r1, r2 } =
+    pub def iteratorKeys(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[k, r1 + r2, r1] \ r1 = {
         let MutMap(_, mm) = m;
-        Map.iteratorKeys(rc, deref mm) |> Iterator.map(x -> { discard deref mm; x })
+        let itRef = ref None @ rc;
+        let next = () -> {
+            let it = match deref itRef {
+                case None =>
+                    let underlying = Map.iteratorKeys(rc, deref mm);
+                    itRef |> Ref.put(Some(underlying));
+                    underlying
+                case Some(v) => v
+            };
+            Iterator.next(it)
+        };
+        Iterator.iterate(rc, next)
+    }
 
     ///
     /// Returns an iterator over values in `m`.
     ///
-    pub def iteratorValues(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[v, r1 + r2, r1] \ { r1, r2 } =
+    pub def iteratorValues(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[v, r1 + r2, r1] \ r1 = {
         let MutMap(_, mm) = m;
-        Map.iteratorValues(rc, deref mm) |> Iterator.map(x -> { discard deref mm; x })
+        let itRef = ref None @ rc;
+        let next = () -> {
+            let it = match deref itRef {
+                case None =>
+                    let underlying = Map.iteratorValues(rc, deref mm);
+                    itRef |> Ref.put(Some(underlying));
+                    underlying
+                case Some(v) => v
+            };
+            Iterator.next(it)
+        };
+        Iterator.iterate(rc, next)
+    }
 
     ///
     /// Extracts a range of key-value pairs from the mutable map `m`.

--- a/main/src/library/MutQueue.flix
+++ b/main/src/library/MutQueue.flix
@@ -30,7 +30,7 @@ pub enum MutQueue[a: Type, r: Region] {
 instance Iterable[MutQueue[a, r]] {
     type Elm = a
     type Aef = r
-    pub def iterator(rc: Region[r1], q: MutQueue[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutQueue.iterator(rc, q)
+    pub def iterator(rc: Region[r1], q: MutQueue[a, r]): Iterator[a, r + r1, r1] \ r1 = MutQueue.iterator(rc, q)
 }
 
 mod MutQueue {
@@ -124,10 +124,20 @@ mod MutQueue {
     ///
     /// Modifying `mq` during iteration is undefined and not recommended.
     ///
-    pub def iterator(rc: Region[r1], mq: MutQueue[a, r2]): Iterator[a, r1 + r2, r1] \ {r1, r2} =
+    pub def iterator(rc: Region[r1], mq: MutQueue[a, r2]): Iterator[a, r1 + r2, r1] \ r1 =
         let MutQueue(_, arr, s) = mq;
-        let it1 = Iterator.range(rc, 0, deref s);
-        Iterator.map(x -> Array.get(x, deref arr), it1)
+        let ix = ref 0 @ rc;
+        let next = () -> {
+            let i = deref ix;
+            if (i < deref s) {
+                let x = Array.get(i, deref arr);
+                Ref.put(i + 1, ix);
+                Some(x)
+            } else {
+                None
+            }
+        };
+        Iterator.iterate(rc, next)
 
     ///
     /// Returns a List representation of `mq`.

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -24,7 +24,7 @@ pub enum MutSet[t: Type, r: Region] {
 instance Iterable[MutSet[a, r]] {
     type Elm = a
     type Aef = r
-    pub def iterator(rc: Region[r1], s: MutSet[a, r]): Iterator[a, r + r1, r1] \ (r + r1) = MutSet.iterator(rc, s)
+    pub def iterator(rc: Region[r1], s: MutSet[a, r]): Iterator[a, r + r1, r1] \ r1 = MutSet.iterator(rc, s)
 }
 
 mod MutSet {
@@ -401,14 +401,25 @@ mod MutSet {
     ///
     /// Returns an iterator over `s`.
     ///
-    pub def iterator(rc: Region[r1], s: MutSet[a, r2]): Iterator[a, r1 + r2, r1] \ { r1, r2 } =
+    pub def iterator(rc: Region[r1], s: MutSet[a, r2]): Iterator[a, r1 + r2, r1] \ r1 =
         let MutSet(_, ms) = s;
-        Set.iterator(rc, deref ms) |> Iterator.map(x -> { discard deref ms; x })
+        let itRef = ref None @ rc;
+        let next = () -> {
+            let it = match deref itRef {
+                case None =>
+                    let underlying = Set.iterator(rc, deref ms);
+                    itRef |> Ref.put(Some(underlying));
+                    underlying
+                case Some(v) => v
+            };
+            Iterator.next(it)
+        };
+        Iterator.iterate(rc, next)
 
     ///
     /// Returns an enumerator over `s`.
     ///
-    pub def enumerator(rc: Region[r1], s: MutSet[a, r2]): Iterator[(Int32, a), r1 + r2, r1] \ { r1, r2 } =
+    pub def enumerator(rc: Region[r1], s: MutSet[a, r2]): Iterator[(Int32, a), r1 + r2, r1] \ r1 =
         iterator(rc, s) |> Iterator.zipWithIndex
 
     ///

--- a/main/test/flix/experimental/Test.Dec.AssocEff.flix
+++ b/main/test/flix/experimental/Test.Dec.AssocEff.flix
@@ -55,7 +55,7 @@ mod Test.Dec.AssocEff {
     trait Iterable[t: Type] {
         type Elm: Type
         type Aef: Eff
-        pub def iterator(rc: Region[r], t: t): Iterator[Iterable.Elm[t], r + Iterable.Aef[t], r] \ r + Iterable.Aef[t]
+        pub def iterator(rc: Region[r], t: t): Iterator[Iterable.Elm[t], r + Iterable.Aef[t], r] \ r
     }
 
     instance Iterable[List[a]] {
@@ -69,7 +69,7 @@ mod Test.Dec.AssocEff {
     instance Iterable[MutList[a, r1]] {
         type Elm = a
         type Aef = r1
-        pub def iterator(rc: Region[r], l: MutList[a, r1]): Iterator[a, r + r1, r] \ r + r1 = {
+        pub def iterator(rc: Region[r], l: MutList[a, r1]): Iterator[a, r + r1, r] \ r = {
             MutList.iterator(rc, l)
         }
     }
@@ -85,7 +85,7 @@ mod Test.Dec.AssocEff {
     instance Iterable[MutMap[k, v, r1]] {
         type Elm = (k, v)
         type Aef = r1
-        pub def iterator(rc: Region[r], l: MutMap[k, v, r1]): Iterator[(k, v), r + r1, r] \ r + r1 = {
+        pub def iterator(rc: Region[r], l: MutMap[k, v, r1]): Iterator[(k, v), r + r1, r] \ r = {
             MutMap.iterator(rc, l)
         }
     }

--- a/main/test/flix/experimental/Test.Dec.AssocType.flix
+++ b/main/test/flix/experimental/Test.Dec.AssocType.flix
@@ -39,7 +39,7 @@ mod Test.Dec.AssocType {
         type Eff[a]: Eff
         type Elem[a]: Type
 
-        pub def iterator(rc: Region[r], x: a): Iterator[Iterable2.Elem[a], Iterable2.Eff[a] + r, r] \ Iterable2.Eff[a] + r
+        pub def iterator(rc: Region[r], x: a): Iterator[Iterable2.Elem[a], Iterable2.Eff[a] + r, r] \ r
     }
 
     instance Iterable2[String] {
@@ -53,7 +53,7 @@ mod Test.Dec.AssocType {
         type Eff[MutList[a, r]] = r
         type Elem[MutList[a, r]] = a
 
-        pub def iterator(rc: Region[r2], x: MutList[a, r]): Iterator[a, r + r2, r2] \ r + r2 = MutList.iterator(rc, x)
+        pub def iterator(rc: Region[r2], x: MutList[a, r]): Iterator[a, r + r2, r2] \ r2 = MutList.iterator(rc, x)
     }
 
     trait C[a] {


### PR DESCRIPTION
Fixes #7849

#### Pro: (smaller) Effect reflects behaviour
This simplifies the effect footprint of creating an iterator (it can be thought of as returning a function that is pure, from the viewpoint of the underlying data)

#### Con: probably less efficient
This costs performance because we're not allowed to peak inside the collection before actually iterating. Fx length can't be precomputed

#### Effectful Lazy use case
Note that many of the iterators reimplements a lazy value with refs of options