### PR TITLE
fix: filter out lib files in GotoProvider

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/GotoProvider.scala
@@ -36,6 +36,7 @@ object GotoProvider {
 
     gotoRight
       .orElse(gotoLeft)
+      .filter(_.targetUri.startsWith("file://")) // We do not support goto for non-file URIs, which is the case for the standard library.
   }
 
   /**


### PR DESCRIPTION
As discussed in #9935
We now filter out standard lib files in the GotoProvider.

I am not not sure if we should do this filtering. Currently if you try to command+click to go to something in the lib, it will say:

<img width="473" alt="image" src="https://github.com/user-attachments/assets/1457f49a-481f-420c-96f6-3675ec34d76a" />

After filtering, it just keeps silent. (But of course, we can say something, in the plain lsp, we can send something back, in vscode, we can print to the console)