### PR TITLE
refactor: n-ary closure applications in front-end

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/Visitor.scala
@@ -299,9 +299,9 @@ object Visitor {
         visitFormalParam(fparam)
         visitExpr(exp)
 
-      case Expr.ApplyClo(exp1, exp2, _, _, _) =>
-        visitExpr(exp1)
-        visitExpr(exp2)
+      case Expr.ApplyClo(exp, exps, _, _, _, _) =>
+        visitExpr(exp)
+        exps.foreach(visitExpr)
 
       case Expr.ApplyDef(symUse, exps, _, _, _, _) =>
         visitDefSymUse(symUse)

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/SemanticTokensProvider.scala
@@ -421,8 +421,10 @@ object SemanticTokensProvider {
     case Expr.Lambda(fparam, exp, _, _) =>
       visitFormalParam(fparam) ++ visitExp(exp)
 
-    case Expr.ApplyClo(exp1, exp2, _, _, _) =>
-      visitExp(exp1) ++ visitExp(exp2)
+    case Expr.ApplyClo(exp, exps, _, _, _, _) =>
+      exps.foldLeft(visitExp(exp)) {
+        case (acc, exp1) => acc ++ visitExp(exp1)
+      }
 
     case Expr.ApplyDef(DefSymUse(sym, loc), exps, _, _, _, _) =>
       val o = if (isOperatorName(sym.name)) SemanticTokenType.Operator else SemanticTokenType.Function

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -19,6 +19,7 @@ package ca.uwaterloo.flix.language.ast
 import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.*
+import ca.uwaterloo.flix.util.InternalCompilerException
 import ca.uwaterloo.flix.util.collection.ListMap
 
 import java.lang.reflect.Field
@@ -86,7 +87,10 @@ object KindedAst {
     case class Cst(cst: Constant, loc: SourceLocation) extends Expr
 
     /** `exps` and `evars` have the same, non-zero length. */
-    case class ApplyClo(exp: Expr, exps: List[Expr], evars: List[Type.Var], tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    case class ApplyClo(exp: Expr, exps: List[Expr], evars: List[Type.Var], tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr {
+      if (exps.sizeIs != evars.size) throw InternalCompilerException("Inconsistent apply closure arity", loc)
+      else if (exps.isEmpty) throw InternalCompilerException("Unexpected empty closure apply", loc)
+    }
 
     case class ApplyDef(symUse: DefSymUse, exps: List[Expr], itvar: Type, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/KindedAst.scala
@@ -85,7 +85,8 @@ object KindedAst {
 
     case class Cst(cst: Constant, loc: SourceLocation) extends Expr
 
-    case class ApplyClo(exp1: Expr, exp2: Expr, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
+    /** `exps` and `evars` have the same, non-zero length. */
+    case class ApplyClo(exp: Expr, exps: List[Expr], evars: List[Type.Var], tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 
     case class ApplyDef(symUse: DefSymUse, exps: List[Expr], itvar: Type, tvar: Type.Var, evar: Type.Var, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -101,7 +101,8 @@ object ResolvedAst {
 
     case class Cst(cst: Constant, loc: SourceLocation) extends Expr
 
-    case class ApplyClo(exp1: Expr, exp2: Expr, loc: SourceLocation) extends Expr
+    /** `exps` must be non-empty. */
+    case class ApplyClo(exp: Expr, exps: List[Expr], loc: SourceLocation) extends Expr
 
     case class ApplyDef(symUse: DefSymUse, exps: List[Expr], loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -19,6 +19,7 @@ package ca.uwaterloo.flix.language.ast
 import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.*
+import ca.uwaterloo.flix.util.InternalCompilerException
 import ca.uwaterloo.flix.util.collection.ListMap
 
 import java.lang.reflect.Field
@@ -102,7 +103,9 @@ object ResolvedAst {
     case class Cst(cst: Constant, loc: SourceLocation) extends Expr
 
     /** `exps` is non-empty. */
-    case class ApplyClo(exp: Expr, exps: List[Expr], loc: SourceLocation) extends Expr
+    case class ApplyClo(exp: Expr, exps: List[Expr], loc: SourceLocation) extends Expr {
+      if (exps.isEmpty) throw InternalCompilerException("Unexpected empty closure args", loc)
+    }
 
     case class ApplyDef(symUse: DefSymUse, exps: List[Expr], loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ResolvedAst.scala
@@ -101,7 +101,7 @@ object ResolvedAst {
 
     case class Cst(cst: Constant, loc: SourceLocation) extends Expr
 
-    /** `exps` must be non-empty. */
+    /** `exps` is non-empty. */
     case class ApplyClo(exp: Expr, exps: List[Expr], loc: SourceLocation) extends Expr
 
     case class ApplyDef(symUse: DefSymUse, exps: List[Expr], loc: SourceLocation) extends Expr

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -121,7 +121,7 @@ object TypedAst {
       def eff: Type = Type.Pure
     }
 
-    /** `exps` and `evars` have the same, non-zero length. */
+    /** `exps` and `argEffs` have the same, non-zero length. */
     case class ApplyClo(exp: Expr, exps: List[Expr], argEffs: List[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr {
       if (exps.sizeIs != argEffs.size) throw InternalCompilerException("Inconsistent apply closure arity", loc)
       else if (exps.isEmpty) throw InternalCompilerException("Unexpected empty closure apply", loc)

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -20,6 +20,7 @@ import ca.uwaterloo.flix.language.CompilationMessage
 import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.language.ast.shared.SymUse.*
 import ca.uwaterloo.flix.language.phase.unification.{EqualityEnv, TraitEnv}
+import ca.uwaterloo.flix.util.InternalCompilerException
 import ca.uwaterloo.flix.util.collection.ListMap
 
 import java.lang.reflect.{Constructor, Field, Method}
@@ -121,7 +122,10 @@ object TypedAst {
     }
 
     /** `exps` and `evars` have the same, non-zero length. */
-    case class ApplyClo(exp: Expr, exps: List[Expr], argEffs: List[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    case class ApplyClo(exp: Expr, exps: List[Expr], argEffs: List[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr {
+      if (exps.sizeIs != argEffs.size) throw InternalCompilerException("Inconsistent apply closure arity", loc)
+      else if (exps.isEmpty) throw InternalCompilerException("Unexpected empty closure apply", loc)
+    }
 
     case class ApplyDef(symUse: DefSymUse, exps: List[Expr], itpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -120,7 +120,7 @@ object TypedAst {
       def eff: Type = Type.Pure
     }
 
-    /** `exps` must be non-empty and `argEffs` has the same size as `exps`. */
+    /** `exps` and `evars` have the same, non-zero length. */
     case class ApplyClo(exp: Expr, exps: List[Expr], argEffs: List[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class ApplyDef(symUse: DefSymUse, exps: List[Expr], itpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Expr

--- a/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TypedAst.scala
@@ -120,7 +120,8 @@ object TypedAst {
       def eff: Type = Type.Pure
     }
 
-    case class ApplyClo(exp1: Expr, exp2: Expr, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
+    /** `exps` must be non-empty and `argEffs` has the same size as `exps`. */
+    case class ApplyClo(exp: Expr, exps: List[Expr], argEffs: List[Type], tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 
     case class ApplyDef(symUse: DefSymUse, exps: List[Expr], itpe: Type, tpe: Type, eff: Type, loc: SourceLocation) extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
@@ -45,7 +45,7 @@ object TypedAstOps {
     case Expr.OpenAs(_, exp, _, _) => sigSymsOf(exp)
     case Expr.Use(_, _, exp, _) => sigSymsOf(exp)
     case Expr.Lambda(_, exp, _, _) => sigSymsOf(exp)
-    case Expr.ApplyClo(exp, exps, _, _, _, _) => exps.flatMap(sigSymsOf).toSet ++ sigSymsOf(exp)
+    case Expr.ApplyClo(exp, exps, _, _, _, _) => sigSymsOf(exp) ++ exps.flatMap(sigSymsOf)
     case Expr.ApplyDef(_, exps, _, _, _, _) => exps.flatMap(sigSymsOf).toSet
     case Expr.ApplyLocalDef(_, exps, _, _, _, _) => exps.flatMap(sigSymsOf).toSet
     case Expr.ApplySig(SigSymUse(sym, _), exps, _, _, _, _) => exps.flatMap(sigSymsOf).toSet + sym

--- a/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/ops/TypedAstOps.scala
@@ -45,7 +45,7 @@ object TypedAstOps {
     case Expr.OpenAs(_, exp, _, _) => sigSymsOf(exp)
     case Expr.Use(_, _, exp, _) => sigSymsOf(exp)
     case Expr.Lambda(_, exp, _, _) => sigSymsOf(exp)
-    case Expr.ApplyClo(exp1, exp2, _, _, _) => sigSymsOf(exp1) ++ sigSymsOf(exp2)
+    case Expr.ApplyClo(exp, exps, _, _, _, _) => exps.flatMap(sigSymsOf).toSet ++ sigSymsOf(exp)
     case Expr.ApplyDef(_, exps, _, _, _, _) => exps.flatMap(sigSymsOf).toSet
     case Expr.ApplyLocalDef(_, exps, _, _, _, _) => exps.flatMap(sigSymsOf).toSet
     case Expr.ApplySig(SigSymUse(sym, _), exps, _, _, _, _) => exps.flatMap(sigSymsOf).toSet + sym
@@ -147,8 +147,10 @@ object TypedAstOps {
     case Expr.Lambda(fparam, exp, _, _) =>
       freeVars(exp) - fparam.bnd.sym
 
-    case Expr.ApplyClo(exp1, exp2, _, _, _) =>
-      freeVars(exp1) ++ freeVars(exp2)
+    case Expr.ApplyClo(exp, exps, _, _, _, _) =>
+      exps.foldLeft(freeVars(exp)) {
+        case (acc, e) => freeVars(e) ++ acc
+      }
 
     case Expr.ApplyDef(_, exps, _, _, _, _) =>
       exps.foldLeft(Map.empty[Symbol.VarSym, Type]) {

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/ResolvedAstPrinter.scala
@@ -49,7 +49,7 @@ object ResolvedAstPrinter {
     case Expr.OpenAs(_, _, _) => DocAst.Expr.Unknown
     case Expr.Use(_, _, _, _) => DocAst.Expr.Unknown
     case Expr.Cst(cst, _) => ConstantPrinter.print(cst)
-    case Expr.ApplyClo(exp1, exp2, _) => DocAst.Expr.App(print(exp1), List(print(exp2)))
+    case Expr.ApplyClo(exp, exps, _) => DocAst.Expr.App(print(exp), exps.map(print))
     case Expr.ApplyDef(DefSymUse(sym, _), exps, _) => DocAst.Expr.ApplyDef(sym, exps.map(print))
     case Expr.ApplyLocalDef(LocalDefSymUse(sym, _), exps, _) => DocAst.Expr.App(printVarSym(sym), exps.map(print))
     case Expr.ApplySig(SigSymUse(sym, _), exps, _) => DocAst.Expr.App(DocAst.Expr.AsIs(sym.name), exps.map(print))

--- a/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
+++ b/main/src/ca/uwaterloo/flix/language/dbg/printer/TypedAstPrinter.scala
@@ -34,7 +34,7 @@ object TypedAstPrinter {
     case Expr.OpenAs(_, _, _, _) => DocAst.Expr.Unknown
     case Expr.Use(_, _, _, _) => DocAst.Expr.Unknown
     case Expr.Lambda(fparam, exp, _, _) => DocAst.Expr.Lambda(List(printFormalParam(fparam)), print(exp))
-    case Expr.ApplyClo(exp1, exp2, _, _, _) => DocAst.Expr.App(print(exp1), List(print(exp2)))
+    case Expr.ApplyClo(exp, exps, _, _, _, _) => DocAst.Expr.App(print(exp), exps.map(print))
     case Expr.ApplyDef(DefSymUse(sym, _), exps, _, _, _, _) => DocAst.Expr.ApplyDef(sym, exps.map(print))
     case Expr.ApplyLocalDef(LocalDefSymUse(sym, _), exps, _, _, _, _) => DocAst.Expr.App(DocAst.Expr.Var(sym), exps.map(print))
     case Expr.ApplySig(SigSymUse(sym, _), exps, _, _, _, _) => DocAst.Expr.App(DocAst.Expr.AsIs(sym.name), exps.map(print))

--- a/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Dependencies.scala
@@ -138,9 +138,9 @@ object Dependencies {
       visitExp(exp)
       visitType(tpe)
 
-    case Expr.ApplyClo(exp1, exp2, tpe, eff, _) =>
-      visitExp(exp1)
-      visitExp(exp2)
+    case Expr.ApplyClo(exp, exps, _, tpe, eff, _) =>
+      visitExp(exp)
+      exps.foreach(visitExp)
       visitType(tpe)
       visitType(eff)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Deriver.scala
@@ -326,14 +326,16 @@ object Deriver {
           List(
             KindedAst.Expr.ApplyClo(
               mkVarExpr(lambdaSym, loc),
-              mkVarExpr(param1, loc),
+              List(mkVarExpr(param1, loc)),
+              List(Type.freshVar(Kind.Eff, loc)),
               Type.freshVar(Kind.Star, loc),
               Type.freshVar(Kind.Eff, loc),
               loc
             ),
             KindedAst.Expr.ApplyClo(
               mkVarExpr(lambdaSym, loc),
-              mkVarExpr(param2, loc),
+              List(mkVarExpr(param2, loc)),
+              List(Type.freshVar(Kind.Eff, loc)),
               Type.freshVar(Kind.Star, loc),
               Type.freshVar(Kind.Eff, loc),
               loc),

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
@@ -90,7 +90,12 @@ object EffectVerifier {
     case Expr.ApplyClo(exp, exps, argEffs, tpe, eff, loc) =>
       visitExp(exp)
       exps.foreach(visitExp)
-      // TODO ?
+      val funType = exps.zip(argEffs).foldRight(tpe){
+        case ((arg, argEff), acc) => Type.mkArrowWithEffect(arg.tpe, argEff, acc, loc)
+      }
+      expectType(funType, exp.tpe, loc)
+      expectType(Type.mkUnion(exp.eff :: exps.map(_.eff) ::: argEffs, loc), eff, loc)
+
     case Expr.ApplyDef(_, exps, itpe, _, eff, loc) =>
       exps.foreach(visitExp)
       val expected = Type.mkUnion(Type.eraseTopAliases(itpe).arrowEffectType :: exps.map(_.eff), loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EffectVerifier.scala
@@ -87,12 +87,10 @@ object EffectVerifier {
       visitExp(exp)
     case Expr.Lambda(fparam, exp, tpe, loc) =>
       visitExp(exp)
-    case Expr.ApplyClo(exp1, exp2, tpe, eff, loc) =>
-      visitExp(exp1)
-      visitExp(exp2)
-      val expected = Type.mkUnion(Type.eraseTopAliases(exp1.tpe).arrowEffectType :: exp1.eff :: exp2.eff :: Nil, loc)
-      val actual = eff
-      expectType(expected, actual, loc)
+    case Expr.ApplyClo(exp, exps, argEffs, tpe, eff, loc) =>
+      visitExp(exp)
+      exps.foreach(visitExp)
+      // TODO ?
     case Expr.ApplyDef(_, exps, itpe, _, eff, loc) =>
       exps.foreach(visitExp)
       val expected = Type.mkUnion(Type.eraseTopAliases(itpe).arrowEffectType :: exps.map(_.eff), loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Kinder.scala
@@ -357,12 +357,13 @@ object Kinder {
     case ResolvedAst.Expr.Cst(cst, loc) =>
       KindedAst.Expr.Cst(cst, loc)
 
-    case ResolvedAst.Expr.ApplyClo(exp10, exp20, loc) =>
-      val exp1 = visitExp(exp10, kenv0, taenv, root)
-      val exp2 = visitExp(exp20, kenv0, taenv, root)
+    case ResolvedAst.Expr.ApplyClo(exp0, exps0, loc) =>
+      val exp1 = visitExp(exp0, kenv0, taenv, root)
+      val exps1 = exps0.map(visitExp(_, kenv0, taenv, root))
       val tvar = Type.freshVar(Kind.Star, loc.asSynthetic)
+      val evars = exps1.map(_ => Type.freshVar(Kind.Eff, loc.asSynthetic))
       val evar = Type.freshVar(Kind.Eff, loc.asSynthetic)
-      KindedAst.Expr.ApplyClo(exp1, exp2, tvar, evar, loc)
+      KindedAst.Expr.ApplyClo(exp1, exps1, evars, tvar, evar, loc)
 
     case ResolvedAst.Expr.ApplyDef(DefSymUse(sym, loc1), exps0, loc2) =>
       val exps = exps0.map(visitExp(_, kenv0, taenv, root))

--- a/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Lowering.scala
@@ -382,7 +382,7 @@ object Lowering {
       val (applies, _) = es.foldLeft((e, funType)){
         case ((f, Type.Apply(Type.Apply(Type.Apply(Type.Cst(TypeConstructor.Arrow(2), _), argEff, _), _argT, _), next, _)), arg) =>
           (
-            LoweredAst.Expr.ApplyClo(f, arg, next, Type.mkUnion(argEff, arg.eff, loc.asSynthetic), loc.asSynthetic),
+            LoweredAst.Expr.ApplyClo(f, arg, next, Type.mkUnion(f.eff, argEff, arg.eff, loc.asSynthetic), loc.asSynthetic),
             next
           )
         case ((_, tpe), _) => throw InternalCompilerException(s"Unexpected type: $tpe", loc)

--- a/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PatMatch.scala
@@ -132,9 +132,9 @@ object PatMatch {
 
       case Expr.Lambda(_, body, _, _) => visitExp(body)
 
-      case Expr.ApplyClo(exp1, exp2, _, _, _) =>
-        visitExp(exp1)
-        visitExp(exp2)
+      case Expr.ApplyClo(exp, exps, _, _, _, _) =>
+        visitExp(exp)
+        exps.foreach(visitExp)
 
       case Expr.ApplyDef(_, exps, _, _, _, _) => exps.foreach(visitExp)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/PredDeps.scala
@@ -112,9 +112,9 @@ object PredDeps {
     case Expr.Lambda(_, exp, _, _) =>
       visitExp(exp)
 
-    case Expr.ApplyClo(exp1, exp2, _, _, _) =>
-      visitExp(exp1)
-      visitExp(exp2)
+    case Expr.ApplyClo(exp, exps, _, _, _, _) =>
+      visitExp(exp)
+      exps.foreach(visitExp)
 
     case Expr.ApplyDef(_, exps, _, _, _, _) =>
       exps.foreach(visitExp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Redundancy.scala
@@ -337,9 +337,9 @@ object Redundancy {
       else
         innerUsed ++ shadowedVar - fparam.bnd.sym
 
-    case Expr.ApplyClo(exp1, exp2, _, _, _) =>
-      val us1 = visitExp(exp1, env0, rc)
-      val us2 = visitExp(exp2, env0, rc)
+    case Expr.ApplyClo(exp, exps, _, _, _, _) =>
+      val us1 = visitExp(exp, env0, rc)
+      val us2 = visitExps(exps, env0, rc)
       us1 ++ us2
 
     case Expr.ApplyDef(DefSymUse(sym, _), exps, _, _, _, _) =>

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1570,9 +1570,8 @@ object Resolver {
         else (mkPureLambda(fp, acc, loc.asSynthetic), false)
     }
 
-    val closureApplication = ResolvedAst.Expr.ApplyClo(fullDefLambda, cloArgs, loc)
-
-    closureApplication
+    if (cloArgs.isEmpty) fullDefLambda
+    else ResolvedAst.Expr.ApplyClo(fullDefLambda, cloArgs, loc)
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Resolver.scala
@@ -1528,10 +1528,7 @@ object Resolver {
       val expVal = resolveExp(exp0, scp0)
       val expsVal = traverse(exps0)(resolveExp(_, scp0))
       mapN(expVal, expsVal) {
-        case (e, es) =>
-          es.foldLeft(e) {
-            case (acc, a) => ResolvedAst.Expr.ApplyClo(acc, a, loc.asSynthetic)
-          }
+        case (e, es) => ResolvedAst.Expr.ApplyClo(e, es, loc.asSynthetic)
       }
   }
 
@@ -1542,10 +1539,7 @@ object Resolver {
     val expsVal = traverse(exps)(resolveExp(_, scp0))
     val exp: ResolvedAst.Expr = ResolvedAst.Expr.Error(err)
     mapN(expsVal) {
-      case es =>
-        es.foldLeft(exp) {
-          case (acc, a) => ResolvedAst.Expr.ApplyClo(acc, a, loc.asSynthetic)
-        }
+      case es => ResolvedAst.Expr.ApplyClo(exp, es, loc.asSynthetic)
     }
   }
 
@@ -1576,9 +1570,7 @@ object Resolver {
         else (mkPureLambda(fp, acc, loc.asSynthetic), false)
     }
 
-    val closureApplication = cloArgs.foldLeft(fullDefLambda) {
-      case (acc, cloArg) => ResolvedAst.Expr.ApplyClo(acc, cloArg, loc)
-    }
+    val closureApplication = ResolvedAst.Expr.ApplyClo(fullDefLambda, cloArgs, loc)
 
     closureApplication
   }

--- a/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Safety.scala
@@ -96,9 +96,9 @@ object Safety {
       // `exp` will be in its own function, so `inTryCatch` is reset.
       visitExp(exp)(inTryCatch = false, renv, sctx, flix)
 
-    case Expr.ApplyClo(exp1, exp2, _, _, _) =>
-      visitExp(exp1)
-      visitExp(exp2)
+    case Expr.ApplyClo(exp, exps, _, _, _, _) =>
+      visitExp(exp)
+      exps.foreach(visitExp)
 
     case Expr.ApplyDef(_, exps, _, _, _, _) =>
       exps.foreach(visitExp)

--- a/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Stratifier.scala
@@ -121,10 +121,10 @@ object Stratifier {
       val e = visitExp(exp)
       Expr.Lambda(fparam, e, tpe, loc)
 
-    case Expr.ApplyClo(exp1, exp2, tpe, eff, loc) =>
-      val e1 = visitExp(exp1)
-      val e2 = visitExp(exp2)
-      Expr.ApplyClo(e1, e2, tpe, eff, loc)
+    case Expr.ApplyClo(exp, exps, argEffs, tpe, eff, loc) =>
+      val e = visitExp(exp)
+      val es = exps.map(visitExp)
+      Expr.ApplyClo(e, es, argEffs, tpe, eff, loc)
 
     case Expr.ApplyDef(symUse, exps, itpe, tpe, eff, loc) =>
       val es = exps.map(visitExp)

--- a/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/TypeReconstruction.scala
@@ -110,10 +110,10 @@ object TypeReconstruction {
 
     case KindedAst.Expr.Cst(cst, loc) => TypedAst.Expr.Cst(cst, Type.constantType(cst), loc)
 
-    case KindedAst.Expr.ApplyClo(exp1, exp2, tvar, evar, loc) =>
-      val e1 = visitExp(exp1)
-      val e2 = visitExp(exp2)
-      TypedAst.Expr.ApplyClo(e1, e2, subst(tvar), subst(evar), loc)
+    case KindedAst.Expr.ApplyClo(exp, exps, evars, tvar, evar, loc) =>
+      val e = visitExp(exp)
+      val es = exps.map(visitExp)
+      TypedAst.Expr.ApplyClo(e, es, evars.map(subst.apply), subst(tvar), subst(evar), loc)
 
     case KindedAst.Expr.ApplyDef(symUse, exps, itvar, tvar, evar, loc) =>
       val es = exps.map(visitExp)

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -82,14 +82,12 @@ object ConstraintGen {
         // e: (t1 -> (t2 -> (.. -> t \ efFreshN) \ efFresh2) \ efFresh1) \ ef
         // ----------------------------------------------
         // e(e1, e2, ..) : t \ ef ∪ ef1 ∪ efFresh1 ∪ ef2 ∪ efFresh2 ∪ ...
-        val lambdaBodyType = freshVar(Kind.Star, loc)
         val (tpe1, eff1) = visitExp(exp)
         val (tpes, effs) = exps.map(visitExp).unzip
-        val expectedType = tpes.zip(evars).foldRight(lambdaBodyType: Type){
+        val expectedType = tpes.zip(evars).foldRight(tvar: Type){
           case ((arg, argEf), t) => Type.mkArrowWithEffect(arg, argEf, t, loc)
         }
         c.expectType(expectedType, tpe1, loc)
-        c.unifyType(tvar, lambdaBodyType, loc)
         c.unifyType(evar,  Type.mkUnion(eff1 :: effs ::: evars, loc), loc)
         val resTpe = tvar
         val resEff = evar

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -82,6 +82,7 @@ object ConstraintGen {
         // e: (t1 -> (t2 -> (.. -> t \ efFreshN) \ efFresh2) \ efFresh1) \ ef
         // ----------------------------------------------
         // e(e1, e2, ..) : t \ ef ∪ ef1 ∪ efFresh1 ∪ ef2 ∪ efFresh2 ∪ ...
+        //
         val (tpe1, eff1) = visitExp(exp)
         val (tpes, effs) = exps.map(visitExp).unzip
         val expectedType = tpes.zip(evars).foldRight(tvar: Type){

--- a/main/src/ca/uwaterloo/flix/tools/Summary.scala
+++ b/main/src/ca/uwaterloo/flix/tools/Summary.scala
@@ -193,7 +193,7 @@ object Summary {
     case Expr.OpenAs(_, exp, _, _) => countCheckedEcasts(exp)
     case Expr.Use(_, _, exp, _) => countCheckedEcasts(exp)
     case Expr.Lambda(_, exp, _, _) => countCheckedEcasts(exp)
-    case Expr.ApplyClo(exp1, exp2, _, _, _) => List(exp1, exp2).map(countCheckedEcasts).sum
+    case Expr.ApplyClo(exp, exps, _, _, _, _) => (exp :: exps).map(countCheckedEcasts).sum
     case Expr.ApplyDef(_, exps, _, _, _, _) => exps.map(countCheckedEcasts).sum
     case Expr.ApplyLocalDef(_, exps, _, _, _, _) => exps.map(countCheckedEcasts).sum
     case Expr.ApplySig(_, exps, _, _, _, _) => exps.map(countCheckedEcasts).sum

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -913,21 +913,4 @@ class TestSafety extends AnyFunSuite with TestUtils {
     expectError[IllegalMethodEffect](result)
   }
 
-  test("IllegalSpawnEffect.01") {
-    val input =
-      """
-        |eff Ask {
-        |    pub def ask(): String
-        |}
-        |
-        |def main(): Unit \ IO =
-        |    region rc {
-        |        spawn Ask.ask() @ rc
-        |    }
-        |
-      """.stripMargin
-    val result = compile(input, Options.DefaultTest)
-    expectError[IllegalSpawnEffect](result)
-  }
-
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -913,4 +913,21 @@ class TestSafety extends AnyFunSuite with TestUtils {
     expectError[IllegalMethodEffect](result)
   }
 
+  test("IllegalSpawnEffect.01") {
+    val input =
+      """
+        |eff Ask {
+        |    pub def ask(): String
+        |}
+        |
+        |def main(): Unit \ IO =
+        |    region rc {
+        |        spawn Ask.ask() @ rc
+        |    }
+        |
+        """.stripMargin
+    val result = compile(input, Options.DefaultTest)
+    expectError[IllegalSpawnEffect](result)
+  }
+
 }

--- a/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
+++ b/main/test/ca/uwaterloo/flix/language/phase/TestSafety.scala
@@ -925,7 +925,7 @@ class TestSafety extends AnyFunSuite with TestUtils {
         |        spawn Ask.ask() @ rc
         |    }
         |
-        """.stripMargin
+      """.stripMargin
     val result = compile(input, Options.DefaultTest)
     expectError[IllegalSpawnEffect](result)
   }


### PR DESCRIPTION
The desugaring of `f(x, y)` to `f(x)(y)` is now postponed to `Lowering`

Part of #10220

- [X] implement
- [X] Perf run
- [x] effect verifier
- [ ] Design choice on `exps` and `argEffs` (`List[a], List[b]` vs `Nel[(a,  b)]`)

```
Xperf --frontend --n 11

PR:
~~~~ Flix Compiler Performance ~~~~

Throughput (best): 32.576 lines/sec (with 8 threads.)

  min: 26.328, max: 32.576, avg: 29.526, median: 29.923

Finished 11 iterations on 66.620 lines of code in 24 seconds.


MASTER:
~~~~ Flix Compiler Performance ~~~~

Throughput (best): 32.878 lines/sec (with 8 threads.)

  min: 26.707, max: 32.878, avg: 29.644, median: 29.339

Finished 11 iterations on 66.620 lines of code in 24 seconds.
```