### PR TITLE
chore: update syntax for imports in IntX.flix files

### DIFF
--- a/main/src/library/Int16.flix
+++ b/main/src/library/Int16.flix
@@ -24,9 +24,8 @@ instance UpperBound[Int16] {
 
 mod Int16 {
 
-    import java.lang.NumberFormatException
-    import java.lang.Short
-    import java.math.BigDecimal
+    import java.lang.{NumberFormatException, Short}
+    import java.math.{BigDecimal, BigInteger}
 
     ///
     /// Returns the number of bits used to represent an `Int16`.
@@ -335,9 +334,7 @@ mod Int16 {
     /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
     ///
     pub def fromString(s: String): Option[Int16] = try {
-        import java.lang.String.strip(): String \ {};
-        import static java.lang.Short.parseShort(String): Int16 \ {};
-        Some(s |> strip |> parseShort)
+        Some(unsafe Short.parseShort(s.strip()))
     } catch {
         case _: NumberFormatException => None
     }
@@ -351,12 +348,10 @@ mod Int16 {
     /// (i.e. -128 to 127).
     ///
     pub def tryToInt8(x: Int16): Option[Int8] =
-        import static java.lang.Short.valueOf(Int16): Short \ {};
-        import java.lang.Short.byteValue(): Int8 \ {};
         if (x < Int8.toInt16(Int8.minValue()) or x > Int8.toInt16(Int8.maxValue()))
             None
         else
-            Some(valueOf(x) |> byteValue)
+            Some(unsafe Short.valueOf(x).byteValue())
 
     ///
     /// Convert `x` to a Int32.
@@ -364,9 +359,7 @@ mod Int16 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toInt32(x: Int16): Int32 =
-        import static java.lang.Short.valueOf(Int16): Short \ {};
-        import java.lang.Short.intValue(): Int32 \ {};
-        (valueOf(x) |> intValue)
+        unsafe Short.valueOf(x).intValue()
 
     ///
     /// Convert `x` to a Int64.
@@ -374,9 +367,7 @@ mod Int16 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toInt64(x: Int16): Int64 =
-        import static java.lang.Short.valueOf(Int16): Short \ {};
-        import java.lang.Short.longValue(): Int64 \ {};
-        (valueOf(x) |> longValue)
+        unsafe Short.valueOf(x).longValue()
 
     ///
     /// Convert `x` to a BigInt.
@@ -384,10 +375,7 @@ mod Int16 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toBigInt(x: Int16): BigInt =
-        import static java.lang.Short.valueOf(Int16): Short \ {} as i16ValueOf;
-        import java.lang.Short.longValue(): Int64 \ {};
-        import static java.math.BigInteger.valueOf(Int64): BigInt \ {} as asBigInt;
-        (i16ValueOf(x) |> longValue |> asBigInt)
+        unsafe BigInteger.valueOf(Short.valueOf(x).longValue())
 
     ///
     /// Convert `x` to a Float32.
@@ -395,9 +383,7 @@ mod Int16 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toFloat32(x: Int16): Float32 =
-        import static java.lang.Short.valueOf(Int16): Short \ {};
-        import java.lang.Short.floatValue(): Float32 \ {};
-        (valueOf(x) |> floatValue)
+        unsafe Short.valueOf(x).floatValue()
 
     ///
     /// Convert `x` to a Float64.
@@ -405,9 +391,7 @@ mod Int16 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toFloat64(x: Int16): Float64 =
-        import static java.lang.Short.valueOf(Int16): Short \ {};
-        import java.lang.Short.doubleValue(): Float64 \ {};
-        (valueOf(x) |> doubleValue)
+        unsafe Short.valueOf(x).doubleValue()
 
     ///
     /// Convert `x` to a BigDecimal.
@@ -435,11 +419,9 @@ mod Int16 {
     /// Returns `x` clamped within the Int8 range `min` to `max`.
     ///
     pub def clampToInt8(min: {min = Int8}, max: {max = Int8}, x: Int16): Int8 =
-        import static java.lang.Short.valueOf(Int16): Short \ {};
-        import java.lang.Short.byteValue(): Int8 \ {};
         let mini16 = Int8.toInt16(min#min);
         let maxi16 = Int8.toInt16(max#max);
-        (valueOf(clamp(min = mini16, max = maxi16, x)) |> byteValue)
+        unsafe Short.valueOf(clamp(min = mini16, max = maxi16, x)).byteValue()
 
     ///
     /// Get the primitive Int16 value from its object representation (i.e. Short).
@@ -448,8 +430,7 @@ mod Int16 {
     /// code you should not need to use `Short`.
     ///
     pub def shortValue(i: Short): Int16 =
-        import java.lang.Short.shortValue(): Int16 \ {};
-        shortValue(i)
+        unsafe i.shortValue()
 
     ///
     /// Convert an Int16 value to its object representation (i.e. Short).
@@ -458,7 +439,6 @@ mod Int16 {
     /// code you should not need to use `Short`.
     ///
     pub def valueOf(i: Int16): Short =
-        import static java.lang.Short.valueOf(Int16): Short \ {};
-        valueOf(i)
+        unsafe Short.valueOf(i)
 
 }

--- a/main/src/library/Int32.flix
+++ b/main/src/library/Int32.flix
@@ -24,9 +24,8 @@ instance UpperBound[Int32] {
 
 mod Int32 {
 
-    import java.lang.Integer
-    import java.lang.NumberFormatException
-    import java.math.BigDecimal
+    import java.lang.{Integer, NumberFormatException, String}
+    import java.math.{BigDecimal, BigInteger}
 
     ///
     /// Returns the number of bits used to represent an `Int32`.
@@ -340,9 +339,7 @@ mod Int32 {
     /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
     ///
     pub def fromString(s: String): Option[Int32] = try {
-        import java.lang.String.strip(): String \ {};
-        import static java.lang.Integer.parseInt(String): Int32 \ {};
-        Some(s |> strip |> parseInt)
+        Some(unsafe Integer.parseInt(s.strip()))
     } catch {
         case _: NumberFormatException => None
     }
@@ -354,9 +351,7 @@ mod Int32 {
     ///
     pub def parse(radix: Int32, s: String): Result[String, Int32] =
         try {
-            import java.lang.String.strip(): String \ {};
-            import static java.lang.Integer.parseInt(String, Int32): Int32 \ {};
-            Ok(parseInt(strip(s), radix))
+            Ok(unsafe Integer.parseInt(s.strip(), radix))
         } catch {
             case _: NumberFormatException => Err("Int32.parse")
         }
@@ -370,12 +365,10 @@ mod Int32 {
     /// (i.e. -128 to 127).
     ///
     pub def tryToInt8(x: Int32): Option[Int8] =
-        import static java.lang.Integer.valueOf(Int32): Integer \ {};
-        import java.lang.Integer.byteValue(): Int8 \ {};
-        if (x < Int8.toInt32(Int8.minValue()) or x > Int8.toInt32(Int8.maxValue()))
+       if (x < Int8.toInt32(Int8.minValue()) or x > Int8.toInt32(Int8.maxValue()))
             None
         else
-            Some(valueOf(x) |> byteValue)
+            Some(unsafe Integer.valueOf(x).byteValue())
 
     ///
     /// Convert `x` to an `Option[Int16]`.
@@ -386,12 +379,10 @@ mod Int32 {
     /// (i.e. -32768 to 32767).
     ///
     pub def tryToInt16(x: Int32): Option[Int16] =
-        import static java.lang.Integer.valueOf(Int32): Integer \ {};
-        import java.lang.Integer.shortValue(): Int16 \ {};
         if (x < Int16.toInt32(Int16.minValue()) or x > Int16.toInt32(Int16.maxValue()))
             None
         else
-            Some(valueOf(x) |> shortValue)
+            Some(unsafe Integer.valueOf(x).shortValue())
 
     ///
     /// Convert `x` to a Int64.
@@ -399,9 +390,7 @@ mod Int32 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toInt64(x: Int32): Int64 =
-        import static java.lang.Integer.valueOf(Int32): Integer \ {};
-        import java.lang.Integer.longValue(): Int64 \ {};
-        (valueOf(x) |> longValue)
+        unsafe Integer.valueOf(x).longValue()
 
     ///
     /// Convert `x` to a BigInt.
@@ -409,10 +398,7 @@ mod Int32 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toBigInt(x: Int32): BigInt =
-        import static java.lang.Integer.valueOf(Int32): Integer \ {} as i16ValueOf;
-        import java.lang.Integer.longValue(): Int64 \ {};
-        import static java.math.BigInteger.valueOf(Int64): BigInt \ {} as asBigInt;
-        (i16ValueOf(x) |> longValue |> asBigInt)
+        unsafe BigInteger.valueOf(Integer.valueOf(x).longValue())
 
     ///
     /// Convert `x` to an Float32.
@@ -420,9 +406,7 @@ mod Int32 {
     /// The numeric value of `x` may lose precision.
     ///
     pub def toFloat32(x: Int32): Float32 =
-        import static java.lang.Integer.valueOf(Int32): Integer \ {};
-        import java.lang.Integer.floatValue(): Float32 \ {};
-        (valueOf(x) |> floatValue)
+        unsafe Integer.valueOf(x).floatValue()
 
     ///
     /// Convert `x` to a Float64.
@@ -430,9 +414,7 @@ mod Int32 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toFloat64(x: Int32): Float64 =
-        import static java.lang.Integer.valueOf(Int32): Integer \ {};
-        import java.lang.Integer.doubleValue(): Float64 \ {};
-        (valueOf(x) |> doubleValue)
+        unsafe Integer.valueOf(x).doubleValue()
 
     ///
     /// Convert `x` to a BigDecimal.
@@ -460,11 +442,9 @@ mod Int32 {
     /// Returns `x` clamped within the Int8 range `min` to `max`.
     ///
     pub def clampToInt8(min: {min = Int8}, max: {max = Int8}, x: Int32): Int8 =
-        import static java.lang.Integer.valueOf(Int32): Integer \ {};
-        import java.lang.Integer.byteValue(): Int8 \ {};
         let mini32 = Int8.toInt32(min#min);
         let maxi32 = Int8.toInt32(max#max);
-        (valueOf(clamp(min = mini32, max = maxi32, x)) |> byteValue)
+        unsafe Integer.valueOf(clamp(min = mini32, max = maxi32, x)).byteValue()
 
 
     ///
@@ -473,11 +453,9 @@ mod Int32 {
     /// Returns `x` clamped within the Int16 range `min` to `max`.
     ///
     pub def clampToInt16(min: {min = Int16}, max: {max = Int16}, x: Int32): Int16 =
-        import static java.lang.Integer.valueOf(Int32): Integer \ {};
-        import java.lang.Integer.shortValue(): Int16 \ {};
         let mini32 = Int16.toInt32(min#min);
         let maxi32 = Int16.toInt32(max#max);
-        (valueOf(clamp(min = mini32, max = maxi32, x)) |> shortValue)
+        unsafe Integer.valueOf(clamp(min = mini32, max = maxi32, x)).shortValue()
 
     ///
     /// Get the primitive Int32 value from its object representation (i.e. Integer).
@@ -486,8 +464,7 @@ mod Int32 {
     /// code you should not need to use `Integer`.
     ///
     pub def intValue(i: Integer): Int32 =
-        import java.lang.Integer.intValue(): Int32 \ {};
-        intValue(i)
+        unsafe i.intValue()
 
     ///
     /// Convert an Int32 value to its object representation (i.e. Integer).
@@ -496,7 +473,6 @@ mod Int32 {
     /// code you should not need to use `Integer`.
     ///
     pub def valueOf(i: Int32): Integer =
-        import static java.lang.Integer.valueOf(Int32): Integer \ {};
-        valueOf(i)
+        unsafe Integer.valueOf(i)
 
 }

--- a/main/src/library/Int64.flix
+++ b/main/src/library/Int64.flix
@@ -24,9 +24,8 @@ instance UpperBound[Int64] {
 
 mod Int64 {
 
-    import java.lang.Long
-    import java.lang.NumberFormatException
-    import java.math.BigDecimal
+    import java.lang.{String, Long, NumberFormatException}
+    import java.math.{BigDecimal, BigInteger}
 
     ///
     /// Returns the number of bits used to represent an `Int64`.
@@ -340,9 +339,7 @@ mod Int64 {
     /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
     ///
     pub def fromString(s: String): Option[Int64] = try {
-        import java.lang.String.strip(): String \ {};
-        import static java.lang.Long.parseLong(String): Int64 \ {};
-        Some(s |> strip |> parseLong)
+        Some(unsafe Long.parseLong(s.strip()))
     } catch {
         case _: NumberFormatException => None
     }
@@ -353,9 +350,7 @@ mod Int64 {
     /// A successful parse is wrapped with `Ok(x)`, a parse failure is indicated by `Err(_)`.
     ///
     pub def parse(radix: Int32, s: String): Result[String, Int64] = try {
-        import java.lang.String.strip(): String \ {};
-        import static java.lang.Long.parseLong(String, Int32): Int64 \ {};
-        Ok(parseLong(strip(s), radix))
+        Ok(unsafe Long.parseLong(s.strip(), radix))
     } catch {
         case _: NumberFormatException => Err("Int64.parse")
     }
@@ -369,12 +364,10 @@ mod Int64 {
     /// (i.e. -128 to 127).
     ///
     pub def tryToInt8(x: Int64): Option[Int8] =
-        import static java.lang.Long.valueOf(Int64): Long \ {};
-        import java.lang.Long.byteValue(): Int8 \ {};
         if (x < Int8.toInt64(Int8.minValue()) or x > Int8.toInt64(Int8.maxValue()))
             None
         else
-            Some(valueOf(x) |> byteValue)
+            Some(unsafe Long.valueOf(x).byteValue())
 
     ///
     /// Convert `x` to an `Option[Int16]`.
@@ -385,12 +378,10 @@ mod Int64 {
     /// (i.e. -32768 to 32767).
     ///
     pub def tryToInt16(x: Int64): Option[Int16] =
-        import static java.lang.Long.valueOf(Int64): Long \ {};
-        import java.lang.Long.shortValue(): Int16 \ {};
         if (x < Int16.toInt64(Int16.minValue()) or x > Int16.toInt64(Int16.maxValue()))
             None
         else
-            Some(valueOf(x) |> shortValue)
+            Some(unsafe Long.valueOf(x).shortValue())
 
     ///
     /// Convert `x` to an `Option[Int32]`.
@@ -401,22 +392,17 @@ mod Int64 {
     /// (i.e. -2147483648 to 2147483647).
     ///
     pub def tryToInt32(x: Int64): Option[Int32] =
-        import static java.lang.Long.valueOf(Int64): Long \ {};
-        import java.lang.Long.intValue(): Int32 \ {};
         if (x < Int32.toInt64(Int32.minValue()) or x > Int32.toInt64(Int32.maxValue()))
             None
         else
-            Some(valueOf(x) |> intValue)
+            Some(unsafe Long.valueOf(x).intValue())
     ///
     /// Convert `x` to a BigInt.
     ///
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toBigInt(x: Int64): BigInt =
-        import static java.lang.Long.valueOf(Int64): Long \ {} as i64ValueOf;
-        import java.lang.Long.longValue(): Int64 \ {};
-        import static java.math.BigInteger.valueOf(Int64): BigInt \ {} as asBigInt;
-        (i64ValueOf(x) |> longValue |> asBigInt)
+        unsafe BigInteger.valueOf(Long.valueOf(x).longValue())
 
     ///
     /// Convert `x` to a Float32.
@@ -424,9 +410,7 @@ mod Int64 {
     /// Warning: The numeric value of `x` may lose precision.
     ///
     pub def toFloat32(x: Int64): Float32 =
-        import static java.lang.Long.valueOf(Int64): Long \ {};
-        import java.lang.Long.floatValue(): Float32 \ {};
-        (valueOf(x) |> floatValue)
+        unsafe Long.valueOf(x).floatValue()
 
     ///
     /// Convert `x` to a Float64.
@@ -434,9 +418,7 @@ mod Int64 {
     /// Warning: The numeric value of `x` may lose precision.
     ///
     pub def toFloat64(x: Int64): Float64 =
-        import static java.lang.Long.valueOf(Int64): Long \ {};
-        import java.lang.Long.doubleValue(): Float64 \ {};
-        (valueOf(x) |> doubleValue)
+        unsafe Long.valueOf(x).doubleValue()
 
     ///
     /// Convert `x` to a BigDecimal.
@@ -464,11 +446,9 @@ mod Int64 {
     /// Returns `x` clamped within the Int8 range `min` to `max`.
     ///
     pub def clampToInt8(min: {min = Int8}, max: {max = Int8}, x: Int64): Int8 =
-        import static java.lang.Long.valueOf(Int64): Long \ {};
-        import java.lang.Long.byteValue(): Int8 \ {};
         let mini64 = Int8.toInt64(min#min);
         let maxi64 = Int8.toInt64(max#max);
-        (valueOf(clamp(min = mini64, max = maxi64, x)) |> byteValue)
+        unsafe Long.valueOf(clamp(min = mini64, max = maxi64, x)).byteValue()
 
     ///
     /// Convert `x` to an `Int16`.
@@ -476,11 +456,9 @@ mod Int64 {
     /// Returns `x` clamped within the Int16 range `min` to `max`.
     ///
     pub def clampToInt16(min: {min = Int16}, max: {max = Int16}, x: Int64): Int16 =
-        import static java.lang.Long.valueOf(Int64): Long \ {};
-        import java.lang.Long.shortValue(): Int16 \ {};
         let mini64 = Int16.toInt64(min#min);
         let maxi64 = Int16.toInt64(max#max);
-        (valueOf(clamp(min = mini64, max = maxi64, x)) |> shortValue)
+        unsafe Long.valueOf(clamp(min = mini64, max = maxi64, x)).shortValue()
 
 
     ///
@@ -489,11 +467,9 @@ mod Int64 {
     /// Returns `x` clamped within the Int32 range `min` to `max`.
     ///
     pub def clampToInt32(min: {min = Int32}, max: {max = Int32}, x: Int64): Int32 =
-        import static java.lang.Long.valueOf(Int64): Long \ {};
-        import java.lang.Long.intValue(): Int32 \ {};
         let mini64 = Int32.toInt64(min#min);
         let maxi64 = Int32.toInt64(max#max);
-        (valueOf(clamp(min = mini64, max = maxi64, x)) |> intValue)
+        unsafe Long.valueOf(clamp(min = mini64, max = maxi64, x)).intValue()
 
     ///
     /// Get the primitive Int64 value from its object representation (i.e. Long).
@@ -502,8 +478,7 @@ mod Int64 {
     /// code you should not need to use `Long`.
     ///
     pub def longValue(i: Long): Int64 =
-        import java.lang.Long.longValue(): Int64 \ {};
-        longValue(i)
+        unsafe i.longValue()
 
     ///
     /// Convert an Int64 value to its object representation (i.e. Long).
@@ -512,7 +487,6 @@ mod Int64 {
     /// code you should not need to use `Long`.
     ///
     pub def valueOf(i: Int64): Long =
-        import static java.lang.Long.valueOf(Int64): Long \ {};
-        valueOf(i)
+        unsafe Long.valueOf(i)
 
 }

--- a/main/src/library/Int8.flix
+++ b/main/src/library/Int8.flix
@@ -24,9 +24,8 @@ instance UpperBound[Int8] {
 
 mod Int8 {
 
-    import java.lang.Byte
-    import java.lang.NumberFormatException
-    import java.math.BigDecimal
+    import java.lang.{String, Byte, NumberFormatException}
+    import java.math.{BigDecimal, BigInteger}
 
     ///
     /// Returns the number of bits used to represent an `Int8`.
@@ -336,9 +335,7 @@ mod Int8 {
     /// A successful parse is wrapped with `Some(x)`, a parse failure is indicated by `None`.
     ///
     pub def fromString(s: String): Option[Int8] = try {
-        import java.lang.String.strip(): String \ {};
-        import static java.lang.Byte.parseByte(String): Int8 \ {};
-        Some(s |> strip |> parseByte)
+        Some(unsafe Byte.parseByte(s.strip()))
     } catch {
         case _: NumberFormatException => None
     }
@@ -349,9 +346,7 @@ mod Int8 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toInt16(x: Int8): Int16 =
-        import static java.lang.Byte.valueOf(Int8): Byte \ {};
-        import java.lang.Byte.shortValue(): Int16 \ {};
-        (valueOf(x) |> shortValue)
+        unsafe Byte.valueOf(x).shortValue()
 
     ///
     /// Convert `x` to an Int32.
@@ -359,9 +354,7 @@ mod Int8 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toInt32(x: Int8): Int32 =
-        import static java.lang.Byte.valueOf(Int8): Byte \ {};
-        import java.lang.Byte.intValue(): Int32 \ {};
-        (valueOf(x) |> intValue)
+        unsafe Byte.valueOf(x).intValue()
 
     ///
     /// Convert `x` to an Int64.
@@ -369,9 +362,7 @@ mod Int8 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toInt64(x: Int8): Int64 =
-        import static java.lang.Byte.valueOf(Int8): Byte \ {};
-        import java.lang.Byte.longValue(): Int64 \ {};
-        (valueOf(x) |> longValue)
+        unsafe Byte.valueOf(x).longValue()
 
     ///
     /// Convert `x` to a BigInt.
@@ -379,10 +370,7 @@ mod Int8 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toBigInt(x: Int8): BigInt =
-        import static java.lang.Byte.valueOf(Int8): Byte \ {} as i8ValueOf;
-        import java.lang.Byte.longValue(): Int64 \ {};
-        import static java.math.BigInteger.valueOf(Int64): BigInt \ {} as asBigInt;
-        (i8ValueOf(x) |> longValue |> asBigInt)
+        unsafe BigInteger.valueOf(Byte.valueOf(x).longValue())
 
     ///
     /// Convert `x` to a Float32.
@@ -390,9 +378,7 @@ mod Int8 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toFloat32(x: Int8): Float32 =
-        import static java.lang.Byte.valueOf(Int8): Byte \ {};
-        import java.lang.Byte.floatValue(): Float32 \ {};
-        (valueOf(x) |> floatValue)
+        unsafe Byte.valueOf(x).floatValue()
 
     ///
     /// Convert `x` to a Float64.
@@ -400,9 +386,7 @@ mod Int8 {
     /// The numeric value of `x` is preserved exactly.
     ///
     pub def toFloat64(x: Int8): Float64 =
-        import static java.lang.Byte.valueOf(Int8): Byte \ {};
-        import java.lang.Byte.doubleValue(): Float64 \ {};
-        (valueOf(x) |> doubleValue)
+        unsafe Byte.valueOf(x).doubleValue()
 
     ///
     /// Convert `x` to a BigDecimal.
@@ -419,8 +403,7 @@ mod Int8 {
     /// code you should not need to use `Byte`.
     ///
     pub def byteValue(i: Byte): Int8 =
-        import java.lang.Byte.byteValue(): Int8 \ {};
-        byteValue(i)
+        unsafe i.byteValue()
 
     ///
     /// Convert an Int8 value to its object representation (i.e. Byte).
@@ -429,7 +412,6 @@ mod Int8 {
     /// code you should not need to use `Byte`.
     ///
     pub def valueOf(i: Int8): Byte =
-        import static java.lang.Byte.valueOf(Int8): Byte \ {};
-        valueOf(i)
+        unsafe Byte.valueOf(i)
 
 }


### PR DESCRIPTION
Related to #8096.
- [x] main/src/library/Int16.flix
- [x] main/src/library/Int32.flix
- [x] main/src/library/Int64.flix
- [x] main/src/library/Int8.flix