### PR TITLE
fix: Handle infinitely recursive struct types with some premature erasure

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -280,7 +280,7 @@ object Simplifier {
             // We must do this here because the `MonoTypes` requires the individual types of each element
             // but the `Type` type only carries around the type arguments. i.e. for `struct S[v, r] {a: List[v]}`
             // at this point we would know `v` but we would need the type of `a`. We also erase to avoid infinitely
-            // expanding infinite types
+            // expanding recursive types
             val struct = root.structs(sym)
             val subst = Substitution(struct.tparams.zip(tpe.typeArguments).toMap)
             val substitutedStructFieldTypes = struct.fields.map { f =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -286,18 +286,6 @@ object Simplifier {
             val substitutedStructFieldTypes = struct.fields.map { f =>
               subst(f.tpe).typeConstructor match {
                 case Some(value) => value match {
-                  case TypeConstructor.AnyType | TypeConstructor.Unit | TypeConstructor.Null | TypeConstructor.BigDecimal |
-                       TypeConstructor.BigInt | TypeConstructor.Str | TypeConstructor.Regex | TypeConstructor.Arrow(_) |
-                       TypeConstructor.RecordRowEmpty | TypeConstructor.RecordRowExtend(_) | TypeConstructor.Record | TypeConstructor.SchemaRowEmpty |
-                       TypeConstructor.SchemaRowExtend(_) | TypeConstructor.Schema | TypeConstructor.Sender | TypeConstructor.Receiver |
-                       TypeConstructor.Lazy | TypeConstructor.Enum(_, _) | TypeConstructor.Struct(_, _) | TypeConstructor.RestrictableEnum(_, _)  |
-                       TypeConstructor.Native(_) | TypeConstructor.JvmConstructor(_) | TypeConstructor.JvmMethod(_) | TypeConstructor.MethodReturnType |
-                       TypeConstructor.Array | TypeConstructor.Vector | TypeConstructor.Ref | TypeConstructor.Tuple(_) | TypeConstructor.Relation | TypeConstructor.Lattice |
-                       TypeConstructor.True | TypeConstructor.False | TypeConstructor.Not | TypeConstructor.And | TypeConstructor.Or | TypeConstructor.Pure |
-                       TypeConstructor.Univ | TypeConstructor.Complement | TypeConstructor.Union | TypeConstructor.Intersection | TypeConstructor.Effect(_) |
-                       TypeConstructor.CaseComplement(_) | TypeConstructor.CaseUnion(_) | TypeConstructor.CaseIntersection(_) | TypeConstructor.CaseSet(_, _) |
-                       TypeConstructor.RegionToStar | TypeConstructor.Error(_, _) | TypeConstructor.Void =>
-                    MonoType.Object
                   case TypeConstructor.Bool => MonoType.Bool
                   case TypeConstructor.Char => MonoType.Char
                   case TypeConstructor.Float32 => MonoType.Float32
@@ -306,6 +294,7 @@ object Simplifier {
                   case TypeConstructor.Int16 => MonoType.Int16
                   case TypeConstructor.Int32 => MonoType.Int32
                   case TypeConstructor.Int64 => MonoType.Int64
+                  case _ => MonoType.Object
                 }
                 case None => throw InternalCompilerException(s"Unexpected type: $tpe", tpe.loc)
               }


### PR DESCRIPTION
This is not the prettiest change. The problem is that the work of the `Monomorpher`, `Eraser`, and `Simplifier` must all be done at once.
- `Monomorpher` because we must determine the individual type of each field
- `Eraser` because we cannot infinitely expand types and therefore must erase at the same time
- `Simplifier` because this is all done during generation of `MonoType`

Though this duplicates work and isn't pretty, I don't think it leads to correctness issues, as it is just doing stuff that is done in earlier / later phases