### PR TITLE
feat: support partially qualified name for SigCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -359,8 +359,11 @@ sealed trait Completion {
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.SigCompletion(sig, ap, qualified, inScope) =>
-      val qualifiedName = sig.sym.toString
+    case Completion.SigCompletion(sig, namespace, ap, qualified, inScope) =>
+      val qualifiedName =  if (namespace.nonEmpty)
+        s"$namespace.${sig.sym.name}"
+      else
+        sig.sym.toString
       val name = if (qualified) qualifiedName else sig.sym.name
       val snippet = CompletionUtils.getApplySnippet(name, sig.spec.fparams)(context)
       val description = if(!qualified) {
@@ -819,7 +822,7 @@ object Completion {
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the signature is inScope.
     */
-  case class SigCompletion(sig: TypedAst.Sig, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
+  case class SigCompletion(sig: TypedAst.Sig, namespace: String,  ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
 
   /**
     * Represents an Enum Tag completion

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/LocalScope.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/LocalScope.scala
@@ -62,4 +62,12 @@ case class LocalScope(env: ListMap[String, Resolution]){
     * Returns the local scope extended with the additional mapping from `name` to `res`.
     */
   def +(kv: (String, Resolution)): LocalScope = LocalScope(env + kv)
+
+  /**
+    * Returns the local scope extended with the additional mapping from `name` to `res`.
+    *
+    * Currently, we just take the first resolution in the list of resolutions.
+    */
+  def resolve(name: String): Option[Resolution] =
+    env.get(name).headOption
 }


### PR DESCRIPTION
Preview:
<img width="725" alt="image" src="https://github.com/user-attachments/assets/9fb07ca8-c85a-49e0-ba27-7691dbd8ad16" />
<img width="734" alt="image" src="https://github.com/user-attachments/assets/a97a314e-fe10-4ffc-b10a-37ef9c88a97c" />
<img width="653" alt="image" src="https://github.com/user-attachments/assets/f6685c1e-e903-4c0b-9451-93d931c8cb39" />

Note:
- The algorithm:
  - get the first item of the namespace (we've checked its non-empty beforehand)
  - search for it in the local scope, we only accept Namespace(BMod above) or Trait(Addable above)
  - if found, concatenate its fully qualified form with the rest of the namespace
  - now use the concatenated name to search for trait
  - provide sig completions from the trait
- the resolution conflict problem:
  - If the user uses two different BMod, then there will be two resolution for BMod in the local scope. In this case BMod is ambiguous and we should not provide the completion starts with BMod. But we cannot just check for duplication. For example, in the case above, `Addable` is also resolved to two traits, but it's totally fine. Currently, I am just use headOpt to get one resolution, now defined in env.resolve(name).