### PR TITLE
feat: extend `Process` effect (#9414)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -73,3 +73,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Joseph Tan](https://github.com/dghosef)
 - [Alexander Dybdahl Troelsen](https://github.com/LoZander)
 - [Chenhao Gao](https://github.com/stormckey)
+- [Maksim Gusev](https://github.com/emaisty)

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -274,7 +274,9 @@ class Flix {
     "FileReadWithResult.flix" -> LocalResource.get("/src/library/FileReadWithResult.flix"),
     "FileWrite.flix" -> LocalResource.get("/src/library/FileWrite.flix"),
     "FileWriteWithResult.flix" -> LocalResource.get("/src/library/FileWriteWithResult.flix"),
+    "ProcessHandle.flix" -> LocalResource.get("/src/library/ProcessHandle.flix"),
     "Process.flix" -> LocalResource.get("/src/library/Process.flix"),
+    "ProcessWithResult.flix" -> LocalResource.get("/src/library/ProcessWithResult.flix"),
     "Severity.flix" -> LocalResource.get("/src/library/Severity.flix"),
     "TimeUnit.flix" -> LocalResource.get("/src/library/TimeUnit.flix"),
 

--- a/main/src/library/Process.flix
+++ b/main/src/library/Process.flix
@@ -27,6 +27,12 @@ eff Process {
 
 mod Process {
 
+    use IoError.ErrorKind
+    use IoError.IoError
+
+    import java.lang.IllegalArgumentException
+    import java.lang.SecurityException
+    import java.io.IOException
     import java.lang.ProcessBuilder
     import java.lang.Runtime
     import java.io.{File => JFile}
@@ -54,26 +60,31 @@ mod Process {
     ///
     /// In other words, re-interprets the `Process` effect using the `Exec` effect.
     ///
-    pub def handle(f: a -> b \ ef): a -> b \ (ef - Process) + {Exec, IO, Abort} = x ->
+    pub def handle(f: a -> b \ ef): a -> Result[IoError,b] \ (ef - Process) + {Exec, IO} = x ->
         run {
-            f(x)
+            Ok(f(x))
         } with Process {
             def execWithCwdAndEnv(cmd, args, cwd, env, handler) = region rc {
-                let arr = List.toArray(rc, cmd :: args);
-                let pb = new ProcessBuilder(arr);
-                match cwd {
-                    case Some("") => Abort.abort("given an empty directory as an argument")
-                    case Some(cwd) => pb.directory(new JFile(cwd)); ()
-                    case None => ()
-                };
-                foreach(e <- Map.toList(env)) {
-                    pb.environment().put(fst(e), snd(e));
-                    ()
-                };
-                let process = pb.start();
-                handler(ProcessHandle.ProcessHandle({stop = () -> process.destroy(), exitValue = () -> process.exitValue(),  
-                    isAlive = () -> process.isAlive()})
-                    )
+                try {
+                    let arr = List.toArray(rc, cmd :: args);
+                    let pb = new ProcessBuilder(arr);
+                    foreach(e <- Map.toList(env)) {
+                        pb.environment().put(fst(e), snd(e));
+                        ()
+                    };
+                    match cwd {
+                        case Some("") => throw new IllegalArgumentException("given an empty directory as an argument")
+                        case Some(cwd) => pb.directory(new JFile(cwd)); ()
+                        case None => ()
+                    };
+                    let process = pb.start();
+                    handler(ProcessHandle.ProcessHandle({stop = () -> process.destroy(),
+                        exitValue = () -> process.exitValue(), isAlive = () -> process.isAlive()}))
+                } catch {
+                    case ex: IllegalArgumentException  => Err(IoError(ErrorKind.InvalidInput, ex.getMessage()))
+                    case ex: SecurityException         => Err(IoError(ErrorKind.PermissionDenied, ex.getMessage()))
+                    case ex: IOException               => Err(IoError(ErrorKind.Other, ex.getMessage()))
+                }
             }
         }
 
@@ -82,7 +93,7 @@ mod Process {
     ///
     /// In other words, re-interprets the `Process` effect using the `Exec` effect.
     ///
-    pub def runWithIO(f: Unit -> a \ ef): a \ (ef - Process) + {Exec, IO} = handle(f)()
+    pub def runWithIO(f: Unit -> a \ ef): Result[IoError,a] \ (ef - Process) + {Exec, IO} = handle(f)()
 
 }
 

--- a/main/src/library/Process.flix
+++ b/main/src/library/Process.flix
@@ -1,6 +1,5 @@
-
 /*
- *  Copyright 2024 Magnus Madsen
+ *  Copyright 2024 Magnus Madsen, Maksim Gusev
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,36 +15,6 @@
  */
 
 ///
-/// Handles the created Process
-///
-enum ProcessHandle({stop = Unit -> Unit \ {Exec, IO}}, {exitValue = Unit -> Int32 \ {Exec, IO}}, 
-    {isAlive = Unit -> Bool \ {Exec, IO}})
-
-mod ProcessHandle {
-
-    ///
-    /// Stops the process
-    ///
-    pub def stop(ph: ProcessHandle) : Unit \ {IO, Exec} = match ph {
-        case ProcessHandle.ProcessHandle({stop}, _, _) => stop()
-    }
-
-    ///
-    /// Returns the exit value of the process
-    ///
-    pub def exitValue(ph: ProcessHandle) : Int32 \ {IO, Exec} = match ph {
-        case ProcessHandle.ProcessHandle(_, {exitValue}, _) => exitValue()
-    }
-
-    ///
-    ///  Returns status of the process, if it alive or not
-    ///
-    pub def isAlive(ph: ProcessHandle) : Bool \ {IO, Exec} = match ph {
-        case ProcessHandle.ProcessHandle(_, _, {isAlive}) => isAlive()
-    }
-}
-
-///
 /// An effect used to start a process outside the JVM.
 ///
 eff Process {
@@ -53,56 +22,59 @@ eff Process {
     ///
     /// Immediately executes the command `cmd` with the arguments `args`, by the path `cwd` and with the environmental `env`
     ///
-    def execWithCwdAndEnv(cmd: String, args: List[String], cwd: String, env: Map[String, String]): ProcessHandle
+    def execWithCwdAndEnv(cmd: String, args: List[String], cwd: Option[String], env: Map[String, String]): ProcessHandle
 }
-
-
 
 mod Process {
 
+    import java.lang.IllegalArgumentException
     import java.lang.ProcessBuilder
     import java.lang.Runtime
     import java.io.{File => JFile}
-
 
     ///
     /// Executes the command `cmd` with the arguments `args`
     ///
     pub def exec(cmd: String, args: List[String]): ProcessHandle \ Process =
-        Process.execWithCwdAndEnv(cmd, args, "", Map.empty())
+        Process.execWithCwdAndEnv(cmd, args, None, Map.empty())
 
     ///
     /// Executes the command `cmd` with the arguments `args`, by the path `cwd`
     ///
-    pub def execWithCwd(cmd: String, args: List[String], cwd: String): ProcessHandle \ Process =
+    pub def execWithCwd(cmd: String, args: List[String], cwd: Option[String]): ProcessHandle \ Process =
         Process.execWithCwdAndEnv(cmd, args, cwd, Map.empty())
 
     ///
     /// Executes the command `cmd` with the arguments `args` and with the environmental `env`
     ///
     pub def execWithEnv(cmd: String, args: List[String], env: Map[String, String]): ProcessHandle \ Process =
-        Process.execWithCwdAndEnv(cmd, args, "", env)
+        Process.execWithCwdAndEnv(cmd, args, None, env)
 
     ///
     /// Handles the `Process` effect of the given function `f`.
     ///
     /// In other words, re-interprets the `Process` effect using the `Exec` effect.
     ///
-    pub def handle(f: a -> b \ ef): a -> b \ (ef - Process) + {Exec, IO} = x ->
+    pub def handle(f: a -> b \ ef): a -> b \ (ef - Process) + {Exec, IO, Abort} = x ->
         run {
             f(x)
         } with Process {
             def execWithCwdAndEnv(cmd, args, cwd, env, handler) = region rc {
                 let arr = List.toArray(rc, cmd :: args);
                 let pb = new ProcessBuilder(arr);
-                pb.directory(new JFile(cwd));
+                match cwd {
+                    case Some("") => Abort.abort("given an empty directory as an argument")
+                    case Some(cwd) => pb.directory(new JFile(cwd)); ()
+                    case None => ()
+                };
                 foreach(e <- Map.toList(env)) {
-                    pb.environment().put(fst(e),snd(e));
+                    pb.environment().put(fst(e), snd(e));
                     ()
                 };
                 let process = pb.start();
-                handler(ProcessHandle.ProcessHandle(stop = () -> process.destroy(),exitValue = () -> process.exitValue(),  
-                    isAlive = () -> process.isAlive()))
+                handler(ProcessHandle.ProcessHandle({stop = () -> process.destroy(), exitValue = () -> process.exitValue(),  
+                    isAlive = () -> process.isAlive()})
+                    )
             }
         }
 
@@ -114,3 +86,4 @@ mod Process {
     pub def runWithIO(f: Unit -> a \ ef): a \ (ef - Process) + {Exec, IO} = handle(f)()
 
 }
+

--- a/main/src/library/Process.flix
+++ b/main/src/library/Process.flix
@@ -23,7 +23,7 @@
 eff Process {
 
     ///
-    /// Immediately executes the command `cmd` with the arguments `args`, by the path `cwd` and with the environmental `env`
+    /// Immediately executes the command `cmd` with the arguments `args`, by the path `cwd` and with the environmental `env`.
     ///
     def execWithCwdAndEnv(cmd: String, args: List[String], cwd: Option[String], env: Map[String, String]): ProcessHandle
 }
@@ -34,6 +34,7 @@ mod Process {
     use IoError.IoError
 
     import java.lang.IllegalArgumentException
+    import java.lang.NullPointerException
     import java.lang.SecurityException
     import java.io.IOException
     import java.lang.ProcessBuilder
@@ -41,19 +42,19 @@ mod Process {
     import java.io.{File => JFile}
 
     ///
-    /// Executes the command `cmd` with the arguments `args`
+    /// Executes the command `cmd` with the arguments `args`.
     ///
     pub def exec(cmd: String, args: List[String]): ProcessHandle \ Process =
         Process.execWithCwdAndEnv(cmd, args, None, Map.empty())
 
     ///
-    /// Executes the command `cmd` with the arguments `args`, by the path `cwd`
+    /// Executes the command `cmd` with the arguments `args`, by the path `cwd`.
     ///
     pub def execWithCwd(cmd: String, args: List[String], cwd: Option[String]): ProcessHandle \ Process =
         Process.execWithCwdAndEnv(cmd, args, cwd, Map.empty())
 
     ///
-    /// Executes the command `cmd` with the arguments `args` and with the environmental `env`
+    /// Executes the command `cmd` with the arguments `args` and with the environmental `env`.
     ///
     pub def execWithEnv(cmd: String, args: List[String], env: Map[String, String]): ProcessHandle \ Process =
         Process.execWithCwdAndEnv(cmd, args, None, env)
@@ -76,15 +77,19 @@ mod Process {
                         ()
                     };
                     match cwd {
-                        case Some("") => throw new IllegalArgumentException("given an empty directory as an argument")
                         case Some(cwd) => pb.directory(new JFile(cwd)); ()
                         case None => ()
                     };
                     let process = pb.start();
-                    handler(ProcessHandle.ProcessHandle({stop = () -> process.destroy(),
-                        exitValue = () -> process.exitValue(), isAlive = () -> process.isAlive()}))
+                    handler(
+                        ProcessHandle.ProcessHandle(
+                            {stop = () -> process.destroy(), exitValue = () -> process.exitValue(), 
+                                isAlive = () -> process.isAlive()}
+                             )
+                        )
                 } catch {
                     case ex: IllegalArgumentException  => Err(IoError(ErrorKind.InvalidInput, ex.getMessage()))
+                    case ex: NullPointerException      => Err(IoError(ErrorKind.InvalidInput, ex.getMessage()))
                     case ex: SecurityException         => Err(IoError(ErrorKind.PermissionDenied, ex.getMessage()))
                     case ex: IOException               => Err(IoError(ErrorKind.Other, ex.getMessage()))
                 }

--- a/main/src/library/Process.flix
+++ b/main/src/library/Process.flix
@@ -27,7 +27,6 @@ eff Process {
 
 mod Process {
 
-    import java.lang.IllegalArgumentException
     import java.lang.ProcessBuilder
     import java.lang.Runtime
     import java.io.{File => JFile}

--- a/main/src/library/Process.flix
+++ b/main/src/library/Process.flix
@@ -1,3 +1,4 @@
+
 /*
  *  Copyright 2024 Magnus Madsen
  *
@@ -15,21 +16,72 @@
  */
 
 ///
+/// Handles the created Process
+///
+enum ProcessHandle({stop = Unit -> Unit \ {Exec, IO}}, {exitValue = Unit -> Int32 \ {Exec, IO}}, 
+    {isAlive = Unit -> Bool \ {Exec, IO}})
+
+mod ProcessHandle {
+
+    ///
+    /// Stops the process
+    ///
+    pub def stop(ph: ProcessHandle) : Unit \ {IO, Exec} = match ph {
+        case ProcessHandle.ProcessHandle({stop}, _, _) => stop()
+    }
+
+    ///
+    /// Returns the exit value of the process
+    ///
+    pub def exitValue(ph: ProcessHandle) : Int32 \ {IO, Exec} = match ph {
+        case ProcessHandle.ProcessHandle(_, {exitValue}, _) => exitValue()
+    }
+
+    ///
+    ///  Returns status of the process, if it alive or not
+    ///
+    pub def isAlive(ph: ProcessHandle) : Bool \ {IO, Exec} = match ph {
+        case ProcessHandle.ProcessHandle(_, _, {isAlive}) => isAlive()
+    }
+}
+
+///
 /// An effect used to start a process outside the JVM.
 ///
 eff Process {
 
     ///
-    /// Immediately executes the command `cmd` passing the arguments `args`.
+    /// Immediately executes the command `cmd` with the arguments `args`, by the path `cwd` and with the environmental `env`
     ///
-    def exec(cmd: String, args: List[String]): Unit
-
+    def execWithCwdAndEnv(cmd: String, args: List[String], cwd: String, env: Map[String, String]): ProcessHandle
 }
+
+
 
 mod Process {
 
     import java.lang.ProcessBuilder
     import java.lang.Runtime
+    import java.io.{File => JFile}
+
+
+    ///
+    /// Executes the command `cmd` with the arguments `args`
+    ///
+    pub def exec(cmd: String, args: List[String]): ProcessHandle \ Process =
+        Process.execWithCwdAndEnv(cmd, args, "", Map.empty())
+
+    ///
+    /// Executes the command `cmd` with the arguments `args`, by the path `cwd`
+    ///
+    pub def execWithCwd(cmd: String, args: List[String], cwd: String): ProcessHandle \ Process =
+        Process.execWithCwdAndEnv(cmd, args, cwd, Map.empty())
+
+    ///
+    /// Executes the command `cmd` with the arguments `args` and with the environmental `env`
+    ///
+    pub def execWithEnv(cmd: String, args: List[String], env: Map[String, String]): ProcessHandle \ Process =
+        Process.execWithCwdAndEnv(cmd, args, "", env)
 
     ///
     /// Handles the `Process` effect of the given function `f`.
@@ -40,11 +92,17 @@ mod Process {
         run {
             f(x)
         } with Process {
-            def exec(cmd, args, k) = region rc {
+            def execWithCwdAndEnv(cmd, args, cwd, env, handler) = region rc {
                 let arr = List.toArray(rc, cmd :: args);
                 let pb = new ProcessBuilder(arr);
-                pb.start();
-                k()
+                pb.directory(new JFile(cwd));
+                foreach(e <- Map.toList(env)) {
+                    pb.environment().put(fst(e),snd(e));
+                    ()
+                };
+                let process = pb.start();
+                handler(ProcessHandle.ProcessHandle(stop = () -> process.destroy(),exitValue = () -> process.exitValue(),  
+                    isAlive = () -> process.isAlive()))
             }
         }
 

--- a/main/src/library/ProcessHandle.flix
+++ b/main/src/library/ProcessHandle.flix
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2024 Maksim Gusev
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+///
+/// Handles the created Process
+///
+enum ProcessHandle({exitValue = Unit -> Int32 \ {Exec, IO}, isAlive = Unit -> Bool \ {Exec, IO}, 
+    stop = Unit -> Unit \ {Exec, IO}})
+
+mod ProcessHandle {
+
+    ///
+    /// Returns the exit value of the process
+    ///
+    pub def exitValue(ph: ProcessHandle) : Int32 \ {IO, Exec} = match ph {
+        case ProcessHandle.ProcessHandle(methods) => methods#exitValue()
+    }
+
+    ///
+    ///  Returns status of the process, if it alive or not
+    ///
+    pub def isAlive(ph: ProcessHandle) : Bool \ {IO, Exec} = match ph {
+        case ProcessHandle.ProcessHandle(methods) => methods#isAlive()
+    }
+
+    ///
+    /// Stops the process
+    ///
+    pub def stop(ph: ProcessHandle) : Unit \ {IO, Exec} = match ph {
+        case ProcessHandle.ProcessHandle(methods) => methods#stop()
+    }
+}

--- a/main/src/library/ProcessHandle.flix
+++ b/main/src/library/ProcessHandle.flix
@@ -15,31 +15,34 @@
  */
 
 ///
-/// Handles the created Process
+/// Handles the created Process.
 ///
-enum ProcessHandle({exitValue = Unit -> Int32 \ {Exec, IO}, isAlive = Unit -> Bool \ {Exec, IO}, 
-    stop = Unit -> Unit \ {Exec, IO}})
+enum ProcessHandle({
+    exitValue = Unit -> Int32 \ {Exec, IO},
+    isAlive = Unit -> Bool \ {Exec, IO}, 
+    stop = Unit -> Unit \ {Exec, IO}
+    })
 
 mod ProcessHandle {
 
     ///
-    /// Returns the exit value of the process
+    /// Returns the exit value of the process.
     ///
-    pub def exitValue(ph: ProcessHandle): Int32 \ {IO, Exec} = match ph {
+    pub def exitValue(ph: ProcessHandle): Int32 \ {Exec, IO} = match ph {
         case ProcessHandle.ProcessHandle(methods) => methods#exitValue()
     }
 
     ///
-    ///  Returns status of the process, if it alive or not
+    ///  Returns status of the process, if it alive or not.
     ///
-    pub def isAlive(ph: ProcessHandle): Bool \ {IO, Exec} = match ph {
+    pub def isAlive(ph: ProcessHandle): Bool \ {Exec, IO} = match ph {
         case ProcessHandle.ProcessHandle(methods) => methods#isAlive()
     }
 
     ///
-    /// Stops the process
+    /// Stops the process.
     ///
-    pub def stop(ph: ProcessHandle): Unit \ {IO, Exec} = match ph {
+    pub def stop(ph: ProcessHandle): Unit \ {Exec, IO} = match ph {
         case ProcessHandle.ProcessHandle(methods) => methods#stop()
     }
 }

--- a/main/src/library/ProcessHandle.flix
+++ b/main/src/library/ProcessHandle.flix
@@ -25,21 +25,21 @@ mod ProcessHandle {
     ///
     /// Returns the exit value of the process
     ///
-    pub def exitValue(ph: ProcessHandle) : Int32 \ {IO, Exec} = match ph {
+    pub def exitValue(ph: ProcessHandle): Int32 \ {IO, Exec} = match ph {
         case ProcessHandle.ProcessHandle(methods) => methods#exitValue()
     }
 
     ///
     ///  Returns status of the process, if it alive or not
     ///
-    pub def isAlive(ph: ProcessHandle) : Bool \ {IO, Exec} = match ph {
+    pub def isAlive(ph: ProcessHandle): Bool \ {IO, Exec} = match ph {
         case ProcessHandle.ProcessHandle(methods) => methods#isAlive()
     }
 
     ///
     /// Stops the process
     ///
-    pub def stop(ph: ProcessHandle) : Unit \ {IO, Exec} = match ph {
+    pub def stop(ph: ProcessHandle): Unit \ {IO, Exec} = match ph {
         case ProcessHandle.ProcessHandle(methods) => methods#stop()
     }
 }

--- a/main/src/library/ProcessWithResult.flix
+++ b/main/src/library/ProcessWithResult.flix
@@ -20,7 +20,7 @@
 eff ProcessWithResult {
 
     ///
-    /// Immediately executes the command `cmd` with the arguments `args`, by the path `cwd` and with the environmental `env`
+    /// Immediately executes the command `cmd` with the arguments `args`, by the path `cwd` and with the environmental `env`.
     ///
     def execWithCwdAndEnv(cmd: String, args: List[String], cwd: Option[String], env: Map[String, String]): Result[IoError, ProcessHandle]
 }
@@ -31,6 +31,7 @@ mod ProcessWithResult {
     use IoError.IoError
 
     import java.lang.IllegalArgumentException
+    import java.lang.NullPointerException
     import java.lang.SecurityException
     import java.io.IOException
     import java.lang.ProcessBuilder
@@ -38,19 +39,19 @@ mod ProcessWithResult {
     import java.io.{File => JFile}
 
     ///
-    /// Executes the command `cmd` with the arguments `args`
+    /// Executes the command `cmd` with the arguments `args`.
     ///
     pub def exec(cmd: String, args: List[String]): Result[IoError, ProcessHandle] \ ProcessWithResult =
         ProcessWithResult.execWithCwdAndEnv(cmd, args, None, Map.empty())
 
     ///
-    /// Executes the command `cmd` with the arguments `args`, by the path `cwd`
+    /// Executes the command `cmd` with the arguments `args`, by the path `cwd`.
     ///
     pub def execWithCwd(cmd: String, args: List[String], cwd: Option[String]): Result[IoError, ProcessHandle] \ ProcessWithResult =
         ProcessWithResult.execWithCwdAndEnv(cmd, args, cwd, Map.empty())
 
     ///
-    /// Executes the command `cmd` with the arguments `args` and with the environmental `env`
+    /// Executes the command `cmd` with the arguments `args` and with the environmental `env`.
     ///
     pub def execWithEnv(cmd: String, args: List[String], env: Map[String, String]): Result[IoError, ProcessHandle] \ ProcessWithResult =
         ProcessWithResult.execWithCwdAndEnv(cmd, args, None, env)
@@ -73,16 +74,20 @@ mod ProcessWithResult {
                         ()
                     };
                     match cwd {
-                        case Some("") => throw new IllegalArgumentException("given an empty directory as an argument")
                         case Some(cwd) => pb.directory(new JFile(cwd)); ()
                         case None => ()
                     };
                     let process = pb.start();
-                    Ok(ProcessHandle.ProcessHandle({stop = () -> process.destroy(),exitValue = () -> process.exitValue(),  
-                        isAlive = () -> process.isAlive()}))
+                    Ok(
+                        ProcessHandle.ProcessHandle(
+                            {stop = () -> process.destroy(),exitValue = () -> process.exitValue(),  
+                                isAlive = () -> process.isAlive()}
+                            )
+                        )
                         
                 } catch {
                     case ex: IllegalArgumentException  => Err(IoError(ErrorKind.InvalidInput, ex.getMessage()))
+                    case ex: NullPointerException      => Err(IoError(ErrorKind.InvalidInput, ex.getMessage()))
                     case ex: SecurityException         => Err(IoError(ErrorKind.PermissionDenied, ex.getMessage()))
                     case ex: IOException               => Err(IoError(ErrorKind.Other, ex.getMessage()))
                 };

--- a/main/src/library/ProcessWithResult.flix
+++ b/main/src/library/ProcessWithResult.flix
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 Magnus Madsen, Maksim Gusev
+ *  Copyright 2024 Maksim Gusev
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,18 +17,15 @@
 ///
 /// An effect used to start a process outside the JVM.
 ///
-/// All operations on this effect are infallible.
-/// If an operation fails the handler must deal with it.
-///
-eff Process {
+eff ProcessWithResult {
 
     ///
     /// Immediately executes the command `cmd` with the arguments `args`, by the path `cwd` and with the environmental `env`
     ///
-    def execWithCwdAndEnv(cmd: String, args: List[String], cwd: Option[String], env: Map[String, String]): ProcessHandle
+    def execWithCwdAndEnv(cmd: String, args: List[String], cwd: Option[String], env: Map[String, String]): Result[IoError, ProcessHandle]
 }
 
-mod Process {
+mod ProcessWithResult {
 
     use IoError.ErrorKind
     use IoError.IoError
@@ -43,32 +40,32 @@ mod Process {
     ///
     /// Executes the command `cmd` with the arguments `args`
     ///
-    pub def exec(cmd: String, args: List[String]): ProcessHandle \ Process =
-        Process.execWithCwdAndEnv(cmd, args, None, Map.empty())
+    pub def exec(cmd: String, args: List[String]): Result[IoError, ProcessHandle] \ ProcessWithResult =
+        ProcessWithResult.execWithCwdAndEnv(cmd, args, None, Map.empty())
 
     ///
     /// Executes the command `cmd` with the arguments `args`, by the path `cwd`
     ///
-    pub def execWithCwd(cmd: String, args: List[String], cwd: Option[String]): ProcessHandle \ Process =
-        Process.execWithCwdAndEnv(cmd, args, cwd, Map.empty())
+    pub def execWithCwd(cmd: String, args: List[String], cwd: Option[String]): Result[IoError, ProcessHandle] \ ProcessWithResult =
+        ProcessWithResult.execWithCwdAndEnv(cmd, args, cwd, Map.empty())
 
     ///
     /// Executes the command `cmd` with the arguments `args` and with the environmental `env`
     ///
-    pub def execWithEnv(cmd: String, args: List[String], env: Map[String, String]): ProcessHandle \ Process =
-        Process.execWithCwdAndEnv(cmd, args, None, env)
+    pub def execWithEnv(cmd: String, args: List[String], env: Map[String, String]): Result[IoError, ProcessHandle] \ ProcessWithResult =
+        ProcessWithResult.execWithCwdAndEnv(cmd, args, None, env)
 
     ///
-    /// Handles the `Process` effect of the given function `f`.
+    /// Handles the `ProcessWithResult` effect of the given function `f`.
     ///
-    /// In other words, re-interprets the `Process` effect using the `Exec` effect.
+    /// In other words, re-interprets the `ProcessWithResult` effect using the `Exec` effect.
     ///
-    pub def handle(f: a -> b \ ef): a -> Result[IoError, b] \ (ef - Process) + {Exec, IO} = x ->
+    pub def handle(f: a -> b \ ef): a -> b \ (ef - ProcessWithResult) + {Exec, IO} = x ->
         run {
-            Ok(f(x))
-        } with Process {
+            f(x)
+        } with ProcessWithResult {
             def execWithCwdAndEnv(cmd, args, cwd, env, handler) = region rc {
-                try {
+                let res = try {
                     let arr = List.toArray(rc, cmd :: args);
                     let pb = new ProcessBuilder(arr);
                     foreach(e <- Map.toList(env)) {
@@ -81,13 +78,15 @@ mod Process {
                         case None => ()
                     };
                     let process = pb.start();
-                    handler(ProcessHandle.ProcessHandle({stop = () -> process.destroy(),
-                        exitValue = () -> process.exitValue(), isAlive = () -> process.isAlive()}))
+                    Ok(ProcessHandle.ProcessHandle({stop = () -> process.destroy(),exitValue = () -> process.exitValue(),  
+                        isAlive = () -> process.isAlive()}))
+                        
                 } catch {
                     case ex: IllegalArgumentException  => Err(IoError(ErrorKind.InvalidInput, ex.getMessage()))
                     case ex: SecurityException         => Err(IoError(ErrorKind.PermissionDenied, ex.getMessage()))
                     case ex: IOException               => Err(IoError(ErrorKind.Other, ex.getMessage()))
-                }
+                };
+                handler(res)
             }
         }
 
@@ -96,7 +95,6 @@ mod Process {
     ///
     /// In other words, re-interprets the `Process` effect using the `Exec` effect.
     ///
-    pub def runWithIO(f: Unit -> a \ ef): Result[IoError, a] \ (ef - Process) + {Exec, IO} = handle(f)()
+    pub def runWithIO(f: Unit -> a \ ef): a \ (ef - ProcessWithResult) + {Exec, IO} = handle(f)()
 
 }
-


### PR DESCRIPTION
Related to #9414 .

The process effect has been changed to a more general one. The module's help functions allow you to call exec with fewer arguments. 

Now, the process returns a `ProcessHelper` -- an interface to manipulate with created processes.