### PR TITLE
experiment: introduce Condition, Then, Else treeKinds

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
+++ b/main/src/ca/uwaterloo/flix/language/ast/SyntaxTree.scala
@@ -194,6 +194,10 @@ object SyntaxTree {
 
       case object CheckedTypeCast extends Expr
 
+      case object Condition extends Expr
+
+      case object Else extends Expr
+
       case object Index extends Expr
 
       case object IndexMut extends Expr
@@ -337,6 +341,8 @@ object SyntaxTree {
       case object Static extends Expr
 
       case object StringInterpolation extends Expr
+
+      case object Then extends Expr
 
       case object Try extends Expr
 

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1861,13 +1861,19 @@ object Parser2 {
       val mark = open()
       expect(TokenKind.KeywordIf, SyntacticContext.Expr.OtherExpr)
       expect(TokenKind.ParenL, SyntacticContext.Expr.OtherExpr)
+      val condMark = open()
       expression()
+      close(condMark, TreeKind.Expr.Condition)
       expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
+      val thenMark = open()
       expression()
+      close(thenMark, TreeKind.Expr.Then)
       if (eat(TokenKind.KeywordElse)) {
         // Only call expression, if we found an 'else'. Otherwise when it is missing, defs might
         // get read as let-rec-defs.
+        val elseMark = open()
         expression()
+        close(elseMark, TreeKind.Expr.Else)
       }
       close(mark, TreeKind.Expr.IfThenElse)
     }

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1385,9 +1385,9 @@ object Parser2 {
     /**
       * Parse an expression.
       *
-      * @param left         The operator that binds the left-hand-side of the expression.
-      * @param leftIsUnary  If true, the left-hand-side is an unary operator.
-      * @param exitTokens   A set of tokens that will prevent exprDelimited from consuming them.
+      * @param left        The operator that binds the left-hand-side of the expression.
+      * @param leftIsUnary If true, the left-hand-side is an unary operator.
+      * @param exitTokens  A set of tokens that will prevent exprDelimited from consuming them.
       */
     def expression(left: TokenKind = TokenKind.Eof, leftIsUnary: Boolean = false, exitTokens: Set[TokenKind] = Set.empty)(implicit s: State): Mark.Closed = {
       var lhs = exprDelimited(exitTokens)
@@ -1601,96 +1601,90 @@ object Parser2 {
     private def exprDelimited(exitTokens: Set[TokenKind])(implicit s: State): Mark.Closed = {
       // If a new expression is added here then add it to FIRST_EXPR too.
       val mark = open()
-      val token = nth(0)
-      if (exitTokens.contains(token)) {
-        val mark = open()
-        val error = UnexpectedToken(expected = NamedTokenSet.Expression, actual = Some(token), SyntacticContext.Expr.OtherExpr, loc = currentSourceLocation())
-        closeWithError(mark, error)
-      } else {
-        token match {
-          case TokenKind.KeywordOpenVariant => openVariantExpr()
-          case TokenKind.KeywordOpenVariantAs => openVariantAsExpr()
-          case TokenKind.HoleNamed
-               | TokenKind.HoleAnonymous => holeExpr()
-          case TokenKind.HoleVariable => holeVariableExpr()
-          case TokenKind.KeywordUse => useExpr()
-          case TokenKind.LiteralString
-               | TokenKind.LiteralChar
-               | TokenKind.LiteralFloat32
-               | TokenKind.LiteralFloat64
-               | TokenKind.LiteralBigDecimal
-               | TokenKind.LiteralInt8
-               | TokenKind.LiteralInt16
-               | TokenKind.LiteralInt32
-               | TokenKind.LiteralInt64
-               | TokenKind.LiteralBigInt
-               | TokenKind.KeywordTrue
-               | TokenKind.KeywordFalse
-               | TokenKind.KeywordNull
-               | TokenKind.LiteralRegex => literalExpr()
-          case TokenKind.ParenL => parenOrTupleOrLambdaExpr()
-          case TokenKind.Underscore => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else nameUnqualified(NAME_VARIABLE, SyntacticContext.Expr.OtherExpr)
-          case TokenKind.NameLowerCase if nth(1) == TokenKind.ArrowThinR => unaryLambdaExpr()
-          case TokenKind.NameLowerCase => nameAllowQualified(NAME_FIELD, context = SyntacticContext.Expr.OtherExpr)
-          case TokenKind.NameUpperCase
-               | TokenKind.NameMath
-               | TokenKind.NameGreek => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else nameAllowQualified(NAME_DEFINITION, context = SyntacticContext.Expr.OtherExpr)
-          case TokenKind.Minus
-               | TokenKind.KeywordNot
-               | TokenKind.Plus
-               | TokenKind.TripleTilde
-               | TokenKind.KeywordLazy
-               | TokenKind.KeywordForce
-               | TokenKind.KeywordDiscard => unaryExpr()
-          case TokenKind.KeywordIf => ifThenElseExpr()
-          case TokenKind.KeywordLet => letMatchExpr()
-          case TokenKind.Annotation | TokenKind.KeywordDef => localDefExpr()
-          case TokenKind.KeywordRegion => scopeExpr()
-          case TokenKind.KeywordMatch => matchOrMatchLambdaExpr()
-          case TokenKind.KeywordTypeMatch => typematchExpr()
-          case TokenKind.KeywordChoose
-               | TokenKind.KeywordChooseStar => restrictableChooseExpr()
-          case TokenKind.KeywordForA => forApplicativeExpr()
-          case TokenKind.KeywordForeach => foreachExpr()
-          case TokenKind.KeywordForM => forMonadicExpr()
-          case TokenKind.CurlyL => blockOrRecordExpr()
-          case TokenKind.ArrayHash => arrayLiteralExpr()
-          case TokenKind.VectorHash => vectorLiteralExpr()
-          case TokenKind.ListHash => listLiteralExpr()
-          case TokenKind.SetHash => setLiteralExpr()
-          case TokenKind.MapHash => mapLiteralExpr()
-          case TokenKind.DotDotDot => dotdotdotLiteral()
-          case TokenKind.KeywordCheckedCast => checkedTypeCastExpr()
-          case TokenKind.KeywordCheckedECast => checkedEffectCastExpr()
-          case TokenKind.KeywordUncheckedCast => uncheckedCastExpr()
-          case TokenKind.KeywordUnsafe => unsafeExpr()
-          case TokenKind.KeywordUnsafely => unsafelyRunExpr()
-          case TokenKind.KeywordRun => runExpr()
-          case TokenKind.KeywordHandler => handlerExpr()
-          case TokenKind.KeywordTry => tryExpr()
-          case TokenKind.KeywordThrow => throwExpr()
-          case TokenKind.KeywordNew => ambiguousNewExpr()
-          case TokenKind.KeywordStaticUppercase => staticExpr()
-          case TokenKind.KeywordSelect => selectExpr()
-          case TokenKind.KeywordSpawn => spawnExpr()
-          case TokenKind.KeywordPar => parYieldExpr()
-          case TokenKind.HashCurlyL => fixpointConstraintSetExpr()
-          case TokenKind.HashParenL => fixpointLambdaExpr()
-          case TokenKind.KeywordSolve => fixpointSolveExpr()
-          case TokenKind.KeywordInject => fixpointInjectExpr()
-          case TokenKind.KeywordQuery => fixpointQueryExpr()
-          case TokenKind.BuiltIn => intrinsicExpr()
-          case TokenKind.LiteralStringInterpolationL
-               | TokenKind.LiteralDebugStringL => interpolatedStringExpr()
-          case TokenKind.KeywordDebug
-               | TokenKind.KeywordDebugBang
-               | TokenKind.KeywordDebugBangBang => debugExpr()
-          case t =>
-            val mark = open()
-            val error = UnexpectedToken(expected = NamedTokenSet.Expression, actual = Some(t), SyntacticContext.Expr.OtherExpr, loc = currentSourceLocation())
+      nth(0) match {
+        case TokenKind.KeywordOpenVariant => openVariantExpr()
+        case TokenKind.KeywordOpenVariantAs => openVariantAsExpr()
+        case TokenKind.HoleNamed
+             | TokenKind.HoleAnonymous => holeExpr()
+        case TokenKind.HoleVariable => holeVariableExpr()
+        case TokenKind.KeywordUse => useExpr()
+        case TokenKind.LiteralString
+             | TokenKind.LiteralChar
+             | TokenKind.LiteralFloat32
+             | TokenKind.LiteralFloat64
+             | TokenKind.LiteralBigDecimal
+             | TokenKind.LiteralInt8
+             | TokenKind.LiteralInt16
+             | TokenKind.LiteralInt32
+             | TokenKind.LiteralInt64
+             | TokenKind.LiteralBigInt
+             | TokenKind.KeywordTrue
+             | TokenKind.KeywordFalse
+             | TokenKind.KeywordNull
+             | TokenKind.LiteralRegex => literalExpr()
+        case TokenKind.ParenL => parenOrTupleOrLambdaExpr()
+        case TokenKind.Underscore => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else nameUnqualified(NAME_VARIABLE, SyntacticContext.Expr.OtherExpr)
+        case TokenKind.NameLowerCase if nth(1) == TokenKind.ArrowThinR => unaryLambdaExpr()
+        case TokenKind.NameLowerCase => nameAllowQualified(NAME_FIELD, context = SyntacticContext.Expr.OtherExpr)
+        case TokenKind.NameUpperCase
+             | TokenKind.NameMath
+             | TokenKind.NameGreek => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else nameAllowQualified(NAME_DEFINITION, context = SyntacticContext.Expr.OtherExpr)
+        case TokenKind.Minus
+             | TokenKind.KeywordNot
+             | TokenKind.Plus
+             | TokenKind.TripleTilde
+             | TokenKind.KeywordLazy
+             | TokenKind.KeywordForce
+             | TokenKind.KeywordDiscard => unaryExpr()
+        case TokenKind.KeywordIf => ifThenElseExpr()
+        case TokenKind.KeywordLet => letMatchExpr()
+        case TokenKind.Annotation | TokenKind.KeywordDef => localDefExpr()
+        case TokenKind.KeywordRegion => scopeExpr()
+        case TokenKind.KeywordMatch => matchOrMatchLambdaExpr()
+        case TokenKind.KeywordTypeMatch => typematchExpr()
+        case TokenKind.KeywordChoose
+             | TokenKind.KeywordChooseStar => restrictableChooseExpr()
+        case TokenKind.KeywordForA => forApplicativeExpr()
+        case TokenKind.KeywordForeach => foreachExpr()
+        case TokenKind.KeywordForM => forMonadicExpr()
+        case TokenKind.CurlyL => blockOrRecordExpr()
+        case TokenKind.ArrayHash => arrayLiteralExpr()
+        case TokenKind.VectorHash => vectorLiteralExpr()
+        case TokenKind.ListHash => listLiteralExpr()
+        case TokenKind.SetHash => setLiteralExpr()
+        case TokenKind.MapHash => mapLiteralExpr()
+        case TokenKind.DotDotDot => dotdotdotLiteral()
+        case TokenKind.KeywordCheckedCast => checkedTypeCastExpr()
+        case TokenKind.KeywordCheckedECast => checkedEffectCastExpr()
+        case TokenKind.KeywordUncheckedCast => uncheckedCastExpr()
+        case TokenKind.KeywordUnsafe => unsafeExpr()
+        case TokenKind.KeywordUnsafely => unsafelyRunExpr()
+        case TokenKind.KeywordRun => runExpr()
+        case TokenKind.KeywordHandler => handlerExpr()
+        case TokenKind.KeywordTry => tryExpr()
+        case TokenKind.KeywordThrow => throwExpr()
+        case TokenKind.KeywordNew => ambiguousNewExpr()
+        case TokenKind.KeywordStaticUppercase => staticExpr()
+        case TokenKind.KeywordSelect => selectExpr()
+        case TokenKind.KeywordSpawn => spawnExpr()
+        case TokenKind.KeywordPar => parYieldExpr()
+        case TokenKind.HashCurlyL => fixpointConstraintSetExpr()
+        case TokenKind.HashParenL => fixpointLambdaExpr()
+        case TokenKind.KeywordSolve => fixpointSolveExpr()
+        case TokenKind.KeywordInject => fixpointInjectExpr()
+        case TokenKind.KeywordQuery => fixpointQueryExpr()
+        case TokenKind.BuiltIn => intrinsicExpr()
+        case TokenKind.LiteralStringInterpolationL
+             | TokenKind.LiteralDebugStringL => interpolatedStringExpr()
+        case TokenKind.KeywordDebug
+             | TokenKind.KeywordDebugBang
+             | TokenKind.KeywordDebugBangBang => debugExpr()
+        case token =>
+          val mark = open()
+          val error = UnexpectedToken(expected = NamedTokenSet.Expression, actual = Some(token), SyntacticContext.Expr.OtherExpr, loc = currentSourceLocation())
+          if (!exitTokens.contains(token))
             advance()
-            closeWithError(mark, error)
-        }
+          closeWithError(mark, error)
       }
       close(mark, TreeKind.Expr.Expr)
     }
@@ -1884,13 +1878,12 @@ object Parser2 {
       val mark = open()
       expect(TokenKind.KeywordIf, SyntacticContext.Expr.OtherExpr)
       expect(TokenKind.ParenL, SyntacticContext.Expr.OtherExpr)
-      val exitTokens: Set[TokenKind] = Set(TokenKind.ParenR, TokenKind.KeywordElse)
       val condMark = open()
-      expression(exitTokens = exitTokens)
+      expression(exitTokens = Set(TokenKind.ParenR))
       close(condMark, TreeKind.Expr.Condition)
       expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
       val thenMark = open()
-      expression(exitTokens = exitTokens)
+      expression(exitTokens = Set(TokenKind.KeywordElse))
       close(thenMark, TreeKind.Expr.Then)
       if (eat(TokenKind.KeywordElse)) {
         // Only call expression, if we found an 'else'. Otherwise when it is missing, defs might

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -37,11 +37,11 @@ import scala.collection.mutable.ArrayBuffer
   *      Conceptually this is exactly the same as inserting parenthesis in a stream of tokens, only
   *      here each parenthesis is annotated with a kind.
   *      For instance:
-  *      {{{def main(): Int32 = 123}}}
+  * {{{def main(): Int32 = 123}}}
   *      Becomes:
-  *      {{{(Def 'def' (Name 'main' ) '(' ')' ':' (Type 'Int32' ) '=' (Literal '123' ) )}}}
+  * {{{(Def 'def' (Name 'main' ) '(' ')' ':' (Type 'Int32' ) '=' (Literal '123' ) )}}}
   *
-  *   2. The flat list of events is automatically turned into a SyntaxTree.Tree.
+  * 2. The flat list of events is automatically turned into a SyntaxTree.Tree.
   *
   * This parser is adopted from 'Resilient LL Parsing Tutorial' by Alex Kladov who works on
   * rust-analyzer. The tutorial is also a great resource for understanding this parser (and a great
@@ -174,16 +174,16 @@ object Parser2 {
           val child = stack.head
           val openToken = locationStack.head
           stack.head.loc = if (stack.head.children.length == 0)
-          // If the subtree has no children, give it a zero length position just after the last
-          // token.
+            // If the subtree has no children, give it a zero length position just after the last
+            // token.
             SourceLocation(
               isReal = true,
               lastAdvance.sp2,
               lastAdvance.sp2
             )
           else
-          // Otherwise the source location can span from the first to the last token in the sub
-          // tree.
+            // Otherwise the source location can span from the first to the last token in the sub
+            // tree.
             SourceLocation(
               isReal = true,
               openToken.sp1,
@@ -1382,8 +1382,8 @@ object Parser2 {
       lhs
     }
 
-    def expression(left: TokenKind = TokenKind.Eof, leftIsUnary: Boolean = false)(implicit s: State): Mark.Closed = {
-      var lhs = exprDelimited()
+    def expression(left: TokenKind = TokenKind.Eof, leftIsUnary: Boolean = false, exitTokens: Set[TokenKind] = Set.empty)(implicit s: State): Mark.Closed = {
+      var lhs = exprDelimited(exitTokens)
       // Handle chained calls and record lookups.
       var continue = true
       while (continue) {
@@ -1586,92 +1586,99 @@ object Parser2 {
       }
     }
 
-    private def exprDelimited()(implicit s: State): Mark.Closed = {
+    private def exprDelimited(exitTokens: Set[TokenKind])(implicit s: State): Mark.Closed = {
       // If a new expression is added here then add it to FIRST_EXPR too.
       val mark = open()
-      nth(0) match {
-        case TokenKind.KeywordOpenVariant => openVariantExpr()
-        case TokenKind.KeywordOpenVariantAs => openVariantAsExpr()
-        case TokenKind.HoleNamed
-             | TokenKind.HoleAnonymous => holeExpr()
-        case TokenKind.HoleVariable => holeVariableExpr()
-        case TokenKind.KeywordUse => useExpr()
-        case TokenKind.LiteralString
-             | TokenKind.LiteralChar
-             | TokenKind.LiteralFloat32
-             | TokenKind.LiteralFloat64
-             | TokenKind.LiteralBigDecimal
-             | TokenKind.LiteralInt8
-             | TokenKind.LiteralInt16
-             | TokenKind.LiteralInt32
-             | TokenKind.LiteralInt64
-             | TokenKind.LiteralBigInt
-             | TokenKind.KeywordTrue
-             | TokenKind.KeywordFalse
-             | TokenKind.KeywordNull
-             | TokenKind.LiteralRegex => literalExpr()
-        case TokenKind.ParenL => parenOrTupleOrLambdaExpr()
-        case TokenKind.Underscore => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else nameUnqualified(NAME_VARIABLE, SyntacticContext.Expr.OtherExpr)
-        case TokenKind.NameLowerCase if nth(1) == TokenKind.ArrowThinR => unaryLambdaExpr()
-        case TokenKind.NameLowerCase => nameAllowQualified(NAME_FIELD, context = SyntacticContext.Expr.OtherExpr)
-        case TokenKind.NameUpperCase
-             | TokenKind.NameMath
-             | TokenKind.NameGreek => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else nameAllowQualified(NAME_DEFINITION, context = SyntacticContext.Expr.OtherExpr)
-        case TokenKind.Minus
-             | TokenKind.KeywordNot
-             | TokenKind.Plus
-             | TokenKind.TripleTilde
-             | TokenKind.KeywordLazy
-             | TokenKind.KeywordForce
-             | TokenKind.KeywordDiscard => unaryExpr()
-        case TokenKind.KeywordIf => ifThenElseExpr()
-        case TokenKind.KeywordLet => letMatchExpr()
-        case TokenKind.Annotation | TokenKind.KeywordDef => localDefExpr()
-        case TokenKind.KeywordRegion => scopeExpr()
-        case TokenKind.KeywordMatch => matchOrMatchLambdaExpr()
-        case TokenKind.KeywordTypeMatch => typematchExpr()
-        case TokenKind.KeywordChoose
-             | TokenKind.KeywordChooseStar => restrictableChooseExpr()
-        case TokenKind.KeywordForA => forApplicativeExpr()
-        case TokenKind.KeywordForeach => foreachExpr()
-        case TokenKind.KeywordForM => forMonadicExpr()
-        case TokenKind.CurlyL => blockOrRecordExpr()
-        case TokenKind.ArrayHash => arrayLiteralExpr()
-        case TokenKind.VectorHash => vectorLiteralExpr()
-        case TokenKind.ListHash => listLiteralExpr()
-        case TokenKind.SetHash => setLiteralExpr()
-        case TokenKind.MapHash => mapLiteralExpr()
-        case TokenKind.DotDotDot => dotdotdotLiteral()
-        case TokenKind.KeywordCheckedCast => checkedTypeCastExpr()
-        case TokenKind.KeywordCheckedECast => checkedEffectCastExpr()
-        case TokenKind.KeywordUncheckedCast => uncheckedCastExpr()
-        case TokenKind.KeywordUnsafe => unsafeExpr()
-        case TokenKind.KeywordUnsafely => unsafelyRunExpr()
-        case TokenKind.KeywordRun => runExpr()
-        case TokenKind.KeywordHandler => handlerExpr()
-        case TokenKind.KeywordTry => tryExpr()
-        case TokenKind.KeywordThrow => throwExpr()
-        case TokenKind.KeywordNew => ambiguousNewExpr()
-        case TokenKind.KeywordStaticUppercase => staticExpr()
-        case TokenKind.KeywordSelect => selectExpr()
-        case TokenKind.KeywordSpawn => spawnExpr()
-        case TokenKind.KeywordPar => parYieldExpr()
-        case TokenKind.HashCurlyL => fixpointConstraintSetExpr()
-        case TokenKind.HashParenL => fixpointLambdaExpr()
-        case TokenKind.KeywordSolve => fixpointSolveExpr()
-        case TokenKind.KeywordInject => fixpointInjectExpr()
-        case TokenKind.KeywordQuery => fixpointQueryExpr()
-        case TokenKind.BuiltIn => intrinsicExpr()
-        case TokenKind.LiteralStringInterpolationL
-             | TokenKind.LiteralDebugStringL => interpolatedStringExpr()
-        case TokenKind.KeywordDebug
-             | TokenKind.KeywordDebugBang
-             | TokenKind.KeywordDebugBangBang => debugExpr()
-        case t =>
-          val mark = open()
-          val error = UnexpectedToken(expected = NamedTokenSet.Expression, actual = Some(t), SyntacticContext.Expr.OtherExpr, loc = currentSourceLocation())
-          advance()
-          closeWithError(mark, error)
+      val token = nth(0)
+      if (exitTokens.contains(token)) {
+        val mark = open()
+        val error = UnexpectedToken(expected = NamedTokenSet.Expression, actual = Some(token), SyntacticContext.Expr.OtherExpr, loc = currentSourceLocation())
+        closeWithError(mark, error)
+      } else {
+        token match {
+          case TokenKind.KeywordOpenVariant => openVariantExpr()
+          case TokenKind.KeywordOpenVariantAs => openVariantAsExpr()
+          case TokenKind.HoleNamed
+               | TokenKind.HoleAnonymous => holeExpr()
+          case TokenKind.HoleVariable => holeVariableExpr()
+          case TokenKind.KeywordUse => useExpr()
+          case TokenKind.LiteralString
+               | TokenKind.LiteralChar
+               | TokenKind.LiteralFloat32
+               | TokenKind.LiteralFloat64
+               | TokenKind.LiteralBigDecimal
+               | TokenKind.LiteralInt8
+               | TokenKind.LiteralInt16
+               | TokenKind.LiteralInt32
+               | TokenKind.LiteralInt64
+               | TokenKind.LiteralBigInt
+               | TokenKind.KeywordTrue
+               | TokenKind.KeywordFalse
+               | TokenKind.KeywordNull
+               | TokenKind.LiteralRegex => literalExpr()
+          case TokenKind.ParenL => parenOrTupleOrLambdaExpr()
+          case TokenKind.Underscore => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else nameUnqualified(NAME_VARIABLE, SyntacticContext.Expr.OtherExpr)
+          case TokenKind.NameLowerCase if nth(1) == TokenKind.ArrowThinR => unaryLambdaExpr()
+          case TokenKind.NameLowerCase => nameAllowQualified(NAME_FIELD, context = SyntacticContext.Expr.OtherExpr)
+          case TokenKind.NameUpperCase
+               | TokenKind.NameMath
+               | TokenKind.NameGreek => if (nth(1) == TokenKind.ArrowThinR) unaryLambdaExpr() else nameAllowQualified(NAME_DEFINITION, context = SyntacticContext.Expr.OtherExpr)
+          case TokenKind.Minus
+               | TokenKind.KeywordNot
+               | TokenKind.Plus
+               | TokenKind.TripleTilde
+               | TokenKind.KeywordLazy
+               | TokenKind.KeywordForce
+               | TokenKind.KeywordDiscard => unaryExpr()
+          case TokenKind.KeywordIf => ifThenElseExpr()
+          case TokenKind.KeywordLet => letMatchExpr()
+          case TokenKind.Annotation | TokenKind.KeywordDef => localDefExpr()
+          case TokenKind.KeywordRegion => scopeExpr()
+          case TokenKind.KeywordMatch => matchOrMatchLambdaExpr()
+          case TokenKind.KeywordTypeMatch => typematchExpr()
+          case TokenKind.KeywordChoose
+               | TokenKind.KeywordChooseStar => restrictableChooseExpr()
+          case TokenKind.KeywordForA => forApplicativeExpr()
+          case TokenKind.KeywordForeach => foreachExpr()
+          case TokenKind.KeywordForM => forMonadicExpr()
+          case TokenKind.CurlyL => blockOrRecordExpr()
+          case TokenKind.ArrayHash => arrayLiteralExpr()
+          case TokenKind.VectorHash => vectorLiteralExpr()
+          case TokenKind.ListHash => listLiteralExpr()
+          case TokenKind.SetHash => setLiteralExpr()
+          case TokenKind.MapHash => mapLiteralExpr()
+          case TokenKind.DotDotDot => dotdotdotLiteral()
+          case TokenKind.KeywordCheckedCast => checkedTypeCastExpr()
+          case TokenKind.KeywordCheckedECast => checkedEffectCastExpr()
+          case TokenKind.KeywordUncheckedCast => uncheckedCastExpr()
+          case TokenKind.KeywordUnsafe => unsafeExpr()
+          case TokenKind.KeywordUnsafely => unsafelyRunExpr()
+          case TokenKind.KeywordRun => runExpr()
+          case TokenKind.KeywordHandler => handlerExpr()
+          case TokenKind.KeywordTry => tryExpr()
+          case TokenKind.KeywordThrow => throwExpr()
+          case TokenKind.KeywordNew => ambiguousNewExpr()
+          case TokenKind.KeywordStaticUppercase => staticExpr()
+          case TokenKind.KeywordSelect => selectExpr()
+          case TokenKind.KeywordSpawn => spawnExpr()
+          case TokenKind.KeywordPar => parYieldExpr()
+          case TokenKind.HashCurlyL => fixpointConstraintSetExpr()
+          case TokenKind.HashParenL => fixpointLambdaExpr()
+          case TokenKind.KeywordSolve => fixpointSolveExpr()
+          case TokenKind.KeywordInject => fixpointInjectExpr()
+          case TokenKind.KeywordQuery => fixpointQueryExpr()
+          case TokenKind.BuiltIn => intrinsicExpr()
+          case TokenKind.LiteralStringInterpolationL
+               | TokenKind.LiteralDebugStringL => interpolatedStringExpr()
+          case TokenKind.KeywordDebug
+               | TokenKind.KeywordDebugBang
+               | TokenKind.KeywordDebugBangBang => debugExpr()
+          case t =>
+            val mark = open()
+            val error = UnexpectedToken(expected = NamedTokenSet.Expression, actual = Some(t), SyntacticContext.Expr.OtherExpr, loc = currentSourceLocation())
+            advance()
+            closeWithError(mark, error)
+        }
       }
       close(mark, TreeKind.Expr.Expr)
     }
@@ -1865,12 +1872,13 @@ object Parser2 {
       val mark = open()
       expect(TokenKind.KeywordIf, SyntacticContext.Expr.OtherExpr)
       expect(TokenKind.ParenL, SyntacticContext.Expr.OtherExpr)
+      val exitTokens: Set[TokenKind] = Set(TokenKind.ParenR, TokenKind.KeywordElse)
       val condMark = open()
-      expression()
+      expression(exitTokens = exitTokens)
       close(condMark, TreeKind.Expr.Condition)
       expect(TokenKind.ParenR, SyntacticContext.Expr.OtherExpr)
       val thenMark = open()
-      expression()
+      expression(exitTokens = exitTokens)
       close(thenMark, TreeKind.Expr.Then)
       if (eat(TokenKind.KeywordElse)) {
         // Only call expression, if we found an 'else'. Otherwise when it is missing, defs might

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1387,7 +1387,7 @@ object Parser2 {
       *
       * @param left        The operator that binds the left-hand-side of the expression.
       * @param leftIsUnary If true, the left-hand-side is an unary operator.
-      * @param exitTokens  A set of tokens that will prevent exprDelimited from consuming them.
+      * @param exitTokens  A set of tokens that will prevent exprDelimited from consuming them as unexpected tokens.
       */
     def expression(left: TokenKind = TokenKind.Eof, leftIsUnary: Boolean = false, exitTokens: Set[TokenKind] = Set.empty)(implicit s: State): Mark.Closed = {
       var lhs = exprDelimited(exitTokens)
@@ -1596,7 +1596,7 @@ object Parser2 {
     /**
       * Parse a delimited expression.
       *
-      * @param exitTokens A set of tokens that will prevent exprDelimited from consuming them.
+      * @param exitTokens A set of tokens that will prevent exprDelimited from consuming them as unexpected tokens.
       */
     private def exprDelimited(exitTokens: Set[TokenKind])(implicit s: State): Mark.Closed = {
       // If a new expression is added here then add it to FIRST_EXPR too.

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1382,6 +1382,13 @@ object Parser2 {
       lhs
     }
 
+    /**
+      * Parse an expression.
+      *
+      * @param left         The operator that binds the left-hand-side of the expression.
+      * @param leftIsUnary  If true, the left-hand-side is an unary operator.
+      * @param exitTokens   A set of tokens that will prevent exprDelimited from consuming them.
+      */
     def expression(left: TokenKind = TokenKind.Eof, leftIsUnary: Boolean = false, exitTokens: Set[TokenKind] = Set.empty)(implicit s: State): Mark.Closed = {
       var lhs = exprDelimited(exitTokens)
       // Handle chained calls and record lookups.
@@ -1586,6 +1593,11 @@ object Parser2 {
       }
     }
 
+    /**
+      * Parse a delimited expression.
+      *
+      * @param exitTokens A set of tokens that will prevent exprDelimited from consuming them.
+      */
     private def exprDelimited(exitTokens: Set[TokenKind])(implicit s: State): Mark.Closed = {
       // If a new expression is added here then add it to FIRST_EXPR too.
       val mark = open()

--- a/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Parser2.scala
@@ -1856,6 +1856,10 @@ object Parser2 {
       close(mark, TreeKind.Expr.Unary)
     }
 
+    /**
+      * The condition and then sub-trees will always exist, but the else sub-tree is optional.
+      * If condition/then branch is missing in the source code, it will be represented as an Expr.Error inside that sub-tree.
+      */
     private def ifThenElseExpr()(implicit s: State): Mark.Closed = {
       assert(at(TokenKind.KeywordIf))
       val mark = open()

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1275,7 +1275,6 @@ object Weeder2 {
             mapN(pickExpr(condTree), pickExpr(thenTree)) {
               val error = UnexpectedToken(NamedTokenSet.FromKinds(Set(TokenKind.KeywordElse)), actual = None, SyntacticContext.Expr.OtherExpr, hint = Some("the else-branch is required in Flix."), tree.loc)
               sctx.errors.add(error)
-              // This Expr.Error is just a placeholder.
               (condExpr, thenExpr) => Expr.IfThenElse(condExpr, thenExpr, Expr.Error(error), tree.loc)
             }
         }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1268,13 +1268,15 @@ object Weeder2 {
       flatMapN(condTreeVal, thenTreeVal) {
         case (condTree, thenTree) => tryPick(TreeKind.Expr.Else, tree) match {
           case Some(elseTree) =>
-            flatMapN(pickExpr(condTree), pickExpr(thenTree), pickExpr(elseTree)) {
-              (condExpr, thenExpr, elseExpr) => Validation.Success(Expr.IfThenElse(condExpr, thenExpr, elseExpr, tree.loc))
+            mapN(pickExpr(condTree), pickExpr(thenTree), pickExpr(elseTree)) {
+              (condExpr, thenExpr, elseExpr) => Expr.IfThenElse(condExpr, thenExpr, elseExpr, tree.loc)
             }
           case None =>
-            flatMapN(pickExpr(condTree), pickExpr(thenTree)) {
+            mapN(pickExpr(condTree), pickExpr(thenTree)) {
+              val error = UnexpectedToken(NamedTokenSet.FromKinds(Set(TokenKind.KeywordElse)), actual = None, SyntacticContext.Expr.OtherExpr, hint = Some("the else-branch is required in Flix."), tree.loc)
+              sctx.errors.add(error)
               // This Expr.Error is just a placeholder.
-              (condExpr, thenExpr) => Validation.Success(Expr.IfThenElse(condExpr, thenExpr, Expr.Error(MisplacedComments(SyntacticContext.Unknown, tree.loc)), tree.loc))
+              (condExpr, thenExpr) => Expr.IfThenElse(condExpr, thenExpr, Expr.Error(MisplacedComments(SyntacticContext.Unknown, tree.loc)), tree.loc)
             }
         }
       }

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1261,10 +1261,6 @@ object Weeder2 {
       }
     }
 
-    /**
-      * The condition and then sub-trees are required, but the else sub-tree is optional.
-      * If condition/then branch is missing in the source code, it will be represented as an Expr.Error inside that sub-tree.
-      */
     private def visitIfThenElseExpr(tree: Tree)(implicit sctx: SharedContext): Validation[Expr, CompilationMessage] = {
       expect(tree, TreeKind.Expr.IfThenElse)
       val condTreeVal = pick(TreeKind.Expr.Condition, tree)

--- a/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
+++ b/main/src/ca/uwaterloo/flix/language/phase/Weeder2.scala
@@ -1276,7 +1276,7 @@ object Weeder2 {
               val error = UnexpectedToken(NamedTokenSet.FromKinds(Set(TokenKind.KeywordElse)), actual = None, SyntacticContext.Expr.OtherExpr, hint = Some("the else-branch is required in Flix."), tree.loc)
               sctx.errors.add(error)
               // This Expr.Error is just a placeholder.
-              (condExpr, thenExpr) => Expr.IfThenElse(condExpr, thenExpr, Expr.Error(MisplacedComments(SyntacticContext.Unknown, tree.loc)), tree.loc)
+              (condExpr, thenExpr) => Expr.IfThenElse(condExpr, thenExpr, Expr.Error(error), tree.loc)
             }
         }
       }


### PR DESCRIPTION
fixes #10219

And it makes the lsp work inside an incomplete if-then-else:
![image](https://github.com/user-attachments/assets/9a84c289-6c37-4397-a906-6b1929fa6d2d)
![image](https://github.com/user-attachments/assets/719560aa-b29d-451d-a2d3-b316acb859c7)

But still doesnt work here:
![image](https://github.com/user-attachments/assets/73754fd9-3b14-48aa-bf9e-f28e3ad86514)

I manually constructed an Expr.Error in the Weeder, and since there is no placeholder, I randomly use MisplacedComment, just to make it compile.

We could handle that in other means, lke designing a placeholder, or constructing that in Parser2.


