### PR TITLE
feat: singleton nullary enum cases

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -27,6 +27,7 @@ import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Visibility.{IsPrivate, Is
 import ca.uwaterloo.flix.language.phase.jvm.ClassMaker.Volatility.{IsVolatile, NotVolatile}
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.MethodDescriptor.mkDescriptor
 import ca.uwaterloo.flix.language.phase.jvm.JvmName.{DevFlixRuntime, JavaLang, JavaLangInvoke, JavaUtil, JavaUtilConcurrent, MethodDescriptor, RootPackage}
+import ca.uwaterloo.flix.util.InternalCompilerException
 import org.objectweb.asm.Opcodes
 
 /**
@@ -41,6 +42,7 @@ sealed trait BackendObjType {
     case BackendObjType.Lazy(tpe) => JvmName(RootPackage, mkClassName("Lazy", tpe))
     case BackendObjType.Tuple(elms) => JvmName(RootPackage, mkClassName("Tuple", elms))
     case BackendObjType.Struct(elms) => JvmName(RootPackage, mkClassName("Struct", elms))
+    case BackendObjType.NullTag(sym) => JvmName(RootPackage, mkClassName(sym.toString))
     case BackendObjType.Tagged => JvmName(RootPackage, mkClassName("Tagged"))
     case BackendObjType.Tag(tpes) => JvmName(RootPackage, mkClassName("Tag", tpes))
     case BackendObjType.Arrow(args, result) => JvmName(RootPackage, mkClassName(s"Fn${args.length}", args :+ result))
@@ -327,7 +329,38 @@ object BackendObjType {
     }
   }
 
-  case class Tag(elms: List[BackendType]) extends BackendObjType with Generatable {
+  sealed trait TagType extends BackendObjType with Generatable
+
+  case class NullTag(sym: Symbol.CaseSym) extends TagType {
+    def genByteCode()(implicit flix: Flix): Array[Byte] = {
+      val cm = ClassMaker.mkClass(this.jvmName, IsFinal, superClass = Tagged.jvmName)
+
+      cm.mkStaticConstructor(StaticConstructor)
+      cm.mkField(SingletonField)
+      cm.mkConstructor(Constructor)
+      cm.mkMethod(ToStringMethod)
+
+      cm.closeClassMaker()
+    }
+
+    def SingletonField: StaticField = StaticField(this.jvmName, IsPublic, IsFinal, NotVolatile, "singleton", this.toTpe)
+
+    def StaticConstructor: StaticConstructorMethod = singletonStaticConstructor(Constructor, SingletonField)
+
+    def Constructor: ConstructorMethod = ConstructorMethod(this.jvmName, IsPublic, Nil, Some(_ =>
+      thisLoad() ~ INVOKESPECIAL(Tagged.Constructor) ~
+        thisLoad() ~ Tagged.mkTagName(sym) ~ PUTFIELD(Tagged.NameField) ~
+        RETURN()
+    ))
+
+    def ToStringMethod: InstanceMethod = JavaObject.ToStringMethod.implementation(this.jvmName, Some(_ =>
+      Tagged.mkTagName(sym) ~ xReturn(String.toTpe)
+    ))
+  }
+
+  case class Tag(elms: List[BackendType]) extends TagType {
+    if (elms.isEmpty) throw InternalCompilerException(s"Unexpected nullary Tag type", SourceLocation.Unknown)
+
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
       val cm = ClassMaker.mkClass(this.jvmName, IsFinal, superClass = Tagged.jvmName)
 
@@ -345,12 +378,9 @@ object BackendObjType {
     def Constructor: ConstructorMethod = nullarySuperConstructor(Tagged.Constructor)
 
     def ToStringMethod: InstanceMethod = JavaObject.ToStringMethod.implementation(this.jvmName, Some(_ =>
-    if (elms.nonEmpty) {
       Util.mkString(Some(thisLoad() ~ GETFIELD(NameField) ~ pushString("(") ~ INVOKEVIRTUAL(String.Concat)), Some(pushString(")")), elms.length, getIndexString) ~
       xReturn(String.toTpe)
-    } else {
-      thisLoad() ~ GETFIELD(NameField) ~ xReturn(String.toTpe)
-    }))
+    ))
 
     /** `[] --> [this.index(i).xString()]` */
     private def getIndexString(i: Int): InstructionSet = {

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/BackendObjType.scala
@@ -42,7 +42,7 @@ sealed trait BackendObjType {
     case BackendObjType.Lazy(tpe) => JvmName(RootPackage, mkClassName("Lazy", tpe))
     case BackendObjType.Tuple(elms) => JvmName(RootPackage, mkClassName("Tuple", elms))
     case BackendObjType.Struct(elms) => JvmName(RootPackage, mkClassName("Struct", elms))
-    case BackendObjType.NullTag(sym) => JvmName(RootPackage, mkClassName(sym.toString))
+    case BackendObjType.NullaryTag(sym) => JvmName(RootPackage, mkClassName(sym.toString))
     case BackendObjType.Tagged => JvmName(RootPackage, mkClassName("Tagged"))
     case BackendObjType.Tag(tpes) => JvmName(RootPackage, mkClassName("Tag", tpes))
     case BackendObjType.Arrow(args, result) => JvmName(RootPackage, mkClassName(s"Fn${args.length}", args :+ result))
@@ -331,7 +331,7 @@ object BackendObjType {
 
   sealed trait TagType extends BackendObjType with Generatable
 
-  case class NullTag(sym: Symbol.CaseSym) extends TagType {
+  case class NullaryTag(sym: Symbol.CaseSym) extends TagType {
     def genByteCode()(implicit flix: Flix): Array[Byte] = {
       val cm = ClassMaker.mkClass(this.jvmName, IsFinal, superClass = Tagged.jvmName)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -549,7 +549,7 @@ object GenExpression {
           case Nil =>
             import BytecodeInstructions.*
             // nullary tags have their own distinct class
-            INSTANCEOF(BackendObjType.NullTag(sym).jvmName)
+            INSTANCEOF(BackendObjType.NullaryTag(sym).jvmName)
           case _ =>
             import BytecodeInstructions.*
             val taggedType = BackendObjType.Tagged
@@ -565,7 +565,7 @@ object GenExpression {
         val ins = terms match {
           case Nil =>
             import BytecodeInstructions.*
-            val tagType = BackendObjType.NullTag(sym)
+            val tagType = BackendObjType.NullaryTag(sym)
             GETSTATIC(tagType.SingletonField)
           case _ =>
             import BytecodeInstructions.*
@@ -582,7 +582,7 @@ object GenExpression {
         val List(exp) = exps
         val MonoType.Enum(_, targs) = exp.tpe
         val cases = JvmOps.instantiateEnum(root.enums(sym.enumSym), targs)
-        // BackendObjType.NullTag cannot happen here since terms must be non-empty.
+        // BackendObjType.NullaryTag cannot happen here since terms must be non-empty.
         val tagType = BackendObjType.Tag(cases(sym))
 
         compileExpr(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/GenExpression.scala
@@ -548,9 +548,8 @@ object GenExpression {
         val ins = terms match {
           case Nil =>
             import BytecodeInstructions.*
-            // nullary tags reuse the same object
-            GETSTATIC(BackendObjType.NullTag(sym).SingletonField) ~
-            ifConditionElse(Condition.ACMPEQ)(pushBool(true))(pushBool(false))
+            // nullary tags have their own distinct class
+            INSTANCEOF(BackendObjType.NullTag(sym).jvmName)
           case _ =>
             import BytecodeInstructions.*
             val taggedType = BackendObjType.Tagged

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmName.scala
@@ -119,7 +119,8 @@ object JvmName {
     replace("#", Flix.Delimiter + "hashtag").
     replace(":", Flix.Delimiter + "colon").
     replace("?", Flix.Delimiter + "question").
-    replace("@", Flix.Delimiter + "at")
+    replace("@", Flix.Delimiter + "at").
+    replace(".", Flix.Delimiter + "dot")
 
   //
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Java Names ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -378,7 +378,7 @@ object JvmOps {
       case (acc, MonoType.Enum(sym, targs)) =>
         val tags = instantiateEnum(root.enums(sym), targs)
         tags.foldLeft(acc) {
-          case (acc, (sym, Nil)) => acc + BackendObjType.NullTag(sym)
+          case (acc, (sym, Nil)) => acc + BackendObjType.NullaryTag(sym)
           case (acc, (_, tagElms)) => acc + BackendObjType.Tag(tagElms)
         }
       case (acc, _) => acc

--- a/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/jvm/JvmOps.scala
@@ -373,12 +373,13 @@ object JvmOps {
   /**
     * Returns the set of erased tag types in `types` without searching recursively.
     */
-  def getErasedTagTypesOf(root: Root, types: Iterable[MonoType]): Set[BackendObjType.Tag] =
-    types.foldLeft(Set.empty[BackendObjType.Tag]) {
+  def getErasedTagTypesOf(root: Root, types: Iterable[MonoType]): Set[BackendObjType.TagType] =
+    types.foldLeft(Set.empty[BackendObjType.TagType]) {
       case (acc, MonoType.Enum(sym, targs)) =>
-        val tags = instantiateEnum(root.enums(sym), targs).values
+        val tags = instantiateEnum(root.enums(sym), targs)
         tags.foldLeft(acc) {
-          case (acc, tagElms) => acc + BackendObjType.Tag(tagElms)
+          case (acc, (sym, Nil)) => acc + BackendObjType.NullTag(sym)
+          case (acc, (_, tagElms)) => acc + BackendObjType.Tag(tagElms)
         }
       case (acc, _) => acc
     }


### PR DESCRIPTION
Idea: for nullary enum tags like `Option.None`, make a `Option$dotNone$` class with a single tag instance. This means that we only have one `Option.None` object and that pattern match checking for `Option.None` can be done with `instanceOf Option$dotNone$`

Fixes #9259 