### PR TITLE
feat: bring SourceLocation with SyntacticContext

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -115,17 +115,17 @@ object CompletionProvider {
     */
   private def getSyntacticCompletions(uri: String, e: ParseError)(implicit root: Root, flix: Flix): List[Completion] = e.sctx match {
     // Expressions.
-    case SyntacticContext.Expr.Constraint => (PredicateCompleter.getCompletions(uri) ++ KeywordCompleter.getConstraintKeywords).toList
-    case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords
+    case SyntacticContext.Expr.Constraint(_) => (PredicateCompleter.getCompletions(uri) ++ KeywordCompleter.getConstraintKeywords).toList
+    case SyntacticContext.Expr.OtherExpr(_) => KeywordCompleter.getExprKeywords
 
     // Declarations.
-    case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords
-    case SyntacticContext.Decl.Effect => KeywordCompleter.getEffectKeywords
-    case SyntacticContext.Decl.Instance => KeywordCompleter.getInstanceKeywords
-    case SyntacticContext.Decl.Module => KeywordCompleter.getModKeywords ++ ExprSnippetCompleter.getCompletions()
-    case SyntacticContext.Decl.Struct => KeywordCompleter.getStructKeywords
-    case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords
-    case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords
+    case SyntacticContext.Decl.Enum(_) => KeywordCompleter.getEnumKeywords
+    case SyntacticContext.Decl.Effect(_) => KeywordCompleter.getEffectKeywords
+    case SyntacticContext.Decl.Instance(_) => KeywordCompleter.getInstanceKeywords
+    case SyntacticContext.Decl.Module(_) => KeywordCompleter.getModKeywords ++ ExprSnippetCompleter.getCompletions()
+    case SyntacticContext.Decl.Struct(_) => KeywordCompleter.getStructKeywords
+    case SyntacticContext.Decl.Trait(_) => KeywordCompleter.getTraitKeywords
+    case SyntacticContext.Decl.Type(_) => KeywordCompleter.getTypeKeywords
 
     case SyntacticContext.Unknown => Nil
   }

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/SyntacticContext.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/SyntacticContext.scala
@@ -15,6 +15,8 @@
  */
 package ca.uwaterloo.flix.language.ast.shared
 
+import ca.uwaterloo.flix.language.ast.SourceLocation
+
 /**
   * A common super-type for syntactic contexts.
   *
@@ -27,29 +29,28 @@ object SyntacticContext {
   sealed trait Decl extends SyntacticContext
 
   object Decl {
-    case object Enum extends Decl
+    case class Enum(loc: SourceLocation) extends Decl
 
-    case object Effect extends Decl
+    case class Effect(loc: SourceLocation) extends Decl
 
-    case object Instance extends SyntacticContext
+    case class Instance(loc: SourceLocation) extends Decl
 
-    case object Module extends Decl
+    case class Module(loc: SourceLocation) extends Decl
 
-    case object Struct extends Decl
+    case class Struct(loc: SourceLocation) extends Decl
 
-    case object Trait extends Decl
+    case class Trait(loc: SourceLocation) extends Decl
 
-    case object Type extends Decl
+    case class Type(loc: SourceLocation) extends Decl
   }
 
   sealed trait Expr extends SyntacticContext
 
   object Expr {
-    case object Constraint extends Expr
+    case class Constraint(loc: SourceLocation) extends Expr
 
-    case object OtherExpr extends Expr
+    case class OtherExpr(loc: SourceLocation) extends Expr
   }
-
 
   case object Unknown extends SyntacticContext
 


### PR DESCRIPTION
Every SyntacticContext now brings a SourceLocation with them except Unknown.

In the parser, we call currentSourceLocation to get the loc.

In Weeder, we use the loc used by nearby exprs(usually tree.loc)