### PR TITLE
ci: remove flix-files from community build

### DIFF
--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -44,7 +44,6 @@ jobs:
           - "JonathanStarup/ListSet"
           - "flix/museum"
           - "jaschdoc/flix-parsers"
-          - "mlutze/flix-files"
           - "mlutze/flix-json"
           - "mlutze/flixball"
           - "stephentetley/charset-locale"


### PR DESCRIPTION
No longer maintained