### PR TITLE
feat: parse less names

### DIFF
--- a/main/src/library/Debug.flix
+++ b/main/src/library/Debug.flix
@@ -11,7 +11,7 @@ mod Debug {
     ///
     @Internal
     pub def debugWithPrefix(prefix: String, x: a): a \ IO =
-        (System.out).println("${prefix}%{x}");
+        System.out.println("${prefix}%{x}");
         x
 
     ///

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -106,7 +106,7 @@ pub def coerce(x: t): Coerce.Out[t] with Coerce[t] = Coerce.coerce(x)
 /// Converts `x` to a string and prints it to standard out followed by a new line.
 ///
 pub def println(x: a): Unit \ IO with ToString[a] =
-    (System.out).println(x |> ToString.toString)
+    System.out.println(x |> ToString.toString)
 
 ///
 /// Touches the given region capability `rc`.


### PR DESCRIPTION
`def name(..)` can be given a tail set that will stop the name parsing, this is lower case name by default, making `Upper.lower.lower` parse as `(Upper.lower).lower`