### PR TITLE
feat: contains function for SourceLocation

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/SourceLocation.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SourceLocation.scala
@@ -54,6 +54,12 @@ case class SourceLocation(isReal: Boolean, sp1: SourcePosition, sp2: SourcePosit
     */
   def beginCol: Int = sp1.col
 
+  def contains(that: SourceLocation): Boolean = {
+    val thatBeginsLater = SourcePosition.PartialOrder.lteq(this.sp1, that.sp1)
+    val thatEndsBefore = SourcePosition.PartialOrder.lteq(that.sp2, this.sp2)
+    thatBeginsLater && thatEndsBefore
+  }
+
   /**
     * Returns the line where the entity ends.
     */

--- a/main/src/ca/uwaterloo/flix/language/ast/SourceLocation.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SourceLocation.scala
@@ -54,6 +54,12 @@ case class SourceLocation(isReal: Boolean, sp1: SourcePosition, sp2: SourcePosit
     */
   def beginCol: Int = sp1.col
 
+  /**
+    * Returns `true` if `this` [[SourceLocation]] completely contains `that`, otherwise `false`.
+    *
+    * What is meant by "contained" is that `this` begins before or at the same position as `that`
+    * and `this` ends after `that` or at the same position. Returns `false` otherwise.
+    */
   def contains(that: SourceLocation): Boolean = {
     val thatBeginsLater = SourcePosition.PartialOrder.lteq(this.sp1, that.sp1)
     val thatEndsBefore = SourcePosition.PartialOrder.lteq(that.sp2, this.sp2)

--- a/main/src/ca/uwaterloo/flix/language/ast/SourcePosition.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SourcePosition.scala
@@ -7,6 +7,22 @@ object SourcePosition {
     * Represents an unknown source position.
     */
   val Unknown: SourcePosition = SourcePosition(Source(Input.Unknown, Array.emptyCharArray), 0, 0)
+
+  implicit object PartialOrder extends PartialOrdering[SourcePosition] {
+    override def tryCompare(x: SourcePosition, y: SourcePosition): Option[Int] = {
+      if (x.source != y.source) { return None }
+      if (x.line != y.line) { return Some(x.line - y.line) }
+      if (x.col != y.col) { return Some(x.col - y.col) }
+      Some(0)
+    }
+
+    override def lteq(x: SourcePosition, y: SourcePosition): Boolean = {
+      tryCompare(x, y) match {
+        case None => false
+        case Some(value) => value <= 0
+      }
+    }
+  }
 }
 
 /**

--- a/main/src/ca/uwaterloo/flix/language/ast/SourcePosition.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SourcePosition.scala
@@ -8,7 +8,21 @@ object SourcePosition {
     */
   val Unknown: SourcePosition = SourcePosition(Source(Input.Unknown, Array.emptyCharArray), 0, 0)
 
+  /**
+    * [[PartialOrdering]] describing if and how two [[SourcePosition]] are ordered.
+    */
   implicit object PartialOrder extends PartialOrdering[SourcePosition] {
+    /**
+      * Returns a comparison between `x` and `y` if the two are comparable. Returns [[None]] otherwise.
+      *
+      * If `x` is less than `y`, the returned number is negative,
+      * if `x` is greater than `y`, it's positive and
+      * if they are the same, it's 0.
+      *
+      * @param x  The [[SourcePosition]] to be compared to `y`
+      * @param y  The [[SourcePosition]] to be comapred to `x`
+      * @return   A comparison between `x` and `y` if they're comparable, [[None]] otherwise.
+      */
     override def tryCompare(x: SourcePosition, y: SourcePosition): Option[Int] = {
       if (x.source != y.source) { return None }
       if (x.line != y.line) { return Some(x.line - y.line) }
@@ -16,6 +30,15 @@ object SourcePosition {
       Some(0)
     }
 
+    /**
+      * Returns `true` if `x` is less than or equal to `y`, `false` otherwise.
+      *
+      * If `x` and `y` aren't comparable, the return value is `false`.
+      *
+      * @param x  The [[SourcePosition]] to be compared to `y`.
+      * @param y  The [[SourcePosition]] to be compared to `x`.
+      * @return   `true` if `x` is less than or equal to `y`, `false` otherwise.
+      */
     override def lteq(x: SourcePosition, y: SourcePosition): Boolean = {
       tryCompare(x, y) match {
         case None => false

--- a/main/test/ca/uwaterloo/flix/language/LanguageSuite.scala
+++ b/main/test/ca/uwaterloo/flix/language/LanguageSuite.scala
@@ -16,6 +16,7 @@
 
 package ca.uwaterloo.flix.language
 
+import ca.uwaterloo.flix.language.ast.AstSuite
 import ca.uwaterloo.flix.language.errors.TestCompilationMessage
 import ca.uwaterloo.flix.language.fmt.TestFormatType
 import ca.uwaterloo.flix.language.phase.PhaseSuite
@@ -25,5 +26,6 @@ class LanguageSuite extends Suites(
   new PhaseSuite,
   new TestFlixErrors,
   new TestFormatType,
-  new TestCompilationMessage
+  new TestCompilationMessage,
+  new AstSuite
 )

--- a/main/test/ca/uwaterloo/flix/language/ast/AstSuite.scala
+++ b/main/test/ca/uwaterloo/flix/language/ast/AstSuite.scala
@@ -3,6 +3,7 @@ package ca.uwaterloo.flix.language.ast
 import org.scalatest.Suites
 
 class AstSuite extends Suites(
-  new SourcePositionSuite
+  new SourcePositionSuite,
+  new SourceLocationSuite
 )
 

--- a/main/test/ca/uwaterloo/flix/language/ast/AstSuite.scala
+++ b/main/test/ca/uwaterloo/flix/language/ast/AstSuite.scala
@@ -1,0 +1,8 @@
+package ca.uwaterloo.flix.language.ast
+
+import org.scalatest.Suites
+
+class AstSuite extends Suites(
+  new SourcePositionSuite
+)
+

--- a/main/test/ca/uwaterloo/flix/language/ast/SourceLocationSuite.scala
+++ b/main/test/ca/uwaterloo/flix/language/ast/SourceLocationSuite.scala
@@ -1,0 +1,177 @@
+package ca.uwaterloo.flix.language.ast
+
+import ca.uwaterloo.flix.language.ast.shared.{Input, SecurityContext, Source}
+import org.scalatest.funsuite.AnyFunSuite
+
+class SourceLocationSuite extends AnyFunSuite {
+  test("l1 contains l2 when l1 starts on earlier line and ends on later") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourceLocation(
+      isReal = true,
+      SourcePosition(source, 2, 9),
+      SourcePosition(source, 10, 3)
+    )
+    val l2 = SourceLocation(
+      isReal = false,
+      SourcePosition(source, 4, 0),
+      SourcePosition(source, 9, 10)
+    )
+
+    assert(l1.contains(l2))
+  }
+
+  test("l1 contains l2 when they start on same line and earlier col and l1 ends on later line and earlier col") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourceLocation(
+      isReal = true,
+      SourcePosition(source, 4, 3),
+      SourcePosition(source, 10, 3)
+    )
+    val l2 = SourceLocation(
+      isReal = false,
+      SourcePosition(source, 4, 4),
+      SourcePosition(source, 9, 10)
+    )
+
+    assert(l1.contains(l2))
+  }
+
+  test("l1 contains l2 when it starts on earlier line and later col and ends on same line and later col") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourceLocation(
+      isReal = true,
+      SourcePosition(source, 2, 10),
+      SourcePosition(source, 9, 11)
+    )
+    val l2 = SourceLocation(
+      isReal = false,
+      SourcePosition(source, 4, 4),
+      SourcePosition(source, 9, 10)
+    )
+
+    assert(l1.contains(l2))
+  }
+
+  test("l1 contains l2 when they start and end on same line and starts on earlier col and ends on later col") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourceLocation(
+      isReal = true,
+      SourcePosition(source, 2, 10),
+      SourcePosition(source, 9, 4)
+    )
+    val l2 = SourceLocation(
+      isReal = false,
+      SourcePosition(source, 2, 12),
+      SourcePosition(source, 9, 2)
+    )
+
+    assert(l1.contains(l2))
+  }
+
+  test("l1 contains l2 when they start and end on same line and starts on earlier col and ends on same col") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourceLocation(
+      isReal = true,
+      SourcePosition(source, 2, 10),
+      SourcePosition(source, 9, 4)
+    )
+    val l2 = SourceLocation(
+      isReal = false,
+      SourcePosition(source, 2, 12),
+      SourcePosition(source, 9, 4)
+    )
+
+    assert(l1.contains(l2))
+  }
+
+  test("l1 contains l2 when they start and end on same line and starts on same col and ends on later col") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourceLocation(
+      isReal = true,
+      SourcePosition(source, 2, 10),
+      SourcePosition(source, 9, 4)
+    )
+    val l2 = SourceLocation(
+      isReal = false,
+      SourcePosition(source, 2, 10),
+      SourcePosition(source, 9, 2)
+    )
+
+    assert(l1.contains(l2))
+  }
+
+  test("l1 contains itself") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourceLocation(
+      isReal = true,
+      SourcePosition(source, 2, 10),
+      SourcePosition(source, 9, 4)
+    )
+
+    assert(l1.contains(l1))
+  }
+
+  test("l1 doesn't contain l2 when l2 starts on earlier line") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourceLocation(
+      isReal = true,
+      SourcePosition(source, 5, 2),
+      SourcePosition(source, 9, 4)
+    )
+    val l2 = SourceLocation(
+      isReal = false,
+      SourcePosition(source, 2, 10),
+      SourcePosition(source, 8, 2)
+    )
+
+    assert(!l1.contains(l2))
+  }
+
+  test("l1 doesn't contain l2 when l2 ends on later line") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourceLocation(
+      isReal = true,
+      SourcePosition(source, 2, 2),
+      SourcePosition(source, 9, 4)
+    )
+    val l2 = SourceLocation(
+      isReal = false,
+      SourcePosition(source, 5, 10),
+      SourcePosition(source, 12, 2)
+    )
+
+    assert(!l1.contains(l2))
+  }
+
+  test("l1 doesn't contain l2 when they start on same line and l1 ends on later line but it starts on later col") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourceLocation(
+      isReal = true,
+      SourcePosition(source, 2, 10),
+      SourcePosition(source, 9, 4)
+    )
+    val l2 = SourceLocation(
+      isReal = false,
+      SourcePosition(source, 2, 2),
+      SourcePosition(source, 8, 2)
+    )
+
+    assert(!l1.contains(l2))
+  }
+
+  test("l1 doesn't contain l2 when it starts on earlier line and they end on the same line but l1 ends on earlier col") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourceLocation(
+      isReal = true,
+      SourcePosition(source, 2, 10),
+      SourcePosition(source, 9, 4)
+    )
+    val l2 = SourceLocation(
+      isReal = false,
+      SourcePosition(source, 4, 2),
+      SourcePosition(source, 9, 7)
+    )
+
+    assert(!l1.contains(l2))
+  }
+}

--- a/main/test/ca/uwaterloo/flix/language/ast/SourceLocationSuite.scala
+++ b/main/test/ca/uwaterloo/flix/language/ast/SourceLocationSuite.scala
@@ -36,7 +36,7 @@ class SourceLocationSuite extends AnyFunSuite {
     assert(l1.contains(l2))
   }
 
-  test("l1 contains l2 when it starts on earlier line and later col and ends on same line and later col") {
+  test("l1 contains l2 when l1 starts on earlier line and later col and ends on same line and later col") {
     val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
     val l1 = SourceLocation(
       isReal = true,
@@ -52,7 +52,7 @@ class SourceLocationSuite extends AnyFunSuite {
     assert(l1.contains(l2))
   }
 
-  test("l1 contains l2 when they start and end on same line and starts on earlier col and ends on later col") {
+  test("l1 contains l2 when they start and end on same line and l1 starts on earlier col and ends on later col") {
     val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
     val l1 = SourceLocation(
       isReal = true,
@@ -68,7 +68,7 @@ class SourceLocationSuite extends AnyFunSuite {
     assert(l1.contains(l2))
   }
 
-  test("l1 contains l2 when they start and end on same line and starts on earlier col and ends on same col") {
+  test("l1 contains l2 when they start and end on same line and l1 starts on earlier col and ends on same col") {
     val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
     val l1 = SourceLocation(
       isReal = true,
@@ -84,7 +84,7 @@ class SourceLocationSuite extends AnyFunSuite {
     assert(l1.contains(l2))
   }
 
-  test("l1 contains l2 when they start and end on same line and starts on same col and ends on later col") {
+  test("l1 contains l2 when they start and end on same line and l1 starts on same col and ends on later col") {
     val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
     val l1 = SourceLocation(
       isReal = true,

--- a/main/test/ca/uwaterloo/flix/language/ast/SourcePositionSuite.scala
+++ b/main/test/ca/uwaterloo/flix/language/ast/SourcePositionSuite.scala
@@ -76,11 +76,81 @@ class SourcePositionSuite extends AnyFunSuite {
   }
 
   test("tryCompare with same line and col gives 0") {
-
     val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
     val l1 = SourcePosition(source, 4, 20)
     val l2 = SourcePosition(source, 4, 20)
 
     assert(SourcePosition.PartialOrder.tryCompare(l1, l2).contains(0))
+  }
+
+  test("lteq with different sources gives none") {
+    val p1 = SourcePosition(
+      Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray),
+      0,
+      0
+    )
+    val p2 = SourcePosition(
+      Source(Input.Text("Dummy2", "dummy", SecurityContext.AllPermissions), Array.emptyCharArray),
+      0,
+      0
+    )
+
+    assert(!SourcePosition.PartialOrder.lteq(p1, p2))
+  }
+
+  test("lteq gives true for lines 2 and 4 and col 3 and 2") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val p1 = SourcePosition(source, 2, 3)
+    val p2 = SourcePosition(source, 4, 2)
+
+    assert(SourcePosition.PartialOrder.lteq(p1, p2))
+  }
+
+  test("lteq gives true for lines 2 and 4 and col 2 and 3") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val p1 = SourcePosition(source, 2, 2)
+    val p2 = SourcePosition(source, 4, 3)
+
+    assert(SourcePosition.PartialOrder.lteq(p1, p2))
+  }
+
+  test("lteq gives false for lines 6 and 3 and col 3 and 2") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val p1 = SourcePosition(source, 6, 3)
+    val p2 = SourcePosition(source, 3, 2)
+
+    assert(!SourcePosition.PartialOrder.lteq(p1, p2))
+  }
+
+  test("lteq gives false for lines 6 and 3 and col 2 and 3") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val p1 = SourcePosition(source, 6, 2)
+    val p2 = SourcePosition(source, 3, 3)
+
+    assert(!SourcePosition.PartialOrder.lteq(p1, p2))
+  }
+
+  test("lteq gives true for same lines and col 5 and 23") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val p1 = SourcePosition(source, 6, 5)
+    val p2 = SourcePosition(source, 6, 23)
+
+    assert(SourcePosition.PartialOrder.lteq(p1, p2))
+  }
+
+  test("lteq gives false for same lines and col 10 and 9") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val p1 = SourcePosition(source, 6, 10)
+    val p2 = SourcePosition(source, 6, 9)
+
+    assert(!SourcePosition.PartialOrder.lteq(p1, p2))
+  }
+
+  test("lteq gives true for same lines and same col") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val p1 = SourcePosition(source, 6, 9)
+    val p2 = SourcePosition(source, 6, 9)
+
+    assert(SourcePosition.PartialOrder.lteq(p1, p2))
   }
 }

--- a/main/test/ca/uwaterloo/flix/language/ast/SourcePositionSuite.scala
+++ b/main/test/ca/uwaterloo/flix/language/ast/SourcePositionSuite.scala
@@ -98,7 +98,7 @@ class SourcePositionSuite extends AnyFunSuite {
     assert(!SourcePosition.PartialOrder.lteq(p1, p2))
   }
 
-  test("lteq gives true for lines 2 and 4 and col 3 and 2") {
+  test("p1 lteq p2 gives true when p1's line is earlier line and col is later") {
     val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
     val p1 = SourcePosition(source, 2, 3)
     val p2 = SourcePosition(source, 4, 2)
@@ -106,7 +106,7 @@ class SourcePositionSuite extends AnyFunSuite {
     assert(SourcePosition.PartialOrder.lteq(p1, p2))
   }
 
-  test("lteq gives true for lines 2 and 4 and col 2 and 3") {
+  test("p1 lteq p2 gives true true when p1's line is earlier and col is earlier") {
     val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
     val p1 = SourcePosition(source, 2, 2)
     val p2 = SourcePosition(source, 4, 3)
@@ -114,7 +114,7 @@ class SourcePositionSuite extends AnyFunSuite {
     assert(SourcePosition.PartialOrder.lteq(p1, p2))
   }
 
-  test("lteq gives false for lines 6 and 3 and col 3 and 2") {
+  test("p1 lteq p2 gives false when p1's line and col is later") {
     val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
     val p1 = SourcePosition(source, 6, 3)
     val p2 = SourcePosition(source, 3, 2)
@@ -122,7 +122,7 @@ class SourcePositionSuite extends AnyFunSuite {
     assert(!SourcePosition.PartialOrder.lteq(p1, p2))
   }
 
-  test("lteq gives false for lines 6 and 3 and col 2 and 3") {
+  test("p1 lteq p2 gives false when p1's line is later and col is earlier") {
     val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
     val p1 = SourcePosition(source, 6, 2)
     val p2 = SourcePosition(source, 3, 3)
@@ -130,7 +130,7 @@ class SourcePositionSuite extends AnyFunSuite {
     assert(!SourcePosition.PartialOrder.lteq(p1, p2))
   }
 
-  test("lteq gives true for same lines and col 5 and 23") {
+  test("p1 lteq p2 gives true when they have same line and p1's col is earlier") {
     val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
     val p1 = SourcePosition(source, 6, 5)
     val p2 = SourcePosition(source, 6, 23)
@@ -138,7 +138,7 @@ class SourcePositionSuite extends AnyFunSuite {
     assert(SourcePosition.PartialOrder.lteq(p1, p2))
   }
 
-  test("lteq gives false for same lines and col 10 and 9") {
+  test("p1 lteq p2 gives false for they have same line and p1's col is later") {
     val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
     val p1 = SourcePosition(source, 6, 10)
     val p2 = SourcePosition(source, 6, 9)
@@ -146,7 +146,7 @@ class SourcePositionSuite extends AnyFunSuite {
     assert(!SourcePosition.PartialOrder.lteq(p1, p2))
   }
 
-  test("lteq gives true for same lines and same col") {
+  test("p1 lteq p2 gives true for same lines and same col") {
     val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
     val p1 = SourcePosition(source, 6, 9)
     val p2 = SourcePosition(source, 6, 9)

--- a/main/test/ca/uwaterloo/flix/language/ast/SourcePositionSuite.scala
+++ b/main/test/ca/uwaterloo/flix/language/ast/SourcePositionSuite.scala
@@ -1,0 +1,86 @@
+package ca.uwaterloo.flix.language.ast
+
+import ca.uwaterloo.flix.language.ast.shared.{Input, SecurityContext, Source}
+import org.scalatest.funsuite.AnyFunSuite
+
+class SourcePositionSuite extends AnyFunSuite {
+  test("tryCompare with different SourcePositions sources gives None") {
+    val l1 = SourcePosition(
+      Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray),
+      0,
+      0
+    )
+    val l2 = SourcePosition(
+      Source(Input.Text("Dummy2", "dummy", SecurityContext.AllPermissions), Array.emptyCharArray),
+      0,
+      0
+    )
+
+    assert(SourcePosition.PartialOrder.tryCompare(l1, l2) === None)
+  }
+
+  test("tryCompare with same SourcePosition sources gives Some") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourcePosition(source, 0, 0)
+    val l2 = SourcePosition(source, 0, 0)
+
+    assert(SourcePosition.PartialOrder.tryCompare(l1, l2).isDefined)
+  }
+
+  test("tryCompare with earlier line and later col gives negative") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourcePosition(source, 2, 5)
+    val l2 = SourcePosition(source, 4, 2)
+
+    assert(SourcePosition.PartialOrder.tryCompare(l1, l2).exists(n => n < 0))
+  }
+
+  test("tryCompare with earlier line and earlier col gives negative") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourcePosition(source, 3, 2)
+    val l2 = SourcePosition(source, 4, 20)
+
+    assert(SourcePosition.PartialOrder.tryCompare(l1, l2).exists(n => n < 0))
+  }
+
+  test("tryCompare with later line and earlier col gives positive") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourcePosition(source, 4, 11)
+    val l2 = SourcePosition(source, 1, 13)
+
+    assert(SourcePosition.PartialOrder.tryCompare(l1, l2).exists(n => n > 0))
+  }
+
+  test("tryCompare with later line and later col gives positive") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourcePosition(source, 4, 20)
+    val l2 = SourcePosition(source, 1, 13)
+
+    assert(SourcePosition.PartialOrder.tryCompare(l1, l2).exists(n => n > 0))
+  }
+
+  test("tryCompare with same line and earlier col gives negative") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourcePosition(source, 4, 4)
+    val l2 = SourcePosition(source, 4, 13)
+
+    assert(SourcePosition.PartialOrder.tryCompare(l1, l2).exists(n => n < 0))
+  }
+
+  test("tryCompare with same line and later col gives positive") {
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourcePosition(source, 4, 19)
+    val l2 = SourcePosition(source, 4, 13)
+
+    assert(SourcePosition.PartialOrder.tryCompare(l1, l2).exists(n => n > 0))
+  }
+
+  test("tryCompare with same line and col gives 0") {
+
+    val source = Source(Input.Text("Dummy1", "dummy dummy", SecurityContext.AllPermissions), Array.emptyCharArray)
+    val l1 = SourcePosition(source, 4, 20)
+    val l2 = SourcePosition(source, 4, 20)
+
+    assert(SourcePosition.PartialOrder.tryCompare(l1, l2).contains(0))
+  }
+}


### PR DESCRIPTION
This adds a `contains` function to `SourceLocation`s as well as a partial ordering on `SourcePosition`s used by the aforementioned.

This is related to #4276 and will be used by the `HighlightProvider`.