### PR TITLE
proposal: use stable order of effect variables

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -666,6 +666,19 @@ object Type {
   }
 
   /**
+    * Returns a fresh type variable of the given kind `k` and rigidity `r`.
+    */
+  def freshSubEffectVar(loc: SourceLocation)(implicit scope: Scope, flix: Flix): Type.Var = {
+    import ca.uwaterloo.flix.language.ast.Symbol.KindedTypeVarSym
+    val offset = -10_000_000
+    val text = Ast.VarText.Absent
+    val kind = Kind.Eff
+    val isRegion = false
+    val sym = new KindedTypeVarSym(flix.genSym.freshId() + offset, text, kind, isRegion, scope, loc)
+    Type.Var(sym, loc)
+  }
+
+  /**
     * Returns a fresh error type of the given kind `k`.
     */
   def freshError(k: Kind, loc: SourceLocation)(implicit flix: Flix): Type = {

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -148,7 +148,7 @@ object ConstraintGen {
           }
           enabled && !useless && !redundant
         }
-        val eff = if (shouldSubeffect) Type.mkUnion(eff0, Type.freshVar(Kind.Eff, loc), loc) else eff0
+        val eff = if (shouldSubeffect) Type.mkUnion(eff0, Type.freshSubEffectVar(loc), loc) else eff0
         val resTpe = Type.mkArrowWithEffect(fparam.tpe, eff, tpe, loc)
         val resEff = Type.Pure
         (resTpe, resEff)
@@ -394,7 +394,7 @@ object ConstraintGen {
           }
           enabled && !useless && !redundant
         }
-        val defEff = if (shouldSubeffect) Type.mkUnion(eff1, Type.freshVar(Kind.Eff, loc), loc) else eff1
+        val defEff = if (shouldSubeffect) Type.mkUnion(eff1, Type.freshSubEffectVar(loc), loc) else eff1
         val defTpe = Type.mkUncurriedArrowWithEffect(fparams.map(_.tpe), defEff, tpe1, sym.loc)
         c.unifyType(sym.tvar, defTpe, sym.loc)
         val (tpe2, eff2) = visitExp(exp2)

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/EffUnification3.scala
@@ -114,7 +114,11 @@ object EffUnification3 {
 
   /** Returns a [[Bimap]] with each [[Atom]] having a unique number. */
   private def mkBidirectionalVarMap(atoms: Set[Atom]): Bimap[Atom, Int] =
-    Bimap.from(atoms.toList.zipWithIndex)
+    Bimap.from(atoms.toList.zipWithIndex.map {
+      case (a@Atom.VarFlex(sym), _) if sym.id < 0 => a -> sym.id
+      case (a@Atom.VarFlex(sym), _) => a -> (sym.id + 10_000_000)
+      case (atom, idx) => atom -> idx
+    })
 
   /** Returns the union of [[Atom]]s for each [[Type]] in `eqs` using [[Atom.getAtoms]]. */
   private def getAtomsFromEquations(eqs: List[(Type, Type, SourceLocation)])(implicit scope: Scope, renv: RigidityEnv): Set[Atom] = {

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/set/SetUnification.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/set/SetUnification.scala
@@ -46,7 +46,7 @@ object SetUnification {
 
   final object Options {
     /** The default [[Options]]. */
-    val default: Options = Options(10, 10, 100_000, 0)
+    val default: Options = Options(10, 1, 5_000, 0)
   }
 
   /** Represents the running mutable state of the solver. */
@@ -536,7 +536,7 @@ object SetUnification {
 
 
     val query = mkEmptyQuery(eq.f1, eq.f2)
-    val fvs = query.variables.toList
+    val fvs = query.variables.toList.reverse
     try {
       val subst = successiveVariableElimination(query, fvs)
       Some(Nil, subst)


### PR DESCRIPTION
This PR demonstrates that the problem is in unstable ordering of effect variables during translation from types to atoms to numbers.

With this PR I can run: 

```
Xperf --par --n 51 --frontend --Xsubeffecting lambdas
```

which does consume a ton of memory (at least 9GB), but it returns with:

```
~~~~ Flix Compiler Performance ~~~~

Throughput (best): 19.350 lines/sec (with 24 threads.)

  min:  8.903, max: 19.350, avg: 18.124, median: 18.354

Finished 51 iterations on 67.196 lines of code in 191 seconds.
```

The PR is an ugly hack. It does two things:

- It hacks the Bimap creation to ensure that stable IDs are used for the effect variables.
- It ensure that subeffect variables are given very low (negative numbers), hence they are solved "first".

I think before we attempt any other performance trick, we need to resolve the issue about stable numbering. Otherwise we are essentially always operating under adverse scheduling. 

@JonathanStarup @mlutze Does it make sense?