### PR TITLE
refactor: introduce Type.decomposeArrow

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/Type.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/Type.scala
@@ -218,13 +218,22 @@ sealed trait Type {
   }
 
   /**
+    * Returns the effect, argument types, and result type of `this` arrow type.
+    *
+    * NB: Assumes that `this` type is an arrow.
+    */
+  def decomposeArrow: (Type, List[Type], Type) = (typeConstructor, typeArguments) match {
+    case (Some(TypeConstructor.Arrow(_)), eff :: (args :+ res)) => (eff, args, res)
+    case _ => throw InternalCompilerException(s"Unexpected non-arrow type: '$this'.", loc)
+  }
+
+  /**
     * Returns the argument types of `this` arrow type.
     *
     * NB: Assumes that `this` type is an arrow.
     */
-  def arrowArgTypes: List[Type] = typeConstructor match {
-    case Some(TypeConstructor.Arrow(_)) => typeArguments.drop(1).dropRight(1)
-    case _ => throw InternalCompilerException(s"Unexpected non-arrow type: '$this'.", loc)
+  def arrowArgTypes: List[Type] = decomposeArrow match {
+    case (_, args, _) => args
   }
 
   /**
@@ -232,9 +241,8 @@ sealed trait Type {
     *
     * NB: Assumes that `this` type is an arrow.
     */
-  def arrowResultType: Type = typeConstructor match {
-    case Some(TypeConstructor.Arrow(_)) => typeArguments.last
-    case _ => throw InternalCompilerException(s"Unexpected non-arrow type: '$this'.", loc)
+  def arrowResultType: Type = decomposeArrow match {
+    case (_, _, res) => res
   }
 
   /**
@@ -242,9 +250,8 @@ sealed trait Type {
     *
     * NB: Assumes that `this` type is an arrow.
     */
-  def arrowEffectType: Type = typeConstructor match {
-    case Some(TypeConstructor.Arrow(_)) => typeArguments.head
-    case _ => throw InternalCompilerException(s"Unexpected non-arrow type: '$this'.", loc)
+  def arrowEffectType: Type = decomposeArrow match {
+    case (eff, _, _) => eff
   }
 
   /**

--- a/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/EntryPoints.scala
@@ -575,8 +575,7 @@ object EntryPoints {
       val mainSym = DefSymUse(oldEntryPoint.sym, SourceLocation.Unknown)
       val mainArgType = Type.Unit
       val mainArg = TypedAst.Expr.Cst(Constant.Unit, mainArgType, SourceLocation.Unknown)
-      val mainReturnType = mainArrowType.arrowResultType
-      val mainEffect = mainArrowType.arrowEffectType
+      val (mainEffect, _, mainReturnType) = mainArrowType.decomposeArrow
       // `mainFunc()`
       val mainCall = TypedAst.Expr.ApplyDef(mainSym, List(mainArg), mainArrowType, mainReturnType, mainEffect, SourceLocation.Unknown)
 

--- a/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/typer/ConstraintGen.scala
@@ -90,9 +90,7 @@ object ConstraintGen {
         val defn = root.defs(sym)
         val (tconstrs1, econstrs1, declaredType, _) = Scheme.instantiate(defn.spec.sc, loc1.asSynthetic)
         val constrs1 = tconstrs1.map(_.copy(loc = loc2))
-        val declaredEff = declaredType.arrowEffectType
-        val declaredArgumentTypes = declaredType.arrowArgTypes
-        val declaredResultType = declaredType.arrowResultType
+        val (declaredEff, declaredArgumentTypes, declaredResultType) = declaredType.decomposeArrow
         val (tpes, effs) = exps.map(visitExp).unzip
         c.unifyType(itvar, declaredType, loc2)
         c.expectTypeArguments(sym, declaredArgumentTypes, tpes, exps.map(_.loc))
@@ -119,9 +117,7 @@ object ConstraintGen {
         val sig = root.traits(sym.trt).sigs(sym)
         val (tconstrs1, econstrs1, declaredType, _) = Scheme.instantiate(sig.spec.sc, loc1.asSynthetic)
         val constrs1 = tconstrs1.map(_.copy(loc = loc1))
-        val declaredEff = declaredType.arrowEffectType
-        val declaredArgumentTypes = declaredType.arrowArgTypes
-        val declaredResultType = declaredType.arrowResultType
+        val (declaredEff, declaredArgumentTypes, declaredResultType) = declaredType.decomposeArrow
         val (tpes, effs) = exps.map(visitExp).unzip
         c.expectTypeArguments(sym, declaredArgumentTypes, tpes, exps.map(_.loc))
         c.addClassConstraints(constrs1, loc2)


### PR DESCRIPTION
I'm not totally convinced by this. The three named functions make it clear what we're getting from the type, but returning a tuple means you need to know what order the returned values are in.