### PR TITLE
feat: add `Throw` support to `PatMatch`, `PredDeps`, `Redundancy`, `Regions`, `Stratifier`, and `CodeHinter`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -198,7 +198,7 @@ object PatMatch {
         val ruleExps = rules.map(_.exp)
         (exp :: ruleExps).flatMap(visitExp)
 
-      case TypedAst.Expr.Throw(_, _, _, _) => throw new RuntimeException("JOE THROW TBD")
+      case TypedAst.Expr.Throw(exp, _, _, _) => visitExp(exp)
 
       case Expr.TryWith(exp, _, rules, _, _, _) =>
         val ruleExps = rules.map(_.exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -230,7 +230,8 @@ object PredDeps {
         case (acc, CatchRule(_, _, e)) => acc + visitExp(e)
       }
 
-    case Expr.Throw(_, _, _, _) => throw new RuntimeException("JOE THROW TBD")
+    case Expr.Throw(exp, _, _, _) =>
+      visitExp(exp)
 
     case Expr.TryWith(exp, _, rules, _, _, _) =>
       rules.foldLeft(visitExp(exp)) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -636,7 +636,8 @@ object Redundancy {
       }
       usedExp ++ usedRules
 
-    case Expr.Throw(_, _, _, _) => throw new RuntimeException("JOE THROW TBD")
+    case Expr.Throw(exp, _, _, _) =>
+      visitExp(exp, env0, rc)
 
     case Expr.TryWith(exp, effUse, rules, _, _, _) =>
       sctx.effSyms.put(effUse.sym, ())

--- a/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
@@ -194,7 +194,8 @@ object Regions {
       }
       rulesErrors ++ visitExp(exp) ++ checkType(tpe, loc)
 
-    case Expr.Throw(_, _, _, _) => throw new RuntimeException("JOE THROW TBD")
+    case Expr.Throw(exp, tpe, eff, loc) =>
+      visitExp(exp) ++ checkType(tpe, loc)
 
     case Expr.TryWith(exp, _, rules, tpe, _, loc) =>
       val rulesErrors = rules.flatMap {

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -342,7 +342,10 @@ object Stratifier {
         case (e, rs) => Expr.TryCatch(e, rs, tpe, eff, loc)
       }
 
-    case Expr.Throw(_, _, _, _) => throw new RuntimeException("JOE THROW TBD")
+    case Expr.Throw(exp, tpe, eff, loc) =>
+      mapN(visitExp(exp)) {
+        case e => Expr.Throw(e, tpe, eff, loc)
+      }
 
     case Expr.TryWith(exp, sym, rules, tpe, eff, loc) =>
       val rulesVal = traverse(rules) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -318,9 +318,8 @@ object Stratifier {
       Expr.TryCatch(e, rs, tpe, eff, loc)
 
     case Expr.Throw(exp, tpe, eff, loc) =>
-      mapN(visitExp(exp)) {
-        case e => Expr.Throw(e, tpe, eff, loc)
-      }
+      val e = visitExp(exp)
+      Expr.Throw(e, tpe, eff, loc)
 
     case Expr.TryWith(exp, sym, rules, tpe, eff, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -225,7 +225,7 @@ object CodeHinter {
         case CatchRule(_, _, exp) => visitExp(exp)
       }
 
-    case Expr.Throw(_, _, _, _) => throw new RuntimeException("JOE THROW TBD")
+    case Expr.Throw(exp, _, _, _) => visitExp(exp)
 
     case Expr.TryWith(exp, _, rules, _, _, _) =>
       visitExp(exp) ++ rules.flatMap {


### PR DESCRIPTION
#8154 

These are all straightforward modifications. I didn't split them up so as to avoid the PR spamming I've been doing, but I would be happy to split them up if that's preferable