### PR TITLE
chore: update import syntax in `Files`

### DIFF
--- a/main/src/library/Files.flix
+++ b/main/src/library/Files.flix
@@ -17,7 +17,7 @@ mod Files {
 
     use IOError.{Generic}
     import java.io.{BufferedReader, File, FileInputStream, FileOutputStream, FileWriter, IOException, OutputStream, PrintWriter, Writer}
-    import java.lang.Class
+    import java.lang.{Class, String}
     import java.nio.charset.Charset
     import java.nio.file.attribute.{FileTime, BasicFileAttributes}
     import java.nio.file.{CopyOption, DirectoryStream, FileVisitOption, LinkOption, Path, StandardCopyOption}
@@ -262,7 +262,6 @@ mod Files {
             try {
                 import java.io.FileInputStream.read(Array[Int8, rc], Int32, Int32): Int32 \ IO;
                 import static java.nio.charset.Charset.forName(String): Charset \ IO;
-                import java_new java.lang.String(Array[Int8, rc], Charset): String \ IO as newString;
 
                 let javaFile = new File(f);
                 let stream = new FileInputStream(javaFile);
@@ -271,7 +270,7 @@ mod Files {
                         let bytes = Array.empty(rc, opts#count);
                         discard read(stream, bytes, 0, opts#count);
                         let charSet = forName(opts#charSet);
-                        let returnString = newString(bytes, charSet);
+                        let returnString = new String(bytes, charSet);
                         Ok(returnString)
                     }
                     case Err(msg) => Err(msg)
@@ -806,12 +805,11 @@ mod Files {
     ///
     pub def list(f: String): Result[IOError, List[String]] \ IO = region rc {
         try {
-            import java_new java.io.File(String): File \ IO as newFile;
             import java.io.File.listFiles(): Array[File, rc] \ IO;
             import java.io.File.toPath(): Path \ IO;
             import java.nio.file.Path.toString(): String \ IO as pathToString;
 
-            let javaList = f |> newFile |> listFiles;
+            let javaList = new File(f) |> listFiles;
 
             if (not Object.isNull(javaList)) {
                 let paths = javaList |> Array.map(rc, toPath >> pathToString);

--- a/main/src/library/Files.flix
+++ b/main/src/library/Files.flix
@@ -17,7 +17,7 @@ mod Files {
 
     use IOError.{Generic}
     import java.io.{BufferedReader, File, FileInputStream, FileOutputStream, FileWriter, IOException, OutputStream, PrintWriter, Writer}
-    import java.lang.{Class, String}
+    import java.lang.{Class, String => JString}
     import java.nio.charset.Charset
     import java.nio.file.attribute.{FileTime, BasicFileAttributes}
     import java.nio.file.{CopyOption, DirectoryStream, FileVisitOption, LinkOption, Path, StandardCopyOption}
@@ -270,7 +270,7 @@ mod Files {
                         let bytes = Array.empty(rc, opts#count);
                         discard read(stream, bytes, 0, opts#count);
                         let charSet = forName(opts#charSet);
-                        let returnString = new String(bytes, charSet);
+                        let returnString = new JString(bytes, charSet);
                         Ok(returnString)
                     }
                     case Err(msg) => Err(msg)


### PR DESCRIPTION
Related to #7944,
should be merged in after array support, i.e., #7926.
@magnus-madsen 