### PR TITLE
fix: disallow qualified name in try-catch

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/DesugaredAst.scala
@@ -378,7 +378,7 @@ object DesugaredAst {
 
   case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], loc: SourceLocation)
 
-  case class CatchRule(ident: Name.Ident, className: String, exp: Expr)
+  case class CatchRule(ident: Name.Ident, className: Name.Ident, exp: Expr)
 
   case class HandlerRule(op: Name.Ident, fparams: List[FormalParam], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/NamedAst.scala
@@ -385,7 +385,7 @@ object NamedAst {
 
   case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], loc: SourceLocation)
 
-  case class CatchRule(sym: Symbol.VarSym, className: String, exp: Expr)
+  case class CatchRule(sym: Symbol.VarSym, className: Name.Ident, exp: Expr)
 
   case class HandlerRule(op: Name.Ident, fparams: List[FormalParam], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/WeededAst.scala
@@ -416,7 +416,7 @@ object WeededAst {
 
   case class JvmMethod(ident: Name.Ident, fparams: List[FormalParam], exp: Expr, tpe: Type, eff: Option[Type], loc: SourceLocation)
 
-  case class CatchRule(ident: Name.Ident, className: String, exp: Expr)
+  case class CatchRule(ident: Name.Ident, className: Name.Ident, exp: Expr)
 
   case class HandlerRule(op: Name.Ident, fparams: List[FormalParam], exp: Expr)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2529,7 +2529,7 @@ object Parser2 {
       expect(TokenKind.KeywordCase, SyntacticContext.Expr.OtherExpr)
       nameUnqualified(NAME_VARIABLE, SyntacticContext.Expr.OtherExpr)
       expect(TokenKind.Colon, SyntacticContext.Expr.OtherExpr)
-      nameUnqualified(NAME_JAVA, SyntacticContext.Expr.OtherExpr)
+      nameAllowQualified(NAME_JAVA, tail = Set(), context = SyntacticContext.Expr.OtherExpr)
       expect(TokenKind.ArrowThickR, SyntacticContext.Expr.OtherExpr)
       statement()
       close(mark, TreeKind.Expr.TryCatchRuleFragment)

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2529,7 +2529,7 @@ object Parser2 {
       expect(TokenKind.KeywordCase, SyntacticContext.Expr.OtherExpr)
       nameUnqualified(NAME_VARIABLE, SyntacticContext.Expr.OtherExpr)
       expect(TokenKind.Colon, SyntacticContext.Expr.OtherExpr)
-      nameAllowQualified(NAME_JAVA, tail = Set(), context = SyntacticContext.Expr.OtherExpr)
+      nameUnqualified(NAME_JAVA, SyntacticContext.Expr.OtherExpr)
       expect(TokenKind.ArrowThickR, SyntacticContext.Expr.OtherExpr)
       statement()
       close(mark, TreeKind.Expr.TryCatchRuleFragment)

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3272,10 +3272,10 @@ object Resolver {
   /**
     * Returns the class reflection object for the given `className`.
     */
-  private def lookupJvmClass2(className: String, ns0: Name.NName, env0: LocalScope, loc: SourceLocation)(implicit flix: Flix): Result[Class[?], ResolutionError] = {
-    lookupJvmClass(className, ns0, loc) match {
+  private def lookupJvmClass2(className: Name.Ident, ns0: Name.NName, env0: LocalScope, loc: SourceLocation)(implicit flix: Flix): Result[Class[?], ResolutionError] = {
+    lookupJvmClass(className.name, ns0, loc) match {
       case Result.Ok(clazz) => Result.Ok(clazz)
-      case Result.Err(e) => env0.get(className) match {
+      case Result.Err(e) => env0.get(className.name) match {
         case List(Resolution.JavaClass(clazz)) => Result.Ok(clazz)
         case _ => Result.Err(e)
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1784,23 +1784,11 @@ object Weeder2 {
       expect(tree, TreeKind.Expr.TryCatchRuleFragment)
       mapN(pickNameIdent(tree), pickQName(tree), pickExpr(tree)) {
         case (ident, qname, expr) if qname.isUnqualified => CatchRule(ident, qname.ident, expr)
-        case _ =>
-          val error = IllegalQualifiedName(tree.loc)
+        case (_, qname, _) =>
+          val error = IllegalQualifiedName(qname.loc)
           sctx.errors.add(error)
           CatchRule(Name.Ident("error", tree.loc), Name.Ident("error", tree.loc), Expr.Error(error))
       }
-//      pickAll(TreeKind.Ident, tree).map(tokenToIdent) match {
-//        case ident :: className :: Nil =>
-//          println("first case")
-//          mapN(pickExpr(tree)){
-//            expr => CatchRule(ident, className, expr)
-//          }
-//        case _ =>
-//          println("second case")
-//          val error = Malformed(NamedTokenSet.CatchRule, SyntacticContext.Expr.OtherExpr, loc = tree.loc)
-//          sctx.errors.add(error)
-//          Validation.Success(CatchRule(Name.Ident("error", tree.loc), Name.Ident("error", tree.loc), Expr.Error(error)))
-//      }
     }
 
     private def visitTryWithBody(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1784,10 +1784,10 @@ object Weeder2 {
       expect(tree, TreeKind.Expr.TryCatchRuleFragment)
       mapN(pickNameIdent(tree), pickQName(tree), pickExpr(tree)) {
         case (ident, qname, expr) if qname.isUnqualified => CatchRule(ident, qname.ident, expr)
-        case (_, qname, _) =>
+        case (ident, qname, expr) =>
           val error = IllegalQualifiedName(qname.loc)
           sctx.errors.add(error)
-          CatchRule(Name.Ident("error", tree.loc), Name.Ident("error", tree.loc), Expr.Error(error))
+          CatchRule(ident, qname.ident, expr)
       }
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1782,9 +1782,11 @@ object Weeder2 {
 
     private def visitTryCatchRule(tree: Tree)(implicit sctx: SharedContext): Validation[CatchRule, CompilationMessage] = {
       expect(tree, TreeKind.Expr.TryCatchRuleFragment)
-      mapN(pickNameIdent(tree), pickQName(tree), pickExpr(tree)) {
-        (ident, qname, expr) => CatchRule(ident, javaQnameToFqn(qname), expr)
+      val idents = pickAll(TreeKind.Ident, tree).map(tokenToIdent)
+      mapN(pickExpr(tree)){
+        expr => CatchRule(idents.head, idents.last, expr)
       }
+
     }
 
     private def visitTryWithBody(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1782,11 +1782,25 @@ object Weeder2 {
 
     private def visitTryCatchRule(tree: Tree)(implicit sctx: SharedContext): Validation[CatchRule, CompilationMessage] = {
       expect(tree, TreeKind.Expr.TryCatchRuleFragment)
-      val idents = pickAll(TreeKind.Ident, tree).map(tokenToIdent)
-      mapN(pickExpr(tree)){
-        expr => CatchRule(idents.head, idents.last, expr)
+      mapN(pickNameIdent(tree), pickQName(tree), pickExpr(tree)) {
+        case (ident, qname, expr) if qname.isUnqualified => CatchRule(ident, qname.ident, expr)
+        case _ =>
+          val error = IllegalQualifiedName(tree.loc)
+          sctx.errors.add(error)
+          CatchRule(Name.Ident("error", tree.loc), Name.Ident("error", tree.loc), Expr.Error(error))
       }
-
+//      pickAll(TreeKind.Ident, tree).map(tokenToIdent) match {
+//        case ident :: className :: Nil =>
+//          println("first case")
+//          mapN(pickExpr(tree)){
+//            expr => CatchRule(ident, className, expr)
+//          }
+//        case _ =>
+//          println("second case")
+//          val error = Malformed(NamedTokenSet.CatchRule, SyntacticContext.Expr.OtherExpr, loc = tree.loc)
+//          sctx.errors.add(error)
+//          Validation.Success(CatchRule(Name.Ident("error", tree.loc), Name.Ident("error", tree.loc), Expr.Error(error)))
+//      }
     }
 
     private def visitTryWithBody(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {


### PR DESCRIPTION
fixes #9685

Now the parser will not accept qualified name in try catch:
<img width="702" alt="image" src="https://github.com/user-attachments/assets/9384120b-32c7-4d4d-84fc-d684875dd647" />

But the error message is helpless, how could we improve this?