### PR TITLE
refactor: replace all uses of `StringBuilder` in `ToString` instances

### DIFF
--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -100,16 +100,7 @@ instance Witherable[Chain]
 
 instance ToString[Chain[a]] with ToString[a] {
     pub def toString(c: Chain[a]): String = region rc {
-        let sb = StringBuilder.empty(rc);
-        StringBuilder.appendString!("Chain#{", sb);
-        Chain.forEachWithIndex((i, x) -> {
-            if (i < 1)
-                StringBuilder.appendString!("${x}", sb)
-            else
-                StringBuilder.appendString!(", ${x}", sb)
-            }, c);
-        StringBuilder.appendString!("}", sb);
-        StringBuilder.toString(sb)
+        "Chain#{" + (Chain.iterator(rc, c) |> Iterator.join(" ,")) + "}"
     }
 }
 

--- a/main/src/library/DelayList.flix
+++ b/main/src/library/DelayList.flix
@@ -133,16 +133,7 @@ mod DelayList {
     ///
     @Experimental
     pub def toString(l: DelayList[a]): String with ToString[a] = region rc {
-        let sb = StringBuilder.empty(rc);
-        StringBuilder.appendString!("DelayList(", sb);
-        forEachWithIndex((i, x) -> {
-            if (i == 0)
-                StringBuilder.appendString!("${x}", sb)
-            else
-                StringBuilder.appendString!(", ${x}", sb)
-            }, l);
-        StringBuilder.appendString!(")", sb);
-        StringBuilder.toString(sb)
+        "DelayList(" + (DelayList.iterator(rc, l) |> Iterator.join(", ")) + ")"
     }
 
     ///

--- a/main/src/library/DelayMap.flix
+++ b/main/src/library/DelayMap.flix
@@ -66,17 +66,7 @@ mod DelayMap {
     ///
     @Experimental
     pub def toString(m: DelayMap[k, v]): String with ToString[k], ToString[v] = region rc {
-        let sb = StringBuilder.empty(rc);
-        let _ = parallelForce(m);
-        StringBuilder.appendString!("DelayMap#{", sb);
-        forEachWithIndex((i, k, v) -> {
-            if (i < 1)
-                StringBuilder.appendString!("${k} => ${v}", sb)
-            else
-                StringBuilder.appendString!(", ${k} => ${v}", sb)
-            }, m);
-        StringBuilder.appendString!("}", sb);
-        StringBuilder.toString(sb)
+        "DelayMap#{" + (DelayMap.iterator(rc, m) |> Iterator.map(match (k, v) -> "${k} => ${v}") |> Iterator.join(", ")) + "}"
     }
 
     ///

--- a/main/src/library/Fixpoint/Ast/Datalog.flix
+++ b/main/src/library/Fixpoint/Ast/Datalog.flix
@@ -66,32 +66,29 @@ mod Fixpoint.Ast.Datalog {
     instance ToString[Datalog[v]] {
         pub def toString(cs: Datalog[v]): String = match cs {
             case Datalog.Datalog(facts, rules) => region rc {
-                let sb = StringBuilder.empty(rc);
-                let appendConstraint = f -> StringBuilder.appendLineWith!(ToString.toString, f, sb);
-                foreach (f <- facts) appendConstraint(f);
-                foreach (ru <- rules) appendConstraint(ru);
-                StringBuilder.toString(sb)
+                Iterator.append(Vector.iterator(rc, facts), Vector.iterator(rc, rules))
+                    |> Iterator.join(String.lineSeparator())
             }
             case Datalog.Model(db) => region rc {
                 use Fixpoint.Ast.Ram.toDenotation;
-                let sb = StringBuilder.empty(rc);
-                Map.forEach(ramSym -> rel -> match toDenotation(ramSym) {
-                    case Denotation.Relational => Map.forEach((tuple, _) -> {
-                        let tupleString = tuple |> Vector.map(Debug.stringify) |> Vector.join(", ");
-                        StringBuilder.appendLine!("${ramSym}(${tupleString}).", sb)
-                    }, rel)
-                    case Denotation.Latticenal(_) => Map.forEach((tuple, lat) -> {
-                        let tupleString = tuple |> Vector.map(Debug.stringify) |> Vector.join(", ");
-                        StringBuilder.appendLine!("${ramSym}(${tupleString}; %{lat}).", sb)
-                    }, rel)
-                }, db);
-                StringBuilder.toString(sb)
+                Map.iterator(rc, db)
+                    |> Iterator.flatMap(match (ramSym, rel) -> {
+                        Map.iterator(rc, rel) |> Iterator.map(match (tuple, lat) -> {
+                            let tupleString = tuple |> Vector.map(Debug.stringify) |> Vector.join(", ");
+                            match toDenotation(ramSym) {
+                                case Denotation.Relational => "${ramSym}(${tupleString})."
+                                case Denotation.Latticenal(_) => "${ramSym}(${tupleString}; %{lat})."
+                            }
+                        })
+                    })
+                    |> Iterator.join(String.lineSeparator())
+                    + String.lineSeparator()
             }
-            case Datalog.Join(d1, d2) => region rc {
-                let sb = StringBuilder.empty(rc);
-                StringBuilder.appendLine!(ToString.toString(d1), sb);
-                StringBuilder.appendLine!(ToString.toString(d2), sb);
-                StringBuilder.toString(sb)
+            case Datalog.Join(d1, d2) => {
+                ToString.toString(d1)
+                    + String.lineSeparator()
+                    + ToString.toString(d2)
+                    + String.lineSeparator()
             }
         }
     }

--- a/main/src/library/List.flix
+++ b/main/src/library/List.flix
@@ -145,11 +145,10 @@ mod List {
     /// Renders the list `l` to a String.
     ///
     pub def toString(l: List[a]): String with ToString[a] = region rc {
-        let sb = StringBuilder.empty(rc);
-        foreach (x <- l)
-            StringBuilder.appendString!("${x} :: ", sb);
-        StringBuilder.appendString!("Nil", sb);
-        StringBuilder.toString(sb)
+        List.iterator(rc, l)
+            |> Iterator.map(ToString.toString)
+            |> xs -> Iterator.append(xs, Iterator.singleton(rc, "Nil"))
+            |> Iterator.join(" :: ")
     }
 
     ///

--- a/main/src/library/Map.flix
+++ b/main/src/library/Map.flix
@@ -135,16 +135,7 @@ mod Map {
     /// Returns a string representation of the given map `m`.
     ///
     pub def toString(m: Map[k, v]): String with ToString[k], ToString[v] = region rc {
-        let sb = StringBuilder.empty(rc);
-        StringBuilder.appendString!("Map#{", sb);
-        forEachWithIndex((i, k, v) -> {
-            if (i < 1)
-                StringBuilder.appendString!("${k} => ${v}", sb)
-            else
-                StringBuilder.appendString!(", ${k} => ${v}", sb)
-            }, m);
-        StringBuilder.appendString!("}", sb);
-        StringBuilder.toString(sb)
+        "Map#{" + (Map.iterator(rc, m) |> Iterator.map(match (k, v) -> "${k} => ${v}") |> Iterator.join(", ")) + "}"
     }
 
     ///

--- a/main/src/library/MultiMap.flix
+++ b/main/src/library/MultiMap.flix
@@ -90,17 +90,7 @@ mod MultiMap {
     /// Returns a string representation of `m`.
     ///
     pub def toString(m: MultiMap[k, v]): String with ToString[k], ToString[v] = region rc {
-        let sb = StringBuilder.empty(rc);
-        let MultiMap(m1) = m;
-        StringBuilder.appendString!("MultiMap#{", sb);
-        Map.forEachWithIndex((i, k, v) -> {
-            if (i < 1)
-                StringBuilder.appendString!("${k} => ${v}", sb)
-            else
-                StringBuilder.appendString!(", ${k} => ${v}", sb)
-            }, m1);
-        StringBuilder.appendString!("}", sb);
-        StringBuilder.toString(sb)
+        "MultiMap#{" + (MultiMap.iterator(rc, m) |> Iterator.map(match (k, v) -> "${k} => ${v}") |> Iterator.join(", ")) + "}"
     }
 
     ///

--- a/main/src/library/Nec.flix
+++ b/main/src/library/Nec.flix
@@ -125,16 +125,7 @@ instance Reducible[Nec] {
 
 instance ToString[Nec[a]] with ToString[a] {
     pub def toString(c: Nec[a]): String = region rc {
-        let sb = StringBuilder.empty(rc);
-        StringBuilder.appendString!("Nec#{", sb);
-        Nec.forEachWithIndex((i, x) -> {
-            if (i < 1)
-                StringBuilder.appendString!("${x}", sb)
-            else
-                StringBuilder.appendString!(", ${x}", sb)
-        }, c);
-        StringBuilder.appendString!("}", sb);
-        StringBuilder.toString(sb)
+        "Nec#{" + (Nec.iterator(rc, c) |> Iterator.join(", ")) + "}"
     }
 }
 

--- a/main/src/library/Nel.flix
+++ b/main/src/library/Nel.flix
@@ -129,16 +129,9 @@ mod Nel {
     ///
     /// Returns a string representation of the given non-empty list `l`.
     ///
-    pub def toString(l: Nel[a]): String with ToString[a] = region rc {
+    pub def toString(l: Nel[a]): String with ToString[a] = {
         let Nel(x, xs) = l;
-        let sb = StringBuilder.empty(rc);
-        StringBuilder.appendString!("Nel(${x}, ", sb);
-
-        let list = List.toString(xs);
-        StringBuilder.appendString!(list, sb);
-        StringBuilder.appendString!(")", sb);
-
-        StringBuilder.toString(sb)
+        "Nel(${x}, ${xs})"
     }
 
     ///

--- a/main/src/library/Set.flix
+++ b/main/src/library/Set.flix
@@ -116,16 +116,7 @@ mod Set {
     /// Returns a string representation of the given set `s`.
     ///
     pub def toString(s: Set[a]): String with ToString[a] = region rc {
-        let sb = StringBuilder.empty(rc);
-        StringBuilder.appendString!("Set#{", sb);
-        forEachWithIndex((i, x) -> {
-            if (i == 0)
-                StringBuilder.appendString!("${x}", sb)
-            else
-                StringBuilder.appendString!(", ${x}", sb)
-        }, s);
-        StringBuilder.appendString!("}", sb);
-        StringBuilder.toString(sb)
+        "Set#{" + (Set.iterator(rc, s) |> Iterator.join(", ")) + "}"
     }
 
     ///

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -161,19 +161,7 @@ mod Vector {
     /// Returns a string representation of the given vector `v`.
     ///
     pub def toString(v: Vector[a]): String with ToString[a] = region rc {
-        let sb = StringBuilder.empty(rc);
-        let first = Ref.fresh(rc, true);
-
-        StringBuilder.appendString!("Vector#{", sb);
-
-        let f = x -> {
-            if (not Ref.get(first)) StringBuilder.appendString!(", ", sb) else Ref.put(false, first);
-            StringBuilder.appendString!("${x}", sb)
-        };
-        forEach(f, v);
-
-        StringBuilder.appendString!("}", sb);
-        StringBuilder.toString(sb)
+        "Vector#{" + (Vector.iterator(rc, v) |> Iterator.join(", ")) + "}"
     }
 
     ///


### PR DESCRIPTION
Fixes #8861