### PR TITLE
refactor: use `phase` in `phaseNew`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -618,7 +618,7 @@ class Flix {
   /**
     * Enters the phase with the given name.
     */
-  def phaseNew[A, B](phaseName: String)(f: => (A, B))(implicit d: Debug[A]): (A, B) = {
+  def phase2[A, B](phaseName: String)(f: => (A, B))(implicit d: Debug[A]): (A, B) = {
     implicit object DebugValue extends Debug[(A, B)] {
       override def emit(phase: String, tuple: (A, B))(implicit flix: Flix): Unit = {
         val (a, _) = tuple

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -631,9 +631,9 @@ class Flix {
   /**
     * Enters the phase with the given name.
     */
-  def phase[A](phase: String)(f: => A)(implicit d: Debug[A]): A = {
+  def phase[A](phaseName: String)(f: => A)(implicit d: Debug[A]): A = {
     // Initialize the phase time object.
-    currentPhase = PhaseTime(phase, 0)
+    currentPhase = PhaseTime(phaseName, 0)
 
     if (options.progress) {
       progressBar.observe(currentPhase.phase, "", sample = false)
@@ -651,7 +651,7 @@ class Flix {
     phaseTimers += currentPhase
 
     if (this.options.xprintphases) {
-      d.emit(phase, r)(this)
+      d.emit(phaseName, r)(this)
     }
 
     // Return the result computed by the phase.

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -34,7 +34,7 @@ object Instances {
     * Validates instances and traits in the given AST root.
     */
   def run(root: TypedAst.Root, oldRoot: TypedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): (Unit, List[InstanceError]) =
-    flix.phaseNew("Instances") {
+    flix.phase2("Instances") {
       val errors = visitInstances(root, oldRoot, changeSet) ::: visitTraits(root)
       ((), errors)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -58,7 +58,7 @@ import scala.jdk.CollectionConverters.CollectionHasAsScala
   */
 object Kinder {
 
-  def run(root: ResolvedAst.Root, oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): (KindedAst.Root, List[KindError]) = flix.phaseNew("Kinder") {
+  def run(root: ResolvedAst.Root, oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): (KindedAst.Root, List[KindError]) = flix.phase2("Kinder") {
     implicit val sctx: SharedContext = SharedContext.mk()
 
     // Type aliases must be processed first in order to provide a `taenv` for looking up type alias symbols.

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -37,7 +37,7 @@ object Namer {
     * Introduces unique names for each syntactic entity in the given `program`.
     * */
   def run(program: DesugaredAst.Root)(implicit flix: Flix): (NamedAst.Root, List[NameError]) =
-    flix.phaseNew("Namer") {
+    flix.phase2("Namer") {
 
       // Construct a new shared context.
       implicit val sctx: SharedContext = SharedContext.mk()

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -109,7 +109,7 @@ object PatMatch {
     * Returns an error message if a pattern match is not exhaustive
     */
   def run(root: TypedAst.Root)(implicit flix: Flix): (Unit, List[NonExhaustiveMatchError]) =
-    flix.phaseNew("PatMatch") {
+    flix.phase2("PatMatch") {
       implicit val r: TypedAst.Root = root
 
       val classDefExprs = root.traits.values.flatMap(_.sigs).flatMap(_.exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Reader.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Reader.scala
@@ -38,7 +38,7 @@ object Reader {
     * Reads the given source inputs into memory.
     */
   def run(inputs: List[Input], names: MultiMap[List[String], String])(implicit flix: Flix): (ReadAst.Root, List[CompilationMessage]) =
-    flix.phaseNew("Reader") {
+    flix.phase2("Reader") {
 
       val result = mutable.Map.empty[Source, Unit]
       for (input <- inputs) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
@@ -34,7 +34,7 @@ import scala.collection.immutable.SortedSet
   */
 object Regions {
 
-  def run(root: Root)(implicit flix: Flix): (Unit, List[CompilationMessage]) = flix.phaseNew("Regions") {
+  def run(root: Root)(implicit flix: Flix): (Unit, List[CompilationMessage]) = flix.phase2("Regions") {
     val defErrors = ParOps.parMap(root.defs)(kv => visitDef(kv._2)).flatten
     val sigErrors = ParOps.parMap(root.sigs)(kv => visitSig(kv._2)).flatten
     val instanceErrors = ParOps.parMap(root.instances)(kv => kv._2.flatMap(visitInstance)).flatten

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -30,7 +30,7 @@ object Safety {
   /**
     * Performs safety and well-formedness checks on the given AST `root`.
     */
-  def run(root: Root)(implicit flix: Flix): (Unit, List[SafetyError]) = flix.phaseNew("Safety") {
+  def run(root: Root)(implicit flix: Flix): (Unit, List[SafetyError]) = flix.phase2("Safety") {
     //
     // Collect all errors.
     //

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -48,7 +48,7 @@ object Stratifier {
   /**
     * Returns a stratified version of the given AST `root`.
     */
-  def run(root: Root)(implicit flix: Flix): (Root, List[StratificationError]) = flix.phaseNew("Stratifier") {
+  def run(root: Root)(implicit flix: Flix): (Root, List[StratificationError]) = flix.phase2("Stratifier") {
     // Construct a new shared context.
     implicit val sctx: SharedContext = SharedContext.mk()
 


### PR DESCRIPTION
Here is how I would refactor `phaseNew` to use `phase` so we can keep both. Note that I also updated the parameter names to avoid shadowing the function name, e.g., `phase(phase)(f)` is not resolved correctly and that I renamed `phaseNew` to `phase2` implying that both functions should be there with different functionality

Related to https://github.com/flix/flix/issues/8815