### PR TITLE
feat: move ident to namespace for QName when there is a trailing dot

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -247,21 +247,10 @@ object CompletionUtils {
   }
 
   /**
-    * Parse given `qn` based on the character immediately following the location.
-    * If the character is a dot, we move the ident to the namespace.
-    * Otherwise, we will just take namespace and ident out of qn.
-    *
-    * Example:
-    *   - Source "A.B.C", QName(["A", "B"], "C") -> ("A.B", "C")
-    *   - Source "A.B.C.", QName(["A", "B"], "C") -> ("A.B.C", "")
+    * Get the namespace and ident from the qualified name.
     */
   def getNamespaceAndIdentFromQName(qn: QName): (List[String], String) = {
-    val ident = if (qn.trailingDot) "" else qn.ident.name
-    val namespace = qn.namespace.idents.map(_.name) ++ {
-      if (qn.trailingDot) List(qn.ident.name)
-      else Nil
-    }
-    (namespace, ident)
+    (qn.namespace.idents.map(_.name), qn.ident.name)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Name.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Name.scala
@@ -160,6 +160,12 @@ object Name {
     * @param namespace    the namespace
     * @param ident        the identifier.
     * @param loc          the source location of the qualified name.
+    *
+    * Note that the ident could be empty if there is a trailing dot.
+    *
+    * Example:
+    *   - "A.B.Color" -> namespace = ["A", "B"], ident = "Color"
+    *   - "A.B." -> namespace = ["A", "B"], ident = ""
     */
   case class QName(namespace: NName, ident: Ident, loc: SourceLocation) {
     /**

--- a/main/src/ca/uwaterloo/flix/language/ast/Name.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Name.scala
@@ -160,45 +160,13 @@ object Name {
     * @param namespace    the namespace
     * @param ident        the identifier.
     * @param loc          the source location of the qualified name.
-    * @param trailingDot  `true` if the qualified name ends with a dot (which implies this name is incomplete)
     */
-  case class QName(namespace: NName, ident: Ident, loc: SourceLocation, trailingDot: Boolean = false) {
+  case class QName(namespace: NName, ident: Ident, loc: SourceLocation) {
     /**
       * Returns `true` if this name is unqualified (i.e. has no namespace).
       */
     def isUnqualified: Boolean = namespace.isRoot
 
-    /**
-     * Returns `true` if `this` qualified name is incomplete, i.e. it ends with a dot.
-     *
-     * May return `false` out of an over abundance of caution.
-     *
-     * Note: In some cases this function may give false positives. For example, in:
-     *
-     * {{{
-     *   x.byteValueExact()
-     * }}}
-     *
-     * We report that the QName `x` ends with a dot.
-     */
-    def endsWithDot: Boolean = {
-      // We return false if this source location is unknown.
-      // This should not happen for code that the programmer is writing.
-      if (loc == SourceLocation.Unknown)
-        false
-      else {
-        val lineNumber = loc.sp2.line
-        val columnOffset = loc.sp2.col - 1
-        val line = loc.sp2.source.getLine(lineNumber)
-        if (!(columnOffset < line.length)) {
-          // Out of bounds; return false.
-          false
-        } else {
-          // Within bounds; check if the qname ends with a dot.
-          '.'== line.charAt(columnOffset)
-        }
-      }
-    }
 
     /**
       * Human readable representation.

--- a/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Desugar.scala
@@ -1342,8 +1342,8 @@ object Desugar {
     @tailrec
     def flatten(exp: WeededAst.Expr, acc: List[WeededAst.Expr]): (List[WeededAst.Expr], Option[WeededAst.Expr]) = exp match {
       case WeededAst.Expr.FCons(e1, e2, _) => flatten(e2, e1 :: acc)
-      case WeededAst.Expr.Ambiguous(Name.QName(nname, Name.Ident("Nil", _), _, _), _) if nname.idents == "List" :: Nil => (acc.reverse, None)
-      case WeededAst.Expr.Ambiguous(Name.QName(nname, Name.Ident("Nil", _), _, _), _) if nname.idents.isEmpty => (acc.reverse, None)
+      case WeededAst.Expr.Ambiguous(Name.QName(nname, Name.Ident("Nil", _), _), _) if nname.idents == "List" :: Nil => (acc.reverse, None)
+      case WeededAst.Expr.Ambiguous(Name.QName(nname, Name.Ident("Nil", _), _), _) if nname.idents.isEmpty => (acc.reverse, None)
       case _ => (acc.reverse, Some(exp))
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -705,8 +705,9 @@ object Parser2 {
               loc = currentSourceLocation()
             )
             val mark = open()
+            advance()
             close(mark, TreeKind.TrailingDot)
-            advanceWithError(error)
+            s.errors.append(error)
             continue = false
           } else {
             advance() // Eat the dot
@@ -725,8 +726,9 @@ object Parser2 {
             loc = currentSourceLocation()
           )
           val mark = open()
+          advance()
           close(mark, TreeKind.TrailingDot)
-          advanceWithError(error)
+          s.errors.append(error)
           continue = false
         case _ => continue = false
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3075,11 +3075,12 @@ object Weeder2 {
     val loc = SourceLocation(isReal = true, first.loc.sp1, last.loc.sp2)
 
     // If there is a trailing dot, we use all the idents as namespace and use "" as the ident
+    // The resulting QName will be something like QName(["A", "B"], "")
     if (trailingDot) {
       val nname = Name.NName(idents, loc)
-      val identLoc = SourceLocation(isReal = true, last.loc.sp2, last.loc.sp2)
-      val ident = Name.Ident("", identLoc)
-      Name.QName(nname, ident, loc)
+      val emptyIdentLoc = SourceLocation(isReal = true, last.loc.sp2, last.loc.sp2)
+      val emptyIdent = Name.Ident("", emptyIdentLoc)
+      Name.QName(nname, emptyIdent, loc)
       // Otherwise we use all but the last ident as namespace and the last ident as the ident
     } else{
       val nname = Name.NName(idents.dropRight(1), loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3083,8 +3083,8 @@ object Weeder2 {
       val emptyIdent = Name.Ident("", emptyIdentLoc)
       val qnameLoc = SourceLocation(isReal = true, first.loc.sp1, positionAfterDot)
       Name.QName(nname, emptyIdent, qnameLoc)
+    } else {
       // Otherwise we use all but the last ident as namespace and the last ident as the ident
-    } else{
       val nname = Name.NName(idents.dropRight(1), loc)
       Name.QName(nname, last, loc)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3078,9 +3078,11 @@ object Weeder2 {
     // The resulting QName will be something like QName(["A", "B"], "")
     if (trailingDot) {
       val nname = Name.NName(idents, loc)
-      val emptyIdentLoc = SourceLocation(isReal = true, last.loc.sp2, last.loc.sp2)
+      val positionAfterDot = last.loc.sp2.copy(col = (last.loc.sp2.col + 1).toShort)
+      val emptyIdentLoc = SourceLocation(isReal = true, positionAfterDot, positionAfterDot)
       val emptyIdent = Name.Ident("", emptyIdentLoc)
-      Name.QName(nname, emptyIdent, loc)
+      val qnameLoc = SourceLocation(isReal = true, first.loc.sp1, positionAfterDot)
+      Name.QName(nname, emptyIdent, qnameLoc)
       // Otherwise we use all but the last ident as namespace and the last ident as the ident
     } else{
       val nname = Name.NName(idents.dropRight(1), loc)


### PR DESCRIPTION
Move the last ident to namespace when constructing the QName

Prev:
`A.B.` will be QName(["A"], "B", trailingDot = true)

Now:
`A.B.` will be QName(["A", "B"], "")

And the completer works fine after the change:
<img width="577" alt="image" src="https://github.com/user-attachments/assets/5910949f-1976-4ed4-b381-ffc3773f3674" />
<img width="584" alt="image" src="https://github.com/user-attachments/assets/53fa274c-2393-48ec-bb27-a17f58d7f490" />
<img width="747" alt="image" src="https://github.com/user-attachments/assets/568704c7-ac78-48ae-9f95-e1faf14372e5" />

Note:
- I find the code duplicate in visitQNameExpr and visitQName, and call the latter form the former.
- Next step would be remove `getNamespaceAndIdentFromQName` from all call site. And just pass the qname for completers to use. That will change a lot of code so I left it for the following PR.