### PR TITLE
feat: thunk shorthand `-> exp`

### DIFF
--- a/examples/larger-examples/restrictable-variants/sequences.flix
+++ b/examples/larger-examples/restrictable-variants/sequences.flix
@@ -182,12 +182,12 @@ mod Seq {
     /// Optionally returns the first element of `l` that satisfies the predicate `f` when searching from right to left.
     ///
     pub def findRight(f: a -> Bool \ ef, l: Seq[s][a]): SOption[a] \ ef =
-        findRightHelper(f, l, () -> open_variant Seq.Nil)
+        findRightHelper(f, l, -> open_variant Seq.Nil)
 
     def findRightHelper(f: a -> Bool \ ef1, l: Seq[s][a], k: Unit -> SOption[a] \ ef2): SOption[a] \ {ef1, ef2} = choose* l {
         case Seq.Nil            => k()
         case Seq.One(x)         => if (f(x)) open_variant Seq.One(x) else k()
-        case Seq.Cons(x, xs)    => findRightHelper(f, xs, () -> if (f(x)) open_variant Seq.One(x) else k())
+        case Seq.Cons(x, xs)    => findRightHelper(f, xs, -> if (f(x)) open_variant Seq.One(x) else k())
     }
 
     ///
@@ -836,7 +836,7 @@ mod Seq {
     ///
     pub def iterator(rc: Region[r], xs: Seq[s][a]): Iterator[a, r, r] \ r =
         let ls = Ref.fresh(rc, open_variant_as Seq xs);
-        let next = () -> {
+        let next = -> {
             choose (Ref.get(ls)) {
                 case Seq.Nil            => None
                 case Seq.One(x)         => Ref.put(open_variant Seq.Nil, ls); Some(x)

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -391,6 +391,7 @@ sealed trait TokenKind {
          | TokenKind.KeywordNull
          | TokenKind.LiteralRegex
          | TokenKind.ParenL
+         | TokenKind.ArrowThinR
          | TokenKind.Underscore
          | TokenKind.NameLowerCase
          | TokenKind.NameUpperCase

--- a/main/src/library/Adaptor.flix
+++ b/main/src/library/Adaptor.flix
@@ -124,7 +124,7 @@ mod Adaptor {
         def next(x) = unchecked_cast(x.next() as _ \ r);
         let entries = entrySet(m);
         let iter = iterator(entries);
-        let getNext = () -> match hasNext(iter) {
+        let getNext = -> match hasNext(iter) {
             case true  => {
                 let entry = {let obj = next(iter); unchecked_cast(obj as Entry)};
                 let (k, v) = fromMapEntry((Proxy.Proxy: Proxy[k]), (Proxy.Proxy: Proxy[v]), entry);
@@ -140,13 +140,13 @@ mod Adaptor {
     pub def fromIterator(rc: Region[r], _: Proxy[a], iter: JIterator): Iterator[a, r, r] =
         def hasNext(x) = unchecked_cast(x.hasNext() as _ \ r);
         def next(x) = unchecked_cast(x.next() as _ \ r);
-        let step = () -> {
+        let step = -> {
             match hasNext(iter) {
                 case true  => next(iter) |> (o -> unchecked_cast(o as a)) |> Some
                 case false => None
             }
         };
-        let iterF = () -> (step());
+        let iterF = -> (step());
         Iterator.iterate(rc, iterF)
 
     ///

--- a/main/src/library/Benchmark.flix
+++ b/main/src/library/Benchmark.flix
@@ -49,7 +49,7 @@ mod Benchmark {
     ///
     @Experimental
     pub def defBenchmark(name: String, f: Unit -> a \ ef): Benchmark =
-        let fn = () -> {
+        let fn = -> {
             let _ = unchecked_cast(f() as _ \ IO);
             ()
         };

--- a/main/src/library/Benchmark/Bench.Chain.flix
+++ b/main/src/library/Benchmark/Bench.Chain.flix
@@ -71,13 +71,13 @@ mod Bench.Chain {
     /// ofArray                                                              ///
     ////////////////////////////////////////////////////////////////////////////
     pub def listOfArray(l: Array[Int32, r]): Benchmark =
-        defBenchmark("List.ofArray", () -> {
+        defBenchmark("List.ofArray", -> {
             l |>
             Array.toList
         })
 
     pub def chainOfArray(l: Array[Int32, r]): Benchmark =
-        defBenchmark("Chain.ofArray", () -> {
+        defBenchmark("Chain.ofArray", -> {
             l |>
             Array.toChain
         })
@@ -87,14 +87,14 @@ mod Bench.Chain {
     /// cons                                                                 ///
     ////////////////////////////////////////////////////////////////////////////
     pub def listCons(l: Array[Int32, r]): Benchmark =
-        defBenchmark("List.cons", () -> {
+        defBenchmark("List.cons", -> {
             l |>
             Array.toList |>
             listConsMany(Nil)
         })
 
     pub def chainCons(l: Array[Int32, r]): Benchmark =
-        defBenchmark("Chain.cons", () -> {
+        defBenchmark("Chain.cons", -> {
             l |>
             Array.toList |>
             chainConsMany(Chain.empty())
@@ -104,14 +104,14 @@ mod Bench.Chain {
     /// snoc                                                                 ///
     ////////////////////////////////////////////////////////////////////////////
     pub def listSnoc(l: Array[Int32, r]): Benchmark =
-        defBenchmark("List.snoc", () -> {
+        defBenchmark("List.snoc", -> {
             l |>
             Array.toList |>
             listSnocMany(Nil)
         })
 
     pub def chainSnoc(l: Array[Int32, r]): Benchmark =
-        defBenchmark("Chain.snoc", () -> {
+        defBenchmark("Chain.snoc", -> {
             l |>
             Array.toList |>
             chainSnocMany(Chain.empty())
@@ -121,13 +121,13 @@ mod Bench.Chain {
     /// append                                                               ///
     ////////////////////////////////////////////////////////////////////////////
     pub def listAppend(l: Array[Int32, r]): Benchmark =
-        defBenchmark("List.append", () -> {
+        defBenchmark("List.append", -> {
             let l1 = Array.toList(l);
             listAppendMany(l1, List.map(List.repeat(3), l1))
         })
 
     pub def chainAppend(l: Array[Int32, r]): Benchmark =
-        defBenchmark("Chain.append", () -> {
+        defBenchmark("Chain.append", -> {
             let c1 = Array.toChain(l);
             let l1 = Array.toList(l);
             chainAppendMany(c1, List.map(Chain.repeat(3), l1))

--- a/main/src/library/Benchmark/Bench.Fixpoint.flix
+++ b/main/src/library/Benchmark/Bench.Fixpoint.flix
@@ -28,11 +28,11 @@ mod Bench.Fixpoint {
         let facts12 = mkFacts(2 ** 12);
         let facts16 = mkFacts(2 ** 16);
         let facts20 = mkFacts(2 ** 20);
-        defBenchmark("Project (Int, Int) into A (n = ${2 ** 04})", () -> { project facts04 into A }) ::
-        defBenchmark("Project (Int, Int) into A (n = ${2 ** 08})", () -> { project facts08 into A }) ::
-        defBenchmark("Project (Int, Int) into A (n = ${2 ** 12})", () -> { project facts12 into A }) ::
-        defBenchmark("Project (Int, Int) into A (n = ${2 ** 16})", () -> { project facts16 into A }) ::
-        defBenchmark("Project (Int, Int) into A (n = ${2 ** 20})", () -> { project facts20 into A }) ::
+        defBenchmark("Project (Int, Int) into A (n = ${2 ** 04})", -> { project facts04 into A }) ::
+        defBenchmark("Project (Int, Int) into A (n = ${2 ** 08})", -> { project facts08 into A }) ::
+        defBenchmark("Project (Int, Int) into A (n = ${2 ** 12})", -> { project facts12 into A }) ::
+        defBenchmark("Project (Int, Int) into A (n = ${2 ** 16})", -> { project facts16 into A }) ::
+        defBenchmark("Project (Int, Int) into A (n = ${2 ** 20})", -> { project facts20 into A }) ::
         Nil
 
     pub def benchmarkSelect(): List[Benchmark] =
@@ -42,11 +42,11 @@ mod Bench.Fixpoint {
         let facts12 = mkFacts(2 ** 12);
         let facts16 = mkFacts(2 ** 16);
         let facts20 = mkFacts(2 ** 20);
-        defBenchmark("Select (Int, Int) from A (n = ${2 ** 04})", () -> { query facts04 select (x, y) from A(x, y) }) ::
-        defBenchmark("Select (Int, Int) from A (n = ${2 ** 08})", () -> { query facts08 select (x, y) from A(x, y) }) ::
-        defBenchmark("Select (Int, Int) from A (n = ${2 ** 12})", () -> { query facts12 select (x, y) from A(x, y) }) ::
-        defBenchmark("Select (Int, Int) from A (n = ${2 ** 16})", () -> { query facts16 select (x, y) from A(x, y) }) ::
-        defBenchmark("Select (Int, Int) from A (n = ${2 ** 20})", () -> { query facts20 select (x, y) from A(x, y) }) ::
+        defBenchmark("Select (Int, Int) from A (n = ${2 ** 04})", -> { query facts04 select (x, y) from A(x, y) }) ::
+        defBenchmark("Select (Int, Int) from A (n = ${2 ** 08})", -> { query facts08 select (x, y) from A(x, y) }) ::
+        defBenchmark("Select (Int, Int) from A (n = ${2 ** 12})", -> { query facts12 select (x, y) from A(x, y) }) ::
+        defBenchmark("Select (Int, Int) from A (n = ${2 ** 16})", -> { query facts16 select (x, y) from A(x, y) }) ::
+        defBenchmark("Select (Int, Int) from A (n = ${2 ** 20})", -> { query facts20 select (x, y) from A(x, y) }) ::
         Nil
 
     pub def benchmarkSolve(): List[Benchmark] =
@@ -64,15 +64,15 @@ mod Bench.Fixpoint {
         let edges512 = mkEdges(2 ** 9);
         //let edges1024 = mkEdges(2 ** 10);
         //let edges2048 = mkEdges(2 ** 11);
-        defBenchmark("Solve (Closure) (n = ${  8 ** 2})", () -> { solve p, edges8 }) ::
-        defBenchmark("Solve (Closure) (n = ${ 16 ** 2})", () -> { solve p, edges16 }) ::
-        defBenchmark("Solve (Closure) (n = ${ 32 ** 2})", () -> { solve p, edges32 }) ::
-        defBenchmark("Solve (Closure) (n = ${ 64 ** 2})", () -> { solve p, edges64 }) ::
-        defBenchmark("Solve (Closure) (n = ${128 ** 2})", () -> { solve p, edges128 }) ::
-        defBenchmark("Solve (Closure) (n = ${256 ** 2})", () -> { solve p, edges256 }) ::
-        defBenchmark("Solve (Closure) (n = ${512 ** 2})", () -> { solve p, edges512 }) ::
-        //defBenchmark("Solve (Closure) (n = ${1024 ** 2})", () -> { solve p, edges1024 }) ::
-        //defBenchmark("Solve (Closure) (n = ${2048 ** 2})", () -> { solve p, edges2048 }) ::
+        defBenchmark("Solve (Closure) (n = ${  8 ** 2})", -> { solve p, edges8 }) ::
+        defBenchmark("Solve (Closure) (n = ${ 16 ** 2})", -> { solve p, edges16 }) ::
+        defBenchmark("Solve (Closure) (n = ${ 32 ** 2})", -> { solve p, edges32 }) ::
+        defBenchmark("Solve (Closure) (n = ${ 64 ** 2})", -> { solve p, edges64 }) ::
+        defBenchmark("Solve (Closure) (n = ${128 ** 2})", -> { solve p, edges128 }) ::
+        defBenchmark("Solve (Closure) (n = ${256 ** 2})", -> { solve p, edges256 }) ::
+        defBenchmark("Solve (Closure) (n = ${512 ** 2})", -> { solve p, edges512 }) ::
+        //defBenchmark("Solve (Closure) (n = ${1024 ** 2})", -> { solve p, edges1024 }) ::
+        //defBenchmark("Solve (Closure) (n = ${2048 ** 2})", -> { solve p, edges2048 }) ::
         Nil
 
     pub def benchmarkCrossProduct2(): List[Benchmark] =
@@ -89,14 +89,14 @@ mod Bench.Fixpoint {
         let facts512  = mkA(512)  <+> mkB(512);
         let facts1024 = mkA(1024) <+> mkB(1024);
         //let facts2048 = mkA(2048) <+> mkB(2048);
-        defBenchmark("Solve (Cross Product 2) (n = ${  16 ** 2})", () -> { solve p,   facts16 }) ::
-        defBenchmark("Solve (Cross Product 2) (n = ${  32 ** 2})", () -> { solve p,   facts32 }) ::
-        defBenchmark("Solve (Cross Product 2) (n = ${  64 ** 2})", () -> { solve p,   facts64 }) ::
-        defBenchmark("Solve (Cross Product 2) (n = ${ 128 ** 2})", () -> { solve p,  facts128 }) ::
-        defBenchmark("Solve (Cross Product 2) (n = ${ 256 ** 2})", () -> { solve p,  facts256 }) ::
-        defBenchmark("Solve (Cross Product 2) (n = ${ 512 ** 2})", () -> { solve p,  facts512 }) ::
-        defBenchmark("Solve (Cross Product 2) (n = ${1024 ** 2})", () -> { solve p, facts1024 }) ::
-        //defBenchmark("Solve (Cross Product 2) (n = ${2048 ** 2})", () -> { solve p, facts2048 }) ::
+        defBenchmark("Solve (Cross Product 2) (n = ${  16 ** 2})", -> { solve p,   facts16 }) ::
+        defBenchmark("Solve (Cross Product 2) (n = ${  32 ** 2})", -> { solve p,   facts32 }) ::
+        defBenchmark("Solve (Cross Product 2) (n = ${  64 ** 2})", -> { solve p,   facts64 }) ::
+        defBenchmark("Solve (Cross Product 2) (n = ${ 128 ** 2})", -> { solve p,  facts128 }) ::
+        defBenchmark("Solve (Cross Product 2) (n = ${ 256 ** 2})", -> { solve p,  facts256 }) ::
+        defBenchmark("Solve (Cross Product 2) (n = ${ 512 ** 2})", -> { solve p,  facts512 }) ::
+        defBenchmark("Solve (Cross Product 2) (n = ${1024 ** 2})", -> { solve p, facts1024 }) ::
+        //defBenchmark("Solve (Cross Product 2) (n = ${2048 ** 2})", -> { solve p, facts2048 }) ::
         Nil
 
     pub def benchmarkCrossProduct3(): List[Benchmark] =
@@ -110,10 +110,10 @@ mod Bench.Fixpoint {
         let facts32   = mkA(32)  <+> mkB(32)  <+> mkC(32);
         let facts64   = mkA(64)  <+> mkB(64)  <+> mkC(64);
         //let facts128  = mkA(128) <+> mkB(128) <+> mkC(128);
-        defBenchmark("Solve (Cross Product 3) (n = ${  16 ** 3})", () -> { solve p,  facts16 }) ::
-        defBenchmark("Solve (Cross Product 3) (n = ${  32 ** 3})", () -> { solve p,  facts32 }) ::
-        defBenchmark("Solve (Cross Product 3) (n = ${  64 ** 3})", () -> { solve p,  facts64 }) ::
-        // defBenchmark("Solve (Cross Product 3) (n = ${  128 ** 3})", () -> { solve p,  facts128 }) ::
+        defBenchmark("Solve (Cross Product 3) (n = ${  16 ** 3})", -> { solve p,  facts16 }) ::
+        defBenchmark("Solve (Cross Product 3) (n = ${  32 ** 3})", -> { solve p,  facts32 }) ::
+        defBenchmark("Solve (Cross Product 3) (n = ${  64 ** 3})", -> { solve p,  facts64 }) ::
+        // defBenchmark("Solve (Cross Product 3) (n = ${  128 ** 3})", -> { solve p,  facts128 }) ::
         Nil
 
     pub def benchmarkSolveIntersect(): List[Benchmark] =
@@ -128,9 +128,9 @@ mod Bench.Fixpoint {
         let facts16 = mkA(2 ** 16) <+> mkB(2 ** 16);
         let facts20 = mkA(2 ** 20) <+> mkB(2 ** 20);
         //let facts21 = mkA(2 ** 21) <+> mkB(2 ** 21);
-        defBenchmark("Solve (Intersect) (n = ${2 **  4})", () -> { solve p, facts04 }) ::
-        defBenchmark("Solve (Intersect) (n = ${2 **  8})", () -> { solve p, facts08 }) ::
-        defBenchmark("Solve (Intersect) (n = ${2 ** 12})", () -> { solve p, facts12 }) ::
+        defBenchmark("Solve (Intersect) (n = ${2 **  4})", -> { solve p, facts04 }) ::
+        defBenchmark("Solve (Intersect) (n = ${2 **  8})", -> { solve p, facts08 }) ::
+        defBenchmark("Solve (Intersect) (n = ${2 ** 12})", -> { solve p, facts12 }) ::
         defBenchmark("Solve (Intersect) (n = ${2 ** 16})", () -> { solve p, facts16 }) ::
         defBenchmark("Solve (Intersect) (n = ${2 ** 20})", () -> { solve p, facts20 }) ::
         //defBenchmark("Solve (Intersect) (n = ${2 ** 21})", () -> { solve p, facts21 }) ::

--- a/main/src/library/Benchmark/Bench.Fusion.flix
+++ b/main/src/library/Benchmark/Bench.Fusion.flix
@@ -62,14 +62,14 @@ mod Bench.Fusion {
     /// length                                                               ///
     ////////////////////////////////////////////////////////////////////////////
     pub def listLength(l: Array[Int32, r]): Benchmark =
-        defBenchmark("List.length", () -> {
+        defBenchmark("List.length", -> {
             l |>
             Array.toList |>
             List.length
         })
 
     pub def delayListLength(l: Array[Int32, r]): Benchmark =
-        defBenchmark("DelayList.length", () -> {
+        defBenchmark("DelayList.length", -> {
             l |>
             Array.toDelayList |>
             DelayList.length
@@ -79,7 +79,7 @@ mod Bench.Fusion {
     /// filter length                                                        ///
     ////////////////////////////////////////////////////////////////////////////
     pub def listFilterLength(l: Array[Int32, r]): Benchmark =
-        defBenchmark("List.filterLength", () -> {
+        defBenchmark("List.filterLength", -> {
             l |>
             Array.toList |>
             List.filter(x -> x `Int32.remainder` 2 == 0) |>
@@ -87,7 +87,7 @@ mod Bench.Fusion {
         })
 
     pub def delayListFilterLength(l: Array[Int32, r]): Benchmark =
-        defBenchmark("DelayList.filterLength", () -> {
+        defBenchmark("DelayList.filterLength", -> {
             l |>
             Array.toDelayList |>
             DelayList.filter(x -> x `Int32.remainder` 2 == 0) |>
@@ -98,7 +98,7 @@ mod Bench.Fusion {
     /// filter map length                                                    ///
     ////////////////////////////////////////////////////////////////////////////
     pub def listFilterMapLength(l: Array[Int32, r]): Benchmark =
-        defBenchmark("List.filterMapLength", () -> {
+        defBenchmark("List.filterMapLength", -> {
             l |>
             Array.toList |>
             List.filter(x -> x `Int32.remainder` 2 == 0) |>
@@ -107,7 +107,7 @@ mod Bench.Fusion {
         })
 
     pub def delayListFilterMapLength(l: Array[Int32, r]): Benchmark =
-        defBenchmark("DelayList.filterMapLength", () -> {
+        defBenchmark("DelayList.filterMapLength", -> {
             l |>
             Array.toDelayList |>
             DelayList.filter(x -> x `Int32.remainder` 2 == 0) |>
@@ -119,14 +119,14 @@ mod Bench.Fusion {
     /// sum                                                                  ///
     ////////////////////////////////////////////////////////////////////////////
     pub def listSum(l: Array[Int32, r]): Benchmark =
-        defBenchmark("List.sum", () -> {
+        defBenchmark("List.sum", -> {
             l |>
             Array.toList |>
             List.sum
         })
 
     pub def delayListSum(l: Array[Int32, r]): Benchmark =
-        defBenchmark("DelayList.sum", () -> {
+        defBenchmark("DelayList.sum", -> {
             l |>
             Array.toDelayList |>
             DelayList.sum
@@ -136,7 +136,7 @@ mod Bench.Fusion {
     /// filter sum                                                           ///
     ////////////////////////////////////////////////////////////////////////////
     pub def listFilterSum(l: Array[Int32, r]): Benchmark =
-        defBenchmark("List.filterSum", () -> {
+        defBenchmark("List.filterSum", -> {
             l |>
             Array.toList |>
             List.filter(x -> x `Int32.remainder` 2 == 0) |>
@@ -144,7 +144,7 @@ mod Bench.Fusion {
         })
 
     pub def delayListFilterSum(l: Array[Int32, r]): Benchmark =
-        defBenchmark("DelayList.filterSum", () -> {
+        defBenchmark("DelayList.filterSum", -> {
             l |>
             Array.toDelayList |>
             DelayList.filter(x -> x `Int32.remainder` 2 == 0) |>
@@ -155,7 +155,7 @@ mod Bench.Fusion {
     /// filter map sum                                                       ///
     ////////////////////////////////////////////////////////////////////////////
     pub def listFilterMapSum(l: Array[Int32, r]): Benchmark =
-        defBenchmark("List.filterMapSum", () -> {
+        defBenchmark("List.filterMapSum", -> {
             l |>
             Array.toList |>
             List.filter(x -> x `Int32.remainder` 2 == 0) |>
@@ -164,7 +164,7 @@ mod Bench.Fusion {
         })
 
     pub def delayListFilterMapSum(l: Array[Int32, r]): Benchmark =
-        defBenchmark("DelayList.filterMapSum", () -> {
+        defBenchmark("DelayList.filterMapSum", -> {
             l |>
             Array.toDelayList |>
             DelayList.filter(x -> x `Int32.remainder` 2 == 0) |>
@@ -176,7 +176,7 @@ mod Bench.Fusion {
     /// filter8                                                              ///
     ////////////////////////////////////////////////////////////////////////////
     pub def listFilter8(l: Array[Int32, r]): Benchmark =
-        defBenchmark("List.filter8", () -> {
+        defBenchmark("List.filter8", -> {
             l |>
             Array.toList |>
             List.filter(x -> x > 1) |>
@@ -191,7 +191,7 @@ mod Bench.Fusion {
         })
 
     pub def delayListFilter8(l: Array[Int32, r]): Benchmark =
-        defBenchmark("DelayList.filter8", () -> {
+        defBenchmark("DelayList.filter8", -> {
             l |>
             Array.toDelayList |>
             DelayList.filter(x -> x > 1) |>
@@ -209,7 +209,7 @@ mod Bench.Fusion {
     /// map8                                                                 ///
     ////////////////////////////////////////////////////////////////////////////
     pub def listMap8(l: Array[Int32, r]): Benchmark =
-        defBenchmark("List.map8", () -> {
+        defBenchmark("List.map8", -> {
             l |>
             Array.toList |>
             List.map(x -> x + 1) |>
@@ -224,7 +224,7 @@ mod Bench.Fusion {
         })
 
     pub def delayListMap8(l: Array[Int32, r]): Benchmark =
-        defBenchmark("DelayList.map8", () -> {
+        defBenchmark("DelayList.map8", -> {
             l |>
             Array.toDelayList |>
             DelayList.map(x -> x + 1) |>
@@ -243,7 +243,7 @@ mod Bench.Fusion {
     ////////////////////////////////////////////////////////////////////////////
     pub def listFlatMapTakeSum(l: Array[Int32, r]): Benchmark =
         let l2 = List.range(1, 10);
-        defBenchmark("List.flatMapTakeSum", () -> {
+        defBenchmark("List.flatMapTakeSum", -> {
             l |>
             Array.toList |>
             List.flatMap(x -> List.map(y -> x * y, l2)) |>
@@ -253,7 +253,7 @@ mod Bench.Fusion {
 
     pub def delayListFlatMapTakeSum(l: Array[Int32, r]): Benchmark =
         let l2 = DelayList.range(1, 10);
-        defBenchmark("DelayList.flatMapTakeSum", () -> {
+        defBenchmark("DelayList.flatMapTakeSum", -> {
             l |>
             Array.toDelayList |>
             DelayList.flatMap(x -> DelayList.map(y -> x * y, l2)) |>
@@ -266,7 +266,7 @@ mod Bench.Fusion {
     ////////////////////////////////////////////////////////////////////////////
     pub def listCartesian(l: Array[Int32, r]): Benchmark =
         let l2 = List.range(1, 10);
-        defBenchmark("List.cartesian", () -> {
+        defBenchmark("List.cartesian", -> {
             l |>
             Array.toList |>
             List.flatMap(x -> List.map(y -> x * y, l2)) |>
@@ -275,7 +275,7 @@ mod Bench.Fusion {
 
     pub def delayListCartesian(l: Array[Int32, r]): Benchmark =
         let l2 = DelayList.range(1, 10);
-        defBenchmark("DelayList.cartesian", () -> {
+        defBenchmark("DelayList.cartesian", -> {
             l |>
             Array.toDelayList |>
             DelayList.flatMap(x -> DelayList.map(y -> x * y, l2)) |>

--- a/main/src/library/BigInt.flix
+++ b/main/src/library/BigInt.flix
@@ -354,7 +354,7 @@ mod BigInt {
     /// Returns `x` clamped within the Float32 range `minimum` to `maximum`.
     ///
     pub def clampToFloat32(x: BigInt, minimum: Float32, maximum: Float32): Float32 =
-        let step = () -> {
+        let step = -> {
             forM (
                 f32min <- Float32.tryToBigInt(minimum);
                 f32max <- Float32.tryToBigInt(maximum)
@@ -375,7 +375,7 @@ mod BigInt {
     /// Returns `x` clamped within the Float64 range `minimum` to `maximum`.
     ///
     pub def clampToFloat64(x: BigInt, minimum: Float64, maximum: Float64): Float64 =
-        let step = () -> {
+        let step = -> {
             forM (
                 f64min <- Float64.tryToBigInt(minimum);
                 f64max <- Float64.tryToBigInt(maximum)

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -825,7 +825,7 @@ mod Chain {
     ///
     pub def iterator(rc: Region[r], c: Chain[a]): Iterator[a, r, r] \ r =
         let cursor = Ref.fresh(rc, viewLeft(c));
-        let next = () -> match (Ref.get(cursor)) {
+        let next = -> match (Ref.get(cursor)) {
             case ViewLeft.NoneLeft        => None
             case ViewLeft.SomeLeft(x, xs) =>
                 Ref.put(viewLeft(xs), cursor);

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -840,8 +840,8 @@ mod DelayList {
     pub def findRight(f: a -> Bool \ ef, l: DelayList[a]): Option[a] \ ef =
         def loop(ll, k) = match ll {
             case ENil         => k()
-            case ECons(x, xs) => loop(      xs, () -> if (f(x)) Some(x) else k())
-            case LCons(x, xs) => loop(force xs, () -> if (f(x)) Some(x) else k())
+            case ECons(x, xs) => loop(      xs, -> if (f(x)) Some(x) else k())
+            case LCons(x, xs) => loop(force xs, -> if (f(x)) Some(x) else k())
             case LList(xs)    => loop(force xs, k)
         };
         loop(l, constant(None))
@@ -1208,7 +1208,7 @@ mod DelayList {
     @Experimental @Lazy
     pub def iterator(rc: Region[r], l: DelayList[a]): Iterator[a, r, r] \ r =
         let cursor = Ref.fresh(rc, l);
-        let next = () -> match head(Ref.get(cursor)) {
+        let next = -> match head(Ref.get(cursor)) {
             case None    => None
             case Some(x) =>
                 Ref.put(tail(Ref.get(cursor)), cursor);

--- a/main/src/library/Files.flix
+++ b/main/src/library/Files.flix
@@ -337,7 +337,7 @@ mod Files {
             let javaPath = javaFile.toPath();
             let reader = JFiles.newBufferedReader(javaPath);
             let line = Ref.fresh(rc, reader.readLine());
-            let next = () -> ({
+            let next = -> ({
                 if (not Object.isNull(Ref.get(line))) {
                     try {
                         let l = Ref.get(line);
@@ -370,7 +370,7 @@ mod Files {
             let javaPath = javaFile.toPath();
             let reader = JFiles.newBufferedReader(javaPath, Charset.forName(opts#charSet));
             let line = Ref.fresh(rc, reader.readLine());
-            let next = () -> ({
+            let next = -> ({
                 if (not Object.isNull(Ref.get(line))) {
                     try {
                         let l = Ref.get(line);
@@ -460,7 +460,7 @@ mod Files {
                 let stream = new FileInputStream(javaFile);
                 let bytes: Ref[Array[Int8, _], _] = Ref.fresh(rc, Array.empty(rc, chunkSize));
                 let numberRead = Ref.fresh(rc, unchecked_cast(stream.read(Ref.get(bytes)) as _ \ IO + r));
-                let next = () -> ({
+                let next = -> ({
                     if (Ref.get(numberRead) >= 0) {
                         try {
                             let chunk = Ref.get(bytes);
@@ -771,7 +771,7 @@ mod Files {
     /// Converts a Java iterator to a Flix Iterator.
     ///
     def fromJavaIter(rc: Region[r], iter: JIterator): Iterator[a, r, r] =
-        let next = () -> {
+        let next = -> {
             if(unchecked_cast(iter.hasNext() as _ \ r)) {
                 unchecked_cast(iter.next() as a \ r) |> Some
             } else {

--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -494,7 +494,7 @@ mod Fixpoint.Solver {
     def injectIntoX(f: t -> List[Boxed] \ ef, p: PredSym, ts: f[t]): Datalog[Boxed] \ (ef + Foldable.Aef[f]) with Foldable[f] =
         region rc {
             let db = MutMap.empty(rc);
-            Foldable.foldLeft(() -> t -> {
+            Foldable.foldLeft(-> t -> {
                 let vs = f(t);
                 let arity = List.length(vs);
                 let ramSym = RamSym.Full(p, arity, Denotation.Relational);

--- a/main/src/library/Iterator.flix
+++ b/main/src/library/Iterator.flix
@@ -42,11 +42,11 @@ mod Iterator {
     /// Returns an iterator built with the stepper function `f`.
     ///
     pub def iterate(rc: Region[r], f: Unit -> Option[a] \ ef): Iterator[a, ef, r] =
-        let f1 = () -> match f() {
+        let f1 = -> match f() {
             case Some(a) => Ans(a)
             case None    => Done
         };
-        let iterF = () -> checked_ecast(f1());
+        let iterF = -> checked_ecast(f1());
         Iterator(rc, iterF)
 
     ///
@@ -86,7 +86,7 @@ mod Iterator {
         if (e <= b)
             empty(rc)
         else {
-            let iterF = () -> match (Ref.get(pos)) {
+            let iterF = -> match (Ref.get(pos)) {
                 case i if i < e => Ref.put(i + 1, pos); Ans(i)
                 case _          => Done
             };
@@ -100,7 +100,7 @@ mod Iterator {
     ///
     pub def repeat(rc: Region[r], n: Int32, x: a): Iterator[a, r, r] \ r =
         let ix = Ref.fresh(rc, n);
-        let iterF = () -> {
+        let iterF = -> {
             let i = Ref.get(ix);
             if (i < 1)
                 Done
@@ -251,7 +251,7 @@ mod Iterator {
             case Skip   => Skip
             case Done   => Done
         };
-        let iterF1 = () -> step(iterF());
+        let iterF1 = -> step(iterF());
         Iterator(rc, iterF1)
 
     ///
@@ -266,7 +266,7 @@ mod Iterator {
             case Skip   => Skip
             case Done   => Done
         };
-        let iterF1 = () -> {let x = iterF(); step(x)};
+        let iterF1 = -> {let x = iterF(); step(x)};
         Iterator(rc, iterF1)
 
     ///
@@ -283,7 +283,7 @@ mod Iterator {
             case Skip   => Skip
             case Done   => Done
         };
-        let iterF1 = () -> {let x = iterF(); step(x)};
+        let iterF1 = -> {let x = iterF(); step(x)};
         Iterator(rc, iterF1)
 
     ///
@@ -314,7 +314,7 @@ mod Iterator {
             case Skip   => loop1(iter1F())
             case Done   => loop2(iter2F())
         };
-        let iter3F = () -> loop1(iter1F());
+        let iter3F = -> loop1(iter1F());
         Iterator(rc, iter3F)
 
     ///
@@ -355,7 +355,7 @@ mod Iterator {
             case (_, _)           => Done
 
         };
-        let iter3F = () -> step(iter1F(), iter2F());
+        let iter3F = -> step(iter1F(), iter2F());
         Iterator(rc, iter3F)
 
     ///
@@ -474,7 +474,7 @@ mod Iterator {
     /// If `f` returns `Err(e)`, then the iterator is depleted.
     ///
     pub def unfoldWithOk(rc: Region[r], f: Unit -> Result[e, a] \ ef): Iterator[a, ef, r] =
-        let iterF = () -> Result.toOption(f());
+        let iterF = -> Result.toOption(f());
         Iterator.iterate(rc, iterF)
 
     ///
@@ -499,7 +499,7 @@ mod Iterator {
                 case Done    => Done
             }
         };
-        let iter1F = () -> loop();
+        let iter1F = -> loop();
         Iterator(rc, iter1F)
 
     ///
@@ -526,7 +526,7 @@ mod Iterator {
                     case Done   => Done
                 }
         };
-        let iter1F = () -> loop();
+        let iter1F = -> loop();
         Iterator(rc, iter1F)
 
     ///
@@ -543,7 +543,7 @@ mod Iterator {
             case Skip   => loop(iterF())
             case Done   => Done
         };
-        let iter1F = () -> loop(iterF());
+        let iter1F = -> loop(iterF());
         Iterator(rc, iter1F)
 
     ///
@@ -566,7 +566,7 @@ mod Iterator {
             case Skip => Skip
             case Done => Done
         };
-        let iter1F = () -> loop();
+        let iter1F = -> loop();
         Iterator(rc, iter1F)
 
     ///
@@ -605,7 +605,7 @@ mod Iterator {
                 }
             }
         };
-        let iter1F = () -> outerLoop();
+        let iter1F = -> outerLoop();
         Iterator(rc, iter1F)
 
     ///
@@ -668,7 +668,7 @@ mod Iterator {
     ///
     def ofList(rc: Region[r], xs: List[a]): Iterator[a, {}, r] \ r =
         let ls = Ref.fresh(rc, xs);
-        let next = () -> {
+        let next = -> {
             match (Ref.get(ls)) {
                 case Nil     => Done
                 case x :: rs => Ref.put(rs, ls); Ans(x)
@@ -721,7 +721,7 @@ mod Iterator {
             case Skip   => Skip
             case Done   => Done
         };
-        let iterF1 = () -> step(iterF());
+        let iterF1 = -> step(iterF());
         Iterator(rc, iterF1)
 
     ///
@@ -735,7 +735,7 @@ mod Iterator {
     pub def cons(x: a, iter: Iterator[a, ef, r]): Iterator[a, ef, r] \ r =
         let Iterator(rc, iterF) = iter;
         let first = Ref.fresh(rc, true);
-        let f = () ->  {
+        let f = ->  {
             if (Ref.get(first)) {
                 Ref.put(false, first);
                 Ans(x)
@@ -743,7 +743,7 @@ mod Iterator {
             else
                 iterF()
         };
-        let iter1F = () -> f();
+        let iter1F = -> f();
         Iterator(rc, iter1F)
 
     ///

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -283,7 +283,7 @@ mod List {
     pub def findRight(f: a -> Bool \ ef, l: List[a]): Option[a] \ ef =
         def loop(ll, k) = match ll {
             case Nil     => k()
-            case x :: xs => loop(xs, () -> if (f(x)) Some(x) else k())
+            case x :: xs => loop(xs, -> if (f(x)) Some(x) else k())
         };
         loop(l, constant(None))
 
@@ -1340,7 +1340,7 @@ mod List {
     ///
     pub def iterator(rc: Region[r], xs: List[a]): Iterator[a, r, r] \ r =
         let ls = Ref.fresh(rc, xs);
-        let next = () -> {
+        let next = -> {
             match (Ref.get(ls)) {
                 case Nil     => None
                 case x :: rs => Ref.put(rs, ls); Some(x)

--- a/main/src/library/MutDeque.flix
+++ b/main/src/library/MutDeque.flix
@@ -397,7 +397,7 @@ mod MutDeque {
     ///
     pub def iterator(rc: Region[r1], d: MutDeque[a, r2]): Iterator[a, r1 + r2, r1] \ { r1, r2 } =
         let i = Ref.fresh(rc, d->front);
-        let next = () -> {
+        let next = -> {
             if (Ref.get(i) < d->back) {
                 let x = Array.get(Ref.get(i), d->values);
                 Ref.put(Ref.get(i) + Int32.bitwiseAnd(1, capacity(d) - 1), i);

--- a/main/src/library/MutList.flix
+++ b/main/src/library/MutList.flix
@@ -869,7 +869,7 @@ mod MutList {
         let MutList(_, a, len) = l;
         let len1 = Ref.get(len);
         let ix = Ref.fresh(rc, 0);
-        let next = () -> {
+        let next = -> {
             let i = Ref.get(ix);
             if (i < len1) {
                 let x = Array.get(i, Ref.get(a));

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -823,7 +823,7 @@ mod Nec {
     ///
     def iteratorHelper(rc: Region[r], vl: Option[ViewLeft[a]]): Iterator[a, r, r] \ r =
         let cursor = Ref.fresh(rc, vl);
-        let next = () -> match (Ref.get(cursor)) {
+        let next = -> match (Ref.get(cursor)) {
             case None             => None
             case Some(OneLeft(x)) =>
                 Ref.put(None, cursor);

--- a/main/src/library/RedBlackTree.flix
+++ b/main/src/library/RedBlackTree.flix
@@ -974,7 +974,7 @@ mod RedBlackTree {
     pub def iterator(rc: Region[r], t: RedBlackTree[k, v]): Iterator[(k, v), r, r] \ r =
         let stack1 = leftmost(t, Nil);
         let state = Ref.fresh(rc, stack1);
-        let next = () -> match Ref.get(state) {
+        let next = -> match Ref.get(state) {
             case Nil                 => None
             case (k, v, rtree) :: es =>
                 Ref.put(leftmost(rtree, es), state);

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -812,6 +812,25 @@ class TestParserHappy extends AnyFunSuite with TestUtils {
     expectSuccess(result)
   }
 
+  test("thunkLambda.01") {
+    val input =
+      """
+        |def foo(): Int32 = (-> 42)()
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectSuccess(result)
+  }
+
+  test("thunkLambda.02") {
+    val input =
+      """
+        |def |>(x: a, f: a -> b \ ef): b \ ef = f(x)
+        |def foo(): Int32 = () |> (-> -> 42)()
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectSuccess(result)
+  }
+
   test("ParseError.Interpolation.01") {
     val input = s"""pub def foo(): String = "$${1 + }""""
     val result = compile(input, Options.TestWithLibNix)


### PR DESCRIPTION
parse `-> exp` as `() -> exp`

This is very nice with handler-type functions like `def run(f: Unit -> a \ ef): a \ (ef - Console) + IO`

`run(() -> exp)` becomes `run(-> exp)`

a very small change, most of the diff is changing `() -> exp` to `-> exp` in lib