### PR TITLE
refactor: unwrap AutoImportCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -70,7 +70,11 @@ object CompletionProvider {
             ModuleCompleter.getCompletions(err)
 
         case err: ResolutionError.UndefinedName =>
-          AutoImportCompleter.getCompletions(err) ++
+          val ap = err.ap
+          val env = err.env
+          val ident = err.qn.ident.name
+          val range = Range.from(err.loc)
+          AutoImportCompleter.getCompletions(ident, range, ap, env) ++
             LocalScopeCompleter.getCompletions(err) ++
             KeywordCompleter.getExprKeywords ++
             DefCompleter.getCompletions(err) ++
@@ -83,8 +87,12 @@ object CompletionProvider {
             ModuleCompleter.getCompletions(err)
 
         case err: ResolutionError.UndefinedType =>
+          val ap = err.ap
+          val env = err.env
+          val ident = err.qn.ident.name
+          val range = Range.from(err.loc)
           TypeBuiltinCompleter.getCompletions ++
-            AutoImportCompleter.getCompletions(err) ++
+            AutoImportCompleter.getCompletions(ident, range, ap, env) ++
             LocalScopeCompleter.getCompletions(err) ++
             EnumCompleter.getCompletions(err) ++
             StructCompleter.getCompletions(err) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -98,12 +98,12 @@ sealed trait Completion {
         }
       )
 
-    case Completion.AutoImportCompletion(name, path, ap, labelDetails , priority) =>
+    case Completion.AutoImportCompletion(name, path, range, ap, labelDetails , priority) =>
       CompletionItem(
         label               = name,
         labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(priority, name),
-        textEdit            = TextEdit(context.range, name),
+        textEdit            = TextEdit(range, name),
         insertTextFormat    = InsertTextFormat.PlainText,
         kind                = CompletionItemKind.Class,
         additionalTextEdits = List(Completion.mkTextEdit(ap, s"import $path"))
@@ -593,11 +593,12 @@ object Completion {
     *
     * @param name          the name to be completed under cursor.
     * @param qualifiedName the path of the java class we will auto-import.
+    * @param range         the range of the completion.
     * @param ap            the anchor position.
     * @param labelDetails  to show the namespace of class we are going to import
     * @param priority      the priority of the completion.
     */
-  case class AutoImportCompletion(name:String, qualifiedName: String, ap: AnchorPosition, labelDetails: CompletionItemLabelDetails, priority: Priority) extends Completion
+  case class AutoImportCompletion(name:String, qualifiedName: String, range: Range, ap: AnchorPosition, labelDetails: CompletionItemLabelDetails, priority: Priority) extends Completion
 
   /**
     * Represents a Snippet completion


### PR DESCRIPTION
We do two things at the same time for one Completer:
- change the signature to get the information it needs directly.
- accept range from the error 