### PR TITLE
feat: make AutoUseCompletion more readable

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -176,7 +176,7 @@ sealed trait Completion {
       val useTextEdit = Completion.mkTextEdit(ap, s"use $qualifiedName;")
       val labelDetails = CompletionItemLabelDetails(
         Some(CompletionUtils.getLabelForSpec(decl.spec)(flix)),
-        Some(qualifiedName))
+        Some(s" use $qualifiedName"))
       CompletionItem(
         label               = name,
         labelDetails        = Some(labelDetails),

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.api.lsp.{CompletionItem, CompletionItemKind, InsertTextFormat, Position, Range, TextEdit}
+import ca.uwaterloo.flix.api.lsp.{CompletionItem, CompletionItemKind, CompletionItemLabelDetails, InsertTextFormat, Position, Range, TextEdit}
 import ca.uwaterloo.flix.language.ast.Symbol.{EnumSym, ModuleSym, StructSym, TypeAliasSym}
 import ca.uwaterloo.flix.language.ast.shared.AnchorPosition
 import ca.uwaterloo.flix.language.ast.{Name, ResolvedAst, SourceLocation, Symbol, Type, TypedAst}
@@ -174,9 +174,12 @@ sealed trait Completion {
       val name = decl.sym.name
       val snippet = CompletionUtils.getApplySnippet(name, decl.spec.fparams)(context)
       val useTextEdit = Completion.mkTextEdit(ap, s"use $qualifiedName;")
-      val label = CompletionUtils.getLabelForNameAndSpec(name, decl.spec)(flix) + s" (use $qualifiedName)"
+      val labelDetails = CompletionItemLabelDetails(
+        Some(CompletionUtils.getLabelForSpec(decl.spec)(flix)),
+        Some(qualifiedName))
       CompletionItem(
-        label               = label,
+        label               = name,
+        labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(Priority.Lower, qualifiedName),
         filterText          = Some(CompletionUtils.getFilterTextForName(qualifiedName)),
         textEdit            = TextEdit(context.range, snippet),

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -35,7 +35,9 @@ object CompletionUtils {
     }
   }
 
-  def getLabelForNameAndSpec(name: String, spec: TypedAst.Spec)(implicit flix: Flix): String = spec match {
+  def getLabelForNameAndSpec(name: String, spec: TypedAst.Spec)(implicit flix: Flix): String = name + getLabelForSpec(spec)
+
+  def getLabelForSpec(spec: TypedAst.Spec)(implicit flix: Flix): String = spec match {
     case TypedAst.Spec(_, _, _, _, fparams, _, retTpe0, eff0, _, _) =>
       val args = if (isUnitFunction(fparams))
         Nil
@@ -51,7 +53,7 @@ object CompletionUtils {
         case p => raw" \ " + FormatType.formatType(p)
       }
 
-      s"$name(${args.mkString(", ")}): $retTpe$eff"
+      s"(${args.mkString(", ")}): $retTpe$eff"
   }
 
   /**


### PR DESCRIPTION
second step for #9365
Preview:
<img width="933" alt="image" src="https://github.com/user-attachments/assets/4309f613-00cb-4639-8095-c26cbf8127e6">

Shall we add an extra space between the function name and the parameters? Or anything others?

Another example:
<img width="615" alt="image" src="https://github.com/user-attachments/assets/6ece7bff-669e-419a-bd1d-ac40ee5e4489">
sometimes a long parameter list will obscure the qualified name :( Maybe we should set an upper bound for the parameter list?