### PR TITLE
refactor: move `LabelledPrecendenceGraph` from `Ast` to `shared`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -16,7 +16,6 @@
 
 package ca.uwaterloo.flix.language.ast
 
-import ca.uwaterloo.flix.language.ast.shared.{Denotation, Fixity, Polarity}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
 import java.util.Objects
@@ -25,64 +24,6 @@ import java.util.Objects
   * A collection of AST nodes that are shared across multiple ASTs.
   */
 object Ast {
-
-  /**
-    * Represents a positive or negative labelled dependency edge.
-    *
-    * The labels represent predicate nodes that must co-occur for the dependency to be relevant.
-    */
-  case class LabelledEdge(head: Name.Pred, polarity: Polarity, fixity: Fixity, labels: Vector[Label], body: Name.Pred, loc: SourceLocation)
-
-  /**
-    * Represents a label in the labelled graph.
-    */
-  case class Label(pred: Name.Pred, den: Denotation, arity: Int, terms: List[Type])
-
-  /**
-    * Represents a labelled graph; the dependency graph with additional labels
-    * on the edges allowing more accurate filtering. The rule `A :- not B, C` would
-    * add dependency edges `B -x> A` and `C -> A`. The labelled graph can then
-    * add labels that allow the two edges to be filtered out together. If we
-    * look at a program consisting of A, B, and D. then the rule `C -> A`
-    * cannot be relevant, but by remembering that B occurred together with A,
-    * we can also rule out `B -x> A`. The labelled edges would be `B -[C]-x> A`
-    * and `C -[B]-> A`.
-    */
-  object LabelledPrecedenceGraph {
-    /**
-      * The empty labelled graph.
-      */
-    val empty: LabelledPrecedenceGraph = LabelledPrecedenceGraph(Vector.empty)
-  }
-
-  case class LabelledPrecedenceGraph(edges: Vector[LabelledEdge]) {
-    /**
-      * Returns a labelled graph with all labelled edges in `this` and `that` labelled graph.
-      */
-    def +(that: LabelledPrecedenceGraph): LabelledPrecedenceGraph = {
-      if (this eq LabelledPrecedenceGraph.empty)
-        that
-      else if (that eq LabelledPrecedenceGraph.empty)
-        this
-      else
-        LabelledPrecedenceGraph(this.edges ++ that.edges)
-    }
-
-    /**
-      * Returns `this` labelled graph including only the edges where all its labels are in
-      * `syms` and the labels match according to `'`labelEq`'`.
-      *
-      * A rule like `A(ta) :- B(tb), not C(tc).` is represented by `edge(A, pos, {la, lb, lc}, B)` etc.
-      * and is only included in the output if `syms` contains all of `la.pred, lb.pred, lc.pred` and `labelEq(syms(A), la)` etc.
-      */
-    def restrict(syms: Map[Name.Pred, Label], labelEq: (Label, Label) => Boolean): LabelledPrecedenceGraph = {
-      def include(l: Label): Boolean = syms.get(l.pred).exists(l2 => labelEq(l, l2))
-
-      LabelledPrecedenceGraph(edges.filter {
-        case LabelledEdge(_, _, _, labels, _, _) => labels.forall(include)
-      })
-    }
-  }
 
   object Stratification {
     /**

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -17,9 +17,8 @@
 package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.language.CompilationMessage
-import ca.uwaterloo.flix.language.ast.Ast.LabelledPrecedenceGraph
-import ca.uwaterloo.flix.language.ast.shared.SymUse.{AssocTypeSymUse, CaseSymUse, DefSymUse, EffectSymUse, LocalDefSymUse, OpSymUse, RestrictableCaseSymUse, RestrictableEnumSymUse, SigSymUse, StructFieldSymUse, TraitSymUse}
-import ca.uwaterloo.flix.language.ast.shared.{Annotations, CheckedCastType, Constant, Denotation, Doc, Fixity, Modifiers, Polarity, Source}
+import ca.uwaterloo.flix.language.ast.shared.SymUse.*
+import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.util.collection.{ListMap, MultiMap}
 
 import java.lang.reflect.{Constructor, Field, Method}

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/LabelledPrecedenceGraph.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/LabelledPrecedenceGraph.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 Holger Dal Mogensen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.ast.shared
+
+import ca.uwaterloo.flix.language.ast.shared.LabelledPrecedenceGraph.{Label, LabelledEdge}
+import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Type}
+
+/**
+  * Represents a labelled graph; the dependency graph with additional labels
+  * on the edges allowing more accurate filtering. The rule `A :- not B, C` would
+  * add dependency edges `B -x> A` and `C -> A`. The labelled graph can then
+  * add labels that allow the two edges to be filtered out together. If we
+  * look at a program consisting of A, B, and D. then the rule `C -> A`
+  * cannot be relevant, but by remembering that B occurred together with A,
+  * we can also rule out `B -x> A`. The labelled edges would be `B -[C]-x> A`
+  * and `C -[B]-> A`.
+  */
+object LabelledPrecedenceGraph {
+  /**
+    * Represents a positive or negative labelled dependency edge.
+    *
+    * The labels represent predicate nodes that must co-occur for the dependency to be relevant.
+    */
+  case class LabelledEdge(head: Name.Pred, polarity: Polarity, fixity: Fixity, labels: Vector[Label], body: Name.Pred, loc: SourceLocation)
+
+  /**
+    * Represents a label in the labelled graph.
+    */
+  case class Label(pred: Name.Pred, den: Denotation, arity: Int, terms: List[Type])
+
+  /**
+    * The empty labelled graph.
+    */
+  val empty: LabelledPrecedenceGraph = LabelledPrecedenceGraph(Vector.empty)
+}
+
+case class LabelledPrecedenceGraph(edges: Vector[LabelledEdge]) {
+  /**
+    * Returns a labelled graph with all labelled edges in `this` and `that` labelled graph.
+    */
+  def +(that: LabelledPrecedenceGraph): LabelledPrecedenceGraph = {
+    if (this eq LabelledPrecedenceGraph.empty)
+      that
+    else if (that eq LabelledPrecedenceGraph.empty)
+      this
+    else
+      LabelledPrecedenceGraph(this.edges ++ that.edges)
+  }
+
+  /**
+    * Returns `this` labelled graph including only the edges where all its labels are in
+    * `syms` and the labels match according to `'`labelEq`'`.
+    *
+    * A rule like `A(ta) :- B(tb), not C(tc).` is represented by `edge(A, pos, {la, lb, lc}, B)` etc.
+    * and is only included in the output if `syms` contains all of `la.pred, lb.pred, lc.pred` and `labelEq(syms(A), la)` etc.
+    */
+  def restrict(syms: Map[Name.Pred, Label], labelEq: (Label, Label) => Boolean): LabelledPrecedenceGraph = {
+    def include(l: Label): Boolean = syms.get(l.pred).exists(l2 => labelEq(l, l2))
+
+    LabelledPrecedenceGraph(edges.filter {
+      case LabelledEdge(_, _, _, labels, _, _) => labels.forall(include)
+    })
+  }
+}

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -17,15 +17,14 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.CompilationMessage
-import ca.uwaterloo.flix.language.ast.Ast.{Label, LabelledEdge, LabelledPrecedenceGraph}
 import ca.uwaterloo.flix.language.ast.Type.eraseAliases
-import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.Body
 import ca.uwaterloo.flix.language.ast.TypedAst.*
-import ca.uwaterloo.flix.language.ast.shared.Denotation
+import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.Body
+import ca.uwaterloo.flix.language.ast.shared.LabelledPrecedenceGraph.{Label, LabelledEdge}
+import ca.uwaterloo.flix.language.ast.shared.{Denotation, LabelledPrecedenceGraph}
 import ca.uwaterloo.flix.language.ast.{Type, TypeConstructor}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
-import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps, Validation}
+import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
 /**
   * The [[PredDeps]] class computes the [[LabelledPrecedenceGraph]] of the whole program,

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -17,16 +17,16 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.Ast.*
-import ca.uwaterloo.flix.language.ast.TypedAst.*
 import ca.uwaterloo.flix.language.ast.*
-import ca.uwaterloo.flix.language.ast.shared.{Fixity, Polarity, Scope}
+import ca.uwaterloo.flix.language.ast.TypedAst.*
+import ca.uwaterloo.flix.language.ast.shared.LabelledPrecedenceGraph.{Label, LabelledEdge}
+import ca.uwaterloo.flix.language.ast.shared.{Fixity, LabelledPrecedenceGraph, Polarity, Scope}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.StratificationError
 import ca.uwaterloo.flix.language.phase.PredDeps.termTypesAndDenotation
 import ca.uwaterloo.flix.language.phase.unification.Unification
 import ca.uwaterloo.flix.util.collection.ListMap
-import ca.uwaterloo.flix.util.{ParOps, Result, Validation}
+import ca.uwaterloo.flix.util.{ParOps, Result}
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.annotation.tailrec

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -16,15 +16,14 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.Ast.LabelledPrecedenceGraph
 import ca.uwaterloo.flix.language.ast.*
-import ca.uwaterloo.flix.language.ast.shared.Scope
+import ca.uwaterloo.flix.language.ast.shared.{LabelledPrecedenceGraph, Scope}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.TypeError
 import ca.uwaterloo.flix.language.phase.typer.{ConstraintGen, ConstraintSolver, TypeContext}
 import ca.uwaterloo.flix.language.phase.unification.Substitution
-import ca.uwaterloo.flix.util.Validation.{mapN, traverse}
 import ca.uwaterloo.flix.util.*
+import ca.uwaterloo.flix.util.Validation.{mapN, traverse}
 import ca.uwaterloo.flix.util.collection.ListMap
 
 object Typer {


### PR DESCRIPTION
Related to #7871