### PR TITLE
fix: null match on tester

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/Tester.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Tester.scala
@@ -147,6 +147,8 @@ object Tester {
             )
             terminal.flush()
             finished = true
+
+          case null => () // tester have not started yet, retry
         }
       }
     }


### PR DESCRIPTION
If you're unlucky or have slow tests, the reporter might get null before the tester has inserted an element yet