### PR TITLE
fix: EnumCompleter should not complete with typeparameters in expr

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumCompleter.scala
@@ -29,7 +29,7 @@ object EnumCompleter {
     * When providing completions for unqualified enums that is not in scope, we will also automatically use the enum.
     */
   def getCompletions(err: ResolutionError.UndefinedName)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    getCompletions(err.qn.loc.source.name, err.ap, err.env, err.qn, withTypeParameters = true)
+    getCompletions(err.qn.loc.source.name, err.ap, err.env, err.qn, withTypeParameters = false)
   }
 
   def getCompletions(err: ResolutionError.UndefinedTag)(implicit root: TypedAst.Root): Iterable[Completion] = {


### PR DESCRIPTION
<img width="461" alt="image" src="https://github.com/user-attachments/assets/814c3449-8512-42dd-a0af-226d3ba051b8" />

Only UndefinedType will bring the type parameter.