### PR TITLE
feat: support AutoUse for enums

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
@@ -68,7 +68,7 @@ object AutoUseCompleter {
     */
   private def mkEffCompletions(word: String, env: LocalScope, ap: AnchorPosition)(implicit root: TypedAst.Root): Iterable[Completion] =
     root.effects.collect{
-        case (sym, eff) if fuzzyMatch(word, sym.name) && checkEffScope(eff, env) => Completion.AutoUseCompletion(sym.name, sym.toString, eff.doc.text, ap)
+        case (sym, eff) if fuzzyMatch(word, sym.name) && checkEffScope(eff, env) => Completion.AutoUseEffCompletion(sym, eff.doc.text, ap)
     }
 
   /**
@@ -87,7 +87,7 @@ object AutoUseCompleter {
    */
   private def mkEnumCompletions(word: String, env: LocalScope, ap: AnchorPosition)(implicit root: TypedAst.Root): Iterable[Completion] =
     root.enums.collect{
-      case (sym, enum) if  fuzzyMatch(word, sym.name) && checkEnumScope(enum, env) => Completion.AutoUseCompletion(sym.name, sym.toString, enum.doc.text, ap)
+      case (sym, enum) if fuzzyMatch(word, sym.name) && checkEnumScope(enum, env) => Completion.AutoUseEnumCompletion(sym, enum.doc.text, ap)
     }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -44,7 +44,9 @@ sealed trait Completion {
         kind             = CompletionItemKind.Enum
       )
 
-    case Completion.AutoUseCompletion(name, qualifiedName, doc, ap) =>
+    case Completion.AutoUseEffCompletion(sym, doc, ap) =>
+      val name = sym.name
+      val qualifiedName = sym.toString
       val additionalTextEdits = List(Completion.mkTextEdit(ap, s"use $qualifiedName"))
       val labelDetails = CompletionItemLabelDetails(
         None,
@@ -55,7 +57,23 @@ sealed trait Completion {
         sortText            = Priority.toSortText(Priority.Lower, name),
         textEdit            = TextEdit(context.range, name),
         documentation       = Some(doc),
-        insertTextFormat    = InsertTextFormat.Snippet,
+        kind                = CompletionItemKind.Enum,
+        additionalTextEdits = additionalTextEdits
+      )
+
+    case Completion.AutoUseEnumCompletion(sym, doc, ap) =>
+      val name = sym.name
+      val qualifiedName = sym.toString
+      val additionalTextEdits = List(Completion.mkTextEdit(ap, s"use $qualifiedName"))
+      val labelDetails = CompletionItemLabelDetails(
+        None,
+        Some(s" use $qualifiedName"))
+      CompletionItem(
+        label               = name,
+        labelDetails        = Some(labelDetails),
+        sortText            = Priority.toSortText(Priority.Lower, name),
+        textEdit            = TextEdit(context.range, name),
+        documentation       = Some(doc),
         kind                = CompletionItemKind.Enum,
         additionalTextEdits = additionalTextEdits
       )
@@ -637,12 +655,20 @@ object Completion {
   /**
    * Represents an auto-import completion.
    *
-   * @param name          the name to complete.
-   * @param qualifiedName the qualified name to use.
+   * @param eff           the effect to complete and use.
    * @param doc           the documentation associated with the effect.
    * @param ap            the anchor position for the use statement.
    */
-  case class AutoUseCompletion(name: String, qualifiedName: String,  doc: String, ap: AnchorPosition) extends Completion
+  case class AutoUseEffCompletion(sym: Symbol.EffectSym, doc: String, ap: AnchorPosition) extends Completion
+
+  /**
+   * Represents an auto-import completion.
+   *
+   * @param enum          the enum to complete and use.
+   * @param doc           the documentation associated with the effect.
+   * @param ap            the anchor position for the use statement.
+   */
+  case class AutoUseEnumCompletion(sym: Symbol.EnumSym, doc: String, ap: AnchorPosition) extends Completion
 
   /**
     * Represents a Snippet completion


### PR DESCRIPTION
Another step for #9347
Preview:
<img width="755" alt="image" src="https://github.com/user-attachments/assets/9aa4b6a5-9220-4bca-a705-8e0950491fc2">

<img width="402" alt="image" src="https://github.com/user-attachments/assets/6d50c693-de6c-4650-b8c1-6cde98f25fa1">

Note:
- The priority for auto use is `Lower`, the same as normal java package import.
- We use the same completion for Effects and Enums. 