### PR TITLE
fix: remove multi-line type token for handler

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -602,8 +602,7 @@ object SemanticTokensProvider {
         case (acc, HandlerRule(op, fparams, exp ,loc)) =>
           val st = SemanticToken(SemanticTokenType.Type, Nil, op.loc)
           val t1 = Iterator(st)
-          val t2 = visitFormalParams(fparams)
-          acc ++ t1 ++ t2 ++ visitExp(exp)
+          acc ++ t1 ++ visitExp(exp)
       }
       st1 ++ st2
 


### PR DESCRIPTION
fixes #10092
Now it looks like:
![image](https://github.com/user-attachments/assets/8135dde9-8480-4eab-b7e4-da7553d5e3e7)

As you can see, resume is not colored, since it's also included in the fparams:
![image](https://github.com/user-attachments/assets/818741df-eb6f-49d1-bf02-2f8336db4342)

So actually we just need to remove the first one, but what is the rule to filter out that? I am not completely sure about why it's there, the whole handler from 43-50 is treated as a fparam?