### PR TITLE
feat: new completion invariant: no completion inside comment

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Token.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Token.scala
@@ -15,6 +15,7 @@
  */
 package ca.uwaterloo.flix.language.ast
 
+import ca.uwaterloo.flix.api.lsp.Position
 import ca.uwaterloo.flix.language.ast.shared.Source
 
 /**
@@ -48,6 +49,14 @@ case class Token(kind: TokenKind, src: Source, start: Int, end: Int, sp1: Source
     * NB: Tokens are zero-indexed
     */
   def mkSourceLocation(isReal: Boolean = true): SourceLocation = SourceLocation(isReal, sp1, sp2)
+
+  def offset(steps: Int): Position = {
+    val text = src.data.slice(start, end).mkString("")
+    val (line, col) = (0 until steps).foldLeft((sp1.line, sp1.col.toInt)) { case ((line, col), char) =>
+      if (text(char) == '\n') (line + 1, 1) else (line, col + 1)
+    }
+    Position(line, col)
+  }
 
   /**
     * Returns a one-indexed string representation of this token. Must only be used for debugging.

--- a/main/src/ca/uwaterloo/flix/language/ast/Token.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Token.scala
@@ -15,7 +15,6 @@
  */
 package ca.uwaterloo.flix.language.ast
 
-import ca.uwaterloo.flix.api.lsp.Position
 import ca.uwaterloo.flix.language.ast.shared.Source
 
 /**
@@ -49,14 +48,6 @@ case class Token(kind: TokenKind, src: Source, start: Int, end: Int, sp1: Source
     * NB: Tokens are zero-indexed
     */
   def mkSourceLocation(isReal: Boolean = true): SourceLocation = SourceLocation(isReal, sp1, sp2)
-
-  def offset(steps: Int): Position = {
-    val text = src.data.slice(start, end).mkString("")
-    val (line, col) = (0 until steps).foldLeft((sp1.line, sp1.col.toInt)) { case ((line, col), char) =>
-      if (text(char) == '\n') (line + 1, 1) else (line, col + 1)
-    }
-    Position(line, col)
-  }
 
   /**
     * Returns a one-indexed string representation of this token. Must only be used for debugging.

--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -229,7 +229,7 @@ class TestCompletionProvider extends AnyFunSuite {
       // Sort the replacements by column in descending order, otherwise former replacements will affect the latter ones
 
       val newProgram = keywordTokens
-        .map(token => (token, randomlyDelete(token.text, Set('\t', '\n', '\r'))))
+        .map(token => (token, randomlyDelete(token.text, Set('/', '*', '\t', '\n', '\r'))))
         // Sort the replacements by column in descending order, otherwise former replacements will affect the latter ones
         .sortBy(-_._1.start)
         .foldLeft(program) { case (currentProg, (token, incomplete)) =>

--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -273,6 +273,8 @@ class TestCompletionProvider extends AnyFunSuite {
     * - d|ef
     * - de|f
     * - def|
+    *
+    * If the token spans multiple lines, we will return all the positions in all the lines, both sides inclusive.
     */
   private def getAllPositionsWithinToken(token: Token): List[Position] = {
     val initialLine = token.sp1.line

--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -295,11 +295,4 @@ class TestCompletionProvider extends AnyFunSuite {
     val input = Input.Text(Uri, content, sctx)
     Source(input, content.toCharArray)
   }
-
-  /**
-    * Randomly deletes characters from the given text that are not in the set of protected characters `protectedChars`.
-    */
-  private def randomlyDelete(text: String, protectedChars: Set[Char]): String = {
-    text.filter(c => protectedChars.contains(c) || scala.util.Random.nextBoolean())
-  }
 }


### PR DESCRIPTION
Comment invariant in #10138

Add some comment to the tested programs and test the invariant the same way we test the former ones.

There is one thing that we can do differently:
we can delete some characters in the original program, the invariant should still hold.

For example, we can randomly delete some characters in the comment, craft the new program and test the invariant again.

I think we can add that as another test?