### PR TITLE
refactor: better completion priorities based on occurances in std lib

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
@@ -97,19 +97,25 @@ object KeywordCompleter {
     */
   def getOtherKeywords: Iterable[Completion] =
     List(
-      Completion.KeywordCompletion("with"             , Priority.Highest),
-      Completion.KeywordCompletion("law"              , Priority.Higher),
-      Completion.KeywordCompletion("@Test"            , Priority.High),
-      Completion.KeywordCompletion("where"            , Priority.Low),
-      Completion.KeywordCompletion("fix"              , Priority.Low),
+      // @
+      Completion.KeywordCompletion("@Test"            , Priority.Highest),
+      Completion.KeywordCompletion("@ParallelWhenPure", Priority.Low),
+      Completion.KeywordCompletion("@Parallel"        , Priority.Higher),
+      Completion.KeywordCompletion("@LazyWhenPure"    , Priority.Lower),
+      Completion.KeywordCompletion("@Lazy"            , Priority.High),
       Completion.KeywordCompletion("@Deprecated"      , Priority.Lowest),
-      Completion.KeywordCompletion("@Parallel"        , Priority.Lowest),
-      Completion.KeywordCompletion("@ParallelWhenPure", Priority.Lowest),
-      Completion.KeywordCompletion("@Lazy"            , Priority.Lowest),
-      Completion.KeywordCompletion("@LazyWhenPure"    , Priority.Lowest),
-      Completion.KeywordCompletion("Record"           , Priority.Lowest),
-      Completion.KeywordCompletion("redef"            , Priority.Lowest),
-      Completion.KeywordCompletion("Schema"           , Priority.Lowest),
+      // S
+      Completion.KeywordCompletion("Schema"           , Priority.Default),
+      // F
+      Completion.KeywordCompletion("fix"              , Priority.Default),
+      // L
+      Completion.KeywordCompletion("law"              , Priority.Default),
+      // R
+      Completion.KeywordCompletion("redef"            , Priority.High),
+      Completion.KeywordCompletion("Record"           , Priority.Low),
+      // W
+      Completion.KeywordCompletion("with"             , Priority.High),
+      Completion.KeywordCompletion("where"            , Priority.Low),
     )
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
@@ -62,42 +62,62 @@ object KeywordCompleter {
     */
   def getExprKeywords: Iterable[Completion] =
     List(
-      "and",
-      "as",
-      "def",
-      "discard",
-      "do",
-      "else",
-      "false",
-      "forA",
-      "forM",
-      "force",
-      "foreach",
-      "from",
-      "if",
-      "inject",
-      "into",
-      "lazy",
-      "let",
-      "match",
-      "new",
-      "not",
-      "or",
-      "par",
-      "query",
-      "region",
-      "select",
-      "solve",
-      "spawn",
-      "struct",
-      "true",
-      "try",
-      "typematch",
-      "unsafe",
-      "use",
-      "without",
-      "yield"
-    ) map (name => Completion.KeywordCompletion(name, Priority.Lower))
+      // A
+      Completion.KeywordCompletion("and"      , Priority.High),
+      Completion.KeywordCompletion("as"       , Priority.Low),
+      // D
+      Completion.KeywordCompletion("def"      , Priority.Higher),
+      Completion.KeywordCompletion("discard"  , Priority.Low),
+      Completion.KeywordCompletion("do"       , Priority.High),
+      // E
+      Completion.KeywordCompletion("else"     , Priority.Default),
+      // F
+      Completion.KeywordCompletion("false"    , Priority.Higher),
+      Completion.KeywordCompletion("forA"     , Priority.Lowest),
+      Completion.KeywordCompletion("forM"     , Priority.Low),
+      Completion.KeywordCompletion("force"    , Priority.High),
+      Completion.KeywordCompletion("foreach"  , Priority.Lower),
+      Completion.KeywordCompletion("from"     , Priority.Highest),
+      // I
+      Completion.KeywordCompletion("if"       , Priority.Higher),
+      Completion.KeywordCompletion("inject"   , Priority.Low),
+      Completion.KeywordCompletion("into"     , Priority.High),
+      // L
+      Completion.KeywordCompletion("lazy"     , Priority.Low),
+      Completion.KeywordCompletion("let"      , Priority.High),
+      // M
+      Completion.KeywordCompletion("match"    , Priority.Default),
+      // N
+      Completion.KeywordCompletion("new"      , Priority.Low),
+      Completion.KeywordCompletion("not"      , Priority.High),
+      // O
+      Completion.KeywordCompletion("or"       , Priority.Default),
+      // P
+      Completion.KeywordCompletion("par"      , Priority.Default),
+      // Q
+      Completion.KeywordCompletion("query"    , Priority.Default),
+      // R
+      Completion.KeywordCompletion("region"   , Priority.Default),
+      // S
+      Completion.KeywordCompletion("select"   , Priority.Higher),
+      Completion.KeywordCompletion("solve"    , Priority.High),
+      Completion.KeywordCompletion("spawn"    , Priority.Low),
+      Completion.KeywordCompletion("struct"   , Priority.Lower),
+      // T
+      Completion.KeywordCompletion("true"     , Priority.Higher),
+      Completion.KeywordCompletion("try"      , Priority.High),
+      Completion.KeywordCompletion("typematch", Priority.Low),
+      // U    
+      // experitments on occurances in stdlib shows *exact* same amount of
+      // occurances of these two. However, I'm fairly confident that
+      // `use` would occur much more often in most programs.
+      Completion.KeywordCompletion("unsafe"   , Priority.Low),
+      Completion.KeywordCompletion("use"      , Priority.High),
+      // W
+      Completion.KeywordCompletion("without"  , Priority.Default),
+      // Y
+      Completion.KeywordCompletion("yield"    , Priority.Default)
+    )
            
   /**
     * Miscellaneous keywords.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
@@ -102,14 +102,13 @@ object KeywordCompleter {
       Completion.KeywordCompletion("select"   , Priority.Higher),
       Completion.KeywordCompletion("solve"    , Priority.High),
       Completion.KeywordCompletion("spawn"    , Priority.Low),
-      Completion.KeywordCompletion("struct"   , Priority.Lower),
       // T
       Completion.KeywordCompletion("true"     , Priority.Higher),
       Completion.KeywordCompletion("try"      , Priority.High),
       Completion.KeywordCompletion("typematch", Priority.Low),
       // U    
-      // experitments on occurances in stdlib shows *exact* same amount of
-      // occurances of these two. However, I'm fairly confident that
+      // experiments on occurrences in stdlib shows the *exact* same amount of
+      // occurrences of these two. However, I'm fairly confident that
       // `use` would occur much more often in most programs.
       Completion.KeywordCompletion("unsafe"   , Priority.Low),
       Completion.KeywordCompletion("use"      , Priority.High),
@@ -125,24 +124,24 @@ object KeywordCompleter {
   def getOtherKeywords: Iterable[Completion] =
     List(
       // @
-      Completion.KeywordCompletion("@Test"            , Priority.Highest),
-      Completion.KeywordCompletion("@ParallelWhenPure", Priority.Low),
-      Completion.KeywordCompletion("@Parallel"        , Priority.Higher),
-      Completion.KeywordCompletion("@LazyWhenPure"    , Priority.Lower),
-      Completion.KeywordCompletion("@Lazy"            , Priority.High),
       Completion.KeywordCompletion("@Deprecated"      , Priority.Lowest),
-      // S
-      Completion.KeywordCompletion("Schema"           , Priority.Default),
+      Completion.KeywordCompletion("@Lazy"            , Priority.High),
+      Completion.KeywordCompletion("@LazyWhenPure"    , Priority.Lower),
+      Completion.KeywordCompletion("@Parallel"        , Priority.Higher),
+      Completion.KeywordCompletion("@ParallelWhenPure", Priority.Low),
+      Completion.KeywordCompletion("@Test"            , Priority.Highest),
       // F
       Completion.KeywordCompletion("fix"              , Priority.Default),
       // L
       Completion.KeywordCompletion("law"              , Priority.Default),
       // R
-      Completion.KeywordCompletion("redef"            , Priority.High),
       Completion.KeywordCompletion("Record"           , Priority.Low),
+      Completion.KeywordCompletion("redef"            , Priority.High),
+      // S
+      Completion.KeywordCompletion("Schema"           , Priority.Default),
       // W
-      Completion.KeywordCompletion("with"             , Priority.High),
       Completion.KeywordCompletion("where"            , Priority.Low),
+      Completion.KeywordCompletion("with"             , Priority.High),
     )
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
@@ -54,7 +54,7 @@ object KeywordCompleter {
     */
   def getEnumKeywords: Iterable[Completion] =
     List(
-      Completion.KeywordCompletion("case", Priority.Low)
+      Completion.KeywordCompletion("case", Priority.Default)
     )
 
   /**
@@ -130,7 +130,7 @@ object KeywordCompleter {
     */
   def getTraitKeywords: Iterable[Completion] =
     List(
-      Completion.KeywordCompletion("def", Priority.Lower),
-      Completion.KeywordCompletion("pub", Priority.Lower),
+      Completion.KeywordCompletion("def", Priority.Default),
+      Completion.KeywordCompletion("pub", Priority.Default),
     )
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KeywordCompleter.scala
@@ -29,17 +29,24 @@ object KeywordCompleter {
     */
   def getDeclKeywords: Iterable[Completion] =
     List(
-      Completion.KeywordCompletion("def"      , Priority.Highest),
-      Completion.KeywordCompletion("pub"      , Priority.Higher),
+      // D
+      Completion.KeywordCompletion("def"      , Priority.Default),
+      // E
+      Completion.KeywordCompletion("eff"      , Priority.Low),
       Completion.KeywordCompletion("enum"     , Priority.High),
-      Completion.KeywordCompletion("type"     , Priority.High),
+      // I
+      Completion.KeywordCompletion("import"   , Priority.Low),
       Completion.KeywordCompletion("instance" , Priority.High),
-      Completion.KeywordCompletion("mod"      , Priority.Low),
-      Completion.KeywordCompletion("eff"      , Priority.Lower),
-      Completion.KeywordCompletion("struct"   , Priority.Lower),
-      Completion.KeywordCompletion("sealed"   , Priority.Lowest),
-      Completion.KeywordCompletion("trait"    , Priority.Lowest),
-      Completion.KeywordCompletion("import"   , Priority.Lowest),
+      // M
+      Completion.KeywordCompletion("mod"      , Priority.Default),
+      // P
+      Completion.KeywordCompletion("pub"      , Priority.Default),
+      // S
+      Completion.KeywordCompletion("sealed"   , Priority.Low),
+      Completion.KeywordCompletion("struct"   , Priority.High),
+      // T
+      Completion.KeywordCompletion("trait"    , Priority.Low),
+      Completion.KeywordCompletion("type"     , Priority.High),
     )
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Priority.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Priority.scala
@@ -36,6 +36,7 @@ object Priority {
   case object Highest extends Priority
   case object Higher extends Priority
   case object High extends Priority
+  case object Default extends Priority
   case object Low extends Priority
   case object Lower extends Priority
   case object Lowest extends Priority
@@ -55,8 +56,9 @@ object Priority {
   	case Priority.Highest => s"1$label"
   	case Priority.Higher  => s"2$label"
   	case Priority.High    => s"3$label"
-  	case Priority.Low     => s"4$label"
-  	case Priority.Lower   => s"5$label"
-  	case Priority.Lowest  => s"6$label"
+  	case Priority.Default => s"4$label"
+  	case Priority.Low     => s"5$label"
+  	case Priority.Lower   => s"6$label"
+  	case Priority.Lowest  => s"7$label"
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeBuiltinCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeBuiltinCompleter.scala
@@ -32,23 +32,33 @@ object TypeBuiltinCompleter {
     */
   def getCompletions: Iterable[Completion] =
     List(
-      Completion.TypeBuiltinCompletion("Unit"      , Priority.High),
-      Completion.TypeBuiltinCompletion("Bool"      , Priority.High),
-      Completion.TypeBuiltinCompletion("Char"      , Priority.High),
-      Completion.TypeBuiltinCompletion("Float64"   , Priority.High),
-      Completion.TypeBuiltinCompletion("BigDecimal", Priority.High),
-      Completion.TypeBuiltinCompletion("Int32"     , Priority.High),
-      Completion.TypeBuiltinCompletion("Int64"     , Priority.High),
+      // A
+      polycompletion("Array"   , List("a", "r")    , Priority.Default),
+      // B
+      Completion.TypeBuiltinCompletion("Bool"      , Priority.Higher),
       Completion.TypeBuiltinCompletion("BigInt"    , Priority.High),
+      Completion.TypeBuiltinCompletion("BigDecimal", Priority.Low),
+      // C
+      Completion.TypeBuiltinCompletion("Char"      , Priority.Default),
+      // F
+      Completion.TypeBuiltinCompletion("Float32"   , Priority.High),
+      Completion.TypeBuiltinCompletion("Float64"   , Priority.Low),
+      // I
+      Completion.TypeBuiltinCompletion("Int16"     , Priority.Low),
+      Completion.TypeBuiltinCompletion("Int32"     , Priority.Higher),
+      Completion.TypeBuiltinCompletion("Int64"     , Priority.High),
+      Completion.TypeBuiltinCompletion("Int8"      , Priority.Lower),
+      // L
+      polycompletion("Lazy"    , List("t")         , Priority.Default),
+      // R
+      polycompletion("Receiver", List("t", "r")    , Priority.Default),
+      // S
       Completion.TypeBuiltinCompletion("String"    , Priority.High),
-      Completion.TypeBuiltinCompletion("Int8"      , Priority.Lowest),
-      Completion.TypeBuiltinCompletion("Int16"     , Priority.Lowest),
-      Completion.TypeBuiltinCompletion("Float32"   , Priority.Lowest),
-      Completion.TypeBuiltinCompletion("Void"      , Priority.Lowest),
-      polycompletion("Array"   , List("a", "r")    , Priority.Lower),
-      polycompletion("Vector"  , List("a")         , Priority.Lower),
-      polycompletion("Sender"  , List("t", "r")    , Priority.Lower),
-      polycompletion("Receiver", List("t", "r")    , Priority.Lower),
-      polycompletion("Lazy"    , List("t")         , Priority.Lower),
+      polycompletion("Sender"  , List("t", "r")    , Priority.Low),
+      // U
+      Completion.TypeBuiltinCompletion("Unit"      , Priority.Default),
+      // V
+      Completion.TypeBuiltinCompletion("Void"      , Priority.Low),
+      polycompletion("Vector"  , List("a")         , Priority.High),
     )
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeBuiltinCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeBuiltinCompleter.scala
@@ -35,9 +35,9 @@ object TypeBuiltinCompleter {
       // A
       polycompletion("Array"   , List("a", "r")    , Priority.Default),
       // B
-      Completion.TypeBuiltinCompletion("Bool"      , Priority.Higher),
-      Completion.TypeBuiltinCompletion("BigInt"    , Priority.High),
       Completion.TypeBuiltinCompletion("BigDecimal", Priority.Low),
+      Completion.TypeBuiltinCompletion("BigInt"    , Priority.High),
+      Completion.TypeBuiltinCompletion("Bool"      , Priority.Higher),
       // C
       Completion.TypeBuiltinCompletion("Char"      , Priority.Default),
       // F
@@ -53,12 +53,12 @@ object TypeBuiltinCompleter {
       // R
       polycompletion("Receiver", List("t", "r")    , Priority.Default),
       // S
-      Completion.TypeBuiltinCompletion("String"    , Priority.High),
       polycompletion("Sender"  , List("t", "r")    , Priority.Low),
+      Completion.TypeBuiltinCompletion("String"    , Priority.High),
       // U
       Completion.TypeBuiltinCompletion("Unit"      , Priority.Default),
       // V
-      Completion.TypeBuiltinCompletion("Void"      , Priority.Low),
       polycompletion("Vector"  , List("a")         , Priority.High),
+      Completion.TypeBuiltinCompletion("Void"      , Priority.Low),
     )
 }


### PR DESCRIPTION
Introduces better priorities based on occurances in std lib. Before, the priorities were based on the occurances relative to all other items in the set. Now it's only relative to the items that share a first letter with them. For instance, while `def` is more common than `pub`, there's no reason to give one a higher priority than the other, because they would never both occur in list of suggestions anyways.

This PR also introduces `Priority.Default`.

Related to #8419.