### PR TITLE
feat: introduce fuzzyMatch for some completions

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoImportCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoImportCompleter.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.lsp.CompletionItemLabelDetails
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.AutoImportCompletion
-import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.{looseMatch, shouldComplete}
+import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils
 import ca.uwaterloo.flix.language.ast.TypedAst.Root
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope}
 import ca.uwaterloo.flix.language.errors.ResolutionError
@@ -54,9 +54,9 @@ object AutoImportCompleter {
    * Note: we will not propose completions for classes with a lowercase name.
    */
   private def javaClassCompletionsByClass(prefix: String, ap: AnchorPosition, env: LocalScope)(implicit root: Root): Iterable[AutoImportCompletion] = {
-    if (!shouldComplete(prefix)) return Nil
+    if (!CompletionUtils.shouldComplete(prefix)) return Nil
     val availableClasses = root.availableClasses.byClass.m.filter(_._1.exists(_.isUpper))
-    availableClasses.keys.filter(looseMatch(prefix, _)).flatMap { className =>
+    availableClasses.keys.filter(CompletionUtils.fuzzyMatch(prefix, _)).flatMap { className =>
       availableClasses(className).collect { case namespace if (!env.m.contains(className)) =>
         val qualifiedName = namespace.mkString(".") + "." + className
         val priority = mkPriority(qualifiedName)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoImportCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoImportCompleter.scala
@@ -56,7 +56,7 @@ object AutoImportCompleter {
   private def javaClassCompletionsByClass(prefix: String, ap: AnchorPosition, env: LocalScope)(implicit root: Root): Iterable[AutoImportCompletion] = {
     if (!shouldComplete(prefix)) return Nil
     val availableClasses = root.availableClasses.byClass.m.filter(_._1.exists(_.isUpper))
-    availableClasses.keys.filter(looseMatch(_, prefix)).flatMap { className =>
+    availableClasses.keys.filter(looseMatch(prefix, _)).flatMap { className =>
       availableClasses(className).collect { case namespace if (!env.m.contains(className)) =>
         val qualifiedName = namespace.mkString(".") + "." + className
         val priority = mkPriority(qualifiedName)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoImportCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoImportCompleter.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.lsp.CompletionItemLabelDetails
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.AutoImportCompletion
-import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.shouldComplete
+import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.{looseMatch, shouldComplete}
 import ca.uwaterloo.flix.language.ast.TypedAst.Root
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope}
 import ca.uwaterloo.flix.language.errors.ResolutionError
@@ -56,7 +56,7 @@ object AutoImportCompleter {
   private def javaClassCompletionsByClass(prefix: String, ap: AnchorPosition, env: LocalScope)(implicit root: Root): Iterable[AutoImportCompletion] = {
     if (!shouldComplete(prefix)) return Nil
     val availableClasses = root.availableClasses.byClass.m.filter(_._1.exists(_.isUpper))
-    availableClasses.keys.filter(_.startsWith(prefix)).flatMap { className =>
+    availableClasses.keys.filter(looseMatch(_, prefix)).flatMap { className =>
       availableClasses(className).collect { case namespace if (!env.m.contains(className)) =>
         val qualifiedName = namespace.mkString(".") + "." + className
         val priority = mkPriority(qualifiedName)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -182,7 +182,7 @@ object CompletionUtils {
     def isInternal(decl: TypedAst.Def): Boolean = decl.spec.ann.isInternal
 
     val isPublic = decl.spec.mod.isPublic && !isInternal(decl)
-    val isMatch = looseMatch(word, decl.sym.text)
+    val isMatch = fuzzyMatch(word, decl.sym.text)
 
     isMatch && isPublic
   }
@@ -194,8 +194,9 @@ object CompletionUtils {
   def shouldComplete(word: String): Boolean = word.length >= 3
 
   /**
-    * Returns `true` if the query is a loose match for the key.
+    * Returns `true` if the query is a fuzzy match for the key.
     * After splitting query and key by camel case, every query segment must be a prefix of some key segment in order.
+    * Works for camelCase and UpperCamelCase.
     *
     * Example:
     *   - looseMatch("fBT",  "fooBarTest") = true
@@ -205,7 +206,7 @@ object CompletionUtils {
     * @param query  The query string, usually from the user input.
     * @param key    The key string, usually from the completion item.
     */
-  def looseMatch(query: String, key: String): Boolean = {
+  def fuzzyMatch(query: String, key: String): Boolean = {
     @tailrec
     def matchSegments(query: List[String], key: List[String]): Boolean = (query, key) match {
       case (Nil, _) => true

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -198,9 +198,9 @@ object CompletionUtils {
     * After splitting query and key by camel case, every query segment must be a prefix of some key segment in order.
     *
     * Example:
-    *   - looseMatch("fBT", "fooBarTest") = true
+    *   - looseMatch("fBT",  "fooBarTest") = true
     *   - looseMatch("fBrT", "fooBarTest") = false
-    *   - looseMatch("fTB", "fooBarTest") = false
+    *   - looseMatch("fTB",  "fooBarTest") = false
     *
     * @param query  The query string, usually from the user input.
     * @param key    The key string, usually from the completion item.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -193,8 +193,7 @@ object CompletionUtils {
   def shouldComplete(word: String): Boolean = word.length >= 3
 
   /**
-    * Returns `true` if the given `thisName` and `thatName` are a loose match
-    * A loose match is when the first three characters of the two names are the same.
+    * Returns `true` if the first `comparedLength` characters of `name1` and `name2` are equal.
     */
   def looseMatch(name1: String, name2: String): Boolean = {
     val comparedLength = Math.min(Math.min(name1.length, name2.length), 3)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -199,9 +199,9 @@ object CompletionUtils {
     * Works for camelCase and UpperCamelCase.
     *
     * Example:
-    *   - looseMatch("fBT",  "fooBarTest") = true
-    *   - looseMatch("fBrT", "fooBarTest") = false
-    *   - looseMatch("fTB",  "fooBarTest") = false
+    *   - fuzzyMatch("fBT",  "fooBarTest") = true
+    *   - fuzzyMatch("fBrT", "fooBarTest") = false
+    *   - fuzzyMatch("fTB",  "fooBarTest") = false
     *
     * @param query  The query string, usually from the user input.
     * @param key    The key string, usually from the completion item.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -225,6 +225,6 @@ object CompletionUtils {
     * Example: "fooBarTest" -> List("foo", "Bar", "Test")
     */
   private def splitByCamelCase(input: String): List[String] = {
-    input.split("(?<!^)(?=[A-Z])").toList
+    input.split("(?=[A-Z])").toList
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -181,14 +181,23 @@ object CompletionUtils {
     def isInternal(decl: TypedAst.Def): Boolean = decl.spec.ann.isInternal
 
     val isPublic = decl.spec.mod.isPublic && !isInternal(decl)
-    val isMatch = decl.sym.text.startsWith(word)
+    val isMatch = looseMatch(decl.sym.text, word)
 
     isMatch && isPublic
   }
 
   /**
-   * Checks if we should offer AutoUseCompletion or AutoImportCompletion.
-   * Currently, we will only offer them if at least three characters have been typed.
-   */
+    * Checks if we should offer AutoUseCompletion or AutoImportCompletion.
+    * Currently, we will only offer them if at least three characters have been typed.
+    */
   def shouldComplete(word: String): Boolean = word.length >= 3
+
+  /**
+    * Returns `true` if the given `thisName` and `thatName` are a loose match
+    * A loose match is when the first three characters of the two names are the same.
+    */
+  def looseMatch(name1: String, name2: String): Boolean = {
+    val comparedLength = Math.min(Math.min(name1.length, name2.length), 3)
+    name1.take(comparedLength) == name2.take(comparedLength)
+  }
 }


### PR DESCRIPTION
fixes #9389
We introduce loose match for AutoUseCompletion and AutoImportCompletion.
A loose match for two string only requires their first three chars to be identical.
<img width="785" alt="image" src="https://github.com/user-attachments/assets/ee3b5636-d761-4cf1-af52-59ec52b1b719">
<img width="769" alt="image" src="https://github.com/user-attachments/assets/7da2a4ab-6cd1-46ed-bc6f-e78e99039551">
