### PR TITLE
refactor: provide completions directly for errors

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -83,9 +83,6 @@ object CompletionProvider {
       // Expressions.
       //
       case SyntacticContext.Expr.Constraint => PredicateCompleter.getCompletions(ctx) ++ KeywordCompleter.getConstraintKeywords
-      case SyntacticContext.Expr.InvokeMethod(tpe, name) => InvokeMethodCompleter.getCompletions(tpe, name)
-      case SyntacticContext.Expr.StaticFieldOrMethod(e) => GetStaticFieldCompleter.getCompletions(e) ++ InvokeStaticMethodCompleter.getCompletions(e)
-      case SyntacticContext.Expr.StructAccess(e) => StructFieldCompleter.getCompletions(e, root)
       case _: SyntacticContext.Expr => ExprCompleter.getCompletions(ctx)
 
       //

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/SyntacticContext.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/SyntacticContext.scala
@@ -48,13 +48,7 @@ object SyntacticContext {
   object Expr {
     case object Constraint extends Expr
 
-    case class InvokeMethod(tpe: ca.uwaterloo.flix.language.ast.Type, name: Name.Ident) extends Expr
-
     case object New extends Expr
-
-    case class StaticFieldOrMethod(e: ResolutionError.UndefinedJvmStaticField) extends Expr
-
-    case class StructAccess(e: ResolutionError.UndefinedStructField) extends Expr
 
     case object OtherExpr extends Expr
   }


### PR DESCRIPTION
fixes #9568
In this PR we cancel the difference between syntactic completion and semantic completion. In stead we provide completions directly for different errors.

It seems that some SyntacticContext is not used anywhere after we cancel syntactic completion, like `SyntacticContext.Expr.InvokeMethod`. Should we remove them? in this PR?