### PR TITLE
fix: make holeCompleter work when there are no errors

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -98,9 +98,10 @@ object CompletionProvider {
                 case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords
                 case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords
 
-                case _ => Nil
-              }
-            })
+              case _ => Nil
+            }
+            case _ => Nil
+          })
         completions.map(comp => comp.toCompletionItem(ctx))
       }.getOrElse(Nil)
     CompletionList(isIncomplete = true, completionItems)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -47,65 +47,60 @@ object CompletionProvider {
         val completions = if (currentErrors.isEmpty)
           HoleCompleter.getHoleCompletion(uri, pos, root)
         else
-        errorsAt(uri, pos, currentErrors).flatMap({
-          case err: WeederError.UnqualifiedUse =>
-            UseCompleter.getCompletions(uri, err)
-          case WeederError.UndefinedAnnotation(_, _) => KeywordCompleter.getModKeywords
-          case err: ResolutionError.UndefinedEffect =>
-            EffectCompleter.getCompletions(err)
-          case err: ResolutionError.UndefinedUse =>
-            UseCompleter.getCompletions(uri, err)
-          case err: ResolutionError.UndefinedTag =>
-            EnumCompleter.getCompletions(err) ++
-              EnumTagCompleter.getCompletions(err) ++
-              ModuleCompleter.getCompletions(err)
-          case err: ResolutionError.UndefinedName =>
-            AutoImportCompleter.getCompletions(err) ++
-              LocalScopeCompleter.getCompletions(err) ++
-              KeywordCompleter.getExprKeywords ++
-              DefCompleter.getCompletions(err) ++
+          errorsAt(uri, pos, currentErrors).flatMap({
+            case err: WeederError.UnqualifiedUse => UseCompleter.getCompletions(uri, err)
+            case WeederError.UndefinedAnnotation(_, _) => KeywordCompleter.getModKeywords
+            case err: ResolutionError.UndefinedEffect => EffectCompleter.getCompletions(err)
+            case err: ResolutionError.UndefinedUse => UseCompleter.getCompletions(uri, err)
+            case err: ResolutionError.UndefinedTag =>
               EnumCompleter.getCompletions(err) ++
-              EffectCompleter.getCompletions(err) ++
-              OpCompleter.getCompletions(err) ++
-              SignatureCompleter.getCompletions(err) ++
-              EnumTagCompleter.getCompletions(err) ++
-              TraitCompleter.getCompletions(err) ++
-              ModuleCompleter.getCompletions(err)
-          case err: ResolutionError.UndefinedType =>
-            TypeBuiltinCompleter.getCompletions ++
+                EnumTagCompleter.getCompletions(err) ++
+                ModuleCompleter.getCompletions(err)
+            case err: ResolutionError.UndefinedName =>
               AutoImportCompleter.getCompletions(err) ++
-              LocalScopeCompleter.getCompletions(err) ++
-              EnumCompleter.getCompletions(err) ++
-              StructCompleter.getCompletions(err) ++
-              EffectCompleter.getCompletions(err) ++
-              TypeAliasCompleter.getCompletions(err) ++
-              ModuleCompleter.getCompletions(err)
-          case err: ResolutionError.UndefinedJvmStaticField => GetStaticFieldCompleter.getCompletions(err) ++ InvokeStaticMethodCompleter.getCompletions(err)
-          case err: ResolutionError.UndefinedJvmImport => ImportCompleter.getCompletions(err)
-          case err: ResolutionError.UndefinedTrait => TraitCompleter.getCompletions(err)
-          case err: ResolutionError.UndefinedStructField => StructFieldCompleter.getCompletions(err, root)
-          case err: ResolutionError.UndefinedKind => KindCompleter.getCompletions(err)
-          case err: ResolutionError.UndefinedOp =>
-            OpCompleter.getCompletions(err)
-          case err: TypeError.FieldNotFound => MagicMatchCompleter.getCompletions(err) ++ InvokeMethodCompleter.getCompletions(err.tpe, err.fieldName)
-          case err: TypeError.MethodNotFound => InvokeMethodCompleter.getCompletions(err.tpe, err.methodName)
-          case err: ParseError => err.sctx match {
-            // Expressions.
-            case SyntacticContext.Expr.Constraint => PredicateCompleter.getCompletions(uri) ++ KeywordCompleter.getConstraintKeywords
-            case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords
+                LocalScopeCompleter.getCompletions(err) ++
+                KeywordCompleter.getExprKeywords ++
+                DefCompleter.getCompletions(err) ++
+                EnumCompleter.getCompletions(err) ++
+                EffectCompleter.getCompletions(err) ++
+                OpCompleter.getCompletions(err) ++
+                SignatureCompleter.getCompletions(err) ++
+                EnumTagCompleter.getCompletions(err) ++
+                TraitCompleter.getCompletions(err) ++
+                ModuleCompleter.getCompletions(err)
+            case err: ResolutionError.UndefinedType =>
+              TypeBuiltinCompleter.getCompletions ++
+                AutoImportCompleter.getCompletions(err) ++
+                LocalScopeCompleter.getCompletions(err) ++
+                EnumCompleter.getCompletions(err) ++
+                StructCompleter.getCompletions(err) ++
+                EffectCompleter.getCompletions(err) ++
+                TypeAliasCompleter.getCompletions(err) ++
+                ModuleCompleter.getCompletions(err)
+            case err: ResolutionError.UndefinedJvmStaticField => GetStaticFieldCompleter.getCompletions(err) ++ InvokeStaticMethodCompleter.getCompletions(err)
+            case err: ResolutionError.UndefinedJvmImport => ImportCompleter.getCompletions(err)
+            case err: ResolutionError.UndefinedTrait => TraitCompleter.getCompletions(err)
+            case err: ResolutionError.UndefinedStructField => StructFieldCompleter.getCompletions(err, root)
+            case err: ResolutionError.UndefinedKind => KindCompleter.getCompletions(err)
+            case err: ResolutionError.UndefinedOp => OpCompleter.getCompletions(err)
+            case err: TypeError.FieldNotFound => MagicMatchCompleter.getCompletions(err) ++ InvokeMethodCompleter.getCompletions(err.tpe, err.fieldName)
+            case err: TypeError.MethodNotFound => InvokeMethodCompleter.getCompletions(err.tpe, err.methodName)
+            case err: ParseError => err.sctx match {
+              // Expressions.
+              case SyntacticContext.Expr.Constraint => PredicateCompleter.getCompletions(uri) ++ KeywordCompleter.getConstraintKeywords
+              case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords
 
-          // Declarations.
-          case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords
-          case SyntacticContext.Decl.Effect => KeywordCompleter.getEffectKeywords
-          case SyntacticContext.Decl.Module => KeywordCompleter.getModKeywords ++ ExprSnippetCompleter.getCompletions()
-          case SyntacticContext.Decl.Struct => KeywordCompleter.getStructKeywords
-          case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords
-          case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords
+                // Declarations.
+                case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords
+                case SyntacticContext.Decl.Effect => KeywordCompleter.getEffectKeywords
+                case SyntacticContext.Decl.Module => KeywordCompleter.getModKeywords ++ ExprSnippetCompleter.getCompletions()
+                case SyntacticContext.Decl.Struct => KeywordCompleter.getStructKeywords
+                case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords
+                case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords
 
-          case _ => Nil
-        }
-
-        })
+                case _ => Nil
+              }
+            })
         completions.map(comp => comp.toCompletionItem(ctx))
       }.getOrElse(Nil)
     CompletionList(isIncomplete = true, completionItems)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -90,13 +90,13 @@ object CompletionProvider {
               case SyntacticContext.Expr.Constraint => PredicateCompleter.getCompletions(uri) ++ KeywordCompleter.getConstraintKeywords
               case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords
 
-                // Declarations.
-                case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords
-                case SyntacticContext.Decl.Effect => KeywordCompleter.getEffectKeywords
-                case SyntacticContext.Decl.Module => KeywordCompleter.getModKeywords ++ ExprSnippetCompleter.getCompletions()
-                case SyntacticContext.Decl.Struct => KeywordCompleter.getStructKeywords
-                case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords
-                case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords
+              // Declarations.
+              case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords
+              case SyntacticContext.Decl.Effect => KeywordCompleter.getEffectKeywords
+              case SyntacticContext.Decl.Module => KeywordCompleter.getModKeywords ++ ExprSnippetCompleter.getCompletions()
+              case SyntacticContext.Decl.Struct => KeywordCompleter.getStructKeywords
+              case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords
+              case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords
 
               case SyntacticContext.Unknown => Nil
             }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -42,53 +42,57 @@ import ca.uwaterloo.flix.language.phase.Lexer
 object CompletionProvider {
 
   def autoComplete(uri: String, pos: Position, source: String, currentErrors: List[CompilationMessage])(implicit flix: Flix, root: TypedAst.Root): CompletionList = {
-    val completionItems = getCompletionContext(source, pos).map { ctx =>
-      errorsAt(uri, pos, currentErrors).flatMap({
-        case err: WeederError.UnqualifiedUse =>
-          UseCompleter.getCompletions(uri, err)
-        case WeederError.UndefinedAnnotation(_, _) => KeywordCompleter.getModKeywords
-        case err: ResolutionError.UndefinedEffect =>
-          EffectCompleter.getCompletions(err)
-        case err: ResolutionError.UndefinedUse =>
-          UseCompleter.getCompletions(uri, err)
-        case err: ResolutionError.UndefinedTag =>
-          EnumCompleter.getCompletions(err) ++
-            EnumTagCompleter.getCompletions(err) ++
-            ModuleCompleter.getCompletions(err)
-        case err: ResolutionError.UndefinedName =>
-          AutoImportCompleter.getCompletions(err) ++
-            LocalScopeCompleter.getCompletions(err) ++
-            KeywordCompleter.getExprKeywords ++
-            DefCompleter.getCompletions(err) ++
+    val completionItems  =
+      getCompletionContext(source, pos).map {ctx =>
+        val completions = if (currentErrors.isEmpty)
+          HoleCompletion.getHoleCompletion(uri, pos, root)
+        else
+        errorsAt(uri, pos, currentErrors).flatMap({
+          case err: WeederError.UnqualifiedUse =>
+            UseCompleter.getCompletions(uri, err)
+          case WeederError.UndefinedAnnotation(_, _) => KeywordCompleter.getModKeywords
+          case err: ResolutionError.UndefinedEffect =>
+            EffectCompleter.getCompletions(err)
+          case err: ResolutionError.UndefinedUse =>
+            UseCompleter.getCompletions(uri, err)
+          case err: ResolutionError.UndefinedTag =>
             EnumCompleter.getCompletions(err) ++
-            EffectCompleter.getCompletions(err) ++
-            OpCompleter.getCompletions(err) ++
-            SignatureCompleter.getCompletions(err) ++
-            EnumTagCompleter.getCompletions(err) ++
-            TraitCompleter.getCompletions(err) ++
-            ModuleCompleter.getCompletions(err)
-        case err: ResolutionError.UndefinedType =>
-          TypeBuiltinCompleter.getCompletions ++
+              EnumTagCompleter.getCompletions(err) ++
+              ModuleCompleter.getCompletions(err)
+          case err: ResolutionError.UndefinedName =>
             AutoImportCompleter.getCompletions(err) ++
-            LocalScopeCompleter.getCompletions(err) ++
-            EnumCompleter.getCompletions(err) ++
-            StructCompleter.getCompletions(err) ++
-            EffectCompleter.getCompletions(err) ++
-            TypeAliasCompleter.getCompletions(err) ++
-            ModuleCompleter.getCompletions(err)
-        case err: ResolutionError.UndefinedJvmStaticField => GetStaticFieldCompleter.getCompletions(err) ++ InvokeStaticMethodCompleter.getCompletions(err)
-        case err: ResolutionError.UndefinedJvmImport => ImportCompleter.getCompletions(err)
-        case err: ResolutionError.UndefinedTrait => TraitCompleter.getCompletions(err)
-        case err: ResolutionError.UndefinedStructField => StructFieldCompleter.getCompletions(err, root)
-        case err: ResolutionError.UndefinedKind => KindCompleter.getCompletions(err)
-        case err: ResolutionError.UndefinedOp =>
-          OpCompleter.getCompletions(err)
-        case err: TypeError.FieldNotFound => MagicMatchCompleter.getCompletions(err) ++ InvokeMethodCompleter.getCompletions(err.tpe, err.fieldName)
-        case err: TypeError.MethodNotFound => InvokeMethodCompleter.getCompletions(err.tpe, err.methodName)
-        case err: ParseError => err.sctx match {
-          // Expressions.
-          case SyntacticContext.Expr.Constraint => PredicateCompleter.getCompletions(uri) ++ KeywordCompleter.getConstraintKeywords
-          case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords
+              LocalScopeCompleter.getCompletions(err) ++
+              KeywordCompleter.getExprKeywords ++
+              DefCompleter.getCompletions(err) ++
+              EnumCompleter.getCompletions(err) ++
+              EffectCompleter.getCompletions(err) ++
+              OpCompleter.getCompletions(err) ++
+              SignatureCompleter.getCompletions(err) ++
+              EnumTagCompleter.getCompletions(err) ++
+              TraitCompleter.getCompletions(err) ++
+              ModuleCompleter.getCompletions(err)
+          case err: ResolutionError.UndefinedType =>
+            TypeBuiltinCompleter.getCompletions ++
+              AutoImportCompleter.getCompletions(err) ++
+              LocalScopeCompleter.getCompletions(err) ++
+              EnumCompleter.getCompletions(err) ++
+              StructCompleter.getCompletions(err) ++
+              EffectCompleter.getCompletions(err) ++
+              TypeAliasCompleter.getCompletions(err) ++
+              ModuleCompleter.getCompletions(err)
+          case err: ResolutionError.UndefinedJvmStaticField => GetStaticFieldCompleter.getCompletions(err) ++ InvokeStaticMethodCompleter.getCompletions(err)
+          case err: ResolutionError.UndefinedJvmImport => ImportCompleter.getCompletions(err)
+          case err: ResolutionError.UndefinedTrait => TraitCompleter.getCompletions(err)
+          case err: ResolutionError.UndefinedStructField => StructFieldCompleter.getCompletions(err, root)
+          case err: ResolutionError.UndefinedKind => KindCompleter.getCompletions(err)
+          case err: ResolutionError.UndefinedOp =>
+            OpCompleter.getCompletions(err)
+          case err: TypeError.FieldNotFound => MagicMatchCompleter.getCompletions(err) ++ InvokeMethodCompleter.getCompletions(err.tpe, err.fieldName)
+          case err: TypeError.MethodNotFound => InvokeMethodCompleter.getCompletions(err.tpe, err.methodName)
+          case err: ParseError => err.sctx match {
+            // Expressions.
+            case SyntacticContext.Expr.Constraint => PredicateCompleter.getCompletions(uri) ++ KeywordCompleter.getConstraintKeywords
+            case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords
 
           // Declarations.
           case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords
@@ -98,17 +102,12 @@ object CompletionProvider {
           case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords
           case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords
 
-          // Unknown syntactic context. The program could be correct-- in which case it is hard to offer suggestions.
-          case SyntacticContext.Unknown =>
-            // Special case: A program with a hole is correct, but we should offer some completion suggestions.
-            HoleCompletion.getHoleCompletion(uri, pos, root)
-
           case _ => Nil
         }
 
-        case _ => HoleCompletion.getHoleCompletion(uri, pos, root)
-      }).map(comp => comp.toCompletionItem(ctx))
-    }.getOrElse(Nil)
+        })
+        completions.map(comp => comp.toCompletionItem(ctx))
+      }.getOrElse(Nil)
     CompletionList(isIncomplete = true, completionItems)
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -98,7 +98,7 @@ object CompletionProvider {
                 case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords
                 case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords
 
-              case _ => Nil
+              case SyntacticContext.Unknown => Nil
             }
             case _ => Nil
           })

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -45,7 +45,7 @@ object CompletionProvider {
     val completionItems  =
       getCompletionContext(source, pos).map {ctx =>
         val completions = if (currentErrors.isEmpty)
-          HoleCompletion.getHoleCompletion(uri, pos, root)
+          HoleCompleter.getHoleCompletion(uri, pos, root)
         else
         errorsAt(uri, pos, currentErrors).flatMap({
           case err: WeederError.UnqualifiedUse =>

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/HoleCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/HoleCompleter.scala
@@ -23,7 +23,7 @@ import ca.uwaterloo.flix.language.ast.shared.Scope
 import ca.uwaterloo.flix.language.ast.{Kind, RigidityEnv, SourceLocation, Symbol, Type, TypedAst}
 import ca.uwaterloo.flix.language.phase.typer.ConstraintSolver2
 
-object HoleCompletion {
+object HoleCompleter {
 
   /**
     * Gets completions for when the cursor position is on a hole expression with an expression
@@ -38,7 +38,7 @@ object HoleCompletion {
 
     stack.getStack.headOption match {
       case Some(TypedAst.Expr.HoleWithExp(TypedAst.Expr.Var(sym, sourceType, _), targetType, _, loc)) =>
-        HoleCompletion.candidates(sourceType, targetType, root)
+        HoleCompleter.candidates(sourceType, targetType, root)
           .map(root.defs(_))
           .filter(_.spec.mod.isPublic)
           .zipWithIndex


### PR DESCRIPTION
fixes #9998
Now we will trigger HoleCompleter if there are no errors.

But actually it still doesn't work:
![image](https://github.com/user-attachments/assets/6a88fbd5-7028-4341-b427-6fa73c1b5239)