### PR TITLE
feat: use qname directly in completers

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -248,21 +248,14 @@ object CompletionUtils {
   }
 
   /**
-    * Get the namespace and ident from the qualified name.
-    */
-  def getNamespaceAndIdentFromQName(qn: Name.QName): (List[String], String) = {
-    (qn.namespace.idents.map(_.name), qn.ident.name)
-  }
-
-  /**
    * Checks if the namespace and ident from the error matches the qualified name.
    * We require a full match on the namespace and a fuzzy match on the ident.
    *
    * Example:
    *   matchesQualifiedName(["A", "B"], "fooBar", ["A", "B"], "fB") => true
    */
-  def matchesQualifiedName(targetNamespace: List[String], targetIdent:String, namespace: List[String], ident: String): Boolean = {
-    targetNamespace == namespace && fuzzyMatch(ident, targetIdent)
+  def matchesQualifiedName(targetNamespace: List[String], targetIdent:String, qn: Name.QName): Boolean = {
+    targetNamespace == qn.namespace.parts && fuzzyMatch(qn.ident.name, targetIdent)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.DefCompletion
 import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.{fuzzyMatch, matchesQualifiedName}
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Def
-import ca.uwaterloo.flix.language.ast.TypedAst
+import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
 import ca.uwaterloo.flix.language.ast.shared.{LocalScope, Resolution}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
@@ -28,15 +28,15 @@ object DefCompleter {
     * Whether the returned completions are qualified is based on whether the UndefinaedName is qualified.
     * When providing completions for unqualified defs that is not in scope, we will also automatically use the def.
     */
-  def getCompletions(err: ResolutionError.UndefinedName, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] ={
-    if (namespace.nonEmpty)
+  def getCompletions(err: ResolutionError.UndefinedName)(implicit root: TypedAst.Root): Iterable[Completion] ={
+    if (err.qn.namespace.nonEmpty)
       root.defs.values.collect{
-        case decl if matchesDef(decl, namespace, ident, err.loc.source.name, qualified = true) =>
+        case decl if matchesDef(decl, err.qn, err.loc.source.name, qualified = true) =>
           DefCompletion(decl, err.ap, qualified = true, inScope = true)
       }
     else
       root.defs.values.collect{
-        case decl if matchesDef(decl, namespace, ident, err.loc.source.name, qualified = false) =>
+        case decl if matchesDef(decl, err.qn, err.loc.source.name, qualified = false) =>
           DefCompletion(decl, err.ap, qualified = false, inScope = inScope(decl, err.env))
       }
   }
@@ -59,13 +59,13 @@ object DefCompleter {
     * Checks if the definition matches the QName.
     * Names should match and the definition should be available.
     */
-  private def matchesDef(decl: TypedAst.Def, namespace: List[String], ident: String, uri: String, qualified: Boolean): Boolean = {
+  private def matchesDef(decl: TypedAst.Def, qn: Name.QName, uri: String, qualified: Boolean): Boolean = {
     val isPublic = decl.spec.mod.isPublic && !decl.spec.ann.isInternal
     val isInFile = decl.sym.loc.source.name == uri
     val isMatch = if (qualified)
-      matchesQualifiedName(decl.sym.namespace, decl.sym.name, namespace, ident)
+      matchesQualifiedName(decl.sym.namespace, decl.sym.name, qn)
     else
-      fuzzyMatch(ident, decl.sym.name)
+      fuzzyMatch(qn.ident.name, decl.sym.name)
     isMatch && (isPublic || isInFile)
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EffectCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EffectCompleter.scala
@@ -2,7 +2,7 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.EffectCompletion
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Effect
-import ca.uwaterloo.flix.language.ast.TypedAst
+import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
@@ -12,23 +12,23 @@ object EffectCompleter {
     * Whether the returned completions are qualified is based on whether the name in the error is qualified.
     * When providing completions for unqualified enums that is not in scope, we will also automatically use the enum.
     */
-  def getCompletions(err: ResolutionError.UndefinedType, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    getCompletions(err.qn.loc.source.name, err.ap, err.env, namespace, ident)
+  def getCompletions(err: ResolutionError.UndefinedType)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    getCompletions(err.qn.loc.source.name, err.ap, err.env, err.qn)
   }
 
-  def getCompletions(err: ResolutionError.UndefinedName, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    getCompletions(err.qn.loc.source.name, err.ap, err.env, namespace, ident)
+  def getCompletions(err: ResolutionError.UndefinedName)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    getCompletions(err.qn.loc.source.name, err.ap, err.env, err.qn)
   }
 
-  private def getCompletions(uri: String, ap: AnchorPosition, env: LocalScope, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    if (namespace.nonEmpty)
+  private def getCompletions(uri: String, ap: AnchorPosition, env: LocalScope, qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    if (qn.namespace.nonEmpty)
       root.effects.values.collect{
-        case effect if matchesEffect(effect, namespace, ident, uri, qualified = true) =>
+        case effect if matchesEffect(effect, qn, uri, qualified = true) =>
           EffectCompletion(effect, ap, qualified = true, inScope = true)
       }
     else
       root.effects.values.collect({
-        case effect if matchesEffect(effect, namespace, ident, uri, qualified = false) =>
+        case effect if matchesEffect(effect, qn, uri, qualified = false) =>
           EffectCompletion(effect, ap, qualified = false, inScope = inScope(effect, env))
       })
   }
@@ -51,13 +51,13 @@ object EffectCompleter {
     * Checks if the definition matches the QName.
     * Names should match and the definition should be available.
     */
-  private def matchesEffect(effect: TypedAst.Effect, namespace: List[String], ident: String, uri: String, qualified: Boolean): Boolean = {
+  private def matchesEffect(effect: TypedAst.Effect, qn: Name.QName, uri: String, qualified: Boolean): Boolean = {
     val isPublic = effect.mod.isPublic && !effect.ann.isInternal
     val isInFile = effect.sym.loc.source.name == uri
     val isMatch = if (qualified) {
-      CompletionUtils.matchesQualifiedName(effect.sym.namespace, effect.sym.name, namespace, ident)
+      CompletionUtils.matchesQualifiedName(effect.sym.namespace, effect.sym.name, qn)
     } else
-      CompletionUtils.fuzzyMatch(ident, effect.sym.name)
+      CompletionUtils.fuzzyMatch(qn.ident.name, effect.sym.name)
     isMatch && (isPublic || isInFile)
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagCompleter.scala
@@ -19,33 +19,31 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.EnumTagCompletion
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Case, Enum}
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
-import ca.uwaterloo.flix.language.ast.TypedAst
+import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
 import ca.uwaterloo.flix.language.errors.ResolutionError
-
-import scala.collection.mutable.ArrayBuffer
 
 object EnumTagCompleter {
   /**
     * Returns a List of Completion for Tag for UndefinedName.
     */
-  def getCompletions(err: ResolutionError.UndefinedName, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    getCompletions(err.loc.source.name, err.ap, err.env, namespace, ident)
+  def getCompletions(err: ResolutionError.UndefinedName)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    getCompletions(err.loc.source.name, err.ap, err.env, err.qn)
   }
 
   /**
     * Returns a List of Completion for Tag for UndefinedTag.
     */
-  def getCompletions(err: ResolutionError.UndefinedTag, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    getCompletions(err.loc.source.name, err.ap, err.env, namespace, ident)
+  def getCompletions(err: ResolutionError.UndefinedTag)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    getCompletions(err.loc.source.name, err.ap, err.env, err.qn)
   }
 
-  private def getCompletions(uri: String, ap: AnchorPosition, env: LocalScope, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    if (namespace.nonEmpty)
-        fullyQualifiedCompletion(uri, ap, namespace, ident) ++ partiallyQualifiedCompletions(uri, ap, env, namespace, ident)
+  private def getCompletions(uri: String, ap: AnchorPosition, env: LocalScope, qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    if (qn.namespace.nonEmpty)
+        fullyQualifiedCompletion(uri, ap, qn) ++ partiallyQualifiedCompletions(uri, ap, env, qn)
     else
       root.enums.values.flatMap(enm =>
         enm.cases.values.collect{
-          case tag if matchesTag(enm, tag, namespace, ident, uri, qualified = false) =>
+          case tag if matchesTag(enm, tag, qn, uri, qualified = false) =>
             EnumTagCompletion(tag, Nil, ap, qualified = false, inScope = inScope(tag, env))
         }
       )
@@ -56,10 +54,10 @@ object EnumTagCompleter {
     *
     * We will assume the user is trying to type a fully qualified name and will only match against fully qualified names.
     */
-  private def fullyQualifiedCompletion(uri: String, ap: AnchorPosition, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
+  private def fullyQualifiedCompletion(uri: String, ap: AnchorPosition, qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
     root.enums.values.flatMap(enm =>
       enm.cases.values.collect{
-        case tag if matchesTag(enm, tag, namespace, ident, uri, qualified = true) =>
+        case tag if matchesTag(enm, tag, qn, uri, qualified = true) =>
           EnumTagCompletion(tag, Nil,  ap, qualified = true, inScope = true)
       }
     )
@@ -73,13 +71,13 @@ object EnumTagCompleter {
     *
     * We need to first find the fully qualified namespace by looking up the local environment, then use it to provide completions.
     */
-  private def partiallyQualifiedCompletions(uri: String, ap: AnchorPosition, env: LocalScope, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
+  private def partiallyQualifiedCompletions(uri: String, ap: AnchorPosition, env: LocalScope, qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
     for {
-      case Resolution.Declaration(Enum(_, _, _, enumSym, _, _, _, _)) <- env.get(namespace.mkString("."))
+      case Resolution.Declaration(Enum(_, _, _, enumSym, _, _, _, _)) <- env.get(qn.namespace.toString)
       enm <- root.enums.get(enumSym).toList
       tag <- enm.cases.values
-      if matchesTag(enm, tag, namespace, ident, uri, qualified = false)
-    } yield EnumTagCompletion(tag, namespace, ap, qualified = true, inScope = true)
+      if matchesTag(enm, tag, qn, uri, qualified = false)
+    } yield EnumTagCompletion(tag, qn.namespace.parts, ap, qualified = true, inScope = true)
   }
 
   private def inScope(tag: TypedAst.Case, scope: LocalScope): Boolean = {
@@ -97,13 +95,13 @@ object EnumTagCompleter {
     *
     * For visibility, we just need to check the parent enum.
     */
-  private def matchesTag(enm: TypedAst.Enum, tag: TypedAst.Case, namespace: List[String], ident: String, uri: String, qualified: Boolean): Boolean = {
+  private def matchesTag(enm: TypedAst.Enum, tag: TypedAst.Case, qn: Name.QName, uri: String, qualified: Boolean): Boolean = {
     val isPublic = enm.mod.isPublic && !enm.ann.isInternal
     val isInFile = enm.loc.source.name == uri
     val isMatch = if (qualified)
-      CompletionUtils.matchesQualifiedName(tag.sym.namespace, tag.sym.name, namespace, ident)
+      CompletionUtils.matchesQualifiedName(tag.sym.namespace, tag.sym.name, qn)
     else
-      CompletionUtils.fuzzyMatch(ident, tag.sym.name)
+      CompletionUtils.fuzzyMatch(qn.ident.name, tag.sym.name)
     isMatch && (isPublic || isInFile)
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ModuleCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ModuleCompleter.scala
@@ -16,7 +16,7 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.language.ast.{Symbol, TypedAst}
+import ca.uwaterloo.flix.language.ast.{Name, Symbol, TypedAst}
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.ModuleCompletion
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Namespace
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
@@ -28,27 +28,27 @@ object ModuleCompleter {
     * Whether the returned completions are qualified is based on whether the name in the error is qualified.
     * When providing completions for unqualified enums that is not in scope, we will also automatically use the module.
     */
-  def getCompletions(err: ResolutionError.UndefinedType, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    getCompletions(err.ap, err.env, namespace, ident)
+  def getCompletions(err: ResolutionError.UndefinedType)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    getCompletions(err.ap, err.env, err.qn)
   }
 
-  def getCompletions(err: ResolutionError.UndefinedName, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    getCompletions(err.ap, err.env, namespace, ident)
+  def getCompletions(err: ResolutionError.UndefinedName)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    getCompletions(err.ap, err.env, err.qn)
   }
 
-  def getCompletions(err: ResolutionError.UndefinedTag, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    getCompletions(err.ap, err.env, namespace, ident)
+  def getCompletions(err: ResolutionError.UndefinedTag)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    getCompletions(err.ap, err.env, err.qn)
   }
 
-  private def getCompletions(ap: AnchorPosition, env: LocalScope, namespace: List[String], ident: String)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    if (namespace.nonEmpty)
+  private def getCompletions(ap: AnchorPosition, env: LocalScope, qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    if (qn.namespace.nonEmpty)
       root.modules.keys.collect{
-        case module if module.ns.nonEmpty && matchesModule(module, namespace, ident, qualified = true) =>
+        case module if module.ns.nonEmpty && matchesModule(module, qn, qualified = true) =>
           ModuleCompletion(module, ap, qualified = true, inScope = true)
       }
     else
       root.modules.keys.collect({
-        case module if module.ns.nonEmpty && matchesModule(module, namespace, ident, qualified = false) =>
+        case module if module.ns.nonEmpty && matchesModule(module, qn, qualified = false) =>
           ModuleCompletion(module, ap, qualified = false, inScope = inScope(module, env))
       })
   }
@@ -74,11 +74,11 @@ object ModuleCompleter {
     *
     * Note: module.ns is required to be non-empty.
     */
-  private def matchesModule(module: Symbol.ModuleSym, namespace: List[String], ident: String, qualified: Boolean): Boolean = {
+  private def matchesModule(module: Symbol.ModuleSym, qn: Name.QName, qualified: Boolean): Boolean = {
     if (qualified) {
-      CompletionUtils.matchesQualifiedName(module.ns.dropRight(1), module.ns.last, namespace, ident)
+      CompletionUtils.matchesQualifiedName(module.ns.dropRight(1), module.ns.last, qn)
     } else
-      CompletionUtils.fuzzyMatch(ident, module.ns.last)
+      CompletionUtils.fuzzyMatch(qn.ident.name, module.ns.last)
   }
 
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/Name.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Name.scala
@@ -136,6 +136,16 @@ object Name {
     def parts: List[String] = idents.map(_.name)
 
     /**
+      * Returns if the namespace is empty.
+      */
+    def isEmpty: Boolean = idents.isEmpty
+
+    /**
+      * Returns if the namespace is non-empty.
+      */
+    def nonEmpty: Boolean = idents.nonEmpty
+
+    /**
       * Returns `true` if `this` namespace equals `that`.
       */
     override def equals(o: scala.Any): Boolean = o match {

--- a/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ResolutionError.scala
@@ -859,12 +859,12 @@ object ResolutionError {
     * @param qname the qualified name of the operation.
     * @param loc   the location where the error occurred.
     */
-  case class UndefinedOp(qname: Name.QName, ap: AnchorPosition, env: LocalScope, loc: SourceLocation) extends ResolutionError {
-    def summary: String = s"Undefined operation '${qname.toString}'."
+  case class UndefinedOp(qn: Name.QName, ap: AnchorPosition, env: LocalScope, loc: SourceLocation) extends ResolutionError {
+    def summary: String = s"Undefined operation '${qn.toString}'."
 
     def message(formatter: Formatter): String = messageWithLink {
       import formatter.*
-      s""">> Undefined operation '${red(qname.toString)}'.
+      s""">> Undefined operation '${red(qn.toString)}'.
          |
          |${code(loc, "operation not found")}
          |


### PR DESCRIPTION
Now we can pass qn where we need it instead of namespace + ident.

Not every completer is tested, but they should all work fine since the change is trivial:
<img width="689" alt="image" src="https://github.com/user-attachments/assets/87940630-ccb5-47f0-8f6e-7f4ab4ad0680" />
<img width="534" alt="image" src="https://github.com/user-attachments/assets/01161815-f5ba-496c-bc3e-9e6e7b98e2cd" />
<img width="646" alt="image" src="https://github.com/user-attachments/assets/52dd909d-eff4-46f5-af4a-3bdd0b4badb8" />
<img width="769" alt="image" src="https://github.com/user-attachments/assets/de555582-86b4-4e0a-9a11-09352482c5a2" />
<img width="370" alt="image" src="https://github.com/user-attachments/assets/473b4312-f5b5-4056-b49d-835372eff715" />
