### PR TITLE
chore: enable struct related tests

### DIFF
--- a/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestInstances.scala
@@ -101,8 +101,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
     expectError[InstanceError.OverlappingInstances](result)
   }
 
-  // JOE STRUCTS TODO: Reenable when kinder is ready
-  ignore("Test.OverlappingInstance.06") {
+  test("Test.OverlappingInstance.06") {
     val input =
       """
         |struct S[a, r] {
@@ -156,8 +155,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
     expectError[InstanceError.ComplexInstance](result)
   }
 
-  // JOE STRUCTS TODO: Reenable when kinder is ready
-  ignore("Test.ComplexInstanceType.04") {
+  test("Test.ComplexInstanceType.04") {
     val input =
       """
         |struct Box[a, r] {
@@ -220,8 +218,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
     expectError[InstanceError.ComplexInstance](result)
   }
 
-  // JOE STRUCTS TODO: Enable when kinder is ready
-  ignore("Test.ComplexInstanceType.09") {
+  test("Test.ComplexInstanceType.09") {
     val input =
       """
         |struct Box[a, r] {
@@ -273,8 +270,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
     expectError[InstanceError.DuplicateTypeVar](result)
   }
 
-  // JOE STRUCTS TODO: Enable when kinder is ready
-  ignore("Test.DuplicateTypeParameter.04") {
+  test("Test.DuplicateTypeParameter.04") {
     val input =
       """
         |struct DoubleBox[a, b, r] {
@@ -440,8 +436,7 @@ class TestInstances extends AnyFunSuite with TestUtils {
 
   }
 
-  // JOE STRUCTS TODO: Enable when kinder is done
-  ignore("Test.MismatchedSignatures.08") {
+  test("Test.MismatchedSignatures.08") {
     val input =
       """
         |trait C[a] {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestKinder.scala
@@ -67,7 +67,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError](result)
   }
 
-  ignore("MismatchedTypeParamKind.Implicit.07") {
+  test("MismatchedTypeParamKind.Implicit.07") {
     val input =
       """
         |struct E[a, r] {
@@ -149,7 +149,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError](result)
   }
 
-  ignore("MismatchedTypeParamKind.Struct.01") {
+  test("MismatchedTypeParamKind.Struct.01") {
     val input =
       """
         |struct S[o, r] {
@@ -160,7 +160,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError](result)
   }
 
-  ignore("MismatchedTypeParamKind.Struct.02") {
+  test("MismatchedTypeParamKind.Struct.02") {
     val input =
       """
         |struct S[e, r] {
@@ -171,7 +171,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError](result)
   }
 
-  ignore("MismatchedTypeParamKind.Struct.03") {
+  test("MismatchedTypeParamKind.Struct.03") {
     val input =
       """
         |struct S[a, r] {
@@ -182,7 +182,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError](result)
   }
 
-  ignore("MismatchedTypeParamKind.Struct.04") {
+  test("MismatchedTypeParamKind.Struct.04") {
     val input =
       """
         |struct S[a, r] {
@@ -193,7 +193,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError](result)
   }
 
-  ignore("MismatchedTypeParamKind.Struct.05") {
+  test("MismatchedTypeParamKind.Struct.05") {
     val input =
       """
         |struct S[e, r] {
@@ -204,7 +204,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError](result)
   }
 
-  ignore("MismatchedTypeParamKind.Struct.06") {
+  test("MismatchedTypeParamKind.Struct.06") {
     val input =
       """
         |struct D[a, r] {
@@ -218,7 +218,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError](result)
   }
 
-  ignore("MismatchedTypeParamKind.Struct.07") {
+  test("MismatchedTypeParamKind.Struct.07") {
     val input =
       """
         |struct D[r] {
@@ -293,7 +293,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError](result)
   }
 
-  ignore("MismatchedTypeParamKind.TypeAlias.07") {
+  test("MismatchedTypeParamKind.TypeAlias.07") {
     val input =
       """
         |struct S[a, r] {
@@ -977,7 +977,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
-  ignore("KindError.Struct.Case.01") {
+  test("KindError.Struct.WrongKind.01") {
     val input =
       """
         |struct S [r] {
@@ -988,7 +988,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
-  ignore("KindError.Struct.Case.02") {
+  test("KindError.Struct.WrongKind.02") {
     val input =
       """
         |struct F[a, r]
@@ -1001,12 +1001,11 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
-  ignore("KindError.Struct.Case.04") {
-    // When some kinds are specified and some aren't, the nonspecified ones
-    // default to kind Type, which is illegal for `r` in this case
+  test("KindError.Struct.WrongKind.04") {
+
     val input =
       """
-        |struct S[a: Type -> Type, r] {
+        |struct S[a: Type, r: Type] {
         |    c: a
         |}
         |""".stripMargin
@@ -1014,7 +1013,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.MismatchedKinds](result)
   }
 
-  ignore("KindError.Struct.Case.05") {
+  test("KindError.Struct.WrongKind.05") {
     val input =
       """
         |struct S[a, r] {
@@ -1025,7 +1024,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
-  ignore("KindError.Struct.Type.01") {
+  test("KindError.Struct.Type.01") {
     val input =
       """
         |struct S [r] {
@@ -1036,7 +1035,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
-  ignore("KindError.Struct.Type.02") {
+  test("KindError.Struct.Type.02") {
     val input =
       """
         |struct S[a, r] {
@@ -1047,7 +1046,7 @@ class TestKinder extends AnyFunSuite with TestUtils {
     expectError[KindError.UnexpectedKind](result)
   }
 
-  ignore("KindError.Struct.Type.05") {
+  test("KindError.Struct.Type.05") {
     val input =
       """
         |struct S[r]{

--- a/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestNamer.scala
@@ -599,7 +599,7 @@ class TestNamer extends AnyFunSuite with TestUtils {
     expectError[NameError.DuplicateUpperName](result)
   }
 
-  ignore("DuplicateUpperName.28") {
+  test("DuplicateUpperName.28") {
     val input =
       """
         |struct S[r] {}

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -1093,8 +1093,7 @@ class TestParserHappy extends AnyFunSuite with TestUtils {
     expectError[ParseError](result)
   }
 
-  // JOE TODO: Reenable
-  ignore("StructNoTParams.01") {
+  test("StructNoTParams.01") {
     val input =
       """
         |struct S { }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -824,8 +824,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     expectError[RedundancyError.ShadowingName](result)
   }
 
-  // JOE TODO: When ready enable this test
-  ignore("ShadowedName.Use.21") {
+  test("ShadowedName.Use.21") {
     val input =
       s"""
          |def foo(): Bool =
@@ -848,8 +847,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     expectError[RedundancyError.ShadowingName](result)
   }
 
-  // JOE TODO: When ready enable this test
-  ignore("UnusedStructSym.01") {
+  test("UnusedStructSym.01") {
     val input =
       s"""
          |mod N {
@@ -862,8 +860,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     expectError[RedundancyError.UnusedStructSym](result)
   }
 
-  // JOE TODO: When ready enable this test
-  ignore("UnusedStructSym.02") {
+  test("UnusedStructSym.02") {
     val input =
       s"""
          |mod N {
@@ -957,8 +954,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     expectError[RedundancyError.UnusedEnumTag](result)
   }
 
-  // JOE TODO: When ready enable this test
-  ignore("PrefixedStructSym.01") {
+  test("PrefixedStructSym.01") {
     val input =
       s"""
          |mod N {
@@ -1138,8 +1134,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     expectError[RedundancyError.UnusedTypeParam](result)
   }
 
-  // JOE TODO: When ready enable this test
-  ignore("UnusedTypeParam.Struct.01") {
+  test("UnusedTypeParam.Struct.01") {
     val input =
       s"""
          |struct Box[a, r] { }
@@ -1149,8 +1144,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     expectError[RedundancyError.UnusedTypeParam](result)
   }
 
-  // JOE TODO: When ready enable this test
-  ignore("UnusedTypeParam.Struct.02") {
+  test("UnusedTypeParam.Struct.02") {
     val input =
       s"""
          |struct Box[a, b, r] {
@@ -1162,8 +1156,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     expectError[RedundancyError.UnusedTypeParam](result)
   }
 
-  // JOE TODO: When ready enable this test
-  ignore("UnusedTypeParam.Struct.03") {
+  test("UnusedTypeParam.Struct.03") {
     val input =
       s"""
          |struct Box[a, b, r] {
@@ -1175,8 +1168,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     expectError[RedundancyError.UnusedTypeParam](result)
   }
 
-  // JOE TODO: When ready enable this test
-  ignore("UnusedTypeParam.Struct.04") {
+  test("UnusedTypeParam.Struct.04") {
     val input =
       s"""
          |struct Box[a, b, c, r] {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -123,7 +123,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
 
   // this test is temporarily ignored because it recovers and proceeds
   // to fail in future unimplemented phases
-  ignore("InaccessibleStruct.03") {
+  test("InaccessibleStruct.03") {
     val input =
       s"""
          |mod A{
@@ -181,7 +181,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.InaccessibleEnum](result)
   }
 
-  ignore("InaccessibleType.03") {
+  test("InaccessibleType.03") {
     val input =
       s"""
          |mod A {
@@ -410,7 +410,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.CyclicTypeAliases](result)
   }
 
-  ignore("CyclicTypeAliases.06") {
+  test("CyclicTypeAliases.06") {
     val input =
       s"""
          |struct S[t, r] {
@@ -1661,7 +1661,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
   // This test is temporarily disabled because the creation of S1 is valid
   // and thus the compiler attempts to continue to compile this program and
   // fails in future unimplemented phases.
-  ignore("ResolutionError.UndefinedStruct.03") {
+  test("ResolutionError.UndefinedStruct.03") {
     val input =
       """
         |mod M {
@@ -1681,7 +1681,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
 
   // A bug was introduced into the kinder when it was refactored, so this test fails, but
   // will reenable it once my next struct kinder support pr is merged
-  ignore("ResoutionError.MissingStructField.01") {
+  test("ResoutionError.MissingStructField.01") {
     val input =
       """
         |mod S {
@@ -1806,6 +1806,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     val result = compile(input, Options.TestWithLibNix)
     expectError[ResolutionError.ExtraStructField](result)
   }
+
   test("ResolutionError.StructFieldIncorrectOrder.01") {
     val input = """
                   |struct S[r] {a: Int32, b: Int32}

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -516,8 +516,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
     expectError[SafetyError.ImpossibleUncheckedCast](result)
   }
 
-  // JOE TODO: Reenable these when ready
-  ignore("ImpossibleCast.10") {
+  test("ImpossibleCast.10") {
     val input =
       """
         |struct A[r] {
@@ -529,7 +528,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
     expectError[SafetyError.ImpossibleUncheckedCast](result)
   }
 
-  ignore("ImpossibleCast.11") {
+  test("ImpossibleCast.11") {
     val input =
       """
         |struct A[r] {
@@ -541,7 +540,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
     expectError[SafetyError.ImpossibleUncheckedCast](result)
   }
 
-  ignore("ImpossibleCast.12") {
+  test("ImpossibleCast.12") {
     val input =
       """
         |struct A[r] {
@@ -930,8 +929,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
     expectError[SafetyError.IllegalExportPolymorphism](result)
   }
 
-
-  ignore("IllegalExportFunction.08") {
+  test("IllegalExportFunction.08") {
     val input =
       """
         |struct S[t, r] {
@@ -943,7 +941,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
     expectError[SafetyError.IllegalExportPolymorphism](result)
   }
 
-  ignore("IllegalExportFunction.09") {
+  test("IllegalExportFunction.09") {
     val input =
       """
         |struct S[t, r] {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestTyper.scala
@@ -1491,8 +1491,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError.AmbiguousMethod](result)
   }
 
-  // JOE TBD: Reenable when structs are completed
-  ignore("TypeError.NewStruct.01") {
+  test("TypeError.NewStruct.01") {
     val input =
       """
         |struct S [v, r] {
@@ -1512,7 +1511,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError](result)
   }
 
-  ignore("TypeError.NewStruct.02") {
+  test("TypeError.NewStruct.02") {
     val input =
       """
         |struct S [v, r] {
@@ -1532,7 +1531,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError](result)
   }
 
-  ignore("TypeError.NewStruct.03") {
+  test("TypeError.NewStruct.03") {
     val input =
       """
         |struct S [v, r] {
@@ -1552,7 +1551,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError](result)
   }
 
-  ignore("TypeError.StructGet.01") {
+  test("TypeError.StructGet.01") {
     val input =
       """
         |mod S {
@@ -1575,7 +1574,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError](result)
   }
 
-  ignore("TypeError.StructGet.02") {
+  test("TypeError.StructGet.02") {
     val input =
       """
         |mod S {
@@ -1597,7 +1596,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError](result)
   }
 
-  ignore("TypeError.StructPut.01") {
+  test("TypeError.StructPut.01") {
     val input =
       """
         |mod S {
@@ -1620,7 +1619,7 @@ class TestTyper extends AnyFunSuite with TestUtils {
     expectError[TypeError](result)
   }
 
-  ignore("TypeError.StructPut.02") {
+  test("TypeError.StructPut.02") {
     val input =
       """
         |mod S {

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -137,7 +137,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.DuplicateTag](result)
   }
 
-  ignore("DuplicateStructField.01") {
+  test("DuplicateStructField.01") {
     val input =
       """struct Person[r] {
          name: String,
@@ -148,7 +148,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.DuplicateStructField](result)
   }
 
-  ignore("DuplicateStructField.02") {
+  test("DuplicateStructField.02") {
     val input =
       """struct Person[r] {
          name: String,
@@ -160,7 +160,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.DuplicateStructField](result)
   }
 
-  ignore("DuplicateStructField.03") {
+  test("DuplicateStructField.03") {
     val input =
       """struct Person[r] {
          name: String,
@@ -173,7 +173,7 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.DuplicateStructField](result)
   }
 
-  ignore("DuplicateStructField.04") {
+  test("DuplicateStructField.04") {
     val input =
       """struct Person[r] {
          name: String,


### PR DESCRIPTION
Now that initial struct support is complete, enable tests that were previously ignored

Tests in the form of flix files will come in a different PR