### PR TITLE
feat: Add checking that the last type parameter in a `struct` declaration is of kind `Effect`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -115,9 +115,9 @@ object Kinder {
   private def visitStruct(struct0: ResolvedAst.Declaration.Struct, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindedAst.Struct, KindError] = struct0 match {
     case ResolvedAst.Declaration.Struct(doc, ann, mod, sym, tparams0, fields0, loc) =>
       val tparams1 = tparams0 match {
-        case ResolvedAst.TypeParams.Kinded(tparams) => ResolvedAst.TypeParams.Kinded(tparams)
-        case ResolvedAst.TypeParams.Unkinded(tparams0) =>
-          val tparams = tparams0.init.map(tparam => ResolvedAst.TypeParam.Kinded(tparam.name, tparam.sym, Kind.Star, tparam.loc)) :+ ResolvedAst.TypeParam.Kinded(tparams0.last.name, tparams0.last.sym, Kind.Eff, tparams0.last.loc)
+        case ResolvedAst.TypeParams.Kinded(t) => ResolvedAst.TypeParams.Kinded(t)
+        case ResolvedAst.TypeParams.Unkinded(t) =>
+          val tparams = t.init.map(tparam => ResolvedAst.TypeParam.Kinded(tparam.name, tparam.sym, Kind.Star, tparam.loc)) :+ ResolvedAst.TypeParam.Kinded(t.last.name, t.last.sym, Kind.Eff, t.last.loc)
           ResolvedAst.TypeParams.Kinded(tparams)
       }
       val kenv0 = getKindEnvFromTypeParamsDefaultStar(tparams1)

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1102,9 +1102,7 @@ object Parser2 {
       expect(TokenKind.KeywordStruct, SyntacticContext.Decl.Struct)
       val nameLoc = currentSourceLocation()
       name(NAME_TYPE, context = SyntacticContext.Decl.Struct)
-      if (at(TokenKind.BracketL)) {
-        Type.parameters()
-      }
+      Type.parameters()
       zeroOrMore(
         namedTokenSet = NamedTokenSet.FromKinds(NAME_FIELD),
         getItem = structField,

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -70,11 +70,11 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("MismatchedTypeParamKind.Implicit.07") {
     val input =
       """
-        |struct E[a] {
+        |struct E[a, r] {
         |    e1: a
         |}
         |
-        |def f(g: E[a -> b \ e]): Int32 \ ~(a & b) = 123
+        |def f(g: E[a -> b \ e, r]): Int32 \ ~(a & b) = 123
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError](result)
@@ -152,7 +152,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("MismatchedTypeParamKind.Struct.01") {
     val input =
       """
-        |struct S[o] {
+        |struct S[o, r] {
         |    a: Int32 -> o \ o
         |}
         |""".stripMargin
@@ -163,7 +163,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("MismatchedTypeParamKind.Struct.02") {
     val input =
       """
-        |struct S[e] {
+        |struct S[e, r] {
         |    a: (Int32 -> Int32 \ e) -> e
         |}
         |""".stripMargin
@@ -174,7 +174,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("MismatchedTypeParamKind.Struct.03") {
     val input =
       """
-        |struct S[a] {
+        |struct S[a, r] {
         |    a: #{| a}, {| a}
         |}
         |""".stripMargin
@@ -185,7 +185,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("MismatchedTypeParamKind.Struct.04") {
     val input =
       """
-        |struct S[a] {
+        |struct S[a, r] {
         |    a: #{X(Int32) | a}, {x = Int32 | a}
         |}
         |""".stripMargin
@@ -196,7 +196,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("MismatchedTypeParamKind.Struct.05") {
     val input =
       """
-        |struct S[e] {
+        |struct S[e, r] {
         |    a: e -> Int32 \ ~e
         |}
         |""".stripMargin
@@ -207,11 +207,11 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("MismatchedTypeParamKind.Struct.06") {
     val input =
       """
-        |struct D[a] {
+        |struct D[a, r] {
         |    d1: a
         |}
-        |struct E[a, b, e] {
-        |    a: D[a -> b \ e] -> Int32 \ ~(a & b)
+        |struct E[a, b, e, r] {
+        |    a: D[a -> b \ e, r] -> Int32 \ ~(a & b)
         |}
         |""".stripMargin
     val result = compile(input, DefaultOptions)
@@ -265,12 +265,12 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("MismatchedTypeParamKind.TypeAlias.07") {
     val input =
       """
-        |struct S[a] {
+        |struct S[a, r] {
         |    field1: a
         |    field2: Int32
         |}
         |
-        |type alias T[a, b, e] = S[a -> b \ e] -> Int32 \ ~(a & b)
+        |type alias T[a, b, e, r] = S[a -> b \ e, r] -> Int32 \ ~(a & b)
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError](result)
@@ -406,7 +406,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("IllegalUninhabitedType.12") {
     val input =
       """
-        |struct P[a, b] {}
+        |struct P[a, b, r] {}
         |
         |def f(p: P[Int32]): Int32 = 123
         |""".stripMargin
@@ -506,9 +506,9 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("IllegalTypeApplication.09") {
     val input =
       """
-        |struct P[a, b] {}
+        |struct P[a, b, r] {}
         |
-        |def f(p: P[Int32, String, String]): Int32 = 123
+        |def f(p: P[Int32, String, String, Region]): Int32 = 123
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError](result)
@@ -611,7 +611,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Expression.Ascribe.08") {
     val input =
       """
-        |struct S[a, b]
+        |struct S[a, b, r]
         |
         |pub def foo(): Int32 =
         |    let x: S[Int32] = ???; 0
@@ -663,9 +663,9 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Expression.Cast.05") {
     val input =
       """
-        |struct S { }
+        |struct S [r] { }
         |
-        |pub def foo(): Int32 = unchecked_cast(0 as S[Int32])
+        |pub def foo(): Int32 = unchecked_cast(0 as S[Int32, Region])
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -739,9 +739,9 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Type.08") {
     val input =
       """
-        |struct S[a]
+        |struct S[a, r]
         |
-        |def f(x: S[Int32, Int32]): Int32 = ???
+        |def f(x: S[Int32, Int32, Region]): Int32 = ???
         |""".stripMargin
     val result = compile(input, DefaultOptions)
     expectError[KindError.UnexpectedKind](result)
@@ -770,7 +770,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Parameter.03") {
     val input =
       """
-        |struct S[a]
+        |struct S[a, r]
         |
         |def f(x: S): Int32 = ???
         |""".stripMargin
@@ -819,7 +819,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Def.Return.05") {
     val input =
       """
-        |struct S[a] {}
+        |struct S[a, r] {}
         |
         |def f(): S = ???
         |""".stripMargin
@@ -949,7 +949,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Struct.Case.01") {
     val input =
       """
-        |struct S {
+        |struct S [r] {
         |    c: { }
         |}
         |""".stripMargin
@@ -960,9 +960,9 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Struct.Case.02") {
     val input =
       """
-        |struct F[a]
+        |struct F[a, r]
         |
-        |struct E {
+        |struct E[r] {
         |    c: F
         |}
         |""".stripMargin
@@ -971,20 +971,22 @@ class TestKinder extends AnyFunSuite with TestUtils {
   }
 
   test("KindError.Struct.Case.04") {
+    // When some kinds are specified and some aren't, the nonspecified ones
+    // default to kind Type, which is illegal for `r` in this case
     val input =
       """
-        |struct S[a: Type -> Type] {
+        |struct S[a: Type -> Type, r] {
         |    c: a
         |}
         |""".stripMargin
     val result = compile(input, DefaultOptions)
-    expectError[KindError.UnexpectedKind](result)
+    expectError[KindError.MismatchedKinds](result)
   }
 
   test("KindError.Struct.Case.05") {
     val input =
       """
-        |struct S[a] {
+        |struct S[a, r] {
         |    c: {i = Int32 | a}
         |}
         |""".stripMargin
@@ -995,7 +997,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Struct.Type.01") {
     val input =
       """
-        |struct S {
+        |struct S [r] {
         |    c: Int32 -> Int32 \ Int32
         |}
         |""".stripMargin
@@ -1006,7 +1008,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Struct.Type.02") {
     val input =
       """
-        |struct S[a] {
+        |struct S[a, r] {
         |    c: Int32-> Int32 \ a
         |}
         |""".stripMargin
@@ -1017,7 +1019,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
   test("KindError.Struct.Type.05") {
     val input =
       """
-        |struct S{
+        |struct S[r]{
         |    c: Int32[Int32
         |}
         |""".stripMargin

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -218,6 +218,37 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError](result)
   }
 
+  test("MismatchedTypeParamKind.Struct.07") {
+    val input =
+      """
+        |struct D[r] {
+        |    d1: r
+        |}
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError](result)
+  }
+
+  test("MismatchedTypeParamKind.Struct.08") {
+    val input =
+      """
+        |struct D[r] { }
+        |def f(d: D[Int32]): Int32 = 123
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError](result)
+  }
+
+  test("MismatchedTypeParamKind.Struct.09") {
+    val input =
+      """
+        |struct D[a, r] { }
+        |def f(d: D[Int32, Int32]): Int32 = 123
+        |""".stripMargin
+    val result = compile(input, DefaultOptions)
+    expectError[KindError](result)
+  }
+
   test("MismatchedTypeParamKind.TypeAlias.01") {
     val input = raw"type alias T[o] = Int32 -> o \ o"
     val result = compile(input, DefaultOptions)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -602,7 +602,7 @@ class TestNamer extends AnyFunSuite with TestUtils {
   ignore("DuplicateUpperName.28") {
     val input =
       """
-        |struct S {}
+        |struct S[r] {}
         |enum S {}
         |""".stripMargin
     val result = compile(input, Options.TestWithLibNix)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -93,7 +93,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     val input =
       s"""
          |mod A{
-         |    struct S {
+         |    struct S[r] {
          |        a: Int32
          |    }
          |}
@@ -113,7 +113,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
          |    def f(): A.B.C.Color = ???
          |
          |    mod B.C {
-         |        struct Color { }
+         |        struct Color[r] { }
          |    }
          |}
        """.stripMargin
@@ -164,7 +164,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
          |  def f(): A.B.C.Color = ???
          |
          |  mod B.C {
-         |    struct Color {
+         |    struct Color[r] {
          |    }
          |  }
          |}
@@ -389,7 +389,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   ignore("CyclicTypeAliases.06") {
     val input =
       s"""
-         |struct S[t] {
+         |struct S[t, r] {
          |    field: t
          |}
          |

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -139,7 +139,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
 
   ignore("DuplicateStructField.01") {
     val input =
-      """struct Person {
+      """struct Person[r] {
          name: String,
          name: String
       }
@@ -150,7 +150,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
 
   ignore("DuplicateStructField.02") {
     val input =
-      """struct Person {
+      """struct Person[r] {
          name: String,
          age: Int32,
          name: String
@@ -162,7 +162,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
 
   ignore("DuplicateStructField.03") {
     val input =
-      """struct Person {
+      """struct Person[r] {
          name: String,
          age: Int32,
          name: String,
@@ -175,7 +175,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
 
   ignore("DuplicateStructField.04") {
     val input =
-      """struct Person {
+      """struct Person[r] {
          name: String,
          age: Int32,
          age: Int32,


### PR DESCRIPTION
The reasoning for this is that the last type parameter of a struct is always its region. Thus, it must have the effect kind