### PR TITLE
feat: add `Process` effect

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -262,6 +262,7 @@ class Flix {
     "Abort.flix" -> LocalResource.get("/src/library/Abort.flix"),
     "Clock.flix" -> LocalResource.get("/src/library/Clock.flix"),
     "Eff/Random.flix" -> LocalResource.get("/src/library/Eff/Random.flix"),
+    "Process.flix" -> LocalResource.get("/src/library/Process.flix"),
     "TimeUnit.flix" -> LocalResource.get("/src/library/TimeUnit.flix"),
 
     "Graph.flix" -> LocalResource.get("/src/library/Graph.flix"),

--- a/main/src/library/Clock.flix
+++ b/main/src/library/Clock.flix
@@ -13,6 +13,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
+///
+/// An effect used to access the current (real-world) time.
+///
 eff Clock {
 
     ///

--- a/main/src/library/Process.flix
+++ b/main/src/library/Process.flix
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2024 Magnus Madsen
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+///
+/// An effect used to start a process outside the JVM.
+///
+eff Process {
+
+    ///
+    /// Immediately executes the command `cmd` passing the arguments `args`.
+    ///
+    pub def exec(cmd: String, args: List[String]): Unit
+
+}


### PR DESCRIPTION
The handler should be:

```scala
mod Process {

    import java.lang.ProcessBuilder
    import java.lang.Runtime

    ///
    /// Runs the `Process` effect of the given function `f`.
    ///
    /// In other words, re-interprets the `Process` effect using the `Exec` effect.
    ///
    pub def run(f: Unit -> a \ ef): a \ (ef - Process) + Exec = {
        // Currently try-with typing is broken, so fix it with checked_ecast
        checked_ecast(try {
            f()
        } with Process {
            def exec(cmd, args, k) = region rc {
                let arr = List.toArray(rc, cmd :: args);
                let pb = new ProcessBuilder(arr);
                pb.start();
                k()
            }
        })
    }

}
```

but this does not work because of #8619