### PR TITLE
chore: remove `StructFieldSym`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -165,10 +165,6 @@ object Symbol {
     new CaseSym(sym, ident.name, ident.loc)
   }
 
-  def mkStructFieldSym(sym: Symbol.StructSym, ident: Ident): StructFieldSym = {
-    new StructFieldSym(sym, ident.name, ident.loc)
-  }
-
   /**
     * Returns the restrictable case symbol for the given name `ident` in the given `enum`.
     */
@@ -549,34 +545,6 @@ object Symbol {
       * The symbol's namespace.
       */
     def namespace: List[String] = enumSym.namespace :+ enumSym.name
-  }
-
-  /**
-   * Struct Field Symbol.
-   */
-  final class StructFieldSym(val structSym: Symbol.StructSym, val name: String, val loc: SourceLocation) extends Symbol {
-    /**
-     * Returns `true` if this symbol is equal to `that` symbol.
-     */
-    override def equals(obj: scala.Any): Boolean = obj match {
-      case that: StructFieldSym => this.structSym == that.structSym && this.name == that.name
-      case _ => false
-    }
-
-    /**
-     * Returns the hash code of this symbol.
-     */
-    override val hashCode: Int = Objects.hash(structSym, name)
-
-    /**
-     * Human readable representation.
-     */
-    override def toString: String = structSym.toString + "." + name
-
-    /**
-     * The symbol's namespace.
-     */
-    def namespace: List[String] = structSym.namespace :+ structSym.name
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3742,7 +3742,6 @@ object Resolver {
     case sym: Symbol.StructSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
     case sym: Symbol.RestrictableEnumSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
     case sym: Symbol.CaseSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
-    case sym: Symbol.StructFieldSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
     case sym: Symbol.RestrictableCaseSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
     case sym: Symbol.TraitSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)
     case sym: Symbol.SigSym => root.symbols(Name.mkUnlocatedNName(sym.namespace))(sym.name)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -97,7 +97,6 @@ object Typer {
         case sym: Symbol.ModuleSym => new Symbol.ModuleSym(sym.ns.init)
 
         case sym: Symbol.CaseSym => throw InternalCompilerException(s"unexpected symbol: $sym", sym.loc)
-        case sym: Symbol.StructFieldSym => throw InternalCompilerException(s"unexpected symbol: $sym", sym.loc)
         case sym: Symbol.RestrictableCaseSym => throw InternalCompilerException(s"unexpected symbol: $sym", sym.loc)
         case sym: Symbol.VarSym => throw InternalCompilerException(s"unexpected symbol: $sym", sym.loc)
         case sym: Symbol.KindedTypeVarSym => throw InternalCompilerException(s"unexpected symbol: $sym", sym.loc)


### PR DESCRIPTION
`StructFieldSym` isn't used anywhere, so it should be deleted.