### PR TITLE
fix: update `java.net` package name for primitive effect annotations

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/phase/typer/PrimitiveEffects.Packages.json
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/PrimitiveEffects.Packages.json
@@ -1,8 +1,8 @@
 {
   "packages": {
     "java.lang.constant": "Sys, IO",
-    "java.lang.net": "Net, IO",
     "java.lang.ref": "Sys, IO",
+    "java.net": "Net, IO",
     "java.util.random": "NonDet, IO"
   }
 }


### PR DESCRIPTION
Related to https://github.com/flix/flix/issues/9523