### PR TITLE
chore: remove `structs` map from SimplifiedAst

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
@@ -23,10 +23,9 @@ import ca.uwaterloo.flix.language.phase.ClosureConv
 
 object SimplifiedAst {
 
-  val empty: Root = Root(Map.empty, Map.empty, Map.empty, None, Set.empty, Map.empty)
+  val empty: Root = Root(Map.empty, Map.empty, None, Set.empty, Map.empty)
 
   case class Root(defs: Map[Symbol.DefnSym, Def],
-                  structs: Map[Symbol.StructSym, Struct],
                   effects: Map[Symbol.EffectSym, Effect],
                   entryPoint: Option[Symbol.DefnSym],
                   reachable: Set[Symbol.DefnSym],

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -35,9 +35,8 @@ object Simplifier {
     implicit val r = root
     val defs = ParOps.parMapValues(root.defs)(visitDef)
     val effects = ParOps.parMapValues(root.effects)(visitEffect)
-    val structs = ParOps.parMapValues(root.structs)(visitStruct)
 
-    SimplifiedAst.Root(defs, structs, effects, root.entryPoint, root.reachable, root.sources)
+    SimplifiedAst.Root(defs, effects, root.entryPoint, root.reachable, root.sources)
   }
 
   private def visitDef(decl: MonoAst.Def)(implicit universe: Set[Symbol.EffectSym], root: MonoAst.Root, flix: Flix): SimplifiedAst.Def = decl match {
@@ -55,19 +54,6 @@ object Simplifier {
       val ops = ops0.map(visitEffOp)
       SimplifiedAst.Effect(ann, mod, sym, ops, loc)
   }
-
-  private def visitStruct(s: MonoAst.Struct): SimplifiedAst.Struct = s match {
-    case MonoAst.Struct(doc, ann, mod, sym, _, fields0, loc) =>
-      val fieldIndices = fields0.map(_.name).zipWithIndex.toMap
-      val fields = fields0.map(visitStructField(fieldIndices))
-      SimplifiedAst.Struct(doc, ann, mod, sym, fields, loc)
-  }
-
-  private def visitStructField(fieldIndices: Map[Name.Label, Int])(field: MonoAst.StructField): SimplifiedAst.StructField = field match {
-    case MonoAst.StructField(name, tpe, loc) =>
-      SimplifiedAst.StructField(name, fieldIndices(name), tpe, loc)
-  }
-
 
   private def visitExp(exp0: MonoAst.Expr)(implicit universe: Set[Symbol.EffectSym], root: MonoAst.Root, flix: Flix): SimplifiedAst.Expr = exp0 match {
     case MonoAst.Expr.Var(sym, tpe, loc) =>


### PR DESCRIPTION
We never use this map, so it should be removed