### PR TITLE
fix: avoid using `contains` in partitionOnValues

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
@@ -67,6 +67,10 @@ sealed trait ChangeSet {
     * Otherwise, it is stale.
     *
     * The type of the value in the map must be the same, since when checking stale, we need to check if the value is in the fresh map.
+    *
+    * @param newMap      the new map
+    * @param oldMap      the old map
+    * @param idExtractor a function to extract the id from the value, which is used to check if two values are the same
     */
   def partitionOnValues[K, V <: Sourceable, ID](newMap: ListMap[K, V], oldMap: ListMap[K, V], idExtractor: V => ID): (ListMap[K, V], ListMap[K, V]) = this match {
     case ChangeSet.Everything =>

--- a/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ChangeSet.scala
@@ -68,17 +68,17 @@ sealed trait ChangeSet {
     *
     * The type of the value in the map must be the same, since when checking stale, we need to check if the value is in the fresh map.
     *
-    * @param newMap      the new map
-    * @param oldMap      the old map
-    * @param idExtractor a function to extract the id from the value, which is used to check if two values are the same
+    * @param newMap  the new map
+    * @param oldMap  the old map
+    * @param eq      the equality function for the value
     */
-  def partitionOnValues[K, V <: Sourceable, ID](newMap: ListMap[K, V], oldMap: ListMap[K, V], idExtractor: V => ID): (ListMap[K, V], ListMap[K, V]) = this match {
+  def partitionOnValues[K, V <: Sourceable](newMap: ListMap[K, V], oldMap: ListMap[K, V], eq: (V, V) => Boolean): (ListMap[K, V], ListMap[K, V]) = this match {
     case ChangeSet.Everything =>
       (newMap, ListMap.empty)
 
     case ChangeSet.Dirty(dirty) =>
       newMap.foldLeft((ListMap.empty[K, V], ListMap.empty[K, V])){ case ((stale, fresh), (k, v)) =>
-        if (oldMap.get(k).exists(idExtractor(_) == idExtractor(v)) && !dirty.contains(v.src.input))
+        if (oldMap.get(k).exists(v2 => eq(v, v2)) && !dirty.contains(v.src.input))
           (stale, fresh + (k -> v))
         else
           (stale + (k -> v), fresh)
@@ -96,9 +96,13 @@ sealed trait ChangeSet {
 
   /**
     * Updates the stale part of the list map with the given function `f`.
+    *
+    * @param newMap  the new map
+    * @param oldMap  the old map
+    * @param eq      the equality function for the value
     */
-  def updateStaleValueLists[K, V <: Sourceable, ID](newMap: ListMap[K, V], oldMap: ListMap[K, V], idExtractor: V => ID)(f: ListMap[K, V] => ListMap[K, V]): ListMap[K, V] = {
-    val (stale, fresh) = partitionOnValues(newMap, oldMap, idExtractor)
+  def updateStaleValueLists[K, V <: Sourceable](newMap: ListMap[K, V], oldMap: ListMap[K, V], eq: (V, V) => Boolean)(f: ListMap[K, V] => ListMap[K, V]): ListMap[K, V] = {
+    val (stale, fresh) = partitionOnValues(newMap, oldMap, eq)
     fresh ++ f(stale)
   }
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -41,7 +41,7 @@ object Dependencies {
     val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(visitDef))
     val effects = changeSet.updateStaleValues(root.effects, oldRoot.effects)(ParOps.parMapValues(_)(visitEff))
     val enums = changeSet.updateStaleValues(root.enums, oldRoot.enums)(ParOps.parMapValues(_)(visitEnum))
-    val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances)(ParOps.parMapValueList(_)(visitInstance))
+    val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (inst: TypedAst.Instance) => inst.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
     val structs = changeSet.updateStaleValues(root.structs, oldRoot.structs)(ParOps.parMapValues(_)(visitStruct))
     val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
     val typeAliases = changeSet.updateStaleValues(root.typeAliases, oldRoot.typeAliases)(ParOps.parMapValues(_)(visitTypeAlias))

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -41,7 +41,7 @@ object Dependencies {
     val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(visitDef))
     val effects = changeSet.updateStaleValues(root.effects, oldRoot.effects)(ParOps.parMapValues(_)(visitEff))
     val enums = changeSet.updateStaleValues(root.enums, oldRoot.enums)(ParOps.parMapValues(_)(visitEnum))
-    val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (inst: TypedAst.Instance) => inst.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
+    val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
     val structs = changeSet.updateStaleValues(root.structs, oldRoot.structs)(ParOps.parMapValues(_)(visitStruct))
     val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
     val typeAliases = changeSet.updateStaleValues(root.typeAliases, oldRoot.typeAliases)(ParOps.parMapValues(_)(visitTypeAlias))

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -41,7 +41,7 @@ object Instances {
   def run(root: TypedAst.Root, oldRoot: TypedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): (TypedAst.Root, List[InstanceError]) = {
     implicit val sctx: SharedContext = SharedContext.mk()
     flix.phaseNew("Instances") {
-      val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances)(ParOps.parMapValueList2(_)(checkInstancesOfTrait(_, root)))
+      val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (inst: TypedAst.Instance) => inst.tpe.typeConstructor)(ParOps.parMapValueList2(_)(checkInstancesOfTrait(_, root)))
       val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
       (root.copy(instances = instances, traits = traits), sctx.errors.asScala.toList)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Instances.scala
@@ -41,7 +41,7 @@ object Instances {
   def run(root: TypedAst.Root, oldRoot: TypedAst.Root, changeSet: ChangeSet)(implicit flix: Flix): (TypedAst.Root, List[InstanceError]) = {
     implicit val sctx: SharedContext = SharedContext.mk()
     flix.phaseNew("Instances") {
-      val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (inst: TypedAst.Instance) => inst.tpe.typeConstructor)(ParOps.parMapValueList2(_)(checkInstancesOfTrait(_, root)))
+      val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList2(_)(checkInstancesOfTrait(_, root)))
       val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
       (root.copy(instances = instances, traits = traits), sctx.errors.asScala.toList)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -91,7 +91,7 @@ object PatMatch {
 
       val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(visitDef))
       val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
-      val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (inst: TypedAst.Instance) => inst.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
+      val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
 
       (root.copy(defs = defs, traits = traits, instances = instances), sctx.errors.asScala.toList)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -91,7 +91,7 @@ object PatMatch {
 
       val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(visitDef))
       val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
-      val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances)(ParOps.parMapValueList(_)(visitInstance))
+      val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (inst: TypedAst.Instance) => inst.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
 
       (root.copy(defs = defs, traits = traits, instances = instances), sctx.errors.asScala.toList)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -23,7 +23,7 @@ import ca.uwaterloo.flix.language.ast.TypedAst.*
 import ca.uwaterloo.flix.language.ast.TypedAst.Predicate.Body
 import ca.uwaterloo.flix.language.ast.shared.LabelledPrecedenceGraph.{Label, LabelledEdge}
 import ca.uwaterloo.flix.language.ast.shared.{Denotation, LabelledPrecedenceGraph}
-import ca.uwaterloo.flix.language.ast.{ChangeSet, Type, TypeConstructor}
+import ca.uwaterloo.flix.language.ast.{ChangeSet, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
@@ -44,7 +44,7 @@ object PredDeps {
 
     val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(visitDef))
     val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
-    val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances)(ParOps.parMapValueList(_)(visitInstance))
+    val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (inst: TypedAst.Instance) => inst.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
 
     val g = LabelledPrecedenceGraph(sctx.edges.asScala.toVector)
     (root.copy(defs = defs, traits = traits, instances = instances, precedenceGraph = g), List.empty)

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -44,7 +44,7 @@ object PredDeps {
 
     val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(visitDef))
     val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
-    val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (inst: TypedAst.Instance) => inst.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
+    val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
 
     val g = LabelledPrecedenceGraph(sctx.edges.asScala.toVector)
     (root.copy(defs = defs, traits = traits, instances = instances, precedenceGraph = g), List.empty)

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -33,7 +33,7 @@ object Safety {
 
     val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(visitDef))
     val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
-    val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (inst: TypedAst.Instance) => inst.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
+    val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (i1: TypedAst.Instance, i2: TypedAst.Instance) => i1.tpe.typeConstructor == i2.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
 
     (root.copy(defs = defs, traits = traits, instances = instances), sctx.errors.asScala.toList)
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -33,7 +33,7 @@ object Safety {
 
     val defs = changeSet.updateStaleValues(root.defs, oldRoot.defs)(ParOps.parMapValues(_)(visitDef))
     val traits = changeSet.updateStaleValues(root.traits, oldRoot.traits)(ParOps.parMapValues(_)(visitTrait))
-    val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances)(ParOps.parMapValueList(_)(visitInstance))
+    val instances = changeSet.updateStaleValueLists(root.instances, oldRoot.instances, (inst: TypedAst.Instance) => inst.tpe.typeConstructor)(ParOps.parMapValueList(_)(visitInstance))
 
     (root.copy(defs = defs, traits = traits, instances = instances), sctx.errors.asScala.toList)
   }

--- a/main/test/ca/uwaterloo/flix/language/ast/TestChangeSet.scala
+++ b/main/test/ca/uwaterloo/flix/language/ast/TestChangeSet.scala
@@ -111,7 +111,7 @@ class TestChangeSet extends AnyFunSuite {
     val newMap = ListMap(3 -> List(src3), 4 -> List(src4, src5))
 
     val cs = ChangeSet.Everything
-    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1, v2) => v1 == v2)
+    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1: MySourceable, v2: MySourceable) => v1 == v2)
 
     assert(staleMap == newMap)
     assert(freshMap == ListMap.empty)
@@ -122,7 +122,7 @@ class TestChangeSet extends AnyFunSuite {
     val newMap = ListMap(1 -> List(src1, src2), 2 -> List(src2))
 
     val cs = ChangeSet.Everything.markChanged(input1, dg1)
-    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1, v2) => v1 == v2)
+    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1: MySourceable, v2: MySourceable) => v1 == v2)
 
     assert(staleMap == ListMap(1 -> List(src1)))
     assert(freshMap == ListMap(1 -> List(src2), 2 -> List(src2)))
@@ -133,7 +133,7 @@ class TestChangeSet extends AnyFunSuite {
     val newMap = ListMap(1 -> List(src1, src2), 2 -> List(src2), 3 -> List(src3), 4 -> List(src4), 5 -> List(src5))
 
     val cs = ChangeSet.Everything.markChanged(input1, dg2)
-    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1, v2) => v1 == v2)
+    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1: MySourceable, v2: MySourceable) => v1 == v2)
 
     assert(staleMap == ListMap(1 -> List(src2, src1), 2 -> List(src2), 3 -> List(src3), 4 -> List(src4), 5 -> List(src5)))
     assert(freshMap == ListMap.empty)
@@ -144,7 +144,7 @@ class TestChangeSet extends AnyFunSuite {
     val newMap = ListMap(1 -> List(src1, src2), 2 -> List(src2, src3), 3 -> List(src4))
 
     val cs = ChangeSet.Everything.markChanged(input3, dg1)
-    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1, v2) => v1 == v2)
+    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1: MySourceable, v2: MySourceable) => v1 == v2)
 
     assert(staleMap == ListMap(2 -> List(src3), 3 -> List(src4)))
     assert(freshMap == ListMap(1 -> List(src2, src1), 2 -> List(src2)))
@@ -155,7 +155,7 @@ class TestChangeSet extends AnyFunSuite {
     val newMap = ListMap(1 -> List(src1, src2), 2 -> List(src2))
 
     val cs = ChangeSet.Everything.markChanged(input3, dg1).markChanged(input4, dg1)
-    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1, v2) => v1 == v2)
+    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1: MySourceable, v2: MySourceable) => v1 == v2)
 
     assert(staleMap == ListMap.empty)
     assert(freshMap == ListMap(1 -> List(src2, src1), 2 -> List(src2)))
@@ -166,7 +166,7 @@ class TestChangeSet extends AnyFunSuite {
     val newMap = ListMap(1 -> List(src1, src2), 2 -> List(src2), 3 -> List(src4, src5))
 
     val cs = ChangeSet.Everything.markChanged(input3, dg1).markChanged(input5, dg1)
-    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1, v2) => v1 == v2)
+    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1: MySourceable, v2: MySourceable) => v1 == v2)
 
     assert(staleMap == ListMap(3 -> List(src5)))
     assert(freshMap == ListMap(1 -> List(src2, src1), 2 -> List(src2), 3 -> List(src4)))
@@ -177,7 +177,7 @@ class TestChangeSet extends AnyFunSuite {
     val newMap = ListMap(1 -> List(src1, src2), 2 -> List(src2), 3 -> List(src4, src5))
 
     val cs = ChangeSet.Everything.markChanged(input1, dg1).markChanged(input3, dg1).markChanged(input4, dg1)
-    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1, v2) => v1 == v2)
+    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1: MySourceable, v2: MySourceable) => v1 == v2)
 
     assert(staleMap == ListMap(1 -> List(src1), 3 -> List(src4)))
     assert(freshMap == ListMap(1 -> List(src2), 2 -> List(src2), 3 -> List(src5)))

--- a/main/test/ca/uwaterloo/flix/language/ast/TestChangeSet.scala
+++ b/main/test/ca/uwaterloo/flix/language/ast/TestChangeSet.scala
@@ -111,7 +111,7 @@ class TestChangeSet extends AnyFunSuite {
     val newMap = ListMap(3 -> List(src3), 4 -> List(src4, src5))
 
     val cs = ChangeSet.Everything
-    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap)
+    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1, v2) => v1 == v2)
 
     assert(staleMap == newMap)
     assert(freshMap == ListMap.empty)
@@ -122,7 +122,7 @@ class TestChangeSet extends AnyFunSuite {
     val newMap = ListMap(1 -> List(src1, src2), 2 -> List(src2))
 
     val cs = ChangeSet.Everything.markChanged(input1, dg1)
-    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap)
+    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1, v2) => v1 == v2)
 
     assert(staleMap == ListMap(1 -> List(src1)))
     assert(freshMap == ListMap(1 -> List(src2), 2 -> List(src2)))
@@ -133,7 +133,7 @@ class TestChangeSet extends AnyFunSuite {
     val newMap = ListMap(1 -> List(src1, src2), 2 -> List(src2), 3 -> List(src3), 4 -> List(src4), 5 -> List(src5))
 
     val cs = ChangeSet.Everything.markChanged(input1, dg2)
-    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap)
+    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1, v2) => v1 == v2)
 
     assert(staleMap == ListMap(1 -> List(src2, src1), 2 -> List(src2), 3 -> List(src3), 4 -> List(src4), 5 -> List(src5)))
     assert(freshMap == ListMap.empty)
@@ -144,7 +144,7 @@ class TestChangeSet extends AnyFunSuite {
     val newMap = ListMap(1 -> List(src1, src2), 2 -> List(src2, src3), 3 -> List(src4))
 
     val cs = ChangeSet.Everything.markChanged(input3, dg1)
-    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap)
+    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1, v2) => v1 == v2)
 
     assert(staleMap == ListMap(2 -> List(src3), 3 -> List(src4)))
     assert(freshMap == ListMap(1 -> List(src2, src1), 2 -> List(src2)))
@@ -155,7 +155,7 @@ class TestChangeSet extends AnyFunSuite {
     val newMap = ListMap(1 -> List(src1, src2), 2 -> List(src2))
 
     val cs = ChangeSet.Everything.markChanged(input3, dg1).markChanged(input4, dg1)
-    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap)
+    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1, v2) => v1 == v2)
 
     assert(staleMap == ListMap.empty)
     assert(freshMap == ListMap(1 -> List(src2, src1), 2 -> List(src2)))
@@ -166,7 +166,7 @@ class TestChangeSet extends AnyFunSuite {
     val newMap = ListMap(1 -> List(src1, src2), 2 -> List(src2), 3 -> List(src4, src5))
 
     val cs = ChangeSet.Everything.markChanged(input3, dg1).markChanged(input5, dg1)
-    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap)
+    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1, v2) => v1 == v2)
 
     assert(staleMap == ListMap(3 -> List(src5)))
     assert(freshMap == ListMap(1 -> List(src2, src1), 2 -> List(src2), 3 -> List(src4)))
@@ -177,7 +177,7 @@ class TestChangeSet extends AnyFunSuite {
     val newMap = ListMap(1 -> List(src1, src2), 2 -> List(src2), 3 -> List(src4, src5))
 
     val cs = ChangeSet.Everything.markChanged(input1, dg1).markChanged(input3, dg1).markChanged(input4, dg1)
-    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap)
+    val (staleMap, freshMap) = cs.partitionOnValues(newMap, oldMap, (v1, v2) => v1 == v2)
 
     assert(staleMap == ListMap(1 -> List(src1), 3 -> List(src4)))
     assert(freshMap == ListMap(1 -> List(src2), 2 -> List(src2), 3 -> List(src5)))


### PR DESCRIPTION
solves  #9966 

Now we use instance.tpe.typeConstructor to compare two instances.
![image](https://github.com/user-attachments/assets/dc013079-e773-47ab-a285-2e82c7e2e272)
