### PR TITLE
refactor: make `Ref` module use `struct`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2448,7 +2448,7 @@ object Resolver {
         case "Lazy" => Validation.success(UnkindedType.Cst(TypeConstructor.Lazy, loc))
         case "Array" => Validation.success(UnkindedType.Cst(TypeConstructor.Array, loc))
         case "Vector" => Validation.success(UnkindedType.Cst(TypeConstructor.Vector, loc))
-        case "Ref" => Validation.success(UnkindedType.Cst(TypeConstructor.Ref, loc))
+        // case "Ref" => Validation.success(UnkindedType.Cst(TypeConstructor.Ref, loc))
         case "Region" => Validation.success(UnkindedType.Cst(TypeConstructor.RegionToStar, loc))
 
         // Disambiguate type.

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2448,7 +2448,6 @@ object Resolver {
         case "Lazy" => Validation.success(UnkindedType.Cst(TypeConstructor.Lazy, loc))
         case "Array" => Validation.success(UnkindedType.Cst(TypeConstructor.Array, loc))
         case "Vector" => Validation.success(UnkindedType.Cst(TypeConstructor.Vector, loc))
-        // case "Ref" => Validation.success(UnkindedType.Cst(TypeConstructor.Ref, loc))
         case "Region" => Validation.success(UnkindedType.Cst(TypeConstructor.RegionToStar, loc))
 
         // Disambiguate type.

--- a/main/src/library/Ref.flix
+++ b/main/src/library/Ref.flix
@@ -14,25 +14,29 @@
  *  limitations under the License.
  */
 
+struct Ref[a, r] {
+    v: a
+}
+
 mod Ref {
 
     ///
     /// Returns a new reference to `x` in the region `rc`.
     ///
     pub def fresh(rc: Region[r], x: a): Ref[a, r] \ r =
-        ref x @ rc
+        new Ref { v = x } @ rc
 
     ///
     /// Returns the element referenced by `rf`.
     ///
     pub def get(rf: Ref[a, r]): a \ r =
-        deref rf
+        rf€v
 
     ///
     /// Updates `rf` to reference `x`.
     ///
     pub def put(x: a, rf: Ref[a, r]): Unit \ r =
-        $REF_ASSIGN$(rf, x)
+        rf€v = x
 
 
     ///
@@ -41,6 +45,6 @@ mod Ref {
     /// I.e. if `rf` references `x` then `rf` is updated to reference `f(x)`.
     ///
     pub def transform(f: a -> a \ ef, rf: Ref[a, r]): Unit \ { r, ef } =
-        put(f(Ref.get(rf)), rf)
+        put(f(rf€v), rf)
 
 }


### PR DESCRIPTION
I could potentially do more work to also get rid of `ref` in the compiler if that would be helpful. 