### PR TITLE
refactor: use new changeset api for existing incremental compilation

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
@@ -85,7 +85,7 @@ sealed trait ChangeSet {
   /**
     * Updates the stale part of the map with the given function `f`.
     */
-  def updateStaleValues[K <: Sourceable, V](newMap: Map[K, V], oldMap: Map[K, V])(f: Map[K, V] => Map[K, V]): Map[K, V] = {
+  def updateStaleValues[K <: Sourceable, V1, V2](newMap: Map[K, V1], oldMap: Map[K, V2])(f: Map[K, V1] => Map[K, V2]): Map[K, V2] = {
     val (stale, fresh) = partition(newMap, oldMap)
     fresh ++ f(stale)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -33,11 +33,8 @@ object Desugar {
     */
   def run(root: WeededAst.Root, oldRoot: DesugaredAst.Root, changeSet: ChangeSet)(implicit flix: Flix): DesugaredAst.Root = flix.phase("Desugar") {
     // Compute the stale and fresh sources.
-    val (stale, fresh) = changeSet.partition(root.units, oldRoot.units)
-
-    val units = ParOps.parMapValues(stale)(visitUnit)
-    val allUnits = units ++ fresh
-    DesugaredAst.Root(allUnits, root.mainEntryPoint, root.availableClasses)
+    val units = changeSet.updateStaleValues(root.units, oldRoot.units)(ParOps.parMapValues(_)(visitUnit))
+    DesugaredAst.Root(units, root.mainEntryPoint, root.availableClasses)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -200,9 +200,8 @@ object Kinder {
     * Performs kinding on the all the traits in the given root.
     */
   private def visitTraits(root: ResolvedAst.Root, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit sctx: SharedContext, flix: Flix): Map[Symbol.TraitSym, KindedAst.Trait] = {
-    val (staleTraits, freshTraits) = changeSet.partition(root.traits, oldRoot.traits)
-    val result = ParOps.parMapValues(staleTraits)(visitTrait(_, taenv, root))
-    freshTraits ++ result
+    val res = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait(_, taenv, root)))
+    res
   }
 
   /**
@@ -251,9 +250,7 @@ object Kinder {
     * Performs kinding on the all the definitions in the given root.
     */
   private def visitDefs(root: ResolvedAst.Root, taenv: Map[Symbol.TypeAliasSym, KindedAst.TypeAlias], oldRoot: KindedAst.Root, changeSet: ChangeSet)(implicit sctx: SharedContext, flix: Flix): Map[Symbol.DefnSym, KindedAst.Def] = {
-    val (staleDefs, freshDefs) = changeSet.partition(root.defs, oldRoot.defs)
-    val result = ParOps.parMapValues(staleDefs)(visitDef(_, KindEnv.empty, taenv, root))
-    freshDefs ++ result
+    changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(visitDef(_, KindEnv.empty, taenv, root)))
   }
 
   /**


### PR DESCRIPTION
Use the new changeSet api for existing incremental compilations.

The perf result:
<img width="596" alt="image" src="https://github.com/user-attachments/assets/00e1e6f5-2698-4141-b1eb-de00b509a930" />

The incremental compilation for `Weeder2` `Parser2` and `Lexer` is left untouched since they do not fit very well.