### PR TITLE
fix: make `Throw` impure in `Simplifier`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -151,7 +151,7 @@ object Simplifier {
           val t = visitType(tpe)
           SimplifiedAst.Expr.ApplyAtomic(AtomicOp.Lazy, List(lambdaExp), t, Purity.Pure, loc)
 
-        case AtomicOp.HoleError(_) =>
+        case AtomicOp.HoleError(_) | AtomicOp.Throw =>
           // Simplify purity to impure, must be done after Monomorph
           val t = visitType(tpe)
           SimplifiedAst.Expr.ApplyAtomic(op, es, t, Purity.Impure, loc)


### PR DESCRIPTION
I'm not sure if this is a bug or not, but it seems that if a `HoleError` is impure, then it should also hold for `Throw`?