### PR TITLE
fix: filter out non-star type in TypeAliasCompleter

### DIFF
--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeAliasCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeAliasCompleter.scala
@@ -20,7 +20,7 @@ import ca.uwaterloo.flix.api.lsp.Range
 import ca.uwaterloo.flix.api.lsp.provider.completion.Completion.TypeAliasCompletion
 import ca.uwaterloo.flix.language.ast.NamedAst.Declaration.TypeAlias
 import ca.uwaterloo.flix.language.ast.shared.{AnchorPosition, LocalScope, Resolution}
-import ca.uwaterloo.flix.language.ast.{Name, TypedAst}
+import ca.uwaterloo.flix.language.ast.{Kind, Name, TypedAst}
 
 object TypeAliasCompleter {
   /**
@@ -31,12 +31,12 @@ object TypeAliasCompleter {
   def getCompletions(qn: Name.QName, range: Range, ap: AnchorPosition, scp: LocalScope)(implicit root: TypedAst.Root): Iterable[Completion] = {
     if (qn.namespace.nonEmpty)
       root.typeAliases.values.collect{
-        case typeAlias if CompletionUtils.isAvailable(typeAlias) && CompletionUtils.matchesName(typeAlias.sym, qn, qualified = true) =>
+        case typeAlias if isStarKind(typeAlias) && CompletionUtils.isAvailable(typeAlias) && CompletionUtils.matchesName(typeAlias.sym, qn, qualified = true) =>
           TypeAliasCompletion(typeAlias, range, ap, qualified = true, inScope = true)
       }
     else
       root.typeAliases.values.collect({
-        case typeAlias if CompletionUtils.isAvailable(typeAlias) && CompletionUtils.matchesName(typeAlias.sym, qn, qualified = false) =>
+        case typeAlias if isStarKind(typeAlias) && CompletionUtils.isAvailable(typeAlias) && CompletionUtils.matchesName(typeAlias.sym, qn, qualified = false) =>
           TypeAliasCompletion(typeAlias, range, ap, qualified = false, inScope = inScope(typeAlias, scp))
       })
   }
@@ -54,4 +54,9 @@ object TypeAliasCompleter {
     val isRoot = typeAlias.sym.namespace.isEmpty
     isRoot || isResolved
   }
+
+  private def isStarKind(typeAlias: TypedAst.TypeAlias): Boolean = typeAlias.tpe.kind match {
+      case Kind.Star => true
+      case _ => false
+    }
 }

--- a/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeAliasCompleter.scala
+++ b/main/src/ca/uwaterloo/flix/api/lsp/provider/completion/TypeAliasCompleter.scala
@@ -55,6 +55,9 @@ object TypeAliasCompleter {
     isRoot || isResolved
   }
 
+  /**
+    * Checks if the type alias is a star kind.
+    */
   private def isStarKind(typeAlias: TypedAst.TypeAlias): Boolean = typeAlias.tpe.kind match {
       case Kind.Star => true
       case _ => false


### PR DESCRIPTION
fixes #10194

We filter out non-star types in type alias completer, so that static is filtered out:

![image](https://github.com/user-attachments/assets/837fd433-77f3-40fa-a0c6-1cc83356d9ef)

Is this a sound filtering? Are we filtering out some types that are actually needed in some UndefinedType errors?