### PR TITLE
fix: drop comments from start of expression in parsing

### DIFF
--- a/examples/functional-style/pure-and-impure-functions.flix
+++ b/examples/functional-style/pure-and-impure-functions.flix
@@ -15,5 +15,5 @@ def twice(f: Int32 -> Int32, x: Int32): Int32 = f(f(x))
 /// We can pass a pure function to twice.
 pub def f(): Int32 = twice(inc, 42)
 
-/// But we *cannot* pass an impure function.
+// But we *cannot* pass an impure function.
 // pub def g(): Int32 = twice(printAndInc, 42)

--- a/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/TokenKind.scala
@@ -211,6 +211,8 @@ sealed trait TokenKind {
     */
   def isComment: Boolean = this == TokenKind.CommentDoc || this.isCommentNonDoc
 
+  def isDocComment = this == TokenKind.CommentDoc
+
   /**
     * Checks if this token is a keyword.
     */


### PR DESCRIPTION
closes #10218

This seemed too easy so is probably wrong! 

I minimised to this:
```
def f(): String  = { 
    // test
    MutDeque.pushFront(1);
    ""
}
```

The AST printed as below: the expression included the comment. 
So I called the comments() method at the start of Parser2.expression(). The AST no longer includes the comment node and the underlining in vscode looks correct.

```
                        Expr(
                            Apply(
                                Expr(
                                    CommentList(CommentLine["// test"]),
                                    QName(
                                        Ident(NameUpperCase["MutDeque"]),
                                        Dot["."],
                                        Ident(NameLowerCase["pushFront"])
                                    )
                                ),
```