### PR TITLE
refactor: remove `SoftFailure` from `Resolver`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2482,9 +2482,10 @@ object Resolver {
       case NamedAst.Type.Var(ident, loc) =>
         lookupTypeVar(ident, wildness, env) match {
           case Result.Ok(sym) => Validation.success(UnkindedType.Var(sym, loc))
-          case Result.Err(e) =>
+          case Result.Err(error) =>
             // Note: We assume the default type variable has kind Star.
-            Validation.toSoftFailure(UnkindedType.Error(loc), e)
+            sctx.errors.add(error)
+            Validation.success(UnkindedType.Error(loc))
         }
 
       case NamedAst.Type.Unit(loc) => Validation.success(UnkindedType.Cst(TypeConstructor.Unit, loc))

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3226,9 +3226,7 @@ object Resolver {
   }
 
   /**
-    * Successfully returns the given `enum0` if it is accessible from the given namespace `ns0`.
-    *
-    * Otherwise fails with a resolution error.
+    * Checks whether `enum0` it is accessible from the given namespace `ns0`.
     *
     * An enum is accessible from a namespace `ns0` if:
     *

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2518,7 +2518,7 @@ object Resolver {
             case TypeLookupResult.Struct(struct) => Validation.success(getStructTypeIfAccessible(struct, ns0, loc))
             case TypeLookupResult.RestrictableEnum(enum0) => getRestrictableEnumTypeIfAccessible(enum0, ns0, loc)
             case TypeLookupResult.TypeAlias(typeAlias) => Validation.success(getTypeAliasTypeIfAccessible(typeAlias, ns0, loc))
-            case TypeLookupResult.Effect(eff) => getEffectTypeIfAccessible(eff, ns0, root, loc)
+            case TypeLookupResult.Effect(eff) => getEffectTypeIfAccessible(eff, ns0, loc)
             case TypeLookupResult.JavaClass(clazz) => Validation.success(flixifyType(clazz, loc))
             case TypeLookupResult.AssocType(assoc) => getAssocTypeTypeIfAccessible(assoc, ns0, root, loc)
             case TypeLookupResult.NotFound =>
@@ -2535,7 +2535,7 @@ object Resolver {
           case TypeLookupResult.Struct(struct) => Validation.success(getStructTypeIfAccessible(struct, ns0, loc))
           case TypeLookupResult.RestrictableEnum(enum0) => getRestrictableEnumTypeIfAccessible(enum0, ns0, loc)
           case TypeLookupResult.TypeAlias(typeAlias) => Validation.success(getTypeAliasTypeIfAccessible(typeAlias, ns0, loc))
-          case TypeLookupResult.Effect(eff) => getEffectTypeIfAccessible(eff, ns0, root, loc)
+          case TypeLookupResult.Effect(eff) => getEffectTypeIfAccessible(eff, ns0, loc)
           case TypeLookupResult.JavaClass(clazz) => Validation.success(flixifyType(clazz, loc))
           case TypeLookupResult.AssocType(assoc) => getAssocTypeTypeIfAccessible(assoc, ns0, root, loc)
           case TypeLookupResult.NotFound =>
@@ -3428,7 +3428,7 @@ object Resolver {
     * (a) the definition is marked public, or
     * (b) the definition is defined in the namespace `ns0` itself or in a parent of `ns0`.
     */
-  private def getEffectIfAccessible(eff0: NamedAst.Declaration.Effect, ns0: Name.NName, loc: SourceLocation): Validation[NamedAst.Declaration.Effect, ResolutionError] = {
+  private def getEffectIfAccessible(eff0: NamedAst.Declaration.Effect, ns0: Name.NName, loc: SourceLocation)(implicit sctx: SharedContext): Validation[NamedAst.Declaration.Effect, ResolutionError] = {
     //
     // Check if the effect is marked public.
     //
@@ -3446,7 +3446,9 @@ object Resolver {
     //
     // The effect is not accessible.
     //
-    Validation.toSoftFailure(eff0, ResolutionError.InaccessibleEffect(eff0.sym, ns0, loc))
+    val error = ResolutionError.InaccessibleEffect(eff0.sym, ns0, loc)
+    sctx.errors.add(error)
+    Validation.success(eff0)
   }
 
   /**
@@ -3454,7 +3456,7 @@ object Resolver {
     *
     * Otherwise fails with a resolution error.
     */
-  private def getEffectTypeIfAccessible(eff0: NamedAst.Declaration.Effect, ns0: Name.NName, root: NamedAst.Root, loc: SourceLocation): Validation[UnkindedType, ResolutionError] = {
+  private def getEffectTypeIfAccessible(eff0: NamedAst.Declaration.Effect, ns0: Name.NName, loc: SourceLocation)(implicit sctx: SharedContext): Validation[UnkindedType, ResolutionError] = {
     mapN(getEffectIfAccessible(eff0, ns0, loc)) {
       alias => mkEffect(alias.sym, loc)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2336,14 +2336,13 @@ object Resolver {
 
     opOpt match {
       case Resolution.Declaration(op: NamedAst.Declaration.Op) :: Nil =>
-        if (isOpAccessible(op, ns0)) {
-          Validation.success(op)
-        } else {
+        if (!isOpAccessible(op, ns0)) {
           val error = ResolutionError.InaccessibleOp(op.sym, ns0, qname.loc)
           sctx.errors.add(error)
-          Validation.success(op)
         }
-      case _ => Validation.toHardFailure(ResolutionError.UndefinedOp(qname, qname.loc))
+        Validation.success(op)
+      case _ =>
+        Validation.toHardFailure(ResolutionError.UndefinedOp(qname, qname.loc))
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3223,7 +3223,7 @@ object Resolver {
   }
 
   /**
-    * Checks whether `enum0` it is accessible from the given namespace `ns0`.
+    * Checks whether `enum0` is accessible from the given namespace `ns0`.
     *
     * An enum is accessible from a namespace `ns0` if:
     *
@@ -3255,9 +3255,7 @@ object Resolver {
   }
 
   /**
-    * Successfully returns the given `struct0` if it is accessible from the given namespace `ns0`.
-    *
-    * Otherwise fails with a resolution error.
+    * Checks whether `struct0` is accessible from the given namespace `ns0`.
     *
     * A struct is accessible from a namespace `ns0` if:
     *

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3382,9 +3382,7 @@ object Resolver {
   }
 
   /**
-    * Successfully returns the type of the given type alias `alia0` if it is accessible from the given namespace `ns0`.
-    *
-    * Otherwise fails with a resolution error.
+    * Returns the type of the given type alias `alias0` if it is accessible from the given namespace `ns0`.
     */
   private def getTypeAliasTypeIfAccessible(alias0: NamedAst.Declaration.TypeAlias, ns0: Name.NName, loc: SourceLocation)(implicit sctx: SharedContext): UnkindedType = {
     checkTypeAliasIsAccessible(alias0, ns0, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2518,7 +2518,7 @@ object Resolver {
             case TypeLookupResult.TypeAlias(typeAlias) => Validation.success(getTypeAliasTypeIfAccessible(typeAlias, ns0, loc))
             case TypeLookupResult.Effect(eff) => Validation.success(getEffectTypeIfAccessible(eff, ns0, loc))
             case TypeLookupResult.JavaClass(clazz) => Validation.success(flixifyType(clazz, loc))
-            case TypeLookupResult.AssocType(assoc) => getAssocTypeTypeIfAccessible(assoc, ns0, root, loc)
+            case TypeLookupResult.AssocType(assoc) => Validation.success(getAssocTypeTypeIfAccessible(assoc, ns0, root, loc))
             case TypeLookupResult.NotFound =>
               val error = ResolutionError.UndefinedType(qname, ns0, loc)
               sctx.errors.add(error)
@@ -2535,7 +2535,7 @@ object Resolver {
           case TypeLookupResult.TypeAlias(typeAlias) => Validation.success(getTypeAliasTypeIfAccessible(typeAlias, ns0, loc))
           case TypeLookupResult.Effect(eff) => Validation.success(getEffectTypeIfAccessible(eff, ns0, loc))
           case TypeLookupResult.JavaClass(clazz) => Validation.success(flixifyType(clazz, loc))
-          case TypeLookupResult.AssocType(assoc) => getAssocTypeTypeIfAccessible(assoc, ns0, root, loc)
+          case TypeLookupResult.AssocType(assoc) => Validation.success(getAssocTypeTypeIfAccessible(assoc, ns0, root, loc))
           case TypeLookupResult.NotFound =>
             val error = ResolutionError.UndefinedType(qname, ns0, loc)
             sctx.errors.add(error)
@@ -3386,28 +3386,23 @@ object Resolver {
   }
 
   /**
-    * Successfully returns the given associated type `assoc0` if it is accessible from the given namespace `ns0`.
-    *
-    * Otherwise fails with a resolution error.
+    * Checks whether the given associated type `assoc0` it is accessible from the given namespace `ns0`.
     *
     * An associated type is accessible from a namespace `ns0` if:
     *
     * (a) its trait is marked public, or
     * (b) the trait is defined in the namespace `ns0` itself or in a parent of `ns0`.
     */
-  private def getAssocTypeIfAccessible(assoc0: NamedAst.Declaration.AssocTypeSig, ns0: Name.NName, loc: SourceLocation): Validation[NamedAst.Declaration.AssocTypeSig, ResolutionError] = {
-    Validation.success(assoc0) // TODO ASSOC-TYPES check class accessibility
+  private def getAssocTypeIfAccessible(assoc0: NamedAst.Declaration.AssocTypeSig, ns0: Name.NName, loc: SourceLocation): NamedAst.Declaration.AssocTypeSig = {
+    assoc0 // TODO ASSOC-TYPES check class accessibility
   }
 
   /**
-    * Successfully returns the type of the given associated type `assoc0` if it is accessible from the given namespace `ns0`.
-    *
-    * Otherwise fails with a resolution error.
+    * Returns the type of the given associated type `assoc0` if it is accessible from the given namespace `ns0`.
     */
-  private def getAssocTypeTypeIfAccessible(assoc0: NamedAst.Declaration.AssocTypeSig, ns0: Name.NName, root: NamedAst.Root, loc: SourceLocation): Validation[UnkindedType, ResolutionError] = {
-    mapN(getAssocTypeIfAccessible(assoc0, ns0, loc)) {
-      assoc => mkUnappliedAssocType(assoc0.sym, loc)
-    }
+  private def getAssocTypeTypeIfAccessible(assoc0: NamedAst.Declaration.AssocTypeSig, ns0: Name.NName, root: NamedAst.Root, loc: SourceLocation): UnkindedType = {
+    getAssocTypeIfAccessible(assoc0, ns0, loc)
+    mkUnappliedAssocType(assoc0.sym, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2517,7 +2517,7 @@ object Resolver {
         // Disambiguate type.
         case typeName =>
           lookupType(qname, env, ns0, root) match {
-            case TypeLookupResult.Enum(enum0) => getEnumTypeIfAccessible(enum0, ns0, loc)
+            case TypeLookupResult.Enum(enum0) => Validation.success(getEnumTypeIfAccessible(enum0, ns0, loc))
             case TypeLookupResult.Struct(struct) => getStructTypeIfAccessible(struct, ns0, loc)
             case TypeLookupResult.RestrictableEnum(enum0) => getRestrictableEnumTypeIfAccessible(enum0, ns0, loc)
             case TypeLookupResult.TypeAlias(typeAlias) => getTypeAliasTypeIfAccessible(typeAlias, ns0, root, loc)
@@ -2534,7 +2534,7 @@ object Resolver {
       case NamedAst.Type.Ambiguous(qname, loc) =>
         // Disambiguate type.
         lookupType(qname, env, ns0, root) match {
-          case TypeLookupResult.Enum(enum0) => getEnumTypeIfAccessible(enum0, ns0, loc)
+          case TypeLookupResult.Enum(enum0) => Validation.success(getEnumTypeIfAccessible(enum0, ns0, loc))
           case TypeLookupResult.Struct(struct) => getStructTypeIfAccessible(struct, ns0, loc)
           case TypeLookupResult.RestrictableEnum(enum0) => getRestrictableEnumTypeIfAccessible(enum0, ns0, loc)
           case TypeLookupResult.TypeAlias(typeAlias) => getTypeAliasTypeIfAccessible(typeAlias, ns0, root, loc)
@@ -3235,7 +3235,7 @@ object Resolver {
     * (a) the definition is marked public, or
     * (b) the definition is defined in the namespace `ns0` itself or in a parent of `ns0`.
     */
-  private def getEnumIfAccessible(enum0: NamedAst.Declaration.Enum, ns0: Name.NName, loc: SourceLocation)(implicit sctx: SharedContext): Validation[NamedAst.Declaration.Enum, ResolutionError] = {
+  private def checkEnumIsAccessible(enum0: NamedAst.Declaration.Enum, ns0: Name.NName, loc: SourceLocation)(implicit sctx: SharedContext): Unit = {
     //
     // Check if the definition is marked public.
     //
@@ -3257,8 +3257,6 @@ object Resolver {
       val error = ResolutionError.InaccessibleEnum(enum0.sym, ns0, loc)
       sctx.errors.add(error)
     }
-
-    Validation.success(enum0)
   }
 
   /**
@@ -3331,10 +3329,10 @@ object Resolver {
     *
     * Otherwise fails with a resolution error.
     */
-  private def getEnumTypeIfAccessible(enum0: NamedAst.Declaration.Enum, ns0: Name.NName, loc: SourceLocation)(implicit sctx: SharedContext): Validation[UnkindedType, ResolutionError] =
-    mapN(getEnumIfAccessible(enum0, ns0, loc)) {
-      case enum0 => mkEnum(enum0.sym, loc)
-    }
+  private def getEnumTypeIfAccessible(enum0: NamedAst.Declaration.Enum, ns0: Name.NName, loc: SourceLocation)(implicit sctx: SharedContext): UnkindedType = {
+    checkEnumIsAccessible(enum0, ns0, loc)
+    mkEnum(enum0.sym, loc)
+  }
 
   /**
     * Successfully returns the type of the given `struct0` if it is accessible from the given namespace `ns0`.

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2525,7 +2525,9 @@ object Resolver {
             case TypeLookupResult.JavaClass(clazz) => Validation.success(flixifyType(clazz, loc))
             case TypeLookupResult.AssocType(assoc) => getAssocTypeTypeIfAccessible(assoc, ns0, root, loc)
             case TypeLookupResult.NotFound =>
-              Validation.toSoftFailure(UnkindedType.Error(loc), ResolutionError.UndefinedType(qname, ns0, loc))
+              val error = ResolutionError.UndefinedType(qname, ns0, loc)
+              sctx.errors.add(error)
+              Validation.success(UnkindedType.Error(loc))
           }
       }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3999,11 +3999,13 @@ object Resolver {
   /**
     * Checks that the operator's arity matches the number of arguments given.
     */
-  private def checkOpArity(op: Declaration.Op, numArgs: Int, loc: SourceLocation): Validation[Unit, ResolutionError] = {
+  private def checkOpArity(op: Declaration.Op, numArgs: Int, loc: SourceLocation)(implicit sctx: SharedContext): Validation[Unit, ResolutionError] = {
     if (op.spec.fparams.length == numArgs) {
       Validation.success(())
     } else {
-      Validation.toSoftFailure((), ResolutionError.MismatchedOpArity(op.sym, op.spec.fparams.length, numArgs, loc))
+      val error = ResolutionError.MismatchedOpArity(op.sym, op.spec.fparams.length, numArgs, loc)
+      sctx.errors.add(error)
+      Validation.success(())
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2740,7 +2740,10 @@ object Resolver {
       case UnkindedType.UnappliedAssocType(sym, loc) =>
         targs match {
           // Case 1: The associated type is under-applied.
-          case Nil => Validation.toSoftFailure(UnkindedType.Error(loc), ResolutionError.UnderAppliedAssocType(sym, loc))
+          case Nil =>
+            val error = ResolutionError.UnderAppliedAssocType(sym, loc)
+            sctx.errors.add(error)
+            Validation.success(UnkindedType.Error(loc))
 
           // Case 2: The associated type is fully applied.
           // Apply the types first type inside the assoc type, then apply any leftover types.

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3267,7 +3267,7 @@ object Resolver {
     * (a) the definition is marked public, or
     * (b) the definition is defined in the namespace `ns0` itself or in a parent of `ns0`.
     */
-  private def getStructIfAccessible(struct0: NamedAst.Declaration.Struct, ns0: Name.NName, loc: SourceLocation): Validation[NamedAst.Declaration.Struct, ResolutionError] = {
+  private def getStructIfAccessible(struct0: NamedAst.Declaration.Struct, ns0: Name.NName, loc: SourceLocation)(implicit sctx: SharedContext): Validation[NamedAst.Declaration.Struct, ResolutionError] = {
     //
     // Check if the definition is marked public.
     //
@@ -3285,7 +3285,9 @@ object Resolver {
     //
     // The struct is not accessible.
     //
-    Validation.toSoftFailure(struct0, ResolutionError.InaccessibleStruct(struct0.sym, ns0, loc))
+    val error = ResolutionError.InaccessibleStruct(struct0.sym, ns0, loc)
+    sctx.errors.add(error)
+    Validation.success(struct0)
   }
 
 
@@ -3337,7 +3339,7 @@ object Resolver {
     *
     * Otherwise fails with a resolution error.
     */
-  private def getStructTypeIfAccessible(struct0: NamedAst.Declaration.Struct, ns0: Name.NName, loc: SourceLocation): Validation[UnkindedType, ResolutionError] =
+  private def getStructTypeIfAccessible(struct0: NamedAst.Declaration.Struct, ns0: Name.NName, loc: SourceLocation)(implicit sctx: SharedContext): Validation[UnkindedType, ResolutionError] =
     mapN(getStructIfAccessible(struct0, ns0, loc)) {
       case struct => mkStruct(struct.sym, loc)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3452,9 +3452,7 @@ object Resolver {
   }
 
   /**
-    * Successfully returns the type of the given effect `eff0` if it is accessible from the given namespace `ns0`.
-    *
-    * Otherwise fails with a resolution error.
+    * Returns the type of the given effect `eff0` if it is accessible from the given namespace `ns0`.
     */
   private def getEffectTypeIfAccessible(eff0: NamedAst.Declaration.Effect, ns0: Name.NName, loc: SourceLocation)(implicit sctx: SharedContext): UnkindedType = {
     checkEffectIsAccessible(eff0, ns0, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3235,7 +3235,7 @@ object Resolver {
     * (a) the definition is marked public, or
     * (b) the definition is defined in the namespace `ns0` itself or in a parent of `ns0`.
     */
-  private def getEnumIfAccessible(enum0: NamedAst.Declaration.Enum, ns0: Name.NName, loc: SourceLocation): Validation[NamedAst.Declaration.Enum, ResolutionError] = {
+  private def getEnumIfAccessible(enum0: NamedAst.Declaration.Enum, ns0: Name.NName, loc: SourceLocation)(implicit sctx: SharedContext): Validation[NamedAst.Declaration.Enum, ResolutionError] = {
     //
     // Check if the definition is marked public.
     //
@@ -3253,7 +3253,9 @@ object Resolver {
     //
     // The enum is not accessible.
     //
-    Validation.toSoftFailure(enum0, ResolutionError.InaccessibleEnum(enum0.sym, ns0, loc))
+    val error = ResolutionError.InaccessibleEnum(enum0.sym, ns0, loc)
+    sctx.errors.add(error)
+    Validation.success(enum0)
   }
 
   /**
@@ -3326,7 +3328,7 @@ object Resolver {
     *
     * Otherwise fails with a resolution error.
     */
-  private def getEnumTypeIfAccessible(enum0: NamedAst.Declaration.Enum, ns0: Name.NName, loc: SourceLocation): Validation[UnkindedType, ResolutionError] =
+  private def getEnumTypeIfAccessible(enum0: NamedAst.Declaration.Enum, ns0: Name.NName, loc: SourceLocation)(implicit sctx: SharedContext): Validation[UnkindedType, ResolutionError] =
     mapN(getEnumIfAccessible(enum0, ns0, loc)) {
       case enum0 => mkEnum(enum0.sym, loc)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3320,9 +3320,7 @@ object Resolver {
 
 
   /**
-    * Successfully returns the type of the given `enum0` if it is accessible from the given namespace `ns0`.
-    *
-    * Otherwise fails with a resolution error.
+    * Returns the type of the given `enum0` if it is accessible from the given namespace `ns0`.
     */
   private def getEnumTypeIfAccessible(enum0: NamedAst.Declaration.Enum, ns0: Name.NName, loc: SourceLocation)(implicit sctx: SharedContext): UnkindedType = {
     checkEnumIsAccessible(enum0, ns0, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3239,22 +3239,25 @@ object Resolver {
     //
     // Check if the definition is marked public.
     //
-    if (enum0.mod.isPublic)
-      return Validation.success(enum0)
+    val isPublic = enum0.mod.isPublic
 
     //
     // Check if the enum is defined in `ns0` or in a parent of `ns0`.
     //
     val prefixNs = enum0.sym.namespace
     val targetNs = ns0.idents.map(_.name)
-    if (targetNs.startsWith(prefixNs))
-      return Validation.success(enum0)
+    val isInScopeOfNS = targetNs.startsWith(prefixNs)
 
-    //
-    // The enum is not accessible.
-    //
-    val error = ResolutionError.InaccessibleEnum(enum0.sym, ns0, loc)
-    sctx.errors.add(error)
+    val isAccessible = isPublic || isInScopeOfNS
+
+    if (!isAccessible) {
+      //
+      // The enum is not accessible.
+      //
+      val error = ResolutionError.InaccessibleEnum(enum0.sym, ns0, loc)
+      sctx.errors.add(error)
+    }
+
     Validation.success(enum0)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3298,7 +3298,6 @@ object Resolver {
     *
     * (a) the definition is marked public, or
     * (b) the definition is defined in the namespace `ns0` itself or in a parent of `ns0`.
-    * TODO: Refactor this function
     */
   private def getRestrictableEnumIfAccessible(enum0: NamedAst.Declaration.RestrictableEnum, ns0: Name.NName, loc: SourceLocation): Validation[NamedAst.Declaration.RestrictableEnum, ResolutionError] = {
     //

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2331,7 +2331,7 @@ object Resolver {
   /**
     * Looks up the effect operation with qualified name `qname` in the namespace `ns0`.
     */
-  private def lookupOp(qname: Name.QName, env: ListMap[String, Resolution], ns0: Name.NName, root: NamedAst.Root): Validation[NamedAst.Declaration.Op, ResolutionError] = {
+  private def lookupOp(qname: Name.QName, env: ListMap[String, Resolution], ns0: Name.NName, root: NamedAst.Root)(implicit sctx: SharedContext): Validation[NamedAst.Declaration.Op, ResolutionError] = {
     val opOpt = tryLookupName(qname, env, ns0, root)
 
     opOpt match {
@@ -2339,7 +2339,9 @@ object Resolver {
         if (isOpAccessible(op, ns0)) {
           Validation.success(op)
         } else {
-          Validation.toSoftFailure(op, ResolutionError.InaccessibleOp(op.sym, ns0, qname.loc))
+          val error = ResolutionError.InaccessibleOp(op.sym, ns0, qname.loc)
+          sctx.errors.add(error)
+          Validation.success(op)
         }
       case _ => Validation.toHardFailure(ResolutionError.UndefinedOp(qname, qname.loc))
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2701,7 +2701,7 @@ object Resolver {
     *
     * Replaces type alias placeholders with the real type aliases.
     */
-  private def finishResolveType(tpe0: UnkindedType, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias]): Validation[UnkindedType, ResolutionError] = {
+  private def finishResolveType(tpe0: UnkindedType, taenv: Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias])(implicit sctx: SharedContext): Validation[UnkindedType, ResolutionError] = {
 
     /**
       * Performs beta-reduction on the given type alias.
@@ -2724,7 +2724,9 @@ object Resolver {
         val numParams = tparams.length
         if (targs.length < numParams) {
           // Case 1: The type alias is under-applied.
-          Validation.toSoftFailure(UnkindedType.Error(loc), ResolutionError.UnderAppliedTypeAlias(sym, loc))
+          val error = ResolutionError.UnderAppliedTypeAlias(sym, loc)
+          sctx.errors.add(error)
+          Validation.success(UnkindedType.Error(loc))
         } else {
           // Case 2: The type alias is fully applied.
           // Apply the types within the alias, then apply any leftover types.

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -311,7 +311,7 @@ object Resolver {
     *
     * The given aliases must be in resolution order.
     */
-  private def finishResolveTypeAliases(aliases0: List[ResolvedAst.Declaration.TypeAlias]): Validation[Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], ResolutionError] = {
+  private def finishResolveTypeAliases(aliases0: List[ResolvedAst.Declaration.TypeAlias])(implicit sctx: SharedContext): Validation[Map[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias], ResolutionError] = {
     Validation.fold(aliases0, Map.empty[Symbol.TypeAliasSym, ResolvedAst.Declaration.TypeAlias]) {
       case (taenv, ResolvedAst.Declaration.TypeAlias(doc, ann, mod, sym, tparams, tpe0, loc)) =>
         mapN(finishResolveType(tpe0, taenv)) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2542,7 +2542,9 @@ object Resolver {
           case TypeLookupResult.JavaClass(clazz) => Validation.success(flixifyType(clazz, loc))
           case TypeLookupResult.AssocType(assoc) => getAssocTypeTypeIfAccessible(assoc, ns0, root, loc)
           case TypeLookupResult.NotFound =>
-            Validation.toSoftFailure(UnkindedType.Error(loc), ResolutionError.UndefinedType(qname, ns0, loc))
+            val error = ResolutionError.UndefinedType(qname, ns0, loc)
+            sctx.errors.add(error)
+            Validation.success(UnkindedType.Error(loc))
         }
 
       case NamedAst.Type.Tuple(elms0, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3330,9 +3330,7 @@ object Resolver {
   }
 
   /**
-    * Successfully returns the type of the given `struct0` if it is accessible from the given namespace `ns0`.
-    *
-    * Otherwise fails with a resolution error.
+    * Returns the type of the given `struct0` if it is accessible from the given namespace `ns0`.
     */
   private def getStructTypeIfAccessible(struct0: NamedAst.Declaration.Struct, ns0: Name.NName, loc: SourceLocation)(implicit sctx: SharedContext): UnkindedType = {
     checkStructIsAccessible(struct0, ns0, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2756,7 +2756,9 @@ object Resolver {
                 val assoc = UnkindedType.AssocType(cst, targHd, tpe0.loc)
                 Validation.success(UnkindedType.mkApply(assoc, targTl, tpe0.loc))
               case _ =>
-                Validation.toSoftFailure(UnkindedType.Error(loc), ResolutionError.IllegalAssocTypeApplication(tpe0.loc))
+                val error = ResolutionError.IllegalAssocTypeApplication(tpe0.loc)
+                sctx.errors.add(error)
+                Validation.success(UnkindedType.Error(loc))
             }
         }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3317,7 +3317,7 @@ object Resolver {
     //
     // The enum is not accessible.
     //
-    Validation.toHardFailure(ResolutionError.InaccessibleRestrictableEnum(enum0.sym, ns0, loc))
+    Validation.toHardFailure(ResolutionError.InaccessibleRestrictableEnum(enum0.sym, ns0, loc)) // TODO: Refactor this to be soft failure
   }
 
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2958,7 +2958,9 @@ object Resolver {
     val symOpt = tryLookupName(qname, env, ns0, root)
 
     symOpt.collectFirst {
-      case Resolution.Declaration(assoc: NamedAst.Declaration.AssocTypeSig) => getAssocTypeIfAccessible(assoc, ns0, qname.loc)
+      case Resolution.Declaration(assoc: NamedAst.Declaration.AssocTypeSig) =>
+        getAssocTypeIfAccessible(assoc, ns0, qname.loc)
+        Validation.success(assoc)
     }.getOrElse(Validation.toHardFailure(ResolutionError.UndefinedNameUnrecoverable(qname, ns0, Map.empty, isUse = false, qname.loc)))
   }
 


### PR DESCRIPTION
Removes all occurrences of `SoftFailure` in `Resolver` (except at the top level)

Related to https://github.com/flix/flix/issues/8812