### PR TITLE
refactor: remove SemanticOp.StringOp.Concat and cases instances of it

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/SemanticOp.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SemanticOp.scala
@@ -651,18 +651,4 @@ object SemanticOp {
 
   }
 
-  /**
-    * String Operators.
-    */
-  sealed trait StringOp extends SemanticOp
-
-  object StringOp {
-
-    /**
-      * Concatenate.
-      */
-    case object Concat extends StringOp with BinaryOp
-
-  }
-
 }

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/OpPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/OpPrinter.scala
@@ -112,8 +112,7 @@ object OpPrinter {
          Int16Op.Add |
          Int32Op.Add |
          Int64Op.Add |
-         Int64Op.And |
-         StringOp.Concat => plus
+         Int64Op.And => plus
     case Float32Op.Sub |
          Float64Op.Sub |
          Int8Op.Sub |

--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -901,7 +901,7 @@ object Deriver {
     * Builds a string concatenation expression from the given expressions.
     */
   private def concat(exp1: KindedAst.Expr, exp2: KindedAst.Expr, loc: SourceLocation)(implicit flix: Flix): KindedAst.Expr = {
-    KindedAst.Expr.InvokeMethod2(exp1, Name.Ident("concat", loc), List(exp2), Type.freshVar(Kind.JvmConstructorOrMethod, loc), Type.freshVar(Kind.Star, loc), Type.freshVar(Kind.Eff, loc), loc)
+    KindedAst.Expr.UncheckedMaskingCast(KindedAst.Expr.InvokeMethod2(exp1, Name.Ident("concat", loc), List(exp2), Type.freshVar(Kind.JvmConstructorOrMethod, loc), Type.freshVar(Kind.Star, loc), Type.freshVar(Kind.Eff, loc), loc), loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -901,7 +901,7 @@ object Deriver {
     * Builds a string concatenation expression from the given expressions.
     */
   private def concat(exp1: KindedAst.Expr, exp2: KindedAst.Expr, loc: SourceLocation)(implicit flix: Flix): KindedAst.Expr = {
-    KindedAst.Expr.Binary(SemanticOp.StringOp.Concat, exp1, exp2, Type.freshVar(Kind.Star, loc), loc)
+    KindedAst.Expr.InvokeMethod2(exp1, Name.Ident("concat", loc), List(exp2), Type.freshVar(Kind.JvmConstructorOrMethod, loc), Type.freshVar(Kind.Star, loc), Type.freshVar(Kind.Eff, loc), loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -83,12 +83,6 @@ object Simplifier {
       val es = exps map visitExp
       val purity = simplifyEffect(eff)
       op match {
-        case AtomicOp.Binary(SemanticOp.StringOp.Concat) =>
-          // Translate to InvokeMethod exp
-          val strClass = Class.forName("java.lang.String")
-          val method = strClass.getMethod("concat", strClass)
-          val t = visitType(tpe)
-          SimplifiedAst.Expr.ApplyAtomic(AtomicOp.InvokeMethod(method), es, t, purity, loc)
 
         case AtomicOp.ArrayLit | AtomicOp.ArrayNew =>
           // The region expression is dropped (head of exps / es)

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -204,7 +204,6 @@ object Verifier {
             case SemanticOp.Int64Op.Shl => (MonoType.Int64, MonoType.Int32, MonoType.Int64)
             case SemanticOp.Int64Op.Shr => (MonoType.Int64, MonoType.Int32, MonoType.Int64)
 
-            case SemanticOp.StringOp.Concat => (MonoType.String, MonoType.String, MonoType.String)
           }
           check(expected = argTpe1)(t1, loc)
           check(expected = argTpe2)(t2, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -910,7 +910,7 @@ object Weeder2 {
             val (processed, errors) = Constants.visitChars(lit, loc)
             val cst = Validation.success(Expr.Cst(Ast.Constant.Str(processed), loc)).withSoftFailures(errors)
             mapN(cst) {
-              cst => Expr.Binary(SemanticOp.StringOp.Concat, acc, cst, tree.loc.asSynthetic)
+              cst => Expr.InvokeMethod2(acc, Name.Ident("concat", tree.loc.asSynthetic), List(cst), tree.loc.asSynthetic)
             }
           }
         // An expression part: Apply 'toString' to it and concat the result
@@ -922,7 +922,7 @@ object Weeder2 {
               "Debug.stringify"
             } else "ToString.toString"
             val str = Expr.Apply(Expr.Ambiguous(Name.mkQName(funcName), loc), List(expr), loc)
-            Expr.Binary(SemanticOp.StringOp.Concat, acc, str, loc)
+            Expr.InvokeMethod2(acc, Name.Ident("concat", loc), List(str), loc)
           })
         // Skip anything else (Parser will have produced an error.)
         case (acc, _) => Validation.success(acc)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -532,8 +532,7 @@ object GenExpression {
             compileExpr(exp2)
             mv.visitInsn(LREM)
 
-          case StringOp.Concat =>
-            throw InternalCompilerException(s"Unexpected BinaryOperator StringOp.Concat. It should have been eliminated by Simplifier", loc)
+          
         }
 
       case AtomicOp.Region =>

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -346,15 +346,7 @@ object ConstraintGen {
           val resEff = Type.mkUnion(eff1, eff2, loc)
           (resTpe, resEff)
 
-        case SemanticOp.StringOp.Concat =>
-          val (tpe1, eff1) = visitExp(exp1)
-          val (tpe2, eff2) = visitExp(exp2)
-          c.expectType(expected = Type.Str, actual = tpe1, exp1.loc)
-          c.expectType(expected = Type.Str, actual = tpe2, exp2.loc)
-          c.unifyType(tvar, Type.Str, loc)
-          val resTpe = tvar
-          val resEff = Type.mkUnion(eff1, eff2, loc)
-          (resTpe, resEff)
+        
       }
 
       case Expr.IfThenElse(exp1, exp2, exp3, loc) =>


### PR DESCRIPTION
Removed StringOp and Concat from SemanticOp and removed case instances across multiple fies. 