### PR TITLE
fix: use project name from toml instead of project path in build-pkg

### DIFF
--- a/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
+++ b/main/src/ca/uwaterloo/flix/tools/pkg/PackageError.scala
@@ -109,4 +109,11 @@ object PackageError {
     override def message(f: Formatter): String = e.message(f)
   }
 
+  case object MissingManifest extends PackageError {
+    override def message(f: Formatter): String =
+      s"""
+         |Cannot build a package without a `flix.toml` file.
+         |""".stripMargin
+  }
+
 }


### PR DESCRIPTION
Hey,

As reported in the Issue. This PR implements the usage of the project name from the toml file instead of the project path itself as the actual `fpkg` package name.
Additionally, I've introduced a `MissingManifest` error in `PackageError`, however, this is definitely up for debate. 

This PR fixes #9824. 
