### PR TITLE
feat: compile flix for stand alone lsp

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Diagnostic.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Diagnostic.scala
@@ -20,6 +20,9 @@ import ca.uwaterloo.flix.language.errors.CodeHint
 import ca.uwaterloo.flix.util.Formatter
 import org.json4s.JsonDSL.*
 import org.json4s.*
+import org.eclipse.lsp4j
+
+import scala.jdk.CollectionConverters.*
 
 /**
   * Companion object for [[Diagnostic]].
@@ -70,4 +73,15 @@ case class Diagnostic(range: Range, severity: Option[DiagnosticSeverity], code: 
       ("message" -> message) ~
       ("fullMessage" -> fullMessage) ~
       ("tags" -> tags.map(_.toInt))
+
+  def toLsp4j: lsp4j.Diagnostic = {
+    val diagnostic = new lsp4j.Diagnostic()
+    diagnostic.setRange(range.toLsp4j)
+    diagnostic.setSeverity(severity.map(_.toLsp4j).getOrElse(DiagnosticSeverity.Error.toLsp4j))
+    diagnostic.setCode(code.orNull)
+    diagnostic.setSource(source.orNull)
+    diagnostic.setMessage(message)
+    diagnostic.setTags(tags.map(_.toLsp4j).asJava)
+    diagnostic
+  }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/DiagnosticSeverity.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/DiagnosticSeverity.scala
@@ -16,6 +16,7 @@
 package ca.uwaterloo.flix.api.lsp
 
 import ca.uwaterloo.flix.language.errors.Severity
+import org.eclipse.lsp4j
 
 /**
   * Represents a `DiagnosticSeverity` in LSP.
@@ -26,6 +27,13 @@ sealed trait DiagnosticSeverity {
     case DiagnosticSeverity.Warning => 2
     case DiagnosticSeverity.Information => 3
     case DiagnosticSeverity.Hint => 4
+  }
+
+  def toLsp4j: lsp4j.DiagnosticSeverity = this match {
+    case DiagnosticSeverity.Error => lsp4j.DiagnosticSeverity.Error
+    case DiagnosticSeverity.Warning => lsp4j.DiagnosticSeverity.Warning
+    case DiagnosticSeverity.Information => lsp4j.DiagnosticSeverity.Information
+    case DiagnosticSeverity.Hint => lsp4j.DiagnosticSeverity.Hint
   }
 }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/DiagnosticTag.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/DiagnosticTag.scala
@@ -15,6 +15,8 @@
  */
 package ca.uwaterloo.flix.api.lsp
 
+import org.eclipse.lsp4j
+
 /**
   * Represents a `DiagnosticTag` in LSP.
   */
@@ -22,6 +24,11 @@ sealed trait DiagnosticTag {
   def toInt: Int = this match {
     case DiagnosticTag.Unnecessary => 1
     case DiagnosticTag.Deprecated => 2
+  }
+
+  def toLsp4j: lsp4j.DiagnosticTag = this match {
+    case DiagnosticTag.Unnecessary => lsp4j.DiagnosticTag.Unnecessary
+    case DiagnosticTag.Deprecated => lsp4j.DiagnosticTag.Deprecated
   }
 }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/Position.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Position.scala
@@ -21,6 +21,8 @@ import ca.uwaterloo.flix.util.Result.{Err, Ok}
 import org.json4s.JsonDSL.*
 import org.json4s.*
 
+import org.eclipse.lsp4j
+
 /**
   * Companion object for [[Position]].
   */
@@ -67,6 +69,8 @@ object Position {
 case class Position(line: Int, character: Int) extends Ordered[Position] {
   // NB: LSP line and column numbers are zero-indexed, but Flix uses one-indexed numbers internally.
   def toJSON: JValue = ("line" -> (line - 1)) ~ ("character" -> (character - 1))
+
+  def toLsp4j: lsp4j.Position = new lsp4j.Position(line - 1, character - 1)
 
   def compare(that: Position): Int = {
     val lineComparison = this.line.compare(that.line)

--- a/main/src/ca/uwaterloo/flix/api/lsp/PublishDiagnosticsParams.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/PublishDiagnosticsParams.scala
@@ -20,6 +20,9 @@ import ca.uwaterloo.flix.language.errors.CodeHint
 import ca.uwaterloo.flix.util.Formatter
 import org.json4s.JsonDSL.*
 import org.json4s.*
+import org.eclipse.lsp4j
+
+import scala.jdk.CollectionConverters.*
 
 /**
   * Companion object of [[PublishDiagnosticsParams]].
@@ -62,4 +65,11 @@ object PublishDiagnosticsParams {
   */
 case class PublishDiagnosticsParams(uri: String, diagnostics: List[Diagnostic]) {
   def toJSON: JValue = ("uri" -> uri) ~ ("diagnostics" -> diagnostics.map(_.toJSON))
+
+  def toLsp4j: lsp4j.PublishDiagnosticsParams = {
+    val params = new lsp4j.PublishDiagnosticsParams()
+    params.setUri(uri)
+    params.setDiagnostics(diagnostics.map(_.toLsp4j).asJava)
+    params
+  }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/Range.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Range.scala
@@ -17,10 +17,10 @@ package ca.uwaterloo.flix.api.lsp
 
 import ca.uwaterloo.flix.language.ast.SourceLocation
 import ca.uwaterloo.flix.util.Result
-import ca.uwaterloo.flix.util.Result.{Err, Ok}
 
 import org.json4s.JsonDSL.*
 import org.json4s.*
+import org.eclipse.lsp4j
 
 /**
   * Companion object of [[Range]].
@@ -57,6 +57,8 @@ object Range {
   */
 case class Range(start: Position, end: Position) {
   def toJSON: JValue = ("start" -> start.toJSON) ~ ("end" -> end.toJSON)
+
+  def toLsp4j: lsp4j.Range = new lsp4j.Range(start.toLsp4j, end.toLsp4j)
 
   /**
     * Returns the range that starts earlier.


### PR DESCRIPTION
Now the standlone lsp will compile flix on open and on change. And diagnostics are properly returned. I also handle the crash situation but I have no immediate example to make it crash.
<img width="660" alt="image" src="https://github.com/user-attachments/assets/ca680425-705d-4360-b465-ed32c3d3472d" />
