### PR TITLE
fix: require operation decl to be annotated with return type

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1289,16 +1289,15 @@ object Parser2 {
       if (at(TokenKind.ParenL)) {
         parameters(SyntacticContext.Decl.Module)
       }
-      if (eat(TokenKind.Colon)) {
-        val typeLoc = currentSourceLocation()
+      expect(TokenKind.Colon, SyntacticContext.Type.Eff)
+      val typeLoc = currentSourceLocation()
+      Type.ttype()
+      // Check for illegal effect
+      if (at(TokenKind.Backslash)) {
+        val mark = open()
+        eat(TokenKind.Backslash)
         Type.ttype()
-        // Check for illegal effect
-        if (at(TokenKind.Backslash)) {
-          val mark = open()
-          eat(TokenKind.Backslash)
-          Type.ttype()
-          closeWithError(mark, WeederError.IllegalEffectfulOperation(typeLoc))
-        }
+        closeWithError(mark, WeederError.IllegalEffectfulOperation(typeLoc))
       }
       if (at(TokenKind.KeywordWith)) {
         Type.constraints()

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -924,6 +924,28 @@ class TestParserHappy extends AnyFunSuite with TestUtils {
     expectError[WeederError.IllegalEffectTypeParams](result)
   }
 
+  test("IllegalOperationWithOutReturnType.01") {
+    val input =
+      """
+        |eff E{
+        |    def op()
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ParseError](result)
+  }
+
+  test("IllegalOperationWithOutReturnType.02") {
+    val input =
+      """
+        |eff E{
+        |    def op():
+        |}
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[ParseError](result)
+  }
+
   test("IllegalEffectfulOperation.01") {
     val input =
       """


### PR DESCRIPTION
fixes #9953
The error message:

<img width="475" alt="image" src="https://github.com/user-attachments/assets/411869f4-9845-49df-8682-dfe288ca2eb9" />