### PR TITLE
feat: introduce `SharedContext` for `Safety` phase

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -692,7 +692,7 @@ object Safety {
     case Expr.NewObject(_, clazz, tpe0, _, methods, loc) =>
       val tpe = Type.eraseAliases(tpe0)
       // `clazz` must be an interface or have a non-private constructor without arguments.
-      if (! clazz.isInterface && !hasNonPrivateZeroArgConstructor(clazz)) {
+      if (!clazz.isInterface && !hasNonPrivateZeroArgConstructor(clazz)) {
         sctx.errors.add(NewObjectMissingPublicZeroArgConstructor(clazz, loc))
       }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -6,7 +6,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.Body
 import ca.uwaterloo.flix.language.ast.ops.TypedAstOps
 import ca.uwaterloo.flix.language.ast.ops.TypedAstOps.*
 import ca.uwaterloo.flix.language.ast.shared.*
-import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
+import ca.uwaterloo.flix.language.ast.{RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.SafetyError
 import ca.uwaterloo.flix.language.errors.SafetyError.*
@@ -213,7 +213,7 @@ object Safety {
       val permissionErrors = checkAllPermissions(loc.security, loc)
       permissionErrors ++ visitExp(exp) ++ castErrors
 
-    case unsafe@Expr.Unsafe(exp, _, _, _, loc) =>
+    case Expr.Unsafe(exp, _, _, _, loc) =>
       val permissionErrors = checkAllPermissions(loc.security, loc)
       permissionErrors ++ visitExp(exp)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -15,6 +15,7 @@ import ca.uwaterloo.flix.util.{JvmUtils, ParOps}
 import java.math.BigInteger
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.annotation.tailrec
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 /**
   * Checks the safety and well-formedness of:
@@ -29,26 +30,27 @@ object Safety {
 
   /** Checks the safety and well-formedness of `root`. */
   def run(root: Root)(implicit flix: Flix): (Root, List[SafetyError]) = flix.phaseNew("Safety") {
-    implicit val sctx: SharedContext = SharedContext(new ConcurrentLinkedQueue())
-    val classSigErrs = ParOps.parMap(root.traits.values.flatMap(_.sigs))(visitSig).flatten
-    val defErrs = ParOps.parMap(root.defs.values)(visitDef).flatten
-    val instanceDefErrs = ParOps.parMap(TypedAstOps.instanceDefsOf(root))(visitDef).flatten
-    val sigErrs = ParOps.parMap(root.sigs.values)(visitSig).flatten
-    val errors = classSigErrs ++ defErrs ++ instanceDefErrs ++ sigErrs
+    implicit val sctx: SharedContext = SharedContext.mk()
+    ParOps.parMap(root.traits.values.flatMap(_.sigs))(visitSig)
+    ParOps.parMap(root.defs.values)(visitDef)
+    ParOps.parMap(TypedAstOps.instanceDefsOf(root))(visitDef)
+    ParOps.parMap(root.sigs.values)(visitSig)
 
-    (root, errors.toList)
+    (root, sctx.errors.asScala.toList)
   }
 
   /** Checks the safety and well-formedness of `sig`. */
-  private def visitSig(sig: Sig)(implicit flix: Flix, sctx: SharedContext): List[SafetyError] = {
+  private def visitSig(sig: Sig)(implicit flix: Flix, sctx: SharedContext): Sig = {
     val renv = RigidityEnv.ofRigidVars(sig.spec.tparams.map(_.sym))
     sig.exp.map(visitExp(_)(inTryCatch = false, renv, flix, sctx)).getOrElse(Nil)
+    sig
   }
 
   /** Checks the safety and well-formedness of `defn`. */
-  private def visitDef(defn: Def)(implicit flix: Flix, sctx: SharedContext): List[SafetyError] = {
+  private def visitDef(defn: Def)(implicit flix: Flix, sctx: SharedContext): Def = {
     val renv = RigidityEnv.ofRigidVars(defn.spec.tparams.map(_.sym))
     visitExp(defn.exp)(inTryCatch = false, renv, flix, sctx)
+    defn
   }
 
   /**
@@ -63,15 +65,15 @@ object Safety {
     * @param inTryCatch indicates whether `exp` is enclosed in a try-catch. This can be reset if the
     *                   expression will later be extracted to its own function (e.g [[Expr.Lambda]]).
     */
-  private def visitExp(exp0: Expr)(implicit inTryCatch: Boolean, renv: RigidityEnv, flix: Flix, sctx: SharedContext): List[SafetyError] = exp0 match {
+  private def visitExp(exp0: Expr)(implicit inTryCatch: Boolean, renv: RigidityEnv, flix: Flix, sctx: SharedContext): Unit = exp0 match {
     case Expr.Cst(_, _, _) =>
-      Nil
+      ()
 
     case Expr.Var(_, _, _) =>
-      Nil
+      ()
 
     case Expr.Hole(_, _, _, _) =>
-      Nil
+      ()
 
     case Expr.HoleWithExp(exp, _, _, _) =>
       visitExp(exp)
@@ -87,47 +89,58 @@ object Safety {
       visitExp(exp)(inTryCatch = false, renv, flix, sctx)
 
     case Expr.ApplyClo(exp1, exp2, _, _, _) =>
-      visitExp(exp1) ++ visitExp(exp2)
+      visitExp(exp1)
+      visitExp(exp2)
 
     case Expr.ApplyDef(_, exps, _, _, _, _) =>
-      exps.flatMap(visitExp)
+      exps.foreach(visitExp)
 
     case Expr.ApplyLocalDef(_, exps, _, _, _, _) =>
-      exps.flatMap(visitExp)
+      exps.foreach(visitExp)
 
     case Expr.ApplySig(_, exps, _, _, _, _) =>
-      exps.flatMap(visitExp)
+      exps.foreach(visitExp)
 
     case Expr.Unary(_, exp, _, _, _) =>
       visitExp(exp)
 
     case Expr.Binary(_, exp1, exp2, _, _, _) =>
-      visitExp(exp1) ++ visitExp(exp2)
+      visitExp(exp1)
+      visitExp(exp2)
 
     case Expr.Let(_, exp1, exp2, _, _, _) =>
-      visitExp(exp1) ++ visitExp(exp2)
+      visitExp(exp1)
+      visitExp(exp2)
 
     case Expr.LocalDef(_, _, exp1, exp2, _, _, _) =>
       // `exp1` will be its own function, so `inTryCatch` is reset.
-      visitExp(exp1)(inTryCatch = false, renv, flix, sctx) ++ visitExp(exp2)
+      visitExp(exp1)(inTryCatch = false, renv, flix, sctx)
+      visitExp(exp2)
 
     case Expr.Region(_, _) =>
-      Nil
+      ()
 
     case Expr.Scope(_, _, exp, _, _, _) =>
       visitExp(exp)
 
     case Expr.IfThenElse(exp1, exp2, exp3, _, _, _) =>
-      visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
+      visitExp(exp1)
+      visitExp(exp2)
+      visitExp(exp3)
 
     case Expr.Stm(exp1, exp2, _, _, _) =>
-      visitExp(exp1) ++ visitExp(exp2)
+      visitExp(exp1)
+      visitExp(exp2)
 
     case Expr.Discard(exp, _, _) =>
       visitExp(exp)
 
     case Expr.Match(exp, rules, _, _, _) =>
-      visitExp(exp) ++ rules.flatMap(rule => rule.guard.map(visitExp).getOrElse(Nil) ++ visitExp(rule.exp))
+      visitExp(exp)
+      rules.foreach { rule =>
+        rule.guard.foreach(visitExp)
+        visitExp(rule.exp)
+      }
 
     case Expr.TypeMatch(exp, rules, _, _, _) =>
       // check whether the last case in the type match looks like `..: _`
@@ -138,61 +151,74 @@ object Safety {
         case Some(_) | None =>
           List(SafetyError.MissingDefaultTypeMatchCase(exp.loc))
       }
-      visitExp(exp) ++ missingDefault ++ rules.flatMap(rule => visitExp(rule.exp))
+      missingDefault.foreach(sctx.errors.add)
+      visitExp(exp)
+      rules.foreach(rule => visitExp(rule.exp))
 
     case Expr.RestrictableChoose(_, exp, rules, _, _, _) =>
-      visitExp(exp) ++ rules.flatMap(rule => visitExp(rule.exp))
+      visitExp(exp)
+      rules.foreach(rule => visitExp(rule.exp))
 
       case Expr.Tag(_, exps, _, _, _) =>
-        exps.flatMap(visitExp)
+        exps.foreach(visitExp)
 
       case Expr.RestrictableTag(_, exps, _, _, _) =>
-        exps.flatMap(visitExp)
+        exps.foreach(visitExp)
 
     case Expr.Tuple(elms, _, _, _) =>
-      elms.flatMap(visitExp)
+      elms.foreach(visitExp)
 
     case Expr.RecordEmpty(_, _) =>
-      Nil
+      ()
 
     case Expr.RecordSelect(exp, _, _, _, _) =>
       visitExp(exp)
 
     case Expr.RecordExtend(_, value, rest, _, _, _) =>
-      visitExp(value) ++ visitExp(rest)
+      visitExp(value)
+      visitExp(rest)
 
     case Expr.RecordRestrict(_, rest, _, _, _) =>
       visitExp(rest)
 
     case Expr.ArrayLit(elms, exp, _, _, _) =>
-      elms.flatMap(visitExp) ++ visitExp(exp)
+      elms.foreach(visitExp)
+      visitExp(exp)
 
     case Expr.ArrayNew(exp1, exp2, exp3, _, _, _) =>
-      visitExp(exp1) ++ visitExp(exp2) ++ visitExp(exp3)
+      visitExp(exp1)
+      visitExp(exp2)
+      visitExp(exp3)
 
     case Expr.ArrayLoad(base, index, _, _, _) =>
-      visitExp(base) ++ visitExp(index)
+      visitExp(base)
+      visitExp(index)
 
     case Expr.ArrayLength(base, _, _) =>
       visitExp(base)
 
     case Expr.ArrayStore(base, index, elm, _, _) =>
-      visitExp(base) ++ visitExp(index) ++ visitExp(elm)
+      visitExp(base)
+      visitExp(index)
+      visitExp(elm)
 
     case Expr.StructNew(_, fields, region, _, _, _) =>
-      fields.flatMap { case (_, exp) => visitExp(exp) } ++ visitExp(region)
+      fields.foreach { case (_, exp) => visitExp(exp) }
+      visitExp(region)
 
     case Expr.StructGet(e, _, _, _, _) =>
       visitExp(e)
 
     case Expr.StructPut(e1, _, e2, _, _, _) =>
-      visitExp(e1) ++ visitExp(e2)
+      visitExp(e1)
+      visitExp(e2)
 
     case Expr.VectorLit(elms, _, _, _) =>
-      elms.flatMap(visitExp)
+      elms.foreach(visitExp)
 
     case Expr.VectorLoad(exp1, exp2, _, _, _) =>
-      visitExp(exp1) ++ visitExp(exp2)
+      visitExp(exp1)
+      visitExp(exp2)
 
     case Expr.VectorLength(exp, _) =>
       visitExp(exp)
@@ -204,75 +230,83 @@ object Safety {
       visitExp(exp)
 
     case cast@Expr.CheckedCast(castType, exp, _, _, _) =>
-      val castErrors = castType match {
+      castType match {
         case CheckedCastType.TypeCast => checkCheckedTypeCast(cast)
-        case CheckedCastType.EffectCast => Nil
+        case CheckedCastType.EffectCast => ()
       }
-      visitExp(exp) ++ castErrors
+      visitExp(exp)
 
     case cast@Expr.UncheckedCast(exp, _, _, _, _, loc) =>
-      val castErrors = verifyUncheckedCast(cast)
-      val permissionErrors = checkAllPermissions(loc.security, loc)
-      permissionErrors ++ visitExp(exp) ++ castErrors
+      verifyUncheckedCast(cast)
+      checkAllPermissions(loc.security, loc)
+      visitExp(exp)
 
     case Expr.Unsafe(exp, _, _, _, loc) =>
-      val permissionErrors = checkAllPermissions(loc.security, loc)
-      permissionErrors ++ visitExp(exp)
+      checkAllPermissions(loc.security, loc)
+      visitExp(exp)
 
     case Expr.Without(exp, _, _, _, _) =>
       visitExp(exp)
 
     case Expr.TryCatch(exp, rules, _, _, loc) =>
       val nestedTryCatchError = if (inTryCatch) List(IllegalNestedTryCatch(loc)) else Nil
-      nestedTryCatchError ++ visitExp(exp)(inTryCatch = true, renv, flix, sctx) ++
-        rules.flatMap { case CatchRule(bnd, clazz, e) => checkCatchClass(clazz, bnd.sym.loc) ++ visitExp(e) }
+      nestedTryCatchError.foreach(sctx.errors.add)
+      visitExp(exp)(inTryCatch = true, renv, flix, sctx)
+      rules.foreach { case CatchRule(bnd, clazz, e) => checkCatchClass(clazz, bnd.sym.loc)
+        visitExp(e)
+      }
 
     case Expr.Throw(exp, _, _, loc) =>
-      val permissionErrors = checkAllPermissions(loc.security, loc)
-      permissionErrors ++ visitExp(exp) ++ checkThrow(exp)
+      checkAllPermissions(loc.security, loc)
+      visitExp(exp)
+      checkThrow(exp)
 
     case Expr.TryWith(exp, effUse, rules, _, _, _) =>
       val effectErrors = {
         if (Symbol.isPrimitiveEff(effUse.sym)) List(PrimitiveEffectInTryWith(effUse.sym, effUse.qname.loc))
         else Nil
       }
-      effectErrors ++ visitExp(exp) ++ rules.flatMap(rule => visitExp(rule.exp))
+      effectErrors.foreach(sctx.errors.add)
+      visitExp(exp)
+      rules.foreach(rule => visitExp(rule.exp))
 
 
     case Expr.Do(_, exps, _, _, _) =>
-      exps.flatMap(visitExp)
+      exps.foreach(visitExp)
 
     case Expr.InvokeConstructor(_, args, _, _, loc) =>
-      val permissionErrors = checkAllPermissions(loc.security, loc)
-      permissionErrors ++ args.flatMap(visitExp)
+      checkAllPermissions(loc.security, loc)
+      args.foreach(visitExp)
 
     case Expr.InvokeMethod(_, exp, args, _, _, loc) =>
-      val permissionErrors = checkAllPermissions(loc.security, loc)
-      permissionErrors ++ visitExp(exp) ++ args.flatMap(visitExp)
+      checkAllPermissions(loc.security, loc)
+      visitExp(exp)
+      args.foreach(visitExp)
 
     case Expr.InvokeStaticMethod(_, args, _, _, loc) =>
-      val permissionErrors = checkAllPermissions(loc.security, loc)
-      permissionErrors ++ args.flatMap(visitExp)
+      checkAllPermissions(loc.security, loc)
+      args.foreach(visitExp)
 
     case Expr.GetField(_, exp, _, _, loc) =>
-      val permissionErrors = checkAllPermissions(loc.security, loc)
-      permissionErrors ++ visitExp(exp)
+      checkAllPermissions(loc.security, loc)
+      visitExp(exp)
 
     case Expr.PutField(_, exp1, exp2, _, _, loc) =>
-      val permissionErrors = checkAllPermissions(loc.security, loc)
-      permissionErrors ++ visitExp(exp1) ++ visitExp(exp2)
+      checkAllPermissions(loc.security, loc)
+      visitExp(exp1)
+      visitExp(exp2)
 
     case Expr.GetStaticField(_, _, _, loc) =>
       checkAllPermissions(loc.security, loc)
 
     case Expr.PutStaticField(_, exp, _, _, loc) =>
-      val permissionErrors = checkAllPermissions(loc.security, loc)
-      permissionErrors ++ visitExp(exp)
+      checkAllPermissions(loc.security, loc)
+      visitExp(exp)
 
     case newObject@Expr.NewObject(_, _, _, _, methods, loc) =>
-      val permissionErrors = checkAllPermissions(loc.security, loc)
-      val objectErrors = checkObjectImplementation(newObject)
-      permissionErrors ++ objectErrors ++ methods.flatMap(method => visitExp(method.exp))
+      checkAllPermissions(loc.security, loc)
+      checkObjectImplementation(newObject)
+      methods.foreach(method => visitExp(method.exp))
 
     case Expr.NewChannel(exp, _, _, _) =>
       visitExp(exp)
@@ -281,12 +315,16 @@ object Safety {
       visitExp(exp)
 
     case Expr.PutChannel(exp1, exp2, _, _, _) =>
-      visitExp(exp1) ++ visitExp(exp2)
+      visitExp(exp1)
+      visitExp(exp2)
 
     case Expr.SelectChannel(rules, default, _, _, _) =>
-      rules.flatMap {
-        case SelectChannelRule(_, chan, body) => visitExp(chan) ++ visitExp(body)
-      } ++ default.map(visitExp).getOrElse(Nil)
+      rules.foreach {
+        case SelectChannelRule(_, chan, body) =>
+          visitExp(chan)
+          visitExp(body)
+      }
+      default.map(visitExp).getOrElse(Nil)
 
     case Expr.Spawn(exp1, exp2, _, _, _) =>
       val illegalSpawnEffect = {
@@ -294,10 +332,13 @@ object Safety {
         else Nil
       }
 
-      illegalSpawnEffect ++ visitExp(exp1) ++ visitExp(exp2)
+      illegalSpawnEffect.foreach(sctx.errors.add)
+      visitExp(exp1)
+      visitExp(exp2)
 
     case Expr.ParYield(frags, exp, _, _, _) =>
-      frags.flatMap(fragment => visitExp(fragment.exp)) ++ visitExp(exp)
+      frags.foreach(fragment => visitExp(fragment.exp))
+      visitExp(exp)
 
     case Expr.Lazy(exp, _, _) =>
       visitExp(exp)
@@ -306,13 +347,14 @@ object Safety {
       visitExp(exp)
 
     case Expr.FixpointConstraintSet(cs, _, _) =>
-      cs.flatMap(checkConstraint)
+      cs.foreach(checkConstraint)
 
     case Expr.FixpointLambda(_, exp, _, _, _) =>
       visitExp(exp)
 
     case Expr.FixpointMerge(exp1, exp2, _, _, _) =>
-      visitExp(exp1) ++ visitExp(exp2)
+      visitExp(exp1)
+      visitExp(exp2)
 
     case Expr.FixpointSolve(exp, _, _, _) =>
       visitExp(exp)
@@ -327,75 +369,75 @@ object Safety {
       visitExp(exp)
 
     case Expr.Error(_, _, _) =>
-      Nil
+      ()
 
   }
 
   /** Checks that `ctx` is [[SecurityContext.AllPermissions]]. */
-  private def checkAllPermissions(ctx: SecurityContext, loc: SourceLocation)(implicit sctx: SharedContext): List[SafetyError] = {
+  private def checkAllPermissions(ctx: SecurityContext, loc: SourceLocation)(implicit sctx: SharedContext): Unit = {
     ctx match {
-      case SecurityContext.AllPermissions => Nil
-      case SecurityContext.NoPermissions => List(SafetyError.Forbidden(ctx, loc))
+      case SecurityContext.AllPermissions => ()
+      case SecurityContext.NoPermissions => sctx.errors.add(SafetyError.Forbidden(ctx, loc))
     }
   }
 
   /** Checks if `cast` is legal. */
-  private def checkCheckedTypeCast(cast: Expr.CheckedCast)(implicit flix: Flix, sctx: SharedContext): List[SafetyError] = cast match {
+  private def checkCheckedTypeCast(cast: Expr.CheckedCast)(implicit flix: Flix, sctx: SharedContext): Unit = cast match {
     case Expr.CheckedCast(_, exp, tpe, _, loc) =>
       val from = exp.tpe
       val to = tpe
       (Type.eraseAliases(from).baseType, Type.eraseAliases(to).baseType) match {
 
         // Allow casting Null to a Java type.
-        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Native(_), _)) => Nil
-        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.BigInt, _)) => Nil
-        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.BigDecimal, _)) => Nil
-        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Str, _)) => Nil
-        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Regex, _)) => Nil
-        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Array, _)) => Nil
+        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Native(_), _)) => ()
+        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.BigInt, _)) => ()
+        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.BigDecimal, _)) => ()
+        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Str, _)) => ()
+        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Regex, _)) => ()
+        case (Type.Cst(TypeConstructor.Null, _), Type.Cst(TypeConstructor.Array, _)) => ()
 
         // Allow casting one Java type to another if there is a sub-type relationship.
         case (Type.Cst(TypeConstructor.Native(left), _), Type.Cst(TypeConstructor.Native(right), _)) =>
-          if (right.isAssignableFrom(left)) Nil else IllegalCheckedCast(from, to, loc) :: Nil
+          if (right.isAssignableFrom(left)) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for String.
         case (Type.Cst(TypeConstructor.Str, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-          if (right.isAssignableFrom(classOf[String])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
+          if (right.isAssignableFrom(classOf[String])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for Regex.
         case (Type.Cst(TypeConstructor.Regex, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-          if (right.isAssignableFrom(classOf[java.util.regex.Pattern])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
+          if (right.isAssignableFrom(classOf[java.util.regex.Pattern])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for BigInt.
         case (Type.Cst(TypeConstructor.BigInt, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-          if (right.isAssignableFrom(classOf[BigInteger])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
+          if (right.isAssignableFrom(classOf[BigInteger])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for BigDecimal.
         case (Type.Cst(TypeConstructor.BigDecimal, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-          if (right.isAssignableFrom(classOf[java.math.BigDecimal])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
+          if (right.isAssignableFrom(classOf[java.math.BigDecimal])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Similar, but for Arrays.
         case (Type.Cst(TypeConstructor.Array, _), Type.Cst(TypeConstructor.Native(right), _)) =>
-          if (right.isAssignableFrom(classOf[Array[Object]])) Nil else IllegalCheckedCast(from, to, loc) :: Nil
+          if (right.isAssignableFrom(classOf[Array[Object]])) () else sctx.errors.add(IllegalCheckedCast(from, to, loc))
 
         // Disallow casting a type variable.
         case (src@Type.Var(_, _), _) =>
-          IllegalCheckedCastFromVar(src, to, loc) :: Nil
+          sctx.errors.add(IllegalCheckedCastFromVar(src, to, loc))
 
         // Disallow casting a type variable (symmetric case)
         case (_, dst@Type.Var(_, _)) =>
-          IllegalCheckedCastToVar(from, dst, loc) :: Nil
+          sctx.errors.add(IllegalCheckedCastToVar(from, dst, loc))
 
         // Disallow casting a Java type to any other type.
         case (Type.Cst(TypeConstructor.Native(clazz), _), _) =>
-          IllegalCheckedCastToNonJava(clazz, to, loc) :: Nil
+          sctx.errors.add(IllegalCheckedCastToNonJava(clazz, to, loc))
 
         // Disallow casting a Java type to any other type (symmetric case).
         case (_, Type.Cst(TypeConstructor.Native(clazz), _)) =>
-          IllegalCheckedCastFromNonJava(from, clazz, loc) :: Nil
+          sctx.errors.add(IllegalCheckedCastFromNonJava(from, clazz, loc))
 
         // Disallow all other casts.
-        case _ => IllegalCheckedCast(from, to, loc) :: Nil
+        case _ => sctx.errors.add(IllegalCheckedCast(from, to, loc))
       }
   }
 
@@ -405,7 +447,7 @@ object Safety {
     *   - No primitive type can be cast to a reference type and vice-versa.
     *   - No Bool type can be cast to a non-Bool type and vice-versa.
     */
-  private def verifyUncheckedCast(cast: Expr.UncheckedCast)(implicit flix: Flix, sctx: SharedContext): List[SafetyError.ImpossibleUncheckedCast] = cast match {
+  private def verifyUncheckedCast(cast: Expr.UncheckedCast)(implicit flix: Flix, sctx: SharedContext): Unit = cast match {
     case Expr.UncheckedCast(exp, declaredType, _, _, _, loc) =>
       val from = exp.tpe
       val to = declaredType
@@ -418,35 +460,35 @@ object Safety {
 
       (Type.eraseAliases(from).baseType, to.map(Type.eraseAliases).map(_.baseType)) match {
         // Allow casts where one side is a type variable.
-        case (Type.Var(_, _), _) => Nil
-        case (_, Some(Type.Var(_, _))) => Nil
+        case (Type.Var(_, _), _) => ()
+        case (_, Some(Type.Var(_, _))) => ()
 
         // Allow casts between Java types.
-        case (Type.Cst(TypeConstructor.Native(_), _), _) => Nil
-        case (_, Some(Type.Cst(TypeConstructor.Native(_), _))) => Nil
+        case (Type.Cst(TypeConstructor.Native(_), _), _) => ()
+        case (_, Some(Type.Cst(TypeConstructor.Native(_), _))) => ()
 
         // Disallow casting a Boolean to another primitive type.
         case (Type.Bool, Some(t2)) if primitives.filter(_ != Type.Bool).contains(t2) =>
-          ImpossibleUncheckedCast(from, to.get, loc) :: Nil
+          sctx.errors.add(ImpossibleUncheckedCast(from, to.get, loc))
 
         // Disallow casting a Boolean to another primitive type (symmetric case).
         case (t1, Some(Type.Bool)) if primitives.filter(_ != Type.Bool).contains(t1) =>
-          ImpossibleUncheckedCast(from, to.get, loc) :: Nil
+          sctx.errors.add(ImpossibleUncheckedCast(from, to.get, loc))
 
         // Disallowing casting a non-primitive type to a primitive type.
         case (t1, Some(t2)) if primitives.contains(t1) && !primitives.contains(t2) =>
-          ImpossibleUncheckedCast(from, to.get, loc) :: Nil
+          sctx.errors.add(ImpossibleUncheckedCast(from, to.get, loc))
 
         // Disallowing casting a non-primitive type to a primitive type (symmetric case).
         case (t1, Some(t2)) if primitives.contains(t2) && !primitives.contains(t1) =>
-          ImpossibleUncheckedCast(from, to.get, loc) :: Nil
+          sctx.errors.add(ImpossibleUncheckedCast(from, to.get, loc))
 
-        case _ => Nil
+        case _  => ()
       }
   }
 
   /** Checks the safety and well-formedness of `c`. */
-  private def checkConstraint(c: Constraint)(implicit inTryCatch: Boolean, renv: RigidityEnv, flix: Flix, sctx: SharedContext): List[SafetyError] = {
+  private def checkConstraint(c: Constraint)(implicit inTryCatch: Boolean, renv: RigidityEnv, flix: Flix, sctx: SharedContext): Unit = {
     // Compute the set of positively defined variable symbols in the constraint.
     val posVars = positivelyDefinedVariables(c)
 
@@ -471,27 +513,25 @@ object Safety {
 
     // Check that all negative atoms only use positively defined variable symbols
     // and that lattice variables are not used in relational position.
-    val err1 = c.body.flatMap(checkBodyPredicate(_, posVars, quantVars, latVars))
+    c.body.foreach(checkBodyPredicate(_, posVars, quantVars, latVars))
 
     // Check that the free relational variables in the head atom are not lattice variables.
-    val err2 = checkHeadPredicate(c.head, unsafeLatVars)
+   checkHeadPredicate(c.head, unsafeLatVars)
 
     // Check that patterns in atom body are legal.
-    val err3 = c.body.flatMap(s => checkBodyPattern(s))
-
-    err1 ++ err2 ++ err3
+   c.body.foreach(s => checkBodyPattern(s))
   }
 
   /** Checks that `p` only contains [[Pattern.Var]], [[Pattern.Wild]], and [[Pattern.Cst]]. */
-  private def checkBodyPattern(p: Predicate.Body)(implicit sctx: SharedContext): List[SafetyError] = p match {
+  private def checkBodyPattern(p: Predicate.Body)(implicit sctx: SharedContext): Unit = p match {
     case Predicate.Body.Atom(_, _, _, _, terms, _, loc) =>
-      terms.flatMap {
-        case Pattern.Var(_, _, _) => None
-        case Pattern.Wild(_, _) => None
-        case Pattern.Cst(_, _, _) => None
-        case _ => Some(IllegalPatternInBodyAtom(loc))
+      terms.foreach {
+        case Pattern.Var(_, _, _) => ()
+        case Pattern.Wild(_, _) => ()
+        case Pattern.Cst(_, _, _) => ()
+        case _ => sctx.errors.add(IllegalPatternInBodyAtom(loc))
       }
-    case _ => Nil
+    case _ => ()
   }
 
   /**
@@ -501,19 +541,18 @@ object Safety {
     * @param quantVars the quantified variables, not bound by lexical scope.
     * @param latVars the variables in lattice position.
     */
-  private def checkBodyPredicate(p: Predicate.Body, posVars: Set[Symbol.VarSym], quantVars: Set[Symbol.VarSym], latVars: Set[Symbol.VarSym])(implicit inTryCatch: Boolean, renv: RigidityEnv, flix: Flix, sctx: SharedContext): List[SafetyError] = p match {
+  private def checkBodyPredicate(p: Predicate.Body, posVars: Set[Symbol.VarSym], quantVars: Set[Symbol.VarSym], latVars: Set[Symbol.VarSym])(implicit inTryCatch: Boolean, renv: RigidityEnv, flix: Flix, sctx: SharedContext): Unit = p match {
     case Predicate.Body.Atom(_, den, polarity, _, terms, _, loc) =>
       // Check for non-positively bound negative variables.
-      val err1 = polarity match {
-        case Polarity.Positive => Nil
+      polarity match {
+        case Polarity.Positive => ()
         case Polarity.Negative =>
           // Compute the free variables in the terms which are *not* bound by the lexical scope.
           val freeVars = terms.flatMap(freeVarsOf).toSet.intersect(quantVars)
-          val wildcardNegErrors = terms.flatMap(visitPat(_, loc))
+          terms.foreach(visitPat(_, loc))
 
           // Check if any free variables are not positively bound.
-          val variableNegErrors = (freeVars -- posVars).map(mkIllegalNonPositivelyBoundVariableError(_, loc)).toList
-          wildcardNegErrors ++ variableNegErrors
+          (freeVars -- posVars).foreach(mkIllegalNonPositivelyBoundVariableError(_, loc))
       }
       // Check for relational use of lattice variables. We still look at fixed atoms since latVars
       // (which means that they occur non-fixed) cannot be in another fixed atom.
@@ -522,17 +561,14 @@ object Safety {
         case Denotation.Latticenal => terms.dropRight(1)
       }
       val relVars = relTerms.flatMap(freeVarsOf).toSet
-      val err2 = relVars.intersect(latVars).map(IllegalRelationalUseOfLatticeVar(_, loc))
-
-      // Combine the messages
-      err1 ++ err2
+      relVars.intersect(latVars).map(IllegalRelationalUseOfLatticeVar(_, loc)).foreach(sctx.errors.add)
 
     case Predicate.Body.Functional(_, exp, loc) =>
       // Check for non-positively in variables (free variables in exp).
       val inVars = freeVars(exp).keySet.intersect(quantVars)
-      val err1 = (inVars -- posVars).toList.map(mkIllegalNonPositivelyBoundVariableError(_, loc))
+      (inVars -- posVars).toList.foreach(mkIllegalNonPositivelyBoundVariableError(_, loc))
 
-      err1 ::: visitExp(exp)
+      visitExp(exp)
 
     case Predicate.Body.Guard(exp, _) =>
       visitExp(exp)
@@ -540,9 +576,10 @@ object Safety {
   }
 
   /** Returns a non-positively bound variable error, depending on `sym.isWild`. */
-  private def mkIllegalNonPositivelyBoundVariableError(sym: Symbol.VarSym, loc: SourceLocation): SafetyError = {
-    if (sym.isWild) IllegalNegativelyBoundWildVar(sym, loc)
+  private def mkIllegalNonPositivelyBoundVariableError(sym: Symbol.VarSym, loc: SourceLocation)(implicit sctx: SharedContext): Unit = {
+    val err = if (sym.isWild) IllegalNegativelyBoundWildVar(sym, loc)
     else IllegalNonPositivelyBoundVar(sym, loc)
+    sctx.errors.add(err)
   }
 
   /** Returns all the free and positively defined variable symbols in the given constraint `c`. */
@@ -585,7 +622,7 @@ object Safety {
   }
 
   /** Checks that the free relational variables in `head` does not include `latVars`. */
-  private def checkHeadPredicate(head: Predicate.Head, latVars: Set[Symbol.VarSym])(implicit sctx: SharedContext): List[SafetyError] = head match {
+  private def checkHeadPredicate(head: Predicate.Head, latVars: Set[Symbol.VarSym])(implicit sctx: SharedContext): Unit = head match {
     case Predicate.Head.Atom(_, Denotation.Latticenal, terms, _, loc) =>
       val relationalTerms = terms.dropRight(1)
       checkTerms(relationalTerms, latVars, loc)
@@ -594,23 +631,25 @@ object Safety {
   }
 
   /** Checks that the free variables in `exps` does not include `latVars`. */
-  private def checkTerms(exps: List[Expr], latVars: Set[Symbol.VarSym], loc: SourceLocation)(implicit sctx: SharedContext): List[SafetyError] = {
+  private def checkTerms(exps: List[Expr], latVars: Set[Symbol.VarSym], loc: SourceLocation)(implicit sctx: SharedContext): Unit = {
     val allFreeVars = exps.flatMap(t => freeVars(t).keys).toSet
 
     // Compute the lattice variables that are illegally used in the exps.
-    allFreeVars.intersect(latVars).toList.map(IllegalRelationalUseOfLatticeVar(_, loc))
+    allFreeVars.intersect(latVars).toList.map(IllegalRelationalUseOfLatticeVar(_, loc)).foreach(sctx.errors.add)
   }
 
   /** Checks that `pat` contains no wildcards. */
-  private def visitPat(pat: Pattern, loc: SourceLocation)(implicit sctx: SharedContext): List[SafetyError] = pat match {
-    case Pattern.Wild(_, _) => List(IllegalNegativelyBoundWildCard(loc))
-    case Pattern.Var(_, _, _) => Nil
-    case Pattern.Cst(_, _, _) => Nil
-    case Pattern.Tag(_, pats, _, _) => pats.flatMap(visitPat(_, loc))
-    case Pattern.Tuple(elms, _, _) => elms.flatMap(visitPat(_, loc))
-    case Pattern.Record(pats, pat, _, _) => pats.map(_.pat).flatMap(visitPat(_, loc)) ++ visitPat(pat, loc)
-    case Pattern.RecordEmpty(_, _) => Nil
-    case Pattern.Error(_, _) => Nil
+  private def visitPat(pat: Pattern, loc: SourceLocation)(implicit sctx: SharedContext): Unit = pat match {
+    case Pattern.Wild(_, _) => sctx.errors.add(IllegalNegativelyBoundWildCard(loc))
+    case Pattern.Var(_, _, _) => ()
+    case Pattern.Cst(_, _, _) => ()
+    case Pattern.Tag(_, pats, _, _) => pats.foreach(visitPat(_, loc))
+    case Pattern.Tuple(elms, _, _) => elms.foreach(visitPat(_, loc))
+    case Pattern.Record(pats, pat, _, _) =>
+      pats.map(_.pat).foreach(visitPat(_, loc))
+      visitPat(pat, loc)
+    case Pattern.RecordEmpty(_, _) => ()
+    case Pattern.Error(_, _) => ()
   }
 
   /**
@@ -619,20 +658,16 @@ object Safety {
     * @param clazz the Java class specified in the catch clause
     * @param loc   the location of the catch parameter.
     */
-  private def checkCatchClass(clazz: Class[?], loc: SourceLocation )(implicit sctx: SharedContext): List[SafetyError] = {
-    if (isThrowable(clazz)) List.empty
-    else List(IllegalCatchType(loc))
-  }
+  private def checkCatchClass(clazz: Class[?], loc: SourceLocation )(implicit sctx: SharedContext): Unit =
+    if (!isThrowable(clazz)) sctx.errors.add(IllegalCatchType(loc))
 
   /** Returns `true` if `clazz` is [[java.lang.Throwable]] or a subclass of it. */
   private def isThrowable(clazz: Class[?]): Boolean =
     classOf[Throwable].isAssignableFrom(clazz)
 
   /** Checks that the type of the argument to `throw` is [[java.lang.Throwable]] or a subclass. */
-  private def checkThrow(exp: Expr )(implicit sctx: SharedContext): List[SafetyError] = {
-    if (isThrowableType(exp.tpe)) List()
-    else List(IllegalThrowType(exp.loc))
-  }
+  private def checkThrow(exp: Expr )(implicit sctx: SharedContext): Unit =
+    if (!isThrowableType(exp.tpe)) sctx.errors.add(IllegalThrowType(exp.loc))
 
   /** Returns `true` if `tpe` is [[java.lang.Throwable]] or a subclass of it. */
   @tailrec
@@ -654,37 +689,28 @@ object Safety {
     *   - `methods` must not include non-existing methods.
     *   - `methods` must not let control effects escape.
     */
-  private def checkObjectImplementation(newObject: Expr.NewObject)(implicit flix: Flix , sctx: SharedContext): List[SafetyError] = newObject match {
+  private def checkObjectImplementation(newObject: Expr.NewObject)(implicit flix: Flix , sctx: SharedContext): Unit = newObject match {
     case Expr.NewObject(_, clazz, tpe0, _, methods, loc) =>
       val tpe = Type.eraseAliases(tpe0)
       // `clazz` must be an interface or have a non-private constructor without arguments.
-      val constructorErrors = {
-        if (clazz.isInterface) {
-          List.empty
-        } else {
-          if (hasNonPrivateZeroArgConstructor(clazz)) List.empty
-          else List(NewObjectMissingPublicZeroArgConstructor(clazz, loc))
-        }
-      }
+      if (!clazz.isInterface && !hasNonPrivateZeroArgConstructor(clazz))
+        sctx.errors.add(NewObjectMissingPublicZeroArgConstructor(clazz, loc))
 
       // `clazz` must be public.
-      val visibilityErrors = {
-        if (!isPublicClass(clazz)) List(NewObjectNonPublicClass(clazz, loc))
-        else List.empty
-      }
+      if (!isPublicClass(clazz)) sctx.errors.add(NewObjectNonPublicClass(clazz, loc))
 
       // `methods` must take the object itself (`this`) as the first argument.
-      val thisErrors = methods.flatMap {
+      methods.foreach {
         case JvmMethod(ident, fparams, _, _, _, methodLoc) =>
           val firstParam = fparams.head
           firstParam.tpe match {
             case t if Type.eraseAliases(t) == tpe =>
-              None
+              ()
             case Type.Unit =>
               // Unit arguments are likely inserted by the compiler.
-              Some(NewObjectMissingThisArg(clazz, ident.name, methodLoc))
+              sctx.errors.add(NewObjectMissingThisArg(clazz, ident.name, methodLoc))
             case _ =>
-              Some(NewObjectIllegalThisType(clazz, firstParam.tpe, ident.name, methodLoc))
+              sctx.errors.add(NewObjectIllegalThisType(clazz, firstParam.tpe, ident.name, methodLoc))
           }
       }
 
@@ -700,17 +726,15 @@ object Safety {
 
       // `methods` must include all required signatures (e.g. abstract methods).
       val unimplemented = mustImplement.diff(implemented)
-      val unimplementedErrors = unimplemented.map(m => NewObjectMissingMethod(clazz, classMethods(m), loc))
+      unimplemented.map(m => NewObjectMissingMethod(clazz, classMethods(m), loc)).foreach(sctx.errors.add)
 
       // `methods` must not include non-existing methods.
       val undefined = implemented.diff(canImplement)
-      val undefinedErrors = undefined.map(m => NewObjectUndefinedMethod(clazz, m.name, flixMethods(m).loc))
+      undefined.map(m => NewObjectUndefinedMethod(clazz, m.name, flixMethods(m).loc)).foreach(sctx.errors.add)
 
       // `methods` must not let control effects escape.
       val controlEffecting = methods.filter(m => hasControlEffects(m.eff))
-      val controlEffectingErrors = controlEffecting.map(m => SafetyError.IllegalMethodEffect(m.eff, m.loc))
-
-      constructorErrors ++ visibilityErrors ++ thisErrors ++ unimplementedErrors ++ undefinedErrors ++ controlEffectingErrors
+      controlEffecting.map(m => SafetyError.IllegalMethodEffect(m.eff, m.loc)).foreach(sctx.errors.add)
   }
 
   /**


### PR DESCRIPTION
Introduce SharedContext for safety and stop returning list of errors.

First two steps for #9554