### PR TITLE
refactor: require imported name in `instanceof`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
@@ -154,7 +154,7 @@ object DesugaredAst {
 
     case class Ascribe(exp: Expr, expectedType: Option[Type], expectedEff: Option[Type], loc: SourceLocation) extends Expr
 
-    case class InstanceOf(exp: Expr, className: String, loc: SourceLocation) extends Expr
+    case class InstanceOf(exp: Expr, className: Name.Ident, loc: SourceLocation) extends Expr
 
     case class CheckedCast(cast: Ast.CheckedCastType, exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -164,7 +164,7 @@ object NamedAst {
 
     case class Ascribe(exp: Expr, expectedType: Option[Type], expectedEff: Option[Type], loc: SourceLocation) extends Expr
 
-    case class InstanceOf(exp: Expr, className: String, loc: SourceLocation) extends Expr
+    case class InstanceOf(exp: Expr, className: Name.Ident, loc: SourceLocation) extends Expr
 
     case class CheckedCast(cast: Ast.CheckedCastType, exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -180,7 +180,7 @@ object WeededAst {
 
     case class Ascribe(exp: Expr, expectedType: Option[Type], expectedEff: Option[Type], loc: SourceLocation) extends Expr
 
-    case class InstanceOf(exp: Expr, className: String, loc: SourceLocation) extends Expr
+    case class InstanceOf(exp: Expr, clazzName: Name.Ident, loc: SourceLocation) extends Expr
 
     case class CheckedCast(cast: Ast.CheckedCastType, exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -654,16 +654,16 @@ object WeederError {
   }
 
   /**
-    * An error raised to indicate an illegal qualified name in an invoke constructor expression.
+    * An error raised to indicate an illegal qualified name.
     *
     * @param loc the location of the illegal qualified name.
     */
-  case class IllegalQualifiedNameInInvokeConstructor(loc: SourceLocation) extends WeederError with Recoverable {
-    override def summary: String = "Unexpected qualified name in new expression"
+  case class IllegalQualifiedName(loc: SourceLocation) extends WeederError with Recoverable {
+    override def summary: String = "Unexpected qualified name"
 
     override def message(formatter: Formatter): String = {
       import formatter._
-      s""">> Unexpected qualified name in new expression.
+      s""">> Unexpected qualified nam.
          |
          |${code(loc, "illegal qualified name")}
          |

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -663,7 +663,7 @@ object WeederError {
 
     override def message(formatter: Formatter): String = {
       import formatter._
-      s""">> Unexpected qualified nam.
+      s""">> Unexpected qualified name.
          |
          |${code(loc, "illegal qualified name")}
          |

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -710,18 +710,18 @@ object Desugar {
       val es = visitExps(exps)
       Expr.Do(op, es, loc)
 
-    case WeededAst.Expr.InvokeConstructor2(clazzName, exps, loc) =>
+    case WeededAst.Expr.InvokeConstructor2(className, exps, loc) =>
       val es = visitExps(exps)
-      Expr.InvokeConstructor2(clazzName, es, loc)
+      Expr.InvokeConstructor2(className, es, loc)
 
     case WeededAst.Expr.InvokeMethod2(exp, name, exps, loc) =>
       val e = visitExp(exp)
       val es = visitExps(exps)
       Expr.InvokeMethod2(e, name, es, loc)
 
-    case WeededAst.Expr.InvokeStaticMethod2(clazzName, methodName, exps, loc) =>
+    case WeededAst.Expr.InvokeStaticMethod2(className, methodName, exps, loc) =>
       val es = visitExps(exps)
-      Expr.InvokeStaticMethod2(clazzName, methodName, es, loc)
+      Expr.InvokeStaticMethod2(className, methodName, es, loc)
 
     case WeededAst.Expr.InvokeConstructor(className, exps, sig, loc) =>
       val es = visitExps(exps)

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -823,9 +823,9 @@ object Namer {
         case e => NamedAst.Expr.Ascribe(e, t, ef, loc)
       }
 
-    case DesugaredAst.Expr.InstanceOf(exp, className, loc) =>
+    case DesugaredAst.Expr.InstanceOf(exp, qname, loc) =>
       mapN(visitExp(exp, ns0)) {
-        case e => NamedAst.Expr.InstanceOf(e, className, loc)
+        case e => NamedAst.Expr.InstanceOf(e, qname, loc)
       }
 
     case DesugaredAst.Expr.CheckedCast(c, exp, loc) =>
@@ -888,10 +888,10 @@ object Namer {
         exps => NamedAst.Expr.Do(op, exps, loc)
       }
 
-    case DesugaredAst.Expr.InvokeConstructor2(clazzName, exps, loc) =>
+    case DesugaredAst.Expr.InvokeConstructor2(className, exps, loc) =>
       val expsVal = traverse(exps)(visitExp(_, ns0))
       mapN(expsVal) {
-        exps => NamedAst.Expr.InvokeConstructor2(clazzName, exps, loc)
+        exps => NamedAst.Expr.InvokeConstructor2(className, exps, loc)
       }
 
     case DesugaredAst.Expr.InvokeMethod2(exp, name, exps, loc) =>
@@ -899,10 +899,10 @@ object Namer {
         case (e, es) => NamedAst.Expr.InvokeMethod2(e, name, es, loc)
       }
 
-    case DesugaredAst.Expr.InvokeStaticMethod2(clazzName, methodName, exps, loc) =>
+    case DesugaredAst.Expr.InvokeStaticMethod2(className, methodName, exps, loc) =>
       val expsVal = traverse(exps)(visitExp(_, ns0))
       mapN(expsVal) {
-        exps => NamedAst.Expr.InvokeStaticMethod2(clazzName, methodName, exps, loc)
+        exps => NamedAst.Expr.InvokeStaticMethod2(className, methodName, exps, loc)
       }
 
     case DesugaredAst.Expr.InvokeConstructor(className, exps, sig, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -823,9 +823,9 @@ object Namer {
         case e => NamedAst.Expr.Ascribe(e, t, ef, loc)
       }
 
-    case DesugaredAst.Expr.InstanceOf(exp, qname, loc) =>
+    case DesugaredAst.Expr.InstanceOf(exp, className, loc) =>
       mapN(visitExp(exp, ns0)) {
-        case e => NamedAst.Expr.InstanceOf(e, qname, loc)
+        case e => NamedAst.Expr.InstanceOf(e, className, loc)
       }
 
     case DesugaredAst.Expr.CheckedCast(c, exp, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1322,11 +1322,14 @@ object Resolver {
           }
 
         case NamedAst.Expr.InstanceOf(exp, className, loc) =>
-          lookupJvmClass(className, loc) match {
-            case Result.Ok(clazz) => mapN(visitExp(exp, env0)) {
-              e => ResolvedAst.Expr.InstanceOf(e, clazz, loc)
+          flatMapN(visitExp(exp, env0)) {
+            case e => env0.get(className.name) match {
+              case Some(List(Resolution.JavaClass(clazz))) =>
+                Validation.success(ResolvedAst.Expr.InstanceOf(e, clazz, loc))
+              case _ =>
+                val m = ResolutionError.UndefinedJvmClass(className.name, "", loc)
+                Validation.toSoftFailure(ResolvedAst.Expr.Error(m), m)
             }
-            case Result.Err(e) => Validation.toSoftFailure(ResolvedAst.Expr.Error(e), e)
           }
 
         case NamedAst.Expr.CheckedCast(c, exp, loc) =>
@@ -1420,14 +1423,14 @@ object Resolver {
               }
           }
 
-        case NamedAst.Expr.InvokeConstructor2(clazzName, exps, loc) =>
+        case NamedAst.Expr.InvokeConstructor2(className, exps, loc) =>
           val esVal = traverse(exps)(visitExp(_, env0))
           flatMapN(esVal) {
-            es => env0.get(clazzName.name) match {
+            es => env0.get(className.name) match {
               case Some(List(Resolution.JavaClass(clazz))) =>
                 Validation.success(ResolvedAst.Expr.InvokeConstructor2(clazz, es, loc))
               case _ =>
-                val m = ResolutionError.UndefinedJvmClass(clazzName.name, "", loc)
+                val m = ResolutionError.UndefinedJvmClass(className.name, "", loc)
                 Validation.toSoftFailure(ResolvedAst.Expr.Error(m), m)
             }
           }
@@ -1440,14 +1443,14 @@ object Resolver {
               ResolvedAst.Expr.InvokeMethod2(e, name, es, loc)
           }
 
-        case NamedAst.Expr.InvokeStaticMethod2(clazzName, methodName, exps, loc) =>
+        case NamedAst.Expr.InvokeStaticMethod2(className, methodName, exps, loc) =>
           val esVal = traverse(exps)(visitExp(_, env0))
           flatMapN(esVal) {
-            es => env0.get(clazzName.name) match {
+            es => env0.get(className.name) match {
               case Some(List(Resolution.JavaClass(clazz))) =>
                 Validation.success(ResolvedAst.Expr.InvokeStaticMethod2(clazz, methodName, es, loc))
               case _ =>
-                val m = ResolutionError.UndefinedJvmClass(clazzName.name, "", loc)
+                val m = ResolutionError.UndefinedJvmClass(className.name, "", loc)
                 Validation.toSoftFailure(ResolvedAst.Expr.Error(m), m)
             }
           }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -832,16 +832,6 @@ class TestParserHappy extends AnyFunSuite with TestUtils {
     expectError[ParseError](result)
   }
 
-  test("ParseError.InstanceOf.02") {
-    val input =
-      """
-        |def foo(): Bool =
-        |    1000ii instanceof BigInt
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ParseError](result)
-  }
-
   test("IllegalEffectTypeParams.01") {
     val input =
       """

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -1404,16 +1404,6 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.UndefinedKind](result)
   }
 
-  test("UndefinedInstanceOf.01") {
-    val input =
-      """
-        |def foo(): Bool =
-        |    1000ii instanceof ##org.undefined.BigInt
-        |""".stripMargin
-    val result = compile(input, Options.TestWithLibNix)
-    expectError[ResolutionError.UndefinedJvmClass](result)
-  }
-
   test("DuplicateAssocTypeDef.01") {
     val input =
       """

--- a/main/test/flix/Test.Exp.Instanceof.flix
+++ b/main/test/flix/Test.Exp.Instanceof.flix
@@ -16,54 +16,65 @@
 
 mod Test.Exp.Instanceof {
 
-    @test
-    def testInstanceof01(): Bool = "Hello World" instanceof ##java.lang.String
+    import java.lang.{CharSequence => JCharSequence}
+    import java.lang.{Enum => JEnum}
+    import java.lang.{Long => JLong}
+    import java.lang.{Number => JNumber}
+    import java.lang.{Object => JObject}
+    import java.lang.{String => JString}
+    import java.lang.StringBuilder
+    import java.math.BigInteger
+    import java.nio.file.StandardOpenOption
+    import java.nio.file.OpenOption
 
     @test
-    def testInstanceof02(): Bool = "Hello World" instanceof ##java.lang.CharSequence
+    def testInstanceof01(): Bool = "Hello World" instanceof JString
 
     @test
-    def testInstanceof03(): Bool = "Hello World" instanceof ##java.lang.Object
+    def testInstanceof02(): Bool = "Hello World" instanceof JCharSequence
 
     @test
-    def testInstanceof04(): Bool = 100ii instanceof ##java.math.BigInteger
+    def testInstanceof03(): Bool = "Hello World" instanceof JObject
 
     @test
-    def testInstanceof05(): Bool = 100ii instanceof ##java.lang.Number
+    def testInstanceof04(): Bool = 100ii instanceof BigInteger
 
     @test
-    def testInstanceof06(): Bool = 100ii instanceof ##java.lang.Object
+    def testInstanceof05(): Bool = 100ii instanceof JNumber
+
+    @test
+    def testInstanceof06(): Bool = 100ii instanceof JObject
 
     @test
     def testInstanceof07(): Bool =
         import static java_get_field java.nio.file.StandardOpenOption.DELETE_ON_CLOSE: ##java.nio.file.StandardOpenOption \ {} as get_DELETE_ON_CLOSE;
-        get_DELETE_ON_CLOSE() instanceof ##java.nio.file.StandardOpenOption
+        get_DELETE_ON_CLOSE() instanceof StandardOpenOption
 
     @test
     def testInstanceof08(): Bool =
         import static java_get_field java.nio.file.StandardOpenOption.DELETE_ON_CLOSE: ##java.nio.file.StandardOpenOption \ {} as get_DELETE_ON_CLOSE;
-        get_DELETE_ON_CLOSE() instanceof ##java.nio.file.OpenOption
+        get_DELETE_ON_CLOSE() instanceof OpenOption
 
     @test
     def testInstanceof09(): Bool =
         import static java_get_field java.nio.file.StandardOpenOption.DELETE_ON_CLOSE: ##java.nio.file.StandardOpenOption \ {} as get_DELETE_ON_CLOSE;
-        get_DELETE_ON_CLOSE() instanceof ##java.lang.Enum
+        get_DELETE_ON_CLOSE() instanceof JEnum
 
     @test
     def testInstanceof10(): Bool =
         import static java_get_field java.nio.file.StandardOpenOption.DELETE_ON_CLOSE: ##java.nio.file.StandardOpenOption \ {} as get_DELETE_ON_CLOSE;
-        get_DELETE_ON_CLOSE() instanceof ##java.lang.Object
+        get_DELETE_ON_CLOSE() instanceof JObject
 
     @test
-    def testInstanceof11(): Bool = (100ii instanceof ##java.lang.Long) == false
+    def testInstanceof11(): Bool = (100ii instanceof JLong) == false
 
     @test
-    def testInstanceof12(): Bool = ("Hello World" instanceof ##java.lang.StringBuilder) == false
+    def testInstanceof12(): Bool = ("Hello World" instanceof StringBuilder) == false
 
     @test
     def testInstanceof13(): Bool \ IO = {
         let arr = Array#{"hi"} @ Static;
-        Array.get(0, arr) instanceof ##java.lang.String
+        Array.get(0, arr) instanceof JString
     }
 
 }


### PR DESCRIPTION
This PR requires you to import a Java class or interface before using it in an `instanceof`.