### PR TITLE
fix: disable EffSymCompleter when the user is not typing a qualified name

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -84,8 +84,7 @@ object CompletionProvider {
       //
       // Types.
       //
-      case SyntacticContext.Type.Eff => EffSymCompleter.getCompletions()
-      case SyntacticContext.Type.OtherType => TypeCompleter.getCompletions(ctx) ++ EffSymCompleter.getCompletions()
+      case SyntacticContext.Type.OtherType => TypeCompleter.getCompletions(ctx)
 
       //
       // Patterns.
@@ -128,7 +127,8 @@ object CompletionProvider {
       //
       case err: ResolutionError.UndefinedJvmClass => ImportCompleter.getCompletions(err)
       case err: ResolutionError.UndefinedName => AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err) ++ AutoUseCompleter.getCompletions(err)
-      case err: ResolutionError.UndefinedType => AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err) ++ AutoUseCompleter.getCompletions(err)
+      case err: ResolutionError.UndefinedType =>
+        AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err) ++ AutoUseCompleter.getCompletions(err) ++ EffSymCompleter.getCompletions(err)
       case err: TypeError.FieldNotFound => MagicMatchCompleter.getCompletions(err)
 
       case _ => Nil

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EffSymCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EffSymCompleter.scala
@@ -17,10 +17,13 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.EffectCompletion
 import ca.uwaterloo.flix.language.ast.TypedAst
+import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object EffSymCompleter {
 
-  def getCompletions()(implicit root: TypedAst.Root): Iterable[EffectCompletion] = {
+  def getCompletions(err: ResolutionError.UndefinedType)(implicit root: TypedAst.Root): Iterable[EffectCompletion] = {
+    if (err.qn.namespace.idents.isEmpty)
+      return Nil
     root.effects.map {
       case (sym, eff) => Completion.EffectCompletion(sym, eff.doc.text)
     }


### PR DESCRIPTION
As suggested in #9434
Preview:
<img width="747" alt="image" src="https://github.com/user-attachments/assets/05e96b5a-5155-416c-9f66-a4d41cc92e63">
