### PR TITLE
feat: support for empty interfaces in subtyping

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
@@ -219,8 +219,8 @@ object TypeReduction {
    * Returns a JavaMethodResolutionResult either containing the Java method or a MethodNotFound object.
    */
   private def retrieveMethod(clazz: Class[_], methodName: String, ts: List[Type], isStatic: Boolean = false, loc: SourceLocation)(implicit flix: Flix): JavaMethodResolutionResult = {
-    // NB: this considers also static methods
-    val candidateMethods = clazz.getMethods.filter(m => isCandidateMethod(m, methodName, isStatic, ts))
+    val objectMethods = if (clazz.isInterface && clazz.getInterfaces.isEmpty) classOf[java.lang.Object].getMethods.toList else Nil
+    val candidateMethods = (clazz.getMethods.toList ++ objectMethods).filter(m => isCandidateMethod(m, methodName, isStatic, ts))
 
     candidateMethods.length match {
       case 0 => JavaMethodResolutionResult.MethodNotFound

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
@@ -219,26 +219,7 @@ object TypeReduction {
    * Returns a JavaMethodResolutionResult either containing the Java method or a MethodNotFound object.
    */
   private def retrieveMethod(clazz: Class[_], methodName: String, ts: List[Type], isStatic: Boolean = false, loc: SourceLocation)(implicit flix: Flix): JavaMethodResolutionResult = {
-    def hasSimilarSignature(m1: Method, m2: Method): Boolean =
-      m1.getName.equals(m2.getName) && (m1.getParameterTypes zip m2.getParameterTypes).forall{ case (c1, c2) => c1 == c2 }
-
-    val candidateMethods =
-      if (clazz.isInterface && clazz.getInterfaces.isEmpty) {
-        // We consider Object's methods in addition to clazz's methods
-        val objectMethods = classOf[java.lang.Object].getMethods.toList
-
-        // Build candidate methods list and remove duplicates from object
-        (clazz.getMethods.toList ++ objectMethods).filter(m => isCandidateMethod(m, methodName, isStatic, ts))
-          .foldLeft(List[Method]()) { (acc, method) =>
-            if (!acc.exists(existingMethod => hasSimilarSignature(method, existingMethod))) {
-              acc :+ method
-            } else {
-              acc
-            }
-          }
-      } else {
-        clazz.getMethods.toList.filter(m => isCandidateMethod(m, methodName, isStatic, ts))
-      }
+    val candidateMethods = getAllCandidateMethods(clazz, methodName, isStatic, ts)
 
     candidateMethods.length match {
       case 0 => JavaMethodResolutionResult.MethodNotFound
@@ -258,6 +239,32 @@ object TypeReduction {
           case _ => JavaMethodResolutionResult.AmbiguousMethod(candidateMethods.toList) // 0 corresponds to no exact method, 2 or higher should be impossible in Java
         }
     }
+  }
+
+  /**
+   * Helper method to retrieve all candidate methods from Object's class, including those that may be missing in an interface definition.
+   * E.g., Serializable.java
+   */
+  private def getAllCandidateMethods(clazz: Class[_], methodName: String, isStatic: Boolean, ts: List[Type])(implicit flix: Flix): List[Method] = {
+    def hasSimilarSignature(m1: Method, m2: Method): Boolean =
+      m1.getName.equals(m2.getName) && (m1.getParameterTypes zip m2.getParameterTypes).forall{ case (c1, c2) => c1 == c2 }
+
+    if (clazz.isInterface && clazz.getInterfaces.isEmpty) {
+        // We consider Object's methods in addition to clazz's methods
+        val objectMethods = classOf[java.lang.Object].getMethods.toList
+
+        // Build candidate methods list and remove duplicates from object
+        (clazz.getMethods.toList ++ objectMethods).filter(m => isCandidateMethod(m, methodName, isStatic, ts))
+          .foldLeft(List[Method]()) { (acc, method) =>
+            if (!acc.exists(existingMethod => hasSimilarSignature(method, existingMethod))) {
+              acc :+ method
+            } else {
+              acc
+            }
+          }
+      } else {
+        clazz.getMethods.toList.filter(m => isCandidateMethod(m, methodName, isStatic, ts))
+      }
   }
 
   /**

--- a/main/test/flix/Test.Exp.Jvm.InvokeMethod2.Interfaces.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeMethod2.Interfaces.flix
@@ -1,0 +1,15 @@
+mod Test.Exp.Jvm.InvokeMethod2.Interfaces {
+
+   // Test possible Object's duplicate definitions
+
+   import java.util.{Map => JMap}
+
+   @test
+   def testInvokeMethod2Interfaces_01(): Bool \ IO =
+       let m = Adaptor.toMap(Map#{"a" => "hello"});
+       unsafe JMap.of("a", "hello").equals(m)
+
+   @test
+   def testInvokeMethod2Interfaces_02(): Int32 \ IO =
+       unsafe JMap.of("b", "d").hashCode()
+}


### PR DESCRIPTION
Related to #8212.
@magnus-madsen 
I was forced implictly to check for explicit interfaces with no super-interfaces. As otherwise it would create duplicate methods, e.g., toString, in candidate methods with interfaces that have redefined it.
It could be done in other ways but this is a fast way.