### PR TITLE
refactor: make processWorkspaceSymbols return WorkspaceSymbols

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/WorkspaceSymbol.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/WorkspaceSymbol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Nicola Dardanis
+ * Copyright 2025 Chenhao Gao
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,44 +13,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package ca.uwaterloo.flix.api.lsp
 
 import org.json4s.JsonDSL.*
 import org.json4s.*
 
 /**
-  * Represents a `SymbolInformation` in LSP.
+  * Represents a `WorkspaceSymbol` in LSP.
   * Provides information about programming constructs like variables, classes, interfaces etc.
   *
   * @param name           The name of this symbol.
   * @param kind           The kind of this symbol.
   * @param tags           Tags for this symbol.
-  * @param deprecated     Indicates if this symbol is deprecated. (@deprecated Use tags instead)
-  * @param location       The location of this symbol. The location's range is used by a tool
-  *                       to reveal the location in the editor. If the symbol is selected in the
-  *                       tool the range's start information is used to position the cursor. So
-  *                       the range usually spans more then the actual symbol's name and does
-  *                       normally include things like visibility modifiers.
-  *                       The range doesn't have to denote a node range in the sense of a abstract
-  *                       syntax tree. It can therefore not be used to re-construct a hierarchy of
-  *                       the symbols.
   * @param containerName  The name of the symbol containing this symbol. This information is for
   *                       user interface purposes (e.g. to render a qualifier in the user interface
   *                       if necessary). It can't be used to re-infer a hierarchy for the document
   *                       symbols.
+  * @param location       The location of this symbol. Whether a server is allowed to
+  *                       return a location without a range depends on the client
+  *                       capability `workspace.symbol.resolveSupport`.
   */
-case class SymbolInformation(name: String,
-                             kind: SymbolKind,
-                             tags: List[SymbolTag] = Nil,
-                             deprecated: Boolean = false,
-                             location: Location,
-                             containerName: Option[String]) {
-
+case class WorkspaceSymbol(name: String,
+                           kind: SymbolKind,
+                           tags: List[SymbolTag] = Nil,
+                           containerName: Option[String],
+                           location: Location,
+                           ) {
   def toJSON: JValue =
     ("name" -> name) ~
       ("kind" -> JInt(kind.toInt)) ~
-      ("location" -> location.toJSON) ~
       ("tags" -> tags.map(_.toJSON)) ~
-      ("deprecated" -> deprecated) ~
-      ("containerName" -> containerName.orNull)
+      ("containerName" -> containerName.orNull) ~
+      ("location" -> location.toJSON)
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
@@ -15,7 +15,7 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider
 
-import ca.uwaterloo.flix.api.lsp.{DocumentSymbol, Location, Range, SymbolInformation, SymbolKind}
+import ca.uwaterloo.flix.api.lsp.{DocumentSymbol, Location, Range, SymbolKind, WorkspaceSymbol}
 import ca.uwaterloo.flix.language.ast.TypedAst
 import ca.uwaterloo.flix.language.ast.TypedAst.Root
 import ca.uwaterloo.flix.language.fmt.FormatKind.formatKind
@@ -28,13 +28,13 @@ object SymbolProvider {
     * As for now we just match the very beginning of the string with the query string,
     * but a more inclusive matching pattern can be implemented.
     */
-  def processWorkspaceSymbols(query: String)(implicit root: Root): List[SymbolInformation] = {
-    val enums = root.enums.values.filter(_.sym.name.startsWith(query)).flatMap(mkEnumSymbolInformation)
-    val defs = root.defs.values.collect { case d if d.sym.name.startsWith(query) => mkDefSymbolInformation(d) }
-    val traits = root.traits.values.collect { case t if t.sym.name.startsWith(query) => mkTraitSymbolInformation(t) }
-    val sigs = root.sigs.values.collect { case sig if sig.sym.name.startsWith(query) => mkSigSymbolInformation(sig) }
-    val effs = root.effects.values.filter(_.sym.name.startsWith(query)).flatMap(mkEffectSymbolInformation)
-    val structs = root.structs.values.filter(_.sym.name.startsWith(query)).flatMap(mkStructSymbolInformation)
+  def processWorkspaceSymbols(query: String)(implicit root: Root): List[WorkspaceSymbol] = {
+    val enums = root.enums.values.filter(_.sym.name.startsWith(query)).flatMap(mkEnumWorkspaceSymbol)
+    val defs = root.defs.values.collect { case d if d.sym.name.startsWith(query) => mkDefWorkspaceSymbol(d) }
+    val traits = root.traits.values.collect { case t if t.sym.name.startsWith(query) => mkTraitWorkSpaceSymbol(t) }
+    val sigs = root.sigs.values.collect { case sig if sig.sym.name.startsWith(query) => mkSigWorkspaceSymbol(sig) }
+    val effs = root.effects.values.filter(_.sym.name.startsWith(query)).flatMap(mkEffectWorkspaceSymbol)
+    val structs = root.structs.values.filter(_.sym.name.startsWith(query)).flatMap(mkStructWorkspaceSymbol)
     (traits ++ defs ++ enums ++ sigs ++ effs ++ structs).toList
   }
 
@@ -53,9 +53,9 @@ object SymbolProvider {
   /**
     * Returns an Interface SymbolInformation from a Trait node.
     */
-  private def mkTraitSymbolInformation(t: TypedAst.Trait) = t match {
-    case TypedAst.Trait(_, _, _, sym, _, _, _, _, _, _) => SymbolInformation(
-      sym.name, SymbolKind.Interface, Nil, deprecated = false, Location(sym.loc.source.name, Range.from(sym.loc)), None,
+  private def mkTraitWorkSpaceSymbol(t: TypedAst.Trait) = t match {
+    case TypedAst.Trait(_, _, _, sym, _, _, _, _, _, _) => WorkspaceSymbol(
+      sym.name, SymbolKind.Interface, Nil, None, Location(sym.loc.source.name, Range.from(sym.loc)),
     )
   }
 
@@ -96,25 +96,25 @@ object SymbolProvider {
   /**
     * Returns a Method SymbolInformation from a Sig node.
     */
-  private def mkSigSymbolInformation(s: TypedAst.Sig): SymbolInformation = s match {
-    case TypedAst.Sig(sym, _, _, _) => SymbolInformation(
-      sym.name, SymbolKind.Method, Nil, deprecated = false, Location(sym.loc.source.name, Range.from(sym.loc)), None,
+  private def mkSigWorkspaceSymbol(s: TypedAst.Sig): WorkspaceSymbol = s match {
+    case TypedAst.Sig(sym, _, _, _) => WorkspaceSymbol(
+      sym.name, SymbolKind.Method, Nil, None, Location(sym.loc.source.name, Range.from(sym.loc)),
     )
   }
 
   /**
    * Returns a Method SymbolInformation from a Struct node.
    */
-  private def mkStructSymbolInformation(s: TypedAst.Struct): List[SymbolInformation] = s match {
+  private def mkStructWorkspaceSymbol(s: TypedAst.Struct): List[WorkspaceSymbol] = s match {
     case TypedAst.Struct(_, _, _, sym, _, _, fields, _) =>
-      fields.values.map(mkFieldSymbolInformation).toList :+ SymbolInformation(
-      sym.name, SymbolKind.Struct, Nil, deprecated = false, Location(sym.loc.source.name, Range.from(sym.loc)), None,
+      fields.values.map(mkFieldWorkspaceSymbol).toList :+ WorkspaceSymbol(
+      sym.name, SymbolKind.Struct, Nil, None, Location(sym.loc.source.name, Range.from(sym.loc)),
     )
   }
 
-  private def mkFieldSymbolInformation(f: TypedAst.StructField): SymbolInformation = f match {
-    case TypedAst.StructField(sym, _, loc) => SymbolInformation(
-      sym.name, SymbolKind.Field, Nil, deprecated = false, Location(loc.source.name, Range.from(loc)), None,
+  private def mkFieldWorkspaceSymbol(f: TypedAst.StructField): WorkspaceSymbol = f match {
+    case TypedAst.StructField(sym, _, loc) => WorkspaceSymbol(
+      sym.name, SymbolKind.Field, Nil, None, Location(loc.source.name, Range.from(loc)),
     )
   }
 
@@ -145,9 +145,9 @@ object SymbolProvider {
   /**
     * Returns a Function SymbolInformation from a Def node.
     */
-  private def mkDefSymbolInformation(d: TypedAst.Def): SymbolInformation = d match {
-    case TypedAst.Def(sym, _, _, _) => SymbolInformation(
-      sym.name, SymbolKind.Function, Nil, deprecated = false, Location(sym.loc.source.name, Range.from(sym.loc)), None,
+  private def mkDefWorkspaceSymbol(d: TypedAst.Def): WorkspaceSymbol = d match {
+    case TypedAst.Def(sym, _, _, _) => WorkspaceSymbol(
+      sym.name, SymbolKind.Function, Nil, None, Location(sym.loc.source.name, Range.from(sym.loc)),
     )
   }
 
@@ -180,28 +180,28 @@ object SymbolProvider {
     * Returns an Enum DocumentSymbol from an Enum node.
     * It navigates the AST and returns also the Cases of the enum to the returned List.
     */
-  private def mkEnumSymbolInformation(enum0: TypedAst.Enum): List[SymbolInformation] = enum0 match {
+  private def mkEnumWorkspaceSymbol(enum0: TypedAst.Enum): List[WorkspaceSymbol] = enum0 match {
     case TypedAst.Enum(_, _, _, sym, _, _, cases, loc) =>
-      cases.values.map(mkCaseSymbolInformation).toList :+ SymbolInformation(
-        sym.name, SymbolKind.Enum, Nil, deprecated = false, Location(loc.source.name, Range.from(loc)), None,
+      cases.values.map(mkCaseWorkspaecSymbol).toList :+ WorkspaceSymbol(
+        sym.name, SymbolKind.Enum, Nil, None, Location(loc.source.name, Range.from(loc)),
       )
   }
 
   /**
     * Returns an EnumMember SymbolInformation from a Case node.
     */
-  private def mkCaseSymbolInformation(c: TypedAst.Case): SymbolInformation = c match {
-    case TypedAst.Case(sym, _, _, loc) => SymbolInformation(
-      sym.name, SymbolKind.EnumMember, Nil, deprecated = false, Location(loc.source.name, Range.from(loc)), None)
+  private def mkCaseWorkspaecSymbol(c: TypedAst.Case): WorkspaceSymbol = c match {
+    case TypedAst.Case(sym, _, _, loc) => WorkspaceSymbol(
+      sym.name, SymbolKind.EnumMember, Nil, None, Location(loc.source.name, Range.from(loc)))
   }
 
   /**
     * Returns an Interface SymbolInformation from an Effect node.
     */
-  private def mkEffectSymbolInformation(effect: TypedAst.Effect): List[SymbolInformation] = effect match {
+  private def mkEffectWorkspaceSymbol(effect: TypedAst.Effect): List[WorkspaceSymbol] = effect match {
     case TypedAst.Effect(_, _, _, sym, ops, _) =>
-      ops.map(mkOpSymbolInformation) :+ SymbolInformation(
-        sym.name, SymbolKind.Interface, Nil, deprecated = false, Location(sym.loc.source.name, Range.from(sym.loc)), None)
+      ops.map(mkOpWorkspaceSymbol) :+ WorkspaceSymbol(
+        sym.name, SymbolKind.Interface, Nil, None, Location(sym.loc.source.name, Range.from(sym.loc)))
   }
 
   /**
@@ -223,9 +223,9 @@ object SymbolProvider {
   /**
     * Returns an Function SymbolInformation from an Op node.
     */
-  private def mkOpSymbolInformation(op: TypedAst.Op): SymbolInformation = op match {
+  private def mkOpWorkspaceSymbol(op: TypedAst.Op): WorkspaceSymbol = op match {
     case TypedAst.Op(sym, _, _) =>
-      SymbolInformation(sym.name, SymbolKind.Function, Nil, deprecated = false, Location(sym.loc.source.name, Range.from(sym.loc)), None)
+      WorkspaceSymbol(sym.name, SymbolKind.Function, Nil, None, Location(sym.loc.source.name, Range.from(sym.loc)))
   }
 
   /**


### PR DESCRIPTION
I think the go to symbol in workspace relies on the `processWorkspaceSymbols`? Or is there other way to test that it works fine?
<img width="927" alt="image" src="https://github.com/user-attachments/assets/6d2ba1c3-7539-435b-a596-db1dc71779be" />
