### PR TITLE
feat: allow effectful f in Foldable.filter

### DIFF
--- a/main/src/library/Foldable.flix
+++ b/main/src/library/Foldable.flix
@@ -312,8 +312,8 @@ pub trait Foldable[t : Type -> Type] {
     ///
     /// Returns an immutable list of all the elements in `t` that satisfy the predicate `f`.
     ///
-    pub def filter(f: a -> Bool, t: t[a]): List[a] \ Foldable.Aef[t] =
-        Foldable.foldRight((x, acc) -> if (f(x)) x :: acc else acc, Nil, t)
+    pub def filter(f: a -> Bool \ ef, t: t[a]): List[a] \ (ef + Foldable.Aef[t]) =
+        Foldable.foldLeft((acc, x) -> if (f(x)) x :: acc else acc, Nil, t) |> List.reverse
 
     ///
     /// Applies `f` to each element in `t`.

--- a/main/test/ca/uwaterloo/flix/library/TestFoldable.flix
+++ b/main/test/ca/uwaterloo/flix/library/TestFoldable.flix
@@ -627,4 +627,48 @@ mod TestFoldable {
     def joinWith04(): Bool =
         Foldable.joinWith(x -> x + x, ",", "1" :: "2" :: "3" :: Nil) == "11,22,33"
 
+    /////////////////////////////////////////////////////////////////////////////
+    // filter                                                                  //
+    /////////////////////////////////////////////////////////////////////////////
+
+    @test
+    def filter01(): Bool =
+        Foldable.filter(_ -> true, (Nil: List[Int32])) == (Nil: List[Int32])
+
+    @test
+    def filter02(): Bool =
+        Foldable.filter(_ -> false, List#{1, 2}) == Nil
+
+    @test
+    def filter03(): Bool =
+        Foldable.filter(x -> x > 2, List#{1, 8, 2, 3}) == List#{8, 3}
+
+    @test
+    def filter04(): Bool =
+        Foldable.filter(x -> x <= 2, List#{1, 8, 2, 3}) == List#{1, 2}
+
+    eff Capture {
+        def capture(x: Int32): Int32
+    }
+
+    @test
+    def filter05(): Bool = region rc {
+        let xs = Vector#{1, 2, 3, 4};
+        let effects = MutList.empty(rc);
+        def f(x) = if (x > 2) {
+            Capture.capture(x);
+            false
+        } else {
+            true
+        };
+        let filtered = run {
+            Foldable.filter(f, xs)
+        } with handler Capture {
+            def capture(x, resume) = {
+                MutList.push(x, effects);
+                resume(x)
+            }
+        };
+        Assert.eq(List#{1, 2}, filtered) and Assert.eq(List#{3, 4}, MutList.toList(effects))
+    }
 }


### PR DESCRIPTION
closes #9490 

I added tests directly on Foldable.filter as there were none. Though I guess List.filter, etc are tested so perhaps not super useful?