### PR TITLE
feat: introduce module kind

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -957,7 +957,7 @@ object Symbol {
   /**
     * Module symbol.
     */
-  final class ModuleSym(val ns: List[String], val kind : ModuleKind) extends Symbol {
+  final class ModuleSym(val ns: List[String], val kind: ModuleKind) extends Symbol {
     /**
       * Returns `true` if this is the root module.
       */

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Name.{Ident, NName}
-import ca.uwaterloo.flix.language.ast.shared.{BoundBy, QualifiedSym, Scope, Source, VarText}
+import ca.uwaterloo.flix.language.ast.shared.{BoundBy, ModuleKind, QualifiedSym, Scope, Source, VarText}
 import ca.uwaterloo.flix.util.InternalCompilerException
 
 import java.util.Objects
@@ -237,7 +237,7 @@ object Symbol {
   /**
     * Returns the module symbol for the given fully qualified name.
     */
-  def mkModuleSym(fqn: List[String]): ModuleSym = new ModuleSym(fqn)
+  def mkModuleSym(fqn: List[String]): ModuleSym = new ModuleSym(fqn, ModuleKind.Standalone)
 
   /**
     * Returns the trait symbol for the given name `ident` in the given namespace `ns`.
@@ -957,11 +957,19 @@ object Symbol {
   /**
     * Module symbol.
     */
-  final class ModuleSym(val ns: List[String]) extends Symbol {
+  final class ModuleSym(val ns: List[String], val kind : ModuleKind) extends Symbol {
     /**
       * Returns `true` if this is the root module.
       */
     def isRoot: Boolean = ns.isEmpty
+
+    /**
+      * Returns `true` if this is a standalone module.
+      */
+    def isStandalone: Boolean = kind match {
+      case ModuleKind.Standalone => true
+      case _ => false
+    }
 
     /**
       * Returns `true` if this symbol is equal to `that` symbol.

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/ModuleKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/ModuleKind.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Chenhao Gao
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.uwaterloo.flix.language.ast.shared
+
+/**
+  * Represents the kind of module.
+  */
+sealed trait ModuleKind {}
+
+object ModuleKind {
+  /**
+    * A Companion modules comes with a flix construct.
+    * To be specific, it is a module that is associated with an effect, enum, struct or trait.
+    */
+  case object Companion extends ModuleKind
+
+  /**
+    * A Standalone module.
+    */
+  case object Standalone extends ModuleKind
+}

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/ModuleKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/ModuleKind.scala
@@ -13,23 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package ca.uwaterloo.flix.language.ast.shared
 
 /**
-  * Represents the kind of module.
+  * Represents the kind of a module.
   */
-sealed trait ModuleKind {}
+sealed trait ModuleKind
 
 object ModuleKind {
   /**
-    * A Companion modules comes with a flix construct.
-    * To be specific, it is a module that is associated with an effect, enum, struct or trait.
+    * A module associated with an effect, enum, struct, or trait.
     */
   case object Companion extends ModuleKind
 
   /**
-    * A Standalone module.
+    * A standalone module.
     */
   case object Standalone extends ModuleKind
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Namer.scala
@@ -97,7 +97,7 @@ object Namer {
       val ns = Name.NName(ns0.idents :+ ident, ident.loc)
       val usesAndImports = usesAndImports0.map(visitUseOrImport)
       val ds = decls.map(visitDecl(_, ns))
-      val sym = new Symbol.ModuleSym(ns.parts)
+      val sym = new Symbol.ModuleSym(ns.parts, ModuleKind.Standalone)
       NamedAst.Declaration.Namespace(sym, usesAndImports, ds, loc)
   }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -84,7 +84,7 @@ object Resolver {
     val usesVal = root.uses.map {
       case (ns, uses0) =>
         mapN(traverse(uses0)(visitUseOrImport(_, ns, root))) {
-          u => new Symbol.ModuleSym(ns.parts) -> u
+          u => new Symbol.ModuleSym(ns.parts, ModuleKind.Standalone) -> u
         }
     }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Typer.scala
@@ -82,26 +82,26 @@ object Typer {
       }.flatMap {
         fullNs =>
           fullNs.inits.collect {
-            case ns@(_ :: _) => new Symbol.ModuleSym(ns)
+            case ns@(_ :: _) => new Symbol.ModuleSym(ns, ModuleKind.Standalone)
           }
       }.toSet
       val syms = syms0 ++ namespaces
 
       val groups = syms.groupBy {
-        case sym: Symbol.DefnSym => new Symbol.ModuleSym(sym.namespace)
-        case sym: Symbol.EnumSym => new Symbol.ModuleSym(sym.namespace)
-        case sym: Symbol.StructSym => new Symbol.ModuleSym(sym.namespace)
-        case sym: Symbol.StructFieldSym => new Symbol.ModuleSym(sym.namespace)
-        case sym: Symbol.RestrictableEnumSym => new Symbol.ModuleSym(sym.namespace)
-        case sym: Symbol.TraitSym => new Symbol.ModuleSym(sym.namespace)
-        case sym: Symbol.TypeAliasSym => new Symbol.ModuleSym(sym.namespace)
-        case sym: Symbol.EffectSym => new Symbol.ModuleSym(sym.namespace)
+        case sym: Symbol.DefnSym => new Symbol.ModuleSym(sym.namespace, ModuleKind.Standalone)
+        case sym: Symbol.EnumSym => new Symbol.ModuleSym(sym.namespace, ModuleKind.Standalone)
+        case sym: Symbol.StructSym => new Symbol.ModuleSym(sym.namespace, ModuleKind.Standalone)
+        case sym: Symbol.StructFieldSym => new Symbol.ModuleSym(sym.namespace, ModuleKind.Standalone)
+        case sym: Symbol.RestrictableEnumSym => new Symbol.ModuleSym(sym.namespace, ModuleKind.Standalone)
+        case sym: Symbol.TraitSym => new Symbol.ModuleSym(sym.namespace, ModuleKind.Standalone)
+        case sym: Symbol.TypeAliasSym => new Symbol.ModuleSym(sym.namespace, ModuleKind.Standalone)
+        case sym: Symbol.EffectSym => new Symbol.ModuleSym(sym.namespace, ModuleKind.Standalone)
 
-        case sym: Symbol.SigSym => new Symbol.ModuleSym(sym.trt.namespace :+ sym.trt.name)
-        case sym: Symbol.OpSym => new Symbol.ModuleSym(sym.eff.namespace :+ sym.eff.name)
-        case sym: Symbol.AssocTypeSym => new Symbol.ModuleSym(sym.trt.namespace :+ sym.trt.name)
+        case sym: Symbol.SigSym => new Symbol.ModuleSym(sym.trt.namespace :+ sym.trt.name, ModuleKind.Standalone)
+        case sym: Symbol.OpSym => new Symbol.ModuleSym(sym.eff.namespace :+ sym.eff.name, ModuleKind.Standalone)
+        case sym: Symbol.AssocTypeSym => new Symbol.ModuleSym(sym.trt.namespace :+ sym.trt.name, ModuleKind.Standalone)
 
-        case sym: Symbol.ModuleSym => new Symbol.ModuleSym(sym.ns.init)
+        case sym: Symbol.ModuleSym => new Symbol.ModuleSym(sym.ns.init, ModuleKind.Standalone)
 
         case sym: Symbol.CaseSym => throw InternalCompilerException(s"unexpected symbol: $sym", sym.loc)
         case sym: Symbol.RestrictableCaseSym => throw InternalCompilerException(s"unexpected symbol: $sym", sym.loc)
@@ -116,7 +116,6 @@ object Typer {
       groups.map {
         case (k, v) => (k, v.toList)
       }
-
   }
 
   /**


### PR DESCRIPTION
As discussed in #9994
We introduce ModuleKind to tell which modules are companion ones.

We will only use it in the completer and the completer will only access the module syms built in Typer.

So the module kind for syms built elsewhere does not matter. I just assume they are all stand alone ones.

It could be complicated to determine the real kind of modules in those places. Or we can introduce a new case Unknown if you prefer