### PR TITLE
fix: include synthetic source locations in visitor

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -908,8 +908,6 @@ object Visitor {
     * @return `true` if `pos` in file at path `uri` is within `loc`. `false` otherwise.
     */
   def inside(uri: String, pos: Position)(loc: SourceLocation): Boolean = {
-    if(!loc.isReal) { return false }
-
     val sameSource = uri == loc.source.name
     if (!sameSource) { return false }
 

--- a/main/test/ca/uwaterloo/flix/api/lsp/VisitorSuite.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/VisitorSuite.scala
@@ -211,7 +211,7 @@ class VisitorSuite extends AnyFunSuite {
     assert(!Visitor.inside("wrong!", pos)(loc))
   }
 
-  test("not inside if SourceLocation isn't real") {
+  ignore("not inside if SourceLocation isn't real") {
     val loc = SourceLocation(
       isReal = false,
       SourcePosition(source, 3, 6),

--- a/main/test/ca/uwaterloo/flix/api/lsp/VisitorSuite.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/VisitorSuite.scala
@@ -210,15 +210,4 @@ class VisitorSuite extends AnyFunSuite {
 
     assert(!Visitor.inside("wrong!", pos)(loc))
   }
-
-  ignore("not inside if SourceLocation isn't real") {
-    val loc = SourceLocation(
-      isReal = false,
-      SourcePosition(source, 3, 6),
-      SourcePosition(source, 6, 10)
-    )
-    val pos = Position(4, 4)
-
-    assert(!Visitor.inside(uri, pos)(loc))
-  }
 }


### PR DESCRIPTION
This PR fixes an issue where the inside function of the LSP visitor is too strict. This is because it concludes that something cannot be inside of a location if it's synthetic, despite synthetic locations occuring within actual, valid AST nodes. This means that the function concludes, erroneously, that positions that are actually within such AST nodes aren't.

This PR fixes this by simply removing the check and the associated test.

Related to #8639