### PR TITLE
feat: `Iterator.upcast`

### DIFF
--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -756,4 +756,13 @@ mod Iterator {
     pub def flatten(iter: Iterator[Iterator[a, ef1, r], ef2, r]): Iterator[a, r + ef1 + ef2, r] \ r =
         flatMap(identity, iter)
 
+
+    ///
+    /// Returns the given iterator, typed with a larger effect.
+    ///
+    pub def upcast(iter: Iterator[a, ef1, r]): Iterator[a, ef1 + ef2, r] = {
+        let Iterator(rc, next) = iter;
+        Iterator(rc, () -> checked_ecast(next()))
+    }
+
 }

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -595,21 +595,21 @@ mod MutMap {
     ///
     pub def iterator(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[(k, v), r1 + r2, r1] \ { r1, r2 } =
         let MutMap(_, mm) = m;
-        Map.iterator(rc, deref mm) |> Iterator.map(eidentity)
+        Map.iterator(rc, deref mm) |> Iterator.upcast
 
     ///
     /// Returns an iterator over keys in `m`.
     ///
     pub def iteratorKeys(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[k, r1 + r2, r1] \ { r1, r2 } =
         let MutMap(_, mm) = m;
-        Map.iteratorKeys(rc, deref mm) |> Iterator.map(eidentity)
+        Map.iteratorKeys(rc, deref mm) |> Iterator.upcast
 
     ///
     /// Returns an iterator over values in `m`.
     ///
     pub def iteratorValues(rc: Region[r1], m: MutMap[k, v, r2]): Iterator[v, r1 + r2, r1] \ { r1, r2 } =
         let MutMap(_, mm) = m;
-        Map.iteratorValues(rc, deref mm) |> Iterator.map(eidentity)
+        Map.iteratorValues(rc, deref mm) |> Iterator.upcast
 
     ///
     /// Extracts a range of key-value pairs from the mutable map `m`.

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -403,7 +403,7 @@ mod MutSet {
     ///
     pub def iterator(rc: Region[r1], s: MutSet[a, r2]): Iterator[a, r1 + r2, r1] \ { r1, r2 } =
         let MutSet(_, ms) = s;
-        Set.iterator(rc, deref ms) |> Iterator.map(eidentity)
+        Set.iterator(rc, deref ms) |> Iterator.upcast
 
     ///
     /// Returns an enumerator over `s`.


### PR DESCRIPTION
Support upcasting the iterator effect without having to do
```
iter |> Iterator.map(eidentity)
```
which is probably reflected in runtime