### PR TITLE
refactor: clean up `Validation`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/unification/TraitEnvironment.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/TraitEnvironment.scala
@@ -41,7 +41,9 @@ object TraitEnvironment {
     } else {
       // Case 2: there is an instance matching tconstr and all of the instance's constraints are entailed by tconstrs0
       Validation.flatMapN(byInst(tconstr, traitEnv, eqEnv)) {
-        case tconstrs => Validation.sequenceX(tconstrs.map(entail(tconstrs0, _, traitEnv, eqEnv)))
+        case tconstrs =>
+          val tconstrErrors = Validation.sequence(tconstrs.map(entail(tconstrs0, _, traitEnv, eqEnv)))
+          Validation.mapN(tconstrErrors)(_ => ())
       }
     }
   }

--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -336,8 +336,9 @@ class Shell(bootstrap: Bootstrap, options: Options) {
   /**
     * Executes the given bootstrap function and prints any errors.
     */
-  private def execBootstrap[T](f: => Validation[T, BootstrapError])(implicit formatter: Formatter, out: PrintStream): Unit = {
-    f.errors.map(_.message(formatter)).foreach(out.println)
+  private def execBootstrap[T](f: => Validation[T, BootstrapError])(implicit formatter: Formatter, out: PrintStream): Unit = f match {
+    case Validation.Success(_) => ()
+    case Validation.Failure(errors) => errors.map(_.message(formatter)).foreach(out.println)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -29,7 +29,7 @@ sealed trait Validation[+T, +E] {
     */
   final def unsafeGet: T = this match {
     case Validation.Success(value) => value
-    case Validation.Failure(errors) => throw new RuntimeException(s"Attempt to retrieve value from Failure. The errors are: ${errors.toList.mkString(", ")}")
+    case Validation.Failure(errors) => throw new IllegalStateException(s"Validation is Failure(${errors.mkString(", ")}).")
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -432,8 +432,6 @@ object Validation {
     }
   }
 
-  // TODO: Everything below this line is deprecated.
-
   /**
     * Folds the given function `f` over all elements `xs`.
     *
@@ -441,9 +439,7 @@ object Validation {
     */
   def fold[In, Out, Error](xs: Iterable[In], zero: Out)(f: (Out, In) => Validation[Out, Error]): Validation[Out, Error] = {
     xs.foldLeft(Success(zero): Validation[Out, Error]) {
-      case (acc, a) => flatMapN(acc) {
-        case value => f(value, a)
-      }
+      case (acc, a) => flatMapN(acc)(f(_, a))
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -33,11 +33,6 @@ sealed trait Validation[+T, +E] {
   }
 
   /**
-    * Returns the errors in this [[Validation.Success]] or [[Validation.Failure]] object.
-    */
-  def errors: Chain[E]
-
-  /**
     * Returns `this` as a [[Result]].
     * Returns [[Result.Ok]] if and only if there are no errors.
     * Returns [[Result.Err]] otherwise.
@@ -348,7 +343,7 @@ object Validation {
   def flatMapN[T1, U, E](t1: Validation[T1, E])(f: T1 => Validation[U, E]): Validation[U, E] =
     t1 match {
       case Success(v1) => f(v1)
-      case _ => Failure(t1.errors)
+      case Failure(errors) => Failure(errors)
     }
 
   /**

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -101,13 +101,6 @@ object Validation {
   }
 
   /**
-    * Sequences the given list of validations `xs`, ignoring non-error results.
-    */
-  def sequenceX[T, E](xs: Iterable[Validation[T, E]]): Validation[Unit, E] = {
-    mapN(sequence(xs))(_ => ())
-  }
-
-  /**
     * Traverses `xs` applying the function `f` to each element.
     */
   def traverse[T, S, E](xs: Iterable[T])(f: T => Validation[S, E]): Validation[List[S], E] = fastTraverse(xs)(f)

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -428,9 +428,7 @@ object Validation {
     */
   def foldRight[T, U, E](xs: Seq[T])(zero: Validation[U, E])(f: (T, U) => Validation[U, E]): Validation[U, E] = {
     xs.foldRight(zero) {
-      case (a, acc) => flatMapN(acc) {
-        case v => f(a, v)
-      }
+      case (a, acc) => flatMapN(acc)(f(a, _))
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/util/Validation.scala
+++ b/main/src/ca/uwaterloo/flix/util/Validation.scala
@@ -42,7 +42,7 @@ sealed trait Validation[+T, +E] {
     * Returns [[Result.Ok]] if and only if there are no errors.
     * Returns [[Result.Err]] otherwise.
     */
-  def toResult: Result[T, Chain[E]] = this match {
+  final def toResult: Result[T, Chain[E]] = this match {
     case Validation.Success(t) => Result.Ok(t)
     case Validation.Failure(errors) => Result.Err(errors)
   }


### PR DESCRIPTION
- [x] Declare toResult as final
- [x] Refactor unsafeGet to throw IllegalStateException -- like in Result
- [x] Drop errors function (replace by pattern matching)
- [x] Drop sequenceX function (replace its one use by mapN/sequence).
- [x] Drop the TODO-- we will keep the fold
- [x] Fix IDEA warnings

Related to https://github.com/flix/flix/issues/9196