### PR TITLE
feat: lex and parse in parallel by size

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -100,8 +100,11 @@ object Lexer {
       // Compute the stale and fresh sources.
       val (stale, fresh) = changeSet.partition(root.sources, oldTokens)
 
+      // Sort the stale inputs by size to increase throughput (i.e. to start work early on the biggest tasks).
+      val staleByDecreasingSize = stale.keys.toList.sortBy(s => -s.data.length)
+
       // Lex each stale source file in parallel.
-      val results = ParOps.parMap(stale.keys)(src => mapN(mapN(lex(src))(fuzz))(tokens => src -> tokens))
+      val results = ParOps.parMap(staleByDecreasingSize)(src => mapN(mapN(lex(src))(fuzz))(tokens => src -> tokens))
 
       // Construct a map from each source to its tokens.
       val reused = fresh.map(m => Validation.success(m))

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -121,8 +121,11 @@ object Parser2 {
       // Compute the stale and fresh sources.
       val (stale, fresh) = changeSet.partition(tokens, oldRoot.units)
 
+      // We benefit from parsing the *largest* source files *first*.
+      val staleByDecreasingSize = stale.toList.sortBy(p => p._2.length)
+
       // Parse each stale source in parallel and join them into a WeededAst.Root
-      val refreshed = ParOps.parMap(stale) {
+      val refreshed = ParOps.parMap(staleByDecreasingSize) {
         case (src, tokens) => mapN(parse(src, tokens))(trees => src -> trees)
       }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -122,7 +122,7 @@ object Parser2 {
       val (stale, fresh) = changeSet.partition(tokens, oldRoot.units)
 
       // Sort the stale inputs by size to increase throughput (i.e. to start work early on the biggest tasks).
-      val staleByDecreasingSize = stale.toList.sortBy(p => p._2.length)
+      val staleByDecreasingSize = stale.toList.sortBy(p => -p._2.length)
 
       // Parse each stale source in parallel and join them into a WeededAst.Root
       val refreshed = ParOps.parMap(staleByDecreasingSize) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -121,7 +121,7 @@ object Parser2 {
       // Compute the stale and fresh sources.
       val (stale, fresh) = changeSet.partition(tokens, oldRoot.units)
 
-      // We benefit from parsing the *largest* source files *first*.
+      // Sort the stale inputs by size to increase throughput (i.e. to start work early on the biggest tasks).
       val staleByDecreasingSize = stale.toList.sortBy(p => p._2.length)
 
       // Parse each stale source in parallel and join them into a WeededAst.Root


### PR DESCRIPTION
```
before:
~~~~ Flix Compiler Performance ~~~~

Throughput (best): 128.377 lines/sec (with 24 threads.)

  min: 87.889, max: 128.377, avg: 108.994, median: 111.914

Finished 51 iterations on 66.980 lines of code in 31 seconds.

after:
~~~~ Flix Compiler Performance ~~~~

Throughput (best): 130.169 lines/sec (with 24 threads.)

  min: 89.968, max: 130.169, avg: 116.259, median: 117.065

Finished 51 iterations on 66.980 lines of code in 29 seconds.

```