### PR TITLE
feat: return instantiated variable mapping in `Scheme.instantiate`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
@@ -57,7 +57,7 @@ object Scheme {
         // Determine the rigidity of the fresh type variable.
         macc + (tvar -> Type.freshVar(tvar.kind, loc, tvar.isRegion, Ast.VarText.Absent))
     }
-    val freshVars = substMap.map(s => s._1.id -> s._2)
+    val freshVars = substMap.map { case (k, v) => k.id -> v }
 
     /**
       * Replaces every variable occurrence in the given type using `freeVars`.

--- a/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
@@ -45,18 +45,19 @@ object Scheme {
   /**
     * Instantiates the given type scheme `sc` by replacing all quantified variables with fresh type variables.
     */
-  def instantiate(sc: Scheme, loc: SourceLocation)(implicit flix: Flix): (List[Ast.TypeConstraint], List[Ast.BroadEqualityConstraint], Type) = {
+  def instantiate(sc: Scheme, loc: SourceLocation)(implicit flix: Flix): (List[Ast.TypeConstraint], List[Ast.BroadEqualityConstraint], Type, Map[Symbol.KindedTypeVarSym, Type.Var]) = {
     // Compute the base type.
     val baseType = sc.base
 
     //
     // Compute the fresh variables taking the instantiation mode into account.
     //
-    val freshVars = sc.quantifiers.foldLeft(Map.empty[Int, Type.Var]) {
+    val substMap = sc.quantifiers.foldLeft(Map.empty[Symbol.KindedTypeVarSym, Type.Var]) {
       case (macc, tvar) =>
         // Determine the rigidity of the fresh type variable.
-        macc + (tvar.id -> Type.freshVar(tvar.kind, loc, tvar.isRegion, Ast.VarText.Absent))
+        macc + (tvar -> Type.freshVar(tvar.kind, loc, tvar.isRegion, Ast.VarText.Absent))
     }
+    val freshVars = substMap.map(s => s._1.id -> s._2)
 
     /**
       * Replaces every variable occurrence in the given type using `freeVars`.
@@ -106,7 +107,7 @@ object Scheme {
         Ast.BroadEqualityConstraint(visitType(tpe1), visitType(tpe2))
     }
 
-    (newTconstrs, newEconstrs, newBase)
+    (newTconstrs, newEconstrs, newBase, substMap)
   }
 
   /**
@@ -137,7 +138,7 @@ object Scheme {
   def lessThanEqual(sc1: Scheme, sc2: Scheme, tenv0: Map[Symbol.TraitSym, Ast.TraitContext], eenv0: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef])(implicit flix: Flix): Boolean = {
 
     // Instantiate sc2, creating [T/α₂]π₂ and [T/α₂]τ₂
-    val (cconstrs2_0, econstrs2_0, tpe2_0) = Scheme.instantiate(sc2, SourceLocation.Unknown)
+    val (cconstrs2_0, econstrs2_0, tpe2_0, _) = Scheme.instantiate(sc2, SourceLocation.Unknown)
 
     // Resolve what we can from the new econstrs
     // TODO ASSOC-TYPES probably these should be narrow from the start

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -46,7 +46,7 @@ object ConstraintGen {
 
       case Expr.Def(sym, tvar, loc) =>
         val defn = root.defs(sym)
-        val (tconstrs, econstrs, defTpe) = Scheme.instantiate(defn.spec.sc, loc.asSynthetic)
+        val (tconstrs, econstrs, defTpe, _) = Scheme.instantiate(defn.spec.sc, loc.asSynthetic)
         c.unifyType(tvar, defTpe, loc)
         val constrs = tconstrs.map(_.copy(loc = loc))
         c.addClassConstraints(tconstrs, loc)
@@ -57,7 +57,7 @@ object ConstraintGen {
 
       case Expr.Sig(sym, tvar, loc) =>
         val sig = root.traits(sym.trt).sigs(sym)
-        val (tconstrs, econstrs, sigTpe) = Scheme.instantiate(sig.spec.sc, loc.asSynthetic)
+        val (tconstrs, econstrs, sigTpe, _) = Scheme.instantiate(sig.spec.sc, loc.asSynthetic)
         c.unifyType(tvar, sigTpe, loc)
         val constrs = tconstrs.map(_.copy(loc = loc))
         c.addClassConstraints(constrs, loc)
@@ -102,14 +102,14 @@ object ConstraintGen {
           case KindedAst.Expr.Def(sym, tvar1, loc1) =>
             // Case 1: Lookup the sym and instantiate its scheme.
             val defn = root.defs(sym)
-            val (tconstrs1, econstrs1, declaredType) = Scheme.instantiate(defn.spec.sc, loc1.asSynthetic)
+            val (tconstrs1, econstrs1, declaredType, _) = Scheme.instantiate(defn.spec.sc, loc1.asSynthetic)
             val constrs1 = tconstrs1.map(_.copy(loc = loc))
             Some((sym, tvar1, constrs1, econstrs1, declaredType))
 
           case KindedAst.Expr.Sig(sym, tvar1, loc1) =>
             // Case 2: Lookup the sym and instantiate its scheme.
             val sig = root.traits(sym.trt).sigs(sym)
-            val (tconstrs1, econstrs1, declaredType) = Scheme.instantiate(sig.spec.sc, loc1.asSynthetic)
+            val (tconstrs1, econstrs1, declaredType, _) = Scheme.instantiate(sig.spec.sc, loc1.asSynthetic)
             val constrs1 = tconstrs1.map(_.copy(loc = loc))
             Some((sym, tvar1, constrs1, econstrs1, declaredType))
 
@@ -442,7 +442,7 @@ object ConstraintGen {
         val decl = root.enums(symUse.sym.enumSym)
         val caze = decl.cases(symUse.sym)
         // We ignore constraints as tag schemes do not have them
-        val (_, _, tagType) = Scheme.instantiate(caze.sc, loc.asSynthetic)
+        val (_, _, tagType, _) = Scheme.instantiate(caze.sc, loc.asSynthetic)
 
         // The tag type is a function from the type of variant to the type of the enum.
         val (tpe, eff) = visitExp(exp)
@@ -967,7 +967,7 @@ object ConstraintGen {
         val decl = root.enums(symUse.sym.enumSym)
         val caze = decl.cases(symUse.sym)
         // We ignore constraints as tag schemes do not have them
-        val (_, _, tagType) = Scheme.instantiate(caze.sc, loc.asSynthetic)
+        val (_, _, tagType, _) = Scheme.instantiate(caze.sc, loc.asSynthetic)
 
         // The tag type is a function from the type of variant to the type of the enum.
         val tpe = visitPattern(pat)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/RestrictableChooseConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/RestrictableChooseConstraintGen.scala
@@ -219,7 +219,7 @@ object RestrictableChooseConstraintGen {
 
 
         // Instantiate the type scheme of the case.
-        val (_, _, tagType) = Scheme.instantiate(caze.sc, loc.asSynthetic)
+        val (_, _, tagType, _) = Scheme.instantiate(caze.sc, loc.asSynthetic)
 
         //
         // The tag type is a function from the type of variant to the type of the enum.
@@ -324,7 +324,7 @@ object RestrictableChooseConstraintGen {
         val caze = decl.cases(symUse.sym)
 
         // Instantiate the type scheme of the case.
-        val (_, _, tagType) = Scheme.instantiate(caze.sc, loc.asSynthetic)
+        val (_, _, tagType, _) = Scheme.instantiate(caze.sc, loc.asSynthetic)
 
         //
         // The tag type is a function from the type of variant to the type of the enum.


### PR DESCRIPTION
This PR updates `Scheme.instantiate` to return a type variable mapping from the original generalized variable to the instantiated variable. It also updates all current uses of `Scheme.instantiate` to ignore it.

This is useful for structs.