### PR TITLE
feat: Add struct support to the `Kinder`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -672,6 +672,7 @@ object SemanticTokensProvider {
     case TypeConstructor.Receiver => true
     case TypeConstructor.Lazy => true
     case TypeConstructor.Enum(_, _) => true
+    case TypeConstructor.Struct(_, _) => true
     case TypeConstructor.RestrictableEnum(_, _) => true
     case TypeConstructor.Native(_) => true
     case TypeConstructor.JvmConstructor(_) => false

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -52,7 +52,7 @@ object KindedAst {
 
   case class Enum(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], derives: Ast.Derivations, cases: Map[Symbol.CaseSym, Case], tpe: Type, loc: SourceLocation)
 
-  case class Struct(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.StructSym, tparams: List[TypeParam], fields: Map[Name.StructField, StructField], tpe: Type, loc: SourceLocation)
+  case class Struct(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.StructSym, tparams: List[TypeParam], fields: Map[Symbol.StructFieldSym, StructField], tpe: Type, loc: SourceLocation)
 
   case class RestrictableEnum(doc: Ast.Doc, ann: Ast.Annotations, mod: Ast.Modifiers, sym: Symbol.RestrictableEnumSym, index: TypeParam, tparams: List[TypeParam], derives: Ast.Derivations, cases: Map[Symbol.RestrictableCaseSym, RestrictableCase], tpe: Type, loc: SourceLocation)
 
@@ -301,7 +301,7 @@ object KindedAst {
 
   case class Case(sym: Symbol.CaseSym, tpe: Type, sc: Scheme, loc: SourceLocation)
 
-  case class StructField(sym: Symbol.StructFieldSym, tpe: Type, sc: Scheme, loc: SourceLocation)
+  case class StructField(sym: Symbol.StructFieldSym, tpe: Type, loc: SourceLocation)
 
   case class RestrictableCase(sym: Symbol.RestrictableCaseSym, tpe: Type, sc: Scheme, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
@@ -201,7 +201,7 @@ object LoweredAst {
 
   case class Case(sym: Symbol.CaseSym, tpe: Type, sc: Scheme, loc: SourceLocation)
 
-  case class StructField(sym: Symbol.StructFieldSym, tpe: Type, sc: Scheme, loc: SourceLocation)
+  case class StructField(sym: Symbol.StructFieldSym, tpe: Type, loc: SourceLocation)
 
   case class Constraint(cparams: List[ConstraintParam], head: Predicate.Head, body: List[Predicate.Body], loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -233,6 +233,12 @@ object TypeConstructor {
   case class Enum(sym: Symbol.EnumSym, kind: Kind) extends TypeConstructor
 
   /**
+   * A type constructor that represents the type of structs.
+   */
+  @IntroducedBy(Kinder.getClass)
+  case class Struct(sym: Symbol.StructSym, kind: Kind) extends TypeConstructor
+
+  /**
     * A type constructor that represents the type of enums.
     */
   @IntroducedBy(Kinder.getClass)

--- a/main/src/ca/uwaterloo/flix/language/fmt/SimpleType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/SimpleType.scala
@@ -429,6 +429,7 @@ object SimpleType {
         case TypeConstructor.Receiver => mkApply(Receiver, t.typeArguments.map(visit))
         case TypeConstructor.Lazy => mkApply(Lazy, t.typeArguments.map(visit))
         case TypeConstructor.Enum(sym, _) => mkApply(Name(sym.name), t.typeArguments.map(visit))
+        case TypeConstructor.Struct(sym, _) => mkApply(Name(sym.name), t.typeArguments.map(visit))
         case TypeConstructor.RestrictableEnum(sym, _) => mkApply(Name(sym.name), t.typeArguments.map(visit))
         case TypeConstructor.Native(clazz) => Name(clazz.getName)
         case TypeConstructor.JvmConstructor(constructor) => Name(constructor.getName)

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -32,7 +32,7 @@ import scala.collection.immutable.SortedSet
 /**
   * Attributes kinds to the types in the AST.
   *
-  * For enums, traits, instances, and type aliases:
+  * For enums, structs, traits, instances, and type aliases:
   * Either:
   *   - type parameters are not annotated and are then assumed all to be Star, or
   *   - type parameters are all annotated with their kinds.
@@ -65,6 +65,8 @@ object Kinder {
 
         val enumsVal = ParOps.parTraverseValues(root.enums)(visitEnum(_, taenv, root))
 
+        val structsVal = ParOps.parTraverseValues(root.structs)(visitStruct(_, taenv, root))
+
         val restrictableEnumsVal = ParOps.parTraverseValues(root.restrictableEnums)(visitRestrictableEnum(_, taenv, root))
 
         val traitsVal = visitTraits(root, taenv, oldRoot, changeSet)
@@ -75,9 +77,9 @@ object Kinder {
 
         val effectsVal = ParOps.parTraverseValues(root.effects)(visitEffect(_, taenv, root))
 
-        mapN(enumsVal, restrictableEnumsVal, traitsVal, defsVal, instancesVal, effectsVal) {
-          case (enums, restrictableEnums, traits, defs, instances, effects) =>
-            KindedAst.Root(traits, instances, defs, enums, Map.empty, restrictableEnums, effects, taenv, root.uses, root.entryPoint, root.sources, root.names)
+        mapN(enumsVal, structsVal, restrictableEnumsVal, traitsVal, defsVal, instancesVal, effectsVal) {
+          case (enums, structs, restrictableEnums, traits, defs, instances, effects) =>
+            KindedAst.Root(traits, instances, defs, enums, structs, restrictableEnums, effects, taenv, root.uses, root.entryPoint, root.sources, root.names)
         }
     }
 
@@ -106,6 +108,30 @@ object Kinder {
           }
       }
   }
+
+  /**
+   * Performs kinding on the given struct.
+   */
+  private def visitStruct(struct0: ResolvedAst.Declaration.Struct, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Struct, KindError] = struct0 match {
+    case ResolvedAst.Declaration.Struct(doc, ann, mod, sym, tparams0, fields0, loc) =>
+      val kenv = getKindEnvFromTypeParamsDefaultStar(tparams0)
+
+      val tparamsVal = traverse(tparams0.tparams)(visitTypeParam(_, kenv))
+
+      flatMapN(tparamsVal) {
+        case tparams =>
+          val targs = tparams.map(tparam => Type.Var(tparam.sym, tparam.loc.asSynthetic))
+          val tpe = Type.mkApply(Type.Cst(TypeConstructor.Struct(sym, getStructKind(struct0)), sym.loc.asSynthetic), targs, sym.loc.asSynthetic)
+          val fieldsVal = traverse(fields0) {
+            case field0 => mapN(visitStructField(field0, tparams, tpe, kenv, taenv, root)) {
+              field => field.sym -> field
+            }
+          }
+          mapN(fieldsVal) {
+            case fields => KindedAst.Struct(doc, ann, mod, sym, tparams, fields.toMap, tpe, loc)
+          }
+      }
+    }
 
   /**
     * Performs kinding on the given restrictable enum.
@@ -178,6 +204,18 @@ object Kinder {
           KindedAst.Case(sym, tpe, sc, loc)
       }
   }
+
+  /**
+   * Performs kinding on the given struct field under the given kind environment.
+   */
+  private def visitStructField(field0: ResolvedAst.Declaration.StructField, tparams: List[KindedAst.TypeParam], resTpe: Type, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.StructField, KindError] = field0 match {
+    case ResolvedAst.Declaration.StructField(sym, tpe0, loc) =>
+      val tpeVal = visitType(tpe0, Kind.Star, kenv, taenv, root)
+      mapN(tpeVal) {
+        case tpe =>
+          KindedAst.StructField(sym, tpe, loc)
+      }
+    }
 
   /**
     * Performs kinding on the given enum case under the given kind environment.
@@ -1233,8 +1271,12 @@ object Kinder {
       }
     
     case UnkindedType.Struct(sym, loc) =>
-      throw new RuntimeException("Joe: Structs are not supported yet.")
-
+      val kind = getStructKind(root.structs(sym))
+      unify(kind, expectedKind) match {
+        case Some(k) => Validation.success(Type.Cst(TypeConstructor.Struct(sym, k), loc))
+        case None => Validation.toHardFailure(KindError.UnexpectedKind(expectedKind = expectedKind, actualKind = kind, loc))
+      }
+    
     case UnkindedType.RestrictableEnum(sym, loc) =>
       val kind = getRestrictableEnumKind(root.restrictableEnums(sym))
       unify(kind, expectedKind) match {
@@ -1576,7 +1618,14 @@ object Kinder {
       }
 
     case UnkindedType.Struct(sym, _) =>
-      throw new RuntimeException("Joe: Structs are not supported in the kind checker yet.")
+      val tyconKind = getStructKind(root.structs(sym))
+      val args = Kind.kindArgs(tyconKind)
+
+      fold(tpe.typeArguments.zip(args), KindEnv.empty) {
+        case (acc, (targ, kind)) => flatMapN(inferType(targ, kind, kenv0, taenv, root)) {
+          kenv => acc ++ kenv
+        }
+      }
 
     case UnkindedType.RestrictableEnum(sym, _) =>
       val tyconKind = getRestrictableEnumKind(root.restrictableEnums(sym))
@@ -1703,6 +1752,17 @@ object Kinder {
     */
   private def getEnumKind(enum0: ResolvedAst.Declaration.Enum)(implicit flix: Flix): Kind = enum0 match {
     case ResolvedAst.Declaration.Enum(_, _, _, _, tparams, _, _, _) =>
+      val kenv = getKindEnvFromTypeParamsDefaultStar(tparams)
+      tparams.tparams.foldRight(Kind.Star: Kind) {
+        case (tparam, acc) => kenv.map(tparam.sym) ->: acc
+      }
+  }
+
+  /**
+   * Gets the kind of the struct.
+   */
+  private def getStructKind(struct0: ResolvedAst.Declaration.Struct)(implicit flix: Flix): Kind = struct0 match {
+    case ResolvedAst.Declaration.Struct(_, _, _, _, tparams, _, _) =>
       val kenv = getKindEnvFromTypeParamsDefaultStar(tparams)
       tparams.tparams.foldRight(Kind.Star: Kind) {
         case (tparam, acc) => kenv.map(tparam.sym) ->: acc

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3501,6 +3501,7 @@ object Resolver {
         case TypeConstructor.AnyType => throw InternalCompilerException(s"unexpected type: $tc", tpe.loc)
         case t: TypeConstructor.Arrow => throw InternalCompilerException(s"unexpected type: $t", tpe.loc)
         case t: TypeConstructor.Enum => throw InternalCompilerException(s"unexpected type: $t", tpe.loc)
+        case t: TypeConstructor.Struct => throw InternalCompilerException(s"unexpected type: $t", tpe.loc)
         case t: TypeConstructor.RestrictableEnum => throw InternalCompilerException(s"unexpected type: $t", tpe.loc)
         case TypeConstructor.JvmConstructor(_) => throw InternalCompilerException(s"unexpected type: $tc", tpe.loc)
         case TypeConstructor.JvmMethod(_) => throw InternalCompilerException(s"unexpected type: $tc", tpe.loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -275,6 +275,8 @@ object Simplifier {
 
           case TypeConstructor.Enum(sym, _) => MonoType.Enum(sym)
 
+          case TypeConstructor.Struct(sym, _) => throw new RuntimeException("Joe: Not implemented yet")
+
           case TypeConstructor.RestrictableEnum(sym, _) =>
             val enumSym = new Symbol.EnumSym(sym.namespace, sym.name, sym.loc)
             MonoType.Enum(enumSym)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -949,6 +949,17 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Struct.Case.01") {
     val input =
       """
+        |struct S {
+        |    c: { }
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError.UnexpectedKind](result)
+  }
+
+  test("KindError.Struct.Case.02") {
+    val input =
+      """
         |struct F[a]
         |
         |struct E {
@@ -959,7 +970,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
-  test("KindError.Struct.Case.02") {
+  test("KindError.Struct.Case.04") {
     val input =
       """
         |struct S[a: Type -> Type] {
@@ -970,7 +981,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
-  test("KindError.Struct.Case.03") {
+  test("KindError.Struct.Case.05") {
     val input =
       """
         |struct S[a] {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -67,6 +67,18 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError](result)
   }
 
+  test("MismatchedTypeParamKind.Implicit.07") {
+    val input =
+      """
+        |struct E[a] {
+        |    e1: a
+        |}
+        |
+        |def f(g: E[a -> b \ e]): Int32 \ ~(a & b) = 123
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError](result)
+  }
 
   test("MismatchedTypeParamKind.Enum.01") {
     val input =
@@ -137,6 +149,75 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError](result)
   }
 
+  test("MismatchedTypeParamKind.Struct.01") {
+    val input =
+      """
+        |struct S[o] {
+        |    a: Int32 -> o \ o
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError](result)
+  }
+
+  test("MismatchedTypeParamKind.Struct.02") {
+    val input =
+      """
+        |struct S[e] {
+        |    a: (Int32 -> Int32 \ e) -> e
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError](result)
+  }
+
+  test("MismatchedTypeParamKind.Struct.03") {
+    val input =
+      """
+        |struct S[a] {
+        |    a: #{| a}, {| a}
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError](result)
+  }
+
+  test("MismatchedTypeParamKind.Struct.04") {
+    val input =
+      """
+        |struct S[a] {
+        |    a: #{X(Int32) | a}, {x = Int32 | a}
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError](result)
+  }
+
+  test("MismatchedTypeParamKind.Struct.05") {
+    val input =
+      """
+        |struct S[e] {
+        |    a: e -> Int32 \ ~e
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError](result)
+  }
+
+  test("MismatchedTypeParamKind.Struct.06") {
+    val input =
+      """
+        |struct D[a] {
+        |    d1: a
+        |}
+        |struct E[a, b, e] {
+        |    a: D[a -> b \ e] -> Int32 \ ~(a & b)
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError](result)
+  }
+
   test("MismatchedTypeParamKind.TypeAlias.01") {
     val input = raw"type alias T[o] = Int32 -> o \ o"
     val result = compile(input, DefaultOptions)
@@ -176,6 +257,20 @@ class TestKinder extends AnyFunSuite with TestUtils {
         |}
         |
         |type alias T[a, b, e] = Option[a -> b \ e] -> Int32 \ ~(a & b)
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError](result)
+  }
+
+  test("MismatchedTypeParamKind.TypeAlias.07") {
+    val input =
+      """
+        |struct S[a] {
+        |    field1: a
+        |    field2: Int32
+        |}
+        |
+        |type alias T[a, b, e] = S[a -> b \ e] -> Int32 \ ~(a & b)
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError](result)
@@ -308,6 +403,17 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError](result)
   }
 
+  test("IllegalUninhabitedType.12") {
+    val input =
+      """
+        |struct P[a, b] {}
+        |
+        |def f(p: P[Int32]): Int32 = 123
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError](result)
+  }
+
   test("IllegalEffect.01") {
     val input = raw"def f(): Int32 = unchecked_cast(1 as _ \ Int32)"
     val result = compile(input, DefaultOptions)
@@ -393,6 +499,17 @@ class TestKinder extends AnyFunSuite with TestUtils {
 
   test("IllegalTypeApplication.08") {
     val input = "def f(a: (Int32, true)): Int32 = 1"
+    val result = compile(input, DefaultOptions)
+    expectError[KindError](result)
+  }
+
+  test("IllegalTypeApplication.09") {
+    val input =
+      """
+        |struct P[a, b] {}
+        |
+        |def f(p: P[Int32, String, String]): Int32 = 123
+        |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError](result)
   }
@@ -491,6 +608,18 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
+  test("KindError.Def.Expression.Ascribe.08") {
+    val input =
+      """
+        |struct S[a, b]
+        |
+        |pub def foo(): Int32 =
+        |    let x: S[Int32] = ???; 0
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError.UnexpectedKind](result)
+  }
+
   test("KindError.Def.Expression.Cast.01") {
     val input =
       """
@@ -530,6 +659,18 @@ class TestKinder extends AnyFunSuite with TestUtils {
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
   }
+
+  test("KindError.Def.Expression.Cast.05") {
+    val input =
+      """
+        |struct S { }
+        |
+        |pub def foo(): Int32 = unchecked_cast(0 as S[Int32])
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError.UnexpectedKind](result)
+  }
+
   test("KindError.Def.Type.01") {
     val input =
       """
@@ -595,6 +736,17 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
+  test("KindError.Def.Type.08") {
+    val input =
+      """
+        |struct S[a]
+        |
+        |def f(x: S[Int32, Int32]): Int32 = ???
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError.UnexpectedKind](result)
+  }
+
   test("KindError.Def.Parameter.01") {
     val input =
       """
@@ -610,6 +762,17 @@ class TestKinder extends AnyFunSuite with TestUtils {
         |enum E[a]
         |
         |def f(x: E): Int32 = ???
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError.UnexpectedKind](result)
+  }
+
+  test("KindError.Def.Parameter.03") {
+    val input =
+      """
+        |struct S[a]
+        |
+        |def f(x: S): Int32 = ???
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -648,6 +811,17 @@ class TestKinder extends AnyFunSuite with TestUtils {
     val input =
       """
         |def f(): () = ???
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError.UnexpectedKind](result)
+  }
+
+  test("KindError.Def.Return.05") {
+    val input =
+      """
+        |struct S[a] {}
+        |
+        |def f(): S = ???
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -766,6 +940,74 @@ class TestKinder extends AnyFunSuite with TestUtils {
       """
         |enum E {
         |  case C(Int32[Int32])
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError.UnexpectedKind](result)
+  }
+
+  test("KindError.Struct.Case.01") {
+    val input =
+      """
+        |struct F[a]
+        |
+        |struct E {
+        |    c: F
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError.UnexpectedKind](result)
+  }
+
+  test("KindError.Struct.Case.02") {
+    val input =
+      """
+        |struct S[a: Type -> Type] {
+        |    c: a
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError.UnexpectedKind](result)
+  }
+
+  test("KindError.Struct.Case.03") {
+    val input =
+      """
+        |struct S[a] {
+        |    c: {i = Int32 | a}
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError.UnexpectedKind](result)
+  }
+
+  test("KindError.Struct.Type.01") {
+    val input =
+      """
+        |struct S {
+        |    c: Int32 -> Int32 \ Int32
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError.UnexpectedKind](result)
+  }
+
+  test("KindError.Struct.Type.02") {
+    val input =
+      """
+        |struct S[a] {
+        |    c: Int32-> Int32 \ a
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError.UnexpectedKind](result)
+  }
+
+  test("KindError.Struct.Type.05") {
+    val input =
+      """
+        |struct S{
+        |    c: Int32[Int32
         |}
         |""".stripMargin
     val result = compile(input, DefaultOptions)


### PR DESCRIPTION
This pull request adds struct support to the kinding phase of the compiler.

Addresses issue #7923 

This PR does not include checking that the last type parameter has kind `Region`.

To keep this PR small, that will come in the next PR as it requires a few changes to the parser and a few other parts too.