### PR TITLE
feat: `verify` option

### DIFF
--- a/main/src/ca/uwaterloo/flix/Main.scala
+++ b/main/src/ca/uwaterloo/flix/Main.scala
@@ -95,13 +95,12 @@ object Main {
       threads = cmdOpts.threads.getOrElse(Options.Default.threads),
       loadClassFiles = Options.Default.loadClassFiles,
       assumeYes = cmdOpts.assumeYes,
-      xnoverify = cmdOpts.xnoverify,
       xprintphases = cmdOpts.xprintphases,
       xnodeprecated = cmdOpts.xnodeprecated,
       xsummary = cmdOpts.xsummary,
       xfuzzer = cmdOpts.xfuzzer,
       xprinttyper = cmdOpts.xprinttyper,
-      xverifyeffects = cmdOpts.xverifyeffects,
+      xverify = if (cmdOpts.xverify) VerificationOptions.EnableAll else VerificationOptions.EnableNone,
       xsubeffecting = cmdOpts.xsubeffecting,
       XPerfFrontend = cmdOpts.XPerfFrontend,
       XPerfPar = cmdOpts.XPerfPar,
@@ -343,7 +342,6 @@ object Main {
                      listen: Option[Int] = None,
                      threads: Option[Int] = None,
                      assumeYes: Boolean = false,
-                     xnoverify: Boolean = false,
                      xbenchmarkCodeSize: Boolean = false,
                      xbenchmarkIncremental: Boolean = false,
                      xbenchmarkPhases: Boolean = false,
@@ -355,7 +353,7 @@ object Main {
                      xsummary: Boolean = false,
                      xfuzzer: Boolean = false,
                      xprinttyper: Option[String] = None,
-                     xverifyeffects: Boolean = false,
+                     xverify: Boolean = false,
                      xsubeffecting: Set[Subeffecting] = Set.empty,
                      XPerfN: Option[Int] = None,
                      XPerfFrontend: Boolean = false,
@@ -528,10 +526,6 @@ object Main {
       note("")
       note("The following options are experimental:")
 
-      // Xnoverify
-      opt[Unit]("Xnoverify").action((_, c) => c.copy(xnoverify = true)).
-        text("disables verification of the last AST.")
-
       // Xbenchmark-code-size
       opt[Unit]("Xbenchmark-code-size").action((_, c) => c.copy(xbenchmarkCodeSize = true)).
         text("[experimental] benchmarks the size of the generated JVM files.")
@@ -577,8 +571,8 @@ object Main {
         text("[experimental] writes constraints to dot files.")
 
       // Xverify-effects
-      opt[String]("Xverify-effects").action((_, c) => c.copy(xverifyeffects = true)).
-        text("[experimental] verifies consistency of effects after typechecking")
+      opt[Unit]("Xverify").action((_, c) => c.copy(xverify = true)).
+        text("[experimental] enables verifiers")
 
       // Xsubeffecting
       opt[Seq[Subeffecting]]("Xsubeffecting").action((subeffectings, c) => c.copy(xsubeffecting = subeffectings.toSet)).

--- a/main/src/ca/uwaterloo/flix/language/verifier/ClassVerifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/verifier/ClassVerifier.scala
@@ -21,6 +21,7 @@ import ca.uwaterloo.flix.language.ast.ReducedAst.*
 import ca.uwaterloo.flix.language.ast.shared.Constant
 import ca.uwaterloo.flix.language.ast.{AtomicOp, MonoType, SemanticOp, SourceLocation, Symbol}
 import ca.uwaterloo.flix.language.dbg.AstPrinter.*
+import ca.uwaterloo.flix.util.VerificationOptions.Verifiers
 import ca.uwaterloo.flix.util.{InternalCompilerException, ParOps}
 
 import scala.annotation.tailrec
@@ -31,10 +32,10 @@ import scala.annotation.tailrec
 object ClassVerifier {
 
   def run(root: Root)(implicit flix: Flix): Root = flix.phase("ClassVerifier") {
-    if (flix.options.xnoverify) {
+    if (flix.options.xverify.isEnabled(Verifiers.ClassVerifier)) {
+      ParOps.parMap(root.defs.values)(visitDef(_)(root))
       root
     } else {
-      ParOps.parMap(root.defs.values)(visitDef(_)(root))
       root
     }
   }

--- a/main/src/ca/uwaterloo/flix/language/verifier/EffectVerifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/verifier/EffectVerifier.scala
@@ -22,6 +22,7 @@ import ca.uwaterloo.flix.language.ast.shared.Scope
 import ca.uwaterloo.flix.language.phase.typer.ConstraintSolver2
 import ca.uwaterloo.flix.language.phase.unification.EqualityEnv
 import ca.uwaterloo.flix.util.*
+import ca.uwaterloo.flix.util.VerificationOptions.Verifiers
 
 /**
   * Performs a re-checking of the effects in the program.
@@ -39,7 +40,7 @@ object EffectVerifier {
     * Verifies the effects in the given root.
     */
   def run(root: Root)(implicit flix: Flix): Unit = {
-    if (flix.options.xverifyeffects) {
+    if (flix.options.xverify.isEnabled(Verifiers.EffectVerifier)) {
       ParOps.parMapValues(root.defs)(visitDef(_)(root.eqEnv, flix))
       ParOps.parMapValues(root.sigs)(visitSig(_)(root.eqEnv, flix))
       ParOps.parMap(root.instances.values)(visitInstance(_)(root.eqEnv, flix))

--- a/main/test/ca/uwaterloo/flix/language/LanguageSuite.scala
+++ b/main/test/ca/uwaterloo/flix/language/LanguageSuite.scala
@@ -27,5 +27,6 @@ class LanguageSuite extends Suites(
   new TestFlixErrors,
   new TestFormatType,
   new TestCompilationMessage,
+  new TestVerifiers,
   new AstSuite
 )

--- a/main/test/ca/uwaterloo/flix/language/TestVerifiers.scala
+++ b/main/test/ca/uwaterloo/flix/language/TestVerifiers.scala
@@ -1,0 +1,16 @@
+package ca.uwaterloo.flix.language
+
+import ca.uwaterloo.flix.TestUtils
+import ca.uwaterloo.flix.util.{Options, VerificationOptions}
+import org.scalatest.funsuite.AnyFunSuite
+
+class TestVerifiers extends AnyFunSuite with TestUtils {
+
+  test("VerifyStandardLib"){
+    // Currently EffectVerifier cannot verify, so skip that one.
+    val verifiers = VerificationOptions.Verifiers.all - VerificationOptions.Verifiers.EffectVerifier
+    val res = compile("", Options.DefaultTest.copy(xverify = VerificationOptions.EnableSome(verifiers)))
+    expectSuccess(res)
+  }
+
+}


### PR DESCRIPTION
- `--Xverify` enables all verifiers, none are enabled by default
  - On master `ClassVerifier` is always run, so this is a change for users
- `VerificationOptions` can be used internally to pick and choose any verifier
- `ClassVerifier` is run on all tests, while `TestVerifiers` runs all verifiers on the standard library
  - `EffectVerifier` fails currently, so its disabled for this PR 

Related to #10293