### PR TITLE
feat: support workspace symbol for stand alone lsp

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
@@ -128,6 +128,7 @@ object LspServer {
       serverCapabilities.setImplementationProvider(true)
       serverCapabilities.setRenameProvider(new RenameOptions(false))
       serverCapabilities.setDocumentSymbolProvider(true)
+      serverCapabilities.setWorkspaceSymbolProvider(true)
       serverCapabilities.setTextDocumentSync(TextDocumentSyncKind.Full)// TODO: make it incremental
 
       serverCapabilities
@@ -346,6 +347,12 @@ object LspServer {
 
     override def didChangeWatchedFiles(didChangeWatchedFilesParams: DidChangeWatchedFilesParams): Unit = {
       System.err.println(s"didChangeWatchedFiles: $didChangeWatchedFilesParams")
+    }
+
+    override def symbol(params: WorkspaceSymbolParams): CompletableFuture[messages.Either[util.List[_ <: SymbolInformation], util.List[_ <: WorkspaceSymbol]]] = {
+      val query = params.getQuery
+      val symbols = SymbolProvider.processWorkspaceSymbols(query)(flixLanguageServer.root)
+      CompletableFuture.completedFuture(messages.Either.forLeft(symbols.map(_.toLsp4j).asJava))
     }
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/LspServer.scala
@@ -352,7 +352,7 @@ object LspServer {
     override def symbol(params: WorkspaceSymbolParams): CompletableFuture[messages.Either[util.List[_ <: SymbolInformation], util.List[_ <: WorkspaceSymbol]]] = {
       val query = params.getQuery
       val symbols = SymbolProvider.processWorkspaceSymbols(query)(flixLanguageServer.root)
-      CompletableFuture.completedFuture(messages.Either.forLeft(symbols.map(_.toLsp4j).asJava))
+      CompletableFuture.completedFuture(messages.Either.forRight(symbols.map(_.toLsp4j).asJava))
     }
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/WorkspaceSymbol.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/WorkspaceSymbol.scala
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package ca.uwaterloo.flix.api.lsp
 
 import org.eclipse.lsp4j
@@ -49,4 +48,14 @@ case class WorkspaceSymbol(name: String,
       ("tags" -> tags.map(_.toJSON)) ~
       ("containerName" -> containerName.orNull) ~
       ("location" -> location.toJSON)
+
+  def toLsp4j: lsp4j.WorkspaceSymbol = {
+    val ws = new lsp4j.WorkspaceSymbol()
+    ws.setName(name)
+    ws.setKind(kind.toLsp4j)
+    ws.setTags(tags.map(_.toLsp4j).asJava)
+    ws.setContainerName(containerName.orNull)
+    ws.setLocation(lsp4j.jsonrpc.messages.Either.forLeft(location.toLsp4j))
+    ws
+  }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/WorkspaceSymbol.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/WorkspaceSymbol.scala
@@ -16,8 +16,11 @@
 
 package ca.uwaterloo.flix.api.lsp
 
+import org.eclipse.lsp4j
 import org.json4s.JsonDSL.*
 import org.json4s.*
+
+import scala.jdk.CollectionConverters.SeqHasAsJava
 
 /**
   * Represents a `WorkspaceSymbol` in LSP.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SymbolProvider.scala
@@ -35,7 +35,9 @@ object SymbolProvider {
     val sigs = root.sigs.values.collect { case sig if sig.sym.name.startsWith(query) => mkSigWorkspaceSymbol(sig) }
     val effs = root.effects.values.filter(_.sym.name.startsWith(query)).flatMap(mkEffectWorkspaceSymbol)
     val structs = root.structs.values.filter(_.sym.name.startsWith(query)).flatMap(mkStructWorkspaceSymbol)
-    (traits ++ defs ++ enums ++ sigs ++ effs ++ structs).toList
+    (traits ++ defs ++ enums ++ sigs ++ effs ++ structs).toList.filter{
+      case WorkspaceSymbol(_, _, _, _, loc) => loc.uri.startsWith("file://")
+    }
   }
 
   /**


### PR DESCRIPTION
now the content is the same as document symbols
<img width="1318" alt="image" src="https://github.com/user-attachments/assets/d63c37e2-a0d0-440f-9d14-a41be2d57b27" />

Note that I filtered out all the symbols whose uri doesn't starts with "file://", which usually refers to flix standard lib files. nvim will panic over such uris. And these usis do not actaully work on vscode:
<img width="878" alt="image" src="https://github.com/user-attachments/assets/a692c574-804c-42c8-96e4-9a35fab5edee" />
<img width="839" alt="image" src="https://github.com/user-attachments/assets/dcf0223b-d2b0-4c05-bc77-71f51bf5f4d8" />

