### PR TITLE
fix: RecordExtend SourceLocations are wrong

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1588,7 +1588,10 @@ object Weeder2 {
       mapN(traverse(fields)(visitLiteralRecordField)) {
         fields =>
           fields.foldRight(Expr.RecordEmpty(tree.loc.asSynthetic): Expr) {
-            case ((label, expr, loc), acc) => Expr.RecordExtend(label, expr, acc, loc)
+            case ((label, expr, loc), acc) =>
+              val SourceLocation(isReal, sp1, _) = loc
+              val extendLoc = SourceLocation(isReal, sp1, tree.loc.sp2)
+              Expr.RecordExtend(label, expr, acc, extendLoc)
           }
       }
     }


### PR DESCRIPTION
This PR fixes an issue with RecordExtend SourceLocations. The issue is that their SourceLocations are directly copied from the field added. As an example for
```flix
{ x = 2, y = 3 }
```
the AST will be of the form `RecordExtend(x, 2, RecordExtend(y, 3, EmptyRecord))` (not correct AST node, just illustrates structure) where the outer RecordExtend's SourceLocation only covers `x = 2`, the inner only covers `y = 3` and the SourceLocation for the EmptyRecord covers the entire thing.

This is wrong, as the SourceLocation for each RecordExtend should completely contain the nested record, except perhaps for the EmptyRecord whose SourceLocation is synthetic. But perhaps there could be an argument that it should still be strictly within the SourceLocation of the RecordExtend that adds `y`.

This issue particularly affects the work being done at #9114 but should naturally be fixed either way.