### PR TITLE
feat: add `Parser2` to `Xprint-phases`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/dbg/AstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/AstPrinter.scala
@@ -34,7 +34,8 @@ object AstPrinter {
   implicit object DebugUnit extends DebugNoOp[Unit]
 
   implicit object DebugSyntaxTree extends Debug[SyntaxTree.Root] {
-    override def emit(phase: String, root: SyntaxTree.Root)(implicit flix: Flix): Unit = ()
+    override def emit(phase: String, root: SyntaxTree.Root)(implicit flix: Flix): Unit =
+      printDocProgram(phase, SyntaxTreePrinter.print(root))
   }
 
   implicit object DebugWeededAst extends Debug[WeededAst.Root] {

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -33,7 +33,8 @@ object DocAst {
 
   case class TypeParam(sym: Symbol.KindedTypeVarSym)
 
-  case class Program(enums: List[Enum], defs: List[Def])
+  /** `misc` is used for printing non-structured asts like [[ca.uwaterloo.flix.language.ast.SyntaxTree]] */
+  case class Program(enums: List[Enum], defs: List[Def], misc: List[(String, Expr)])
 
   case class JvmMethod(ident: Name.Ident, fparams: List[Expr.Ascription], clo: Expr, tpe: Type)
 

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAstFormatter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAstFormatter.scala
@@ -27,7 +27,7 @@ object DocAstFormatter {
 
   def format(p: Program)(implicit i: Indent): List[Doc] = {
     import scala.math.Ordering.Implicits.seqOrdering
-    val Program(enums0, defs0) = p
+    val Program(enums0, defs0, misc0) = p
     val enums = enums0.map {
       case Enum(_, _, sym, tparams, cases) =>
         val tparamsf = if (tparams.isEmpty) empty else text("[") |:: sep(text(", "), tparams.map {
@@ -58,7 +58,13 @@ object DocAstFormatter {
         )
         ((sym.namespace: Seq[String], sym.name), d)
     }
-    (enums ++ defs).sortBy(_._1).map(_._2)
+    val misc = misc0.map {
+      case (name, expr) =>
+        val intro = text("/*") +: sep(breakWith(" "), name.split(" ").toList.map(text)) +: text("*/")
+        val e = format(expr)
+        intro +: e
+    }
+    (enums ++ defs).sortBy(_._1).map(_._2) ++ misc
   }
 
   def format(d: Expr)(implicit i: Indent): Doc =

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LiftedAstPrinter.scala
@@ -39,7 +39,7 @@ object LiftedAstPrinter {
           print(exp)
         )
     }.toList
-    DocAst.Program(Nil, defs)
+    DocAst.Program(Nil, defs, Nil)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/LoweredAstPrinter.scala
@@ -45,7 +45,7 @@ object LoweredAstPrinter {
           print(exp)
         )
     }.toList
-    DocAst.Program(enums, defs)
+    DocAst.Program(enums, defs, Nil)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/MonoAstPrinter.scala
@@ -22,7 +22,7 @@ object MonoAstPrinter {
         val e = print(exp)
         DocAst.Def(ann, mod, sym, fps, rtpe, ef, e)
     }.toList
-    DocAst.Program(enums, defs)
+    DocAst.Program(enums, defs, Nil)
   }
 
   private def print(e: MonoAst.Expr): DocAst.Expr = e match {

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ReducedAstPrinter.scala
@@ -39,7 +39,7 @@ object ReducedAstPrinter {
           print(stmt)
         )
     }.toList
-    DocAst.Program(Nil, defs)
+    DocAst.Program(Nil, defs, Nil)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
@@ -30,7 +30,7 @@ object ResolvedAstPrinter {
       case ResolvedAst.Declaration.Def(sym, spec, exp, _) =>
         DocAst.Def(spec.ann, spec.mod, sym, spec.fparams.map(printFormalParam), DocAst.Type.Unknown, DocAst.Eff.AsIs("Unknown"), print(exp))
     }.toList
-    DocAst.Program(Nil, defs)
+    DocAst.Program(Nil, defs, Nil)
   }
 
   /** Returns the [[DocAst.Expr]] representation of `exp`. */

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/SimplifiedAstPrinter.scala
@@ -39,7 +39,7 @@ object SimplifiedAstPrinter {
           print(exp)
         )
     }.toList
-    DocAst.Program(Nil, defs)
+    DocAst.Program(Nil, defs, Nil)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/SyntaxTreePrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/SyntaxTreePrinter.scala
@@ -32,9 +32,9 @@ object SyntaxTreePrinter {
   private def print(token: Token): DocAst.Expr = token.kind match {
     // Err is not a case object, so we can't rely on the generated `toString`.
     case TokenKind.Err(_) =>
-      DocAst.Expr.App(DocAst.Expr.AsIs("Err"), List(DocAst.Expr.AsIs(s"\"${token.text}\"")))
+      DocAst.Expr.SquareApp(DocAst.Expr.AsIs("Err"), List(DocAst.Expr.AsIs(s"\"${token.text}\"")))
     case other =>
-      DocAst.Expr.App(DocAst.Expr.AsIs(other.toString), List(DocAst.Expr.AsIs(s"\"${token.text}\"")))
+      DocAst.Expr.SquareApp(DocAst.Expr.AsIs(other.toString), List(DocAst.Expr.AsIs(s"\"${token.text}\"")))
   }
 
   private def print(child: SyntaxTree.Child): DocAst.Expr = child match {

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/SyntaxTreePrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/SyntaxTreePrinter.scala
@@ -32,9 +32,9 @@ object SyntaxTreePrinter {
   private def print(token: Token): DocAst.Expr = token.kind match {
     // Err is not a case object, so we can't rely on the generated `toString`.
     case TokenKind.Err(_) =>
-      DocAst.Expr.AsIs("Err")
+      DocAst.Expr.App(DocAst.Expr.AsIs("Err"), List(DocAst.Expr.AsIs(s"\"${token.text}\"")))
     case other =>
-      DocAst.Expr.AsIs(other.toString)
+      DocAst.Expr.App(DocAst.Expr.AsIs(other.toString), List(DocAst.Expr.AsIs(s"\"${token.text}\"")))
   }
 
   private def print(child: SyntaxTree.Child): DocAst.Expr = child match {

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/SyntaxTreePrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/SyntaxTreePrinter.scala
@@ -1,0 +1,46 @@
+package ca.uwaterloo.flix.language.dbg.printer
+
+import ca.uwaterloo.flix.language.ast.{Ast, SourceLocation, SyntaxTree, Token, TokenKind}
+import ca.uwaterloo.flix.language.ast.SyntaxTree.TreeKind
+import ca.uwaterloo.flix.language.ast.SyntaxTree.TreeKind.{Decl, Expr, Pattern, Predicate, Type, UsesOrImports}
+import ca.uwaterloo.flix.language.ast.shared.Source
+import ca.uwaterloo.flix.language.dbg.DocAst
+import ca.uwaterloo.flix.util.InternalCompilerException
+import ca.uwaterloo.flix.util.collection.MapOps
+
+object SyntaxTreePrinter {
+
+  /**
+    * Returns the [[DocAst.Program]] representation of `root`.
+    */
+  def print(root: SyntaxTree.Root): DocAst.Program = {
+    val units = root.units.map{case (src, tree) => (src.name, print(tree))}.toList
+    DocAst.Program(Nil, Nil, units)
+  }
+
+  private def print(tree: SyntaxTree.Tree): DocAst.Expr = {
+    val SyntaxTree.Tree(kind, children, _) = tree
+    kind match {
+      // ErrorTree is not a case object, so we can't rely on the generated `toString`.
+      case TreeKind.ErrorTree(_) =>
+        DocAst.Expr.App(DocAst.Expr.AsIs("ErrorTree"), children.iterator.map(print).toList)
+      case other =>
+        DocAst.Expr.App(DocAst.Expr.AsIs(other.toString), children.iterator.map(print).toList)
+    }
+  }
+
+  private def print(token: Token): DocAst.Expr = token.kind match {
+    // Err is not a case object, so we can't rely on the generated `toString`.
+    case TokenKind.Err(_) =>
+      DocAst.Expr.AsIs("Err")
+    case other =>
+      DocAst.Expr.AsIs(other.toString)
+  }
+
+  private def print(child: SyntaxTree.Child): DocAst.Expr = child match {
+    case token: Token => print(token)
+    case tree: SyntaxTree.Tree => print(tree)
+    case _ => DocAst.Expr.Unknown
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -20,7 +20,7 @@ object TypedAstPrinter {
       case TypedAst.Def(sym, TypedAst.Spec(_, ann, mod, _, fparams, _, retTpe, eff, _, _), exp, _) =>
         DocAst.Def(ann, mod, sym, fparams.map(printFormalParam), TypePrinter.print(retTpe), TypePrinter.printAsEffect(eff), print(exp))
     }.toList
-    DocAst.Program(enums, defs)
+    DocAst.Program(enums, defs, Nil)
   }
 
   /**


### PR DESCRIPTION
Now you can see the syntax tree (also fixed stack blowup for ast printer)

```scala
enum Opt[t] {
    case None
    case Some(t, Opt[t])
}
```
gives
```scala
/* ..\test.flix */ Root(
    UseOrImportList(),
    Enum(
        Doc(),
        AnnotationList(),
        ModifierList(),
        KeywordEnum["enum"],
        Ident(NameUpperCase["Opt"]),
        TypeParameterList(
            BracketL["["],
            Parameter(Ident(NameLowerCase["t"])),
            BracketR["]"]
        ),
        CurlyL["{"],
        Case(Doc(), KeywordCase["case"], Ident(NameUpperCase["None"])),
        Case(
            Doc(),
            KeywordCase["case"],
            Ident(NameUpperCase["Some"]),
            Type(
                Tuple(
                    ParenL["("],
                    Type(Variable(NameLowerCase["t"])),
                    Comma[","],
                    Type(
                        Apply(
                            Type(QName(Ident(NameUpperCase["Opt"]))),
                            ArgumentList(
                                BracketL["["],
                                Argument(Type(Variable(NameLowerCase["t"]))),
                                BracketR["]"]
                            )
                        )
                    ),
                    ParenR[")"]
                )
            )
        ),
        CurlyR["}"]
    )
)
```