### PR TITLE
chore: use Unknown as the default SyntacticContext param

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/errors/ParseError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ParseError.scala
@@ -262,7 +262,7 @@ object ParseError {
     * @param hint     Optional hint with more details about the error
     * @param loc      The source location.
     */
-  case class UnexpectedToken(expected: NamedTokenSet, actual: Option[TokenKind], sctx: SyntacticContext, hint: Option[String] = None, loc: SourceLocation) extends ParseError {
+  case class UnexpectedToken(expected: NamedTokenSet, actual: Option[TokenKind], sctx: SyntacticContext = SyntacticContext.Unknown, hint: Option[String] = None, loc: SourceLocation) extends ParseError {
     override val kind: CompilationMessageKind.ParseError = CompilationMessageKind.ParseError(sctx)
 
     def summary: String = {


### PR DESCRIPTION
fixes #10015

Add default param to expect, expectAny, zeroOrMore, oneOrMore, nameUnqualified, nameAllowQualified, aliasedName

Now all the "free" Unknown in parser2 is eliminated.