### PR TITLE
fix: produce correct source position for number literals

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -176,8 +176,11 @@ object Lexer {
     if (c == '\n') {
       s.current.line -= 1
       s.current.column = 0
+      s.end.line -= 1
+      s.end.column = 0
     } else {
       s.current.column -= 1
+      s.end.column -= 1
     }
   }
 
@@ -962,13 +965,6 @@ object Lexer {
           case _ if isMatch("ff") => error.getOrElse(TokenKind.LiteralBigDecimal)
           case _ =>
             retreat()
-            if (peek() == ';') {
-              // Special case: the retreat functions does not rewind the `end` field
-              // in the state. However, if we encounter a ';' here the number ended
-              // before what the `end.column` state was set to so we manually update
-              // the `end` column.
-              s.end.column -= 1
-            }
             if (isDecimal) {
               error.getOrElse(TokenKind.LiteralFloat64)
             } else {

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -216,7 +216,7 @@ object Lexer {
 
   /**
     * Peeks the character that state is currently sitting on without advancing.
-    * Note: Peek does not to bound checks. This is done under the assumption that the lexer
+    * Note: Peek does not perform bound checks. This is done under the assumption that the lexer
     * is only ever advanced using `advance`.
     * Since `advance` cannot move past EOF peek will always be in bounds.
     */
@@ -962,6 +962,13 @@ object Lexer {
           case _ if isMatch("ff") => error.getOrElse(TokenKind.LiteralBigDecimal)
           case _ =>
             retreat()
+            if (peek() == ';') {
+              // Special case: the retreat functions does not rewind the `end` field
+              // in the state. However, if we encounter a ';' here the number ended
+              // before what the `end.column` state was set to so we manually update
+              // the `end` column.
+              s.end.column -= 1
+            }
             if (isDecimal) {
               error.getOrElse(TokenKind.LiteralFloat64)
             } else {


### PR DESCRIPTION
Tested this manually by hovering in VSCode. It works now (also for decimals which suffered from the same issue).

Closes https://github.com/flix/flix/issues/8798