### PR TITLE
test: remove fuzzing sources after each test

### DIFF
--- a/main/test/flix/fuzzers/FuzzDeleteLines.scala
+++ b/main/test/flix/fuzzers/FuzzDeleteLines.scala
@@ -65,8 +65,10 @@ class FuzzDeleteLines extends AnyFunSuite with TestUtils {
       val iStepped = Math.min(i * step, numLines)
       val (before, after) = lines.splitAt(iStepped)
       val src = (before ::: after.drop(1)).mkString("\n")
-      flix.addSourceCode(s"$name-delete-line-$i", src)(SecurityContext.AllPermissions)
+      val sourceName = s"$name-delete-line-$i"
+      flix.addSourceCode(sourceName, src)(SecurityContext.AllPermissions)
       flix.compile() // We simply care that this does not crash.
+      flix.remSourceCode(sourceName)
     }
   }
 

--- a/main/test/flix/fuzzers/FuzzDeleteLines.scala
+++ b/main/test/flix/fuzzers/FuzzDeleteLines.scala
@@ -33,19 +33,19 @@ class FuzzDeleteLines extends AnyFunSuite with TestUtils {
   test("simple-card-game") {
     val filepath = Paths.get("examples/larger-examples/simple-card-game.flix")
     val lines = Files.lines(filepath)
-    compileAllLinesExceptOne(filepath.getFileName.toString, lines)
+    compileAllLinesExceptOne(lines)
   }
 
   test("the-ast-typing-problem-with-polymorphic-records") {
     val filepath = Paths.get("examples/records/the-ast-typing-problem-with-polymorphic-records.flix")
     val lines = Files.lines(filepath)
-    compileAllLinesExceptOne(filepath.getFileName.toString, lines)
+    compileAllLinesExceptOne(lines)
   }
 
   test("ford-fulkerson") {
     val filepath = Paths.get("examples/larger-examples/datalog/ford-fulkerson.flix")
     val lines = Files.lines(filepath)
-    compileAllLinesExceptOne(filepath.getFileName.toString, lines)
+    compileAllLinesExceptOne(lines)
   }
 
   /**
@@ -53,7 +53,7 @@ class FuzzDeleteLines extends AnyFunSuite with TestUtils {
     * For example, in a file with 100 lines and N = 10 we make variants without line 1, 10, 20, and so on.
     * The program may not be valid: We just care that it does not crash the compiler.
     */
-  private def compileAllLinesExceptOne(name: String, stream: java.util.stream.Stream[String]): Unit = {
+  private def compileAllLinesExceptOne(stream: java.util.stream.Stream[String]): Unit = {
     val lines = stream.iterator().asScala.toList
     val numLines = lines.length
     val NFixed = N.min(numLines)
@@ -65,10 +65,9 @@ class FuzzDeleteLines extends AnyFunSuite with TestUtils {
       val iStepped = Math.min(i * step, numLines)
       val (before, after) = lines.splitAt(iStepped)
       val src = (before ::: after.drop(1)).mkString("\n")
-      val sourceName = s"$name-delete-line-$i"
-      flix.addSourceCode(sourceName, src)(SecurityContext.AllPermissions)
+      // We use the same name for all inputs to simulate editing a file
+      flix.addSourceCode("<input>", src)(SecurityContext.AllPermissions)
       flix.compile() // We simply care that this does not crash.
-      flix.remSourceCode(sourceName)
     }
   }
 

--- a/main/test/flix/fuzzers/FuzzDuplicateLines.scala
+++ b/main/test/flix/fuzzers/FuzzDuplicateLines.scala
@@ -33,26 +33,26 @@ class FuzzDuplicateLines extends AnyFunSuite with TestUtils {
   test("simple-card-game") {
     val filepath = Paths.get("examples/larger-examples/simple-card-game.flix")
     val lines = Files.lines(filepath)
-    compileWithDuplicateLine(filepath.getFileName.toString, lines)
+    compileWithDuplicateLine(lines)
   }
 
   test("the-ast-typing-problem-with-polymorphic-records") {
     val filepath = Paths.get("examples/records/the-ast-typing-problem-with-polymorphic-records.flix")
     val lines = Files.lines(filepath)
-    compileWithDuplicateLine(filepath.getFileName.toString, lines)
+    compileWithDuplicateLine(lines)
   }
 
   test("ford-fulkerson") {
     val filepath = Paths.get("examples/larger-examples/datalog/ford-fulkerson.flix")
     val lines = Files.lines(filepath)
-    compileWithDuplicateLine(filepath.getFileName.toString, lines)
+    compileWithDuplicateLine(lines)
   }
 
   /**
     * Compile N variants of the given program with a single line duplicated.
     * The program may not be valid: We just care that it does not crash the compiler.
     */
-  private def compileWithDuplicateLine(name: String, stream: java.util.stream.Stream[String]): Unit = {
+  private def compileWithDuplicateLine(stream: java.util.stream.Stream[String]): Unit = {
     val lines = stream.iterator().asScala.toList
     val numLines = lines.length
     val NFixed = N.min(numLines)
@@ -64,10 +64,9 @@ class FuzzDuplicateLines extends AnyFunSuite with TestUtils {
       val iStepped = Math.min(i * step, numLines)
       val (before, after) = lines.splitAt(iStepped)
       val src = (before ::: after.head :: after).mkString("\n")
-      val sourceName = s"$name-duplicate-line-$iStepped"
-      flix.addSourceCode(sourceName, src)(SecurityContext.AllPermissions)
+      // We use the same name for all inputs to simulate editing a file
+      flix.addSourceCode("<input>", src)(SecurityContext.AllPermissions)
       flix.compile() // We simply care that this does not crash.
-      flix.remSourceCode(sourceName)
     }
   }
 

--- a/main/test/flix/fuzzers/FuzzDuplicateLines.scala
+++ b/main/test/flix/fuzzers/FuzzDuplicateLines.scala
@@ -64,8 +64,10 @@ class FuzzDuplicateLines extends AnyFunSuite with TestUtils {
       val iStepped = Math.min(i * step, numLines)
       val (before, after) = lines.splitAt(iStepped)
       val src = (before ::: after.head :: after).mkString("\n")
-      flix.addSourceCode(s"$name-duplicate-line-$iStepped", src)(SecurityContext.AllPermissions)
+      val sourceName = s"$name-duplicate-line-$iStepped"
+      flix.addSourceCode(sourceName, src)(SecurityContext.AllPermissions)
       flix.compile() // We simply care that this does not crash.
+      flix.remSourceCode(sourceName)
     }
   }
 

--- a/main/test/flix/fuzzers/FuzzPrefixes.scala
+++ b/main/test/flix/fuzzers/FuzzPrefixes.scala
@@ -32,19 +32,19 @@ class FuzzPrefixes extends AnyFunSuite with TestUtils {
   test("simple-card-game") {
     val filepath = Paths.get("examples/larger-examples/simple-card-game.flix")
     val input = Files.readString(filepath)
-    compilePrefixes(filepath.getFileName.toString, input)
+    compilePrefixes(input)
   }
 
   test("the-ast-typing-problem-with-polymorphic-records") {
     val filepath = Paths.get("examples/records/the-ast-typing-problem-with-polymorphic-records.flix")
     val input = Files.readString(filepath)
-    compilePrefixes(filepath.getFileName.toString, input)
+    compilePrefixes(input)
   }
 
   test("ford-fulkerson") {
     val filepath = Paths.get("examples/larger-examples/datalog/ford-fulkerson.flix")
     val input = Files.readString(filepath)
-    compilePrefixes(filepath.getFileName.toString, input)
+    compilePrefixes(input)
   }
 
   /**
@@ -52,7 +52,7 @@ class FuzzPrefixes extends AnyFunSuite with TestUtils {
     * For example, if N is 100 and the input has length 300 then we create prefixes of length 3, 6, 9, ...
     * The program may not be valid: We just care that it does not crash the compiler.
     */
-  private def compilePrefixes(name: String, input: String): Unit = {
+  private def compilePrefixes(input: String): Unit = {
     val length = input.length
     val step = length / N
 
@@ -61,10 +61,9 @@ class FuzzPrefixes extends AnyFunSuite with TestUtils {
     for (i <- 1 until N) {
       val e = Math.min(i * step, length)
       val prefix = input.substring(0, e)
-      val sourceName = s"$name-prefix-$e"
-      flix.addSourceCode(sourceName, prefix)(SecurityContext.AllPermissions)
+      // We use the same name for all inputs to simulate editing a file
+      flix.addSourceCode("<input>", prefix)(SecurityContext.AllPermissions)
       flix.compile() // We simply care that this does not crash.
-      flix.remSourceCode(sourceName)
     }
   }
 

--- a/main/test/flix/fuzzers/FuzzPrefixes.scala
+++ b/main/test/flix/fuzzers/FuzzPrefixes.scala
@@ -29,28 +29,23 @@ class FuzzPrefixes extends AnyFunSuite with TestUtils {
     */
   private val N: Int = 100
 
-//  test("simple-card-game") {
-//    val filepath = Paths.get("examples/larger-examples/simple-card-game.flix")
-//    val input = Files.readString(filepath)
-//    compilePrefixes(filepath.getFileName.toString, input)
-//  }
-//
-//  test("the-ast-typing-problem-with-polymorphic-records") {
-//    val filepath = Paths.get("examples/records/the-ast-typing-problem-with-polymorphic-records.flix")
-//    val input = Files.readString(filepath)
-//    compilePrefixes(filepath.getFileName.toString, input)
-//  }
-//
-//  test("ford-fulkerson") {
-//    val filepath = Paths.get("examples/larger-examples/datalog/ford-fulkerson.flix")
-//    val input = Files.readString(filepath)
-//    compilePrefixes(filepath.getFileName.toString, input)
-//  }
+  test("simple-card-game") {
+    val filepath = Paths.get("examples/larger-examples/simple-card-game.flix")
+    val input = Files.readString(filepath)
+    compilePrefixes(filepath.getFileName.toString, input)
+  }
 
-  testFile("simple-card-game", "examples/larger-examples/simple-card-game.flix")
-  testFile("the-ast-typing-problem-with-polymorphic-records", "examples/records/the-ast-typing-problem-with-polymorphic-records.flix")
-  testFile("ford-fulkerson", "examples/larger-examples/datalog/ford-fulkerson.flix")
+  test("the-ast-typing-problem-with-polymorphic-records") {
+    val filepath = Paths.get("examples/records/the-ast-typing-problem-with-polymorphic-records.flix")
+    val input = Files.readString(filepath)
+    compilePrefixes(filepath.getFileName.toString, input)
+  }
 
+  test("ford-fulkerson") {
+    val filepath = Paths.get("examples/larger-examples/datalog/ford-fulkerson.flix")
+    val input = Files.readString(filepath)
+    compilePrefixes(filepath.getFileName.toString, input)
+  }
 
   /**
     * We break the given string `input` down into N prefixes and compile each of them.
@@ -73,22 +68,4 @@ class FuzzPrefixes extends AnyFunSuite with TestUtils {
     }
   }
 
-  def testFile(name: String, filepath: String) = {
-    val input = Files.readString(Paths.get(filepath))
-    val length = input.length
-    val step = length / N
-
-    val flix = new Flix()
-    flix.compile()
-    for (i <- 1 until N) {
-      val e = Math.min(i * step, length)
-      val prefix = input.substring(0, e)
-      val sourceName = s"$name-prefix-$e"
-      test(sourceName) {
-        flix.addSourceCode(sourceName, prefix)(SecurityContext.AllPermissions)
-        flix.compile() // We simply care that this does not crash.
-        flix.remSourceCode(sourceName)
-      }
-    }
-  }
 }

--- a/main/test/flix/fuzzers/FuzzPrefixes.scala
+++ b/main/test/flix/fuzzers/FuzzPrefixes.scala
@@ -29,23 +29,28 @@ class FuzzPrefixes extends AnyFunSuite with TestUtils {
     */
   private val N: Int = 100
 
-  test("simple-card-game") {
-    val filepath = Paths.get("examples/larger-examples/simple-card-game.flix")
-    val input = Files.readString(filepath)
-    compilePrefixes(filepath.getFileName.toString, input)
-  }
+//  test("simple-card-game") {
+//    val filepath = Paths.get("examples/larger-examples/simple-card-game.flix")
+//    val input = Files.readString(filepath)
+//    compilePrefixes(filepath.getFileName.toString, input)
+//  }
+//
+//  test("the-ast-typing-problem-with-polymorphic-records") {
+//    val filepath = Paths.get("examples/records/the-ast-typing-problem-with-polymorphic-records.flix")
+//    val input = Files.readString(filepath)
+//    compilePrefixes(filepath.getFileName.toString, input)
+//  }
+//
+//  test("ford-fulkerson") {
+//    val filepath = Paths.get("examples/larger-examples/datalog/ford-fulkerson.flix")
+//    val input = Files.readString(filepath)
+//    compilePrefixes(filepath.getFileName.toString, input)
+//  }
 
-  test("the-ast-typing-problem-with-polymorphic-records") {
-    val filepath = Paths.get("examples/records/the-ast-typing-problem-with-polymorphic-records.flix")
-    val input = Files.readString(filepath)
-    compilePrefixes(filepath.getFileName.toString, input)
-  }
+  testFile("simple-card-game", "examples/larger-examples/simple-card-game.flix")
+  testFile("the-ast-typing-problem-with-polymorphic-records", "examples/records/the-ast-typing-problem-with-polymorphic-records.flix")
+  testFile("ford-fulkerson", "examples/larger-examples/datalog/ford-fulkerson.flix")
 
-  test("ford-fulkerson") {
-    val filepath = Paths.get("examples/larger-examples/datalog/ford-fulkerson.flix")
-    val input = Files.readString(filepath)
-    compilePrefixes(filepath.getFileName.toString, input)
-  }
 
   /**
     * We break the given string `input` down into N prefixes and compile each of them.
@@ -68,4 +73,22 @@ class FuzzPrefixes extends AnyFunSuite with TestUtils {
     }
   }
 
+  def testFile(name: String, filepath: String) = {
+    val input = Files.readString(Paths.get(filepath))
+    val length = input.length
+    val step = length / N
+
+    val flix = new Flix()
+    flix.compile()
+    for (i <- 1 until N) {
+      val e = Math.min(i * step, length)
+      val prefix = input.substring(0, e)
+      val sourceName = s"$name-prefix-$e"
+      test(sourceName) {
+        flix.addSourceCode(sourceName, prefix)(SecurityContext.AllPermissions)
+        flix.compile() // We simply care that this does not crash.
+        flix.remSourceCode(sourceName)
+      }
+    }
+  }
 }

--- a/main/test/flix/fuzzers/FuzzPrefixes.scala
+++ b/main/test/flix/fuzzers/FuzzPrefixes.scala
@@ -61,8 +61,10 @@ class FuzzPrefixes extends AnyFunSuite with TestUtils {
     for (i <- 1 until N) {
       val e = Math.min(i * step, length)
       val prefix = input.substring(0, e)
-      flix.addSourceCode(s"$name-prefix-$e", prefix)(SecurityContext.AllPermissions)
+      val sourceName = s"$name-prefix-$e"
+      flix.addSourceCode(sourceName, prefix)(SecurityContext.AllPermissions)
       flix.compile() // We simply care that this does not crash.
+      flix.remSourceCode(sourceName)
     }
   }
 

--- a/main/test/flix/fuzzers/FuzzSwapLines.scala
+++ b/main/test/flix/fuzzers/FuzzSwapLines.scala
@@ -70,8 +70,10 @@ class FuzzSwapLines extends AnyFunSuite with TestUtils {
       for (j <- i + 1 until numSwapLinesFixed) {
         val jStepped = Math.min(j * step, numLines)
         val src = lines.updated(iStepped, lines(jStepped)).updated(jStepped, lines(iStepped)).mkString("\n")
-        flix.addSourceCode(s"$name-swap-lines-$iStepped-and-$jStepped", src)(SecurityContext.AllPermissions)
+        val sourceName = s"$name-swap-lines-$iStepped-and-$jStepped"
+        flix.addSourceCode(sourceName, src)(SecurityContext.AllPermissions)
         flix.compile() // We simply care that this does not crash.
+        flix.remSourceCode(sourceName)
       }
     }
   }

--- a/main/test/flix/fuzzers/FuzzSwapLines.scala
+++ b/main/test/flix/fuzzers/FuzzSwapLines.scala
@@ -36,19 +36,19 @@ class FuzzSwapLines extends AnyFunSuite with TestUtils {
   test("simple-card-game") {
     val filepath = Paths.get("examples/larger-examples/simple-card-game.flix")
     val lines = Files.lines(filepath)
-    compileWithSwappedLines(filepath.getFileName.toString, lines)
+    compileWithSwappedLines(lines)
   }
 
   test("the-ast-typing-problem-with-polymorphic-records") {
     val filepath = Paths.get("examples/records/the-ast-typing-problem-with-polymorphic-records.flix")
     val lines = Files.lines(filepath)
-    compileWithSwappedLines(filepath.getFileName.toString, lines)
+    compileWithSwappedLines(lines)
   }
 
   test("ford-fulkerson") {
     val filepath = Paths.get("examples/larger-examples/datalog/ford-fulkerson.flix")
     val lines = Files.lines(filepath)
-    compileWithSwappedLines(filepath.getFileName.toString, lines)
+    compileWithSwappedLines(lines)
   }
 
   /**
@@ -57,7 +57,7 @@ class FuzzSwapLines extends AnyFunSuite with TestUtils {
     * line 0 with line 10, 20, 30, 40, 50, 60, 70, 80, 90 and 100.
     * The program may not be valid: We just care that it does not crash the compiler.
     */
-  private def compileWithSwappedLines(name: String, stream: java.util.stream.Stream[String]): Unit = {
+  private def compileWithSwappedLines(stream: java.util.stream.Stream[String]): Unit = {
     val lines = stream.iterator().asScala.toList
     val numLines = lines.length
     val numSwapLinesFixed = numLines.min(numSwapLines)
@@ -70,10 +70,9 @@ class FuzzSwapLines extends AnyFunSuite with TestUtils {
       for (j <- i + 1 until numSwapLinesFixed) {
         val jStepped = Math.min(j * step, numLines)
         val src = lines.updated(iStepped, lines(jStepped)).updated(jStepped, lines(iStepped)).mkString("\n")
-        val sourceName = s"$name-swap-lines-$iStepped-and-$jStepped"
-        flix.addSourceCode(sourceName, src)(SecurityContext.AllPermissions)
+        // We use the same name for all inputs to simulate editing a file
+        flix.addSourceCode("<input>", src)(SecurityContext.AllPermissions)
         flix.compile() // We simply care that this does not crash.
-        flix.remSourceCode(sourceName)
       }
     }
   }


### PR DESCRIPTION
This should allow https://github.com/flix/flix/pull/10117 to go through.

Depends on
- https://github.com/flix/flix/pull/10199

I've created a ticket to track the discovered resiliency issue: https://github.com/flix/flix/issues/10181