### PR TITLE
feat: new completion invariant: no completions on name definition

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -18,7 +18,7 @@ package ca.uwaterloo.flix.language.ast
 
 import ca.uwaterloo.flix.api.Flix
 import ca.uwaterloo.flix.language.ast.Name.{Ident, NName}
-import ca.uwaterloo.flix.language.ast.shared.{BoundBy, ModuleKind, QualifiedSym, Scope, Source, VarText}
+import ca.uwaterloo.flix.language.ast.shared.*
 import ca.uwaterloo.flix.util.InternalCompilerException
 
 import java.util.Objects
@@ -499,7 +499,7 @@ object Symbol {
   /**
     * Enum Symbol.
     */
-  final class EnumSym(val namespace: List[String], val text: String, val loc: SourceLocation) extends Sourceable with Symbol with QualifiedSym {
+  final class EnumSym(val namespace: List[String], val text: String, val loc: SourceLocation) extends Sourceable with Locatable with Symbol with QualifiedSym {
 
     /**
       * Returns the name of `this` symbol.
@@ -533,7 +533,7 @@ object Symbol {
   /**
    * Struct Symbol.
    */
-  final class StructSym(val namespace: List[String], val text: String, val loc: SourceLocation) extends Sourceable with Symbol with QualifiedSym {
+  final class StructSym(val namespace: List[String], val text: String, val loc: SourceLocation) extends Sourceable with Locatable with Symbol with QualifiedSym {
     /**
       * Returns the name of `this` symbol.
       */
@@ -688,7 +688,7 @@ object Symbol {
   /**
     * Trait Symbol.
     */
-  final class TraitSym(val namespace: List[String], val name: String, val loc: SourceLocation) extends Sourceable with Symbol with QualifiedSym {
+  final class TraitSym(val namespace: List[String], val name: String, val loc: SourceLocation) extends Sourceable with Locatable with Symbol with QualifiedSym {
     /**
       * Returns `true` if this symbol is equal to `that` symbol.
       */
@@ -716,7 +716,7 @@ object Symbol {
   /**
     * Signature Symbol.
     */
-  final class SigSym(val trt: Symbol.TraitSym, val name: String, val loc: SourceLocation) extends Sourceable with Symbol with QualifiedSym {
+  final class SigSym(val trt: Symbol.TraitSym, val name: String, val loc: SourceLocation) extends Sourceable with Locatable with Symbol with QualifiedSym {
     /**
       * Returns `true` if this symbol is equal to `that` symbol.
       */
@@ -795,7 +795,7 @@ object Symbol {
   /**
     * TypeAlias Symbol.
     */
-  final class TypeAliasSym(val namespace: List[String], val name: String, val loc: SourceLocation) extends Sourceable with Symbol with QualifiedSym {
+  final class TypeAliasSym(val namespace: List[String], val name: String, val loc: SourceLocation) extends Sourceable with Locatable with Symbol with QualifiedSym {
     /**
       * Returns `true` if this symbol is equal to `that` symbol.
       */
@@ -862,7 +862,7 @@ object Symbol {
   /**
     * Effect symbol.
     */
-  final class EffectSym(val namespace: List[String], val name: String, val loc: SourceLocation) extends Sourceable with Ordered[EffectSym] with Symbol with QualifiedSym {
+  final class EffectSym(val namespace: List[String], val name: String, val loc: SourceLocation) extends Sourceable with Locatable with Ordered[EffectSym] with Symbol with QualifiedSym {
 
     /**
       * Returns the source of `this`.

--- a/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Symbol.scala
@@ -499,7 +499,7 @@ object Symbol {
   /**
     * Enum Symbol.
     */
-  final class EnumSym(val namespace: List[String], val text: String, val loc: SourceLocation) extends Sourceable with Locatable with Symbol with QualifiedSym {
+  final class EnumSym(val namespace: List[String], val text: String, val loc: SourceLocation) extends Sourceable with Symbol with QualifiedSym {
 
     /**
       * Returns the name of `this` symbol.
@@ -533,7 +533,7 @@ object Symbol {
   /**
    * Struct Symbol.
    */
-  final class StructSym(val namespace: List[String], val text: String, val loc: SourceLocation) extends Sourceable with Locatable with Symbol with QualifiedSym {
+  final class StructSym(val namespace: List[String], val text: String, val loc: SourceLocation) extends Sourceable with Symbol with QualifiedSym {
     /**
       * Returns the name of `this` symbol.
       */
@@ -688,7 +688,7 @@ object Symbol {
   /**
     * Trait Symbol.
     */
-  final class TraitSym(val namespace: List[String], val name: String, val loc: SourceLocation) extends Sourceable with Locatable with Symbol with QualifiedSym {
+  final class TraitSym(val namespace: List[String], val name: String, val loc: SourceLocation) extends Sourceable with Symbol with QualifiedSym {
     /**
       * Returns `true` if this symbol is equal to `that` symbol.
       */
@@ -716,7 +716,7 @@ object Symbol {
   /**
     * Signature Symbol.
     */
-  final class SigSym(val trt: Symbol.TraitSym, val name: String, val loc: SourceLocation) extends Sourceable with Locatable with Symbol with QualifiedSym {
+  final class SigSym(val trt: Symbol.TraitSym, val name: String, val loc: SourceLocation) extends Sourceable with Symbol with QualifiedSym {
     /**
       * Returns `true` if this symbol is equal to `that` symbol.
       */
@@ -795,7 +795,7 @@ object Symbol {
   /**
     * TypeAlias Symbol.
     */
-  final class TypeAliasSym(val namespace: List[String], val name: String, val loc: SourceLocation) extends Sourceable with Locatable with Symbol with QualifiedSym {
+  final class TypeAliasSym(val namespace: List[String], val name: String, val loc: SourceLocation) extends Sourceable with Symbol with QualifiedSym {
     /**
       * Returns `true` if this symbol is equal to `that` symbol.
       */
@@ -862,7 +862,7 @@ object Symbol {
   /**
     * Effect symbol.
     */
-  final class EffectSym(val namespace: List[String], val name: String, val loc: SourceLocation) extends Sourceable with Locatable with Ordered[EffectSym] with Symbol with QualifiedSym {
+  final class EffectSym(val namespace: List[String], val name: String, val loc: SourceLocation) extends Sourceable with Ordered[EffectSym] with Symbol with QualifiedSym {
 
     /**
       * Returns the source of `this`.

--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -117,6 +117,19 @@ class TestCompletionProvider extends AnyFunSuite  {
     }
   }
 
+  test("No completions on name definition"){
+    Programs.foreach{ program =>
+      val (root, flix, errors) = compile(program, Options.Default)
+      val allNameDefs = root.defs.keys ++ root.enums.keys ++ root.sigs.keys ++ root.traits.keys ++ root.effects.keys ++
+        root.structs.keys ++ root.typeAliases.keys
+      val validNameDef = allNameDefs.filter(_.src.name.startsWith(Uri)).map(_.loc)
+      validNameDef.foreach{ loc =>
+        val completions = CompletionProvider.autoComplete(Uri, Position.from(loc.sp2), errors)(root, flix)
+        assert(completions.items.isEmpty)
+      }
+    }
+  }
+
   /**
     * The uri of the test source.
     */

--- a/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
+++ b/main/test/ca/uwaterloo/flix/api/lsp/TestCompletionProvider.scala
@@ -117,13 +117,77 @@ class TestCompletionProvider extends AnyFunSuite  {
     }
   }
 
-  test("No completions on name definition"){
+  test("No completions when defining the name for defs"){
     Programs.foreach{ program =>
       val (root, flix, errors) = compile(program, Options.Default)
-      val allNameDefs = root.defs.keys ++ root.enums.keys ++ root.sigs.keys ++ root.traits.keys ++ root.effects.keys ++
-        root.structs.keys ++ root.typeAliases.keys
-      val validNameDef = allNameDefs.filter(_.src.name.startsWith(Uri)).map(_.loc)
-      validNameDef.foreach{ loc =>
+      val allNameDefLocs = root.defs.keys.filter(_.src.name.startsWith(Uri)).map(_.loc)
+      allNameDefLocs.foreach{ loc =>
+        val completions = CompletionProvider.autoComplete(Uri, Position.from(loc.sp2), errors)(root, flix)
+        assert(completions.items.isEmpty)
+      }
+    }
+  }
+
+  test("No completions when defining the name for enums"){
+    Programs.foreach{ program =>
+      val (root, flix, errors) = compile(program, Options.Default)
+      val allNameDefLocs = root.enums.keys.filter(_.src.name.startsWith(Uri)).map(_.loc)
+      allNameDefLocs.foreach{ loc =>
+        val completions = CompletionProvider.autoComplete(Uri, Position.from(loc.sp2), errors)(root, flix)
+        assert(completions.items.isEmpty)
+      }
+    }
+  }
+
+  test("No completions when defining the name for sigs"){
+    Programs.foreach{ program =>
+      val (root, flix, errors) = compile(program, Options.Default)
+      val allNameDefLocs = root.sigs.keys.filter(_.src.name.startsWith(Uri)).map(_.loc)
+      allNameDefLocs.foreach{ loc =>
+        val completions = CompletionProvider.autoComplete(Uri, Position.from(loc.sp2), errors)(root, flix)
+        assert(completions.items.isEmpty)
+      }
+    }
+  }
+
+  test("No completions when defining the name for traits"){
+    Programs.foreach{ program =>
+      val (root, flix, errors) = compile(program, Options.Default)
+      val allNameDefLocs = root.traits.keys.filter(_.src.name.startsWith(Uri)).map(_.loc)
+      allNameDefLocs.foreach{ loc =>
+        val completions = CompletionProvider.autoComplete(Uri, Position.from(loc.sp2), errors)(root, flix)
+        assert(completions.items.isEmpty)
+      }
+    }
+  }
+
+  test("No completions when defining the name for effects"){
+    Programs.foreach{ program =>
+      val (root, flix, errors) = compile(program, Options.Default)
+      val allNameDefLocs = root.effects.keys.filter(_.src.name.startsWith(Uri)).map(_.loc)
+      allNameDefLocs.foreach{ loc =>
+        val completions = CompletionProvider.autoComplete(Uri, Position.from(loc.sp2), errors)(root, flix)
+        assert(completions.items.isEmpty)
+      }
+    }
+  }
+
+  test("No completions when defining the name for structs"){
+    Programs.foreach{ program =>
+      val (root, flix, errors) = compile(program, Options.Default)
+      val allNameDefLocs = root.structs.keys.filter(_.src.name.startsWith(Uri)).map(_.loc)
+      allNameDefLocs.foreach{ loc =>
+        val completions = CompletionProvider.autoComplete(Uri, Position.from(loc.sp2), errors)(root, flix)
+        assert(completions.items.isEmpty)
+      }
+    }
+  }
+
+  test("No completions when defining the name for type aliases"){
+    Programs.foreach{ program =>
+      val (root, flix, errors) = compile(program, Options.Default)
+      val allNameDefLocs = root.typeAliases.keys.filter(_.src.name.startsWith(Uri)).map(_.loc)
+      allNameDefLocs.foreach{ loc =>
         val completions = CompletionProvider.autoComplete(Uri, Position.from(loc.sp2), errors)(root, flix)
         assert(completions.items.isEmpty)
       }


### PR DESCRIPTION
name definition invariant in #10138

We collect names from the root and filter out those whose src does not start with "<test>", which means that they are not defined in the tested program, but in the library.

Then I add Sourceable and Locatable to all the Symbols used, so that I can concatenate them together, do the filtering, and map to loc.

Then we just call completion and test its emptiness.


Possible improvements:

- We can modify the name a little bit, the invariant should still hold. But I will wait to reuse the helper functions from other PR to modify the code.
- We can include more name definitions, like parameters, local variable defs, and other bindings.
