### PR TITLE
refactor: always return root and errors from phases

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -504,30 +504,30 @@ class Flix {
       implicit def map[C](f: A => C): Validation[C, B] = Validation.mapN(v)(f)
     }
 
-    val (afterReader, _) = Reader.run(getInputs, knownClassesAndInterfaces)
+    val (afterReader, readerErrors) = Reader.run(getInputs, knownClassesAndInterfaces)
     val (afterLexer, lexerErrors) = Lexer.run(afterReader, cachedLexerTokens, changeSet)
     val (afterParser, parserErrors) = Parser2.run(afterLexer, cachedParserCst, changeSet)
 
     /** Remember to update [[AstPrinter]] about the list of phases. */
     val result = for {
-      afterWeeder <- Weeder2.run(afterReader, entryPoint, afterParser, cachedWeederAst, changeSet).withSoftFailures(lexerErrors).withSoftFailures(parserErrors)
+      afterWeeder <- Weeder2.run(afterReader, entryPoint, afterParser, cachedWeederAst, changeSet).withSoftFailures(readerErrors).withSoftFailures(lexerErrors).withSoftFailures(parserErrors)
       afterDesugar = Desugar.run(afterWeeder, cachedDesugarAst, changeSet)
       (afterNamer, namerErrors) = Namer.run(afterDesugar)
       afterResolver <- Resolver.run(afterNamer, cachedResolverAst, changeSet).withSoftFailures(namerErrors)
       (afterKinder, kinderErrors) = Kinder.run(afterResolver, cachedKinderAst, changeSet)
       (afterDeriver, derivationErrors) = Deriver.run(afterKinder)
       afterTyper <- Typer.run(afterDeriver, cachedTyperAst, changeSet).withSoftFailures(kinderErrors).withSoftFailures(derivationErrors)
-      _ = EffectVerifier.run(afterTyper)
-      (_, regionErrors) = Regions.run(afterTyper)
-      (afterEntryPoint, entryPointErrors) = EntryPoint.run(afterTyper)
-      (_, instanceErrors) = Instances.run(afterEntryPoint, cachedTyperAst, changeSet)
-      afterPredDeps = PredDeps.run(afterEntryPoint)
+      () = EffectVerifier.run(afterTyper)
+      (afterRegions, regionErrors) = Regions.run(afterTyper)
+      (afterEntryPoint, entryPointErrors) = EntryPoint.run(afterRegions)
+      (afterInstances, instanceErrors) = Instances.run(afterEntryPoint, cachedTyperAst, changeSet)
+      (afterPredDeps, predDepErrors) = PredDeps.run(afterInstances)
       (afterStratifier, stratificationErrors) = Stratifier.run(afterPredDeps)
-      (_, patMatchErrors) = PatMatch.run(afterStratifier)
-      redundancyErrors = Redundancy.run(afterStratifier)
-      (_, safetyErrors) = Safety.run(afterStratifier)
-      errors = regionErrors ::: entryPointErrors ::: instanceErrors ::: stratificationErrors ::: patMatchErrors ::: redundancyErrors ::: safetyErrors
-      output <- Validation.toSuccessOrSoftFailure(afterStratifier, errors) // Minimal change for things to still work. Will be removed once Validation is removed.
+      (afterPatMatch, patMatchErrors) = PatMatch.run(afterStratifier)
+      (afterRedundancy, redundancyErrors) = Redundancy.run(afterPatMatch)
+      (afterSafety, safetyErrors) = Safety.run(afterRedundancy)
+      errors = regionErrors ::: entryPointErrors ::: instanceErrors ::: predDepErrors ::: stratificationErrors ::: patMatchErrors ::: redundancyErrors ::: safetyErrors
+      output <- Validation.toSuccessOrSoftFailure(afterSafety, errors) // Minimal change for things to still work. Will be removed once Validation is removed.
     } yield {
       // Update caches for incremental compilation.
       if (options.incremental) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugUnit
+import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugTypedAst
 import ca.uwaterloo.flix.language.ast.ops.TypedAstOps
 import ca.uwaterloo.flix.language.ast.shared.Scope
 import ca.uwaterloo.flix.language.ast.{Ast, ChangeSet, RigidityEnv, Scheme, Symbol, Type, TypeConstructor, TypedAst}
@@ -33,10 +33,10 @@ object Instances {
   /**
     * Validates instances and traits in the given AST root.
     */
-  def run(root: TypedAst.Root, oldRoot: TypedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): (Unit, List[InstanceError]) =
+  def run(root: TypedAst.Root, oldRoot: TypedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): (TypedAst.Root, List[InstanceError]) =
     flix.phaseNew("Instances") {
       val errors = visitInstances(root, oldRoot, changeSet) ::: visitTraits(root)
-      ((), errors)
+      (root, errors)
     }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -109,7 +109,7 @@ object PatMatch {
   /**
     * Returns an error message if a pattern match is not exhaustive
     */
-  def run(root: TypedAst.Root)(implicit flix: Flix): (Unit, List[NonExhaustiveMatchError]) =
+  def run(root: TypedAst.Root)(implicit flix: Flix): (Root, List[NonExhaustiveMatchError]) =
     flix.phaseNew("PatMatch") {
       implicit val r: TypedAst.Root = root
 
@@ -123,7 +123,7 @@ object PatMatch {
 
       val errors = classDefErrs ++ defErrs ++ instanceDefErrs ++ sigsErrs
 
-      ((), errors.toList)
+      (root, errors.toList)
     }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -17,6 +17,7 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.Type.eraseAliases
 import ca.uwaterloo.flix.language.ast.TypedAst.*
 import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.Body
@@ -24,6 +25,7 @@ import ca.uwaterloo.flix.language.ast.shared.LabelledPrecedenceGraph.{Label, Lab
 import ca.uwaterloo.flix.language.ast.shared.{Denotation, LabelledPrecedenceGraph}
 import ca.uwaterloo.flix.language.ast.{Type, TypeConstructor}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
+import ca.uwaterloo.flix.language.errors.Recoverable
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
 /**
@@ -34,7 +36,7 @@ import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
   */
 object PredDeps {
 
-  def run(root: Root)(implicit flix: Flix): Root = flix.phase("PredDeps") {
+  def run(root: Root)(implicit flix: Flix): (Root, List[CompilationMessage & Recoverable]) = flix.phaseNew("PredDeps") {
     // Compute an over-approximation of the dependency graph for all constraints in the program.
     val defExps = root.defs.values.map(_.exp)
     val instanceExps = root.instances.values.flatten.flatMap(_.defs).map(_.exp)
@@ -45,7 +47,7 @@ object PredDeps {
       case (acc, d) => acc + visitExp(d)
     }, _ + _)
 
-    root.copy(precedenceGraph = g)
+    (root.copy(precedenceGraph = g), List.empty)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
@@ -34,11 +34,12 @@ import scala.collection.immutable.SortedSet
   */
 object Regions {
 
-  def run(root: Root)(implicit flix: Flix): (Unit, List[TypeError]) = flix.phaseNew("Regions") {
+  def run(root: Root)(implicit flix: Flix): (Root, List[TypeError]) = flix.phaseNew("Regions") {
     val defErrors = ParOps.parMap(root.defs)(kv => visitDef(kv._2)).flatten
     val sigErrors = ParOps.parMap(root.sigs)(kv => visitSig(kv._2)).flatten
     val instanceErrors = ParOps.parMap(root.instances)(kv => kv._2.flatMap(visitInstance)).flatten
-    ((), (defErrors ++ sigErrors ++ instanceErrors).toList)
+    val errors = defErrors ++ sigErrors ++ instanceErrors
+    (root, errors.toList)
   }
 
   private def visitDef(def0: Def)(implicit flix: Flix): List[TypeError.RegionVarEscapes] =

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -30,7 +30,7 @@ object Safety {
   /**
     * Performs safety and well-formedness checks on the given AST `root`.
     */
-  def run(root: Root)(implicit flix: Flix): (Unit, List[SafetyError]) = flix.phaseNew("Safety") {
+  def run(root: Root)(implicit flix: Flix): (Root, List[SafetyError]) = flix.phaseNew("Safety") {
     //
     // Collect all errors.
     //
@@ -44,7 +44,7 @@ object Safety {
     //
     // Check if any errors were found.
     //
-    ((), errors.toList)
+    (root, errors.toList)
   }
 
   /**


### PR DESCRIPTION
Updates phases to consistently return a root and a possibly empty list of errors.

Related to https://github.com/flix/flix/issues/8815