### PR TITLE
feat: support AutoUse for effects

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -128,7 +128,7 @@ object CompletionProvider {
       //
       case err: ResolutionError.UndefinedJvmClass => ImportCompleter.getCompletions(err)
       case err: ResolutionError.UndefinedName => AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err) ++ AutoUseCompleter.getCompletions(err)
-      case err: ResolutionError.UndefinedType => AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err)
+      case err: ResolutionError.UndefinedType => AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err) ++ AutoUseCompleter.getCompletions(err)
       case err: TypeError.FieldNotFound => MagicMatchCompleter.getCompletions(err)
 
       case _ => Nil

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
@@ -27,6 +27,7 @@ object AutoUseCompleter {
 
   /**
     * Returns a list of auto-use completions to complete the name and use the flix construct.
+    * The completions should fit in an expression context.
     *
     * Example:
     *  If we have an undefined name which is the prefix of an existing and unused flix function
@@ -50,7 +51,17 @@ object AutoUseCompleter {
   def getCompletions(err: ResolutionError.UndefinedName)(implicit root: TypedAst.Root): Iterable[Completion] = {
     if (!shouldComplete(err.qn.ident.name)) return Nil
     if (err.qn.namespace.idents.nonEmpty) return Nil
-    mkDefCompletions(err.qn.ident.name, err.env, err.ap) ++ mkEffCompletions(err.qn.ident.name, err.env, err.ap)
+    mkDefCompletions(err.qn.ident.name, err.env, err.ap)
+  }
+
+  /**
+    * Returns a list of auto-use completions to complete the name and use the flix construct.
+    * The completions should fit in a type context.
+    */
+  def getCompletions(err: ResolutionError.UndefinedType)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    if (!shouldComplete(err.qn.ident.name)) return Nil
+    if (err.qn.namespace.idents.nonEmpty) return Nil
+    mkEffCompletions(err.qn.ident.name, err.env, err.ap)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
@@ -18,9 +18,9 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.AutoUseDefCompletion
 import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.filterDefsByScope
 import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.shouldComplete
-import ca.uwaterloo.flix.language.ast.Name.QName
+import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Effect
 import ca.uwaterloo.flix.language.ast.TypedAst
-import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope}
+import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object AutoUseCompleter {
@@ -49,16 +49,34 @@ object AutoUseCompleter {
     */
   def getCompletions(err: ResolutionError.UndefinedName)(implicit root: TypedAst.Root): Iterable[Completion] = {
     if (!shouldComplete(err.qn.ident.name)) return Nil
-    defCompletions(err.qn, err.env, err.ap)
+    if (err.qn.namespace.idents.nonEmpty) return Nil
+    mkDefCompletions(err.qn.ident.name, err.env, err.ap) ++ mkEffCompletions(err.qn.ident.name, err.env, err.ap)
+  }
+
+  /**
+    * Returns a list of completions for effects.
+    */
+  private def mkEffCompletions(word: String, env: LocalScope, ap: AnchorPosition)(implicit root: TypedAst.Root): Iterable[Completion] =
+    root.effects.collect{
+        case (sym, eff) if sym.name.startsWith(word) && checkEffScope(eff, env) => Completion.AutoUseEffCompletion(sym, eff.doc.text, ap)
+    }
+
+  /**
+    * Checks if the effect is in the scope.
+    */
+  private def checkEffScope(eff: TypedAst.Effect, scope: LocalScope): Boolean = {
+    val thisName = eff.sym.toString
+    scope.m.values.forall(_.exists {
+      case Resolution.Declaration(Effect(_, _, _, thatName, _, _)) => thisName != thatName.toString
+      case _ => true
+    })
   }
 
   /**
     * Returns a List of Completion for defs.
     */
-  private def defCompletions(qn: QName, env: LocalScope, ap: AnchorPosition)(implicit root: TypedAst.Root): Iterable[AutoUseDefCompletion] = {
-    if (qn.namespace.idents.nonEmpty)
-      return Nil
-    filterDefsByScope(qn.ident.name, root, env, whetherInScope = false)
+  private def mkDefCompletions(word: String, env: LocalScope, ap: AnchorPosition)(implicit root: TypedAst.Root): Iterable[AutoUseDefCompletion] = {
+    filterDefsByScope(word, root, env, whetherInScope = false)
       .map(Completion.AutoUseDefCompletion(_, ap))
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -44,6 +44,24 @@ sealed trait Completion {
         kind             = CompletionItemKind.Enum
       )
 
+    case Completion.AutoUseEffCompletion(sym, doc, ap) =>
+      val name = sym.name
+      val qualifiedName = sym.toString
+      val additionalTextEdits = List(Completion.mkTextEdit(ap, s"use $qualifiedName;"))
+      val labelDetails = CompletionItemLabelDetails(
+        None,
+        Some(s" use $qualifiedName"))
+      CompletionItem(
+        label               = name,
+        labelDetails        = Some(labelDetails),
+        sortText            = name,
+        textEdit            = TextEdit(context.range, name),
+        documentation       = Some(doc),
+        insertTextFormat    = InsertTextFormat.Snippet,
+        kind                = CompletionItemKind.Enum,
+        additionalTextEdits = additionalTextEdits
+      )
+
     case Completion.KeywordCompletion(name, priority) =>
       CompletionItem(
         label    = name,
@@ -617,6 +635,15 @@ object Completion {
    * @param ap            the anchor position for the use statement.
    */
   case class AutoUseDefCompletion(decl: TypedAst.Def, ap: AnchorPosition) extends Completion
+
+  /**
+   * Represents an auto-import completion.
+   *
+   * @param eff           the effect to complete and use.
+   * @param doc           the documentation associated with the effect.
+   * @param ap            the anchor position for the use statement.
+   */
+  case class AutoUseEffCompletion(eff: Symbol.EffectSym, doc: String, ap: AnchorPosition) extends Completion
 
   /**
     * Represents a Snippet completion


### PR DESCRIPTION
Another step for #9347
Preview:
<img width="701" alt="image" src="https://github.com/user-attachments/assets/e5d39111-7190-4783-90cd-95d794800483">
<img width="325" alt="image" src="https://github.com/user-attachments/assets/c9813812-2024-40c1-8729-f3e4afe10676">
<img width="679" alt="image" src="https://github.com/user-attachments/assets/713101da-ac1c-45f1-b0cc-e89efd6b4f45">

A problem is that the former completer will still suggest to complete `A.FooBar` even when `FooBar` is in scope. We'll need to change `EffSymCompleter`, but that would be another PR.

By the way, should we keep `AutoUseEffCompletion` and `EffectCompletion` two different things? We can otherwise use `Option[AnchorPosition]` to indicate if we should auto use and merge them.