### PR TITLE
feat: add label to StackConsumer

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/StackConsumer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/StackConsumer.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst.*
 import ca.uwaterloo.flix.language.ast.TypedAst.Pattern.Record.RecordLabelPattern
 import ca.uwaterloo.flix.language.ast.shared.SymUse.*
 import ca.uwaterloo.flix.language.ast.shared.{Annotation, EqualityConstraint, TraitConstraint}
-import ca.uwaterloo.flix.language.ast.{Symbol, Type}
+import ca.uwaterloo.flix.language.ast.{Name, Symbol, Type}
 
 /**
   * Consumer that collects every visited AST nodes on a stack where the head is the last element visited.
@@ -66,6 +66,7 @@ case class StackConsumer() extends Consumer {
   override def consumeHandlerRule(rule: HandlerRule): Unit = push(rule)
   override def consumeInstance(ins: Instance): Unit = push(ins)
   override def consumeJvmMethod(method: JvmMethod): Unit = push(method)
+  override def consumeLabel(label: Name.Label): Unit = push(label)
   override def consumeLocalDefSym(symUse: LocalDefSymUse): Unit = push(symUse)
   override def consumeMatchRule(rule: MatchRule): Unit = push(rule)
   override def consumeOp(op: Op): Unit = push(op)


### PR DESCRIPTION
This PR makes it such that the StackConsumer also pushes labels onto the stack.

Related to #9114