### PR TITLE
test: allow specifying error locations in tests

### DIFF
--- a/main/test/ca/uwaterloo/flix/TestUtils.scala
+++ b/main/test/ca/uwaterloo/flix/TestUtils.scala
@@ -114,7 +114,34 @@ trait TestUtils {
           if (actual.loc == SourceLocation.Unknown) {
             if (!allowUnknown) fail("Error contains unknown source location.")
           }
+
+          // Check that the error is where specified (according to the ERROR string)
+          getExpectedErrorLine(actual) match {
+            case None => () // fall through
+            case Some(expectedLine) =>
+              val startLine = actual.loc.sp1.line
+              val endLine = actual.loc.sp2.line
+              if (startLine != expectedLine || endLine != expectedLine) {
+                fail(s"Error was expected on line $expectedLine but found on lines $startLine - $endLine.")
+              }
+          }
+
         case None => fail(s"Expected an error of type ${expected.getSimpleName}, but found:\n\n${actuals.map(p => p._2.getName)}.")
       }
+  }
+
+  /**
+    * Returns the line where the error is expected, if specified.
+    */
+  private def getExpectedErrorLine(error: CompilationMessage): Option[Int] = {
+    val content = new String(error.source.data)
+    val expectedIndex = content.linesIterator.indexWhere(_.contains("ERROR"))
+
+    // expectedIndex is -1 if no line contains ERROR
+    // line numbers are offset by 1
+    expectedIndex match {
+      case -1 => None
+      case index => Some(index + 1)
+    }
   }
 }


### PR DESCRIPTION
This change allows a test writer to specify where an error is expected.

For example, I can do this:
```
  test("TestLeq02") {
    val input =
      """
        |def foo(): List[a] = 21 :: Nil // ERROR
        |
        |enum List[t] {
        |    case Nil,
        |    case Cons(t, List[t])
        |}
      """.stripMargin
    val result = compile(input, Options.TestWithLibNix)
    expectError[TypeError](result)
  }
```

Which will ensure the error is on the second line, and fail the test if it is not.