### PR TITLE
feat: add support for varargs

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -52,6 +52,7 @@ sealed trait TokenKind {
       case TokenKind.CurlyR => "'}'"
       case TokenKind.Dollar => "'$'"
       case TokenKind.Dot => "'.'"
+      case TokenKind.DotDotDot => "'...'"
       case TokenKind.DotWhiteSpace => "'. '"
       case TokenKind.DotCurlyL => "'.{'"
       case TokenKind.Equal => "'='"
@@ -422,6 +423,7 @@ sealed trait TokenKind {
          | TokenKind.ListHash
          | TokenKind.SetHash
          | TokenKind.MapHash
+         | TokenKind.DotDotDot
          | TokenKind.KeywordCheckedCast
          | TokenKind.KeywordCheckedECast
          | TokenKind.KeywordUncheckedCast
@@ -650,6 +652,8 @@ object TokenKind {
   case object Dollar extends TokenKind
 
   case object Dot extends TokenKind
+
+  case object DotDotDot extends TokenKind
 
   case object DotWhiteSpace extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -286,7 +286,7 @@ object TypeConstructor {
     */
   case object Vector extends TypeConstructor {
     /**
-      * The shape of an array is `Array[t]`.
+      * The shape of a vector is `Vector[t]`.
       */
     def kind: Kind = Kind.Star ->: Kind.Star
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -324,8 +324,11 @@ object Lexer {
       case '\\' => TokenKind.Backslash
       case _ if isMatch(".{") => TokenKind.DotCurlyL
       case '.' =>
-        // Check for whitespace around dot.
-        if (previousPrevious().exists(_.isWhitespace)) {
+        if (peek() == '.' && peekPeek().contains('.')) {
+          advance()
+          advance()
+          TokenKind.DotDotDot
+        } else if (previousPrevious().exists(_.isWhitespace)) {
           // If the dot is prefixed with whitespace we treat that as an error.
           TokenKind.Err(LexerError.FreeDot(sourceLocationAtStart()))
         } else if (peek().isWhitespace) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1620,6 +1620,7 @@ object Parser2 {
         case TokenKind.ListHash => listLiteralExpr()
         case TokenKind.SetHash => setLiteralExpr()
         case TokenKind.MapHash => mapLiteralExpr()
+        case TokenKind.DotDotDot => dotdotdotLiteral()
         case TokenKind.KeywordCheckedCast => checkedTypeCastExpr()
         case TokenKind.KeywordCheckedECast => checkedEffectCastExpr()
         case TokenKind.KeywordUncheckedCast => uncheckedCastExpr()
@@ -2374,6 +2375,22 @@ object Parser2 {
       expect(TokenKind.ArrowThickR, SyntacticContext.Expr.OtherExpr)
       expression()
       close(mark, TreeKind.Expr.LiteralMapKeyValueFragment)
+    }
+
+    private def dotdotdotLiteral()(implicit s: State): Mark.Closed = {
+      assert(at(TokenKind.DotDotDot))
+      val mark = open()
+      expect(TokenKind.DotDotDot, SyntacticContext.Expr.OtherExpr)
+      zeroOrMore(
+        namedTokenSet = NamedTokenSet.Expression,
+        getItem = () => expression(),
+        checkForItem = _.isFirstExpr,
+        breakWhen = _.isRecoverExpr,
+        delimiterL = TokenKind.CurlyL,
+        delimiterR = TokenKind.CurlyR,
+        context = SyntacticContext.Expr.OtherExpr
+      )
+      close(mark, TreeKind.Expr.LiteralVector)
     }
 
     private def checkedTypeCastExpr()(implicit s: State): Mark.Closed = {

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
@@ -322,6 +322,17 @@ object TypeReduction {
       val arrType = phantomArr.getClass
       arrType
 
+    // Vectors
+    case Type.Apply(Type.Cst(TypeConstructor.Vector, _), elmType, _) =>
+      // Find the Java class of the element type.
+      val t = getJavaType(elmType)
+
+      // Find the Java class of the array type.
+      // See: https://stackoverflow.com/questions/1679421/how-to-get-the-array-class-for-a-given-class-in-java
+      val phantomArr = java.lang.reflect.Array.newInstance(t, 0)
+      val arrType = phantomArr.getClass
+      arrType
+
     // Functions
     case Type.Apply(Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Arrow(2), _), _, _), varArg, _), varRet, _) =>
       (varArg, varRet) match {

--- a/main/test/flix/Test.Exp.Jvm.InvokeMethod.VarArgs.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeMethod.VarArgs.flix
@@ -1,0 +1,9 @@
+mod Test.Exp.Jvm.InvokeMethod.VarArgs {
+
+    import java.nio.file.Path
+
+    def main(): Unit \ IO =
+        let foo = Path.of("hello", ...{"abc"});
+        println(foo.toString())
+
+}

--- a/main/test/flix/Test.Exp.Jvm.InvokeMethod.VarArgs.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeMethod.VarArgs.flix
@@ -2,8 +2,16 @@ mod Test.Exp.Jvm.InvokeMethod.VarArgs {
 
     import java.nio.file.Path
 
-    def main(): Unit \ IO =
-        let foo = Path.of("hello", ...{"abc"});
-        println(foo.toString())
+    @Test
+    def testInvokeVarArgs01(): Path \ IO =
+        Path.of("hello", (...{}: Vector[String]))
+
+    @Test
+    def testInvokeVarArgs02(): Path \ IO =
+        Path.of("hello", ...{"foo.txt"})
+
+    @Test
+    def testInvokeVarArgs03(): Path \ IO =
+        Path.of("hello", ...{"foo.txt", "bar.txt"})
 
 }


### PR DESCRIPTION
Example:

```scala
import java.nio.file.Path

@Test
def testInvokeVarArgs01(): Path \ IO =
    Path.of("hello", (...{}: Vector[String]))

@Test
def testInvokeVarArgs02(): Path \ IO =
    Path.of("hello", ...{"foo.txt"})

@Test
def testInvokeVarArgs03(): Path \ IO =
    Path.of("hello", ...{"foo.txt", "bar.txt"})
```