### PR TITLE
refactor: move `IntroducedBy` and `EliminatedBy` from `Ast` to `shared.ScalaAnnotations`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -25,16 +25,6 @@ import java.util.Objects
   */
 object Ast {
 
-  /**
-    * Represents that the annotated element is introduced by the class `clazz`.
-    */
-  case class IntroducedBy(clazz: java.lang.Class[?]) extends scala.annotation.StaticAnnotation
-
-  /**
-    * Represents that the annotated element is eliminated by the class `clazz`.
-    */
-  case class EliminatedBy(clazz: java.lang.Class[?]) extends scala.annotation.StaticAnnotation
-
   case object TraitConstraint {
     /**
       * Represents the head (located class) of a type constraint.

--- a/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LiftedAst.scala
@@ -16,8 +16,8 @@
 
 package ca.uwaterloo.flix.language.ast
 
-import ca.uwaterloo.flix.language.ast.Ast.IntroducedBy
 import ca.uwaterloo.flix.language.ast.Purity.Pure
+import ca.uwaterloo.flix.language.ast.shared.ScalaAnnotations.IntroducedBy
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{EffectSymUse, OpSymUse}
 import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, Modifiers, Source}
 import ca.uwaterloo.flix.language.phase.Inliner

--- a/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
@@ -16,10 +16,8 @@
 
 package ca.uwaterloo.flix.language.ast
 
-import ca.uwaterloo.flix.language.ast.Ast.EliminatedBy
-import ca.uwaterloo.flix.language.ast.shared.SymUse.{AssocTypeSymUse, CaseSymUse, EffectSymUse, OpSymUse, TraitSymUse}
-import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, Denotation, Doc, Fixity, Modifiers, Polarity, Source}
-import ca.uwaterloo.flix.language.phase.Monomorpher
+import ca.uwaterloo.flix.language.ast.shared.SymUse.*
+import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.util.collection.ListMap
 
 object LoweredAst {

--- a/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/MonoAst.scala
@@ -16,10 +16,8 @@
 
 package ca.uwaterloo.flix.language.ast
 
-import ca.uwaterloo.flix.language.ast.Ast.EliminatedBy
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{CaseSymUse, EffectSymUse, OpSymUse}
-import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, Denotation, Doc, Fixity, Modifiers, Polarity, Source}
-import ca.uwaterloo.flix.language.phase.Monomorpher
+import ca.uwaterloo.flix.language.ast.shared.*
 
 object MonoAst {
 

--- a/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SimplifiedAst.scala
@@ -16,8 +16,8 @@
 
 package ca.uwaterloo.flix.language.ast
 
-import ca.uwaterloo.flix.language.ast.Ast.IntroducedBy
 import ca.uwaterloo.flix.language.ast.Purity.Pure
+import ca.uwaterloo.flix.language.ast.shared.ScalaAnnotations.IntroducedBy
 import ca.uwaterloo.flix.language.ast.shared.SymUse.{EffectSymUse, OpSymUse}
 import ca.uwaterloo.flix.language.ast.shared.{Annotations, Constant, Modifiers, Source}
 import ca.uwaterloo.flix.language.phase.ClosureConv

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -231,8 +231,8 @@ object TypeConstructor {
   case class Enum(sym: Symbol.EnumSym, kind: Kind) extends TypeConstructor
 
   /**
-    * A type constructor that represents the type of structs.
-    */
+   * A type constructor that represents the type of structs.
+   */
   @IntroducedBy(Kinder.getClass)
   case class Struct(sym: Symbol.StructSym, kind: Kind) extends TypeConstructor
 
@@ -250,15 +250,15 @@ object TypeConstructor {
   }
 
   /**
-    * A type constructor that represents the type of a Java constructor.
-    * */
+   * A type constructor that represents the type of a Java constructor.
+   * */
   case class JvmConstructor(constructor: Constructor[?]) extends TypeConstructor {
     def kind: Kind = Kind.Jvm
   }
 
   /**
-    * A type constructor that represents the type of a Java method.
-    */
+   * A type constructor that represents the type of a Java method.
+   */
   case class JvmMethod(method: Method) extends TypeConstructor {
     def kind: Kind = Kind.Jvm
   }

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -1,8 +1,7 @@
 package ca.uwaterloo.flix.language.ast
 
-import ca.uwaterloo.flix.language.ast.Ast.{EliminatedBy, IntroducedBy}
-import ca.uwaterloo.flix.language.phase.typer.TypeReduction
-import ca.uwaterloo.flix.language.phase.{Kinder, Lowering, Monomorpher, TypeReconstruction}
+import ca.uwaterloo.flix.language.ast.shared.ScalaAnnotations.{EliminatedBy, IntroducedBy}
+import ca.uwaterloo.flix.language.phase.{Kinder, Lowering, Monomorpher}
 
 import java.lang.reflect.{Constructor, Field, Method}
 import scala.collection.immutable.SortedSet
@@ -232,8 +231,8 @@ object TypeConstructor {
   case class Enum(sym: Symbol.EnumSym, kind: Kind) extends TypeConstructor
 
   /**
-   * A type constructor that represents the type of structs.
-   */
+    * A type constructor that represents the type of structs.
+    */
   @IntroducedBy(Kinder.getClass)
   case class Struct(sym: Symbol.StructSym, kind: Kind) extends TypeConstructor
 
@@ -251,15 +250,15 @@ object TypeConstructor {
   }
 
   /**
-   * A type constructor that represents the type of a Java constructor.
-   * */
+    * A type constructor that represents the type of a Java constructor.
+    * */
   case class JvmConstructor(constructor: Constructor[?]) extends TypeConstructor {
     def kind: Kind = Kind.Jvm
   }
 
   /**
-   * A type constructor that represents the type of a Java method.
-   */
+    * A type constructor that represents the type of a Java method.
+    */
   case class JvmMethod(method: Method) extends TypeConstructor {
     def kind: Kind = Kind.Jvm
   }

--- a/main/src/ca/uwaterloo/flix/language/ast/UnkindedType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/UnkindedType.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.Ast.EliminatedBy
+import ca.uwaterloo.flix.language.ast.shared.ScalaAnnotations.EliminatedBy
 import ca.uwaterloo.flix.language.ast.shared.{Denotation, Scope}
 import ca.uwaterloo.flix.language.phase.Resolver
 import ca.uwaterloo.flix.util.InternalCompilerException

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/ScalaAnnotations.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/ScalaAnnotations.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Holger Dal Mogensen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.ast.shared
+
+object ScalaAnnotations {
+  /**
+    * Represents that the annotated element is introduced by the class `clazz`.
+    */
+  case class IntroducedBy(clazz: java.lang.Class[?]) extends scala.annotation.StaticAnnotation
+
+  /**
+    * Represents that the annotated element is eliminated by the class `clazz`.
+    */
+  case class EliminatedBy(clazz: java.lang.Class[?]) extends scala.annotation.StaticAnnotation
+}


### PR DESCRIPTION
Related to #7871