### PR TITLE
refactor: switch from `Hash` symbol to `Currency` symbol for `InvokeMethod2`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -50,6 +50,7 @@ sealed trait TokenKind {
       case TokenKind.Comma => "','"
       case TokenKind.CurlyL => "'{'"
       case TokenKind.CurlyR => "'}'"
+      case TokenKind.Currency => "'¤'"
       case TokenKind.Dollar => "'$'"
       case TokenKind.Dot => "'.'"
       case TokenKind.DotWhiteSpace => "'. '"
@@ -644,6 +645,8 @@ object TokenKind {
   case object CurlyL extends TokenKind
 
   case object CurlyR extends TokenKind
+
+  case object Currency extends TokenKind
 
   case object Dollar extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -329,6 +329,7 @@ object Lexer {
       case _ if isMatch("#{") => TokenKind.HashCurlyL
       case _ if isMatch("#(") => TokenKind.HashParenL
       case '#' => TokenKind.Hash
+      case '¤' => TokenKind.Currency
       case _ if isMatch("//") => acceptLineOrDocComment()
       case _ if isMatch("/*") => acceptBlockComment()
       case '/' => TokenKind.Slash

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1465,7 +1465,7 @@ object Parser2 {
              | TokenKind.LiteralRegex => literalExpr()
         case TokenKind.ParenL => parenOrTupleOrLambdaExpr()
         case TokenKind.Underscore => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else name(NAME_VARIABLE, context = SyntacticContext.Expr.OtherExpr)
-        case TokenKind.NameLowerCase if nth(1) == TokenKind.Hash => invokeMethod2Expr()
+        case TokenKind.NameLowerCase if nth(1) == TokenKind.Currency => invokeMethod2Expr()
         case TokenKind.NameLowerCase => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else name(NAME_FIELD, allowQualified = true, context = SyntacticContext.Expr.OtherExpr)
         case TokenKind.NameUpperCase
              | TokenKind.NameMath
@@ -2400,8 +2400,8 @@ object Parser2 {
       assert(at(TokenKind.NameLowerCase))
       val mark = open()
       name(Set(TokenKind.NameLowerCase), context = SyntacticContext.Expr.OtherExpr)
-      // TODO INTEROP emit an error if we are not at an hash here
-      while (eat(TokenKind.Hash)) {
+      // TODO INTEROP emit an error if we are not at a Java operator here
+      while (eat(TokenKind.Currency)) {
         val fragmentMark = open()
         name(Set(TokenKind.NameUpperCase, TokenKind.NameLowerCase), context = SyntacticContext.Expr.OtherExpr)
         arguments()

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1468,10 +1468,10 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |def main(): Unit \ IO =
         |    import java_new java.lang.StringBuilder(String): ##java.lang.StringBuilder \ IO as newSB;
         |    let a = testInvokeMethod2_01(newSB(""));
-        |    println(a#toString())
+        |    println(a¤toString())
         |
         |def testInvokeMethod2_01(sb: ##java.lang.StringBuilder): ##java.lang.StringBuilder \ IO =
-        |    sb#append(null)
+        |    sb¤append(null)
         |""".stripMargin
     val result = compile(input, Options.Default)
     expectError[TypeError.AmbiguousMethod](result)
@@ -1485,7 +1485,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
         |    testInvokeMethod2_01(newPS(""))
         |
         |def testInvokeMethod2_01(ps: ##java.io.PrintStream): Unit \ IO =
-        |    ps#println(null)
+        |    ps¤println(null)
         |""".stripMargin
     val result = compile(input, Options.Default)
     expectError[TypeError.AmbiguousMethod](result)

--- a/main/test/flix/Test.Exp.Jvm.InvokeMethod2.Chaining.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeMethod2.Chaining.flix
@@ -3,56 +3,56 @@ mod Test.Exp.Jvm.InvokeMethod2.Chaining {
     @test
     def testInvokeMethod2_01(): Bool \ IO =
         let obj = "HeLlO WoRlD";
-        obj#toUpperCase()#toLowerCase() == "hello world"
+        obj¤toUpperCase()¤toLowerCase() == "hello world"
 
     @test
     def testInvokeMethod2_02(): Bool \ IO =
         let obj = "hEllO WoRld";
-        obj#toLowerCase()#toUpperCase() == "HELLO WORLD"
+        obj¤toLowerCase()¤toUpperCase() == "HELLO WORLD"
 
     @test
     def testInvokeMethod2_03(): Bool \ IO =
         let obj = "hello world";
-        obj#substring(1, 11)#length() == 10
+        obj¤substring(1, 11)¤length() == 10
 
     @test
     def testInvokeMethod2_04(): Bool \ IO =
         let obj = "   hello world    ";
         let obj2 = "hello world";
-        obj#trim()#length() == obj2#length()
+        obj¤trim()¤length() == obj2¤length()
 
     @test
     def testInvokeMethod2_05(): Bool \ IO =
         let val = 123488ii;
-        val#modPow(10ii, 32023ii)#modInverse(4831ii) == 4493ii
+        val¤modPow(10ii, 32023ii)¤modInverse(4831ii) == 4493ii
 
     @test
     def testInvokeMethod2_06(): Bool \ IO =
         let val = 94832ii;
-        val#multiply(11ii)#negate() == -1043152ii
+        val¤multiply(11ii)¤negate() == -1043152ii
 
     @test
     def testInvokeMethod2_07(): Bool \ IO =
         let val = 324521ii;
-        val#shiftLeft(2)#max(1284ii)#modPow(1ii, 10ii) == 4ii
+        val¤shiftLeft(2)¤max(1284ii)¤modPow(1ii, 10ii) == 4ii
 
     @test
     def testInvokeMethod2_08(): Bool \ IO =
         let val = 9999.999999999ff;
-        val#max(9999.99999999ff)#min(12.4938ff) == 12.4938ff
+        val¤max(9999.99999999ff)¤min(12.4938ff) == 12.4938ff
 
     @test
     def testInvokeMethod2_09(): Bool \ IO =
         let val = -932983.1113ff;
-        val#multiply(1.049309ff)#negate() == 978987.5755350917ff
+        val¤multiply(1.049309ff)¤negate() == 978987.5755350917ff
 
     @test
     def testInvokeMethod2_10(): Bool \ IO =
         let val = 833.1ff;
-        val#pow(4)#pow(2)#pow(1) == 232047597200769719005766.94527841ff
+        val¤pow(4)¤pow(2)¤pow(1) == 232047597200769719005766.94527841ff
 
     @test
     def testInvokeMethod2_11(): Bool \ IO =
         let val = 9012111.9834ff;
-        val#remainder(429.01ff)#max(32ff) == 327.9234ff
+        val¤remainder(429.01ff)¤max(32ff) == 327.9234ff
 }

--- a/main/test/flix/Test.Exp.Jvm.InvokeMethod2.ZeroArg.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeMethod2.ZeroArg.flix
@@ -3,75 +3,75 @@ mod Test.Exp.Jvm.InvokeMethod2.ZeroArg {
     @test
     def testInvokeMethod2_01(): Bool \ IO =
         let obj = "HELLO WORLD";
-        obj#toLowerCase() == "hello world"
+        obj¤toLowerCase() == "hello world"
 
     @test
     def testInvokeMethod2_02(): Bool \ IO =
         let obj = "hello world";
-        obj#toUpperCase() == "HELLO WORLD"
+        obj¤toUpperCase() == "HELLO WORLD"
 
     @test
     def testInvokeMethod2_03(): Bool \ IO =
         let obj = "hello world";
-        obj#length() == 11
+        obj¤length() == 11
 
     @test
     def testInvokeMethod2_04(): Bool \ IO =
         let obj = "   hello world    ";
-        obj#trim() == "hello world"
+        obj¤trim() == "hello world"
 
     @test
     def testInvokeMethod2_05(): Bool \ IO =
         let obj = "hello world";
-        obj#intern() == obj
+        obj¤intern() == obj
 
     @test
     def testInvokeMethod2_6(): Bool \ IO =
         let val = 12093ii;
-        val#intValueExact() == 12093
+        val¤intValueExact() == 12093
 
     @test
     def testInvokeMethod2_7(): Bool \ IO =
         let val = -20938ii;
-        val#floatValue() == -20938f32
+        val¤floatValue() == -20938f32
 
     @test
     def testInvokeMethod2_8(): Bool \ IO =
         let val = 34882ii;
-        val#getLowestSetBit() == 1
+        val¤getLowestSetBit() == 1
 
     @test
     def testInvokeMethod2_9(): Bool \ IO =
         let val = 2384721ii;
-        val#bitCount() == 9
+        val¤bitCount() == 9
 
     @test
     def testInvokeMethod2_10(): Bool \ IO =
         let val = -32ii;
-        val#abs() == 32ii
+        val¤abs() == 32ii
 
     @test
     def testInvokeMethod2_11(): Bool \ IO =
         let val = -123.45ff;
-        val#abs() == 123.45ff
+        val¤abs() == 123.45ff
 
     @test
     def testInvokeMethod2_12(): Bool \ IO =
         let val = 12443.1489ff;
-        val#precision() == 9
+        val¤precision() == 9
 
     @test
     def testInvokeMethod2_13(): Bool \ IO =
         let val = -50.000001ff;
-        val#plus() == -50.000001ff
+        val¤plus() == -50.000001ff
 
     @test
     def testInvokeMethod2_14(): Bool \ IO =
         let val = 23984.1119ff;
-        val#doubleValue() == 23984.1119f64
+        val¤doubleValue() == 23984.1119f64
 
     @test
     def testInvokeMethod2_15(): Bool \ IO =
         let val = 57842.0109ff;
-        val#floatValue() == 57842.0109f32
+        val¤floatValue() == 57842.0109f32
 }

--- a/main/test/flix/Test.Exp.Jvm.InvokeMethod2.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeMethod2.flix
@@ -3,67 +3,67 @@ mod Test.Exp.Jvm.InvokeMethod2 {
    @test
    def testInvokeMethod2_01(): Bool \ IO =
        let obj = "HELLO WORLD";
-       obj#indexOf("E") == 1
+       obj¤indexOf("E") == 1
 
    @test
    def testInvokeMethod2_02(): Bool \ IO =
        let obj = "HELLO WORLD";
-       obj#indexOf("W", 5) == 6
+       obj¤indexOf("W", 5) == 6
 
    @test
    def testInvokeMethod2_03(): Bool \ IO =
        let obj = "HELLO WORLD";
-       obj#indexOf("W", 7) == -1
+       obj¤indexOf("W", 7) == -1
 
    @test
    def testInvokeMethod2_04(): Bool \ IO =
        let obj = "HELLO WORLD";
-       obj#charAt(3) == 'L'
+       obj¤charAt(3) == 'L'
 
    @test
    def testInvokeMethod2_05(): Bool \ IO =
        let val = -32ii;
-       val#add(500ii) == 468ii
+       val¤add(500ii) == 468ii
 
    @test
    def testInvokeMethod2_06(): Bool \ IO =
        let val = 500ii;
-       val#compareTo(-80ii) == 1
+       val¤compareTo(-80ii) == 1
 
    // TODO: this test doesn't pass because of keyword ambiguity
    //@test
    //def testInvokeMethod2_07(): Bool \ IO =
    //    let val = 150ii;
-   //    val#and(-100ii) == 148ii
+   //    val¤and(-100ii) == 148ii
 
    // TODO: this doesn't pass for the same reason as and method
    // @test
    // def testInvokeMethod2_08(): Bool \ IO =
    //    let val = 123488ii;
-   //    val#mod(23ii) == 1
+   //    val¤mod(23ii) == 1
 
    @test
    def testInvokeMethod2_09(): Bool \ IO =
        let val = 123488ii;
-       val#modPow(10ii, 32023ii) == 8247ii
+       val¤modPow(10ii, 32023ii) == 8247ii
 
    @test
    def testInvokeMethod2_10(): Bool \ IO =
        let val = 9999.999999999ff;
-       val#max(9999.99999999ff) == 9999.999999999ff
+       val¤max(9999.99999999ff) == 9999.999999999ff
 
    @test
    def testInvokeMethod2_11(): Bool \ IO =
        let val = -98432.23ff;
-       val#multiply(42.15ff) == -4148918.4945ff
+       val¤multiply(42.15ff) == -4148918.4945ff
 
    @test
    def testInvokeMethod2_12(): Bool \ IO =
        let val = 9834.003001ff;
-       val#pow(4) == 9352362803567718.561955395843171390012001ff
+       val¤pow(4) == 9352362803567718.561955395843171390012001ff
 
    @test
    def testInvokeMethod2_13(): Bool \ IO =
        let val = 9012111.9834ff;
-       val#remainder(429.01ff) == 327.9234ff
+       val¤remainder(429.01ff) == 327.9234ff
 }


### PR DESCRIPTION
Part of #7834.