### PR TITLE
refactor: return type var symbols from Type.typeVars

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/RigidityEnv.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/RigidityEnv.scala
@@ -62,7 +62,7 @@ case class RigidityEnv(s: SortedSet[Symbol.KindedTypeVarSym]) {
   /**
     * Returns the flexible vars from the given list.
     */
-  def getFlexibleVarsOf(tvars: List[Type.Var]): List[Type.Var] = tvars.filter(tvar => isFlexible(tvar.sym))
+  def getFlexibleVarsOf(tvars: List[Symbol.KindedTypeVarSym]): List[Symbol.KindedTypeVarSym] = tvars.filter(isFlexible)
 
   /**
     * Marks the given `sym` as rigid in this environment.

--- a/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
@@ -116,7 +116,7 @@ object Scheme {
   def generalize(tconstrs: List[Ast.TraitConstraint], econstrs: List[Ast.BroadEqualityConstraint], tpe0: Type, renv: RigidityEnv): Scheme = {
     val tvars = tpe0.typeVars ++ tconstrs.flatMap(tconstr => tconstr.arg.typeVars) ++ econstrs.flatMap(econstr => econstr.tpe1.typeVars ++ econstr.tpe2.typeVars)
     val quantifiers = renv.getFlexibleVarsOf(tvars.toList)
-    Scheme(quantifiers.map(_.sym), tconstrs, econstrs, tpe0)
+    Scheme(quantifiers, tconstrs, econstrs, tpe0)
   }
 
   /**
@@ -171,7 +171,7 @@ object Scheme {
     val tvars = cconstrs2.flatMap(_.arg.typeVars) ++
       econstrs2.flatMap { econstr => econstr.tpe1.typeVars ++ econstr.tpe2.typeVars } ++
       tpe2.typeVars
-    val renv = tvars.foldLeft(RigidityEnv.empty) { case (r, tvar) => r.markRigid(tvar.sym) }
+    val renv = tvars.foldLeft(RigidityEnv.empty) { case (r, tvar) => r.markRigid(tvar) }
 
     // Check that the constraints from sc1 hold
     // And that the bases unify

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -48,13 +48,13 @@ sealed trait Type {
     *
     * Note: We cache `typeVars` to improve performance.
     */
-  lazy val typeVars: SortedSet[Type.Var] = this match {
-    case x: Type.Var => SortedSet(x)
+  lazy val typeVars: SortedSet[Symbol.KindedTypeVarSym] = this match {
+    case Type.Var(sym, _) => SortedSet(sym)
 
-    case Type.Cst(tc, _) => SortedSet.empty
+    case Type.Cst(_, _) => SortedSet.empty
 
     case Type.Apply(tpe1, tpe2, _) => tpe1.typeVars ++ tpe2.typeVars
-    case Type.Alias(_, args, _, _) => args.foldLeft(SortedSet.empty[Type.Var])((acc, t) => acc ++ t.typeVars)
+    case Type.Alias(_, args, _, _) => args.foldLeft(SortedSet.empty[Symbol.KindedTypeVarSym])((acc, t) => acc ++ t.typeVars)
     case Type.AssocType(_, arg, _, _) => arg.typeVars // TODO ASSOC-TYPES throw error?
   }
 

--- a/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/TypeError.scala
@@ -23,10 +23,10 @@ import ca.uwaterloo.flix.language.ast.TypeConstructor.JvmMethod
 import ca.uwaterloo.flix.language.ast._
 import ca.uwaterloo.flix.language.dbg.DocAst.Type.JvmConstructor
 import ca.uwaterloo.flix.language.fmt.FormatEqualityConstraint.formatEqualityConstraint
-import ca.uwaterloo.flix.language.fmt.FormatType.formatType
+import ca.uwaterloo.flix.language.fmt.FormatType.{formatType, formatTypeVarSym}
 import ca.uwaterloo.flix.util.{Formatter, Grammar}
 
-import java.lang.reflect.{Method, Constructor};
+import java.lang.reflect.{Constructor, Method};
 
 /**
   * A common super-type for type errors.
@@ -673,12 +673,12 @@ object TypeError {
     * @param tpe  the type wherein the region variable escapes.
     * @param loc  the location where the error occurred.
     */
-  case class RegionVarEscapes(rvar: Type.Var, tpe: Type, loc: SourceLocation)(implicit flix: Flix) extends TypeError with Recoverable {
-    def summary: String = s"Region variable '${formatType(rvar)}' escapes its scope."
+  case class RegionVarEscapes(rvar: Symbol.KindedTypeVarSym, tpe: Type, loc: SourceLocation)(implicit flix: Flix) extends TypeError with Recoverable {
+    def summary: String = s"Region variable '${formatTypeVarSym(rvar)}' escapes its scope."
 
     def message(formatter: Formatter): String = {
       import formatter._
-      s""">> The region variable '${red(formatType(rvar))}' escapes its scope.
+      s""">> The region variable '${red(formatTypeVarSym(rvar))}' escapes its scope.
          |
          |${code(loc, "region variable escapes.")}
          |

--- a/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
+++ b/main/src/ca/uwaterloo/flix/language/fmt/FormatType.scala
@@ -44,15 +44,15 @@ object FormatType {
     */
   private def alphaRename(tpe: Type, renv: RigidityEnv): Type = {
     // Compute the free type variables.
-    val freeVars = tpe.typeVars.toList.sortBy(_.sym.id)
+    val freeVars = tpe.typeVars.toList.sortBy(_.id)
 
     // Compute the flexible variables (i.e. the free variables that are not rigid).
     val flexibleVars = renv.getFlexibleVarsOf(freeVars)
 
     // Compute a substitution that maps the first flexible variable to id 1 and so forth.
     val m = flexibleVars.zipWithIndex.map {
-      case (tvar@Type.Var(sym, loc), index) =>
-        sym -> (Type.Var(new Symbol.KindedTypeVarSym(index, sym.text, sym.kind, sym.isRegion, loc), loc): Type)
+      case (sym, index) =>
+        sym -> (Type.Var(new Symbol.KindedTypeVarSym(index, sym.text, sym.kind, sym.isRegion, SourceLocation.Unknown), SourceLocation.Unknown): Type)
     }
     val s = Substitution(m.toMap)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
@@ -374,7 +374,7 @@ object EffectVerifier {
     */
   private def expectType(expected: Type, actual: Type, loc: SourceLocation)(implicit eqEnv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], flix: Flix): Unit = {
     // mark everything as rigid
-    val renv = RigidityEnv.ofRigidVars(expected.typeVars.map(_.sym) ++ actual.typeVars.map(_.sym))
+    val renv = RigidityEnv.ofRigidVars(expected.typeVars ++ actual.typeVars)
     if (!Unification.unifiesWith(expected, actual, renv, eqEnv)) {
       throw InternalCompilerException(s"Expected type $expected but found $actual at $loc", loc)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Monomorpher.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Monomorpher.scala
@@ -561,7 +561,7 @@ object Monomorpher {
       // make the tvars in `exp`'s type rigid
       // so that Nil: List[x%123] can only match List[_]
       val renv = expTpe.typeVars.foldLeft(RigidityEnv.empty) {
-        case (acc, Type.Var(sym, _)) => acc.markRigid(sym)
+        case (acc, sym) => acc.markRigid(sym)
       }
       ListOps.findMap(rules) {
         case LoweredAst.TypeMatchRule(sym, t, body0) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -135,7 +135,7 @@ object Redundancy {
     val result = new ListBuffer[RedundancyError]
     for ((_, decl) <- root.enums) {
       val usedTypeVars = decl.cases.foldLeft(Set.empty[Symbol.KindedTypeVarSym]) {
-        case (sacc, (_, Case(_, tpe, _, _))) => sacc ++ tpe.typeVars.map(_.sym)
+        case (sacc, (_, Case(_, tpe, _, _))) => sacc ++ tpe.typeVars
       }
       val unusedTypeParams = decl.tparams.filter {
         tparam =>
@@ -169,7 +169,7 @@ object Redundancy {
     for ((_, decl) <- root.structs) {
       val usedTypeVars = decl.fields.foldLeft(Set.empty[Symbol.KindedTypeVarSym]) {
         case (acc, (name, field)) =>
-          acc ++ field.tpe.typeVars.map(_.sym)
+          acc ++ field.tpe.typeVars
       }
       val unusedTypeParams = decl.tparams.init.filter { // the last tparam is implicitly used for the region
         tparam =>
@@ -276,7 +276,7 @@ object Redundancy {
   private def findUnusedTypeParameters(spec: Spec): List[UnusedTypeParam] = spec match {
     case Spec(_, _, _, tparams, fparams, _, tpe, eff, tconstrs, econstrs, _) =>
       val tpes = fparams.map(_.tpe) ::: tpe :: eff :: tconstrs.map(_.arg) ::: econstrs.map(_.tpe1) ::: econstrs.map(_.tpe2)
-      val used = tpes.flatMap { t => t.typeVars.map(_.sym) }.toSet
+      val used = tpes.flatMap { t => t.typeVars }.toSet
       tparams.collect {
         case tparam if deadTypeVar(tparam.sym, used) => UnusedTypeParam(tparam.name, tparam.loc)
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -269,7 +269,7 @@ object Typer {
   private def visitInstance(inst: KindedAst.Instance, root: KindedAst.Root, traitEnv: Map[Symbol.TraitSym, Ast.TraitContext], eqEnv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef])(implicit flix: Flix): Validation[TypedAst.Instance, TypeError] = inst match {
     case KindedAst.Instance(doc, ann, mod, sym, tpe0, tconstrs0, assocs0, defs0, ns, loc) =>
       val tpe = tpe0 // TODO ASSOC-TYPES redundant?
-      val renv = tpe0.typeVars.map(_.sym).foldLeft(RigidityEnv.empty)(_.markRigid(_))
+      val renv = tpe0.typeVars.foldLeft(RigidityEnv.empty)(_.markRigid(_))
       val tconstrs = tconstrs0 // no subst to be done
       val assocs = assocs0.map {
         case KindedAst.AssocTypeDef(doc, mod, sym, args, tpe, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -1085,7 +1085,7 @@ object ConstraintGen {
       // This marking only really affects wildcards,
       // as non-wildcard variables must come from the function signature
       // and are therefore already rigid.
-      declTpe.typeVars.map(_.sym).foreach(c.rigidify)
+      declTpe.typeVars.foreach(c.rigidify)
 
       // Unify the variable's type with the declared type
       c.unifyType(sym.tvar, declTpe, sym.loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
@@ -72,7 +72,7 @@ object TypeReduction {
       simplify(arg, renv0, loc).flatMap {
         case (t, p) =>
           // we mark t's tvars as rigid so we get the substitution in the right direction
-          val renv = t.typeVars.map(_.sym).foldLeft(RigidityEnv.empty)(_.markRigid(_))
+          val renv = t.typeVars.foldLeft(RigidityEnv.empty)(_.markRigid(_))
           val insts = eenv(cst.sym)
 
           // find the first (and only) instance that matches

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/BoolAlg.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/BoolAlg.scala
@@ -104,7 +104,7 @@ trait BoolAlg[F] {
   def getEnv(fs: List[Type]): Bimap[BoolFormula.VarOrEff, Int] = {
     // Compute the variables in `tpe`.
     val tvars =
-      fs.foldLeft(SortedSet.empty[Symbol.KindedTypeVarSym])((acc, tpe) => acc ++ tpe.typeVars.map(_.sym))
+      fs.foldLeft(SortedSet.empty[Symbol.KindedTypeVarSym])((acc, tpe) => acc ++ tpe.typeVars)
         .toList.map(BoolFormula.VarOrEff.Var)
 
     val effs =

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/CaseSetUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/CaseSetUnification.scala
@@ -41,10 +41,10 @@ object CaseSetUnification {
     /// Get rid of of trivial variable cases.
     ///
     (tpe1, tpe2) match {
-      case (t1@Type.Var(x, _), t2) if renv0.isFlexible(x) && !t2.typeVars.contains(t1) =>
+      case (Type.Var(x, _), t2) if renv0.isFlexible(x) && !t2.typeVars.contains(x) =>
         return Ok(Substitution.singleton(x, t2))
 
-      case (t1, t2@Type.Var(x, _)) if renv0.isFlexible(x) && !t1.typeVars.contains(t2) =>
+      case (t1, Type.Var(x, _)) if renv0.isFlexible(x) && !t1.typeVars.contains(x) =>
         return Ok(Substitution.singleton(x, t1))
 
       case _ => // nop

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification.scala
@@ -124,10 +124,10 @@ object EffUnification {
         case (_, Type.Cst(TypeConstructor.Error(_, _), _)) =>
           return Ok((Substitution.empty, Nil))
 
-        case (t1@Type.Var(x, _), t2) if renv0.isFlexible(x) && !t2.typeVars.contains(t1) =>
+        case (Type.Var(x, _), t2) if renv0.isFlexible(x) && !t2.typeVars.contains(x) =>
           return Ok(Substitution.singleton(x, t2), Nil)
 
-        case (t1, t2@Type.Var(x, _)) if renv0.isFlexible(x) && !t1.typeVars.contains(t2) =>
+        case (t1, Type.Var(x, _)) if renv0.isFlexible(x) && !t1.typeVars.contains(x) =>
           return Ok(Substitution.singleton(x, t1), Nil)
 
         case _ => // nop

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EqualityEnvironment.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EqualityEnvironment.scala
@@ -83,7 +83,7 @@ object EqualityEnvironment {
     * Only performs one reduction step. The result may itself contain associated types.
     */
   def reduceAssocTypeStep(cst: Ast.AssocTypeConstructor, arg: Type, eqEnv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef])(implicit flix: Flix): Result[Type, UnificationError] = {
-    val renv = arg.typeVars.map(_.sym).foldLeft(RigidityEnv.empty)(_.markRigid(_))
+    val renv = arg.typeVars.foldLeft(RigidityEnv.empty)(_.markRigid(_))
     val insts = eqEnv(cst.sym)
     insts.iterator.flatMap { // TODO ASSOC-TYPES generalize this pattern (also in monomorph)
       inst =>

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/RecordUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/RecordUnification.scala
@@ -77,7 +77,7 @@ object RecordUnification {
       case (tvar: Type.Var, Type.Apply(Type.Apply(Type.Cst(TypeConstructor.RecordRowExtend(label1), _), labelType1, _), _, _)) =>
         val tv = tvar
         // Case 2: The row is a type variable.
-        if (staticRow.typeVars.contains(tv)) {
+        if (staticRow.typeVars.contains(tv.sym)) {
           Err(UnificationError.OccursCheck(tv, staticRow))
         } else {
           // Introduce a fresh type variable to represent one more level of the row.

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/SchemaUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/SchemaUnification.scala
@@ -78,7 +78,7 @@ object SchemaUnification {
       case (tvar: Type.Var, Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label1), _), fieldType1, _), _, _)) =>
         val tv = tvar
         // Case 2: The row is a type variable.
-        if (staticRow.typeVars contains tv) {
+        if (staticRow.typeVars.contains(tv.sym)) {
           Err(UnificationError.OccursCheck(tv, staticRow))
         } else {
           // Introduce a fresh type variable to represent one more level of the row.

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/SetFormula.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/SetFormula.scala
@@ -221,7 +221,7 @@ object SetFormula {
     * Creates an environment for mapping between proper types and formulas.
     */
   def mkEnv(ts: List[Type], univ: SortedSet[Symbol.RestrictableCaseSym]): (Bimap[VarOrCase, Int], Set[Int]) = {
-    val vars = ts.flatMap(_.typeVars).map(_.sym).distinct.map(VarOrCase.Var)
+    val vars = ts.flatMap(_.typeVars).distinct.map(VarOrCase.Var)
     val cases = (univ.toSet ++ ts.flatMap(_.cases)).map(VarOrCase.Case)
     // TODO RESTR-VARS do I even need the ts part here?
 

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/TraitEnvironment.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/TraitEnvironment.scala
@@ -113,7 +113,7 @@ object TraitEnvironment {
     case Ast.TraitConstraint(head, arg, loc) =>
       val matchingInstances = traitEnv.get(head.sym).map(_.instances).getOrElse(Nil)
 
-      val renv = RigidityEnv.ofRigidVars(arg.typeVars.map(_.sym))
+      val renv = RigidityEnv.ofRigidVars(arg.typeVars)
 
       def tryInst(inst: Ast.Instance): Validation[List[Ast.TraitConstraint], UnificationError] = {
         val substVal = Unification.unifyTypes(inst.tpe, arg, renv).toValidation

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/TypeMinimization.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/TypeMinimization.scala
@@ -49,7 +49,7 @@ object TypeMinimization {
   def minimizeScheme(sc: Scheme): Scheme = sc match {
     case Scheme(quantifiers, tconstrs, econstrs, base) =>
       val newBase = minimizeType(base)
-      val tvars = newBase.typeVars.map(_.sym)
+      val tvars = newBase.typeVars
 
       // filter out unused quantifiers
       val newQuants = quantifiers.filter(tvars.contains)
@@ -88,7 +88,7 @@ object TypeMinimization {
     }
 
     // Compute the variables in `tpe`.
-    val tvars = tpe.typeVars.toList.map(tvar => BoolFormula.VarOrEff.Var(tvar.sym))
+    val tvars = tpe.typeVars.toList.map(tvar => BoolFormula.VarOrEff.Var(tvar))
     val effs = tpe.effects.toList.map(BoolFormula.VarOrEff.Eff)
     val assocs = tpe.assocs.toList.map(assoc => BoolFormula.VarOrEff.Assoc(assoc.cst.sym, assoc.arg))
 

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/Unification.scala
@@ -58,7 +58,7 @@ object Unification {
       // TODO ASSOC-TYPES probably the same situation for type aliases
       case assoc: Type.AssocType =>
         // don't do the substitution if the var is in the assoc type
-        if (assoc.typeVars contains x) {
+        if (assoc.typeVars.contains(x.sym)) {
           Result.Ok((Substitution.empty, List(Ast.BroadEqualityConstraint(x, assoc))))
         } else {
           Result.Ok((Substitution.singleton(x.sym, assoc), Nil))
@@ -72,7 +72,7 @@ object Unification {
         }
 
         // Check if `x` occurs within `tpe`.
-        if (tpe.typeVars contains x) {
+        if (tpe.typeVars.contains(x.sym)) {
           return Result.Err(UnificationError.OccursCheck(x, tpe))
         }
 


### PR DESCRIPTION
In the vast majority of cases, we immediately map the vars to symbols. In other cases, IMO the location does not matter.