### PR TITLE
feat: require escaping keyword names

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -170,6 +170,7 @@ sealed trait TokenKind {
       case TokenKind.NameUpperCase => "<Name>"
       case TokenKind.NameMath => "<math name>"
       case TokenKind.NameGreek => "<greek name>"
+      case TokenKind.NameEscaped => "<Name>"
       case TokenKind.UserDefinedOperator => "<user-defined operator>"
       case TokenKind.Annotation => "<annotation>"
       case TokenKind.BuiltIn => "<built in>"
@@ -362,6 +363,7 @@ sealed trait TokenKind {
          | TokenKind.LiteralStringInterpolationR
          | TokenKind.MapHash
          | TokenKind.Minus
+         | TokenKind.NameEscaped
          | TokenKind.NameGreek
          | TokenKind.NameLowerCase
          | TokenKind.NameMath
@@ -628,6 +630,7 @@ sealed trait TokenKind {
          | TokenKind.KeywordYield
          | TokenKind.LiteralDebugStringR
          | TokenKind.LiteralStringInterpolationR
+         | TokenKind.NameEscaped
          | TokenKind.ParenR
          | TokenKind.Semi
          | TokenKind.Slash
@@ -1070,6 +1073,8 @@ object TokenKind {
   case object MapHash extends TokenKind
 
   case object Minus extends TokenKind
+
+  case object NameEscaped extends TokenKind
 
   case object NameGreek extends TokenKind
 

--- a/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/LexerError.scala
@@ -249,6 +249,24 @@ object LexerError {
   }
 
   /**
+    * An error raised when an unterminated escaped name is encountered.
+    *
+    * @param loc The location of the opening '&#96;'.
+    */
+  case class UnterminatedEscapedName(loc: SourceLocation) extends LexerError {
+    override def summary: String = s"Unterminated escaped name."
+
+    override def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> Missing '`' in escaped name.
+         |
+         |${code(loc, "Escaped name starts here.")}
+         |
+         |""".stripMargin
+    }
+  }
+
+  /**
     * An error raised when an unterminated char is encountered.
     *
     * @param loc The location of the opening `'`.

--- a/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/WeederError.scala
@@ -145,6 +145,34 @@ object WeederError {
   }
 
   /**
+    * An error raised to indicate that an escaped name is empty.
+    *
+    * @param loc the location of the escaped name.
+    */
+  case class EmptyEscapedName(loc: SourceLocation) extends WeederError {
+    def summary: String = "An escaped name cannot be empty."
+
+    def message(formatter: Formatter): String = {
+      import formatter.*
+      s""">> An escaped name cannot be empty.
+         |
+         |${code(loc, "Escaped name does not contain anything.")}
+         |
+         |""".stripMargin
+    }
+
+    override def explain(formatter: Formatter): Option[String] = Some({
+      s"""A loop must contain a collection comprehension.
+         |
+         |A minimal loop is written as follows:
+         |
+         |    foreach (x <- xs) yield x
+         |
+         |""".stripMargin
+    })
+  }
+
+  /**
     * An error raised to indicate that a loop does not contain any fragments.
     *
     * @param loc the location of the for-loop with no fragments.

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1408,6 +1408,18 @@ object Parser2 {
               lhs = close(mark, TreeKind.Expr.GetField)
             }
             lhs = close(openBefore(lhs), TreeKind.Expr.Expr)
+          case TokenKind.Dot if nth(1) == TokenKind.NameEscaped => // invoke method
+            val mark = openBefore(lhs)
+            eat(TokenKind.Dot)
+            nameUnqualified(Set(TokenKind.NameEscaped), SyntacticContext.Expr.OtherExpr)
+            // exp.`f` is a Java field lookup and exp.`f`(..) is a Java method invocation
+            if (at(TokenKind.ParenL)) {
+              arguments()
+              lhs = close(mark, TreeKind.Expr.InvokeMethod)
+            } else {
+              lhs = close(mark, TreeKind.Expr.GetField)
+            }
+            lhs = close(openBefore(lhs), TreeKind.Expr.Expr)
           case TokenKind.Hash if nth(1) == TokenKind.NameLowerCase => // record lookup
             val mark = openBefore(lhs)
             eat(TokenKind.Hash)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3146,6 +3146,11 @@ object Weeder2 {
     */
   private def tokenToIdent(tree: Tree)(implicit sctx: SharedContext): Name.Ident = {
     tree.children.headOption match {
+      case Some(token@Token(TokenKind.NameEscaped, _, _, _, sp1, sp2)) =>
+        val content = token.text.stripPrefix("`").stripSuffix("`")
+        val loc = SourceLocation(isReal = true, sp1, sp2)
+        if (content.isEmpty) sctx.errors.add(EmptyEscapedName(loc))
+        Name.Ident(content, loc)
       case Some(token@Token(_, _, _, _, sp1, sp2)) =>
         Name.Ident(token.text, SourceLocation(isReal = true, sp1, sp2))
       // If child is an ErrorTree, that means the parse already reported and error.

--- a/main/src/library/BigInt.flix
+++ b/main/src/library/BigInt.flix
@@ -133,25 +133,25 @@ mod BigInt {
     /// Returns the bitwise AND of `x` and `y`.
     ///
     pub def bitwiseAnd(x: BigInt, y: BigInt): BigInt =
-        unsafe x.and(y)
+        unsafe x.`and`(y)
 
     ///
     /// Returns the bitwise NOT of `x`.
     ///
     pub def bitwiseNot(x: BigInt): BigInt =
-        unsafe x.not()
+        unsafe x.`not`()
 
     ///
     /// Returns the bitwise OR of `x` and `y`.
     ///
     pub def bitwiseOr(x: BigInt, y: BigInt): BigInt =
-        unsafe x.or(y)
+        unsafe x.`or`(y)
 
     ///
     /// Returns the bitwise XOR of `x` and `y`.
     ///
     pub def bitwiseXor(x: BigInt, y: BigInt): BigInt =
-        unsafe x.xor(y)
+        unsafe x.`xor`(y)
 
     ///
     /// Return a string representation of `x`.

--- a/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestLexer.scala
@@ -174,6 +174,30 @@ class TestLexer extends AnyFunSuite with TestUtils {
     expectError[LexerError.UnterminatedBuiltIn](result)
   }
 
+  test("LexerError.UnterminatedEscapedName.01") {
+    val input = "x.`test"
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.UnterminatedEscapedName](result)
+  }
+
+  test("LexerError.UnterminatedEscapedName.02") {
+    val input = "x.`a_"
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.UnterminatedEscapedName](result)
+  }
+
+  test("LexerError.UnterminatedEscapedName.03") {
+    val input = "x.`a$"
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.UnterminatedEscapedName](result)
+  }
+
+  test("LexerError.UnterminatedEscapedName.04") {
+    val input = "x.`"
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError.UnterminatedEscapedName](result)
+  }
+
   test("LexerError.UnterminatedChar.01") {
     val input = "'a"
     val result = compile(input, Options.TestWithLibNix)

--- a/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestWeeder.scala
@@ -124,6 +124,15 @@ class TestWeeder extends AnyFunSuite with TestUtils {
     expectError[WeederError.DuplicateStructField](result)
   }
 
+  test("EmptyEscapedName.01") {
+    val input =
+      """
+        |def f(o: Object): String = o.``
+        |""".stripMargin
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[WeederError.EmptyEscapedName](result)
+  }
+
   test("EmptyForFragment.01") {
     val input =
       """

--- a/main/test/flix/Test.Exp.Jvm.InvokeMethod2.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeMethod2.flix
@@ -33,12 +33,12 @@ mod Test.Exp.Jvm.InvokeMethod {
    @test
    def testInvokeMethod_07(): Bool \ IO =
        let val = 150ii;
-       val.and(-100ii) == 148ii
+       val.`and`(-100ii) == 148ii
 
     @test
     def testInvokeMethod_08(): Bool \ IO =
        let val = 123488ii;
-       val.mod(23ii) == 1ii
+       val.`mod`(23ii) == 1ii
 
    @test
    def testInvokeMethod_09(): Bool \ IO =


### PR DESCRIPTION
`x.and(y)` now needs to be
```
x.`and`(y)
```
Fixes #10002
Fixes #9213