### PR TITLE
fix: unsafe `unsafe` blocks

### DIFF
--- a/main/src/library/Adaptor.flix
+++ b/main/src/library/Adaptor.flix
@@ -152,15 +152,16 @@ mod Adaptor {
     ///
     /// Returns a Flix Iterator of the elements in the given Java Stream.
     ///
-    pub def fromStreamToIterator(rc: Region[r], proxy: Proxy[a], strm: Stream): Iterator[a, r, r] =
-        let iter = unsafe (checked_cast(strm): BaseStream).iterator();
+    pub def fromStreamToIterator(rc: Region[r], proxy: Proxy[a], strm: Stream): Iterator[a, r, r] \ r =
+        let baseStream: BaseStream = checked_cast(strm);
+        let iter = unchecked_cast ((baseStream.iterator(): _ \ IO) as _ \ r);
         Adaptor.fromIterator(rc, proxy, iter)
 
     ///
     /// Returns a Flix Iterator of the elements in the given Java Collection.
     ///
-    pub def fromCollectionToIterator(rc: Region[r], proxy: Proxy[a], col: Collection): Iterator[a, r, r] =
-        let iter = unsafe col.iterator();
+    pub def fromCollectionToIterator(rc: Region[r], proxy: Proxy[a], col: Collection): Iterator[a, r, r] \ r =
+        let iter = unchecked_cast ((col.iterator(): _ \ IO) as _ \ r);
         Adaptor.fromIterator(rc, proxy, iter)
 
     ///

--- a/main/src/library/Chain.flix
+++ b/main/src/library/Chain.flix
@@ -123,7 +123,8 @@ instance ToJava[Chain[a]] {
 instance FromJava[Chain[a]] {
     type In = JList
     pub def fromJava(l: JList): Chain[a] = region rc {
-        unsafe l.iterator() |> Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[a])) |> Iterator.toChain
+        let it = unchecked_cast ((l.iterator(): _ \ IO) as _ \ rc);
+        it |> Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[a])) |> Iterator.toChain
     }
 }
 

--- a/main/src/library/Environment.flix
+++ b/main/src/library/Environment.flix
@@ -29,18 +29,20 @@ mod Environment {
     /// Returns the arguments passed to the program via the command line.
     ///
     pub def getArgs(): List[String] =
-        unsafe Array.toList(unsafe Global.getArgs())
+        unsafe Array.toList(Global.getArgs())
 
     ///
     /// Returns an map of the current system environment.
     ///
-    pub def getEnv(): Map[String, String] =
+    pub def getEnv(): Map[String, String] = region rc {
         try {
-            let iter = unsafe System.getenv().entrySet().iterator();
+            let _ = rc;
+            let iter = unchecked_cast ((System.getenv().entrySet().iterator(): _ \ IO) as _ \ rc);
             getEnvHelper(iter, Map.empty())
         } catch {
             case _: Exception => Map.empty()
         }
+    }
 
     ///
     /// Returns the value of the specified environment variable.

--- a/main/src/library/Files.flix
+++ b/main/src/library/Files.flix
@@ -746,7 +746,7 @@ mod Files {
             let javaIter = javaStream.iterator();
 
             let iter: Iterator[Path, _, _] = fromJavaIter(rc, javaIter);
-            Iterator.map(x -> unsafe x.toString(), iter)
+            Iterator.map(x -> unchecked_cast ((x.toString(): _ \ IO) as _ \ r), iter)
         })
 
     ///
@@ -764,7 +764,7 @@ mod Files {
             let javaIter = javaStream.iterator();
 
             let iter: Iterator[Path, _, _] = fromJavaIter(rc, javaIter);
-            Iterator.map(x -> unsafe x.toString(), iter)
+            Iterator.map(x -> unchecked_cast ((x.toString(): _ \ IO) as _ \ r), iter)
         })
 
     ///

--- a/main/src/library/Regex.flix
+++ b/main/src/library/Regex.flix
@@ -552,7 +552,7 @@ mod Regex {
     /// Create a Matcher for Regex `rgx` on the source String `input`.
     ///
     def newMatcher(_: Region[r], rgx: Regex, s: String): Matcher[r] \ r =
-        Matcher(checked_ecast(unsafe rgx.matcher(s)))
+        Matcher(unchecked_cast ((rgx.matcher(s): _ \ IO) as _ \ r))
 
     ///
     /// Create a Matcher for Regex `rgx` on the source String `input` with bounds `start` and `end`.
@@ -574,7 +574,7 @@ mod Regex {
     ///
     def find!(m: Matcher[r]): Bool \ r =
         let Matcher(m1) = m;
-        checked_ecast(unsafe m1.find())
+        unchecked_cast ((m1.find(): _ \ IO) as _ \ r)
 
     ///
     /// Attempt to find the next match after the supplied position `pos`.
@@ -586,7 +586,7 @@ mod Regex {
     def findFrom!(pos: Int32, m: Matcher[r]): Bool \ r =
         Result.tryCatch(_ -> {
             let Matcher(m1) = m;
-            checked_ecast(unsafe m1.find(pos))
+            unchecked_cast ((m1.find(pos): _ \ IO) as _ \ r)
         }) |> Result.getWithDefault(false)
 
 
@@ -625,7 +625,7 @@ mod Regex {
     def setBounds!(start: {start = Int32}, end: {end = Int32}, m: Matcher[r]): Result[String, Unit] \ r =
         Result.tryCatch(_ -> {
             let Matcher(m1) = m;
-            checked_ecast(unsafe discard m1.₹region(start#start, end#end))
+            unchecked_cast ((discard m1.₹region(start#start, end#end): _ \ IO) as _ \ r)
         })
 
 
@@ -635,7 +635,7 @@ mod Regex {
     def matcherStart(m: Matcher[r]): Result[String, Int32] \ r =
         Result.tryCatch(_ -> {
             let Matcher(m1) = m;
-            checked_ecast(unsafe m1.start())
+            unchecked_cast ((m1.start(): _ \ IO) as _ \ r)
         })
 
     ///
@@ -644,7 +644,7 @@ mod Regex {
     def matcherEnd(m: Matcher[r]): Result[String, Int32] \ r =
         Result.tryCatch(_ -> {
             let Matcher(m1) = m;
-            checked_ecast(unsafe m1.end())
+            unchecked_cast ((m1.end(): _ \ IO) as _ \ r)
         })
 
     ///
@@ -662,7 +662,7 @@ mod Regex {
     def matcherContent(m: Matcher[r]): Result[String, String] \ r =
         Result.tryCatch(_ -> {
             let Matcher(m1) = m;
-            checked_ecast(unsafe m1.group())
+            unchecked_cast ((m1.group(): _ \ IO) as _ \ r)
         })
 
     ///

--- a/main/src/library/StringBuilder.flix
+++ b/main/src/library/StringBuilder.flix
@@ -28,7 +28,7 @@ mod StringBuilder {
     /// Returns a new mutable StringBuilder.
     ///
     pub def empty(_: Region[r]): StringBuilder[r] \ r =
-        StringBuilder(checked_ecast(unsafe new JStringBuilder()))
+        StringBuilder(unchecked_cast ((new JStringBuilder(): _ \ IO) as _ \ r))
 
     ///
     /// Append `x` to the StringBuilder `sb`.
@@ -43,7 +43,7 @@ mod StringBuilder {
     ///
     pub def appendString!(s: String, sb: StringBuilder[r]): Unit \ r =
         let StringBuilder(msb) = sb;
-        unchecked_cast((unsafe msb.append(s)) as _ \ r);
+        unchecked_cast((msb.append(s): _ \ IO) as _ \ r);
         ()
 
     ///
@@ -51,7 +51,7 @@ mod StringBuilder {
     ///
     pub def appendCodePoint!(cp: Int32, sb: StringBuilder[r]): Unit \ r =
         let StringBuilder(msb) = sb;
-        unchecked_cast((unsafe msb.appendCodePoint(cp)) as _ \ r);
+        unchecked_cast((msb.appendCodePoint(cp): _ \ IO) as _ \ r);
         ()
 
     ///
@@ -110,7 +110,7 @@ mod StringBuilder {
     ///
     pub def iterator(rc: Region[r1], sb: StringBuilder[r2]): Iterator[Char, r1 + r2, r1] \ { r1, r2 } =
         let StringBuilder(msb) = sb;
-        Iterator.range(rc, 0, length(sb)) |> Iterator.map(i -> unchecked_cast((unsafe msb.charAt(i)) as _ \ r2))
+        Iterator.range(rc, 0, length(sb)) |> Iterator.map(i -> unchecked_cast((msb.charAt(i): _ \ IO) as _ \ r2))
 
     ///
     /// Returns an iterator over `l` zipped with the indices of the elements.
@@ -123,7 +123,7 @@ mod StringBuilder {
     ///
     pub def length(sb: StringBuilder[r]): Int32 \ r =
         let StringBuilder(msb) = sb;
-        unchecked_cast((unsafe msb.length()) as _ \ r)
+        unchecked_cast((msb.length(): _ \ IO) as _ \ r)
 
     ///
     /// Return the number of characters in the StringBuilder `sb`.
@@ -135,13 +135,13 @@ mod StringBuilder {
     ///
     pub def setLength!(newLength: Int32, sb: StringBuilder[r]): Unit \ r =
         let StringBuilder.StringBuilder(msb) = sb;
-        unchecked_cast((unsafe msb.setLength(newLength)) as _ \ r)
+        unchecked_cast((msb.setLength(newLength): _ \ IO) as _ \ r)
 
     ///
     /// Convert the StringBuilder `sb` to a string.
     ///
     pub def toString(sb: StringBuilder[r]): String \ r =
         let StringBuilder(msb) = sb;
-        unchecked_cast(unsafe msb.toString() as _ \ r)
+        unchecked_cast((msb.toString(): _ \ IO) as _ \ r)
 
 }

--- a/main/src/library/Vector.flix
+++ b/main/src/library/Vector.flix
@@ -129,7 +129,8 @@ instance ToJava[Vector[a]] {
 instance FromJava[Vector[a]] {
     type In = JList
     pub def fromJava(l: JList): Vector[a] = region rc {
-        (unsafe l.iterator()) |> Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[a])) |> Iterator.toVector
+        let iter = unchecked_cast ((l.iterator(): _ \ IO) as _ \ rc);
+        iter |> Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[a])) |> Iterator.toVector
     }
 }
 

--- a/main/test/ca/uwaterloo/flix/library/TestAdaptor.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestAdaptor.flix
@@ -247,19 +247,19 @@ mod TestAdaptor {
 
     @test
     def fromCollectionToIterator01(): Bool \ {} = region rc {
-        let col = checked_cast(unsafe JList.of());
+        let col = unsafe JList.of();
         Iterator.toList(Adaptor.fromCollectionToIterator(rc, (Proxy.Proxy: Proxy[String]), col)) == (Nil : List[String])
     }
 
     @test
     def fromCollectionToIterator02(): Bool \ {} = region rc {
-        let col = checked_cast(unsafe JList.of("hello"));
+        let col = unsafe JList.of("hello");
         Iterator.toList(Adaptor.fromCollectionToIterator(rc, (Proxy.Proxy: Proxy[String]), col)) == "hello" :: Nil
     }
 
     @test
     def fromCollectionToIterator03(): Bool \ {} = region rc {
-        let col = checked_cast(unsafe JList.of("hello", "world"));
+        let col = unsafe JList.of("hello", "world");
         Iterator.toList(Adaptor.fromCollectionToIterator(rc, (Proxy.Proxy: Proxy[String]), col)) == "hello" :: "world" :: Nil
     }
 
@@ -270,12 +270,12 @@ mod TestAdaptor {
     @test
     def toOptional01(): Bool \ IO =
         let o = Adaptor.toOptional(None);
-        o.equals(unsafe Optional.empty())
+        o.equals(Optional.empty())
 
     @test
     def toOptional02(): Bool \ IO =
         let o = Adaptor.toOptional(Some("hello"));
-        o.equals(unsafe Optional.of("hello"))
+        o.equals(Optional.of("hello"))
 
     /////////////////////////////////////////////////////////////////////////////
     // toMapEntry                                                              //
@@ -284,7 +284,7 @@ mod TestAdaptor {
     @test
     def toMapEntry01(): Bool \ IO =
         let e = Adaptor.toMapEntry(("hello", "world"));
-        e.equals(unsafe JMap.entry("hello", "world"))
+        e.equals(JMap.entry("hello", "world"))
 
     /////////////////////////////////////////////////////////////////////////////
     // toList                                                                  //
@@ -293,17 +293,17 @@ mod TestAdaptor {
     @test
     def toList01(): Bool \ IO =
         let l = Adaptor.toList(Nil);
-        unsafe JList.of().equals(l)
+        JList.of().equals(l)
 
     @test
     def toList02(): Bool \ IO =
         let l = Adaptor.toList(List#{"hello"});
-        unsafe JList.of("hello").equals(l)
+        JList.of("hello").equals(l)
 
     @test
     def toList03(): Bool \ IO =
         let l = Adaptor.toList(List#{"hello", "world"});
-        unsafe JList.of("hello", "world").equals(l)
+        JList.of("hello", "world").equals(l)
 
     /////////////////////////////////////////////////////////////////////////////
     // toArrayList                                                             //
@@ -312,7 +312,7 @@ mod TestAdaptor {
     @test
     def toArrayList01(): Bool \ IO =
         let l = Adaptor.toArrayList(Nil);
-        new ArrayList(unsafe JList.of()).equals(l)
+        new ArrayList(JList.of()).equals(l)
 
     @test
     def toArrayList02(): Bool \ IO =
@@ -369,7 +369,7 @@ mod TestAdaptor {
     @test
     def toTreeSet01(): Bool \ IO =
         let s = Adaptor.toTreeSet((Set#{} : Set[String]));
-        new TreeSet(unsafe JList.of()).equals(s)
+        new TreeSet(JList.of()).equals(s)
 
     @test
     def toTreeSet02(): Bool \ IO =
@@ -388,17 +388,17 @@ mod TestAdaptor {
     @test
     def toMap01(): Bool \ IO =
         let m = Adaptor.toMap((Map#{} : Map[String, String]));
-        unsafe JMap.of().equals(m)
+        JMap.of().equals(m)
 
     @test
     def toMap02(): Bool \ IO =
         let m = Adaptor.toMap(Map#{"a" => "hello"});
-        unsafe JMap.of("a", "hello").equals(m)
+        JMap.of("a", "hello").equals(m)
 
     @test
     def toMap03(): Bool \ IO =
         let m = Adaptor.toMap(Map#{"a" => "hello", "b" => "world"});
-        unsafe JMap.of("a", "hello", "b", "world").equals(m)
+        JMap.of("a", "hello", "b", "world").equals(m)
 
     /////////////////////////////////////////////////////////////////////////////
     // toTreeMap                                                               //
@@ -407,17 +407,17 @@ mod TestAdaptor {
     @test
     def toTreeMap01(): Bool \ IO =
         let m = Adaptor.toTreeMap((Map#{} : Map[String, String]));
-        new TreeMap(unsafe JMap.of()).equals(m)
+        new TreeMap(JMap.of()).equals(m)
 
     @test
     def toTreeMap02(): Bool \ IO =
         let m = Adaptor.toTreeMap(Map#{"a" => "hello"});
-        new TreeMap(unsafe JMap.of("a", "hello")).equals(m)
+        new TreeMap(JMap.of("a", "hello")).equals(m)
 
     @test
     def toTreeMap03(): Bool \ IO =
         let m = Adaptor.toTreeMap(Map#{"a" => "hello", "b" => "world"});
-        new TreeMap(unsafe JMap.of("a", "hello", "b", "world")).equals(m)
+        new TreeMap(JMap.of("a", "hello", "b", "world")).equals(m)
 
 
 }

--- a/main/test/ca/uwaterloo/flix/library/TestAdaptor.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestAdaptor.flix
@@ -247,19 +247,19 @@ mod TestAdaptor {
 
     @test
     def fromCollectionToIterator01(): Bool \ {} = region rc {
-        let col = unsafe JList.of();
+        let col = checked_cast (unsafe JList.of());
         Iterator.toList(Adaptor.fromCollectionToIterator(rc, (Proxy.Proxy: Proxy[String]), col)) == (Nil : List[String])
     }
 
     @test
     def fromCollectionToIterator02(): Bool \ {} = region rc {
-        let col = unsafe JList.of("hello");
+        let col = checked_cast (unsafe JList.of("hello"));
         Iterator.toList(Adaptor.fromCollectionToIterator(rc, (Proxy.Proxy: Proxy[String]), col)) == "hello" :: Nil
     }
 
     @test
     def fromCollectionToIterator03(): Bool \ {} = region rc {
-        let col = unsafe JList.of("hello", "world");
+        let col = checked_cast (unsafe JList.of("hello", "world"));
         Iterator.toList(Adaptor.fromCollectionToIterator(rc, (Proxy.Proxy: Proxy[String]), col)) == "hello" :: "world" :: Nil
     }
 

--- a/main/test/ca/uwaterloo/flix/library/TestToJava.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestToJava.flix
@@ -188,17 +188,17 @@ mod TestToJava {
     @test
     def chainToJava01(): Bool \ IO =
         let l: JList = ToJava.toJava((Chain.empty() : Chain[String]));
-        unsafe JList.of().equals(l)
+        JList.of().equals(l)
 
     @test
     def chainToJava02(): Bool \ IO =
         let l: JList = ToJava.toJava(Chain.singleton("one"));
-        unsafe JList.of("one").equals(l)
+        JList.of("one").equals(l)
 
     @test
     def chainToJava03(): Bool \ IO =
         let l: JList = ToJava.toJava(Chain.cons("one", Chain.singleton("two")));
-        unsafe JList.of("one", "two").equals(l)
+        JList.of("one", "two").equals(l)
 
     /////////////////////////////////////////////////////////////////////////////
     // List                                                                     //
@@ -207,17 +207,17 @@ mod TestToJava {
     @test
     def listToJava01(): Bool \ IO =
         let l: JList = ToJava.toJava((Nil : List[String]));
-        unsafe JList.of().equals(l)
+        JList.of().equals(l)
 
     @test
     def listToJava02(): Bool \ IO =
         let l: JList = ToJava.toJava(List#{"one"});
-        unsafe JList.of("one").equals(l)
+        JList.of("one").equals(l)
 
     @test
     def listToJava03(): Bool \ IO =
         let l: JList = ToJava.toJava(List#{"one", "two"});
-        unsafe JList.of("one", "two").equals(l)
+        JList.of("one", "two").equals(l)
 
     /////////////////////////////////////////////////////////////////////////////
     // Map                                                                     //
@@ -226,17 +226,17 @@ mod TestToJava {
     @test
     def mapToJava01(): Bool \ IO =
         let m: JMap = ToJava.toJava((Map#{} : Map[String, String]));
-        unsafe JMap.of().equals(m)
+        JMap.of().equals(m)
 
     @test
     def mapToJava02(): Bool \ IO =
         let m: JMap = ToJava.toJava(Map#{"a" => "one"});
-        unsafe JMap.of("a", "one").equals(m)
+        JMap.of("a", "one").equals(m)
 
     @test
     def mapToJava03(): Bool \ IO =
         let m: JMap = ToJava.toJava(Map#{"a" => "one", "b" => "two"});
-        unsafe JMap.of("a", "one", "b", "two").equals(m)
+        JMap.of("a", "one", "b", "two").equals(m)
 
     /////////////////////////////////////////////////////////////////////////////
     // Nec                                                                     //
@@ -245,12 +245,12 @@ mod TestToJava {
     @test
     def necToJava01(): Bool \ IO =
         let l: JList = ToJava.toJava(Nec.singleton("one"));
-        unsafe JList.of("one").equals(l)
+        JList.of("one").equals(l)
 
     @test
     def necToJava02(): Bool \ IO =
         let l: JList = ToJava.toJava(Nec.cons("one", Nec.singleton("two")));
-        unsafe JList.of("one", "two").equals(l)
+        JList.of("one", "two").equals(l)
 
     /////////////////////////////////////////////////////////////////////////////
     // Nel                                                                     //
@@ -259,12 +259,12 @@ mod TestToJava {
     @test
     def nelToJava01(): Bool \ IO =
         let l: JList = ToJava.toJava(Nel.singleton("one"));
-        unsafe JList.of("one").equals(l)
+        JList.of("one").equals(l)
 
     @test
     def nelToJava02(): Bool \ IO =
         let l: JList = ToJava.toJava(Nel.cons("one", Nel.singleton("two")));
-        unsafe JList.of("one", "two").equals(l)
+        JList.of("one", "two").equals(l)
 
     /////////////////////////////////////////////////////////////////////////////
     // Set                                                                     //
@@ -273,17 +273,17 @@ mod TestToJava {
     @test
     def setToJava01(): Bool \ IO =
         let s: JSet = ToJava.toJava((Set#{} : Set[String]));
-        unsafe JSet.of().equals(s)
+        JSet.of().equals(s)
 
     @test
     def setToJava02(): Bool \ IO =
         let s: JSet = ToJava.toJava(Set#{"one"});
-        unsafe JSet.of("one").equals(s)
+        JSet.of("one").equals(s)
 
     @test
     def setToJava03(): Bool \ IO =
         let s: JSet = ToJava.toJava(Set#{"one", "two"});
-        unsafe JSet.of("one", "two").equals(s)
+        JSet.of("one", "two").equals(s)
 
     /////////////////////////////////////////////////////////////////////////////
     // Vector                                                                  //
@@ -292,16 +292,16 @@ mod TestToJava {
     @test
     def vectorToJava01(): Bool \ IO =
         let v: JList = ToJava.toJava((Vector#{} : Vector[String]));
-        unsafe JList.of().equals(v)
+        JList.of().equals(v)
 
     @test
     def vectorToJava02(): Bool \ IO =
         let v: JList = ToJava.toJava(Vector#{"one"});
-        unsafe JList.of("one").equals(v)
+        JList.of("one").equals(v)
 
     @test
     def vectorToJava03(): Bool \ IO =
         let v: JList = ToJava.toJava(Vector#{"one", "two"});
-        unsafe JList.of("one", "two").equals(v)
+        JList.of("one", "two").equals(v)
 
 }

--- a/main/test/flix/Test.Exp.UncheckedTypeCast.flix
+++ b/main/test/flix/Test.Exp.UncheckedTypeCast.flix
@@ -36,13 +36,15 @@ mod Test.Exp.UncheckedTypeCast {
     @test
     def testUncheckedTypeCast05(): Serializable = region rc {
         let _ = rc;
-        unchecked_cast(unsafe new StringBuilder() as Serializable)
+        let sb = unchecked_cast ((new StringBuilder(): _ \ IO) as _ \ rc);
+        unchecked_cast(sb as Serializable)
     }
 
     @test
     def testUncheckedTypeCast06(): Object = region rc {
         let _ = rc;
-        unchecked_cast(unsafe new StringBuilder() as Object)
+        let sb = unchecked_cast ((new StringBuilder(): _ \ IO) as _ \ rc);
+        unchecked_cast(sb as Object)
     }
 
 }


### PR DESCRIPTION
This pr reduces the use of `unsafe` and uses more precise and sound `unchecked_cast`

Should't `Environment.getEnv()` be impure? can't that change during computation? 