### PR TITLE
refactor: move `TraitContext` from `Ast` to `shared`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -16,7 +16,6 @@
 
 package ca.uwaterloo.flix.language.ast
 
-import ca.uwaterloo.flix.language.ast.shared.Instance
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
 /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -25,11 +25,6 @@ import ca.uwaterloo.flix.language.errors.ResolutionError
 object Ast {
 
   /**
-    * Represents the super traits and instances available for a particular traits.
-    */
-  case class TraitContext(superTraits: List[Symbol.TraitSym], instances: List[Instance])
-
-  /**
     * Represents the definition of an associated type.
     * If this associated type is named `Assoc`, then
     * Assoc[arg] = ret.

--- a/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/LoweredAst.scala
@@ -35,7 +35,7 @@ object LoweredAst {
                   entryPoint: Option[Symbol.DefnSym],
                   reachable: Set[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],
-                  traitEnv: Map[Symbol.TraitSym, Ast.TraitContext],
+                  traitEnv: Map[Symbol.TraitSym, TraitContext],
                   eqEnv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef])
 
   case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[AssocTypeSig], signatures: List[Sig], laws: List[Def], loc: SourceLocation)

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -41,7 +41,7 @@ object TypedAst {
                   entryPoint: Option[Symbol.DefnSym],
                   reachable: Set[Symbol.DefnSym],
                   sources: Map[Source, SourceLocation],
-                  traitEnv: Map[Symbol.TraitSym, Ast.TraitContext],
+                  traitEnv: Map[Symbol.TraitSym, TraitContext],
                   eqEnv: ListMap[Symbol.AssocTypeSym, Ast.AssocTypeDef],
                   names: MultiMap[List[String], String],
                   precedenceGraph: LabelledPrecedenceGraph)

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/TraitContext.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/TraitContext.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Holger Dal Mogensen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.ast.shared
+
+import ca.uwaterloo.flix.language.ast.Symbol
+
+/**
+  * Represents the super traits and instances available for a particular traits.
+  */
+case class TraitContext(superTraits: List[Symbol.TraitSym], instances: List[Instance])

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -129,7 +129,7 @@ object Typer {
         }
         // ignore the super trait parameters since they should all be the same as the trait param
         val superTraits = trt.superTraits.map(_.head.sym)
-        (traitSym, Ast.TraitContext(superTraits, envInsts))
+        (traitSym, TraitContext(superTraits, envInsts))
     }
     TraitEnv(m)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/unification/TraitEnv.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/TraitEnv.scala
@@ -15,14 +15,14 @@
  */
 package ca.uwaterloo.flix.language.phase.unification
 
-import ca.uwaterloo.flix.language.ast.shared.Instance
-import ca.uwaterloo.flix.language.ast.{Ast, Symbol, Type}
+import ca.uwaterloo.flix.language.ast.shared.{Instance, TraitContext}
+import ca.uwaterloo.flix.language.ast.{Symbol, Type}
 import ca.uwaterloo.flix.util.InternalCompilerException
 
 /**
   * The trait environment stores information about traits.
   */
-case class TraitEnv(private val m: Map[Symbol.TraitSym, Ast.TraitContext]) {
+case class TraitEnv(private val m: Map[Symbol.TraitSym, TraitContext]) {
 
   /**
     * Returns the instances of the given trait.
@@ -87,7 +87,7 @@ case class TraitEnv(private val m: Map[Symbol.TraitSym, Ast.TraitContext]) {
       case (acc, s) =>
         val inst = Instance(tpe, Nil)
         val context = m.get(s) match {
-          case Some(Ast.TraitContext(supers, insts)) => Ast.TraitContext(supers, inst :: insts)
+          case Some(TraitContext(supers, insts)) => TraitContext(supers, inst :: insts)
           case None => throw InternalCompilerException(s"unexpected unknown trait sym: $sym", sym.loc)
         }
         acc + (s -> context)
@@ -98,7 +98,7 @@ case class TraitEnv(private val m: Map[Symbol.TraitSym, Ast.TraitContext]) {
   /**
     * Returns a map from trait symbols to trait context.
     */
-  def toMap: Map[Symbol.TraitSym, Ast.TraitContext] = m
+  def toMap: Map[Symbol.TraitSym, TraitContext] = m
 
   /**
     * Returns the super traits of the symbol, as well as the super traits' super traits, etc.


### PR DESCRIPTION
Related to #7871 