### PR TITLE
refactor: unwrap UseCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -62,7 +62,7 @@ object CompletionProvider {
       errorsAt(uri, pos, currentErrors).flatMap {
         case err: WeederError.UndefinedAnnotation => KeywordCompleter.getModKeywords
 
-        case err: WeederError.UnqualifiedUse => UseCompleter.getCompletions(uri, err)
+        case err: WeederError.UnqualifiedUse => UseCompleter.getCompletions(err.qn, Range.from(err.loc))
 
         case err: ResolutionError.UndefinedTag =>
           EnumCompleter.getCompletions(err) ++
@@ -99,7 +99,7 @@ object CompletionProvider {
         case err: ResolutionError.UndefinedOp => OpCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedStructField => StructFieldCompleter.getCompletions(err, root)
         case err: ResolutionError.UndefinedTrait => TraitCompleter.getCompletions(err)
-        case err: ResolutionError.UndefinedUse => UseCompleter.getCompletions(uri, err)
+        case err: ResolutionError.UndefinedUse => UseCompleter.getCompletions(err.qn, Range.from(err.loc))
 
         case err: TypeError.FieldNotFound => MagicMatchCompleter.getCompletions(err) ++ InvokeMethodCompleter.getCompletions(err.tpe, err.fieldName)
         case err: TypeError.MethodNotFound => InvokeMethodCompleter.getCompletions(err.tpe, err.methodName)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -437,11 +437,11 @@ sealed trait Completion {
         additionalTextEdits = additionalTextEdit
       )
 
-    case Completion.UseCompletion(name, kind) =>
+    case Completion.UseCompletion(name, range, kind) =>
       CompletionItem(
         label         = name,
         sortText      = name,
-        textEdit      = TextEdit(context.range, name),
+        textEdit      = TextEdit(range, name),
         documentation = None,
         kind          = kind
       )
@@ -777,9 +777,10 @@ object Completion {
     * Represents a Use completion.
     *
     * @param name               the name of the use completion.
+    * @param range              the range of the completion.
     * @param completionItemKind the kind of the completion.
     */
-  case class UseCompletion(name: String, completionItemKind: CompletionItemKind) extends Completion
+  case class UseCompletion(name: String, range: Range, completionItemKind: CompletionItemKind) extends Completion
 
   /**
    * Represents a struct field completion.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/UseCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/UseCompleter.scala
@@ -15,65 +15,56 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.api.lsp.CompletionItemKind
+import ca.uwaterloo.flix.api.lsp.{CompletionItemKind, Range}
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.UseCompletion
 import ca.uwaterloo.flix.api.lsp.provider.completion.CompletionUtils.fuzzyMatch
 import ca.uwaterloo.flix.language.ast.{Name, Symbol, TypedAst}
-import ca.uwaterloo.flix.language.errors.{ResolutionError, WeederError}
 
 object UseCompleter {
   /**
     * Returns a List of Completions for use clause.
     */
-  def getCompletions(uri: String, err: WeederError.UnqualifiedUse)(implicit root: TypedAst.Root): Iterable[Completion] = {
-      getCompletions(uri, err.qn)
-    }
-
-  def getCompletions(uri: String, err: ResolutionError.UndefinedUse)(implicit root: TypedAst.Root): Iterable[Completion] = {
-    getCompletions(uri, err.qn)
-  }
-
-  private def getCompletions(uri: String, qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] ={
+  def getCompletions(qn: Name.QName, range: Range)(implicit root: TypedAst.Root): Iterable[Completion] ={
     val namespace = qn.namespace.idents.map(_.name)
     val ident = qn.ident.name
     val moduleSym = Symbol.mkModuleSym(namespace)
     root.modules.get(moduleSym).collect{
-      case mod:  Symbol.ModuleSym if fuzzyMatch(ident, mod.ns.last) => UseCompletion(mod.toString, CompletionItemKind.Module)
-      case enm:  Symbol.EnumSym   if fuzzyMatch(ident, enm.name)  && CompletionUtils.isAvailable(enm)  => UseCompletion(enm.toString, CompletionItemKind.Enum)
-      case eff:  Symbol.EffectSym if fuzzyMatch(ident, eff.name)  && CompletionUtils.isAvailable(eff)  => UseCompletion(eff.toString, CompletionItemKind.Event)
-      case defn: Symbol.DefnSym   if fuzzyMatch(ident, defn.name) && CompletionUtils.isAvailable(defn) => UseCompletion(defn.toString, CompletionItemKind.Function)
-      case trt:  Symbol.TraitSym  if fuzzyMatch(ident, trt.name)  && CompletionUtils.isAvailable(trt)  => UseCompletion(trt.toString, CompletionItemKind.Interface)
-    } ++ getSigCompletions(uri, qn) ++ getOpCompletions(qn) ++ getTagCompletions(qn)
+      case mod:  Symbol.ModuleSym if fuzzyMatch(ident, mod.ns.last) => UseCompletion(mod.toString, range, CompletionItemKind.Module)
+      case enm:  Symbol.EnumSym   if fuzzyMatch(ident, enm.name)  && CompletionUtils.isAvailable(enm)  => UseCompletion(enm.toString, range, CompletionItemKind.Enum)
+      case eff:  Symbol.EffectSym if fuzzyMatch(ident, eff.name)  && CompletionUtils.isAvailable(eff)  => UseCompletion(eff.toString, range, CompletionItemKind.Event)
+      case defn: Symbol.DefnSym   if fuzzyMatch(ident, defn.name) && CompletionUtils.isAvailable(defn) => UseCompletion(defn.toString, range, CompletionItemKind.Function)
+      case trt:  Symbol.TraitSym  if fuzzyMatch(ident, trt.name)  && CompletionUtils.isAvailable(trt)  => UseCompletion(trt.toString, range, CompletionItemKind.Interface)
+    } ++ getSigCompletions(qn, range) ++ getOpCompletions(qn, range) ++ getTagCompletions(qn, range)
   }
 
   /**
     * Returns a List of Completion for signatures.
     */
-  private def getSigCompletions(uri: String, qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
+  private def getSigCompletions(qn: Name.QName, range: Range)(implicit root: TypedAst.Root): Iterable[Completion] = {
     val traitSym = Symbol.mkTraitSym(qn.namespace.toString)
     root.traits.get(traitSym).filter(CompletionUtils.isAvailable).map(_.sigs.collect {
-      case sig if fuzzyMatch(qn.ident.name, sig.sym.name) && (sig.spec.mod.isPublic || sig.sym.loc.source.name == uri) =>
-        UseCompletion(sig.sym.toString, CompletionItemKind.Method)
+      case sig if fuzzyMatch(qn.ident.name, sig.sym.name) && sig.spec.mod.isPublic =>
+        UseCompletion(sig.sym.toString, range, CompletionItemKind.Method)
     }).getOrElse(Nil)
   }
 
   /**
     * Returns a List of Completion for ops.
     */
-  private def getOpCompletions(qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
+  private def getOpCompletions(qn: Name.QName, range: Range)(implicit root: TypedAst.Root): Iterable[Completion] = {
     val effectSym = Symbol.mkEffectSym(qn.namespace.toString)
     root.effects.get(effectSym).filter(CompletionUtils.isAvailable).map(_.ops.collect {
-      case op if fuzzyMatch(qn.ident.name, op.sym.name) => UseCompletion(op.sym.toString, CompletionItemKind.Method)
+      case op if fuzzyMatch(qn.ident.name, op.sym.name) => UseCompletion(op.sym.toString, range, CompletionItemKind.Method)
     }).getOrElse(Nil)
   }
 
   /**
     * Returns a List of Completion for tags.
     */
-  private def getTagCompletions(qn: Name.QName)(implicit root: TypedAst.Root): Iterable[Completion] = {
+  private def getTagCompletions(qn: Name.QName, range: Range)(implicit root: TypedAst.Root): Iterable[Completion] = {
     val enumSym = Symbol.mkEnumSym(qn.namespace.toString)
     root.enums.get(enumSym).filter(CompletionUtils.isAvailable).map(_.cases.values.collect {
-      case tag if fuzzyMatch(qn.ident.name, tag.sym.name) => UseCompletion(tag.sym.toString, CompletionItemKind.EnumMember)
+      case tag if fuzzyMatch(qn.ident.name, tag.sym.name) => UseCompletion(tag.sym.toString, range, CompletionItemKind.EnumMember)
     }).getOrElse(Nil)
   }
 }


### PR DESCRIPTION
We do two things at the same time for one Completer:

change the signature to get the information it needs directly.
accept range from the error