### PR TITLE
feat: annotate `java.lang.ref` with primitive effects

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/PrimitiveEffects.Packages.json
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/PrimitiveEffects.Packages.json
@@ -2,6 +2,7 @@
   "packages": {
     "java.lang.constant": "Sys, IO",
     "java.lang.net": "Net, IO",
+    "java.lang.ref": "Sys, IO",
     "java.util.random": "NonDet, IO"
   }
 }


### PR DESCRIPTION
Functionality for working with the garbage collector. Does not seem dangerous per se, but `Sys` does cover "interacting with the jvm"

https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/ref/package-summary.html

Related to https://github.com/flix/flix/issues/9523