### PR TITLE
refactor: remove unnecessary named parameters in Regex

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -74,3 +74,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Alexander Dybdahl Troelsen](https://github.com/LoZander)
 - [Chenhao Gao](https://github.com/stormckey)
 - [Maksim Gusev](https://github.com/emaisty)
+- [gwydd](https://github.com/gwydd12)

--- a/main/src/library/Regex.flix
+++ b/main/src/library/Regex.flix
@@ -149,8 +149,8 @@ mod Regex {
     /// If `substr` regexp matches the empty string, positions where an empty match
     /// has been recognized will be returned.
     ///
-    pub def indices(substr: {substr = Regex}, s: String): List[Int32] = region rc {
-        let m = newMatcher(rc, substr#substr, s);
+    pub def indices(substr: Regex, s: String): List[Int32] = region rc {
+        let m = newMatcher(rc, substr, s);
         match foldSubmatches(Chain.snoc, Chain.empty(), matcherStart, m) {
             case Ok(c)  => Chain.toList(c)
             case Err(_) => Nil
@@ -162,8 +162,8 @@ mod Regex {
     ///
     /// Returns `Nil` if `substr` is the empty string.
     ///
-    pub def submatches(substr: {substr = Regex}, s: String): List[String] = region rc {
-        let m = newMatcher(rc, substr#substr, s);
+    pub def submatches(substr: Regex, s: String): List[String] = region rc {
+        let m = newMatcher(rc, substr, s);
         match foldSubmatches(Chain.snoc, Chain.empty(), matcherContent, m) {
             case Ok(c)  => Chain.toList(c)
             case Err(_) => Nil
@@ -173,8 +173,8 @@ mod Regex {
     ///
     /// Count the occurrences of `substr` in string `s`.
     ///
-    pub def countSubmatches(substr: {substr = Regex}, s: String): Int32 = region rc {
-        let m = newMatcher(rc, substr#substr, s);
+    pub def countSubmatches(substr: Regex, s: String): Int32 = region rc {
+        let m = newMatcher(rc, substr, s);
         match foldSubmatches((acc, _) -> acc + 1, 0, matcherStart, m) {
             case Ok(n)  => n
             case Err(_) => 0
@@ -182,10 +182,10 @@ mod Regex {
     }
 
     ///
-    /// Splits the string `s` around matches of the Regex `regex`.
+    /// Splits the string `s` around matches of the Regex `rgx`.
     ///
-    pub def split(regex: {regex = Regex}, s: String): List[String] =
-        unsafe Array.toList(unsafe regex#regex.split(s))
+    pub def split(rgx: Regex, s: String): List[String] =
+        unsafe Array.toList(unsafe rgx.split(s))
 
     ///
     /// Returns string `s` with every match of the Regex `src` replaced by the string `dst`.
@@ -206,8 +206,8 @@ mod Regex {
     ///
     /// Returns `true` if the string `s` starts the Regex `prefix`.
     ///
-    pub def startsWith(prefix: {prefix = Regex}, s: String): Bool = region rc {
-        let Matcher(m1) = newMatcher(rc, prefix#prefix, s);
+    pub def startsWith(prefix: Regex, s: String): Bool = region rc {
+        let Matcher(m1) = newMatcher(rc, prefix, s);
         unsafe m1.lookingAt()
     }
 
@@ -217,8 +217,8 @@ mod Regex {
     /// This will be slower than `startsWith` because there is no primitive Java function
     /// to call, instead the matches of `patt` are iterated until the last one is found.
     ///
-    pub def endsWith(suffix: {suffix = Regex}, s: String): Bool = region rc {
-        let m = newMatcher(rc, suffix#suffix, s);
+    pub def endsWith(suffix: Regex, s: String): Bool = region rc {
+        let m = newMatcher(rc, suffix, s);
         match lastSubmatch(matcherRange, m) {
             case Err(_)  => false
             case Ok(rng) => String.length(s) == rng#end
@@ -228,8 +228,8 @@ mod Regex {
     ///
     /// Returns `Some(prefix)` of string `s` if its prefix matches `substr`.
     ///
-    pub def getPrefix(substr: {substr = Regex}, s: String): Option[String] = region rc {
-        let m = newMatcher(rc, substr#substr, s);
+    pub def getPrefix(substr: Regex, s: String): Option[String] = region rc {
+        let m = newMatcher(rc, substr, s);
         match firstSubmatch(matcherRange, m) {
             case Err(_) => None
             case Ok(r)  => if (r#start == 0) Some(String.takeLeft(r#end, s)) else None
@@ -239,8 +239,8 @@ mod Regex {
     ///
     /// Returns `Some(suffix)` of string `s` if its suffix matches `substr`.
     ///
-    pub def getSuffix(substr: {substr = Regex}, s: String): Option[String] = region rc {
-        let m = newMatcher(rc, substr#substr, s);
+    pub def getSuffix(substr: Regex, s: String): Option[String] = region rc {
+        let m = newMatcher(rc, substr, s);
         match lastSubmatch(matcherRange, m) {
             case Err(_) => None
             case Ok(r)  => if (r#end == String.length(s)) Some(String.dropLeft(r#start, s)) else None
@@ -250,8 +250,8 @@ mod Regex {
     ///
     /// Returns `Some(suffix)` of string `s` if its prefix matches `substr`.
     ///
-    pub def stripPrefix(substr: {substr = Regex}, s: String): Option[String] = region rc {
-        let m = newMatcher(rc, substr#substr, s);
+    pub def stripPrefix(substr: Regex, s: String): Option[String] = region rc {
+        let m = newMatcher(rc, substr, s);
         match firstSubmatch(matcherRange, m) {
             case Err(_) => None
             case Ok(r)  => if (r#start == 0) Some(String.dropLeft(r#end, s)) else None
@@ -261,8 +261,8 @@ mod Regex {
     ///
     /// Returns `Some(prefix)` of string `s` if its suffix matches `substr`.
     ///
-    pub def stripSuffix(substr: {substr = Regex}, s: String): Option[String] = region rc {
-        let m = newMatcher(rc, substr#substr, s);
+    pub def stripSuffix(substr: Regex, s: String): Option[String] = region rc {
+        let m = newMatcher(rc, substr, s);
         match lastSubmatch(matcherRange, m) {
             case Err(_) => None
             case Ok(r)  => if (r#end == String.length(s)) Some(String.takeLeft(r#start, s)) else None
@@ -274,8 +274,8 @@ mod Regex {
     ///
     /// If the Regex `substr` is not present in `s` return None.
     ///
-    pub def indexOfFirst(substr: {substr = Regex}, s: String): Option[Int32] = region rc {
-        let m = newMatcher(rc, substr#substr, s);
+    pub def indexOfFirst(substr: Regex, s: String): Option[Int32] = region rc {
+        let m = newMatcher(rc, substr, s);
         firstSubmatch(matcherStart, m) |> Result.toOption
     }
 
@@ -284,8 +284,8 @@ mod Regex {
     ///
     /// If the Regex `substr` is not present in `s` return None.
     ///
-    pub def indexOfLast(substr: {substr = Regex}, s: String): Option[Int32] = region rc {
-        let m = newMatcher(rc, substr#substr, s);
+    pub def indexOfLast(substr: Regex, s: String): Option[Int32] = region rc {
+        let m = newMatcher(rc, substr, s);
         lastSubmatch(matcherStart, m) |> Result.toOption
     }
 
@@ -294,8 +294,8 @@ mod Regex {
     ///
     /// If the Regex `substr` is not present in `s` return None.
     ///
-    pub def getFirst(substr: {substr = Regex}, s: String): Option[String] = region rc {
-        let m = newMatcher(rc, substr#substr, s);
+    pub def getFirst(substr: Regex, s: String): Option[String] = region rc {
+        let m = newMatcher(rc, substr, s);
         firstSubmatch(matcherContent, m) |> Result.toOption
     }
 
@@ -304,8 +304,8 @@ mod Regex {
     ///
     /// If the Regex `substr` is not present in `s` return None.
     ///
-    pub def getLast(substr: {substr = Regex}, s: String): Option[String] = region rc {
-        let m = newMatcher(rc, substr#substr, s);
+    pub def getLast(substr: Regex, s: String): Option[String] = region rc {
+        let m = newMatcher(rc, substr, s);
         lastSubmatch(matcherContent, m) |> Result.toOption
     }
 
@@ -314,9 +314,9 @@ mod Regex {
     ///
     /// If the Regex `substr` is not present in `s` return None.
     ///
-    pub def indexOfFirstWithOffset(substr: {substr = Regex}, offset: {offset = Int32}, s: String): Option[Int32] = region rc {
-        let m = newMatcher(rc, substr#substr, s);
-        match setBounds(start = offset#offset, end = String.length(s), m) {
+    pub def indexOfFirstWithOffset(substr: Regex, offset: Int32, s: String): Option[Int32] = region rc {
+        let m = newMatcher(rc, substr, s);
+        match setBounds(start = offset, end = String.length(s), m) {
             case Ok()   => firstSubmatch(matcherStart, m) |> Result.toOption
             case Err(_) => None
         }
@@ -327,9 +327,9 @@ mod Regex {
     ///
     /// If the Regex `substr` is not present in `s` return None.
     ///
-    pub def indexOfLastWithOffset(substr: {substr = Regex}, offset: {offset = Int32}, s: String): Option[Int32] = region rc {
-        let m = newMatcher(rc, substr#substr, s);
-        match setBounds(start = offset#offset, end = String.length(s), m) {
+    pub def indexOfLastWithOffset(substr: Regex, offset: Int32, s: String): Option[Int32] = region rc {
+        let m = newMatcher(rc, substr, s);
+        match setBounds(start = offset, end = String.length(s), m) {
             case Ok()   => lastSubmatch(matcherStart, m) |> Result.toOption
             case Err(_) => None
         }
@@ -340,9 +340,9 @@ mod Regex {
     ///
     /// If the Regex `substr` is not present in `s` return None.
     ///
-    pub def getFirstWithOffset(substr: {substr = Regex}, offset: {offset = Int32}, s: String): Option[String] = region rc {
-        let m = newMatcher(rc, substr#substr, s);
-        match setBounds(start = offset#offset, end = String.length(s), m) {
+    pub def getFirstWithOffset(substr: Regex, offset: Int32, s: String): Option[String] = region rc {
+        let m = newMatcher(rc, substr, s);
+        match setBounds(start = offset, end = String.length(s), m) {
             case Ok()   => firstSubmatch(matcherContent, m) |> Result.toOption
             case Err(_) => None
         }
@@ -353,9 +353,9 @@ mod Regex {
     ///
     /// If the Regex `substr` is not present in `s` return None.
     ///
-    pub def getLastWithOffset(substr: {substr = Regex}, offset: {offset = Int32}, s: String): Option[String] = region rc {
-        let m = newMatcher(rc, substr#substr, s);
-        match setBounds(start = offset#offset, end = String.length(s), m) {
+    pub def getLastWithOffset(substr: Regex, offset: Int32, s: String): Option[String] = region rc {
+        let m = newMatcher(rc, substr, s);
+        match setBounds(start = offset, end = String.length(s), m) {
             case Ok()   => lastSubmatch(matcherContent, m) |> Result.toOption
             case Err(_) => None
         }
@@ -365,8 +365,8 @@ mod Regex {
     /// Find the first instance of Regex `substr` in string `s`, return a pair of the
     /// prefix of string `s` up to `sub` and the rest of string `s` including `sub`.
     ///
-    pub def breakOnFirst(substr: {substr = Regex}, s: String): (String, String) = region rc {
-        let m = newMatcher(rc, substr#substr, s);
+    pub def breakOnFirst(substr: Regex, s: String): (String, String) = region rc {
+        let m = newMatcher(rc, substr, s);
         match firstSubmatch(matcherRange, m) {
             case Err(_) => (s, "")
             case Ok(r)  => (String.sliceLeft(end = r#start, s), String.sliceRight(start = r#start, s))
@@ -377,8 +377,8 @@ mod Regex {
     /// Find the first instance of Regex `substr` in string `s`, return a pair of the
     /// prefix of string `s` up to and including `sub` and the rest of string `s` after `sub`.
     ///
-    pub def breakAfterFirst(substr: {substr = Regex}, s: String): (String, String) = region rc {
-        let m = newMatcher(rc, substr#substr, s);
+    pub def breakAfterFirst(substr: Regex, s: String): (String, String) = region rc {
+        let m = newMatcher(rc, substr, s);
         match firstSubmatch(matcherRange, m) {
             case Err(_) => (s, "")
             case Ok(r)  => (String.sliceLeft(end = r#end, s), String.sliceRight(start = r#end, s))
@@ -389,8 +389,8 @@ mod Regex {
     /// Find the last instance of `substr` in string `s`, return a pair of the
     /// initial string including `substr` and suffix from `substr`.
     ///
-    pub def breakOnLast(substr: {substr = Regex}, s: String): (String, String) = region rc {
-        let m = newMatcher(rc, substr#substr, s);
+    pub def breakOnLast(substr: Regex, s: String): (String, String) = region rc {
+        let m = newMatcher(rc, substr, s);
         match lastSubmatch(matcherRange, m) {
             case Err(_) => (s, "")
             case Ok(r)  => (String.sliceLeft(end = r#end, s), String.sliceRight(start = r#end, s))
@@ -401,8 +401,8 @@ mod Regex {
     /// Find the last instance of `substr` in string `s`, return a pair of the
     /// initial string including `substr` and suffix from `substr`.
     ///
-    pub def breakBeforeLast(substr: {substr = Regex}, s: String): (String, String) = region rc {
-        let m = newMatcher(rc, substr#substr, s);
+    pub def breakBeforeLast(substr: Regex, s: String): (String, String) = region rc {
+        let m = newMatcher(rc, substr, s);
         match lastSubmatch(matcherRange, m) {
             case Err(_) => (s, "")
             case Ok(r)  => (String.sliceLeft(end = r#start, s), String.sliceRight(start = r#start, s))
@@ -443,8 +443,8 @@ mod Regex {
     ///
     /// Returns `Nil` if there are no matches or the bounds are invalid.
     ///
-    pub def indicesWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): List[Int32] = region rc {
-        match newMatcherWithBounds(rc, substr#substr, start, end, s) {
+    pub def indicesWithBounds(substr: Regex, start: {start = Int32}, end: {end = Int32}, s: String): List[Int32] = region rc {
+        match newMatcherWithBounds(rc, substr, start, end, s) {
             case Ok(m)  => match foldSubmatches(Chain.snoc, Chain.empty(), matcherStart, m) {
                case Ok(c)  => Chain.toList(c)
                case Err(_) => Nil
@@ -459,8 +459,8 @@ mod Regex {
     ///
     /// Returns `Nil` if `substr` is the empty string or the bounds are invalid.
     ///
-    pub def submatchesWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): List[String] = region rc {
-        match newMatcherWithBounds(rc, substr#substr, start, end, s) {
+    pub def submatchesWithBounds(substr: Regex, start: {start = Int32}, end: {end = Int32}, s: String): List[String] = region rc {
+        match newMatcherWithBounds(rc, substr, start, end, s) {
             case Ok(m)   => match foldSubmatches(Chain.snoc, Chain.empty(), matcherContent, m) {
                 case Ok(c)  => Chain.toList(c)
                 case Err(_) => Nil
@@ -474,8 +474,8 @@ mod Regex {
     ///
     /// Returns 0 if the bounds are invalid.
     ///
-    pub def countSubmatchesWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): Int32 = region rc {
-        match newMatcherWithBounds(rc, substr#substr, start, end, s) {
+    pub def countSubmatchesWithBounds(substr: Regex, start: {start = Int32}, end: {end = Int32}, s: String): Int32 = region rc {
+        match newMatcherWithBounds(rc, substr, start, end, s) {
             case Ok(m)  => match foldSubmatches((acc, _) -> acc + 1, 0, matcherStart, m) {
                 case Ok(n)  => n
                 case Err(_) => 0
@@ -490,8 +490,8 @@ mod Regex {
     ///
     /// If the Regex `substr` is not present in `s` or the bounds are invalid return `None`.
     ///
-    pub def indexOfFirstWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): Option[Int32] = region rc {
-        match newMatcherWithBounds(rc, substr#substr, start, end, s) {
+    pub def indexOfFirstWithBounds(substr: Regex, start: {start = Int32}, end: {end = Int32}, s: String): Option[Int32] = region rc {
+        match newMatcherWithBounds(rc, substr, start, end, s) {
             case Ok(m)  => firstSubmatch(matcherStart, m) |> Result.toOption
             case Err(_) => None
         }
@@ -503,8 +503,8 @@ mod Regex {
     ///
     /// If the Regex `substr` is not present in `s` or the bounds are invalid return `None`.
     ///
-    pub def indexOfLastWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): Option[Int32] = region rc {
-        match newMatcherWithBounds(rc, substr#substr, start, end, s) {
+    pub def indexOfLastWithBounds(substr: Regex, start: {start = Int32}, end: {end = Int32}, s: String): Option[Int32] = region rc {
+        match newMatcherWithBounds(rc, substr, start, end, s) {
             case Ok(m)  => lastSubmatch(matcherStart, m) |> Result.toOption
             case Err(_) => None
         }
@@ -516,8 +516,8 @@ mod Regex {
     ///
     /// If the Regex `substr` is not present in `s` or the bounds are invalid return `None`.
     ///
-    pub def getFirstWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): Option[String] = region rc {
-        match newMatcherWithBounds(rc, substr#substr, start, end, s) {
+    pub def getFirstWithBounds(substr: Regex, start: {start = Int32}, end: {end = Int32}, s: String): Option[String] = region rc {
+        match newMatcherWithBounds(rc, substr, start, end, s) {
             case Ok(m)  => firstSubmatch(matcherContent, m) |> Result.toOption
             case Err(_) => None
         }
@@ -529,8 +529,8 @@ mod Regex {
     ///
     /// If the Regex `substr` is not present in `s` or the bounds are invalid return `None`.
     ///
-    pub def getLastWithBounds(substr: {substr = Regex}, start: {start = Int32}, end: {end = Int32}, s: String): Option[String] = region rc {
-        match newMatcherWithBounds(rc, substr#substr, start, end, s) {
+    pub def getLastWithBounds(substr: Regex, start: {start = Int32}, end: {end = Int32}, s: String): Option[String] = region rc {
+        match newMatcherWithBounds(rc, substr, start, end, s) {
             case Ok(m)  => lastSubmatch(matcherContent, m) |> Result.toOption
             case Err(_) => None
         }

--- a/main/src/library/String.flix
+++ b/main/src/library/String.flix
@@ -1348,7 +1348,7 @@ mod String {
         else {
             // Find the last occurrence of non-whitespace followed by whitespace
             // This is the end of the first line
-            let endOpt = Regex.indexOfLastWithBounds({substr = regex"(?<!\\s)\\s"}, {start = 0}, {end = w}, s);
+            let endOpt = Regex.indexOfLastWithBounds(regex"(?<!\\s)\\s", {start = 0}, {end = w}, s);
             let end = match endOpt {
                 case Some(end) => end
                 case None => w

--- a/main/test/ca/uwaterloo/flix/library/TestRegex.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestRegex.flix
@@ -148,55 +148,55 @@ mod TestRegex {
 
     @test
     def indices01(): Bool =
-        Regex.indices(substr = Regex.unmatchable(), "") == List#{}
+        Regex.indices(Regex.unmatchable(), "") == List#{}
 
     @test
     def indices02(): Bool =
-        Regex.indices(substr = Regex.unmatchable(), "a::b::c") == List#{}
+        Regex.indices(Regex.unmatchable(), "a::b::c") == List#{}
 
     @test
     def indices03(): Bool =
-        Regex.indices(substr = regex":{2}", "") == List#{}
+        Regex.indices(regex":{2}", "") == List#{}
 
     @test
     def indices04(): Bool =
-        Regex.indices(substr = regex":{2}", "a") == List#{}
+        Regex.indices(regex":{2}", "a") == List#{}
 
     @test
     def indices05(): Bool =
-        Regex.indices(substr = regex":{2}", "::") == List#{0}
+        Regex.indices(regex":{2}", "::") == List#{0}
 
     @test
     def indices06(): Bool =
-        Regex.indices(substr = regex":{2}", "ab") == List#{}
+        Regex.indices(regex":{2}", "ab") == List#{}
 
     @test
     def indices07(): Bool =
-        Regex.indices(substr = regex":{2}", "::a") == List#{0}
+        Regex.indices(regex":{2}", "::a") == List#{0}
 
     @test
     def indices08(): Bool =
-        Regex.indices(substr = regex":{2}", "a::") == List#{1}
+        Regex.indices(regex":{2}", "a::") == List#{1}
 
     @test
     def indices09(): Bool =
-        Regex.indices(substr = regex":{2}", "a::b::") == List#{1, 4}
+        Regex.indices(regex":{2}", "a::b::") == List#{1, 4}
 
     @test
     def indices10(): Bool =
-        Regex.indices(substr = regex":{2}", "a::b::c") == List#{1, 4}
+        Regex.indices(regex":{2}", "a::b::c") == List#{1, 4}
 
     @test
     def indices11(): Bool =
-        Regex.indices(substr = regex":{2}", "a::b::c:") == List#{1, 4}
+        Regex.indices(regex":{2}", "a::b::c:") == List#{1, 4}
 
     @test
     def indices12(): Bool =
-        Regex.indices(substr = regex":{2}", ":a::b::c") == List#{2, 5}
+        Regex.indices(regex":{2}", ":a::b::c") == List#{2, 5}
 
     @test
     def indices13(): Bool =
-        Regex.indices(substr = regex":{2}", "::::") == List#{0, 2}
+        Regex.indices(regex":{2}", "::::") == List#{0, 2}
 
     /////////////////////////////////////////////////////////////////////////////
     // submatches                                                              //
@@ -204,55 +204,55 @@ mod TestRegex {
 
     @test
     def submatches01(): Bool =
-        Regex.submatches(substr = Regex.unmatchable(), "") == List#{}
+        Regex.submatches(Regex.unmatchable(), "") == List#{}
 
     @test
     def submatches02(): Bool =
-        Regex.submatches(substr = Regex.unmatchable(), "a::b::c") == List#{}
+        Regex.submatches(Regex.unmatchable(), "a::b::c") == List#{}
 
     @test
     def submatches03(): Bool =
-        Regex.submatches(substr = regex"\\p{Alpha}+", "") == List#{}
+        Regex.submatches(regex"\\p{Alpha}+", "") == List#{}
 
     @test
     def submatches04(): Bool =
-        Regex.submatches(substr = regex"\\p{Alpha}+", "a") == List#{"a"}
+        Regex.submatches(regex"\\p{Alpha}+", "a") == List#{"a"}
 
     @test
     def submatches05(): Bool =
-        Regex.submatches(substr = regex"\\p{Alpha}+", "::") == List#{}
+        Regex.submatches(regex"\\p{Alpha}+", "::") == List#{}
 
     @test
     def submatches06(): Bool =
-        Regex.submatches(substr = regex"\\p{Alpha}+", "ab") == List#{"ab"}
+        Regex.submatches(regex"\\p{Alpha}+", "ab") == List#{"ab"}
 
     @test
     def submatches07(): Bool =
-        Regex.submatches(substr = regex"\\p{Alpha}+", "::a") == List#{"a"}
+        Regex.submatches(regex"\\p{Alpha}+", "::a") == List#{"a"}
 
     @test
     def submatches08(): Bool =
-        Regex.submatches(substr = regex"\\p{Alpha}+", "a::") == List#{"a"}
+        Regex.submatches(regex"\\p{Alpha}+", "a::") == List#{"a"}
 
     @test
     def submatches09(): Bool =
-        Regex.submatches(substr = regex"\\p{Alpha}+", "a::b::") == List#{"a", "b"}
+        Regex.submatches(regex"\\p{Alpha}+", "a::b::") == List#{"a", "b"}
 
     @test
     def submatches10(): Bool =
-        Regex.submatches(substr = regex"\\p{Alpha}+", "a::b::c") == List#{"a", "b", "c"}
+        Regex.submatches(regex"\\p{Alpha}+", "a::b::c") == List#{"a", "b", "c"}
 
     @test
     def submatches11(): Bool =
-        Regex.submatches(substr = regex"\\p{Alpha}+", "a::b::c:") == List#{"a", "b", "c"}
+        Regex.submatches(regex"\\p{Alpha}+", "a::b::c:") == List#{"a", "b", "c"}
 
     @test
     def submatches12(): Bool =
-        Regex.submatches(substr = regex"\\p{Alpha}+", ":a::b::c") == List#{"a", "b", "c"}
+        Regex.submatches(regex"\\p{Alpha}+", ":a::b::c") == List#{"a", "b", "c"}
 
     @test
     def submatches13(): Bool =
-        Regex.submatches(substr = regex"\\p{Alpha}+", "::::") == List#{}
+        Regex.submatches(regex"\\p{Alpha}+", "::::") == List#{}
 
     /////////////////////////////////////////////////////////////////////////////
     // countSubmatches                                                         //
@@ -260,55 +260,55 @@ mod TestRegex {
 
     @test
     def countSubmatches01(): Bool =
-        Regex.countSubmatches(substr = Regex.unmatchable(), "") == 0
+        Regex.countSubmatches(Regex.unmatchable(), "") == 0
 
     @test
     def countSubmatches02(): Bool =
-        Regex.countSubmatches(substr = Regex.unmatchable(), "a::b::c") == 0
+        Regex.countSubmatches(Regex.unmatchable(), "a::b::c") == 0
 
     @test
     def countSubmatches03(): Bool =
-        Regex.countSubmatches(substr = regex"\\p{Alpha}+", "") == 0
+        Regex.countSubmatches(regex"\\p{Alpha}+", "") == 0
 
     @test
     def countSubmatches04(): Bool =
-        Regex.countSubmatches(substr = regex"\\p{Alpha}+", "a") == 1
+        Regex.countSubmatches(regex"\\p{Alpha}+", "a") == 1
 
     @test
     def countSubmatches05(): Bool =
-        Regex.countSubmatches(substr = regex"\\p{Alpha}+", "::") == 0
+        Regex.countSubmatches(regex"\\p{Alpha}+", "::") == 0
 
     @test
     def countSubmatches06(): Bool =
-        Regex.countSubmatches(substr = regex"\\p{Alpha}+", "ab") == 1
+        Regex.countSubmatches(regex"\\p{Alpha}+", "ab") == 1
 
     @test
     def countSubmatches07(): Bool =
-        Regex.countSubmatches(substr = regex"\\p{Alpha}+", "::a") == 1
+        Regex.countSubmatches(regex"\\p{Alpha}+", "::a") == 1
 
     @test
     def countSubmatches08(): Bool =
-        Regex.countSubmatches(substr = regex"\\p{Alpha}+", "a::") == 1
+        Regex.countSubmatches(regex"\\p{Alpha}+", "a::") == 1
 
     @test
     def countSubmatches09(): Bool =
-        Regex.countSubmatches(substr = regex"\\p{Alpha}+", "a::b::") == 2
+        Regex.countSubmatches(regex"\\p{Alpha}+", "a::b::") == 2
 
     @test
     def countSubmatches10(): Bool =
-        Regex.countSubmatches(substr = regex"\\p{Alpha}+", "a::b::c") == 3
+        Regex.countSubmatches(regex"\\p{Alpha}+", "a::b::c") == 3
 
     @test
     def countSubmatches11(): Bool =
-        Regex.countSubmatches(substr = regex"\\p{Alpha}+", "a::b::c:") == 3
+        Regex.countSubmatches(regex"\\p{Alpha}+", "a::b::c:") == 3
 
     @test
     def countSubmatches12(): Bool =
-        Regex.countSubmatches(substr = regex"\\p{Alpha}+", ":a::b::c") == 3
+        Regex.countSubmatches(regex"\\p{Alpha}+", ":a::b::c") == 3
 
     @test
     def countSubmatches13(): Bool =
-        Regex.countSubmatches(substr = regex"\\p{Alpha}+", "::::") == 0
+        Regex.countSubmatches(regex"\\p{Alpha}+", "::::") == 0
 
     /////////////////////////////////////////////////////////////////////////////
     // split                                                                   //
@@ -316,15 +316,15 @@ mod TestRegex {
 
     @test
     def split01(): Bool =
-        Regex.split(regex = regex"\\p{Blank}+", "A B C") == List#{"A", "B", "C"}
+        Regex.split(regex"\\p{Blank}+", "A B C") == List#{"A", "B", "C"}
 
     @test
     def split02(): Bool =
-        Regex.split(regex = regex"\\p{Blank}+", "A  B   C") == List#{"A", "B", "C"}
+        Regex.split(regex"\\p{Blank}+", "A  B   C") == List#{"A", "B", "C"}
 
     @test
     def split03(): Bool =
-        Regex.split(regex = regex"\\p{Blank}+", "ABC") == List#{"ABC"}
+        Regex.split(regex"\\p{Blank}+", "ABC") == List#{"ABC"}
 
     /////////////////////////////////////////////////////////////////////////////
     // replace                                                                 //
@@ -388,27 +388,27 @@ mod TestRegex {
 
     @test
     def startsWith01(): Bool =
-        Regex.startsWith(prefix = Regex.unmatchable(), "") == false
+        Regex.startsWith(Regex.unmatchable(), "") == false
 
     @test
     def startsWith02(): Bool =
-        Regex.startsWith(prefix = Regex.unmatchable(), "A B C") == false
+        Regex.startsWith(Regex.unmatchable(), "A B C") == false
 
     @test
     def startsWith03(): Bool =
-        Regex.startsWith(prefix = regex"\\p{Alpha}+", "") == false
+        Regex.startsWith(regex"\\p{Alpha}+", "") == false
 
     @test
     def startsWith04(): Bool =
-        Regex.startsWith(prefix = regex"\\p{Alpha}+", "   A B C") == false
+        Regex.startsWith(regex"\\p{Alpha}+", "   A B C") == false
 
     @test
     def startsWith05(): Bool =
-        Regex.startsWith(prefix = regex"\\p{Alpha}+", "A B C") == true
+        Regex.startsWith(regex"\\p{Alpha}+", "A B C") == true
 
     @test
     def startsWith06(): Bool =
-        Regex.startsWith(prefix = regex"\\p{Alpha}+", "AA BBB CCCC") == true
+        Regex.startsWith(regex"\\p{Alpha}+", "AA BBB CCCC") == true
 
     /////////////////////////////////////////////////////////////////////////////
     // endsWith                                                                //
@@ -416,27 +416,27 @@ mod TestRegex {
 
     @test
     def endsWith01(): Bool =
-        Regex.endsWith(suffix = Regex.unmatchable(), "") == false
+        Regex.endsWith(Regex.unmatchable(), "") == false
 
     @test
     def endsWith02(): Bool =
-        Regex.endsWith(suffix = Regex.unmatchable(), "A B C") == false
+        Regex.endsWith(Regex.unmatchable(), "A B C") == false
 
     @test
     def endsWith03(): Bool =
-        Regex.endsWith(suffix = regex"\\p{Alpha}+", "") == false
+        Regex.endsWith(regex"\\p{Alpha}+", "") == false
 
     @test
     def endsWith04(): Bool =
-        Regex.endsWith(suffix = regex"\\p{Alpha}+", "A B C  ") == false
+        Regex.endsWith(regex"\\p{Alpha}+", "A B C  ") == false
 
     @test
     def endsWith05(): Bool =
-        Regex.endsWith(suffix = regex"\\p{Alpha}+", "A B C") == true
+        Regex.endsWith(regex"\\p{Alpha}+", "A B C") == true
 
     @test
     def endsWith06(): Bool =
-        Regex.endsWith(suffix = regex"\\p{Alpha}+", "AA BBB CCCC") == true
+        Regex.endsWith(regex"\\p{Alpha}+", "AA BBB CCCC") == true
 
     /////////////////////////////////////////////////////////////////////////////
     // getPrefix                                                               //
@@ -444,27 +444,27 @@ mod TestRegex {
 
     @test
     def getPrefix01(): Bool =
-        Regex.getPrefix(substr = Regex.unmatchable(), "") == None
+        Regex.getPrefix(Regex.unmatchable(), "") == None
 
     @test
     def getPrefix02(): Bool =
-        Regex.getPrefix(substr = Regex.unmatchable(), "A B C") == None
+        Regex.getPrefix(Regex.unmatchable(), "A B C") == None
 
     @test
     def getPrefix03(): Bool =
-        Regex.getPrefix(substr = regex"\\p{Alpha}+", "") == None
+        Regex.getPrefix(regex"\\p{Alpha}+", "") == None
 
     @test
     def getPrefix04(): Bool =
-        Regex.getPrefix(substr = regex"\\p{Alpha}+", "   A B C") == None
+        Regex.getPrefix(regex"\\p{Alpha}+", "   A B C") == None
 
     @test
     def getPrefix05(): Bool =
-        Regex.getPrefix(substr = regex"\\p{Alpha}+", "A B C") == Some("A")
+        Regex.getPrefix(regex"\\p{Alpha}+", "A B C") == Some("A")
 
     @test
     def getPrefix06(): Bool =
-        Regex.getPrefix(substr = regex"\\p{Alpha}+", "AA BBB CCCC") == Some("AA")
+        Regex.getPrefix(regex"\\p{Alpha}+", "AA BBB CCCC") == Some("AA")
 
     /////////////////////////////////////////////////////////////////////////////
     // getSuffix                                                               //
@@ -472,27 +472,27 @@ mod TestRegex {
 
     @test
     def getSuffix01(): Bool =
-        Regex.getSuffix(substr = Regex.unmatchable(), "") == None
+        Regex.getSuffix(Regex.unmatchable(), "") == None
 
     @test
     def getSuffix02(): Bool =
-        Regex.getSuffix(substr = Regex.unmatchable(), "A B C") == None
+        Regex.getSuffix(Regex.unmatchable(), "A B C") == None
 
     @test
     def getSuffix03(): Bool =
-        Regex.getSuffix(substr = regex"\\p{Alpha}+", "") == None
+        Regex.getSuffix(regex"\\p{Alpha}+", "") == None
 
     @test
     def getSuffix04(): Bool =
-        Regex.getSuffix(substr = regex"\\p{Alpha}+", "A B C  ") == None
+        Regex.getSuffix(regex"\\p{Alpha}+", "A B C  ") == None
 
     @test
     def getSuffix05(): Bool =
-        Regex.getSuffix(substr = regex"\\p{Alpha}+", "A B C") == Some("C")
+        Regex.getSuffix(regex"\\p{Alpha}+", "A B C") == Some("C")
 
     @test
     def getSuffix06(): Bool =
-        Regex.getSuffix(substr = regex"\\p{Alpha}+", "AA BBB CCCC") == Some("CCCC")
+        Regex.getSuffix(regex"\\p{Alpha}+", "AA BBB CCCC") == Some("CCCC")
 
     /////////////////////////////////////////////////////////////////////////////
     // stripPrefix                                                             //
@@ -500,27 +500,27 @@ mod TestRegex {
 
     @test
     def stripPrefix01(): Bool =
-        Regex.stripPrefix(substr = Regex.unmatchable(), "") == None
+        Regex.stripPrefix(Regex.unmatchable(), "") == None
 
     @test
     def stripPrefix02(): Bool =
-        Regex.stripPrefix(substr = Regex.unmatchable(), "A B C") == None
+        Regex.stripPrefix(Regex.unmatchable(), "A B C") == None
 
     @test
     def stripPrefix03(): Bool =
-        Regex.stripPrefix(substr = regex"\\p{Alpha}+", "") == None
+        Regex.stripPrefix(regex"\\p{Alpha}+", "") == None
 
     @test
     def stripPrefix04(): Bool =
-        Regex.stripPrefix(substr = regex"\\p{Alpha}+", "   A B C") == None
+        Regex.stripPrefix(regex"\\p{Alpha}+", "   A B C") == None
 
     @test
     def stripPrefix05(): Bool =
-        Regex.stripPrefix(substr = regex"\\p{Alpha}+", "A B C") == Some(" B C")
+        Regex.stripPrefix(regex"\\p{Alpha}+", "A B C") == Some(" B C")
 
     @test
     def stripPrefix06(): Bool =
-        Regex.stripPrefix(substr = regex"\\p{Alpha}+", "AA BBB CCCC") == Some(" BBB CCCC")
+        Regex.stripPrefix(regex"\\p{Alpha}+", "AA BBB CCCC") == Some(" BBB CCCC")
 
     /////////////////////////////////////////////////////////////////////////////
     // stripSuffix                                                             //
@@ -528,27 +528,27 @@ mod TestRegex {
 
     @test
     def stripSuffix01(): Bool =
-        Regex.stripSuffix(substr = Regex.unmatchable(), "") == None
+        Regex.stripSuffix(Regex.unmatchable(), "") == None
 
     @test
     def stripSuffix02(): Bool =
-        Regex.stripSuffix(substr = Regex.unmatchable(), "A B C") == None
+        Regex.stripSuffix(Regex.unmatchable(), "A B C") == None
 
     @test
     def stripSuffix03(): Bool =
-        Regex.stripSuffix(substr = regex"\\p{Alpha}+", "") == None
+        Regex.stripSuffix(regex"\\p{Alpha}+", "") == None
 
     @test
     def stripSuffix04(): Bool =
-        Regex.stripSuffix(substr = regex"\\p{Alpha}+", "A B C  ") == None
+        Regex.stripSuffix(regex"\\p{Alpha}+", "A B C  ") == None
 
     @test
     def stripSuffix05(): Bool =
-        Regex.stripSuffix(substr = regex"\\p{Alpha}+", "A B C") == Some("A B ")
+        Regex.stripSuffix(regex"\\p{Alpha}+", "A B C") == Some("A B ")
 
     @test
     def stripSuffix06(): Bool =
-        Regex.stripSuffix(substr = regex"\\p{Alpha}+", "AA BBB CCCC") == Some("AA BBB ")
+        Regex.stripSuffix(regex"\\p{Alpha}+", "AA BBB CCCC") == Some("AA BBB ")
 
     /////////////////////////////////////////////////////////////////////////////
     // indexOfFirst                                                            //
@@ -556,39 +556,39 @@ mod TestRegex {
 
     @test
     def indexOfFirst01(): Bool =
-        Regex.indexOfFirst(substr = regex"\\p{Alpha}+", "") == None
+        Regex.indexOfFirst(regex"\\p{Alpha}+", "") == None
 
     @test
     def indexOfFirst02(): Bool =
-        Regex.indexOfFirst(substr = regex"\\p{Alpha}+", "_") == None
+        Regex.indexOfFirst(regex"\\p{Alpha}+", "_") == None
 
     @test
     def indexOfFirst03(): Bool =
-        Regex.indexOfFirst(substr = regex"\\p{Alpha}+", "a") == Some(0)
+        Regex.indexOfFirst(regex"\\p{Alpha}+", "a") == Some(0)
 
     @test
     def indexOfFirst04(): Bool =
-        Regex.indexOfFirst(substr = regex"\\p{Alpha}+", "__") == None
+        Regex.indexOfFirst(regex"\\p{Alpha}+", "__") == None
 
     @test
     def indexOfFirst05(): Bool =
-        Regex.indexOfFirst(substr = regex"\\p{Alpha}+", "ab") == Some(0)
+        Regex.indexOfFirst(regex"\\p{Alpha}+", "ab") == Some(0)
 
     @test
     def indexOfFirst06(): Bool =
-        Regex.indexOfFirst(substr = regex"\\p{Alpha}+", "_b") == Some(1)
+        Regex.indexOfFirst(regex"\\p{Alpha}+", "_b") == Some(1)
 
     @test
     def indexOfFirst07(): Bool =
-        Regex.indexOfFirst(substr = regex"\\p{Alpha}+", "ab") == Some(0)
+        Regex.indexOfFirst(regex"\\p{Alpha}+", "ab") == Some(0)
 
     @test
     def indexOfFirst08(): Bool =
-        Regex.indexOfFirst(substr = regex"\\p{Alpha}+", "ab_") == Some(0)
+        Regex.indexOfFirst(regex"\\p{Alpha}+", "ab_") == Some(0)
 
     @test
     def indexOfFirst09(): Bool =
-        Regex.indexOfFirst(substr = regex"\\p{Alpha}+", "_bc") == Some(1)
+        Regex.indexOfFirst(regex"\\p{Alpha}+", "_bc") == Some(1)
 
     /////////////////////////////////////////////////////////////////////////////
     // indexOfLast                                                             //
@@ -596,39 +596,39 @@ mod TestRegex {
 
     @test
     def indexOfLast01(): Bool =
-        Regex.indexOfLast(substr = regex"\\p{Alpha}+", "") == None
+        Regex.indexOfLast(regex"\\p{Alpha}+", "") == None
 
     @test
     def indexOfLast02(): Bool =
-        Regex.indexOfLast(substr = regex"\\p{Alpha}+", "_") == None
+        Regex.indexOfLast(regex"\\p{Alpha}+", "_") == None
 
     @test
     def indexOfLast03(): Bool =
-        Regex.indexOfLast(substr = regex"\\p{Alpha}+", "a") == Some(0)
+        Regex.indexOfLast(regex"\\p{Alpha}+", "a") == Some(0)
 
     @test
     def indexOfLast04(): Bool =
-        Regex.indexOfLast(substr = regex"\\p{Alpha}+", "__") == None
+        Regex.indexOfLast(regex"\\p{Alpha}+", "__") == None
 
     @test
     def indexOfLast05(): Bool =
-        Regex.indexOfLast(substr = regex"\\p{Alpha}+", "a_") == Some(0)
+        Regex.indexOfLast(regex"\\p{Alpha}+", "a_") == Some(0)
 
     @test
     def indexOfLast06(): Bool =
-        Regex.indexOfLast(substr = regex"\\p{Alpha}+", "_b") == Some(1)
+        Regex.indexOfLast(regex"\\p{Alpha}+", "_b") == Some(1)
 
     @test
     def indexOfLast07(): Bool =
-        Regex.indexOfLast(substr = regex"\\p{Alpha}+", "aa") == Some(0)
+        Regex.indexOfLast(regex"\\p{Alpha}+", "aa") == Some(0)
 
     @test
     def indexOfLast08(): Bool =
-        Regex.indexOfLast(substr = regex"\\p{Alpha}{2}", "ab") == Some(0)
+        Regex.indexOfLast(regex"\\p{Alpha}{2}", "ab") == Some(0)
 
     @test
     def indexOfLast09(): Bool =
-        Regex.indexOfLast(substr = regex"\\p{Alpha}{2}", "abcd") == Some(2)
+        Regex.indexOfLast(regex"\\p{Alpha}{2}", "abcd") == Some(2)
 
     /////////////////////////////////////////////////////////////////////////////
     // getFirst                                                                //
@@ -636,39 +636,39 @@ mod TestRegex {
 
     @test
     def getFirst01(): Bool =
-        Regex.getFirst(substr = regex"\\p{Alpha}+", "") == None
+        Regex.getFirst(regex"\\p{Alpha}+", "") == None
 
     @test
     def getFirst02(): Bool =
-        Regex.getFirst(substr = regex"\\p{Alpha}+", "_") == None
+        Regex.getFirst(regex"\\p{Alpha}+", "_") == None
 
     @test
     def getFirst03(): Bool =
-        Regex.getFirst(substr = regex"\\p{Alpha}+", "a") == Some("a")
+        Regex.getFirst(regex"\\p{Alpha}+", "a") == Some("a")
 
     @test
     def getFirst04(): Bool =
-        Regex.getFirst(substr = regex"\\p{Alpha}+", "__") == None
+        Regex.getFirst(regex"\\p{Alpha}+", "__") == None
 
     @test
     def getFirst05(): Bool =
-        Regex.getFirst(substr = regex"\\p{Alpha}+", "ab") == Some("ab")
+        Regex.getFirst(regex"\\p{Alpha}+", "ab") == Some("ab")
 
     @test
     def getFirst06(): Bool =
-        Regex.getFirst(substr = regex"\\p{Alpha}+", "_b") == Some("b")
+        Regex.getFirst(regex"\\p{Alpha}+", "_b") == Some("b")
 
     @test
     def getFirst07(): Bool =
-        Regex.getFirst(substr = regex"\\p{Alpha}+", "a_") == Some("a")
+        Regex.getFirst(regex"\\p{Alpha}+", "a_") == Some("a")
 
     @test
     def getFirst08(): Bool =
-        Regex.getFirst(substr = regex"\\p{Alpha}+", "ab_") == Some("ab")
+        Regex.getFirst(regex"\\p{Alpha}+", "ab_") == Some("ab")
 
     @test
     def getFirst09(): Bool =
-        Regex.getFirst(substr = regex"\\p{Alpha}+", "_bc") == Some("bc")
+        Regex.getFirst(regex"\\p{Alpha}+", "_bc") == Some("bc")
 
     /////////////////////////////////////////////////////////////////////////////
     // getLast                                                                 //
@@ -676,39 +676,39 @@ mod TestRegex {
 
     @test
     def getLast01(): Bool =
-        Regex.getLast(substr = regex"\\p{Alpha}+", "") == None
+        Regex.getLast(regex"\\p{Alpha}+", "") == None
 
     @test
     def getLast02(): Bool =
-        Regex.getLast(substr = regex"\\p{Alpha}+", "_") == None
+        Regex.getLast(regex"\\p{Alpha}+", "_") == None
 
     @test
     def getLast03(): Bool =
-        Regex.getLast(substr = regex"\\p{Alpha}+", "a") == Some("a")
+        Regex.getLast(regex"\\p{Alpha}+", "a") == Some("a")
 
     @test
     def getLast04(): Bool =
-        Regex.getLast(substr = regex"\\p{Alpha}+", "__") == None
+        Regex.getLast(regex"\\p{Alpha}+", "__") == None
 
     @test
     def getLast05(): Bool =
-        Regex.getLast(substr = regex"\\p{Alpha}+", "a_") == Some("a")
+        Regex.getLast(regex"\\p{Alpha}+", "a_") == Some("a")
 
     @test
     def getLast06(): Bool =
-        Regex.getLast(substr = regex"\\p{Alpha}+", "_b") == Some("b")
+        Regex.getLast(regex"\\p{Alpha}+", "_b") == Some("b")
 
     @test
     def getLast07(): Bool =
-        Regex.getLast(substr = regex"\\p{Alpha}+", "aa") == Some("aa")
+        Regex.getLast(regex"\\p{Alpha}+", "aa") == Some("aa")
 
     @test
     def getLast08(): Bool =
-        Regex.getLast(substr = regex"\\p{Alpha}{2}", "ab") == Some("ab")
+        Regex.getLast(regex"\\p{Alpha}{2}", "ab") == Some("ab")
 
     @test
     def getLast09(): Bool =
-        Regex.getLast(substr = regex"\\p{Alpha}{2}", "abcd") == Some("cd")
+        Regex.getLast(regex"\\p{Alpha}{2}", "abcd") == Some("cd")
 
     /////////////////////////////////////////////////////////////////////////////
     // indexOfFirstWithOffset                                                  //
@@ -716,47 +716,47 @@ mod TestRegex {
 
     @test
     def indexOfFirstWithOffset01(): Bool =
-        Regex.indexOfFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "") == None
+        Regex.indexOfFirstWithOffset(regex"\\p{Alpha}+", 0, "") == None
 
     @test
     def indexOfFirstWithOffset02(): Bool =
-        Regex.indexOfFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "_") == None
+        Regex.indexOfFirstWithOffset(regex"\\p{Alpha}+", 0, "_") == None
 
     @test
     def indexOfFirstWithOffset03(): Bool =
-        Regex.indexOfFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "a") == Some(0)
+        Regex.indexOfFirstWithOffset(regex"\\p{Alpha}+", 0, "a") == Some(0)
 
     @test
     def indexOfFirstWithOffset04(): Bool =
-        Regex.indexOfFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "a") == None
+        Regex.indexOfFirstWithOffset(regex"\\p{Alpha}+", 1, "a") == None
 
     @test
     def indexOfFirstWithOffset05(): Bool =
-        Regex.indexOfFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "ab") == Some(0)
+        Regex.indexOfFirstWithOffset(regex"\\p{Alpha}+", 0, "ab") == Some(0)
 
     @test
     def indexOfFirstWithOffset06(): Bool =
-        Regex.indexOfFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "aa") == Some(1)
+        Regex.indexOfFirstWithOffset(regex"\\p{Alpha}+", 1, "aa") == Some(1)
 
     @test
     def indexOfFirstWithOffset07(): Bool =
-        Regex.indexOfFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "_b") == Some(1)
+        Regex.indexOfFirstWithOffset(regex"\\p{Alpha}+", 0, "_b") == Some(1)
 
     @test
     def indexOfFirstWithOffset08(): Bool =
-        Regex.indexOfFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "ab ab") == Some(0)
+        Regex.indexOfFirstWithOffset(regex"\\p{Alpha}+", 0, "ab ab") == Some(0)
 
     @test
     def indexOfFirstWithOffset09(): Bool =
-        Regex.indexOfFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "ab ab") == Some(1)
+        Regex.indexOfFirstWithOffset(regex"\\p{Alpha}+", 1, "ab ab") == Some(1)
 
     @test
     def indexOfFirstWithOffset10(): Bool =
-        Regex.indexOfFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 2, "ab ab") == Some(3)
+        Regex.indexOfFirstWithOffset(regex"\\p{Alpha}+", 2, "ab ab") == Some(3)
 
     @test
     def indexOfFirstWithOffset11(): Bool =
-        Regex.indexOfFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 3, "ab ab") == Some(3)
+        Regex.indexOfFirstWithOffset(regex"\\p{Alpha}+", 3, "ab ab") == Some(3)
 
     /////////////////////////////////////////////////////////////////////////////
     // indexOfLastWithOffset                                                   //
@@ -764,55 +764,55 @@ mod TestRegex {
 
     @test
     def indexOfLastWithOffset01(): Bool =
-        Regex.indexOfLastWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "") == None
+        Regex.indexOfLastWithOffset(regex"\\p{Alpha}+", 0, "") == None
 
     @test
     def indexOfLastWithOffset02(): Bool =
-        Regex.indexOfLastWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "_") == None
+        Regex.indexOfLastWithOffset(regex"\\p{Alpha}+", 0, "_") == None
 
     @test
     def indexOfLastWithOffset03(): Bool =
-        Regex.indexOfLastWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "a") == Some(0)
+        Regex.indexOfLastWithOffset(regex"\\p{Alpha}+", 0, "a") == Some(0)
 
     @test
     def indexOfLastWithOffset04(): Bool =
-        Regex.indexOfLastWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "a") == None
+        Regex.indexOfLastWithOffset(regex"\\p{Alpha}+", 1, "a") == None
 
     @test
     def indexOfLastWithOffset05(): Bool =
-        Regex.indexOfLastWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "ab") == Some(1)
+        Regex.indexOfLastWithOffset(regex"\\p{Alpha}+", 1, "ab") == Some(1)
 
     @test
     def indexOfLastWithOffset06(): Bool =
-        Regex.indexOfLastWithOffset(substr = regex"\\p{Alpha}+", offset = 2, "aa") == None
+        Regex.indexOfLastWithOffset(regex"\\p{Alpha}+", 2, "aa") == None
 
     @test
     def indexOfLastWithOffset07(): Bool =
-        Regex.indexOfLastWithOffset(substr = regex"\\p{Alpha}+", offset = 3, "ab") == None
+        Regex.indexOfLastWithOffset(regex"\\p{Alpha}+", 3, "ab") == None
 
     @test
     def indexOfLastWithOffset08(): Bool =
-        Regex.indexOfLastWithOffset(substr = regex"\\p{Alpha}+", offset = 3, "ab ab") == Some(3)
+        Regex.indexOfLastWithOffset(regex"\\p{Alpha}+", 3, "ab ab") == Some(3)
 
     @test
     def indexOfLastWithOffset09(): Bool =
-        Regex.indexOfLastWithOffset(substr = regex"\\p{Alpha}+", offset= 2, "ab ab") == Some(3)
+        Regex.indexOfLastWithOffset(regex"\\p{Alpha}+", 2, "ab ab") == Some(3)
 
     @test
     def indexOfLastWithOffset10(): Bool =
-        Regex.indexOfLastWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "ab ab") == Some(3)
+        Regex.indexOfLastWithOffset(regex"\\p{Alpha}+", 1, "ab ab") == Some(3)
 
     @test
     def indexOfLastWithOffset11(): Bool =
-        Regex.indexOfLastWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "ab ab") == Some(3)
+        Regex.indexOfLastWithOffset(regex"\\p{Alpha}+", 0, "ab ab") == Some(3)
 
     @test
     def indexOfLastWithOffset12(): Bool =
-        Regex.indexOfLastWithOffset(substr = regex"\\p{Alpha}+", offset = -1, "ab ab") == None
+        Regex.indexOfLastWithOffset(regex"\\p{Alpha}+", -1, "ab ab") == None
 
     @test
     def indexOfLastWithOffset13(): Bool =
-        Regex.indexOfLastWithOffset(substr = regex"\\p{Alpha}+", offset = 2, "ab __") == None
+        Regex.indexOfLastWithOffset(regex"\\p{Alpha}+", 2, "ab __") == None
 
     /////////////////////////////////////////////////////////////////////////////
     // getFirstWithOffset                                                      //
@@ -820,47 +820,47 @@ mod TestRegex {
 
     @test
     def getFirstWithOffset01(): Bool =
-        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "") == None
+        Regex.getFirstWithOffset(regex"\\p{Alpha}+", 0, "") == None
 
     @test
     def getFirstWithOffset02(): Bool =
-        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "_") == None
+        Regex.getFirstWithOffset(regex"\\p{Alpha}+", 0, "_") == None
 
     @test
     def getFirstWithOffset03(): Bool =
-        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "a") == Some("a")
+        Regex.getFirstWithOffset(regex"\\p{Alpha}+", 0, "a") == Some("a")
 
     @test
     def getFirstWithOffset04(): Bool =
-        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "a") == None
+        Regex.getFirstWithOffset(regex"\\p{Alpha}+", 1, "a") == None
 
     @test
     def getFirstWithOffset05(): Bool =
-        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "ab") == Some("ab")
+        Regex.getFirstWithOffset(regex"\\p{Alpha}+", 0, "ab") == Some("ab")
 
     @test
     def getFirstWithOffset06(): Bool =
-        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "aa") == Some("a")
+        Regex.getFirstWithOffset(regex"\\p{Alpha}+", 1, "aa") == Some("a")
 
     @test
     def getFirstWithOffset07(): Bool =
-        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "_b") == Some("b")
+        Regex.getFirstWithOffset(regex"\\p{Alpha}+", 0, "_b") == Some("b")
 
     @test
     def getFirstWithOffset08(): Bool =
-        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "ab cd") == Some("ab")
+        Regex.getFirstWithOffset(regex"\\p{Alpha}+", 0, "ab cd") == Some("ab")
 
     @test
     def getFirstWithOffset09(): Bool =
-        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "ab cd") == Some("b")
+        Regex.getFirstWithOffset(regex"\\p{Alpha}+", 1, "ab cd") == Some("b")
 
     @test
     def getFirstWithOffset10(): Bool =
-        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 2, "ab cd") == Some("cd")
+        Regex.getFirstWithOffset(regex"\\p{Alpha}+", 2, "ab cd") == Some("cd")
 
     @test
     def getFirstWithOffset11(): Bool =
-        Regex.getFirstWithOffset(substr = regex"\\p{Alpha}+", offset = 3, "ab cd") == Some("cd")
+        Regex.getFirstWithOffset(regex"\\p{Alpha}+", 3, "ab cd") == Some("cd")
 
     /////////////////////////////////////////////////////////////////////////////
     // getLastWithOffset                                                       //
@@ -868,55 +868,55 @@ mod TestRegex {
 
     @test
     def getLastWithOffset01(): Bool =
-        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "") == None
+        Regex.getLastWithOffset(regex"\\p{Alpha}+", 0, "") == None
 
     @test
     def getLastWithOffset02(): Bool =
-        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "_") == None
+        Regex.getLastWithOffset(regex"\\p{Alpha}+", 0, "_") == None
 
     @test
     def getLastWithOffset03(): Bool =
-        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "a") == Some("a")
+        Regex.getLastWithOffset(regex"\\p{Alpha}+", 0, "a") == Some("a")
 
     @test
     def getLastWithOffset04(): Bool =
-        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "a") == None
+        Regex.getLastWithOffset(regex"\\p{Alpha}+", 1, "a") == None
 
     @test
     def getLastWithOffset05(): Bool =
-        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "ab") == Some("b")
+        Regex.getLastWithOffset(regex"\\p{Alpha}+", 1, "ab") == Some("b")
 
     @test
     def getLastWithOffset06(): Bool =
-        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 2, "aa") == None
+        Regex.getLastWithOffset(regex"\\p{Alpha}+", 2, "aa") == None
 
     @test
     def getLastWithOffset07(): Bool =
-        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 3, "ab") == None
+        Regex.getLastWithOffset(regex"\\p{Alpha}+", 3, "ab") == None
 
     @test
     def getLastWithOffset08(): Bool =
-        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 3, "ab cd") == Some("cd")
+        Regex.getLastWithOffset(regex"\\p{Alpha}+", 3, "ab cd") == Some("cd")
 
     @test
     def getLastWithOffset09(): Bool =
-        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset= 2, "ab cd") == Some("cd")
+        Regex.getLastWithOffset(regex"\\p{Alpha}+", 2, "ab cd") == Some("cd")
 
     @test
     def getLastWithOffset10(): Bool =
-        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 1, "ab cd") == Some("cd")
+        Regex.getLastWithOffset(regex"\\p{Alpha}+", 1, "ab cd") == Some("cd")
 
     @test
     def getLastWithOffset11(): Bool =
-        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 0, "ab cd") == Some("cd")
+        Regex.getLastWithOffset(regex"\\p{Alpha}+", 0, "ab cd") == Some("cd")
 
     @test
     def getLastWithOffset12(): Bool =
-        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = -1, "ab cd") == None
+        Regex.getLastWithOffset(regex"\\p{Alpha}+", -1, "ab cd") == None
 
     @test
     def getLastWithOffset13(): Bool =
-        Regex.getLastWithOffset(substr = regex"\\p{Alpha}+", offset = 2, "ab __") == None
+        Regex.getLastWithOffset(regex"\\p{Alpha}+", 2, "ab __") == None
 
     /////////////////////////////////////////////////////////////////////////////
     // breakOnFirst                                                            //
@@ -924,35 +924,35 @@ mod TestRegex {
 
     @test
     def breakOnFirst01(): Bool =
-        Regex.breakOnFirst(substr = regex":{2}", "") == ("", "")
+        Regex.breakOnFirst(regex":{2}", "") == ("", "")
 
     @test
     def breakOnFirst02(): Bool =
-        Regex.breakOnFirst(substr = regex":{2}", "aaa") == ("aaa", "")
+        Regex.breakOnFirst(regex":{2}", "aaa") == ("aaa", "")
 
     @test
     def breakOnFirst03(): Bool =
-        Regex.breakOnFirst(substr = regex":{2}", "::") == ("", "::")
+        Regex.breakOnFirst(regex":{2}", "::") == ("", "::")
 
     @test
     def breakOnFirst04(): Bool =
-        Regex.breakOnFirst(substr = regex":{2}", "::aaa") == ("", "::aaa")
+        Regex.breakOnFirst(regex":{2}", "::aaa") == ("", "::aaa")
 
     @test
     def breakOnFirst05(): Bool =
-        Regex.breakOnFirst(substr = regex":{2}", "aaa:") == ("aaa:", "")
+        Regex.breakOnFirst(regex":{2}", "aaa:") == ("aaa:", "")
 
     @test
     def breakOnFirst06(): Bool =
-        Regex.breakOnFirst(substr = regex":{2}", "aaa::") == ("aaa", "::")
+        Regex.breakOnFirst(regex":{2}", "aaa::") == ("aaa", "::")
 
     @test
     def breakOnFirst07(): Bool =
-        Regex.breakOnFirst(substr = regex":{2}", "aaa::bbb") == ("aaa", "::bbb")
+        Regex.breakOnFirst(regex":{2}", "aaa::bbb") == ("aaa", "::bbb")
 
     @test
     def breakOnFirst08(): Bool =
-        Regex.breakOnFirst(substr = regex":{2}", "aaa::bbb::ccc") == ("aaa", "::bbb::ccc")
+        Regex.breakOnFirst(regex":{2}", "aaa::bbb::ccc") == ("aaa", "::bbb::ccc")
 
     /////////////////////////////////////////////////////////////////////////////
     // breakAfterFirst                                                         //
@@ -960,35 +960,35 @@ mod TestRegex {
 
     @test
     def breakAfterFirst01(): Bool =
-        Regex.breakAfterFirst(substr = regex":{2}", "") == ("", "")
+        Regex.breakAfterFirst(regex":{2}", "") == ("", "")
 
     @test
     def breakAfterFirst02(): Bool =
-        Regex.breakAfterFirst(substr = regex":{2}", "aaa") == ("aaa", "")
+        Regex.breakAfterFirst(regex":{2}", "aaa") == ("aaa", "")
 
     @test
     def breakAfterFirst03(): Bool =
-        Regex.breakAfterFirst(substr = regex":{2}", "::") == ("::", "")
+        Regex.breakAfterFirst(regex":{2}", "::") == ("::", "")
 
     @test
     def breakAfterFirst04(): Bool =
-        Regex.breakAfterFirst(substr = regex":{2}", "::aaa") == ("::", "aaa")
+        Regex.breakAfterFirst(regex":{2}", "::aaa") == ("::", "aaa")
 
     @test
     def breakAfterFirst05(): Bool =
-        Regex.breakAfterFirst(substr = regex":{2}", "aaa:") == ("aaa:", "")
+        Regex.breakAfterFirst(regex":{2}", "aaa:") == ("aaa:", "")
 
     @test
     def breakAfterFirst06(): Bool =
-        Regex.breakAfterFirst(substr = regex":{2}", "aaa::") == ("aaa::", "")
+        Regex.breakAfterFirst(regex":{2}", "aaa::") == ("aaa::", "")
 
     @test
     def breakAfterFirst07(): Bool =
-        Regex.breakAfterFirst(substr = regex":{2}", "aaa::bbb") == ("aaa::", "bbb")
+        Regex.breakAfterFirst(regex":{2}", "aaa::bbb") == ("aaa::", "bbb")
 
     @test
     def breakAfterFirst08(): Bool =
-        Regex.breakAfterFirst(substr = regex":{2}", "aaa::bbb::ccc") == ("aaa::", "bbb::ccc")
+        Regex.breakAfterFirst(regex":{2}", "aaa::bbb::ccc") == ("aaa::", "bbb::ccc")
 
     /////////////////////////////////////////////////////////////////////////////
     // breakOnLast                                                             //
@@ -996,35 +996,35 @@ mod TestRegex {
 
     @test
     def breakOnLast01(): Bool =
-        Regex.breakOnLast(substr = regex":{2}", "") == ("", "")
+        Regex.breakOnLast(regex":{2}", "") == ("", "")
 
     @test
     def breakOnLast02(): Bool =
-        Regex.breakOnLast(substr = regex":{2}", "aaa") == ("aaa", "")
+        Regex.breakOnLast(regex":{2}", "aaa") == ("aaa", "")
 
     @test
     def breakOnLast03(): Bool =
-        Regex.breakOnLast(substr = regex":{2}", "::") == ("::", "")
+        Regex.breakOnLast(regex":{2}", "::") == ("::", "")
 
     @test
     def breakOnLast04(): Bool =
-        Regex.breakOnLast(substr = regex":{2}", "aaa") == ("aaa", "")
+        Regex.breakOnLast(regex":{2}", "aaa") == ("aaa", "")
 
     @test
     def breakOnLast05(): Bool =
-        Regex.breakOnLast(substr = regex":{2}", "aaa:") == ("aaa:", "")
+        Regex.breakOnLast(regex":{2}", "aaa:") == ("aaa:", "")
 
     @test
     def breakOnLast06(): Bool =
-        Regex.breakOnLast(substr = regex":{2}", "aaa::") == ("aaa::", "")
+        Regex.breakOnLast(regex":{2}", "aaa::") == ("aaa::", "")
 
     @test
     def breakOnLast07(): Bool =
-        Regex.breakOnLast(substr = regex":{2}", "aaa::bbb") == ("aaa::", "bbb")
+        Regex.breakOnLast(regex":{2}", "aaa::bbb") == ("aaa::", "bbb")
 
     @test
     def breakOnLast08(): Bool =
-        Regex.breakOnLast(substr = regex":{2}", "aaa::bbb::ccc") == ("aaa::bbb::", "ccc")
+        Regex.breakOnLast(regex":{2}", "aaa::bbb::ccc") == ("aaa::bbb::", "ccc")
 
     /////////////////////////////////////////////////////////////////////////////
     // breakBeforeLast                                                         //
@@ -1032,35 +1032,35 @@ mod TestRegex {
 
     @test
     def breakBeforeLast01(): Bool =
-        Regex.breakBeforeLast(substr = regex":{2}", "") == ("", "")
+        Regex.breakBeforeLast(regex":{2}", "") == ("", "")
 
     @test
     def breakBeforeLast02(): Bool =
-        Regex.breakBeforeLast(substr = regex":{2}", "aaa") == ("aaa", "")
+        Regex.breakBeforeLast(regex":{2}", "aaa") == ("aaa", "")
 
     @test
     def breakBeforeLast03(): Bool =
-        Regex.breakBeforeLast(substr = regex":{2}", "::") == ("", "::")
+        Regex.breakBeforeLast(regex":{2}", "::") == ("", "::")
 
     @test
     def breakBeforeLast04(): Bool =
-        Regex.breakBeforeLast(substr = regex":{2}", "aaa") == ("aaa", "")
+        Regex.breakBeforeLast(regex":{2}", "aaa") == ("aaa", "")
 
     @test
     def breakBeforeLast05(): Bool =
-        Regex.breakBeforeLast(substr = regex":{2}", "aaa:") == ("aaa:", "")
+        Regex.breakBeforeLast(regex":{2}", "aaa:") == ("aaa:", "")
 
     @test
     def breakBeforeLast06(): Bool =
-        Regex.breakBeforeLast(substr = regex":{2}", "aaa::") == ("aaa", "::")
+        Regex.breakBeforeLast(regex":{2}", "aaa::") == ("aaa", "::")
 
     @test
     def breakBeforeLast07(): Bool =
-        Regex.breakBeforeLast(substr = regex":{2}", "aaa::bbb") == ("aaa", "::bbb")
+        Regex.breakBeforeLast(regex":{2}", "aaa::bbb") == ("aaa", "::bbb")
 
     @test
     def breakBeforeLast08(): Bool =
-        Regex.breakBeforeLast(substr = regex":{2}", "aaa::bbb::ccc") == ("aaa::bbb", "::ccc")
+        Regex.breakBeforeLast(regex":{2}", "aaa::bbb::ccc") == ("aaa::bbb", "::ccc")
 
     /////////////////////////////////////////////////////////////////////////////
     // isMatchWithBounds                                                       //
@@ -1132,27 +1132,27 @@ mod TestRegex {
 
     @test
     def indicesWithBounds01(): Bool =
-        Regex.indicesWithBounds(substr = regex":{2}", start = 0, end = 1, "") == List#{}
+        Regex.indicesWithBounds(regex":{2}", start = 0, end = 1, "") == List#{}
 
     @test
     def indicesWithBounds02(): Bool =
-        Regex.indicesWithBounds(substr = regex":{2}", start = -1, end = 10, "a::b::c") == List#{}
+        Regex.indicesWithBounds(regex":{2}", start = -1, end = 10, "a::b::c") == List#{}
 
     @test
     def indicesWithBounds03(): Bool =
-        Regex.indicesWithBounds(substr = regex":{2}", start = 0, end = 7, "a::b::c") == List#{1, 4}
+        Regex.indicesWithBounds(regex":{2}", start = 0, end = 7, "a::b::c") == List#{1, 4}
 
     @test
     def indicesWithBounds04(): Bool =
-        Regex.indicesWithBounds(substr = regex":{2}", start = 0, end = 3, "a::b::c") == List#{1}
+        Regex.indicesWithBounds(regex":{2}", start = 0, end = 3, "a::b::c") == List#{1}
 
     @test
     def indicesWithBounds05(): Bool =
-        Regex.indicesWithBounds(substr = regex":{2}", start = 3, end = 7, "a::b::c") == List#{4}
+        Regex.indicesWithBounds(regex":{2}", start = 3, end = 7, "a::b::c") == List#{4}
 
     @test
     def indicesWithBounds06(): Bool =
-        Regex.indicesWithBounds(substr = regex":{2}", start = 0, end = 3, "a:b") == List#{}
+        Regex.indicesWithBounds(regex":{2}", start = 0, end = 3, "a:b") == List#{}
 
     /////////////////////////////////////////////////////////////////////////////
     // submatchesWithBounds                                                    //
@@ -1160,55 +1160,55 @@ mod TestRegex {
 
     @test
     def submatchesWithBounds01(): Bool =
-        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "") == List#{}
+        Regex.submatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 1, "") == List#{}
 
     @test
     def submatchesWithBounds02(): Bool =
-        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = -1, end = 10, "a::b::c") == List#{}
+        Regex.submatchesWithBounds(regex"\\p{Alpha}+", start = -1, end = 10, "a::b::c") == List#{}
 
     @test
     def submatchesWithBounds03(): Bool =
-        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 3, "aaa") == List#{"aaa"}
+        Regex.submatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 3, "aaa") == List#{"aaa"}
 
     @test
     def submatchesWithBounds04(): Bool =
-        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 10, "aaa") == List#{}
+        Regex.submatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 10, "aaa") == List#{}
 
     @test
     def submatchesWithBounds05(): Bool =
-        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 2, "::") == List#{}
+        Regex.submatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 2, "::") == List#{}
 
     @test
     def submatchesWithBounds06(): Bool =
-        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 2, "ab") == List#{"ab"}
+        Regex.submatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 2, "ab") == List#{"ab"}
 
     @test
     def submatchesWithBounds07(): Bool =
-        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 3, "::a") == List#{"a"}
+        Regex.submatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 3, "::a") == List#{"a"}
 
     @test
     def submatchesWithBounds08(): Bool =
-        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 3, "a::") == List#{"a"}
+        Regex.submatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 3, "a::") == List#{"a"}
 
     @test
     def submatchesWithBounds09(): Bool =
-        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 3, "a::b::") == List#{"a"}
+        Regex.submatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 3, "a::b::") == List#{"a"}
 
     @test
     def submatchesWithBounds10(): Bool =
-        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 2, end = 7, "a::b::c") == List#{"b", "c"}
+        Regex.submatchesWithBounds(regex"\\p{Alpha}+", start = 2, end = 7, "a::b::c") == List#{"b", "c"}
 
     @test
     def submatchesWithBounds11(): Bool =
-        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c:") == List#{"a", "b", "c"}
+        Regex.submatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c:") == List#{"a", "b", "c"}
 
     @test
     def submatchesWithBounds12(): Bool =
-        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 6, ":a::b::c") == List#{"a", "b"}
+        Regex.submatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 6, ":a::b::c") == List#{"a", "b"}
 
     @test
     def submatchesWithBounds13(): Bool =
-        Regex.submatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 4, "::::") == List#{}
+        Regex.submatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 4, "::::") == List#{}
 
     /////////////////////////////////////////////////////////////////////////////
     // countSubmatchesWithBounds                                               //
@@ -1216,55 +1216,55 @@ mod TestRegex {
 
     @test
     def countSubmatchesWithBounds01(): Bool =
-        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "") == 0
+        Regex.countSubmatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 1, "") == 0
 
     @test
     def countSubmatchesWithBounds02(): Bool =
-        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = -1, end = 10, "a::b::c") == 0
+        Regex.countSubmatchesWithBounds(regex"\\p{Alpha}+", start = -1, end = 10, "a::b::c") == 0
 
     @test
     def countSubmatchesWithBounds03(): Bool =
-        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c") == 3
+        Regex.countSubmatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c") == 3
 
     @test
     def countSubmatchesWithBounds04(): Bool =
-        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 4, "a::b::c") == 2
+        Regex.countSubmatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 4, "a::b::c") == 2
 
     @test
     def countSubmatchesWithBounds05(): Bool =
-        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 1, end = 7, "a::b::c") == 2
+        Regex.countSubmatchesWithBounds(regex"\\p{Alpha}+", start = 1, end = 7, "a::b::c") == 2
 
     @test
     def countSubmatchesWithBounds06(): Bool =
-        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 2, "ab") == 1
+        Regex.countSubmatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 2, "ab") == 1
 
     @test
     def countSubmatchesWithBounds07(): Bool =
-        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 1, end = 3, "::a") == 1
+        Regex.countSubmatchesWithBounds(regex"\\p{Alpha}+", start = 1, end = 3, "::a") == 1
 
     @test
     def countSubmatchesWithBounds08(): Bool =
-        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 2, "a::") == 1
+        Regex.countSubmatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 2, "a::") == 1
 
     @test
     def countSubmatchesWithBounds09(): Bool =
-        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 4, "a::b::") == 2
+        Regex.countSubmatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 4, "a::b::") == 2
 
     @test
     def countSubmatchesWithBounds10(): Bool =
-        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 4, "a::b::c") == 2
+        Regex.countSubmatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 4, "a::b::c") == 2
 
     @test
     def countSubmatchesWithBounds11(): Bool =
-        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 4, end = 8, "a::b::c:") == 1
+        Regex.countSubmatchesWithBounds(regex"\\p{Alpha}+", start = 4, end = 8, "a::b::c:") == 1
 
     @test
     def countSubmatchesWithBounds12(): Bool =
-        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 4, ":a::b::c") == 1
+        Regex.countSubmatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 4, ":a::b::c") == 1
 
     @test
     def countSubmatchesWithBounds13(): Bool =
-        Regex.countSubmatchesWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 4, "::::") == 0
+        Regex.countSubmatchesWithBounds(regex"\\p{Alpha}+", start = 0, end = 4, "::::") == 0
 
     /////////////////////////////////////////////////////////////////////////////
     // indexOfFirstWithBounds                                                  //
@@ -1272,39 +1272,39 @@ mod TestRegex {
 
     @test
     def indexOfFirstWithBounds01(): Bool =
-        Regex.indexOfFirstWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "") == None
+        Regex.indexOfFirstWithBounds(regex"\\p{Alpha}+", start = 0, end = 1, "") == None
 
     @test
     def indexOfFirstWithBounds02(): Bool =
-        Regex.indexOfFirstWithBounds(substr = regex"\\p{Alpha}+", start = -1, end = 5, "a::b") == None
+        Regex.indexOfFirstWithBounds(regex"\\p{Alpha}+", start = -1, end = 5, "a::b") == None
 
     @test
     def indexOfFirstWithBounds03(): Bool =
-        Regex.indexOfFirstWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "a") == Some(0)
+        Regex.indexOfFirstWithBounds(regex"\\p{Alpha}+", start = 0, end = 1, "a") == Some(0)
 
     @test
     def indexOfFirstWithBounds04(): Bool =
-        Regex.indexOfFirstWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c") == Some(0)
+        Regex.indexOfFirstWithBounds(regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c") == Some(0)
 
     @test
     def indexOfFirstWithBounds05(): Bool =
-        Regex.indexOfFirstWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 2, "a::b::c") == Some(0)
+        Regex.indexOfFirstWithBounds(regex"\\p{Alpha}+", start = 0, end = 2, "a::b::c") == Some(0)
 
     @test
     def indexOfFirstWithBounds06(): Bool =
-        Regex.indexOfFirstWithBounds(substr = regex"\\p{Alpha}+", start = 3, end = 7, "a::b::c") == Some(3)
+        Regex.indexOfFirstWithBounds(regex"\\p{Alpha}+", start = 3, end = 7, "a::b::c") == Some(3)
 
     @test
     def indexOfFirstWithBounds07(): Bool =
-        Regex.indexOfFirstWithBounds(substr = regex"\\p{Alpha}+", start = 6, end = 7, "a::b::c") == Some(6)
+        Regex.indexOfFirstWithBounds(regex"\\p{Alpha}+", start = 6, end = 7, "a::b::c") == Some(6)
 
     @test
     def indexOfFirstWithBounds08(): Bool =
-        Regex.indexOfFirstWithBounds(substr = regex"\\p{Alpha}+", start = 1, end = 6, "a::b::c") == Some(3)
+        Regex.indexOfFirstWithBounds(regex"\\p{Alpha}+", start = 1, end = 6, "a::b::c") == Some(3)
 
     @test
     def indexOfFirstWithBounds09(): Bool =
-        Regex.indexOfFirstWithBounds(substr = regex"\\p{Alpha}+", start = 7, end = 9, "a::b::c::") == None
+        Regex.indexOfFirstWithBounds(regex"\\p{Alpha}+", start = 7, end = 9, "a::b::c::") == None
 
     /////////////////////////////////////////////////////////////////////////////
     // indexOfLastWithBounds                                                   //
@@ -1312,39 +1312,39 @@ mod TestRegex {
 
     @test
     def indexOfLastWithBounds01(): Bool =
-        Regex.indexOfLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "") == None
+        Regex.indexOfLastWithBounds(regex"\\p{Alpha}+", start = 0, end = 1, "") == None
 
     @test
     def indexOfLastWithBounds02(): Bool =
-        Regex.indexOfLastWithBounds(substr = regex"\\p{Alpha}+", start = -1, end = 5, "a::b") == None
+        Regex.indexOfLastWithBounds(regex"\\p{Alpha}+", start = -1, end = 5, "a::b") == None
 
     @test
     def indexOfLastWithBounds03(): Bool =
-        Regex.indexOfLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "a") == Some(0)
+        Regex.indexOfLastWithBounds(regex"\\p{Alpha}+", start = 0, end = 1, "a") == Some(0)
 
     @test
     def indexOfLastWithBounds04(): Bool =
-        Regex.indexOfLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c") == Some(6)
+        Regex.indexOfLastWithBounds(regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c") == Some(6)
 
     @test
     def indexOfLastWithBounds05(): Bool =
-        Regex.indexOfLastWithBounds(substr = regex"\\p{Alpha}+", start = 5, end = 7, "a::b::c") == Some(6)
+        Regex.indexOfLastWithBounds(regex"\\p{Alpha}+", start = 5, end = 7, "a::b::c") == Some(6)
 
     @test
     def indexOfLastWithBounds06(): Bool =
-        Regex.indexOfLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 6, "a::b::c") == Some(3)
+        Regex.indexOfLastWithBounds(regex"\\p{Alpha}+", start = 0, end = 6, "a::b::c") == Some(3)
 
     @test
     def indexOfLastWithBounds07(): Bool =
-        Regex.indexOfLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 3, "a::b::c") == Some(0)
+        Regex.indexOfLastWithBounds(regex"\\p{Alpha}+", start = 0, end = 3, "a::b::c") == Some(0)
 
     @test
     def indexOfLastWithBounds08(): Bool =
-        Regex.indexOfLastWithBounds(substr = regex"\\p{Alpha}+", start = 1, end = 6, "a::b::c") == Some(3)
+        Regex.indexOfLastWithBounds(regex"\\p{Alpha}+", start = 1, end = 6, "a::b::c") == Some(3)
 
     @test
     def indexOfLastWithBounds09(): Bool =
-        Regex.indexOfLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 2, "::a::b::c") == None
+        Regex.indexOfLastWithBounds(regex"\\p{Alpha}+", start = 0, end = 2, "::a::b::c") == None
 
     /////////////////////////////////////////////////////////////////////////////
     // getFirstWithBounds                                                      //
@@ -1352,39 +1352,39 @@ mod TestRegex {
 
     @test
     def getFirstWithBounds01(): Bool =
-        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "") == None
+        Regex.getFirstWithBounds(regex"\\p{Alpha}+", start = 0, end = 1, "") == None
 
     @test
     def getFirstWithBounds02(): Bool =
-        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = -1, end = 5, "a::b") == None
+        Regex.getFirstWithBounds(regex"\\p{Alpha}+", start = -1, end = 5, "a::b") == None
 
     @test
     def getFirstWithBounds03(): Bool =
-        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "a") == Some("a")
+        Regex.getFirstWithBounds(regex"\\p{Alpha}+", start = 0, end = 1, "a") == Some("a")
 
     @test
     def getFirstWithBounds04(): Bool =
-        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c") == Some("a")
+        Regex.getFirstWithBounds(regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c") == Some("a")
 
     @test
     def getFirstWithBounds05(): Bool =
-        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 2, "a::b::c") == Some("a")
+        Regex.getFirstWithBounds(regex"\\p{Alpha}+", start = 0, end = 2, "a::b::c") == Some("a")
 
     @test
     def getFirstWithBounds06(): Bool =
-        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 3, end = 7, "a::b::c") == Some("b")
+        Regex.getFirstWithBounds(regex"\\p{Alpha}+", start = 3, end = 7, "a::b::c") == Some("b")
 
     @test
     def getFirstWithBounds07(): Bool =
-        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 6, end = 7, "a::b::c") == Some("c")
+        Regex.getFirstWithBounds(regex"\\p{Alpha}+", start = 6, end = 7, "a::b::c") == Some("c")
 
     @test
     def getFirstWithBounds08(): Bool =
-        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 1, end = 6, "a::b::c") == Some("b")
+        Regex.getFirstWithBounds(regex"\\p{Alpha}+", start = 1, end = 6, "a::b::c") == Some("b")
 
     @test
     def getFirstWithBounds09(): Bool =
-        Regex.getFirstWithBounds(substr = regex"\\p{Alpha}+", start = 7, end = 9, "a::b::c::") == None
+        Regex.getFirstWithBounds(regex"\\p{Alpha}+", start = 7, end = 9, "a::b::c::") == None
 
     /////////////////////////////////////////////////////////////////////////////
     // getLastWithBounds                                                       //
@@ -1392,38 +1392,38 @@ mod TestRegex {
 
     @test
     def getLastWithBounds01(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "") == None
+        Regex.getLastWithBounds(regex"\\p{Alpha}+", start = 0, end = 1, "") == None
 
     @test
     def getLastWithBounds02(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = -1, end = 5, "a::b") == None
+        Regex.getLastWithBounds(regex"\\p{Alpha}+", start = -1, end = 5, "a::b") == None
 
     @test
     def getLastWithBounds03(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 1, "a") == Some("a")
+        Regex.getLastWithBounds(regex"\\p{Alpha}+", start = 0, end = 1, "a") == Some("a")
 
     @test
     def getLastWithBounds04(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c") == Some("c")
+        Regex.getLastWithBounds(regex"\\p{Alpha}+", start = 0, end = 7, "a::b::c") == Some("c")
 
     @test
     def getLastWithBounds05(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 5, end = 7, "a::b::c") == Some("c")
+        Regex.getLastWithBounds(regex"\\p{Alpha}+", start = 5, end = 7, "a::b::c") == Some("c")
 
     @test
     def getLastWithBounds06(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 6, "a::b::c") == Some("b")
+        Regex.getLastWithBounds(regex"\\p{Alpha}+", start = 0, end = 6, "a::b::c") == Some("b")
 
     @test
     def getLastWithBounds07(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 3, "a::b::c") == Some("a")
+        Regex.getLastWithBounds(regex"\\p{Alpha}+", start = 0, end = 3, "a::b::c") == Some("a")
 
     @test
     def getLastWithBounds08(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 1, end = 6, "a::b::c") == Some("b")
+        Regex.getLastWithBounds(regex"\\p{Alpha}+", start = 1, end = 6, "a::b::c") == Some("b")
 
     @test
     def getLastWithBounds09(): Bool =
-        Regex.getLastWithBounds(substr = regex"\\p{Alpha}+", start = 0, end = 2, "::a::b::c") == None
+        Regex.getLastWithBounds(regex"\\p{Alpha}+", start = 0, end = 2, "::a::b::c") == None
 
 }


### PR DESCRIPTION
Hey,

First of all, sorry for the bigger change.
Nevertheless, this should address all the points from the issue #9471.
> 1. The first one would be such with only two parameters, one a regex and a string.
> 2. The second one would be such that have more than two parameters, however have different types.
> 3. The third one would be functions that still have to use named parameters, however not all of them need to be named parameters.

Additionally, I've changed one minor thing in the `Regex.flix` even though it was not directly discussed in the issue itself. This would be the renaming of the `split` parameter from `regex` to `rgx` as all the other functions used `rgx` and not `regex`. In the case this should not be wanted, I'll remove the change immediately.

Feel free to ping me at anytime with further improvements for this PR. Thank you^^.

All changes are related to #9471.

