### PR TITLE
fix: broken annotation completions

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -246,6 +246,7 @@ object CompletionProvider {
       case ResolutionError.UndefinedOp(_, _) => (1, SyntacticContext.Expr.Do)
       case WeederError.MalformedIdentifier(_, _) => (2, SyntacticContext.Import)
       case WeederError.UnappliedIntrinsic(_, _) => (5, SyntacticContext.Expr.OtherExpr)
+      case WeederError.UndefinedAnnotation(_, _) => (1, SyntacticContext.Decl.Module)
       case err: ResolutionError.UndefinedJvmStaticField => (1, SyntacticContext.Expr.StaticFieldOrMethod(err))
       case err: TypeError.MethodNotFound => (1, SyntacticContext.Expr.InvokeMethod(err.tpe, err.methodName))
       case err: TypeError.FieldNotFound => (1, SyntacticContext.Expr.InvokeMethod(err.tpe, err.fieldName))


### PR DESCRIPTION
This fixes an issue where annotation completions aren't suggested as expect. For instance, typing `@T` would not give us the suggestion `@Test`. Now it does.

If only typing `@` we only get suggestions by invoking the suggestions using ctrl+space. However, when typing for instance `@D` we immediately get the suggestion `@Deprecated`.

For now I've given the priority 1 to the new `getSyntacticContext` case. I believe that what really matters is that it's prioritised above parse error, but I'm unsure. Currently, it seems to have the intended behaviour.

Related to #8638