### PR TITLE
fix: add annotation to runWithStratification

### DIFF
--- a/main/src/library/Fixpoint/Solver.flix
+++ b/main/src/library/Fixpoint/Solver.flix
@@ -48,11 +48,12 @@ mod Fixpoint.Solver {
     @Internal
     def runWithStratification(d0: Datalog[v], stf: Map[PredSym, Int32]): Datalog[v] with Order[v] = {
         let d = Fixpoint.Debugging.notifyPreSolve(d0);
-        let compiler = cs ->
-            Fixpoint.Phase.Compiler.compile(cs, stf) |>
-            Fixpoint.Phase.Simplifier.simplifyStmt |>
-            Fixpoint.Phase.IndexSelection.queryStmt |>
-            Fixpoint.Phase.VarsToIndices.lowerStmt;
+        def compiler(cs: Datalog[v]) = {
+            Fixpoint.Phase.Compiler.compile(cs, stf)
+            |> Fixpoint.Phase.Simplifier.simplifyStmt
+            |> Fixpoint.Phase.IndexSelection.queryStmt
+            |> Fixpoint.Phase.VarsToIndices.lowerStmt
+        };
         let model = match d {
             case Datalog(_, _) => region rc {
                 compiler(d) |> Fixpoint.Interpreter.interpret(rc) |> toModel


### PR DESCRIPTION
This is an example of a limitation that results from the correctness of the new solver. We cannot infer the type of `compiler` because the constraints that would infer it cross region boundaries.