### PR TITLE
fix: reenable test

### DIFF
--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -764,8 +764,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[TypeError.MethodNotFound](result)
   }
 
-  // succeeds now
-  ignore("UndefinedJvmMethod.07") {
+  test("UndefinedJvmMethod.07") {
     val input =
       """
         |import java.util.Arrays
@@ -774,7 +773,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
         |}
         |""".stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[TypeError.StaticMethodNotFound](result)
+    expectError[TypeError](result)
   }
 
   test("MismatchingType.01") {


### PR DESCRIPTION
previously the test said method not found because of the simplified logic in `isKnown` but now (#8497) it correctly doesn't touch the JVM constraint (because of the type variable in the array) so its just some mismatched types