### PR TITLE
feat: rework spawn

### DIFF
--- a/examples/concurrency-and-parallelism/select-with-defaults-and-timers.flix
+++ b/examples/concurrency-and-parallelism/select-with-defaults-and-timers.flix
@@ -1,5 +1,5 @@
 /// Sends the value `x` on the channel `c` after a delay.
-def slow(x: Int32, tx: Sender[Int32, r]): Unit \ { r, IO } =
+def slow(x: Int32, tx: Sender[Int32]): Unit \ { Global, IO } =
     use Time.Duration.fromSeconds;
     Thread.sleep(fromSeconds(10));
     Channel.send(x, tx);
@@ -7,7 +7,7 @@ def slow(x: Int32, tx: Sender[Int32, r]): Unit \ { r, IO } =
 
 /// Reads a value from the channel `c`.
 /// Returns the default value `1` if `c` is not ready.
-def recvWithDefault(rx: Receiver[Int32, r]): Int32 \ r =
+def recvWithDefault(rx: Receiver[Int32]): Int32 \ { Global, NonDet } =
     select {
         case x <- recv(rx) => x
         case _             => 1
@@ -15,9 +15,9 @@ def recvWithDefault(rx: Receiver[Int32, r]): Int32 \ r =
 
 /// Reads a value from the channel `c`.
 /// Returns the default value `2` if after a timeout.
-def recvWithTimeout(rc: Region[r], c: Receiver[Int32, r]): Int32 \ { r, IO } =
+def recvWithTimeout(c: Receiver[Int32]): Int32 \ { Global, NonDet, IO } =
     use Time.Duration.fromSeconds;
-    let t = Channel.timeout(rc, fromSeconds(1));
+    let t = Channel.timeout(fromSeconds(1));
     select {
         case x <- recv(c) => x
         case _ <- recv(t) => 2
@@ -26,10 +26,10 @@ def recvWithTimeout(rc: Region[r], c: Receiver[Int32, r]): Int32 \ { r, IO } =
 /// Creates two channels.
 /// Sends values on both after one minute.
 /// Receives from both using defaults and timeouts.
-def main(): Unit \ IO = region rc {
-    let (tx1, rx1) = Channel.buffered(rc, 1);
-    let (tx2, rx2) = Channel.buffered(rc, 1);
+def main(): Unit \ { Global, NonDet, IO } = region rc {
+    let (tx1, rx1) = Channel.buffered(1);
+    let (tx2, rx2) = Channel.buffered(1);
     spawn slow(123, tx1) @ rc;
     spawn slow(456, tx2) @ rc;
-    (recvWithDefault(rx1) + recvWithTimeout(rc, rx2)) |> println
+    (recvWithDefault(rx1) + recvWithTimeout(rx2)) |> println
 }

--- a/examples/concurrency-and-parallelism/select-with-defaults-and-timers.flix
+++ b/examples/concurrency-and-parallelism/select-with-defaults-and-timers.flix
@@ -26,10 +26,10 @@ def recvWithTimeout(c: Receiver[Int32]): Int32 \ { Global, NonDet, IO } =
 /// Creates two channels.
 /// Sends values on both after one minute.
 /// Receives from both using defaults and timeouts.
-def main(): Unit \ { Global, NonDet, IO } = region rc {
+def main(): Unit \ { Global, NonDet, IO } = {
     let (tx1, rx1) = Channel.buffered(1);
     let (tx2, rx2) = Channel.buffered(1);
-    spawn slow(123, tx1) @ rc;
-    spawn slow(456, tx2) @ rc;
+    spawn slow(123, tx1);
+    spawn slow(456, tx2);
     (recvWithDefault(rx1) + recvWithTimeout(rx2)) |> println
 }

--- a/examples/concurrency-and-parallelism/sending-and-receiving-on-channels.flix
+++ b/examples/concurrency-and-parallelism/sending-and-receiving-on-channels.flix
@@ -1,5 +1,5 @@
 /// A function that sends every element of a list
-def sendAll(l: List[Int32], s: Sender[Int32, r]): Unit \ r + IO =
+def sendAll(l: List[Int32], s: Sender[Int32]): Unit \ Global + IO =
     match l {
         case Nil     => ()
         case x :: xs => Channel.send(x, s); sendAll(xs, s)
@@ -7,16 +7,16 @@ def sendAll(l: List[Int32], s: Sender[Int32, r]): Unit \ r + IO =
 
 /// A function that receives n elements
 /// and collects them into a list.
-def recvN(n: Int32, r: Receiver[Int32, r]): List[Int32] \ r + IO =
+def recvN(n: Int32, r: Receiver[Int32]): List[Int32] \ Global + NonDet =
     match n {
         case 0 => Nil
         case _ => Channel.recv(r) :: recvN(n - 1, r)
     }
 
 /// Spawn a process for send and wait, and print the result.
-def main(): Unit \ IO = region rc {
+def main(): Unit \ Global + IO = region rc {
     let l = 1 :: 2 :: 3 :: Nil;
-    let (tx, rx) = Channel.buffered(rc, 100);
+    let (tx, rx) = Channel.buffered(100);
     spawn sendAll(l, tx) @ rc;
     spawn recvN(List.length(l), rx) @ rc
 }

--- a/examples/concurrency-and-parallelism/sending-and-receiving-on-channels.flix
+++ b/examples/concurrency-and-parallelism/sending-and-receiving-on-channels.flix
@@ -1,5 +1,5 @@
 /// A function that sends every element of a list
-def sendAll(l: List[Int32], s: Sender[Int32]): Unit \ Global + IO =
+def sendAll(l: List[Int32], s: Sender[Int32]): Unit \ Global =
     match l {
         case Nil     => ()
         case x :: xs => Channel.send(x, s); sendAll(xs, s)
@@ -14,9 +14,9 @@ def recvN(n: Int32, r: Receiver[Int32]): List[Int32] \ Global + NonDet =
     }
 
 /// Spawn a process for send and wait, and print the result.
-def main(): Unit \ Global + IO = region rc {
+def main(): Unit \ Global + NonDet = {
     let l = 1 :: 2 :: 3 :: Nil;
     let (tx, rx) = Channel.buffered(100);
-    spawn sendAll(l, tx) @ rc;
-    spawn recvN(List.length(l), rx) @ rc
+    spawn sendAll(l, tx);
+    spawn recvN(List.length(l), rx)
 }

--- a/examples/concurrency-and-parallelism/using-channels-and-select.flix
+++ b/examples/concurrency-and-parallelism/using-channels-and-select.flix
@@ -20,13 +20,13 @@ def hiss(tx: Sender[String], n: Int32): Unit \ Global =
     }
 
 /// Start the animal farm...
-def main(): Unit \ Global + IO + NonDet = region rc {
+def main(): Unit \ Global + IO + NonDet = {
     let (tx1, rx1) = Channel.buffered(10);
     let (tx2, rx2) = Channel.buffered(10);
     let (tx3, rx3) = Channel.buffered(10);
-    spawn mooo(tx1, 0) @ rc;
-    spawn meow(tx2, 3) @ rc;
-    spawn hiss(tx3, 7) @ rc;
+    spawn mooo(tx1, 0);
+    spawn meow(tx2, 3);
+    spawn hiss(tx3, 7);
     select {
         case m <- recv(rx1) => m |> println
         case m <- recv(rx2) => m |> println

--- a/examples/concurrency-and-parallelism/using-channels-and-select.flix
+++ b/examples/concurrency-and-parallelism/using-channels-and-select.flix
@@ -1,29 +1,29 @@
  /// Mooo's `n` times on channel `c`.
-def mooo(tx: Sender[String, r], n: Int32): Unit \ r + IO =
+def mooo(tx: Sender[String], n: Int32): Unit \ Global =
     match n {
         case 0 => ()
         case x => Channel.send("Mooo!", tx); mooo(tx, x - 1)
     }
 
 /// Meow's `n` times on channel `c`.
-def meow(tx: Sender[String, r], n: Int32): Unit \ r + IO =
+def meow(tx: Sender[String], n: Int32): Unit \ Global =
     match n {
         case 0 => ()
         case x => Channel.send("Meow!", tx); meow(tx, x - 1)
     }
 
 /// Hiss'es `n` times on channel `c`.
-def hiss(tx: Sender[String, r], n: Int32): Unit \ r + IO =
+def hiss(tx: Sender[String], n: Int32): Unit \ Global =
     match n {
         case 0 => ()
         case x => Channel.send("Hiss!", tx); hiss(tx, x - 1)
     }
 
 /// Start the animal farm...
-def main(): Unit \ IO = region rc {
-    let (tx1, rx1) = Channel.buffered(rc, 10);
-    let (tx2, rx2) = Channel.buffered(rc, 10);
-    let (tx3, rx3) = Channel.buffered(rc, 10);
+def main(): Unit \ Global + IO + NonDet = region rc {
+    let (tx1, rx1) = Channel.buffered(10);
+    let (tx2, rx2) = Channel.buffered(10);
+    let (tx3, rx3) = Channel.buffered(10);
     spawn mooo(tx1, 0) @ rc;
     spawn meow(tx2, 3) @ rc;
     spawn hiss(tx3, 7) @ rc;

--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -452,8 +452,8 @@ object Indexer {
       }
       i0 ++ i1 ++ Index.occurrenceOf(exp0)
 
-    case Expr.Spawn(exp1, exp2, _, _, _) =>
-      visitExp(exp1) ++ visitExp(exp2) ++ Index.occurrenceOf(exp0)
+    case Expr.Spawn(exp, _, _, _) =>
+      visitExp(exp) ++ Index.occurrenceOf(exp0)
 
     case Expr.ParYield(frags, exp, _, _, _) =>
       val i0 = visitExp(exp) ++ Index.occurrenceOf(exp0)

--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -435,8 +435,8 @@ object Indexer {
           Index.traverse(fparams)(visitFormalParam) ++ visitExp(exp) ++ visitType(tpe) ++ visitType(eff)
       }
 
-    case Expr.NewChannel(exp1, exp2, _, _, _) =>
-      visitExp(exp1) ++ visitExp(exp2) ++ Index.occurrenceOf(exp0)
+    case Expr.NewChannel(exp, _, _, _) =>
+      visitExp(exp) ++ Index.occurrenceOf(exp0)
 
     case Expr.GetChannel(exp, _, _, _) =>
       visitExp(exp) ++ Index.occurrenceOf(exp0)

--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -518,9 +518,8 @@ object Visitor {
         rules.foreach(visitSelectChannelRule)
         default.foreach(visitExpr)
 
-      case Expr.Spawn(exp1, exp2, _, _, _) =>
-        visitExpr(exp1)
-        visitExpr(exp2)
+      case Expr.Spawn(exp, _, _, _) =>
+        visitExpr(exp)
 
       case Expr.ParYield(frags, exp, _, _, _) =>
         visitExpr(exp)

--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -504,9 +504,8 @@ object Visitor {
       case Expr.NewObject(_, _, _, _, methods, _) =>
         methods.foreach(visitJvmMethod)
 
-      case Expr.NewChannel(exp1, exp2, _, _, _) =>
-        visitExpr(exp1)
-        visitExpr(exp2)
+      case Expr.NewChannel(exp, _, _, _) =>
+        visitExpr(exp)
 
       case Expr.GetChannel(exp, _, _, _) =>
         visitExpr(exp)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -581,7 +581,7 @@ object SemanticTokensProvider {
       val d = default.map(visitExp).getOrElse(Iterator.empty)
       rs ++ d
 
-    case Expr.Spawn(exp1, exp2, _, _, _) => visitExp(exp1) ++ visitExp(exp2)
+    case Expr.Spawn(exp, _, _, _) => visitExp(exp)
 
     case Expr.ParYield(frags, exp, _, _, _) =>
       val e0 = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -566,7 +566,7 @@ object SemanticTokensProvider {
         case (acc, m) => acc ++ visitJvmMethod(m)
       }
 
-    case Expr.NewChannel(exp1, exp2, _, _, _) => visitExp(exp1) ++ visitExp(exp2)
+    case Expr.NewChannel(exp, _, _, _) => visitExp(exp)
 
     case Expr.GetChannel(exp, _, _, _) => visitExp(exp)
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeBuiltinCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeBuiltinCompleter.scala
@@ -51,10 +51,10 @@ object TypeBuiltinCompleter {
       // L
       polycompletion("Lazy"    , List("t")         , Priority.Default),
       // R
-      polycompletion("Receiver", List("t", "r")    , Priority.Low),
+      polycompletion("Receiver", List("t")         , Priority.Low),
       polycompletion("Region"  , List("r")         , Priority.High),
       // S
-      polycompletion("Sender"  , List("t", "r")    , Priority.Low),
+      polycompletion("Sender"  , List("t")         , Priority.Low),
       Completion.TypeBuiltinCompletion("String"    , Priority.High),
       // U
       Completion.TypeBuiltinCompletion("Unit"      , Priority.Default),

--- a/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
@@ -177,7 +177,7 @@ object DesugaredAst {
 
     case class NewObject(tpe: Type, methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
-    case class NewChannel(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class NewChannel(exp: Expr, loc: SourceLocation) extends Expr
 
     case class GetChannel(exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
@@ -185,7 +185,7 @@ object DesugaredAst {
 
     case class SelectChannel(rules: List[SelectChannelRule], exp: Option[Expr], loc: SourceLocation) extends Expr
 
-    case class Spawn(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Spawn(exp: Expr, loc: SourceLocation) extends Expr
 
     case class ParYield(frags: List[ParYieldFragment], exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -196,7 +196,7 @@ object KindedAst {
 
     case class SelectChannel(rules: List[SelectChannelRule], default: Option[Expr], tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 
-    case class Spawn(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Spawn(exp: Expr, loc: SourceLocation) extends Expr
 
     case class ParYield(frags: List[ParYieldFragment], exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -188,7 +188,7 @@ object KindedAst {
 
     case class NewObject(name: String, clazz: java.lang.Class[?], methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
-    case class NewChannel(exp1: Expr, exp2: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class NewChannel(exp: Expr, tvar: Type.Var, loc: SourceLocation) extends Expr
 
     case class GetChannel(exp: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -188,7 +188,7 @@ object NamedAst {
 
     case class NewObject(name: String, tpe: Type, methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
-    case class NewChannel(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class NewChannel(exp: Expr, loc: SourceLocation) extends Expr
 
     case class GetChannel(exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -196,7 +196,7 @@ object NamedAst {
 
     case class SelectChannel(rules: List[SelectChannelRule], default: Option[Expr], loc: SourceLocation) extends Expr
 
-    case class Spawn(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Spawn(exp: Expr, loc: SourceLocation) extends Expr
 
     case class ParYield(frags: List[ParYieldFragment], exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -213,7 +213,7 @@ object ResolvedAst {
 
     case class SelectChannel(rules: List[SelectChannelRule], default: Option[Expr], loc: SourceLocation) extends Expr
 
-    case class Spawn(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Spawn(exp: Expr, loc: SourceLocation) extends Expr
 
     case class ParYield(frags: List[ParYieldFragment], exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -205,7 +205,7 @@ object ResolvedAst {
 
     case class NewObject(name: String, clazz: java.lang.Class[?], methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
-    case class NewChannel(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class NewChannel(exp: Expr, loc: SourceLocation) extends Expr
 
     case class GetChannel(exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -36,6 +36,7 @@ object Symbol {
   val Exec: EffectSym = mkEffectSym(Name.RootNS, Ident("Exec", SourceLocation.Unknown))
   val FsRead: EffectSym = mkEffectSym(Name.RootNS, Ident("FsRead", SourceLocation.Unknown))
   val FsWrite: EffectSym = mkEffectSym(Name.RootNS, Ident("FsWrite", SourceLocation.Unknown))
+  val Global: EffectSym = mkEffectSym(Name.RootNS, Ident("Global", SourceLocation.Unknown))
   val IO: EffectSym = mkEffectSym(Name.RootNS, Ident("IO", SourceLocation.Unknown))
   val Net: EffectSym = mkEffectSym(Name.RootNS, Ident("Net", SourceLocation.Unknown))
   val NonDet: EffectSym = mkEffectSym(Name.RootNS, Ident("NonDet", SourceLocation.Unknown))
@@ -45,7 +46,7 @@ object Symbol {
     * The set of all primitive effects defined in the Prelude.
     */
   val PrimitiveEffs: SortedSet[EffectSym] = SortedSet.from(List(
-    Env, Exec, FsRead, FsWrite, IO, Net, NonDet, Sys
+    Env, Exec, FsRead, FsWrite, Global, IO, Net, NonDet, Sys
   ))
 
   /**
@@ -56,6 +57,7 @@ object Symbol {
     case Exec => true
     case FsRead => true
     case FsWrite => true
+    case Global => true
     case IO => true
     case Net => true
     case NonDet => true
@@ -73,6 +75,7 @@ object Symbol {
     case "Exec" => Exec
     case "FsRead" => FsRead
     case "FsWrite" => FsWrite
+    case "Global" => Global
     case "IO" => IO
     case "Net" => Net
     case "NonDet" => NonDet

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -429,6 +429,11 @@ object Type {
   val NonDet: Type = Type.Cst(TypeConstructor.Effect(Symbol.NonDet), SourceLocation.Unknown)
 
   /**
+    * Represents the Global effect.
+    */
+  val Global: Type = Type.Cst(TypeConstructor.Effect(Symbol.Global), SourceLocation.Unknown)
+
+  /**
     * Represents the Sys effect.
     */
   val Sys: Type = Type.Cst(TypeConstructor.Effect(Symbol.Sys), SourceLocation.Unknown)
@@ -761,16 +766,16 @@ object Type {
   def mkEffUniv(loc: SourceLocation): Type = Type.Cst(TypeConstructor.Univ, loc)
 
   /**
-    * Returns the type `Sender[tpe, reg]` with the given optional source location `loc`.
+    * Returns the type `Sender[tpe]` with the given optional source location `loc`.
     */
-  def mkSender(tpe: Type, reg: Type, loc: SourceLocation): Type =
-    Apply(Apply(Cst(TypeConstructor.Sender, loc), tpe, loc), reg, loc)
+  def mkSender(tpe: Type, loc: SourceLocation): Type =
+    Apply(Cst(TypeConstructor.Sender, loc), tpe, loc)
 
   /**
-    * Returns the type `Receiver[tpe, reg]` with the given optional source location `loc`.
+    * Returns the type `Receiver[tpe]` with the given optional source location `loc`.
     */
-  def mkReceiver(tpe: Type, reg: Type, loc: SourceLocation): Type =
-    Apply(Apply(Cst(TypeConstructor.Receiver, loc), tpe, loc), reg, loc)
+  def mkReceiver(tpe: Type, loc: SourceLocation): Type =
+    Apply(Cst(TypeConstructor.Receiver, loc), tpe, loc)
 
   /**
     * Returns the Lazy type with the given source location `loc`.

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -434,6 +434,11 @@ object Type {
   val Global: Type = Type.Cst(TypeConstructor.Effect(Symbol.Global), SourceLocation.Unknown)
 
   /**
+    * The union of the primitive effects.
+    */
+  def PrimitiveEffs: Type = Type.mkUnion(Symbol.PrimitiveEffs.toList.map(sym => Type.Cst(TypeConstructor.Effect(sym), SourceLocation.Unknown)), SourceLocation.Unknown)
+
+  /**
     * Represents the Sys effect.
     */
   val Sys: Type = Type.Cst(TypeConstructor.Effect(Symbol.Sys), SourceLocation.Unknown)

--- a/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypeConstructor.scala
@@ -208,9 +208,9 @@ object TypeConstructor {
   @EliminatedBy(Lowering.getClass)
   case object Sender extends TypeConstructor {
     /**
-      * The shape of a sender is Sender[t, r].
+      * The shape of a sender is Sender[t].
       */
-    def kind: Kind = Kind.Star ->: Kind.Eff ->: Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Star
   }
 
   /**
@@ -219,9 +219,9 @@ object TypeConstructor {
   @EliminatedBy(Lowering.getClass)
   case object Receiver extends TypeConstructor {
     /**
-      * The shape of a sender is Receiver[t, r].
+      * The shape of a sender is Receiver[t].
       */
-    def kind: Kind = Kind.Star ->: Kind.Eff ->: Kind.Star
+    def kind: Kind = Kind.Star ->: Kind.Star
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -230,7 +230,7 @@ object TypedAst {
 
     case class NewObject(name: String, clazz: java.lang.Class[?], tpe: Type, eff: Type, methods: List[JvmMethod], loc: SourceLocation) extends Expr
 
-    case class NewChannel(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class NewChannel(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class GetChannel(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -238,7 +238,7 @@ object TypedAst {
 
     case class SelectChannel(rules: List[SelectChannelRule], default: Option[Expr], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
-    case class Spawn(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Spawn(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class ParYield(frags: List[ParYieldFragment], exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -205,7 +205,7 @@ object WeededAst {
 
     case class Static(loc: SourceLocation) extends Expr
 
-    case class NewChannel(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class NewChannel(exp: Expr, loc: SourceLocation) extends Expr
 
     case class GetChannel(exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -213,7 +213,7 @@ object WeededAst {
 
     case class SelectChannel(rules: List[SelectChannelRule], exp: Option[Expr], loc: SourceLocation) extends Expr
 
-    case class Spawn(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    case class Spawn(exp: Expr, loc: SourceLocation) extends Expr
 
     case class ParYield(frags: List[ParYieldFragment], exp: Expr, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
@@ -101,7 +101,7 @@ object TypedAstOps {
     case Expr.GetChannel(exp, _, _, _) => sigSymsOf(exp)
     case Expr.PutChannel(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
     case Expr.SelectChannel(rules, default, _, _, _) => rules.flatMap(rule => sigSymsOf(rule.chan) ++ sigSymsOf(rule.exp)).toSet ++ default.toSet.flatMap(sigSymsOf)
-    case Expr.Spawn(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
+    case Expr.Spawn(exp, _, _, _) => sigSymsOf(exp)
     case Expr.ParYield(frags, exp, _, _, _) => sigSymsOf(exp) ++ frags.flatMap(f => sigSymsOf(f.exp))
     case Expr.Lazy(exp, _, _) => sigSymsOf(exp)
     case Expr.Force(exp, _, _, _) => sigSymsOf(exp)
@@ -352,8 +352,8 @@ object TypedAstOps {
         case (acc, SelectChannelRule(Binder(sym, _), chan, exp)) => acc ++ ((freeVars(chan) ++ freeVars(exp)) - sym)
       }
 
-    case Expr.Spawn(exp1, exp2, _, _, _) =>
-      freeVars(exp1) ++ freeVars(exp2)
+    case Expr.Spawn(exp, _, _, _) =>
+      freeVars(exp)
 
     case Expr.ParYield(frags, exp, _, _, _) =>
       val freeFragVars = frags.foldLeft(Map.empty[Symbol.VarSym, Type]) {

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
@@ -97,7 +97,7 @@ object TypedAstOps {
     case Expr.GetStaticField(_, _, _, _) => Set.empty
     case Expr.PutStaticField(_, exp, _, _, _) => sigSymsOf(exp)
     case Expr.NewObject(_, _, _, _, methods, _) => methods.flatMap(method => sigSymsOf(method.exp)).toSet
-    case Expr.NewChannel(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
+    case Expr.NewChannel(exp, _, _, _) => sigSymsOf(exp)
     case Expr.GetChannel(exp, _, _, _) => sigSymsOf(exp)
     case Expr.PutChannel(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
     case Expr.SelectChannel(rules, default, _, _, _) => rules.flatMap(rule => sigSymsOf(rule.chan) ++ sigSymsOf(rule.exp)).toSet ++ default.toSet.flatMap(sigSymsOf)
@@ -337,8 +337,8 @@ object TypedAstOps {
         case (acc, JvmMethod(_, fparams, exp, _, _, _)) => acc ++ freeVars(exp) -- fparams.map(_.bnd.sym)
       }
 
-    case Expr.NewChannel(exp1, exp2, _, _, _) =>
-      freeVars(exp1) ++ freeVars(exp2)
+    case Expr.NewChannel(exp, _, _, _) =>
+      freeVars(exp)
 
     case Expr.GetChannel(exp, _, _, _) =>
       freeVars(exp)

--- a/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/DocAst.scala
@@ -234,8 +234,8 @@ object DocAst {
       if (ds.isEmpty) defName else App(defName, ds)
     }
 
-    def Spawn(d1: Expr, d2: Expr): Expr =
-      InRegion(Keyword("spawn", d1), d2)
+    def Spawn(d1: Expr): Expr =
+      Keyword("spawn", d1)
 
     def Cast(d: Expr, tpe: Type): Expr =
       DoubleKeyword("cast", d, "as", Right(tpe))

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/OpPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/OpPrinter.scala
@@ -199,7 +199,7 @@ object OpPrinter {
     case (AtomicOp.RecordExtend(label), List(d1, d2)) => RecordExtend(label, d1, d2)
     case (AtomicOp.ArrayNew, List(d1, d2)) => ArrayNew(d1, d2)
     case (AtomicOp.ArrayLoad, List(d1, d2)) => ArrayLoad(d1, d2)
-    case (AtomicOp.Spawn, List(d1, d2)) => Spawn(d1, d2)
+    case (AtomicOp.Spawn, List(d)) => Spawn(d)
     case (AtomicOp.PutField(field), List(d1, d2)) => JavaPutField(field, d1, d2)
     case (AtomicOp.ArrayStore, List(d1, d2, d3)) => ArrayStore(d1, d2, d3)
     case (AtomicOp.InvokeMethod(method), d :: rs) => JavaInvokeMethod(method, d, rs)

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
@@ -107,7 +107,7 @@ object ResolvedAstPrinter {
     case Expr.GetChannel(_, _) => DocAst.Expr.Unknown
     case Expr.PutChannel(_, _, _) => DocAst.Expr.Unknown
     case Expr.SelectChannel(_, _, _) => DocAst.Expr.Unknown
-    case Expr.Spawn(_, _, _) => DocAst.Expr.Unknown
+    case Expr.Spawn(_, _) => DocAst.Expr.Unknown
     case Expr.ParYield(_, _, _) => DocAst.Expr.Unknown
     case Expr.Lazy(_, _) => DocAst.Expr.Unknown
     case Expr.Force(_, _) => DocAst.Expr.Unknown

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
@@ -103,7 +103,7 @@ object ResolvedAstPrinter {
     case Expr.GetStaticField(_, _) => DocAst.Expr.Unknown
     case Expr.PutStaticField(_, _, _) => DocAst.Expr.Unknown
     case Expr.NewObject(_, _, _, _) => DocAst.Expr.Unknown
-    case Expr.NewChannel(_, _, _) => DocAst.Expr.Unknown
+    case Expr.NewChannel(_, _) => DocAst.Expr.Unknown
     case Expr.GetChannel(_, _) => DocAst.Expr.Unknown
     case Expr.PutChannel(_, _, _) => DocAst.Expr.Unknown
     case Expr.SelectChannel(_, _, _) => DocAst.Expr.Unknown

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -89,7 +89,7 @@ object TypedAstPrinter {
     case Expr.GetChannel(_, _, _, _) => DocAst.Expr.Unknown
     case Expr.PutChannel(_, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.SelectChannel(_, _, _, _, _) => DocAst.Expr.Unknown
-    case Expr.Spawn(exp1, exp2, _, _, _) => DocAst.Expr.Spawn(print(exp1), print(exp2))
+    case Expr.Spawn(exp, _, _, _) => DocAst.Expr.Spawn(print(exp))
     case Expr.ParYield(_, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.Lazy(exp, _, _) => DocAst.Expr.Lazy(print(exp))
     case Expr.Force(exp, _, _, _) => DocAst.Expr.Force(print(exp))

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -85,7 +85,7 @@ object TypedAstPrinter {
     case Expr.GetStaticField(field, _, _, _) => DocAst.Expr.JavaGetStaticField(field)
     case Expr.PutStaticField(field, exp, _, _, _) => DocAst.Expr.JavaPutStaticField(field, print(exp))
     case Expr.NewObject(name, clazz, tpe, _, methods, _) => DocAst.Expr.NewObject(name, clazz, TypePrinter.print(tpe), methods.map(printJvmMethod))
-    case Expr.NewChannel(_, _, _, _, _) => DocAst.Expr.Unknown
+    case Expr.NewChannel(_, _, _, _) => DocAst.Expr.Unknown
     case Expr.GetChannel(_, _, _, _) => DocAst.Expr.Unknown
     case Expr.PutChannel(_, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.SelectChannel(_, _, _, _, _) => DocAst.Expr.Unknown

--- a/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/SafetyError.scala
@@ -160,24 +160,6 @@ object SafetyError {
   }
 
   /**
-    * An error raised to indicate an illegal effect in a spawn expression.
-    *
-    * @param eff the illegal effect.
-    * @param loc the source location of the spawn.
-    */
-  case class IllegalSpawnEffect(eff: Type, loc: SourceLocation)(implicit flix: Flix) extends SafetyError {
-    override def summary: String = "Illegal spawn effect"
-
-    override def message(formatter: Formatter): String = {
-      import formatter.*
-      s""">> Illegal spawn effect: '${red(FormatType.formatType(eff, None))}'. A spawn expression must be pure or have a primitive effect.
-         |
-         |${code(loc, "illegal effect.")}
-         |""".stripMargin
-    }
-  }
-
-  /**
     * An error raised to indicate that the Java class in a catch clause is not a Throwable.
     *
     * @param loc the location of the catch parameter.

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -743,10 +743,9 @@ object Desugar {
       val tpe = Type.mkRegion(Type.IO, loc)
       DesugaredAst.Expr.Region(tpe, loc)
 
-    case WeededAst.Expr.NewChannel(exp1, exp2, loc) =>
-      val e1 = visitExp(exp1)
-      val e2 = visitExp(exp2)
-      Expr.NewChannel(e1, e2, loc)
+    case WeededAst.Expr.NewChannel(exp, loc) =>
+      val e = visitExp(exp)
+      Expr.NewChannel(e, loc)
 
     case WeededAst.Expr.GetChannel(exp, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -761,10 +761,9 @@ object Desugar {
       val es = exp.map(visitExp)
       Expr.SelectChannel(rs, es, loc)
 
-    case WeededAst.Expr.Spawn(exp1, exp2, loc) =>
-      val e1 = visitExp(exp1)
-      val e2 = visitExp(exp2)
-      Expr.Spawn(e1, e2, loc)
+    case WeededAst.Expr.Spawn(exp, loc) =>
+      val e = visitExp(exp)
+      Expr.Spawn(e, loc)
 
     case WeededAst.Expr.ParYield(frags, exp, loc) =>
       val fs = frags.map(visitParYieldFragment)

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
@@ -322,9 +322,8 @@ object EffectVerifier {
       methods.foreach { m => visitExp(m.exp) }
       // TODO Java stuff
       ()
-    case Expr.NewChannel(exp1, exp2, tpe, eff, loc) =>
-      visitExp(exp1)
-      visitExp(exp2)
+    case Expr.NewChannel(exp, tpe, eff, loc) =>
+      visitExp(exp)
       // TODO region stuff
       ()
     case Expr.GetChannel(exp, tpe, eff, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
@@ -340,9 +340,8 @@ object EffectVerifier {
       default.foreach { d => visitExp(d) }
       // TODO region stuff
       ()
-    case Expr.Spawn(exp1, exp2, tpe, eff, loc) =>
-      visitExp(exp1)
-      visitExp(exp2)
+    case Expr.Spawn(exp, tpe, eff, loc) =>
+      visitExp(exp)
       // TODO ?
       ()
     case Expr.ParYield(frags, exp, tpe, eff, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -672,12 +672,10 @@ object Kinder {
       val methods = methods0.map(visitJvmMethod(_, kenv0, taenv, henv0, root))
       KindedAst.Expr.NewObject(name, clazz, methods, loc)
 
-    case ResolvedAst.Expr.NewChannel(exp10, exp20, loc) =>
-      val exp1 = visitExp(exp10, kenv0, taenv, henv0, root)
-      val exp2 = visitExp(exp20, kenv0, taenv, henv0, root)
+    case ResolvedAst.Expr.NewChannel(exp0, loc) =>
+      val exp = visitExp(exp0, kenv0, taenv, henv0, root)
       val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
-      val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-      KindedAst.Expr.NewChannel(exp1, exp2, tvar, evar, loc)
+      KindedAst.Expr.NewChannel(exp, tvar, loc)
 
     case ResolvedAst.Expr.GetChannel(exp0, loc) =>
       val exp = visitExp(exp0, kenv0, taenv, henv0, root)

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -696,10 +696,9 @@ object Kinder {
       val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
       KindedAst.Expr.SelectChannel(rules, exp, tvar, evar, loc)
 
-    case ResolvedAst.Expr.Spawn(exp10, exp20, loc) =>
-      val exp1 = visitExp(exp10, kenv0, taenv, henv0, root)
-      val exp2 = visitExp(exp20, kenv0, taenv, henv0, root)
-      KindedAst.Expr.Spawn(exp1, exp2, loc)
+    case ResolvedAst.Expr.Spawn(exp0, loc) =>
+      val exp = visitExp(exp0, kenv0, taenv, henv0, root)
+      KindedAst.Expr.Spawn(exp, loc)
 
     case ResolvedAst.Expr.ParYield(frags0, exp0, loc) =>
       val frags = frags0.map {

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -655,11 +655,11 @@ object Lowering {
       LoweredAst.Expr.NewObject(name, clazz, t, eff, ms, loc)
 
     // New channel expressions are rewritten as follows:
-    //     chan Int32 10
+    //     $CHANNEL_NEW$(m)
     // becomes a call to the standard library function:
     //     Concurrent/Channel.newChannel(10)
     //
-    case TypedAst.Expr.NewChannel(_, exp, tpe, eff, loc) =>
+    case TypedAst.Expr.NewChannel(exp, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
       mkNewChannelTuple(e, t, eff, loc)
@@ -898,17 +898,15 @@ object Lowering {
       case _ => tpe0 // Performance: Reuse tpe0.
     }
 
-    // Rewrite Sender[t, r] to Concurrent.Channel.Mpmc[t, r]
-    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Sender, loc), tpe1, _), tpe2, _) =>
-      val t1 = visitType(tpe1)
-      val t2 = visitType(tpe2)
-      mkChannelTpe(t1, t2, loc)
+    // Rewrite Sender[t] to Concurrent.Channel.Mpmc[t, IO]
+    case Type.Apply(Type.Cst(TypeConstructor.Sender, loc), tpe, _) =>
+      val t = visitType(tpe)
+      mkChannelTpe(t, loc)
 
-    // Rewrite Receiver[t, r] to Concurrent.Channel.Mpmc[t, r]
-    case Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Receiver, loc), tpe1, _), tpe2, _) =>
-      val t1 = visitType(tpe1)
-      val t2 = visitType(tpe2)
-      mkChannelTpe(t1, t2, loc)
+    // Rewrite Receiver[t] to Concurrent.Channel.Mpmc[t, IO]
+    case Type.Apply(Type.Cst(TypeConstructor.Receiver, loc), tpe, _) =>
+      val t = visitType(tpe)
+      mkChannelTpe(t, loc)
 
     case Type.Apply(tpe1, tpe2, loc) =>
       val t1 = visitType(tpe1)

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -1689,9 +1689,8 @@ object Lowering {
         val loc = e.loc.asSynthetic
         val e1 = mkChannelExp(sym, e.tpe, loc) // The channel `ch`
         val e2 = mkPutChannel(e1, e, Type.IO, loc) // The put exp: `ch <- exp0`.
-        val e3 = LoweredAst.Expr.ApplyAtomic(AtomicOp.Region, List.empty, Type.mkRegion(Type.IO, loc), Type.Pure, loc)
-        val e4 = LoweredAst.Expr.ApplyAtomic(AtomicOp.Spawn, List(e2, e3), Type.Unit, Type.IO, loc) // Spawn the put expression from above i.e. `spawn ch <- exp0`.
-        LoweredAst.Expr.Stm(e4, acc, acc.tpe, Type.mkUnion(e4.eff, acc.eff, loc), loc) // Return a statement expression containing the other spawn expressions along with this one.
+        val e3 = LoweredAst.Expr.ApplyAtomic(AtomicOp.Spawn, List(e2), Type.Unit, Type.IO, loc) // Spawn the put expression from above i.e. `spawn ch <- exp0`.
+        LoweredAst.Expr.Stm(e3, acc, acc.tpe, Type.mkUnion(e3.eff, acc.eff, loc), loc) // Return a statement expression containing the other spawn expressions along with this one.
     }
 
     // Make let bindings `let ch = chan 1;`.

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -719,11 +719,10 @@ object Lowering {
         case ((sym, c), e) => LoweredAst.Expr.Let(sym, c, e, t, eff, loc)
       }
 
-    case TypedAst.Expr.Spawn(exp1, exp2, tpe, eff, loc) =>
-      val e1 = visitExp(exp1)
-      val e2 = visitExp(exp2)
+    case TypedAst.Expr.Spawn(exp, tpe, eff, loc) =>
+      val e = visitExp(exp)
       val t = visitType(tpe)
-      LoweredAst.Expr.ApplyAtomic(AtomicOp.Spawn, List(e1, e2), t, eff, loc)
+      LoweredAst.Expr.ApplyAtomic(AtomicOp.Spawn, List(e), t, eff, loc)
 
     case TypedAst.Expr.ParYield(frags, exp, tpe, eff, loc) =>
       val fs = frags.map {

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -809,10 +809,9 @@ object Namer {
       val e = exp.map(visitExp(_, ns0))
       NamedAst.Expr.SelectChannel(rs, e, loc)
 
-    case DesugaredAst.Expr.Spawn(exp1, exp2, loc) =>
-      val e1 = visitExp(exp1, ns0)
-      val e2 = visitExp(exp2, ns0)
-      NamedAst.Expr.Spawn(e1, e2, loc)
+    case DesugaredAst.Expr.Spawn(exp, loc) =>
+      val e = visitExp(exp, ns0)
+      NamedAst.Expr.Spawn(e, loc)
 
     case DesugaredAst.Expr.ParYield(frags, exp, loc) =>
       val e = visitExp(exp, ns0)

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -791,10 +791,9 @@ object Namer {
       val name = s"Anon$$${flix.genSym.freshId()}"
       NamedAst.Expr.NewObject(name, t, ms, loc)
 
-    case DesugaredAst.Expr.NewChannel(exp1, exp2, loc) =>
-      val e1 = visitExp(exp1, ns0)
-      val e2 = visitExp(exp2, ns0)
-      NamedAst.Expr.NewChannel(e1, e2, loc)
+    case DesugaredAst.Expr.NewChannel(exp, loc) =>
+      val e = visitExp(exp, ns0)
+      NamedAst.Expr.NewChannel(e, loc)
 
     case DesugaredAst.Expr.GetChannel(exp, loc) =>
       val e = visitExp(exp, ns0)

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2634,7 +2634,6 @@ object Parser2 {
       val mark = open()
       expect(TokenKind.KeywordSpawn, SyntacticContext.Expr.OtherExpr)
       expression()
-      scopeName()
       close(mark, TreeKind.Expr.Spawn)
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -225,7 +225,7 @@ object PatMatch {
         val chans = rules.map(_.chan)
         (ruleExps ::: chans ::: default.toList).flatMap(visitExp)
 
-      case Expr.Spawn(exp1, exp2, _, _, _) => List(exp1, exp2).flatMap(visitExp)
+      case Expr.Spawn(exp, _, _, _) => visitExp(exp)
 
       case Expr.ParYield(frags, exp, _, _, loc) =>
         val fragsExps = frags.map(_.exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -216,7 +216,7 @@ object PatMatch {
       case Expr.GetStaticField(_, _, _, _) => Nil
       case Expr.PutStaticField(_, exp, _, _, _) => visitExp(exp)
       case Expr.NewObject(_, _, _, _, methods, _) => methods.flatMap(m => visitExp(m.exp))
-      case Expr.NewChannel(exp1, exp2, _, _, _) => List(exp1, exp2).flatMap(visitExp)
+      case Expr.NewChannel(exp, _, _, _) => visitExp(exp)
       case Expr.GetChannel(exp, _, _, _) => visitExp(exp)
       case Expr.PutChannel(exp1, exp2, _, _, _) => List(exp1, exp2).flatMap(visitExp)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -285,8 +285,8 @@ object PredDeps {
     case Expr.NewObject(_, _, _, _, _, _) =>
       LabelledPrecedenceGraph.empty
 
-    case Expr.NewChannel(exp1, exp2, _, _, _) =>
-      visitExp(exp1) + visitExp(exp2)
+    case Expr.NewChannel(exp, _, _, _) =>
+      visitExp(exp)
 
     case Expr.GetChannel(exp, _, _, _) =>
       visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -304,8 +304,8 @@ object PredDeps {
         case (acc, SelectChannelRule(_, exp1, exp2)) => acc + visitExp(exp1) + visitExp(exp2)
       }
 
-    case Expr.Spawn(exp1, exp2, _, _, _) =>
-      visitExp(exp1) + visitExp(exp2)
+    case Expr.Spawn(exp, _, _, _) =>
+      visitExp(exp)
 
     case Expr.ParYield(frags, exp, _, _, _) =>
       frags.foldLeft(visitExp(exp)) {

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -730,10 +730,8 @@ object Redundancy {
           acc ++ used ++ unusedFParams
       }
 
-    case Expr.NewChannel(exp1, exp2, _, _, _) =>
-      val us1 = visitExp(exp1, env0, rc)
-      val us2 = visitExp(exp2, env0, rc)
-      us1 ++ us2
+    case Expr.NewChannel(exp, _, _, _) =>
+      visitExp(exp, env0, rc)
 
     case Expr.GetChannel(exp, _, _, _) =>
       visitExp(exp, env0, rc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -770,10 +770,8 @@ object Redundancy {
         case (acc, used) => acc ++ used
       }
 
-    case Expr.Spawn(exp1, exp2, _, _, _) =>
-      val us1 = visitExp(exp1, env0, rc)
-      val us2 = visitExp(exp2, env0, rc)
-      us1 ++ us2
+    case Expr.Spawn(exp, _, _, _) =>
+      visitExp(exp, env0, rc)
 
     case Expr.ParYield(frags, exp, _, _, _) =>
       val (used, env1, fvs) = visitParYieldFragments(frags, env0, rc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
@@ -239,8 +239,8 @@ object Regions {
     case Expr.NewObject(_, _, tpe, _, methods, loc) =>
       methods.flatMap(visitJvmMethod) ++ checkType(tpe, loc)
 
-    case Expr.NewChannel(exp1, exp2, tpe, _, loc) =>
-      visitExp(exp1) ++ visitExp(exp2) ++ checkType(tpe, loc)
+    case Expr.NewChannel(exp, tpe, _, loc) =>
+      visitExp(exp) ++ checkType(tpe, loc)
 
     case Expr.GetChannel(exp, tpe, _, loc) =>
       visitExp(exp) ++ checkType(tpe, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Regions.scala
@@ -255,8 +255,8 @@ object Regions {
       val defaultErrors = default.map(visitExp).getOrElse(Nil)
       rulesErrors ++ defaultErrors ++ checkType(tpe, loc)
 
-    case Expr.Spawn(exp1, exp2, tpe, _, loc) =>
-      visitExp(exp1) ++ visitExp(exp2) ++ checkType(tpe, loc)
+    case Expr.Spawn(exp, tpe, _, loc) =>
+      visitExp(exp) ++ checkType(tpe, loc)
 
     case Expr.ParYield(frags, exp, tpe, _, loc) =>
       val fragsErrors = frags.flatMap {

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1390,12 +1390,11 @@ object Resolver {
         case (rs, d) => ResolvedAst.Expr.SelectChannel(rs, d, loc)
       }
 
-    case NamedAst.Expr.Spawn(exp1, exp2, loc) =>
-      val e1Val = resolveExp(exp1, env0)
-      val e2Val = resolveExp(exp2, env0)
-      mapN(e1Val, e2Val) {
-        case (e1, e2) =>
-          ResolvedAst.Expr.Spawn(e1, e2, loc)
+    case NamedAst.Expr.Spawn(exp, loc) =>
+      val eVal = resolveExp(exp, env0)
+      mapN(eVal) {
+        case e =>
+          ResolvedAst.Expr.Spawn(e, loc)
       }
 
     case NamedAst.Expr.ParYield(frags, exp, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1346,11 +1346,10 @@ object Resolver {
           }
       }
 
-    case NamedAst.Expr.NewChannel(exp1, exp2, loc) =>
-      val e1Val = resolveExp(exp1, env0)
-      val e2Val = resolveExp(exp2, env0)
-      mapN(e1Val, e2Val) {
-        case (e1, e2) => ResolvedAst.Expr.NewChannel(e1, e2, loc)
+    case NamedAst.Expr.NewChannel(exp, loc) =>
+      val eVal = resolveExp(exp, env0)
+      mapN(eVal) {
+        case e => ResolvedAst.Expr.NewChannel(e, loc)
       }
 
     case NamedAst.Expr.GetChannel(exp, loc) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -295,13 +295,8 @@ object Safety {
         case SelectChannelRule(_, chan, body) => visitExp(chan) ++ visitExp(body)
       } ++ default.map(visitExp).getOrElse(Nil)
 
-    case Expr.Spawn(exp1, exp2, _, _, _) =>
-      val illegalSpawnEffect = {
-        if (hasControlEffects(exp1.eff)) List(IllegalSpawnEffect(exp1.eff, exp1.loc))
-        else Nil
-      }
-
-      illegalSpawnEffect ++ visitExp(exp1) ++ visitExp(exp2)
+    case Expr.Spawn(exp, _, _, _) =>
+      visitExp(exp)
 
     case Expr.ParYield(frags, exp, _, _, _) =>
       frags.flatMap(fragment => visitExp(fragment.exp)) ++ visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -281,8 +281,8 @@ object Safety {
       val objectErrors = checkObjectImplementation(newObject)
       permissionErrors ++ objectErrors ++ methods.flatMap(method => visitExp(method.exp))
 
-    case Expr.NewChannel(exp1, exp2, _, _, _) =>
-      visitExp(exp1) ++ visitExp(exp2)
+    case Expr.NewChannel(exp, _, _, _) =>
+      visitExp(exp)
 
     case Expr.GetChannel(exp, _, _, _) =>
       visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -135,12 +135,12 @@ object Simplifier {
 
         case AtomicOp.Spawn =>
           // Wrap the expression in a closure: () -> tpe \ ef
-          val List(e1, e2) = es
-          val lambdaTyp = MonoType.Arrow(List(MonoType.Unit), e1.tpe)
+          val List(e) = es
+          val lambdaTyp = MonoType.Arrow(List(MonoType.Unit), e.tpe)
           val fp = SimplifiedAst.FormalParam(Symbol.freshVarSym("_spawn", BoundBy.FormalParam, loc), Modifiers.Empty, MonoType.Unit, loc)
-          val lambdaExp = SimplifiedAst.Expr.Lambda(List(fp), e1, lambdaTyp, loc)
+          val lambdaExp = SimplifiedAst.Expr.Lambda(List(fp), e, lambdaTyp, loc)
           val t = visitType(tpe)
-          SimplifiedAst.Expr.ApplyAtomic(AtomicOp.Spawn, List(lambdaExp, e2), t, Purity.Impure, loc)
+          SimplifiedAst.Expr.ApplyAtomic(AtomicOp.Spawn, List(lambdaExp), t, Purity.Impure, loc)
 
         case AtomicOp.Lazy =>
           // Wrap the expression in a closure: () -> tpe \ Pure

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -348,10 +348,9 @@ object Stratifier {
       val ms = methods.map(visitJvmMethod)
       Expr.NewObject(name, clazz, tpe, eff, ms, loc)
 
-    case Expr.NewChannel(exp1, exp2, tpe, eff, loc) =>
-      val e1 = visitExp(exp1)
-      val e2 = visitExp(exp2)
-      Expr.NewChannel(e1, e2, tpe, eff, loc)
+    case Expr.NewChannel(exp, tpe, eff, loc) =>
+      val e = visitExp(exp)
+      Expr.NewChannel(e, tpe, eff, loc)
 
     case Expr.GetChannel(exp, tpe, eff, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -366,10 +366,9 @@ object Stratifier {
       val rs = rules.map(visitSelectChannelRule)
       Expr.SelectChannel(rs, e, tpe, eff, loc)
 
-    case Expr.Spawn(exp1, exp2, tpe, eff, loc) =>
-      val e1 = visitExp(exp1)
-      val e2 = visitExp(exp2)
-      Expr.Spawn(e1, e2, tpe, eff, loc)
+    case Expr.Spawn(exp, tpe, eff, loc) =>
+      val e = visitExp(exp)
+      Expr.Spawn(e, tpe, eff, loc)
 
     case Expr.ParYield(frags, exp, tpe, eff, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -526,12 +526,11 @@ object TypeReconstruction {
       val d = default.map(visitExp(_))
       TypedAst.Expr.SelectChannel(rs, d, subst(tvar), subst(evar), loc)
 
-    case KindedAst.Expr.Spawn(exp1, exp2, loc) =>
-      val e1 = visitExp(exp1)
-      val e2 = visitExp(exp2)
+    case KindedAst.Expr.Spawn(exp, loc) =>
+      val e = visitExp(exp)
       val tpe = Type.Unit
-      val eff = Type.IO
-      TypedAst.Expr.Spawn(e1, e2, tpe, eff, loc)
+      val eff = e.eff
+      TypedAst.Expr.Spawn(e, tpe, eff, loc)
 
     case KindedAst.Expr.ParYield(frags, exp, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -500,10 +500,10 @@ object TypeReconstruction {
       val ms = methods map visitJvmMethod
       TypedAst.Expr.NewObject(name, clazz, tpe, eff, ms, loc)
 
-    case KindedAst.Expr.NewChannel(exp1, exp2, tvar, evar, loc) =>
-      val e1 = visitExp(exp1)
-      val e2 = visitExp(exp2)
-      TypedAst.Expr.NewChannel(e1, e2, subst(tvar), subst(evar), loc)
+    case KindedAst.Expr.NewChannel(exp, tvar, loc) =>
+      val e = visitExp(exp)
+      val eff = Type.mkUnion(e.eff, Type.Global, loc)
+      TypedAst.Expr.NewChannel(e, subst(tvar), eff, loc)
 
     case KindedAst.Expr.GetChannel(exp, tvar, evar, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
@@ -530,12 +530,11 @@ object TypeReconstruction2 {
       val d = default.map(visitExp(_))
       TypedAst.Expr.SelectChannel(rs, d, subst(tvar), subst(evar), loc)
 
-    case KindedAst.Expr.Spawn(exp1, exp2, loc) =>
-      val e1 = visitExp(exp1)
-      val e2 = visitExp(exp2)
+    case KindedAst.Expr.Spawn(exp, loc) =>
+      val e = visitExp(exp)
       val tpe = Type.Unit
-      val eff = Type.IO
-      TypedAst.Expr.Spawn(e1, e2, tpe, eff, loc)
+      val eff = e.eff
+      TypedAst.Expr.Spawn(e, tpe, eff, loc)
 
     case KindedAst.Expr.ParYield(frags, exp, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
@@ -504,10 +504,10 @@ object TypeReconstruction2 {
       val ms = methods map visitJvmMethod
       TypedAst.Expr.NewObject(name, clazz, tpe, eff, ms, loc)
 
-    case KindedAst.Expr.NewChannel(exp1, exp2, tvar, evar, loc) =>
-      val e1 = visitExp(exp1)
-      val e2 = visitExp(exp2)
-      TypedAst.Expr.NewChannel(e1, e2, subst(tvar), subst(evar), loc)
+    case KindedAst.Expr.NewChannel(exp, tvar, loc) =>
+      val e = visitExp(exp)
+      val eff = Type.mkUnion(e.eff, Type.Global, loc)
+      TypedAst.Expr.NewChannel(e, subst(tvar), eff, loc)
 
     case KindedAst.Expr.GetChannel(exp, tvar, evar, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Verifier.scala
@@ -391,13 +391,12 @@ object Verifier {
           check(expected = MonoType.Region)(actual = tpe, loc)
 
         case AtomicOp.Spawn =>
-          val List(t1, t2) = ts
-          t1 match {
+          val List(t) = ts
+          t match {
             case MonoType.Arrow(List(MonoType.Unit), _) => ()
-            case _ => failMismatchedShape(t1, "Arrow(List(Unit), _)", loc)
+            case _ => failMismatchedShape(t, "Arrow(List(Unit), _)", loc)
           }
 
-          check(expected = MonoType.Region)(actual = t2, loc)
           check(expected = MonoType.Unit)(actual = tpe, loc)
 
         case AtomicOp.GetField(field) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -2172,7 +2172,7 @@ object Weeder2 {
         case ("INT64_GE", e1 :: e2 :: Nil) => Validation.Success(Expr.Binary(SemanticOp.Int64Op.Ge, e1, e2, loc))
         case ("CHANNEL_GET", e1 :: Nil) => Validation.Success(Expr.GetChannel(e1, loc))
         case ("CHANNEL_PUT", e1 :: e2 :: Nil) => Validation.Success(Expr.PutChannel(e1, e2, loc))
-        case ("CHANNEL_NEW", e1 :: e2 :: Nil) => Validation.Success(Expr.NewChannel(e1, e2, loc))
+        case ("CHANNEL_NEW", e :: Nil) => Validation.Success(Expr.NewChannel(e, loc))
         case ("ARRAY_NEW", e1 :: e2 :: e3 :: Nil) => Validation.Success(Expr.ArrayNew(e1, e2, e3, loc))
         case ("ARRAY_LENGTH", e1 :: Nil) => Validation.Success(Expr.ArrayLength(e1, loc))
         case ("ARRAY_LOAD", e1 :: e2 :: Nil) => Validation.Success(Expr.ArrayLoad(e1, e2, loc))

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1942,14 +1942,8 @@ object Weeder2 {
 
     private def visitSpawnExpr(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {
       expect(tree, TreeKind.Expr.Spawn)
-      val scopeName = tryPick(TreeKind.Expr.ScopeName, tree)
-      mapN(pickExpr(tree), traverseOpt(scopeName)(visitScopeName)) {
-        case (expr1, Some(expr2)) =>
-          Expr.Spawn(expr1, expr2, tree.loc)
-        case (expr1, None) =>
-          val error = MissingScope(TokenKind.KeywordSpawn, SyntacticContext.Expr.OtherExpr, loc = tree.loc)
-          sctx.errors.add(error)
-          Expr.Spawn(expr1, Expr.Error(error), tree.loc)
+      mapN(pickExpr(tree)) {
+        case expr => Expr.Spawn(expr, tree.loc)
       }
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -274,8 +274,8 @@ object CodeHinter {
         case SelectChannelRule(_, chan, exp) => visitExp(chan) ++ visitExp(exp)
       } ++ default.map(visitExp).getOrElse(Nil)
 
-    case Expr.Spawn(exp1, exp2, _, _, _) =>
-      visitExp(exp1) ++ visitExp(exp2)
+    case Expr.Spawn(exp, _, _, _) =>
+      visitExp(exp)
 
     case Expr.ParYield(frags, exp, _, _, _) =>
       frags.flatMap {

--- a/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/extra/CodeHinter.scala
@@ -260,8 +260,8 @@ object CodeHinter {
         case JvmMethod(_, _, exp, _, _, _) => visitExp(exp)
       }
 
-    case Expr.NewChannel(exp1, exp2, _, _, _) =>
-      visitExp(exp1) ++ visitExp(exp2)
+    case Expr.NewChannel(exp, _, _, _) =>
+      visitExp(exp)
 
     case Expr.GetChannel(exp, _, _, _) =>
       visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -902,15 +902,13 @@ object ConstraintGen {
         val resEff = evar
         (resTpe, resEff)
 
-      case Expr.Spawn(exp1, exp2, loc) =>
-        // TODO it is unclear what the type rules of spawn should be
-        val regionVar = Type.freshVar(Kind.Eff, loc)
-        val regionType = Type.mkRegion(regionVar, loc)
-        val (_, _) = visitExp(exp1)
-        val (tpe2, _) = visitExp(exp2)
-        c.expectType(expected = regionType, actual = tpe2, exp2.loc)
+      case Expr.Spawn(exp, loc) =>
+        val (_, eff) = visitExp(exp)
+        val allowedEffs = Type.PrimitiveEffs
+        val expectedEff = Type.mkIntersection(Type.freshVar(Kind.Eff, loc), allowedEffs, loc)
+        c.expectType(expectedEff, actual = eff, loc)
         val resTpe = Type.Unit
-        val resEff = Type.mkUnion(Type.IO, regionVar, loc)
+        val resEff = eff
         (resTpe, resEff)
 
       case Expr.ParYield(frags, exp, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -861,50 +861,43 @@ object ConstraintGen {
         val resEff = Type.IO
         (resTpe, resEff)
 
-      case Expr.NewChannel(exp1, exp2, tvar, evar, loc) =>
-        val regionVar = Type.freshVar(Kind.Eff, loc)
-        val regionType = Type.mkRegion(regionVar, loc)
-        val (tpe1, eff1) = visitExp(exp1)
-        val (tpe2, eff2) = visitExp(exp2)
-        c.expectType(expected = regionType, actual = tpe1, exp1.loc)
-        c.expectType(expected = Type.Int32, actual = tpe2, exp2.loc)
-        c.unifyType(evar, regionVar, loc)
-        // TODO unify tvar with return type?
+      case Expr.NewChannel(exp, tvar, loc) =>
+        val elmTpe = Type.freshVar(Kind.Star, loc)
+        val (tpe, eff) = visitExp(exp)
+        c.expectType(expected = Type.Int32, actual = tpe, exp.loc)
+        c.unifyType(tvar, Type.mkTuple(List(Type.mkSender(elmTpe, loc), Type.mkReceiver(elmTpe, loc)), loc), loc)
         val resTpe = tvar
-        val resEff = Type.mkUnion(eff1, eff2, regionVar, loc)
+        val resEff = Type.mkUnion(eff, Type.Global, loc)
         (resTpe, resEff)
 
       case Expr.GetChannel(exp, tvar, evar, loc) =>
-        val regionVar = Type.freshVar(Kind.Eff, loc)
         val elmTpe = Type.freshVar(Kind.Star, loc)
-        val receiverTpe = Type.mkReceiver(elmTpe, regionVar, loc)
+        val receiverTpe = Type.mkReceiver(elmTpe, loc)
         val (tpe, eff) = visitExp(exp)
         c.expectType(expected = receiverTpe, actual = tpe, exp.loc)
         c.unifyType(tvar, elmTpe, loc)
-        c.unifyType(evar, Type.mkUnion(eff, regionVar, loc), loc)
+        c.unifyType(evar, Type.mkUnion(eff, Type.Global, Type.NonDet, loc), loc)
         val resTpe = tvar
         val resEff = evar
         (resTpe, resEff)
 
       case Expr.PutChannel(exp1, exp2, evar, loc) =>
-        val regionVar = Type.freshVar(Kind.Eff, loc)
         val elmTpe = Type.freshVar(Kind.Star, loc)
-        val senderTpe = Type.mkSender(elmTpe, regionVar, loc)
+        val senderTpe = Type.mkSender(elmTpe, loc)
         val (tpe1, eff1) = visitExp(exp1)
         val (tpe2, eff2) = visitExp(exp2)
         c.expectType(expected = senderTpe, actual = tpe1, exp1.loc)
         c.expectType(expected = elmTpe, actual = tpe2, exp2.loc)
-        c.unifyType(evar, Type.mkUnion(eff1, eff2, regionVar, loc), loc)
+        c.unifyType(evar, Type.mkUnion(eff1, eff2, Type.Global, loc), loc)
         val resTpe = Type.mkUnit(loc)
         val resEff = evar
         (resTpe, resEff)
 
       case Expr.SelectChannel(rules, default, tvar, evar, loc) =>
-        val regionVar = Type.freshVar(Kind.Eff, loc)
-        val (ruleTypes, ruleEffs) = rules.map(visitSelectRule(_, regionVar)).unzip
+        val (ruleTypes, ruleEffs) = rules.map(visitSelectRule).unzip
         val (defaultType, eff2) = visitDefaultRule(default, loc)
         c.unifyAllTypes(tvar :: defaultType :: ruleTypes, loc)
-        c.unifyType(evar, Type.mkUnion(regionVar :: eff2 :: ruleEffs, loc), loc)
+        c.unifyType(evar, Type.mkUnion(eff2 :: ruleEffs, loc), loc)
         val resTpe = tvar
         val resEff = evar
         (resTpe, resEff)
@@ -1139,14 +1132,14 @@ object ConstraintGen {
     *
     * Returns the type and effect of the rule.
     */
-  private def visitSelectRule(sr0: KindedAst.SelectChannelRule, regionVar: Type)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
+  private def visitSelectRule(sr0: KindedAst.SelectChannelRule)(implicit c: TypeContext, root: KindedAst.Root, flix: Flix): (Type, Type) = {
     sr0 match {
       case KindedAst.SelectChannelRule(sym, chan, body) =>
         val (chanType, eff1) = visitExp(chan)
         val (bodyType, eff2) = visitExp(body)
-        c.unifyType(chanType, Type.mkReceiver(sym.tvar, regionVar, sym.loc), sym.loc)
+        c.unifyType(chanType, Type.mkReceiver(sym.tvar, sym.loc), sym.loc)
         val resTpe = bodyType
-        val resEff = Type.mkUnion(eff1, eff2, regionVar, body.loc)
+        val resEff = Type.mkUnion(eff1, eff2, Type.Global, Type.NonDet, body.loc)
         (resTpe, resEff)
     }
   }

--- a/main/src/ca/uwaterloo/flix/tools/Summary.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Summary.scala
@@ -265,7 +265,7 @@ object Summary {
     case Expr.SelectChannel(rules, default, _, _, _) => default.map(countCheckedEcasts).sum + rules.map {
       case TypedAst.SelectChannelRule(_, chan, exp) => countCheckedEcasts(chan) + countCheckedEcasts(exp)
     }.sum
-    case Expr.Spawn(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Expr.Spawn(exp, _, _, _) => countCheckedEcasts(exp)
     case Expr.ParYield(frags, exp, _, _, _) => countCheckedEcasts(exp) + frags.map {
       case TypedAst.ParYieldFragment(_, exp, _) => countCheckedEcasts(exp)
     }.sum

--- a/main/src/ca/uwaterloo/flix/tools/Summary.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Summary.scala
@@ -259,7 +259,7 @@ object Summary {
     case Expr.NewObject(_, _, _, _, methods, _) => methods.map {
       case TypedAst.JvmMethod(_, _, exp, _, _, _) => countCheckedEcasts(exp)
     }.sum
-    case Expr.NewChannel(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Expr.NewChannel(exp, _, _, _) => countCheckedEcasts(exp)
     case Expr.GetChannel(exp, _, _, _) => countCheckedEcasts(exp)
     case Expr.PutChannel(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
     case Expr.SelectChannel(rules, default, _, _, _) => default.map(countCheckedEcasts).sum + rules.map {

--- a/main/src/library/Channel.flix
+++ b/main/src/library/Channel.flix
@@ -20,28 +20,28 @@ mod Channel {
     ///
     /// Returns a new buffered channel with capacity for `n` elements.
     ///
-    pub def buffered(rc: Region[r], n: Int32): (Sender[t, r], Receiver[t, r]) \ r =
+    pub def buffered(n: Int32): (Sender[t], Receiver[t]) \ Global =
         let m = if (n < 0) 0 else n;
-        $CHANNEL_NEW$(rc, m)
+        $CHANNEL_NEW$(m)
 
     ///
     /// Returns a new unbuffered channel (i.e. a channel with zero capacity).
     ///
-    pub def unbuffered(rc: Region[r]): (Sender[t, r], Receiver[t, r]) \ r = buffered(rc, 0)
+    pub def unbuffered(): (Sender[t], Receiver[t]) \ Global = buffered(0)
 
     ///
     /// Receives a message from the given channel `r`.
     ///
     /// Blocks until a message is dequeued.
     ///
-    pub def recv(receiver: Receiver[t, r]): t \ r = $CHANNEL_GET$(receiver)
+    pub def recv(receiver: Receiver[t]): t \ {Global, NonDet} = $CHANNEL_GET$(receiver)
 
     ///
     /// Sends the message `m` on the given channel `s`.
     ///
     /// Blocks until the message is enqueued.
     ///
-    pub def send(m: t, sender: Sender[t, r]): Unit \ r with Sendable[t] = $CHANNEL_PUT$(sender, m)
+    pub def send(m: t, sender: Sender[t]): Unit \ Global with Sendable[t] = $CHANNEL_PUT$(sender, m)
 
     ///
     /// Sends the message `m` on the given channel `s`.
@@ -51,14 +51,14 @@ mod Channel {
     /// Identical to `send` but doesn't require `Sendable`.
     /// It is up to programmer to ensure that race conditions cannot arise due to concurrent access to `m`.
     ///
-    pub def unsafeSend(m: t, sender: Sender[t, r]): Unit \ r = $CHANNEL_PUT$(sender, m)
+    pub def unsafeSend(m: t, sender: Sender[t]): Unit \ Global = $CHANNEL_PUT$(sender, m)
 
     ///
     /// Returns a channel that receives the `Unit` message after duration `d`.
     ///
-    pub def timeout(rc: Region[r], d: Duration): Receiver[Unit, r] \ { r, IO } =
-        let (tx, rx) = Channel.unbuffered(rc);
-        spawn { Thread.sleep(d); send((), tx) } @ rc;
+    pub def timeout(d: Duration): Receiver[Unit] \ {Global, IO} =
+        let (tx, rx) = Channel.buffered(1);
+        spawn { Thread.sleep(d); send((), tx) } @ Static;
         rx
 
 }

--- a/main/src/library/Channel.flix
+++ b/main/src/library/Channel.flix
@@ -58,7 +58,7 @@ mod Channel {
     ///
     pub def timeout(d: Duration): Receiver[Unit] \ {Global, IO} =
         let (tx, rx) = Channel.buffered(1);
-        spawn { Thread.sleep(d); send((), tx) } @ Static;
+        spawn { Thread.sleep(d); send((), tx) };
         rx
 
 }

--- a/main/src/library/Prelude.flix
+++ b/main/src/library/Prelude.flix
@@ -62,6 +62,15 @@ pub eff FsWrite
 type alias FileIO = {FsRead, FsWrite}
 
 ///
+/// The uninterpretable Global effect.
+///
+/// The `Global` effect represents a region with a global scope.
+///
+/// The `Global` effect is uninterpretable which means that it cannot be handled.
+///
+pub eff Global
+
+///
 /// The uninterpretable IO effect.
 ///
 /// The `IO` effect represents the actions not described by any other effect.

--- a/main/test/ca/uwaterloo/flix/language/TestFlixErrors.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestFlixErrors.scala
@@ -97,8 +97,8 @@ class TestFlixErrors extends AnyFunSuite with TestUtils {
   test("SpawnedThreadError.04") {
     val input =
       """
-        |def main(): Unit \ IO = region rc {
-        |    let (_tx, rx) = Channel.unbuffered(rc);
+        |def main(): Unit \ IO + Global + NonDet = region rc {
+        |    let (_tx, rx) = Channel.unbuffered();
         |    spawn {
         |        spawn { String.concat(checked_cast(null), "foo") } @ rc
         |    } @ rc;

--- a/main/test/ca/uwaterloo/flix/language/TestFlixErrors.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestFlixErrors.scala
@@ -54,11 +54,11 @@ class TestFlixErrors extends AnyFunSuite with TestUtils {
     expectRuntimeError(result, BackendObjType.HoleError.jvmName.name)
   }
 
-  test("SpawnedThreadError.01") {
+  ignore("SpawnedThreadError.01") {
     val input =
       """
-        |def main(): Unit \ IO = region rc {
-        |    spawn { bug!("Something bad happened") } @ rc;
+        |def main(): Unit \ IO = {
+        |    spawn { bug!("Something bad happened") };
         |    Thread.sleep(Time.Duration.fromSeconds(1))
         |}
       """.stripMargin
@@ -66,13 +66,13 @@ class TestFlixErrors extends AnyFunSuite with TestUtils {
     expectRuntimeError(result, BackendObjType.HoleError.jvmName.name)
   }
 
-  test("SpawnedThreadError.02") {
+  ignore("SpawnedThreadError.02") {
     val input =
       """
-        |def main(): Unit \ IO = region rc {
+        |def main(): Unit \ IO = {
         |    spawn {
-        |        spawn { bug!("Something bad happened")  } @ rc
-        |    } @ rc;
+        |        spawn { bug!("Something bad happened")  }
+        |    };
         |    Thread.sleep(Time.Duration.fromSeconds(1))
         |}
       """.stripMargin
@@ -80,13 +80,13 @@ class TestFlixErrors extends AnyFunSuite with TestUtils {
     expectRuntimeError(result, BackendObjType.HoleError.jvmName.name)
   }
 
-  test("SpawnedThreadError.03") {
+  ignore("SpawnedThreadError.03") {
     val input =
       """
-        |def main(): Unit \ IO = region rc {
+        |def main(): Unit \ IO = {
         |    spawn {
-        |        spawn { String.concat(checked_cast(null), "foo") } @ rc
-        |    } @ rc;
+        |        spawn { String.concat(checked_cast(null), "foo") }
+        |    };
         |    Thread.sleep(Time.Duration.fromSeconds(1))
         |}
       """.stripMargin
@@ -94,14 +94,14 @@ class TestFlixErrors extends AnyFunSuite with TestUtils {
     expectRuntimeError(result, "NullPointerException")
   }
 
-  test("SpawnedThreadError.04") {
+  ignore("SpawnedThreadError.04") {
     val input =
       """
-        |def main(): Unit \ IO + Global + NonDet = region rc {
+        |def main(): Unit \ Global + NonDet = {
         |    let (_tx, rx) = Channel.unbuffered();
         |    spawn {
-        |        spawn { String.concat(checked_cast(null), "foo") } @ rc
-        |    } @ rc;
+        |        spawn { String.concat(checked_cast(null), "foo") }
+        |    };
         |    discard Channel.recv(rx)
         |}
       """.stripMargin

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.phase
 
 import ca.uwaterloo.flix.TestUtils
 import ca.uwaterloo.flix.language.errors.{EntryPointError, SafetyError}
-import ca.uwaterloo.flix.language.errors.SafetyError.{IllegalCatchType, IllegalMethodEffect, IllegalNegativelyBoundWildCard, IllegalNestedTryCatch, IllegalNonPositivelyBoundVar, IllegalPatternInBodyAtom, IllegalRelationalUseOfLatticeVar, IllegalSpawnEffect, IllegalThrowType}
+import ca.uwaterloo.flix.language.errors.SafetyError.{IllegalCatchType, IllegalMethodEffect, IllegalNegativelyBoundWildCard, IllegalNestedTryCatch, IllegalNonPositivelyBoundVar, IllegalPatternInBodyAtom, IllegalRelationalUseOfLatticeVar, IllegalThrowType}
 import ca.uwaterloo.flix.util.Options
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -929,23 +929,6 @@ class TestSafety extends AnyFunSuite with TestUtils {
       """.stripMargin
     val result = compile(input, Options.DefaultTest)
     expectError[IllegalMethodEffect](result)
-  }
-
-  test("IllegalSpawnEffect.01") {
-    val input =
-      """
-        |eff Ask {
-        |    pub def ask(): String
-        |}
-        |
-        |def main(): Unit \ IO =
-        |    region rc {
-        |        spawn Ask.ask() @ rc
-        |    }
-        |
-      """.stripMargin
-    val result = compile(input, Options.DefaultTest)
-    expectError[IllegalSpawnEffect](result)
   }
 
 }

--- a/main/test/flix/Test.Exp.Concurrency.Buffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Buffered.flix
@@ -115,116 +115,116 @@ mod Test.Exp.Concurrency.Buffered {
     }
 
     @test
-    def testBufferedChannelWithSpawn01(): Bool \ Global + IO + NonDet = region rc {
+    def testBufferedChannelWithSpawn01(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.buffered(1);
-        spawn Channel.send((), tx) @ rc;
+        spawn Channel.send((), tx);
         () == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn02(): Bool \ Global + IO + NonDet = region rc {
+    def testBufferedChannelWithSpawn02(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.buffered(1);
-        spawn Channel.send(true, tx) @ rc;
+        spawn Channel.send(true, tx);
         true == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn03(): Bool \ Global + IO + NonDet = region rc {
+    def testBufferedChannelWithSpawn03(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.buffered(1);
-        spawn Channel.send(123.456f32, tx) @ rc;
+        spawn Channel.send(123.456f32, tx);
         123.456f32 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn04(): Bool \ Global + IO + NonDet = region rc {
+    def testBufferedChannelWithSpawn04(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.buffered(1);
-        spawn Channel.send(123.456f64, tx) @ rc;
+        spawn Channel.send(123.456f64, tx);
         123.456f64 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn05(): Bool \ Global + IO + NonDet = region rc {
+    def testBufferedChannelWithSpawn05(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.buffered(1);
-        spawn Channel.send(42i8, tx) @ rc;
+        spawn Channel.send(42i8, tx);
         42i8 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn06(): Bool \ Global + IO + NonDet = region rc {
+    def testBufferedChannelWithSpawn06(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.buffered(1);
-        spawn Channel.send(42i16, tx) @ rc;
+        spawn Channel.send(42i16, tx);
         42i16 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn07(): Bool \ Global + IO + NonDet = region rc {
+    def testBufferedChannelWithSpawn07(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.buffered(1);
-        spawn Channel.send(42i32, tx) @ rc;
+        spawn Channel.send(42i32, tx);
         42i32 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn08(): Bool \ Global + IO + NonDet = region rc {
+    def testBufferedChannelWithSpawn08(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.buffered(1);
-        spawn Channel.send(42i64, tx) @ rc;
+        spawn Channel.send(42i64, tx);
         42i64 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn09(): Bool \ Global + IO + NonDet = region rc {
+    def testBufferedChannelWithSpawn09(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.buffered(1);
-        spawn Channel.send(42ii, tx) @ rc;
+        spawn Channel.send(42ii, tx);
         42ii == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn10(): Bool \ Global + IO + NonDet = region rc {
+    def testBufferedChannelWithSpawn10(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.buffered(1);
-        spawn Channel.send("Hello World!", tx) @ rc;
+        spawn Channel.send("Hello World!", tx);
         "Hello World!" == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn11(): Bool \ Global + IO + NonDet = region rc {
+    def testBufferedChannelWithSpawn11(): Bool \ Global + NonDet = {
         let (tx, rx): (Sender[Option[Int32]], Receiver[Option[Int32]]) = Channel.buffered(1);
-        spawn Channel.send(None, tx) @ rc;
+        spawn Channel.send(None, tx);
         None == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn12(): Bool \ Global + IO + NonDet = region rc {
+    def testBufferedChannelWithSpawn12(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.buffered(1);
-        spawn Channel.send(Some(123), tx) @ rc;
+        spawn Channel.send(Some(123), tx);
         Some(123) == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn13(): Bool \ Global + IO + NonDet = region rc {
+    def testBufferedChannelWithSpawn13(): Bool \ Global + NonDet = {
         let (tx, rx): (Sender[Result[String, Int32]], Receiver[Result[String, Int32]]) = Channel.buffered(1);
-        spawn Channel.send(Ok(123), tx) @ rc;
+        spawn Channel.send(Ok(123), tx);
         Ok(123) == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn14(): Bool \ Global + IO + NonDet = region rc {
+    def testBufferedChannelWithSpawn14(): Bool \ Global + NonDet = {
         let (tx, rx): (Sender[Result[String, Int32]], Receiver[Result[String, Int32]]) = Channel.buffered(1);
-        spawn Channel.send(Err("Goodbye World!"), tx) @ rc;
+        spawn Channel.send(Err("Goodbye World!"), tx);
         Err("Goodbye World!") == Channel.recv(rx)
     }
 
-    @test
-    def testBufferedChannelWithSpawn15(): Bool \ Global + IO + NonDet = region rc {
-        let (tx, rx) = Channel.buffered(1);
-        spawn Channel.unsafeSend(Array#{1, 2, 3} @ rc, tx) @ rc;
-        2 == Array.get(1, Channel.recv(rx))
-    }
-
-    @test
-    def testBufferedChannelWithSpawn16(): Bool \ Global + IO + NonDet = region rc {
-        let (tx1, rx1) = Channel.buffered(1);
-        let (tx2, rx2) = Channel.buffered(1);
-        spawn Channel.unsafeSend(rx2, tx1) @ rc;
-        spawn Channel.send(42, tx2) @ rc;
-        42 == Channel.recv(Channel.recv(rx1))
-    }
+//    @test
+//    def testBufferedChannelWithSpawn15(): Bool \ Global + NonDet = {
+//        let (tx, rx) = Channel.buffered(1);
+//        spawn Channel.unsafeSend(Array#{1, 2, 3} @ rc, tx);
+//        2 == Array.get(1, Channel.recv(rx))
+//    }
+//
+//    @test
+//    def testBufferedChannelWithSpawn16(): Bool \ Global + NonDet = {
+//        let (tx1, rx1) = Channel.buffered(1);
+//        let (tx2, rx2) = Channel.buffered(1);
+//        spawn Channel.unsafeSend(rx2, tx1);
+//        spawn Channel.send(42, tx2);
+//        42 == Channel.recv(Channel.recv(rx1))
+//    }
 }

--- a/main/test/flix/Test.Exp.Concurrency.Buffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Buffered.flix
@@ -1,228 +1,228 @@
 mod Test.Exp.Concurrency.Buffered {
 
     @test
-    def testBufferedChannel01(): Bool \ {} = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannel01(): Bool \ Global + NonDet = {
+        let (tx, rx) = Channel.buffered(1);
         Channel.send((), tx);
         () == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannel02(): Bool \ {} = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannel02(): Bool \ Global + NonDet = {
+        let (tx, rx) = Channel.buffered(1);
         Channel.send(true, tx);
         true == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannel03(): Bool \ {} = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannel03(): Bool \ Global + NonDet = {
+        let (tx, rx) = Channel.buffered(1);
         Channel.send(123.456f32, tx);
         123.456f32 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannel04(): Bool \ {} = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannel04(): Bool \ Global + NonDet = {
+        let (tx, rx) = Channel.buffered(1);
         Channel.send(123.456f64, tx);
         123.456f64 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannel05(): Bool \ {} = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannel05(): Bool \ Global + NonDet = {
+        let (tx, rx) = Channel.buffered(1);
         Channel.send(42i8, tx);
         42i8 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannel06(): Bool \ {} = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannel06(): Bool \ Global + NonDet = {
+        let (tx, rx) = Channel.buffered(1);
         Channel.send(42i16, tx);
         42i16 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannel07(): Bool \ {} = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannel07(): Bool \ Global + NonDet = {
+        let (tx, rx) = Channel.buffered(1);
         Channel.send(42i32, tx);
         42i32 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannel08(): Bool \ {} = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannel08(): Bool \ Global + NonDet = {
+        let (tx, rx) = Channel.buffered(1);
         Channel.send(42i64, tx);
         42i64 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannel09(): Bool \ {} = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannel09(): Bool \ Global + NonDet = {
+        let (tx, rx) = Channel.buffered(1);
         Channel.send(42ii, tx);
         42ii == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannel10(): Bool \ {} = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannel10(): Bool \ Global + NonDet = {
+        let (tx, rx) = Channel.buffered(1);
         Channel.send("Hello World!", tx);
         "Hello World!" == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannel11(): Bool \ {} = region rc {
-        let (tx, rx): (Sender[Option[Int32], _], Receiver[Option[Int32], _]) = Channel.buffered(rc, 1);
+    def testBufferedChannel11(): Bool \ Global + NonDet = {
+        let (tx, rx): (Sender[Option[Int32]], Receiver[Option[Int32]]) = Channel.buffered(1);
         Channel.send(None, tx);
         None == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannel12(): Bool \ {} = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannel12(): Bool \ Global + NonDet = {
+        let (tx, rx) = Channel.buffered(1);
         Channel.send(Some(123), tx);
         Some(123) == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannel13(): Bool \ {} = region rc {
-        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.buffered(rc, 1);
+    def testBufferedChannel13(): Bool \ Global + NonDet = {
+        let (tx, rx): (Sender[Result[String, Int32]], Receiver[Result[String, Int32]]) = Channel.buffered(1);
         Channel.send(Ok(123), tx);
         Ok(123) == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannel14(): Bool \ {} = region rc {
-        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.buffered(rc, 1);
+    def testBufferedChannel14(): Bool \ Global + NonDet = {
+        let (tx, rx): (Sender[Result[String, Int32]], Receiver[Result[String, Int32]]) = Channel.buffered(1);
         Channel.send(Err("Goodbye World!"), tx);
         Err("Goodbye World!") == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannel15(): Bool \ {} = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannel15(): Bool \ Global + NonDet = region rc {
+        let (tx, rx) = Channel.buffered(1);
         Channel.unsafeSend(Array#{1, 2, 3} @ rc, tx);
         2 == Array.get(1, Channel.recv(rx))
     }
 
     @test
-    def testBufferedChannel16(): Bool \ {} = region rc {
-        let (tx1, rx1) = Channel.buffered(rc, 1);
-        let (tx2, rx2) = Channel.buffered(rc, 1);
+    def testBufferedChannel16(): Bool \ Global + NonDet = {
+        let (tx1, rx1) = Channel.buffered(1);
+        let (tx2, rx2) = Channel.buffered(1);
         Channel.unsafeSend(rx2, tx1);
         Channel.send(42, tx2);
         42 == Channel.recv(Channel.recv(rx1))
     }
 
     @test
-    def testBufferedChannelWithSpawn01(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn01(): Bool \ Global + IO + NonDet = region rc {
+        let (tx, rx) = Channel.buffered(1);
         spawn Channel.send((), tx) @ rc;
         () == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn02(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn02(): Bool \ Global + IO + NonDet = region rc {
+        let (tx, rx) = Channel.buffered(1);
         spawn Channel.send(true, tx) @ rc;
         true == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn03(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn03(): Bool \ Global + IO + NonDet = region rc {
+        let (tx, rx) = Channel.buffered(1);
         spawn Channel.send(123.456f32, tx) @ rc;
         123.456f32 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn04(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn04(): Bool \ Global + IO + NonDet = region rc {
+        let (tx, rx) = Channel.buffered(1);
         spawn Channel.send(123.456f64, tx) @ rc;
         123.456f64 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn05(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn05(): Bool \ Global + IO + NonDet = region rc {
+        let (tx, rx) = Channel.buffered(1);
         spawn Channel.send(42i8, tx) @ rc;
         42i8 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn06(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn06(): Bool \ Global + IO + NonDet = region rc {
+        let (tx, rx) = Channel.buffered(1);
         spawn Channel.send(42i16, tx) @ rc;
         42i16 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn07(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn07(): Bool \ Global + IO + NonDet = region rc {
+        let (tx, rx) = Channel.buffered(1);
         spawn Channel.send(42i32, tx) @ rc;
         42i32 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn08(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn08(): Bool \ Global + IO + NonDet = region rc {
+        let (tx, rx) = Channel.buffered(1);
         spawn Channel.send(42i64, tx) @ rc;
         42i64 == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn09(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn09(): Bool \ Global + IO + NonDet = region rc {
+        let (tx, rx) = Channel.buffered(1);
         spawn Channel.send(42ii, tx) @ rc;
         42ii == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn10(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn10(): Bool \ Global + IO + NonDet = region rc {
+        let (tx, rx) = Channel.buffered(1);
         spawn Channel.send("Hello World!", tx) @ rc;
         "Hello World!" == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn11(): Bool \ IO = region rc {
-        let (tx, rx): (Sender[Option[Int32], _], Receiver[Option[Int32], _]) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn11(): Bool \ Global + IO + NonDet = region rc {
+        let (tx, rx): (Sender[Option[Int32]], Receiver[Option[Int32]]) = Channel.buffered(1);
         spawn Channel.send(None, tx) @ rc;
         None == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn12(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn12(): Bool \ Global + IO + NonDet = region rc {
+        let (tx, rx) = Channel.buffered(1);
         spawn Channel.send(Some(123), tx) @ rc;
         Some(123) == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn13(): Bool \ IO = region rc {
-        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn13(): Bool \ Global + IO + NonDet = region rc {
+        let (tx, rx): (Sender[Result[String, Int32]], Receiver[Result[String, Int32]]) = Channel.buffered(1);
         spawn Channel.send(Ok(123), tx) @ rc;
         Ok(123) == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn14(): Bool \ IO = region rc {
-        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn14(): Bool \ Global + IO + NonDet = region rc {
+        let (tx, rx): (Sender[Result[String, Int32]], Receiver[Result[String, Int32]]) = Channel.buffered(1);
         spawn Channel.send(Err("Goodbye World!"), tx) @ rc;
         Err("Goodbye World!") == Channel.recv(rx)
     }
 
     @test
-    def testBufferedChannelWithSpawn15(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn15(): Bool \ Global + IO + NonDet = region rc {
+        let (tx, rx) = Channel.buffered(1);
         spawn Channel.unsafeSend(Array#{1, 2, 3} @ rc, tx) @ rc;
         2 == Array.get(1, Channel.recv(rx))
     }
 
     @test
-    def testBufferedChannelWithSpawn16(): Bool \ IO = region rc {
-        let (tx1, rx1) = Channel.buffered(rc, 1);
-        let (tx2, rx2) = Channel.buffered(rc, 1);
+    def testBufferedChannelWithSpawn16(): Bool \ Global + IO + NonDet = region rc {
+        let (tx1, rx1) = Channel.buffered(1);
+        let (tx2, rx2) = Channel.buffered(1);
         spawn Channel.unsafeSend(rx2, tx1) @ rc;
         spawn Channel.send(42, tx2) @ rc;
         42 == Channel.recv(Channel.recv(rx1))

--- a/main/test/flix/Test.Exp.Concurrency.Select.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Select.flix
@@ -1,8 +1,8 @@
 mod Test.Exp.Concurrency.Select {
 
     @test
-    def testSelectBuffered01(): Bool \ IO = region rc {
-        let (tx1, rx1) = Channel.buffered(rc, 1);
+    def testSelectBuffered01(): Bool \ Global + IO + NonDet = region rc {
+        let (tx1, rx1) = Channel.buffered(1);
         spawn Channel.send(1, tx1) @ rc;
         select {
             case x <- recv(rx1) => x == 1
@@ -10,9 +10,9 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectBuffered02(): Bool \ IO = region rc {
-        let (tx1, rx1) = Channel.buffered(rc, 1);
-        let (tx2, rx2) = Channel.buffered(rc, 1);
+    def testSelectBuffered02(): Bool \ Global + IO + NonDet = region rc {
+        let (tx1, rx1) = Channel.buffered(1);
+        let (tx2, rx2) = Channel.buffered(1);
         spawn Channel.send(1, tx1) @ rc;
         spawn Channel.send(2, tx2) @ rc;
         select {
@@ -22,53 +22,53 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectBuffered03(): Bool \ IO = region rc {
-        let (tx1, rx1) = Channel.buffered(rc, 1);
-        let (tx2, rx2) = Channel.buffered(rc, 1);
-        let (tx3, rx3) = Channel.buffered(rc, 1);
-        spawn Channel.send(1, tx1) @ rc;
-        spawn Channel.send(2, tx2) @ rc;
-        spawn Channel.send(3, tx3) @ rc;
-        select {
-            case x <- recv(rx1) => x == 1
-            case x <- recv(rx2) => x == 2
-            case x <- recv(rx3) => x == 3
-        }
-    }
-
-    @test
-    def testSelectBuffered04(): Bool \ IO = region rc {
-        let (tx1, rx1) = Channel.buffered(rc, 1);
-        let (tx2, rx2) = Channel.buffered(rc, 1);
-        let (tx3, rx3) = Channel.buffered(rc, 1);
-        let (tx4, rx4) = Channel.buffered(rc, 1);
+    def testSelectBuffered03(): Bool \ Global + IO + NonDet = region rc {
+        let (tx1, rx1) = Channel.buffered(1);
+        let (tx2, rx2) = Channel.buffered(1);
+        let (tx3, rx3) = Channel.buffered(1);
         spawn Channel.send(1, tx1) @ rc;
         spawn Channel.send(2, tx2) @ rc;
         spawn Channel.send(3, tx3) @ rc;
-        spawn Channel.send(4, tx4) @ rc;
         select {
             case x <- recv(rx1) => x == 1
-            case x <- recv(rx1) => x == 1
-            case x <- recv(rx2) => x == 2
             case x <- recv(rx2) => x == 2
             case x <- recv(rx3) => x == 3
-            case x <- recv(rx3) => x == 3
-            case x <- recv(rx4) => x == 4
-            case x <- recv(rx4) => x == 4
         }
     }
 
     @test
-    def testSelectBuffered05(): Bool \ IO = region rc {
-        let (tx1, rx1) = Channel.buffered(rc, 1);
-        let (tx2, rx2) = Channel.buffered(rc, 1);
-        let (tx3, rx3) = Channel.buffered(rc, 1);
-        let (tx4, rx4) = Channel.buffered(rc, 1);
+    def testSelectBuffered04(): Bool \ Global + IO + NonDet = region rc {
+        let (tx1, rx1) = Channel.buffered(1);
+        let (tx2, rx2) = Channel.buffered(1);
+        let (tx3, rx3) = Channel.buffered(1);
+        let (tx4, rx4) = Channel.buffered(1);
         spawn Channel.send(1, tx1) @ rc;
         spawn Channel.send(2, tx2) @ rc;
         spawn Channel.send(3, tx3) @ rc;
         spawn Channel.send(4, tx4) @ rc;
         select {
+            case x <- recv(rx1) => x == 1
+            case x <- recv(rx1) => x == 1
+            case x <- recv(rx2) => x == 2
+            case x <- recv(rx2) => x == 2
+            case x <- recv(rx3) => x == 3
+            case x <- recv(rx3) => x == 3
+            case x <- recv(rx4) => x == 4
+            case x <- recv(rx4) => x == 4
+        }
+    }
+
+    @test
+    def testSelectBuffered05(): Bool \ Global + IO + NonDet = region rc {
+        let (tx1, rx1) = Channel.buffered(1);
+        let (tx2, rx2) = Channel.buffered(1);
+        let (tx3, rx3) = Channel.buffered(1);
+        let (tx4, rx4) = Channel.buffered(1);
+        spawn Channel.send(1, tx1) @ rc;
+        spawn Channel.send(2, tx2) @ rc;
+        spawn Channel.send(3, tx3) @ rc;
+        spawn Channel.send(4, tx4) @ rc;
+        select {
             case x <- recv(rx4) => x == 4
             case x <- recv(rx3) => x == 3
             case x <- recv(rx2) => x == 2
@@ -81,11 +81,11 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectBuffered06(): Bool \ IO = region rc {
-        let (_, rx1) = Channel.buffered(rc, 1);
-        let (tx2, rx2) = Channel.buffered(rc, 1);
-        let (_, rx3) = Channel.buffered(rc, 1);
-        let (_, rx4) = Channel.buffered(rc, 1);
+    def testSelectBuffered06(): Bool \ Global + IO + NonDet = region rc {
+        let (_, rx1) = Channel.buffered(1);
+        let (tx2, rx2) = Channel.buffered(1);
+        let (_, rx3) = Channel.buffered(1);
+        let (_, rx4) = Channel.buffered(1);
         spawn Channel.send(1, tx2) @ rc;
         select {
             case _ <- recv(rx4) => false
@@ -96,11 +96,11 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectBuffered07(): Bool \ IO = region rc {
-        let (tx1, rx1) = Channel.buffered(rc, 1);
-        let (tx2, rx2) = Channel.buffered(rc, 1);
-        let (tx3, rx3) = Channel.buffered(rc, 1);
-        let (tx4, rx4) = Channel.buffered(rc, 1);
+    def testSelectBuffered07(): Bool \ Global + IO + NonDet = region rc {
+        let (tx1, rx1) = Channel.buffered(1);
+        let (tx2, rx2) = Channel.buffered(1);
+        let (tx3, rx3) = Channel.buffered(1);
+        let (tx4, rx4) = Channel.buffered(1);
         spawn Channel.send(1i8, tx1) @ rc;
         spawn Channel.send(2i16, tx2) @ rc;
         spawn Channel.send(3i32, tx3) @ rc;
@@ -114,30 +114,30 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectDefault01(): Bool = region rc {
+    def testSelectDefault01(): Bool \ Global + NonDet = {
         select {
-            case x <- recv({let (_, rx) = Channel.buffered(rc, 1); rx}) => x
-            case _                                                     => true
+            case x <- recv({let (_, rx) = Channel.buffered(1); rx}) => x
+            case _                                                  => true
         }
     }
 
     @test
-    def testSelectDefault02(): Bool = region rc {
+    def testSelectDefault02(): Bool \ Global + NonDet = {
         (1 + select {
-            case _ <- recv({let (_, rx) = Channel.buffered(rc, 2); rx}) => 2
-            case _                                                     => 1
+            case _ <- recv({let (_, rx) = Channel.buffered(2); rx}) => 2
+            case _                                                  => 1
         }) == 2
     }
 
-    def recvWithDefault(rx: Receiver[Int32, r]): Int32 \ r = {
+    def recvWithDefault(rx: Receiver[Int32]): Int32 \ Global + NonDet = {
         select {
             case x <- Channel.recv(rx) => x
             case _                     => 1
         }
     }
 
-    def mainx(): Int32 \ IO = {
-      let (_, rx) = Channel.buffered(Static, 1);
+    def mainx(): Int32 \ Global + NonDet = {
+      let (_, rx) = Channel.buffered(1);
       recvWithDefault(rx)
     }
 
@@ -147,20 +147,20 @@ mod Test.Exp.Concurrency.Select {
       unchecked_cast(println(mainx()) as _ \ IO)
 
     @test
-    def testSelectRandom01(): Unit \ IO = region rc {
-        let (tx9, rx9) = Channel.buffered(rc, 0);
-        let (tx10, rx10) = Channel.buffered(rc, 0);
-        let (tx11, rx11) = Channel.buffered(rc, 0);
-        let (tx12, rx12) = Channel.buffered(rc, 0);
-        let (tx13, rx13) = Channel.buffered(rc, 0);
+    def testSelectRandom01(): Unit \ Global + IO + NonDet = region rc {
+        let (tx9, rx9) = Channel.buffered(0);
+        let (tx10, rx10) = Channel.buffered(0);
+        let (tx11, rx11) = Channel.buffered(0);
+        let (tx12, rx12) = Channel.buffered(0);
+        let (tx13, rx13) = Channel.buffered(0);
         spawn { Channel.send((), tx13) ; () } @ rc; spawn { Channel.send((), tx12) ; () } @ rc; spawn { Channel.send((), tx11) ; () } @ rc; spawn { Channel.send((), tx10) ; () } @ rc; spawn { Channel.send((), tx9) ; () } @ rc; select {
         case _ <- recv(rx13) => select {
         case _ <- recv(rx11) => ()
         case _ <- recv(rx11) => ()
-        } ; Channel.recv(rx9) ; Channel.recv(rx10) ; Channel.recv(rx12) ; let (tx42, rx42) = Channel.buffered(rc, 0);
-        let (tx43, rx43) = Channel.buffered(rc, 0);
-        let (tx44, rx44) = Channel.buffered(rc, 0);
-        let (tx45, rx45) = Channel.buffered(rc, 0);
+        } ; Channel.recv(rx9) ; Channel.recv(rx10) ; Channel.recv(rx12) ; let (tx42, rx42) = Channel.buffered(0);
+        let (tx43, rx43) = Channel.buffered(0);
+        let (tx44, rx44) = Channel.buffered(0);
+        let (tx45, rx45) = Channel.buffered(0);
         spawn { Channel.send((), tx45) ; () } @ rc; spawn { Channel.send((), tx44) ; () } @ rc; spawn { Channel.send((), tx43) ; () } @ rc; spawn { Channel.send((), tx42) ; () } @ rc; select {
         case _ <- recv(rx43) => Channel.recv(rx42) ; Channel.recv(rx44) ; Channel.recv(rx45)
         case _ <- recv(rx42) => Channel.recv(rx45) ; Channel.recv(rx43) ; Channel.recv(rx44) ; ()
@@ -168,10 +168,10 @@ mod Test.Exp.Concurrency.Select {
         case _ <- recv(rx13) => select {
         case _ <- recv(rx11) => ()
         case _ <- recv(rx11) => ()
-        } ; Channel.recv(rx9) ; Channel.recv(rx10) ; Channel.recv(rx12) ; let (tx42, rx42) = Channel.buffered(rc, 0);
-        let (tx43, rx43) = Channel.buffered(rc, 0);
-        let (tx44, rx44) = Channel.buffered(rc, 0);
-        let (tx45, rx45) = Channel.buffered(rc, 0);
+        } ; Channel.recv(rx9) ; Channel.recv(rx10) ; Channel.recv(rx12) ; let (tx42, rx42) = Channel.buffered(0);
+        let (tx43, rx43) = Channel.buffered(0);
+        let (tx44, rx44) = Channel.buffered(0);
+        let (tx45, rx45) = Channel.buffered(0);
         spawn { Channel.send((), tx45) ; () } @ rc; spawn { Channel.send((), tx44) ; () } @ rc; spawn { Channel.send((), tx43) ; () } @ rc; spawn { Channel.send((), tx42) ; () } @ rc; select {
         case _ <- recv(rx43) => Channel.recv(rx42) ; Channel.recv(rx44) ; Channel.recv(rx45) ; ()
         case _ <- recv(rx42) => Channel.recv(rx45) ; Channel.recv(rx43) ; Channel.recv(rx44)
@@ -181,11 +181,11 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectRandom02(): Unit \ IO = region rc {
-        let (tx10, rx10) = Channel.buffered(rc, 0);
-        let (tx11, rx11) = Channel.buffered(rc, 0);
-        let (tx12, rx12) = Channel.buffered(rc, 0);
-        let (tx13, rx13) = Channel.buffered(rc, 0);
+    def testSelectRandom02(): Unit \ Global + IO + NonDet = region rc {
+        let (tx10, rx10) = Channel.buffered(0);
+        let (tx11, rx11) = Channel.buffered(0);
+        let (tx12, rx12) = Channel.buffered(0);
+        let (tx13, rx13) = Channel.buffered(0);
         spawn { Channel.send((), tx13) ; () } @ rc; spawn { Channel.send((), tx12) ; () } @ rc; if (false) { spawn { Channel.send((), tx11) ; () } @ rc; spawn { Channel.send((), tx10) ; () } @ rc; if (true) { () } else { () } } else { spawn { Channel.send((), tx11) ; () } @ rc; spawn { Channel.send((), tx10) ; () } @ rc; if (true) { () } else { () } } ; select {
         case _ <- recv(rx10) => Channel.recv(rx13) ; Channel.recv(rx12) ; Channel.recv(rx11)
         case _ <- recv(rx13) => Channel.recv(rx12) ; Channel.recv(rx10) ; Channel.recv(rx11) ; ()
@@ -195,15 +195,15 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectRandom03(): Unit \ IO = region rc {
-        let (tx14, rx14) = Channel.buffered(rc, 0);
-        let (tx15, rx15) = Channel.buffered(rc, 0);
-        let (tx16, rx16) = Channel.buffered(rc, 0);
-        let (tx17, rx17) = Channel.buffered(rc, 0);
-        let (tx18, rx18) = Channel.buffered(rc, 0);
-        spawn { Channel.send((), tx18) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { Channel.send((), tx18) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; let (tx141, rx141) = Channel.buffered(rc, 0);
-        let (tx139, rx139) = Channel.buffered(rc, 0);
-        let (tx140, rx140) = Channel.buffered(rc, 0);
+    def testSelectRandom03(): Unit \ Global + IO = region rc {
+        let (tx14, rx14) = Channel.buffered(0);
+        let (tx15, rx15) = Channel.buffered(0);
+        let (tx16, rx16) = Channel.buffered(0);
+        let (tx17, rx17) = Channel.buffered(0);
+        let (tx18, rx18) = Channel.buffered(0);
+        spawn { Channel.send((), tx18) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { Channel.send((), tx18) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; let (tx141, rx141) = Channel.buffered(0);
+        let (tx139, rx139) = Channel.buffered(0);
+        let (tx140, rx140) = Channel.buffered(0);
         spawn { Channel.send((), tx141) ; () } @ rc; spawn { Channel.send((), tx140) ; () } @ rc; spawn { Channel.send((), tx139) ; () } @ rc; spawn { Channel.send((), tx141) ; () } @ rc; spawn { Channel.send((), tx140) ; () } @ rc; spawn { Channel.send((), tx139) ; () } @ rc; spawn { Channel.send((), tx141) ; () } @ rc; spawn { Channel.send((), tx140) ; () } @ rc; spawn { Channel.send((), tx139) ; () } @ rc; spawn { select {
         case _ <- recv(rx141) => Channel.recv(rx140) ; Channel.recv(rx139) ; ()
         } } @ rc; spawn { select {
@@ -230,13 +230,13 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectRandom04(): Unit \ IO = region rc {
-        let (tx10, rx10) = Channel.buffered(rc, 0);
-        let (tx11, rx11) = Channel.buffered(rc, 0);
-        let (tx12, rx12) = Channel.buffered(rc, 0);
-        spawn { Channel.send((), tx12) ; () } @ rc; spawn { Channel.send((), tx11) ; () } @ rc; spawn { Channel.send((), tx10) ; () } @ rc; let (tx40, rx40) = Channel.buffered(rc, 0);
-        let (tx41, rx41) = Channel.buffered(rc, 0);
-        let (tx42, rx42) = Channel.buffered(rc, 0);
+    def testSelectRandom04(): Unit \ Global + IO + NonDet = region rc {
+        let (tx10, rx10) = Channel.buffered(0);
+        let (tx11, rx11) = Channel.buffered(0);
+        let (tx12, rx12) = Channel.buffered(0);
+        spawn { Channel.send((), tx12) ; () } @ rc; spawn { Channel.send((), tx11) ; () } @ rc; spawn { Channel.send((), tx10) ; () } @ rc; let (tx40, rx40) = Channel.buffered(0);
+        let (tx41, rx41) = Channel.buffered(0);
+        let (tx42, rx42) = Channel.buffered(0);
         spawn { Channel.send((), tx42) ; () } @ rc; spawn { Channel.send((), tx41) ; () } @ rc; spawn { Channel.send((), tx40) ; () } @ rc; spawn { Channel.send((), tx42) ; () } @ rc; spawn { Channel.send((), tx41) ; () } @ rc; spawn { Channel.send((), tx40) ; () } @ rc; spawn { Channel.send((), tx42) ; () } @ rc; spawn { Channel.send((), tx41) ; () } @ rc; spawn { Channel.send((), tx40) ; () } @ rc; spawn { Channel.send((), tx42) ; () } @ rc; spawn { Channel.send((), tx41) ; () } @ rc; spawn { Channel.send((), tx40) ; () } @ rc; spawn { select {
         case _ <- recv(rx40) => Channel.recv(rx41) ; Channel.recv(rx42) ; ()
         } } @ rc; spawn { select {
@@ -254,19 +254,19 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectRandom05(): Unit \ IO = region rc {
-        let (tx14, rx14) = Channel.buffered(rc, 0);
-        let (tx15, rx15) = Channel.buffered(rc, 0);
-        let (tx16, rx16) = Channel.buffered(rc, 0);
-        let (tx17, rx17) = Channel.buffered(rc, 0);
+    def testSelectRandom05(): Unit \ Global + IO = region rc {
+        let (tx14, rx14) = Channel.buffered(0);
+        let (tx15, rx15) = Channel.buffered(0);
+        let (tx16, rx16) = Channel.buffered(0);
+        let (tx17, rx17) = Channel.buffered(0);
         spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { select {
         case _ <- recv(rx17) => Channel.recv(rx14) ; Channel.recv(rx15) ; Channel.recv(rx16)
         } } @ rc; spawn { select {
         case _ <- recv(rx16) => Channel.recv(rx14) ; Channel.recv(rx15) ; Channel.recv(rx17) ; ()
         } } @ rc; spawn { select {
-        case _ <- recv(rx17) => Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx14) ; let (tx171, rx171) = Channel.buffered(rc, 0);
-        let (tx172, rx172) = Channel.buffered(rc, 0);
-        let (tx173, rx173) = Channel.buffered(rc, 0);
+        case _ <- recv(rx17) => Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx14) ; let (tx171, rx171) = Channel.buffered(0);
+        let (tx172, rx172) = Channel.buffered(0);
+        let (tx173, rx173) = Channel.buffered(0);
         spawn { Channel.send((), tx173) ; () } @ rc; spawn { Channel.send((), tx172) ; () } @ rc; spawn { Channel.send((), tx171) ; () } @ rc; spawn { Channel.send((), tx173) ; () } @ rc; spawn { Channel.send((), tx172) ; () } @ rc; spawn { Channel.send((), tx171) ; () } @ rc; spawn { Channel.send((), tx173) ; () } @ rc; spawn { Channel.send((), tx172) ; () } @ rc; spawn { Channel.send((), tx171) ; () } @ rc; spawn { Channel.send((), tx173) ; () } @ rc; spawn { Channel.send((), tx172) ; () } @ rc; spawn { Channel.send((), tx171) ; () } @ rc; spawn { select {
         case _ <- recv(rx172) => Channel.recv(rx173) ; Channel.recv(rx171) ; ()
         } } @ rc; spawn { select {
@@ -291,13 +291,13 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectRandom06(): Unit \ IO = region rc {
-        let (tx2, rx2) = Channel.buffered(rc, 0);
-        let (tx3, rx3) = Channel.buffered(rc, 0);
+    def testSelectRandom06(): Unit \ Global + IO + NonDet = region rc {
+        let (tx2, rx2) = Channel.buffered(0);
+        let (tx3, rx3) = Channel.buffered(0);
         spawn { Channel.send((), tx3) ; () } @ rc; spawn { Channel.send((), tx2) ; () } @ rc; Channel.recv(rx3) ; select {
         case _ <- recv(rx2) => ()
         case _ <- recv(rx2) => ()
-        } ; let (tx24, rx24) = Channel.buffered(rc, 0);
+        } ; let (tx24, rx24) = Channel.buffered(0);
         spawn { select {
         case _ <- recv(rx24) => ()
         case _ <- recv(rx24) => ()
@@ -306,20 +306,20 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectRandom07(): Unit \ IO = region rc {
-        let (tx12, rx12) = Channel.buffered(rc, 0);
-        let (tx13, rx13) = Channel.buffered(rc, 0);
-        let (tx14, rx14) = Channel.buffered(rc, 0);
-        let (tx15, rx15) = Channel.buffered(rc, 0);
-        let (tx16, rx16) = Channel.buffered(rc, 0);
+    def testSelectRandom07(): Unit \ Global + IO = region rc {
+        let (tx12, rx12) = Channel.buffered(0);
+        let (tx13, rx13) = Channel.buffered(0);
+        let (tx14, rx14) = Channel.buffered(0);
+        let (tx15, rx15) = Channel.buffered(0);
+        let (tx16, rx16) = Channel.buffered(0);
         spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { Channel.send((), tx13) ; () } @ rc; spawn { Channel.send((), tx12) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { Channel.send((), tx13) ; () } @ rc; spawn { Channel.send((), tx12) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { Channel.send((), tx13) ; () } @ rc; spawn { Channel.send((), tx12) ; () } @ rc; spawn { select {
         case _ <- recv(rx14) => Channel.recv(rx12) ; Channel.recv(rx13) ; Channel.recv(rx15) ; Channel.recv(rx16) ; ()
         } } @ rc; spawn { select {
         case _ <- recv(rx16) => Channel.recv(rx13) ; Channel.recv(rx14) ; Channel.recv(rx12) ; Channel.recv(rx15) ; ()
         case _ <- recv(rx15) => Channel.recv(rx14) ; Channel.recv(rx13) ; Channel.recv(rx16) ; Channel.recv(rx12) ; ()
-        case _ <- recv(rx12) => Channel.recv(rx13) ; Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx14) ; let (tx180, rx180) = Channel.buffered(rc, 0);
-        let (tx178, rx178) = Channel.buffered(rc, 0);
-        let (tx179, rx179) = Channel.buffered(rc, 0);
+        case _ <- recv(rx12) => Channel.recv(rx13) ; Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx14) ; let (tx180, rx180) = Channel.buffered(0);
+        let (tx178, rx178) = Channel.buffered(0);
+        let (tx179, rx179) = Channel.buffered(0);
         spawn { Channel.send((), tx180) ; () } @ rc; spawn { Channel.send((), tx179) ; () } @ rc; spawn { Channel.send((), tx178) ; () } @ rc; spawn { Channel.send((), tx180) ; () } @ rc; spawn { Channel.send((), tx179) ; () } @ rc; spawn { Channel.send((), tx178) ; () } @ rc; spawn { select {
         case _ <- recv(rx178) => Channel.recv(rx180) ; Channel.recv(rx179)
         case _ <- recv(rx179) => select {
@@ -338,12 +338,12 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectRandom08(): Unit \ IO = region rc {
-        let (tx15, rx15) = Channel.buffered(rc, 0);
-        let (tx16, rx16) = Channel.buffered(rc, 0);
-        let (tx17, rx17) = Channel.buffered(rc, 0);
-        let (tx18, rx18) = Channel.buffered(rc, 0);
-        let (tx19, rx19) = Channel.buffered(rc, 0);
+    def testSelectRandom08(): Unit \ Global + IO = region rc {
+        let (tx15, rx15) = Channel.buffered(0);
+        let (tx16, rx16) = Channel.buffered(0);
+        let (tx17, rx17) = Channel.buffered(0);
+        let (tx18, rx18) = Channel.buffered(0);
+        let (tx19, rx19) = Channel.buffered(0);
         spawn { Channel.send((), tx19) ; () } @ rc; spawn { Channel.send((), tx18) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx19) ; () } @ rc; spawn { Channel.send((), tx18) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx19) ; () } @ rc; spawn { Channel.send((), tx18) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx19) ; () } @ rc; spawn { Channel.send((), tx18) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { select {
         case _ <- recv(rx15) => Channel.recv(rx17) ; Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx19) ; ()
         } } @ rc; spawn { select {
@@ -361,10 +361,10 @@ mod Test.Exp.Concurrency.Select {
         case _ <- recv(rx16) => Channel.recv(rx18) ; select {
         case _ <- recv(rx15) => ()
         case _ <- recv(rx15) => ()
-        } ; Channel.recv(rx17) ; Channel.recv(rx19) ; let (tx214, rx214) = Channel.buffered(rc, 0);
-        let (tx215, rx215) = Channel.buffered(rc, 0);
-        let (tx216, rx216) = Channel.buffered(rc, 0);
-        let (tx217, rx217) = Channel.buffered(rc, 0);
+        } ; Channel.recv(rx17) ; Channel.recv(rx19) ; let (tx214, rx214) = Channel.buffered(0);
+        let (tx215, rx215) = Channel.buffered(0);
+        let (tx216, rx216) = Channel.buffered(0);
+        let (tx217, rx217) = Channel.buffered(0);
         spawn { Channel.send((), tx217) ; () } @ rc; spawn { Channel.send((), tx216) ; () } @ rc; spawn { Channel.send((), tx215) ; () } @ rc; spawn { Channel.send((), tx214) ; () } @ rc; select {
         case _ <- recv(rx215) => Channel.recv(rx214) ; Channel.recv(rx216) ; Channel.recv(rx217) ; ()
         case _ <- recv(rx214) => Channel.recv(rx216) ; Channel.recv(rx215) ; Channel.recv(rx217) ; ()
@@ -375,11 +375,11 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectRandom09(): Unit \ IO = region rc {
-        let (tx6, rx6) = Channel.buffered(rc, 0);
-        let (tx7, rx7) = Channel.buffered(rc, 0);
-        let (tx8, rx8) = Channel.buffered(rc, 0);
-        let (tx9, rx9) = Channel.buffered(rc, 0);
+    def testSelectRandom09(): Unit \ Global + IO + NonDet = region rc {
+        let (tx6, rx6) = Channel.buffered(0);
+        let (tx7, rx7) = Channel.buffered(0);
+        let (tx8, rx8) = Channel.buffered(0);
+        let (tx9, rx9) = Channel.buffered(0);
         spawn { select {
         case _ <- recv(rx8) => ()
         case _ <- recv(rx8) => ()
@@ -391,11 +391,11 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectRandom10(): Unit \ IO = region rc {
-        let (tx10, rx10) = Channel.buffered(rc, 0);
-        let (tx11, rx11) = Channel.buffered(rc, 0);
-        let (tx12, rx12) = Channel.buffered(rc, 0);
-        let (tx13, rx13) = Channel.buffered(rc, 0);
+    def testSelectRandom10(): Unit \ Global + IO + NonDet = region rc {
+        let (tx10, rx10) = Channel.buffered(0);
+        let (tx11, rx11) = Channel.buffered(0);
+        let (tx12, rx12) = Channel.buffered(0);
+        let (tx13, rx13) = Channel.buffered(0);
         spawn { Channel.send((), tx13) ; () } @ rc;
         spawn { Channel.send((), tx12) ; () } @ rc;
         spawn { Channel.send((), tx11) ; () } @ rc;
@@ -409,9 +409,9 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectSideEffecting01(): Bool = region rc {
-        def mkChan(): Receiver[Int32, rc] = {
-            let (tx, rx) = Channel.buffered(rc, 1);
+    def testSelectSideEffecting01(): Bool \ Global + NonDet = {
+        def mkChan(): Receiver[Int32] = {
+            let (tx, rx) = Channel.buffered(1);
             Channel.send(42, tx);
             rx
         };
@@ -422,10 +422,10 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectSideEffecting02(): Bool = region rc {
-        let (tx1, rx1) = Channel.buffered(rc, 10);
-        let (tx2, rx2) = Channel.buffered(rc, 10);
-        let (tx3, rx3) = Channel.buffered(rc, 10);
+    def testSelectSideEffecting02(): Bool \ Global + NonDet = {
+        let (tx1, rx1) = Channel.buffered(10);
+        let (tx2, rx2) = Channel.buffered(10);
+        let (tx3, rx3) = Channel.buffered(10);
 
         select {
             case x <- recv({Channel.send(1, tx3); rx1}) => x + (Channel.recv(rx2)) + (Channel.recv(rx3)) == 6
@@ -434,13 +434,13 @@ mod Test.Exp.Concurrency.Select {
         }
     }
 
-    type alias MyReceiver[a: Type, r: Region] = Receiver[a, r]
+    type alias MyReceiver[a: Type] = Receiver[a]
 
     @test
-    def testSelectAliasedChannel(): Bool = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testSelectAliasedChannel(): Bool \ Global + NonDet = {
+        let (tx, rx) = Channel.buffered(1);
 
-        def useChan(mr: MyReceiver[Int32, rc]) : Bool =
+        def useChan(mr: MyReceiver[Int32]) : Bool =
             select {
                 case x <- recv(mr) => x == 42
             };
@@ -450,8 +450,8 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectOptionalSyntax01(): Bool \ IO = region rc {
-        let (tx1, rx1) = Channel.buffered(rc, 1);
+    def testSelectOptionalSyntax01(): Bool \ Global + IO + NonDet = region rc {
+        let (tx1, rx1) = Channel.buffered(1);
         spawn Channel.send(1, tx1) @ rc;
         select {
             case x <- Channel.recv(rx1) => x == 1

--- a/main/test/flix/Test.Exp.Concurrency.Select.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Select.flix
@@ -1,20 +1,20 @@
 mod Test.Exp.Concurrency.Select {
 
     @test
-    def testSelectBuffered01(): Bool \ Global + IO + NonDet = region rc {
+    def testSelectBuffered01(): Bool \ Global + NonDet = {
         let (tx1, rx1) = Channel.buffered(1);
-        spawn Channel.send(1, tx1) @ rc;
+        spawn Channel.send(1, tx1);
         select {
             case x <- recv(rx1) => x == 1
         }
     }
 
     @test
-    def testSelectBuffered02(): Bool \ Global + IO + NonDet = region rc {
+    def testSelectBuffered02(): Bool \ Global + NonDet = {
         let (tx1, rx1) = Channel.buffered(1);
         let (tx2, rx2) = Channel.buffered(1);
-        spawn Channel.send(1, tx1) @ rc;
-        spawn Channel.send(2, tx2) @ rc;
+        spawn Channel.send(1, tx1);
+        spawn Channel.send(2, tx2);
         select {
             case x <- recv(rx1) => x == 1
             case x <- recv(rx2) => x == 2
@@ -22,52 +22,52 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectBuffered03(): Bool \ Global + IO + NonDet = region rc {
-        let (tx1, rx1) = Channel.buffered(1);
-        let (tx2, rx2) = Channel.buffered(1);
-        let (tx3, rx3) = Channel.buffered(1);
-        spawn Channel.send(1, tx1) @ rc;
-        spawn Channel.send(2, tx2) @ rc;
-        spawn Channel.send(3, tx3) @ rc;
-        select {
-            case x <- recv(rx1) => x == 1
-            case x <- recv(rx2) => x == 2
-            case x <- recv(rx3) => x == 3
-        }
-    }
-
-    @test
-    def testSelectBuffered04(): Bool \ Global + IO + NonDet = region rc {
+    def testSelectBuffered03(): Bool \ Global + NonDet = {
         let (tx1, rx1) = Channel.buffered(1);
         let (tx2, rx2) = Channel.buffered(1);
         let (tx3, rx3) = Channel.buffered(1);
-        let (tx4, rx4) = Channel.buffered(1);
-        spawn Channel.send(1, tx1) @ rc;
-        spawn Channel.send(2, tx2) @ rc;
-        spawn Channel.send(3, tx3) @ rc;
-        spawn Channel.send(4, tx4) @ rc;
+        spawn Channel.send(1, tx1);
+        spawn Channel.send(2, tx2);
+        spawn Channel.send(3, tx3);
         select {
             case x <- recv(rx1) => x == 1
-            case x <- recv(rx1) => x == 1
-            case x <- recv(rx2) => x == 2
             case x <- recv(rx2) => x == 2
             case x <- recv(rx3) => x == 3
-            case x <- recv(rx3) => x == 3
-            case x <- recv(rx4) => x == 4
-            case x <- recv(rx4) => x == 4
         }
     }
 
     @test
-    def testSelectBuffered05(): Bool \ Global + IO + NonDet = region rc {
+    def testSelectBuffered04(): Bool \ Global + NonDet = {
         let (tx1, rx1) = Channel.buffered(1);
         let (tx2, rx2) = Channel.buffered(1);
         let (tx3, rx3) = Channel.buffered(1);
         let (tx4, rx4) = Channel.buffered(1);
-        spawn Channel.send(1, tx1) @ rc;
-        spawn Channel.send(2, tx2) @ rc;
-        spawn Channel.send(3, tx3) @ rc;
-        spawn Channel.send(4, tx4) @ rc;
+        spawn Channel.send(1, tx1);
+        spawn Channel.send(2, tx2);
+        spawn Channel.send(3, tx3);
+        spawn Channel.send(4, tx4);
+        select {
+            case x <- recv(rx1) => x == 1
+            case x <- recv(rx1) => x == 1
+            case x <- recv(rx2) => x == 2
+            case x <- recv(rx2) => x == 2
+            case x <- recv(rx3) => x == 3
+            case x <- recv(rx3) => x == 3
+            case x <- recv(rx4) => x == 4
+            case x <- recv(rx4) => x == 4
+        }
+    }
+
+    @test
+    def testSelectBuffered05(): Bool \ Global + NonDet = {
+        let (tx1, rx1) = Channel.buffered(1);
+        let (tx2, rx2) = Channel.buffered(1);
+        let (tx3, rx3) = Channel.buffered(1);
+        let (tx4, rx4) = Channel.buffered(1);
+        spawn Channel.send(1, tx1);
+        spawn Channel.send(2, tx2);
+        spawn Channel.send(3, tx3);
+        spawn Channel.send(4, tx4);
         select {
             case x <- recv(rx4) => x == 4
             case x <- recv(rx3) => x == 3
@@ -81,12 +81,12 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectBuffered06(): Bool \ Global + IO + NonDet = region rc {
+    def testSelectBuffered06(): Bool \ Global + NonDet = {
         let (_, rx1) = Channel.buffered(1);
         let (tx2, rx2) = Channel.buffered(1);
         let (_, rx3) = Channel.buffered(1);
         let (_, rx4) = Channel.buffered(1);
-        spawn Channel.send(1, tx2) @ rc;
+        spawn Channel.send(1, tx2);
         select {
             case _ <- recv(rx4) => false
             case _ <- recv(rx3) => false
@@ -96,15 +96,15 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectBuffered07(): Bool \ Global + IO + NonDet = region rc {
+    def testSelectBuffered07(): Bool \ Global + NonDet = {
         let (tx1, rx1) = Channel.buffered(1);
         let (tx2, rx2) = Channel.buffered(1);
         let (tx3, rx3) = Channel.buffered(1);
         let (tx4, rx4) = Channel.buffered(1);
-        spawn Channel.send(1i8, tx1) @ rc;
-        spawn Channel.send(2i16, tx2) @ rc;
-        spawn Channel.send(3i32, tx3) @ rc;
-        spawn Channel.send(4i64, tx4) @ rc;
+        spawn Channel.send(1i8, tx1);
+        spawn Channel.send(2i16, tx2);
+        spawn Channel.send(3i32, tx3);
+        spawn Channel.send(4i64, tx4);
         select {
             case x <- recv(rx4) => x == 4i64
             case x <- recv(rx3) => x == 3i32
@@ -147,13 +147,13 @@ mod Test.Exp.Concurrency.Select {
       unchecked_cast(println(mainx()) as _ \ IO)
 
     @test
-    def testSelectRandom01(): Unit \ Global + IO + NonDet = region rc {
+    def testSelectRandom01(): Unit \ Global + NonDet = {
         let (tx9, rx9) = Channel.buffered(0);
         let (tx10, rx10) = Channel.buffered(0);
         let (tx11, rx11) = Channel.buffered(0);
         let (tx12, rx12) = Channel.buffered(0);
         let (tx13, rx13) = Channel.buffered(0);
-        spawn { Channel.send((), tx13) ; () } @ rc; spawn { Channel.send((), tx12) ; () } @ rc; spawn { Channel.send((), tx11) ; () } @ rc; spawn { Channel.send((), tx10) ; () } @ rc; spawn { Channel.send((), tx9) ; () } @ rc; select {
+        spawn { Channel.send((), tx13); () }; spawn { Channel.send((), tx12); () }; spawn { Channel.send((), tx11); () }; spawn { Channel.send((), tx10); () }; spawn { Channel.send((), tx9); () }; select {
         case _ <- recv(rx13) => select {
         case _ <- recv(rx11) => ()
         case _ <- recv(rx11) => ()
@@ -161,7 +161,7 @@ mod Test.Exp.Concurrency.Select {
         let (tx43, rx43) = Channel.buffered(0);
         let (tx44, rx44) = Channel.buffered(0);
         let (tx45, rx45) = Channel.buffered(0);
-        spawn { Channel.send((), tx45) ; () } @ rc; spawn { Channel.send((), tx44) ; () } @ rc; spawn { Channel.send((), tx43) ; () } @ rc; spawn { Channel.send((), tx42) ; () } @ rc; select {
+        spawn { Channel.send((), tx45); () }; spawn { Channel.send((), tx44); () }; spawn { Channel.send((), tx43); () }; spawn { Channel.send((), tx42); () }; select {
         case _ <- recv(rx43) => Channel.recv(rx42) ; Channel.recv(rx44) ; Channel.recv(rx45)
         case _ <- recv(rx42) => Channel.recv(rx45) ; Channel.recv(rx43) ; Channel.recv(rx44) ; ()
         }
@@ -172,7 +172,7 @@ mod Test.Exp.Concurrency.Select {
         let (tx43, rx43) = Channel.buffered(0);
         let (tx44, rx44) = Channel.buffered(0);
         let (tx45, rx45) = Channel.buffered(0);
-        spawn { Channel.send((), tx45) ; () } @ rc; spawn { Channel.send((), tx44) ; () } @ rc; spawn { Channel.send((), tx43) ; () } @ rc; spawn { Channel.send((), tx42) ; () } @ rc; select {
+        spawn { Channel.send((), tx45); () }; spawn { Channel.send((), tx44); () }; spawn { Channel.send((), tx43); () }; spawn { Channel.send((), tx42); () }; select {
         case _ <- recv(rx43) => Channel.recv(rx42) ; Channel.recv(rx44) ; Channel.recv(rx45) ; ()
         case _ <- recv(rx42) => Channel.recv(rx45) ; Channel.recv(rx43) ; Channel.recv(rx44)
         }
@@ -181,12 +181,12 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectRandom02(): Unit \ Global + IO + NonDet = region rc {
+    def testSelectRandom02(): Unit \ Global + NonDet = {
         let (tx10, rx10) = Channel.buffered(0);
         let (tx11, rx11) = Channel.buffered(0);
         let (tx12, rx12) = Channel.buffered(0);
         let (tx13, rx13) = Channel.buffered(0);
-        spawn { Channel.send((), tx13) ; () } @ rc; spawn { Channel.send((), tx12) ; () } @ rc; if (false) { spawn { Channel.send((), tx11) ; () } @ rc; spawn { Channel.send((), tx10) ; () } @ rc; if (true) { () } else { () } } else { spawn { Channel.send((), tx11) ; () } @ rc; spawn { Channel.send((), tx10) ; () } @ rc; if (true) { () } else { () } } ; select {
+        spawn { Channel.send((), tx13) ; () }; spawn { Channel.send((), tx12) ; () }; if (false) { spawn { Channel.send((), tx11) ; () }; spawn { Channel.send((), tx10) ; () }; if (true) { () } else { () } } else { spawn { Channel.send((), tx11) ; () }; spawn { Channel.send((), tx10) ; () }; if (true) { () } else { () } } ; select {
         case _ <- recv(rx10) => Channel.recv(rx13) ; Channel.recv(rx12) ; Channel.recv(rx11)
         case _ <- recv(rx13) => Channel.recv(rx12) ; Channel.recv(rx10) ; Channel.recv(rx11) ; ()
         case _ <- recv(rx11) => Channel.recv(rx13) ; Channel.recv(rx12) ; Channel.recv(rx10) ; ()
@@ -195,27 +195,27 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectRandom03(): Unit \ Global + IO = region rc {
+    def testSelectRandom03(): Unit \ Global + NonDet = {
         let (tx14, rx14) = Channel.buffered(0);
         let (tx15, rx15) = Channel.buffered(0);
         let (tx16, rx16) = Channel.buffered(0);
         let (tx17, rx17) = Channel.buffered(0);
         let (tx18, rx18) = Channel.buffered(0);
-        spawn { Channel.send((), tx18) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { Channel.send((), tx18) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; let (tx141, rx141) = Channel.buffered(0);
+        spawn { Channel.send((), tx18) ; () }; spawn { Channel.send((), tx17) ; () }; spawn { Channel.send((), tx16) ; () }; spawn { Channel.send((), tx15) ; () }; spawn { Channel.send((), tx14) ; () }; spawn { Channel.send((), tx18) ; () }; spawn { Channel.send((), tx17) ; () }; spawn { Channel.send((), tx16) ; () }; spawn { Channel.send((), tx15) ; () }; spawn { Channel.send((), tx14) ; () }; let (tx141, rx141) = Channel.buffered(0);
         let (tx139, rx139) = Channel.buffered(0);
         let (tx140, rx140) = Channel.buffered(0);
-        spawn { Channel.send((), tx141) ; () } @ rc; spawn { Channel.send((), tx140) ; () } @ rc; spawn { Channel.send((), tx139) ; () } @ rc; spawn { Channel.send((), tx141) ; () } @ rc; spawn { Channel.send((), tx140) ; () } @ rc; spawn { Channel.send((), tx139) ; () } @ rc; spawn { Channel.send((), tx141) ; () } @ rc; spawn { Channel.send((), tx140) ; () } @ rc; spawn { Channel.send((), tx139) ; () } @ rc; spawn { select {
+        spawn { Channel.send((), tx141) ; () }; spawn { Channel.send((), tx140) ; () }; spawn { Channel.send((), tx139) ; () }; spawn { Channel.send((), tx141) ; () }; spawn { Channel.send((), tx140) ; () }; spawn { Channel.send((), tx139) ; () }; spawn { Channel.send((), tx141) ; () }; spawn { Channel.send((), tx140) ; () }; spawn { Channel.send((), tx139) ; () }; spawn { select {
         case _ <- recv(rx141) => Channel.recv(rx140) ; Channel.recv(rx139) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx139) => Channel.recv(rx140) ; Channel.recv(rx141) ; ()
         case _ <- recv(rx140) => Channel.recv(rx141) ; Channel.recv(rx139) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx139) => select {
         case _ <- recv(rx140) => ()
         case _ <- recv(rx140) => ()
         } ; Channel.recv(rx141) ; ()
         case _ <- recv(rx141) => Channel.recv(rx140) ; Channel.recv(rx139) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx15) => Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx17) ; Channel.recv(rx14) ; ()
         case _ <- recv(rx14) => Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx15) ; Channel.recv(rx17) ; ()
         case _ <- recv(rx17) => Channel.recv(rx15) ; Channel.recv(rx18) ; select {
@@ -223,140 +223,140 @@ mod Test.Exp.Concurrency.Select {
         case _ <- recv(rx16) => ()
         } ; Channel.recv(rx14)
         case _ <- recv(rx18) => Channel.recv(rx15) ; Channel.recv(rx14) ; Channel.recv(rx17) ; Channel.recv(rx16) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx16) => Channel.recv(rx18) ; Channel.recv(rx17) ; Channel.recv(rx15) ; Channel.recv(rx14) ; ()
-        } } @ rc;
+        } };
         ()
     }
 
     @test
-    def testSelectRandom04(): Unit \ Global + IO + NonDet = region rc {
+    def testSelectRandom04(): Unit \ Global + NonDet = {
         let (tx10, rx10) = Channel.buffered(0);
         let (tx11, rx11) = Channel.buffered(0);
         let (tx12, rx12) = Channel.buffered(0);
-        spawn { Channel.send((), tx12) ; () } @ rc; spawn { Channel.send((), tx11) ; () } @ rc; spawn { Channel.send((), tx10) ; () } @ rc; let (tx40, rx40) = Channel.buffered(0);
+        spawn { Channel.send((), tx12) ; () }; spawn { Channel.send((), tx11) ; () }; spawn { Channel.send((), tx10) ; () }; let (tx40, rx40) = Channel.buffered(0);
         let (tx41, rx41) = Channel.buffered(0);
         let (tx42, rx42) = Channel.buffered(0);
-        spawn { Channel.send((), tx42) ; () } @ rc; spawn { Channel.send((), tx41) ; () } @ rc; spawn { Channel.send((), tx40) ; () } @ rc; spawn { Channel.send((), tx42) ; () } @ rc; spawn { Channel.send((), tx41) ; () } @ rc; spawn { Channel.send((), tx40) ; () } @ rc; spawn { Channel.send((), tx42) ; () } @ rc; spawn { Channel.send((), tx41) ; () } @ rc; spawn { Channel.send((), tx40) ; () } @ rc; spawn { Channel.send((), tx42) ; () } @ rc; spawn { Channel.send((), tx41) ; () } @ rc; spawn { Channel.send((), tx40) ; () } @ rc; spawn { select {
+        spawn { Channel.send((), tx42) ; () }; spawn { Channel.send((), tx41) ; () }; spawn { Channel.send((), tx40) ; () }; spawn { Channel.send((), tx42) ; () }; spawn { Channel.send((), tx41) ; () }; spawn { Channel.send((), tx40) ; () }; spawn { Channel.send((), tx42) ; () }; spawn { Channel.send((), tx41) ; () }; spawn { Channel.send((), tx40) ; () }; spawn { Channel.send((), tx42) ; () }; spawn { Channel.send((), tx41) ; () }; spawn { Channel.send((), tx40) ; () }; spawn { select {
         case _ <- recv(rx40) => Channel.recv(rx41) ; Channel.recv(rx42) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx40) => Channel.recv(rx42) ; Channel.recv(rx41) ; ()
         case _ <- recv(rx40) => Channel.recv(rx42) ; Channel.recv(rx41) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx42) => Channel.recv(rx40) ; Channel.recv(rx41) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx42) => Channel.recv(rx40) ; Channel.recv(rx41) ; ()
         case _ <- recv(rx42) => Channel.recv(rx40) ; Channel.recv(rx41) ; ()
-        } } @ rc; select {
+        } }; select {
         case _ <- recv(rx10) => Channel.recv(rx12) ; Channel.recv(rx11) ; ()
         };
         ()
     }
 
     @test
-    def testSelectRandom05(): Unit \ Global + IO = region rc {
+    def testSelectRandom05(): Unit \ Global + NonDet = {
         let (tx14, rx14) = Channel.buffered(0);
         let (tx15, rx15) = Channel.buffered(0);
         let (tx16, rx16) = Channel.buffered(0);
         let (tx17, rx17) = Channel.buffered(0);
-        spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { select {
+        spawn { Channel.send((), tx17) ; () }; spawn { Channel.send((), tx16) ; () }; spawn { Channel.send((), tx15) ; () }; spawn { Channel.send((), tx14) ; () }; spawn { Channel.send((), tx17) ; () }; spawn { Channel.send((), tx16) ; () }; spawn { Channel.send((), tx15) ; () }; spawn { Channel.send((), tx14) ; () }; spawn { Channel.send((), tx17) ; () }; spawn { Channel.send((), tx16) ; () }; spawn { Channel.send((), tx15) ; () }; spawn { Channel.send((), tx14) ; () }; spawn { Channel.send((), tx17) ; () }; spawn { Channel.send((), tx16) ; () }; spawn { Channel.send((), tx15) ; () }; spawn { Channel.send((), tx14) ; () }; spawn { select {
         case _ <- recv(rx17) => Channel.recv(rx14) ; Channel.recv(rx15) ; Channel.recv(rx16)
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx16) => Channel.recv(rx14) ; Channel.recv(rx15) ; Channel.recv(rx17) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx17) => Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx14) ; let (tx171, rx171) = Channel.buffered(0);
         let (tx172, rx172) = Channel.buffered(0);
         let (tx173, rx173) = Channel.buffered(0);
-        spawn { Channel.send((), tx173) ; () } @ rc; spawn { Channel.send((), tx172) ; () } @ rc; spawn { Channel.send((), tx171) ; () } @ rc; spawn { Channel.send((), tx173) ; () } @ rc; spawn { Channel.send((), tx172) ; () } @ rc; spawn { Channel.send((), tx171) ; () } @ rc; spawn { Channel.send((), tx173) ; () } @ rc; spawn { Channel.send((), tx172) ; () } @ rc; spawn { Channel.send((), tx171) ; () } @ rc; spawn { Channel.send((), tx173) ; () } @ rc; spawn { Channel.send((), tx172) ; () } @ rc; spawn { Channel.send((), tx171) ; () } @ rc; spawn { select {
+        spawn { Channel.send((), tx173) ; () }; spawn { Channel.send((), tx172) ; () }; spawn { Channel.send((), tx171) ; () }; spawn { Channel.send((), tx173) ; () }; spawn { Channel.send((), tx172) ; () }; spawn { Channel.send((), tx171) ; () }; spawn { Channel.send((), tx173) ; () }; spawn { Channel.send((), tx172) ; () }; spawn { Channel.send((), tx171) ; () }; spawn { Channel.send((), tx173) ; () }; spawn { Channel.send((), tx172) ; () }; spawn { Channel.send((), tx171) ; () }; spawn { select {
         case _ <- recv(rx172) => Channel.recv(rx173) ; Channel.recv(rx171) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx171) => Channel.recv(rx173) ; Channel.recv(rx172) ; ()
         case _ <- recv(rx173) => Channel.recv(rx172) ; Channel.recv(rx171) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx171) => Channel.recv(rx173) ; Channel.recv(rx172) ; ()
         case _ <- recv(rx173) => Channel.recv(rx171) ; Channel.recv(rx172) ; ()
         case _ <- recv(rx171) => Channel.recv(rx173) ; Channel.recv(rx172) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx171) => Channel.recv(rx173) ; select {
         case _ <- recv(rx172) => ()
         case _ <- recv(rx172) => ()
         } ; ()
         case _ <- recv(rx173) => Channel.recv(rx171) ; Channel.recv(rx172) ; ()
-        } } @ rc; ()
+        } }; ()
         case _ <- recv(rx14) => Channel.recv(rx17) ; Channel.recv(rx15) ; Channel.recv(rx16) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx17) => Channel.recv(rx16) ; Channel.recv(rx15) ; Channel.recv(rx14) ; ()
-        } } @ rc;
+        } };
         ()
     }
 
     @test
-    def testSelectRandom06(): Unit \ Global + IO + NonDet = region rc {
+    def testSelectRandom06(): Unit \ Global + NonDet = {
         let (tx2, rx2) = Channel.buffered(0);
         let (tx3, rx3) = Channel.buffered(0);
-        spawn { Channel.send((), tx3) ; () } @ rc; spawn { Channel.send((), tx2) ; () } @ rc; Channel.recv(rx3) ; select {
+        spawn { Channel.send((), tx3) ; () }; spawn { Channel.send((), tx2) ; () }; Channel.recv(rx3) ; select {
         case _ <- recv(rx2) => ()
         case _ <- recv(rx2) => ()
         } ; let (tx24, rx24) = Channel.buffered(0);
         spawn { select {
         case _ <- recv(rx24) => ()
         case _ <- recv(rx24) => ()
-        } } @ rc; Channel.send((), tx24) ;
+        } }; Channel.send((), tx24) ;
         ()
     }
 
     @test
-    def testSelectRandom07(): Unit \ Global + IO = region rc {
+    def testSelectRandom07(): Unit \ Global + NonDet = {
         let (tx12, rx12) = Channel.buffered(0);
         let (tx13, rx13) = Channel.buffered(0);
         let (tx14, rx14) = Channel.buffered(0);
         let (tx15, rx15) = Channel.buffered(0);
         let (tx16, rx16) = Channel.buffered(0);
-        spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { Channel.send((), tx13) ; () } @ rc; spawn { Channel.send((), tx12) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { Channel.send((), tx13) ; () } @ rc; spawn { Channel.send((), tx12) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx14) ; () } @ rc; spawn { Channel.send((), tx13) ; () } @ rc; spawn { Channel.send((), tx12) ; () } @ rc; spawn { select {
+        spawn { Channel.send((), tx16) ; () }; spawn { Channel.send((), tx15) ; () }; spawn { Channel.send((), tx14) ; () }; spawn { Channel.send((), tx13) ; () }; spawn { Channel.send((), tx12) ; () }; spawn { Channel.send((), tx16) ; () }; spawn { Channel.send((), tx15) ; () }; spawn { Channel.send((), tx14) ; () }; spawn { Channel.send((), tx13) ; () }; spawn { Channel.send((), tx12) ; () }; spawn { Channel.send((), tx16) ; () }; spawn { Channel.send((), tx15) ; () }; spawn { Channel.send((), tx14) ; () }; spawn { Channel.send((), tx13) ; () }; spawn { Channel.send((), tx12) ; () }; spawn { select {
         case _ <- recv(rx14) => Channel.recv(rx12) ; Channel.recv(rx13) ; Channel.recv(rx15) ; Channel.recv(rx16) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx16) => Channel.recv(rx13) ; Channel.recv(rx14) ; Channel.recv(rx12) ; Channel.recv(rx15) ; ()
         case _ <- recv(rx15) => Channel.recv(rx14) ; Channel.recv(rx13) ; Channel.recv(rx16) ; Channel.recv(rx12) ; ()
         case _ <- recv(rx12) => Channel.recv(rx13) ; Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx14) ; let (tx180, rx180) = Channel.buffered(0);
         let (tx178, rx178) = Channel.buffered(0);
         let (tx179, rx179) = Channel.buffered(0);
-        spawn { Channel.send((), tx180) ; () } @ rc; spawn { Channel.send((), tx179) ; () } @ rc; spawn { Channel.send((), tx178) ; () } @ rc; spawn { Channel.send((), tx180) ; () } @ rc; spawn { Channel.send((), tx179) ; () } @ rc; spawn { Channel.send((), tx178) ; () } @ rc; spawn { select {
+        spawn { Channel.send((), tx180) ; () }; spawn { Channel.send((), tx179) ; () }; spawn { Channel.send((), tx178) ; () }; spawn { Channel.send((), tx180) ; () }; spawn { Channel.send((), tx179) ; () }; spawn { Channel.send((), tx178) ; () }; spawn { select {
         case _ <- recv(rx178) => Channel.recv(rx180) ; Channel.recv(rx179)
         case _ <- recv(rx179) => select {
         case _ <- recv(rx178) => ()
         case _ <- recv(rx178) => ()
         } ; Channel.recv(rx180) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx178) => Channel.recv(rx179) ; Channel.recv(rx180) ; ()
         case _ <- recv(rx180) => Channel.recv(rx178) ; Channel.recv(rx179) ; ()
-        } } @ rc; ()
-        } } @ rc; spawn { select {
+        } }; ()
+        } }; spawn { select {
         case _ <- recv(rx14) => Channel.recv(rx15) ; Channel.recv(rx12) ; Channel.recv(rx16) ; Channel.recv(rx13) ; ()
         case _ <- recv(rx13) => Channel.recv(rx12) ; Channel.recv(rx14) ; Channel.recv(rx15) ; Channel.recv(rx16) ; ()
-        } } @ rc;
+        } };
         ()
     }
 
     @test
-    def testSelectRandom08(): Unit \ Global + IO = region rc {
+    def testSelectRandom08(): Unit \ Global + NonDet = {
         let (tx15, rx15) = Channel.buffered(0);
         let (tx16, rx16) = Channel.buffered(0);
         let (tx17, rx17) = Channel.buffered(0);
         let (tx18, rx18) = Channel.buffered(0);
         let (tx19, rx19) = Channel.buffered(0);
-        spawn { Channel.send((), tx19) ; () } @ rc; spawn { Channel.send((), tx18) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx19) ; () } @ rc; spawn { Channel.send((), tx18) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx19) ; () } @ rc; spawn { Channel.send((), tx18) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { Channel.send((), tx19) ; () } @ rc; spawn { Channel.send((), tx18) ; () } @ rc; spawn { Channel.send((), tx17) ; () } @ rc; spawn { Channel.send((), tx16) ; () } @ rc; spawn { Channel.send((), tx15) ; () } @ rc; spawn { select {
+        spawn { Channel.send((), tx19) ; () }; spawn { Channel.send((), tx18) ; () }; spawn { Channel.send((), tx17) ; () }; spawn { Channel.send((), tx16) ; () }; spawn { Channel.send((), tx15) ; () }; spawn { Channel.send((), tx19) ; () }; spawn { Channel.send((), tx18) ; () }; spawn { Channel.send((), tx17) ; () }; spawn { Channel.send((), tx16) ; () }; spawn { Channel.send((), tx15) ; () }; spawn { Channel.send((), tx19) ; () }; spawn { Channel.send((), tx18) ; () }; spawn { Channel.send((), tx17) ; () }; spawn { Channel.send((), tx16) ; () }; spawn { Channel.send((), tx15) ; () }; spawn { Channel.send((), tx19) ; () }; spawn { Channel.send((), tx18) ; () }; spawn { Channel.send((), tx17) ; () }; spawn { Channel.send((), tx16) ; () }; spawn { Channel.send((), tx15) ; () }; spawn { select {
         case _ <- recv(rx15) => Channel.recv(rx17) ; Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx19) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx15) => Channel.recv(rx19) ; Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx17) ; ()
         case _ <- recv(rx18) => Channel.recv(rx19) ; Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx17) ; ()
         case _ <- recv(rx19) => Channel.recv(rx16) ; Channel.recv(rx17) ; Channel.recv(rx18) ; Channel.recv(rx15) ; ()
         case _ <- recv(rx17) => Channel.recv(rx15) ; Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx19) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx17) => Channel.recv(rx18) ; Channel.recv(rx15) ; Channel.recv(rx16) ; Channel.recv(rx19) ; ()
         case _ <- recv(rx15) => Channel.recv(rx17) ; Channel.recv(rx16) ; Channel.recv(rx18) ; Channel.recv(rx19) ; ()
         case _ <- recv(rx16) => Channel.recv(rx15) ; Channel.recv(rx18) ; Channel.recv(rx17) ; Channel.recv(rx19) ; ()
         case _ <- recv(rx19) => Channel.recv(rx15) ; Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx17) ; ()
-        } } @ rc; spawn { select {
+        } }; spawn { select {
         case _ <- recv(rx17) => Channel.recv(rx18) ; Channel.recv(rx16) ; Channel.recv(rx19) ; Channel.recv(rx15) ; ()
         case _ <- recv(rx16) => Channel.recv(rx18) ; select {
         case _ <- recv(rx15) => ()
@@ -365,17 +365,17 @@ mod Test.Exp.Concurrency.Select {
         let (tx215, rx215) = Channel.buffered(0);
         let (tx216, rx216) = Channel.buffered(0);
         let (tx217, rx217) = Channel.buffered(0);
-        spawn { Channel.send((), tx217) ; () } @ rc; spawn { Channel.send((), tx216) ; () } @ rc; spawn { Channel.send((), tx215) ; () } @ rc; spawn { Channel.send((), tx214) ; () } @ rc; select {
+        spawn { Channel.send((), tx217) ; () }; spawn { Channel.send((), tx216) ; () }; spawn { Channel.send((), tx215) ; () }; spawn { Channel.send((), tx214) ; () }; select {
         case _ <- recv(rx215) => Channel.recv(rx214) ; Channel.recv(rx216) ; Channel.recv(rx217) ; ()
         case _ <- recv(rx214) => Channel.recv(rx216) ; Channel.recv(rx215) ; Channel.recv(rx217) ; ()
         case _ <- recv(rx216) => Channel.recv(rx214) ; Channel.recv(rx217) ; Channel.recv(rx215)
         }
-        } } @ rc;
+        } };
         ()
     }
 
     @test
-    def testSelectRandom09(): Unit \ Global + IO + NonDet = region rc {
+    def testSelectRandom09(): Unit \ Global + NonDet = {
         let (tx6, rx6) = Channel.buffered(0);
         let (tx7, rx7) = Channel.buffered(0);
         let (tx8, rx8) = Channel.buffered(0);
@@ -383,23 +383,23 @@ mod Test.Exp.Concurrency.Select {
         spawn { select {
         case _ <- recv(rx8) => ()
         case _ <- recv(rx8) => ()
-        } ; Channel.send((), tx9) ; () } @ rc; spawn { Channel.recv(rx7) ; Channel.send((), tx8) ; () } @ rc; spawn { select {
+        } ; Channel.send((), tx9) ; () }; spawn { Channel.recv(rx7) ; Channel.send((), tx8) ; () }; spawn { select {
         case _ <- recv(rx6) => ()
         case _ <- recv(rx6) => ()
-        } ; Channel.send((), tx7) ; () } @ rc; Channel.send((), tx6) ; Channel.recv(rx9);
+        } ; Channel.send((), tx7) ; () }; Channel.send((), tx6) ; Channel.recv(rx9);
         ()
     }
 
     @test
-    def testSelectRandom10(): Unit \ Global + IO + NonDet = region rc {
+    def testSelectRandom10(): Unit \ Global + NonDet = {
         let (tx10, rx10) = Channel.buffered(0);
         let (tx11, rx11) = Channel.buffered(0);
         let (tx12, rx12) = Channel.buffered(0);
         let (tx13, rx13) = Channel.buffered(0);
-        spawn { Channel.send((), tx13) ; () } @ rc;
-        spawn { Channel.send((), tx12) ; () } @ rc;
-        spawn { Channel.send((), tx11) ; () } @ rc;
-        spawn { Channel.send((), tx10) ; () } @ rc;
+        spawn { Channel.send((), tx13) ; () };
+        spawn { Channel.send((), tx12) ; () };
+        spawn { Channel.send((), tx11) ; () };
+        spawn { Channel.send((), tx10) ; () };
         select {
             case _ <- recv(rx10) => Channel.recv(rx13) ; Channel.recv(rx12) ; Channel.recv(rx11)
             case _ <- recv(rx13) => Channel.recv(rx12) ; Channel.recv(rx10) ; Channel.recv(rx11)
@@ -450,9 +450,9 @@ mod Test.Exp.Concurrency.Select {
     }
 
     @test
-    def testSelectOptionalSyntax01(): Bool \ Global + IO + NonDet = region rc {
+    def testSelectOptionalSyntax01(): Bool \ Global + NonDet = {
         let (tx1, rx1) = Channel.buffered(1);
-        spawn Channel.send(1, tx1) @ rc;
+        spawn Channel.send(1, tx1);
         select {
             case x <- Channel.recv(rx1) => x == 1
         }

--- a/main/test/flix/Test.Exp.Concurrency.Spawn.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Spawn.flix
@@ -3,86 +3,86 @@ mod Test.Exp.Concurrency.Spawn {
     import java.lang.NullPointerException
 
     @test
-    def testSpawn01(): Unit \ IO = region rc { spawn () @ rc }
+    def testSpawn01(): Unit = spawn ()
 
     @test
-    def testSpawn02(): Unit \ IO = region rc { spawn true @ rc }
+    def testSpawn02(): Unit = spawn true
 
     @test
-    def testSpawn03(): Unit \ IO = region rc { spawn 'a' @ rc }
+    def testSpawn03(): Unit = spawn 'a'
 
     @test
-    def testSpawn04(): Unit \ IO = region rc { spawn 1.0f32 + 2.0f32 @ rc }
+    def testSpawn04(): Unit = spawn 1.0f32 + 2.0f32
 
     @test
-    def testSpawn05(): Unit \ IO = region rc { spawn 1.0f64 + 2.0f64 @ rc }
+    def testSpawn05(): Unit = spawn 1.0f64 + 2.0f64
 
     @test
-    def testSpawn06(): Unit \ IO = region rc { spawn 1i8 + 2i8 @ rc }
+    def testSpawn06(): Unit = spawn 1i8 + 2i8
 
     @test
-    def testSpawn07(): Unit \ IO = region rc { spawn 1i16 + 2i16 @ rc }
+    def testSpawn07(): Unit = spawn 1i16 + 2i16
 
     @test
-    def testSpawn08(): Unit \ IO = region rc { spawn 1i32 + 2i32 @ rc }
+    def testSpawn08(): Unit = spawn 1i32 + 2i32
 
     @test
-    def testSpawn09(): Unit \ IO = region rc { spawn 1i64 + 2i64 @ rc }
+    def testSpawn09(): Unit = spawn 1i64 + 2i64
 
     @test
-    def testSpawn10(): Unit \ IO = region rc { spawn 1ii + 2ii @ rc }
+    def testSpawn10(): Unit = spawn 1ii + 2ii
 
     @test
-    def testSpawn11(): Unit \ IO = region rc { spawn "Hello World!" @ rc }
+    def testSpawn11(): Unit = spawn "Hello World!"
 
     @test
-    def testSpawn12(): Unit \ IO = region rc { spawn (123, 456) @ rc }
+    def testSpawn12(): Unit = spawn (123, 456)
 
     @test
-    def testSpawn13(): Unit \ IO = region rc { spawn None @ rc }
+    def testSpawn13(): Unit = spawn None
 
     @test
-    def testSpawn14(): Unit \ IO = region rc { spawn Some(42) @ rc }
+    def testSpawn14(): Unit = spawn Some(42)
 
     @test
-    def testSpawn15(): Unit \ IO = region rc { spawn Ok(42) @ rc }
+    def testSpawn15(): Unit = spawn Ok(42)
 
     @test
-    def testSpawn16(): Unit \ IO = region rc { spawn Err(42) @ rc }
+    def testSpawn16(): Unit = spawn Err(42)
 
     @test
-    def testSpawn17(): Unit \ IO = region rc { spawn spawn 123 @ rc @ rc }
+    def testSpawn17(): Unit = spawn spawn 123
 
     @test
-    def testSpawn18(): Unit \ IO = region rc { spawn spawn spawn 123 @ rc @ rc @ rc }
+    def testSpawn18(): Unit = spawn spawn spawn 123
 
-    @test
-    def testExceptionsInChildThread01(): Bool \ IO =
-        try {
-            region rc {
-                spawn {
-                    spawn { String.concat(checked_cast(null), "foo") } @ rc
-                } @ rc;
-                Thread.sleep(Time.Duration.fromSeconds(1));
-                false
-            }
-        } catch {
-            case _: NullPointerException => true
-        }
+//    @test
+//    def testExceptionsInChildThread01(): Bool \ IO =
+//        try {
+//            region rc {
+//                spawn {
+//                    spawn { String.concat(checked_cast(null), "foo") }
+//                };
+//                Thread.sleep(Time.Duration.fromSeconds(1));
+//                false
+//            }
+//        } catch {
+//            case _: NullPointerException => true
+//        }
 
 
-    @test
-    def testExceptionsInChildThread02(): Bool \ IO = region rc {
-        spawn {
-            spawn {
-                try {
-                    String.concat(checked_cast(null), "foo")
-                } catch {
-                    case _: NullPointerException => ""
-                }
-            } @ rc
-        } @ rc;
-        Thread.sleep(Time.Duration.fromSeconds(1));
-        true
-    }
+//    @test
+//    def testExceptionsInChildThread02(): Bool \ IO = region rc {
+//        spawn {
+//            spawn {
+//                try {
+//                    String.concat(checked_cast(null), "foo")
+//                } catch {
+//                    case _: NullPointerException => ""
+//                }
+//            }
+//        };
+//        Thread.sleep(Time.Duration.fromSeconds(1));
+//        true
+//    }
 }

--- a/main/test/flix/Test.Exp.Concurrency.Unbuffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Unbuffered.flix
@@ -1,230 +1,230 @@
 mod Test.Exp.Concurrency.Unbuffered {
 
     @test
-    def testUnbufferedChannelPutGet01(): Bool \ Global + NonDet + IO = region rc {
+    def testUnbufferedChannelPutGet01(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.send((), tx) @ rc;
+        spawn Channel.send((), tx);
         () == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet02(): Bool \ Global + NonDet + IO = region rc {
+    def testUnbufferedChannelPutGet02(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.send(true, tx) @ rc;
+        spawn Channel.send(true, tx);
         true == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet03(): Bool \ Global + NonDet + IO = region rc {
+    def testUnbufferedChannelPutGet03(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.send(123.456f32, tx) @ rc;
+        spawn Channel.send(123.456f32, tx);
         123.456f32 == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet04(): Bool \ Global + NonDet + IO = region rc {
+    def testUnbufferedChannelPutGet04(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.send(123.456f64, tx) @ rc;
+        spawn Channel.send(123.456f64, tx);
         123.456f64 == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet05(): Bool \ Global + NonDet + IO = region rc {
+    def testUnbufferedChannelPutGet05(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.send(42i8, tx) @ rc;
+        spawn Channel.send(42i8, tx);
         42i8 == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet06(): Bool \ Global + NonDet + IO = region rc {
+    def testUnbufferedChannelPutGet06(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.send(42i16, tx) @ rc;
+        spawn Channel.send(42i16, tx);
         42i16 == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet07(): Bool \ Global + NonDet + IO = region rc {
+    def testUnbufferedChannelPutGet07(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.send(42i32, tx) @ rc;
+        spawn Channel.send(42i32, tx);
         42i32 == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet08(): Bool \ Global + NonDet + IO = region rc {
+    def testUnbufferedChannelPutGet08(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.send(42i64, tx) @ rc;
+        spawn Channel.send(42i64, tx);
         42i64 == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet09(): Bool \ Global + NonDet + IO = region rc {
+    def testUnbufferedChannelPutGet09(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.send(42ii, tx) @ rc;
+        spawn Channel.send(42ii, tx);
         42ii == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet10(): Bool \ Global + NonDet + IO = region rc {
+    def testUnbufferedChannelPutGet10(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.send("Hello World!", tx) @ rc;
+        spawn Channel.send("Hello World!", tx);
         "Hello World!" == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet11(): Bool \ Global + NonDet + IO = region rc {
+    def testUnbufferedChannelPutGet11(): Bool \ Global + NonDet = {
         let (tx, rx): (Sender[Option[Int32]], Receiver[Option[Int32]]) = Channel.unbuffered();
-        spawn Channel.send(None, tx) @ rc;
+        spawn Channel.send(None, tx);
         None == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet12(): Bool \ Global + NonDet + IO = region rc {
+    def testUnbufferedChannelPutGet12(): Bool \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.send(Some(123), tx) @ rc;
+        spawn Channel.send(Some(123), tx);
         Some(123) == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet13(): Bool \ Global + NonDet + IO = region rc {
+    def testUnbufferedChannelPutGet13(): Bool \ Global + NonDet = {
         let (tx, rx): (Sender[Result[String, Int32]], Receiver[Result[String, Int32]]) = Channel.unbuffered();
-        spawn Channel.send(Ok(123), tx) @ rc;
+        spawn Channel.send(Ok(123), tx);
         Ok(123) == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet14(): Bool \ Global + NonDet + IO = region rc {
+    def testUnbufferedChannelPutGet14(): Bool \ Global + NonDet = {
         let (tx, rx): (Sender[Result[String, Int32]], Receiver[Result[String, Int32]]) = Channel.unbuffered();
-        spawn Channel.send(Err("Goodbye World!"), tx) @ rc;
+        spawn Channel.send(Err("Goodbye World!"), tx);
         Err("Goodbye World!") == Channel.recv(rx)
     }
 
-    @test
-    def testUnbufferedChannelPutGet15(): Bool \ Global + NonDet + IO = region rc {
-        let (tx, rx) = Channel.unbuffered();
-        spawn Channel.unsafeSend(Array#{1, 2, 3} @ rc, tx) @ rc;
-        2 == Array.get(1, Channel.recv(rx))
-    }
+//    @test
+//    def testUnbufferedChannelPutGet15(): Bool \ Global + NonDet = region rc {
+//        let (tx, rx) = Channel.unbuffered();
+//        spawn Channel.unsafeSend(Array#{1, 2, 3} @ rc, tx);
+//        2 == Array.get(1, Channel.recv(rx))
+//    }
 
     @test
-    def testUnbufferedChannelPutGet16(): Bool \ Global + NonDet + IO = region rc {
+    def testUnbufferedChannelPutGet16(): Bool \ Global + NonDet = {
         let (tx1, rx1) = Channel.unbuffered();
         let (tx2, rx2) = Channel.unbuffered();
-        spawn Channel.unsafeSend(rx2, tx1) @ rc;
-        spawn Channel.send(42, tx2) @ rc;
+        spawn Channel.unsafeSend(rx2, tx1);
+        spawn Channel.send(42, tx2);
         42 == Channel.recv(Channel.recv(rx1))
     }
 
     @test
-    def testUnbufferedChannelGetPut01(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut01(): Unit \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.recv(rx) @ rc;
+        spawn Channel.recv(rx);
         Channel.send((), tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut02(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut02(): Unit \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.recv(rx) @ rc;
+        spawn Channel.recv(rx);
         Channel.send(true, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut03(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut03(): Unit \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.recv(rx) @ rc;
+        spawn Channel.recv(rx);
         Channel.send(123.456f32, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut04(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut04(): Unit \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.recv(rx) @ rc;
+        spawn Channel.recv(rx);
         Channel.send(123.456f64, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut05(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut05(): Unit \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.recv(rx) @ rc;
+        spawn Channel.recv(rx);
         Channel.send(42i8, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut06(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut06(): Unit \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.recv(rx) @ rc;
+        spawn Channel.recv(rx);
         Channel.send(42i16, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut07(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut07(): Unit \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.recv(rx) @ rc;
+        spawn Channel.recv(rx);
         Channel.send(42i32, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut08(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut08(): Unit \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.recv(rx) @ rc;
+        spawn Channel.recv(rx);
         Channel.send(42i64, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut09(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut09(): Unit \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.recv(rx) @ rc;
+        spawn Channel.recv(rx);
         Channel.send(42ii, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut10(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut10(): Unit \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.recv(rx) @ rc;
+        spawn Channel.recv(rx);
         Channel.send("Hello World!", tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut11(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut11(): Unit \ Global + NonDet = {
         let (tx, rx): (Sender[Option[Int32]], Receiver[Option[Int32]]) = Channel.unbuffered();
-        spawn Channel.recv(rx) @ rc;
+        spawn Channel.recv(rx);
         Channel.send(None, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut12(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut12(): Unit \ Global + NonDet = {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.recv(rx) @ rc;
+        spawn Channel.recv(rx);
         Channel.send(Some(123), tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut13(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut13(): Unit \ Global + NonDet = {
         let (tx, rx): (Sender[Result[String, Int32]], Receiver[Result[String, Int32]]) = Channel.unbuffered();
-        spawn Channel.recv(rx) @ rc;
+        spawn Channel.recv(rx);
         Channel.send(Ok(123), tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut14(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut14(): Unit \ Global + NonDet = {
         let (tx, rx): (Sender[Result[String, Int32]], Receiver[Result[String, Int32]]) = Channel.unbuffered();
-        spawn Channel.recv(rx) @ rc;
+        spawn Channel.recv(rx);
         Channel.send(Err("Goodbye World!"), tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut15(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut15(): Unit \ Global + NonDet = region rc {
         let (tx, rx) = Channel.unbuffered();
-        spawn Channel.recv(rx) @ rc;
+        spawn Channel.recv(rx);
         Channel.unsafeSend(Array#{1, 2, 3} @ rc, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut16(): Unit \ Global + IO = region rc {
+    def testUnbufferedChannelGetPut16(): Unit \ Global + NonDet = {
         let (tx1, rx1) = Channel.unbuffered();
         let (tx2, rx2) = Channel.unbuffered();
-        spawn Channel.recv(Channel.recv(rx1)) @ rc;
-        spawn Channel.unsafeSend(rx2, tx1) @ rc;
+        spawn Channel.recv(Channel.recv(rx1));
+        spawn Channel.unsafeSend(rx2, tx1);
         Channel.send(42, tx2)
     }
 }

--- a/main/test/flix/Test.Exp.Concurrency.Unbuffered.flix
+++ b/main/test/flix/Test.Exp.Concurrency.Unbuffered.flix
@@ -1,228 +1,228 @@
 mod Test.Exp.Concurrency.Unbuffered {
 
     @test
-    def testUnbufferedChannelPutGet01(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet01(): Bool \ Global + NonDet + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.send((), tx) @ rc;
         () == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet02(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet02(): Bool \ Global + NonDet + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.send(true, tx) @ rc;
         true == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet03(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet03(): Bool \ Global + NonDet + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.send(123.456f32, tx) @ rc;
         123.456f32 == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet04(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet04(): Bool \ Global + NonDet + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.send(123.456f64, tx) @ rc;
         123.456f64 == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet05(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet05(): Bool \ Global + NonDet + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.send(42i8, tx) @ rc;
         42i8 == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet06(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet06(): Bool \ Global + NonDet + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.send(42i16, tx) @ rc;
         42i16 == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet07(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet07(): Bool \ Global + NonDet + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.send(42i32, tx) @ rc;
         42i32 == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet08(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet08(): Bool \ Global + NonDet + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.send(42i64, tx) @ rc;
         42i64 == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet09(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet09(): Bool \ Global + NonDet + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.send(42ii, tx) @ rc;
         42ii == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet10(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet10(): Bool \ Global + NonDet + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.send("Hello World!", tx) @ rc;
         "Hello World!" == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet11(): Bool \ IO = region rc {
-        let (tx, rx): (Sender[Option[Int32], _], Receiver[Option[Int32], _]) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet11(): Bool \ Global + NonDet + IO = region rc {
+        let (tx, rx): (Sender[Option[Int32]], Receiver[Option[Int32]]) = Channel.unbuffered();
         spawn Channel.send(None, tx) @ rc;
         None == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet12(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet12(): Bool \ Global + NonDet + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.send(Some(123), tx) @ rc;
         Some(123) == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet13(): Bool \ IO = region rc {
-        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet13(): Bool \ Global + NonDet + IO = region rc {
+        let (tx, rx): (Sender[Result[String, Int32]], Receiver[Result[String, Int32]]) = Channel.unbuffered();
         spawn Channel.send(Ok(123), tx) @ rc;
         Ok(123) == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet14(): Bool \ IO = region rc {
-        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet14(): Bool \ Global + NonDet + IO = region rc {
+        let (tx, rx): (Sender[Result[String, Int32]], Receiver[Result[String, Int32]]) = Channel.unbuffered();
         spawn Channel.send(Err("Goodbye World!"), tx) @ rc;
         Err("Goodbye World!") == Channel.recv(rx)
     }
 
     @test
-    def testUnbufferedChannelPutGet15(): Bool \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet15(): Bool \ Global + NonDet + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.unsafeSend(Array#{1, 2, 3} @ rc, tx) @ rc;
         2 == Array.get(1, Channel.recv(rx))
     }
 
     @test
-    def testUnbufferedChannelPutGet16(): Bool \ IO = region rc {
-        let (tx1, rx1) = Channel.unbuffered(rc);
-        let (tx2, rx2) = Channel.unbuffered(rc);
+    def testUnbufferedChannelPutGet16(): Bool \ Global + NonDet + IO = region rc {
+        let (tx1, rx1) = Channel.unbuffered();
+        let (tx2, rx2) = Channel.unbuffered();
         spawn Channel.unsafeSend(rx2, tx1) @ rc;
         spawn Channel.send(42, tx2) @ rc;
         42 == Channel.recv(Channel.recv(rx1))
     }
 
     @test
-    def testUnbufferedChannelGetPut01(): Unit \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut01(): Unit \ Global + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.recv(rx) @ rc;
         Channel.send((), tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut02(): Unit \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut02(): Unit \ Global + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.recv(rx) @ rc;
         Channel.send(true, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut03(): Unit \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut03(): Unit \ Global + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.recv(rx) @ rc;
         Channel.send(123.456f32, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut04(): Unit \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut04(): Unit \ Global + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.recv(rx) @ rc;
         Channel.send(123.456f64, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut05(): Unit \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut05(): Unit \ Global + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.recv(rx) @ rc;
         Channel.send(42i8, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut06(): Unit \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut06(): Unit \ Global + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.recv(rx) @ rc;
         Channel.send(42i16, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut07(): Unit \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut07(): Unit \ Global + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.recv(rx) @ rc;
         Channel.send(42i32, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut08(): Unit \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut08(): Unit \ Global + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.recv(rx) @ rc;
         Channel.send(42i64, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut09(): Unit \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut09(): Unit \ Global + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.recv(rx) @ rc;
         Channel.send(42ii, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut10(): Unit \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut10(): Unit \ Global + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.recv(rx) @ rc;
         Channel.send("Hello World!", tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut11(): Unit \ IO = region rc {
-        let (tx, rx): (Sender[Option[Int32], _], Receiver[Option[Int32], _]) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut11(): Unit \ Global + IO = region rc {
+        let (tx, rx): (Sender[Option[Int32]], Receiver[Option[Int32]]) = Channel.unbuffered();
         spawn Channel.recv(rx) @ rc;
         Channel.send(None, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut12(): Unit \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut12(): Unit \ Global + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.recv(rx) @ rc;
         Channel.send(Some(123), tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut13(): Unit \ IO = region rc {
-        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut13(): Unit \ Global + IO = region rc {
+        let (tx, rx): (Sender[Result[String, Int32]], Receiver[Result[String, Int32]]) = Channel.unbuffered();
         spawn Channel.recv(rx) @ rc;
         Channel.send(Ok(123), tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut14(): Unit \ IO = region rc {
-        let (tx, rx): (Sender[Result[String, Int32], _], Receiver[Result[String, Int32], _]) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut14(): Unit \ Global + IO = region rc {
+        let (tx, rx): (Sender[Result[String, Int32]], Receiver[Result[String, Int32]]) = Channel.unbuffered();
         spawn Channel.recv(rx) @ rc;
         Channel.send(Err("Goodbye World!"), tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut15(): Unit \ IO = region rc {
-        let (tx, rx) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut15(): Unit \ Global + IO = region rc {
+        let (tx, rx) = Channel.unbuffered();
         spawn Channel.recv(rx) @ rc;
         Channel.unsafeSend(Array#{1, 2, 3} @ rc, tx)
     }
 
     @test
-    def testUnbufferedChannelGetPut16(): Unit \ IO = region rc {
-        let (tx1, rx1) = Channel.unbuffered(rc);
-        let (tx2, rx2) = Channel.unbuffered(rc);
+    def testUnbufferedChannelGetPut16(): Unit \ Global + IO = region rc {
+        let (tx1, rx1) = Channel.unbuffered();
+        let (tx2, rx2) = Channel.unbuffered();
         spawn Channel.recv(Channel.recv(rx1)) @ rc;
         spawn Channel.unsafeSend(rx2, tx1) @ rc;
         Channel.send(42, tx2)

--- a/main/test/flix/Test.Exp.Null.flix
+++ b/main/test/flix/Test.Exp.Null.flix
@@ -16,9 +16,8 @@ mod Test.Exp.Null {
     }
 
     @test
-    def testNullChannel01(): Unit \ IO = region rc {
-        let _ = rc;
-        discard unchecked_cast(unchecked_cast(null as _ \ IO) as Receiver[String, rc] \ IO)
+    def testNullChannel01(): Unit \ IO = {
+        discard unchecked_cast(unchecked_cast(null as _ \ IO) as Receiver[String] \ IO)
     }
 
     @test

--- a/main/test/flix/Test.Handler.Spawn.flix
+++ b/main/test/flix/Test.Handler.Spawn.flix
@@ -36,28 +36,28 @@ mod Test.Handler.Spawn {
         }
 
     @Test
-    def testSpawn01(): Bool \ Global + NonDet + IO =
-        let result = region rc {
+    def testSpawn01(): Bool \ Global + NonDet =
+        let result = {
             let (tx, rx) = Channel.unbuffered();
-            spawn runGen(tx) @ rc;
+            spawn runGen(tx);
             Channel.recv(rx)
         };
         Assert.eq(42, result)
 
     @Test
-    def testSpawn02(): Bool \ Global + NonDet + IO =
-        let result = region rc {
+    def testSpawn02(): Bool \ Global + NonDet =
+        let result = {
             let (tx, rx) = Channel.unbuffered();
-            spawn runAsk(tx) @ rc;
+            spawn runAsk(tx);
             Channel.recv(rx)
         };
         Assert.eq(42, result)
 
     @Test
-    def testSpawn03(): Bool \ Global + NonDet + IO =
-        let result = region rc {
+    def testSpawn03(): Bool \ Global + NonDet =
+        let result = {
             let (tx, rx) = Channel.unbuffered();
-            spawn runGenAsk(tx) @ rc;
+            spawn runGenAsk(tx);
             Channel.recv(rx)
         };
         Assert.eq(84, result)

--- a/main/test/flix/Test.Handler.Spawn.flix
+++ b/main/test/flix/Test.Handler.Spawn.flix
@@ -8,21 +8,21 @@ mod Test.Handler.Spawn {
         def gen(): Int32
     }
 
-    def runAsk(tx: Sender[Int32, rc]): Unit \ rc =
+    def runAsk(tx: Sender[Int32]): Unit \ Global =
         try {
             Ask.ask(42)
         } with Ask {
             def ask(x, _) = Channel.send(x, tx)
         }
 
-    def runGen(tx: Sender[Int32, rc]): Unit \ rc =
+    def runGen(tx: Sender[Int32]): Unit \ Global =
         try {
             Channel.send(Gen.gen(), tx)
         } with Gen {
             def gen(k) = k(42)
         }
 
-    def runGenAsk(tx: Sender[Int32, rc]): Unit \ rc =
+    def runGenAsk(tx: Sender[Int32]): Unit \ Global =
         try {
             Ask.ask(
                 try {
@@ -36,27 +36,27 @@ mod Test.Handler.Spawn {
         }
 
     @Test
-    def testSpawn01(): Bool \ IO =
+    def testSpawn01(): Bool \ Global + NonDet + IO =
         let result = region rc {
-            let (tx, rx) = Channel.unbuffered(rc);
+            let (tx, rx) = Channel.unbuffered();
             spawn runGen(tx) @ rc;
             Channel.recv(rx)
         };
         Assert.eq(42, result)
 
     @Test
-    def testSpawn02(): Bool \ IO =
+    def testSpawn02(): Bool \ Global + NonDet + IO =
         let result = region rc {
-            let (tx, rx) = Channel.unbuffered(rc);
+            let (tx, rx) = Channel.unbuffered();
             spawn runAsk(tx) @ rc;
             Channel.recv(rx)
         };
         Assert.eq(42, result)
 
     @Test
-    def testSpawn03(): Bool \ IO =
+    def testSpawn03(): Bool \ Global + NonDet + IO =
         let result = region rc {
-            let (tx, rx) = Channel.unbuffered(rc);
+            let (tx, rx) = Channel.unbuffered();
             spawn runGenAsk(tx) @ rc;
             Channel.recv(rx)
         };

--- a/main/test/flix/Test.Unused.Var.flix
+++ b/main/test/flix/Test.Unused.Var.flix
@@ -55,8 +55,8 @@ mod Test.Unused.Var {
         }
 
     @test
-    def testUnusedVar10(): Int32 = region rc {
-        let (tx, rx) = Channel.buffered(rc, 1);
+    def testUnusedVar10(): Int32 \ Global + NonDet = {
+        let (tx, rx) = Channel.buffered(1);
         Channel.send(0, tx);
         select {
             case _foo <- recv(rx) => 123
@@ -64,9 +64,9 @@ mod Test.Unused.Var {
     }
 
     @test
-    def testUnusedVar11(): Int32 = region rc {
-        let (tx1, rx1) = Channel.buffered(rc, 1);
-        let (tx2, rx2) = Channel.buffered(rc, 1);
+    def testUnusedVar11(): Int32 \ Global + NonDet = {
+        let (tx1, rx1) = Channel.buffered(1);
+        let (tx2, rx2) = Channel.buffered(1);
         Channel.send(0, tx1);
         Channel.send(0, tx2);
         select {


### PR DESCRIPTION
This is a follow up to #9371

In this PR channels lose their region - which means that the exception propagation doesn't work anymore. I suppose its more sensible to keep the region on spawn. something to consider @magnus-madsen 