### PR TITLE
feat: use AnchorPosition for some codeactions

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -191,11 +191,7 @@ object CodeActionProvider {
         CodeAction(
           title = s"use '$sym'",
           kind = CodeActionKind.QuickFix,
-          edit = Some(WorkspaceEdit(
-            Map(uri -> List(mkTextEdit(ap,
-              s"use $sym;"
-            )))
-          )),
+          edit = Some(WorkspaceEdit(Map(uri -> List(mkTextEdit(ap, s"use $sym;"))))),
           command = None
         )
     }.toList.sortBy(_.title)
@@ -275,11 +271,7 @@ object CodeActionProvider {
       CodeAction(
         title = s"import '$path'",
         kind = CodeActionKind.QuickFix,
-        edit = Some(WorkspaceEdit(
-          Map(uri -> List(mkTextEdit(ap,
-            s"import $path"
-          )))
-        )),
+        edit = Some(WorkspaceEdit(Map(uri -> List(mkTextEdit(ap, s"import $path"))))),
         command = None
       )
     }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -38,7 +38,7 @@ object CodeActionProvider {
   }
 
   private def getActionsFromErrors(uri: String, range: Range, errors: List[CompilationMessage])(implicit root: Root): List[CodeAction] = errors.flatMap {
-    case ResolutionError.UndefinedEffect(qn, _, loc) if overlaps(range, loc) =>
+    case ResolutionError.UndefinedEffect(qn, _,  _, loc) if overlaps(range, loc) =>
       if (qn.namespace.isRoot)
         mkUseEffect(qn.ident, uri)
       else
@@ -58,7 +58,7 @@ object CodeActionProvider {
           Nil
       }
 
-    case ResolutionError.UndefinedTrait(qn, _, loc) if overlaps(range, loc) =>
+    case ResolutionError.UndefinedTrait(qn, _,  _, loc) if overlaps(range, loc) =>
       if (qn.namespace.isRoot)
         mkUseTrait(qn.ident, uri)
       else

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -229,7 +229,8 @@ object CodeActionProvider {
         s"""
           |enum $name {
           |
-          |}""".stripMargin
+          |}
+          |""".stripMargin
       )))
     )),
     command = None
@@ -312,7 +313,8 @@ object CodeActionProvider {
         s"""
            |struct $name[r] {
            |
-           |}""".stripMargin
+           |}
+           |""".stripMargin
       )))
     )),
     command = None

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -41,8 +41,8 @@ object CodeActionProvider {
     case ResolutionError.UndefinedEffect(qn, ap,  _, loc) if overlaps(range, loc) =>
         mkUseEffect(qn.ident, uri, ap)
 
-    case ResolutionError.UndefinedStruct(qn,  loc) if overlaps(range, loc) =>
-        mkNewStruct(qn.ident.name, uri) :: Nil
+//    case ResolutionError.UndefinedStruct(qn,  loc) if overlaps(range, loc) =>
+//        mkNewStruct(qn.ident.name, uri) :: Nil
 
     case ResolutionError.UndefinedJvmClass(name, ap, _, loc) if overlaps(range, loc) =>
       mkImportJava(name, uri, ap)
@@ -54,14 +54,7 @@ object CodeActionProvider {
       mkUseTrait(qn.ident, uri, ap)
 
     case ResolutionError.UndefinedType(qn, ap, loc) if overlaps(range, loc) =>
-      mkNewEnum(qn.ident.name, uri, ap) :: mkNewStruct(qn.ident.name, uri, ap) :: mkUseType(qn.ident, uri, ap)
-    case ResolutionError.UndefinedType(qn, ap, loc) if overlaps(range, loc) =>
-      mkNewEnum(qn.ident.name, uri) :: mkNewStruct(qn.ident.name, uri) :: mkImportJava(qn.ident.name, uri, ap) ++ {
-        if (qn.namespace.isRoot)
-          mkUseType(qn.ident, uri)
-        else
-          Nil
-      }
+      mkNewEnum(qn.ident.name, uri, ap) :: mkNewStruct(qn.ident.name, uri, ap) :: mkUseType(qn.ident, uri, ap) ++ mkImportJava(qn.ident.name, uri, ap)
 
     case TypeError.MissingInstanceEq(tpe, _, loc) if overlaps(range, loc) =>
       mkDeriveMissingEq(tpe, uri)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -41,8 +41,8 @@ object CodeActionProvider {
     case ResolutionError.UndefinedEffect(qn, ap,  _, loc) if overlaps(range, loc) =>
         mkUseEffect(qn.ident, uri, ap)
 
-//    case ResolutionError.UndefinedStruct(qn,  loc) if overlaps(range, loc) =>
-//        mkNewStruct(qn.ident.name, uri) :: Nil
+    case ResolutionError.UndefinedStruct(qn, ap, loc) if overlaps(range, loc) =>
+        mkNewStruct(qn.ident.name, uri, ap) :: Nil
 
     case ResolutionError.UndefinedJvmClass(name, ap, _, loc) if overlaps(range, loc) =>
       mkImportJava(name, uri, ap)

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -539,7 +539,7 @@ object ResolutionError {
     * @param ns  the current namespace.
     * @param loc the location where the error occurred.
     */
-  case class UndefinedTrait(qn: Name.QName, ns: Name.NName, loc: SourceLocation) extends ResolutionError {
+  case class UndefinedTrait(qn: Name.QName, ap: AnchorPosition, ns: Name.NName, loc: SourceLocation) extends ResolutionError {
     def summary: String = s"Undefined class: '${qn.toString}'."
 
     def message(formatter: Formatter): String = {
@@ -558,6 +558,10 @@ object ResolutionError {
 
   }
 
+  object UndefinedTrait {
+    def apply(qn: Name.QName, ns: Name.NName, loc: SourceLocation): UndefinedTrait = UndefinedTrait(qn, AnchorPosition.mkImportOrUseAnchor(ns), ns, loc)
+  }
+
   /**
     * Undefined Effect Error.
     *
@@ -565,7 +569,7 @@ object ResolutionError {
     * @param ns  the current namespace.
     * @param loc the location where the error occurred.
     */
-  case class UndefinedEffect(qn: Name.QName, ns: Name.NName, loc: SourceLocation) extends ResolutionError {
+  case class UndefinedEffect(qn: Name.QName, ap: AnchorPosition, ns: Name.NName, loc: SourceLocation) extends ResolutionError {
     def summary: String = s"Undefined effect '${qn.toString}'."
 
     def message(formatter: Formatter): String = {
@@ -582,6 +586,10 @@ object ResolutionError {
       s"${underline("Tip:")} Possible typo or non-existent effect?"
     })
 
+  }
+
+  object UndefinedEffect {
+    def apply(qn: Name.QName, ns: Name.NName, loc: SourceLocation): UndefinedEffect = UndefinedEffect(qn, AnchorPosition.mkImportOrUseAnchor(ns), ns, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -953,7 +953,7 @@ object ResolutionError {
     * @param name the name of the undefined struct.
     * @param loc  the location where the error occurred.
     */
-  case class UndefinedStruct(name: Name.QName, loc: SourceLocation) extends ResolutionError {
+  case class UndefinedStruct(name: Name.QName, ap: AnchorPosition, loc: SourceLocation) extends ResolutionError {
     override def summary: String = s"Undefined struct"
 
     def message(formatter: Formatter): String = {

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -558,10 +558,6 @@ object ResolutionError {
 
   }
 
-  object UndefinedTrait {
-    def apply(qn: Name.QName, ns: Name.NName, loc: SourceLocation): UndefinedTrait = UndefinedTrait(qn, AnchorPosition.mkImportOrUseAnchor(ns), ns, loc)
-  }
-
   /**
     * Undefined Effect Error.
     *
@@ -586,10 +582,6 @@ object ResolutionError {
       s"${underline("Tip:")} Possible typo or non-existent effect?"
     })
 
-  }
-
-  object UndefinedEffect {
-    def apply(qn: Name.QName, ns: Name.NName, loc: SourceLocation): UndefinedEffect = UndefinedEffect(qn, AnchorPosition.mkImportOrUseAnchor(ns), ns, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2311,7 +2311,7 @@ object Resolver {
     }
     matches match {
       // Case 0: No matches. Error.
-      case Nil => Result.Err(ResolutionError.UndefinedStruct(qname, qname.loc))
+      case Nil => Result.Err(ResolutionError.UndefinedStruct(qname, AnchorPosition.mkImportOrUseAnchor(ns0), qname.loc))
       // Case 1: A match was found. Success. Note that multiple matches can be found but they are prioritized by tryLookupName so this is fine.
       case st :: _ => Result.Ok(st)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2186,7 +2186,7 @@ object Resolver {
             Validation.Success(trt)
         }
       case None =>
-        Validation.Failure(ResolutionError.UndefinedTrait(qname, ns0, qname.loc))
+        Validation.Failure(ResolutionError.UndefinedTrait(qname, AnchorPosition.mkImportOrUseAnchor(ns0), ns0, qname.loc))
     }
   }
 
@@ -2209,7 +2209,7 @@ object Resolver {
             Some(trt)
         }
       case None =>
-        val error = ResolutionError.UndefinedTrait(qname, ns0, qname.loc)
+        val error = ResolutionError.UndefinedTrait(qname, AnchorPosition.mkImportOrUseAnchor(ns0), ns0, qname.loc)
         sctx.errors.add(error)
         None
     }
@@ -2881,7 +2881,7 @@ object Resolver {
     }
 
     effOpt match {
-      case None => Result.Err(ResolutionError.UndefinedEffect(qname, ns0, qname.loc))
+      case None => Result.Err(ResolutionError.UndefinedEffect(qname, AnchorPosition.mkImportOrUseAnchor(ns0), ns0, qname.loc))
       case Some(decl) => Result.Ok(decl)
     }
   }


### PR DESCRIPTION
fixes #9233
Preview:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/ccbc828d-ff2a-4307-ace9-d6a13f189de5">
<img width="357" alt="image" src="https://github.com/user-attachments/assets/e01de7f3-9130-41c1-a407-f13fa51f7633">

There is still one code action that is under the `isRoot` check, which is `mkFixMisspelling`, is this still necessary?