### PR TITLE
feat: improve `instanceof` parsing

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -630,7 +630,7 @@ object WeederError {
 
     override def message(formatter: Formatter): String = {
       import formatter.*
-      s""">> Unexpected qualified name.
+      s""">> Unexpected qualified name. Java names must be imported, e.g., `import java.lang.Object`.
          |
          |${code(loc, "illegal qualified name")}
          |


### PR DESCRIPTION
Improve errors and avoid pickQName
```
>> Expected <QName>.

1 | def main(): Int32 = 32 instanceof java.lang.Object
                                      ^^^^^^^^^
                                      Here
Hint: Use a single unqualified Java type like 'Object' instead of 'java.lang.object'.
```

```
>> Unexpected qualified name. Java names must be imported, e.g., `import java.lang.Object`.

1 | def main(): Int32 = 32 instanceof Java.Lang.Object
                                      ^^^^^^^^^^^^^^^^
                                      illegal qualified name
```