### PR TITLE
refactor: remove `Validation` from `Namer`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -921,12 +921,7 @@ object Namer {
 
     case DesugaredAst.Expr.ParYield(frags, exp, loc) =>
       val e = visitExp(exp, ns0)
-      val fs = frags.map {
-        case DesugaredAst.ParYieldFragment(pat, exp1, l) =>
-          val p = visitPattern(pat)
-          val e1 = visitExp(exp1, ns0)
-          NamedAst.ParYieldFragment(p, e1, l)
-      }
+      val fs = visitParYieldFragments(frags, ns0)
       NamedAst.Expr.ParYield(fs, e, loc)
 
     case DesugaredAst.Expr.Lazy(exp, loc) =>
@@ -1100,6 +1095,23 @@ object Namer {
     */
   private def visitSelectChannelRules(rules0: List[DesugaredAst.SelectChannelRule], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.SelectChannelRule] = {
     rules0.map(visitSelectChannelRule(_, ns0))
+  }
+
+  /**
+    * Performs naming on the given par-yield fragment `frag0`.
+    */
+  private def visitParYieldFragment(frag0: DesugaredAst.ParYieldFragment, ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): NamedAst.ParYieldFragment = frag0 match {
+    case DesugaredAst.ParYieldFragment(pat, exp1, l) =>
+      val p = visitPattern(pat)
+      val e1 = visitExp(exp1, ns0)
+      NamedAst.ParYieldFragment(p, e1, l)
+  }
+
+  /**
+    * Performs naming on the given par-yield fragments `frags0`.
+    */
+  private def visitParYieldFragments(frags0: List[DesugaredAst.ParYieldFragment], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.ParYieldFragment] = {
+    frags0.map(visitParYieldFragment(_, ns0))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.{BoundBy, Source}
 import ca.uwaterloo.flix.language.ast.DesugaredAst.Pattern.Record
-import ca.uwaterloo.flix.language.ast.DesugaredAst.RestrictableChoosePattern
+import ca.uwaterloo.flix.language.ast.DesugaredAst.{Declaration, RestrictableChoosePattern}
 import ca.uwaterloo.flix.language.ast.{NamedAst, _}
 import ca.uwaterloo.flix.language.dbg.AstPrinter._
 import ca.uwaterloo.flix.language.errors.NameError
@@ -445,7 +445,7 @@ object Namer {
 
       val sts = visitTypeConstraints(superTraits)
       val ascs = visitAssocTypeSigs(assocs, sym) // TODO switch param order to match visitSig
-      val sigs = signatures.map(visitSig(_, ns0, sym))
+      val sigs = visitSigs(signatures, ns0, sym)
       val lawsVal = traverse(laws0)(visitDef(_, ns0, DefKind.Member))
 
       mapN(lawsVal) {
@@ -523,6 +523,13 @@ object Namer {
       val sym = Symbol.mkSigSym(traitSym, ident)
       val spec = NamedAst.Spec(doc, ann, mod, tparams, fps, t, ef, tcsts, ecsts, loc)
       NamedAst.Declaration.Sig(sym, spec, e)
+  }
+
+  /**
+    * Performs naming on the given signature declarations `sigs0`.
+    */
+  private def visitSigs(sigs0: List[Declaration.Sig], ns0: Name.NName, sym: Symbol.TraitSym)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.Declaration.Sig] = {
+    sigs0.map(visitSig(_, ns0, sym))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -910,14 +910,7 @@ object Namer {
       NamedAst.Expr.PutChannel(e1, e2, loc)
 
     case DesugaredAst.Expr.SelectChannel(rules, exp, loc) =>
-      val rs = rules.map {
-        case DesugaredAst.SelectChannelRule(ident, exp1, exp2) =>
-          // make a fresh variable symbol for the local recursive variable.
-          val sym = Symbol.freshVarSym(ident, BoundBy.SelectRule)
-          val e1 = visitExp(exp1, ns0)
-          val e2 = visitExp(exp2, ns0)
-          NamedAst.SelectChannelRule(sym, e1, e2)
-      }
+      val rs = visitSelectChannelRules(rules, ns0)
       val e = exp.map(visitExp(_, ns0))
       NamedAst.Expr.SelectChannel(rs, e, loc)
 
@@ -1088,6 +1081,25 @@ object Namer {
     */
   private def visitTryWithRules(rules0: List[DesugaredAst.HandlerRule], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.HandlerRule] = {
     rules0.map(visitTryWithRule(_, ns0))
+  }
+
+  /**
+    * Performs naming on the given select channel rule `rule0`.
+    */
+  private def visitSelectChannelRule(rule0: DesugaredAst.SelectChannelRule, ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): NamedAst.SelectChannelRule = rule0 match {
+    case DesugaredAst.SelectChannelRule(ident, exp1, exp2) =>
+      // make a fresh variable symbol for the local recursive variable.
+      val sym = Symbol.freshVarSym(ident, BoundBy.SelectRule)
+      val e1 = visitExp(exp1, ns0)
+      val e2 = visitExp(exp2, ns0)
+      NamedAst.SelectChannelRule(sym, e1, e2)
+  }
+
+  /**
+    * Performs naming on the given select channel rules `rules0`.
+    */
+  private def visitSelectChannelRules(rules0: List[DesugaredAst.SelectChannelRule], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.SelectChannelRule] = {
+    rules0.map(visitSelectChannelRule(_, ns0))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -765,14 +765,14 @@ object Namer {
       NamedAst.Expr.ArrayLength(e, loc)
 
     case DesugaredAst.Expr.StructNew(name, exps, exp, loc) =>
-      val structsym = Symbol.mkStructSym(name.namespace, name.ident)
+      val structSym = Symbol.mkStructSym(name.namespace, name.ident)
       val e = visitExp(exp, ns0)
       val es = exps.map {
         case (n, exp1) =>
           val e = visitExp(exp1, ns0)
-          (Symbol.mkStructFieldSym(structsym, n), e)
+          (Symbol.mkStructFieldSym(structSym, n), e)
       }
-      NamedAst.Expr.StructNew(structsym, es, e, loc)
+      NamedAst.Expr.StructNew(structSym, es, e, loc)
 
     case DesugaredAst.Expr.StructGet(exp, name, loc) =>
       val structSym = Symbol.mkStructSym(ns0, ns0.idents.last)

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -702,13 +702,7 @@ object Namer {
 
     case DesugaredAst.Expr.TypeMatch(exp, rules, loc) =>
       val e = visitExp(exp, ns0)
-      val rs = rules.map {
-        case DesugaredAst.TypeMatchRule(ident, tpe, body) =>
-          val sym = Symbol.freshVarSym(ident, BoundBy.Pattern)
-          val t = visitType(tpe)
-          val b = visitExp(body, ns0)
-          NamedAst.TypeMatchRule(sym, t, b)
-      }
+      val rs = visitTypeMatchRules(rules, ns0)
       NamedAst.Expr.TypeMatch(e, rs, loc)
 
     case DesugaredAst.Expr.RestrictableChoose(star, exp, rules, loc) =>
@@ -1030,6 +1024,23 @@ object Namer {
     rules0.map(visitMatchRule(_, ns0))
   }
 
+  /**
+    * Performs naming on the given typematch rule `rule0`.
+    */
+  private def visitTypeMatchRule(rule0: DesugaredAst.TypeMatchRule, ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): NamedAst.TypeMatchRule = rule0 match {
+    case DesugaredAst.TypeMatchRule(ident, tpe, body) =>
+      val sym = Symbol.freshVarSym(ident, BoundBy.Pattern)
+      val t = visitType(tpe)
+      val b = visitExp(body, ns0)
+      NamedAst.TypeMatchRule(sym, t, b)
+  }
+
+  /**
+    * Performs naming on the given typematch rules `rules0`.
+    */
+  private def visitTypeMatchRules(rules0: List[DesugaredAst.TypeMatchRule], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.TypeMatchRule] = {
+    rules0.map(visitTypeMatchRule(_, ns0))
+  }
 
   /**
     * Names the given pattern `pat0`.

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -86,7 +86,7 @@ object Namer {
   private def visitDecl(decl0: DesugaredAst.Declaration, ns0: Name.NName)(implicit sctx: SharedContext, flix: Flix): Validation[NamedAst.Declaration, NameError] = decl0 match {
     case decl: DesugaredAst.Declaration.Namespace => visitNamespace(decl, ns0)
     case decl: DesugaredAst.Declaration.Trait => visitTrait(decl, ns0)
-    case decl: DesugaredAst.Declaration.Instance => visitInstance(decl, ns0)
+    case decl: DesugaredAst.Declaration.Instance => Validation.success(visitInstance(decl, ns0))
     case decl: DesugaredAst.Declaration.Def => Validation.success(visitDef(decl, ns0, DefKind.NonMember))
     case decl: DesugaredAst.Declaration.Enum => Validation.success(visitEnum(decl, ns0))
     case decl: DesugaredAst.Declaration.Struct => Validation.success(visitStruct(decl, ns0))
@@ -454,14 +454,14 @@ object Namer {
   /**
     * Performs naming on the given instance `instance`.
     */
-  private def visitInstance(instance: DesugaredAst.Declaration.Instance, ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): Validation[NamedAst.Declaration.Instance, NameError] = instance match {
+  private def visitInstance(instance: DesugaredAst.Declaration.Instance, ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): NamedAst.Declaration.Instance = instance match {
     case DesugaredAst.Declaration.Instance(doc, ann, mod, clazz, tpe, tconstrs, assocs, defs, loc) =>
       val tparams = getImplicitTypeParamsFromTypes(List(tpe))
       val t = visitType(tpe)
       val tcsts = visitTypeConstraints(tconstrs)
       val ascs = visitAssocTypeDefs(assocs)
       val ds = visitDefs(defs, ns0)
-      Validation.success(NamedAst.Declaration.Instance(doc, ann, mod, clazz, tparams, t, tcsts, ascs, ds, ns0.parts, loc))
+      NamedAst.Declaration.Instance(doc, ann, mod, clazz, tparams, t, tcsts, ascs, ds, ns0.parts, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -46,7 +46,7 @@ object Namer {
         case (macc, root) => macc + (root.loc.source -> root.loc)
       }
 
-      val units = ParOps.parMap(program.units) { case (s, u) => (s, visitUnit(u)) }.toMap
+      val units = ParOps.parMapValues(program.units)(visitUnit)
       val SymbolTable(symbols0, instances0, uses0) = units.values.foldLeft(SymbolTable.empty)(tableUnit)
 
       // TODO NS-REFACTOR remove use of NName

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -401,13 +401,13 @@ object Namer {
   /**
     * Performs naming on the given associated type signature `s0`.
     */
-  private def visitAssocTypeSig(s0: DesugaredAst.Declaration.AssocTypeSig, trt: Symbol.TraitSym)(implicit flix: Flix, sctx: SharedContext): Validation[NamedAst.Declaration.AssocTypeSig, NameError] = s0 match {
+  private def visitAssocTypeSig(s0: DesugaredAst.Declaration.AssocTypeSig, trt: Symbol.TraitSym)(implicit flix: Flix, sctx: SharedContext): NamedAst.Declaration.AssocTypeSig = s0 match {
     case DesugaredAst.Declaration.AssocTypeSig(doc, mod, ident, tparams0, kind0, tpe, loc) =>
       val sym = Symbol.mkAssocTypeSym(trt, ident)
       val tparam = visitTypeParam(tparams0)
       val kind = visitKind(kind0)
       val t = tpe.map(visitType)
-      Validation.success(NamedAst.Declaration.AssocTypeSig(doc, mod, sym, tparam, kind, t, loc))
+      NamedAst.Declaration.AssocTypeSig(doc, mod, sym, tparam, kind, t, loc)
   }
 
   /**
@@ -430,12 +430,12 @@ object Namer {
       val tparam = visitTypeParam(tparams0)
 
       val sts = visitTypeConstraints(superTraits)
-      val assocsVal = traverse(assocs0)(visitAssocTypeSig(_, sym)) // TODO switch param order to match visitSig
+      val assocs = assocs0.map(visitAssocTypeSig(_, sym)) // TODO switch param order to match visitSig
       val sigsVal = traverse(signatures)(visitSig(_, ns0, sym))
       val lawsVal = traverse(laws0)(visitDef(_, ns0, DefKind.Member))
 
-      mapN(assocsVal, sigsVal, lawsVal) {
-        case (assocs, sigs, laws) =>
+      mapN(sigsVal, lawsVal) {
+        case (sigs, laws) =>
           NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam, sts, assocs, sigs, laws, loc)
       }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -835,12 +835,7 @@ object Namer {
 
     case DesugaredAst.Expr.TryWith(exp, eff, rules, loc) =>
       val e = visitExp(exp, ns0)
-      val rs = rules.map {
-        case DesugaredAst.HandlerRule(op, fparams, body0) =>
-          val fps = visitFormalParams(fparams)
-          val b = visitExp(body0, ns0)
-          NamedAst.HandlerRule(op, fps, b)
-      }
+      val rs = visitTryWithRules(rules, ns0)
       NamedAst.Expr.TryWith(e, eff, rs, loc)
 
     case DesugaredAst.Expr.Do(op, exps, loc) =>
@@ -1076,6 +1071,23 @@ object Namer {
     */
   private def visitTryCatchRules(rules0: List[DesugaredAst.CatchRule], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.CatchRule] = {
     rules0.map(visitTryCatchRule(_, ns0))
+  }
+
+  /**
+    * Performs naming on the given handler rule `rule0`.
+    */
+  private def visitTryWithRule(rule0: DesugaredAst.HandlerRule, ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): NamedAst.HandlerRule = rule0 match {
+    case DesugaredAst.HandlerRule(op, fparams, body0) =>
+      val fps = visitFormalParams(fparams)
+      val b = visitExp(body0, ns0)
+      NamedAst.HandlerRule(op, fps, b)
+  }
+
+  /**
+    * Performs naming on the given handler rules `rules0`.
+    */
+  private def visitTryWithRules(rules0: List[DesugaredAst.HandlerRule], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.HandlerRule] = {
+    rules0.map(visitTryWithRule(_, ns0))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -563,7 +563,7 @@ object Namer {
       val sym = Symbol.mkEffectSym(ns0, ident)
 
       val mod = visitModifiers(mod0, ns0)
-      val ops = ops0.map(visitOp(_, ns0, sym))
+      val ops = visitOps(ops0, ns0, sym)
 
       Validation.success(NamedAst.Declaration.Effect(doc, ann, mod, sym, ops, loc))
   }
@@ -586,6 +586,13 @@ object Namer {
       val sym = Symbol.mkOpSym(effSym, ident)
       val spec = NamedAst.Spec(doc, ann, mod, tparams, fps, t, eff, tcsts, econstrs, loc)
       NamedAst.Declaration.Op(sym, spec)
+  }
+
+  /**
+    * Performs naming on the given effect operations `ops0`.
+    */
+  private def visitOps(ops0: List[DesugaredAst.Declaration.Op], ns0: Name.NName, effSym: Symbol.EffectSym)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.Declaration.Op] = {
+    ops0.map(visitOp(_, ns0, effSym))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -830,12 +830,7 @@ object Namer {
 
     case DesugaredAst.Expr.TryCatch(exp, rules, loc) =>
       val e = visitExp(exp, ns0)
-      val rs = rules.map {
-        case DesugaredAst.CatchRule(ident, className, body) =>
-          val sym = Symbol.freshVarSym(ident, BoundBy.CatchRule)
-          val b = visitExp(body, ns0)
-          NamedAst.CatchRule(sym, className, b)
-      }
+      val rs = visitTryCatchRules(rules, ns0)
       NamedAst.Expr.TryCatch(e, rs, loc)
 
     case DesugaredAst.Expr.TryWith(exp, eff, rules, loc) =>
@@ -1064,6 +1059,23 @@ object Namer {
     */
   private def visitStructFields(exps0: List[(Name.Ident, DesugaredAst.Expr)], ns0: Name.NName, structSym: Symbol.StructSym)(implicit flix: Flix, sctx: SharedContext): List[(Symbol.StructFieldSym, NamedAst.Expr)] = {
     exps0.map(visitStructField(_, ns0, structSym))
+  }
+
+  /**
+    * Performs naming on the given try-catch rule `rule0`.
+    */
+  private def visitTryCatchRule(rule0: DesugaredAst.CatchRule, ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): NamedAst.CatchRule = rule0 match {
+    case DesugaredAst.CatchRule(ident, className, body) =>
+      val sym = Symbol.freshVarSym(ident, BoundBy.CatchRule)
+      val b = visitExp(body, ns0)
+      NamedAst.CatchRule(sym, className, b)
+  }
+
+  /**
+    * Performs naming on the given try-catch rules `rules0`.
+    */
+  private def visitTryCatchRules(rules0: List[DesugaredAst.CatchRule], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.CatchRule] = {
+    rules0.map(visitTryCatchRule(_, ns0))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -428,6 +428,14 @@ object Namer {
   }
 
   /**
+    * Performs naming on the given associated type definitions `assocs0`.
+    */
+  private def visitAssocTypeDefs(assocs0: List[DesugaredAst.Declaration.AssocTypeDef])(implicit flix: Flix, sctx: SharedContext): List[NamedAst.Declaration.AssocTypeDef] = {
+    assocs0.map(visitAssocTypeDef)
+  }
+
+
+  /**
     * Performs naming on the given trait `trt`.
     */
   private def visitTrait(trt: DesugaredAst.Declaration.Trait, ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): Validation[NamedAst.Declaration.Trait, NameError] = trt match {
@@ -455,7 +463,7 @@ object Namer {
       val tparams = getImplicitTypeParamsFromTypes(List(tpe))
       val t = visitType(tpe)
       val tcsts = visitTypeConstraints(tconstrs)
-      val ascs = assocs.map(visitAssocTypeDef)
+      val ascs = visitAssocTypeDefs(assocs)
       val defsVal = traverse(defs0)(visitDef(_, ns0, DefKind.Member))
       mapN(defsVal) {
         defs => NamedAst.Declaration.Instance(doc, ann, mod, clazz, tparams, t, tcsts, ascs, defs, ns0.parts, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -445,11 +445,11 @@ object Namer {
 
       val sts = visitTypeConstraints(superTraits)
       val ascs = visitAssocTypeSigs(assocs, sym) // TODO switch param order to match visitSig
-      val sigsVal = traverse(signatures)(visitSig(_, ns0, sym))
+      val sigs = signatures.map(visitSig(_, ns0, sym))
       val lawsVal = traverse(laws0)(visitDef(_, ns0, DefKind.Member))
 
-      mapN(sigsVal, lawsVal) {
-        case (sigs, laws) =>
+      mapN(lawsVal) {
+        case laws =>
           NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam, sts, ascs, sigs, laws, loc)
       }
   }
@@ -505,7 +505,7 @@ object Namer {
   /**
     * Performs naming on the given signature declaration `sig`.
     */
-  private def visitSig(sig: DesugaredAst.Declaration.Sig, ns0: Name.NName, traitSym: Symbol.TraitSym)(implicit flix: Flix, sctx: SharedContext): Validation[NamedAst.Declaration.Sig, NameError] = sig match {
+  private def visitSig(sig: DesugaredAst.Declaration.Sig, ns0: Name.NName, traitSym: Symbol.TraitSym)(implicit flix: Flix, sctx: SharedContext): NamedAst.Declaration.Sig = sig match {
     case DesugaredAst.Declaration.Sig(doc, ann, mod0, ident, tparams0, fparams, exp, tpe, eff, tconstrs, econstrs, loc) =>
       val tparams = getTypeParamsFromFormalParams(tparams0, fparams, tpe, eff, econstrs)
 
@@ -522,7 +522,7 @@ object Namer {
 
       val sym = Symbol.mkSigSym(traitSym, ident)
       val spec = NamedAst.Spec(doc, ann, mod, tparams, fps, t, ef, tcsts, ecsts, loc)
-      Validation.success(NamedAst.Declaration.Sig(sym, spec, e))
+      NamedAst.Declaration.Sig(sym, spec, e)
   }
 
   /**
@@ -1064,7 +1064,7 @@ object Namer {
   /**
     * Names the given pattern `pat0`
     */
-  private def visitRestrictablePattern(pat0: DesugaredAst.RestrictableChoosePattern)(implicit flix: Flix, sctx: SharedContext): NamedAst.RestrictableChoosePattern = {
+  private def visitRestrictablePattern(pat0: DesugaredAst.RestrictableChoosePattern)(implicit flix: Flix): NamedAst.RestrictableChoosePattern = {
     def visitVarPlace(vp: DesugaredAst.RestrictableChoosePattern.VarOrWild): NamedAst.RestrictableChoosePattern.VarOrWild = vp match {
       case RestrictableChoosePattern.Wild(loc) => NamedAst.RestrictableChoosePattern.Wild(loc)
       case RestrictableChoosePattern.Var(ident, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -510,7 +510,7 @@ object Namer {
       val ecsts = visitEqualityConstraints(econstrs)
 
       // Then visit the parts depending on the parameters
-      val e = exp.map(visitExp(_, ns0))
+      val e = visitExp(exp, ns0)
 
       val sym = Symbol.mkSigSym(traitSym, ident)
       val spec = NamedAst.Spec(doc, ann, mod, tparams, fps, t, ef, tcsts, ecsts, loc)
@@ -909,7 +909,7 @@ object Namer {
 
     case DesugaredAst.Expr.SelectChannel(rules, exp, loc) =>
       val rs = visitSelectChannelRules(rules, ns0)
-      val e = exp.map(visitExp(_, ns0))
+      val e = visitExp(exp, ns0)
       NamedAst.Expr.SelectChannel(rs, e, loc)
 
     case DesugaredAst.Expr.Spawn(exp1, exp2, loc) =>
@@ -967,6 +967,13 @@ object Namer {
   }
 
   /**
+    * Performs naming on the given expression `exp0`.
+    */
+  private def visitExp(exp0: Option[DesugaredAst.Expr], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): Option[NamedAst.Expr] = {
+    exp0.map(visitExp(_, ns0))
+  }
+
+  /**
     * Performs naming on the given expressions `exps0`.
     */
   private def visitExps(exps0: List[DesugaredAst.Expr], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.Expr] = {
@@ -979,7 +986,7 @@ object Namer {
   private def visitMatchRule(rule0: DesugaredAst.MatchRule, ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): NamedAst.MatchRule = rule0 match {
     case DesugaredAst.MatchRule(pat, exp1, exp2) =>
       val p = visitPattern(pat)
-      val e1 = exp1.map(visitExp(_, ns0))
+      val e1 = visitExp(exp1, ns0)
       val e2 = visitExp(exp2, ns0)
       NamedAst.MatchRule(p, e1, e2)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -1414,7 +1414,7 @@ object Namer {
   /**
     * Performs naming on the given type parameter.
     */
-  private def visitTypeParam(tparam0: DesugaredAst.TypeParam)(implicit flix: Flix, sctx: SharedContext): NamedAst.TypeParam = tparam0 match {
+  private def visitTypeParam(tparam0: DesugaredAst.TypeParam)(implicit flix: Flix): NamedAst.TypeParam = tparam0 match {
     case DesugaredAst.TypeParam.Kinded(ident, kind) =>
       NamedAst.TypeParam.Kinded(ident, mkTypeVarSym(ident), visitKind(kind), ident.loc)
     case DesugaredAst.TypeParam.Unkinded(ident) =>
@@ -1448,7 +1448,7 @@ object Namer {
   /**
     * Names the explicit kinded type params.
     */
-  private def visitExplicitKindedTypeParams(tparams0: List[DesugaredAst.TypeParam.Kinded])(implicit flix: Flix, sctx: SharedContext): NamedAst.TypeParams.Kinded = {
+  private def visitExplicitKindedTypeParams(tparams0: List[DesugaredAst.TypeParam.Kinded])(implicit flix: Flix): NamedAst.TypeParams.Kinded = {
     val tparams = tparams0.map {
       case DesugaredAst.TypeParam.Kinded(ident, kind) =>
         NamedAst.TypeParam.Kinded(ident, mkTypeVarSym(ident), visitKind(kind), ident.loc)
@@ -1459,7 +1459,7 @@ object Namer {
   /**
     * Returns the explicit unkinded type parameters from the given type parameter names and implicit type parameters.
     */
-  private def visitExplicitTypeParams(tparams0: List[DesugaredAst.TypeParam.Unkinded])(implicit flix: Flix, sctx: SharedContext): NamedAst.TypeParams.Unkinded = {
+  private def visitExplicitTypeParams(tparams0: List[DesugaredAst.TypeParam.Unkinded])(implicit flix: Flix): NamedAst.TypeParams.Unkinded = {
     val tparams = tparams0.map {
       case DesugaredAst.TypeParam.Unkinded(ident) =>
         NamedAst.TypeParam.Unkinded(ident, mkTypeVarSym(ident), ident.loc)
@@ -1470,7 +1470,7 @@ object Namer {
   /**
     * Returns the implicit type parameters constructed from the given types.
     */
-  private def getImplicitTypeParamsFromTypes(types: List[DesugaredAst.Type])(implicit flix: Flix, sctx: SharedContext): NamedAst.TypeParams.Implicit = {
+  private def getImplicitTypeParamsFromTypes(types: List[DesugaredAst.Type])(implicit flix: Flix): NamedAst.TypeParams.Implicit = {
     val tvars = types.flatMap(freeTypeVars).distinct
     val tparams = tvars.map {
       ident => NamedAst.TypeParam.Implicit(ident, mkTypeVarSym(ident), ident.loc)
@@ -1481,7 +1481,7 @@ object Namer {
   /**
     * Returns the implicit type parameters constructed from the given formal parameters and type.
     */
-  private def visitImplicitTypeParamsFromFormalParams(fparams: List[DesugaredAst.FormalParam], tpe: DesugaredAst.Type, eff: Option[DesugaredAst.Type], econstrs: List[DesugaredAst.EqualityConstraint])(implicit flix: Flix, sctx: SharedContext): NamedAst.TypeParams = {
+  private def visitImplicitTypeParamsFromFormalParams(fparams: List[DesugaredAst.FormalParam], tpe: DesugaredAst.Type, eff: Option[DesugaredAst.Type], econstrs: List[DesugaredAst.EqualityConstraint])(implicit flix: Flix): NamedAst.TypeParams = {
     // Compute the type variables that occur in the formal parameters.
     val fparamTvars = fparams.flatMap {
       case DesugaredAst.FormalParam(_, _, Some(tpe1), _) => freeTypeVars(tpe1)

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -85,7 +85,7 @@ object Namer {
     */
   private def visitDecl(decl0: DesugaredAst.Declaration, ns0: Name.NName)(implicit sctx: SharedContext, flix: Flix): Validation[NamedAst.Declaration, NameError] = decl0 match {
     case decl: DesugaredAst.Declaration.Namespace => visitNamespace(decl, ns0)
-    case decl: DesugaredAst.Declaration.Trait => visitTrait(decl, ns0)
+    case decl: DesugaredAst.Declaration.Trait => Validation.success(visitTrait(decl, ns0))
     case decl: DesugaredAst.Declaration.Instance => Validation.success(visitInstance(decl, ns0))
     case decl: DesugaredAst.Declaration.Def => Validation.success(visitDef(decl, ns0, DefKind.NonMember))
     case decl: DesugaredAst.Declaration.Enum => Validation.success(visitEnum(decl, ns0))
@@ -437,7 +437,7 @@ object Namer {
   /**
     * Performs naming on the given trait `trt`.
     */
-  private def visitTrait(trt: DesugaredAst.Declaration.Trait, ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): Validation[NamedAst.Declaration.Trait, NameError] = trt match {
+  private def visitTrait(trt: DesugaredAst.Declaration.Trait, ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): NamedAst.Declaration.Trait = trt match {
     case DesugaredAst.Declaration.Trait(doc, ann, mod0, ident, tparams0, superTraits, assocs, signatures, laws, loc) =>
       val sym = Symbol.mkTraitSym(ns0, ident)
       val mod = visitModifiers(mod0, ns0)
@@ -448,7 +448,7 @@ object Namer {
       val sigs = visitSigs(signatures, ns0, sym)
       val ls = visitDefs(laws, ns0)
 
-      Validation.success(NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam, sts, ascs, sigs, ls, loc))
+      NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam, sts, ascs, sigs, ls, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -759,11 +759,7 @@ object Namer {
     case DesugaredAst.Expr.StructNew(name, exps, exp, loc) =>
       val structSym = Symbol.mkStructSym(name.namespace, name.ident)
       val e = visitExp(exp, ns0)
-      val es = exps.map {
-        case (n, exp1) =>
-          val e = visitExp(exp1, ns0)
-          (Symbol.mkStructFieldSym(structSym, n), e)
-      }
+      val es = visitStructFields(exps, ns0, structSym)
       NamedAst.Expr.StructNew(structSym, es, e, loc)
 
     case DesugaredAst.Expr.StructGet(exp, name, loc) =>
@@ -1052,6 +1048,22 @@ object Namer {
     */
   private def visitRestrictableChooseRules(rules0: List[DesugaredAst.RestrictableChooseRule], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.RestrictableChooseRule] = {
     rules0.map(visitRestrictableChooseRule(_, ns0))
+  }
+
+  /**
+    * Performs naming on the given struct field expression `exp0`.
+    */
+  private def visitStructField(exp0: (Name.Ident, DesugaredAst.Expr), ns0: Name.NName, structSym: Symbol.StructSym)(implicit flix: Flix, sctx: SharedContext): (Symbol.StructFieldSym, NamedAst.Expr) = exp0 match {
+    case (n, exp1) =>
+      val e = visitExp(exp1, ns0)
+      (Symbol.mkStructFieldSym(structSym, n), e)
+  }
+
+  /**
+    * Performs naming on the given struct field expressions `exps0`.
+    */
+  private def visitStructFields(exps0: List[(Name.Ident, DesugaredAst.Expr)], ns0: Name.NName, structSym: Symbol.StructSym)(implicit flix: Flix, sctx: SharedContext): List[(Symbol.StructFieldSym, NamedAst.Expr)] = {
+    exps0.map(visitStructField(_, ns0, structSym))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.{BoundBy, Source}
 import ca.uwaterloo.flix.language.ast.DesugaredAst.Pattern.Record
-import ca.uwaterloo.flix.language.ast.DesugaredAst.{Declaration, RestrictableChoosePattern}
+import ca.uwaterloo.flix.language.ast.DesugaredAst.RestrictableChoosePattern
 import ca.uwaterloo.flix.language.ast.{NamedAst, _}
 import ca.uwaterloo.flix.language.dbg.AstPrinter._
 import ca.uwaterloo.flix.language.errors.NameError
@@ -522,7 +522,7 @@ object Namer {
   /**
     * Performs naming on the given signature declarations `sigs0`.
     */
-  private def visitSigs(sigs0: List[Declaration.Sig], ns0: Name.NName, sym: Symbol.TraitSym)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.Declaration.Sig] = {
+  private def visitSigs(sigs0: List[DesugaredAst.Declaration.Sig], ns0: Name.NName, sym: Symbol.TraitSym)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.Declaration.Sig] = {
     sigs0.map(visitSig(_, ns0, sym))
   }
 
@@ -560,7 +560,7 @@ object Namer {
   /**
     * Performs naming on the given definition declarations `decls0`.
     */
-  private def visitDefs(decls0: List[Declaration.Def], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.Declaration.Def] = {
+  private def visitDefs(decls0: List[DesugaredAst.Declaration.Def], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.Declaration.Def] = {
     decls0.map(visitDef(_, ns0, DefKind.Member))
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -967,40 +967,33 @@ object Namer {
 
     case DesugaredAst.Expr.FixpointLambda(pparams, exp, loc) =>
       val ps = pparams.map(visitPredicateParam)
-      val expVal = visitExp(exp, ns0)
-      mapN(expVal) {
-        case e => NamedAst.Expr.FixpointLambda(ps, e, loc)
-      }
+      val e = visitExp(exp, ns0)
+      NamedAst.Expr.FixpointLambda(ps, e, loc)
 
     case DesugaredAst.Expr.FixpointMerge(exp1, exp2, loc) =>
-      mapN(visitExp(exp1, ns0), visitExp(exp2, ns0)) {
-        case (e1, e2) => NamedAst.Expr.FixpointMerge(e1, e2, loc)
-      }
+      val e1 = visitExp(exp1, ns0)
+      val e2 = visitExp(exp2, ns0)
+      NamedAst.Expr.FixpointMerge(e1, e2, loc)
 
     case DesugaredAst.Expr.FixpointSolve(exp, loc) =>
-      mapN(visitExp(exp, ns0)) {
-        case e => NamedAst.Expr.FixpointSolve(e, loc)
-      }
+      val e = visitExp(exp, ns0)
+      NamedAst.Expr.FixpointSolve(e, loc)
 
     case DesugaredAst.Expr.FixpointFilter(ident, exp, loc) =>
-      mapN(visitExp(exp, ns0)) {
-        case e => NamedAst.Expr.FixpointFilter(ident, e, loc)
-      }
+      val e = visitExp(exp, ns0)
+      NamedAst.Expr.FixpointFilter(ident, e, loc)
 
     case DesugaredAst.Expr.FixpointInject(exp, pred, loc) =>
-      mapN(visitExp(exp, ns0)) {
-        case e => NamedAst.Expr.FixpointInject(e, pred, loc)
-      }
+      val e = visitExp(exp, ns0)
+      NamedAst.Expr.FixpointInject(e, pred, loc)
 
     case DesugaredAst.Expr.FixpointProject(pred, exp1, exp2, loc) =>
-      mapN(visitExp(exp1, ns0), visitExp(exp2, ns0)) {
-        case (e1, e2) => NamedAst.Expr.FixpointProject(pred, e1, e2, loc)
-      }
+      val e1 = visitExp(exp1, ns0)
+      val e2 = visitExp(exp2, ns0)
+      NamedAst.Expr.FixpointProject(pred, e1, e2, loc)
 
     case DesugaredAst.Expr.Error(m) =>
-      // Note: We must NOT use [[Validation.toSoftFailure]] because
-      // that would duplicate the error inside the Validation.
-      Validation.success(NamedAst.Expr.Error(m))
+      NamedAst.Expr.Error(m)
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -74,7 +74,7 @@ object Namer {
   private def visitUnit(unit: DesugaredAst.CompilationUnit)(implicit sctx: SharedContext, flix: Flix): Validation[NamedAst.CompilationUnit, NameError] = unit match {
     case DesugaredAst.CompilationUnit(usesAndImports0, decls, loc) =>
       val usesAndImports = usesAndImports0.map(visitUseOrImport)
-      val ds = decls.map(visitDecl(_, Name.RootNS))
+      val ds = visitDecls(decls, Name.RootNS)
       Validation.success(NamedAst.CompilationUnit(usesAndImports, ds, loc))
   }
 
@@ -95,13 +95,20 @@ object Namer {
   }
 
   /**
+    * Performs naming on the given declarations `decls0`.
+    */
+  private def visitDecls(decls0: List[DesugaredAst.Declaration], ns0: Name.NName)(implicit sctx: SharedContext, flix: Flix): List[NamedAst.Declaration] = {
+    decls0.map(visitDecl(_, ns0))
+  }
+
+  /**
     * Performs naming on the given namespace.
     */
   private def visitNamespace(decl: DesugaredAst.Declaration.Namespace, ns0: Name.NName)(implicit sctx: SharedContext, flix: Flix): NamedAst.Declaration.Namespace = decl match {
     case DesugaredAst.Declaration.Namespace(ident, usesAndImports0, decls, loc) =>
       val ns = Name.NName(ns0.idents :+ ident, ident.loc)
       val usesAndImports = usesAndImports0.map(visitUseOrImport)
-      val ds = decls.map(visitDecl(_, ns))
+      val ds = visitDecls(decls, ns)
       val sym = new Symbol.ModuleSym(ns.parts)
       NamedAst.Declaration.Namespace(sym, usesAndImports, ds, loc)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -18,7 +18,6 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.{BoundBy, Source}
-import ca.uwaterloo.flix.language.ast.DesugaredAst.Pattern.Record
 import ca.uwaterloo.flix.language.ast.{NamedAst, _}
 import ca.uwaterloo.flix.language.dbg.AstPrinter._
 import ca.uwaterloo.flix.language.errors.NameError
@@ -1392,8 +1391,8 @@ object Namer {
   /**
     * Returns the free variables in the list of [[Record.RecordLabelPattern]] `pats`.
     */
-  private def recordPatternFreeVars(pats: List[Record.RecordLabelPattern]): List[Name.Ident] = {
-    def optFreeVars(rfp: Record.RecordLabelPattern): List[Name.Ident] = rfp.pat.map(freeVars).getOrElse(Nil)
+  private def recordPatternFreeVars(pats: List[DesugaredAst.Pattern.Record.RecordLabelPattern]): List[Name.Ident] = {
+    def optFreeVars(rfp: DesugaredAst.Pattern.Record.RecordLabelPattern): List[Name.Ident] = rfp.pat.map(freeVars).getOrElse(Nil)
 
     pats.flatMap(optFreeVars)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -707,12 +707,7 @@ object Namer {
 
     case DesugaredAst.Expr.RestrictableChoose(star, exp, rules, loc) =>
       val e = visitExp(exp, ns0)
-      val rs = rules.map {
-        case DesugaredAst.RestrictableChooseRule(pat, exp1) =>
-          val p = visitRestrictablePattern(pat)
-          val e1 = visitExp(exp1, ns0)
-          NamedAst.RestrictableChooseRule(p, e1)
-      }
+      val rs = visitRestrictableChooseRules(rules, ns0)
       NamedAst.Expr.RestrictableChoose(star, e, rs, loc)
 
     case DesugaredAst.Expr.Tuple(exps, loc) =>
@@ -1040,6 +1035,23 @@ object Namer {
     */
   private def visitTypeMatchRules(rules0: List[DesugaredAst.TypeMatchRule], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.TypeMatchRule] = {
     rules0.map(visitTypeMatchRule(_, ns0))
+  }
+
+  /**
+    * Performs naming on the given restrictable choose rule `rule0`.
+    */
+  private def visitRestrictableChooseRule(rule0: DesugaredAst.RestrictableChooseRule, ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): NamedAst.RestrictableChooseRule = rule0 match {
+    case DesugaredAst.RestrictableChooseRule(pat, exp1) =>
+      val p = visitRestrictablePattern(pat)
+      val e1 = visitExp(exp1, ns0)
+      NamedAst.RestrictableChooseRule(p, e1)
+  }
+
+  /**
+    * Performs naming on the given restrictable choose rules `rules0`.
+    */
+  private def visitRestrictableChooseRules(rules0: List[DesugaredAst.RestrictableChooseRule], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.RestrictableChooseRule] = {
+    rules0.map(visitRestrictableChooseRule(_, ns0))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -19,7 +19,6 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.{BoundBy, Source}
 import ca.uwaterloo.flix.language.ast.DesugaredAst.Pattern.Record
-import ca.uwaterloo.flix.language.ast.DesugaredAst.RestrictableChoosePattern
 import ca.uwaterloo.flix.language.ast.{NamedAst, _}
 import ca.uwaterloo.flix.language.dbg.AstPrinter._
 import ca.uwaterloo.flix.language.errors.NameError
@@ -1157,8 +1156,8 @@ object Namer {
     */
   private def visitRestrictablePattern(pat0: DesugaredAst.RestrictableChoosePattern)(implicit flix: Flix): NamedAst.RestrictableChoosePattern = {
     def visitVarPlace(vp: DesugaredAst.RestrictableChoosePattern.VarOrWild): NamedAst.RestrictableChoosePattern.VarOrWild = vp match {
-      case RestrictableChoosePattern.Wild(loc) => NamedAst.RestrictableChoosePattern.Wild(loc)
-      case RestrictableChoosePattern.Var(ident, loc) =>
+      case DesugaredAst.RestrictableChoosePattern.Wild(loc) => NamedAst.RestrictableChoosePattern.Wild(loc)
+      case DesugaredAst.RestrictableChoosePattern.Var(ident, loc) =>
         // make a fresh variable symbol for the local variable.
         val sym = Symbol.freshVarSym(ident, BoundBy.Pattern)
         NamedAst.RestrictableChoosePattern.Var(sym, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -72,42 +72,38 @@ object Namer {
     * Performs naming on the given compilation unit `unit` under the given (partial) program `prog0`.
     */
   private def visitUnit(unit: DesugaredAst.CompilationUnit)(implicit sctx: SharedContext, flix: Flix): Validation[NamedAst.CompilationUnit, NameError] = unit match {
-    case DesugaredAst.CompilationUnit(usesAndImports0, decls0, loc) =>
+    case DesugaredAst.CompilationUnit(usesAndImports0, decls, loc) =>
       val usesAndImports = usesAndImports0.map(visitUseOrImport)
-      val declsVal = traverse(decls0)(visitDecl(_, Name.RootNS))
-      mapN(declsVal) {
-        case decls => NamedAst.CompilationUnit(usesAndImports, decls, loc)
-      }
+      val ds = decls.map(visitDecl(_, Name.RootNS))
+      Validation.success(NamedAst.CompilationUnit(usesAndImports, ds, loc))
   }
 
   /**
     * Performs naming on the given declaration.
     */
-  private def visitDecl(decl0: DesugaredAst.Declaration, ns0: Name.NName)(implicit sctx: SharedContext, flix: Flix): Validation[NamedAst.Declaration, NameError] = decl0 match {
+  private def visitDecl(decl0: DesugaredAst.Declaration, ns0: Name.NName)(implicit sctx: SharedContext, flix: Flix): NamedAst.Declaration = decl0 match {
     case decl: DesugaredAst.Declaration.Namespace => visitNamespace(decl, ns0)
-    case decl: DesugaredAst.Declaration.Trait => Validation.success(visitTrait(decl, ns0))
-    case decl: DesugaredAst.Declaration.Instance => Validation.success(visitInstance(decl, ns0))
-    case decl: DesugaredAst.Declaration.Def => Validation.success(visitDef(decl, ns0, DefKind.NonMember))
-    case decl: DesugaredAst.Declaration.Enum => Validation.success(visitEnum(decl, ns0))
-    case decl: DesugaredAst.Declaration.Struct => Validation.success(visitStruct(decl, ns0))
-    case decl: DesugaredAst.Declaration.RestrictableEnum => Validation.success(visitRestrictableEnum(decl, ns0))
-    case decl: DesugaredAst.Declaration.TypeAlias => Validation.success(visitTypeAlias(decl, ns0))
-    case decl: DesugaredAst.Declaration.Effect => Validation.success(visitEffect(decl, ns0))
+    case decl: DesugaredAst.Declaration.Trait => visitTrait(decl, ns0)
+    case decl: DesugaredAst.Declaration.Instance => visitInstance(decl, ns0)
+    case decl: DesugaredAst.Declaration.Def => visitDef(decl, ns0, DefKind.NonMember)
+    case decl: DesugaredAst.Declaration.Enum => visitEnum(decl, ns0)
+    case decl: DesugaredAst.Declaration.Struct => visitStruct(decl, ns0)
+    case decl: DesugaredAst.Declaration.RestrictableEnum => visitRestrictableEnum(decl, ns0)
+    case decl: DesugaredAst.Declaration.TypeAlias => visitTypeAlias(decl, ns0)
+    case decl: DesugaredAst.Declaration.Effect => visitEffect(decl, ns0)
     case decl: DesugaredAst.Declaration.Law => throw InternalCompilerException("unexpected law", decl.loc)
   }
 
   /**
     * Performs naming on the given namespace.
     */
-  private def visitNamespace(decl: DesugaredAst.Declaration.Namespace, ns0: Name.NName)(implicit sctx: SharedContext, flix: Flix): Validation[NamedAst.Declaration.Namespace, NameError] = decl match {
-    case DesugaredAst.Declaration.Namespace(ident, usesAndImports0, decls0, loc) =>
+  private def visitNamespace(decl: DesugaredAst.Declaration.Namespace, ns0: Name.NName)(implicit sctx: SharedContext, flix: Flix): NamedAst.Declaration.Namespace = decl match {
+    case DesugaredAst.Declaration.Namespace(ident, usesAndImports0, decls, loc) =>
       val ns = Name.NName(ns0.idents :+ ident, ident.loc)
       val usesAndImports = usesAndImports0.map(visitUseOrImport)
-      val declsVal = traverse(decls0)(visitDecl(_, ns))
+      val ds = decls.map(visitDecl(_, ns))
       val sym = new Symbol.ModuleSym(ns.parts)
-      mapN(declsVal) {
-        case decls => NamedAst.Declaration.Namespace(sym, usesAndImports, decls, loc)
-      }
+      NamedAst.Declaration.Namespace(sym, usesAndImports, ds, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -566,17 +566,15 @@ object Namer {
       val sym = Symbol.mkEffectSym(ns0, ident)
 
       val mod = visitModifiers(mod0, ns0)
-      val opsVal = traverse(ops0)(visitOp(_, ns0, sym))
+      val ops = ops0.map(visitOp(_, ns0, sym))
 
-      mapN(opsVal) {
-        case ops => NamedAst.Declaration.Effect(doc, ann, mod, sym, ops, loc)
-      }
+      Validation.success(NamedAst.Declaration.Effect(doc, ann, mod, sym, ops, loc))
   }
 
   /**
     * Performs naming on the given effect operation `op0`.
     */
-  private def visitOp(op0: DesugaredAst.Declaration.Op, ns0: Name.NName, effSym: Symbol.EffectSym)(implicit flix: Flix, sctx: SharedContext): Validation[NamedAst.Declaration.Op, NameError] = op0 match {
+  private def visitOp(op0: DesugaredAst.Declaration.Op, ns0: Name.NName, effSym: Symbol.EffectSym)(implicit flix: Flix, sctx: SharedContext): NamedAst.Declaration.Op = op0 match {
     case DesugaredAst.Declaration.Op(doc, ann, mod0, ident, fparams, tpe, tconstrs, loc) =>
       // First visit all the top-level information
       val mod = visitModifiers(mod0, ns0)
@@ -590,7 +588,7 @@ object Namer {
 
       val sym = Symbol.mkOpSym(effSym, ident)
       val spec = NamedAst.Spec(doc, ann, mod, tparams, fps, t, eff, tcsts, econstrs, loc)
-      Validation.success(NamedAst.Declaration.Op(sym, spec))
+      NamedAst.Declaration.Op(sym, spec)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -92,7 +92,7 @@ object Namer {
     case decl: DesugaredAst.Declaration.Struct => Validation.success(visitStruct(decl, ns0))
     case decl: DesugaredAst.Declaration.RestrictableEnum => Validation.success(visitRestrictableEnum(decl, ns0))
     case decl: DesugaredAst.Declaration.TypeAlias => Validation.success(visitTypeAlias(decl, ns0))
-    case decl: DesugaredAst.Declaration.Effect => visitEffect(decl, ns0)
+    case decl: DesugaredAst.Declaration.Effect => Validation.success(visitEffect(decl, ns0))
     case decl: DesugaredAst.Declaration.Law => throw InternalCompilerException("unexpected law", decl.loc)
   }
 
@@ -566,14 +566,12 @@ object Namer {
   /**
     * Performs naming on the given effect `eff0`.
     */
-  private def visitEffect(eff0: DesugaredAst.Declaration.Effect, ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): Validation[NamedAst.Declaration.Effect, NameError] = eff0 match {
+  private def visitEffect(eff0: DesugaredAst.Declaration.Effect, ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): NamedAst.Declaration.Effect = eff0 match {
     case DesugaredAst.Declaration.Effect(doc, ann, mod0, ident, ops0, loc) =>
       val sym = Symbol.mkEffectSym(ns0, ident)
-
       val mod = visitModifiers(mod0, ns0)
       val ops = visitOps(ops0, ns0, sym)
-
-      Validation.success(NamedAst.Declaration.Effect(doc, ann, mod, sym, ops, loc))
+      NamedAst.Declaration.Effect(doc, ann, mod, sym, ops, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -446,7 +446,7 @@ object Namer {
       val sts = visitTypeConstraints(superTraits)
       val ascs = visitAssocTypeSigs(assocs, sym) // TODO switch param order to match visitSig
       val sigs = visitSigs(signatures, ns0, sym)
-      val ls = laws.map(visitDef(_, ns0, DefKind.Member))
+      val ls = visitDefs(laws, ns0)
 
       Validation.success(NamedAst.Declaration.Trait(doc, ann, mod, sym, tparam, sts, ascs, sigs, ls, loc))
   }
@@ -460,7 +460,7 @@ object Namer {
       val t = visitType(tpe)
       val tcsts = visitTypeConstraints(tconstrs)
       val ascs = visitAssocTypeDefs(assocs)
-      val ds = defs.map(visitDef(_, ns0, DefKind.Member))
+      val ds = visitDefs(defs, ns0)
       Validation.success(NamedAst.Declaration.Instance(doc, ann, mod, clazz, tparams, t, tcsts, ascs, ds, ns0.parts, loc))
   }
 
@@ -556,6 +556,13 @@ object Namer {
       val sym = Symbol.mkDefnSym(ns0, ident, id)
       val spec = NamedAst.Spec(doc, ann, mod, tparams, fps, t, ef, tcsts, ecsts, loc)
       NamedAst.Declaration.Def(sym, spec, e)
+  }
+
+  /**
+    * Performs naming on the given definition declarations `decls0`.
+    */
+  private def visitDefs(decls0: List[Declaration.Def], ns0: Name.NName)(implicit flix: Flix, sctx: SharedContext): List[NamedAst.Declaration.Def] = {
+    decls0.map(visitDef(_, ns0, DefKind.Member))
   }
 
   /**


### PR DESCRIPTION
This is one big PR containing all changes to `Namer`. We can either choose to merge it all or just split it out into smaller PRs.

Depends on https://github.com/flix/flix/pull/8056
Closes https://github.com/flix/flix/issues/7875