### PR TITLE
fix: `StructGet` and `StructPut` backend type fixes

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -106,8 +106,8 @@ object Eraser {
         case AtomicOp.ArrayStore => ApplyAtomic(op, es, t, purity, loc)
         case AtomicOp.ArrayLength => ApplyAtomic(op, es, t, purity, loc)
         case AtomicOp.StructNew(_, _) => ApplyAtomic(op, es, t, purity, loc)
-        case AtomicOp.StructGet(_, _, _) => ApplyAtomic(op, es, t, purity, loc)
-        case AtomicOp.StructPut(_, _, _) => ApplyAtomic(op, es, t, purity, loc)
+        case AtomicOp.StructGet(_, _, _) => castExp(ApplyAtomic(op, es, erase(tpe), purity, loc), t, purity, loc)
+        case AtomicOp.StructPut(_, _, _) => ApplyAtomic(op, es, erase(tpe), purity, loc)
         case AtomicOp.Ref => ApplyAtomic(op, es, t, purity, loc)
         case AtomicOp.Deref =>
           castExp(ApplyAtomic(op, es, erase(tpe), purity, loc), t, purity, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -107,7 +107,7 @@ object Eraser {
         case AtomicOp.ArrayLength => ApplyAtomic(op, es, t, purity, loc)
         case AtomicOp.StructNew(_, _) => ApplyAtomic(op, es, t, purity, loc)
         case AtomicOp.StructGet(_, _, _) => castExp(ApplyAtomic(op, es, erase(tpe), purity, loc), t, purity, loc)
-        case AtomicOp.StructPut(_, _, _) => ApplyAtomic(op, es, erase(tpe), purity, loc)
+        case AtomicOp.StructPut(_, _, _) => ApplyAtomic(op, es, t, purity, loc)
         case AtomicOp.Ref => ApplyAtomic(op, es, t, purity, loc)
         case AtomicOp.Deref =>
           castExp(ApplyAtomic(op, es, erase(tpe), purity, loc), t, purity, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -580,7 +580,6 @@ object GenExpression {
 
       case AtomicOp.Index(idx) =>
         val List(exp) = exps
-
         val MonoType.Tuple(elmTypes) = exp.tpe
         val tupleType = BackendObjType.Tuple(elmTypes.map(BackendType.asErasedBackendType))
         // evaluating the `base`
@@ -790,8 +789,8 @@ object GenExpression {
         compileExpr(region)
         BytecodeInstructions.xPop(BackendType.toErasedBackendType(region.tpe))(new BytecodeInstructions.F(mv))
         // We get the JvmType of the class for the struct
-        val elmTypes = fieldExps.map(_.tpe)
-        val structType = BackendObjType.Struct(elmTypes.map(BackendType.toErasedBackendType))
+        val MonoType.Struct(_, elmTypes, _) = tpe
+        val structType = BackendObjType.Struct(elmTypes.map(BackendType.asErasedBackendType))
         val internalClassName = structType.jvmName.toInternalName
         // Instantiating a new object of struct
         mv.visitTypeInsn(NEW, internalClassName)
@@ -807,11 +806,11 @@ object GenExpression {
       case AtomicOp.StructGet(_, idx, _) =>
         val List(exp) = exps
         val MonoType.Struct(_, elmTypes, _) = exp.tpe
-        val structType = BackendObjType.Struct(elmTypes.map(BackendType.toErasedBackendType))
+        val structType = BackendObjType.Struct(elmTypes.map(BackendType.asErasedBackendType))
         // evaluating the `base`
         compileExpr(exp)
         // Retrieving the field `field${offset}`
-        mv.visitFieldInsn(GETFIELD, structType.jvmName.toInternalName, s"field$idx", JvmOps.getErasedJvmType(tpe).toDescriptor)
+        mv.visitFieldInsn(GETFIELD, structType.jvmName.toInternalName, s"field$idx", JvmOps.asErasedJvmType(tpe).toDescriptor)
 
       case AtomicOp.StructPut(_, idx, _) =>
         val List(exp1, exp2) = exps

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -815,13 +815,13 @@ object GenExpression {
       case AtomicOp.StructPut(_, idx, _) =>
         val List(exp1, exp2) = exps
         val MonoType.Struct(_, elmTypes, _) = exp1.tpe
-        val structType = BackendObjType.Struct(elmTypes.map(BackendType.toErasedBackendType))
+        val structType = BackendObjType.Struct(elmTypes.map(BackendType.asErasedBackendType))
         // evaluating the `base`
         compileExpr(exp1)
         // evaluating the `rhs`
         compileExpr(exp2)
         // set the field `field${offset}`
-        mv.visitFieldInsn(PUTFIELD, structType.jvmName.toInternalName, s"field$idx", JvmOps.getErasedJvmType(exp2.tpe).toDescriptor)
+        mv.visitFieldInsn(PUTFIELD, structType.jvmName.toInternalName, s"field$idx", JvmOps.asErasedJvmType(exp2.tpe).toDescriptor)
         // Since the return type is unit, we put an instance of unit on top of the stack
         mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -815,7 +815,7 @@ object GenExpression {
       case AtomicOp.StructPut(_, idx, _) =>
         val List(exp1, exp2) = exps
         val MonoType.Struct(_, elmTypes, _) = exp1.tpe
-        val structType = BackendObjType.Struct(elmTypes.map(BackendType.toErasedBackendType))
+        val structType = BackendObjType.Struct(elmTypes.map(BackendType.asErasedBackendType))
         // evaluating the `base`
         compileExpr(exp1)
         // evaluating the `rhs`

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -815,7 +815,7 @@ object GenExpression {
       case AtomicOp.StructPut(_, idx, _) =>
         val List(exp1, exp2) = exps
         val MonoType.Struct(_, elmTypes, _) = exp1.tpe
-        val structType = BackendObjType.Struct(elmTypes.map(BackendType.asErasedBackendType))
+        val structType = BackendObjType.Struct(elmTypes.map(BackendType.toErasedBackendType))
         // evaluating the `base`
         compileExpr(exp1)
         // evaluating the `rhs`

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -821,7 +821,7 @@ object GenExpression {
         // evaluating the `rhs`
         compileExpr(exp2)
         // set the field `field${offset}`
-        mv.visitFieldInsn(PUTFIELD, structType.jvmName.toInternalName, s"field$idx", JvmOps.asErasedJvmType(exp2.tpe).toDescriptor)
+        mv.visitFieldInsn(PUTFIELD, structType.jvmName.toInternalName, s"field$idx", JvmOps.getErasedJvmType(exp2.tpe).toDescriptor)
         // Since the return type is unit, we put an instance of unit on top of the stack
         mv.visitFieldInsn(GETSTATIC, BackendObjType.Unit.jvmName.toInternalName, BackendObjType.Unit.SingletonField.name, BackendObjType.Unit.jvmName.toDescriptor)
 


### PR DESCRIPTION
Currently, if we have

`struct.field.field`, the initial `struct.field` gets erased to `Object` and then the JVM complains. This fixes this.

Also, in general it changes the `struct` backend to resemble `Tuple` more.