### PR TITLE
feat: add partition and merge api to ChangeSet

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
@@ -80,6 +80,23 @@ sealed trait ChangeSet {
           (stale + (k -> v), fresh)
       }
   }
+
+
+  /**
+    * Updates the stale part of the map with the given function `f`.
+    */
+  def updateStaleValues[K <: Sourceable, V](newMap: Map[K, V], oldMap: Map[K, V], f: Map[K, V] => Map[K, V]): Map[K, V] = {
+    val (stale, fresh) = partition(newMap, oldMap)
+    fresh ++ stale
+  }
+
+  /**
+    * Updates the stale part of the list map with the given function `f`.
+    */
+  def updateStaleValueLists[K, V <: Sourceable](newMap: ListMap[K, V], oldMap: ListMap[K, V], f: ListMap[K, V] => ListMap[K, V]): ListMap[K, V] = {
+    val (stale, fresh) = partitionOnValues(newMap, oldMap)
+    fresh ++ f(stale)
+  }
 }
 
 object ChangeSet {


### PR DESCRIPTION
fixes #9693
Add two apis to first partition, then process the stale part and finally merge it.

If we want to improve the efficiency of merging for ListMap, we should update ListMap.++

An example usage for safety would look like:
```scala
    val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs, ParOps.parMapValues2[Symbol.DefnSym, Def, Def](visitDef))
    val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits, ParOps.parMapValues2[Symbol.TraitSym, Trait, Trait](visitTrait))
    val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, ParOps.parMapValueList2[Symbol.TraitSym, TypedAst.Instance, TypedAst.Instance](visitInstance))

    (root.copy(defs = defs, traits = traits, instances = instances), sctx.errors.asScala.toList)
```

I've done several things to make the code compile:
- annotate ParMapValues to avoid the type mismatch:
  ![image](https://github.com/user-attachments/assets/137d2eea-0c35-455d-8416-06588e98c4e3)
  I'm not sure if there is a way to get rid of that
- write parMapValues2 where `f` is the first argument so that we can make a partial function out of it.

What do you think of this api and usage? Any suggestions?
