### PR TITLE
refactor: move `ExpPosition` from `Ast` to `shared`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -27,23 +27,6 @@ import java.util.Objects
 object Ast {
 
   /**
-    * A common super-type that represents an expression position (tail position or not).
-    */
-  sealed trait ExpPosition
-
-  object ExpPosition {
-    /**
-      * Represents an expression in tail position.
-      */
-    case object Tail extends ExpPosition
-
-    /**
-      * Represents an expression in non-tail position.
-      */
-    case object NonTail extends ExpPosition
-  }
-
-  /**
     * Documentation.
     *
     * @param lines the lines of the comments.

--- a/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ReducedAst.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.language.ast.Purity.Pure
-import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, Source}
+import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, ExpPosition, Source}
 
 import java.lang.reflect.Method
 
@@ -72,9 +72,9 @@ object ReducedAst {
 
     case class ApplyAtomic(op: AtomicOp, exps: List[Expr], tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class ApplyClo(exp: Expr, exps: List[Expr], ct: Ast.ExpPosition, tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyClo(exp: Expr, exps: List[Expr], ct: ExpPosition, tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class ApplyDef(symUse: Symbol.DefnSym, exps: List[Expr], ct: Ast.ExpPosition, tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
+    case class ApplyDef(symUse: Symbol.DefnSym, exps: List[Expr], ct: ExpPosition, tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
 
     case class ApplySelfTail(sym: Symbol.DefnSym, actuals: List[Expr], tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
 
@@ -94,7 +94,7 @@ object ReducedAst {
 
     case class TryCatch(exp: Expr, rules: List[CatchRule], tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
 
-    case class TryWith(exp: Expr, effUse: Ast.EffectSymUse, rules: List[HandlerRule], ct: Ast.ExpPosition, tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
+    case class TryWith(exp: Expr, effUse: Ast.EffectSymUse, rules: List[HandlerRule], ct: ExpPosition, tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
 
     case class Do(op: Ast.OpSymUse, exps: List[Expr], tpe: MonoType, purity: Purity, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/ExpPosition.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/ExpPosition.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Holger Dal Mogensen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.ast.shared
+
+
+/**
+  * A common super-type that represents an expression position (tail position or not).
+  */
+sealed trait ExpPosition
+
+object ExpPosition {
+  /**
+    * Represents an expression in tail position.
+    */
+  case object Tail extends ExpPosition
+
+  /**
+    * Represents an expression in non-tail position.
+    */
+  case object NonTail extends ExpPosition
+}

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -16,7 +16,7 @@
 
 package ca.uwaterloo.flix.language.dbg
 
-import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant}
+import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, ExpPosition}
 import ca.uwaterloo.flix.language.ast.{Ast, Name, Symbol}
 
 import java.lang.reflect.{Constructor, Field, Method}
@@ -259,13 +259,13 @@ object DocAst {
     def Cst(cst: Constant): Expr =
       printer.ConstantPrinter.print(cst)
 
-    def ApplyClo(d: Expr, ds: List[Expr], ct: Option[Ast.ExpPosition]): Expr =
+    def ApplyClo(d: Expr, ds: List[Expr], ct: Option[ExpPosition]): Expr =
       App(d, ds)
 
     def ApplySelfTail(sym: Symbol.DefnSym, ds: List[Expr]): Expr =
       App(AsIs(sym.toString), ds)
 
-    def ApplyDef(sym: Symbol.DefnSym, ds: List[Expr], ct: Option[Ast.ExpPosition]): Expr =
+    def ApplyDef(sym: Symbol.DefnSym, ds: List[Expr], ct: Option[ExpPosition]): Expr =
       App(AsIs(sym.toString), ds)
 
     def Do(sym: Symbol.OpSym, ds: List[Expr]): Expr =

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectBinder.scala
@@ -17,9 +17,9 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.Ast.{BoundBy, ExpPosition}
+import ca.uwaterloo.flix.language.ast.Ast.BoundBy
 import ca.uwaterloo.flix.language.ast.Symbol.{DefnSym, VarSym}
-import ca.uwaterloo.flix.language.ast.shared.Scope
+import ca.uwaterloo.flix.language.ast.shared.{ExpPosition, Scope}
 import ca.uwaterloo.flix.language.ast.{AtomicOp, LiftedAst, Purity, ReducedAst, SemanticOp, SourceLocation, Symbol}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugReducedAst
 import ca.uwaterloo.flix.language.phase.jvm.GenExpression

--- a/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reducer.scala
@@ -16,9 +16,9 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.Ast.ExpPosition
 import ca.uwaterloo.flix.language.ast.{MonoType, Purity}
 import ca.uwaterloo.flix.language.ast.ReducedAst.*
+import ca.uwaterloo.flix.language.ast.shared.ExpPosition
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.util.ParOps
 

--- a/main/src/ca/uwaterloo/flix/language/phase/TailPos.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TailPos.scala
@@ -19,6 +19,7 @@ package ca.uwaterloo.flix.language.phase
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Ast
 import ca.uwaterloo.flix.language.ast.ReducedAst.*
+import ca.uwaterloo.flix.language.ast.shared.ExpPosition
 import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugReducedAst
 import ca.uwaterloo.flix.util.ParOps
 import ca.uwaterloo.flix.util.collection.MapOps
@@ -30,10 +31,10 @@ import ca.uwaterloo.flix.util.collection.MapOps
   * Specifically, it replaces [[Expr.ApplyDef]] AST nodes with [[Expr.ApplySelfTail]] AST nodes
   * when the [[Expr.ApplyDef]] node calls the enclosing function and occurs in tail position.
   *
-  * Otherwise, it adds [[Ast.ExpPosition.Tail]] to function calls and try-with expressions in tail
+  * Otherwise, it adds [[ExpPosition.Tail]] to function calls and try-with expressions in tail
   * position.
   *
-  * For correctness it is assumed that all calls in the given AST have [[Ast.ExpPosition.NonTail]]
+  * For correctness it is assumed that all calls in the given AST have [[ExpPosition.NonTail]]
   * and there are no [[Expr.ApplySelfTail]] nodes present.
   */
 object TailPos {
@@ -89,13 +90,13 @@ object TailPos {
 
       case Expr.ApplyClo(exp, exps, _, tpe, purity, loc) =>
         // Mark expression as tail position.
-        Expr.ApplyClo(exp, exps, Ast.ExpPosition.Tail, tpe, purity, loc)
+        Expr.ApplyClo(exp, exps, ExpPosition.Tail, tpe, purity, loc)
 
       case Expr.ApplyDef(sym, exps, _, tpe, purity, loc) =>
         // Check whether this is a self recursive call.
         if (defn.sym != sym) {
           // Mark expression as tail position.
-          Expr.ApplyDef(sym, exps, Ast.ExpPosition.Tail, tpe, purity, loc)
+          Expr.ApplyDef(sym, exps, ExpPosition.Tail, tpe, purity, loc)
         } else {
           // Self recursive tail call.
           Expr.ApplySelfTail(sym, exps, tpe, purity, loc)
@@ -103,7 +104,7 @@ object TailPos {
 
       case Expr.TryWith(exp, effUse, rules, _, tpe, purity, loc) =>
         // Mark expression as tail position.
-        Expr.TryWith(exp, effUse, rules, Ast.ExpPosition.Tail, tpe, purity, loc)
+        Expr.TryWith(exp, effUse, rules, ExpPosition.Tail, tpe, purity, loc)
 
       // Non-tail expressions
       case Expr.ApplyAtomic(_, _, _, _, _) => exp0

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -18,10 +18,9 @@
 package ca.uwaterloo.flix.language.phase.jvm
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.Ast.ExpPosition
 import ca.uwaterloo.flix.language.ast.ReducedAst.*
 import ca.uwaterloo.flix.language.ast.SemanticOp.*
-import ca.uwaterloo.flix.language.ast.shared.Constant
+import ca.uwaterloo.flix.language.ast.shared.{Constant, ExpPosition}
 import ca.uwaterloo.flix.language.ast.{MonoType, *}
 import ca.uwaterloo.flix.language.dbg.printer.OpPrinter
 import ca.uwaterloo.flix.language.phase.jvm.BackendObjType.JavaObject


### PR DESCRIPTION
Related to #7871