### PR TITLE
feat: support code lens for stand alone lsp

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/CodeLens.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/CodeLens.scala
@@ -15,6 +15,7 @@
  */
 package ca.uwaterloo.flix.api.lsp
 
+import org.eclipse.lsp4j
 import org.json4s.JsonDSL.*
 import org.json4s.*
 
@@ -26,4 +27,11 @@ import org.json4s.*
   */
 case class CodeLens(range: Range, command: Option[Command]) {
   def toJSON: JValue = ("range" -> range.toJSON) ~ ("command" -> command.map(_.toJSON))
+
+  def toLsp4j: lsp4j.CodeLens = {
+    val codeLens = new lsp4j.CodeLens()
+    codeLens.setRange(range.toLsp4j)
+    command.foreach(cmd => codeLens.setCommand(cmd.toLsp4j))
+    codeLens
+  }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
@@ -16,7 +16,7 @@
 package ca.uwaterloo.flix.api.lsp
 
 import ca.uwaterloo.flix.api.lsp.Range
-import ca.uwaterloo.flix.api.lsp.provider.{CodeActionProvider, CompletionProvider, FindReferencesProvider, GotoProvider, HighlightProvider, HoverProvider, InlayHintProvider, RenameProvider, SemanticTokensProvider, SymbolProvider}
+import ca.uwaterloo.flix.api.lsp.provider.{CodeActionProvider, CodeLensProvider, CompletionProvider, FindReferencesProvider, GotoProvider, HighlightProvider, HoverProvider, InlayHintProvider, RenameProvider, SemanticTokensProvider, SymbolProvider}
 import ca.uwaterloo.flix.api.{CrashHandler, Flix}
 import ca.uwaterloo.flix.api.lsp.{Position, PublishDiagnosticsParams}
 import ca.uwaterloo.flix.language.CompilationMessage
@@ -122,6 +122,7 @@ object LspServer {
         )
       )
       serverCapabilities.setCodeActionProvider(true)
+      serverCapabilities.setCodeLensProvider(new CodeLensOptions(true))
       serverCapabilities.setCompletionProvider(new CompletionOptions(true, TriggerChars.asJava))
       serverCapabilities.setReferencesProvider(true)
       serverCapabilities.setDefinitionProvider(true)
@@ -253,6 +254,12 @@ object LspServer {
         .map(messages.Either.forRight[Command, CodeAction])
         .asJava
       CompletableFuture.completedFuture(codeActions)
+    }
+
+    override def codeLens(params: CodeLensParams): CompletableFuture[util.List[_ <: CodeLens]] = {
+      val uri = params.getTextDocument.getUri
+      val codeLens = CodeLensProvider.processCodeLens(uri)(flixLanguageServer.root).map(_.toLsp4j).asJava
+      CompletableFuture.completedFuture(codeLens)
     }
 
     override def completion(params: CompletionParams): CompletableFuture[messages.Either[util.List[CompletionItem], CompletionList]] = {

--- a/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
@@ -90,8 +90,8 @@ object LspServer {
       */
     private var clientCapabilities: ClientCapabilities = _
 
-    private val flixTextDocumentService = new FlixTextDocumentService(this, flixLanguageClient)
-    private val flixWorkspaceService = new FlixWorkspaceService(this, flixLanguageClient)
+    private val flixTextDocumentService = new FlixTextDocumentService(this)
+    private val flixWorkspaceService = new FlixWorkspaceService(this)
 
     /**
       * Initializes the language server.
@@ -207,7 +207,7 @@ object LspServer {
 
 
 
-  private class FlixTextDocumentService(flixLanguageServer: FlixLanguageServer, flixLanguageClient: LanguageClient) extends TextDocumentService {
+  private class FlixTextDocumentService(flixLanguageServer: FlixLanguageServer) extends TextDocumentService {
     /**
       * Called when a text document is opened.
       * If the document is a Flix source file, we add the source code to the Flix instance and check it.
@@ -347,7 +347,7 @@ object LspServer {
     }
   }
 
-  private class FlixWorkspaceService(flixLanguageServer: FlixLanguageServer, flixLanguageClient: LanguageClient) extends WorkspaceService {
+  private class FlixWorkspaceService(flixLanguageServer: FlixLanguageServer) extends WorkspaceService {
     override def didChangeConfiguration(didChangeConfigurationParams: DidChangeConfigurationParams): Unit = {
       System.err.println(s"didChangeConfiguration: $didChangeConfigurationParams")
     }


### PR DESCRIPTION
Preview:
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/21aec8c1-49a0-4776-b982-1a92b3754723" />
<img width="933" alt="image" src="https://github.com/user-attachments/assets/55cb387d-a8e4-41a9-a5e7-8bbdce04a190" />

Note:
- for nvim, we need to first call `vim.lsp.codelens.refresh()` to get the codelens and then use the shortcut `<leader>cl`(which will call `vim.lsp.codelens.run()` to run the codelens. Usually, it's recommended to add this config to refresh automatically:
  ```lua
        vim.api.nvim_create_autocmd({ "BufEnter", "CursorHold", "InsertLeave" }, {
          pattern = "<buffer>",
          callback = function()
            vim.lsp.codelens.refresh({ bufnr = bufnr })
          end,
        })
   ```
  Should we add this to the minimal config? It makes no sense to just gives a shortcut that doesn't work on its own.
- The commands in the received code lens still need to be implemented. In VSCode, these commands are implemented on the client side, which is not available for nvim. Currently I just add some mock method to handle that on the server side. I think it's possible to handle all of them on the server side so that we do not need to implement them every time we support a new IDE.