### PR TITLE
feat: support partially qualified name for EnumTagCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -381,8 +381,11 @@ sealed trait Completion {
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.EnumTagCompletion(tag, ap, qualified, inScope) =>
-      val qualifiedName = tag.sym.toString
+    case Completion.EnumTagCompletion(tag, namespace, ap, qualified, inScope) =>
+      val qualifiedName = if (namespace.nonEmpty)
+        namespace.mkString(".") + "." + tag.sym.name
+      else
+        tag.sym.toString
       val name = if (qualified) qualifiedName else tag.sym.name
       val description = if(!qualified) {
         Some(if (inScope) qualifiedName else s"use $qualifiedName")
@@ -814,11 +817,12 @@ object Completion {
     * Represents an Enum Tag completion
     *
     * @param tag        the tag.
+    * @param namespace  the namespace of the tag, if not provided, we use the fully qualified name.
     * @param ap         the anchor position for the use statement.
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the signature is inScope.
     */
-  case class EnumTagCompletion(tag: TypedAst.Case, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
+  case class EnumTagCompletion(tag: TypedAst.Case, namespace: List[String], ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
 
   /**
     * Represents a Module completion


### PR DESCRIPTION
The first PR try to support partially qualified name(`Clr.Green` below, if we call it this way)

Preview:
<img width="738" alt="image" src="https://github.com/user-attachments/assets/c7eff43b-8bf6-43b1-93e8-5946b6d330dc" />

The general procedure would be:
- find if the namespace(`Clr`) is resolved in the local scope
  - If yes, find the fully qualified name(`AMod.BMod.Clr`) of the namespace 
  - Then use the fully qualified name to find the parent construct from root
  - provide partially qualified completions

Actually we can find the construct in the LocalScope directly. But the construct stored there is from former phases(like NamedAst, ResolvedAst), so we will use the map to get the newest version and use it to provide completions.

The parent construct here is Enum, other possible construct could be Sig, Effect and Module.