### PR TITLE
fix: UndefinedJvmImport should not include import in the range

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -3273,7 +3273,7 @@ object Resolver {
     * Returns the class reflection object for the given `className`.
     */
   private def lookupJvmClass2(className: Name.Ident, ns0: Name.NName, env0: LocalScope, loc: SourceLocation)(implicit flix: Flix): Result[Class[?], ResolutionError] = {
-    lookupJvmClass(className.name, ns0, loc) match {
+    lookupJvmClass(className.name, ns0, className.loc) match {
       case Result.Ok(clazz) => Result.Ok(clazz)
       case Result.Err(e) => env0.get(className.name) match {
         case List(Resolution.JavaClass(clazz)) => Result.Ok(clazz)
@@ -3356,7 +3356,7 @@ object Resolver {
     }
 
     case NamedAst.UseOrImport.Import(name, alias, loc) =>
-      val clazzVal = lookupJvmClass(name.toString, ns, loc).toValidation
+      val clazzVal = lookupJvmClass(name.toString, ns, name.loc).toValidation
       mapN(clazzVal) {
         case clazz => UseOrImport.Import(clazz, alias, loc)
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -3110,19 +3110,12 @@ object Weeder2 {
   }
 
   private def pickJavaName(tree: Tree): Validation[Name.JavaName, CompilationMessage] = {
-    val idents = pickQNameIdents(tree)
-    mapN(idents) {
-      idents => Name.JavaName(idents, tree.loc)
+    mapN(pick(TreeKind.QName, tree)){
+      qname => Name.JavaName(pickAll(TreeKind.Ident, qname).flatMap(text), qname.loc)
     }
   }
 
-  private def pickQNameIdents(tree: Tree): Validation[List[String], CompilationMessage] = {
-    flatMapN(pick(TreeKind.QName, tree)) {
-      qname => mapN(traverse(pickAll(TreeKind.Ident, qname))(t => Validation.Success(text(t))))(_.flatten)
-    }
-  }
-
-  ////////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////////
   /// HELPERS ////////////////////////////////////////////////////////////////////
   ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
The first wrong loc we meet when trying to get rid of CompletionContext.

After this PR it becomes:

<img width="694" alt="image" src="https://github.com/user-attachments/assets/d32c4b3e-029d-4a5e-85ff-ad5983aaf61c" />

We want to use this range in Completion. So it should not include the import.

Actually the wrong loc of the jname is also fixed in this PR.