### PR TITLE
chore: remove unused CompletionContext fields

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionContext.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionContext.scala
@@ -15,16 +15,11 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.api.lsp.{Position, Range}
+import ca.uwaterloo.flix.api.lsp.Range
 
 /**
   * Represents a completion context.
   *
-  * @param uri          Source file URI (from client)
-  * @param pos          The position in LSP
   * @param range        Start and end position of the word underneath (or alongside) the cursor
-  * @param word         The word underneath (or alongside) the cursor
-  * @param previousWord The word before the above (note that this may be on either the current or previous line)
-  * @param prefix       The text from the start of the line up to the cursor
   */
-case class CompletionContext(uri: String, pos: Position, range: Range, word: String, previousWord: String, prefix: String)
+case class CompletionContext(range: Range)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/HoleCompletion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/HoleCompletion.scala
@@ -28,12 +28,12 @@ object HoleCompletion {
   /**
     * Gets completions for when the cursor position is on a hole expression with an expression
     */
-  def getHoleCompletion(ctx: CompletionContext, root: TypedAst.Root)(implicit flix: Flix): Iterable[Completion] = {
+  def getHoleCompletion(uri: String, pos: Position, root: TypedAst.Root)(implicit flix: Flix): Iterable[Completion] = {
     val stack = StackConsumer()
 
-    if (ctx.pos.character >= 2) {
-      val leftPos = Position(ctx.pos.line, ctx.pos.character - 1)
-      Visitor.visitRoot(root, stack, InsideAcceptor(ctx.uri, leftPos))
+    if (pos.character >= 2) {
+      val leftPos = Position(pos.line, pos.character - 1)
+      Visitor.visitRoot(root, stack, InsideAcceptor(uri, leftPos))
     }
 
     stack.getStack.headOption match {


### PR DESCRIPTION
Now completionContext only has one field: range.

Since we also remove previousWord, we can no longer tell if a def completion comes after |> etc. Relative code is removed too.