### PR TITLE
fix: fixed `struct` verifier bug

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -249,7 +249,7 @@ object Verifier {
 
         case AtomicOp.StructPut(sym0, _) =>
           ts match {
-            case tpe1 :: Nil =>
+            case tpe1 :: _ :: Nil =>
               checkStructType(tpe1, sym0, loc)
               tpe
             case _ => failMismatchedShape(tpe, "Struct", loc)


### PR DESCRIPTION
struct put has 2 expressions, but I had previously implemented it like it only had one in the verifier. This PR fixes this