### PR TITLE
refactor: explicit effect up casting

### DIFF
--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -595,21 +595,21 @@ mod MutMap {
     ///
     pub def iterator(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[(k, v), r1 + r2, r1] \ { r1, r2 } =
         let MutMap(_, mm) = m;
-        Map.iterator(rc, deref mm) |> Iterator.map(x -> { discard deref mm; x })
+        Map.iterator(rc, deref mm) |> Iterator.map(eidentity)
 
     ///
     /// Returns an iterator over keys in `m`.
     ///
     pub def iteratorKeys(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[k, r1 + r2, r1] \ { r1, r2 } =
         let MutMap(_, mm) = m;
-        Map.iteratorKeys(rc, deref mm) |> Iterator.map(x -> { discard deref mm; x })
+        Map.iteratorKeys(rc, deref mm) |> Iterator.map(eidentity)
 
     ///
     /// Returns an iterator over values in `m`.
     ///
     pub def iteratorValues(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[v, r1 + r2, r1] \ { r1, r2 } =
         let MutMap(_, mm) = m;
-        Map.iteratorValues(rc, deref mm) |> Iterator.map(x -> { discard deref mm; x })
+        Map.iteratorValues(rc, deref mm) |> Iterator.map(eidentity)
 
     ///
     /// Extracts a range of key-value pairs from the mutable map `m`.

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -403,7 +403,7 @@ mod MutSet {
     ///
     pub def iterator(rc: Region[r1], s: MutSet[a, r2]): Iterator[a, r1 + r2, r1] \ { r1, r2 } =
         let MutSet(_, ms) = s;
-        Set.iterator(rc, deref ms) |> Iterator.map(x -> { discard deref ms; x })
+        Set.iterator(rc, deref ms) |> Iterator.map(eidentity)
 
     ///
     /// Returns an enumerator over `s`.


### PR DESCRIPTION
notice that actually here you would like to have sub-effecting on the structure itself, i.e. `Iterator[a, b, c] <: Iterato[a, d, e]` if `b <: d` and `c <: e`