### PR TITLE
refactor: make show ast provider return path

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/VSCodeLspServer.scala
@@ -298,7 +298,7 @@ class VSCodeLspServer(port: Int, o: Options) extends WebSocketServer(new InetSoc
       ("id" -> id) ~ ("status" -> ResponseStatus.Success) ~ ("result" -> InlayHintProvider.getInlayHints(uri, range).map(_.toJSON))
 
     case Request.ShowAst(id) =>
-      ("id" -> id) ~ ("status" -> ResponseStatus.Success) ~ ("result" -> ShowAstProvider.showAst()(flix))
+      ("id" -> id) ~ ("status" -> ResponseStatus.Success) ~ ("result" -> ("path" -> ShowAstProvider.showAst()(flix).toAbsolutePath.toString))
 
     case Request.CodeAction(id, uri, range, _) =>
       ("id" -> id) ~ ("status" -> ResponseStatus.Success) ~ ("result" -> CodeActionProvider.getCodeActions(uri, range, currentErrors)(root).map(_.toJSON))

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
@@ -34,15 +34,11 @@ object ShowAstProvider {
     *   - `title` (a string like `Namer.flix.ir`)
     *   - `text` (a string with the ir representation).
     */
-  def showAst()(implicit flix: Flix): JObject = {
+  def showAst()(implicit flix: Flix): Path = {
     val oldOpts = flix.options
     flix.setOptions(oldOpts.copy(xprintphases = true))
     flix.compile()
     flix.setOptions(oldOpts)
-    pathObject(AstPrinter.astFolderPath)
-  }
-
-  private def pathObject(path: Path): JObject = {
-    ("path" -> path.toAbsolutePath.toString)
+    AstPrinter.astFolderPath
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/ShowAstProvider.scala
@@ -29,10 +29,7 @@ import java.nio.file.Path
 object ShowAstProvider {
 
   /**
-    * Returns a JSON object with
-    *
-    *   - `title` (a string like `Namer.flix.ir`)
-    *   - `text` (a string with the ir representation).
+    * Returns a Path
     */
   def showAst()(implicit flix: Flix): Path = {
     val oldOpts = flix.options


### PR DESCRIPTION
The mechanism to open the desired ast file is kind of broken(Not due to the change in this PR).

But the ast is correctly printed.

<img width="743" alt="image" src="https://github.com/user-attachments/assets/19bb94f2-7d66-4cf4-8512-05c5475ef888" />

Will fix the problem in the following PR.