### PR TITLE
feat: must use everything (remove `@MustUse`)

### DIFF
--- a/examples/effects-and-handlers/advanced/collatz.flix
+++ b/examples/effects-and-handlers/advanced/collatz.flix
@@ -11,7 +11,7 @@ pub def main(): Unit \ IO = region rc {
         State.put(0);
         def loop(k: Int32) = {
             if (k == 1)
-                k
+                ()
             else if (Int32.modulo(k, 2) == 0) {
                 State.put(State.get() + 1);
                 loop(k / 2)

--- a/examples/effects-and-handlers/advanced/nqueens.flix
+++ b/examples/effects-and-handlers/advanced/nqueens.flix
@@ -65,7 +65,7 @@ pub def findOneSolution(size: Int32, queens: Int32): Placement \ Searchable =
 ///
 pub def countSolutions(size: Int32): Int32 =
     run {
-        findOneSolution(size, size);
+        discard findOneSolution(size, size);
         1
     } with handler Searchable {
         //

--- a/examples/interoperability/exceptions/catching-java-exceptions.flix
+++ b/examples/interoperability/exceptions/catching-java-exceptions.flix
@@ -4,7 +4,7 @@ import java.io.IOException
 def main(): Unit \ IO =
     try {
         let reader = new FileReader("foo.txt");
-        reader.read();
+        discard reader.read();
         reader.close()
     } catch {
         case ex: IOException => ex.printStackTrace()

--- a/examples/interoperability/swing/simple-swing-app.flix
+++ b/examples/interoperability/swing/simple-swing-app.flix
@@ -6,7 +6,7 @@ def main(): Unit \ IO = {
     frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
     let label = new JLabel("Hello World!");
-    frame.getContentPane().add(label);
+    discard frame.getContentPane().add(label);
 
     frame.pack();
     frame.setVisible(true)

--- a/examples/interoperability/swing/swing-dial.flix
+++ b/examples/interoperability/swing/swing-dial.flix
@@ -18,15 +18,15 @@ def createAndShowGUI(): Unit \ IO = {
     frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
     frame.setLayout(new GridLayout(3, 3));
-    frame.getContentPane().add(mkButton("1"));
-    frame.getContentPane().add(mkButton("2"));
-    frame.getContentPane().add(mkButton("3"));
-    frame.getContentPane().add(mkButton("4"));
-    frame.getContentPane().add(mkButton("5"));
-    frame.getContentPane().add(mkButton("6"));
-    frame.getContentPane().add(mkButton("7"));
-    frame.getContentPane().add(mkButton("8"));
-    frame.getContentPane().add(mkButton("9"));
+    discard frame.getContentPane().add(mkButton("1"));
+    discard frame.getContentPane().add(mkButton("2"));
+    discard frame.getContentPane().add(mkButton("3"));
+    discard frame.getContentPane().add(mkButton("4"));
+    discard frame.getContentPane().add(mkButton("5"));
+    discard frame.getContentPane().add(mkButton("6"));
+    discard frame.getContentPane().add(mkButton("7"));
+    discard frame.getContentPane().add(mkButton("8"));
+    discard frame.getContentPane().add(mkButton("9"));
 
     frame.pack();
     frame.setVisible(true)

--- a/examples/interoperability/swing/swing-dialog.flix
+++ b/examples/interoperability/swing/swing-dialog.flix
@@ -17,7 +17,7 @@ def createAndShowGUI(): Unit \ IO = {
     let openDialog = _ -> showDialog(title = "Are you sure?", content = "The button was clicked. Pick an option", frame);
     let button = mkButton("Click me to open a dialog", openDialog);
 
-    frame.getContentPane().add(button);
+    discard frame.getContentPane().add(button);
     frame.pack();
     frame.setVisible(true)
 }
@@ -33,6 +33,6 @@ def mkButton(content: String, onClick: ActionEvent -> Unit \ ef): JButton \ IO =
 }
 
 def showDialog(title: { title = String }, content: { content = String }, frame: JFrame): Unit \ IO = {
-    JOptionPane.showConfirmDialog(frame, content#content, title#title, JOptionPane.YES_NO_CANCEL_OPTION);
+    discard JOptionPane.showConfirmDialog(frame, content#content, title#title, JOptionPane.YES_NO_CANCEL_OPTION);
     ()
 }

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/Annotation.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/Annotation.scala
@@ -99,15 +99,6 @@ object Annotation {
   }
 
   /**
-    * An annotation that marks a type as must-use.
-    *
-    * @param loc the source location of the annotation.
-    */
-  case class MustUse(loc: SourceLocation) extends Annotation {
-    override def toString: String = "@MustUse"
-  }
-
-  /**
     * An AST node that represents a `@Skip` annotation.
     *
     * A function marked with `Skip` is skipped by the test framework.

--- a/main/src/ca/uwaterloo/flix/language/ast/shared/Annotations.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/shared/Annotations.scala
@@ -62,11 +62,6 @@ case class Annotations(annotations: List[Annotation]) {
   def isLazyWhenPure: Boolean = annotations exists (_.isInstanceOf[Annotation.LazyWhenPure])
 
   /**
-    * Returns `true` if `this` sequence contains the `@MustUse` annotation.
-    */
-  def isMustUse: Boolean = annotations exists (_.isInstanceOf[Annotation.MustUse])
-
-  /**
     * Returns `true` if `this` sequence contains the `@Parallel` annotation.
     */
   def isParallel: Boolean = annotations exists (_.isInstanceOf[Annotation.Parallel])

--- a/main/src/ca/uwaterloo/flix/language/errors/RedundancyError.scala
+++ b/main/src/ca/uwaterloo/flix/language/errors/RedundancyError.scala
@@ -513,36 +513,6 @@ object RedundancyError {
   }
 
   /**
-    * An error raised to indicate that the value of an expression must be used.
-    *
-    * @param tpe the type of the expression.
-    * @param loc the location of the expression.
-    */
-  case class UnusedMustUseValue(tpe: Type, loc: SourceLocation)(implicit flix: Flix) extends RedundancyError {
-    def summary: String = "Unused value but its type is marked as @MustUse"
-
-    def message(formatter: Formatter): String = {
-      import formatter.*
-      s""">> Unused value but its type is marked as @MustUse.
-         |
-         |${code(loc, "unused value.")}
-         |
-         |The expression has type '${FormatType.formatType(tpe)}'
-         |""".stripMargin
-    }
-
-    override def explain(formatter: Formatter): Option[String] = Some({
-      s"""
-         |Possible fixes:
-         |
-         |  (1)  Use the value.
-         |  (2)  Explicit mark the value as unused with `discard`.
-         |
-         |""".stripMargin
-    })
-  }
-
-  /**
     * An error raised to indicate that the given type parameter `ident` is not used.
     *
     * @param ident the unused type variable.

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -451,8 +451,6 @@ object Redundancy {
         (us1 ++ us2) + UnderAppliedFunction(exp1.tpe, exp1.loc)
       } else if (isUselessExpression(exp1)) {
         (us1 ++ us2) + UselessExpression(exp1.tpe, exp1.loc)
-      } else if (isMustUse(exp1)(root) && !isHole(exp1)) {
-        (us1 ++ us2) + UnusedMustUseValue(exp1.tpe, exp1.loc)
       } else {
         us1 ++ us2
       }
@@ -989,21 +987,6 @@ object Redundancy {
     */
   private def isUselessExpression(exp: Expr): Boolean =
     isPure(exp)
-
-  /**
-    * Returns `true` if the expression must be used.
-    */
-  private def isMustUse(exp: Expr)(implicit root: Root): Boolean =
-    isMustUseType(exp.tpe)
-
-  /**
-    * Returns `true` if the given type `tpe` is marked as `@MustUse` or is intrinsically `@MustUse`.
-    */
-  private def isMustUseType(tpe: Type)(implicit root: Root): Boolean = tpe.typeConstructor match {
-    case Some(TypeConstructor.Arrow(_)) => true
-    case Some(TypeConstructor.Enum(sym, _)) => root.enums(sym).ann.isMustUse
-    case _ => false
-  }
 
   /**
     * Returns true if the expression is a hole.

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -664,7 +664,6 @@ object Weeder2 {
         case "@ParallelWhenPure" => ParallelWhenPure(loc)
         case "@Lazy" => Lazy(loc)
         case "@LazyWhenPure" => LazyWhenPure(loc)
-        case "@MustUse" => MustUse(loc)
         case "@Skip" => Skip(loc)
         case "@Test" | "@test" => Test(loc)
         case "@TailRec" => TailRecursive(loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -355,8 +355,9 @@ object ConstraintGen {
         (resTpe, resEff)
 
       case Expr.Stm(exp1, exp2, loc) =>
-        val (_, eff1) = visitExp(exp1)
+        val (tpe1, eff1) = visitExp(exp1)
         val (tpe2, eff2) = visitExp(exp2)
+        c.expectType(expected = Type.Unit, actual = tpe1, exp1.loc)
         val resTpe = tpe2
         val resEff = Type.mkUnion(eff1, eff2, loc)
         (resTpe, resEff)

--- a/main/src/library/FileWrite.flix
+++ b/main/src/library/FileWrite.flix
@@ -117,7 +117,7 @@ mod FileWrite {
             def write(data, f, k) = {
                 try {
                     let bytes = data#str.getBytes(StandardCharsets.UTF_8);
-                    Files.write(Paths.get(f), bytes, (...{}: Vector[OpenOption]));
+                    discard Files.write(Paths.get(f), bytes, (...{}: Vector[OpenOption]));
                     k(())
                 } catch {
                     case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
@@ -146,7 +146,7 @@ mod FileWrite {
                 try {
                     region rc {
                         let bytes = Vector.toArray(rc, data);
-                        Files.write(Paths.get(f), bytes, (...{}: Vector[OpenOption]));
+                        discard Files.write(Paths.get(f), bytes, (...{}: Vector[OpenOption]));
                         k(())
                     }
                 } catch {
@@ -160,7 +160,7 @@ mod FileWrite {
                 try {
                     let bytes = data#str.getBytes(StandardCharsets.UTF_8);
                     let opt: OpenOption = checked_cast(StandardOpenOption.APPEND);
-                    Files.write(Paths.get(f), bytes, ...{opt});
+                    discard Files.write(Paths.get(f), bytes, ...{opt});
                     k(())
                 } catch {
                     case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
@@ -191,7 +191,7 @@ mod FileWrite {
                     region rc {
                         let bytes = Vector.toArray(rc, data);
                         let opt: OpenOption = checked_cast(StandardOpenOption.APPEND);
-                        Files.write(Paths.get(f), bytes, ...{opt});
+                        discard Files.write(Paths.get(f), bytes, ...{opt});
                         k(())
                     }
                 } catch {
@@ -206,7 +206,7 @@ mod FileWrite {
                     region rc {
                         let opt: OpenOption = checked_cast(StandardOpenOption.TRUNCATE_EXISTING);
                         let arr: Array[Int8, rc] = Array#{} @ rc;
-                        Files.write(Paths.get(f), arr, ...{opt});
+                        discard Files.write(Paths.get(f), arr, ...{opt});
                         k(())
                     }
                 } catch {
@@ -218,7 +218,7 @@ mod FileWrite {
 
             def mkDir(d, k) = {
                 try {
-                    Files.createDirectory(Paths.get(d), (...{}: Vector[FileAttribute]));
+                    discard Files.createDirectory(Paths.get(d), (...{}: Vector[FileAttribute]));
                     k(())
                 } catch {
                     case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
@@ -230,7 +230,7 @@ mod FileWrite {
 
             def mkDirs(d, k) = {
                 try {
-                    Files.createDirectories(Paths.get(d), (...{}: Vector[FileAttribute]));
+                    discard Files.createDirectories(Paths.get(d), (...{}: Vector[FileAttribute]));
                     k(())
                 } catch {
                     case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))

--- a/main/src/library/FileWriteWithResult.flix
+++ b/main/src/library/FileWriteWithResult.flix
@@ -114,7 +114,7 @@ mod FileWriteWithResult {
             def write(data, f, k) = {
                 let res = try {
                     let bytes = data#str.getBytes(StandardCharsets.UTF_8);
-                    Files.write(Paths.get(f), bytes, (...{}: Vector[OpenOption]));
+                    discard Files.write(Paths.get(f), bytes, (...{}: Vector[OpenOption]));
                     Ok(())
                 } catch {
                     case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
@@ -145,7 +145,7 @@ mod FileWriteWithResult {
                 let res = try {
                     region rc {
                         let bytes = Vector.toArray(rc, data);
-                        Files.write(Paths.get(f), bytes, (...{}: Vector[OpenOption]));
+                        discard Files.write(Paths.get(f), bytes, (...{}: Vector[OpenOption]));
                         Ok(())
                     }
                 } catch {
@@ -160,7 +160,7 @@ mod FileWriteWithResult {
                 let res = try {
                     let bytes = data#str.getBytes(StandardCharsets.UTF_8);
                     let opt: OpenOption = checked_cast(StandardOpenOption.APPEND);
-                    Files.write(Paths.get(f), bytes, ...{opt});
+                    discard Files.write(Paths.get(f), bytes, ...{opt});
                     Ok(())
                 } catch {
                     case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
@@ -193,7 +193,7 @@ mod FileWriteWithResult {
                     region rc {
                         let bytes = Vector.toArray(rc, data);
                         let opt: OpenOption = checked_cast(StandardOpenOption.APPEND);
-                        Files.write(Paths.get(f), bytes, ...{opt});
+                        discard Files.write(Paths.get(f), bytes, ...{opt});
                         Ok(())
                     }
                 } catch {
@@ -209,7 +209,7 @@ mod FileWriteWithResult {
                     region rc {
                         let opt: OpenOption = checked_cast(StandardOpenOption.TRUNCATE_EXISTING);
                         let arr: Array[Int8, rc] = Array#{} @ rc;
-                        Files.write(Paths.get(f), arr, ...{opt});
+                        discard Files.write(Paths.get(f), arr, ...{opt});
                         Ok(())
                     }
                 } catch {
@@ -222,7 +222,7 @@ mod FileWriteWithResult {
 
             def mkDir(d, k) = {
                 let res = try {
-                    Files.createDirectory(Paths.get(d), (...{}: Vector[FileAttribute]));
+                    discard Files.createDirectory(Paths.get(d), (...{}: Vector[FileAttribute]));
                     Ok(())
                 } catch {
                     case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))
@@ -235,7 +235,7 @@ mod FileWriteWithResult {
 
             def mkDirs(d, k) = {
                 let res = try {
-                    Files.createDirectories(Paths.get(d), (...{}: Vector[FileAttribute]));
+                    discard Files.createDirectories(Paths.get(d), (...{}: Vector[FileAttribute]));
                     Ok(())
                 } catch {
                     case ex: InvalidPathException          => Err(IoError(ErrorKind.InvalidPath, ex.getMessage()))

--- a/main/src/library/Process.flix
+++ b/main/src/library/Process.flix
@@ -73,11 +73,11 @@ mod Process {
                     let arr = List.toArray(rc, cmd :: args);
                     let pb = new ProcessBuilder(arr);
                     foreach(e <- Map.toList(env)) {
-                        pb.environment().put(fst(e), snd(e));
+                        discard pb.environment().put(fst(e), snd(e));
                         ()
                     };
                     match cwd {
-                        case Some(cwd) => pb.directory(new JFile(cwd)); ()
+                        case Some(cwd) => discard pb.directory(new JFile(cwd)); ()
                         case None => ()
                     };
                     let process = pb.start();

--- a/main/src/library/ProcessWithResult.flix
+++ b/main/src/library/ProcessWithResult.flix
@@ -70,11 +70,11 @@ mod ProcessWithResult {
                     let arr = List.toArray(rc, cmd :: args);
                     let pb = new ProcessBuilder(arr);
                     foreach(e <- Map.toList(env)) {
-                        pb.environment().put(fst(e), snd(e));
+                        discard pb.environment().put(fst(e), snd(e));
                         ()
                     };
                     match cwd {
-                        case Some(cwd) => pb.directory(new JFile(cwd)); ()
+                        case Some(cwd) => discard pb.directory(new JFile(cwd)); ()
                         case None => ()
                     };
                     let process = pb.start();

--- a/main/src/library/Result.flix
+++ b/main/src/library/Result.flix
@@ -21,7 +21,6 @@
 /// The constructor `Ok(v)` represents the successful value `v`,
 /// whereas the constructor `Err(v)` represents the error value `v`.
 ///
-@MustUse
 pub enum Result[e, t] with Eq, Order, ToString {
     case Ok(t),
     case Err(e)

--- a/main/src/library/StringBuilder.flix
+++ b/main/src/library/StringBuilder.flix
@@ -43,7 +43,7 @@ mod StringBuilder {
     ///
     pub def appendString(s: String, sb: StringBuilder[r]): Unit \ r =
         let StringBuilder(msb) = sb;
-        unchecked_cast((msb.append(s): _ \ IO) as _ \ r);
+        unchecked_cast((discard msb.append(s): _ \ IO) as _ \ r);
         ()
 
     ///
@@ -51,7 +51,7 @@ mod StringBuilder {
     ///
     pub def appendCodePoint(cp: Int32, sb: StringBuilder[r]): Unit \ r =
         let StringBuilder(msb) = sb;
-        unchecked_cast((msb.appendCodePoint(cp): _ \ IO) as _ \ r);
+        unchecked_cast((discard msb.appendCodePoint(cp): _ \ IO) as _ \ r);
         ()
 
     ///

--- a/main/src/library/Validation.flix
+++ b/main/src/library/Validation.flix
@@ -17,7 +17,6 @@
 ///
 /// The Validation type.
 ///
-@MustUse
 pub enum Validation[e, t] with Eq, Order, ToString {
     case Success(t),
     case Failure(Nec[e])

--- a/main/src/resources/benchmark/BenchmarkSuite.flix
+++ b/main/src/resources/benchmark/BenchmarkSuite.flix
@@ -55,7 +55,7 @@ def iterateN(f: Unit -> Unit \ IO, n: Int32): Unit \ IO = match n {
 /// Consumes `t` in a way that the optimizer cannot discard.
 ///
 def blackhole(t: a): Unit \ IO =
-    Ref.fresh(Static, t); ()
+    discard Ref.fresh(Static, t); ()
 
 ///
 /// Returns the median of the given list `l`.

--- a/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestRedundancy.scala
@@ -1879,10 +1879,9 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
     expectError[RedundancyError.RedundantDiscard](result)
   }
 
-  test("MustUse.01") {
+  test("NonUnitStm.01") {
     val input =
       """
-        |@MustUse
         |enum A {
         |    case A
         |}
@@ -1894,10 +1893,10 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
         |""".stripMargin
 
     val result = compile(input, Options.TestWithLibMin)
-    expectError[RedundancyError.UnusedMustUseValue](result)
+    expectError[TypeError](result)
   }
 
-  test("MustUse.02") {
+  test("NonUnitStm.02") {
     val input =
       """
         |def f(): Int32 \ IO =
@@ -1907,7 +1906,7 @@ class TestRedundancy extends AnyFunSuite with TestUtils {
         |""".stripMargin
 
     val result = compile(input, Options.TestWithLibMin)
-    expectError[RedundancyError.UnusedMustUseValue](result)
+    expectError[TypeError](result)
   }
 
   test("RedundantCheckedTypeCast.01") {

--- a/main/test/ca/uwaterloo/flix/library/TestMutPriorityQueue.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestMutPriorityQueue.flix
@@ -37,8 +37,8 @@ mod TestMutPriorityQueue {
     def testToString03(): Bool = region rc {
         let mq = MutPriorityQueue.empty(rc);
         MutPriorityQueue.enqueueAll(mq, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: Nil);
-        MutPriorityQueue.dequeue(mq);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         MutPriorityQueue.toString(mq) == "MutPriorityQueue {6, 4, 5, 1, 3, 2}"
     }
 
@@ -73,7 +73,7 @@ mod TestMutPriorityQueue {
     def testSize03(): Bool = region rc {
         let mq = MutPriorityQueue.empty(rc);
         MutPriorityQueue.enqueueAll(mq, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: Nil);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         MutPriorityQueue.size(mq) == 7
     }
 
@@ -98,17 +98,17 @@ mod TestMutPriorityQueue {
     def testIsEmpty03(): Bool = region rc {
         let mq = MutPriorityQueue.empty(rc);
         MutPriorityQueue.enqueueAll(mq, 1 :: 2 :: 3 :: Nil);
-        MutPriorityQueue.dequeue(mq);
-        MutPriorityQueue.dequeue(mq);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         MutPriorityQueue.isEmpty(mq)
     }
 
     @Test def testIsEmpty04(): Bool = region rc {
         let mq = MutPriorityQueue.empty(rc);
         MutPriorityQueue.enqueueAll(mq, 1 :: 2 :: Nil);
-        MutPriorityQueue.dequeue(mq);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         MutPriorityQueue.enqueue(mq, 1);
         not MutPriorityQueue.isEmpty(mq)
     }
@@ -134,9 +134,9 @@ mod TestMutPriorityQueue {
     def testNonEmpty03(): Bool = region rc {
         let mq = MutPriorityQueue.empty(rc);
         MutPriorityQueue.enqueueAll(mq, 1 :: 2 :: 3 :: Nil);
-        MutPriorityQueue.dequeue(mq);
-        MutPriorityQueue.dequeue(mq);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         not MutPriorityQueue.nonEmpty(mq)
     }
 
@@ -144,8 +144,8 @@ mod TestMutPriorityQueue {
     def testNonEmpty04(): Bool = region rc {
         let mq = MutPriorityQueue.empty(rc);
         MutPriorityQueue.enqueueAll(mq, 1 :: 2 :: Nil);
-        MutPriorityQueue.dequeue(mq);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         MutPriorityQueue.enqueue(mq, 1);
         MutPriorityQueue.nonEmpty(mq)
     }
@@ -158,7 +158,7 @@ mod TestMutPriorityQueue {
     def testPeek01(): Bool = region rc {
         let mq = MutPriorityQueue.empty(rc);
         MutPriorityQueue.enqueue(mq, 3);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         MutPriorityQueue.peek(mq) == None
     }
 
@@ -173,7 +173,7 @@ mod TestMutPriorityQueue {
     def testPeek03(): Bool = region rc {
         let mq = MutPriorityQueue.empty(rc);
         MutPriorityQueue.enqueueAll(mq, 1 :: 9 :: 2 :: 8 :: 3 :: 7 :: Nil);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         MutPriorityQueue.peek(mq) == Some(8)
     }
 
@@ -188,7 +188,7 @@ mod TestMutPriorityQueue {
         let mq = MutPriorityQueue.empty(rc);
         MutPriorityQueue.enqueue(mq, 5);
         MutPriorityQueue.enqueue(mq, 5);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         MutPriorityQueue.peek(mq) == Some(5)
     }
 
@@ -252,7 +252,7 @@ mod TestMutPriorityQueue {
     @Test
     def testDequeue01(): Bool = region rc {
         let mq = (MutPriorityQueue.empty(rc) : MutPriorityQueue[Int32, rc]);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         MutPriorityQueue.size(mq) == 0
     }
 
@@ -266,8 +266,8 @@ mod TestMutPriorityQueue {
     def testDequeue03(): Bool = region rc {
         let mq = MutPriorityQueue.empty(rc);
         MutPriorityQueue.enqueueAll(mq, 1 :: 2 :: 3 :: 4 :: 5 :: Nil);
-        MutPriorityQueue.dequeue(mq);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         MutPriorityQueue.size(mq) == 3
     }
 
@@ -275,7 +275,7 @@ mod TestMutPriorityQueue {
     def testDequeue04(): Bool = region rc {
         let mq = MutPriorityQueue.empty(rc);
         MutPriorityQueue.enqueueAll(mq, 1 :: 2 :: 3 :: 4 :: 5 :: Nil);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         MutPriorityQueue.dequeue(mq) == Some(4)
     }
 
@@ -283,9 +283,9 @@ mod TestMutPriorityQueue {
     def testDequeue05(): Bool = region rc {
         let mq = MutPriorityQueue.empty(rc);
         MutPriorityQueue.enqueueAll(mq, 1 :: 2 :: 3 :: Nil);
-        MutPriorityQueue.dequeue(mq);
-        MutPriorityQueue.dequeue(mq);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         MutPriorityQueue.size(mq) == 0
     }
 
@@ -399,8 +399,8 @@ mod TestMutPriorityQueue {
     def testToList06(): Bool = region rc {
         let mq = MutPriorityQueue.empty(rc);
         MutPriorityQueue.enqueueAll(mq, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: Nil);
-        MutPriorityQueue.dequeue(mq);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         MutPriorityQueue.toList(mq) == 6 :: 4 :: 5 :: 1 :: 3 :: 2 :: Nil
     }
 
@@ -439,8 +439,8 @@ mod TestMutPriorityQueue {
     def testToNel05(): Bool = region rc {
         let mq = MutPriorityQueue.empty(rc);
         MutPriorityQueue.enqueueAll(mq, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: Nil);
-        MutPriorityQueue.dequeue(mq);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         MutPriorityQueue.toNel(mq) == Some(Nel.Nel(6, 4 :: 5 :: 1 :: 3 :: 2 :: Nil))
     }
 
@@ -486,8 +486,8 @@ mod TestMutPriorityQueue {
     def testToArray06(): Bool = region rc {
         let mq = (MutPriorityQueue.empty(rc) : MutPriorityQueue[Int32, rc]);
         MutPriorityQueue.enqueueAll(mq, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: Nil);
-        MutPriorityQueue.dequeue(mq);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         Array.toString(MutPriorityQueue.toArray(rc, mq)) == "Array#{6, 4, 5, 1, 3, 2}"
     }
 
@@ -533,8 +533,8 @@ mod TestMutPriorityQueue {
     def testToVector06(): Bool = region rc {
         let mq = (MutPriorityQueue.empty(rc) : MutPriorityQueue[Int32, rc]);
         MutPriorityQueue.enqueueAll(mq, 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: Nil);
-        MutPriorityQueue.dequeue(mq);
-        MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
+        discard MutPriorityQueue.dequeue(mq);
         MutPriorityQueue.toVector(mq) == Vector#{6, 4, 5, 1, 3, 2}
     }
 

--- a/main/test/flix/Test.Exp.Jvm.Complex.flix
+++ b/main/test/flix/Test.Exp.Jvm.Complex.flix
@@ -11,7 +11,7 @@ mod Test.Exp.Jvm.Complex {
 
     pub def start(): Unit \ {Net, IO} =
         let server = HttpServer.create(new InetSocketAddress(3000), 0);
-        server.createContext("/", httpHandler());
+        discard server.createContext("/", httpHandler());
         ()
 
     def httpHandler(): HttpHandler \ IO = new HttpHandler {

--- a/main/test/flix/Test.Exp.Jvm.InvokeMethod2.Overload.Null.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeMethod2.Overload.Null.flix
@@ -22,6 +22,6 @@ mod Test.Exp.Jvm.InvokeMethod.Overload.Null {
    @test
    def testInvokeMethod_04(): Bool \ IO =
       let sb = new StringBuilder("hello ");
-      sb.append((checked_cast(null) : String));
+      discard sb.append((checked_cast(null) : String));
       sb.toString() == "hello null"
 }

--- a/main/test/flix/Test.Exp.Jvm.InvokeMethod2.Overload.Subtypes.flix
+++ b/main/test/flix/Test.Exp.Jvm.InvokeMethod2.Overload.Subtypes.flix
@@ -9,11 +9,11 @@ mod Test.Exp.Jvm.InvokeMethod.Overload.Subtypes {
    @test
    def testInvokeMethod_02(): Bool \ IO =
       let cs = CharBuffer.allocate(5);
-      cs.append('h');
-      cs.append('e');
-      cs.append('l');
-      cs.append('l');
-      cs.append('o');
+      discard cs.append('h');
+      discard cs.append('e');
+      discard cs.append('l');
+      discard cs.append('l');
+      discard cs.append('o');
       let obj = "hello world";
       obj.contains(cs)
 

--- a/main/test/flix/Test.Exp.Struct.New.flix
+++ b/main/test/flix/Test.Exp.Struct.New.flix
@@ -6,8 +6,7 @@ mod Mod1 {
         @test
         def testOuterMod01(): Unit =
             region rc {
-                new Mod1.S2 @ rc {};
-                ()
+                discard new Mod1.S2 @ rc {}
             }
     }
 }
@@ -116,117 +115,101 @@ mod Test.Exp.Struct.New {
     @test
     def testEmptyStruct01(): Unit =
         region rc {
-            new Empty @ rc {};
-            ()
+            discard new Empty @ rc {}
         }
 
     @test
     def testEmptyStruct02(): Unit =
         region rc {
-            new OneEmpty @ rc {a = new Empty @ rc { }};
-            ()
+            discard new OneEmpty @ rc {a = new Empty @ rc { }}
         }
 
     @test
     def testEmptyStruct03(): Unit =
         region rc {
-            new TwoEmpty @ rc {two_a = new Empty @ rc {}, two_b = new Empty @ rc {}};
-            ()
+            discard new TwoEmpty @ rc {two_a = new Empty @ rc {}, two_b = new Empty @ rc {}}
         }
 
     @test
     def testEmptyStruct04(): Unit =
         region rc {
-            new EmptyA @ rc { emptyb = new EmptyB @ rc { b = new EmptyC @ rc { c = new Empty @ rc {} } } };
-            ()
+            discard new EmptyA @ rc { emptyb = new EmptyB @ rc { b = new EmptyC @ rc { c = new Empty @ rc {} } } }
         }
 
     @test
     def testStructLiteral01(): Unit =
         region rc {
-            new Name @ rc { name = "Lucky Luke" };
-            ()
+            discard new Name @ rc { name = "Lucky Luke" }
         }
 
     @test
     def testStructLiteral02(): Unit =
         region rc {
-            new FullName @ rc { fstName = "Lucky", lstName = "Luke" };
-            ()
+            discard new FullName @ rc { fstName = "Lucky", lstName = "Luke" }
         }
 
     @test
     def testStructLiteral03(): Unit =
         region rc {
-            new Person @ rc { person_fstName = "Lucky", person_lstName = "Luke", person_age = 42 };
-            ()
+            discard new Person @ rc { person_fstName = "Lucky", person_lstName = "Luke", person_age = 42 }
         }
 
     @test
     def testStructLiteral04(): Unit =
         region rc {
-            new Cowboy @ rc { cowboy_fstName = "Lucky", cowboy_lstName = "Luke", cowboy_age = 42, cowboy = true };
-            ()
+            discard new Cowboy @ rc { cowboy_fstName = "Lucky", cowboy_lstName = "Luke", cowboy_age = 42, cowboy = true }
         }
 
     @test
     def testStructLiteral05(): Unit =
         region rc {
-            new TwoInts @ rc { x = 0, y = 0 };
-            ()
+            discard new TwoInts @ rc { x = 0, y = 0 }
         }
 
     @test
     def testStructLiteral06(): Unit =
         region rc {
-            new ThreeInts @ rc { three_x = 0, three_y = 0, three_z = 0 };
-            ()
+            discard new ThreeInts @ rc { three_x = 0, three_y = 0, three_z = 0 }
         }
 
     @test
     def testNestedStructLiteral01(): Unit =
         region rc {
-            new TwoIntsHolder @ rc { twoints = new TwoInts @ rc { x = 1, y = 2 }};
-            ()
+            discard new TwoIntsHolder @ rc { twoints = new TwoInts @ rc { x = 1, y = 2 }}
         }
 
     @test
     def testNestedStructLiteral02(): Unit =
         region rc {
-            new Outer @ rc { inner1 = new TwoInts @ rc { x = 1, y = 2 }, inner2 = new TwoInts @ rc { x = 3, y = 4 } };
-            ()
+            discard new Outer @ rc { inner1 = new TwoInts @ rc { x = 1, y = 2 }, inner2 = new TwoInts @ rc { x = 3, y = 4 } }
         }
 
     @test
     def testNestedStructLiteral03(): Unit =
         region rc {
-            new A @ rc {bstruct = new B @ rc {cstruct = new C @ rc {dstruct = new D @ rc {i = 42}}}};
-            ()
+            discard new A @ rc {bstruct = new B @ rc {cstruct = new C @ rc {dstruct = new D @ rc {i = 42}}}}
         }
 
     @test
     def testNestedLabels01(): Unit =
         region rc {
-            new A3 @ rc {a2 = new A2 @ rc {a1 = new A1 @ rc {empty = new Empty @ rc {}}}};
-            ()
+            discard new A3 @ rc {a2 = new A2 @ rc {a1 = new A1 @ rc {empty = new Empty @ rc {}}}}
         }
 
     @test
     def testOtherMod01(): Unit =
         region rc {
-            new Mod1.S @ rc {};
-            ()
+            discard new Mod1.S @ rc {}
         }
 
     @test
     def binaryTree01(): Unit =
         region rc {
-            new BinaryTree @ rc {
+            discard new BinaryTree @ rc {
                 left = None,
                 right = None,
                 value = 3
-            };
-            ()
+            }
         }
 
     @test
@@ -237,12 +220,11 @@ mod Test.Exp.Struct.New {
                 right = None,
                 value = 3
             };
-            new BinaryTree @ rc {
+            discard new BinaryTree @ rc {
                 left = Some(leaf),
                 right = Some(leaf),
                 value = 3
-            };
-            ()
+            }
         }
 
     @test
@@ -258,12 +240,11 @@ mod Test.Exp.Struct.New {
                 right = Some(leaf),
                 value = 3
             };
-            new BinaryTree @ rc {
+            discard new BinaryTree @ rc {
                 left = Some(innernode),
                 right = Some(innernode),
                 value = 3
-            };
-            ()
+            }
         }
 
     @test

--- a/main/test/flix/Test.Exp.Struct.Put.flix
+++ b/main/test/flix/Test.Exp.Struct.Put.flix
@@ -159,9 +159,10 @@ mod Nested {
     def nestedPut01(): Bool =
         region rc {
             let nested = new Nested @ rc { v = new Nested @ rc { v = new Nested @ rc {v = new Nested @ rc {v = 15} }} };
-            nested->v->v->v->v == 15;
+            let b1 = nested->v->v->v->v == 15;
             nested->v->v->v->v = 37;
-            nested->v->v->v->v == 37
+            let b2 = nested->v->v->v->v == 37;
+            b1 and b2
         }
 }
 

--- a/main/test/flix/Test.Exp.TypeMatch.flix
+++ b/main/test/flix/Test.Exp.TypeMatch.flix
@@ -741,7 +741,7 @@ mod Test.Exp.TypeMatch {
     def reg2(x: a): String \ IO =
         typematch x {
             case y: Array[_, Static] =>
-                Array.get(0, y);
+                discard Array.get(0, y);
                 "Array"
             case _: _ =>
                 "Not Array"

--- a/main/test/flix/Test.Handler.Gen.AtomicInteger.flix
+++ b/main/test/flix/Test.Handler.Gen.AtomicInteger.flix
@@ -13,7 +13,7 @@ mod Test.Handler.Gen.AtomicInteger {
     }
 
     def generator(): Unit \ Gen =
-        Gen.gen(); generator()
+        discard Gen.gen(); generator()
 
     def sample(limit: Int32): List[AtomicInteger] =
         region rc {

--- a/main/test/flix/Test.Handler.Gen.Bool.flix
+++ b/main/test/flix/Test.Handler.Gen.Bool.flix
@@ -5,7 +5,7 @@ mod Test.Handler.Gen.Bool {
     }
 
     def generator(): Unit \ Gen =
-        Gen.gen(); generator()
+        discard Gen.gen(); generator()
 
     def sample(limit: Int32): List[Bool] =
         region rc {

--- a/main/test/flix/Test.Handler.Gen.Char.flix
+++ b/main/test/flix/Test.Handler.Gen.Char.flix
@@ -5,7 +5,7 @@ mod Test.Handler.Gen.Char {
     }
 
     def generator(): Unit \ Gen =
-        Gen.gen(); generator()
+        discard Gen.gen(); generator()
 
     def sample(limit: Char): List[Char] =
         region rc {

--- a/main/test/flix/Test.Handler.Gen.Enum.flix
+++ b/main/test/flix/Test.Handler.Gen.Enum.flix
@@ -5,7 +5,7 @@ mod Test.Handler.Gen.Enum {
     }
 
     def generator(): Unit \ Gen =
-        Gen.gen(); generator()
+        discard Gen.gen(); generator()
 
     def sample(limit: Int32): List[Option[Int32]] =
         region rc {

--- a/main/test/flix/Test.Handler.Gen.Float32.flix
+++ b/main/test/flix/Test.Handler.Gen.Float32.flix
@@ -5,7 +5,7 @@ mod Test.Handler.Gen.Float32 {
     }
 
     def generator(): Unit \ Gen =
-        Gen.gen(); generator()
+        discard Gen.gen(); generator()
 
     def sample(limit: Float32): List[Float32] =
         region rc {

--- a/main/test/flix/Test.Handler.Gen.Float64.flix
+++ b/main/test/flix/Test.Handler.Gen.Float64.flix
@@ -5,7 +5,7 @@ mod Test.Handler.Gen.Float64 {
     }
 
     def generator(): Unit \ Gen =
-        Gen.gen(); generator()
+        discard Gen.gen(); generator()
 
     def sample(limit: Float64): List[Float64] =
         region rc {

--- a/main/test/flix/Test.Handler.Gen.Int16.flix
+++ b/main/test/flix/Test.Handler.Gen.Int16.flix
@@ -5,7 +5,7 @@ mod Test.Handler.Gen.Int16 {
     }
 
     def generator(): Unit \ Gen =
-        Gen.gen(); generator()
+        discard Gen.gen(); generator()
 
     def sample(limit: Int16): List[Int16] =
         region rc {

--- a/main/test/flix/Test.Handler.Gen.Int32.flix
+++ b/main/test/flix/Test.Handler.Gen.Int32.flix
@@ -5,7 +5,7 @@ mod Test.Handler.Gen.Int32 {
     }
 
     def generator(): Unit \ Gen =
-        Gen.gen(); generator()
+        discard Gen.gen(); generator()
 
     def sample(limit: Int32): List[Int32] =
         region rc {

--- a/main/test/flix/Test.Handler.Gen.Int64.flix
+++ b/main/test/flix/Test.Handler.Gen.Int64.flix
@@ -5,7 +5,7 @@ mod Test.Handler.Gen.Int64 {
     }
 
     def generator(): Unit \ Gen =
-        Gen.gen(); generator()
+        discard Gen.gen(); generator()
 
     def sample(limit: Int64): List[Int64] =
         region rc {

--- a/main/test/flix/Test.Handler.Gen.Int8.flix
+++ b/main/test/flix/Test.Handler.Gen.Int8.flix
@@ -5,7 +5,7 @@ mod Test.Handler.Gen.Int8 {
     }
 
     def generator(): Unit \ Gen =
-        Gen.gen(); generator()
+        discard Gen.gen(); generator()
 
     def sample(limit: Int8): List[Int8] =
         region rc {

--- a/main/test/flix/Test.Handler.Gen.String.flix
+++ b/main/test/flix/Test.Handler.Gen.String.flix
@@ -5,7 +5,7 @@ mod Test.Handler.Gen.String {
     }
 
     def generator(): Unit \ Gen =
-        Gen.gen(); generator()
+        discard Gen.gen(); generator()
 
     def sample(limit: String): List[String] =
         region rc {

--- a/main/test/flix/Test.Handler.ZeroShot.AtomicInteger.flix
+++ b/main/test/flix/Test.Handler.ZeroShot.AtomicInteger.flix
@@ -25,7 +25,7 @@ mod Test.Handler.ZeroShot.AtomicInteger {
     @Test
     def testLinear02(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
         let result = run {
             f2()
         } with handler Exc {
@@ -36,8 +36,8 @@ mod Test.Handler.ZeroShot.AtomicInteger {
     @Test
     def testLinear03(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
-        def f3() = { f2(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
+        def f3() = { discard f2(); unreachable!() };
         let result = run {
             f3()
         } with handler Exc {
@@ -48,7 +48,7 @@ mod Test.Handler.ZeroShot.AtomicInteger {
     @Test
     def testRecursiveLetRec01(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(0)
         } with handler Exc {
@@ -59,7 +59,7 @@ mod Test.Handler.ZeroShot.AtomicInteger {
     @Test
     def testRecursiveLetRec02(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(1)
         } with handler Exc {
@@ -70,7 +70,7 @@ mod Test.Handler.ZeroShot.AtomicInteger {
     @Test
     def testRecursiveLetRec03(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(10)
         } with handler Exc {
@@ -133,13 +133,13 @@ mod Test.Handler.ZeroShot.AtomicInteger {
         Assert.eq(toInt(newAtomicInteger(40)), toInt(result))
 
     def f(): AtomicInteger \ Exc =
-         Exc.raise();
+         discard Exc.raise();
          unreachable!()
 
     def mutual1(x: Int32): AtomicInteger \ Exc =
-        if (x == 0) f() else { mutual2(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual2(x - 1); unreachable!() }
 
     def mutual2(x: Int32): AtomicInteger \ Exc =
-        if (x == 0) f() else { mutual1(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual1(x - 1); unreachable!() }
 
 }

--- a/main/test/flix/Test.Handler.ZeroShot.Bool.flix
+++ b/main/test/flix/Test.Handler.ZeroShot.Bool.flix
@@ -17,7 +17,7 @@ mod Test.Handler.ZeroShot.Bool {
     @Test
     def testLinear02(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
         let result = run {
             f2()
         } with handler Exc {
@@ -28,8 +28,8 @@ mod Test.Handler.ZeroShot.Bool {
     @Test
     def testLinear03(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
-        def f3() = { f2(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
+        def f3() = { discard f2(); unreachable!() };
         let result = run {
             f3()
         } with handler Exc {
@@ -40,7 +40,7 @@ mod Test.Handler.ZeroShot.Bool {
     @Test
     def testRecursiveLetRec01(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(0)
         } with handler Exc {
@@ -51,7 +51,7 @@ mod Test.Handler.ZeroShot.Bool {
     @Test
     def testRecursiveLetRec02(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(1)
         } with handler Exc {
@@ -62,7 +62,7 @@ mod Test.Handler.ZeroShot.Bool {
     @Test
     def testRecursiveLetRec03(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(10)
         } with handler Exc {
@@ -125,13 +125,13 @@ mod Test.Handler.ZeroShot.Bool {
         Assert.eq(false, result)
 
     def f(): Bool \ Exc =
-         Exc.raise();
+         discard Exc.raise();
          unreachable!()
 
     def mutual1(x: Int32): Bool \ Exc =
-        if (x == 0) f() else { mutual2(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual2(x - 1); unreachable!() }
 
     def mutual2(x: Int32): Bool \ Exc =
-        if (x == 0) f() else { mutual1(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual1(x - 1); unreachable!() }
 
 }

--- a/main/test/flix/Test.Handler.ZeroShot.Char.flix
+++ b/main/test/flix/Test.Handler.ZeroShot.Char.flix
@@ -17,7 +17,7 @@ mod Test.Handler.ZeroShot.Char {
     @Test
     def testLinear02(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
         let result = run {
             f2()
         } with handler Exc {
@@ -28,8 +28,8 @@ mod Test.Handler.ZeroShot.Char {
     @Test
     def testLinear03(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
-        def f3() = { f2(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
+        def f3() = { discard f2(); unreachable!() };
         let result = run {
             f3()
         } with handler Exc {
@@ -40,7 +40,7 @@ mod Test.Handler.ZeroShot.Char {
     @Test
     def testRecursiveLetRec01(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(0)
         } with handler Exc {
@@ -51,7 +51,7 @@ mod Test.Handler.ZeroShot.Char {
     @Test
     def testRecursiveLetRec02(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(1)
         } with handler Exc {
@@ -62,7 +62,7 @@ mod Test.Handler.ZeroShot.Char {
     @Test
     def testRecursiveLetRec03(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(10)
         } with handler Exc {
@@ -125,13 +125,13 @@ mod Test.Handler.ZeroShot.Char {
         Assert.eq('b', result)
 
     def f(): Char \ Exc =
-         Exc.raise();
+         discard Exc.raise();
          unreachable!()
 
     def mutual1(x: Int32): Char \ Exc =
-        if (x == 0) f() else { mutual2(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual2(x - 1); unreachable!() }
 
     def mutual2(x: Int32): Char \ Exc =
-        if (x == 0) f() else { mutual1(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual1(x - 1); unreachable!() }
 
 }

--- a/main/test/flix/Test.Handler.ZeroShot.Enum.flix
+++ b/main/test/flix/Test.Handler.ZeroShot.Enum.flix
@@ -17,7 +17,7 @@ mod Test.Handler.ZeroShot.Enum {
     @Test
     def testLinear02(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
         let result = run {
             f2()
         } with handler Exc {
@@ -28,8 +28,8 @@ mod Test.Handler.ZeroShot.Enum {
     @Test
     def testLinear03(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
-        def f3() = { f2(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
+        def f3() = { discard f2(); unreachable!() };
         let result = run {
             f3()
         } with handler Exc {
@@ -40,7 +40,7 @@ mod Test.Handler.ZeroShot.Enum {
     @Test
     def testRecursiveLetRec01(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(0)
         } with handler Exc {
@@ -51,7 +51,7 @@ mod Test.Handler.ZeroShot.Enum {
     @Test
     def testRecursiveLetRec02(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(1)
         } with handler Exc {
@@ -62,7 +62,7 @@ mod Test.Handler.ZeroShot.Enum {
     @Test
     def testRecursiveLetRec03(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(10)
         } with handler Exc {
@@ -125,13 +125,13 @@ mod Test.Handler.ZeroShot.Enum {
         Assert.eq(None, result)
 
     def f(): Option[Int32] \ Exc =
-         Exc.raise();
+         discard Exc.raise();
          unreachable!()
 
     def mutual1(x: Int32): Option[Int32] \ Exc =
-        if (x == 0) f() else { mutual2(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual2(x - 1); unreachable!() }
 
     def mutual2(x: Int32): Option[Int32] \ Exc =
-        if (x == 0) f() else { mutual1(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual1(x - 1); unreachable!() }
 
 }

--- a/main/test/flix/Test.Handler.ZeroShot.Float32.flix
+++ b/main/test/flix/Test.Handler.ZeroShot.Float32.flix
@@ -17,7 +17,7 @@ mod Test.Handler.ZeroShot.Float32 {
     @Test
     def testLinear02(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
         let result = run {
             f2()
         } with handler Exc {
@@ -28,8 +28,8 @@ mod Test.Handler.ZeroShot.Float32 {
     @Test
     def testLinear03(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
-        def f3() = { f2(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
+        def f3() = { discard f2(); unreachable!() };
         let result = run {
             f3()
         } with handler Exc {
@@ -40,7 +40,7 @@ mod Test.Handler.ZeroShot.Float32 {
     @Test
     def testRecursiveLetRec01(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(0)
         } with handler Exc {
@@ -51,7 +51,7 @@ mod Test.Handler.ZeroShot.Float32 {
     @Test
     def testRecursiveLetRec02(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(1)
         } with handler Exc {
@@ -62,7 +62,7 @@ mod Test.Handler.ZeroShot.Float32 {
     @Test
     def testRecursiveLetRec03(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(10)
         } with handler Exc {
@@ -125,13 +125,13 @@ mod Test.Handler.ZeroShot.Float32 {
         Assert.eq(40.0f32, result)
 
     def f(): Float32 \ Exc =
-         Exc.raise();
+         discard Exc.raise();
          unreachable!()
 
     def mutual1(x: Int32): Float32 \ Exc =
-        if (x == 0) f() else { mutual2(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual2(x - 1); unreachable!() }
 
     def mutual2(x: Int32): Float32 \ Exc =
-        if (x == 0) f() else { mutual1(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual1(x - 1); unreachable!() }
 
 }

--- a/main/test/flix/Test.Handler.ZeroShot.Float64.flix
+++ b/main/test/flix/Test.Handler.ZeroShot.Float64.flix
@@ -17,7 +17,7 @@ mod Test.Handler.ZeroShot.Float64 {
     @Test
     def testLinear02(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
         let result = run {
             f2()
         } with handler Exc {
@@ -28,8 +28,8 @@ mod Test.Handler.ZeroShot.Float64 {
     @Test
     def testLinear03(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
-        def f3() = { f2(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
+        def f3() = { discard f2(); unreachable!() };
         let result = run {
             f3()
         } with handler Exc {
@@ -40,7 +40,7 @@ mod Test.Handler.ZeroShot.Float64 {
     @Test
     def testRecursiveLetRec01(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(0)
         } with handler Exc {
@@ -51,7 +51,7 @@ mod Test.Handler.ZeroShot.Float64 {
     @Test
     def testRecursiveLetRec02(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(1)
         } with handler Exc {
@@ -62,7 +62,7 @@ mod Test.Handler.ZeroShot.Float64 {
     @Test
     def testRecursiveLetRec03(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(10)
         } with handler Exc {
@@ -125,13 +125,13 @@ mod Test.Handler.ZeroShot.Float64 {
         Assert.eq(40.0f64, result)
 
     def f(): Float64 \ Exc =
-         Exc.raise();
+         discard Exc.raise();
          unreachable!()
 
     def mutual1(x: Int32): Float64 \ Exc =
-        if (x == 0) f() else { mutual2(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual2(x - 1); unreachable!() }
 
     def mutual2(x: Int32): Float64 \ Exc =
-        if (x == 0) f() else { mutual1(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual1(x - 1); unreachable!() }
 
 }

--- a/main/test/flix/Test.Handler.ZeroShot.Int16.flix
+++ b/main/test/flix/Test.Handler.ZeroShot.Int16.flix
@@ -17,7 +17,7 @@ mod Test.Handler.ZeroShot.Int16 {
     @Test
     def testLinear02(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
         let result = run {
             f2()
         } with handler Exc {
@@ -28,8 +28,8 @@ mod Test.Handler.ZeroShot.Int16 {
     @Test
     def testLinear03(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
-        def f3() = { f2(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
+        def f3() = { discard f2(); unreachable!() };
         let result = run {
             f3()
         } with handler Exc {
@@ -40,7 +40,7 @@ mod Test.Handler.ZeroShot.Int16 {
     @Test
     def testRecursiveLetRec01(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(0)
         } with handler Exc {
@@ -51,7 +51,7 @@ mod Test.Handler.ZeroShot.Int16 {
     @Test
     def testRecursiveLetRec02(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(1)
         } with handler Exc {
@@ -62,7 +62,7 @@ mod Test.Handler.ZeroShot.Int16 {
     @Test
     def testRecursiveLetRec03(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(10)
         } with handler Exc {
@@ -116,13 +116,13 @@ mod Test.Handler.ZeroShot.Int16 {
         Assert.eq(42i16, result)
 
     def f(): Int16 \ Exc =
-         Exc.raise();
+         discard Exc.raise();
          unreachable!()
 
     def mutual1(x: Int32): Int16 \ Exc =
-        if (x == 0) f() else { mutual2(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual2(x - 1); unreachable!() }
 
     def mutual2(x: Int32): Int16 \ Exc =
-        if (x == 0) f() else { mutual1(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual1(x - 1); unreachable!() }
 
 }

--- a/main/test/flix/Test.Handler.ZeroShot.Int32.flix
+++ b/main/test/flix/Test.Handler.ZeroShot.Int32.flix
@@ -17,7 +17,7 @@ mod Test.Handler.ZeroShot.Int32 {
     @Test
     def testLinear02(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
         let result = run {
             f2()
         } with handler Exc {
@@ -28,8 +28,8 @@ mod Test.Handler.ZeroShot.Int32 {
     @Test
     def testLinear03(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
-        def f3() = { f2(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
+        def f3() = { discard f2(); unreachable!() };
         let result = run {
             f3()
         } with handler Exc {
@@ -40,7 +40,7 @@ mod Test.Handler.ZeroShot.Int32 {
     @Test
     def testRecursiveLetRec01(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(0)
         } with handler Exc {
@@ -51,7 +51,7 @@ mod Test.Handler.ZeroShot.Int32 {
     @Test
     def testRecursiveLetRec02(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(1)
         } with handler Exc {
@@ -62,7 +62,7 @@ mod Test.Handler.ZeroShot.Int32 {
     @Test
     def testRecursiveLetRec03(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(10)
         } with handler Exc {
@@ -116,13 +116,13 @@ mod Test.Handler.ZeroShot.Int32 {
         Assert.eq(42, result)
 
     def f(): Int32 \ Exc =
-         Exc.raise();
+         discard Exc.raise();
          unreachable!()
 
     def mutual1(x: Int32): Int32 \ Exc =
-        if (x == 0) f() else { mutual2(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual2(x - 1); unreachable!() }
 
     def mutual2(x: Int32): Int32 \ Exc =
-        if (x == 0) f() else { mutual1(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual1(x - 1); unreachable!() }
 
 }

--- a/main/test/flix/Test.Handler.ZeroShot.Int64.flix
+++ b/main/test/flix/Test.Handler.ZeroShot.Int64.flix
@@ -17,7 +17,7 @@ mod Test.Handler.ZeroShot.Int64 {
     @Test
     def testLinear02(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
         let result = run {
             f2()
         } with handler Exc {
@@ -28,8 +28,8 @@ mod Test.Handler.ZeroShot.Int64 {
     @Test
     def testLinear03(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
-        def f3() = { f2(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
+        def f3() = { discard f2(); unreachable!() };
         let result = run {
             f3()
         } with handler Exc {
@@ -40,7 +40,7 @@ mod Test.Handler.ZeroShot.Int64 {
     @Test
     def testRecursiveLetRec01(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(0)
         } with handler Exc {
@@ -51,7 +51,7 @@ mod Test.Handler.ZeroShot.Int64 {
     @Test
     def testRecursiveLetRec02(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(1)
         } with handler Exc {
@@ -62,7 +62,7 @@ mod Test.Handler.ZeroShot.Int64 {
     @Test
     def testRecursiveLetRec03(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(10)
         } with handler Exc {
@@ -116,13 +116,13 @@ mod Test.Handler.ZeroShot.Int64 {
         Assert.eq(42i64, result)
 
     def f(): Int64 \ Exc =
-         Exc.raise();
+         discard Exc.raise();
          unreachable!()
 
     def mutual1(x: Int32): Int64 \ Exc =
-        if (x == 0) f() else { mutual2(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual2(x - 1); unreachable!() }
 
     def mutual2(x: Int32): Int64 \ Exc =
-        if (x == 0) f() else { mutual1(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual1(x - 1); unreachable!() }
 
 }

--- a/main/test/flix/Test.Handler.ZeroShot.Int8.flix
+++ b/main/test/flix/Test.Handler.ZeroShot.Int8.flix
@@ -17,7 +17,7 @@ mod Test.Handler.ZeroShot.Int8 {
     @Test
     def testLinear02(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
         let result = run {
             f2()
         } with handler Exc {
@@ -28,8 +28,8 @@ mod Test.Handler.ZeroShot.Int8 {
     @Test
     def testLinear03(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
-        def f3() = { f2(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
+        def f3() = { discard f2(); unreachable!() };
         let result = run {
             f3()
         } with handler Exc {
@@ -40,7 +40,7 @@ mod Test.Handler.ZeroShot.Int8 {
     @Test
     def testRecursiveLetRec01(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(0)
         } with handler Exc {
@@ -51,7 +51,7 @@ mod Test.Handler.ZeroShot.Int8 {
     @Test
     def testRecursiveLetRec02(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(1)
         } with handler Exc {
@@ -62,7 +62,7 @@ mod Test.Handler.ZeroShot.Int8 {
     @Test
     def testRecursiveLetRec03(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(10)
         } with handler Exc {
@@ -116,13 +116,13 @@ mod Test.Handler.ZeroShot.Int8 {
         Assert.eq(42i8, result)
 
     def f(): Int8 \ Exc =
-         Exc.raise();
+         discard Exc.raise();
          unreachable!()
 
     def mutual1(x: Int32): Int8 \ Exc =
-        if (x == 0) f() else { mutual2(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual2(x - 1); unreachable!() }
 
     def mutual2(x: Int32): Int8 \ Exc =
-        if (x == 0) f() else { mutual1(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual1(x - 1); unreachable!() }
 
 }

--- a/main/test/flix/Test.Handler.ZeroShot.String.flix
+++ b/main/test/flix/Test.Handler.ZeroShot.String.flix
@@ -17,7 +17,7 @@ mod Test.Handler.ZeroShot.String {
     @Test
     def testLinear02(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
         let result = run {
             f2()
         } with handler Exc {
@@ -28,8 +28,8 @@ mod Test.Handler.ZeroShot.String {
     @Test
     def testLinear03(): Bool =
         def f1() = Exc.raise();
-        def f2() = { f1(); unreachable!() };
-        def f3() = { f2(); unreachable!() };
+        def f2() = { discard f1(); unreachable!() };
+        def f3() = { discard f2(); unreachable!() };
         let result = run {
             f3()
         } with handler Exc {
@@ -40,7 +40,7 @@ mod Test.Handler.ZeroShot.String {
     @Test
     def testRecursiveLetRec01(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(0)
         } with handler Exc {
@@ -51,7 +51,7 @@ mod Test.Handler.ZeroShot.String {
     @Test
     def testRecursiveLetRec02(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(1)
         } with handler Exc {
@@ -62,7 +62,7 @@ mod Test.Handler.ZeroShot.String {
     @Test
     def testRecursiveLetRec03(): Bool =
         def f() = Exc.raise();
-        def r(x) = if (x == 0) f() else { r(x - 1); unreachable!() } ;
+        def r(x) = if (x == 0) f() else { discard r(x - 1); unreachable!() } ;
         let result = run {
             r(10)
         } with handler Exc {
@@ -125,13 +125,13 @@ mod Test.Handler.ZeroShot.String {
         Assert.eq("b", result)
 
     def f(): String \ Exc =
-         Exc.raise();
+         discard Exc.raise();
          unreachable!()
 
     def mutual1(x: Int32): String \ Exc =
-        if (x == 0) f() else { mutual2(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual2(x - 1); unreachable!() }
 
     def mutual2(x: Int32): String \ Exc =
-        if (x == 0) f() else { mutual1(x - 1); unreachable!() }
+        if (x == 0) f() else { discard mutual1(x - 1); unreachable!() }
 
 }

--- a/main/test/flix/Test.Kind.Trait.flix
+++ b/main/test/flix/Test.Kind.Trait.flix
@@ -76,7 +76,7 @@ mod Test.Kind.Trait {
 
             mod Exp {
                 trait CStar1[a] {
-                    law star: forall(x: a) { (???: a); ??? }
+                    law star: forall(x: a) { let _: a = ???; ??? }
                 }
             }
         }
@@ -195,7 +195,7 @@ mod Test.Kind.Trait {
 
             mod Exp {
                 trait CStar1[a: Type] {
-                    law star: forall(x: a) { (???: a); ??? }
+                    law star: forall(x: a) { let _: a = ???; ??? }
                 }
             }
         }


### PR DESCRIPTION
1. You cannot know just from a given type whether it can be ignored - `@MustUse` is broken
2. The default is that you can ignore types - very contrary to Flix design
3. `@MustUse` doesn't work in general (e.g. cant write `def example(f: Unit -> t \ ef): Unit \ ef where t is not @MustUse`)
4. The price to require Unit for statement is very low (just write `discard e`)
  a. `discard` is mostly used for java methods - Flix code generally avoids  such patterns
  b. The standard library only needed 21 discards, 20 of them java related.
5. Requiring Unit for statement position finds bug (already 1 bug found in this PR)
  a. This adheres to Flix's general safety vibe

Previous PR attempt: #9709