### PR TITLE
refactor: remove App evar

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -86,11 +86,11 @@ object KindedAst {
 
     case class ApplyClo(exp: Expr, exps: List[Expr], tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 
-    case class ApplyDef(symUse: DefSymUse, exps: List[Expr], itvar: Type, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class ApplyDef(symUse: DefSymUse, exps: List[Expr], itvar: Type, tvar: Type.Var, loc: SourceLocation) extends Expr
 
-    case class ApplyLocalDef(symUse: LocalDefSymUse, exps: List[Expr], arrowTvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class ApplyLocalDef(symUse: LocalDefSymUse, exps: List[Expr], arrowTvar: Type.Var, tvar: Type.Var, loc: SourceLocation) extends Expr
 
-    case class ApplySig(symUse: SigSymUse, exps: List[Expr], itvar: Type.Var, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class ApplySig(symUse: SigSymUse, exps: List[Expr], itvar: Type.Var, tvar: Type.Var, loc: SourceLocation) extends Expr
 
     case class Lambda(fparam: FormalParam, exp: Expr, allowSubeffecting: Boolean, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -220,7 +220,6 @@ object Deriver {
             ),
             Type.freshVar(Kind.Star, loc),
             Type.freshVar(Kind.Star, loc),
-            Type.freshVar(Kind.Eff, loc),
             loc
           )
       }
@@ -344,7 +343,6 @@ object Deriver {
           ),
           Type.freshVar(Kind.Star, loc),
           Type.freshVar(Kind.Star, loc),
-          Type.freshVar(Kind.Eff, loc),
           loc
         )
       )
@@ -430,7 +428,6 @@ object Deriver {
             ),
             Type.freshVar(Kind.Star, loc),
             Type.freshVar(Kind.Star, loc),
-            Type.freshVar(Kind.Eff, loc),
             loc
           )
       }
@@ -448,7 +445,6 @@ object Deriver {
           ),
           Type.freshVar(Kind.Star, loc),
           Type.freshVar(Kind.Star, loc),
-          Type.freshVar(Kind.Eff, loc),
           loc
         )
       }
@@ -579,7 +575,6 @@ object Deriver {
             List(mkVarExpr(varSym, loc)),
             Type.freshVar(Kind.Star, loc),
             Type.freshVar(Kind.Star, loc),
-            Type.freshVar(Kind.Eff, loc),
             loc
           )
       }
@@ -720,13 +715,11 @@ object Deriver {
                 List(mkVarExpr(varSym, loc)),
                 Type.freshVar(Kind.Star, loc),
                 Type.freshVar(Kind.Star, loc),
-                Type.freshVar(Kind.Eff, loc),
                 loc
               ),
             ),
             Type.freshVar(Kind.Star, loc),
             Type.freshVar(Kind.Star, loc),
-            Type.freshVar(Kind.Eff, loc),
             loc
           )
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -373,22 +373,19 @@ object Kinder {
       val exps = exps0.map(visitExp(_, kenv0, taenv, henv0, root))
       val itvar = Type.freshVar(Kind.Star, loc1.asSynthetic)
       val tvar = Type.freshVar(Kind.Star, loc2.asSynthetic)
-      val evar = Type.freshVar(Kind.Eff, loc2.asSynthetic)
-      KindedAst.Expr.ApplyDef(DefSymUse(sym, loc1), exps, itvar, tvar, evar, loc2)
+      KindedAst.Expr.ApplyDef(DefSymUse(sym, loc1), exps, itvar, tvar, loc2)
 
     case ResolvedAst.Expr.ApplyLocalDef(symUse, exps0, loc) =>
       val exps = exps0.map(visitExp(_, kenv0, taenv, henv0, root))
       val arrowTvar = Type.freshVar(Kind.Star, loc.asSynthetic) // use loc of symuse
       val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-      val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-      KindedAst.Expr.ApplyLocalDef(symUse, exps, arrowTvar, tvar, evar, loc)
+      KindedAst.Expr.ApplyLocalDef(symUse, exps, arrowTvar, tvar, loc)
 
     case ResolvedAst.Expr.ApplySig(SigSymUse(sym, loc1), exps0, loc2) =>
       val exps = exps0.map(visitExp(_, kenv0, taenv, henv0, root))
       val itvar = Type.freshVar(Kind.Star, loc1.asSynthetic)
       val tvar = Type.freshVar(Kind.Star, loc2.asSynthetic)
-      val evar = Type.freshVar(Kind.Eff, loc2.asSynthetic)
-      KindedAst.Expr.ApplySig(SigSymUse(sym, loc1), exps, itvar, tvar, evar, loc2)
+      KindedAst.Expr.ApplySig(SigSymUse(sym, loc1), exps, itvar, tvar, loc2)
 
     case ResolvedAst.Expr.Lambda(fparam0, exp0, allowSubeffecting, loc) =>
       val fparam = visitFormalParam(fparam0, kenv0, taenv, root)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -114,20 +114,23 @@ object TypeReconstruction {
       val es = exps.map(visitExp(_))
       TypedAst.Expr.ApplyClo(e, es, subst(tvar), subst(evar), loc)
 
-    case KindedAst.Expr.ApplyDef(symUse, exps, itvar, tvar, evar, loc) =>
+    case KindedAst.Expr.ApplyDef(symUse, exps, itvar, tvar, loc) =>
       val es = exps.map(visitExp)
-      TypedAst.Expr.ApplyDef(symUse, es, subst(itvar), subst(tvar), subst(evar), loc)
+      val iv = subst(itvar)
+      val eff = Type.mkUnion(iv.arrowEffectType :: es.map(_.eff), loc)
+      TypedAst.Expr.ApplyDef(symUse, es, iv, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.ApplySig(symUse, exps, itvar, tvar, evar, loc) =>
+    case KindedAst.Expr.ApplySig(symUse, exps, itvar, tvar, loc) =>
       val es = exps.map(visitExp)
-      TypedAst.Expr.ApplySig(symUse, es, subst(itvar), subst(tvar), subst(evar), loc)
+      val iv = subst(itvar)
+      val eff = Type.mkUnion(iv.arrowEffectType :: es.map(_.eff), loc)
+      TypedAst.Expr.ApplySig(symUse, es, itvar, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.ApplyLocalDef(symUse, exps, arrowTvar, tvar, evar, loc) =>
+    case KindedAst.Expr.ApplyLocalDef(symUse, exps, arrowTvar, tvar, loc) =>
       val es = exps.map(visitExp)
-      val at = subst(arrowTvar)
-      val t = subst(tvar)
-      val ef = subst(evar)
-      TypedAst.Expr.ApplyLocalDef(symUse, es, at, t, ef, loc)
+      val atvar = subst(arrowTvar)
+      val eff = Type.mkUnion(atvar.arrowEffectType :: es.map(_.eff), loc)
+      TypedAst.Expr.ApplyLocalDef(symUse, es, atvar, subst(tvar), eff, loc)
 
     case KindedAst.Expr.Lambda(fparam, exp, _, loc) =>
       val p = visitFormalParam(fparam, subst)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -124,7 +124,7 @@ object TypeReconstruction {
       val es = exps.map(visitExp)
       val iv = subst(itvar)
       val eff = Type.mkUnion(Type.eraseTopAliases(iv).arrowEffectType :: es.map(_.eff), loc)
-      TypedAst.Expr.ApplySig(symUse, es, itvar, subst(tvar), eff, loc)
+      TypedAst.Expr.ApplySig(symUse, es, iv, subst(tvar), eff, loc)
 
     case KindedAst.Expr.ApplyLocalDef(symUse, exps, arrowTvar, tvar, loc) =>
       val es = exps.map(visitExp)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -117,19 +117,19 @@ object TypeReconstruction {
     case KindedAst.Expr.ApplyDef(symUse, exps, itvar, tvar, loc) =>
       val es = exps.map(visitExp)
       val iv = subst(itvar)
-      val eff = Type.mkUnion(iv.arrowEffectType :: es.map(_.eff), loc)
+      val eff = Type.mkUnion(Type.eraseTopAliases(iv).arrowEffectType :: es.map(_.eff), loc)
       TypedAst.Expr.ApplyDef(symUse, es, iv, subst(tvar), eff, loc)
 
     case KindedAst.Expr.ApplySig(symUse, exps, itvar, tvar, loc) =>
       val es = exps.map(visitExp)
       val iv = subst(itvar)
-      val eff = Type.mkUnion(iv.arrowEffectType :: es.map(_.eff), loc)
+      val eff = Type.mkUnion(Type.eraseTopAliases(iv).arrowEffectType :: es.map(_.eff), loc)
       TypedAst.Expr.ApplySig(symUse, es, itvar, subst(tvar), eff, loc)
 
     case KindedAst.Expr.ApplyLocalDef(symUse, exps, arrowTvar, tvar, loc) =>
       val es = exps.map(visitExp)
       val atvar = subst(arrowTvar)
-      val eff = Type.mkUnion(atvar.arrowEffectType :: es.map(_.eff), loc)
+      val eff = Type.mkUnion(Type.eraseTopAliases(atvar).arrowEffectType :: es.map(_.eff), loc)
       TypedAst.Expr.ApplyLocalDef(symUse, es, atvar, subst(tvar), eff, loc)
 
     case KindedAst.Expr.Lambda(fparam, exp, _, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
@@ -112,20 +112,23 @@ object TypeReconstruction2 {
       val es = exps.map(visitExp(_))
       TypedAst.Expr.ApplyClo(e, es, subst(tvar), subst(evar), loc)
 
-    case KindedAst.Expr.ApplyDef(symUse, exps, itvar, tvar, evar, loc) =>
+    case KindedAst.Expr.ApplyDef(symUse, exps, itvar, tvar, loc) =>
       val es = exps.map(visitExp)
-      TypedAst.Expr.ApplyDef(symUse, es, subst(itvar), subst(tvar), subst(evar), loc)
+      val iv = subst(itvar)
+      val eff = Type.mkUnion(iv.arrowEffectType :: es.map(_.eff), loc)
+      TypedAst.Expr.ApplyDef(symUse, es, iv, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.ApplySig(symUse, exps, itvar, tvar, evar, loc) =>
+    case KindedAst.Expr.ApplySig(symUse, exps, itvar, tvar, loc) =>
       val es = exps.map(visitExp)
-      TypedAst.Expr.ApplySig(symUse, es, subst(itvar), subst(tvar), subst(evar), loc)
+      val iv = subst(itvar)
+      val eff = Type.mkUnion(iv.arrowEffectType :: es.map(_.eff), loc)
+      TypedAst.Expr.ApplySig(symUse, es, itvar, subst(tvar), eff, loc)
 
-    case KindedAst.Expr.ApplyLocalDef(symUse, exps, arrowTvar, tvar, evar, loc) =>
+    case KindedAst.Expr.ApplyLocalDef(symUse, exps, arrowTvar, tvar, loc) =>
       val es = exps.map(visitExp)
-      val at = subst(arrowTvar)
-      val t = subst(tvar)
-      val ef = subst(evar)
-      TypedAst.Expr.ApplyLocalDef(symUse, es, at, t, ef, loc)
+      val atvar = subst(arrowTvar)
+      val eff = Type.mkUnion(atvar.arrowEffectType :: es.map(_.eff), loc)
+      TypedAst.Expr.ApplyLocalDef(symUse, es, atvar, subst(tvar), eff, loc)
 
     case KindedAst.Expr.Lambda(fparam, exp, _, loc) =>
       val p = visitFormalParam(fparam, subst)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
@@ -122,7 +122,7 @@ object TypeReconstruction2 {
       val es = exps.map(visitExp)
       val iv = subst(itvar)
       val eff = Type.mkUnion(iv.arrowEffectType :: es.map(_.eff), loc)
-      TypedAst.Expr.ApplySig(symUse, es, itvar, subst(tvar), eff, loc)
+      TypedAst.Expr.ApplySig(symUse, es, iv, subst(tvar), eff, loc)
 
     case KindedAst.Expr.ApplyLocalDef(symUse, exps, arrowTvar, tvar, loc) =>
       val es = exps.map(visitExp)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -85,7 +85,7 @@ object ConstraintGen {
         val resEff = evar
         (resTpe, resEff)
 
-      case Expr.ApplyDef(DefSymUse(sym, loc1), exps, itvar, tvar, evar, loc2) =>
+      case Expr.ApplyDef(DefSymUse(sym, loc1), exps, itvar, tvar, loc2) =>
         val defn = root.defs(sym)
         val (tconstrs1, econstrs1, declaredType, _) = Scheme.instantiate(defn.spec.sc, loc1.asSynthetic)
         val constrs1 = tconstrs1.map(_.copy(loc = loc2))
@@ -98,23 +98,21 @@ object ConstraintGen {
         c.addClassConstraints(constrs1, loc2)
         econstrs1.foreach { econstr => c.unifyType(econstr.tpe1, econstr.tpe2, loc2) }
         c.unifyType(tvar, declaredResultType, loc2)
-        c.unifyType(evar, Type.mkUnion(declaredEff :: effs, loc2), loc2)
         val resTpe = tvar
-        val resEff = evar
+        val resEff = Type.mkUnion(declaredEff :: effs, loc2)
         (resTpe, resEff)
 
-      case Expr.ApplyLocalDef(LocalDefSymUse(sym, loc1), exps, arrowTvar, tvar, evar, loc2) =>
+      case Expr.ApplyLocalDef(LocalDefSymUse(sym, loc1), exps, arrowTvar, tvar, loc2) =>
         val (tpes, effs) = exps.map(visitExp).unzip
         val defEff = Type.freshVar(Kind.Eff, loc1.asSynthetic)
         val actualDefTpe = Type.mkUncurriedArrowWithEffect(tpes, defEff, tvar, loc1)
         c.unifyType(actualDefTpe, arrowTvar, loc1)
         c.expectType(sym.tvar, actualDefTpe, loc1)
-        c.unifyType(evar, Type.mkUnion(defEff :: effs, loc2), loc2)
         val resTpe = tvar
-        val resEff = evar
+        val resEff = Type.mkUnion(defEff :: effs, loc2)
         (resTpe, resEff)
 
-      case Expr.ApplySig(SigSymUse(sym, loc1), exps, itvar, tvar, evar, loc2) =>
+      case Expr.ApplySig(SigSymUse(sym, loc1), exps, itvar, tvar, loc2) =>
         val sig = root.traits(sym.trt).sigs(sym)
         val (tconstrs1, econstrs1, declaredType, _) = Scheme.instantiate(sig.spec.sc, loc1.asSynthetic)
         val constrs1 = tconstrs1.map(_.copy(loc = loc1))
@@ -127,9 +125,8 @@ object ConstraintGen {
         econstrs1.foreach { econstr => c.unifyType(econstr.tpe1, econstr.tpe2, loc2) }
         c.unifyType(itvar, declaredType, loc2)
         c.unifyType(tvar, declaredResultType, loc2)
-        c.unifyType(evar, Type.mkUnion(declaredEff :: effs, loc2), loc2)
         val resTpe = tvar
-        val resEff = evar
+        val resEff = Type.mkUnion(declaredEff :: effs, loc2)
         (resTpe, resEff)
 
       case Expr.Lambda(fparam, exp, allowSubeffecting, loc) =>


### PR DESCRIPTION
Removing the evar requires destructing an arrow type which reveals three enemies
- type aliases (not too bad)
- associated types (hmmm)
- wrong typing?? (how can it be a variable after substitution when its unified with an arrow type??)