### PR TITLE
chore: fix method calls in: `prelude.flix,` `regex.flix,` `string.flix,` `testAdaptor.flix,` `testFromJava.flix,` `TestInt8.flix,` `TestToJava.flix,` `Test.Exp.CheckedTypeCast.flix,` `Test.Exp.Jvm.GetField.flix,` `Test.Exp.Jvm.GetFieldDoubleNestedClass.flix,` `Test.Exp.Jvm.GetFieldStaticInnerClass.flix,` `Test.Exp.Jvm.NewObject.flix,` `Test.Exp.Jvm.PutField.flix,` `Test.Exp.Jvm.PutStaticField.flix,` `Test.Exp.Jvm.TryCatch.flix,` `Test.Exp.UncheckedTypeCast.flix`

### DIFF
--- a/main/src/library/Benchmark.flix
+++ b/main/src/library/Benchmark.flix
@@ -24,6 +24,7 @@ pub enum Benchmark {
 
 mod Benchmark {
 
+    import java.lang.System
 
     ///
     /// Returns the minimum number of iterations a benchmark can be executed.
@@ -68,8 +69,7 @@ mod Benchmark {
             println("No benchmarks");
             1
         } else {
-            import static java.lang.System.nanoTime(): Int64 \ IO;
-            let t = nanoTime();
+            let t = System.nanoTime();
             printHeader();
             println("");
             let benchmarksWithEstimates = warmupAndEstimate(rc, bs);
@@ -78,7 +78,7 @@ mod Benchmark {
             printCols();
             runAll(benchmarksWithEstimates, budget);
             println("");
-            let e = nanoTime() - t;
+            let e = System.nanoTime() - t;
             println("Total time elapsed: ${toSeconds(e)} seconds. Time budget was: ${toSeconds(budget)} seconds.");
             0
         }
@@ -111,11 +111,10 @@ mod Benchmark {
     /// Runs the given benchmark `b` exactly `n` times.
     ///
     def runBenchmark(b: Benchmark, n: Int32): BenchmarkResult \ IO =
-        import static java.lang.System.nanoTime(): Int64 \ IO;
         let Benchmark(r) = b;
-        let t = nanoTime();
+        let t = System.nanoTime();
         loop(r#f, n);
-        let e = nanoTime() - t;
+        let e = System.nanoTime() - t;
         BenchmarkResult.Success({name = r#name, rounds = n, total = e})
 
     ///
@@ -126,10 +125,9 @@ mod Benchmark {
     ///
     def runBenchmarkOnce(b: Benchmark): Int64 \ IO =
         let Benchmark(r) = b;
-        import static java.lang.System.nanoTime(): Int64 \ IO;
-        let t = nanoTime();
+        let t = System.nanoTime();
         (r#f)();
-        (nanoTime() - t) / scaleFactor()
+        (System.nanoTime() - t) / scaleFactor()
 
     ///
     /// Executes the given function `f` exactly `n` times.

--- a/main/src/library/Environment.flix
+++ b/main/src/library/Environment.flix
@@ -122,8 +122,7 @@ mod Environment {
     /// The returned value is never less than one.
     ///
     pub def getVirtualProcessors(): Int32 =
-        import static java.lang.Runtime.getRuntime(): Runtime \ {};
-        unsafe getRuntime().availableProcessors()
+        unsafe Runtime.getRuntime().availableProcessors()
 
     def getEnvHelper(iter: JIterator, m: Map[String, String]): Map[String, String] =
         if (unsafe iter.hasNext())

--- a/main/src/library/Environment.flix
+++ b/main/src/library/Environment.flix
@@ -19,25 +19,24 @@ mod Environment {
     import java.lang.{Object => JObject}
     import java.util.{Iterator => JIterator, Map => JMap, Set => JSet}
     import java.io.File
+    import java.lang.System
+    import dev.flix.runtime.Global
 
     ///
     /// Returns the arguments passed to the program via the command line.
     ///
     pub def getArgs(): List[String] = region rc {
-        import static dev.flix.runtime.Global.getArgs(): Array[String, rc] \ rc;
         let _ = rc; // Avoids redundancy error.
-        Array.toList(getArgs())
+        unsafe Array.toList(unsafe Global.getArgs())
     }
 
     ///
     /// Returns an map of the current system environment.
     ///
     pub def getEnv(): Map[String, String] = region rc {
-        import static java.lang.System.getenv(): JMap \ rc;
-        import java.util.Map.entrySet(): JSet \ { rc };
         let _ = rc; // Avoids redundancy error.
         try {
-            let iter = unsafe (getenv() |> entrySet).iterator();
+            let iter = unsafe (System.getenv().entrySet()).iterator();
             getEnvHelper(iter, Map.empty())
         } catch {
             case _: Exception => Map.empty()
@@ -48,9 +47,8 @@ mod Environment {
     /// Returns the value of the specified environment variable.
     ///
     pub def getVar(name: String): Option[String] =
-        import static java.lang.System.getenv(String): String \ {};
         try {
-            let result = getenv(name);
+            let result = unsafe System.getenv(name);
             Object.toOption(result)
         } catch {
             case _: Exception => None
@@ -60,9 +58,8 @@ mod Environment {
     /// Returns the system property by name.
     ///
     pub def getProp(name: String): Option[String] =
-        import static java.lang.System.getProperty(String): String \ {};
         try {
-            let result = getProperty(name);
+            let result = unsafe System.getProperty(name);
             Object.toOption(result)
         } catch {
             case _: Exception => None
@@ -97,8 +94,7 @@ mod Environment {
     /// Returns the system line separator
     ///
     pub def getLineSeparator(): String =
-        import static java.lang.System.lineSeparator(): String \ {};
-        lineSeparator()
+        unsafe System.lineSeparator()
 
     ///
     /// Returns the user's current working directory
@@ -130,8 +126,7 @@ mod Environment {
         unsafe getRuntime().availableProcessors()
 
     def getEnvHelper(iter: JIterator, m: Map[String, String]): Map[String, String] =
-        import java.util.Iterator.hasNext(): Bool \ {};
-        if (hasNext(iter))
+        if (unsafe iter.hasNext())
             let e = unsafe unchecked_cast(iter.next() as ##java.util.Map$Entry);
             let k = unsafe unchecked_cast(e.getKey() as String);
             let v = unsafe unchecked_cast(e.getValue() as String);

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -106,8 +106,7 @@ pub def coerce(x: t): Coerce.Out[t] with Coerce[t] = Coerce.coerce(x)
 /// Converts `x` to a string and prints it to standard out followed by a new line.
 ///
 pub def println(x: a): Unit \ IO with ToString[a] =
-    import java.io.PrintStream.println(String): Unit \ IO;
-    x |> ToString.toString |> println(System.out)
+    (System.out).println(x |> ToString.toString)
 
 ///
 /// Touches the given region capability `rc`.
@@ -118,14 +117,12 @@ pub def touch(_: Region[r]): Unit \ r = checked_ecast(())
 /// Crashes the current process with the given message `m`.
 ///
 pub def bug!(m: String): a = masked_cast({
-    import java.io.PrintStream.println(String): Unit \ IO;
-    let prt = println(System.err);
-    prt("*".repeat(80));
-    prt("**") ;
-    prt("**  BUG: ${m}") ;
-    prt("**") ;
-    prt("*".repeat(80));
-    prt("");
+    (System.err).println("*".repeat(80));
+    (System.err).println("**") ;
+    (System.err).println("**  BUG: ${m}") ;
+    (System.err).println("**") ;
+    (System.err).println("*".repeat(80));
+    (System.err).println("");
     ?panic
 })
 

--- a/main/src/library/Regex.flix
+++ b/main/src/library/Regex.flix
@@ -100,8 +100,7 @@ mod Regex {
     ///
     pub def unmatchable(): Regex =
         try {
-            import static java.util.regex.Pattern.compile(String): ##java.util.regex.Pattern \ {};
-            compile("^\\b$")
+            unsafe Pattern.compile("^\\b$")
         } catch {
             case _: ##java.lang.Exception => unreachable!()
         }
@@ -110,8 +109,7 @@ mod Regex {
     /// Return the regular expression string that matches the the literal string `s`.
     ///
     pub def quote(s: String): String =
-        import static java.util.regex.Pattern.quote(String): String \ {};
-        quote(s)
+        unsafe Pattern.quote(s)
 
     ///
     /// Return the regular expression string used to build this Regex.

--- a/main/src/library/Regex.flix
+++ b/main/src/library/Regex.flix
@@ -129,9 +129,8 @@ mod Regex {
     /// Returns `true` if the entire string `s` is matched by the Regex `rgx`.
     ///
     pub def isMatch(rgx: Regex, s: String): Bool = region rc {
-        import java.util.regex.Matcher.matches(): Bool \ rc;
         let Matcher(m1) = newMatcher(rc, rgx, s);
-        matches(m1)
+        unsafe m1.matches()
     }
 
     ///
@@ -184,9 +183,8 @@ mod Regex {
     /// Splits the string `s` around matches of the Regex `regex`.
     ///
     pub def split(regex: {regex = Regex}, s: String): List[String] = region rc {
-        import java.util.regex.Pattern.split(##java.lang.CharSequence): Array[String, rc] \ rc;
         let _ = rc; // This avoids a redundancy error.
-        Array.toList(split(regex#regex, checked_cast(s)))
+        unsafe Array.toList(unsafe regex#regex.split(s))
     }
 
 
@@ -194,27 +192,24 @@ mod Regex {
     /// Returns string `s` with every match of the Regex `src` replaced by the string `dst`.
     ///
     pub def replace(src: {src = Regex}, dst: {dst = String}, s: String): String = region rc {
-        import java.util.regex.Matcher.replaceAll(String): String \ rc;
         let Matcher(m1) = newMatcher(rc, src#src, s);
-        replaceAll(m1, dst#dst)
+        unsafe m1.replaceAll(dst#dst)
     }
 
     ///
     /// Returns string `s` with the first match of the regular expression `src` replaced by the string `dst`.
     ///
     pub def replaceFirst(src: {src = Regex}, dst: {dst = String}, s: String): String = region rc {
-        import java.util.regex.Matcher.replaceFirst(String): String \ rc;
         let Matcher(m1) = newMatcher(rc, src#src, s);
-        replaceFirst(m1, dst#dst)
+        unsafe m1.replaceFirst(dst#dst)
     }
 
     ///
     /// Returns `true` if the string `s` starts the Regex `prefix`.
     ///
     pub def startsWith(prefix: {prefix = Regex}, s: String): Bool = region rc {
-        import java.util.regex.Matcher.lookingAt(): Bool \ rc;
         let Matcher(m1) = newMatcher(rc, prefix#prefix, s);
-        lookingAt(m1)
+        unsafe m1.lookingAt()
     }
 
     ///
@@ -421,9 +416,8 @@ mod Regex {
     /// Returns `false` if the entire string does not match or the bounds are invalid.
     ///
     pub def isMatchWithBounds(rgx: Regex, start: {start = Int32}, end: {end = Int32}, s: String): Bool = region rc {
-        import java.util.regex.Matcher.matches(): Bool \ rc;
         match newMatcherWithBounds(rc, rgx, start, end, s) {
-            case Ok(m)  => {let Matcher(m1) = m; matches(m1)}
+            case Ok(m)  => {let Matcher(m1) = m; unsafe m1.matches()}
             case Err(_) => false
         }
     }

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -88,9 +88,8 @@ mod String {
     /// Splits the string `s` around matches of the regular expression `regex`.
     ///
     pub def split(regex: {regex = String}, s: String): List[String] = region rc {
-        import java.lang.String.split(String): Array[String, rc] \ rc;
         let _ = rc; // This avoids a redundancy error.
-        Array.toList(split(s, regex#regex))
+        unsafe Array.toList(unsafe s.split(regex#regex))
     }
 
     ///

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -17,6 +17,7 @@
 mod String {
 
     import java.lang.System
+    import java.util.regex.Pattern
 
     use Regex.Flag
 
@@ -150,8 +151,7 @@ mod String {
     ///
     pub def toRegex(regex: String): Result[String, Regex] =
         Result.tryCatch(_ -> {
-            import static java.util.regex.Pattern.compile(String): ##java.util.regex.Pattern \ {};
-            compile(regex)
+            unsafe Pattern.compile(regex)
         })
 
 
@@ -166,8 +166,7 @@ mod String {
     ///
     pub def toRegexWithFlags(flags: Set[Flag], regex: String): Result[String, Regex] =
         Result.tryCatch(_ -> {
-            import static java.util.regex.Pattern.compile(String, Int32): ##java.util.regex.Pattern \ {};
-            compile(regex, Regex.sumFlags(flags))
+            unsafe Pattern.compile(regex, Regex.sumFlags(flags))
         })
 
 
@@ -298,9 +297,8 @@ mod String {
     /// Note - use `isSubmatch` to search for a substring.
     ///
     pub def isMatch(regex: {regex = String}, s: String): Bool =
-        import java.lang.String.matches(String): Bool \ {};
         try {
-            matches(s, regex#regex)
+            unsafe s.matches(regex#regex)
         } catch {
             case _: ##java.util.regex.PatternSyntaxException => false
         }
@@ -315,14 +313,11 @@ mod String {
     /// Helper function for `isSubmatch`.
     ///
     def isSubmatchHelper(pattern: String, s: String): Bool = region rc {
-        import static java.util.regex.Pattern.compile(String): ##java.util.regex.Pattern \ rc;
-        import java.util.regex.Pattern.matcher(##java.lang.CharSequence): ##java.util.regex.Matcher \ rc;
-        import java.util.regex.Matcher.find(Int32): Bool \ rc;
         let _ = rc; // This avoids a redundancy error.
         try {
-            let p1 = compile(pattern);
-            let m1 = matcher(p1, checked_cast(s));
-            find(m1, 0)
+            let p1 = unsafe Pattern.compile(pattern);
+            let m1 = unsafe p1.matcher(s);
+            unsafe m1.find(0)
         } catch {
             case _: ##java.util.regex.PatternSyntaxException => false
         }

--- a/main/test/ca/uwaterloo/flix/library/TestAdaptor.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestAdaptor.flix
@@ -16,6 +16,16 @@
 
 mod TestAdaptor {
 
+    import java.util.Optional
+    import java.util.stream.Stream
+    import java.util.{Map => JMap}
+    import java.util.{Set => JSet}
+    import java.util.{List => JList}
+    import java.util.TreeMap
+    import java.util.TreeSet
+    import java.util.ArrayList
+    import java.util.LinkedList
+
     /////////////////////////////////////////////////////////////////////////////
     // Comparator                                                              //
     /////////////////////////////////////////////////////////////////////////////
@@ -41,14 +51,12 @@ mod TestAdaptor {
 
     @test
     def fromOptional01(): Bool \ {} =
-        import static java.util.Optional.empty(): ##java.util.Optional \ {};
-        let o = empty();
+        let o = unsafe Optional.empty();
         Adaptor.fromOptional((Proxy.Proxy: Proxy[String]), o) == (None : Option[String])
 
     @test
     def fromOptional02(): Bool \ {} =
-        import static java.util.Optional.of(##java.lang.Object): ##java.util.Optional \ {};
-        let o = of(checked_cast("Hello"));
+        let o = unsafe Optional.of("Hello");
         Adaptor.fromOptional((Proxy.Proxy: Proxy[String]), o) == Some("Hello")
 
     /////////////////////////////////////////////////////////////////////////////
@@ -57,8 +65,7 @@ mod TestAdaptor {
 
     @test
     def fromMapEntry01(): Bool \ {} =
-        import static java.util.Map.entry(##java.lang.Object, ##java.lang.Object): ##java.util.Map$Entry \ {};
-        let e = entry(checked_cast("hello"), checked_cast("world"));
+        let e = unsafe JMap.entry("hello", "world");
         Adaptor.fromMapEntry((Proxy.Proxy: Proxy[String]), (Proxy.Proxy: Proxy[String]), e) == ("hello", "world")
 
     /////////////////////////////////////////////////////////////////////////////
@@ -67,20 +74,17 @@ mod TestAdaptor {
 
     @test
     def fromList01(): Bool \ {} =
-        import static java.util.List.of(): ##java.util.List \ {};
-        let l = of();
+        let l = unsafe JList.of();
         Adaptor.fromList(l) == (List#{} : List[String])
 
     @test
     def fromList02(): Bool \ {} =
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
-        let l = of(checked_cast("hello"));
+        let l = unsafe JList.of("hello");
         Adaptor.fromList(l) == List#{"hello"}
 
     @test
     def fromList03(): Bool \ {} =
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
-        let l = of(checked_cast("hello"), checked_cast("world"));
+        let l = unsafe JList.of("hello", "world");
         Adaptor.fromList(l) == List#{"hello", "world"}
 
     /////////////////////////////////////////////////////////////////////////////
@@ -89,22 +93,19 @@ mod TestAdaptor {
 
     @test
     def fromListToIterator01(): Bool \ {} = region rc {
-        import static java.util.List.of(): ##java.util.List \ {};
-        let l = of();
+        let l = unsafe JList.of();
         Iterator.toList(Adaptor.fromListToIterator(rc, (Proxy.Proxy: Proxy[String]), l)) == (List#{} : List[String])
     }
 
     @test
     def fromListToIterator02(): Bool \ {} = region rc {
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
-        let l = of(checked_cast("hello"));
+        let l = unsafe JList.of("hello");
         Iterator.toList(Adaptor.fromListToIterator(rc, (Proxy.Proxy: Proxy[String]), l)) == List#{"hello"}
     }
 
     @test
     def fromListToIterator03(): Bool \ {} = region rc {
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
-        let l = of(checked_cast("hello"), checked_cast("world"));
+        let l = unsafe JList.of("hello", "world");
         Iterator.toList(Adaptor.fromListToIterator(rc, (Proxy.Proxy: Proxy[String]), l)) == List#{"hello", "world"}
     }
 
@@ -114,20 +115,17 @@ mod TestAdaptor {
 
     @test
     def fromSet01(): Bool \ {} =
-        import static java.util.Set.of(): ##java.util.Set \ {};
-        let s = of();
+        let s = unsafe JSet.of();
         Adaptor.fromSet(s) == (Set#{} : Set[String])
 
     @test
     def fromSet02(): Bool \ {} =
-        import static java.util.Set.of(##java.lang.Object): ##java.util.Set \ {};
-        let s = of(checked_cast("hello"));
+        let s = unsafe JSet.of("hello");
         Adaptor.fromSet(s) == Set#{"hello"}
 
     @test
     def fromSet03(): Bool \ {} =
-        import static java.util.Set.of(##java.lang.Object, ##java.lang.Object): ##java.util.Set \ {};
-        let s = of(checked_cast("hello"), checked_cast("world"));
+        let s = unsafe JSet.of("hello", "world");
         Adaptor.fromSet(s) == Set#{"hello", "world"}
 
     /////////////////////////////////////////////////////////////////////////////
@@ -136,22 +134,19 @@ mod TestAdaptor {
 
     @test
     def fromSetToIterator01(): Bool \ {} = region rc {
-        import static java.util.Set.of(): ##java.util.Set \ {};
-        let s = of();
+        let s = unsafe JSet.of();
         Iterator.toSet(Adaptor.fromSetToIterator(rc, (Proxy.Proxy: Proxy[String]), s)) == (Set#{} : Set[String])
     }
 
     @test
     def fromSetToIterator02(): Bool \ {} = region rc {
-        import static java.util.Set.of(##java.lang.Object): ##java.util.Set \ {};
-        let s = of(checked_cast("hello"));
+        let s = unsafe JSet.of("hello");
         Iterator.toSet(Adaptor.fromSetToIterator(rc, (Proxy.Proxy: Proxy[String]), s)) == Set#{"hello"}
     }
 
     @test
     def fromSetToIterator03(): Bool \ {} = region rc {
-        import static java.util.Set.of(##java.lang.Object, ##java.lang.Object): ##java.util.Set \ {};
-        let s = of(checked_cast("hello"), checked_cast("world"));
+        let s = unsafe JSet.of("hello", "world");
         Iterator.toSet(Adaptor.fromSetToIterator(rc, (Proxy.Proxy: Proxy[String]), s)) == Set#{"hello", "world"}
     }
 
@@ -161,20 +156,17 @@ mod TestAdaptor {
 
     @test
     def fromMap01(): Bool \ {} =
-        import static java.util.Map.of(): ##java.util.Map \ {};
-        let m = of();
+        let m = unsafe JMap.of();
         Adaptor.fromMap(m) == (Map#{} : Map[String, String])
 
     @test
     def fromMap02(): Bool \ {} =
-        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
-        let m = of(checked_cast("a"), checked_cast("hello"));
+        let m = unsafe JMap.of("a", "hello");
         Adaptor.fromMap(m) == Map#{"a" => "hello"}
 
     @test
     def fromMap03(): Bool \ {} =
-        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object, ##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
-        let m = of(checked_cast("a"), checked_cast("hello"), checked_cast("b"), checked_cast("world"));
+        let m = unsafe JMap.of("a", "hello", "b", "world");
         Adaptor.fromMap(m) == Map#{"a" => "hello", "b" => "world"}
 
     /////////////////////////////////////////////////////////////////////////////
@@ -183,22 +175,19 @@ mod TestAdaptor {
 
     @test
     def fromMapToIterator01(): Bool \ {} = region rc {
-        import static java.util.Map.of(): ##java.util.Map \ {};
-        let m = of();
+        let m = unsafe JMap.of();
         Iterator.toMap(Adaptor.fromMapToIterator(rc, m)) == (Map#{} : Map[String, String])
     }
 
     @test
     def fromMapToIterator02(): Bool \ {} = region rc {
-        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
-        let m = of(checked_cast("a"), checked_cast("hello"));
+        let m = unsafe JMap.of("a", "hello");
         Iterator.toMap(Adaptor.fromMapToIterator(rc, m)) == Map#{"a" => "hello"}
     }
 
     @test
     def fromMapToIterator03(): Bool \ {} = region rc {
-        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object, ##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
-        let m = of(checked_cast("a"), checked_cast("hello"), checked_cast("b"), checked_cast("world"));
+        let m = unsafe JMap.of("a", "hello", "b", "world");
         Iterator.toMap(Adaptor.fromMapToIterator(rc, m)) == Map#{"a" => "hello", "b" => "world"}
     }
 
@@ -208,16 +197,14 @@ mod TestAdaptor {
 
     @test
     def fromIterator01(): Bool \ {} = region rc {
-        import static java.util.List.of(): ##java.util.List \ {};
-        let iter = unsafe of().iterator();
+        let iter = unsafe JList.of().iterator();
         let flixIter = Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[String]), iter);
         Iterator.toList(flixIter) == (Nil : List[String])
     }
 
     @test
     def fromIterator02(): Bool \ {} = region rc {
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
-        let iter = unsafe of(checked_cast("hello")).iterator();
+        let iter = unsafe JList.of("hello").iterator();
         let flixIter = Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[String]), iter);
         Iterator.toList(flixIter) == List#{"hello"}
     }
@@ -225,8 +212,7 @@ mod TestAdaptor {
 
     @test
     def fromIterator03(): Bool \ {} = region rc {
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
-        let iter = unsafe of(checked_cast("hello"), checked_cast("world")).iterator();
+        let iter = unsafe JList.of("hello", "world").iterator();
         let flixIter = Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[String]), iter);
         Iterator.toList(flixIter) == List#{"hello", "world"}
     }
@@ -237,15 +223,13 @@ mod TestAdaptor {
 
     @test
     def fromStreamToIterator01(): Bool \ {} = region rc {
-        import static java.util.stream.Stream.empty(): ##java.util.stream.Stream \ {};
-        let s = empty();
+        let s = unsafe Stream.empty();
         Iterator.toList(Adaptor.fromStreamToIterator(rc, (Proxy.Proxy: Proxy[String]), s)) == (Nil : List[String])
     }
 
     @test
     def fromStreamToIterator02(): Bool \ {} = region rc {
-        import static java.util.stream.Stream.of(##java.lang.Object): ##java.util.stream.Stream \ {};
-        let s = of(checked_cast("hello"));
+        let s = unsafe Stream.of("hello");
         Iterator.toList(Adaptor.fromStreamToIterator(rc, (Proxy.Proxy: Proxy[String]), s)) == "hello" :: Nil
     }
 
@@ -263,22 +247,19 @@ mod TestAdaptor {
 
     @test
     def fromCollectionToIterator01(): Bool \ {} = region rc {
-        import static java.util.List.of(): ##java.util.List \ {};
-        let col = checked_cast(of());
+        let col = checked_cast(unsafe JList.of());
         Iterator.toList(Adaptor.fromCollectionToIterator(rc, (Proxy.Proxy: Proxy[String]), col)) == (Nil : List[String])
     }
 
     @test
     def fromCollectionToIterator02(): Bool \ {} = region rc {
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
-        let col = checked_cast(of(checked_cast("hello")));
+        let col = checked_cast(unsafe JList.of("hello"));
         Iterator.toList(Adaptor.fromCollectionToIterator(rc, (Proxy.Proxy: Proxy[String]), col)) == "hello" :: Nil
     }
 
     @test
     def fromCollectionToIterator03(): Bool \ {} = region rc {
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
-        let col = checked_cast(of(checked_cast("hello"), checked_cast("world")));
+        let col = checked_cast(unsafe JList.of("hello", "world"));
         Iterator.toList(Adaptor.fromCollectionToIterator(rc, (Proxy.Proxy: Proxy[String]), col)) == "hello" :: "world" :: Nil
     }
 
@@ -288,15 +269,13 @@ mod TestAdaptor {
 
     @test
     def toOptional01(): Bool \ IO =
-        import static java.util.Optional.empty(): ##java.util.Optional \ {};
         let o = Adaptor.toOptional(None);
-        o.equals(empty())
+        o.equals(unsafe Optional.empty())
 
     @test
     def toOptional02(): Bool \ IO =
-        import static java.util.Optional.of(##java.lang.Object): ##java.util.Optional \ {};
         let o = Adaptor.toOptional(Some("hello"));
-        o.equals(of(checked_cast("hello")))
+        o.equals(unsafe Optional.of("hello"))
 
     /////////////////////////////////////////////////////////////////////////////
     // toMapEntry                                                              //
@@ -304,9 +283,8 @@ mod TestAdaptor {
 
     @test
     def toMapEntry01(): Bool \ IO =
-        import static java.util.Map.entry(##java.lang.Object, ##java.lang.Object): ##java.util.Map$Entry \ {};
         let e = Adaptor.toMapEntry(("hello", "world"));
-        e.equals(entry(checked_cast("hello"), checked_cast("world")))
+        e.equals(unsafe JMap.entry("hello", "world"))
 
     /////////////////////////////////////////////////////////////////////////////
     // toList                                                                  //
@@ -314,21 +292,18 @@ mod TestAdaptor {
 
     @test
     def toList01(): Bool \ IO =
-        import static java.util.List.of(): ##java.util.List \ {};
         let l = Adaptor.toList(Nil);
-        of().equals(l)
+        unsafe JList.of().equals(l)
 
     @test
     def toList02(): Bool \ IO =
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
         let l = Adaptor.toList(List#{"hello"});
-        of(checked_cast("hello")).equals(l)
+        unsafe JList.of("hello").equals(l)
 
     @test
     def toList03(): Bool \ IO =
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
         let l = Adaptor.toList(List#{"hello", "world"});
-        of(checked_cast("hello"), checked_cast("world")).equals(l)
+        unsafe JList.of("hello", "world").equals(l)
 
     /////////////////////////////////////////////////////////////////////////////
     // toArrayList                                                             //
@@ -336,24 +311,18 @@ mod TestAdaptor {
 
     @test
     def toArrayList01(): Bool \ IO =
-        import java_new java.util.ArrayList(##java.util.Collection): ##java.util.ArrayList \ {} as newArrayList;
-        import static java.util.List.of(): ##java.util.List \ {};
         let l = Adaptor.toArrayList(Nil);
-        newArrayList(checked_cast(of())).equals(l)
+        new ArrayList(unsafe JList.of()).equals(l)
 
     @test
     def toArrayList02(): Bool \ IO =
-        import java_new java.util.ArrayList(##java.util.Collection): ##java.util.ArrayList \ {} as newArrayList;
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
         let l = Adaptor.toArrayList(List#{"hello"});
-        newArrayList(checked_cast(of(checked_cast("hello")))).equals(l)
+        new ArrayList(JList.of("hello")).equals(l)
 
     @test
     def toArrayList03(): Bool \ IO =
-        import java_new java.util.ArrayList(##java.util.Collection): ##java.util.ArrayList \ {} as newArrayList;
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
         let l = Adaptor.toArrayList(List#{"hello", "world"});
-        newArrayList(checked_cast(of(checked_cast("hello"), checked_cast("world")))).equals(l)
+        new ArrayList(JList.of("hello", "world")).equals(l)
 
     /////////////////////////////////////////////////////////////////////////////
     // toLinkedList                                                            //
@@ -361,24 +330,18 @@ mod TestAdaptor {
 
     @test
     def toLinkedList01(): Bool \ IO =
-        import java_new java.util.LinkedList(##java.util.Collection): ##java.util.LinkedList \ {} as newLinkedList;
-        import static java.util.List.of(): ##java.util.List \ {};
         let l = Adaptor.toLinkedList(Nil);
-        newLinkedList(checked_cast(of())).equals(l)
+        new LinkedList(JList.of()).equals(l)
 
     @test
     def toLinkedList02(): Bool \ IO =
-        import java_new java.util.LinkedList(##java.util.Collection): ##java.util.LinkedList \ {} as newLinkedList;
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
         let l = Adaptor.toLinkedList(List#{"hello"});
-        newLinkedList(checked_cast(of(checked_cast("hello")))).equals(l)
+        new LinkedList(JList.of("hello")).equals(l)
 
     @test
     def toLinkedList03(): Bool \ IO =
-        import java_new java.util.LinkedList(##java.util.Collection): ##java.util.LinkedList \ {} as newLinkedList;
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
         let l = Adaptor.toLinkedList(List#{"hello", "world"});
-        newLinkedList(checked_cast(of(checked_cast("hello"), checked_cast("world")))).equals(l)
+        new LinkedList(JList.of("hello", "world")).equals(l)
 
     /////////////////////////////////////////////////////////////////////////////
     // toSet                                                                   //
@@ -386,21 +349,18 @@ mod TestAdaptor {
 
     @test
     def toSet01(): Bool \ IO =
-        import static java.util.Set.of(): ##java.util.Set \ {};
         let s = Adaptor.toSet((Set#{} : Set[String]));
-        of().equals(s)
+        JSet.of().equals(s)
 
     @test
     def toSet02(): Bool \ IO =
-        import static java.util.Set.of(##java.lang.Object): ##java.util.Set \ {};
         let s = Adaptor.toSet(Set#{"hello"});
-        of(checked_cast("hello")).equals(s)
+        JSet.of("hello").equals(s)
 
     @test
     def toSet03(): Bool \ IO =
-        import static java.util.Set.of(##java.lang.Object, ##java.lang.Object): ##java.util.Set \ {};
         let s = Adaptor.toSet(Set#{"hello", "world"});
-        of(checked_cast("hello"), checked_cast("world")).equals(s)
+        JSet.of("hello", "world").equals(s)
 
     /////////////////////////////////////////////////////////////////////////////
     // toTreeSet                                                               //
@@ -408,24 +368,18 @@ mod TestAdaptor {
 
     @test
     def toTreeSet01(): Bool \ IO =
-        import java_new java.util.TreeSet(##java.util.Collection): ##java.util.TreeSet \ {} as newTreeSet;
-        import static java.util.List.of(): ##java.util.List \ {};
         let s = Adaptor.toTreeSet((Set#{} : Set[String]));
-        newTreeSet(checked_cast(of())).equals(s)
+        new TreeSet(unsafe JList.of()).equals(s)
 
     @test
     def toTreeSet02(): Bool \ IO =
-        import java_new java.util.TreeSet(##java.util.Collection): ##java.util.TreeSet \ {} as newTreeSet;
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
         let s = Adaptor.toTreeSet(Set#{"hello"});
-        newTreeSet(checked_cast(of(checked_cast("hello")))).equals(s)
+        new TreeSet(JList.of("hello")).equals(s)
 
     @test
     def toTreeSet03(): Bool \ IO =
-        import java_new java.util.TreeSet(##java.util.Collection): ##java.util.TreeSet \ {} as newTreeSet;
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
         let s = Adaptor.toTreeSet(Set#{"hello", "world"});
-        newTreeSet(checked_cast(of(checked_cast("hello"), checked_cast("world")))).equals(s)
+        new TreeSet(JList.of("hello", "world")).equals(s)
 
     /////////////////////////////////////////////////////////////////////////////
     // toMap                                                                   //
@@ -433,21 +387,18 @@ mod TestAdaptor {
 
     @test
     def toMap01(): Bool \ IO =
-        import static java.util.Map.of(): ##java.util.Map \ {};
         let m = Adaptor.toMap((Map#{} : Map[String, String]));
-        of().equals(m)
+        unsafe JMap.of().equals(m)
 
     @test
     def toMap02(): Bool \ IO =
-        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
         let m = Adaptor.toMap(Map#{"a" => "hello"});
-        of(checked_cast("a"), checked_cast("hello")).equals(m)
+        unsafe JMap.of("a", "hello").equals(m)
 
     @test
     def toMap03(): Bool \ IO =
-        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object, ##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
         let m = Adaptor.toMap(Map#{"a" => "hello", "b" => "world"});
-        of(checked_cast("a"), checked_cast("hello"), checked_cast("b"), checked_cast("world")).equals(m)
+        unsafe JMap.of("a", "hello", "b", "world").equals(m)
 
     /////////////////////////////////////////////////////////////////////////////
     // toTreeMap                                                               //
@@ -455,24 +406,18 @@ mod TestAdaptor {
 
     @test
     def toTreeMap01(): Bool \ IO =
-        import java_new java.util.TreeMap(##java.util.Map): ##java.util.TreeMap \ {} as newTreeMap;
-        import static java.util.Map.of(): ##java.util.Map \ {};
         let m = Adaptor.toTreeMap((Map#{} : Map[String, String]));
-        newTreeMap(of()).equals(m)
+        new TreeMap(unsafe JMap.of()).equals(m)
 
     @test
     def toTreeMap02(): Bool \ IO =
-        import java_new java.util.TreeMap(##java.util.Map): ##java.util.TreeMap \ {} as newTreeMap;
-        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
         let m = Adaptor.toTreeMap(Map#{"a" => "hello"});
-        newTreeMap(of(checked_cast("a"), checked_cast("hello"))).equals(m)
+        new TreeMap(unsafe JMap.of("a", "hello")).equals(m)
 
     @test
     def toTreeMap03(): Bool \ IO =
-        import java_new java.util.TreeMap(##java.util.Map): ##java.util.TreeMap \ {} as newTreeMap;
-        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object, ##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
         let m = Adaptor.toTreeMap(Map#{"a" => "hello", "b" => "world"});
-        newTreeMap(of(checked_cast("a"), checked_cast("hello"), checked_cast("b"), checked_cast("world"))).equals(m)
+        new TreeMap(unsafe JMap.of("a", "hello", "b", "world")).equals(m)
 
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestAdaptor.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestAdaptor.flix
@@ -235,9 +235,8 @@ mod TestAdaptor {
 
     @test
     def fromStreamToIterator03(): Bool \ {} = region rc {
-        import static java.util.stream.Stream.of(Array[##java.lang.Object, rc]): ##java.util.stream.Stream \ {};
-        let arr = Array#{checked_cast("hello"), checked_cast("world")} @ rc;
-        let s = of(arr);
+        let arr = Array#{"hello", "world"} @ rc;
+        unsafe let s = Stream.of(unsafe arr);
         Iterator.toList(Adaptor.fromStreamToIterator(rc, (Proxy.Proxy: Proxy[String]), s)) == "hello" :: "world" :: Nil
     }
 

--- a/main/test/ca/uwaterloo/flix/library/TestFile.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFile.flix
@@ -28,9 +28,6 @@ mod TestFile {
     /// Use `java.nio.file.Path` functions for platform independence.
     ///
     def makeTempPath(fileName: String): Result[IOError, String] = region rc {
-        import static java.nio.file.Path.of(String, Array[String, rc]): Path \ rc as ofPath;
-        import java.nio.file.Path.toString(): String \ {};
-        import java.nio.file.Path.normalize(): Path \ {};
         let tempdir = match Environment.getTemporaryDirectory() {
             case Some(dir)  => Ok(dir)
             case None       => Err(Generic("Could not find TemporaryDirectory"))
@@ -38,7 +35,7 @@ mod TestFile {
         try {
             Result.flatMap(root ->  {
                 let arr = List.toArray(rc, fileName :: Nil);
-                let path = ofPath(root, arr) |> normalize |> toString;
+                let path = unsafe Path.of(root, arr).normalize().toString();
                 Ok(path)
             }, tempdir)
         } catch {

--- a/main/test/ca/uwaterloo/flix/library/TestFromJava.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFromJava.flix
@@ -16,6 +16,12 @@
 
 mod TestFromJava {
 
+    import java.util.{Map => JMap}
+    import java.util.{Set => JSet}
+    import java.util.{List => JList}
+    import java.lang.{String => JString}
+    import java.math.BigInteger
+    import java.math.BigDecimal
     /////////////////////////////////////////////////////////////////////////////
     // Int8                                                                    //
     /////////////////////////////////////////////////////////////////////////////
@@ -106,14 +112,12 @@ mod TestFromJava {
 
     @test
     def bigIntFromJava01(): Bool =
-        import static java.math.BigInteger.valueOf(Int64): ##java.math.BigInteger \ {};
-        let i = valueOf(0i64);
+        let i = unsafe BigInteger.valueOf(0i64);
         FromJava.fromJava(i) == 0ii
 
     @test
     def bigIntFromJava02(): Bool =
-        import static java.math.BigInteger.valueOf(Int64): ##java.math.BigInteger \ {};
-        let i = valueOf(100i64);
+        let i = unsafe BigInteger.valueOf(100i64);
         FromJava.fromJava(i) == 100ii
 
     /////////////////////////////////////////////////////////////////////////////
@@ -122,14 +126,12 @@ mod TestFromJava {
 
     @test
     def bigDecimalFromJava01(): Bool =
-        import static java.math.BigDecimal.valueOf(Int64): ##java.math.BigDecimal \ {};
-        let d = valueOf(0i64);
+        let d = unsafe BigDecimal.valueOf(0i64);
         FromJava.fromJava(d) == 0.0ff
 
     @test
     def bigDecimalFromJava02(): Bool =
-        import static java.math.BigDecimal.valueOf(Int64): ##java.math.BigDecimal \ {};
-        let d = valueOf(100i64);
+        let d = unsafe BigDecimal.valueOf(100i64);
         FromJava.fromJava(d) == 100.0ff
 
     /////////////////////////////////////////////////////////////////////////////
@@ -152,14 +154,12 @@ mod TestFromJava {
 
     @test
     def stringFromJava01(): Bool =
-        import static java.lang.String.valueOf(Bool): ##java.lang.String \ {};
-        let s = valueOf(true);
+        let s = unsafe JString.valueOf(true);
         FromJava.fromJava(s) == "true"
 
     @test
     def stringFromJava02(): Bool =
-        import static java.lang.String.valueOf(Bool): ##java.lang.String \ {};
-        let s = valueOf(false);
+        let s = unsafe JString.valueOf(false);
         FromJava.fromJava(s) == "false"
 
     /////////////////////////////////////////////////////////////////////////////
@@ -168,20 +168,17 @@ mod TestFromJava {
 
     @test
     def chainFromJava01(): Bool =
-        import static java.util.List.of(): ##java.util.List \ {};
-        let l = of();
+        let l = unsafe JList.of();
         (FromJava.fromJava(l): Chain[String]) == (Chain.empty(): Chain[String])
 
     @test
     def chainFromJava02(): Bool =
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
-        let l = of(checked_cast("one"));
+        let l = unsafe JList.of("one");
         (FromJava.fromJava(l): Chain[String]) == Chain.singleton("one")
 
     @test
     def chainFromJava03(): Bool =
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
-        let l = of(checked_cast("one"), checked_cast("two"));
+        let l = unsafe JList.of("one", "two");
         (FromJava.fromJava(l): Chain[String]) == List.toChain(List#{"one", "two"})
 
     /////////////////////////////////////////////////////////////////////////////
@@ -190,20 +187,17 @@ mod TestFromJava {
 
     @test
     def listFromJava01(): Bool =
-        import static java.util.List.of(): ##java.util.List \ {};
-        let l = of();
+        let l = unsafe JList.of();
         (FromJava.fromJava(l): List[String]) == (Nil: List[String])
 
     @test
     def listFromJava02(): Bool =
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
-        let l = of(checked_cast("one"));
+        let l = unsafe JList.of("one");
         (FromJava.fromJava(l): List[String]) == List#{"one"}
 
     @test
     def listFromJava03(): Bool =
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
-        let l = of(checked_cast("one"), checked_cast("two"));
+        let l = unsafe JList.of("one", "two");
         (FromJava.fromJava(l): List[String]) == List#{"one", "two"}
 
     /////////////////////////////////////////////////////////////////////////////
@@ -212,20 +206,17 @@ mod TestFromJava {
 
     @test
     def mapFromJava01(): Bool =
-        import static java.util.Map.of(): ##java.util.Map \ {};
-        let m = of();
+        let m = unsafe JMap.of();
         (FromJava.fromJava(m): Map[String, String]) == Map#{}
 
     @test
     def mapFromJava02(): Bool =
-        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
-        let m = of(checked_cast("a"), checked_cast("one"));
+        let m = unsafe JMap.of("a", "one");
         (FromJava.fromJava(m): Map[String, String]) == Map#{"a" => "one"}
 
     @test
     def mapFromJava03(): Bool =
-        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object, ##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
-        let m = of(checked_cast("a"), checked_cast("one"), checked_cast("b"), checked_cast("two"));
+        let m = unsafe JMap.of("a", "one", "b", "two");
         (FromJava.fromJava(m): Map[String, String]) == Map#{"a" => "one", "b" => "two"}
 
     /////////////////////////////////////////////////////////////////////////////
@@ -234,20 +225,17 @@ mod TestFromJava {
 
     @test
     def setFromJava01(): Bool=
-        import static java.util.Set.of(): ##java.util.Set \ {};
-        let s = of();
+        let s = unsafe JSet.of();
         (FromJava.fromJava(s): Set[String]) == Set#{}
 
     @test
     def setFromJava02(): Bool =
-        import static java.util.Set.of(##java.lang.Object): ##java.util.Set \ {};
-        let s = of(checked_cast("one"));
+        let s = unsafe JSet.of("one");
         (FromJava.fromJava(s): Set[String]) == Set#{"one"}
 
     @test
     def setFromJava03(): Bool =
-        import static java.util.Set.of(##java.lang.Object, ##java.lang.Object): ##java.util.Set \ {};
-        let s = of(checked_cast("one"), checked_cast("two"));
+        let s = unsafe JSet.of("one", "two");
         (FromJava.fromJava(s): Set[String]) == Set#{"one", "two"}
 
     /////////////////////////////////////////////////////////////////////////////
@@ -256,20 +244,17 @@ mod TestFromJava {
 
     @test
     def vectorFromJava01(): Bool =
-        import static java.util.List.of(): ##java.util.List \ {};
-        let v = of();
+        let v = unsafe JList.of();
         (FromJava.fromJava(v): Vector[String]) == Vector#{}
 
     @test
     def vectorFromJava02(): Bool =
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
-        let v = of(checked_cast("one"));
+        let v = unsafe JList.of("one");
         (FromJava.fromJava(v): Vector[String]) == Vector#{"one"}
 
     @test
     def vectorFromJava03(): Bool =
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
-        let v = of(checked_cast("one"), checked_cast("two"));
+        let v = unsafe JList.of("one", "two");
         (FromJava.fromJava(v): Vector[String]) == Vector#{"one", "two"}
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestInt8.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestInt8.flix
@@ -1106,20 +1106,17 @@ mod TestInt8 {
 
     @test
     def valueOf01(): Bool =
-        import java.lang.Byte.equals(##java.lang.Object): Bool \ {};
         let i = Int8.valueOf(0i8);
-        equals(i, checked_cast(Int8.valueOf(0i8)))
+        unsafe i.equals(Int8.valueOf(0i8))
 
     @test
     def valueOf02(): Bool =
-        import java.lang.Byte.equals(##java.lang.Object): Bool \ {};
         let i = Int8.valueOf(1i8);
-        equals(i, checked_cast(Int8.valueOf(1i8)))
+        unsafe i.equals(Int8.valueOf(1i8))
 
     @test
     def valueOf03(): Bool =
-        import java.lang.Byte.equals(##java.lang.Object): Bool \ {};
         let i = Int8.valueOf(-1i8);
-        equals(i, checked_cast(Int8.valueOf(-1i8)))
+        unsafe i.equals(Int8.valueOf(-1i8))
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestToJava.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestToJava.flix
@@ -16,6 +16,10 @@
 
 mod TestToJava {
 
+    import java.util.{List => JList}
+    import java.util.{Map => JMap}
+    import java.util.{Set => JSet}
+
     /////////////////////////////////////////////////////////////////////////////
     // toJavaObject                                                            //
     /////////////////////////////////////////////////////////////////////////////
@@ -182,21 +186,18 @@ mod TestToJava {
 
     @test
     def chainToJava01(): Bool \ IO =
-        import static java.util.List.of(): ##java.util.List \ {};
         let l: ##java.util.List = ToJava.toJava((Chain.empty() : Chain[String]));
-        of().equals(l)
+        unsafe JList.of().equals(l)
 
     @test
     def chainToJava02(): Bool \ IO =
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
         let l: ##java.util.List = ToJava.toJava(Chain.singleton("one"));
-        of(checked_cast("one")).equals(l)
+        unsafe JList.of("one").equals(l)
 
     @test
     def chainToJava03(): Bool \ IO =
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
         let l: ##java.util.List = ToJava.toJava(Chain.cons("one", Chain.singleton("two")));
-        of(checked_cast("one"), checked_cast("two")).equals(l)
+        unsafe JList.of("one", "two").equals(l)
 
     /////////////////////////////////////////////////////////////////////////////
     // List                                                                     //
@@ -204,21 +205,18 @@ mod TestToJava {
 
     @test
     def listToJava01(): Bool \ IO =
-        import static java.util.List.of(): ##java.util.List \ {};
         let l: ##java.util.List = ToJava.toJava((Nil : List[String]));
-        of().equals(l)
+        unsafe JList.of().equals(l)
 
     @test
     def listToJava02(): Bool \ IO =
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
         let l: ##java.util.List = ToJava.toJava(List#{"one"});
-        of(checked_cast("one")).equals(l)
+        unsafe JList.of("one").equals(l)
 
     @test
     def listToJava03(): Bool \ IO =
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
         let l: ##java.util.List = ToJava.toJava(List#{"one", "two"});
-        of(checked_cast("one"), checked_cast("two")).equals(l)
+        unsafe JList.of("one", "two").equals(l)
 
     /////////////////////////////////////////////////////////////////////////////
     // Map                                                                     //
@@ -226,21 +224,18 @@ mod TestToJava {
 
     @test
     def mapToJava01(): Bool \ IO =
-        import static java.util.Map.of(): ##java.util.Map \ {};
         let m: ##java.util.Map = ToJava.toJava((Map#{} : Map[String, String]));
-        of().equals(m)
+        unsafe JMap.of().equals(m)
 
     @test
     def mapToJava02(): Bool \ IO =
-        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
         let m: ##java.util.Map = ToJava.toJava(Map#{"a" => "one"});
-        of(checked_cast("a"), checked_cast("one")).equals(m)
+        unsafe JMap.of("a", "one").equals(m)
 
     @test
     def mapToJava03(): Bool \ IO =
-        import static java.util.Map.of(##java.lang.Object, ##java.lang.Object, ##java.lang.Object, ##java.lang.Object): ##java.util.Map \ {};
         let m: ##java.util.Map = ToJava.toJava(Map#{"a" => "one", "b" => "two"});
-        of(checked_cast("a"), checked_cast("one"), checked_cast("b"), checked_cast("two")).equals(m)
+        unsafe JMap.of("a", "one", "b", "two").equals(m)
 
     /////////////////////////////////////////////////////////////////////////////
     // Nec                                                                     //
@@ -248,15 +243,13 @@ mod TestToJava {
 
     @test
     def necToJava01(): Bool \ IO =
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
         let l: ##java.util.List = ToJava.toJava(Nec.singleton("one"));
-        of(checked_cast("one")).equals(l)
+        unsafe JList.of("one").equals(l)
 
     @test
     def necToJava02(): Bool \ IO =
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
         let l: ##java.util.List = ToJava.toJava(Nec.cons("one", Nec.singleton("two")));
-        of(checked_cast("one"), checked_cast("two")).equals(l)
+        unsafe JList.of("one", "two").equals(l)
 
     /////////////////////////////////////////////////////////////////////////////
     // Nel                                                                     //
@@ -264,15 +257,13 @@ mod TestToJava {
 
     @test
     def nelToJava01(): Bool \ IO =
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
         let l: ##java.util.List = ToJava.toJava(Nel.singleton("one"));
-        of(checked_cast("one")).equals(l)
+        unsafe JList.of("one").equals(l)
 
     @test
     def nelToJava02(): Bool \ IO =
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
         let l: ##java.util.List = ToJava.toJava(Nel.cons("one", Nel.singleton("two")));
-        of(checked_cast("one"), checked_cast("two")).equals(l)
+        unsafe JList.of("one", "two").equals(l)
 
     /////////////////////////////////////////////////////////////////////////////
     // Set                                                                     //
@@ -280,21 +271,18 @@ mod TestToJava {
 
     @test
     def setToJava01(): Bool \ IO =
-        import static java.util.Set.of(): ##java.util.Set \ {};
         let s: ##java.util.Set = ToJava.toJava((Set#{} : Set[String]));
-        of().equals(s)
+        unsafe JSet.of().equals(s)
 
     @test
     def setToJava02(): Bool \ IO =
-        import static java.util.Set.of(##java.lang.Object): ##java.util.Set \ {};
         let s: ##java.util.Set = ToJava.toJava(Set#{"one"});
-        of(checked_cast("one")).equals(s)
+        unsafe JSet.of("one").equals(s)
 
     @test
     def setToJava03(): Bool \ IO =
-        import static java.util.Set.of(##java.lang.Object, ##java.lang.Object): ##java.util.Set \ {};
         let s: ##java.util.Set = ToJava.toJava(Set#{"one", "two"});
-        of(checked_cast("one"), checked_cast("two")).equals(s)
+        unsafe JSet.of("one", "two").equals(s)
 
     /////////////////////////////////////////////////////////////////////////////
     // Vector                                                                  //
@@ -302,20 +290,17 @@ mod TestToJava {
 
     @test
     def vectorToJava01(): Bool \ IO =
-        import static java.util.List.of(): ##java.util.List \ {};
         let v: ##java.util.List = ToJava.toJava((Vector#{} : Vector[String]));
-        of().equals(v)
+        unsafe JList.of().equals(v)
 
     @test
     def vectorToJava02(): Bool \ IO =
-        import static java.util.List.of(##java.lang.Object): ##java.util.List \ {};
         let v: ##java.util.List = ToJava.toJava(Vector#{"one"});
-        of(checked_cast("one")).equals(v)
+        unsafe JList.of("one").equals(v)
 
     @test
     def vectorToJava03(): Bool \ IO =
-        import static java.util.List.of(##java.lang.Object, ##java.lang.Object): ##java.util.List \ {};
         let v: ##java.util.List = ToJava.toJava(Vector#{"one", "two"});
-        of(checked_cast("one"), checked_cast("two")).equals(v)
+        unsafe JList.of("one", "two").equals(v)
 
 }

--- a/main/test/flix/Test.Exp.CheckedTypeCast.flix
+++ b/main/test/flix/Test.Exp.CheckedTypeCast.flix
@@ -40,15 +40,13 @@ mod Test.Exp.CheckedTypeCast {
     @test
     def testCheckedTypeCast06(): Serializable = region rc {
         let _ = rc;
-        import java_new java.lang.StringBuilder(): JStringBuilder \ rc as mkSb;
-        checked_cast(mkSb())
+        checked_cast(unsafe new JStringBuilder())
     }
 
     @test
     def testCheckedTypeCast07(): Object = region rc {
         let _ = rc;
-        import java_new java.lang.StringBuilder(): JStringBuilder \ rc as mkSb;
-        checked_cast(mkSb())
+        checked_cast(unsafe new JStringBuilder())
     }
 
     @test

--- a/main/test/flix/Test.Exp.Jvm.GetField.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetField.flix
@@ -1,89 +1,79 @@
 mod Test.Exp.Jvm.GetField {
 
     import java.lang.Object
+    import dev.flix.test.TestClass
+    import dev.flix.test.TestClassWithInheritedMethod
 
     @test
     def testGetBoolField01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.boolField: Bool \ IO as getField;
-        let o = newObject();
+        let o = new TestClass();
         getField(o) == true
 
     @test
     def testGetCharField01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.charField: Char \ IO as getField;
-        let o = newObject();
+        let o = new TestClass();
         getField(o) == 'A'
 
     @test
     def testGetFloat32Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.float32Field: Float32 \ IO as getField;
-        let o = newObject();
+        let o = new TestClass();
         getField(o) == 123.456f32
 
     @test
     def testGetFloat64Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.float64Field: Float64 \ IO as getField;
-        let o = newObject();
+        let o = new TestClass();
         getField(o) == 123.456f64
 
     @test
     def testGetInt8Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.int8Field: Int8 \ IO as getField;
-        let o = newObject();
+        let o = new TestClass();
         getField(o) == 127i8
 
     @test
     def testGetInt16Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.int16Field: Int16 \ IO as getField;
-        let o = newObject();
+        let o = new TestClass();
         getField(o) == 127i16
 
     @test
     def testGetInt32Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.int32Field: Int32 \ IO as getField;
-        let o = newObject();
+        let o = new TestClass();
         getField(o) == 127i32
 
     @test
     def testGetInt64Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.int64Field: Int64 \ IO as getField;
-        let o = newObject();
+        let o = new TestClass();
         getField(o) == 127i64
 
     @test
     def testGetStringField01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.stringField: String \ IO as getField;
-        let o = newObject();
+        let o = new TestClass();
         getField(o) == "Hello World"
 
     @test
     def testGetPureField01(): Bool =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ {} as newObject;
         import java_get_field dev.flix.test.TestClass.stringField: String \ {} as getField;
-        let o = newObject();
+        let o = unsafe new TestClass();
         getField(o) == "Hello World"
 
     @test
     def testGetObjectField01(): Object \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.stringField: ##java.lang.Object \ IO as getField;
-        let o = newObject();
+        let o = unsafe new TestClass();
         getField(o)
 
     @test
     def testGetInheritedField01(): Bool \ IO =
-        import java_new dev.flix.test.TestClassWithInheritedMethod(): ##dev.flix.test.TestClassWithInheritedMethod as newObj;
         import java_get_field dev.flix.test.TestClassWithInheritedMethod.m_x: Int32 \ {} as getField;
-        let obj = newObj();
+        let obj = new TestClassWithInheritedMethod();
         getField(obj) == 42
 
 }

--- a/main/test/flix/Test.Exp.Jvm.GetFieldDoubleNestedClass.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetFieldDoubleNestedClass.flix
@@ -1,81 +1,71 @@
 mod Test.Exp.Jvm.GetFieldDoubleNestedClass {
 
     import java.lang.Object
+    import dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass
 
     @test
     def testGetBoolField01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.boolField: Bool \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = new TestClass$_StaticNestedClass$DoubleNestedClass();
         getField(o) == true
 
     @test
     def testGetCharField01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.charField: Char \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = new TestClass$_StaticNestedClass$DoubleNestedClass();
         getField(o) == 'A'
 
     @test
     def testGetFloat32Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.float32Field: Float32 \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = new TestClass$_StaticNestedClass$DoubleNestedClass();
         getField(o) == 123.456f32
 
     @test
     def testGetFloat64Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.float64Field: Float64 \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = new TestClass$_StaticNestedClass$DoubleNestedClass();
         getField(o) == 123.456f64
 
     @test
     def testGetInt8Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.int8Field: Int8 \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = new TestClass$_StaticNestedClass$DoubleNestedClass();
         getField(o) == 127i8
 
     @test
     def testGetInt16Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.int16Field: Int16 \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = new TestClass$_StaticNestedClass$DoubleNestedClass();
         getField(o) == 127i16
 
     @test
     def testGetInt32Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.int32Field: Int32 \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = new TestClass$_StaticNestedClass$DoubleNestedClass();
         getField(o) == 127i32
 
     @test
     def testGetInt64Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.int64Field: Int64 \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = new TestClass$_StaticNestedClass$DoubleNestedClass();
         getField(o) == 127i64
 
     @test
     def testGetStringField01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.stringField: String \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = new TestClass$_StaticNestedClass$DoubleNestedClass();
         getField(o) == "Hello World"
 
     @test
     def testGetPureField01(): Bool =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass \ {} as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.stringField: String \ {} as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = unsafe new TestClass$_StaticNestedClass$DoubleNestedClass();
         getField(o) == "Hello World"
 
     @test
     def testGetObjectField01(): Object \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass.stringField: ##java.lang.Object \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass$DoubleNestedClass = new TestClass$_StaticNestedClass$DoubleNestedClass();
         getField(o)
 }

--- a/main/test/flix/Test.Exp.Jvm.GetFieldStaticInnerClass.flix
+++ b/main/test/flix/Test.Exp.Jvm.GetFieldStaticInnerClass.flix
@@ -1,81 +1,71 @@
 mod Test.Exp.Jvm.GetFieldStaticInnerClass {
 
     import java.lang.Object
+    import dev.flix.test.TestClass$_StaticNestedClass
 
     @test
     def testGetBoolField01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass.boolField: Bool \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass = new TestClass$_StaticNestedClass();
         getField(o) == true
 
     @test
     def testGetCharField01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass.charField: Char \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass = new TestClass$_StaticNestedClass();
         getField(o) == 'A'
 
     @test
     def testGetFloat32Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass.float32Field: Float32 \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass = new TestClass$_StaticNestedClass();
         getField(o) == 123.456f32
 
     @test
     def testGetFloat64Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass.float64Field: Float64 \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass = new TestClass$_StaticNestedClass();
         getField(o) == 123.456f64
 
     @test
     def testGetInt8Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass.int8Field: Int8 \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass = new TestClass$_StaticNestedClass();
         getField(o) == 127i8
 
     @test
     def testGetInt16Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass.int16Field: Int16 \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass = new TestClass$_StaticNestedClass();
         getField(o) == 127i16
 
     @test
     def testGetInt32Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass.int32Field: Int32 \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass = new TestClass$_StaticNestedClass();
         getField(o) == 127i32
 
     @test
     def testGetInt64Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass.int64Field: Int64 \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass = new TestClass$_StaticNestedClass();
         getField(o) == 127i64
 
     @test
     def testGetStringField01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass.stringField: String \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass = new TestClass$_StaticNestedClass();
         getField(o) == "Hello World"
 
     @test
     def testGetPureField01(): Bool =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass \ {} as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass.stringField: String \ {} as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass = unsafe new TestClass$_StaticNestedClass();
         getField(o) == "Hello World"
 
     @test
     def testGetObjectField01(): Object \ IO =
-        import java_new dev.flix.test.TestClass$_StaticNestedClass(): ##dev.flix.test.TestClass$_StaticNestedClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass$_StaticNestedClass.stringField: ##java.lang.Object \ IO as getField;
-        let o: ##dev.flix.test.TestClass$_StaticNestedClass = newObject();
+        let o: ##dev.flix.test.TestClass$_StaticNestedClass = new TestClass$_StaticNestedClass();
         getField(o)
 }

--- a/main/test/flix/Test.Exp.Jvm.NewObject.flix
+++ b/main/test/flix/Test.Exp.Jvm.NewObject.flix
@@ -77,158 +77,140 @@ mod Test.Exp.Jvm.NewObject {
 
     @test
     def testVoidInterface01(): Bool \ IO =
-        import static dev.flix.test.TestVoidInterface.runTest(TestVoidInterface): Bool;
         let anon = new TestVoidInterface {
             def testMethod(_this: TestVoidInterface): Unit = ()
         };
-        runTest(anon)
+        TestVoidInterface.runTest(anon)
 
     @test
     def testBoolInterface01(): Bool \ IO =
-        import static dev.flix.test.TestBoolInterface.runTest(TestBoolInterface): Bool;
         let anon = new TestBoolInterface {
             def testMethod(_this: TestBoolInterface, x: Bool): Bool = not x
         };
-        runTest(anon)
+        TestBoolInterface.runTest(anon)
 
     @test
     def testCharInterface01(): Bool \ IO =
-        import static dev.flix.test.TestCharInterface.runTest(TestCharInterface): Bool;
         let anon = new TestCharInterface {
             def testMethod(_this: TestCharInterface, x: Char): Char = Char.toUpperCase(x)
         };
-        runTest(anon)
+        TestCharInterface.runTest(anon)
 
     @test
     def testInt16Interface01(): Bool \ IO =
-        import static dev.flix.test.TestInt16Interface.runTest(TestInt16Interface): Bool;
         let anon = new TestInt16Interface {
             def testMethod(_this: TestInt16Interface, x: Int16): Int16 = x + 1i16
         };
-        runTest(anon)
+        TestInt16Interface.runTest(anon)
 
     @test
     def testInt32Interface01(): Bool \ IO =
-        import static dev.flix.test.TestInt32Interface.runTest(TestInt32Interface): Bool;
         let anon = new TestInt32Interface {
             def testMethod(_this: TestInt32Interface, x: Int32): Int32 = x + 1
         };
-        runTest(anon)
+        TestInt32Interface.runTest(anon)
 
     @test
     def testInt64Interface01(): Bool \ IO =
-        import static dev.flix.test.TestInt64Interface.runTest(TestInt64Interface): Bool;
         let anon = new TestInt64Interface {
             def testMethod(_this: TestInt64Interface, x: Int64): Int64 = x + 1i64
         };
-        runTest(anon)
+        TestInt64Interface.runTest(anon)
 
     @test
     def testFloat32Interface01(): Bool \ IO =
-        import static dev.flix.test.TestFloat32Interface.runTest(TestFloat32Interface): Bool;
         let anon = new TestFloat32Interface {
             def testMethod(_this: TestFloat32Interface, x: Float32): Float32 = x + 0.23f32
         };
-        runTest(anon)
+        TestFloat32Interface.runTest(anon)
 
     @test
     def testFloat64Interface01(): Bool \ IO =
-        import static dev.flix.test.TestFloat64Interface.runTest(TestFloat64Interface): Bool;
         let anon = new TestFloat64Interface {
             def testMethod(_this: TestFloat64Interface, x: Float64): Float64 = x + 0.23f64
         };
-        runTest(anon)
+        TestFloat64Interface.runTest(anon)
 
     @test
     def testBoolArrayInterface01(): Bool \ IO =
-        import static dev.flix.test.TestBoolArrayInterface.runTest(TestBoolArrayInterface): Bool;
         let anon = new TestBoolArrayInterface {
             def testMethod(_this: TestBoolArrayInterface, xs: Array[Bool, Static]): Array[Bool, Static] \ IO =
                 xs |> Array.map(Static, x -> not x)
         };
-        runTest(anon)
+        TestBoolArrayInterface.runTest(anon)
 
     @test
     def testCharArrayInterface01(): Bool \ IO =
-        import static dev.flix.test.TestCharArrayInterface.runTest(TestCharArrayInterface): Bool;
         let anon = new TestCharArrayInterface {
             def testMethod(_this: TestCharArrayInterface, xs: Array[Char, Static]): Array[Char, Static] \ IO =
                 xs |> Array.map(Static, Char.toUpperCase)
         };
-        runTest(anon)
+        TestCharArrayInterface.runTest(anon)
 
     @test
     def testInt8ArrayInterface01(): Bool \ IO =
-        import static dev.flix.test.TestInt8ArrayInterface.runTest(TestInt8ArrayInterface): Bool;
         let anon = new TestInt8ArrayInterface {
             def testMethod(_this: TestInt8ArrayInterface, xs: Array[Int8, Static]): Array[Int8, Static] \ IO =
                 xs |> Array.map(Static, x -> x + 1i8)
         };
-        runTest(anon)
+        TestInt8ArrayInterface.runTest(anon)
 
     @test
     def testInt16ArrayInterface01(): Bool \ IO =
-        import static dev.flix.test.TestInt16ArrayInterface.runTest(TestInt16ArrayInterface): Bool;
         let anon = new TestInt16ArrayInterface {
             def testMethod(_this: TestInt16ArrayInterface, xs: Array[Int16, Static]): Array[Int16, Static] \ IO =
                 xs |> Array.map(Static, x -> x + 1i16)
         };
-        runTest(anon)
+        TestInt16ArrayInterface.runTest(anon)
 
     @test
     def testInt32ArrayInterface01(): Bool \ IO =
-        import static dev.flix.test.TestInt32ArrayInterface.runTest(TestInt32ArrayInterface): Bool;
         let anon = new TestInt32ArrayInterface {
             def testMethod(_this: TestInt32ArrayInterface, xs: Array[Int32, Static]): Array[Int32, Static] \ IO =
                 xs |> Array.map(Static, x -> x + 1)
         };
-        runTest(anon)
+        TestInt32ArrayInterface.runTest(anon)
 
     @test
     def testInt64ArrayInterface01(): Bool \ IO =
-        import static dev.flix.test.TestInt64ArrayInterface.runTest(TestInt64ArrayInterface): Bool;
         let anon = new TestInt64ArrayInterface {
             def testMethod(_this: TestInt64ArrayInterface, xs: Array[Int64, Static]): Array[Int64, Static] \ IO =
                 xs |> Array.map(Static, x -> x + 1i64)
         };
-        runTest(anon)
+        TestInt64ArrayInterface.runTest(anon)
 
     @test
     def testFloat32ArrayInterface01(): Bool \ IO =
-        import static dev.flix.test.TestFloat32ArrayInterface.runTest(TestFloat32ArrayInterface): Bool;
         let anon = new TestFloat32ArrayInterface {
             def testMethod(_this: TestFloat32ArrayInterface, xs: Array[Float32, Static]): Array[Float32, Static] \ IO =
                 xs |> Array.map(Static, x -> x + 0.5f32)
         };
-        runTest(anon)
+        TestFloat32ArrayInterface.runTest(anon)
 
     @test
     def testFloat64ArrayInterface01(): Bool \ IO =
-        import static dev.flix.test.TestFloat64ArrayInterface.runTest(TestFloat64ArrayInterface): Bool;
         let anon = new TestFloat64ArrayInterface {
             def testMethod(_this: TestFloat64ArrayInterface, xs: Array[Float64, Static]): Array[Float64, Static] \ IO =
                 xs |> Array.map(Static, x -> x + 0.5f64)
         };
-        runTest(anon)
+        TestFloat64ArrayInterface.runTest(anon)
 
     @test
     def testStackOffsets01(): Bool \ IO =
-        import static dev.flix.test.TestStackOffsets.runTest(TestStackOffsets): Bool;
         let anon = new TestStackOffsets {
             def testMethod(_this: TestStackOffsets, a: Bool, b: Char, c: Int8, d: Int16, e: Int32, f: Int64, g: Float32, h: Float64): String =
                 "${a}, ${b}, ${c}, ${d}, ${e}, ${f}, ${g}, ${h}"
         };
-        runTest(anon)
+        TestStackOffsets.runTest(anon)
 
     @test
     def testOverloadedMethods01(): Bool \ IO =
-        import static dev.flix.test.TestOverloadedMethods.runTest(TestOverloadedMethods): Bool;
         let anon = new TestOverloadedMethods {
             def overloadedMethod(_this: TestOverloadedMethods): Int32 = 42
             def overloadedMethod(_this: TestOverloadedMethods, x: Int32): Int32 = x + 1
             def overloadedMethod(_this: TestOverloadedMethods, x: String, y: Float64, z: Float64): String = "${x}${y / z}"
         };
-        runTest(anon)
+        TestOverloadedMethods.runTest(anon)
 
     @test
     def testDefaultMethods01(): Bool \ IO =
@@ -247,58 +229,52 @@ mod Test.Exp.Jvm.NewObject {
 
     @test
     def testGenericInterface01(): Bool \ IO =
-        import static dev.flix.test.TestGenericInterface.runTest(TestGenericInterface): Bool;
         let anon = new TestGenericInterface {
             def testMethod(_this: TestGenericInterface, x: ##java.lang.Object): ##java.lang.Object =
                 let str = unchecked_cast(x as String);
                 checked_cast("${str}, ${str}")
         };
-        runTest(anon)
+        TestGenericInterface.runTest(anon)
 
     @test
     def testGenericMethod01(): Bool \ IO =
-        import static dev.flix.test.TestGenericMethod.runTest(TestGenericMethod): Bool;
         let anon = new TestGenericMethod {
             def testMethod(_this: TestGenericMethod, x: Object): Object =
                 let str = unchecked_cast(x as String);
                 checked_cast("${str}, ${str}")
         };
-        runTest(anon)
+        TestGenericMethod.runTest(anon)
 
     @test
     def testAliasesInObject01(): Bool \ IO =
-        import static dev.flix.test.TestGenericInterface.runTest(TestGenericInterface): Bool;
         let anon = new TestGenericInterface {
             def testMethod(_this: TestGenericInterface, x: Object): Object =
                 let str = unchecked_cast(x as String);
                 checked_cast("${str}, ${str}")
         };
-        runTest(anon)
+        TestGenericInterface.runTest(anon)
 
     @test
     def testVarargsInterface01(): Bool \ IO =
-        import static dev.flix.test.TestVarargsInterface.runTest(TestVarargsInterface): Bool;
         let anon = new TestVarargsInterface {
             def testMethod(_this: TestVarargsInterface, xs: Array[Int32, Static]): Int32 \ IO =
                 xs |> Array.sum
         };
-        runTest(anon)
+        TestVarargsInterface.runTest(anon)
 
     @test
     def testThrowingInterface01(): Bool \ IO =
-        import static dev.flix.test.TestThrowingInterface.runTest(TestThrowingInterface): Bool;
         let anon = new TestThrowingInterface {
             def testMethod(_this: TestThrowingInterface): Unit = ()
         };
-        runTest(anon)
+        TestThrowingInterface.runTest(anon)
 
     @test
     def testFunctionalInterface01(): Bool \ IO =
-        import static dev.flix.test.TestFunctionalInterface.runTest(TestFunctionalInterface): Bool;
         let anon = new TestFunctionalInterface {
             def testMethod(_this: TestFunctionalInterface, x: Int32): Int32 = x + 1
         };
-        runTest(anon)
+        TestFunctionalInterface.runTest(anon)
 
     @test
     def testFunctionalInterface02(): Bool \ IO =

--- a/main/test/flix/Test.Exp.Jvm.PutField.flix
+++ b/main/test/flix/Test.Exp.Jvm.PutField.flix
@@ -1,92 +1,84 @@
 mod Test.Exp.Jvm.PutField {
 
+    import dev.flix.test.TestClass
+    import dev.flix.test.TestClassWithInheritedMethod
     @test
     def testPutBoolField01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.boolField: Bool \ IO as getField;
         import java_set_field dev.flix.test.TestClass.boolField: Unit \ IO as setField;
-        let o = newObject();
+        let o = new TestClass();
         o `setField` false;
         getField(o) == false
 
     @test
     def testPutCharField01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.charField: Char \ IO as getField;
         import java_set_field dev.flix.test.TestClass.charField: Unit \ IO as setField;
-        let o = newObject();
+        let o = new TestClass();
         o `setField` 'X';
         getField(o) == 'X'
 
     @test
     def testPutFloat32Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.float32Field: Float32 \ IO as getField;
         import java_set_field dev.flix.test.TestClass.float32Field: Unit \ IO as setField;
-        let o = newObject();
+        let o = new TestClass();
         o `setField` 21.42f32;
         getField(o) == 21.42f32
 
     @test
     def testPutFloat64Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.float64Field: Float64 \ IO as getField;
         import java_set_field dev.flix.test.TestClass.float64Field: Unit \ IO as setField;
-        let o = newObject();
+        let o = new TestClass();
         o `setField` 21.42f64;
         getField(o) == 21.42f64
 
     @test
     def testPutInt8Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.int8Field: Int8 \ IO as getField;
         import java_set_field dev.flix.test.TestClass.int8Field: Unit \ IO as setField;
-        let o = newObject();
+        let o = new TestClass();
         o `setField` 42i8;
         getField(o) == 42i8
 
     @test
     def testPutInt16Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.int16Field: Int16 \ IO as getField;
         import java_set_field dev.flix.test.TestClass.int16Field: Unit \ IO as setField;
-        let o = newObject();
+        let o = new TestClass();
         setField(o, 42i16);
         getField(o) == 42i16
 
     @test
     def testPutInt32Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.int32Field: Int32 \ IO as getField;
         import java_set_field dev.flix.test.TestClass.int32Field: Unit \ IO as setField;
-        let o = newObject();
+        let o = new TestClass();
         setField(o, 42i32);
         getField(o) == 42i32
 
     @test
     def testPutInt64Field01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.int64Field: Int64 \ IO as getField;
         import java_set_field dev.flix.test.TestClass.int64Field: Unit \ IO as setField;
-        let o = newObject();
+        let o = new TestClass();
         setField(o, 42i64);
         getField(o) == 42i64
 
     @test
     def testPutStringField01(): Bool \ IO =
-        import java_new dev.flix.test.TestClass(): ##dev.flix.test.TestClass \ IO as newObject;
         import java_get_field dev.flix.test.TestClass.stringField: String \ IO as getField;
         import java_set_field dev.flix.test.TestClass.stringField: Unit \ IO as setField;
-        let o = newObject();
+        let o = new TestClass();
         setField(o, "Goodbye World");
         getField(o) == "Goodbye World"
 
     @test
     def testPutInheritedField01(): Bool \ IO =
-        import java_new dev.flix.test.TestClassWithInheritedMethod(): ##dev.flix.test.TestClassWithInheritedMethod as newObj;
         import java_get_field dev.flix.test.TestClassWithInheritedMethod.m_x: Int32 \ {} as getField;
         import java_set_field dev.flix.test.TestClassWithInheritedMethod.m_x: Unit \ IO as setField;
-        let obj = newObj();
+        let obj = new TestClassWithInheritedMethod();
         setField(obj, 123);
         getField(obj) == 123
 }

--- a/main/test/flix/Test.Exp.Jvm.PutStaticField.flix
+++ b/main/test/flix/Test.Exp.Jvm.PutStaticField.flix
@@ -1,5 +1,7 @@
 mod Test.Exp.Jvm.PutStaticField {
 
+    import dev.flix.test.TestClass
+    import dev.flix.test.TestClassWithInheritedMethod
     @test
     def testPutStaticBoolField01(): Bool \ IO =
         import static java_get_field dev.flix.test.TestClass.BOOL_FIELD: Bool \ IO as getField;

--- a/main/test/flix/Test.Exp.Jvm.TryCatch.flix
+++ b/main/test/flix/Test.Exp.Jvm.TryCatch.flix
@@ -16,9 +16,10 @@
 
 mod Test.Exp.Jvm.TestTryCatch {
 
+    import java.lang.Math
+
     def exception(): Unit \ IO =
-        import static java.lang.Math.floorDiv(Int32, Int32): Int32 \ IO;
-        discard floorDiv(1, 0);
+        discard Math.floorDiv(1, 0);
         ()
 
     @test

--- a/main/test/flix/Test.Exp.UncheckedTypeCast.flix
+++ b/main/test/flix/Test.Exp.UncheckedTypeCast.flix
@@ -20,6 +20,7 @@ mod Test.Exp.UncheckedTypeCast {
     import java.lang.Object
     import java.lang.{String => JString}
     import java.io.Serializable
+    import java.lang.StringBuilder
 
     @test
     def testUncheckedTypeCast01(): Object = unchecked_cast(null as Object)
@@ -36,15 +37,13 @@ mod Test.Exp.UncheckedTypeCast {
     @test
     def testUncheckedTypeCast05(): Serializable = region rc {
         let _ = rc;
-        import java_new java.lang.StringBuilder(): ##java.lang.StringBuilder \ rc as mkSb;
-        unchecked_cast(mkSb() as Serializable)
+        unchecked_cast(unsafe new StringBuilder() as Serializable)
     }
 
     @test
     def testUncheckedTypeCast06(): Object = region rc {
         let _ = rc;
-        import java_new java.lang.StringBuilder(): ##java.lang.StringBuilder \ rc as mkSb;
-        unchecked_cast(mkSb() as Object)
+        unchecked_cast(unsafe new StringBuilder() as Object)
     }
 
 }


### PR DESCRIPTION
#8096