### PR TITLE
refactor: `Simplifier.visitType`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -321,8 +321,8 @@ object Simplifier {
           case TypeConstructor.RegionToStar => MonoType.Region
 
           case TypeConstructor.Tuple(_) =>
-            val elms = tpe.typeArguments
-            MonoType.Tuple(elms.map(visitType))
+            val targs = tpe.typeArguments
+            MonoType.Tuple(targs.map(visitType))
 
           case TypeConstructor.Arrow(_) =>
             // arrow type arguments are ordered (effect, args.., result type)

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -311,7 +311,7 @@ object Simplifier {
           case TypeConstructor.Native(clazz) => MonoType.Native(clazz)
 
           case TypeConstructor.Array =>
-            val List(elm) = tpe.typeArguments
+            val List(elm, reg) = tpe.typeArguments
             MonoType.Array(visitType(elm))
 
           case TypeConstructor.Vector =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -224,8 +224,6 @@ object Simplifier {
 
   private def visitType(tpe: Type)(implicit root: MonoAst.Root, flix: Flix): MonoType = {
     val base = tpe.typeConstructor
-    val args = tpe.typeArguments.map(visitType)
-
     base match {
       case None => tpe match {
         case _ => throw InternalCompilerException(s"Unexpected type: $tpe", tpe.loc)
@@ -271,17 +269,22 @@ object Simplifier {
 
           case TypeConstructor.Receiver => throw InternalCompilerException("Unexpected Receiver", tpe.loc)
 
-          case TypeConstructor.Lazy => MonoType.Lazy(args.head)
+          case TypeConstructor.Lazy =>
+            val List(elm) = tpe.typeArguments
+            MonoType.Lazy(visitType(elm))
 
-          case TypeConstructor.Enum(sym, _) => MonoType.Enum(sym, args)
+          case TypeConstructor.Enum(sym, _) =>
+            val targs = tpe.typeArguments
+            MonoType.Enum(sym, targs.map(visitType))
 
           case TypeConstructor.Struct(sym, _) =>
+            val targs = tpe.typeArguments
             // We must do this here because the `MonoTypes` requires the individual types of each element
             // but the `Type` type only carries around the type arguments. i.e. for `struct S[v, r] {a: List[v]}`
             // at this point we would know `v` but we would need the type of `a`. We also erase to avoid infinitely
             // expanding recursive types
             val struct = root.structs(sym)
-            val subst = Substitution(struct.tparams.zip(tpe.typeArguments).toMap)
+            val subst = Substitution(struct.tparams.zip(targs).toMap)
             val substitutedStructFieldTypes = struct.fields.map { f =>
               subst(f.tpe).typeConstructor match {
                 case Some(value) => value match {
@@ -298,27 +301,43 @@ object Simplifier {
                 case None => throw InternalCompilerException(s"Unexpected type: $tpe", tpe.loc)
               }
             }
-            MonoType.Struct(sym, substitutedStructFieldTypes, args)
+            MonoType.Struct(sym, substitutedStructFieldTypes, targs.map(visitType))
 
           case TypeConstructor.RestrictableEnum(sym, _) =>
+            val targs = tpe.typeArguments
             val enumSym = new Symbol.EnumSym(sym.namespace, sym.name, sym.loc)
-            MonoType.Enum(enumSym, args)
+            MonoType.Enum(enumSym, targs.map(visitType))
 
           case TypeConstructor.Native(clazz) => MonoType.Native(clazz)
 
-          case TypeConstructor.Array => MonoType.Array(args.head)
+          case TypeConstructor.Array =>
+            val List(elm) = tpe.typeArguments
+            MonoType.Array(visitType(elm))
 
-          case TypeConstructor.Vector => MonoType.Array(args.head)
+          case TypeConstructor.Vector =>
+            val List(elm) = tpe.typeArguments
+            MonoType.Array(visitType(elm))
 
           case TypeConstructor.RegionToStar => MonoType.Region
 
-          case TypeConstructor.Tuple(_) => MonoType.Tuple(args)
+          case TypeConstructor.Tuple(_) =>
+            val elms = tpe.typeArguments
+            MonoType.Tuple(elms.map(visitType))
 
-          case TypeConstructor.Arrow(_) => MonoType.Arrow(args.drop(1).init, args.last) // Erase the purity
+          case TypeConstructor.Arrow(_) =>
+            // arrow type arguments are ordered (effect, args.., result type)
+            val eff :: targs = tpe.typeArguments
+            val (args, List(res)) = targs.splitAt(targs.length - 1)
+            MonoType.Arrow(args.map(visitType), visitType(res))
 
-          case TypeConstructor.RecordRowExtend(label) => MonoType.RecordExtend(label.name, args.head, args(1))
+          case TypeConstructor.RecordRowExtend(label) =>
+            val List(labelType, restType) = tpe.typeArguments
+            MonoType.RecordExtend(label.name, visitType(labelType), visitType(restType))
 
-          case TypeConstructor.Record => args.head
+          case TypeConstructor.Record =>
+            val List(elm) = tpe.typeArguments
+            // The row types themselves return monotype records, so we do nothing here.
+            visitType(elm)
 
           case TypeConstructor.True => MonoType.Unit
           case TypeConstructor.False => MonoType.Unit


### PR DESCRIPTION
Instead of converting args up front and the destructing the list. I now destruct the list first and then convert. This achieves:
- More checking of expected list lengths
- allows adding array regions and arrow effects to monotypes in follow up PR