### PR TITLE
fix: missing region type completion

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeBuiltinCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeBuiltinCompleter.scala
@@ -51,7 +51,8 @@ object TypeBuiltinCompleter {
       // L
       polycompletion("Lazy"    , List("t")         , Priority.Default),
       // R
-      polycompletion("Receiver", List("t", "r")    , Priority.Default),
+      polycompletion("Receiver", List("t", "r")    , Priority.Low),
+      polycompletion("Region"  , List("r")         , Priority.High),
       // S
       polycompletion("Sender"  , List("t", "r")    , Priority.Low),
       Completion.TypeBuiltinCompletion("String"    , Priority.High),


### PR DESCRIPTION
Support for the `Region[r]` type completion was missing, it has now been added.

Related to #8676, specifically item 2