### PR TITLE
fix: removed double visit of sigs in lsp visitor

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -167,6 +167,9 @@ object Visitor {
     implicit val c: Consumer = consumer
     implicit val a: Acceptor = acceptor
 
+    // NB: the signatures in `root.sigs` are not visited here, since they will be visited after
+    // their corresponding trait
+
     root.defs.values.foreach(visitDef)
 
     root.effects.values.foreach(visitEffect)
@@ -174,8 +177,6 @@ object Visitor {
     root.enums.values.foreach(visitEnum)
 
     root.instances.values.flatten.foreach(visitInstance)
-
-    root.sigs.values.foreach(visitSig)
 
     root.structs.values.foreach(visitStruct)
 


### PR DESCRIPTION
This PR removed an accidental double visit to signatures in the LSP visitor. This problem occured because everything in both `root.traits` and `root.sigs` was visited. But since every signature is in a trait, they would then also be visited again after visiting their `trait`. The issue has been fixed by simply removing the line that visits everything in `root.sigs`.

Related to #9114