### PR TITLE
refactor: let KeywordCompleter use its own range

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Range.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Range.scala
@@ -17,10 +17,9 @@ package ca.uwaterloo.flix.api.lsp
 
 import ca.uwaterloo.flix.language.ast.SourceLocation
 import ca.uwaterloo.flix.util.Result
-
-import org.json4s.JsonDSL.*
-import org.json4s.*
 import org.eclipse.lsp4j
+import org.json4s.*
+import org.json4s.JsonDSL.*
 
 /**
   * Companion object of [[Range]].
@@ -73,6 +72,11 @@ case class Range(start: Position, end: Position) {
     */
   private def laterEnd(that: Range): Range =
     if (end > that.end) this else that
+
+  /**
+    * Returns the range that starts earlier and ends later.
+    */
+  def isEmpty: Boolean = start == end
 
   /**
     * Checks if this range overlaps with the other range.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -123,7 +123,9 @@ object CompletionProvider {
     */
   private def getSyntacticCompletions(uri: String, e: ParseError)(implicit root: Root, flix: Flix): List[Completion] = {
     val range: Range = Range.from(e.loc)
-    e.sctx match {
+    if (range.isEmpty)
+      Nil
+    else e.sctx match {
       // Expressions.
       case SyntacticContext.Expr.Constraint => (PredicateCompleter.getCompletions(uri, range) ++ KeywordCompleter.getConstraintKeywords(range)).toList
       case SyntacticContext.Expr.OtherExpr => KeywordCompleter.getExprKeywords(range)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -32,19 +32,19 @@ sealed trait Completion {
     */
   def toCompletionItem(context: CompletionContext)(implicit flix: Flix): CompletionItem = this match {
 
-    case Completion.KeywordCompletion(name, priority) =>
+    case Completion.KeywordCompletion(name, range, priority) =>
       CompletionItem(
         label    = name,
         sortText = Priority.toSortText(priority, name),
-        textEdit = TextEdit(context.range, s"$name "),
+        textEdit = TextEdit(range, s"$name "),
         kind     = CompletionItemKind.Keyword
       )
 
-    case Completion.KeywordLiteralCompletion(name, priority) =>
+    case Completion.KeywordLiteralCompletion(name, range, priority) =>
       CompletionItem(
         label            = name,
         sortText         = Priority.toSortText(priority, name),
-        textEdit         = TextEdit(context.range, name),
+        textEdit         = TextEdit(range, name),
         insertTextFormat = InsertTextFormat.PlainText,
         kind             = CompletionItemKind.Keyword
       )
@@ -521,9 +521,10 @@ object Completion {
     * Represents a keyword completion.
     *
     * @param name      the name of the keyword.
+    * @param range     the range of the completion.
     * @param priority  the completion priority of the keyword.
     */
-  case class KeywordCompletion(name: String, priority: Priority) extends Completion
+  case class KeywordCompletion(name: String, range: Range, priority: Priority) extends Completion
 
   /**
     * Represents a keyword literal completion (i.e. `true`).
@@ -543,9 +544,10 @@ object Completion {
     * `f(fal)`  --->    `f(false˽)`
     *
     * @param literal   the literal keyword text.
+    * @param range     the range of the completion.
     * @param priority  the priority of the keyword.
     */
-  case class KeywordLiteralCompletion(literal: String, priority: Priority) extends Completion
+  case class KeywordLiteralCompletion(literal: String, range: Range, priority: Priority) extends Completion
 
   /**
     * Represents a completion for a kind.

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/syntactic/KeywordCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/syntactic/KeywordCompleter.scala
@@ -28,9 +28,9 @@ object KeywordCompleter {
     */
   def getConstraintKeywords(range: Range): List[Completion] =
     List(
-      Completion.KeywordCompletion("fix", Priority.Default),
-      Completion.KeywordCompletion("if" , Priority.Default),
-      Completion.KeywordCompletion("not", Priority.Default),
+      Completion.KeywordCompletion("fix", range, Priority.Default),
+      Completion.KeywordCompletion("if" , range, Priority.Default),
+      Completion.KeywordCompletion("not", range, Priority.Default),
     )
 
   /**
@@ -39,34 +39,34 @@ object KeywordCompleter {
   def getModKeywords(range: Range): List[Completion] =
     List(
       // D
-      Completion.KeywordCompletion("@Deprecated"      , Priority.Low),
-      Completion.KeywordCompletion("def"              , Priority.High),
+      Completion.KeywordCompletion("@Deprecated"      , range, Priority.Low),
+      Completion.KeywordCompletion("def"              , range, Priority.High),
       // E
-      Completion.KeywordCompletion("eff"              , Priority.Low),
-      Completion.KeywordCompletion("enum"             , Priority.High),
+      Completion.KeywordCompletion("eff"              , range, Priority.Low),
+      Completion.KeywordCompletion("enum"             , range, Priority.High),
       // I
-      Completion.KeywordCompletion("import"           , Priority.Low),
-      Completion.KeywordCompletion("instance"         , Priority.High),
+      Completion.KeywordCompletion("import"           , range, Priority.Low),
+      Completion.KeywordCompletion("instance"         , range, Priority.High),
       // L
-      Completion.KeywordCompletion("@Lazy"            , Priority.High),
-      Completion.KeywordCompletion("@LazyWhenPure"    , Priority.Low),
+      Completion.KeywordCompletion("@Lazy"            , range, Priority.High),
+      Completion.KeywordCompletion("@LazyWhenPure"    , range, Priority.Low),
       // M
-      Completion.KeywordCompletion("mod"              , Priority.Default),
+      Completion.KeywordCompletion("mod"              , range, Priority.Default),
       // P
-      Completion.KeywordCompletion("@Parallel"        , Priority.Low),
-      Completion.KeywordCompletion("@ParallelWhenPure", Priority.Lower),
-      Completion.KeywordCompletion("pub"              , Priority.High),
+      Completion.KeywordCompletion("@Parallel"        , range, Priority.Low),
+      Completion.KeywordCompletion("@ParallelWhenPure", range, Priority.Lower),
+      Completion.KeywordCompletion("pub"              , range, Priority.High),
       // S
-      Completion.KeywordCompletion("sealed"           , Priority.Low),
-      Completion.KeywordCompletion("struct"           , Priority.High),
+      Completion.KeywordCompletion("sealed"           , range, Priority.Low),
+      Completion.KeywordCompletion("struct"           , range, Priority.High),
       // T
-      Completion.KeywordCompletion("@Test"            , Priority.Low),
-      Completion.KeywordCompletion("trait"            , Priority.High),
-      Completion.KeywordCompletion("type"             , Priority.Higher),
+      Completion.KeywordCompletion("@Test"            , range, Priority.Low),
+      Completion.KeywordCompletion("trait"            , range, Priority.High),
+      Completion.KeywordCompletion("type"             , range, Priority.Higher),
       // U
-      Completion.KeywordCompletion("use"              , Priority.Default),
+      Completion.KeywordCompletion("use"              , range, Priority.Default),
       // W
-      Completion.KeywordCompletion("with"             , Priority.Default),
+      Completion.KeywordCompletion("with"             , range, Priority.Default),
     )
 
   /**
@@ -74,7 +74,7 @@ object KeywordCompleter {
     */
   def getEnumKeywords(range: Range): List[Completion] =
     List(
-      Completion.KeywordCompletion("case", Priority.Default)
+      Completion.KeywordCompletion("case", range, Priority.Default)
     )
 
   /**
@@ -82,7 +82,7 @@ object KeywordCompleter {
     */
   def getEffectKeywords(range: Range): List[Completion] =
     List(
-      Completion.KeywordCompletion("def", Priority.Default)
+      Completion.KeywordCompletion("def", range, Priority.Default)
     )
 
   /**
@@ -91,64 +91,64 @@ object KeywordCompleter {
   def getExprKeywords(range: Range): List[Completion] =
     List(
       // A
-      Completion.KeywordCompletion("and"         , Priority.Default),
+      Completion.KeywordCompletion("and"         , range, Priority.Default),
       // C
-      Completion.KeywordCompletion("catch"       , Priority.Default),
+      Completion.KeywordCompletion("catch"       , range, Priority.Default),
       // D
-      Completion.KeywordCompletion("def"         , Priority.Higher),
-      Completion.KeywordCompletion("discard"     , Priority.Low),
-      Completion.KeywordCompletion("do"          , Priority.High),
+      Completion.KeywordCompletion("def"         , range, Priority.Higher),
+      Completion.KeywordCompletion("discard"     , range, Priority.Low),
+      Completion.KeywordCompletion("do"          , range, Priority.High),
       // E
-      Completion.KeywordCompletion("else"        , Priority.Default),
+      Completion.KeywordCompletion("else"        , range, Priority.Default),
       // F
-      Completion.KeywordLiteralCompletion("false", Priority.Higher),
-      Completion.KeywordCompletion("forA"        , Priority.Lowest),
-      Completion.KeywordCompletion("forM"        , Priority.Low),
-      Completion.KeywordCompletion("force"       , Priority.High),
-      Completion.KeywordCompletion("foreach"     , Priority.Lower),
-      Completion.KeywordCompletion("from"        , Priority.Highest),
+      Completion.KeywordLiteralCompletion("false", range, Priority.Higher),
+      Completion.KeywordCompletion("forA"        , range, Priority.Lowest),
+      Completion.KeywordCompletion("forM"        , range, Priority.Low),
+      Completion.KeywordCompletion("force"       , range, Priority.High),
+      Completion.KeywordCompletion("foreach"     , range, Priority.Lower),
+      Completion.KeywordCompletion("from"        , range, Priority.Highest),
       // H
-      Completion.KeywordCompletion("handler", Priority.Default),
+      Completion.KeywordCompletion("handler"     , range, Priority.Default),
       // I
-      Completion.KeywordCompletion("if"          , Priority.Higher),
-      Completion.KeywordCompletion("inject"      , Priority.Low),
-      Completion.KeywordCompletion("instanceof"  , Priority.Lowest),
-      Completion.KeywordCompletion("into"        , Priority.High),
+      Completion.KeywordCompletion("if"          , range, Priority.Higher),
+      Completion.KeywordCompletion("inject"      , range, Priority.Low),
+      Completion.KeywordCompletion("instanceof"  , range, Priority.Lowest),
+      Completion.KeywordCompletion("into"        , range, Priority.High),
       // L
-      Completion.KeywordCompletion("lazy"        , Priority.Low),
-      Completion.KeywordCompletion("let"         , Priority.High),
+      Completion.KeywordCompletion("lazy"        , range, Priority.Low),
+      Completion.KeywordCompletion("let"         , range, Priority.High),
       // M
-      Completion.KeywordCompletion("match"       , Priority.Default),
+      Completion.KeywordCompletion("match"       , range, Priority.Default),
       // N
-      Completion.KeywordCompletion("new"         , Priority.Low),
-      Completion.KeywordCompletion("not"         , Priority.High),
-      Completion.KeywordLiteralCompletion("null" , Priority.Lower),
+      Completion.KeywordCompletion("new"         , range, Priority.Low),
+      Completion.KeywordCompletion("not"         , range, Priority.High),
+      Completion.KeywordLiteralCompletion("null" , range, Priority.Lower),
       // O
-      Completion.KeywordCompletion("or"          , Priority.Default),
+      Completion.KeywordCompletion("or"          , range, Priority.Default),
       // P
-      Completion.KeywordCompletion("par"         , Priority.Low),
-      Completion.KeywordCompletion("project"     , Priority.High),
+      Completion.KeywordCompletion("par"         , range, Priority.Low),
+      Completion.KeywordCompletion("project"     , range, Priority.High),
       // Q
-      Completion.KeywordCompletion("query"       , Priority.Default),
+      Completion.KeywordCompletion("query"       , range, Priority.Default),
       // R
-      Completion.KeywordCompletion("region"      , Priority.Default),
+      Completion.KeywordCompletion("region"      , range, Priority.Default),
       // S
-      Completion.KeywordCompletion("select"      , Priority.Higher),
-      Completion.KeywordCompletion("solve"       , Priority.High),
-      Completion.KeywordCompletion("spawn"       , Priority.Low),
+      Completion.KeywordCompletion("select"      , range, Priority.Higher),
+      Completion.KeywordCompletion("solve"       , range, Priority.High),
+      Completion.KeywordCompletion("spawn"       , range, Priority.Low),
       // T
-      Completion.KeywordCompletion("throw"       , Priority.Lowest),
-      Completion.KeywordLiteralCompletion("true" , Priority.Higher),
-      Completion.KeywordCompletion("try"         , Priority.High),
-      Completion.KeywordCompletion("typematch"   , Priority.Low),
+      Completion.KeywordCompletion("throw"       , range, Priority.Lowest),
+      Completion.KeywordLiteralCompletion("true" , range, Priority.Higher),
+      Completion.KeywordCompletion("try"         , range, Priority.High),
+      Completion.KeywordCompletion("typematch"   , range, Priority.Low),
       // U
-      Completion.KeywordCompletion("unsafe"      , Priority.Low),
-      Completion.KeywordCompletion("use"         , Priority.High),
+      Completion.KeywordCompletion("unsafe"      , range, Priority.Low),
+      Completion.KeywordCompletion("use"         , range, Priority.High),
       // W
-      Completion.KeywordCompletion("with"        , Priority.Default),
-      Completion.KeywordCompletion("without"     , Priority.Default),
+      Completion.KeywordCompletion("with"        , range, Priority.Default),
+      Completion.KeywordCompletion("without"     , range, Priority.Default),
       // Y
-      Completion.KeywordCompletion("yield"       , Priority.Default)
+      Completion.KeywordCompletion("yield"       , range, Priority.Default)
     )
 
   /**
@@ -156,9 +156,9 @@ object KeywordCompleter {
     */
   def getInstanceKeywords(range: Range): List[Completion] =
     List(
-      Completion.KeywordCompletion("def"  , Priority.Default),
-      Completion.KeywordCompletion("pub"  , Priority.Default),
-      Completion.KeywordCompletion("redef", Priority.Default),
+      Completion.KeywordCompletion("def"  , range, Priority.Default),
+      Completion.KeywordCompletion("pub"  , range, Priority.Default),
+      Completion.KeywordCompletion("redef", range, Priority.Default),
     )
 
   /**
@@ -166,7 +166,7 @@ object KeywordCompleter {
     */
   def getStructKeywords(range: Range): List[Completion] =
     List(
-      Completion.KeywordCompletion("mut", Priority.Default)
+      Completion.KeywordCompletion("mut", range, Priority.Default)
     )
 
   /**
@@ -174,8 +174,8 @@ object KeywordCompleter {
     */
   def getTraitKeywords(range: Range): List[Completion] =
     List(
-      Completion.KeywordCompletion("def", Priority.Default),
-      Completion.KeywordCompletion("pub", Priority.Default),
+      Completion.KeywordCompletion("def", range, Priority.Default),
+      Completion.KeywordCompletion("pub", range, Priority.Default),
     )
 
   /**
@@ -184,7 +184,7 @@ object KeywordCompleter {
     */
   def getTypeKeywords(range: Range): List[Completion] =
     List(
-      Completion.KeywordCompletion("alias", Priority.Default)
+      Completion.KeywordCompletion("alias", range, Priority.Default)
     )
 
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0940eec7-8c82-43c3-9e77-bc1d47856dcc)
![image](https://github.com/user-attachments/assets/af02eccd-d667-458e-9256-533a57376cb4)
![image](https://github.com/user-attachments/assets/1afd1fa4-9809-4a98-904d-1f4e5504ef4f)
![image](https://github.com/user-attachments/assets/db8f3b9c-1097-4abb-b4b0-ea821e57e182)
![image](https://github.com/user-attachments/assets/988e2c37-3cf9-4eaa-8b36-4a3ad9b99ed8)


In the enum case, we have two errors, so the completion is now duplicated.

The first is from the failure of parsing a decl when meeting enu.

After that the parser leave the enu as is and the module will try to parse it again and emit another other.
![image](https://github.com/user-attachments/assets/6e620d69-db70-402b-9775-9c6ece196d4e)
