### PR TITLE
fix: let compiler emit undefined new

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -831,6 +831,24 @@ object WeederError {
   }
 
   /**
+    * An error raised to indicate that an argument list is missing a kind.
+    *
+    * @param loc the location of the type parameter.
+    */
+  case class MissingArgumentList(loc: SourceLocation) extends WeederError {
+    def summary: String = "An argument list is required here"
+
+    def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> Missing argument list. An argument list is required here.
+         |
+         |${code(loc, "missing argument list.")}
+         |
+         |""".stripMargin
+    }
+  }
+
+  /**
     * An error raised to indicate that a type parameter is missing a kind.
     *
     * @param loc the location of the type parameter.

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -813,24 +813,6 @@ object WeederError {
   }
 
   /**
-    * An error raised to indicate that the formal parameter lacks a type declaration.
-    *
-    * @param name the name of the parameter.
-    * @param loc  the location of the formal parameter.
-    */
-  case class MissingFormalParamAscription(name: String, loc: SourceLocation) extends WeederError {
-    def summary: String = "Missing type ascription. Type ascriptions are required for parameters here."
-
-    def message(formatter: Formatter): String = {
-      import formatter.*
-      s""">> The formal parameter '${red(name)}' must have a declared type.
-         |
-         |${code(loc, "has no declared type.")}
-         |""".stripMargin
-    }
-  }
-
-  /**
     * An error raised to indicate that an argument list is missing a kind.
     *
     * @param loc the location of the argument list.
@@ -844,6 +826,24 @@ object WeederError {
          |
          |${code(loc, "missing argument list.")}
          |
+         |""".stripMargin
+    }
+  }
+
+  /**
+    * An error raised to indicate that the formal parameter lacks a type declaration.
+    *
+    * @param name the name of the parameter.
+    * @param loc  the location of the formal parameter.
+    */
+  case class MissingFormalParamAscription(name: String, loc: SourceLocation) extends WeederError {
+    def summary: String = "Missing type ascription. Type ascriptions are required for parameters here."
+
+    def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> The formal parameter '${red(name)}' must have a declared type.
+         |
+         |${code(loc, "has no declared type.")}
          |""".stripMargin
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -833,7 +833,7 @@ object WeederError {
   /**
     * An error raised to indicate that an argument list is missing a kind.
     *
-    * @param loc the location of the type parameter.
+    * @param loc the location of the argument list.
     */
   case class MissingArgumentList(loc: SourceLocation) extends WeederError {
     def summary: String = "An argument list is required here"

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1813,18 +1813,19 @@ object Weeder2 {
           val error = WeederError.MissingArgumentList(tree.loc)
           sctx.errors.add(error)
           Validation.Success(List.empty)
-        case Some(argumentList) => visitMethodArguments(argumentList)
+        case Some(argumentList) =>
+          visitMethodArguments(argumentList)
       }
-          mapN(Types.pickType(tree), expsValidation) {
-            (tpe, exps) => tpe match {
-                case WeededAst.Type.Ambiguous(qname, _) if qname.isUnqualified =>
-                  Expr.InvokeConstructor(qname.ident, exps, tree.loc)
-                case _ =>
-                  val error = IllegalQualifiedName(tree.loc)
-                  sctx.errors.add(error)
-                  Expr.Error(error)
-              }
+      mapN(Types.pickType(tree), expsValidation) {
+        (tpe, exps) => tpe match {
+            case WeededAst.Type.Ambiguous(qname, _) if qname.isUnqualified =>
+              Expr.InvokeConstructor(qname.ident, exps, tree.loc)
+            case _ =>
+              val error = IllegalQualifiedName(tree.loc)
+              sctx.errors.add(error)
+              Expr.Error(error)
           }
+      }
     }
 
     private def visitInvokeMethodExpr(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1808,11 +1808,11 @@ object Weeder2 {
 
     private def visitInvokeConstructorExpr(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {
       expect(tree, TreeKind.Expr.InvokeConstructor)
-      mapN(Types.pickType(tree), pickRawArguments(tree, synctx = SyntacticContext.Expr.New)) {
+      mapN(Types.pickType(tree), traverseOpt(tryPick(TreeKind.ArgumentList, tree))(visitMethodArguments)) {
         (tpe, exps) =>
           tpe match {
             case WeededAst.Type.Ambiguous(qname, _) if qname.isUnqualified =>
-              Expr.InvokeConstructor(qname.ident, exps, tree.loc)
+              Expr.InvokeConstructor(qname.ident, exps.getOrElse(Nil), tree.loc)
             case _ =>
               val error = IllegalQualifiedName(tree.loc)
               sctx.errors.add(error)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -949,6 +949,34 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.MismatchedTypeParameters](result)
   }
 
+  test("MissingArgumentList.01") {
+    val input =
+      """
+        |struct Person[r] {
+        |    name: String,
+        |    age: Int32
+        |}
+        |
+        |def f(): Person[r] = new Per
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.MissingArgumentList](result)
+  }
+
+  test("MissingArgumentList.02") {
+    val input =
+      """
+        |struct Person[r] {
+        |    name: String,
+        |    age: Int32
+        |}
+        |
+        |def f(): Person[r] = new Person
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.MissingArgumentList](result)
+  }
+
   test("MissingFormalParamAscription.01") {
     val input =
       """


### PR DESCRIPTION
refer to #8759 for the context
Now the master branch will only emit a parse error:
<img width="698" alt="image" src="https://github.com/user-attachments/assets/ccea52ca-2c6b-4284-b6c6-d7e79faa54f0" />
And the reason is that pickRawArguments will fails if there is nothing.

We have to recover from that case and build a invokeConstructor with an empty list of args.

Then it works
<img width="764" alt="image" src="https://github.com/user-attachments/assets/e7e0238a-49e2-49ce-a396-acbe97f77a6d" />
