### PR TITLE
feat: add `name` parameter to `mkTestDirCollected`

### DIFF
--- a/main/test/ca/uwaterloo/flix/BenchmarkSuite.scala
+++ b/main/test/ca/uwaterloo/flix/BenchmarkSuite.scala
@@ -21,6 +21,6 @@ class BenchmarkSuite extends FlixSuite(incremental = true) {
 
   private implicit val TestOptions: Options = Options.TestWithLibAll
 
-  mkTestDirCollected("main/src/resources/benchmark")
+  mkTestDirCollected("main/src/resources/benchmark", name = "BenchmarkSuite.flix")
 
 }

--- a/main/test/ca/uwaterloo/flix/util/FlixSuite.scala
+++ b/main/test/ca/uwaterloo/flix/util/FlixSuite.scala
@@ -39,10 +39,9 @@ class FlixSuite(incremental: Boolean) extends AnyFunSuite {
     * Subdirectories are excluded.
     *
     */
-  def mkTestDirCollected(path: String)(implicit options: Options): Unit = {
+  def mkTestDirCollected(path: String, name: String)(implicit options: Options): Unit = {
     val files = FileOps.getFlixFilesIn(path, 1)
-    val n = files.headOption.map(p => p.getFileName.toString).getOrElse(path)
-    test(n)(compileAndRun(files))
+    test(name)(compileAndRun(files))
   }
 
   /**


### PR DESCRIPTION
The name parameter is the test name shown when running the test