### PR TITLE
refactor: update java imports in `File.flix`

### DIFF
--- a/main/src/library/File.flix
+++ b/main/src/library/File.flix
@@ -31,6 +31,7 @@ mod File {
 
     use IOError.{Generic}
     use File.Mode.{ReadOnly, ReadWrite, ReadWriteS, ReadWriteD}
+    import java.io.RandomAccessFile
 
     ///
     /// Represents a mode for opening files used by the function `open`.
@@ -73,7 +74,7 @@ mod File {
     ///
     pub def open(path: String, mode: Mode): Result[IOError, File] \ IO =
         IOError.tryCatch(_ -> {
-            import java_new java.io.RandomAccessFile(String, String): ##java.io.RandomAccessFile \ IO as newRandomAccessFile;
+            import java_new java.io.RandomAccessFile(String, String): RandomAccessFile \ IO as newRandomAccessFile;
             let mode1 = modeString(mode);
             File(newRandomAccessFile(path, mode1))
         })


### PR DESCRIPTION
What do we do in this case:
```flix
enum File(##java.io.RandomAccessFile)
```
The enum is declared outside the module.

Related to https://github.com/flix/flix/issues/7872