### PR TITLE
feat: take account type parameters in enum completion

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumCompleter.scala
@@ -29,27 +29,27 @@ object EnumCompleter {
     * When providing completions for unqualified enums that is not in scope, we will also automatically use the enum.
     */
   def getCompletions(err: ResolutionError.UndefinedName)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    getCompletions(err.qn.loc.source.name, err.ap, err.env, err.qn)
+    getCompletions(err.qn.loc.source.name, err.ap, err.env, err.qn, withTypeParameters = true)
   }
 
   def getCompletions(err: ResolutionError.UndefinedTag)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    getCompletions(err.qn.loc.source.name, err.ap, err.env, err.qn)
+    getCompletions(err.qn.loc.source.name, err.ap, err.env, err.qn, withTypeParameters = false)
   }
 
   def getCompletions(err: ResolutionError.UndefinedType)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    getCompletions(err.qn.loc.source.name, err.ap, err.env, err.qn)
+    getCompletions(err.qn.loc.source.name, err.ap, err.env, err.qn, withTypeParameters = true)
   }
 
-  private def getCompletions(uri: String, ap: AnchorPosition, env: LocalScope, qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
+  private def getCompletions(uri: String, ap: AnchorPosition, env: LocalScope, qn: Name.QName, withTypeParameters: Boolean)(implicit root: TypedAst.Root): Iterable[Completion] = {
     if (qn.namespace.nonEmpty)
       root.enums.values.collect{
         case enum if matchesEnum(enum, qn, uri, qualified = true) =>
-          EnumCompletion(enum, ap, qualified = true, inScope = true)
+          EnumCompletion(enum, ap, qualified = true, inScope = true, withTypeParameters = withTypeParameters)
       }
     else
       root.enums.values.collect({
         case enum if matchesEnum(enum, qn, uri, qualified = false) =>
-          EnumCompletion(enum, ap, qualified = false, inScope = inScope(enum, env))
+          EnumCompletion(enum, ap, qualified = false, inScope = inScope(enum, env), withTypeParameters = withTypeParameters)
       })
   }
 


### PR DESCRIPTION
First mentioned in #9652
Now we will consider type parameters (when triggered from undefined type)

<img width="751" alt="image" src="https://github.com/user-attachments/assets/8fc7e3f7-eab8-4578-8c77-31bac9801811" />
<img width="318" alt="image" src="https://github.com/user-attachments/assets/4d856880-fe34-4f79-a10c-7f39a801adb2" />
