### PR TITLE
refactor: unwrap InvokeStaticMethodCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -102,7 +102,7 @@ object CompletionProvider {
 
         case err: ResolutionError.UndefinedEffect => EffectCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedJvmImport => ImportCompleter.getCompletions(err.name, Range.from(err.loc))
-        case err: ResolutionError.UndefinedJvmStaticField => GetStaticFieldCompleter.getCompletions(err.clazz, err.field) ++ InvokeStaticMethodCompleter.getCompletions(err)
+        case err: ResolutionError.UndefinedJvmStaticField => GetStaticFieldCompleter.getCompletions(err.clazz, err.field) ++ InvokeStaticMethodCompleter.getCompletions(err.clazz, err.field)
         case err: ResolutionError.UndefinedKind => KindCompleter.getCompletions(err.qn.ident.name, Range.from(err.loc))
         case err: ResolutionError.UndefinedOp => OpCompleter.getCompletions(err)
         case err: ResolutionError.UndefinedStructField => StructFieldCompleter.getCompletions(err, root)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/semantic/InvokeStaticMethodCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/semantic/InvokeStaticMethodCompleter.scala
@@ -17,13 +17,13 @@ package ca.uwaterloo.flix.api.lsp.provider.completion.semantic
 
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.MethodCompletion
-import ca.uwaterloo.flix.language.errors.ResolutionError
+import ca.uwaterloo.flix.language.ast.Name
 import ca.uwaterloo.flix.util.JvmUtils
 
 object InvokeStaticMethodCompleter {
 
-  def getCompletions(e: ResolutionError.UndefinedJvmStaticField): List[Completion] = {
-    JvmUtils.getStaticMethods(e.clazz).sortBy(_.getName).map(MethodCompletion(e.field, _))
+  def getCompletions(clazz: Class[?], field: Name.Ident): List[Completion] = {
+    JvmUtils.getStaticMethods(clazz).sortBy(_.getName).map(MethodCompletion(field, _))
   }
 
 }


### PR DESCRIPTION
We do two things at the same time for one Completer:

change the signature to get the information it needs directly.
accept range from the error