### PR TITLE
feat: EnumTagCompleter now supports snippet

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -212,6 +212,7 @@ sealed trait Completion {
         sortText            = Priority.toSortText(priority, qualifiedName),
         filterText          = Some(CompletionUtils.getFilterTextForName(qualifiedName)),
         textEdit            = TextEdit(range, snippet),
+        insertTextFormat    = InsertTextFormat.Snippet,
         documentation       = Some(enm.doc.text),
         kind                = CompletionItemKind.Enum,
         additionalTextEdits = additionalTextEdit
@@ -404,6 +405,8 @@ sealed trait Completion {
       else
         tag.sym.toString
       val name = if (qualified) qualifiedName else tag.sym.name
+      val snippet = name + CompletionUtils.formatTypesSnippet(tag.tpes)
+      val label = name + CompletionUtils.formatTypes(tag.tpes)
       val description = if(!qualified) {
         Some(if (inScope) qualifiedName else s"use $qualifiedName")
       } else None
@@ -411,10 +414,11 @@ sealed trait Completion {
       val additionalTextEdit = if (inScope) Nil else List(Completion.mkTextEdit(ap, s"use $qualifiedName"))
       val priority: Priority = if (inScope) Priority.High else Priority.Lower
       CompletionItem(
-        label               = name,
+        label               = label,
         labelDetails        = Some(labelDetails),
         sortText            = Priority.toSortText(priority, name),
-        textEdit            = TextEdit(context.range, name),
+        textEdit            = TextEdit(context.range, snippet),
+        insertTextFormat    = InsertTextFormat.Snippet,
         kind                = CompletionItemKind.EnumMember,
         additionalTextEdits = additionalTextEdit
       )

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/CompletionUtils.scala
@@ -192,6 +192,16 @@ object CompletionUtils {
   }
 
   /**
+    * Format types in the right form to be displayed in the list of completions
+    * e.g. "(Int32, String)"
+    */
+  def formatTypes(tpes: List[Type]): String =
+    tpes match {
+      case Nil => ""
+      case _ => tpes.map(_.toString).mkString("(", ", ", ")")
+    }
+
+  /**
     * Format type params in the right form to be inserted as a snippet
     * e.g. "[${1:a}, ${2:b}, ${3:c}]"
     */
@@ -203,6 +213,18 @@ object CompletionUtils {
       }.mkString("[", ", ", "]")
     }
   }
+
+  /**
+    * Format types in the right form to be inserted as a snippet
+    * e.g. "(${1:Int32}, ${2:String})"
+    */
+  def formatTypesSnippet(tpes: List[Type]): String =
+    tpes match {
+      case Nil => ""
+      case _ => tpes.zipWithIndex.map {
+        case (tpe, idx) => "$" + s"{${idx + 1}:?$tpe}"
+      }.mkString("(", ", ", ")")
+    }
 
 
   /**


### PR DESCRIPTION
Preview:
<img width="416" alt="image" src="https://github.com/user-attachments/assets/ab8cb6fe-9700-4c87-a8ff-721de6b40857" />
<img width="495" alt="image" src="https://github.com/user-attachments/assets/1f8f353e-d45f-4186-bad5-33a348d60003" />

But there is a problem in displaying the type parameter:
<img width="439" alt="image" src="https://github.com/user-attachments/assets/ac70804a-897d-4beb-a555-bcebca6a5ec5" />
<img width="597" alt="image" src="https://github.com/user-attachments/assets/75e3579c-61bf-4b1b-b43b-11a1ce5f7037" />
Ideally they should be replace by a or String. But how could we achieve that?