### PR TITLE
refactor: merge DefCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.api.lsp.provider
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.*
 import ca.uwaterloo.flix.api.lsp.provider.completion.*
-import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.updateQNameBasedOnDot
+import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.getNamespaceAndIdentFromQName
 import ca.uwaterloo.flix.api.lsp.provider.completion.semantic.{GetStaticFieldCompleter, InvokeStaticMethodCompleter}
 import ca.uwaterloo.flix.api.lsp.provider.completion.syntactic.{ExprSnippetCompleter, KeywordCompleter}
 import ca.uwaterloo.flix.language.CompilationMessage
@@ -52,7 +52,7 @@ object CompletionProvider {
         case ResolutionError.UndefinedUse(_, _, _, _) => UseCompleter.getCompletions(ctx)
         case ResolutionError.UndefinedTag(_, _, _, _) => ModuleCompleter.getCompletions(ctx) ++ EnumTagCompleter.getCompletions(ctx)
         case err: ResolutionError.UndefinedName =>
-          val (namespace, ident) = updateQNameBasedOnDot(err.qn, err.loc)
+          val (namespace, ident) = getNamespaceAndIdentFromQName(err.qn, err.loc)
           AutoImportCompleter.getCompletions(err) ++
             LocalScopeCompleter.getCompletions(err) ++
             AutoUseCompleter.getCompletions(err) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -18,6 +18,7 @@ package ca.uwaterloo.flix.api.lsp.provider
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.*
 import ca.uwaterloo.flix.api.lsp.provider.completion.*
+import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.updateQNameBasedOnDot
 import ca.uwaterloo.flix.api.lsp.provider.completion.semantic.{GetStaticFieldCompleter, InvokeStaticMethodCompleter}
 import ca.uwaterloo.flix.api.lsp.provider.completion.syntactic.{ExprSnippetCompleter, KeywordCompleter}
 import ca.uwaterloo.flix.language.CompilationMessage
@@ -50,11 +51,13 @@ object CompletionProvider {
         case WeederError.UndefinedAnnotation(_, _) => KeywordCompleter.getModKeywords ++ ExprSnippetCompleter.getCompletions()
         case ResolutionError.UndefinedUse(_, _, _, _) => UseCompleter.getCompletions(ctx)
         case ResolutionError.UndefinedTag(_, _, _, _) => ModuleCompleter.getCompletions(ctx) ++ EnumTagCompleter.getCompletions(ctx)
-        case err: ResolutionError.UndefinedName => AutoImportCompleter.getCompletions(err) ++
-          LocalScopeCompleter.getCompletions(err) ++
-          AutoUseCompleter.getCompletions(err) ++
-          ExprCompleter.getCompletions(ctx) ++
-          DefCompleter.getCompletions(err)
+        case err: ResolutionError.UndefinedName =>
+          val qn = updateQNameBasedOnDot(err.qn, err.loc)
+          AutoImportCompleter.getCompletions(err) ++
+            LocalScopeCompleter.getCompletions(err) ++
+            AutoUseCompleter.getCompletions(err) ++
+            ExprCompleter.getCompletions(ctx) ++
+            DefCompleter.getCompletions(err, qn)
         case err: ResolutionError.UndefinedType => AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err) ++ AutoUseCompleter.getCompletions(err) ++ EffSymCompleter.getCompletions(err) ++ TypeCompleter.getCompletions(ctx)
         case err: ResolutionError.UndefinedJvmStaticField => GetStaticFieldCompleter.getCompletions(err) ++ InvokeStaticMethodCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedJvmClass => ImportCompleter.getCompletions(err)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -52,7 +52,7 @@ object CompletionProvider {
         case ResolutionError.UndefinedUse(_, _, _, _) => UseCompleter.getCompletions(ctx)
         case ResolutionError.UndefinedTag(_, _, _, _) => ModuleCompleter.getCompletions(ctx) ++ EnumTagCompleter.getCompletions(ctx)
         case err: ResolutionError.UndefinedName =>
-          val (namespace, ident) = getNamespaceAndIdentFromQName(err.qn, err.loc)
+          val (namespace, ident) = getNamespaceAndIdentFromQName(err.qn)
           AutoImportCompleter.getCompletions(err) ++
             LocalScopeCompleter.getCompletions(err) ++
             AutoUseCompleter.getCompletions(err) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -50,7 +50,11 @@ object CompletionProvider {
         case WeederError.UndefinedAnnotation(_, _) => KeywordCompleter.getModKeywords ++ ExprSnippetCompleter.getCompletions()
         case ResolutionError.UndefinedUse(_, _, _, _) => UseCompleter.getCompletions(ctx)
         case ResolutionError.UndefinedTag(_, _, _, _) => ModuleCompleter.getCompletions(ctx) ++ EnumTagCompleter.getCompletions(ctx)
-        case err: ResolutionError.UndefinedName => AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err) ++ AutoUseCompleter.getCompletions(err) ++ ExprCompleter.getCompletions(ctx)
+        case err: ResolutionError.UndefinedName => AutoImportCompleter.getCompletions(err) ++
+          LocalScopeCompleter.getCompletions(err) ++
+          AutoUseCompleter.getCompletions(err) ++
+          ExprCompleter.getCompletions(ctx) ++
+          DefCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedType => AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err) ++ AutoUseCompleter.getCompletions(err) ++ EffSymCompleter.getCompletions(err) ++ TypeCompleter.getCompletions(ctx)
         case err: ResolutionError.UndefinedJvmStaticField => GetStaticFieldCompleter.getCompletions(err) ++ InvokeStaticMethodCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedJvmClass => ImportCompleter.getCompletions(err)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -52,12 +52,12 @@ object CompletionProvider {
         case ResolutionError.UndefinedUse(_, _, _, _) => UseCompleter.getCompletions(ctx)
         case ResolutionError.UndefinedTag(_, _, _, _) => ModuleCompleter.getCompletions(ctx) ++ EnumTagCompleter.getCompletions(ctx)
         case err: ResolutionError.UndefinedName =>
-          val qn = updateQNameBasedOnDot(err.qn, err.loc)
+          val (namespace, ident) = updateQNameBasedOnDot(err.qn, err.loc)
           AutoImportCompleter.getCompletions(err) ++
             LocalScopeCompleter.getCompletions(err) ++
             AutoUseCompleter.getCompletions(err) ++
             ExprCompleter.getCompletions(ctx) ++
-            DefCompleter.getCompletions(err, qn)
+            DefCompleter.getCompletions(err, namespace, ident)
         case err: ResolutionError.UndefinedType => AutoImportCompleter.getCompletions(err) ++ LocalScopeCompleter.getCompletions(err) ++ AutoUseCompleter.getCompletions(err) ++ EffSymCompleter.getCompletions(err) ++ TypeCompleter.getCompletions(ctx)
         case err: ResolutionError.UndefinedJvmStaticField => GetStaticFieldCompleter.getCompletions(err) ++ InvokeStaticMethodCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedJvmClass => ImportCompleter.getCompletions(err)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoUseCompleter.scala
@@ -15,8 +15,7 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.AutoUseDefCompletion
-import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.{filterDefsByScope, fuzzyMatch, shouldComplete}
+import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.{fuzzyMatch, shouldComplete}
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Effect, Enum}
 import ca.uwaterloo.flix.language.ast.TypedAst
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
@@ -50,7 +49,7 @@ object AutoUseCompleter {
   def getCompletions(err: ResolutionError.UndefinedName)(implicit root: TypedAst.Root): Iterable[Completion] = {
     if (!shouldComplete(err.qn.ident.name)) return Nil
     if (err.qn.namespace.idents.nonEmpty) return Nil
-    mkDefCompletions(err.qn.ident.name, err.env, err.ap)
+    Nil
   }
 
   /**
@@ -99,13 +98,5 @@ object AutoUseCompleter {
       case Resolution.Declaration(Enum(_, _, _, thatName, _, _, _, _)) => thisName != thatName.toString
       case _ => true
     })
-  }
-
-  /**
-    * Returns a List of Completion for defs.
-    */
-  private def mkDefCompletions(word: String, env: LocalScope, ap: AnchorPosition)(implicit root: TypedAst.Root): Iterable[AutoUseDefCompletion] = {
-    filterDefsByScope(word, root, env, whetherInScope = false)
-      .map(Completion.AutoUseDefCompletion(_, ap))
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -274,10 +274,11 @@ sealed trait Completion {
       } else None
       val labelDetails = CompletionItemLabelDetails(Some(CompletionUtils.getLabelForSpec(decl.spec)(flix)), description)
       val additionalTextEdit = if (inScope) Nil else List(Completion.mkTextEdit(ap, s"use $qualifiedName"))
+      val priority = if (inScope) Priority.High else Priority.Lower
       CompletionItem(
         label               = label,
         labelDetails        = Some(labelDetails),
-        sortText            = Priority.toSortText(Priority.Lower, qualifiedName),
+        sortText            = Priority.toSortText(priority, qualifiedName),
         filterText          = Some(CompletionUtils.getFilterTextForName(qualifiedName)),
         textEdit            = TextEdit(context.range, snippet),
         detail              = Some(FormatScheme.formatScheme(decl.spec.declaredScheme)(flix)),

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -231,21 +231,21 @@ object CompletionUtils {
   }
 
   /**
-    * Updates the given `qn` based on the character immediately following the location.
+    * Parse given `qn` based on the character immediately following the location.
     * If the character is a dot, we move the ident to the namespace.
-    * Otherwise, we will keep the `qn` as it is.
+    * Otherwise, we will just take namespace and ident out of qn.
     *
     * Example:
-    *   - Source "AA.BB", QName(["AA"], "BB") -> QName(["AA"], "BB")
-    *   - Source "AA.BB.", QName(["AA"], "BB") -> QName(["AA", "BB"], "")
+    *   - Source "A.B.C", QName(["A", "B"], "C") -> ("A.B", "C")
+    *   - Source "A.B.C.", QName(["A", "B"], "C") -> ("A.B.C", "")
     */
-  def updateQNameBasedOnDot(qn: QName, loc: SourceLocation): (List[String], String) = {
+  def getNamespaceAndIdentFromQName(qn: QName, loc: SourceLocation): (String, String) = {
     val ident = if (followedByDot(loc)) "" else qn.ident.name
     val namespace = qn.namespace.idents.map(_.name) ++ {
       if (followedByDot(loc)) List(qn.ident.name)
       else Nil
     }
-    (namespace, ident)
+    (namespace.mkString("."), ident)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -239,13 +239,13 @@ object CompletionUtils {
     *   - Source "AA.BB", QName(["AA"], "BB") -> QName(["AA"], "BB")
     *   - Source "AA.BB.", QName(["AA"], "BB") -> QName(["AA", "BB"], "")
     */
-  def updateQNameBasedOnDot(qn: QName, loc: SourceLocation): QName = {
+  def updateQNameBasedOnDot(qn: QName, loc: SourceLocation): (List[String], String) = {
     val ident = if (followedByDot(loc)) "" else qn.ident.name
     val namespace = qn.namespace.idents.map(_.name) ++ {
       if (followedByDot(loc)) List(qn.ident.name)
       else Nil
     }
-    Name.mkQName(namespace, ident, SourceLocation.Unknown)
+    (namespace, ident)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Paul Butcher, Lukas Rønn, Magnus Madsen
+ * Copyright 2025 Chenhao Gao
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +19,7 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Name.QName
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Def
-import ca.uwaterloo.flix.language.ast.{Name, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
+import ca.uwaterloo.flix.language.ast.{SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.ast.shared.{LocalScope, Resolution}
 import ca.uwaterloo.flix.language.fmt.FormatType
 
@@ -239,10 +240,10 @@ object CompletionUtils {
     *   - Source "A.B.C", QName(["A", "B"], "C") -> ("A.B", "C")
     *   - Source "A.B.C.", QName(["A", "B"], "C") -> ("A.B.C", "")
     */
-  def getNamespaceAndIdentFromQName(qn: QName, loc: SourceLocation): (List[String], String) = {
-    val ident = if (followedByDot(loc)) "" else qn.ident.name
+  def getNamespaceAndIdentFromQName(qn: QName): (List[String], String) = {
+    val ident = if (followedByDot(qn.loc)) "" else qn.ident.name
     val namespace = qn.namespace.idents.map(_.name) ++ {
-      if (followedByDot(loc)) List(qn.ident.name)
+      if (followedByDot(qn.loc)) List(qn.ident.name)
       else Nil
     }
     (namespace, ident)
@@ -251,7 +252,7 @@ object CompletionUtils {
   /**
     * Returns true if the character immediately following the location is a dot.
     * Note:
-    *   - loc.endCol will point to the next character after QName.
+    *   - loc.endCol will point to the next character after QName. That's exactly what we want to check.
     *   - loc is 1-indexed, so we are actually checking the character at loc.endCol-1.
     */
   private def followedByDot(loc: SourceLocation): Boolean = {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -239,13 +239,13 @@ object CompletionUtils {
     *   - Source "A.B.C", QName(["A", "B"], "C") -> ("A.B", "C")
     *   - Source "A.B.C.", QName(["A", "B"], "C") -> ("A.B.C", "")
     */
-  def getNamespaceAndIdentFromQName(qn: QName, loc: SourceLocation): (String, String) = {
+  def getNamespaceAndIdentFromQName(qn: QName, loc: SourceLocation): (List[String], String) = {
     val ident = if (followedByDot(loc)) "" else qn.ident.name
     val namespace = qn.namespace.idents.map(_.name) ++ {
       if (followedByDot(loc)) List(qn.ident.name)
       else Nil
     }
-    (namespace.mkString("."), ident)
+    (namespace, ident)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
@@ -16,9 +16,10 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.DefCompletion
+import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.fuzzyMatch
 import ca.uwaterloo.flix.language.ast.Name.QName
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Def
-import ca.uwaterloo.flix.language.ast.{SourceLocation, TypedAst}
+import ca.uwaterloo.flix.language.ast.TypedAst
 import ca.uwaterloo.flix.language.ast.shared.{LocalScope, Resolution}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
@@ -52,7 +53,7 @@ object DefCompleter {
     val isMatch = if (qualified)
       decl.sym.toString.startsWith(qn.toString)
     else
-      decl.sym.name.startsWith(qn.ident.name)
+      fuzzyMatch(qn.ident.name, decl.sym.name)
     isMatch && (isPublic || isInFile)
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.DefCompletion
-import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.{fuzzyMatch, updateQNameBasedOnDot}
+import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.fuzzyMatch
 import ca.uwaterloo.flix.language.ast.Name.QName
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Def
 import ca.uwaterloo.flix.language.ast.TypedAst

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
@@ -24,8 +24,7 @@ import ca.uwaterloo.flix.language.ast.shared.{LocalScope, Resolution}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object DefCompleter {
-  def getCompletions(err: ResolutionError.UndefinedName)(implicit root: TypedAst.Root): Iterable[Completion] ={
-    val qn = updateQNameBasedOnDot(err.qn, err.loc)
+  def getCompletions(err: ResolutionError.UndefinedName, qn: QName)(implicit root: TypedAst.Root): Iterable[Completion] ={
     if (qn.namespace.idents.nonEmpty)
       root.defs.values.collect{
         case decl if matchesDef(decl, qn, err.loc.source.name, qualified = true)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
@@ -28,7 +28,7 @@ object DefCompleter {
     * Whether the returned completions are qualified is based on whether the UndefinaedName is qualified.
     * When providing completions for unqualified defs that is not in scope, we will also automatically use the def.
     */
-  def getCompletions(err: ResolutionError.UndefinedName, namespace: String, ident: String)(implicit root: TypedAst.Root): Iterable[Completion] ={
+  def getCompletions(err: ResolutionError.UndefinedName, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] ={
     if (namespace.nonEmpty)
       root.defs.values.collect{
         case decl if matchesDef(decl, namespace, ident, err.loc.source.name, qualified = true) =>
@@ -59,7 +59,7 @@ object DefCompleter {
     * Checks if the definition matches the QName.
     * Names should match and the definition should be available.
     */
-  private def matchesDef(decl: TypedAst.Def, namespace: String, ident: String, uri: String, qualified: Boolean): Boolean = {
+  private def matchesDef(decl: TypedAst.Def, namespace: List[String], ident: String, uri: String, qualified: Boolean): Boolean = {
     val isPublic = decl.spec.mod.isPublic && !decl.spec.ann.isInternal
     val isInFile = decl.sym.loc.source.name == uri
     val isMatch = if (qualified)
@@ -76,8 +76,9 @@ object DefCompleter {
     * Example:
     *   matchesQualifiedDef("A.B.fooBar", "A.B", "fB") => true
     */
-  private def matchesQualifiedDef(decl: TypedAst.Def, namespace: String, ident: String): Boolean = {
+  private def matchesQualifiedDef(decl: TypedAst.Def, namespace: List[String], ident: String): Boolean = {
     val qualifiedDef = decl.sym.toString
-    qualifiedDef.startsWith(namespace) && fuzzyMatch(ident, qualifiedDef.substring(namespace.length + 1))
+    val nsString = namespace.mkString(".")
+    qualifiedDef.startsWith(nsString) && fuzzyMatch(ident, qualifiedDef.substring(nsString.length + 1))
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
@@ -22,7 +22,6 @@ import ca.uwaterloo.flix.language.ast.TypedAst
 object ExprCompleter {
 
   def getCompletions(context: CompletionContext)(implicit flix: Flix, root: TypedAst.Root): Iterable[Completion] = {
-//      DefCompleter.getCompletions(context) ++
       LabelCompleter.getCompletions(context) ++
       KeywordCompleter.getExprKeywords ++
       SignatureCompleter.getCompletions(context) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
@@ -22,7 +22,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst
 object ExprCompleter {
 
   def getCompletions(context: CompletionContext)(implicit flix: Flix, root: TypedAst.Root): Iterable[Completion] = {
-      DefCompleter.getCompletions(context) ++
+//      DefCompleter.getCompletions(context) ++
       LabelCompleter.getCompletions(context) ++
       KeywordCompleter.getExprKeywords ++
       SignatureCompleter.getCompletions(context) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
@@ -15,10 +15,9 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{AssocTypeDef, AssocTypeSig, Case, Def, Effect, Enum, Namespace, Op, Sig, Struct, StructField, TypeAlias}
-import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.filterDefsByScope
+import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{AssocTypeDef, AssocTypeSig, Case, Effect, Enum, Namespace, Op, Sig, Struct, StructField, TypeAlias}
 import ca.uwaterloo.flix.language.errors.ResolutionError
-import ca.uwaterloo.flix.language.ast.shared.{LocalScope, Resolution}
+import ca.uwaterloo.flix.language.ast.shared.Resolution
 import ca.uwaterloo.flix.language.ast.TypedAst
 
 /**
@@ -37,7 +36,7 @@ object LocalScopeCompleter {
    err.env.env.m.foldLeft((List.empty[Completion])){case (acc, (name, resolutions)) =>
       acc ++ mkDeclarationCompletionForExpr(name, resolutions) ++ mkJavaClassCompletion(name, resolutions) ++
         mkVarCompletion(name, resolutions) ++ mkLocalDefCompletion(resolutions)
-   } ++ mkDefCompletion(err.qn.ident.name, err.env)
+   }
 
   /**
     * Returns a list of completions for UndefinedType.
@@ -73,12 +72,6 @@ object LocalScopeCompleter {
            Resolution.Declaration(AssocTypeDef(_, _, _, _, _, _)) |
            Resolution.Declaration(Effect(_, _, _, _, _, _)) => Completion.LocalDeclarationCompletion(k)
     }
-
-  /**
-    * Tries to create a DefCompletion for the given word and env.
-    */
-  private def mkDefCompletion(name: String, env: LocalScope)(implicit root: TypedAst.Root): Iterable[Completion] =
-    filterDefsByScope(name, root, env, whetherInScope = true).map(Completion.DefCompletion(_, qualified = false))
 
   /**
     * Tries to create a JavaClassCompletion for the given name and resolutions.


### PR DESCRIPTION
According to #9355, we are now merge different parts of DefCompleter from LocalScopeCompleter, ExprCompleter and AutoUseCompleter into a single DefCompleter.
Preview:
<img width="668" alt="image" src="https://github.com/user-attachments/assets/bc923b3a-ca0a-4b42-9b53-d7c6889a8c28" />
<img width="479" alt="image" src="https://github.com/user-attachments/assets/23a29525-6df2-46c9-b5e7-0cfe1beb8cfa" />
<img width="736" alt="image" src="https://github.com/user-attachments/assets/8f703e91-81ca-4cb7-8a40-07f69b83eeb8" />
<img width="539" alt="image" src="https://github.com/user-attachments/assets/8f4f2ee6-ed1e-4727-b3b5-36533b296c3b" />

But some problems remain:
- There used to be another guard named `canApplySnippet` that will check if we should use a snippet in situations with `|>` or similar things. But that needs the `previousWord` information from `CompletionContext`. To preserve that guard, we should add this to the error or find the `previousWord` anyway in the completer.
- Some ParseError will carry a `SyntacticContext.Expr.OtherExpr` that will now trigger `ExprCompleter`. If we remove `DefCompleter` and other completers gradually from `ExprCompleter`, how should we handle these `ParseError`? This applies to many other completers too. Something used in `DefCompleter`, like LocalScope or AnchorPosition, is not available just from `SyntacticContext.Expr.OtherExpr`.
- `DefCompleter` now provides completions for defs in scope, defs out of scope and qualified defs. But offering completions for qualified defs still suffers from the dot problem we met before. I suggest that we just provide completions for defs in scope and out of scope in `DefCompleter`, while delegating the completions for qualified defs and other qualified things to the something like a "NameSpaceCompleter", as we can handle with the dot problem in one place and provide completions for all sorts of things in the namespace.