### PR TITLE
refactor: introduce sig completer

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -59,7 +59,8 @@ object CompletionProvider {
             DefCompleter.getCompletions(err, namespace, ident) ++
             EnumCompleter.getCompletions(err, namespace, ident) ++
             EffectCompleter.getCompletions(err, namespace, ident) ++
-            OpCompleter.getCompletions(err, namespace, ident)
+            OpCompleter.getCompletions(err, namespace, ident) ++
+            SignatureCompleter.getCompletions(err, namespace, ident)
         case err: ResolutionError.UndefinedType =>
           val (namespace, ident) = getNamespaceAndIdentFromQName(err.qn)
           AutoImportCompleter.getCompletions(err) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -785,10 +785,10 @@ object Completion {
   /**
     * Represents a Signature completion
     *
-    * @param sig  the signature.
+    * @param sig        the signature.
     * @param ap         the anchor position for the use statement.
     * @param qualified  indicate whether to use a qualified label.
-    * @param inScope    indicate whether to the type alias is inScope.
+    * @param inScope    indicate whether to the signature is inScope.
     */
   case class SigCompletion(sig: TypedAst.Sig, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -359,22 +359,26 @@ sealed trait Completion {
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.SigCompletion(decl) =>
-      val name = decl.sym.toString
-      val snippet = CompletionUtils.getApplySnippet(name, decl.spec.fparams)(context)
-      val labelDetails = CompletionItemLabelDetails(
-        Some(CompletionUtils.getLabelForSpec(decl.spec)(flix)),
-        None)
+    case Completion.SigCompletion(sig, ap, qualified, inScope) =>
+      val qualifiedName = sig.sym.toString
+      val name = if (qualified) qualifiedName else sig.sym.name
+      val snippet = CompletionUtils.getApplySnippet(name, sig.spec.fparams)(context)
+      val description = if(!qualified) {
+        Some(if (inScope) qualifiedName else s"use $qualifiedName")
+      } else None
+      val labelDetails = CompletionItemLabelDetails(None, description)
+      val additionalTextEdit = if (inScope) Nil else List(Completion.mkTextEdit(ap, s"use $qualifiedName"))
+      val priority: Priority = if (inScope) Priority.High else Priority.Lower
       CompletionItem(
-        label            = name,
-        labelDetails     = Some(labelDetails),
-        sortText         = Priority.toSortText(Priority.Lower, name),
-        filterText       = Some(CompletionUtils.getFilterTextForName(name)),
-        textEdit         = TextEdit(context.range, snippet),
-        detail           = Some(FormatScheme.formatScheme(decl.spec.declaredScheme)(flix)),
-        documentation    = Some(decl.spec.doc.text),
-        insertTextFormat = InsertTextFormat.Snippet,
-        kind             = CompletionItemKind.Interface
+        label               = name,
+        labelDetails        = Some(labelDetails),
+        sortText            = Priority.toSortText(priority, name),
+        textEdit            = TextEdit(context.range, snippet),
+        detail              = Some(FormatScheme.formatScheme(sig.spec.declaredScheme)(flix)),
+        documentation       = Some(sig.spec.doc.text),
+        insertTextFormat    = InsertTextFormat.Snippet,
+        kind                = CompletionItemKind.Function,
+        additionalTextEdits = additionalTextEdit
       )
 
     case Completion.InstanceCompletion(trt, completion) =>
@@ -781,9 +785,12 @@ object Completion {
   /**
     * Represents a Signature completion
     *
-    * @param decl the signature decl.
+    * @param sig  the signature.
+    * @param ap         the anchor position for the use statement.
+    * @param qualified  indicate whether to use a qualified label.
+    * @param inScope    indicate whether to the type alias is inScope.
     */
-  case class SigCompletion(decl: TypedAst.Sig) extends Completion
+  case class SigCompletion(sig: TypedAst.Sig, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
 
   /**
     * Represents an Instance completion (based on traits)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
@@ -24,7 +24,6 @@ object ExprCompleter {
   def getCompletions(context: CompletionContext)(implicit flix: Flix, root: TypedAst.Root): Iterable[Completion] = {
       LabelCompleter.getCompletions(context) ++
       KeywordCompleter.getExprKeywords ++
-      SignatureCompleter.getCompletions(context) ++
       EnumTagCompleter.getCompletions(context) ++
       ExprSnippetCompleter.getCompletions() ++
       ModuleCompleter.getCompletions(context) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
@@ -53,7 +53,6 @@ object LocalScopeCompleter {
   private def mkDeclarationCompletionForExpr(k: String, v: List[Resolution]): Iterable[Completion] =
     v.collect {
       case Resolution.Declaration(Namespace(_, _, _, _)) |
-           Resolution.Declaration(Sig(_, _, _, _)) |
            Resolution.Declaration(StructField(_, _, _, _)) |
            Resolution.Declaration(Case(_, _, _)) => Completion.LocalDeclarationCompletion(k)
     }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/SignatureCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/SignatureCompleter.scala
@@ -54,7 +54,7 @@ object SignatureCompleter {
   }
 
   /**
-    * Returns `true` if the given trait signature `sig` should be included in the suggestions.
+    * Returns `true` if the given signature `sig` should be included in the suggestions.
     */
   private def matchesSig(sig: TypedAst.Sig, namespace: List[String], ident: String, uri: String, qualified: Boolean): Boolean = {
     val isPublic = sig.spec.mod.isPublic && !sig.spec.ann.isInternal

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/SignatureCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/SignatureCompleter.scala
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Paul Butcher, Lukas Rønn
+ * Copyright 2025 Chenhao Gao
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,37 +17,52 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.SigCompletion
+import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Sig
 import ca.uwaterloo.flix.language.ast.TypedAst
+import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
+import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object SignatureCompleter {
   /**
-    * Returns a List of Completion for completer.
+    * Returns a List of Completion for Sig for UndefinedName.
     */
-  def getCompletions(context: CompletionContext)(implicit root: TypedAst.Root): Iterable[SigCompletion] = {
-    val word = context.word
-    val uri = context.uri
+  def getCompletions(err: ResolutionError.UndefinedName, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    getCompletions(err.loc.source.name, err.ap, err.env, namespace, ident)
+  }
 
-    root.sigs.values.filter(matchesSig(_, word, uri))
-      .flatMap(decl =>
-        if (CompletionUtils.canApplySnippet(decl.spec.fparams)(context))
-          Some(Completion.SigCompletion(decl))
-        else
-          None
-      )
+  private def getCompletions(uri: String, ap: AnchorPosition, env: LocalScope, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    if (namespace.nonEmpty)
+      root.sigs.values.collect{
+        case sig if matchesSig(sig, namespace, ident, uri, qualified = true) =>
+          SigCompletion(sig, ap, qualified = true, inScope = true)
+      }
+    else
+      root.sigs.values.collect{
+        case sig if matchesSig(sig, namespace, ident, uri, qualified = false) =>
+          SigCompletion(sig, ap, qualified = false, inScope = inScope(sig, env))
+      }
+  }
+
+  private def inScope(sig: TypedAst.Sig, scope: LocalScope): Boolean = {
+    val thisName = sig.sym.toString
+    val isResolved = scope.m.values.exists(_.exists {
+      case Resolution.Declaration(Sig(thatName, _, _, _)) => thisName == thatName.toString
+      case _ => false
+    })
+    val isRoot = sig.sym.namespace.isEmpty
+    isRoot || isResolved
   }
 
   /**
-    * Returns `true` if the given signature `sign` should be included in the suggestions.
+    * Returns `true` if the given trait signature `sig` should be included in the suggestions.
     */
-  private def matchesSig(sign: TypedAst.Sig, word: String, uri: String): Boolean = {
-    val isPublic = sign.spec.mod.isPublic
-    val isNamespace = word.nonEmpty && word.head.isUpper
-    val isMatch = if (isNamespace)
-      sign.sym.toString.startsWith(word)
+  private def matchesSig(sig: TypedAst.Sig, namespace: List[String], ident: String, uri: String, qualified: Boolean): Boolean = {
+    val isPublic = sig.spec.mod.isPublic && !sig.spec.ann.isInternal
+    val isInFile = sig.sym.loc.source.name == uri
+    val isMatch = if (qualified)
+      CompletionUtils.matchesQualifiedName(sig.sym.namespace, sig.sym.name, namespace, ident)
     else
-      sign.sym.name.startsWith(word)
-    val isInFile = sign.sym.loc.source.name == uri
-
+      CompletionUtils.fuzzyMatch(ident, sig.sym.name)
     isMatch && (isPublic || isInFile)
   }
 }


### PR DESCRIPTION
Preview:
<img width="726" alt="image" src="https://github.com/user-attachments/assets/f44c1ab7-0151-4c17-b52c-6e791c1ba292" />
<img width="617" alt="image" src="https://github.com/user-attachments/assets/366eebee-3551-49ce-99fa-3d726798c57e" />
<img width="650" alt="image" src="https://github.com/user-attachments/assets/42f889c1-7173-40cc-9f87-4497db1e6810" />
<img width="607" alt="image" src="https://github.com/user-attachments/assets/a17eb9f1-1a10-4276-b4b7-62d8d665acbf" />
<img width="680" alt="image" src="https://github.com/user-attachments/assets/733542af-85ee-4ec2-a533-b7dbef53c590" />

Note:
- Since there is no traitCompleter(#9675 is blocked), we do not provide completions for `A.Tr`.
- `Trait.si` still doesn't work, the same as what we mentioned in OpCompleter. I think we need to figure out a way to process that case together efficiently.


