### PR TITLE
fix: remove fixed height from README img

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We refer you to the [official Flix website (flix.dev)](https://flix.dev/) for mo
 
 ## Example
 <p align="center" >
-    <img src="https://raw.githubusercontent.com/flix/flix/master/docs/example.png" height="627px" 
+    <img src="https://raw.githubusercontent.com/flix/flix/master/docs/example.png"
     alt="Example Flix Program" 
     title="Example Flix Program">
 </p>


### PR DESCRIPTION
Currently it looks really bad on mobile...

<table>
<tr>
<th width="50%">Before</th>
<th width="50%">After</th>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/64aa68f6-cd2e-4e81-9765-ba643ab4a398"></td>
<td><img src="https://github.com/user-attachments/assets/60bb7532-fa08-4dee-b9d6-3a837fc261e1"></td>
</tr>
<tr>
<td>Code is barely readable.</td>
<td>A bit small but still a remarkable improvement. User can tap it for full-size or zoom in with gestures quite easily.</td>
</tr>
</table>

It may be worth considering #3821, but I'm hesitant about that until GitHub supports Flix syntax highlighting.