### PR TITLE
feat: provide semantic tokens to constants

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -333,7 +333,35 @@ object SemanticTokensProvider {
 
     case Expr.Use(_, _, exp, _) => visitExp(exp) // TODO NS-REFACTOR add token for sym
 
-    case cst: Expr.Cst => visitCst(cst)
+    case Expr.Cst(Constant.Str(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.String, Nil, loc))
+
+    case Expr.Cst(Constant.Char(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.String, Nil, loc))
+
+    case Expr.Cst(Constant.Int8(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+
+    case Expr.Cst(Constant.Int16(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+
+    case Expr.Cst(Constant.Int32(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+
+    case Expr.Cst(Constant.Int64(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+
+    case Expr.Cst(Constant.BigInt(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+
+    case Expr.Cst(Constant.Float32(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+
+    case Expr.Cst(Constant.Float64(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+
+    case Expr.Cst(Constant.BigDecimal(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+
+    case Expr.Cst(_: Constant.Regex, _, loc) => Iterator(SemanticToken(SemanticTokenType.Regexp, Nil, loc))
+
+    case Expr.Cst(_: Constant.Bool, _, loc) => Iterator(SemanticToken(SemanticTokenType.Type, Nil, loc))
+
+    case Expr.Cst(Constant.Unit, _, loc) => Iterator(SemanticToken(SemanticTokenType.Type, Nil, loc))
+
+    case Expr.Cst(Constant.Null, _, loc) => Iterator(SemanticToken(SemanticTokenType.Type, Nil, loc))
+
+    case Expr.Cst(Constant.RecordEmpty, _, loc) => Iterator(SemanticToken(SemanticTokenType.Type, Nil, loc))
 
     case Expr.Lambda(fparam, exp, _, _) =>
       visitFormalParam(fparam) ++ visitExp(exp)
@@ -624,24 +652,6 @@ object SemanticTokensProvider {
     */
   private def visitExps(exps0: List[Expr]): Iterator[SemanticToken] =
     exps0.flatMap(visitExp).iterator
-
-  private def visitCst(constant: Expr.Cst): Iterator[SemanticToken] = constant.cst match {
-    case _ : Constant.Str |
-         _ : Constant.Char => Iterator(SemanticToken(SemanticTokenType.String, Nil, constant.loc))
-    case _ : Constant.Int8 |
-         _ : Constant.Int16 |
-         _ : Constant.Int32 |
-         _ : Constant.Int64 |
-         _ : Constant.BigInt |
-         _ : Constant.Float32 |
-         _ : Constant.Float64 |
-         _ : Constant.BigDecimal => Iterator(SemanticToken(SemanticTokenType.Number, Nil, constant.loc))
-    case _ : Constant.Regex => Iterator(SemanticToken(SemanticTokenType.Regexp, Nil, constant.loc))
-    case _ : Constant.Bool |
-         Constant.Unit |
-         Constant.Null |
-         Constant.RecordEmpty => Iterator(SemanticToken(SemanticTokenType.Type, Nil, constant.loc))
-  }
 
   /**
     * Returns all semantic tokens in the given pattern `pat0`.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -636,8 +636,11 @@ object SemanticTokensProvider {
          _ : Constant.Float32 |
          _ : Constant.Float64 |
          _ : Constant.BigDecimal => Iterator(SemanticToken(SemanticTokenType.Number, Nil, constant.loc))
-    case _: Constant.Regex => Iterator(SemanticToken(SemanticTokenType.Regexp, Nil, constant.loc))
-    case _ => Iterator(SemanticToken(SemanticTokenType.Type, Nil, constant.loc))
+    case _ : Constant.Regex => Iterator(SemanticToken(SemanticTokenType.Regexp, Nil, constant.loc))
+    case _ : Constant.Bool |
+         Constant.Unit |
+         Constant.Null |
+         Constant.RecordEmpty => Iterator(SemanticToken(SemanticTokenType.Type, Nil, constant.loc))
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -333,7 +333,7 @@ object SemanticTokensProvider {
 
     case Expr.Use(_, _, exp, _) => visitExp(exp) // TODO NS-REFACTOR add token for sym
 
-    case Expr.Cst(_, _, _) => Iterator.empty
+    case cst: Expr.Cst => visitCst(cst)
 
     case Expr.Lambda(fparam, exp, _, _) =>
       visitFormalParam(fparam) ++ visitExp(exp)
@@ -624,6 +624,21 @@ object SemanticTokensProvider {
     */
   private def visitExps(exps0: List[Expr]): Iterator[SemanticToken] =
     exps0.flatMap(visitExp).iterator
+
+  private def visitCst(constant: Expr.Cst): Iterator[SemanticToken] = constant.cst match {
+    case _ : Constant.Str |
+         _ : Constant.Char => Iterator(SemanticToken(SemanticTokenType.String, Nil, constant.loc))
+    case _ : Constant.Int8 |
+         _ : Constant.Int16 |
+         _ : Constant.Int32 |
+         _ : Constant.Int64 |
+         _ : Constant.BigInt |
+         _ : Constant.Float32 |
+         _ : Constant.Float64 |
+         _ : Constant.BigDecimal => Iterator(SemanticToken(SemanticTokenType.Number, Nil, constant.loc))
+    case _: Constant.Regex => Iterator(SemanticToken(SemanticTokenType.Regexp, Nil, constant.loc))
+    case _ => Iterator(SemanticToken(SemanticTokenType.Type, Nil, constant.loc))
+  }
 
   /**
     * Returns all semantic tokens in the given pattern `pat0`.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -333,35 +333,37 @@ object SemanticTokensProvider {
 
     case Expr.Use(_, _, exp, _) => visitExp(exp) // TODO NS-REFACTOR add token for sym
 
-    case Expr.Cst(Constant.Str(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.String, Nil, loc))
+    case Expr.Cst(cst, _, loc) => cst match {
+      case Constant.Unit => Iterator(SemanticToken(SemanticTokenType.Type, Nil, loc))
 
-    case Expr.Cst(Constant.Char(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.String, Nil, loc))
+      case Constant.Null => Iterator(SemanticToken(SemanticTokenType.Type, Nil, loc))
 
-    case Expr.Cst(Constant.Int8(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+      case Constant.Bool(_) => Iterator(SemanticToken(SemanticTokenType.Type, Nil, loc))
 
-    case Expr.Cst(Constant.Int16(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+      case Constant.Char(_) => Iterator(SemanticToken(SemanticTokenType.String, Nil, loc))
 
-    case Expr.Cst(Constant.Int32(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+      case Constant.Float32(_) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
 
-    case Expr.Cst(Constant.Int64(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+      case Constant.Float64(_) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
 
-    case Expr.Cst(Constant.BigInt(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+      case Constant.BigDecimal(_) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
 
-    case Expr.Cst(Constant.Float32(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+      case Constant.Int8(_) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
 
-    case Expr.Cst(Constant.Float64(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+      case Constant.Int16(_) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
 
-    case Expr.Cst(Constant.BigDecimal(_), _, loc) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
+      case Constant.Int32(_) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
 
-    case Expr.Cst(_: Constant.Regex, _, loc) => Iterator(SemanticToken(SemanticTokenType.Regexp, Nil, loc))
+      case Constant.Int64(_) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
 
-    case Expr.Cst(_: Constant.Bool, _, loc) => Iterator(SemanticToken(SemanticTokenType.Type, Nil, loc))
+      case Constant.BigInt(_) => Iterator(SemanticToken(SemanticTokenType.Number, Nil, loc))
 
-    case Expr.Cst(Constant.Unit, _, loc) => Iterator(SemanticToken(SemanticTokenType.Type, Nil, loc))
+      case Constant.Str(_) => Iterator(SemanticToken(SemanticTokenType.String, Nil, loc))
 
-    case Expr.Cst(Constant.Null, _, loc) => Iterator(SemanticToken(SemanticTokenType.Type, Nil, loc))
+      case Constant.Regex(_) => Iterator(SemanticToken(SemanticTokenType.Regexp, Nil, loc))
 
-    case Expr.Cst(Constant.RecordEmpty, _, loc) => Iterator(SemanticToken(SemanticTokenType.Type, Nil, loc))
+      case Constant.RecordEmpty => Iterator(SemanticToken(SemanticTokenType.Type, Nil, loc))
+    }
 
     case Expr.Lambda(fparam, exp, _, _) =>
       visitFormalParam(fparam) ++ visitExp(exp)


### PR DESCRIPTION
Now in nvim, constants are colored:
<img width="761" alt="image" src="https://github.com/user-attachments/assets/769b5863-8d47-4061-94b5-12ba89443fee" />

We should also remove the syntax highlight for vscode and adjust the SemanticTokenTypes used by the client.

Note:
- maybe we can just use the full list of SemanticTokenTypes and Modifiers so that we dont need to change it every time we add something new:
  <img width="659" alt="image" src="https://github.com/user-attachments/assets/d5ccba04-0435-429c-823d-55e6659c34f9" />
- I assign Char and Str the String type
- I assign Regex the Regexp type
- I assign number to Int* Float* BigInt BigDecimal
- The rest falls back to Type