### PR TITLE
feat: introduce UndefinedJvmImport and UndefinedNew

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -45,7 +45,7 @@ object CodeActionProvider {
     case ResolutionError.UndefinedStruct(qn, ap, loc) if overlaps(range, loc) =>
       mkUseStruct(qn.ident, uri, ap) ++ mkNewStruct(qn.ident.name, uri, ap)
 
-    case ResolutionError.UndefinedJvmClass(name, ap, _, loc) if overlaps(range, loc) =>
+    case ResolutionError.UndefinedJvmImport(name, ap, _, loc) if overlaps(range, loc) =>
       mkImportJava(Name.mkQName(name), uri, ap)
 
     case ResolutionError.UndefinedName(qn, ap, env, loc) if overlaps(range, loc) =>

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -69,7 +69,7 @@ object CompletionProvider {
             EnumCompleter.getCompletions(err, namespace, ident) ++
             StructCompleter.getCompletions(err, namespace, ident)
         case err: ResolutionError.UndefinedJvmStaticField => GetStaticFieldCompleter.getCompletions(err) ++ InvokeStaticMethodCompleter.getCompletions(err)
-        case err: ResolutionError.UndefinedJvmClass => ImportCompleter.getCompletions(err)
+        case err: ResolutionError.UndefinedJvmImport => ImportCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedStructField => StructFieldCompleter.getCompletions(err, root)
         case err: ResolutionError.UndefinedKind => KindCompleter.getCompletions(err)
         case err: TypeError.FieldNotFound => MagicMatchCompleter.getCompletions(err) ++ InvokeMethodCompleter.getCompletions(err.tpe, err.fieldName)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ImportCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ImportCompleter.scala
@@ -21,7 +21,7 @@ import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object ImportCompleter {
 
-  def getCompletions(err: ResolutionError.UndefinedJvmClass)(implicit root: TypedAst.Root): Iterable[ImportCompletion] = {
+  def getCompletions(err: ResolutionError.UndefinedJvmImport)(implicit root: TypedAst.Root): Iterable[ImportCompletion] = {
     val path = err.name.split('.').toList
     // Get completions for if we are currently typing the next package/class and if we have just finished typing a package
     javaClassCompletionsFromPrefix(path)(root) ++ javaClassCompletionsFromPrefix(path.dropRight(1))(root)

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -680,6 +680,28 @@ object ResolutionError {
   }
 
   /**
+    * An error raised to indicate that a class name was not found.
+    *
+    * @param name  the class name.
+    * @param ap    the anchor position.
+    * @param msg   the Java error message.
+    * @param loc   the location of the class name.
+    */
+  case class UndefinedJvmClass(name: Name.Ident, ap: AnchorPosition, msg: String, loc: SourceLocation) extends ResolutionError {
+    def summary: String = s"Undefined Java class: '$name'."
+
+    def message(formatter: Formatter): String = messageWithLink {
+      import formatter.*
+      s""">> Undefined Java class '${red(name.name)}'.
+         |
+         |${code(loc, "undefined class.")}
+         |
+         |$msg
+         |""".stripMargin
+    }
+  }
+
+  /**
     * An error raised to indicate that the class name in an importing was not found.
     *
     * @param name the class name.
@@ -688,13 +710,13 @@ object ResolutionError {
     * @param loc  the location of the class name.
     */
   case class UndefinedJvmImport(name: String, ap: AnchorPosition, msg: String, loc: SourceLocation) extends ResolutionError {
-    def summary: String = s"Undefined Java Import: '$name'."
+    def summary: String = s"Undefined class in Java Import: '$name'."
 
     def message(formatter: Formatter): String = messageWithLink {
       import formatter.*
-      s""">> Undefined Java Import '${red(name)}'.
+      s""">> Undefined class in Java Import '${red(name)}'.
          |
-         |${code(loc, "undefined Import.")}
+         |${code(loc, "undefined class.")}
          |
          |$msg
          |""".stripMargin
@@ -708,50 +730,6 @@ object ResolutionError {
         Some(s"Static nested classes should be specified using '$$', e.g. java.util.Locale$$Builder")
       else
         None
-    }
-  }
-
-  /**
-    * An error raised to indicate that a class name was not found.
-    * @param name  the class name.
-    * @param ap    the anchor position.
-    * @param msg   the Java error message.
-    * @param loc   the location of the class name.
-    */
-  case class UndefinedJvmClass(name: String, ap: AnchorPosition, msg: String, loc: SourceLocation) extends ResolutionError {
-    def summary: String = s"Undefined Java class: '$name'."
-
-    def message(formatter: Formatter): String = messageWithLink {
-      import formatter.*
-      s""">> Undefined Java class '${red(name)}'.
-         |
-         |${code(loc, "undefined class.")}
-         |
-         |$msg
-         |""".stripMargin
-    }
-  }
-
-  /**
-    * An error raised to indicate that class/struct name was not found in a new expression.
-    *
-    * @param name the class/struct name
-    * @param ap   the anchor position.
-    * @param env  the variables in the scope.
-    * @param msg  the error message.
-    * @param loc  the location of the class/struct name.
-    */
-  case class UndefinedNew(name: String, ap: AnchorPosition, env: LocalScope, msg: String, loc: SourceLocation) extends ResolutionError {
-    def summary: String = s"Undefined New: '$name'."
-
-    def message(formatter: Formatter): String = messageWithLink {
-      import formatter.*
-      s""">> Undefined New '${red(name)}'.
-         |
-         |${code(loc, "undefined new.")}
-         |
-         |$msg
-         |""".stripMargin
     }
   }
 
@@ -850,6 +828,29 @@ object ResolutionError {
       s"${underline("Tip:")} Possible typo or non-existent definition?"
     })
 
+  }
+
+  /**
+    * An error raised to indicate that class/struct name was not found in a new expression.
+    *
+    * @param name the jvm class/struct name
+    * @param ap   the anchor position.
+    * @param env  the local scope.
+    * @param msg  the error message.
+    * @param loc  the location of the class/struct name.
+    */
+  case class UndefinedNewJvmClassOrStruct(name: Name.Ident, ap: AnchorPosition, env: LocalScope, msg: String, loc: SourceLocation) extends ResolutionError {
+    def summary: String = s"Undefined New: '$name'."
+
+    def message(formatter: Formatter): String = messageWithLink {
+      import formatter.*
+      s""">> Undefined New '${red(name.name)}'.
+         |
+         |${code(loc, "undefined new.")}
+         |
+         |$msg
+         |""".stripMargin
+    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -680,21 +680,21 @@ object ResolutionError {
   }
 
   /**
-    * An error raised to indicate that the class name was not found.
+    * An error raised to indicate that the class name in an importing was not found.
     *
     * @param name the class name.
     * @param ap   the anchor position.
     * @param msg  the Java error message.
     * @param loc  the location of the class name.
     */
-  case class UndefinedJvmClass(name: String, ap: AnchorPosition, msg: String, loc: SourceLocation) extends ResolutionError {
-    def summary: String = s"Undefined Java class: '$name'."
+  case class UndefinedJvmImport(name: String, ap: AnchorPosition, msg: String, loc: SourceLocation) extends ResolutionError {
+    def summary: String = s"Undefined Java Import: '$name'."
 
     def message(formatter: Formatter): String = messageWithLink {
       import formatter.*
-      s""">> Undefined Java class '${red(name)}'.
+      s""">> Undefined Java Import '${red(name)}'.
          |
-         |${code(loc, "undefined class.")}
+         |${code(loc, "undefined Import.")}
          |
          |$msg
          |""".stripMargin
@@ -708,6 +708,50 @@ object ResolutionError {
         Some(s"Static nested classes should be specified using '$$', e.g. java.util.Locale$$Builder")
       else
         None
+    }
+  }
+
+  /**
+    * An error raised to indicate that a class name was not found.
+    * @param name  the class name.
+    * @param ap    the anchor position.
+    * @param msg   the Java error message.
+    * @param loc   the location of the class name.
+    */
+  case class UndefinedJvmClass(name: String, ap: AnchorPosition, msg: String, loc: SourceLocation) extends ResolutionError {
+    def summary: String = s"Undefined Java class: '$name'."
+
+    def message(formatter: Formatter): String = messageWithLink {
+      import formatter.*
+      s""">> Undefined Java class '${red(name)}'.
+         |
+         |${code(loc, "undefined class.")}
+         |
+         |$msg
+         |""".stripMargin
+    }
+  }
+
+  /**
+    * An error raised to indicate that class/struct name was not found in a new expression.
+    *
+    * @param name the class/struct name
+    * @param ap   the anchor position.
+    * @param env  the variables in the scope.
+    * @param msg  the error message.
+    * @param loc  the location of the class/struct name.
+    */
+  case class UndefinedNew(name: String, ap: AnchorPosition, env: LocalScope, msg: String, loc: SourceLocation) extends ResolutionError {
+    def summary: String = s"Undefined New: '$name'."
+
+    def message(formatter: Formatter): String = messageWithLink {
+      import formatter.*
+      s""">> Undefined New '${red(name)}'.
+         |
+         |${code(loc, "undefined new.")}
+         |
+         |$msg
+         |""".stripMargin
     }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1229,7 +1229,7 @@ object Resolver {
           case Some(List(Resolution.JavaClass(clazz))) =>
             Validation.Success(ResolvedAst.Expr.InstanceOf(e, clazz, loc))
           case _ =>
-            val error = ResolutionError.UndefinedJvmClass(className.name, AnchorPosition.mkImportOrUseAnchor(ns0), "", loc)
+            val error = ResolutionError.UndefinedJvmClass(className, AnchorPosition.mkImportOrUseAnchor(ns0), "", loc)
             sctx.errors.add(error)
             Validation.Success(ResolvedAst.Expr.Error(error))
         }
@@ -1317,7 +1317,7 @@ object Resolver {
             case Some(List(Resolution.JavaClass(clazz))) =>
               Validation.Success(ResolvedAst.Expr.InvokeConstructor(clazz, es, loc))
             case _ =>
-              val error = ResolutionError.UndefinedNew(className.name, AnchorPosition.mkImportOrUseAnchor(ns0), env0, "", loc)
+              val error = ResolutionError.UndefinedNewJvmClassOrStruct(className, AnchorPosition.mkImportOrUseAnchor(ns0), env0, "", loc)
               sctx.errors.add(error)
               Validation.Success(ResolvedAst.Expr.Error(error))
           }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1317,7 +1317,7 @@ object Resolver {
             case Some(List(Resolution.JavaClass(clazz))) =>
               Validation.Success(ResolvedAst.Expr.InvokeConstructor(clazz, es, loc))
             case _ =>
-              val error = ResolutionError.UndefinedJvmClass(className.name, AnchorPosition.mkImportOrUseAnchor(ns0), "", loc)
+              val error = ResolutionError.UndefinedNew(className.name, AnchorPosition.mkImportOrUseAnchor(ns0), env0, "", loc)
               sctx.errors.add(error)
               Validation.Success(ResolvedAst.Expr.Error(error))
           }
@@ -3267,8 +3267,8 @@ object Resolver {
     val initialize = false
     Result.Ok(Class.forName(className, initialize, flix.jarLoader))
   } catch {
-    case ex: ClassNotFoundException => Result.Err(ResolutionError.UndefinedJvmClass(className, AnchorPosition.mkImportOrUseAnchor(ns0), ex.getMessage, loc))
-    case ex: NoClassDefFoundError => Result.Err(ResolutionError.UndefinedJvmClass(className, AnchorPosition.mkImportOrUseAnchor(ns0), ex.getMessage, loc))
+    case ex: ClassNotFoundException => Result.Err(ResolutionError.UndefinedJvmImport(className, AnchorPosition.mkImportOrUseAnchor(ns0), ex.getMessage, loc))
+    case ex: NoClassDefFoundError => Result.Err(ResolutionError.UndefinedJvmImport(className, AnchorPosition.mkImportOrUseAnchor(ns0), ex.getMessage, loc))
   }
 
   /**

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -639,7 +639,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[TypeError.ConstructorNotFound](result)
   }
 
-  test("UndefinedJvmClass.01") {
+  test("UndefinedJvmImport.01") {
     val input =
       raw"""
            |import foo.bar.Baz
@@ -651,7 +651,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.UndefinedJvmImport](result)
   }
 
-  test("UndefinedJvmClass.02") {
+  test("UndefinedJvmImport.02") {
     val input =
       raw"""
            |import foo.bar.Baz
@@ -664,7 +664,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.UndefinedJvmImport](result)
   }
 
-  test("UndefinedJvmClass.03") {
+  test("UndefinedJvmImport.03") {
     val input =
       raw"""
            |import foo.bar.Baz

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -648,7 +648,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
            |    ()
        """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[ResolutionError.UndefinedJvmClass](result)
+    expectError[ResolutionError.UndefinedJvmImport](result)
   }
 
   test("UndefinedJvmClass.02") {
@@ -661,7 +661,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
            |    ()
        """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[ResolutionError.UndefinedJvmClass](result)
+    expectError[ResolutionError.UndefinedJvmImport](result)
   }
 
   test("UndefinedJvmClass.03") {
@@ -673,7 +673,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
            |    ()
        """.stripMargin
     val result = compile(input, Options.TestWithLibMin)
-    expectError[ResolutionError.UndefinedJvmClass](result)
+    expectError[ResolutionError.UndefinedJvmImport](result)
   }
 
   test("UndefinedJvmMethod.01") {


### PR DESCRIPTION
UndefinedJvmImport will be triggered in importing expression:
<img width="767" alt="image" src="https://github.com/user-attachments/assets/584bb8fc-d98d-4008-a360-2e119404d218" />

UndefinedJvmClass will be triggered in instanceof:
<img width="666" alt="image" src="https://github.com/user-attachments/assets/3316447e-2487-4d34-a804-ba4b71ea0f1d" />

UndefinedNew will be triggered in new expression:
<img width="683" alt="image" src="https://github.com/user-attachments/assets/8581084b-1f40-4193-b802-126d6a539e4f" />

The first error will be handled by ImportCompleter. It works fine.

The second error need a completion for all local java classes. To be Done.

The third error need a completion for either local java classes or structs. We can provide a snippet for the struct part.

Later we can introduce a completer for the local java class. Then a new completer for the struct snippet/or adapt the current StructCompleter for this case.

Note:
- the UndefinedNew is very unstable, it stops working when confronting
  - qualified name <img width="1043" alt="image" src="https://github.com/user-attachments/assets/3eb135b4-4625-4f68-a179-142e58168337" />
  - no trailing expression<img width="1091" alt="image" src="https://github.com/user-attachments/assets/7a4493b3-0c35-4c59-8e1f-f61d8018abdc" />
- we may also need a module completer after the parser works with the qualified name.
