### PR TITLE
refactor: introduce OpCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -57,7 +57,9 @@ object CompletionProvider {
             LocalScopeCompleter.getCompletions(err) ++
             ExprCompleter.getCompletions(ctx) ++
             DefCompleter.getCompletions(err, namespace, ident) ++
-            EnumCompleter.getCompletions(err, namespace, ident)
+            EnumCompleter.getCompletions(err, namespace, ident) ++
+            EffectCompleter.getCompletions(err, namespace, ident) ++
+            OpCompleter.getCompletions(err, namespace, ident)
         case err: ResolutionError.UndefinedType =>
           val (namespace, ident) = getNamespaceAndIdentFromQName(err.qn)
           AutoImportCompleter.getCompletions(err) ++
@@ -71,6 +73,9 @@ object CompletionProvider {
         case err: ResolutionError.UndefinedJvmImport => ImportCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedStructField => StructFieldCompleter.getCompletions(err, root)
         case err: ResolutionError.UndefinedKind => KindCompleter.getCompletions(err)
+        case err: ResolutionError.UndefinedOp =>
+          val (namespace, ident) = getNamespaceAndIdentFromQName(err.qname)
+          OpCompleter.getCompletions(err, namespace, ident)
         case err: TypeError.FieldNotFound => MagicMatchCompleter.getCompletions(err) ++ InvokeMethodCompleter.getCompletions(err.tpe, err.fieldName)
         case err: TypeError.MethodNotFound => InvokeMethodCompleter.getCompletions(err.tpe, err.methodName)
         case err: ParseError => err.sctx match {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -79,6 +79,23 @@ object CompletionUtils {
   }
 
   /**
+    * Generate a snippet which represents calling a function.
+    * Drops the last one or two arguments in the event that the function is in a pipeline
+    * (i.e. is preceeded by `|>`, `!>`, or `||>`)
+    */
+  def getOpHandlerSnippet(name: String, fparams: List[TypedAst.FormalParam])(implicit context: CompletionContext): String = {
+    val functionIsUnit = isUnitFunction(fparams)
+
+    val args = fparams.zipWithIndex.map {
+      case (fparam, idx) => "$" + s"{${idx + 1}:?${fparam.bnd.sym.text}}"
+    } :+ s"$${${fparams.length + 1}:resume}"
+    if (functionIsUnit)
+      s"$name($${1:resume}) = "
+    else
+      s"$name(${args.mkString(", ")}) = "
+  }
+
+  /**
     * Helper function for deciding if a snippet can be generated.
     * Returns false if there are too few arguments.
     */

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -79,9 +79,7 @@ object CompletionUtils {
   }
 
   /**
-    * Generate a snippet which represents calling a function.
-    * Drops the last one or two arguments in the event that the function is in a pipeline
-    * (i.e. is preceeded by `|>`, `!>`, or `||>`)
+    * Generate a snippet which represents defining an effect operation handler, with an extra `resume` as the last argument.
     */
   def getOpHandlerSnippet(name: String, fparams: List[TypedAst.FormalParam])(implicit context: CompletionContext): String = {
     val functionIsUnit = isUnitFunction(fparams)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EffectCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EffectCompleter.scala
@@ -16,6 +16,10 @@ object EffectCompleter {
     getCompletions(err.qn.loc.source.name, err.ap, err.env, namespace, ident)
   }
 
+  def getCompletions(err: ResolutionError.UndefinedName, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    getCompletions(err.qn.loc.source.name, err.ap, err.env, namespace, ident)
+  }
+
   private def getCompletions(uri: String, ap: AnchorPosition, env: LocalScope, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
     if (namespace.nonEmpty)
       root.effects.values.collect{

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
@@ -28,8 +28,7 @@ object ExprCompleter {
       EnumTagCompleter.getCompletions(context) ++
       ExprSnippetCompleter.getCompletions() ++
       ModuleCompleter.getCompletions(context) ++
-      HoleCompletion.getHoleCompletion(context, root) ++
-      OpCompleter.getCompletions(context)
+      HoleCompletion.getHoleCompletion(context, root)
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
@@ -55,7 +55,6 @@ object LocalScopeCompleter {
       case Resolution.Declaration(Namespace(_, _, _, _)) |
            Resolution.Declaration(Sig(_, _, _, _)) |
            Resolution.Declaration(StructField(_, _, _, _)) |
-           Resolution.Declaration(Op(_, _, _)) |
            Resolution.Declaration(Case(_, _, _)) => Completion.LocalDeclarationCompletion(k)
     }
 

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -859,7 +859,7 @@ object ResolutionError {
     * @param qname the qualified name of the operation.
     * @param loc   the location where the error occurred.
     */
-  case class UndefinedOp(qname: Name.QName, loc: SourceLocation) extends ResolutionError {
+  case class UndefinedOp(qname: Name.QName, ap: AnchorPosition, env: LocalScope, loc: SourceLocation) extends ResolutionError {
     def summary: String = s"Undefined operation '${qname.toString}'."
 
     def message(formatter: Formatter): String = messageWithLink {


### PR DESCRIPTION
OpCompleter will work for two cases:
- UndefinedName:
  <img width="677" alt="image" src="https://github.com/user-attachments/assets/09573447-1a98-4a4e-a36b-93a6120ed3a0" />
  <img width="494" alt="image" src="https://github.com/user-attachments/assets/9ca03c26-603a-43a5-8934-4f9a99c7df0e" />
  <img width="672" alt="image" src="https://github.com/user-attachments/assets/a349bf4b-779c-4b90-ae54-16e7c12bb56c" />
  <img width="655" alt="image" src="https://github.com/user-attachments/assets/a28310fd-2d55-49da-9f6f-7498a91ed19a" />
  <img width="552" alt="image" src="https://github.com/user-attachments/assets/57cf8d20-5d86-4a7f-8897-94ae982d8274" />
- UndefinedOp
  <img width="714" alt="image" src="https://github.com/user-attachments/assets/26469eab-f585-4018-8697-f387cbb53a4d" />
  <img width="533" alt="image" src="https://github.com/user-attachments/assets/2fbd6a4e-894f-47bb-a1cb-d468320ac3cb" />
  Due to the syntax of effect handling, we will never auto use UndefinedOp, neither will we provide completions for qualified name.

Note:
- I add EffectCompleter to UndefinedName so that we can first complete `DivByZero` then its op.
- The completer will not work in this case:
  <img width="491" alt="image" src="https://github.com/user-attachments/assets/c5fba4ac-6819-49e9-8aa2-a830e753cdff" />
  And the reason is that the completer that should work here is OpCompleter, which should find this is a qualified name and check if there is a qualified op that matches. But it will only check for `A.DivByZero.divByZero` which doesn't match with `DivByZero.divBy`. The problem is that every time we meet a dot, we are not looking into that thing. But calling different completers to check if they have matched qualified name. Here `DivByZero` is in scope, but that is not what the qualified name part of OpCompleter will consider currently.
- The completer will not work in this case:
  <img width="763" alt="image" src="https://github.com/user-attachments/assets/df8224cf-1068-45b8-ac64-91706878187d" />
  As you can see, no resolution error is triggered in this case. We need to improve the parser to fix this.
  I will create a ticket to discuss this.
