### PR TITLE
feat: add `unsafe` expression

### DIFF
--- a/examples/railroad-network.flix
+++ b/examples/railroad-network.flix
@@ -4,7 +4,7 @@
 /// Given two railroad stations a and b, if they are only connected through some station c,
 /// then they are unsafely connected. Because if c fails there is no way to get from a to b.
 ///
-def safeConnects(src: n, links: f[(n, n)]): {safe = Vector[n], unsafe = Vector[n]} \ Foldable.Aef[f] with Foldable[f], Order[n] =
+def safeConnects(src: n, links: f[(n, n)]): {safe = Vector[n], unsafe1 = Vector[n]} \ Foldable.Aef[f] with Foldable[f], Order[n] =
     let db = inject links into Link;
     let pr = #{
         // Directly linked stations.
@@ -34,8 +34,8 @@ def safeConnects(src: n, links: f[(n, n)]): {safe = Vector[n], unsafe = Vector[n
     };
     let model = solve db <+> pr;
     let safe = query model select b from SafelyConnected(src, b);
-    let unsafe = query model select b from UnsafelyConnected(src, b);
-    {safe = safe, unsafe = unsafe}
+    let unsafe1 = query model select b from UnsafelyConnected(src, b);
+    {safe = safe, unsafe1 = unsafe1}
 
 ///
 /// Define some example graph to test the function `safeConnects`.
@@ -85,4 +85,4 @@ def test(): Unit \ IO =
     println("Safe:");
     rec.safe |> Vector.sort |> Vector.map(Console.green) |> Vector.forEach(println);
     println("Unsafe:");
-    rec.unsafe |> Vector.sort |> Vector.map(Console.red) |> Vector.forEach(println)
+    rec.unsafe1 |> Vector.sort |> Vector.map(Console.red) |> Vector.forEach(println)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordExprCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordExprCompleter.scala
@@ -56,6 +56,7 @@ object KeywordExprCompleter extends Completer {
       "true",
       "try",
       "typematch",
+      "unsafe",
       "use",
       "without",
       "yield"

--- a/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
@@ -341,6 +341,8 @@ object SyntaxTree {
 
       case object UncheckedMaskingCast extends Expr
 
+      case object Unsafe extends Expr
+
       case object Use extends Expr
 
       case object Without extends Expr

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -136,6 +136,7 @@ sealed trait TokenKind {
       case TokenKind.KeywordTypeMatch => "'typematch'"
       case TokenKind.KeywordUncheckedCast => "'unchecked_cast'"
       case TokenKind.KeywordUniv => "'univ'"
+      case TokenKind.KeywordUnsafe => "'unsafe'"
       case TokenKind.KeywordUse => "'use'"
       case TokenKind.KeywordWhere => "'where'"
       case TokenKind.KeywordWith => "'with'"
@@ -288,6 +289,7 @@ sealed trait TokenKind {
     case TokenKind.KeywordTypeMatch => true
     case TokenKind.KeywordUncheckedCast => true
     case TokenKind.KeywordUniv => true
+    case TokenKind.KeywordUnsafe => true
     case TokenKind.KeywordUse => true
     case TokenKind.KeywordWhere => true
     case TokenKind.KeywordWith => true
@@ -423,6 +425,7 @@ sealed trait TokenKind {
          | TokenKind.KeywordCheckedCast
          | TokenKind.KeywordCheckedECast
          | TokenKind.KeywordUncheckedCast
+         | TokenKind.KeywordUnsafe
          | TokenKind.KeywordMaskedCast
          | TokenKind.KeywordTry
          | TokenKind.KeywordDo
@@ -823,6 +826,8 @@ object TokenKind {
   case object KeywordUncheckedCast extends TokenKind
 
   case object KeywordUniv extends TokenKind
+
+  case object KeywordUnsafe extends TokenKind
 
   case object KeywordUse extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -188,6 +188,8 @@ object WeededAst {
 
     case class UncheckedMaskingCast(exp: Expr, loc: SourceLocation) extends Expr
 
+    case class Unsafe(exp: Expr, loc: SourceLocation) extends Expr
+
     case class Without(exp: Expr, eff: Name.QName, loc: SourceLocation) extends Expr
 
     case class TryCatch(exp: Expr, handlers: List[CatchRule], loc: SourceLocation) extends Expr

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -682,6 +682,13 @@ object Desugar {
       val e = visitExp(exp)
       Expr.UncheckedMaskingCast(e, loc)
 
+    case WeededAst.Expr.Unsafe(exp, loc) =>
+      // We desugar an unsafe expression to an unchecked cast to pure.
+      val e = visitExp(exp)
+      val declaredType = None
+      val declaredEff = Some(DesugaredAst.Type.Pure(loc.asSynthetic))
+      Expr.UncheckedCast(e, declaredType, declaredEff, loc)
+
     case WeededAst.Expr.Without(exp, eff, loc) =>
       val e = visitExp(exp)
       Expr.Without(e, eff, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -433,6 +433,7 @@ object Lexer {
       case _ if isKeyword("typematch") => TokenKind.KeywordTypeMatch
       case _ if isKeyword("unchecked_cast") => TokenKind.KeywordUncheckedCast
       case _ if isKeyword("Univ") => TokenKind.KeywordUniv
+      case _ if isKeyword("unsafe") => TokenKind.KeywordUnsafe
       case _ if isKeyword("use") => TokenKind.KeywordUse
       case _ if isKeyword("where") => TokenKind.KeywordWhere
       case _ if isKeyword("with") => TokenKind.KeywordWith

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1501,6 +1501,7 @@ object Parser2 {
         case TokenKind.KeywordCheckedCast => checkedTypeCastExpr()
         case TokenKind.KeywordCheckedECast => checkedEffectCastExpr()
         case TokenKind.KeywordUncheckedCast => uncheckedCastExpr()
+        case TokenKind.KeywordUnsafe => unsafeExpr()
         case TokenKind.KeywordMaskedCast => uncheckedMaskingCastExpr()
         case TokenKind.KeywordTry => tryExpr()
         case TokenKind.KeywordDo => doExpr()
@@ -2296,6 +2297,14 @@ object Parser2 {
         expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
       }
       close(mark, TreeKind.Expr.UncheckedCast)
+    }
+
+    private def unsafeExpr()(implicit s: State): Mark.Closed = {
+      assert(at(TokenKind.KeywordUnsafe))
+      val mark = open()
+      expect(TokenKind.KeywordUnsafe, SyntacticContext.Expr.OtherExpr)
+      expression()
+      close(mark, TreeKind.Expr.Unsafe)
     }
 
     private def uncheckedMaskingCastExpr()(implicit s: State): Mark.Closed = {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1599,7 +1599,7 @@ object Weeder2 {
       expect(tree, TreeKind.Expr.Unsafe)
       mapN(pickExpr(tree)) {
         expr =>
-          // We desugar an unsafe block to an unchecked cast to pure.
+          // We desugar an unsafe expression to an unchecked cast to pure.
           val declaredType = None
           val declaredEff = Some(Type.Pure(tree.loc))
           Expr.UncheckedCast(expr, declaredType, declaredEff, tree.loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -782,6 +782,7 @@ object Weeder2 {
         case TreeKind.Expr.CheckedEffectCast => visitCheckedEffectCastExpr(tree)
         case TreeKind.Expr.UncheckedCast => visitUncheckedCastExpr(tree)
         case TreeKind.Expr.UncheckedMaskingCast => visitUncheckedMaskingCastExpr(tree)
+        case TreeKind.Expr.Unsafe => visitUnsafeExpr(tree)
         case TreeKind.Expr.Without => visitWithoutExpr(tree)
         case TreeKind.Expr.Try => visitTryExpr(tree)
         case TreeKind.Expr.Do => visitDoExpr(tree)
@@ -1591,6 +1592,17 @@ object Weeder2 {
       expect(tree, TreeKind.Expr.UncheckedMaskingCast)
       mapN(pickExpr(tree)) {
         expr => Expr.UncheckedMaskingCast(expr, tree.loc)
+      }
+    }
+
+    private def visitUnsafeExpr(tree: Tree): Validation[Expr, CompilationMessage] = {
+      expect(tree, TreeKind.Expr.Unsafe)
+      mapN(pickExpr(tree)) {
+        expr =>
+          // We desugar an unsafe block to an unchecked cast to pure.
+          val declaredType = None
+          val declaredEff = Some(Type.Pure(tree.loc))
+          Expr.UncheckedCast(expr, declaredType, declaredEff, tree.loc)
       }
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1598,11 +1598,7 @@ object Weeder2 {
     private def visitUnsafeExpr(tree: Tree): Validation[Expr, CompilationMessage] = {
       expect(tree, TreeKind.Expr.Unsafe)
       mapN(pickExpr(tree)) {
-        expr =>
-          // We desugar an unsafe expression to an unchecked cast to pure.
-          val declaredType = None
-          val declaredEff = Some(Type.Pure(tree.loc))
-          Expr.UncheckedCast(expr, declaredType, declaredEff, tree.loc)
+        expr => Expr.Unsafe(expr, tree.loc)
       }
     }
 

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -21,9 +21,7 @@ mod String {
     ///
     /// Returns the character at position `i` in the string `s`.
     ///
-    pub def charAt(i: Int32, s: String): Char =
-        import java.lang.String.charAt(Int32): Char \ {};
-        charAt(s, i)
+    pub def charAt(i: Int32, s: String): Char = unsafe s¤charAt(i)
 
     ///
     /// Optionally return the character at position `i` in the string `s`.


### PR DESCRIPTION
This is a shorthand for an unchecked effect cast to pure. 

We will want it for our OO-refactoring, as shown with one example in String.flix

We can discuss later if it should have richer semantics.