### PR TITLE
feat: provide semantic tokens for types

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -427,7 +427,7 @@ object Visitor {
       case Expr.VectorLength(exp, _) =>
         visitExpr(exp)
 
-      case Expr.Ascribe(exp, _, _, _) =>
+      case Expr.Ascribe(exp, _, _, _, _, _) =>
         visitExpr(exp)
 
       case Expr.InstanceOf(exp, _, _) =>

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -541,7 +541,7 @@ object SemanticTokensProvider {
     case Expr.VectorLength(exp, _) =>
       visitExp(exp)
 
-    case Expr.Ascribe(exp, _, expectedType, _, expectedEff, _) =>
+    case Expr.Ascribe(exp, expectedType, expectedEff, _, _, _) =>
       visitExp(exp) ++ expectedType.map(visitType).getOrElse(Iterator.empty) ++ expectedEff.map(visitType).getOrElse(Iterator.empty)
 
     case Expr.InstanceOf(exp, _, _) =>

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -541,8 +541,8 @@ object SemanticTokensProvider {
     case Expr.VectorLength(exp, _) =>
       visitExp(exp)
 
-    case Expr.Ascribe(exp, tpe, _, _) =>
-      visitExp(exp) ++ visitType(tpe)
+    case Expr.Ascribe(exp, _, _, declaredType, declaredEff, _) =>
+      visitExp(exp) ++ declaredType.map(visitType).getOrElse(Iterator()) ++ declaredEff.map(visitType).getOrElse(Iterator())
 
     case Expr.InstanceOf(exp, _, _) =>
       visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -541,8 +541,8 @@ object SemanticTokensProvider {
     case Expr.VectorLength(exp, _) =>
       visitExp(exp)
 
-    case Expr.Ascribe(exp, _, _, declaredType, declaredEff, _) =>
-      visitExp(exp) ++ declaredType.map(visitType).getOrElse(Iterator()) ++ declaredEff.map(visitType).getOrElse(Iterator())
+    case Expr.Ascribe(exp, _, expectedType, _, expectedEff, _) =>
+      visitExp(exp) ++ expectedType.map(visitType).getOrElse(Iterator.empty) ++ expectedEff.map(visitType).getOrElse(Iterator.empty)
 
     case Expr.InstanceOf(exp, _, _) =>
       visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -193,7 +193,7 @@ object TypedAst {
       def tpe: Type = Type.Int32
     }
 
-    case class Ascribe(exp: Expr, tpe: Type, expectedType: Option[Type], eff: Type, expectedEff: Option[Type], loc: SourceLocation) extends Expr
+    case class Ascribe(exp: Expr, expectedType: Option[Type], expectedEff: Option[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class InstanceOf(exp: Expr, clazz: java.lang.Class[?], loc: SourceLocation) extends Expr {
       def eff: Type = exp.eff

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -193,7 +193,7 @@ object TypedAst {
       def tpe: Type = Type.Int32
     }
 
-    case class Ascribe(exp: Expr, tpe: Type, eff: Type, declaredType: Option[Type], declaredEff: Option[Type], loc: SourceLocation) extends Expr
+    case class Ascribe(exp: Expr, tpe: Type, expectedType: Option[Type], eff: Type, expectedEff: Option[Type], loc: SourceLocation) extends Expr
 
     case class InstanceOf(exp: Expr, clazz: java.lang.Class[?], loc: SourceLocation) extends Expr {
       def eff: Type = exp.eff

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -193,7 +193,7 @@ object TypedAst {
       def tpe: Type = Type.Int32
     }
 
-    case class Ascribe(exp: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class Ascribe(exp: Expr, tpe: Type, eff: Type, declaredType: Option[Type], declaredEff: Option[Type], loc: SourceLocation) extends Expr
 
     case class InstanceOf(exp: Expr, clazz: java.lang.Class[?], loc: SourceLocation) extends Expr {
       def eff: Type = exp.eff

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
@@ -78,7 +78,7 @@ object TypedAstOps {
     case Expr.VectorLit(exps, _, _, _) => exps.flatMap(sigSymsOf).toSet
     case Expr.VectorLoad(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
     case Expr.VectorLength(exp, _) => sigSymsOf(exp)
-    case Expr.Ascribe(exp, _, _, _) => sigSymsOf(exp)
+    case Expr.Ascribe(exp, _, _, _, _, _) => sigSymsOf(exp)
     case Expr.InstanceOf(exp, _, _) => sigSymsOf(exp)
     case Expr.CheckedCast(_, exp, _, _, _) => sigSymsOf(exp)
     case Expr.UncheckedCast(exp, _, _, _, _, _) => sigSymsOf(exp)
@@ -272,7 +272,7 @@ object TypedAstOps {
     case Expr.VectorLength(exp, _) =>
       freeVars(exp)
 
-    case Expr.Ascribe(exp, _, _, _) =>
+    case Expr.Ascribe(exp, _, _, _, _, _) =>
       freeVars(exp)
 
     case Expr.Without(exp, _, _, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -67,7 +67,7 @@ object TypedAstPrinter {
     case Expr.VectorLit(exps, _, _, _) => DocAst.Expr.VectorLit(exps.map(print))
     case Expr.VectorLoad(exp1, exp2, _, _, _) => DocAst.Expr.VectorLoad(print(exp1), print(exp2))
     case Expr.VectorLength(exp, _) => DocAst.Expr.VectorLength(print(exp))
-    case Expr.Ascribe(exp, tpe, _, _) => DocAst.Expr.AscriptionTpe(print(exp), TypePrinter.print(tpe))
+    case Expr.Ascribe(exp, tpe, _, _, _, _) => DocAst.Expr.AscriptionTpe(print(exp), TypePrinter.print(tpe))
     case Expr.InstanceOf(exp, clazz, _) => DocAst.Expr.InstanceOf(print(exp), clazz)
     case Expr.CheckedCast(_, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.UncheckedCast(_, _, _, _, _, _) => DocAst.Expr.Unknown

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -67,7 +67,7 @@ object TypedAstPrinter {
     case Expr.VectorLit(exps, _, _, _) => DocAst.Expr.VectorLit(exps.map(print))
     case Expr.VectorLoad(exp1, exp2, _, _, _) => DocAst.Expr.VectorLoad(print(exp1), print(exp2))
     case Expr.VectorLength(exp, _) => DocAst.Expr.VectorLength(print(exp))
-    case Expr.Ascribe(exp, tpe, _, _, _, _) => DocAst.Expr.AscriptionTpe(print(exp), TypePrinter.print(tpe))
+    case Expr.Ascribe(exp, _, _, tpe, _, _) => DocAst.Expr.AscriptionTpe(print(exp), TypePrinter.print(tpe))
     case Expr.InstanceOf(exp, clazz, _) => DocAst.Expr.InstanceOf(print(exp), clazz)
     case Expr.CheckedCast(_, _, _, _, _) => DocAst.Expr.Unknown
     case Expr.UncheckedCast(_, _, _, _, _, _) => DocAst.Expr.Unknown

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -333,7 +333,7 @@ object Dependencies {
     case Expr.VectorLength(exp, _) =>
       visitExp(exp)
 
-    case Expr.Ascribe(exp, tpe, eff, _, _, _) =>
+    case Expr.Ascribe(exp, tpe, _, eff, _, _) =>
       visitExp(exp)
       visitType(tpe)
       visitType(eff)

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -333,7 +333,7 @@ object Dependencies {
     case Expr.VectorLength(exp, _) =>
       visitExp(exp)
 
-    case Expr.Ascribe(exp, tpe, _, eff, _, _) =>
+    case Expr.Ascribe(exp, _, _, tpe, eff, _) =>
       visitExp(exp)
       visitType(tpe)
       visitType(eff)

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -333,7 +333,7 @@ object Dependencies {
     case Expr.VectorLength(exp, _) =>
       visitExp(exp)
 
-    case Expr.Ascribe(exp, tpe, eff, _) =>
+    case Expr.Ascribe(exp, tpe, eff, _, _, _) =>
       visitExp(exp)
       visitType(tpe)
       visitType(eff)

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
@@ -258,7 +258,7 @@ object EffectVerifier {
       expectType(expected, actual, loc)
     case Expr.VectorLength(exp, loc) =>
       visitExp(exp)
-    case Expr.Ascribe(exp, tpe, expectedType, eff, expectedEff, loc) =>
+    case Expr.Ascribe(exp, expectedType, expectedEff, tpe, eff, loc) =>
       visitExp(exp)
     case Expr.InstanceOf(exp, clazz, loc) =>
       visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
@@ -258,7 +258,7 @@ object EffectVerifier {
       expectType(expected, actual, loc)
     case Expr.VectorLength(exp, loc) =>
       visitExp(exp)
-    case Expr.Ascribe(exp, tpe, eff, loc) =>
+    case Expr.Ascribe(exp, tpe, eff, declaredType, declaredEff, loc) =>
       visitExp(exp)
     case Expr.InstanceOf(exp, clazz, loc) =>
       visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
@@ -258,7 +258,7 @@ object EffectVerifier {
       expectType(expected, actual, loc)
     case Expr.VectorLength(exp, loc) =>
       visitExp(exp)
-    case Expr.Ascribe(exp, tpe, eff, declaredType, declaredEff, loc) =>
+    case Expr.Ascribe(exp, tpe, expectedType, eff, expectedEff, loc) =>
       visitExp(exp)
     case Expr.InstanceOf(exp, clazz, loc) =>
       visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -558,7 +558,7 @@ object Lowering {
       val b = visitExp(base)
       LoweredAst.Expr.VectorLength(b, loc)
 
-    case TypedAst.Expr.Ascribe(exp, tpe, _, eff, _, loc) =>
+    case TypedAst.Expr.Ascribe(exp, _, _, tpe, eff, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
       LoweredAst.Expr.Ascribe(e, t, eff, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -558,7 +558,7 @@ object Lowering {
       val b = visitExp(base)
       LoweredAst.Expr.VectorLength(b, loc)
 
-    case TypedAst.Expr.Ascribe(exp, tpe, eff, loc) =>
+    case TypedAst.Expr.Ascribe(exp, tpe, eff, _, _, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
       LoweredAst.Expr.Ascribe(e, t, eff, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -558,7 +558,7 @@ object Lowering {
       val b = visitExp(base)
       LoweredAst.Expr.VectorLength(b, loc)
 
-    case TypedAst.Expr.Ascribe(exp, tpe, eff, _, _, loc) =>
+    case TypedAst.Expr.Ascribe(exp, tpe, _, eff, _, loc) =>
       val e = visitExp(exp)
       val t = visitType(tpe)
       LoweredAst.Expr.Ascribe(e, t, eff, loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -240,7 +240,7 @@ object PatMatch {
 
       case Expr.VectorLength(exp, _) => visitExp(exp)
 
-      case Expr.Ascribe(exp, _, _, _) => visitExp(exp)
+      case Expr.Ascribe(exp, _, _, _, _, _) => visitExp(exp)
 
       case Expr.InstanceOf(exp, _, _) => visitExp(exp)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -232,7 +232,7 @@ object PredDeps {
     case Expr.VectorLength(exp, _) =>
       visitExp(exp)
 
-    case Expr.Ascribe(exp, _, _, _) =>
+    case Expr.Ascribe(exp, _, _, _, _, _) =>
       visitExp(exp)
 
     case Expr.InstanceOf(exp, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -626,7 +626,7 @@ object Redundancy {
     case Expr.VectorLength(exp, _) =>
       visitExp(exp, env0, rc)
 
-    case Expr.Ascribe(exp, _, _, _) =>
+    case Expr.Ascribe(exp, _, _, _, _, _) =>
       visitExp(exp, env0, rc)
 
     case Expr.InstanceOf(exp, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -227,7 +227,7 @@ object Safety {
     case Expr.VectorLength(exp, _) =>
       visitExp(exp)
 
-    case Expr.Ascribe(exp, _, _, _) =>
+    case Expr.Ascribe(exp, _, _, _, _, _) =>
       visitExp(exp)
 
     case Expr.InstanceOf(exp, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -275,9 +275,9 @@ object Stratifier {
       val e = visitExp(exp)
       Expr.VectorLength(e, loc)
 
-    case Expr.Ascribe(exp, tpe, eff, declaredType, declaredEff, loc) =>
+    case Expr.Ascribe(exp, tpe, expectedType, eff, expectedEff, loc) =>
       val e = visitExp(exp)
-      Expr.Ascribe(e, tpe, eff, declaredType, declaredEff, loc)
+      Expr.Ascribe(e, tpe, expectedType, eff, expectedEff, loc)
 
     case Expr.InstanceOf(exp, clazz, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -275,9 +275,9 @@ object Stratifier {
       val e = visitExp(exp)
       Expr.VectorLength(e, loc)
 
-    case Expr.Ascribe(exp, tpe, expectedType, eff, expectedEff, loc) =>
+    case Expr.Ascribe(exp, expectedType, expectedEff, tpe, eff, loc) =>
       val e = visitExp(exp)
-      Expr.Ascribe(e, tpe, expectedType, eff, expectedEff, loc)
+      Expr.Ascribe(e, expectedType, expectedEff, tpe, eff, loc)
 
     case Expr.InstanceOf(exp, clazz, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -275,9 +275,9 @@ object Stratifier {
       val e = visitExp(exp)
       Expr.VectorLength(e, loc)
 
-    case Expr.Ascribe(exp, tpe, eff, loc) =>
+    case Expr.Ascribe(exp, tpe, eff, declaredType, declaredEff, loc) =>
       val e = visitExp(exp)
-      Expr.Ascribe(e, tpe, eff, loc)
+      Expr.Ascribe(e, tpe, eff, declaredType, declaredEff, loc)
 
     case Expr.InstanceOf(exp, clazz, loc) =>
       val e = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -349,7 +349,7 @@ object TypeReconstruction {
     case KindedAst.Expr.Ascribe(exp, expectedType, expectedEff, tvar, loc) =>
       val e = visitExp(exp)
       val eff = e.eff
-      TypedAst.Expr.Ascribe(e, subst(tvar), expectedType, eff, expectedEff, loc)
+      TypedAst.Expr.Ascribe(e, expectedType, expectedEff, subst(tvar), eff, loc)
 
     case KindedAst.Expr.InstanceOf(exp, clazz, loc) =>
       val e1 = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -346,10 +346,10 @@ object TypeReconstruction {
       val e = visitExp(exp)
       TypedAst.Expr.VectorLength(e, loc)
 
-    case KindedAst.Expr.Ascribe(exp, _, _, tvar, loc) =>
+    case KindedAst.Expr.Ascribe(exp, declaredType, declaredEff, tvar, loc) =>
       val e = visitExp(exp)
       val eff = e.eff
-      TypedAst.Expr.Ascribe(e, subst(tvar), eff, loc)
+      TypedAst.Expr.Ascribe(e, subst(tvar), eff, declaredType, declaredEff, loc)
 
     case KindedAst.Expr.InstanceOf(exp, clazz, loc) =>
       val e1 = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -346,10 +346,10 @@ object TypeReconstruction {
       val e = visitExp(exp)
       TypedAst.Expr.VectorLength(e, loc)
 
-    case KindedAst.Expr.Ascribe(exp, declaredType, declaredEff, tvar, loc) =>
+    case KindedAst.Expr.Ascribe(exp, expectedType, expectedEff, tvar, loc) =>
       val e = visitExp(exp)
       val eff = e.eff
-      TypedAst.Expr.Ascribe(e, subst(tvar), eff, declaredType, declaredEff, loc)
+      TypedAst.Expr.Ascribe(e, subst(tvar), expectedType, eff, expectedEff, loc)
 
     case KindedAst.Expr.InstanceOf(exp, clazz, loc) =>
       val e1 = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
@@ -347,11 +347,10 @@ object TypeReconstruction2 {
       val e = visitExp(exp)
       TypedAst.Expr.VectorLength(e, loc)
 
-    case KindedAst.Expr.Ascribe(exp, tpe, _, tvar, loc) =>
+    case KindedAst.Expr.Ascribe(exp, declaredType, declaredEff, tvar, loc) =>
       val e = visitExp(exp)
       val eff = e.eff
-      val t = tpe.getOrElse(subst(tvar))
-      TypedAst.Expr.Ascribe(e, t, eff, loc)
+      TypedAst.Expr.Ascribe(e, subst(tvar), eff, declaredType, declaredEff, loc)
 
     case KindedAst.Expr.InstanceOf(exp, clazz, loc) =>
       val e1 = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
@@ -347,10 +347,10 @@ object TypeReconstruction2 {
       val e = visitExp(exp)
       TypedAst.Expr.VectorLength(e, loc)
 
-    case KindedAst.Expr.Ascribe(exp, declaredType, declaredEff, tvar, loc) =>
+    case KindedAst.Expr.Ascribe(exp, expectedType, expectedEff, tvar, loc) =>
       val e = visitExp(exp)
       val eff = e.eff
-      TypedAst.Expr.Ascribe(e, subst(tvar), eff, declaredType, declaredEff, loc)
+      TypedAst.Expr.Ascribe(e, subst(tvar), expectedType, eff, expectedEff, loc)
 
     case KindedAst.Expr.InstanceOf(exp, clazz, loc) =>
       val e1 = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
@@ -350,7 +350,7 @@ object TypeReconstruction2 {
     case KindedAst.Expr.Ascribe(exp, expectedType, expectedEff, tvar, loc) =>
       val e = visitExp(exp)
       val eff = e.eff
-      TypedAst.Expr.Ascribe(e, subst(tvar), expectedType, eff, expectedEff, loc)
+      TypedAst.Expr.Ascribe(e, expectedType, expectedEff, subst(tvar), eff, loc)
 
     case KindedAst.Expr.InstanceOf(exp, clazz, loc) =>
       val e1 = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction2.scala
@@ -347,10 +347,11 @@ object TypeReconstruction2 {
       val e = visitExp(exp)
       TypedAst.Expr.VectorLength(e, loc)
 
-    case KindedAst.Expr.Ascribe(exp, _, _, tvar, loc) =>
+    case KindedAst.Expr.Ascribe(exp, tpe, _, tvar, loc) =>
       val e = visitExp(exp)
       val eff = e.eff
-      TypedAst.Expr.Ascribe(e, subst(tvar), eff, loc)
+      val t = tpe.getOrElse(subst(tvar))
+      TypedAst.Expr.Ascribe(e, t, eff, loc)
 
     case KindedAst.Expr.InstanceOf(exp, clazz, loc) =>
       val e1 = visitExp(exp)

--- a/main/src/ca/uwaterloo/flix/tools/Summary.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Summary.scala
@@ -234,7 +234,7 @@ object Summary {
     case Expr.VectorLit(exps, _, _, _) => exps.map(countCheckedEcasts).sum
     case Expr.VectorLoad(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
     case Expr.VectorLength(exp, _) => countCheckedEcasts(exp)
-    case Expr.Ascribe(exp, _, _, _) => countCheckedEcasts(exp)
+    case Expr.Ascribe(exp, _, _, _, _, _) => countCheckedEcasts(exp)
     case Expr.InstanceOf(exp, _, _) => countCheckedEcasts(exp)
     case Expr.CheckedCast(CheckedCastType.EffectCast, exp, _, _, _) => 1 + countCheckedEcasts(exp)
     case Expr.CheckedCast(CheckedCastType.TypeCast, exp, _, _, _) => countCheckedEcasts(exp)


### PR DESCRIPTION
fixes #9931
Fix the problem in Ascribe, now we can highlight most of the cases for types:
<img width="236" alt="image" src="https://github.com/user-attachments/assets/2abdd8c9-9ab4-4ce2-94ed-43459e2b4bdc" />
