### PR TITLE
feat: introduce partitionOnValues

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
@@ -72,12 +72,11 @@ sealed trait ChangeSet {
       (newMap, Map.empty)
 
     case ChangeSet.Dirty(dirty) =>
-      val (stale, fresh) = newMap.foldLeft((Map.empty[K, List[V]], Map.empty[K, List[V]])){ case ((stale, fresh), (k, vList)) =>
+      newMap.foldLeft((Map.empty[K, List[V]], Map.empty[K, List[V]])){ case ((stale, fresh), (k, vList)) =>
         val oldList = oldMap.getOrElse(k, Nil)
         val (freshList, staleList) = vList.partition(v => oldList.contains(v) &&  !dirty.contains(v.src.input))
         (stale + (k -> staleList), fresh + (k -> freshList))
       }
-      (stale, fresh)
   }
 }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
@@ -16,6 +16,7 @@
 package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.language.ast.shared.{DependencyGraph, Input}
+import jdk.jshell.SourceCodeAnalysis
 
 sealed trait ChangeSet {
 
@@ -54,7 +55,33 @@ sealed trait ChangeSet {
       (stale, fresh)
   }
 
+  /**
+    * Returns two maps: `stale` and `fresh` according to the given `newMap` and `oldMap`, the value of the map is a list of Sourceable.
+    *
+    * A fresh item in the value list is one that can be reused.
+    * A stale item in the value list is one that must be re-compiled.
+    * An item that is neither fresh nor stale can be deleted.
+    * Actually, all fresh and stale items will be in the newMap
+    *
+    * An item from newMap is fresh if it is also in `oldMap`, and it is not dirty (i.e. has not changed).
+    * Otherwise, it is stale.
+    *
+    * The type of the value in the map must be the same, since when checking stale, we need to check if the value is in the fresh map.
+    */
+  def partitionOnValues[K, V <: Sourceable](newMap: Map[K, List[V]], oldMap: Map[K, List[V]]): (Map[K, List[V]], Map[K, List[V]]) = this match {
+    case ChangeSet.Everything =>
+      (newMap, Map.empty)
+
+    case ChangeSet.Dirty(dirty) =>
+      val (stale, fresh) = newMap.foldLeft((Map.empty[K, List[V]], Map.empty[K, List[V]])){ case ((stale, fresh), (k, vList)) =>
+        val oldList = oldMap.getOrElse(k, Nil)
+        val (freshList, staleList) = vList.partition(v => oldList.contains(v) &&  !dirty.contains(v.src.input))
+        (stale + (k -> staleList), fresh + (k -> freshList))
+      }
+      (stale, fresh)
+  }
 }
+
 
 object ChangeSet {
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
@@ -75,7 +75,9 @@ sealed trait ChangeSet {
       newMap.foldLeft((Map.empty[K, List[V]], Map.empty[K, List[V]])){ case ((stale, fresh), (k, vList)) =>
         val oldList = oldMap.getOrElse(k, Nil)
         val (freshList, staleList) = vList.partition(v => oldList.contains(v) &&  !dirty.contains(v.src.input))
-        (stale + (k -> staleList), fresh + (k -> freshList))
+        val staleMap = if (staleList.nonEmpty) stale + (k -> staleList) else stale
+        val freshMap = if (freshList.nonEmpty) fresh + (k -> freshList) else fresh
+        (staleMap, freshMap)
       }
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
@@ -16,7 +16,6 @@
 package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.language.ast.shared.{DependencyGraph, Input}
-import jdk.jshell.SourceCodeAnalysis
 
 sealed trait ChangeSet {
 
@@ -81,7 +80,6 @@ sealed trait ChangeSet {
       (stale, fresh)
   }
 }
-
 
 object ChangeSet {
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -49,7 +49,9 @@ object TypedAst {
 
   case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[AssocTypeSig], sigs: List[Sig], laws: List[Def], loc: SourceLocation)
 
-  case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, trt: TraitSymUse, tpe: Type, tconstrs: List[TraitConstraint], assocs: List[AssocTypeDef], defs: List[Def], ns: Name.NName, loc: SourceLocation)
+  case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, trt: TraitSymUse, tpe: Type, tconstrs: List[TraitConstraint], assocs: List[AssocTypeDef], defs: List[Def], ns: Name.NName, loc: SourceLocation) extends Sourceable {
+    override def src: Source = loc.source
+  }
 
   case class Sig(sym: Symbol.SigSym, spec: Spec, exp: Option[Expr], loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -37,7 +37,7 @@ object Safety {
     val (staleInstances, freshInstances) = changeSet.partitionOnValues(root.instances, oldRoot.instances)
     val defs = freshDefs ++ ParOps.parMapValues(staleDefs)(visitDef)
     val traits = freshTraits ++ ParOps.parMapValues(staleTraits)(visitTrait)
-    val instances = MergeMapdList(freshInstances, ParOps.parMapValues(staleInstances)(visitInstanceList))
+    val instances = mergeMappedList(freshInstances, ParOps.parMapValues(staleInstances)(visitInstanceList))
 
     val newRoot = root.copy(
       defs = defs,
@@ -809,7 +809,7 @@ object Safety {
     !eff.effects.forall(Symbol.isPrimitiveEff)
   }
 
-  private def MergeMapdList[K, V](map1: Map[K, List[V]], map2: Map[K, List[V]]): Map[K, List[V]] = {
+  private def mergeMappedList[K, V](map1: Map[K, List[V]], map2: Map[K, List[V]]): Map[K, List[V]] = {
     map2.foldLeft(map1) {
       case (acc, (k, v)) => acc.updated(k, acc.getOrElse(k, Nil) ++ v)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -6,7 +6,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.Body
 import ca.uwaterloo.flix.language.ast.ops.TypedAstOps
 import ca.uwaterloo.flix.language.ast.ops.TypedAstOps.*
 import ca.uwaterloo.flix.language.ast.shared.*
-import ca.uwaterloo.flix.language.ast.{ChangeSet, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.{ChangeSet, RigidityEnv, SourceLocation, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.language.errors.SafetyError
 import ca.uwaterloo.flix.language.errors.SafetyError.*
@@ -34,11 +34,17 @@ object Safety {
 
     val (staleDefs, freshDefs) = changeSet.partition(root.defs, oldRoot.defs)
     val (staleTraits, freshTraits) = changeSet.partition(root.traits, oldRoot.traits)
+    val (staleInstances, freshInstances) = changeSet.partitionOnValues(root.instances, oldRoot.instances)
     val defs = freshDefs ++ ParOps.parMapValues(staleDefs)(visitDef)
     val traits = freshTraits ++ ParOps.parMapValues(staleTraits)(visitTrait)
-    ParOps.parMap(TypedAstOps.instanceDefsOf(root))(visitDef)
+    val instances = MergeMapdList(freshInstances, ParOps.parMapValues(staleInstances)(visitInstanceList))
 
-    (root.copy(defs = defs, traits = traits), sctx.errors.asScala.toList)
+    val newRoot = root.copy(
+      defs = defs,
+      traits = traits,
+      instances = instances
+    )
+    (newRoot, sctx.errors.asScala.toList)
   }
 
   private def visitTrait(trt: Trait)(implicit sctx: SharedContext, flix: Flix): Trait = {
@@ -59,6 +65,14 @@ object Safety {
     visitExp(defn.exp)(inTryCatch = false, renv, sctx, flix)
     defn
   }
+
+  private def visitInstanceList(insts: List[TypedAst.Instance])(implicit sctx: SharedContext, flix: Flix): List[TypedAst.Instance] = {
+    insts.foreach(visitInstance)
+    insts
+  }
+
+  private def visitInstance(inst: TypedAst.Instance)(implicit sctx: SharedContext, flix: Flix): Unit =
+    inst.defs.foreach(visitDef)
 
   /**
     * Checks tje safety and well-formedness of `exp0`.
@@ -793,6 +807,12 @@ object Safety {
   private def hasControlEffects(eff: Type): Boolean = {
     // TODO: This is unsound and incomplete because it ignores type variables, associated types, etc.
     !eff.effects.forall(Symbol.isPrimitiveEff)
+  }
+
+  private def MergeMapdList[K, V](map1: Map[K, List[V]], map2: Map[K, List[V]]): Map[K, List[V]] = {
+    map2.foldLeft(map1) {
+      case (acc, (k, v)) => acc.updated(k, acc.getOrElse(k, Nil) ++ v)
+    }
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/language/ast/AstSuite.scala
+++ b/main/test/ca/uwaterloo/flix/language/ast/AstSuite.scala
@@ -4,6 +4,7 @@ import org.scalatest.Suites
 
 class AstSuite extends Suites(
   new SourcePositionSuite,
-  new SourceLocationSuite
+  new SourceLocationSuite,
+  new TestChangeSet,
 )
 

--- a/main/test/ca/uwaterloo/flix/language/ast/TestChangeSet.scala
+++ b/main/test/ca/uwaterloo/flix/language/ast/TestChangeSet.scala
@@ -1,0 +1,101 @@
+package ca.uwaterloo.flix.language.ast
+
+import ca.uwaterloo.flix.language.ast.shared.SecurityContext.AllPermissions
+import ca.uwaterloo.flix.language.ast.shared.{DependencyGraph, Input, Source}
+import ca.uwaterloo.flix.util.collection.MultiMap
+import org.scalatest.funsuite.AnyFunSuite
+
+class TestChangeSet extends AnyFunSuite {
+  case class MySourceable(input: Input) extends Sourceable {
+    override def src: Source = Source(input, Array.emptyCharArray)
+  }
+
+  private def mkInput(name: String): Input = Input.Text(name, "", AllPermissions)
+
+  private val input1 = mkInput("input1")
+  private val input2 = mkInput("input2")
+  private val input3 = mkInput("input3")
+  private val input4 = mkInput("input4")
+  private val input5 = mkInput("input5")
+
+  private val src1 = MySourceable(input1)
+  private val src2 = MySourceable(input2)
+  private val src3 = MySourceable(input3)
+  private val src4 = MySourceable(input4)
+  private val src5 = MySourceable(input5)
+
+  private val dg1 = DependencyGraph.empty
+  private val dg2 = DependencyGraph(MultiMap(Map(
+    input1 -> Set(input2, input3), input2 -> Set(input4), input3 -> Set(input5)
+  )))
+
+  test("ChangeSet.Everything.partition should make everything stale") {
+    val cs = ChangeSet.Everything
+    val oldMap = Map(src1 -> 1, src2 -> 2)
+    val newMap = Map(src3 -> 3, src4 -> 4)
+    val (staleMap, freshMap) = cs.partition(newMap, oldMap)
+
+    assert(staleMap == newMap)
+    assert(freshMap == Map.empty)
+  }
+
+  test("ChangeSet.Dirty.partition should put something changed into staleMap.01") {
+    val oldMap = Map(src1 -> 1, src2 -> 2)
+    val newMap = Map(src1 -> 3, src2 -> 2)
+    val cs = ChangeSet.Everything.markChanged(input1, dg1)
+    val (staleMap, freshMap) = cs.partition(newMap, oldMap)
+
+    assert(staleMap == Map(src1 -> 3))
+    assert(freshMap == Map(src2 -> 2))
+  }
+
+  test("ChangeSet.Dirty.partition should put something changed into staleMap.02") {
+    val oldMap = Map(src1 -> 1, src2 -> 2, src3 -> 3, src4 -> 4, src5 -> 5)
+    val newMap = Map(src1 -> 3, src2 -> 2, src3 -> 3, src4 -> 4, src5 -> 5)
+    val cs = ChangeSet.Everything.markChanged(input1, dg2)
+    val (staleMap, freshMap) = cs.partition(newMap, oldMap)
+
+    assert(staleMap == Map(src1 -> 3, src2 -> 2, src3 -> 3, src4 -> 4, src5 -> 5))
+    assert(freshMap == Map.empty)
+  }
+
+  test("ChangeSet.Dirty.partition should put something new into staleMap") {
+    val oldMap = Map(src1 -> 1, src2 -> 2)
+    val newMap = Map(src1 -> 1, src2 -> 2, src3 -> 3)
+    val cs = ChangeSet.Dirty(Set.empty)
+    val (staleMap, freshMap) = cs.partition(newMap, oldMap)
+
+    assert(staleMap == Map(src3 -> 3))
+    assert(freshMap == Map(src1 -> 1, src2 -> 2))
+  }
+
+  test("ChangeSet.Dirty.partition should ignore anything deleted") {
+    val oldMap = Map(src1 -> 1, src2 -> 2, src3 -> 3)
+    val newMap = Map(src1 -> 1, src2 -> 2)
+    val cs = ChangeSet.Dirty(Set.empty)
+    val (staleMap, freshMap) = cs.partition(newMap, oldMap)
+
+    assert(staleMap == Map.empty)
+    assert(freshMap == Map(src1 -> 1, src2 -> 2))
+  }
+
+  test("ChangeSet.Dirty.partition test with both newed and deleted input") {
+    val oldMap = Map(src1 -> 1, src2 -> 2, src3 -> 3)
+    val newMap = Map(src2 -> 2, src3 -> 3, src4 -> 4)
+    val cs = ChangeSet.Dirty(Set.empty)
+    val (staleMap, freshMap) = cs.partition(newMap, oldMap)
+
+    assert(staleMap == Map(src4 -> 4))
+    assert(freshMap == Map(src2 -> 2, src3 -> 3))
+  }
+
+  test("ChangeSet.Dirty.partition test with new, deleted and changed input") {
+    val oldMap = Map(src1 -> 1, src2 -> 2, src3 -> 3, src5 -> 5)
+    val newMap = Map(src2 -> 2, src3 -> 30, src4 -> 4, src5 -> 5)
+    val cs = ChangeSet.Everything.markChanged(input3, dg2)
+    val (staleMap, freshMap) = cs.partition(newMap, oldMap)
+
+    assert(staleMap == Map(src3 -> 30, src4 -> 4, src5 -> 5))
+    assert(freshMap == Map(src2 -> 2))
+  }
+}

--- a/main/test/ca/uwaterloo/flix/language/ast/TestChangeSet.scala
+++ b/main/test/ca/uwaterloo/flix/language/ast/TestChangeSet.scala
@@ -40,7 +40,7 @@ class TestChangeSet extends AnyFunSuite {
     assert(freshMap == Map.empty)
   }
 
-  test("ChangeSet.partition should put something changed into staleMap.01") {
+  test("ChangeSet.partition should put anything changed into staleMap.01") {
     val oldMap = Map(src1 -> 1, src2 -> 2)
     val newMap = Map(src1 -> 3, src2 -> 2)
 
@@ -51,7 +51,7 @@ class TestChangeSet extends AnyFunSuite {
     assert(freshMap == Map(src2 -> 2))
   }
 
-  test("ChangeSet.partition should put something changed into staleMap.02") {
+  test("ChangeSet.partition should put anything changed into staleMap.02") {
     val oldMap = Map(src1 -> 1, src2 -> 2, src3 -> 3, src4 -> 4, src5 -> 5)
     val newMap = Map(src1 -> 3, src2 -> 2, src3 -> 3, src4 -> 4, src5 -> 5)
 
@@ -62,7 +62,7 @@ class TestChangeSet extends AnyFunSuite {
     assert(freshMap == Map.empty)
   }
 
-  test("ChangeSet.partition should put something new into staleMap") {
+  test("ChangeSet.partition should put anything new into staleMap") {
     val oldMap = Map(src1 -> 1, src2 -> 2)
     val newMap = Map(src1 -> 1, src2 -> 2, src3 -> 3)
 
@@ -117,7 +117,7 @@ class TestChangeSet extends AnyFunSuite {
     assert(freshMap == Map.empty)
   }
 
-  test("ChangeSet.partitionOnValues should put something changed into staleMap.01") {
+  test("ChangeSet.partitionOnValues should put anything changed into staleMap.01") {
     val oldMap = Map(1 -> List(src1, src2), 2 -> List(src2))
     val newMap = Map(1 -> List(src1, src2), 2 -> List(src2))
 
@@ -128,7 +128,7 @@ class TestChangeSet extends AnyFunSuite {
     assert(freshMap == Map(1 -> List(src2), 2 -> List(src2)))
   }
 
-  test("ChangeSet.partitionOnValues should put something changed into staleMap.02") {
+  test("ChangeSet.partitionOnValues should put anything changed into staleMap.02") {
     val oldMap = Map(1 -> List(src1, src2), 2 -> List(src2), 3 -> List(src3), 4 -> List(src4), 5 -> List(src5))
     val newMap = Map(1 -> List(src1, src2), 2 -> List(src2), 3 -> List(src3), 4 -> List(src4), 5 -> List(src5))
 
@@ -139,7 +139,7 @@ class TestChangeSet extends AnyFunSuite {
     assert(freshMap == Map.empty)
   }
 
-  test("ChangeSet.partitionOnValues should put something new into staleMap") {
+  test("ChangeSet.partitionOnValues should put anything new into staleMap") {
     val oldMap = Map(1 -> List(src1, src2), 2 -> List(src2))
     val newMap = Map(1 -> List(src1, src2), 2 -> List(src2, src3), 3 -> List(src4))
 


### PR DESCRIPTION
Introduce partitionOnValues to handle cases like root.Instances.

We will determine if an instance is stale or fresh by looking at the value of the map, instead of the key. I replicate the logic used in `partition` to implement this function.

I think the second filter in 
```
      val fresh = oldMap.filter(kv => !dirty.contains(kv._1.src.input)).filter(kv => newMap.contains(kv._1))
```
is redundant, if it's old and not dirty, it should still be in the newMap. Is there any special case for that?

I implement partitionOnValues in another way to make it more efficient. You can help check its correctness.

If the assertion above, "an item is old and not dirty will also be in the new map", is correct, I think this way works.

The incremental ratio is still 0.5
![incrementalism json](https://github.com/user-attachments/assets/749a9a78-73b3-4141-b604-ebcdc2c3e849)

Note:
- `mergeMappedList` could be placed in an util package so that it can also be used elsewhere. Maybe just phase/util?
- I make Instance Sourceable and add the body right in its definition. What is the best way to provide this src?