### PR TITLE
feat: `CompletionProvider` with lsp visitor

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
@@ -283,7 +283,7 @@ class VSCodeLspServer(port: Int, o: Options) extends WebSocketServer(new InetSoc
     case Request.Complete(id, uri, pos) =>
       // Find the source of the given URI (which should always exist).
       val sourceCode = sources(uri)
-      ("id" -> id) ~ CompletionProvider.autoComplete(uri, pos, sourceCode, currentErrors)(flix, index, root)
+      ("id" -> id) ~ CompletionProvider.autoComplete(uri, pos, sourceCode, currentErrors)(flix, root)
 
     case Request.Highlight(id, uri, pos) =>
       ("id" -> id) ~ HighlightProvider.processHighlight(uri, pos)(root)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -43,7 +43,7 @@ import org.json4s.JsonDSL.*
   */
 object CompletionProvider {
 
-  def autoComplete(uri: String, pos: Position, source: String, currentErrors: List[CompilationMessage])(implicit flix: Flix, index: Index, root: TypedAst.Root): JObject = {
+  def autoComplete(uri: String, pos: Position, source: String, currentErrors: List[CompilationMessage])(implicit flix: Flix, root: TypedAst.Root): JObject = {
     getCompletionContext(source, uri, pos, currentErrors) match {
       case None =>
         // We were not able to compute the completion context. Return no suggestions.
@@ -52,7 +52,7 @@ object CompletionProvider {
       case Some(ctx) =>
         // We were able to compute the completion context. Compute suggestions.
         val sctx = getSyntacticContext(uri, pos, currentErrors)
-        val syntacticCompletions = getSyntacticCompletions(sctx, ctx)(flix, index, root)
+        val syntacticCompletions = getSyntacticCompletions(sctx, ctx)(flix, root)
         val semanticCompletions = getSemanticCompletions(ctx, currentErrors)(root)
         val completions = syntacticCompletions ++ semanticCompletions
         val completionItems = completions.map(comp => comp.toCompletionItem(ctx))
@@ -60,7 +60,7 @@ object CompletionProvider {
     }
   }
 
-  private def getSyntacticCompletions(sctx: SyntacticContext, ctx: CompletionContext)(implicit flix: Flix, index: Index, root: TypedAst.Root): Iterable[Completion] = {
+  private def getSyntacticCompletions(sctx: SyntacticContext, ctx: CompletionContext)(implicit flix: Flix, root: TypedAst.Root): Iterable[Completion] = {
     sctx match {
       //
       // Expressions.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -113,7 +113,7 @@ object CompletionProvider {
       //
       case SyntacticContext.Unknown =>
         // Special case: A program with a hole is correct, but we should offer some completion suggestions.
-        HoleCompletion.getHoleCompletion(ctx, index, root)
+        HoleCompletion.getHoleCompletion(ctx, root)
 
       case _ => Nil
     }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
@@ -30,7 +30,7 @@ object ExprCompleter {
       EnumTagCompleter.getCompletions(context) ++
       ExprSnippetCompleter.getCompletions() ++
       ModuleCompleter.getCompletions(context) ++
-      HoleCompletion.getHoleCompletion(context, index, root) ++
+      HoleCompletion.getHoleCompletion(context, root) ++
       OpCompleter.getCompletions(context)
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst
 
 object ExprCompleter {
 
-  def getCompletions(context: CompletionContext)(implicit flix: Flix, index: Index, root: TypedAst.Root): Iterable[Completion] = {
+  def getCompletions(context: CompletionContext)(implicit flix: Flix, root: TypedAst.Root): Iterable[Completion] = {
       DefCompleter.getCompletions(context) ++
       LabelCompleter.getCompletions(context) ++
       KeywordCompleter.getExprKeywords ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LabelCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LabelCompleter.scala
@@ -15,15 +15,18 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.api.lsp.Index
+import ca.uwaterloo.flix.api.lsp.acceptors.{AllAcceptor, FileAcceptor}
+import ca.uwaterloo.flix.api.lsp.{Consumer, Index, Visitor}
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.LabelCompletion
+import ca.uwaterloo.flix.language.ast.TypedAst.Root
+import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Type, TypeConstructor, TypedAst}
 
 object LabelCompleter {
 
   /**
     * Returns a list of [[LabelCompletion]]s.
     */
-  def getCompletions(context: CompletionContext)(implicit index: Index): Iterable[LabelCompletion] = {
+  def getCompletions(context: CompletionContext)(implicit root: Root): Iterable[LabelCompletion] = {
     // Do not get label completions if we are importing or using.
     if (context.prefix.contains("import") || context.prefix.contains("use")) {
       return Nil
@@ -33,12 +36,24 @@ object LabelCompleter {
 
     context.word match {
       case regex(prefix) if isFirstCharLowerCase(prefix) =>
-        index.labelDefs.m.concat(index.labelUses.m)
-          .filter { case (_, locs) => locs.exists(loc => loc.source.name == context.uri) }
-          .map {
-            case (label, _) =>
-              Completion.LabelCompletion(label, prefix)
+        var labels: Set[Name.Label] = Set.empty
+        object LabelConsumer extends Consumer {
+          override def consumeExpr(exp: TypedAst.Expr): Unit = exp match {
+            case TypedAst.Expr.RecordRestrict(label, _, _, _, _) => labels += label
+            case TypedAst.Expr.RecordExtend(label, _, _, _, _, _) => labels += label
+            case TypedAst.Expr.RecordSelect(_, label, _, _, _) => labels += label
+            case _ => ()
           }
+
+          override def consumeType(tpe: Type): Unit = tpe match {
+            case Type.Cst(TypeConstructor.RecordRowExtend(label), _) => labels += label
+            case _ => ()
+          }
+        }
+
+        Visitor.visitRoot(root, LabelConsumer, FileAcceptor(context.uri))
+
+        labels.map(label => Completion.LabelCompletion(label, prefix))
       case _ => Nil
     }
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/PredicateCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/PredicateCompleter.scala
@@ -16,27 +16,37 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.api.lsp.Index
+import ca.uwaterloo.flix.api.lsp.acceptors.FileAcceptor
+import ca.uwaterloo.flix.api.lsp.consumers.StackConsumer
+import ca.uwaterloo.flix.api.lsp.{Consumer, Index, Visitor}
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.PredicateCompletion
-import ca.uwaterloo.flix.language.ast.{Type, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.TypedAst.Root
+import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.fmt.FormatType
 
 object PredicateCompleter {
 
-  def getCompletions(ctx: CompletionContext)(implicit index: Index, flix: Flix): Iterable[PredicateCompletion] = {
+  def getCompletions(ctx: CompletionContext)(implicit root: Root, flix: Flix): Iterable[PredicateCompletion] = {
+
     //
     // Find all predicates together with their type and source location.
     //
-    val predsWithTypeAndLoc = index.predTypes
+    var predsWithTypeAndLoc: Set[(Name.Pred, Type)] = Set.empty
+
+    object PredConsumer extends Consumer {
+      override def consumePredicate(p: TypedAst.Predicate): Unit = p match {
+        case TypedAst.Predicate.Head.Atom(name, _, _, tpe, _) => predsWithTypeAndLoc += ((name, tpe))
+        case TypedAst.Predicate.Body.Atom(name, _, _, _, _, tpe, _) => predsWithTypeAndLoc += ((name, tpe))
+        case _ => ()
+      }
+    }
 
     //
     // Select all predicate symbols that occur in the same file.
     //
-    for (
-      (pred, arityAndLocs) <- predsWithTypeAndLoc.m;
-      (tpe, loc) <- arityAndLocs
-      if loc.source.name == ctx.uri
-    ) yield Completion.PredicateCompletion(pred.name, arityOf(tpe), FormatType.formatType(tpe))
+    Visitor.visitRoot(root, PredConsumer, FileAcceptor(ctx.uri))
+
+    predsWithTypeAndLoc.map{case (predName, tpe) => Completion.PredicateCompletion(predName.name, arityOf(tpe), FormatType.formatType(tpe))}
   }
 
   /**


### PR DESCRIPTION
This PR replaces the uses of `Index` in the `CompletionProvider` by the LSP visitor.

Related to #9506.