### PR TITLE
fix: unfitting keyword completion suggestions in element headers (function signatures, module names, etc.)

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -119,18 +119,18 @@ object CompletionProvider {
       //
       // Declarations.
       //
-      case SyntacticContext.Decl.Def      => Nil
-      case SyntacticContext.Decl.Enum     => KeywordCompleter.getEnumKeywords
-      case SyntacticContext.Decl.EnumHeader => Nil
-      case SyntacticContext.Decl.Instance => InstanceCompleter.getCompletions(context) ++ KeywordCompleter.getInstanceKeywords
+      case SyntacticContext.Decl.Def            => Nil
+      case SyntacticContext.Decl.Enum           => KeywordCompleter.getEnumKeywords
+      case SyntacticContext.Decl.EnumHeader     => Nil
+      case SyntacticContext.Decl.Instance       => InstanceCompleter.getCompletions(context) ++ KeywordCompleter.getInstanceKeywords
       case SyntacticContext.Decl.InstanceHeader => Nil
-      case SyntacticContext.Decl.Module   => KeywordCompleter.getModKeywords ++ SnippetCompleter.getCompletions(context)
-      case SyntacticContext.Decl.ModuleHeader => Nil
-      case SyntacticContext.Decl.Struct   => KeywordCompleter.getStructKeywords
-      case SyntacticContext.Decl.StructHeader => Nil
-      case SyntacticContext.Decl.Trait    => KeywordCompleter.getTraitKeywords
-      case SyntacticContext.Decl.TraitHeader => Nil
-      case SyntacticContext.Decl.Type     => KeywordCompleter.getTypeKeywords
+      case SyntacticContext.Decl.Module         => KeywordCompleter.getModKeywords ++ SnippetCompleter.getCompletions(context)
+      case SyntacticContext.Decl.ModuleHeader   => Nil
+      case SyntacticContext.Decl.Struct         => KeywordCompleter.getStructKeywords
+      case SyntacticContext.Decl.StructHeader   => Nil
+      case SyntacticContext.Decl.Trait          => KeywordCompleter.getTraitKeywords
+      case SyntacticContext.Decl.TraitHeader    => Nil
+      case SyntacticContext.Decl.Type           => KeywordCompleter.getTypeKeywords
 
       //
       // Imports.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -119,11 +119,17 @@ object CompletionProvider {
       //
       // Declarations.
       //
+      case SyntacticContext.Decl.Def      => Nil
       case SyntacticContext.Decl.Enum     => KeywordCompleter.getEnumKeywords
+      case SyntacticContext.Decl.EnumHeader => Nil
       case SyntacticContext.Decl.Instance => InstanceCompleter.getCompletions(context) ++ KeywordCompleter.getInstanceKeywords
+      case SyntacticContext.Decl.InstanceHeader => Nil
       case SyntacticContext.Decl.Module   => KeywordCompleter.getModKeywords ++ SnippetCompleter.getCompletions(context)
+      case SyntacticContext.Decl.ModuleHeader => Nil
       case SyntacticContext.Decl.Struct   => KeywordCompleter.getStructKeywords
+      case SyntacticContext.Decl.StructHeader => Nil
       case SyntacticContext.Decl.Trait    => KeywordCompleter.getTraitKeywords
+      case SyntacticContext.Decl.TraitHeader => Nil
       case SyntacticContext.Decl.Type     => KeywordCompleter.getTypeKeywords
 
       //

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -119,23 +119,28 @@ object CompletionProvider {
       //
       // Declarations.
       //
-      case SyntacticContext.Decl.Def            => Nil
-      case SyntacticContext.Decl.Enum           => KeywordCompleter.getEnumKeywords
-      case SyntacticContext.Decl.EnumHeader     => Nil
-      case SyntacticContext.Decl.Instance       => InstanceCompleter.getCompletions(context) ++ KeywordCompleter.getInstanceKeywords
-      case SyntacticContext.Decl.InstanceHeader => Nil
-      case SyntacticContext.Decl.Module         => KeywordCompleter.getModKeywords ++ SnippetCompleter.getCompletions(context)
-      case SyntacticContext.Decl.ModuleHeader   => Nil
-      case SyntacticContext.Decl.Struct         => KeywordCompleter.getStructKeywords
-      case SyntacticContext.Decl.StructHeader   => Nil
-      case SyntacticContext.Decl.Trait          => KeywordCompleter.getTraitKeywords
-      case SyntacticContext.Decl.TraitHeader    => Nil
-      case SyntacticContext.Decl.Type           => KeywordCompleter.getTypeKeywords
+      case SyntacticContext.Decl.Def      => Nil
+      case SyntacticContext.Decl.Enum     => KeywordCompleter.getEnumKeywords
+      case SyntacticContext.Decl.Instance => InstanceCompleter.getCompletions(context) ++ KeywordCompleter.getInstanceKeywords
+      case SyntacticContext.Decl.Module   => KeywordCompleter.getModKeywords ++ SnippetCompleter.getCompletions(context)
+      case SyntacticContext.Decl.Struct   => KeywordCompleter.getStructKeywords
+      case SyntacticContext.Decl.Trait    => KeywordCompleter.getTraitKeywords
+      case SyntacticContext.Decl.Type     => KeywordCompleter.getTypeKeywords
 
       //
       // Imports.
       //
       case SyntacticContext.Import => ImportCompleter.getCompletions(context)
+
+      //
+      // Keywords. Note that this is not the context in which keywords can occur, but the context of a keyword, i.e. inside a keyword.
+      //
+      case SyntacticContext.Keyword => Nil
+
+      //
+      // Names.
+      //
+      case SyntacticContext.Name => Nil
 
       //
       // Types.

--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -544,15 +544,27 @@ object Ast {
     sealed trait Decl extends SyntacticContext
 
     object Decl {
+      case object Def extends Decl
+
       case object Enum extends Decl
+
+      case object EnumHeader extends Decl
 
       case object Instance extends Decl
 
+      case object InstanceHeader extends Decl
+
       case object Module extends Decl
+
+      case object ModuleHeader extends Decl
 
       case object Struct extends Decl
 
+      case object StructHeader extends Decl
+
       case object Trait extends Decl
+
+      case object TraitHeader extends Decl
 
       case object Type extends Decl
     }

--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -16,6 +16,8 @@
 
 package ca.uwaterloo.flix.language.ast
 
+import ca.uwaterloo.flix.language.ast
+
 import ca.uwaterloo.flix.language.ast.shared.{Annotation, Denotation, Fixity, Polarity}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
@@ -548,23 +550,13 @@ object Ast {
 
       case object Enum extends Decl
 
-      case object EnumHeader extends Decl
-
       case object Instance extends Decl
-
-      case object InstanceHeader extends Decl
 
       case object Module extends Decl
 
-      case object ModuleHeader extends Decl
-
       case object Struct extends Decl
 
-      case object StructHeader extends Decl
-
       case object Trait extends Decl
-
-      case object TraitHeader extends Decl
 
       case object Type extends Decl
     }
@@ -576,7 +568,7 @@ object Ast {
 
       case object Do extends Expr
 
-      case class InvokeMethod(tpe: ca.uwaterloo.flix.language.ast.Type, name: Name.Ident) extends Expr
+      case class InvokeMethod(tpe: ca.uwaterloo.flix.language.ast.Type, name: ast.Name.Ident) extends Expr
 
       case class StaticFieldOrMethod(e: ResolutionError.UndefinedJvmStaticField) extends Expr
 
@@ -586,6 +578,10 @@ object Ast {
     }
 
     case object Import extends SyntacticContext
+
+    case object Keyword extends SyntacticContext
+
+    case object Name extends SyntacticContext
 
     sealed trait Pat extends SyntacticContext
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -879,8 +879,8 @@ object Parser2 {
 
     private def moduleDecl(mark: Mark.Opened, nestingLevel: Int = 0)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordMod))
-      expect(TokenKind.KeywordMod, SyntacticContext.Decl.Module)
-      name(NAME_MODULE, allowQualified = true, context = SyntacticContext.Decl.Module)
+      expect(TokenKind.KeywordMod, SyntacticContext.Decl.ModuleHeader)
+      name(NAME_MODULE, allowQualified = true, context = SyntacticContext.Decl.ModuleHeader)
       expect(TokenKind.CurlyL, SyntacticContext.Decl.Module)
       usesOrImports()
       var continue = true
@@ -905,8 +905,8 @@ object Parser2 {
 
     private def traitDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordTrait))
-      expect(TokenKind.KeywordTrait, SyntacticContext.Decl.Trait)
-      name(NAME_DEFINITION, context = SyntacticContext.Decl.Trait)
+      expect(TokenKind.KeywordTrait, SyntacticContext.Decl.TraitHeader)
+      name(NAME_DEFINITION, context = SyntacticContext.Decl.TraitHeader)
       Type.parameters()
       if (at(TokenKind.KeywordWith)) {
         Type.constraints()
@@ -941,8 +941,8 @@ object Parser2 {
 
     private def instanceDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordInstance))
-      expect(TokenKind.KeywordInstance, SyntacticContext.Decl.Instance)
-      name(NAME_DEFINITION, allowQualified = true, context = SyntacticContext.Decl.Instance)
+      expect(TokenKind.KeywordInstance, SyntacticContext.Decl.InstanceHeader)
+      name(NAME_DEFINITION, allowQualified = true, context = SyntacticContext.Decl.InstanceHeader)
       if (!eat(TokenKind.BracketL)) {
         // Produce an error for missing type parameter.
         expect(TokenKind.BracketL, SyntacticContext.Decl.Instance, hint = Some("Instances must have a type parameter."))
@@ -1006,13 +1006,13 @@ object Parser2 {
 
     private def definitionDecl(mark: Mark.Opened, declKind: TokenKind = TokenKind.KeywordDef)(implicit s: State): Mark.Closed = {
       assert(at(declKind))
-      expect(declKind, SyntacticContext.Decl.Module)
-      name(NAME_DEFINITION, context = SyntacticContext.Decl.Module)
+      expect(declKind, SyntacticContext.Decl.Def)
+      name(NAME_DEFINITION, context = SyntacticContext.Decl.Def)
       if (at(TokenKind.BracketL)) {
         Type.parameters()
       }
-      parameters(SyntacticContext.Decl.Module)
-      expect(TokenKind.Colon, SyntacticContext.Decl.Module)
+      parameters(SyntacticContext.Decl.Def)
+      expect(TokenKind.Colon, SyntacticContext.Decl.Def)
       Type.typeAndEffect()
       if (at(TokenKind.KeywordWith)) {
         Type.constraints()
@@ -1028,7 +1028,7 @@ object Parser2 {
       if (eat(TokenKind.Equal)) {
         Expr.statement()
       } else {
-        expect(TokenKind.Equal, SyntacticContext.Decl.Module) // Produce an error for missing '='
+        expect(TokenKind.Equal, SyntacticContext.Decl.Def) // Produce an error for missing '='
       }
 
       val treeKind = if (declKind == TokenKind.KeywordRedef) TreeKind.Decl.Redef else TreeKind.Decl.Def
@@ -1150,9 +1150,9 @@ object Parser2 {
 
     private def structDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordStruct))
-      expect(TokenKind.KeywordStruct, SyntacticContext.Decl.Struct)
+      expect(TokenKind.KeywordStruct, SyntacticContext.Decl.StructHeader)
       val nameLoc = currentSourceLocation()
-      name(NAME_TYPE, context = SyntacticContext.Decl.Struct)
+      name(NAME_TYPE, context = SyntacticContext.Decl.StructHeader)
       Type.parameters()
       zeroOrMore(
         namedTokenSet = NamedTokenSet.FromKinds(NAME_FIELD),

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -983,8 +983,8 @@ object Parser2 {
 
     private def signatureDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordDef))
-      expect(TokenKind.KeywordDef, SyntacticContext.Decl.Module)
-      name(NAME_DEFINITION, context = SyntacticContext.Decl.Module)
+      expect(TokenKind.KeywordDef, SyntacticContext.Keyword)
+      name(NAME_DEFINITION, context = SyntacticContext.Name)
       if (at(TokenKind.BracketL)) {
         Type.parameters()
       }
@@ -1006,8 +1006,8 @@ object Parser2 {
 
     private def definitionDecl(mark: Mark.Opened, declKind: TokenKind = TokenKind.KeywordDef)(implicit s: State): Mark.Closed = {
       assert(at(declKind))
-      expect(declKind, SyntacticContext.Decl.Def)
-      name(NAME_DEFINITION, context = SyntacticContext.Decl.Def)
+      expect(declKind, SyntacticContext.Keyword)
+      name(NAME_DEFINITION, context = SyntacticContext.Name)
       if (at(TokenKind.BracketL)) {
         Type.parameters()
       }
@@ -1037,8 +1037,8 @@ object Parser2 {
 
     private def lawDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordLaw))
-      expect(TokenKind.KeywordLaw, SyntacticContext.Decl.Module)
-      name(NAME_DEFINITION, context = SyntacticContext.Decl.Module)
+      expect(TokenKind.KeywordLaw, SyntacticContext.Keyword)
+      name(NAME_DEFINITION, context = SyntacticContext.Name)
       expect(TokenKind.Colon, SyntacticContext.Decl.Module)
       expect(TokenKind.KeywordForall, SyntacticContext.Decl.Module)
       if (at(TokenKind.BracketL)) {
@@ -1060,9 +1060,9 @@ object Parser2 {
     private def enumerationDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(atAny(Set(TokenKind.KeywordRestrictable, TokenKind.KeywordEnum)))
       val isRestrictable = eat(TokenKind.KeywordRestrictable)
-      expect(TokenKind.KeywordEnum, SyntacticContext.Decl.Enum)
+      expect(TokenKind.KeywordEnum, SyntacticContext.Keyword)
       val nameLoc = currentSourceLocation()
-      name(NAME_TYPE, context = SyntacticContext.Decl.Enum)
+      name(NAME_TYPE, context = SyntacticContext.Name)
       if (isRestrictable) {
         expect(TokenKind.BracketL, SyntacticContext.Decl.Enum)
         val markParam = open()
@@ -1150,9 +1150,9 @@ object Parser2 {
 
     private def structDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordStruct))
-      expect(TokenKind.KeywordStruct, SyntacticContext.Decl.StructHeader)
+      expect(TokenKind.KeywordStruct, SyntacticContext.Keyword)
       val nameLoc = currentSourceLocation()
-      name(NAME_TYPE, context = SyntacticContext.Decl.StructHeader)
+      name(NAME_TYPE, context = SyntacticContext.Name)
       Type.parameters()
       zeroOrMore(
         namedTokenSet = NamedTokenSet.FromKinds(NAME_FIELD),
@@ -1178,9 +1178,9 @@ object Parser2 {
 
     private def typeAliasDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordType))
-      expect(TokenKind.KeywordType, SyntacticContext.Decl.Type)
+      expect(TokenKind.KeywordType, SyntacticContext.Keyword)
       expect(TokenKind.KeywordAlias, SyntacticContext.Decl.Type)
-      name(NAME_TYPE, context = SyntacticContext.Decl.Type)
+      name(NAME_TYPE, context = SyntacticContext.Name)
       if (at(TokenKind.BracketL)) {
         Type.parameters()
       }
@@ -1192,8 +1192,8 @@ object Parser2 {
 
     private def associatedTypeSigDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordType))
-      expect(TokenKind.KeywordType, SyntacticContext.Decl.Module)
-      name(NAME_TYPE, context = SyntacticContext.Decl.Module)
+      expect(TokenKind.KeywordType, SyntacticContext.Keyword)
+      name(NAME_TYPE, context = SyntacticContext.Name)
       if (at(TokenKind.BracketL)) {
         Type.parameters()
       }
@@ -1207,8 +1207,8 @@ object Parser2 {
     }
 
     private def associatedTypeDefDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
-      expect(TokenKind.KeywordType, SyntacticContext.Decl.Module)
-      name(NAME_TYPE, context = SyntacticContext.Decl.Module)
+      expect(TokenKind.KeywordType, SyntacticContext.Keyword)
+      name(NAME_TYPE, context = SyntacticContext.Name)
       if (at(TokenKind.BracketL)) {
         Type.arguments()
       }
@@ -1220,8 +1220,8 @@ object Parser2 {
 
     private def effectDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordEff))
-      expect(TokenKind.KeywordEff, SyntacticContext.Decl.Module)
-      name(NAME_EFFECT, context = SyntacticContext.Decl.Module)
+      expect(TokenKind.KeywordEff, SyntacticContext.Keyword)
+      name(NAME_EFFECT, context = SyntacticContext.Name)
 
       // Check for illegal type parameters.
       if (at(TokenKind.BracketL)) {
@@ -1257,8 +1257,8 @@ object Parser2 {
     }
 
     private def operationDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
-      expect(TokenKind.KeywordDef, SyntacticContext.Decl.Module)
-      name(NAME_DEFINITION, context = SyntacticContext.Decl.Module)
+      expect(TokenKind.KeywordDef, SyntacticContext.Keyword)
+      name(NAME_DEFINITION, context = SyntacticContext.Name)
 
       // Check for illegal type parameters.
       if (at(TokenKind.BracketL)) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -879,8 +879,8 @@ object Parser2 {
 
     private def moduleDecl(mark: Mark.Opened, nestingLevel: Int = 0)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordMod))
-      expect(TokenKind.KeywordMod, SyntacticContext.Decl.ModuleHeader)
-      name(NAME_MODULE, allowQualified = true, context = SyntacticContext.Decl.ModuleHeader)
+      expect(TokenKind.KeywordMod, SyntacticContext.Keyword)
+      name(NAME_MODULE, allowQualified = true, context = SyntacticContext.Name)
       expect(TokenKind.CurlyL, SyntacticContext.Decl.Module)
       usesOrImports()
       var continue = true
@@ -905,8 +905,8 @@ object Parser2 {
 
     private def traitDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordTrait))
-      expect(TokenKind.KeywordTrait, SyntacticContext.Decl.TraitHeader)
-      name(NAME_DEFINITION, context = SyntacticContext.Decl.TraitHeader)
+      expect(TokenKind.KeywordTrait, SyntacticContext.Keyword)
+      name(NAME_DEFINITION, context = SyntacticContext.Name)
       Type.parameters()
       if (at(TokenKind.KeywordWith)) {
         Type.constraints()
@@ -941,8 +941,8 @@ object Parser2 {
 
     private def instanceDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordInstance))
-      expect(TokenKind.KeywordInstance, SyntacticContext.Decl.InstanceHeader)
-      name(NAME_DEFINITION, allowQualified = true, context = SyntacticContext.Decl.InstanceHeader)
+      expect(TokenKind.KeywordInstance, SyntacticContext.Keyword)
+      name(NAME_DEFINITION, allowQualified = true, context = SyntacticContext.Name)
       if (!eat(TokenKind.BracketL)) {
         // Produce an error for missing type parameter.
         expect(TokenKind.BracketL, SyntacticContext.Decl.Instance, hint = Some("Instances must have a type parameter."))


### PR DESCRIPTION
A problem arised for keyword completion suggestions in which keywords that may occur within the body of some declaration would actually also occur within it's "header". Here header is everything that comes before the body.

For instance, we'd get the suggestion `def` for the following (where | is the cursor)

```
pub def d|
```

This PR fixes this issue by introducing distinct syntactic contexts for the headers such that keyword suggestions for these can be different from those of the corresponding bodies.

Related to #8676, specifically the first point