### PR TITLE
feat: Make traits for struct fields

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -228,13 +228,14 @@ object Weeder2 {
 
 
       // STRUCT TODO: Give this a name that cannot be accidentally overshadowed by the user?
-      val ident = Name.Ident("Dot" ++ fieldName, loc)
+      val traitName = "Dot_" ++ fieldName
+      val ident = Name.Ident(traitName, loc)
       val tparam = WeededAst.TypeParam.Kinded(Name.Ident("st_typ", loc), Kind.Ambiguous(Name.mkQName("Type", loc), loc))
       val fieldAssocType = WeededAst.Declaration.AssocTypeSig(doc, mod, Name.Ident("FieldType", loc), TypeParam.Unkinded(Name.Ident("st_typ", loc)), Kind.Ambiguous(Name.mkQName("Type"), loc), None, loc)
       val fieldAssocEff = WeededAst.Declaration.AssocTypeSig(doc, mod, Name.Ident("Eff", loc), TypeParam.Unkinded(Name.Ident("st_typ", loc)), Kind.Ambiguous(Name.mkQName("Eff"), loc), None, loc)
       val tvar = WeededAst.Type.Var(Name.Ident("st_typ", loc), loc)
-      val fieldType = Type.Apply(Type.Ambiguous(Name.mkQName("DotField.FieldType", loc), loc), tvar, loc)
-      val effType = Type.Apply(Type.Ambiguous(Name.mkQName("DotField.Aef", loc), loc), tvar, loc)
+      val fieldType = Type.Apply(Type.Ambiguous(Name.mkQName(traitName ++ ".FieldType", loc), loc), tvar, loc)
+      val effType = Type.Apply(Type.Ambiguous(Name.mkQName(traitName ++ ".Aef", loc), loc), tvar, loc)
       val getFormalParams = List(FormalParam(Name.Ident("st_val", loc), mod, Some(tvar), loc))
       val putFormalParams = getFormalParams :+ FormalParam(Name.Ident("field_val", loc), mod, Some(fieldType), loc)
       val getSig = WeededAst.Declaration.Sig(doc, ann, mod, Name.Ident("get", loc), TypeParams.Elided, getFormalParams, None, fieldType, Some(effType), List(), List(), loc)


### PR DESCRIPTION
The easiest way to do type inference for structs is to use `traits` and `instances` under the hood. For example
```
struct S [r] {
    a: Int32
}

```
will generate something like this:
```
trait Dot_a[st] {
    type FieldType[st]: Type
    type Aef[st]: Eff
    pub def get(s: st): Dot_a.FieldType[st] \ Dot_a.Aef[st]
    pub def put(s: st, v: Dot_a.FieldType[st]): Unit \ Dot_a.Aef[st]
}
instance Dot_a[S[r]] {
    type FieldType = Int32
    type Aef = r
    pub def get(st: S[r]): Int32 \ r = {TBD}
    pub def put(st: S[r], v: Int32): Unit \ r = {TBD}
}
```

This PR does the `trait` part of this process. 
