### PR TITLE
fix: semantic token of unchecked cast

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -500,8 +500,8 @@ object SemanticTokensProvider {
     case Expr.CheckedCast(_, exp, _, _, _) =>
       visitExp(exp)
 
-    case Expr.UncheckedCast(exp, _, _, tpe, _, _) =>
-      visitExp(exp) ++ visitType(tpe)
+    case Expr.UncheckedCast(exp, declaredType, declaredEff, _, _, _) =>
+      visitExp(exp) ++ declaredType.map(visitType).getOrElse(Iterator())  ++ declaredEff.map(visitType).getOrElse(Iterator())
 
     case Expr.Without(exp, eff, _, _, _) =>
       val t = SemanticToken(SemanticTokenType.Type, Nil, eff.loc)


### PR DESCRIPTION
Fixes #9518

Now visits the optional syntactic types instead of the arbitrary expression type