### PR TITLE
feat: support effects and structs in mkUseType

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -190,9 +190,10 @@ object CodeActionProvider {
     val names = root.enums.map { case (sym, _) => sym.name } ++
       root.restrictableEnums.map { case (sym, _) => sym.name } ++
       root.traits.map { case (sym, _) => sym.name } ++
-      root.typeAliases.map { case (sym, _) => sym.name }
+      root.typeAliases.map { case (sym, _) => sym.name } ++
+      root.effects.map { case (sym, _) => sym.name }
 
-    val syms = (root.enums ++ root.restrictableEnums ++ root.traits ++ root.typeAliases).map {
+    val syms = (root.enums ++ root.restrictableEnums ++ root.traits ++ root.typeAliases ++ root.effects).map {
       case (sym, _) => sym
     }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -191,9 +191,10 @@ object CodeActionProvider {
       root.restrictableEnums.map { case (sym, _) => sym.name } ++
       root.traits.map { case (sym, _) => sym.name } ++
       root.typeAliases.map { case (sym, _) => sym.name } ++
-      root.effects.map { case (sym, _) => sym.name }
+      root.effects.map { case (sym, _) => sym.name } ++
+      root.structs.map {case (sym, _) => sym.name}
 
-    val syms = (root.enums ++ root.restrictableEnums ++ root.traits ++ root.typeAliases ++ root.effects).map {
+    val syms = (root.enums ++ root.restrictableEnums ++ root.traits ++ root.typeAliases ++ root.effects ++ root.structs).map {
       case (sym, _) => sym
     }
 


### PR DESCRIPTION
fixes #9271 fixes #9272
Preview:

effect
<img width="273" alt="image" src="https://github.com/user-attachments/assets/301d89a0-d85d-455e-9dd0-e2c7623fc22b">
<img width="345" alt="image" src="https://github.com/user-attachments/assets/a42056e6-c11e-4e5a-85b6-dd38bac72b89">

struct
<img width="294" alt="image" src="https://github.com/user-attachments/assets/5684d6ad-c77a-414a-bb0f-4ec06f563c50">
<img width="265" alt="image" src="https://github.com/user-attachments/assets/ec98a443-db19-4040-bae3-2c7e7399c4c0">
