### PR TITLE
fix: `EffectVerifier` of `StructNew`

### DIFF
--- a/main/src/ca/uwaterloo/flix/language/verifier/EffectVerifier.scala
+++ b/main/src/ca/uwaterloo/flix/language/verifier/EffectVerifier.scala
@@ -232,11 +232,10 @@ object EffectVerifier {
       // TODO region stuff
       ()
     case Expr.StructNew(sym, fields, region, tpe, eff, loc) =>
-      val expected = Type.mkUnion(fields.map { case (k, v) => v.eff } :+ region.eff, loc)
-      val actual = eff
-      expectType(expected, actual, loc)
       fields.map { case (k, v) => v }.foreach(visitExp)
       visitExp(region)
+      // TODO region stuff
+      ()
     case Expr.StructGet(e, _, t, _, _) =>
       // JOE TODO region stuff
       visitExp(e)


### PR DESCRIPTION
The verifier does not account for the intrinsic region effect, so I've put it as todo like the above region things