### PR TITLE
feat: add mkNewStruct action to UndefinedStruct

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -44,6 +44,9 @@ object CodeActionProvider {
       else
         Nil
 
+    case ResolutionError.UndefinedStruct(qn,  loc) if overlaps(range, loc) =>
+        mkNewStruct(qn.ident.name, uri) :: Nil
+
     case ResolutionError.UndefinedJvmClass(name, ap, _, loc) if overlaps(range, loc) =>
       mkImportJava(name, uri, ap)
 
@@ -218,6 +221,7 @@ object CodeActionProvider {
            |enum $name {
            |
            |}
+           |
            |""".stripMargin
       )))
     )),
@@ -310,6 +314,7 @@ object CodeActionProvider {
            |struct $name[r] {
            |
            |}
+           |
            |""".stripMargin
       )))
     )),


### PR DESCRIPTION
fixes #9232
Preview:
<img width="604" alt="image" src="https://github.com/user-attachments/assets/8a998a32-1c20-432f-9355-5be3a5a0c79d">

<img width="626" alt="image" src="https://github.com/user-attachments/assets/29bdfc9b-5d05-4180-a75a-8419ab086b1c">

This is a simple code action. But we can extend `mkNewStruct` based on the information in the construction statement. We'll need to extend `UndefinedStruct` first.