### PR TITLE
fix: use `System.out` as `PrintStream` in `Main`

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -123,7 +123,7 @@ object Main {
     // check if command was passed.
     try {
       implicit val formatter: Formatter = Formatter.getDefault
-      implicit val out: PrintStream = System.err
+      implicit val out: PrintStream = System.out
 
       cmdOpts.command match {
         case Command.None =>


### PR DESCRIPTION
Why did we use `System.err` before?

- [x] Check it works in vscode

