### PR TITLE
feat: introduce Decl for TypedAst constructs

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CodeActionProvider.scala
@@ -104,7 +104,7 @@ object CodeActionProvider {
     */
   private def mkUseDef(ident: Name.Ident, uri: String, ap: AnchorPosition)(implicit root: Root): List[CodeAction] = {
     val syms = root.defs.collect {
-      case (sym, defn) if CompletionUtils.isPublic(defn) => sym
+      case (sym, defn) if CompletionUtils.isAvailable(defn) => sym
     }
     mkUseSym(ident, syms.map(_.name), syms, uri, ap)
   }
@@ -114,7 +114,7 @@ object CodeActionProvider {
     */
   private def mkUseTrait(ident: Name.Ident, uri: String, ap: AnchorPosition)(implicit root: Root): List[CodeAction] = {
     val syms = root.traits.collect {
-      case (sym, trt) if CompletionUtils.isPublic(trt) => sym
+      case (sym, trt) if CompletionUtils.isAvailable(trt) => sym
     }
     mkUseSym(ident, syms.map(_.name), syms, uri, ap)
   }
@@ -124,7 +124,7 @@ object CodeActionProvider {
     */
   private def mkUseEffect(ident: Name.Ident, uri: String, ap: AnchorPosition)(implicit root: Root): List[CodeAction] = {
     val syms = root.effects.collect {
-      case (sym, eff) if CompletionUtils.isPublic(eff) => sym
+      case (sym, eff) if CompletionUtils.isAvailable(eff) => sym
     }
     mkUseSym(ident, syms.map(_.name), syms, uri, ap)
   }
@@ -146,7 +146,7 @@ object CodeActionProvider {
     * }}}
     */
   private def mkUseTag(tagName: String, uri: String, ap: AnchorPosition)(implicit root: Root): List[CodeAction] = {
-    val candidateEnums = root.enums.filter{ case (_, enm) => enm.cases.keys.exists(_.name == tagName) && CompletionUtils.isPublic(enm)}
+    val candidateEnums = root.enums.filter{ case (_, enm) => enm.cases.keys.exists(_.name == tagName) && CompletionUtils.isAvailable(enm)}
     candidateEnums.keys.map{ enumName =>
       CodeAction(
         title = s"use '$enumName.$tagName'",
@@ -174,7 +174,7 @@ object CodeActionProvider {
     * }}}
     */
   private def mkQualifyTag(tagName: String, uri: String, loc: SourceLocation)(implicit root: Root): List[CodeAction] = {
-    val candidateEnums = root.enums.filter{ case (_, enm) => enm.cases.keys.exists(_.name == tagName) && CompletionUtils.isPublic(enm)}
+    val candidateEnums = root.enums.filter{ case (_, enm) => enm.cases.keys.exists(_.name == tagName) && CompletionUtils.isAvailable(enm)}
     candidateEnums.keys.map{ enumName =>
       CodeAction(
         title = s"Prefix with '$enumName.'",
@@ -189,17 +189,17 @@ object CodeActionProvider {
     * Returns a code action that proposes to `use` a type.
     */
   private def mkUseType(ident: Name.Ident, uri: String, ap: AnchorPosition)(implicit root: Root): List[CodeAction] = {
-    val enumNames = root.enums.collect { case (sym, enm) if CompletionUtils.isPublic(enm) => sym.name }
-    val enumSyms = root.enums.collect { case (sym, enm) if CompletionUtils.isPublic(enm) => sym }
+    val enumNames = root.enums.collect { case (sym, enm) if CompletionUtils.isAvailable(enm) => sym.name }
+    val enumSyms = root.enums.collect { case (sym, enm) if CompletionUtils.isAvailable(enm) => sym }
 
-    val restrictableEnumNames = root.restrictableEnums.collect { case (sym, enm) if CompletionUtils.isPublic(enm) => sym.name }
-    val restrictableEnumSyms = root.restrictableEnums.collect { case (sym, enm) if CompletionUtils.isPublic(enm) => sym }
+    val restrictableEnumNames = root.restrictableEnums.collect { case (sym, enm) if CompletionUtils.isAvailable(enm) => sym.name }
+    val restrictableEnumSyms = root.restrictableEnums.collect { case (sym, enm) if CompletionUtils.isAvailable(enm) => sym }
 
-    val traitNames = root.traits.collect { case (sym, trt) if CompletionUtils.isPublic(trt) => sym.name }
-    val traitSyms = root.traits.collect { case (sym, trt) if CompletionUtils.isPublic(trt) => sym }
+    val traitNames = root.traits.collect { case (sym, trt) if CompletionUtils.isAvailable(trt) => sym.name }
+    val traitSyms = root.traits.collect { case (sym, trt) if CompletionUtils.isAvailable(trt) => sym }
 
-    val typeAliasNames = root.typeAliases.collect { case (sym, alias) if CompletionUtils.isPublic(alias) => sym.name }
-    val typeAliasSyms = root.typeAliases.collect { case (sym, alias) if CompletionUtils.isPublic(alias) => sym }
+    val typeAliasNames = root.typeAliases.collect { case (sym, alias) if CompletionUtils.isAvailable(alias) => sym.name }
+    val typeAliasSyms = root.typeAliases.collect { case (sym, alias) if CompletionUtils.isAvailable(alias) => sym }
 
     val names = enumNames ++ restrictableEnumNames ++ traitNames ++ typeAliasNames
     val syms = enumSyms ++ restrictableEnumSyms ++ traitSyms ++ typeAliasSyms

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -17,9 +17,8 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.Name
+import ca.uwaterloo.flix.language.ast.{Declaration, Name, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Def
-import ca.uwaterloo.flix.language.ast.{Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.ast.shared.{LocalScope, Modifier, Resolution}
 import ca.uwaterloo.flix.language.fmt.FormatType
 
@@ -282,38 +281,44 @@ object CompletionUtils {
     }
   }
 
+  /**
+    * Checks if the given class is public.
+    */
+  def isAvailable(decl: Declaration): Boolean =
+    !decl.ann.isInternal && decl.mod.isPublic
 
   /**
-    * Checks if the given spec is public.
+    * Checks if the given def is public.
     */
-  def isPublic(defn: TypedAst.Def): Boolean = defn.spec.mod.isPublic && !defn.spec.ann.isInternal
-  def isPublic(defn: Symbol.DefnSym)(implicit root: TypedAst.Root): Boolean = root.defs.get(defn).exists(isPublic)
+  def isAvailable(defn: TypedAst.Def): Boolean = isAvailable(defn.spec)
 
   /**
-    * Checks if the given trait is public.
+    * Checks if the given sig is public.
     */
-  def isPublic(trt: TypedAst.Trait): Boolean = trt.mod.isPublic && !trt.ann.isInternal
-  def isPublic(trt: Symbol.TraitSym)(implicit root: TypedAst.Root): Boolean = root.traits.get(trt).exists(isPublic)
+  def isAvailable(sig: TypedAst.Sig): Boolean = isAvailable(sig.spec)
 
   /**
-    * Checks if the given effect is public.
+    * Checks if the given op is public.
     */
-  def isPublic(eff: TypedAst.Effect): Boolean = eff.mod.isPublic && !eff.ann.isInternal
-  def isPublic(eff: Symbol.EffectSym)(implicit root: TypedAst.Root): Boolean = root.effects.get(eff).exists(isPublic)
+  def isAvailable(op: TypedAst.Op): Boolean = isAvailable(op.spec)
 
   /**
-    * Checks if the given enum is public.
+    * Checks if the def of the given symbol is public.
     */
-  def isPublic(enm: TypedAst.Enum): Boolean = enm.mod.isPublic && !enm.ann.isInternal
-  def isPublic(enumMap: Symbol.EnumSym)(implicit root: TypedAst.Root): Boolean = root.enums.get(enumMap).exists(isPublic)
+  def isAvailable(defn: Symbol.DefnSym)(implicit root: TypedAst.Root): Boolean = root.defs.get(defn).exists(isAvailable)
 
   /**
-    * Checks if the given restrictable enum is public.
+    * Checks if the trait of the given symbol is public.
     */
-  def isPublic(enm: TypedAst.RestrictableEnum): Boolean = enm.mod.isPublic && !enm.ann.isInternal
+  def isAvailable(trt: Symbol.TraitSym)(implicit root: TypedAst.Root): Boolean = root.traits.get(trt).exists(isAvailable)
 
   /**
-    * Checks if the given type alias is public.
+    * Checks if the effect of the given symbol is public.
     */
-  def isPublic(alias: TypedAst.TypeAlias): Boolean = alias.mod.isPublic && !alias.ann.isInternal
+  def isAvailable(eff: Symbol.EffectSym)(implicit root: TypedAst.Root): Boolean = root.effects.get(eff).exists(isAvailable)
+
+  /**
+    * Checks if the enum of the given symbol is public.
+    */
+  def isAvailable(enumMap: Symbol.EnumSym)(implicit root: TypedAst.Root): Boolean = root.enums.get(enumMap).exists(isAvailable)
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -17,12 +17,13 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.Flix
-import ca.uwaterloo.flix.language.ast.{Declaration, Name, Symbol, Type, TypeConstructor, TypedAst}
+import ca.uwaterloo.flix.language.ast.Name
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Def
-import ca.uwaterloo.flix.language.ast.shared.{LocalScope, Modifier, Resolution}
+import ca.uwaterloo.flix.language.ast.TypedAst.Decl
+import ca.uwaterloo.flix.language.ast.{Symbol, Type, TypeConstructor, TypedAst}
+import ca.uwaterloo.flix.language.ast.shared.{LocalScope, Resolution}
 import ca.uwaterloo.flix.language.fmt.FormatType
 
-import java.util
 import scala.annotation.tailrec
 
 object CompletionUtils {
@@ -281,10 +282,11 @@ object CompletionUtils {
     }
   }
 
+
   /**
     * Checks if the given class is public.
     */
-  def isAvailable(decl: Declaration): Boolean =
+  def isAvailable(decl: Decl): Boolean =
     !decl.ann.isInternal && decl.mod.isPublic
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/UseCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/UseCompleter.scala
@@ -38,10 +38,10 @@ object UseCompleter {
     val moduleSym = Symbol.mkModuleSym(namespace)
     root.modules.get(moduleSym).collect{
       case mod:  Symbol.ModuleSym if fuzzyMatch(ident, mod.ns.last) => ModCompletion(mod)
-      case enm:  Symbol.EnumSym   if fuzzyMatch(ident, enm.name)  && CompletionUtils.isPublic(enm)  => UseEnumCompletion(enm.toString)
-      case eff:  Symbol.EffectSym if fuzzyMatch(ident, eff.name)  && CompletionUtils.isPublic(eff)  => UseEffCompletion(eff.toString)
-      case defn: Symbol.DefnSym   if fuzzyMatch(ident, defn.name) && CompletionUtils.isPublic(defn) => UseDefCompletion(defn.toString)
-      case trt:  Symbol.TraitSym  if fuzzyMatch(ident, trt.name)  && CompletionUtils.isPublic(trt)  => UseTrtCompletion(trt.toString)
+      case enm:  Symbol.EnumSym   if fuzzyMatch(ident, enm.name)  && CompletionUtils.isAvailable(enm)  => UseEnumCompletion(enm.toString)
+      case eff:  Symbol.EffectSym if fuzzyMatch(ident, eff.name)  && CompletionUtils.isAvailable(eff)  => UseEffCompletion(eff.toString)
+      case defn: Symbol.DefnSym   if fuzzyMatch(ident, defn.name) && CompletionUtils.isAvailable(defn) => UseDefCompletion(defn.toString)
+      case trt:  Symbol.TraitSym  if fuzzyMatch(ident, trt.name)  && CompletionUtils.isAvailable(trt)  => UseTrtCompletion(trt.toString)
     } ++ getSigCompletions(uri, qn) ++ getOpCompletions(qn) ++ getTagCompletions(qn)
   }
 
@@ -50,7 +50,7 @@ object UseCompleter {
     */
   private def getSigCompletions(uri: String, qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
     val traitSym = Symbol.mkTraitSym(qn.namespace.toString)
-    root.traits.get(traitSym).filter(CompletionUtils.isPublic).map(_.sigs.collect {
+    root.traits.get(traitSym).filter(CompletionUtils.isAvailable).map(_.sigs.collect {
       case sig if fuzzyMatch(qn.ident.name, sig.sym.name) && (sig.spec.mod.isPublic || sig.sym.loc.source.name == uri) =>
         UseSignatureCompletion(sig.sym.toString)
     }).getOrElse(Nil)
@@ -61,7 +61,7 @@ object UseCompleter {
     */
   private def getOpCompletions(qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
     val effectSym = Symbol.mkEffectSym(qn.namespace.toString)
-    root.effects.get(effectSym).filter(CompletionUtils.isPublic).map(_.ops.collect {
+    root.effects.get(effectSym).filter(CompletionUtils.isAvailable).map(_.ops.collect {
       case op if fuzzyMatch(qn.ident.name, op.sym.name) => UseOpCompletion(op.sym.toString)
     }).getOrElse(Nil)
   }
@@ -71,7 +71,7 @@ object UseCompleter {
     */
   private def getTagCompletions(qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
     val enumSym = Symbol.mkEnumSym(qn.namespace.toString)
-    root.enums.get(enumSym).filter(CompletionUtils.isPublic).map(_.cases.values.collect {
+    root.enums.get(enumSym).filter(CompletionUtils.isAvailable).map(_.cases.values.collect {
       case tag if fuzzyMatch(qn.ident.name, tag.sym.name) => UseEnumTagCompletion(tag.sym.toString)
     }).getOrElse(Nil)
   }

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -49,14 +49,14 @@ object TypedAst {
                   dependencyGraph: DependencyGraph,
                   tokens: Map[Source, Array[Token]])
 
-  sealed trait Declaration {
+  sealed trait Decl {
     val ann: Annotations
     val mod: Modifiers
   }
 
-  case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[AssocTypeSig], sigs: List[Sig], laws: List[Def], loc: SourceLocation) extends Declaration
+  case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[AssocTypeSig], sigs: List[Sig], laws: List[Def], loc: SourceLocation) extends Decl
 
-  case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, trt: TraitSymUse, tpe: Type, tconstrs: List[TraitConstraint], assocs: List[AssocTypeDef], defs: List[Def], ns: Name.NName, loc: SourceLocation) extends Sourceable with Declaration {
+  case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, trt: TraitSymUse, tpe: Type, tconstrs: List[TraitConstraint], assocs: List[AssocTypeDef], defs: List[Def], ns: Name.NName, loc: SourceLocation) extends Sourceable with Decl {
     override def src: Source = loc.source
   }
 
@@ -64,15 +64,15 @@ object TypedAst {
 
   case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Expr, loc: SourceLocation)
 
-  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: List[FormalParam], declaredScheme: Scheme, retTpe: Type, eff: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint]) extends Declaration
+  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: List[FormalParam], declaredScheme: Scheme, retTpe: Type, eff: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint]) extends Decl
 
-  case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.CaseSym, Case], loc: SourceLocation) extends Declaration
+  case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.CaseSym, Case], loc: SourceLocation) extends Decl
 
-  case class Struct(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.StructSym, tparams: List[TypeParam], sc: Scheme, fields: Map[Symbol.StructFieldSym, StructField], loc: SourceLocation) extends Declaration
+  case class Struct(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.StructSym, tparams: List[TypeParam], sc: Scheme, fields: Map[Symbol.StructFieldSym, StructField], loc: SourceLocation) extends Decl
 
-  case class RestrictableEnum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.RestrictableEnumSym, index: TypeParam, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.RestrictableCaseSym, RestrictableCase], loc: SourceLocation) extends Declaration
+  case class RestrictableEnum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.RestrictableEnumSym, index: TypeParam, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.RestrictableCaseSym, RestrictableCase], loc: SourceLocation) extends Decl
 
-  case class TypeAlias(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TypeAliasSym, tparams: List[TypeParam], tpe: Type, loc: SourceLocation) extends Declaration
+  case class TypeAlias(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TypeAliasSym, tparams: List[TypeParam], tpe: Type, loc: SourceLocation) extends Decl
 
   // TODO ASSOC-TYPES can probably be combined with KindedAst.AssocTypeSig
   case class AssocTypeSig(doc: Doc, mod: Modifiers, sym: Symbol.AssocTypeSym, tparam: TypeParam, kind: Kind, tpe: Option[Type], loc: SourceLocation)
@@ -80,7 +80,7 @@ object TypedAst {
   // TODO ASSOC-TYPES can probably be combined with KindedAst.AssocTypeSig
   case class AssocTypeDef(doc: Doc, mod: Modifiers, sym: AssocTypeSymUse, arg: Type, tpe: Type, loc: SourceLocation)
 
-  case class Effect(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EffectSym, ops: List[Op], loc: SourceLocation) extends Declaration
+  case class Effect(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EffectSym, ops: List[Op], loc: SourceLocation) extends Decl
 
   case class Op(sym: Symbol.OpSym, spec: Spec, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -24,11 +24,6 @@ import ca.uwaterloo.flix.util.collection.{ListMap, MultiMap}
 
 import java.lang.reflect.{Constructor, Field, Method}
 
-sealed trait Declaration {
-  val ann: Annotations
-  val mod: Modifiers
-}
-
 object TypedAst {
 
   val empty: Root = Root(ListMap.empty, Map.empty, ListMap.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, ListMap.empty, None, Set.empty, Map.empty, TraitEnv.empty, EqualityEnv.empty, AvailableClasses.empty, LabelledPrecedenceGraph.empty, DependencyGraph.empty, Map.empty)
@@ -53,6 +48,11 @@ object TypedAst {
                   precedenceGraph: LabelledPrecedenceGraph,
                   dependencyGraph: DependencyGraph,
                   tokens: Map[Source, Array[Token]])
+
+  sealed trait Declaration {
+    val ann: Annotations
+    val mod: Modifiers
+  }
 
   case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[AssocTypeSig], sigs: List[Sig], laws: List[Def], loc: SourceLocation) extends Declaration
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -24,11 +24,9 @@ import ca.uwaterloo.flix.util.collection.{ListMap, MultiMap}
 
 import java.lang.reflect.{Constructor, Field, Method}
 
-sealed trait HasAvailable {
+sealed trait Declaration {
   val ann: Annotations
   val mod: Modifiers
-
-  def available: Boolean = !ann.isInternal && mod.isPublic
 }
 
 object TypedAst {
@@ -56,9 +54,9 @@ object TypedAst {
                   dependencyGraph: DependencyGraph,
                   tokens: Map[Source, Array[Token]])
 
-  case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[AssocTypeSig], sigs: List[Sig], laws: List[Def], loc: SourceLocation) extends HasAvailable
+  case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[AssocTypeSig], sigs: List[Sig], laws: List[Def], loc: SourceLocation) extends Declaration
 
-  case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, trt: TraitSymUse, tpe: Type, tconstrs: List[TraitConstraint], assocs: List[AssocTypeDef], defs: List[Def], ns: Name.NName, loc: SourceLocation) extends Sourceable with HasAvailable {
+  case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, trt: TraitSymUse, tpe: Type, tconstrs: List[TraitConstraint], assocs: List[AssocTypeDef], defs: List[Def], ns: Name.NName, loc: SourceLocation) extends Sourceable with Declaration {
     override def src: Source = loc.source
   }
 
@@ -66,27 +64,23 @@ object TypedAst {
 
   case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Expr, loc: SourceLocation)
 
-  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: List[FormalParam], declaredScheme: Scheme, retTpe: Type, eff: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint]) extends HasAvailable
+  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: List[FormalParam], declaredScheme: Scheme, retTpe: Type, eff: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint]) extends Declaration
 
-  case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.CaseSym, Case], loc: SourceLocation) extends HasAvailable
+  case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.CaseSym, Case], loc: SourceLocation) extends Declaration
 
-  case class Struct(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.StructSym, tparams: List[TypeParam], sc: Scheme, fields: Map[Symbol.StructFieldSym, StructField], loc: SourceLocation) extends HasAvailable
+  case class Struct(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.StructSym, tparams: List[TypeParam], sc: Scheme, fields: Map[Symbol.StructFieldSym, StructField], loc: SourceLocation) extends Declaration
 
-  case class RestrictableEnum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.RestrictableEnumSym, index: TypeParam, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.RestrictableCaseSym, RestrictableCase], loc: SourceLocation) extends HasAvailable
+  case class RestrictableEnum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.RestrictableEnumSym, index: TypeParam, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.RestrictableCaseSym, RestrictableCase], loc: SourceLocation) extends Declaration
 
-  case class TypeAlias(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TypeAliasSym, tparams: List[TypeParam], tpe: Type, loc: SourceLocation) extends HasAvailable
-
-  // TODO ASSOC-TYPES can probably be combined with KindedAst.AssocTypeSig
-  case class AssocTypeSig(doc: Doc, mod: Modifiers, sym: Symbol.AssocTypeSym, tparam: TypeParam, kind: Kind, tpe: Option[Type], loc: SourceLocation) {
-    def available: Boolean = mod.isPublic
-  }
+  case class TypeAlias(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TypeAliasSym, tparams: List[TypeParam], tpe: Type, loc: SourceLocation) extends Declaration
 
   // TODO ASSOC-TYPES can probably be combined with KindedAst.AssocTypeSig
-  case class AssocTypeDef(doc: Doc, mod: Modifiers, sym: AssocTypeSymUse, arg: Type, tpe: Type, loc: SourceLocation) {
-    def available: Boolean = mod.isPublic
-  }
+  case class AssocTypeSig(doc: Doc, mod: Modifiers, sym: Symbol.AssocTypeSym, tparam: TypeParam, kind: Kind, tpe: Option[Type], loc: SourceLocation)
 
-  case class Effect(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EffectSym, ops: List[Op], loc: SourceLocation) extends HasAvailable
+  // TODO ASSOC-TYPES can probably be combined with KindedAst.AssocTypeSig
+  case class AssocTypeDef(doc: Doc, mod: Modifiers, sym: AssocTypeSymUse, arg: Type, tpe: Type, loc: SourceLocation)
+
+  case class Effect(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EffectSym, ops: List[Op], loc: SourceLocation) extends Declaration
 
   case class Op(sym: Symbol.OpSym, spec: Spec, loc: SourceLocation)
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -24,6 +24,13 @@ import ca.uwaterloo.flix.util.collection.{ListMap, MultiMap}
 
 import java.lang.reflect.{Constructor, Field, Method}
 
+sealed trait HasAvailable {
+  val ann: Annotations
+  val mod: Modifiers
+
+  def available: Boolean = !ann.isInternal && mod.isPublic
+}
+
 object TypedAst {
 
   val empty: Root = Root(ListMap.empty, Map.empty, ListMap.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, ListMap.empty, None, Set.empty, Map.empty, TraitEnv.empty, EqualityEnv.empty, AvailableClasses.empty, LabelledPrecedenceGraph.empty, DependencyGraph.empty, Map.empty)
@@ -49,9 +56,9 @@ object TypedAst {
                   dependencyGraph: DependencyGraph,
                   tokens: Map[Source, Array[Token]])
 
-  case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[AssocTypeSig], sigs: List[Sig], laws: List[Def], loc: SourceLocation)
+  case class Trait(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TraitSym, tparam: TypeParam, superTraits: List[TraitConstraint], assocs: List[AssocTypeSig], sigs: List[Sig], laws: List[Def], loc: SourceLocation) extends HasAvailable
 
-  case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, trt: TraitSymUse, tpe: Type, tconstrs: List[TraitConstraint], assocs: List[AssocTypeDef], defs: List[Def], ns: Name.NName, loc: SourceLocation) extends Sourceable {
+  case class Instance(doc: Doc, ann: Annotations, mod: Modifiers, trt: TraitSymUse, tpe: Type, tconstrs: List[TraitConstraint], assocs: List[AssocTypeDef], defs: List[Def], ns: Name.NName, loc: SourceLocation) extends Sourceable with HasAvailable {
     override def src: Source = loc.source
   }
 
@@ -59,23 +66,27 @@ object TypedAst {
 
   case class Def(sym: Symbol.DefnSym, spec: Spec, exp: Expr, loc: SourceLocation)
 
-  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: List[FormalParam], declaredScheme: Scheme, retTpe: Type, eff: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint])
+  case class Spec(doc: Doc, ann: Annotations, mod: Modifiers, tparams: List[TypeParam], fparams: List[FormalParam], declaredScheme: Scheme, retTpe: Type, eff: Type, tconstrs: List[TraitConstraint], econstrs: List[EqualityConstraint]) extends HasAvailable
 
-  case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.CaseSym, Case], loc: SourceLocation)
+  case class Enum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EnumSym, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.CaseSym, Case], loc: SourceLocation) extends HasAvailable
 
-  case class Struct(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.StructSym, tparams: List[TypeParam], sc: Scheme, fields: Map[Symbol.StructFieldSym, StructField], loc: SourceLocation)
+  case class Struct(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.StructSym, tparams: List[TypeParam], sc: Scheme, fields: Map[Symbol.StructFieldSym, StructField], loc: SourceLocation) extends HasAvailable
 
-  case class RestrictableEnum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.RestrictableEnumSym, index: TypeParam, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.RestrictableCaseSym, RestrictableCase], loc: SourceLocation)
+  case class RestrictableEnum(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.RestrictableEnumSym, index: TypeParam, tparams: List[TypeParam], derives: Derivations, cases: Map[Symbol.RestrictableCaseSym, RestrictableCase], loc: SourceLocation) extends HasAvailable
 
-  case class TypeAlias(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TypeAliasSym, tparams: List[TypeParam], tpe: Type, loc: SourceLocation)
-
-  // TODO ASSOC-TYPES can probably be combined with KindedAst.AssocTypeSig
-  case class AssocTypeSig(doc: Doc, mod: Modifiers, sym: Symbol.AssocTypeSym, tparam: TypeParam, kind: Kind, tpe: Option[Type], loc: SourceLocation)
+  case class TypeAlias(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.TypeAliasSym, tparams: List[TypeParam], tpe: Type, loc: SourceLocation) extends HasAvailable
 
   // TODO ASSOC-TYPES can probably be combined with KindedAst.AssocTypeSig
-  case class AssocTypeDef(doc: Doc, mod: Modifiers, sym: AssocTypeSymUse, arg: Type, tpe: Type, loc: SourceLocation)
+  case class AssocTypeSig(doc: Doc, mod: Modifiers, sym: Symbol.AssocTypeSym, tparam: TypeParam, kind: Kind, tpe: Option[Type], loc: SourceLocation) {
+    def available: Boolean = mod.isPublic
+  }
 
-  case class Effect(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EffectSym, ops: List[Op], loc: SourceLocation)
+  // TODO ASSOC-TYPES can probably be combined with KindedAst.AssocTypeSig
+  case class AssocTypeDef(doc: Doc, mod: Modifiers, sym: AssocTypeSymUse, arg: Type, tpe: Type, loc: SourceLocation) {
+    def available: Boolean = mod.isPublic
+  }
+
+  case class Effect(doc: Doc, ann: Annotations, mod: Modifiers, sym: Symbol.EffectSym, ops: List[Op], loc: SourceLocation) extends HasAvailable
 
   case class Op(sym: Symbol.OpSym, spec: Spec, loc: SourceLocation)
 


### PR DESCRIPTION
As discussed in #9775

We first introduce available on constructs, so that we can always all it to get the bool instead of writing a function for each.

Next step will be introducing some thing like IsQName(?) to Symbols with namespace and name, so that we can reuse a `match(sym: IsQName, qn: Name.QName, qualified: Boolean`  to handle all matches.

After that we can get rids of all the matchesEnum matchesStruct things.