### PR TITLE
fix: add missing priority for some completions

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -37,7 +37,7 @@ sealed trait Completion {
       val name = sym.toString
       CompletionItem(
         label            = name,
-        sortText         = name,
+        sortText         = Priority.toSortText(Priority.Lower, name),
         textEdit         = TextEdit(context.range, name),
         documentation    = Some(doc),
         insertTextFormat = InsertTextFormat.Snippet,
@@ -158,9 +158,9 @@ sealed trait Completion {
 
     case Completion.WithHandlerCompletion(name, textEdit) =>
       CompletionItem(
-        label = name,
-        sortText = Priority.toSortText(Priority.Highest, name),
-        textEdit = textEdit,
+        label            = name,
+        sortText         = Priority.toSortText(Priority.Highest, name),
+        textEdit         = textEdit,
         documentation    = None,
         insertTextFormat = InsertTextFormat.PlainText,
         kind             = CompletionItemKind.Snippet


### PR DESCRIPTION
I've found that the sortText of some completion is bare String.
I've changed that of EffectCompletion to `Lower`, same as DefCompletion.

Some completion remains:
- most use completion <img width="580" alt="image" src="https://github.com/user-attachments/assets/e1ea93bd-403c-4fcf-b68d-f61d26dc4c5c">
- hole completion, where priority is a string <img width="455" alt="image" src="https://github.com/user-attachments/assets/ff8df0d9-81d0-4ffb-bd15-396e54072e80">

Shall we change them to use Priority?