### PR TITLE
feat: introduce SyntacticContext.Instance

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -121,13 +121,11 @@ object CompletionProvider {
     // Declarations.
     case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords
     case SyntacticContext.Decl.Effect => KeywordCompleter.getEffectKeywords
+    case SyntacticContext.Decl.Instance => KeywordCompleter.getInstanceKeywords
     case SyntacticContext.Decl.Module => KeywordCompleter.getModKeywords ++ ExprSnippetCompleter.getCompletions()
     case SyntacticContext.Decl.Struct => KeywordCompleter.getStructKeywords
     case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords
     case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords
-
-    // Instance
-    case SyntacticContext.Instance => KeywordCompleter.getInstanceKeywords
 
     case SyntacticContext.Unknown => Nil
   }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -126,6 +126,9 @@ object CompletionProvider {
     case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords
     case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords
 
+    // Instance
+    case SyntacticContext.Instance => KeywordCompleter.getInstanceKeywords
+
     case SyntacticContext.Unknown => Nil
   }
 

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/SyntacticContext.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/SyntacticContext.scala
@@ -15,9 +15,6 @@
  */
 package ca.uwaterloo.flix.language.ast.shared
 
-import ca.uwaterloo.flix.language.ast.Name
-import ca.uwaterloo.flix.language.errors.ResolutionError
-
 /**
   * A common super-type for syntactic contexts.
   *
@@ -33,6 +30,8 @@ object SyntacticContext {
     case object Enum extends Decl
 
     case object Effect extends Decl
+
+    case object Instance extends SyntacticContext
 
     case object Module extends Decl
 
@@ -51,7 +50,6 @@ object SyntacticContext {
     case object OtherExpr extends Expr
   }
 
-  case object Instance extends SyntacticContext
 
   case object Unknown extends SyntacticContext
 

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/SyntacticContext.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/SyntacticContext.scala
@@ -51,6 +51,8 @@ object SyntacticContext {
     case object OtherExpr extends Expr
   }
 
+  case object Instance extends SyntacticContext
+
   case object Unknown extends SyntacticContext
 
 }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -988,7 +988,7 @@ object Parser2 {
               while (!nth(0).isFirstInstance && !eat(TokenKind.CurlyR) && !eof()) {
                 advance()
               }
-              val error = UnexpectedToken(expected = NamedTokenSet.FromKinds(Set(TokenKind.KeywordType, TokenKind.KeywordDef)), actual = Some(at), loc = loc)
+              val error = UnexpectedToken(expected = NamedTokenSet.FromKinds(Set(TokenKind.KeywordType, TokenKind.KeywordDef)), actual = Some(at), SyntacticContext.Instance, loc = loc)
               closeWithError(errMark, error, Some(at))
           }
         }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -988,7 +988,7 @@ object Parser2 {
               while (!nth(0).isFirstInstance && !eat(TokenKind.CurlyR) && !eof()) {
                 advance()
               }
-              val error = UnexpectedToken(expected = NamedTokenSet.FromKinds(Set(TokenKind.KeywordType, TokenKind.KeywordDef)), actual = Some(at), SyntacticContext.Instance, loc = loc)
+              val error = UnexpectedToken(expected = NamedTokenSet.FromKinds(Set(TokenKind.KeywordType, TokenKind.KeywordDef)), actual = Some(at), SyntacticContext.Decl.Instance, loc = loc)
               closeWithError(errMark, error, Some(at))
           }
         }
@@ -1172,7 +1172,7 @@ object Parser2 {
       zeroOrMore(
         namedTokenSet = NamedTokenSet.FromKinds(NAME_FIELD),
         getItem = structField,
-        checkForItem = (token => NAME_FIELD.contains(token) || token.isModifier),
+        checkForItem = token => NAME_FIELD.contains(token) || token.isModifier,
         breakWhen = _.isRecoverExpr,
         delimiterL = TokenKind.CurlyL,
         delimiterR = TokenKind.CurlyR,


### PR DESCRIPTION
fixes #10056
Now the three completions can be triggered in instance:
<img width="390" alt="image" src="https://github.com/user-attachments/assets/72d2899e-3dea-43f3-a259-7384a50d0638" />
<img width="387" alt="image" src="https://github.com/user-attachments/assets/0fa518ec-13fa-421f-9b0e-acf14c8957b0" />
<img width="358" alt="image" src="https://github.com/user-attachments/assets/4d4c9814-2453-4a54-a458-9c9c75b948ff" />
