### PR TITLE
feat: emit undefined effect in handler

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2488,11 +2488,8 @@ object Parser2 {
           delimiterR = TokenKind.CurlyR,
           context = SyntacticContext.Expr.OtherExpr
         )
-        close(mark, TreeKind.Expr.Handler)
-      } else {
-        val token = nth(0)
-        closeWithError(mark, ParseError.UnexpectedToken(NamedTokenSet.FromKinds(Set(TokenKind.CurlyL)), Some(token), SyntacticContext.WithHandler, loc = currentSourceLocation()))
       }
+      close(mark, TreeKind.Expr.Handler)
     }
 
     private def tryExpr()(implicit s: State): Mark.Closed = {

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -2488,6 +2488,8 @@ object Parser2 {
           delimiterR = TokenKind.CurlyR,
           context = SyntacticContext.Expr.OtherExpr
         )
+      } else {
+        s.errors.append(ParseError.UnexpectedToken(expected = NamedTokenSet.FromKinds(Set(TokenKind.CurlyL)) , actual = Some(nth(0)), sctx = SyntacticContext.Expr.OtherExpr, loc = currentSourceLocation()))
       }
       close(mark, TreeKind.Expr.Handler)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1763,7 +1763,6 @@ object Resolver {
             Result.Ok((symUse, rules))
         }
       case Result.Err(error) =>
-        sctx.errors.add(error)
         Validation.Success(Result.Err(error))
     }
   }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -740,6 +740,21 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
+  test("MissingWithBody.01") {
+    val input =
+      """
+        |def foo(): Bool =
+        |    let result = run {
+        |        mutual1(10)
+        |    } with handler AskTell ;
+        |    Assert.eq(Some(84), result)
+        |def main(): Int32 = 123
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ParseError](result)
+    expectMain(result)
+  }
+
   test("MissingCatchBody.01") {
     val input =
       """

--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -740,21 +740,6 @@ class TestParserRecovery extends AnyFunSuite with TestUtils {
     expectMain(result)
   }
 
-  test("MissingWithBody.01") {
-    val input =
-      """
-        |def foo(): Bool =
-        |    let result = run {
-        |        mutual1(10)
-        |    } with handler AskTell ;
-        |    Assert.eq(Some(84), result)
-        |def main(): Int32 = 123
-        |""".stripMargin
-    val result = check(input, Options.TestWithLibMin)
-    expectErrorOnCheck[ParseError](result)
-    expectMain(result)
-  }
-
   test("MissingCatchBody.01") {
     val input =
       """

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -2009,7 +2009,7 @@ class TestResolver extends AnyFunSuite with TestUtils {
         |    } with handler E
         |}
         |""".stripMargin
-    val result = check(input, Options.TestWithLibMin)
+    val result = check(input, Options.TestWithLibNix)
     expectErrorOnCheck[ResolutionError.MissingHandlerDef](result)
     expectMain(result)
   }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -538,6 +538,15 @@ class TestResolver extends AnyFunSuite with TestUtils {
     expectError[ResolutionError.UndefinedEffect](result)
   }
 
+ test("UndefinedEffect.02") {
+   val input =
+     """
+       |def f(): Unit = run () with handler Ef
+       |""".stripMargin
+   val result = compile(input, Options.TestWithLibNix)
+   expectError[ResolutionError.UndefinedEffect](result)
+ }
+
   test("UndefinedOp.01") {
     val input =
       """
@@ -1985,4 +1994,20 @@ class TestResolver extends AnyFunSuite with TestUtils {
     val result = compile(input, Options.TestWithLibNix)
     expectError[ResolutionError.MissingHandlerDef](result)
   }
+
+  test("ResolutionError.MissingHandlerDef.03") {
+    val input =
+      """
+        |def foo(): Bool =
+        |    let result = run {
+        |        mutual1(10)
+        |    } with handler AskTell ;
+        |    Assert.eq(Some(84), result)
+        |def main(): Int32 = 123
+        |""".stripMargin
+    val result = check(input, Options.TestWithLibMin)
+    expectErrorOnCheck[ResolutionError.MissingHandlerDef](result)
+    expectMain(result)
+  }
+
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -1998,12 +1998,16 @@ class TestResolver extends AnyFunSuite with TestUtils {
   test("ResolutionError.MissingHandlerDef.03") {
     val input =
       """
-        |def foo(): Bool =
-        |    let result = run {
-        |        mutual1(10)
-        |    } with handler AskTell ;
-        |    Assert.eq(Some(84), result)
-        |def main(): Int32 = 123
+        |eff E {
+        |    def op1(): Unit
+        |    def op2(): Unit
+        |}
+        |
+        |def foo(): Unit = {
+        |    run {
+        |      E.op1()
+        |    } with handler E
+        |}
         |""".stripMargin
     val result = check(input, Options.TestWithLibMin)
     expectErrorOnCheck[ResolutionError.MissingHandlerDef](result)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestResolver.scala
@@ -2011,7 +2011,6 @@ class TestResolver extends AnyFunSuite with TestUtils {
         |""".stripMargin
     val result = check(input, Options.TestWithLibNix)
     expectErrorOnCheck[ResolutionError.MissingHandlerDef](result)
-    expectMain(result)
   }
 
 }


### PR DESCRIPTION
Currently, we can only see a parse error with withHandler context, and WithHandlerCompleter, which is an evil ctx-dependent completer, will provide completions.

![image](https://github.com/user-attachments/assets/9281e4ec-27b0-484e-b9eb-e1470fbb81a1)

So I first change the parser to recover from a handler with only the name(maybe incomplete name).

Then the resolver will find out that it's a undefined effect.

![image](https://github.com/user-attachments/assets/caa73a46-665b-452f-8f6e-1011db439196)

And if the name is resolved, there is still an error indicating the missing handler:
![image](https://github.com/user-attachments/assets/13304ee1-983c-4e5c-a254-01776d05a77b)

So the next step:
- add env to UndefinedEff (#9997)
- call EffectCompleter over UndefinedEfffect(yes, currently it's not called) and provide completion with the op snippet. Then we can remove WithHandlerCompleter.
