### PR TITLE
refactor: use `Grammar.scala` in `MismatchedOpArity`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -19,6 +19,7 @@ package ca.uwaterloo.flix.language.errors
 import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, UnkindedType}
 import ca.uwaterloo.flix.util.Formatter
+import ca.uwaterloo.flix.util.Grammar.count
 
 import java.lang.reflect.{Constructor, Field, Method}
 
@@ -1083,10 +1084,7 @@ object ResolutionError {
     * @param loc      the location where the error occurred.
     */
   case class MismatchedOpArity(op: Symbol.OpSym, expected: Int, actual: Int, loc: SourceLocation) extends ResolutionError with Recoverable {
-    val params: String = if (expected == 1) "parameter" else "parameters"
-    val be: String = if (actual == 1) "is" else "are"
-
-    override def summary: String = s"Expected $expected $params but found $actual."
+    override def summary: String = s"Expected ${count(expected, Some("parameter"))} but found $actual."
 
     /**
       * Returns the formatted error message.
@@ -1095,10 +1093,10 @@ object ResolutionError {
       import formatter._
       s""">> Mismatched arity.
          |
-         |The operation $op expects $expected $params,
-         |but $actual $be provided here.
+         |The operation $op expects ${count(expected, Some("parameter"))},
+         |but ${count(actual, None, are=true)} provided here.
          |
-         |${code(loc, s"expected $expected $params but found $actual")}
+         |${code(loc, s"expected ${count(expected, Some("parameter"))} but found $actual")}
          |""".stripMargin
     }
 

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -1083,7 +1083,7 @@ object ResolutionError {
     * @param loc      the location where the error occurred.
     */
   case class MismatchedOpArity(op: Symbol.OpSym, expected: Int, actual: Int, loc: SourceLocation) extends ResolutionError with Recoverable {
-    override def summary: String = s"Expected ${Grammar.count(expected, Some("parameter"))} but found $actual."
+    override def summary: String = s"Expected ${Grammar.n_things(expected, "parameter")} but found $actual."
 
     /**
       * Returns the formatted error message.
@@ -1092,10 +1092,10 @@ object ResolutionError {
       import formatter._
       s""">> Mismatched arity.
          |
-         |The operation $op expects ${Grammar.count(expected, Some("parameter"))},
-         |but ${Grammar.count(actual, None, are=true)} provided here.
+         |The operation $op expects ${Grammar.n_things(expected, "parameter")},
+         |but ${Grammar.n_are(actual)} provided here.
          |
-         |${code(loc, s"expected ${Grammar.count(expected, Some("parameter"))} but found $actual")}
+         |${code(loc, s"expected ${Grammar.n_things(expected, "parameter")} but found $actual")}
          |""".stripMargin
     }
 

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -18,8 +18,7 @@ package ca.uwaterloo.flix.language.errors
 
 import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, UnkindedType}
-import ca.uwaterloo.flix.util.Formatter
-import ca.uwaterloo.flix.util.Grammar.count
+import ca.uwaterloo.flix.util.{Formatter, Grammar}
 
 import java.lang.reflect.{Constructor, Field, Method}
 
@@ -1084,7 +1083,7 @@ object ResolutionError {
     * @param loc      the location where the error occurred.
     */
   case class MismatchedOpArity(op: Symbol.OpSym, expected: Int, actual: Int, loc: SourceLocation) extends ResolutionError with Recoverable {
-    override def summary: String = s"Expected ${count(expected, Some("parameter"))} but found $actual."
+    override def summary: String = s"Expected ${Grammar.count(expected, Some("parameter"))} but found $actual."
 
     /**
       * Returns the formatted error message.
@@ -1093,10 +1092,10 @@ object ResolutionError {
       import formatter._
       s""">> Mismatched arity.
          |
-         |The operation $op expects ${count(expected, Some("parameter"))},
-         |but ${count(actual, None, are=true)} provided here.
+         |The operation $op expects ${Grammar.count(expected, Some("parameter"))},
+         |but ${Grammar.count(actual, None, are=true)} provided here.
          |
-         |${code(loc, s"expected ${count(expected, Some("parameter"))} but found $actual")}
+         |${code(loc, s"expected ${Grammar.count(expected, Some("parameter"))} but found $actual")}
          |""".stripMargin
     }
 

--- a/main/src/ca/uwaterloo/flix/util/Grammar.scala
+++ b/main/src/ca/uwaterloo/flix/util/Grammar.scala
@@ -31,7 +31,7 @@ object Grammar {
     * Returns a string representation of a count of `n` things called `name` that optionally `are` something.
     * When `n` is 1, the sentence will be singular, otherwise it will be plural.
     *
-    * It is assumes that `name` is a regular noun, that can be pluralized by appending an "s".
+    * It is assumed that `name` is a regular noun, that can be pluralized by appending an "s".
     *
     * For example, given `count(1, Some("cat"), are=true)` returns "1 cat is",
     * and given `count(2, Some("cat"), are=true)` returns "2 cats are".

--- a/main/src/ca/uwaterloo/flix/util/Grammar.scala
+++ b/main/src/ca/uwaterloo/flix/util/Grammar.scala
@@ -28,36 +28,33 @@ object Grammar {
   }
 
   /**
-    * Returns a string representation of a count of `n` things called `name` that optionally `are` something.
-    * When `n` is 1, the sentence will be singular, otherwise it will be plural.
+    * Returns a string representing `n` things called `name`, with the correct plural form,
+    * assuming that `name` is a regular noun that can be pluralized by appending an "s".
     *
-    * It is assumed that `name` is a regular noun, that can be pluralized by appending an "s".
-    *
-    * For example, given `count(1, Some("cat"), are=true)` returns "1 cat is",
-    * and given `count(2, Some("cat"), are=true)` returns "2 cats are".
-    *
-    * The `name` argument is optional, for example `count(2, None, are=true)` returns "2 are".
-    *
-    * The `are` parameter can be false (default), for example `count(3, Some("cat"))` returns "3 cats".
+    * For example:
+    *  - `n_things(1, "cat")` -> "1 cat"
+    *  - `n_things(2, "cat")` -> "2 cats"
     */
-  def count(n: Int, name: Option[String], are: Boolean = false): String = {
+  def n_things(n: Int, name: String): String = {
     val plural = n != 1
-    var s = n.toString
+    if (plural)
+      s"$n ${name}s"
+    else
+      s"$n $name"
+  }
 
-    name match {
-      case Some(ns) =>
-        s += " " + ns
-        if (plural)
-          s += "s"
-      case None => // Do nothing
-    }
-
-    if (are)
-      if (plural)
-        s += " are"
-      else
-        s += " is"
-
-    s
+  /**
+    * Returns a string representing that `n` things 'are', with the correct plural form.
+    *
+    * For example:
+    *  - `n_are(1)` -> "1 is"
+    *  - `n_are(2)` -> "2 are"
+    */
+  def n_are(n: Int): String = {
+    val plural = n != 1
+    if (plural)
+      s"$n are"
+    else
+      s"$n is"
   }
 }

--- a/main/src/ca/uwaterloo/flix/util/Grammar.scala
+++ b/main/src/ca/uwaterloo/flix/util/Grammar.scala
@@ -44,10 +44,12 @@ object Grammar {
     val plural = n != 1
     var s = n.toString
 
-    name.foreach { ns =>
-      s += " " + ns
-      if (plural)
-        s += "s"
+    name match {
+      case Some(ns) =>
+        s += " " + ns
+        if (plural)
+          s += "s"
+      case None => // Do nothing
     }
 
     if (are)

--- a/main/src/ca/uwaterloo/flix/util/Grammar.scala
+++ b/main/src/ca/uwaterloo/flix/util/Grammar.scala
@@ -26,4 +26,36 @@ object Grammar {
       case (end, suffix) if n.toString.endsWith(end) => n.toString + suffix
     }.getOrElse(n.toString + defaultSuffix)
   }
+
+  /**
+    * Returns a string representation of a count of `n` things called `name` that optionally `are` something.
+    * When `n` is 1, the sentence will be singular, otherwise it will be plural.
+    *
+    * It is assumes that `name` is a regular noun, that can be pluralized by appending an "s".
+    *
+    * For example, given `count(1, Some("cat"), are=true)` returns "1 cat is",
+    * and given `count(2, Some("cat"), are=true)` returns "2 cats are".
+    *
+    * The `name` argument is optional, for example `count(2, None, are=true)` returns "2 are".
+    *
+    * The `are` parameter can be false (default), for example `count(3, Some("cat"))` returns "3 cats".
+    */
+  def count(n: Int, name: Option[String], are: Boolean = false): String = {
+    val plural = n != 1
+    var s = n.toString
+
+    name.foreach { ns =>
+      s += " " + ns
+      if (plural)
+        s += "s"
+    }
+
+    if (are)
+      if (plural)
+        s += " are"
+      else
+        s += " is"
+
+    s
+  }
 }


### PR DESCRIPTION
Fixes #8314