### PR TITLE
Remove unnecessary mkStructSym function

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -452,6 +452,31 @@ object Symbol {
     override def toString: String = if (namespace.isEmpty) name else namespace.mkString(".") + "." + name
   }
 
+  final class StructSym(val namespace: List[String], val text: String, val loc: SourceLocation) extends Symbol {
+    /**
+      * Returns the name of `this` symbol.
+      */
+    def name: String = text
+
+    /**
+      * Returns `true` if this symbol is equal to `that` symbol.
+      */
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case that: StructSym => this.namespace == that.namespace && this.text == that.text
+      case _ => false
+    }
+
+    /**
+      * Returns the hash code of this symbol.
+      */
+    override val hashCode: Int = 5 * namespace.hashCode() + 7 * text.hashCode()
+
+    /**
+      * Human readable representation.
+      */
+    override def toString: String = if (namespace.isEmpty) name else namespace.mkString(".") + "." + name
+  }
+
   /**
     * Restrictable Enum Symbol.
     */

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -158,14 +158,6 @@ object Symbol {
   }
 
   /**
-   * Returns the struct symbol for the given fully qualified name.
-   */
-  def mkStructSym(fqn: String): StructSym = split(fqn) match {
-    case None => new StructSym(Nil, fqn, SourceLocation.Unknown)
-    case Some((ns, name)) => new StructSym(ns, name, SourceLocation.Unknown)
-  }
-
-  /**
     * Returns the case symbol for the given name `ident` in the given `enum`.
     */
   def mkCaseSym(sym: Symbol.EnumSym, ident: Ident): CaseSym = {

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -136,6 +136,13 @@ object Symbol {
   }
 
   /**
+   * Returns the struct symbol for the given name `ident` in the given namespace `ns`.
+   */
+  def mkStructSym(ns: NName, ident: Ident): StructSym = {
+    new StructSym(ns.parts, ident.name, ident.loc)
+  }
+
+  /**
     * Returns the restrictable enum symbol for the given name `ident` in the given namespace `ns`.
     */
   def mkRestrictableEnumSym(ns: NName, ident: Ident, cases: List[Ident]): RestrictableEnumSym = {
@@ -148,6 +155,14 @@ object Symbol {
   def mkEnumSym(fqn: String): EnumSym = split(fqn) match {
     case None => new EnumSym(Nil, fqn, SourceLocation.Unknown)
     case Some((ns, name)) => new EnumSym(ns, name, SourceLocation.Unknown)
+  }
+
+  /**
+   * Returns the struct symbol for the given fully qualified name.
+   */
+  def mkStructSym(fqn: String): StructSym = split(fqn) match {
+    case None => new StructSym(Nil, fqn, SourceLocation.Unknown)
+    case Some((ns, name)) => new StructSym(ns, name, SourceLocation.Unknown)
   }
 
   /**
@@ -452,6 +467,9 @@ object Symbol {
     override def toString: String = if (namespace.isEmpty) name else namespace.mkString(".") + "." + name
   }
 
+  /**
+   * Struct Symbol.
+   */
   final class StructSym(val namespace: List[String], val text: String, val loc: SourceLocation) extends Symbol {
     /**
       * Returns the name of `this` symbol.

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3514,6 +3514,7 @@ object Resolver {
   private def infallableLookupSym(sym: Symbol, root: NamedAst.Root)(implicit flix: Flix): List[NamedAst.Declaration] = sym match {
     case sym: Symbol.DefnSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
     case sym: Symbol.EnumSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
+    case sym: Symbol.StructSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
     case sym: Symbol.RestrictableEnumSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
     case sym: Symbol.CaseSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
     case sym: Symbol.RestrictableCaseSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -83,6 +83,7 @@ object Typer {
       val groups = syms.groupBy {
         case sym: Symbol.DefnSym => new Symbol.ModuleSym(sym.namespace)
         case sym: Symbol.EnumSym => new Symbol.ModuleSym(sym.namespace)
+        case sym: Symbol.StructSym => new Symbol.ModuleSym(sym.namespace)
         case sym: Symbol.RestrictableEnumSym => new Symbol.ModuleSym(sym.namespace)
         case sym: Symbol.TraitSym => new Symbol.ModuleSym(sym.namespace)
         case sym: Symbol.TypeAliasSym => new Symbol.ModuleSym(sym.namespace)


### PR DESCRIPTION
PR #7946 added an unnecessary `mkStructSym` overload. This PR removes that.