### PR TITLE
feat: add support for `ImplementationProvider` for standalone lsp

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
@@ -125,6 +125,7 @@ object LspServer {
       serverCapabilities.setCompletionProvider(new CompletionOptions(true, TriggerChars.asJava))
       serverCapabilities.setReferencesProvider(true)
       serverCapabilities.setDefinitionProvider(true)
+      serverCapabilities.setImplementationProvider(true)
       serverCapabilities.setTextDocumentSync(TextDocumentSyncKind.Full)// TODO: make it incremental
 
       serverCapabilities
@@ -301,6 +302,13 @@ object LspServer {
       val pos = Position.fromLsp4j(params.getPosition)
       val references = FindReferencesProvider.findRefs(uri, pos)(flixLanguageServer.root)
       CompletableFuture.completedFuture(references.map(_.toLsp4j).toList.asJava)
+    }
+
+    override def implementation(params: ImplementationParams): CompletableFuture[messages.Either[util.List[_ <: Location], util.List[_ <: LocationLink]]] = {
+      val uri = params.getTextDocument.getUri
+      val pos = Position.fromLsp4j(params.getPosition)
+      val implementation = GotoProvider.processGoto(uri, pos)(flixLanguageServer.root)
+      CompletableFuture.completedFuture(messages.Either.forRight(implementation.map(_.toLsp4j).toList.asJava))
     }
   }
 


### PR DESCRIPTION
will jump to the implementation
<img width="627" alt="image" src="https://github.com/user-attachments/assets/f108d993-3d71-4a68-8028-555491d11a93" />
<img width="682" alt="image" src="https://github.com/user-attachments/assets/99b18218-27d7-4c82-bbcb-62cf594d6fce" />
<img width="1365" alt="image" src="https://github.com/user-attachments/assets/3dd8afbc-13be-4d70-bc73-0a6fc7282546" />
