### PR TITLE
refactor: introduce tag completer

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -54,8 +54,8 @@ object CodeActionProvider {
     case ResolutionError.UndefinedTrait(qn, ap,  _, loc) if overlaps(range, loc) =>
       mkUseTrait(qn.ident, uri, ap)
 
-    case ResolutionError.UndefinedTag(name, ap, _, loc) if overlaps(range, loc) =>
-      mkUseTag(name, uri, ap) ++ mkQualifyTag(name, uri, loc)
+    case ResolutionError.UndefinedTag(name, ap, _, _, loc) if overlaps(range, loc) =>
+      mkUseTag(name.ident.name, uri, ap) ++ mkQualifyTag(name.ident.name, uri, loc)
 
     case ResolutionError.UndefinedType(qn, _, ap, _, loc) if overlaps(range, loc) =>
       mkUseType(qn.ident, uri, ap) ++ mkImportJava(qn, uri, ap) ++ mkNewEnum(qn.ident.name, uri, ap) ++ mkNewStruct(qn.ident.name, uri, ap)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -100,7 +100,6 @@ object CompletionProvider {
 
           // Patterns.
           case _: SyntacticContext.Pat => ModuleCompleter.getCompletions(ctx)
-//            ++ EnumTagCompleter.getCompletions(ctx)
 
           // Uses.
           case SyntacticContext.Use => UseCompleter.getCompletions(ctx)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -50,7 +50,9 @@ object CompletionProvider {
         case WeederError.UnqualifiedUse(_) => UseCompleter.getCompletions(ctx)
         case WeederError.UndefinedAnnotation(_, _) => KeywordCompleter.getModKeywords ++ ExprSnippetCompleter.getCompletions()
         case ResolutionError.UndefinedUse(_, _, _, _) => UseCompleter.getCompletions(ctx)
-        case ResolutionError.UndefinedTag(_, _, _, _) => ModuleCompleter.getCompletions(ctx) ++ EnumTagCompleter.getCompletions(ctx)
+        case err: ResolutionError.UndefinedTag =>
+          val (namespace, ident) = getNamespaceAndIdentFromQName(err.qn)
+          ModuleCompleter.getCompletions(ctx) ++ EnumTagCompleter.getCompletions(err, namespace, ident)
         case err: ResolutionError.UndefinedName =>
           val (namespace, ident) = getNamespaceAndIdentFromQName(err.qn)
           AutoImportCompleter.getCompletions(err) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -52,7 +52,7 @@ object CompletionProvider {
         case ResolutionError.UndefinedUse(_, _, _, _) => UseCompleter.getCompletions(ctx)
         case err: ResolutionError.UndefinedTag =>
           val (namespace, ident) = getNamespaceAndIdentFromQName(err.qn)
-          ModuleCompleter.getCompletions(ctx) ++ EnumTagCompleter.getCompletions(err, namespace, ident)
+          EnumCompleter.getCompletions(err, namespace, ident) ++ EnumTagCompleter.getCompletions(err, namespace, ident)
         case err: ResolutionError.UndefinedName =>
           val (namespace, ident) = getNamespaceAndIdentFromQName(err.qn)
           AutoImportCompleter.getCompletions(err) ++
@@ -62,7 +62,8 @@ object CompletionProvider {
             EnumCompleter.getCompletions(err, namespace, ident) ++
             EffectCompleter.getCompletions(err, namespace, ident) ++
             OpCompleter.getCompletions(err, namespace, ident) ++
-            SignatureCompleter.getCompletions(err, namespace, ident)
+            SignatureCompleter.getCompletions(err, namespace, ident) ++
+            EnumTagCompleter.getCompletions(err, namespace, ident)
         case err: ResolutionError.UndefinedType =>
           val (namespace, ident) = getNamespaceAndIdentFromQName(err.qn)
           AutoImportCompleter.getCompletions(err) ++
@@ -98,7 +99,8 @@ object CompletionProvider {
           case SyntacticContext.Type.OtherType => TypeCompleter.getCompletions(ctx)
 
           // Patterns.
-          case _: SyntacticContext.Pat => ModuleCompleter.getCompletions(ctx) ++ EnumTagCompleter.getCompletions(ctx)
+          case _: SyntacticContext.Pat => ModuleCompleter.getCompletions(ctx)
+//            ++ EnumTagCompleter.getCompletions(ctx)
 
           // Uses.
           case SyntacticContext.Use => UseCompleter.getCompletions(ctx)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumCompleter.scala
@@ -32,6 +32,10 @@ object EnumCompleter {
     getCompletions(err.qn.loc.source.name, err.ap, err.env, namespace, ident)
   }
 
+  def getCompletions(err: ResolutionError.UndefinedTag, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    getCompletions(err.qn.loc.source.name, err.ap, err.env, namespace, ident)
+  }
+
   def getCompletions(err: ResolutionError.UndefinedType, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
     getCompletions(err.qn.loc.source.name, err.ap, err.env, namespace, ident)
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagCompleter.scala
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Lukas Rønn
+ * Copyright 2025 Chenhao Gao
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,95 +17,48 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.EnumTagCompletion
-import ca.uwaterloo.flix.language.ast.Symbol.{CaseSym, EnumSym}
-import ca.uwaterloo.flix.language.ast.{SourceLocation, Type, TypeConstructor, TypedAst}
+import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Case
+import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
+import ca.uwaterloo.flix.language.ast.TypedAst
+import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object EnumTagCompleter {
-
   /**
-    * Returns a List of Completion for enum tags.
+    * Returns a List of Completion for Tag for UndefinedName.
     */
-  def getCompletions(context: CompletionContext)(implicit root: TypedAst.Root): Iterable[EnumTagCompletion] = {
-    // We don't know if the user has provided a tag, so we have to try both cases
-    val fqn = context.word.split('.').toList
+  def getCompletions(err: ResolutionError.UndefinedName, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    getCompletions(err.loc.source.name, err.ap, err.env, namespace, ident)
+  }
 
-    getEnumTagCompletionsWithoutTag(fqn) ++
-      getEnumTagCompletionsWithTag(fqn)
+  private def getCompletions(uri: String, ap: AnchorPosition, env: LocalScope, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    if (namespace.nonEmpty)
+      root.enums.values.flatMap(_.cases.values).collect{
+        case tag if matchesTag(tag, namespace, ident, uri, qualified = true) =>
+          EnumTagCompletion(tag, ap, qualified = true, inScope = true)
+      }
+    else
+      root.enums.values.flatMap(_.cases.values).collect{
+        case tag if matchesTag(tag, namespace, ident, uri, qualified = false) =>
+          EnumTagCompletion(tag, ap, qualified = false, inScope = inScope(tag, env))
+      }
+  }
+
+  private def inScope(tag: TypedAst.Case, scope: LocalScope): Boolean = {
+    val thisName = tag.sym.toString
+    val isResolved = scope.m.values.exists(_.exists {
+      case Resolution.Declaration(Case(thatName, _, _)) => thisName == thatName.toString
+      case _ => false
+    })
+    val isRoot = tag.sym.namespace.isEmpty
+    isRoot || isResolved
   }
 
   /**
-    * Gets completions for enum tags without tag provided
+    * Returns `true` if the given signature `sig` should be included in the suggestions.
     */
-  private def getEnumTagCompletionsWithoutTag(fqn: List[String])(implicit root: TypedAst.Root): Iterable[EnumTagCompletion] = {
-    val enumSym = mkEnumSym(fqn)
-    root.enums.get(enumSym) match {
-      case None => // Case 1: Enum does not exist.
-        Nil
-      case Some(enm) => // Case 2: Enum does exist -> Get cases.
-        enm.cases.map {
-          case (_, cas) => EnumTagCompletion(enumSym, cas)
-        }
-    }
-  }
-
-  /**
-    * Gets completions for enum tags with tag provided
-    */
-  private def getEnumTagCompletionsWithTag(fqn: List[String])(implicit root: TypedAst.Root): Iterable[EnumTagCompletion] = {
-    // The user has provided a tag
-    // We know that there is at least one dot, so we split the context.word and
-    // make a fqn from the everything but the the last (hence it could be the tag).
-    if (fqn.isEmpty) {
-      return Nil
-    }
-
-    val fqnWithTag = fqn.dropRight(1)
-    val tag = fqn.takeRight(1).mkString
-    val enumSym = mkEnumSym(fqnWithTag)
-
-    root.enums.get(enumSym) match {
-      case None => // Case 1: Enum does not exist.
-        Nil
-      case Some(enm) => // Case 2: Enum does exist
-        enm.cases.flatMap {
-          case (caseSym, cas) =>
-            if (matchesTag(caseSym, tag)) {
-              // Case 2.1: Tag provided and it matches the case
-              Some(EnumTagCompletion(enumSym, cas))
-            } else {
-              // Case 2.2: Tag provided doesn't match the case
-              None
-            }
-        }
-    }
-  }
-
-  /**
-    * Checks if the provided tag matches the case.
-    *
-    * @param caseSym the caseSym of the case from the enum.
-    * @param tag     the provided tag.
-    * @return        true, if the provided tag matches the case, false otherwise.
-    */
-  private def matchesTag(caseSym: CaseSym, tag: String): Boolean = caseSym.name.startsWith(tag)
-
-  /**
-    * Generates an enumSym with a correct nameSpace. This is different from the one in Symbol.scala.
-    *
-    * Symbol.mkEnumSym("A.B.C.Color") would make an enumSym with namespace=List("A"), and name = "B.C.Color"
-    *
-    * This function: mkEnumSym(List["A","B","C","Color"]) makes an enumSym with namespace=List("A","B","C") and name = "Color"
-    *
-    * @param fqn the fully qualified name as a List[String].
-    * @return    the enum symbol for the given fully qualified name.
-    */
-  private def mkEnumSym(fqn: List[String]): EnumSym = {
-    if (fqn.isEmpty) {
-      new EnumSym(Nil, "", SourceLocation.Unknown)
-    } else {
-      val ns = fqn.dropRight(1)
-      val name = fqn.takeRight(1).mkString
-      new EnumSym(ns, name, SourceLocation.Unknown)
-    }
-  }
+  private def matchesTag(tag: TypedAst.Case, namespace: List[String], ident: String, uri: String, qualified: Boolean): Boolean =
+    if (qualified)
+      CompletionUtils.matchesQualifiedName(tag.sym.namespace, tag.sym.name, namespace, ident)
+    else
+      CompletionUtils.fuzzyMatch(ident, tag.sym.name)
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagCompleter.scala
@@ -30,6 +30,13 @@ object EnumTagCompleter {
     getCompletions(err.loc.source.name, err.ap, err.env, namespace, ident)
   }
 
+  /**
+    * Returns a List of Completion for Tag for UndefinedTag.
+    */
+  def getCompletions(err: ResolutionError.UndefinedTag, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    getCompletions(err.loc.source.name, err.ap, err.env, namespace, ident)
+  }
+
   private def getCompletions(uri: String, ap: AnchorPosition, env: LocalScope, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
     if (namespace.nonEmpty)
       root.enums.values.flatMap(_.cases.values).collect{

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Magnus Madsen
+ * Copyright 2025 Chenhao Gao
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
@@ -25,7 +25,6 @@ object ExprCompleter {
   def getCompletions(context: CompletionContext)(implicit flix: Flix, root: TypedAst.Root): Iterable[Completion] = {
       LabelCompleter.getCompletions(context) ++
       KeywordCompleter.getExprKeywords ++
-      EnumTagCompleter.getCompletions(context) ++
       ExprSnippetCompleter.getCompletions() ++
       ModuleCompleter.getCompletions(context) ++
       HoleCompletion.getHoleCompletion(context, root)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
@@ -53,8 +53,7 @@ object LocalScopeCompleter {
   private def mkDeclarationCompletionForExpr(k: String, v: List[Resolution]): Iterable[Completion] =
     v.collect {
       case Resolution.Declaration(Namespace(_, _, _, _)) |
-           Resolution.Declaration(StructField(_, _, _, _)) |
-           Resolution.Declaration(Case(_, _, _)) => Completion.LocalDeclarationCompletion(k)
+           Resolution.Declaration(StructField(_, _, _, _)) => Completion.LocalDeclarationCompletion(k)
     }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -932,16 +932,16 @@ object ResolutionError {
   /**
     * Undefined Tag Error.
     *
-    * @param tag the tag.
+    * @param qn the tag.
     * @param ns  the current namespace.
     * @param loc the location where the error occurred.
     */
-  case class UndefinedTag(tag: String, ap: AnchorPosition, ns: Name.NName, loc: SourceLocation) extends ResolutionError {
-    def summary: String = s"Undefined tag: '$tag'."
+  case class UndefinedTag(qn: Name.QName, ap: AnchorPosition, env: LocalScope, ns: Name.NName, loc: SourceLocation) extends ResolutionError {
+    def summary: String = s"Undefined tag: '$qn'."
 
     def message(formatter: Formatter): String = messageWithLink {
       import formatter.*
-      s""">> Undefined tag '${red(tag)}'.
+      s""">> Undefined tag '${red(qn.toString)}'.
          |
          |${code(loc, "tag not found.")}
          |

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2236,7 +2236,7 @@ object Resolver {
 
     matches match {
       // Case 0: No matches. Error.
-      case Nil => Result.Err(ResolutionError.UndefinedTag(qname.ident.name, AnchorPosition.mkImportOrUseAnchor(ns0), ns0, qname.loc))
+      case Nil => Result.Err(ResolutionError.UndefinedTag(qname,AnchorPosition.mkImportOrUseAnchor(ns0), env, ns0, qname.loc))
       // Case 1: A match was found. Success. Note that multiple matches can be found, but they are prioritized by tryLookupName so this is fine.
       case caze :: _ => Result.Ok(caze)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -2236,7 +2236,7 @@ object Resolver {
 
     matches match {
       // Case 0: No matches. Error.
-      case Nil => Result.Err(ResolutionError.UndefinedTag(qname,AnchorPosition.mkImportOrUseAnchor(ns0), env, ns0, qname.loc))
+      case Nil => Result.Err(ResolutionError.UndefinedTag(qname, AnchorPosition.mkImportOrUseAnchor(ns0), env, ns0, qname.loc))
       // Case 1: A match was found. Success. Note that multiple matches can be found, but they are prioritized by tryLookupName so this is fine.
       case caze :: _ => Result.Ok(caze)
     }


### PR DESCRIPTION
Preview:
<img width="752" alt="image" src="https://github.com/user-attachments/assets/0e774ff1-155b-44c9-8aad-72ba3f32af76" />
<img width="438" alt="image" src="https://github.com/user-attachments/assets/9a6cf62c-c5c9-4353-9a0e-96339aca8471" />
<img width="707" alt="image" src="https://github.com/user-attachments/assets/b0ac96c3-0147-45d3-8448-4855c310c850" />
<img width="698" alt="image" src="https://github.com/user-attachments/assets/4349850f-f131-41a5-91cc-8bea4a9fff43" />
<img width="793" alt="image" src="https://github.com/user-attachments/assets/33721075-36a7-4470-94ab-1979c4bc5871" />
Also works for UndefinedTag
<img width="740" alt="image" src="https://github.com/user-attachments/assets/5bdc155d-55b9-49eb-9892-23e96c332b24" />
<img width="681" alt="image" src="https://github.com/user-attachments/assets/808f1866-def9-427f-9b4d-86b88308c902" />
<img width="758" alt="image" src="https://github.com/user-attachments/assets/03be43ae-adcf-4c58-8890-4b652d8fc9cb" />

The previous EnumTagCompleter is also used for `SyntacticContext.Pat`, I write a case to repeat this context, and we can see that `UndefinedTag` is also raised here, so it's safe to remove EnumTagCompleter from this `SyntacticContext.Pat` in this case. But I am not sure if there is another case of `SyntacticContext.Pat`.
<img width="898" alt="image" src="https://github.com/user-attachments/assets/656efd6d-2bce-4cd6-a2d7-81529d5b92e2" />

Note:
- I add EnumCompleter to UndefinedTag so that we can first complete "A.Clr" then "A.Clr.Green"
- Unlike other completers, we don't check if the tag is public since that syntax is not valid. But maybe we should check if the enum is public? The same issue may also apply to other internal constructs like sigs or ops.