### PR TITLE
feat: keep empty modules

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -19,7 +19,7 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.TypedAst.Decl
 import ca.uwaterloo.flix.language.ast.shared.*
-import ca.uwaterloo.flix.language.ast.{Kind, Name, Symbol, Type, TypeConstructor, TypedAst}
+import ca.uwaterloo.flix.language.ast.{Kind, Name, QualifiedSym, Symbol, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.fmt.FormatType
 
 import scala.annotation.tailrec

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -26,6 +26,12 @@ import scala.collection.immutable.SortedSet
 
 sealed trait Symbol
 
+sealed trait QualifiedSym extends Symbol{
+  def namespace: List[String]
+  def name: String
+}
+
+
 object Symbol {
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/QualifiedSym.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/QualifiedSym.scala
@@ -13,10 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package ca.uwaterloo.flix.language.ast.shared
-
-trait QualifiedSym{
-  def namespace: List[String]
-  def name: String
-}

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -92,8 +92,8 @@ object Typer {
       val companion_modules =
         for {
           sym <- constructs_with_companion_module
-          modSym = new Symbol.ModuleSym(sym.namespace :+ sym.name)
-        } yield modSym -> Iterable.empty
+          modSym = new Symbol.ModuleSym(sym.namespace :+ sym.name, ModuleKind.Companion)
+        } yield modSym -> List.empty[Symbol]
 
       val groups = syms.groupBy {
         case sym: Symbol.DefnSym => new Symbol.ModuleSym(sym.namespace, ModuleKind.Standalone)
@@ -121,8 +121,8 @@ object Typer {
         case sym: Symbol.HoleSym => throw InternalCompilerException(s"unexpected symbol: $sym", sym.loc)
       }
 
-      groups.map {
-        case (k, v) => (k, v.toList)
+      groups.foldLeft(companion_modules.toMap) {
+        case (acc, (mod, syms)) => acc.updated(mod, syms.toList)
       }
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -87,13 +87,14 @@ object Typer {
       }.toSet
       val syms = syms0 ++ namespaces
 
-      val constructs_with_companion_module = traits.keys ++ enums.keys ++ structs.keys ++ effects.keys
+      val constructsWithCompanionModule = traits.keys ++ enums.keys ++ structs.keys ++ effects.keys
+
       // The companion modules, empty by default.
-      val companion_modules =
-        for {
-          sym <- constructs_with_companion_module
-          modSym = new Symbol.ModuleSym(sym.namespace :+ sym.name, ModuleKind.Companion)
-        } yield modSym -> List.empty[Symbol]
+      val companionModules = constructsWithCompanionModule.map {
+        sym =>
+          val modSym = new Symbol.ModuleSym(sym.namespace :+ sym.name, ModuleKind.Companion)
+          modSym -> List.empty[Symbol]
+      }
 
       val groups = syms.groupBy {
         case sym: Symbol.DefnSym => new Symbol.ModuleSym(sym.namespace, ModuleKind.Standalone)
@@ -121,7 +122,7 @@ object Typer {
         case sym: Symbol.HoleSym => throw InternalCompilerException(s"unexpected symbol: $sym", sym.loc)
       }
 
-      groups.foldLeft(companion_modules.toMap) {
+      groups.foldLeft(companionModules.toMap) {
         case (acc, (mod, syms)) => acc.updated(mod, syms.toList)
       }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -136,6 +136,9 @@ object Typer {
       }
   }
 
+  /**
+    * Adds the given qualified symbol to the set of symbols for the given module in the given map.
+    */
   private def addToModuleMap(qualifiedSym: QualifiedSym, moduleMap: Map[ModuleSym, Set[Symbol]]) = {
     val mod = new Symbol.ModuleSym(qualifiedSym.namespace, ModuleKind.Standalone)
     val set = moduleMap.getOrElse(mod, Set.empty)

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -93,14 +93,14 @@ object Typer {
       val companionModules = constructsWithCompanionModule.foldLeft(Map.empty[ModuleSym, Set[Symbol]]) {
         case (acc, sym) =>
           val companionModule = new Symbol.ModuleSym(sym.namespace :+ sym.name, ModuleKind.Companion)
-          val parentMod = new Symbol.ModuleSym(sym.namespace, ModuleKind.Standalone)
-          val set = acc.getOrElse(parentMod, Set.empty)
+          val parentModule = new Symbol.ModuleSym(sym.namespace, ModuleKind.Standalone)
+          val set = acc.getOrElse(parentModule, Set.empty)
           // Add the companion module to the set of symbols for its parent module
           // Also, add the companion module with a default empty set of symbols
-          acc.updated(parentMod, set + companionModule).updated(companionModule, Set.empty)
+          acc.updated(parentModule, set + companionModule).updated(companionModule, Set.empty)
       }
 
-      val mods = syms.foldLeft(companionModules) {
+      val modules = syms.foldLeft(companionModules) {
         case (acc, sym) =>
           sym match {
             case sym: Symbol.CaseSym => throw InternalCompilerException(s"unexpected symbol: $sym", sym.loc)
@@ -122,7 +122,7 @@ object Typer {
           }
       }
 
-      mods.map{
+      modules.map{
         case (mod, syms) => mod -> syms.toList
       }
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -87,6 +87,14 @@ object Typer {
       }.toSet
       val syms = syms0 ++ namespaces
 
+      val constructs_with_companion_module = traits.keys ++ enums.keys ++ structs.keys ++ effects.keys
+      // The companion modules, empty by default.
+      val companion_modules =
+        for {
+          sym <- constructs_with_companion_module
+          modSym = new Symbol.ModuleSym(sym.namespace :+ sym.name)
+        } yield modSym -> Iterable.empty
+
       val groups = syms.groupBy {
         case sym: Symbol.DefnSym => new Symbol.ModuleSym(sym.namespace, ModuleKind.Standalone)
         case sym: Symbol.EnumSym => new Symbol.ModuleSym(sym.namespace, ModuleKind.Standalone)


### PR DESCRIPTION
first step to #9976

Now we will have this empty companion modules. So we will has duplicated completion suggestions.

<img width="738" alt="image" src="https://github.com/user-attachments/assets/61e9e9a5-d08a-46ce-977a-0165a323c08d" />


Next step will be let ModuleCompleter take the duty of those dedicated completers.

But the Construct Kind is erased: they are all just modules. If we want to keep that, maybe keep a map in the root?