### PR TITLE
feat: add `--Xno-deprecated` and enable for old-style Java interop

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -101,7 +101,7 @@ object Main {
       xnoqmc = cmdOpts.xnoqmc,
       xnooptimizer = cmdOpts.xnooptimizer,
       xprintphases = cmdOpts.xprintphases,
-      xdeprecated = cmdOpts.xdeprecated,
+      xnodeprecated = cmdOpts.xnodeprecated,
       xsummary = cmdOpts.xsummary,
       xfuzzer = cmdOpts.xfuzzer,
       xprinttyper = cmdOpts.xprinttyper,
@@ -358,7 +358,7 @@ object Main {
                      xbenchmarkPhases: Boolean = false,
                      xbenchmarkFrontend: Boolean = false,
                      xbenchmarkThroughput: Boolean = false,
-                     xdeprecated: Boolean = false,
+                     xnodeprecated: Boolean = false,
                      xbddthreshold: Option[Int] = None,
                      xlib: LibLevel = LibLevel.All,
                      xnoboolcache: Boolean = false,
@@ -558,9 +558,9 @@ object Main {
       opt[LibLevel]("Xlib").action((arg, c) => c.copy(xlib = arg)).
         text("[experimental] controls the amount of std. lib. to include (nix, min, all).")
 
-      // Xdeprecated
-      opt[Unit]("Xdeprecated").action((_, c) => c.copy(xdeprecated = true)).
-        text("[experimental] enables deprecated features.")
+      // Xnl-deprecated
+      opt[Unit]("Xno-deprecated").action((_, c) => c.copy(xnodeprecated = true)).
+        text("[experimental] disables deprecated features.")
 
       // Xno-optimizer
       opt[Unit]("Xno-optimizer").action((_, c) => c.copy(xnooptimizer = true)).

--- a/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
@@ -184,11 +184,11 @@ object DesugaredAst {
 
     case class InvokeStaticMethod2(clazzName: Name.Ident, methodName: Name.Ident, exps: List[Expr], loc: SourceLocation) extends Expr
 
-    case class InvokeConstructor(className: String, exps: List[Expr], sig: List[Type], loc: SourceLocation) extends Expr
+    case class InvokeConstructorOld(className: String, exps: List[Expr], sig: List[Type], loc: SourceLocation) extends Expr
 
-    case class InvokeMethod(className: String, methodName: String, exp: Expr, exps: List[Expr], sig: List[Type], retTpe: Type, loc: SourceLocation) extends Expr
+    case class InvokeMethodOld(className: String, methodName: String, exp: Expr, exps: List[Expr], sig: List[Type], retTpe: Type, loc: SourceLocation) extends Expr
 
-    case class InvokeStaticMethod(className: String, methodName: String, exps: List[Expr], sig: List[Type], retTpe: Type, loc: SourceLocation) extends Expr
+    case class InvokeStaticMethodOld(className: String, methodName: String, exps: List[Expr], sig: List[Type], retTpe: Type, loc: SourceLocation) extends Expr
 
     case class GetField(className: String, fieldName: String, exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -182,11 +182,11 @@ object KindedAst {
 
     case class InvokeStaticMethod2(clazz: Class[_], methodName: Name.Ident, exps: List[Expr], mvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 
-    case class InvokeConstructor(constructor: Constructor[_], exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeConstructorOld(constructor: Constructor[_], exps: List[Expr], loc: SourceLocation) extends Expr
 
-    case class InvokeMethod(method: Method, clazz: java.lang.Class[_], exp: Expr, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeMethodOld(method: Method, clazz: java.lang.Class[_], exp: Expr, exps: List[Expr], loc: SourceLocation) extends Expr
 
-    case class InvokeStaticMethod(method: Method, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeStaticMethodOld(method: Method, exps: List[Expr], loc: SourceLocation) extends Expr
 
     case class GetField(field: Field, clazz: java.lang.Class[_], exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -196,11 +196,11 @@ object NamedAst {
 
     case class InvokeStaticMethod2(clazzName: Name.Ident, methodName: Name.Ident, exps: List[Expr], loc: SourceLocation) extends Expr
 
-    case class InvokeConstructor(className: String, exps: List[Expr], sig: List[Type], loc: SourceLocation) extends Expr
+    case class InvokeConstructorOld(className: String, exps: List[Expr], sig: List[Type], loc: SourceLocation) extends Expr
 
-    case class InvokeMethod(className: String, methodName: String, exp: Expr, exps: List[Expr], sig: List[Type], retTpe: Type, loc: SourceLocation) extends Expr
+    case class InvokeMethodOld(className: String, methodName: String, exp: Expr, exps: List[Expr], sig: List[Type], retTpe: Type, loc: SourceLocation) extends Expr
 
-    case class InvokeStaticMethod(className: String, methodName: String, exps: List[Expr], sig: List[Type], retTpe: Type, loc: SourceLocation) extends Expr
+    case class InvokeStaticMethodOld(className: String, methodName: String, exps: List[Expr], sig: List[Type], retTpe: Type, loc: SourceLocation) extends Expr
 
     case class GetField(className: String, fieldName: String, exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -199,11 +199,11 @@ object ResolvedAst {
 
     case class InvokeStaticMethod2(clazz: Class[_], methodName: Name.Ident, exps: List[Expr], loc: SourceLocation) extends Expr
 
-    case class InvokeConstructor(constructor: Constructor[_], exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeConstructorOld(constructor: Constructor[_], exps: List[Expr], loc: SourceLocation) extends Expr
 
-    case class InvokeMethod(method: Method, clazz: java.lang.Class[_], exp: Expr, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeMethodOld(method: Method, clazz: java.lang.Class[_], exp: Expr, exps: List[Expr], loc: SourceLocation) extends Expr
 
-    case class InvokeStaticMethod(method: Method, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class InvokeStaticMethodOld(method: Method, exps: List[Expr], loc: SourceLocation) extends Expr
 
     case class GetField(field: Field, clazz: java.lang.Class[_], exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -208,20 +208,6 @@ object WeededAst {
 
     case class InvokeStaticMethod2(clazzName: Name.Ident, methodName: Name.Ident, exps: List[Expr], loc: SourceLocation) extends Expr
 
-    case class InvokeConstructor(className: String, exps: List[Expr], sig: List[Type], loc: SourceLocation) extends Expr
-
-    case class InvokeMethod(className: String, methodName: String, exp: Expr, exps: List[Expr], sig: List[Type], retTpe: Type, loc: SourceLocation) extends Expr
-
-    case class InvokeStaticMethod(className: String, methodName: String, exps: List[Expr], sig: List[Type], retTpe: Type, loc: SourceLocation) extends Expr
-
-    case class GetField(className: String, fieldName: String, exp: Expr, loc: SourceLocation) extends Expr
-
-    case class PutField(className: String, fieldName: String, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
-
-    case class GetStaticField(className: String, fieldName: String, loc: SourceLocation) extends Expr
-
-    case class PutStaticField(className: String, fieldName: String, exp: Expr, loc: SourceLocation) extends Expr
-
     case class NewObject(tpe: Type, methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
     case class StructGet(exp: Expr, label: Name.Label, loc: SourceLocation) extends Expr

--- a/main/src/ca/uwaterloo/flix/language/errors/NameError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/NameError.scala
@@ -30,6 +30,25 @@ sealed trait NameError extends CompilationMessage with Recoverable {
 object NameError {
 
   /**
+    * An error raised to indicate a deprecated feature
+    * *
+    * @param loc the location of the deprecated feature.
+    */
+  case class Deprecated(loc: SourceLocation) extends NameError with Recoverable {
+    def summary: String = s"Deprecated feature."
+
+    def message(formatter: Formatter): String = {
+      import formatter._
+      s""">> Deprecated feature. Use --Xdeprecated to enable.
+         |
+         |${code(loc, "deprecated")}
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = None
+  }
+
+  /**
     * An error raised to indicate that the given `name` is defined multiple time.
     *
     * @param name the name.

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -29,26 +29,6 @@ sealed trait WeederError extends CompilationMessage {
 
 object WeederError {
 
-
-  /**
-   * An error raised to indicate a deprecated feature
-   * *
-   * @param loc the location of the deprecated feature.
-   */
-  case class Deprecated(loc: SourceLocation) extends WeederError with Recoverable {
-    def summary: String = s"Deprecated feature."
-
-    def message(formatter: Formatter): String = {
-      import formatter._
-      s""">> Deprecated feature. Use --Xdeprecated to enable.
-         |
-         |${code(loc, "deprecated")}
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = None
-  }
-
   /**
     * An error raised to indicate that the annotation `name` was used multiple times.
     *

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -636,7 +636,7 @@ object Desugar {
       val e3 = visitExp(exp3)
       Expr.ArrayStore(e1, e2, e3, loc)
 
-    case WeededAst.Expr.StructNew(name, fields0, region0, loc) => 
+    case WeededAst.Expr.StructNew(name, fields0, region0, loc) =>
       val fields = fields0.map(field => (field._1, visitExp(field._2)))
       val region = visitExp(region0)
       Expr.StructNew(name, fields, region, loc)
@@ -753,40 +753,6 @@ object Desugar {
     case WeededAst.Expr.InvokeStaticMethod2(className, methodName, exps, loc) =>
       val es = visitExps(exps)
       Expr.InvokeStaticMethod2(className, methodName, es, loc)
-
-    case WeededAst.Expr.InvokeConstructor(className, exps, sig, loc) =>
-      val es = visitExps(exps)
-      val ts = sig.map(visitType)
-      Expr.InvokeConstructor(className, es, ts, loc)
-
-    case WeededAst.Expr.InvokeMethod(className, methodName, exp, exps, sig, retTpe, loc) =>
-      val e = visitExp(exp)
-      val es = visitExps(exps)
-      val ts = sig.map(visitType)
-      val rt = visitType(retTpe)
-      Expr.InvokeMethod(className, methodName, e, es, ts, rt, loc)
-
-    case WeededAst.Expr.InvokeStaticMethod(className, methodName, exps, sig, retTpe, loc) =>
-      val es = visitExps(exps)
-      val ts = sig.map(visitType)
-      val rt = visitType(retTpe)
-      Expr.InvokeStaticMethod(className, methodName, es, ts, rt, loc)
-
-    case WeededAst.Expr.GetField(className, fieldName, exp, loc) =>
-      val e = visitExp(exp)
-      Expr.GetField(className, fieldName, e, loc)
-
-    case WeededAst.Expr.PutField(className, fieldName, exp1, exp2, loc) =>
-      val e1 = visitExp(exp1)
-      val e2 = visitExp(exp2)
-      Expr.PutField(className, fieldName, e1, e2, loc)
-
-    case WeededAst.Expr.GetStaticField(className, fieldName, loc) =>
-      Expr.GetStaticField(className, fieldName, loc)
-
-    case WeededAst.Expr.PutStaticField(className, fieldName, exp, loc) =>
-      val e = visitExp(exp)
-      Expr.PutStaticField(className, fieldName, e, loc)
 
     case WeededAst.Expr.NewObject(tpe, methods, loc) =>
       val t = visitType(tpe)
@@ -1146,7 +1112,7 @@ object Desugar {
     ts match {
       case Nil => // Case 1: No arguments.
         val fparam = DesugaredAst.FormalParam(Name.Ident("_", loc0), Ast.Modifiers.Empty, Some(DesugaredAst.Type.Unit(loc0)), loc0)
-        val call = DesugaredAst.Expr.InvokeConstructor(className, Nil, Nil, loc0)
+        val call = DesugaredAst.Expr.InvokeConstructorOld(className, Nil, Nil, loc0)
         val lambdaBody = jvmCast(call, tpe, eff, loc0)
         val e1 = DesugaredAst.Expr.Lambda(fparam, lambdaBody, loc0)
         DesugaredAst.Expr.Let(ident0, Ast.Modifiers.Empty, e1, e, loc0)
@@ -1167,7 +1133,7 @@ object Desugar {
         }
 
         // Assemble the lambda expression.
-        val call = DesugaredAst.Expr.InvokeConstructor(className, as, ts, loc0)
+        val call = DesugaredAst.Expr.InvokeConstructorOld(className, as, ts, loc0)
         val lambdaBody = jvmCast(call, tpe, eff, loc0)
         val e1 = mkCurried(fs, lambdaBody, loc0)
         DesugaredAst.Expr.Let(ident0, Ast.Modifiers.Empty, e1, e, loc0)
@@ -1226,7 +1192,7 @@ object Desugar {
     }
 
     // Assemble the lambda expression.
-    val call = DesugaredAst.Expr.InvokeMethod(className, methodName, as.head, as.tail, ts, tpe, loc0)
+    val call = DesugaredAst.Expr.InvokeMethodOld(className, methodName, as.head, as.tail, ts, tpe, loc0)
     val lambdaBody = jvmCast(call, tpe, eff, loc0)
     val e1 = mkCurried(fs, lambdaBody, loc0)
     DesugaredAst.Expr.Let(ident, Ast.Modifiers.Empty, e1, e, loc0)
@@ -1251,7 +1217,7 @@ object Desugar {
     ts match {
       case Nil => // Case 1: No arguments.
         val fparam = DesugaredAst.FormalParam(Name.Ident("_", loc0), Ast.Modifiers.Empty, Some(DesugaredAst.Type.Unit(loc0)), loc0)
-        val call = DesugaredAst.Expr.InvokeStaticMethod(className, methodName, Nil, Nil, tpe, loc0)
+        val call = DesugaredAst.Expr.InvokeStaticMethodOld(className, methodName, Nil, Nil, tpe, loc0)
         val lambdaBody = jvmCast(call, tpe, eff, loc0)
         val e1 = DesugaredAst.Expr.Lambda(fparam, lambdaBody, loc0)
         DesugaredAst.Expr.Let(ident, Ast.Modifiers.Empty, e1, e, loc0)
@@ -1272,7 +1238,7 @@ object Desugar {
         }
 
         // Assemble the lambda expression.
-        val call = DesugaredAst.Expr.InvokeStaticMethod(className, methodName, as, ts, tpe, loc0)
+        val call = DesugaredAst.Expr.InvokeStaticMethodOld(className, methodName, as, ts, tpe, loc0)
         val lambdaBody = jvmCast(call, tpe, eff, loc0)
         val e1 = mkCurried(fs, lambdaBody, loc0)
         DesugaredAst.Expr.Let(ident, Ast.Modifiers.Empty, e1, e, loc0)

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -851,23 +851,23 @@ object Kinder {
           KindedAst.Expr.InvokeStaticMethod2(clazz, methodName, exps, mvar, tvar, evar, loc)
       }
 
-    case ResolvedAst.Expr.InvokeConstructor(constructor, args0, loc) =>
+    case ResolvedAst.Expr.InvokeConstructorOld(constructor, args0, loc) =>
       val argsVal = traverse(args0)(visitExp(_, kenv0, taenv, henv0, root))
       mapN(argsVal) {
-        args => KindedAst.Expr.InvokeConstructor(constructor, args, loc)
+        args => KindedAst.Expr.InvokeConstructorOld(constructor, args, loc)
       }
 
-    case ResolvedAst.Expr.InvokeMethod(method, clazz, exp0, args0, loc) =>
+    case ResolvedAst.Expr.InvokeMethodOld(method, clazz, exp0, args0, loc) =>
       val expVal = visitExp(exp0, kenv0, taenv, henv0, root)
       val argsVal = traverse(args0)(visitExp(_, kenv0, taenv, henv0, root))
       mapN(expVal, argsVal) {
-        case (exp, args) => KindedAst.Expr.InvokeMethod(method, clazz, exp, args, loc)
+        case (exp, args) => KindedAst.Expr.InvokeMethodOld(method, clazz, exp, args, loc)
       }
 
-    case ResolvedAst.Expr.InvokeStaticMethod(method, args0, loc) =>
+    case ResolvedAst.Expr.InvokeStaticMethodOld(method, args0, loc) =>
       val argsVal = traverse(args0)(visitExp(_, kenv0, taenv, henv0, root))
       mapN(argsVal) {
-        args => KindedAst.Expr.InvokeStaticMethod(method, args, loc)
+        args => KindedAst.Expr.InvokeStaticMethodOld(method, args, loc)
       }
 
     case ResolvedAst.Expr.GetField(field, clazz, exp0, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -853,19 +853,37 @@ object Namer {
       val es = visitExps(exps, ns0)
       NamedAst.Expr.InvokeStaticMethod2(className, methodName, es, loc)
 
-    case DesugaredAst.Expr.InvokeConstructor(className, exps, sig, loc) =>
+    case DesugaredAst.Expr.InvokeConstructorOld(className, exps, sig, loc) =>
+      if (!flix.options.xdeprecated) {
+        val m = NameError.Deprecated(loc)
+        sctx.errors.add(m)
+        return NamedAst.Expr.Error(m)
+      }
+
       val es = visitExps(exps, ns0)
       val ts = sig.map(visitType)
       NamedAst.Expr.InvokeConstructor(className, es, ts, loc)
 
-    case DesugaredAst.Expr.InvokeMethod(className, methodName, exp, exps, sig, tpe, loc) =>
+    case DesugaredAst.Expr.InvokeMethodOld(className, methodName, exp, exps, sig, tpe, loc) =>
+      if (!flix.options.xdeprecated) {
+        val m = NameError.Deprecated(loc)
+        sctx.errors.add(m)
+        return NamedAst.Expr.Error(m)
+      }
+
       val e = visitExp(exp, ns0)
       val es = visitExps(exps, ns0)
       val ts = sig.map(visitType)
       val t = visitType(tpe)
       NamedAst.Expr.InvokeMethod(className, methodName, e, es, ts, t, loc)
 
-    case DesugaredAst.Expr.InvokeStaticMethod(className, methodName, exps, sig, tpe, loc) =>
+    case DesugaredAst.Expr.InvokeStaticMethodOld(className, methodName, exps, sig, tpe, loc) =>
+      if (!flix.options.xdeprecated) {
+        val m = NameError.Deprecated(loc)
+        sctx.errors.add(m)
+        return NamedAst.Expr.Error(m)
+      }
+
       val es = visitExps(exps, ns0)
       val ts = sig.map(visitType)
       val t = visitType(tpe)

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -854,7 +854,7 @@ object Namer {
       NamedAst.Expr.InvokeStaticMethod2(className, methodName, es, loc)
 
     case DesugaredAst.Expr.InvokeConstructorOld(className, exps, sig, loc) =>
-      if (!flix.options.xdeprecated) {
+      if (flix.options.xnodeprecated) {
         val m = NameError.Deprecated(loc)
         sctx.errors.add(m)
         return NamedAst.Expr.Error(m)
@@ -862,10 +862,10 @@ object Namer {
 
       val es = visitExps(exps, ns0)
       val ts = sig.map(visitType)
-      NamedAst.Expr.InvokeConstructor(className, es, ts, loc)
+      NamedAst.Expr.InvokeConstructorOld(className, es, ts, loc)
 
     case DesugaredAst.Expr.InvokeMethodOld(className, methodName, exp, exps, sig, tpe, loc) =>
-      if (!flix.options.xdeprecated) {
+      if (flix.options.xnodeprecated) {
         val m = NameError.Deprecated(loc)
         sctx.errors.add(m)
         return NamedAst.Expr.Error(m)
@@ -875,10 +875,10 @@ object Namer {
       val es = visitExps(exps, ns0)
       val ts = sig.map(visitType)
       val t = visitType(tpe)
-      NamedAst.Expr.InvokeMethod(className, methodName, e, es, ts, t, loc)
+      NamedAst.Expr.InvokeMethodOld(className, methodName, e, es, ts, t, loc)
 
     case DesugaredAst.Expr.InvokeStaticMethodOld(className, methodName, exps, sig, tpe, loc) =>
-      if (!flix.options.xdeprecated) {
+      if (flix.options.xnodeprecated) {
         val m = NameError.Deprecated(loc)
         sctx.errors.add(m)
         return NamedAst.Expr.Error(m)
@@ -887,7 +887,7 @@ object Namer {
       val es = visitExps(exps, ns0)
       val ts = sig.map(visitType)
       val t = visitType(tpe)
-      NamedAst.Expr.InvokeStaticMethod(className, methodName, es, ts, t, loc)
+      NamedAst.Expr.InvokeStaticMethodOld(className, methodName, es, ts, t, loc)
 
     case DesugaredAst.Expr.GetField(className, fieldName, exp, loc) =>
       val e = visitExp(exp, ns0)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1534,7 +1534,7 @@ object Resolver {
             }
           }
 
-        case NamedAst.Expr.InvokeConstructor(className, args, sig, loc) =>
+        case NamedAst.Expr.InvokeConstructorOld(className, args, sig, loc) =>
           lookupJvmClass(className, loc) match {
             case Result.Ok(clazz) =>
               val argsVal = traverse(args)(visitExp(_, env0))
@@ -1544,7 +1544,7 @@ object Resolver {
                   flatMapN(lookupSignature(sig, loc)) {
                     case ts => lookupJvmConstructor(clazz, ts, loc) match {
                       case Result.Ok(constructor) =>
-                        Validation.success(ResolvedAst.Expr.InvokeConstructor(constructor, as, loc))
+                        Validation.success(ResolvedAst.Expr.InvokeConstructorOld(constructor, as, loc))
                       case Result.Err(e) => Validation.toSoftFailure(ResolvedAst.Expr.Error(e), e)
                     }
                   }
@@ -1552,7 +1552,7 @@ object Resolver {
             case Result.Err(e) => Validation.toSoftFailure(ResolvedAst.Expr.Error(e), e)
           }
 
-        case NamedAst.Expr.InvokeMethod(className, methodName, exp, args, sig, retTpe, loc) =>
+        case NamedAst.Expr.InvokeMethodOld(className, methodName, exp, args, sig, retTpe, loc) =>
           val expVal = visitExp(exp, env0)
           val argsVal = traverse(args)(visitExp(_, env0))
           val sigVal = traverse(sig)(resolveType(_, Wildness.ForbidWild, env0, taenv, ns0, root))
@@ -1563,13 +1563,13 @@ object Resolver {
               flatMapN(lookupSignature(signature, loc)) {
                 case sig => lookupJvmMethod(clazz, methodName, sig, ret, static = false, loc) match {
                   case Result.Ok(method) =>
-                    Validation.success(ResolvedAst.Expr.InvokeMethod(method, clazz, e, as, loc))
+                    Validation.success(ResolvedAst.Expr.InvokeMethodOld(method, clazz, e, as, loc))
                   case Result.Err(e) => Validation.toSoftFailure(ResolvedAst.Expr.Error(e), e)
                 }
               }
           }
 
-        case NamedAst.Expr.InvokeStaticMethod(className, methodName, args, sig, retTpe, loc) =>
+        case NamedAst.Expr.InvokeStaticMethodOld(className, methodName, args, sig, retTpe, loc) =>
           val argsVal = traverse(args)(visitExp(_, env0))
           val sigVal = traverse(sig)(resolveType(_, Wildness.ForbidWild, env0, taenv, ns0, root))
           val retVal = resolveType(retTpe, Wildness.ForbidWild, env0, taenv, ns0, root)
@@ -1579,7 +1579,7 @@ object Resolver {
               flatMapN(lookupSignature(signature, loc)) {
                 case sig => lookupJvmMethod(clazz, methodName, sig, ret, static = true, loc) match {
                   case Result.Ok(method) =>
-                    Validation.success(ResolvedAst.Expr.InvokeStaticMethod(method, as, loc))
+                    Validation.success(ResolvedAst.Expr.InvokeStaticMethodOld(method, as, loc))
                   case Result.Err(e) => Validation.toSoftFailure(ResolvedAst.Expr.Error(e), e)
                 }
               }

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -465,20 +465,20 @@ object TypeReconstruction {
           TypedAst.Expr.Error(TypeError.UnresolvedMethod(loc), methodTpe, eff) // TODO INTEROP: UnresolvedStaticMethod ?
       }
 
-    case KindedAst.Expr.InvokeConstructor(constructor, args, loc) =>
+    case KindedAst.Expr.InvokeConstructorOld(constructor, args, loc) =>
       val as = args.map(visitExp(_))
       val tpe = getFlixType(constructor.getDeclaringClass)
       val eff = Type.IO
       TypedAst.Expr.InvokeConstructor(constructor, as, tpe, eff, loc)
 
-    case KindedAst.Expr.InvokeMethod(method, _, exp, args, loc) =>
+    case KindedAst.Expr.InvokeMethodOld(method, _, exp, args, loc) =>
       val e = visitExp(exp)
       val as = args.map(visitExp(_))
       val tpe = getFlixType(method.getReturnType)
       val eff = Type.IO
       TypedAst.Expr.InvokeMethod(method, e, as, tpe, eff, loc)
 
-    case KindedAst.Expr.InvokeStaticMethod(method, args, loc) =>
+    case KindedAst.Expr.InvokeStaticMethodOld(method, args, loc) =>
       val as = args.map(visitExp(_))
       val tpe = getFlixType(method.getReturnType)
       val eff = Type.IO

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -786,14 +786,14 @@ object ConstraintGen {
         val resEff = evar
         (resTpe, resEff)
 
-      case Expr.InvokeConstructor(constructor, exps, _) =>
+      case Expr.InvokeConstructorOld(constructor, exps, _) =>
         val classTpe = Type.getFlixType(constructor.getDeclaringClass)
         val (_, _) = exps.map(visitExp).unzip
         val resTpe = classTpe
         val resEff = Type.IO
         (resTpe, resEff)
 
-      case Expr.InvokeMethod(method, clazz, exp, exps, loc) =>
+      case Expr.InvokeMethodOld(method, clazz, exp, exps, loc) =>
         val classTpe = Type.getFlixType(clazz)
         val (thisTpe, _) = visitExp(exp)
         c.unifyType(thisTpe, classTpe, loc)
@@ -802,7 +802,7 @@ object ConstraintGen {
         val resEff = Type.IO
         (resTpe, resEff)
 
-      case Expr.InvokeStaticMethod(method, exps, _) =>
+      case Expr.InvokeStaticMethodOld(method, exps, _) =>
         val (_, _) = exps.map(visitExp).unzip
         val resTpe = Type.getFlixType(method.getReturnType)
         val resEff = Type.IO

--- a/main/src/ca/uwaterloo/flix/util/Options.scala
+++ b/main/src/ca/uwaterloo/flix/util/Options.scala
@@ -48,7 +48,7 @@ object Options {
     xnooptimizer = false,
     xprintphases = false,
     xnoqmc = false,
-    xdeprecated = false,
+    xnodeprecated = false,
     xsummary = false,
     xfuzzer = false,
     xprinttyper = None,
@@ -102,7 +102,7 @@ object Options {
   * @param xnoqmc              enables the Quine McCluskey algorihm when using BDDs.
   * @param xprintphases        prints all ASTs to the build folder after each phase.
   * @param xsummary            prints a summary of the compiled modules.
-  * @param xdeprecated         enables deprecated features.
+  * @param xnodeprecated       disables deprecated features.
   * @param xfuzzer             enables compiler fuzzing.
   */
 case class Options(lib: LibLevel,
@@ -127,7 +127,7 @@ case class Options(lib: LibLevel,
                    xnoqmc: Boolean,
                    xnooptimizer: Boolean,
                    xprintphases: Boolean,
-                   xdeprecated: Boolean,
+                   xnodeprecated: Boolean,
                    xsummary: Boolean,
                    xfuzzer: Boolean,
                    xprinttyper: Option[String],

--- a/main/src/library/BigInt.flix
+++ b/main/src/library/BigInt.flix
@@ -15,7 +15,8 @@
  */
 
 mod BigInt {
-    import java.math.BigDecimal;
+    import java.math.BigDecimal
+    import java.math.BigInteger
 
     ///
     /// Returns the smaller of `x` and `y`.
@@ -170,8 +171,7 @@ mod BigInt {
     ///
     pub def fromString(s: String): Option[BigInt] = try {
         import java.lang.String.strip(): String \ {};
-        import java_new java.math.BigInteger(String): BigInt \ {} as parseBigInt;
-        Some(s |> strip |> parseBigInt)
+        unsafe Some(new BigInteger(s |> strip))
     } catch {
         case _: ##java.lang.NumberFormatException => None
     }

--- a/main/test/ca/uwaterloo/flix/TestMain.scala
+++ b/main/test/ca/uwaterloo/flix/TestMain.scala
@@ -207,10 +207,10 @@ class TestMain extends AnyFunSuite {
     assert(opts.explain)
   }
 
-  test("--Xdeprecated") {
-    val args = Array("--Xdeprecated")
+  test("--Xno-deprecated") {
+    val args = Array("--Xno-deprecated")
     val opts = Main.parseCmdOpts(args).get
-    assert(opts.xdeprecated)
+    assert(opts.xnodeprecated)
   }
 
   test("--Xsummary") {


### PR DESCRIPTION
The idea is to have a flag that, when enables, fails on deprecated features.

(The flag is temporary, but needed for the big interop migration.)