### PR TITLE
ci: give IDE tests their own concurrency group

### DIFF
--- a/.github/workflows/ide-tests.yaml
+++ b/.github/workflows/ide-tests.yaml
@@ -5,7 +5,7 @@ on: [pull_request, merge_group]
 # Cancel previous runs if the PR is updated
 concurrency:
   cancel-in-progress: true
-  group: build-${{ github.ref }}
+  group: ide-tests-${{ github.ref }}
 
 jobs:
   vscode:


### PR DESCRIPTION
This fixes interference between the normal testing suite and the IDE testing suite.