### PR TITLE
refactor: lazy val `isGround`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/unification/set/SetFormula.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/unification/set/SetFormula.scala
@@ -75,7 +75,7 @@ sealed trait SetFormula {
   }
 
   /** `true` if `this` contains neither [[Var]] nor [[Cst]]. */
-  final def isGround: Boolean = this match {
+  final lazy val isGround: Boolean = this match {
     case Univ => true
     case Empty => true
     case Cst(_) => false


### PR DESCRIPTION
~2.3 % frontend throughput increase

(doing just `val` was 0.9 % faster)