### PR TITLE
fix: match completion suggestions at odd times

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/MatchCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/MatchCompleter.scala
@@ -25,14 +25,13 @@ object MatchCompleter {
     * Returns a List of Completion for match.
     */
   def getCompletions(context: CompletionContext)(implicit flix: Flix, index: Index, root: TypedAst.Root): Iterable[MatchCompletion] = {
-    val matchPattern = raw".*\s*ma?t?c?h?\s?.*".r
+    val matchPattern = raw".*\s*match(\s\S*)?".r
 
     if (!(matchPattern matches context.prefix)) {
       return Nil
     }
 
-    val wordPattern = "ma?t?c?h?".r
-    val currentWordIsMatch = wordPattern matches context.word
+    val currentWordIsMatch = context.word == "match"
 
     root.enums.foldLeft[List[MatchCompletion]](Nil)((acc, enm) => {
       if (enm._2.cases.size >= 2) matchCompletion(enm._2, currentWordIsMatch) match {


### PR DESCRIPTION
This PR fixed an issue where match completions are suggested at odd times. This was due to a too "forgiving" regex which has now been fixed.

Now match completions are only suggested if you've just typed "match" or if the previous word was "match" and the current word matches an enum.

Related to #8676, specifically item 3