### PR TITLE
refactor: remove `unchecked_cast`s

### DIFF
--- a/main/src/library/Adaptor.flix
+++ b/main/src/library/Adaptor.flix
@@ -142,7 +142,7 @@ mod Adaptor {
     ///
     pub def fromStreamToIterator(rc: Region[r], proxy: Proxy[a], strm: ##java.util.stream.Stream): Iterator[a, r, r] =
         import java.util.stream.BaseStream.iterator(): ##java.util.Iterator \ {};
-        let iter = iterator(unchecked_cast(strm as ##java.util.stream.BaseStream));
+        let iter = iterator(checked_cast(strm));
         Adaptor.fromIterator(rc, proxy, iter)
 
     ///

--- a/main/test/ca/uwaterloo/flix/library/TestAdaptor.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestAdaptor.flix
@@ -270,21 +270,21 @@ mod TestAdaptor {
     @test
     def fromCollectionToIterator01(): Bool \ {} = region rc {
         import static java.util.List.of(): ##java.util.List \ {};
-        let col = unchecked_cast(of() as ##java.util.Collection);
+        let col = checked_cast(of());
         Iterator.toList(Adaptor.fromCollectionToIterator(rc, (Proxy.Proxy: Proxy[String]), col)) == (Nil : List[String])
     }
 
     @test
     def fromCollectionToIterator02(): Bool \ {} = region rc {
         import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
-        let col = unchecked_cast(of(checked_cast("hello")) as ##java.util.Collection);
+        let col = checked_cast(of(checked_cast("hello")));
         Iterator.toList(Adaptor.fromCollectionToIterator(rc, (Proxy.Proxy: Proxy[String]), col)) == "hello" :: Nil
     }
 
     @test
     def fromCollectionToIterator03(): Bool \ {} = region rc {
         import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
-        let col = unchecked_cast(of(checked_cast("hello"), checked_cast("world")) as ##java.util.Collection);
+        let col = checked_cast(of(checked_cast("hello"), checked_cast("world")));
         Iterator.toList(Adaptor.fromCollectionToIterator(rc, (Proxy.Proxy: Proxy[String]), col)) == "hello" :: "world" :: Nil
     }
 
@@ -352,7 +352,7 @@ mod TestAdaptor {
         import static java.util.List.of(): ##java.util.List \ {};
         import java.util.ArrayList.equals(##java.lang.Object): Bool \ {};
         let l = Adaptor.toArrayList(Nil);
-        equals(newArrayList(unchecked_cast(of() as ##java.util.Collection)), checked_cast(l))
+        equals(newArrayList(checked_cast(of())), checked_cast(l))
 
     @test
     def toArrayList02(): Bool \ IO =
@@ -360,7 +360,7 @@ mod TestAdaptor {
         import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
         import java.util.ArrayList.equals(##java.lang.Object): Bool \ {};
         let l = Adaptor.toArrayList(List#{"hello"});
-        equals(newArrayList(unchecked_cast(of(checked_cast("hello")) as ##java.util.Collection)), checked_cast(l))
+        equals(newArrayList(checked_cast(of(checked_cast("hello")))), checked_cast(l))
 
     @test
     def toArrayList03(): Bool \ IO =
@@ -368,7 +368,7 @@ mod TestAdaptor {
         import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
         import java.util.ArrayList.equals(##java.lang.Object): Bool \ {};
         let l = Adaptor.toArrayList(List#{"hello", "world"});
-        equals(newArrayList(unchecked_cast(of(checked_cast("hello"), checked_cast("world")) as ##java.util.Collection)), checked_cast(l))
+        equals(newArrayList(checked_cast(of(checked_cast("hello"), checked_cast("world")))), checked_cast(l))
 
     /////////////////////////////////////////////////////////////////////////////
     // toLinkedList                                                            //
@@ -380,7 +380,7 @@ mod TestAdaptor {
         import static java.util.List.of(): ##java.util.List \ {};
         import java.util.LinkedList.equals(##java.lang.Object): Bool \ {};
         let l = Adaptor.toLinkedList(Nil);
-        equals(newLinkedList(unchecked_cast(of() as ##java.util.Collection)), checked_cast(l))
+        equals(newLinkedList(checked_cast(of())), checked_cast(l))
 
     @test
     def toLinkedList02(): Bool \ IO =
@@ -388,7 +388,7 @@ mod TestAdaptor {
         import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
         import java.util.LinkedList.equals(##java.lang.Object): Bool \ {};
         let l = Adaptor.toLinkedList(List#{"hello"});
-        equals(newLinkedList(unchecked_cast(of(checked_cast("hello")) as ##java.util.Collection)), checked_cast(l))
+        equals(newLinkedList(checked_cast(of(checked_cast("hello")))), checked_cast(l))
 
     @test
     def toLinkedList03(): Bool \ IO =
@@ -396,7 +396,7 @@ mod TestAdaptor {
         import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
         import java.util.LinkedList.equals(##java.lang.Object): Bool \ {};
         let l = Adaptor.toLinkedList(List#{"hello", "world"});
-        equals(newLinkedList(unchecked_cast(of(checked_cast("hello"), checked_cast("world")) as ##java.util.Collection)), checked_cast(l))
+        equals(newLinkedList(checked_cast(of(checked_cast("hello"), checked_cast("world")))), checked_cast(l))
 
     /////////////////////////////////////////////////////////////////////////////
     // toSet                                                                   //
@@ -433,7 +433,7 @@ mod TestAdaptor {
         import static java.util.List.of(): ##java.util.List \ {};
         import java.util.TreeSet.equals(##java.lang.Object): Bool \ {};
         let s = Adaptor.toTreeSet((Set#{} : Set[String]));
-        equals(newTreeSet(unchecked_cast(of() as ##java.util.Collection)), checked_cast(s))
+        equals(newTreeSet(checked_cast(of())), checked_cast(s))
 
     @test
     def toTreeSet02(): Bool \ IO =
@@ -441,7 +441,7 @@ mod TestAdaptor {
         import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
         import java.util.TreeSet.equals(##java.lang.Object): Bool \ {};
         let s = Adaptor.toTreeSet(Set#{"hello"});
-        equals(newTreeSet(unchecked_cast(of(checked_cast("hello")) as ##java.util.Collection)), checked_cast(s))
+        equals(newTreeSet(checked_cast(of(checked_cast("hello")))), checked_cast(s))
 
     @test
     def toTreeSet03(): Bool \ IO =
@@ -449,7 +449,7 @@ mod TestAdaptor {
         import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
         import java.util.TreeSet.equals(##java.lang.Object): Bool \ {};
         let s = Adaptor.toTreeSet(Set#{"hello", "world"});
-        equals(newTreeSet(unchecked_cast(of(checked_cast("hello"), checked_cast("world")) as ##java.util.Collection)), checked_cast(s))
+        equals(newTreeSet(checked_cast(of(checked_cast("hello"), checked_cast("world")))), checked_cast(s))
 
     /////////////////////////////////////////////////////////////////////////////
     // toMap                                                                   //

--- a/main/test/ca/uwaterloo/flix/library/TestDebug.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestDebug.flix
@@ -199,19 +199,19 @@ mod TestDebug {
 
      @test
      def testNullStringify02(): Bool = {
-         let s = stringify(unchecked_cast(null as String));
+         let s = stringify((checked_cast(null): String));
          s == "null"
      }
 
      @test
      def testNullStringify03(): Bool = {
-         let s = stringify(unchecked_cast(null as BigInt));
+         let s = stringify((checked_cast(null): BigInt));
          s == "null"
      }
 
     @test
     def testNullStringify04(): Bool = {
-        let s = stringify(Poly.This(unchecked_cast(null as String)));
+        let s = stringify(Poly.This((checked_cast(null): String)));
         s == "This(null)"
     }
 
@@ -223,13 +223,13 @@ mod TestDebug {
 
     @test
     def testNullStringify06(): Bool = region rc {
-        let s = stringify(Array#{unchecked_cast(null as String), "42"} @ rc);
+        let s = stringify(Array#{(checked_cast(null): String), "42"} @ rc);
         s == "[null, 42]"
     }
 
     @test
     def testNullStringify07(): Bool = {
-        let s = stringify({label = unchecked_cast(null as String)});
+        let s = stringify({label = (checked_cast(null): String)});
         s == "{label = null}"
     }
 }

--- a/main/test/ca/uwaterloo/flix/library/TestObject.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestObject.flix
@@ -53,13 +53,13 @@ mod TestObject {
     def isNullBigInt01(): Bool = not Object.isNull(123ii)
 
     @test
-    def isNullBigInt02(): Bool = Object.isNull(unchecked_cast(null as BigInt))
+    def isNullBigInt02(): Bool = Object.isNull((checked_cast(null): BigInt))
 
     @test
     def isNullString01(): Bool = not Object.isNull("hello")
 
     @test
-    def isNullString02(): Bool = Object.isNull(unchecked_cast(null as String))
+    def isNullString02(): Bool = Object.isNull((checked_cast(null): String))
 
     @test
     def isNullArray01(): Bool \ IO = not Object.isNull(Array#{} @ Static)
@@ -67,7 +67,7 @@ mod TestObject {
     @test
     def isNullArray02(): Bool = region rc {
         let _ = rc;
-        Object.isNull(unchecked_cast(null as Array[Int32, rc]))
+        Object.isNull((checked_cast(null): Array[Int32, rc]))
     }
 
     @test
@@ -80,7 +80,7 @@ mod TestObject {
     // toOption                                                                //
     /////////////////////////////////////////////////////////////////////////////
     @test
-    def toOption01(): Bool = Object.toOption(unchecked_cast(null as String)) == None
+    def toOption01(): Bool = Object.toOption((checked_cast(null): String)) == None
 
     @test
     def toOption02(): Bool = Object.toOption("") == Some("")

--- a/main/test/flix/Test.Exp.Null.flix
+++ b/main/test/flix/Test.Exp.Null.flix
@@ -7,7 +7,7 @@ mod Test.Exp.Null {
     def testNullUnit01(): Unit = unchecked_cast(null as Unit)
 
     @test
-    def testNullString01(): String = unchecked_cast(null as String)
+    def testNullString01(): String = checked_cast(null)
 
     @test
     def testNullArray01(): Unit \ IO = region rc {
@@ -28,13 +28,13 @@ mod Test.Exp.Null {
     def testNullRecord02(): {name = String} = unchecked_cast(null as {name = String})
 
     @test
-    def testNullRecord03(): {name = String} = {name = unchecked_cast(null as String)}
+    def testNullRecord03(): {name = String} = {name = checked_cast(null)}
 
     @test
     def testNullRecord04(): {fstName = String, lstName = String} = unchecked_cast(null as {fstName = String, lstName = String})
 
     @test
-    def testNullRecord05(): {fstName = String, lstName = String} = {fstName = unchecked_cast(null as String), lstName = unchecked_cast(null as String)}
+    def testNullRecord05(): {fstName = String, lstName = String} = {fstName = checked_cast(null), lstName = checked_cast(null)}
 
     @test
     def testNullRef01(): Unit \ IO = region rc {
@@ -46,33 +46,33 @@ mod Test.Exp.Null {
     def testNullTuple01(): (String, String) = unchecked_cast(null as (String, String))
 
     @test
-    def testNullTuple02(): (String, String) = (unchecked_cast(null as String), "abc")
+    def testNullTuple02(): (String, String) = (checked_cast(null), "abc")
 
     @test
-    def testNullTuple03(): (String, String) = ("abc", unchecked_cast(null as String))
+    def testNullTuple03(): (String, String) = ("abc", checked_cast(null))
 
     @test
     def testNullOption01(): Option[String] = unchecked_cast(null as Option[String])
 
     @test
-    def testNullOption02(): Option[String] = Some(unchecked_cast(null as String))
+    def testNullOption02(): Option[String] = Some(checked_cast(null))
 
     @test
     def testNullList01(): List[String] = unchecked_cast(null as List[String])
 
     @test
-    def testNullList02(): List[String] = (unchecked_cast(null as String)) :: Nil
+    def testNullList02(): List[String] = (checked_cast(null)) :: Nil
 
     @test
     def testNullResult01(): Result[String, String] = unchecked_cast(null as Result[String, String])
 
     @test
-    def testNullResult03(): Result[String, String] = Ok(unchecked_cast(null as String))
+    def testNullResult03(): Result[String, String] = Ok(checked_cast(null))
 
     @test
-    def testNullResult04(): Result[String, String] = Err(unchecked_cast(null as String))
+    def testNullResult04(): Result[String, String] = Err(checked_cast(null))
 
     @test
-    def testNullArrow01(): (String -> String) = (_: String) -> unchecked_cast(null as String)
+    def testNullArrow01(): (String -> String) = (_: String) -> checked_cast(null)
 
 }

--- a/main/test/flix/Test.Kind.Def.flix
+++ b/main/test/flix/Test.Kind.Def.flix
@@ -47,11 +47,11 @@ mod Test.Kind.Def {
         mod Effect {
             pub enum EBool[_a: Eff]
 
-            pub def bool(): Int32 \ ef = unchecked_cast(??? as _ \ ef)
+            pub def bool(): Int32 \ ef = ???()
 
-            pub def func(x: Int32 -> Int32 \ ef): Int32 \ ef = unchecked_cast(??? as _ \ ef)
+            pub def func(x: Int32 -> Int32 \ ef): Int32 \ ef = ???()
 
-            pub def enum_(x: EBool[ef]): Int32 \ ef = unchecked_cast(??? as _ \ ef)
+            pub def enum_(x: EBool[ef]): Int32 \ ef = ???()
         }
 
         mod Exp {
@@ -87,7 +87,7 @@ mod Test.Kind.Def {
             pub def starToStar[a: Type -> Type](x: a[Int32]): Int32 with CStarToStar[a] = ???
 
             // cannot be inferred
-            pub def boolToStar[a: Eff -> Type, ef: Eff](x: a[ef]): Int32 \ ef with CBoolToStar[a] = unchecked_cast(??? as _ \ ef)
+            pub def boolToStar[a: Eff -> Type, ef: Eff](x: a[ef]): Int32 \ ef with CBoolToStar[a] = ???()
         }
 
         mod Enum {
@@ -110,11 +110,11 @@ mod Test.Kind.Def {
         mod Effect {
             pub enum EBool[_a: Eff]
 
-            pub def bool[ef: Eff](): Int32 \ ef = unchecked_cast(??? as _ \ ef)
+            pub def bool[ef: Eff](): Int32 \ ef = ???()
 
-            pub def func[ef: Eff](x: Int32 -> Int32 \ ef): Int32 \ ef = unchecked_cast(??? as _ \ ef)
+            pub def func[ef: Eff](x: Int32 -> Int32 \ ef): Int32 \ ef = ???()
 
-            pub def enum_[ef: Eff](x: EBool[ef]): Int32 \ ef = unchecked_cast(??? as _ \ ef)
+            pub def enum_[ef: Eff](x: EBool[ef]): Int32 \ ef = ???()
         }
 
         mod Exp {


### PR DESCRIPTION
Either by
- `checked_cast`
- `???()` instead of `unchecked_cast(??? as _ \ IO)`

Additional could be removed if we
- Checked composite types `Array[String, r]` to `Array[Object, r]`
- Allowed null consistently `Null` to `List[Int32]`
- Char <-> Int32
- `CharSequence` to `String`
- `List[Int32]` to `Object`