### PR TITLE
refactor: introduce module completer

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -52,7 +52,9 @@ object CompletionProvider {
         case ResolutionError.UndefinedUse(_, _, _, _) => UseCompleter.getCompletions(ctx)
         case err: ResolutionError.UndefinedTag =>
           val (namespace, ident) = getNamespaceAndIdentFromQName(err.qn)
-          EnumCompleter.getCompletions(err, namespace, ident) ++ EnumTagCompleter.getCompletions(err, namespace, ident)
+          EnumCompleter.getCompletions(err, namespace, ident) ++
+            EnumTagCompleter.getCompletions(err, namespace, ident) ++
+            ModuleCompleter.getCompletions(err, namespace, ident)
         case err: ResolutionError.UndefinedName =>
           val (namespace, ident) = getNamespaceAndIdentFromQName(err.qn)
           AutoImportCompleter.getCompletions(err) ++
@@ -100,9 +102,6 @@ object CompletionProvider {
 
           // Types.
           case SyntacticContext.Type.OtherType => TypeCompleter.getCompletions(ctx)
-
-          // Patterns.
-//          case _: SyntacticContext.Pat => ModuleCompleter.getCompletions(ctx)
 
           // Uses.
           case SyntacticContext.Use => UseCompleter.getCompletions(ctx)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -63,7 +63,8 @@ object CompletionProvider {
             EffectCompleter.getCompletions(err, namespace, ident) ++
             OpCompleter.getCompletions(err, namespace, ident) ++
             SignatureCompleter.getCompletions(err, namespace, ident) ++
-            EnumTagCompleter.getCompletions(err, namespace, ident)
+            EnumTagCompleter.getCompletions(err, namespace, ident) ++
+            ModuleCompleter.getCompletions(err, namespace, ident)
         case err: ResolutionError.UndefinedType =>
           val (namespace, ident) = getNamespaceAndIdentFromQName(err.qn)
           AutoImportCompleter.getCompletions(err) ++
@@ -72,7 +73,8 @@ object CompletionProvider {
             EnumCompleter.getCompletions(err, namespace, ident) ++
             StructCompleter.getCompletions(err, namespace, ident) ++
             EffectCompleter.getCompletions(err, namespace, ident) ++
-            TypeAliasCompleter.getCompletions(err, namespace, ident)
+            TypeAliasCompleter.getCompletions(err, namespace, ident) ++
+            ModuleCompleter.getCompletions(err, namespace, ident)
         case err: ResolutionError.UndefinedJvmStaticField => GetStaticFieldCompleter.getCompletions(err) ++ InvokeStaticMethodCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedJvmImport => ImportCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedStructField => StructFieldCompleter.getCompletions(err, root)
@@ -100,7 +102,7 @@ object CompletionProvider {
           case SyntacticContext.Type.OtherType => TypeCompleter.getCompletions(ctx)
 
           // Patterns.
-          case _: SyntacticContext.Pat => ModuleCompleter.getCompletions(ctx)
+//          case _: SyntacticContext.Pat => ModuleCompleter.getCompletions(ctx)
 
           // Uses.
           case SyntacticContext.Use => UseCompleter.getCompletions(ctx)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ExprCompleter.scala
@@ -26,7 +26,6 @@ object ExprCompleter {
       LabelCompleter.getCompletions(context) ++
       KeywordCompleter.getExprKeywords ++
       ExprSnippetCompleter.getCompletions() ++
-      ModuleCompleter.getCompletions(context) ++
       HoleCompletion.getHoleCompletion(context, root)
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
@@ -52,8 +52,7 @@ object LocalScopeCompleter {
     */
   private def mkDeclarationCompletionForExpr(k: String, v: List[Resolution]): Iterable[Completion] =
     v.collect {
-      case Resolution.Declaration(Namespace(_, _, _, _)) |
-           Resolution.Declaration(StructField(_, _, _, _)) => Completion.LocalDeclarationCompletion(k)
+      case Resolution.Declaration(StructField(_, _, _, _)) => Completion.LocalDeclarationCompletion(k)
     }
 
   /**
@@ -61,8 +60,7 @@ object LocalScopeCompleter {
     */
   private def mkDeclarationCompletionForType(k: String, v: List[Resolution]): Iterable[Completion] =
     v.collect {
-      case Resolution.Declaration(Namespace(_, _, _, _)) |
-           Resolution.Declaration(AssocTypeSig(_, _, _, _, _, _, _)) |
+      case Resolution.Declaration(AssocTypeSig(_, _, _, _, _, _, _)) |
            Resolution.Declaration(AssocTypeDef(_, _, _, _, _, _)) => Completion.LocalDeclarationCompletion(k)
     }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ModuleCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ModuleCompleter.scala
@@ -15,14 +15,62 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.language.ast.TypedAst
-import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.ModCompletion
+import ca.uwaterloo.flix.language.ast.{Symbol, TypedAst}
+import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.{ModCompletion, ModuleCompletion}
+import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Namespace
+import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
+import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object ModuleCompleter {
+  /**
+    * Returns a List of Completion for modules.
+    * Whether the returned completions are qualified is based on whether the name in the error is qualified.
+    * When providing completions for unqualified enums that is not in scope, we will also automatically use the enum.
+    */
+  def getCompletions(err: ResolutionError.UndefinedType, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    getCompletions(err.ap, err.env, namespace, ident)
+  }
 
-  def getCompletions(ctx: CompletionContext)(implicit root: TypedAst.Root): Iterable[ModCompletion] = {
-    val nestedModules = CompletionUtils.getNestedModules(ctx.word)
-    nestedModules.map(mod => Completion.ModCompletion(mod))
+  def getCompletions(err: ResolutionError.UndefinedName, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    getCompletions(err.ap, err.env, namespace, ident)
+  }
+
+  private def getCompletions(ap: AnchorPosition, env: LocalScope, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    if (namespace.nonEmpty)
+      root.modules.keys.collect{
+        case module if module.ns.nonEmpty && matchesModule(module, namespace, ident, qualified = true) =>
+          ModuleCompletion(module, ap, qualified = true, inScope = true)
+      }
+    else
+      root.modules.keys.collect({
+        case module if module.ns.nonEmpty && matchesModule(module, namespace, ident, qualified = false) =>
+          ModuleCompletion(module, ap, qualified = false, inScope = inScope(module, env))
+      })
+  }
+
+  /**
+    * Checks if the definition is in scope.
+    * If we can find the definition in the scope or the definition is in the root namespace, it is in scope.
+    */
+  private def inScope(module: Symbol.ModuleSym, scope: LocalScope): Boolean = {
+    val thisName = module.toString
+    val isResolved = scope.m.values.exists(_.exists {
+      case Resolution.Declaration(Namespace(thatName, _, _, _)) => thisName == thatName.toString
+      case _ => false
+    })
+    val isRoot = module.ns.length <= 1
+    isRoot || isResolved
+  }
+
+  /**
+    * Checks if the definition matches the QName.
+    * Names should match and the definition should be available.
+    */
+  private def matchesModule(module: Symbol.ModuleSym, namespace: List[String], ident: String, qualified: Boolean): Boolean = {
+    if (qualified) {
+      CompletionUtils.matchesQualifiedName(module.ns.dropRight(1), module.ns.last, namespace, ident)
+    } else
+      CompletionUtils.fuzzyMatch(ident, module.ns.last)
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ModuleCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ModuleCompleter.scala
@@ -26,7 +26,7 @@ object ModuleCompleter {
   /**
     * Returns a List of Completion for modules.
     * Whether the returned completions are qualified is based on whether the name in the error is qualified.
-    * When providing completions for unqualified enums that is not in scope, we will also automatically use the enum.
+    * When providing completions for unqualified enums that is not in scope, we will also automatically use the module.
     */
   def getCompletions(err: ResolutionError.UndefinedType, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
     getCompletions(err.ap, err.env, namespace, ident)
@@ -50,10 +50,10 @@ object ModuleCompleter {
   }
 
   /**
-    * Checks if the definition is in scope.
-    * If we can find the definition in the scope or the definition is in the root namespace, it is in scope.
+    * Checks if the module is in scope.
+    * If we can find the module in the scope or the module is in the root namespace, it is in scope.
     *
-    * Note: the module.ns is required to be non-empty.
+    * Note: module.ns is required to be non-empty.
     */
   private def inScope(module: Symbol.ModuleSym, scope: LocalScope): Boolean = {
     val thisName = module.toString
@@ -66,10 +66,9 @@ object ModuleCompleter {
   }
 
   /**
-    * Checks if the definition matches the QName.
-    * Names should match and the definition should be available.
+    * Checks if the module name matches the QName.
     *
-    * Note: the module.ns is required to be non-empty.
+    * Note: module.ns is required to be non-empty.
     */
   private def matchesModule(module: Symbol.ModuleSym, namespace: List[String], ident: String, qualified: Boolean): Boolean = {
     if (qualified) {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ModuleCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ModuleCompleter.scala
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Lukas Rønn
+ * Copyright 2025 Chenhao Gao
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +17,7 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.language.ast.{Symbol, TypedAst}
-import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.{ModCompletion, ModuleCompletion}
+import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.ModuleCompletion
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Namespace
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
 import ca.uwaterloo.flix.language.errors.ResolutionError
@@ -51,6 +52,8 @@ object ModuleCompleter {
   /**
     * Checks if the definition is in scope.
     * If we can find the definition in the scope or the definition is in the root namespace, it is in scope.
+    *
+    * Note: the module.ns is required to be non-empty.
     */
   private def inScope(module: Symbol.ModuleSym, scope: LocalScope): Boolean = {
     val thisName = module.toString
@@ -65,6 +68,8 @@ object ModuleCompleter {
   /**
     * Checks if the definition matches the QName.
     * Names should match and the definition should be available.
+    *
+    * Note: the module.ns is required to be non-empty.
     */
   private def matchesModule(module: Symbol.ModuleSym, namespace: List[String], ident: String, qualified: Boolean): Boolean = {
     if (qualified) {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ModuleCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ModuleCompleter.scala
@@ -36,6 +36,10 @@ object ModuleCompleter {
     getCompletions(err.ap, err.env, namespace, ident)
   }
 
+  def getCompletions(err: ResolutionError.UndefinedTag, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    getCompletions(err.ap, err.env, namespace, ident)
+  }
+
   private def getCompletions(ap: AnchorPosition, env: LocalScope, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
     if (namespace.nonEmpty)
       root.modules.keys.collect{

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeCompleter.scala
@@ -23,7 +23,6 @@ object TypeCompleter {
     * Returns a List of Completion for types (enums, aliases and builtin).
     */
   def getCompletions(context: CompletionContext)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    ModuleCompleter.getCompletions(context) ++
       TypeBuiltinCompleter.getCompletions
   }
 


### PR DESCRIPTION
Preview:
<img width="702" alt="image" src="https://github.com/user-attachments/assets/a9602ca3-7a44-4311-8334-547f70ac71b1" />
<img width="454" alt="image" src="https://github.com/user-attachments/assets/9d3c2fd5-b50d-4f6d-8777-02d029d4b0c4" />
<img width="657" alt="image" src="https://github.com/user-attachments/assets/ed07a990-fd4b-4b44-85a6-dc5b60dbd253" />
<img width="740" alt="image" src="https://github.com/user-attachments/assets/3fb44501-481f-4702-90b7-af215d623f06" />

Note:
- we do not check visibility for modules, since they can not be annotated.
- I remove SyntacticContext.Pat and add ModuleCompleter to UndefinedTag to work for this case:
  <img width="465" alt="image" src="https://github.com/user-attachments/assets/e6c8f057-fdeb-41bb-a4bd-01bac017b91e" />
