### PR TITLE
feat: add CodeAction to use UndefinedTag

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -54,7 +54,7 @@ object CodeActionProvider {
       mkUseTrait(qn.ident, uri, ap)
 
     case ResolutionError.UndefinedTag(name, ap, _, loc) if overlaps(range, loc) =>
-      mkUseTag(name, uri, ap) ++ replaceFullTag(name, uri, loc)
+      mkUseTag(name, uri, ap) ++ mkQualifyTag(name, uri, loc)
 
     case ResolutionError.UndefinedType(qn, ap, loc) if overlaps(range, loc) =>
       mkUseType(qn.ident, uri, ap) ++ mkImportJava(qn.ident.name, uri, ap) ++ mkNewEnum(qn.ident.name, uri, ap) ++ mkNewStruct(qn.ident.name, uri, ap)
@@ -147,7 +147,7 @@ object CodeActionProvider {
     val candidateEnums = root.enums.filter(_._2.cases.keys.exists(_.name == tagName))
     candidateEnums.keys.map{ enumName =>
       CodeAction(
-        title = s"use $enumName.$tagName",
+        title = s"use '$enumName.$tagName'",
         kind = CodeActionKind.QuickFix,
         edit = Some(WorkspaceEdit(Map(uri -> List(mkTextEdit(ap, s"use $enumName.$tagName"))))),
         command = None
@@ -171,11 +171,11 @@ object CodeActionProvider {
     *   case Color.Red => ???
     * }}}
     */
-  private def replaceFullTag(tagName: String, uri: String, loc: SourceLocation)(implicit root: Root): List[CodeAction] = {
+  private def mkQualifyTag(tagName: String, uri: String, loc: SourceLocation)(implicit root: Root): List[CodeAction] = {
     val candidateEnums = root.enums.filter(_._2.cases.keys.exists(_.name == tagName))
     candidateEnums.keys.map{ enumName =>
       CodeAction(
-        title = s"Replace with $enumName.$tagName",
+        title = s"Prefix with '$enumName.'",
         kind = CodeActionKind.QuickFix,
         edit = Some(WorkspaceEdit(Map(uri -> List(TextEdit(sourceLocation2Range(loc), s"$enumName.$tagName"))))),
         command = None

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -53,8 +53,8 @@ object CodeActionProvider {
     case ResolutionError.UndefinedTrait(qn, ap,  _, loc) if overlaps(range, loc) =>
       mkUseTrait(qn.ident, uri, ap)
 
-    case ResolutionError.UndefinedTag(name, _, loc) if overlaps(range, loc) =>
-      replaceFullTag(name, uri, loc)
+    case ResolutionError.UndefinedTag(name, ap, _, loc) if overlaps(range, loc) =>
+      mkUseTag(name, uri, ap) ++ replaceFullTag(name, uri, loc)
 
     case ResolutionError.UndefinedType(qn, ap, loc) if overlaps(range, loc) =>
       mkUseType(qn.ident, uri, ap) ++ mkImportJava(qn.ident.name, uri, ap) ++ mkNewEnum(qn.ident.name, uri, ap) ++ mkNewStruct(qn.ident.name, uri, ap)
@@ -128,7 +128,48 @@ object CodeActionProvider {
   }
 
   /**
+    * Returns a code action that proposes to use the tag of an enum.
+    *
+    * For example, if we have:
+    *
+    * {{{
+    *   match color {
+    *      case Red => ???
+    *   }
+    * }}}
+    *
+    * where the user actually want to refer to Color.Red, this code action proposes to add:
+    * {{{
+    *   use Color.Red
+    * }}}
+    */
+  private def mkUseTag(tagName: String, uri: String, ap: AnchorPosition)(implicit root: Root): List[CodeAction] = {
+    val candidateEnums = root.enums.filter(_._2.cases.keys.exists(_.name == tagName))
+    candidateEnums.keys.map{ enumName =>
+      CodeAction(
+        title = s"use $enumName.$tagName",
+        kind = CodeActionKind.QuickFix,
+        edit = Some(WorkspaceEdit(Map(uri -> List(mkTextEdit(ap, s"use $enumName.$tagName"))))),
+        command = None
+      )
+    }.toList
+  }
+
+  /**
     * Returns a code action that proposes to qualify the tag with the enum name.
+    *
+    * For example, if we have:
+    *
+    * {{{
+    *   match color {
+    *      case Red => ???
+    *   }
+    * }}}
+    *
+    * where the user actually want to refer to Color.Red, this code action proposes to replace the tag with:
+    * {{{
+    *   case Color.Red => ???
+    * }}}
     */
   private def replaceFullTag(tagName: String, uri: String, loc: SourceLocation)(implicit root: Root): List[CodeAction] = {
     val candidateEnums = root.enums.filter(_._2.cases.keys.exists(_.name == tagName))

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -212,7 +212,7 @@ object CompletionProvider {
       case ResolutionError.UndefinedName(_, _, _, isUse, _) => if (isUse) (1, SyntacticContext.Use) else (2, SyntacticContext.Expr.OtherExpr)
       case ResolutionError.UndefinedNameUnrecoverable(_, _, _, isUse, _) => if (isUse) (1, SyntacticContext.Use) else (2, SyntacticContext.Expr.OtherExpr)
       case ResolutionError.UndefinedType(_, _, _) => (1, SyntacticContext.Type.OtherType)
-      case ResolutionError.UndefinedTag(_, _, _) => (1, SyntacticContext.Pat.OtherPat)
+      case ResolutionError.UndefinedTag(_, _,  _, _) => (1, SyntacticContext.Pat.OtherPat)
       case WeederError.UnappliedIntrinsic(_, _) => (5, SyntacticContext.Expr.OtherExpr)
       case WeederError.UndefinedAnnotation(_, _) => (1, SyntacticContext.Decl.Module)
       case err: ResolutionError.UndefinedJvmStaticField => (1, SyntacticContext.Expr.StaticFieldOrMethod(err))

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -800,7 +800,7 @@ object ResolutionError {
     * @param ns  the current namespace.
     * @param loc the location where the error occurred.
     */
-  case class UndefinedTag(tag: String, ns: Name.NName, loc: SourceLocation) extends ResolutionError {
+  case class UndefinedTag(tag: String, ap: AnchorPosition, ns: Name.NName, loc: SourceLocation) extends ResolutionError {
     def summary: String = s"Undefined tag: '$tag'."
 
     def message(formatter: Formatter): String = {

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2295,7 +2295,7 @@ object Resolver {
 
     matches match {
       // Case 0: No matches. Error.
-      case Nil => Result.Err(ResolutionError.UndefinedTag(qname.ident.name, ns0, qname.loc))
+      case Nil => Result.Err(ResolutionError.UndefinedTag(qname.ident.name, AnchorPosition.mkImportOrUseAnchor(ns0), ns0, qname.loc))
       // Case 1: A match was found. Success. Note that multiple matches can be found but they are prioritized by tryLookupName so this is fine.
       case caze :: _ => Result.Ok(caze)
     }


### PR DESCRIPTION
further update to #9267

Now if there is an undefined tag, we also propose to use it:

<img width="405" alt="image" src="https://github.com/user-attachments/assets/51c9323e-6273-441e-87e1-bd475de33b33">

<img width="434" alt="image" src="https://github.com/user-attachments/assets/7ae160bc-86d9-4459-be39-ecd8231f4817">

Some left problems:
- Shall we check by prefix, like also providing those for 'Re', 'Gree'
- Shall we propose to use all the cases in the same enum?
