### PR TITLE
chore: update import syntax completely for  `Console.flix`

### DIFF
--- a/main/src/library/Console.flix
+++ b/main/src/library/Console.flix
@@ -59,9 +59,7 @@ mod Console {
     /// See also `System/StdOut.print`.
     ///
     pub def print(x: a): Unit \ IO with ToString[a] =
-        import java.io.Console.writer(): ##java.io.PrintWriter \ IO;
-        import java.io.PrintWriter.print(String): Unit \ IO as printWriterPrint;
-        console() |> Option.forEach(c -> printWriterPrint(writer(c), ToString.toString(x)))
+        console() |> Option.forEach(c -> c.writer().print(ToString.toString(x)))
 
     ///
     /// Converts `x` to a string and prints it to the console followed by a new line.
@@ -75,9 +73,7 @@ mod Console {
     /// See also `System/StdOut.println`.
     ///
     pub def println(x: a): Unit \ IO with ToString[a] =
-        import java.io.Console.writer(): ##java.io.PrintWriter \ IO;
-        import java.io.PrintWriter.println(String): Unit \ IO as printWriterPrintln;
-        console() |> Option.forEach(c -> printWriterPrintln(writer(c), ToString.toString(x)))
+        console() |> Option.forEach(c -> c.writer().println(ToString.toString(x)))
 
     ///
     /// Flushes the console output.


### PR DESCRIPTION
Related to #8096.
The consecutive call seems to be working, probably because thanks to #8168. 