### PR TITLE
refactor: support for `InvokeConstructor2` in `Int32.flix`

### DIFF
--- a/main/src/library/Int32.flix
+++ b/main/src/library/Int32.flix
@@ -437,7 +437,7 @@ mod Int32 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toBigDecimal(x: Int32): BigDecimal =
-        new BigDecimal(x)
+        unsafe new BigDecimal(x)
 
     ///
     /// Helper function for the `clamp` conversion functions.

--- a/main/src/library/Int32.flix
+++ b/main/src/library/Int32.flix
@@ -23,6 +23,7 @@ instance UpperBound[Int32] {
 }
 
 mod Int32 {
+    import java.math.BigDecimal;
 
     ///
     /// Returns the number of bits used to represent an `Int32`.
@@ -436,8 +437,7 @@ mod Int32 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toBigDecimal(x: Int32): BigDecimal =
-        import java_new java.math.BigDecimal(Int32): BigDecimal \ {} as fromInt32;
-        fromInt32(x)
+        new BigDecimal(x)
 
     ///
     /// Helper function for the `clamp` conversion functions.


### PR DESCRIPTION
Part of #7944.