### PR TITLE
feat: support semantic tokens for standalone lsp

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
@@ -292,6 +292,7 @@ class VSCodeLspServer(port: Int, o: Options) extends WebSocketServer(new InetSoc
       ("id" -> id) ~ FindReferencesProvider.findRefs(uri, pos)(root)
 
     case Request.SemanticTokens(id, uri) =>
+//      ("id" -> id) ~ ("status" -> ResponseStatus.Success) ~ ("result" -> ("data" -> Nil))
       ("id" -> id) ~ ("status" -> ResponseStatus.Success) ~ ("result" -> ("data" -> SemanticTokensProvider.provideSemanticTokens(uri)(root)))
 
     case Request.InlayHint(id, uri, range) =>

--- a/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
@@ -292,7 +292,6 @@ class VSCodeLspServer(port: Int, o: Options) extends WebSocketServer(new InetSoc
       ("id" -> id) ~ FindReferencesProvider.findRefs(uri, pos)(root)
 
     case Request.SemanticTokens(id, uri) =>
-//      ("id" -> id) ~ ("status" -> ResponseStatus.Success) ~ ("result" -> ("data" -> Nil))
       ("id" -> id) ~ ("status" -> ResponseStatus.Success) ~ ("result" -> ("data" -> SemanticTokensProvider.provideSemanticTokens(uri)(root)))
 
     case Request.InlayHint(id, uri, range) =>


### PR DESCRIPTION
Preview:
<img width="603" alt="image" src="https://github.com/user-attachments/assets/eb603752-a25b-4da9-818c-3c1140136518" />

Note that variables are also highlighted, but their color scheme here is blank:
<img width="293" alt="image" src="https://github.com/user-attachments/assets/982e8baf-6b8f-42f8-a3fd-94f905154afb" />
