### PR TITLE
feat: make PatMatch incremental

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/Flix.scala
+++ b/main/src/ca/uwaterloo/flix/api/Flix.scala
@@ -586,7 +586,7 @@ class Flix {
             val (afterStratifier, stratificationErrors) = Stratifier.run(afterPredDeps)
             errors ++= stratificationErrors
 
-            val (afterPatMatch, patMatchErrors) = PatMatch.run(afterStratifier)
+            val (afterPatMatch, patMatchErrors) = PatMatch.run(afterStratifier, cachedTyperAst, changeSet)
             errors ++= patMatchErrors
 
             val (afterRedundancy, redundancyErrors) = Redundancy.run(afterPatMatch)


### PR DESCRIPTION
fixes #9656
perf figure:
<img width="602" alt="image" src="https://github.com/user-attachments/assets/3896a60c-0522-4fd1-a224-c9d1f88837e5" />

I remembered that Matt said root.sig is redundant, so I only visit all the traits, same as what we did in safety.