### PR TITLE
feat: load main for the standalone lsp when initializing

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -265,8 +265,7 @@ object Main {
           }
 
         case PlainLsp =>
-          val lspServer = new LspServer(options)
-          lspServer.run()
+          LspServer.run(options)
           System.exit(0)
 
         case Command.VSCodeLsp(port) =>

--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -265,7 +265,8 @@ object Main {
           }
 
         case PlainLsp =>
-          LspServer.run(options)
+          val lspServer = new LspServer(options)
+          lspServer.run()
           System.exit(0)
 
         case Command.VSCodeLsp(port) =>

--- a/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
@@ -23,7 +23,7 @@ import ca.uwaterloo.flix.util.Formatter.NoFormatter
 import ca.uwaterloo.flix.util.{Options, StreamOps}
 import org.eclipse.lsp4j.*
 import org.eclipse.lsp4j.launch.LSPLauncher
-import org.eclipse.lsp4j.services.{LanguageServer, TextDocumentService, WorkspaceService}
+import org.eclipse.lsp4j.services.{LanguageClient, LanguageClientAware, LanguageServer, TextDocumentService, WorkspaceService}
 
 import java.nio.file.{Files, Paths}
 import java.util.concurrent.CompletableFuture
@@ -35,34 +35,53 @@ object LspServer {
     val out = System.out
     val server = new FlixLanguageServer(o)
     System.err.println(s"Starting Default LSP Server...")
-    LSPLauncher.createServerLauncher(server, in, out).startListening.get()
+    val launcher = LSPLauncher.createServerLauncher(server, in, out)
+    server.connect(launcher.getRemoteProxy)
+    launcher.startListening().get()
     System.err.println(s"LSP Server Terminated.")
   }
 
-  private class FlixLanguageServer(o: Options) extends LanguageServer {
+  private class FlixLanguageServer(o: Options) extends LanguageServer with LanguageClientAware {
+    /**
+      * The Flix instance (the same instance is used for incremental compilation).
+      */
+    val flix: Flix = new Flix().setFormatter(NoFormatter).setOptions(o)
 
-    private val flixTextDocumentService = new FlixTextDocumentService(o)
-    private val flixWorkspaceService = new FlixWorkspaceService
+    /**
+      * A map from source URIs to source code.
+      */
+    val sources: mutable.Map[String, String] = mutable.Map.empty
+
+    /**
+      * The current AST root. The root is null until the source code is compiled.
+      */
+    var root: Root = TypedAst.empty
+
+    var flixLanguageClient: LanguageClient = _
+
+    private var clientCapabilities: ClientCapabilities = _;
+
+    private val flixTextDocumentService = new FlixTextDocumentService(this)
+    private val flixWorkspaceService = new FlixWorkspaceService(this)
 
     override def initialize(initializeParams: InitializeParams): CompletableFuture[InitializeResult] = {
       System.err.println(s"initialize: $initializeParams")
 
-      val capabilities = new ServerCapabilities
-      capabilities.setHoverProvider(true)
-      if (initializeParams.getWorkspaceFolders == null || initializeParams.getWorkspaceFolders.isEmpty) {
-        System.err.println("No workspace folders.")
-        return CompletableFuture.failedFuture(new RuntimeException("No workspace folders"))
+      clientCapabilities = initializeParams.getCapabilities
+
+      val serverCapabilities = new ServerCapabilities
+      serverCapabilities.setHoverProvider(true)
+      serverCapabilities.setTextDocumentSync(TextDocumentSyncKind.Full)
+
+      try {
+        loadMain(initializeParams)
+      } catch {
+        case ex: Throwable =>
+          System.err.println(s"Failed to initialize the LSP: ${ex.getMessage}")
+          return CompletableFuture.failedFuture(ex)
       }
-      val mainPath = Paths.get(initializeParams.getWorkspaceFolders.get(0).getName, "Main.flix")
-      val mainUri = mainPath.toString
-      if (Files.exists(mainPath)) {
-        val mainSrc = StreamOps.readAll(Files.newInputStream(mainPath))
-        flixTextDocumentService.addSourceCode(mainUri, mainSrc)
-        CompletableFuture.completedFuture(new InitializeResult(capabilities))
-      } else {
-        System.err.println(s"Main file not found: $mainPath")
-        CompletableFuture.failedFuture(new RuntimeException("Main file not found"))
-      }
+
+      CompletableFuture.completedFuture(new InitializeResult(serverCapabilities))
     }
 
     override def shutdown(): CompletableFuture[AnyRef] = {
@@ -74,27 +93,38 @@ object LspServer {
       System.err.println("exit")
     }
 
+    override def connect(client: LanguageClient): Unit = {
+      System.err.println("connect to the client")
+      flixLanguageClient = client
+    }
+
     override def getTextDocumentService: TextDocumentService = flixTextDocumentService
 
     override def getWorkspaceService: WorkspaceService = flixWorkspaceService
+
+    private def loadMain(initializeParams: InitializeParams): Unit = {
+      if (initializeParams.getWorkspaceFolders == null || initializeParams.getWorkspaceFolders.isEmpty) {
+        System.err.println("No workspace folders.")
+        throw new RuntimeException("No workspace folders")
+      }
+      val mainPath = Paths.get(initializeParams.getWorkspaceFolders.get(0).getName, "Main.flix")
+      val mainUri = mainPath.toString
+      if (Files.exists(mainPath)) {
+        val mainSrc = StreamOps.readAll(Files.newInputStream(mainPath))
+        addSourceCode(mainUri, mainSrc)
+      } else {
+        System.err.println(s"Main file not found: $mainPath")
+        throw new RuntimeException("Main file not found")
+      }
+    }
+
+    private def addSourceCode(uri: String, src: String): Unit = {
+      flix.addSourceCode(uri, src)(SecurityContext.AllPermissions)
+      sources.put(uri, src)
+    }
   }
 
-  private class FlixTextDocumentService(o: Options) extends TextDocumentService {
-    /**
-      * The Flix instance (the same instance is used for incremental compilation).
-      */
-    private val flix: Flix = new Flix().setFormatter(NoFormatter).setOptions(o)
-
-    /**
-      * A map from source URIs to source code.
-      */
-    private val sources: mutable.Map[String, String] = mutable.Map.empty
-
-    /**
-      * The current AST root. The root is null until the source code is compiled.
-      */
-    private var root: Root = TypedAst.empty
-
+  private class FlixTextDocumentService(flixLanguageServer: FlixLanguageServer) extends TextDocumentService {
     override def didOpen(didOpenTextDocumentParams: DidOpenTextDocumentParams): Unit = {
       System.err.println(s"didOpen: $didOpenTextDocumentParams")
     }
@@ -117,14 +147,9 @@ object LspServer {
       val h = new Hover(new MarkupContent("plaintext", "Hello World from Hover!"))
       CompletableFuture.completedFuture(h)
     }
-
-    def addSourceCode(uri: String, src: String): Unit = {
-      flix.addSourceCode(uri, src)(SecurityContext.AllPermissions)
-      sources.put(uri, src)
-    }
   }
 
-  private class FlixWorkspaceService extends WorkspaceService {
+  private class FlixWorkspaceService(flixLanguageServer: FlixLanguageServer) extends WorkspaceService {
     override def didChangeConfiguration(didChangeConfigurationParams: DidChangeConfigurationParams): Unit = {
       System.err.println(s"didChangeConfiguration: $didChangeConfigurationParams")
     }

--- a/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
@@ -69,8 +69,8 @@ object LspServer {
       */
     private var clientCapabilities: ClientCapabilities = _
 
-    private val flixTextDocumentService = new FlixTextDocumentService(this)
-    private val flixWorkspaceService = new FlixWorkspaceService(this)
+    private val flixTextDocumentService = new FlixTextDocumentService(this, flixLanguageClient)
+    private val flixWorkspaceService = new FlixWorkspaceService(this, flixLanguageClient)
 
     /**
       * Initializes the language server.
@@ -118,7 +118,7 @@ object LspServer {
     }
   }
 
-  private class FlixTextDocumentService(flixLanguageServer: FlixLanguageServer) extends TextDocumentService {
+  private class FlixTextDocumentService(flixLanguageServer: FlixLanguageServer, flixLanguageClient: LanguageClient) extends TextDocumentService {
     /**
       * Called when a text document is opened.
       * If the document is a Flix source file, we add the source code to the Flix instance.
@@ -156,7 +156,7 @@ object LspServer {
     }
   }
 
-  private class FlixWorkspaceService(flixLanguageServer: FlixLanguageServer) extends WorkspaceService {
+  private class FlixWorkspaceService(flixLanguageServer: FlixLanguageServer, flixLanguageClient: LanguageClient) extends WorkspaceService {
     override def didChangeConfiguration(didChangeConfigurationParams: DidChangeConfigurationParams): Unit = {
       System.err.println(s"didChangeConfiguration: $didChangeConfigurationParams")
     }

--- a/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
@@ -15,6 +15,10 @@
  */
 package ca.uwaterloo.flix.api.lsp
 
+import ca.uwaterloo.flix.api.Flix
+import ca.uwaterloo.flix.language.ast.TypedAst
+import ca.uwaterloo.flix.language.ast.TypedAst.Root
+import ca.uwaterloo.flix.util.Formatter.NoFormatter
 import ca.uwaterloo.flix.util.Options
 import org.eclipse.lsp4j.*
 import org.eclipse.lsp4j.launch.LSPLauncher
@@ -22,9 +26,19 @@ import org.eclipse.lsp4j.services.{LanguageServer, TextDocumentService, Workspac
 
 import java.util.concurrent.CompletableFuture
 
-object LspServer {
+class LspServer(o: Options) {
 
-  def run(o: Options): Unit = {
+  /**
+    * The Flix instance (the same instance is used for incremental compilation).
+    */
+  private val flix: Flix = new Flix().setFormatter(NoFormatter).setOptions(o)
+
+  /**
+    * The current AST root. The root is null until the source code is compiled.
+    */
+  private var root: Root = TypedAst.empty
+
+  def run(): Unit = {
     val in = System.in
     val out = System.out
     val server = new FlixLanguageServer


### PR DESCRIPTION
Change the architect a little bit.

`didOpen` will try to add the opened file to the flix instance if it's a flix source file.