### PR TITLE
feat: Add name resolution for struct expressions

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -154,7 +154,7 @@ object NamedAst {
 
     case class ArrayLength(base: Expr, loc: SourceLocation) extends Expr
 
-    case class StructNew(name: Name.QName, exps: List[(Name.Ident, Expr)], region: Expr, loc: SourceLocation) extends Expr
+    case class StructNew(name: Symbol.StructSym, exps: List[(Symbol.StructFieldSym, Expr)], region: Expr, loc: SourceLocation) extends Expr
 
     case class StructGet(exp: Expr, name: Name.Label, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -154,6 +154,12 @@ object NamedAst {
 
     case class ArrayLength(base: Expr, loc: SourceLocation) extends Expr
 
+    case class StructNew(name: Name.QName, exps: List[(Name.Ident, Expr)], region: Expr, loc: SourceLocation) extends Expr
+
+    case class StructGet(exp: Expr, name: Name.Label, loc: SourceLocation) extends Expr
+
+    case class StructPut(exp1: Expr, name: Name.Label, exp2: Expr, loc: SourceLocation) extends Expr
+
     case class VectorLit(exps: List[Expr], loc: SourceLocation) extends Expr
 
     case class VectorLoad(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -791,11 +791,26 @@ object Namer {
         case e => NamedAst.Expr.ArrayLength(e, loc)
       }
     
-    case DesugaredAst.Expr.StructNew(_, _, _, _) => throw new RuntimeException("Joe: Not implemented yet")
+    case DesugaredAst.Expr.StructNew(name, exps0, region0, loc) =>
+      val expsVal = traverse(exps0) {
+        case (n, e) => mapN(visitExp(e, ns0)) {
+          case e => (n, e)
+        }
+      }
+      val regionVal = visitExp(region0, ns0)
+      mapN(expsVal, regionVal) {
+        case (exps, region) => NamedAst.Expr.StructNew(name, exps, region, loc)
+      }
 
-    case DesugaredAst.Expr.StructGet(_, _, _) => throw new RuntimeException("Joe: Not implemented yet")
+    case DesugaredAst.Expr.StructGet(e, name, loc) => 
+      mapN(visitExp(e, ns0)) {
+        case e => NamedAst.Expr.StructGet(e, name, loc)
+      }
 
-    case DesugaredAst.Expr.StructPut(_, _, _, _) => throw new RuntimeException("Joe: Not implemented yet")
+    case DesugaredAst.Expr.StructPut(e1, name, e2, loc) =>
+      mapN(visitExp(e1, ns0), visitExp(e2, ns0)) {
+        case (e1, e2) => NamedAst.Expr.StructPut(e1, name, e2, loc)
+      }
 
     case DesugaredAst.Expr.VectorLit(exps, loc) =>
       mapN(traverse(exps)(visitExp(_, ns0))) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -790,19 +790,20 @@ object Namer {
       mapN(visitExp(exp, ns0)) {
         case e => NamedAst.Expr.ArrayLength(e, loc)
       }
-    
+
     case DesugaredAst.Expr.StructNew(name, exps0, region0, loc) =>
+      val structsym = Symbol.mkStructSym(name.namespace, name.ident)
       val expsVal = traverse(exps0) {
         case (n, e) => mapN(visitExp(e, ns0)) {
-          case e => (n, e)
+          case e => (Symbol.mkStructFieldSym(structsym, n), e)
         }
       }
       val regionVal = visitExp(region0, ns0)
       mapN(expsVal, regionVal) {
-        case (exps, region) => NamedAst.Expr.StructNew(name, exps, region, loc)
+        case (exps, region) => NamedAst.Expr.StructNew(structsym, exps, region, loc)
       }
 
-    case DesugaredAst.Expr.StructGet(e, name, loc) => 
+    case DesugaredAst.Expr.StructGet(e, name, loc) =>
       mapN(visitExp(e, ns0)) {
         case e => NamedAst.Expr.StructGet(e, name, loc)
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1324,6 +1324,10 @@ object Resolver {
           mapN(bVal) {
             b => ResolvedAst.Expr.ArrayLength(b, loc)
           }
+        
+        case NamedAst.Expr.StructNew(_, _, _, _) => throw new RuntimeException("Joe todo")
+        case NamedAst.Expr.StructGet(_, _, _) => throw new RuntimeException("Joe todo")
+        case NamedAst.Expr.StructPut(_, _, _, _) => throw new RuntimeException("Joe todo")
 
         case NamedAst.Expr.VectorLit(exps, loc) =>
           val expsVal = traverse(exps)(visitExp(_, env0))


### PR DESCRIPTION
The only significant transformation is with expressions of the form
```
new StructName { } @ r
```

I don't think anything can be done to the get and put struct expressions since with those the struct name is not listed