### PR TITLE
docs: consistent `size` and `length` wording

### DIFF
--- a/examples/larger-examples/restrictable-variants/sequences.flix
+++ b/examples/larger-examples/restrictable-variants/sequences.flix
@@ -96,7 +96,7 @@ mod Seq {
     }
 
     ///
-    /// Returns the length of `l`.
+    /// Returns the number of elements in `l`.
     ///
     pub def length(l: Seq[s][a]): Int32 = choose l{
         case Seq.Nil => 0

--- a/main/src/library/Array.flix
+++ b/main/src/library/Array.flix
@@ -130,7 +130,7 @@ mod Array {
     pub def nonEmpty(a: Array[a, r]): Bool \ r = not isEmpty(a)
 
     ///
-    /// Returns the length of the array `a`.
+    /// Returns the number of elements in the array `a`.
     ///
     pub def length(a: Array[a, r]): Int32 \ r = $ARRAY_LENGTH$(a)
 

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -237,7 +237,7 @@ mod Chain {
     }
 
     ///
-    /// Returns the length of `c`.
+    /// Returns the number of elements in `c`.
     ///
     pub def length(c: Chain[a]): Int32 = foldRight((_, acc) -> acc + 1, 0, c)
 

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -215,7 +215,7 @@ mod DelayList {
     }
 
     ///
-    /// Returns the length of `l`.
+    /// Returns the number of elements in `l`.
     ///
     /// Forces the entire list `l`.
     ///

--- a/main/src/library/File.flix
+++ b/main/src/library/File.flix
@@ -93,7 +93,7 @@ mod File {
         })
 
     ///
-    /// Get the length of an open file.
+    /// Returns the number of bytes in the file.
     ///
     pub def length(f: File): Result[IOError, Int64] \ IO =
         IOError.tryCatch(_ -> {

--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -44,7 +44,7 @@ pub trait Foldable[t : Type -> Type] {
     pub def foldRightWithCont(f: (a, Unit -> b \ ef) -> b \ ef, s: b, t: t[a]): b \ (ef + Foldable.Aef[t])
 
     ///
-    /// Returns the length of `t`, i.e. the number of times it can be folded over.
+    /// Returns the number of elements in `t`.
     ///
     pub def length(t: t[a]): Int32 \ Foldable.Aef[t] =
         Foldable.foldLeft((acc, _) -> acc + 1, 0, t)

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -192,7 +192,7 @@ mod List {
     }
 
     ///
-    /// Returns the length of `l`.
+    /// Returns the number of elements in `l`.
     ///
     pub def length(l: List[a]): Int32 =
         def loop(ll, acc) = match ll {

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -156,7 +156,7 @@ mod Map {
         minSize >= 1024
 
     ///
-    /// Returns the size of `m`.
+    /// Returns the number of keys in `m`.
     ///
     pub def size(m: Map[k, v]): Int32 =
         let Map(xs) = m;

--- a/main/src/library/MutMap.flix
+++ b/main/src/library/MutMap.flix
@@ -193,7 +193,7 @@ mod MutMap {
         Map.valuesOf(Ref.get(mm))
 
     ///
-    /// Returns the size of the mutable map `m`.
+    /// Returns the number of keys in the mutable map `m`.
     ///
     pub def size(m: MutMap[k, v, r]): Int32 \ r =
         let MutMap(_, mm) = m;

--- a/main/src/library/MutSet.flix
+++ b/main/src/library/MutSet.flix
@@ -185,7 +185,7 @@ mod MutSet {
         Set.maximumBy(cmp, Ref.get(ms))
 
     ///
-    /// Returns the size of the mutable set `s`.
+    /// Returns the number of elements in the mutable set `s`.
     ///
     pub def size(s: MutSet[a, r]): Int32 \ r =
         let MutSet(_, ms) = s;

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -240,7 +240,7 @@ mod Nec {
     }
 
     ///
-    /// Returns the length of `c`.
+    /// Returns the number of elements in `c`.
     ///
     pub def length(c: Nec[a]): Int32 = foldRight((_, acc) -> acc + 1, 0, c)
 

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -186,7 +186,7 @@ mod Nel {
     }
 
     ///
-    /// Returns the length of `l`.
+    /// Returns the number of elements in `l`.
     ///
     pub def length(l: Nel[a]): Int32 = match l {
         case Nel(_, xs) => 1 + List.length(xs)

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -147,7 +147,7 @@ mod Set {
         minSize >= 1024
 
     ///
-    /// Returns the size of `s`.
+    /// Returns the number of elements in `s`.
     ///
     pub def size(s: Set[a]): Int32 =
         let Set(t) = s;

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -69,7 +69,7 @@ mod String {
     pub def nonEmpty(s: String): Bool = not isEmpty(s)
 
     ///
-    /// Returns the length of the string `s`.
+    /// Returns the number of characters the string `s`.
     ///
     pub def length(s: String): Int32 =
         unsafe s.length()

--- a/main/src/library/StringBuilder.flix
+++ b/main/src/library/StringBuilder.flix
@@ -119,7 +119,7 @@ mod StringBuilder {
         iterator(rc1, sb) |> Iterator.zipWithIndex
 
     ///
-    /// Return the length of the StringBuilder `sb`.
+    /// Return the number of characters in the StringBuilder `sb`.
     ///
     pub def length(sb: StringBuilder[r]): Int32 \ r =
         let StringBuilder(msb) = sb;

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -235,7 +235,7 @@ mod Vector {
     pub def nonEmpty(v: Vector[a]): Bool = not isEmpty(v)
 
     ///
-    /// Returns the length of the vector `v`.
+    /// Returns the number of elements in the vector `v`.
     ///
     pub def length(v: Vector[a]): Int32 = $VECTOR_LENGTH$(v)
 


### PR DESCRIPTION
The remaining inconsistencies are here because of other per-file consistencies about naming the subject fx.