### PR TITLE
refactor: move functions in TypeReduction

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeMethodCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeMethodCompleter.scala
@@ -19,8 +19,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.Index
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.MethodCompletion
 import ca.uwaterloo.flix.language.ast.{Name, Type, TypeConstructor, TypedAst}
-import ca.uwaterloo.flix.language.errors.TypeError
-import ca.uwaterloo.flix.language.phase.typer.TypeReduction
+import ca.uwaterloo.flix.language.phase.jvm.JvmOps
 
 import java.lang.reflect.Method
 
@@ -38,7 +37,7 @@ object InvokeMethodCompleter {
    * Returns all relevant methods available on the given `clazz`.
    */
   private def getMethods(clazz: Class[_]): List[Method] = {
-    val availableMethods = TypeReduction.getMethods(clazz)
+    val availableMethods = JvmOps.getMethods(clazz)
     // TODO: Add more filtering
     availableMethods.sortBy(_.getName)
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeStaticMethodCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeStaticMethodCompleter.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.MethodCompletion
 import ca.uwaterloo.flix.language.errors.ResolutionError
-import ca.uwaterloo.flix.language.phase.typer.TypeReduction
+import ca.uwaterloo.flix.language.phase.jvm.JvmOps
 
 import java.lang.reflect.{Method, Modifier}
 
@@ -29,7 +29,7 @@ object InvokeStaticMethodCompleter {
   }
 
   private def getMethods(clazz: Class[_]): List[Method] = {
-    val availableMethods = TypeReduction.getMethods(clazz)
+    val availableMethods = JvmOps.getMethods(clazz)
     val staticMethods = availableMethods.filter(m => Modifier.isStatic(m.getModifiers))
     staticMethods.sortBy(_.getName)
   }

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -1129,6 +1129,19 @@ object Type {
   }
 
   /**
+    * Returns true if the given type contains [[Type.JvmToType]] or [[Type.UnresolvedJvmType]] somewhere within it.
+    */
+  def hasJvmType(tpe: Type): Boolean = tpe match {
+    case Type.Var(_, _) => false
+    case Type.Cst(_, _) => false
+    case Type.Apply(tpe1, tpe2, _) => hasJvmType(tpe1) || hasJvmType(tpe2)
+    case Type.Alias(_, _, tpe, _) => hasJvmType(tpe)
+    case Type.AssocType(_, arg, _, _) => hasJvmType(arg)
+    case Type.JvmToType(_, _) => true
+    case Type.UnresolvedJvmType(_, _) => true
+  }
+
+  /**
     * Returns the Flix Type of a Java Class.
     *
     * Arrays are returned with the [[Type.IO]] region.

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -20,15 +20,16 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast.{BoundBy, VarText}
 import ca.uwaterloo.flix.language.ast.NamedAst.{Declaration, RestrictableChoosePattern}
 import ca.uwaterloo.flix.language.ast.ResolvedAst.Pattern.Record
-import ca.uwaterloo.flix.language.ast.UnkindedType._
+import ca.uwaterloo.flix.language.ast.UnkindedType.*
 import ca.uwaterloo.flix.language.ast.shared.Scope
-import ca.uwaterloo.flix.language.ast.{NamedAst, Symbol, _}
-import ca.uwaterloo.flix.language.dbg.AstPrinter._
-import ca.uwaterloo.flix.language.errors.ResolutionError._
+import ca.uwaterloo.flix.language.ast.{NamedAst, Symbol, *}
+import ca.uwaterloo.flix.language.dbg.AstPrinter.*
+import ca.uwaterloo.flix.language.errors.ResolutionError.*
 import ca.uwaterloo.flix.language.errors.{Recoverable, ResolutionError, Unrecoverable}
+import ca.uwaterloo.flix.language.phase.jvm.JvmOps
 import ca.uwaterloo.flix.language.phase.typer.TypeReduction
-import ca.uwaterloo.flix.util.Validation._
-import ca.uwaterloo.flix.util._
+import ca.uwaterloo.flix.util.Validation.*
+import ca.uwaterloo.flix.util.*
 import ca.uwaterloo.flix.util.collection.{Chain, ListMap, MapOps}
 
 import java.lang.reflect.{Constructor, Field, Method, Modifier}
@@ -3453,7 +3454,7 @@ private def getRestrictableEnumIfAccessible(enum0: NamedAst.Declaration.Restrict
       }
     } catch {
       case ex: NoSuchMethodException =>
-        val candidateMethods = TypeReduction.getMethods(clazz).filter(m => m.getName == methodName)
+        val candidateMethods = JvmOps.getMethods(clazz).filter(m => m.getName == methodName)
         Result.Err(ResolutionError.UndefinedJvmMethod(clazz.getName, methodName, static, signature, candidateMethods, loc))
       // ClassNotFoundException:  Cannot happen because we already have the `Class` object.
       // NoClassDefFoundError:    Cannot happen because we already have the `Class` object.

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -11,6 +11,7 @@ import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.SafetyError
 import ca.uwaterloo.flix.language.errors.SafetyError.*
+import ca.uwaterloo.flix.language.phase.jvm.JvmOps
 import ca.uwaterloo.flix.language.phase.typer.TypeReduction
 import ca.uwaterloo.flix.util.{ParOps, Validation}
 
@@ -1029,7 +1030,7 @@ object Safety {
     * Get a Set of MethodSignatures representing the methods of `clazz`. Returns a map to allow subsequent reverse lookup.
     */
   private def getJavaMethodSignatures(clazz: java.lang.Class[_]): Map[MethodSignature, java.lang.reflect.Method] = {
-    val methods = TypeReduction.getMethods(clazz).filterNot(isStaticMethod)
+    val methods = JvmOps.getMethods(clazz).filterNot(JvmOps.isStatic)
     methods.foldLeft(Map.empty[MethodSignature, java.lang.reflect.Method]) {
       case (acc, m) =>
         val signature = MethodSignature(m.getName, m.getParameterTypes.toList.map(Type.getFlixType), Type.getFlixType(m.getReturnType))
@@ -1060,11 +1061,5 @@ object Safety {
     */
   private def isAbstractMethod(m: java.lang.reflect.Method): Boolean =
     java.lang.reflect.Modifier.isAbstract(m.getModifiers)
-
-  /**
-    * Returns `true` if the given method `m` is static.
-    */
-  private def isStaticMethod(m: java.lang.reflect.Method): Boolean =
-    java.lang.reflect.Modifier.isStatic(m.getModifiers)
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Loader.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Loader.scala
@@ -85,7 +85,7 @@ object Loader {
     * Returns a map from names to method objects for the given class `clazz`.
     */
   private def methodsOf(clazz: Class[_]): Map[String, Method] = {
-    TypeReduction.getMethods(clazz).foldLeft(Map.empty[String, Method]) {
+    JvmOps.getMethods(clazz).foldLeft(Map.empty[String, Method]) {
       case (macc, method) =>
         if (method.isSynthetic)
           macc

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver.scala
@@ -269,7 +269,7 @@ object ConstraintSolver {
         (t2, p2) <- TypeReduction.simplify(tmin2, renv, prov.loc)
         ResolutionResult(subst, constrs, p) <-
           // A small hack to ensure that we do not add reducible types to the substitution.
-          if (TypeReduction.containsJvmTypes(t1) || TypeReduction.containsJvmTypes(t2)) {
+          if (Type.hasJvmType(t1) || Type.hasJvmType(t2)) {
             Result.Ok(ResolutionResult.constraints(List(TypeConstraint.Equality(t1, t2, prov)), p1 || p2))
           } else {
             resolveEquality(t1, t2, prov, renv, constr0.loc)


### PR DESCRIPTION
They are in logical order now and some functions are moved to `Type` or `JvmOps`

Related to #8574 

Follow up issue to clean up jvm interop logic in phases #8592