### PR TITLE
Experiment: Binding Blocks in Desugar

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
@@ -103,13 +103,9 @@ object DesugaredAst {
 
     case class IfThenElse(exp1: Expr, exp2: Expr, exp3: Expr, loc: SourceLocation) extends Expr
 
-    case class Stm(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
-
     case class Discard(exp: Expr, loc: SourceLocation) extends Expr
 
-    case class Let(ident: Name.Ident, exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
-
-    case class LocalDef(ident: Name.Ident, fparams: List[FormalParam], exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Block(bs: List[Binding], exp: Expr, loc: SourceLocation) extends Expr
 
     case class Region(tpe: ca.uwaterloo.flix.language.ast.Type, loc: SourceLocation) extends Expr
 
@@ -212,6 +208,20 @@ object DesugaredAst {
     case class Error(m: CompilationMessage) extends Expr {
       override def loc: SourceLocation = m.loc
     }
+
+  }
+
+  sealed trait Binding {
+    def loc: SourceLocation
+  }
+
+  object Binding {
+
+    case class Let(ident: Name.Ident, exp: Expr, loc: SourceLocation) extends Binding
+
+    case class LocalDef(ident: Name.Ident, fparams: List[FormalParam], exp1: Expr, loc: SourceLocation) extends Binding
+
+    case class Stm(exp: Expr, loc: SourceLocation) extends Binding
 
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -608,28 +608,30 @@ object Namer {
       val e3 = visitExp(exp3, ns0)
       NamedAst.Expr.IfThenElse(e1, e2, e3, loc)
 
-    case DesugaredAst.Expr.Stm(exp1, exp2, loc) =>
-      val e1 = visitExp(exp1, ns0)
-      val e2 = visitExp(exp2, ns0)
-      NamedAst.Expr.Stm(e1, e2, loc)
-
     case DesugaredAst.Expr.Discard(exp, loc) =>
       val e = visitExp(exp, ns0)
       NamedAst.Expr.Discard(e, loc)
 
-    case DesugaredAst.Expr.Let(ident, exp1, exp2, loc) =>
-      // make a fresh variable symbol for the local variable.
-      val sym = Symbol.freshVarSym(ident, BoundBy.Let)
-      val e1 = visitExp(exp1, ns0)
-      val e2 = visitExp(exp2, ns0)
-      NamedAst.Expr.Let(sym, e1, e2, loc)
+    case DesugaredAst.Expr.Block(bs, exp0, _) =>
+      bs.foldRight(visitExp(exp0, ns0)){
 
-    case DesugaredAst.Expr.LocalDef(ident, fparams, exp1, exp2, loc) =>
-      val sym = Symbol.freshVarSym(ident, BoundBy.LocalDef)
-      val fps = fparams.map(visitFormalParam(_))
-      val e1 = visitExp(exp1, ns0)
-      val e2 = visitExp(exp2, ns0)
-      NamedAst.Expr.LocalDef(sym, fps, e1, e2, loc)
+        case (DesugaredAst.Binding.Let(ident, exp, loc), acc) =>
+          // make a fresh variable symbol for the local variable.
+          val sym = Symbol.freshVarSym(ident, BoundBy.Let)
+          val exp1 = visitExp(exp, ns0)
+          NamedAst.Expr.Let(sym, exp1, acc, loc)
+
+        case (DesugaredAst.Binding.Stm(exp, loc), acc) =>
+          val exp1 = visitExp(exp, ns0)
+          NamedAst.Expr.Stm(exp1, acc, loc)
+
+        case (DesugaredAst.Binding.LocalDef(ident, fparams, exp, loc), acc) =>
+          val sym = Symbol.freshVarSym(ident, BoundBy.LocalDef)
+          val fps = fparams.map(visitFormalParam(_))
+          val exp1 = visitExp(exp, ns0)
+          NamedAst.Expr.LocalDef(sym, fps, exp1, acc, loc)
+
+      }
 
     case DesugaredAst.Expr.Region(tpe, loc) =>
       NamedAst.Expr.Region(tpe, loc)


### PR DESCRIPTION
Have flat lists of binders instead of nested singular binders

This seems pretty doable - one issue is that source locations get muddled between the different representations