### PR TITLE
chore: remove unused syntactic context

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -88,7 +88,7 @@ object CompletionProvider {
         case err: ParseError => err.sctx match {
           // Expressions.
           case SyntacticContext.Expr.Constraint => PredicateCompleter.getCompletions(uri) ++ KeywordCompleter.getConstraintKeywords
-          case _: SyntacticContext.Expr => ExprCompleter.getCompletions(ctx)
+          case SyntacticContext.Expr.OtherExpr => ExprCompleter.getCompletions(ctx)
 
           // Declarations.
           case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords
@@ -97,11 +97,6 @@ object CompletionProvider {
           case SyntacticContext.Decl.Struct => KeywordCompleter.getStructKeywords
           case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords
           case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords
-
-          // Unknown syntactic context. The program could be correct-- in which case it is hard to offer suggestions.
-          case SyntacticContext.Unknown =>
-            // Special case: A program with a hole is correct, but we should offer some completion suggestions.
-            HoleCompletion.getHoleCompletion(ctx, root)
 
           case _ => Nil
         }

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/SyntacticContext.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/SyntacticContext.scala
@@ -34,8 +34,6 @@ object SyntacticContext {
 
     case object Effect extends Decl
 
-    case object Instance extends Decl
-
     case object Module extends Decl
 
     case object Struct extends Decl
@@ -50,32 +48,8 @@ object SyntacticContext {
   object Expr {
     case object Constraint extends Expr
 
-    case object New extends Expr
-
     case object OtherExpr extends Expr
   }
-
-  case object Import extends SyntacticContext
-
-  sealed trait Pat extends SyntacticContext
-
-  object Pat {
-    case object OtherPat extends Pat
-  }
-
-  sealed trait Type extends SyntacticContext
-
-  object Type {
-    case object Eff extends Type
-
-    case object OtherType extends Type
-  }
-
-  case object Use extends SyntacticContext
-
-  case object WithClause extends SyntacticContext
-
-  case object WithHandler extends SyntacticContext
 
   case object Unknown extends SyntacticContext
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -804,19 +804,19 @@ object Parser2 {
   private def use()(implicit s: State): Mark.Closed = {
     assert(at(TokenKind.KeywordUse))
     val mark = open()
-    expect(TokenKind.KeywordUse, SyntacticContext.Use)
-    nameAllowQualified(NAME_USE, context = SyntacticContext.Use)
+    expect(TokenKind.KeywordUse, SyntacticContext.Unknown)
+    nameAllowQualified(NAME_USE, context = SyntacticContext.Unknown)
     // handle use many case
     if (at(TokenKind.DotCurlyL)) {
       val mark = open()
       oneOrMore(
         namedTokenSet = NamedTokenSet.Name,
-        getItem = () => aliasedName(NAME_USE, SyntacticContext.Use),
+        getItem = () => aliasedName(NAME_USE, SyntacticContext.Unknown),
         checkForItem = NAME_USE.contains,
         breakWhen = _.isRecoverUseOrImport,
         delimiterL = TokenKind.DotCurlyL,
         delimiterR = TokenKind.CurlyR,
-        context = SyntacticContext.Use
+        context = SyntacticContext.Unknown
       ) match {
         case Some(err) => closeWithError(open(), err)
         case None =>
@@ -829,19 +829,19 @@ object Parser2 {
   private def iimport()(implicit s: State): Mark.Closed = {
     assert(at(TokenKind.KeywordImport))
     val mark = open()
-    expect(TokenKind.KeywordImport, SyntacticContext.Import)
-    nameAllowQualified(NAME_JAVA, tail = Set(), context = SyntacticContext.Import)
+    expect(TokenKind.KeywordImport, SyntacticContext.Unknown)
+    nameAllowQualified(NAME_JAVA, tail = Set(), context = SyntacticContext.Unknown)
     // handle import many case
     if (at(TokenKind.DotCurlyL)) {
       val mark = open()
       oneOrMore(
         namedTokenSet = NamedTokenSet.Name,
-        getItem = () => aliasedName(NAME_JAVA, SyntacticContext.Import),
+        getItem = () => aliasedName(NAME_JAVA, SyntacticContext.Unknown),
         checkForItem = NAME_JAVA.contains,
         breakWhen = _.isRecoverUseOrImport,
         delimiterL = TokenKind.DotCurlyL,
         delimiterR = TokenKind.CurlyR,
-        context = SyntacticContext.Import
+        context = SyntacticContext.Unknown
       ) match {
         case Some(err) => closeWithError(open(), err)
         case None =>
@@ -959,20 +959,20 @@ object Parser2 {
 
     private def instanceDecl(mark: Mark.Opened)(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordInstance))
-      expect(TokenKind.KeywordInstance, SyntacticContext.Decl.Instance)
-      nameAllowQualified(NAME_DEFINITION, context = SyntacticContext.Decl.Instance)
+      expect(TokenKind.KeywordInstance, SyntacticContext.Unknown)
+      nameAllowQualified(NAME_DEFINITION, context = SyntacticContext.Unknown)
       if (!eat(TokenKind.BracketL)) {
         // Produce an error for missing type parameter.
-        expect(TokenKind.BracketL, SyntacticContext.Decl.Instance, hint = Some("Instances must have a type parameter."))
+        expect(TokenKind.BracketL, SyntacticContext.Unknown, hint = Some("Instances must have a type parameter."))
       } else {
         Type.ttype()
-        expect(TokenKind.BracketR, SyntacticContext.Decl.Instance)
+        expect(TokenKind.BracketR, SyntacticContext.Unknown)
       }
       if (at(TokenKind.KeywordWith)) {
         Type.constraints()
       }
       if (at(TokenKind.CurlyL)) {
-        expect(TokenKind.CurlyL, SyntacticContext.Decl.Instance)
+        expect(TokenKind.CurlyL, SyntacticContext.Unknown)
         var continue = true
         while (continue && !eof()) {
           val docMark = docComment()
@@ -994,7 +994,7 @@ object Parser2 {
               closeWithError(errMark, error, Some(at))
           }
         }
-        expect(TokenKind.CurlyR, SyntacticContext.Decl.Instance)
+        expect(TokenKind.CurlyR, SyntacticContext.Unknown)
       }
       close(mark, TreeKind.Decl.Instance)
     }
@@ -1101,7 +1101,7 @@ object Parser2 {
           getItem = () => Type.ttype(),
           checkForItem = _.isFirstType,
           breakWhen = _.isRecoverType,
-          context = SyntacticContext.Type.OtherType
+          context = SyntacticContext.Unknown
         ) match {
           case Some(error) => closeWithError(mark, error)
           case None => close(mark, TreeKind.Type.Tuple)
@@ -1289,7 +1289,7 @@ object Parser2 {
       if (at(TokenKind.ParenL)) {
         parameters(SyntacticContext.Decl.Module)
       }
-      expect(TokenKind.Colon, SyntacticContext.Type.Eff)
+      expect(TokenKind.Colon, SyntacticContext.Unknown)
       val typeLoc = currentSourceLocation()
       Type.ttype()
       // Check for illegal effect
@@ -1474,7 +1474,7 @@ object Parser2 {
         if (at(TokenKind.CurlyL)) {
           oneOrMore(
             namedTokenSet = NamedTokenSet.Effect,
-            getItem = () => nameAllowQualified(NAME_EFFECT, context = SyntacticContext.Type.Eff),
+            getItem = () => nameAllowQualified(NAME_EFFECT, context = SyntacticContext.Unknown),
             checkForItem = NAME_EFFECT.contains,
             breakWhen = _.isRecoverExpr,
             delimiterL = TokenKind.CurlyL,
@@ -2476,7 +2476,7 @@ object Parser2 {
       assert(at(TokenKind.KeywordHandler))
       val mark = open()
       expect(TokenKind.KeywordHandler, SyntacticContext.Expr.OtherExpr)
-      nameAllowQualified(NAME_EFFECT, context = SyntacticContext.WithHandler)
+      nameAllowQualified(NAME_EFFECT, context = SyntacticContext.Unknown)
       if (at(TokenKind.CurlyL)) {
         zeroOrMore(
           namedTokenSet = NamedTokenSet.WithRule,
@@ -2913,7 +2913,7 @@ object Parser2 {
         case TokenKind.Minus => unaryPat()
         case t =>
           val mark = open()
-          val error = UnexpectedToken(expected = NamedTokenSet.Pattern, actual = Some(t), SyntacticContext.Pat.OtherPat, loc = currentSourceLocation())
+          val error = UnexpectedToken(expected = NamedTokenSet.Pattern, actual = Some(t), SyntacticContext.Unknown, loc = currentSourceLocation())
           closeWithError(mark, error)
       }
       // Handle FCons
@@ -2927,7 +2927,7 @@ object Parser2 {
 
     private def variablePat()(implicit s: State): Mark.Closed = {
       val mark = open()
-      nameUnqualified(NAME_VARIABLE, SyntacticContext.Pat.OtherPat)
+      nameUnqualified(NAME_VARIABLE, SyntacticContext.Unknown)
       close(mark, TreeKind.Pattern.Variable)
     }
 
@@ -2939,7 +2939,7 @@ object Parser2 {
 
     private def tagPat()(implicit s: State): Mark.Closed = {
       val mark = open()
-      nameAllowQualified(NAME_TAG, context = SyntacticContext.Pat.OtherPat)
+      nameAllowQualified(NAME_TAG, context = SyntacticContext.Unknown)
       if (at(TokenKind.ParenL)) {
         tuplePat()
       }
@@ -2954,7 +2954,7 @@ object Parser2 {
         getItem = pattern,
         checkForItem = _.isFirstPattern,
         breakWhen = _.isRecoverExpr,
-        context = SyntacticContext.Pat.OtherPat
+        context = SyntacticContext.Unknown
       )
       close(mark, TreeKind.Pattern.Tuple)
     }
@@ -2970,14 +2970,14 @@ object Parser2 {
         delimiterR = TokenKind.CurlyR,
         optionallyWith = Some((TokenKind.Bar, () => pattern())),
         breakWhen = _.isRecoverExpr,
-        context = SyntacticContext.Pat.OtherPat
+        context = SyntacticContext.Unknown
       )
       close(mark, TreeKind.Pattern.Record)
     }
 
     private def recordField()(implicit s: State): Mark.Closed = {
       val mark = open()
-      nameUnqualified(NAME_FIELD, SyntacticContext.Pat.OtherPat)
+      nameUnqualified(NAME_FIELD, SyntacticContext.Unknown)
       if (eat(TokenKind.Equal)) {
         pattern()
       }
@@ -3085,7 +3085,7 @@ object Parser2 {
         delimiterL = TokenKind.BracketL,
         delimiterR = TokenKind.BracketR,
         breakWhen = _.isRecoverType,
-        context = SyntacticContext.Type.OtherType
+        context = SyntacticContext.Unknown
       )
       close(mark, TreeKind.Type.ArgumentList)
     }
@@ -3105,7 +3105,7 @@ object Parser2 {
         delimiterL = TokenKind.BracketL,
         delimiterR = TokenKind.BracketR,
         breakWhen = _.isRecoverType,
-        context = SyntacticContext.Type.OtherType
+        context = SyntacticContext.Unknown
       ) match {
         case Some(error) => closeWithError(mark, error)
         case None => close(mark, TreeKind.TypeParameterList)
@@ -3114,9 +3114,9 @@ object Parser2 {
 
     private def parameter()(implicit s: State): Mark.Closed = {
       val mark = open()
-      nameUnqualified(NAME_VARIABLE ++ NAME_TYPE, SyntacticContext.Type.OtherType)
+      nameUnqualified(NAME_VARIABLE ++ NAME_TYPE, SyntacticContext.Unknown)
       if (at(TokenKind.Colon)) {
-        expect(TokenKind.Colon, SyntacticContext.Type.OtherType)
+        expect(TokenKind.Colon, SyntacticContext.Unknown)
         Type.kind()
       }
       close(mark, TreeKind.Parameter)
@@ -3125,14 +3125,14 @@ object Parser2 {
     def constraints()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordWith))
       val mark = open()
-      expect(TokenKind.KeywordWith, SyntacticContext.WithClause)
+      expect(TokenKind.KeywordWith, SyntacticContext.Unknown)
       // Note, Can't use zeroOrMore here since there's are no delimiterR.
       var continue = true
       while (continue && !eof()) {
         if (atAny(NAME_DEFINITION)) {
           constraint()
         } else {
-          val error = UnexpectedToken(expected = NamedTokenSet.FromKinds(NAME_DEFINITION), actual = Some(nth(0)), SyntacticContext.WithClause, loc = currentSourceLocation())
+          val error = UnexpectedToken(expected = NamedTokenSet.FromKinds(NAME_DEFINITION), actual = Some(nth(0)), SyntacticContext.Unknown, loc = currentSourceLocation())
           closeWithError(open(), error)
           continue = false
         }
@@ -3145,24 +3145,24 @@ object Parser2 {
 
     private def constraint()(implicit s: State): Mark.Closed = {
       val mark = open()
-      nameAllowQualified(NAME_DEFINITION, context = SyntacticContext.WithClause)
-      expect(TokenKind.BracketL, SyntacticContext.WithClause)
+      nameAllowQualified(NAME_DEFINITION, context = SyntacticContext.Unknown)
+      expect(TokenKind.BracketL, SyntacticContext.Unknown)
       Type.ttype()
-      expect(TokenKind.BracketR, SyntacticContext.WithClause)
+      expect(TokenKind.BracketR, SyntacticContext.Unknown)
       close(mark, TreeKind.Type.Constraint)
     }
 
     def derivations()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordWith))
       val mark = open()
-      expect(TokenKind.KeywordWith, SyntacticContext.WithClause)
+      expect(TokenKind.KeywordWith, SyntacticContext.Unknown)
       // Note, Can't use zeroOrMore here since there's are no delimiterR.
       var continue = true
       while (continue && !eof()) {
         if (atAny(NAME_QNAME)) {
-          nameAllowQualified(NAME_QNAME, context = SyntacticContext.WithClause)
+          nameAllowQualified(NAME_QNAME, context = SyntacticContext.Unknown)
         } else {
-          val error = UnexpectedToken(expected = NamedTokenSet.FromKinds(NAME_QNAME), actual = Some(nth(0)), SyntacticContext.WithClause, loc = currentSourceLocation())
+          val error = UnexpectedToken(expected = NamedTokenSet.FromKinds(NAME_QNAME), actual = Some(nth(0)), SyntacticContext.Unknown, loc = currentSourceLocation())
           closeWithError(open(), error)
           continue = false
         }
@@ -3177,10 +3177,10 @@ object Parser2 {
       // If a new type is added here, remember to add it to TYPE_FIRST too.
       val mark = open()
       nth(0) match {
-        case TokenKind.NameUpperCase => nameAllowQualified(NAME_TYPE, context = SyntacticContext.Type.OtherType)
+        case TokenKind.NameUpperCase => nameAllowQualified(NAME_TYPE, context = SyntacticContext.Unknown)
         case TokenKind.NameMath
              | TokenKind.NameGreek
-             | TokenKind.Underscore => nameUnqualified(NAME_VARIABLE, SyntacticContext.Type.OtherType)
+             | TokenKind.Underscore => nameUnqualified(NAME_VARIABLE, SyntacticContext.Unknown)
         case TokenKind.NameLowerCase => variableType()
         case TokenKind.KeywordUniv
              | TokenKind.KeywordFalse

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -990,7 +990,7 @@ object Parser2 {
               while (!nth(0).isFirstInstance && !eat(TokenKind.CurlyR) && !eof()) {
                 advance()
               }
-              val error = UnexpectedToken(expected = NamedTokenSet.FromKinds(Set(TokenKind.KeywordType, TokenKind.KeywordDef)), actual = Some(at), SyntacticContext.Decl.Instance, loc = loc)
+              val error = UnexpectedToken(expected = NamedTokenSet.FromKinds(Set(TokenKind.KeywordType, TokenKind.KeywordDef)), actual = Some(at), SyntacticContext.Unknown, loc = loc)
               closeWithError(errMark, error, Some(at))
           }
         }
@@ -3195,10 +3195,10 @@ object Parser2 {
              | TokenKind.KeywordRvnot => unaryType()
         // TODO: Static is used as a type name in Prelude.flix. That requires special handling here.
         // If we remove this rule, remove KeywordStaticUppercase from FIRST_TYPE too.
-        case TokenKind.KeywordStaticUppercase => nameUnqualified(Set(TokenKind.KeywordStaticUppercase), SyntacticContext.Type.OtherType)
+        case TokenKind.KeywordStaticUppercase => nameUnqualified(Set(TokenKind.KeywordStaticUppercase), SyntacticContext.Unknown)
         case t =>
           val mark = open()
-          val error = UnexpectedToken(expected = NamedTokenSet.Type, actual = Some(t), SyntacticContext.Type.OtherType, loc = currentSourceLocation())
+          val error = UnexpectedToken(expected = NamedTokenSet.Type, actual = Some(t), SyntacticContext.Unknown, loc = currentSourceLocation())
           closeWithError(mark, error)
       }
       close(mark, TreeKind.Type.Type)
@@ -3208,7 +3208,7 @@ object Parser2 {
 
     private def variableType()(implicit s: State): Mark.Closed = {
       val mark = open()
-      expectAny(TYPE_VAR, SyntacticContext.Type.OtherType)
+      expectAny(TYPE_VAR, SyntacticContext.Unknown)
       close(mark, TreeKind.Type.Variable)
     }
 
@@ -3216,7 +3216,7 @@ object Parser2 {
 
     private def constantType()(implicit s: State): Mark.Closed = {
       val mark = open()
-      expectAny(TYPE_CONSTANT, SyntacticContext.Type.OtherType)
+      expectAny(TYPE_CONSTANT, SyntacticContext.Unknown)
       close(mark, TreeKind.Type.Constant)
     }
 
@@ -3243,7 +3243,7 @@ object Parser2 {
         checkForItem = NAME_FIELD.contains,
         breakWhen = _.isRecoverType,
         optionallyWith = Some((TokenKind.Bar, variableType)),
-        context = SyntacticContext.Type.OtherType
+        context = SyntacticContext.Unknown
       )
       close(mark, TreeKind.Type.RecordRow)
     }
@@ -3256,7 +3256,7 @@ object Parser2 {
         getItem = () => ttype(),
         checkForItem = _.isFirstType,
         breakWhen = _.isRecoverType,
-        context = SyntacticContext.Type.OtherType
+        context = SyntacticContext.Unknown
       )
       close(mark, TreeKind.Type.Tuple)
     }
@@ -3292,7 +3292,7 @@ object Parser2 {
             delimiterL = TokenKind.CurlyL,
             delimiterR = TokenKind.CurlyR,
             optionallyWith = Some((TokenKind.Bar, variableType)),
-            context = SyntacticContext.Type.OtherType
+            context = SyntacticContext.Unknown
           )
           close(mark, TreeKind.Type.Record)
       }
@@ -3300,8 +3300,8 @@ object Parser2 {
 
     private def recordField()(implicit s: State): Mark.Closed = {
       val mark = open()
-      nameUnqualified(NAME_FIELD, SyntacticContext.Type.OtherType)
-      expect(TokenKind.Equal, SyntacticContext.Type.OtherType)
+      nameUnqualified(NAME_FIELD, SyntacticContext.Unknown)
+      expect(TokenKind.Equal, SyntacticContext.Unknown)
       ttype()
       close(mark, TreeKind.Type.RecordFieldFragment)
     }
@@ -3315,7 +3315,7 @@ object Parser2 {
         breakWhen = _.isRecoverType,
         delimiterL = TokenKind.CurlyL,
         delimiterR = TokenKind.CurlyR,
-        context = SyntacticContext.Type.Eff
+        context = SyntacticContext.Unknown
       )
       close(mark, TreeKind.Type.EffectSet)
     }
@@ -3330,8 +3330,8 @@ object Parser2 {
         delimiterL = TokenKind.HashCurlyL,
         delimiterR = TokenKind.CurlyR,
         breakWhen = _.isRecoverType,
-        optionallyWith = Some(TokenKind.Bar, () => nameUnqualified(NAME_VARIABLE, SyntacticContext.Type.OtherType)),
-        context = SyntacticContext.Type.OtherType
+        optionallyWith = Some(TokenKind.Bar, () => nameUnqualified(NAME_VARIABLE, SyntacticContext.Unknown)),
+        context = SyntacticContext.Unknown
       )
       close(mark, TreeKind.Type.Schema)
     }
@@ -3345,15 +3345,15 @@ object Parser2 {
         checkForItem = NAME_PREDICATE.contains,
         delimiterL = TokenKind.HashParenL,
         breakWhen = _.isRecoverType,
-        optionallyWith = Some(TokenKind.Bar, () => nameUnqualified(NAME_VARIABLE, SyntacticContext.Type.OtherType)),
-        context = SyntacticContext.Type.OtherType
+        optionallyWith = Some(TokenKind.Bar, () => nameUnqualified(NAME_VARIABLE, SyntacticContext.Unknown)),
+        context = SyntacticContext.Unknown
       )
       close(mark, TreeKind.Type.SchemaRow)
     }
 
     private def schemaTerm()(implicit s: State): Mark.Closed = {
       val mark = open()
-      nameAllowQualified(NAME_PREDICATE, context = SyntacticContext.Type.OtherType)
+      nameAllowQualified(NAME_PREDICATE, context = SyntacticContext.Unknown)
       if (at(TokenKind.BracketL)) {
         arguments()
         close(mark, TreeKind.Type.PredicateWithAlias)
@@ -3363,7 +3363,7 @@ object Parser2 {
           getItem = () => ttype(),
           checkForItem = _.isFirstType,
           breakWhen = _.isRecoverType,
-          context = SyntacticContext.Type.OtherType,
+          context = SyntacticContext.Unknown,
           optionallyWith = Some(TokenKind.Semi, () => {
             val mark = open()
             ttype()
@@ -3379,12 +3379,12 @@ object Parser2 {
       val mark = open()
       zeroOrMore(
         namedTokenSet = NamedTokenSet.FromKinds(NAME_DEFINITION),
-        getItem = () => nameAllowQualified(NAME_DEFINITION, context = SyntacticContext.Type.OtherType),
+        getItem = () => nameAllowQualified(NAME_DEFINITION, context = SyntacticContext.Unknown),
         checkForItem = NAME_DEFINITION.contains,
         breakWhen = _.isRecoverType,
         delimiterL = TokenKind.AngleL,
         delimiterR = TokenKind.AngleR,
-        context = SyntacticContext.Type.OtherType
+        context = SyntacticContext.Unknown
       )
       close(mark, TreeKind.Type.CaseSet)
     }
@@ -3395,7 +3395,7 @@ object Parser2 {
       val mark = open()
       val op = nth(0)
       val markOp = open()
-      expectAny(FIRST_TYPE_UNARY, SyntacticContext.Type.OtherType)
+      expectAny(FIRST_TYPE_UNARY, SyntacticContext.Unknown)
       close(markOp, TreeKind.Operator)
       ttype(left = op)
       close(mark, TreeKind.Type.Unary)
@@ -3404,14 +3404,14 @@ object Parser2 {
     def kind()(implicit s: State): Mark.Closed = {
       def kindFragment(): Unit = {
         val inParens = eat(TokenKind.ParenL)
-        nameUnqualified(NAME_KIND, SyntacticContext.Type.OtherType)
+        nameUnqualified(NAME_KIND, SyntacticContext.Unknown)
         // Check for arrow kind
         if (eat(TokenKind.ArrowThinR)) {
           kind()
         }
         // consume ')' is necessary
         if (inParens) {
-          expect(TokenKind.ParenR, SyntacticContext.Type.OtherType)
+          expect(TokenKind.ParenR, SyntacticContext.Unknown)
         }
       }
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -138,7 +138,7 @@ object Weeder2 {
 
       // recover from missing alias by using ident
       case ident :: _ =>
-        val error = Malformed(NamedTokenSet.Alias, SyntacticContext.Use, hint = Some(s"Give an alias after ${TokenKind.ArrowThickR.display}."), loc = tree.loc)
+        val error = Malformed(NamedTokenSet.Alias, SyntacticContext.Unknown, hint = Some(s"Give an alias after ${TokenKind.ArrowThickR.display}."), loc = tree.loc)
         sctx.errors.add(error)
         val qname = Name.QName(namespace, ident, tree.loc)
         UseOrImport.Use(qname, ident, ident.loc)
@@ -184,7 +184,7 @@ object Weeder2 {
         UseOrImport.Import(jname, alias, tree.loc)
       // recover from missing alias by using ident
       case ident :: _ =>
-        val error = Malformed(NamedTokenSet.Alias, SyntacticContext.Import, hint = Some(s"Give an alias after ${TokenKind.ArrowThickR.display}."), loc = tree.loc)
+        val error = Malformed(NamedTokenSet.Alias, SyntacticContext.Unknown, hint = Some(s"Give an alias after ${TokenKind.ArrowThickR.display}."), loc = tree.loc)
         sctx.errors.add(error)
         UseOrImport.Import(Name.JavaName(Seq(ident.name), tree.loc), ident, ident.loc)
       case _ => throw InternalCompilerException("Parser passed malformed use with alias", tree.loc)
@@ -2215,7 +2215,7 @@ object Weeder2 {
           // Avoid double reporting errors by returning a success here
           case TreeKind.ErrorTree(_) => Validation.Success(Pattern.Error(tree.loc))
           case _ =>
-            val error = UnexpectedToken(NamedTokenSet.Pattern, actual = None, SyntacticContext.Pat.OtherPat, loc = tree.loc)
+            val error = UnexpectedToken(NamedTokenSet.Pattern, actual = None, SyntacticContext.Unknown, loc = tree.loc)
             sctx.errors.add(error)
             Validation.Success(Pattern.Error(tree.loc))
         }


### PR DESCRIPTION
fixes #10015
Only SyntacticContext used in `CompletionProvider` is reserved:

```scala
        case err: ParseError => err.sctx match {
          // Expressions.
          case SyntacticContext.Expr.Constraint => PredicateCompleter.getCompletions(uri) ++ KeywordCompleter.getConstraintKeywords
          case SyntacticContext.Expr.OtherExpr => ExprCompleter.getCompletions(ctx)

          // Declarations.
          case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords
          case SyntacticContext.Decl.Effect => KeywordCompleter.getEffectKeywords
          case SyntacticContext.Decl.Module => KeywordCompleter.getModKeywords ++ ExprSnippetCompleter.getCompletions()
          case SyntacticContext.Decl.Struct => KeywordCompleter.getStructKeywords
          case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords
          case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords

          case _ => Nil
        }
```

But those SyntacticContext is sill used in the Parser/Weeder. For example, it's in the signature of expect:
```scala
  private def expect(kind: TokenKind, context: SyntacticContext, hint: Option[String] = None)(implicit s: State): Unit = {
```

What should we use to replace? SyntacticContext.Unknown?