### PR TITLE
chore: clean up old imports in `Prelude`, `Random`, `Regex`(partially), `Set`, `Stringbuilder`, `String`

### DIFF
--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -119,13 +119,12 @@ pub def touch(_: Region[r]): Unit \ r = checked_ecast(())
 pub def bug!(m: String): a = masked_cast({
     import static java_get_field java.lang.System.err: ##java.io.PrintStream \ {} as getErr;
     import java.io.PrintStream.println(String): Unit \ IO;
-    import java.lang.String.repeat(Int32): ##java.lang.String \ {};
     let prt = println(getErr());
-    prt(repeat("*", 80));
+    prt("*".repeat(80));
     prt("**") ;
     prt("**  BUG: ${m}") ;
     prt("**") ;
-    prt(repeat("*", 80));
+    prt("*".repeat(80));
     prt("");
     ?panic
 })

--- a/main/src/library/Random.flix
+++ b/main/src/library/Random.flix
@@ -37,55 +37,48 @@ mod Random {
     /// Returns the next pseudorandom boolean from the given random number generator `r`.
     ///
     pub def nextBool(r: Random): Bool \ IO =
-        import java.util.Random.nextBoolean(): Bool \ IO;
         let Random(o) = r;
-        nextBoolean(o)
+        o.nextBoolean()
 
     ///
     /// Returns the next pseudorandom 32-bit floating point number from the given random number generator `r`.
     ///
     pub def nextFloat32(r: Random): Float32 \ IO =
-        import java.util.Random.nextFloat(): Float32 \ IO;
         let Random(o) = r;
-        nextFloat(o)
+        o.nextFloat()
 
     ///
     /// Returns the next pseudorandom 64-bit floating point number from the given random number generator `r`.
     ///
     pub def nextFloat64(r: Random): Float64 \ IO =
-        import java.util.Random.nextDouble(): Float64 \ IO;
         let Random(o) = r;
-        nextDouble(o)
+        o.nextDouble()
 
     ///
     /// Returns the next pseudorandom 32-bit integer value from the given random number generator `r`.
     ///
     pub def nextInt32(r: Random): Int32 \ IO =
-        import java.util.Random.nextInt(): Int32 \ IO;
         let Random(o) = r;
-        nextInt(o)
+        o.nextInt()
 
     ///
     /// Returns the next pseudorandom 64-bit integer value from the given random number generator `r`.
     ///
     pub def nextInt64(r: Random): Int64 \ IO =
-        import java.util.Random.nextLong(): Int64 \ IO;
         let Random(o) = r;
-        nextLong(o)
+        o.nextLong()
 
     ///
     /// Returns the next pseudorandom Gaussian distributed 64-bit floating point number.
     ///
     pub def nextGaussian(r: Random): Float64 \ IO =
-        import java.util.Random.nextGaussian(): Float64 \ IO;
         let Random(o) = r;
-        nextGaussian(o)
+        o.nextGaussian()
 
     ///
     /// Returns the next pseudorandom 32-bit integer value between `0` and `m` (exclusive) using the given random number generator `r`.
     ///
     pub def nextNatWithMax(r: Random, m: Int32): Int32 \ IO =
-        import java.util.Random.nextInt(Int32): Int32 \ IO;
         let Random(o) = r;
-        nextInt(o, m)
+        o.nextInt(m)
 }

--- a/main/src/library/Regex.flix
+++ b/main/src/library/Regex.flix
@@ -117,15 +117,13 @@ mod Regex {
     /// Return the regular expression string used to build this Regex.
     ///
     pub def pattern(rgx: Regex): String =
-        import java.util.regex.Pattern.pattern(): String \ {};
-        pattern(rgx)
+        unsafe rgx.pattern()
 
     ///
     /// Return the flags used to build the Regex `rgx`.
     ///
     pub def flags(rgx: Regex): Set[Flag] =
-        import java.util.regex.Pattern.flags(): Int32 \ {};
-        let i = flags(rgx);
+        let i = unsafe rgx.flags();
         listFlags(i) |> List.toSet
 
 

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -96,15 +96,13 @@ mod String {
     /// Returns the lower case version of the string `s`.
     ///
     pub def toLowerCase(s: String): String =
-        import java.lang.String.toLowerCase(): String \ {};
-        toLowerCase(s)
+        unsafe s.toLowerCase()
 
     ///
     /// Returns the upper case version of the string `s`.
     ///
     pub def toUpperCase(s: String): String =
-        import java.lang.String.toUpperCase(): String \ {};
-        toUpperCase(s)
+        unsafe s.toUpperCase()
 
     ///
     /// Returns the given string `s` as a list of characters.
@@ -117,8 +115,7 @@ mod String {
     /// Returns a new empty string if there is no characters in `s`.
     ///
     pub def trim(s: String): String =
-        import java.lang.String.trim(): String \ {};
-        trim(s)
+        unsafe s.trim()
 
     ///
     /// Get the system line separator.
@@ -337,8 +334,7 @@ mod String {
     /// If `b` or `e` are out-of-bounds, return the empty string.
     ///
     pub def slice(start: {start = Int32}, end: {end = Int32}, s: String): String = try {
-        import java.lang.String.substring(Int32, Int32): String \ {};
-        substring(s, start#start, end#end)
+        unsafe s.substring(start#start, end#end)
     } catch {
         case _: ##java.lang.IndexOutOfBoundsException => ""
     }
@@ -764,11 +760,10 @@ mod String {
     /// Returns the empty string if `n < 0`.
     ///
     pub def repeat(n: Int32, s: String): String =
-        import java.lang.String.repeat(Int32): String \ {};
         if (n < 0)
             ""
         else
-            repeat(s, n)
+            unsafe s.repeat(n)
 
     ///
     /// Pad the string `s` at the left with the supplied char `c` to fit the width `w`.
@@ -817,29 +812,25 @@ mod String {
     /// Returns `s` with every match of the substring `src` replaced by the string `dst`.
     ///
     pub def replace(src: {src = String}, dst: {dst = String}, s: String): String =
-        import java.lang.String.replace(##java.lang.CharSequence, ##java.lang.CharSequence): String \ {};
-        replace(s, checked_cast(src#src), checked_cast(dst#dst))
+        unsafe s.replace(src#src, dst#dst)
 
     ///
     /// Returns `s` with every match of the character `src` replaced by the character `dst`.
     ///
     pub def replaceChar(src: {src = Char}, dst: {dst = Char}, s: String): String =
-        import java.lang.String.replace(Char, Char): String \ {};
-        replace(s, src#src, dst#dst)
+        unsafe s.replace(src#src, dst#dst)
 
     ///
     /// Returns `s` with every match of the regular expression `regex` replaced by the string `to`.
     ///
     pub def replaceMatches(regex: {regex = String}, to: {to = String}, s: String): String =
-        import java.lang.String.replaceAll(String, String): String \ {};
-        replaceAll(s, regex#regex, to#to)
+        unsafe s.replaceAll(regex#regex, to#to)
 
     ///
     /// Returns `s` with the first match of the regular expression `regex` replaced by the string `to`.
     ///
     pub def replaceFirstMatch(regex: {regex = String}, to: {to = String}, s: String): String =
-        import java.lang.String.replaceFirst(String, String): String \ {};
-        replaceFirst(s, regex#regex, to#to)
+        unsafe s.replaceFirst(regex#regex, to#to)
 
     ///
     /// Returns `s` with the element at index `i` replaced by `a`.
@@ -993,11 +984,10 @@ mod String {
     /// If `substr` is the empty string return None.
     ///
     pub def indexOfLeft(substr: {substr = String}, s: String): Option[Int32] =
-        import java.lang.String.indexOf(String): Int32 \ {};
         if (isEmpty(substr#substr))
             None
         else {
-            let i = indexOf(s, substr#substr);
+            let i = unsafe s.indexOf(substr#substr);
             if (i < 0) None else Some(i)
         }
 
@@ -1009,11 +999,10 @@ mod String {
     /// If `substr` is the empty string return None.
     ///
     pub def indexOfRight(substr: {substr = String}, s: String): Option[Int32] =
-        import java.lang.String.lastIndexOf(String): Int32 \ {};
         if (isEmpty(substr#substr))
             None
         else {
-            let i = lastIndexOf(s, substr#substr);
+            let i = unsafe s.lastIndexOf(substr#substr);
             if (i < 0) None else Some(i)
         }
 

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -52,15 +52,13 @@ mod String {
     /// Returns the string `s1` followed by the string `s2`.
     ///
     pub def concat(s1: String, s2: String): String =
-        import java.lang.String.concat(String): String \ {};
-        (s1 `concat` s2)
+        unsafe s1.concat(s2)
 
     ///
     /// Returns `true` if the string `s` is the empty string.
     ///
     pub def isEmpty(s: String): Bool =
-        import java.lang.String.isEmpty(): Bool \ {};
-        isEmpty(s)
+        unsafe s.isEmpty()
 
     ///
     /// Returns `true` if the string `s` is non-empty.
@@ -71,22 +69,19 @@ mod String {
     /// Returns the length of the string `s`.
     ///
     pub def length(s: String): Int32 =
-        import java.lang.String.length(): Int32 \ {};
-        length(s)
+        unsafe s.length()
 
     ///
     /// Returns `true` if the string `s` starts with the string `prefix`.
     ///
     pub def startsWith(prefix: {prefix = String}, s: String): Bool =
-        import java.lang.String.startsWith(String): Bool \ {};
-        (s `startsWith` prefix#prefix)
+        unsafe s.startsWith(prefix#prefix)
 
     ///
     /// Returns `true` if the string `s` ends with the string `suffix`.
     ///
     pub def endsWith(suffix: {suffix = String}, s: String): Bool =
-        import java.lang.String.endsWith(String): Bool \ {};
-        (s `endsWith` suffix#suffix)
+        unsafe s.endsWith(suffix#suffix)
 
     ///
     /// Splits the string `s` around matches of the regular expression `regex`.
@@ -1203,11 +1198,10 @@ mod String {
     /// Returns `None` if `substr` is the empty string.
     ///
     pub def indexOfLeftWithOffset(substr: {substr = String}, offset: {offset = Int32}, s: String): Option[Int32] =
-        import java.lang.String.indexOf(String, Int32): Int32 \ {};
         if (isEmpty(substr#substr))
             None
         else {
-            let ix = indexOf(s, substr#substr, offset#offset);
+            let ix = unsafe s.indexOf(substr#substr, offset#offset);
             if (ix < 0) None else Some(ix)
         }
 
@@ -1217,11 +1211,10 @@ mod String {
     /// Returns `None` if `substr` is the empty string.
     ///
     pub def indexOfRightWithOffset(substr: {substr = String}, offset: {offset = Int32}, s: String): Option[Int32] =
-        import java.lang.String.lastIndexOf(String, Int32): Int32 \ {};
         if (isEmpty(substr#substr))
             None
         else {
-            let ix = lastIndexOf(s, substr#substr, offset#offset);
+            let ix = unsafe s.lastIndexOf(substr#substr, offset#offset);
             if (ix < 0) None else Some(ix)
         }
 

--- a/main/src/library/StringBuilder.flix
+++ b/main/src/library/StringBuilder.flix
@@ -40,8 +40,9 @@ mod StringBuilder {
     /// Append the String `s` to the StringBuilder `sb`.
     ///
     pub def appendString!(s: String, sb: StringBuilder[r]): Unit \ r =
+        import java.lang.StringBuilder.append(String): ##java.lang.StringBuilder \ r;
         let StringBuilder(msb) = sb;
-        discard unsafe msb.append(s);
+        discard msb `append` s;
         ()
 
     ///


### PR DESCRIPTION
Some of the files in the title had nothing to cleanup, but for completeness/documentation I put them there.

Some of the method invocations, especially related to regex, couldn't be transformed for some reason. I documented them here: https://github.com/flix/flix/issues/8139.

I also didn't update any of the invocations that were expected to have a region effect

This addresses #8096 