### PR TITLE
refactor: support for `InvokeConstructor2` in `StringBuilder.flix`

### DIFF
--- a/main/src/library/StringBuilder.flix
+++ b/main/src/library/StringBuilder.flix
@@ -20,13 +20,13 @@
 enum StringBuilder[_: Region](##java.lang.StringBuilder)
 
 mod StringBuilder {
+    import java.lang.{StringBuilder => JStringBuilder};
 
     ///
     /// Returns a new mutable StringBuilder.
     ///
     pub def empty(_: Region[r]): StringBuilder[r] \ r =
-        import java_new java.lang.StringBuilder(): ##java.lang.StringBuilder \ r as newStringBuilder;
-        StringBuilder(newStringBuilder())
+        StringBuilder(checked_ecast(unsafe new JStringBuilder()))
 
     ///
     /// Append `x` to the StringBuilder `sb`.


### PR DESCRIPTION
Part of #7944.