### PR TITLE
feat: support multiline semantic token

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/SourceLocation.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SourceLocation.scala
@@ -118,7 +118,7 @@ case class SourceLocation(isReal: Boolean, sp1: SourcePosition, sp2: SourcePosit
   /**
     * Returns a string representation of `this` source location with the line and column numbers.
     */
-  def format: String = s"${source.name}:$beginLine:$beginCol"
+  def format: String = s"${source.name}:$beginLine:$beginCol-$endLine:$endCol"
 
   /**
     * Returns the source text of the source location.


### PR DESCRIPTION
fixes #10027

The issue is that formerly we will filter out multiline tokens. And the multiline-token feature is not supported by all clients(at least nvim doesn't support this by default). So we have to process this manually--split the multiline token into several single-line tokens.

Now the comment block is highlighted properly:
![image](https://github.com/user-attachments/assets/1123732b-0df2-4977-9577-a30caf3becd7)
