### PR TITLE
fix: allow matching on BigInt

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -638,6 +638,13 @@ object Simplifier {
         val op = AtomicOp.InvokeMethod(method)
         return SimplifiedAst.Expr.ApplyAtomic(op, List(e1, e2), MonoType.Bool, Purity.combine(e1.purity, e2.purity), loc)
 
+      case (MonoType.BigInt, _) =>
+        val bigIntClass = Class.forName("java.math.BigInteger")
+        val objClass = Class.forName("java.lang.Object")
+        val method = bigIntClass.getMethod("equals", objClass)
+        val op = AtomicOp.InvokeMethod(method)
+        return SimplifiedAst.Expr.ApplyAtomic(op, List(e1, e2), MonoType.Bool, Purity.combine(e1.purity, e2.purity), loc)
+
       case _ => // fallthrough
     }
 

--- a/main/test/flix/Test.Exp.Match.BigInt.flix
+++ b/main/test/flix/Test.Exp.Match.BigInt.flix
@@ -1,0 +1,47 @@
+mod Test.Exp.Match.BigInt {
+
+    @test
+    def testMatchBigInt01(): Bool = match 0ii {
+        case 0ii => true
+        case 1ii => false
+        case 2ii => false
+        case _    => false
+    }
+
+    @test
+    def testMatchBigInt02(): Bool = match 1ii {
+        case 0ii => false
+        case 1ii => true
+        case 2ii => false
+        case _    => false
+    }
+
+    @test
+    def testMatchBigInt03(): Bool = match 2ii {
+        case 0ii => false
+        case 1ii => false
+        case 2ii => true
+        case _    => false
+    }
+
+    @test
+    def testMatchBigInt04(): Bool = match 3ii {
+        case 0ii => false
+        case 1ii => false
+        case 2ii => false
+        case _    => true
+    }
+
+    @test
+    def testMatchBigIntVar01(): Bool = match 0ii {
+        case x => x == 0ii
+    }
+
+    @test
+    def testMatchBigIntVar02(): Bool = match 2ii {
+        case 0ii => false
+        case 1ii => false
+        case x   => x == 2ii
+    }
+
+}


### PR DESCRIPTION
fixes https://github.com/flix/flix/issues/9537

We may consider the same for BigDecimal, but that requires more thinking since the definition of equality for them is perhaps unintuitive.