### PR TITLE
ci: remove fcwg from community build

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -43,7 +43,6 @@ jobs:
           - "JonathanStarup/Flix-ANSI-Terminal"
           - "flix/museum"
           - "jaschdoc/flix-parsers"
-          - "mlutze/fcwg"
           - "mlutze/flix-json"
           - "mlutze/flixball"
           - "stephentetley/charset-locale"


### PR DESCRIPTION
This project will be archived as the improved Java interop renders it redundant.