### PR TITLE
fix: remove ExprSnippetCompleter from UndefinedAnnotation

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -48,7 +48,7 @@ object CompletionProvider {
     val completionItems = getCompletionContext(source, uri, pos, currentErrors).map {ctx =>
       errorsAt(ctx.uri, ctx.pos, currentErrors).flatMap({
         case WeederError.UnqualifiedUse(_) => UseCompleter.getCompletions(ctx)
-        case WeederError.UndefinedAnnotation(_, _) => KeywordCompleter.getModKeywords ++ ExprSnippetCompleter.getCompletions()
+        case WeederError.UndefinedAnnotation(_, _) => KeywordCompleter.getModKeywords
         case ResolutionError.UndefinedUse(_, _, _, _) => UseCompleter.getCompletions(ctx)
         case err: ResolutionError.UndefinedTag =>
           val (namespace, ident) = getNamespaceAndIdentFromQName(err.qn)


### PR DESCRIPTION
Does it make any sense to provide ExprSnippetCompletion there?