### PR TITLE
fix: Algebraic effects in REPL expressions

### DIFF
--- a/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
+++ b/main/src/ca/uwaterloo/flix/runtime/shell/Shell.scala
@@ -308,10 +308,13 @@ class Shell(bootstrap: Bootstrap, options: Options) {
         // The name of the generated main function.
         val main = Symbol.mkDefnSym("shell1")
 
-        // Cast the println to allow escaping effects
+        val effString = Symbol.PrimitiveEffs.map(_.toString).mkString(" + ")
+        // Cast to allow any subset of the primitive effects
         val src =
-          s"""def ${main.name}(): Unit \\ IO =
-             |unchecked_cast(println($s) as _ \\ IO)
+          s"""def ${main.name}(): Unit \\ $effString =
+             |checked_ecast(
+             |  println($s)
+             |)
              |""".stripMargin
         flix.addSourceCode("<shell>", src)(SecurityContext.AllPermissions)
         run(main)

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -18,6 +18,15 @@ pub enum Proxy[_] {
 }
 
 ///
+/// The uninterpretable `Env` effect.
+///
+/// The `Env` effect represents ..
+///
+/// The `Env` effect is uninterpretable which means that it cannot be handled.
+///
+pub eff Env
+
+///
 /// The uninterpretable `Exec` effect.
 ///
 /// The `Exec` effect represents the actions required to start (i.e. run) a new process outside the JVM.

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -20,7 +20,8 @@ pub enum Proxy[_] {
 ///
 /// The uninterpretable `Env` effect.
 ///
-/// The `Env` effect represents ..
+/// The `Env` effect represents actions that read from the environment (e.g. information
+/// about the shell, operating system, or hardware)
 ///
 /// The `Env` effect is uninterpretable which means that it cannot be handled.
 ///


### PR DESCRIPTION
Fixes #8601

This PR correctly checks for algebraic effects, but also disallows any non-primitive effect. I think this is okay, because how would you even use regions in the repl?

@magnus-madsen Env is missing in Prelude - do you have a documentation comment in mind that I can insert?