### PR TITLE
feat: add 'use' to Module keywords

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/syntactic/KeywordCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/syntactic/KeywordCompleter.scala
@@ -62,6 +62,8 @@ object KeywordCompleter {
       Completion.KeywordCompletion("@Test"            , Priority.Low),
       Completion.KeywordCompletion("trait"            , Priority.High),
       Completion.KeywordCompletion("type"             , Priority.Higher),
+      // U
+      Completion.KeywordCompletion("use"              , Priority.Default),
       // W
       Completion.KeywordCompletion("with"             , Priority.Default),
     )


### PR DESCRIPTION
fixes #9574
Preview:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/bb341aa0-5ba9-4553-b4c7-25b7a6fca6f3" />
