### PR TITLE
feat: improve onSameLine to check overlap

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Position.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Position.scala
@@ -64,7 +64,12 @@ object Position {
   * @param line      Line position in a document (one-indexed).
   * @param character Character offset on a line in a document (one-indexed).
   */
-case class Position(line: Int, character: Int) {
+case class Position(line: Int, character: Int) extends Ordered[Position] {
   // NB: LSP line and column numbers are zero-indexed, but Flix uses one-indexed numbers internally.
   def toJSON: JValue = ("line" -> (line - 1)) ~ ("character" -> (character - 1))
+
+  def compare(that: Position): Int = {
+    val lineComparison = this.line.compare(that.line)
+    if (lineComparison != 0) lineComparison else this.character.compare(that.character)
+  }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/Range.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Range.scala
@@ -61,27 +61,21 @@ case class Range(start: Position, end: Position) {
   /**
     * Returns the range that starts earlier.
     */
-  private def earlierStart(other: Range): Range =
-    if (start < other.start)
-      this
-    else
-      other
+  private def earlierStart(that: Range): Range =
+     if (start < that.start) this else that
 
   /**
     * Returns the range that ends later.
     */
-  private def laterEnd(other: Range): Range =
-    if (end > other.end)
-      this
-    else
-      other
+  private def laterEnd(that: Range): Range =
+    if (end > that.end) this else that
 
   /**
     * Checks if this range overlaps with the other range.
     */
-  def overlapsWith(other: Range): Boolean = {
-    val fst = earlierStart(other)
-    val lst = laterEnd(other)
+  def overlapsWith(that: Range): Boolean = {
+    val fst = earlierStart(that)
+    val lst = laterEnd(that)
     fst == lst || fst.end > lst.start
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/Range.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Range.scala
@@ -57,4 +57,31 @@ object Range {
   */
 case class Range(start: Position, end: Position) {
   def toJSON: JValue = ("start" -> start.toJSON) ~ ("end" -> end.toJSON)
+
+  /**
+    * Returns the range that starts earlier.
+    */
+  private def earlierStart(other: Range): Range =
+    if (start < other.start)
+      this
+    else
+      other
+
+  /**
+    * Returns the range that ends later.
+    */
+  private def laterEnd(other: Range): Range =
+    if (end > other.end)
+      this
+    else
+      other
+
+  /**
+    * Checks if this range overlaps with the other range.
+    */
+  def overlapsWith(other: Range): Boolean = {
+    val fst = earlierStart(other)
+    val lst = laterEnd(other)
+    fst == lst || fst.end > lst.start
+  }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.api.lsp.provider
 
 import ca.uwaterloo.flix.api.lsp.{CodeAction, CodeActionKind, Position, Range, TextEdit, WorkspaceEdit}
 import ca.uwaterloo.flix.language.CompilationMessage
-import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
+import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, SourcePosition, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.ast.TypedAst.Root
 import ca.uwaterloo.flix.language.errors.{InstanceError, ResolutionError, TypeError}
 import ca.uwaterloo.flix.util.Similarity
@@ -371,6 +371,16 @@ object CodeActionProvider {
     * Returns `true` if the given `range` starts on the same line as the given source location `loc`.
     */
   // TODO: We should introduce a mechanism that checks if the given range *overlaps* with the given loc.
-  private def onSameLine(range: Range, loc: SourceLocation): Boolean = range.start.line == loc.beginLine
+  private def onSameLine(range: Range, loc: SourceLocation): Boolean = {
+    val range2 = sourceLocation2Range(loc)
+    range.overlapsWith(range2)
+  }
 
+  private def sourcePosition2Position(sourcePosition: SourcePosition): Position = {
+    Position(sourcePosition.line, sourcePosition.col)
+  }
+
+  private def sourceLocation2Range(sourceLocation: SourceLocation): Range = {
+    Range(sourcePosition2Position(sourceLocation.sp1), sourcePosition2Position(sourceLocation.sp2))
+  }
 }


### PR DESCRIPTION
Improve the check in `onSameLine` as suggested on #9125.

Some problems:
- should we change the name since it's not just checking if the ranges are on the same line?
- another conversion function from `SourceLocation` to `Range` is written, which is the same as the one in `MagicMatchCompleter`