### PR TITLE
feat: lsp visitor should recurse into types

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -824,7 +824,6 @@ object Visitor {
     c.consumeType(tpe)
 
     tpe match {
-      case _: Type.BaseType => ()
       case Type.Var(_, _) => ()
       case Type.Cst(_, _) => ()
       case Type.Apply(tpe1, tpe2, _) =>

--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -820,7 +820,22 @@ object Visitor {
 
   private def visitType(tpe: Type)(implicit a: Acceptor, c: Consumer): Unit = {
     if (!a.accept(tpe.loc)) { return }
+
     c.consumeType(tpe)
+
+    tpe match {
+      case _: Type.BaseType => ()
+      case Type.Var(_, _) => ()
+      case Type.Cst(_, _) => ()
+      case Type.Apply(tpe1, tpe2, _) =>
+        visitType(tpe1)
+        visitType(tpe2)
+      case Type.Alias(_, args, _, _) => args.foreach(visitType)
+      case Type.AssocType(_, _, _, _) => visitType(tpe)
+      case Type.JvmToType(tpe, _) => visitType(tpe)
+      case Type.JvmToEff(tpe, _) => visitType(tpe)
+      case Type.UnresolvedJvmType(_, _) => ()
+    }
   }
 
   private def visitAnnotations(anns: Annotations)(implicit a: Acceptor, c: Consumer): Unit = {


### PR DESCRIPTION
This PR extends the LSP visitor to recursive into types (instead of just consider top-most types).

Related to #9114