### PR TITLE
fix: use empty `ChangeSet` upon successful incremental compilation

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -607,6 +607,9 @@ class Flix {
               this.cachedResolverAst = afterResolver
               this.cachedTyperAst = afterDependencies
 
+              // We record that no files are dirty in the change set.
+              this.changeSet = ChangeSet.Dirty(Set.empty)
+
               // We save all the current errors.
               this.cachedErrors = errors.toList
             }


### PR DESCRIPTION
… `Flix`