### PR TITLE
fix: correct `Random.handleWithSeed` type and fix region check

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -477,6 +477,13 @@ object Type {
   val Difference: Type = Type.Cst(TypeConstructor.Difference, SourceLocation.Unknown)
 
   /**
+    * Represents the Symmetric Difference type constructor.
+    *
+    * NB: This type has kind: Eff -> (Eff -> Eff).
+    */
+  val SymmetricDiff: Type = Type.Cst(TypeConstructor.SymmetricDiff, SourceLocation.Unknown)
+
+  /**
     * Represents the True Boolean algebra value.
     */
   val True: Type = Type.Cst(TypeConstructor.True, SourceLocation.Unknown)

--- a/main/src/library/Random.flix
+++ b/main/src/library/Random.flix
@@ -59,17 +59,19 @@ mod Random {
     ///
     /// In other words, re-interprets the `Random` effect using the `NonDet` and `IO` effects.
     ///
-    pub def handle(f: a -> b \ ef): (a -> b \ (ef - Random) + {NonDet, IO}) \ {NonDet, IO} =
-        let rnd = new JRandom(); // Reuse Random instance.
-        x -> run {
-            f(x)
-        } with Random {
-            def randomBool(k)       = k(rnd.nextBoolean())
-            def randomFloat32(k)    = k(rnd.nextFloat())
-            def randomFloat64(k)    = k(rnd.nextDouble())
-            def randomInt32(k)      = k(rnd.nextInt())
-            def randomInt64(k)      = k(rnd.nextLong())
-            def randomGaussian(k)   = k(rnd.nextGaussian())
+    pub def handle(f: a -> b \ ef): a -> b \ (ef - Random) + {NonDet, IO} =
+        x -> {
+            let rnd = new JRandom(); // Reuse Random instance.
+            run {
+                f(x)
+            } with Random {
+                def randomBool(k)       = k(rnd.nextBoolean())
+                def randomFloat32(k)    = k(rnd.nextFloat())
+                def randomFloat64(k)    = k(rnd.nextDouble())
+                def randomInt32(k)      = k(rnd.nextInt())
+                def randomInt64(k)      = k(rnd.nextLong())
+                def randomGaussian(k)   = k(rnd.nextGaussian())
+            }
         }
 
     ///
@@ -84,24 +86,29 @@ mod Random {
     ///
     /// In other words, re-interprets the `Random` effect using seeded deterministic randomness.
     ///
-    pub def handleWithSeed(seed: Int64, f: a -> b \ ef): (a -> b \ (ef - Random) + {NonDet, IO}) \ {NonDet, IO} =
-        let rnd = new JRandom(seed); // Reuse Random instance.
-        x -> run {
-            f(x)
-        } with Random {
-            def randomBool(k)       = k(rnd.nextBoolean())
-            def randomFloat32(k)    = k(rnd.nextFloat())
-            def randomFloat64(k)    = k(rnd.nextDouble())
-            def randomInt32(k)      = k(rnd.nextInt())
-            def randomInt64(k)      = k(rnd.nextLong())
-            def randomGaussian(k)   = k(rnd.nextGaussian())
+    pub def handleWithSeed(seed: Int64, f: a -> b \ ef): a -> b \ ef - Random = {
+        // Given a specifc seed, JRandom is just a mutable iterator and therefore we type it as such.
+        x -> region local {
+            let _ = local; // avoid redundancy check
+            let rnd = unchecked_cast (new JRandom(seed) as _ \ local);
+            run {
+                f(x)
+            } with Random {
+                def randomBool(k)       = k(unchecked_cast (rnd.nextBoolean() as _ \ local))
+                def randomFloat32(k)    = k(unchecked_cast (rnd.nextFloat() as _ \ local))
+                def randomFloat64(k)    = k(unchecked_cast (rnd.nextDouble() as _ \ local))
+                def randomInt32(k)      = k(unchecked_cast (rnd.nextInt() as _ \ local))
+                def randomInt64(k)      = k(unchecked_cast (rnd.nextLong() as _ \ local))
+                def randomGaussian(k)   = k(unchecked_cast (rnd.nextGaussian() as _ \ local))
+            }
         }
+    }
 
     ///
     /// Runs the `Random` effect of the given function `f` from an initial seed.
     ///
     /// In other words, re-interprets the `Random` effect using seeded deterministic randomness.
     ///
-    pub def runWithSeed(seed: Int64, f: Unit -> a \ ef): a \ (ef - Random) + {NonDet, IO} = handleWithSeed(seed, f)()
+    pub def runWithSeed(seed: Int64, f: Unit -> a \ ef): a \ ef - Random = handleWithSeed(seed, f)()
 
 }


### PR DESCRIPTION
- Stop `Random.handleX` from being stateful before the last argument
- Remove unnecessary effects from seeded handler
- Fix region checking for effect with minus, xor, and concrete effects