### PR TITLE
refactor: rename `utils.Jvm` to `utils.JvmUtils`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/GetStaticFieldCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/GetStaticFieldCompleter.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.FieldCompletion
 import ca.uwaterloo.flix.language.errors.ResolutionError
-import ca.uwaterloo.flix.util.Jvm
+import ca.uwaterloo.flix.util.JvmUtils
 
 import java.lang.reflect.Field
 
@@ -30,7 +30,7 @@ object GetStaticFieldCompleter {
 
   private def getFields(clazz: Class[?]): List[Field] = {
     val availableFields = clazz.getFields.toList
-    val staticFields = availableFields.filter(m => Jvm.isStatic(m))
+    val staticFields = availableFields.filter(m => JvmUtils.isStatic(m))
     staticFields.sortBy(_.getName)
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeMethodCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeMethodCompleter.scala
@@ -19,7 +19,7 @@ import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.Index
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.MethodCompletion
 import ca.uwaterloo.flix.language.ast.{Name, Type, TypedAst}
-import ca.uwaterloo.flix.util.Jvm
+import ca.uwaterloo.flix.util.JvmUtils
 
 object InvokeMethodCompleter {
 
@@ -28,7 +28,7 @@ object InvokeMethodCompleter {
       case None =>
         Nil
       case Some(clazz) =>
-        Jvm.getInstanceMethods(clazz).sortBy(_.getName).map(MethodCompletion(name, _))
+        JvmUtils.getInstanceMethods(clazz).sortBy(_.getName).map(MethodCompletion(name, _))
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeStaticMethodCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/InvokeStaticMethodCompleter.scala
@@ -17,12 +17,12 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.MethodCompletion
 import ca.uwaterloo.flix.language.errors.ResolutionError
-import ca.uwaterloo.flix.util.Jvm
+import ca.uwaterloo.flix.util.JvmUtils
 
 object InvokeStaticMethodCompleter {
 
   def getCompletions(e: ResolutionError.UndefinedJvmStaticField): Iterable[MethodCompletion] = {
-    Jvm.getStaticMethods(e.clazz).sortBy(_.getName).map(MethodCompletion(e.field, _))
+    JvmUtils.getStaticMethods(e.clazz).sortBy(_.getName).map(MethodCompletion(e.field, _))
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -798,7 +798,7 @@ object Resolver {
           case Some(List(Resolution.JavaClass(clazz))) =>
             // We have a static field access.
             val fieldName = qname.ident
-            Jvm.getField(clazz, fieldName.name, static = true) match {
+            JvmUtils.getField(clazz, fieldName.name, static = true) match {
               case Some(field) =>
                 // Returns out of resolveExp
                 return Validation.success(ResolvedAst.Expr.GetStaticField(field, loc))
@@ -3423,7 +3423,7 @@ object Resolver {
       val method = clazz.getMethod(methodName, signature *)
 
       // Check if the method should be and is static.
-      if (static != Jvm.isStatic(method)) {
+      if (static != JvmUtils.isStatic(method)) {
         throw new NoSuchMethodException()
       } else {
         // Check that the return type of the method matches the declared type.
@@ -3451,7 +3451,7 @@ object Resolver {
       }
     } catch {
       case ex: NoSuchMethodException =>
-        val candidateMethods = Jvm.getMethods(clazz).filter(_.getName == methodName)
+        val candidateMethods = JvmUtils.getMethods(clazz).filter(_.getName == methodName)
         Result.Err(ResolutionError.UndefinedJvmMethod(clazz.getName, methodName, static, signature, candidateMethods, loc))
       // ClassNotFoundException:  Cannot happen because we already have the `Class` object.
       // NoClassDefFoundError:    Cannot happen because we already have the `Class` object.
@@ -3469,7 +3469,7 @@ object Resolver {
           val field = clazz.getField(fieldName)
 
           // Check if the field should be and is static.
-          if (static == Jvm.isStatic(field))
+          if (static == JvmUtils.isStatic(field))
             Result.Ok((clazz, field))
           else
             throw new NoSuchFieldException()

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -10,7 +10,7 @@ import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.SafetyError
 import ca.uwaterloo.flix.language.errors.SafetyError.*
-import ca.uwaterloo.flix.util.{Jvm, ParOps, Validation}
+import ca.uwaterloo.flix.util.{JvmUtils, ParOps, Validation}
 
 import java.math.BigInteger
 import scala.annotation.tailrec
@@ -1038,7 +1038,7 @@ object Safety {
     * Get a Set of MethodSignatures representing the methods of `clazz`. Returns a map to allow subsequent reverse lookup.
     */
   private def getJavaMethodSignatures(clazz: java.lang.Class[?]): Map[MethodSignature, java.lang.reflect.Method] = {
-    val methods = Jvm.getInstanceMethods(clazz)
+    val methods = JvmUtils.getInstanceMethods(clazz)
     methods.foldLeft(Map.empty[MethodSignature, java.lang.reflect.Method]) {
       case (acc, m) =>
         val signature = MethodSignature(m.getName, m.getParameterTypes.toList.map(Type.getFlixType), Type.getFlixType(m.getReturnType))

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/Loader.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/Loader.scala
@@ -3,7 +3,7 @@ package ca.uwaterloo.flix.language.phase.jvm
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.ReducedAst.Root
 import ca.uwaterloo.flix.language.ast.SourceLocation
-import ca.uwaterloo.flix.util.{InternalCompilerException, Jvm}
+import ca.uwaterloo.flix.util.{InternalCompilerException, JvmUtils}
 
 import java.lang.reflect.{InvocationTargetException, Method}
 
@@ -84,7 +84,7 @@ object Loader {
     * Returns a map from names to method objects for the given class `clazz`.
     */
   private def methodsOf(clazz: Class[?]): Map[String, Method] = {
-    Jvm.getMethods(clazz).foldLeft(Map.empty[String, Method]) {
+    JvmUtils.getMethods(clazz).foldLeft(Map.empty[String, Method]) {
       case (macc, method) =>
         if (method.isSynthetic)
           macc

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/TypeReduction.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.ast.{Ast, Kind, RigidityEnv, SourceLocation, S
 import ca.uwaterloo.flix.language.errors.TypeError
 import ca.uwaterloo.flix.language.phase.unification.Unification
 import ca.uwaterloo.flix.util.collection.{ListMap, ListOps}
-import ca.uwaterloo.flix.util.{InternalCompilerException, Jvm, Result}
+import ca.uwaterloo.flix.util.{InternalCompilerException, JvmUtils, Result}
 import org.apache.commons.lang3.reflect.{ConstructorUtils, MethodUtils}
 
 import java.lang.reflect.{Constructor, Field, Method}
@@ -207,7 +207,7 @@ object TypeReduction {
     val tparams = ts.map(getJavaType)
     val m = MethodUtils.getMatchingAccessibleMethod(clazz, methodName, tparams *)
     // We check if we found a method and if its static flag matches.
-    if (m != null && Jvm.isStatic(m) == static) {
+    if (m != null && JvmUtils.isStatic(m) == static) {
       // Case 1: We found the method on the clazz.
       JavaMethodResolution.Resolved(m)
     } else {
@@ -215,7 +215,7 @@ object TypeReduction {
       // We make one attempt on java.lang.Object.
       val classObj = classOf[java.lang.Object]
       val m = MethodUtils.getMatchingAccessibleMethod(classObj, methodName, tparams *)
-      if (m != null && Jvm.isStatic(m) == static) {
+      if (m != null && JvmUtils.isStatic(m) == static) {
         // Case 2.1: We found the method on java.lang.Object.
         JavaMethodResolution.Resolved(m)
       } else {
@@ -297,7 +297,7 @@ object TypeReduction {
     if (!typeIsKnown) return JavaFieldResolution.UnresolvedTypes
     val opt = for {
       clazz <- Type.classFromFlixType(thisObj)
-      field <- Jvm.getField(clazz, fieldName, static = false)
+      field <- JvmUtils.getField(clazz, fieldName, static = false)
     } yield JavaFieldResolution.Resolved(field)
     opt.getOrElse(JavaFieldResolution.NotFound)
   }

--- a/main/src/ca/uwaterloo/flix/util/JvmUtils.scala
+++ b/main/src/ca/uwaterloo/flix/util/JvmUtils.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.util
 
 import java.lang.reflect.{Field, Member, Method}
 
-object Jvm {
+object JvmUtils {
 
   /**
     * Returns the (static/dynamic) `fieldName` field of `clazz` if it exists.


### PR DESCRIPTION
To be consistent.