### PR TITLE
feat: incremental `Safety`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -91,6 +91,7 @@ class Flix {
   private var cachedKinderAst: KindedAst.Root = KindedAst.empty
   private var cachedResolverAst: ResolvedAst.Root = ResolvedAst.empty
   private var cachedTyperAst: TypedAst.Root = TypedAst.empty
+  private var cachedSafetyAst: TypedAst.Root = TypedAst.empty
 
   /**
     * A cache of error messages for incremental compilation.
@@ -593,7 +594,7 @@ class Flix {
             val (afterRedundancy, redundancyErrors) = Redundancy.run(afterPatMatch)
             errors ++= redundancyErrors
 
-            val (afterSafety, safetyErrors) = Safety.run(afterRedundancy)
+            val (afterSafety, safetyErrors) = Safety.run(afterRedundancy, cachedSafetyAst, changeSet)
             errors ++= safetyErrors
 
             val (afterDependencies, _) = Dependencies.run(afterSafety)
@@ -606,6 +607,7 @@ class Flix {
               this.cachedKinderAst = afterKinder
               this.cachedResolverAst = afterResolver
               this.cachedTyperAst = afterDependencies
+              this.cachedSafetyAst = afterSafety
 
               // We record that no files are dirty in the change set.
               this.changeSet = ChangeSet.Dirty(Set.empty)

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -91,7 +91,6 @@ class Flix {
   private var cachedKinderAst: KindedAst.Root = KindedAst.empty
   private var cachedResolverAst: ResolvedAst.Root = ResolvedAst.empty
   private var cachedTyperAst: TypedAst.Root = TypedAst.empty
-  private var cachedRedundancyAst: TypedAst.Root = TypedAst.empty
 
   /**
     * A cache of error messages for incremental compilation.
@@ -594,7 +593,7 @@ class Flix {
             val (afterRedundancy, redundancyErrors) = Redundancy.run(afterPatMatch)
             errors ++= redundancyErrors
 
-            val (_, safetyErrors) = Safety.run(afterRedundancy, cachedRedundancyAst, changeSet)
+            val (_, safetyErrors) = Safety.run(afterRedundancy, cachedTyperAst, changeSet)
             errors ++= safetyErrors
 
             val (afterDependencies, _) = Dependencies.run(afterRedundancy)
@@ -606,7 +605,6 @@ class Flix {
               this.cachedDesugarAst = afterDesugar
               this.cachedKinderAst = afterKinder
               this.cachedResolverAst = afterResolver
-              this.cachedRedundancyAst = afterRedundancy
               this.cachedTyperAst = afterDependencies
 
               // We record that no files are dirty in the change set.

--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -91,7 +91,7 @@ class Flix {
   private var cachedKinderAst: KindedAst.Root = KindedAst.empty
   private var cachedResolverAst: ResolvedAst.Root = ResolvedAst.empty
   private var cachedTyperAst: TypedAst.Root = TypedAst.empty
-  private var cachedSafetyAst: TypedAst.Root = TypedAst.empty
+  private var cachedRedundancyAst: TypedAst.Root = TypedAst.empty
 
   /**
     * A cache of error messages for incremental compilation.
@@ -594,10 +594,10 @@ class Flix {
             val (afterRedundancy, redundancyErrors) = Redundancy.run(afterPatMatch)
             errors ++= redundancyErrors
 
-            val (afterSafety, safetyErrors) = Safety.run(afterRedundancy, cachedSafetyAst, changeSet)
+            val (_, safetyErrors) = Safety.run(afterRedundancy, cachedRedundancyAst, changeSet)
             errors ++= safetyErrors
 
-            val (afterDependencies, _) = Dependencies.run(afterSafety)
+            val (afterDependencies, _) = Dependencies.run(afterRedundancy)
 
             if (options.incremental) {
               this.cachedLexerTokens = afterLexer
@@ -606,8 +606,8 @@ class Flix {
               this.cachedDesugarAst = afterDesugar
               this.cachedKinderAst = afterKinder
               this.cachedResolverAst = afterResolver
+              this.cachedRedundancyAst = afterRedundancy
               this.cachedTyperAst = afterDependencies
-              this.cachedSafetyAst = afterSafety
 
               // We record that no files are dirty in the change set.
               this.changeSet = ChangeSet.Dirty(Set.empty)

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -691,7 +691,7 @@ object Symbol {
   /**
     * Signature Symbol.
     */
-  final class SigSym(val trt: Symbol.TraitSym, val name: String, val loc: SourceLocation) extends Symbol {
+  final class SigSym(val trt: Symbol.TraitSym, val name: String, val loc: SourceLocation) extends Sourceable with Symbol {
     /**
       * Returns `true` if this symbol is equal to `that` symbol.
       */
@@ -714,6 +714,11 @@ object Symbol {
       * The symbol's namespace.
       */
     def namespace: List[String] = trt.namespace :+ trt.name
+
+    /**
+      * Returns the source of `this`.
+      */
+    override def src: Source = loc.source
   }
 
   /**


### PR DESCRIPTION
fixes #9554

I've made part of this phase incremental. But two problems reamin:
- I don't know how to trigger the test that will output the chart
- Safety will iterate over the internal defs in instances and internal sigs for traits, which makes it hard to reconstruct based on the return value. I can rewrite it to check just stale parts(instances or traits), but I'm not sure if it's easy to employ a finer granularity or reconstruct new instances and traits. 