### PR TITLE
feat: add tests for `invokeConstructor2`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
@@ -209,7 +209,7 @@ object TypeReduction {
         // Among candidate constructors if there already exists the one with the exact signature,
         // we should ignore the rest.
         val exactConstructor = candidateConstructors
-          .filter(c => // Parameter types correspondance with subtyping
+          .filter(c => // Parameter types correspondence with subtyping
             (c.getParameterTypes zip ts).forall {
               case (clazz, tpe) => Type.getFlixType(clazz) == tpe
             })

--- a/main/test/flix/Test.Exp.Jvm.InvokeConstructor2.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeConstructor2.flix
@@ -1,0 +1,50 @@
+mod Test.Exp.Jvm.InvokeConstructor2 {
+
+    import java.lang.{Boolean, Character, Float, Double, Byte, Long, Short, Integer, String};
+    import java.util.{Locale$Builder => Builder}
+
+    @test
+    def testInvokeConstructor2_01(): ##java.lang.Boolean \ IO =
+        new Boolean(true)
+
+    @test
+    def testInvokeConstructor2_02(): ##java.lang.Character \ IO =
+        new Character('a')
+
+    @test
+    def testInvokeConstructor2_03(): ##java.lang.Float \ IO =
+        new Float(123.456f32)
+
+    @test
+    def testInvokeConstructor2_04(): ##java.lang.Double \ IO =
+        new Double(123.456f64)
+
+    @test
+    def testInvokeConstructor2_05(): ##java.lang.Byte \ IO =
+        new Byte(123i8)
+
+    @test
+    def testInvokeConstructor2_06(): ##java.lang.Short \ IO =
+        new Short(123i16)
+
+    @test
+    def testInvokeConstructor2_07(): ##java.lang.Integer \ IO =
+        new Integer(123i32)
+
+    @test
+    def testInvokeConstructor2_08(): ##java.lang.Long \ IO =
+        new Long(123i64)
+
+    @test
+    def testInvokeConstructor2_09(): ##java.lang.String \ IO =
+        new String("Hello World")
+
+    @test
+    def testInvokeObjectConstructor2_01(): ##java.lang.Object \ IO =
+        let obj = new String("Hello World");
+        (checked_cast(obj) : ##java.lang.Object)
+
+    @test
+    def testInvokeStaticNestedConstructor2_01(): ##java.util.Locale$Builder \ IO =
+        new Builder()
+}


### PR DESCRIPTION
The tests are duplicated from `invokeConstructor`.
Support for array is not yet available.

Also, empty constructor test is not passing until #7918 has been merged in.