### PR TITLE
fix: EnumTagCompleter now supports all partially-qualified name

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -394,7 +394,7 @@ sealed trait Completion {
 
     case Completion.EnumTagCompletion(tag, namespace, ap, qualified, inScope) =>
       val qualifiedName = if (namespace.nonEmpty)
-        namespace.mkString(".") + "." + tag.sym.name
+        s"$namespace.${tag.sym.name}"
       else
         tag.sym.toString
       val name = if (qualified) qualifiedName else tag.sym.name
@@ -779,7 +779,7 @@ object Completion {
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the signature is inScope.
     */
-  case class EnumTagCompletion(tag: TypedAst.Case, namespace: List[String], ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
+  case class EnumTagCompletion(tag: TypedAst.Case, namespace: String, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
 
   /**
     * Represents a Module completion

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagCompleter.scala
@@ -17,7 +17,8 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.EnumTagCompletion
-import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Case, Enum}
+import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Case, Enum, Namespace}
+import ca.uwaterloo.flix.language.ast.Symbol
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
 import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
 import ca.uwaterloo.flix.language.errors.ResolutionError
@@ -44,7 +45,7 @@ object EnumTagCompleter {
       root.enums.values.flatMap(enm =>
         enm.cases.values.collect{
           case tag if CompletionUtils.isAvailable(enm) && CompletionUtils.matchesName(tag.sym, qn, qualified = false) =>
-            EnumTagCompletion(tag, Nil, ap, qualified = false, inScope = inScope(tag, env))
+            EnumTagCompletion(tag, "", ap, qualified = false, inScope = inScope(tag, env))
         }
       )
   }
@@ -52,13 +53,13 @@ object EnumTagCompleter {
   /**
     * Returns a List of Completion for Tag for fully qualified names.
     *
-    * We will assume the user is trying to type a fully qualified name and will only match against fully qualified names.
+    * We assume the user is trying to type a fully qualified name and will only match against fully qualified names.
     */
   private def fullyQualifiedCompletion(uri: String, ap: AnchorPosition, qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
     root.enums.values.flatMap(enm =>
       enm.cases.values.collect{
         case tag if CompletionUtils.isAvailable(enm) && CompletionUtils.matchesName(tag.sym, qn, qualified = true) =>
-          EnumTagCompletion(tag, Nil,  ap, qualified = true, inScope = true)
+          EnumTagCompletion(tag, "",  ap, qualified = true, inScope = true)
       }
     )
   }
@@ -72,12 +73,18 @@ object EnumTagCompleter {
     * We need to first find the fully qualified namespace by looking up the local environment, then use it to provide completions.
     */
   private def partiallyQualifiedCompletions(uri: String, ap: AnchorPosition, env: LocalScope, qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    val fullyQualifiedNamespaceHead = env.resolve(qn.namespace.idents.head.name) match {
+      case Some(Resolution.Declaration(Enum(_, _, _, sym, _, _, _, _))) => sym.toString
+      case Some(Resolution.Declaration(Namespace(name, _, _, _))) => name.toString
+      case _ => return Nil
+    }
+    val namespaceTail = qn.namespace.idents.tail.map(_.name).mkString(".")
+    val fullyQualifiedEnum = if (namespaceTail.isEmpty) fullyQualifiedNamespaceHead else s"$fullyQualifiedNamespaceHead.$namespaceTail"
     for {
-      case Resolution.Declaration(Enum(_, _, _, enumSym, _, _, _, _)) <- env.get(qn.namespace.toString)
-      enm <- root.enums.get(enumSym).toList
+      enm <- root.enums.get(Symbol.mkEnumSym(fullyQualifiedEnum)).toList
       tag <- enm.cases.values
       if CompletionUtils.isAvailable(enm) && CompletionUtils.matchesName(tag.sym, qn, qualified = false)
-    } yield EnumTagCompletion(tag, qn.namespace.parts, ap, qualified = true, inScope = true)
+    } yield EnumTagCompletion(tag, qn.namespace.toString, ap, qualified = true, inScope = true)
   }
 
   private def inScope(tag: TypedAst.Case, scope: LocalScope): Boolean = {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/SignatureCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/SignatureCompleter.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.SigCompletion
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Namespace, Sig, Trait}
-import ca.uwaterloo.flix.language.ast.Symbol.mkTraitSym
+import ca.uwaterloo.flix.language.ast.Symbol
 import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
 import ca.uwaterloo.flix.language.errors.ResolutionError
@@ -74,7 +74,7 @@ object SignatureCompleter {
     val namespaceTail = qn.namespace.idents.tail.map(_.name).mkString(".")
     val fullyQualifiedTrait = if (namespaceTail.isEmpty) fullyQualifiedNamespaceHead else s"$fullyQualifiedNamespaceHead.$namespaceTail"
     for {
-      trt <- root.traits.get(mkTraitSym(fullyQualifiedTrait)).toList
+      trt <- root.traits.get(Symbol.mkTraitSym(fullyQualifiedTrait)).toList
       sig <- trt.sigs
       if CompletionUtils.isAvailable(trt) && CompletionUtils.matchesName(sig.sym, qn, qualified = false)
     } yield SigCompletion(sig, qn.namespace.toString, ap, qualified = true, inScope = true)


### PR DESCRIPTION
Use the same algorithm used in SignatureCompleter. Now we support the namspace head to be either module or enum:
<img width="631" alt="image" src="https://github.com/user-attachments/assets/7e979e76-c466-49df-9479-7280c5f092b2" />
<img width="558" alt="image" src="https://github.com/user-attachments/assets/a7d16d8e-1d86-4160-9550-d6b3abf045d9" />

Although the algorithm is the same, the pattern matching and field accessing makes it hard to reuse to code:
![image](https://github.com/user-attachments/assets/17fe95c1-8cb0-40c1-b7ca-872f8e749d3e)
