### PR TITLE
fix: Cons parsing edgecase

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst.Pattern.Record.RecordLabelPattern
 import ca.uwaterloo.flix.language.ast.TypedAst.{AssocTypeDef, Instance, *}
 import ca.uwaterloo.flix.language.ast.shared.SymUse.*
 import ca.uwaterloo.flix.language.ast.shared.{Annotation, Annotations, EqualityConstraint, TraitConstraint}
-import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol, Type}
+import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, Type}
 
 object Visitor {
 
@@ -73,6 +73,7 @@ object Visitor {
     def consumeHandlerRule(rule: HandlerRule): Unit = ()
     def consumeInstance(ins: Instance): Unit = ()
     def consumeJvmMethod(method: JvmMethod): Unit = ()
+    def consumeLabel(label: Name.Label): Unit = ()
     def consumeLocalDefSym(symUse: LocalDefSymUse): Unit = ()
     def consumeMatchRule(rule: MatchRule): Unit = ()
     def consumeOp(op: Op): Unit = ()
@@ -504,14 +505,17 @@ object Visitor {
 
       case Expr.RecordEmpty(_, _) => ()
 
-      case Expr.RecordSelect(exp, _, _, _, _) =>
+      case Expr.RecordSelect(exp, label, _, _, _) =>
         visitExpr(exp)
+        visitLabel(label)
 
-      case Expr.RecordExtend(_, exp1, exp2, _, _, _) =>
+      case Expr.RecordExtend(label, exp1, exp2, _, _, _) =>
+        visitLabel(label)
         visitExpr(exp1)
         visitExpr(exp2)
 
-      case Expr.RecordRestrict(_, exp, _, _, _) =>
+      case Expr.RecordRestrict(label, exp, _, _, _) =>
+        visitLabel(label)
         visitExpr(exp)
 
       case Expr.ArrayLit(exps, exp, _, _, _) =>
@@ -678,6 +682,12 @@ object Visitor {
 
       case Expr.Error(_, _, _) => ()
     }
+  }
+
+  private def visitLabel(label: Name.Label)(implicit a: Acceptor, c: Consumer): Unit = {
+    if (!a.accept(label.loc)) { return }
+
+    c.consumeLabel(label)
   }
 
   private def visitBinder(bnd: Binder)(implicit a: Acceptor, c: Consumer): Unit = {
@@ -917,9 +927,13 @@ object Visitor {
   }
 
   private def visitRecordLabelPattern(pat: RecordLabelPattern)(implicit a: Acceptor, c: Consumer): Unit = {
-    val RecordLabelPattern(_, p, _, loc) = pat
+    val RecordLabelPattern(label, p, _, loc) = pat
+
     if (!a.accept(loc)) { return }
+
     c.consumeRecordLabelPattern(pat)
+
+    visitLabel(label)
     visitPattern(p)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -319,10 +319,9 @@ object Parser2 {
     * Look-ahead `lookahead` tokens.
     * Consumes one fuel and throws [[InternalCompilerException]] if the parser is out of fuel.
     * Does not consume fuel if parser has hit end-of-file.
-    * Does not consume fuel if `consume` is false. This should be used sparingly.
     * This lets the parser return what ever errors were produced from a deep call-stack without running out of fuel.
     */
-  private def nth(lookahead: Int, consume: Boolean = true)(implicit s: State): TokenKind = {
+  private def nth(lookahead: Int)(implicit s: State): TokenKind = {
     if (s.fuel == 0) {
       throw InternalCompilerException(s"Parser is stuck", currentSourceLocation())
     }
@@ -330,9 +329,7 @@ object Parser2 {
     if (s.position + lookahead >= s.tokens.length - 1) {
       TokenKind.Eof
     } else {
-      if (consume) {
-        s.fuel -= 1
-      }
+      s.fuel -= 1
       s.tokens(s.position + lookahead).kind
     }
   }
@@ -1433,10 +1430,7 @@ object Parser2 {
       // Handle binary operators
       continue = true
       while (continue) {
-        // We want to allow an unbounded number of cons (a :: b :: c :: ...).
-        // Hence we special case on whether the left token is ::. If it is,
-        // we avoid consuming any fuel.
-        val right = nth(0, consume = left != TokenKind.ColonColon)
+        val right = nth(0)
         if (rightBindsTighter(left, right, leftIsUnary)) {
           val mark = openBefore(lhs)
           val markOp = open()
@@ -1446,11 +1440,15 @@ object Parser2 {
           lhs = close(mark, TreeKind.Expr.Binary)
           lhs = close(openBefore(lhs), TreeKind.Expr.Expr)
         } else {
+          // We want to allow an unbounded number of cons (a :: b :: c :: ...).
+          // Hence we special case on whether the left token is ::. If it is,
+          // we avoid consuming any fuel.
+          // The next nth lookup will always fail, so we add fuel to account for it.
+          // The lookup for KeywordWithout will always happen to we add fuel to account for it.
+          if (left == TokenKind.ColonColon) s.fuel += 2
           continue = false
         }
       }
-      // fuel for the next eat, when goin down the callstack for cons.
-      if (left == TokenKind.ColonColon) s.fuel += 1 // recu
       // Handle without expressions
       if (eat(TokenKind.KeywordWithout)) {
         val mark = open()

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1449,6 +1449,8 @@ object Parser2 {
           continue = false
         }
       }
+      // fuel for the next eat, when goin down the callstack for cons.
+      if (left == TokenKind.ColonColon) s.fuel += 1 // recu
       // Handle without expressions
       if (eat(TokenKind.KeywordWithout)) {
         val mark = open()


### PR DESCRIPTION
Currently we can only parse cons lists up to 256 in some cases
```
1 :: 2 :: .. :: Nil; ???
```
The cons list can look infinitely, but going down the call stack drains fuel because of the last failing nth check (correctly special-cased currently) and `if (eat(TokenKind.KeywordWith)) {` line. This means that the statement rule dies when it looks for `;`. If the following rule advances without checking then the fuel is reset so it doesn't always show.

In this PR I just add 2 fuel to account for the stack wind down. The way up is now issue because it is using advance() before calling