### PR TITLE
feat: introduce SchemaConstraintSolver

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintSolver.scala
@@ -336,16 +336,7 @@ object ConstraintSolver {
       Result.Ok(RecordConstraintSolver.solve(t1, t2, prov, renv))
 
     case (Kind.SchemaRow, Kind.SchemaRow) =>
-      // first simplify the types to get rid of assocs if we can
-      for {
-        res0 <- SchemaUnification.unifyRows(t1, t2, renv).mapErr(toTypeError(_, prov))
-        res =
-          if (res0._2.isEmpty) {
-            ResolutionResult.newSubst(res0._1)
-          } else {
-            ResolutionResult.constraints(List(TypeConstraint.Equality(t1, t2, prov)), progress = false)
-          }
-      } yield res
+      Result.Ok(SchemaConstraintSolver.solve(t1, t2, prov, renv))
 
     case (Kind.CaseSet(sym1), Kind.CaseSet(sym2)) if sym1 == sym2 =>
       for {

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2024 Matthew Lutze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.phase.typer
+
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.shared.Scope
+import ca.uwaterloo.flix.language.ast.{Kind, Name, RigidityEnv, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.phase.typer.ConstraintSolver.ResolutionResult
+import ca.uwaterloo.flix.language.phase.typer.TypeConstraint.{Equality, Provenance}
+import ca.uwaterloo.flix.language.phase.unification.Substitution
+import ca.uwaterloo.flix.util.InternalCompilerException
+
+//
+// This is a copy of the SchemaConstraintSolver. Because the shapes are slightly different, we cannot reuse the same solver.
+//
+object SchemaConstraintSolver {
+
+  /**
+    * Unifies the two given schema types.
+    */
+  def solve(tpe1: Type, tpe2: Type, prov: Provenance, renv: RigidityEnv)(implicit scope: Scope, flix: Flix): ResolutionResult = (tpe1, tpe2) match {
+
+    // ----------
+    // ρ ~ ρ => ∅
+    case (t1, t2) if t1 == t2 =>
+      ResolutionResult.elimination
+
+    //    α ∉ fv(ρ)
+    // ----------------
+    // α ~ ρ  =>  {α ↦ ρ}
+    case (Type.Var(sym, _), tpe) if !tpe.typeVars.exists(_.sym == sym) && renv.isFlexible(sym) =>
+      ResolutionResult.newSubst(Substitution.singleton(sym, tpe))
+
+    //    α ∉ fv(ρ)
+    // ----------------
+    //  ρ ~ α  =>  {α ↦ ρ}
+    case (tpe, Type.Var(sym, _)) if !tpe.typeVars.exists(_.sym == sym) && renv.isFlexible(sym) =>
+      ResolutionResult.newSubst(Substitution.singleton(sym, tpe))
+
+    // If labels match, then we compare the label types and rest of the record.
+    //
+    // -------------------------------------------------------------
+    // ( ℓ : τ₁  | ρ₁ ) ~ ( ℓ : τ₂  | ρ₂ )  =>  { τ₁ ~ τ₂, ρ₁ ~ ρ₂ }
+    case (Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label1), _), t1, _), rest1, _), Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label2), _), t2, _), rest2, _)) if label1 == label2 =>
+      ResolutionResult.constraints(List(Equality(t1, t2, prov), Equality(rest1, rest2, prov)), progress = true)
+
+    // If labels do not match, then we pivot the right record to make them match.
+    //
+    //        ρ₂ ~~{ℓ : τ₁}~~> { ℓ : τ₃ | ρ₃ } ; S
+    // -------------------------------------------------
+    // { ℓ : τ₁ | ρ₁ } ~ ρ₂  => { τ₁ ~ τ₃, ρ₁ ~ ρ₃ } ; S
+    case (r1@Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label), _), t1, _), _, _), r2) =>
+      pivot(r2, label, t1, r1.typeVars.map(_.sym), renv) match {
+        case Some((newRow, subst)) =>
+          ResolutionResult(subst, List(Equality(r1, newRow, prov)), progress = true)
+
+        case None =>
+          ResolutionResult.constraints(List(Equality(tpe1, tpe2, prov)), progress = false)
+      }
+
+    // If nothing matches, we give up and return the constraints as we got them.
+    case _ => ResolutionResult.constraints(List(Equality(tpe1, tpe2, prov)), progress = false)
+  }
+
+  /**
+    * Rearranges the row so that the given label is at the front.
+    *
+    * Returns None if no such pivot is possible.
+    */
+  private def pivot(row: Type, hdLabel: Name.Pred, hdTpe: Type, tvars: Set[Symbol.KindedTypeVarSym], renv: RigidityEnv)(implicit scope: Scope, flix: Flix): Option[(Type, Substitution)] = row match {
+
+    // If head labels match, then there is nothing to do. We return the same record.
+    //
+    // -------------------------------------------
+    // { ℓ : τ₁ | ρ } ~~{ℓ : τ₂}~~> { ℓ : τ₁ | ρ }
+    case r@Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label), _), _, _), _, _) if label == hdLabel =>
+      Some((r, Substitution.empty))
+
+    // If head labels do not match, we need to recurse and bring the selected label to the front.
+    //
+    //       ℓ₁ ≠ ℓ₂    ρ₁ ~~{ℓ₂ : τ₂}~~> { ℓ₂ : τ₃  | ρ₃ }
+    // ---------------------------------------------------------
+    // { ℓ₁ : τ₁ | ρ₁ } ~~{ℓ₂ : τ₂}~~> { ℓ₂ : τ₃, ℓ₁ : τ₁ | ρ₃ }
+    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label), _), tpe, _), rest, loc) =>
+      pivot(rest, hdLabel, hdTpe, tvars, renv).map {
+        case (Type.Apply(newHead, rest, _), subst) =>
+          // The new row from the recursive call has the selected label at the head.
+          // Now we just swap the new row's head with ours, to keep the selected label on top.
+          val newRow = Type.Apply(newHead, Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label), loc), tpe, loc), rest, loc), loc)
+          (newRow, subst)
+
+        case _ => throw InternalCompilerException("unexpected non-record", loc)
+      }
+
+    // If we have a variable, then we can map it to a fresh record type with the selected label at the head.
+    //
+    //     β fresh, α ∉ fv(ρ)
+    // ----------------------------------------------------
+    //  α ~~{ℓ : τ}~~> { ℓ : τ | β } ; {α ↦ { ℓ : τ | β }}
+    case Type.Var(sym, loc) if !tvars.contains(sym) && renv.isFlexible(sym) =>
+      val tvar = Type.freshVar(Kind.SchemaRow, loc)
+      val newRow = Type.mkSchemaRowExtend(hdLabel, hdTpe, tvar, loc)
+      val subst = Substitution.singleton(sym, newRow)
+      Some((newRow, subst))
+
+    // If no rule matches, then we cannot pivot this record type.
+    case _ => None
+  }
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
@@ -64,8 +64,12 @@ object SchemaConstraintSolver {
     // { ℓ : τ₁ | ρ₁ } ~ ρ₂  => { τ₁ ~ τ₃, ρ₁ ~ ρ₃ } ; S
     case (r1@Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label), _), t1, _), rest1, _), r2) =>
       pivot(r2, label, t1, r1.typeVars.map(_.sym), renv) match {
+        // ideally we should return these constraints, but for efficiency reasons we recurse to solve the whole row
         case Some((Type.Apply(Type.Apply(_, t3, _), rest3, _), subst)) =>
-          ResolutionResult(subst, List(Equality(t1, t3, prov), Equality(rest1, rest3, prov)), progress = true)
+          solve(subst(rest1), subst(rest3), prov, renv) match {
+            case ResolutionResult(restSubst, restConstrs, _) =>
+              ResolutionResult(restSubst @@ subst, Equality(t1, t3, prov) :: restConstrs, progress = true)
+          }
 
         case None =>
           ResolutionResult.constraints(List(Equality(tpe1, tpe2, prov)), progress = false)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
@@ -24,7 +24,7 @@ import ca.uwaterloo.flix.language.phase.unification.Substitution
 import ca.uwaterloo.flix.util.InternalCompilerException
 
 //
-// This is a copy of the SchemaConstraintSolver. Because the shapes are slightly different, we cannot reuse the same solver.
+// This is a copy of the RecordConstraintSolver. Because the shapes are slightly different, we cannot reuse the same solver.
 //
 object SchemaConstraintSolver {
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
@@ -62,10 +62,10 @@ object SchemaConstraintSolver {
     //        ρ₂ ~~{ℓ : τ₁}~~> { ℓ : τ₃ | ρ₃ } ; S
     // -------------------------------------------------
     // { ℓ : τ₁ | ρ₁ } ~ ρ₂  => { τ₁ ~ τ₃, ρ₁ ~ ρ₃ } ; S
-    case (r1@Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label), _), t1, _), _, _), r2) =>
+    case (r1@Type.Apply(Type.Apply(Type.Cst(TypeConstructor.SchemaRowExtend(label), _), t1, _), rest1, _), r2) =>
       pivot(r2, label, t1, r1.typeVars.map(_.sym), renv) match {
-        case Some((newRow, subst)) =>
-          ResolutionResult(subst, List(Equality(r1, newRow, prov)), progress = true)
+        case Some((Type.Apply(Type.Apply(_, t3, _), rest3, _), subst)) =>
+          ResolutionResult(subst, List(Equality(t1, t3, prov), Equality(rest1, rest3, prov)), progress = true)
 
         case None =>
           ResolutionResult.constraints(List(Equality(tpe1, tpe2, prov)), progress = false)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/SchemaConstraintSolver.scala
@@ -69,6 +69,8 @@ object SchemaConstraintSolver {
 
         case None =>
           ResolutionResult.constraints(List(Equality(tpe1, tpe2, prov)), progress = false)
+
+        case Some((t, _)) => throw InternalCompilerException("unexpected result from pivot: " + t, t.loc)
       }
 
     // If nothing matches, we give up and return the constraints as we got them.

--- a/main/src/ca/uwaterloo/flix/util/Options.scala
+++ b/main/src/ca/uwaterloo/flix/util/Options.scala
@@ -56,7 +56,7 @@ object Options {
     xsubeffecting = SubEffectLevel.Nothing,
     XPerfN = None,
     XPerfFrontend = false,
-    xiterations = 1000
+    xiterations = 2000
   )
 
   /**

--- a/main/src/ca/uwaterloo/flix/util/Options.scala
+++ b/main/src/ca/uwaterloo/flix/util/Options.scala
@@ -56,7 +56,7 @@ object Options {
     xsubeffecting = SubEffectLevel.Nothing,
     XPerfN = None,
     XPerfFrontend = false,
-    xiterations = 2000
+    xiterations = 5000
   )
 
   /**


### PR DESCRIPTION
The same as the last PR. I will follow up to change everywhere it says "record" to "row", but I will leave the type rules as they are.

I've bumped up the solver iteration limit since some schema cases were struggling.