### PR TITLE
refactor: unwrap LocalScopeCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/CompletionProvider.scala
@@ -80,7 +80,7 @@ object CompletionProvider {
           val qn = err.qn
           val range = Range.from(err.loc)
           AutoImportCompleter.getCompletions(ident, range, ap, env) ++
-            LocalScopeCompleter.getCompletions(err) ++
+            LocalScopeCompleter.getCompletionsExpr(range, env) ++
             KeywordCompleter.getExprKeywords(range) ++
             DefCompleter.getCompletions(qn, range, ap, env) ++
             EnumCompleter.getCompletions(qn, range, ap, env, withTypeParameters = false) ++
@@ -99,7 +99,7 @@ object CompletionProvider {
           val range = Range.from(err.loc)
           TypeBuiltinCompleter.getCompletions ++
             AutoImportCompleter.getCompletions(ident, range, ap, env) ++
-            LocalScopeCompleter.getCompletions(err) ++
+            LocalScopeCompleter.getCompletionsType(range, env) ++
             EnumCompleter.getCompletions(qn, range, ap, env, withTypeParameters = true) ++
             StructCompleter.getCompletions(qn, range, ap, env) ++
             EffectCompleter.getCompletions(qn, range, ap, env, inHandler = false) ++

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/Completion.scala
@@ -129,39 +129,31 @@ sealed trait Completion {
         kind             = CompletionItemKind.Snippet
       )
 
-    case Completion.LocalVarCompletion(name) =>
+    case Completion.LocalVarCompletion(name, range) =>
       CompletionItem(
         label    = name,
         sortText = Priority.toSortText(Priority.High, name),
-        textEdit = TextEdit(context.range, name),
+        textEdit = TextEdit(range, name),
         kind     = CompletionItemKind.Variable
       )
 
-    case Completion.LocalDeclarationCompletion(name) =>
-        CompletionItem(
-          label    = name,
-          sortText = Priority.toSortText(Priority.High, name),
-          textEdit = TextEdit(context.range, name),
-          kind     = CompletionItemKind.Enum
-        )
-
-    case Completion.LocalJavaClassCompletion(name, clazz) =>
+    case Completion.LocalJavaClassCompletion(name, clazz, range) =>
       val description = Option(clazz.getCanonicalName)
       val labelDetails = CompletionItemLabelDetails(None, description)
       CompletionItem(
         label         = name,
         labelDetails  = Some(labelDetails),
         sortText      = Priority.toSortText(Priority.High, name),
-        textEdit      = TextEdit(context.range, name),
+        textEdit      = TextEdit(range, name),
         kind          = CompletionItemKind.Class
       )
 
-    case Completion.LocalDefCompletion(sym, fparams) =>
+    case Completion.LocalDefCompletion(sym, fparams, range) =>
       val snippet = sym.text + fparams.zipWithIndex.map{ case (fparam, idx) => s"$${${idx + 1}:${fparam.sym.text}}" }.mkString("(", ", ", ")")
       CompletionItem(
         label    = sym.text,
         sortText = Priority.toSortText(Priority.High, sym.text),
-        textEdit = TextEdit(context.range, snippet),
+        textEdit = TextEdit(range, snippet),
         insertTextFormat = InsertTextFormat.Snippet,
         kind     = CompletionItemKind.Function
       )
@@ -645,31 +637,27 @@ object Completion {
     * Represents a Var completion
     *
     * @param name the name of the variable to complete.
+    * @param range the range of the completion.
     */
-  case class LocalVarCompletion(name: String) extends Completion
-
-  /**
-    * Represents a Declaration completion
-    *
-    * @param name the name of the declaration to complete.
-    */
-  case class LocalDeclarationCompletion(name: String) extends Completion
+  case class LocalVarCompletion(name: String, range: Range) extends Completion
 
   /**
     * Represents a Java Class completion
     *
     * @param name  the name of the java class to complete.
     * @param clazz the java class to complete.
+    * @param range the range of the completion.
     */
-  case class LocalJavaClassCompletion(name: String, clazz: Class[?]) extends Completion
+  case class LocalJavaClassCompletion(name: String, clazz: Class[?], range: Range) extends Completion
 
   /**
     * Represents a local def completion
     *
     * @param sym     the symbol of the local function
     * @param fparams the formal parameters of the local function
+    * @param range   the range of the completion.
     */
-  case class LocalDefCompletion(sym: Symbol.VarSym, fparams: List[ResolvedAst.FormalParam]) extends Completion
+  case class LocalDefCompletion(sym: Symbol.VarSym, fparams: List[ResolvedAst.FormalParam], range: Range) extends Completion
 
   /**
     * Represents a Def completion

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/LocalScopeCompleter.scala
@@ -15,9 +15,8 @@
  */
 package ca.uwaterloo.flix.api.lsp.provider.completion
 
-import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.{AssocTypeDef, AssocTypeSig, StructField}
-import ca.uwaterloo.flix.language.ast.shared.Resolution
-import ca.uwaterloo.flix.language.errors.ResolutionError
+import ca.uwaterloo.flix.api.lsp.Range
+import ca.uwaterloo.flix.language.ast.shared.{LocalScope, Resolution}
 
 /**
   * Provides completions for items in local scope, including:
@@ -31,61 +30,43 @@ object LocalScopeCompleter {
     * Returns a list of completions for UndefinedName.
     * We will provide all sorts of completions except for Resolution.TypeVar
     */
-  def getCompletions(err: ResolutionError.UndefinedName): Iterable[Completion] =
-   err.env.env.m.foldLeft(List.empty[Completion]){case (acc, (name, resolutions)) =>
-      acc ++ mkDeclarationCompletionForExpr(name, resolutions) ++ mkJavaClassCompletion(name, resolutions) ++
-        mkVarCompletion(name, resolutions) ++ mkLocalDefCompletion(resolutions)
+  def getCompletionsExpr(range: Range, env: LocalScope): Iterable[Completion] =
+   env.env.m.foldLeft(List.empty[Completion]){case (acc, (name, resolutions)) =>
+      acc ++ mkJavaClassCompletion(name, resolutions, range) ++ mkVarCompletion(name, resolutions, range) ++ mkLocalDefCompletion(resolutions, range)
    }
 
   /**
     * Returns a list of completions for UndefinedType.
     * We will provide completions for Resolution.Declaration and Resolution.JavaClass
     */
-  def getCompletions(err: ResolutionError.UndefinedType): Iterable[Completion] =
-    err.env.env.m.foldLeft(List.empty[Completion]){case (acc, (name, resolutions)) =>
-       acc ++ mkDeclarationCompletionForType(name, resolutions) ++ mkJavaClassCompletion(name, resolutions)
-    }
-
-  /**
-    * Tries to create a DeclarationCompletion for the given name and resolutions. the returned Completion should fit in an expression context.
-    */
-  private def mkDeclarationCompletionForExpr(k: String, v: List[Resolution]): Iterable[Completion] =
-    v.collect {
-      case Resolution.Declaration(StructField(_, _, _, _)) => Completion.LocalDeclarationCompletion(k)
-    }
-
-  /**
-    * Tries to create a DeclarationCompletion for the given name and resolutions, the returned Completion should fit in a type context.
-    */
-  private def mkDeclarationCompletionForType(k: String, v: List[Resolution]): Iterable[Completion] =
-    v.collect {
-      case Resolution.Declaration(AssocTypeSig(_, _, _, _, _, _, _)) |
-           Resolution.Declaration(AssocTypeDef(_, _, _, _, _, _)) => Completion.LocalDeclarationCompletion(k)
+  def getCompletionsType(range: Range, env: LocalScope): Iterable[Completion] =
+    env.env.m.foldLeft(List.empty[Completion]){case (acc, (name, resolutions)) =>
+       acc ++ mkJavaClassCompletion(name, resolutions, range)
     }
 
   /**
     * Tries to create a JavaClassCompletion for the given name and resolutions.
     */
-  private def mkJavaClassCompletion(name: String, resolutions: List[Resolution]): Iterable[Completion] = {
+  private def mkJavaClassCompletion(name: String, resolutions: List[Resolution], range: Range): Iterable[Completion] = {
     resolutions.collect {
-      case Resolution.JavaClass(clazz) => Completion.LocalJavaClassCompletion(name, clazz)
+      case Resolution.JavaClass(clazz) => Completion.LocalJavaClassCompletion(name, clazz, range)
     }
   }
 
   /**
     * Tries to create a VarCompletion for the given name and resolutions.
     */
-  private def mkVarCompletion(name: String, resolutions: List[Resolution]): Iterable[Completion] = {
+  private def mkVarCompletion(name: String, resolutions: List[Resolution], range: Range): Iterable[Completion] = {
     if (resolutions.exists{
       case Resolution.Var(_) => true
       case _ => false
-    }) Completion.LocalVarCompletion(name) :: Nil else Nil
+    }) Completion.LocalVarCompletion(name, range) :: Nil else Nil
   }
 
   /**
     * Tries to create a LocalDefCompletion for the given name and resolutions.
     */
-  private def mkLocalDefCompletion(resolutions: List[Resolution]): Iterable[Completion] =
-    resolutions.collect{ case Resolution.LocalDef(sym, fparams) => (sym, fparams)}.map(Completion.LocalDefCompletion.tupled)
+  private def mkLocalDefCompletion(resolutions: List[Resolution], range: Range): Iterable[Completion] =
+    resolutions.collect{ case Resolution.LocalDef(sym, fparams) => Completion.LocalDefCompletion(sym, fparams, range)}
 
 }


### PR DESCRIPTION
I also remove the support of localscope completion for structfield, assoctype, assoceff.

Relative discussion in #9773. But it's been hanging there for quite a while. 

I think it's safe to remove these either impossible or uncommon cases.

I preserve two entry points: Expr one and Type one