### PR TITLE
feat: rerun typer on errors

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Scheme.scala
@@ -145,7 +145,7 @@ object Scheme {
     // Resolve what we can from the new econstrs
     // TODO ASSOC-TYPES probably these should be narrow from the start
     val tconstrs2_0 = econstrs2_0.map { case Ast.BroadEqualityConstraint(t1, t2) => TypeConstraint.Equality(t1, t2, Provenance.Match(t1, t2, SourceLocation.Unknown)) }
-    val (subst, econstrs2_1) = ConstraintSolver.resolve(tconstrs2_0, Substitution.empty, RigidityEnv.empty)(scope, tenv0, eenv0, flix) match {
+    val (subst, econstrs2_1) = ConstraintSolver.resolve(tconstrs2_0, Substitution.empty, RigidityEnv.empty, sorting = true)(scope, tenv0, eenv0, flix) match {
       case Result.Ok(ResolutionResult(newSubst, newConstrs, _)) =>
         (newSubst, newConstrs)
       case _ => throw InternalCompilerException("unexpected inconsistent type constraints", SourceLocation.Unknown)
@@ -180,7 +180,7 @@ object Scheme {
     val cconstrs = sc1.tconstrs.map { case Ast.TraitConstraint(head, arg, loc) => TypeConstraint.Trait(head.sym, arg, loc) }
     val econstrs = sc1.econstrs.map { case Ast.BroadEqualityConstraint(t1, t2) => TypeConstraint.Equality(t1, t2, Provenance.Match(t1, t2, SourceLocation.Unknown)) }
     val baseConstr = TypeConstraint.Equality(sc1.base, tpe2, Provenance.Match(sc1.base, tpe2, SourceLocation.Unknown))
-    ConstraintSolver.resolve(baseConstr :: cconstrs ::: econstrs, subst, renv)(scope, cenv, eenv, flix) match {
+    ConstraintSolver.resolve(baseConstr :: cconstrs ::: econstrs, subst, renv, sorting = true)(scope, cenv, eenv, flix) match {
       // We succeed only if there are no leftover constraints
       case Result.Ok(ResolutionResult(_, Nil, _)) => true
       case _ => false

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -165,16 +165,14 @@ object Typer {
         case defn =>
           // Use sub-effecting for defs if the appropriate option is set
           val open = flix.options.xsubeffecting >= SubEffectLevel.LambdasAndDefs
-          val res = visitDef(defn, tconstrs0 = Nil, RigidityEnv.empty, root, traitEnv, eqEnv, open)
-          if (res.errors.isEmpty) res
-          else visitDef(defn, tconstrs0 = Nil, RigidityEnv.empty, root, traitEnv, eqEnv, open, sorting = false)
+          visitDef(defn, tconstrs0 = Nil, RigidityEnv.empty, root, traitEnv, eqEnv, open)
       })(_ ++ freshDefs)
     }
 
   /**
     * Reconstructs types in the given def.
     */
-  private def visitDef(defn: KindedAst.Def, tconstrs0: List[Ast.TraitConstraint], renv0: RigidityEnv, root: KindedAst.Root, traitEnv: Map[Symbol.TraitSym, Ast.TraitContext], eqEnv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], open: Boolean, sorting: Boolean = true)(implicit flix: Flix): Validation[TypedAst.Def, TypeError] = {
+  private def visitDef(defn: KindedAst.Def, tconstrs0: List[Ast.TraitConstraint], renv0: RigidityEnv, root: KindedAst.Root, traitEnv: Map[Symbol.TraitSym, Ast.TraitContext], eqEnv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef], open: Boolean)(implicit flix: Flix): Validation[TypedAst.Def, TypeError] = {
     implicit val scope: Scope = Scope.Top
     implicit val r: KindedAst.Root = root
     implicit val context: TypeContext = new TypeContext
@@ -184,7 +182,7 @@ object Typer {
     // If open is set and the annotated effect is not pure, use a sub-effecting
     val eff = if (!open || defn.spec.eff == Type.Pure) eff0 else Type.mkUnion(eff0, Type.freshVar(Kind.Eff, eff0.loc), eff0.loc)
     val infResult = ConstraintSolver.InfResult(infTconstrs, tpe, eff, infRenv)
-    val substVal = ConstraintSolver.visitDef(defn, infResult, renv0, tconstrs0, traitEnv, eqEnv, root, sorting)
+    val substVal = ConstraintSolver.visitDef(defn, infResult, renv0, tconstrs0, traitEnv, eqEnv, root)
     val assocVal = checkAssocTypes(defn.spec, tconstrs0, traitEnv)
     mapN(substVal, assocVal) {
       case (subst, _) => TypeReconstruction.visitDef(defn, subst)


### PR DESCRIPTION
Simple idea: if there is a type error in a function, rerun without constraint sorting. This transforms this program (#7598)
```scala
def example(rc: Region[r]): Int32 = {
    let _r = Ref.fresh(rc, 42);
    42
}
```
currently has error
```
>> Unable to unify the effect formulas: 'Pure' and 'r'.

2 |     let _r = Ref.fresh(rc, 42);
                           ^^
                           mismatched effect formulas.

Type One: Region[Pure]
Type Two: Region[r]
```
in this PR it has error
```
>> Expected type: 'Pure' but found type: 'r'.

1 |> def example(rc: Region[r]): Int32 = {
2 |>     let _r = Ref.fresh(rc, 42);
3 |>     42
4 |> }

expression has unexpected type.
```
Fixes #8509