### PR TITLE
refactor: unwrap ImportCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -93,7 +93,7 @@ object CompletionProvider {
             ModuleCompleter.getCompletions(err)
 
         case err: ResolutionError.UndefinedEffect => EffectCompleter.getCompletions(err)
-        case err: ResolutionError.UndefinedJvmImport => ImportCompleter.getCompletions(err)
+        case err: ResolutionError.UndefinedJvmImport => ImportCompleter.getCompletions(err.name, Range.from(err.loc))
         case err: ResolutionError.UndefinedJvmStaticField => GetStaticFieldCompleter.getCompletions(err) ++ InvokeStaticMethodCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedKind => KindCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedOp => OpCompleter.getCompletions(err)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -85,11 +85,11 @@ sealed trait Completion {
         kind             = CompletionItemKind.Enum
       )
 
-    case Completion.ImportCompletion(name, isPackage) =>
+    case Completion.ImportCompletion(name, range, isPackage) =>
       CompletionItem(
         label            = name,
         sortText         = Priority.toSortText(Priority.Highest, name),
-        textEdit         = TextEdit(context.range, name),
+        textEdit         = TextEdit(range, name),
         documentation    = None,
         insertTextFormat = InsertTextFormat.PlainText,
         kind             = {
@@ -584,9 +584,10 @@ object Completion {
     * Represents a package, class, or interface completion.
     *
     * @param name       the name to be completed.
+    * @param range      the range of the completion.
     * @param isPackage  whether the completion is a package.
     */
-  case class ImportCompletion(name: String, isPackage: Boolean) extends Completion
+  case class ImportCompletion(name: String, range: Range, isPackage: Boolean) extends Completion
 
   /**
     * Represents an auto-import completion.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ImportCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/ImportCompleter.scala
@@ -15,28 +15,34 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
+import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.ImportCompletion
 import ca.uwaterloo.flix.language.ast.TypedAst
-import ca.uwaterloo.flix.language.errors.ResolutionError
 
 object ImportCompleter {
 
-  def getCompletions(err: ResolutionError.UndefinedJvmImport)(implicit root: TypedAst.Root): Iterable[ImportCompletion] = {
-    val path = err.name.split('.').toList
+  /**
+    * Returns a list of completions.
+    *
+    * @param name  The whole name of the unresolved import. e.g. java.io.Fi
+    * @param range The range of the completion.
+    */
+  def getCompletions(name: String, range: Range)(implicit root: TypedAst.Root): Iterable[ImportCompletion] = {
+    val path = name.split('.').toList
     // Get completions for if we are currently typing the next package/class and if we have just finished typing a package
-    javaClassCompletionsFromPrefix(path)(root) ++ javaClassCompletionsFromPrefix(path.dropRight(1))(root)
+    javaClassCompletionsFromPrefix(path ,range)(root) ++ javaClassCompletionsFromPrefix(path.dropRight(1), range)(root)
   }
 
   /**
     * Gets completions from a java path prefix
     */
-  private def javaClassCompletionsFromPrefix(prefix: List[String])(implicit root: TypedAst.Root): Iterable[ImportCompletion] = {
+  private def javaClassCompletionsFromPrefix(prefix: List[String], range: Range)(implicit root: TypedAst.Root): Iterable[ImportCompletion] = {
     root.availableClasses.byPackage(prefix).map(clazz => {
       val label = prefix match {
         case Nil => clazz
         case v => v.mkString("", ".", s".$clazz")
       }
-      Completion.ImportCompletion(label, isPackage = clazz.head.isLower)
+      Completion.ImportCompletion(label, range, isPackage = clazz.head.isLower)
     })
   }
 }


### PR DESCRIPTION
We do two things at the same time for one Completer:

change the signature to get the information it needs directly.
accept range from the error