### PR TITLE
refactor: add `SharedContext` to `Namer`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/NameError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/NameError.scala
@@ -23,7 +23,7 @@ import ca.uwaterloo.flix.util.Formatter
 /**
   * A common super-type for naming errors.
   */
-sealed trait NameError extends CompilationMessage {
+sealed trait NameError extends CompilationMessage with Recoverable {
   val kind = "Name Error"
 }
 


### PR DESCRIPTION
This is in preparation for removing the use of `Validation` in `Namer`