### PR TITLE
fix: infinite recursion in visitType

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -826,13 +826,13 @@ object Visitor {
     tpe match {
       case Type.Var(_, _) => ()
       case Type.Cst(_, _) => ()
-      case Type.Apply(tpe1, tpe2, _) =>
-        visitType(tpe1)
-        visitType(tpe2)
+      case Type.Apply(t1, t2, _) =>
+        visitType(t1)
+        visitType(t2)
       case Type.Alias(_, args, _, _) => args.foreach(visitType)
-      case Type.AssocType(_, _, _, _) => visitType(tpe)
-      case Type.JvmToType(tpe, _) => visitType(tpe)
-      case Type.JvmToEff(tpe, _) => visitType(tpe)
+      case Type.AssocType(_, t, _, _) => visitType(t)
+      case Type.JvmToType(t, _) => visitType(t)
+      case Type.JvmToEff(t, _) => visitType(t)
       case Type.UnresolvedJvmType(_, _) => ()
     }
   }


### PR DESCRIPTION
This PR fixes an issue where the LSP visitor would fall into endless recursion on `visitType` for assoc types.

Related to #9114