### PR TITLE
fix: string interpolation after double backslash

### DIFF
--- a/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestParser.scala
@@ -845,6 +845,12 @@ class TestParserHappy extends AnyFunSuite with TestUtils {
     expectError[LexerError](result)
   }
 
+  test("ParseError.Interpolation.03") {
+    val input = """pub def foo(): String = "\\${""""
+    val result = compile(input, Options.TestWithLibNix)
+    expectError[LexerError](result)
+  }
+
   test("ParseError.EnumCase.01") {
     val input =
       """

--- a/main/test/flix/Test.Exp.Interpolation.flix
+++ b/main/test/flix/Test.Exp.Interpolation.flix
@@ -196,6 +196,14 @@ mod Test.Exp.Interpolation {
         "\"${x}\"" == "\"abc\""
 
     @test
+    def interpolation37(): Bool =
+        "\${" == String.concat("$", "{")
+
+    @test
+    def interpolation38(): Bool =
+        "\\\${" == String.concat("\\$", "{")
+
+    @test
     def interpolationDebug01(): Bool =
         "%{123}" == "123"
 
@@ -206,6 +214,15 @@ mod Test.Exp.Interpolation {
 
     @test
     def interpolationDebug03(): Bool =
+        let x = "123";
+        "\\%{x}" == "\\\"123\""
+
+    @test
+    def interpolationDebug04(): Bool =
+        "\%{x}" == String.concat("%", "{x}")
+
+    @test
+    def interpolationDebug05(): Bool =
         let x = EnumSansToString.CaseSansToString(123);
         "my object is %{x}" == "my object is CaseSansToString(123)"
 


### PR DESCRIPTION
```
flix> "${10+2}"
12                                                                              
flix> "\${10+2}"
${10+2}                                                                         
flix> "\\${10+2}"
\12                                                                             
flix> "\\\%{10+2}"
\%{10+2}                                                                        
flix> "\\\\%{10+2}"
\\12                                                                            
```

Fixes #10215