### PR TITLE
feat: simplify application evars

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -112,22 +112,25 @@ object TypeReconstruction {
     case KindedAst.Expr.ApplyClo(exp, exps, tvar, evar, loc) =>
       val e = visitExp(exp)
       val es = exps.map(visitExp(_))
-      TypedAst.Expr.ApplyClo(e, es, subst(tvar), subst(evar), loc)
+      val eff = Type.mkUnion(subst(evar) :: e.eff :: es.map(_.eff), loc)
+      TypedAst.Expr.ApplyClo(e, es, subst(tvar), eff, loc)
 
     case KindedAst.Expr.ApplyDef(symUse, exps, itvar, tvar, evar, loc) =>
       val es = exps.map(visitExp)
-      TypedAst.Expr.ApplyDef(symUse, es, subst(itvar), subst(tvar), subst(evar), loc)
+      val eff = Type.mkUnion(subst(evar) :: es.map(_.eff), loc)
+      TypedAst.Expr.ApplyDef(symUse, es, subst(itvar), subst(tvar), eff, loc)
 
     case KindedAst.Expr.ApplySig(symUse, exps, itvar, tvar, evar, loc) =>
       val es = exps.map(visitExp)
-      TypedAst.Expr.ApplySig(symUse, es, subst(itvar), subst(tvar), subst(evar), loc)
+      val eff = Type.mkUnion(subst(evar) :: es.map(_.eff), loc)
+      TypedAst.Expr.ApplySig(symUse, es, subst(itvar), subst(tvar), eff, loc)
 
     case KindedAst.Expr.ApplyLocalDef(symUse, exps, arrowTvar, tvar, evar, loc) =>
       val es = exps.map(visitExp)
       val at = subst(arrowTvar)
       val t = subst(tvar)
-      val ef = subst(evar)
-      TypedAst.Expr.ApplyLocalDef(symUse, es, at, t, ef, loc)
+      val eff = Type.mkUnion(subst(evar) :: es.map(_.eff), loc)
+      TypedAst.Expr.ApplyLocalDef(symUse, es, at, t, eff, loc)
 
     case KindedAst.Expr.Lambda(fparam, exp, _, loc) =>
       val p = visitFormalParam(fparam, subst)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
@@ -110,15 +110,18 @@ object TypeReconstruction2 {
     case KindedAst.Expr.ApplyClo(exp, exps, tvar, evar, loc) =>
       val e = visitExp(exp)
       val es = exps.map(visitExp(_))
-      TypedAst.Expr.ApplyClo(e, es, subst(tvar), subst(evar), loc)
+      val eff = Type.mkUnion(subst(evar) :: e.eff :: es.map(_.eff), loc)
+      TypedAst.Expr.ApplyClo(e, es, subst(tvar), eff, loc)
 
     case KindedAst.Expr.ApplyDef(symUse, exps, itvar, tvar, evar, loc) =>
       val es = exps.map(visitExp)
-      TypedAst.Expr.ApplyDef(symUse, es, subst(itvar), subst(tvar), subst(evar), loc)
+      val eff = Type.mkUnion(subst(evar) :: es.map(_.eff), loc)
+      TypedAst.Expr.ApplyDef(symUse, es, subst(itvar), subst(tvar), eff, loc)
 
     case KindedAst.Expr.ApplySig(symUse, exps, itvar, tvar, evar, loc) =>
       val es = exps.map(visitExp)
-      TypedAst.Expr.ApplySig(symUse, es, subst(itvar), subst(tvar), subst(evar), loc)
+      val eff = Type.mkUnion(subst(evar) :: es.map(_.eff), loc)
+      TypedAst.Expr.ApplySig(symUse, es, subst(itvar), subst(tvar), eff, loc)
 
     case KindedAst.Expr.ApplyLocalDef(symUse, exps, arrowTvar, tvar, evar, loc) =>
       val es = exps.map(visitExp)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -80,9 +80,9 @@ object ConstraintGen {
         val (tpes, effs) = exps.map(visitExp).unzip
         c.expectType(tpe, Type.mkUncurriedArrowWithEffect(tpes, lambdaBodyEff, lambdaBodyType, loc), loc)
         c.unifyType(tvar, lambdaBodyType, loc)
-        c.unifyType(evar, Type.mkUnion(lambdaBodyEff :: eff :: effs, loc), loc)
+        c.unifyType(evar, lambdaBodyEff, loc)
         val resTpe = tvar
-        val resEff = evar
+        val resEff = Type.mkUnion(lambdaBodyEff :: eff :: effs, loc)
         (resTpe, resEff)
 
       case Expr.ApplyDef(DefSymUse(sym, loc1), exps, itvar, tvar, evar, loc2) =>
@@ -98,9 +98,9 @@ object ConstraintGen {
         c.addClassConstraints(constrs1, loc2)
         econstrs1.foreach { econstr => c.unifyType(econstr.tpe1, econstr.tpe2, loc2) }
         c.unifyType(tvar, declaredResultType, loc2)
-        c.unifyType(evar, Type.mkUnion(declaredEff :: effs, loc2), loc2)
+        c.unifyType(evar, declaredEff, loc2)
         val resTpe = tvar
-        val resEff = evar
+        val resEff = Type.mkUnion(declaredEff :: effs, loc2)
         (resTpe, resEff)
 
       case Expr.ApplyLocalDef(LocalDefSymUse(sym, loc1), exps, arrowTvar, tvar, evar, loc2) =>
@@ -109,9 +109,9 @@ object ConstraintGen {
         val actualDefTpe = Type.mkUncurriedArrowWithEffect(tpes, defEff, tvar, loc1)
         c.unifyType(actualDefTpe, arrowTvar, loc1)
         c.expectType(sym.tvar, actualDefTpe, loc1)
-        c.unifyType(evar, Type.mkUnion(defEff :: effs, loc2), loc2)
+        c.unifyType(evar, defEff, loc2)
         val resTpe = tvar
-        val resEff = evar
+        val resEff = Type.mkUnion(defEff :: effs, loc2)
         (resTpe, resEff)
 
       case Expr.ApplySig(SigSymUse(sym, loc1), exps, itvar, tvar, evar, loc2) =>
@@ -127,9 +127,9 @@ object ConstraintGen {
         econstrs1.foreach { econstr => c.unifyType(econstr.tpe1, econstr.tpe2, loc2) }
         c.unifyType(itvar, declaredType, loc2)
         c.unifyType(tvar, declaredResultType, loc2)
-        c.unifyType(evar, Type.mkUnion(declaredEff :: effs, loc2), loc2)
+        c.unifyType(evar, declaredEff, loc2)
         val resTpe = tvar
-        val resEff = evar
+        val resEff = Type.mkUnion(declaredEff :: effs, loc2)
         (resTpe, resEff)
 
       case Expr.Lambda(fparam, exp, allowSubeffecting, loc) =>


### PR DESCRIPTION
for `Xperf --frontend --n 11` this PR moves the median throughput from 19.985 to  22.644 (+13%)

when you have an application we currently have
```
outsideconstraints ~ evar
evar ~ Union(.. funEff ..)
```
but with this PR it is instead (requiring TypeReduction to rebuild the union)
```
outsideconstraints ~ Union(.. funEff ..)
evar ~ funEff
```
which has the very trivial `var ~ var` constraint