### PR TITLE
feat: support mkUseStruct as a code action

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -42,7 +42,7 @@ object CodeActionProvider {
       mkUseEffect(qn.ident, uri, ap)
 
     case ResolutionError.UndefinedStruct(qn, ap, loc) if overlaps(range, loc) =>
-      mkNewStruct(qn.ident.name, uri, ap)
+      mkUseStruct(qn.ident, uri, ap) ++ mkNewStruct(qn.ident.name, uri, ap)
 
     case ResolutionError.UndefinedJvmClass(name, ap, _, loc) if overlaps(range, loc) =>
       mkImportJava(Name.mkQName(name), uri, ap)
@@ -197,6 +197,16 @@ object CodeActionProvider {
     }
 
     mkUseSym(ident, names, syms, uri, ap)
+  }
+
+  /**
+    * Returns a code action that proposes to `use` a struct.
+    */
+  private def mkUseStruct(ident: Name.Ident, str1: String, position: AnchorPosition)(implicit root: Root): List[CodeAction] = {
+    val syms = root.structs.map {
+      case (sym, _) => sym
+    }
+    mkUseSym(ident, syms.map(_.name), syms, str1, position)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -202,11 +202,11 @@ object CodeActionProvider {
   /**
     * Returns a code action that proposes to `use` a struct.
     */
-  private def mkUseStruct(ident: Name.Ident, str1: String, position: AnchorPosition)(implicit root: Root): List[CodeAction] = {
+  private def mkUseStruct(ident: Name.Ident, uri: String, position: AnchorPosition)(implicit root: Root): List[CodeAction] = {
     val syms = root.structs.map {
       case (sym, _) => sym
     }
-    mkUseSym(ident, syms.map(_.name), syms, str1, position)
+    mkUseSym(ident, syms.map(_.name), syms, uri, position)
   }
 
   /**


### PR DESCRIPTION
fixes #9270
Preview:
<img width="323" alt="image" src="https://github.com/user-attachments/assets/3a8d8e3c-5afc-42b6-9e24-9b22af9a4f79">
<img width="390" alt="image" src="https://github.com/user-attachments/assets/8d6768b6-637d-469a-a761-05e3f5bac2a1">

Shall we keep the trailing ';'?