### PR TITLE
feat: make Regions incremental

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -571,7 +571,7 @@ class Flix {
 
             EffectVerifier.run(afterTyper)
 
-            val (afterRegions, regionErrors) = Regions.run(afterTyper)
+            val (afterRegions, regionErrors) = Regions.run(afterTyper, cachedTyperAst, changeSet)
             errors ++= regionErrors
 
             val (afterEntryPoint, entryPointErrors) = EntryPoints.run(afterRegions)


### PR DESCRIPTION
fixes #9658
perf figure:
<img width="601" alt="image" src="https://github.com/user-attachments/assets/863588f5-82a2-45a0-b436-196fbe13c978" />

I just use cachedTyperAst as the oldRoot, as it's used both before and after Regions. What is the rule to choose the oldRoot?