### PR TITLE
docs: fix lists and code in doc comments

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
@@ -32,8 +32,8 @@ object ShowAstProvider {
   /**
     * Returns a JSON object with
     *
-    * - `title` (a string like `Namer.flix.ir`)
-    * - `text` (a string with the ir representation).
+    *   - `title` (a string like `Namer.flix.ir`)
+    *   - `text` (a string with the ir representation).
     */
   def showAst()(implicit flix: Flix): JObject = {
     val oldOpts = flix.options

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/VarCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/VarCompleter.scala
@@ -27,9 +27,7 @@ object VarCompleter extends Completer {
     * Returns a List of Completion for var.
     */
   override def getCompletions(context: CompletionContext)(implicit flix: Flix, index: Index, root: TypedAst.Root): Iterable[VarCompletion] = {
-    ///
-    /// Find all local variables in the current uri with a given range.
-    ///
+    // Find all local variables in the current uri with a given range.
     index.queryWithRange(context.uri, queryLine = context.range.start.line, beforeLine = 20, afterLine = 10).collect {
       case Entity.LocalVar(sym, tpe) => Completion.VarCompletion(sym, tpe)
       case Entity.FormalParam(fparam) => Completion.VarCompletion(fparam.sym, fparam.tpe)

--- a/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoType.scala
@@ -24,9 +24,9 @@ sealed trait MonoType
 
 object MonoType {
 
-  ///
-  /// Primitive Types.
-  ///
+  //
+  // Primitive Types.
+  //
 
   /**
     * Represents an uninhabited type, not an absent value like in Java.
@@ -65,9 +65,9 @@ object MonoType {
 
   case object Null extends MonoType
 
-  ///
-  /// Compound Types.
-  ///
+  //
+  // Compound Types.
+  //
 
   case class Array(tpe: MonoType) extends MonoType
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Purity.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Purity.scala
@@ -23,9 +23,9 @@ sealed trait Purity
 /**
   * Represents the purity of an expression.
   *
-  * - Pure expressions are treated as mathematical functions.
-  * - Impure expressions can use mutation or interact with the system.
-  * - Control-Impure expressions can do all the above but also use unhandled
+  *   - Pure expressions are treated as mathematical functions.
+  *   - Impure expressions can use mutation or interact with the system.
+  *   - Control-Impure expressions can do all the above but also use unhandled
   *   algebraic effects.
   *
   * In terms of the set of expressions that is allowed under each effect the

--- a/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
@@ -27,8 +27,8 @@ import ca.uwaterloo.flix.language.ast.shared.Source
  * more children. Each child is either a [[Child.TokenChild]] or a [[Child.TreeChild]].
  *
  * Note that [[SyntaxTree]] offers few guarantees. In particular:
- *     - There is no guarantee that a specific node is present or absent as a child.
- *     - There is no guarantee that a specific node has a specific number of children.
+ *   - There is no guarantee that a specific node is present or absent as a child.
+ *   - There is no guarantee that a specific node has a specific number of children.
  */
 object SyntaxTree {
 

--- a/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
@@ -120,7 +120,7 @@ object SyntaxTree {
     case object TypeParameterList extends TreeKind
 
     //////////////////////////////////////////////////////////////////////////////////////////
-    /// DECLARATIONS                                                                        //
+    // DECLARATIONS                                                                         //
     //////////////////////////////////////////////////////////////////////////////////////////
     sealed trait Decl extends TreeKind
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -272,9 +272,9 @@ object TypeConstructor {
    *
    * A few examples:
    *
-   * - The type: `Apply(InvokeMethod("length", 0), String)` is equivalent to `Int32`.
-   * - The type: `Apply(Apply(InvokeMethod("startsWith", 1), String), String)` is equivalent to `Bool`.
-   * - The type: `Apply(Apply(Apply(InvokeMethod("substring", 2), String), Int32), Int32)` is equivalent to `String`.
+   *   - The type: `Apply(InvokeMethod("length", 0), String)` is equivalent to `Int32`.
+   *   - The type: `Apply(Apply(InvokeMethod("startsWith", 1), String), String)` is equivalent to `Bool`.
+   *   - The type: `Apply(Apply(Apply(InvokeMethod("substring", 2), String), Int32), Int32)` is equivalent to `String`.
    *
    * The type constructor requires a java method or constructor type constructor.
    */

--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -382,7 +382,7 @@ object Deriver {
 
   /**
     * Creates a comparison match rule, comparing the elements of two tags of the same type.
-    * ```case (C2(x0, x1), C2(y0, y1)) => compare(x0, y0) `thenCompare` lazy(x1, y1)```
+    * {{{ case (C2(x0, x1), C2(y0, y1)) => compare(x0, y0) thenCompare lazy(x1, y1) }}}
     */
   private def mkComparePairMatchRule(caze: KindedAst.Case, loc: SourceLocation, root: KindedAst.Root)(implicit flix: Flix): KindedAst.MatchRule = caze match {
     case KindedAst.Case(sym, tpe, _, _) =>
@@ -430,7 +430,7 @@ object Deriver {
       }
 
       // Put it all together
-      // ```compare(x0, y0) `thenCompare` lazy compare(x1, y1)```
+      // compare(x0, y0) `thenCompare` lazy compare(x1, y1)
       val exp = compares match {
         // Case 1: no variables to compare; just return true
         case Nil => KindedAst.Expr.Tag(Ast.CaseSymUse(equalToSym, loc), KindedAst.Expr.Cst(Ast.Constant.Unit, loc), Type.freshVar(Kind.Star, loc), loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Eraser.scala
@@ -14,21 +14,21 @@ import ca.uwaterloo.flix.util.ParOps
   * This means that expressions should cast their output but assume correct
   * input types.
   *
-  * - Ref
-  *   - component type erasure
-  *   - deref casting
-  * - Tuple
-  *   - component type erasure
-  *   - index casting
-  * - Record
-  *   - component type erasure
-  *   - select casting
-  * - Lazy
-  *   - component type erasure
-  *   - force casting
-  * - Function
-  *   - result type boxing, this includes return types of defs and their applications
-  *   - function call return value casting
+  *   - Ref
+  *     - component type erasure
+  *     - deref casting
+  *   - Tuple
+  *     - component type erasure
+  *     - index casting
+  *   - Record
+  *     - component type erasure
+  *     - select casting
+  *   - Lazy
+  *     - component type erasure
+  *     - force casting
+  *   - Function
+  *     - result type boxing, this includes return types of defs and their applications
+  *     - function call return value casting
   */
 object Eraser {
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -1242,7 +1242,7 @@ object Kinder {
   /**
     * Performs kinding on the given type under the given kind environment, with `expectedKind` expected from context.
     * This is roughly analogous to the reassembly of expressions under a type environment, except that:
-    * - Kind errors may be discovered here as they may not have been found during inference (or inference may not have happened at all).
+    *   - Kind errors may be discovered here as they may not have been found during inference (or inference may not have happened at all).
     */
   private def visitType(tpe0: UnkindedType, expectedKind: Kind, kenv: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[Type, KindError] = tpe0 match {
     case tvar: UnkindedType.Var => visitTypeVar(tvar, expectedKind, kenv)
@@ -1601,8 +1601,8 @@ object Kinder {
     * Infers a kind environment from the given type, with an expectation from context.
     * The inference is roughly analogous to the inference of types for expressions.
     * The primary differences are:
-    * - There are no kind variables; kinds that cannot be determined are instead marked with [[Kind.Wild]].
-    * - Subkinding may allow a variable to be ascribed with two different kinds; the most specific is used in the returned environment.
+    *   - There are no kind variables; kinds that cannot be determined are instead marked with [[Kind.Wild]].
+    *   - Subkinding may allow a variable to be ascribed with two different kinds; the most specific is used in the returned environment.
     */
   private def inferType(tpe: UnkindedType, expectedKind: Kind, kenv0: KindEnv, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], root: ResolvedAst.Root)(implicit flix: Flix): Validation[KindEnv, KindError] = tpe.baseType match {
     // Case 1: the type constructor is a variable: all args are * and the constructor is * -> * -> * ... -> expectedType

--- a/main/src/ca/uwaterloo/flix/language/phase/MonoTypes.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/MonoTypes.scala
@@ -24,8 +24,8 @@ import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
 /**
   * This phase does two things:
-  * - Erase enums, such that `Option[t]` becomes `Option`
-  * - Removes all type aliases in types
+  *   - Erase enums, such that `Option[t]` becomes `Option`
+  *   - Removes all type aliases in types
   */
 object MonoTypes {
 
@@ -291,12 +291,12 @@ object MonoTypes {
 
   /**
     * Returns the given type where
-    * - aliases have been removed.
-    * - `Enum[a, b, c]` have been replaced by `Enum`.
+    *   - aliases have been removed.
+    *   - `Enum[a, b, c]` have been replaced by `Enum`.
     *
     * Assumes that the type has no
-    * - Associated types.
-    * - Variables.
+    *   - Associated types.
+    *   - Variables.
     *
     * Performance Note: We are on a hot path. We take extra care to avoid redundant type objects.
     */

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorpher.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorpher.scala
@@ -41,16 +41,16 @@ import scala.collection.mutable
   *
   * For example, the polymorphic program:
   *
-  * -   def fst[a, b](p: (a, b)): a = let (x, y) = p ; x
-  * -   def f: Bool = fst((true, 'a'))
-  * -   def g: Int32 = fst((42, "foo"))
+  *   -   def fst[a, b](p: (a, b)): a = let (x, y) = p ; x
+  *   -   def f: Bool = fst((true, 'a'))
+  *   -   def g: Int32 = fst((42, "foo"))
   *
   * is, roughly speaking, translated to:
   *
-  * -   def fst$1(p: (Bool, Char)): Bool = let (x, y) = p ; x
-  * -   def fst$2(p: (Int32, String)): Int32 = let (x, y) = p ; x
-  * -   def f: Bool = fst$1((true, 'a'))
-  * -   def g: Bool = fst$2((42, "foo"))
+  *   -   def fst$1(p: (Bool, Char)): Bool = let (x, y) = p ; x
+  *   -   def fst$2(p: (Int32, String)): Int32 = let (x, y) = p ; x
+  *   -   def f: Bool = fst$1((true, 'a'))
+  *   -   def g: Bool = fst$2((42, "foo"))
   *
   * Additionally for things like record types and effect formulas, equivalent types are flattened
   * and ordered. This means that `{b = String, a = String}` becomes `{a = String, b = String}` and
@@ -58,24 +58,25 @@ import scala.collection.mutable
   *
   * At a high-level, monomorphization works as follows:
   *
-  * 1. We maintain a queue of functions and the concrete, normalized types they must be specialized
-  *    to.
-  * 2. We populate the queue by specialization of non-parametric function definitions.
-  * 3. We iteratively extract a function from the queue and specialize it:
-  *    a. We replace every type variable appearing anywhere in the definition by its concrete type.
-  *       b. We create new fresh local variable symbols (since the function is effectively being
-  *          copied).
-  *       c. We enqueue (or re-used) other functions referenced by the current function which
-  *          require specialization.
-  *       4. We reconstruct the AST from the specialized functions and remove all parametric
-  *          functions (Enum declarations are deleted to avoid specializing them).
+  *   1. We maintain a queue of functions and the concrete, normalized types they must be
+  *      specialized to.
+  *   1. We populate the queue by specialization of non-parametric function definitions.
+  *   1. We iteratively extract a function from the queue and specialize it:
+  *      a. We replace every type variable appearing anywhere in the definition by its concrete
+  *         type.
+  *      a. We create new fresh local variable symbols (since the function is effectively being
+  *         copied).
+  *      a. We enqueue (or re-used) other functions referenced by the current function which require
+  *         specialization.
+  *   1. We reconstruct the AST from the specialized functions and remove all parametric functions
+  *      (Enum declarations are deleted to avoid specializing them).
   *
   * Type normalization details:
   *
-  * - Record fields are in alphabetical order
-  * - Schema fields are in alphabetical order
-  * - Effect formulas are flat unions of effects in alphabetical order.
-  * - Case set formulas are a single CaseSet literal.
+  *   - Record fields are in alphabetical order
+  *   - Schema fields are in alphabetical order
+  *   - Effect formulas are flat unions of effects in alphabetical order.
+  *   - Case set formulas are a single CaseSet literal.
   *
   */
 object Monomorpher {
@@ -87,10 +88,10 @@ object Monomorpher {
     * kind. This is safe since otherwise the type would not be polymorphic after type-inference.
     *
     * Properties of normalized types (which is returned by apply):
-    * - No type variables
-    * - No associated types
-    * - No type aliases
-    * - Equivalent types are uniquely represented (e.g. fields in records types are alphabetized)
+    *   - No type variables
+    *   - No associated types
+    *   - No type aliases
+    *   - Equivalent types are uniquely represented (e.g. fields in records types are alphabetized)
     *
     * Notes on `s`: It is only applied to variables directly in the apply of the strict
     * substitution. They image of `s` does not have type aliases or associated types but can have
@@ -222,7 +223,7 @@ object Monomorpher {
       *
       * For example, if the queue contains the entry:
       *
-      * -   (f$1, f, [a -> Int32])
+      *   -   (f$1, f, [a -> Int32])
       *
       * it means that the function definition f should be specialized w.r.t. the map [a -> Int32] under the fresh name f$1.
       *
@@ -265,11 +266,11 @@ object Monomorpher {
       *
       * For example, if the function:
       *
-      * -   def fst[a, b](x: a, y: b): a = ...
+      *   -   def fst[a, b](x: a, y: b): a = ...
       *
       * has been specialized w.r.t. to `Int32` and `String` then this map will contain an entry:
       *
-      * -   (fst, (Int32, String) -> Int32) -> fst$1
+      *   -   (fst, (Int32, String) -> Int32) -> fst$1
       */
     private val def2def: mutable.Map[(Symbol.DefnSym, Type), Symbol.DefnSym] = mutable.Map.empty
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -34,17 +34,19 @@ import scala.collection.mutable.ArrayBuffer
   * A resilient LL parser.
   * Parses a stream of tokens into a [[SyntaxTree.Tree]].
   * This parser works in two steps:
+  *
   * 1. First the list of tokens is traversed while emitting Open, Advance and Close events.
   * Conceptually this is exactly the same as inserting parenthesis in a stream of tokens, only here each parenthesis is annotated with a kind.
   * For instance:
-  * def main(): Int32 = 123
+  * {{{def main(): Int32 = 123}}}
   * Becomes:
-  * (Def 'def' (Name 'main' ) '(' ')' ':' (Type 'Int32' ) '=' (Literal '123' ) )
+  * {{{(Def 'def' (Name 'main' ) '(' ')' ':' (Type 'Int32' ) '=' (Literal '123' ) )}}}
+  *
   * 2. The flat list of events is automatically turned into a SyntaxTree.Tree.
   *
   * This parser is adopted from 'Resilient LL Parsing Tutorial' by Alex Kladov who works on rust-analyzer.
   * The tutorial is also a great resource for understanding this parser (and a great read to boot!)
-  * https://matklad.github.io/2023/05/21/resilient-ll-parsing-tutorial.html
+  * [[https://matklad.github.io/2023/05/21/resilient-ll-parsing-tutorial.html]]
   */
 object Parser2 {
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -30,9 +30,9 @@ import scala.jdk.CollectionConverters._
 
 /**
   * Objectives of this phase:
-  * 1. Collect a list of the local parameters of each def
-  * 2. Collect a set of all anonymous class / new object expressions
-  * 3. Collect a flat set of all types of the program, i.e., if `List[String]` is
+  *   1. Collect a list of the local parameters of each def
+  *   1. Collect a set of all anonymous class / new object expressions
+  *   1. Collect a flat set of all types of the program, i.e., if `List[String]` is
   *   in the list, so is `String`.
   */
 object Reducer {

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -37,9 +37,9 @@ import scala.collection.mutable.ListBuffer
   *
   * For example, the redundancy phase ensures that there are no:
   *
-  * - unused local variables.
-  * - unused enums, definitions, ...
-  * - useless expressions.
+  *   - unused local variables.
+  *   - unused enums, definitions, ...
+  *   - useless expressions.
   *
   * and so on.
   *
@@ -827,12 +827,9 @@ object Redundancy {
     * Visits the [[ParYieldFragment]]s `frags`.
     *
     * Returns a tuple of three entries:
-    *
-    * 1. The used variables
-    *
-    * 2. An updated environment with the free variables
-    *
-    * 3. All the free variables.
+    *   1. The used variables
+    *   1. An updated environment with the free variables
+    *   1. All the free variables.
     */
   private def visitParYieldFragments(frags: List[ParYieldFragment], env0: Env, rc: RecursionContext)(implicit lctx: LocalContext, sctx: SharedContext, root: Root, flix: Flix): (Used, Env, Set[Symbol.VarSym]) = {
     frags.foldLeft((Used.empty, env0, Set.empty[Symbol.VarSym])) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -19,12 +19,12 @@ import scala.annotation.tailrec
 /**
   * Performs safety and well-formedness checks on:
   *
-  *  - Datalog constraints.
-  *  - New object expressions.
-  *  - CheckedCast expressions.
-  *  - UncheckedCast expressions.
-  *  - TypeMatch expressions.
-  *  - Throw expressions
+  *   - Datalog constraints.
+  *   - New object expressions.
+  *   - CheckedCast expressions.
+  *   - UncheckedCast expressions.
+  *   - TypeMatch expressions.
+  *   - Throw expressions
   */
 object Safety {
 
@@ -564,8 +564,8 @@ object Safety {
   /**
     * Checks if there are any impossible casts, i.e. casts that always fail.
     *
-    * - No primitive type can be cast to a reference type and vice-versa.
-    * - No Bool type can be cast to a non-Bool type  and vice-versa.
+    *   - No primitive type can be cast to a reference type and vice-versa.
+    *   - No Bool type can be cast to a non-Bool type  and vice-versa.
     */
   private def verifyUncheckedCast(cast: Expr.UncheckedCast)(implicit flix: Flix): List[SafetyError.ImpossibleUncheckedCast] = {
     val tpe1 = Type.eraseAliases(cast.exp.tpe).baseType

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -38,10 +38,10 @@ import scala.collection.mutable.ArrayBuffer
   * Weeder2 walks a [[Tree]], validates it and thereby transforms it into a [[WeededAst]].
   *
   * Function names in Weeder2 follow this pattern:
-  * 1. visit* : Visits a Tree of a known kind. These functions assert that the kind is indeed known.
-  * 2. pick* : Picks first sub-Tree of a kind and visits it.
-  * 3. tryPick* : Works like pick* but only runs the visitor if the child of kind is found. Returns an option containing the result.
-  * 3. pickAll* : These will pick all subtrees of a specified kind and run a visitor on it.
+  *   1. visit* : Visits a Tree of a known kind. These functions assert that the kind is indeed known.
+  *   1. pick* : Picks first sub-Tree of a kind and visits it.
+  *   1. tryPick* : Works like pick* but only runs the visitor if the child of kind is found. Returns an option containing the result.
+  *   1. pickAll* : These will pick all subtrees of a specified kind and run a visitor on it.
   */
 object Weeder2 {
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenEffectClasses.scala
@@ -8,42 +8,43 @@ import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes._
 
-/// An effect class like this:
-/// ```
-/// eff SomeEffect {
-///     pub def flip(): Bool
-///     pub def add(x: Int32, y: Int32): Int32
-/// }
-/// ```
-/// Is conceptually understood as (the input types of `cont` are actually boxed in `Value`):
-/// ```
-/// eff SomeEffect {
-///     pub def flip(unit: Unit, cont: Bool -> Result): Value
-///     pub def add(x: Int32, y: Int32, cont: Int32 -> Result): Value
-/// }
-/// ```
-/// and is generated like so:
-/// ```
-/// public final class Eff$SomeEffect implements Handler {
-///     public Fn2$Obj$Obj$Obj flip;
-///     public Fn3$Int32$Int32&Obj$Obj add;
-///
-///     public static EffectCall flip(Object var0, Handler h, Resumption r) {
-///         Fn2$Obj$Obj$Obj f = ((Eff$SomeEffect) h).flip;
-///         f.arg0 = var0;
-///         f.arg1 = new ResumptionWrapper(r);
-///         return f.invoke();
-///     }
-///
-///     public static EffectCall add(Int var0, Int var1, Handler h, Resumption r) {
-///         Fn2$Obj$Obj$Obj f = ((Eff$SomeEffect) h).flip;
-///         f.arg0 = var0;
-///         f.arg1 = var1;
-///         f.arg2 = new ResumptionWrapper(r);
-///         return f.invoke();
-///     }
-/// }
-/// ```
+/** An effect class like this:
+  * {{{
+  * eff SomeEffect {
+  *     pub def flip(): Bool
+  *     pub def add(x: Int32, y: Int32): Int32
+  * }
+  * }}}
+  * Is conceptually understood as (the input types of `cont` are actually boxed in `Value`):
+  * {{{
+  * eff SomeEffect {
+  *     pub def flip(unit: Unit, cont: Bool -> Result): Value
+  *     pub def add(x: Int32, y: Int32, cont: Int32 -> Result): Value
+  * }
+  * }}}
+  * and is generated like so:
+  * {{{
+  * public final class Eff$SomeEffect implements Handler {
+  *     public Fn2$Obj$Obj$Obj flip;
+  *     public Fn3$Int32$Int32&Obj$Obj add;
+  *
+  *     public static EffectCall flip(Object var0, Handler h, Resumption r) {
+  *         Fn2$Obj$Obj$Obj f = ((Eff$SomeEffect) h).flip;
+  *         f.arg0 = var0;
+  *         f.arg1 = new ResumptionWrapper(r);
+  *         return f.invoke();
+  *     }
+  *
+  *     public static EffectCall add(Int var0, Int var1, Handler h, Resumption r) {
+  *         Fn2$Obj$Obj$Obj f = ((Eff$SomeEffect) h).flip;
+  *         f.arg0 = var0;
+  *         f.arg1 = var1;
+  *         f.arg2 = new ResumptionWrapper(r);
+  *         return f.invoke();
+  *     }
+  * }
+  * }}}
+  */
 object GenEffectClasses {
 
   def gen(effects: Iterable[Effect])(implicit flix: Flix): Map[JvmName, JvmClass] = {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenFunAndClosureClasses.scala
@@ -71,7 +71,7 @@ object GenFunAndClosureClasses {
   /**
     * `(a|b)` is used to represent the function (left) or closure version (right)
     *
-    * ```
+    * {{{
     * public final class (Def$example|Clo$example$152) extends (Fn2$Obj$Int$Obj|Clo2$Obj$Int$Obj) implements Frame {
     *   // locals variables (present for both functions and closures)
     *   public int l0;
@@ -122,7 +122,7 @@ object GenFunAndClosureClasses {
     *     return x;
     *   }
     * }
-    * ```
+    * }}}
     */
   private def genCode(classType: JvmType.Reference, kind: FunctionKind, defn: Def)(implicit root: Root, flix: Flix): Array[Byte] = {
     val visitor = AsmOps.mkClassWriter()

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -23,9 +23,9 @@ import ca.uwaterloo.flix.language.phase.unification.Substitution
 
 /**
   * This phase generates a list of type constraints, which include
-  * - equality constraints `tpe1 ~ tpe2`
-  * - trait constraints `C[tpe1]`
-  * - purification constraints `eff1 ~ eff2[sym ↦ Pure]`
+  *   - equality constraints `tpe1 ~ tpe2`
+  *   - trait constraints `C[tpe1]`
+  *   - purification constraints `eff1 ~ eff2[sym ↦ Pure]`
   *
   * We gather constraints as we traverse each def.
   * Constraints are later resolved in ConstraintResolution.

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver.scala
@@ -32,9 +32,9 @@ import scala.annotation.tailrec
   * Constraint resolution works by iteratively building up a substitution from the constraints.
   *
   * Given a constraint set, we
-  * 1. select a constraint from the set,
-  * 2. attempt to resolve it, yielding a substitution and new constraints
-  * 3. apply the substitution to the accumulated substitution and add the new constraints to our set
+  *   1. select a constraint from the set,
+  *   1. attempt to resolve it, yielding a substitution and new constraints
+  *   1. apply the substitution to the accumulated substitution and add the new constraints to our set
   *
   * We repeat this until we cannot make any more progress or we discover an invalid constraint.
   */
@@ -190,8 +190,8 @@ object ConstraintSolver {
     * The initial substitution should come from e.g., formal parameter type ascriptions.
     *
     * Returns a result, either:
-    * - a substitution and leftover constraints, or
-    * - an error if resolution failed
+    *   - a substitution and leftover constraints, or
+    *   - an error if resolution failed
     */
   def resolve(constrs: List[TypeConstraint], subst0: Substitution, renv: RigidityEnv)(implicit tenv: Map[Symbol.TraitSym, Ast.TraitContext], eenv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], flix: Flix): Result[ResolutionResult, TypeError] = {
 
@@ -657,28 +657,28 @@ object ConstraintSolver {
     * Converts the given unification error into a type error.
     *
     * ExpectType
-    * - pretend it's just unifyType
-    * - if mismatchedtypes then map the error to PossibleChecked or UnexpectedType
-    * - else return as is
+    *   - pretend it's just unifyType
+    *   - if mismatchedtypes then map the error to PossibleChecked or UnexpectedType
+    *   - else return as is
     *
     * ExpectEffect
-    * - pretend it's just unifyType
-    * - if mismatchedEffects then map the error to possiblechecke or unexpectedeffect
-    * - else return as is
+    *   - pretend it's just unifyType
+    *   - if mismatchedEffects then map the error to possiblechecke or unexpectedeffect
+    *   - else return as is
     *
     * ExpectTypeArguments
-    * - pretend it's just unifytype
-    * - if mismatchedbools or mismatchedarroweffects or mismatchedtypes then map the error to unexpectedarg
-    * - else return as is
+    *   - pretend it's just unifytype
+    *   - if mismatchedbools or mismatchedarroweffects or mismatchedtypes then map the error to unexpectedarg
+    *   - else return as is
     *
     * Match
-    * - mismatched types
-    *   - check for over/under applied
-    *   - else return as is
-    *     - mismatched bools -> mismatched bools
-    *     - mismatched effects
-    *   - check for mismatched arrow effects
-    *   - else return as is
+    *   - mismatched types
+    *     - check for over/under applied
+    *     - else return as is
+    *       - mismatched bools -> mismatched bools
+    *       - mismatched effects
+    *     - check for mismatched arrow effects
+    *     - else return as is
     *     - mismatched case sets -> mismatched case sets
     *     - mismatched arity -> mismatched arity
     *     - rigid var -> mismatched types
@@ -694,7 +694,7 @@ object ConstraintSolver {
     *     - ord
     *     - hash
     *     - ?
-    *       - (other cases should be impossible on this branch)
+    *     - (other cases should be impossible on this branch)
     */
   // TODO ASSOC-TYPES This translation does not work well
   // TODO ASSOC-TYPES because provenance is not propogated properly.
@@ -802,9 +802,9 @@ object ConstraintSolver {
     /**
       * Composes `this` equality result with `that` equality result.
       *
-      * - Composes the substitution,
-      * - combines the leftover constraints, and
-      * - indicates progress if one of the two made progress.
+      *   - Composes the substitution,
+      *   - combines the leftover constraints, and
+      *   - indicates progress if one of the two made progress.
       */
     def @@(that: ResolutionResult): ResolutionResult = {
       val ResolutionResult(s1, cs1, p1) = this

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeConstraint.scala
@@ -112,8 +112,8 @@ object TypeConstraint {
 
   /**
     * A constraint indicating that:
-    * - `eff1` is equivalent to `eff2` when the region `sym` is purified in `eff2`, and
-    * - the nested constraints all hold
+    *   - `eff1` is equivalent to `eff2` when the region `sym` is purified in `eff2`, and
+    *   - the nested constraints all hold
     *
     * This constraint arises when exiting a region.
     * All nested constraints must be resolved before determining the equality of `eff1` and `eff2`,

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
@@ -322,9 +322,11 @@ object TypeReduction {
    *
    * There are three possible outcomes:
    *
-   * 1. Resolved(tpe): Indicates that there was some progress in the resolution and returns a simplified type of the java method.
-   * 2. AmbiguousMethod: The resolution lacked some elements to find a java method among a set of methods.
-   * 3. MethodNotFound(): The resolution failed to find a corresponding java method.
+   *   1. Resolved(tpe): Indicates that there was some progress in the resolution and returns a
+   *      simplified type of the java method.
+   *   1. AmbiguousMethod: The resolution lacked some elements to find a java method among a set of
+   *      methods.
+   *   1. MethodNotFound(): The resolution failed to find a corresponding java method.
    */
   sealed trait JavaMethodResolutionResult
   object JavaMethodResolutionResult {
@@ -337,10 +339,9 @@ object TypeReduction {
    * Represents the result of a resolution process of a java constructor.
    *
    * There are three possible outcomes:
-   *
-   * 1. Resolved(tpe): Indicates that there was some progress in the resolution and returns a simplified type of the java constructor.
-   * 2. AmbiguousConstructor: The resolution lacked some elements to find a java constructor among a set of constructors.
-   * 3. ConstructorNotFound(): The resolution failed to find a corresponding java constructor.
+   *   1. Resolved(tpe): Indicates that there was some progress in the resolution and returns a simplified type of the java constructor.
+   *   1. AmbiguousConstructor: The resolution lacked some elements to find a java constructor among a set of constructors.
+   *   1. ConstructorNotFound(): The resolution failed to find a corresponding java constructor.
    */
   sealed trait JavaConstructorResolutionResult
   object JavaConstructorResolutionResult {

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/CaseSetUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/CaseSetUnification.scala
@@ -184,8 +184,8 @@ object CaseSetUnification {
 
   /**
     * A DNF formula is either:
-    * - a union of intersections of literals.
-    * - the universal set
+    *   - a union of intersections of literals.
+    *   - the universal set
     */
   private sealed trait Dnf
 

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/FastBoolUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/FastBoolUnification.scala
@@ -116,8 +116,8 @@ object FastBoolUnification {
   /**
     * A stateful phased solver for Boolean unification equations. The solver maintains two fields that change over time:
     *
-    * - The current (pending) unification equations to solve.
-    * - The current (partial) substitution which represents the solution.
+    *   - The current (pending) unification equations to solve.
+    *   - The current (partial) substitution which represents the solution.
     *
     * @param l The input list of Boolean unification equations to solve.
     */
@@ -292,18 +292,18 @@ object FastBoolUnification {
     * Throws a [[ConflictException]] if an unsolvable equation is encountered.
     *
     * A trivial equation is one of:
-    * -     true ~ true
-    * -    false ~ false
-    * -        c ~ c        (same constant)
-    * -        x ~ x        (same variable)
+    *   -     true ~ true
+    *   -    false ~ false
+    *   -        c ~ c        (same constant)
+    *   -        x ~ x        (same variable)
     *
     *
     * An unsolvable (conflicted) equation is one of:
     *
-    * -      true ~ false   (and mirrored)
-    * -       c_i ~ c_j     (different constants)
-    * -        c ~ true     (and mirrored)
-    * -        c ~ false    (and mirrored)
+    *   -      true ~ false   (and mirrored)
+    *   -       c_i ~ c_j     (different constants)
+    *   -        c ~ true     (and mirrored)
+    *   -        c ~ false    (and mirrored)
     */
   private def checkAndSimplify(l: List[Equation]): List[Equation] = l match {
     case Nil => Nil
@@ -336,9 +336,9 @@ object FastBoolUnification {
     *
     * The implementation uses three rewrite rules:
     *
-    * - `x ~ true` becomes `[x -> true]`.
-    * - `x ~ c` becomes `[x -> c]`.
-    * - `x /\ y /\ ... = true` becomes `[x -> true, y -> true, ...]`.
+    *   - `x ~ true` becomes `[x -> true]`.
+    *   - `x ~ c` becomes `[x -> c]`.
+    *   - `x /\ y /\ ... = true` becomes `[x -> true, y -> true, ...]`.
     *
     * For example, if the equation system is:
     *
@@ -901,15 +901,15 @@ object FastBoolUnification {
       * Returns a unification equation  `t1 ~ t2` between the terms `t1` and `t2`.
       *
       * The smart constructor performs normalization:
-      * - We move true and false to the rhs.
-      * - We move a single variable to the lhs.
-      * - We reorder constant/variables so that the smaller constant/variable is on the lhs.
+      *   - We move true and false to the rhs.
+      *   - We move a single variable to the lhs.
+      *   - We reorder constant/variables so that the smaller constant/variable is on the lhs.
       *
       * Examples:
-      * -     true ~ x7 ==> x7 ~ true
-      * -       c3 ~ c2 ==> c2 ~ c3
-      * -       x7 ~ x5 ==> x5 ~ x7
-      * - x3 /\ x7 ~ x4 ==> x4 ~ x3 /\ x7
+      *   -     true ~ x7 ==> x7 ~ true
+      *   -       c3 ~ c2 ==> c2 ~ c3
+      *   -       x7 ~ x5 ==> x5 ~ x7
+      *   - x3 /\ x7 ~ x4 ==> x4 ~ x3 /\ x7
       */
     def mk(t1: Term, t2: Term, loc: SourceLocation): Equation = (t1, t2) match {
       case (Term.Cst(c1), Term.Cst(c2)) => if (c1 <= c2) Equation(t1, t2, loc) else Equation(t2, t1, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/TraitEnvironment.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/TraitEnvironment.scala
@@ -145,12 +145,12 @@ object TraitEnvironment {
     * Returns the list of constraints that hold if the given constraint `tconstr` holds, using the super traits of the constraint.
     *
     * E.g. if we have 3 traits: `A`, `B`, `C` where
-    * - `A` extends `B`
-    * - `B` extends `C`
+    *   - `A` extends `B`
+    *   - `B` extends `C`
     * Then for the constraint `t : A`, we return:
-    * - `t : A` (given)
-    * - `t : B` (because `B` is a super trait of `A`)
-    * - `t : C` (because `C` is a super trait of `B`, and transitively a super trait of `A`)
+    *   - `t : A` (given)
+    *   - `t : B` (because `B` is a super trait of `A`)
+    *   - `t : C` (because `C` is a super trait of `B`, and transitively a super trait of `A`)
     *
     */
   private def bySuper(tconstr: Ast.TypeConstraint, traitEnv: Map[Symbol.TraitSym, Ast.TraitContext]): List[Ast.TypeConstraint] = {

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/TypeNormalization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/TypeNormalization.scala
@@ -27,16 +27,16 @@ object TypeNormalization {
     * normalized form, which will be the same for all other equivalent types.
     *
     * Returns a type where
-    * 1. Formulas in types have been fully evaluated (and ordered in the case of
-    *    sets)
-    * 2. Types involving rows have been sorted alphabetically (respecting
-    *    duplicate label ordering)
-    * 3. The assumptions still hold
+    *   1. Formulas in types have been fully evaluated (and ordered in the case of
+    *      sets)
+    *   1. Types involving rows have been sorted alphabetically (respecting
+    *      duplicate label ordering)
+    *   1. The assumptions still hold
     *
     * Assumes that
-    * 1. `tpe` is ground (no type variables)
-    * 2. `tpe` has no aliases
-    * 3. `tpe` has no associated types
+    *   1. `tpe` is ground (no type variables)
+    *   1. `tpe` has no aliases
+    *   1. `tpe` has no associated types
     */
   def normalizeType(tpe: Type): Type = tpe match {
     case Type.Var(sym, loc) =>

--- a/main/src/ca/uwaterloo/flix/tools/CompilerPerf.scala
+++ b/main/src/ca/uwaterloo/flix/tools/CompilerPerf.scala
@@ -291,9 +291,9 @@ object CompilerPerf {
         })
     writeFile("speedupWithInc.json", speedupInc)
 
-    ///
-    /// Throughput
-    ///
+    //
+    // Throughput
+    //
     val throughoutBaseLine =
     ("timestamp" -> timestamp) ~
       ("threads" -> MinThreads) ~

--- a/main/src/ca/uwaterloo/flix/tools/Summary.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Summary.scala
@@ -133,12 +133,12 @@ object Summary {
   }
 
   /**
-    * - prefixFileName("a/b", None) = "a/b"
-    * - prefixFileName("a/b", Some(1)) = "a/..."
-    * - prefixFileName("a/b", Some(2)) = "a/b"
-    * - prefixFileName("a/b/c", Some(2)) = "a/b/..."
-    * - prefixFileName("a/b", Some(0) = "a/b"
-    * - prefixFileName("a/b", Some(-1) = "a/b"
+    *   - prefixFileName("a/b", None) = "a/b"
+    *   - prefixFileName("a/b", Some(1)) = "a/..."
+    *   - prefixFileName("a/b", Some(2)) = "a/b"
+    *   - prefixFileName("a/b/c", Some(2)) = "a/b/..."
+    *   - prefixFileName("a/b", Some(0) = "a/b"
+    *   - prefixFileName("a/b", Some(-1) = "a/b"
     */
   private def prefixFileName(name: String, nsDepth: Option[Int]): String = {
     nsDepth match {
@@ -244,9 +244,9 @@ object Summary {
 
   /**
     * Represents the direct effect of a function
-    * - `def f(x: Int32): Int32` is `Pure`
-    * - `def f(x: Int32): Unit \ IO` is `JustIO`
-    * - `def f(x: Array[Int32, r]): IO + r` is `Poly`
+    *   - `def f(x: Int32): Int32` is `Pure`
+    *   - `def f(x: Int32): Unit \ IO` is `JustIO`
+    *   - `def f(x: Array[Int32, r]): IO + r` is `Poly`
     */
   private sealed trait ResEffect
 
@@ -260,9 +260,9 @@ object Summary {
 
   /**
     * This type is used to differentiate between
-    * - normal defs
-    * - instance defs, and
-    * - trait defs with implementation
+    *   - normal defs
+    *   - instance defs, and
+    *   - trait defs with implementation
     */
   private sealed trait FunctionSym {
     def loc: SourceLocation

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -20,10 +20,10 @@ class TestParser extends Suites(
   * There is an theoretically infinite amount of possible syntax errors (we could just start fuzzing random strings),
   * so these test cover some "sensible amount" of broad errors.
   * Some areas that could use more test are:
-  * - Declarations other than definitions (module, enum, trait, signature, effect).
-  * - Patterns
-  * - Map, Set, List, Vector and Array literals.
-  * - "Niche" expressions (OpenAs, JVMops, Fixpoint expressions).
+  *   - Declarations other than definitions (module, enum, trait, signature, effect).
+  *   - Patterns
+  *   - Map, Set, List, Vector and Array literals.
+  *   - "Niche" expressions (OpenAs, JVMops, Fixpoint expressions).
   *
   * Note that these tests use [[check]] rather than [[compile]].
   * That's because a compile converts any check failure into a HardFailure before running, codegen so the result we would like to expect is lost.


### PR DESCRIPTION
1. Lists must start their line with whitespace to parse
2. Lists must always use 1. 1. 1. 1. or A. A. A. otherwise it doesn't parse
3. ` is inline code, no matter if there three or one
4. {{{ }}} is code blocks
5. /// doesn't do anything, its not flix