### PR TITLE
refactor: move `AliasConstructor` from `Ast` to `shared`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Indexer.scala
@@ -20,7 +20,7 @@ import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.ast.TypedAst.*
 import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.{Body, Head}
 import ca.uwaterloo.flix.language.ast.shared.SymUse.*
-import ca.uwaterloo.flix.language.ast.shared.{Derivation, EqualityConstraint, TraitConstraint}
+import ca.uwaterloo.flix.language.ast.shared.{AliasConstructor, Derivation, EqualityConstraint, TraitConstraint}
 
 object Indexer {
 
@@ -594,7 +594,7 @@ object Indexer {
       case _ => Index.occurrenceOf(tpe0)
     }
     case Type.Apply(tpe1, tpe2, _) => visitType(tpe1) ++ visitType(tpe2)
-    case Type.Alias(Ast.AliasConstructor(sym, loc), args, _, _) => Index.occurrenceOf(tpe0) ++ Index.useOf(sym, loc) ++ traverse(args)(visitType)
+    case Type.Alias(AliasConstructor(sym, loc), args, _, _) => Index.occurrenceOf(tpe0) ++ Index.useOf(sym, loc) ++ traverse(args)(visitType)
     case Type.AssocType(Ast.AssocTypeConstructor(sym, loc), arg, _, _) => Index.occurrenceOf(tpe0) ++ Index.useOf(sym, loc) ++ visitType(arg)
 
     // Jvm types should not be exposed to the user.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/FindReferencesProvider.scala
@@ -16,12 +16,12 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider
 
+import ca.uwaterloo.flix.api.lsp.*
 import ca.uwaterloo.flix.api.lsp.acceptors.{AllAcceptor, InsideAcceptor}
 import ca.uwaterloo.flix.api.lsp.consumers.StackConsumer
-import ca.uwaterloo.flix.api.lsp.*
 import ca.uwaterloo.flix.language.ast.Ast.AssocTypeConstructor
 import ca.uwaterloo.flix.language.ast.TypedAst.{Binder, Root}
-import ca.uwaterloo.flix.language.ast.shared.{EqualityConstraint, Input, SymUse, TraitConstraint}
+import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.{Ast, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import org.json4s.JsonAST.JObject
 import org.json4s.JsonDSL.*
@@ -232,7 +232,7 @@ object FindReferencesProvider {
     case TraitConstraint.Head(sym, _) => Some(getTraitSymOccurs(sym))
     // Type Alias
     case TypedAst.TypeAlias(_, _, _, sym, _, _, _) => Some(getTypeAliasSymOccurs(sym))
-    case Type.Alias(Ast.AliasConstructor(sym, _), _, _, _) => Some(getTypeAliasSymOccurs(sym))
+    case Type.Alias(AliasConstructor(sym, _), _, _, _) => Some(getTypeAliasSymOccurs(sym))
     // Type Vars
     case TypedAst.TypeParam(_, sym, _) => Some(getTypeVarSymOccurs(sym))
     case Type.Var(sym, _) => Some(getTypeVarSymOccurs(sym))
@@ -436,7 +436,7 @@ object FindReferencesProvider {
 
     object TypeAliasSymConsumer extends Consumer {
       override def consumeType(tpe: Type): Unit = tpe match {
-        case Type.Alias(Ast.AliasConstructor(sym, loc), _, _, _) => consider(sym, loc)
+        case Type.Alias(AliasConstructor(sym, loc), _, _, _) => consider(sym, loc)
         case _ => ()
       }
     }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/HighlightProvider.scala
@@ -16,12 +16,12 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider
 
-import ca.uwaterloo.flix.api.lsp.{Acceptor, Consumer, DocumentHighlight, DocumentHighlightKind, Position, Range, ResponseStatus, Visitor}
 import ca.uwaterloo.flix.api.lsp.acceptors.{FileAcceptor, InsideAcceptor}
 import ca.uwaterloo.flix.api.lsp.consumers.StackConsumer
+import ca.uwaterloo.flix.api.lsp.{Acceptor, Consumer, DocumentHighlight, DocumentHighlightKind, Position, Range, ResponseStatus, Visitor}
 import ca.uwaterloo.flix.language.ast.TypedAst.{Binder, Expr, Root}
 import ca.uwaterloo.flix.language.ast.shared.SymUse.CaseSymUse
-import ca.uwaterloo.flix.language.ast.shared.{SymUse, TraitConstraint}
+import ca.uwaterloo.flix.language.ast.shared.{AliasConstructor, SymUse, TraitConstraint}
 import ca.uwaterloo.flix.language.ast.{Ast, Name, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import org.json4s.JsonAST.{JArray, JObject}
 import org.json4s.JsonDSL.*
@@ -301,7 +301,7 @@ object HighlightProvider {
       case TraitConstraint.Head(sym, _) => Some(highlightTraitSym(sym))
       // Type Aliases
       case TypedAst.TypeAlias(_, _, _, sym, _, _, _) => Some(highlightTypeAliasSym(sym))
-      case Type.Alias(Ast.AliasConstructor(sym, _), _, _, _) => Some(highlightTypeAliasSym(sym))
+      case Type.Alias(AliasConstructor(sym, _), _, _, _) => Some(highlightTypeAliasSym(sym))
       // Type Variables
       case TypedAst.TypeParam(_, sym, _) => Some(highlightTypeVarSym(sym))
       case Type.Var(sym, _) => Some(highlightTypeVarSym(sym))
@@ -481,7 +481,7 @@ object HighlightProvider {
     object TypeAliasSymConsumer extends Consumer {
       override def consumeTypeAlias(alias: TypedAst.TypeAlias): Unit = builder.considerWrite(alias.sym, alias.sym.loc)
       override def consumeType(tpe: Type): Unit = tpe match {
-        case Type.Alias(Ast.AliasConstructor(sym, _), _, _, loc) => builder.considerRead(sym, loc)
+        case Type.Alias(AliasConstructor(sym, _), _, _, loc) => builder.considerRead(sym, loc)
         case _ => ()
       }
     }

--- a/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Ast.scala
@@ -24,11 +24,6 @@ import ca.uwaterloo.flix.language.errors.ResolutionError
 object Ast {
 
   /**
-    * A constructor for a type alias. (Not a valid type by itself).
-    */
-  case class AliasConstructor(sym: Symbol.TypeAliasSym, loc: SourceLocation)
-
-  /**
     * A constructor for an associated type. (Not a valid type by itself).
     */
   case class AssocTypeConstructor(sym: Symbol.AssocTypeSym, loc: SourceLocation)

--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -17,7 +17,7 @@
 package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.shared.{Constant, Scope, VarText}
+import ca.uwaterloo.flix.language.ast.shared.{AliasConstructor, Constant, Scope, VarText}
 import ca.uwaterloo.flix.language.fmt.{FormatOptions, FormatType}
 import ca.uwaterloo.flix.util.InternalCompilerException
 
@@ -586,7 +586,7 @@ object Type {
   /**
     * A type alias, including the arguments passed to it and the type it represents.
     */
-  case class Alias(cst: Ast.AliasConstructor, args: List[Type], tpe: Type, loc: SourceLocation) extends Type with BaseType {
+  case class Alias(cst: AliasConstructor, args: List[Type], tpe: Type, loc: SourceLocation) extends Type with BaseType {
     override def kind: Kind = tpe.kind
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/UnkindedType.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/UnkindedType.scala
@@ -17,7 +17,7 @@ package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.shared.ScalaAnnotations.EliminatedBy
-import ca.uwaterloo.flix.language.ast.shared.{Denotation, Scope, VarText}
+import ca.uwaterloo.flix.language.ast.shared.{AliasConstructor, Denotation, Scope, VarText}
 import ca.uwaterloo.flix.language.phase.Resolver
 import ca.uwaterloo.flix.util.InternalCompilerException
 
@@ -280,9 +280,9 @@ object UnkindedType {
   /**
     * A fully resolved type alias.
     */
-  case class Alias(cst: Ast.AliasConstructor, args: List[UnkindedType], tpe: UnkindedType, loc: SourceLocation) extends UnkindedType {
+  case class Alias(cst: AliasConstructor, args: List[UnkindedType], tpe: UnkindedType, loc: SourceLocation) extends UnkindedType {
     override def equals(that: Any): Boolean = that match {
-      case Alias(Ast.AliasConstructor(sym2, _), args2, tpe2, _) => cst.sym == sym2 && args == args2 && tpe == tpe2
+      case Alias(AliasConstructor(sym2, _), args2, tpe2, _) => cst.sym == sym2 && args == args2 && tpe == tpe2
       case _ => false
     }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/AliasConstructor.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/AliasConstructor.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Holger Dal Mogensen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.language.ast.shared
+
+import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol}
+
+/**
+  * A constructor for a type alias. (Not a valid type by itself).
+  */
+case class AliasConstructor(sym: Symbol.TypeAliasSym, loc: SourceLocation)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2559,7 +2559,7 @@ object Resolver {
     def applyAlias(alias: ResolvedAst.Declaration.TypeAlias, args: List[UnkindedType], cstLoc: SourceLocation): UnkindedType = {
       val map = alias.tparams.map(_.sym).zip(args).toMap[Symbol.UnkindedTypeVarSym, UnkindedType]
       val tpe = alias.tpe.map(map)
-      val cst = Ast.AliasConstructor(alias.sym, cstLoc)
+      val cst = AliasConstructor(alias.sym, cstLoc)
       UnkindedType.Alias(cst, args, tpe, tpe0.loc)
     }
 

--- a/main/test/ca/uwaterloo/flix/language/fmt/TestFormatType.scala
+++ b/main/test/ca/uwaterloo/flix/language/fmt/TestFormatType.scala
@@ -17,8 +17,8 @@
 package ca.uwaterloo.flix.language.fmt
 
 import ca.uwaterloo.flix.TestUtils
-import ca.uwaterloo.flix.language.ast.shared.{Scope, VarText}
-import ca.uwaterloo.flix.language.ast.{Ast, Kind, Name, SourceLocation, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.shared.{AliasConstructor, Scope, VarText}
+import ca.uwaterloo.flix.language.ast.{Kind, Name, SourceLocation, Symbol, Type, TypeConstructor}
 import org.scalatest.funsuite.AnyFunSuite
 
 class TestFormatType extends AnyFunSuite with TestUtils {
@@ -71,7 +71,7 @@ class TestFormatType extends AnyFunSuite with TestUtils {
     val name = Name.mkQName("MyEmptyRecordRow")
     val ident = name.ident
     val sym = Symbol.mkTypeAliasSym(name.namespace, ident)
-    val alias = Type.Alias(Ast.AliasConstructor(sym, loc), Nil, Type.RecordRowEmpty, loc)
+    val alias = Type.Alias(AliasConstructor(sym, loc), Nil, Type.RecordRowEmpty, loc)
 
     val tpe = Type.mkRecordRowExtend(Name.Label("x", loc), Type.Int32, alias, loc)
 
@@ -85,7 +85,7 @@ class TestFormatType extends AnyFunSuite with TestUtils {
     val name = Name.mkQName("MyEmptyRecordRow")
     val ident = name.ident
     val sym = Symbol.mkTypeAliasSym(name.namespace, ident)
-    val alias = Type.Alias(Ast.AliasConstructor(sym, loc), Nil, Type.RecordRowEmpty, loc)
+    val alias = Type.Alias(AliasConstructor(sym, loc), Nil, Type.RecordRowEmpty, loc)
 
     val tpe = Type.mkRecord(alias, loc)
 
@@ -205,7 +205,7 @@ class TestFormatType extends AnyFunSuite with TestUtils {
     val name = Name.mkQName("MyEmptySchemaRow")
     val ident = name.ident
     val sym = Symbol.mkTypeAliasSym(name.namespace, ident)
-    val alias = Type.Alias(Ast.AliasConstructor(sym, loc), Nil, Type.RecordRowEmpty, loc)
+    val alias = Type.Alias(AliasConstructor(sym, loc), Nil, Type.RecordRowEmpty, loc)
 
     val latticeType1 = Type.mkLattice(List(Type.Str, Type.Bool), loc)
 
@@ -222,7 +222,7 @@ class TestFormatType extends AnyFunSuite with TestUtils {
     val ident = name.ident
     val sym = Symbol.mkTypeAliasSym(name.namespace, ident)
     val latticeType1 = Type.mkLattice(List(Type.Str, Type.Bool), loc)
-    val alias = Type.Alias(Ast.AliasConstructor(sym, loc), Nil, latticeType1, loc)
+    val alias = Type.Alias(AliasConstructor(sym, loc), Nil, latticeType1, loc)
 
 
     val tpe = Type.mkSchemaRowExtend(Name.Pred("X", loc), alias, Type.SchemaRowEmpty, loc)
@@ -441,7 +441,7 @@ class TestFormatType extends AnyFunSuite with TestUtils {
     val name = Name.mkQName("MyType")
     val ident = name.ident
     val sym = Symbol.mkTypeAliasSym(name.namespace, ident)
-    val tpe = Type.Alias(Ast.AliasConstructor(sym, loc), Nil, Type.Int32, loc)
+    val tpe = Type.Alias(AliasConstructor(sym, loc), Nil, Type.Int32, loc)
 
     val expected = "MyType"
     val actual = FormatType.formatTypeWithOptions(tpe, standardFormat)


### PR DESCRIPTION
Related to #7871