### PR TITLE
test: rename module `Test.Exp.ReifyType` to `Test.Exp.TypeMatch`

### DIFF
--- a/main/test/flix/Test.Exp.TypeMatch.flix
+++ b/main/test/flix/Test.Exp.TypeMatch.flix
@@ -1,7 +1,7 @@
-mod Test.Exp.ReifyType {
+mod Test.Exp.TypeMatch {
 
     //////////////////////////////////////
-    // Emulating reifyType              //
+    // Emulating type reflection        //
     //////////////////////////////////////
 
     @Test
@@ -313,7 +313,7 @@ mod Test.Exp.ReifyType {
     }
 
     //////////////////////////////////////
-    // Emulating reifyEff               //
+    // Emulating effect reflection      //
     //////////////////////////////////////
 
     @Test


### PR DESCRIPTION
Updated it to match its file name.