### PR TITLE
refactor: unwrap KindCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -95,7 +95,7 @@ object CompletionProvider {
         case err: ResolutionError.UndefinedEffect => EffectCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedJvmImport => ImportCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedJvmStaticField => GetStaticFieldCompleter.getCompletions(err) ++ InvokeStaticMethodCompleter.getCompletions(err)
-        case err: ResolutionError.UndefinedKind => KindCompleter.getCompletions(err)
+        case err: ResolutionError.UndefinedKind => KindCompleter.getCompletions(err.qn.ident.name, Range.from(err.loc))
         case err: ResolutionError.UndefinedOp => OpCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedStructField => StructFieldCompleter.getCompletions(err, root)
         case err: ResolutionError.UndefinedTrait => TraitCompleter.getCompletions(err)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KindCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/KindCompleter.scala
@@ -15,14 +15,13 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.KindCompletion
 import ca.uwaterloo.flix.api.lsp.Range
-import ca.uwaterloo.flix.language.errors.ResolutionError
+import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.KindCompletion
 
 object KindCompleter {
-  def getCompletions(err: ResolutionError.UndefinedKind): List[Completion] = {
+  def getCompletions(name: String, range: Range): List[Completion] = {
     val kinds = List("Type", "Eff", "Bool")
     kinds.collect{
-      case kind if kind.startsWith(err.qn.ident.name) => KindCompletion(kind, Range.from(err.loc))}
+      case kind if kind.startsWith(name) => KindCompletion(kind, range)}
   }
 }


### PR DESCRIPTION
We do two things at the same time for one Completer:

change the signature to get the information it needs directly.
accept range from the error