### PR TITLE
feat: introduce KindCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -130,6 +130,7 @@ object CompletionProvider {
       case err: ResolutionError.UndefinedType =>
         AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err) ++ AutoUseCompleter.getCompletions(err) ++ EffSymCompleter.getCompletions(err)
       case err: TypeError.FieldNotFound => MagicMatchCompleter.getCompletions(err)
+      case err: ResolutionError.UndefinedKind => KindCompleter.getCompletions(err)
 
       case _ => Nil
     })

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -95,6 +95,14 @@ sealed trait Completion {
         kind             = CompletionItemKind.Keyword
       )
 
+    case Completion.KindCompletion(kind) =>
+      CompletionItem(
+        label    = kind,
+        sortText = Priority.toSortText(Priority.Highest, kind),
+        textEdit = TextEdit(context.range, kind),
+        kind     = CompletionItemKind.TypeParameter
+      )
+
     case Completion.LabelCompletion(label, prefix) =>
       val name = s"$prefix#${label.name}"
       CompletionItem(
@@ -536,6 +544,13 @@ object Completion {
     * @param priority  the priority of the keyword.
     */
   case class KeywordLiteralCompletion(literal: String, priority: Priority) extends Completion
+
+  /**
+    * Represents a completion for a kind.
+    *
+    * @param kind the name of the kind.
+    */
+  case class KindCompletion(kind: String) extends Completion
 
   /**
     * Represents a label completion.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KindCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KindCompleter.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Chenhao Gao
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.uwaterloo.flix.api.lsp.provider.completion
+
+import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.KindCompletion
+import ca.uwaterloo.flix.language.errors.ResolutionError
+
+object KindCompleter {
+  def getCompletions(err: ResolutionError.UndefinedKind): List[Completion] = {
+    val kinds = List("Type", "Eff", "Bool")
+    kinds.collect{
+      case kind if kind.startsWith(err.qn.ident.name) => KindCompletion(kind)}
+  }
+}


### PR DESCRIPTION
fixes #8582
Preview: 
<img width="623" alt="image" src="https://github.com/user-attachments/assets/f6460849-7ca0-4081-8e09-c45a1a91ecf3" />
<img width="510" alt="image" src="https://github.com/user-attachments/assets/525e2c27-d185-4243-b59d-2bc087dcc7fd" />
<img width="686" alt="image" src="https://github.com/user-attachments/assets/90f855e3-d0b6-42f3-8284-c5b4913aac9d" />

Note:
- I use the Highest Priority since this is the most useful completion for UndefinedKind.
- There is no CompletionItemKind for Kind so I just use TypeParameter. Or should we use something others?