### PR TITLE
fix: lexer positions

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Token.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Token.scala
@@ -30,9 +30,9 @@ import ca.uwaterloo.flix.language.ast.shared.Source
   * @param kind  The kind of token this instance represents.
   * @param src   A pointer to the source that this lexeme stems from.
   * @param start The absolute character offset into `src` of the beginning of the lexeme. Must be zero-indexed.
-  * @param end   The absolute character offset into `src` of the end of the lexeme. Must be zero-indexed.
+  * @param end   The absolute character offset into `src` of the end (exclusive) of the lexeme. Must be zero-indexed.
   * @param sp1   The source position that the lexeme __starts__ on. Must be one-indexed.
-  * @param sp2   The source position that the lexeme __ends__ on. Must be one-indexed.
+  * @param sp2   The source position that the lexeme __ends__ on (exclusive). Must be one-indexed.
   */
 case class Token(kind: TokenKind, src: Source, start: Int, end: Int, sp1: SourcePosition, sp2: SourcePosition) extends SyntaxTree.Child {
   /**


### PR DESCRIPTION
`Lexer.retreat` didn't handle lines/columns properly and I couldn't comprehend how `State.end` was tracked.

Now i save the width of the previous line, making the end position computable on the spot when building tokens instead of keeping track of it dynamically. This width of the previous line needs to be recomputed if you retreat across multiple lines. In a follow up PR i think we should remove `retreat` and instead store checkpoints (line/col/offset/prevWidth) and just directly reset instead of going back one by one. So i judge this potential performance cost small and gone in the next PR.

These new positions agree with all locations of the existing lexer, except for some lines ending with an integer literal, in which the existing lexer gives a wrong location.