### PR TITLE
feat: differentiate between expressions and types in LocalScopeCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
@@ -15,7 +15,7 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Case, Def, Op, RestrictableCase, StructField}
+import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{AssocTypeDef, AssocTypeSig, Case, Def, Effect, Enum, Namespace, Op, Sig, Struct, StructField, TypeAlias}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 import ca.uwaterloo.flix.language.ast.shared.Resolution
 
@@ -50,23 +50,26 @@ object LocalScopeCompleter {
     */
   private def mkDeclarationCompletionForExpr(k: String, v: List[Resolution]): Iterable[Completion] =
     v.collect {
-      case  Resolution.Declaration(Def(_, _, _, _)) => Completion.LocalDeclarationCompletion(k)
+      case Resolution.Declaration(Namespace(_, _, _, _)) |
+           Resolution.Declaration(Sig(_, _, _, _)) |
+           Resolution.Declaration(Def(_, _, _, _)) |
+           Resolution.Declaration(StructField(_, _, _, _)) |
+           Resolution.Declaration(Op(_, _, _)) |
+           Resolution.Declaration(Case(_, _, _)) => Completion.LocalDeclarationCompletion(k)
     }
-
   /**
     * Tries to create a DeclarationCompletion for the given name and resolutions, the returned Completion should fit in a type context.
     */
   private def mkDeclarationCompletionForType(k: String, v: List[Resolution]): Iterable[Completion] =
-    if (v.exists{
-      case Resolution.Declaration(Def(_, _, _, _))
-        | Resolution.Declaration(StructField(_, _, _, _))
-        | Resolution.Declaration(Op(_, _, _))
-        | Resolution.Declaration(Case(_, _, _))
-        | Resolution.Declaration(RestrictableCase(_, _, _)) => false
-      case Resolution.Declaration(_) => true
-      case _ => false
-    }) Completion.LocalDeclarationCompletion(k) :: Nil else Nil
-
+    v.collect {
+      case Resolution.Declaration(Namespace(_, _, _, _)) |
+           Resolution.Declaration(Enum(_, _, _, _, _, _, _, _)) |
+           Resolution.Declaration(Struct(_, _, _, _, _, _, _, _)) |
+           Resolution.Declaration(TypeAlias(_, _, _, _, _, _, _)) |
+           Resolution.Declaration(AssocTypeSig(_, _, _, _, _, _, _)) |
+           Resolution.Declaration(AssocTypeDef(_, _, _, _, _, _)) |
+           Resolution.Declaration(Effect(_, _, _, _, _, _)) => Completion.LocalDeclarationCompletion(k)
+    }
   /**
     * Tries to create a JavaClassCompletion for the given name and resolutions.
     */

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
@@ -15,7 +15,7 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Case, Def, Op, RestrictableCase}
+import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Case, Def, Op, RestrictableCase, StructField}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 import ca.uwaterloo.flix.language.ast.shared.Resolution
 
@@ -59,6 +59,7 @@ object LocalScopeCompleter {
   private def mkDeclarationCompletionForType(k: String, v: List[Resolution]): Iterable[Completion] =
     if (v.exists{
       case Resolution.Declaration(Def(_, _, _, _))
+        | Resolution.Declaration(StructField(_, _, _, _))
         | Resolution.Declaration(Op(_, _, _))
         | Resolution.Declaration(Case(_, _, _))
         | Resolution.Declaration(RestrictableCase(_, _, _)) => false


### PR DESCRIPTION
fixes #9374 
<img width="382" alt="image" src="https://github.com/user-attachments/assets/29a67a0a-595e-42fd-a29e-4f41efa91098">

I am not familier with all the cases in `Resolution.Declaration`, now I just pick out something like is most likely to be wrong.

The list of all cases:
- Namespace
- Trait
- Instance
- Sig
- Def
- Enum
- Struct
- StructField
- RestrictableEnum
- TypeAlias
- AssocTypeSig
- AssocTypeDef
- Effect
- Op
- Case
- RestrictableCase
