### PR TITLE
refactor: stop using context range if possible

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -83,7 +83,7 @@ object CompletionProvider {
             ModuleCompleter.getCompletions(err)
 
         case err: ResolutionError.UndefinedType =>
-          TypeBuiltinCompleter.getCompletions ++
+          TypeBuiltinCompleter.getCompletions(err) ++
             AutoImportCompleter.getCompletions(err) ++
             LocalScopeCompleter.getCompletions(err) ++
             EnumCompleter.getCompletions(err) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoImportCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/AutoImportCompleter.scala
@@ -15,8 +15,9 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.api.lsp.CompletionItemLabelDetails
+import ca.uwaterloo.flix.api.lsp.{CompletionItemLabelDetails, Range}
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.AutoImportCompletion
+import ca.uwaterloo.flix.language.ast.SourceLocation
 import ca.uwaterloo.flix.language.ast.TypedAst.Root
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope}
 import ca.uwaterloo.flix.language.errors.ResolutionError
@@ -42,25 +43,26 @@ object AutoImportCompleter {
    *  }}}
    */
   def getCompletions(err: ResolutionError.UndefinedName)(implicit root: Root): Iterable[AutoImportCompletion] =
-    javaClassCompletionsByClass(err.qn.ident.name, err.ap, err.env)
+    javaClassCompletionsByClass(err.qn.ident.name, err.loc, err.ap, err.env)
 
   def getCompletions(err: ResolutionError.UndefinedType)(implicit root: Root): Iterable[AutoImportCompletion] =
-    javaClassCompletionsByClass(err.qn.ident.name, err.ap, err.env)
+    javaClassCompletionsByClass(err.qn.ident.name, err.loc, err.ap, err.env)
 
   /**
    * Gets completions from a java class prefix.
    *
    * Note: we will not propose completions for classes with a lowercase name.
    */
-  private def javaClassCompletionsByClass(prefix: String, ap: AnchorPosition, env: LocalScope)(implicit root: Root): Iterable[AutoImportCompletion] = {
+  private def javaClassCompletionsByClass(prefix: String, loc: SourceLocation, ap: AnchorPosition, env: LocalScope)(implicit root: Root): Iterable[AutoImportCompletion] = {
     if (!CompletionUtils.shouldComplete(prefix)) return Nil
+    val range = Range.from(loc)
     val availableClasses = root.availableClasses.byClass.m.filter(_._1.exists(_.isUpper))
     availableClasses.keys.filter(CompletionUtils.fuzzyMatch(prefix, _)).flatMap { className =>
-      availableClasses(className).collect { case namespace if (!env.m.contains(className)) =>
+      availableClasses(className).collect { case namespace if !env.m.contains(className) =>
         val qualifiedName = namespace.mkString(".") + "." + className
         val priority = mkPriority(qualifiedName)
         val labelDetails = CompletionItemLabelDetails(None, Some(s"import $qualifiedName"))
-          AutoImportCompletion(className, qualifiedName, ap, labelDetails, priority)
+          AutoImportCompletion(className, range, qualifiedName, ap, labelDetails, priority)
       }
     }
  }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -68,28 +68,29 @@ sealed trait Completion {
         insertTextFormat = InsertTextFormat.Snippet
       )
 
-    case Completion.TypeBuiltinCompletion(name, priority) =>
+    case Completion.TypeBuiltinCompletion(name, range, priority) =>
       CompletionItem(
         label            = name,
         sortText         = Priority.toSortText(priority, name),
-        textEdit         = TextEdit(context.range, name),
+        textEdit         = TextEdit(range, name),
         insertTextFormat = InsertTextFormat.PlainText,
-        kind             = CompletionItemKind.Enum
+        kind             = CompletionItemKind.TypeParameter
       )
 
-    case Completion.TypeBuiltinPolyCompletion(name, edit, priority) =>
+    case Completion.TypeBuiltinPolyCompletion(name, range, edit, priority) =>
       CompletionItem(label = name,
         sortText         = Priority.toSortText(priority, name),
-        textEdit         = TextEdit(context.range, edit),
+        textEdit         = TextEdit(range, edit),
         insertTextFormat = InsertTextFormat.Snippet,
-        kind             = CompletionItemKind.Enum
+        kind             = CompletionItemKind.TypeParameter
       )
 
-    case Completion.ImportCompletion(name, isPackage) =>
+    case Completion.ImportCompletion(name, range, isPackage) =>
+      println(range)
       CompletionItem(
         label            = name,
         sortText         = Priority.toSortText(Priority.Highest, name),
-        textEdit         = TextEdit(context.range, name),
+        textEdit         = TextEdit(range, name),
         documentation    = None,
         insertTextFormat = InsertTextFormat.PlainText,
         kind             = {
@@ -98,12 +99,12 @@ sealed trait Completion {
         }
       )
 
-    case Completion.AutoImportCompletion(name, path, ap, labelDetails , priority) =>
+    case Completion.AutoImportCompletion(name, range, path, ap, labelDetails , priority) =>
       CompletionItem(
         label               = name,
         labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(priority, name),
-        textEdit            = TextEdit(context.range, name),
+        textEdit            = TextEdit(range, name),
         insertTextFormat    = InsertTextFormat.PlainText,
         kind                = CompletionItemKind.Class,
         additionalTextEdits = List(Completion.mkTextEdit(ap, s"import $path"))
@@ -567,37 +568,41 @@ object Completion {
   /**
     * Represents a type completion for builtin
     *
-    * @param name             the name of the BuiltinType.
-    * @param priority         the priority of the BuiltinType.
+    * @param name       the name of the BuiltinType.
+    * @param range      the range of the completion.
+    * @param priority   the priority of the BuiltinType.
     */
-  case class TypeBuiltinCompletion(name: String, priority: Priority) extends Completion
+  case class TypeBuiltinCompletion(name: String, range: Range, priority: Priority) extends Completion
 
   /**
     * Represents a type completion for a builtin polymorphic type.
     *
     * @param name      the name of the type.
+    * @param range      the range of the completion.
     * @param priority  the priority of the type.
     */
-  case class TypeBuiltinPolyCompletion(name: String, edit: String, priority: Priority) extends Completion
+  case class TypeBuiltinPolyCompletion(name: String, range: Range, edit: String, priority: Priority) extends Completion
 
   /**
     * Represents a package, class, or interface completion.
     *
     * @param name       the name to be completed.
+    * @param range      the range of the completion.
     * @param isPackage  whether the completion is a package.
     */
-  case class ImportCompletion(name: String, isPackage: Boolean) extends Completion
+  case class ImportCompletion(name: String, range: Range, isPackage: Boolean) extends Completion
 
   /**
     * Represents an auto-import completion.
     *
     * @param name          the name to be completed under cursor.
+    * @param range      the range of the completion.
     * @param qualifiedName the path of the java class we will auto-import.
     * @param ap            the anchor position.
     * @param labelDetails  to show the namespace of class we are going to import
     * @param priority      the priority of the completion.
     */
-  case class AutoImportCompletion(name:String, qualifiedName: String, ap: AnchorPosition, labelDetails: CompletionItemLabelDetails, priority: Priority) extends Completion
+  case class AutoImportCompletion(name:String, range: Range, qualifiedName: String, ap: AnchorPosition, labelDetails: CompletionItemLabelDetails, priority: Priority) extends Completion
 
   /**
     * Represents a Snippet completion

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -283,7 +283,7 @@ sealed trait Completion {
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.EffectCompletion(effect, ap, qualified, inScope) =>
+    case Completion.EffectCompletion(effect, range, ap, qualified, inScope) =>
       val qualifiedName = effect.sym.toString
       val name = if (qualified) qualifiedName else effect.sym.name
       val description = if(!qualified) {
@@ -296,13 +296,13 @@ sealed trait Completion {
         label               = name,
         labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(priority, name),
-        textEdit            = TextEdit(context.range, name),
+        textEdit            = TextEdit(range, name),
         documentation       = Some(effect.doc.text),
         kind                = CompletionItemKind.Event,
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.HandlerCompletion(effect, ap, qualified, inScope) =>
+    case Completion.HandlerCompletion(effect, range, ap, qualified, inScope) =>
       val qualifiedName = effect.sym.toString
       val name = if (qualified) qualifiedName else effect.sym.name
       val description = if(!qualified) {
@@ -317,13 +317,13 @@ sealed trait Completion {
         label               = name,
         labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(priority, name),
-        textEdit            = TextEdit(context.range, snippet),
+        textEdit            = TextEdit(range, snippet),
         documentation       = Some(effect.doc.text),
         kind                = CompletionItemKind.Event,
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.TypeAliasCompletion(typeAlias, ap, qualified, inScope) =>
+    case Completion.TypeAliasCompletion(typeAlias, range, ap, qualified, inScope) =>
       val qualifiedName = typeAlias.sym.toString
       val name = if (qualified) qualifiedName else typeAlias.sym.name
       val label = name + CompletionUtils.formatTParams(typeAlias.tparams)
@@ -338,14 +338,14 @@ sealed trait Completion {
         label               = label,
         labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(priority, name),
-        textEdit            = TextEdit(context.range, snippet),
+        textEdit            = TextEdit(range, snippet),
         documentation       = Some(typeAlias.doc.text),
         kind                = CompletionItemKind.TypeParameter,
         insertTextFormat    = InsertTextFormat.Snippet,
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.OpCompletion(op, namespace, ap, qualified, inScope, isHandler) =>
+    case Completion.OpCompletion(op, range, namespace, ap, qualified, inScope, isHandler) =>
       val qualifiedName =  if (namespace.nonEmpty)
         s"$namespace.${op.sym.name}"
       else
@@ -365,7 +365,7 @@ sealed trait Completion {
         label               = name,
         labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(priority, name),
-        textEdit            = TextEdit(context.range, snippet),
+        textEdit            = TextEdit(range, snippet),
         detail              = Some(FormatScheme.formatScheme(op.spec.declaredScheme)(flix)),
         documentation       = Some(op.spec.doc.text),
         insertTextFormat    = InsertTextFormat.Snippet,
@@ -722,7 +722,7 @@ object Completion {
     * @param qualified indicate whether to use a qualified label.
     * @param inScope   indicate whether to the effect is inScope.
     */
-  case class EffectCompletion(effect: TypedAst.Effect, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
+  case class EffectCompletion(effect: TypedAst.Effect, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
 
   /**
     * Represents a handler completion
@@ -733,7 +733,7 @@ object Completion {
     * @param qualified indicate whether to use a qualified label.
     * @param inScope   indicate whether to the related effect is inScope.
     */
-  case class HandlerCompletion(effect: TypedAst.Effect, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
+  case class HandlerCompletion(effect: TypedAst.Effect, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
 
   /**
     * Represents a TypeAlias completion
@@ -744,7 +744,7 @@ object Completion {
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the type alias is inScope.
     */
-  case class TypeAliasCompletion(typeAlias: TypedAst.TypeAlias, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
+  case class TypeAliasCompletion(typeAlias: TypedAst.TypeAlias, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
 
   /**
     * Represents an Op completion
@@ -757,7 +757,7 @@ object Completion {
     * @param inScope    indicate whether to the op is inScope.
     * @param isHandler  indicate whether the completion is in a handler.
     */
-  case class OpCompletion(op: TypedAst.Op, namespace: String, ap: AnchorPosition, qualified: Boolean, inScope: Boolean, isHandler: Boolean) extends Completion
+  case class OpCompletion(op: TypedAst.Op, range: Range, namespace: String, ap: AnchorPosition, qualified: Boolean, inScope: Boolean, isHandler: Boolean) extends Completion
 
   /**
     * Represents a Signature completion

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -576,9 +576,9 @@ object Completion {
   /**
     * Represents a type completion for a builtin polymorphic type.
     *
-    * @param name      the name of the type.
+    * @param name       the name of the type.
     * @param range      the range of the completion.
-    * @param priority  the priority of the type.
+    * @param priority   the priority of the type.
     */
   case class TypeBuiltinPolyCompletion(name: String, range: Range, edit: String, priority: Priority) extends Completion
 
@@ -594,12 +594,12 @@ object Completion {
   /**
     * Represents an auto-import completion.
     *
-    * @param name          the name to be completed under cursor.
-    * @param range      the range of the completion.
-    * @param qualifiedName the path of the java class we will auto-import.
-    * @param ap            the anchor position.
-    * @param labelDetails  to show the namespace of class we are going to import
-    * @param priority      the priority of the completion.
+    * @param name           the name to be completed under cursor.
+    * @param range          the range of the completion.
+    * @param qualifiedName  the path of the java class we will auto-import.
+    * @param ap             the anchor position.
+    * @param labelDetails   to show the namespace of class we are going to import
+    * @param priority       the priority of the completion.
     */
   case class AutoImportCompletion(name:String, range: Range, qualifiedName: String, ap: AnchorPosition, labelDetails: CompletionItemLabelDetails, priority: Priority) extends Completion
 
@@ -670,11 +670,11 @@ object Completion {
   /**
     * Represents an Enum completion
     *
-    * @param enm      the enum construct.
-    * @param range     the range for TextEdit.
-    * @param ap        the anchor position for the use statement.
-    * @param qualified indicate whether to use a qualified label.
-    * @param inScope   indicate whether to the enum is inScope.
+    * @param enm                the enum construct.
+    * @param range              the range for TextEdit.
+    * @param ap                 the anchor position for the use statement.
+    * @param qualified          indicate whether to use a qualified label.
+    * @param inScope            indicate whether to the enum is inScope.
     * @param withTypeParameters indicate whether to include type parameters in the completion.
     */
   case class EnumCompletion(enm: TypedAst.Enum, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean, withTypeParameters: Boolean) extends Completion
@@ -706,7 +706,7 @@ object Completion {
     * Represents a trait completion
     *
     * @param trt            trait construct.
-    * @param range     the range for TextEdit.
+    * @param range          the range for TextEdit.
     * @param ap             the anchor position for the use statement.
     * @param qualified      indicate whether to use a qualified label.
     * @param inScope        indicate whether to the trait is inScope.
@@ -739,7 +739,7 @@ object Completion {
     * Represents a TypeAlias completion
     *
     * @param typeAlias  the type alias.
-    * @param range     the range for TextEdit.
+    * @param range      the range for TextEdit.
     * @param ap         the anchor position for the use statement.
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the type alias is inScope.
@@ -750,7 +750,7 @@ object Completion {
     * Represents an Op completion
     *
     * @param op         the op.
-    * @param range     the range for TextEdit.
+    * @param range      the range for TextEdit.
     * @param namespace  the namespace of the op, if not provided, we use the fully qualified name.
     * @param ap         the anchor position for the use statement.
     * @param qualified  indicate whether to use a qualified label.
@@ -763,7 +763,7 @@ object Completion {
     * Represents a Signature completion
     *
     * @param sig        the signature.
-    * @param range     the range for TextEdit.
+    * @param range      the range for TextEdit.
     * @param ap         the anchor position for the use statement.
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the signature is inScope.
@@ -774,7 +774,7 @@ object Completion {
     * Represents an Enum Tag completion
     *
     * @param tag        the tag.
-    * @param range     the range for TextEdit.
+    * @param range      the range for TextEdit.
     * @param namespace  the namespace of the tag, if not provided, we use the fully qualified name.
     * @param ap         the anchor position for the use statement.
     * @param qualified  indicate whether to use a qualified label.
@@ -785,8 +785,8 @@ object Completion {
   /**
     * Represents a Module completion
     *
-    * @param module        the module.
-    * @param range     the range for TextEdit.
+    * @param module     the module.
+    * @param range      the range for TextEdit.
     * @param ap         the anchor position for the use statement.
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the signature is inScope.
@@ -797,7 +797,7 @@ object Completion {
     * Represents a Use completion.
     *
     * @param name               the name of the use completion.
-    * @param range     the range for TextEdit.
+    * @param range              the range for TextEdit.
     * @param completionItemKind the kind of the completion.
     */
   case class UseCompletion(name: String, range: Range, completionItemKind: CompletionItemKind) extends Completion

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -169,7 +169,7 @@ sealed trait Completion {
     case Completion.DefCompletion(decl, range, ap, qualified, inScope) =>
       val qualifiedName = decl.sym.toString
       val label = if (qualified) qualifiedName else decl.sym.name
-      val snippet = CompletionUtils.getApplySnippet(label, decl.spec.fparams)(context)
+      val snippet = CompletionUtils.getApplySnippet(label, decl.spec.fparams)
       val description = if(!qualified) {
         Some(if (inScope) qualifiedName else s"use $qualifiedName")
       } else None
@@ -352,9 +352,9 @@ sealed trait Completion {
         op.sym.toString
       val name = if (qualified) qualifiedName else op.sym.name
       val snippet = if (isHandler)
-          CompletionUtils.getOpHandlerSnippet(name, op.spec.fparams)(context)
+          CompletionUtils.getOpHandlerSnippet(name, op.spec.fparams)
         else
-          CompletionUtils.getApplySnippet(name, op.spec.fparams)(context)
+          CompletionUtils.getApplySnippet(name, op.spec.fparams)
       val description = if(!qualified) {
         Some(if (inScope) qualifiedName else s"use $qualifiedName")
       } else None
@@ -379,7 +379,7 @@ sealed trait Completion {
       else
         sig.sym.toString
       val name = if (qualified) qualifiedName else sig.sym.name
-      val snippet = CompletionUtils.getApplySnippet(name, sig.spec.fparams)(context)
+      val snippet = CompletionUtils.getApplySnippet(name, sig.spec.fparams)
       val description = if(!qualified) {
         Some(if (inScope) qualifiedName else s"use $qualifiedName")
       } else None

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -137,31 +137,31 @@ sealed trait Completion {
         kind     = CompletionItemKind.Variable
       )
 
-    case Completion.LocalDeclarationCompletion(name) =>
+    case Completion.LocalDeclarationCompletion(name, range) =>
         CompletionItem(
           label    = name,
           sortText = Priority.toSortText(Priority.High, name),
-          textEdit = TextEdit(context.range, name),
+          textEdit = TextEdit(range, name),
           kind     = CompletionItemKind.Enum
         )
 
-    case Completion.LocalJavaClassCompletion(name, clazz) =>
+    case Completion.LocalJavaClassCompletion(name, range, clazz) =>
       val description = Option(clazz.getCanonicalName)
       val labelDetails = CompletionItemLabelDetails(None, description)
       CompletionItem(
         label         = name,
         labelDetails  = Some(labelDetails),
         sortText      = Priority.toSortText(Priority.High, name),
-        textEdit      = TextEdit(context.range, name),
+        textEdit      = TextEdit(range, name),
         kind          = CompletionItemKind.Class
       )
 
-    case Completion.LocalDefCompletion(sym, fparams) =>
+    case Completion.LocalDefCompletion(sym, range, fparams) =>
       val snippet = sym.text + fparams.zipWithIndex.map{ case (fparam, idx) => s"$${${idx + 1}:${fparam.sym.text}}" }.mkString("(", ", ", ")")
       CompletionItem(
         label    = sym.text,
         sortText = Priority.toSortText(Priority.High, sym.text),
-        textEdit = TextEdit(context.range, snippet),
+        textEdit = TextEdit(range, snippet),
         insertTextFormat = InsertTextFormat.Snippet,
         kind     = CompletionItemKind.Function
       )
@@ -625,33 +625,36 @@ object Completion {
   /**
     * Represents a Var completion
     *
-    * @param name     the name of the variable to complete.
-    * @param range    the range for TextEdit.
+    * @param name   the name of the variable to complete.
+    * @param range  the range for TextEdit.
     */
   case class LocalVarCompletion(name: String, range: Range) extends Completion
 
   /**
     * Represents a Declaration completion
     *
-    * @param name the name of the declaration to complete.
+    * @param name   the name of the declaration to complete.
+    * @param range  the range for TextEdit.
     */
-  case class LocalDeclarationCompletion(name: String) extends Completion
+  case class LocalDeclarationCompletion(name: String, range: Range) extends Completion
 
   /**
     * Represents a Java Class completion
     *
     * @param name  the name of the java class to complete.
+    * @param range  the range for TextEdit.
     * @param clazz the java class to complete.
     */
-  case class LocalJavaClassCompletion(name: String, clazz: Class[?]) extends Completion
+  case class LocalJavaClassCompletion(name: String, range: Range, clazz: Class[?]) extends Completion
 
   /**
     * Represents a local def completion
     *
-    * @param sym     the symbol of the local function
-    * @param fparams the formal parameters of the local function
+    * @param sym      the symbol of the local function
+    * @param range    the range for TextEdit.
+    * @param fparams  the formal parameters of the local function
     */
-  case class LocalDefCompletion(sym: Symbol.VarSym, fparams: List[ResolvedAst.FormalParam]) extends Completion
+  case class LocalDefCompletion(sym: Symbol.VarSym, range: Range, fparams: List[ResolvedAst.FormalParam]) extends Completion
 
   /**
     * Represents a Def completion

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -189,7 +189,7 @@ sealed trait Completion {
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.EnumCompletion(enm, ap, qualified, inScope, withTypeParameters) =>
+    case Completion.EnumCompletion(enm, range, ap, qualified, inScope, withTypeParameters) =>
       val qualifiedName = enm.sym.toString
       val name = if (qualified) qualifiedName else enm.sym.name
       val description = if(!qualified) {
@@ -211,7 +211,7 @@ sealed trait Completion {
         labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(priority, qualifiedName),
         filterText          = Some(CompletionUtils.getFilterTextForName(qualifiedName)),
-        textEdit            = TextEdit(context.range, snippet),
+        textEdit            = TextEdit(range, snippet),
         documentation       = Some(enm.doc.text),
         kind                = CompletionItemKind.Enum,
         additionalTextEdits = additionalTextEdit
@@ -671,12 +671,13 @@ object Completion {
     * Represents an Enum completion
     *
     * @param enm      the enum construct.
+    * @param range     the range for TextEdit.
     * @param ap        the anchor position for the use statement.
     * @param qualified indicate whether to use a qualified label.
     * @param inScope   indicate whether to the enum is inScope.
     * @param withTypeParameters indicate whether to include type parameters in the completion.
     */
-  case class EnumCompletion(enm: TypedAst.Enum, ap: AnchorPosition, qualified: Boolean, inScope: Boolean, withTypeParameters: Boolean) extends Completion
+  case class EnumCompletion(enm: TypedAst.Enum, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean, withTypeParameters: Boolean) extends Completion
 
   /**
     * Represents a struct completion

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -217,7 +217,7 @@ sealed trait Completion {
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.StructCompletion(struct, ap, qualified, inScope) =>
+    case Completion.StructCompletion(struct, range, ap, qualified, inScope) =>
       val qualifiedName = struct.sym.toString
       val name = if (qualified) qualifiedName else struct.sym.name
       val label = name + CompletionUtils.formatTParams(struct.tparams)
@@ -232,14 +232,14 @@ sealed trait Completion {
         label               = label,
         labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(priority, name),
-        textEdit            = TextEdit(context.range, snippet),
+        textEdit            = TextEdit(range, snippet),
         documentation       = Some(struct.doc.text),
         insertTextFormat    = InsertTextFormat.Snippet,
         kind                = CompletionItemKind.Struct,
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.TraitCompletion(trt, ap, qualified, inScope, withTypeParameter) =>
+    case Completion.TraitCompletion(trt, range, ap, qualified, inScope, withTypeParameter) =>
       val qualifiedName = trt.sym.toString
       val name = if (qualified) qualifiedName else trt.sym.name
       val description = if(!qualified) {
@@ -254,14 +254,14 @@ sealed trait Completion {
         label               = label,
         labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(priority, name),
-        textEdit            = TextEdit(context.range, snippet),
+        textEdit            = TextEdit(range, snippet),
         documentation       = Some(trt.doc.text),
         insertTextFormat    = InsertTextFormat.Snippet,
         kind                = CompletionItemKind.Interface,
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.InstanceCompletion(trt, ap, qualified, inScope) =>
+    case Completion.InstanceCompletion(trt, range, ap, qualified, inScope) =>
       val qualifiedName = trt.sym.toString
       val name = if (qualified) qualifiedName else trt.sym.name
       val label = name + CompletionUtils.formatTParams(List(trt.tparam))
@@ -276,7 +276,7 @@ sealed trait Completion {
         label               = label,
         labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(priority, name),
-        textEdit            = TextEdit(context.range, snippet),
+        textEdit            = TextEdit(range, snippet),
         documentation       = Some(trt.doc.text),
         insertTextFormat    = InsertTextFormat.Snippet,
         kind                = CompletionItemKind.Interface,
@@ -683,37 +683,41 @@ object Completion {
     * Represents a struct completion
     *
     * @param struct    the struct construct.
+    * @param range     the range for TextEdit.
     * @param ap        the anchor position for the use statement.
     * @param qualified indicate whether to use a qualified label.
     * @param inScope   indicate whether to the enum is inScope.
     */
-  case class StructCompletion(struct: TypedAst.Struct, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
+  case class StructCompletion(struct: TypedAst.Struct, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
 
   /**
     * Represents a trait completion
     *
     * @param trt                trait construct.
+    * @param range              the range for TextEdit.
     * @param ap                 the anchor position for the use statement.
     * @param qualified          indicate whether to use a qualified label.
     * @param inScope            indicate whether to the trait is inScope.
     * @param withTypeParameter  indicate whether to include the type parameter in the completion.
     */
-  case class TraitCompletion(trt: TypedAst.Trait, ap: AnchorPosition, qualified: Boolean, inScope: Boolean, withTypeParameter: Boolean) extends Completion
+  case class TraitCompletion(trt: TypedAst.Trait, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean, withTypeParameter: Boolean) extends Completion
 
   /**
     * Represents a trait completion
     *
     * @param trt            trait construct.
+    * @param range     the range for TextEdit.
     * @param ap             the anchor position for the use statement.
     * @param qualified      indicate whether to use a qualified label.
     * @param inScope        indicate whether to the trait is inScope.
     */
-  case class InstanceCompletion(trt: TypedAst.Trait, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
+  case class InstanceCompletion(trt: TypedAst.Trait, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
 
   /**
     * Represents an Effect completion
     *
     * @param effect    the effect construct.
+    * @param range     the range for TextEdit.
     * @param ap        the anchor position for the use statement.
     * @param qualified indicate whether to use a qualified label.
     * @param inScope   indicate whether to the effect is inScope.
@@ -724,6 +728,7 @@ object Completion {
     * Represents a handler completion
     *
     * @param effect    the related effect.
+    * @param range     the range for TextEdit.
     * @param ap        the anchor position for the use statement.
     * @param qualified indicate whether to use a qualified label.
     * @param inScope   indicate whether to the related effect is inScope.
@@ -734,6 +739,7 @@ object Completion {
     * Represents a TypeAlias completion
     *
     * @param typeAlias  the type alias.
+    * @param range     the range for TextEdit.
     * @param ap         the anchor position for the use statement.
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the type alias is inScope.
@@ -744,6 +750,7 @@ object Completion {
     * Represents an Op completion
     *
     * @param op         the op.
+    * @param range     the range for TextEdit.
     * @param namespace  the namespace of the op, if not provided, we use the fully qualified name.
     * @param ap         the anchor position for the use statement.
     * @param qualified  indicate whether to use a qualified label.
@@ -756,6 +763,7 @@ object Completion {
     * Represents a Signature completion
     *
     * @param sig        the signature.
+    * @param range     the range for TextEdit.
     * @param ap         the anchor position for the use statement.
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the signature is inScope.
@@ -766,6 +774,7 @@ object Completion {
     * Represents an Enum Tag completion
     *
     * @param tag        the tag.
+    * @param range     the range for TextEdit.
     * @param namespace  the namespace of the tag, if not provided, we use the fully qualified name.
     * @param ap         the anchor position for the use statement.
     * @param qualified  indicate whether to use a qualified label.
@@ -777,6 +786,7 @@ object Completion {
     * Represents a Module completion
     *
     * @param module        the module.
+    * @param range     the range for TextEdit.
     * @param ap         the anchor position for the use statement.
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the signature is inScope.
@@ -787,6 +797,7 @@ object Completion {
     * Represents a Use completion.
     *
     * @param name               the name of the use completion.
+    * @param range     the range for TextEdit.
     * @param completionItemKind the kind of the completion.
     */
   case class UseCompletion(name: String, completionItemKind: CompletionItemKind) extends Completion
@@ -795,6 +806,7 @@ object Completion {
    * Represents a struct field completion.
    *
    * @param field the candidate field.
+    * @param range     the range for TextEdit.
    */
   case class StructFieldCompletion(field: String, symLoc: SourceLocation, tpe: Type) extends Completion
 
@@ -802,6 +814,7 @@ object Completion {
    * Represents a Java field completion.
    *
    * @param ident  the partial field name.
+    * @param range     the range for TextEdit.
    * @param field the candidate field.
    */
   case class FieldCompletion(ident: Name.Ident, field: Field) extends Completion
@@ -810,6 +823,7 @@ object Completion {
     * Represents a Java method completion.
     *
     * @param ident  the partial method name.
+    * @param range     the range for TextEdit.
     * @param method the candidate method.
     */
   case class MethodCompletion(ident: Name.Ident, method: Method) extends Completion
@@ -818,6 +832,7 @@ object Completion {
     * Represents a hole completion.
     *
     * @param sym      the variable symbol being completed on.
+    * @param range     the range for TextEdit.
     * @param decl     the proposed def declaration to call.
     * @param priority the priority of the completion (multiple suggestions are possible and they are ranked).
     * @param loc      the source location of the hole.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -373,7 +373,7 @@ sealed trait Completion {
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.SigCompletion(sig, namespace, ap, qualified, inScope) =>
+    case Completion.SigCompletion(sig, range, namespace, ap, qualified, inScope) =>
       val qualifiedName =  if (namespace.nonEmpty)
         s"$namespace.${sig.sym.name}"
       else
@@ -390,7 +390,7 @@ sealed trait Completion {
         label               = name,
         labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(priority, name),
-        textEdit            = TextEdit(context.range, snippet),
+        textEdit            = TextEdit(range, snippet),
         detail              = Some(FormatScheme.formatScheme(sig.spec.declaredScheme)(flix)),
         documentation       = Some(sig.spec.doc.text),
         insertTextFormat    = InsertTextFormat.Snippet,
@@ -398,7 +398,7 @@ sealed trait Completion {
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.EnumTagCompletion(tag, namespace, ap, qualified, inScope) =>
+    case Completion.EnumTagCompletion(tag, range, namespace, ap, qualified, inScope) =>
       val qualifiedName = if (namespace.nonEmpty)
         s"$namespace.${tag.sym.name}"
       else
@@ -414,12 +414,12 @@ sealed trait Completion {
         label               = name,
         labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(priority, name),
-        textEdit            = TextEdit(context.range, name),
+        textEdit            = TextEdit(range, name),
         kind                = CompletionItemKind.EnumMember,
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.ModuleCompletion(module, ap, qualified, inScope) =>
+    case Completion.ModuleCompletion(module, range, ap, qualified, inScope) =>
       val qualifiedName = module.toString
       val name = if (qualified) qualifiedName else module.ns.last
       val description = if(!qualified) {
@@ -432,7 +432,7 @@ sealed trait Completion {
         label               = name,
         labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(priority, name),
-        textEdit            = TextEdit(context.range, name),
+        textEdit            = TextEdit(range, name),
         kind                = CompletionItemKind.Module,
         additionalTextEdits = additionalTextEdit
       )
@@ -768,7 +768,7 @@ object Completion {
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the signature is inScope.
     */
-  case class SigCompletion(sig: TypedAst.Sig, namespace: String,  ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
+  case class SigCompletion(sig: TypedAst.Sig, range: Range, namespace: String,  ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
 
   /**
     * Represents an Enum Tag completion
@@ -780,7 +780,7 @@ object Completion {
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the signature is inScope.
     */
-  case class EnumTagCompletion(tag: TypedAst.Case, namespace: String, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
+  case class EnumTagCompletion(tag: TypedAst.Case, range: Range, namespace: String, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
 
   /**
     * Represents a Module completion
@@ -791,7 +791,7 @@ object Completion {
     * @param qualified  indicate whether to use a qualified label.
     * @param inScope    indicate whether to the signature is inScope.
     */
-  case class ModuleCompletion(module: Symbol.ModuleSym, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
+  case class ModuleCompletion(module: Symbol.ModuleSym, range: Range, ap: AnchorPosition, qualified: Boolean, inScope: Boolean) extends Completion
 
   /**
     * Represents a Use completion.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -437,11 +437,11 @@ sealed trait Completion {
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.UseCompletion(name, kind) =>
+    case Completion.UseCompletion(name, range, kind) =>
       CompletionItem(
         label         = name,
         sortText      = name,
-        textEdit      = TextEdit(context.range, name),
+        textEdit      = TextEdit(range, name),
         documentation = None,
         kind          = kind
       )
@@ -800,30 +800,27 @@ object Completion {
     * @param range     the range for TextEdit.
     * @param completionItemKind the kind of the completion.
     */
-  case class UseCompletion(name: String, completionItemKind: CompletionItemKind) extends Completion
+  case class UseCompletion(name: String, range: Range, completionItemKind: CompletionItemKind) extends Completion
 
   /**
-   * Represents a struct field completion.
-   *
-   * @param field the candidate field.
-    * @param range     the range for TextEdit.
-   */
+    * Represents a struct field completion.
+    *
+    * @param field the candidate field.
+    */
   case class StructFieldCompletion(field: String, symLoc: SourceLocation, tpe: Type) extends Completion
 
   /**
-   * Represents a Java field completion.
-   *
-   * @param ident  the partial field name.
-    * @param range     the range for TextEdit.
-   * @param field the candidate field.
-   */
+    * Represents a Java field completion.
+    *
+    * @param ident  the partial field name.
+    * @param field  the candidate field.
+    */
   case class FieldCompletion(ident: Name.Ident, field: Field) extends Completion
 
   /**
     * Represents a Java method completion.
     *
     * @param ident  the partial method name.
-    * @param range     the range for TextEdit.
     * @param method the candidate method.
     */
   case class MethodCompletion(ident: Name.Ident, method: Method) extends Completion
@@ -832,7 +829,6 @@ object Completion {
     * Represents a hole completion.
     *
     * @param sym      the variable symbol being completed on.
-    * @param range     the range for TextEdit.
     * @param decl     the proposed def declaration to call.
     * @param priority the priority of the completion (multiple suggestions are possible and they are ranked).
     * @param loc      the source location of the hole.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -86,7 +86,6 @@ sealed trait Completion {
       )
 
     case Completion.ImportCompletion(name, range, isPackage) =>
-      println(range)
       CompletionItem(
         label            = name,
         sortText         = Priority.toSortText(Priority.Highest, name),
@@ -130,11 +129,11 @@ sealed trait Completion {
         kind             = CompletionItemKind.Snippet
       )
 
-    case Completion.LocalVarCompletion(name) =>
+    case Completion.LocalVarCompletion(name, range) =>
       CompletionItem(
         label    = name,
         sortText = Priority.toSortText(Priority.High, name),
-        textEdit = TextEdit(context.range, name),
+        textEdit = TextEdit(range, name),
         kind     = CompletionItemKind.Variable
       )
 
@@ -626,9 +625,10 @@ object Completion {
   /**
     * Represents a Var completion
     *
-    * @param name the name of the variable to complete.
+    * @param name     the name of the variable to complete.
+    * @param range    the range for TextEdit.
     */
-  case class LocalVarCompletion(name: String) extends Completion
+  case class LocalVarCompletion(name: String, range: Range) extends Completion
 
   /**
     * Represents a Declaration completion

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -166,7 +166,7 @@ sealed trait Completion {
         kind     = CompletionItemKind.Function
       )
 
-    case Completion.DefCompletion(decl, ap, qualified, inScope) =>
+    case Completion.DefCompletion(decl, range, ap, qualified, inScope) =>
       val qualifiedName = decl.sym.toString
       val label = if (qualified) qualifiedName else decl.sym.name
       val snippet = CompletionUtils.getApplySnippet(label, decl.spec.fparams)(context)
@@ -181,7 +181,7 @@ sealed trait Completion {
         labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(priority, qualifiedName),
         filterText          = Some(CompletionUtils.getFilterTextForName(qualifiedName)),
-        textEdit            = TextEdit(context.range, snippet),
+        textEdit            = TextEdit(range, snippet),
         detail              = Some(FormatScheme.formatScheme(decl.spec.declaredScheme)(flix)),
         documentation       = Some(decl.spec.doc.text),
         insertTextFormat    = InsertTextFormat.Snippet,
@@ -660,11 +660,12 @@ object Completion {
     * Represents a Def completion
     *
     * @param decl      the def decl.
+    * @param range     the range for TextEdit.
     * @param ap        the anchor position for the use statement.
     * @param qualified indicate whether to use a qualified label.
     * @param inScope   indicate whether to the def is inScope.
     */
-  case class DefCompletion(decl: TypedAst.Def, ap: AnchorPosition, qualified:Boolean, inScope: Boolean) extends Completion
+  case class DefCompletion(decl: TypedAst.Def, range: Range, ap: AnchorPosition, qualified:Boolean, inScope: Boolean) extends Completion
 
   /**
     * Represents an Enum completion

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -53,7 +53,7 @@ object CompletionUtils {
   /**
     * Generate a snippet which represents calling a function.
     */
-  def getApplySnippet(name: String, fparams: List[TypedAst.FormalParam])(implicit context: CompletionContext): String = {
+  def getApplySnippet(name: String, fparams: List[TypedAst.FormalParam]): String = {
     val functionIsUnit = isUnitFunction(fparams)
 
     val args = fparams.zipWithIndex.map {
@@ -70,7 +70,7 @@ object CompletionUtils {
   /**
     * Generate a snippet which represents defining an effect operation handler, with an extra `resume` as the last argument.
     */
-  def getOpHandlerSnippet(name: String, fparams: List[TypedAst.FormalParam])(implicit context: CompletionContext): String = {
+  def getOpHandlerSnippet(name: String, fparams: List[TypedAst.FormalParam]): String = {
     val functionIsUnit = isUnitFunction(fparams)
 
     val args = fparams.zipWithIndex.map {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -247,6 +247,11 @@ object CompletionUtils {
   def isAvailable(enumMap: Symbol.EnumSym)(implicit root: TypedAst.Root): Boolean = root.enums.get(enumMap).exists(isAvailable)
 
   /**
+    * Checks if the struct of the given symbol is public.
+    */
+  def isAvailable(struct: Symbol.StructSym)(implicit root: TypedAst.Root): Boolean = root.structs.get(struct).exists(isAvailable)
+
+  /**
     * Replaces the given symbol with a variable named by the given `newText`.
     */
   private def replaceText(oldSym: Symbol, tpe: Type, newText: String)(implicit flix: Flix): Type = {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/DefCompleter.scala
@@ -15,6 +15,7 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
+import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.DefCompletion
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Def
 import ca.uwaterloo.flix.language.ast.TypedAst
@@ -28,15 +29,16 @@ object DefCompleter {
     * When providing completions for unqualified defs that is not in scope, we will also automatically use the def.
     */
   def getCompletions(err: ResolutionError.UndefinedName)(implicit root: TypedAst.Root): Iterable[Completion] ={
+    val range = Range.from(err.loc)
     if (err.qn.namespace.nonEmpty)
       root.defs.values.collect{
         case decl if CompletionUtils.isAvailable(decl.spec) && CompletionUtils.matchesName(decl.sym, err.qn, qualified = true) =>
-          DefCompletion(decl, err.ap, qualified = true, inScope = true)
+          DefCompletion(decl, range, err.ap, qualified = true, inScope = true)
       }
     else
       root.defs.values.collect{
         case decl if CompletionUtils.isAvailable(decl.spec) && CompletionUtils.matchesName(decl.sym, err.qn, qualified = false) =>
-          DefCompletion(decl, err.ap, qualified = false, inScope = inScope(decl, err.env))
+          DefCompletion(decl, range, err.ap, qualified = false, inScope = inScope(decl, err.env))
       }
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EffectCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EffectCompleter.scala
@@ -1,9 +1,10 @@
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
+import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.{EffectCompletion, HandlerCompletion}
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Effect
-import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
+import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object EffectCompleter {
@@ -25,21 +26,22 @@ object EffectCompleter {
   }
 
   private def getCompletions(uri: String, ap: AnchorPosition, env: LocalScope, qn: Name.QName, inHandler: Boolean)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    val range = Range.from(qn.loc)
     if (qn.namespace.nonEmpty)
       root.effects.values.collect{
         case effect if CompletionUtils.isAvailable(effect) && CompletionUtils.matchesName(effect.sym, qn, qualified = true) =>
           if (inHandler)
-            HandlerCompletion(effect, ap, qualified = true, inScope = true)
+            HandlerCompletion(effect, range, ap, qualified = true, inScope = true)
           else
-            EffectCompletion(effect, ap, qualified = true, inScope = true)
+            EffectCompletion(effect, range, ap, qualified = true, inScope = true)
       }
     else
       root.effects.values.collect({
         case effect if CompletionUtils.isAvailable(effect) && CompletionUtils.matchesName(effect.sym, qn, qualified = false) =>
           if (inHandler)
-            HandlerCompletion(effect, ap, qualified = false, inScope = inScope(effect, env))
+            HandlerCompletion(effect, range, ap, qualified = false, inScope = inScope(effect, env))
           else
-          EffectCompletion(effect, ap, qualified = false, inScope = inScope(effect, env))
+          EffectCompletion(effect, range, ap, qualified = false, inScope = inScope(effect, env))
       })
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumCompleter.scala
@@ -15,10 +15,11 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
+import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.EnumCompletion
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Enum
-import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
+import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object EnumCompleter {
@@ -40,15 +41,16 @@ object EnumCompleter {
   }
 
   private def getCompletions(uri: String, ap: AnchorPosition, env: LocalScope, qn: Name.QName, withTypeParameters: Boolean)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    val range = Range.from(qn.loc)
     if (qn.namespace.nonEmpty)
       root.enums.values.collect{
         case enum if CompletionUtils.isAvailable(enum) && CompletionUtils.matchesName(enum.sym, qn, qualified = true) =>
-          EnumCompletion(enum, ap, qualified = true, inScope = true, withTypeParameters = withTypeParameters)
+          EnumCompletion(enum, range, ap, qualified = true, inScope = true, withTypeParameters = withTypeParameters)
       }
     else
       root.enums.values.collect({
         case enum if CompletionUtils.isAvailable(enum) && CompletionUtils.matchesName(enum.sym, qn, qualified = false) =>
-          EnumCompletion(enum, ap, qualified = false, inScope = inScope(enum, env), withTypeParameters = withTypeParameters)
+          EnumCompletion(enum, range, ap, qualified = false, inScope = inScope(enum, env), withTypeParameters = withTypeParameters)
       })
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/EnumTagCompleter.scala
@@ -16,11 +16,11 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
+import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.EnumTagCompletion
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Case, Enum, Namespace}
-import ca.uwaterloo.flix.language.ast.Symbol
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
-import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
+import ca.uwaterloo.flix.language.ast.{Name, Symbol, TypedAst}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object EnumTagCompleter {
@@ -45,7 +45,7 @@ object EnumTagCompleter {
       root.enums.values.flatMap(enm =>
         enm.cases.values.collect{
           case tag if CompletionUtils.isAvailable(enm) && CompletionUtils.matchesName(tag.sym, qn, qualified = false) =>
-            EnumTagCompletion(tag, "", ap, qualified = false, inScope = inScope(tag, env))
+            EnumTagCompletion(tag, Range.from(qn.loc), "", ap, qualified = false, inScope = inScope(tag, env))
         }
       )
   }
@@ -59,7 +59,7 @@ object EnumTagCompleter {
     root.enums.values.flatMap(enm =>
       enm.cases.values.collect{
         case tag if CompletionUtils.isAvailable(enm) && CompletionUtils.matchesName(tag.sym, qn, qualified = true) =>
-          EnumTagCompletion(tag, "",  ap, qualified = true, inScope = true)
+          EnumTagCompletion(tag, Range.from(qn.loc), "",  ap, qualified = true, inScope = true)
       }
     )
   }
@@ -84,7 +84,7 @@ object EnumTagCompleter {
       enm <- root.enums.get(Symbol.mkEnumSym(fullyQualifiedEnum)).toList
       tag <- enm.cases.values
       if CompletionUtils.isAvailable(enm) && CompletionUtils.matchesName(tag.sym, qn, qualified = false)
-    } yield EnumTagCompletion(tag, qn.namespace.toString, ap, qualified = true, inScope = true)
+    } yield EnumTagCompletion(tag, Range.from(qn.loc), qn.namespace.toString, ap, qualified = true, inScope = true)
   }
 
   private def inScope(tag: TypedAst.Case, scope: LocalScope): Boolean = {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ImportCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ImportCompleter.scala
@@ -15,6 +15,7 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
+import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.ImportCompletion
 import ca.uwaterloo.flix.language.ast.TypedAst
 import ca.uwaterloo.flix.language.errors.ResolutionError
@@ -23,20 +24,21 @@ object ImportCompleter {
 
   def getCompletions(err: ResolutionError.UndefinedJvmImport)(implicit root: TypedAst.Root): Iterable[ImportCompletion] = {
     val path = err.name.split('.').toList
+    val range = Range.from(err.loc)
     // Get completions for if we are currently typing the next package/class and if we have just finished typing a package
-    javaClassCompletionsFromPrefix(path)(root) ++ javaClassCompletionsFromPrefix(path.dropRight(1))(root)
+    javaClassCompletionsFromPrefix(path, range)(root) ++ javaClassCompletionsFromPrefix(path.dropRight(1), range)(root)
   }
 
   /**
     * Gets completions from a java path prefix
     */
-  private def javaClassCompletionsFromPrefix(prefix: List[String])(implicit root: TypedAst.Root): Iterable[ImportCompletion] = {
+  private def javaClassCompletionsFromPrefix(prefix: List[String], range: Range)(implicit root: TypedAst.Root): Iterable[ImportCompletion] = {
     root.availableClasses.byPackage(prefix).map(clazz => {
       val label = prefix match {
         case Nil => clazz
         case v => v.mkString("", ".", s".$clazz")
       }
-      Completion.ImportCompletion(label, isPackage = clazz.head.isLower)
+      Completion.ImportCompletion(label, range, isPackage = clazz.head.isLower)
     })
   }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
@@ -57,7 +57,7 @@ object LocalScopeCompleter {
     */
   private def mkDeclarationCompletionForExpr(k: String, v: List[Resolution])(implicit range:Range): Iterable[Completion] =
     v.collect {
-      case Resolution.Declaration(StructField(_, _, _, _)) => Completion.LocalDeclarationCompletion(k)
+      case Resolution.Declaration(StructField(_, _, _, _)) => Completion.LocalDeclarationCompletion(k, range)
     }
 
   /**
@@ -66,7 +66,7 @@ object LocalScopeCompleter {
   private def mkDeclarationCompletionForType(k: String, v: List[Resolution])(implicit range:Range): Iterable[Completion] =
     v.collect {
       case Resolution.Declaration(AssocTypeSig(_, _, _, _, _, _, _)) |
-           Resolution.Declaration(AssocTypeDef(_, _, _, _, _, _)) => Completion.LocalDeclarationCompletion(k)
+           Resolution.Declaration(AssocTypeDef(_, _, _, _, _, _)) => Completion.LocalDeclarationCompletion(k, range)
     }
 
   /**
@@ -74,7 +74,7 @@ object LocalScopeCompleter {
     */
   private def mkJavaClassCompletion(name: String, resolutions: List[Resolution])(implicit range:Range): Iterable[Completion] =
     resolutions.collect {
-      case Resolution.JavaClass(clazz) => Completion.LocalJavaClassCompletion(name, clazz)
+      case Resolution.JavaClass(clazz) => Completion.LocalJavaClassCompletion(name, range, clazz)
     }
 
   /**
@@ -91,5 +91,5 @@ object LocalScopeCompleter {
     * Tries to create a LocalDefCompletion for the given name and resolutions.
     */
   private def mkLocalDefCompletion(resolutions: List[Resolution])(implicit range:Range): Iterable[Completion] =
-    resolutions.collect{ case Resolution.LocalDef(sym, fparams) => (sym, fparams)}.map(Completion.LocalDefCompletion.tupled)
+    resolutions.collect{ case Resolution.LocalDef(sym, fparams) => Completion.LocalDefCompletion(sym, range, fparams)}
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ModuleCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ModuleCompleter.scala
@@ -16,10 +16,11 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.language.ast.{Name, Symbol, TypedAst}
+import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.ModuleCompletion
-import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Effect, Enum, Namespace, Struct, Trait}
+import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.*
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
+import ca.uwaterloo.flix.language.ast.{Name, Symbol, TypedAst}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object ModuleCompleter {
@@ -41,15 +42,16 @@ object ModuleCompleter {
   }
 
   private def getCompletions(ap: AnchorPosition, env: LocalScope, qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    val range = Range.from(qn.loc)
     if (qn.namespace.nonEmpty)
       root.modules.keys.collect{
         case module if module.ns.nonEmpty && matchesModule(module, qn, qualified = true) =>
-          ModuleCompletion(module, ap, qualified = true, inScope = true)
+          ModuleCompletion(module, range, ap, qualified = true, inScope = true)
       }
     else
       root.modules.keys.collect({
         case module if module.ns.nonEmpty && matchesModule(module, qn, qualified = false) =>
-          ModuleCompletion(module, ap, qualified = false, inScope = inScope(module, env))
+          ModuleCompletion(module, range, ap, qualified = false, inScope = inScope(module, env))
       })
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/OpCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/OpCompleter.scala
@@ -16,10 +16,11 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
+import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.OpCompletion
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Effect, Namespace, Op}
-import ca.uwaterloo.flix.language.ast.{Symbol, Name, TypedAst}
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
+import ca.uwaterloo.flix.language.ast.{Name, Symbol, TypedAst}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object OpCompleter {
@@ -30,7 +31,7 @@ object OpCompleter {
     root.effects.values.flatMap(eff =>
       eff.ops.collect {
         case op if CompletionUtils.isAvailable(eff) && CompletionUtils.matchesName(op.sym, err.qn, qualified = false) =>
-          OpCompletion(op, "", err.ap, qualified = false, inScope = true, isHandler = true)
+          OpCompletion(op, Range.from(err.loc), "", err.ap, qualified = false, inScope = true, isHandler = true)
       }
     )
   }
@@ -49,7 +50,7 @@ object OpCompleter {
       root.effects.values.flatMap(eff =>
         eff.ops.collect {
           case op if CompletionUtils.isAvailable(eff) && CompletionUtils.matchesName(op.sym, qn, qualified = false) =>
-            OpCompletion(op, "", ap, qualified = false, inScope(op, env), isHandler = false)
+            OpCompletion(op, Range.from(qn.loc), "", ap, qualified = false, inScope(op, env), isHandler = false)
         }
       )
     }
@@ -64,7 +65,7 @@ object OpCompleter {
     root.effects.values.flatMap(eff =>
       eff.ops.collect {
         case op if CompletionUtils.isAvailable(eff) && CompletionUtils.matchesName(op.sym, qn, qualified = true) =>
-          OpCompletion(op, "", ap, qualified = true, inScope = true, isHandler = false)
+          OpCompletion(op, Range.from(qn.loc), "", ap, qualified = true, inScope = true, isHandler = false)
       }
     )
   }
@@ -89,7 +90,7 @@ object OpCompleter {
       eff <- root.effects.get(Symbol.mkEffectSym(fullyQualifiedEffect)).toList
       op <- eff.ops
       if CompletionUtils.isAvailable(eff) && CompletionUtils.matchesName(op.sym, qn, qualified = false)
-    } yield OpCompletion(op, qn.namespace.toString, ap, qualified = true, inScope = true, isHandler = false)
+    } yield OpCompletion(op, Range.from(qn.loc), qn.namespace.toString, ap, qualified = true, inScope = true, isHandler = false)
   }
 
   private def inScope(op: TypedAst.Op, scope: LocalScope): Boolean = {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/SignatureCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/SignatureCompleter.scala
@@ -16,11 +16,11 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
+import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.SigCompletion
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{Namespace, Sig, Trait}
-import ca.uwaterloo.flix.language.ast.Symbol
-import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
+import ca.uwaterloo.flix.language.ast.{Name, Symbol, TypedAst}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object SignatureCompleter {
@@ -38,7 +38,7 @@ object SignatureCompleter {
       root.traits.values.flatMap(trt =>
         trt.sigs.collect {
           case sig if CompletionUtils.isAvailable(trt) && CompletionUtils.matchesName(sig.sym, qn, qualified = false) =>
-            SigCompletion(sig, "", ap, qualified = false, inScope = inScope(sig, env))
+            SigCompletion(sig, Range.from(qn.loc), "", ap, qualified = false, inScope = inScope(sig, env))
         }
       )
   }
@@ -52,7 +52,7 @@ object SignatureCompleter {
     root.traits.values.flatMap(trt =>
       trt.sigs.collect {
         case sig if CompletionUtils.isAvailable(trt) && CompletionUtils.matchesName(sig.sym, qn, qualified = true) =>
-          SigCompletion(sig, "", ap, qualified = true, inScope = true)
+          SigCompletion(sig, Range.from(qn.loc), "", ap, qualified = true, inScope = true)
       }
     )
   }
@@ -77,7 +77,7 @@ object SignatureCompleter {
       trt <- root.traits.get(Symbol.mkTraitSym(fullyQualifiedTrait)).toList
       sig <- trt.sigs
       if CompletionUtils.isAvailable(trt) && CompletionUtils.matchesName(sig.sym, qn, qualified = false)
-    } yield SigCompletion(sig, qn.namespace.toString, ap, qualified = true, inScope = true)
+    } yield SigCompletion(sig, Range.from(qn.loc), qn.namespace.toString, ap, qualified = true, inScope = true)
   }
 
   private def inScope(sig: TypedAst.Sig, scope: LocalScope): Boolean = {

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/StructCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/StructCompleter.scala
@@ -15,10 +15,11 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
+import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.StructCompletion
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.Struct
-import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
+import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object StructCompleter {
@@ -33,15 +34,16 @@ object StructCompleter {
   }
 
   private def getCompletions(uri: String, ap: AnchorPosition, env: LocalScope, qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    val range = Range.from(qn.loc)
     if (qn.namespace.nonEmpty)
       root.structs.values.collect{
         case struct if CompletionUtils.isAvailable(struct) && CompletionUtils.matchesName(struct.sym, qn, qualified = true) =>
-          StructCompletion(struct, ap, qualified = true, inScope = true)
+          StructCompletion(struct, range, ap, qualified = true, inScope = true)
       }
     else
       root.structs.values.collect({
         case struct if CompletionUtils.isAvailable(struct) && CompletionUtils.matchesName(struct.sym, qn, qualified = false) =>
-          StructCompletion(struct, ap, qualified = false, inScope = inScope(struct, env))
+          StructCompletion(struct, range, ap, qualified = false, inScope = inScope(struct, env))
       })
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeAliasCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeAliasCompleter.scala
@@ -16,10 +16,11 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
+import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.TypeAliasCompletion
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.TypeAlias
-import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
+import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
 import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object TypeAliasCompleter {
@@ -33,15 +34,16 @@ object TypeAliasCompleter {
   }
 
   private def getCompletions(uri: String, ap: AnchorPosition, env: LocalScope, qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
+    val range = Range.from(qn.loc)
     if (qn.namespace.nonEmpty)
       root.typeAliases.values.collect{
         case typeAlias if CompletionUtils.isAvailable(typeAlias) && CompletionUtils.matchesName(typeAlias.sym, qn, qualified = true) =>
-          TypeAliasCompletion(typeAlias, ap, qualified = true, inScope = true)
+          TypeAliasCompletion(typeAlias, range, ap, qualified = true, inScope = true)
       }
     else
       root.typeAliases.values.collect({
         case typeAlias if CompletionUtils.isAvailable(typeAlias) && CompletionUtils.matchesName(typeAlias.sym, qn, qualified = false) =>
-          TypeAliasCompletion(typeAlias, ap, qualified = false, inScope = inScope(typeAlias, env))
+          TypeAliasCompletion(typeAlias, range, ap, qualified = false, inScope = inScope(typeAlias, env))
       })
   }
 

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeBuiltinCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeBuiltinCompleter.scala
@@ -15,46 +15,51 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
+import ca.uwaterloo.flix.api.lsp.Range
+import ca.uwaterloo.flix.language.errors.ResolutionError
+
 object TypeBuiltinCompleter {
-  private def polycompletion(name: String, params: List[String], p: Priority): Completion = {
+  private def polycompletion(name: String, params: List[String], range: Range, p: Priority): Completion = {
     val edit = params.zipWithIndex.map { case (param, i) => s"$${${i + 1}:$param}"}.mkString(s"$name[", ", ", "]")
     val finalName = params.mkString(s"$name[", ", ", "]")
-    Completion.TypeBuiltinPolyCompletion(finalName, edit, p)
+    Completion.TypeBuiltinPolyCompletion(finalName, range, edit, p)
   }
 
   /**
     * Returns a List of Completion for builtin types.
     */
-  def getCompletions: Iterable[Completion] =
+  def getCompletions(err: ResolutionError.UndefinedType): Iterable[Completion] = {
+    val range = Range.from(err.loc)
     List(
       // A
-      polycompletion("Array"   , List("a", "r")    , Priority.Default),
+      polycompletion("Array"   , List("a", "r")    , range,  Priority.Default),
       // B
-      Completion.TypeBuiltinCompletion("BigDecimal", Priority.Low),
-      Completion.TypeBuiltinCompletion("BigInt"    , Priority.High),
-      Completion.TypeBuiltinCompletion("Bool"      , Priority.Higher),
+      Completion.TypeBuiltinCompletion("BigDecimal", range, Priority.Low),
+      Completion.TypeBuiltinCompletion("BigInt"    , range, Priority.High),
+      Completion.TypeBuiltinCompletion("Bool"      , range, Priority.Higher),
       // C
-      Completion.TypeBuiltinCompletion("Char"      , Priority.Default),
+      Completion.TypeBuiltinCompletion("Char"      , range, Priority.Default),
       // F
-      Completion.TypeBuiltinCompletion("Float32"   , Priority.High),
-      Completion.TypeBuiltinCompletion("Float64"   , Priority.Low),
+      Completion.TypeBuiltinCompletion("Float32"   , range, Priority.High),
+      Completion.TypeBuiltinCompletion("Float64"   , range, Priority.Low),
       // I
-      Completion.TypeBuiltinCompletion("Int16"     , Priority.Low),
-      Completion.TypeBuiltinCompletion("Int32"     , Priority.Higher),
-      Completion.TypeBuiltinCompletion("Int64"     , Priority.High),
-      Completion.TypeBuiltinCompletion("Int8"      , Priority.Lower),
+      Completion.TypeBuiltinCompletion("Int16"     , range, Priority.Low),
+      Completion.TypeBuiltinCompletion("Int32"     , range, Priority.Higher),
+      Completion.TypeBuiltinCompletion("Int64"     , range, Priority.High),
+      Completion.TypeBuiltinCompletion("Int8"      , range, Priority.Lower),
       // L
-      polycompletion("Lazy"    , List("t")         , Priority.Default),
+      polycompletion("Lazy"    , List("t")         , range, Priority.Default),
       // R
-      polycompletion("Receiver", List("t")         , Priority.Low),
-      polycompletion("Region"  , List("r")         , Priority.High),
+      polycompletion("Receiver", List("t")         , range, Priority.Low),
+      polycompletion("Region"  , List("r")         , range, Priority.High),
       // S
-      polycompletion("Sender"  , List("t")         , Priority.Low),
-      Completion.TypeBuiltinCompletion("String"    , Priority.High),
+      polycompletion("Sender"  , List("t")         , range, Priority.Low),
+      Completion.TypeBuiltinCompletion("String"    , range, Priority.High),
       // U
-      Completion.TypeBuiltinCompletion("Unit"      , Priority.Default),
+      Completion.TypeBuiltinCompletion("Unit"      , range, Priority.Default),
       // V
-      polycompletion("Vector"  , List("a")         , Priority.High),
-      Completion.TypeBuiltinCompletion("Void"      , Priority.Low),
+      polycompletion("Vector"  , List("a")         , range, Priority.High),
+      Completion.TypeBuiltinCompletion("Void"      , range, Priority.Low),
     )
+  }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/UseCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/UseCompleter.scala
@@ -15,9 +15,9 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.api.lsp.{CompletionItemKind, Range}
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.UseCompletion
 import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.fuzzyMatch
+import ca.uwaterloo.flix.api.lsp.{CompletionItemKind, Range}
 import ca.uwaterloo.flix.language.ast.{Name, Symbol, TypedAst}
 import ca.uwaterloo.flix.language.errors.{ResolutionError, WeederError}
 
@@ -39,11 +39,12 @@ object UseCompleter {
     val ident = qn.ident.name
     val moduleSym = Symbol.mkModuleSym(namespace)
     root.modules.get(moduleSym).collect{
-      case mod:  Symbol.ModuleSym if fuzzyMatch(ident, mod.ns.last) => UseCompletion(mod.toString, range, CompletionItemKind.Module)
-      case enm:  Symbol.EnumSym   if fuzzyMatch(ident, enm.name)  && CompletionUtils.isAvailable(enm)  => UseCompletion(enm.toString, range, CompletionItemKind.Enum)
-      case eff:  Symbol.EffectSym if fuzzyMatch(ident, eff.name)  && CompletionUtils.isAvailable(eff)  => UseCompletion(eff.toString, range, CompletionItemKind.Event)
-      case defn: Symbol.DefnSym   if fuzzyMatch(ident, defn.name) && CompletionUtils.isAvailable(defn) => UseCompletion(defn.toString, range, CompletionItemKind.Function)
-      case trt:  Symbol.TraitSym  if fuzzyMatch(ident, trt.name)  && CompletionUtils.isAvailable(trt)  => UseCompletion(trt.toString, range, CompletionItemKind.Interface)
+      case mod:  Symbol.ModuleSym   if fuzzyMatch(ident, mod.ns.last) => UseCompletion(mod.toString, range, CompletionItemKind.Module)
+      case enm:  Symbol.EnumSym     if fuzzyMatch(ident, enm.name)    && CompletionUtils.isAvailable(enm)     => UseCompletion(enm.toString, range, CompletionItemKind.Enum)
+      case eff:  Symbol.EffectSym   if fuzzyMatch(ident, eff.name)    && CompletionUtils.isAvailable(eff)     => UseCompletion(eff.toString, range, CompletionItemKind.Event)
+      case defn: Symbol.DefnSym     if fuzzyMatch(ident, defn.name)   && CompletionUtils.isAvailable(defn)    => UseCompletion(defn.toString, range, CompletionItemKind.Function)
+      case trt:  Symbol.TraitSym    if fuzzyMatch(ident, trt.name)    && CompletionUtils.isAvailable(trt)     => UseCompletion(trt.toString, range, CompletionItemKind.Interface)
+      case struct: Symbol.StructSym if fuzzyMatch(ident, struct.name) && CompletionUtils.isAvailable(struct)  => UseCompletion(struct.toString, range, CompletionItemKind.Struct)
     } ++ getSigCompletions(uri, qn) ++ getOpCompletions(qn) ++ getTagCompletions(qn)
   }
 


### PR DESCRIPTION
Most Completers are now independent of CompletionContext.

The only usage of CompletionContext is KeywordCompleter, PredicateCompleter and ExprSnippetCompleter, the completers on syntacticContext.

In next PR, we should refactor syntacticContext to bring the loc/range. Then we can remove CompletionContext.

I've tested most of the completers after this refactoring and they all work fine now.