### PR TITLE
feat: remove trivial `IfThenElse` in `Simplifier`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Simplifier.scala
@@ -771,7 +771,12 @@ object Simplifier {
         */
       case (Nil, Nil) =>
         val g = visitExp(guard)
-        SimplifiedAst.Expr.IfThenElse(g, succ, fail, succ.tpe, g.purity, g.loc)
+        // Only produce IfThenElse if g is non-trivial
+        g match {
+          case SimplifiedAst.Expr.Cst(Constant.Bool(true), _, _) => succ
+          case SimplifiedAst.Expr.Cst(Constant.Bool(false), _, _) => fail
+          case e => SimplifiedAst.Expr.IfThenElse(e, succ, fail, succ.tpe, g.purity, g.loc)
+        }
 
       /**
         * Matching a wildcard is guaranteed to succeed.


### PR DESCRIPTION
Now `Simplifier` does not produce trivial `if`-expressions from guards in pattern matching.