### PR TITLE
feat: support rename for standalone lsp

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
@@ -311,6 +311,8 @@ object LspServer {
       val pos = Position.fromLsp4j(params.getPosition)
       RenameProvider.processRename(newName, uri, pos)(flixLanguageServer.root) match {
         case Some(rename) => CompletableFuture.completedFuture(rename.toLsp4j)
+
+        // If nothing is found it's OK to return the empty WorkspaceEdit.
         case None => CompletableFuture.completedFuture(new WorkspaceEdit())
       }
     }


### PR DESCRIPTION
<img width="726" alt="image" src="https://github.com/user-attachments/assets/19c016f8-6378-463a-b601-7758ae53008c" />
<img width="695" alt="image" src="https://github.com/user-attachments/assets/4826ec7e-b8b9-46a3-a84a-77cdf21cf9a0" />
<img width="693" alt="image" src="https://github.com/user-attachments/assets/159b5248-4529-46eb-8cb3-f6dfa3173559" />

The capability is the same as the vscode client:
<img width="533" alt="image" src="https://github.com/user-attachments/assets/c0aaf776-447a-4080-8534-e373246aafbc" />

It's ok to return an empty workspaceEdit when there is no edit:
<img width="813" alt="image" src="https://github.com/user-attachments/assets/a92374f1-3e25-43bc-ab9e-5e19e4a6510d" />
