### PR TITLE
fix: source locations regarding tag expressions are wrong

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1519,30 +1519,30 @@ object Resolver {
     * Curry the tag, wrapping it in a lambda expression if it is not nullary.
     */
   private def visitTag(caze: NamedAst.Declaration.Case, loc: SourceLocation)(implicit scope: Scope, flix: Flix): ResolvedAst.Expr = {
-    val synth_loc = SourceLocation(isReal = false, loc.sp1, loc.sp2)
+    val synthLoc = SourceLocation(isReal = false, loc.sp1, loc.sp2)
     // Check if the tag value has Unit type.
     if (isUnitType(caze.tpe)) {
       // Case 1: The tag value has Unit type. Construct the Unit expression.
-      val e = ResolvedAst.Expr.Cst(Constant.Unit, synth_loc)
+      val e = ResolvedAst.Expr.Cst(Constant.Unit, synthLoc)
       ResolvedAst.Expr.Tag(CaseSymUse(caze.sym, loc), e, loc)
     } else {
       // Case 2: The tag has a non-Unit type. Hence the tag is used as a function.
       // If the tag is `Some` we construct the lambda: x -> Some(x).
 
       // Construct a fresh symbol for the formal parameter.
-      val freshVar = freshVarSym("x", BoundBy.FormalParam, synth_loc)
+      val freshVar = freshVarSym("x", BoundBy.FormalParam, synthLoc)
 
       // Construct the formal parameter for the fresh symbol.
-      val freshParam = ResolvedAst.FormalParam(freshVar, Modifiers.Empty, None, synth_loc)
+      val freshParam = ResolvedAst.FormalParam(freshVar, Modifiers.Empty, None, synthLoc)
 
       // Construct a variable expression for the fresh symbol.
-      val varExp = ResolvedAst.Expr.Var(freshVar, synth_loc)
+      val varExp = ResolvedAst.Expr.Var(freshVar, synthLoc)
 
       // Construct the tag expression on the fresh symbol expression.
       val tagExp = ResolvedAst.Expr.Tag(CaseSymUse(caze.sym, loc), varExp, loc)
 
       // Assemble the lambda expression (we know this must be pure).
-      mkPureLambda(freshParam, tagExp, allowSubeffecting = false, synth_loc)
+      mkPureLambda(freshParam, tagExp, allowSubeffecting = false, synthLoc)
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1744,9 +1744,9 @@ object Resolver {
         ResolvedAst.Expr.Tag(CaseSymUse(caze.sym, innerLoc), e, outerLoc)
       // Case 2: multiple expressions. Make them a tuple
       case es =>
-        val last_loc = es.last.loc
-        val tuple_loc = SourceLocation(last_loc.isReal, innerLoc.sp2, last_loc.sp2)
-        val exp = ResolvedAst.Expr.Tuple(es, tuple_loc)
+        val lastLoc = es.last.loc
+        val tupleLoc = SourceLocation(lastLoc.isReal, innerLoc.sp2, lastLoc.sp2)
+        val exp = ResolvedAst.Expr.Tuple(es, tupleLoc)
         ResolvedAst.Expr.Tag(CaseSymUse(caze.sym, innerLoc), exp, outerLoc)
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1743,7 +1743,9 @@ object Resolver {
         ResolvedAst.Expr.Tag(CaseSymUse(caze.sym, innerLoc), e, outerLoc)
       // Case 2: multiple expressions. Make them a tuple
       case es =>
-        val exp = ResolvedAst.Expr.Tuple(es, outerLoc)
+        val last_loc = es.last.loc
+        val tuple_loc = SourceLocation(last_loc.isReal, innerLoc.sp2, last_loc.sp2)
+        val exp = ResolvedAst.Expr.Tuple(es, tuple_loc)
         ResolvedAst.Expr.Tag(CaseSymUse(caze.sym, innerLoc), exp, outerLoc)
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1519,29 +1519,30 @@ object Resolver {
     * Curry the tag, wrapping it in a lambda expression if it is not nullary.
     */
   private def visitTag(caze: NamedAst.Declaration.Case, loc: SourceLocation)(implicit scope: Scope, flix: Flix): ResolvedAst.Expr = {
+    val synth_loc = SourceLocation(isReal = false, loc.sp1, loc.sp2)
     // Check if the tag value has Unit type.
     if (isUnitType(caze.tpe)) {
       // Case 1: The tag value has Unit type. Construct the Unit expression.
-      val e = ResolvedAst.Expr.Cst(Constant.Unit, loc)
+      val e = ResolvedAst.Expr.Cst(Constant.Unit, synth_loc)
       ResolvedAst.Expr.Tag(CaseSymUse(caze.sym, loc), e, loc)
     } else {
       // Case 2: The tag has a non-Unit type. Hence the tag is used as a function.
       // If the tag is `Some` we construct the lambda: x -> Some(x).
 
       // Construct a fresh symbol for the formal parameter.
-      val freshVar = freshVarSym("x", BoundBy.FormalParam, loc)
+      val freshVar = freshVarSym("x", BoundBy.FormalParam, synth_loc)
 
       // Construct the formal parameter for the fresh symbol.
-      val freshParam = ResolvedAst.FormalParam(freshVar, Modifiers.Empty, None, loc)
+      val freshParam = ResolvedAst.FormalParam(freshVar, Modifiers.Empty, None, synth_loc)
 
       // Construct a variable expression for the fresh symbol.
-      val varExp = ResolvedAst.Expr.Var(freshVar, loc)
+      val varExp = ResolvedAst.Expr.Var(freshVar, synth_loc)
 
       // Construct the tag expression on the fresh symbol expression.
       val tagExp = ResolvedAst.Expr.Tag(CaseSymUse(caze.sym, loc), varExp, loc)
 
       // Assemble the lambda expression (we know this must be pure).
-      mkPureLambda(freshParam, tagExp, allowSubeffecting = false, loc)
+      mkPureLambda(freshParam, tagExp, allowSubeffecting = false, synth_loc)
     }
   }
 


### PR DESCRIPTION
This PR fixes issues regarding the `SourceLocation`s associated tag expressions.

The first issue is that the `SourceLocation` for the tuple subexpressions (for 2+ arity cases) of tag expressions overlap with the `SourceLocation` of the `CaseSymUse` of the tag expressions.

The second issue might be up for debate, but I think it's an issue. The issue is that the location for all the AST nodes introduced by `visitTag` like the unit constant and the AST nodes introduced to wrap tags in lambdas for expressions like `let x = Enum.Case` have the `SourceLocation` of the tag expression itself. What location these should have is unclear, but they should at the very least be synthetic. So here I keep them the same but simply make them synthetic.

The first issue is particularly a problem for the work being done at #9114. The second issue has not come up yet, but I believe it will since a) there is no way for LSP visitor to tell these artificial AST nodes apart from real source code b) these locations completely overlap the "real" tag AST node. If the SourceLocations are synthetic, at least they can be filtered out.