### PR TITLE
refactor: remove redundant call to `flatMapN`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1954,12 +1954,13 @@ object Weeder2 {
     private def visitSpawnExpr(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {
       expect(tree, TreeKind.Expr.Spawn)
       val scopeName = tryPick(TreeKind.Expr.ScopeName, tree)
-      flatMapN(pickExpr(tree), traverseOpt(scopeName)(visitScopeName)) {
-        case (expr1, Some(expr2)) => Validation.success(Expr.Spawn(expr1, expr2, tree.loc))
+      mapN(pickExpr(tree), traverseOpt(scopeName)(visitScopeName)) {
+        case (expr1, Some(expr2)) =>
+          Expr.Spawn(expr1, expr2, tree.loc)
         case (expr1, None) =>
           val error = MissingScope(TokenKind.KeywordSpawn, SyntacticContext.Expr.OtherExpr, loc = tree.loc)
           sctx.errors.add(error)
-          Validation.success(Expr.Spawn(expr1, Expr.Error(error), tree.loc))
+          Expr.Spawn(expr1, Expr.Error(error), tree.loc)
       }
     }
 


### PR DESCRIPTION
Very minor change in `visitSpawnExpr` in `Weeder2` that just replace a call to `flatMapN` with a call to `mapN`