### PR TITLE
feat: use loc from parse error

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -113,21 +113,24 @@ object CompletionProvider {
   /**
     * Returns completions based on the syntactic context.
     */
-  private def getSyntacticCompletions(uri: String, e: ParseError)(implicit root: Root, flix: Flix): List[Completion] = e.sctx match {
-    // Expressions.
-    case SyntacticContext.Expr.Constraint => (PredicateCompleter.getCompletions(uri) ++ KeywordCompleter.getConstraintKeywords).toList
-    case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords
+  private def getSyntacticCompletions(uri: String, e: ParseError)(implicit root: Root, flix: Flix): List[Completion] = {
+    implicit val range: Range = Range.from(e.loc)
+    e.sctx match {
+      // Expressions.
+      case SyntacticContext.Expr.Constraint => (PredicateCompleter.getCompletions(uri) ++ KeywordCompleter.getConstraintKeywords).toList
+      case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords
 
-    // Declarations.
-    case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords
-    case SyntacticContext.Decl.Effect => KeywordCompleter.getEffectKeywords
-    case SyntacticContext.Decl.Instance => KeywordCompleter.getInstanceKeywords
-    case SyntacticContext.Decl.Module => KeywordCompleter.getModKeywords ++ ExprSnippetCompleter.getCompletions()
-    case SyntacticContext.Decl.Struct => KeywordCompleter.getStructKeywords
-    case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords
-    case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords
+      // Declarations.
+      case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords
+      case SyntacticContext.Decl.Effect => KeywordCompleter.getEffectKeywords
+      case SyntacticContext.Decl.Instance => KeywordCompleter.getInstanceKeywords
+      case SyntacticContext.Decl.Module => KeywordCompleter.getModKeywords ++ ExprSnippetCompleter.getCompletions()
+      case SyntacticContext.Decl.Struct => KeywordCompleter.getStructKeywords
+      case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords
+      case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords
 
-    case SyntacticContext.Unknown => Nil
+      case SyntacticContext.Unknown => Nil
+    }
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -60,7 +60,7 @@ object CompletionProvider {
       HoleCompleter.getHoleCompletion(uri, pos, root).toList
     else
       errorsAt(uri, pos, currentErrors).flatMap {
-        case err: WeederError.UndefinedAnnotation => KeywordCompleter.getModKeywords
+        case err: WeederError.UndefinedAnnotation => KeywordCompleter.getModKeywords(Range.from(err.loc))
 
         case err: WeederError.UnqualifiedUse => UseCompleter.getCompletions(uri, err)
 
@@ -72,7 +72,7 @@ object CompletionProvider {
         case err: ResolutionError.UndefinedName =>
           AutoImportCompleter.getCompletions(err) ++
             LocalScopeCompleter.getCompletions(err) ++
-            KeywordCompleter.getExprKeywords ++
+            KeywordCompleter.getExprKeywords(Range.from(err.loc)) ++
             DefCompleter.getCompletions(err) ++
             EnumCompleter.getCompletions(err) ++
             EffectCompleter.getCompletions(err) ++
@@ -114,20 +114,20 @@ object CompletionProvider {
     * Returns completions based on the syntactic context.
     */
   private def getSyntacticCompletions(uri: String, e: ParseError)(implicit root: Root, flix: Flix): List[Completion] = {
-    implicit val range: Range = Range.from(e.loc)
+    val range: Range = Range.from(e.loc)
     e.sctx match {
       // Expressions.
-      case SyntacticContext.Expr.Constraint => (PredicateCompleter.getCompletions(uri) ++ KeywordCompleter.getConstraintKeywords).toList
-      case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords
+      case SyntacticContext.Expr.Constraint => (PredicateCompleter.getCompletions(uri, range) ++ KeywordCompleter.getConstraintKeywords(range)).toList
+      case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords(range)
 
       // Declarations.
-      case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords
-      case SyntacticContext.Decl.Effect => KeywordCompleter.getEffectKeywords
-      case SyntacticContext.Decl.Instance => KeywordCompleter.getInstanceKeywords
-      case SyntacticContext.Decl.Module => KeywordCompleter.getModKeywords ++ ExprSnippetCompleter.getCompletions()
-      case SyntacticContext.Decl.Struct => KeywordCompleter.getStructKeywords
-      case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords
-      case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords
+      case SyntacticContext.Decl.Enum => KeywordCompleter.getEnumKeywords(range)
+      case SyntacticContext.Decl.Effect => KeywordCompleter.getEffectKeywords(range)
+      case SyntacticContext.Decl.Instance => KeywordCompleter.getInstanceKeywords(range)
+      case SyntacticContext.Decl.Module => KeywordCompleter.getModKeywords(range) ++ ExprSnippetCompleter.getCompletions(range)
+      case SyntacticContext.Decl.Struct => KeywordCompleter.getStructKeywords(range)
+      case SyntacticContext.Decl.Trait => KeywordCompleter.getTraitKeywords(range)
+      case SyntacticContext.Decl.Type => KeywordCompleter.getTypeKeywords(range)
 
       case SyntacticContext.Unknown => Nil
     }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/PredicateCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/PredicateCompleter.scala
@@ -17,15 +17,15 @@ package ca.uwaterloo.flix.api.lsp.provider.completion
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.api.lsp.acceptors.FileAcceptor
-import ca.uwaterloo.flix.api.lsp.{Consumer, Visitor}
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.PredicateCompletion
+import ca.uwaterloo.flix.api.lsp.{Consumer, Range, Visitor}
 import ca.uwaterloo.flix.language.ast.TypedAst.Root
 import ca.uwaterloo.flix.language.ast.{Name, Type, TypeConstructor, TypedAst}
 import ca.uwaterloo.flix.language.fmt.FormatType
 
 object PredicateCompleter {
 
-  def getCompletions(uri: String)(implicit root: Root, flix: Flix): Iterable[PredicateCompletion] = {
+  def getCompletions(uri: String, range: Range)(implicit root: Root, flix: Flix): Iterable[PredicateCompletion] = {
 
     //
     // Find all predicates together with their type and source location.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/syntactic/ExprSnippetCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/syntactic/ExprSnippetCompleter.scala
@@ -15,11 +15,12 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion.syntactic
 
+import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion
 
 object ExprSnippetCompleter {
 
-  def getCompletions(): Iterable[Completion] = List(
+  def getCompletions(range: Range): Iterable[Completion] = List(
     // NB: Please keep the list alphabetically sorted.
     Completion.SnippetCompletion("main",
       "def main(): Unit \\ IO = \n    println(\"Hello World!\")",

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/syntactic/KeywordCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/syntactic/KeywordCompleter.scala
@@ -15,6 +15,7 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion.syntactic
 
+import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.{Completion, Priority}
 
 /**
@@ -25,7 +26,7 @@ object KeywordCompleter {
   /**
     * Constraint keywords. These are keywords that can occur in datalog constraints.
     */
-  def getConstraintKeywords: List[Completion] =
+  def getConstraintKeywords(range: Range): List[Completion] =
     List(
       Completion.KeywordCompletion("fix", Priority.Default),
       Completion.KeywordCompletion("if" , Priority.Default),
@@ -35,7 +36,7 @@ object KeywordCompleter {
   /**
     * Module keywords. These are keywords that can occur in a module.
     */
-  def getModKeywords: List[Completion] =
+  def getModKeywords(range: Range): List[Completion] =
     List(
       // D
       Completion.KeywordCompletion("@Deprecated"      , Priority.Low),
@@ -71,7 +72,7 @@ object KeywordCompleter {
   /**
     * Enum keywords. These are keywords that can appear within the declaration of an enum.
     */
-  def getEnumKeywords: List[Completion] =
+  def getEnumKeywords(range: Range): List[Completion] =
     List(
       Completion.KeywordCompletion("case", Priority.Default)
     )
@@ -79,7 +80,7 @@ object KeywordCompleter {
   /**
     * Effect keywords. These are keywords that can appear within the declaration of an effect.
     */
-  def getEffectKeywords: List[Completion] =
+  def getEffectKeywords(range: Range): List[Completion] =
     List(
       Completion.KeywordCompletion("def", Priority.Default)
     )
@@ -87,7 +88,7 @@ object KeywordCompleter {
   /**
     * Expression keywords. These are keywords that can appear within expressions (fx within the body of a function).
     */
-  def getExprKeywords: List[Completion] =
+  def getExprKeywords(range: Range): List[Completion] =
     List(
       // A
       Completion.KeywordCompletion("and"         , Priority.Default),
@@ -153,7 +154,7 @@ object KeywordCompleter {
   /**
     * Instance declaration keywords.
     */
-  def getInstanceKeywords: List[Completion] =
+  def getInstanceKeywords(range: Range): List[Completion] =
     List(
       Completion.KeywordCompletion("def"  , Priority.Default),
       Completion.KeywordCompletion("pub"  , Priority.Default),
@@ -163,7 +164,7 @@ object KeywordCompleter {
   /**
     * Struct declaration keywords. These are keywords that occur within a struct declaration.
     */
-  def getStructKeywords: List[Completion] =
+  def getStructKeywords(range: Range): List[Completion] =
     List(
       Completion.KeywordCompletion("mut", Priority.Default)
     )
@@ -171,7 +172,7 @@ object KeywordCompleter {
   /**
     * Trait declaration keywords. These are keywords that occur within a trait declaration.
     */
-  def getTraitKeywords: List[Completion] =
+  def getTraitKeywords(range: Range): List[Completion] =
     List(
       Completion.KeywordCompletion("def", Priority.Default),
       Completion.KeywordCompletion("pub", Priority.Default),
@@ -181,7 +182,7 @@ object KeywordCompleter {
     * Type declaration keywords. These are the keywords that can occur
     * within a type declaration.
     */
-  def getTypeKeywords: List[Completion] =
+  def getTypeKeywords(range: Range): List[Completion] =
     List(
       Completion.KeywordCompletion("alias", Priority.Default)
     )

--- a/main/src/ca/uwaterloo/flix/language/errors/ParseError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ParseError.scala
@@ -16,9 +16,9 @@
 
 package ca.uwaterloo.flix.language.errors
 
-import ca.uwaterloo.flix.language.{CompilationMessage, CompilationMessageKind}
 import ca.uwaterloo.flix.language.ast.shared.SyntacticContext
 import ca.uwaterloo.flix.language.ast.{SourceLocation, SyntaxTree, TokenKind}
+import ca.uwaterloo.flix.language.{CompilationMessage, CompilationMessageKind}
 import ca.uwaterloo.flix.util.Formatter
 
 /**
@@ -26,6 +26,7 @@ import ca.uwaterloo.flix.util.Formatter
   */
 sealed trait ParseError extends CompilationMessage {
   val sctx: SyntacticContext
+  val loc: SourceLocation
   val kind: CompilationMessageKind = CompilationMessageKind.ParseError(sctx)
 }
 

--- a/main/src/ca/uwaterloo/flix/language/errors/ParseError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/ParseError.scala
@@ -25,9 +25,9 @@ import ca.uwaterloo.flix.util.Formatter
   * A common super-type for parser errors.
   */
 sealed trait ParseError extends CompilationMessage {
-  val sctx: SyntacticContext
-  val loc: SourceLocation
-  val kind: CompilationMessageKind = CompilationMessageKind.ParseError(sctx)
+  def kind: CompilationMessageKind = CompilationMessageKind.ParseError(sctx)
+  def sctx: SyntacticContext
+  def loc: SourceLocation
 }
 
 object ParseError {


### PR DESCRIPTION
In the first commit, I just extract the loc from ParseError but not use it.

But that change is too small, so I also use the loc in the second commit. If you prefer, we can use another PR.

Note:
- I use implicit to pass the range in CompletionProvider, since it's convenient and we also do this for root, flix etc.
- It would also be convenient to make range implicit for KeywordCompletion etc. But we dont do that for any completion. So I pass them manually.
- I also check that the range must not be empty. In the following case, we have an empty range and since "" is the prefix of any string, we get all the completions:
  <img width="725" alt="image" src="https://github.com/user-attachments/assets/ed9f198b-6c34-4532-a0e2-1587b070ffe9" />
