### PR TITLE
feat: Add support for structs to the Weeder

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -52,6 +52,8 @@ object WeededAst {
 
     case class RestrictableEnum(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, ident: Name.Ident, index: TypeParam, tparams: TypeParams, derives: Derivations, cases: List[RestrictableCase], loc: SourceLocation) extends Declaration
 
+    case class Struct(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, ident: Name.Ident, tparams: TypeParams, fields: List[StructField], loc: SourceLocation) extends Declaration
+
     case class TypeAlias(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, ident: Name.Ident, tparams: TypeParams, tpe: Type, loc: SourceLocation) extends Declaration
 
     case class AssocTypeSig(doc: Ast.Doc, mod: Ast.Modifiers, ident: Name.Ident, tparam: TypeParam, kind: Kind, tpe: Option[Type], loc: SourceLocation)
@@ -426,6 +428,8 @@ object WeededAst {
   case class Attribute(ident: Name.Ident, tpe: Type, loc: SourceLocation)
 
   case class Case(ident: Name.Ident, tpe: Type, loc: SourceLocation)
+
+  case class StructField(ident: Name.Ident, tpe: Type, loc: SourceLocation)
 
   case class RestrictableCase(ident: Name.Ident, tpe: Type, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -74,6 +74,8 @@ object Desugar {
     case d: WeededAst.Declaration.Law => visitLaw(d)
     case d: WeededAst.Declaration.Enum => visitEnum(d)
     case d: WeededAst.Declaration.RestrictableEnum => visitRestrictableEnum(d)
+    case _: WeededAst.Declaration.Struct =>
+      throw new RuntimeException("No struct support yet")
     case d: WeededAst.Declaration.TypeAlias => visitTypeAlias(d)
     case d: WeededAst.Declaration.Effect => visitEffect(d)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -191,6 +191,7 @@ object Weeder2 {
       val definitions = pickAll(TreeKind.Decl.Def, tree)
       val enums = pickAll(TreeKind.Decl.Enum, tree)
       val restrictableEnums = pickAll(TreeKind.Decl.RestrictableEnum, tree)
+      val structs = pickAll(TreeKind.Decl.Struct, tree)
       val typeAliases = pickAll(TreeKind.Decl.TypeAlias, tree)
       val effects = pickAll(TreeKind.Decl.Effect, tree)
       mapN(
@@ -199,12 +200,13 @@ object Weeder2 {
         traverse(instances)(visitInstanceDecl),
         traverse(definitions)(visitDefinitionDecl(_)),
         traverse(enums)(visitEnumDecl),
+        traverse(structs)(visitStructDecl),
         traverse(restrictableEnums)(visitRestrictableEnumDecl),
         traverse(typeAliases)(visitTypeAliasDecl),
         traverse(effects)(visitEffectDecl)
       ) {
-        case (modules, traits, instances, definitions, enums, rEnums, typeAliases, effects) =>
-          (modules ++ traits ++ instances ++ definitions ++ enums ++ rEnums ++ typeAliases ++ effects).sortBy(_.loc)
+        case (modules, traits, instances, definitions, enums, rEnums, structs, typeAliases, effects) =>
+          (modules ++ traits ++ instances ++ definitions ++ enums ++ rEnums ++ structs ++ typeAliases ++ effects).sortBy(_.loc)
       }
     }
 
@@ -446,6 +448,37 @@ object Weeder2 {
       }
     }
 
+    private def visitStructDecl(tree: Tree): Validation[Declaration.Struct, CompilationMessage] = {
+      expect(tree, TreeKind.Decl.Struct)
+      val fields = pickAll(TreeKind.StructField, tree)
+      flatMapN(
+        pickDocumentation(tree),
+        pickAnnotations(tree),
+        pickModifiers(tree, allowed = Set(TokenKind.KeywordPub)),
+        pickNameIdent(tree),
+        Types.pickParameters(tree),
+        traverse(fields)(visitStructField)
+      ) {
+        (doc, ann, mods, ident, tparams, fields) =>
+        // TODO: Validation, e.g., never duplicate names
+        Validation.success(Declaration.Struct(
+          doc, ann, mods, ident, tparams, fields.sortBy(_.loc), tree.loc
+        ))
+      }
+    }
+
+    private def visitStructField(tree: Tree): Validation[StructField, CompilationMessage] = {
+      expect(tree, TreeKind.StructField)
+      mapN(
+        pickNameIdent(tree),
+        Types.pickType(tree)
+      ) {
+        (ident, ttype) =>
+          // Make a source location that spans the name and type
+          val loc = SourceLocation(isReal = true, ident.loc.sp1, tree.loc.sp2)
+          StructField(ident, ttype, loc)
+      }
+    }
     private def visitTypeAliasDecl(tree: Tree): Validation[Declaration.TypeAlias, CompilationMessage] = {
       expect(tree, TreeKind.Decl.TypeAlias)
       mapN(


### PR DESCRIPTION
This PR adds support for structs to the weeder. It does not include checking for duplicate fields yet - that will come in a little bit(which is why this is a draft for now). This is related to issue #7924