### PR TITLE
docs: update playground samples to `#` for `RecordSelect` syntax

### DIFF
--- a/examples/file-information.flix
+++ b/examples/file-information.flix
@@ -13,9 +13,9 @@ def main(): Unit \ IO =
   // Get statistics of the file 'README.md'.
   match Files.stat(f) {
     case Ok(stats) => {
-      println("${f} is of type: ${stats.fileType}");
-      println("The size of ${f} is: ${stats.size}.");
-      println("The creation time of ${f} is: ${stats.creationTime}.")
+      println("${f} is of type: ${stats#fileType}");
+      println("The size of ${f} is: ${stats#size}.");
+      println("The creation time of ${f} is: ${stats#creationTime}.")
     }
-    case Err(msg)    => println("An error occurred with message: ${msg}")
+    case Err(msg) => println("An error occurred with message: ${msg}")
   }

--- a/examples/polymorphic-record-extension-and-restriction.flix
+++ b/examples/polymorphic-record-extension-and-restriction.flix
@@ -19,4 +19,4 @@ def main2(): Unit \ IO =
     let r1 = {fstName = "Julius", lstName = "Caesar"};
     let r2 = withAge(r1, 55);
     let r3 = withoutAge(r2);
-    "Mr. ${r3fstName} ${r3lstName}" |> println
+    "Mr. ${r3#fstName} ${r3#lstName}" |> println

--- a/examples/polymorphic-record-extension-and-restriction.flix
+++ b/examples/polymorphic-record-extension-and-restriction.flix
@@ -12,11 +12,11 @@ def main(): Unit \ IO =
     let r1 = withAge({fstName = "Julius", lstName = "Caesar"}, 55);
     let r2 = withAge({monument = "Flavian Amphitheatre"}, 2019 - 80);
     let r3 = withAge({country = "United States"}, 2019 - 1776);
-    (r1.age + r2.age + r3.age) |> println
+    (r1#age + r2#age + r3#age) |> println
 
 /// Constructs a record, extends it with an age, and restricts it.
 def main2(): Unit \ IO =
     let r1 = {fstName = "Julius", lstName = "Caesar"};
     let r2 = withAge(r1, 55);
     let r3 = withoutAge(r2);
-    "Mr. ${r3.fstName} ${r3.lstName}" |> println
+    "Mr. ${r3fstName} ${r3lstName}" |> println

--- a/examples/polymorphic-record-update.flix
+++ b/examples/polymorphic-record-update.flix
@@ -6,7 +6,7 @@ def setX(r: {x = Int32, y = Int32}, v: Int32): {x = Int32, y = Int32} =
 def main2(): Int32 =
     let r1 = {x = 1, y = 2};
     let r2 = setX(r1, 3);
-    r1.x + r2.x
+    r1#x + r2#x
 
 /// Returns the record `r` with a new value of its `y` label.
 /// Preserves (retains) all other labels polymorphically.
@@ -19,4 +19,4 @@ def main(): Unit \ IO =
     let r2 = {x = 1, y = 2, z = 3};
     let r3 = setY(r1, 0);
     let r4 = setY(r2, 1);
-    (r3.y + r4.y + r4.z) |> println
+    (r3#y + r4#y + r4#z) |> println

--- a/examples/record-construction-and-use.flix
+++ b/examples/record-construction-and-use.flix
@@ -1,6 +1,6 @@
 /// Returns the area of the rectangle `r`.
 /// The record `r` must have `x` and `y` labels, and no other labels.
-def area(r: {x = Int32, y = Int32}): Int32 = r.x * r.y
+def area(r: {x = Int32, y = Int32}): Int32 = r#x * r#y
 
 /// Computes the area of various rectangle records.
 /// Note that the order of labels is immaterial.
@@ -11,7 +11,7 @@ def areas(): List[Int32] =
 /// Returns the area of the polymorphic record `r`.
 /// Note that the use of the type variable `a` permits the record `r`
 /// to have labels other than `x` and `y`.
-def polyArea(r : {x = Int32, y = Int32 | a}): Int32 = r.x * r.y
+def polyArea(r : {x = Int32, y = Int32 | a}): Int32 = r#x * r#y
 
 /// Computes the area of various rectangle records.
 /// Note that some records have additional labels.

--- a/examples/working-with-files-and-directories.flix
+++ b/examples/working-with-files-and-directories.flix
@@ -15,5 +15,5 @@ def main(): Unit \ IO =
     case Ok(subpaths) => {
       println("All files or directories in ${dir} is: '${subpaths}'.")
     }
-    case Err(msg)     => println("An error occurred with message: ${msg}")
+    case Err(msg) => println("An error occurred with message: ${msg}")
   }


### PR DESCRIPTION
Updates the examples on the playground. However, once https://github.com/flix/flix/pull/7930 has been merged records will use `#` everywhere, i.e., all examples will be fixed, not just the ones in the playground.

Related to https://github.com/flix/flix/issues/7897