### PR TITLE
refactor: add support for `InvokeConstructor2` in `Int64.flix`

### DIFF
--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -23,6 +23,7 @@ instance UpperBound[Int64] {
 }
 
 mod Int64 {
+    import java.math.BigDecimal;
 
     ///
     /// Returns the number of bits used to represent an `Int64`.
@@ -440,8 +441,7 @@ mod Int64 {
     /// Warning: The numeric value of `x` may lose precision.
     ///
     pub def toBigDecimal(x: Int64): BigDecimal =
-        import java_new java.math.BigDecimal(Int64): BigDecimal \ {} as fromInt64;
-        fromInt64(x)
+        unsafe new BigDecimal(x)
 
     ///
     /// Helper function for the `clamp` conversion functions.


### PR DESCRIPTION
Part of #7944.