### PR TITLE
feat: add struct support to `EffectVerifier` and `Regions`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
@@ -199,9 +199,19 @@ object EffectVerifier {
       visitExp(exp3)
       // TODO region stuff
       ()
-    case Expr.StructNew(sym, fields, region, tpe, eff, loc) => throw new RuntimeException("JOE TBD")
-    case Expr.StructGet(sym, exp, field, tpe, eff, loc) => throw new RuntimeException("JOE TBD")
-    case Expr.StructPut(sym, exp1, field, exp2, tpe, eff, loc) => throw new RuntimeException("JOE TBD")
+    case Expr.StructNew(sym, fields, region, tpe, eff, loc) =>
+      val expected = Type.mkUnion(fields.map {case (k, v) => v.eff} :+ region.eff, loc)
+      val actual = eff
+      expectType(expected, actual, loc)
+      fields.map {case(k, v) => v}.map(visitExp)
+      visitExp(region)
+    case Expr.StructGet(_, e, _, t, _, _) =>
+      // JOE TODO region stuff
+      visitExp(e)
+    case Expr.StructPut(_, e1, _, e2, t, _, _) =>
+      // JOE TODO region stuff
+      visitExp(e1)
+      visitExp(e2)
     case Expr.VectorLit(exps, tpe, eff, loc) =>
       exps.foreach(visitExp)
       val expected = Type.mkUnion(exps.map(_.eff), loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
@@ -152,9 +152,14 @@ object Regions {
     case Expr.ArrayStore(exp1, exp2, exp3, _, loc) =>
       visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
 
-    case Expr.StructNew(sym, fields, region, tpe, eff, loc) => throw new RuntimeException("JOE TBD")
-    case Expr.StructGet(sym, exp, field, tpe, eff, loc) => throw new RuntimeException("JOE TBD")
-    case Expr.StructPut(sym, exp1, field, exp2, tpe, eff, loc) => throw new RuntimeException("JOE TBD")
+    case Expr.StructNew(_, fields, region, tpe, _, loc) =>
+      fields.map{case (k, v) => v}.flatMap(visitExp) ++ visitExp(region) ++ checkType(tpe, loc)
+
+    case Expr.StructGet(_, e, _, tpe, _, loc) =>
+      visitExp(e) ++ checkType(tpe, loc)
+
+    case Expr.StructPut(_, e1, _, e2, tpe, _, loc) =>
+      visitExp(e1) ++ visitExp(e2) ++ checkType(tpe, loc)
 
     case Expr.VectorLit(exps, tpe, _, loc) =>
       exps.flatMap(visitExp) ++ checkType(tpe, loc)


### PR DESCRIPTION
Like arrays, the `EffectVerifier` doesn't yet verify the region effects of struct put/get