### PR TITLE
chore: update vulnerable dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.17.0'
     implementation("com.lihaoyi:sourcecode_2.13:0.4.2")
 
-    implementation('io.get-coursier:coursier_2.13:2.1.14')
+    implementation('io.get-coursier:coursier_2.13:2.1.24')
 
     // Note: The tomlj library determines the antlr library.
     // We cannot upgrade the antlr library independently.


### PR DESCRIPTION
intelliJ warned my about coursier `2.1.14` so just bumping to latest release