### PR TITLE
feat: Introduce AutoUseCompleter, now support def

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -127,7 +127,7 @@ object CompletionProvider {
       // Imports.
       //
       case err: ResolutionError.UndefinedJvmClass => ImportCompleter.getCompletions(err)
-      case err: ResolutionError.UndefinedName => AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err)
+      case err: ResolutionError.UndefinedName => AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err) ++ AutoUseCompleter.getCompletions(err, ctx)
       case err: ResolutionError.UndefinedType => AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err)
       case err: TypeError.FieldNotFound => MagicMatchCompleter.getCompletions(err)
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -127,7 +127,7 @@ object CompletionProvider {
       // Imports.
       //
       case err: ResolutionError.UndefinedJvmClass => ImportCompleter.getCompletions(err)
-      case err: ResolutionError.UndefinedName => AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err) ++ AutoUseCompleter.getCompletions(err, ctx)
+      case err: ResolutionError.UndefinedName => AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err) ++ AutoUseCompleter.getCompletions(err)
       case err: ResolutionError.UndefinedType => AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err)
       case err: TypeError.FieldNotFound => MagicMatchCompleter.getCompletions(err)
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
@@ -46,14 +46,14 @@ object AutoUseCompleter {
     *  }}}
     */
   def getCompletions(err: ResolutionError.UndefinedName, ctx: CompletionContext)(implicit root: TypedAst.Root): Iterable[Completion] =
-    defCompletions(err.qn.ident.name, err.env, err.ap, ctx)
+    defCompletions(err.env, err.ap, ctx)
 
   /**
     * Returns a List of Completion for defs.
     */
-  private def defCompletions(word: String, env: LocalScope, ap: AnchorPosition, ctx: CompletionContext)(implicit root: TypedAst.Root): Iterable[AutoUseDefCompletion] = {
+  private def defCompletions(env: LocalScope, ap: AnchorPosition, ctx: CompletionContext)(implicit root: TypedAst.Root): Iterable[AutoUseDefCompletion] = {
     root.defs.values
-      .filter(decl => matchesDef(decl, word, ctx.uri) && outOfScope(decl, env))
+      .filter(decl => matchesDef(decl, ctx.word, ctx.uri) && outOfScope(decl, env))
       .map(Completion.AutoUseDefCompletion(_,ap))
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
@@ -58,7 +58,7 @@ object AutoUseCompleter {
       .map { decl =>
         val path = decl.sym.toString
         val name = decl.sym.name
-        val label = s"${name} (use ${path})"
+        val label = s"$name (use $path)"
         Completion.AutoUseCompletion(label, name, path, ap, Function)
       }
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
@@ -15,8 +15,7 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.api.lsp.CompletionItemKind.Function
-import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.AutoUseCompletion
+import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.AutoUseDefCompletion
 import ca.uwaterloo.flix.language.ast.TypedAst
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Def
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, Resolution, LocalScope}
@@ -46,21 +45,16 @@ object AutoUseCompleter {
     *    let s = bar
     *  }}}
     */
-  def getCompletions(err: ResolutionError.UndefinedName, ctx: CompletionContext)(implicit root: TypedAst.Root): Iterable[AutoUseCompletion] =
+  def getCompletions(err: ResolutionError.UndefinedName, ctx: CompletionContext)(implicit root: TypedAst.Root): Iterable[Completion] =
     defCompletions(err.qn.ident.name, err.env, err.ap, ctx)
 
   /**
     * Returns a List of Completion for defs.
     */
-  private def defCompletions(word: String, env: LocalScope, ap: AnchorPosition, ctx: CompletionContext)(implicit root: TypedAst.Root): Iterable[AutoUseCompletion] = {
+  private def defCompletions(word: String, env: LocalScope, ap: AnchorPosition, ctx: CompletionContext)(implicit root: TypedAst.Root): Iterable[AutoUseDefCompletion] = {
     root.defs.values
       .filter(decl => matchesDef(decl, word, ctx.uri) && outOfScope(decl, env))
-      .map { decl =>
-        val path = decl.sym.toString
-        val name = decl.sym.name
-        val label = s"$name (use $path)"
-        Completion.AutoUseCompletion(label, name, path, ap, Function)
-      }
+      .map(Completion.AutoUseDefCompletion(_,ap))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
@@ -78,7 +78,7 @@ object AutoUseCompleter {
     val isPublic = decl.spec.mod.isPublic && !isInternal(decl)
     val isNamespace = word.nonEmpty && word.head.isUpper
     val isMatch = if (isNamespace)
-      decl.sym.toString.startsWith(word)
+      false
     else
       decl.sym.text.startsWith(word)
     val isInFile = decl.sym.loc.source.name == uri

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Chenhao Gao
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.api.lsp.provider.completion
+
+import ca.uwaterloo.flix.api.lsp.CompletionItemKind.Function
+import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.AutoUseCompletion
+import ca.uwaterloo.flix.language.ast.TypedAst
+import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Def
+import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, Resolution, LocalScope}
+import ca.uwaterloo.flix.language.errors.ResolutionError
+
+object AutoUseCompleter {
+
+  /**
+    * Returns a list of auto-use completions to complete the name and use the flix construct.
+    *
+    * Example:
+    *  If we have an undefined name which is the prefix of an existing and unused flix function
+    *
+    *  {{{
+    *    mod A{
+    *      pub def bar(): Unit = ???
+    *    }
+    *    ...
+    *    let s = ba // undefined name error
+    *  }}}
+    *
+    *  We propose to complete the name to `bar` and use the function `A.bar`
+    *
+    *  {{{
+    *    use A.bar;
+    *    ...
+    *    let s = bar
+    *  }}}
+    */
+  def getCompletions(err: ResolutionError.UndefinedName, ctx: CompletionContext)(implicit root: TypedAst.Root): Iterable[AutoUseCompletion] =
+    defCompletions(err.qn.ident.name, err.env, err.ap, ctx)
+
+  /**
+    * Returns a List of Completion for defs.
+    */
+  private def defCompletions(word: String, env: LocalScope, ap: AnchorPosition, ctx: CompletionContext)(implicit root: TypedAst.Root): Iterable[AutoUseCompletion] = {
+    root.defs.values
+      .filter(decl => matchesDef(decl, word, ctx.uri) && outOfScope(decl, env))
+      .map { decl =>
+        val path = decl.sym.toString
+        val name = decl.sym.name
+        val label = s"${name} (use ${path})"
+        Completion.AutoUseCompletion(label, name, path, ap, Function)
+      }
+  }
+
+  /**
+    * Returns `true` if the given definition `decl` is not in the given `scope`.
+    */
+  private def outOfScope(decl: TypedAst.Def, scope: LocalScope): Boolean = {
+    val thisName = decl.sym.toString
+    scope.m.values.forall(_.exists {
+      case Resolution.Declaration(Def(thatName, _, _, _)) =>
+        thisName != thatName.toString
+      case _ => true
+    })
+  }
+
+  /**
+    * Returns `true` if the given definition `decl` should be included in the suggestions.
+    */
+  private def matchesDef(decl: TypedAst.Def, word: String, uri: String): Boolean = {
+    def isInternal(decl: TypedAst.Def): Boolean = decl.spec.ann.isInternal
+
+    val isPublic = decl.spec.mod.isPublic && !isInternal(decl)
+    val isNamespace = word.nonEmpty && word.head.isUpper
+    val isMatch = if (isNamespace)
+      decl.sym.toString.startsWith(word)
+    else
+      decl.sym.text.startsWith(word)
+    val isInFile = decl.sym.loc.source.name == uri
+
+    isMatch && (isPublic || isInFile)
+  }
+
+}

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -169,6 +169,16 @@ sealed trait Completion {
         additionalTextEdits = List(Completion.mkTextEdit(ap, s"import $path"))
       )
 
+    case Completion.AutoUseCompletion(label, name, path, ap, kind) =>
+      CompletionItem(
+        label               = label,
+        sortText            = Priority.toSortText(Priority.Lower, name),
+        textEdit            = TextEdit(context.range, name),
+        insertTextFormat    = InsertTextFormat.PlainText,
+        kind                = kind,
+        additionalTextEdits = List(Completion.mkTextEdit(ap, s"use $path;"))
+      )
+
     case Completion.SnippetCompletion(name, snippet, documentation) =>
       CompletionItem(
         label            = name,
@@ -561,6 +571,17 @@ object Completion {
     * @param shouldImport  a boolean indicating whether the completion should be imported.
     */
   case class AutoImportCompletion(label: String, name:String, path: String, ap: AnchorPosition, documentation: Option[String]) extends Completion
+
+  /**
+   * Represents an auto-import completion.
+   *
+   * @param label         the label of the completion, displayed in the completion item.
+   * @param name          the name to be completed under cursor.
+   * @param path          the path of a flix construct to be used.
+   * @param ap            the anchor position for the use statement.
+   * @param kind          the kind of the completion.
+   */
+  case class AutoUseCompletion(label: String, name:String, path: String, ap: AnchorPosition, kind: CompletionItemKind) extends Completion
 
   /**
     * Represents a Snippet completion

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
@@ -46,7 +46,7 @@ object DefCompleter {
     val isMatch = if (isNamespace)
       decl.sym.toString.startsWith(word)
     else
-      decl.sym.text.startsWith(word)
+      false
     val isInFile = decl.sym.loc.source.name == uri
 
     isMatch && (isPublic || isInFile)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
@@ -42,13 +42,10 @@ object DefCompleter {
     def isInternal(decl: TypedAst.Def): Boolean = decl.spec.ann.isInternal
 
     val isPublic = decl.spec.mod.isPublic && !isInternal(decl)
-    val isNamespace = word.nonEmpty && word.head.isUpper
-    val isMatch = if (isNamespace)
-      decl.sym.toString.startsWith(word)
-    else
-      false
     val isInFile = decl.sym.loc.source.name == uri
+    val isNamespace = word.nonEmpty && word.head.isUpper
+    val isMatch = decl.sym.toString.startsWith(word)
 
-    isMatch && (isPublic || isInFile)
+    isNamespace && isMatch && (isPublic || isInFile)
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
@@ -23,7 +23,6 @@ import ca.uwaterloo.flix.language.ast.TypedAst
 object ExprCompleter {
 
   def getCompletions(context: CompletionContext)(implicit flix: Flix, index: Index, root: TypedAst.Root): Iterable[Completion] = {
-//    DefCompleter.getCompletions(context) ++
       LabelCompleter.getCompletions(context) ++
       KeywordCompleter.getExprKeywords ++
       SignatureCompleter.getCompletions(context) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
@@ -23,6 +23,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst
 object ExprCompleter {
 
   def getCompletions(context: CompletionContext)(implicit flix: Flix, index: Index, root: TypedAst.Root): Iterable[Completion] = {
+      DefCompleter.getCompletions(context) ++
       LabelCompleter.getCompletions(context) ++
       KeywordCompleter.getExprKeywords ++
       SignatureCompleter.getCompletions(context) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
@@ -23,7 +23,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst
 object ExprCompleter {
 
   def getCompletions(context: CompletionContext)(implicit flix: Flix, index: Index, root: TypedAst.Root): Iterable[Completion] = {
-    DefCompleter.getCompletions(context) ++
+//    DefCompleter.getCompletions(context) ++
       LabelCompleter.getCompletions(context) ++
       KeywordCompleter.getExprKeywords ++
       SignatureCompleter.getCompletions(context) ++


### PR DESCRIPTION
first step for #9347.

Preview:
<img width="411" alt="image" src="https://github.com/user-attachments/assets/99d50c8c-ffda-4a80-9de7-b8b14950b747">
<img width="389" alt="image" src="https://github.com/user-attachments/assets/d3810c17-da0a-45f0-bf84-6a5bc40e2d43">
<img width="575" alt="image" src="https://github.com/user-attachments/assets/41bf41b1-e3ab-4483-8e92-845dfdd902e9">

Currently we use `AutoUseCompletion` to provide the option, but we can actually make the completion option more informative if we design a specific completion for it.