### PR TITLE
refactor: get rid of `Lexer.retreat`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -103,7 +103,6 @@ object Lexer {
       Checkpoint(
         start = new Position(this.start.line, this.start.column, this.start.offset),
         current = new Position(this.current.line, this.current.column, this.current.offset),
-        end = new Position(this.end.line, this.end.column, this.end.offset),
         tokensLength = tokens.length,
         interpolationNestingLevel = this.interpolationNestingLevel
       )
@@ -117,14 +116,11 @@ object Lexer {
       this.current.line = c.current.line
       this.current.column = c.current.column
       this.current.offset = c.current.offset
-      this.end.line = c.end.line
-      this.end.column = c.end.column
-      this.end.offset = c.end.offset
       this.interpolationNestingLevel = c.interpolationNestingLevel
     }
   }
 
-  private case class Checkpoint(start: Position, current: Position, end: Position, tokensLength: Int, interpolationNestingLevel: Int)
+  private case class Checkpoint(start: Position, current: Position, tokensLength: Int, interpolationNestingLevel: Int)
 
   /**
     * A source position keeping track of both line, column as well as absolute character offset.

--- a/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lexer.scala
@@ -20,7 +20,7 @@ import ca.uwaterloo.flix.language.ast.shared.Source
 import ca.uwaterloo.flix.language.ast.*
 import ca.uwaterloo.flix.language.dbg.AstPrinter.DebugNoOp
 import ca.uwaterloo.flix.language.errors.LexerError
-import ca.uwaterloo.flix.util.ParOps
+import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
 import scala.collection.mutable
 import scala.util.Random
@@ -98,8 +98,9 @@ object Lexer {
 
     /** Restore a previously saved checkpoint. No tokens must have been produced since the checkpoint was created. */
     def restore(c: Checkpoint): Unit = {
-      if (tokens.length != c.tokensLength) ???
-      if (start.line != c.start.line || start.column != c.start.column || start.offset != c.start.offset) ???
+      if (tokens.length != c.tokensLength) throw InternalCompilerException("Restored checkpoint across token generation", sourceLocationAtCurrent()(this))
+      if (start.line != c.start.line || start.column != c.start.column || start.offset != c.start.offset)
+        throw InternalCompilerException("Restored checkpoint across token generation (start was moved)", sourceLocationAtCurrent()(this))
       this.current.line = c.current.line
       this.current.column = c.current.column
       this.current.offset = c.current.offset


### PR DESCRIPTION
retreat has a bug with positions so now there is a simpler checkpoint mechanism. This might be a bit slower but its used rarely. 2/3 places could also avoid using checkpoints with a new version of the isMatch function

This PR changes some source locations a la #9548, but it that PR is merged first, then this will have no location changes