### PR TITLE
refactor: remove `CompletionContext` from `KindCompleter`

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -50,11 +50,11 @@ sealed trait Completion {
         kind             = CompletionItemKind.Keyword
       )
 
-    case Completion.KindCompletion(kind) =>
+    case Completion.KindCompletion(kind, range) =>
       CompletionItem(
         label    = kind,
         sortText = Priority.toSortText(Priority.Highest, kind),
-        textEdit = TextEdit(context.range, kind),
+        textEdit = TextEdit(range, kind),
         kind     = CompletionItemKind.TypeParameter
       )
 
@@ -545,9 +545,10 @@ object Completion {
   /**
     * Represents a completion for a kind.
     *
-    * @param kind the name of the kind.
+    * @param kind   the name of the kind.
+    * @param range  the range of the completion.
     */
-  case class KindCompletion(kind: String) extends Completion
+  case class KindCompletion(kind: String, range: Range) extends Completion
 
   /**
     * Represents a predicate completion.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KindCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KindCompleter.scala
@@ -16,12 +16,13 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.KindCompletion
+import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object KindCompleter {
   def getCompletions(err: ResolutionError.UndefinedKind): List[Completion] = {
     val kinds = List("Type", "Eff", "Bool")
     kinds.collect{
-      case kind if kind.startsWith(err.qn.ident.name) => KindCompletion(kind)}
+      case kind if kind.startsWith(err.qn.ident.name) => KindCompletion(kind, Range.from(err.loc))}
   }
 }


### PR DESCRIPTION
Now only change KindCompletion to avoid using CompletionContext.range, as a preview.

This way, we'll need to add range to every Completion, build it from loc(if available), and test if the range from loc is exactly what we want.

Also sometimes we'll meet problems like in KeywordCompletion loc is not available.

Do you think it's okay to impl this way?