### PR TITLE
feat: add support for manifest permissions to `flix.toml`

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/pkg/Dependency.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/Dependency.scala
@@ -21,7 +21,7 @@ sealed trait Dependency
 
 object Dependency {
 
-  case class FlixDependency(repo: Repository, username: String, projectName: String, version: SemVer) extends Dependency
+  case class FlixDependency(repo: Repository, username: String, projectName: String, version: SemVer, permissions: Option[List[Permission]]) extends Dependency
 
   case class MavenDependency(groupId: String, artifactId: String, versionTag: String) extends Dependency
 

--- a/main/src/ca/uwaterloo/flix/tools/pkg/Dependency.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/Dependency.scala
@@ -21,7 +21,7 @@ sealed trait Dependency
 
 object Dependency {
 
-  case class FlixDependency(repo: Repository, username: String, projectName: String, version: SemVer, permissions: Option[List[Permission]]) extends Dependency
+  case class FlixDependency(repo: Repository, username: String, projectName: String, version: SemVer, permissions: List[Permission]) extends Dependency
 
   case class MavenDependency(groupId: String, artifactId: String, versionTag: String) extends Dependency
 

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestError.scala
@@ -83,10 +83,11 @@ object ManifestError {
     }
   }
 
-  case class FlixDependencyPermissionTypeError(path: Path, lib: String, perm: AnyRef) extends ManifestError {
+  case class FlixDependencyPermissionTypeError(path: Option[Path], lib: String, perm: AnyRef) extends ManifestError {
     override def message(f: Formatter): String = {
+      val pStr = path.map(_.toString).getOrElse("\"unknown\"")
       val typ = perm.getClass
-      s"""Unexpected permissions format in Flix dependency ${f.bold(lib)}.
+      s"""Unexpected permissions format of Flix dependency ${f.bold(lib)} in file ${f.cyan(pStr)}.
          |Expected an Array of Strings but got: ${f.bold(f.red(typ.toString))}.
          |""".stripMargin
     }
@@ -144,6 +145,15 @@ object ManifestError {
          |Instead found: ${f.red(depName)}.
          |The toml file was found at ${f.cyan(if (path == null) "null" else path.toString)}.
          |""".stripMargin
+  }
+
+  case class VersionTypeError(path: Option[Path], lib: String, ver: AnyRef) extends ManifestError {
+    override def message(f: Formatter): String = {
+      val pStr = path.map(_.toString).getOrElse("unknown file")
+      s"""Unexpected version type for dependency ${f.bold(lib)} in file ${f.cyan(pStr)}.
+         |Expected ${f.bold("String")} but found ${f.bold(f.red(ver.getClass.toString))}.
+         |""".stripMargin
+    }
   }
 
   case class DependencyFormatError(path: Path, message: String) extends ManifestError {

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestError.scala
@@ -79,6 +79,16 @@ object ManifestError {
          |""".stripMargin
   }
 
+  case class FlixVersionFormatError(path: Path, lib: String,  version: String) extends ManifestError {
+    override def message(f: Formatter): String = {
+      // Should have package name as well for ease of use.
+      s"""
+         |Unrecognized version format for package ${f.bold(lib)}: ${f.bold(f.red(version))}.
+         |The project file was found at ${f.cyan(if (path == null) "Unknown file path" else path.toString)}
+         |""".stripMargin
+    }
+  }
+
   case class RepositoryFormatError(path: Path, repository: String) extends ManifestError {
     override def message(f: Formatter): String =
       s"""

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestError.scala
@@ -74,11 +74,11 @@ object ManifestError {
          |""".stripMargin
   }
 
-  case class FlixVersionFormatError(path: Path, lib: String, version: String) extends ManifestError {
+  case class FlixVersionFormatError(path: Option[Path], lib: String, version: String) extends ManifestError {
     override def message(f: Formatter): String = {
-      // Should have package name as well for ease of use.
+      val pathStr = path.map(_.toString).getOrElse("Unknown file path")
       s"""Unrecognized version format for package ${f.bold(lib)}: ${f.bold(f.red(version))}.
-         |The project file was found at ${f.cyan(if (path == null) "Unknown file path" else path.toString)}
+         |The project file was found at ${f.cyan(pathStr)}
          |""".stripMargin
     }
   }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestError.scala
@@ -79,12 +79,30 @@ object ManifestError {
          |""".stripMargin
   }
 
-  case class FlixVersionFormatError(path: Path, lib: String,  version: String) extends ManifestError {
+  case class FlixVersionFormatError(path: Path, lib: String, version: String) extends ManifestError {
     override def message(f: Formatter): String = {
       // Should have package name as well for ease of use.
       s"""
          |Unrecognized version format for package ${f.bold(lib)}: ${f.bold(f.red(version))}.
          |The project file was found at ${f.cyan(if (path == null) "Unknown file path" else path.toString)}
+         |""".stripMargin
+    }
+  }
+
+  case class FlixDependencyPermissionTypeError(path: Path, lib: String, perm: AnyRef) extends ManifestError {
+    override def message(f: Formatter): String = {
+      val typ = perm.getClass
+      s"""
+         |Unexpected permissions format in Flix dependency ${f.bold(lib)}.
+         |Expected an Array of Strings but got: ${f.bold(f.red(typ.toString))}.
+         |""".stripMargin
+    }
+  }
+
+  case class FlixUnknownPermissionError(path: Path, lib: String, perm: String) extends ManifestError {
+    override def message(f: Formatter): String = {
+      s"""
+         |Unknown permission in dependency ${f.bold(lib)}: ${f.red(f.bold(perm))}.
          |""".stripMargin
     }
   }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestError.scala
@@ -57,14 +57,6 @@ object ManifestError {
     }
   }
 
-  case class MavenVersionHasWrongLength(path: Path, version: String) extends ManifestError {
-    override def message(f: Formatter): String = {
-      s"""This toml file has a Maven version number of the wrong format: ${f.red(version)}.
-         |A version in Maven should be formatted like so: 'x.x.x', 'x.x', 'x.x.x.x' or 'x.x.x-x'.
-         |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
-         |""".stripMargin
-    }
-  }
 
   case class VersionNumberWrong(path: Path, version: String, message: String) extends ManifestError {
     override def message(f: Formatter): String =

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestError.scala
@@ -170,10 +170,9 @@ object ManifestError {
          |""".stripMargin
   }
 
-  case class AuthorNameError(path: Path, message: String) extends ManifestError {
+  case class AuthorNameError(path: Path) extends ManifestError {
     override def message(f: Formatter): String =
       s"""There was an author name which was not of type String:
-         |$message
          |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
          |""".stripMargin
   }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestError.scala
@@ -30,40 +30,36 @@ object ManifestError {
 
   case class MissingRequiredProperty(path: Path, property: String, message: Option[String]) extends ManifestError {
     override def message(f: Formatter): String =
-    s"""
-      |The toml file does not contain a required property called ${f.bold(property)}.
-      |${
+    s"""The toml file does not contain a required property called ${f.bold(property)}.
+       |${
       message match {
         case Some(e) => e
         case None => ""
       }}
-      |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
-      |""".stripMargin
+       |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
+       |""".stripMargin
   }
 
   case class RequiredPropertyHasWrongType(path: Path, property: String, requiredType: String, message: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-        |The property ${f.bold(property)} is required to have a value of type ${f.bold(requiredType)}.
-        |$message
-        |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
-        |""".stripMargin
+      s"""The property ${f.bold(property)} is required to have a value of type ${f.bold(requiredType)}.
+         |$message
+         |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
+         |""".stripMargin
   }
 
   case class FlixVersionHasWrongLength(path: Path, version: String) extends ManifestError {
     override def message(f: Formatter): String = {
-      s"""
-        |This toml file has a Flix version number of the wrong length: ${f.red(version)}.
-        |A version in Flix should be formatted like so: 'x.x.x'.
-        |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
-        |""".stripMargin
+      s"""This toml file has a Flix version number of the wrong length: ${f.red(version)}.
+         |A version in Flix should be formatted like so: 'x.x.x'.
+         |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
+         |""".stripMargin
     }
   }
 
   case class MavenVersionHasWrongLength(path: Path, version: String) extends ManifestError {
     override def message(f: Formatter): String = {
-      s"""
-         |This toml file has a Maven version number of the wrong format: ${f.red(version)}.
+      s"""This toml file has a Maven version number of the wrong format: ${f.red(version)}.
          |A version in Maven should be formatted like so: 'x.x.x', 'x.x', 'x.x.x.x' or 'x.x.x-x'.
          |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
          |""".stripMargin
@@ -72,8 +68,7 @@ object ManifestError {
 
   case class VersionNumberWrong(path: Path, version: String, message: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |This toml file has a version number which includes things that are not numbers: ${f.red(version)}.
+      s"""This toml file has a version number which includes things that are not numbers: ${f.red(version)}.
          |$message
          |The toml file was found at ${f.cyan(if (path == null) "null" else path.toString)}.
          |""".stripMargin
@@ -82,8 +77,7 @@ object ManifestError {
   case class FlixVersionFormatError(path: Path, lib: String, version: String) extends ManifestError {
     override def message(f: Formatter): String = {
       // Should have package name as well for ease of use.
-      s"""
-         |Unrecognized version format for package ${f.bold(lib)}: ${f.bold(f.red(version))}.
+      s"""Unrecognized version format for package ${f.bold(lib)}: ${f.bold(f.red(version))}.
          |The project file was found at ${f.cyan(if (path == null) "Unknown file path" else path.toString)}
          |""".stripMargin
     }
@@ -92,8 +86,7 @@ object ManifestError {
   case class FlixDependencyPermissionTypeError(path: Path, lib: String, perm: AnyRef) extends ManifestError {
     override def message(f: Formatter): String = {
       val typ = perm.getClass
-      s"""
-         |Unexpected permissions format in Flix dependency ${f.bold(lib)}.
+      s"""Unexpected permissions format in Flix dependency ${f.bold(lib)}.
          |Expected an Array of Strings but got: ${f.bold(f.red(typ.toString))}.
          |""".stripMargin
     }
@@ -101,16 +94,13 @@ object ManifestError {
 
   case class FlixUnknownPermissionError(path: Path, lib: String, perm: String) extends ManifestError {
     override def message(f: Formatter): String = {
-      s"""
-         |Unknown permission in dependency ${f.bold(lib)}: ${f.red(f.bold(perm))}.
-         |""".stripMargin
+      s"Unknown permission in dependency ${f.bold(lib)}: ${f.red(f.bold(perm))}."
     }
   }
 
   case class RepositoryFormatError(path: Path, repository: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |A reference to a repository should be formatted like so: 'github:username/projectname'.
+      s"""A reference to a repository should be formatted like so: 'github:username/projectname'.
          |Instead found: ${f.red(repository)}.
          |The toml file was found at ${f.cyan(if (path == null) "null" else path.toString)}.
          |""".stripMargin
@@ -118,8 +108,7 @@ object ManifestError {
 
   case class MavenDependencyFormatError(path: Path, depName: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |A Maven dependency should be formatted like so: 'group:artifact'.
+      s"""A Maven dependency should be formatted like so: 'group:artifact'.
          |Instead found: ${f.red(depName)}.
          |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
          |""".stripMargin
@@ -127,8 +116,7 @@ object ManifestError {
 
   case class FlixDependencyFormatError(path: Path, depName: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |A Flix dependency should be formatted like so: 'repository:username/projectname'.
+      s"""A Flix dependency should be formatted like so: 'repository:username/projectname'.
          |Instead found: ${f.red(depName)}.
          |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
          |""".stripMargin
@@ -136,8 +124,7 @@ object ManifestError {
 
   case class JarUrlFormatError(path: Path, depUrl: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |A jar dependency should be formatted like so: 'url:https://website/fileName.jar'.
+      s"""A jar dependency should be formatted like so: 'url:https://website/fileName.jar'.
          |Instead found: ${f.red(depUrl)}.
          |The toml file was found at ${f.cyan(if (path == null) "null" else path.toString)}.
          |""".stripMargin
@@ -145,8 +132,7 @@ object ManifestError {
 
   case class JarUrlExtensionError(path: Path, depName: String, extension: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |The file to save a jar in should have the extension .jar not .${f.red(extension)}.
+      s"""The file to save a jar in should have the extension .jar not .${f.red(extension)}.
          |Full name given: $depName.
          |The toml file was found at ${f.cyan(if (path == null) "null" else path.toString)}.
          |""".stripMargin
@@ -154,8 +140,7 @@ object ManifestError {
 
   case class JarUrlFileNameError(path: Path, depName: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |The file to save a jar in should be formatted like so: 'fileName.jar'.
+      s"""The file to save a jar in should be formatted like so: 'fileName.jar'.
          |Instead found: ${f.red(depName)}.
          |The toml file was found at ${f.cyan(if (path == null) "null" else path.toString)}.
          |""".stripMargin
@@ -163,8 +148,7 @@ object ManifestError {
 
   case class DependencyFormatError(path: Path, message: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |All versions should be of type String:
+      s"""All versions should be of type String:
          |$message
          |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
          |""".stripMargin
@@ -172,8 +156,7 @@ object ManifestError {
 
   case class JarUrlTypeError(path: Path, message: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |All URLs should be of type String:
+      s"""All URLs should be of type String:
          |$message
          |The toml file was found at ${f.cyan(if (path == null) "null" else path.toString)}.
          |""".stripMargin
@@ -181,8 +164,7 @@ object ManifestError {
 
   case class WrongUrlFormat(path: Path, url: String, message: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |Could not construct a URL from ${f.red(url)}:
+      s"""Could not construct a URL from ${f.red(url)}:
          |$message
          |The toml file was found at ${f.cyan(if (path == null) "null" else path.toString)}.
          |""".stripMargin
@@ -190,8 +172,7 @@ object ManifestError {
 
   case class AuthorNameError(path: Path, message: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |There was an author name which was not of type String:
+      s"""There was an author name which was not of type String:
          |$message
          |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
          |""".stripMargin
@@ -199,8 +180,7 @@ object ManifestError {
 
   case class ManifestParseError(path: Path, msg: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |There was a problem parsing the toml file with the following errors:
+      s"""There was a problem parsing the toml file with the following errors:
          |'$msg'
          |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
          |""".stripMargin
@@ -208,8 +188,7 @@ object ManifestError {
 
   case class UnsupportedRepository(path: Path, attemptedRepo: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |${f.red(attemptedRepo)} is not supported as a repository to download Flix dependencies from.
+      s"""${f.red(attemptedRepo)} is not supported as a repository to download Flix dependencies from.
          |Supported repositories: ${f.bold("github")}.
          |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
          |""".stripMargin
@@ -217,8 +196,7 @@ object ManifestError {
 
   case class IllegalName(path: Path, dependency: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |A dependency includes a non-supported character: ${f.red(dependency)}
+      s"""A dependency includes a non-supported character: ${f.red(dependency)}
          |The dependencies in a toml file can only include the following characters:
          |a-z, A-Z, 0-9, ., :, -, _, /
          |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
@@ -227,8 +205,7 @@ object ManifestError {
 
   case class IOError(path: Path, message: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |An I/O error occured while parsing the toml file:
+      s"""An I/O error occured while parsing the toml file:
          |$message
          |The toml file was found at ${f.cyan(if(path == null) "null" else path.toString)}.
          |""".stripMargin
@@ -236,8 +213,7 @@ object ManifestError {
 
   case class IllegalTableFound(path: Path, tableName: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |The toml file has a table named ${f.red(tableName)}, which is not allowed.
+      s"""The toml file has a table named ${f.red(tableName)}, which is not allowed.
          |Allowed table names:
          |  package, dependencies, dev-dependencies, mvn-dependencies, dev-mvn-dependencies, jar-dependencies
          |The toml file was found at ${f.cyan(if (path == null) "null" else path.toString)}.
@@ -246,8 +222,7 @@ object ManifestError {
 
   case class IllegalPackageKeyFound(path: Path, entryName: String) extends ManifestError {
     override def message(f: Formatter): String =
-      s"""
-         |The toml file has an entry in the package table named ${f.red(entryName)}, which is not allowed.
+      s"""The toml file has an entry in the package table named ${f.red(entryName)}, which is not allowed.
          |Allowed entry names in the package table:
          |  name, description, version, repository, modules, flix, authors, license
          |The toml file was found at ${f.cyan(if (path == null) "null" else path.toString)}.

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
@@ -25,7 +25,6 @@ import org.tomlj.{Toml, TomlArray, TomlInvalidTypeException, TomlParseResult, To
 import java.io.{IOException, StringReader}
 import java.net.{URI, URL}
 import java.nio.file.Path
-import scala.collection.mutable
 import scala.jdk.CollectionConverters.{SetHasAsScala,ListHasAsScala}
 
 object ManifestParser {

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
@@ -366,9 +366,11 @@ object ManifestParser {
           if (!depTbl.isString(verKey)) {
             return Err(ManifestError.VersionTypeError(Option.apply(p), depKey, depTbl.get(verKey)))
           }
+
           if (!depTbl.isArray(permKey)) {
             return Err(ManifestError.FlixDependencyPermissionTypeError(Option.apply(p), depKey, depTbl.get(permKey)))
           }
+
           for (
             ver <- getFlixVersion(depTbl, verKey, p);
             perm <- getPermissions(depTbl, permKey, p)

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
@@ -363,7 +363,7 @@ object ManifestParser {
             Dependency.FlixDependency(repo, username, projectName, _, Nil).toOk
           )
 
-        // If the dependency maps to a table, get the version and permissions.
+          // If the dependency maps to a table, get the version and permissions.
         } else if (deps.isTable(depKey)) {
           val depTbl = deps.getTable(depKey)
           val verKey = "version"
@@ -381,7 +381,7 @@ object ManifestParser {
   }
 
   /**
-   *
+   * Attempt to retrieve a [[SemVer]] at `depKey` from the table `deps`.
    */
   private def getFlixVersion(deps: TomlTable, depKey: String, p: Path): Result[SemVer, ManifestError] = {
     // Ensure the version is a String.
@@ -475,7 +475,6 @@ object ManifestParser {
     } else {
       Err(ManifestError.JarUrlFileNameError(p, depName))
     }
-
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
@@ -397,7 +397,7 @@ object ManifestParser {
     }
     val permArray = depTbl.getArray(key)
     permArray.toList.asScala.toList.map({
-      case s: String => Permission.ofString(s) match {
+      case s: String => Permission.mkPermission(s) match {
         case Some(p) => p
         case None => return Err(ManifestError.FlixUnknownPermissionError(p, key, s))
       }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
@@ -449,7 +449,7 @@ object ManifestParser {
             case Some(v) => v
             case None => return Err(ManifestError.FlixVersionFormatError(p, depKey, depVer))
           }
-          Ok(Dependency.FlixDependency(repo, username, projectName, ver))
+          Ok(Dependency.FlixDependency(repo, username, projectName, ver, None))
         } else {
           val typ = deps.get(depKey).getClass
           Err(ManifestError.DependencyFormatError(p, s"Flix dependency error: expected String but received $typ"))

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
@@ -29,6 +29,12 @@ import scala.collection.mutable
 import scala.jdk.CollectionConverters.{SetHasAsScala,ListHasAsScala}
 
 object ManifestParser {
+  /**
+   * [[Regex]] defining a valid string for user name and project name.
+   * Concretely, a valid name is a [[String]] consisting only of alphanumeric characters
+   * or the symbols `.`,`:`,`/`,`_` and `-`.
+   */
+  private val ValidName = "[a-zA-Z0-9.:/_-]+".r
 
   /**
     * Creates a Manifest from the .toml file
@@ -439,9 +445,9 @@ object ManifestParser {
           case Some(r) => r
           case None => return Err(ManifestError.UnsupportedRepository(p, repoStr))
         }
-        if (!username.matches(s"^$validName$$"))
+        if (!username.matches(s"^$ValidName$$"))
           return Err(ManifestError.IllegalName(p, depKey))
-        if (!projectName.matches(s"^$validName$$"))
+        if (!projectName.matches(s"^$ValidName$$"))
           return Err(ManifestError.IllegalName(p, depKey))
         if (deps.isString(depKey)) {
           for (ver <- getFlixVersion(deps, depKey, p))
@@ -548,8 +554,6 @@ object ManifestParser {
         Ok(PackageModules.Selected(moduleSet))
     }
   }
-
-  private val validName = "[a-zA-Z0-9.:/_-]+".r
 
   /**
     * Checks that a package name does not include any illegal characters.

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
@@ -380,7 +380,11 @@ object ManifestParser {
     }
   }
 
+  /**
+   *
+   */
   private def getFlixVersion(deps: TomlTable, depKey: String, p: Path): Result[SemVer, ManifestError] = {
+    // Ensure the version is a String.
     if (!deps.isString(depKey)) {
       Err(ManifestError.VersionTypeError(Option.apply(p), depKey, deps.get(depKey)))
     } else {
@@ -392,17 +396,23 @@ object ManifestParser {
     }
   }
 
+  /**
+   * Retrieve a list of permissions from a [[TomlTable]] `depTbl` at `key`.
+   */
   private def getPermissions(depTbl: TomlTable, key: String, p: Path): Result[List[Permission], ManifestError] = {
+    // Ensure the permissions are an Array.
     if (!depTbl.isArray(key)) {
       val perms = depTbl.get(key)
       Err(ManifestError.FlixDependencyPermissionTypeError(Option.apply(p), key, perms))
     } else {
       val permArray = depTbl.getArray(key)
       permArray.toList.asScala.toList.map({
+        // Ensure the contents of the array are strings.
         case s: String => Permission.mkPermission(s) match {
           case Some(p) => p
           case None => return Err(ManifestError.FlixUnknownPermissionError(p, key, s))
         }
+        // If an entry is not a string, return an error.
         case _ => return Err(ManifestError.FlixDependencyPermissionTypeError(Option.apply(p), key, permArray))
       }).toOk
     }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/ManifestParser.scala
@@ -15,31 +15,31 @@
  */
 package ca.uwaterloo.flix.tools.pkg
 
+import ca.uwaterloo.flix.language.ast.Symbol
 import ca.uwaterloo.flix.tools.pkg.Dependency.{FlixDependency, JarDependency, MavenDependency}
 import ca.uwaterloo.flix.tools.pkg.github.GitHub
 import ca.uwaterloo.flix.util.Result
 import ca.uwaterloo.flix.util.Result.{Err, Ok, ToOk, traverse}
-import ca.uwaterloo.flix.language.ast.Symbol
-import org.tomlj.{Toml, TomlArray, TomlInvalidTypeException, TomlParseResult, TomlTable}
+import org.tomlj._
 
 import java.io.{IOException, StringReader}
 import java.net.{URI, URL}
 import java.nio.file.Path
-import scala.jdk.CollectionConverters.{SetHasAsScala,ListHasAsScala}
+import scala.jdk.CollectionConverters.{ListHasAsScala, SetHasAsScala}
 
 object ManifestParser {
   /**
-   * [[Regex]] defining a valid string for user name and project name.
+   * Regular expression defining a valid string for user name and project name.
    * Concretely, a valid name is a [[String]] consisting only of alphanumeric characters
    * or the symbols `.`,`:`,`/`,`_` and `-`.
    */
   private val ValidName = "[a-zA-Z0-9.:/_-]+".r
 
   /**
-    * Creates a Manifest from the .toml file
-    * at path `p` and returns an error if
-    * there are parsing errors
-    */
+   * Creates a Manifest from the .toml file
+   * at path `p` and returns an error if
+   * there are parsing errors
+   */
   def parse(p: Path): Result[Manifest, ManifestError] = {
     val parser = try {
       Toml.parse(p)
@@ -50,12 +50,12 @@ object ManifestParser {
   }
 
   /**
-    * Creates a Manifest from the String `s`
-    * which should have the .toml format and
-    * returns an error if there are parsing
-    * errors. The path `p` should be where `s`
-    * comes from.
-    */
+   * Creates a Manifest from the String `s`
+   * which should have the .toml format and
+   * returns an error if there are parsing
+   * errors. The path `p` should be where `s`
+   * comes from.
+   */
   def parse(s: String, p: Path): Result[Manifest, ManifestError] = {
     val stringReader = new StringReader(s)
     val parser = try {
@@ -67,10 +67,10 @@ object ManifestParser {
   }
 
   /**
-    * Creates a Manifest from the TomlParseResult
-    * which should be at path `p` and returns an
-    * error if there are parsing errors.
-    */
+   * Creates a Manifest from the TomlParseResult
+   * which should be at path `p` and returns an
+   * error if there are parsing errors.
+   */
   private def createManifest(parser: TomlParseResult, p: Path): Result[Manifest, ManifestError] = {
     val errors = parser.errors
     if (errors.size() > 0) {
@@ -121,7 +121,7 @@ object ManifestParser {
     val allowedKeys = Set("package", "dependencies", "dev-dependencies", "mvn-dependencies", "dev-mvn-dependencies", "jar-dependencies")
     val illegalKeys = keySet.diff(allowedKeys)
 
-    if(illegalKeys.nonEmpty) {
+    if (illegalKeys.nonEmpty) {
       return Err(ManifestError.IllegalTableFound(p, illegalKeys.head))
     }
 
@@ -137,10 +137,10 @@ object ManifestParser {
   }
 
   /**
-    * Parses a String which should be at `propString`
-    * and returns the String or an error if the result
-    * cannot be found.
-    */
+   * Parses a String which should be at `propString`
+   * and returns the String or an error if the result
+   * cannot be found.
+   */
   private def getRequiredStringProperty(propString: String, parser: TomlParseResult, p: Path): Result[String, ManifestError] = {
     try {
       val prop = parser.getString(propString)
@@ -155,9 +155,9 @@ object ManifestParser {
   }
 
   /**
-    * Parses a String which might be at `propString`
-    * and returns the String as an Option.
-    */
+   * Parses a String which might be at `propString`
+   * and returns the String as an Option.
+   */
   private def getOptionalStringProperty(propString: String, parser: TomlParseResult, p: Path): Result[Option[String], ManifestError] = {
     try {
       val prop = parser.getString(propString)
@@ -169,10 +169,10 @@ object ManifestParser {
   }
 
   /**
-    * Parses an Array which should be at `propString`
-    * and returns the Array or an error if the result
-    * cannot be found.
-    */
+   * Parses an Array which should be at `propString`
+   * and returns the Array or an error if the result
+   * cannot be found.
+   */
   private def getRequiredArrayProperty(propString: String, parser: TomlParseResult, p: Path): Result[TomlArray, ManifestError] = {
     try {
       val array = parser.getArray(propString)
@@ -187,24 +187,24 @@ object ManifestParser {
   }
 
   /**
-    * Parses an Array which might be at `propString`
-    * and returns the Array as an Option.
-    */
+   * Parses an Array which might be at `propString`
+   * and returns the Array as an Option.
+   */
   private def getOptionalArrayProperty(propString: String, parser: TomlParseResult, p: Path): Result[Option[TomlArray], ManifestError] = {
     try {
       val array = parser.getArray(propString)
       Ok(Option(array))
     } catch {
-      case e: IllegalArgumentException => Ok(None)
+      case _: IllegalArgumentException => Ok(None)
       case e: TomlInvalidTypeException => Err(ManifestError.RequiredPropertyHasWrongType(p, propString, "Array", e.getMessage))
     }
   }
 
   /**
-    * Parses a Table which should be at `propString`
-    * and returns the Table or an error if the result
-    * cannot be found.
-    */
+   * Parses a Table which should be at `propString`
+   * and returns the Table or an error if the result
+   * cannot be found.
+   */
   private def getOptionalTableProperty(propString: String, parser: TomlParseResult, p: Path): Result[Option[TomlTable], ManifestError] = {
     try {
       val table = parser.getTable(propString)
@@ -216,10 +216,10 @@ object ManifestParser {
   }
 
   /**
-    * Converts a String `s` to a semantic version and returns
-    * an error if the String is not of the correct format.
-    * The only allowed format is "x.x.x"
-    */
+   * Converts a String `s` to a semantic version and returns
+   * an error if the String is not of the correct format.
+   * The only allowed format is "x.x.x"
+   */
   private def toFlixVer(s: String, p: Path): Result[SemVer, ManifestError] = {
     try {
       s.split('.') match {
@@ -233,10 +233,10 @@ object ManifestParser {
   }
 
   /**
-    * Converts a String `s` to a reference to a GitHub project.
-    * Returns an error if the string is not in the correct format.
-    * The only allowed format is "github:<username>/<repository>".
-    */
+   * Converts a String `s` to a reference to a GitHub project.
+   * Returns an error if the string is not in the correct format.
+   * The only allowed format is "github:<username>/<repository>".
+   */
   private def toGithubProject(s: String, p: Path): Result[GitHub.Project, ManifestError] = {
     s.split(':') match {
       case Array("github", repo) =>
@@ -247,14 +247,14 @@ object ManifestParser {
   }
 
   /**
-    * Converts a TomlTable to a list of Dependencies. This requires
-    * the value of each entry is a String which can be converted to a
-    * semantic version. `flixDep` decides whether the Dependency is a Flix
-    * or MavenDependency and `prodDep` decides whether it is for production
-    * or development. `jarDep` decides whether it is an external jar. This
-    * overrides `flixDep` and `prodDep`.
-    * Returns an error if anything is not as expected.
-    */
+   * Converts a TomlTable to a list of Dependencies. This requires
+   * the value of each entry is a String which can be converted to a
+   * semantic version. `flixDep` decides whether the Dependency is a Flix
+   * or MavenDependency and `prodDep` decides whether it is for production
+   * or development. `jarDep` decides whether it is an external jar. This
+   * overrides `flixDep` and `prodDep`.
+   * Returns an error if anything is not as expected.
+   */
   private def collectDependencies(deps: Option[TomlTable], flixDep: Boolean, jarDep: Boolean, p: Path): Result[List[Dependency], ManifestError] = {
     deps match {
       case None => Ok(List.empty)
@@ -277,51 +277,26 @@ object ManifestParser {
   }
 
   /**
-    * Retrieves the repository for a Flix dependency
-    * and returns an error if it is not formatted correctly
-    * or has characters that are not allowed.
-    */
-  private def getRepository(depName: String, p: Path): Result[Repository, ManifestError] = {
-    depName.split(':') match {
-      case Array(repo, _) =>
-        if (repo == "github") Ok(Repository.GitHub)
-        else Err(ManifestError.UnsupportedRepository(p, repo))
-      case _ => Err(ManifestError.FlixDependencyFormatError(p, depName))
+   * Creates a MavenDependency.
+   * Group id and artifact id are given by `depName`.
+   * The version is given by `depVer`.
+   * `p` is for reporting errors.
+   */
+  private def createMavenDep(depName: String, depVer: AnyRef, p: Path): Result[MavenDependency, ManifestError] = {
+    for (
+      groupId <- getGroupId(depName, p);
+      artifactId <- getArtifactId(depName, p);
+      version <- getMavenVersion(depVer, p)
+    ) yield {
+      Dependency.MavenDependency(groupId, artifactId, version)
     }
   }
 
   /**
-    * Retrieves the username for a Flix dependency
-    * and returns an error if it is not formatted correctly
-    * or has characters that are not allowed.
-    */
-  private def getUsername(depName: String, p: Path): Result[String, ManifestError] = {
-    depName.split(':') match {
-      case Array(_, rest) => rest.split('/') match {
-        case Array(username, _) => checkNameCharacters(username, p)
-        case _ => Err(ManifestError.FlixDependencyFormatError(p, depName))
-      }
-      case _ => Err(ManifestError.FlixDependencyFormatError(p, depName))
-    }
-  }
-
-  /**
-    * Retrieves the project name for a Flix dependency
-    * and returns an error if it is not formatted correctly
-    * or has characters that are not allowed.
-    */
-  private def getProjectName(depName: String, p: Path): Result[String, ManifestError] = {
-    depName.split('/') match {
-      case Array(_, projectName) => checkNameCharacters(projectName, p)
-      case _ => Err(ManifestError.FlixDependencyFormatError(p, depName))
-    }
-  }
-
-  /**
-    * Retrieves the group id for a Maven dependency
-    * and returns an error if it is not formatted correctly
-    * or has characters that are not allowed.
-    */
+   * Retrieves the group id for a Maven dependency
+   * and returns an error if it is not formatted correctly
+   * or has characters that are not allowed.
+   */
   private def getGroupId(depName: String, p: Path): Result[String, ManifestError] = {
     depName.split(':') match {
       case Array(groupId, _) => checkNameCharacters(groupId, p)
@@ -330,10 +305,10 @@ object ManifestParser {
   }
 
   /**
-    * Retrieves the artifact id for a Maven dependency
-    * and returns an error if it is not formatted correctly
-    * or has characters that are not allowed.
-    */
+   * Retrieves the artifact id for a Maven dependency
+   * and returns an error if it is not formatted correctly
+   * or has characters that are not allowed.
+   */
   private def getArtifactId(depName: String, p: Path): Result[String, ManifestError] = {
     depName.split(':') match {
       case Array(_, artifactId) => checkNameCharacters(artifactId, p)
@@ -342,9 +317,111 @@ object ManifestParser {
   }
 
   /**
-    * Converts `depUrl` to a String and retrieves the URL for a jar dependency.
-    * Returns an error if it is not formatted correctly.
-    */
+   * A Maven version number is an uninterpreted tag. Maven (the repository) does not
+   * enforce a format for version numbers so we must be liberal about what we accept.
+   */
+  private def getMavenVersion(depVer: AnyRef, p: Path): Result[String, ManifestError] = {
+    try {
+      val version = depVer.asInstanceOf[String]
+      Ok(version)
+    } catch {
+      case e: ClassCastException =>
+        Err(ManifestError.DependencyFormatError(p, e.getMessage))
+    }
+  }
+
+  /**
+   * Create a [[FlixDependency]].
+   *
+   * @param deps   [[TomlTable]] of declared Flix dependencies.
+   * @param depKey Repository address of the package.
+   * @param p      [[Path]] of the project Toml file.
+   * @return [[Result]] of the [[FlixDependency]] if succesful, otherwise a [[ManifestError]]
+   */
+  private def createFlixDep(deps: TomlTable, depKey: String, p: Path): Result[FlixDependency, ManifestError] = {
+    // Regex for extracting repository, username, and project name.
+    // (.+) is a capturing group, where . matches any character.
+    val validPkg = s"^\"(.+):(.+)/(.+)\"$$".r
+    depKey match {
+      case validPkg(repoStr, username, projectName) =>
+        val repo = Repository.mkRepository(repoStr) match {
+          case Ok(r) => r
+          case Err(_) => return Err(ManifestError.UnsupportedRepository(p, repoStr))
+        }
+
+        if (!username.matches(s"^$ValidName$$"))
+          return Err(ManifestError.IllegalName(p, depKey))
+
+        if (!projectName.matches(s"^$ValidName$$"))
+          return Err(ManifestError.IllegalName(p, depKey))
+
+        if (deps.isString(depKey)) {
+          getFlixVersion(deps, depKey, p).flatMap(
+            Dependency.FlixDependency(repo, username, projectName, _, Nil).toOk
+          )
+        } else if (deps.isTable(depKey)) {
+          val depTbl = deps.getTable(depKey)
+          val verKey = "version"
+          val permKey = "permissions"
+          if (!depTbl.isString(verKey)) {
+            return Err(ManifestError.VersionTypeError(Option.apply(p), depKey, depTbl.get(verKey)))
+          }
+          if (!depTbl.isArray(permKey)) {
+            return Err(ManifestError.FlixDependencyPermissionTypeError(Option.apply(p), depKey, depTbl.get(permKey)))
+          }
+          for (
+            ver <- getFlixVersion(depTbl, verKey, p);
+            perm <- getPermissions(depTbl, permKey, p)
+          ) yield FlixDependency(repo, username, projectName, ver, perm)
+        } else {
+          Err(ManifestError.VersionTypeError(Option.apply(p), depKey, deps.get(depKey)))
+        }
+      case _ => Err(ManifestError.FlixDependencyFormatError(p, depKey))
+    }
+  }
+
+  private def getFlixVersion(deps: TomlTable, depKey: String, p: Path): Result[SemVer, ManifestError] = {
+    val depVer = deps.getString(depKey)
+    SemVer.ofString(depVer) match {
+      case Some(v) => Ok(v)
+      case None => Err(ManifestError.FlixVersionFormatError(Some(p), depKey, depVer))
+    }
+  }
+
+  private def getPermissions(depTbl: TomlTable, key: String, p: Path): Result[List[Permission], ManifestError] = {
+    if (!depTbl.isArray(key)) {
+      val perms = depTbl.get(key)
+      return Err(ManifestError.FlixDependencyPermissionTypeError(Option.apply(p), key, perms))
+    }
+    val permArray = depTbl.getArray(key)
+    permArray.toList.asScala.toList.map({
+      case s: String => Permission.ofString(s) match {
+        case Some(p) => p
+        case None => return Err(ManifestError.FlixUnknownPermissionError(p, key, s))
+      }
+      case _ => return Err(ManifestError.FlixDependencyPermissionTypeError(Option.apply(p), key, permArray))
+    }).toOk
+  }
+
+  /**
+   * Creates a JarDependency.
+   * URL and website is given by `depUrl`.
+   * The file name is given by `depName`.
+   * `p` is for reporting errors.
+   */
+  private def createJarDep(depName: String, depUrl: AnyRef, p: Path): Result[JarDependency, ManifestError] = {
+    for (
+      url <- getUrl(depUrl, p);
+      fileName <- getFileName(depName, p)
+    ) yield {
+      Dependency.JarDependency(url, fileName)
+    }
+  }
+
+  /**
+   * Converts `depUrl` to a String and retrieves the URL for a jar dependency.
+   * Returns an error if it is not formatted correctly.
+   */
   private def getUrl(depUrl: AnyRef, p: Path): Result[URL, ManifestError] = {
     try {
       val url = depUrl.asInstanceOf[String]
@@ -367,19 +444,19 @@ object ManifestParser {
   }
 
   /**
-    * Retrieves the file name for a jar dependency
-    * and returns an error if it is not formatted correctly
-    * or has characters that are not allowed.
-    */
+   * Retrieves the file name for a jar dependency
+   * and returns an error if it is not formatted correctly
+   * or has characters that are not allowed.
+   */
   private def getFileName(depName: String, p: Path): Result[String, ManifestError] = {
     val split = depName.split('.')
-    if(split.length >= 2) {
-      val extension = split.apply(split.length-1)
+    if (split.length >= 2) {
+      val extension = split.apply(split.length - 1)
       if (extension == "jar") {
-          checkNameCharacters(depName, p)
-        } else {
-          Err(ManifestError.JarUrlExtensionError(p, depName, extension))
-        }
+        checkNameCharacters(depName, p)
+      } else {
+        Err(ManifestError.JarUrlExtensionError(p, depName, extension))
+      }
     } else {
       Err(ManifestError.JarUrlFileNameError(p, depName))
     }
@@ -387,142 +464,19 @@ object ManifestParser {
   }
 
   /**
-    * Converts `depVer` to a String and then to a semantic version
-    * and returns an error if `depVer` is not of the correct format.
-    */
-  def getFlixVersion(depVer: AnyRef, p: Path): Result[SemVer, ManifestError] = {
-    try {
-      toFlixVer(depVer.asInstanceOf[String], p)
-    } catch {
-      case e: ClassCastException =>
-        Err(ManifestError.DependencyFormatError(p, e.getMessage))
-    }
-  }
-
-  /**
-    * A Maven version number is an uninterpreted tag. Maven (the repository) does not
-    * enforce a format for version numbers so we must be liberal about what we accept.
-    */
-  private def getMavenVersion(depVer: AnyRef, p: Path): Result[String, ManifestError] = {
-    try {
-      val version = depVer.asInstanceOf[String]
-      Ok(version)
-    } catch {
-      case e: ClassCastException =>
-        Err(ManifestError.DependencyFormatError(p, e.getMessage))
-    }
-  }
-
-  /**
-    * Creates a MavenDependency.
-    * Group id and artifact id are given by `depName`.
-    * The version is given by `depVer`.
-    * `p` is for reporting errors.
-    */
-  private def createMavenDep(depName: String, depVer: AnyRef, p: Path): Result[MavenDependency, ManifestError] = {
-    for(
-      groupId <- getGroupId(depName, p);
-      artifactId <- getArtifactId(depName, p);
-      version <- getMavenVersion(depVer, p)
-    ) yield {
-        Dependency.MavenDependency(groupId, artifactId, version)
-    }
-  }
-
-  /**
-   * Create a [[FlixDependency]].
-   * @param deps [[TomlTable]] of declared Flix dependencies.
-   * @param depKey Repository address of the package.
-   * @param p [[Path]] of the project Toml file.
-   * @return [[Result]] of the [[FlixDependency]] if succesful, otherwise a [[ManifestError]]
+   * Checks that a package name does not include any illegal characters.
    */
-  private def createFlixDep(deps: TomlTable, depKey: String, p: Path): Result[FlixDependency, ManifestError] = {
-    // Regex for extracting repository, username, and project name.
-    // (.+) is a capturing group, where . matches any character.
-    val validPkg = s"^\"(.+):(.+)/(.+)\"$$".r
-    depKey match {
-      case validPkg(repoStr, username, projectName) =>
-        val repo = Repository.mkRepository(repoStr) match {
-          case Ok(r) => r
-          case Err(_) => return Err(ManifestError.UnsupportedRepository(p, repoStr))
-        }
-
-        if (!username.matches(s"^$ValidName$$"))
-          return Err(ManifestError.IllegalName(p, depKey))
-
-        if (!projectName.matches(s"^$ValidName$$"))
-          return Err(ManifestError.IllegalName(p, depKey))
-
-        if (deps.isString(depKey)) {
-          for (ver <- getFlixVersion(deps, depKey, p))
-            yield Dependency.FlixDependency(repo, username, projectName, ver, List())
-        } else if (deps.isTable(depKey)) {
-          val depTbl = deps.getTable(depKey)
-          val verKey = "version"
-          val permKey = "permissions"
-          if (!depTbl.isString(verKey)) {
-            val typ = depTbl.get(verKey).getClass
-            return Err(ManifestError.DependencyFormatError(p, s"Flix dependency error: expected String but received $typ"))
-          }
-          if (!depTbl.isArray(permKey)) {
-            val typ = depTbl.get(permKey).getClass
-            return Err(ManifestError.DependencyFormatError(p, s"Flix dependency error: expected String but received $typ"))
-          }
-          getFlixVersion(depTbl, verKey, p)
-          for (
-            ver <- getFlixVersion(depTbl, verKey, p);
-            perm <- getPermissions(depTbl, permKey, p)
-          ) yield FlixDependency(repo, username, projectName, ver, perm)
-        } else {
-          val typ = deps.get(depKey).getClass
-          Err(ManifestError.DependencyFormatError(p, s"Flix dependency error: expected String but received $typ"))
-        }
-      case _ => Err(ManifestError.FlixDependencyFormatError(p, depKey))
-    }
-  }
-
-  private def getFlixVersion(deps: TomlTable, depKey: String, p: Path): Result[SemVer, ManifestError] = {
-    val depVer = deps.getString(depKey)
-    SemVer.ofString(depVer) match {
-      case Some(v) => Ok(v)
-      case None => Err(ManifestError.FlixVersionFormatError(Some(p), depKey, depVer))
-    }
-  }
-
-  private def getPermissions(depTbl: TomlTable, key: String, p: Path): Result[List[Permission], ManifestError] = {
-    if (!depTbl.isArray(key)) {
-      val perms = depTbl.get(key)
-      return Err(ManifestError.FlixDependencyPermissionTypeError(p, key, perms))
-    }
-    val permArray = depTbl.getArray(key)
-    permArray.toList.asScala.toList.map({
-      case s: String => Permission.ofString(s) match {
-        case Some(p) => p
-        case None => return Err(ManifestError.FlixUnknownPermissionError(p, key, s))
-      }
-      case _ => return Err(ManifestError.FlixDependencyPermissionTypeError(p, key, permArray))
-    }).toOk
+  private def checkNameCharacters(name: String, p: Path): Result[String, ManifestError] = {
+    if (name.matches("^[a-zA-Z0-9.:/_-]+$"))
+      Ok(name)
+    else
+      Err(ManifestError.IllegalName(p, name))
   }
 
   /**
-    * Creates a JarDependency.
-    * URL and website is given by `depUrl`.
-    * The file name is given by `depName`.
-    * `p` is for reporting errors.
-    */
-  private def createJarDep(depName: String, depUrl: AnyRef, p: Path): Result[JarDependency, ManifestError] = {
-    for (
-      url <- getUrl(depUrl, p);
-      fileName <- getFileName(depName, p)
-    ) yield {
-      Dependency.JarDependency(url, fileName)
-    }
-  }
-
-  /**
-    * Converts a TomlArray to a list of Strings. Returns
-    * an error if anything in the array is not a String.
-    */
+   * Converts a TomlArray to a list of Strings. Returns
+   * an error if anything in the array is not a String.
+   */
   private def convertTomlArrayToStringList(array: TomlArray, p: Path): Result[List[String], ManifestError] = {
     array.toList.asScala.toList.map({
       case s: String => s
@@ -531,8 +485,8 @@ object ManifestParser {
   }
 
   /**
-    * Creates the `PackageModules` object from `optList`.
-    */
+   * Creates the `PackageModules` object from `optList`.
+   */
   private def toPackageModules(optList: Option[List[String]], p: Path): Result[PackageModules, ManifestError] = {
     optList match {
       case None =>
@@ -544,16 +498,6 @@ object ManifestParser {
         }.toSet
         Ok(PackageModules.Selected(moduleSet))
     }
-  }
-
-  /**
-    * Checks that a package name does not include any illegal characters.
-    */
-  private def checkNameCharacters(name: String, p: Path): Result[String, ManifestError] = {
-    if(name.matches("^[a-zA-Z0-9.:/_-]+$"))
-      Ok(name)
-    else
-      Err(ManifestError.IllegalName(p, name))
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
@@ -30,30 +30,25 @@ sealed trait PackageError {
 object PackageError {
   case class VersionDoesNotExist(version: SemVer, project: Project) extends PackageError {
     override def message(f: Formatter): String =
-      s"""
-         |Version ${f.bold(version.toString)} does not exist for project ${f.bold(project.toString)}
-         |""".stripMargin
+      s"Version ${f.bold(version.toString)} does not exist for project ${f.bold(project.toString)}"
   }
 
   case class InvalidProjectName(projectString: String) extends PackageError {
     override def message(f: Formatter): String =
-      s"""
-         |A GitHub project should be formatted like so: 'owner/repository'.
+      s"""A GitHub project should be formatted like so: 'owner/repository'.
          |Instead found: ${f.red(projectString)}.
          |""".stripMargin
   }
 
   case class NoReleasesFound(project: Project) extends PackageError {
     override def message(f: Formatter): String =
-      s"""
-         |No releases found for project ${f.bold(project.toString)}.
+      s"""No releases found for project ${f.bold(project.toString)}.
          |""".stripMargin
   }
 
   case class ProjectNotFound(url: URL, project: Project) extends PackageError {
     override def message(f: Formatter): String =
-      s"""
-         |An I/O error occurred while trying to read the following url:
+      s"""An I/O error occurred while trying to read the following url:
          |${f.cyan(url.toString)}
          |Project: ${f.bold(project.toString)}
          |""".stripMargin
@@ -61,8 +56,7 @@ object PackageError {
 
   case class JsonError(json: String, project: Project) extends PackageError {
     override def message(f: Formatter): String =
-      s"""
-         |An error occurred while trying to parse the following as JSON:
+      s"""An error occurred while trying to parse the following as JSON:
          |${f.cyan(json)}
          |Project: ${f.bold(project.toString)}
          |""".stripMargin
@@ -70,8 +64,7 @@ object PackageError {
 
   case class DownloadError(asset: Asset, message: Option[String]) extends PackageError {
     override def message(f: Formatter): String =
-      s"""
-         |A download error occurred while downloading ${f.bold(asset.name)}
+      s"""A download error occurred while downloading ${f.bold(asset.name)}
          |${
          message match {
            case Some(e) => e
@@ -82,8 +75,7 @@ object PackageError {
 
   case class DownloadErrorJar(url: String, fileName: String, message: Option[String]) extends PackageError {
     override def message(f: Formatter): String =
-      s"""
-         |A download error occurred while downloading ${f.bold(fileName)} from $url
+      s"""A download error occurred while downloading ${f.bold(fileName)} from $url
          |${
         message match {
           case Some(e) => e
@@ -95,23 +87,20 @@ object PackageError {
 
   case class CoursierError(errorMsg: String) extends PackageError {
     override def message(f: Formatter): String =
-      s"""
-         |An error occurred with Coursier:
+      s"""An error occurred with Coursier:
          |$errorMsg
          |""".stripMargin
   }
 
   case class NoSuchFile(project: String, extension: String) extends PackageError {
     override def message(f: Formatter): String =
-      s"""
-         |There are no files in project '${f.bold(project)}' with extension '${f.bold(s".$extension")}'.
+      s"""There are no files in project '${f.bold(project)}' with extension '${f.bold(s".$extension")}'.
          |""".stripMargin
   }
 
   case class TooManyFiles(project: String, extension: String) extends PackageError {
     override def message(f: Formatter): String =
-      s"""
-         |There are too many files in project '${f.bold(project)}' with extension '${f.bold(s".$extension")}'.
+      s"""There are too many files in project '${f.bold(project)}' with extension '${f.bold(s".$extension")}'.
          |There should only be one $extension file in each project.
          |""".stripMargin
   }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/Permission.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/Permission.scala
@@ -43,7 +43,7 @@ object Permission {
     override def toString: String = "unchecked-cast"
   }
 
-  def ofString(s: String): Option[Permission] = s match {
+  def mkPermission(s: String): Option[Permission] = s match {
     case "java-interop" => Some(JavaInterop)
     case "unchecked-cast" => Some(UncheckedCast)
     case "effect" => Some(Effect)

--- a/main/src/ca/uwaterloo/flix/tools/pkg/Permission.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/Permission.scala
@@ -17,23 +17,35 @@ package ca.uwaterloo.flix.tools.pkg
 
 sealed trait Permission
 
+/**
+ * Permissions for dependencies.
+ */
 object Permission {
 
-  case object JavaInterop extends Permission {
-    override def toString: String = "java-interop"
-  }
-
-  case object UnsafeCast extends Permission {
-    override def toString: String = "unsafe-cast"
-  }
-
+  /**
+   * Permission to have an effect.
+   */
   case object Effect extends Permission {
     override def toString: String = "effect"
   }
 
+  /**
+   * Permission to call Java libraries.
+   */
+  case object JavaInterop extends Permission {
+    override def toString: String = "java-interop"
+  }
+
+  /**
+   * Permission to use unchecked casts.
+   */
+  case object UncheckedCast extends Permission {
+    override def toString: String = "unchecked-cast"
+  }
+
   def ofString(s: String): Option[Permission] = s match {
     case "java-interop" => Some(JavaInterop)
-    case "unsafe-cast" => Some(UnsafeCast)
+    case "unchecked-cast" => Some(UncheckedCast)
     case "effect" => Some(Effect)
     case _ => None
   }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/Permission.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/Permission.scala
@@ -4,16 +4,22 @@ sealed trait Permission
 
 object Permission {
 
-  case object JavaInterop extends Permission
+  case object JavaInterop extends Permission {
+    override def toString: String = "java-interop"
+  }
 
-  case object UnsafeCast extends Permission
+  case object UnsafeCast extends Permission {
+    override def toString: String = "unsafe-cast"
+  }
 
-  case object Effect extends Permission
+  case object Effect extends Permission {
+    override def toString: String = "effect"
+  }
 
   def ofString(s: String): Option[Permission] = s match {
     case "java-interop" => Some(JavaInterop)
-    case "unsafe-cast"  => Some(UnsafeCast)
-    case "effect"       => Some(Effect)
-    case _              => None
+    case "unsafe-cast" => Some(UnsafeCast)
+    case "effect" => Some(Effect)
+    case _ => None
   }
 }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/Permission.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/Permission.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 Andreas Stenbæk Larsen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ca.uwaterloo.flix.tools.pkg
 
 sealed trait Permission

--- a/main/src/ca/uwaterloo/flix/tools/pkg/Permission.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/Permission.scala
@@ -1,0 +1,19 @@
+package ca.uwaterloo.flix.tools.pkg
+
+sealed trait Permission
+
+object Permission {
+
+  case object JavaInterop extends Permission
+
+  case object UnsafeCast extends Permission
+
+  case object Effect extends Permission
+
+  def ofString(s: String): Option[Permission] = s match {
+    case "java-interop" => Some(JavaInterop)
+    case "unsafe-cast"  => Some(UnsafeCast)
+    case "effect"       => Some(Effect)
+    case _              => None
+  }
+}

--- a/main/src/ca/uwaterloo/flix/tools/pkg/Repository.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/Repository.scala
@@ -18,5 +18,10 @@ package ca.uwaterloo.flix.tools.pkg
 sealed trait Repository
 
 object Repository {
+  def ofString(s: String): Option[Repository] = s match {
+    case "github" => Some(Repository.GitHub)
+    case _ => None
+  }
+
   case object GitHub extends Repository
 }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/RepositoryError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/RepositoryError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Magnus Madsen
+ * Copyright 2024 Andreas Stenbæk Larsen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,23 +15,8 @@
  */
 package ca.uwaterloo.flix.tools.pkg
 
-import ca.uwaterloo.flix.util.Result
-import ca.uwaterloo.flix.util.Result.{Err, Ok}
+sealed trait RepositoryError
 
-sealed trait Repository
-
-object Repository {
-
-  /**
-   * Convert a [[String]] into a [[Repository]].
-   */
-  def mkRepository(s: String): Result[Repository, RepositoryError] = s match {
-    case "github" => Ok(Repository.GitHub)
-    case _ => Err(RepositoryError.UnsupportedRepositoryError(s))
-  }
-
-  /**
-   * A GitHub repository.
-   */
-  case object GitHub extends Repository
+object RepositoryError {
+  case class UnsupportedRepositoryError(s: String) extends RepositoryError
 }

--- a/main/src/ca/uwaterloo/flix/tools/pkg/SemVer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/SemVer.scala
@@ -25,7 +25,7 @@ object SemVer {
       .orElseBy(_.minor)
       .orElseBy(_.patch)
 
-  def parse(input: String): Option[SemVer] = {
+  def ofString(input: String): Option[SemVer] = {
     val numPattern = raw"0|[1-9]\d*".r
     val pattern = raw"^($numPattern)\.($numPattern)\.($numPattern)$$".r
     input match {

--- a/main/src/ca/uwaterloo/flix/tools/pkg/SemVer.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/SemVer.scala
@@ -25,6 +25,15 @@ object SemVer {
       .orElseBy(_.minor)
       .orElseBy(_.patch)
 
+  def parse(input: String): Option[SemVer] = {
+    val numPattern = raw"0|[1-9]\d*".r
+    val pattern = raw"^($numPattern)\.($numPattern)\.($numPattern)$$".r
+    input match {
+      case pattern(major, minor, patch) =>
+        Some(SemVer(major.toInt, minor.toInt, patch.toInt))
+      case _ => None
+    }
+  }
 }
 
 /**

--- a/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
@@ -1072,7 +1072,7 @@ class TestManifestParser extends AnyFunSuite {
     expectError[ManifestError.IllegalName](result)
   }
 
-  test("ManifestError.FlixVersionHasWrongLength.05") {
+  test("ManifestError.FlixVersionFormatError.01") {
     val toml = {
       """
         |[package]
@@ -1090,10 +1090,10 @@ class TestManifestParser extends AnyFunSuite {
         |""".stripMargin
     }
     val result = ManifestParser.parse(toml, null)
-    expectError[ManifestError.FlixVersionHasWrongLength](result)
+    expectError[ManifestError.FlixVersionFormatError](result)
   }
 
-  test("ManifestError.FlixVersionHasWrongLength.06") {
+  test("ManifestError.FlixVersionFormatError.02") {
     val toml = {
       """
         |[package]
@@ -1111,7 +1111,7 @@ class TestManifestParser extends AnyFunSuite {
         |""".stripMargin
     }
     val result = ManifestParser.parse(toml, null)
-    expectError[ManifestError.FlixVersionHasWrongLength](result)
+    expectError[ManifestError.FlixVersionFormatError](result)
   }
 
   test("ManifestError.FlixDependencyFormatError.01") {
@@ -1156,7 +1156,7 @@ class TestManifestParser extends AnyFunSuite {
     expectError[ManifestError.FlixDependencyFormatError](result)
   }
 
-  test("ManifestError.VersionNumberWrong.07") {
+  test("ManifestError.FlixVersionFormatError.03") {
     val toml = {
       """
         |[package]
@@ -1174,10 +1174,10 @@ class TestManifestParser extends AnyFunSuite {
         |""".stripMargin
     }
     val result = ManifestParser.parse(toml, null)
-    expectError[ManifestError.VersionNumberWrong](result)
+    expectError[ManifestError.FlixVersionFormatError](result)
   }
 
-  test("ManifestError.VersionNumberWrong.08") {
+  test("ManifestError.FlixVersionFormatError.04") {
     val toml = {
       """
         |[package]
@@ -1195,10 +1195,10 @@ class TestManifestParser extends AnyFunSuite {
         |""".stripMargin
     }
     val result = ManifestParser.parse(toml, null)
-    expectError[ManifestError.VersionNumberWrong](result)
+    expectError[ManifestError.FlixVersionFormatError](result)
   }
 
-  test("ManifestError.VersionNumberWrong.09") {
+  test("ManifestError.FlixVersionFormatError.05") {
     val toml = {
       """
         |[package]
@@ -1216,7 +1216,7 @@ class TestManifestParser extends AnyFunSuite {
         |""".stripMargin
     }
     val result = ManifestParser.parse(toml, null)
-    expectError[ManifestError.VersionNumberWrong](result)
+    expectError[ManifestError.FlixVersionFormatError](result)
   }
 
   //Mvn-dependencies

--- a/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
@@ -1035,7 +1035,7 @@ class TestManifestParser extends AnyFunSuite {
         |""".stripMargin
     }
     val result = ManifestParser.parse(toml, null)
-    expectError[ManifestError.DependencyFormatError](result)
+    expectError[ManifestError.VersionTypeError](result)
   }
 
   test("ManifestError.IllegalTableFound.01") {

--- a/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
@@ -187,8 +187,8 @@ class TestManifestParser extends AnyFunSuite {
   }
 
   test("Ok.dependencies") {
-    assertResult(expected = List(Dependency.FlixDependency(Repository.GitHub, "jls", "tic-tac-toe", SemVer(1, 2, 3)),
-                                 Dependency.FlixDependency(Repository.GitHub, "mlutze", "flixball", SemVer(3, 2, 1)),
+    assertResult(expected = List(Dependency.FlixDependency(Repository.GitHub, "jls", "tic-tac-toe", SemVer(1, 2, 3), None),
+                                 Dependency.FlixDependency(Repository.GitHub, "mlutze", "flixball", SemVer(3, 2, 1), None),
                                  Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3.4"),
                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "4.7.0-M1"),
                                  Dependency.JarDependency(new URI("https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar").toURL, "myJar.jar")))(actual = {

--- a/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
@@ -188,8 +188,8 @@ class TestManifestParser extends AnyFunSuite {
   }
 
   test("Ok.dependencies") {
-    assertResult(expected = List(Dependency.FlixDependency(Repository.GitHub, "jls", "tic-tac-toe", SemVer(1, 2, 3), List()),
-                                 Dependency.FlixDependency(Repository.GitHub, "mlutze", "flixball", SemVer(3, 2, 1), List()),
+    assertResult(expected = List(Dependency.FlixDependency(Repository.GitHub, "jls", "tic-tac-toe", SemVer(1, 2, 3), Nil),
+                                 Dependency.FlixDependency(Repository.GitHub, "mlutze", "flixball", SemVer(3, 2, 1), Nil),
                                  Dependency.MavenDependency("org.postgresql", "postgresql", "1.2.3.4"),
                                  Dependency.MavenDependency("org.eclipse.jetty", "jetty-server", "4.7.0-M1"),
                                  Dependency.JarDependency(new URI("https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar").toURL, "myJar.jar")))(actual = {

--- a/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestManifestParser.scala
@@ -331,10 +331,10 @@ class TestManifestParser extends AnyFunSuite {
         |authors = ["John Doe <john@example.com>"]
         |
         |[dependencies]
-        |"github:jls/tic-tac-toe" = { version = "1.2.3", permissions = ["java-interop", "unsafe-cast", "effect"] }
+        |"github:jls/tic-tac-toe" = { version = "1.2.3", permissions = ["java-interop", "unchecked-cast", "effect"] }
         |""".stripMargin
     }
-    assertResult(expected = Set(Permission.JavaInterop, Permission.UnsafeCast, Permission.Effect))(actual =
+    assertResult(expected = Set(Permission.JavaInterop, Permission.UncheckedCast, Permission.Effect))(actual =
       ManifestParser.parse(toml, null) match {
         case Ok(m) =>
           m.dependencies

--- a/main/test/ca/uwaterloo/flix/tools/TestPermission.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestPermission.scala
@@ -6,7 +6,7 @@ import ca.uwaterloo.flix.tools.pkg.Permission
 class TestPermission extends AnyFunSuite{
   test("toString-ofString-java-interop") {
     val perm = Permission.JavaInterop
-    val res = Permission.ofString(perm.toString) match {
+    val res = Permission.mkPermission(perm.toString) match {
       case Some(r) => r
       case None => fail()
     }
@@ -14,8 +14,8 @@ class TestPermission extends AnyFunSuite{
   }
 
   test("toString-ofString-unsafe-cast") {
-    val perm = Permission.UnsafeCast
-    val res = Permission.ofString(perm.toString) match {
+    val perm = Permission.UncheckedCast
+    val res = Permission.mkPermission(perm.toString) match {
       case Some(r) => r
       case None => fail()
     }
@@ -24,7 +24,7 @@ class TestPermission extends AnyFunSuite{
 
   test("toString-ofString-effect") {
     val perm = Permission.Effect
-    val res = Permission.ofString((perm.toString)) match {
+    val res = Permission.mkPermission((perm.toString)) match {
       case Some(r) => r
       case None => fail()
     }

--- a/main/test/ca/uwaterloo/flix/tools/TestPermission.scala
+++ b/main/test/ca/uwaterloo/flix/tools/TestPermission.scala
@@ -1,0 +1,33 @@
+package ca.uwaterloo.flix.tools
+
+import org.scalatest.funsuite.AnyFunSuite
+import ca.uwaterloo.flix.tools.pkg.Permission
+
+class TestPermission extends AnyFunSuite{
+  test("toString-ofString-java-interop") {
+    val perm = Permission.JavaInterop
+    val res = Permission.ofString(perm.toString) match {
+      case Some(r) => r
+      case None => fail()
+    }
+    assertResult(perm)(res)
+  }
+
+  test("toString-ofString-unsafe-cast") {
+    val perm = Permission.UnsafeCast
+    val res = Permission.ofString(perm.toString) match {
+      case Some(r) => r
+      case None => fail()
+    }
+    assertResult(perm)(res)
+  }
+
+  test("toString-ofString-effect") {
+    val perm = Permission.Effect
+    val res = Permission.ofString((perm.toString)) match {
+      case Some(r) => r
+      case None => fail()
+    }
+    assertResult(perm)(res)
+  }
+}

--- a/main/test/ca/uwaterloo/flix/tools/ToolsSuite.scala
+++ b/main/test/ca/uwaterloo/flix/tools/ToolsSuite.scala
@@ -4,6 +4,7 @@ import org.scalatest.Suites
 
 class ToolsSuite extends Suites(
   new TestBootstrap,
+  new TestPermission,
   new TestManifestParser
 ) {
   /* left empty */


### PR DESCRIPTION
#7753
Added support for permission to `toml` files.

Is this along the lines of what we want?