### PR TITLE
fix: ImportJava CodeAction now displays the right prompt

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -288,7 +288,7 @@ object CodeActionProvider {
     root.availableClasses.byClass.get(name).toList.flatten.map { path =>
       val completePath = path.mkString(".") + "." + name
       CodeAction(
-        title = s"import '$path'",
+        title = s"import '$completePath'",
         kind = CodeActionKind.QuickFix,
         edit = Some(WorkspaceEdit(Map(uri -> List(mkTextEdit(ap, s"import $completePath"))))),
         command = None


### PR DESCRIPTION
Previous:
![image](https://github.com/user-attachments/assets/60ec537f-50f5-42df-806e-c69636882dea)
Now:
<img width="358" alt="image" src="https://github.com/user-attachments/assets/4a921712-24dd-4c5d-a98d-300700daf294">
