### PR TITLE
fix: TestCompilationMessage on windows

### DIFF
--- a/main/test/ca/uwaterloo/flix/language/errors/TestCompilationMessage.scala
+++ b/main/test/ca/uwaterloo/flix/language/errors/TestCompilationMessage.scala
@@ -22,7 +22,7 @@ class TestCompilationMessage extends AnyFunSuite with TestUtils {
 
     val actual = TestCompilationMessage.messageWithLoc(NoFormatter)
 
-    assert(expected == actual)
+    assert(actual.replace("\r\n", "\n") == expected.replace("\r\n", "\n"))
   }
 
 


### PR DESCRIPTION
This test doesn't pass on windows. There's something wrong with line endings - I really couldn't figure it out, so this is the lazy fix

Ah, the issue is that the file is in LF, so stripMargin produces \n newlines instead of the code that produces \r\n newlines even though the system uses \r\n. I think this supported the fact that we should ignore the newline format when comparing strings here