### PR TITLE
refactor: clean up safety

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -41,6 +41,7 @@ jobs:
       matrix:
         repo:
           - "JonathanStarup/Flix-ANSI-Terminal"
+          - "JonathanStarup/ListSet"
           - "flix/museum"
           - "jaschdoc/flix-parsers"
           - "mlutze/flix-json"

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -572,31 +572,30 @@ object SafetyError {
   }
 
   /**
-    * An error raised to indicate that an object derivation includes a method that doesn't exist in the superclass being implemented.
+    * An error raised to indicate that an object derivation includes a method that doesn't exist
+    * in the superclass being implemented.
     *
     * @param clazz The type of superclass
-    * @param name  The name of the extra method.
+    * @param name  The name of the undefined method.
     * @param loc   The source location of the method.
     */
-  case class NewObjectUnreachableMethod(clazz: java.lang.Class[?], name: String, loc: SourceLocation) extends SafetyError {
-    def summary: String = s"Method '$name' not found in superclass '${clazz.getName}'"
+  case class NewObjectUndefinedMethod(clazz: java.lang.Class[?], name: String, loc: SourceLocation) extends SafetyError {
+    def summary: String = s"Method '$name' not found in superclass '${clazz.getName}' with the written signature"
 
     def message(formatter: Formatter): String = {
       import formatter.*
-      s""">> Method '${red(name)}' not found in superclass '${red(clazz.getName)}'
+      s""">> Method '${red(name)}' not found in superclass '${red(clazz.getName)}' with the written signature
          |
          |${code(loc, "the method occurs here.")}
          |""".stripMargin
     }
   }
 
-  /**
-    * Format a Java type suitable for method implementation.
-    */
+  /** Format a Java type suitable for method implementation. */
   private def formatJavaType(t: java.lang.Class[?]): String = {
     if (t.isPrimitive || t.isArray)
       Type.getFlixType(t).toString
     else
-      s"##${t.getName}"
+      t.getName
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -7,9 +7,7 @@ import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol, Type}
 import ca.uwaterloo.flix.language.fmt.FormatType
 import ca.uwaterloo.flix.util.Formatter
 
-/**
-  * A common super-type for safety errors.
-  */
+/** A common super-type for safety errors. */
 sealed trait SafetyError extends CompilationMessage {
   val kind: String = "Safety Error"
 }
@@ -53,8 +51,6 @@ object SafetyError {
          |To  : ${FormatType.formatType(to, None)}
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -77,8 +73,6 @@ object SafetyError {
          |To  : ${formatJavaType(to)}
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -101,8 +95,6 @@ object SafetyError {
          |To  : ${FormatType.formatType(to, None)}
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -125,8 +117,6 @@ object SafetyError {
          |To  : ${FormatType.formatType(to, None)}
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -149,8 +139,6 @@ object SafetyError {
          |To  : ${FormatType.formatType(to, None)}
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -338,9 +326,6 @@ object SafetyError {
          |""".stripMargin
     }
 
-    /**
-      * Returns a formatted string with helpful suggestions.
-      */
     override def explain(formatter: Formatter): Option[String] = Some({
       s"""A lattice variable cannot be used as relational variable unless the atom
          |from which it originates is marked with `fix`.
@@ -349,9 +334,9 @@ object SafetyError {
   }
 
   /**
-    * Unable to derive Sendable error
+    * Unable to derive Sendable error.
     *
-    * @param tpe the type that is not sendable.
+    * @param tpe the type that is not Sendable.
     * @param loc the location where the error occurred.
     */
   case class IllegalSendableInstance(tpe: Type, loc: SourceLocation) extends SafetyError {
@@ -397,8 +382,6 @@ object SafetyError {
          |To  : ${FormatType.formatType(to, None)}
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -446,8 +429,6 @@ object SafetyError {
          |${code(loc, s"attempted to handle the ${sym.name} effect here.")}
          |""".stripMargin
     }
-
-    override def explain(formatter: Formatter): Option[String] = None
   }
 
   /**
@@ -591,11 +572,11 @@ object SafetyError {
     }
   }
 
-  /** Format a Java type suitable for method implementation. */
-  private def formatJavaType(t: java.lang.Class[?]): String = {
-    if (t.isPrimitive || t.isArray)
-      Type.getFlixType(t).toString
+  /** Returns the string representation of `tpe`. */
+  private def formatJavaType(tpe: java.lang.Class[?]): String = {
+    if (tpe.isPrimitive || tpe.isArray)
+      Type.getFlixType(tpe).toString
     else
-      t.getName
+      tpe.getName
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -1,59 +1,48 @@
 package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.Body
 import ca.uwaterloo.flix.language.ast.TypedAst.*
+import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.Body
 import ca.uwaterloo.flix.language.ast.ops.TypedAstOps
 import ca.uwaterloo.flix.language.ast.ops.TypedAstOps.*
-import ca.uwaterloo.flix.language.ast.shared.{CheckedCastType, Denotation, Fixity, Polarity, Scope, SecurityContext}
-import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.shared.*
+import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.SafetyError
 import ca.uwaterloo.flix.language.errors.SafetyError.*
-import ca.uwaterloo.flix.util.{JvmUtils, ParOps, Validation}
+import ca.uwaterloo.flix.util.{JvmUtils, ParOps}
 
 import java.math.BigInteger
 import scala.annotation.tailrec
 
 /**
-  * Performs safety and well-formedness checks on:
-  *
+  * Checks the safety and well-formedness of:
   *   - Datalog constraints.
   *   - New object expressions.
   *   - CheckedCast expressions.
   *   - UncheckedCast expressions.
   *   - TypeMatch expressions.
-  *   - Throw expressions
+  *   - Throw expressions.
   */
 object Safety {
 
-  /**
-    * Performs safety and well-formedness checks on the given AST `root`.
-    */
+  /** Checks the safety and well-formedness of `root`. */
   def run(root: Root)(implicit flix: Flix): (Root, List[SafetyError]) = flix.phaseNew("Safety") {
-    //
-    // Collect all errors.
-    //
     val classSigErrs = ParOps.parMap(root.traits.values.flatMap(_.sigs))(visitSig).flatten
     val defErrs = ParOps.parMap(root.defs.values)(visitDef).flatten
     val instanceDefErrs = ParOps.parMap(TypedAstOps.instanceDefsOf(root))(visitDef).flatten
     val sigErrs = ParOps.parMap(root.sigs.values)(visitSig).flatten
-    val errors = classSigErrs ++ defErrs ++ instanceDefErrs ++ sigErrs ++ visitSendable(root)
+    val errors = classSigErrs ++ defErrs ++ instanceDefErrs ++ sigErrs ++ checkSendableInstances(root)
 
-    //
-    // Check if any errors were found.
-    //
     (root, errors.toList)
   }
 
-  /**
-    * Checks that no type parameters for types that implement `Sendable` of kind `Region`
-    */
-  private def visitSendable(root: Root): List[SafetyError] = {
+  /** Checks that no type parameters for types that implement `Sendable` are of kind [[Kind.Eff]]. */
+  private def checkSendableInstances(root: Root): List[SafetyError] = {
     val sendableClass = new Symbol.TraitSym(Nil, "Sendable", SourceLocation.Unknown)
 
-    root.instances.getOrElse(sendableClass, Nil) flatMap {
-      case Instance(_, _, _, _, tpe, _, _, _, _, loc) =>
+    root.instances.getOrElse(sendableClass, Nil).flatMap {
+      case TypedAst.Instance(_, _, _, _, tpe, _, _, _, _, loc) =>
         if (tpe.typeArguments.exists(_.kind == Kind.Eff))
           List(SafetyError.IllegalSendableInstance(tpe, loc))
         else
@@ -61,579 +50,422 @@ object Safety {
     }
   }
 
-  /**
-    * Performs safety and well-formedness checks on the given signature `sig`.
-    */
+  /** Checks the safety and well-formedness of `sig`. */
   private def visitSig(sig: Sig)(implicit flix: Flix): List[SafetyError] = {
-    val renv = sig.spec.tparams.map(_.sym).foldLeft(RigidityEnv.empty) {
-      case (acc, e) => acc.markRigid(e)
-    }
-    sig.exp match {
-      case Some(exp) => visitExp(exp, renv)(inTryCatch = false, flix)
-      case None => Nil
-    }
+    val renv = RigidityEnv.ofRigidVars(sig.spec.tparams.map(_.sym))
+    sig.exp.map(visitExp(_)(inTryCatch = false, renv, flix)).getOrElse(Nil)
+  }
+
+  /** Checks the safety and well-formedness of `defn`. */
+  private def visitDef(defn: Def)(implicit flix: Flix): List[SafetyError] = {
+    val renv = RigidityEnv.ofRigidVars(defn.spec.tparams.map(_.sym))
+    visitExp(defn.exp)(inTryCatch = false, renv, flix)
   }
 
   /**
-    * Performs safety and well-formedness checks on the given definition `def0`.
-    */
-  private def visitDef(def0: Def)(implicit flix: Flix): List[SafetyError] = {
-    val renv = def0.spec.tparams.map(_.sym).foldLeft(RigidityEnv.empty) {
-      case (acc, e) => acc.markRigid(e)
-    }
-    visitExp(def0.exp, renv)(inTryCatch = false, flix)
-  }
-
-  /**
-    * Returns `true` if the given `defn` has a single `Unit` parameter.
-    */
-  private def hasUnitParameter(defn: Def): Boolean = {
-    defn.spec.fparams match {
-      case fparam :: Nil =>
-        // Case 1: A single parameter. Must be Unit.
-        fparam.tpe.typeConstructor.contains(TypeConstructor.Unit)
-      case _ =>
-        // Case 2: Multiple parameters.
-        false
-    }
-  }
-
-  /**
-    * Returns `true` if the given `tpe` is supported in exported signatures.
+    * Checks tje safety and well-formedness of `exp0`.
     *
-    * Currently this is only types that are immune to erasure, i.e. the
-    * primitive java types and Object.
+    * The checks are:
+    *   - Nested [[Expr.TryCatch]] expressions are disallowed unless the inner [[Expr.TryCatch]]
+    *     will be extracted (e.g. Lambda).
+    *   - [[Expr.TypeMatch]] must end with a default case.
     *
-    * Note that signatures should be exportable as-is, this means that even
-    * though the signature contains `MyAlias[Bool]` where
-    * `type alias MyAlias[t] = t`, it uses flix-specific type information which
-    * is not allowed.
+    *
+    * @param inTryCatch indicates whether `exp` is enclosed in a try-catch. This can be reset if the
+    *                   expression will later be extracted to its own function (e.g [[Expr.Lambda]]).
     */
-  private def isExportableType(tpe: Type): Boolean = tpe.typeConstructor match {
-    case None => false
-    case Some(cst) => cst match {
-      case TypeConstructor.Bool => true
-      case TypeConstructor.Char => true
-      case TypeConstructor.Float32 => true
-      case TypeConstructor.Float64 => true
-      case TypeConstructor.Int8 => true
-      case TypeConstructor.Int16 => true
-      case TypeConstructor.Int32 => true
-      case TypeConstructor.Int64 => true
-      case TypeConstructor.Native(clazz) if clazz == classOf[Object] => true
-      // Error is accepted to avoid cascading errors
-      case TypeConstructor.Error(_, _) => true
-      case _ => false
-    }
-  }
-
-  /**
-    * Returns `true` if given `defn` has a name that is directly valid in Java.
-    */
-  private def validJavaName(sym: Symbol.DefnSym): Boolean = {
-    sym.name.matches("[a-z][a-zA-Z0-9]*")
-  }
-
-  /**
-    * Returns `true` if the given `defn` is pure or has an effect that is allowed for a top-level function.
-    */
-  private def isAllowedEffect(defn: Def): Boolean = {
-    defn.spec.eff.effects.forall {
-      case Symbol.Env => true
-      case Symbol.Exec => true
-      case Symbol.FsRead => true
-      case Symbol.FsWrite => true
-      case Symbol.IO => true
-      case Symbol.Net => true
-      case Symbol.NonDet => true
-      case Symbol.Sys => true
-      case _ => false
-    }
-  }
-
-  /**
-    * Performs safety and well-formedness checks on the given expression `exp0`.
-    */
-  private def visitExp(e0: Expr, renv: RigidityEnv)(implicit inTryCatch: Boolean, flix: Flix): List[SafetyError] = {
-
-    // Nested try-catch generates wrong code in the backend, so it is disallowed.
-    def visit(exp0: Expr)(implicit inTryCatch: Boolean): List[SafetyError] = exp0 match {
-      case Expr.Cst(_, _, _) => Nil
-
-      case Expr.Var(_, _, _) => Nil
-
-      case Expr.Hole(_, _, _, _) => Nil
-
-      case Expr.HoleWithExp(exp, _, _, _) =>
-        visit(exp)
-
-      case Expr.OpenAs(_, exp, _, _) =>
-        visit(exp)
-
-      case Expr.Use(_, _, exp, _) =>
-        visit(exp)
-
-      case Expr.Lambda(_, exp, _, _) =>
-        // The inside expression will be its own function, so inTryCatch is reset
-        visit(exp)(inTryCatch = false)
-
-      case Expr.ApplyClo(exp, exps, _, _, _) =>
-        visit(exp) ++ exps.flatMap(visit)
-
-      case Expr.ApplyDef(_, exps, _, _, _, _) =>
-        exps.flatMap(visit)
-
-      case Expr.ApplyLocalDef(_, exps, _, _, _, _) =>
-        exps.flatMap(visit)
-
-      case Expr.ApplySig(_, exps, _, _, _, _) =>
-        exps.flatMap(visit)
-
-      case Expr.Unary(_, exp, _, _, _) =>
-        visit(exp)
-
-      case Expr.Binary(_, exp1, exp2, _, _, _) =>
-        visit(exp1) ++ visit(exp2)
-
-      case Expr.Let(_, exp1, exp2, _, _, _) =>
-        visit(exp1) ++ visit(exp2)
+  private def visitExp(exp0: Expr)(implicit inTryCatch: Boolean, renv: RigidityEnv, flix: Flix): List[SafetyError] = exp0 match {
+    case Expr.Cst(_, _, _) =>
+      Nil
 
-      case Expr.LocalDef(_, _, exp1, exp2, _, _, _) =>
-        // The inside expression will be its own function, so inTryCatch is reset
-        visit(exp1)(inTryCatch = false) ++ visit(exp2)
-
-      case Expr.Region(_, _) =>
-        Nil
-
-      case Expr.Scope(_, _, exp, _, _, _) =>
-        visit(exp)
-
-      case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) =>
-        visit(exp1) ++ visit(exp2) ++ visit(exp3)
+    case Expr.Var(_, _, _) =>
+      Nil
 
-      case Expr.Stm(exp1, exp2, _, _, _) =>
-        visit(exp1) ++ visit(exp2)
+    case Expr.Hole(_, _, _, _) =>
+      Nil
 
-      case Expr.Discard(exp, _, _) =>
-        visit(exp)
+    case Expr.HoleWithExp(exp, _, _, _) =>
+      visitExp(exp)
 
-      case Expr.Match(exp, rules, _, _, _) =>
-        visit(exp) ++
-          rules.flatMap { case MatchRule(_, g, e) => g.toList.flatMap(visit) ++ visit(e) }
+    case Expr.OpenAs(_, exp, _, _) =>
+      visitExp(exp)
 
-      case Expr.TypeMatch(exp, rules, _, _, _) =>
-        // check whether the last case in the type match looks like `...: _`
-        val missingDefault = rules.last match {
-          case TypeMatchRule(_, tpe, _) => tpe match {
-            // use top scope since the rigidity check only cares if it's a syntactically known variable
-            case Type.Var(sym, _) if renv.isFlexible(sym)(Scope.Top) => Nil
-            case _ => List(SafetyError.MissingDefaultTypeMatchCase(exp.loc))
-          }
-        }
-        visit(exp) ++ missingDefault ++
-          rules.flatMap { case TypeMatchRule(_, _, e) => visit(e) }
+    case Expr.Use(_, _, exp, _) =>
+      visitExp(exp)
 
-      case Expr.RestrictableChoose(_, exp, rules, _, _, _) =>
-        visit(exp) ++
-          rules.flatMap { case RestrictableChooseRule(_, exp) => visit(exp) }
+    case Expr.Lambda(_, exp, _, _) =>
+      // `exp` will be in its own function, so `inTryCatch` is reset.
+      visitExp(exp)(inTryCatch = false, renv, flix)
 
-      case Expr.Tag(_, exp, _, _, _) =>
-        visit(exp)
+    case Expr.ApplyClo(exp, exps, _, _, _) =>
+      visitExp(exp) ++ exps.flatMap(visitExp)
 
-      case Expr.RestrictableTag(_, exp, _, _, _) =>
-        visit(exp)
+    case Expr.ApplyDef(_, exps, _, _, _, _) =>
+      exps.flatMap(visitExp)
 
-      case Expr.Tuple(elms, _, _, _) =>
-        elms.flatMap(visit)
+    case Expr.ApplyLocalDef(_, exps, _, _, _, _) =>
+      exps.flatMap(visitExp)
 
-      case Expr.RecordEmpty(_, _) => Nil
+    case Expr.ApplySig(_, exps, _, _, _, _) =>
+      exps.flatMap(visitExp)
 
-      case Expr.RecordSelect(exp, _, _, _, _) =>
-        visit(exp)
-
-      case Expr.RecordExtend(_, value, rest, _, _, _) =>
-        visit(value) ++ visit(rest)
+    case Expr.Unary(_, exp, _, _, _) =>
+      visitExp(exp)
 
-      case Expr.RecordRestrict(_, rest, _, _, _) =>
-        visit(rest)
-
-      case Expr.ArrayLit(elms, exp, _, _, _) =>
-        elms.flatMap(visit) ++ visit(exp)
-
-      case Expr.ArrayNew(exp1, exp2, exp3, _, _, _) =>
-        visit(exp1) ++ visit(exp2) ++ visit(exp3)
-
-      case Expr.ArrayLoad(base, index, _, _, _) =>
-        visit(base) ++ visit(index)
-
-      case Expr.ArrayLength(base, _, _) =>
-        visit(base)
-
-      case Expr.ArrayStore(base, index, elm, _, _) =>
-        visit(base) ++ visit(index) ++ visit(elm)
-
-      case Expr.StructNew(_, fields, region, _, _, _) =>
-        fields.map { case (_, v) => v }.flatMap(visit) ++ visit(region)
-
-      case Expr.StructGet(e, _, _, _, _) =>
-        visit(e)
-
-      case Expr.StructPut(e1, _, e2, _, _, _) =>
-        visit(e1) ++ visit(e2)
-
-      case Expr.VectorLit(elms, _, _, _) =>
-        elms.flatMap(visit)
-
-      case Expr.VectorLoad(exp1, exp2, _, _, _) =>
-        visit(exp1) ++ visit(exp2)
-
-      case Expr.VectorLength(exp, _) =>
-        visit(exp)
-
-      case Expr.Ascribe(exp, _, _, _) =>
-        visit(exp)
-
-      case Expr.InstanceOf(exp, _, _) =>
-        visit(exp)
-
-      case Expr.CheckedCast(cast, exp, tpe, _, loc) =>
-        cast match {
-          case CheckedCastType.TypeCast =>
-            val from = Type.eraseAliases(exp.tpe)
-            val to = Type.eraseAliases(tpe)
-            val errors = verifyCheckedTypeCast(from, to, loc)
-            visit(exp) ++ errors
-
-          case CheckedCastType.EffectCast =>
-            visit(exp)
-        }
-
-      case e@Expr.UncheckedCast(exp, _, _, _, _, loc) =>
-        val errors = verifyUncheckedCast(e)
-        val res = visit(exp) ++ errors
-
-        val ctx = loc.security
-        if (ctx == SecurityContext.AllPermissions) {
-          // Permitted
-          res
-        } else {
-          // Forbidden
-          SafetyError.Forbidden(ctx, loc) :: res
-        }
-
-      case Expr.UncheckedMaskingCast(exp, _, _, loc) =>
-        val res = visit(exp)
-
-        val ctx = loc.security
-        if (ctx == SecurityContext.AllPermissions) {
-          // Allowed...
-          res
-        } else {
-          // Extra Forbidden!!
-          SafetyError.Forbidden(ctx, loc) :: res
-        }
-
-      case Expr.Without(exp, _, _, _, _) =>
-        visit(exp)
-
-      case Expr.TryCatch(exp, rules, _, _, loc) =>
-        val nestedTryCatchError = if (inTryCatch) List(IllegalNestedTryCatch(loc)) else Nil
-        nestedTryCatchError ++ visit(exp)(inTryCatch = true) ++
-          rules.flatMap { case CatchRule(bnd, clazz, e) => checkCatchClass(clazz, bnd.sym.loc) ++ visit(e) }
-
-      case Expr.Throw(exp, _, _, loc) =>
-        val res = visit(exp) ++ checkThrow(exp)
-
-        val ctx = loc.security
-        if (ctx == SecurityContext.AllPermissions) {
-          // Permitted
-          res
-        } else {
-          // Forbidden
-          SafetyError.Forbidden(ctx, loc) :: res
-        }
-
-      case Expr.TryWith(exp, effUse, rules, _, _, _) =>
-        val res = visit(exp) ++
-          rules.flatMap { case HandlerRule(_, _, e) => visit(e) }
-
-        if (Symbol.isPrimitiveEff(effUse.sym)) {
-          PrimitiveEffectInTryWith(effUse.sym, effUse.loc) :: res
-        } else {
-          res
-        }
-
-      case Expr.Do(_, exps, _, _, _) =>
-        exps.flatMap(visit)
-
-      case Expr.InvokeConstructor(_, args, _, _, loc) =>
-        val res = args.flatMap(visit)
-
-        val ctx = loc.security
-        if (ctx == SecurityContext.AllPermissions) {
-          // Permitted
-          res
-        } else {
-          // Forbidden
-          SafetyError.Forbidden(ctx, loc) :: res
-        }
-
-      case Expr.InvokeMethod(_, exp, args, _, _, loc) =>
-        val res = visit(exp) ++ args.flatMap(visit)
-
-        val ctx = loc.security
-        if (ctx == SecurityContext.AllPermissions) {
-          res
-        } else {
-          SafetyError.Forbidden(ctx, loc) :: res
-        }
-
-      case Expr.InvokeStaticMethod(_, args, _, _, loc) =>
-        val res = args.flatMap(visit)
-
-        val ctx = loc.security
-        if (ctx == SecurityContext.AllPermissions) {
-          res
-        } else {
-          SafetyError.Forbidden(ctx, loc) :: res
-        }
-
-      case Expr.GetField(_, exp, _, _, loc) =>
-        val res = visit(exp)
-
-        val ctx = loc.security
-        if (ctx == SecurityContext.AllPermissions) {
-          res
-        } else {
-          SafetyError.Forbidden(ctx, loc) :: res
-        }
-
-      case Expr.PutField(_, exp1, exp2, _, _, loc) =>
-        val res = visit(exp1) ++ visit(exp2)
-
-        val ctx = loc.security
-        if (ctx == SecurityContext.AllPermissions) {
-          res
-        } else {
-          SafetyError.Forbidden(ctx, loc) :: res
-        }
-
-      case Expr.GetStaticField(_, _, _, loc) =>
-        val ctx = loc.security
-        if (ctx == SecurityContext.AllPermissions) {
+    case Expr.Binary(_, exp1, exp2, _, _, _) =>
+      visitExp(exp1) ++ visitExp(exp2)
+
+    case Expr.Let(_, exp1, exp2, _, _, _) =>
+      visitExp(exp1) ++ visitExp(exp2)
+
+    case Expr.LocalDef(_, _, exp1, exp2, _, _, _) =>
+      // `exp1` will be its own function, so `inTryCatch` is reset.
+      visitExp(exp1)(inTryCatch = false, renv, flix) ++ visitExp(exp2)
+
+    case Expr.Region(_, _) =>
+      Nil
+
+    case Expr.Scope(_, _, exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) =>
+      visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
+
+    case Expr.Stm(exp1, exp2, _, _, _) =>
+      visitExp(exp1) ++ visitExp(exp2)
+
+    case Expr.Discard(exp, _, _) =>
+      visitExp(exp)
+
+    case Expr.Match(exp, rules, _, _, _) =>
+      visitExp(exp) ++ rules.flatMap(rule => rule.guard.map(visitExp).getOrElse(Nil) ++ visitExp(rule.exp))
+
+    case Expr.TypeMatch(exp, rules, _, _, _) =>
+      // check whether the last case in the type match looks like `..: _`
+      val missingDefault = rules.lastOption match {
+        // Use top scope since the rigidity check only cares if it's a syntactically known variable
+        case Some(TypeMatchRule(_, Type.Var(sym, _), _)) if renv.isFlexible(sym)(Scope.Top) =>
           Nil
-        } else {
-          SafetyError.Forbidden(ctx, loc) :: Nil
-        }
+        case Some(_) | None =>
+          List(SafetyError.MissingDefaultTypeMatchCase(exp.loc))
+      }
+      visitExp(exp) ++ missingDefault ++ rules.flatMap(rule => visitExp(rule.exp))
 
-      case Expr.PutStaticField(_, exp, _, _, loc) =>
-        val res = visit(exp)
+    case Expr.RestrictableChoose(_, exp, rules, _, _, _) =>
+      visitExp(exp) ++ rules.flatMap(rule => visitExp(rule.exp))
 
-        val ctx = loc.security
-        if (ctx == SecurityContext.AllPermissions) {
-          res
-        } else {
-          SafetyError.Forbidden(ctx, loc) :: res
-        }
+    case Expr.Tag(_, exp, _, _, _) =>
+      visitExp(exp)
 
-      case Expr.NewObject(_, clazz, tpe, _, methods, loc) =>
-        val erasedType = Type.eraseAliases(tpe)
-        val res =
-          checkObjectImplementation(clazz, erasedType, methods, loc) ++
-            methods.flatMap {
-              case JvmMethod(_, _, exp, _, _, _) => visit(exp)
-            }
+    case Expr.RestrictableTag(_, exp, _, _, _) =>
+      visitExp(exp)
 
-        val ctx = loc.security
-        if (ctx == SecurityContext.AllPermissions) {
-          res
-        } else {
-          SafetyError.Forbidden(ctx, loc) :: res
-        }
+    case Expr.Tuple(elms, _, _, _) =>
+      elms.flatMap(visitExp)
 
-      case Expr.NewChannel(exp1, exp2, _, _, _) =>
-        visit(exp1) ++ visit(exp2)
+    case Expr.RecordEmpty(_, _) =>
+      Nil
 
-      case Expr.GetChannel(exp, _, _, _) =>
-        visit(exp)
+    case Expr.RecordSelect(exp, _, _, _, _) =>
+      visitExp(exp)
 
-      case Expr.PutChannel(exp1, exp2, _, _, _) =>
-        visit(exp1) ++ visit(exp2)
+    case Expr.RecordExtend(_, value, rest, _, _, _) =>
+      visitExp(value) ++ visitExp(rest)
 
-      case Expr.SelectChannel(rules, default, _, _, _) =>
-        rules.flatMap { case SelectChannelRule(_, chan, body) => visit(chan) ++
-          visit(body)
-        } ++
-          default.map(visit).getOrElse(Nil)
+    case Expr.RecordRestrict(_, rest, _, _, _) =>
+      visitExp(rest)
 
-      case Expr.Spawn(exp1, exp2, _, _, _) =>
-        val ctrlEffs = getControlEffs(exp1.eff)
-        val illegalSpawnEffect =
-          if (ctrlEffs.isEmpty)
-            Nil
-          else
-            List(IllegalSpawnEffect(exp1.eff, exp1.loc))
+    case Expr.ArrayLit(elms, exp, _, _, _) =>
+      elms.flatMap(visitExp) ++ visitExp(exp)
 
-        illegalSpawnEffect ++ visit(exp1) ++ visit(exp2)
+    case Expr.ArrayNew(exp1, exp2, exp3, _, _, _) =>
+      visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
 
-      case Expr.ParYield(frags, exp, _, _, _) =>
-        frags.flatMap { case ParYieldFragment(_, e, _) => visit(e) } ++ visit(exp)
+    case Expr.ArrayLoad(base, index, _, _, _) =>
+      visitExp(base) ++ visitExp(index)
 
-      case Expr.Lazy(exp, _, _) =>
-        visit(exp)
+    case Expr.ArrayLength(base, _, _) =>
+      visitExp(base)
 
-      case Expr.Force(exp, _, _, _) =>
-        visit(exp)
+    case Expr.ArrayStore(base, index, elm, _, _) =>
+      visitExp(base) ++ visitExp(index) ++ visitExp(elm)
 
-      case Expr.FixpointConstraintSet(cs, _, _) =>
-        cs.flatMap(checkConstraint(_, renv))
+    case Expr.StructNew(_, fields, region, _, _, _) =>
+      fields.flatMap { case (_, exp) => visitExp(exp) } ++ visitExp(region)
 
-      case Expr.FixpointLambda(_, exp, _, _, _) =>
-        visit(exp)
+    case Expr.StructGet(e, _, _, _, _) =>
+      visitExp(e)
 
-      case Expr.FixpointMerge(exp1, exp2, _, _, _) =>
-        visit(exp1) ++ visit(exp2)
+    case Expr.StructPut(e1, _, e2, _, _, _) =>
+      visitExp(e1) ++ visitExp(e2)
 
-      case Expr.FixpointSolve(exp, _, _, _) =>
-        visit(exp)
+    case Expr.VectorLit(elms, _, _, _) =>
+      elms.flatMap(visitExp)
 
-      case Expr.FixpointFilter(_, exp, _, _, _) =>
-        visit(exp)
+    case Expr.VectorLoad(exp1, exp2, _, _, _) =>
+      visitExp(exp1) ++ visitExp(exp2)
 
-      case Expr.FixpointInject(exp, _, _, _, _) =>
-        visit(exp)
+    case Expr.VectorLength(exp, _) =>
+      visitExp(exp)
 
-      case Expr.FixpointProject(_, exp, _, _, _) =>
-        visit(exp)
+    case Expr.Ascribe(exp, _, _, _) =>
+      visitExp(exp)
 
-      case Expr.Error(_, _, _) =>
-        Nil
+    case Expr.InstanceOf(exp, _, _) =>
+      visitExp(exp)
 
-    }
+    case cast@Expr.CheckedCast(castType, exp, _, _, _) =>
+      val castErrors = castType match {
+        case CheckedCastType.TypeCast => checkCheckedTypeCast(cast)
+        case CheckedCastType.EffectCast => Nil
+      }
+      visitExp(exp) ++ castErrors
 
-    visit(e0)
+    case cast@Expr.UncheckedCast(exp, _, _, _, _, loc) =>
+      val castErrors = verifyUncheckedCast(cast)
+      val permissionErrors = checkAllPermissions(loc.security, loc)
+      permissionErrors ++ visitExp(exp) ++ castErrors
+
+    case Expr.UncheckedMaskingCast(exp, _, _, loc) =>
+      val permissionErrors = checkAllPermissions(loc.security, loc)
+      permissionErrors ++ visitExp(exp)
+
+    case Expr.Without(exp, _, _, _, _) =>
+      visitExp(exp)
+
+    case Expr.TryCatch(exp, rules, _, _, loc) =>
+      val nestedTryCatchError = if (inTryCatch) List(IllegalNestedTryCatch(loc)) else Nil
+      nestedTryCatchError ++ visitExp(exp)(inTryCatch = true, renv, flix) ++
+        rules.flatMap { case CatchRule(bnd, clazz, e) => checkCatchClass(clazz, bnd.sym.loc) ++ visitExp(e) }
+
+    case Expr.Throw(exp, _, _, loc) =>
+      val permissionErrors = checkAllPermissions(loc.security, loc)
+      permissionErrors ++ visitExp(exp) ++ checkThrow(exp)
+
+    case Expr.TryWith(exp, effUse, rules, _, _, _) =>
+      val effectErrors = {
+        if (Symbol.isPrimitiveEff(effUse.sym)) List(PrimitiveEffectInTryWith(effUse.sym, effUse.loc))
+        else Nil
+      }
+      effectErrors ++ visitExp(exp) ++ rules.flatMap(rule => visitExp(rule.exp))
+
+
+    case Expr.Do(_, exps, _, _, _) =>
+      exps.flatMap(visitExp)
+
+    case Expr.InvokeConstructor(_, args, _, _, loc) =>
+      val permissionErrors = checkAllPermissions(loc.security, loc)
+      permissionErrors ++ args.flatMap(visitExp)
+
+    case Expr.InvokeMethod(_, exp, args, _, _, loc) =>
+      val permissionErrors = checkAllPermissions(loc.security, loc)
+      permissionErrors ++ visitExp(exp) ++ args.flatMap(visitExp)
+
+    case Expr.InvokeStaticMethod(_, args, _, _, loc) =>
+      val permissionErrors = checkAllPermissions(loc.security, loc)
+      permissionErrors ++ args.flatMap(visitExp)
+
+    case Expr.GetField(_, exp, _, _, loc) =>
+      val permissionErrors = checkAllPermissions(loc.security, loc)
+      permissionErrors ++ visitExp(exp)
+
+    case Expr.PutField(_, exp1, exp2, _, _, loc) =>
+      val permissionErrors = checkAllPermissions(loc.security, loc)
+      permissionErrors ++ visitExp(exp1) ++ visitExp(exp2)
+
+    case Expr.GetStaticField(_, _, _, loc) =>
+      checkAllPermissions(loc.security, loc)
+
+    case Expr.PutStaticField(_, exp, _, _, loc) =>
+      val permissionErrors = checkAllPermissions(loc.security, loc)
+      permissionErrors ++ visitExp(exp)
+
+    case newObject@Expr.NewObject(_, _, _, _, methods, loc) =>
+      val permissionErrors = checkAllPermissions(loc.security, loc)
+      val objectErrors = checkObjectImplementation(newObject)
+      permissionErrors ++ objectErrors ++ methods.flatMap(method => visitExp(method.exp))
+
+    case Expr.NewChannel(exp1, exp2, _, _, _) =>
+      visitExp(exp1) ++ visitExp(exp2)
+
+    case Expr.GetChannel(exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expr.PutChannel(exp1, exp2, _, _, _) =>
+      visitExp(exp1) ++ visitExp(exp2)
+
+    case Expr.SelectChannel(rules, default, _, _, _) =>
+      rules.flatMap {
+        case SelectChannelRule(_, chan, body) => visitExp(chan) ++ visitExp(body)
+      } ++ default.map(visitExp).getOrElse(Nil)
+
+    case Expr.Spawn(exp1, exp2, _, _, _) =>
+      val illegalSpawnEffect = {
+        if (hasControlEffects(exp1.eff)) List(IllegalSpawnEffect(exp1.eff, exp1.loc))
+        else Nil
+      }
+
+      illegalSpawnEffect ++ visitExp(exp1) ++ visitExp(exp2)
+
+    case Expr.ParYield(frags, exp, _, _, _) =>
+      frags.flatMap(fragment => visitExp(fragment.exp)) ++ visitExp(exp)
+
+    case Expr.Lazy(exp, _, _) =>
+      visitExp(exp)
+
+    case Expr.Force(exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expr.FixpointConstraintSet(cs, _, _) =>
+      cs.flatMap(checkConstraint)
+
+    case Expr.FixpointLambda(_, exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expr.FixpointMerge(exp1, exp2, _, _, _) =>
+      visitExp(exp1) ++ visitExp(exp2)
+
+    case Expr.FixpointSolve(exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expr.FixpointFilter(_, exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expr.FixpointInject(exp, _, _, _, _) =>
+      visitExp(exp)
+
+    case Expr.FixpointProject(_, exp, _, _, _) =>
+      visitExp(exp)
+
+    case Expr.Error(_, _, _) =>
+      Nil
 
   }
 
-  /**
-    * Checks if the given type cast is legal.
-    */
-  private def verifyCheckedTypeCast(from: Type, to: Type, loc: SourceLocation)(implicit flix: Flix): List[SafetyError] = {
-    (from.baseType, to.baseType) match {
-
-      // Allow casting Null to a Java type.
-      case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Native(_), _)) => Nil
-      case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.BigInt, _)) => Nil
-      case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.BigDecimal, _)) => Nil
-      case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Str, _)) => Nil
-      case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Regex, _)) => Nil
-      case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Array, _)) => Nil
-
-      // Allow casting one Java type to another if there is a sub-type relationship.
-      case (Type.Cst(TypeConstructor.Native(left), _), Type.Cst(TypeConstructor.Native(right), _)) =>
-        if (right.isAssignableFrom(left)) Nil else IllegalCheckedCast(from, to, loc) :: Nil
-
-      // Similar, but for String.
-      case (Type.Cst(TypeConstructor.Str, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-        if (right.isAssignableFrom(classOf[String])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
-
-      // Similar, but for Regex.
-      case (Type.Cst(TypeConstructor.Regex, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-        if (right.isAssignableFrom(classOf[java.util.regex.Pattern])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
-
-      // Similar, but for BigInt.
-      case (Type.Cst(TypeConstructor.BigInt, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-        if (right.isAssignableFrom(classOf[BigInteger])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
-
-      // Similar, but for BigDecimal.
-      case (Type.Cst(TypeConstructor.BigDecimal, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-        if (right.isAssignableFrom(classOf[java.math.BigDecimal])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
-
-      // Similar, but for Arrays.
-      case (Type.Cst(TypeConstructor.Array, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-        if (right.isAssignableFrom(classOf[Array[Object]])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
-
-      // Disallow casting a type variable.
-      case (src@Type.Var(_, _), _) =>
-        IllegalCheckedCastFromVar(src, to, loc) :: Nil
-
-      // Disallow casting a type variable (symmetric case)
-      case (_, dst@Type.Var(_, _)) =>
-        IllegalCheckedCastToVar(from, dst, loc) :: Nil
-
-      // Disallow casting a Java type to any other type.
-      case (Type.Cst(TypeConstructor.Native(clazz), _), _) =>
-        IllegalCheckedCastToNonJava(clazz, to, loc) :: Nil
-
-      // Disallow casting a Java type to any other type (symmetric case).
-      case (_, Type.Cst(TypeConstructor.Native(clazz), _)) =>
-        IllegalCheckedCastFromNonJava(from, clazz, loc) :: Nil
-
-      // Disallow all other casts.
-      case _ => IllegalCheckedCast(from, to, loc) :: Nil
+  /** Checks that `ctx` is [[SecurityContext.AllPermissions]]. */
+  private def checkAllPermissions(ctx: SecurityContext, loc: SourceLocation): List[SafetyError] = {
+    ctx match {
+      case SecurityContext.AllPermissions => Nil
+      case SecurityContext.NoPermissions => List(SafetyError.Forbidden(ctx, loc))
     }
+  }
+
+  /** Checks if `cast` is legal. */
+  private def checkCheckedTypeCast(cast: Expr.CheckedCast)(implicit flix: Flix): List[SafetyError] = cast match {
+    case Expr.CheckedCast(_, exp, tpe, _, loc) =>
+      val from = exp.tpe
+      val to = tpe
+      (Type.eraseAliases(from).baseType, Type.eraseAliases(to).baseType) match {
+
+        // Allow casting Null to a Java type.
+        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Native(_), _)) => Nil
+        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.BigInt, _)) => Nil
+        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.BigDecimal, _)) => Nil
+        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Str, _)) => Nil
+        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Regex, _)) => Nil
+        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Array, _)) => Nil
+
+        // Allow casting one Java type to another if there is a sub-type relationship.
+        case (Type.Cst(TypeConstructor.Native(left), _), Type.Cst(TypeConstructor.Native(right), _)) =>
+          if (right.isAssignableFrom(left)) Nil else IllegalCheckedCast(from, to, loc) :: Nil
+
+        // Similar, but for String.
+        case (Type.Cst(TypeConstructor.Str, _), Type.Cst(TypeConstructor.Native(right), _)) =>
+          if (right.isAssignableFrom(classOf[String])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
+
+        // Similar, but for Regex.
+        case (Type.Cst(TypeConstructor.Regex, _), Type.Cst(TypeConstructor.Native(right), _)) =>
+          if (right.isAssignableFrom(classOf[java.util.regex.Pattern])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
+
+        // Similar, but for BigInt.
+        case (Type.Cst(TypeConstructor.BigInt, _), Type.Cst(TypeConstructor.Native(right), _)) =>
+          if (right.isAssignableFrom(classOf[BigInteger])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
+
+        // Similar, but for BigDecimal.
+        case (Type.Cst(TypeConstructor.BigDecimal, _), Type.Cst(TypeConstructor.Native(right), _)) =>
+          if (right.isAssignableFrom(classOf[java.math.BigDecimal])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
+
+        // Similar, but for Arrays.
+        case (Type.Cst(TypeConstructor.Array, _), Type.Cst(TypeConstructor.Native(right), _)) =>
+          if (right.isAssignableFrom(classOf[Array[Object]])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
+
+        // Disallow casting a type variable.
+        case (src@Type.Var(_, _), _) =>
+          IllegalCheckedCastFromVar(src, to, loc) :: Nil
+
+        // Disallow casting a type variable (symmetric case)
+        case (_, dst@Type.Var(_, _)) =>
+          IllegalCheckedCastToVar(from, dst, loc) :: Nil
+
+        // Disallow casting a Java type to any other type.
+        case (Type.Cst(TypeConstructor.Native(clazz), _), _) =>
+          IllegalCheckedCastToNonJava(clazz, to, loc) :: Nil
+
+        // Disallow casting a Java type to any other type (symmetric case).
+        case (_, Type.Cst(TypeConstructor.Native(clazz), _)) =>
+          IllegalCheckedCastFromNonJava(from, clazz, loc) :: Nil
+
+        // Disallow all other casts.
+        case _ => IllegalCheckedCast(from, to, loc) :: Nil
+      }
   }
 
   /**
     * Checks if there are any impossible casts, i.e. casts that always fail.
     *
     *   - No primitive type can be cast to a reference type and vice-versa.
-    *   - No Bool type can be cast to a non-Bool type  and vice-versa.
+    *   - No Bool type can be cast to a non-Bool type and vice-versa.
     */
-  private def verifyUncheckedCast(cast: Expr.UncheckedCast)(implicit flix: Flix): List[SafetyError.ImpossibleUncheckedCast] = {
-    val tpe1 = Type.eraseAliases(cast.exp.tpe).baseType
-    val tpe2 = cast.declaredType.map(Type.eraseAliases).map(_.baseType)
+  private def verifyUncheckedCast(cast: Expr.UncheckedCast)(implicit flix: Flix): List[SafetyError.ImpossibleUncheckedCast] = cast match {
+    case Expr.UncheckedCast(exp, declaredType, _, _, _, loc) =>
+      val from = exp.tpe
+      val to = declaredType
+      val primitives = List(
+        Type.Unit, Type.Bool, Type.Char,
+        Type.Float32, Type.Float64, Type.Int8,
+        Type.Int16, Type.Int32, Type.Int64,
+        Type.Str, Type.Regex, Type.BigInt, Type.BigDecimal
+      )
 
-    val primitives = {
-      Type.Unit :: Type.Bool :: Type.Char ::
-        Type.Float32 :: Type.Float64 :: Type.Int8 ::
-        Type.Int16 :: Type.Int32 :: Type.Int64 ::
-        Type.Str :: Type.Regex :: Type.BigInt :: Type.BigDecimal :: Nil
-    }
+      (Type.eraseAliases(from).baseType, to.map(Type.eraseAliases).map(_.baseType)) match {
+        // Allow casts where one side is a type variable.
+        case (Type.Var(_, _), _) => Nil
+        case (_, Some(Type.Var(_, _))) => Nil
 
-    (tpe1, tpe2) match {
-      // Allow casts where one side is a type variable.
-      case (Type.Var(_, _), _) => Nil
-      case (_, Some(Type.Var(_, _))) => Nil
+        // Allow casts between Java types.
+        case (Type.Cst(TypeConstructor.Native(_), _), _) => Nil
+        case (_, Some(Type.Cst(TypeConstructor.Native(_), _))) => Nil
 
-      // Allow casts between Java types.
-      case (Type.Cst(TypeConstructor.Native(_), _), _) => Nil
-      case (_, Some(Type.Cst(TypeConstructor.Native(_), _))) => Nil
+        // Disallow casting a Boolean to another primitive type.
+        case (Type.Bool, Some(t2)) if primitives.filter(_ != Type.Bool).contains(t2) =>
+          ImpossibleUncheckedCast(from, to.get, loc) :: Nil
 
-      // Disallow casting a Boolean to another primitive type.
-      case (Type.Bool, Some(t2)) if primitives.filter(_ != Type.Bool).contains(t2) =>
-        ImpossibleUncheckedCast(cast.exp.tpe, cast.declaredType.get, cast.loc) :: Nil
+        // Disallow casting a Boolean to another primitive type (symmetric case).
+        case (t1, Some(Type.Bool)) if primitives.filter(_ != Type.Bool).contains(t1) =>
+          ImpossibleUncheckedCast(from, to.get, loc) :: Nil
 
-      // Disallow casting a Boolean to another primitive type (symmetric case).
-      case (t1, Some(Type.Bool)) if primitives.filter(_ != Type.Bool).contains(t1) =>
-        ImpossibleUncheckedCast(cast.exp.tpe, cast.declaredType.get, cast.loc) :: Nil
+        // Disallowing casting a non-primitive type to a primitive type.
+        case (t1, Some(t2)) if primitives.contains(t1) && !primitives.contains(t2) =>
+          ImpossibleUncheckedCast(from, to.get, loc) :: Nil
 
-      // Disallowing casting a non-primitive type to a primitive type.
-      case (t1, Some(t2)) if primitives.contains(t1) && !primitives.contains(t2) =>
-        ImpossibleUncheckedCast(cast.exp.tpe, cast.declaredType.get, cast.loc) :: Nil
+        // Disallowing casting a non-primitive type to a primitive type (symmetric case).
+        case (t1, Some(t2)) if primitives.contains(t2) && !primitives.contains(t1) =>
+          ImpossibleUncheckedCast(from, to.get, loc) :: Nil
 
-      // Disallowing casting a non-primitive type to a primitive type (symmetric case).
-      case (t1, Some(t2)) if primitives.contains(t2) && !primitives.contains(t1) =>
-        ImpossibleUncheckedCast(cast.exp.tpe, cast.declaredType.get, cast.loc) :: Nil
-
-      case _ => Nil
-    }
+        case _ => Nil
+      }
   }
 
-  /**
-    * Performs safety and well-formedness checks on the given constraint `c0`.
-    */
-  private def checkConstraint(c0: Constraint, renv: RigidityEnv)(implicit inTryCatch: Boolean, flix: Flix): List[SafetyError] = {
-    //
+  /** Checks the safety and well-formedness of `c`. */
+  private def checkConstraint(c: Constraint)(implicit inTryCatch: Boolean, renv: RigidityEnv, flix: Flix): List[SafetyError] = {
     // Compute the set of positively defined variable symbols in the constraint.
-    //
-    val posVars = positivelyDefinedVariables(c0)
+    val posVars = positivelyDefinedVariables(c)
 
-    // The variables that are used in a non-fixed lattice position
-    val latVars0 = nonFixedLatticeVariablesOf(c0)
+    // The variables that are used in a non-fixed lattice position.
+    val latVars0 = nonFixedLatticeVariablesOf(c)
 
-    // the variables that are used in a fixed position
-    val fixedLatVars0 = fixedLatticeVariablesOf(c0)
+    // The variables that are used in a fixed position.
+    val fixedLatVars0 = fixedLatticeVariablesOf(c)
 
     // The variables that are used in lattice position, either fixed or non-fixed.
     val latVars = latVars0 union fixedLatVars0
@@ -644,351 +476,283 @@ object Safety {
     // The lattice variables that cannot be used relationally in the head.
     val unsafeLatVars = latVars -- safeLatVars
 
-    //
     // Compute the quantified variables in the constraint.
-    //
     // A lexically bound variable does not appear in this set and is never free.
-    //
-    val quantVars = c0.cparams.map(_.bnd.sym).toSet
+    val quantVars = c.cparams.map(_.bnd.sym).toSet
 
-    //
     // Check that all negative atoms only use positively defined variable symbols
     // and that lattice variables are not used in relational position.
-    //
-    val err1 = c0.body.flatMap(checkBodyPredicate(_, posVars, quantVars, latVars, renv))
+    val err1 = c.body.flatMap(checkBodyPredicate(_, posVars, quantVars, latVars))
 
-    //
     // Check that the free relational variables in the head atom are not lattice variables.
-    //
-    val err2 = checkHeadPredicate(c0.head, unsafeLatVars)
+    val err2 = checkHeadPredicate(c.head, unsafeLatVars)
 
-    //
-    // Check that patterns in atom body are legal
-    //
-    val err3 = c0.body.flatMap(s => checkBodyPattern(s))
+    // Check that patterns in atom body are legal.
+    val err3 = c.body.flatMap(s => checkBodyPattern(s))
 
     err1 ++ err2 ++ err3
   }
 
-  /**
-    * Performs safety check on the pattern of an atom body.
-    */
-  private def checkBodyPattern(p0: Predicate.Body): List[SafetyError] = p0 match {
+  /** Checks that `p` only contains [[Pattern.Var]], [[Pattern.Wild]], and [[Pattern.Cst]]. */
+  private def checkBodyPattern(p: Predicate.Body): List[SafetyError] = p match {
     case Predicate.Body.Atom(_, _, _, _, terms, _, loc) =>
-      terms.foldLeft[List[SafetyError]](Nil)((acc, term) => term match {
-        case Pattern.Var(_, _, _) => acc
-        case Pattern.Wild(_, _) => acc
-        case Pattern.Cst(_, _, _) => acc
-        case _ => IllegalPatternInBodyAtom(loc) :: acc
-      })
+      terms.flatMap {
+        case Pattern.Var(_, _, _) => None
+        case Pattern.Wild(_, _) => None
+        case Pattern.Cst(_, _, _) => None
+        case _ => Some(IllegalPatternInBodyAtom(loc))
+      }
     case _ => Nil
   }
 
   /**
-    * Performs safety and well-formedness checks on the given body predicate `p0`
-    * with the given positively defined variable symbols `posVars`.
+    * Checks that `p` is well-formed.
+    *
+    * @param posVars the positively bound variables.
+    * @param quantVars the quantified variables, not bound by lexical scope.
+    * @param latVars the variables in lattice position.
     */
-  private def checkBodyPredicate(p0: Predicate.Body, posVars: Set[Symbol.VarSym], quantVars: Set[Symbol.VarSym], latVars: Set[Symbol.VarSym], renv: RigidityEnv)(implicit inTryCatch: Boolean, flix: Flix): List[SafetyError] = p0 match {
+  private def checkBodyPredicate(p: Predicate.Body, posVars: Set[Symbol.VarSym], quantVars: Set[Symbol.VarSym], latVars: Set[Symbol.VarSym])(implicit inTryCatch: Boolean, renv: RigidityEnv, flix: Flix): List[SafetyError] = p match {
     case Predicate.Body.Atom(_, den, polarity, _, terms, _, loc) =>
-      // check for non-positively bound negative variables.
+      // Check for non-positively bound negative variables.
       val err1 = polarity match {
         case Polarity.Positive => Nil
         case Polarity.Negative =>
           // Compute the free variables in the terms which are *not* bound by the lexical scope.
-          val freeVars = terms.flatMap(freeVarsOf).toSet intersect quantVars
-          val wildcardNegErrors = visitPats(terms, loc)
+          val freeVars = terms.flatMap(freeVarsOf).toSet.intersect(quantVars)
+          val wildcardNegErrors = terms.flatMap(visitPat(_, loc))
 
           // Check if any free variables are not positively bound.
-          val variableNegErrors = ((freeVars -- posVars) map (makeIllegalNonPositivelyBoundVariableError(_, loc))).toList
+          val variableNegErrors = (freeVars -- posVars).map(mkIllegalNonPositivelyBoundVariableError(_, loc)).toList
           wildcardNegErrors ++ variableNegErrors
       }
-      // check for relational use of lattice variables. We still look at fixed
-      // atoms since latVars (which means that they occur non-fixed) cannot be
-      // in another fixed atom.
+      // Check for relational use of lattice variables. We still look at fixed atoms since latVars
+      // (which means that they occur non-fixed) cannot be in another fixed atom.
       val relTerms = den match {
         case Denotation.Relational => terms
         case Denotation.Latticenal => terms.dropRight(1)
       }
-      val err2 = relTerms.flatMap(freeVarsOf).filter(latVars.contains).map(
-        s => IllegalRelationalUseOfLatticeVar(s, loc)
-      )
+      val relVars = relTerms.flatMap(freeVarsOf).toSet
+      val err2 = relVars.intersect(latVars).map(IllegalRelationalUseOfLatticeVar(_, loc))
 
       // Combine the messages
       err1 ++ err2
 
     case Predicate.Body.Functional(_, exp, loc) =>
-      // check for non-positively in variables (free variables in exp).
-      val inVars = freeVars(exp).keySet intersect quantVars
-      val err1 = ((inVars -- posVars) map (makeIllegalNonPositivelyBoundVariableError(_, loc))).toList
+      // Check for non-positively in variables (free variables in exp).
+      val inVars = freeVars(exp).keySet.intersect(quantVars)
+      val err1 = (inVars -- posVars).toList.map(mkIllegalNonPositivelyBoundVariableError(_, loc))
 
-      err1 ::: visitExp(exp, renv)
+      err1 ::: visitExp(exp)
 
-    case Predicate.Body.Guard(exp, _) => visitExp(exp, renv)
+    case Predicate.Body.Guard(exp, _) =>
+      visitExp(exp)
 
   }
 
-  /**
-    * Creates an error for a non-positively bound variable, dependent on `sym.isWild`.
-    *
-    * @param loc the location of the atom containing the terms.
-    */
-  private def makeIllegalNonPositivelyBoundVariableError(sym: Symbol.VarSym, loc: SourceLocation): SafetyError =
-    if (sym.isWild) IllegalNegativelyBoundWildVar(sym, loc) else IllegalNonPositivelyBoundVar(sym, loc)
+  /** Returns a non-positively bound variable error, depending on `sym.isWild`. */
+  private def mkIllegalNonPositivelyBoundVariableError(sym: Symbol.VarSym, loc: SourceLocation): SafetyError = {
+    if (sym.isWild) IllegalNegativelyBoundWildVar(sym, loc)
+    else IllegalNonPositivelyBoundVar(sym, loc)
+  }
 
-  /**
-    * Returns all the positively defined variable symbols in the given constraint `c0`.
-    */
-  private def positivelyDefinedVariables(c0: Constraint): Set[Symbol.VarSym] =
-    c0.body.flatMap(positivelyDefinedVariables).toSet
+  /** Returns all the free and positively defined variable symbols in the given constraint `c`. */
+  private def positivelyDefinedVariables(c: Constraint): Set[Symbol.VarSym] =
+    c.body.flatMap(positivelyDefinedVariables).toSet
 
-  /**
-    * Returns all positively defined variable symbols in the given body predicate `p0`.
-    */
-  private def positivelyDefinedVariables(p0: Predicate.Body): Set[Symbol.VarSym] = p0 match {
-    case Predicate.Body.Atom(_, _, polarity, _, terms, _, _) => polarity match {
-      case Polarity.Positive =>
-        // Case 1: A positive atom positively defines all its free variables.
-        terms.flatMap(freeVarsOf).toSet
-      case Polarity.Negative =>
-        // Case 2: A negative atom does not positively define any variables.
-        Set.empty
-    }
-
-    case Predicate.Body.Functional(_, _, _) =>
-      // A functional does not positively bind any variables. Not even its outVars.
+  /** Returns all free and positively defined variable symbols in the given body predicate `p`. */
+  private def positivelyDefinedVariables(p: Predicate.Body): Set[Symbol.VarSym] = p match {
+    case Predicate.Body.Atom(_, _, Polarity.Positive, _, terms, _, _) =>
+      terms.flatMap(freeVarsOf).toSet
+    case Predicate.Body.Atom(_, _, Polarity.Negative, _, _, _, _) =>
       Set.empty
-
-    case Predicate.Body.Guard(_, _) => Set.empty
-
+    case Predicate.Body.Functional(_, _, _) =>
+      // Functional does not positively bind any variables. Not even its outVars.
+      Set.empty
+    case Predicate.Body.Guard(_, _) =>
+      Set.empty
   }
 
-  /**
-    * Computes the free variables that occur in lattice position in
-    * atoms that are marked with fix.
-    */
-  private def fixedLatticeVariablesOf(c0: Constraint): Set[Symbol.VarSym] =
-    c0.body.flatMap(fixedLatticenalVariablesOf).toSet
+  /** Returns the free lattice variables of `c` that are marked with fix. */
+  private def fixedLatticeVariablesOf(c: Constraint): Set[Symbol.VarSym] =
+    c.body.flatMap(fixedLatticenalVariablesOf).toSet
 
-  /**
-    * Computes the lattice variables of `p0` if it is a fixed atom.
-    */
-  private def fixedLatticenalVariablesOf(p0: Predicate.Body): Set[Symbol.VarSym] = p0 match {
+  /** Returns the free lattice variables of `p` that are marked with fix. */
+  private def fixedLatticenalVariablesOf(p: Predicate.Body): Set[Symbol.VarSym] = p match {
     case Body.Atom(_, Denotation.Latticenal, _, Fixity.Fixed, terms, _, _) =>
       terms.lastOption.map(freeVarsOf).getOrElse(Set.empty)
-
     case _ => Set.empty
   }
 
-  /**
-    * Computes the free variables that occur in a lattice position in
-    * atoms that are not marked with fix.
-    */
-  private def nonFixedLatticeVariablesOf(c0: Constraint): Set[Symbol.VarSym] =
-    c0.body.flatMap(latticenalVariablesOf).toSet
+  /** Returns the free lattice variables of `c` that are not marked with fix. */
+  private def nonFixedLatticeVariablesOf(c: Constraint): Set[Symbol.VarSym] =
+    c.body.flatMap(latticeVariablesOf).toSet
 
-  /**
-    * Computes the lattice variables of `p0` if it is not a fixed atom.
-    */
-  private def latticenalVariablesOf(p0: Predicate.Body): Set[Symbol.VarSym] = p0 match {
+  /** Returns the free lattice variables of `p` that are not marked with fix. */
+  private def latticeVariablesOf(p: Predicate.Body): Set[Symbol.VarSym] = p match {
     case Predicate.Body.Atom(_, Denotation.Latticenal, _, Fixity.Loose, terms, _, _) =>
       terms.lastOption.map(freeVarsOf).getOrElse(Set.empty)
-
     case _ => Set.empty
   }
 
-  /**
-    * Checks for `IllegalRelationalUseOfLatticeVariable` in the given `head` predicate.
-    */
+  /** Checks that the free relational variables in `head` does not include `latVars`. */
   private def checkHeadPredicate(head: Predicate.Head, latVars: Set[Symbol.VarSym]): List[SafetyError] = head match {
     case Predicate.Head.Atom(_, Denotation.Latticenal, terms, _, loc) =>
-      // Check the relational terms ("the keys").
-      checkTerms(terms.dropRight(1), latVars, loc)
+      val relationalTerms = terms.dropRight(1)
+      checkTerms(relationalTerms, latVars, loc)
     case Predicate.Head.Atom(_, Denotation.Relational, terms, _, loc) =>
-      // Check every term.
       checkTerms(terms, latVars, loc)
   }
 
-  /**
-    * Checks that the free variables of the terms does not contain any of the variables in `latVars`.
-    * If they do contain a lattice variable then a `IllegalRelationalUseOfLatticeVariable` is created.
-    */
-  private def checkTerms(terms: List[Expr], latVars: Set[Symbol.VarSym], loc: SourceLocation): List[SafetyError] = {
-    // Compute the free variables in all terms.
-    val allVars = terms.foldLeft(Set.empty[Symbol.VarSym])({
-      case (acc, term) => acc ++ freeVars(term).keys
-    })
+  /** Checks that the free variables in `exps` does not include `latVars`. */
+  private def checkTerms(exps: List[Expr], latVars: Set[Symbol.VarSym], loc: SourceLocation): List[SafetyError] = {
+    val allFreeVars = exps.flatMap(t => freeVars(t).keys).toSet
 
-    // Compute the lattice variables that are illegally used in the terms.
-    allVars.intersect(latVars).toList.map(sym => IllegalRelationalUseOfLatticeVar(sym, loc))
+    // Compute the lattice variables that are illegally used in the exps.
+    allFreeVars.intersect(latVars).toList.map(IllegalRelationalUseOfLatticeVar(_, loc))
   }
 
-  /**
-    * Returns an error for each occurrence of wildcards in each term.
-    *
-    * @param loc the location of the atom containing the terms.
-    */
-  private def visitPats(terms: List[Pattern], loc: SourceLocation): List[SafetyError] = {
-    terms.flatMap(visitPat(_, loc))
-  }
-
-  /**
-    * Returns an error for each occurrence of wildcards.
-    *
-    * @param loc the location of the atom containing the term.
-    */
-  @tailrec
-  private def visitPat(term: Pattern, loc: SourceLocation): List[SafetyError] = term match {
+  /** Checks that `pat` contains no wildcards. */
+  private def visitPat(pat: Pattern, loc: SourceLocation): List[SafetyError] = pat match {
     case Pattern.Wild(_, _) => List(IllegalNegativelyBoundWildCard(loc))
     case Pattern.Var(_, _, _) => Nil
     case Pattern.Cst(_, _, _) => Nil
     case Pattern.Tag(_, pat, _, _) => visitPat(pat, loc)
-    case Pattern.Tuple(elms, _, _) => visitPats(elms, loc)
-    case Pattern.Record(pats, pat, _, _) => visitRecordPattern(pats, pat, loc)
+    case Pattern.Tuple(elms, _, _) => elms.flatMap(visitPat(_, loc))
+    case Pattern.Record(pats, pat, _, _) => pats.map(_.pat).flatMap(visitPat(_, loc)) ++ visitPat(pat, loc)
     case Pattern.RecordEmpty(_, _) => Nil
     case Pattern.Error(_, _) => Nil
   }
 
   /**
-    * Helper function for [[visitPat]].
-    */
-  private def visitRecordPattern(pats: List[Pattern.Record.RecordLabelPattern], pat: Pattern, loc: SourceLocation): List[SafetyError] = {
-    visitPats(pats.map(_.pat), loc) ++ visitPat(pat, loc)
-  }
-
-  /**
-    * Ensures that the Java type in a catch clause is Throwable or a subclass.
+    * Checks that `clazz` is [[java.lang.Throwable]] or a subclass.
     *
     * @param clazz the Java class specified in the catch clause
     * @param loc   the location of the catch parameter.
     */
-  private def checkCatchClass(clazz: java.lang.Class[?], loc: SourceLocation): List[SafetyError] = {
-    if (!classOf[Throwable].isAssignableFrom(clazz)) {
-      List(IllegalCatchType(loc))
-    } else {
-      List.empty
-    }
+  private def checkCatchClass(clazz: Class[?], loc: SourceLocation): List[SafetyError] = {
+    if (isThrowable(clazz)) List.empty
+    else List(IllegalCatchType(loc))
   }
 
-  /**
-    * Ensures that the type of the argument to `throw` is Throwable or a subclass.
-    *
-    * @param exp the expression to check
-    */
+  /** Returns `true` if `clazz` is [[java.lang.Throwable]] or a subclass of it. */
+  private def isThrowable(clazz: Class[?]): Boolean =
+    classOf[Throwable].isAssignableFrom(clazz)
+
+  /** Checks that the type of the argument to `throw` is [[java.lang.Throwable]] or a subclass. */
   private def checkThrow(exp: Expr): List[SafetyError] = {
-    val valid = exp.tpe match {
-      case Type.Cst(TypeConstructor.Native(clazz), _) => classOf[Throwable].isAssignableFrom(clazz)
-      case _ => false
-    }
-    if (valid) {
-      List()
-    } else {
-      List(IllegalThrowType(exp.loc))
-    }
+    if (isThrowableType(exp.tpe)) List()
+    else List(IllegalThrowType(exp.loc))
+  }
+
+  /** Returns `true` if `tpe` is [[java.lang.Throwable]] or a subclass of it. */
+  @tailrec
+  private def isThrowableType(tpe: Type): Boolean = tpe match {
+    case Type.Cst(TypeConstructor.Native(clazz), _) => isThrowable(clazz)
+    case Type.Alias(_, _, tpe, _) => isThrowableType(tpe)
+    case _ => false
   }
 
   /**
-    * Ensures that `methods` fully implement `clazz`
+    * Checks that `newObject` correctly implements its class. `newObject` contains `methods` that
+    * are supposed to implement `clazz`.
+    *
+    * The conditions are that:
+    *   - `clazz` must be an interface or have a non-private constructor without arguments.
+    *   - `clazz` must be public.
+    *   - `methods` must take the object itself (`this`) as the first argument.
+    *   - `methods` must include all required signatures (e.g. abstract methods).
+    *   - `methods` must not include non-existing methods.
+    *   - `methods` must not let control effects escape.
     */
-  private def checkObjectImplementation(clazz: java.lang.Class[?], tpe: Type, methods: List[JvmMethod], loc: SourceLocation)(implicit flix: Flix): List[SafetyError] = {
-    //
-    // Check that `clazz` doesn't have a non-default constructor
-    //
-    val constructorErrors = if (clazz.isInterface) {
-      // Case 1: Interface. No need for a constructor.
-      List.empty
-    } else {
-      // Case 2: Class. Must have a non-private zero argument constructor.
-      if (hasNonPrivateZeroArgConstructor(clazz))
-        List.empty
-      else
-        List(NewObjectMissingPublicZeroArgConstructor(clazz, loc))
-    }
-
-    //
-    // Check that `clazz` is public
-    //
-    val visibilityErrors = if (!isPublicClass(clazz))
-      List(NewObjectNonPublicClass(clazz, loc))
-    else
-      List.empty
-
-    //
-    // Check that the first argument looks like "this"
-    //
-    val thisErrors = methods.flatMap {
-      case JvmMethod(ident, fparams, _, _, _, methodLoc) =>
-        // Check that the declared type of `this` matches the type of the class or interface.
-        val fparam = fparams.head
-        val thisType = Type.eraseAliases(fparam.tpe)
-        thisType match {
-          case `tpe` => None
-          case Type.Unit => Some(NewObjectMissingThisArg(clazz, ident.name, methodLoc))
-          case _ => Some(NewObjectIllegalThisType(clazz, fparam.tpe, ident.name, methodLoc))
+  private def checkObjectImplementation(newObject: Expr.NewObject)(implicit flix: Flix): List[SafetyError] = newObject match {
+    case Expr.NewObject(_, clazz, tpe0, _, methods, loc) =>
+      val tpe = Type.eraseAliases(tpe0)
+      // `clazz` must be an interface or have a non-private constructor without arguments.
+      val constructorErrors = {
+        if (clazz.isInterface) {
+          List.empty
+        } else {
+          if (hasNonPrivateZeroArgConstructor(clazz)) List.empty
+          else List(NewObjectMissingPublicZeroArgConstructor(clazz, loc))
         }
-    }
+      }
 
-    val flixMethods = getFlixMethodSignatures(methods)
-    val implemented = flixMethods.keySet
+      // `clazz` must be public.
+      val visibilityErrors = {
+        if (!isPublicClass(clazz)) List(NewObjectNonPublicClass(clazz, loc))
+        else List.empty
+      }
 
-    val javaMethods = getJavaMethodSignatures(clazz)
-    val objectMethods = getJavaMethodSignatures(classOf[Object]).keySet
-    val canImplement = javaMethods.keySet
-    val mustImplement = canImplement.filter(m => isAbstractMethod(javaMethods(m)) && !objectMethods.contains(m))
+      // `methods` must take the object itself (`this`) as the first argument.
+      val thisErrors = methods.flatMap {
+        case JvmMethod(ident, fparams, _, _, _, methodLoc) =>
+          val firstParam = fparams.head
+          firstParam.tpe match {
+            case t if Type.eraseAliases(t) == tpe =>
+              None
+            case Type.Unit =>
+              // Unit arguments are likely inserted by the compiler.
+              Some(NewObjectMissingThisArg(clazz, ident.name, methodLoc))
+            case _ =>
+              Some(NewObjectIllegalThisType(clazz, firstParam.tpe, ident.name, methodLoc))
+          }
+      }
 
-    //
-    // Check that there are no unimplemented methods.
-    //
-    val unimplemented = mustImplement diff implemented
-    val unimplementedErrors = unimplemented.map(m => NewObjectMissingMethod(clazz, javaMethods(m), loc))
+      val flixMethods = getFlixMethodSignatures(methods)
+      val implemented = flixMethods.keySet
 
-    //
-    // Check that there are no methods that aren't in the interface
-    //
-    val extra = implemented diff canImplement
-    val extraErrors = extra.map(m => NewObjectUnreachableMethod(clazz, m.name, flixMethods(m).loc))
+      val classMethods = getInstanceMethods(clazz)
+      val objectClassMethods = getInstanceMethods(classOf[Object]).keySet
+      val canImplement = classMethods.keySet
+      val mustImplement = canImplement.filter(m =>
+        isAbstractMethod(classMethods(m)) && !objectClassMethods.contains(m)
+      )
 
-    //
-    // Check that methods are pure or only have primitive effects.
-    //
-    val methodErrors = methods.filter(m => getControlEffs(m.eff).nonEmpty).map(m => SafetyError.IllegalMethodEffect(m.eff, m.loc))
+      // `methods` must include all required signatures (e.g. abstract methods).
+      val unimplemented = mustImplement.diff(implemented)
+      val unimplementedErrors = unimplemented.map(m => NewObjectMissingMethod(clazz, classMethods(m), loc))
 
-    constructorErrors ++ visibilityErrors ++ thisErrors ++ unimplementedErrors ++ extraErrors ++ methodErrors
+      // `methods` must not include non-existing methods.
+      val undefined = implemented.diff(canImplement)
+      val undefinedErrors = undefined.map(m => NewObjectUndefinedMethod(clazz, m.name, flixMethods(m).loc))
+
+      // `methods` must not let control effects escape.
+      val controlEffecting = methods.filter(m => hasControlEffects(m.eff))
+      val controlEffectingErrors = controlEffecting.map(m => SafetyError.IllegalMethodEffect(m.eff, m.loc))
+
+      constructorErrors ++ visibilityErrors ++ thisErrors ++ unimplementedErrors ++ undefinedErrors ++ controlEffectingErrors
   }
 
   /**
-    * Represents the signature of a method, used to compare Java signatures against Flix signatures.
+    * Represents the Flix signature of a Java method.
+    *
+    * The signature contains no [[Type.Alias]].
     */
   private case class MethodSignature(name: String, paramTypes: List[Type], retTpe: Type)
 
-  /**
-    * Convert a list of Flix methods to a set of MethodSignatures. Returns a map to allow subsequent reverse lookup.
-    */
+  /** Returns a map of `methods` based on their [[MethodSignature]]. */
   private def getFlixMethodSignatures(methods: List[JvmMethod]): Map[MethodSignature, JvmMethod] = {
-    methods.foldLeft(Map.empty[MethodSignature, JvmMethod]) {
-      case (acc, m@JvmMethod(ident, fparams, _, retTpe, _, _)) =>
+    methods.map {
+      case m@JvmMethod(ident, fparams, _, retTpe, _, _) =>
         // Drop the first formal parameter (which always represents `this`)
         val paramTypes = fparams.tail.map(_.tpe)
-        val signature = MethodSignature(ident.name, paramTypes.map(t => Type.eraseAliases(t)), Type.eraseAliases(retTpe))
-        acc + (signature -> m)
-    }
+        val signature = MethodSignature(ident.name, paramTypes.map(Type.eraseAliases), Type.eraseAliases(retTpe))
+        signature -> m
+    }.toMap
   }
 
-  /**
-    * Get a Set of MethodSignatures representing the methods of `clazz`. Returns a map to allow subsequent reverse lookup.
-    */
-  private def getJavaMethodSignatures(clazz: java.lang.Class[?]): Map[MethodSignature, java.lang.reflect.Method] = {
+  /** Returns the instance methods of `clazz` with their [[MethodSignature]]. */
+  private def getInstanceMethods(clazz: Class[?]): Map[MethodSignature, java.lang.reflect.Method] = {
     val methods = JvmUtils.getInstanceMethods(clazz)
-    methods.foldLeft(Map.empty[MethodSignature, java.lang.reflect.Method]) {
-      case (acc, m) =>
-        val signature = MethodSignature(m.getName, m.getParameterTypes.toList.map(Type.getFlixType), Type.getFlixType(m.getReturnType))
-        acc + (signature -> m)
-    }
+    methods.map(m => {
+      val signature = MethodSignature(m.getName, m.getParameterTypes.toList.map(Type.getFlixType), Type.getFlixType(m.getReturnType))
+      signature -> m
+    }).toMap
   }
 
-  /**
-    * Return true if the given `clazz` has a non-private zero argument constructor.
-    */
-  private def hasNonPrivateZeroArgConstructor(clazz: java.lang.Class[?]): Boolean = {
+  /** Return `true` if `clazz` has a non-private constructor with zero arguments. */
+  private def hasNonPrivateZeroArgConstructor(clazz: Class[?]): Boolean = {
     try {
       val constructor = clazz.getDeclaredConstructor()
       !java.lang.reflect.Modifier.isPrivate(constructor.getModifiers)
@@ -997,25 +761,18 @@ object Safety {
     }
   }
 
-  /**
-    * Returns `true` if the given class `c` is public.
-    */
-  private def isPublicClass(c: java.lang.Class[?]): Boolean =
+  /** Returns `true` if `c` is public. */
+  private def isPublicClass(c: Class[?]): Boolean =
     java.lang.reflect.Modifier.isPublic(c.getModifiers)
 
-  /**
-    * Return `true` if the given method `m` is abstract.
-    */
+  /** Return `true` if `m` is abstract. */
   private def isAbstractMethod(m: java.lang.reflect.Method): Boolean =
     java.lang.reflect.Modifier.isAbstract(m.getModifiers)
 
-  /**
-    * Returns the control-effects inside `tpe`.
-    */
-  private def getControlEffs(tpe: Type): Set[Symbol.EffectSym] =
-    tpe.typeConstructors.foldLeft(Set.empty[Symbol.EffectSym]) {
-      case (acc, TypeConstructor.Effect(sym)) if !Symbol.isPrimitiveEff(sym) => acc + sym
-      case (acc, _) => acc
-    }
+  /** Returns `true` if `eff` includes control effects (e.g. Console). */
+  private def hasControlEffects(eff: Type): Boolean = {
+    // TODO: This is unsound and incomplete because it ignores type variables, associated types, etc.
+    !eff.effects.forall(Symbol.isPrimitiveEff)
+  }
 
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -378,7 +378,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |  }
       """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[SafetyError.NewObjectUnreachableMethod](result)
+    expectError[SafetyError.NewObjectUndefinedMethod](result)
   }
 
   test("TestNonDefaultConstructor.01") {


### PR DESCRIPTION
Fixes #9264

This is essentially a non-functional refactoring. Some errors have become a little more precise and might not erase user alias in error messages and the order or errors have been made consistent but otherwise nothing has changed.