### PR TITLE
feat: Optimize generated lambda subeffecting

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -136,7 +136,16 @@ object ConstraintGen {
         c.unifyType(fparam.sym.tvar, fparam.tpe, loc)
         val (tpe, eff0) = visitExp(exp)
         // SUB-EFFECTING: Check if sub-effecting is enabled for lambda expressions.
-        val shouldSubeffect = flix.options.xsubeffecting.contains(Subeffecting.Lambdas)
+        val shouldSubeffect = {
+          val enabled = flix.options.xsubeffecting.contains(Subeffecting.Lambdas)
+          val redundant = exp match {
+            case Expr.Ascribe(_, _, Some(Type.Pure), _, _) =>
+              println("bang")
+              true
+            case _ => false
+          }
+          enabled && !redundant
+        }
         val eff = if (shouldSubeffect) Type.mkUnion(eff0, Type.freshVar(Kind.Eff, loc), loc) else eff0
         val resTpe = Type.mkArrowWithEffect(fparam.tpe, eff, tpe, loc)
         val resEff = Type.Pure
@@ -371,7 +380,16 @@ object ConstraintGen {
         val (tpe1, eff1) = visitExp(exp1)
         fparams.foreach(fp => c.unifyType(fp.sym.tvar, fp.tpe, loc))
         // SUB-EFFECTING: Check if sub-effecting is enabled for lambda expressions (which include local defs).
-        val shouldSubeffect = flix.options.xsubeffecting.contains(Subeffecting.Lambdas)
+        val shouldSubeffect = {
+          val enabled = flix.options.xsubeffecting.contains(Subeffecting.Lambdas)
+          val redundant = exp1 match {
+            case Expr.Ascribe(_, _, Some(Type.Pure), _, _) =>
+              println("bang")
+              true
+            case _ => false
+          }
+          enabled && !redundant
+        }
         val defEff = if (shouldSubeffect) Type.mkUnion(eff1, Type.freshVar(Kind.Eff, loc), loc) else eff1
         val defTpe = Type.mkUncurriedArrowWithEffect(fparams.map(_.tpe), defEff, tpe1, sym.loc)
         c.unifyType(sym.tvar, defTpe, sym.loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -139,9 +139,7 @@ object ConstraintGen {
         val shouldSubeffect = {
           val enabled = flix.options.xsubeffecting.contains(Subeffecting.Lambdas)
           val redundant = exp match {
-            case Expr.Ascribe(_, _, Some(Type.Pure), _, _) =>
-              println("bang")
-              true
+            case Expr.Ascribe(_, _, Some(Type.Pure), _, _) => true
             case _ => false
           }
           enabled && !redundant
@@ -383,9 +381,7 @@ object ConstraintGen {
         val shouldSubeffect = {
           val enabled = flix.options.xsubeffecting.contains(Subeffecting.Lambdas)
           val redundant = exp1 match {
-            case Expr.Ascribe(_, _, Some(Type.Pure), _, _) =>
-              println("bang")
-              true
+            case Expr.Ascribe(_, _, Some(Type.Pure), _, _) => true
             case _ => false
           }
           enabled && !redundant


### PR DESCRIPTION
Based on #8998, now we can omit some redundant subeffecting on lambdas (can be merged independently)