### PR TITLE
feat: identify trailing dot in QName

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -256,9 +256,9 @@ object CompletionUtils {
     *   - Source "A.B.C.", QName(["A", "B"], "C") -> ("A.B.C", "")
     */
   def getNamespaceAndIdentFromQName(qn: QName): (List[String], String) = {
-    val ident = if (qn.endsWithDot) "" else qn.ident.name
+    val ident = if (qn.trailingDot) "" else qn.ident.name
     val namespace = qn.namespace.idents.map(_.name) ++ {
-      if (qn.endsWithDot) List(qn.ident.name)
+      if (qn.trailingDot) List(qn.ident.name)
       else Nil
     }
     (namespace, ident)

--- a/main/src/ca/uwaterloo/flix/language/ast/Name.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Name.scala
@@ -157,11 +157,12 @@ object Name {
   /**
     * Qualified Name.
     *
-    * @param namespace the namespace
-    * @param ident     the identifier.
-    * @param loc       the source location of the qualified name.
+    * @param namespace    the namespace
+    * @param ident        the identifier.
+    * @param loc          the source location of the qualified name.
+    * @param trailingDot  `true` if the qualified name ends with a dot.
     */
-  case class QName(namespace: NName, ident: Ident, loc: SourceLocation) {
+  case class QName(namespace: NName, ident: Ident, loc: SourceLocation, trailingDot: Boolean = false) {
     /**
       * Returns `true` if this name is unqualified (i.e. has no namespace).
       */

--- a/main/src/ca/uwaterloo/flix/language/ast/Name.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Name.scala
@@ -160,7 +160,7 @@ object Name {
     * @param namespace    the namespace
     * @param ident        the identifier.
     * @param loc          the source location of the qualified name.
-    * @param trailingDot  `true` if the qualified name ends with a dot.
+    * @param trailingDot  `true` if the qualified name ends with a dot (which implies this name is incomplete)
     */
   case class QName(namespace: NName, ident: Ident, loc: SourceLocation, trailingDot: Boolean = false) {
     /**

--- a/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
@@ -115,6 +115,8 @@ object SyntaxTree {
 
     case object StructField extends TreeKind
 
+    case object TrailingDot extends TreeKind
+
     case object TypeParameter extends TreeKind
 
     case object TypeParameterList extends TreeKind

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -1342,8 +1342,8 @@ object Desugar {
     @tailrec
     def flatten(exp: WeededAst.Expr, acc: List[WeededAst.Expr]): (List[WeededAst.Expr], Option[WeededAst.Expr]) = exp match {
       case WeededAst.Expr.FCons(e1, e2, _) => flatten(e2, e1 :: acc)
-      case WeededAst.Expr.Ambiguous(Name.QName(nname, Name.Ident("Nil", _), _), _) if nname.idents == "List" :: Nil => (acc.reverse, None)
-      case WeededAst.Expr.Ambiguous(Name.QName(nname, Name.Ident("Nil", _), _), _) if nname.idents.isEmpty => (acc.reverse, None)
+      case WeededAst.Expr.Ambiguous(Name.QName(nname, Name.Ident("Nil", _), _, _), _) if nname.idents == "List" :: Nil => (acc.reverse, None)
+      case WeededAst.Expr.Ambiguous(Name.QName(nname, Name.Ident("Nil", _), _, _), _) if nname.idents.isEmpty => (acc.reverse, None)
       case _ => (acc.reverse, Some(exp))
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -699,12 +699,15 @@ object Parser2 {
             // Trailing dot, stop parsing the qualified name.
             val error = UnexpectedToken(
               expected = NamedTokenSet.FromKinds(kinds),
-              actual = Some(TokenKind.Dot),
+              actual = None,
               sctx = context,
-              hint = None,
+              hint = Some("Expect something after '.'"),
               loc = currentSourceLocation()
             )
-            advanceWithError(error)
+            val mark = open()
+            advance()
+            close(mark, TreeKind.TrailingDot)
+            s.errors.append(error)
             continue = false
           } else {
             advance() // Eat the dot
@@ -717,12 +720,15 @@ object Parser2 {
           // Trailing dot, stop parsing the qualified name.
           val error = UnexpectedToken(
             expected = NamedTokenSet.FromKinds(kinds),
-            actual = Some(TokenKind.Dot),
+            actual = None,
             sctx = context,
-            hint = None,
+            hint = Some("Expect something after '.'"),
             loc = currentSourceLocation()
           )
-          advanceWithError(error)
+          val mark = open()
+          advance()
+          close(mark, TreeKind.TrailingDot)
+          s.errors.append(error)
           continue = false
         case _ => continue = false
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -701,13 +701,12 @@ object Parser2 {
               expected = NamedTokenSet.FromKinds(kinds),
               actual = None,
               sctx = context,
-              hint = Some("Expect something after '.'"),
+              hint = Some("Expect ident after '.'"),
               loc = currentSourceLocation()
             )
             val mark = open()
-            advance()
             close(mark, TreeKind.TrailingDot)
-            s.errors.append(error)
+            advanceWithError(error)
             continue = false
           } else {
             advance() // Eat the dot
@@ -722,13 +721,12 @@ object Parser2 {
             expected = NamedTokenSet.FromKinds(kinds),
             actual = None,
             sctx = context,
-            hint = Some("Expect something after '.'"),
+            hint = Some("Expect ident after '.'"),
             loc = currentSourceLocation()
           )
           val mark = open()
-          advance()
           close(mark, TreeKind.TrailingDot)
-          s.errors.append(error)
+          advanceWithError(error)
           continue = false
         case _ => continue = false
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -911,13 +911,14 @@ object Weeder2 {
     private def visitQnameExpr(tree: Tree)(implicit sctx: SharedContext): Expr.Ambiguous = {
       expect(tree, TreeKind.QName)
       val idents = pickAll(TreeKind.Ident, tree).map(tokenToIdent)
+      val trailingDot = tryPick(TreeKind.TrailingDot, tree).nonEmpty
       assert(idents.nonEmpty) // Require at least one ident
       val first = idents.head
       val ident = idents.last
       val nnameIdents = idents.dropRight(1)
       val loc = SourceLocation(isReal = true, first.loc.sp1, ident.loc.sp2)
       val nname = Name.NName(nnameIdents, loc)
-      val qname = Name.QName(nname, ident, loc)
+      val qname = Name.QName(nname, ident, loc, trailingDot)
       Expr.Ambiguous(qname, qname.loc)
     }
 
@@ -3076,13 +3077,14 @@ object Weeder2 {
   private def visitQName(tree: Tree)(implicit sctx: SharedContext): Name.QName = {
     expect(tree, TreeKind.QName)
     val idents = pickAll(TreeKind.Ident, tree).map(tokenToIdent)
+    val trailingDot = tryPick(TreeKind.TrailingDot, tree).nonEmpty
     assert(idents.nonEmpty) // We require at least one element to construct a qname
     val first = idents.head
     val ident = idents.last
     val nnameIdents = idents.dropRight(1)
     val loc = SourceLocation(isReal = true, first.loc.sp1, ident.loc.sp2)
     val nname = Name.NName(nnameIdents, loc)
-    Name.QName(nname, ident, loc)
+    Name.QName(nname, ident, loc, trailingDot)
   }
 
   private def pickNameIdent(tree: Tree)(implicit sctx: SharedContext): Validation[Name.Ident, CompilationMessage] = {


### PR DESCRIPTION
Add a new field `trailingDot` to QName to indicate if there is a trailing dot.

Note:
- I add a new TreeKind named TrailingDot and tryPick that to check
- I add `trailingDot` as the last field so that we can set a default value for it

I'll start using this field in the following PR. But some preliminary tests show that it works fine.

I am not sure if it's possible to process this in another way. When detecting the existence of a trailing dot. we just use all the idents as the namespace and use an empty string as ident.

The benefit is:
- Currently `use AMod.BMod.` will not trigger a resolution error since the QName is AMod as namespace and BMod as ident, which is a valid use. We have to manually check if there is a trailing dot when resolving. However, if we have [AMod, BMod] as namespace and "" as Ident, the resolve will fail and we do not need to check trailing dot manually.
- In completers, we are just using trailingDot to move ident to namespace for further usage(transform ([AMod], BMod) to ([AMod, BMod], "")). And we have to call the function to extract that namespace and ident in every completer, which is tedious. With this change, we can just use the namespace and ident from QName directly.
- Since trailing dot is only possible when the user is writing the code. The change over trailing dot will not break existing code.